### PR TITLE
dts: arm: Add missing ADC2 node for STM32F302xC

### DIFF
--- a/dts/arm/st/f3/stm32f302Xc.dtsi
+++ b/dts/arm/st/f3/stm32f302Xc.dtsi
@@ -108,6 +108,23 @@
 				clocks = <&rcc STM32_CLOCK(AHB1, 21)>;
 			};
 		};
+
+		adc2: adc@50000100 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000100 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 28)>;
+			clock-names = "adcx";
+			interrupts = <18 0>;
+			#io-channel-cells = <1>;
+			st,adc-resolutions = <12 10 8 6>;
+			sampling-times = <2 3 5 8 20 62 182 602>;
+			st,adc-sequencer = "programmable";
+			st,adc-oversampler = "none";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-differential-support;
+			st,adc-has-injected-support;
+			status = "disabled";
+		};
 	};
 };
 


### PR DESCRIPTION
This PR adds the missing `adc2` peripheral node to `stm32f302Xc.dtsi`. 

According to the RM0365 reference manual, STM32F302xC devices feature both ADC1 and ADC2. The `stm32f302X8.dtsi` file is left as-is, since x6/x8 variants only support ADC1.

Fixes #109510