### PR TITLE
Support lpit on imx93 m33 core

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021,2024-2025 NXP
+ * Copyright 2021,2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -324,6 +324,19 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 			break;
 		case 2:
 			clock_root = kCLOCK_Root_Lpit3;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+#elif defined(CONFIG_SOC_MIMX9352_M33)
+	case IMX_CCM_LPIT_CLK:
+		switch (instance) {
+		case 0:
+			clock_root = kCLOCK_Root_BusAon;
+			break;
+		case 1:
+			clock_root = kCLOCK_Root_BusWakeup;
 			break;
 		default:
 			return -EINVAL;

--- a/dts/arm/nxp/imx/nxp_imx93_m33.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx93_m33.dtsi
@@ -138,6 +138,68 @@
 			status = "disabled";
 		};
 
+		lpit1: timer@442f0000 {
+			compatible = "nxp,lpit";
+			reg = <0x442f0000 0x1000>;
+			interrupts = <15 0>;
+			clocks = <&ccm IMX_CCM_LPIT1_CLK 0x0 0>;
+			max-load-value = <0xffffffff>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+
+			lpit1_channel0: lpit-channel@0 {
+				compatible = "nxp,lpit-channel";
+				reg = <0>;
+			};
+
+			lpit1_channel1: lpit-channel@1 {
+				compatible = "nxp,lpit-channel";
+				reg = <1>;
+			};
+
+			lpit1_channel2: lpit-channel@2 {
+				compatible = "nxp,lpit-channel";
+				reg = <2>;
+			};
+
+			lpit1_channel3: lpit-channel@3 {
+				compatible = "nxp,lpit-channel";
+				reg = <3>;
+			};
+		};
+
+		lpit2: timer@424c0000 {
+			compatible = "nxp,lpit";
+			reg = <0x424c0000 0x1000>;
+			interrupts = <64 0>;
+			clocks = <&ccm IMX_CCM_LPIT2_CLK 0x0 0>;
+			max-load-value = <0xffffffff>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+
+			lpit2_channel0: lpit-channel@0 {
+				compatible = "nxp,lpit-channel";
+				reg = <0>;
+			};
+
+			lpit2_channel1: lpit-channel@1 {
+				compatible = "nxp,lpit-channel";
+				reg = <1>;
+			};
+
+			lpit2_channel2: lpit-channel@2 {
+				compatible = "nxp,lpit-channel";
+				reg = <2>;
+			};
+
+			lpit2_channel3: lpit-channel@3 {
+				compatible = "nxp,lpit-channel";
+				reg = <3>;
+			};
+		};
+
 		iomuxc: iomuxc@443c0000 {
 			compatible = "nxp,imx-iomuxc";
 			reg = <0x443c0000 DT_SIZE_K(64)>;

--- a/tests/drivers/counter/counter_basic_api/boards/imx93_evk_mimx9352_m33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/imx93_evk_mimx9352_m33.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lpit1 {
+	status = "okay";
+};
+
+&lpit1_channel0 {
+	status = "okay";
+};
+
+&lpit1_channel1 {
+	status = "okay";
+};
+
+&lpit1_channel2 {
+	status = "okay";
+};
+
+&lpit1_channel3 {
+	status = "okay";
+};
+
+&lpit2 {
+	status = "okay";
+};
+
+&lpit2_channel0 {
+	status = "okay";
+};
+
+&lpit2_channel1 {
+	status = "okay";
+};
+
+&lpit2_channel2 {
+	status = "okay";
+};
+
+&lpit2_channel3 {
+	status = "okay";
+};


### PR DESCRIPTION
- Add lpit node support on imx93 m33 core
- Enable lpit test in tests/drivers/counter/counter_basic_api