### PR TITLE
boards: microchip: pic32cm_jh01: Updates LED default state

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.dts
@@ -26,7 +26,7 @@
 		compatible = "gpio-leds";
 
 		led0: led_0 {
-			gpios = <&porta 19 GPIO_ACTIVE_HIGH>;
+			gpios = <&porta 19 GPIO_ACTIVE_LOW>;
 			label = "Yellow LED";
 		};
 	};

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
@@ -33,7 +33,7 @@
 		compatible = "gpio-leds";
 
 		led0: led_0 {
-			gpios = <&portc 5 GPIO_ACTIVE_HIGH>;
+			gpios = <&portc 5 GPIO_ACTIVE_LOW>;
 			label = "Yellow LED";
 		};
 	};


### PR DESCRIPTION
- Updates the LED0 to ACTIVE_LOW as per userguide 

 #### pic32cm_jh01_cpro
<img width="884" height="212" alt="image" src="https://github.com/user-attachments/assets/74fa8344-b71b-46d9-9779-aff4a7e56aee" />


#### pic32cm_jh01_cnano
<img width="884" height="212" alt="Screenshot from 2026-05-19 12-58-15" src="https://github.com/user-attachments/assets/cc990b2c-4500-4d12-9ed0-31ce416f91b0" />
