### PR TITLE
drivers: video: arducam: fix compilation errors

### DIFF
--- a/boards/shields/arducam_mega/Kconfig.shield
+++ b/boards/shields/arducam_mega/Kconfig.shield
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Mario Paja
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_ARDUCAM_MEGA
+	def_bool $(shields_list_contains,arducam_mega)
+
+config SHIELD_ARDUCAM_MEGA_ARDUINO
+	def_bool $(shields_list_contains,arducam_mega_arduino)
+
+config SHIELD_ARDUCAM_MEGA_MIKROBUS
+	def_bool $(shields_list_contains,arducam_mega_mikrobus)
+
+config SHIELD_ARDUCAM_MEGA_XIAO
+	def_bool $(shields_list_contains,arducam_mega_xiao)

--- a/boards/shields/arducam_mega/arducam_mega.overlay
+++ b/boards/shields/arducam_mega/arducam_mega.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Mario Paja
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,camera = &arducam_mega;
+	};
+};
+
+&arducam_mega_spi {
+	arducam_mega: arducam-mega@0 {
+		compatible = "arducam,mega";
+		reg = <0>;
+		spi-max-frequency = <4000000>;
+	};
+};

--- a/boards/shields/arducam_mega/arducam_mega_arduino.overlay
+++ b/boards/shields/arducam_mega/arducam_mega_arduino.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Mario Paja
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+arducam_mega_spi: &arduino_spi {};
+
+#include "arducam_mega.overlay"

--- a/boards/shields/arducam_mega/arducam_mega_mikrobus.overlay
+++ b/boards/shields/arducam_mega/arducam_mega_mikrobus.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Mario Paja
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+arducam_mega_spi: &mikrobus_spi {};
+
+#include "arducam_mega.overlay"

--- a/boards/shields/arducam_mega/arducam_mega_xiao.overlay
+++ b/boards/shields/arducam_mega/arducam_mega_xiao.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Mario Paja
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+arducam_mega_spi: &xiao_spi {};
+
+#include "arducam_mega.overlay"

--- a/boards/shields/arducam_mega/doc/index.rst
+++ b/boards/shields/arducam_mega/doc/index.rst
@@ -1,0 +1,108 @@
+.. _arducam_mega:
+
+ArduCam Mega SPI Camera Shield
+###############################
+
+Overview
+********
+
+The ArduCam Mega SPI shield provides the Arducam Mega image sensor over a standard
+SPI interface. Four shield variants are available:
+
+- ``arducam_mega`` - generic variant; requires a board-specific overlay
+- ``arducam_mega_arduino`` - for boards exposing an Arduino-compatible SPI header
+- ``arducam_mega_mikrobus`` - for boards exposing a MikroBus connector
+- ``arducam_mega_xiao`` - for boards exposing a Seeed XIAO connector
+
+Requirements
+************
+
+This shield requires a board that provides:
+
+- An SPI bus
+- A chip select GPIO
+
+Each connector-specific variant relies on a standard SPI alias defined by the board
+(``arduino_spi``, ``mikrobus_spi``, or ``xiao_spi``), which is assigned to the
+``arducam_mega_spi`` alias used by the shared ``arducam_mega.overlay``. The base
+``arducam_mega`` variant requires a board-specific overlay to define the
+``arducam_mega_spi`` alias and CS pin manually.
+
+Board Overlays
+==============
+
+The connector-specific variants assign the appropriate board SPI bus to the
+``arducam_mega_spi`` alias and then include the shared ``arducam_mega.overlay``,
+which registers the device node and sets ``zephyr,camera``.
+
+**arducam_mega_arduino** — uses the ``arduino_spi`` alias:
+
+.. code-block:: dts
+
+   arducam_mega_spi: &arduino_spi {};
+   #include "arducam_mega.overlay"
+
+**arducam_mega_mikrobus** — uses the ``mikrobus_spi`` alias:
+
+.. code-block:: dts
+
+   arducam_mega_spi: &mikrobus_spi {};
+   #include "arducam_mega.overlay"
+
+**arducam_mega_xiao** — uses the ``xiao_spi`` alias:
+
+.. code-block:: dts
+
+   arducam_mega_spi: &xiao_spi {};
+   #include "arducam_mega.overlay"
+
+**arducam_mega** — generic variant; the shield overlay is intentionally empty.
+Create ``boards/<board_name>.overlay`` inside the shield directory, replacing
+``<board_spi_bus>``, ``<gpio_port>``, and ``<pin>`` with values appropriate for
+your board:
+
+.. code-block:: dts
+
+   arducam_mega_spi: &<board_spi_bus> {
+       cs-gpios = <&<gpio_port> <pin> GPIO_ACTIVE_LOW>;
+   };
+   #include "arducam_mega.overlay"
+
+The shared ``arducam_mega.overlay`` included by all variants contains:
+
+.. code-block:: dts
+
+   / {
+       chosen {
+           zephyr,camera = &arducam_mega;
+       };
+   };
+
+   &arducam_mega_spi {
+       arducam_mega: arducam-mega@0 {
+           compatible = "arducam,mega";
+           reg = <0>;
+           spi-max-frequency = <4000000>;
+       };
+   };
+
+Programming
+***********
+
+Select the shield variant that matches your board's connector and pass it to
+``west build``. For example, using the Arduino variant on the ``nucleo_h563zi``:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/video/tcpserversink
+   :board: nucleo_h563zi
+   :shield: arducam_mega_arduino
+   :gen-args: -DCONFIG_NET_PKT_RX_COUNT=10 -DCONFIG_NET_PKT_TX_COUNT=10 -DCONFIG_NET_BUF_RX_COUNT=20 -DCONFIG_NET_BUF_TX_COUNT=20 -DCONFIG_NET_MAX_CONTEXTS=10 -DCONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=131072 -DCONFIG_VIDEO_FRAME_WIDTH=96 -DCONFIG_VIDEO_FRAME_HEIGHT=96 -DCONFIG_VIDEO_PIXEL_FORMAT=\"JPEG\"
+   :goals: build flash
+
+References
+**********
+
+.. target-notes::
+
+.. _Arducam Mega:
+   https://blog.arducam.com/camera-for-any-microcontroller/

