### PR TITLE
modem: pipe: support dual transmit buffers

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -212,8 +212,6 @@ enum modem_chat_script_send_state {
 	MODEM_CHAT_SCRIPT_SEND_STATE_IDLE,
 	/* Sending request */
 	MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST,
-	/* Sending delimiter */
-	MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER,
 };
 
 /**

--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -161,7 +161,9 @@ struct modem_cmux_frame {
 	bool pf;
 	uint8_t type;
 	const uint8_t *data;
+	const uint8_t *tx_extra;
 	uint16_t data_len;
+	uint16_t tx_extra_len;
 };
 
 struct modem_cmux_work {

--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -52,13 +52,18 @@ typedef int (*modem_pipe_api_open)(void *data);
 
 typedef int (*modem_pipe_api_transmit)(void *data, const uint8_t *buf, size_t size);
 
+typedef int (*modem_pipe_api_transmit_double)(void *data, const uint8_t *buf, size_t size,
+					      const uint8_t *extra_buf, size_t extra_size);
+
 typedef int (*modem_pipe_api_receive)(void *data, uint8_t *buf, size_t size);
 
 typedef int (*modem_pipe_api_close)(void *data);
 
 struct modem_pipe_api {
 	modem_pipe_api_open open;
+	/* Only one of 'transmit' and 'transmit_double' needs to be implemented */
 	modem_pipe_api_transmit transmit;
+	modem_pipe_api_transmit_double transmit_double;
 	modem_pipe_api_receive receive;
 	modem_pipe_api_close close;
 };
@@ -126,6 +131,23 @@ int modem_pipe_open_async(struct modem_pipe *pipe);
 void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback, void *user_data);
 
 /**
+ * @brief Transmit two data buffers through pipe
+ *
+ * @param pipe Pipe to transmit through
+ * @param buf Data to transmit
+ * @param size Number of bytes to transmit
+ * @param extra_buf Optional second buffer to transmit
+ * @param extra_size Number of bytes in @a extra_buf
+ *
+ * @return Number of bytes placed in pipe (0 if pipe closed)
+ * @retval -errno code on error
+ *
+ * @warning This call must be non-blocking
+ */
+int modem_pipe_transmit_double(struct modem_pipe *pipe, const uint8_t *buf, size_t size,
+			       const uint8_t *extra_buf, size_t extra_size);
+
+/**
  * @brief Transmit data through pipe
  *
  * @param pipe Pipe to transmit through
@@ -137,7 +159,10 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
  *
  * @warning This call must be non-blocking
  */
-int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size);
+static inline int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size)
+{
+	return modem_pipe_transmit_double(pipe, buf, size, NULL, 0);
+}
 
 /**
  * @brief Receive data through pipe

--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -132,8 +132,7 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
  * @param buf Data to transmit
  * @param size Number of bytes to transmit
  *
- * @return Number of bytes placed in pipe
- * @retval -EPERM if pipe is closed
+ * @return Number of bytes placed in pipe (0 if pipe closed)
  * @retval -errno code on error
  *
  * @warning This call must be non-blocking
@@ -147,8 +146,7 @@ int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size
  * @param buf Destination for received data; must not be already in use in a modem module.
  * @param size Capacity of destination for received data
  *
- * @return Number of bytes received from pipe
- * @retval -EPERM if pipe is closed
+ * @return Number of bytes received from pipe (0 if pipe closed)
  * @retval -errno code on error
  *
  * @warning This call must be non-blocking

--- a/subsys/modem/backends/modem_backend_tty.c
+++ b/subsys/modem/backends/modem_backend_tty.c
@@ -65,12 +65,16 @@ static int modem_backend_tty_open(void *data)
 	return 0;
 }
 
-static int modem_backend_tty_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_tty_transmit_double(void *data, const uint8_t *buf, size_t size,
+					     const uint8_t *extra_buf, size_t extra_size)
 {
 	struct modem_backend_tty *backend = (struct modem_backend_tty *)data;
 	int ret;
 
 	ret = nsi_host_write(backend->tty_fd, buf, size);
+	if ((ret == size) && (extra_size > 0)) {
+		ret += nsi_host_write(backend->tty_fd, extra_buf, extra_size);
+	}
 	modem_pipe_notify_transmit_idle(&backend->pipe);
 	return ret;
 }
@@ -100,7 +104,7 @@ static int modem_backend_tty_close(void *data)
 
 static const struct modem_pipe_api modem_backend_tty_api = {
 	.open = modem_backend_tty_open,
-	.transmit = modem_backend_tty_transmit,
+	.transmit_double = modem_backend_tty_transmit_double,
 	.receive = modem_backend_tty_receive,
 	.close = modem_backend_tty_close,
 };

--- a/subsys/modem/backends/modem_backend_uart_async.c
+++ b/subsys/modem/backends/modem_backend_uart_async.c
@@ -213,11 +213,15 @@ static uint32_t get_transmit_buf_size(struct modem_backend_uart *backend)
 	return backend->async.common.transmit_buf_size;
 }
 
-static int modem_backend_uart_async_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_uart_async_transmit_double(void *data, const uint8_t *buf, size_t size,
+						    const uint8_t *extra_buf, size_t extra_size)
 {
 	struct modem_backend_uart *backend = (struct modem_backend_uart *)data;
 	bool transmitting;
+	uint32_t tx_buf_size = get_transmit_buf_size(backend);
+	uint32_t extra_bytes_to_transmit;
 	uint32_t bytes_to_transmit;
+	uint32_t total_transmit;
 	int ret;
 
 	transmitting = atomic_test_and_set_bit(&backend->async.common.state,
@@ -227,25 +231,29 @@ static int modem_backend_uart_async_transmit(void *data, const uint8_t *buf, siz
 	}
 
 	/* Determine amount of bytes to transmit */
