### PR TITLE
drivers: pwm: mcux_ctimer: add PWM capture support

### DIFF
--- a/drivers/pwm/Kconfig.mcux_ctimer
+++ b/drivers/pwm/Kconfig.mcux_ctimer
@@ -1,4 +1,5 @@
 # (c) Meta Platforms, Inc. and affiliates.
+# Copyright 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config PWM_MCUX_CTIMER
@@ -6,5 +7,6 @@ config PWM_MCUX_CTIMER
 	default y
 	depends on DT_HAS_NXP_CTIMER_PWM_ENABLED
 	select PINCTRL
+	select NXP_INPUTMUX if PWM_CAPTURE
 	help
 	  Enable ctimer based pwm driver.

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -354,8 +354,11 @@ static void mcux_pwm_isr(const struct device *dev)
 		err = u32_add_overflow(capture->overflow_count, 1, &capture->overflow_count);
 	}
 
-	if (capture->capture_channel == 0) {
-		/* Handle Channel A capture */
+	switch (capture->capture_channel) {
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELA) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELA == 1U)
+	case 0:
+		/* Channel A */
 		if (status & kPWM_CaptureA0Flag) {
 			capture->overflow_count = 0;
 		}
@@ -367,8 +370,12 @@ static void mcux_pwm_isr(const struct device *dev)
 			mcux_pwm_handle_capture(dev, first_edge_value, second_edge_value,
 				modValue, err);
 		}
-	} else if (capture->capture_channel == 1) {
-		/* Handle Channel B capture */
+		break;
+#endif
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELB) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELB == 1U)
+	case 1:
+		/* Channel B */
 		if (status & kPWM_CaptureB0Flag) {
 			capture->overflow_count = 0;
 		}
@@ -380,8 +387,12 @@ static void mcux_pwm_isr(const struct device *dev)
 			mcux_pwm_handle_capture(dev, first_edge_value, second_edge_value,
 						modValue, err);
 		}
-	} else {
-		/* Handle Channel X capture */
+		break;
+#endif
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELX) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELX == 1U)
+	case 2:
+		/* Channel X */
 		if (status & kPWM_CaptureX0Flag) {
 			capture->overflow_count = 0;
 		}
@@ -393,6 +404,11 @@ static void mcux_pwm_isr(const struct device *dev)
 			mcux_pwm_handle_capture(dev, first_edge_value, second_edge_value,
 						modValue, err);
 		}
+		break;
+#endif
+	default:
+		/* unsupported channel for this SoC: check_channel() should have rejected it */
+		break;
 	}
 }
 
@@ -547,21 +563,40 @@ static int mcux_pwm_enable_capture(const struct device *dev, uint32_t channel)
 	status = PWM_GetStatusFlags(config->base, config->index);
 	PWM_ClearStatusFlags(config->base, config->index, status);
 	/* Enable interrupt and clear the capture FIFOs by reading them */
-	if (channel == 0U) {
+	switch (channel) {
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELA) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELA == 1U)
+	case 0U:
+		/* Channel A */
 		(void)config->base->SM[config->index].CVAL2;
 		(void)config->base->SM[config->index].CVAL3;
 		PWM_EnableInterrupts(config->base, config->index, kPWM_CaptureA0InterruptEnable |
 			kPWM_CaptureA1InterruptEnable | kPWM_ReloadInterruptEnable);
-	} else if (channel == 1U) {
+		break;
+#endif
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELB) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELB == 1U)
+	case 1U:
+		/* Channel B */
 		(void)config->base->SM[config->index].CVAL4;
 		(void)config->base->SM[config->index].CVAL5;
 		PWM_EnableInterrupts(config->base, config->index, kPWM_CaptureB0InterruptEnable |
 			kPWM_CaptureB1InterruptEnable | kPWM_ReloadInterruptEnable);
-	} else {
+		break;
+#endif
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELX) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELX == 1U)
+	case 2U:
+		/* Channel X */
 		(void)config->base->SM[config->index].CVAL0;
 		(void)config->base->SM[config->index].CVAL1;
 		PWM_EnableInterrupts(config->base, config->index, kPWM_CaptureX0InterruptEnable |
 			kPWM_CaptureX1InterruptEnable | kPWM_ReloadInterruptEnable);
