### PR TITLE
kernel: userspace: abort timer before freeing

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2112,6 +2112,18 @@ static inline void *z_impl_k_timer_user_data_get(const struct k_timer *timer)
 	return timer->user_data;
 }
 
+/**
+ * @brief Stop a dynamically allocated timer before free
+ *
+ * If a timer object is dynamically allocated, it needs to be stopped
+ * before associated resources are released.
+ *
+ * @param timer Address of the timer.
+ * @retval 0 on success
+ * @retval -EAGAIN when object is still in use
+ */
+int k_timer_cleanup(struct k_timer *timer);
+
 /** @} */
 
 /**

--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -1948,6 +1948,20 @@
  */
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)
 
+/**
+ * @brief Trace Timer cleanup attempt entry
+ * @param timer Timer object
+ */
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+
+/**
+ * @brief Trace Timer cleanup outcome
+ * @param timer Timer object
+ * @param ret Return value
+ */
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
+
+
 /** @} */ /* end of subsys_tracing_apis_timer */
 
 /**

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/internal/syscall_handler.h>
+#include <zephyr/sys/check.h>
 #include <stdbool.h>
 #include <zephyr/spinlock.h>
 #include <ksched.h>
@@ -172,6 +173,34 @@ void k_timer_init(struct k_timer *timer,
 	z_timer_observer_on_init(timer);
 }
 
+int k_timer_cleanup(struct k_timer *timer)
+{
+	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, cleanup, timer);
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	CHECKIF(z_waitq_head(&timer->wait_q) != NULL) {
+		k_spin_unlock(&lock, key);
+
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, -EAGAIN);
+
+		return -EAGAIN;
+	}
+
+	/* Need to abort the timer so it will not trigger anymore.
+	 * Cannot call k_timer_stop() here as that will call any
+	 * defined callbacks. If we get to this point, we can
+	 * reasonably assume that no one cares about the timer
+	 * anymore, and we simply remove the timeout in queue.
+	 */
+	z_abort_timeout(&timer->timeout);
+
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, 0);
+
+	k_spin_unlock(&lock, key);
+
+	return 0;
+}
 
 void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,
 			  k_timeout_t period)

--- a/kernel/userspace/userspace.c
+++ b/kernel/userspace/userspace.c
@@ -664,6 +664,14 @@ static void unref_check(struct k_object *ko, uintptr_t index)
 	case K_OBJ_STACK:
 		k_stack_cleanup((struct k_stack *)ko->name);
 		break;
+	case K_OBJ_TIMER:
+		if ((ko->flags & K_OBJ_FLAG_INITIALIZED) == K_OBJ_FLAG_INITIALIZED) {
+			/* k_timer_cleanup() does not check if timer has been
+			 * initialized. So we need to do it here before calling.
+			 */
+			k_timer_cleanup((struct k_timer *)ko->name);
+		}
+		break;
 	default:
 		/* Nothing to do */
 		break;

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -204,6 +204,8 @@ extern "C" {
 	sys_trace_k_timer_stop_fn_expiry_enter(timer)
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)                                          \
 	sys_trace_k_timer_stop_fn_expiry_exit(timer)
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
 
 #define sys_port_trace_k_condvar_init(condvar, ret)    sys_trace_k_condvar_init(condvar, ret)
 #define sys_port_trace_k_condvar_signal_enter(condvar) sys_trace_k_condvar_signal_enter(condvar)

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -745,6 +745,9 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)                                          \
 	SEGGER_SYSVIEW_RecordEndCall(TID_TIMER_STOP_EXPIRY)
 
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
+
 #define sys_port_trace_syscall_enter(id, name, ...)                                                \
 	SEGGER_SYSVIEW_RecordString(TID_SYSCALL, (const char *)#name)
 

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -437,6 +437,8 @@
 	sys_trace_k_timer_stop_fn_expiry_enter(timer)
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)					   \
 	sys_trace_k_timer_stop_fn_expiry_exit(timer)
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
 
 #define sys_port_trace_k_event_init(event) sys_trace_k_event_init(event)
 #define sys_port_trace_k_event_post_enter(event, events, events_mask)   \

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -418,6 +418,8 @@ void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iode
 					sys_trace_timer_stop_fn_expiry_enter(timer)
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)			\
 					sys_trace_timer_stop_fn_expiry_exit(timer)
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
 
 #define sys_port_trace_k_event_init(event)
 #define sys_port_trace_k_event_post_enter(event, events, events_mask)


### PR DESCRIPTION
When a dynamic kernel timer object is being freed automatically due to not being used by any threads, we must abort the timer also so it will not trigger again.