### PR TITLE
boards: lilygo: twatch_s3: add lora device

### DIFF
--- a/boards/lilygo/twatch_s3/twatch_s3-pinctrl.dtsi
+++ b/boards/lilygo/twatch_s3/twatch_s3-pinctrl.dtsi
@@ -25,6 +25,18 @@
 		};
 	};
 
+	spim2_default: spim2_default {
+		group1 {
+			pinmux = <SPIM2_SCLK_GPIO3>,
+				 <SPIM2_MISO_GPIO4>;
+		};
+
+		group2 {
+			pinmux = <SPIM2_MOSI_GPIO1>;
+			output-low;
+		};
+	};
+
 	spim3_default: spim3_default {
 		group1 {
 			pinmux = <SPIM3_SCLK_GPIO18>,

--- a/boards/lilygo/twatch_s3/twatch_s3_procpu.dts
+++ b/boards/lilygo/twatch_s3/twatch_s3_procpu.dts
@@ -10,6 +10,7 @@
 #include <espressif/partitions_0x0_amp_16M.dtsi>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/display/panel.h>
+#include <zephyr/dt-bindings/lora/sx126x.h>
 
 / {
 	model = "T-Watch S3 PROCPU";
@@ -22,6 +23,7 @@
 		rtc = &pfc8563_rtc;
 		pwm-led0 = &backlight_pwm;
 		fuel-gauge0 = &fuel_gauge;
+		lora0 = &lora0;
 	};
 
 	chosen {
@@ -95,6 +97,27 @@
 	channel0@0 {
 		reg = <0x0>;
 		timer = <0>;
+	};
+};
+
+&spi2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+	pinctrl-0 = <&spim2_default>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+
+	lora0: lora@0 {
+		compatible = "semtech,sx1262";
+		reg = <0>;
+		reset-gpios = <&gpio0 8 (GPIO_OPEN_DRAIN | GPIO_ACTIVE_LOW)>;
+		busy-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+		dio1-gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		dio2-tx-enable;
+		dio3-tcxo-voltage = <SX126X_DIO3_TCXO_3V0>;
+		tcxo-power-startup-delay-ms = <5>;
+		spi-max-frequency = <4000000>;
 	};
 };
 

--- a/boards/lilygo/twatch_s3/twatch_s3_procpu.dts
+++ b/boards/lilygo/twatch_s3/twatch_s3_procpu.dts
@@ -308,3 +308,7 @@
 &ipm0 {
 	status = "okay";
 };
+
+&wifi {
+	status = "okay";
+};

--- a/boards/lilygo/twatch_s3/twatch_s3_procpu.yaml
+++ b/boards/lilygo/twatch_s3/twatch_s3_procpu.yaml
@@ -16,4 +16,5 @@ supported:
   - input
   - video
   - rtc
+  - lora
 vendor: lilygo


### PR DESCRIPTION
Add pinctrl for spi2 and enable SX1262 LoRa module as per the board's schematics and reference sample code (for TCXO voltage)

Also enable wifi node while at it.