### PR TITLE
samples: input: input_dump: add frdm_imxrt1186 board support

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -28,4 +28,5 @@ supported:
   - i2c
   - watchdog
   - pwm
+  - kpp
 vendor: nxp

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
@@ -24,4 +24,5 @@ supported:
   - i2c
   - watchdog
   - pwm
+  - kpp
 vendor: nxp

--- a/samples/subsys/input/input_dump/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/samples/subsys/input/input_dump/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * External 2x2 keypad wiring on FRDM-IMXRT1186 Arduino headers:
+ *
+ *   Keypad term    SoC pin         Arduino socket    KPP signal
+ *   -----------    -------------   --------------    ----------
+ *   R1             GPIO_EMC_B1_14  J1-10             KPP_ROW0
+ *   R2             GPIO_AD_16      J51-4             KPP_ROW5
+ *   C1             GPIO_EMC_B1_15  J1-12             KPP_COL0
+ *   C2             GPIO_AD_17      J51-6             KPP_COL5
+ *
+ * Required jumper settings (default is ECAT route, switch to Arduino):
+ *   J28 = 2-3  (route GPIO_AD_16 to Arduino J51-4)
+ *   J32 = 2-3  (route GPIO_AD_17 to Arduino J51-6)
+ */
+
+/ {
+	aliases {
+		kpp = &kpp;
+	};
+};
+
+&pinctrl {
+	kpp_default: kpp_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_16_kpp_row5>,
+				 <&iomuxc_gpio_emc_b1_14_kpp_row0>,
+				 <&iomuxc_gpio_ad_17_kpp_col5>,
+				 <&iomuxc_gpio_emc_b1_15_kpp_col0>;
+			drive-strength = "high";
+			bias-pull-up;
+			slew-rate = "fast";
+		};
+	};
+};
+
+&kpp {
+	pinctrl-0 = <&kpp_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/samples/subsys/input/input_dump/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/samples/subsys/input/input_dump/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * External 2x2 keypad wiring on FRDM-IMXRT1186 Arduino headers:
+ *
+ *   Keypad term    SoC pin         Arduino socket    KPP signal
+ *   -----------    -------------   --------------    ----------
+ *   R1             GPIO_EMC_B1_14  J1-10             KPP_ROW0
+ *   R2             GPIO_AD_16      J51-4             KPP_ROW5
+ *   C1             GPIO_EMC_B1_15  J1-12             KPP_COL0
+ *   C2             GPIO_AD_17      J51-6             KPP_COL5
+ *
+ * Required jumper settings (default is ECAT route, switch to Arduino):
+ *   J28 = 2-3  (route GPIO_AD_16 to Arduino J51-4)
+ *   J32 = 2-3  (route GPIO_AD_17 to Arduino J51-6)
+ */
+
+/ {
+	aliases {
+		kpp = &kpp;
+	};
+};
+
+&pinctrl {
+	kpp_default: kpp_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_16_kpp_row5>,
+				 <&iomuxc_gpio_emc_b1_14_kpp_row0>,
+				 <&iomuxc_gpio_ad_17_kpp_col5>,
+				 <&iomuxc_gpio_emc_b1_15_kpp_col0>;
+			drive-strength = "high";
+			bias-pull-up;
+			slew-rate = "fast";
+		};
+	};
+};
+
+&kpp {
+	pinctrl-0 = <&kpp_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};


### PR DESCRIPTION
- Add overlay enabling the KPP controller for an external 2x2 keypad wired to the Arduino headers. The overlay header documents pin wiring and J28/J32 jumper position. 
- Declare the kpp capability in both core variants' YAML.
- Remove the redundant configurations from the mimxrt1180-evk
