### PR TITLE
Bluetooth: CAP: Handover: Expand stream ctx checks

### DIFF
--- a/subsys/bluetooth/audio/cap_handover.c
+++ b/subsys/bluetooth/audio/cap_handover.c
@@ -471,8 +471,14 @@ static bool valid_unicast_to_broadcast_stream_metadata_param(
 	}
 
 	broadcast_ret = bt_audio_codec_cfg_meta_get_stream_context(subgroup_param->codec_cfg);
+	if (broadcast_ret <= 0) {
+		LOG_DBG("Could not get broadcast stream context: %d", broadcast_ret);
+		return false;
+	}
+
 	if (unicast_ret != broadcast_ret) {
-		LOG_DBG("Could not get broadcast stream context: %d", unicast_ret);
+		LOG_DBG("Unicast and broadcast stream context differ: 0x%04X != 0x%04X",
+			unicast_ret, broadcast_ret);
 		return false;
 	}
 


### PR DESCRIPTION
Add a specific check for getting the broadcast streaming context, and log the individual values for unicast and broadcast if they differ.