### PR TITLE
tests/kernel/threads/thread_stack: Exclude posix arch targets

### DIFF
--- a/tests/kernel/threads/thread_stack/testcase.yaml
+++ b/tests/kernel/threads/thread_stack/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  arch_exclude: posix # In this architecture we do not use the Zephyr managed stack
 tests:
   kernel.threads.thread_stack:
     tags:


### PR DESCRIPTION
In the POSIX architecture, we do not use the Zephyr allocated stacks, but rely on the automatically allocated underlaying host pthread stacks.

Therefore this test does not really make sense for this architecture, and can either fault or fail in all kinds of ways as many of the assumptions in the test do not hold.

It's almost a miracle this test did not break in the 6 years it was enabled for this arch f856d0cf40b5499522038dc0a69a335cfac39199