### PR TITLE
Expose the input_kbd_matrix_active function and use it in the bee driver

### DIFF
--- a/drivers/input/input_bee_keyscan.c
+++ b/drivers/input/input_bee_keyscan.c
@@ -156,19 +156,6 @@ static void manual_keyscan_timer_cb(struct k_timer *timer)
 
 	bee_keyscan_init_driver(dev, KeyScan_Manual_Scan_Mode, KeyScan_Manual_Sel_Bit);
 }
-
-static bool
-bee_keyscan_all_released_and_debounced(const struct input_kbd_matrix_common_config *config)
-{
-	for (int c = 0; c < config->col_size; c++) {
-		if (config->matrix_unstable_state[c] != 0 || config->matrix_stable_state[c] != 0) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 #endif
 
 static void bee_keyscan_process_matrix(const struct device *dev, uint8_t new_press_num,
@@ -206,7 +193,7 @@ static void bee_keyscan_process_matrix(const struct device *dev, uint8_t new_pre
 	input_kbd_matrix_update_state(dev);
 
 #ifndef CONFIG_BEE_INPUT_KEYSCAN_AUTOSCAN_MODE
-	if (new_press_num == 0 && bee_keyscan_all_released_and_debounced(cfg_common)) {
+	if (new_press_num == 0 && !input_kbd_matrix_active(dev)) {
 		k_timer_stop(&manual_keyscan_timer);
 		(void)clock_control_off(BEE_CLOCK_CONTROLLER,
 					(clock_control_subsys_t)&config->clkid);

--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -246,7 +246,7 @@ static void input_kbd_matrix_check_key_events(const struct device *dev)
 	input_kbd_matrix_update_state(dev);
 }
 
-static bool input_kbd_matrix_active(const struct device *dev)
+bool input_kbd_matrix_active(const struct device *dev)
 {
 	const struct input_kbd_matrix_common_config *cfg = dev->config;
 

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -354,6 +354,19 @@ bool input_kbd_matrix_ghosting(const struct device *dev);
  */
 void input_kbd_matrix_update_state(const struct device *dev);
 
+/**
+ * @brief Returns true if the matrix is considered active.
+ *
+ * Returns true if the matrix is considered active, that is if either a key is
+ * pressed or waiting to be debounced or released.
+ *
+ * @param dev Keyboard matrix device instance.
+ *
+ * @retval true  The matrix is a active.
+ * @retval false The matrix is idle, all keys have been released.
+ */
+bool input_kbd_matrix_active(const struct device *dev);
+
 /** @} */
 
 #endif /* ZEPHYR_INCLUDE_INPUT_KBD_MATRIX_H_ */


### PR DESCRIPTION
Expose the new input_kbd_matrix_active function and use it in the bee driver, the implementation checks for matrix_new_state as well which the current bee function doesn't but I believe that is the right thing to do, I'd imagine the condition were this would differ is with the right timing the current code could go to detect and then immediately back to scanning, while the new one would just keep scanning.