### PR TITLE
Update ov7670 driver

### DIFF
--- a/boards/nxp/frdm_mcxn236/board.c
+++ b/boards/nxp/frdm_mcxn236/board.c
@@ -311,11 +311,11 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_Smartdma);
 	RESET_PeripheralReset(kSMART_DMA_RST_SHIFT_RSTn);
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(video_sdma))
-	/* Drive CLKOUT from FRO12M, divided by 2 to yield 6MHz clock
+	/* Drive CLKOUT from FROHF 48M, divided by 2 to yield 24MHz clock
 	 * The camera will use this clock signal to generate
 	 * PCLK, HSYNC, and VSYNC
 	 */
-	CLOCK_AttachClk(kFRO12M_to_CLKOUT);
+	CLOCK_AttachClk(kFRO_HF_to_CLKOUT);
 	CLOCK_SetClkDiv(kCLOCK_DivClkOut, 2U);
 #endif
 #endif

--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -316,12 +316,12 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_Smartdma);
 	RESET_PeripheralReset(kSMART_DMA_RST_SHIFT_RSTn);
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(video_sdma))
-	/* Drive CLKOUT from main clock, divided by 25 to yield 6MHz clock
+	/* Drive CLKOUT from main clock, divided by 6 to yield 25MHz clock
 	 * The camera will use this clock signal to generate
 	 * PCLK, HSYNC, and VSYNC
 	 */
 	CLOCK_AttachClk(kMAIN_CLK_to_CLKOUT);
-	CLOCK_SetClkDiv(kCLOCK_DivClkOut, 25U);
+	CLOCK_SetClkDiv(kCLOCK_DivClkOut, 6U);
 #endif
 #endif
 

--- a/boards/shields/dvp_20pin_ov7670/boards/frdm_mcxn236.overlay
+++ b/boards/shields/dvp_20pin_ov7670/boards/frdm_mcxn236.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ov7670 {
+	pclk-hb-disable;
+};

--- a/boards/shields/dvp_20pin_ov7670/boards/frdm_mcxn947_cpu0.overlay
+++ b/boards/shields/dvp_20pin_ov7670/boards/frdm_mcxn947_cpu0.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ov7670 {
+	pclk-hb-disable;
+};

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -302,6 +302,17 @@ USB
   use an STM32N6 SoC with custom clock mux configuration must now set the ``clocks``
   property on :samp:`usbphyc{N}` instead of :samp:`usbotg_hs{N}`. (:github:`107813`)
 
+Video
+=====
+
+* The :dtcompatible:`ovti,ov7670` and :dtcompatible:`ovti,ov7675` camera drivers now assume a
+  24 MHz XCLK input instead of the previous 6 MHz, matching the typical XCLK frequency listed in
+  the OV7670 datasheet. Boards driving an OV7670 or OV7675 sensor must update their board-level
+  XCLK clock configuration accordingly. For example, ``frdm_mcxn236`` has been switched from
+  ``kFRO12M_to_CLKOUT`` (divided by 2 to yield 6 MHz) to ``kFRO_HF_to_CLKOUT`` (divided by 2 to
+  yield 24 MHz), and ``frdm_mcxn947`` keeps ``kMAIN_CLK_to_CLKOUT`` but changes the CLKOUT
+  divider from 25 to 6 to yield 24 MHz. (:github:`109393`)
+
 WiFi
 ====
 

