### PR TITLE
drivers: i2c: dw: rebuild target mode IC_CON

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1126,20 +1126,34 @@ static int i2c_dw_set_master_mode(const struct device *dev)
 	return 0;
 }
 
-static int i2c_dw_set_slave_mode(const struct device *dev, uint8_t addr)
+static int i2c_dw_set_slave_mode(const struct device *dev, uint16_t addr, uint8_t flags)
 {
+	struct i2c_dw_dev_config *const dw = dev->data;
 	uint32_t reg_base = get_regs(dev);
 	union ic_con_register ic_con;
 
-	ic_con.raw = read_con(reg_base);
+	ic_con = i2c_dw_target_mode_con((flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0U);
+
+	switch (I2C_SPEED_GET(dw->app_config)) {
+	case I2C_SPEED_STANDARD:
+		ic_con.bits.speed = I2C_DW_SPEED_STANDARD;
+		break;
+	case I2C_SPEED_FAST:
+		__fallthrough;
+	case I2C_SPEED_FAST_PLUS:
+		ic_con.bits.speed = I2C_DW_SPEED_FAST;
+		break;
+	case I2C_SPEED_HIGH:
+		if (!dw->support_hs_mode) {
+			return -EINVAL;
+		}
+		ic_con.bits.speed = I2C_DW_SPEED_HIGH;
+		break;
+	default:
+		return -EINVAL;
+	}
 
 	clear_bit_enable_en(reg_base);
-
-	ic_con.bits.master_mode = 0U;
-	ic_con.bits.slave_disable = 0U;
-	ic_con.bits.rx_fifo_full = 1U;
-	ic_con.bits.restart_en = 1U;
-	ic_con.bits.stop_det = 1U;
 
 	write_con(ic_con.raw, reg_base);
 	write_sar(addr, reg_base);
@@ -1163,7 +1177,11 @@ static int i2c_dw_slave_register(const struct device *dev, struct i2c_target_con
 
 	dw->read_in_progress = false;
 	dw->slave_cfg = cfg;
-	ret = i2c_dw_set_slave_mode(dev, cfg->address);
+	ret = i2c_dw_set_slave_mode(dev, cfg->address, cfg->flags);
+	if (ret != 0) {
+		return ret;
+	}
+
 	write_intr_mask(DW_INTR_MASK_RX_FULL | DW_INTR_MASK_RD_REQ |
 			DW_INTR_MASK_TX_ABRT | DW_INTR_MASK_STOP_DET |
 			DW_INTR_MASK_START_DET,

--- a/drivers/i2c/i2c_dw_con.h
+++ b/drivers/i2c/i2c_dw_con.h
@@ -1,0 +1,47 @@
+/* i2c_dw_con.h - DesignWare I2C IC_CON helpers */
+
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_I2C_I2C_DW_CON_H_
+#define ZEPHYR_DRIVERS_I2C_I2C_DW_CON_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/toolchain.h>
+
+/* IC_CON bits */
+union ic_con_register {
+	uint32_t raw;
+	struct {
+		uint32_t master_mode: 1 __packed;
+		uint32_t speed: 2 __packed;
+		uint32_t addr_slave_10bit: 1 __packed;
+		uint32_t addr_master_10bit: 1 __packed;
+		uint32_t restart_en: 1 __packed;
+		uint32_t slave_disable: 1 __packed;
+		uint32_t stop_det: 1 __packed;
+		uint32_t tx_empty_ctl: 1 __packed;
+		uint32_t rx_fifo_full: 1 __packed;
+		uint32_t stop_det_mstactive: 1 __packed;
+		uint32_t bus_clear: 1 __packed;
+	} bits;
+};
+
+static inline union ic_con_register i2c_dw_target_mode_con(bool addr_10bit)
+{
+	union ic_con_register ic_con = { .raw = 0U };
+
+	ic_con.bits.addr_slave_10bit = addr_10bit ? 1U : 0U;
+	ic_con.bits.rx_fifo_full = 1U;
+	ic_con.bits.restart_en = 1U;
+	ic_con.bits.stop_det = 1U;
+
+	return ic_con;
+}
+
+#endif /* ZEPHYR_DRIVERS_I2C_I2C_DW_CON_H_ */

--- a/drivers/i2c/i2c_dw_registers.h
+++ b/drivers/i2c/i2c_dw_registers.h
@@ -8,27 +8,11 @@
 #ifndef ZEPHYR_DRIVERS_I2C_I2C_DW_REGISTERS_H_
 #define ZEPHYR_DRIVERS_I2C_I2C_DW_REGISTERS_H_
 
+#include "i2c_dw_con.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/*  IC_CON bits */
-union ic_con_register {
-	uint32_t raw;
-	struct {
-		uint32_t master_mode: 1 __packed;
-		uint32_t speed: 2 __packed;
-		uint32_t addr_slave_10bit: 1 __packed;
-		uint32_t addr_master_10bit: 1 __packed;
-		uint32_t restart_en: 1 __packed;
-		uint32_t slave_disable: 1 __packed;
-		uint32_t stop_det: 1 __packed;
-		uint32_t tx_empty_ctl: 1 __packed;
-		uint32_t rx_fifo_full: 1 __packed;
-		uint32_t stop_det_mstactive: 1 __packed;
-		uint32_t bus_clear: 1 __packed;
-	} bits;
-};
 
 /* IC_DATA_CMD bits */
 #define IC_DATA_CMD_DAT_MASK 0xFF

--- a/tests/unit/i2c_dw_target_con/CMakeLists.txt
+++ b/tests/unit/i2c_dw_target_con/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(i2c_dw_target_con)
+
+target_include_directories(testbinary PRIVATE ${ZEPHYR_BASE}/drivers/i2c)
+target_sources(testbinary PRIVATE main.c)

--- a/tests/unit/i2c_dw_target_con/main.c
+++ b/tests/unit/i2c_dw_target_con/main.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+
+#include <zephyr/ztest.h>
+
+#include "i2c_dw_con.h"
+
+ZTEST(i2c_dw_target_con, test_7_bit_target_mode_does_not_set_10_bit_addressing)
+{
+	union ic_con_register ic_con;
+
+	ic_con = i2c_dw_target_mode_con(false);
+
+	zassert_equal(ic_con.bits.master_mode, 0U);
+	zassert_equal(ic_con.bits.slave_disable, 0U);
+	zassert_equal(ic_con.bits.addr_slave_10bit, 0U);
+	zassert_equal(ic_con.bits.addr_master_10bit, 0U);
+	zassert_equal(ic_con.bits.speed, 0U);
+	zassert_equal(ic_con.bits.rx_fifo_full, 1U);
+	zassert_equal(ic_con.bits.restart_en, 1U);
+	zassert_equal(ic_con.bits.stop_det, 1U);
+	zassert_equal(ic_con.bits.tx_empty_ctl, 0U);
+	zassert_equal(ic_con.bits.stop_det_mstactive, 0U);
+	zassert_equal(ic_con.bits.bus_clear, 0U);
+}
+
+ZTEST(i2c_dw_target_con, test_10_bit_target_mode_sets_slave_addressing)
+{
+	union ic_con_register ic_con;
+
+	ic_con = i2c_dw_target_mode_con(true);
+
+	zassert_equal(ic_con.bits.master_mode, 0U);
+	zassert_equal(ic_con.bits.slave_disable, 0U);
+	zassert_equal(ic_con.bits.addr_slave_10bit, 1U);
+	zassert_equal(ic_con.bits.addr_master_10bit, 0U);
+	zassert_equal(ic_con.bits.speed, 0U);
+	zassert_equal(ic_con.bits.rx_fifo_full, 1U);
+	zassert_equal(ic_con.bits.restart_en, 1U);
+	zassert_equal(ic_con.bits.stop_det, 1U);
+	zassert_equal(ic_con.bits.tx_empty_ctl, 0U);
+	zassert_equal(ic_con.bits.stop_det_mstactive, 0U);
+	zassert_equal(ic_con.bits.bus_clear, 0U);
+}
+
+ZTEST_SUITE(i2c_dw_target_con, NULL, NULL, NULL, NULL, NULL);

--- a/tests/unit/i2c_dw_target_con/prj.conf
+++ b/tests/unit/i2c_dw_target_con/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/unit/i2c_dw_target_con/testcase.yaml
+++ b/tests/unit/i2c_dw_target_con/testcase.yaml
@@ -1,0 +1,6 @@
+tests:
+  drivers.i2c.dw.target_con:
+    tags:
+      - drivers
+      - i2c
+    type: unit


### PR DESCRIPTION
Fixes #109178.

## Summary

- Rebuild DesignWare target-mode `IC_CON` from a zeroed value instead of preserving the previous hardware register contents.
- Set `addr_slave_10bit` only when `I2C_TARGET_FLAGS_ADDR_10_BITS` is requested by the target configuration.
- Keep target-mode speed programming explicit and add a unit test for the target-mode `IC_CON` helper.

## Validation

- `git diff HEAD^..HEAD --check`
- `scripts/checkpatch.pl --git HEAD --no-signoff`
- `/tmp/zephyr-venv-109178/bin/python scripts/ci/check_compliance.py -c upstream/main..HEAD -m Checkpatch -m GitDiffCheck -m Nits -m LicenseAndCopyrightCheck -m TextEncoding -m BinaryFiles -m YAMLLint -m CMakeStyle`
- Direct host compile/run of `drivers/i2c/i2c_dw_con.h` helper assertions with Apple `cc`.

## Known draft blockers

- DCO/Identity is intentionally unresolved because Zephyr's AI contribution guidance says AI agents must not add `Signed-off-by` tags. The human submitter needs to amend this commit with a real author email and their own `Signed-off-by` line before marking the PR ready for review.
- `twister -T tests/unit/i2c_dw_target_con` was attempted locally. Default Twister requires Zephyr SDK, which is not installed on this machine. With `ZEPHYR_TOOLCHAIN_VARIANT=host`, AppleClang fails in ztest iterable-section attributes on Mach-O before running this test.

AI assistance disclosure: OpenAI GPT-5.