+		break;
+#endif
+	default:
+		/* unsupported channel for this SoC: check_channel() should have rejected it */
+		break;
 	}
 
 	/* Start the PWM counter if it's stopped.*/
@@ -584,15 +619,34 @@ static int mcux_pwm_disable_capture(const struct device *dev, uint32_t channel)
 	}
 
 	/* Disable capture interrupts */
-	if (channel == 0U) {
+	switch (channel) {
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELA) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELA == 1U)
+	case 0U:
+		/* Channel A */
 		PWM_DisableInterrupts(config->base, config->index, kPWM_CaptureA0InterruptEnable |
 			kPWM_CaptureA1InterruptEnable | kPWM_ReloadInterruptEnable);
-	} else if (channel == 1U) {
+		break;
+#endif
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELB) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELB == 1U)
+	case 1U:
+		/* Channel B */
 		PWM_DisableInterrupts(config->base, config->index, kPWM_CaptureB0InterruptEnable |
 			kPWM_CaptureB1InterruptEnable | kPWM_ReloadInterruptEnable);
-	} else {
+		break;
+#endif
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELX) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELX == 1U)
+	case 2U:
+		/* Channel X */
 		PWM_DisableInterrupts(config->base, config->index, kPWM_CaptureX0InterruptEnable |
 			kPWM_CaptureX1InterruptEnable | kPWM_ReloadInterruptEnable);
+		break;
+#endif
+	default:
+		/* unsupported channel for this SoC: check_channel() should have rejected it */
+		break;
 	}
 
 	data->capture_active = false;

--- a/drivers/pwm/pwm_mcux_ctimer.c
+++ b/drivers/pwm/pwm_mcux_ctimer.c
@@ -14,6 +14,10 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#ifdef CONFIG_PWM_CAPTURE
+#include <zephyr/irq.h>
+#include <fsl_inputmux.h>
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pwm_mcux_ctimer, CONFIG_PWM_LOG_LEVEL);
@@ -31,11 +35,33 @@ struct pwm_ctimer_channel_state {
 	uint32_t cycles;
 };
 
