### PR TITLE
drivers: mfd: npm10xx: Add and handle more Devicetree PMIC configs

### DIFF
--- a/drivers/mfd/mfd_npm10xx.c
+++ b/drivers/mfd/mfd_npm10xx.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/mfd/npm10xx.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/dt-bindings/gpio/nordic-npm10xx-gpio.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -30,12 +31,18 @@ LOG_MODULE_REGISTER(mfd_npm10xx, CONFIG_MFD_LOG_LEVEL);
 /* GPIO registers */
 #define NPM10_GPIO_CONFIG  0xA0U
 #define NPM10_GPIO_USAGE   0xA3U
+#define NPM10_GPIO_CTRL2   0xABU
+#define GPIO_CONFIG_INPUT  BIT(0)
 #define GPIO_CONFIG_OUTPUT BIT(1)
 #define GPIO_CONFIG_OPENDR BIT(2)
 #define GPIO_CONFIG_PULLDN BIT(3)
 #define GPIO_CONFIG_PULLUP BIT(4)
+#define GPIO_CONFIG_DRIVE  BIT(5)
+#define GPIO_CONFIG_DEBNC  BIT(6)
 #define GPIO_USAGE_IRQ     0x01U
 #define GPIO_USAGE_INV     BIT(4)
+#define GPIO_CTRL2_LP_MASK (BIT_MASK(2) << 3)
+#define GPIO_CTRL2_LP_POL  BIT(5)
 
 /* EVENTS registers */
 #define NPM10_EVENTS_SET       0x00U
@@ -83,8 +90,6 @@ LOG_MODULE_REGISTER(mfd_npm10xx, CONFIG_MFD_LOG_LEVEL);
 #define RESET_LONGPRESS_DEBOUNCE_10S  (2U << 2)
 #define RESET_LONGPRESS_DEBOUNCE_20S  (3U << 2)
 
-#define RESET_LONGPRESS_CFG BIT(4)
-
 /* SHPHLD (0xE8) */
 #define RESET_SHPHLD_DEBOUNCESEL BIT(0)
 
@@ -94,7 +99,7 @@ LOG_MODULE_REGISTER(mfd_npm10xx, CONFIG_MFD_LOG_LEVEL);
 #define RESET_SHPHLD_DEBOUNCE_500MS (2U << 1)
 #define RESET_SHPHLD_DEBOUNCE_1S    (3U << 1)
 
-#define RESET_SHPHLD_WAKEUP BIT(3)
+#define RESET_SHPHLD_WAKEUP_NOPIN BIT(3)
 
 /* VBUSCONFIG (0xEA) */
 #define RESET_VBUSCONFIG_HIBERNATE        BIT(0)
@@ -125,13 +130,21 @@ LOG_MODULE_REGISTER(mfd_npm10xx, CONFIG_MFD_LOG_LEVEL);
 #define NPM10_TIMER_MAX_VALUE 0xFFFFFFU
 #define NPM10_TIMER_VALUE(ms) ((ms) * 8 / 125 - 1)
 
+struct mfd_npm10xx_gpio_config {
+	uint8_t pin;
+	gpio_flags_t flags;
+};
+
 struct mfd_npm10xx_config {
 	struct i2c_dt_spec i2c;
 	struct gpio_dt_spec host_int_gpio;
-	struct {
-		uint8_t pin;
-		gpio_flags_t flags;
-	} pmic_int_gpio;
+	struct mfd_npm10xx_gpio_config pmic_int_gpio;
+	struct mfd_npm10xx_gpio_config lp_reset_gpio;
+	uint8_t lp_reset_src;
+	uint8_t lp_reset_debounce;
+	uint8_t pwr_cycle_delay;
+	uint8_t wakeup_debounce;
+	bool wakeup_disable;
 };
 
 struct mfd_npm10xx_data {
@@ -444,13 +457,144 @@ int mfd_npm10xx_timer_status_get(const struct device *dev, bool *busy)
 	return 0;
 }
 
