### PR TITLE
doc: twister: fix cmd for single test

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -2408,4 +2408,4 @@ To run a single testsuite instead of a whole group of test you can run:
 
 .. code-block:: bash
 
-   $ twister -p qemu_riscv32 -s tests/kernel/interrupt/arch.shared_interrupt
+   $ west twister -p qemu_riscv32 -s arch.shared_interrupt


### PR DESCRIPTION
the command for runing a single
test was wrong. This fixes it.

This then also matches the output
from twister, how to re-run the test.