### PR TITLE
arch: riscv: incrementally load from misaligned instruction address

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -268,6 +268,20 @@ SECTION_FUNC(exception.entry, _isr_wrapper)
 	 * Notably QEMU when a CSR instruction is involved.
 	 */
 	bnez t2, 1f
+#ifdef CONFIG_RISCV_ISA_EXT_C
+       /*
+        * If compressed extension is enabled, the instruction address may
+        * be misaligned. Check and load instruction incrementally if so.
+       */
+       andi t2, t0, 3
+       beqz t0, 2f
+       lhu t2, 2(t0)
+       slli t2, t2, 16
+       lhu t1, 0(t0)
+       or t2, t2, t1
+       j 1f
+2:
+#endif
 	lw t2, 0(t0)		/* t0 = RV_EPC */
 1:
 #endif


### PR DESCRIPTION
If a core does not populate MTVAL when a floating point instruction triggers an illegal instruction exception, the instruction is loaded from the address in MEPC. However, if the compressed extension is enabled, the address of the instruction may not be aligned on a 4 byte boundary, which results in a nested load address misaligned exception on `lw`.

This patch adds a check on whether the instruction address is aligned when the compressed extension is enabled. If misaligned, the instruction is loaded one halfword at a time (relaxes to 2 byte alignment).

Example exception demonstrating this behavior:

```

[00:00:05.536,841] <err> os: 
[00:00:05.537,246] <err> os:  mcause: 4, Load address misaligned
[00:00:05.537,259] <err> os:   mtval: 230027e6
[00:00:05.537,273] <err> os:      a0: 00000000    t0: 230027e6
[00:00:05.537,282] <err> os:      a1: 00000000    t1: 00000002
[00:00:05.537,286] <err> os:      a2: 00000000    t2: 00000000
[00:00:05.537,294] <err> os:      a3: 40240000    t3: 0000006c
[00:00:05.537,303] <err> os:      a4: 00000000    t4: 00000047
[00:00:05.537,312] <err> os:      a5: 23032000    t5: 23036000
[00:00:05.537,316] <err> os:      a6: 08c41000    t6: 00000001
[00:00:05.537,468] <err> os:      a7: 00800000
[00:00:05.537,482] <err> os:      sp: 42021be0
[00:00:05.537,490] <err> os:      ra: 2302fff4
[00:00:05.537,494] <err> os:    mepc: 23001562
[00:00:05.537,503] <err> os: mstatus: 00001800
[00:00:05.537,511] <err> os: 
[00:00:05.537,520] <err> os:      s0: 4201e44c    s6: 00000000
[00:00:05.537,529] <err> os:      s1: 00000001    s7: 40240000
[00:00:05.537,537] <err> os:      s2: 0000000a    s8: 00000000
[00:00:05.537,546] <err> os:      s3: 23018000    s9: 00000000
[00:00:05.537,550] <err> os:      s4: 00000000   s10: 00000000
[00:00:05.537,559] <err> os:      s5: 00000000   s11: 00000000
[00:00:05.537,567] <err> os: 
[00:00:05.537,586] <err> os: call trace:
[00:00:05.537,653] <err> os:       0: sp: 42021be4 ra: 2302fff4
[00:00:05.537,662] <err> os:       1: sp: 42021bec ra: 23030570
[00:00:05.537,676] <err> os:       2: sp: 42021c28 ra: 230027e6
[00:00:05.537,691] <err> os:       3: sp: 42021c70 ra: 23018000
[00:00:05.537,701] <err> os:       4: sp: 42021c80 ra: 2302fff4
[00:00:05.537,710] <err> os:       5: sp: 42021c90 ra: 23030074
[00:00:05.537,720] <err> os:       6: sp: 42021ca0 ra: 2302ecb8
[00:00:05.537,730] <err> os:       7: sp: 42021cb0 ra: 230272fa
[00:00:05.537,739] <err> os: 
[00:00:05.537,798] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
[00:00:05.537,846] <err> os: Current thread: 0x4201db18 (unknown)
[00:00:05.549,922] <err> os: Halting system

```

`mepc` points to the following:

```
23001562 <_isr_wrapper+0x62>:
23001562:	0002a383          	lw	t2,0(t0)
```

`mtval` (now in the nested trap) holds the address of the floating point instruction because it is the portion of the load address that caused the misaligned exception. `t0` also holds the same value because it was previously read from `mepc` on the initial floating point illegal instruction address exception.

```
230027e6 <__divdf3+0x22>:
230027e6:	00202af3          	frrm	s5
```