### PR TITLE
Update maintainer map for Display and MIPI DSI driver

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1273,6 +1273,7 @@ Display drivers:
     - VynDragon
     - KATE-WANG-NXP
     - avolmat-st
+    - RuoshanShi
   files:
     - drivers/display/
     - dts/bindings/display/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2140,6 +2140,7 @@ Documentation Infrastructure:
   collaborators:
     - JarmouniA
     - KATE-WANG-NXP
+    - RuoshanShi
   files:
     - drivers/mipi_dsi/
     - include/zephyr/drivers/mipi_dsi.h


### PR DESCRIPTION
Add myslef as a collaborator for the MIPI DSI and Display subsystems.
I have been actively contributing to MIPI DSI  and Display implementations. 

New MIPI DSI driver:  drivers/mipi_dsi/dsi_nxp_dwc.c
New Display driver: drivers/display/display_socionext_dpu.c   
New panel driver: 
drivers/display/display_rm67199.c
drivers/display/display_rm692c9.c 
New NXP shield: 
boards/shields/nxp_mx8_dsi_oled1a
boards/shields/nxp_mx9_dsi_oled

Updated and contributed drivers and shields：
drivers/display/display_mcux_lcdifv3.c
boards/shields/waveshare_dsi_lcd