### PR TITLE
dts: bindings: use min/max properties instead of most ranges informative descriptions

### DIFF
--- a/boards/rakwireless/rak11160/rak11160.dts
+++ b/boards/rakwireless/rak11160/rak11160.dts
@@ -51,9 +51,9 @@
 
 &pll {
 	div-m = <1>;
-	mul-n = <3>;
-	div-r = <2>;
-	div-q = <2>;
+	mul-n = <6>;
+	div-r = <4>;
+	div-q = <4>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };

--- a/boards/rakwireless/rak3172/rak3172.dts
+++ b/boards/rakwireless/rak3172/rak3172.dts
@@ -49,9 +49,9 @@ stm32_lp_tick_source: &lptim1 {
 
 &pll {
 	div-m = <1>;
-	mul-n = <3>;
-	div-r = <2>;
-	div-q = <2>;
+	mul-n = <6>;
+	div-r = <4>;
+	div-q = <4>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };

--- a/dts/bindings/adc/silabs,siwx91x-adc.yaml
+++ b/dts/bindings/adc/silabs,siwx91x-adc.yaml
@@ -16,7 +16,8 @@ properties:
     description: |
         ADC reference voltage in mv. This voltage is common for all
         the channels.
-        Valid range: 1800 - 3600
+    min: 1800
+    max: 3600
     required: true
 
   silabs,adc-sampling-rate:

--- a/dts/bindings/adc/zephyr,adc-emul.yaml
+++ b/dts/bindings/adc/zephyr,adc-emul.yaml
@@ -11,7 +11,9 @@ properties:
   nchannels:
     type: int
     required: true
-    description: Number of emulated ADC channels. Should be in 1-32 range.
+    description: Number of emulated ADC channels.
+    min: 1
+    max: 32
 
   ref-internal-mv:
     type: int

--- a/dts/bindings/can/infineon,xmc4xxx-can.yaml
+++ b/dts/bindings/can/infineon,xmc4xxx-can.yaml
@@ -16,7 +16,9 @@ properties:
   clock-prescaler:
     type: int
     required: true
-    description: Clock divider for the input clock. Valid range is [1, 1023].
+    description: Clock divider for the input clock.
+    min: 1
+    max: 1023
 
   message-objects:
     type: int

--- a/dts/bindings/can/microchip,mcp251xfd.yaml
+++ b/dts/bindings/can/microchip,mcp251xfd.yaml
@@ -37,7 +37,8 @@ properties:
     description: |
       Prescaler value for computing the timestamps of received messages.
       The timestamp counter is derived from the internal clock divided by this value.
-      Valid range is [1, 1024].
+    min: 1
+    max: 1024
 
   sof-on-clko:
     type: boolean

--- a/dts/bindings/can/nxp,lpc-mcan.yaml
+++ b/dts/bindings/can/nxp,lpc-mcan.yaml
@@ -26,5 +26,7 @@ properties:
     type: int
     default: 1
     description: |
-      Configure the prescaler for the external timestamp counter. Valid range is 1 to 2048. Default
-      is 1, corresponding to the ETSCC register reset value.
+      Configure the prescaler for the external timestamp counter.
+      Default is 1, corresponding to the ETSCC register reset value.
+    min: 1
+    max: 2048

--- a/dts/bindings/can/renesas,ra-canfd.yaml
+++ b/dts/bindings/can/renesas,ra-canfd.yaml
@@ -22,4 +22,5 @@ properties:
     type: int
     description: |
       To determine the maximum rx filters can be added on this CAN device.
-      Valid range: 0 - 16
+    min: 0
+    max: 16

--- a/dts/bindings/can/renesas,rz-canfd.yaml
+++ b/dts/bindings/can/renesas,rz-canfd.yaml
@@ -23,4 +23,5 @@ properties:
     required: true
     description: |
       To determine the maximum rx filters can be added on this CAN device.
-      Valid range: 1 - 128
+    min: 1
+    max: 128

--- a/dts/bindings/clock/nxp,mcxw7x-clock.yaml
+++ b/dts/bindings/clock/nxp,mcxw7x-clock.yaml
@@ -132,21 +132,24 @@ properties:
     required: true
     description: |
       System clock divider for bus clock.
-      Valid range: 1 to 16.
+    min: 1
+    max: 16
 
   sys-clk-div-slow:
     type: int
     required: true
     description: |
       System clock divider for slow clock.
-      Valid range: 1 to 16.
+    min: 1
+    max: 16
 
   sys-clk-div-core:
     type: int
     required: true
     description: |
       System clock divider for core clock.
-      Valid range: 1 to 16.
+    min: 1
+    max: 16
 
   enable-sosc:
     type: boolean

--- a/dts/bindings/clock/raspberrypi,pico-pll.yaml
+++ b/dts/bindings/clock/raspberrypi,pico-pll.yaml
@@ -14,18 +14,21 @@ properties:
     required: true
     description: |
       The feedback divider value.
-      The valid range is 16 to 320.
+    min: 16
+    max: 320
 
   post-div1:
     type: int
     required: true
     description: |
       The post clock divider.
-      The valid range is 1 to 49.
+    min: 1
+    max: 49
 
   post-div2:
     type: int
     required: true
     description: |
       The post clock divider.
-      The valid range is 1 to 49.
+    min: 1
+    max: 49

--- a/dts/bindings/clock/raspberrypi,pico-rosc.yaml
+++ b/dts/bindings/clock/raspberrypi,pico-rosc.yaml
@@ -35,4 +35,5 @@ properties:
     type: int
     description: |
       The phase-shift value.
-      The valid range is 0 to 3
+    min: 0
+    max: 3

--- a/dts/bindings/clock/st,stm32f0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f0-pll-clock.yaml
@@ -38,4 +38,5 @@ properties:
     required: true
     description: |
         PLL multiplication factor for output clock
-        Valid range: 2 - 16
+    min: 2
+    max: 16

--- a/dts/bindings/clock/st,stm32f1-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f1-pll-clock.yaml
@@ -30,7 +30,8 @@ properties:
     required: true
     description: |
         Main PLL multiplication factor for VCO
-        Valid range: 2 - 16
+    min: 2
+    max: 16
 
   xtpre:
     type: boolean

--- a/dts/bindings/clock/st,stm32f100-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f100-pll-clock.yaml
@@ -33,4 +33,5 @@ properties:
     required: true
     description: |
         PLL multiplication factor for output clock
-        Valid range: 2 - 16
+    min: 2
+    max: 16

--- a/dts/bindings/clock/st,stm32f105-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f105-pll-clock.yaml
@@ -50,7 +50,8 @@ properties:
     required: true
     description: |
         Configurable prescaler
-        Valid range: 1 - 16
+    min: 1
+    max: 16
 
   otgfspre:
     type: boolean

--- a/dts/bindings/clock/st,stm32fx-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32fx-pll-clock.yaml
@@ -46,7 +46,8 @@ properties:
         On all other SoCs, the division factor M is shared between
         PLL, PLLSAI and PLLI2S, hence same value must be used
         for those PLLs when used together.
-        Valid range: 2 - 63
+    min: 2
+    max: 63
 
   mul-n:
     type: int
@@ -79,7 +80,8 @@ properties:
         and on all STM32F7x for PLLI2S.
         Available only on STM32F427, F429, F437, F439, F446, F469, F479
         and on all STM32F7x for PLLSAI.
-        Valid range: 2 - 15
+    min: 2
+    max: 15
 
   post-div-q:
     type: int
@@ -91,7 +93,8 @@ properties:
         and on all STM32F7x for PLLSAI.
         If the div-q property is used and this property is applicable for the SoC, then it is
         required to define it.
-        Valid range: 1 - 32
+    min: 1
+    max: 32
 
   div-r:
     type: int
@@ -101,7 +104,8 @@ properties:
         Available on all SoCs except STM32F410 for PLLI2S.
         Available only on STM32F427, F429, F437, F439, F469, F479
         and on STM32F74x and higher for PLLSAI.
-        Valid range: 2 - 7
+    min: 2
+    max: 7
 
   post-div-r:
     type: int

--- a/dts/bindings/clock/st,stm32g0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32g0-pll-clock.yaml
@@ -35,30 +35,35 @@ properties:
     required: true
     description: |
         Division factor for PLL input clock
-        Valid range: 1 - 8
+    min: 1
+    max: 8
 
   mul-n:
     type: int
     required: true
     description: |
         Main PLL multiplication factor for VCO
-        Valid range: 8 - 86
+    min: 8
+    max: 86
 
   div-p:
     type: int
     description: |
         PLL division factor for PLL P output
-        Valid range: 2 - 32
+    min: 2
+    max: 32
 
   div-q:
     type: int
     description: |
         PLL division factor for PLL Q output
-        Valid range: 2 - 8
+    min: 2
+    max: 8
 
   div-r:
     type: int
     required: true
     description: |
         PLL division factor for PLLCLK (system clock)
-        Valid range: 2 - 8
+    min: 2
+    max: 8

--- a/dts/bindings/clock/st,stm32g4-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32g4-pll-clock.yaml
@@ -35,17 +35,20 @@ properties:
     required: true
     description: |
         Division factor for PLL input clock
-        Valid range: 1 - 16
+    min: 1
+    max: 16
 
   mul-n:
     type: int
     required: true
     description: |
         Main PLL multiplication factor for VCO
-        Valid range: 8 - 127
+    min: 8
+    max: 127
 
   div-p:
     type: int
     description: |
         Main PLL division factor for ADC
-        Valid range: 2 - 31
+    min: 2
+    max: 31

--- a/dts/bindings/clock/st,stm32h7-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32h7-pll-clock.yaml
@@ -39,35 +39,41 @@ properties:
     description: |
         Division factor for PLLx
         input clock
-        Valid range: 1 - 63
+    min: 1
+    max: 63
 
   mul-n:
     type: int
     required: true
     description: |
         Main PLL multiplication factor for VCOx
-        Valid range: 4 - 512
+    min: 4
+    max: 512
 
   div-p:
     type: int
     description: |
         PLL division factor for pllx_p_ck
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-q:
     type: int
     description: |
         PLL division factor for pllx_q_ck
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-r:
     type: int
     description: |
         PLL division factor for pllx_r_ck
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   fracn:
     type: int
     description: |
         PLLx FRACN value
-        Valid range: 0 - 8191
+    min: 0
+    max: 8191

--- a/dts/bindings/clock/st,stm32h7rs-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32h7rs-pll-clock.yaml
@@ -31,10 +31,12 @@ properties:
     type: int
     description: |
         PLL division factor for pllx_s_ck : valid for PLL1, 2, 3
-        Valid range: 1 - 8
+    min: 1
+    max: 8
 
   div-t:
     type: int
     description: |
         PLL division factor for pllx_t_ck : valid for PLL2
-        Valid range: 1 - 8
+    min: 1
+    max: 8

--- a/dts/bindings/clock/st,stm32mp13-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32mp13-pll-clock.yaml
@@ -53,35 +53,41 @@ properties:
     required: true
     description: |
         PLLx division factor (aka DIVM1 + 1) of the input clock divider
-        Valid range: 1 - 64
+    min: 1
+    max: 64
 
   mul-n:
     type: int
     required: true
     description: |
         PLLx multiplication factor (aka DIVN + 1) for VCO
-        Valid range: 25 - 200
+    min: 25
+    max: 200
 
   div-p:
     type: int
     description: |
         PLLx_P division factor (aka DIVP + 1)
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-q:
     type: int
     description: |
         PLLx_Q division factor (aka DIVQ + 1)
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-r:
     type: int
     description: |
         PLLx_R division factor (aka DIVR + 1)
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   fracn:
     type: int
     description: |
         PLLx FRACV fractional latch
-        Valid range: 0 - 8191
+    min: 0
+    max: 8191

--- a/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
@@ -32,4 +32,5 @@ properties:
     description: |
         ICx integer division factor
         The input ICx frequency is divided by the specified value
-        Valid range: 1 - 256
+    min: 1
+    max: 256

--- a/dts/bindings/clock/st,stm32n6-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32n6-pll-clock.yaml
@@ -40,23 +40,27 @@ properties:
     description: |
         Prescaler for PLLx
         input clock
-        Valid range: 1 - 63
+    min: 1
+    max: 63
 
   mul-n:
     type: int
     required: true
     description: |
         PLLx multiplication factor for VCO
-        Valid range: 16 - 2500
+    min: 16
+    max: 2500
 
   div-p1:
     type: int
     description: |
         PLLx DIVP1 division factor
-        Valid range: 1 - 7
+    min: 1
+    max: 7
 
   div-p2:
     type: int
     description: |
         PLLx DIVP2 division factor
-        Valid range: 1 - 7
+    min: 1
+    max: 7

--- a/dts/bindings/clock/st,stm32u0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32u0-pll-clock.yaml
@@ -36,30 +36,35 @@ properties:
     description: |
         Division factor M of the PLL
         input clock divider
-        Valid range: 1 - 8
+    min: 1
+    max: 8
 
   mul-n:
     type: int
     required: true
     description: |
         PLL frequency multiplication factor N
-        Valid range: 4 - 127
+    min: 4
+    max: 127
 
   div-p:
     type: int
     description: |
         PLL VCO division factor P
-        Valid range: 2 - 32
+    min: 2
+    max: 32
 
   div-q:
     type: int
     description: |
         PLL VCO division factor Q
-        Valid range: 2 - 8
+    min: 2
+    max: 8
 
   div-r:
     type: int
     required: true
     description: |
         PLL VCO division factor R
-        Valid range: 2 - 8
+    min: 2
+    max: 8

--- a/dts/bindings/clock/st,stm32u5-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32u5-pll-clock.yaml
@@ -42,26 +42,30 @@ properties:
     description: |
         Prescaler for PLLx
         input clock
-        Valid range: 1 - 16
+    min: 1
+    max: 16
 
   mul-n:
     type: int
     required: true
     description: |
         PLLx multiplication factor for VCO
-        Valid range: 4 - 512
+    min: 4
+    max: 512
 
   div-p:
     type: int
     description: |
         PLLx DIVP division factor
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-q:
     type: int
     description: |
         PLLx DIVQ division factor
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-r:
     type: int
@@ -70,10 +74,12 @@ properties:
         PLLx DIVR division factor
         On PLL1, only division by 1 and even division values are allowed.
         No restrictions for PLL2 and PLL3
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   fracn:
     type: int
     description: |
         PLLx FRACN value
-        Valid range: 0 - 8191
+    min: 0
+    max: 8191

--- a/dts/bindings/clock/st,stm32wb-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32wb-pll-clock.yaml
@@ -40,30 +40,35 @@ properties:
     required: true
     description: |
         Main PLL division factor for PLL input clock
-        Valid range: 1 - 8
+    min: 1
+    max: 8
 
   mul-n:
     type: int
     required: true
     description: |
         Main PLL multiplication factor for VCO
-        Valid range: 6 - 127
+    min: 6
+    max: 127
 
   div-p:
     type: int
     description: |
         Main PLL division factor for PLLPCLK
-        Valid range: 2 - 32
+    min: 2
+    max: 32
 
   div-q:
     type: int
     description: |
         Main PLL division factor for PLLQCLK
-        Valid range: 2 - 8
+    min: 2
+    max: 8
 
   div-r:
     type: int
     required: true
     description: |
         Main PLL division factor for PLLRCLK (system clock)
-        Valid range: 2 - 8
+    min: 2
+    max: 8

--- a/dts/bindings/clock/st,stm32wba-hse-clock.yaml
+++ b/dts/bindings/clock/st,stm32wba-hse-clock.yaml
@@ -18,4 +18,5 @@ properties:
     type: int
     description: |
         HSE clock trimming
-        Valid range: 0 - 63
+    min: 0
+    max: 63

--- a/dts/bindings/clock/st,stm32wba-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32wba-pll-clock.yaml
@@ -42,31 +42,36 @@ properties:
     description: |
         Prescaler for PLLx
         input clock
-        Valid range: 1 - 8
+    min: 1
+    max: 8
 
   mul-n:
     type: int
     required: true
     description: |
         PLLx multiplication factor for VCO
-        Valid range: 4 - 512
+    min: 4
+    max: 512
 
   div-p:
     type: int
     required: true
     description: |
         PLLx DIVP division factor
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-q:
     type: int
     description: |
         PLLx DIVQ division factor
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-r:
     type: int
     required: true
     description: |
         PLLx DIVR division factor
-        Valid range: 1 - 128
+    min: 1
+    max: 128

--- a/dts/bindings/clock/ti,mspm0-clk.yaml
+++ b/dts/bindings/clock/ti,mspm0-clk.yaml
@@ -24,7 +24,9 @@ properties:
   clk-div:
     type: int
     description: |
-      Clock divider selection value. Valid range [2 ... 16].
+      Clock divider selection value.
+    min: 2
+    max: 16
 
 clock-cells:
   - clk

--- a/dts/bindings/comparator/microchip,ac-g1-comparator.yaml
+++ b/dts/bindings/comparator/microchip,ac-g1-comparator.yaml
@@ -62,7 +62,8 @@ properties:
     description: |
       VSCALE = (VDDANA * (value + 1)) / 64
       Only used when either positive or negative input is configured as "vscale".
-      Valid range: 0 to 63
+    min: 0
+    max: 63
 
   output-mode:
     type: string

--- a/dts/bindings/comparator/nxp,cmp.yaml
+++ b/dts/bindings/comparator/nxp,cmp.yaml
@@ -83,7 +83,8 @@ properties:
     type: int
     description: |
       Specifies the sampling period, in bus clock cycles.
-      Valid range: 0 - 255.
+    min: 0
+    max: 255
 
   dac-vref-source:
     type: string

--- a/dts/bindings/comparator/nxp,hscmp.yaml
+++ b/dts/bindings/comparator/nxp,hscmp.yaml
@@ -76,7 +76,8 @@ properties:
     type: int
     description: |
       Sampling period for the filter in bus clock cycles.
-      Valid range: 0 - 255.
+    min: 0
+    max: 255
 
   dac-vref-source:
     type: string
@@ -90,7 +91,8 @@ properties:
     type: int
     description: |
       8-bit DAC code used when an input channel is set to DAC output.
-      Valid range: 0 - 255.
+    min: 0
+    max: 255
 
   positive-mux-input:
     type: string

--- a/dts/bindings/comparator/nxp,lpcmp.yaml
+++ b/dts/bindings/comparator/nxp,lpcmp.yaml
@@ -69,7 +69,8 @@ properties:
     type: int
     description: |
       Sampling period for the filter in bus clock cycles.
-      Valid range: 0 - 255.
+    min: 0
+    max: 255
 
   dac-vref-source:
     type: string
@@ -83,7 +84,8 @@ properties:
     type: int
     description: |
       8-bit DAC code used when an input is set to DAC output.
-      Valid range: 0 - 255.
+    min: 0
+    max: 255
 
   positive-mux-input:
     type: string

--- a/dts/bindings/counter/atmel,sam-tc.yaml
+++ b/dts/bindings/counter/atmel,sam-tc.yaml
@@ -22,7 +22,8 @@ properties:
     type: int
     description: |
       Timer / Counter channel to use, channel 0 is the default.
-      Valid range: 0 - 2
+    min: 0
+    max: 2
 
   clk:
     type: int

--- a/dts/bindings/ethernet/xlnx,gem.yaml
+++ b/dts/bindings/ethernet/xlnx,gem.yaml
@@ -135,8 +135,9 @@ properties:
     type: int
     required: true
     description: |
-      Data offset in the hardware RX packet buffer (in bytes). Valid range is
-      0-3 bytes.
+      Data offset in the hardware RX packet buffer (in bytes).
+    min: 0
+    max: 3
 
   hw-tx-buffer-size-full:
     type: boolean

--- a/dts/bindings/gnss/globaltop,pa6h.yaml
+++ b/dts/bindings/gnss/globaltop,pa6h.yaml
@@ -14,4 +14,5 @@ properties:
     default: 1000
     description: |
       Initial fix update interval in milliseconds.
-      Valid range is 100 to 10000 ms.
+    min: 100
+    max: 10000

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -15,14 +15,16 @@ properties:
     description: |
       This property specifies the amount of time that the SDA line is held
       after a transmit operation. The value is in units of I2C clock cycles.
-      Valid range is 0 to 0xffff.
+    min: 0
+    max: 0xffff
     type: int
 
   sda-hold-rx:
     description: |
       This property specifies the amount of time that the SDA line is held
       after a receive operation. The value is in units of I2C clock cycles.
-      Valid range is 0 to 0xff.
+    min: 0
+    max: 0xff
     type: int
 
   lcnt-offset:

--- a/dts/bindings/input/futaba,sbus.yaml
+++ b/dts/bindings/input/futaba,sbus.yaml
@@ -29,7 +29,8 @@ child-binding:
       required: true
       description: |
         SBUS input channel
-        Valid range: 1 - 16
+      min: 1
+      max: 16
     type:
       type: int
       required: true

--- a/dts/bindings/input/tbs,crsf.yaml
+++ b/dts/bindings/input/tbs,crsf.yaml
@@ -67,7 +67,8 @@ child-binding:
       required: true
       description: |
         CRSF input channel
-        Valid range: 1 - 16
+      min: 1
+      max: 16
     type:
       type: int
       required: true

--- a/dts/bindings/interrupt-controller/riscv,imsic.yaml
+++ b/dts/bindings/interrupt-controller/riscv,imsic.yaml
@@ -18,6 +18,8 @@ properties:
     description: |
       Number of interrupt identities (EIIDs) supported by this IMSIC instance.
       Per RISC-V AIA specification, valid range is 1-2047 (EIID 0 is reserved).
+    min: 1
+    max: 2047
 
   riscv,hart-id:
     type: int

--- a/dts/bindings/led/ti,lp5562.yaml
+++ b/dts/bindings/led/ti,lp5562.yaml
@@ -8,32 +8,36 @@ properties:
   red-output-current:
     type: int
     default: 175
-    description: Output current of red channel in 0.1 mA (0-25.5 mA).
-                 Default value is the power-on default.
+    description: |
+      Output current of red channel in 0.1 mA (0-25.5 mA).
+      Default value is the power-on default.
     min: 0
     max: 255
 
   green-output-current:
     type: int
     default: 175
-    description: Output current of green channel in 0.1 mA (0-25.5 mA)
-                 Default value is the power-on default.
+    description: |
+      Output current of green channel in 0.1 mA (0-25.5 mA).
+      Default value is the power-on default.
     min: 0
     max: 255
 
   blue-output-current:
     type: int
     default: 175
-    description: Output current of blue channel in 0.1 mA (0-25.5 mA)
-                 Default value is the power-on default.
+    description: |
+      Output current of blue channel in 0.1 mA (0-25.5 mA).
+      Default value is the power-on default.
     min: 0
     max: 255
 
   white-output-current:
     type: int
     default: 175
-    description: Output current of white channel in 0.1 mA (0-25.5 mA)
-                 Default value is the power-on default.
+    description: |
+      Output current of white channel in 0.1 mA (0-25.5 mA).
+      Default value is the power-on default.
     min: 0
     max: 255
 

--- a/dts/bindings/led/ti,lp5562.yaml
+++ b/dts/bindings/led/ti,lp5562.yaml
@@ -9,22 +9,33 @@ properties:
     type: int
     default: 175
     description: Output current of red channel in 0.1 mA (0-25.5 mA).
-                 Default value is the power-on default. Valid range = 0 - 255
+                 Default value is the power-on default.
+    min: 0
+    max: 255
+
   green-output-current:
     type: int
     default: 175
     description: Output current of green channel in 0.1 mA (0-25.5 mA)
-                 Default value is the power-on default. Valid range = 0 - 255
+                 Default value is the power-on default.
+    min: 0
+    max: 255
+
   blue-output-current:
     type: int
     default: 175
     description: Output current of blue channel in 0.1 mA (0-25.5 mA)
-                 Default value is the power-on default. Valid range = 0 - 255
+                 Default value is the power-on default.
+    min: 0
+    max: 255
+
   white-output-current:
     type: int
     default: 175
     description: Output current of white channel in 0.1 mA (0-25.5 mA)
-                 Default value is the power-on default. Valid range = 0 - 255
+                 Default value is the power-on default.
+    min: 0
+    max: 255
 
   enable-gpios:
     type: phandle-array

--- a/dts/bindings/memory-controllers/atmel,sam-smc.yaml
+++ b/dts/bindings/memory-controllers/atmel,sam-smc.yaml
@@ -88,7 +88,8 @@ child-binding:
       required: true
       description: |
         The device's SMC Chip Select number.
-        Valid range: 0 - 3
+      min: 0
+      max: 3
 
     atmel,smc-write-mode:
       type: string

--- a/dts/bindings/mtd/ti,cc23x0-ccfg-flash.yaml
+++ b/dts/bindings/mtd/ti,cc23x0-ccfg-flash.yaml
@@ -20,17 +20,19 @@ properties:
     type: int
     description: |
       Bootloader entry point when a boot from flash is selected.
-      Valid range: 0 - 0x0effffff
       Default is 0, which is the standard initial configuration.
+    min: 0
+    max: 0x0effffff
     default: 0
 
   ti,serial-io-cfg-index:
     type: int
     description: |
       Index of which I/O mapping to use for UART/SPI.
-      Valid range: 0 - 2
       Default is 0, which is the standard initial configuration. Other values can be
       used depending on I/O availability.
+    min: 0
+    max: 2
     default: 0
 
   ti,pin-trigger:
@@ -43,9 +45,10 @@ properties:
     type: int
     description: |
       Index of DIO pin to use for pin trigger check.
-      Valid range: 0 - 25
       Default is 0, which is the standard initial configuration. Other values can be
       used depending on DIO availability.
+    min: 0
+    max: 25
     default: 0
 
   ti,pin-trigger-level-hi:
@@ -100,8 +103,9 @@ properties:
       Controls whether flash programming is allowed through SACI. The same mechanism
       controls whether the application is allowed to program these sectors.
       0 = protected.
-      Valid range: 0 - 0xffffffff
       Default is 0xffffffff to allow programming these sectors.
+    min: 0
+    max: 0xffffffff
     default: 0xffffffff
 
   ti,wr-er-prot-sect32-255:
@@ -110,32 +114,36 @@ properties:
       Bitmask for write/erase protection of groups of 8 sectors, in sector range [32, 255].
       Bit i protects sectors [32 + 8i, 39 + 8i].
       0 = protected.
-      Valid range: 0 - 0xffffffff
       Default is 0xffffffff to allow programming these sectors.
+    min: 0
+    max: 0xffffffff
     default: 0xffffffff
 
   ti,wr-er-prot-ccfg-sect:
     type: int
     description: |
       Bitmask for write/erase protection of CCFG sectors.
-      Valid range: 0 - 0xffffffff
       Default is 0 to prevent from mistakenly programming these sectors.
+    min: 0
+    max: 0xffffffff
     default: 0
 
   ti,wr-er-prot-fcfg-sect:
     type: int
     description: |
       Bitmask for write/erase protection of FCFG sectors.
-      Valid range: 0 - 0xffffffff
       Default is 0 to prevent from mistakenly programming these sectors.
+    min: 0
+    max: 0xffffffff
     default: 0
 
   ti,wr-er-prot-engr-sect:
     type: int
     description: |
       Bitmask for write/erase protection of ENGR sectors.
-      Valid range: 0 - 0xffffffff
       Default is 0 to prevent from mistakenly programming these sectors.
+    min: 0
+    max: 0xffffffff
     default: 0
 
   ti,chip-er-retain-sect0-31:
@@ -146,8 +154,9 @@ properties:
       to allow flash sectors devoted to logging or runtime state/configuration to survive
       the chip erase during a FW update.
       0 = protected.
-      Valid range: 0 - 0xffffffff
       Default is 0 to prevent from mistakenly programming these sectors.
+    min: 0
+    max: 0xffffffff
     default: 0
 
   ti,chip-er-retain-sect32-255:
@@ -156,6 +165,7 @@ properties:
       Bitmask for chip erase protection of groups of 8 sectors, in sector range [32, 255].
       Bit i protects sectors [32 + 8i, 39 + 8i].
       0 = protected.
-      Valid range: 0 - 0xffffffff
       Default is 0 to prevent from mistakenly programming these sectors.
+    min: 0
+    max: 0xffffffff
     default: 0

--- a/dts/bindings/opamp/st,stm32g4-opamp.yaml
+++ b/dts/bindings/opamp/st,stm32g4-opamp.yaml
@@ -245,7 +245,8 @@ properties:
       If value is present and self-calibration is enabled, this value will overwrite values
       calculated during self-calibration.
       Please refer to RM0440 Rev 9, pp. 789/2140 for more details.
-      NOTE: Acceptable range is 0x00 to 0x1f.
+    min: 0
+    max: 0x1f
 
   st,nmos-trimming-value:
     type: int
@@ -255,4 +256,5 @@ properties:
       If value is present and self-calibration is enabled, this value will overwrite values
       calculated during self-calibration.
       Please refer to RM0440 Rev 9, pp. 789/2140 for more details.
-      NOTE: Acceptable range is 0x00 to 0x1f.
+    min: 0
+    max: 0x1f

--- a/dts/bindings/pwm/nxp,ctimer-pwm.yaml
+++ b/dts/bindings/pwm/nxp,ctimer-pwm.yaml
@@ -15,8 +15,10 @@ properties:
     type: int
     default: 1
     description: |
-      Specifies the prescale value. Valid range: 0x0 - 0xFFFFFFFF.
+      Specifies the prescale value.
       The clock is divided by (prescaler + 1).
+    min: 0
+    max: 0xFFFFFFFF
 
   clk-source:
     type: int

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -55,8 +55,9 @@ properties:
       the input filter accepting an input transition. The number of samples
       is the decimal value of this field plus three: the bit field value of 0-7
       represents 3-10 samples, respectively. The value affects the input latency.
-      Valid range: 0 - 7
       Note this property only takes effect when capture input filter register is available.
+    min: 0
+    max: 7
 
   input-filter-period:
     type: int
@@ -65,8 +66,9 @@ properties:
       Each input is sampled multiple times at the rate specified by this field.
       If the value is 0x00 (default), then the input filter is bypassed. The value affects
       the input latency.
-      Valid range: 0 - 255
       Note this property only takes effect when capture input filter register is available.
+    min: 0
+    max: 255
 
   "#pwm-cells":
     const: 3

--- a/dts/bindings/qspi/nxp,s32-qspi-sfp-frad.yaml
+++ b/dts/bindings/qspi/nxp,s32-qspi-sfp-frad.yaml
@@ -49,5 +49,6 @@ child-binding:
       default: 0
       description: |
         The domain master ID that owns the exclusive access lock.
-        Valid range: 0 - 63. The default corresponds to the reset
-        value of the register field.
+        The default corresponds to the reset value of the register field.
+      min: 0
+      max: 63

--- a/dts/bindings/qspi/nxp,s32-qspi-sfp-mdad.yaml
+++ b/dts/bindings/qspi/nxp,s32-qspi-sfp-mdad.yaml
@@ -40,8 +40,9 @@ child-binding:
       default: 0
       description: |
         Defines the mask value for the ID-Match comparison.
-        Valid range: 0 - 63. The default corresponds to the
-        reset value of the register field.
+        The default corresponds to the reset value of the register field.
+      min: 0
+      max: 63
 
     domain-id:
       type: int

--- a/dts/bindings/qspi/nxp,s32-qspi-sfp-mdad.yaml
+++ b/dts/bindings/qspi/nxp,s32-qspi-sfp-mdad.yaml
@@ -48,4 +48,5 @@ child-binding:
       required: true
       description: |
         Domain ID Reference value of the Domain-ID (MID) for MID-comparison.
-        Valid range: 0 - 63.
+      min: 0
+      max: 63

--- a/dts/bindings/reset/reset-mmio.yaml
+++ b/dts/bindings/reset/reset-mmio.yaml
@@ -17,7 +17,8 @@ properties:
     required: true
     description: |
       Number of resets controlled by the register.
-      Can be in the range [1, 31].
+    min: 1
+    max: 31
   active-low:
     description: Reset is active in low state.
     type: boolean

--- a/dts/bindings/rtc/st,stm32-rtc.yaml
+++ b/dts/bindings/rtc/st,stm32-rtc.yaml
@@ -58,4 +58,5 @@ properties:
       Not required, since RTC Alarm interrupt could be routed directly to Nested
       Vectored Interrupt Controller (NVIC) and to Power Control (PWR) wake-up
       pins on some series.
-      Valid range: 0 - 31
+    min: 0
+    max: 31

--- a/dts/bindings/sensor/adi,adxl345-common.yaml
+++ b/dts/bindings/sensor/adi,adxl345-common.yaml
@@ -37,7 +37,8 @@ properties:
     type: int
     description: |
       Specify the FIFO watermark level in frame count.
-      Valid range: 1 - 31
+    min: 1
+    max: 31
 
   int1-gpios:
     type: phandle-array

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -50,7 +50,8 @@ properties:
     type: int
     description: |
       Specify the FIFO watermark level in frame count.
-      Valid range: 0 - 511
+    min: 0
+    max: 511
 
 examples:
   - |

--- a/dts/bindings/sensor/adi,adxl372-common.yaml
+++ b/dts/bindings/sensor/adi,adxl372-common.yaml
@@ -88,7 +88,8 @@ properties:
     type: int
     description: |
       Specify the FIFO watermark level in frame count.
-      Valid range: 0 - 512
+    min: 0
+    max: 512
 
 examples:
   - |

--- a/dts/bindings/sensor/bosch,bmp581-common.yaml
+++ b/dts/bindings/sensor/bosch,bmp581-common.yaml
@@ -137,7 +137,8 @@ properties:
     description: |
       Specify the FIFO watermark level in frame count.
       Only supports frames with both Pressure and Temperature
-      Valid range: 1 - 15
+    min: 1
+    max: 15
 
   int-active-low:
     type: boolean

--- a/dts/bindings/sensor/invensense,icm45600-common.yaml
+++ b/dts/bindings/sensor/invensense,icm45600-common.yaml
@@ -117,7 +117,8 @@ properties:
     description: |
       Specify the FIFO watermark level in frame count.
       Default is power-up configuration (disabled).
-      Valid range: 0 - 104
+    min: 0
+    max: 104
 
   fifo-watermark-equals:
     type: boolean

--- a/dts/bindings/sensor/invensense,mpu9250.yaml
+++ b/dts/bindings/sensor/invensense,mpu9250.yaml
@@ -25,7 +25,8 @@ properties:
       Default gyrscope sample rate divider. This divider is only effective
       when gyro-dlpf is in range 5-184.
       rate = sample_rate / (1 + gyro-sr-div)
-      Valid range: 0 - 255
+    min: 0
+    max: 255
 
   gyro-dlpf:
     type: int

--- a/dts/bindings/sensor/nxp,mcux-qdc.yaml
+++ b/dts/bindings/sensor/nxp,mcux-qdc.yaml
@@ -35,7 +35,9 @@ properties:
     type: int
     description: |
       Sampling period, in IPBus clock cycles, of the decoder input signals.
-      Valid range: 0-255. If value is 0, then the input filter is bypassed.
+      If value is 0, then the input filter is bypassed.
+    min: 0
+    max: 255
 
   input-channels:
     type: array

--- a/dts/bindings/sensor/pixart,pat9136.yaml
+++ b/dts/bindings/sensor/pixart,pat9136.yaml
@@ -15,8 +15,9 @@ properties:
     description: |
       The resolution of the sensor which indirectly results in counts per inch
       (CPI), following the formula CPI = (1 + resolution) * 100.
-      Valid range is 0 to 199.
       Default is value set during Performance Optimization Settings.
+    min: 0
+    max: 199
 
   int-gpios:
     type: phandle-array

--- a/dts/bindings/sensor/st,iis2dlpc-common.yaml
+++ b/dts/bindings/sensor/st,iis2dlpc-common.yaml
@@ -98,30 +98,33 @@ properties:
     default: 0x0
     description: |
       Tap shock value. Default is power-up configuration.
-      (values range from 0x0 to 0x3)
       This register represents the maximum time of an over-threshold signal
       detection to be recognized as a tap event. Where 0 equals 4*1/ODR and
       1LSB = 8*1/ODR.
+    min: 0
+    max: 3
 
   tap-latency:
     type: int
     default: 0x0
     description: |
       Tap latency. Default is power-up configuration.
-      (values range from 0x0 to 0xF)
       When double-tap recognition is enabled, this register expresses the
       maximum time between two successive detected taps to determine a
       double-tap event. Where 0 equals 16*1/ODR and 1LSB = 32*1/ODR.
+    min: 0
+    max: 0xf
 
   tap-quiet:
     type: int
     default: 0x0
     description: |
       Expected quiet time after a tap detection. Default is power-up configuration.
-      (values range from 0x0 to 0x3)
       This register represents the time after the first detected tap in which
       there must not be any overthreshold event. Where 0 equals 2*1/ODR
       and 1LSB = 4*1/ODR.
+    min: 0
+    max: 3
 
 examples:
   - |

--- a/dts/bindings/sensor/st,iis3dwb.yaml
+++ b/dts/bindings/sensor/st,iis3dwb.yaml
@@ -110,7 +110,8 @@ properties:
       Specify the default FIFO watermark threshold. Every unit indicates a FIFO row (1 byte of TAG +
       6 bytes of data). (min 0; max 255)
       A typical threshold value is 32 which is then used as default.
-      Valid range: 0 - 511
+    min: 0
+    max: 511
 
   accel-fifo-batch-rate:
     type: int

--- a/dts/bindings/sensor/st,lis2dw12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-common.yaml
@@ -123,30 +123,33 @@ properties:
     default: 0x0
     description: |
       Tap shock value. Default is power-up configuration.
-      (values range from 0x0 to 0x3)
       This register represents the maximum time of an over-threshold signal
       detection to be recognized as a tap event. Where 0 equals 4*1/ODR and
       1LSB = 8*1/ODR.
+    min: 0
+    max: 3
 
   tap-latency:
     type: int
     default: 0x0
     description: |
       Tap latency. Default is power-up configuration.
-      (values range from 0x0 to 0xF)
       When double-tap recognition is enabled, this register expresses the
       maximum time between two successive detected taps to determine a
       double-tap event. Where 0 equals 16*1/ODR and 1LSB = 32*1/ODR.
+    min: 0
+    max: 0xf
 
   tap-quiet:
     type: int
     default: 0x0
     description: |
       Expected quiet time after a tap detection. Default is power-up configuration.
-      (values range from 0x0 to 0x3)
       This register represents the time after the first detected tap in which
       there must not be any overthreshold event. Where 0 equals 2*1/ODR
       and 1LSB = 4*1/ODR.
+    min: 0
+    max: 3
 
   low-noise:
     type: boolean

--- a/dts/bindings/sensor/st,stts22h-i2c.yaml
+++ b/dts/bindings/sensor/st,stts22h-i2c.yaml
@@ -24,21 +24,24 @@ properties:
     default: 0
     description: |
       HIGH temperature threshold above which an alarm is triggered.
-      Valid range is 0 to 255. It defaults to 0 (alarm off) which is
+      It defaults to 0 (alarm off) which is
       the configuration at power-up. This threshold must be calculated
       from a temperature T in Celsius using the formula
       temperature-hi-threshold = 63 + T/0.64 C.
-
+    min: 0
+    max: 255
 
   temperature-lo-threshold:
     type: int
     default: 0
     description: |
       LOW temperature threshold below which an alarm is triggered.
-      Valid range is 0 to 255. It defaults to 0 (alarm off) which is
+      It defaults to 0 (alarm off) which is
       the configuration at power-up. This threshold must be calculated
       from a temperature T in Celsius using the formula
       temperature-lo-threshold = 63 + T/0.64 C.
+    min: 0
+    max: 255
 
   sampling-rate:
     type: int

--- a/dts/bindings/sensor/ti,fdc2x1x.yaml
+++ b/dts/bindings/sensor/ti,fdc2x1x.yaml
@@ -183,7 +183,8 @@ child-binding:
       required: true
       description: |
         Channel X Reference Count Conversion Interval Time.
-        Valid range: 256 - 65535
+      min: 256
+      max: 65535
 
     offset:
       type: int
@@ -191,7 +192,8 @@ child-binding:
       description: |
         Channel X Conversion Offset (FDC2112 and FDC2212 only).
         The default offset value after power-on-reset is 0.
-        Valid range: 0 - 65535
+      min: 0
+      max: 65535
 
     settlecount:
       type: int
@@ -201,7 +203,8 @@ child-binding:
 
         The FDC will use this settling time to allow the LC sensor to
         stabilize before initiation of a conversion on Channel X.
-        Valid range: 0 - 65535
+      min: 0
+      max: 65535
 
     fref-divider:
       type: int
@@ -211,7 +214,8 @@ child-binding:
 
         Sets the divider for Channel X reference.
         Use this to scale the maximum conversion frequency.
-        Valid range: 1 - 1023
+      min: 1
+      max: 1023
 
     idrive:
       type: int
@@ -221,7 +225,8 @@ child-binding:
 
         This field defines the Drive Current used during the settling +
         conversion time of Channel X sensor clock.
-        Valid range: 0 - 31
+      min: 0
+      max: 31
 
     fin-sel:
       type: int

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -66,7 +66,8 @@ properties:
       This property is required on stm32 devices where the wakeup interrupt signal could be
       configured masked at boot (sm32wl55 for instance), preventing the device to wakeup
       the core from stop mode(s).
-      Valid range: 0 - 31
+    min: 0
+    max: 31
 
   de-enable:
     type: boolean
@@ -80,7 +81,8 @@ properties:
     description: |
       Defines the time between the activation of the DE signal and the beginning of the start bit.
       It is expressed in 16th of a bit time.
-      Valid range: 0 - 31
+    min: 0
+    max: 31
 
   de-deassert-time:
     type: int
@@ -88,7 +90,8 @@ properties:
     description: |
       Defines the time between the end of the stop bit and the deactivation of the DE signal.
       It is expressed in 16th of a bit time.
-      Valid range: 0 - 31
+    min: 0
+    max: 31
 
   de-invert:
     type: boolean

--- a/dts/bindings/stepper/adi/adi,tmc51xx-uart.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc51xx-uart.yaml
@@ -25,7 +25,8 @@ properties:
     type: int
     description: |
         UART device address for TMC51XX in UART mode.
-        Valid range: 0 - 253
+    min: 0
+    max: 253
 
 examples:
   - |

--- a/dts/bindings/tcpc/st,stm32-ucpd.yaml
+++ b/dts/bindings/tcpc/st,stm32-ucpd.yaml
@@ -46,7 +46,8 @@ properties:
       inter-frame gap timer clock (tInterFrameGap).
       The division ratio 15 is to apply for Tx clock at the USB PD 2.0
       specification nominal value.
-      Valid range: 2 - 32
+    min: 2
+    max: 32
 
   transwin:
     type: int
@@ -54,7 +55,8 @@ properties:
     description: |
       Determines the division ratio of a hbit_clk divider producing
       tTransitionWindow interval.
-      Valid range: 2 - 32
+    min: 2
+    max: 32
 
   hbitclkdiv:
     type: int
@@ -62,7 +64,8 @@ properties:
     description: |
       Determines the division ratio of a ucpd_clk divider producing
       half-bit clock (hbit_clk)
-      Valid range: 1 - 64
+    min: 1
+    max: 64
 
   dead-battery:
     type: boolean

--- a/dts/bindings/timer/st,stm32-lptim.yaml
+++ b/dts/bindings/timer/st,stm32-lptim.yaml
@@ -46,6 +46,8 @@ properties:
         Gives the LPTIM an exact counting value (s) for timeout expiration.
         Valid range is [1, 256] and should be consistent with st,prescaler
         pre-defined setting. If not, an error is raised.
+    min: 1
+    max: 256
 
 examples:
   - |

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -60,8 +60,8 @@ properties:
       to your product's Reference Manual for more information about this
       feature's availability. (In particular, certain series such as
       STM32L0/STM32L1 have no instance supporting this feature).
