### PR TITLE
modem: chat: dynamic chat requests

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -104,12 +104,35 @@ extern const struct modem_chat_match modem_chat_any_match;
 /* Helper struct to match nothing. */
 extern const struct modem_chat_match modem_chat_empty_matches[0];
 
+/** Special value that signifies union member is `request_fn`, not `request` */
+#define MODEM_CHAT_REQUEST_FN_LEN UINT16_MAX
+
+/**
+ * @brief Function that retrieves the request to send
+ *
+ * @note The lifetime of the output request pointer must match or exceed the
+ *       lifetime of script_chat.
+ *
+ * @note This function can be called multiple times per request that is sent.
+ *
+ * @param request pointer to store the request in
+ * @param user_data modem chat user data
+ *
+ * @retval Length of @a request
+ */
+typedef uint16_t (*modem_chat_script_request_fn)(const uint8_t **request, void *user_data);
+
 /**
  * @brief Modem chat script chat
  */
 struct modem_chat_script_chat {
-	/** Request to send to modem */
-	const uint8_t *request;
+	/** Request string, or function to retrieve request string */
+	union {
+		/** Request to send to modem */
+		const uint8_t *request;
+		/** Function that returns request to send to modem */
+		modem_chat_script_request_fn request_fn;
+	};
 	/** Size of request */
 	uint16_t request_size;
 	/** Expected responses to request */
@@ -142,6 +165,51 @@ struct modem_chat_script_chat {
 	{                                                                                          \
 		.request = (uint8_t *)(_request),                                                  \
 		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
+		.response_matches = NULL,                                                          \
+		.response_matches_size = 0,                                                        \
+		.timeout = _timeout_ms,                                                            \
+	}
+
+/**
+ * @brief Dynamic command from function with a single response
+ *
+ * @param _request_fn Function pointer that returns the command string
+ * @param _response_match Response match from @ref MODEM_CHAT_MATCH_DEFINE
+ */
+#define MODEM_CHAT_SCRIPT_CMD_RESP_FN(_request_fn, _response_match)                                \
+	{                                                                                          \
+		.request_fn = _request_fn,                                                         \
+		.request_size = MODEM_CHAT_REQUEST_FN_LEN,                                         \
+		.response_matches = &_response_match,                                              \
+		.response_matches_size = 1,                                                        \
+		.timeout = 0,                                                                      \
+	}
+
+/**
+ * @brief Dynamic command from function with multiple possible responses
+ *
+ * @param _request_fn Function pointer that returns the command string
+ * @param _response_matches Array of response matches from @ref MODEM_CHAT_MATCHES_DEFINE
+ */
+#define MODEM_CHAT_SCRIPT_CMD_RESP_MULT_FN(_request_fn, _response_matches)                         \
+	{                                                                                          \
+		.request_fn = _request_fn,                                                         \
+		.request_size = MODEM_CHAT_REQUEST_FN_LEN,                                         \
+		.response_matches = _response_matches,                                             \
+		.response_matches_size = ARRAY_SIZE(_response_matches),                            \
+		.timeout = 0,                                                                      \
+	}
+
+/**
+ * @brief Dynamic command from function with no response
+ *
+ * @param _request_fn Function pointer that returns the command string
+ * @param _timeout_ms Timeout after which the next command is run
+ */
+#define MODEM_CHAT_SCRIPT_CMD_RESP_NONE_FN(_request_fn, _timeout_ms)                               \
+	{                                                                                          \
+		.request_fn = _request_fn,                                                         \
+		.request_size = MODEM_CHAT_REQUEST_FN_LEN,                                         \
 		.response_matches = NULL,                                                          \
 		.response_matches_size = 0,                                                        \
 		.timeout = _timeout_ms,                                                            \

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -275,19 +275,24 @@ static bool modem_chat_send_script_request_part(struct modem_chat *chat)
 	const struct modem_chat_script_chat *script_chat =
 		&chat->script->script_chats[chat->script_chat_it];
 
-	uint8_t *request_part;
+	const uint8_t *request_part;
 	uint16_t request_size;
 	uint16_t request_part_size;
 	int ret;
 
 	switch (chat->script_send_state) {
 	case MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST:
-		request_part = (uint8_t *)(&script_chat->request[chat->script_send_pos]);
-		request_size = script_chat->request_size;
+		if (script_chat->request_size == MODEM_CHAT_REQUEST_FN_LEN) {
+			request_size = script_chat->request_fn(&request_part, chat->user_data);
+			request_part += chat->script_send_pos;
+		} else {
+			request_part = (uint8_t *)(&script_chat->request[chat->script_send_pos]);
+			request_size = script_chat->request_size;
+		}
 		break;
 
 	case MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER:
-		request_part = (uint8_t *)(&chat->delimiter[chat->script_send_pos]);
+		request_part = &chat->delimiter[chat->script_send_pos];
 		request_size = chat->delimiter_size;
 		break;
 
@@ -1008,9 +1013,9 @@ int modem_chat_script_chat_set_request(struct modem_chat_script_chat *script_cha
 {
 	size_t size;
 
-	size = strnlen(request, UINT16_MAX + 1);
+	size = strnlen(request, UINT16_MAX);
 
-	if (size == (UINT16_MAX + 1)) {
+	if (size == (UINT16_MAX)) {
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
Add the option for request strings to be selected at runtime from a function instead of hardcoded at compile time.
Extracted from #97702 as this was the core point of contention, and I would like to re-open the proposal to get it in.

### Problem

Some configuration values for modems are best described in devicetree, for example using a faster baudrate after boot.
Modem chat commands, e.g. `MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match)`, are currently compile-time constant strings only.
If a user wishes to send a command based on a devicetree property, there are currently two options.

#### 1) Define entire script in instance macro
```
#define MODEM_CELLULAR_DEVICE_U_BLOX_LARA_R6(inst)                                                 \
    ...
    MODEM_CHAT_SCRIPT_CMDS_DEFINE(
	  u_blox_lara_r6_set_baudrate_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
	  MODEM_CHAT_SCRIPT_CMD_RESP("AT+IPR=" STRINGIFY(DT_INST_PROP(inst, target_baudrate)), ok_match));

     MODEM_CHAT_SCRIPT_DEFINE(u_blox_lara_r6_set_baudrate_chat_script,
	  u_blox_lara_r6_set_baudrate_chat_script_cmds, abort_matches,
	  modem_cellular_chat_callback_handler, 1);
      ...
```
This option is possible acceptable for scripts that are dedicated to a single configuration (e.g. `set_baudrate`), but becomes unwieldy as soon as the options are embedded into larger scripts (e.g. `init`).
The recent addition of #108641 also makes this more annoying, as the `scripts` struct also needs to move into the macro.

#### 2) Dynamic script creation
In code "somewhere" create and configure the script dynamically at runtime (example adapted from `modem_at_shell`).
```
void init_dynamic_script(void) {
	/* Match the expected response and terminate script */
	modem_chat_match_init(&at_shell_script_chat_matches[1]);
        modem_chat_script_chat_set_request(at_shell_script_chat,  "Some AT CMD (maybe from strncpy)");
	modem_chat_match_set_match(&at_shell_script_chat_matches[1], "OK");
	modem_chat_match_set_separators(&at_shell_script_chat_matches[1], "");
	modem_chat_match_set_callback(&at_shell_script_chat_matches[1], at_shell_print_match);
	modem_chat_match_set_partial(&at_shell_script_chat_matches[1], false);
	modem_chat_match_enable_wildcards(&at_shell_script_chat_matches[1], false);

	modem_chat_script_chat_init(at_shell_script_chat);
	modem_chat_script_chat_set_response_matches(at_shell_script_chat,
						    at_shell_script_chat_matches,
						    ARRAY_SIZE(at_shell_script_chat_matches));
	modem_chat_script_chat_set_timeout(at_shell_script_chat,
					   CONFIG_MODEM_AT_SHELL_RESPONSE_TIMEOUT_S);
}
```
IMO this is not an easy to use approach even for a single configuration option, and suffers the same challenges as 1 when considering configuration options in the middle of the `init` script.

### Proposed solution

The addition proposed in this PR allows the configuration string to be created in the instantiation macro and substituted in at runtime. It composes well with the existing `MODEM_CHAT_SCRIPT_CMD_*` macros, being a direct substitution for the existing macros. This means devicetree based configuration can be slotted into the middle of `init` scripts without a complete rework of the script.
```
MODEM_CHAT_SCRIPT_CMDS_DEFINE(telit_le910cx_le_baudrate_chat_script_cmds,
			      MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match),
			      MODEM_CHAT_SCRIPT_CMD_RESP(("AT+IPR=" STRINGIFY(CONFIG_), ok_match));
```
becomes
```
static uint16_t modem_baudrate_cmd(const uint8_t **request, void *user_data)
{
	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;

	*request = data->target_baudrate_req;
	return strlen(*request);
}

MODEM_CHAT_SCRIPT_CMDS_DEFINE(telit_le910cx_le_baudrate_chat_script_cmds,
			      MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match),
			      MODEM_CHAT_SCRIPT_CMD_RESP_FN(modem_baudrate_cmd, ok_match));
```

### State from #97702 

Approvals from @rerickson1 and @maass-hamburg.

Opposition from @bjarki-andreasen (maintainer) copied in for full transparency

> The third solution is not necessary nor scalable, thus it is not a proper solution to the problem.

> The solution in this PR is not proper, a SPI transfer does not have a callback to change any of the buffers mid transfer, RTIO does not have a callback to modify an SQE mid transaction, modem_chat does not have a callback to modify a script mid transaction, I could go on. The entire transaction is known BEFORE the transaction is started, thus, that is when it shall be defined.