+#ifdef CONFIG_PWM_CAPTURE
+struct pwm_ctimer_capture_data {
+	pwm_capture_callback_handler_t callback;
+	void *user_data;
+	uint32_t capture_channel;
+	bool pulse_capture;
+	bool inverted;
+	bool continuous;
+	bool active;
+	bool first_edge_seen;
+};
+
+struct pwm_ctimer_inputmux_entry {
+	INPUTMUX_Type *base;
+	uint16_t channel;
+	uint32_t connection;
+};
+#endif /* CONFIG_PWM_CAPTURE */
+
 struct pwm_mcux_ctimer_data {
 	struct pwm_ctimer_channel_state channel_states[CHANNEL_COUNT];
 	ctimer_match_t current_period_channel;
 	bool is_period_channel_set;
 	uint32_t num_active_pulse_chans;
+#ifdef CONFIG_PWM_CAPTURE
+	struct pwm_ctimer_capture_data capture;
+#endif
 };
 
 struct pwm_mcux_ctimer_config {
@@ -45,6 +71,11 @@ struct pwm_mcux_ctimer_config {
 	const struct device *clock_control;
 	clock_control_subsys_t clock_id;
 	const struct pinctrl_dev_config *pincfg;
+#ifdef CONFIG_PWM_CAPTURE
+	const struct pwm_ctimer_inputmux_entry *inputmux_entries;
+	uint8_t inputmux_entries_count;
+	void (*irq_config_func)(const struct device *dev);
+#endif
 };
 
 /*
@@ -162,6 +193,13 @@ static int mcux_ctimer_pwm_set_cycles(const struct device *dev, uint32_t pulse_c
 		return -ENOTSUP;
 	}
 
+#ifdef CONFIG_PWM_CAPTURE
+	if (data->capture.active) {
+		LOG_ERR("Cannot set PWM cycles while capture is active");
+		return -EBUSY;
+	}
+#endif
+
 	ret = mcux_ctimer_pwm_select_period_channel(data, pulse_channel, period_cycles,
 						    &period_channel);
 	if (ret != 0) {
@@ -230,6 +268,224 @@ static int mcux_ctimer_pwm_get_cycles_per_sec(const struct device *dev, uint32_t
 	return err;
 }
 
+#ifdef CONFIG_PWM_CAPTURE
+
+static void mcux_ctimer_pwm_setup_inputmux(const struct pwm_mcux_ctimer_config *config)
+{
+	for (uint8_t i = 0; i < config->inputmux_entries_count; i++) {
+		const struct pwm_ctimer_inputmux_entry *entry = &config->inputmux_entries[i];
+
+		INPUTMUX_Init(entry->base);
+		INPUTMUX_AttachSignal(entry->base, entry->channel,
+				      (inputmux_connection_t)entry->connection);
+		INPUTMUX_Deinit(entry->base);
+	}
+}
+
+static int mcux_ctimer_pwm_configure_capture(const struct device *dev, uint32_t channel,
+					     pwm_flags_t flags,
+					     pwm_capture_callback_handler_t cb, void *user_data)
+{
+	struct pwm_mcux_ctimer_data *data = dev->data;
+	struct pwm_ctimer_capture_data *capture = &data->capture;
+
+	if (channel >= CHANNEL_COUNT) {
+		LOG_ERR("invalid capture channel %u", channel);
+		return -EINVAL;
+	}
+
+	if ((flags & PWM_CAPTURE_TYPE_MASK) == 0U) {
+		LOG_ERR("no capture type specified");
+		return -EINVAL;
+	}
+
+	if ((flags & PWM_CAPTURE_TYPE_MASK) == PWM_CAPTURE_TYPE_BOTH) {
+		LOG_ERR("simultaneous period and pulse capture not supported");
+		return -ENOTSUP;
+	}
+
+	if (cb == NULL) {
+		LOG_ERR("PWM capture callback is not configured");
+		return -EINVAL;
+	}
+
+	if (capture->active) {
+		LOG_ERR("capture already active on this ctimer");
+		return -EBUSY;
+	}
+
+	if (data->num_active_pulse_chans != 0U) {
+		LOG_ERR("cannot capture while PWM output active on same ctimer");
+		return -EBUSY;
+	}
+
+	capture->callback = cb;
+	capture->user_data = user_data;
+	capture->capture_channel = channel;
+	capture->pulse_capture = ((flags & PWM_CAPTURE_TYPE_MASK) == PWM_CAPTURE_TYPE_PULSE);
+	capture->inverted = ((flags & PWM_POLARITY_MASK) == PWM_POLARITY_INVERTED);
+	capture->continuous = ((flags & PWM_CAPTURE_MODE_MASK) == PWM_CAPTURE_MODE_CONTINUOUS);
+	capture->first_edge_seen = false;
+
+	return 0;
+}
+
+static int mcux_ctimer_pwm_enable_capture(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_ctimer_config *config = dev->config;
+	struct pwm_mcux_ctimer_data *data = dev->data;
+	struct pwm_ctimer_capture_data *capture = &data->capture;
+	CTIMER_Type *base = config->base;
+	ctimer_capture_channel_t ch;
+	ctimer_capture_edge_t irq_edge;
+	uint32_t selcc_value;
+	bool clear_on_rising;
+
+	if (channel >= CHANNEL_COUNT) {
+		return -EINVAL;
+	}
+
+	if (capture->callback == NULL) {
+		LOG_ERR("capture not configured");
+		return -EINVAL;
+	}
+
+	if (capture->active) {
+		LOG_ERR("capture already active");
+		return -EBUSY;
+	}
+
+	if (channel != capture->capture_channel) {
+		LOG_ERR("channel %u does not match configured channel %u", channel,
+			capture->capture_channel);
+		return -EINVAL;
+	}
+
+	ch = (ctimer_capture_channel_t)capture->capture_channel;
+	clear_on_rising = !capture->inverted;
+	if (capture->pulse_capture) {
+		irq_edge = capture->inverted ? kCTIMER_Capture_RiseEdge : kCTIMER_Capture_FallEdge;
+	} else {
+		irq_edge = capture->inverted ? kCTIMER_Capture_FallEdge : kCTIMER_Capture_RiseEdge;
+	}
+
+	/* stop timer and reset TC before arming so the first edge starts fresh */
+	CTIMER_StopTimer(base);
+	CTIMER_Reset(base);
+	CTIMER_ClearStatusFlags(base, CTIMER_IR_CR0INT_MASK << capture->capture_channel);
+
+	capture->first_edge_seen = false;
+	capture->active = true;
+
+	/* CCR: select capture edge for this channel, enable capture interrupt */
+	CTIMER_SetupCapture(base, ch, irq_edge, true);
+
+	/*
+	 * Enable the ctimer "capture clears timer" feature: the chosen edge on
+	 * the selected capture channel automatically resets TC and PC in
+	 * hardware. The next capture event therefore latches CR equal to the
+	 * time elapsed since that reset edge, i.e. one period or one pulse
+	 * width directly, with no software subtraction and no TC wrap-around
+	 * handling.
+	 */
+	selcc_value = ((uint32_t)ch * 2U) + (clear_on_rising ? 0U : 1U);
+	base->CTCR = (base->CTCR & ~(CTIMER_CTCR_SELCC_MASK | CTIMER_CTCR_ENCC_MASK)) |
+		     CTIMER_CTCR_ENCC_MASK | CTIMER_CTCR_SELCC(selcc_value);
+
+	CTIMER_StartTimer(base);
+
+	return 0;
+}
+
+static int mcux_ctimer_pwm_disable_capture(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_ctimer_config *config = dev->config;
+	struct pwm_mcux_ctimer_data *data = dev->data;
+	struct pwm_ctimer_capture_data *capture = &data->capture;
+
+	if (channel >= CHANNEL_COUNT) {
+		return -EINVAL;
+	}
+
+	if (!capture->active) {
+		return 0;
+	}
+
+	if (channel != capture->capture_channel) {
+		LOG_ERR("channel %u does not match configured channel %u",
+			channel, capture->capture_channel);
+		return -EINVAL;
+	}
+
+	/*
+	 * Tear down the capture channel: disable the capture interrupt, clear
+	 * both rising/falling edge enables, and turn off the capture-clears-TC
+	 * feature in CTCR.
+	 */
+	ctimer_capture_channel_t ch = (ctimer_capture_channel_t)capture->capture_channel;
+
+	CTIMER_DisableInterrupts(config->base, CTIMER_CCR_CAP0I_MASK << ((uint32_t)ch * 3U));
+	CTIMER_EnableRisingEdgeCapture(config->base, ch, false);
+	CTIMER_EnableFallingEdgeCapture(config->base, ch, false);
+	config->base->CTCR &= ~(CTIMER_CTCR_ENCC_MASK | CTIMER_CTCR_SELCC_MASK);
+
+	CTIMER_StopTimer(config->base);
+	CTIMER_ClearStatusFlags(config->base, CTIMER_IR_CR0INT_MASK << capture->capture_channel);
+
+	capture->active = false;
+	capture->first_edge_seen = false;
+
+	return 0;
+}
+
+static void mcux_ctimer_pwm_isr(const struct device *dev)
+{
+	const struct pwm_mcux_ctimer_config *config = dev->config;
+	struct pwm_mcux_ctimer_data *data = dev->data;
+	struct pwm_ctimer_capture_data *capture = &data->capture;
+	uint32_t cap_flag;
+	uint32_t cycles;
+
+	if (!capture->active) {
+		CTIMER_ClearStatusFlags(config->base, CTIMER_IR_CR0INT_MASK |
+			CTIMER_IR_CR1INT_MASK | CTIMER_IR_CR2INT_MASK | CTIMER_IR_CR3INT_MASK);
+
+		return;
+	}
+
+	cap_flag = CTIMER_IR_CR0INT_MASK << capture->capture_channel;
+	if ((CTIMER_GetStatusFlags(config->base) & cap_flag) == 0U) {
+		return;
+	}
+
+	cycles = config->base->CR[capture->capture_channel];
+	CTIMER_ClearStatusFlags(config->base, cap_flag);
+
+	if (!capture->first_edge_seen) {
+		/*
+		 * First edge after enable: TC was started at an unknown point in the
+		 * input waveform, so the captured value is not meaningful. Skip it and
+		 * use subsequent edges (TC has now been cleared by hardware on the
+		 * configured edge, so the next capture is referenced from that edge).
+		 */
+		capture->first_edge_seen = true;
+		return;
+	}
+
+	if (!capture->continuous) {
+		mcux_ctimer_pwm_disable_capture(dev, capture->capture_channel);
+	}
+
+	if (capture->pulse_capture) {
+		capture->callback(dev, capture->capture_channel, 0U, cycles, 0,
+				  capture->user_data);
+	} else {
+		capture->callback(dev, capture->capture_channel, cycles, 0U, 0,
+				  capture->user_data);
+	}
+}
+#endif /* CONFIG_PWM_CAPTURE */
+
 static int mcux_ctimer_pwm_init(const struct device *dev)
 {
 	const struct pwm_mcux_ctimer_config *config = dev->config;
@@ -251,16 +507,65 @@ static int mcux_ctimer_pwm_init(const struct device *dev)
 	pwm_config.prescale = config->prescale;
 
 	CTIMER_Init(config->base, &pwm_config);
+
+#ifdef CONFIG_PWM_CAPTURE
+	mcux_ctimer_pwm_setup_inputmux(config);
+	if (config->irq_config_func != NULL) {
+		config->irq_config_func(dev);
+	}
+#endif
+
 	return 0;
 }
 
 static DEVICE_API(pwm, pwm_mcux_ctimer_driver_api) = {
 	.set_cycles = mcux_ctimer_pwm_set_cycles,
 	.get_cycles_per_sec = mcux_ctimer_pwm_get_cycles_per_sec,
+#ifdef CONFIG_PWM_CAPTURE
+	.configure_capture = mcux_ctimer_pwm_configure_capture,
+	.enable_capture = mcux_ctimer_pwm_enable_capture,
+	.disable_capture = mcux_ctimer_pwm_disable_capture,
+#endif
 };
 
 #define PWM_MCUX_CTIMER_PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
 #define PWM_MCUX_CTIMER_PINCTRL_INIT(n)   .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