--- a/boards/shields/arducam_mega/shield.yml
+++ b/boards/shields/arducam_mega/shield.yml
@@ -1,0 +1,24 @@
+shields:
+  - name: arducam_mega
+    full_name: Arducam Mega Shield
+    vendor: arducam
+    supported_features:
+      - video
+
+  - name: arducam_mega_arduino
+    full_name: Arducam Mega Shield (Arduino)
+    vendor: arducam
+    supported_features:
+      - video
+
+  - name: arducam_mega_mikrobus
+    full_name: Arducam Mega Shield (MikroBus)
+    vendor: arducam
+    supported_features:
+      - video
+
+  - name: arducam_mega_xiao
+    full_name: Arducam Mega Shield (Xiao)
+    vendor: arducam
+    supported_features:
+      - video

--- a/drivers/video/video_arducam_mega.c
+++ b/drivers/video/video_arducam_mega.c
@@ -428,8 +428,8 @@ static int arducam_mega_await_bus_idle(const struct spi_dt_spec *spec, int tries
 	return 0;
 }
 
-static int arducam_mega_write_reg_wait(const struct arducam_mega_bus *bus, uint16_t reg,
-				       uint8_t value, uint32_t idle_timeout_ms)
+static int arducam_mega_write_reg_wait(const struct spi_dt_spec *bus, uint16_t reg, uint8_t value,
+				       uint32_t idle_timeout_ms)
 {
 	int ret = 0;
 
@@ -581,7 +581,7 @@ static int arducam_mega_set_jpeg_quality(const struct device *dev, enum mega_ima
 	const struct arducam_mega_config *cfg = dev->config;
 	struct arducam_mega_data *drv_data = dev->data;
 
-	LOG_DBG("JPEG quality level: %d", __func__, qc);
+	LOG_DBG("JPEG quality level: %d", qc);
 
 	if (drv_data->fmt.pixelformat != VIDEO_PIX_FMT_JPEG) {
 		LOG_ERR("Image format does not support setting JPEG quality");
@@ -1353,7 +1353,7 @@ static int arducam_mega_init(const struct device *dev)
 	static const struct arducam_mega_config arducam_mega_cfg_##inst = {                        \
 		.bus = SPI_DT_SPEC_INST_GET(                                                       \
 			inst,                                                                      \
-			SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_LINES_SINGLE | SPI_LOCK_ON, 0), \
+			SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_LINES_SINGLE | SPI_LOCK_ON),    \
 	};                                                                                         \
                                                                                                    \
 	static struct arducam_mega_data arducam_mega_data_##inst;                                  \

--- a/drivers/video/video_arducam_mega.c
+++ b/drivers/video/video_arducam_mega.c
@@ -1242,7 +1242,7 @@ static int arducam_mega_init_controls(const struct device *dev)
 	if (drv_data->features & MEGA_HAS_FOCUS) {
 		ret = video_init_ctrl(
 			&ctrls->focus_auto, dev, VIDEO_CID_FOCUS_AUTO,
-			(struct video_ctrl_range){.min = 0, .max = 65535, .step = 1, .def = 0});
+			(struct video_ctrl_range){.min = 0, .max = 1, .step = 1, .def = 0});
 		if (ret < 0) {
 			return ret;
 		}

--- a/tests/drivers/build_all/video/spi_devices.overlay
+++ b/tests/drivers/build_all/video/spi_devices.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Mario Paja
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/ {
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_gpio: gpio@10001000 {
+			compatible = "vnd,gpio";
+			gpio-controller;
+			reg = <0x10001000 0x1000>;
+			#gpio-cells = <0x2>;
+			status = "okay";
+		};
+
+		test_spi: spi@10004000 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,spi";
+			reg = <0x10004000 0x1000>;
+			status = "okay";
+			clock-frequency = <8000000>;
+
+			/* one entry for every device at spi.dtsi */
+			cs-gpios = <&test_gpio 0 0>;
+
+			test_spi_arducam_mega: arducam-mega@0 {
+				compatible = "arducam,mega";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+				status = "okay";
+			};
+		};
+	};
+};

