### PR TITLE
drivers: i3c: cdns: native RTIO submit path

### DIFF
--- a/drivers/i2c/i2c_rtio.c
+++ b/drivers/i2c/i2c_rtio.c
@@ -267,3 +267,105 @@ out:
 	k_sem_give(&ctx->lock);
 	return res;
 }
+
+#ifdef CONFIG_I2C_CALLBACK
+/*
+ * Allocate a callback closure slot. Lock-free via atomic_test_and_set_bit;
+ * safe from any context. Returns NULL when the pool is exhausted.
+ */
+static struct i2c_rtio_cb_slot *i2c_rtio_cb_slot_alloc(struct i2c_rtio *ctx)
+{
+	for (uint32_t i = 0; i < ARRAY_SIZE(ctx->cb_slots); i++) {
+		if (!atomic_test_and_set_bit(ctx->cb_slot_used, i)) {
+			struct i2c_rtio_cb_slot *slot = &ctx->cb_slots[i];
+
+			slot->ctx = ctx;
+			return slot;
+		}
+	}
+
+	return NULL;
+}
+
+static void i2c_rtio_cb_slot_free(struct i2c_rtio_cb_slot *slot)
+{
+	struct i2c_rtio *ctx = slot->ctx;
+	uint32_t i = slot - &ctx->cb_slots[0];
+
+	atomic_clear_bit(ctx->cb_slot_used, i);
+}
+
+/*
+ * Trampoline invoked by RTIO_OP_CALLBACK after the chained transaction
+ * completes. last_result carries the transfer status. Releases ctx->lock
+ * (which the helper held to keep ctx->dt_spec.addr stable for the driver)
+ * before invoking the user callback.
+ */
+static void i2c_rtio_cb_trampoline(struct rtio *r, const struct rtio_sqe *sqe, int last_result,
+				   void *arg0)
+{
+	struct i2c_rtio_cb_slot *slot = arg0;
+	struct i2c_rtio *ctx = slot->ctx;
+	i2c_callback_t cb = slot->cb;
+	void *userdata = slot->userdata;
+	const struct device *dev = slot->dev;
+
+	ARG_UNUSED(r);
+	ARG_UNUSED(sqe);
+
+	i2c_rtio_cb_slot_free(slot);
+	k_sem_give(&ctx->lock);
+
+	cb(dev, last_result, userdata);
+}
+
+int i2c_rtio_transfer_cb(struct i2c_rtio *ctx, const struct device *dev, struct i2c_msg *msgs,
+			 uint8_t num_msgs, uint16_t addr, i2c_callback_t cb, void *userdata)
+{
+	struct rtio_iodev *iodev = &ctx->iodev;
+	struct rtio *const r = ctx->r;
+	struct rtio_sqe *last_msg_sqe;
+	struct rtio_sqe *cb_sqe;
+	struct i2c_rtio_cb_slot *slot;
+
+	__ASSERT_NO_MSG(num_msgs > 0);
+	__ASSERT_NO_MSG(cb != NULL);
+
+	slot = i2c_rtio_cb_slot_alloc(ctx);
+	if (slot == NULL) {
+		return -ENOMEM;
+	}
+
+	k_sem_take(&ctx->lock, K_FOREVER);
+
+	ctx->dt_spec.addr = addr;
+
+	last_msg_sqe = i2c_rtio_copy(r, iodev, msgs, num_msgs);
+	if (last_msg_sqe == NULL) {
+		k_sem_give(&ctx->lock);
+		i2c_rtio_cb_slot_free(slot);
+		return -ENOMEM;
+	}
+
+	cb_sqe = rtio_sqe_acquire(r);
+	if (cb_sqe == NULL) {
+		rtio_sqe_drop_all(r);
+		k_sem_give(&ctx->lock);
+		i2c_rtio_cb_slot_free(slot);
+		return -ENOMEM;
+	}
+
+	slot->cb = cb;
+	slot->userdata = userdata;
+	slot->dev = dev;
+
+	rtio_sqe_prep_callback(cb_sqe, i2c_rtio_cb_trampoline, slot, NULL);
+	cb_sqe->flags |= RTIO_SQE_NO_RESPONSE;
+
+	last_msg_sqe->flags |= RTIO_SQE_CHAINED;
+
+	rtio_submit(r, 0);
+
+	return 0;
+}
+#endif /* CONFIG_I2C_CALLBACK */

--- a/drivers/i3c/CMakeLists.txt
+++ b/drivers/i3c/CMakeLists.txt
@@ -36,7 +36,8 @@ zephyr_library_sources_ifdef(
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_I3CM_IT51XXX i3cm_it51xxx.c)
 zephyr_library_sources_ifdef(CONFIG_I3CS_IT51XXX i3cs_it51xxx.c)
-zephyr_library_sources_ifdef(CONFIG_I3C_CADENCE i3c_cdns.c)
+zephyr_library_sources_ifdef(CONFIG_I3C_CADENCE i3c_cdns.c i3c_cdns_common.c)
+zephyr_library_sources_ifdef(CONFIG_I3C_CADENCE_RTIO i3c_cdns_rtio.c)
 zephyr_library_sources_ifdef(CONFIG_I3C_DW i3c_dw.c)
 zephyr_library_sources_ifdef(CONFIG_I3C_IBI_WORKQUEUE i3c_ibi_workq.c)
 zephyr_library_sources_ifdef(CONFIG_I3C_MAX32 i3c_max32.c)
@@ -46,3 +47,7 @@ zephyr_library_sources_ifdef(CONFIG_I3C_RENESAS_RA i3c_renesas_ra.c)
 zephyr_library_sources_ifdef(CONFIG_I3C_STM32 i3c_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_I3C_TEST i3c_test.c)
 # zephyr-keep-sorted-stop
+
+if(CONFIG_I3C_CADENCE AND NOT CONFIG_I3C_CADENCE_RTIO)
+  zephyr_library_sources(i3c_cdns_legacy.c)
+endif()

--- a/drivers/i3c/Kconfig.cdns
+++ b/drivers/i3c/Kconfig.cdns
@@ -36,4 +36,29 @@ config I3C_CADENCE_TRANSFER_TIMEOUT_MARGIN_US
 	  The base timeout is derived from the number of bits to be
 	  transferred and the SCL frequency.
 
+config I3C_CADENCE_RTIO
+	bool "Cadence I3C native RTIO submit path"
+	depends on I3C_RTIO
+	select I2C
+	select I2C_RTIO
+	default n
+	help
+	  Drive the Cadence I3C controller's CMD/TX/RX FIFOs from the RTIO
+	  submit path. Replaces i3c_iodev_submit_fallback. Handles
+	  RTIO_OP_TX / RX / TINY_TX / I3C_CCC in SDR controller mode, plus
+	  HDR-DDR streaming via TX_THR / RX_THR thresholds. HDR-TS / HDR-BT
+	  fall back to -ENOTSUP. Legacy i3c_xfers() and i3c_do_ccc() become
+	  thin wrappers around i3c_rtio_transfer() / i3c_rtio_ccc(). I2C-on-I3C
+	  transfers also funnel through the RTIO path (i2c_rtio_*).
+
+config I3C_CADENCE_TARGET_RX_BUF_SIZE
+	int "Cadence I3C target RX buffer size"
+	default 256
+	depends on I3C_TARGET_BUFFER_MODE
+	help
+	  Size in bytes of the buffer used by the Cadence I3C target to
+	  accumulate received data before delivering it to the application
+	  via buf_write_received_cb. Must be large enough to hold the
+	  largest expected private write payload.
+
 endif # I3C_CADENCE

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -17,595 +17,11 @@
 
 #include <stdlib.h>
 
-#define DEV_ID            0x0
-#define DEV_ID_I3C_MASTER 0x5034
+#include "i3c_cdns.h"
 
-#define CONF_STATUS0                      0x4
-#define CONF_STATUS0_CMDR_DEPTH(x)        (4 << (((x) & GENMASK(31, 29)) >> 29))
-#define CONF_STATUS0_ECC_CHK              BIT(28)
-#define CONF_STATUS0_INTEG_CHK            BIT(27)
-#define CONF_STATUS0_CSR_DAP_CHK          BIT(26)
-#define CONF_STATUS0_TRANS_TOUT_CHK       BIT(25)
-#define CONF_STATUS0_PROT_FAULTS_CHK      BIT(24)
-#define CONF_STATUS0_GPO_NUM(x)           (((x) & GENMASK(23, 16)) >> 16)
-#define CONF_STATUS0_GPI_NUM(x)           (((x) & GENMASK(15, 8)) >> 8)
-#define CONF_STATUS0_IBIR_DEPTH(x)        (4 << (((x) & GENMASK(7, 6)) >> 6))
-/* CONF_STATUS0_SUPPORTS_DDR moved to CONF_STATUS1 in rev >= 1p7 */
-#define CONF_STATUS0_SUPPORTS_DDR         BIT(5)
-#define CONF_STATUS0_SEC_MASTER           BIT(4)
-/* And it was replaced with a Dev Role mask */
-#define CONF_STATUS0_DEV_ROLE(x)          (((x) & GENMASK(5, 4)) >> 4)
-#define CONF_STATUS0_DEV_ROLE_MAIN_MASTER 0
-#define CONF_STATUS0_DEV_ROLE_SEC_MASTER  1
-#define CONF_STATUS0_DEV_ROLE_SLAVE       2
-#define CONF_STATUS0_DEVS_NUM(x)          ((x) & GENMASK(3, 0))
-
-#define CONF_STATUS1                     0x8
-#define CONF_STATUS1_IBI_HW_RES(x)       ((((x) & GENMASK(31, 28)) >> 28) + 1)
-#define CONF_STATUS1_CMD_DEPTH(x)        (4 << (((x) & GENMASK(27, 26)) >> 26))
-#define CONF_STATUS1_SLV_DDR_RX_DEPTH(x) (8 << (((x) & GENMASK(25, 21)) >> 21))
-#define CONF_STATUS1_SLV_DDR_TX_DEPTH(x) (8 << (((x) & GENMASK(20, 16)) >> 16))
-#define CONF_STATUS1_SUPPORTS_DDR        BIT(14)
-#define CONF_STATUS1_ALT_MODE            BIT(13)
-#define CONF_STATUS1_IBI_DEPTH(x)        (2 << (((x) & GENMASK(12, 10)) >> 10))
-#define CONF_STATUS1_RX_DEPTH(x)         (8 << (((x) & GENMASK(9, 5)) >> 5))
-#define CONF_STATUS1_TX_DEPTH(x)         (8 << ((x) & GENMASK(4, 0)))
-
-#define REV_ID               0xc
-#define REV_ID_VID(id)       (((id) & GENMASK(31, 20)) >> 20)
-#define REV_ID_PID(id)       (((id) & GENMASK(19, 8)) >> 8)
-#define REV_ID_REV(id)       ((id) & GENMASK(7, 0))
-#define REV_ID_VERSION(m, n) (((m) << 5) | (n))
-#define REV_ID_REV_MAJOR(id) (((id) & GENMASK(7, 5)) >> 5)
-#define REV_ID_REV_MINOR(id) ((id) & GENMASK(4, 0))
-
-#define CTRL                     0x10
-#define CTRL_DEV_EN              BIT(31)
-#define CTRL_HALT_EN             BIT(30)
-#define CTRL_MCS                 BIT(29)
-#define CTRL_MCS_EN              BIT(28)
-#define CTRL_I3C_11_SUPP         BIT(26)
-#define CTRL_THD_DELAY(x)        (((x) << 24) & GENMASK(25, 24))
-#define CTRL_TC_EN               BIT(9)
-#define CTRL_HJ_DISEC            BIT(8)
-#define CTRL_MST_ACK             BIT(7)
-#define CTRL_HJ_ACK              BIT(6)
-#define CTRL_HJ_INIT             BIT(5)
-#define CTRL_MST_INIT            BIT(4)
-#define CTRL_AHDR_OPT            BIT(3)
-#define CTRL_PURE_BUS_MODE       0
-#define CTRL_MIXED_FAST_BUS_MODE 2
-#define CTRL_MIXED_SLOW_BUS_MODE 3
-#define CTRL_BUS_MODE_MASK       GENMASK(1, 0)
-#define THD_DELAY_MAX            3
-
-#define PRESCL_CTRL0         0x14
-#define PRESCL_CTRL0_I2C(x)  ((x) << 16)
-#define PRESCL_CTRL0_I3C(x)  (x)
-#define PRESCL_CTRL0_I3C_MAX GENMASK(9, 0)
-#define PRESCL_CTRL0_I2C_MAX GENMASK(15, 0)
-
-#define PRESCL_CTRL1             0x18
-#define PRESCL_CTRL1_PP_LOW_MASK GENMASK(15, 8)
-#define PRESCL_CTRL1_PP_LOW(x)   ((x) << 8)
-#define PRESCL_CTRL1_OD_LOW_MASK GENMASK(7, 0)
-#define PRESCL_CTRL1_OD_LOW(x)   (x)
-
-#define SLV_STATUS4                 0x1C
-#define SLV_STATUS4_BUSCON_FILL_LVL GENMASK(16, 8)
-#define SLV_STATUS5_BUSCON_DATA     GENMASK(7, 0)
-
-#define MST_IER           0x20
-#define MST_IDR           0x24
-#define MST_IMR           0x28
-#define MST_ICR           0x2c
-#define MST_ISR           0x30
-#define MST_INT_HALTED    BIT(18)
-#define MST_INT_MR_DONE   BIT(17)
-#define MST_INT_IMM_COMP  BIT(16)
-#define MST_INT_TX_THR    BIT(15)
-#define MST_INT_TX_OVF    BIT(14)
-#define MST_INT_C_REF_ROV BIT(13)
-#define MST_INT_IBID_THR  BIT(12)
-#define MST_INT_IBID_UNF  BIT(11)
-#define MST_INT_IBIR_THR  BIT(10)
-#define MST_INT_IBIR_UNF  BIT(9)
-#define MST_INT_IBIR_OVF  BIT(8)
-#define MST_INT_RX_THR    BIT(7)
-#define MST_INT_RX_UNF    BIT(6)
-#define MST_INT_CMDD_EMP  BIT(5)
-#define MST_INT_CMDD_THR  BIT(4)
-#define MST_INT_CMDD_OVF  BIT(3)
-#define MST_INT_CMDR_THR  BIT(2)
-#define MST_INT_CMDR_UNF  BIT(1)
-#define MST_INT_CMDR_OVF  BIT(0)
-#define MST_INT_MASK      GENMASK(18, 0)
-
-#define MST_STATUS0             0x34
-#define MST_STATUS0_IDLE        BIT(18)
-#define MST_STATUS0_HALTED      BIT(17)
-#define MST_STATUS0_MASTER_MODE BIT(16)
-#define MST_STATUS0_TX_FULL     BIT(13)
-#define MST_STATUS0_IBID_FULL   BIT(12)
-#define MST_STATUS0_IBIR_FULL   BIT(11)
-#define MST_STATUS0_RX_FULL     BIT(10)
-#define MST_STATUS0_CMDD_FULL   BIT(9)
-#define MST_STATUS0_CMDR_FULL   BIT(8)
-#define MST_STATUS0_TX_EMP      BIT(5)
-#define MST_STATUS0_IBID_EMP    BIT(4)
-#define MST_STATUS0_IBIR_EMP    BIT(3)
-#define MST_STATUS0_RX_EMP      BIT(2)
-#define MST_STATUS0_CMDD_EMP    BIT(1)
-#define MST_STATUS0_CMDR_EMP    BIT(0)
-
-#define CMDR                    0x38
-#define CMDR_NO_ERROR           0
-#define CMDR_DDR_PREAMBLE_ERROR 1
-#define CMDR_DDR_PARITY_ERROR   2
-#define CMDR_DDR_RX_FIFO_OVF    3
-#define CMDR_DDR_TX_FIFO_UNF    4
-#define CMDR_M0_ERROR           5
-#define CMDR_M1_ERROR           6
-#define CMDR_M2_ERROR           7
-#define CMDR_MST_ABORT          8
-#define CMDR_NACK_RESP          9
-#define CMDR_INVALID_DA         10
-#define CMDR_DDR_DROPPED        11
-#define CMDR_ERROR(x)           (((x) & GENMASK(27, 24)) >> 24)
-#define CMDR_XFER_BYTES(x)      (((x) & GENMASK(19, 8)) >> 8)
-#define CMDR_CMDID_HJACK_DISEC  0xfe
-#define CMDR_CMDID_HJACK_ENTDAA 0xff
-#define CMDR_CMDID(x)           ((x) & GENMASK(7, 0))
-
-#define IBIR               0x3c
-#define IBIR_ACKED         BIT(12)
-#define IBIR_SLVID(x)      (((x) & GENMASK(11, 8)) >> 8)
-#define IBIR_SLVID_INV     0xF
-#define IBIR_ERROR         BIT(7)
-#define IBIR_XFER_BYTES(x) (((x) & GENMASK(6, 2)) >> 2)
-#define IBIR_TYPE_IBI      0
-#define IBIR_TYPE_HJ       1
-#define IBIR_TYPE_MR       2
-#define IBIR_TYPE(x)       ((x) & GENMASK(1, 0))
-
-#define SLV_IER             0x40
-#define SLV_IDR             0x44
-#define SLV_IMR             0x48
-#define SLV_ICR             0x4c
-#define SLV_ISR             0x50
-#define SLV_INT_CHIP_RST    BIT(31)
-#define SLV_INT_PERIPH_RST  BIT(30)
-#define SLV_INT_FLUSH_DONE  BIT(29)
-#define SLV_INT_RST_DAA     BIT(28)
-#define SLV_INT_BUSCON_UP   BIT(26)
-#define SLV_INT_MRL_UP      BIT(25)
-#define SLV_INT_MWL_UP      BIT(24)
-#define SLV_INT_IBI_THR     BIT(23)
-#define SLV_INT_IBI_DONE    BIT(22)
-#define SLV_INT_DEFSLVS     BIT(21)
-#define SLV_INT_TM          BIT(20)
-#define SLV_INT_ERROR       BIT(19)
-#define SLV_INT_EVENT_UP    BIT(18)
-#define SLV_INT_HJ_DONE     BIT(17)
-#define SLV_INT_MR_DONE     BIT(16)
-#define SLV_INT_DA_UPD      BIT(15)
-#define SLV_INT_SDR_FAIL    BIT(14)
-#define SLV_INT_DDR_FAIL    BIT(13)
-#define SLV_INT_M_RD_ABORT  BIT(12)
-#define SLV_INT_DDR_RX_THR  BIT(11)
-#define SLV_INT_DDR_TX_THR  BIT(10)
-#define SLV_INT_SDR_RX_THR  BIT(9)
-#define SLV_INT_SDR_TX_THR  BIT(8)
-#define SLV_INT_DDR_RX_UNF  BIT(7)
-#define SLV_INT_DDR_TX_OVF  BIT(6)
-#define SLV_INT_SDR_RX_UNF  BIT(5)
-#define SLV_INT_SDR_TX_OVF  BIT(4)
-#define SLV_INT_DDR_RD_COMP BIT(3)
-#define SLV_INT_DDR_WR_COMP BIT(2)
-#define SLV_INT_SDR_RD_COMP BIT(1)
-#define SLV_INT_SDR_WR_COMP BIT(0)
-
-#define SLV_STATUS0                   0x54
-#define SLV_STATUS0_IBI_XFRD_BYTEs(s) (((s) & GENMASK(31, 24)) >> 24)
-#define SLV_STATUS0_REG_ADDR(s)       (((s) & GENMASK(23, 16)) >> 16)
-#define SLV_STATUS0_XFRD_BYTES(s)     ((s) & GENMASK(15, 0))
-
-#define SLV_STATUS1              0x58
-#define SLV_STATUS1_SCL_IN_RST   BIT(31)
-#define SLV_STATUS1_HJ_IN_USE    BIT(30)
-#define SLV_STATUS1_NACK_NXT_PW  BIT(29)
-#define SLV_STATUS1_NACK_NXT_PR  BIT(28)
-#define SLV_STATUS1_MR_PEND      BIT(27)
-#define SLV_STATUS1_HJ_PEND      BIT(26)
-#define SLV_STATUS1_IBI_PEND     BIT(25)
-#define SLV_STATUS1_IBI_DIS      BIT(24)
-#define SLV_STATUS1_BUS_VAR      BIT(23)
-#define SLV_STATUS1_TCAM0_DIS    BIT(22)
-#define SLV_STATUS1_AS(s)        (((s) & GENMASK(21, 20)) >> 20)
-#define SLV_STATUS1_VEN_TM       BIT(19)
-#define SLV_STATUS1_HJ_DIS       BIT(18)
-#define SLV_STATUS1_MR_DIS       BIT(17)
-#define SLV_STATUS1_PROT_ERR     BIT(16)
-#define SLV_STATUS1_DA(s)        (((s) & GENMASK(15, 9)) >> 9)
-#define SLV_STATUS1_HAS_DA       BIT(8)
-#define SLV_STATUS1_DDR_RX_FULL  BIT(7)
-#define SLV_STATUS1_DDR_TX_FULL  BIT(6)
-#define SLV_STATUS1_DDR_RX_EMPTY BIT(5)
-#define SLV_STATUS1_DDR_TX_EMPTY BIT(4)
-#define SLV_STATUS1_SDR_RX_FULL  BIT(3)
-#define SLV_STATUS1_SDR_TX_FULL  BIT(2)
-#define SLV_STATUS1_SDR_RX_EMPTY BIT(1)
-#define SLV_STATUS1_SDR_TX_EMPTY BIT(0)
-
-#define SLV_IBI_CTRL               0x5c
-#define SLV_IBI_TCAM_EVNT(x)       ((x) << 27)
-#define SLV_IBI_PL(x)              ((x) << 16)
-#define SLV_IBI_TCAM0              BIT(9)
-#define SLV_IBI_REQ                BIT(8)
-#define SLV_IBI_AUTO_CLR_IBI       1
-#define SLV_IBI_AUTO_CLR_PR        2
-#define SLV_IBI_AUTO_CLR_IBI_OR_PR 3
-#define SLV_IBI_CLEAR_TRIGGER(x)   ((x) << 4)
-
-#define CMD0_FIFO                   0x60
-#define CMD0_FIFO_IS_DDR            BIT(31)
-#define CMD0_FIFO_IS_CCC            BIT(30)
-#define CMD0_FIFO_BCH               BIT(29)
-#define XMIT_BURST_STATIC_SUBADDR   0
-#define XMIT_SINGLE_INC_SUBADDR     1
-#define XMIT_SINGLE_STATIC_SUBADDR  2
-#define XMIT_BURST_WITHOUT_SUBADDR  3
-#define CMD0_FIFO_PRIV_XMIT_MODE(m) ((m) << 27)
-#define CMD0_FIFO_SBCA              BIT(26)
-#define CMD0_FIFO_RSBC              BIT(25)
-#define CMD0_FIFO_IS_10B            BIT(24)
-#define CMD0_FIFO_PL_LEN(l)         ((l) << 12)
-#define CMD0_FIFO_IS_DB             BIT(11)
-#define CMD0_FIFO_PL_LEN_MAX        4095
-#define CMD0_FIFO_DEV_ADDR(a)       ((a) << 1)
-#define CMD0_FIFO_RNW               BIT(0)
-
-#define CMD1_FIFO            0x64
-#define CMD1_FIFO_CMDID(id)  ((id) << 24)
-#define CMD1_FIFO_DB(db)     FIELD_PREP(GENMASK(15, 8), (db))
-#define CMD1_FIFO_CSRADDR(a) (a)
-#define CMD1_FIFO_CCC(id)    (id)
-
-#define TX_FIFO 0x68
-
-#define TX_FIFO_STATUS 0x6C
-
-#define IMD_CMD0             0x70
-#define IMD_CMD0_PL_LEN(l)   ((l) << 12)
-#define IMD_CMD0_DEV_ADDR(a) ((a) << 1)
-#define IMD_CMD0_RNW         BIT(0)
-
-#define IMD_CMD1         0x74
-#define IMD_CMD1_CCC(id) (id)
-
-#define IMD_DATA                    0x78
-#define RX_FIFO                     0x80
-#define IBI_DATA_FIFO               0x84
-#define SLV_DDR_TX_FIFO             0x88
-#define SLV_DDR_RX_FIFO             0x8c
-#define DDR_PREAMBLE_MASK           GENMASK(19, 18)
-#define DDR_PREAMBLE_CMD_CRC        (0x1 << 18)
-#define DDR_PREAMBLE_DATA_ABORT     (0x2 << 18)
-#define DDR_PREAMBLE_DATA_ABORT_ALT (0x3 << 18)
-#define DDR_DATA(x)                 (((x) & GENMASK(17, 2)) >> 2)
-#define DDR_EVEN_PARITY             BIT(0)
-#define DDR_ODD_PARITY              BIT(1)
-#define DDR_CRC_AND_HEADER_SIZE     0x4
-#define DDR_CONVERT_BUF_LEN(x)      (4 * (x))
-
-#define HDR_CMD_RD         BIT(15)
-#define HDR_CMD_CODE(c)    (((c) & GENMASK(6, 0)) << 8)
-#define DDR_CRC_TOKEN      (0xC << 14)
-#define DDR_CRC_TOKEN_MASK GENMASK(17, 14)
-#define DDR_CRC(t)         (((t) & (GENMASK(13, 9))) >> 9)
-#define DDR_CRC_WR_SETUP   BIT(8)
-
-#define CMD_IBI_THR_CTRL 0x90
-#define IBIR_THR(t)      ((t) << 24)
-#define CMDR_THR(t)      ((t) << 16)
-#define CMDR_THR_MASK    (GENMASK(20, 16))
-#define IBI_THR(t)       ((t) << 8)
-#define CMD_THR(t)       (t)
-
-#define TX_RX_THR_CTRL 0x94
-#define RX_THR(t)      ((t) << 16)
-#define RX_THR_MASK    (GENMASK(31, 16))
-#define TX_THR(t)      (t)
-#define TX_THR_MASK    (GENMASK(15, 0))
-
-#define SLV_DDR_TX_RX_THR_CTRL 0x98
-#define SLV_DDR_RX_THR(t)      ((t) << 16)
-#define SLV_DDR_TX_THR(t)      (t)
-
-#define FLUSH_CTRL            0x9c
-#define FLUSH_IBI_RESP        BIT(24)
-#define FLUSH_CMD_RESP        BIT(23)
-#define FLUSH_SLV_DDR_RX_FIFO BIT(22)
-#define FLUSH_SLV_DDR_TX_FIFO BIT(21)
-#define FLUSH_IMM_FIFO        BIT(20)
-#define FLUSH_IBI_FIFO        BIT(19)
-#define FLUSH_RX_FIFO         BIT(18)
-#define FLUSH_TX_FIFO         BIT(17)
-#define FLUSH_CMD_FIFO        BIT(16)
-
-#define SLV_CTRL 0xA0
-
-#define SLV_PROT_ERR_TYPE 0xA4
-#define SLV_ERR6_IBI      BIT(9)
-#define SLV_ERR6_PR       BIT(8)
-#define SLV_ERR_GETCCC    BIT(7)
-#define SLV_ERR5          BIT(6)
-#define SLV_ERR4          BIT(5)
-#define SLV_ERR3          BIT(4)
-#define SLV_ERR2_PW       BIT(3)
-#define SLV_ERR2_SETCCC   BIT(2)
-#define SLV_ERR1          BIT(1)
-#define SLV_ERR0          BIT(0)
-
-#define SLV_STATUS2        0xA8
-#define SLV_STATUS2_MRL(s) (((s) & GENMASK(23, 8)) >> 8)
-
-#define SLV_STATUS3           0xAC
-#define SLV_STATUS3_BC_FSM(s) (((s) & GENMASK(26, 16)) >> 16)
-#define SLV_STATUS3_MWL(s)    ((s) & GENMASK(15, 0))
-
-#define TTO_PRESCL_CTRL0               0xb0
-#define TTO_PRESCL_CTRL0_PRESCL_I2C(x) ((x) << 16)
-#define TTO_PRESCL_CTRL0_PRESCL_I3C(x) (x)
-
-#define TTO_PRESCL_CTRL1           0xb4
-#define TTO_PRESCL_CTRL1_DIVB(x)   ((x) << 16)
-#define TTO_PRESCL_CTRL1_DIVA(x)   (x)
-#define TTO_PRESCL_CTRL1_PP_LOW(x) ((x) << 8)
-#define TTO_PRESCL_CTRL1_OD_LOW(x) (x)
-
-#define DEVS_CTRL                  0xb8
-#define DEVS_CTRL_DEV_CLR_SHIFT    16
-#define DEVS_CTRL_DEV_CLR_ALL      GENMASK(31, 16)
-#define DEVS_CTRL_DEV_CLR(dev)     BIT(16 + (dev))
-#define DEVS_CTRL_DEV_ACTIVE(dev)  BIT(dev)
-#define DEVS_CTRL_DEVS_ACTIVE_MASK GENMASK(15, 0)
-#define MAX_DEVS                   16
-
-#define DEV_ID_RR0(d)              (0xc0 + ((d) * 0x10))
-#define DEV_ID_RR0_LVR_EXT_ADDR    BIT(11)
-#define DEV_ID_RR0_HDR_CAP         BIT(10)
-#define DEV_ID_RR0_IS_I3C          BIT(9)
-#define DEV_ID_RR0_DEV_ADDR_MASK   (GENMASK(7, 1) | GENMASK(15, 13))
-#define DEV_ID_RR0_SET_DEV_ADDR(a) (((a << 1) & GENMASK(7, 1)) | (((a) & GENMASK(9, 7)) << 13))
-#define DEV_ID_RR0_GET_DEV_ADDR(x) ((((x) >> 1) & GENMASK(6, 0)) | (((x) >> 6) & GENMASK(9, 7)))
-
-#define DEV_ID_RR1(d)           (0xc4 + ((d) * 0x10))
-#define DEV_ID_RR1_PID_MSB(pid) (pid)
-
-#define DEV_ID_RR2(d)           (0xc8 + ((d) * 0x10))
-#define DEV_ID_RR2_PID_LSB(pid) ((pid) << 16)
-#define DEV_ID_RR2_BCR(bcr)     ((bcr) << 8)
-#define DEV_ID_RR2_DCR(dcr)     (dcr)
-#define DEV_ID_RR2_LVR(lvr)     (lvr)
-
-#define SIR_MAP(x)               (0x180 + ((x) * 4))
-#define SIR_MAP_DEV_REG(d)       SIR_MAP((d) / 2)
-#define SIR_MAP_DEV_SHIFT(d, fs) ((fs) + (((d) % 2) ? 16 : 0))
-#define SIR_MAP_DEV_CONF_MASK(d) (GENMASK(15, 0) << (((d) % 2) ? 16 : 0))
-#define SIR_MAP_DEV_CONF(d, c)   ((c) << (((d) % 2) ? 16 : 0))
-#define DEV_ROLE_SLAVE           0
-#define DEV_ROLE_MASTER          1
-#define SIR_MAP_DEV_ROLE(role)   ((role) << 14)
-#define SIR_MAP_DEV_SLOW         BIT(13)
-#define SIR_MAP_DEV_PL(l)        ((l) << 8)
-#define SIR_MAP_PL_MAX           GENMASK(4, 0)
-#define SIR_MAP_DEV_DA(a)        ((a) << 1)
-#define SIR_MAP_DEV_ACK          BIT(0)
-
-#define GRPADDR_LIST 0x198
-
-#define GRPADDR_CS 0x19C
-
-#define GPIR_WORD(x)     (0x200 + ((x) * 4))
-#define GPI_REG(val, id) (((val) >> (((id) % 4) * 8)) & GENMASK(7, 0))
-
-#define GPOR_WORD(x)     (0x220 + ((x) * 4))
-#define GPO_REG(val, id) (((val) >> (((id) % 4) * 8)) & GENMASK(7, 0))
-
-#define ASF_INT_STATUS        0x300
-#define ASF_INT_RAW_STATUS    0x304
-#define ASF_INT_MASK          0x308
-#define ASF_INT_TEST          0x30c
-#define ASF_INT_FATAL_SELECT  0x310
-#define ASF_INTEGRITY_ERR     BIT(6)
-#define ASF_PROTOCOL_ERR      BIT(5)
-#define ASF_TRANS_TIMEOUT_ERR BIT(4)
-#define ASF_CSR_ERR           BIT(3)
-#define ASF_DAP_ERR           BIT(2)
-#define ASF_SRAM_UNCORR_ERR   BIT(1)
-#define ASF_SRAM_CORR_ERR     BIT(0)
-
-#define ASF_SRAM_CORR_FAULT_STATUS      0x320
-#define ASF_SRAM_UNCORR_FAULT_STATUS    0x324
-#define ASF_SRAM_CORR_FAULT_INSTANCE(x) ((x) >> 24)
-#define ASF_SRAM_CORR_FAULT_ADDR(x)     ((x) & GENMASK(23, 0))
-
-#define ASF_SRAM_FAULT_STATS           0x328
-#define ASF_SRAM_FAULT_UNCORR_STATS(x) ((x) >> 16)
-#define ASF_SRAM_FAULT_CORR_STATS(x)   ((x) & GENMASK(15, 0))
-
-#define ASF_TRANS_TOUT_CTRL   0x330
-#define ASF_TRANS_TOUT_EN     BIT(31)
-#define ASF_TRANS_TOUT_VAL(x) (x)
-
-#define ASF_TRANS_TOUT_FAULT_MASK      0x334
-#define ASF_TRANS_TOUT_FAULT_STATUS    0x338
-#define ASF_TRANS_TOUT_FAULT_APB       BIT(3)
-#define ASF_TRANS_TOUT_FAULT_SCL_LOW   BIT(2)
-#define ASF_TRANS_TOUT_FAULT_SCL_HIGH  BIT(1)
-#define ASF_TRANS_TOUT_FAULT_FSCL_HIGH BIT(0)
-
-#define ASF_PROTO_FAULT_MASK            0x340
-#define ASF_PROTO_FAULT_STATUS          0x344
-#define ASF_PROTO_FAULT_SLVSDR_RD_ABORT BIT(31)
-#define ASF_PROTO_FAULT_SLVDDR_FAIL     BIT(30)
-#define ASF_PROTO_FAULT_S(x)            BIT(16 + (x))
-#define ASF_PROTO_FAULT_MSTSDR_RD_ABORT BIT(15)
-#define ASF_PROTO_FAULT_MSTDDR_FAIL     BIT(14)
-#define ASF_PROTO_FAULT_M(x)            BIT(x)
-
-/*******************************************************************************
- * Local Constants Definition
- ******************************************************************************/
-
-/* Maximum i3c devices that the IP can be built with */
-#define I3C_MAX_DEVS                     11
-#define I3C_MAX_MSGS                     10
-#define I3C_SIR_DEFAULT_DA               0x7F
-#define I3C_MAX_IDLE_CANCEL_WAIT_RETRIES 50
-#define I3C_PRESCL_REG_SCALE             (4)
-#define I2C_PRESCL_REG_SCALE             (5)
-#define I3C_WAIT_FOR_IDLE_STATE_US       CONFIG_I3C_CADENCE_IDLE_TIMEOUT_US
-#define I3C_IDLE_TIMEOUT_CYC                                                                       \
-	(I3C_WAIT_FOR_IDLE_STATE_US * (sys_clock_hw_cycles_per_sec() / USEC_PER_SEC))
-
-/*
- * MIPI I3C v1.1.1 Spec defines SDA Signal Data Hold in Push Pull max as the
- * minimum of the clock rise and fall time plus 3ns
- */
-#define I3C_HD_PP_DEFAULT_NS 10
-
-/* Interrupt thresholds. */
-/* command response fifo threshold */
-#define I3C_CMDR_THR 1
-/* command tx fifo threshold - unused */
-#define I3C_CMDD_THR 1
-/* in-band-interrupt response queue threshold */
-#define I3C_IBIR_THR 1
-/* tx data threshold - unused */
-#define I3C_TX_THR   1
 
 #define LOG_MODULE_NAME I3C_CADENCE
 LOG_MODULE_REGISTER(I3C_CADENCE, CONFIG_I3C_CADENCE_LOG_LEVEL);
