### PR TITLE
boards: st: increase H7RS based board sysclk to reach maximum 600MHz

### DIFF
--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
@@ -78,8 +78,8 @@
 
 &pll {
 	div-m = <12>;
-	mul-n = <200>;
-	div-p = <2>;
+	mul-n = <300>;
+	div-p = <1>;
 	div-q = <2>;
 	div-r = <2>;
 	div-s = <2>;
@@ -103,9 +103,9 @@
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(200)>;
+	clock-frequency = <DT_FREQ_M(600)>;
 	dcpre = <1>;
-	hpre = <1>;
+	hpre = <2>;
 	ppre1 = <2>;
 	ppre2 = <2>;
 	ppre4 = <2>;

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -124,8 +124,8 @@
 
 &pll {
 	div-m = <12>;
-	mul-n = <250>;
-	div-p = <2>;
+	mul-n = <300>;
+	div-p = <1>;
 	div-q = <2>;
 	div-r = <2>;
 	div-s = <2>;
@@ -144,9 +144,9 @@
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(250)>;
+	clock-frequency = <DT_FREQ_M(600)>;
 	dcpre = <1>;
-	hpre = <1>;
+	hpre = <2>;
 	ppre1 = <2>;
 	ppre2 = <2>;
 	ppre4 = <2>;

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -73,6 +73,11 @@ Boards
   * ``#include <haltium_power.h>`` with ``#include <soc_power.h>``.
   * ``#include <haltium_pm_s2ram.h>`` with ``#include <soc_pm_s2ram.h>``.
 
+* The system clock on STM32H7RS-based boards (stm32h7s78_dk and nucleo_h7s3l8)
+  has been increased to 600 MHz. This is achieved by increasing the PLL1 frequency
+  to 300 MHz, which also affects the bus and kernel clocks, resulting in slightly
+  higher frequencies.
+
 Device Drivers and Devicetree
 *****************************
 


### PR DESCRIPTION
Nucleo and Disco boards based on STM32H7RS currently have their sysclk set to 200 MHz and 250 MHz, respectively, while the maximum SoC frequency is 600 MHz.
Update the PLL1 settings on both boards to reach this maximum frequency and improve performance.