### PR TITLE
kernel: Add RESET_ON_FATAL_ERROR kconfig option

### DIFF
--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -14,6 +14,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/fatal.h>
 #include <zephyr/debug/coredump.h>
+#include <zephyr/sys/reboot.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
@@ -38,10 +39,16 @@ __weak void k_sys_fatal_error_handler(unsigned int reason,
 				      const struct arch_esf *esf)
 {
 	ARG_UNUSED(esf);
-
 	LOG_PANIC();
-	LOG_ERR("Halting system");
+
+#if CONFIG_RESET_ON_FATAL_ERROR
+	LOG_ERR("Resetting system\n");
+	sys_reboot(SYS_REBOOT_WARM);
+#else
+	LOG_ERR("Halting system\n");
 	arch_system_halt(reason);
+#endif /* CONFIG_RESET_ON_FATAL_ERROR */
+
 	CODE_UNREACHABLE;
 }
 /* LCOV_EXCL_STOP */

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -132,6 +132,12 @@ config REBOOT
 	  needed to perform a "safe" reboot (e.g. to stop the system clock before
 	  issuing a reset).
 
+config RESET_ON_FATAL_ERROR
+	bool "Reset the system when a fatal error occurs after printing relevant debug output"
+	select REBOOT
+	help
+		Initiate a system reset when a fatal error would normally halt the system.
+
 config HAS_POWEROFF
 	bool
 	help


### PR DESCRIPTION
Add RESET_ON_FATAL_ERROR kconfig option that initiates a system reset when a fatal error would normally halt the system.