### PR TITLE
Add clock source, pinctrl and capture api to counter_mcux_gpt

### DIFF
--- a/drivers/counter/Kconfig.mcux_gpt
+++ b/drivers/counter/Kconfig.mcux_gpt
@@ -8,5 +8,7 @@ config COUNTER_MCUX_GPT
 	default y
 	depends on DT_HAS_NXP_IMX_GPT_ENABLED
 	select KERNEL_DIRECT_MAP if MMU
+	select COUNTER_SUPPORTS_CAPTURE
+	select PINCTRL if COUNTER_CAPTURE
 	help
 	  Enable support for mcux General Purpose Timer (GPT) driver.

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -15,6 +15,10 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/barrier.h>
 
+#ifdef CONFIG_PINCTRL
+#include <zephyr/drivers/pinctrl.h>
+#endif
+
 LOG_MODULE_REGISTER(mcux_gpt, CONFIG_COUNTER_LOG_LEVEL);
 
 #define DEV_CFG(_dev) ((const struct mcux_gpt_config *)(_dev)->config)
@@ -40,7 +44,9 @@ struct mcux_gpt_config {
 	uint32_t low_freq;
 	uint32_t osc_freq;
 #endif
-
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pincfg;
+#endif
 	void (*irq_config_func)(void);
 };
 
@@ -244,6 +250,16 @@ static int mcux_gpt_init(const struct device *dev)
 	GPT_Type *base;
 
 	DEVICE_MMIO_NAMED_MAP(dev, gpt_mmio, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
+
+#ifdef CONFIG_PINCTRL
+	{
+		int ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+
+		if (ret < 0 && ret != -ENOENT) {
+			return ret;
+		}
+	}
+#endif
 
 	GPT_GetDefaultConfig(&gptConfig);
 	gptConfig.enableFreeRun = config->enable_free_run;

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019, Linaro Limited.
  * Copyright 2024-2025 NXP
+ * Copyright 2026 Basalte bv
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -28,6 +29,18 @@ struct mcux_gpt_config {
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	bool enable_free_run;
+	gpt_clock_source_t clock_source;
+	uint8_t osc_divider;
+#ifdef CONFIG_COUNTER_64BITS_FREQ
+	uint64_t high_freq;
+	uint64_t low_freq;
+	uint64_t osc_freq;
+#else
+	uint32_t high_freq;
+	uint32_t low_freq;
+	uint32_t osc_freq;
+#endif
+
 	void (*irq_config_func)(void);
 };
 
@@ -232,29 +245,75 @@ static int mcux_gpt_init(const struct device *dev)
 
 	DEVICE_MMIO_NAMED_MAP(dev, gpt_mmio, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
 
-	if (!device_is_ready(config->clock_dev)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
-	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
-				   &clock_freq)) {
-		return -EINVAL;
-	}
-
-	/* Adjust divider to match expected freq */
-	if (clock_freq % config->info.freq) {
-		LOG_ERR("Cannot Adjust GPT freq to %u\n", config->info.freq);
-		LOG_ERR("clock src is %u\n", clock_freq);
-		return -EINVAL;
-	}
-
 	GPT_GetDefaultConfig(&gptConfig);
 	gptConfig.enableFreeRun = config->enable_free_run;
-	gptConfig.clockSource = kGPT_ClockSource_Periph;
-	gptConfig.divider = clock_freq / config->info.freq;
+	gptConfig.clockSource = config->clock_source;
+
+	switch (config->clock_source) {
+	case kGPT_ClockSource_Off:
+		gptConfig.divider = 1U;
+		break;
+	case kGPT_ClockSource_Ext:
+		/* External clock: frequency unknown to CCM; prescaler fixed at 1 */
+		gptConfig.divider = 1U;
+		break;
+	case kGPT_ClockSource_HighFreq:
+	case kGPT_ClockSource_LowFreq: {
+		uint32_t ref_freq = (config->clock_source == kGPT_ClockSource_HighFreq)
+					    ? config->high_freq
+					    : config->low_freq;
+
+		if (ref_freq == 0 || config->info.freq == 0 ||
+		    (ref_freq % config->info.freq != 0)) {
+			LOG_ERR("Cannot adjust GPT freq to %u", config->info.freq);
+			return -EINVAL;
+		}
+
+		gptConfig.divider = ref_freq / config->info.freq;
+		break;
+	}
+	case kGPT_ClockSource_Osc:
+		uint32_t osc_in;
+
+		if (config->osc_freq == 0) {
+			LOG_ERR("kGPT_ClockSource_Osc is selected but osc_freq is 0");
+			return -EINVAL;
+		}
+		osc_in = config->osc_freq / config->osc_divider;
+
+		if (config->info.freq == 0 || (osc_in % config->info.freq != 0)) {
+			LOG_ERR("Cannot adjust GPT freq to %u with OSC clock",
+				config->info.freq);
+			return -EINVAL;
+		}
+		gptConfig.divider = osc_in / config->info.freq;
+
+		break;
+	default:
+		/* Internal clock sources (periph): query CCM */
+		if (!device_is_ready(config->clock_dev)) {
+			LOG_ERR("clock control device not ready");
+			return -ENODEV;
+		}
+		if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
+					   &clock_freq)) {
+			return -EINVAL;
+		}
+		if (config->info.freq == 0 || (clock_freq % config->info.freq != 0)) {
+			LOG_ERR("Cannot adjust GPT freq to %u", config->info.freq);
+			return -EINVAL;
+		}
+		gptConfig.divider = clock_freq / config->info.freq;
+		break;
+	}
+
 	base = get_base(dev);
 	GPT_Init(base, &gptConfig);
