### PR TITLE
mgmt: hawkbit: use k_malloc instead of k_calloc

### DIFF
--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -1285,7 +1285,7 @@ static void s_http_start(void *o)
 
 	s->hb_context.response_data_size = RESPONSE_BUFFER_SIZE;
 
-	s->hb_context.response_data = k_calloc(s->hb_context.response_data_size, sizeof(uint8_t));
+	s->hb_context.response_data = k_malloc(s->hb_context.response_data_size);
 	if (s->hb_context.response_data == NULL) {
 		cleanup_connection(&s->hb_context.sock);
 		s->hb_context.code_status = HAWKBIT_ALLOC_ERROR;


### PR DESCRIPTION
the buffer for the response of the http client doesn't need to be zero initialized.
therefore we don't need to use k_calloc.
It can already be seen, when we need to increase the buffer we do it with k_realloc, which doesn't set the additional space to zeros.