-	bytes_to_transmit = MIN(size, get_transmit_buf_size(backend));
+	bytes_to_transmit = MIN(size, tx_buf_size);
+	extra_bytes_to_transmit = MIN(extra_size, tx_buf_size - bytes_to_transmit);
+	total_transmit = bytes_to_transmit + extra_bytes_to_transmit;
 
 	/* Copy buf to transmit buffer which is passed to UART */
 	memcpy(backend->async.common.transmit_buf, buf, bytes_to_transmit);
+	memcpy(backend->async.common.transmit_buf + bytes_to_transmit, extra_buf,
+	       extra_bytes_to_transmit);
 
-	ret = uart_tx(backend->uart, backend->async.common.transmit_buf, bytes_to_transmit,
+	ret = uart_tx(backend->uart, backend->async.common.transmit_buf, total_transmit,
 		      CONFIG_MODEM_BACKEND_UART_ASYNC_TRANSMIT_TIMEOUT_MS * 1000L);
 
 #if CONFIG_MODEM_STATS
-	advertise_transmit_buf_stats(backend, bytes_to_transmit);
+	advertise_transmit_buf_stats(backend, total_transmit);
 #endif
 
 	if (ret != 0) {
 		LOG_ERR("Failed to %s %u bytes. (%d)",
-			"start async transmit for", bytes_to_transmit, ret);
+			"start async transmit for", total_transmit, ret);
 		return ret;
 	}
 
-	return (int)bytes_to_transmit;
+	return (int)total_transmit;
 }
 
 static int modem_backend_uart_async_receive(void *data, uint8_t *buf, size_t size)
@@ -296,7 +304,7 @@ static int modem_backend_uart_async_close(void *data)
 
 static const struct modem_pipe_api modem_backend_uart_async_api = {
 	.open = modem_backend_uart_async_open,
-	.transmit = modem_backend_uart_async_transmit,
+	.transmit_double = modem_backend_uart_async_transmit_double,
 	.receive = modem_backend_uart_async_receive,
 	.close = modem_backend_uart_async_close,
 };

--- a/subsys/modem/backends/modem_backend_uart_async_hwfc.c
+++ b/subsys/modem/backends/modem_backend_uart_async_hwfc.c
@@ -270,11 +270,16 @@ static uint32_t get_transmit_buf_size(const struct modem_backend_uart *backend)
 	return backend->async.common.transmit_buf_size;
 }
 
