### PR TITLE
dts: wifi: nxp: add out of band reset gpio pin

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_1xk_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_1xk_wifi_bt.overlay
@@ -33,6 +33,7 @@
 	nxp_wifi {
 		compatible = "nxp,wifi";
 		wakeup-gpios = <&gpio1 26 GPIO_ACTIVE_LOW>;
+		oob-gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };

--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_2el_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_2el_wifi_bt.overlay
@@ -33,6 +33,7 @@
 	nxp_wifi {
 		compatible = "nxp,wifi";
 		wakeup-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		oob-gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };

--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_2ll_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_2ll_wifi_bt.overlay
@@ -33,6 +33,7 @@
 	nxp_wifi {
 		compatible = "nxp,wifi";
 		wakeup-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		oob-gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };

--- a/dts/bindings/wifi/nxp,wifi.yaml
+++ b/dts/bindings/wifi/nxp,wifi.yaml
@@ -32,3 +32,9 @@ properties:
       This pin defaults to active high when consumed by the SD card. The
       property value should ensure the flags properly describe the signal
       that is presented to the driver.
+
+  oob-gpios:
+    type: phandle-array
+    description: |
+      Out of band Wi-Fi reset gpio on host platform.
+      This GPIO will be used to reset Wi-Fi controller from host side.


### PR DESCRIPTION
Add out of band reset gpio pin in host platform.
Toggle this pin when about to reset Wi-Fi firmware from out of band.