### PR TITLE
drivers: regulator: espressif: power up LDOs at probe

### DIFF
--- a/drivers/regulator/regulator_esp32.c
+++ b/drivers/regulator/regulator_esp32.c
@@ -77,7 +77,16 @@ static DEVICE_API(regulator, regulator_esp32_api) = {
 
 static int regulator_esp32_init(const struct device *dev)
 {
+	const struct regulator_esp32_config *config = dev->config;
+	const struct regulator_common_config *common = &config->common;
+
 	regulator_common_data_init(dev);
+
+	if (common->init_uv > INT32_MIN) {
+		regulator_esp32_set_voltage(dev, common->init_uv, common->init_uv);
+	}
+
+	regulator_esp32_enable(dev);
 
 	return regulator_common_init(dev, true);
 }
@@ -87,7 +96,7 @@ static int regulator_esp32_init(const struct device *dev)
                                                                                                    \
 	static const struct regulator_esp32_config config_##node = {                               \
 		.common = REGULATOR_DT_COMMON_CONFIG_INIT(node),                                   \
-		.ldo_unit = LDO_ID2UNIT(DT_PROP(node, espressif_ldo_channel)),                     \
+		.ldo_unit = LDO_ID2UNIT(DT_REG_ADDR(node)),                                        \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_DEFINE(node, regulator_esp32_init, NULL, &data_##node, &config_##node,           \

--- a/dts/bindings/regulator/espressif,esp32-regulator.yaml
+++ b/dts/bindings/regulator/espressif,esp32-regulator.yaml
@@ -16,6 +16,13 @@ compatible: "espressif,esp32-regulator"
 
 include: base.yaml
 
+properties:
+  "#address-cells":
+    const: 1
+
+  "#size-cells":
+    const: 0
+
 child-binding:
   include:
     - name: regulator.yaml
@@ -28,46 +35,36 @@ child-binding:
         - regulator-max-microvolt
 
   properties:
+    reg:
+      type: int
+      required: true
+      description: |
+        LDO output channel number (1-4), corresponding to VO1-VO4.
+
     regulator-min-microvolt:
       default: 500000
 
     regulator-max-microvolt:
       default: 3300000
 
-    espressif,ldo-channel:
-      type: int
-      required: true
-      enum:
-        - 1
-        - 2
-        - 3
-        - 4
-      description: |
-        LDO output channel number (1-4), corresponding to VO1-VO4.
-        All channels support eFuse-calibrated output for precise voltage
-        regulation. Refer to the SoC datasheet for channel-specific
-        capabilities and typical usage.
-
 examples:
   - |
     ldo {
       compatible = "espressif,esp32-regulator";
+      #address-cells = <1>;
+      #size-cells = <0>;
 
-      ldo1 {
+      ldo1@1 {
+        reg = <1>;
         regulator-name = "ldo1";
-        regulator-min-microvolt = <500000>;
-        regulator-max-microvolt = <3300000>;
         regulator-boot-on;
         regulator-always-on;
         regulator-init-microvolt = <3300000>;
-        espressif,ldo-channel = <1>;
       };
 
-      ldo2 {
+      ldo2@2 {
+        reg = <2>;
         regulator-name = "ldo2";
-        regulator-min-microvolt = <500000>;
-        regulator-max-microvolt = <3300000>;
         regulator-init-microvolt = <1800000>;
-        espressif,ldo-channel = <2>;
       };
     };


### PR DESCRIPTION
Honor regulator-init-microvolt and the boot-on / always-on properties at init so on-chip LDOs come up before the kernel runs.

Switch the binding from the custom espressif,ldo-channel property to a standard reg + unit-address layout, and read the channel via DT_REG_ADDR().