-
-/*******************************************************************************
- * Local Types Definition
- ******************************************************************************/
-
-/** Describes peripheral HW configuration determined from CONFx registers. */
-struct cdns_i3c_hw_config {
-	/* Revision ID */
-	uint32_t rev_id;
-	/* The maximum command queue depth. */
-	uint32_t cmd_mem_depth;
-	/* The maximum command response queue depth. */
-	uint32_t cmdr_mem_depth;
-	/* The maximum RX FIFO depth. */
-	uint32_t rx_mem_depth;
-	/* The maximum TX FIFO depth. */
-	uint32_t tx_mem_depth;
-	/* The maximum DDR RX FIFO depth. */
-	uint32_t ddr_rx_mem_depth;
-	/* The maximum DDR TX FIFO depth. */
-	uint32_t ddr_tx_mem_depth;
-	/* The maximum IBIR FIFO depth. */
-	uint32_t ibir_mem_depth;
-	/* The maximum IBI FIFO depth. */
-	uint32_t ibi_mem_depth;
-};
-
-/* Cadence I3C/I2C Device Private Data */
-struct cdns_i3c_i2c_dev_data {
-	/* Device id within the retaining registers. This is set after bus initialization by the
-	 * controller.
-	 */
-	uint8_t id;
-};
-
-/* Single command/transfer */
-struct cdns_i3c_cmd {
-	uint32_t cmd0;
-	uint32_t cmd1;
-	uint32_t ddr_header;
-	uint32_t ddr_crc;
-	uint32_t len;
-	uint32_t *num_xfer;
-	void *buf;
-	uint32_t error;
-	enum i3c_sdr_controller_error_types *sdr_err;
-	enum i3c_data_rate hdr;
-};
-
-/* Transfer data */
-struct cdns_i3c_xfer {
-	struct k_sem complete;
-	int ret;
-	int num_cmds;
-	struct cdns_i3c_cmd cmds[I3C_MAX_MSGS];
-};
-
-#ifdef CONFIG_I3C_USE_IBI
-/* IBI transferred data */
-struct cdns_i3c_ibi_buf {
-	uint8_t ibi_data[CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE];
-	uint8_t ibi_data_cnt;
-};
-#endif
-
-/* Driver config */
-struct cdns_i3c_config {
-	struct i3c_driver_config common;
-	/** base address of the controller */
-	uintptr_t base;
-	/** input frequency to the I3C Cadence */
-	uint32_t input_frequency;
-	/** Interrupt configuration function. */
-	void (*irq_config_func)(const struct device *dev);
-	/** IBID Threshold value */
-	uint8_t ibid_thr;
-};
-
-/* Driver instance data */
-struct cdns_i3c_data {
-	/* common must be first! */
-	struct i3c_driver_data common;
-	struct cdns_i3c_hw_config hw_cfg;
-	struct k_mutex bus_lock;
-#ifdef CONFIG_I3C_CONTROLLER
-	struct cdns_i3c_i2c_dev_data cdns_i3c_i2c_priv_data[I3C_MAX_DEVS];
-#if defined(CONFIG_I3C_CALLBACK) || defined(CONFIG_I2C_CALLBACK)
-	struct k_timer timeout;
-	i3c_callback_t cb;
-	void *userdata;
-	struct k_sem async_sem;
-#endif
-#endif /* CONFIG_I3C_CONTROLLER */
-	struct cdns_i3c_xfer xfer;
-#ifdef CONFIG_I3C_TARGET
-	struct i3c_target_config *target_config;
-#endif /* CONFIG_I3C_TARGET */
-#ifdef CONFIG_I3C_USE_IBI
-	struct cdns_i3c_ibi_buf ibi_buf;
-#ifdef CONFIG_I3C_TARGET
-	struct k_sem ibi_hj_complete;
-#ifdef CONFIG_I3C_CONTROLLER
-	struct k_sem ibi_cr_complete;
-#endif /* CONFIG_I3C_CONTROLLER */
-#endif /* CONFIG_I3C_TARGET */
-#endif /* CONFIG_I3C_USE_IBI*/
-#if (defined(CONFIG_I3C_CONTROLLER) && defined(CONFIG_I3C_TARGET)) ||                              \
-	defined(CONFIG_I3C_CALLBACK) || defined(CONFIG_I2C_CALLBACK)
-	const struct device *dev;
-#endif
-#if defined(CONFIG_I3C_CONTROLLER) && defined(CONFIG_I3C_TARGET)
-	struct k_work deftgts_work;
-	struct k_sem ch_complete;
-#endif /* CONFIG_I3C_CONTROLLER && CONFIG_I3C_TARGET */
-	uint32_t free_rr_slots;
-	uint16_t fifo_bytes_read;
-	uint8_t max_devs;
-};
 
 /*******************************************************************************
  * Global Variables Declaration
@@ -618,175 +34,6 @@ struct cdns_i3c_data {
 /*******************************************************************************
  * Private Functions Code
  ******************************************************************************/
-
-static uint8_t i3c_cdns_crc5(uint8_t crc5, uint16_t word)
-{
-	uint8_t crc0;
-	int i;
-
-	/*
-	 * crc0 = next_data_bit ^ crc[4]
-	 *                1         2            3       4
-	 * crc[4:0] = { crc[3:2], crc[1]^crc0, crc[0], crc0 }
-	 */
-	for (i = 15; i >= 0; --i) {
-		crc0 = ((word >> i) ^ (crc5 >> 4)) & 0x1;
-		crc5 = ((crc5 << 1) & 0x1a) | (((crc5 >> 1) ^ crc0) << 2) | crc0;
-	}
-
-	return crc5 & 0x1f;
-}
-
-static uint8_t cdns_i3c_ddr_parity(uint16_t payload)
-{
-	uint16_t pb;
-	uint8_t parity;
-
-	/* Calculate odd parity. */
-	pb = (payload >> 15) ^ (payload >> 13) ^ (payload >> 11) ^ (payload >> 9) ^ (payload >> 7) ^
-	     (payload >> 5) ^ (payload >> 3) ^ (payload >> 1);
-	parity = (pb & 1) << 1;
-	/* Calculate even and 1 parity */
-	pb = (payload >> 14) ^ (payload >> 12) ^ (payload >> 10) ^ (payload >> 8) ^ (payload >> 6) ^
-	     (payload >> 4) ^ (payload >> 2) ^ payload ^ 1;
-	parity |= (pb & 1);
-
-	return parity;
-}
-
-/* This prepares the ddr word from the payload add adding on parity, This
- * does not write the preamble
- */
-static uint32_t prepare_ddr_word(uint16_t payload)
-{
-	return (uint32_t)payload << 2 | cdns_i3c_ddr_parity(payload);
-}
-
-/* This ensures that PA0 contains 1'b1 which allows for easier Bus Turnaround */
-static uint16_t prepare_ddr_cmd_parity_adjustment_bit(uint16_t word)
-{
-	uint16_t pb;
-
-	pb = (word >> 14) ^ (word >> 12) ^ (word >> 10) ^ (word >> 8) ^ (word >> 6) ^ (word >> 4) ^
-	     (word >> 2);
-
-	if (pb & 1) {
-		word |= BIT(0);
-	}
-
-	return word;
-}
-#ifdef CONFIG_I3C_CONTROLLER
-/* Computes and sets parity */
-/* Returns [7:1] 7-bit addr, [0] even/xor parity */
-static uint8_t cdns_i3c_even_parity_byte(uint8_t byte)
-{
-	uint8_t parity = 0;
-	uint8_t b = byte;
-
-	while (b) {
-		parity = !parity;
-		b = b & (b - 1);
-	}
-	b = (byte << 1) | !parity;
-
-	return b;
-}
-#endif /* CONFIG_I3C_CONTROLLER */
-
-/* Check if command response fifo is empty */
-static inline bool cdns_i3c_cmd_rsp_fifo_empty(const struct cdns_i3c_config *config)
-{
-	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
-
-	return ((mst_st & MST_STATUS0_CMDR_EMP) ? true : false);
-}
-
-/* Check if command fifo is empty */
-static inline bool cdns_i3c_cmd_fifo_empty(const struct cdns_i3c_config *config)
-{
-	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
-
-	return ((mst_st & MST_STATUS0_CMDD_EMP) ? true : false);
-}
-
-/* Check if command fifo is full */
-static inline bool cdns_i3c_cmd_fifo_full(const struct cdns_i3c_config *config)
-{
-	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
-
-	return ((mst_st & MST_STATUS0_CMDD_FULL) ? true : false);
-}
-
-/* Check if ibi response fifo is empty */
-static inline bool cdns_i3c_ibi_rsp_fifo_empty(const struct cdns_i3c_config *config)
-{
-	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
-
-	return ((mst_st & MST_STATUS0_IBIR_EMP) ? true : false);
-}
-
-/* Check if tx fifo is full */
-static inline bool cdns_i3c_tx_fifo_full(const struct cdns_i3c_config *config)
-{
-	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
-
-	return ((mst_st & MST_STATUS0_TX_FULL) ? true : false);
-}
-
-/* Check if rx fifo is full */
-static inline bool cdns_i3c_rx_fifo_full(const struct cdns_i3c_config *config)
-{
-	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
-
-	return ((mst_st & MST_STATUS0_RX_FULL) ? true : false);
-}
-
-/* Check if rx fifo is empty */
-static inline bool cdns_i3c_rx_fifo_empty(const struct cdns_i3c_config *config)
-{
-	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
-
-	return ((mst_st & MST_STATUS0_RX_EMP) ? true : false);
-}
-
-/* Check if ibi fifo is empty */
-static inline bool cdns_i3c_ibi_fifo_empty(const struct cdns_i3c_config *config)
-{
-	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
-
-	return ((mst_st & MST_STATUS0_IBID_EMP) ? true : false);
-}
-
-/* Interrupt handling */
-static inline void cdns_i3c_interrupts_disable(const struct cdns_i3c_config *config)
-{
-	sys_write32(MST_INT_MASK, config->base + MST_IDR);
-}
-
-static inline void cdns_i3c_interrupts_clear(const struct cdns_i3c_config *config)
-{
-	sys_write32(MST_INT_MASK, config->base + MST_ICR);
-}
-
-/* FIFO mgmt */
-static void cdns_i3c_write_tx_fifo(const struct cdns_i3c_config *config, const void *buf,
-				   uint32_t len)
-{
-	const uint32_t *ptr = buf;
-	uint32_t remain, val;
-
-	for (remain = len; remain >= 4; remain -= 4) {
-		val = *ptr++;
-		sys_write32(val, config->base + TX_FIFO);
-	}
-
-	if (remain > 0) {
-		val = 0;
-		memcpy(&val, ptr, remain);
-		sys_write32(val, config->base + TX_FIFO);
-	}
-}
 
 #ifdef CONFIG_I3C_TARGET
 static void cdns_i3c_write_ddr_tx_fifo(const struct cdns_i3c_config *config, const void *buf,
@@ -830,6 +77,7 @@ static void cdns_i3c_write_ibi_fifo(const struct cdns_i3c_config *config, const 
 #endif /* CONFIG_I3C_TARGET */
 #endif /* CONFIG_I3C_USE_IBI */
 #ifdef CONFIG_I3C_TARGET
+#ifndef CONFIG_I3C_TARGET_BUFFER_MODE
 static void cdns_i3c_target_read_rx_fifo(const struct device *dev)
 {
 	const struct cdns_i3c_config *config = dev->config;
@@ -864,91 +112,9 @@ static void cdns_i3c_target_read_rx_fifo(const struct device *dev)
 		target_cb->write_received_cb(data->target_config, rx_data);
 	}
 }
+#endif /* !CONFIG_I3C_TARGET_BUFFER_MODE */
 #endif /* CONFIG_I3C_TARGET */
 #ifdef CONFIG_I3C_CONTROLLER
-static int cdns_i3c_read_rx_fifo(const struct cdns_i3c_config *config, void *buf, uint32_t len)
-{
-	uint32_t *ptr = buf;
-	uint32_t remain, val;
-
-	for (remain = len; remain >= 4; remain -= 4) {
-		if (cdns_i3c_rx_fifo_empty(config)) {
-			return -EIO;
-		}
-		val = sys_le32_to_cpu(sys_read32(config->base + RX_FIFO));
-		*ptr++ = val;
-	}
-
-	if (remain > 0) {
-		if (cdns_i3c_rx_fifo_empty(config)) {
-			return -EIO;
-		}
-		val = sys_le32_to_cpu(sys_read32(config->base + RX_FIFO));
-		memcpy(ptr, &val, remain);
-	}
-
-	return 0;
-}
-
-static int cdns_i3c_read_rx_fifo_ddr_xfer(const struct cdns_i3c_config *config, void *buf,
-					  uint32_t len, uint32_t ddr_header)
-{
-	uint16_t *ptr = buf;
-	uint32_t val;
-	uint32_t preamble;
-	uint8_t crc5 = 0x1F;
-
-	/*
-	 * TODO: This function does not support threshold interrupts, it is expected that the
-	 * whole packet to be within the FIFO and not split across multiple calls to this function.
-	 */
-	crc5 = i3c_cdns_crc5(crc5, (uint16_t)DDR_DATA(ddr_header));
-
-	for (int i = 0; i < len; i++) {
-		if (cdns_i3c_rx_fifo_empty(config)) {
-			return -EIO;
-		}
-		val = sys_read32(config->base + RX_FIFO);
-		preamble = (val & DDR_PREAMBLE_MASK);
-
-		if (preamble == DDR_PREAMBLE_DATA_ABORT ||
-		    preamble == DDR_PREAMBLE_DATA_ABORT_ALT) {
-			*ptr++ = sys_cpu_to_be16((uint16_t)DDR_DATA(val));
-			crc5 = i3c_cdns_crc5(crc5, (uint16_t)DDR_DATA(val));
-		} else if ((preamble == DDR_PREAMBLE_CMD_CRC) &&
-			   ((val & DDR_CRC_TOKEN_MASK) == DDR_CRC_TOKEN)) {
-			uint8_t crc = (uint8_t)DDR_CRC(val);
-
-			if (crc5 != crc) {
-				LOG_ERR("DDR RX crc error");
-				return -EIO;
-			}
-		}
-	}
-
-	return 0;
-}
-
-static inline int cdns_i3c_wait_for_idle(const struct device *dev)
-{
-	const struct cdns_i3c_config *config = dev->config;
-	uint32_t start_time = k_cycle_get_32();
-
-	/**
-	 * Spin waiting for device to go idle. It is unlikely that this will
-	 * actually take any time unless if the last transaction came immediately
-	 * after an error condition.
-	 */
-	while (!(sys_read32(config->base + MST_STATUS0) & MST_STATUS0_IDLE)) {
-		if (k_cycle_get_32() - start_time > I3C_IDLE_TIMEOUT_CYC) {
-			LOG_ERR("%s: Timeout waiting for idle", dev->name);
-			return -EAGAIN;
-		}
-	}
-
-	return 0;
-}
-
 static void cdns_i3c_set_prescalers(const struct device *dev)
 {
 	struct cdns_i3c_data *data = dev->data;
@@ -1030,7 +196,6 @@ static void cdns_i3c_set_prescalers(const struct device *dev)
 		sys_write32(CTRL_DEV_EN | ctrl, config->base + CTRL);
 	}
 }
-#ifdef CONFIG_I3C_CONTROLLER
 /**
  * @brief Compute RR0 Value from addr
  *
@@ -1054,6 +219,7 @@ static uint32_t prepare_rr0_dev_address(uint16_t addr)
 }
 #endif /* CONFIG_I3C_CONTROLLER */
 
+#ifdef CONFIG_I3C_CONTROLLER
 /**
  * @brief Program Retaining Registers with device lists
  *
@@ -1349,433 +515,9 @@ error:
 #endif /* CONFIG_I3C_USE_IBI */
 
 #ifdef CONFIG_I3C_CONTROLLER
-static void cdns_i3c_cancel_transfer(const struct device *dev)
-{
-	struct cdns_i3c_data *data = dev->data;
-	const struct cdns_i3c_config *config = dev->config;
-	uint32_t val;
 
-	/* Disable further interrupts */
-	sys_write32(MST_INT_CMDD_EMP, config->base + MST_IDR);
 
-	/* Ignore if no pending transfer */
-	if (data->xfer.num_cmds == 0) {
-		return;
-	}
 
-	data->xfer.num_cmds = 0;
-
-	/* Clear main enable bit to disable further transactions */
-	sys_write32(~CTRL_DEV_EN & sys_read32(config->base + CTRL), config->base + CTRL);
-
-	/**
-	 * Spin waiting for device to go idle. It is unlikely that this will
-	 * actually take any time since we only get here if a transaction didn't
-	 * complete in a long time.
-	 */
-	bool idle = false;
-
-	for (uint32_t i = 0; i < I3C_MAX_IDLE_CANCEL_WAIT_RETRIES; i++) {
-		val = sys_read32(config->base + MST_STATUS0);
-		if (val & MST_STATUS0_IDLE) {
-			idle = true;
-			break;
-		}
-		k_msleep(10);
-	}
-	if (!idle) {
-		data->xfer.ret = -ETIMEDOUT;
-	}
-
-	/**
-	 * Flush all queues.
-	 */
-	sys_write32(FLUSH_RX_FIFO | FLUSH_TX_FIFO | FLUSH_CMD_FIFO | FLUSH_CMD_RESP,
-		    config->base + FLUSH_CTRL);
-
-	/* Re-enable device */
-	sys_write32(CTRL_DEV_EN | sys_read32(config->base + CTRL), config->base + CTRL);
-}
-
-#if defined(CONFIG_I3C_CALLBACK) || defined(CONFIG_I2C_CALLBACK)
-static void cdns_i3c_cb_timeout(struct k_timer *timer)
-{
-	struct cdns_i3c_data *data = CONTAINER_OF(timer, struct cdns_i3c_data, timeout);
-	const struct device *dev = data->dev;
-
-	cdns_i3c_cancel_transfer(dev);
-	k_sem_give(&data->async_sem);
-	pm_device_busy_clear(dev);
-	if (data->cb) {
-		data->cb(dev, -ETIMEDOUT, data->userdata);
-	}
-}
-#endif
-
-/**
- * @brief Start a I3C/I2C Transfer
- *
- * This is to be called from a I3C/I2C transfer function. This will write
- * all data to tx and cmd fifos
- *
- * @param dev Pointer to controller device driver instance.
- */
-static void cdns_i3c_start_transfer(const struct device *dev)
-{
-	struct cdns_i3c_data *data = dev->data;
-	const struct cdns_i3c_config *config = dev->config;
-	struct cdns_i3c_xfer *xfer = &data->xfer;
-
-	/* Ensure no pending command response queue threshold interrupt */
-	sys_write32(MST_INT_CMDD_EMP, config->base + MST_ICR);
-
-	/* Make sure RX FIFO is empty. */
-	while (!cdns_i3c_rx_fifo_empty(config)) {
-		(void)sys_read32(config->base + RX_FIFO);
-	}
-	/* Make sure CMDR FIFO is empty too */
-	while (!cdns_i3c_cmd_rsp_fifo_empty(config)) {
-		(void)sys_read32(config->base + CMDR);
-	}
-
-	/* Write all tx data to fifo */
-	for (unsigned int i = 0; i < xfer->num_cmds; i++) {
-		if (xfer->cmds[i].hdr == I3C_DATA_RATE_SDR) {
-			if (!(xfer->cmds[i].cmd0 & CMD0_FIFO_RNW)) {
-				cdns_i3c_write_tx_fifo(config, xfer->cmds[i].buf,
-						       xfer->cmds[i].len);
-			}
-		} else if (xfer->cmds[i].hdr == I3C_DATA_RATE_HDR_DDR) {
-			/* DDR Xfer requires sending header block*/
-			cdns_i3c_write_tx_fifo(config, &xfer->cmds[i].ddr_header,
-					       DDR_CRC_AND_HEADER_SIZE);
-			/* If not read operation need to send data + crc of data*/
-			if (!(DDR_DATA(xfer->cmds[i].ddr_header) & HDR_CMD_RD)) {
-				uint8_t *buf = (uint8_t *)xfer->cmds[i].buf;
-				uint32_t ddr_message = 0;
-				uint16_t ddr_data_payload = sys_get_be16(&buf[0]);
-				/* HDR-DDR Data Words */
-				ddr_message = (DDR_PREAMBLE_DATA_ABORT |
-					       prepare_ddr_word(ddr_data_payload));
-				cdns_i3c_write_tx_fifo(config, &ddr_message,
-						       DDR_CRC_AND_HEADER_SIZE);
-				for (int j = 2; j < ((xfer->cmds[i].len - 2) * 2); j += 2) {
-					ddr_data_payload = sys_get_be16(&buf[j]);
-					ddr_message = (DDR_PREAMBLE_DATA_ABORT_ALT |
-						       prepare_ddr_word(ddr_data_payload));
-					cdns_i3c_write_tx_fifo(config, &ddr_message,
-							       DDR_CRC_AND_HEADER_SIZE);
-				}
-				/* HDR-DDR CRC Word */
-				cdns_i3c_write_tx_fifo(config, &xfer->cmds[i].ddr_crc,
-						       DDR_CRC_AND_HEADER_SIZE);
-			}
-		} else {
-			xfer->ret = -ENOTSUP;
-			return;
-		}
-	}
-
-	/* Write all data to cmd fifos */
-	for (unsigned int i = 0; i < xfer->num_cmds; i++) {
-		/* The command ID is just the msg index. */
-		xfer->cmds[i].cmd1 |= CMD1_FIFO_CMDID(i);
-		sys_write32(xfer->cmds[i].cmd1, config->base + CMD1_FIFO);
-		sys_write32(xfer->cmds[i].cmd0, config->base + CMD0_FIFO);
-
-		if (xfer->cmds[i].hdr == I3C_DATA_RATE_HDR_DDR) {
-			sys_write32(0x00, config->base + CMD1_FIFO);
-			if ((DDR_DATA(xfer->cmds[i].ddr_header) & HDR_CMD_RD)) {
-				sys_write32(CMD0_FIFO_IS_DDR | CMD0_FIFO_PL_LEN(1),
-					    config->base + CMD0_FIFO);
-			} else {
-				sys_write32(CMD0_FIFO_IS_DDR | CMD0_FIFO_PL_LEN(xfer->cmds[i].len),
-					    config->base + CMD0_FIFO);
-			}
-		}
-	}
-
-	/* kickoff transfer */
-	sys_write32(MST_INT_CMDD_EMP, config->base + MST_IER);
-	sys_write32(CTRL_MCS | sys_read32(config->base + CTRL), config->base + CTRL);
-}
-
-static k_timeout_t cdns_i3c_calc_timeout_i3c(const struct i3c_msg *msgs, uint8_t num_msgs,
-					      uint32_t scl_hz)
-{
-	uint64_t us = 0;
-	bool send_broadcast = true;
-
-	for (uint8_t i = 0; i < num_msgs; i++) {
-		uint32_t bits;
-
-		if ((msgs[i].flags & I3C_MSG_HDR) && (msgs[i].hdr_mode & I3C_MSG_HDR_DDR)) {
-			/*
-			 * HDR-DDR preamble: ENTHDR0 broadcast CCC (0x7E addr + cmd code) = 18
-			 * SDR bits. DDR payload: (len/2) 16-bit data words + 1 DDR command header
-			 * word + 1 DDR CRC word = (len/2 + 2) words total, each taking 8 SCL
-			 * cycles (DDR encodes 2 bits per SCL edge, so 16 bits = 8 cycles).
-			 */
-			bits = 18 + ((msgs[i].len / 2) + 2) * 8;
-		} else {
-			/* SDR: address frame (9 bits) + data bytes (9 bits each) */
-			bits = 9 + (msgs[i].len * 9);
-			if (!(msgs[i].flags & I3C_MSG_NBCH) && send_broadcast) {
-				bits += 9; /* broadcast header 0x7E */
-				send_broadcast = false;
-			}
-			if (((i + 1) == num_msgs) || (msgs[i].flags & I3C_MSG_STOP)) {
-				send_broadcast = true;
-			}
-		}
-
-		us += DIV_ROUND_UP((uint64_t)bits * USEC_PER_SEC, scl_hz);
-	}
-
-	us += CONFIG_I3C_CADENCE_TRANSFER_TIMEOUT_MARGIN_US;
-
-	return K_TICKS(k_us_to_ticks_ceil64(us));
-}
-
-static k_timeout_t cdns_i3c_calc_timeout_i2c(const struct i2c_msg *msgs, uint8_t num_msgs,
-					      uint32_t scl_hz)
-{
-	uint64_t us = 0;
-
-	for (uint8_t i = 0; i < num_msgs; i++) {
-		uint32_t bits = (msgs[i].flags & I2C_MSG_ADDR_10_BITS) ? 18 : 9;
-
-		bits += msgs[i].len * 9;
-		us += DIV_ROUND_UP((uint64_t)bits * USEC_PER_SEC, scl_hz);
-	}
-
-	us += CONFIG_I3C_CADENCE_TRANSFER_TIMEOUT_MARGIN_US;
-
-	return K_TICKS(k_us_to_ticks_ceil64(us));
-}
-
-static k_timeout_t cdns_i3c_calc_timeout_ccc(const struct i3c_ccc_payload *payload,
-					      uint32_t scl_hz)
-{
-	/*
-	 * CCC frame on the wire: broadcast addr (9) + CCC command byte (9) + optional
-	 * defining/broadcast data byte(s) (9 each). Per the I3C spec these are
-	 * transmitted once per CCC frame regardless of the number of addressed targets.
-	 *
-	 * For a direct CCC the controller then issues, per target, a repeated start +
-	 * target address (9) + per-target data bytes (9 each). The Cadence IP requires
-	 * one queued command per target so it knows the direction and length, but it
-	 * still emits a single CCC byte / defining byte at the head of the wire frame.
-	 */
-	uint64_t us;
-	uint32_t bits = 18 + (payload->ccc.data_len * 9);
-
-	if (!i3c_ccc_is_payload_broadcast(payload)) {
-		for (size_t i = 0; i < payload->targets.num_targets; i++) {
-			bits += 9 + (payload->targets.payloads[i].data_len * 9);
-		}
-	}
-
-	us = DIV_ROUND_UP((uint64_t)bits * USEC_PER_SEC, scl_hz);
-	us += CONFIG_I3C_CADENCE_TRANSFER_TIMEOUT_MARGIN_US;
-
-	return K_TICKS(k_us_to_ticks_ceil64(us));
-}
-
-static int cdns_i3c_do_ccc_do(const struct device *dev, struct i3c_ccc_payload *payload, bool async,
-			      i3c_callback_t cb, void *userdata)
-{
-	const struct cdns_i3c_config *config = dev->config;
-	struct cdns_i3c_data *data = dev->data;
-	struct cdns_i3c_cmd *cmd;
-	int ret = 0;
-	uint8_t num_cmds = 0;
-
-	__ASSERT_NO_MSG(payload != NULL);
-
-	/*
-	 * Ensure data will fit within FIFOs.
-	 *
-	 * TODO: This limitation prevents burst transfers greater than the
-	 *       FIFO sizes and should be replaced with an implementation that
-	 *       utilizes the RX/TX data threshold interrupts.
-	 */
-	uint32_t num_msgs =
-		1 + ((payload->ccc.data_len > 0) ? payload->targets.num_targets
-						 : MAX(payload->targets.num_targets - 1, 0));
-	if (num_msgs > data->hw_cfg.cmd_mem_depth || num_msgs > data->hw_cfg.cmdr_mem_depth) {
-		LOG_ERR("%s: Too many messages", dev->name);
-		return -ENOMEM;
-	}
-
-	uint32_t rxsize = 0;
-	/* defining byte is stored in a separate register for direct CCCs */
-	uint32_t txsize =
-		i3c_ccc_is_payload_broadcast(payload) ? ROUND_UP(payload->ccc.data_len, 4) : 0;
-
-	for (int i = 0; i < payload->targets.num_targets; i++) {
-		if (payload->targets.payloads[i].rnw) {
-			rxsize += ROUND_UP(payload->targets.payloads[i].data_len, 4);
-		} else {
-			txsize += ROUND_UP(payload->targets.payloads[i].data_len, 4);
-		}
-	}
-	if ((rxsize > data->hw_cfg.rx_mem_depth) || (txsize > data->hw_cfg.tx_mem_depth)) {
-		LOG_ERR("%s: Total RX and/or TX transfer larger than FIFO", dev->name);
-		return -ENOMEM;
-	}
-
-	k_mutex_lock(&data->bus_lock, K_FOREVER);
-#ifdef CONFIG_I3C_CALLBACK
-	k_sem_take(&data->async_sem, K_FOREVER);
-	if (async) {
-		data->cb = cb;
-		data->userdata = userdata;
-	} else {
-		data->cb = NULL;
-		data->userdata = NULL;
-	}
-#endif
-	pm_device_busy_set(dev);
-
-	/* make sure we are currently the active controller */
-	if (!(sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE)) {
-		ret = -EACCES;
-		goto error;
-	}
-
-	/* wait for idle */
-	ret = cdns_i3c_wait_for_idle(dev);
-	if (ret != 0) {
-		goto error;
-	}
-
-	/* if this is a direct CCC */
-	if (!i3c_ccc_is_payload_broadcast(payload)) {
-		/* if the CCC has no data bytes, then the target payload must be in
-		 * the same command buffer
-		 */
-		for (int i = 0; i < payload->targets.num_targets; i++) {
-			cmd = &data->xfer.cmds[i];
-			num_cmds++;
-			cmd->cmd1 = CMD1_FIFO_CCC(payload->ccc.id);
-			cmd->cmd0 = CMD0_FIFO_IS_CCC;
-			/* if there is a defining byte */
-			if (payload->ccc.data_len == 1) {
-				/* Only revision 1p7 supports defining byte for direct CCCs */
-				if (REV_ID_REV(data->hw_cfg.rev_id) >= REV_ID_VERSION(1, 7)) {
-					cmd->cmd0 |= CMD0_FIFO_IS_DB;
-					cmd->cmd1 |= CMD1_FIFO_DB(payload->ccc.data[0]);
-				} else {
-					LOG_ERR("%s: Defining Byte with Direct CCC not supported "
-						"with rev %lup%lu",
-						dev->name, REV_ID_REV_MAJOR(data->hw_cfg.rev_id),
-						REV_ID_REV_MINOR(data->hw_cfg.rev_id));
-					ret = -ENOTSUP;
-					goto error;
-				}
-			} else if (payload->ccc.data_len > 1) {
-				LOG_ERR("%s: Defining Byte length greater than 1", dev->name);
-				ret = -EINVAL;
-				goto error;
-			}
-			/* for a short CCC, i.e. where a direct ccc has multiple targets,
-			 * BCH must be 0 for subsequent targets and RSBC must be 1, otherwise
-			 * if there is just one target, RSBC must be 0 on the first target
-			 */
-			if (i == 0) {
-				cmd->cmd0 |= CMD0_FIFO_BCH;
-			}
-			if (i < (payload->targets.num_targets - 1)) {
-				cmd->cmd0 |= CMD0_FIFO_RSBC;
-			}
-			cmd->buf = payload->targets.payloads[i].data;
-			cmd->len = payload->targets.payloads[i].data_len;
-			cmd->cmd0 |= CMD0_FIFO_DEV_ADDR(payload->targets.payloads[i].addr) |
-				     CMD0_FIFO_PL_LEN(payload->targets.payloads[i].data_len);
-			if (payload->targets.payloads[i].rnw) {
-				cmd->cmd0 |= CMD0_FIFO_RNW;
-			}
-			cmd->hdr = I3C_DATA_RATE_SDR;
-			/*
-			 * write the address of num_xfer and err which is to be updated upon
-			 * message completion
-			 */
-			cmd->num_xfer = (uint32_t *)&(payload->targets.payloads[i].num_xfer);
-			cmd->sdr_err = &(payload->targets.payloads[i].err);
-		}
-	} else {
-		cmd = &data->xfer.cmds[0];
-		num_cmds++;
-		cmd->cmd1 = CMD1_FIFO_CCC(payload->ccc.id);
-		cmd->cmd0 = CMD0_FIFO_IS_CCC | CMD0_FIFO_BCH;
-		cmd->hdr = I3C_DATA_RATE_SDR;
-
-		if (payload->ccc.data_len > 0) {
-			/* Write additional data for CCC if needed */
-			cmd->buf = payload->ccc.data;
-			cmd->len = payload->ccc.data_len;
-			cmd->cmd0 |= CMD0_FIFO_PL_LEN(payload->ccc.data_len);
-			/* write the address of num_xfer which is to be updated upon message
-			 * completion
-			 */
-			cmd->num_xfer = (uint32_t *)&(payload->ccc.num_xfer);
-		} else {
-			/* no data to transfer */
-			cmd->len = 0;
-			cmd->num_xfer = NULL;
-		}
-		cmd->sdr_err = &(payload->ccc.err);
-	}
-
-	data->xfer.ret = -ETIMEDOUT;
-	data->xfer.num_cmds = num_cmds;
-
-	k_timeout_t xfer_timeout = cdns_i3c_calc_timeout_ccc(payload,
-							      data->common.ctrl_config.scl.i3c);
-
-	cdns_i3c_start_transfer(dev);
-	if (!async) {
-		if (k_sem_take(&data->xfer.complete, xfer_timeout) != 0) {
-			LOG_ERR("%s: transfer timed out", dev->name);
-			cdns_i3c_cancel_transfer(dev);
-		}
-	}
-#ifdef CONFIG_I3C_CALLBACK
-	else {
-		k_timer_start(&data->timeout, xfer_timeout, K_NO_WAIT);
-	}
-#endif
-
-	if (!async && data->xfer.ret < 0) {
-		LOG_ERR("%s: CCC[0x%02x] error (%d)", dev->name, payload->ccc.id, data->xfer.ret);
-	}
-
-	if (!async) {
-		ret = data->xfer.ret;
-	} else {
-		ret = 0;
-	}
-#if defined(CONFIG_I3C_CONTROLLER) && defined(CONFIG_I3C_TARGET)
-	/* TODO: decide if this is the right approach or add a new separate API for CH */
-	/* Wait for Controller Handoff to finish */
-	if (payload->ccc.id == I3C_CCC_GETACCCR) {
-		ret = k_sem_take(&data->ch_complete, K_MSEC(1000));
-	}
-#endif /* CONFIG_I3C_CONTROLLER && CONFIG_I3C_TARGET */
-error:
-#ifdef CONFIG_I3C_CALLBACK
-	if (!async || ret != 0) {
-		pm_device_busy_clear(dev);
-		k_sem_give(&data->async_sem);
-	}
-#else
-	pm_device_busy_clear(dev);
-#endif
-	k_mutex_unlock(&data->bus_lock);
-
-	return ret;
-}
 
 /**
  * @brief Send Common Command Code (CCC).
@@ -1789,7 +531,13 @@ error:
  */
 static int cdns_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *payload)
 {
+#ifdef CONFIG_I3C_CADENCE_RTIO
+	struct cdns_i3c_data *data = dev->data;
+
+	return i3c_rtio_ccc(data->rtio->i3c_ctx, payload);
+#else
 	return cdns_i3c_do_ccc_do(dev, payload, false, NULL, NULL);
+#endif
 }
 
 #ifdef CONFIG_I3C_CALLBACK
