### PR TITLE
drivers/eeprom_shell: warn more on invalid arguments

### DIFF
--- a/drivers/eeprom/eeprom_shell.c
+++ b/drivers/eeprom/eeprom_shell.c
@@ -39,8 +39,18 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	size_t upto;
 	int err;
 
-	addr = strtoul(argv[args_indx.offset], NULL, 0);
-	len = strtoul(argv[args_indx.length], NULL, 0);
+	err = 0;
+	addr = shell_strtoul(argv[args_indx.offset], 0, &err);
+	if (err) {
+		shell_error(sh, "Error parsing offset");
+		return -EINVAL;
+	}
+	err = 0;
+	len = shell_strtoul(argv[args_indx.length], 0, &err);
+	if (err) {
+		shell_error(sh, "Error parsing length");
+		return -EINVAL;
+	}
 
 	eeprom = shell_device_get_binding(argv[args_indx.device]);
 	if (!eeprom) {
@@ -80,7 +90,12 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	int err;
 	int i;
 
-	offset = strtoul(argv[args_indx.offset], NULL, 0);
+	err = 0;
+	offset = shell_strtoul(argv[args_indx.offset], 0, &err);
+	if (err) {
+		shell_error(sh, "Error parsing offset");
+		return -EINVAL;
+	}
 	len = argc - args_indx.data;
 
 	if (len > sizeof(wr_buf)) {
@@ -90,9 +105,10 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	for (i = 0; i < len; i++) {
-		byte = strtoul(argv[args_indx.data + i], NULL, 0);
-		if (byte > UINT8_MAX) {
-			shell_error(sh, "Error parsing data byte %d", i);
+		err = 0;
+		byte = shell_strtoul(argv[args_indx.data + i], 0, &err);
+		if ((byte > UINT8_MAX) || err) {
+			shell_error(sh, "Error parsing b%d: <%s>", i, argv[args_indx.data + i]);
 			return -EINVAL;
 		}
 		wr_buf[i] = byte;
@@ -157,11 +173,22 @@ static int cmd_fill(const struct shell *sh, size_t argc, char **argv)
 	size_t upto;
 	int err;
 
-	initial_offset = strtoul(argv[args_indx.offset], NULL, 0);
-	len = strtoul(argv[args_indx.length], NULL, 0);
+	err = 0;
+	initial_offset = shell_strtoul(argv[args_indx.offset], 0, &err);
+	if (err) {
+		shell_error(sh, "Error parsing offset");
+		return -EINVAL;
+	}
+	err = 0;
+	len = shell_strtoul(argv[args_indx.length], 0, &err);
+	if (err) {
+		shell_error(sh, "Error parsing length");
+		return -EINVAL;
+	}
 
-	pattern = strtoul(argv[args_indx.pattern], NULL, 0);
-	if (pattern > UINT8_MAX) {
+	err = 0;
+	pattern = shell_strtoul(argv[args_indx.pattern], 0, &err);
+	if (err || pattern > UINT8_MAX) {
 		shell_error(sh, "Error parsing pattern byte");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Previously, we warned for arguments that parsed as integers, but were out of range.  Parse failures, such as below, would simply write 0 for the failing bytes.

eeprom write <dev> <offset> 05 06 07 08
or
eeprom write <dev> <offset> fa ce be ef

While this change doesn't make the read format viable to feed back to what write expects, it will at least warn now that it has failed to parse, instead of silently proceeding with 0 bytes substituted.