### PR TITLE
logging: log_output_custom: drop fatal assert on unset callback

### DIFF
--- a/subsys/logging/log_output_custom.c
+++ b/subsys/logging/log_output_custom.c
@@ -28,8 +28,6 @@ static log_timestamp_format_func_t log_timestamp_format_func;
 int log_custom_timestamp_print(const struct log_output *output, const log_timestamp_t timestamp,
 			      const log_timestamp_printer_t printer)
 {
-	__ASSERT(log_timestamp_format_func != NULL, "custom timestamp format function not set");
-
 	if (log_timestamp_format_func) {
 		return log_timestamp_format_func(output, timestamp, printer);
 	}


### PR DESCRIPTION
## Summary

`log_custom_timestamp_print()` asserts that `log_timestamp_format_func`
is non-NULL before falling through to an `if`-guarded call of that
same pointer. The `if`-branch already returns 0 (no timestamp
emitted) when the pointer is NULL — the assert is redundant, and it
turns a benign "callback not yet registered" state into a kernel
panic.

That panic is reachable through a legitimate SMP race: with
`CONFIG_LOG_OUTPUT_FORMAT_CUSTOM_TIMESTAMP=y`, the deferred log
processing thread can dispatch a queued boot-time log message on a
secondary CPU before the application has had a chance to call
`log_custom_timestamp_set()`. The full root-cause analysis is in
issue #109536.

Dropping the assert lets the function degrade gracefully: a user who
genuinely forgot to register their callback sees missing timestamps
rather than a system-wide panic.

Fixes #109536