### PR TITLE
rtio: add opaque command operation

### DIFF
--- a/doc/services/rtio/index.rst
+++ b/doc/services/rtio/index.rst
@@ -122,6 +122,17 @@ does this work is up to the author of the iodev, perhaps the entire queue of
 operations can be converted to a set of DMA transfer descriptors, meaning the
 hardware does almost all of the real work.
 
+Opaque Commands
+***************
+
+Some devices need RTIO scheduling semantics for work that does not naturally fit
+the built-in read, write, or transceive operations. For these cases,
+``RTIO_OP_CMD`` carries an opaque command buffer to an iodev. RTIO does not
+interpret the command contents; it only handles submission ordering, chaining,
+cancellation, and completion delivery. The iodev defines the command format and
+validates any device-specific payload. The caller must keep the command buffer
+valid until the SQE completes.
+
 Cancellation
 ************
 

--- a/include/zephyr/rtio/sqe.h
+++ b/include/zephyr/rtio/sqe.h
@@ -176,6 +176,9 @@ extern "C" {
 /** An operation to await a signal while blocking the iodev (if one is provided) */
 #define RTIO_OP_AWAIT (RTIO_OP_I3C_CCC+1)
 
+/** An operation carrying an opaque command buffer */
+#define RTIO_OP_CMD (RTIO_OP_AWAIT+1)
+
 /**
  * @}
  */
@@ -353,6 +356,12 @@ struct rtio_sqe {
 			const uint8_t *tx_buf; /**< Buffer to write from */
 			uint8_t *rx_buf; /**< Buffer to read into */
 		} txrx;
+
+		/** OP_CMD */
+		struct {
+			uint32_t buf_len; /**< Length of command buffer */
+			const void *buf; /**< Command buffer */
+		} cmd;
 
 #ifdef CONFIG_RTIO_OP_DELAY
 		/** OP_DELAY */
@@ -571,6 +580,32 @@ static inline void rtio_sqe_prep_transceive(struct rtio_sqe *sqe,
 	sqe->txrx.buf_len = buf_len;
 	sqe->txrx.tx_buf = tx_buf;
 	sqe->txrx.rx_buf = rx_buf;
+	sqe->userdata = userdata;
+}
+
+/**
+ * @brief Prepare an opaque iodev command op submission
+ *
+ * The command buffer is interpreted by the selected iodev. RTIO only provides
+ * queueing, ordering, and completion handling for this operation.
+ *
+ * The caller must keep @p buf valid until the SQE completes.
+ */
+static inline void rtio_sqe_prep_cmd(struct rtio_sqe *sqe,
+				     const struct rtio_iodev *iodev,
+				     int8_t prio,
+				     const void *buf,
+				     uint32_t buf_len,
+				     void *userdata)
+{
+	__ASSERT_NO_MSG(iodev != NULL);
+
+	memset(sqe, 0, sizeof(struct rtio_sqe));
+	sqe->op = RTIO_OP_CMD;
+	sqe->prio = prio;
+	sqe->iodev = iodev;
+	sqe->cmd.buf = buf;
+	sqe->cmd.buf_len = buf_len;
 	sqe->userdata = userdata;
 }
 

--- a/subsys/rtio/rtio_syscalls.c
+++ b/subsys/rtio/rtio_syscalls.c
@@ -44,6 +44,9 @@ static inline bool rtio_vrfy_sqe(struct rtio_sqe *sqe)
 		valid_sqe &= K_SYSCALL_MEMORY(sqe->txrx.tx_buf, sqe->txrx.buf_len, true);
 		valid_sqe &= K_SYSCALL_MEMORY(sqe->txrx.rx_buf, sqe->txrx.buf_len, true);
 		break;
+	case RTIO_OP_CMD:
+		valid_sqe &= K_SYSCALL_MEMORY(sqe->cmd.buf, sqe->cmd.buf_len, false);
+		break;
 	default:
 		/* RTIO OP must be known and allowable from user mode
 		 * otherwise it is invalid

--- a/tests/subsys/rtio/rtio_api/src/rtio_iodev_test.h
+++ b/tests/subsys/rtio/rtio_api/src/rtio_iodev_test.h
@@ -31,6 +31,10 @@ struct rtio_iodev_test_data {
 
 	/* Mocked result to receive by the IODEV */
 	int result;
+
+	/* Last opaque command observed by the IODEV */
+	const void *cmd_buf;
+	uint32_t cmd_len;
 };
 
 static void rtio_iodev_test_next(struct rtio_iodev_test_data *data, bool completion)
