### PR TITLE
Add a ZMS iterator API to enumerate live entries without a predefined ID list

### DIFF
--- a/doc/services/storage/zms/zms.rst
+++ b/doc/services/storage/zms/zms.rst
@@ -171,6 +171,114 @@ the most recent ones to the oldest ones. If it finds a valid ATE with a matching
 its data and returns the number of bytes that were read.
 If a history count is provided and different than 0, older data with same ID is retrieved.
 
+ZMS entry enumeration (iterator API)
+====================================
+
+Applications can enumerate stored entries without supplying a predefined list of IDs.
+This is useful when IDs are derived from payload data (for example packed addresses) and the
+application does not keep a separate index in flash.
+
+This API family is generally used at boot, when the application rebuilds its in-memory state from
+the ID/length metadata persisted in ZMS.
+
+  The iterator API consists of:
+
+- :c:func:`zms_iter_init` to initialize iterator state.
+- :c:func:`zms_iter_init_with_config` to initialize iterator state with optional ID mask and
+  inclusive ID range and predicate filters.
+- :c:func:`zms_iter_next` to retrieve one live entry (unique ID) at a time.
+- :c:func:`zms_iter_next_all` to retrieve all matching entries (full history, including delete markers).
+
+Choosing between :c:func:`zms_iter_next` and :c:func:`zms_iter_next_all`
+--------------------------------------------------------------------------
+
+- :c:func:`zms_iter_next` returns unique live ``(id, len)`` pairs:
+
+  - Sector/header entries are skipped.
+  - Delete markers (entries with ``len == 0``) are skipped.
+  - If the same ID appears multiple times in storage history, only the newest valid occurrence is
+    returned.
+  - To guarantee uniqueness, ZMS checks for newer entries of each candidate ID, which can require
+    additional scanning.
+
+- :c:func:`zms_iter_next_all` is faster and returns all matching ``(id, len)`` pairs as encountered:
+
+  - Historical entries for the same ID are returned.
+  - Delete markers (entries with ``len == 0``) are returned.
+  - No uniqueness filtering is performed.
+  - The application is responsible for filtering/compacting the returned pairs according to its
+    own policy.
+
+  Use :c:func:`zms_iter_init_with_config` when you want to enumerate only IDs matching a bitmask,
+  a specific inclusive ID range, a predicate callback, or any combination of those filters.
+
+Iterator return values
+----------------------
+
+Calling either :c:func:`zms_iter_next` or :c:func:`zms_iter_next_all` returns:
+
+- ``1`` when an entry is found; output arguments contain ID and data length.
+- ``0`` when there are no more entries to enumerate.
+- Negative errno on error (for example ``-EINVAL``, ``-EIO``, ``-ENXIO``).
+
+The iterator reports metadata only (ID and length). Data can then be read explicitly using
+:c:func:`zms_read` for the latest value, or :c:func:`zms_read_hist` for older revisions.
+
+Concurrency and snapshot behavior
+---------------------------------
+
+The iterator captures a traversal boundary when :c:func:`zms_iter_init` is called.
+Entries written after initialization are not part of that traversal.
+
+Do not call :c:func:`zms_write` (including delete operations) on the same :c:struct:`zms_fs`
+between two iterator-step calls (:c:func:`zms_iter_next` or :c:func:`zms_iter_next_all`).
+If a write triggers garbage collection while iterating, iterator behavior is undefined.
+
+Usage example
+-------------
+
+.. code-block:: c
+
+  struct zms_iter iter;
+  bool predicate_id_not_2(zms_id_t id)
+  {
+    return id != (zms_id_t)2;
+  }
+
+  struct zms_iter_config iter_config = {
+    .mask_id = (zms_id_t)0x03,
+    .min_id = (zms_id_t)0x01,
+    .max_id = (zms_id_t)0x03,
+    .use_mask = true,
+    .use_range = true,
+    .use_predicate = true,
+    .predicate_func = predicate_id_not_2,
+  };
+  zms_id_t id;
+  size_t len;
+  int rc;
+
+  rc = zms_iter_init_with_config(&fs, &iter, &iter_config);
+  if (rc) {
+    /* handle error */
+  }
+
+  while ((rc = zms_iter_next(&fs, &iter, &id, &len)) == 1) {
+    /* id: entry ID matching configured mask/range/predicate, len: current stored size */
+    printk("id=0x%llx len=%zu\n", (unsigned long long)id, len);
+  }
+
+  if (rc < 0) {
+    /* handle iterator error */
+  }
+
+Zero-initialize :c:struct:`zms_iter_config` or leave ``use_mask``, ``use_range``, and
+``use_predicate`` disabled to keep the default behavior: accept all IDs and the full
+``zms_id_t`` range.
+
+To determine how many revisions exist for an ID returned by the iterator,
+call :c:func:`zms_read_hist` with increasing ``cnt`` until ``-ENOENT`` is returned.
+
 ZMS free space calculation
 ==========================
 
@@ -419,6 +527,8 @@ Version 1
   and reinitialization on mount failure)
 - Supports a lookup cache to speed up repeated ID lookups with optional per-instance cache
   configuration to customize the cache size on a per-partition basis
+- Supports live-entry enumeration without predeclared ID lists via
+  :c:func:`zms_iter_init` and :c:func:`zms_iter_next`
 
 Future features
 ===============

--- a/doc/services/storage/zms/zms.rst
+++ b/doc/services/storage/zms/zms.rst
@@ -171,6 +171,127 @@ the most recent ones to the oldest ones. If it finds a valid ATE with a matching
 its data and returns the number of bytes that were read.
 If a history count is provided and different than 0, older data with same ID is retrieved.
 
+ZMS entry enumeration (iterator API)
+====================================
+
+Applications can enumerate stored entries without supplying a predefined list of IDs.
+This is useful when IDs are derived from payload data (for example packed addresses) and the
+application does not keep a separate index in flash.
+
+This API family is generally used at boot, when the application rebuilds its in-memory state from
+the ID/length metadata persisted in ZMS.
+
+The iterator API consists of:
+
+- :c:func:`zms_iter_init` to initialize iterator state.
+- :c:func:`zms_iter_init_with_config` to initialize iterator state with optional ID mask and
+  inclusive ID range and predicate filters.
+- :c:func:`zms_iter_next` to retrieve one live entry (unique ID) at a time.
+- :c:func:`zms_iter_next_all` to retrieve all matching entries (full history, including delete markers).
+
+Choosing between :c:func:`zms_iter_next` and :c:func:`zms_iter_next_all`
+--------------------------------------------------------------------------
+
+- :c:func:`zms_iter_next` returns unique live ``(id, len)`` pairs:
+
+  - Sector/header entries are skipped.
+  - Delete markers (entries with ``len == 0``) are skipped.
+  - If the same ID appears multiple times in storage history, only the newest valid occurrence is
+    returned.
+  - To guarantee uniqueness, ZMS checks for newer entries of each candidate ID, which can require
+    additional scanning.
+
+- :c:func:`zms_iter_next_all` is faster and returns all matching ``(id, len)`` pairs as encountered:
+
+  - Historical entries for the same ID are returned.
+  - Delete markers (entries with ``len == 0``) are returned.
+  - No uniqueness filtering is performed.
+  - The application is responsible for filtering/compacting the returned pairs according to its
+    own policy.
+
+  Use :c:func:`zms_iter_init_with_config` when you want to enumerate only IDs matching a bitmask,
+  a specific inclusive ID range, a predicate callback, or any combination of those filters.
+
+Iterator return values
+----------------------
+
+Calling either :c:func:`zms_iter_next` or :c:func:`zms_iter_next_all` returns:
+
+- ``1`` when an entry is found; output arguments contain ID and data length.
+- ``0`` when there are no more entries to enumerate.
+- Negative errno on error (for example ``-EINVAL``, ``-EIO``, ``-ENXIO``).
+
+The iterator always reports metadata (ID and length). In addition, when the caller provides a
+non-NULL ``data`` buffer, the iterator also copies the entry's content directly into it, but
+only for entries small enough to be stored inside the ATE. For larger entries, or when no
+buffer is provided, the data must be read explicitly using :c:func:`zms_read` for the latest
+value, or :c:func:`zms_read_hist` for older revisions.
+
+Concurrency and snapshot behavior
+---------------------------------
+
+The iterator captures a traversal boundary when :c:func:`zms_iter_init` is called.
+Entries written after initialization are not part of that traversal.
+
+Do not call :c:func:`zms_write` (including delete operations) on the same :c:struct:`zms_fs`
+between two iterator-step calls (:c:func:`zms_iter_next` or :c:func:`zms_iter_next_all`).
+If a write triggers garbage collection while iterating, iterator behavior is undefined.
+
+Usage example
+-------------
+
+.. code-block:: c
+
+  struct zms_iter iter;
+  bool predicate_id_not_2(zms_id_t id)
+  {
+    return id != (zms_id_t)2;
+  }
+
+  struct zms_iter_config iter_config = {
+    .mask_id = (zms_id_t)0x03,
+    .min_id = (zms_id_t)0x01,
+    .max_id = (zms_id_t)0x03,
+    .use_mask = true,
+    .use_range = true,
+    .use_predicate = true,
+    .predicate_func = predicate_id_not_2,
+  };
+  zms_id_t id;
+  size_t len;
+  uint8_t data[ZMS_DATA_IN_ATE_SIZE];
+  int rc;
+
+  rc = zms_iter_init_with_config(&fs, &iter, &iter_config);
+  if (rc) {
+    /* handle error */
+  }
+
+  while ((rc = zms_iter_next(&fs, &iter, &id, &len, data, sizeof(data))) == 1) {
+    /* id: entry ID matching configured mask/range/predicate, len: current stored size */
+    /* data: filled with the entry's content when it is small enough to be
+     * stored directly inside the ATE; otherwise left untouched, in which case
+     * zms_read() must be used to fetch it.
+     */
+    printk("id=0x%llx len=%zu\n", (unsigned long long)id, len);
+  }
+
+  if (rc < 0) {
+    /* handle iterator error */
+  }
+
+The optional ``data``/``data_len`` arguments can be set to ``NULL``/``0`` when only the
+``(id, len)`` pairs are needed. When a buffer is provided, only the data that ZMS stores
+directly inside the ATE is copied; larger entries must still be retrieved with
+:c:func:`zms_read`.
+
+Zero-initialize :c:struct:`zms_iter_config` or leave ``use_mask``, ``use_range``, and
+``use_predicate`` disabled to keep the default behavior: accept all IDs and the full
+``zms_id_t`` range.
+
+To determine how many revisions exist for an ID returned by the iterator,
+call :c:func:`zms_read_hist` with increasing ``cnt`` until ``-ENOENT`` is returned.
+
 ZMS free space calculation
 ==========================
 
@@ -444,6 +565,8 @@ Version 1
   and reinitialization on mount failure)
 - Supports a lookup cache to speed up repeated ID lookups with optional per-instance cache
   configuration to customize the cache size on a per-partition basis
+- Supports live-entry enumeration without predeclared ID lists via
+  :c:func:`zms_iter_init` and :c:func:`zms_iter_next`
 
 Future features
 ===============

--- a/include/zephyr/kvss/zms.h
+++ b/include/zephyr/kvss/zms.h
@@ -42,6 +42,29 @@ enum zms_mount_flags {
 	ZMS_MOUNT_FLAG_NO_FORMAT = BIT(0),
 };
 
