### PR TITLE
MAINTAINERS: Add OpenThread collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4403,6 +4403,7 @@ Networking:
     - pdgendt
     - kkasperczyk-no
     - edmont
+    - Cristib05
   files:
     - subsys/net/l2/openthread/
     - samples/net/openthread/
@@ -6721,6 +6722,7 @@ West:
     - pdgendt
     - kkasperczyk-no
     - edmont
+    - Cristib05
   files:
     - modules/openthread/
   labels:


### PR DESCRIPTION
Adding Cristib05 as OpenThread collaborator for OpenThread related repos, especially for Border Router project.