-
-      Valid range [0 ... 255].
+    min: 0
+    max: 255
 
   st,mastermode:
     type: string

--- a/dts/bindings/timer/ti,mspm0-timer.yaml
+++ b/dts/bindings/timer/ti,mspm0-timer.yaml
@@ -19,7 +19,8 @@ properties:
     required: true
     description: |
       TIMCLK clock source prescaler value.
-      Valid range [0 ... 255].
+    min: 0
+    max: 255
 
   ti,clk-div:
     type: int

--- a/dts/bindings/usb-c/usb-c-connector.yaml
+++ b/dts/bindings/usb-c/usb-c-connector.yaml
@@ -93,7 +93,6 @@ properties:
         * PDO_BATT
         * PDO_VAR
         * PDO_PPS_APDO
-      Valid range: 1 - 7
 
   sink-pdos:
     type: array
@@ -105,7 +104,6 @@ properties:
         * PDO_BATT
         * PDO_VAR
         * PDO_PPS_APDO
-      Valid range: 1 - 7
 
   sink-vdos:
     type: array

--- a/dts/bindings/usb-c/usb-c-connector.yaml
+++ b/dts/bindings/usb-c/usb-c-connector.yaml
@@ -119,7 +119,8 @@ properties:
         * VDO_PCABLE
         * VDO_ACABLE
         * VDO_VPD
