### PR TITLE
tests: drivers: spi: enable SPI support for FLPR core

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuflpr_xip_0_9_0.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuflpr_xip_0_9_0.yaml
@@ -13,3 +13,4 @@ flash: 48
 supported:
   - gpio
   - counter
+  - spi

--- a/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_GPIO_NRFX_INTERRUPT=n
+CONFIG_NRFX_GPIOTE=y

--- a/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio6 {
+	status = "okay";
+};
+
+&gpio7 {
+	status = "okay";
+};
+
+&pinctrl {
+	spis120_default_alt: spis120_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 6, 0)>,
+				<NRF_PSEL(SPIS_MISO, 6, 3)>,
+				<NRF_PSEL(SPIS_MOSI, 6, 4)>,
+				<NRF_PSEL(SPIS_CSN, 6, 9)>;
+		};
+	};
+
+	spis120_sleep_alt: spis120_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 6, 0)>,
+				<NRF_PSEL(SPIS_MISO, 6, 3)>,
+				<NRF_PSEL(SPIS_MOSI, 6, 4)>,
+				<NRF_PSEL(SPIS_CSN, 6, 9)>;
+			low-power-enable;
+		};
+	};
+
+	spi120_default: spi120_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 7, 6)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
+		};
+	};
+
+	spi120_sleep: spi120_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MISO, 7, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			low-power-enable;
+		};
+	};
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+dut_spis: &spis120 {
+	compatible = "nordic,nrf-spis";
+	status = "okay";
+	def-char = <0x00>;
+	pinctrl-0 = <&spis120_default_alt>;
+	pinctrl-1 = <&spis120_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+};
+
+&spi120 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	pinctrl-0 = <&spi120_default>;
+	pinctrl-1 = <&spi120_sleep>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	memory-regions = <&dma_fast_region>;
+	zephyr,pm-device-runtime-auto;
+	cs-gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};
+
+&uart120 {
+	status = "disabled";
+};

--- a/tests/drivers/spi/spi_error_cases/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_error_cases/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -3,14 +3,121 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "../../../boards/nrf54h20dk_nrf54h20_common.dtsi"
+
+&gpio1 {
+	status = "reserved";
+};
+
+&gpio0 {
+	status = "reserved";
+};
+
+&gpio6 {
+	status = "reserved";
+};
+
+&gpio7 {
+	status = "reserved";
+};
+
+&pinctrl {
+	spi130_default_alt: spi130_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
+				<NRF_PSEL(SPIM_MISO, 0, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+		};
+	};
+
+	spi130_sleep_alt: spi130_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
+				<NRF_PSEL(SPIM_MISO, 0, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+			low-power-enable;
+		};
+	};
+
+	spis131_default_alt: spis131_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
+				<NRF_PSEL(SPIS_MISO, 0, 7)>,
+				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
+				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+		};
+	};
+
+	spis131_sleep_alt: spis131_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
+				<NRF_PSEL(SPIS_MISO, 0, 7)>,
+				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
+				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+			low-power-enable;
+		};
+	};
+
+	spis120_default_alt: spis120_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 6, 0)>,
+				<NRF_PSEL(SPIS_MISO, 6, 3)>,
+				<NRF_PSEL(SPIS_MOSI, 6, 4)>,
+				<NRF_PSEL(SPIS_CSN, 6, 9)>;
+		};
+	};
+
+	spis120_sleep_alt: spis120_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 6, 0)>,
+				<NRF_PSEL(SPIS_MISO, 6, 3)>,
+				<NRF_PSEL(SPIS_MOSI, 6, 4)>,
+				<NRF_PSEL(SPIS_CSN, 6, 9)>;
+			low-power-enable;
+		};
+	};
+
+	spi120_default: spi120_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 7, 6)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
+		};
+	};
+
+	spi120_sleep: spi120_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MISO, 7, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			low-power-enable;
+		};
+	};
+};
 
 &spi130 {
 	status = "reserved";
+	pinctrl-0 = <&spi130_default_alt>;
+	pinctrl-1 = <&spi130_sleep_alt>;
+	pinctrl-names = "default", "sleep";
 	interrupt-parent = <&cpuppr_clic>;
 };
 
