### PR TITLE
drivers: mdio: mdio_nxp_enet: nxp_enet_mdio_wait_xfer: Returns success on timeout

### DIFF
--- a/drivers/ethernet/mdio/mdio_nxp_enet.c
+++ b/drivers/ethernet/mdio/mdio_nxp_enet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 NXP
+ * Copyright 2023-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,8 +35,8 @@ struct nxp_enet_mdio_data {
  * This function is used for both read and write operations
  * in order to wait for the completion of an MDIO transaction.
  * It returns -ETIMEDOUT if timeout occurs as specified in DT,
- * otherwise returns 0 if EIR MII bit is set indicting completed
- * operation, otherwise -EIO.
+ * -EWOULDBLOCK if called from ISR context where blocking is
+ * not possible, or 0 on success.
  */
 static int nxp_enet_mdio_wait_xfer(const struct device *dev)
 {
@@ -54,7 +54,11 @@ static int nxp_enet_mdio_wait_xfer(const struct device *dev)
 	}
 
 	/* Wait for the MDIO transaction to finish or time out */
-	k_sem_take(&data->mdio_sem, K_USEC(CONFIG_MDIO_NXP_ENET_TIMEOUT));
+	int result = k_sem_take(&data->mdio_sem, K_USEC(CONFIG_MDIO_NXP_ENET_TIMEOUT));
+
+	if (result == -EAGAIN) {
+		return -ETIMEDOUT;
+	}
 
 	return 0;
 }

--- a/drivers/ethernet/mdio/mdio_nxp_enet.c
+++ b/drivers/ethernet/mdio/mdio_nxp_enet.c
@@ -78,6 +78,9 @@ static int mdio_transfer(const struct device *dev, uint8_t prtad, uint8_t regad,
 	 */
 	data->base->EIR = ENET_EIR_MII_MASK;
 
+	/* Reset semaphore to discard any stale k_sem_give from a previous timed-out transfer */
+	k_sem_reset(&data->mdio_sem);
+
 	/*
 	 * Write MDIO frame to MII management register which will
 	 * send the command and data out to the MDIO bus as this frame:


### PR DESCRIPTION
This fixes issue #99905, by catching and propagating the returned value from k_sem_take().

Additionally, also implements the proposed improvement to reset the semaphore before each MDIO transfer.