### PR TITLE
tests: workq/work: skip SMP test with only 1 CPU

### DIFF
--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -331,7 +331,7 @@ ZTEST(work_1cpu, test_1cpu_simple_queue)
 /* Basic SMP check submitting with a non-blocking handler. */
 ZTEST(work, test_smp_simple_queue)
 {
-	if (!IS_ENABLED(CONFIG_SMP)) {
+	if (!IS_ENABLED(CONFIG_SMP) || (CONFIG_MP_MAX_NUM_CPUS == 1)) {
 		ztest_test_skip();
 		return;
 	}
@@ -828,7 +828,7 @@ ZTEST(work, test_smp_running_cancel)
 {
 	int rc;
 
-	if (!IS_ENABLED(CONFIG_SMP)) {
+	if (!IS_ENABLED(CONFIG_SMP) || (CONFIG_MP_MAX_NUM_CPUS == 1)) {
 		ztest_test_skip();
 		return;
 	}


### PR DESCRIPTION
It is possible for CONFIG_SMP being enabled but with only 1 CPU enabled. The workqueue SMP tests may fail because the workqueue thread never gets scheduled. So skip those SMP tests that need multiple CPUs to work correctly if only 1 CPU is enabled.