### PR TITLE
modem: pipe: align API docs with behaviour

### DIFF
--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -132,8 +132,7 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
  * @param buf Data to transmit
  * @param size Number of bytes to transmit
  *
- * @return Number of bytes placed in pipe
- * @retval -EPERM if pipe is closed
+ * @return Number of bytes placed in pipe (0 if pipe closed)
  * @retval -errno code on error
  *
  * @warning This call must be non-blocking
@@ -147,8 +146,7 @@ int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size
  * @param buf Destination for received data; must not be already in use in a modem module.
  * @param size Capacity of destination for received data
  *
- * @return Number of bytes received from pipe
- * @retval -EPERM if pipe is closed
+ * @return Number of bytes received from pipe (0 if pipe closed)
  * @retval -errno code on error
  *
  * @warning This call must be non-blocking

--- a/tests/subsys/modem/modem_chat/Kconfig
+++ b/tests/subsys/modem/modem_chat/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Embeint Pty Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+config MODEM_MOCK_BACKEND_LIMIT
+	int "Mock backend TX limit for test"
+	default 8
+
+source "Kconfig.zephyr"

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -276,7 +276,7 @@ static void *test_modem_chat_setup(void)
 		.rx_buf_size = ARRAY_SIZE(mock_rx_buf),
 		.tx_buf = mock_tx_buf,
 		.tx_buf_size = ARRAY_SIZE(mock_tx_buf),
-		.limit = 8,
+		.limit = CONFIG_MODEM_MOCK_BACKEND_LIMIT,
 	};
 
 	mock_pipe = modem_backend_mock_init(&mock, &mock_config);

--- a/tests/subsys/modem/modem_chat/testcase.yaml
+++ b/tests/subsys/modem/modem_chat/testcase.yaml
@@ -10,6 +10,9 @@ common:
     - native_sim
 tests:
   modem.modem_chat: {}
+  modem.modem_chat.single_byte:
+    extra_configs:
+      - CONFIG_MODEM_MOCK_BACKEND_LIMIT=1
   modem.modem_chat.workq:
     extra_configs:
       - CONFIG_MODEM_DEDICATED_WORKQUEUE=y


### PR DESCRIPTION
The pipe transmit and receive functions return 0 if the pipe is closed, not `-EPERM`.