### PR TITLE
pmci: mctp: I2C+GPIO fixes

### DIFF
--- a/include/zephyr/pmci/mctp/mctp_i2c_gpio_target.h
+++ b/include/zephyr/pmci/mctp/mctp_i2c_gpio_target.h
@@ -29,6 +29,7 @@ struct mctp_binding_i2c_gpio_target {
 	uint8_t reg_addr;
 	bool rxtx;
 	uint8_t rx_idx;
+	uint8_t rx_exp_len;
 	struct mctp_pktbuf *rx_pkt;
 	struct k_sem *tx_lock;
 	struct k_sem *tx_complete;

--- a/samples/subsys/pmci/mctp/i2c_gpio_bus_endpoint/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/samples/subsys/pmci/mctp/i2c_gpio_bus_endpoint/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,6 +1,11 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
-/* Sets up I2C and a GPIO on JP8 to use as our i2c bus for MCTP */
+/* Sets up I2C and a GPIO on JP8 to use as our i2c bus for MCTP.
+ * SDA: J2.18
+ * SCL: J2.20
+ * GPIO: J8.8
+ * GND: J8.2
+ */
 
 &nxp_lcd_8080_connector {
 	status = "disabled";

--- a/subsys/pmci/mctp/mctp_i2c_gpio_controller.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_controller.c
@@ -33,6 +33,10 @@ static void rx_completion(struct rtio *r, const struct rtio_sqe *sqe, int result
 	}
 
 	struct mctp_pktbuf *pkt = mctp_pktbuf_alloc(&b->binding, b->rx_buf_len);
+	if (pkt == NULL) {
+		LOG_ERR("Failed to allocate pktbuf");
+		return;
+	}
 
 	memcpy(pkt->data, b->rx_buf, b->rx_buf_len);
 

--- a/subsys/pmci/mctp/mctp_i2c_gpio_target.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_target.c
@@ -44,19 +44,31 @@ int mctp_i2c_gpio_target_write_received(struct i2c_target_config *config, uint8_
 		break;
 	case MCTP_I2C_GPIO_RX_MSG_LEN_ADDR:
 		b->rxtx = true;
-		b->rx_pkt = mctp_pktbuf_alloc(&b->binding, (size_t)val);
+		b->rx_exp_len = val;
 		/* Reset state machine to wait for next register */
 		b->reg_addr = MCTP_I2C_GPIO_INVALID_ADDR;
 		break;
 	case MCTP_I2C_GPIO_RX_MSG_ADDR:
-		b->rxtx = true;
-		b->rx_pkt->data[b->rx_idx] = val;
-		b->rx_idx += 1;
+		if (b->rx_pkt == NULL) {
+			b->rx_pkt = mctp_pktbuf_alloc(&b->binding, (size_t)b->rx_exp_len);
+			if (b->rx_pkt == NULL) {
+				LOG_ERR("Failed to allocate packet buffer");
+				ret = -ENOMEM;
+				break;
+			}
+		}
 
 		/* buffer full */
 		if (b->rx_idx >= b->rx_pkt->size) {
 			ret = -ENOMEM;
+			LOG_ERR("Received byte %d when packet buffer is full", val);
+			break;
 		}
+
+		b->rxtx = true;
+		b->rx_pkt->data[b->rx_idx] = val;
+		b->rx_idx += 1;
+
 		break;
 	default:
 		LOG_ERR("Write when reg_addr is %d", b->reg_addr);
@@ -144,6 +156,7 @@ int mctp_i2c_gpio_target_stop(struct i2c_target_config *config)
 			mctp_bus_rx(&b->binding, b->rx_pkt);
 			mctp_pktbuf_free(b->rx_pkt);
 			b->rx_pkt = NULL;
+			b->rx_exp_len = 0;
 			break;
 		case MCTP_I2C_GPIO_RX_MSG_LEN_ADDR:
 		case MCTP_I2C_GPIO_TX_MSG_LEN_ADDR:


### PR DESCRIPTION
 - Some packet allocation checks and flow fixes;
 - Comment which pins are being used on sample overlay for FRDM-MCXN947 - so one can skip looking at schematics to figure then out.

Fixes: #111116