@@ -112,6 +116,11 @@ static void rtio_iodev_timer_fn(struct k_timer *tm)
 	case RTIO_OP_AWAIT:
 		rtio_iodev_sqe_await_signal(iodev_sqe, rtio_iodev_await_signaled, data);
 		break;
+	case RTIO_OP_CMD:
+		data->cmd_buf = iodev_sqe->sqe.cmd.buf;
+		data->cmd_len = iodev_sqe->sqe.cmd.buf_len;
+		rtio_iodev_test_complete(data, data->result);
+		break;
 	default:
 		rtio_iodev_test_complete(data, -ENOTSUP);
 	}
@@ -143,6 +152,8 @@ void rtio_iodev_test_init(struct rtio_iodev *test)
 	data->txn_curr = NULL;
 	k_timer_init(&data->timer, rtio_iodev_timer_fn, NULL);
 	data->result = 0;
+	data->cmd_buf = NULL;
+	data->cmd_len = 0U;
 }
 
 void rtio_iodev_test_set_result(struct rtio_iodev *test, int result)

--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -77,6 +77,45 @@ ZTEST(rtio_api, test_rtio_simple)
 	}
 }
 
+RTIO_DEFINE(r_cmd, SQE_POOL_SIZE, CQE_POOL_SIZE);
+
+RTIO_IODEV_TEST_DEFINE(iodev_test_cmd);
+
+ZTEST(rtio_api, test_rtio_cmd)
+{
+	const uint8_t command[] = { 0x12, 0x34, 0x56, 0x78 };
+	uintptr_t userdata = 0x1234;
+	struct rtio_iodev_test_data *data = iodev_test_cmd.data;
+	struct rtio_sqe *sqe;
+	struct rtio_cqe *cqe;
+	int res;
+
+	rtio_iodev_test_init(&iodev_test_cmd);
+
+	sqe = rtio_sqe_acquire(&r_cmd);
+	zassert_not_null(sqe, "Expected a valid sqe");
+
+	rtio_sqe_prep_cmd(sqe, &iodev_test_cmd, RTIO_PRIO_NORM,
+			  command, sizeof(command), &userdata);
+
+	zassert_equal(RTIO_OP_CMD, sqe->op, "Expected command op");
+	zassert_equal_ptr(&iodev_test_cmd, sqe->iodev, "Expected target iodev");
+	zassert_equal_ptr(command, sqe->cmd.buf, "Expected command buffer");
+	zassert_equal(sizeof(command), sqe->cmd.buf_len, "Expected command size");
+
+	res = rtio_submit(&r_cmd, 1);
+	zassert_ok(res, "Should return ok from rtio_submit");
+
+	cqe = rtio_cqe_consume(&r_cmd);
+	zassert_not_null(cqe, "Expected a valid cqe");
+	zassert_ok(cqe->result, "Result should be ok");
+	zassert_equal_ptr(cqe->userdata, &userdata, "Expected userdata back");
+	zassert_equal_ptr(data->cmd_buf, command, "Expected command buffer at iodev");
+	zassert_equal(data->cmd_len, sizeof(command), "Expected command size at iodev");
+
+	rtio_cqe_release(&r_cmd, cqe);
+}
+
 ZTEST(rtio_api, test_rtio_no_response)
 {
 	int res;


### PR DESCRIPTION
Some devices need RTIO scheduling and completion semantics for work that does not naturally map to a read, write, or transceive transfer.

Add `RTIO_OP_CMD` with a small `SQE` payload carrying an opaque command buffer and length to the selected `iodev`.

The command buffer is not copied, so callers must keep it valid until the `SQE` completes.