### PR TITLE
include: dt-bindings: remove deprecated PWM_STM32_COMPLEMENTARY

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -217,6 +217,9 @@ PWM
   by ``pcr-scr`` (int type) to use encoded PCR register index and bit position macros
   (:github:`104570`).
 
+* STM32 PWM DT bindings macro ``PWM_STM32_COMPLEMENTARY`` that is deprecated since
+  Zephyr v3.3.0 is no more defined. One shall use ``STM32_PWM_COMPLEMENTARY`` instead.
+
 SD Host Controller
 ==================
 

--- a/include/zephyr/dt-bindings/pwm/stm32_pwm.h
+++ b/include/zephyr/dt-bindings/pwm/stm32_pwm.h
@@ -17,10 +17,6 @@
  */
 /** PWM complementary output pin is enabled */
 #define STM32_PWM_COMPLEMENTARY	(1U << 8)
-/**
- * @deprecated Use the PWM complementary `STM32_PWM_COMPLEMENTARY` flag instead.
- */
-#define PWM_STM32_COMPLEMENTARY	(1U << 8)
 
 /** @cond INTERNAL_HIDDEN */
 #define STM32_PWM_COMPLEMENTARY_MASK	0x100


### PR DESCRIPTION
Remove definition of `PWM_STM32_COMPLEMENTARY` macro that was deprecated in Zephyr v3.3.0.