+
+	/* Set oscillator prescaler AFTER GPT_Init (SWR resets PRESCALER24M) */
+	if (config->clock_source == kGPT_ClockSource_Osc) {
+		GPT_SetOscClockDivider(base, config->osc_divider);
+	}
 
 	config->irq_config_func();
 
@@ -273,40 +332,47 @@ static DEVICE_API(counter, mcux_gpt_driver_api) = {
 	.reset = mcux_gpt_reset,
 };
 
-#define GPT_DEVICE_INIT_MCUX(n)						\
-	static struct mcux_gpt_data mcux_gpt_data_ ## n;		\
-	static void mcux_gpt_irq_config_ ## n(void);			\
-									\
-	static const struct mcux_gpt_config mcux_gpt_config_ ## n = {	\
-		DEVICE_MMIO_NAMED_ROM_INIT(gpt_mmio, DT_DRV_INST(n)),	\
-		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
-		.clock_subsys =						\
-			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
-		.enable_free_run = (DT_INST_ENUM_IDX_OR(n, run_mode, 0) == 1),\
-		.info = {						\
-			.max_top_value = UINT32_MAX,			\
-			.freq = DT_INST_PROP(n, gptfreq),           \
-			.channels = 1,					\
-			.flags = COUNTER_CONFIG_INFO_COUNT_UP,		\
-		},							\
-		.irq_config_func = mcux_gpt_irq_config_ ## n,		\
-	};								\
-									\
-	DEVICE_DT_INST_DEFINE(n,					\
-			    mcux_gpt_init,				\
-			    NULL,					\
-			    &mcux_gpt_data_ ## n,			\
-			    &mcux_gpt_config_ ## n,			\
-			    POST_KERNEL,				\
-			    CONFIG_COUNTER_INIT_PRIORITY,		\
-			    &mcux_gpt_driver_api);			\
-									\
-	static void mcux_gpt_irq_config_ ## n(void)			\
-	{								\
-		IRQ_CONNECT(DT_INST_IRQN(n),				\
-			    DT_INST_IRQ(n, priority),			\
-			    mcux_gpt_isr, DEVICE_DT_INST_GET(n), 0);	\
-		irq_enable(DT_INST_IRQN(n));				\
-	}								\
+#ifdef CONFIG_PINCTRL
+#define MCUX_GPT_PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n)
+#define MCUX_GPT_PINCTRL_INIT(n)   .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
+#else
+#define MCUX_GPT_PINCTRL_DEFINE(n)
+#define MCUX_GPT_PINCTRL_INIT(n)
+#endif
+
+#define GPT_DEVICE_INIT_MCUX(n)                                                                    \
+	MCUX_GPT_PINCTRL_DEFINE(n);                                                                \
+	static struct mcux_gpt_data mcux_gpt_data_##n;                                             \
+	static void mcux_gpt_irq_config_##n(void);                                                 \
+                                                                                                   \
+	static const struct mcux_gpt_config mcux_gpt_config_##n = {                                \
+		DEVICE_MMIO_NAMED_ROM_INIT(gpt_mmio, DT_DRV_INST(n)),                              \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                \
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),              \
+		.enable_free_run = (DT_INST_ENUM_IDX_OR(n, run_mode, 0) == 1),                     \
+		.clock_source = (gpt_clock_source_t)DT_INST_ENUM_IDX_OR(n, clock_source, 1),       \
+		.high_freq = DT_INST_PROP_OR(n, high_freq, 0),                                     \
+		.low_freq = DT_INST_PROP_OR(n, low_freq, 0),                                       \
+		.osc_freq = DT_INST_PROP_OR(n, osc_freq, 0),                                       \
+		.osc_divider = DT_INST_PROP_OR(n, osc_divider, 1),                                 \
+		.info =                                                                            \
+			{                                                                          \
+				.max_top_value = UINT32_MAX,                                       \
+				.freq = DT_INST_PROP_OR(n, gptfreq, 0),                            \
+				.channels = IMX_GPT_N_CHANNELS,                                    \
+				.flags = COUNTER_CONFIG_INFO_COUNT_UP,                             \
+			},                                                                         \
+		.irq_config_func = mcux_gpt_irq_config_##n,                                        \
+		MCUX_GPT_PINCTRL_INIT(n)};                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, mcux_gpt_init, NULL, &mcux_gpt_data_##n, &mcux_gpt_config_##n,    \
+			      POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY, &mcux_gpt_driver_api);    \
+                                                                                                   \
+	static void mcux_gpt_irq_config_##n(void)                                                  \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), mcux_gpt_isr,               \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQN(n));                                                       \
+	}
 
 DT_INST_FOREACH_STATUS_OKAY(GPT_DEVICE_INIT_MCUX)

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -21,6 +21,14 @@
 
 LOG_MODULE_REGISTER(mcux_gpt, CONFIG_COUNTER_LOG_LEVEL);
 
