### PR TITLE
samples: Bluetooth: add build instructions to classic samples

### DIFF
--- a/samples/bluetooth/classic/a2dp_sink/README.rst
+++ b/samples/bluetooth/classic/a2dp_sink/README.rst
@@ -22,11 +22,13 @@ Requirements
 Building and Running
 ********************
 
-1. Build and flash the sample to the board.
-2. The device will become discoverable as "a2dp_sink".
-3. Connect and stream audio on your A2DP source device.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/classic/a2dp_sink
+   :board: mimxrt1170_evk@B/mimxrt1176/cm7
+   :goals: build flash
+   :compact:
 
-This sample can be found under :zephyr_file:`samples/bluetooth/classic/a2dp_sink` in
-the Zephyr tree.
+After flashing, the device becomes discoverable as ``a2dp_sink``. Connect and stream audio
+from your A2DP source device.
 
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/classic/a2dp_source/README.rst
+++ b/samples/bluetooth/classic/a2dp_source/README.rst
@@ -21,11 +21,13 @@ Requirements
 Building and Running
 ********************
 
-1. Build and flash the sample to the board.
-2. The device will discover a2dp sink devices nearby.
-3. Connect and stream audio automatically.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/classic/a2dp_source
+   :board: mimxrt1170_evk@B/mimxrt1176/cm7
+   :goals: build flash
+   :compact:
 
-This sample can be found under :zephyr_file:`samples/bluetooth/classic/a2dp_source` in
-the Zephyr tree.
+After flashing, the device discovers nearby A2DP sink devices and starts streaming audio
+automatically.
 
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/classic/handsfree/README.rst
+++ b/samples/bluetooth/classic/handsfree/README.rst
@@ -15,19 +15,20 @@ Requirements
 * BlueZ running on the host, or
 * A board with Bluetooth BR/EDR (Classic) support
 
-Building
-********
+Building and Running
+********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/classic/handsfree
+   :board: mimxrt1170_evk@B/mimxrt1176/cm7
+   :goals: build flash
+   :compact:
 
-Running
-*******
+After flashing, the device works as a Hands-Free unit. After the Bluetooth Host stack is
+initialized, connectable and discoverable modes will be automatically enabled. The peer device AG
+(Audio Gateway) can discover and connect to the device.
 
-The application works a Hands-Free uint. After the Bluetooth Host stack is initialized, the
-connectable and discoverable will be automatically enabled. The peer device AG (Audio Gateway) can
-discover and connect to the device.
-
-When the SCO connect is established, the application will initialize the codec and pcm interface
+When the SCO connection is established, the application will initialize the codec and pcm interface
 for voice streaming if the codec and pcm configurations are available.
 
 The HFP application requires the following optional configuration options:
@@ -35,6 +36,8 @@ The codec depends on the devicetree alias named ``i2s-codec-rx`` and ``i2s-codec
 The PCM interface depends on the devicetree alias named ``pcm-rxtx``, or ``pcm-tx`` and ``pcm-rx``.
 
 This sample has been tested on :zephyr:board:`mimxrt1170_evk@B/mimxrt1176/cm7 <mimxrt1170_evk>`.
+
+See :zephyr:code-sample-category:`bluetooth` samples for details.
 
 
 .. graphviz::

--- a/samples/bluetooth/classic/handsfree_ag/README.rst
+++ b/samples/bluetooth/classic/handsfree_ag/README.rst
@@ -18,16 +18,17 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/classic/handsfree_ag
+   :board: mimxrt1170_evk@B/mimxrt1176/cm7
+   :goals: build flash
+   :compact:
 
-Running
-*******
-
-The application works as a Hands-Free Audio Gateway. After the Bluetooth Host stack is initialized,
-the GAP discovery procedure will be started automatically. The target device is Hands-Free Unit
-(The major of COD is 0x04 (:c:macro:`BT_COD_MAJOR_AUDIO_VIDEO`), the minor of the COD is 0x02
-(:c:macro:`BT_COD_MAJOR_AUDIO_VIDEO_MINOR_HANDS_FREE`)). When the target device is discovered,
-the AG will connect to the device.
+After flashing, the device works as a Hands-Free Audio Gateway. After the Bluetooth Host
+stack is initialized, the GAP discovery procedure will be started automatically. The target
+device is a Hands-Free Unit (the major of COD is 0x04 (:c:macro:`BT_COD_MAJOR_AUDIO_VIDEO`), the
+minor of the COD is 0x02 (:c:macro:`BT_COD_MAJOR_AUDIO_VIDEO_MINOR_HANDS_FREE`)). When the target
+device is discovered, the AG will connect to the device.
 
 After the ACL connection is established, the AG will initiate the Service Discovery Protocol (SDP)
 to discover the Hands-Free Unit's supported features. Once the HFP connection is established, the
@@ -41,7 +42,7 @@ direction of the call is determined by :kconfig:option:`CONFIG_BT_HFP_AG_CALL_OU
 Once a call is initiated, the AG will establish an SCO (Synchronous Connection-Oriented) link for
 audio transmission.
 
-When the SCO connect is established, the application will initialize the codec and pcm interface
+When the SCO connection is established, the application will initialize the codec and pcm interface
 for voice streaming if the codec and pcm configurations are available.
 
 The HFP application requires the following optional configuration options:
@@ -52,6 +53,8 @@ After the call is active, the AG will start a delay-able worker with the 10 seco
 disconnect the ACL connection directly.
 
 This sample has been tested on :zephyr:board:`mimxrt1170_evk@B/mimxrt1176/cm7 <mimxrt1170_evk>`.
+
+See :zephyr:code-sample-category:`bluetooth` samples for details.
 
 
 .. graphviz::


### PR DESCRIPTION
Add zephyr-app-commands directives to the a2dp_sink, a2dp_source, handsfree, and handsfree_ag sample READMEs.

Fixes parts of: #87162