### PR TITLE
samples: Bluetooth: bap_unicast_client: fix wrong sample path in build instructions

### DIFF
--- a/samples/bluetooth/bap_unicast_client/README.rst
+++ b/samples/bluetooth/bap_unicast_client/README.rst
@@ -49,7 +49,7 @@ core with:
 If you prefer to only build the application core image, you can do so by doing instead:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/bluetooth/bap_unicast_server/
+   :zephyr-app: samples/bluetooth/bap_unicast_client/
    :board: nrf5340dk/nrf5340/cpuapp
    :goals: build
 


### PR DESCRIPTION
The zephyr-app-commands block for building without sysbuild on nrf5340dk referenced bap_unicast_server instead of bap_unicast_client.