+#ifdef CONFIG_COUNTER_CAPTURE
+#define IMX_GPT_N_CAPTURE_CHANNELS 2
+#else
+#define IMX_GPT_N_CAPTURE_CHANNELS 1
+#endif
+
+#define IMX_GPT_N_CHANNELS IMX_GPT_N_CAPTURE_CHANNELS
+
 #define DEV_CFG(_dev) ((const struct mcux_gpt_config *)(_dev)->config)
 #define DEV_DATA(_dev) ((struct mcux_gpt_data *)(_dev)->data)
 
@@ -56,7 +64,28 @@ struct mcux_gpt_data {
 	counter_top_callback_t top_callback;
 	void *alarm_user_data;
 	void *top_user_data;
+#ifdef CONFIG_COUNTER_CAPTURE
+	counter_capture_cb_t capture_callback[IMX_GPT_N_CAPTURE_CHANNELS];
+	void *capture_user_data[IMX_GPT_N_CAPTURE_CHANNELS];
+	gpt_input_operation_mode_t capture_mode[IMX_GPT_N_CAPTURE_CHANNELS];
+	bool capture_single_shot[IMX_GPT_N_CAPTURE_CHANNELS];
+#endif
 };
+
+#ifdef CONFIG_COUNTER_CAPTURE
+static const gpt_input_capture_channel_t capture_ch[IMX_GPT_N_CAPTURE_CHANNELS] = {
+	kGPT_InputCapture_Channel1, /* chan_id=0 → CAPTURE1 */
+	kGPT_InputCapture_Channel2, /* chan_id=1 → CAPTURE2 */
+};
+static const uint32_t capture_irq[IMX_GPT_N_CAPTURE_CHANNELS] = {
+	kGPT_InputCapture1InterruptEnable,
+	kGPT_InputCapture2InterruptEnable,
+};
+static const uint32_t capture_flag[IMX_GPT_N_CAPTURE_CHANNELS] = {
+	kGPT_InputCapture1Flag,
+	kGPT_InputCapture2Flag,
+};
+#endif /* CONFIG_COUNTER_CAPTURE */
 
 static GPT_Type *get_base(const struct device *dev)
 {
@@ -145,6 +174,9 @@ void mcux_gpt_isr(const struct device *dev)
 	uint32_t status;
 
 	status =  GPT_GetStatusFlags(base, kGPT_OutputCompare1Flag |
+#ifdef CONFIG_COUNTER_CAPTURE
+				     kGPT_InputCapture1Flag | kGPT_InputCapture2Flag |
+#endif
 				     kGPT_RollOverFlag);
 	GPT_ClearStatusFlags(base, status);
 	barrier_dsync_fence_full();
@@ -160,13 +192,48 @@ void mcux_gpt_isr(const struct device *dev)
 	if ((status & kGPT_RollOverFlag) && data->top_callback) {
 		data->top_callback(dev, data->top_user_data);
 	}
+
+#ifdef CONFIG_COUNTER_CAPTURE
+	for (uint8_t i = 0; i < ARRAY_SIZE(capture_ch); i++) {
+		counter_capture_flags_t cflags;
+		counter_capture_cb_t cb;
+		bool single_shot;
+		uint32_t ticks;
+
+		if ((status & capture_flag[i]) != capture_flag[i]) {
+			continue;
+		}
+
+		/* Read ICR before potentially disabling (ICR holds until next capture) */
+		ticks = GPT_GetInputCaptureValue(base, capture_ch[i]);
+		cb = data->capture_callback[i];
+		single_shot = data->capture_single_shot[i];
+		cflags = single_shot ? COUNTER_CAPTURE_SINGLE_SHOT : COUNTER_CAPTURE_CONTINUOUS;
+
+		if (single_shot) {
+			GPT_DisableInterrupts(base, capture_irq[i]);
+			GPT_SetInputOperationMode(base, capture_ch[i],
+						  kGPT_InputOperation_Disabled);
+			data->capture_callback[i] = NULL;
+		}
+
+		if (cb != NULL) {
+			cb(dev, i, cflags, ticks, data->capture_user_data[i]);
+		}
+	}
+#endif /* CONFIG_COUNTER_CAPTURE */
 }
 
 static uint32_t mcux_gpt_get_pending_int(const struct device *dev)
 {
 	GPT_Type *base = get_base(dev);
+	uint32_t flags = kGPT_OutputCompare1Flag;
 
-	return GPT_GetStatusFlags(base, kGPT_OutputCompare1Flag);
+#ifdef CONFIG_COUNTER_CAPTURE
+	flags |= kGPT_InputCapture1Flag | kGPT_InputCapture2Flag;
+#endif
+
+	return GPT_GetStatusFlags(base, flags);
 }
 
 static int mcux_gpt_set_top_value(const struct device *dev,
@@ -196,6 +263,79 @@ static uint32_t mcux_gpt_get_top_value(const struct device *dev)
 
 	return config->info.max_top_value;
 }