@@ -1808,7 +556,13 @@ static int cdns_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *pay
 static int cdns_i3c_do_ccc_cb(const struct device *dev, struct i3c_ccc_payload *payload,
 			      i3c_callback_t cb, void *userdata)
 {
+#ifdef CONFIG_I3C_CADENCE_RTIO
+	struct cdns_i3c_data *data = dev->data;
+
+	return i3c_rtio_ccc_cb(data->rtio->i3c_ctx, dev, payload, cb, userdata);
+#else
 	return cdns_i3c_do_ccc_do(dev, payload, true, cb, userdata);
+#endif
 }
 #endif
 
@@ -2045,373 +799,7 @@ static int cdns_i3c_configure(const struct device *dev, enum i3c_config_type typ
 	return 0;
 }
 
-#ifdef CONFIG_I3C_CONTROLLER
-/**
- * @brief Complete a I3C/I2C Transfer
- *
- * This is to be called from an ISR when the Command Response FIFO
- * is Empty. This will check each Command Response reading the RX
- * FIFO if message was a RnW and if any message had an error.
- *
- * @param dev Pointer to controller device driver instance.
- */
-static void cdns_i3c_complete_transfer(const struct device *dev)
-{
-	struct cdns_i3c_data *data = dev->data;
-	const struct cdns_i3c_config *config = dev->config;
-	uint32_t cmdr;
-	uint32_t id = 0;
-	uint32_t xfer = 0;
-	int ret = 0;
-	struct cdns_i3c_cmd *cmd;
-	bool was_full;
-
-	/* Used only to determine in the case of a controller abort */
-	was_full = cdns_i3c_rx_fifo_full(config);
-
-	/* Disable further interrupts */
-	sys_write32(MST_INT_CMDD_EMP, config->base + MST_IDR);
-
-	/* Ignore if no pending transfer */
-	if (data->xfer.num_cmds == 0) {
-		return;
-	}
-
-	/* Process all results in fifo */
-	for (uint32_t status0 = sys_read32(config->base + MST_STATUS0);
-	     !(status0 & MST_STATUS0_CMDR_EMP); status0 = sys_read32(config->base + MST_STATUS0)) {
-		cmdr = sys_read32(config->base + CMDR);
-		id = CMDR_CMDID(cmdr);
-
-		if (id == CMDR_CMDID_HJACK_DISEC || id == CMDR_CMDID_HJACK_ENTDAA ||
-		    id >= data->xfer.num_cmds) {
-			continue;
-		}
-
-		cmd = &data->xfer.cmds[id];
-
-		xfer = MIN(CMDR_XFER_BYTES(cmdr), cmd->len);
-		if (cmd->num_xfer != NULL) {
-			*cmd->num_xfer = xfer;
-		}
-		/* Read any rx data into buffer */
-		if (cmd->cmd0 & CMD0_FIFO_RNW) {
-			ret = cdns_i3c_read_rx_fifo(config, cmd->buf, xfer);
-		}
-
-		if ((cmd->hdr == I3C_DATA_RATE_HDR_DDR) &&
-		    (DDR_DATA(cmd->ddr_header) & HDR_CMD_RD)) {
-			ret = cdns_i3c_read_rx_fifo_ddr_xfer(config, cmd->buf, xfer,
-							     cmd->ddr_header);
-		}
-
-		/* Record error */
-		cmd->error = CMDR_ERROR(cmdr);
-	}
-
-	for (int i = 0; i < data->xfer.num_cmds; i++) {
-		switch (data->xfer.cmds[i].error) {
-		case CMDR_NO_ERROR:
-			if (data->xfer.cmds[i].sdr_err) {
-				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_NONE;
-			}
-			break;
-
-		case CMDR_MST_ABORT:
-			/*
-			 * A controller abort is forced if the RX FIFO fills up
-			 * There is also the case where the fifo can be full as
-			 * the len of the packet is the same length of the fifo
-			 * Check that the requested len is greater than the total
-			 * transferred to confirm that is not case. Otherwise the
-			 * abort was caused by the buffer length being meet and
-			 * the target did not give an End of Data (EoD) in the T
-			 * bit. Do not treat that condition as an error because
-			 * some targets will just auto-increment the read address
-			 * way beyond the buffer not giving an EoD.
-			 */
-			if ((was_full) && (data->xfer.cmds[i].len > *data->xfer.cmds[i].num_xfer)) {
-				ret = -ENOSPC;
-			} else {
-				LOG_DBG("%s: Controller Abort due to buffer length exceeded with "
-					"no EoD from target",
-					dev->name);
-			}
-			if (data->xfer.cmds[i].sdr_err) {
-				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_NONE;
-			}
-			break;
-
-		case CMDR_M0_ERROR: {
-			uint8_t ccc = data->xfer.cmds[i].cmd1 & 0xFF;
-			/*
-			 * The M0 is an illegally formatted CCC. i.e. the Controller
-			 * receives 1 byte instead of 2 with the GETMWL CCC. This can
-			 * be problematic for CCCs that can have variable length such
-			 * as GETMXDS and GETCAPS. Verify the number of bytes received matches
-			 * what's expected from the specification and ignore the error. The IP will
-			 * still retramsit the same CCC and there's nothing that can be done to
-			 * prevent this. It it still up to the application to read `num_xfer` to
-			 * determine the number of bytes returned.
-			 */
-			if (ccc == I3C_CCC_GETMXDS) {
-				/*
-				 * Whether GETMXDS format 1 and format 2 can't be known ahead of
-				 * time which will be returned.
-				 */
-				if ((*data->xfer.cmds[i].num_xfer !=
-				     SIZEOF_FIELD(union i3c_ccc_getmxds, fmt1)) &&
-				    (*data->xfer.cmds[i].num_xfer !=
-				     SIZEOF_FIELD(union i3c_ccc_getmxds, fmt2))) {
-					ret = -EIO;
-				}
-			} else if (ccc == I3C_CCC_GETCAPS) {
-				/* GETCAPS can only return 1-4 bytes */
-				if (*data->xfer.cmds[i].num_xfer > sizeof(union i3c_ccc_getcaps)) {
-					ret = -EIO;
-				}
-			} else {
-				if (data->xfer.cmds[i].sdr_err) {
-					*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE0;
-				}
-				ret = -EIO;
-			}
-			break;
-		}
-
-		case CMDR_M1_ERROR:
-			if (data->xfer.cmds[i].sdr_err) {
-				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE1;
-			}
-			ret = -EIO;
-			break;
-		case CMDR_M2_ERROR:
-			if (data->xfer.cmds[i].sdr_err) {
-				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE2;
-			}
-			ret = -EIO;
-			break;
-
-		case CMDR_DDR_PREAMBLE_ERROR:
-		case CMDR_DDR_PARITY_ERROR:
-		case CMDR_NACK_RESP:
-		case CMDR_DDR_DROPPED:
-			if (data->xfer.cmds[i].sdr_err) {
-				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_UNKNOWN;
-			}
-			ret = -EIO;
-			break;
-
-		case CMDR_DDR_RX_FIFO_OVF:
-		case CMDR_DDR_TX_FIFO_UNF:
-			if (data->xfer.cmds[i].sdr_err) {
-				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_UNKNOWN;
-			}
-			ret = -ENOSPC;
-			break;
-
-		case CMDR_INVALID_DA:
-		default:
-			if (data->xfer.cmds[i].sdr_err) {
-				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_UNKNOWN;
-			}
-			ret = -EINVAL;
-			break;
-		}
-	}
-
-	data->xfer.ret = ret;
-
-	/* Indicate no transfer is pending */
-	data->xfer.num_cmds = 0;
-#if defined(CONFIG_I3C_CALLBACK) || defined(CONFIG_I2C_CALLBACK)
-	pm_device_busy_clear(dev);
-	if (data->cb) {
-		k_timer_stop(&data->timeout);
-		data->cb(dev, ret, data->userdata);
-		k_sem_give(&data->async_sem);
-	} else {
-		k_sem_give(&data->xfer.complete);
-	}
-#else
-	k_sem_give(&data->xfer.complete);
-#endif
-}
-#endif /* CONFIG_I3C_CONTROLLER */
 #if CONFIG_I3C_CONTROLLER
