### PR TITLE
Backport CVE 2026-5590 fix for 4.3

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2313,7 +2313,7 @@ static enum net_verdict tcp_recv(struct net_conn *net_conn,
 	if (th_flags(th) & SYN && !(th_flags(th) & ACK)) {
 		struct tcp *conn_old = ((struct net_context *)user_data)->tcp;
 
-		if (tcp_backlog_is_full(conn_old)) {
+		if (conn_old == NULL || tcp_backlog_is_full(conn_old)) {
 			/* If the connection backlog is full, ignore the SYN
 			 * packet (same behavior as on Linux). Retransmitted SYN
 			 * attempts may be successful later.


### PR DESCRIPTION
Vulnerability https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-4vqm-pw24-g9jp states that it affects 4.3 but the linked fix is not included in v4.3 branch. Perhaps because there is no bug issue about it so it went without backporting? Anyways, cherry-pick the proposed fix to v4.3 branch.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/109549