### PR TITLE
boards: cdns_swerv: CONFIG_SWERV_PIC_MAX_GENERIC_IRQ to 32

### DIFF
--- a/boards/cdns/swerv/Kconfig.defconfig
+++ b/boards/cdns/swerv/Kconfig.defconfig
@@ -23,7 +23,7 @@ config NUM_IRQS
 	default 288
 
 config SWERV_PIC_MAX_GENERIC_IRQ
-	default 31
+	default 32
 
 config WHISPER_TARGET
 	default y
@@ -38,7 +38,7 @@ config NUM_IRQS
 	default 288
 
 config SWERV_PIC_MAX_GENERIC_IRQ
-	default 31
+	default 32
 
 config WHISPER_TARGET
 	default y
@@ -59,7 +59,7 @@ config NUM_IRQS
 	default 288
 
 config SWERV_PIC_MAX_GENERIC_IRQ
-	default 31
+	default 32
 
 config WHISPER_TARGET
 	default y


### PR DESCRIPTION
This changes defaults for CONFIG_SWERV_PIC_MAX_GENERIC_IRQ to be 32 instead of 31. There was a misunderstanding of the doc on my part when I first submitted that.