### PR TITLE
llext: arm: Restrict llext veneer support to Mainline cores.

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -34,7 +34,6 @@ config CPU_CORTEX_M
 	select ARCH_HAS_SUSPEND_TO_RAM
 	select ARCH_HAS_CODE_DATA_RELOCATION
 	select ARCH_SUPPORTS_ROM_START
-	select ARCH_HAS_LLEXT_VENEERS
 	imply XIP
 	help
 	  This option signifies the use of a CPU of the Cortex-M family.

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -228,6 +228,7 @@ config ARMV7_M_ARMV8_M_MAINLINE
 	select CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 	select CPU_CORTEX_M_HAS_SYSTICK
 	select USE_SWITCH_SUPPORTED
+	select ARCH_HAS_LLEXT_VENEERS
 	help
 	  This option signifies the use of an ARMv7-M processor
 	  implementation, or the use of a backwards-compatible


### PR DESCRIPTION
Restrict ARCH_HAS_LLEXT_VENEERS to ARMV7_M_ARMV8_M_MAINLINE instead of all CPU_CORTEX_M targets, since the veneer implementation relies on a Mainline-only Thumb-2 instruction sequence not supported on Baseline cores.