### PR TITLE
bluetooth: mesh: fix friend clear confirm dropped when sent by lpn

### DIFF
--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -248,13 +248,8 @@ int bt_mesh_friend_clear(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 	struct bt_mesh_ctl_friend_clear *msg = (void *)buf->data;
 	struct bt_mesh_friend *frnd;
 	uint16_t lpn_addr, lpn_counter;
-	struct bt_mesh_net_tx tx = {
-		.sub  = rx->sub,
-		.ctx  = &rx->ctx,
-		.src  = bt_mesh_primary_addr(),
-		.xmit = bt_mesh_net_transmit_get(),
-	};
-	struct bt_mesh_ctl_friend_clear_confirm cfm;
+	uint8_t xmit = bt_mesh_net_transmit_get();
+	int32_t delay;
 
 	if (buf->len < sizeof(*msg)) {
 		LOG_WRN("Too short Friend Clear");
@@ -283,15 +278,42 @@ int bt_mesh_friend_clear(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 		return 0;
 	}
 
-	tx.ctx->send_ttl = BT_MESH_TTL_MAX;
-
-	cfm.lpn_addr    = msg->lpn_addr;
-	cfm.lpn_counter = msg->lpn_counter;
-
-	bt_mesh_ctl_send(&tx, TRANS_CTL_OP_FRIEND_CLEAR_CFM, &cfm,
-			 sizeof(cfm), NULL, NULL);
+	/* Store context for the delayed Confirm before clearing the slot. */
+	frnd->clear.cfm.net_idx = rx->sub->net_idx;
+	frnd->clear.cfm.dst = rx->ctx.addr;
+	frnd->clear.cfm.lpn_addr = msg->lpn_addr;
+	frnd->clear.cfm.lpn_counter = msg->lpn_counter;
+	frnd->clear.cfm.ttl = rx->ctx.recv_ttl == 0 ? 0 : BT_MESH_TTL_MAX;
 
 	friend_clear(frnd);
+
+	/* Estimate how long the LPN advertises before it starts scanning.
+	 * The Friend does not know the LPN's actual Network Transmit state,
+	 * so we use our own as a best-effort approximation (nodes in the
+	 * same network typically share the same transmit configuration).
+	 *
+	 * The LPN retransmits its Friend Clear as (COUNT + 1) advertising
+	 * events. Between each pair of events the Mesh spec allows a random
+	 * delay of 0-10 ms on top of the configured interval, so the
+	 * worst-case gap is (interval + 10) ms.  The total advertising
+	 * duration is therefore at most (COUNT + 1) * (interval + 10) ms.
+	 *
+	 * Example with COUNT=2, interval=20 ms (3 events total):
+	 *
+	 *   t=0 ms    event 1
+	 *   t<=30 ms  event 2
+	 *   t<=60 ms  event 3 (last)
+	 *   t~=70 ms  LPN finishes, starts scanning
+	 *   t=delay   Timer fires, Friend sends Confirm
+	 *
+	 * The formula intentionally overestimates to provide margin for
+	 * scheduling jitter and scanner startup time.
+	 */
+	delay = (BT_MESH_TRANSMIT_COUNT(xmit) + 1) *
+		(BT_MESH_TRANSMIT_INT(xmit) + 10);
+
+	frnd->pending_cfm = 1U;
+	k_work_reschedule(&frnd->clear.timer, K_MSEC(delay));
 
 	return 0;
 }
@@ -832,6 +854,38 @@ static void clear_timeout(struct k_work *work)
 						   clear.timer);
 	uint32_t duration;
 