-/**
- * @brief Transfer messages in I2C mode.
- *
- * @param dev Pointer to device driver instance.
- * @param target Pointer to target device descriptor.
- * @param msgs Pointer to I2C messages.
- * @param num_msgs Number of messages to transfers.
- *
- * @retval 0 If successful.
- * @retval -EIO General input / output error.
- * @retval -EINVAL Address not registered
- */
-static int cdns_i3c_i2c_transfer_do(const struct device *dev, struct i3c_i2c_device_desc *i2c_dev,
-				    struct i2c_msg *msgs, uint8_t num_msgs, bool async,
-				    i2c_callback_t cb, void *userdata)
-{
-	const struct cdns_i3c_config *config = dev->config;
-	struct cdns_i3c_data *data = dev->data;
-	uint32_t txsize = 0;
-	uint32_t rxsize = 0;
-	int ret;
-	k_timeout_t xfer_timeout;
-
-	__ASSERT_NO_MSG(num_msgs > 0);
-
-	if (num_msgs > data->hw_cfg.cmd_mem_depth || num_msgs > data->hw_cfg.cmdr_mem_depth) {
-		LOG_ERR("%s: Too many messages", dev->name);
-		return -ENOMEM;
-	}
-
-	/*
-	 * Ensure data will fit within FIFOs
-	 */
-	for (unsigned int i = 0; i < num_msgs; i++) {
-		if ((msgs[i].flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) {
-			rxsize += ROUND_UP(msgs[i].len, 4);
-		} else {
-			txsize += ROUND_UP(msgs[i].len, 4);
-		}
-	}
-	if ((rxsize > data->hw_cfg.rx_mem_depth) || (txsize > data->hw_cfg.tx_mem_depth)) {
-		LOG_ERR("%s: Total RX and/or TX transfer larger than FIFO", dev->name);
-		return -ENOMEM;
-	}
-
-	k_mutex_lock(&data->bus_lock, K_FOREVER);
-#ifdef CONFIG_I2C_CALLBACK
-	k_sem_take(&data->async_sem, K_FOREVER);
-	if (async) {
-		data->cb = cb;
-		data->userdata = userdata;
-	} else {
-		data->cb = NULL;
-		data->userdata = NULL;
-	}
-#endif
-	pm_device_busy_set(dev);
-
-	/* make sure we are currently the active controller */
-	if (!(sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE)) {
-		ret = -EACCES;
-		goto error;
-	}
-
-	/* wait for idle */
-	ret = cdns_i3c_wait_for_idle(dev);
-	if (ret != 0) {
-		goto error;
-	}
-
-	for (unsigned int i = 0; i < num_msgs; i++) {
-		struct cdns_i3c_cmd *cmd = &data->xfer.cmds[i];
-
-		cmd->len = msgs[i].len;
-		cmd->buf = msgs[i].buf;
-		/* not an i3c transfer, but must be set to sdr */
-		cmd->hdr = I3C_DATA_RATE_SDR;
-
-		cmd->cmd0 = CMD0_FIFO_PRIV_XMIT_MODE(XMIT_BURST_WITHOUT_SUBADDR);
-		cmd->cmd0 |= CMD0_FIFO_DEV_ADDR(i2c_dev->addr);
-		cmd->cmd0 |= CMD0_FIFO_PL_LEN(msgs[i].len);
-
-		/* Send repeated start on all transfers except the last or those marked STOP. */
-		if ((i < (num_msgs - 1)) && ((msgs[i].flags & I2C_MSG_STOP) == 0)) {
-			cmd->cmd0 |= CMD0_FIFO_RSBC;
-		}
-
-		if (msgs[i].flags & I2C_MSG_ADDR_10_BITS) {
-			cmd->cmd0 |= CMD0_FIFO_IS_10B;
-		}
-
-		if ((msgs[i].flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) {
-			cmd->cmd0 |= CMD0_FIFO_RNW;
-		}
-
-		/* i2c transfers are a don't care for num_xfer and sdr error */
-		cmd->num_xfer = NULL;
-		cmd->sdr_err = NULL;
-	}
-
-	data->xfer.ret = -ETIMEDOUT;
-	data->xfer.num_cmds = num_msgs;
-
-	xfer_timeout = cdns_i3c_calc_timeout_i2c(msgs, num_msgs,
-						  data->common.ctrl_config.scl.i2c);
-
-	cdns_i3c_start_transfer(dev);
-	if (!async) {
-		if (k_sem_take(&data->xfer.complete, xfer_timeout) != 0) {
-			cdns_i3c_cancel_transfer(dev);
-		}
-		ret = data->xfer.ret;
-	}
-#ifdef CONFIG_I2C_CALLBACK
-	else {
-		k_timer_start(&data->timeout, xfer_timeout, K_NO_WAIT);
-		ret = 0;
-	}
-#endif
-error:
-#ifdef CONFIG_I2C_CALLBACK
-	if (!async || ret != 0) {
-		pm_device_busy_clear(dev);
-		k_sem_give(&data->async_sem);
-	}
-#else
-	pm_device_busy_clear(dev);
-#endif
-	k_mutex_unlock(&data->bus_lock);
-
-	return ret;
-}
-
-/**
- * @brief Transfer messages in I2C mode.
- *
- * @see i2c_transfer
- *
- * @param dev Pointer to device driver instance.
- * @param i2c_dev Pointer to I2C device descriptor.
- * @param msgs Pointer to I2C messages.
- * @param num_msgs Number of messages to transfer.
- *
- * @return @see i2c_transfer
- */
-static int cdns_i3c_i2c_transfer(const struct device *dev, struct i3c_i2c_device_desc *i2c_dev,
-				 struct i2c_msg *msgs, uint8_t num_msgs)
-{
-	return cdns_i3c_i2c_transfer_do(dev, i2c_dev, msgs, num_msgs, false, NULL, NULL);
-}
-
-#ifdef CONFIG_I2C_CALLBACK
-/**
- * @brief Transfer messages in I2C mode with completion callback.
- *
- * @see i2c_transfer_cb
- *
- * @param dev Pointer to device driver instance.
- * @param i2c_dev Pointer to I2C device descriptor.
- * @param msgs Pointer to I2C messages.
- * @param num_msgs Number of messages to transfer.
- * @param cb Callback function
- * @param userdata User data for callback function
- *
- * @return @see i2c_transfer_cb
- */
-static int cdns_i3c_i2c_transfer_cb(const struct device *dev,
-				    struct i3c_i2c_device_desc *i2c_dev, struct i2c_msg *msgs,
-				    uint8_t num_msgs, i2c_callback_t cb, void *userdata)
-{
-	return cdns_i3c_i2c_transfer_do(dev, i2c_dev, msgs, num_msgs, true, cb, userdata);
-}
-#endif
 
 static int cdns_i3c_master_get_rr_slot(const struct device *dev, uint8_t dyn_addr)
 {
@@ -2618,218 +1006,6 @@ static int cdns_i3c_i2c_detach_device(const struct device *dev, struct i3c_i2c_d
 	return 0;
 }
 
-static int cdns_i3c_transfer_do(const struct device *dev, struct i3c_device_desc *target,
-				struct i3c_msg *msgs, uint8_t num_msgs, bool async,
-				i3c_callback_t cb, void *userdata)
-{
-	const struct cdns_i3c_config *config = dev->config;
-	struct cdns_i3c_data *data = dev->data;
-	int txsize = 0;
-	int rxsize = 0;
-	int ret;
-	k_timeout_t xfer_timeout;
-
-	__ASSERT_NO_MSG(num_msgs > 0);
-
-	if (num_msgs > data->hw_cfg.cmd_mem_depth || num_msgs > data->hw_cfg.cmdr_mem_depth) {
-		LOG_ERR("%s: Too many messages", dev->name);
-		return -ENOMEM;
-	}
-
-	/*
-	 * Ensure data will fit within FIFOs.
-	 *
-	 * TODO: This limitation prevents burst transfers greater than the
-	 *       FIFO sizes and should be replaced with an implementation that
-	 *       utilizes the RX/TX data interrupts.
-	 */
-	for (int i = 0; i < num_msgs; i++) {
-		if ((msgs[i].flags & I3C_MSG_RW_MASK) == I3C_MSG_READ) {
-			rxsize += ROUND_UP(msgs[i].len, 4);
-		} else {
-			txsize += ROUND_UP(msgs[i].len, 4);
-		}
-	}
-	if ((rxsize > data->hw_cfg.rx_mem_depth) || (txsize > data->hw_cfg.tx_mem_depth)) {
-		LOG_ERR("%s: Total RX and/or TX transfer larger than FIFO", dev->name);
-		return -ENOMEM;
-	}
-
-	k_mutex_lock(&data->bus_lock, K_FOREVER);
-#ifdef CONFIG_I3C_CALLBACK
-	k_sem_take(&data->async_sem, K_FOREVER);
-	if (async) {
-		data->cb = cb;
-		data->userdata = userdata;
-	} else {
-		data->cb = NULL;
-		data->userdata = NULL;
-	}
-#endif
-	pm_device_busy_set(dev);
-
-	/* make sure we are currently the active controller */
-	if (!(sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE)) {
-		ret = -EACCES;
-		goto error;
-	}
-
-	/* wait for idle */
-	ret = cdns_i3c_wait_for_idle(dev);
-	if (ret != 0) {
-		goto error;
-	}
-
-	/*
-	 * Prepare transfer commands. Currently there is only a single transfer
-	 * in-flight but it would be possible to keep a queue of transfers. If so,
-	 * this preparation could be completed outside of the bus lock allowing
-	 * greater parallelism.
-	 */
-	bool send_broadcast = true;
-
-	for (int i = 0; i < num_msgs; i++) {
-		struct cdns_i3c_cmd *cmd = &data->xfer.cmds[i];
-		uint32_t pl = msgs[i].len;
-		/* check hdr mode */
-		if ((!(msgs[i].flags & I3C_MSG_HDR)) ||
-		    ((msgs[i].flags & I3C_MSG_HDR) && (msgs[i].hdr_mode == 0))) {
-			/* HDR message flag is not set or if hdr flag is set but no hdr mode is set
-			 */
-			cmd->len = pl;
-			cmd->buf = msgs[i].buf;
-
-			cmd->cmd0 = CMD0_FIFO_PRIV_XMIT_MODE(XMIT_BURST_WITHOUT_SUBADDR);
-			cmd->cmd0 |= CMD0_FIFO_DEV_ADDR(target->dynamic_addr);
-			if ((msgs[i].flags & I3C_MSG_RW_MASK) == I3C_MSG_READ) {
-				cmd->cmd0 |= CMD0_FIFO_RNW;
-			}
-			/*
-			 * For I3C_XMIT_MODE_NO_ADDR reads in SDN mode,
-			 * CMD0_FIFO_PL_LEN specifies the abort limit not bytes to read
-			 */
-			cmd->cmd0 |= CMD0_FIFO_PL_LEN(pl);
-
-			/* Send broadcast header on first transfer or after a STOP. */
-			if (!(msgs[i].flags & I3C_MSG_NBCH) && (send_broadcast)) {
-				cmd->cmd0 |= CMD0_FIFO_BCH;
-				send_broadcast = false;
-			}
-
-			/*
-			 * Send repeated start on all transfers except the last or those marked
-			 * STOP.
-			 */
-			if ((i < (num_msgs - 1)) && ((msgs[i].flags & I3C_MSG_STOP) == 0)) {
-				cmd->cmd0 |= CMD0_FIFO_RSBC;
-			} else {
-				send_broadcast = true;
-			}
-
-			/*
-			 * write the address of num_xfer which is to be updated upon message
-			 * completion
-			 */
-			cmd->num_xfer = &(msgs[i].num_xfer);
-			cmd->sdr_err = &(msgs[i].err);
-			cmd->hdr = I3C_DATA_RATE_SDR;
-		} else if ((data->common.ctrl_config.supported_hdr & I3C_MSG_HDR_DDR) &&
-			   (msgs[i].hdr_mode == I3C_MSG_HDR_DDR) && (msgs[i].flags & I3C_MSG_HDR)) {
-			uint16_t ddr_header_payload;
-
-			/* DDR sends data out in 16b, so len must be a multiple of 2 */
-			if (!((pl % 2) == 0)) {
-				ret = -EINVAL;
-				goto error;
-			}
-			/* HDR message flag is set and hdr mode is DDR */
-			cmd->buf = msgs[i].buf;
-			if ((msgs[i].flags & I3C_MSG_RW_MASK) == I3C_MSG_READ) {
-				/* HDR-DDR Read */
-				ddr_header_payload = HDR_CMD_RD |
-						     HDR_CMD_CODE(msgs[i].hdr_cmd_code) |
-						     (target->dynamic_addr << 1);
-				/* Parity Adjustment Bit for Reads */
-				ddr_header_payload =
-					prepare_ddr_cmd_parity_adjustment_bit(ddr_header_payload);
-				/* HDR-DDR Command Word */
-				cmd->ddr_header =
-					DDR_PREAMBLE_CMD_CRC | prepare_ddr_word(ddr_header_payload);
-			} else {
-				uint8_t crc5 = 0x1F;
-				/* HDR-DDR Write */
-				ddr_header_payload = HDR_CMD_CODE(msgs[i].hdr_cmd_code) |
-						     (target->dynamic_addr << 1);
-				/* HDR-DDR Command Word */
-				cmd->ddr_header =
-					DDR_PREAMBLE_CMD_CRC | prepare_ddr_word(ddr_header_payload);
-				/* calculate crc5 */
-				crc5 = i3c_cdns_crc5(crc5, ddr_header_payload);
-				for (int j = 0; j < pl; j += 2) {
-					crc5 = i3c_cdns_crc5(
-						crc5,
-						sys_get_be16((void *)((uintptr_t)cmd->buf + j)));
-				}
-				cmd->ddr_crc = DDR_PREAMBLE_CMD_CRC | DDR_CRC_TOKEN | (crc5 << 9) |
-					       DDR_CRC_WR_SETUP;
-			}
-			/* Length of DDR Transfer is length of payload (in 16b) + header and CRC
-			 * blocks
-			 */
-			cmd->len = ((pl / 2) + 2);
-
-			/* prep command FIFO for ENTHDR0 */
-			cmd->cmd0 = CMD0_FIFO_IS_CCC;
-			cmd->cmd1 = I3C_CCC_ENTHDR0;
-			/* write the address of num_xfer which is to be updated upon message
-			 * completion
-			 */
-			cmd->num_xfer = &(msgs[i].num_xfer);
-			cmd->sdr_err = &(msgs[i].err);
-			cmd->hdr = I3C_DATA_RATE_HDR_DDR;
-		} else {
-			LOG_ERR("%s: Unsupported HDR Mode %d", dev->name, msgs[i].hdr_mode);
-			ret = -ENOTSUP;
-			goto error;
-		}
-	}
-
-	data->xfer.ret = -ETIMEDOUT;
-	data->xfer.num_cmds = num_msgs;
-
-	xfer_timeout = cdns_i3c_calc_timeout_i3c(msgs, num_msgs,
-						  data->common.ctrl_config.scl.i3c);
-
-	cdns_i3c_start_transfer(dev);
-	if (!async) {
-		if (k_sem_take(&data->xfer.complete, xfer_timeout) != 0) {
-			LOG_ERR("%s: transfer timed out", dev->name);
-			cdns_i3c_cancel_transfer(dev);
-		}
-	}
-#ifdef CONFIG_I3C_CALLBACK
-	else {
-		k_timer_start(&data->timeout, xfer_timeout, K_NO_WAIT);
-	}
-#endif
-	if (!async) {
-		ret = data->xfer.ret;
-	} else {
-		ret = 0;
-	}
-error:
-#ifdef CONFIG_I3C_CALLBACK
-	if (!async || ret != 0) {
-		pm_device_busy_clear(dev);
-		k_sem_give(&data->async_sem);
-	}
-#else
-	pm_device_busy_clear(dev);
-#endif
-	k_mutex_unlock(&data->bus_lock);
-
-	return ret;
-}
 
 /**
  * @brief Transfer messages in I3C mode.
@@ -2846,7 +1022,13 @@ error:
 static int cdns_i3c_transfer(const struct device *dev, struct i3c_device_desc *target,
 			     struct i3c_msg *msgs, uint8_t num_msgs)
 {
+#ifdef CONFIG_I3C_CADENCE_RTIO
+	struct cdns_i3c_data *data = dev->data;
+
+	return i3c_rtio_transfer(data->rtio->i3c_ctx, msgs, num_msgs, target);
+#else
 	return cdns_i3c_transfer_do(dev, target, msgs, num_msgs, false, NULL, NULL);
+#endif
 }
 
 #ifdef CONFIG_I3C_CALLBACK
@@ -2868,7 +1050,14 @@ static int cdns_i3c_transfer_cb(const struct device *dev, struct i3c_device_desc
 				struct i3c_msg *msgs, uint8_t num_msgs, i3c_callback_t cb,
 				void *userdata)
 {
+#ifdef CONFIG_I3C_CADENCE_RTIO
+	struct cdns_i3c_data *data = dev->data;
+
+	return i3c_rtio_transfer_cb(data->rtio->i3c_ctx, dev, msgs, num_msgs, target, cb,
+				    userdata);
+#else
 	return cdns_i3c_transfer_do(dev, target, msgs, num_msgs, true, cb, userdata);
+#endif
 }
 #endif
 #endif /* CONFIG_I3C_CONTROLLER */
@@ -3120,10 +1309,22 @@ static void cdns_i3c_irq_handler(const struct device *dev)
 		LOG_WRN("Core Halted, 2 read aborts");
 	}
 
+#ifdef CONFIG_I3C_CADENCE_RTIO
+	if (int_st & MST_INT_TX_THR) {
+		cdns_i3c_rtio_irq_tx_thr(dev);
+	}
+	if (int_st & MST_INT_RX_THR) {
+		cdns_i3c_rtio_irq_rx_thr(dev);
+	}
+	if (int_st & MST_INT_CMDD_EMP) {
+		cdns_i3c_rtio_irq_cmdd_emp(dev);
+	}
+#else
 	/* Command queue empty */
 	if (int_st & MST_INT_CMDD_EMP) {
 		cdns_i3c_complete_transfer(dev);
 	}
+#endif
 
 	/* In-band interrupt */
 	if (int_st & MST_INT_IBIR_THR) {
@@ -3179,12 +1380,27 @@ static void cdns_i3c_irq_handler(const struct device *dev)
 
 	/* SLV SDR rx fifo threshold */
 	if (int_sl & SLV_INT_SDR_RX_THR) {
-		/* while rx fifo is not empty */
-		while (!(sys_read32(config->base + SLV_STATUS1) & SLV_STATUS1_SDR_RX_EMPTY)) {
+#ifdef CONFIG_I3C_TARGET_BUFFER_MODE
+		/* Buffer mode: accumulate into target_rx_buf,
+		 * deliver in bulk at WR_COMP.
+		 */
+		while (!(sys_read32(config->base + SLV_STATUS1) &
+			 SLV_STATUS1_SDR_RX_EMPTY)) {
+			if (data->target_rx_len < sizeof(data->target_rx_buf)) {
+				data->target_rx_buf[data->target_rx_len++] =
+					(uint8_t)sys_read32(config->base + RX_FIFO);
+			} else {
+				(void)sys_read32(config->base + RX_FIFO);
+			}
+		}
+#else
+		while (!(sys_read32(config->base + SLV_STATUS1) &
+			 SLV_STATUS1_SDR_RX_EMPTY)) {
 			if (target_cb != NULL && target_cb->write_received_cb != NULL) {
 				cdns_i3c_target_read_rx_fifo(dev);
 			}
 		}
+#endif /* CONFIG_I3C_TARGET_BUFFER_MODE */
 	}
 
 	/* SLV SDR tx fifo threshold */
@@ -3194,9 +1410,7 @@ static void cdns_i3c_irq_handler(const struct device *dev)
 
 	/* SLV SDR rx complete */
 	if (int_sl & SLV_INT_SDR_RD_COMP) {
-		/* a read needs to be done on slv_status 0 else a NACK will happen */
 		(void)sys_read32(config->base + SLV_STATUS0);
-		/* call stop function pointer */
 		if (target_cb != NULL && target_cb->stop_cb) {
 			target_cb->stop_cb(data->target_config);
 		}
@@ -3204,11 +1418,36 @@ static void cdns_i3c_irq_handler(const struct device *dev)
 
 	/* SLV SDR tx complete */
 	if (int_sl & SLV_INT_SDR_WR_COMP) {
-		/* a read needs to be done on slv_status 0 else a NACK will happen */
 		(void)sys_read32(config->base + SLV_STATUS0);
-		/* clear bytes read parameter */
+#ifdef CONFIG_I3C_TARGET_BUFFER_MODE
+		/* Drain any tail bytes and deliver the complete buffer */
+		while (!(sys_read32(config->base + SLV_STATUS1) &
+			 SLV_STATUS1_SDR_RX_EMPTY)) {
+			if (data->target_rx_len < sizeof(data->target_rx_buf)) {
+				data->target_rx_buf[data->target_rx_len++] =
+					(uint8_t)sys_read32(config->base + RX_FIFO);
+			} else {
+				(void)sys_read32(config->base + RX_FIFO);
+			}
+		}
+		if (target_cb != NULL && target_cb->buf_write_received_cb != NULL) {
+			target_cb->buf_write_received_cb(data->target_config,
+							 data->target_rx_buf,
+							 data->target_rx_len);
+		}
+		data->target_rx_len = 0;
+#else
+		/* Drain any remaining bytes from the RX FIFO */
+		while (!(sys_read32(config->base + SLV_STATUS1) &
+			 SLV_STATUS1_SDR_RX_EMPTY)) {
+			if (target_cb != NULL && target_cb->write_received_cb != NULL) {
+				cdns_i3c_target_read_rx_fifo(dev);
+			} else {
+				(void)sys_read32(config->base + RX_FIFO);
+			}
+		}
+#endif /* CONFIG_I3C_TARGET_BUFFER_MODE */
 		data->fifo_bytes_read = 0;
-		/* call stop function pointer */
 		if (target_cb != NULL && target_cb->stop_cb) {
 			target_cb->stop_cb(data->target_config);
 		}
@@ -3688,23 +1927,6 @@ static struct i3c_device_desc *cdns_i3c_device_find(const struct device *dev,
 	return i3c_dev_list_find(&config->common.dev_list, id);
 }
 
-/**
- * Find a registered I2C target device.
- *
- * Controller only API.
- *
- * This returns the I2C device descriptor of the I2C device
- * matching the device address @p addr.
- *
- * @param dev Pointer to controller device driver instance.
- * @param id I2C target device address.
- *
- * @return @see i3c_i2c_device_find.
- */
-static struct i3c_i2c_device_desc *cdns_i3c_i2c_device_find(const struct device *dev, uint16_t addr)
-{
-	return i3c_dev_list_i2c_addr_find(dev, addr);
-}
 #endif
 #ifdef CONFIG_I3C_CONTROLLER
 /**
@@ -3722,6 +1944,11 @@ static struct i3c_i2c_device_desc *cdns_i3c_i2c_device_find(const struct device 
 static int cdns_i3c_i2c_api_transfer(const struct device *dev, struct i2c_msg *msgs,
 				     uint8_t num_msgs, uint16_t addr)
 {
+#ifdef CONFIG_I3C_CADENCE_RTIO
+	struct cdns_i3c_data *data = dev->data;
+
+	return i2c_rtio_transfer(data->rtio->i2c_ctx, msgs, num_msgs, addr);
+#else
 	struct i3c_i2c_device_desc *i2c_dev = cdns_i3c_i2c_device_find(dev, addr);
 	int ret;
 
@@ -3732,6 +1959,7 @@ static int cdns_i3c_i2c_api_transfer(const struct device *dev, struct i2c_msg *m
 	}
 
 	return ret;
+#endif
 }
 
 #ifdef CONFIG_I2C_CALLBACK
@@ -3739,6 +1967,11 @@ static int cdns_i3c_i2c_api_transfer_cb(const struct device *dev, struct i2c_msg
 					uint8_t num_msgs, uint16_t addr, i2c_callback_t cb,
 					void *userdata)
 {
+#ifdef CONFIG_I3C_CADENCE_RTIO
+	struct cdns_i3c_data *data = dev->data;
+
+	return i2c_rtio_transfer_cb(data->rtio->i2c_ctx, dev, msgs, num_msgs, addr, cb, userdata);
+#else
 	struct i3c_i2c_device_desc *i2c_dev = cdns_i3c_i2c_device_find(dev, addr);
 
 	if (i2c_dev == NULL) {
@@ -3746,6 +1979,7 @@ static int cdns_i3c_i2c_api_transfer_cb(const struct device *dev, struct i2c_msg
 	}
 
 	return cdns_i3c_i2c_transfer_cb(dev, i2c_dev, msgs, num_msgs, cb, userdata);
+#endif
 }
 #endif /* CONFIG_I2C_CALLBACK */
 #endif /* CONFIG_I3C_CONTROLLER */
@@ -3942,7 +2176,15 @@ static int cdns_i3c_bus_init(const struct device *dev)
 #endif /* CONFIG_I3C_USE_IBI */
 #if defined(CONFIG_I3C_CONTROLLER) && (defined(CONFIG_I3C_CALLBACK) || defined(CONFIG_I2C_CALLBACK))
 	k_sem_init(&data->async_sem, 1, 1);
+#ifndef CONFIG_I3C_CADENCE_RTIO
+	/*
+	 * The legacy hw-driving path uses k_timer to bound the async transfer.
+	 * The native RTIO path doesn't have an equivalent watchdog (yet) and
+	 * doesn't reference cdns_i3c_cb_timeout — which lives in i3c_cdns_legacy.c
+	 * and isn't compiled when CADENCE_RTIO=y.
+	 */
 	k_timer_init(&data->timeout, cdns_i3c_cb_timeout, NULL);
+#endif
 #endif /* CONFIG_I3C_CONTROLLER && (CONFIG_I3C_CALLBACK || CONFIG_I2C_CALLBACK) */
 
 	cdns_i3c_interrupts_disable(config);
@@ -4018,15 +2260,6 @@ static int cdns_i3c_bus_init(const struct device *dev)
 			    IBIR_THR(I3C_IBIR_THR),
 		    config->base + CMD_IBI_THR_CTRL);
 
-	/* Set TX/RX interrupt thresholds. */
-	if (sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE) {
-		sys_write32(TX_THR(I3C_TX_THR) | RX_THR(data->hw_cfg.rx_mem_depth),
-			    config->base + TX_RX_THR_CTRL);
-	} else {
-		sys_write32(TX_THR(1) | RX_THR(1), config->base + TX_RX_THR_CTRL);
-		sys_write32(SLV_DDR_TX_THR(0) | SLV_DDR_RX_THR(1),
-			    config->base + SLV_DDR_TX_RX_THR_CTRL);
-	}
 #ifdef CONFIG_I3C_TARGET
 	/* enable target interrupts */
 	sys_write32(SLV_INT_DA_UPD | SLV_INT_SDR_RD_COMP | SLV_INT_SDR_WR_COMP |
@@ -4047,6 +2280,38 @@ static int cdns_i3c_bus_init(const struct device *dev)
 	if (ret != 0) {
 		return ret;
 	}
+
+#ifdef CONFIG_I3C_CADENCE_RTIO
+	ret = cdns_i3c_rtio_init(dev);
+	if (ret != 0) {
+		return ret;
+	}
+	/* Override master-mode TX/RX thresholds for RTIO streaming.
+	 * Half-FIFO thresholds let each TX_THR/RX_THR IRQ move a useful
+	 * chunk of bytes. Target-mode thresholds are left as-is.
+	 */
+	if (sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE) {
+		uint32_t tx_thr = MAX(data->hw_cfg.tx_mem_depth / sizeof(uint32_t) / 2, 1U);
+		uint32_t rx_thr = MAX(data->hw_cfg.rx_mem_depth / sizeof(uint32_t) / 2, 1U);
+
+		sys_write32(TX_THR(tx_thr) | RX_THR(rx_thr),
+			    config->base + TX_RX_THR_CTRL);
+	} else {
+		sys_write32(TX_THR(1) | RX_THR(1), config->base + TX_RX_THR_CTRL);
+		sys_write32(SLV_DDR_TX_THR(0) | SLV_DDR_RX_THR(1),
+			    config->base + SLV_DDR_TX_RX_THR_CTRL);
+	}
+#else
+	/* Set TX/RX interrupt thresholds. */
+	if (sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE) {
+		sys_write32(TX_THR(I3C_TX_THR) | RX_THR(data->hw_cfg.rx_mem_depth),
+			    config->base + TX_RX_THR_CTRL);
+	} else {
+		sys_write32(TX_THR(1) | RX_THR(1), config->base + TX_RX_THR_CTRL);
+		sys_write32(SLV_DDR_TX_THR(0) | SLV_DDR_RX_THR(1),
+			    config->base + SLV_DDR_TX_RX_THR_CTRL);
+	}
+#endif
 
 	/* only primary controllers are responsible for initializing the bus */
 	if (!ctrl_config->is_secondary) {
@@ -4079,7 +2344,11 @@ static DEVICE_API(i3c, api) = {
 	.i2c_api.transfer_cb = cdns_i3c_i2c_api_transfer_cb,
 #endif
 #ifdef CONFIG_I2C_RTIO
+#ifdef CONFIG_I3C_CADENCE_RTIO
+	.i2c_api.iodev_submit = cdns_i3c_i2c_iodev_submit,
+#else
 	.i2c_api.iodev_submit = i2c_iodev_submit_fallback,
+#endif
 #endif
 #endif /* CONFIG_I3C_CONTROLLER */
 
@@ -4125,9 +2394,29 @@ static DEVICE_API(i3c, api) = {
 #endif
 
 #ifdef CONFIG_I3C_RTIO
+#ifdef CONFIG_I3C_CADENCE_RTIO
+	.iodev_submit = cdns_i3c_iodev_submit,
+#else
 	.iodev_submit = i3c_iodev_submit_fallback,
 #endif
+#endif
 };
+
+#ifdef CONFIG_I3C_CADENCE_RTIO
+#define CADENCE_I3C_RTIO_DEFINE(n)                                                                 \
+	I3C_RTIO_DEFINE(_cdns_i3c##n##_rtio_ctx, CONFIG_I3C_RTIO_SQ_SIZE,                          \
+			CONFIG_I3C_RTIO_CQ_SIZE);                                                  \
+	I2C_RTIO_DEFINE(_cdns_i3c##n##_i2c_rtio_ctx, CONFIG_I2C_RTIO_SQ_SIZE,                      \
+			CONFIG_I2C_RTIO_CQ_SIZE);                                                  \
+	static struct cdns_i3c_rtio_state _cdns_i3c##n##_rtio_state = {                            \
+		.i3c_ctx = &_cdns_i3c##n##_rtio_ctx,                                               \
+		.i2c_ctx = &_cdns_i3c##n##_i2c_rtio_ctx,                                           \
+	};
+#define CADENCE_I3C_RTIO_DATA_INIT(n) .rtio = &_cdns_i3c##n##_rtio_state,
+#else
+#define CADENCE_I3C_RTIO_DEFINE(n)
+#define CADENCE_I3C_RTIO_DATA_INIT(n)
+#endif
 
 #define CADENCE_I3C_INSTANTIATE(n)                                                                 \
 	static void cdns_i3c_config_func_##n(const struct device *dev);                            \
@@ -4135,6 +2424,7 @@ static DEVICE_API(i3c, api) = {
 	(static struct i3c_device_desc cdns_i3c_device_array_##n[] = I3C_DEVICE_ARRAY_DT_INST(n);  \
 	static struct i3c_i2c_device_desc cdns_i3c_i2c_device_array_##n[] =                        \
 		I3C_I2C_DEVICE_ARRAY_DT_INST(n);))                                                 \
+	CADENCE_I3C_RTIO_DEFINE(n)                                                                 \
 	static const struct cdns_i3c_config i3c_config_##n = {                                     \
 		.base = DT_INST_REG_ADDR(n),                                                       \
 		.input_frequency = DT_INST_PROP(n, input_clock_frequency),                         \
@@ -4157,6 +2447,7 @@ static DEVICE_API(i3c, api) = {
 				DT_INST_PROP(n, od_thigh_min_ns),                                  \
 			.common.ctrl_config.scl_od_min.low_ns =                                    \
 				DT_INST_PROP(n, od_tlow_min_ns),))                                 \
+		CADENCE_I3C_RTIO_DATA_INIT(n)                                                      \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(n, cdns_i3c_bus_init, NULL, &i3c_data_##n, &i3c_config_##n,          \
 			      POST_KERNEL, CONFIG_I3C_CONTROLLER_INIT_PRIORITY, &api);             \

--- a/drivers/i3c/i3c_cdns.h
+++ b/drivers/i3c/i3c_cdns.h
@@ -1,0 +1,843 @@
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and its affiliates.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_I3C_I3C_CDNS_H_
+#define ZEPHYR_DRIVERS_I3C_I3C_CDNS_H_
+
+#include <errno.h>
+#include <stdint.h>
+
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
+
+#define DEV_ID            0x0
+#define DEV_ID_I3C_MASTER 0x5034
+
+#define CONF_STATUS0                      0x4
+#define CONF_STATUS0_CMDR_DEPTH(x)        (4 << (((x) & GENMASK(31, 29)) >> 29))
+#define CONF_STATUS0_ECC_CHK              BIT(28)
+#define CONF_STATUS0_INTEG_CHK            BIT(27)
+#define CONF_STATUS0_CSR_DAP_CHK          BIT(26)
+#define CONF_STATUS0_TRANS_TOUT_CHK       BIT(25)
+#define CONF_STATUS0_PROT_FAULTS_CHK      BIT(24)
+#define CONF_STATUS0_GPO_NUM(x)           (((x) & GENMASK(23, 16)) >> 16)
+#define CONF_STATUS0_GPI_NUM(x)           (((x) & GENMASK(15, 8)) >> 8)
+#define CONF_STATUS0_IBIR_DEPTH(x)        (4 << (((x) & GENMASK(7, 6)) >> 6))
+/* CONF_STATUS0_SUPPORTS_DDR moved to CONF_STATUS1 in rev >= 1p7 */
+#define CONF_STATUS0_SUPPORTS_DDR         BIT(5)
+#define CONF_STATUS0_SEC_MASTER           BIT(4)
+/* And it was replaced with a Dev Role mask */
+#define CONF_STATUS0_DEV_ROLE(x)          (((x) & GENMASK(5, 4)) >> 4)
+#define CONF_STATUS0_DEV_ROLE_MAIN_MASTER 0
+#define CONF_STATUS0_DEV_ROLE_SEC_MASTER  1
+#define CONF_STATUS0_DEV_ROLE_SLAVE       2
+#define CONF_STATUS0_DEVS_NUM(x)          ((x) & GENMASK(3, 0))
+
+#define CONF_STATUS1                     0x8
+#define CONF_STATUS1_IBI_HW_RES(x)       ((((x) & GENMASK(31, 28)) >> 28) + 1)
+#define CONF_STATUS1_CMD_DEPTH(x)        (4 << (((x) & GENMASK(27, 26)) >> 26))
+#define CONF_STATUS1_SLV_DDR_RX_DEPTH(x) (8 << (((x) & GENMASK(25, 21)) >> 21))
+#define CONF_STATUS1_SLV_DDR_TX_DEPTH(x) (8 << (((x) & GENMASK(20, 16)) >> 16))
+#define CONF_STATUS1_SUPPORTS_DDR        BIT(14)
+#define CONF_STATUS1_ALT_MODE            BIT(13)
+#define CONF_STATUS1_IBI_DEPTH(x)        (2 << (((x) & GENMASK(12, 10)) >> 10))
+#define CONF_STATUS1_RX_DEPTH(x)         (8 << (((x) & GENMASK(9, 5)) >> 5))
+#define CONF_STATUS1_TX_DEPTH(x)         (8 << ((x) & GENMASK(4, 0)))
+
+#define REV_ID               0xc
+#define REV_ID_VID(id)       (((id) & GENMASK(31, 20)) >> 20)
+#define REV_ID_PID(id)       (((id) & GENMASK(19, 8)) >> 8)
+#define REV_ID_REV(id)       ((id) & GENMASK(7, 0))
+#define REV_ID_VERSION(m, n) (((m) << 5) | (n))
+#define REV_ID_REV_MAJOR(id) (((id) & GENMASK(7, 5)) >> 5)
+#define REV_ID_REV_MINOR(id) ((id) & GENMASK(4, 0))
+
+#define CTRL                     0x10
+#define CTRL_DEV_EN              BIT(31)
+#define CTRL_HALT_EN             BIT(30)
+#define CTRL_MCS                 BIT(29)
+#define CTRL_MCS_EN              BIT(28)
+#define CTRL_I3C_11_SUPP         BIT(26)
+#define CTRL_THD_DELAY(x)        (((x) << 24) & GENMASK(25, 24))
+#define CTRL_TC_EN               BIT(9)
+#define CTRL_HJ_DISEC            BIT(8)
+#define CTRL_MST_ACK             BIT(7)
+#define CTRL_HJ_ACK              BIT(6)
+#define CTRL_HJ_INIT             BIT(5)
+#define CTRL_MST_INIT            BIT(4)
+#define CTRL_AHDR_OPT            BIT(3)
+#define CTRL_PURE_BUS_MODE       0
+#define CTRL_MIXED_FAST_BUS_MODE 2
+#define CTRL_MIXED_SLOW_BUS_MODE 3
+#define CTRL_BUS_MODE_MASK       GENMASK(1, 0)
+#define THD_DELAY_MAX            3
+
+#define PRESCL_CTRL0         0x14
+#define PRESCL_CTRL0_I2C(x)  ((x) << 16)
+#define PRESCL_CTRL0_I3C(x)  (x)
+#define PRESCL_CTRL0_I3C_MAX GENMASK(9, 0)
+#define PRESCL_CTRL0_I2C_MAX GENMASK(15, 0)
+
+#define PRESCL_CTRL1             0x18
+#define PRESCL_CTRL1_PP_LOW_MASK GENMASK(15, 8)
+#define PRESCL_CTRL1_PP_LOW(x)   ((x) << 8)
+#define PRESCL_CTRL1_OD_LOW_MASK GENMASK(7, 0)
+#define PRESCL_CTRL1_OD_LOW(x)   (x)
+
+#define SLV_STATUS4                 0x1C
+#define SLV_STATUS4_BUSCON_FILL_LVL GENMASK(16, 8)
+#define SLV_STATUS5_BUSCON_DATA     GENMASK(7, 0)
+
+#define MST_IER           0x20
+#define MST_IDR           0x24
+#define MST_IMR           0x28
+#define MST_ICR           0x2c
+#define MST_ISR           0x30
+#define MST_INT_HALTED    BIT(18)
+#define MST_INT_MR_DONE   BIT(17)
+#define MST_INT_IMM_COMP  BIT(16)
+#define MST_INT_TX_THR    BIT(15)
+#define MST_INT_TX_OVF    BIT(14)
+#define MST_INT_C_REF_ROV BIT(13)
+#define MST_INT_IBID_THR  BIT(12)
+#define MST_INT_IBID_UNF  BIT(11)
+#define MST_INT_IBIR_THR  BIT(10)
+#define MST_INT_IBIR_UNF  BIT(9)
+#define MST_INT_IBIR_OVF  BIT(8)
+#define MST_INT_RX_THR    BIT(7)
+#define MST_INT_RX_UNF    BIT(6)
+#define MST_INT_CMDD_EMP  BIT(5)
+#define MST_INT_CMDD_THR  BIT(4)
+#define MST_INT_CMDD_OVF  BIT(3)
+#define MST_INT_CMDR_THR  BIT(2)
+#define MST_INT_CMDR_UNF  BIT(1)
+#define MST_INT_CMDR_OVF  BIT(0)
+#define MST_INT_MASK      GENMASK(18, 0)
+
+#define MST_STATUS0             0x34
+#define MST_STATUS0_IDLE        BIT(18)
+#define MST_STATUS0_HALTED      BIT(17)
+#define MST_STATUS0_MASTER_MODE BIT(16)
+#define MST_STATUS0_TX_FULL     BIT(13)
+#define MST_STATUS0_IBID_FULL   BIT(12)
+#define MST_STATUS0_IBIR_FULL   BIT(11)
+#define MST_STATUS0_RX_FULL     BIT(10)
+#define MST_STATUS0_CMDD_FULL   BIT(9)
+#define MST_STATUS0_CMDR_FULL   BIT(8)
+#define MST_STATUS0_TX_EMP      BIT(5)
+#define MST_STATUS0_IBID_EMP    BIT(4)
+#define MST_STATUS0_IBIR_EMP    BIT(3)
+#define MST_STATUS0_RX_EMP      BIT(2)
+#define MST_STATUS0_CMDD_EMP    BIT(1)
+#define MST_STATUS0_CMDR_EMP    BIT(0)
+
+#define CMDR                    0x38
+#define CMDR_NO_ERROR           0
+#define CMDR_DDR_PREAMBLE_ERROR 1
+#define CMDR_DDR_PARITY_ERROR   2
+#define CMDR_DDR_RX_FIFO_OVF    3
+#define CMDR_DDR_TX_FIFO_UNF    4
+#define CMDR_M0_ERROR           5
+#define CMDR_M1_ERROR           6
+#define CMDR_M2_ERROR           7
+#define CMDR_MST_ABORT          8
+#define CMDR_NACK_RESP          9
+#define CMDR_INVALID_DA         10
+#define CMDR_DDR_DROPPED        11
+#define CMDR_ERROR(x)           (((x) & GENMASK(27, 24)) >> 24)
+#define CMDR_XFER_BYTES(x)      (((x) & GENMASK(19, 8)) >> 8)
+#define CMDR_CMDID_HJACK_DISEC  0xfe
+#define CMDR_CMDID_HJACK_ENTDAA 0xff
+#define CMDR_CMDID(x)           ((x) & GENMASK(7, 0))
+
+#define IBIR               0x3c
+#define IBIR_ACKED         BIT(12)
+#define IBIR_SLVID(x)      (((x) & GENMASK(11, 8)) >> 8)
+#define IBIR_SLVID_INV     0xF
+#define IBIR_ERROR         BIT(7)
+#define IBIR_XFER_BYTES(x) (((x) & GENMASK(6, 2)) >> 2)
+#define IBIR_TYPE_IBI      0
+#define IBIR_TYPE_HJ       1
+#define IBIR_TYPE_MR       2
+#define IBIR_TYPE(x)       ((x) & GENMASK(1, 0))
+
+#define SLV_IER             0x40
+#define SLV_IDR             0x44
+#define SLV_IMR             0x48
+#define SLV_ICR             0x4c
+#define SLV_ISR             0x50
+#define SLV_INT_CHIP_RST    BIT(31)
+#define SLV_INT_PERIPH_RST  BIT(30)
+#define SLV_INT_FLUSH_DONE  BIT(29)
+#define SLV_INT_RST_DAA     BIT(28)
+#define SLV_INT_BUSCON_UP   BIT(26)
+#define SLV_INT_MRL_UP      BIT(25)
+#define SLV_INT_MWL_UP      BIT(24)
+#define SLV_INT_IBI_THR     BIT(23)
+#define SLV_INT_IBI_DONE    BIT(22)
+#define SLV_INT_DEFSLVS     BIT(21)
+#define SLV_INT_TM          BIT(20)
+#define SLV_INT_ERROR       BIT(19)
+#define SLV_INT_EVENT_UP    BIT(18)
+#define SLV_INT_HJ_DONE     BIT(17)
+#define SLV_INT_MR_DONE     BIT(16)
+#define SLV_INT_DA_UPD      BIT(15)
+#define SLV_INT_SDR_FAIL    BIT(14)
+#define SLV_INT_DDR_FAIL    BIT(13)
+#define SLV_INT_M_RD_ABORT  BIT(12)
+#define SLV_INT_DDR_RX_THR  BIT(11)
+#define SLV_INT_DDR_TX_THR  BIT(10)
+#define SLV_INT_SDR_RX_THR  BIT(9)
+#define SLV_INT_SDR_TX_THR  BIT(8)
+#define SLV_INT_DDR_RX_UNF  BIT(7)
+#define SLV_INT_DDR_TX_OVF  BIT(6)
+#define SLV_INT_SDR_RX_UNF  BIT(5)
+#define SLV_INT_SDR_TX_OVF  BIT(4)
+#define SLV_INT_DDR_RD_COMP BIT(3)
+#define SLV_INT_DDR_WR_COMP BIT(2)
+#define SLV_INT_SDR_RD_COMP BIT(1)
+#define SLV_INT_SDR_WR_COMP BIT(0)
+
+#define SLV_STATUS0                   0x54
+#define SLV_STATUS0_IBI_XFRD_BYTEs(s) (((s) & GENMASK(31, 24)) >> 24)
+#define SLV_STATUS0_REG_ADDR(s)       (((s) & GENMASK(23, 16)) >> 16)
+#define SLV_STATUS0_XFRD_BYTES(s)     ((s) & GENMASK(15, 0))
+
+#define SLV_STATUS1              0x58
+#define SLV_STATUS1_SCL_IN_RST   BIT(31)
+#define SLV_STATUS1_HJ_IN_USE    BIT(30)
+#define SLV_STATUS1_NACK_NXT_PW  BIT(29)
+#define SLV_STATUS1_NACK_NXT_PR  BIT(28)
+#define SLV_STATUS1_MR_PEND      BIT(27)
+#define SLV_STATUS1_HJ_PEND      BIT(26)
+#define SLV_STATUS1_IBI_PEND     BIT(25)
+#define SLV_STATUS1_IBI_DIS      BIT(24)
+#define SLV_STATUS1_BUS_VAR      BIT(23)
+#define SLV_STATUS1_TCAM0_DIS    BIT(22)
+#define SLV_STATUS1_AS(s)        (((s) & GENMASK(21, 20)) >> 20)
+#define SLV_STATUS1_VEN_TM       BIT(19)
+#define SLV_STATUS1_HJ_DIS       BIT(18)
+#define SLV_STATUS1_MR_DIS       BIT(17)
+#define SLV_STATUS1_PROT_ERR     BIT(16)
+#define SLV_STATUS1_DA(s)        (((s) & GENMASK(15, 9)) >> 9)
+#define SLV_STATUS1_HAS_DA       BIT(8)
+#define SLV_STATUS1_DDR_RX_FULL  BIT(7)
+#define SLV_STATUS1_DDR_TX_FULL  BIT(6)
+#define SLV_STATUS1_DDR_RX_EMPTY BIT(5)
+#define SLV_STATUS1_DDR_TX_EMPTY BIT(4)
+#define SLV_STATUS1_SDR_RX_FULL  BIT(3)
+#define SLV_STATUS1_SDR_TX_FULL  BIT(2)
+#define SLV_STATUS1_SDR_RX_EMPTY BIT(1)
+#define SLV_STATUS1_SDR_TX_EMPTY BIT(0)
+
+#define SLV_IBI_CTRL               0x5c
+#define SLV_IBI_TCAM_EVNT(x)       ((x) << 27)
+#define SLV_IBI_PL(x)              ((x) << 16)
+#define SLV_IBI_TCAM0              BIT(9)
+#define SLV_IBI_REQ                BIT(8)
+#define SLV_IBI_AUTO_CLR_IBI       1
+#define SLV_IBI_AUTO_CLR_PR        2
+#define SLV_IBI_AUTO_CLR_IBI_OR_PR 3
+#define SLV_IBI_CLEAR_TRIGGER(x)   ((x) << 4)
+
+#define CMD0_FIFO                   0x60
+#define CMD0_FIFO_IS_DDR            BIT(31)
+#define CMD0_FIFO_IS_CCC            BIT(30)
+#define CMD0_FIFO_BCH               BIT(29)
+#define XMIT_BURST_STATIC_SUBADDR   0
+#define XMIT_SINGLE_INC_SUBADDR     1
+#define XMIT_SINGLE_STATIC_SUBADDR  2
+#define XMIT_BURST_WITHOUT_SUBADDR  3
+#define CMD0_FIFO_PRIV_XMIT_MODE(m) ((m) << 27)
+#define CMD0_FIFO_SBCA              BIT(26)
+#define CMD0_FIFO_RSBC              BIT(25)
+#define CMD0_FIFO_IS_10B            BIT(24)
+#define CMD0_FIFO_PL_LEN(l)         ((l) << 12)
+#define CMD0_FIFO_IS_DB             BIT(11)
+#define CMD0_FIFO_PL_LEN_MAX        4095
+#define CMD0_FIFO_DEV_ADDR(a)       ((a) << 1)
+#define CMD0_FIFO_RNW               BIT(0)
+
+#define CMD1_FIFO            0x64
+#define CMD1_FIFO_CMDID(id)  ((id) << 24)
+#define CMD1_FIFO_DB(db)     FIELD_PREP(GENMASK(15, 8), (db))
+#define CMD1_FIFO_CSRADDR(a) (a)
+#define CMD1_FIFO_CCC(id)    (id)
+
+#define TX_FIFO 0x68
+
+#define TX_FIFO_STATUS 0x6C
+
+#define IMD_CMD0             0x70
+#define IMD_CMD0_PL_LEN(l)   ((l) << 12)
+#define IMD_CMD0_DEV_ADDR(a) ((a) << 1)
+#define IMD_CMD0_RNW         BIT(0)
+
+#define IMD_CMD1         0x74
+#define IMD_CMD1_CCC(id) (id)
+
+#define IMD_DATA                    0x78
+#define RX_FIFO                     0x80
+#define IBI_DATA_FIFO               0x84
+#define SLV_DDR_TX_FIFO             0x88
+#define SLV_DDR_RX_FIFO             0x8c
+#define DDR_PREAMBLE_MASK           GENMASK(19, 18)
+#define DDR_PREAMBLE_CMD_CRC        (0x1 << 18)
+#define DDR_PREAMBLE_DATA_ABORT     (0x2 << 18)
+#define DDR_PREAMBLE_DATA_ABORT_ALT (0x3 << 18)
+#define DDR_DATA(x)                 (((x) & GENMASK(17, 2)) >> 2)
+#define DDR_EVEN_PARITY             BIT(0)
+#define DDR_ODD_PARITY              BIT(1)
+#define DDR_CRC_AND_HEADER_SIZE     0x4
+#define DDR_CONVERT_BUF_LEN(x)      (4 * (x))
+
+#define HDR_CMD_RD         BIT(15)
+#define HDR_CMD_CODE(c)    (((c) & GENMASK(6, 0)) << 8)
+#define DDR_CRC_TOKEN      (0xC << 14)
+#define DDR_CRC_TOKEN_MASK GENMASK(17, 14)
+#define DDR_CRC(t)         (((t) & (GENMASK(13, 9))) >> 9)
+#define DDR_CRC_WR_SETUP   BIT(8)
+
+#define CMD_IBI_THR_CTRL 0x90
+#define IBIR_THR(t)      ((t) << 24)
+#define CMDR_THR(t)      ((t) << 16)
+#define CMDR_THR_MASK    (GENMASK(20, 16))
+#define IBI_THR(t)       ((t) << 8)
+#define CMD_THR(t)       (t)
+
+#define TX_RX_THR_CTRL 0x94
+#define RX_THR(t)      ((t) << 16)
+#define RX_THR_MASK    (GENMASK(31, 16))
+#define TX_THR(t)      (t)
+#define TX_THR_MASK    (GENMASK(15, 0))
+
+#define SLV_DDR_TX_RX_THR_CTRL 0x98
+#define SLV_DDR_RX_THR(t)      ((t) << 16)
+#define SLV_DDR_TX_THR(t)      (t)
+
+#define FLUSH_CTRL            0x9c
+#define FLUSH_IBI_RESP        BIT(24)
+#define FLUSH_CMD_RESP        BIT(23)
+#define FLUSH_SLV_DDR_RX_FIFO BIT(22)
+#define FLUSH_SLV_DDR_TX_FIFO BIT(21)
+#define FLUSH_IMM_FIFO        BIT(20)
+#define FLUSH_IBI_FIFO        BIT(19)
+#define FLUSH_RX_FIFO         BIT(18)
+#define FLUSH_TX_FIFO         BIT(17)
+#define FLUSH_CMD_FIFO        BIT(16)
+
+#define SLV_CTRL 0xA0
+
+#define SLV_PROT_ERR_TYPE 0xA4
+#define SLV_ERR6_IBI      BIT(9)
+#define SLV_ERR6_PR       BIT(8)
+#define SLV_ERR_GETCCC    BIT(7)
+#define SLV_ERR5          BIT(6)
+#define SLV_ERR4          BIT(5)
+#define SLV_ERR3          BIT(4)
+#define SLV_ERR2_PW       BIT(3)
+#define SLV_ERR2_SETCCC   BIT(2)
+#define SLV_ERR1          BIT(1)
+#define SLV_ERR0          BIT(0)
+
+#define SLV_STATUS2        0xA8
+#define SLV_STATUS2_MRL(s) (((s) & GENMASK(23, 8)) >> 8)
+
+#define SLV_STATUS3           0xAC
+#define SLV_STATUS3_BC_FSM(s) (((s) & GENMASK(26, 16)) >> 16)
+#define SLV_STATUS3_MWL(s)    ((s) & GENMASK(15, 0))
+
+#define TTO_PRESCL_CTRL0               0xb0
+#define TTO_PRESCL_CTRL0_PRESCL_I2C(x) ((x) << 16)
+#define TTO_PRESCL_CTRL0_PRESCL_I3C(x) (x)
+
+#define TTO_PRESCL_CTRL1           0xb4
+#define TTO_PRESCL_CTRL1_DIVB(x)   ((x) << 16)
+#define TTO_PRESCL_CTRL1_DIVA(x)   (x)
+#define TTO_PRESCL_CTRL1_PP_LOW(x) ((x) << 8)
+#define TTO_PRESCL_CTRL1_OD_LOW(x) (x)
+
+#define DEVS_CTRL                  0xb8
+#define DEVS_CTRL_DEV_CLR_SHIFT    16
+#define DEVS_CTRL_DEV_CLR_ALL      GENMASK(31, 16)
+#define DEVS_CTRL_DEV_CLR(dev)     BIT(16 + (dev))
+#define DEVS_CTRL_DEV_ACTIVE(dev)  BIT(dev)
+#define DEVS_CTRL_DEVS_ACTIVE_MASK GENMASK(15, 0)
+#define MAX_DEVS                   16
+
+#define DEV_ID_RR0(d)              (0xc0 + ((d) * 0x10))
+#define DEV_ID_RR0_LVR_EXT_ADDR    BIT(11)
+#define DEV_ID_RR0_HDR_CAP         BIT(10)
+#define DEV_ID_RR0_IS_I3C          BIT(9)
+#define DEV_ID_RR0_DEV_ADDR_MASK   (GENMASK(7, 1) | GENMASK(15, 13))
+#define DEV_ID_RR0_SET_DEV_ADDR(a) (((a << 1) & GENMASK(7, 1)) | (((a) & GENMASK(9, 7)) << 13))
+#define DEV_ID_RR0_GET_DEV_ADDR(x) ((((x) >> 1) & GENMASK(6, 0)) | (((x) >> 6) & GENMASK(9, 7)))
+
+#define DEV_ID_RR1(d)           (0xc4 + ((d) * 0x10))
+#define DEV_ID_RR1_PID_MSB(pid) (pid)
+
+#define DEV_ID_RR2(d)           (0xc8 + ((d) * 0x10))
+#define DEV_ID_RR2_PID_LSB(pid) ((pid) << 16)
+#define DEV_ID_RR2_BCR(bcr)     ((bcr) << 8)
+#define DEV_ID_RR2_DCR(dcr)     (dcr)
+#define DEV_ID_RR2_LVR(lvr)     (lvr)
+
+#define SIR_MAP(x)               (0x180 + ((x) * 4))
+#define SIR_MAP_DEV_REG(d)       SIR_MAP((d) / 2)
+#define SIR_MAP_DEV_SHIFT(d, fs) ((fs) + (((d) % 2) ? 16 : 0))
+#define SIR_MAP_DEV_CONF_MASK(d) (GENMASK(15, 0) << (((d) % 2) ? 16 : 0))
+#define SIR_MAP_DEV_CONF(d, c)   ((c) << (((d) % 2) ? 16 : 0))
+#define DEV_ROLE_SLAVE           0
+#define DEV_ROLE_MASTER          1
+#define SIR_MAP_DEV_ROLE(role)   ((role) << 14)
+#define SIR_MAP_DEV_SLOW         BIT(13)
+#define SIR_MAP_DEV_PL(l)        ((l) << 8)
+#define SIR_MAP_PL_MAX           GENMASK(4, 0)
+#define SIR_MAP_DEV_DA(a)        ((a) << 1)
+#define SIR_MAP_DEV_ACK          BIT(0)
+
+#define GRPADDR_LIST 0x198
+
+#define GRPADDR_CS 0x19C
+
+#define GPIR_WORD(x)     (0x200 + ((x) * 4))
+#define GPI_REG(val, id) (((val) >> (((id) % 4) * 8)) & GENMASK(7, 0))
+
+#define GPOR_WORD(x)     (0x220 + ((x) * 4))
+#define GPO_REG(val, id) (((val) >> (((id) % 4) * 8)) & GENMASK(7, 0))
+
+#define ASF_INT_STATUS        0x300
+#define ASF_INT_RAW_STATUS    0x304
+#define ASF_INT_MASK          0x308
+#define ASF_INT_TEST          0x30c
+#define ASF_INT_FATAL_SELECT  0x310
+#define ASF_INTEGRITY_ERR     BIT(6)
+#define ASF_PROTOCOL_ERR      BIT(5)
+#define ASF_TRANS_TIMEOUT_ERR BIT(4)
+#define ASF_CSR_ERR           BIT(3)
+#define ASF_DAP_ERR           BIT(2)
+#define ASF_SRAM_UNCORR_ERR   BIT(1)
+#define ASF_SRAM_CORR_ERR     BIT(0)
+
+#define ASF_SRAM_CORR_FAULT_STATUS      0x320
+#define ASF_SRAM_UNCORR_FAULT_STATUS    0x324
+#define ASF_SRAM_CORR_FAULT_INSTANCE(x) ((x) >> 24)
+#define ASF_SRAM_CORR_FAULT_ADDR(x)     ((x) & GENMASK(23, 0))
+
+#define ASF_SRAM_FAULT_STATS           0x328
+#define ASF_SRAM_FAULT_UNCORR_STATS(x) ((x) >> 16)
+#define ASF_SRAM_FAULT_CORR_STATS(x)   ((x) & GENMASK(15, 0))
+
+#define ASF_TRANS_TOUT_CTRL   0x330
+#define ASF_TRANS_TOUT_EN     BIT(31)
+#define ASF_TRANS_TOUT_VAL(x) (x)
+
+#define ASF_TRANS_TOUT_FAULT_MASK      0x334
+#define ASF_TRANS_TOUT_FAULT_STATUS    0x338
+#define ASF_TRANS_TOUT_FAULT_APB       BIT(3)
+#define ASF_TRANS_TOUT_FAULT_SCL_LOW   BIT(2)
+#define ASF_TRANS_TOUT_FAULT_SCL_HIGH  BIT(1)
+#define ASF_TRANS_TOUT_FAULT_FSCL_HIGH BIT(0)
+
+#define ASF_PROTO_FAULT_MASK            0x340
+#define ASF_PROTO_FAULT_STATUS          0x344
+#define ASF_PROTO_FAULT_SLVSDR_RD_ABORT BIT(31)
+#define ASF_PROTO_FAULT_SLVDDR_FAIL     BIT(30)
+#define ASF_PROTO_FAULT_S(x)            BIT(16 + (x))
+#define ASF_PROTO_FAULT_MSTSDR_RD_ABORT BIT(15)
+#define ASF_PROTO_FAULT_MSTDDR_FAIL     BIT(14)
+#define ASF_PROTO_FAULT_M(x)            BIT(x)
+
+/*******************************************************************************
+ * Local Constants Definition
+ ******************************************************************************/
+
+/* Maximum i3c devices that the IP can be built with */
+#define I3C_MAX_DEVS                     11
+#define I3C_MAX_MSGS                     10
+#define I3C_SIR_DEFAULT_DA               0x7F
+#define I3C_MAX_IDLE_CANCEL_WAIT_RETRIES 50
+#define I3C_PRESCL_REG_SCALE             (4)
+#define I2C_PRESCL_REG_SCALE             (5)
+#define I3C_WAIT_FOR_IDLE_STATE_US       CONFIG_I3C_CADENCE_IDLE_TIMEOUT_US
+#define I3C_IDLE_TIMEOUT_CYC                                                                       \
+	(I3C_WAIT_FOR_IDLE_STATE_US * (sys_clock_hw_cycles_per_sec() / USEC_PER_SEC))
+
+/*
+ * MIPI I3C v1.1.1 Spec defines SDA Signal Data Hold in Push Pull max as the
+ * minimum of the clock rise and fall time plus 3ns
+ */
+#define I3C_HD_PP_DEFAULT_NS 10
+
+/* Interrupt thresholds. */
+/* command response fifo threshold */
+#define I3C_CMDR_THR 1
+/* command tx fifo threshold - unused */
+#define I3C_CMDD_THR 1
+/* in-band-interrupt response queue threshold */
+#define I3C_IBIR_THR 1
+/* tx data threshold - unused */
+#define I3C_TX_THR   1
+
+/*******************************************************************************
+ * Local Types Definition
+ ******************************************************************************/
+
+/** Describes peripheral HW configuration determined from CONFx registers. */
+struct cdns_i3c_hw_config {
+	/* Revision ID */
+	uint32_t rev_id;
+	/* The maximum command queue depth. */
+	uint32_t cmd_mem_depth;
+	/* The maximum command response queue depth. */
+	uint32_t cmdr_mem_depth;
+	/* The maximum RX FIFO depth. */
+	uint32_t rx_mem_depth;
+	/* The maximum TX FIFO depth. */
+	uint32_t tx_mem_depth;
+	/* The maximum DDR RX FIFO depth. */
+	uint32_t ddr_rx_mem_depth;
+	/* The maximum DDR TX FIFO depth. */
+	uint32_t ddr_tx_mem_depth;
+	/* The maximum IBIR FIFO depth. */
+	uint32_t ibir_mem_depth;
+	/* The maximum IBI FIFO depth. */
+	uint32_t ibi_mem_depth;
+};
+
+/* Cadence I3C/I2C Device Private Data */
+struct cdns_i3c_i2c_dev_data {
+	/* Device id within the retaining registers. This is set after bus initialization by the
+	 * controller.
+	 */
+	uint8_t id;
+};
+
+/* Single command/transfer */
+struct cdns_i3c_cmd {
+	uint32_t cmd0;
+	uint32_t cmd1;
+	uint32_t ddr_header;
+	uint32_t ddr_crc;
+	uint32_t len;
+	uint32_t *num_xfer;
+	void *buf;
+	uint32_t error;
+	enum i3c_sdr_controller_error_types *sdr_err;
+	enum i3c_data_rate hdr;
+};
+
+/* Transfer data */
+struct cdns_i3c_xfer {
+	struct k_sem complete;
+	int ret;
+	int num_cmds;
+	struct cdns_i3c_cmd cmds[I3C_MAX_MSGS];
+};
+
+#ifdef CONFIG_I3C_USE_IBI
+/* IBI transferred data */
+struct cdns_i3c_ibi_buf {
+	uint8_t ibi_data[CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE];
+	uint8_t ibi_data_cnt;
+};
+#endif
+
+/* Driver config */
+struct cdns_i3c_config {
+	struct i3c_driver_config common;
+	/** base address of the controller */
+	uintptr_t base;
+	/** input frequency to the I3C Cadence */
+	uint32_t input_frequency;
+	/** Interrupt configuration function. */
+	void (*irq_config_func)(const struct device *dev);
+	/** IBID Threshold value */
+	uint8_t ibid_thr;
+};
+
+#ifdef CONFIG_I3C_CADENCE_RTIO
+#include <zephyr/drivers/i2c/rtio.h>
+#include <zephyr/drivers/i3c/rtio.h>
+#include <zephyr/sys/mpsc_lockfree.h>
+
+/*
+ * Per-sqe record kept while a transaction is in flight so that the CMDR
+ * drain ISR can route response bytes / errors back to the originating sqe.
+ *
+ * sqe is the originating rtio_iodev_sqe; for direct CCCs (one CMD per
+ * target) ccc_target_idx points back at payload->targets.payloads[N]; for
+ * data sqes it is unused.
+ *
+ * For DDR cmds (is_ddr=true) the pre-built header word and CRC token are
+ * stashed during start so streaming TX/RX can consume them without
+ * recomputation. ddr_crc carries a running CRC5 used by the RX decoder.
+ */
+struct cdns_i3c_rtio_cmd {
+	struct rtio_iodev_sqe *sqe;
+	uint16_t len;
+	bool is_read;
+	bool is_ccc_target;
+	bool is_ddr;
+	uint8_t ccc_target_idx;
+	uint32_t ddr_header;
+	uint32_t ddr_crc_word;
+	uint8_t ddr_crc;
+};
+
+/*
+ * DDR TX streaming phase. One per active TX cursor — DDR cmds emit
+ * header → data... → crc → done across multiple TX_THR IRQs.
+ */
+enum cdns_i3c_rtio_ddr_tx_phase {
+	DDR_TX_HEADER = 0,
+	DDR_TX_DATA,
+	DDR_TX_CRC,
+	DDR_TX_DONE,
+};
+
+/*
+ * Single per-controller RTIO state. Both i3c and i2c sqes flow through one
+ * unified mpsc queue (unified_q), preserving submit-time ordering. The
+ * active transaction's "kind" is implicit in active_head->sqe.iodev->api.
+ *
+ * i3c_ctx and i2c_ctx are retained only so the blocking helpers
+ * (i3c_rtio_transfer, i2c_rtio_transfer) work — their ctx->iodev field is
+ * the bridge into our iodev_submit callbacks. The ctxes' own io_q /
+ * txn_head / txn_curr fields go unused on the cdns path; unified_q is the
+ * sole queue we drive from.
+ *
+ * active_head non-NULL means "controller is busy driving the bus right
+ * now". Submit-side checks this under slock to decide whether to kick
+ * start or defer to the in-flight ISR's completion-tail.
+ */
+struct cdns_i3c_rtio_state {
+	struct i3c_rtio *i3c_ctx;
+	struct i2c_rtio *i2c_ctx;
+
+	struct k_spinlock slock;
+	struct mpsc unified_q;
+	struct rtio_iodev_sqe *active_head;
+
+	struct rtio_iodev_sqe *tx_sqe;
+	uint32_t tx_off;
+
+	struct rtio_iodev_sqe *rx_sqe;
+	uint32_t rx_off;
+
+	/*
+	 * Index into cmds[] tracking which entry the TX/RX cursor is on.
+	 * For DDR streaming we need to look up per-cmd state (header, CRC,
+	 * phase) without scanning. Non-DDR (SDR/CCC) doesn't strictly need
+	 * these but we update them anyway for symmetry.
+	 */
+	uint8_t tx_cmd_idx;
+	uint8_t rx_cmd_idx;
+
+	enum cdns_i3c_rtio_ddr_tx_phase ddr_tx_phase;
+
+	uint8_t num_cmds;
+	int xfer_status;
+
+	struct cdns_i3c_rtio_cmd cmds[I3C_MAX_MSGS];
+};
+#endif /* CONFIG_I3C_CADENCE_RTIO */
+
+/* Driver instance data */
+struct cdns_i3c_data {
+	/* common must be first! */
+	struct i3c_driver_data common;
+	struct cdns_i3c_hw_config hw_cfg;
+	struct k_mutex bus_lock;
+#ifdef CONFIG_I3C_CONTROLLER
+	struct cdns_i3c_i2c_dev_data cdns_i3c_i2c_priv_data[I3C_MAX_DEVS];
+#if defined(CONFIG_I3C_CALLBACK) || defined(CONFIG_I2C_CALLBACK)
+	struct k_timer timeout;
+	i3c_callback_t cb;
+	void *userdata;
+	struct k_sem async_sem;
+#endif
+#endif /* CONFIG_I3C_CONTROLLER */
+	struct cdns_i3c_xfer xfer;
+#ifdef CONFIG_I3C_TARGET
+	struct i3c_target_config *target_config;
+#ifdef CONFIG_I3C_TARGET_BUFFER_MODE
+	uint8_t target_rx_buf[CONFIG_I3C_CADENCE_TARGET_RX_BUF_SIZE];
+	uint32_t target_rx_len;
+#endif /* CONFIG_I3C_TARGET_BUFFER_MODE */
+#endif /* CONFIG_I3C_TARGET */
+#ifdef CONFIG_I3C_USE_IBI
+	struct cdns_i3c_ibi_buf ibi_buf;
+#ifdef CONFIG_I3C_TARGET
+	struct k_sem ibi_hj_complete;
+#ifdef CONFIG_I3C_CONTROLLER
+	struct k_sem ibi_cr_complete;
+#endif /* CONFIG_I3C_CONTROLLER */
+#endif /* CONFIG_I3C_TARGET */
+#endif /* CONFIG_I3C_USE_IBI*/
+#if (defined(CONFIG_I3C_CONTROLLER) && defined(CONFIG_I3C_TARGET)) ||                              \
+	defined(CONFIG_I3C_CALLBACK) || defined(CONFIG_I2C_CALLBACK)
+	const struct device *dev;
+#endif
+#if defined(CONFIG_I3C_CONTROLLER) && defined(CONFIG_I3C_TARGET)
+	struct k_work deftgts_work;
+	struct k_sem ch_complete;
+#endif /* CONFIG_I3C_CONTROLLER && CONFIG_I3C_TARGET */
+	uint32_t free_rr_slots;
+	uint16_t fifo_bytes_read;
+	uint8_t max_devs;
+#ifdef CONFIG_I3C_CADENCE_RTIO
+	struct cdns_i3c_rtio_state *rtio;
+#endif
+};
+
+/*******************************************************************************
+ * FIFO Status Helpers (inline)
+ ******************************************************************************/
+
+/* Check if command response fifo is empty */
+static inline bool cdns_i3c_cmd_rsp_fifo_empty(const struct cdns_i3c_config *config)
+{
+	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
+
+	return ((mst_st & MST_STATUS0_CMDR_EMP) ? true : false);
+}
+
+/* Check if command fifo is empty */
+static inline bool cdns_i3c_cmd_fifo_empty(const struct cdns_i3c_config *config)
+{
+	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
+
+	return ((mst_st & MST_STATUS0_CMDD_EMP) ? true : false);
+}
+
+/* Check if command fifo is full */
+static inline bool cdns_i3c_cmd_fifo_full(const struct cdns_i3c_config *config)
+{
+	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
+
+	return ((mst_st & MST_STATUS0_CMDD_FULL) ? true : false);
+}
+
+/* Check if ibi response fifo is empty */
+static inline bool cdns_i3c_ibi_rsp_fifo_empty(const struct cdns_i3c_config *config)
+{
+	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
+
+	return ((mst_st & MST_STATUS0_IBIR_EMP) ? true : false);
+}
+
+/* Check if tx fifo is full */
+static inline bool cdns_i3c_tx_fifo_full(const struct cdns_i3c_config *config)
+{
+	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
+
+	return ((mst_st & MST_STATUS0_TX_FULL) ? true : false);
+}
+
+/* Check if rx fifo is full */
+static inline bool cdns_i3c_rx_fifo_full(const struct cdns_i3c_config *config)
+{
+	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
+
+	return ((mst_st & MST_STATUS0_RX_FULL) ? true : false);
+}
+
+/* Check if rx fifo is empty */
+static inline bool cdns_i3c_rx_fifo_empty(const struct cdns_i3c_config *config)
+{
+	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
+
+	return ((mst_st & MST_STATUS0_RX_EMP) ? true : false);
+}
+
+/* Check if ibi fifo is empty */
+static inline bool cdns_i3c_ibi_fifo_empty(const struct cdns_i3c_config *config)
+{
+	uint32_t mst_st = sys_read32(config->base + MST_STATUS0);
+
+	return ((mst_st & MST_STATUS0_IBID_EMP) ? true : false);
+}
+
+/* Interrupt handling */
+static inline void cdns_i3c_interrupts_disable(const struct cdns_i3c_config *config)
+{
+	sys_write32(MST_INT_MASK, config->base + MST_IDR);
+}
+
+static inline void cdns_i3c_interrupts_clear(const struct cdns_i3c_config *config)
+{
+	sys_write32(MST_INT_MASK, config->base + MST_ICR);
+}
+
+/*******************************************************************************
+ * Shared helpers (defined in i3c_cdns_common.c)
+ ******************************************************************************/
+
+uint8_t i3c_cdns_crc5(uint8_t crc5, uint16_t word);
+uint8_t cdns_i3c_ddr_parity(uint16_t payload);
+uint32_t prepare_ddr_word(uint16_t payload);
+uint16_t prepare_ddr_cmd_parity_adjustment_bit(uint16_t word);
+#ifdef CONFIG_I3C_CONTROLLER
+uint8_t cdns_i3c_even_parity_byte(uint8_t byte);
+#endif
+
+void cdns_i3c_write_tx_fifo(const struct cdns_i3c_config *config, const void *buf, uint32_t len);
+#ifdef CONFIG_I3C_CONTROLLER
+int cdns_i3c_read_rx_fifo(const struct cdns_i3c_config *config, void *buf, uint32_t len);
+int cdns_i3c_wait_for_idle(const struct device *dev);
+#endif
+
+/*******************************************************************************
+ * RTIO native submit hooks (defined in i3c_cdns_rtio.c)
+ ******************************************************************************/
+
+#ifdef CONFIG_I3C_CADENCE_RTIO
+struct rtio_iodev_sqe;
+
+void cdns_i3c_iodev_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+void cdns_i3c_i2c_iodev_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+int cdns_i3c_rtio_init(const struct device *dev);
+void cdns_i3c_rtio_irq_cmdd_emp(const struct device *dev);
+void cdns_i3c_rtio_irq_tx_thr(const struct device *dev);
+void cdns_i3c_rtio_irq_rx_thr(const struct device *dev);
+#endif /* CONFIG_I3C_CADENCE_RTIO */
+
+/*******************************************************************************
+ * Legacy hardware-driving path (defined in i3c_cdns_legacy.c)
+ *
+ * These funnel through cdns_i3c_start_transfer / cdns_i3c_complete_transfer
+ * and back-pressure to the legacy data->xfer.cmds[] queue. Only compiled and
+ * referenced when CONFIG_I3C_CADENCE_RTIO is NOT enabled.
+ ******************************************************************************/
+
+#ifndef CONFIG_I3C_CADENCE_RTIO
+
+void cdns_i3c_complete_transfer(const struct device *dev);
+
+#if defined(CONFIG_I3C_CALLBACK) || defined(CONFIG_I2C_CALLBACK)
+void cdns_i3c_cb_timeout(struct k_timer *timer);
+#endif
+
+int cdns_i3c_do_ccc_do(const struct device *dev, struct i3c_ccc_payload *payload, bool async,
+		       i3c_callback_t cb, void *userdata);
+int cdns_i3c_transfer_do(const struct device *dev, struct i3c_device_desc *target,
+			 struct i3c_msg *msgs, uint8_t num_msgs, bool async, i3c_callback_t cb,
+			 void *userdata);
+int cdns_i3c_i2c_transfer(const struct device *dev, struct i3c_i2c_device_desc *i2c_dev,
+			  struct i2c_msg *msgs, uint8_t num_msgs);
+#ifdef CONFIG_I2C_CALLBACK
+int cdns_i3c_i2c_transfer_cb(const struct device *dev, struct i3c_i2c_device_desc *i2c_dev,
+			     struct i2c_msg *msgs, uint8_t num_msgs, i2c_callback_t cb,
+			     void *userdata);
+#endif
+struct i3c_i2c_device_desc *cdns_i3c_i2c_device_find(const struct device *dev, uint16_t addr);
+
+#endif /* !CONFIG_I3C_CADENCE_RTIO */
+
+#endif /* ZEPHYR_DRIVERS_I3C_I3C_CDNS_H_ */

--- a/drivers/i3c/i3c_cdns_common.c
+++ b/drivers/i3c/i3c_cdns_common.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and its affiliates.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Shared helpers used by the Cadence I3C driver core and its native RTIO
+ * submit path. These were previously file-static in i3c_cdns.c and have been
+ * promoted to be linkable from i3c_cdns_rtio.c as well.
+ */
+
+#include <string.h>
+
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
+
+#include "i3c_cdns.h"
+
+LOG_MODULE_DECLARE(I3C_CADENCE, CONFIG_I3C_CADENCE_LOG_LEVEL);
+
+/*
+ * Nibble-wise table-driven CRC5 for I3C HDR-DDR.
+ *
+ * Equivalent to the bit-serial recurrence below (4 bits per step instead of 1):
+ *
+ *     crc0     = next_data_bit ^ crc[4]
+ *     crc[4:0] = { crc[3:2], crc[1]^crc0, crc[0], crc0 }
+ *
+ * Tables were generated and exhaustively verified against the bit-serial
+ * reference for all (crc, word) pairs (2^21 combinations, 0 mismatches).
+ *
+ *   crc5_data_tab[n]    = step4(0, n)  applied to a 4-bit input nibble n
+ *   crc5_shift_tab[c]   = step4(c, 0)  autonomous LFSR evolution by 4 steps
+ *
+ * By linearity, step4(crc, n) = step4(crc, 0) ^ step4(0, n).
+ */
+static const uint8_t crc5_data_tab[16] = {
+	[0x0] = 0x00, [0x1] = 0x05, [0x2] = 0x0A, [0x3] = 0x0F,
+	[0x4] = 0x14, [0x5] = 0x11, [0x6] = 0x1E, [0x7] = 0x1B,
+	[0x8] = 0x0D, [0x9] = 0x08, [0xA] = 0x07, [0xB] = 0x02,
+	[0xC] = 0x19, [0xD] = 0x1C, [0xE] = 0x13, [0xF] = 0x16,
+};
+
+static const uint8_t crc5_shift_tab[32] = {
+	[0x00] = 0x00, [0x01] = 0x10, [0x02] = 0x05, [0x03] = 0x15,
+	[0x04] = 0x0A, [0x05] = 0x1A, [0x06] = 0x0F, [0x07] = 0x1F,
+	[0x08] = 0x14, [0x09] = 0x04, [0x0A] = 0x11, [0x0B] = 0x01,
+	[0x0C] = 0x1E, [0x0D] = 0x0E, [0x0E] = 0x1B, [0x0F] = 0x0B,
+	[0x10] = 0x0D, [0x11] = 0x1D, [0x12] = 0x08, [0x13] = 0x18,
+	[0x14] = 0x07, [0x15] = 0x17, [0x16] = 0x02, [0x17] = 0x12,
+	[0x18] = 0x19, [0x19] = 0x09, [0x1A] = 0x1C, [0x1B] = 0x0C,
+	[0x1C] = 0x13, [0x1D] = 0x03, [0x1E] = 0x16, [0x1F] = 0x06,
+};
+
+uint8_t i3c_cdns_crc5(uint8_t crc5, uint16_t word)
+{
+	/* First mask guards against a caller seeding bits above bit 4.
+	 * Subsequent iterations operate on values already bounded to 5 bits
+	 * by the table contents, so no further masking is needed.
+	 */
+	crc5 = crc5_shift_tab[crc5 & 0x1f] ^ crc5_data_tab[(word >> 12) & 0xf];
+	crc5 = crc5_shift_tab[crc5] ^ crc5_data_tab[(word >> 8) & 0xf];
+	crc5 = crc5_shift_tab[crc5] ^ crc5_data_tab[(word >> 4) & 0xf];
+	crc5 = crc5_shift_tab[crc5] ^ crc5_data_tab[word & 0xf];
+
+	return crc5;
+}
+
+uint8_t cdns_i3c_ddr_parity(uint16_t payload)
+{
+	/*
+	 * PA1 = odd parity over odd-indexed bits (1,3,5,...,15).
+	 * PA0 = even parity over even-indexed bits (0,2,4,...,14) — i.e. XOR of those
+	 *       bits inverted, equivalent to parity ^ 1.
+	 */
+	uint8_t pa1 = (uint8_t)__builtin_parity((unsigned int)(payload & 0xaaaau));
+	uint8_t pa0 = (uint8_t)(__builtin_parity((unsigned int)(payload & 0x5555u)) ^ 1u);
+
+	return (uint8_t)((pa1 << 1) | pa0);
+}
+
+/* This prepares the ddr word from the payload add adding on parity, This
+ * does not write the preamble
+ */
+uint32_t prepare_ddr_word(uint16_t payload)
+{
+	return (uint32_t)payload << 2 | cdns_i3c_ddr_parity(payload);
+}
+
+/* This ensures that PA0 contains 1'b1 which allows for easier Bus Turnaround */
+uint16_t prepare_ddr_cmd_parity_adjustment_bit(uint16_t word)
+{
+	/* XOR of bits 2,4,6,8,10,12,14 == parity(word & 0x5554). */
+	if (__builtin_parity((unsigned int)(word & 0x5554u))) {
+		word |= BIT(0);
+	}
+
+	return word;
+}
+
+#ifdef CONFIG_I3C_CONTROLLER
+/* Computes and sets parity */
+/* Returns [7:1] 7-bit addr, [0] even/xor parity */
+uint8_t cdns_i3c_even_parity_byte(uint8_t byte)
+{
+	return (uint8_t)((byte << 1) | (uint8_t)(__builtin_parity((unsigned int)byte) ^ 1u));
+}
+#endif /* CONFIG_I3C_CONTROLLER */
+
+void cdns_i3c_write_tx_fifo(const struct cdns_i3c_config *config, const void *buf, uint32_t len)
+{
+	const uint32_t *ptr = buf;
+	uint32_t remain, val;
+
+	for (remain = len; remain >= 4; remain -= 4) {
+		val = *ptr++;
+		sys_write32(val, config->base + TX_FIFO);
+	}
+
+	if (remain > 0) {
+		val = 0;
+		memcpy(&val, ptr, remain);
+		sys_write32(val, config->base + TX_FIFO);
+	}
+}
+
+#ifdef CONFIG_I3C_CONTROLLER
+int cdns_i3c_read_rx_fifo(const struct cdns_i3c_config *config, void *buf, uint32_t len)
+{
+	uint32_t *ptr = buf;
+	uint32_t remain, val;
+
+	for (remain = len; remain >= 4; remain -= 4) {
+		if (cdns_i3c_rx_fifo_empty(config)) {
+			return -EIO;
+		}
+		val = sys_le32_to_cpu(sys_read32(config->base + RX_FIFO));
+		*ptr++ = val;
+	}
+
+	if (remain > 0) {
+		if (cdns_i3c_rx_fifo_empty(config)) {
+			return -EIO;
+		}
+		val = sys_le32_to_cpu(sys_read32(config->base + RX_FIFO));
+		memcpy(ptr, &val, remain);
+	}
+
+	return 0;
+}
+
+int cdns_i3c_wait_for_idle(const struct device *dev)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	uint32_t start_time = k_cycle_get_32();
+
+	/**
+	 * Spin waiting for device to go idle. It is unlikely that this will
+	 * actually take any time unless if the last transaction came immediately
+	 * after an error condition.
+	 */
+	while (!(sys_read32(config->base + MST_STATUS0) & MST_STATUS0_IDLE)) {
+		if (k_cycle_get_32() - start_time > I3C_IDLE_TIMEOUT_CYC) {
+			LOG_ERR("%s: Timeout waiting for idle", dev->name);
+			return -EAGAIN;
+		}
+	}
+
+	return 0;
+}
+#endif /* CONFIG_I3C_CONTROLLER */

--- a/drivers/i3c/i3c_cdns_legacy.c
+++ b/drivers/i3c/i3c_cdns_legacy.c
@@ -1,0 +1,1038 @@
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and its affiliates.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Legacy hardware-driving path for the Cadence I3C controller.
+ *
+ * This file holds the original "build commands into data->xfer.cmds[],
+ * call cdns_i3c_start_transfer, complete via the CMDD_EMP ISR" code.
+ * Compiled only when CONFIG_I3C_CADENCE_RTIO is NOT enabled. When the
+ * native RTIO submit path is selected, every controller-mode hardware
+ * driving entry point funnels through it instead and this entire file
+ * drops out of the build.
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
+
+#include "i3c_cdns.h"
+
+LOG_MODULE_DECLARE(I3C_CADENCE, CONFIG_I3C_CADENCE_LOG_LEVEL);
+
+#ifdef CONFIG_I3C_CONTROLLER
+static int cdns_i3c_read_rx_fifo_ddr_xfer(const struct cdns_i3c_config *config, void *buf,
+					  uint32_t len, uint32_t ddr_header)
+{
+	uint16_t *ptr = buf;
+	uint32_t val;
+	uint32_t preamble;
+	uint8_t crc5 = 0x1F;
+
+	/*
+	 * TODO: This function does not support threshold interrupts, it is expected that the
+	 * whole packet to be within the FIFO and not split across multiple calls to this function.
+	 */
+	crc5 = i3c_cdns_crc5(crc5, (uint16_t)DDR_DATA(ddr_header));
+
+	for (int i = 0; i < len; i++) {
+		if (cdns_i3c_rx_fifo_empty(config)) {
+			return -EIO;
+		}
+		val = sys_read32(config->base + RX_FIFO);
+		preamble = (val & DDR_PREAMBLE_MASK);
+
+		if (preamble == DDR_PREAMBLE_DATA_ABORT ||
+		    preamble == DDR_PREAMBLE_DATA_ABORT_ALT) {
+			*ptr++ = sys_cpu_to_be16((uint16_t)DDR_DATA(val));
+			crc5 = i3c_cdns_crc5(crc5, (uint16_t)DDR_DATA(val));
+		} else if ((preamble == DDR_PREAMBLE_CMD_CRC) &&
+			   ((val & DDR_CRC_TOKEN_MASK) == DDR_CRC_TOKEN)) {
+			uint8_t crc = (uint8_t)DDR_CRC(val);
+
+			if (crc5 != crc) {
+				LOG_ERR("DDR RX crc error");
+				return -EIO;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static void cdns_i3c_cancel_transfer(const struct device *dev)
+{
+	struct cdns_i3c_data *data = dev->data;
+	const struct cdns_i3c_config *config = dev->config;
+	uint32_t val;
+
+	/* Disable further interrupts */
+	sys_write32(MST_INT_CMDD_EMP, config->base + MST_IDR);
+
+	/* Ignore if no pending transfer */
+	if (data->xfer.num_cmds == 0) {
+		return;
+	}
+
+	data->xfer.num_cmds = 0;
+
+	/* Clear main enable bit to disable further transactions */
+	sys_write32(~CTRL_DEV_EN & sys_read32(config->base + CTRL), config->base + CTRL);
+
+	/**
+	 * Spin waiting for device to go idle. It is unlikely that this will
+	 * actually take any time since we only get here if a transaction didn't
+	 * complete in a long time.
+	 */
+	bool idle = false;
+
+	for (uint32_t i = 0; i < I3C_MAX_IDLE_CANCEL_WAIT_RETRIES; i++) {
+		val = sys_read32(config->base + MST_STATUS0);
+		if (val & MST_STATUS0_IDLE) {
+			idle = true;
+			break;
+		}
+		k_msleep(10);
+	}
+	if (!idle) {
+		data->xfer.ret = -ETIMEDOUT;
+	}
+
+	/**
+	 * Flush all queues.
+	 */
+	sys_write32(FLUSH_RX_FIFO | FLUSH_TX_FIFO | FLUSH_CMD_FIFO | FLUSH_CMD_RESP,
+		    config->base + FLUSH_CTRL);
+
+	/* Re-enable device */
+	sys_write32(CTRL_DEV_EN | sys_read32(config->base + CTRL), config->base + CTRL);
+}
+
+#if defined(CONFIG_I3C_CALLBACK) || defined(CONFIG_I2C_CALLBACK)
+void cdns_i3c_cb_timeout(struct k_timer *timer)
+{
+	struct cdns_i3c_data *data = CONTAINER_OF(timer, struct cdns_i3c_data, timeout);
+	const struct device *dev = data->dev;
+
+	cdns_i3c_cancel_transfer(dev);
+	k_sem_give(&data->async_sem);
+	pm_device_busy_clear(dev);
+	if (data->cb) {
+		data->cb(dev, -ETIMEDOUT, data->userdata);
+	}
+}
+#endif
+
+/**
+ * @brief Start a I3C/I2C Transfer
+ *
+ * This is to be called from a I3C/I2C transfer function. This will write
+ * all data to tx and cmd fifos
+ *
+ * @param dev Pointer to controller device driver instance.
+ */
+static void cdns_i3c_start_transfer(const struct device *dev)
+{
+	struct cdns_i3c_data *data = dev->data;
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_xfer *xfer = &data->xfer;
+
+	/* Ensure no pending command response queue threshold interrupt */
+	sys_write32(MST_INT_CMDD_EMP, config->base + MST_ICR);
+
+	/* Make sure RX FIFO is empty. */
+	while (!cdns_i3c_rx_fifo_empty(config)) {
+		(void)sys_read32(config->base + RX_FIFO);
+	}
+	/* Make sure CMDR FIFO is empty too */
+	while (!cdns_i3c_cmd_rsp_fifo_empty(config)) {
+		(void)sys_read32(config->base + CMDR);
+	}
+
+	/* Write all tx data to fifo */
+	for (unsigned int i = 0; i < xfer->num_cmds; i++) {
+		if (xfer->cmds[i].hdr == I3C_DATA_RATE_SDR) {
+			if (!(xfer->cmds[i].cmd0 & CMD0_FIFO_RNW)) {
+				cdns_i3c_write_tx_fifo(config, xfer->cmds[i].buf,
+						       xfer->cmds[i].len);
+			}
+		} else if (xfer->cmds[i].hdr == I3C_DATA_RATE_HDR_DDR) {
+			/* DDR Xfer requires sending header block*/
+			cdns_i3c_write_tx_fifo(config, &xfer->cmds[i].ddr_header,
+					       DDR_CRC_AND_HEADER_SIZE);
+			/* If not read operation need to send data + crc of data*/
+			if (!(DDR_DATA(xfer->cmds[i].ddr_header) & HDR_CMD_RD)) {
+				uint8_t *buf = (uint8_t *)xfer->cmds[i].buf;
+				uint32_t ddr_message = 0;
+				uint16_t ddr_data_payload = sys_get_be16(&buf[0]);
+				/* HDR-DDR Data Words */
+				ddr_message = (DDR_PREAMBLE_DATA_ABORT |
+					       prepare_ddr_word(ddr_data_payload));
+				cdns_i3c_write_tx_fifo(config, &ddr_message,
+						       DDR_CRC_AND_HEADER_SIZE);
+				for (int j = 2; j < ((xfer->cmds[i].len - 2) * 2); j += 2) {
+					ddr_data_payload = sys_get_be16(&buf[j]);
+					ddr_message = (DDR_PREAMBLE_DATA_ABORT_ALT |
+						       prepare_ddr_word(ddr_data_payload));
+					cdns_i3c_write_tx_fifo(config, &ddr_message,
+							       DDR_CRC_AND_HEADER_SIZE);
+				}
+				/* HDR-DDR CRC Word */
+				cdns_i3c_write_tx_fifo(config, &xfer->cmds[i].ddr_crc,
+						       DDR_CRC_AND_HEADER_SIZE);
+			}
+		} else {
+			xfer->ret = -ENOTSUP;
+			return;
+		}
+	}
+
+	/* Write all data to cmd fifos */
+	for (unsigned int i = 0; i < xfer->num_cmds; i++) {
+		/* The command ID is just the msg index. */
+		xfer->cmds[i].cmd1 |= CMD1_FIFO_CMDID(i);
+		sys_write32(xfer->cmds[i].cmd1, config->base + CMD1_FIFO);
+		sys_write32(xfer->cmds[i].cmd0, config->base + CMD0_FIFO);
+
+		if (xfer->cmds[i].hdr == I3C_DATA_RATE_HDR_DDR) {
+			sys_write32(0x00, config->base + CMD1_FIFO);
+			if ((DDR_DATA(xfer->cmds[i].ddr_header) & HDR_CMD_RD)) {
+				sys_write32(CMD0_FIFO_IS_DDR | CMD0_FIFO_PL_LEN(1),
+					    config->base + CMD0_FIFO);
+			} else {
+				sys_write32(CMD0_FIFO_IS_DDR | CMD0_FIFO_PL_LEN(xfer->cmds[i].len),
+					    config->base + CMD0_FIFO);
+			}
+		}
+	}
+
+	/* kickoff transfer */
+	sys_write32(MST_INT_CMDD_EMP, config->base + MST_IER);
+	sys_write32(CTRL_MCS | sys_read32(config->base + CTRL), config->base + CTRL);
+}
+
+static k_timeout_t cdns_i3c_calc_timeout_i3c(const struct i3c_msg *msgs, uint8_t num_msgs,
+					      uint32_t scl_hz)
+{
+	uint64_t us = 0;
+	bool send_broadcast = true;
+
+	for (uint8_t i = 0; i < num_msgs; i++) {
+		uint32_t bits;
+
+		if ((msgs[i].flags & I3C_MSG_HDR) && (msgs[i].hdr_mode & I3C_MSG_HDR_DDR)) {
+			/*
+			 * HDR-DDR preamble: ENTHDR0 broadcast CCC (0x7E addr + cmd code) = 18
+			 * SDR bits. DDR payload: (len/2) 16-bit data words + 1 DDR command header
+			 * word + 1 DDR CRC word = (len/2 + 2) words total, each taking 8 SCL
+			 * cycles (DDR encodes 2 bits per SCL edge, so 16 bits = 8 cycles).
+			 */
+			bits = 18 + ((msgs[i].len / 2) + 2) * 8;
+		} else {
+			/* SDR: address frame (9 bits) + data bytes (9 bits each) */
+			bits = 9 + (msgs[i].len * 9);
+			if (!(msgs[i].flags & I3C_MSG_NBCH) && send_broadcast) {
+				bits += 9; /* broadcast header 0x7E */
+				send_broadcast = false;
+			}
+			if (((i + 1) == num_msgs) || (msgs[i].flags & I3C_MSG_STOP)) {
+				send_broadcast = true;
+			}
+		}
+
+		us += DIV_ROUND_UP((uint64_t)bits * USEC_PER_SEC, scl_hz);
+	}
+
+	us += CONFIG_I3C_CADENCE_TRANSFER_TIMEOUT_MARGIN_US;
+
+	return K_TICKS(k_us_to_ticks_ceil64(us));
+}
+
+static k_timeout_t cdns_i3c_calc_timeout_i2c(const struct i2c_msg *msgs, uint8_t num_msgs,
+					      uint32_t scl_hz)
+{
+	uint64_t us = 0;
+
+	for (uint8_t i = 0; i < num_msgs; i++) {
+		uint32_t bits = (msgs[i].flags & I2C_MSG_ADDR_10_BITS) ? 18 : 9;
+
+		bits += msgs[i].len * 9;
+		us += DIV_ROUND_UP((uint64_t)bits * USEC_PER_SEC, scl_hz);
+	}
+
+	us += CONFIG_I3C_CADENCE_TRANSFER_TIMEOUT_MARGIN_US;
+
+	return K_TICKS(k_us_to_ticks_ceil64(us));
+}
+
+static k_timeout_t cdns_i3c_calc_timeout_ccc(const struct i3c_ccc_payload *payload,
+					      uint32_t scl_hz)
+{
+	/*
+	 * CCC frame on the wire: broadcast addr (9) + CCC command byte (9) + optional
+	 * defining/broadcast data byte(s) (9 each). Per the I3C spec these are
+	 * transmitted once per CCC frame regardless of the number of addressed targets.
+	 *
+	 * For a direct CCC the controller then issues, per target, a repeated start +
+	 * target address (9) + per-target data bytes (9 each). The Cadence IP requires
+	 * one queued command per target so it knows the direction and length, but it
+	 * still emits a single CCC byte / defining byte at the head of the wire frame.
+	 */
+	uint64_t us;
+	uint32_t bits = 18 + (payload->ccc.data_len * 9);
+
+	if (!i3c_ccc_is_payload_broadcast(payload)) {
+		for (size_t i = 0; i < payload->targets.num_targets; i++) {
+			bits += 9 + (payload->targets.payloads[i].data_len * 9);
+		}
+	}
+
+	us = DIV_ROUND_UP((uint64_t)bits * USEC_PER_SEC, scl_hz);
+	us += CONFIG_I3C_CADENCE_TRANSFER_TIMEOUT_MARGIN_US;
+
+	return K_TICKS(k_us_to_ticks_ceil64(us));
+}
+
+int cdns_i3c_do_ccc_do(const struct device *dev, struct i3c_ccc_payload *payload, bool async,
+		       i3c_callback_t cb, void *userdata)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_cmd *cmd;
+	int ret = 0;
+	uint8_t num_cmds = 0;
+
+	__ASSERT_NO_MSG(payload != NULL);
+
+	/*
+	 * Ensure data will fit within FIFOs.
+	 *
+	 * TODO: This limitation prevents burst transfers greater than the
+	 *       FIFO sizes and should be replaced with an implementation that
+	 *       utilizes the RX/TX data threshold interrupts.
+	 */
+	uint32_t num_msgs =
+		1 + ((payload->ccc.data_len > 0) ? payload->targets.num_targets
+						 : MAX(payload->targets.num_targets - 1, 0));
+	if (num_msgs > data->hw_cfg.cmd_mem_depth || num_msgs > data->hw_cfg.cmdr_mem_depth) {
+		LOG_ERR("%s: Too many messages", dev->name);
+		return -ENOMEM;
+	}
+
+	uint32_t rxsize = 0;
+	/* defining byte is stored in a separate register for direct CCCs */
+	uint32_t txsize =
+		i3c_ccc_is_payload_broadcast(payload) ? ROUND_UP(payload->ccc.data_len, 4) : 0;
+
+	for (int i = 0; i < payload->targets.num_targets; i++) {
+		if (payload->targets.payloads[i].rnw) {
+			rxsize += ROUND_UP(payload->targets.payloads[i].data_len, 4);
+		} else {
+			txsize += ROUND_UP(payload->targets.payloads[i].data_len, 4);
+		}
+	}
+	if ((rxsize > data->hw_cfg.rx_mem_depth) || (txsize > data->hw_cfg.tx_mem_depth)) {
+		LOG_ERR("%s: Total RX and/or TX transfer larger than FIFO", dev->name);
+		return -ENOMEM;
+	}
+
+	k_mutex_lock(&data->bus_lock, K_FOREVER);
+#ifdef CONFIG_I3C_CALLBACK
+	k_sem_take(&data->async_sem, K_FOREVER);
+	if (async) {
+		data->cb = cb;
+		data->userdata = userdata;
+	} else {
+		data->cb = NULL;
+		data->userdata = NULL;
+	}
+#endif
+	pm_device_busy_set(dev);
+
+	/* make sure we are currently the active controller */
+	if (!(sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE)) {
+		ret = -EACCES;
+		goto error;
+	}
+
+	/* wait for idle */
+	ret = cdns_i3c_wait_for_idle(dev);
+	if (ret != 0) {
+		goto error;
+	}
+
+	/* if this is a direct CCC */
+	if (!i3c_ccc_is_payload_broadcast(payload)) {
+		/* if the CCC has no data bytes, then the target payload must be in
+		 * the same command buffer
+		 */
+		for (int i = 0; i < payload->targets.num_targets; i++) {
+			cmd = &data->xfer.cmds[i];
+			num_cmds++;
+			cmd->cmd1 = CMD1_FIFO_CCC(payload->ccc.id);
+			cmd->cmd0 = CMD0_FIFO_IS_CCC;
+			/* if there is a defining byte */
+			if (payload->ccc.data_len == 1) {
+				/* Only revision 1p7 supports defining byte for direct CCCs */
+				if (REV_ID_REV(data->hw_cfg.rev_id) >= REV_ID_VERSION(1, 7)) {
+					cmd->cmd0 |= CMD0_FIFO_IS_DB;
+					cmd->cmd1 |= CMD1_FIFO_DB(payload->ccc.data[0]);
+				} else {
+					LOG_ERR("%s: Defining Byte with Direct CCC not supported "
+						"with rev %lup%lu",
+						dev->name, REV_ID_REV_MAJOR(data->hw_cfg.rev_id),
+						REV_ID_REV_MINOR(data->hw_cfg.rev_id));
+					ret = -ENOTSUP;
+					goto error;
+				}
+			} else if (payload->ccc.data_len > 1) {
+				LOG_ERR("%s: Defining Byte length greater than 1", dev->name);
+				ret = -EINVAL;
+				goto error;
+			}
+			/* for a short CCC, i.e. where a direct ccc has multiple targets,
+			 * BCH must be 0 for subsequent targets and RSBC must be 1, otherwise
+			 * if there is just one target, RSBC must be 0 on the first target
+			 */
+			if (i == 0) {
+				cmd->cmd0 |= CMD0_FIFO_BCH;
+			}
+			if (i < (payload->targets.num_targets - 1)) {
+				cmd->cmd0 |= CMD0_FIFO_RSBC;
+			}
+			cmd->buf = payload->targets.payloads[i].data;
+			cmd->len = payload->targets.payloads[i].data_len;
+			cmd->cmd0 |= CMD0_FIFO_DEV_ADDR(payload->targets.payloads[i].addr) |
+				     CMD0_FIFO_PL_LEN(payload->targets.payloads[i].data_len);
+			if (payload->targets.payloads[i].rnw) {
+				cmd->cmd0 |= CMD0_FIFO_RNW;
+			}
+			cmd->hdr = I3C_DATA_RATE_SDR;
+			/*
+			 * write the address of num_xfer and err which is to be updated upon
+			 * message completion
+			 */
+			cmd->num_xfer = (uint32_t *)&(payload->targets.payloads[i].num_xfer);
+			cmd->sdr_err = &(payload->targets.payloads[i].err);
+		}
+	} else {
+		cmd = &data->xfer.cmds[0];
+		num_cmds++;
+		cmd->cmd1 = CMD1_FIFO_CCC(payload->ccc.id);
+		cmd->cmd0 = CMD0_FIFO_IS_CCC | CMD0_FIFO_BCH;
+		cmd->hdr = I3C_DATA_RATE_SDR;
+
+		if (payload->ccc.data_len > 0) {
+			/* Write additional data for CCC if needed */
+			cmd->buf = payload->ccc.data;
+			cmd->len = payload->ccc.data_len;
+			cmd->cmd0 |= CMD0_FIFO_PL_LEN(payload->ccc.data_len);
+			/* write the address of num_xfer which is to be updated upon message
+			 * completion
+			 */
+			cmd->num_xfer = (uint32_t *)&(payload->ccc.num_xfer);
+		} else {
+			/* no data to transfer */
+			cmd->len = 0;
+			cmd->num_xfer = NULL;
+		}
+		cmd->sdr_err = &(payload->ccc.err);
+	}
+
+	data->xfer.ret = -ETIMEDOUT;
+	data->xfer.num_cmds = num_cmds;
+
+	k_timeout_t xfer_timeout = cdns_i3c_calc_timeout_ccc(payload,
+							      data->common.ctrl_config.scl.i3c);
+
+	cdns_i3c_start_transfer(dev);
+	if (!async) {
+		if (k_sem_take(&data->xfer.complete, xfer_timeout) != 0) {
+			LOG_ERR("%s: transfer timed out", dev->name);
+			cdns_i3c_cancel_transfer(dev);
+		}
+	}
+#ifdef CONFIG_I3C_CALLBACK
+	else {
+		k_timer_start(&data->timeout, xfer_timeout, K_NO_WAIT);
+	}
+#endif
+
+	if (!async && data->xfer.ret < 0) {
+		LOG_ERR("%s: CCC[0x%02x] error (%d)", dev->name, payload->ccc.id, data->xfer.ret);
+	}
+
+	if (!async) {
+		ret = data->xfer.ret;
+	} else {
+		ret = 0;
+	}
+#if defined(CONFIG_I3C_CONTROLLER) && defined(CONFIG_I3C_TARGET)
+	/* TODO: decide if this is the right approach or add a new separate API for CH */
+	/* Wait for Controller Handoff to finish */
+	if (payload->ccc.id == I3C_CCC_GETACCCR) {
+		ret = k_sem_take(&data->ch_complete, K_MSEC(1000));
+	}
+#endif /* CONFIG_I3C_CONTROLLER && CONFIG_I3C_TARGET */
+error:
+#ifdef CONFIG_I3C_CALLBACK
+	if (!async || ret != 0) {
+		pm_device_busy_clear(dev);
+		k_sem_give(&data->async_sem);
+	}
+#else
+	pm_device_busy_clear(dev);
+#endif
+	k_mutex_unlock(&data->bus_lock);
+
+	return ret;
+}
+
+void cdns_i3c_complete_transfer(const struct device *dev)
+{
+	struct cdns_i3c_data *data = dev->data;
+	const struct cdns_i3c_config *config = dev->config;
+	uint32_t cmdr;
+	uint32_t id = 0;
+	uint32_t xfer = 0;
+	int ret = 0;
+	struct cdns_i3c_cmd *cmd;
+	bool was_full;
+
+	/* Used only to determine in the case of a controller abort */
+	was_full = cdns_i3c_rx_fifo_full(config);
+
+	/* Disable further interrupts */
+	sys_write32(MST_INT_CMDD_EMP, config->base + MST_IDR);
+
+	/* Ignore if no pending transfer */
+	if (data->xfer.num_cmds == 0) {
+		return;
+	}
+
+	/* Process all results in fifo */
+	for (uint32_t status0 = sys_read32(config->base + MST_STATUS0);
+	     !(status0 & MST_STATUS0_CMDR_EMP); status0 = sys_read32(config->base + MST_STATUS0)) {
+		cmdr = sys_read32(config->base + CMDR);
+		id = CMDR_CMDID(cmdr);
+
+		if (id == CMDR_CMDID_HJACK_DISEC || id == CMDR_CMDID_HJACK_ENTDAA ||
+		    id >= data->xfer.num_cmds) {
+			continue;
+		}
+
+		cmd = &data->xfer.cmds[id];
+
+		xfer = MIN(CMDR_XFER_BYTES(cmdr), cmd->len);
+		if (cmd->num_xfer != NULL) {
+			*cmd->num_xfer = xfer;
+		}
+		/* Read any rx data into buffer */
+		if (cmd->cmd0 & CMD0_FIFO_RNW) {
+			ret = cdns_i3c_read_rx_fifo(config, cmd->buf, xfer);
+		}
+
+		if ((cmd->hdr == I3C_DATA_RATE_HDR_DDR) &&
+		    (DDR_DATA(cmd->ddr_header) & HDR_CMD_RD)) {
+			ret = cdns_i3c_read_rx_fifo_ddr_xfer(config, cmd->buf, xfer,
+							     cmd->ddr_header);
+		}
+
+		/* Record error */
+		cmd->error = CMDR_ERROR(cmdr);
+	}
+
+	for (int i = 0; i < data->xfer.num_cmds; i++) {
+		switch (data->xfer.cmds[i].error) {
+		case CMDR_NO_ERROR:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_NONE;
+			}
+			break;
+
+		case CMDR_MST_ABORT:
+			/*
+			 * A controller abort is forced if the RX FIFO fills up
+			 * There is also the case where the fifo can be full as
+			 * the len of the packet is the same length of the fifo
+			 * Check that the requested len is greater than the total
+			 * transferred to confirm that is not case. Otherwise the
+			 * abort was caused by the buffer length being meet and
+			 * the target did not give an End of Data (EoD) in the T
+			 * bit. Do not treat that condition as an error because
+			 * some targets will just auto-increment the read address
+			 * way beyond the buffer not giving an EoD.
+			 */
+			if ((was_full) && (data->xfer.cmds[i].len > *data->xfer.cmds[i].num_xfer)) {
+				ret = -ENOSPC;
+			} else {
+				LOG_DBG("%s: Controller Abort due to buffer length exceeded with "
+					"no EoD from target",
+					dev->name);
+			}
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_NONE;
+			}
+			break;
+
+		case CMDR_M0_ERROR: {
+			uint8_t ccc = data->xfer.cmds[i].cmd1 & 0xFF;
+			/*
+			 * The M0 is an illegally formatted CCC. i.e. the Controller
+			 * receives 1 byte instead of 2 with the GETMWL CCC. This can
+			 * be problematic for CCCs that can have variable length such
+			 * as GETMXDS and GETCAPS. Verify the number of bytes received matches
+			 * what's expected from the specification and ignore the error. The IP will
+			 * still retramsit the same CCC and there's nothing that can be done to
+			 * prevent this. It is still up to the application to read `num_xfer` to
+			 * determine the number of bytes returned.
+			 */
+			if (ccc == I3C_CCC_GETMXDS) {
+				/*
+				 * Whether GETMXDS format 1 and format 2 can't be known ahead of
+				 * time which will be returned.
+				 */
+				if ((*data->xfer.cmds[i].num_xfer !=
+				     SIZEOF_FIELD(union i3c_ccc_getmxds, fmt1)) &&
+				    (*data->xfer.cmds[i].num_xfer !=
+				     SIZEOF_FIELD(union i3c_ccc_getmxds, fmt2))) {
+					ret = -EIO;
+				}
+			} else if (ccc == I3C_CCC_GETCAPS) {
+				/* GETCAPS can only return 1-4 bytes */
+				if (*data->xfer.cmds[i].num_xfer > sizeof(union i3c_ccc_getcaps)) {
+					ret = -EIO;
+				}
+			} else {
+				if (data->xfer.cmds[i].sdr_err) {
+					*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE0;
+				}
+				ret = -EIO;
+			}
+			break;
+		}
+
+		case CMDR_M1_ERROR:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE1;
+			}
+			ret = -EIO;
+			break;
+		case CMDR_M2_ERROR:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE2;
+			}
+			ret = -EIO;
+			break;
+
+		case CMDR_DDR_PREAMBLE_ERROR:
+		case CMDR_DDR_PARITY_ERROR:
+		case CMDR_NACK_RESP:
+		case CMDR_DDR_DROPPED:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_UNKNOWN;
+			}
+			ret = -EIO;
+			break;
+
+		case CMDR_DDR_RX_FIFO_OVF:
+		case CMDR_DDR_TX_FIFO_UNF:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_UNKNOWN;
+			}
+			ret = -ENOSPC;
+			break;
+
+		case CMDR_INVALID_DA:
+		default:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_UNKNOWN;
+			}
+			ret = -EINVAL;
+			break;
+		}
+	}
+
+	data->xfer.ret = ret;
+
+	/* Indicate no transfer is pending */
+	data->xfer.num_cmds = 0;
+#if defined(CONFIG_I3C_CALLBACK) || defined(CONFIG_I2C_CALLBACK)
+	pm_device_busy_clear(dev);
+	if (data->cb) {
+		k_timer_stop(&data->timeout);
+		data->cb(dev, ret, data->userdata);
+		k_sem_give(&data->async_sem);
+	} else {
+		k_sem_give(&data->xfer.complete);
+	}
+#else
+	k_sem_give(&data->xfer.complete);
+#endif
+}
+
+static int cdns_i3c_i2c_transfer_do(const struct device *dev, struct i3c_i2c_device_desc *i2c_dev,
+				    struct i2c_msg *msgs, uint8_t num_msgs, bool async,
+				    i2c_callback_t cb, void *userdata)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
+	uint32_t txsize = 0;
+	uint32_t rxsize = 0;
+	int ret;
+	k_timeout_t xfer_timeout;
+
+	__ASSERT_NO_MSG(num_msgs > 0);
+
+	if (num_msgs > data->hw_cfg.cmd_mem_depth || num_msgs > data->hw_cfg.cmdr_mem_depth) {
+		LOG_ERR("%s: Too many messages", dev->name);
+		return -ENOMEM;
+	}
+
+	/*
+	 * Ensure data will fit within FIFOs
+	 */
+	for (unsigned int i = 0; i < num_msgs; i++) {
+		if ((msgs[i].flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) {
+			rxsize += ROUND_UP(msgs[i].len, 4);
+		} else {
+			txsize += ROUND_UP(msgs[i].len, 4);
+		}
+	}
+	if ((rxsize > data->hw_cfg.rx_mem_depth) || (txsize > data->hw_cfg.tx_mem_depth)) {
+		LOG_ERR("%s: Total RX and/or TX transfer larger than FIFO", dev->name);
+		return -ENOMEM;
+	}
+
+	k_mutex_lock(&data->bus_lock, K_FOREVER);
+#ifdef CONFIG_I2C_CALLBACK
+	k_sem_take(&data->async_sem, K_FOREVER);
+	if (async) {
+		data->cb = cb;
+		data->userdata = userdata;
+	} else {
+		data->cb = NULL;
+		data->userdata = NULL;
+	}
+#endif
+	pm_device_busy_set(dev);
+
+	/* make sure we are currently the active controller */
+	if (!(sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE)) {
+		ret = -EACCES;
+		goto error;
+	}
+
+	/* wait for idle */
+	ret = cdns_i3c_wait_for_idle(dev);
+	if (ret != 0) {
+		goto error;
+	}
+
+	for (unsigned int i = 0; i < num_msgs; i++) {
+		struct cdns_i3c_cmd *cmd = &data->xfer.cmds[i];
+
+		cmd->len = msgs[i].len;
+		cmd->buf = msgs[i].buf;
+		/* not an i3c transfer, but must be set to sdr */
+		cmd->hdr = I3C_DATA_RATE_SDR;
+
+		cmd->cmd0 = CMD0_FIFO_PRIV_XMIT_MODE(XMIT_BURST_WITHOUT_SUBADDR);
+		cmd->cmd0 |= CMD0_FIFO_DEV_ADDR(i2c_dev->addr);
+		cmd->cmd0 |= CMD0_FIFO_PL_LEN(msgs[i].len);
+
+		/* Send repeated start on all transfers except the last or those marked STOP. */
+		if ((i < (num_msgs - 1)) && ((msgs[i].flags & I2C_MSG_STOP) == 0)) {
+			cmd->cmd0 |= CMD0_FIFO_RSBC;
+		}
+
+		if (msgs[i].flags & I2C_MSG_ADDR_10_BITS) {
+			cmd->cmd0 |= CMD0_FIFO_IS_10B;
+		}
+
+		if ((msgs[i].flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) {
+			cmd->cmd0 |= CMD0_FIFO_RNW;
+		}
+
+		/* i2c transfers are a don't care for num_xfer and sdr error */
+		cmd->num_xfer = NULL;
+		cmd->sdr_err = NULL;
+	}
+
+	data->xfer.ret = -ETIMEDOUT;
+	data->xfer.num_cmds = num_msgs;
+
+	xfer_timeout = cdns_i3c_calc_timeout_i2c(msgs, num_msgs,
+						  data->common.ctrl_config.scl.i2c);
+
+	cdns_i3c_start_transfer(dev);
+	if (!async) {
+		if (k_sem_take(&data->xfer.complete, xfer_timeout) != 0) {
+			cdns_i3c_cancel_transfer(dev);
+		}
+		ret = data->xfer.ret;
+	}
+#ifdef CONFIG_I2C_CALLBACK
+	else {
+		k_timer_start(&data->timeout, xfer_timeout, K_NO_WAIT);
+		ret = 0;
+	}
+#endif
+error:
+#ifdef CONFIG_I2C_CALLBACK
+	if (!async || ret != 0) {
+		pm_device_busy_clear(dev);
+		k_sem_give(&data->async_sem);
+	}
+#else
+	pm_device_busy_clear(dev);
+#endif
+	k_mutex_unlock(&data->bus_lock);
+
+	return ret;
+}
+
+int cdns_i3c_i2c_transfer(const struct device *dev, struct i3c_i2c_device_desc *i2c_dev,
+			  struct i2c_msg *msgs, uint8_t num_msgs)
+{
+	return cdns_i3c_i2c_transfer_do(dev, i2c_dev, msgs, num_msgs, false, NULL, NULL);
+}
+
+#ifdef CONFIG_I2C_CALLBACK
+int cdns_i3c_i2c_transfer_cb(const struct device *dev, struct i3c_i2c_device_desc *i2c_dev,
+			     struct i2c_msg *msgs, uint8_t num_msgs, i2c_callback_t cb,
+			     void *userdata)
+{
+	return cdns_i3c_i2c_transfer_do(dev, i2c_dev, msgs, num_msgs, true, cb, userdata);
+}
+#endif
+
+int cdns_i3c_transfer_do(const struct device *dev, struct i3c_device_desc *target,
+			 struct i3c_msg *msgs, uint8_t num_msgs, bool async, i3c_callback_t cb,
+			 void *userdata)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
+	int txsize = 0;
+	int rxsize = 0;
+	int ret;
+	k_timeout_t xfer_timeout;
+
+	__ASSERT_NO_MSG(num_msgs > 0);
+
+	if (num_msgs > data->hw_cfg.cmd_mem_depth || num_msgs > data->hw_cfg.cmdr_mem_depth) {
+		LOG_ERR("%s: Too many messages", dev->name);
+		return -ENOMEM;
+	}
+
+	/*
+	 * Ensure data will fit within FIFOs.
+	 *
+	 * TODO: This limitation prevents burst transfers greater than the
+	 *       FIFO sizes and should be replaced with an implementation that
+	 *       utilizes the RX/TX data interrupts.
+	 */
+	for (int i = 0; i < num_msgs; i++) {
+		if ((msgs[i].flags & I3C_MSG_RW_MASK) == I3C_MSG_READ) {
+			rxsize += ROUND_UP(msgs[i].len, 4);
+		} else {
+			txsize += ROUND_UP(msgs[i].len, 4);
+		}
+	}
+	if ((rxsize > data->hw_cfg.rx_mem_depth) || (txsize > data->hw_cfg.tx_mem_depth)) {
+		LOG_ERR("%s: Total RX and/or TX transfer larger than FIFO", dev->name);
+		return -ENOMEM;
+	}
+
+	k_mutex_lock(&data->bus_lock, K_FOREVER);
+#ifdef CONFIG_I3C_CALLBACK
+	k_sem_take(&data->async_sem, K_FOREVER);
+	if (async) {
+		data->cb = cb;
+		data->userdata = userdata;
+	} else {
+		data->cb = NULL;
+		data->userdata = NULL;
+	}
+#endif
+	pm_device_busy_set(dev);
+
+	/* make sure we are currently the active controller */
+	if (!(sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE)) {
+		ret = -EACCES;
+		goto error;
+	}
+
+	/* wait for idle */
+	ret = cdns_i3c_wait_for_idle(dev);
+	if (ret != 0) {
+		goto error;
+	}
+
+	/*
+	 * Prepare transfer commands. Currently there is only a single transfer
+	 * in-flight but it would be possible to keep a queue of transfers. If so,
+	 * this preparation could be completed outside of the bus lock allowing
+	 * greater parallelism.
+	 */
+	bool send_broadcast = true;
+
+	for (int i = 0; i < num_msgs; i++) {
+		struct cdns_i3c_cmd *cmd = &data->xfer.cmds[i];
+		uint32_t pl = msgs[i].len;
+		/* check hdr mode */
+		if ((!(msgs[i].flags & I3C_MSG_HDR)) ||
+		    ((msgs[i].flags & I3C_MSG_HDR) && (msgs[i].hdr_mode == 0))) {
+			/* HDR message flag is not set or if hdr flag is set but no hdr mode is set
+			 */
+			cmd->len = pl;
+			cmd->buf = msgs[i].buf;
+
+			cmd->cmd0 = CMD0_FIFO_PRIV_XMIT_MODE(XMIT_BURST_WITHOUT_SUBADDR);
+			cmd->cmd0 |= CMD0_FIFO_DEV_ADDR(target->dynamic_addr);
+			if ((msgs[i].flags & I3C_MSG_RW_MASK) == I3C_MSG_READ) {
+				cmd->cmd0 |= CMD0_FIFO_RNW;
+			}
+			/*
+			 * For I3C_XMIT_MODE_NO_ADDR reads in SDN mode,
+			 * CMD0_FIFO_PL_LEN specifies the abort limit not bytes to read
+			 */
+			cmd->cmd0 |= CMD0_FIFO_PL_LEN(pl);
+
+			/* Send broadcast header on first transfer or after a STOP. */
+			if (!(msgs[i].flags & I3C_MSG_NBCH) && (send_broadcast)) {
+				cmd->cmd0 |= CMD0_FIFO_BCH;
+				send_broadcast = false;
+			}
+
+			/*
+			 * Send repeated start on all transfers except the last or those marked
+			 * STOP.
+			 */
+			if ((i < (num_msgs - 1)) && ((msgs[i].flags & I3C_MSG_STOP) == 0)) {
+				cmd->cmd0 |= CMD0_FIFO_RSBC;
+			} else {
+				send_broadcast = true;
+			}
+
+			/*
+			 * write the address of num_xfer which is to be updated upon message
+			 * completion
+			 */
+			cmd->num_xfer = &(msgs[i].num_xfer);
+			cmd->sdr_err = &(msgs[i].err);
+			cmd->hdr = I3C_DATA_RATE_SDR;
+		} else if ((data->common.ctrl_config.supported_hdr & I3C_MSG_HDR_DDR) &&
+			   (msgs[i].hdr_mode == I3C_MSG_HDR_DDR) && (msgs[i].flags & I3C_MSG_HDR)) {
+			uint16_t ddr_header_payload;
+
+			/* DDR sends data out in 16b, so len must be a multiple of 2 */
+			if (!((pl % 2) == 0)) {
+				ret = -EINVAL;
+				goto error;
+			}
+			/* HDR message flag is set and hdr mode is DDR */
+			cmd->buf = msgs[i].buf;
+			if ((msgs[i].flags & I3C_MSG_RW_MASK) == I3C_MSG_READ) {
+				/* HDR-DDR Read */
+				ddr_header_payload = HDR_CMD_RD |
+						     HDR_CMD_CODE(msgs[i].hdr_cmd_code) |
+						     (target->dynamic_addr << 1);
+				/* Parity Adjustment Bit for Reads */
+				ddr_header_payload =
+					prepare_ddr_cmd_parity_adjustment_bit(ddr_header_payload);
+				/* HDR-DDR Command Word */
+				cmd->ddr_header =
+					DDR_PREAMBLE_CMD_CRC | prepare_ddr_word(ddr_header_payload);
+			} else {
+				uint8_t crc5 = 0x1F;
+				/* HDR-DDR Write */
+				ddr_header_payload = HDR_CMD_CODE(msgs[i].hdr_cmd_code) |
+						     (target->dynamic_addr << 1);
+				/* HDR-DDR Command Word */
+				cmd->ddr_header =
+					DDR_PREAMBLE_CMD_CRC | prepare_ddr_word(ddr_header_payload);
+				/* calculate crc5 */
+				crc5 = i3c_cdns_crc5(crc5, ddr_header_payload);
+				for (int j = 0; j < pl; j += 2) {
+					crc5 = i3c_cdns_crc5(
+						crc5,
+						sys_get_be16((void *)((uintptr_t)cmd->buf + j)));
+				}
+				cmd->ddr_crc = DDR_PREAMBLE_CMD_CRC | DDR_CRC_TOKEN | (crc5 << 9) |
+					       DDR_CRC_WR_SETUP;
+			}
+			/* Length of DDR Transfer is length of payload (in 16b) + header and CRC
+			 * blocks
+			 */
+			cmd->len = ((pl / 2) + 2);
+
+			/* prep command FIFO for ENTHDR0 */
+			cmd->cmd0 = CMD0_FIFO_IS_CCC;
+			cmd->cmd1 = I3C_CCC_ENTHDR0;
+			/* write the address of num_xfer which is to be updated upon message
+			 * completion
+			 */
+			cmd->num_xfer = &(msgs[i].num_xfer);
+			cmd->sdr_err = &(msgs[i].err);
+			cmd->hdr = I3C_DATA_RATE_HDR_DDR;
+		} else {
+			LOG_ERR("%s: Unsupported HDR Mode %d", dev->name, msgs[i].hdr_mode);
+			ret = -ENOTSUP;
+			goto error;
+		}
+	}
+
+	data->xfer.ret = -ETIMEDOUT;
+	data->xfer.num_cmds = num_msgs;
+
+	xfer_timeout = cdns_i3c_calc_timeout_i3c(msgs, num_msgs,
+						  data->common.ctrl_config.scl.i3c);
+
+	cdns_i3c_start_transfer(dev);
+	if (!async) {
+		if (k_sem_take(&data->xfer.complete, xfer_timeout) != 0) {
+			LOG_ERR("%s: transfer timed out", dev->name);
+			cdns_i3c_cancel_transfer(dev);
+		}
+	}
+#ifdef CONFIG_I3C_CALLBACK
+	else {
+		k_timer_start(&data->timeout, xfer_timeout, K_NO_WAIT);
+	}
+#endif
+	if (!async) {
+		ret = data->xfer.ret;
+	} else {
+		ret = 0;
+	}
+error:
+#ifdef CONFIG_I3C_CALLBACK
+	if (!async || ret != 0) {
+		pm_device_busy_clear(dev);
+		k_sem_give(&data->async_sem);
+	}
+#else
+	pm_device_busy_clear(dev);
+#endif
+	k_mutex_unlock(&data->bus_lock);
+
+	return ret;
+}
+
+struct i3c_i2c_device_desc *cdns_i3c_i2c_device_find(const struct device *dev, uint16_t addr)
+{
+	return i3c_dev_list_i2c_addr_find(dev, addr);
+}
+#endif /* CONFIG_I3C_CONTROLLER */

--- a/drivers/i3c/i3c_cdns_rtio.c
+++ b/drivers/i3c/i3c_cdns_rtio.c
@@ -1,0 +1,1094 @@
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and its affiliates.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Native RTIO submit path for the Cadence I3C controller.
+ *
+ * Owns BOTH the i3c-RTIO and i2c-on-i3c-RTIO data paths. Each iodev_submit
+ * entry pushes into its respective RTIO queue (i3c_rtio or i2c_rtio); the
+ * controller-level state in cdns_i3c_rtio_state guarantees only one
+ * transaction drives the bus at a time.
+ *
+ * The active transaction's "kind" is implicit in active_head->sqe.iodev->api:
+ *   - &i3c_iodev_api -> i3c data sqe (RTIO_OP_RX/TX/TINY_TX) or CCC sqe
+ *   - &i2c_iodev_api -> i2c-on-i3c sqe
+ *
+ * Scope: SDR controller mode plus HDR-DDR. Ops handled natively are
+ * RTIO_OP_TX, RTIO_OP_RX, RTIO_OP_TINY_TX, and RTIO_OP_I3C_CCC. HDR-DDR
+ * streams via TX_THR / RX_THR thresholds. HDR-TS, HDR-BT, TXRX,
+ * I3C_CONFIGURE, and I3C_RECOVER fall back to -ENOTSUP from this path.
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i2c/rtio.h>
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/drivers/i3c/rtio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
+
+#include "i3c_cdns.h"
+
+LOG_MODULE_DECLARE(I3C_CADENCE, CONFIG_I3C_CADENCE_LOG_LEVEL);
+
+static void cdns_i3c_rtio_complete_txn(const struct device *dev, int status);
+
+static inline bool sqe_is_i3c(const struct rtio_iodev_sqe *iodev_sqe)
+{
+	return iodev_sqe != NULL && iodev_sqe->sqe.iodev != NULL &&
+	       iodev_sqe->sqe.iodev->api == &i3c_iodev_api;
+}
+
+static inline bool sqe_is_i2c(const struct rtio_iodev_sqe *iodev_sqe)
+{
+	return iodev_sqe != NULL && iodev_sqe->sqe.iodev != NULL &&
+	       iodev_sqe->sqe.iodev->api == &i2c_iodev_api;
+}
+
+/*
+ * Resolve i3c_device_desc for an i3c data sqe. CCC sqes do not need a desc.
+ */
+static struct i3c_device_desc *cdns_i3c_rtio_resolve_i3c_desc(const struct device *dev,
+							      struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+	const struct i3c_iodev_data *iodev_data;
+
+	if (!sqe_is_i3c(iodev_sqe)) {
+		return NULL;
+	}
+
+	if (iodev_sqe->sqe.iodev == &state->i3c_ctx->iodev) {
+		return state->i3c_ctx->i3c_desc;
+	}
+
+	if (iodev_sqe->sqe.iodev->data == NULL) {
+		return NULL;
+	}
+
+	iodev_data = (const struct i3c_iodev_data *)iodev_sqe->sqe.iodev->data;
+	if (iodev_data->bus != dev) {
+		return NULL;
+	}
+
+	return i3c_device_find(dev, &iodev_data->dev_id);
+}
+
+static const struct i2c_dt_spec *cdns_i3c_rtio_resolve_i2c_spec(struct rtio_iodev_sqe *iodev_sqe)
+{
+	if (!sqe_is_i2c(iodev_sqe) || iodev_sqe->sqe.iodev->data == NULL) {
+		return NULL;
+	}
+
+	return (const struct i2c_dt_spec *)iodev_sqe->sqe.iodev->data;
+}
+
+static bool cdns_i3c_rtio_sqe_tx_buf(const struct rtio_iodev_sqe *iodev_sqe,
+				     const uint8_t **out_buf, uint32_t *out_len);
+
+/*
+ * Pull the next outbound source from the TX cursor, advancing past sqes
+ * that have nothing more to send. For DDR cmds, "more to send" includes
+ * the header phase (before any payload) and CRC phase (after all payload
+ * bytes are consumed) — not just tx_off < len.
+ *
+ * Returns true when the cursor is positioned on a cmd with TX work
+ * remaining; false when the entire transaction has been pushed.
+ */
+static bool cdns_i3c_rtio_advance_tx_cursor(struct cdns_i3c_rtio_state *state)
+{
+	while (state->tx_sqe != NULL) {
+		struct cdns_i3c_rtio_cmd *cmd =
+			(state->tx_cmd_idx < state->num_cmds) ? &state->cmds[state->tx_cmd_idx]
+							      : NULL;
+		bool more = false;
+
+		if (cmd != NULL && cmd->is_ddr) {
+			if (cmd->is_read) {
+				/* DDR reads only push the header on the TX side. */
+				more = (state->ddr_tx_phase == DDR_TX_HEADER);
+			} else {
+				more = (state->ddr_tx_phase != DDR_TX_DONE);
+			}
+		} else {
+			uint32_t tx_len = 0;
+
+			switch (state->tx_sqe->sqe.op) {
+			case RTIO_OP_TX:
+				tx_len = state->tx_sqe->sqe.tx.buf_len;
+				break;
+			case RTIO_OP_TINY_TX:
+				tx_len = state->tx_sqe->sqe.tiny_tx.buf_len;
+				break;
+			default:
+				break;
+			}
+			more = (tx_len > state->tx_off);
+		}
+
+		if (more) {
+			return true;
+		}
+
+		state->tx_sqe = rtio_txn_next(state->tx_sqe);
+		state->tx_off = 0;
+		state->tx_cmd_idx++;
+		state->ddr_tx_phase = DDR_TX_HEADER;
+	}
+
+	return false;
+}
+
+static bool cdns_i3c_rtio_advance_rx_cursor(struct cdns_i3c_rtio_state *state)
+{
+	while (state->rx_sqe != NULL) {
+		struct cdns_i3c_rtio_cmd *cmd =
+			(state->rx_cmd_idx < state->num_cmds) ? &state->cmds[state->rx_cmd_idx]
+							      : NULL;
+
+		if (cmd != NULL && cmd->is_ddr && cmd->is_read) {
+			/* DDR reads always have a CRC token after the data
+			 * words; "more" includes the still-pending CRC. The
+			 * decoder loop checks rx_off vs len to know whether the
+			 * next FIFO word is data or CRC.
+			 */
+			if (state->rx_sqe->sqe.op == RTIO_OP_RX) {
+				return true;
+			}
+		} else if (state->rx_sqe->sqe.op == RTIO_OP_RX &&
+			   state->rx_sqe->sqe.rx.buf_len > state->rx_off) {
+			return true;
+		}
+
+		state->rx_sqe = rtio_txn_next(state->rx_sqe);
+		state->rx_off = 0;
+		state->rx_cmd_idx++;
+	}
+
+	return false;
+}
+
+static void cdns_i3c_rtio_drain_tx(const struct device *dev)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+
+	while (cdns_i3c_rtio_advance_tx_cursor(state)) {
+		struct cdns_i3c_rtio_cmd *cmd = &state->cmds[state->tx_cmd_idx];
+
+		if (cdns_i3c_tx_fifo_full(config)) {
+			return;
+		}
+
+		if (cmd->is_ddr) {
+			const uint8_t *src;
+			uint32_t src_len;
+			uint16_t pl;
+			uint32_t preamble;
+			uint32_t word;
+
+			switch (state->ddr_tx_phase) {
+			case DDR_TX_HEADER:
+				sys_write32(cmd->ddr_header, config->base + TX_FIFO);
+				/* Reads have no data/CRC on TX side. */
+				state->ddr_tx_phase = cmd->is_read ? DDR_TX_DONE : DDR_TX_DATA;
+				break;
+			case DDR_TX_DATA:
+				if (!cdns_i3c_rtio_sqe_tx_buf(state->tx_sqe, &src, &src_len)) {
+					/* Shouldn't happen — walk validated this. */
+					state->ddr_tx_phase = DDR_TX_DONE;
+					break;
+				}
+				pl = sys_get_be16(&src[state->tx_off]);
+				preamble = (state->tx_off == 0) ? DDR_PREAMBLE_DATA_ABORT
+								: DDR_PREAMBLE_DATA_ABORT_ALT;
+				word = preamble | prepare_ddr_word(pl);
+				sys_write32(word, config->base + TX_FIFO);
+				state->tx_off += 2;
+				if (state->tx_off >= cmd->len) {
+					state->ddr_tx_phase = DDR_TX_CRC;
+				}
+				break;
+			case DDR_TX_CRC:
+				sys_write32(cmd->ddr_crc_word, config->base + TX_FIFO);
+				state->ddr_tx_phase = DDR_TX_DONE;
+				break;
+			case DDR_TX_DONE:
+			default:
+				/* Shouldn't reach here — advance_tx_cursor would
+				 * have moved on. Defensive: fall through to next
+				 * loop iteration which will advance.
+				 */
+				break;
+			}
+		} else {
+			const uint8_t *src;
+			uint32_t total;
+
+			if (state->tx_sqe->sqe.op == RTIO_OP_TX) {
+				src = state->tx_sqe->sqe.tx.buf;
+				total = state->tx_sqe->sqe.tx.buf_len;
+			} else {
+				src = state->tx_sqe->sqe.tiny_tx.buf;
+				total = state->tx_sqe->sqe.tiny_tx.buf_len;
+			}
+
+			uint32_t remaining = total - state->tx_off;
+			uint32_t chunk = MIN(remaining, sizeof(uint32_t));
+
+			cdns_i3c_write_tx_fifo(config, &src[state->tx_off], chunk);
+			state->tx_off += chunk;
+		}
+	}
+}
+
+static void cdns_i3c_rtio_drain_rx(const struct device *dev)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+
+	while (cdns_i3c_rtio_advance_rx_cursor(state)) {
+		struct cdns_i3c_rtio_cmd *cmd = &state->cmds[state->rx_cmd_idx];
+		uint8_t *dst = state->rx_sqe->sqe.rx.buf;
+
+		if (cdns_i3c_rx_fifo_empty(config)) {
+			return;
+		}
+
+		if (cmd->is_ddr) {
+			uint32_t val = sys_read32(config->base + RX_FIFO);
+			uint32_t preamble = val & DDR_PREAMBLE_MASK;
+
+			if (preamble == DDR_PREAMBLE_DATA_ABORT ||
+			    preamble == DDR_PREAMBLE_DATA_ABORT_ALT) {
+				uint16_t pl = (uint16_t)DDR_DATA(val);
+
+				if (state->rx_off + 2 <= cmd->len) {
+					sys_put_be16(pl, &dst[state->rx_off]);
+					state->rx_off += 2;
+				}
+				cmd->ddr_crc = i3c_cdns_crc5(cmd->ddr_crc, pl);
+			} else if (preamble == DDR_PREAMBLE_CMD_CRC &&
+				   (val & DDR_CRC_TOKEN_MASK) == DDR_CRC_TOKEN) {
+				uint8_t crc = (uint8_t)DDR_CRC(val);
+
+				if (cmd->ddr_crc != crc) {
+					LOG_ERR("DDR RX crc error");
+					if (state->xfer_status == 0) {
+						state->xfer_status = -EIO;
+					}
+				}
+				/* Force advance to next sqe — CRC token marks
+				 * end of this cmd's RX stream, even if some
+				 * data words were dropped above (rx_off < len).
+				 */
+				state->rx_off = cmd->len;
+			}
+			/* Other preambles silently ignored (legacy parity). */
+		} else {
+			uint32_t total = state->rx_sqe->sqe.rx.buf_len;
+			uint32_t remaining = total - state->rx_off;
+			uint32_t chunk = MIN(remaining, sizeof(uint32_t));
+
+			if (cdns_i3c_read_rx_fifo(config, &dst[state->rx_off], chunk) != 0) {
+				return;
+			}
+			state->rx_off += chunk;
+		}
+	}
+}
+
+static int cdns_i3c_rtio_translate_cmdr_error(uint32_t err)
+{
+	switch (err) {
+	case CMDR_NO_ERROR:
+		return 0;
+	case CMDR_DDR_RX_FIFO_OVF:
+	case CMDR_DDR_TX_FIFO_UNF:
+		return -ENOSPC;
+	case CMDR_NACK_RESP:
+	case CMDR_INVALID_DA:
+		return -ENXIO;
+	default:
+		return -EIO;
+	}
+}
+
+static enum i3c_sdr_controller_error_types cdns_i3c_rtio_cmdr_sdr_error(uint32_t err)
+{
+	switch (err) {
+	case CMDR_NO_ERROR:
+	case CMDR_MST_ABORT:
+		return I3C_ERROR_CE_NONE;
+	case CMDR_M0_ERROR:
+		return I3C_ERROR_CE0;
+	case CMDR_M1_ERROR:
+		return I3C_ERROR_CE1;
+	case CMDR_M2_ERROR:
+		return I3C_ERROR_CE2;
+	default:
+		return I3C_ERROR_CE_UNKNOWN;
+	}
+}
+
+/*
+ * Walk an i3c data transaction starting at txn_head. Validates ops, fills
+ * state->cmds[], returns the number of commands or a negative errno.
+ */
+static int cdns_i3c_rtio_walk_i3c_txn(const struct device *dev)
+{
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+	struct rtio_iodev_sqe *cur = state->active_head;
+	bool ddr_supported =
+		(data->common.ctrl_config.supported_hdr & I3C_MSG_HDR_DDR) != 0;
+	uint8_t n = 0;
+
+	while (cur != NULL) {
+		uint32_t buf_len;
+		uint16_t plen;
+		bool is_read;
+		bool is_ddr = false;
+
+		if (n >= I3C_MAX_MSGS || n >= data->hw_cfg.cmd_mem_depth ||
+		    n >= data->hw_cfg.cmdr_mem_depth) {
+			return -ENOMEM;
+		}
+
+		switch (cur->sqe.op) {
+		case RTIO_OP_RX:
+			buf_len = cur->sqe.rx.buf_len;
+			is_read = true;
+			break;
+		case RTIO_OP_TX:
+			buf_len = cur->sqe.tx.buf_len;
+			is_read = false;
+			break;
+		case RTIO_OP_TINY_TX:
+			buf_len = cur->sqe.tiny_tx.buf_len;
+			is_read = false;
+			break;
+		default:
+			return -ENOTSUP;
+		}
+
+		if (cur->sqe.iodev_flags & RTIO_IODEV_I3C_HDR) {
+			uint32_t mode = RTIO_IODEV_I3C_HDR_MODE_GET(cur->sqe.iodev_flags);
+
+			if (mode != I3C_MSG_HDR_DDR) {
+				/* Only HDR-DDR is wired up in v1; other HDR modes
+				 * (TS, BT) fall through to the fallback.
+				 */
+				return -ENOTSUP;
+			}
+			if (!ddr_supported) {
+				return -ENOTSUP;
+			}
+			/* DDR sends data 16b at a time; payload must be even. */
+			if ((buf_len % 2) != 0) {
+				return -EINVAL;
+			}
+			/*
+			 * DDR PL_LEN counts 16-bit words: (len/2) data words + 1 cmd
+			 * header word + 1 CRC word. Must fit in the 12-bit PL_LEN field.
+			 */
+			if (((buf_len / 2) + 2) > CMD0_FIFO_PL_LEN_MAX) {
+				return -EMSGSIZE;
+			}
+			is_ddr = true;
+		} else {
+			/* SDR PL_LEN field is 12 bits → byte count must fit. */
+			if (buf_len > CMD0_FIFO_PL_LEN_MAX) {
+				return -EMSGSIZE;
+			}
+		}
+
+		plen = (uint16_t)buf_len;
+
+		state->cmds[n].sqe = cur;
+		state->cmds[n].len = plen;
+		state->cmds[n].is_read = is_read;
+		state->cmds[n].is_ccc_target = false;
+		state->cmds[n].is_ddr = is_ddr;
+
+		n++;
+		cur = rtio_txn_next(cur);
+	}
+
+	return n;
+}
+
+/*
+ * Walk an i2c-on-i3c data transaction. Same shape as i3c walk but no HDR
+ * check and addressing comes from i2c_dt_spec; we only validate ops here.
+ */
+static int cdns_i3c_rtio_walk_i2c_txn(const struct device *dev)
+{
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+	struct rtio_iodev_sqe *cur = state->active_head;
+	uint8_t n = 0;
+
+	while (cur != NULL) {
+		uint32_t buf_len;
+		uint16_t plen;
+		bool is_read;
+
+		if (n >= I3C_MAX_MSGS || n >= data->hw_cfg.cmd_mem_depth ||
+		    n >= data->hw_cfg.cmdr_mem_depth) {
+			return -ENOMEM;
+		}
+
+		switch (cur->sqe.op) {
+		case RTIO_OP_RX:
+			buf_len = cur->sqe.rx.buf_len;
+			is_read = true;
+			break;
+		case RTIO_OP_TX:
+			buf_len = cur->sqe.tx.buf_len;
+			is_read = false;
+			break;
+		case RTIO_OP_TINY_TX:
+			buf_len = cur->sqe.tiny_tx.buf_len;
+			is_read = false;
+			break;
+		default:
+			return -ENOTSUP;
+		}
+
+		/* PL_LEN field is 12 bits → byte count must fit. */
+		if (buf_len > CMD0_FIFO_PL_LEN_MAX) {
+			return -EMSGSIZE;
+		}
+
+		plen = (uint16_t)buf_len;
+
+		state->cmds[n].sqe = cur;
+		state->cmds[n].len = plen;
+		state->cmds[n].is_read = is_read;
+		state->cmds[n].is_ccc_target = false;
+		state->cmds[n].is_ddr = false;
+
+		n++;
+		cur = rtio_txn_next(cur);
+	}
+
+	return n;
+}
+
+static int cdns_i3c_rtio_build_ccc(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct cdns_i3c_data *data = dev->data;
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+	struct i3c_ccc_payload *payload = iodev_sqe->sqe.ccc_payload;
+	bool broadcast;
+
+	if (payload == NULL) {
+		return -EINVAL;
+	}
+
+	broadcast = i3c_ccc_is_payload_broadcast(payload);
+
+	if (broadcast) {
+		uint32_t cmd0 = CMD0_FIFO_IS_CCC | CMD0_FIFO_BCH;
+		uint32_t cmd1 = CMD1_FIFO_CCC(payload->ccc.id) | CMD1_FIFO_CMDID(0);
+
+		if (payload->ccc.data_len > CMD0_FIFO_PL_LEN_MAX ||
+		    payload->ccc.data_len > data->hw_cfg.tx_mem_depth) {
+			return -EMSGSIZE;
+		}
+
+		state->cmds[0].sqe = iodev_sqe;
+		state->cmds[0].len = payload->ccc.data_len;
+		state->cmds[0].is_read = false;
+		state->cmds[0].is_ccc_target = false;
+		state->cmds[0].is_ddr = false;
+
+		if (payload->ccc.data_len > 0) {
+			cmd0 |= CMD0_FIFO_PL_LEN(payload->ccc.data_len);
+			cdns_i3c_write_tx_fifo(config, payload->ccc.data, payload->ccc.data_len);
+		}
+
+		sys_write32(cmd1, config->base + CMD1_FIFO);
+		sys_write32(cmd0, config->base + CMD0_FIFO);
+
+		return 1;
+	}
+
+	if (payload->targets.num_targets == 0 || payload->targets.num_targets > I3C_MAX_MSGS) {
+		return -EINVAL;
+	}
+
+	if (payload->ccc.data_len == 1) {
+		if (REV_ID_REV(data->hw_cfg.rev_id) < REV_ID_VERSION(1, 7)) {
+			LOG_ERR("%s: Defining Byte with Direct CCC not supported with rev %lup%lu",
+				dev->name, REV_ID_REV_MAJOR(data->hw_cfg.rev_id),
+				REV_ID_REV_MINOR(data->hw_cfg.rev_id));
+			return -ENOTSUP;
+		}
+	} else if (payload->ccc.data_len > 1) {
+		LOG_ERR("%s: Defining Byte length greater than 1", dev->name);
+		return -EINVAL;
+	}
+
+	/*
+	 * Pre-flight: sum direct-CCC per-target writes/reads and reject any that
+	 * would overrun TX/RX FIFOs or exceed the PL_LEN field max. Native RTIO
+	 * CCC writes/reads aren't streamed via *_THR IRQs (legacy parity), so
+	 * the controller must hold the full payload up-front.
+	 */
+	{
+		uint32_t txsum = 0;
+		uint32_t rxsum = 0;
+
+		for (uint8_t i = 0; i < payload->targets.num_targets; i++) {
+			size_t plen = payload->targets.payloads[i].data_len;
+
+			if (plen > CMD0_FIFO_PL_LEN_MAX) {
+				return -EMSGSIZE;
+			}
+			if (payload->targets.payloads[i].rnw) {
+				rxsum += plen;
+			} else {
+				txsum += plen;
+			}
+		}
+		if (txsum > data->hw_cfg.tx_mem_depth || rxsum > data->hw_cfg.rx_mem_depth) {
+			return -EMSGSIZE;
+		}
+	}
+
+	for (uint8_t i = 0; i < payload->targets.num_targets; i++) {
+		uint32_t cmd0 = CMD0_FIFO_IS_CCC;
+		uint32_t cmd1 = CMD1_FIFO_CCC(payload->ccc.id) | CMD1_FIFO_CMDID(i);
+		uint8_t addr = payload->targets.payloads[i].addr;
+		size_t plen = payload->targets.payloads[i].data_len;
+
+		if (i == 0) {
+			cmd0 |= CMD0_FIFO_BCH;
+			if (payload->ccc.data_len == 1 &&
+			    REV_ID_REV(data->hw_cfg.rev_id) >= REV_ID_VERSION(1, 7)) {
+				cmd0 |= CMD0_FIFO_IS_DB;
+				cmd1 |= CMD1_FIFO_DB(payload->ccc.data[0]);
+			}
+		}
+		if (i < (payload->targets.num_targets - 1)) {
+			cmd0 |= CMD0_FIFO_RSBC;
+		}
+
+		cmd0 |= CMD0_FIFO_DEV_ADDR(addr) | CMD0_FIFO_PL_LEN(plen);
+
+		state->cmds[i].sqe = iodev_sqe;
+		state->cmds[i].len = plen;
+		state->cmds[i].is_read = payload->targets.payloads[i].rnw;
+		state->cmds[i].is_ccc_target = true;
+		state->cmds[i].is_ddr = false;
+		state->cmds[i].ccc_target_idx = i;
+
+		if (payload->targets.payloads[i].rnw) {
+			cmd0 |= CMD0_FIFO_RNW;
+		} else if (plen > 0) {
+			cdns_i3c_write_tx_fifo(config, payload->targets.payloads[i].data, plen);
+		}
+
+		sys_write32(cmd1, config->base + CMD1_FIFO);
+		sys_write32(cmd0, config->base + CMD0_FIFO);
+	}
+
+	return (int)payload->targets.num_targets;
+}
+
+/*
+ * Resolve TX source bytes for a sqe (RTIO_OP_TX or RTIO_OP_TINY_TX).
+ * Sets *out_buf and *out_len. Returns false for non-TX-bearing ops.
+ */
+static bool cdns_i3c_rtio_sqe_tx_buf(const struct rtio_iodev_sqe *iodev_sqe,
+				     const uint8_t **out_buf, uint32_t *out_len)
+{
+	switch (iodev_sqe->sqe.op) {
+	case RTIO_OP_TX:
+		*out_buf = iodev_sqe->sqe.tx.buf;
+		*out_len = iodev_sqe->sqe.tx.buf_len;
+		return true;
+	case RTIO_OP_TINY_TX:
+		*out_buf = iodev_sqe->sqe.tiny_tx.buf;
+		*out_len = iodev_sqe->sqe.tiny_tx.buf_len;
+		return true;
+	default:
+		return false;
+	}
+}
+
+/*
+ * Pre-build the DDR header + CRC for a DDR cmd. For writes, the entire
+ * source buffer is folded into the running CRC so the final CRC token is
+ * known before streaming begins. For reads, only the header bits seed the
+ * CRC; subsequent words come in via RX and the decoder continues folding.
+ */
+static int cdns_i3c_rtio_ddr_prep(struct cdns_i3c_rtio_cmd *cmd, uint16_t dyn_addr)
+{
+	uint8_t hdr_cmd_code = RTIO_IODEV_I3C_HDR_CMD_CODE_GET(cmd->sqe->sqe.iodev_flags);
+	uint8_t crc5 = 0x1F;
+	uint16_t header;
+
+	if (cmd->is_read) {
+		header = HDR_CMD_RD | HDR_CMD_CODE(hdr_cmd_code) | (dyn_addr << 1);
+		header = prepare_ddr_cmd_parity_adjustment_bit(header);
+		cmd->ddr_header = DDR_PREAMBLE_CMD_CRC | prepare_ddr_word(header);
+		crc5 = i3c_cdns_crc5(crc5, header);
+		cmd->ddr_crc = crc5;
+	} else {
+		const uint8_t *src;
+		uint32_t src_len;
+
+		if (!cdns_i3c_rtio_sqe_tx_buf(cmd->sqe, &src, &src_len)) {
+			return -ENOTSUP;
+		}
+		if (src_len < cmd->len) {
+			return -EINVAL;
+		}
+
+		header = HDR_CMD_CODE(hdr_cmd_code) | (dyn_addr << 1);
+		cmd->ddr_header = DDR_PREAMBLE_CMD_CRC | prepare_ddr_word(header);
+
+		crc5 = i3c_cdns_crc5(crc5, header);
+		for (uint32_t j = 0; j < cmd->len; j += 2) {
+			crc5 = i3c_cdns_crc5(crc5, sys_get_be16(&src[j]));
+		}
+		cmd->ddr_crc_word = DDR_PREAMBLE_CMD_CRC | DDR_CRC_TOKEN |
+				    ((uint32_t)crc5 << 9) | DDR_CRC_WR_SETUP;
+	}
+
+	return 0;
+}
+
+/*
+ * Push CMD0/CMD1 pairs for a previously-walked data transaction. For SDR
+ * cmds: a single (CMD1, CMD0) pair. For DDR cmds: a CCC ENTHDR0 frame
+ * followed by a CMD0_FIFO_IS_DDR data frame (matches legacy).
+ *
+ * target_addr supplies dynamic_addr (i3c) or i2c_dt_spec.addr (i2c).
+ * is_i3c controls BCH/NBCH semantics. is_10b applies only to i2c.
+ */
+static void cdns_i3c_rtio_push_data_cmds(const struct device *dev, uint8_t n,
+					 uint16_t target_addr, bool is_i3c, bool is_10b)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+
+	for (uint8_t i = 0; i < n; i++) {
+		struct cdns_i3c_rtio_cmd *cmd = &state->cmds[i];
+		struct rtio_iodev_sqe *s = cmd->sqe;
+		uint32_t iodev_flags = s->sqe.iodev_flags;
+		bool is_last = (i == n - 1);
+		bool stop;
+
+		if (is_i3c) {
+			stop = !!(iodev_flags & RTIO_IODEV_I3C_STOP);
+		} else {
+			stop = !!(iodev_flags & RTIO_IODEV_I2C_STOP);
+		}
+
+		if (cmd->is_ddr) {
+			/* CCC frame: ENTHDR0 announces the HDR-DDR transfer. */
+			uint32_t ccc_cmd0 = CMD0_FIFO_IS_CCC;
+			uint32_t ccc_cmd1 = I3C_CCC_ENTHDR0 | CMD1_FIFO_CMDID(i);
+
+			sys_write32(ccc_cmd1, config->base + CMD1_FIFO);
+			sys_write32(ccc_cmd0, config->base + CMD0_FIFO);
+
+			/* IS_DDR data frame. CMDID intentionally omitted (the
+			 * paired CCC above carries the response ID). PL_LEN is
+			 * in DDR words: header + data + crc = (pl/2) + 2 for
+			 * writes; reads use 1 (legacy quirk).
+			 */
+			uint32_t ddr_cmd0 = CMD0_FIFO_IS_DDR;
+
+			if (cmd->is_read) {
+				ddr_cmd0 |= CMD0_FIFO_PL_LEN(1);
+			} else {
+				ddr_cmd0 |= CMD0_FIFO_PL_LEN((cmd->len / 2) + 2);
+			}
+
+			sys_write32(0x00, config->base + CMD1_FIFO);
+			sys_write32(ddr_cmd0, config->base + CMD0_FIFO);
+		} else {
+			uint32_t cmd0 = CMD0_FIFO_PRIV_XMIT_MODE(XMIT_BURST_WITHOUT_SUBADDR);
+			uint32_t cmd1 = CMD1_FIFO_CMDID(i);
+
+			cmd0 |= CMD0_FIFO_DEV_ADDR(target_addr);
+			cmd0 |= CMD0_FIFO_PL_LEN(cmd->len);
+			if (cmd->is_read) {
+				cmd0 |= CMD0_FIFO_RNW;
+			}
+			if (is_10b) {
+				cmd0 |= CMD0_FIFO_IS_10B;
+			}
+
+			if (is_i3c && i == 0 && !(iodev_flags & RTIO_IODEV_I3C_NBCH)) {
+				cmd0 |= CMD0_FIFO_BCH;
+			}
+
+			if (!is_last && !stop) {
+				cmd0 |= CMD0_FIFO_RSBC;
+			}
+
+			sys_write32(cmd1, config->base + CMD1_FIFO);
+			sys_write32(cmd0, config->base + CMD0_FIFO);
+		}
+	}
+}
+
+/*
+ * Program the controller for the transaction at active_head and kick the
+ * bus. Caller has already set state->active_head and ensured no other
+ * transaction is in flight.
+ */
+static void cdns_i3c_rtio_start(const struct device *dev)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+	struct rtio_iodev_sqe *head = state->active_head;
+	int n;
+
+	if (head == NULL) {
+		return;
+	}
+
+	if (!(sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE)) {
+		cdns_i3c_rtio_complete_txn(dev, -EACCES);
+		return;
+	}
+
+	if (cdns_i3c_wait_for_idle(dev) != 0) {
+		cdns_i3c_rtio_complete_txn(dev, -EAGAIN);
+		return;
+	}
+
+	while (!cdns_i3c_rx_fifo_empty(config)) {
+		(void)sys_read32(config->base + RX_FIFO);
+	}
+	while (!cdns_i3c_cmd_rsp_fifo_empty(config)) {
+		(void)sys_read32(config->base + CMDR);
+	}
+
+	state->tx_sqe = head;
+	state->tx_off = 0;
+	state->rx_sqe = head;
+	state->rx_off = 0;
+	state->tx_cmd_idx = 0;
+	state->rx_cmd_idx = 0;
+	state->ddr_tx_phase = DDR_TX_HEADER;
+	state->xfer_status = 0;
+
+	if (head->sqe.op == RTIO_OP_I3C_CCC) {
+		n = cdns_i3c_rtio_build_ccc(dev, head);
+	} else if (sqe_is_i3c(head)) {
+		struct i3c_device_desc *desc = cdns_i3c_rtio_resolve_i3c_desc(dev, head);
+
+		if (desc == NULL) {
+			cdns_i3c_rtio_complete_txn(dev, -ENODEV);
+			return;
+		}
+		n = cdns_i3c_rtio_walk_i3c_txn(dev);
+		if (n < 0) {
+			cdns_i3c_rtio_complete_txn(dev, n);
+			return;
+		}
+		/* Pre-build header/CRC for any DDR cmds before pushing CMDs and
+		 * starting the bus.
+		 */
+		for (uint8_t i = 0; i < (uint8_t)n; i++) {
+			if (state->cmds[i].is_ddr) {
+				int rc = cdns_i3c_rtio_ddr_prep(&state->cmds[i],
+								desc->dynamic_addr);
+
+				if (rc < 0) {
+					cdns_i3c_rtio_complete_txn(dev, rc);
+					return;
+				}
+			}
+		}
+		cdns_i3c_rtio_push_data_cmds(dev, (uint8_t)n, desc->dynamic_addr, true, false);
+	} else if (sqe_is_i2c(head)) {
+		const struct i2c_dt_spec *spec = cdns_i3c_rtio_resolve_i2c_spec(head);
+		bool is_10b;
+
+		if (spec == NULL) {
+			cdns_i3c_rtio_complete_txn(dev, -ENODEV);
+			return;
+		}
+		n = cdns_i3c_rtio_walk_i2c_txn(dev);
+		if (n < 0) {
+			cdns_i3c_rtio_complete_txn(dev, n);
+			return;
+		}
+		is_10b = (head->sqe.iodev_flags & RTIO_IODEV_I2C_10_BITS) != 0;
+		cdns_i3c_rtio_push_data_cmds(dev, (uint8_t)n, spec->addr, false, is_10b);
+	} else {
+		cdns_i3c_rtio_complete_txn(dev, -ENOTSUP);
+		return;
+	}
+
+	if (n <= 0) {
+		cdns_i3c_rtio_complete_txn(dev, (n == 0) ? -EINVAL : n);
+		return;
+	}
+
+	state->num_cmds = (uint8_t)n;
+
+	if (head->sqe.op != RTIO_OP_I3C_CCC) {
+		cdns_i3c_rtio_drain_tx(dev);
+	}
+
+	sys_write32(MST_INT_CMDD_EMP | MST_INT_TX_THR | MST_INT_RX_THR,
+		    config->base + MST_IER);
+	sys_write32(CTRL_MCS | sys_read32(config->base + CTRL), config->base + CTRL);
+}
+
+/*
+ * Pop the next queued transaction from the unified mpsc queue. Returns a
+ * head sqe (and atomically claims the bus by setting state->active_head)
+ * or NULL if the queue is empty.
+ *
+ * Time-ordered across i3c and i2c sqes — they all flow into the same queue
+ * from submit, so popping FIFO preserves submit-time ordering.
+ *
+ * Called from ISR or from submit thread; uses state->slock for the
+ * active_head transition.
+ */
+static struct rtio_iodev_sqe *cdns_i3c_rtio_pop_next(struct cdns_i3c_rtio_state *state)
+{
+	struct mpsc_node *node;
+	struct rtio_iodev_sqe *head;
+	k_spinlock_key_t key = k_spin_lock(&state->slock);
+
+	if (state->active_head != NULL) {
+		k_spin_unlock(&state->slock, key);
+		return NULL;
+	}
+
+	node = mpsc_pop(&state->unified_q);
+	if (node == NULL) {
+		k_spin_unlock(&state->slock, key);
+		return NULL;
+	}
+
+	head = CONTAINER_OF(node, struct rtio_iodev_sqe, q);
+	state->active_head = head;
+	k_spin_unlock(&state->slock, key);
+	return head;
+}
+
+/*
+ * Complete the active transaction. status applies to the whole batch
+ * (sticky error from CMDR drain). We signal completion on the head sqe
+ * directly via the RTIO executor — it walks the transaction chain (via
+ * RTIO_SQE_TRANSACTION flag) and posts a CQE per sqe. No per-ctx queue
+ * bookkeeping needed because we don't use the i*c_rtio ctx queues.
+ */
+static void cdns_i3c_rtio_complete_txn(const struct device *dev, int status)
+{
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+	struct rtio_iodev_sqe *head = state->active_head;
+
+	/* Release bus ownership before invoking completion (which can recurse
+	 * back into start via the next-txn pop).
+	 */
+	{
+		k_spinlock_key_t key = k_spin_lock(&state->slock);
+
+		state->active_head = NULL;
+		k_spin_unlock(&state->slock, key);
+	}
+
+	if (head == NULL) {
+		return;
+	}
+
+	if (status < 0) {
+		rtio_iodev_sqe_err(head, status);
+	} else {
+		rtio_iodev_sqe_ok(head, status);
+	}
+
+	if (cdns_i3c_rtio_pop_next(state) != NULL) {
+		cdns_i3c_rtio_start(dev);
+	}
+}
+
+void cdns_i3c_iodev_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+
+	mpsc_push(&state->unified_q, &iodev_sqe->q);
+
+	if (cdns_i3c_rtio_pop_next(state) != NULL) {
+		cdns_i3c_rtio_start(dev);
+	}
+}
+
+void cdns_i3c_i2c_iodev_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+
+	mpsc_push(&state->unified_q, &iodev_sqe->q);
+
+	if (cdns_i3c_rtio_pop_next(state) != NULL) {
+		cdns_i3c_rtio_start(dev);
+	}
+}
+
+int cdns_i3c_rtio_init(const struct device *dev)
+{
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+
+	if (state == NULL || state->i3c_ctx == NULL || state->i2c_ctx == NULL) {
+		return -EINVAL;
+	}
+
+	mpsc_init(&state->unified_q);
+
+	i3c_rtio_init(state->i3c_ctx, dev);
+	i2c_rtio_init(state->i2c_ctx, dev);
+
+	return 0;
+}
+
+void cdns_i3c_rtio_irq_tx_thr(const struct device *dev)
+{
+	cdns_i3c_rtio_drain_tx(dev);
+}
+
+void cdns_i3c_rtio_irq_rx_thr(const struct device *dev)
+{
+	cdns_i3c_rtio_drain_rx(dev);
+}
+
+void cdns_i3c_rtio_irq_cmdd_emp(const struct device *dev)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_rtio_state *state = data->rtio;
+	int sticky = 0;
+	bool was_full;
+
+	sys_write32(MST_INT_CMDD_EMP | MST_INT_TX_THR | MST_INT_RX_THR,
+		    config->base + MST_IDR);
+
+	/* Snapshot before draining — used to distinguish real RX overflow
+	 * from a benign controller abort (no EoD from target).
+	 */
+	was_full = cdns_i3c_rx_fifo_full(config);
+
+	for (uint32_t status0 = sys_read32(config->base + MST_STATUS0);
+	     !(status0 & MST_STATUS0_CMDR_EMP);
+	     status0 = sys_read32(config->base + MST_STATUS0)) {
+		uint32_t cmdr = sys_read32(config->base + CMDR);
+		uint8_t id = CMDR_CMDID(cmdr);
+		uint32_t err = CMDR_ERROR(cmdr);
+		uint32_t bytes = CMDR_XFER_BYTES(cmdr);
+		int rc;
+
+		if (id == CMDR_CMDID_HJACK_DISEC || id == CMDR_CMDID_HJACK_ENTDAA ||
+		    id >= state->num_cmds) {
+			continue;
+		}
+
+		/* For CCC sqes, plumb num_xfer + RX bytes back into the payload. */
+		if (state->cmds[id].is_ccc_target) {
+			struct rtio_iodev_sqe *ccc_sqe = state->cmds[id].sqe;
+			struct i3c_ccc_payload *p = ccc_sqe->sqe.ccc_payload;
+			uint8_t t = state->cmds[id].ccc_target_idx;
+			uint16_t got = MIN(bytes, state->cmds[id].len);
+
+			p->targets.payloads[t].num_xfer = got;
+			p->targets.payloads[t].err = cdns_i3c_rtio_cmdr_sdr_error(err);
+			if (state->cmds[id].is_read && got > 0) {
+				(void)cdns_i3c_read_rx_fifo(config,
+							    p->targets.payloads[t].data, got);
+			}
+		} else if (sqe_is_i3c(state->cmds[id].sqe) &&
+			   state->cmds[id].sqe->sqe.op == RTIO_OP_I3C_CCC) {
+			/* Broadcast CCC: single command, num_xfer in ccc.num_xfer. */
+			struct i3c_ccc_payload *p = state->cmds[id].sqe->sqe.ccc_payload;
+
+			p->ccc.num_xfer = MIN(bytes, state->cmds[id].len);
+			p->ccc.err = cdns_i3c_rtio_cmdr_sdr_error(err);
+		} else if (state->cmds[id].sqe->sqe.iodev == &state->i3c_ctx->iodev &&
+			   state->cmds[id].sqe->sqe.userdata != NULL) {
+			struct i3c_msg *msg = state->cmds[id].sqe->sqe.userdata;
+
+			msg->num_xfer = MIN(bytes, state->cmds[id].len);
+			msg->err = cdns_i3c_rtio_cmdr_sdr_error(err);
+		}
+
+		rc = cdns_i3c_rtio_translate_cmdr_error(err);
+
+		/*
+		 * M0 error on variable-length CCCs (GETMXDS, GETCAPS) is
+		 * expected -- the IP reports M0 when fewer bytes are returned
+		 * than PL_LEN requested, which is normal for these CCCs.
+		 * Suppress the error if the byte count is within spec.
+		 */
+		if (rc != 0 && err == CMDR_M0_ERROR && state->cmds[id].is_ccc_target) {
+			struct rtio_iodev_sqe *ccc_sqe = state->cmds[id].sqe;
+
+			if (ccc_sqe->sqe.op == RTIO_OP_I3C_CCC) {
+				struct i3c_ccc_payload *p = ccc_sqe->sqe.ccc_payload;
+				uint8_t ccc = p->ccc.id;
+
+				if (ccc == I3C_CCC_GETMXDS) {
+					if (bytes == SIZEOF_FIELD(union i3c_ccc_getmxds, fmt1) ||
+					    bytes == SIZEOF_FIELD(union i3c_ccc_getmxds, fmt2)) {
+						rc = 0;
+					}
+				} else if (ccc == I3C_CCC_GETCAPS) {
+					if (bytes <= sizeof(union i3c_ccc_getcaps)) {
+						rc = 0;
+					}
+				}
+			}
+		}
+
+		/*
+		 * Controller abort is forced when the RX FIFO fills up.
+		 * If the FIFO was full and the requested length exceeds
+		 * what was transferred, it is a real overflow. Otherwise
+		 * the abort was caused by the read length being met while
+		 * the target did not give an End of Data -- not an error.
+		 */
+		if (rc != 0 && err == CMDR_MST_ABORT) {
+			if (was_full && state->cmds[id].len > bytes) {
+				rc = -ENOSPC;
+			} else {
+				rc = 0;
+			}
+		}
+
+		if (rc != 0 && sticky == 0) {
+			sticky = rc;
+		}
+	}
+
+	cdns_i3c_rtio_drain_rx(dev);
+
+	cdns_i3c_rtio_complete_txn(dev, sticky);
+}

