### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -358,7 +358,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: b452ce26db23a79fe50d7307adabfff3a75a53ad
+      revision: cd44ed9674d115457fd620d5a43741576f328e4b
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 47bd5b4ebd357ba637be0f2b092e1c0d370eea2f


### PR DESCRIPTION
Update the HW models module to:
cd44ed9674d115457fd620d5a43741576f328e4b

Including the following:
cd44ed9 hal: use original nrf_uicr.h
9d93e6c 54 CCM: Remove not applicate note
eaa16db 54 FICR: Set INFO.PART & RRAM from NHW_config instead of same value