### PR TITLE
drivers: wifi: esp32: add task stack-size kconfig

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -310,6 +310,15 @@ config ESP32_WIFI_MAX_THREAD_PRIORITY
 	help
 	  Maximum priority of thread used for processing driver work queue items.
 
+config ESP32_WIFI_TASK_STACK_SIZE
+	int "Wi-Fi task stack size (floor)"
+	default 3584
+	help
+	  Minimum stack size for the Wi-Fi tasks spawned by the Wi-Fi
+	  library blobs. The actual stack used is the larger of this value
+	  and the stack depth requested by the blob at runtime, so a higher
+	  Kconfig value only raises the floor.
+
 config ESP32_WIFI_SLP_DEFAULT_MIN_ACTIVE_TIME
 	int "Minimum active time"
 	range 8 60

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 7f2e2f94ac76c7161c94d26b9806020c2de40389
+      revision: e317fb14bf61a772161b3c2913451b96e751d6dc
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Add ESP32_WIFI_TASK_STACK_SIZE to control the stack size used by the Wi-Fi tasks spawned through the blobs. The adapter applies the value as a floor: when the Wi-Fi library passes a larger stack, at runtime, the larger value wins, so a higher Kconfig only raises the minimum and never shrinks the request.