### PR TITLE
drivers: modem: telit: align LE910C1TX with generic cellular modem patterns

### DIFF
--- a/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
@@ -59,7 +59,7 @@ static const struct modem_cellular_config_scripts telit_le910c1tx_scripts = {
 };
 
 #define MODEM_CELLULAR_DEVICE_TELIT_LE910C1TX(inst)                                                \
-	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
+	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
 		.chat_delimiter = "\r",                                                            \

--- a/dts/bindings/modem/telit,le910c1tx.yaml
+++ b/dts/bindings/modem/telit,le910c1tx.yaml
@@ -5,7 +5,7 @@ description: Telit LE910C1tx Modem
 
 compatible: "telit,le910c1tx"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-power-gpios:


### PR DESCRIPTION
Follow-up to drivers: modem: add Telit LEx10Q1 support in generic cellular modem driver (#109206).

This change aligns the previously added Telit LE910C1TX modem with the generic cellular modem patterns used across Zephyr.

The update is a follow-up cleanup inspired by the review of newer Telit modem support and addresses the same integration aspects.

Changes:
- Switch the devicetree binding to zephyr,cellular-modem-device.yaml
- Replace MODEM_PPP_DEFINE with MODEM_DT_INST_PPP_DEFINE to properly associate the PPP net device with the modem device and preserve runtime PM integration

No functional changes are intended beyond consistency with other cellular modem drivers and correct runtime power management behavior.