### PR TITLE
tests: bluetooth: Remove ns nrf5340 from memory leak testcase

### DIFF
--- a/tests/bluetooth/gatt/testcase.yaml
+++ b/tests/bluetooth/gatt/testcase.yaml
@@ -52,7 +52,6 @@ tests:
       - native_sim/native/64
       - qemu_x86
       - qemu_cortex_m3
-      - nrf5340dk/nrf5340/cpuapp/ns
       - nrf52840dk/nrf52840
     integration_platforms:
       - native_sim


### PR DESCRIPTION
Remove nrf5340ns from memory leak testcase
The memory leak test case assumes CONFIG_MBEDTLS_PSA_CRYPTO_C is enabled This cannot be the case for a non secure application