### PR TITLE
valgrind: Suppress hasmap library realloc(ptr,size=0) warning

### DIFF
--- a/scripts/valgrind.supp
+++ b/scripts/valgrind.supp
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 {
    getpwuid() libC issue
    Memcheck:Leak
@@ -46,4 +48,11 @@
    match-leak-kinds: possible
    fun:malloc
    fun:lvgl_allocate_rendering_buffers
+}
+{
+   hash-map realloc as free
+   Memcheck:ReallocZero
+   fun:realloc
+   fun:sys_hashmap_*
+   ...
 }


### PR DESCRIPTION
Add to the valgrind suppression file a rule to waive the warning about the hash_map code using realloc() with size 0 as free().

Valgrind warns because this is not standard behaviour, but a (common) extension:
https://en.cppreference.com/c/memory/realloc

But this is the behaviour the API requires from a realloc used with this component:
https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/sys/hash_map_api.h#L76

As a freebie, add a license and copyright line to silence the CI check warning