### PR TITLE
dts: bindings: clock: moved comments to descriptions

### DIFF
--- a/dts/bindings/clock/st,stm32-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32-msi-clock.yaml
@@ -13,20 +13,20 @@ properties:
     type: int
     default: 6
     description: |
-      MSI clock ranges
-    enum:
-      - 0 # range 0 around 100 kHz
-      - 1 # range 1 around 200 kHz
-      - 2 # range 2 around 400 kHz
-      - 3 # range 3 around 800 kHz
-      - 4 # range 4 around 1 MHz
-      - 5 # range 5 around 2 MHz
-      - 6 # range 6 around 4 MHz (reset value)
-      - 7 # range 7 around 8 MHz
-      - 8 # range 8 around 16 MHz
-      - 9 # range 9 around 24 MHz
-      - 10 # range 10 around 32 MHz
-      - 11 # range 11 around 48 MHz
+      MSI clock ranges:
+      0: around 100 kHz
+      1: around 200 kHz
+      2: around 400 kHz
+      3: around 800 kHz
+      4: around 1 MHz
+      5: around 2 MHz
+      6: around 4 MHz (reset value)
+      7: around 8 MHz
+      8: around 16 MHz
+      9: around 24 MHz
+      10: around 32 MHz
+      11: around 48 MHz
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
   msi-pll-mode:
     type: boolean

--- a/dts/bindings/clock/st,stm32h7-hsi-clock.yaml
+++ b/dts/bindings/clock/st,stm32h7-hsi-clock.yaml
@@ -13,8 +13,8 @@ properties:
     required: true
     description: |
       HSI clock divider. Configures the output HSI clock frequency
-    enum:
-      - 1 # hsi_clk = 64MHz
-      - 2 # hsi_clk = 32MHz
-      - 4 # hsi_clk = 16MHz
-      - 8 # hsi_clk = 8MHz
+      1: 64 MHz
+      2: 32 MHz
+      4: 16 MHz
+      8: 8 MHz
+    enum: [1, 2, 4, 8]

--- a/dts/bindings/clock/st,stm32l0-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32l0-msi-clock.yaml
@@ -16,12 +16,12 @@ properties:
     type: int
     default: 5
     description: |
-      MSI clock ranges
-    enum:
-      - 0 # range 0, around 65.536 kHz
-      - 1 # range 1, around 131.072 kHz
-      - 2 # range 2, around 262.144 kHz
-      - 3 # range 3, around 524.288 kHz
-      - 4 # range 4, around 1.048 MHz
-      - 5 # range 5, around 2.097 MHz (reset value)
-      - 6 # range 6, around 4.194 MHz
+      MSI clock ranges:
+      0: around 65.536 kHz
+      1: around 131.072 kHz
+      2: around 262.144 kHz
+      3: around 524.288 kHz
+      4: around 1.048 MHz
+      5: around 2.097 MHz (reset value)
+      6: around 4.194 MHz
+    enum: [0, 1, 2, 3, 4, 5, 6]

--- a/dts/bindings/clock/st,stm32u5-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32u5-msi-clock.yaml
@@ -17,21 +17,21 @@ properties:
     required: true
     type: int
     description: |
-      MSI clock ranges
-    enum:
-      - 0 # range 0 around 48 MHz
-      - 1 # range 1 around 24 MHz
-      - 2 # range 2 around 16 MHz
-      - 3 # range 3 around 12 MHz
-      - 4 # range 4 around 4 MHz (reset value)
-      - 5 # range 5 around 2 MHz
-      - 6 # range 6 around 1.33 MHz
-      - 7 # range 7 around 1 MHz
-      - 8 # range 8 around 3.072 MHz
-      - 9 # range 9 around 1.536 MHz
-      - 10 # range 10 around 1.024 MHz
-      - 11 # range 11 around 768 KHz
-      - 12 # range 12 around 400 KHz
-      - 13 # range 13 around 200 KHz
-      - 14 # range 14 around 133 KHz
-      - 15 # range 14 around 100 KHz
+      MSI clock ranges:
+      0: around 48 MHz
+      1: around 24 MHz
+      2: around 16 MHz
+      3: around 12 MHz
+      4: around 4 MHz (reset value)
+      5: around 2 MHz
+      6: around 1.33 MHz
+      7: around 1 MHz
+      8: around 3.072 MHz
+      9: around 1.536 MHz
+      10: around 1.024 MHz
+      11: around 768 KHz
+      12: around 400 KHz
+      13: around 200 KHz
+      14: around 133 KHz
+      15: around 100 KHz
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]


### PR DESCRIPTION
Moved many of the clock names to the description sections, so when the website is generate you'll be able to quickly see all the possible values.

No c code was modified just yaml documents.  

@erwango 