### PR TITLE
soc: bflb70xl: do not preemptively enable FPU

### DIFF
--- a/soc/bflb/bl70xl/rf_callbacks.c
+++ b/soc/bflb/bl70xl/rf_callbacks.c
@@ -50,14 +50,4 @@ void rf_full_cal_start_callback(uint32_t addr, uint32_t size)
 	/* No DMA conflict checking needed during early init */
 	ARG_UNUSED(addr);
 	ARG_UNUSED(size);
-
-	/*
-	 * RF calibration uses double-precision float (__muldf3) which accesses
-	 * FP CSRs (frrm). With FPU_SHARING the FPU starts disabled per-thread
-	 * and relies on an illegal-instruction trap to lazy-enable it. The
-	 * BL70XL doesn't populate mtval with the faulting instruction encoding,
-	 * breaking the trap handler's FP instruction decoder. Pre-enable the
-	 * FPU here to avoid the trap entirely.
-	 */
-	__asm__ volatile("csrs mstatus, %0" ::"r"(MSTATUS_FS_INIT));
 }


### PR DESCRIPTION
Avoids preemptively enabling FPU in RF callback. The fact that MTVAL is not populated on illegal instruction exception with `frrm` is handled in the RISC-V _isr_wrapper, and the offending instruction is loaded from the address in `mepc`.

This was fixed recently in https://github.com/zephyrproject-rtos/zephyr/pull/108805

Note that this can still encounter issues until https://github.com/zephyrproject-rtos/zephyr/pull/109033 is merged.