### PR TITLE
drivers: sensor: ina237: fix sample_fetch blocking in triggered mode

### DIFF
--- a/drivers/sensor/ti/ina2xx/ina237.c
+++ b/drivers/sensor/ti/ina2xx/ina237.c
@@ -229,7 +229,25 @@ static int ina237_sample_fetch(const struct device *dev, enum sensor_channel cha
 	int ret;
 
 	if (ina237_is_triggered_mode_set(dev)) {
+		const struct ina237_config *cfg = dev->config;
+		const struct ina2xx_config *common = &cfg->common;
+		uint16_t diag_alrt;
+
 		ret = ina237_trigg_one_shot_request(dev, chan);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* Block until CNVRF is set in DIAG_ALRT, indicating conversion is done */
+		if (!WAIT_FOR(
+			    ina2xx_reg_read_16(&common->bus, INA237_REG_ALERT, &diag_alrt) == 0 &&
+			    (diag_alrt & INA237_DIAG_ALRT_CNVRF),
+			    5 * USEC_PER_SEC, k_sleep(K_MSEC(1)))) {
+			LOG_ERR("INA237: conversion ready timeout");
+			return -ETIMEDOUT;
+		}
+
+		ret = ina2xx_sample_fetch(dev, chan);
 	} else {
 		ret = ina2xx_sample_fetch(dev, chan);
 	}

--- a/drivers/sensor/ti/ina2xx/ina237.c
+++ b/drivers/sensor/ti/ina2xx/ina237.c
@@ -243,6 +243,12 @@ static int ina237_sample_fetch(const struct device *dev, enum sensor_channel cha
 			    ina2xx_reg_read_16(&common->bus, INA237_REG_ALERT, &diag_alrt) == 0 &&
 			    (diag_alrt & INA237_DIAG_ALRT_CNVRF),
 			    5 * USEC_PER_SEC, k_sleep(K_MSEC(1)))) {
+			ret = ina2xx_reg_read_16(&common->bus, INA237_REG_ALERT, &diag_alrt);
+			if (ret < 0) {
+				LOG_ERR("INA237: failed to read conversion status after timeout: %d", ret);
+				return ret;
+			}
+
 			LOG_ERR("INA237: conversion ready timeout");
 			return -ETIMEDOUT;
 		}

--- a/drivers/sensor/ti/ina2xx/ina237.h
+++ b/drivers/sensor/ti/ina2xx/ina237.h
@@ -28,6 +28,7 @@
 #define INA237_REG_CURRENT    0x07
 #define INA237_REG_POWER      0x08
 #define INA237_REG_ALERT      0x0B
+#define INA237_DIAG_ALRT_CNVRF  BIT(1)  /* Conversion Ready Flag */
 #define INA237_REG_SOVL       0x0C
 #define INA237_REG_SUVL       0x0D
 #define INA237_REG_BOVL       0x0E


### PR DESCRIPTION
When the ADC is set to one-shot/triggered mode in the device tree, calling sensor_sample_fetch() starts a conversion by writing ADC_CONFIG but returns immediately without ever reading the result registers. Any sensor_channel_get() call right after gets whatever was in the buffers from the previous fetch.

The fix polls the CNVRF bit (bit 1) in DIAG_ALRT after triggering the one-shot. Once the flag is set the conversion is done and ina2xx_sample_fetch() reads the fresh values into the data buffers. I used a 5-second timeout to cover even the worst-case 1024-average configuration (~4.2 s conversion time). WAIT_FOR with a 1 ms sleep keeps the I2C bus quiet while waiting.

INA237_DIAG_ALRT_CNVRF is added to ina237.h next to the register address it belongs to.

Fixes #98547