### PR TITLE
tests: logging: log_core_additional: drain pre-test logs in log_setup

### DIFF
--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -166,6 +166,14 @@ static void log_setup(bool backend2_enable)
 	log_thread_set(k_current_get());
 #endif
 
+	/* Drain any log messages queued before this test (e.g. a boot-time
+	 * LOG_WRN from the kernel) so they are dispatched to whichever
+	 * backends were already active.  Without this, the freshly enabled
+	 * test backend below would also receive those pre-test messages on
+	 * its first dispatch and the counter would start above zero.
+	 */
+	log_flush();
+
 	memset(&backend1_cb, 0, sizeof(backend1_cb));
 
 	log_backend_enable(&backend1, &backend1_cb, LOG_LEVEL_DBG);


### PR DESCRIPTION
## Summary

`tests/subsys/logging/log_core_additional/src/log_test.c::test_log_domain_id` deterministically fails on `fvp_base_revc_2xaem` and similar ARM64 FVP boards. The test sets `total_logs=1`, emits one `LOG_INF`, drains the queue, and expects `backend1` to have received exactly one message. On the failing boards backend1 sees two: the test's own `LOG_INF` plus a stale boot-time `LOG_WRN` already in the queue when the test starts.

The boot-time message that bleeds into the test is the new "xlat tables low: …" warning added in commit `92382add7102` ("arch: arm64: mmu: track xlat tables usage and warn before exhaustion"). `fvp_base_revc_2xaem`'s memory map drives MMU table allocation past the low-water mark at `SYS_INIT` time, queueing a `LOG_WRN` that nobody has drained when `test_log_domain_id` runs as the second test in the suite. `qemu_cortex_a53`'s simpler memory map stays below the threshold, no warning is logged, and the test passes there.

The warning itself is legitimate, and the test is the fragile party: it assumes the log queue is empty when `log_setup()` runs, which is only true when no subsystem has logged anything at boot. Any future boot-time `LOG_*` from any subsystem on any platform would break it the same way.

Call `log_flush()` in `log_setup()` before enabling the test backend, so any messages queued before this test get dispatched to whichever backends were already active (UART, RTT, etc.) and do not bleed into the new test backend's counter.

Verified on `fvp_base_revc_2xaem/v9a` with `logging.async`, `logging.sync`, and `logging.thread` variants — all four `test_log_core_additional` tests that use `log_setup` pass cleanly where `test_log_domain_id` previously failed in 0.001s.

Fixes #109520