+	if (frnd->pending_cfm) {
+		struct bt_mesh_subnet *sub;
+		struct bt_mesh_msg_ctx ctx = {
+			.net_idx = frnd->clear.cfm.net_idx,
+			.app_idx = BT_MESH_KEY_UNUSED,
+			.addr = frnd->clear.cfm.dst,
+			.send_ttl = frnd->clear.cfm.ttl,
+		};
+		struct bt_mesh_net_tx tx = {
+			.ctx = &ctx,
+			.src = bt_mesh_primary_addr(),
+			.xmit = bt_mesh_net_transmit_get(),
+		};
+		struct bt_mesh_ctl_friend_clear_confirm cfm = {
+			.lpn_addr = frnd->clear.cfm.lpn_addr,
+			.lpn_counter = frnd->clear.cfm.lpn_counter,
+		};
+
+		frnd->pending_cfm = 0U;
+
+		sub = bt_mesh_subnet_get(frnd->clear.cfm.net_idx);
+		if (!sub) {
+			LOG_DBG("No subnet for Friend Clear Confirm");
+			return;
+		}
+
+		tx.sub = sub;
+		bt_mesh_ctl_send(&tx, TRANS_CTL_OP_FRIEND_CLEAR_CFM,
+				 &cfm, sizeof(cfm), NULL, NULL);
+		return;
+	}
+
 	if (frnd->clear.frnd == BT_MESH_ADDR_UNASSIGNED) {
 		/* Failed cancelling timer, return early. */
 		return;
@@ -1024,7 +1078,7 @@ int bt_mesh_friend_req(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 	}
 
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.frnd); i++) {
-		if (!bt_mesh.frnd[i].subnet) {
+		if (!bt_mesh.frnd[i].subnet && !bt_mesh.frnd[i].pending_cfm) {
 			frnd = &bt_mesh.frnd[i];
 			break;
 		}

--- a/subsys/bluetooth/mesh/lpn.h
+++ b/subsys/bluetooth/mesh/lpn.h
@@ -41,6 +41,15 @@ static inline bool bt_mesh_lpn_waiting_update(void)
 #endif
 }
 
+static inline bool bt_mesh_lpn_clearing(void)
+{
+#if defined(CONFIG_BT_MESH_LOW_POWER)
+	return (bt_mesh.lpn.state == BT_MESH_LPN_CLEAR);
+#else
+	return false;
+#endif
+}
+
 
 void bt_mesh_lpn_msg_received(struct bt_mesh_net_rx *rx);
 

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -62,7 +62,8 @@ struct bt_mesh_friend {
 	      send_last:1,
 	      pending_req:1,
 	      pending_buf:1,
-	      established:1;
+	      established:1,
+	      pending_cfm:1;
 	int32_t poll_to;
 	uint8_t  num_elem;
 	uint16_t lpn_counter;
@@ -91,12 +92,31 @@ struct bt_mesh_friend {
 	sys_slist_t queue;
 	uint32_t queue_size;
 
-	/* Friend Clear Procedure */
+	/* Friend Clear Procedure / Friend Clear Confirm */
 	struct {
-		uint32_t start;                  /* Clear Procedure start */
-		uint16_t frnd;                   /* Previous Friend's address */
-		uint16_t repeat_sec;             /* Repeat timeout in seconds */
-		struct k_work_delayable timer;   /* Repeat timer */
+		struct k_work_delayable timer;
+		union {
+			/* Friend Clear Procedure context */
+			struct {
+				uint32_t start;       /* Procedure start */
+				uint16_t frnd;        /* Previous Friend's address */
+				uint16_t repeat_sec;  /* Repeat timeout in seconds */
+			};
+			/* Pending Friend Clear Confirm context.
+			 * Delayed to allow the LPN to finish advertising
+			 * its Friend Clear and start scanning.
+			 * Scheduling this timer also cancels any ongoing
+			 * Friend Clear Procedure, which is no longer needed
+			 * since the friendship has been terminated.
+			 */
+			struct {
+				uint16_t net_idx;
+				uint16_t dst;
+				uint16_t lpn_addr;
+				uint16_t lpn_counter;
+				uint8_t ttl;
+			} cfm;
+		};
 	} clear;
 };
 

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1645,6 +1645,7 @@ int bt_mesh_trans_recv(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx)
 	 */
 	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER) &&
 	    bt_mesh_lpn_established() && rx->net_if == BT_MESH_NET_IF_ADV &&
+	    !bt_mesh_lpn_clearing() &&
 	    (!bt_mesh_lpn_waiting_update() || !rx->friend_cred)) {
 		LOG_WRN("Ignoring unexpected message in Low Power mode");
 		return -EAGAIN;

--- a/tests/bsim/bluetooth/mesh/src/test_friendship.c
+++ b/tests/bsim/bluetooth/mesh/src/test_friendship.c
@@ -5,6 +5,7 @@
  */
 #include "mesh_test.h"
 #include "mesh/net.h"
+#include "mesh/lpn.h"
 #include "mesh/transport.h"
 #include "mesh/va.h"
 #include <zephyr/sys/byteorder.h>
@@ -337,6 +338,24 @@ static void test_friend_group(void)
 	PASS();
 }
 
