### PR TITLE
drivers: clock_control: mcux_ccm: use QspiClkRoot on i.MX 8M

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -479,7 +479,11 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 #endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexspi))
 	case IMX_CCM_FLEXSPI_CLK:
+#ifdef CONFIG_SOC_SERIES_IMX8M
+		*rate = CLOCK_GetClockRootFreq(kCLOCK_QspiClkRoot);
+#else
 		*rate = CLOCK_GetClockRootFreq(kCLOCK_FlexspiClkRoot);
+#endif
 		break;
 #endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexspi2))


### PR DESCRIPTION
The NXP HAL for the i.MX 8M family (MIMX8MM, MIMX8MN, MIMX8MQ, MIMX8ML) exposes only kCLOCK_QspiClkRoot; kCLOCK_FlexspiClkRoot is unavailable, so building the IMX_CCM_FLEXSPI_CLK case of mcux_ccm_get_subsys_rate() fails for any board that adds a flexspi node on an 8M SoC.

Select kCLOCK_QspiClkRoot on CONFIG_SOC_SERIES_IMX8M and keep kCLOCK_FlexspiClkRoot for all other i.MX SoCs.