### PR TITLE
dts: arm: st: h5: add SAI2 nodes & correct SAI1

### DIFF
--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -132,7 +132,7 @@
 			#size-cells = <0>;
 			reg = <0x40015404 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
-				 <&rcc STM32_SRC_PLL1_P SAI1_SEL(0)>;
+				 <&rcc STM32_SRC_PLL1_Q SAI1_SEL(0)>;
 			dmas = <&gpdma1 1 53 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 					      STM32_DMA_16BITS)>;
 			status = "disabled";
@@ -144,8 +144,32 @@
 			#size-cells = <0>;
 			reg = <0x40015424 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
-				 <&rcc STM32_SRC_PLL1_P SAI1_SEL(0)>;
+				 <&rcc STM32_SRC_PLL1_Q SAI1_SEL(0)>;
 			dmas = <&gpdma1 0 54 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
+					      STM32_DMA_16BITS)>;
+			status = "disabled";
+		};
+
+		sai2_a: sai2@40015804 {
+			compatible = "st,stm32-sai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40015804 0x20>;
+			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
+				 <&rcc STM32_SRC_PLL1_Q SAI2_SEL(0)>;
+			dmas = <&gpdma1 1 55 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
+					      STM32_DMA_16BITS)>;
+			status = "disabled";
+		};
+
+		sai2_b: sai2@40015824 {
+			compatible = "st,stm32-sai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40015824 0x20>;
+			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
+				 <&rcc STM32_SRC_PLL1_Q SAI2_SEL(0)>;
+			dmas = <&gpdma1 0 56 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 					      STM32_DMA_16BITS)>;
 			status = "disabled";
 		};


### PR DESCRIPTION
Add missing SAI2 nodes in root DTSI for STM32H5 series. SAI2 is present in the same devices as SAI1.

While at it, fix the default clock configuration of existing SAI1 nodes: SAIn_SEL(0) corresponds to pll1_q_ck, not pll1_p_ck:
<img width="544" height="320" alt="image" src="https://github.com/user-attachments/assets/7e930545-515b-4201-a00d-79469a3b8a37" />
