### PR TITLE
soc: espressif: fix build missing references in SPI and cache tests 

### DIFF
--- a/drivers/cache/cache_esp32.c
+++ b/drivers/cache/cache_esp32.c
@@ -26,6 +26,21 @@ void cache_data_disable(void)
 	/* Not supported */
 }
 
+int cache_data_flush_all(void)
+{
+	return -ENOTSUP;
+}
+
+int cache_data_invd_all(void)
+{
+	return -ENOTSUP;
+}
+
+int cache_data_flush_and_invd_all(void)
+{
+	return -ENOTSUP;
+}
+
 int cache_data_flush_range(void *addr, size_t size)
 {
 	esp_err_t ret;

--- a/soc/espressif/esp32c5/Kconfig.defconfig
+++ b/soc/espressif/esp32c5/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if SOC_SERIES_ESP32C5
 
 configdefault CACHE_MANAGEMENT
-	default y if ESP_SPIRAM
+	default y
 
 choice CACHE_TYPE
 	default EXTERNAL_CACHE if CACHE_MANAGEMENT

--- a/soc/espressif/esp32s2/Kconfig.defconfig
+++ b/soc/espressif/esp32s2/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if SOC_SERIES_ESP32S2
 
 configdefault CACHE_MANAGEMENT
-	default y if ESP_SPIRAM
+	default y
 
 choice CACHE_TYPE
 	default EXTERNAL_CACHE if CACHE_MANAGEMENT

--- a/soc/espressif/esp32s3/Kconfig.defconfig
+++ b/soc/espressif/esp32s3/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if SOC_SERIES_ESP32S3
 
 configdefault CACHE_MANAGEMENT
-	default y if ESP_SPIRAM
+	default y
 
 choice CACHE_TYPE
 	default EXTERNAL_CACHE if CACHE_MANAGEMENT

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 2a5bec22444196328e262561e9dd7b2ea1a21b20
+      revision: 7f2e2f94ac76c7161c94d26b9806020c2de40389
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Fix undefined references in SPI and cache build tests/samples:

tests/drivers/build_all/eeprom on esp32c5_devkitc
tests/drivers/build_all/gpio   on esp32c6_devkitc
tests/drivers/spi/spi_loopback on esp32h2_devkitm
tests/kernel/cache on esp32s2_devkitc
tests/kernel/cache on esp32s3_devkitc/procpu
