### PR TITLE
firmware: scmi: add function for transfer initialization

### DIFF
--- a/drivers/firmware/scmi/base.c
+++ b/drivers/firmware/scmi/base.c
@@ -94,14 +94,11 @@ static int scmi_base_xfer_no_tx(uint8_t msg_id, void *rx_buf, size_t rx_len)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(msg_id,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = 0;
-	msg.content = NULL;
-
-	reply.hdr = msg.hdr;
-	reply.len = rx_len;
-	reply.content = rx_buf;
+	ret = scmi_xfer_init(proto, &msg, &reply, msg_id,
+			     NULL, 0x0, rx_buf, rx_len);
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -248,13 +245,12 @@ int scmi_base_discover_agent(uint32_t agent_id, struct scmi_agent_info *agent_in
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(DISCOVER_AGENT, SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(agent_id);
-	msg.content = &agent_id;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(struct scmi_msg_base_discover_agent_reply);
-	reply.content = &reply_buffer;
+	ret = scmi_xfer_init(proto, &msg, &reply, DISCOVER_AGENT,
+			     &agent_id, sizeof(agent_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -294,14 +290,11 @@ int scmi_base_device_permission(uint32_t agent_id, uint32_t device_id, bool allo
 	cfg.device_id = device_id;
 	cfg.flags = allow ? SCMI_BASE_DEVICE_ACCESS_ALLOW : 0;
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SET_DEVICE_PERMISSIONS, SCMI_COMMAND, proto->id,
-					0x0);
-	msg.len = sizeof(cfg);
-	msg.content = &cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, SET_DEVICE_PERMISSIONS,
+			     &cfg, sizeof(cfg), &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -338,14 +331,11 @@ int scmi_base_reset_agent_cfg(uint32_t agent_id, bool reset_perm)
 	cfg.agent_id = agent_id;
 	cfg.flags = reset_perm ? SCMI_BASE_AGENT_PERMISSIONS_RESET : 0;
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(RESET_AGENT_CONFIGURATION, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(cfg);
-	msg.content = &cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, RESET_AGENT_CONFIGURATION,
+			     &cfg, sizeof(cfg), &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {

--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -70,14 +70,12 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_RATE_GET,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(clk_id);
-	msg.content = &clk_id;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
+	ret = scmi_xfer_init(proto, &msg, &reply, CLOCK_RATE_GET,
+			     &clk_id, sizeof(clk_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -112,13 +110,11 @@ int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_conf
 		return -ENOTSUP;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_RATE_SET, SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, CLOCK_RATE_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -143,14 +139,12 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 		return -EINVAL;
 	}
 
-	msg.hdr =
-		SCMI_MESSAGE_HDR_MAKE(CLOCK_PARENT_GET, SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(clk_id);
-	msg.content = &clk_id;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
+	ret = scmi_xfer_init(proto, &msg, &reply, CLOCK_PARENT_GET,
+			     &clk_id, sizeof(clk_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -181,14 +175,11 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 		return -EINVAL;
 	}
 
-	msg.hdr =
-		SCMI_MESSAGE_HDR_MAKE(CLOCK_PARENT_SET, SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(cfg);
-	msg.content = &cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, CLOCK_PARENT_SET,
+			     &cfg, sizeof(cfg), &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -228,14 +219,11 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_CONFIG_SET,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, CLOCK_CONFIG_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -259,14 +247,12 @@ int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_ATTRIBUTES,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(clk_id);
-	msg.content = &clk_id;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(*attributes);
-	reply.content = attributes;
+	ret = scmi_xfer_init(proto, &msg, &reply, CLOCK_ATTRIBUTES,
+			     &clk_id, sizeof(clk_id),
+			     attributes, sizeof(*attributes));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -291,14 +277,12 @@ int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_GET_PERMISSIONS,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(clk_id);
-	msg.content = &clk_id;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
+	ret = scmi_xfer_init(proto, &msg, &reply, CLOCK_GET_PERMISSIONS,
+			     &clk_id, sizeof(clk_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {

--- a/drivers/firmware/scmi/common.c
+++ b/drivers/firmware/scmi/common.c
@@ -63,14 +63,11 @@ int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PROTOCOL_VERSION, SCMI_COMMAND,
-			proto->id, 0x0);
-	msg.len = 0;
-	msg.content = NULL;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
+	ret = scmi_xfer_init(proto, &msg, &reply, PROTOCOL_VERSION,
+			     NULL, 0x0, &reply_buffer, sizeof(reply_buffer));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -92,14 +89,11 @@ int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attribut
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PROTOCOL_ATTRIBUTES, SCMI_COMMAND,
-			proto->id, 0x0);
-	msg.len = 0;
-	msg.content = NULL;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
+	ret = scmi_xfer_init(proto, &msg, &reply, PROTOCOL_ATTRIBUTES,
+			     NULL, 0x0, &reply_buffer, sizeof(reply_buffer));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -122,14 +116,12 @@ int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PROTOCOL_MESSAGE_ATTRIBUTES, SCMI_COMMAND,
-			proto->id, 0x0);
-	msg.len = sizeof(message_id);
-	msg.content = &message_id;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
+	ret = scmi_xfer_init(proto, &msg, &reply, PROTOCOL_MESSAGE_ATTRIBUTES,
+			     &message_id, sizeof(message_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, true);
 	if (ret < 0) {
@@ -151,14 +143,12 @@ int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t versio
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(NEGOTIATE_PROTOCOL_VERSION, SCMI_COMMAND,
-			proto->id, 0x0);
-	msg.len = sizeof(version);
-	msg.content = &version;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, NEGOTIATE_PROTOCOL_VERSION,
+			     &version, sizeof(version),
+			     &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {

--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -240,3 +240,19 @@ int scmi_core_transport_init(const struct device *transport)
 
 	return scmi_core_protocol_setup(transport);
 }
+
+int scmi_xfer_init(struct scmi_protocol *proto,
+		   struct scmi_message *tx, struct scmi_message *rx,
+		   uint8_t msg_id, void *tx_buf, uint32_t tx_len,
+		   void *rx_buf, uint32_t rx_len)
+{
+	tx->hdr = SCMI_MESSAGE_HDR_MAKE(msg_id, SCMI_COMMAND, proto->id, 0x0);
+	tx->len = tx_len;
+	tx->content = tx_buf;
+
+	rx->hdr = tx->hdr;
+	rx->len = rx_len;
+	rx->content = rx_buf;
+
+	return 0;
+}

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -45,14 +45,11 @@ int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CPU_SLEEP_MODE_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, CPU_SLEEP_MODE_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	/* Set the PM-related scmi api to use poll mode to ensure that
 	 * the CPU is not woken up by unnecessary scmi interrupts
@@ -83,14 +80,11 @@ int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CPU_PD_LPM_CONFIG_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, CPU_PD_LPM_CONFIG_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	use_polling = true;
 
@@ -117,14 +111,11 @@ int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CPU_IRQ_WAKE_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, CPU_IRQ_WAKE_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, true);
 	if (ret < 0) {
@@ -149,14 +140,11 @@ int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CPU_RESET_VECTOR_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, CPU_RESET_VECTOR_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, true);
 	if (ret < 0) {
@@ -182,14 +170,12 @@ int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CPU_INFO_GET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(uint32_t);
-	msg.content = &cpu_id;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
+	ret = scmi_xfer_init(proto, &msg, &reply, CPU_INFO_GET,
+			     &cpu_id, sizeof(uint32_t),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, true);
 	if (ret < 0) {

--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -53,15 +53,14 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PINCTRL_SETTINGS_CONFIGURE,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(*settings) -
-		(ARM_SCMI_PINCTRL_MAX_CONFIG_SIZE - config_num * 2) * 4;
-	msg.content = settings;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, PINCTRL_SETTINGS_CONFIGURE,
+			     settings,
+			     sizeof(*settings) -
+			     (ARM_SCMI_PINCTRL_MAX_CONFIG_SIZE - config_num * 2) * 4,
+			     &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -41,14 +41,12 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(POWER_STATE_GET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(domain_id);
-	msg.content = &domain_id;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
+	ret = scmi_xfer_init(proto, &msg, &reply, POWER_STATE_GET,
+			     &domain_id, sizeof(domain_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
@@ -84,14 +82,12 @@ int scmi_power_state_set(struct scmi_power_state_config *cfg)
 		return -ENOTSUP;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(POWER_STATE_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, POWER_STATE_SET,
+			     cfg, sizeof(*cfg),
+			     &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {

--- a/drivers/firmware/scmi/system.c
+++ b/drivers/firmware/scmi/system.c
@@ -60,14 +60,11 @@ int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SYSTEM_POWER_STATE_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &msg, &reply, SYSTEM_POWER_STATE_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret) {
+		return ret;
+	}
 
 	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -164,6 +164,29 @@ int scmi_send_message(struct scmi_protocol *proto,
 		      bool use_polling);
 
 /**
+ * @brief Prepare the message structures for an SCMI transfer
+ *
+ * Prepare the TX and RX message structures for a transfer (i.e. an SCMI
+ * command followed by its synchronous reply).
+ *
+ * @param proto protocol handle
+ * @param tx message to send
+ * @param rx message to receive
+ * @param msg_id message ID
+ * @param tx_buf TX buffer
+ * @param tx_len TX buffer length
+ * @param rx_buf RX buffer
+ * @param rx_len RX buffer length
+ *
+ * @retval 0 if successful
+ * @retval <0 negative errno code if failure
+ */
+int scmi_xfer_init(struct scmi_protocol *proto,
+		   struct scmi_message *tx, struct scmi_message *rx,
+		   uint8_t msg_id, void *tx_buf, uint32_t tx_len,
+		   void *rx_buf, uint32_t rx_len);
+
+/**
  * @brief Get protocol version
  *
  * @param proto Protocol instance


### PR DESCRIPTION
Introduce `scmi_xfer_init` and switch to using it in the protocol layer.