--- a/drivers/i3c/i3c_rtio.c
+++ b/drivers/i3c/i3c_rtio.c
@@ -20,7 +20,7 @@ const struct rtio_iodev_api i3c_iodev_api = {
 	.submit = i3c_iodev_submit,
 };
 
-struct rtio_sqe *i3c_rtio_copy(struct rtio *r, struct rtio_iodev *iodev, const struct i3c_msg *msgs,
+struct rtio_sqe *i3c_rtio_copy(struct rtio *r, struct rtio_iodev *iodev, struct i3c_msg *msgs,
 			       uint8_t num_msgs)
 {
 	__ASSERT(num_msgs > 0, "Expecting at least one message to copy");
@@ -37,10 +37,10 @@ struct rtio_sqe *i3c_rtio_copy(struct rtio *r, struct rtio_iodev *iodev, const s
 
 		if (msgs[i].flags & I3C_MSG_READ) {
 			rtio_sqe_prep_read(sqe, iodev, RTIO_PRIO_NORM, msgs[i].buf, msgs[i].len,
-					   NULL);
+					   (void *)&msgs[i]);
 		} else {
 			rtio_sqe_prep_write(sqe, iodev, RTIO_PRIO_NORM, msgs[i].buf, msgs[i].len,
-					    NULL);
+					    (void *)&msgs[i]);
 		}
 		sqe->flags |= RTIO_SQE_TRANSACTION;
 		sqe->iodev_flags =
@@ -57,13 +57,15 @@ struct rtio_sqe *i3c_rtio_copy(struct rtio *r, struct rtio_iodev *iodev, const s
 	return sqe;
 }
 
-void i3c_rtio_init(struct i3c_rtio *ctx)
+void i3c_rtio_init(struct i3c_rtio *ctx, const struct device *dev)
 {
 	k_sem_init(&ctx->lock, 1, 1);
 	mpsc_init(&ctx->io_q);
 	ctx->txn_curr = NULL;
 	ctx->txn_head = NULL;
+	ctx->iodev_data.bus = dev;
 	ctx->iodev.api = &i3c_iodev_api;
+	ctx->iodev.data = &ctx->iodev_data;
 }
 
 /**
@@ -268,3 +270,167 @@ out:
 	k_sem_give(&ctx->lock);
 	return res;
 }
+
+#ifdef CONFIG_I3C_CALLBACK
+/*
+ * Allocate a callback closure slot. Lock-free via atomic_test_and_set_bit;
+ * safe from any context. Returns NULL when the pool is exhausted (caller
+ * treats as -ENOMEM).
+ */
+static struct i3c_rtio_cb_slot *i3c_rtio_cb_slot_alloc(struct i3c_rtio *ctx)
+{
+	for (uint32_t i = 0; i < ARRAY_SIZE(ctx->cb_slots); i++) {
+		if (!atomic_test_and_set_bit(ctx->cb_slot_used, i)) {
+			struct i3c_rtio_cb_slot *slot = &ctx->cb_slots[i];
+
+			slot->ctx = ctx;
+			return slot;
+		}
+	}
+
+	return NULL;
+}
+
+static void i3c_rtio_cb_slot_free(struct i3c_rtio_cb_slot *slot)
+{
+	struct i3c_rtio *ctx = slot->ctx;
+	uint32_t i = slot - &ctx->cb_slots[0];
+
+	atomic_clear_bit(ctx->cb_slot_used, i);
+}
+
+/*
+ * Trampoline invoked by RTIO_OP_CALLBACK after the preceding chained
+ * transaction completes. last_result carries the transfer status.
+ *
+ * The async helper held ctx->lock for the duration of the transfer (so that
+ * ctx->i3c_desc / ctx->dt_spec stayed stable for the driver's iodev_submit).
+ * Release it here before invoking user code so that another async caller
+ * can start while the user runs.
+ */
+static void i3c_rtio_cb_trampoline(struct rtio *r, const struct rtio_sqe *sqe, int last_result,
+				   void *arg0)
+{
+	struct i3c_rtio_cb_slot *slot = arg0;
+	struct i3c_rtio *ctx = slot->ctx;
+	i3c_callback_t cb = slot->cb;
+	void *userdata = slot->userdata;
+	const struct device *dev = slot->dev;
+
+	ARG_UNUSED(r);
+	ARG_UNUSED(sqe);
+
+	/* Snapshot, free the slot, release lock, then invoke user code. */
+	i3c_rtio_cb_slot_free(slot);
+	k_sem_give(&ctx->lock);
+
+	cb(dev, last_result, userdata);
+}
+
+int i3c_rtio_transfer_cb(struct i3c_rtio *ctx, const struct device *dev, struct i3c_msg *msgs,
+			 uint8_t num_msgs, struct i3c_device_desc *desc, i3c_callback_t cb,
+			 void *userdata)
+{
+	struct rtio_iodev *iodev = &ctx->iodev;
+	struct rtio *const r = ctx->r;
+	struct rtio_sqe *last_msg_sqe;
+	struct rtio_sqe *cb_sqe;
+	struct i3c_rtio_cb_slot *slot;
+
+	__ASSERT_NO_MSG(num_msgs > 0);
+	__ASSERT_NO_MSG(cb != NULL);
+
+	slot = i3c_rtio_cb_slot_alloc(ctx);
+	if (slot == NULL) {
+		return -ENOMEM;
+	}
+
+	/*
+	 * Take ctx->lock so ctx->i3c_desc stays bound to this transaction
+	 * until the trampoline releases it. Matches the blocking helper's
+	 * locking discipline.
+	 */
+	k_sem_take(&ctx->lock, K_FOREVER);
+
+	ctx->i3c_desc = desc;
+
+	last_msg_sqe = i3c_rtio_copy(r, iodev, msgs, num_msgs);
+	if (last_msg_sqe == NULL) {
+		k_sem_give(&ctx->lock);
+		i3c_rtio_cb_slot_free(slot);
+		return -ENOMEM;
+	}
+
+	cb_sqe = rtio_sqe_acquire(r);
+	if (cb_sqe == NULL) {
+		rtio_sqe_drop_all(r);
+		k_sem_give(&ctx->lock);
+		i3c_rtio_cb_slot_free(slot);
+		return -ENOMEM;
+	}
+
+	slot->cb = cb;
+	slot->userdata = userdata;
+	slot->dev = dev;
+
+	rtio_sqe_prep_callback(cb_sqe, i3c_rtio_cb_trampoline, slot, NULL);
+	cb_sqe->flags |= RTIO_SQE_NO_RESPONSE;
+
+	/* Chain the callback after the (last) msg sqe. */
+	last_msg_sqe->flags |= RTIO_SQE_CHAINED;
+
+	rtio_submit(r, 0);
+
+	return 0;
+}
+
+int i3c_rtio_ccc_cb(struct i3c_rtio *ctx, const struct device *dev,
+		    struct i3c_ccc_payload *payload, i3c_callback_t cb, void *userdata)
+{
+	struct rtio_iodev *iodev = &ctx->iodev;
+	struct rtio *const r = ctx->r;
+	struct rtio_sqe *ccc_sqe;
+	struct rtio_sqe *cb_sqe;
+	struct i3c_rtio_cb_slot *slot;
+
+	__ASSERT_NO_MSG(cb != NULL);
+
+	slot = i3c_rtio_cb_slot_alloc(ctx);
+	if (slot == NULL) {
+		return -ENOMEM;
+	}
+
+	k_sem_take(&ctx->lock, K_FOREVER);
+
+	ccc_sqe = rtio_sqe_acquire(r);
+	if (ccc_sqe == NULL) {
+		k_sem_give(&ctx->lock);
+		i3c_rtio_cb_slot_free(slot);
+		return -ENOMEM;
+	}
+
+	ccc_sqe->op = RTIO_OP_I3C_CCC;
+	ccc_sqe->flags = RTIO_SQE_CHAINED;
+	ccc_sqe->iodev = iodev;
+	ccc_sqe->ccc_payload = payload;
+
+	cb_sqe = rtio_sqe_acquire(r);
+	if (cb_sqe == NULL) {
+		rtio_sqe_drop_all(r);
+		k_sem_give(&ctx->lock);
+		i3c_rtio_cb_slot_free(slot);
+		return -ENOMEM;
+	}
+
+	slot->cb = cb;
+	slot->userdata = userdata;
+	slot->dev = dev;
+
+	rtio_sqe_prep_callback(cb_sqe, i3c_rtio_cb_trampoline, slot, NULL);
+	cb_sqe->flags |= RTIO_SQE_NO_RESPONSE;
+
+	rtio_submit(r, 0);
+
+	return 0;
+}
+#endif /* CONFIG_I3C_CALLBACK */

--- a/include/zephyr/drivers/i2c/rtio.h
+++ b/include/zephyr/drivers/i2c/rtio.h
@@ -10,10 +10,27 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/atomic.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifdef CONFIG_I2C_CALLBACK
+/**
+ * @brief Per-callback closure used by the *_cb async helpers.
+ *
+ * Allocated from the i2c_rtio context's pool when a *_cb call submits work
+ * and freed by the trampoline once the user callback has been invoked.
+ */
+struct i2c_rtio;
+struct i2c_rtio_cb_slot {
+	struct i2c_rtio *ctx;
+	i2c_callback_t cb;
+	void *userdata;
+	const struct device *dev;
+};
+#endif /* CONFIG_I2C_CALLBACK */
 
 /**
  * @brief Driver context for implementing i2c with rtio
@@ -27,6 +44,18 @@ struct i2c_rtio {
 	struct rtio_iodev_sqe *txn_head;
 	struct rtio_iodev_sqe *txn_curr;
 	struct i2c_dt_spec dt_spec;
+
+#ifdef CONFIG_I2C_CALLBACK
+	/*
+	 * Callback closure pool for the *_cb async helpers. Sized to
+	 * CONFIG_I2C_RTIO_SQ_SIZE — you can't have more outstanding async
+	 * transfers than the submission queue can hold. The free bitmap is
+	 * managed lock-free via atomic_test_and_set_bit / atomic_clear_bit
+	 * so allocation and release are safe from any context (including ISR).
+	 */
+	struct i2c_rtio_cb_slot cb_slots[CONFIG_I2C_RTIO_SQ_SIZE];
+	ATOMIC_DEFINE(cb_slot_used, CONFIG_I2C_RTIO_SQ_SIZE);
+#endif
 };
 
 /**
@@ -107,6 +136,25 @@ int i2c_rtio_transfer(struct i2c_rtio *ctx, struct i2c_msg *msgs, uint8_t num_ms
  * See i2c_recover().
  */
 int i2c_rtio_recover(struct i2c_rtio *ctx);
