### PR TITLE
MAINTAINERS: add venodela as Xilinx collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6915,6 +6915,7 @@ Xilinx Platforms:
     - ibirnbaum
     - kedareswararao
     - neeliajay
+    - venodela
   files:
     - boards/amd/
     - drivers/*/*xilinx*


### PR DESCRIPTION
Add venodela (Venkatesh Odela) as a collaborator for "Xilinx Platforms"
I have been actively contributing and will continue reviewing and testing patches for the Xilinx subsystems

My Contributions: 
  - #109283                                                                                                                                               
  - #106816 
  - #106767                                                                                                                                      
  - #103412 
  - #97521                                                                                                                                                     
  - #97469                                                                                                                                               
  - #92411                                                                                                                              
  - #91258  
  
Nominate venodela (Venkatesh Odela) as a contributor   https://github.com/zephyrproject-rtos/zephyr/issues/109484
  
  @kedareswararao @neeliajay 