### PR TITLE
debug: thread_analyzer: Use fixed size format for stack sizes and %

### DIFF
--- a/subsys/debug/thread_analyzer/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer/thread_analyzer.c
@@ -49,7 +49,7 @@ static void thread_print_cb(struct thread_analyzer_info *info)
 #ifdef CONFIG_THREAD_RUNTIME_STATS
 	THREAD_ANALYZER_PRINT(
 		THREAD_ANALYZER_FMT(
-			" %-20s: STACK: unused %zu usage %zu / %zu (%zu %%); CPU: %u %%"),
+			" %-20s: STACK: unused %4zu usage %4zu / %4zu (%3zu %%); CPU: %3u %%"),
 		THREAD_ANALYZER_VSTR(info->name),
 		info->stack_size - info->stack_used, info->stack_used,
 		info->stack_size, pcnt,
@@ -61,7 +61,7 @@ static void thread_print_cb(struct thread_analyzer_info *info)
 
 		THREAD_ANALYZER_PRINT(
 			THREAD_ANALYZER_FMT(
-				" %-20s: PRIV_STACK: unused %zu usage %zu / %zu (%zu %%)"),
+				" %-20s: PRIV_STACK: unused %4zu usage %4zu / %4zu (%3zu %%)"),
 			" ", info->priv_stack_size - info->priv_stack_used, info->priv_stack_used,
 			info->priv_stack_size, pcnt);
 	}
@@ -84,7 +84,7 @@ static void thread_print_cb(struct thread_analyzer_info *info)
 #else
 	THREAD_ANALYZER_PRINT(
 		THREAD_ANALYZER_FMT(
-			" %-20s: unused %zu usage %zu / %zu (%zu %%)"),
+			" %-20s: unused %4zu usage %4zu / %4zu (%3zu %%)"),
 		THREAD_ANALYZER_VSTR(info->name),
 		info->stack_size - info->stack_used, info->stack_used,
 		info->stack_size, pcnt);

--- a/tests/subsys/debug/thread_analyzer/testcase.yaml
+++ b/tests/subsys/debug/thread_analyzer/testcase.yaml
@@ -25,8 +25,8 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
-        - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"
+        - "(.*)ISR0([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"
   debug.thread_analyzer.printk.stack_safety:
     extra_configs:
       - CONFIG_THREAD_ANALYZER_USE_PRINTK=y
@@ -36,9 +36,9 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"
         - " : Stack Safety Warning: Threshold crossed"
-        - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - "(.*)ISR0([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"
   debug.thread_analyzer.printk.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
@@ -48,8 +48,8 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
-        - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"
+        - "(.*)ISR0([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"
   debug.thread_analyzer.printk.userspace.priv_stack:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
@@ -65,9 +65,9 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
-        - "(.*)PRIV_STACK: unused [0-9]+ usage [0-9]+ / [0-9]+"
-        - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"
+        - "(.*)PRIV_STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+"
+        - "(.*)ISR0([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"
   debug.thread_analyzer.log_backend:
     extra_configs:
       - CONFIG_THREAD_ANALYZER_USE_LOG=y
@@ -77,8 +77,8 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
-        - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"
+        - "(.*)ISR0([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"
   debug.thread_analyzer.log_backend.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
@@ -90,5 +90,5 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
-        - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"
+        - "(.*)ISR0([ ]+) : STACK: unused\\s+[0-9]+ usage\\s+[0-9]+ /\\s+[0-9]+ (.*)"


### PR DESCRIPTION
Modify stack sizes to start at the fixed size of 4 and % with a fixed size of 3. Percentages should never be more than 3 digits in this case, and the majority of stack sizes should never exceed 9999, and if they do, then it just pads them.

The purpose of this is to just a slightly cleaner table where each row has the same width.