### PR TITLE
tests/subsys/shell: Fix buffer overflow in test data

### DIFF
--- a/tests/subsys/shell/shell/prj.conf
+++ b/tests/subsys/shell/shell/prj.conf
@@ -8,3 +8,5 @@ CONFIG_SHELL_METAKEYS=n
 CONFIG_LOG=n
 CONFIG_ZTEST=y
 CONFIG_TEST_LOGGING_DEFAULTS=n
+# Remove the 50ms timeout to avoid potential failures (see commit description)
+CONFIG_SHELL_TX_TIMEOUT_MS=0

--- a/tests/subsys/shell/shell/src/main.c
+++ b/tests/subsys/shell/shell/src/main.c
@@ -739,7 +739,7 @@ ZTEST(sh, test_shell_readline_errors)
 
 	const struct shell *sh = shell_backend_dummy_get_ptr();
 
-	shell_backend_dummy_push_input(sh, short_line, sizeof(long_line));
+	shell_backend_dummy_push_input(sh, short_line, sizeof(short_line));
 	test_shell_execute_cmd("test_readline_null_buf", -ENOBUFS);
 	shell_backend_dummy_clear_input(sh);
 


### PR DESCRIPTION
Fix a buffer overflow in the test data which causes random crashes

Fixes random failures seen in CI depending on memory layout:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/26127485571/job/76886974127#step:12:2236

The issue can be pinpointed building with ASAN for native_sim:
```
cmake -GNinja -DBOARD=native_sim ../tests/subsys/shell/shell -DCONFIG_SHELL_METAKEYS=y -DCONFIG_ASAN=y
ninja
zephyr/zephyr.exe
```
```
START - test_shell_readline_errors
=================================================================
==583051==ERROR: AddressSanitizer: global-buffer-overflow on address 0x0808e8e7 at pc 0xe8bd050a bp 0xe5bff1c8 sp 0xe5bfed9c
READ of size 37 at 0x0808e8e7 thread T25
    #0 0xe8bd0509 in memcpy ../../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115
    #1 0x8056fe2 in shell_backend_dummy_push_input subsys/shell/backends/shell_dummy.c:162
    #2 0x804c2ea in sh_test_shell_readline_errors tests/subsys/shell/shell/src/main.c:742
    #3 0x804c2ea in _sh_test_shell_readline_errors_wrapper tests/subsys/shell/shell/src/main.c:735
    #4 0x8067ca6 in run_test_functions subsys/testsuite/ztest/src/ztest.c:328
    #5 0x8067ca6 in test_cb subsys/testsuite/ztest/src/ztest.c:664
    #6 0x8066981 in z_thread_entry kernel/sys/thread_entry.c:60
    #7 0x8067115 in posix_arch_thread_entry arch/posix/core/thread.c:124
    #8 0x8074873 in nct_thread_starter scripts/native_simulator//common/src/nct.c:291
    #9 0xe8b249a3 in asan_thread_start ../../../../../src/libsanitizer/asan/asan_interceptors.cpp:234
    #10 0xe882bfe6 in start_thread nptl/pthread_create.c:447
    #11 0xe88c35a7 in clone3 ../sysdeps/unix/sysv/linux/i386/clone3.S:111

0x0808e8e7 is located 57 bytes before global variable '__func__' defined in 'tests/subsys/shell/shell/src/main.c:522:2' (0x808e920) of size 25
  '__func__' is ascii string 'sh_test_shell_set_bypass'
0x0808e8e7 is located 0 bytes after global variable 'short_line' defined in 'tests/subsys/shell/shell/src/main.c:737:20' (0x808e8e0) of size 7
  'short_line' is ascii string 'short'
```

--------

This test has been seen failing in a quite difficult to reproduce manner:
The test seems to fail quite repeatedly on CI, for qemu_x86_64/atom
on shell.core.metakeys, on the first check of test_shell_readline_errors
where instead of ENOBUF, ENOEXEC is returned.
Reproducing the issue locally has proven challenging.

A guess on the problem is that the shell does not manage to lock its
semaphore in the 50ms timeout, and that is the cause of the failure.

In this commit we disable this timeout hoping this will fix it.

