### PR TITLE
boards: mpfs_icicle: disable CPUs for non-SMP variants

### DIFF
--- a/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54.dts
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54.dts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /dts-v1/;
 #include "mpfs_icicle_common.dtsi"
 
@@ -6,6 +12,18 @@
 
 	cpus {
 		cpu@0 {
+			status = "disabled";
+		};
+
+		cpu@2 {
+			status = "disabled";
+		};
+
+		cpu@3 {
+			status = "disabled";
+		};
+
+		cpu@4 {
 			status = "disabled";
 		};
 	};

--- a/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54_smp.dts
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54_smp.dts
@@ -1,8 +1,20 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /dts-v1/;
-#include "mpfs_icicle_polarfire_u54.dts"
+#include "mpfs_icicle_common.dtsi"
 
 / {
 	compatible = "microchip,mpfs-icicle-kit", "microchip,mpfs";
+
+	cpus {
+		cpu@0 {
+			status = "disabled";
+		};
+	};
 
 	chosen {
 		zephyr,console = &uart1;


### PR DESCRIPTION
Non-SMP builds should not advertise multiple CPUs. Reference Commit 1ab7159