### PR TITLE
sensor: pac194x: fetch optimization and devicetree refresh-mode support

### DIFF
--- a/drivers/sensor/microchip/pac194x/pac194x.c
+++ b/drivers/sensor/microchip/pac194x/pac194x.c
@@ -76,6 +76,7 @@ static const struct pac194x_chip_info pac194x_chip_info_table[] = {
 struct pac194x_config {
 	struct i2c_dt_spec i2c;
 	uint32_t shunt_micro_ohms;
+	uint8_t refresh_mode;
 	struct pac194x_channel_config channels[4];
 };
 
@@ -703,6 +704,26 @@ static void pac194x_dump_config(const struct device *dev)
 	LOG_DBG("-------------------------------------------");
 }
 
+static void pac194x_configure_refresh(const struct device *dev)
+{
+	const struct pac194x_config *config = dev->config;
+	struct pac194x_data *data = dev->data;
+	int refresh_mode = config->refresh_mode;
+
+	switch (refresh_mode) {
+	case PAC_REFRESH_AUTO_NOWAIT:
+		data->refresh_mode = PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_NOWAIT;
+		break;
+	case PAC_REFRESH_AUTO_WAIT:
+		data->refresh_mode = PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_NOWAIT;
+		break;
+	case PAC_REFRESH_MANUAL:
+	default:
+		data->refresh_mode = PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_NOWAIT;
+		break;
+	}
+}
+
 static int pac194x_configure_channels(const struct device *dev)
 {
 	const struct pac194x_config *config = dev->config;
@@ -811,6 +832,8 @@ static int pac194x_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	pac194x_configure_refresh(dev);
+
 	if (pac194x_configure_channels(dev)) {
 		LOG_ERR("failed to configure channels");
 		return -EINVAL;
@@ -836,6 +859,7 @@ static int pac194x_init(const struct device *dev)
 												\
 	static const struct pac194x_config pac194x_config_##inst = {				\
 		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
+		.refresh_mode = DT_INST_PROP(inst, microchip_refresh_mode),			\
 		.channels = {									\
 			DT_INST_FOREACH_CHILD_STATUS_OKAY(inst, PAC194X_SET_CHANNEL)		\
 		},										\

--- a/drivers/sensor/microchip/pac194x/pac194x.c
+++ b/drivers/sensor/microchip/pac194x/pac194x.c
@@ -123,6 +123,42 @@ static char *pac194x_accum_mode_name_get(uint8_t mode)
 	}
 }
 
+static inline uint8_t pac194x_sensor_channel_to_chan_id(enum sensor_channel chan)
+{
+	int chan_id;
+	/* Convert channel to channel ID */
+	switch ((enum pac194x_sensor_channel)chan) {
+	case PAC194X_CHAN_VBUS1:
+	case PAC194X_CHAN_CURR1:
+	case PAC194X_CHAN_ACC1:
+	case PAC194X_CHAN_ACC1_AVG:
+		chan_id = 0;
+		break;
+	case PAC194X_CHAN_VBUS2:
+	case PAC194X_CHAN_CURR2:
+	case PAC194X_CHAN_ACC2:
+	case PAC194X_CHAN_ACC2_AVG:
+		chan_id = 1;
+		break;
+	case PAC194X_CHAN_VBUS3:
+	case PAC194X_CHAN_CURR3:
+	case PAC194X_CHAN_ACC3:
+	case PAC194X_CHAN_ACC3_AVG:
+		chan_id = 2;
+		break;
+	case PAC194X_CHAN_VBUS4:
+	case PAC194X_CHAN_CURR4:
+	case PAC194X_CHAN_ACC4:
+	case PAC194X_CHAN_ACC4_AVG:
+		chan_id = 3;
+		break;
+	default:
+		chan_id = 0xff;
+	}
+
+	return chan_id;
+}
+
 static int pac194x_cmd_refresh(const struct device *dev)
 {
 	const struct pac194x_config *config = dev->config;
@@ -152,79 +188,150 @@ static int pac194x_cmd_refresh_all(const struct device *dev)
 	return 0;
 }
 
