### PR TITLE
subsys: sd: fix out-of-bounds memcpy for unaligned buffer reads/writes

### DIFF
--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -578,6 +578,7 @@ int card_read_blocks(struct sd_card *card, uint8_t *rbuf, uint32_t start_block, 
 		sector = 0;
 		buf_offset = rbuf;
 		while (sector < num_blocks) {
+			rlen = MIN(rlen, num_blocks - sector);
 			/* Read from disk to card buffer */
 			ret = card_read(card, card->card_buffer, sector + start_block, rlen);
 			if (ret) {
@@ -743,6 +744,7 @@ int card_write_blocks(struct sd_card *card, const uint8_t *wbuf, uint32_t start_
 		sector = 0;
 		buf_offset = wbuf;
 		while (sector < num_blocks) {
+			wlen = MIN(wlen, num_blocks - sector);
 			/* Copy data into card buffer */
 			memcpy(card->card_buffer, buf_offset, wlen * card->block_size);
 			/* Write card buffer to disk */


### PR DESCRIPTION
card_read_blocks() and card_write_blocks() compute how many blocks fit in the internal card_buffer (rlen = sizeof(card->card_buffer) / block_size) but never clamp rlen to the number of blocks actually remaining in the loop. On the last iteration, when fewer than rlen blocks are left, the memcpy in card_read_blocks writes beyond the end of the caller's buffer, and the memcpy in card_write_blocks reads past the end of the caller's source. Both are out-of-bounds memory accesses whenever num_blocks isn't an exact multiple of the buffer capacity.

The fix is a single MIN() clamp inside each loop: rlen = MIN(rlen, num_blocks - sector) and the matching wlen equivalent. No effect when the counts divide evenly.

Fixes #108627