### PR TITLE
soc: st: common: stm32cube_hal: add assertions glue for HAL2

### DIFF
--- a/soc/st/stm32/common/stm32cube_hal.c
+++ b/soc/st/stm32/common/stm32cube_hal.c
@@ -37,17 +37,31 @@ void HAL_Delay(__IO uint32_t Delay)
 }
 
 #ifdef CONFIG_USE_STM32_ASSERT
-/**
- * @brief Generates an assert on STM32Cube HAL/LL assert trigger.
- * @param file: specifies the file name where assert expression failed.
- * @param line: specifies the line number where assert expression failed.
- * @return None
- */
+#ifdef CONFIG_STM32_HAL2
+void assert_dbg_state_failed(uint8_t *file, uint32_t line)
+{
+	/*
+	 * New assertion hook exclusive to STM32Cube HAL2.
+	 * Called when state validation checks fail. For example, calling
+	 * a function that modifies a peripheral's configuration while the
+	 * peripheral is active would trigger this assertion.
+	 */
+	__ASSERT(false, "HAL assertion failed (illegal state) @ %s:%d\n", file, line);
+}
+
+void assert_dbg_param_failed(uint8_t *file, uint32_t line)
+{
+	/*
+	 * The assertion hook called when parameter validation checks fail
+	 * still exists in STM32Cube HAL2, but under a different name.
+	 */
+	__ASSERT(false, "HAL assertion failed (invalid parameter) @ %s:%d\n", file, line);
+}
+#else /* CONFIG_STM32_HAL2 */
 void assert_failed(uint8_t *file, uint32_t line)
 {
-	/* Assert condition have been verified at Cube level, force
-	 * generation here.
-	 */
-	__ASSERT(false, "Invalid value line %d @ %s\n", line, file);
+	/* Called when parameter validation checks fail */
+	__ASSERT(false, "HAL assertion failed (invalid parameter) @ %s:%d\n", file, line);
 }
+#endif /* CONFIG_STM32_HAL2 */
 #endif /* CONFIG_USE_STM32_ASSERT */


### PR DESCRIPTION
The STM32Cube HAL2 uses different hooks for assertion failures. Attempting to enable HAL assertions on series using HAL2 right now results in a build failure because we don't provide these hooks.

For example (log messages shortened for clarity):
```
$ west build samples/net/dhcpv4_client/ -b nucleo_c5a3zg -DCONFIG_ASSERT=y -DCONFIG_USE_STM32_ASSERT=y -p
   [...]
[293/298] Linking C executable zephyr/zephyr_pre0.elf
FAILED: zephyr/zephyr_pre0.elf zephyr/zephyr_pre0.map
ld.bfd: in function `HAL_RCC_PSI_GetConfig':
.../stm32c5xx/drivers/hal/stm32c5xx_hal_rcc.c:1596: undefined reference to `assert_dbg_param_failed'
ld.bfd: in function `HAL_ETH_SetConfig':
.../stm32c5xx/drivers/hal/stm32c5xx_hal_eth.c:1465: undefined reference to `assert_dbg_state_failed'
```

Add glue code needed for compatibility with HAL2 and, while at it, also clean up the HAL1-specific hook.

---

Tested (build only) by running
```
$ west build samples/net/dhcpv4_client/ -b nucleo_h743zi -DCONFIG_ASSERT=y -DCONFIG_USE_STM32_ASSERT=y -p
  [...HAL1-based series: builds OK...]
$ west build samples/net/dhcpv4_client/ -b nucleo_c5a3zg -DCONFIG_ASSERT=y -DCONFIG_USE_STM32_ASSERT=y -p
  [...HAL2-based series: builds OK...]
```