-static int modem_backend_uart_async_hwfc_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_uart_async_hwfc_transmit_double(void *data, const uint8_t *buf,
+							 size_t size, const uint8_t *extra_buf,
+							 size_t extra_size)
 {
 	struct modem_backend_uart *backend = (struct modem_backend_uart *)data;
 	bool transmitting;
+	uint32_t tx_buf_size = get_transmit_buf_size(backend);
+	uint32_t extra_bytes_to_transmit;
 	uint32_t bytes_to_transmit;
+	uint32_t total_transmit;
 	int ret;
 
 	transmitting = atomic_test_and_set_bit(&backend->async.common.state,
@@ -284,25 +289,29 @@ static int modem_backend_uart_async_hwfc_transmit(void *data, const uint8_t *buf
 	}
 
 	/* Determine amount of bytes to transmit */
-	bytes_to_transmit = MIN(size, get_transmit_buf_size(backend));
+	bytes_to_transmit = MIN(size, tx_buf_size);
+	extra_bytes_to_transmit = MIN(extra_size, tx_buf_size - bytes_to_transmit);
+	total_transmit = bytes_to_transmit + extra_bytes_to_transmit;
 
 	/* Copy buf to transmit buffer which is passed to UART */
 	memcpy(backend->async.common.transmit_buf, buf, bytes_to_transmit);
+	memcpy(backend->async.common.transmit_buf + bytes_to_transmit, extra_buf,
+	       extra_bytes_to_transmit);
 
-	ret = uart_tx(backend->uart, backend->async.common.transmit_buf, bytes_to_transmit,
+	ret = uart_tx(backend->uart, backend->async.common.transmit_buf, total_transmit,
 		      CONFIG_MODEM_BACKEND_UART_ASYNC_TRANSMIT_TIMEOUT_MS * 1000L);
 
 #if CONFIG_MODEM_STATS
-	advertise_transmit_buf_stats(backend, bytes_to_transmit);
+	advertise_transmit_buf_stats(backend, total_transmit);
 #endif
 
 	if (ret != 0) {
 		LOG_ERR("Failed to %s %u bytes. (%d)",
-			"start async transmit for", bytes_to_transmit, ret);
+			"start async transmit for", total_transmit, ret);
 		return ret;
 	}
 
-	return (int)bytes_to_transmit;
+	return (int)total_transmit;
 }
 
 static int modem_backend_uart_async_hwfc_receive(void *data, uint8_t *buf, size_t size)
@@ -386,7 +395,7 @@ static int modem_backend_uart_async_hwfc_close(void *data)
 
 static const struct modem_pipe_api modem_backend_uart_async_api = {
 	.open = modem_backend_uart_async_hwfc_open,
-	.transmit = modem_backend_uart_async_hwfc_transmit,
+	.transmit_double = modem_backend_uart_async_hwfc_transmit_double,
 	.receive = modem_backend_uart_async_hwfc_receive,
 	.close = modem_backend_uart_async_hwfc_close,
 };

--- a/subsys/modem/backends/modem_backend_uart_isr.c
+++ b/subsys/modem/backends/modem_backend_uart_isr.c
@@ -182,7 +182,8 @@ static bool modem_backend_uart_isr_transmit_buf_above_limit(struct modem_backend
 	return backend->isr.transmit_buf_put_limit < get_transmit_buf_length(backend);
 }
 
-static int modem_backend_uart_isr_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_uart_isr_transmit_double(void *data, const uint8_t *buf, size_t size,
+						  const uint8_t *extra_buf, size_t extra_size)
 {
 	struct modem_backend_uart *backend = (struct modem_backend_uart *)data;
 	int written;
@@ -193,6 +194,9 @@ static int modem_backend_uart_isr_transmit(void *data, const uint8_t *buf, size_
 
 	uart_irq_tx_disable(backend->uart);
 	written = ring_buf_put(&backend->isr.transmit_rb, buf, size);
+	if ((written == size) && (extra_size > 0)) {
+		written += ring_buf_put(&backend->isr.transmit_rb, extra_buf, extra_size);
+	}
 	uart_irq_tx_enable(backend->uart);
 
 	/* Update transmit buf capacity tracker */
@@ -270,7 +274,7 @@ static int modem_backend_uart_isr_close(void *data)
 
 static const struct modem_pipe_api modem_backend_uart_isr_api = {
 	.open = modem_backend_uart_isr_open,
-	.transmit = modem_backend_uart_isr_transmit,
+	.transmit_double = modem_backend_uart_isr_transmit_double,
 	.receive = modem_backend_uart_isr_receive,
 	.close = modem_backend_uart_isr_close,
 };

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -274,32 +274,30 @@ static bool modem_chat_send_script_request_part(struct modem_chat *chat)
 {
 	const struct modem_chat_script_chat *script_chat =
 		&chat->script->script_chats[chat->script_chat_it];
-
-	uint8_t *request_part;
-	uint16_t request_size;
-	uint16_t request_part_size;
+	uint32_t total_size = script_chat->request_size + chat->delimiter_size;
+	const uint8_t *buf;
+	size_t buf_len;
+	const uint8_t *extra_buf = NULL;
+	size_t extra_len = 0;
 	int ret;
 
-	switch (chat->script_send_state) {
-	case MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST:
-		request_part = (uint8_t *)(&script_chat->request[chat->script_send_pos]);
-		request_size = script_chat->request_size;
-		break;
-
-	case MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER:
-		request_part = (uint8_t *)(&chat->delimiter[chat->script_send_pos]);
-		request_size = chat->delimiter_size;
-		break;
-
-	default:
-		return false;
+	if (chat->script_send_pos < script_chat->request_size) {
+		/* Still sending the request */
+		buf = &script_chat->request[chat->script_send_pos];
+		buf_len = script_chat->request_size - chat->script_send_pos;
+		extra_buf = (uint8_t *)chat->delimiter;
+		extra_len = chat->delimiter_size;
+	} else {
+		/* Purely into the delimiter */
+		buf = &chat->delimiter[chat->script_send_pos - script_chat->request_size];
+		buf_len = total_size - chat->script_send_pos;
 	}
 
-	request_part_size = request_size - chat->script_send_pos;
-	ret = modem_pipe_transmit(chat->pipe, request_part, request_part_size);
+	ret = modem_pipe_transmit_double(chat->pipe, buf, buf_len, extra_buf, extra_len);
 	if (ret < 1) {
 		if (ret < 0) {
-			LOG_ERR("Failed to %s %u bytes. (%d)", "transmit", request_part_size, ret);
+			LOG_ERR("Failed to %s %zu bytes. (%d)", "transmit",
+				buf_len + extra_len, ret);
 		}
 		return false;
 	}
@@ -307,7 +305,7 @@ static bool modem_chat_send_script_request_part(struct modem_chat *chat)
 	chat->script_send_pos += (uint16_t)ret;
 
 	/* Return true if all data was sent */
-	return request_size <= chat->script_send_pos;
+	return total_size <= chat->script_send_pos;
 }
 
 static void modem_chat_script_send_handler(struct k_work *item)
@@ -318,26 +316,17 @@ static void modem_chat_script_send_handler(struct k_work *item)
 		return;
 	}
 
-	switch (chat->script_send_state) {
-	case MODEM_CHAT_SCRIPT_SEND_STATE_IDLE:
+	if (chat->script_send_state == MODEM_CHAT_SCRIPT_SEND_STATE_IDLE) {
 		return;
-
-	case MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST:
-		if (!modem_chat_send_script_request_part(chat)) {
-			return;
-		}
-
-		modem_chat_set_script_send_state(chat, MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER);
-		__fallthrough;
-
-	case MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER:
-		if (!modem_chat_send_script_request_part(chat)) {
-			return;
-		}
-
-		modem_chat_set_script_send_state(chat, MODEM_CHAT_SCRIPT_SEND_STATE_IDLE);
-		break;
 	}
+
+	if (!modem_chat_send_script_request_part(chat)) {
+		/* Request still in progress */
+		return;
+	}
+
+	/* Request transmission complete */
+	modem_chat_set_script_send_state(chat, MODEM_CHAT_SCRIPT_SEND_STATE_IDLE);
 
 	if (modem_chat_script_chat_has_matches(chat)) {
 		modem_chat_script_set_response_matches(chat);

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -409,9 +409,13 @@ static void modem_cmux_log_frame(const struct modem_cmux_frame *frame,
 				 const char *action, size_t hexdump_len)
 {
 	LOG_DBG("%s ch:%u cr:%u pf:%u type:%s dlen:%u", action, frame->dlci_address,
-		frame->cr, frame->pf, modem_cmux_frame_type_to_str(frame->type), frame->data_len);
+		frame->cr, frame->pf, modem_cmux_frame_type_to_str(frame->type),
+		frame->data_len + frame->tx_extra_len);
 	if (hexdump_len > 0) {
 		LOG_HEXDUMP_DBG(frame->data, hexdump_len, "data:");
+	}
+	if (frame->tx_extra_len > 0) {
+		LOG_HEXDUMP_DBG(frame->tx_extra, frame->tx_extra_len, "data:");
 	}
 }
 #else
@@ -559,12 +563,18 @@ static uint16_t modem_cmux_transmit_frame(struct modem_cmux *cmux,
 	uint8_t buf[MODEM_CMUX_HEADER_SIZE];
 	uint8_t fcs;
 	uint16_t space;
+	uint16_t tx_len = frame->data_len + frame->tx_extra_len;
+	uint16_t real_extra_len;
+	uint16_t real_len;
 	uint16_t data_len;
 	uint16_t buf_idx;
 
 	space = ring_buf_space_get(&cmux->transmit_rb) - MODEM_CMUX_HEADER_SIZE;
-	data_len = MIN(space, frame->data_len);
+	data_len = MIN(space, tx_len);
 	data_len = MIN(data_len, CONFIG_MODEM_CMUX_MTU);
+
+	real_len = MIN(frame->data_len, data_len);
+	real_extra_len = data_len - real_len;
 
 	/* SOF */
 	buf[0] = MODEM_CMUX_SOF;
@@ -589,17 +599,22 @@ static uint16_t modem_cmux_transmit_frame(struct modem_cmux *cmux,
 	fcs = crc8_rohc(MODEM_CMUX_FCS_INIT_VALUE, &buf[1], (buf_idx - 1));
 
 	/* FCS final */
-	if (frame->type == MODEM_CMUX_FRAME_TYPE_UIH) {
-		fcs = 0xFF - fcs;
-	} else {
-		fcs = 0xFF - crc8_rohc(fcs, frame->data, data_len);
+	if (frame->type != MODEM_CMUX_FRAME_TYPE_UIH) {
+		fcs = crc8_rohc(fcs, frame->data, real_len);
+		if (real_extra_len > 0) {
+			fcs = crc8_rohc(fcs, frame->tx_extra, real_extra_len);
+		}
 	}
+	fcs = 0xFF - fcs;
 
 	/* Frame header */
 	ring_buf_put(&cmux->transmit_rb, buf, buf_idx);
 
 	/* Data */
-	ring_buf_put(&cmux->transmit_rb, frame->data, data_len);
+	ring_buf_put(&cmux->transmit_rb, frame->data, real_len);
+	if (real_extra_len > 0) {
+		ring_buf_put(&cmux->transmit_rb, frame->tx_extra, real_extra_len);
+	}
 
 	/* FCS and EOF will be put on the same call */
 	buf[0] = fcs;
@@ -1929,7 +1944,8 @@ static int modem_cmux_dlci_pipe_api_open(void *data)
 	return 0;
 }
 
-static int modem_cmux_dlci_pipe_api_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_cmux_dlci_pipe_api_transmit_double(void *data, const uint8_t *buf, size_t size,
+						    const uint8_t *extra_buf, size_t extra_size)
 {
 	struct modem_cmux_dlci *dlci = (struct modem_cmux_dlci *)data;
 	struct modem_cmux *cmux = dlci->cmux;
@@ -1955,7 +1971,9 @@ static int modem_cmux_dlci_pipe_api_transmit(void *data, const uint8_t *buf, siz
 		.pf = false,
 		.type = MODEM_CMUX_FRAME_TYPE_UIH,
 		.data = buf,
+		.tx_extra = extra_buf,
 		.data_len = size,
+		.tx_extra_len = extra_size,
 	};
 
 	return modem_cmux_transmit_data_frame(cmux, &frame);
@@ -2010,7 +2028,7 @@ static int modem_cmux_dlci_pipe_api_close(void *data)
 
 static const struct modem_pipe_api modem_cmux_dlci_pipe_api = {
 	.open = modem_cmux_dlci_pipe_api_open,
-	.transmit = modem_cmux_dlci_pipe_api_transmit,
+	.transmit_double = modem_cmux_dlci_pipe_api_transmit_double,
 	.receive = modem_cmux_dlci_pipe_api_receive,
 	.close = modem_cmux_dlci_pipe_api_close,
 };

--- a/subsys/modem/modem_pipe.c
+++ b/subsys/modem/modem_pipe.c
@@ -62,8 +62,12 @@ static int pipe_call_open(struct modem_pipe *pipe)
 	return pipe->api->open(pipe->data);
 }
 
-static int pipe_call_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size)
+static int pipe_call_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size,
+			      const uint8_t *extra_buf, size_t extra_size)
 {
+	if (pipe->api->transmit_double) {
+		return pipe->api->transmit_double(pipe->data, buf, size, extra_buf, extra_size);
+	}
 	return pipe->api->transmit(pipe->data, buf, size);
 }
 
@@ -133,14 +137,15 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
 	}
 }
 
-int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size)
+int modem_pipe_transmit_double(struct modem_pipe *pipe, const uint8_t *buf, size_t size,
+			const uint8_t *extra_buf, size_t extra_size)
 {
 	if (!pipe_test_events(pipe, PIPE_EVENT_OPENED_BIT)) {
 		return 0;
 	}
 
 	pipe_clear_events(pipe, PIPE_EVENT_TRANSMIT_IDLE_BIT);
-	return pipe_call_transmit(pipe, buf, size);
+	return pipe_call_transmit(pipe, buf, size, extra_buf, extra_size);
 }
 
 int modem_pipe_receive(struct modem_pipe *pipe, uint8_t *buf, size_t size)

--- a/tests/subsys/modem/mock/modem_backend_mock.c
+++ b/tests/subsys/modem/mock/modem_backend_mock.c
@@ -47,6 +47,60 @@ static bool modem_backend_mock_update(struct modem_backend_mock *mock, const uin
 	return false;
 }
 
+#ifdef CONFIG_TEST_MODEM_MOCK_BACKEND_DOUBLE_TRANSMIT
+
+static int modem_backend_mock_transmit_double(void *data, const uint8_t *buf, size_t size,
+					      const uint8_t *extra_buf, size_t extra_size)
+{
+	struct modem_backend_mock *mock = (struct modem_backend_mock *)data;
+	int ret;
+
+	if ((size + extra_size) > mock->limit) {
+		if (size > mock->limit) {
+			size = mock->limit;
+			extra_size = 0;
+		} else {
+			extra_size = mock->limit - size;
+		}
+	}
+
+	if (mock->bridge) {
+		struct modem_backend_mock *t_mock = mock->bridge;
+
+		ret = ring_buf_put(&t_mock->rx_rb, buf, size);
+		if (extra_size > 0) {
+			ret += ring_buf_put(&t_mock->rx_rb, extra_buf, extra_size);
+		}
+		k_work_submit(&t_mock->receive_ready_work);
+		k_work_submit(&mock->transmit_idle_work);
+		return ret;
+	}
+
+	k_work_submit(&mock->transmit_idle_work);
+
+	if (modem_backend_mock_update(mock, buf, size)) {
+		/* Skip ringbuffer if transaction consumes bytes */
+		ret = size;
+		modem_backend_mock_put(mock, mock->transaction->put,
+				       mock->transaction->put_size);
+
+		modem_backend_mock_prime(mock, mock->transaction->next);
+	} else {
+		ret = ring_buf_put(&mock->tx_rb, buf, size);
+	}
+	if (modem_backend_mock_update(mock, extra_buf, extra_size)) {
+		ret += extra_size;
+		modem_backend_mock_put(mock, mock->transaction->put,
+				       mock->transaction->put_size);
+
+		modem_backend_mock_prime(mock, mock->transaction->next);
+	}
+
+	return ret;
+}
+
+#else
+
 static int modem_backend_mock_transmit(void *data, const uint8_t *buf, size_t size)
 {
 	struct modem_backend_mock *mock = (struct modem_backend_mock *)data;
@@ -79,6 +133,8 @@ static int modem_backend_mock_transmit(void *data, const uint8_t *buf, size_t si
 	return ret;
 }
 
+#endif
+
 static int modem_backend_mock_receive(void *data, uint8_t *buf, size_t size)
 {
 	struct modem_backend_mock *mock = (struct modem_backend_mock *)data;
@@ -97,7 +153,11 @@ static int modem_backend_mock_close(void *data)
 
 struct modem_pipe_api modem_backend_mock_api = {
 	.open = modem_backend_mock_open,
+#ifdef CONFIG_TEST_MODEM_MOCK_BACKEND_DOUBLE_TRANSMIT
+	.transmit_double = modem_backend_mock_transmit_double,
+#else
 	.transmit = modem_backend_mock_transmit,
+#endif
 	.receive = modem_backend_mock_receive,
 	.close = modem_backend_mock_close,
 };

--- a/tests/subsys/modem/modem_chat/Kconfig
+++ b/tests/subsys/modem/modem_chat/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Embeint Pty Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+config MODEM_MOCK_BACKEND_LIMIT
+	int "Mock backend TX limit for test"
+	default 8
+
+source "Kconfig.zephyr"

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -276,7 +276,7 @@ static void *test_modem_chat_setup(void)
 		.rx_buf_size = ARRAY_SIZE(mock_rx_buf),
 		.tx_buf = mock_tx_buf,
 		.tx_buf_size = ARRAY_SIZE(mock_tx_buf),
-		.limit = 8,
+		.limit = CONFIG_MODEM_MOCK_BACKEND_LIMIT,
 	};
 
 	mock_pipe = modem_backend_mock_init(&mock, &mock_config);

--- a/tests/subsys/modem/modem_chat/testcase.yaml
+++ b/tests/subsys/modem/modem_chat/testcase.yaml
@@ -10,6 +10,9 @@ common:
     - native_sim
 tests:
   modem.modem_chat: {}
+  modem.modem_chat.single_byte:
+    extra_configs:
+      - CONFIG_MODEM_MOCK_BACKEND_LIMIT=1
   modem.modem_chat.workq:
     extra_configs:
       - CONFIG_MODEM_DEDICATED_WORKQUEUE=y

--- a/tests/subsys/modem/modem_cmux/Kconfig
+++ b/tests/subsys/modem/modem_cmux/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Embeint Inc
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_MODEM_MOCK_BACKEND_DOUBLE_TRANSMIT
+	bool "Support the `double_transmit` API variant"
+
+source "Kconfig.zephyr"

--- a/tests/subsys/modem/modem_cmux/src/main.c
+++ b/tests/subsys/modem/modem_cmux/src/main.c
@@ -1019,6 +1019,25 @@ ZTEST(modem_cmux, test_modem_cmux_split_large_data)
 		     "Incorrect number of bytes transmitted %d", ret);
 }
 