+
+#ifdef CONFIG_COUNTER_CAPTURE
+static int mcux_gpt_capture_configure(const struct device *dev, uint8_t chan_id,
+				      counter_capture_flags_t flags, counter_capture_cb_t cb,
+				      void *user_data)
+{
+	GPT_Type *base = get_base(dev);
+	struct mcux_gpt_data *data = dev->data;
+	gpt_input_operation_mode_t mode;
+
+	if (chan_id >= ARRAY_SIZE(capture_ch)) {
+		return -EINVAL;
+	}
+	if (cb == NULL) {
+		return -EINVAL;
+	}
+	if (GPT_GetInputOperationMode(base, capture_ch[chan_id]) != kGPT_InputOperation_Disabled) {
+		LOG_ERR("Invalid operation mode");
+		return -EBUSY;
+	}
+
+	if ((flags & COUNTER_CAPTURE_BOTH_EDGES) == COUNTER_CAPTURE_BOTH_EDGES) {
+		mode = kGPT_InputOperation_BothEdge;
+	} else if ((flags & COUNTER_CAPTURE_FALLING_EDGE) == COUNTER_CAPTURE_FALLING_EDGE) {
+		mode = kGPT_InputOperation_FallEdge;
+	} else if ((flags & COUNTER_CAPTURE_RISING_EDGE) == COUNTER_CAPTURE_RISING_EDGE) {
+		mode = kGPT_InputOperation_RiseEdge;
+	} else {
+		return -EINVAL;
+	}
+
+	data->capture_callback[chan_id] = cb;
+	data->capture_user_data[chan_id] = user_data;
+	data->capture_mode[chan_id] = mode;
+	data->capture_single_shot[chan_id] = (flags & COUNTER_CAPTURE_SINGLE_SHOT) != 0;
+
+	return 0;
+}
+
+static int mcux_gpt_enable_capture(const struct device *dev, uint8_t chan_id)
+{
+	GPT_Type *base = get_base(dev);
+	struct mcux_gpt_data *data = dev->data;
+
+	if (chan_id >= ARRAY_SIZE(capture_ch)) {
+		return -EINVAL;
+	}
+	if (data->capture_callback[chan_id] == NULL) {
+		return -EINVAL;
+	}
+
+	GPT_SetInputOperationMode(base, capture_ch[chan_id], data->capture_mode[chan_id]);
+	GPT_EnableInterrupts(base, capture_irq[chan_id]);
+
+	return 0;
+}
+
+static int mcux_gpt_disable_capture(const struct device *dev, uint8_t chan_id)
+{
+	GPT_Type *base = get_base(dev);
+	struct mcux_gpt_data *data = dev->data;
+
+	if (chan_id >= ARRAY_SIZE(capture_ch)) {
+		return -EINVAL;
+	}
+
+	GPT_DisableInterrupts(base, capture_irq[chan_id]);
+	GPT_SetInputOperationMode(base, capture_ch[chan_id], kGPT_InputOperation_Disabled);
+	data->capture_callback[chan_id] = NULL;
+
+	return 0;
+}
+#endif /* CONFIG_COUNTER_CAPTURE */
 
 static int mcux_gpt_reset(const struct device *dev)
 {
@@ -346,6 +486,11 @@ static DEVICE_API(counter, mcux_gpt_driver_api) = {
 	.get_pending_int = mcux_gpt_get_pending_int,
 	.get_top_value = mcux_gpt_get_top_value,
 	.reset = mcux_gpt_reset,
+#ifdef CONFIG_COUNTER_CAPTURE
+	.capture_configure = mcux_gpt_capture_configure,
+	.enable_capture = mcux_gpt_enable_capture,
+	.disable_capture = mcux_gpt_disable_capture,
+#endif
 };
 
 #ifdef CONFIG_PINCTRL

--- a/dts/arm/nxp/imx/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx94x.dtsi
@@ -659,6 +659,8 @@
 			reg = <0x428c0000 0x4000>;
 			interrupts = <146 0>;
 			gptfreq = <DT_FREQ_M(24)>;
+			low-freq = <DT_FREQ_K(32)>;
+			osc-freq = <DT_FREQ_M(24)>;
 			clocks = <&scmi_clk IMX943_CLK_GPT4>;
 		};
 

