### PR TITLE
acpi: break on zero-length subtable in MADT and DMAR entry iterators

### DIFF
--- a/arch/common/acpi/acpi.c
+++ b/arch/common/acpi/acpi.c
@@ -732,6 +732,10 @@ int acpi_madt_entry_get(int type, ACPI_SUBTABLE_HEADER **tables, int *num_inst)
 
 		offset += subtable->Length;
 		subtable = ACPI_ADD_PTR(ACPI_SUBTABLE_HEADER, base, offset);
+
+		if (!subtable->Length) {
+			break;
+		}
 	}
 
 	return -ENODEV;
@@ -757,6 +761,10 @@ int acpi_dmar_entry_get(enum AcpiDmarType type, ACPI_SUBTABLE_HEADER **tables)
 		}
 		offset += subtable->Length;
 		subtable = ACPI_ADD_PTR(ACPI_DMAR_HEADER, base, offset);
+
+		if (!subtable->Length) {
+			break;
+		}
 	}
 
 	return -ENODEV;


### PR DESCRIPTION
acpi_madt_entry_get() and acpi_dmar_entry_get() advance their loop
offset by subtable->Length with no check for zero.  A malformed (or
malicious) firmware table with a subtable whose Length field is 0
would cause offset to never advance while the loop condition
(offset < table_length) remains true, hanging the boot indefinitely.

acpi_get_subtable_entry_num() already carries the fix: after
advancing the pointer it checks if the next subtable's Length is 0
and breaks.  Apply the identical guard to both entry-get loops so
that a zero-length subtable is handled consistently across all three
ACPI iteration sites.
