### PR TITLE
arch: arm: core: mpu: simplify predicate for MPU variant selection

### DIFF
--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -62,21 +62,10 @@ BUILD_ASSERT((DT_FOREACH_STATUS_OKAY_NODE_VARGS(
 static uint8_t static_regions_num;
 
 /* Include architecture-specific internal headers. */
-#if defined(CONFIG_CPU_CORTEX_M0PLUS) || \
-	defined(CONFIG_CPU_CORTEX_M3) || \
-	defined(CONFIG_CPU_CORTEX_M4) || \
-	defined(CONFIG_CPU_CORTEX_M7) || \
-	defined(CONFIG_ARMV7_R)
-#include "arm_mpu_v7_internal.h"
-#elif defined(CONFIG_CPU_CORTEX_M23) || \
-	defined(CONFIG_CPU_CORTEX_M33) || \
-	defined(CONFIG_CPU_CORTEX_M52) || \
-	defined(CONFIG_CPU_CORTEX_M55) || \
-	defined(CONFIG_CPU_CORTEX_M85) || \
-	defined(CONFIG_AARCH32_ARMV8_R)
+#if Z_ARM_CPU_HAS_PMSAV8_MPU
 #include "arm_mpu_v8_internal.h"
 #else
-#error "Unsupported ARM CPU"
+#include "arm_mpu_v7_internal.h"
 #endif
 
 static int region_allocate_and_init(const uint8_t index,

--- a/arch/arm/core/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v8_internal.h
@@ -31,9 +31,7 @@ struct dynamic_region_info {
  * regions may be configured.
  */
 static struct dynamic_region_info dyn_reg_info[MPU_DYNAMIC_REGION_AREAS_NUM];
-#if defined(CONFIG_CPU_CORTEX_M23) || defined(CONFIG_CPU_CORTEX_M33) || \
-	defined(CONFIG_CPU_CORTEX_M52) || defined(CONFIG_CPU_CORTEX_M55) || \
-	defined(CONFIG_CPU_CORTEX_M85)
+#if !defined(CONFIG_AARCH32_ARMV8_R)
 static inline void mpu_set_mair0(uint32_t mair0)
 {
 	MPU->MAIR0 = mair0;
@@ -77,8 +75,7 @@ static inline void mpu_clear_region(uint32_t rnr)
 {
 	ARM_MPU_ClrRegion(rnr);
 }
-
-#elif defined(CONFIG_AARCH32_ARMV8_R)
+#else
 static inline void mpu_set_mair0(uint32_t mair0)
 {
 	write_mair0(mair0);
@@ -131,9 +128,6 @@ static inline void mpu_clear_region(uint32_t rnr)
 	mpu_set_rbar(0);
 	mpu_set_rlar(0);
 }
-
-#else
-#error "Unsupported ARM CPU"
 #endif
 
 /* Global MPU configuration at system initialization. */

--- a/include/zephyr/arch/arm/mpu/arm_mpu.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu.h
@@ -6,23 +6,15 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_H_
 
-#if defined(CONFIG_CPU_CORTEX_M0PLUS) || defined(CONFIG_CPU_CORTEX_M3) ||                          \
-	defined(CONFIG_CPU_CORTEX_M4) || defined(CONFIG_CPU_CORTEX_M7) || defined(CONFIG_ARMV7_R)
-#include <zephyr/arch/arm/mpu/arm_mpu_v7m.h>
-#elif defined(CONFIG_CPU_CORTEX_M23) || defined(CONFIG_CPU_CORTEX_M33) ||                          \
-	defined(CONFIG_CPU_CORTEX_M52) || defined(CONFIG_CPU_CORTEX_M55) ||                        \
-	defined(CONFIG_CPU_CORTEX_M85) || defined(CONFIG_AARCH32_ARMV8_R)
-#include <zephyr/arch/arm/mpu/arm_mpu_v8.h>
-#else
-#error "Unsupported ARM CPU"
-#endif
-
-#if defined(CONFIG_ARMV8_M_MAINLINE) || defined(CONFIG_ARMV8_M_BASELINE)
+#if defined(CONFIG_ARMV8_M_MAINLINE) || defined(CONFIG_ARMV8_M_BASELINE) ||                        \
+	defined(CONFIG_AARCH32_ARMV8_R)
 /* PMSAv8 MPU */
 #define Z_ARM_CPU_HAS_PMSAV8_MPU 1
+#include <zephyr/arch/arm/mpu/arm_mpu_v8.h>
 #else
 /* PMSAv6 / PMSAv7 (MPU is identical) */
 #define Z_ARM_CPU_HAS_PMSAV8_MPU 0
+#include <zephyr/arch/arm/mpu/arm_mpu_v7m.h>
 #endif
 
 #if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE) || defined(CONFIG_ARMV8_M_MAINLINE)


### PR DESCRIPTION
We already determine whether the target is PMSAv8 or (PMSAv6/PMSAv7) using the selected architecture profile (ARMv6-M/ARMv7-M or ARMv8-M Baseline/Mainline) and define a symbol accordingly. Make use of that symbol everywhere instead of repeating CPU checks all over arch code.

However, keep around the allowlist which generates a build error when the MPU is enabled on an "unknown" CPU as it ensures that all CPUs on which the MPU can be used have been tested.