### PR TITLE
drivers: can: mcan: set TX/RX FIFO sizes based on CAN mode

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1377,6 +1377,7 @@ int can_mcan_configure_mram(const struct device *dev, uintptr_t mrba, uintptr_t 
 		return err;
 	}
 
+#ifdef CONFIG_CAN_FD_MODE
 	/* 64 byte Tx Buffer data fields size */
 	reg = CAN_MCAN_TXESC_TBDS;
 	err = can_mcan_write_reg(dev, CAN_MCAN_TXESC, reg);
@@ -1390,6 +1391,7 @@ int can_mcan_configure_mram(const struct device *dev, uintptr_t mrba, uintptr_t 
 	if (err != 0) {
 		return err;
 	}
+#endif /* CONFIG_CAN_FD_MODE */
 
 	return 0;
 }

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -937,8 +937,13 @@ struct can_mcan_rx_fifo_hdr {
 struct can_mcan_rx_fifo {
 	struct can_mcan_rx_fifo_hdr hdr;
 	union {
+#ifdef CONFIG_CAN_FD_MODE
 		uint8_t data[64];
 		uint32_t data_32[16];
+#else
+		uint8_t data[8];
+		uint32_t data_32[2];
+#endif
 	};
 } __packed __aligned(4);
 
@@ -978,8 +983,13 @@ struct can_mcan_tx_buffer_hdr {
 struct can_mcan_tx_buffer {
 	struct can_mcan_tx_buffer_hdr hdr;
 	union {
+#ifdef CONFIG_CAN_FD_MODE
 		uint8_t data[64];
 		uint32_t data_32[16];
+#else
+		uint8_t data[8];
+		uint32_t data_32[2];
+#endif
 	};
 } __packed __aligned(4);
 


### PR DESCRIPTION
Set the MCAN TX/RX FIFO sizes based on CAN_FD_MODE. This allows more efficient use of MRAM if CAN_FD_MODE is disabled.