### PR TITLE
boards: nxp: frdm_imxrt1186: add counter support

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -21,6 +21,7 @@ supported:
   - flash
   - gpio
   - can
+  - counter
   - uart
   - hwinfo
   - mbox

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
@@ -18,6 +18,7 @@ supported:
   - flash
   - gpio
   - can
+  - counter
   - uart
   - hwinfo
   - mbox

--- a/tests/drivers/counter/counter_basic_api/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -4,6 +4,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&gpt1 {
+	status = "okay";
+	run-mode = "free-run";
+};
+
 &gpt2 {
 	run-mode = "free-run";
+};
+
+&lpit1 {
+	status = "okay";
+};
+
+&lpit1_channel0 {
+	status = "okay";
+};
+
+&lptmr1 {
+	status = "okay";
+};
+
+&qtmr1 {
+	status = "okay";
+};
+
+&qtmr1_timer0 {
+	status = "okay";
+	primary-source = "kQTMR_ClockDivide_128";
+	mode = "kQTMR_PriSrcRiseEdge";
+};
+
+&tpm1 {
+	compatible = "nxp,tpm-timer";
+	status = "okay";
 };

--- a/tests/drivers/counter/counter_basic_api/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * CM33 and CM7 share the same peripheral instances on i.MX RT1186;
+ * reuse the CM33 overlay to keep the test configuration in sync.
+ */
+#include "frdm_imxrt1186_mimxrt1186_cm33.overlay"


### PR DESCRIPTION
Add counter (timer) feature support for frdm_imxrt1186 board on both CM33 and CM7 cores. The following counter IPs are enabled: GPT, LPIT, LPTMR, and QTMR.

Include board-specific device tree overlays and Kconfig fragments for the counter_basic_api test case.

Tested on frdm_imxrt1186 with both CM33 and CM7 cores, counter_basic_api test case passed.