--- a/tests/drivers/build_all/video/testcase.yaml
+++ b/tests/drivers/build_all/video/testcase.yaml
@@ -11,6 +11,16 @@ tests:
     depends_on:
       - gpio
       - i2c
+  drivers.video.spi.build:
+    extra_args: DTC_OVERLAY_FILE="spi_devices.overlay"
+    extra_configs:
+      - CONFIG_SPI=y
+    platform_allow:
+      - native_sim
+    min_ram: 32
+    depends_on:
+      - gpio
+      - spi
   drivers.video.mcux_csi.build:
     platform_allow:
       - mimxrt1064_evk


### PR DESCRIPTION
Fix compilation issues in the Arducam Mega video driver:

- Fix incompatible pointer type when calling arducam_mega_await_bus_idle() by aligning const-correctness of struct arducam_mega_bus.
- Correct LOG_DBG format string mismatch in JPEG quality logging (fix incorrect argument usage with %d).
- Address deprecated SPI DT macro usage by updating initialization to avoid deprecated delay parameter warning.

----

`xiao_esp32s3_esp32s3_procpu.overlay`:
```
/ {
	chosen {
		zephyr,camera = &arducam_mega;
	};
};

&xiao_spi {
	cs-gpios = <&xiao_d 2 GPIO_ACTIVE_LOW>;

	arducam_mega: arducam-mega0@0 {
		compatible = "arducam,mega";
		reg = <0>;
		spi-max-frequency = <4000000>;
		status = "okay";
	};
};
```
------

`xiao_esp32s3_esp32s3_procpu.conf`:
```
CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=524288
CONFIG_ESP_SPIRAM=y
CONFIG_SPIRAM_MODE_OCT=y
CONFIG_VIDEO_BUFFER_POOL_ALIGN=32
CONFIG_DMA_ESP32_MAX_DESCRIPTOR_NUM=64
CONFIG_VIDEO_BUFFER_USE_SHARED_MULTI_HEAP=y
CONFIG_VIDEO_BUFFER_SMH_ATTRIBUTE=2

CONFIG_MAIN_STACK_SIZE=8192
CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=6144
CONFIG_SHELL_STACK_SIZE=6144

CONFIG_EARLY_CONSOLE=y

CONFIG_NETWORKING=y
CONFIG_TEST_RANDOM_GENERATOR=y

CONFIG_MAIN_STACK_SIZE=5200
CONFIG_SHELL_STACK_SIZE=5200
CONFIG_NET_TX_STACK_SIZE=2048
CONFIG_NET_RX_STACK_SIZE=2048

CONFIG_NET_PKT_RX_COUNT=10
CONFIG_NET_PKT_TX_COUNT=10
CONFIG_NET_BUF_RX_COUNT=20
CONFIG_NET_BUF_TX_COUNT=20
CONFIG_NET_MAX_CONTEXTS=10
CONFIG_NET_DHCPV4=y

CONFIG_NET_IPV4=y
CONFIG_NET_IPV6=n

CONFIG_NET_TCP=y

CONFIG_NET_LOG=y
CONFIG_INIT_STACKS=y

CONFIG_NET_SHELL=y

CONFIG_NET_STATISTICS=y
CONFIG_NET_STATISTICS_PERIODIC_OUTPUT=n

CONFIG_WIFI=y
CONFIG_WIFI_LOG_LEVEL_ERR=y
CONFIG_NET_L2_WIFI_SHELL=y
# printing of scan results puts pressure on queues in new locking
# design in net_mgmt. So, use a higher timeout for a crowded
# environment.
CONFIG_NET_MGMT_EVENT_QUEUE_TIMEOUT=5000
CONFIG_NET_MGMT_EVENT_QUEUE_SIZE=16

CONFIG_NET_CONFIG_SETTINGS=n

CONFIG_VIDEO_PIXEL_FORMAT="JPEG"
```

-------
Connect to Wifi:
`wifi connect -s "ssid" -p pass-k 10`
Stream: 
`gst-launch-1.0 tcpclientsrc host=serversinkip port=5000 ! jpegparse ! jpegdec ! videoconvert ! fpsdisplaysink text-overlay=false sync=false`

<img width="1374" height="535" alt="image" src="https://github.com/user-attachments/assets/4afd2834-9cff-462d-ba7a-4f1cfe8a97bb" />