-      Valid range: 3 - 6
+    min: 3
+    max: 6
 
   sink-vdos-v1:
     type: array
@@ -132,7 +133,8 @@ properties:
         * VDO_PRODUCT
         * VDO_CABLE
         * VDO_AMA
-      Valid range: 3 - 6
+    min: 3
+    max: 6
 
   op-sink-microwatt:
     type: int

--- a/dts/bindings/usb/usb-audio-feature-volume.yaml
+++ b/dts/bindings/usb/usb-audio-feature-volume.yaml
@@ -17,7 +17,8 @@ properties:
       attention: this attribute is a signed value.
       This attribute represents the maximum volume level.
       The range from +127.9961 dB (0x7FFF) down to -127.9961 dB (0x8001).
-      Valid range: 0 - 0xFFFF
+    min: 0
+    max: 0xFFFF
   volume-min:
     type: int
     default: 0xBA00
@@ -25,7 +26,8 @@ properties:
       attention: this attribute is a signed value.
       This attribute represents the minimum volume level.
       The range from +127.9961 dB (0x7FFF) down to -127.9961 dB (0x8001).
-      Valid range: 0 - 0xFFFF
+    min: 0
+    max: 0xFFFF
   volume-res:
     type: int
     default: 0x100
@@ -34,4 +36,5 @@ properties:
       This attribute represents the volume resolution(step).
       1 = 1/256 dB or 0.00390625 dB.
       0x100(256) = 1dB.
