### PR TITLE
soc: nordic: Add dummy TF-M platform services implementation

### DIFF
--- a/soc/nordic/common/soc_secure.c
+++ b/soc/nordic/common/soc_secure.c
@@ -7,6 +7,8 @@
 #include <soc_secure.h>
 #include <errno.h>
 
+#if !defined(CONFIG_TFM_USE_NS_APP)
+
 #include "tfm_platform_api.h"
 #include "tfm_ioctl_api.h"
 
@@ -43,3 +45,19 @@ int soc_secure_mem_read(void *dst, void *src, size_t len)
 		return -EPERM;
 	}
 }
+
+#else
+
+#if NRF_GPIO_HAS_SEL
+void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_sel_t mcu)
+{
+	__ASSERT(FALSE, "This function can only be called from Zephyr NS app.");
+}
+#endif /* NRF_GPIO_HAS_SEL */
+
+int soc_secure_mem_read(void *dst, void *src, size_t len)
+{
+	return -EINVAL;
+}
+
+#endif /* !CONFIG_TFM_USE_NS_APP */


### PR DESCRIPTION
The commit 06dd00c3409 changed how the tfm_api library is build which is now only build when !CONFIG_TFM_USE_NS_APP.

Since the tfm_api includes the ioctl NS API calls the soc_secure.c implementation fails with unresolved references when the TF-M tests are being build (since only the TF-M tests use CONFIG_TFM_USE_NS_APP as for now).

This adds a dummy implementation of the soc_secure functions for this use case. The dummy functions allow us to build and only affect the TF-M tests which don't use these services anyway.

The alternative will be to remove the soc_secure.c from building but then we will have to ifdef the references to it which is more intrusive.