### PR TITLE
bluetooth: mesh: fix connectable adv restart after disconnect

### DIFF
--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -49,6 +49,8 @@ static struct bt_mesh_proxy_role *cli;
 static bool service_registered;
 static bool adv_restart_pending;
 
+static int prov_gatt_service_unregister(void);
+
 static void proxy_msg_recv(struct bt_mesh_proxy_role *role)
 {
 	switch (role->msg_type) {
@@ -120,10 +122,10 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 	bt_mesh_pb_gatt_close(conn);
 
 	if (bt_mesh_is_provisioned()) {
-		(void)bt_mesh_pb_gatt_srv_disable();
-	} else {
-		adv_restart_pending = true;
+		(void)prov_gatt_service_unregister();
 	}
+
+	adv_restart_pending = true;
 }
 
 static void prov_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
@@ -172,6 +174,18 @@ static struct bt_gatt_attr prov_attrs[] = {
 
 static struct bt_gatt_service prov_svc = BT_GATT_SERVICE(prov_attrs);
 
+static int prov_gatt_service_unregister(void)
+{
+	if (!service_registered) {
+		return -EALREADY;
+	}
+
+	(void)bt_gatt_service_unregister(&prov_svc);
+	service_registered = false;
+
+	return 0;
+}
+
 int bt_mesh_pb_gatt_srv_enable(void)
 {
 	LOG_DBG("");
@@ -193,14 +207,14 @@ int bt_mesh_pb_gatt_srv_enable(void)
 
 int bt_mesh_pb_gatt_srv_disable(void)
 {
+	int err;
+
 	LOG_DBG("");
 
-	if (!service_registered) {
-		return -EALREADY;
+	err = prov_gatt_service_unregister();
+	if (err) {
+		return err;
 	}
-
-	bt_gatt_service_unregister(&prov_svc);
-	service_registered = false;
 
 	bt_mesh_adv_gatt_update();
 

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -47,6 +47,7 @@ static int gatt_send(struct bt_conn *conn,
 
 static struct bt_mesh_proxy_role *cli;
 static bool service_registered;
+static bool adv_restart_pending;
 
 static void proxy_msg_recv(struct bt_mesh_proxy_role *role)
 {
@@ -120,6 +121,8 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 
 	if (bt_mesh_is_provisioned()) {
 		(void)bt_mesh_pb_gatt_srv_disable();
+	} else {
+		adv_restart_pending = true;
 	}
 }
 
@@ -310,7 +313,16 @@ int bt_mesh_pb_gatt_srv_adv_start(void)
 
 }
 
+static void conn_recycled(void)
+{
+	if (adv_restart_pending) {
+		adv_restart_pending = false;
+		bt_mesh_adv_gatt_update();
+	}
+}
+
 BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = gatt_connected,
 	.disconnected = gatt_disconnected,
+	.recycled = conn_recycled,
 };

--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -348,8 +348,6 @@ void bt_mesh_proxy_role_cleanup(struct bt_mesh_proxy_role *role)
 	role->conn = NULL;
 
 	conn_count--;
-
-	bt_mesh_adv_gatt_update();
 }
 
 bool bt_mesh_proxy_has_avail_conn(void)

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -958,11 +958,9 @@ static struct bt_gatt_attr proxy_attrs[] = {
 
 static struct bt_gatt_service proxy_svc = BT_GATT_SERVICE(proxy_attrs);
 
-int bt_mesh_proxy_gatt_enable(void)
+static int proxy_gatt_service_register(void)
 {
 	int err;
-
-	LOG_DBG("");
 
 	if (!bt_mesh_is_provisioned()) {
 		return -ENOTSUP;
@@ -984,6 +982,20 @@ int bt_mesh_proxy_gatt_enable(void)
 		if (clients[i].cli) {
 			clients[i].filter_type = ACCEPT;
 		}
+	}
+
+	return 0;
+}
+
+int bt_mesh_proxy_gatt_enable(void)
+{
+	int err;
+
+	LOG_DBG("");
+
+	err = proxy_gatt_service_register();
+	if (err) {
+		return err;
 	}
 
 	bt_mesh_adv_gatt_update();
@@ -1169,7 +1181,8 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 	}
 
 	if (!service_registered && bt_mesh_is_provisioned()) {
-		(void)bt_mesh_proxy_gatt_enable();
+		(void)proxy_gatt_service_register();
+		adv_restart_pending = true;
 		return;
 	}
 

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -71,6 +71,7 @@ static struct bt_mesh_proxy_client {
 };
 
 static bool service_registered;
+static bool adv_restart_pending;
 
 static struct bt_mesh_proxy_client *find_client(struct bt_conn *conn)
 {
@@ -1176,6 +1177,7 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 	if (client->cli) {
 		bt_mesh_proxy_role_cleanup(client->cli);
 		client->cli = NULL;
+		adv_restart_pending = true;
 	}
 }
 
@@ -1207,9 +1209,18 @@ int bt_mesh_proxy_adv_start(void)
 	return gatt_proxy_advertise();
 }
 
+static void conn_recycled(void)
+{
+	if (adv_restart_pending) {
+		adv_restart_pending = false;
+		bt_mesh_adv_gatt_update();
+	}
+}
+
 BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = gatt_connected,
 	.disconnected = gatt_disconnected,
+	.recycled = conn_recycled,
 };
 
 uint8_t bt_mesh_proxy_srv_connected_cnt(void)


### PR DESCRIPTION
When a PB-GATT or GATT Proxy connection disconnects on a device with CONFIG_BT_MAX_CONN=1, the mesh stack attempts to restart connectable advertising from the disconnected callback. This fails with -ENOMEM because the BLE host still holds a reference to the connection object at that point, and bt_le_ext_adv_start() cannot pre-allocate a new connection slot.

Fix this by using the bt_conn_cb.recycled callback to trigger advertising restart. The recycled callback fires only after the connection object is fully released, guaranteeing a free slot is available for connectable advertising.

Remove bt_mesh_adv_gatt_update() from bt_mesh_proxy_role_cleanup() and instead set an adv_restart_pending flag in the disconnected handler. The recycled callback checks this flag to avoid unnecessary advertising restart attempts from unrelated disconnections.

Assisted-by: Claude:claude-opus-4.6