+
+/** Initialize as a friend, wait for establishment and termination. */
+static void test_friend_est_clear(void)
+{
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+	bt_mesh_friend_set(BT_MESH_FEATURE_ENABLED);
+
+	ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_FRIEND_ESTABLISHED,
+						       K_SECONDS(5)),
+		      "Friendship not established");
+
+	ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_FRIEND_TERMINATED,
+						       K_SECONDS(10)),
+		      "Friendship not terminated");
+
+	PASS();
+}
 
 /* Friend no-establish test functions */
 
@@ -1020,6 +1039,32 @@ static void test_other_group(void)
 	PASS();
 }
 
+/** Verify Friend Clear Confirm reception on LPN side. */
+static void test_lpn_clear_cfm(void)
+{
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+
+	bt_mesh_lpn_set(true);
+	ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_LPN_ESTABLISHED,
+						       K_SECONDS(5)),
+		      "LPN not established");
+
+	/* Terminate friendship — LPN sends Friend Clear to Friend */
+	bt_mesh_lpn_set(false);
+	ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_LPN_TERMINATED,
+						       K_SECONDS(5)),
+		      "LPN did not terminate friendship");
+
+	/* If Friend Clear Confirm was received, clear_friendship() sets
+	 * old_friend to BT_MESH_ADDR_UNASSIGNED. If it was not received
+	 * (retry exhaustion), old_friend would be set to the friend's address.
+	 */
+	ASSERT_EQUAL(BT_MESH_ADDR_UNASSIGNED, bt_mesh.lpn.old_friend);
+
+	PASS();
+}
+
 /** LPN disable test.
  *
  * Check that toggling lpn_set() results in correct disabled state
@@ -1181,6 +1226,85 @@ static void test_lpn_va_collision(void)
 	PASS();
 }
 
+/** Friend Clear Procedure: new Friend (C) clears old Friend (B). */
+static void test_friend_clear_proc(void)
+{
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+
+	/* Wait for LPN to establish with B first, then enable friend. */
+	k_sleep(K_SECONDS(5));
+
+	bt_mesh_friend_set(BT_MESH_FEATURE_ENABLED);
+
+	ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_FRIEND_ESTABLISHED,
+						       K_SECONDS(10)),
+		      "Friendship not established with LPN");
+
+	/* Verify clear procedure completed: frnd->clear.frnd is set to
+	 * BT_MESH_ADDR_UNASSIGNED only when bt_mesh_friend_clear_cfm()
+	 * processes an incoming Friend Clear Confirm message.
+	 */
+	k_sleep(K_SECONDS(3));
+	ASSERT_EQUAL(BT_MESH_ADDR_UNASSIGNED, bt_mesh.frnd[0].clear.frnd);
+
+	PASS();
+}
+
+static void test_other_clear_proc(void)
+{
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+	bt_mesh_friend_set(BT_MESH_FEATURE_ENABLED);
+
+	/* Establish friendship with LPN. */
+	ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_FRIEND_ESTABLISHED,
+						       K_SECONDS(5)),
+		      "Friendship not established with LPN");
+
+	/* LPN will force-disable without sending Friend Clear.
+	 * Later, the new Friend (C) sends Friend Clear to us.
+	 * Verify friendship terminated.
+	 */
+	ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_FRIEND_TERMINATED,
+						       K_SECONDS(15)),
+		      "Friendship not terminated by Friend Clear");
+
+	PASS();
+}
+
+static void test_lpn_clear_proc(void)
+{
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+
+	/* Step 1: Establish with Friend B (addr 0x0002). Friend C is not
+	 * available yet (sleeping for 5s).
+	 */
+	bt_mesh_lpn_set(true);
+	ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_LPN_ESTABLISHED,
+						       K_SECONDS(5)),
+		      "LPN not established with Friend B");
+	ASSERT_EQUAL(other_cfg.addr, bt_mesh.lpn.frnd);
+
+	/* Step 2: Force-disable LPN without sending Friend Clear.
+	 * This sets old_friend = Friend B's address.
+	 */
+	bt_mesh_lpn_disable(true);
+	ASSERT_EQUAL(other_cfg.addr, bt_mesh.lpn.old_friend);
+
+	/* Step 3: Wait for Friend C to enable, then re-establish. */
+	k_sleep(K_SECONDS(5));
+
+	bt_mesh_lpn_set(true);
+	ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_LPN_ESTABLISHED,
+						       K_SECONDS(10)),
+		      "LPN not established with Friend C");
+	ASSERT_EQUAL(friend_cfg.addr, bt_mesh.lpn.frnd);
+
+	PASS();
+}
+
 #define TEST_CASE(role, name, description)                  \
 	{                                                   \
 		.test_id = "friendship_" #role "_" #name,   \
@@ -1198,6 +1322,8 @@ static const struct bst_test_instance test_connect[] = {
 	TEST_CASE(friend, group,            "Friend: send to group addrs"),
 	TEST_CASE(friend, no_est,           "Friend: do not establish friendship"),
 	TEST_CASE(friend, va_collision,     "Friend: send to virtual addrs with collision"),
+	TEST_CASE(friend, est_clear,        "Friend: establish and wait for termination"),
+	TEST_CASE(friend, clear_proc,       "Friend: verify clear procedure completes"),
 
 	TEST_CASE(lpn,    est,              "LPN: establish friendship"),
 	TEST_CASE(lpn,    msg_frnd,         "LPN: message exchange with friend"),
@@ -1210,9 +1336,12 @@ static const struct bst_test_instance test_connect[] = {
 	TEST_CASE(lpn,    disable,          "LPN: disable LPN"),
 	TEST_CASE(lpn,    term_cb_check,    "LPN: no terminate cb trigger"),
 	TEST_CASE(lpn,    va_collision,     "LPN: receive on virtual addrs with collision"),
+	TEST_CASE(lpn,    clear_cfm,        "LPN: verify Friend Clear Confirm reception"),
+	TEST_CASE(lpn,    clear_proc,       "LPN: trigger Friend Clear Procedure"),
 
 	TEST_CASE(other,  msg,              "Other mesh device: message exchange"),
 	TEST_CASE(other,  group,            "Other mesh device: send to group addrs"),
+	TEST_CASE(other,  clear_proc,       "Other: old friend in clear procedure"),
 	BSTEST_END_MARKER
 };
 

--- a/tests/bsim/bluetooth/mesh/tests_scripts/friendship/clear_cfm.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/friendship/clear_cfm.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test LPN-initiated friendship termination with Friend Clear Confirm.
+#
+# Devices:
+#   A = LPN    (device 1, addr 0x0004)
+#   B = Friend (device 0, addr 0x0001)
+#
+# Scenario:
+# 1. A establishes friendship with B.
+# 2. A terminates by sending Friend Clear to B.
+# 3. B receives Friend Clear, terminates the friendship, and sends
+#    a delayed Friend Clear Confirm back to A.
+# 4. A receives the Confirm (verified by old_friend == UNASSIGNED).
+#    Without the delay, B's Confirm would be transmitted while A is
+#    still advertising its Friend Clear retransmissions.
+RunTest mesh_friendship_clear_cfm \
+	friendship_friend_est_clear \
+	friendship_lpn_clear_cfm

--- a/tests/bsim/bluetooth/mesh/tests_scripts/friendship/clear_proc.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/friendship/clear_proc.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test Friend Clear Procedure: new Friend (C) clears old Friend (B).
+#
+# Devices:
+#   A = LPN          (device 2, addr 0x0005)
+#   B = Old Friend   (device 1, addr 0x0002)
+#   C = New Friend   (device 0, addr 0x0001)
+#
+# Scenario:
+# 1. A establishes friendship with B (C is not yet available, delayed 5s)
+# 2. A force-disables LPN without sending Friend Clear, so B still
+#    considers the friendship active and old_friend is set to B's address
+# 3. A re-enables LPN and sends Friend Request with prev_addr=B.
+#    C responds first (lower device index) and establishes with A.
+# 4. C automatically starts the Friend Clear Procedure: sends Friend
+#    Clear (LPN addr + counter) to B.
+# 5. B finds the LPN in its slot, terminates the friendship, and
+#    responds with Friend Clear Confirm to C.
+# 6. C receives the Confirm and completes the clear procedure.
+RunTest mesh_friendship_clear_proc \
+	friendship_friend_clear_proc \
+	friendship_other_clear_proc \
+	friendship_lpn_clear_proc


### PR DESCRIPTION
## Problem

When the LPN terminates a friendship by sending Friend Clear (TTL=0), it never receives the Friend Clear Confirm from the Friend node. This is caused by two issues:

1. **Queue interception**: The Friend's Confirm was enqueued into the Friend Queue (for later polling), then immediately purged by `friend_clear()` which clears the queue.

2. **Radio timing overlap**: Even after fixing (1), the Friend transmits the Confirm while the LPN is still advertising its own Friend Clear retransmissions. Since a BLE device cannot scan while advertising, the LPN misses the Confirm entirely.

## Solution

### `subsys/bluetooth/mesh/friend.c`
- Call `friend_clear()` before sending Confirm, so the friendship is already terminated and `bt_mesh_friend_match()` won't intercept the outgoing message.
- Delay the Confirm transmission using a timer. The delay is calculated from network transmit parameters to ensure the LPN finishes advertising before the Confirm goes on air.
- Store the Confirm context (`net_idx`, `dst`, `lpn_addr`, `lpn_counter`, `ttl`) in `frnd->clear.cfm` and use the `pending_cfm` flag to distinguish the timer's purpose in `clear_timeout()`.
- Set TTL per spec: 0 if received TTL was 0, otherwise `BT_MESH_TTL_MAX`.

### `subsys/bluetooth/mesh/net.h`
- Add `pending_cfm` bit to `struct bt_mesh_friend`.
- Use an anonymous union inside `clear` struct to share memory between the clear procedure context and the Confirm context (they are mutually exclusive for the same slot).

### `subsys/bluetooth/mesh/transport.c`
- Bypass the LPN message filter when in `BT_MESH_LPN_CLEAR` state, so the incoming Confirm is not dropped.

## Tests

Two BabbleSim tests added:

- **`clear_cfm.sh`**: LPN establishes friendship, terminates it, and verifies the Confirm was received (`old_friend == UNASSIGNED`).
- **`clear_proc.sh`**: 3-device test where LPN moves from old Friend (B) to new Friend (C). Verifies C sends Friend Clear to B, B terminates and responds with Confirm, and C completes the clear procedure.