+ZTEST(modem_cmux, test_modem_cmux_dual_send)
+{
+	int ret;
+	uint32_t events;
+	const char *request = "ATE0";
+	const char *delim = "\r";
+
+	ret = modem_pipe_transmit_double(dlci2_pipe, request, 4, delim, 1);
+	zassert_true(ret == 5, "Failed to transmit both buffers %d", ret);
+
+	events = k_event_wait(&cmux_event, EVENT_CMUX_DLCI2_TRANSMIT_IDLE, false, K_MSEC(200));
+	zassert_equal(events, EVENT_CMUX_DLCI2_TRANSMIT_IDLE,
+		      "Transmit idle event not received for DLCI2 pipe");
+
+	ret = modem_backend_mock_get(&bus_mock, buffer2, sizeof(buffer2));
+	zassert_true(ret == CMUX_BASIC_HRD_SMALL_SIZE + 5,
+		     "Incorrect number of bytes transmitted %d", ret);
+}
+
 ZTEST(modem_cmux, test_modem_cmux_invalid_cr)
 {
 	uint32_t events;

--- a/tests/subsys/modem/modem_cmux/testcase.yaml
+++ b/tests/subsys/modem/modem_cmux/testcase.yaml
@@ -1,11 +1,15 @@
 # Copyright (c) 2023 Trackunit Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+common:
+  tags: modem_cmux
+  harness: ztest
+  platform_allow:
+    - native_sim
+  integration_platforms:
+    - native_sim
 tests:
-  modem.modem_cmux:
-    tags: modem_cmux
-    harness: ztest
-    platform_allow:
-      - native_sim
-    integration_platforms:
-      - native_sim
+  modem.modem_cmux: {}
+  modem.modem_cmux.double_transmit:
+    extra_configs:
+      - CONFIG_TEST_MODEM_MOCK_BACKEND_DOUBLE_TRANSMIT=y

--- a/tests/subsys/modem/modem_pipe/Kconfig
+++ b/tests/subsys/modem/modem_pipe/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Embeint Inc
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_PIPE_BACKEND_DOUBLE_TRANSMIT
+	bool "Support the `double_transmit` API variant"
+
+source "Kconfig.zephyr"

--- a/tests/subsys/modem/modem_pipe/src/main.c
+++ b/tests/subsys/modem/modem_pipe/src/main.c
@@ -32,6 +32,8 @@ struct modem_backend_fake {
 
 	const uint8_t *transmit_buffer;
 	size_t transmit_buffer_size;
+	const uint8_t *extra_transmit_buffer;
+	size_t extra_transmit_buffer_size;
 
 	uint8_t *receive_buffer;
 	size_t receive_buffer_size;
@@ -39,6 +41,7 @@ struct modem_backend_fake {
 	uint8_t synchronous : 1;
 	uint8_t open_called : 1;
 	uint8_t transmit_called : 1;
+	uint8_t transmit_double_called : 1;
 	uint8_t receive_called : 1;
 	uint8_t close_called : 1;
 };
@@ -76,6 +79,30 @@ static void modem_backend_fake_transmit_idle_handler(struct k_work *item)
 	modem_pipe_notify_transmit_idle(&backend->pipe);
 }
 
+#ifdef CONFIG_TEST_PIPE_BACKEND_DOUBLE_TRANSMIT
+
+static int modem_backend_fake_transmit_double(void *data, const uint8_t *buf, size_t size,
+					      const uint8_t *extra_buf, size_t extra_size)
+{
+	struct modem_backend_fake *backend = data;
+
+	backend->transmit_double_called = true;
+	backend->transmit_buffer = buf;
+	backend->transmit_buffer_size = size;
+	backend->extra_transmit_buffer = extra_buf;
+	backend->extra_transmit_buffer_size = extra_size;
+
+	if (backend->synchronous) {
+		modem_pipe_notify_transmit_idle(&backend->pipe);
+	} else {
+		k_work_schedule(&backend->transmit_idle_dwork, TEST_MODEM_PIPE_NOTIFY_TIMEOUT);
+	}
+
+	return size + extra_size;
+}
+
+#else
+
 static int modem_backend_fake_transmit(void *data, const uint8_t *buf, size_t size)
 {
 	struct modem_backend_fake *backend = data;
@@ -92,6 +119,8 @@ static int modem_backend_fake_transmit(void *data, const uint8_t *buf, size_t si
 
 	return size;
 }
+
+#endif /* CONFIG_TEST_PIPE_BACKEND_DOUBLE_TRANSMIT */
 
 static int modem_backend_fake_receive(void *data, uint8_t *buf, size_t size)
 {
@@ -129,7 +158,11 @@ static int modem_backend_fake_close(void *data)
 
 static struct modem_pipe_api modem_backend_fake_api = {
 	.open = modem_backend_fake_open,
+#ifdef CONFIG_TEST_PIPE_BACKEND_DOUBLE_TRANSMIT
+	.transmit_double = modem_backend_fake_transmit_double,
+#else
 	.transmit = modem_backend_fake_transmit,
+#endif
 	.receive = modem_backend_fake_receive,
 	.close = modem_backend_fake_close,
 };
@@ -267,11 +300,18 @@ static void test_pipe_reclose(void)
 
 static void test_pipe_async_transmit(void)
 {
+	bool is_double = IS_ENABLED(CONFIG_TEST_PIPE_BACKEND_DOUBLE_TRANSMIT);
+
 	zassert_equal(modem_pipe_transmit(test_pipe, test_buffer, test_buffer_size),
 		      test_buffer_size, "Failed to transmit");
-	zassert_true(test_backend.transmit_called, "transmit was not called");
+	zassert_equal(is_double, test_backend.transmit_double_called,
+		      "Unexpected transmit_double call count");
+	zassert_equal(!is_double, test_backend.transmit_called, "Unexpected transmit call count");
 	zassert_equal(test_backend.transmit_buffer, test_buffer, "Incorrect buffer");
 	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size,
+		      "Incorrect buffer size");
+	zassert_equal(test_backend.extra_transmit_buffer, NULL, "Incorrect buffer");
+	zassert_equal(test_backend.extra_transmit_buffer_size, 0,
 		      "Incorrect buffer size");
 	zassert_equal(atomic_get(&test_state), 0, "Unexpected state %u",
 		      (uint32_t)atomic_get(&test_state));
@@ -282,11 +322,61 @@ static void test_pipe_async_transmit(void)
 
 static void test_pipe_sync_transmit(void)
 {
+	bool is_double = IS_ENABLED(CONFIG_TEST_PIPE_BACKEND_DOUBLE_TRANSMIT);
+
 	zassert_equal(modem_pipe_transmit(test_pipe, test_buffer, test_buffer_size),
 		      test_buffer_size, "Failed to transmit");
-	zassert_true(test_backend.transmit_called, "transmit was not called");
+	zassert_equal(is_double, test_backend.transmit_double_called,
+		      "Unexpected transmit_double call count");
+	zassert_equal(!is_double, test_backend.transmit_called, "Unexpected transmit call count");
 	zassert_equal(test_backend.transmit_buffer, test_buffer, "Incorrect buffer");
 	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size,
+		      "Incorrect buffer size");
+	zassert_equal(test_backend.extra_transmit_buffer, NULL, "Incorrect buffer");
+	zassert_equal(test_backend.extra_transmit_buffer_size, 0,
+		      "Incorrect buffer size");
+	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT),
+		      "Unexpected state %u", (uint32_t)atomic_get(&test_state));
+}
+
+static void test_pipe_async_transmit_double(void)
+{
+	bool is_double = IS_ENABLED(CONFIG_TEST_PIPE_BACKEND_DOUBLE_TRANSMIT);
+	int rc;
+
+	rc = modem_pipe_transmit_double(test_pipe, test_buffer, test_buffer_size, test_buffer, 1);
+	zassert_equal(is_double, test_backend.transmit_double_called,
+		      "Unexpected transmit_double call count");
+	zassert_equal(!is_double, test_backend.transmit_called, "Unexpected transmit call count");
+	zassert_equal(rc, test_buffer_size + (is_double ? 1 : 0));
+	zassert_equal(test_backend.transmit_buffer, test_buffer, "Incorrect buffer");
+	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size, "Incorrect buffer size");
+	zassert_equal(test_backend.extra_transmit_buffer, is_double ? test_buffer : NULL,
+		      "Incorrect buffer");
+	zassert_equal(test_backend.extra_transmit_buffer_size, is_double ? 1 : 0,
+		      "Incorrect buffer size");
+	zassert_equal(atomic_get(&test_state), 0, "Unexpected state %u",
+		      (uint32_t)atomic_get(&test_state));
+	k_sleep(TEST_MODEM_PIPE_WAIT_TIMEOUT);
+	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT),
+		      "Unexpected state %u", (uint32_t)atomic_get(&test_state));
+}
+
+static void test_pipe_sync_transmit_double(void)
+{
+	bool is_double = IS_ENABLED(CONFIG_TEST_PIPE_BACKEND_DOUBLE_TRANSMIT);
+	int rc;
+
+	rc = modem_pipe_transmit_double(test_pipe, test_buffer, test_buffer_size, test_buffer, 1);
+	zassert_equal(is_double, test_backend.transmit_double_called,
+		      "Unexpected transmit_double call count");
+	zassert_equal(!is_double, test_backend.transmit_called, "Unexpected transmit call count");
+	zassert_equal(rc, test_buffer_size + (is_double ? 1 : 0));
+	zassert_equal(test_backend.transmit_buffer, test_buffer, "Incorrect buffer");
+	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size, "Incorrect buffer size");
+	zassert_equal(test_backend.extra_transmit_buffer, is_double ? test_buffer : NULL,
+		      "Incorrect buffer");
+	zassert_equal(test_backend.extra_transmit_buffer_size, is_double ? 1 : 0,
 		      "Incorrect buffer size");
 	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT),
 		      "Unexpected state %u", (uint32_t)atomic_get(&test_state));