+/**
+ * @brief ID type used in the ZMS API.
+ *
+ * @note The width of this type depends on @kconfig{CONFIG_ZMS_ID_64BIT}.
+ */
+#if CONFIG_ZMS_ID_64BIT
+typedef uint64_t zms_id_t;
+#else
+typedef uint32_t zms_id_t;
+#endif
+
+/** Default minimum ID accepted by iterator range filtering. */
+#define ZMS_ITER_ID_MIN ((zms_id_t)0)
+
+/** Default maximum ID accepted by iterator range filtering. */
+#define ZMS_ITER_ID_MAX ((zms_id_t)~(zms_id_t)0)
+
+/** Default mask that accepts all IDs during iterator filtering. */
+#define ZMS_ITER_MASK_ALL ZMS_ITER_ID_MAX
+
+/** Iterator predicate callback type used by @ref zms_iter_init_with_config. */
+typedef bool (*zms_iter_predicate_t)(zms_id_t id);
+
 /** Zephyr Memory Storage file system structure */
 struct zms_fs {
 	/** File system offset in flash */
@@ -88,6 +111,66 @@ struct zms_fs {
 };
 
 /**
+ * @brief Iterator configuration for @ref zms_iter_init_with_config.
+ *
+ * Leave @ref use_mask, @ref use_range, and @ref use_predicate disabled to use
+ * the default behavior:
+ * all IDs in the full @ref zms_id_t range are accepted.
+ */
+struct zms_iter_config {
+	/** Mask applied when @ref use_mask is true. */
+	zms_id_t mask_id;
+	/** Minimum accepted ID when @ref use_range is true. */
+	zms_id_t min_id;
+	/** Maximum accepted ID when @ref use_range is true. */
+	zms_id_t max_id;
+	/** Enable mask-based filtering. */
+	bool use_mask;
+	/** Enable inclusive range-based filtering. */
+	bool use_range;
+	/** Enable callback-based filtering. */
+	bool use_predicate;
+	/** Predicate callback used when @ref use_predicate is true. */
+	zms_iter_predicate_t predicate_func;
+};
+
+/** Default initializer for @ref zms_iter_config. */
+#define ZMS_ITER_CONFIG_DEFAULT \
+	{ \
+		.mask_id = ZMS_ITER_MASK_ALL, \
+		.min_id = ZMS_ITER_ID_MIN, \
+		.max_id = ZMS_ITER_ID_MAX, \
+		.use_mask = false, \
+		.use_range = false, \
+		.use_predicate = false, \
+		.predicate_func = NULL, \
+	}
+
+/**
+ * @brief Opaque iterator state for @ref zms_iter_next and @ref zms_iter_next_all.
+ *
+ * Must be initialised with @ref zms_iter_init or @ref zms_iter_init_with_config
+ * before use.
+ * Do not access fields directly.
+ */
+struct zms_iter {
+	/**  Current walk address in the ATE ring */
+	uint64_t walk_addr;
+	/**  Snapshot of ate_wra taken at iterator initialization time */
+	uint64_t end_addr;
+	/**  ID mask used to filter returned entries */
+	zms_id_t mask_id;
+	/**  Inclusive minimum ID accepted by the iterator */
+	zms_id_t min_id;
+	/**  Inclusive maximum ID accepted by the iterator */
+	zms_id_t max_id;
+	/**  Optional callback used to filter IDs */
+	zms_iter_predicate_t predicate_func;
+	/**  True once the walk has completed the full ring */
+	bool exhausted;
+};
+
+/**
  * @}
  */
 
@@ -96,17 +179,6 @@ struct zms_fs {
  * @ingroup zms
  * @{
  */
-
-/**
- * @brief ID type used in the ZMS API.
- *
- * @note The width of this type depends on @kconfig{CONFIG_ZMS_ID_64BIT}.
- */
-#if CONFIG_ZMS_ID_64BIT
-typedef uint64_t zms_id_t;
-#else
-typedef uint32_t zms_id_t;
-#endif
 
 /**
  * @brief Mount a ZMS file system onto the device specified in `fs`.
@@ -344,6 +416,107 @@ int zms_get_num_cycles(struct zms_fs *fs, uint32_t *cycles);
  * @retval -ENOENT if the sector has no valid empty ATE.
  */
 int zms_get_sector_num_cycles(struct zms_fs *fs, uint32_t sector, uint32_t *cycles);
+
+/**
+ * @brief Initialise a ZMS iterator with filtering configuration.
+ *
+ * Captures the current write position of the file system as the iteration
+ * boundary. Entries written or deleted after this call will not appear in
+ * subsequent calls to @ref zms_iter_next.
+ *
+ * When @p config->use_mask is true, an entry is returned only if
+ * ``(id & config->mask_id) == id``.
+ * When @p config->use_range is true, an entry is returned only if its ID lies
+ * in the inclusive range ``[config->min_id, config->max_id]``.
+ * When @p config->use_predicate is true, an entry is returned only if
+ * ``config->predicate_func(id)`` returns true.
+ *
+ * If either filter is disabled, the iterator falls back to the default value:
+ * @ref ZMS_ITER_MASK_ALL for the mask and the full
+ * ``[ZMS_ITER_ID_MIN, ZMS_ITER_ID_MAX]`` range. Predicate filtering is disabled
+ * by default.
+ *
+ * @note The caller must not write to or delete from @p fs between
+ *       zms_iter_init_with_config() and the last zms_iter_next() call.
+ *
+ * @param fs      Mounted file system instance.
+ * @param iter    Iterator state to initialise.
+ * @param config  Iterator configuration supplied by the caller.
+ *
+ * @retval 0       Success.
+ * @retval -EINVAL @p fs, @p iter, or @p config is NULL, @p fs is not mounted,
+ *                 @p config->predicate_func is NULL while @p use_predicate is
+ *                 enabled, or the configured range is invalid.
+ */
+int zms_iter_init_with_config(const struct zms_fs *fs, struct zms_iter *iter,
+			      const struct zms_iter_config *config);
+
+/**
+ * @brief Initialise a ZMS iterator.
+ *
+ * Captures the current write position of the file system as the iteration
+ * boundary. Entries written or deleted after this call will not appear in
+ * subsequent calls to @ref zms_iter_next.
+ *
+ * @note The caller must not write to or delete from @p fs between
+ *       zms_iter_init() and the last zms_iter_next() call.
+ *
+ * @param fs   Mounted file system instance.
+ * @param iter Iterator state to initialise.
+ *
+ * @retval 0       Success.
+ * @retval -EINVAL @p fs or @p iter is NULL, or @p fs is not mounted.
+ */
+int zms_iter_init(const struct zms_fs *fs, struct zms_iter *iter);
+
+/**
+ * @brief Advance the iterator to the next live entry.
+ *
+ * Walks the ATE ring from newest to oldest. For each ID, only the most
+ * recently written, non-deleted (len > 0) entry is yielded; older history
+ * revisions and delete-markers are skipped transparently.
+ *
+ * @param fs    Mounted file system instance.
+ * @param iter  Iterator state (must be initialised with @ref zms_iter_init).
+ * @param id    On success (return value 1): populated with the entry ID.
+ * @param len   On success (return value 1): populated with the stored data
+ *              length in bytes.
+ *
+ * @retval 1   Entry found; @p id and @p len are valid.
+ * @retval 0   No more entries; the walk is complete.
+ * @retval -EINVAL @p fs, @p iter, @p id, or @p len is NULL, or @p fs is
+ *              not mounted.
+ * @retval -EIO   Flash read error.
+ * @retval -ENXIO Device error.
+ */
+int zms_iter_next(struct zms_fs *fs, struct zms_iter *iter,
+	zms_id_t *id, size_t *len);
+
+/**
+ * @brief Advance the iterator to the next matching ATE.
+ *
+ * Walks the ATE ring from newest to oldest and returns all matching ATEs,
+ * including delete markers (len == 0) and older history revisions.
+ *
+ * This function does not perform ID uniqueness filtering. IDs can therefore
+ * appear multiple times during traversal.
+ *
+ * @param fs    Mounted file system instance.
+ * @param iter  Iterator state (must be initialised with @ref zms_iter_init or
+ *              @ref zms_iter_init_with_config).
+ * @param id    On success (return value 1): populated with the entry ID.
+ * @param len   On success (return value 1): populated with the stored data
+ *              length in bytes (0 means delete marker).
+ *
+ * @retval 1   Entry found; @p id and @p len are valid.
+ * @retval 0   No more entries; the walk is complete.
+ * @retval -EINVAL @p fs, @p iter, @p id, or @p len is NULL, or @p fs is
+ *              not mounted.
+ * @retval -EIO   Flash read error.
+ * @retval -ENXIO Device error.
+ */
+int zms_iter_next_all(struct zms_fs *fs, struct zms_iter *iter,
+	zms_id_t *id, size_t *len);
 
 /**
  * @}

--- a/include/zephyr/kvss/zms.h
+++ b/include/zephyr/kvss/zms.h
@@ -49,6 +49,44 @@ enum zms_mount_flags {
 	ZMS_MOUNT_FLAG_NO_FORMAT = BIT(0),
 };
 
+/**
+ * @brief ID type used in the ZMS API.
+ *
+ * @note The width of this type depends on @kconfig{CONFIG_ZMS_ID_64BIT}.
+ */
+#if CONFIG_ZMS_ID_64BIT
+typedef uint64_t zms_id_t;
+#else
+typedef uint32_t zms_id_t;
+#endif
+
+/**
+ * @brief Maximum data size in bytes that ZMS stores directly inside an ATE.
+ *
+ * Entries whose data length does not exceed this value are kept in the ATE
+ * itself rather than in the sector's data area. Its width depends on
+ * @kconfig{CONFIG_ZMS_ID_64BIT}. This is the maximum amount of data that the
+ * iterator (@ref zms_iter_next / @ref zms_iter_next_all) can copy into a
+ * caller-provided buffer.
+ */
+#if CONFIG_ZMS_ID_64BIT
+#define ZMS_DATA_IN_ATE_SIZE 4
+#else
+#define ZMS_DATA_IN_ATE_SIZE 8
+#endif
+
+/** Default minimum ID accepted by iterator range filtering. */
+#define ZMS_ITER_ID_MIN ((zms_id_t)0)
+
+/** Default maximum ID accepted by iterator range filtering. */
+#define ZMS_ITER_ID_MAX ((zms_id_t)~(zms_id_t)0)
+
+/** Default mask that accepts all IDs during iterator filtering. */
+#define ZMS_ITER_MASK_ALL ZMS_ITER_ID_MAX
+
+/** Iterator predicate callback type used by @ref zms_iter_init_with_config. */
+typedef bool (*zms_iter_predicate_t)(zms_id_t id);
+
 /** Zephyr Memory Storage file system structure */
 struct zms_fs {
 	/** File system offset in flash */
@@ -95,6 +133,66 @@ struct zms_fs {
 };
 
 /**
+ * @brief Iterator configuration for @ref zms_iter_init_with_config.
+ *
+ * Leave @ref use_mask, @ref use_range, and @ref use_predicate disabled to use
+ * the default behavior:
+ * all IDs in the full @ref zms_id_t range are accepted.
+ */
+struct zms_iter_config {
+	/** Mask applied when @ref use_mask is true. */
+	zms_id_t mask_id;
+	/** Minimum accepted ID when @ref use_range is true. */
+	zms_id_t min_id;
+	/** Maximum accepted ID when @ref use_range is true. */
+	zms_id_t max_id;
+	/** Enable mask-based filtering. */
+	bool use_mask;
+	/** Enable inclusive range-based filtering. */
+	bool use_range;
+	/** Enable callback-based filtering. */
+	bool use_predicate;
+	/** Predicate callback used when @ref use_predicate is true. */
+	zms_iter_predicate_t predicate_func;
+};
+
+/** Default initializer for @ref zms_iter_config. */
+#define ZMS_ITER_CONFIG_DEFAULT \
+	{ \
+		.mask_id = ZMS_ITER_MASK_ALL, \
+		.min_id = ZMS_ITER_ID_MIN, \
+		.max_id = ZMS_ITER_ID_MAX, \
+		.use_mask = false, \
+		.use_range = false, \
+		.use_predicate = false, \
+		.predicate_func = NULL, \
+	}
+
+/**
+ * @brief Opaque iterator state for @ref zms_iter_next and @ref zms_iter_next_all.
+ *
+ * Must be initialised with @ref zms_iter_init or @ref zms_iter_init_with_config
+ * before use.
+ * Do not access fields directly.
+ */
+struct zms_iter {
+	/**  Current walk address in the ATE ring */
+	uint64_t walk_addr;
+	/**  Snapshot of ate_wra taken at iterator initialization time */
+	uint64_t end_addr;
+	/**  ID mask used to filter returned entries */
+	zms_id_t mask_id;
+	/**  Inclusive minimum ID accepted by the iterator */
+	zms_id_t min_id;
+	/**  Inclusive maximum ID accepted by the iterator */
+	zms_id_t max_id;
+	/**  Optional callback used to filter IDs */
+	zms_iter_predicate_t predicate_func;
+	/**  True once the walk has completed the full ring */
+	bool exhausted;
+};
+
+/**
  * @}
  */
 
@@ -103,17 +201,6 @@ struct zms_fs {
  * @ingroup zms
  * @{
  */
-
-/**
- * @brief ID type used in the ZMS API.
- *
- * @note The width of this type depends on @kconfig{CONFIG_ZMS_ID_64BIT}.
- */
-#if CONFIG_ZMS_ID_64BIT
-typedef uint64_t zms_id_t;
-#else
-typedef uint32_t zms_id_t;
-#endif
 
 /**
  * @brief Mount a ZMS file system onto the device specified in `fs`.
@@ -351,6 +438,143 @@ int zms_get_num_cycles(struct zms_fs *fs, uint32_t *cycles);
  * @retval -ENOENT if the sector has no valid empty ATE.
  */
 int zms_get_sector_num_cycles(struct zms_fs *fs, uint32_t sector, uint32_t *cycles);
+
+/**
+ * @brief Initialise a ZMS iterator with filtering configuration.
+ *
+ * Captures the current write position of the file system as the iteration
+ * boundary. Entries written or deleted after this call will not appear in
+ * subsequent calls to @ref zms_iter_next.
+ *
+ * When @p config->use_mask is true, an entry is returned only if
+ * ``(id & config->mask_id) == id``.
+ * When @p config->use_range is true, an entry is returned only if its ID lies
+ * in the inclusive range ``[config->min_id, config->max_id]``.
+ * When @p config->use_predicate is true, an entry is returned only if
+ * ``config->predicate_func(id)`` returns true.
+ *
+ * If either filter is disabled, the iterator falls back to the default value:
+ * @ref ZMS_ITER_MASK_ALL for the mask and the full
+ * ``[ZMS_ITER_ID_MIN, ZMS_ITER_ID_MAX]`` range. Predicate filtering is disabled
+ * by default.
+ *
+ * @note The caller must not write to or delete from @p fs between
+ *       zms_iter_init_with_config() and the last zms_iter_next() call.
+ *
+ * @param fs      Mounted file system instance.
+ * @param iter    Iterator state to initialise.
+ * @param config  Iterator configuration supplied by the caller.
+ *
+ * @retval 0       Success.
+ * @retval -EINVAL @p fs, @p iter, or @p config is NULL, @p fs is not mounted,
+ *                 @p config->predicate_func is NULL while @p use_predicate is
+ *                 enabled, or the configured range is invalid.
+ */
+int zms_iter_init_with_config(const struct zms_fs *fs, struct zms_iter *iter,
+			      const struct zms_iter_config *config);
+
+/**
+ * @brief Initialise a ZMS iterator.
+ *
+ * Captures the current write position of the file system as the iteration
+ * boundary. Entries written or deleted after this call will not appear in
+ * subsequent calls to @ref zms_iter_next.
+ *
+ * @note The caller must not write to or delete from @p fs between
+ *       zms_iter_init() and the last zms_iter_next() call.
+ *
+ * @param fs   Mounted file system instance.
+ * @param iter Iterator state to initialise.
+ *
+ * @retval 0       Success.
+ * @retval -EINVAL @p fs or @p iter is NULL, or @p fs is not mounted.
+ */
+int zms_iter_init(const struct zms_fs *fs, struct zms_iter *iter);
+
+/**
+ * @brief Advance the iterator to the next live entry.
+ *
+ * Walks the ATE ring from newest to oldest. For each ID, only the most
+ * recently written, non-deleted (len > 0) entry is yielded; older history
+ * revisions and delete-markers are skipped transparently.
+ *
+ * @note When the returned @p len (the data length stored in the ATE) does not
+ *       exceed @ref ZMS_DATA_IN_ATE_SIZE, the entry's data is held inside the
+ *       ATE itself. In that case, and only if a @p data buffer is provided, the
+ *       data is copied into it directly (no extra flash read). At most
+ *       @p data_len bytes are copied, so provide a buffer with @p data_len
+ *       greater than or equal to @p len to receive the complete data. Entries
+ *       whose @p len exceeds @ref ZMS_DATA_IN_ATE_SIZE are not copied and must
+ *       be read with @ref zms_read.
+ *
+ * @param fs    Mounted file system instance.
+ * @param iter  Iterator state (must be initialised with @ref zms_iter_init).
+ * @param id    On success (return value 1): populated with the entry ID.
+ * @param len   On success (return value 1): populated with the stored data
+ *              length in bytes.
+ * @param data  Optional caller-allocated buffer. When non-NULL and the entry's
+ *              data is stored directly inside the ATE (its length does not
+ *              exceed @ref ZMS_DATA_IN_ATE_SIZE), that data is copied here (at
+ *              most @p data_len bytes). Data that is not stored inside the ATE
+ *              (larger entries) is not copied; use @ref zms_read to retrieve it.
+ *              Pass NULL to skip copying.
+ * @param data_len Size in bytes of the buffer pointed to by @p data. Ignored
+ *              when @p data is NULL.
+ *
+ * @retval 1   Entry found; @p id and @p len are valid.
+ * @retval 0   No more entries; the walk is complete.
+ * @retval -EINVAL @p fs, @p iter, @p id, or @p len is NULL, or @p fs is
+ *              not mounted.
+ * @retval -EIO   Flash read error.
+ * @retval -ENXIO Device error.
+ */
+int zms_iter_next(struct zms_fs *fs, struct zms_iter *iter, zms_id_t *id, size_t *len, void *data,
+		  size_t data_len);
+
+/**
+ * @brief Advance the iterator to the next matching ATE.
+ *
+ * Walks the ATE ring from newest to oldest and returns all matching ATEs,
+ * including delete markers (len == 0) and older history revisions.
+ *
+ * This function does not perform ID uniqueness filtering. IDs can therefore
+ * appear multiple times during traversal.
+ *
+ * @note When the returned @p len (the data length stored in the ATE) does not
+ *       exceed @ref ZMS_DATA_IN_ATE_SIZE, the entry's data is held inside the
+ *       ATE itself. In that case, and only if a @p data buffer is provided, the
+ *       data is copied into it directly (no extra flash read). At most
+ *       @p data_len bytes are copied, so provide a buffer with @p data_len
+ *       greater than or equal to @p len to receive the complete data.
+ *       Entries whose @p len exceeds @ref ZMS_DATA_IN_ATE_SIZE, and delete markers
+ *       (@p len == 0), are not copied; use @ref zms_read for the latest value
+ *       or @ref zms_read_hist to retrieve older revisions.
+ *
+ * @param fs    Mounted file system instance.
+ * @param iter  Iterator state (must be initialised with @ref zms_iter_init or
+ *              @ref zms_iter_init_with_config).
+ * @param id    On success (return value 1): populated with the entry ID.
+ * @param len   On success (return value 1): populated with the stored data
+ *              length in bytes (0 means delete marker).
+ * @param data  Optional caller-allocated buffer. When non-NULL and the entry's
+ *              data is stored directly inside the ATE (its length does not
+ *              exceed @ref ZMS_DATA_IN_ATE_SIZE), that data is copied here (at
+ *              most @p data_len bytes). Data that is not stored inside the ATE
+ *              (larger entries) and delete markers (len == 0) are not copied;
+ *              use @ref zms_read to retrieve stored data. Pass NULL to skip
+ *              copying.
+ * @param data_len Size in bytes of the buffer pointed to by @p data. Ignored
+ *              when @p data is NULL.
+ *
+ * @retval 1   Entry found; @p id and @p len are valid.
+ * @retval 0   No more entries; the walk is complete.
+ * @retval -EINVAL @p fs, @p iter, @p id, or @p len is NULL, or @p fs is
+ *              not mounted.
+ * @retval -EIO   Flash read error.
+ * @retval -ENXIO Device error.
+ */
+int zms_iter_next_all(struct zms_fs *fs, struct zms_iter *iter, zms_id_t *id, size_t *len,
+		      void *data, size_t data_len);
 
 /**
  * @}

--- a/samples/subsys/kvss/zms/README.rst
+++ b/samples/subsys/kvss/zms/README.rst
@@ -6,8 +6,12 @@
 
 Overview
 ********
- The sample shows how to use ZMS to store ID/VALUE pairs and reads them back.
- Deleting an ID/VALUE pair is also shown in this sample.
+The sample shows how to use ZMS to store ID/VALUE pairs and reads them back.
+Deleting an ID/VALUE pair is also shown in this sample.
+The sample also demonstrates how an application can enumerate all live entries
+using the iterator API (``zms_iter_init()`` and ``zms_iter_next()``), or filter
+the results with ``zms_iter_init_with_config()`` (mask/range/predicate),
+without predeclaring the list of IDs.
 
  The sample stores the following items:
 
@@ -16,6 +20,13 @@ Overview
     data={0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF}
  #. A variable (32bit): stored at id=2, data=cnt
  #. A long set of data (128 bytes)
+
+    After the write/read loop completes, the sample runs a full iterator pass and
+    then a masked iterator pass, printing one line per live entry with:
+
+ #. entry ID
+ #. current stored length
+ #. revision depth (number of history revisions available through ``zms_read_hist()``)
 
  A loop is executed where we mount the storage system, and then write all set
  of data.
@@ -89,6 +100,11 @@ Sample Output
    Id: 3, Longarray: 0 1 2 3 4 5 6 7 8 9 a b c d e f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f 40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f 50 51 52 53 5
    4 55 56 57 58 59 5a 5b 5c 5d 5e 5f 60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70 71 72 73 74 75 76 77 78 79 7a 7b 7c 7d 7e 7f
    Adding Longarray at id 3
+   Enumerating live entries with zms_iter_next:
+   id=0x3, len=128, revisions=9
+   id=0x2, len=4, revisions=9
+   id=0xbeefdead, len=8, revisions=9
+   id=0x1, len=12, revisions=9
    Memory is full let's delete all items
    Free space in storage is 8064 bytes
    Sample code finished Successfully

--- a/samples/subsys/kvss/zms/README.rst
+++ b/samples/subsys/kvss/zms/README.rst
@@ -6,8 +6,12 @@
 
 Overview
 ********
- The sample shows how to use ZMS to store ID/VALUE pairs and reads them back.
- Deleting an ID/VALUE pair is also shown in this sample.
+The sample shows how to use ZMS to store ID/VALUE pairs and reads them back.
+Deleting an ID/VALUE pair is also shown in this sample.
+The sample also demonstrates how an application can enumerate all live entries
+using the iterator API (``zms_iter_init()`` and ``zms_iter_next()``), or filter
+the results with ``zms_iter_init_with_config()`` (mask/range/predicate),
+without predeclaring the list of IDs.
 
  The sample stores the following items:
 
@@ -16,6 +20,13 @@ Overview
     data={0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF}
  #. A variable (32bit): stored at id=2, data=cnt
  #. A long set of data (128 bytes)
+
+    After the write/read loop completes, the sample runs a full iterator pass and
+    then a masked iterator pass, printing one line per live entry with:
+
+ #. entry ID
+ #. current stored length
+ #. revision depth (number of history revisions available through ``zms_read_hist()``)
 
  A loop is executed where we mount the storage system, and then write all set
  of data.
@@ -89,6 +100,11 @@ Sample Output
    Id: 3, Longarray: 0 1 2 3 4 5 6 7 8 9 a b c d e f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f 40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f 50 51 52 53 5
    4 55 56 57 58 59 5a 5b 5c 5d 5e 5f 60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70 71 72 73 74 75 76 77 78 79 7a 7b 7c 7d 7e 7f
    Adding Longarray at id 3
+   Enumerating live entries with zms_iter_next:
+   id=0x3, len=128, revisions=9
+   id=0x2, len=4, revisions=9, data=08000000
+   id=0xbeefdead, len=8, revisions=9, data=deadbeefdeadbeef
+   id=0x1, len=12, revisions=9
    Memory is full let's delete all items
    Free space in storage is 8064 bytes
    Sample code finished Successfully

--- a/samples/subsys/kvss/zms/src/main.c
+++ b/samples/subsys/kvss/zms/src/main.c
@@ -10,12 +10,12 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/device.h>
+#include <errno.h>
+#include <inttypes.h>
 #include <string.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/kvss/zms.h>
-
-static struct zms_fs fs;
 
 #define ZMS_PARTITION        storage_partition
 #define ZMS_PARTITION_DEVICE PARTITION_DEVICE(ZMS_PARTITION)
@@ -25,6 +25,17 @@ static struct zms_fs fs;
 #define KEY_VALUE_ID  COND_CODE_1(CONFIG_ZMS_ID_64BIT, (0xbeefdead00000002ULL), (0xbeefdeadULL))
 #define CNT_ID        2
 #define LONG_DATA_ID  3
+#define ITER_ARRAY_MAX_ENTRIES 32
+
+struct iter_array_entry {
+	zms_id_t id;
+	size_t len;
+};
+
+static bool filter_out_id_2(zms_id_t id)
+{
+	return id != CNT_ID;
+}
 
 static int delete_and_verify_items(struct zms_fs *fs, zms_id_t id)
 {
@@ -75,17 +86,230 @@ static int delete_basic_items(struct zms_fs *fs)
 	return rc;
 }
 
+static int get_history_depth(struct zms_fs *fs, zms_id_t id, uint32_t *depth)
+{
+	ssize_t len;
+	uint32_t cnt = 0U;
+
+	if (!depth) {
+		return -EINVAL;
+	}
+
+	while (true) {
+		len = zms_read_hist(fs, id, NULL, 0, cnt);
+		if (len == -ENOENT) {
+			break;
+		}
+
+		if (len < 0) {
+			return (int)len;
+		}
+
+		cnt++;
+	}
+
+	*depth = cnt;
+
+	return 0;
+}
+
+static int enumerate_live_entries(struct zms_fs *fs)
+{
+	int rc;
+	uint32_t depth;
+	zms_id_t id;
+	size_t len;
+	struct zms_iter iter;
+
+	rc = zms_iter_init(fs, &iter);
+	if (rc) {
+		printk("Iterator init failed, rc=%d\n", rc);
+		return rc;
+	}
+
+	printk("Enumerating live entries with zms_iter_next:\n");
+	while (true) {
+		rc = zms_iter_next(fs, &iter, &id, &len);
+		if (rc == 0) {
+			break;
+		}
+
+		if (rc < 0) {
+			printk("Iterator step failed, rc=%d\n", rc);
+			return rc;
+		}
+
+		rc = get_history_depth(fs, id, &depth);
+		if (rc) {
+			printk("History query failed for id=0x%" PRIx64 ", rc=%d\n", (uint64_t)id,
+			      rc);
+			return rc;
+		}
+
+		printk("  id=0x%" PRIx64 ", len=%zu, revisions=%" PRIu32 "\n", (uint64_t)id,
+		       len, depth);
+	}
+
+	return 0;
+}
+
+static int enumerate_live_entries_with_filters(struct zms_fs *fs, zms_id_t mask_id,
+				       zms_id_t min_id, zms_id_t max_id)
+{
+	int rc;
+	uint32_t depth;
+	zms_id_t id;
+	size_t len;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.mask_id = mask_id,
+		.min_id = min_id,
+		.max_id = max_id,
+		.use_mask = true,
+		.use_range = true,
+		.use_predicate = true,
+		.predicate_func = filter_out_id_2,
+	};
+
+	rc = zms_iter_init_with_config(fs, &iter, &config);
+	if (rc) {
+		printk("Iterator init with filters failed, rc=%d\n", rc);
+		return rc;
+	}
+
+	printk("Enumerating live entries with zms_iter_next, mask 0x%" PRIx64
+	       ", range [0x%" PRIx64 ", 0x%" PRIx64 "], predicate: id != 0x%" PRIx64
+	       "\n",
+	       (uint64_t)mask_id, (uint64_t)min_id, (uint64_t)max_id,
+	       (uint64_t)CNT_ID);
+	while (true) {
+		rc = zms_iter_next(fs, &iter, &id, &len);
+		if (rc == 0) {
+			break;
+		}
+
+		if (rc < 0) {
+			printk("Iterator step failed, rc=%d\n", rc);
+			return rc;
+		}
+
+		rc = get_history_depth(fs, id, &depth);
+		if (rc) {
+			printk("History query failed for id=0x%" PRIx64 ", rc=%d\n", (uint64_t)id,
+			      rc);
+			return rc;
+		}
+
+		printk("  id=0x%" PRIx64 ", len=%zu, revisions=%" PRIu32 "\n", (uint64_t)id,
+		       len, depth);
+	}
+
+	return 0;
+}
+
+static int enumerate_all_ates(struct zms_fs *fs, zms_id_t mask_id,
+			      zms_id_t min_id, zms_id_t max_id)
+{
+	int rc;
+	zms_id_t id;
+	size_t len;
+	size_t i;
+	size_t used_entries = 0U;
+	size_t live_entries = 0U;
+	struct zms_iter iter;
+	static struct iter_array_entry entries[ITER_ARRAY_MAX_ENTRIES];
+	struct zms_iter_config config = {
+		.mask_id = mask_id,
+		.min_id = min_id,
+		.max_id = max_id,
+		.use_mask = true,
+		.use_range = true,
+		.use_predicate = true,
+		.predicate_func = filter_out_id_2,
+	};
+
+	rc = zms_iter_init_with_config(fs, &iter, &config);
+	if (rc) {
+		printk("All-ATE iterator init with filters failed, rc=%d\n", rc);
+		return rc;
+	}
+
+	printk("Building array from zms_iter_next_all (mask 0x%" PRIx64
+	       ", range [0x%" PRIx64 ", 0x%" PRIx64 "], predicate: id != 0x%" PRIx64
+	       ")\n",
+	       (uint64_t)mask_id, (uint64_t)min_id, (uint64_t)max_id,
+	       (uint64_t)CNT_ID);
+
+	while (true) {
+		bool exists = false;
+
+		rc = zms_iter_next_all(fs, &iter, &id, &len);
+		if (rc == 0) {
+			break;
+		}
+
+		if (rc < 0) {
+			printk("All-ATE iterator step failed, rc=%d\n", rc);
+			return rc;
+		}
+
+		for (i = 0U; i < used_entries; i++) {
+			if (entries[i].id == id) {
+				exists = true;
+				break;
+			}
+		}
+
+		if (exists) {
+			continue;
+		}
+
+		if (used_entries >= ARRAY_SIZE(entries)) {
+			printk("Array dedupe storage full while processing id=0x%" PRIx64 "\n",
+			       (uint64_t)id);
+			return -ENOMEM;
+		}
+
+		entries[used_entries].id = id;
+		entries[used_entries].len = len;
+		used_entries++;
+
+		printk("  kept id=0x%" PRIx64 " as %s\n", (uint64_t)id,
+		       len == 0U ? "deleted" : "live");
+	}
+
+	/* Remove tombstones from the deduplicated array. */
+	for (i = 0U; i < used_entries; i++) {
+		if (entries[i].len == 0U) {
+			continue;
+		}
+
+		entries[live_entries] = entries[i];
+		live_entries++;
+	}
+
+	printk("Live IDs after tombstone removal (%zu entries):\n", live_entries);
+	for (i = 0U; i < live_entries; i++) {
+		printk("  id=0x%" PRIx64 "\n", (uint64_t)entries[i].id);
+	}
+
+	return 0;
+}
+
 int main(void)
 {
+	struct zms_fs fs = {0};
 	int rc = 0;
-	char buf[16];
-	uint8_t key[8] = {0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF}, longarray[128];
+	static char buf[16];
+	static uint8_t key[8] = {0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF};
+	static uint8_t longarray[128];
 	uint32_t i_cnt = 0U;
 	uint32_t i;
 	zms_id_t id = 0;
 	ssize_t free_space = 0;
 	struct flash_pages_info info;
 
+	/* Initialize longarray with pattern */
 	for (int n = 0; n < sizeof(longarray); n++) {
 		longarray[n] = n;
 	}
@@ -204,6 +428,27 @@ int main(void)
 
 	if (i != CONFIG_MAX_ITERATIONS) {
 		printk("Error: Something went wrong at iteration %u rc=%d\n", i, rc);
+		return 0;
+	}
+
+	/* Application-style enumeration of all currently live entries. */
+	rc = enumerate_live_entries(&fs);
+	if (rc) {
+		printk("Error while enumerating entries, rc=%d\n", rc);
+		return 0;
+	}
+
+	/* Application-style enumeration with an ID mask and inclusive range. */
+	rc = enumerate_live_entries_with_filters(&fs, (zms_id_t)0x03, (zms_id_t)0x01,
+						 (zms_id_t)0x03);
+	if (rc) {
+		printk("Error while enumerating filtered entries, rc=%d\n", rc);
+		return 0;
+	}
+
+	rc = enumerate_all_ates(&fs, (zms_id_t)0x03, (zms_id_t)0x01, (zms_id_t)0x03);
+	if (rc) {
+		printk("Error while enumerating all ATEs, rc=%d\n", rc);
 		return 0;
 	}
 

--- a/samples/subsys/kvss/zms/src/main.c
+++ b/samples/subsys/kvss/zms/src/main.c
@@ -10,12 +10,12 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/device.h>
+#include <errno.h>
+#include <inttypes.h>
 #include <string.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/kvss/zms.h>
-
-static struct zms_fs fs;
 
 #define ZMS_PARTITION        storage_partition
 #define ZMS_PARTITION_DEVICE PARTITION_DEVICE(ZMS_PARTITION)
@@ -25,6 +25,17 @@ static struct zms_fs fs;
 #define KEY_VALUE_ID  COND_CODE_1(CONFIG_ZMS_ID_64BIT, (0xbeefdead00000002ULL), (0xbeefdeadULL))
 #define CNT_ID        2
 #define LONG_DATA_ID  3
+#define ITER_ARRAY_MAX_ENTRIES 32
+
+struct iter_array_entry {
+	zms_id_t id;
+	size_t len;
+};
+
+static bool filter_out_id_2(zms_id_t id)
+{
+	return id != CNT_ID;
+}
 
 static int delete_and_verify_items(struct zms_fs *fs, zms_id_t id)
 {
@@ -75,17 +86,243 @@ static int delete_basic_items(struct zms_fs *fs)
 	return rc;
 }
 
+static int get_history_depth(struct zms_fs *fs, zms_id_t id, uint32_t *depth)
+{
+	ssize_t len;
+	uint32_t cnt = 0U;
+
+	if (!depth) {
+		return -EINVAL;
+	}
+
+	while (true) {
+		len = zms_read_hist(fs, id, NULL, 0, cnt);
+		if (len == -ENOENT) {
+			break;
+		}
+
+		if (len < 0) {
+			return (int)len;
+		}
+
+		cnt++;
+	}
+
+	*depth = cnt;
+
+	return 0;
+}
+
+static int enumerate_live_entries(struct zms_fs *fs)
+{
+	int rc;
+	uint32_t depth;
+	zms_id_t id;
+	size_t len;
+	struct zms_iter iter;
+	/* Buffer large enough to receive any data that ZMS stores inside the ATE.
+	 * The iterator fills it directly for such entries, avoiding an extra read.
+	 */
+	uint8_t data[ZMS_DATA_IN_ATE_SIZE];
+
+	rc = zms_iter_init(fs, &iter);
+	if (rc) {
+		printk("Iterator init failed, rc=%d\n", rc);
+		return rc;
+	}
+
+	printk("Enumerating live entries with zms_iter_next:\n");
+	while (true) {
+		rc = zms_iter_next(fs, &iter, &id, &len, data, sizeof(data));
+		if (rc == 0) {
+			break;
+		}
+
+		if (rc < 0) {
+			printk("Iterator step failed, rc=%d\n", rc);
+			return rc;
+		}
+
+		rc = get_history_depth(fs, id, &depth);
+		if (rc) {
+			printk("History query failed for id=0x%" PRIx64 ", rc=%d\n", (uint64_t)id,
+			      rc);
+			return rc;
+		}
+
+		printk("  id=0x%" PRIx64 ", len=%zu, revisions=%" PRIu32, (uint64_t)id, len, depth);
+		/* Data that fits inside the ATE has been copied into the buffer by
+		 * the iterator, so it can be printed without a separate read.
+		 */
+		if ((len > 0) && (len <= sizeof(data))) {
+			printk(", data=");
+			for (size_t i = 0; i < len; i++) {
+				printk("%02x", data[i]);
+			}
+		}
+		printk("\n");
+	}
+
+	return 0;
+}
+
+static int enumerate_live_entries_with_filters(struct zms_fs *fs, zms_id_t mask_id,
+				       zms_id_t min_id, zms_id_t max_id)
+{
+	int rc;
+	uint32_t depth;
+	zms_id_t id;
+	size_t len;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.mask_id = mask_id,
+		.min_id = min_id,
+		.max_id = max_id,
+		.use_mask = true,
+		.use_range = true,
+		.use_predicate = true,
+		.predicate_func = filter_out_id_2,
+	};
+
+	rc = zms_iter_init_with_config(fs, &iter, &config);
+	if (rc) {
+		printk("Iterator init with filters failed, rc=%d\n", rc);
+		return rc;
+	}
+
+	printk("Enumerating live entries with zms_iter_next, mask 0x%" PRIx64
+	       ", range [0x%" PRIx64 ", 0x%" PRIx64 "], predicate: id != 0x%" PRIx64
+	       "\n",
+	       (uint64_t)mask_id, (uint64_t)min_id, (uint64_t)max_id,
+	       (uint64_t)CNT_ID);
+	while (true) {
+		rc = zms_iter_next(fs, &iter, &id, &len, NULL, 0);
+		if (rc == 0) {
+			break;
+		}
+
+		if (rc < 0) {
+			printk("Iterator step failed, rc=%d\n", rc);
+			return rc;
+		}
+
+		rc = get_history_depth(fs, id, &depth);
+		if (rc) {
+			printk("History query failed for id=0x%" PRIx64 ", rc=%d\n", (uint64_t)id,
+			      rc);
+			return rc;
+		}
+
+		printk("  id=0x%" PRIx64 ", len=%zu, revisions=%" PRIu32 "\n", (uint64_t)id,
+		       len, depth);
+	}
+
+	return 0;
+}
+
+static int enumerate_all_ates(struct zms_fs *fs, zms_id_t mask_id,
+			      zms_id_t min_id, zms_id_t max_id)
+{
+	int rc;
+	zms_id_t id;
+	size_t len;
+	size_t i;
+	size_t used_entries = 0U;
+	size_t live_entries = 0U;
+	struct zms_iter iter;
+	static struct iter_array_entry entries[ITER_ARRAY_MAX_ENTRIES];
+	struct zms_iter_config config = {
+		.mask_id = mask_id,
+		.min_id = min_id,
+		.max_id = max_id,
+		.use_mask = true,
+		.use_range = true,
+		.use_predicate = true,
+		.predicate_func = filter_out_id_2,
+	};
+
+	rc = zms_iter_init_with_config(fs, &iter, &config);
+	if (rc) {
+		printk("All-ATE iterator init with filters failed, rc=%d\n", rc);
+		return rc;
+	}
+
+	printk("Building array from zms_iter_next_all (mask 0x%" PRIx64
+	       ", range [0x%" PRIx64 ", 0x%" PRIx64 "], predicate: id != 0x%" PRIx64
+	       ")\n",
+	       (uint64_t)mask_id, (uint64_t)min_id, (uint64_t)max_id,
+	       (uint64_t)CNT_ID);
+
+	while (true) {
+		bool exists = false;
+
+		rc = zms_iter_next_all(fs, &iter, &id, &len, NULL, 0);
+		if (rc == 0) {
+			break;
+		}
+
+		if (rc < 0) {
+			printk("All-ATE iterator step failed, rc=%d\n", rc);
+			return rc;
+		}
+
+		for (i = 0U; i < used_entries; i++) {
+			if (entries[i].id == id) {
+				exists = true;
+				break;
+			}
+		}
+
+		if (exists) {
+			continue;
+		}
+
+		if (used_entries >= ARRAY_SIZE(entries)) {
+			printk("Array dedupe storage full while processing id=0x%" PRIx64 "\n",
+			       (uint64_t)id);
+			return -ENOMEM;
+		}
+
+		entries[used_entries].id = id;
+		entries[used_entries].len = len;
+		used_entries++;
+
+		printk("  kept id=0x%" PRIx64 " as %s\n", (uint64_t)id,
+		       len == 0U ? "deleted" : "live");
+	}
+
+	/* Remove tombstones from the deduplicated array. */
+	for (i = 0U; i < used_entries; i++) {
+		if (entries[i].len == 0U) {
+			continue;
+		}
+
+		entries[live_entries] = entries[i];
+		live_entries++;
+	}
+
+	printk("Live IDs after tombstone removal (%zu entries):\n", live_entries);
+	for (i = 0U; i < live_entries; i++) {
+		printk("  id=0x%" PRIx64 "\n", (uint64_t)entries[i].id);
+	}
+
+	return 0;
+}
+
 int main(void)
 {
+	struct zms_fs fs = {0};
 	int rc = 0;
-	char buf[16];
-	uint8_t key[8] = {0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF}, longarray[128];
+	static char buf[16];
+	static uint8_t key[8] = {0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF};
+	static uint8_t longarray[128];
 	uint32_t i_cnt = 0U;
 	uint32_t i;
 	zms_id_t id = 0;
 	ssize_t free_space = 0;
 	struct flash_pages_info info;
 
+	/* Initialize longarray with pattern */
 	for (int n = 0; n < sizeof(longarray); n++) {
 		longarray[n] = n;
 	}
@@ -204,6 +441,27 @@ int main(void)
 
 	if (i != CONFIG_MAX_ITERATIONS) {
 		printk("Error: Something went wrong at iteration %u rc=%d\n", i, rc);
+		return 0;
+	}
+
+	/* Application-style enumeration of all currently live entries. */
+	rc = enumerate_live_entries(&fs);
+	if (rc) {
+		printk("Error while enumerating entries, rc=%d\n", rc);
+		return 0;
+	}
+
+	/* Application-style enumeration with an ID mask and inclusive range. */
+	rc = enumerate_live_entries_with_filters(&fs, (zms_id_t)0x03, (zms_id_t)0x01,
+						 (zms_id_t)0x03);
+	if (rc) {
+		printk("Error while enumerating filtered entries, rc=%d\n", rc);
+		return 0;
+	}
+
+	rc = enumerate_all_ates(&fs, (zms_id_t)0x03, (zms_id_t)0x01, (zms_id_t)0x03);
+	if (rc) {
+		printk("Error while enumerating all ATEs, rc=%d\n", rc);
 		return 0;
 	}
 

--- a/subsys/kvss/zms/zms.c
+++ b/subsys/kvss/zms/zms.c
@@ -29,6 +29,8 @@ static int zms_get_sector_header(struct zms_fs *fs, uint64_t addr, struct zms_at
 				 struct zms_ate *close_ate);
 static int zms_ate_valid_different_sector(struct zms_fs *fs, const struct zms_ate *entry,
 					  uint8_t cycle_cnt);
+static int zms_find_ate_with_id(struct zms_fs *fs, zms_id_t id, uint64_t start_addr,
+			     uint64_t end_addr, struct zms_ate *ate, uint64_t *ate_addr);
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
 
@@ -2235,4 +2237,212 @@ int zms_get_sector_num_cycles(struct zms_fs *fs, uint32_t sector, uint32_t *cycl
 	k_mutex_unlock(&fs->zms_lock);
 
 	return rc;
+}
+
+int zms_iter_init_with_config(const struct zms_fs *fs, struct zms_iter *iter,
+			      const struct zms_iter_config *config)
+{
+	if (!fs || !iter || !config) {
+		LOG_ERR("Invalid fs, iter, or config");
+		return -EINVAL;
+	}
+
+	if (!fs->ready) {
+		LOG_ERR("ZMS not initialized");
+		return -EINVAL;
+	}
+
+	iter->mask_id = config->use_mask ? config->mask_id : ZMS_ITER_MASK_ALL;
+	iter->min_id = config->use_range ? config->min_id : ZMS_ITER_ID_MIN;
+	iter->max_id = config->use_range ? config->max_id : ZMS_ITER_ID_MAX;
+	iter->predicate_func = config->use_predicate ? config->predicate_func : NULL;
+
+	if (config->use_predicate && config->predicate_func == NULL) {
+		LOG_ERR("Invalid iterator predicate");
+		return -EINVAL;
+	}
+
+	if (iter->min_id > iter->max_id) {
+		LOG_ERR("Invalid iterator range");
+		return -EINVAL;
+	}
+
+	iter->walk_addr = fs->ate_wra;
+	iter->end_addr = fs->ate_wra;
+	iter->exhausted = false;
+
+	return 0;
+}
+
+int zms_iter_init(const struct zms_fs *fs, struct zms_iter *iter)
+{
+	const struct zms_iter_config config = ZMS_ITER_CONFIG_DEFAULT;
+
+	return zms_iter_init_with_config(fs, iter, &config);
+}
+
+static int zms_iter_has_newer_id(struct zms_fs *fs, struct zms_iter *iter,
+				 zms_id_t id, uint64_t ate_addr)
+{
+	int newer_found;
+	struct zms_ate dummy_ate;
+	uint64_t dummy_addr;
+
+#ifdef CONFIG_ZMS_LOOKUP_CACHE
+	int rc;
+	uint64_t cached = fs->lookup_cache[zms_lookup_cache_pos(id)];
+
+	if (cached != ZMS_LOOKUP_CACHE_NO_ADDR && cached != ate_addr) {
+		struct zms_ate cached_ate;
+
+		/* Cache points to a newer ATE for this ID unless it is a collision. */
+		rc = zms_flash_ate_rd(fs, cached, &cached_ate);
+		if (rc == 0 && cached_ate.id == id) {
+			return 1;
+		}
+	}
+#endif
+
+	newer_found = zms_find_ate_with_id(fs, id, iter->end_addr, ate_addr,
+					   &dummy_ate, &dummy_addr);
+	return newer_found;
+}
+
+static int zms_iter_filter_common(struct zms_fs *fs, struct zms_iter *iter,
+					  struct zms_ate *ate, uint64_t ate_addr,
+					  int *previous_sector_num, uint8_t *current_cycle)
+{
+	int rc;
+
+	/* Skip non-data ATEs (sector headers). */
+	if (ate->id == ZMS_HEAD_ID) {
+		return 0;
+	}
+
+	rc = zms_get_cycle_on_sector_change(fs, ate_addr, *previous_sector_num, current_cycle);
+	if (rc) {
+		return rc;
+	}
+	*previous_sector_num = SECTOR_NUM(ate_addr);
+
+	if (!zms_ate_valid_different_sector(fs, ate, *current_cycle)) {
+		return 0;
+	}
+
+	if (((zms_id_t)ate->id & (zms_id_t)iter->mask_id) != (zms_id_t)ate->id) {
+		return 0;
+	}
+
+	if ((ate->id < iter->min_id) || (ate->id > iter->max_id)) {
+		return 0;
+	}
+
+	if (iter->predicate_func && !iter->predicate_func(ate->id)) {
+		return 0;
+	}
+
+	return 1;
+}
+
+static int zms_iter_filter_unique(struct zms_fs *fs, struct zms_iter *iter,
+					  struct zms_ate *ate, uint64_t ate_addr,
+					  bool unique_only)
+{
+	int rc;
+
+	if (!unique_only) {
+		return 1;
+	}
+
+	if (ate->len == 0U) {
+		return 0;
+	}
+
+	rc = zms_iter_has_newer_id(fs, iter, ate->id, ate_addr);
+	if (rc < 0) {
+		return rc;
+	}
+
+	/* A fresher ATE exists, skip this one. */
+	if (rc == 1) {
+		return 0;
+	}
+
+	return 1;
+}
+
+static int zms_iter_next_common(struct zms_fs *fs, struct zms_iter *iter,
+				zms_id_t *id, size_t *len, bool unique_only)
+{
+	int rc;
+	int previous_sector_num = ZMS_INVALID_SECTOR_NUM;
+	uint64_t ate_addr;
+	uint8_t current_cycle;
+	struct zms_ate ate;
+
+	if (!fs || !iter || !id || !len) {
+		LOG_ERR("Invalid parameters");
+		return -EINVAL;
+	}
+
+	if (!fs->ready) {
+		LOG_ERR("ZMS not initialized");
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&fs->zms_lock, K_FOREVER);
+
+	while (!iter->exhausted) {
+		ate_addr = iter->walk_addr;
+		rc = zms_prev_ate(fs, &iter->walk_addr, &ate);
+		if (rc) {
+			goto end;
+		}
+
+		/* Mark exhausted before processing so we don't miss the last ATE */
+		if (iter->walk_addr == iter->end_addr) {
+			iter->exhausted = true;
+		}
+
+		rc = zms_iter_filter_common(fs, iter, &ate, ate_addr, &previous_sector_num,
+					    &current_cycle);
+		if (rc < 0) {
+			goto end;
+		}
+		if (rc == 0) {
+			continue;
+		}
+
+		rc = zms_iter_filter_unique(fs, iter, &ate, ate_addr, unique_only);
+		if (rc < 0) {
+			goto end;
+		}
+		if (rc == 0) {
+			continue;
+		}
+
+		*id = ate.id;
+		*len = ate.len;
+		rc = 1;
+		goto end;
+	}
+
+	rc = 0;
+
+end:
+	k_mutex_unlock(&fs->zms_lock);
+
+	return rc;
+}
+
+int zms_iter_next(struct zms_fs *fs, struct zms_iter *iter,
+		  zms_id_t *id, size_t *len)
+{
+	return zms_iter_next_common(fs, iter, id, len, true);
+}
+
+int zms_iter_next_all(struct zms_fs *fs, struct zms_iter *iter,
+		      zms_id_t *id, size_t *len)
+{
+	return zms_iter_next_common(fs, iter, id, len, false);
 }

--- a/subsys/kvss/zms/zms.c
+++ b/subsys/kvss/zms/zms.c
@@ -2290,7 +2290,7 @@ static int zms_iter_has_newer_id(struct zms_fs *fs, struct zms_iter *iter,
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
 	int rc;
-	uint64_t cached = fs->lookup_cache[zms_lookup_cache_pos(id)];
+	uint64_t cached = zms_lookup_cache_addr(fs, id);
 
 	if (cached != ZMS_LOOKUP_CACHE_NO_ADDR && cached != ate_addr) {
 		struct zms_ate cached_ate;

--- a/subsys/kvss/zms/zms.c
+++ b/subsys/kvss/zms/zms.c
@@ -29,6 +29,8 @@ static int zms_get_sector_header(struct zms_fs *fs, uint64_t addr, struct zms_at
 				 struct zms_ate *close_ate);
 static int zms_ate_valid_different_sector(struct zms_fs *fs, const struct zms_ate *entry,
 					  uint8_t cycle_cnt);
+static int zms_find_ate_with_id(struct zms_fs *fs, zms_id_t id, uint64_t start_addr,
+			     uint64_t end_addr, struct zms_ate *ate, uint64_t *ate_addr);
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
 
@@ -2235,4 +2237,222 @@ int zms_get_sector_num_cycles(struct zms_fs *fs, uint32_t sector, uint32_t *cycl
 	k_mutex_unlock(&fs->zms_lock);
 
 	return rc;
+}
+
+int zms_iter_init_with_config(const struct zms_fs *fs, struct zms_iter *iter,
+			      const struct zms_iter_config *config)
+{
+	if (!fs || !iter || !config) {
+		LOG_ERR("Invalid fs, iter, or config");
+		return -EINVAL;
+	}
+
+	if (!fs->ready) {
+		LOG_ERR("ZMS not initialized");
+		return -EINVAL;
+	}
+
+	iter->mask_id = config->use_mask ? config->mask_id : ZMS_ITER_MASK_ALL;
+	iter->min_id = config->use_range ? config->min_id : ZMS_ITER_ID_MIN;
+	iter->max_id = config->use_range ? config->max_id : ZMS_ITER_ID_MAX;
+	iter->predicate_func = config->use_predicate ? config->predicate_func : NULL;
+
+	if (config->use_predicate && config->predicate_func == NULL) {
+		LOG_ERR("Invalid iterator predicate");
+		return -EINVAL;
+	}
+
+	if (iter->min_id > iter->max_id) {
+		LOG_ERR("Invalid iterator range");
+		return -EINVAL;
+	}
+
+	iter->walk_addr = fs->ate_wra;
+	iter->end_addr = fs->ate_wra;
+	iter->exhausted = false;
+
+	return 0;
+}
+
+int zms_iter_init(const struct zms_fs *fs, struct zms_iter *iter)
+{
+	const struct zms_iter_config config = ZMS_ITER_CONFIG_DEFAULT;
+
+	return zms_iter_init_with_config(fs, iter, &config);
+}
+
+static int zms_iter_has_newer_id(struct zms_fs *fs, struct zms_iter *iter,
+				 zms_id_t id, uint64_t ate_addr)
+{
+	int newer_found;
+	struct zms_ate dummy_ate;
+	uint64_t dummy_addr;
+
+#ifdef CONFIG_ZMS_LOOKUP_CACHE
+	int rc;
+	uint64_t cached = fs->lookup_cache[zms_lookup_cache_pos(id)];
+
+	if (cached != ZMS_LOOKUP_CACHE_NO_ADDR && cached != ate_addr) {
+		struct zms_ate cached_ate;
+
+		/* Cache points to a newer ATE for this ID unless it is a collision. */
+		rc = zms_flash_ate_rd(fs, cached, &cached_ate);
+		if (rc == 0 && cached_ate.id == id) {
+			return 1;
+		}
+	}
+#endif
+
+	newer_found = zms_find_ate_with_id(fs, id, iter->end_addr, ate_addr,
+					   &dummy_ate, &dummy_addr);
+	return newer_found;
+}
+
+static int zms_iter_filter_common(struct zms_fs *fs, struct zms_iter *iter,
+					  struct zms_ate *ate, uint64_t ate_addr,
+					  int *previous_sector_num, uint8_t *current_cycle)
+{
+	int rc;
+
+	/* Skip non-data ATEs (sector headers). */
+	if (ate->id == ZMS_HEAD_ID) {
+		return 0;
+	}
+
+	rc = zms_get_cycle_on_sector_change(fs, ate_addr, *previous_sector_num, current_cycle);
+	if (rc) {
+		return rc;
+	}
+	*previous_sector_num = SECTOR_NUM(ate_addr);
+
+	if (!zms_ate_valid_different_sector(fs, ate, *current_cycle)) {
+		return 0;
+	}
+
+	if (((zms_id_t)ate->id & (zms_id_t)iter->mask_id) != (zms_id_t)ate->id) {
+		return 0;
+	}
+
+	if ((ate->id < iter->min_id) || (ate->id > iter->max_id)) {
+		return 0;
+	}
+
+	if (iter->predicate_func && !iter->predicate_func(ate->id)) {
+		return 0;
+	}
+
+	return 1;
+}
+
+static int zms_iter_filter_unique(struct zms_fs *fs, struct zms_iter *iter,
+					  struct zms_ate *ate, uint64_t ate_addr,
+					  bool unique_only)
+{
+	int rc;
+
+	if (!unique_only) {
+		return 1;
+	}
+
+	if (ate->len == 0U) {
+		return 0;
+	}
+
+	rc = zms_iter_has_newer_id(fs, iter, ate->id, ate_addr);
+	if (rc < 0) {
+		return rc;
+	}
+
+	/* A fresher ATE exists, skip this one. */
+	if (rc == 1) {
+		return 0;
+	}
+
+	return 1;
+}
+
+static int zms_iter_next_common(struct zms_fs *fs, struct zms_iter *iter, zms_id_t *id, size_t *len,
+				void *data, size_t data_len, bool unique_only)
+{
+	int rc;
+	int previous_sector_num = ZMS_INVALID_SECTOR_NUM;
+	uint64_t ate_addr;
+	uint8_t current_cycle;
+	struct zms_ate ate;
+
+	if (!fs || !iter || !id || !len) {
+		LOG_ERR("Invalid parameters");
+		return -EINVAL;
+	}
+
+	if (!fs->ready) {
+		LOG_ERR("ZMS not initialized");
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&fs->zms_lock, K_FOREVER);
+
+	while (!iter->exhausted) {
+		ate_addr = iter->walk_addr;
+		rc = zms_prev_ate(fs, &iter->walk_addr, &ate);
+		if (rc) {
+			goto end;
+		}
+
+		/* Mark exhausted before processing so we don't miss the last ATE */
+		if (iter->walk_addr == iter->end_addr) {
+			iter->exhausted = true;
+		}
+
+		rc = zms_iter_filter_common(fs, iter, &ate, ate_addr, &previous_sector_num,
+					    &current_cycle);
+		if (rc < 0) {
+			goto end;
+		}
+		if (rc == 0) {
+			continue;
+		}
+
+		rc = zms_iter_filter_unique(fs, iter, &ate, ate_addr, unique_only);
+		if (rc < 0) {
+			goto end;
+		}
+		if (rc == 0) {
+			continue;
+		}
+
+		*id = ate.id;
+		*len = ate.len;
+
+		/* If the caller provided a buffer, copy the data that is stored
+		 * directly inside the ATE. Data is only stored in the ATE when
+		 * its length does not exceed ZMS_DATA_IN_ATE_SIZE; larger data is
+		 * kept elsewhere in the sector and is therefore not copied here.
+		 */
+		if (data && (ate.len > 0U) && (ate.len <= ZMS_DATA_IN_ATE_SIZE)) {
+			memcpy(data, &ate.data, MIN(data_len, ate.len));
+		}
+
+		rc = 1;
+		goto end;
+	}
+
+	rc = 0;
+
+end:
+	k_mutex_unlock(&fs->zms_lock);
+
+	return rc;
+}
+
+int zms_iter_next(struct zms_fs *fs, struct zms_iter *iter, zms_id_t *id, size_t *len, void *data,
+		  size_t data_len)
+{
+	return zms_iter_next_common(fs, iter, id, len, data, data_len, true);
+}
+
+int zms_iter_next_all(struct zms_fs *fs, struct zms_iter *iter, zms_id_t *id, size_t *len,
+		      void *data, size_t data_len)
+{
+	return zms_iter_next_common(fs, iter, id, len, data, data_len, false);
 }

--- a/subsys/kvss/zms/zms_priv.h
+++ b/subsys/kvss/zms/zms_priv.h
@@ -110,6 +110,10 @@ struct zms_ate {
 
 } __packed;
 
-#define ZMS_DATA_IN_ATE_SIZE SIZEOF_FIELD(struct zms_ate, data)
+/* ZMS_DATA_IN_ATE_SIZE is defined in the public header <zephyr/kvss/zms.h>.
+ * Make sure it stays in sync with the actual size of the in-ATE data field.
+ */
+BUILD_ASSERT(ZMS_DATA_IN_ATE_SIZE == SIZEOF_FIELD(struct zms_ate, data),
+	     "ZMS_DATA_IN_ATE_SIZE does not match the ATE data field size");
 
 #endif /* __ZMS_PRIV_H_ */

--- a/tests/subsys/kvss/zms/src/main.c
+++ b/tests/subsys/kvss/zms/src/main.c
@@ -1847,3 +1847,744 @@ ZTEST_F(zms, test_zms_read_evil_ate)
 	len = zms_read(&fixture->fs, 3, buffer, sizeof(buffer));
 	zassert_equal(len, -ENOENT, "zms_read(id=3) should return -ENOENT, got %zd", len);
 }
+
+ZTEST_F(zms, test_zms_iter_empty_partition)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Initialize iterator on empty partition */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Should immediately return 0 (no entries) */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len);
+	zassert_equal(err, 0, "zms_iter_next should return 0 on empty partition: %d", err);
+}
+
+ZTEST_F(zms, test_zms_iter_single_entry)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t test_data = 0xDEADBEEFU;
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write a single entry */
+	written = zms_write(&fixture->fs, 100, &test_data, sizeof(test_data));
+	zassert_equal(written, sizeof(test_data), "zms_write failed: %zd", written);
+
+	/* Initialize iterator */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Should find the entry */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len);
+	zassert_equal(err, 1, "zms_iter_next should find entry: %d", err);
+	zassert_equal(id, 100, "ID mismatch: got %llu", (unsigned long long)id);
+	zassert_equal(len, sizeof(test_data), "len mismatch: got %zu", len);
+
+	/* Second call should return 0 (no more entries) */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len);
+	zassert_equal(err, 0, "zms_iter_next should return 0 after last entry: %d", err);
+}
+
+ZTEST_F(zms, test_zms_iter_multiple_entries)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t data1 = 0x11111111;
+	uint32_t data2 = 0x22222222;
+	uint32_t data3 = 0x33333333;
+	int found_count = 0;
+	int found_ids[3] = {0};
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write three distinct entries */
+	written = zms_write(&fixture->fs, 200, &data1, sizeof(data1));
+	zassert_equal(written, sizeof(data1), "zms_write ID 200 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 201, &data2, sizeof(data2));
+	zassert_equal(written, sizeof(data2), "zms_write ID 201 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 202, &data3, sizeof(data3));
+	zassert_equal(written, sizeof(data3), "zms_write ID 202 failed: %zd", written);
+
+	/* Initialize iterator */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Collect all entries */
+	while (1) {
+		err = zms_iter_next(&fixture->fs, &iter, &id, &len);
+		if (err == 0) {
+			break;
+		}
+		zassert_equal(err, 1, "zms_iter_next returned error: %d", err);
+		zassert_equal(len, sizeof(uint32_t), "len mismatch for ID %llu: got %zu",
+			      (unsigned long long)id, len);
+
+		found_ids[found_count] = id;
+		found_count++;
+		zassert_true(found_count <= 3, "Found more than 3 entries");
+	}
+
+	/* Verify all three entries were found */
+	zassert_equal(found_count, 3, "Expected 3 entries, found: %d", found_count);
+
+	/* Verify all IDs were found (order may vary due to reverse walk) */
+	bool found_200 = false, found_201 = false, found_202 = false;
+
+	for (int i = 0; i < found_count; i++) {
+		if (found_ids[i] == 200) {
+			found_200 = true;
+		}
+		if (found_ids[i] == 201) {
+			found_201 = true;
+		}
+		if (found_ids[i] == 202) {
+			found_202 = true;
+		}
+	}
+	zassert_true(found_200, "ID 200 not found");
+	zassert_true(found_201, "ID 201 not found");
+	zassert_true(found_202, "ID 202 not found");
+}
+
+static bool iter_predicate_id_ge_0x20(zms_id_t id)
+{
+	return id >= (zms_id_t)0x20;
+}
+
+ZTEST_F(zms, test_zms_iter_id_mask)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.mask_id = (zms_id_t)0xFF,
+		.use_mask = true,
+	};
+	zms_id_t id;
+	size_t len;
+	uint32_t data1 = 0x11111111;
+	uint32_t data2 = 0x22222222;
+	uint32_t data3 = 0x33333333;
+	int found_count = 0;
+	bool found_id_05 = false;
+	bool found_id_a0 = false;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x05, &data1, sizeof(data1)),
+		      sizeof(data1), "zms_write ID 0x05 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0xA0, &data2, sizeof(data2)),
+		      sizeof(data2), "zms_write ID 0xA0 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x1A0, &data3, sizeof(data3)),
+		      sizeof(data3), "zms_write ID 0x1A0 failed");
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len)) == 1) {
+		zassert_equal(len, sizeof(uint32_t), "len mismatch: %zu", len);
+		found_count++;
+
+		if (id == (zms_id_t)0x05) {
+			found_id_05 = true;
+		} else if (id == (zms_id_t)0xA0) {
+			found_id_a0 = true;
+		} else {
+			zassert_unreachable("Unexpected ID returned by masked iterator");
+		}
+	}
+
+	zassert_equal(err, 0, "zms_iter_next returned unexpected error: %d", err);
+	zassert_equal(found_count, 2, "Expected 2 entries with mask, found: %d", found_count);
+	zassert_true(found_id_05, "ID 0x05 not found with mask");
+	zassert_true(found_id_a0, "ID 0xA0 not found with mask");
+}
+
+ZTEST_F(zms, test_zms_iter_config_default_filters)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {0};
+	zms_id_t id;
+	size_t len;
+	uint32_t data = 0xA5A5A5A5U;
+	int found_count = 0;
+	bool found_id_0 = false;
+	bool found_id_ff = false;
+	bool found_id_100 = false;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x00, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x00 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0xFF, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0xFF failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x100, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x100 failed");
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len)) == 1) {
+		zassert_equal(len, sizeof(uint32_t), "len mismatch: %zu", len);
+		found_count++;
+
+		if (id == (zms_id_t)0x00) {
+			found_id_0 = true;
+		} else if (id == (zms_id_t)0xFF) {
+			found_id_ff = true;
+		} else if (id == (zms_id_t)0x100) {
+			found_id_100 = true;
+		} else {
+			zassert_unreachable("Unexpected ID returned by default config iterator");
+		}
+	}
+
+	zassert_equal(err, 0, "zms_iter_next returned unexpected error: %d", err);
+	zassert_equal(found_count, 3, "Expected 3 entries with default config, found: %d",
+		      found_count);
+	zassert_true(found_id_0, "ID 0x00 not found with default config");
+	zassert_true(found_id_ff, "ID 0xFF not found with default config");
+	zassert_true(found_id_100, "ID 0x100 not found with default config");
+}
+
+ZTEST_F(zms, test_zms_iter_id_range)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.min_id = (zms_id_t)0x20,
+		.max_id = (zms_id_t)0xA0,
+		.use_range = true,
+	};
+	zms_id_t id;
+	size_t len;
+	uint32_t data = 0x11111111;
+	int found_count = 0;
+	bool found_id_20 = false;
+	bool found_id_a0 = false;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x05, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x05 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x20, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x20 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0xA0, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0xA0 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0xA1, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0xA1 failed");
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len)) == 1) {
+		zassert_equal(len, sizeof(uint32_t), "len mismatch: %zu", len);
+		found_count++;
+
+		if (id == (zms_id_t)0x20) {
+			found_id_20 = true;
+		} else if (id == (zms_id_t)0xA0) {
+			found_id_a0 = true;
+		} else {
+			zassert_unreachable("Unexpected ID returned by range iterator");
+		}
+	}
+
+	zassert_equal(err, 0, "zms_iter_next returned unexpected error: %d", err);
+	zassert_equal(found_count, 2, "Expected 2 entries in range, found: %d", found_count);
+	zassert_true(found_id_20, "ID 0x20 not found in range");
+	zassert_true(found_id_a0, "ID 0xA0 not found in range");
+}
+
+ZTEST_F(zms, test_zms_iter_predicate)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.use_predicate = true,
+		.predicate_func = iter_predicate_id_ge_0x20,
+	};
+	zms_id_t id;
+	size_t len;
+	uint32_t data = 0x11111111;
+	int found_count = 0;
+	bool found_id_20 = false;
+	bool found_id_a0 = false;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x05, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x05 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x20, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x20 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0xA0, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0xA0 failed");
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len)) == 1) {
+		zassert_equal(len, sizeof(uint32_t), "len mismatch: %zu", len);
+		found_count++;
+
+		if (id == (zms_id_t)0x20) {
+			found_id_20 = true;
+		} else if (id == (zms_id_t)0xA0) {
+			found_id_a0 = true;
+		} else {
+			zassert_unreachable("Unexpected ID returned by predicate iterator");
+		}
+	}
+
+	zassert_equal(err, 0, "zms_iter_next returned unexpected error: %d", err);
+	zassert_equal(found_count, 2, "Expected 2 entries from predicate, found: %d", found_count);
+	zassert_true(found_id_20, "ID 0x20 not found with predicate");
+	zassert_true(found_id_a0, "ID 0xA0 not found with predicate");
+}
+
+ZTEST_F(zms, test_zms_iter_update_only_latest)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t data_v1 = 0x11111111;
+	uint32_t data_v2 = 0x22222222;
+	ssize_t written;
+	uint32_t read_data;
+	ssize_t read_len;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write same ID twice with different data */
+	written = zms_write(&fixture->fs, 300, &data_v1, sizeof(data_v1));
+	zassert_equal(written, sizeof(data_v1), "zms_write v1 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 300, &data_v2, sizeof(data_v2));
+	zassert_equal(written, sizeof(data_v2), "zms_write v2 failed: %zd", written);
+
+	/* Initialize iterator */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Should find ID 300 exactly once (the latest version) */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len);
+	zassert_equal(err, 1, "zms_iter_next should find entry: %d", err);
+	zassert_equal(id, 300, "ID mismatch: got %llu", (unsigned long long)id);
+	zassert_equal(len, sizeof(data_v2), "len mismatch: got %zu", len);
+
+	/* Verify it's the latest data by reading it back */
+	read_len = zms_read(&fixture->fs, 300, &read_data, sizeof(read_data));
+	zassert_equal(read_len, sizeof(read_data), "zms_read failed: %zd", read_len);
+	zassert_equal(read_data, data_v2, "Should read latest version: got 0x%x", read_data);
+
+	/* Second iter_next should return 0 (only one unique ID) */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len);
+	zassert_equal(err, 0, "zms_iter_next should return 0 after last entry: %d", err);
+}
+
+ZTEST_F(zms, test_zms_iter_deleted_entries)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t data1 = 0x11111111;
+	uint32_t data2 = 0x22222222;
+	int found_count = 0;
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write two entries, then delete one */
+	written = zms_write(&fixture->fs, 400, &data1, sizeof(data1));
+	zassert_equal(written, sizeof(data1), "zms_write ID 400 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 401, &data2, sizeof(data2));
+	zassert_equal(written, sizeof(data2), "zms_write ID 401 failed: %zd", written);
+
+	/* Delete ID 400 */
+	err = zms_delete(&fixture->fs, 400);
+	zassert_equal(err, 0, "zms_delete failed: %d", err);
+
+	/* Initialize iterator */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Iterator should only find ID 401 (ID 400 is deleted) */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len);
+	zassert_equal(err, 1, "zms_iter_next should find entry: %d", err);
+	zassert_equal(id, 401, "Expected ID 401, got %llu", (unsigned long long)id);
+	found_count++;
+
+	/* Second call should return 0 */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len);
+	zassert_equal(err, 0, "zms_iter_next should return 0: %d", err);
+
+	zassert_equal(found_count, 1, "Should only find 1 entry (ID 400 is deleted)");
+}
+
+ZTEST_F(zms, test_zms_iter_invalid_params)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Test with NULL fs */
+	err = zms_iter_init(NULL, &iter);
+	zassert_equal(err, -EINVAL, "zms_iter_init should return -EINVAL for NULL fs");
+
+	/* Test with NULL iter */
+	err = zms_iter_init(&fixture->fs, NULL);
+	zassert_equal(err, -EINVAL, "zms_iter_init should return -EINVAL for NULL iter");
+
+	/* Test zms_iter_init_with_config with NULL fs */
+	{
+		struct zms_iter_config config = {
+			.mask_id = (zms_id_t)0xFF,
+			.use_mask = true,
+		};
+
+		err = zms_iter_init_with_config(NULL, &iter, &config);
+	}
+	zassert_equal(err, -EINVAL,
+		      "zms_iter_init_with_config should return -EINVAL for NULL fs");
+
+	/* Test zms_iter_init_with_config with NULL iter */
+	{
+		struct zms_iter_config config = {
+			.mask_id = (zms_id_t)0xFF,
+			.use_mask = true,
+		};
+
+		err = zms_iter_init_with_config(&fixture->fs, NULL, &config);
+	}
+	zassert_equal(err, -EINVAL,
+		      "zms_iter_init_with_config should return -EINVAL for NULL iter");
+
+	/* Test zms_iter_init_with_config with NULL config */
+	err = zms_iter_init_with_config(&fixture->fs, &iter, NULL);
+	zassert_equal(err, -EINVAL,
+		      "zms_iter_init_with_config should return -EINVAL for NULL config");
+
+	/* Test zms_iter_init_with_config with invalid range */
+	{
+		struct zms_iter_config config = {
+			.min_id = (zms_id_t)10,
+			.max_id = (zms_id_t)5,
+			.use_range = true,
+		};
+
+		err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	}
+	zassert_equal(err, -EINVAL,
+		      "zms_iter_init_with_config should return -EINVAL for invalid range");
+
+	/* Test zms_iter_init_with_config with missing predicate function */
+	{
+		struct zms_iter_config config = {
+			.use_predicate = true,
+			.predicate_func = NULL,
+		};
+
+		err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	}
+	zassert_equal(err, -EINVAL,
+		      "zms_iter_init_with_config should return -EINVAL for missing predicate");
+
+	/* Test iter_next with NULL fs */
+	zms_iter_init(&fixture->fs, &iter);
+	err = zms_iter_next(NULL, &iter, &id, &len);
+	zassert_equal(err, -EINVAL, "zms_iter_next should return -EINVAL for NULL fs");
+
+	/* Test iter_next with NULL iter */
+	err = zms_iter_next(&fixture->fs, NULL, &id, &len);
+	zassert_equal(err, -EINVAL, "zms_iter_next should return -EINVAL for NULL iter");
+
+	/* Test iter_next with NULL id */
+	zms_iter_init(&fixture->fs, &iter);
+	err = zms_iter_next(&fixture->fs, &iter, NULL, &len);
+	zassert_equal(err, -EINVAL, "zms_iter_next should return -EINVAL for NULL id");
+
+	/* Test iter_next with NULL len */
+	zms_iter_init(&fixture->fs, &iter);
+	err = zms_iter_next(&fixture->fs, &iter, &id, NULL);
+	zassert_equal(err, -EINVAL, "zms_iter_next should return -EINVAL for NULL len");
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_empty_partition)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Should immediately return 0 (no ATEs) */
+	err = zms_iter_next_all(&fixture->fs, &iter, &id, &len);
+	zassert_equal(err, 0, "zms_iter_next_all should return 0 on empty partition: %d", err);
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_includes_history)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t data_v1 = 0x11111111;
+	uint32_t data_v2 = 0x22222222;
+	uint32_t data_v3 = 0x33333333;
+	int count = 0;
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write same ID three times (creates 3 ATEs for same ID) */
+	written = zms_write(&fixture->fs, 500, &data_v1, sizeof(data_v1));
+	zassert_equal(written, sizeof(data_v1), "zms_write v1 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 500, &data_v2, sizeof(data_v2));
+	zassert_equal(written, sizeof(data_v2), "zms_write v2 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 500, &data_v3, sizeof(data_v3));
+	zassert_equal(written, sizeof(data_v3), "zms_write v3 failed: %zd", written);
+
+	/* zms_iter_next should find ID 500 exactly once (latest only) */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len)) == 1) {
+		count++;
+	}
+	zassert_equal(err, 0, "zms_iter_next returned error: %d", err);
+	zassert_equal(count, 1, "zms_iter_next should return 1 unique entry, got %d", count);
+
+	/* zms_iter_next_all should find all 3 historical ATEs */
+	count = 0;
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	while ((err = zms_iter_next_all(&fixture->fs, &iter, &id, &len)) == 1) {
+		zassert_equal(id, 500, "expected ID 500, got %llu", (unsigned long long)id);
+		zassert_equal(len, sizeof(uint32_t), "unexpected len: %zu", len);
+		count++;
+	}
+	zassert_equal(err, 0, "zms_iter_next_all returned error: %d", err);
+	zassert_equal(count, 3, "zms_iter_next_all should return all 3 revisions, got %d", count);
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_includes_deleted)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t data1 = 0x11111111;
+	uint32_t data2 = 0x22222222;
+	int count_all = 0;
+	int count_unique = 0;
+	int deleted_count = 0;
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write two entries */
+	written = zms_write(&fixture->fs, 600, &data1, sizeof(data1));
+	zassert_equal(written, sizeof(data1), "zms_write ID 600 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 601, &data2, sizeof(data2));
+	zassert_equal(written, sizeof(data2), "zms_write ID 601 failed: %zd", written);
+
+	/* Delete ID 600 (writes a delete ATE with len==0) */
+	err = zms_delete(&fixture->fs, 600);
+	zassert_equal(err, 0, "zms_delete failed: %d", err);
+
+	/* zms_iter_next should only return ID 601 */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len)) == 1) {
+		count_unique++;
+		zassert_equal(id, 601, "zms_iter_next returned deleted ID %llu",
+			      (unsigned long long)id);
+	}
+	zassert_equal(err, 0, "zms_iter_next returned error: %d", err);
+	zassert_equal(count_unique, 1, "expected 1 live entry, got %d", count_unique);
+
+	/* zms_iter_next_all should return the delete marker (len==0) for ID 600 as well */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	while ((err = zms_iter_next_all(&fixture->fs, &iter, &id, &len)) == 1) {
+		count_all++;
+		if (len == 0U) {
+			/* This is the delete marker */
+			deleted_count++;
+			zassert_equal(id, 600, "unexpected delete marker for ID %llu",
+				      (unsigned long long)id);
+		}
+	}
+	zassert_equal(err, 0, "zms_iter_next_all returned error: %d", err);
+
+	/* We expect at least: data ATE for 600, delete ATE for 600, data ATE for 601 */
+	zassert_true(count_all >= 3, "expected at least 3 ATEs from _all, got %d", count_all);
+	zassert_equal(deleted_count, 1, "expected 1 delete marker, got %d", deleted_count);
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_mask)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.mask_id = (zms_id_t)0x0F,
+		.use_mask = true,
+	};
+	zms_id_t id;
+	size_t len;
+	uint32_t data_v1 = 0xDEADBEEFU;
+	uint32_t data_v2 = 0xCAFEBABEU;
+	uint32_t data = 0x12345678;
+	int count = 0;
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write three entries: two match mask 0x0F, one does not */
+	written = zms_write(&fixture->fs, (zms_id_t)0x01, &data_v1, sizeof(data_v1));
+	zassert_equal(written, sizeof(data_v1), "zms_write ID 0x01 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, (zms_id_t)0x03, &data, sizeof(data));
+	zassert_equal(written, sizeof(data), "zms_write ID 0x03 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, (zms_id_t)0x10, &data, sizeof(data));
+	zassert_equal(written, sizeof(data), "zms_write ID 0x10 failed: %zd", written);
+
+	/* Update 0x01 with different data so there are 2 ATEs for it */
+	written = zms_write(&fixture->fs, (zms_id_t)0x01, &data_v2, sizeof(data_v2));
+	zassert_equal(written, sizeof(data_v2), "zms_write ID 0x01 update failed: %zd", written);
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next_all(&fixture->fs, &iter, &id, &len)) == 1) {
+		/* Only IDs whose bits are a subset of 0x0F should appear */
+		zassert_equal((id & (zms_id_t)0x0F), id,
+			      "ID 0x%llx does not match mask 0x0F", (unsigned long long)id);
+		count++;
+	}
+	zassert_equal(err, 0, "zms_iter_next_all returned error: %d", err);
+
+	/* Expect 3: two ATEs for ID 0x01 plus one for ID 0x03; ID 0x10 must be excluded */
+	zassert_equal(count, 3, "expected 3 ATEs with mask 0x0F, got %d", count);
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_mask_and_range)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.mask_id = (zms_id_t)0x0F,
+		.min_id = (zms_id_t)0x01,
+		.max_id = (zms_id_t)0x03,
+		.use_mask = true,
+		.use_range = true,
+	};
+	zms_id_t id;
+	size_t len;
+	uint32_t data = 0x12345678;
+	int count = 0;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x01, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x01 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x03, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x03 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x07, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x07 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x10, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x10 failed");
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next_all(&fixture->fs, &iter, &id, &len)) == 1) {
+		zassert_true(id >= (zms_id_t)0x01 && id <= (zms_id_t)0x03,
+			     "ID 0x%llx not within configured range", (unsigned long long)id);
+		zassert_equal((id & (zms_id_t)0x0F), id,
+		      "ID 0x%llx does not match mask 0x0F", (unsigned long long)id);
+		zassert_equal(len, sizeof(uint32_t), "unexpected len: %zu", len);
+		count++;
+	}
+	zassert_equal(err, 0, "zms_iter_next_all returned error: %d", err);
+	zassert_equal(count, 2, "expected 2 ATEs with mask+range, got %d", count);
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_invalid_params)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zms_iter_init(&fixture->fs, &iter);
+
+	/* NULL fs */
+	err = zms_iter_next_all(NULL, &iter, &id, &len);
+	zassert_equal(err, -EINVAL, "zms_iter_next_all should return -EINVAL for NULL fs");
+
+	/* NULL iter */
+	err = zms_iter_next_all(&fixture->fs, NULL, &id, &len);
+	zassert_equal(err, -EINVAL, "zms_iter_next_all should return -EINVAL for NULL iter");
+
+	/* NULL id */
+	zms_iter_init(&fixture->fs, &iter);
+	err = zms_iter_next_all(&fixture->fs, &iter, NULL, &len);
+	zassert_equal(err, -EINVAL, "zms_iter_next_all should return -EINVAL for NULL id");
+
+	/* NULL len */
+	zms_iter_init(&fixture->fs, &iter);
+	err = zms_iter_next_all(&fixture->fs, &iter, &id, NULL);
+	zassert_equal(err, -EINVAL, "zms_iter_next_all should return -EINVAL for NULL len");
+}

