### PR TITLE
ipc: open-amp: Kconfig: improve appearance of rsc-table related items in menuconfig

### DIFF
--- a/subsys/ipc/open-amp/Kconfig
+++ b/subsys/ipc/open-amp/Kconfig
@@ -12,9 +12,10 @@ config OPENAMP_RSC_TABLE
 	  add the resource table in the generated binary. This table is
 	  compatible with linux remote proc framework and OpenAMP library.
 
+if OPENAMP_RSC_TABLE
+
 config OPENAMP_VENDOR_RSC_TABLE
 	bool "Vendor specific resource table"
-	depends on OPENAMP_RSC_TABLE
 	help
 	  Enable vendor-specific resource table with features
 	  supported by remote processor.
@@ -22,7 +23,6 @@ config OPENAMP_VENDOR_RSC_TABLE
 config OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF
 	int "Resource table number of rpmsg buffers"
 	default 0
-	depends on OPENAMP_RSC_TABLE
 	help
 	  This option specifies the number of buffer used in a Vring for
 	  interprocessor communication
@@ -30,7 +30,6 @@ config OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF
 config OPENAMP_RSC_TABLE_IPM_RX_ID
 	int "IPM RX channel ID"
 	default 0
-	depends on OPENAMP_RSC_TABLE
 	help
 	   This option specifies the IPM RX channel ID used in a VRING
 	   for interprocessor communication
@@ -38,7 +37,6 @@ config OPENAMP_RSC_TABLE_IPM_RX_ID
 config OPENAMP_RSC_TABLE_IPM_TX_ID
 	int "IPM TX channel ID"
 	default 1
-	depends on OPENAMP_RSC_TABLE
 	help
 	   This option specifies the IPM TX channel ID used in a VRING
 	   for interprocessor communication
@@ -54,7 +52,6 @@ config OPENAMP_VRING_ALIGNMENT
 
 config OPENAMP_COPY_RSC_TABLE
 	bool "Copy resource table section"
-	depends on OPENAMP_RSC_TABLE
 	help
 	  The .resource_table section must be placed in a specific location
 	  known by both this core and the remote core. If this is not taken
@@ -75,7 +72,6 @@ config OPENAMP_VENDOR_RSC_TABLE_FILE
 
 config OPENAMP_VENDOR_ADDR_TRANSLATION
 	bool "Address translation support for OpenAMP"
-	depends on OPENAMP_RSC_TABLE
 	help
 	  Enable support for address translation from remote driver to device
 
@@ -86,3 +82,5 @@ config OPENAMP_VENDOR_ADDR_TRANSLATION_FILE
 	help
 	  Name of a header file containing vendor-specific
 	  address translation table.
+
+endif

--- a/subsys/ipc/open-amp/Kconfig
+++ b/subsys/ipc/open-amp/Kconfig
@@ -20,6 +20,14 @@ config OPENAMP_VENDOR_RSC_TABLE
 	  Enable vendor-specific resource table with features
 	  supported by remote processor.
 
+config OPENAMP_VENDOR_RSC_TABLE_FILE
+	string "Source file containing vendor-specific resource table"
+	default "resource_table.c"
+	depends on OPENAMP_VENDOR_RSC_TABLE
+	help
+	  Name of a source file containing vendor-specific
+	  resource table.
+
 config OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF
 	int "Resource table number of rpmsg buffers"
 	default 0
@@ -61,14 +69,6 @@ config OPENAMP_COPY_RSC_TABLE
 
 	  This is not needed if the remote loads this firmware and has control
 	  over the placement of the .resource_table section such as remoteproc.
-
-config OPENAMP_VENDOR_RSC_TABLE_FILE
-	string "Source file containing vendor-specific resource table"
-	default "resource_table.c"
-	depends on OPENAMP_VENDOR_RSC_TABLE
-	help
-	  Name of a source file containing vendor-specific
-	  resource table.
 
 config OPENAMP_VENDOR_ADDR_TRANSLATION
 	bool "Address translation support for OpenAMP"


### PR DESCRIPTION
- Add 'depends on' for OPENAMP_VRING_ALGNMENT who depends on OPENAMP_RSC_TABLE. This also fixes
identation of items after this one within menuconfig.

- Move OPENAMP_VENDOR_RSC_TABLE_FILE just below OPEN_AMP_VENDOR_RSC_TABLE
who it depends on. This improves identation in menuconfig for other
config items.