+static int mfd_npm10xx_gpio_configure(const struct i2c_dt_spec *i2c, uint8_t pin,
+				      gpio_flags_t flags)
+{
+	uint8_t pin_config;
+
+	if (pin > 2U) {
+		LOG_ERR("Pin index out of range [0,2]");
+		return -EINVAL;
+	}
+
+	pin_config = FIELD_PREP(GPIO_CONFIG_INPUT, !!(flags & GPIO_INPUT)) |
+		     FIELD_PREP(GPIO_CONFIG_OUTPUT, !!(flags & GPIO_OUTPUT)) |
+		     FIELD_PREP(GPIO_CONFIG_OPENDR, !!(flags & GPIO_OPEN_DRAIN)) |
+		     FIELD_PREP(GPIO_CONFIG_PULLUP, !!(flags & GPIO_PULL_UP)) |
+		     FIELD_PREP(GPIO_CONFIG_PULLDN, !!(flags & GPIO_PULL_DOWN)) |
+		     FIELD_PREP(GPIO_CONFIG_DRIVE, !!(flags & NPM10XX_GPIO_DRIVE_HIGH)) |
+		     FIELD_PREP(GPIO_CONFIG_DEBNC, !!(flags & NPM10XX_GPIO_DEBOUNCE_ON));
+
+	return i2c_reg_write_byte_dt(i2c, NPM10_GPIO_CONFIG + pin, pin_config);
+}
+
+static inline int mfd_npm10xx_longpress_cfg(const struct device *dev)
+{
+	const struct mfd_npm10xx_config *config = dev->config;
+	int ret;
+	uint8_t reg;
+
+	if (config->lp_reset_src == RESET_LONGPRESS_PINSEL_NONE) {
+		return 0;
+	}
+
+	if (config->lp_reset_src != RESET_LONGPRESS_PINSEL_SHPHLD) {
+		ret = mfd_npm10xx_gpio_configure(&config->i2c, config->lp_reset_gpio.pin,
+						 config->lp_reset_gpio.flags | GPIO_INPUT);
+		if (ret < 0) {
+			return ret;
+		}
+
+		reg = FIELD_PREP(GPIO_CTRL2_LP_MASK, config->lp_reset_gpio.pin + 1U) |
+		      FIELD_PREP(GPIO_CTRL2_LP_POL,
+				 !(config->lp_reset_gpio.flags & GPIO_ACTIVE_LOW));
+
+		ret = i2c_reg_update_byte_dt(&config->i2c, NPM10_GPIO_CTRL2,
+					     GPIO_CTRL2_LP_MASK | GPIO_CTRL2_LP_POL, reg);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	reg = FIELD_PREP(RESET_LONGPRESS_PINSEL_MASK, config->lp_reset_src) |
+	      FIELD_PREP(RESET_LONGPRESS_DEBOUNCE_MASK, config->lp_reset_debounce);
+
+	return i2c_reg_write_byte_dt(&config->i2c, NPM10_RESET_LONGPRESS, reg);
+}
+
+static inline int mfd_npm10xx_wakeup_cfg(const struct device *dev)
+{
+	const struct mfd_npm10xx_config *config = dev->config;
+	uint8_t reg;
+
+	if (!config->wakeup_disable && (config->wakeup_debounce == UINT8_MAX)) {
+		return 0;
+	}
+
+	reg = FIELD_PREP(RESET_SHPHLD_WAKEUP_NOPIN, config->wakeup_disable);
+
+	if (config->wakeup_debounce < UINT8_MAX) {
+		reg |= FIELD_PREP(RESET_SHPHLD_DEBOUNCE_MASK, config->wakeup_debounce);
+	}
+
+	return i2c_reg_write_byte_dt(&config->i2c, NPM10_RESET_SHPHLD, reg);
+}
+
+static inline int mfd_npm10xx_interrupt_cfg(const struct device *dev)
+{
+	const struct mfd_npm10xx_config *config = dev->config;
+	struct mfd_npm10xx_data *data = dev->data;
+	int ret;
+	uint8_t pin_usage;
+	uint8_t disable_all_buf[EVENTS_REG_NUM] = {0xFFU, 0xFFU, 0xFFU, 0xFFU, 0xFFU, 0xFFU, 0xFFU};
+
+	if (config->host_int_gpio.port == NULL) {
+		return 0;
+	}
+
+	if (!gpio_is_ready_dt(&config->host_int_gpio)) {
+		LOG_ERR("GPIO port used for interrupt input is not ready");
+		return -ENODEV;
+	}
+
+	/* disable all interrupts to avoid the situation where an interrupt is active
+	 * without a handler
+	 */
+	ret = i2c_burst_write_dt(&config->i2c, NPM10_EVENTS_INTEN_CLR, disable_all_buf,
+				 sizeof(disable_all_buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = mfd_npm10xx_gpio_configure(&config->i2c, config->pmic_int_gpio.pin,
+					 config->pmic_int_gpio.flags | GPIO_OUTPUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* interrupt output is active low by default, set "invert" bit otherwise */
+	pin_usage = GPIO_USAGE_IRQ |
+		    FIELD_PREP(GPIO_USAGE_INV, !(config->pmic_int_gpio.flags & GPIO_ACTIVE_LOW));
+
+	ret = i2c_reg_write_byte_dt(&config->i2c, NPM10_GPIO_USAGE + config->pmic_int_gpio.pin,
+				    pin_usage);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = gpio_pin_configure_dt(&config->host_int_gpio, GPIO_INPUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_work_init(&data->work, events_handler);
+
+	gpio_init_callback(&data->gpio_cb, pmic_int_handler, BIT(config->host_int_gpio.pin));
+
+	ret = gpio_add_callback(config->host_int_gpio.port, &data->gpio_cb);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return gpio_pin_interrupt_configure_dt(&config->host_int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+}
+
 static int mfd_npm10xx_init(const struct device *dev)
 {
 	const struct mfd_npm10xx_config *config = dev->config;
 	struct mfd_npm10xx_data *data = dev->data;
 	int ret;
-	uint8_t pin_config, pin_usage;
-	uint8_t disable_all_buf[EVENTS_REG_NUM] = {0xFFU, 0xFFU, 0xFFU, 0xFFU, 0xFFU, 0xFFU, 0xFFU};
+	uint8_t reg;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
 		LOG_ERR("I2C bus is not ready");
@@ -470,69 +614,26 @@ static int mfd_npm10xx_init(const struct device *dev)
 		LOG_ERR("Failed to initialize mutex");
 	}
 
-	if (config->host_int_gpio.port != NULL) {
-		if (!gpio_is_ready_dt(&config->host_int_gpio)) {
-			LOG_ERR("GPIO port used for interrupt input is not ready");
-			return -ENODEV;
-		}
+	ret = mfd_npm10xx_longpress_cfg(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
-		/* disable all interrupts to avoid the situation where an interrupt is active
-		 * without a handler
-		 */
-		ret = i2c_burst_write_dt(&config->i2c, NPM10_EVENTS_INTEN_CLR, disable_all_buf,
-					 sizeof(disable_all_buf));
-		if (ret < 0) {
-			return ret;
-		}
+	ret = mfd_npm10xx_wakeup_cfg(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
-		pin_config = GPIO_CONFIG_OUTPUT |
-			     FIELD_PREP(GPIO_CONFIG_OPENDR,
-					!!(config->pmic_int_gpio.flags & GPIO_OPEN_DRAIN)) |
-			     FIELD_PREP(GPIO_CONFIG_PULLUP,
-					!!(config->pmic_int_gpio.flags & GPIO_PULL_UP)) |
-			     FIELD_PREP(GPIO_CONFIG_PULLDN,
-					!!(config->pmic_int_gpio.flags & GPIO_PULL_DOWN));
+	if (config->pwr_cycle_delay < UINT8_MAX) {
+		reg = FIELD_PREP(RESET_CONFIG_PWRWAIT_MASK, config->pwr_cycle_delay);
 
-		/* interrupt output is active low by default, set "invert" bit otherwise */
-		pin_usage = GPIO_USAGE_IRQ |
-			    FIELD_PREP(GPIO_USAGE_INV,
-				       !(config->pmic_int_gpio.flags & GPIO_ACTIVE_LOW));
-
-		ret = i2c_reg_write_byte_dt(
-			&config->i2c, NPM10_GPIO_CONFIG + config->pmic_int_gpio.pin, pin_config);
-		if (ret < 0) {
-			return ret;
-		}
-
-		ret = i2c_reg_write_byte_dt(
-			&config->i2c, NPM10_GPIO_USAGE + config->pmic_int_gpio.pin, pin_usage);
-		if (ret < 0) {
-			return ret;
-		}
-
-		ret = gpio_pin_configure_dt(&config->host_int_gpio, GPIO_INPUT);
-		if (ret < 0) {
-			return ret;
-		}
-
-		k_work_init(&data->work, events_handler);
-
-		gpio_init_callback(&data->gpio_cb, pmic_int_handler,
-				   BIT(config->host_int_gpio.pin));
-
-		ret = gpio_add_callback(config->host_int_gpio.port, &data->gpio_cb);
-		if (ret < 0) {
-			return ret;
-		}
-
-		ret = gpio_pin_interrupt_configure_dt(&config->host_int_gpio,
-						      GPIO_INT_EDGE_TO_ACTIVE);
+		ret = i2c_reg_write_byte_dt(&config->i2c, NPM10_RESET_CONFIG, reg);
 		if (ret < 0) {
 			return ret;
 		}
 	}
 
-	return 0;
+	return mfd_npm10xx_interrupt_cfg(dev);
 }
 
 #define MFD_NPM10XX_DEFINE(n)                                                                      \
@@ -543,12 +644,28 @@ static int mfd_npm10xx_init(const struct device *dev)
 	BUILD_ASSERT(COND_CODE_1(DT_INST_NODE_HAS_PROP(n, pmic_int_gpio_config),                   \
 				 (DT_INST_PROP_BY_IDX(n, pmic_int_gpio_config, 0)),                \
 				 (0)) < 3,                                                         \
-		     "PMIC output interrupt pin index out of range");                              \
+		     "pmic-int-gpio-config pin index out of range");                               \
+                                                                                                   \
+	BUILD_ASSERT(COND_CODE_1(DT_INST_NODE_HAS_PROP(n, longpress_reset_gpio_config),            \
+				 (DT_INST_PROP_BY_IDX(n, longpress_reset_gpio_config, 0)),         \
+				 (0)) < 3,                                                         \
+		     "longpress-reset-gpio-config pin index out of range");                        \
+                                                                                                   \
+	BUILD_ASSERT(DT_INST_ENUM_IDX_OR(n, longpress_reset_source, 0) % 2 ==                      \
+			     DT_INST_NODE_HAS_PROP(n, longpress_reset_gpio_config),                \
+		     "longpress-reset-source 'gpio' and 'both' require a "                         \
+		     "longpress-reset-gpio-config to be provided");                                \
                                                                                                    \
 	static const struct mfd_npm10xx_config mfd_config##n = {                                   \
 		.i2c = I2C_DT_SPEC_INST_GET(n),                                                    \
 		.host_int_gpio = GPIO_DT_SPEC_INST_GET_OR(n, host_int_gpios, {0}),                 \
 		.pmic_int_gpio = DT_INST_PROP_OR(n, pmic_int_gpio_config, {UINT8_MAX}),            \
+		.lp_reset_gpio = DT_INST_PROP_OR(n, longpress_reset_gpio_config, {UINT8_MAX}),     \
+		.lp_reset_src = DT_INST_ENUM_IDX(n, longpress_reset_source),                       \
+		.lp_reset_debounce = DT_INST_ENUM_IDX(n, longpress_reset_debounce_s),              \
+		.pwr_cycle_delay = DT_INST_ENUM_IDX_OR(n, pwr_cycle_delay_ms, UINT8_MAX),          \
+		.wakeup_debounce = DT_INST_ENUM_IDX_OR(n, shphld_wakeup_debounce_ms, UINT8_MAX),   \
+		.wakeup_disable = DT_INST_PROP(n, shphld_wakeup_disable),                          \
 	};                                                                                         \
                                                                                                    \
 	static struct mfd_npm10xx_data mfd_data##n;                                                \

--- a/dts/bindings/mfd/nordic,npm10xx.yaml
+++ b/dts/bindings/mfd/nordic,npm10xx.yaml
@@ -19,6 +19,61 @@ properties:
       PMIC GPIO config for interrupt output <idx flags>. Index is 0 to 2. Use flags to provide
       additional configuration, for example, GPIO_OPEN_DRAIN.
 
+  pwr-cycle-delay-ms:
+    type: int
+    enum:
+      - 350
+      - 250
+      - 150
+      - 50
+    description: Length of the PMIC power cycle in milliseconds.
+
+  longpress-reset-source:
+    type: string
+    default: "none"
+    enum:
+      - "none"
+      - "gpio"
+      - "shphld"
+      - "both"
+    description: |
+      Select long press reset source for the PMIC. Choose one of the following:
+        none - no reset source, hardware's default
+        gpio - reset button connected to GPIO, choose GPIO number using longpress-reset-gpio
+        shphld - reset button connected to SHPHLD pin
+        both - reset button connected to both SHPHLD and GPIO pins, choose GPIO number
+
+  longpress-reset-gpio-config:
+    type: array
+    description: |
+      GPIO pin config <idx flags> to use for long press reset in combination with "gpio" or "both"
+      reset source.
+
+  longpress-reset-debounce-s:
+    type: int
+    default: 3
+    enum:
+      - 3
+      - 5
+      - 10
+      - 20
+    description: |
+      Duration in seconds the reset button(s) need to be pressed to issue a reset. Defaults to the
+      hardware reset value.
+
+  shphld-wakeup-disable:
+    type: boolean
+    description: Disable the wake up from hibernation functionality of the SHPHLD pin.
+
+  shphld-wakeup-debounce-ms:
+    type: int
+    enum:
+      - 50
+      - 100
+      - 500
+      - 1000
+    description: SHPHLD pin wake up debounce in milliseconds.
+
 examples:
   - |
     npm1012: pmic@6a {


### PR DESCRIPTION
Add "long press" reset and SHPHLD wake-up configurations to the nPM10 Series MFD driver's Devicetree properties.