--- a/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
@@ -178,6 +178,8 @@
 			reg = <0x401f0000 0x4000>;
 			interrupts = <101 0>;
 			gptfreq = <DT_FREQ_M(25)>;
+			low-freq = <DT_FREQ_K(32)>;
+			osc-freq = <DT_FREQ_M(24)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x68 24>;
 		};
 

--- a/dts/arm/nxp/imxrt/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt118x.dtsi
@@ -393,6 +393,8 @@
 		reg = <0x46c0000 0x4000>;
 		interrupts = <209 0>;
 		gptfreq = <DT_FREQ_M(240)>;
+		low-freq = <DT_FREQ_K(32)>;
+		osc-freq = <DT_FREQ_M(24)>;
 		clocks = <&ccm IMX_CCM_GPT1_CLK 0x41 0>;
 		status = "disabled";
 	};
@@ -402,6 +404,8 @@
 		reg = <0x2ec0000 0x4000>;
 		interrupts = <210 0>;
 		gptfreq = <DT_FREQ_M(240)>;
+		low-freq = <DT_FREQ_K(32)>;
+		osc-freq = <DT_FREQ_M(24)>;
 		clocks = <&ccm IMX_CCM_GPT2_CLK 0x41 0>;
 	};
 

--- a/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
@@ -120,6 +120,8 @@
 			reg = <0x400f0000 0x4000>;
 			interrupts = <120 0>;
 			gptfreq = <DT_FREQ_M(24)>;
