### PR TITLE
drivers: virtio: Fixes for riscv32 platforms

### DIFF
--- a/drivers/virtio/virtio_mmio.c
+++ b/drivers/virtio/virtio_mmio.c
@@ -57,6 +57,19 @@ static inline void virtio_mmio_write32(const struct device *dev, uint32_t offset
 	barrier_dmem_fence_full();
 }
 
+static void virtio_mmio_write_addr64(const struct device *dev, uint32_t offset_low,
+				     uint32_t offset_high, void *addr)
+{
+	uintptr_t phys_addr = k_mem_phys_addr(addr);
+
+	virtio_mmio_write32(dev, offset_low, phys_addr & UINT32_MAX);
+#ifdef CONFIG_64BIT
+	virtio_mmio_write32(dev, offset_high, phys_addr >> 32);
+#else
+	virtio_mmio_write32(dev, offset_high, 0);
+#endif /* CONFIG_64BIT */
+}
+
 static void virtio_mmio_isr(const struct device *dev)
 {
 	struct virtio_mmio_data *data = dev->data;
@@ -180,18 +193,12 @@ static int virtio_mmio_set_virtqueue(const struct device *dev, uint16_t virtqueu
 	}
 
 	virtio_mmio_write32(dev, VIRTIO_MMIO_QUEUE_SIZE, virtqueue->num);
-	virtio_mmio_write32(dev, VIRTIO_MMIO_QUEUE_DESC_LOW,
-			    k_mem_phys_addr(virtqueue->desc) & UINT32_MAX);
-	virtio_mmio_write32(dev, VIRTIO_MMIO_QUEUE_DESC_HIGH,
-			    k_mem_phys_addr(virtqueue->desc) >> 32);
-	virtio_mmio_write32(dev, VIRTIO_MMIO_QUEUE_AVAIL_LOW,
-			    k_mem_phys_addr(virtqueue->avail) & UINT32_MAX);
-	virtio_mmio_write32(dev, VIRTIO_MMIO_QUEUE_AVAIL_HIGH,
-			    k_mem_phys_addr(virtqueue->avail) >> 32);
-	virtio_mmio_write32(dev, VIRTIO_MMIO_QUEUE_USED_LOW,
-			    k_mem_phys_addr(virtqueue->used) & UINT32_MAX);
-	virtio_mmio_write32(dev, VIRTIO_MMIO_QUEUE_USED_HIGH,
-			    k_mem_phys_addr(virtqueue->used) >> 32);
+	virtio_mmio_write_addr64(dev, VIRTIO_MMIO_QUEUE_DESC_LOW, VIRTIO_MMIO_QUEUE_DESC_HIGH,
+				 virtqueue->desc);
+	virtio_mmio_write_addr64(dev, VIRTIO_MMIO_QUEUE_AVAIL_LOW, VIRTIO_MMIO_QUEUE_AVAIL_HIGH,
+				 virtqueue->avail);
+	virtio_mmio_write_addr64(dev, VIRTIO_MMIO_QUEUE_USED_LOW, VIRTIO_MMIO_QUEUE_USED_HIGH,
+				 virtqueue->used);
 
 	virtio_mmio_write32(dev, VIRTIO_MMIO_QUEUE_READY, 1);
 

--- a/drivers/virtio/virtqueue.c
+++ b/drivers/virtio/virtqueue.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Antmicro <www.antmicro.com>
+ * Copyright (c) 2024-2026 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/barrier.h>
+#include <zephyr/sys/util.h>
 #include <errno.h>
 
 LOG_MODULE_REGISTER(virtio, CONFIG_VIRTIO_LOG_LEVEL);
@@ -42,7 +43,9 @@ int virtq_create(struct virtq *v, size_t size)
 	size_t used_ring_size = 8 * size + 6;
 	size_t shared_size =
 		descriptor_table_size + available_ring_size + used_ring_pad + used_ring_size;
-	size_t v_size = shared_size + sizeof(struct virtq_receive_callback_entry) * size;
+	size_t recv_cbs_pad = WB_UP(shared_size) - shared_size;
+	size_t recv_cbs_size = recv_cbs_pad + sizeof(struct virtq_receive_callback_entry) * size;
+	size_t v_size = shared_size + recv_cbs_size;
 
 	uint8_t *v_area = k_aligned_alloc(16, v_size);
 
@@ -55,7 +58,8 @@ int virtq_create(struct virtq *v, size_t size)
 	v->desc = (struct virtq_desc *)v_area;
 	v->avail = (struct virtq_avail *)((uint8_t *)v->desc + descriptor_table_size);
 	v->used = (struct virtq_used *)((uint8_t *)v->avail + available_ring_size + used_ring_pad);
-	v->recv_cbs = (struct virtq_receive_callback_entry *)((uint8_t *)v->used + used_ring_size);
+	v->recv_cbs = (struct virtq_receive_callback_entry *)((uint8_t *)v->used + used_ring_size +
+							      recv_cbs_pad);
 
 	/*
 	 * At the beginning of the descriptor table, the available ring and the used ring have to be


### PR DESCRIPTION
This PR addresses 2 issues in Virtio driver I found while working on a RISC-V 32 bits platform:
- virtio_mmio was not handling properly 32 bits addresses;
- virtqueue receiving callbacks addresses must be aligned on RISC-V.