+
+#ifdef CONFIG_PWM_CAPTURE
+#define PWM_MCUX_CTIMER_IRQ_FUNC_DECL(n)                                                           \
+	static void pwm_mcux_ctimer_irq_config_##n(const struct device *dev);
+#define PWM_MCUX_CTIMER_IRQ_FUNC_INIT(n) .irq_config_func = pwm_mcux_ctimer_irq_config_##n,
+#define PWM_MCUX_CTIMER_IRQ_FUNC_DEFINE(n)                                                         \
+	static void pwm_mcux_ctimer_irq_config_##n(const struct device *dev)                       \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), mcux_ctimer_pwm_isr,        \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQN(n));                                                       \
+	}
+#define PWM_MCUX_CTIMER_INPUTMUX_ENTRY(node_id, prop, idx)                                         \
+	{                                                                                          \
+		.base = (INPUTMUX_Type *)DT_REG_ADDR(DT_PHANDLE_BY_IDX(node_id, prop, idx)),       \
+		.channel = (uint16_t)DT_PHA_BY_IDX(node_id, prop, idx, channel),                   \
+		.connection = (uint32_t)DT_PHA_BY_IDX(node_id, prop, idx, connection),             \
+	}
+#define PWM_MCUX_CTIMER_INPUTMUX_DEFINE(n)                                                         \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, inputmux_connections),                                \
+		    (static const struct pwm_ctimer_inputmux_entry                                 \
+			    pwm_mcux_ctimer_inputmux_entries_##n[] = {                             \
+			    DT_INST_FOREACH_PROP_ELEM_SEP(n, inputmux_connections,                 \
+							  PWM_MCUX_CTIMER_INPUTMUX_ENTRY, (,))     \
+		    };), ())
+#define PWM_MCUX_CTIMER_INPUTMUX_INIT(n)                                                           \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, inputmux_connections),                                \
+		    (.inputmux_entries = pwm_mcux_ctimer_inputmux_entries_##n,                     \
+		     .inputmux_entries_count = DT_INST_PROP_LEN(n, inputmux_connections),), ())
+#else
+#define PWM_MCUX_CTIMER_IRQ_FUNC_DECL(n)
+#define PWM_MCUX_CTIMER_IRQ_FUNC_INIT(n)
+#define PWM_MCUX_CTIMER_IRQ_FUNC_DEFINE(n)
+#define PWM_MCUX_CTIMER_INPUTMUX_DEFINE(n)
+#define PWM_MCUX_CTIMER_INPUTMUX_INIT(n)
+#endif
 
 #define PWM_MCUX_CTIMER_DEVICE_INIT_MCUX(n)                                                        \
 	static struct pwm_mcux_ctimer_data pwm_mcux_ctimer_data_##n = {                            \