--- a/drivers/video/ov767x.c
+++ b/drivers/video/ov767x.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024, 2026 NXP
  * Copyright (c) 2025 Michael Smorto
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -23,6 +23,7 @@ struct ov767x_config {
 	struct i2c_dt_spec bus;
 	uint32_t camera_model;
 	const struct video_format_cap *fmts;
+	bool pclk_hb_disable;
 #if DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(ovti_ov7670, reset_gpios) ||                                \
 	DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(ovti_ov7675, reset_gpios)
 	struct gpio_dt_spec reset;
@@ -133,6 +134,9 @@ struct ov767x_data {
 #define OV767X_HAECC5             0xA8
 #define OV767X_HAECC6             0xA9
 
+/* COM10 bit definitions */
+#define OV767X_PCLK_NO_HBLANK 0x20 /* PCLK does not toggle during HBLANK */
+
 /* Addition defines to support OV7675 */
 #define OV767X_RGB444               0x8C /* REG444 */
 #define OV767X_COM3_DCW_EN          0x04 /* DCW enable */
@@ -186,18 +190,16 @@ static const struct video_format_cap ov7675_fmts[] = {
 
 /*
  * This initialization table is based on the MCUX SDK driver for the OV7670.
- * Note that this table assumes the camera is fed a 6MHz XCLK signal
+ * Note that this table assumes the camera is fed a 24MHz XCLK signal
  */
 static const struct video_reg8 ov767x_init_regtbl[] = {
 	{OV767X_MVFP, 0x00}, /* MVFP: Mirror/VFlip,Normal image */
 
 	/* configure the output timing */
-	/* PCLK does not toggle during horizontal blank, one PCLK, one pixel */
-	{OV767X_COM10, 0x20}, /* COM10 */
 	{OV767X_COM12, 0x00}, /* COM12,No HREF when VSYNC is low */
 	/* Brightness Control, with signal -128 to +128, 0x00 is middle value */
 	{OV767X_BRIGHT, 0x2f},
-	{OV767X_CLKRC, 0x81}, /* Clock Div, Input/(n+1), bit6 set to 1 to disable divider */
+	{OV767X_CLKRC, 0x87}, /* Clock Div: 24MHz / (7+1) = 3MHz internal (for 24MHz XCLK) */
 
 	/* SCALING_PCLK_DIV */
 	/* 0: Enable clock divider, 010: Divided by 4 */
@@ -256,7 +258,7 @@ static const struct video_reg8 ov767x_init_regtbl[] = {
 	{OV767X_COM13, 0x80}, /* Common Control 13 */
 	{OV767X_MANU, 0x11},  /* Manual U Value */
 	{OV767X_MANV, 0xFF},  /* Manual V Value */
-	/* config the output window data, this can be configured later */
+	/* config the output window data, this can be configured later in ov767x_set_fmt */
 	{OV767X_HSTART, 0x15}, /*  HSTART */
 	{OV767X_HSTOP, 0x03},  /*  HSTOP */
 	{OV767X_VSTRT, 0x02},  /*  VSTRT */
@@ -378,16 +380,27 @@ static const struct video_reg8 ov767x_rgb565_regs[] = {
 
 
 #if DT_HAS_COMPAT_STATUS_OKAY(ovti_ov7670)
-/* Resolution settings for camera, based on those present in MCUX SDK */
 static const struct video_reg8 ov7670_regs_qcif[] = {
-	{OV767X_COM7, 0x2c},
-	{OV767X_COM3, 0x00},
+	{OV767X_COM3, 0x0C},
+	{OV767X_COM3, 0x04},
 	{OV767X_COM14, 0x11},
-	{OV767X_SCALING_XSC, 0x3a},
-	{OV767X_SCALING_YSC, 0x35},
-	{OV767X_SCALING_DCWCTR, 0x11},
 	{OV767X_SCALING_PCLK_DIV, 0xf1},
-	{OV767X_SCALING_PCLK_DELAY, 0x52},
+	{OV767X_GAM1, 0x1C},
+	{OV767X_GAM2, 0x28},
+	{OV767X_GAM3, 0x3C},
+	{OV767X_GAM5, 0x69},
+	{OV767X_COM9, 0x38},
+	{0xA1, 0x0B},
+	{0x74, 0x19},
+	{0x9A, 0x80},
+	{OV767X_AWBC1, 0x14},
+	{OV767X_COM13, 0xC0},
+	{OV767X_HSTART, 0x39},
+	{OV767X_HSTOP, 0x03},
+	{OV767X_HREF, 0x80},
+	{OV767X_VSTRT, 0x03},
+	{OV767X_VSTOP, 0x7B},
+	{OV767X_VREF, 0x0A},
 };
 
 static const struct video_reg8 ov7670_regs_qvga[] = {
@@ -403,13 +416,14 @@ static const struct video_reg8 ov7670_regs_qvga[] = {
 
 static const struct video_reg8 ov7670_regs_cif[] = {
 	{OV767X_COM7, 0x24},
-	{OV767X_COM3, 0x08},
-	{OV767X_COM14, 0x11},
-	{OV767X_SCALING_XSC, 0x3a},
-	{OV767X_SCALING_YSC, 0x35},
-	{OV767X_SCALING_DCWCTR, 0x11},
-	{OV767X_SCALING_PCLK_DIV, 0xf1},
-	{OV767X_SCALING_PCLK_DELAY, 0x02},
+	{OV767X_COM3, 0x00},
+	{OV767X_COM14, 0x00},
+	{OV767X_HSTART, 0x15},
+	{OV767X_HSTOP, 0x0b},
+	{OV767X_HREF, 0x92},
+	{OV767X_VSTRT, 0x03},
+	{OV767X_VSTOP, 0x7b},
+	{OV767X_VREF, 0x0a},
 };
 
 static const struct video_reg8 ov7670_regs_vga[] = {
@@ -419,8 +433,12 @@ static const struct video_reg8 ov7670_regs_vga[] = {
 	{OV767X_SCALING_XSC, 0x3a},
 	{OV767X_SCALING_YSC, 0x35},
 	{OV767X_SCALING_DCWCTR, 0x11},
-	{OV767X_SCALING_PCLK_DIV, 0xf0},
-	{OV767X_SCALING_PCLK_DELAY, 0x02},
+	{OV767X_HREF, 0x36},
+	{OV767X_HSTART, 0x13},
+	{OV767X_HSTOP, 0x01},
+	{OV767X_VREF, 0x0a},
+	{OV767X_VSTRT, 0x02},
+	{OV767X_VSTOP, 0x7a},
 };
 #endif
 
@@ -497,7 +515,7 @@ static int ov7670_set_fmt(const struct device *dev, struct video_format *fmt)
 				ret = video_write_cci_multiregs8(&config->bus, ov7670_regs_qcif,
 								 ARRAY_SIZE(ov7670_regs_qcif));
 				break;
-			case 352: /* QCIF */
+			case 352: /* CIF */
 				ret = video_write_cci_multiregs8(&config->bus, ov7670_regs_cif,
 								 ARRAY_SIZE(ov7670_regs_cif));
 				break;
@@ -511,7 +529,7 @@ static int ov7670_set_fmt(const struct device *dev, struct video_format *fmt)
 				break;
 			default: /* QVGA */
 				ret = video_write_cci_multiregs8(&config->bus, ov7670_regs_qvga,
-								 ARRAY_SIZE(ov7670_regs_vga));
+								 ARRAY_SIZE(ov7670_regs_qvga));
 				break;
 			}
 			if (ret < 0) {
@@ -740,14 +758,22 @@ static int ov767x_init(const struct device *dev)
 	/* Delay after reset */
 	k_msleep(5);
 
+	/* Write initialization values to OV767X */
+	ret = video_write_cci_multiregs8(&config->bus, ov767x_init_regtbl,
+					 ARRAY_SIZE(ov767x_init_regtbl));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Set video format after initialization */
 	ret = ov767x_set_fmt(dev, &fmt);
 	if (ret < 0) {
 		return ret;
 	}
 
-	/* Write initialization values to OV767X */
-	ret = video_write_cci_multiregs8(&config->bus, ov767x_init_regtbl,
-					 ARRAY_SIZE(ov767x_init_regtbl));
+	/* Configure PCLK behavior during horizontal blanking */
+	ret = video_write_cci_reg(&config->bus, OV767X_REG8(OV767X_COM10),
+				  config->pclk_hb_disable ? OV767X_PCLK_NO_HBLANK : 0);
 	if (ret < 0) {
 		return ret;
 	}
@@ -804,6 +830,7 @@ static DEVICE_API(video, ov767x_api) = {
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.camera_model = id,                                                                \
 		.fmts = ov##id##_fmts,                                                             \
+		.pclk_hb_disable = DT_INST_PROP(inst, pclk_hb_disable),                            \
 		OV767X_RESET_GPIO(inst)	OV767X_PWDN_GPIO(inst)};                                   \
                                                                                                    \
 	static struct ov767x_data ov##id##_data##inst;                                             \

--- a/dts/bindings/video/ovti,ov7670.yaml
+++ b/dts/bindings/video/ovti,ov7670.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright 2024, 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: OV7670 CMOS video sensor
@@ -16,6 +16,12 @@ properties:
     description: |
       The PWDN pin is asserted to power down the sensor. The sensor
       receives this as an active high signal
+  pclk-hb-disable:
+    type: boolean
+    description: |
+      If set, PCLK does not toggle during the horizontal blank period.
+      When not set, PCLK is free running and continues to toggle during
+      horizontal blanking (COM10[5] = 0, default).
 
 include: i2c-device.yaml
 

--- a/dts/bindings/video/ovti,ov7675.yaml
+++ b/dts/bindings/video/ovti,ov7675.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright 2024, 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: OV7675 CMOS video sensor
@@ -16,6 +16,12 @@ properties:
     description: |
       The PWDN pin is asserted to power down the sensor. The sensor
       receives this as an active high signal
+  pclk-hb-disable:
+    type: boolean
+    description: |
+      If set, PCLK does not toggle during the horizontal blank period.
+      When not set, PCLK is free running and continues to toggle during
+      horizontal blanking (COM10[5] = 0, default).
 
 include: i2c-device.yaml
 


### PR DESCRIPTION
- Add pclk-hb-disable DTS property to control PCLK toggling during horizontal blank periods. Different camera receivers may have different requirement on this configuration. For example, the mcux smartdma requires the pclk to disable during h-blank to work, while the mcux flexio camera requires a free running pclk.
 - Reorder initialization sequence to apply format settings after the common initialization table. Different format may apply different configurations and overwrite the default configurations.
- Change the input XCLK frequency from 6MHz to 24MHz. According to the data sheet and software application note, the camera sensor requires the clock to be within the range of 10~48 MHz and the typical value is 24 MHz. It can work with 6MHz XCLK but the performance is not ideal. For example it glitches with VGA resolution.
- Fix resolution-specific register tables for QCIF, CIF, and VGA modes with corrected timing and gamma settings for OV7670. When the OV7670 driver was originally enabled with the camera receiver smartdma, only the QVGA resolution is tested, since smartdma can only support this resolution, the others are not tested. All the configurations are updated according to https://github.com/torvalds/linux/blob/master/drivers/media/i2c/ov7670.c and tested using mcux_flexio_camera enabled in https://github.com/zephyrproject-rtos/zephyr/pull/109382
- Change CLKOUT frequency from 6mHz to 24mHz for frdm_mcxn947 and frdm_mcxn236, to align with the update of OV7670 camera sensor requirements.
- Add board-specific device tree overlay for frdm_mcxn947 and frdm_mcxn236 to enable pclk-hblank-disable property for the OV7670 camera sensor since they use smartdma camera.

This PR is the dependency for https://github.com/zephyrproject-rtos/zephyr/pull/109382/