### PR TITLE
ci: fix template injection in GitHub Actions workflows

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -41,8 +41,10 @@ jobs:
     - name: Fetch west.yml/Maintainer.yml from pull request
       if: >
         github.event_name == 'pull_request_target' && github.base_ref == 'main'
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        git fetch origin pull/${{ github.event.pull_request.number }}/merge
+        git fetch origin "pull/${PR_NUMBER}/merge"
         git show FETCH_HEAD:west.yml > pr_west.yml
         git show FETCH_HEAD:MAINTAINERS.yml > pr_MAINTAINERS.yml
 
@@ -57,23 +59,29 @@ jobs:
     - name: Run assignment script
       env:
         GITHUB_TOKEN: ${{ secrets.ZB_PR_ASSIGNER_GITHUB_TOKEN }}
+        REPO_OWNER: ${{ github.event.repository.owner.login }}
+        REPO_NAME: ${{ github.event.repository.name }}
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_REF: ${{ github.base_ref }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
       run: |
         FLAGS="-v"
-        FLAGS+=" -o ${{ github.event.repository.owner.login }}"
-        FLAGS+=" -r ${{ github.event.repository.name }}"
+        FLAGS+=" -o ${REPO_OWNER}"
+        FLAGS+=" -r ${REPO_NAME}"
         FLAGS+=" -M MAINTAINERS.yml"
-        if [ "${{ github.event_name }}" = "pull_request_target" ]; then
-          if [ "${{ github.base_ref }}" = "main" ]; then
-            FLAGS+=" -P ${{ github.event.pull_request.number }} --updated-manifest pr_west.yml --updated-maintainer-file pr_MAINTAINERS.yml"
+        if [ "${EVENT_NAME}" = "pull_request_target" ]; then
+          if [ "${BASE_REF}" = "main" ]; then
+            FLAGS+=" -P ${PR_NUMBER} --updated-manifest pr_west.yml --updated-maintainer-file pr_MAINTAINERS.yml"
           else
-            FLAGS+=" -P ${{ github.event.pull_request.number }}"
+            FLAGS+=" -P ${PR_NUMBER}"
           fi
-        elif [ "${{ github.event_name }}" = "issues" ]; then
-          FLAGS+=" -I ${{ github.event.issue.number }}"
-        elif [ "${{ github.event_name }}" = "schedule" ]; then
+        elif [ "${EVENT_NAME}" = "issues" ]; then
+          FLAGS+=" -I ${ISSUE_NUMBER}"
+        elif [ "${EVENT_NAME}" = "schedule" ]; then
           FLAGS+=" --modules"
         else
-          echo "Unknown event: ${{ github.event_name }}"
+          echo "Unknown event: ${EVENT_NAME}"
           exit 1
         fi
         python3 scripts/ci/set_assignees.py $FLAGS

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -42,9 +42,13 @@ jobs:
       - name: Run backport issue checker
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           ./scripts/release/list_backports.py \
-          -o ${{ github.event.repository.owner.login }} \
-          -r ${{ github.event.repository.name }} \
-          -b ${{ github.event.pull_request.base.ref }} \
-          -p ${{ github.event.pull_request.number }}
+          -o "${REPO_OWNER}" \
+          -r "${REPO_NAME}" \
+          -b "${BASE_REF}" \
+          -p "${PR_NUMBER}"

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -76,6 +76,7 @@ jobs:
       id: compliance
       env:
         BASE_REF: ${{ github.base_ref }}
+        GH_ACTOR: ${{ github.actor }}
       run: |
         export ZEPHYR_BASE=$PWD
         # debug
@@ -85,7 +86,7 @@ jobs:
         git config diff.renameLimit 10000
         excludes="-e KconfigBasic -e SysbuildKconfigBasic -e ClangFormat"
         # The signed-off-by check for dependabot should be skipped
-        if [ "${{ github.actor }}" == "dependabot[bot]" ]; then
+        if [ "${GH_ACTOR}" == "dependabot[bot]" ]; then
           excludes="$excludes -e Identity"
         fi
         ./scripts/ci/check_compliance.py --annotate $excludes -c origin/${BASE_REF}..

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -122,6 +122,10 @@ jobs:
           ELASTICSEARCH_KEY: ${{ secrets.ELASTICSEARCH_KEY }}
           ELASTICSEARCH_SERVER: "https://elasticsearch.zephyrproject.io:443"
           ELASTICSEARCH_INDEX: ${{ vars.FOOTPRINT_TRACKING_INDEX }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           shopt -s globstar
           run_date=`date --iso-8601=minutes`
@@ -129,10 +133,10 @@ jobs:
             --flatten footprint \
             --flatten-list-names "{'children':'name'}" \
             --transform "{ 'footprint_name': '^(?P<footprint_area>([^\/]+\/){0,2})(?P<footprint_path>([^\/]*\/)*)(?P<footprint_symbol>[^\/]*)$' }" \
-            --run-id "${{ github.run_id }}" \
-            --run-attempt "${{ github.run_attempt }}" \
-            --run-workflow "footprint-tracking:${{ github.event_name }}" \
-            --run-branch "${{ github.ref_name }}" \
+            --run-id "${RUN_ID}" \
+            --run-attempt "${RUN_ATTEMPT}" \
+            --run-workflow "footprint-tracking:${EVENT_NAME}" \
+            --run-branch "${REF_NAME}" \
             -i ${ELASTICSEARCH_INDEX} \
             ./footprint_data/**/twister_footprint.json
         #

--- a/.github/workflows/ready-to-merge.yml
+++ b/.github/workflows/ready-to-merge.yml
@@ -16,11 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check status of all required jobs"
+        env:
+          NEEDS_CONTEXT: ${{ inputs.needs_context }}
         run: |-
-          NEEDS_CONTEXT='${{ inputs.needs_context }}'
-          JOB_IDS=$(echo "$NEEDS_CONTEXT" | jq -r 'keys[]')
+          JOB_IDS=$(echo "${NEEDS_CONTEXT}" | jq -r 'keys[]')
           for JOB_ID in $JOB_IDS; do
-            RESULT=$(echo "$NEEDS_CONTEXT" | jq -r ".[\"$JOB_ID\"].result")
+            RESULT=$(echo "${NEEDS_CONTEXT}" | jq -r ".[\"$JOB_ID\"].result")
             echo "$JOB_ID job result: $RESULT"
             if [[ $RESULT != "success" && $RESULT != "skipped" ]]; then
               echo "***"

--- a/.github/workflows/twister-publish.yaml
+++ b/.github/workflows/twister-publish.yaml
@@ -48,17 +48,21 @@ jobs:
 
       - name: Upload to elasticsearch
         if: steps.download-artifacts.outputs.found_artifact == 'true'
+        env:
+          WORKFLOW_EVENT: ${{ github.event.workflow_run.event }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # set run date on upload to get consistent and unified data across the matrix.
           run_date=`date --iso-8601=minutes`
-          if [ "${{github.event.workflow_run.event}}" = "push" ]; then
+          if [ "${WORKFLOW_EVENT}" = "push" ]; then
             python3 ./scripts/ci/upload_test_results_es.py -r ${run_date} \
-            --run-attempt ${{github.run_attempt}} \
-            --run-branch ${{github.ref_name}} \
+            --run-attempt "${RUN_ATTEMPT}" \
+            --run-branch "${REF_NAME}" \
             --index zephyr-main-ci-push-1 artifacts/*/*/twister.json
-          elif [ "${{github.event.workflow_run.event}}" = "schedule" ]; then
+          elif [ "${WORKFLOW_EVENT}" = "schedule" ]; then
             python3 ./scripts/ci/upload_test_results_es.py -r ${run_date} \
-            --run-attempt ${{github.run_attempt}} \
-            --run-branch ${{github.ref_name}} \
+            --run-attempt "${RUN_ATTEMPT}" \
+            --run-branch "${REF_NAME}" \
             --index zephyr-main-ci-weekly-1 artifacts/*/*/twister.json
           fi

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -200,15 +200,19 @@ jobs:
           echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
 
       - name: Check Environment
+        env:
+          GH_REF: ${{ github.ref }}
+          GH_BASE_REF: ${{ github.base_ref }}
+          GH_REF_NAME: ${{ github.ref_name }}
         run: |
           cmake --version
           gcc --version
           cargo --version
           rustup target list --installed
           ls -la
-          echo "github.ref: ${{ github.ref }}"
-          echo "github.base_ref: ${{ github.base_ref }}"
-          echo "github.ref_name: ${{ github.ref_name }}"
+          echo "github.ref: ${GH_REF}"
+          echo "github.base_ref: ${GH_BASE_REF}"
+          echo "github.ref_name: ${GH_REF_NAME}"
 
       - name: Install Python packages
         run: |


### PR DESCRIPTION
Replace inline ${{ }} template expressions in shell run: steps with env: variable references to prevent template injection attacks.

Fixed workflows:
- assigner.yml: github.base_ref, event.repository.*, event_name, pull_request.number, issue.number
- backport_issue_check.yml: pull_request.base.ref, repository.*, pull_request.number
- compliance.yml: github.actor
- footprint-tracking.yml: github.ref_name, run_id, run_attempt, event_name
- ready-to-merge.yml: inputs.needs_context (caller-controlled JSON)
- twister-publish.yaml: workflow_run.event, run_attempt, ref_name
- twister.yaml: github.ref, base_ref, ref_name in echo statements

All expressions are now passed via env: block and referenced as ${VAR_NAME} in shell, which prevents shell metacharacter injection regardless of the input content.

Issues identified using zizmor v1.25.2 static analysis (auditor persona).