@@ -279,15 +584,21 @@ static DEVICE_API(pwm, pwm_mcux_ctimer_driver_api) = {
 		.is_period_channel_set = false,                                                    \
 	};                                                                                         \
 	PWM_MCUX_CTIMER_PINCTRL_DEFINE(n)                                                          \
+	PWM_MCUX_CTIMER_IRQ_FUNC_DECL(n)                                                           \
+	PWM_MCUX_CTIMER_INPUTMUX_DEFINE(n)                                                         \
 	static const struct pwm_mcux_ctimer_config pwm_mcux_ctimer_config_##n = {                  \
 		.base = (CTIMER_Type *)DT_INST_REG_ADDR(n),                                        \
 		.prescale = DT_INST_PROP(n, prescaler),                                            \
 		.clock_control = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                            \
 		.clock_id = (clock_control_subsys_t)(DT_INST_CLOCKS_CELL(n, name)),                \
-		PWM_MCUX_CTIMER_PINCTRL_INIT(n)};                                                  \
+		PWM_MCUX_CTIMER_PINCTRL_INIT(n)                                                    \
+		PWM_MCUX_CTIMER_INPUTMUX_INIT(n)                                                   \
+		PWM_MCUX_CTIMER_IRQ_FUNC_INIT(n)                                                   \
+	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, mcux_ctimer_pwm_init, NULL, &pwm_mcux_ctimer_data_##n,            \
 			      &pwm_mcux_ctimer_config_##n, POST_KERNEL,                            \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &pwm_mcux_ctimer_driver_api);
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &pwm_mcux_ctimer_driver_api);    \
+	PWM_MCUX_CTIMER_IRQ_FUNC_DEFINE(n)
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_MCUX_CTIMER_DEVICE_INIT_MCUX)

