### PR TITLE
tests/bluetooth/audio: Be sure to free all malloc'ed memory

### DIFF
--- a/tests/bluetooth/audio/bap_base/src/main.c
+++ b/tests/bluetooth/audio/bap_base/src/main.c
@@ -101,6 +101,7 @@ static void bap_base_test_suite_after(void *f)
 	struct bap_base_test_suite_fixture *fixture = f;
 
 	free(fixture->valid_base_data);
+	free(fixture->invalid_base_data);
 }
 
 static void bap_base_test_suite_teardown(void *f)

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
@@ -34,6 +34,7 @@ struct cap_initiator_test_unicast_group_fixture {
 	struct bt_cap_unicast_group_param *group_param;
 	struct bt_cap_unicast_group *unicast_group;
 	struct bt_bap_qos_cfg *qos_cfg;
+	void *cap_streams;
 };
 
 static void *cap_initiator_test_unicast_group_setup(void)
@@ -88,6 +89,7 @@ static void cap_initiator_test_unicast_group_before(void *f)
 		pair_cnt = str_cnt / 2U;
 	}
 
+	fixture->cap_streams = cap_streams;
 	fixture->group_param->packing = BT_ISO_PACKING_SEQUENTIAL;
 	fixture->group_param->params_count = pair_cnt;
 	fixture->group_param->params = pair_params;
@@ -109,7 +111,7 @@ static void cap_initiator_test_unicast_group_after(void *f)
 
 	group_param = fixture->group_param;
 
-	free(group_param->params[0].rx_param->stream);
+	free(fixture->cap_streams);
 	free(group_param->params[0].rx_param);
 	free(group_param->params);
 	free(group_param);


### PR DESCRIPTION
To avoid memory leak warnings with valgrind.

The one in bap_base is evident.

The other is due to a tests that is purposely overwriting the stream pointer to NULL.
Which means it is lost and can't be free'd.
So, let's make sure we free it at the end of each test by keeping the cap_streams ptr in the fixture.
