### PR TITLE
dts: arm: renesas: ra: Correct max-bitrate-supported for iic1 on RA6M5

### DIFF
--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -822,3 +822,7 @@
 &dac_global {
 	has-output-amplifier;
 };
+
+&iic1 {
+	max-bitrate-supported = <I2C_BITRATE_FAST_PLUS>;
+};

--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -188,6 +188,7 @@
 			channel = <0>;
 			reg = <0x4009f000 0x100>;
 			clocks = <&pclkb MSTPB 9>;
+			max-bitrate-supported = <I2C_BITRATE_FAST_PLUS>;
 			status = "disabled";
 		};
 

--- a/west.yml
+++ b/west.yml
@@ -234,7 +234,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: b994af098811b0ea02d5388efeefd0ac54f082e3
+      revision: 29d0d3b9c7f9e3929839c74a6cb10c487c24994f
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Correct `max-bitrate-supported` for `iic1` on Renesas RA6M5

Solve: #109556 