### PR TITLE
boards: st: stm32u3: add support for board revision E

### DIFF
--- a/boards/st/nucleo_u385rg_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u385rg_q/arduino_r3_connector.dtsi
@@ -32,12 +32,21 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+#ifdef BOARD_REVISION_E
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 13 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 14 0>;
+#else
 			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
 			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
+#endif
 	};
 };
 
+#ifdef BOARD_REVISION_E
+arduino_i2c: &i2c2 {};
+#else
 arduino_i2c: &i2c1 {};
+#endif
 
 arduino_spi: &spi1 {};
 

--- a/boards/st/nucleo_u385rg_q/board.yml
+++ b/boards/st/nucleo_u385rg_q/board.yml
@@ -2,5 +2,11 @@ board:
   name: nucleo_u385rg_q
   full_name: Nucleo U385RG Q
   vendor: st
+  revision:
+    format: letter
+    default: "D"
+    revisions:
+      - name: "D"
+      - name: "E"
   socs:
     - name: stm32u385xx

--- a/boards/st/nucleo_u385rg_q/doc/index.rst
+++ b/boards/st/nucleo_u385rg_q/doc/index.rst
@@ -186,7 +186,8 @@ Default Zephyr Peripheral Mapping:
 ----------------------------------
 
 - DAC1_OUT1 : PA4
-- I2C1 SCL/SDA : PB6/PB7 (Arduino I2C)
+- I2C1 SCL/SDA : PB6/PB7 (Arduino I2C for board revision D, see board revisions)
+- I2C2 SCL/SDA : PB13/PB14 (Arduino I2C for board revision E, see board revisions)
 - FDCAN1_TX : PA12
 - FDCAN1_RX : PA11
 - LD4 : PA5
@@ -281,7 +282,7 @@ You should see the following message on the console:
 Debugging
 =========
 
-Default debugger for this board is OpenOCD. It can be used in the usual way.
+You can debug an application in the usual way.
 Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
@@ -292,6 +293,29 @@ Here is an example for the :zephyr:code-sample:`blinky` application.
 Note: Check the ``build/tfm`` directory to ensure that the commands required by these scripts
 (``readlink``, etc.) are available on your system. Please also check ``STM32_Programmer_CLI``
 (which is used for initialization) is available in the PATH.
+
+Board Revisions
+***************
+
+`STM32U385RG board user manual`_ mentions two board revisions:
+
+- MB1841 D: Arduino pins D14/D15 mapped to PB7/PB6 (I2C1/I2C4)
+- MB1841 E: Arduino pins D14/D15 configurable via solder bridges SB42/SB43/SB44/SB45
+  - By default mapped to PB14/PB13 (I2C2/I3C2)
+  - Alternatively mapped to PB7/PB6 (I2C1/I2C4)
+
+By default the board revision D is used. Here is an example for building and flashing
+:zephyr:code-sample:`blinky` application on board revision E:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_u385rg_q@E
+   :goals: build flash
+
+References
+**********
+
+.. target-notes::
 
 .. _NUCLEO_U385RG website:
   https://www.st.com/en/evaluation-tools/nucleo-u385rg.html

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -7,8 +7,8 @@
 /dts-v1/;
 #include <st/u3/stm32u385Xg.dtsi>
 #include <st/u3/stm32u385rgtxq-pinctrl.dtsi>
-#include "arduino_r3_connector.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+/* arduino R3 connector is included by board revision specific overlays */
 
 / {
 	model = "STMicroelectronics STM32U385RG-NUCLEO-Q board";

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q_D.overlay
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q_D.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Zuehlke Engineering AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define BOARD_REVISION_D
+#include "arduino_r3_connector.dtsi"

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q_E.overlay
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q_E.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Zuehlke Engineering AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define BOARD_REVISION_E
+#include "arduino_r3_connector.dtsi"


### PR DESCRIPTION
There is a newer board revision for the Nucleo U385RG board which by default has a different pinout for Arduino D14/D15 pins. This breaks all samples using I2C Arduino shields.

Please let me know if there is a more conventional way of how to deal with this. One single overlay file for the new board revision did not work because it is not possible to redefine the existing node label "arduino_i2c".

A simpler, but in my opinion less convenient alternative would be to just mention in the documentation to change the appropriate solder bridges on the new revision E.