+			low-freq = <DT_FREQ_K(32)>;
+			osc-freq = <DT_FREQ_M(16)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x41 0>;
 		};
 
@@ -128,6 +130,8 @@
 			reg = <0x400f4000 0x4000>;
 			interrupts = <121 0>;
 			gptfreq = <DT_FREQ_M(24)>;
+			low-freq = <DT_FREQ_K(32)>;
+			osc-freq = <DT_FREQ_M(16)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x42 0>;
 		};
 
@@ -136,6 +140,8 @@
 			reg = <0x400f8000 0x4000>;
 			interrupts = <122 0>;
 			gptfreq = <DT_FREQ_M(24)>;
+			low-freq = <DT_FREQ_K(32)>;
+			osc-freq = <DT_FREQ_M(16)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x43 0>;
 		};
 
@@ -144,6 +150,8 @@
 			reg = <0x400fc000 0x4000>;
 			interrupts = <123 0>;
 			gptfreq = <DT_FREQ_M(24)>;
+			low-freq = <DT_FREQ_K(32)>;
+			osc-freq = <DT_FREQ_M(16)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x44 0>;
 		};
 
@@ -152,6 +160,8 @@
 			reg = <0x40100000 0x4000>;
 			interrupts = <124 0>;
 			gptfreq = <DT_FREQ_M(24)>;
+			low-freq = <DT_FREQ_K(32)>;
+			osc-freq = <DT_FREQ_M(16)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x45 0>;
 		};
 

--- a/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
@@ -156,6 +156,8 @@
 		interrupts = <GIC_SPI 55 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
 		gptfreq = <24000000>;
+		low-freq = <DT_FREQ_K(32)>;
+		osc-freq = <DT_FREQ_M(24)>;
 		clocks = <&ccm IMX_CCM_GPT_IPG_CLK 0x6c 20>;
 		status = "disabled";
 	};
@@ -168,6 +170,8 @@
 			      IRQ_DEFAULT_PRIORITY>;
 		gptfreq = <24000000>;
 		clocks = <&ccm IMX_CCM_GPT_IPG_CLK 0x68 24>;
+		low-freq = <DT_FREQ_K(32)>;
+		osc-freq = <DT_FREQ_M(24)>;
 		status = "disabled";
 	};
 

--- a/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
@@ -157,6 +157,8 @@
 		interrupts = <GIC_SPI 55 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
 		gptfreq = <24000000>;
+		low-freq = <DT_FREQ_K(32)>;
+		osc-freq = <DT_FREQ_M(24)>;
 		clocks = <&ccm IMX_CCM_GPT_IPG_CLK 0x6c 20>;
 		status = "disabled";
 	};
@@ -168,6 +170,8 @@
 		interrupts = <GIC_SPI 54 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
 		gptfreq = <24000000>;
+		low-freq = <DT_FREQ_K(32)>;
+		osc-freq = <DT_FREQ_M(24)>;
 		clocks = <&ccm IMX_CCM_GPT_IPG_CLK 0x68 24>;
 		status = "disabled";
 	};

--- a/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
@@ -158,6 +158,8 @@
 			interrupts = <GIC_SPI 55 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>;
 			gptfreq = <24000000>;
+			low-freq = <DT_FREQ_K(32)>;
+			osc-freq = <DT_FREQ_M(24)>;
 			clocks = <&ccm IMX_CCM_GPT_IPG_CLK 0x6c 20>;
 			status = "disabled";
 		};
@@ -169,6 +171,8 @@
 			interrupts = <GIC_SPI 54 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>;
 			gptfreq = <24000000>;
