### PR TITLE
arch: arm: fix arm-m-switch.h include order in exception.h

### DIFF
--- a/include/zephyr/arch/arm/cortex_m/exception.h
+++ b/include/zephyr/arch/arm/cortex_m/exception.h
@@ -15,9 +15,6 @@
 #include <zephyr/devicetree.h>
 
 #include <zephyr/arch/arm/cortex_m/nvic.h>
-#ifndef _ASMLANGUAGE
-#include <zephyr/arch/arm/arm-m-switch.h>
-#endif
 
 /* for assembler, only works with constants */
 #define Z_EXC_PRIO(pri) (((pri) << (8 - NUM_IRQ_PRIO_BITS)) & 0xff)
@@ -65,6 +62,7 @@ GTEXT(z_arm_exc_exit);
 #endif
 #else
 #include <zephyr/types.h>
+#include <zephyr/arch/arm/arm-m-switch.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/arch/exception.h
+++ b/include/zephyr/arch/exception.h
@@ -8,6 +8,8 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_EXCEPTION_H_
 #define ZEPHYR_INCLUDE_ARCH_EXCEPTION_H_
 
+#ifndef _ASMLANGUAGE
+
 #if defined(CONFIG_EXCEPTION_DUMP_HOOK)
 
 #include <stdbool.h>
@@ -105,6 +107,8 @@ static inline void arch_exception_call_dump_hook(const char *format, ...)
 #define EXCEPTION_DUMP(format, ...) printk(format "\n", ##__VA_ARGS__)
 #endif
 #endif
+
+#endif /* _ASMLANGUAGE */
 
 #if defined(CONFIG_X86_64)
 #include <zephyr/arch/x86/intel64/exception.h>


### PR DESCRIPTION
arm-m-switch.h is included in cortex_m/exception.h before _EXC_IRQ_DEFAULT_PRIO is defined. arm-m-switch.h transitively pulls in asm_inline_gcc.h via kernel/thread.h -> arch/cpu.h -> arm/arch.h, and that file uses _EXC_IRQ_DEFAULT_PRIO. Since the cortex_m/exception.h include guard is already set at this point, the macro is left undefined.

Move the arm-m-switch.h include to after all macro definitions.

Also add an _ASMLANGUAGE guard around the CONFIG_EXCEPTION_DUMP_HOOK block in arch/exception.h to prevent build failures when included from assembly files.

Signed-off-by: Fangwei Que <15259288389@163.com>