+
+#ifdef CONFIG_I2C_CALLBACK
+/**
+ * @brief Transfer i2c messages asynchronously, invoking @p cb on completion.
+ *
+ * Non-blocking analog of i2c_rtio_transfer(). The user callback is invoked
+ * once the entire transaction completes; @p result is the same int that
+ * i2c_rtio_transfer() would return synchronously.
+ *
+ * The @p msgs array (and the buffers it references) must remain valid until
+ * @p cb fires, matching the i2c_transfer_cb() contract. @p cb must be
+ * non-NULL.
+ *
+ * @retval 0 on successful submission (the transfer is in flight)
+ * @retval -ENOMEM if no submission slots or callback closure slots are free
+ */
+int i2c_rtio_transfer_cb(struct i2c_rtio *ctx, const struct device *dev, struct i2c_msg *msgs,
+			 uint8_t num_msgs, uint16_t addr, i2c_callback_t cb, void *userdata);
+#endif /* CONFIG_I2C_CALLBACK */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/i2c/rtio.h
+++ b/include/zephyr/drivers/i2c/rtio.h
@@ -10,10 +10,27 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/atomic.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifdef CONFIG_I2C_CALLBACK
+/**
+ * @brief Per-callback closure used by the *_cb async helpers.
+ *
+ * Allocated from the i2c_rtio context's pool when a *_cb call submits work
+ * and freed by the trampoline once the user callback has been invoked.
+ */
+struct i2c_rtio;
+struct i2c_rtio_cb_slot {
+	struct i2c_rtio *ctx;
+	i2c_callback_t cb;
+	void *userdata;
+	const struct device *dev;
+};
+#endif /* CONFIG_I2C_CALLBACK */
 
 /**
  * @brief Driver context for implementing i2c with rtio
@@ -27,6 +44,18 @@ struct i2c_rtio {
 	struct rtio_iodev_sqe *txn_head;
 	struct rtio_iodev_sqe *txn_curr;
 	struct i2c_dt_spec dt_spec;
+
+#ifdef CONFIG_I2C_CALLBACK
+	/*
+	 * Callback closure pool for the *_cb async helpers. Sized to
+	 * CONFIG_I2C_RTIO_SQ_SIZE — you can't have more outstanding async
+	 * transfers than the submission queue can hold. The free bitmap is
+	 * managed lock-free via atomic_test_and_set_bit / atomic_clear_bit
+	 * so allocation and release are safe from any context (including ISR).
+	 */
+	struct i2c_rtio_cb_slot cb_slots[CONFIG_I2C_RTIO_SQ_SIZE];
+	ATOMIC_DEFINE(cb_slot_used, CONFIG_I2C_RTIO_SQ_SIZE);
+#endif
 };
 
 /**
@@ -143,6 +172,25 @@ static inline bool i2c_rtio_run_sync_start_async(const struct device *dev, struc
 
 	return true;
 }
+
+#ifdef CONFIG_I2C_CALLBACK
+/**
+ * @brief Transfer i2c messages asynchronously, invoking @p cb on completion.
+ *
+ * Non-blocking analog of i2c_rtio_transfer(). The user callback is invoked
+ * once the entire transaction completes; @p result is the same int that
+ * i2c_rtio_transfer() would return synchronously.
+ *
+ * The @p msgs array (and the buffers it references) must remain valid until
+ * @p cb fires, matching the i2c_transfer_cb() contract. @p cb must be
+ * non-NULL.
+ *
+ * @retval 0 on successful submission (the transfer is in flight)
+ * @retval -ENOMEM if no submission slots or callback closure slots are free
+ */
+int i2c_rtio_transfer_cb(struct i2c_rtio *ctx, const struct device *dev, struct i2c_msg *msgs,
+			 uint8_t num_msgs, uint16_t addr, i2c_callback_t cb, void *userdata);
+#endif /* CONFIG_I2C_CALLBACK */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -3021,6 +3021,11 @@ extern const struct rtio_iodev_api i3c_iodev_api;
 /**
  * @brief Copy the i3c_msgs into a set of RTIO requests
  *
+ * Each sqe carries a pointer to its originating struct i3c_msg in the sqe
+ * userdata. Drivers may write back msg->num_xfer and msg->err via this
+ * pointer at completion. The msgs array must remain valid until the
+ * transaction completes.
+ *
  * @param r RTIO context
  * @param iodev RTIO IODev to target for the submissions
  * @param msgs Array of messages
@@ -3031,7 +3036,7 @@ extern const struct rtio_iodev_api i3c_iodev_api;
  */
 struct rtio_sqe *i3c_rtio_copy(struct rtio *r,
 			       struct rtio_iodev *iodev,
-			       const struct i3c_msg *msgs,
+			       struct i3c_msg *msgs,
 			       uint8_t num_msgs);
 
 #endif /* CONFIG_I3C_RTIO */

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -3205,6 +3205,11 @@ extern const struct rtio_iodev_api i3c_iodev_api;
 /**
  * @brief Copy the i3c_msgs into a set of RTIO requests
  *
+ * Each sqe carries a pointer to its originating struct i3c_msg in the sqe
+ * userdata. Drivers may write back msg->num_xfer and msg->err via this
+ * pointer at completion. The msgs array must remain valid until the
+ * transaction completes.
+ *
  * @kconfig_dep{CONFIG_I3C_RTIO}
  *
  * @param r RTIO context
@@ -3217,7 +3222,7 @@ extern const struct rtio_iodev_api i3c_iodev_api;
  */
 struct rtio_sqe *i3c_rtio_copy(struct rtio *r,
 			       struct rtio_iodev *iodev,
-			       const struct i3c_msg *msgs,
+			       struct i3c_msg *msgs,
 			       uint8_t num_msgs);
 
 #endif /* CONFIG_I3C_RTIO */

