### PR TITLE
arch: arm: cortex_m: fix PendSV clobbering _main in arch_switch_to_main_thread

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -610,17 +610,22 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 	 * Set PSP to the highest address of the main stack
 	 * before enabling interrupts and jumping to main.
 	 *
-	 * The compiler may store _main on the stack, but this
-	 * location is relative to `PSP`.
-	 * This assembly block ensures that _main is stored in
-	 * a callee saved register before switching stack and continuing
-	 * with the thread entry process.
+	 * _main is saved on MSP (the interrupt stack) across the
+	 * arch_irq_unlock_outlined call rather than held in a
+	 * callee-saved register.  Enabling interrupts may let a
+	 * pending timer IRQ fire immediately; if z_arm_exc_exit
+	 * then pends PendSV, the context-switch handler’s
+	 * stmia/ldmia of r4-r11 will overwrite any callee-saved
+	 * register with the (uninitialised) target thread’s save
+	 * area — typically zero, causing z_thread_entry(NULL).
+	 * MSP contents are not touched by PendSV so the push/pop
+	 * is safe across this window.
 	 *
 	 * When calling arch_irq_unlock_outlined, LR is lost which is fine since
 	 * we do not intend to return after calling z_thread_entry.
 	 */
-	__asm__ volatile("mov   r4,  %0\n" /* force _main to be stored in a register */
-			 "msr   PSP, %1\n" /* __set_PSP(stack_ptr) */
+	__asm__ volatile("msr   PSP, %1\n" /* __set_PSP(stack_ptr) */
+			 "push  {%0}\n"    /* save _main on MSP */
 
 			 "movs  r0,  #0\n" /* arch_irq_unlock(0) */
 #ifdef CONFIG_SLOW_FLASH_DATA
@@ -631,8 +636,8 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 #endif
 			 "blx   r3\n"
 
-			 "mov   r0, r4\n" /* z_thread_entry(_main, NULL, NULL, NULL) */
-			 "movs  r1, #0\n"
+			 "pop   {r0}\n"    /* restore _main */
+			 "movs  r1, #0\n"  /* z_thread_entry(_main, 0, 0, 0) */
 			 "movs  r2, #0\n"
 			 "movs  r3, #0\n"
 #ifdef CONFIG_SLOW_FLASH_DATA


### PR DESCRIPTION
## Summary

`arch_switch_to_main_thread()` stores `_main` in r4 (callee-saved) before
calling `arch_irq_unlock_outlined()`, which enables interrupts for the first
time during boot. If a timer interrupt is already pending it fires immediately;
`z_arm_exc_exit()` may then pend PendSV, whose `stmia`/`ldmia` of r4-r11
overwrites r4 with the uninitialised target thread's save area (typically zero).
The subsequent `mov r0, r4` passes NULL to `z_thread_entry()`, causing a fatal
fault.

The bug is latent on every Cortex-M board but only manifests when the timing
window between `cpsie` and `mov r0, r4` is hit. Boards whose system timer fires
quickly enough after the first `irq_unlock` reproduce it reliably — we hit it
100% of the time on the nRF54L15 (ISP2454 SiP) whose GRTC fires within a few
cycles of interrupt enable.

## Fix

Push `_main` onto MSP (the interrupt stack) before `arch_irq_unlock_outlined()`
and pop it into r0 afterwards. PendSV only saves/restores r4-r11 to the thread's
callee-saved area and never touches MSP contents, so the push/pop is safe across
this window.

## Reproducer (nRF54L15-DK, NCS v2.9.0)

The bug reproduces 100% on the **nRF54L15-DK** (PCA10156) with the unmodified
`samples/hello_world` sample — no custom board or config required.

> **Note on upstream main**: The identical vulnerable assembly pattern
> (`mov r4,r5` / `blx r3` / `mov r0,r4`) is present in upstream Zephyr main
> (4.4.99), but does **not** trigger reliably on the same hardware. We tested
> 10 consecutive resets of an upstream-main build on the same DK — all booted
> normally. The race window exists in the code, but the timing differs between
> NCS v2.9.0 (Zephyr 3.7.99) and upstream main (Zephyr 4.4.99), likely due to
> differences in SRAM layout (188 KB vs 256 KB), GRTC timer initialisation, or
> kernel scheduler internals. The crash is 100% reproducible on NCS v2.9.0,
> which shares this code path.

### Build & flash (NCS v2.9.0)

```bash
west build -b nrf54l15dk/nrf54l15/cpuapp zephyr/samples/hello_world \
  -- -DCONFIG_SERIAL=n -DCONFIG_UART_CONSOLE=n \
     -DCONFIG_RTT_CONSOLE=y -DCONFIG_USE_SEGGER_RTT=y -DCONFIG_CONSOLE=y
west flash
```

### Without this patch — UsageFault every boot

Halting the core after reset shows the device stuck in `arch_system_halt`
(fatal.c:30) with **IPSR = 0x006 (UsageFault)**:

```
PC = 00004918       ← arch_system_halt (b.n self-loop)
XPSR = 29000006     ← IPSR = 6 = UsageFault
```

The exception frame on PSP confirms `z_thread_entry` was called with
`_main = NULL`:

```
PSP+0x00  R0  = 0x00000000   ← _main (should be non-zero)
PSP+0x18  PC  = 0x00000000   ← blx r4 jumped to NULL
PSP+0x1C  xPSR= 0x08000000
```

Disassembly of `z_thread_entry`:
```
000042b2 <z_thread_entry>:
  42b2:  mov   r4, r0        ← r0 is NULL (PendSV clobbered it)
  ...
  42bc:  blx   r4            ← jump to address 0x00000000 → UsageFault
```

The RTT buffer is **empty** — the crash happens before any output is produced.

### With this patch — boots normally

```
PC = 000044B0       ← __WFE (idle loop)
XPSR = 41000000     ← IPSR = 0 = NoException
```

RTT buffer contains:
```
*** Booting nRF Connect SDK v2.9.0-7787b2649840 ***
*** Using Zephyr OS v3.7.99-1f8f3dc29142 ***
Hello World! nrf54l15dk/nrf54l15/cpuapp
```

## Test plan

- [x] Verified fix on nRF54L15-DK (PCA10156) with stock `samples/hello_world` — crash 100% without patch, boots cleanly with patch (NCS v2.9.0)
- [x] Verified fix on nRF54L15 (ISP2454 SiP) — custom board, same result
- [x] Tested both secure-only and TF-M/NS builds
- [x] Confirmed upstream Zephyr main has same vulnerable pattern but different timing — 0/10 crash on same DK
- [x] `checkpatch.pl` passes on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)