### PR TITLE
hostap: Fix HostAP legacy crypto for enterprise (CRYPTO_EXT, oid.h)

### DIFF
--- a/snippets/wifi/wifi-enterprise/wifi-enterprise-nrf.conf
+++ b/snippets/wifi/wifi-enterprise/wifi-enterprise-nrf.conf
@@ -1,5 +1,5 @@
-# For TLS and X.509 processing MbedTLS needs large heap size and using separate heap
-# for MbedTLS gives us more control over the heap size.
-CONFIG_MBEDTLS_HEAP_SIZE=75000
+# nRF5340 app RAM is 448 KiB; trim heaps vs wifi-enterprise.conf (100000 / 70000).
+CONFIG_NRF_WIFI_DATA_HEAP_SIZE=28672
+CONFIG_MBEDTLS_HEAP_SIZE=70000
 CONFIG_WIFI_CREDENTIALS_RUNTIME_CERTIFICATES=y
 CONFIG_WIFI_SHELL_RUNTIME_CERTIFICATES=y

--- a/west.yml
+++ b/west.yml
@@ -294,7 +294,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 45e1b7c2b186d39eae2acad37ade4a079726328b
+      revision: 1eae1d6f775d1a6edd5ea30a71bdb69a6f925dc3
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
* Build HostAP removed DHM/DES via legacy_support.cmake for CRYPTO_EXT as well as CRYPTO_ALT.
* Re-export mbedtls/oid.h on the mbedtls interface when HostAP needs it (Oberon TF-PSA no longer ships it; WPA3 EC still does).
* wifi-enterprise-nrf: Smaller heaps on nRF5340 to fix flash overflow