--- a/include/zephyr/drivers/i3c/rtio.h
+++ b/include/zephyr/drivers/i3c/rtio.h
@@ -11,10 +11,27 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/i3c.h>
 #include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/atomic.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifdef CONFIG_I3C_CALLBACK
+/**
+ * @brief Per-callback closure used by the *_cb async helpers.
+ *
+ * Allocated from the i3c_rtio context's pool when a *_cb call submits work
+ * and freed by the trampoline once the user callback has been invoked.
+ */
+struct i3c_rtio;
+struct i3c_rtio_cb_slot {
+	struct i3c_rtio *ctx;
+	i3c_callback_t cb;
+	void *userdata;
+	const struct device *dev;
+};
+#endif /* CONFIG_I3C_CALLBACK */
 
 /**
  * @brief Driver context for implementing i3c with rtio
@@ -25,9 +42,27 @@ struct i3c_rtio {
 	struct rtio *r;
 	struct mpsc io_q;
 	struct rtio_iodev iodev;
+	/**
+	 * Backing storage for iodev.data so i3c_iodev_submit() can route
+	 * sqes built via this ctx's iodev to the owning controller's
+	 * iodev_submit. Initialized by i3c_rtio_init().
+	 */
+	struct i3c_iodev_data iodev_data;
 	struct rtio_iodev_sqe *txn_head;
 	struct rtio_iodev_sqe *txn_curr;
 	struct i3c_device_desc *i3c_desc;