-static int pac194x_sample_fetch(const struct device *dev, enum sensor_channel chan)
+static int pac194x_read_16(const struct device *dev, uint8_t reg, uint16_t *data)
 {
 	const struct pac194x_config *config = dev->config;
-	struct pac194x_data *data = dev->data;
-	uint8_t buf_4[4];
+	uint8_t buf[2];
 	int ret;
-	int i;
 
-	/* Trigger REFRESH in non-default AUTO_WAIT mode. Specification requires
-	 * to wait at least 1ms before latched values are valid. We don't want to
-	 * call msleep inside the sample_fetch routine unless the user explicitly
-	 * choose to wait. This is the only way to gather data from a current
-	 * measurement window automatically.
-	 */
-	if (data->refresh_mode == PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_WAIT) {
-		/* Trigger REFRESH to latch current data into readable registers */
-		pac194x_cmd_refresh(dev);
-		k_msleep(2);
-	}
-
-	for (i = 0; i < data->info->phys_channels; i++) {
-		/* Check if the channel is enabled */
-		if (!data->channels[i].enabled) {
-			continue;
-		}
-
-		uint8_t buf_2[2];
-		uint8_t buf_8[8];
-
-		/* Read VBUS (Bus Voltage) - 2 bytes */
-		ret = i2c_burst_read_dt(&config->i2c, PAC194X_REG_VBUS1 + i, buf_2, sizeof(buf_2));
-		if (ret < 0) {
-			return ret;
-		}
-		data->channels[i].vbus = sys_get_be16(buf_2);
-
-		/* Read VSENSE (Sense Resistor Voltage) - 2 bytes */
-		ret = i2c_burst_read_dt(&config->i2c, PAC194X_REG_VSENSE1 + i,
-					buf_2, sizeof(buf_2));
-		if (ret < 0) {
-			return ret;
-		}
-		data->channels[i].vsense = sys_get_be16(buf_2);
-
-		/* Read VACC (Accumulator) - 56 bits (7 bytes) */
-		buf_8[0] = 0;
-		ret = i2c_burst_read_dt(&config->i2c, PAC194X_REG_VACC1 + i, &buf_8[1], 7);
-		if (ret < 0) {
-			return ret;
-		}
-		data->channels[i].vacc = sys_get_be64(buf_8);
-	}
-
-	/* Store Accumulator counter */
-	ret = i2c_burst_read_dt(&config->i2c, PAC194X_REG_ACC_COUNT, buf_4, sizeof(buf_4));
+	ret = i2c_burst_read_dt(&config->i2c, reg, buf, sizeof(buf));
 	if (ret < 0) {
 		return ret;
 	}
-	data->acc_count = sys_get_be32(buf_4);
 
-	/* DEFAULT:
-	 * Trigger REFRESH in AUTO_NOWAIT mode. PAC needs to wait 1ms after the data
-	 * is latched and available. Call refresh at the end of sample_fetch so it
-	 * will available on the next iteration. This way we gather data from the
-	 * last measurement window (not current) but we don't need to wait and
-	 * block the calling thread.
-	 */
-	if (data->refresh_mode == PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_NOWAIT) {
-		/*
-		 * Trigger REFRESH to latch current data into readable registers,
-		 * will be available on the next sample fetch.
+	*data = sys_get_be16(buf);
+
+	return ret;
+}
+
+static int pac194x_read_32(const struct device *dev, uint8_t reg, uint32_t *data)
+{
+	const struct pac194x_config *config = dev->config;
+	uint8_t buf[4];
+	int ret;
+
+	ret = i2c_burst_read_dt(&config->i2c, reg, buf, sizeof(buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	*data = sys_get_be32(buf);
+
+	return ret;
+}
+
+static int pac194x_read_56(const struct device *dev, uint8_t reg, uint64_t *data)
+{
+	const struct pac194x_config *config = dev->config;
+	uint8_t buf[8];
+	int ret;
+
+	buf[0] = 0;
+	ret = i2c_burst_read_dt(&config->i2c, reg, &buf[1], sizeof(buf) - 1);
+	if (ret < 0) {
+		return ret;
+	}
+
+	*data = sys_get_be64(buf);
+
+	return ret;
+}
+
+static int pac194x_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct pac194x_data *data = dev->data;
+	uint8_t chan_id;
+	int ret;
+	int i;
+
+	chan_id = pac194x_sensor_channel_to_chan_id(chan);
+	if ((int)chan >= PAC194X_CHAN_VBUS1 && (int)chan <= PAC194X_CHAN_VBUS4) {
+		/* Read VBUS (Bus Voltage) - 2 bytes */
+		ret = pac194x_read_16(dev, PAC194X_REG_VBUS1 + chan_id,
+				      &data->channels[chan_id].vbus);
+		if (ret < 0) {
+			return ret;
+		}
+	} else if ((int)chan >= PAC194X_CHAN_CURR1 && (int)chan <= PAC194X_CHAN_CURR4) {
+		/* Read VSENSE (Sense Resistor Voltage) - 2 bytes */
+		ret = pac194x_read_16(dev, PAC194X_REG_VSENSE1 + chan_id,
+				      &data->channels[chan_id].vsense);
+		if (ret < 0) {
+			return ret;
+		}
+	} else if ((int)chan >= PAC194X_CHAN_ACC1 && (int)chan <= PAC194X_CHAN_ACC4_AVG) {
+		/* Read VACC (Accumulator) - 56 bits (7 bytes) */
+		ret = pac194x_read_56(dev, PAC194X_REG_VACC1 + chan_id,
+				      &data->channels[chan_id].vacc);
+		if (ret < 0) {
+			return ret;
+		}
+	} else if ((int)chan == PAC194X_CHAN_ACC_COUNT) {
+		/* Store Accumulator counter */
+		ret = pac194x_read_32(dev, PAC194X_REG_ACC_COUNT, &data->acc_count);
+		if (ret < 0) {
+			return ret;
+		}
+	} else if ((int)chan == SENSOR_CHAN_ALL) {
+		/* Trigger REFRESH in non-default AUTO_WAIT mode. Specification requires
+		 * to wait at least 1ms before latched values are valid. We don't want to
+		 * call msleep inside the sample_fetch routine unless the user explicitly
+		 * choose to wait. This is the only way to gather data from a current
+		 * measurement window automatically.
 		 */
-		pac194x_cmd_refresh(dev);
+		if (data->refresh_mode == PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_WAIT) {
+			/* Trigger REFRESH to latch current data into readable registers */
+			pac194x_cmd_refresh(dev);
+			k_msleep(2);
+		}
+
+		for (i = 0; i < data->info->phys_channels; i++) {
+			/* Check if the channel is enabled */
+			if (!data->channels[i].enabled) {
+				continue;
+			}
+			/* Read VBUS (Bus Voltage) - 2 bytes */
+			ret = pac194x_read_16(dev, PAC194X_REG_VBUS1 + i, &data->channels[i].vbus);
+			if (ret < 0) {
+				return ret;
+			}
+
+			/* Read VSENSE (Sense Resistor Voltage) - 2 bytes */
+			ret = pac194x_read_16(dev, PAC194X_REG_VSENSE1 + i,
+					      &data->channels[i].vsense);
+			if (ret < 0) {
+				return ret;
+			}
+
+			/* Read VACC (Accumulator) - 56 bits (7 bytes) */
+			ret = pac194x_read_56(dev, PAC194X_REG_VACC1 + i, &data->channels[i].vacc);
+			if (ret < 0) {
+				return ret;
+			}
+		}
+
+		/* Store Accumulator counter */
+		ret = pac194x_read_32(dev, PAC194X_REG_ACC_COUNT, &data->acc_count);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* DEFAULT:
+		 * Trigger REFRESH in AUTO_NOWAIT mode. PAC needs to wait 1ms after the data
+		 * is latched and available. Call refresh at the end of sample_fetch so it
+		 * will available on the next iteration. This way we gather data from the
+		 * last measurement window (not current) but we don't need to wait and
+		 * block the calling thread.
+		 */
+		if (data->refresh_mode == PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_NOWAIT) {
+			/*
+			 * Trigger REFRESH to latch current data into readable registers,
+			 * will be available on the next sample fetch.
+			 */
+			pac194x_cmd_refresh(dev);
+		}
+	} else {
+		return -ENOTSUP;
 	}
 
 	return 0;
@@ -519,39 +626,9 @@ static int pac194x_attr_set(const struct device *dev,
 {
 	const struct pac194x_config *config = dev->config;
 	struct pac194x_data *data = dev->data;
+	uint8_t chan_id = pac194x_sensor_channel_to_chan_id(chan);
 	int mode;
 	int ret;
-	uint8_t chan_id;
-
-	/* Convert channel to channel ID */
-	switch ((enum pac194x_sensor_channel)chan) {
-	case PAC194X_CHAN_VBUS1:
-	case PAC194X_CHAN_CURR1:
-	case PAC194X_CHAN_ACC1:
-	case PAC194X_CHAN_ACC1_AVG:
-		chan_id = 0;
-		break;
-	case PAC194X_CHAN_VBUS2:
-	case PAC194X_CHAN_CURR2:
-	case PAC194X_CHAN_ACC2:
-	case PAC194X_CHAN_ACC2_AVG:
-		chan_id = 1;
-		break;
-	case PAC194X_CHAN_VBUS3:
-	case PAC194X_CHAN_CURR3:
-	case PAC194X_CHAN_ACC3:
-	case PAC194X_CHAN_ACC3_AVG:
-		chan_id = 2;
-		break;
-	case PAC194X_CHAN_VBUS4:
-	case PAC194X_CHAN_CURR4:
-	case PAC194X_CHAN_ACC4:
-	case PAC194X_CHAN_ACC4_AVG:
-		chan_id = 3;
-		break;
-	default:
-		chan_id = 0xff;
-	}
 
 	mode = val->val1;
 	switch ((int)attr) {
@@ -715,11 +792,11 @@ static void pac194x_configure_refresh(const struct device *dev)
 		data->refresh_mode = PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_NOWAIT;
 		break;
 	case PAC_REFRESH_AUTO_WAIT:
-		data->refresh_mode = PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_NOWAIT;
+		data->refresh_mode = PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_WAIT;
 		break;
 	case PAC_REFRESH_MANUAL:
 	default:
-		data->refresh_mode = PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_NOWAIT;
+		data->refresh_mode = PAC194X_SENSOR_ATTR_REFRESH_MODE_MANUAL;
 		break;
 	}
 }

--- a/dts/bindings/sensor/microchip,pac194x.yaml
+++ b/dts/bindings/sensor/microchip,pac194x.yaml
@@ -11,6 +11,18 @@ compatible: "microchip,pac194x"
 
 include: [sensor-device.yaml, i2c-device.yaml]
 
+properties:
+  microchip,refresh-mode:
+    type: int
+    default: 0
+    description: |
+      Refresh mode
+      Default mode prevents the sensor from automatically resetting accumulators.
+    enum:
+      - 0 # PAC_REFRESH_MANUAL
+      - 1 # PAC_REFRESH_AUTO_WAIT
+      - 2 # PAC_REFRESH_AUTO_NOWAIT
+
 child-binding:
   description: PAC194X/PAC195X specific channel configuration
   properties:

--- a/include/zephyr/dt-bindings/sensor/pac194x.h
+++ b/include/zephyr/dt-bindings/sensor/pac194x.h
@@ -26,4 +26,14 @@
 /** Accumulate Voltage data */
 #define PAC_ACCUM_VBUS		2
 
+
+/** Refresh mode manual */
+#define PAC_REFRESH_MANUAL	0
+
+/** Refresh mode */
+#define PAC_REFRESH_AUTO_WAIT	1
+
+/** Refresh mode */
+#define PAC_REFRESH_AUTO_NOWAIT	2
+
 #endif /* PAC194X_H_DTS_BINDINGS */

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1575,6 +1575,7 @@ test_i2c_pac194x: pac194x@d0 {
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
+	microchip,refresh-mode = <PAC_REFRESH_AUTO_NOWAIT>;
 
 	channel@1 {
 		reg = <0x1>;


### PR DESCRIPTION
Key Changes
 - I2C Bus Optimization: Modified the `pac194x_sample_fetch` routine to respect the specific sensor channel. 
 - Devicetree Configuration: Added the microchip,refresh-mode property to the devicetree bindings. This allows board  to configure the sensor's refresh behavior directly via the DTS.