### PR TITLE
boards: shields: ad_apardpfw_sl: Fix overlay for APARD32690

### DIFF
--- a/boards/shields/ad_apardpfw_sl/boards/apard32690_max32690_m4.overlay
+++ b/boards/shields/ad_apardpfw_sl/boards/apard32690_max32690_m4.overlay
@@ -67,16 +67,14 @@
 	};
 };
 
-&spi3 {
-	adin1110@0 {
+&adin1110 {
+	status = "disabled";
+
+	mdio {
 		status = "disabled";
 
-		mdio {
+		ethernet-phy@1 {
 			status = "disabled";
-
-			ethernet-phy@1 {
-				status = "disabled";
-			};
 		};
 	};
 };


### PR DESCRIPTION
ADIN1110 on the APARD32690 board is a child of spi3 on revD and a child of spi4 on revE, causing a build error for revE, as there is no ADIN1110 node under spi3 to be disabled.

Reference the adin1110 node directly instead of through its parent.