--- a/drivers/pwm/pwm_mcux_ctimer.c
+++ b/drivers/pwm/pwm_mcux_ctimer.c
@@ -169,9 +169,25 @@ static int mcux_ctimer_pwm_set_cycles(const struct device *dev, uint32_t pulse_c
 		return ret;
 	}
 
+	/*
+	 * CTIMER PWM-mode output: after each TC reset the pin starts LOW; it
+	 * transitions HIGH when TC matches MR[pulse_channel] and stays HIGH until
+	 * the next TC reset (MR[period_channel] match). So in hardware:
+	 *     LOW  duration = MR[pulse_channel]
+	 *     HIGH duration = period - MR[pulse_channel]
+	 * Boundary handling (symmetric across polarity):
+	 *   - MR > period  → match never fires → pin stays LOW the whole period
+	 *   - MR == 0      → match fires at TC=0 → pin stays HIGH (approx) the whole period
+	 */
 	if (flags & PWM_POLARITY_INVERTED) {
+		if (pulse_cycles == period_cycles) {
+			/* always active(LOW): keep pin LOW the entire period */
+			pulse_cycles = period_cycles + 1;
+		}
+		/* else: pulse_cycles passes through unchanged as MR[pulse] */
+	} else {
 		if (pulse_cycles == 0) {
-			/* make pulse cycles greater than period so event never occurs */
+			/* always inactive(LOW): keep pin LOW the entire period */
 			pulse_cycles = period_cycles + 1;
 		} else {
 			pulse_cycles = period_cycles - pulse_cycles;

--- a/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
@@ -238,6 +238,12 @@
 			nxp,kinetis-port = <&portd>;
 		};
 
+		inputmux0: inputmux@40001000 {
+			compatible = "nxp,inputmux";
+			reg = <0x40001000 0x1000>;
+			#inputmux-cells = <2>;
+		};
+
 		i3c0: i3c@40002000 {
 			compatible = "nxp,mcux-i3c";
 			reg = <0x40002000 0x1000>;

--- a/dts/bindings/mux/nxp,inputmux.yaml
+++ b/dts/bindings/mux/nxp,inputmux.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  NXP INPUTMUX peripheral.
+
+  The INPUTMUX is an on-chip signal router that connects internal
+  trigger sources to peripheral capture/trigger inputs (e.g. CTIMER
+  capture inputs, DMA triggers, PINT sources).
+
+  Consumers reference an INPUTMUX via a phandle-array property and
+  pass two specifier cells:
+    - channel:    destination index inside the destination register
+                  group (e.g. CAPTSEL0..3, PINTSEL0..7).
+    - connection: 32-bit inputmux_connection_t value from the NXP HAL
+                  header fsl_inputmux_connections.h. It encodes the
+                  destination register-group offset in the upper bits
+                  and the source/function id in the lower bits.
+
+compatible: "nxp,inputmux"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  "#inputmux-cells":
+    type: int
+    const: 2
+
+inputmux-cells:
+  - channel
+  - connection

--- a/dts/bindings/pwm/nxp,ctimer-pwm.yaml
+++ b/dts/bindings/pwm/nxp,ctimer-pwm.yaml
@@ -1,4 +1,5 @@
 # (c) Meta Platforms, Inc. and affiliates.
+# Copyright 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP CTimer PWM
@@ -22,6 +23,20 @@ properties:
     type: int
     required: true
     description: clock to use
+
+  inputmux-connections:
+    type: phandle-array
+    specifier-space: inputmux
+    description: |
+      INPUTMUX routing for PWM capture inputs. Each phandle-array entry
+      is <&inputmuxN channel connection> where:
+        - &inputmuxN is the INPUTMUX node providing the route
+        - channel is the CAPTSEL destination index (0..3)
+        - connection is an inputmux_connection_t value from
+          fsl_inputmux_connections.h
+
+      Example (route CT_INP15 to CTIMER2 CAPTSEL[0] via INPUTMUX0):
+        inputmux-connections = <&inputmux0 0 0x06000010>;
 
   "#pwm-cells":
     const: 3

--- a/tests/drivers/pwm/pwm_loopback/boards/frdm_mcxa153.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/frdm_mcxa153.overlay
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+&pinctrl {
+	pinmux_ctimer1_pwm_out: pinmux_ctimer1_pwm_out {
+		group0 {
+			pinmux = <CT1_MAT0_P2_4>;
+			slew-rate = "fast";
+			drive-strength = "low";
+		};
+	};
+
+	pinmux_ctimer2_pwm_cap: pinmux_ctimer2_pwm_cap {
+		group0 {
+			pinmux = <CT_INP15_P2_5>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+		};
+	};
+};
+
+/* To test this sample, connect
+ * PIO2_4(J1-6) ---> PIO2_5(J1-10)
+ */
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&ctimer1 0 0 PWM_POLARITY_NORMAL>, /* OUT: CT1_MAT0 P2_4 (J1-6) */
+		       <&ctimer2 0 0 PWM_POLARITY_NORMAL>; /* IN : CT_INP15 P2_5 (J1-10) */
+	};
+};
+
+&ctimer1 {
+	status = "okay";
+	compatible = "nxp,ctimer-pwm";
+	prescaler = <95>;
+	#pwm-cells = <3>;
+	pinctrl-0 = <&pinmux_ctimer1_pwm_out>;
+	pinctrl-names = "default";
+};
+
+&ctimer2 {
+	status = "okay";
+	compatible = "nxp,ctimer-pwm";
+	prescaler = <95>;
+	#pwm-cells = <3>;
+	/*
+	 * Route CT_INP15 (P2_5) to CTIMER2 CAPTSEL[0] via INPUTMUX0.
+	 * Cells: <&inputmux0 channel connection> where connection is
+	 * kINPUTMUX_CtimerInp15ToTimer2Captsel = 16U | (TIMER2CAPTSEL0 << 20)
+	 * = 0x06000010.
+	 */
+	inputmux-connections = <&inputmux0 0 0x06000010>;
+	pinctrl-0 = <&pinmux_ctimer2_pwm_cap>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
1. Implement the Zephyr PWM capture API using CTIMER
2. Fix pwm_loopback build error caused by undefined data
3. Enable pwm_loopback for frdm_mcxa153