### PR TITLE
Replace hardcoded echo-timeout

### DIFF
--- a/drivers/sensor/hc_sr04/hc_sr04.c
+++ b/drivers/sensor/hc_sr04/hc_sr04.c
@@ -28,6 +28,7 @@ struct hcsr04_data {
 struct hcsr04_config {
 	struct gpio_dt_spec trigger_gpios;
 	struct gpio_dt_spec echo_gpios;
+	k_timeout_t echo_timeout;
 };
 
 static void hcsr04_gpio_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins);
@@ -143,7 +144,7 @@ static int hcsr04_sample_fetch(const struct device *dev, enum sensor_channel cha
 		return ret;
 	}
 
-	if (k_sem_take(&data->sem, K_MSEC(10)) != 0) {
+	if (k_sem_take(&data->sem, cfg->echo_timeout) != 0) {
 		LOG_ERR("Echo signal was not received");
 		return -EIO;
 	}
@@ -180,6 +181,7 @@ static DEVICE_API(sensor, hcsr04_driver_api) = {
 	static struct hcsr04_config hcsr04_config_##index = {                         \
 		.trigger_gpios = GPIO_DT_SPEC_INST_GET(index, trigger_gpios),         \
 		.echo_gpios = GPIO_DT_SPEC_INST_GET(index, echo_gpios),               \
+		.echo_timeout = K_MSEC(DT_INST_PROP(index, echo_timeout_ms)),     \
 	};                                                                            \
                                                                                       \
 	SENSOR_DEVICE_DT_INST_DEFINE(index, &hcsr04_init, NULL, &hcsr04_data_##index, \

--- a/dts/bindings/sensor/hc-sr04.yaml
+++ b/dts/bindings/sensor/hc-sr04.yaml
@@ -20,3 +20,11 @@ properties:
       Input pin. The pulse received on this pin corresponds to
       the duration between the ultrasonic pulse emission and
       the reception of its "echo".
+
+  echo-timeout-ms:
+    type: int
+    default: 10
+    description: |
+      Maximum time the driver waits for the echo to return.
+      Default value of 10ms is equivalent to approx. 1.5m maximum range.
+      Measurements with no target will abort when timeout is reached.


### PR DESCRIPTION
The echo-timeout defines the maximum range of the ultrasonic sensor and was hardcoded to 10ms (~1.5m). 
This commit creates a dts property for the timeout, so users can configure the maximum range per sensor instance.
A default setting of 10ms was chosen to keep compability with the existing implementation.