@@ -360,6 +450,7 @@ ZTEST(modem_pipe, test_sync_open_close)
 
 ZTEST(modem_pipe, test_async_transmit)
 {
+	modem_backend_fake_set_sync(&test_backend, false);
 	test_pipe_open();
 	test_reset();
 	test_pipe_async_transmit();
@@ -371,6 +462,22 @@ ZTEST(modem_pipe, test_sync_transmit)
 	test_pipe_open();
 	test_reset();
 	test_pipe_sync_transmit();
+}
+
+ZTEST(modem_pipe, test_async_transmit_double)
+{
+	modem_backend_fake_set_sync(&test_backend, false);
+	test_pipe_open();
+	test_reset();
+	test_pipe_async_transmit_double();
+}
+
+ZTEST(modem_pipe, test_sync_transmit_double)
+{
+	modem_backend_fake_set_sync(&test_backend, true);
+	test_pipe_open();
+	test_reset();
+	test_pipe_sync_transmit_double();
 }
 
 ZTEST(modem_pipe, test_attach)

--- a/tests/subsys/modem/modem_pipe/testcase.yaml
+++ b/tests/subsys/modem/modem_pipe/testcase.yaml
@@ -1,8 +1,12 @@
 # Copyright (c) 2023 Trackunit Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+common:
