### PR TITLE
tests: application_development: ram_context_for_isr: exclude STM32 SoCs

### DIFF
--- a/tests/application_development/ram_context_for_isr/testcase.yaml
+++ b/tests/application_development/ram_context_for_isr/testcase.yaml
@@ -2,6 +2,7 @@ common:
   tags: linker
   arch_allow: arm
   filter: CONFIG_CPU_CORTEX_M_HAS_VTOR
+          and not CONFIG_SOC_FAMILY_STM32
 tests:
   application_development.ram_context_for_isr:
     # Exclude mps3/corstone310 because it uses another mechanism to support relocation
@@ -25,6 +26,3 @@ tests:
       - frdm_kl25z/mkl25z4
       - mcx_n9xx_evk/mcxn947/cpu0/qspi
       - frdm_k32l2b3/k32l2b31a
-      - stm32n6570_dk/stm32n657xx/sb
-      - crd40l50/stm32f401xd
-      - arduino_nicla_vision/stm32h747xx/m7


### PR DESCRIPTION
Exclude STM32 SoCs from ram_context_for_isr tests since the default config for these SoCs set CONFIG_NUM_IRQS based on already assigned IRQs (see https://github.com/zephyrproject-rtos/zephyr/pull/104819) which is quite inconvenient for finding a reliable free IRQ for this ram_context_for_isr tests.

Remove 3 boards from the platform_exclude filter since they are already addressed by the 'not CONFIG_SOC_FAMILY_STM32' filter.

This change prevents CI test to fail building this test on STM32 SoCs based board.