-      Valid range: 1 - 0x7FFF
+    min: 1
+    max: 0x7FFF

--- a/dts/bindings/xspi/nxp,s32-xspi-sfp-mdad.yaml
+++ b/dts/bindings/xspi/nxp,s32-xspi-sfp-mdad.yaml
@@ -40,8 +40,9 @@ child-binding:
       default: 0
       description: |
         Defines the mask value for the ID-Match comparison.
-        Valid range: 0 - 63. The default corresponds to the
-        reset value of the register field.
+        The default corresponds to the reset value of the register field.
+      min: 0
+      max: 63
 
     domain-id:
       type: int

--- a/dts/bindings/xspi/nxp,s32-xspi-sfp-mdad.yaml
+++ b/dts/bindings/xspi/nxp,s32-xspi-sfp-mdad.yaml
@@ -48,4 +48,5 @@ child-binding:
       required: true
       description: |
         Domain ID Reference value of the Domain-ID (MID) for MID-comparison.
-        Valid range: 0 - 63.
+      min: 0
+      max: 63


### PR DESCRIPTION
This series proposes to replace most of the description of numerical DT properties ranges from the informative `descriptions` tag to the recently added build-time asserted `min:` and `max:` tags.

The biggest commit handles most case where something like `Valid range: VALUE1 - VALUE2` is used, with the help of the below shell script (awk command written with the assistance of *OPENAI - GPT54Mini*):
<details>
<summary>(shell script used for the biggest commit, click to expand)</summary>

