### PR TITLE
tests/net/conn_mgr_nsos: Initialize address to 0 to avoid valgrind warning

### DIFF
--- a/tests/net/conn_mgr_nsos/src/main.c
+++ b/tests/net/conn_mgr_nsos/src/main.c
@@ -130,7 +130,7 @@ ZTEST(conn_mgr_nsos, test_conn_mgr_nsos)
 ZTEST(conn_mgr_nsos, test_conn_mgr_nsos_idle)
 {
 	struct net_if *iface = net_if_get_default();
-	struct net_sockaddr_in v4addr;
+	struct net_sockaddr_in v4addr = {0};
 	int sock, rc;
 
 	/* 2 second idle timeout */


### PR DESCRIPTION

Initialize the whole address to 0, to avoid a valgrind warning when a copy of the address is passed to the Linux kernel:
```
Syscall param socketcall.sendto(to.sin_addr) points to uninitialised bytes
at _dl_sysinfo_int80 (in /usr/lib/i386-linux-gnu/ld-linux.so.2)
by sendto (sendto.c:30)
by nsos_adapt_sendto (nsos_adapt.c:544)
```