### PR TITLE
drivers: flash: stm32 ospi driver with TimeOut in MemoryMapped mode

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1698,6 +1698,15 @@ void HAL_OSPI_StatusMatchCallback(OSPI_HandleTypeDef *hospi)
  */
 void HAL_OSPI_TimeOutCallback(OSPI_HandleTypeDef *hospi)
 {
+#ifdef CONFIG_STM32_MEMMAP
+	/*
+	 * When TO occurs, it only comes from MemoryMapped mode read operation
+	 * if the TimeOutActivation was enabled.
+	 * Then no sync semaphore was set when reading with memcpy().
+	 * If TimeOutActivation is not enabled, then no TO callback happens.
+	 * No need to k_sem_give(&dev_data->sync); nothing to do.
+	 */
+#else /* CONFIG_STM32_MEMMAP*/
 	struct flash_stm32_ospi_data *dev_data =
 		CONTAINER_OF(hospi, struct flash_stm32_ospi_data, hospi);
 
@@ -1706,6 +1715,7 @@ void HAL_OSPI_TimeOutCallback(OSPI_HandleTypeDef *hospi)
 	dev_data->cmd_status = -EIO;
 
 	k_sem_give(&dev_data->sync);
+#endif /* CONFIG_STM32_MEMMAP */
 }
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)


### PR DESCRIPTION
Following the PR https://github.com/zephyrproject-rtos/zephyr/pull/108040/  we had some situtations where the write  failed with : 
```
[00:00:00.191,000] <err> flash_stm32_ospi: OSPI flash write enable cmd failed
[00:00:00.191,000] <err> flash_stm32_ospi: Erase failed : write enable
[00:00:00.199,000] <err> flash_stm32_ospi: OSPI AutoPoll command failed
[00:00:00.199,000] <err> flash_stm32_ospi: OSPI: write not ready
```

It comes from the HAL_OSPI_TimeOutCallback() of the drivers/flash/flash_stm32_ospi driver.
When setting the Memory Mapped mode with HAL_OSPI_TIMEOUT_COUNTER_ENABLE, a TimeOut IRQ occurs with its HAL_OSPI_TimeOutCallback function. At this time, no sem was taken by the read operation made by a memcopy (Memory Mapped mode) then no sem has to be released.
