### PR TITLE
dts: vendor: nordic: Disable usbhs_wrapper in .dtsi

### DIFF
--- a/boards/nordic/nrf54lm20dk/nrf54lm20_a_b_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20_a_b_cpuapp_common.dtsi
@@ -110,6 +110,10 @@ temp_sensor: &temp {
 	status = "okay";
 };
 
+&usbhs_wrapper {
+	status = "okay";
+};
+
 zephyr_udc0: &usbhs {
 	status = "okay";
 };

--- a/dts/vendor/nordic/nrf54lm20_a_b.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b.dtsi
@@ -242,6 +242,7 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 				regulator = <&vregusb>;
+				status = "disabled";
 
 				usbhs: usbhs@20000 {
 					compatible = "nordic,nrf-usbhs-nrf54l", "snps,dwc2";


### PR DESCRIPTION
Set the status for usbhs_wrapper to disabled to avoid having to explicitly disable it for boards that do not use it. The node is enabled in nrf54lm20dk to keep it as before.