+
+#ifdef CONFIG_I3C_CALLBACK
+	/*
+	 * Callback closure pool for the *_cb async helpers. Sized to
+	 * CONFIG_I3C_RTIO_SQ_SIZE — you can't have more outstanding async
+	 * transfers than the submission queue can hold. The free bitmap is
+	 * managed lock-free via atomic_test_and_set_bit / atomic_clear_bit
+	 * so allocation and release are safe from any context (including ISR).
+	 */
+	struct i3c_rtio_cb_slot cb_slots[CONFIG_I3C_RTIO_SQ_SIZE];
+	ATOMIC_DEFINE(cb_slot_used, CONFIG_I3C_RTIO_SQ_SIZE);
+#endif
 };
 
 /**
@@ -46,18 +81,26 @@ struct i3c_rtio {
 /**
  * @brief Copy an array of i3c_msgs to rtio submissions and a transaction
  *
+ * Each sqe carries a pointer to its originating struct i3c_msg in the
+ * sqe userdata. Drivers may write back msg->num_xfer and msg->err via this
+ * pointer at completion, matching the legacy i3c_transfer() contract. The
+ * msgs array must therefore remain valid until the transaction completes.
+ *
  * @retval sqe Last sqe setup in the copy
  * @retval NULL Not enough memory to copy the transaction
  */
-struct rtio_sqe *i3c_rtio_copy(struct rtio *r, struct rtio_iodev *iodev, const struct i3c_msg *msgs,
+struct rtio_sqe *i3c_rtio_copy(struct rtio *r, struct rtio_iodev *iodev, struct i3c_msg *msgs,
 			       uint8_t num_msgs);
 
 /**
  * @brief Initialize an i3c rtio context
  *
  * @param ctx I3C RTIO driver context
+ * @param dev I3C controller device that owns this context. Bound into
+ *            ctx->iodev so i3c_iodev_submit() can dispatch sqes built
+ *            via ctx->iodev back to this controller's iodev_submit.
  */
-void i3c_rtio_init(struct i3c_rtio *ctx);
+void i3c_rtio_init(struct i3c_rtio *ctx, const struct device *dev);
 
 /**
  * @brief Signal that the current (ctx->txn_curr) submission has been completed
@@ -118,6 +161,38 @@ int i3c_rtio_recover(struct i3c_rtio *ctx);
  * See i3c_do_ccc().
  */
 int i3c_rtio_ccc(struct i3c_rtio *ctx, struct i3c_ccc_payload *payload);
+
+#ifdef CONFIG_I3C_CALLBACK
+/**
+ * @brief Transfer i3c messages asynchronously, invoking @p cb on completion.
+ *
+ * Non-blocking analog of i3c_rtio_transfer(). The user callback is invoked
+ * once the entire transaction completes; the result int passed to @p cb is
+ * the same value i3c_rtio_transfer() would return synchronously.
+ *
+ * The @p msgs array (and the buffers it references) must remain valid until
+ * @p cb fires. Each msg's @c num_xfer and @c err fields may be updated by
+ * the driver before the callback, matching the i3c_transfer_cb() contract.
+ * @p cb must be non-NULL.
+ *
+ * @retval 0 on successful submission (the transfer is in flight)
+ * @retval -ENOMEM if no submission slots or callback closure slots are free
+ */
+int i3c_rtio_transfer_cb(struct i3c_rtio *ctx, const struct device *dev,
+			 struct i3c_msg *msgs, uint8_t num_msgs,
+			 struct i3c_device_desc *desc, i3c_callback_t cb,
+			 void *userdata);
+
+/**
+ * @brief Send a CCC asynchronously, invoking @p cb on completion.
+ *
+ * Non-blocking analog of i3c_rtio_ccc(). See i3c_rtio_transfer_cb() for the
+ * callback invocation contract.
+ */
+int i3c_rtio_ccc_cb(struct i3c_rtio *ctx, const struct device *dev,
+		    struct i3c_ccc_payload *payload, i3c_callback_t cb,
+		    void *userdata);
+#endif /* CONFIG_I3C_CALLBACK */
 
 #ifdef __cplusplus
 }

--- a/tests/drivers/build_all/i3c/testcase.yaml
+++ b/tests/drivers/build_all/i3c/testcase.yaml
@@ -9,6 +9,11 @@ tests:
     platform_allow: qemu_cortex_m3
     tags: i3c_cdns i3c_dw
     extra_args: "CONFIG_I3C_DUAL_ROLE=y CONFIG_I3C_RTIO=y"
+  drivers.i3c.build.cadence_rtio_native:
+    # exercises the Cadence native RTIO submit path
+    platform_allow: qemu_cortex_m3
+    tags: i3c_cdns
+    extra_args: "CONFIG_I3C_DUAL_ROLE=y CONFIG_I3C_RTIO=y CONFIG_I3C_CADENCE_RTIO=y"
   drivers.i3c.build.controller_role_only:
     # will cover drivers without in-tree boards
     platform_allow: qemu_cortex_m3

--- a/tests/drivers/build_all/i3c/tests.yaml
+++ b/tests/drivers/build_all/i3c/tests.yaml
@@ -11,6 +11,11 @@ tests:
       - nucleo_u385rg_q
     tags: i3c_cdns i3c_dw
     extra_args: "CONFIG_I3C_DUAL_ROLE=y CONFIG_I3C_RTIO=y"
+  drivers.i3c.build.cadence_rtio_native:
+    # exercises the Cadence native RTIO submit path
+    platform_allow: qemu_cortex_m3
+    tags: i3c_cdns
+    extra_args: "CONFIG_I3C_DUAL_ROLE=y CONFIG_I3C_RTIO=y CONFIG_I3C_CADENCE_RTIO=y"
   drivers.i3c.build.controller_role_only:
     # will cover drivers without in-tree boards
     platform_allow:


### PR DESCRIPTION
## Summary

Adds a native RTIO submit path for the Cadence I3C controller. Drives CMD/TX/RX FIFOs directly from the RTIO queue instead of bouncing through ``i3c_iodev_submit_fallback``'s workqueue.

- Splits ``i3c_cdns.c`` into a header + ``i3c_cdns_common.c`` + ``i3c_cdns_legacy.c`` (built only when ``CONFIG_I3C_CADENCE_RTIO=n``) + ``i3c_cdns_rtio.c`` (the native path)
- Both i3c and i2c-on-i3c sqes flow through a single driver-owned mpsc queue so submit-time ordering is preserved across protocols
- HDR-DDR support with streaming TX/RX via threshold IRQs
- New ``i3c_rtio_transfer_cb`` / ``i3c_rtio_ccc_cb`` / ``i2c_rtio_transfer_cb`` async helpers (gated by ``CONFIG_I*C_CALLBACK``)
- TX/RX thresholds programmed at init time at half-FIFO
- Lock-free atomic bitmap for the cb closure pool
- Fixes the existing CCC RTIO path: ``num_xfer`` reporting and direct-CCC RX byte drain
- ISR ``xfer_owner`` flag eliminated under ``CADENCE_RTIO=y``

Did some improvements on 'speed' of calculation for HDR DDR CRC5 and parity