### PR TITLE
net: coap/lwm2m: Fix uninitialized variables

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -893,8 +893,8 @@ static int sm_send_registration(bool send_obj_support_data,
 {
 	struct lwm2m_message *msg;
 	int ret;
-	char binding[CLIENT_BINDING_LEN];
-	char queue[CLIENT_QUEUE_LEN];
+	char binding[CLIENT_BINDING_LEN] = { 0 };
+	char queue[CLIENT_QUEUE_LEN] = { 0 };
 
 	msg = rd_get_message();
 	if (!msg) {

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -2008,7 +2008,7 @@ ZTEST(coap, test_response_matching)
 		struct coap_packet response_pkt = { 0 };
 		struct net_sockaddr from = { 0 };
 		struct coap_reply *match;
-		uint8_t data[64];
+		uint8_t data[64] = { 0 };
 		int ret;
 
 		ret = coap_packet_init(&response_pkt, data, sizeof(data), COAP_VERSION_1,

--- a/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
+++ b/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
@@ -247,7 +247,7 @@ ZTEST(lwm2m_registry, test_temp_sensor)
 	uint8_t u8_buf = 0;
 	time_t time_buf = 0;
 	double dbl_buf = 0;
-	char char_buf[10];
+	char char_buf[10] = { 0 };
 
 	uint8_t u8_getbuf = 0;
 	time_t time_getbuf = 0;


### PR DESCRIPTION
Fix further issues reported by Valgrind, this time in CoAP/LwM2M area.