### PR TITLE
dma: mcux: edma: preserve burst length for peripheral-triggered transfers

### DIFF
--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -621,8 +621,15 @@ static inline void dma_mcux_edma_set_xfer_settings(const struct device *dev, uin
 	(!defined(FSL_FEATURE_SOC_DMAMUX_COUNT) || (FSL_FEATURE_SOC_DMAMUX_COUNT == 0))
 	struct dma_block_config *block_config = config->head_block;
 
+	/* Only collapse the minor loop into the whole block for genuine
+	 * software-triggered mem2mem transfers. When a peripheral request is
+	 * routed via the channel mux (dma_slot != 0), each minor loop is
+	 * paced by that request and the caller-chosen burst length must be
+	 * preserved (e.g. FlexIO LCDIF expects one minor loop per shifter
+	 * round).
+	 */
 	if (xfer_settings->transfer_type == kEDMA_MemoryToMemory &&
-	    !config->source_chaining_en) {
+	    !config->source_chaining_en && config->dma_slot == 0) {
 		xfer_settings->source_burst_length = block_config->block_size;
 	}
 #endif


### PR DESCRIPTION
When a DMA channel is routed through the channel mux (dma_slot != 0), each minor loop is paced by the peripheral request signal. In this case, the caller-chosen burst length must be preserved to ensure correct operation.
Previously, the driver would collapse the minor loop into the whole block for all memory-to-memory transfers without source chaining, but this logic should only apply to genuine software-triggered transfers. Peripheral- triggered transfers (e.g., FlexIO LCDIF) expect one minor loop per shifter round, and collapsing the loop breaks this requirement.
Add a check for dma_slot == 0 to ensure burst length collapsing only occurs for software-triggered transfers, not peripheral-triggered ones.

 This fixes the issue of display demo on frdm_mcxn947 
'west build -b frdm_mcxn947/mcxn947/cpu0 samples/drivers/display -DSHIELD="lcd_par_s035_8080"'