### PR TITLE
soc: nxp: imx95: Refine condition to enable MCUX_LPTMR_TIMER

### DIFF
--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
@@ -4,6 +4,8 @@
 if SOC_MIMX9596_M7
 
 DT_CHOSEN_Z_FLASH := zephyr,flash
+DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
+DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
 
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
@@ -43,10 +45,7 @@ config NUM_IRQS
 	default 250 # 2ND_LVL_ISR_TBL_OFFSET + MAX_IRQ_PER_AGGREGATOR * NUM_2ND_LEVEL_AGGREGATORS
 
 config MCUX_LPTMR_TIMER
-	default y if !COUNTER_MCUX_LPTMR
-
-DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
-DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
+	default y if !COUNTER_MCUX_LPTMR && $(dt_chosen_enabled,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
 
 config CORTEX_M_SYSTICK
 	default n if MCUX_LPTMR_TIMER


### PR DESCRIPTION
For i.MX95 M7 MCUX_LPTMR_TIMER defaults to y if COUNTER_MCUX_LPTMR not enabled.

This prevents us on enabling CORTEX_M_SYSTICK. So refine the condition so that MCUX_LPTMR_TIMER only defaults to enabled if COUNTER_MCUX_LPTMR not set (as it is now) and also add condition that zephyr,system-timer is actually set.

This also moves DT_CHOSEN_ZEPHYR_SYSTEM_TIMER, DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH definitions at the top of the file.

Fixes: 0c4382ae5e7d ("drivers: timer: keep mcux_lptmr policy explicit")

This also fixes SOF build for i.MX95 https://github.com/thesofproject/sof/pull/10765