### PR TITLE
dts: bindings: stm32: Replace enum with min/max for st,csbound property

### DIFF
--- a/dts/bindings/memory-controllers/st,stm32-ospi-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-ospi-psram.yaml
@@ -158,8 +158,8 @@ properties:
       The default is the minimum recommended value in the Reference Manual. It
       is recommended to set this value according to the length of the burst wrap
       of the PSRAM device for the linear burst command.
-    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-           21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+    min: 0
+    max: 31
 
   st,refresh:
     type: int

--- a/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
@@ -157,8 +157,8 @@ properties:
       The default is the minimum recommended value in the Reference Manual. It
       is recommended to set this value according to the length of the burst wrap
       of the PSRAM device for the linear burst command.
-    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-           21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+    min: 0
+    max: 31
 
   st,refresh:
     type: int

--- a/dts/bindings/mspi/st,stm32-ospi-controller.yaml
+++ b/dts/bindings/mspi/st,stm32-ospi-controller.yaml
@@ -114,8 +114,8 @@ properties:
       Feature is disabled by default. It is recommended to set this value
       according to the length of the burst wrap of the PSRAM device for the
       linear burst command.
-    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-           21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+    min: 0
+    max: 31
 
   st,dqs-port:
     type: int

--- a/dts/bindings/mspi/st,stm32-xspi-controller.yaml
+++ b/dts/bindings/mspi/st,stm32-xspi-controller.yaml
@@ -53,5 +53,5 @@ properties:
       The default is the minimum recommended value in the Reference Manual. It
       is recommended to set this value according to the length of the burst wrap
       of the PSRAM device for the linear burst command.
-    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-           21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+    min: 0
+    max: 31


### PR DESCRIPTION
Use the `min`/`max` properties instead of an `enum` for the `st,csbound` property in multiple bindings files.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/107190