+			low-freq = <DT_FREQ_K(32)>;
+			osc-freq = <DT_FREQ_M(24)>;
 			clocks = <&ccm IMX_CCM_GPT_IPG_CLK 0x68 24>;
 			status = "disabled";
 		};

--- a/dts/arm64/nxp/nxp_mimx943_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx943_a55.dtsi
@@ -382,6 +382,8 @@
 		reg = <0x428c0000 DT_SIZE_K(16)>;
 		interrupts = <GIC_SPI 146 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		gptfreq = <DT_FREQ_M(24)>;
+		low-freq = <DT_FREQ_K(32)>;
+		osc-freq = <DT_FREQ_M(24)>;
 		clocks = <&scmi_clk IMX943_CLK_GPT4>;
 		status = "disabled";
 	};

--- a/dts/bindings/counter/nxp,imx-gpt.yaml
+++ b/dts/bindings/counter/nxp,imx-gpt.yaml
@@ -17,8 +17,12 @@ properties:
 
   gptfreq:
     type: int
-    required: true
-    description: gpt frequencies
+    description: |
+      Desired counter tick frequency in Hz. Required for all internal clock
+      sources (periph, high-freq, low-freq, osc).
+      Can be left out when clock-source = "ext" — the external clock
+      frequency is unknown; counter_get_freq() returns 0 and the prescaler
+      is fixed at 1.
 
   run-mode:
     type: string
@@ -35,3 +39,40 @@ properties:
       - restart
       - free-run
     default: restart
+
+  clock-source:
+    type: string
+    description: |
+      GPT clock source. The enum order matches gpt_clock_source_t in fsl_gpt.h
+      exactly so DT_INST_ENUM_IDX can be cast directly to gpt_clock_source_t.
+    enum:
+      - "off"
+      - "periph"
+      - "high-freq"
+      - "ext"
+      - "low-freq"
+      - "osc"
+    default: "periph"
+
+  high-freq:
+    type: int
+    description:
+      High-frequency reference clock in Hz. Only applies when clock-source = "high-freq".
+
+  low-freq:
+    type: int
+    description:
+      Low-frequency reference clock in Hz. Only applies when clock-source = "low-freq".
+
+  osc-freq:
+    type: int
+    description:
+      Oscillator frequency expressed in Hz. Only applies when clock-source = "osc".
+
+  osc-divider:
+    type: int
+    default: 1
+    min: 1
+    max: 16
+    description: |
+      Prescaler for the oscillator clock. Only applies when clock-source = "osc".

--- a/dts/bindings/counter/nxp,imx-gpt.yaml
+++ b/dts/bindings/counter/nxp,imx-gpt.yaml
@@ -6,7 +6,7 @@ description: NXP MCUX General-Purpose Timer (GPT)
 
 compatible: "nxp,imx-gpt"
 
-include: base.yaml
+include: [base.yaml, pinctrl-device.yaml]
 
 properties:
   reg:

--- a/tests/drivers/build_all/counter/tests.yaml
+++ b/tests/drivers/build_all/counter/tests.yaml
@@ -38,3 +38,12 @@ tests:
       - mimxrt1064_evk
       - mimxrt1180_evk/mimxrt1189/cm33
       - mimxrt1180_evk/mimxrt1189/cm7
+  drivers.counter.build.imx_gpt.capture:
+    extra_configs:
+      - CONFIG_COUNTER_CAPTURE=y
+    platform_allow:
+      - mimxrt1064_evk
+      - mimxrt1170_evk/mimxrt1176/cm7
+      - mimxrt1180_evk/mimxrt1189/cm33
+      - imx943_evk/mimx94398/m33
+      - imx8mp_evk/mimx8ml8/m7


### PR DESCRIPTION
Add the following to the existing counter_mcux_gpt driver:
- Allow users to select the clock source via the device tree (e.g., external clock source)
- Allow users to define a pinctrl in the device tree, to mux the correct gpio (e.g., iomuxc_gpio_ad_b0_09_gpt2_clk)
- Extend the driver to support the counter capture API (CONFIG_COUNTER_CAPTURE)
- Add a build_all test for all boards using the above driver, with CONFIG_COUNTER_CAPTURE enabled

Assisted-by: Claude:claude-sonnet-4.6