```shell
#!/bin/bash -
# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
# SPDX-License-Identifier: Apache-2.0

set -o nounset

tempfile=`mktemp`
echo "tempfile: $tempfile"

# Replace the below description lines with min:/max: DT properties
# "Valid range: V1 - V2"
# "Valid range is V1 to V2"
# The valid range is V1 to V2"
# Take care of indentation.
# Possibly with: a terminal dot, brakets on value range "[V1 - V2]", space chars before ':'
# Value separator can possibly be "-", "...", or "to" (with space chars around)
# Handle case where "Valid range..." is not the last line of the description field.
awk_cmd()
{
  awk '
function process_line(line) {
  if (line ~ /^([[:space:]]*)description:/) {
    desc_indent = gensub(/^([[:space:]]*).*/, "\\1", 1, line)
    print line
    return
  }

  if (prev_indent != 0) {
    new_indent = gensub(/^([[:space:]]*).*/, "\\1", 1, line)
    if (prev_indent != 0 && new_indent <= prev_indent) {
      print prev_indent "min: " min
      print desc_indent "max: " max
      prev_indent = 0
    }
  }

  if ( \
    match(line, /^([[:space:]]*)(The valid|Valid) range[[:space:]]*(:|is)[[:space:]]*\[?([[:alnum:]]+)[[:space:]]*(,|-|to|\.*)[[:space:]]*([[:alnum:]]+)\]?\.?$/, m) \
  ) {
    prev_indent=desc_indent
    min=m[4]
    max=m[6]
  } else {
    print line
  }
}

NR == 1 {
  prev_line = $0
  next
}
{
  process_line(prev_line)
  prev_line = $0
}

END {
  process_line(prev_line)

  if (prev_indent != 0) {
    print desc_indent "min: " min
    print desc_indent "max: " max
  }
}
' $1  > $2
}

files=`grep -rsli "valid range" dts/bindings`
for f in $files; do
    awk_cmd $f $tempfile
    cat $tempfile > $f
done

rm $tempfile
echo "done, tempfile removed"

```

</details>

The other commits are manual changes based on remaining "valid range" occurrences in YAML files, plus a few changes on ST related YAML files, plus a few changes in generic YAML files.

Other changes:
* First commit removes value range info from **usb-c-connector.yaml** that seems not applicable.
* A last commit addresses a formatting issue in **ti,lp5562.yaml** file, reported during this P-R review.