+  tags: modem_pipe
+  harness: ztest
+  platform_allow: native_sim
 tests:
-  modem.modem_pipe:
-    tags: modem_pipe
-    harness: ztest
-    platform_allow: native_sim
+  modem.modem_pipe: {}
+  modem.modem_pipe.double_transmit:
+    extra_configs:
+      - CONFIG_TEST_PIPE_BACKEND_DOUBLE_TRANSMIT=y


### PR DESCRIPTION
Rework of #98541 to address compatibility feedback.
The existing function `modem_pipe_transmit` continues to work as it does now, regardless of backend support for `transmit_double`.
The new function `modem_pipe_transmit_double` works regardless of backend support for `transmit_double`.

Handle sending the request and delimiter strings in a single call to the pipe backend. This has two advantages:
     1. No time gap between request and delimiter on the interface (more efficient line utilization)
     2. Fewer bytes transmitted on the line for pipes that perform wrapping (CMUX).

For example, sending "ATE0" + "\n" through CMUX now takes 11 bytes, instead of the previous 17 bytes (10 + 7):
```
[00:00:38.268,064] <wrn> modem_cmux: TX
                                     f9 0b ef 0b 41 54 45 30  0d 5d f9                |....ATE0 .].
```

The double buffer send functionality is exposed through a new function in the modem pipe API, meaning all existing code does not require any changes.