--- a/tests/subsys/kvss/zms/src/main.c
+++ b/tests/subsys/kvss/zms/src/main.c
@@ -1849,3 +1849,928 @@ ZTEST_F(zms, test_zms_read_evil_ate)
 	len = zms_read(&fixture->fs, 3, buffer, sizeof(buffer));
 	zassert_equal(len, -ENOENT, "zms_read(id=3) should return -ENOENT, got %zd", len);
 }
+
+ZTEST_F(zms, test_zms_iter_empty_partition)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Initialize iterator on empty partition */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Should immediately return 0 (no entries) */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0);
+	zassert_equal(err, 0, "zms_iter_next should return 0 on empty partition: %d", err);
+}
+
+ZTEST_F(zms, test_zms_iter_single_entry)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t test_data = 0xDEADBEEFU;
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write a single entry */
+	written = zms_write(&fixture->fs, 100, &test_data, sizeof(test_data));
+	zassert_equal(written, sizeof(test_data), "zms_write failed: %zd", written);
+
+	/* Initialize iterator */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Should find the entry */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0);
+	zassert_equal(err, 1, "zms_iter_next should find entry: %d", err);
+	zassert_equal(id, 100, "ID mismatch: got %llu", (unsigned long long)id);
+	zassert_equal(len, sizeof(test_data), "len mismatch: got %zu", len);
+
+	/* Second call should return 0 (no more entries) */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0);
+	zassert_equal(err, 0, "zms_iter_next should return 0 after last entry: %d", err);
+}
+
+ZTEST_F(zms, test_zms_iter_multiple_entries)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t data1 = 0x11111111;
+	uint32_t data2 = 0x22222222;
+	uint32_t data3 = 0x33333333;
+	int found_count = 0;
+	zms_id_t found_ids[3] = {0};
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write three distinct entries */
+	written = zms_write(&fixture->fs, 200, &data1, sizeof(data1));
+	zassert_equal(written, sizeof(data1), "zms_write ID 200 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 201, &data2, sizeof(data2));
+	zassert_equal(written, sizeof(data2), "zms_write ID 201 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 202, &data3, sizeof(data3));
+	zassert_equal(written, sizeof(data3), "zms_write ID 202 failed: %zd", written);
+
+	/* Initialize iterator */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Collect all entries */
+	while (1) {
+		err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0);
+		if (err == 0) {
+			break;
+		}
+		zassert_equal(err, 1, "zms_iter_next returned error: %d", err);
+		zassert_equal(len, sizeof(uint32_t), "len mismatch for ID %llu: got %zu",
+			      (unsigned long long)id, len);
+
+		zassert_true(found_count < 3, "Found more than 3 entries");
+		found_ids[found_count] = id;
+		found_count++;
+	}
+
+	/* Verify all three entries were found */
+	zassert_equal(found_count, 3, "Expected 3 entries, found: %d", found_count);
+
+	/* Verify all IDs were found (order may vary due to reverse walk) */
+	bool found_200 = false, found_201 = false, found_202 = false;
+
+	for (int i = 0; i < found_count; i++) {
+		if (found_ids[i] == 200) {
+			found_200 = true;
+		}
+		if (found_ids[i] == 201) {
+			found_201 = true;
+		}
+		if (found_ids[i] == 202) {
+			found_202 = true;
+		}
+	}
+	zassert_true(found_200, "ID 200 not found");
+	zassert_true(found_201, "ID 201 not found");
+	zassert_true(found_202, "ID 202 not found");
+}
+
+static bool iter_predicate_id_ge_0x20(zms_id_t id)
+{
+	return id >= (zms_id_t)0x20;
+}
+
+ZTEST_F(zms, test_zms_iter_id_mask)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.mask_id = (zms_id_t)0xFF,
+		.use_mask = true,
+	};
+	zms_id_t id;
+	size_t len;
+	uint32_t data1 = 0x11111111;
+	uint32_t data2 = 0x22222222;
+	uint32_t data3 = 0x33333333;
+	int found_count = 0;
+	bool found_id_05 = false;
+	bool found_id_a0 = false;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x05, &data1, sizeof(data1)),
+		      sizeof(data1), "zms_write ID 0x05 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0xA0, &data2, sizeof(data2)),
+		      sizeof(data2), "zms_write ID 0xA0 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x1A0, &data3, sizeof(data3)),
+		      sizeof(data3), "zms_write ID 0x1A0 failed");
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0)) == 1) {
+		zassert_equal(len, sizeof(uint32_t), "len mismatch: %zu", len);
+		found_count++;
+
+		if (id == (zms_id_t)0x05) {
+			found_id_05 = true;
+		} else if (id == (zms_id_t)0xA0) {
+			found_id_a0 = true;
+		} else {
+			zassert_unreachable("Unexpected ID returned by masked iterator");
+		}
+	}
+
+	zassert_equal(err, 0, "zms_iter_next returned unexpected error: %d", err);
+	zassert_equal(found_count, 2, "Expected 2 entries with mask, found: %d", found_count);
+	zassert_true(found_id_05, "ID 0x05 not found with mask");
+	zassert_true(found_id_a0, "ID 0xA0 not found with mask");
+}
+
+ZTEST_F(zms, test_zms_iter_config_default_filters)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {0};
+	zms_id_t id;
+	size_t len;
+	uint32_t data = 0xA5A5A5A5U;
+	int found_count = 0;
+	bool found_id_0 = false;
+	bool found_id_ff = false;
+	bool found_id_100 = false;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x00, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x00 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0xFF, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0xFF failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x100, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x100 failed");
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0)) == 1) {
+		zassert_equal(len, sizeof(uint32_t), "len mismatch: %zu", len);
+		found_count++;
+
+		if (id == (zms_id_t)0x00) {
+			found_id_0 = true;
+		} else if (id == (zms_id_t)0xFF) {
+			found_id_ff = true;
+		} else if (id == (zms_id_t)0x100) {
+			found_id_100 = true;
+		} else {
+			zassert_unreachable("Unexpected ID returned by default config iterator");
+		}
+	}
+
+	zassert_equal(err, 0, "zms_iter_next returned unexpected error: %d", err);
+	zassert_equal(found_count, 3, "Expected 3 entries with default config, found: %d",
+		      found_count);
+	zassert_true(found_id_0, "ID 0x00 not found with default config");
+	zassert_true(found_id_ff, "ID 0xFF not found with default config");
+	zassert_true(found_id_100, "ID 0x100 not found with default config");
+}
+
+ZTEST_F(zms, test_zms_iter_id_range)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.min_id = (zms_id_t)0x20,
+		.max_id = (zms_id_t)0xA0,
+		.use_range = true,
+	};
+	zms_id_t id;
+	size_t len;
+	uint32_t data = 0x11111111;
+	int found_count = 0;
+	bool found_id_20 = false;
+	bool found_id_a0 = false;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x05, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x05 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x20, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x20 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0xA0, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0xA0 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0xA1, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0xA1 failed");
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0)) == 1) {
+		zassert_equal(len, sizeof(uint32_t), "len mismatch: %zu", len);
+		found_count++;
+
+		if (id == (zms_id_t)0x20) {
+			found_id_20 = true;
+		} else if (id == (zms_id_t)0xA0) {
+			found_id_a0 = true;
+		} else {
+			zassert_unreachable("Unexpected ID returned by range iterator");
+		}
+	}
+
+	zassert_equal(err, 0, "zms_iter_next returned unexpected error: %d", err);
+	zassert_equal(found_count, 2, "Expected 2 entries in range, found: %d", found_count);
+	zassert_true(found_id_20, "ID 0x20 not found in range");
+	zassert_true(found_id_a0, "ID 0xA0 not found in range");
+}
+
+ZTEST_F(zms, test_zms_iter_predicate)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.use_predicate = true,
+		.predicate_func = iter_predicate_id_ge_0x20,
+	};
+	zms_id_t id;
+	size_t len;
+	uint32_t data = 0x11111111;
+	int found_count = 0;
+	bool found_id_20 = false;
+	bool found_id_a0 = false;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x05, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x05 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x20, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x20 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0xA0, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0xA0 failed");
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0)) == 1) {
+		zassert_equal(len, sizeof(uint32_t), "len mismatch: %zu", len);
+		found_count++;
+
+		if (id == (zms_id_t)0x20) {
+			found_id_20 = true;
+		} else if (id == (zms_id_t)0xA0) {
+			found_id_a0 = true;
+		} else {
+			zassert_unreachable("Unexpected ID returned by predicate iterator");
+		}
+	}
+
+	zassert_equal(err, 0, "zms_iter_next returned unexpected error: %d", err);
+	zassert_equal(found_count, 2, "Expected 2 entries from predicate, found: %d", found_count);
+	zassert_true(found_id_20, "ID 0x20 not found with predicate");
+	zassert_true(found_id_a0, "ID 0xA0 not found with predicate");
+}
+
+ZTEST_F(zms, test_zms_iter_update_only_latest)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t data_v1 = 0x11111111;
+	uint32_t data_v2 = 0x22222222;
+	ssize_t written;
+	uint32_t read_data;
+	ssize_t read_len;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write same ID twice with different data */
+	written = zms_write(&fixture->fs, 300, &data_v1, sizeof(data_v1));
+	zassert_equal(written, sizeof(data_v1), "zms_write v1 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 300, &data_v2, sizeof(data_v2));
+	zassert_equal(written, sizeof(data_v2), "zms_write v2 failed: %zd", written);
+
+	/* Initialize iterator */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Should find ID 300 exactly once (the latest version) */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0);
+	zassert_equal(err, 1, "zms_iter_next should find entry: %d", err);
+	zassert_equal(id, 300, "ID mismatch: got %llu", (unsigned long long)id);
+	zassert_equal(len, sizeof(data_v2), "len mismatch: got %zu", len);
+
+	/* Verify it's the latest data by reading it back */
+	read_len = zms_read(&fixture->fs, 300, &read_data, sizeof(read_data));
+	zassert_equal(read_len, sizeof(read_data), "zms_read failed: %zd", read_len);
+	zassert_equal(read_data, data_v2, "Should read latest version: got 0x%x", read_data);
+
+	/* Second iter_next should return 0 (only one unique ID) */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0);
+	zassert_equal(err, 0, "zms_iter_next should return 0 after last entry: %d", err);
+}
+
+ZTEST_F(zms, test_zms_iter_deleted_entries)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t data1 = 0x11111111;
+	uint32_t data2 = 0x22222222;
+	int found_count = 0;
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write two entries, then delete one */
+	written = zms_write(&fixture->fs, 400, &data1, sizeof(data1));
+	zassert_equal(written, sizeof(data1), "zms_write ID 400 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 401, &data2, sizeof(data2));
+	zassert_equal(written, sizeof(data2), "zms_write ID 401 failed: %zd", written);
+
+	/* Delete ID 400 */
+	err = zms_delete(&fixture->fs, 400);
+	zassert_equal(err, 0, "zms_delete failed: %d", err);
+
+	/* Initialize iterator */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Iterator should only find ID 401 (ID 400 is deleted) */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0);
+	zassert_equal(err, 1, "zms_iter_next should find entry: %d", err);
+	zassert_equal(id, 401, "Expected ID 401, got %llu", (unsigned long long)id);
+	found_count++;
+
+	/* Second call should return 0 */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0);
+	zassert_equal(err, 0, "zms_iter_next should return 0: %d", err);
+
+	zassert_equal(found_count, 1, "Should only find 1 entry (ID 400 is deleted)");
+}
+
+ZTEST_F(zms, test_zms_iter_invalid_params)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Test with NULL fs */
+	err = zms_iter_init(NULL, &iter);
+	zassert_equal(err, -EINVAL, "zms_iter_init should return -EINVAL for NULL fs");
+
+	/* Test with NULL iter */
+	err = zms_iter_init(&fixture->fs, NULL);
+	zassert_equal(err, -EINVAL, "zms_iter_init should return -EINVAL for NULL iter");
+
+	/* Test zms_iter_init_with_config with NULL fs */
+	{
+		struct zms_iter_config config = {
+			.mask_id = (zms_id_t)0xFF,
+			.use_mask = true,
+		};
+
+		err = zms_iter_init_with_config(NULL, &iter, &config);
+	}
+	zassert_equal(err, -EINVAL,
+		      "zms_iter_init_with_config should return -EINVAL for NULL fs");
+
+	/* Test zms_iter_init_with_config with NULL iter */
+	{
+		struct zms_iter_config config = {
+			.mask_id = (zms_id_t)0xFF,
+			.use_mask = true,
+		};
+
+		err = zms_iter_init_with_config(&fixture->fs, NULL, &config);
+	}
+	zassert_equal(err, -EINVAL,
+		      "zms_iter_init_with_config should return -EINVAL for NULL iter");
+
+	/* Test zms_iter_init_with_config with NULL config */
+	err = zms_iter_init_with_config(&fixture->fs, &iter, NULL);
+	zassert_equal(err, -EINVAL,
+		      "zms_iter_init_with_config should return -EINVAL for NULL config");
+
+	/* Test zms_iter_init_with_config with invalid range */
+	{
+		struct zms_iter_config config = {
+			.min_id = (zms_id_t)10,
+			.max_id = (zms_id_t)5,
+			.use_range = true,
+		};
+
+		err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	}
+	zassert_equal(err, -EINVAL,
+		      "zms_iter_init_with_config should return -EINVAL for invalid range");
+
+	/* Test zms_iter_init_with_config with missing predicate function */
+	{
+		struct zms_iter_config config = {
+			.use_predicate = true,
+			.predicate_func = NULL,
+		};
+
+		err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	}
+	zassert_equal(err, -EINVAL,
+		      "zms_iter_init_with_config should return -EINVAL for missing predicate");
+
+	/* Test iter_next with NULL fs */
+	zms_iter_init(&fixture->fs, &iter);
+	err = zms_iter_next(NULL, &iter, &id, &len, NULL, 0);
+	zassert_equal(err, -EINVAL, "zms_iter_next should return -EINVAL for NULL fs");
+
+	/* Test iter_next with NULL iter */
+	err = zms_iter_next(&fixture->fs, NULL, &id, &len, NULL, 0);
+	zassert_equal(err, -EINVAL, "zms_iter_next should return -EINVAL for NULL iter");
+
+	/* Test iter_next with NULL id */
+	zms_iter_init(&fixture->fs, &iter);
+	err = zms_iter_next(&fixture->fs, &iter, NULL, &len, NULL, 0);
+	zassert_equal(err, -EINVAL, "zms_iter_next should return -EINVAL for NULL id");
+
+	/* Test iter_next with NULL len */
+	zms_iter_init(&fixture->fs, &iter);
+	err = zms_iter_next(&fixture->fs, &iter, &id, NULL, NULL, 0);
+	zassert_equal(err, -EINVAL, "zms_iter_next should return -EINVAL for NULL len");
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_empty_partition)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Should immediately return 0 (no ATEs) */
+	err = zms_iter_next_all(&fixture->fs, &iter, &id, &len, NULL, 0);
+	zassert_equal(err, 0, "zms_iter_next_all should return 0 on empty partition: %d", err);
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_includes_history)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t data_v1 = 0x11111111;
+	uint32_t data_v2 = 0x22222222;
+	uint32_t data_v3 = 0x33333333;
+	int count = 0;
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write same ID three times (creates 3 ATEs for same ID) */
+	written = zms_write(&fixture->fs, 500, &data_v1, sizeof(data_v1));
+	zassert_equal(written, sizeof(data_v1), "zms_write v1 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 500, &data_v2, sizeof(data_v2));
+	zassert_equal(written, sizeof(data_v2), "zms_write v2 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 500, &data_v3, sizeof(data_v3));
+	zassert_equal(written, sizeof(data_v3), "zms_write v3 failed: %zd", written);
+
+	/* zms_iter_next should find ID 500 exactly once (latest only) */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0)) == 1) {
+		count++;
+	}
+	zassert_equal(err, 0, "zms_iter_next returned error: %d", err);
+	zassert_equal(count, 1, "zms_iter_next should return 1 unique entry, got %d", count);
+
+	/* zms_iter_next_all should find all 3 historical ATEs */
+	count = 0;
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	while ((err = zms_iter_next_all(&fixture->fs, &iter, &id, &len, NULL, 0)) == 1) {
+		zassert_equal(id, 500, "expected ID 500, got %llu", (unsigned long long)id);
+		zassert_equal(len, sizeof(uint32_t), "unexpected len: %zu", len);
+		count++;
+	}
+	zassert_equal(err, 0, "zms_iter_next_all returned error: %d", err);
+	zassert_equal(count, 3, "zms_iter_next_all should return all 3 revisions, got %d", count);
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_includes_deleted)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint32_t data1 = 0x11111111;
+	uint32_t data2 = 0x22222222;
+	int count_all = 0;
+	int count_unique = 0;
+	int deleted_count = 0;
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write two entries */
+	written = zms_write(&fixture->fs, 600, &data1, sizeof(data1));
+	zassert_equal(written, sizeof(data1), "zms_write ID 600 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, 601, &data2, sizeof(data2));
+	zassert_equal(written, sizeof(data2), "zms_write ID 601 failed: %zd", written);
+
+	/* Delete ID 600 (writes a delete ATE with len==0) */
+	err = zms_delete(&fixture->fs, 600);
+	zassert_equal(err, 0, "zms_delete failed: %d", err);
+
+	/* zms_iter_next should only return ID 601 */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	while ((err = zms_iter_next(&fixture->fs, &iter, &id, &len, NULL, 0)) == 1) {
+		count_unique++;
+		zassert_equal(id, 601, "zms_iter_next returned deleted ID %llu",
+			      (unsigned long long)id);
+	}
+	zassert_equal(err, 0, "zms_iter_next returned error: %d", err);
+	zassert_equal(count_unique, 1, "expected 1 live entry, got %d", count_unique);
+
+	/* zms_iter_next_all should return the delete marker (len==0) for ID 600 as well */
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	while ((err = zms_iter_next_all(&fixture->fs, &iter, &id, &len, NULL, 0)) == 1) {
+		count_all++;
+		if (len == 0U) {
+			/* This is the delete marker */
+			deleted_count++;
+			zassert_equal(id, 600, "unexpected delete marker for ID %llu",
+				      (unsigned long long)id);
+		}
+	}
+	zassert_equal(err, 0, "zms_iter_next_all returned error: %d", err);
+
+	/* We expect at least: data ATE for 600, delete ATE for 600, data ATE for 601 */
+	zassert_true(count_all >= 3, "expected at least 3 ATEs from _all, got %d", count_all);
+	zassert_equal(deleted_count, 1, "expected 1 delete marker, got %d", deleted_count);
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_mask)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.mask_id = (zms_id_t)0x0F,
+		.use_mask = true,
+	};
+	zms_id_t id;
+	size_t len;
+	uint32_t data_v1 = 0xDEADBEEFU;
+	uint32_t data_v2 = 0xCAFEBABEU;
+	uint32_t data = 0x12345678;
+	int count = 0;
+	ssize_t written;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write three entries: two match mask 0x0F, one does not */
+	written = zms_write(&fixture->fs, (zms_id_t)0x01, &data_v1, sizeof(data_v1));
+	zassert_equal(written, sizeof(data_v1), "zms_write ID 0x01 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, (zms_id_t)0x03, &data, sizeof(data));
+	zassert_equal(written, sizeof(data), "zms_write ID 0x03 failed: %zd", written);
+
+	written = zms_write(&fixture->fs, (zms_id_t)0x10, &data, sizeof(data));
+	zassert_equal(written, sizeof(data), "zms_write ID 0x10 failed: %zd", written);
+
+	/* Update 0x01 with different data so there are 2 ATEs for it */
+	written = zms_write(&fixture->fs, (zms_id_t)0x01, &data_v2, sizeof(data_v2));
+	zassert_equal(written, sizeof(data_v2), "zms_write ID 0x01 update failed: %zd", written);
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next_all(&fixture->fs, &iter, &id, &len, NULL, 0)) == 1) {
+		/* Only IDs whose bits are a subset of 0x0F should appear */
+		zassert_equal((id & (zms_id_t)0x0F), id,
+			      "ID 0x%llx does not match mask 0x0F", (unsigned long long)id);
+		count++;
+	}
+	zassert_equal(err, 0, "zms_iter_next_all returned error: %d", err);
+
+	/* Expect 3: two ATEs for ID 0x01 plus one for ID 0x03; ID 0x10 must be excluded */
+	zassert_equal(count, 3, "expected 3 ATEs with mask 0x0F, got %d", count);
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_mask_and_range)
+{
+	int err;
+	struct zms_iter iter;
+	struct zms_iter_config config = {
+		.mask_id = (zms_id_t)0x0F,
+		.min_id = (zms_id_t)0x01,
+		.max_id = (zms_id_t)0x03,
+		.use_mask = true,
+		.use_range = true,
+	};
+	zms_id_t id;
+	size_t len;
+	uint32_t data = 0x12345678;
+	int count = 0;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x01, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x01 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x03, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x03 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x07, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x07 failed");
+	zassert_equal(zms_write(&fixture->fs, (zms_id_t)0x10, &data, sizeof(data)),
+		      sizeof(data), "zms_write ID 0x10 failed");
+
+	err = zms_iter_init_with_config(&fixture->fs, &iter, &config);
+	zassert_equal(err, 0, "zms_iter_init_with_config failed: %d", err);
+
+	while ((err = zms_iter_next_all(&fixture->fs, &iter, &id, &len, NULL, 0)) == 1) {
+		zassert_true(id >= (zms_id_t)0x01 && id <= (zms_id_t)0x03,
+			     "ID 0x%llx not within configured range", (unsigned long long)id);
+		zassert_equal((id & (zms_id_t)0x0F), id,
+		      "ID 0x%llx does not match mask 0x0F", (unsigned long long)id);
+		zassert_equal(len, sizeof(uint32_t), "unexpected len: %zu", len);
+		count++;
+	}
+	zassert_equal(err, 0, "zms_iter_next_all returned error: %d", err);
+	zassert_equal(count, 2, "expected 2 ATEs with mask+range, got %d", count);
+}
+
+ZTEST_F(zms, test_zms_iter_next_all_invalid_params)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	zms_iter_init(&fixture->fs, &iter);
+
+	/* NULL fs */
+	err = zms_iter_next_all(NULL, &iter, &id, &len, NULL, 0);
+	zassert_equal(err, -EINVAL, "zms_iter_next_all should return -EINVAL for NULL fs");
+
+	/* NULL iter */
+	err = zms_iter_next_all(&fixture->fs, NULL, &id, &len, NULL, 0);
+	zassert_equal(err, -EINVAL, "zms_iter_next_all should return -EINVAL for NULL iter");
+
+	/* NULL id */
+	zms_iter_init(&fixture->fs, &iter);
+	err = zms_iter_next_all(&fixture->fs, &iter, NULL, &len, NULL, 0);
+	zassert_equal(err, -EINVAL, "zms_iter_next_all should return -EINVAL for NULL id");
+
+	/* NULL len */
+	zms_iter_init(&fixture->fs, &iter);
+	err = zms_iter_next_all(&fixture->fs, &iter, &id, NULL, NULL, 0);
+	zassert_equal(err, -EINVAL, "zms_iter_next_all should return -EINVAL for NULL len");
+}
+
+/* When the data fits inside the ATE and the caller provides a buffer, the
+ * iterator copies that data into it.
+ */
+ZTEST_F(zms, test_zms_iter_next_data_in_ate)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint8_t wr_data[ZMS_DATA_IN_ATE_SIZE];
+	uint8_t rd_data[ZMS_DATA_IN_ATE_SIZE];
+	ssize_t written;
+
+	for (size_t i = 0; i < sizeof(wr_data); i++) {
+		wr_data[i] = (uint8_t)(0xA0 + i);
+	}
+	memset(rd_data, 0, sizeof(rd_data));
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Data fits inside the ATE (len <= ZMS_DATA_IN_ATE_SIZE) */
+	written = zms_write(&fixture->fs, 700, wr_data, sizeof(wr_data));
+	zassert_equal(written, sizeof(wr_data), "zms_write failed: %zd", written);
+
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Iterator returns the entry and copies the in-ATE data into the buffer */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len, rd_data, sizeof(rd_data));
+	zassert_equal(err, 1, "zms_iter_next should find entry: %d", err);
+	zassert_equal(id, 700, "ID mismatch: got %llu", (unsigned long long)id);
+	zassert_equal(len, sizeof(wr_data), "len mismatch: got %zu", len);
+	zassert_mem_equal(rd_data, wr_data, sizeof(wr_data),
+			  "iterator did not copy in-ATE data correctly");
+}
+
+/* Data that is too large to be stored inside the ATE is not copied by the
+ * iterator; the buffer is left untouched and the payload is fetched via
+ * zms_read().
+ */
+ZTEST_F(zms, test_zms_iter_next_data_larger_than_ate)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint8_t wr_data[ZMS_DATA_IN_ATE_SIZE + 16];
+	uint8_t rd_data[sizeof(wr_data)];
+	uint8_t sentinel[sizeof(wr_data)];
+	ssize_t ret;
+
+	for (size_t i = 0; i < sizeof(wr_data); i++) {
+		wr_data[i] = (uint8_t)(0x10 + i);
+	}
+	/* Prefill the iterator buffer with a sentinel to detect any writes */
+	memset(rd_data, 0xEE, sizeof(rd_data));
+	memset(sentinel, 0xEE, sizeof(sentinel));
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Data too large to be stored inside the ATE */
+	ret = zms_write(&fixture->fs, 701, wr_data, sizeof(wr_data));
+	zassert_equal(ret, sizeof(wr_data), "zms_write failed: %zd", ret);
+
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len, rd_data, sizeof(rd_data));
+	zassert_equal(err, 1, "zms_iter_next should find entry: %d", err);
+	zassert_equal(id, 701, "ID mismatch: got %llu", (unsigned long long)id);
+	zassert_equal(len, sizeof(wr_data), "len mismatch: got %zu", len);
+
+	/* Buffer must be left untouched: data is not stored inside the ATE */
+	zassert_mem_equal(rd_data, sentinel, sizeof(rd_data),
+			  "iterator must not copy data that is not stored inside the ATE");
+
+	/* The payload can still be retrieved with zms_read() */
+	ret = zms_read(&fixture->fs, 701, rd_data, sizeof(rd_data));
+	zassert_equal(ret, sizeof(wr_data), "zms_read failed: %zd", ret);
+	zassert_mem_equal(rd_data, wr_data, sizeof(wr_data), "zms_read data mismatch");
+}
+
+/* A buffer smaller than the entry only receives data_len bytes; the iterator
+ * never writes past the caller-provided length.
+ */
+ZTEST_F(zms, test_zms_iter_next_data_truncated)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint8_t wr_data[ZMS_DATA_IN_ATE_SIZE];
+	uint8_t rd_data[ZMS_DATA_IN_ATE_SIZE];
+	const size_t small = 1;
+	ssize_t written;
+
+	for (size_t i = 0; i < sizeof(wr_data); i++) {
+		wr_data[i] = (uint8_t)(0x55 + i);
+	}
+	memset(rd_data, 0xEE, sizeof(rd_data));
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	written = zms_write(&fixture->fs, 702, wr_data, sizeof(wr_data));
+	zassert_equal(written, sizeof(wr_data), "zms_write failed: %zd", written);
+
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	/* Provide a buffer smaller than the entry: only 'small' bytes are copied */
+	err = zms_iter_next(&fixture->fs, &iter, &id, &len, rd_data, small);
+	zassert_equal(err, 1, "zms_iter_next should find entry: %d", err);
+	zassert_equal(len, sizeof(wr_data), "len should be full data length: got %zu", len);
+
+	/* Only the first 'small' bytes are copied; the rest keeps the sentinel */
+	zassert_mem_equal(rd_data, wr_data, small, "truncated copy mismatch");
+	for (size_t i = small; i < sizeof(rd_data); i++) {
+		zassert_equal(rd_data[i], 0xEE, "iterator wrote past data_len at index %zu", i);
+	}
+}
+
+/* zms_iter_next_all() copies in-ATE data for live entries but leaves the buffer
+ * untouched for delete markers (len == 0).
+ */
+ZTEST_F(zms, test_zms_iter_next_all_data_in_ate)
+{
+	int err;
+	struct zms_iter iter;
+	zms_id_t id;
+	size_t len;
+	uint8_t wr_data[ZMS_DATA_IN_ATE_SIZE];
+	uint8_t rd_data[ZMS_DATA_IN_ATE_SIZE];
+	uint8_t sentinel[ZMS_DATA_IN_ATE_SIZE];
+	ssize_t written;
+	bool saw_data = false;
+	bool saw_delete = false;
+
+	for (size_t i = 0; i < sizeof(wr_data); i++) {
+		wr_data[i] = (uint8_t)(0x33 + i);
+	}
+	memset(sentinel, 0xEE, sizeof(sentinel));
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Write a small entry then delete it: creates a data ATE + a delete marker */
+	written = zms_write(&fixture->fs, 800, wr_data, sizeof(wr_data));
+	zassert_equal(written, sizeof(wr_data), "zms_write failed: %zd", written);
+	err = zms_delete(&fixture->fs, 800);
+	zassert_equal(err, 0, "zms_delete failed: %d", err);
+
+	err = zms_iter_init(&fixture->fs, &iter);
+	zassert_equal(err, 0, "zms_iter_init failed: %d", err);
+
+	while (1) {
+		memset(rd_data, 0xEE, sizeof(rd_data));
+		err = zms_iter_next_all(&fixture->fs, &iter, &id, &len, rd_data, sizeof(rd_data));
+		if (err == 0) {
+			break;
+		}
+		zassert_equal(err, 1, "zms_iter_next_all returned error: %d", err);
+		zassert_equal(id, 800, "unexpected ID %llu", (unsigned long long)id);
+
+		if (len == 0) {
+			/* Delete marker: buffer must stay untouched */
+			saw_delete = true;
+			zassert_mem_equal(rd_data, sentinel, sizeof(rd_data),
+					  "buffer modified for delete marker");
+		} else {
+			/* Live in-ATE entry: data must be copied */
+			saw_data = true;
+			zassert_equal(len, sizeof(wr_data), "len mismatch: %zu", len);
+			zassert_mem_equal(rd_data, wr_data, sizeof(wr_data),
+					  "in-ATE data not copied by zms_iter_next_all");
+		}
+	}
+
+	zassert_true(saw_data, "did not encounter the live in-ATE entry");
+	zassert_true(saw_delete, "did not encounter the delete marker");
+}


### PR DESCRIPTION
This PR  introduces the iterator API, adds mask-based filtering support at initialization,
and then adds the related tests, sample usage, and documentation.

## Why

Applications that do not maintain a separate ID index need a way to discover
currently live entries directly from ZMS. The iterator API provides that
capability, and optional masking allows narrowing enumeration to relevant IDs.

## Behavior

When using zms_iter_next:
   - Iterator returns live entries only
   - Header entries are skipped
   - Deleted entries are skipped
   - Older revisions are skipped (latest live entry is returned)

When using zms_iter_next_all:
   - Iterator returns all entries (even old entries)
   - Deleted entries are returned as well
   - Header entries are skipped

Default initialization enumerates all live IDs
Masked initialization enumerates only IDs matching the provided mask