-&dut_spis {
+&spi131 {
 	status = "reserved";
+	pinctrl-0 = <&spis131_default_alt>;
+	pinctrl-1 = <&spis131_sleep_alt>;
+	pinctrl-names = "default", "sleep";
 	interrupt-parent = <&cpuppr_clic>;
+};
+
+&spis120 {
+	status = "reserved";
+	pinctrl-0 = <&spis120_default_alt>;
+	pinctrl-1 = <&spis120_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	interrupt-parent = <&cpuflpr_clic>;
 };

--- a/tests/drivers/spi/spi_error_cases/testcase.yaml
+++ b/tests/drivers/spi/spi_error_cases/testcase.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpuppr
+      - nrf54h20dk/nrf54h20/cpuflpr/xip
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=15
+
+# nRF54H20 FLPR has no GPIO interrupts available
+CONFIG_GPIO_NRFX_INTERRUPT=n
+CONFIG_NRFX_GPIOTE=y

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+&cpuflpr_code_partition {
+	reg = <0xf4000 DT_SIZE_K(64)>;
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pinctrl {
+	spi120_default: spi120_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 7, 6)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
+		};
+	};
+
+	spi120_sleep: spi120_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MISO, 7, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio7 {
+	status = "okay";
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&spi120 {
+	status = "okay";
+	pinctrl-0 = <&spi120_default>;
+	pinctrl-1 = <&spi120_sleep>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	memory-regions = <&dma_fast_region>;
+	zephyr,pm-device-runtime-auto;
+
+	slow@1 {
+		compatible = "test-spi-loopback-slow";
+		reg = <1>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
+	};
+
+	dut_fast: fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};
+
+&uart120 {
+	status = "disabled";
+};

--- a/tests/drivers/spi/spi_loopback/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -3,9 +3,72 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "../../../boards/nrf54h20dk_nrf54h20_common.dtsi"
+
+&pinctrl {
+	spi120_default: spi120_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 7, 6)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
+		};
+	};
+
+	spi120_sleep: spi120_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MISO, 7, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			low-power-enable;
+		};
+	};
+
+	spi130_default: spi130_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
+				<NRF_PSEL(SPIM_MISO, 0, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 7)>;
+		};
+	};
+
+	spi130_sleep: spi130_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
+				<NRF_PSEL(SPIM_MISO, 0, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 7)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio7 {
+	status = "reserved";
+};
+
+&gpio1 {
+	status = "reserved";
+};
 
 &spi130 {
 	status = "reserved";
+	pinctrl-0 = <&spi130_default>;
+	pinctrl-1 = <&spi130_sleep>;
+	pinctrl-names = "default", "sleep";
 	interrupt-parent = <&cpuppr_clic>;
+};
+
+&spi120 {
+	status = "reserved";
+	pinctrl-0 = <&spi120_default>;
+	pinctrl-1 = <&spi120_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+	interrupt-parent = <&cpuflpr_clic>;
+};
+
+&dma_fast_region {
+	status = "okay";
 };

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -309,6 +309,18 @@ tests:
       - CONFIG_NRF_REGTOOL_VERBOSITY=2
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+  drivers.spi.nrf54h_flpr_fast_8mhz:
+    sysbuild: true
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_8mhz.overlay"
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuflpr/xip
+  drivers.spi.nrf54h_flpr_fast_32mhz:
+    sysbuild: true
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_32mhz.overlay"
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuflpr/xip
   drivers.spi.nrf54l_1mhz:
     extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_1mhz.overlay"
     platform_allow:


### PR DESCRIPTION
Add corresponding test overlays so that the SPI
tests run correctly under Twister for the FLPR core.