### PR TITLE
Bluetooth: Mesh: rename SRC macro to avoid name collision

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -47,14 +47,6 @@ LOG_MODULE_REGISTER(bt_mesh_net);
 /* Seq limit after IV Update is triggered */
 #define IV_UPDATE_SEQ_LIMIT CONFIG_BT_MESH_IV_UPDATE_SEQ_LIMIT
 
-#define IVI(pdu)           ((pdu)[0] >> 7)
-#define NID(pdu)           ((pdu)[0] & 0x7f)
-#define CTL(pdu)           ((pdu)[1] >> 7)
-#define TTL(pdu)           ((pdu)[1] & 0x7f)
-#define SEQ(pdu)           (sys_get_be24(&pdu[2]))
-#define SRC(pdu)           (sys_get_be16(&(pdu)[5]))
-#define DST(pdu)           (sys_get_be16(&(pdu)[7]))
-
 /* Information needed for bridging the network PDUs */
 struct pdu_ctx {
 	struct net_buf_simple *sbuf;
@@ -124,6 +116,41 @@ K_MEM_SLAB_DEFINE_TYPE(loopback_buf_pool, struct loopback_buf,
 static uint32_t dup_cache[CONFIG_BT_MESH_MSG_CACHE_SIZE];
 static int   dup_cache_next;
 
+static uint8_t pdu_ivi(const uint8_t *pdu)
+{
+	return (pdu[0] >> 7);
+}
+
+static uint8_t pdu_nid(const uint8_t *pdu)
+{
+	return (pdu[0] & 0x7f);
+}
+
+static uint8_t pdu_ctl(const uint8_t *pdu)
+{
+	return (pdu[1] >> 7);
+}
+
+static uint8_t pdu_ttl(const uint8_t *pdu)
+{
+	return (pdu[1] & 0x7f);
+}
+
+static uint32_t pdu_seq(const uint8_t *pdu)
+{
+	return sys_get_be24(&pdu[2]);
+}
+
+static uint16_t pdu_src(const uint8_t *pdu)
+{
+	return sys_get_be16(&pdu[5]);
+}
+
+static uint16_t pdu_dst(const uint8_t *pdu)
+{
+	return sys_get_be16(&pdu[7]);
+}
+
 static bool check_dup(struct net_buf_simple *data)
 {
 	const uint8_t *tail = net_buf_simple_tail(data);
@@ -155,16 +182,16 @@ static bool msg_cache_match(struct net_buf_simple *pdu, uint16_t net_idx)
 	uint16_t i;
 
 	for (i = msg_cache_next; i > 0U;) {
-		if (msg_cache[--i].src == SRC(pdu->data) &&
-		    msg_cache[i].seq == (SEQ(pdu->data) & BIT_MASK(17)) &&
+		if (msg_cache[--i].src == pdu_src(pdu->data) &&
+		    msg_cache[i].seq == (pdu_seq(pdu->data) & BIT_MASK(17)) &&
 		    msg_cache[i].net_idx == net_idx) {
 			return true;
 		}
 	}
 
 	for (i = ARRAY_SIZE(msg_cache); i > msg_cache_next;) {
-		if (msg_cache[--i].src == SRC(pdu->data) &&
-		    msg_cache[i].seq == (SEQ(pdu->data) & BIT_MASK(17)) &&
+		if (msg_cache[--i].src == pdu_src(pdu->data) &&
+		    msg_cache[i].seq == (pdu_seq(pdu->data) & BIT_MASK(17)) &&
 		    msg_cache[i].net_idx == net_idx) {
 			return true;
 		}
@@ -414,18 +441,18 @@ static void bt_mesh_net_local(struct k_work *work)
 				.net_idx = buf->sub->net_idx,
 				/* Initialize AppIdx to a sane value */
 				.app_idx = BT_MESH_KEY_UNUSED,
-				.recv_ttl = TTL(buf->data),
+				.recv_ttl = pdu_ttl(buf->data),
 				/* TTL=1 only goes to local IF */
 				.send_ttl = 1U,
-				.addr = SRC(buf->data),
-				.recv_dst = DST(buf->data),
+				.addr = pdu_src(buf->data),
+				.recv_dst = pdu_dst(buf->data),
 				.recv_rssi = 0,
 			},
 			.net_if = BT_MESH_NET_IF_LOCAL,
 			.sub = buf->sub,
-			.old_iv = (IVI(buf->data) != (bt_mesh.iv_index & 0x01)),
-			.ctl = CTL(buf->data),
-			.seq = SEQ(buf->data),
+			.old_iv = (pdu_ivi(buf->data) != (bt_mesh.iv_index & 0x01)),
+			.ctl = pdu_ctl(buf->data),
+			.seq = pdu_seq(buf->data),
 			.new_key = SUBNET_KEY_TX_IDX(buf->sub),
 			.local_match = 1U,
 			.friend_match = 0U,
@@ -617,7 +644,7 @@ void bt_mesh_net_loopback_clear(uint16_t net_idx)
 		struct loopback_buf *buf = CONTAINER_OF(node, struct loopback_buf, node);
 
 		if (net_idx == BT_MESH_KEY_ANY || net_idx == buf->sub->net_idx) {
-			LOG_DBG("Dropped 0x%06x", SEQ(buf->data));
+			LOG_DBG("Dropped 0x%06x", pdu_seq(buf->data));
 			k_mem_slab_free(&loopback_buf_pool, (void *)buf);
 		} else {
 			sys_slist_append(&new_list, &buf->node);
@@ -633,14 +660,14 @@ static bool net_decrypt(struct bt_mesh_net_rx *rx, struct net_buf_simple *in,
 {
 	bool proxy = (rx->net_if == BT_MESH_NET_IF_PROXY_CFG);
 
-	if (NID(in->data) != cred->nid) {
+	if (pdu_nid(in->data) != cred->nid) {
 		return false;
 	}
 
-	LOG_DBG("NID 0x%02x", NID(in->data));
-	LOG_DBG("IVI %u net->iv_index 0x%08x", IVI(in->data), bt_mesh.iv_index);
+	LOG_DBG("NID 0x%02x", pdu_nid(in->data));
+	LOG_DBG("IVI %u net->iv_index 0x%08x", pdu_ivi(in->data), bt_mesh.iv_index);
 
-	rx->old_iv = (IVI(in->data) != (bt_mesh.iv_index & 0x01));
+	rx->old_iv = (pdu_ivi(in->data) != (bt_mesh.iv_index & 0x01));
 
 	net_buf_simple_reset(out);
 	net_buf_simple_add_mem(out, in->data, in->len);
@@ -650,7 +677,7 @@ static bool net_decrypt(struct bt_mesh_net_rx *rx, struct net_buf_simple *in,
 		return false;
 	}
 
-	rx->ctx.addr = SRC(out->data);
+	rx->ctx.addr = pdu_src(out->data);
 	if (!BT_MESH_ADDR_IS_UNICAST(rx->ctx.addr)) {
 		LOG_DBG("Ignoring non-unicast src addr 0x%04x", rx->ctx.addr);
 		return false;
@@ -733,7 +760,7 @@ static void bt_mesh_net_relay(struct net_buf_simple *sbuf, struct bt_mesh_net_rx
 
 	cred = &rx->sub->keys[SUBNET_KEY_TX_IDX(rx->sub)].msg;
 
-	LOG_DBG("Relaying packet. TTL is now %u", TTL(adv->b.data));
+	LOG_DBG("Relaying packet. TTL is now %u", pdu_ttl(adv->b.data));
 
 	/* Update NID if RX, RX was with friend credentials or when bridging the message */
 	if (rx->friend_cred || bridge) {
@@ -801,12 +828,12 @@ static void bt_mesh_sbr_check_cb(uint16_t new_net_idx, void *user_data)
 void bt_mesh_net_header_parse(struct net_buf_simple *buf,
 			      struct bt_mesh_net_rx *rx)
 {
-	rx->old_iv = (IVI(buf->data) != (bt_mesh.iv_index & 0x01));
-	rx->ctl = CTL(buf->data);
-	rx->ctx.recv_ttl = TTL(buf->data);
-	rx->seq = SEQ(buf->data);
-	rx->ctx.addr = SRC(buf->data);
-	rx->ctx.recv_dst = DST(buf->data);
+	rx->old_iv = (pdu_ivi(buf->data) != (bt_mesh.iv_index & 0x01));
+	rx->ctl = pdu_ctl(buf->data);
+	rx->ctx.recv_ttl = pdu_ttl(buf->data);
+	rx->seq = pdu_seq(buf->data);
+	rx->ctx.addr = pdu_src(buf->data);
+	rx->ctx.recv_dst = pdu_dst(buf->data);
 }
 
 int bt_mesh_net_decode(struct net_buf_simple *in, enum bt_mesh_net_if net_if,
@@ -839,7 +866,7 @@ int bt_mesh_net_decode(struct net_buf_simple *in, enum bt_mesh_net_if net_if,
 	/* Initialize AppIdx to a sane value */
 	rx->ctx.app_idx = BT_MESH_KEY_UNUSED;
 
-	rx->ctx.recv_ttl = TTL(out->data);
+	rx->ctx.recv_ttl = pdu_ttl(out->data);
 
 	/* Default to responding with TTL 0 for non-routed messages */
 	if (rx->ctx.recv_ttl == 0U) {
@@ -848,9 +875,9 @@ int bt_mesh_net_decode(struct net_buf_simple *in, enum bt_mesh_net_if net_if,
 		rx->ctx.send_ttl = BT_MESH_TTL_DEFAULT;
 	}
 
-	rx->ctl = CTL(out->data);
-	rx->seq = SEQ(out->data);
-	rx->ctx.recv_dst = DST(out->data);
+	rx->ctl = pdu_ctl(out->data);
+	rx->seq = pdu_seq(out->data);
+	rx->ctx.recv_dst = pdu_dst(out->data);
 
 	LOG_DBG("Decryption successful. Payload len %u", out->len);
 


### PR DESCRIPTION
Rename SRC() macro in Bluetooth Mesh net layer to BT_MESH_SRC() to avoid a name collision with SoC vendor headers.

On some platforms (e.g. NXP MCUX SDK), SRC is defined as a macro representing a hardware register base address. This causes a preprocessor conflict when building Zephyr Bluetooth Mesh, as the Mesh net layer also defines a SRC() helper macro for extracting the source address from network PDUs.

The rename prevents macro redefinition warnings and avoids unexpected substitution issues during compilation on affected toolchains.

No functional change intended.

Fixes #109401