### PR TITLE
dts: R-Car V4H: Fix clock frequency value

### DIFF
--- a/dts/arm/renesas/rcar/gen4/r8a779g0.dtsi
+++ b/dts/arm/renesas/rcar/gen4/r8a779g0.dtsi
@@ -68,7 +68,7 @@
 	clocks {
 		clock-cl16m_rt {
 			compatible = "fixed-clock";
-			clock-frequency = <16666667>;
+			clock-frequency = <16660000>;
 			#clock-cells = <0>;
 		};
 	};


### PR DESCRIPTION
Hi,

I would like to fix the value of CL16M_RT clock source to match hardware specification: 16.66 MHz