### PR TITLE
drivers: audio: dmic_pdm_nrfx: used defined gain symbols

### DIFF
--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -286,11 +286,12 @@ static int dmic_nrfx_pdm_configure(const struct device *dev,
 		channel->act_chan_map_lo = alt_map;
 	}
 
-	/* Limit requested gain to +- 20dB */
-	gain_limit = CLAMP(stream->gain_db, -20, 20);
-	/* Registers are 0.5dB steps */
-	nrfx_cfg.gain_l = NRF_PDM_GAIN_DEFAULT + (2 * gain_limit);
-	nrfx_cfg.gain_r = NRF_PDM_GAIN_DEFAULT + (2 * gain_limit);
+	/* Convert requested gain to 0.5 dB steps limited by defined bounds. */
+	gain_limit = CLAMP((2 * stream->gain_db + NRF_PDM_GAIN_DEFAULT),
+			   NRF_PDM_GAIN_MINIMUM,
+			   NRF_PDM_GAIN_MAXIMUM);
+	nrfx_cfg.gain_l = gain_limit;
+	nrfx_cfg.gain_r = gain_limit;
 
 #if NRF_PDM_HAS_SELECTABLE_CLOCK
 	nrfx_cfg.mclksrc = drv_cfg->clk_src == ACLK


### PR DESCRIPTION
Avoid using magic numbers for gain values, use defined symbols instead.