### PR TITLE
Add frdm imxrt1186 flexio features

### DIFF
--- a/tests/drivers/pwm/pwm_api/boards/frdm_imxrt1186_flexio_pwm.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/frdm_imxrt1186_flexio_pwm.overlay
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &flexio2_pwm;
+	};
+};
+
+&pinctrl {
+	pinmux_flexio2_pwm: pinmux_flexio2_pwm {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_12_flexio2_d12>; /* Arduino D8 */
+			drive-strength = "normal";
+			slew-rate = "slow";
+		};
+	};
+};
+
+&flexio2 {
+	status = "okay";
+
+	flexio2_pwm: flexio2_pwm {
+		compatible = "nxp,flexio-pwm";
+		#pwm-cells = <3>;
+		status = "okay";
+		pinctrl-0 = <&pinmux_flexio2_pwm>;
+		pinctrl-names = "default";
+
+		pwm_0 {
+			pin-id = <12>;
+			prescaler = <1>;
+		};
+	};
+};

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -21,6 +21,8 @@ tests:
       - platform:frdm_mcxa366/mcxa366:DTC_OVERLAY_FILE="boards/frdm_mcxa366_flexio_pwm.overlay"
       - platform:frdm_mcxa266/mcxa266:DTC_OVERLAY_FILE="boards/frdm_mcxa266_flexio_pwm.overlay"
       - platform:frdm_mcxe247/mcxe247:DTC_OVERLAY_FILE="boards/frdm_mcxe247_flexio_pwm.overlay"
+      - platform:frdm_imxrt1186/mimxrt1186/cm33:DTC_OVERLAY_FILE="boards/frdm_imxrt1186_flexio_pwm.overlay"
+      - platform:frdm_imxrt1186/mimxrt1186/cm7:DTC_OVERLAY_FILE="boards/frdm_imxrt1186_flexio_pwm.overlay"
     platform_allow:
       - frdm_ke17z
       - frdm_ke17z512
@@ -30,6 +32,8 @@ tests:
       - frdm_mcxa366/mcxa366
       - frdm_mcxa266/mcxa266
       - frdm_mcxe247
+      - frdm_imxrt1186/mimxrt1186/cm33
+      - frdm_imxrt1186/mimxrt1186/cm7
     filter: dt_alias_exists("pwm-test") and CONFIG_DT_HAS_NXP_FLEXIO_ENABLED
      and CONFIG_DT_HAS_NXP_FLEXIO_PWM_ENABLED
     depends_on: pwm

--- a/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_flexio_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_flexio_spi.overlay
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Move J32 and J31 to 2-3, then short J51-6 <-> J51-12 for the loopback. */
+
+&lpi2c3 {
+	status = "disabled";
+};
+
+&pinctrl {
+	pinmux_flexio2_spi: pinmux_flexio2_spi {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_16_gpio4_io16>,  /* cs  */
+				 <&iomuxc_gpio_ad_17_flexio2_d17>, /* sdo */
+				 <&iomuxc_gpio_ad_18_flexio2_d18>, /* sdi */
+				 <&iomuxc_gpio_ad_19_flexio2_d19>; /* sck */
+			drive-strength = "high";
+			slew-rate = "slow";
+		};
+	};
+};
+
+&flexio2 {
+	status = "okay";
+
+	flexio2_spi: flexio2_spi {
+		compatible = "nxp,flexio-spi";
+		cs-gpios = <&gpio4 16 GPIO_ACTIVE_LOW>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		sdo-pin = <17>;
+		sdi-pin = <18>;
+		sck-pin = <19>;
+		pinctrl-0 = <&pinmux_flexio2_spi>;
+		pinctrl-names = "default";
+		status = "okay";
+
+		slow@0 {
+			compatible = "test-spi-loopback-slow";
+			reg = <0>;
+			spi-max-frequency = <500000>;
+		};
+
+		fast@0 {
+			compatible = "test-spi-loopback-fast";
+			reg = <0>;
+			spi-max-frequency = <16000000>;
+		};
+	};
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -266,6 +266,8 @@ tests:
       - platform:mimxrt1064_evk:DTC_OVERLAY_FILE="overlay-mcux-flexio-spi.overlay"
       - platform:mimxrt1060_evk/mimxrt1062/qspi:DTC_OVERLAY_FILE="overlay-mcux-flexio-spi.overlay"
       - platform:mimxrt1040_evk:DTC_OVERLAY_FILE="boards/mimxrt1040_evk_flexio_spi.overlay"
+      - platform:frdm_imxrt1186/mimxrt1186/cm33:DTC_OVERLAY_FILE="boards/frdm_imxrt1186_flexio_spi.overlay"
+      - platform:frdm_imxrt1186/mimxrt1186/cm7:DTC_OVERLAY_FILE="boards/frdm_imxrt1186_flexio_spi.overlay"
     filter: CONFIG_DT_HAS_NXP_FLEXIO_ENABLED and
             CONFIG_DT_HAS_NXP_FLEXIO_SPI_ENABLED
     platform_allow:
@@ -275,6 +277,8 @@ tests:
       - mimxrt1064_evk
       - mimxrt1060_evk/mimxrt1062/qspi
       - mimxrt1040_evk
+      - frdm_imxrt1186/mimxrt1186/cm33
+      - frdm_imxrt1186/mimxrt1186/cm7
   drivers.spi.nrf54h_fast_2mhz:
     extra_args:
       - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"


### PR DESCRIPTION
Enable FlexIO PWM and SPI loopback tests on FRDM-iMXRT1186 for both CM33 and CM7 cores:
- `drivers.pwm.pwm_flexio`
- `drivers.spi.flexio_spi.loopback`
