### PR TITLE
soc: espressif: fix psram heap and linker-reserved window

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -28,7 +28,7 @@ if WIFI_ESP32
 config HEAP_MEM_POOL_ADD_SIZE_ESP_WIFI
 	int
 	default 51200 if ESP_WIFI_HEAP_SYSTEM
-	default 19456 if ESP_WIFI_HEAP_SPIRAM
+	default 25400 if ESP_WIFI_HEAP_SPIRAM
 	help
 	  Make sure there is a minimal heap available for Wi-Fi driver.
 

--- a/soc/espressif/common/esp_psram.c
+++ b/soc/espressif/common/esp_psram.c
@@ -18,6 +18,8 @@ extern int _rodata_reserved_end;
 
 extern int _ext_ram_bss_start;
 extern int _ext_ram_bss_end;
+extern int _ext_ram_heap_start;
+extern int _ext_ram_heap_end;
 
 struct shared_multi_heap_region smh_psram = {
 	.attr = SMH_REG_ATTR_EXTERNAL,
@@ -64,14 +66,20 @@ void esp_init_psram(void)
 	}
 
 	esp_psram_get_mapped_region(&mapped_vaddr, &mapped_size);
+	ARG_UNUSED(mapped_vaddr);
+	ARG_UNUSED(mapped_size);
 
 	/*
-	 * Use the runtime MMU-mapped address for the heap. On SoCs with
-	 * unified cache (e.g. C5, C6, H2), the exact virtual address
-	 * depends on MMU page allocation at runtime.
+	 * Use the linker-reserved heap window inside the PSRAM-backed
+	 * .ext_ram.data output section. The linker places ext_ram_noinit
+	 * and ext_ram_bss content before the heap, so starting the SMH
+	 * region at the raw MMU-mapped base would overlap and clobber
+	 * those allocations (e.g. relocated thread stacks and net packet
+	 * pools under CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM).
 	 */
-	smh_psram.addr = (uintptr_t)mapped_vaddr;
-	smh_psram.size = MIN(mapped_size, CONFIG_ESP_SPIRAM_HEAP_SIZE);
+	smh_psram.addr = (uintptr_t)&_ext_ram_heap_start;
+	smh_psram.size = (uintptr_t)&_ext_ram_heap_end -
+			 (uintptr_t)&_ext_ram_heap_start;
 
 	if (IS_ENABLED(CONFIG_ESP_SPIRAM_MEMTEST)) {
 		if (esp_psram_is_initialized()) {

--- a/soc/espressif/esp32c5/default.ld
+++ b/soc/espressif/esp32c5/default.ld
@@ -88,8 +88,11 @@ MEMORY
 
 #if defined(CONFIG_ESP_SPIRAM)
   /* ext_dram_seg and irom0_0_seg share the same bus (unified cache address space).
+   * Size the segment to the cache window so the dummy section reserved for
+   * flash content plus the PSRAM heap window always fit; the actual usable
+   * PSRAM is capped at link time by the ext_ram-overflow ASSERT below.
    * A dummy section is used to skip flash content and avoid overlap. */
-  ext_dram_seg(RW): org = IROM_SEG_ORG, len = CONFIG_ESP_SPIRAM_SIZE
+  ext_dram_seg(RW): org = EXTRAM_START, len = EXTRAM_SIZE
 #endif
 
 #if CONFIG_ESP32_ULP_COPROC_ENABLED
@@ -766,8 +769,23 @@ SECTIONS
   .dram0.noinit (NOLOAD):
   {
     . = ALIGN(4);
+#ifdef CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM
+    *(EXCLUDE_FILE(
+      *libdrivers__wifi.a:*
+      *libsubsys__net__l2__ethernet.a:*
+      *libsubsys__net__lib__config.a:*
+      *libsubsys__net__ip.a:*
+      *libsubsys__net.a:* ) .noinit)
+    *(EXCLUDE_FILE(
+      *libdrivers__wifi.a:*
+      *libsubsys__net__l2__ethernet.a:*
+      *libsubsys__net__lib__config.a:*
+      *libsubsys__net__ip.a:*
+      *libsubsys__net.a:* ) .noinit.*)
+#else
     *(.noinit)
     *(.noinit.*)
+#endif /* CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM */
 #ifdef CONFIG_USERSPACE
     z_user_stacks_start = .;
     *(.user_stacks*)
@@ -1018,6 +1036,14 @@ SECTIONS
   {
     _ext_ram_start = ABSOLUTE(.);
     _ext_ram_noinit_start = ABSOLUTE(.);
+
+#ifdef CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM
+    *libdrivers__wifi.a:(.noinit .noinit.*)
+    *libsubsys__net__l2__ethernet.a:(.noinit .noinit.*)
+    *libsubsys__net__lib__config.a:(.noinit .noinit.*)
+    *libsubsys__net__ip.a:(.noinit .noinit.*)
+    *libsubsys__net.a:(.noinit .noinit.*)
+#endif
     . = ALIGN(16);
     *(.ext_ram_noinit.*)
     . = ALIGN(16);

--- a/soc/espressif/esp32c5/memory.h
+++ b/soc/espressif/esp32c5/memory.h
@@ -91,9 +91,11 @@
 #define DROM_SEG_ORG IROM_SEG_ORG
 #define DROM_SEG_LEN FLASH_SIZE
 
-/* External RAM (PSRAM)
- * From HAL soc.h: SOC_EXTRAM_DATA_LOW = 0x42000000, SOC_EXTRAM_DATA_HIGH = 0x44000000
- * Shares the same bus as IROM/DROM (unified cache).
+/* External RAM (PSRAM) cache window. Derived from the DT ext_ram node so
+ * the linker uses the full virtual range the MMU can map (32 MB on c5),
+ * not the physical chip size. Shares the same bus as IROM/DROM (unified
+ * cache). Physical PSRAM size is enforced by the ext_ram-overflow ASSERT
+ * in default.ld using CONFIG_ESP_SPIRAM_SIZE.
  */
-#define EXTRAM_START 0x42000000
-#define EXTRAM_SIZE  0x2000000
+#define EXTRAM_START DT_REG_ADDR(DT_NODELABEL(ext_ram))
+#define EXTRAM_SIZE  DT_REG_SIZE(DT_NODELABEL(ext_ram))

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -32,9 +32,9 @@ procpu_drom_len = DCACHE0_SIZE - APPCPU_ROM_SIZE;
 
 #if defined(CONFIG_ESP_SPIRAM)
 procpu_ext_dram_org = procpu_drom_org;
-procpu_ext_dram_len = CONFIG_ESP_SPIRAM_SIZE;
+procpu_ext_dram_len = procpu_drom_len;
 procpu_ext_iram_org = procpu_irom_org;
-procpu_ext_iram_len = CONFIG_ESP_SPIRAM_SIZE;
+procpu_ext_iram_len = procpu_irom_len;
 #endif
 
 /* RTC RAM memory segments */


### PR DESCRIPTION
Wi-Fi on PSRAM-enabled builds was failing because the shared multi heap overlapped relocated .ext_ram.data noinit content. Anchor the heap on the linker-reserved window, size esp32c5 and esp32s3 ext segments to the cache window and bump the Wi-Fi SPIRAM heap floor.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/109602