### PR TITLE
Fix MWDT arcmwdt middleware libc compatibility with picolibc

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -125,7 +125,7 @@ endif()
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp98 "-std=c++98")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp11 "-std=c++11")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp14 "-std=c++14")
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp17 "-std=c++17")
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp17 "-std=c++17" "-Wno-register")
 
 # no support of C++2a, C++20, C++2b, C++23
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a "")

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -350,6 +350,16 @@ SECTIONS
 	__kernel_ram_end = .;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
+#ifdef CONFIG_ARCMWDT_LIBC
+	/*
+	 * MWDT picolibc sbrk requires _fheap/_eheap symbols.
+	 * Set both equal for zero heap size so sbrk returns ENOMEM.
+	 * Zephyr's COMMON_LIBC_MALLOC provides malloc via sys_heap, not sbrk.
+	 */
+	_fheap = __kernel_ram_end;
+	_eheap = __kernel_ram_end;
+#endif /* CONFIG_ARCMWDT_LIBC */
+
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_itcm), okay)
 GROUP_START(ITCM)
 

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -137,6 +137,7 @@ config ARCMWDT_LIBC
 	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "arcmwdt"
 	select STATIC_INIT_GNU
 	select LIBC_ALLOW_LESS_THAN_64BIT_TIME
+	imply COMMON_LIBC_MALLOC
 	help
 	  C library provided by ARC MWDT toolchain.
 

--- a/lib/libc/arcmwdt/include/sys/cdefs.h
+++ b/lib/libc/arcmwdt/include/sys/cdefs.h
@@ -4,4 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* MWDT has no it's own cdefs. Add this one for satisfy dependencies */
+/*
+ * MWDT picolibc provides sys/cdefs.h; mwlibc does not.
+ * Forward to it when available, otherwise no-op.
+ */
+
+#ifndef LIB_LIBC_ARCMWDT_INCLUDE_SYS_CDEFS_H_
+#define LIB_LIBC_ARCMWDT_INCLUDE_SYS_CDEFS_H_
+
+#if __has_include_next(<sys/cdefs.h>)
+#include_next <sys/cdefs.h>
+#endif /* __has_include_next */
+
+#endif /* LIB_LIBC_ARCMWDT_INCLUDE_SYS_CDEFS_H_ */

--- a/lib/libc/arcmwdt/include/sys/types.h
+++ b/lib/libc/arcmwdt/include/sys/types.h
@@ -27,4 +27,10 @@ typedef int ssize_t;
 #endif /* CONFIG_64BIT */
 #endif /* _SSIZE_T_DEFINED */
 
+#ifdef __PICOLIBC__
+#define _ITIMERSPEC_DECLARED
+#define _TIMESPEC_DECLARED
+#define _LOCALE_T_DECLARED
+#endif /* __PICOLIBC__ */
+
 #endif /* LIB_LIBC_ARCMWDT_INCLUDE_SYS_TYPES_H_ */

--- a/lib/libc/arcmwdt/libc-hooks.c
+++ b/lib/libc/arcmwdt/libc-hooks.c
@@ -91,10 +91,13 @@ int _isatty(int file)
 	return 0;
 }
 
+/* MWDT picolibc provides ___errno(); mwlibc does not. */
+#ifndef __PICOLIBC__
 int *___errno(void)
 {
 	return z_errno();
 }
+#endif
 
 __weak void _exit(int status)
 {

--- a/lib/libc/arcmwdt/libc-hooks.c
+++ b/lib/libc/arcmwdt/libc-hooks.c
@@ -69,9 +69,25 @@ int _write(int fd, const char *buf, unsigned int nbytes)
 
 	return zephyr_write_stdout(buf, nbytes);
 }
-#endif
 
+#ifdef __PICOLIBC__
 #ifndef CONFIG_POSIX_DEVICE_IO
+/*
+ * MWDT picolibc runtime calls write() (POSIX convention), not _write()
+ * (mwlibc convention). Override the MWDT host library write(),
+ * so output is routed through Zephyr's console instead.
+ * Not needed when CONFIG_POSIX_DEVICE_IO is enabled, as device_io.c
+ * already provides write() via the VFS layer.
+ */
+ssize_t write(int fd, const void *buf, size_t nbytes)
+{
+	return _write(fd, (const char *)buf, (unsigned int)nbytes);
+}
+#endif /* !CONFIG_POSIX_DEVICE_IO */
+#endif /* __PICOLIBC__ */
+#endif /* !CONFIG_POSIX_DEVICE_IO_ALIAS_WRITE */
+
+#if !defined(CONFIG_POSIX_DEVICE_IO) && !defined(__PICOLIBC__)
 __weak int fileno(FILE *file)
 {
 	return _fileno(file);


### PR DESCRIPTION
MWDT introduces picolibc as another C runtime library. The existing `ARCMWDT_LIBC` middleware was written for classic mwlibc and is not compatible with picolibc out of the box, causing numerous build and runtime failures.

**Changes:**

- `sys/cdefs.h`, `sys/types.h`, `time.h`: guard redefinitions that conflict with picolibc's own headers
- libc-hooks.c: guard `___errno()` and `fileno()` stubs that picolibc already provides; add a strong `write()` override to route picolibc stdio/C++ iostream output through Zephyr's console driver instead of MWDT's host library
- Kconfig: add `imply COMMON_LIBC_MALLOC` so Zephyr's sys_heap allocator is used instead of picolibc's sbrk-based malloc
- `linker.ld`: define `_fheap`/`_eheap` symbols required by picolibc's sbrk, set equal to disable sbrk heap in favour of `COMMON_LIBC_MALLOC`
- `compiler_flags.cmake`: add `-Wno-register` to C++17 dialect flags to suppress picolibc header warnings