### PR TITLE
Correct dcmi gpio-nexus bindings file and add ST camera / display connectors in shield porting doc

### DIFF
--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -69,7 +69,7 @@
 	};
 
 	dsi_lcd_qsh_030: connector_dsi_lcd {
-		compatible = "st,dsi-lcd-qsh-030";
+		compatible = "st,dsi-lcd-qsh-030-connector";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/st/stm32h747i_disco/stm32h747i_disco.dtsi
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco.dtsi
@@ -86,7 +86,7 @@
 	};
 
 	dsi_lcd_qsh_030: connector_dsi_lcd {
-		compatible = "st,dsi-lcd-qsh-030";
+		compatible = "st,dsi-lcd-qsh-030-connector";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/st/stm32h747i_disco/stm32h747i_disco.dtsi
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco.dtsi
@@ -104,7 +104,7 @@
 	};
 
 	dcmi_camera_connector: connector_dcmi_camera {
-		compatible = "st,stm32-dcmi-camera-fpu-330zh";
+		compatible = "st,dvp-cam-zif-30-connector";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/st/stm32h757i_eval/stm32h757i_eval.dtsi
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval.dtsi
@@ -92,7 +92,7 @@
 	};
 
 	dsi_lcd_qsh_030: connector_dsi_lcd {
-		compatible = "st,dsi-lcd-qsh-030";
+		compatible = "st,dsi-lcd-qsh-030-connector";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -73,7 +73,7 @@
 	};
 
 	dcmi_camera_connector: connector_dcmi_camera {
-		compatible = "st,stm32-dcmi-camera-fpu-330zh";
+		compatible = "st,dvp-cam-zif-30-connector";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -68,7 +68,7 @@
 	};
 
 	dcmi_camera_connector: connector_dcmi_camera {
-		compatible = "st,stm32-dcmi-camera-fpu-330zh";
+		compatible = "st,dvp-cam-zif-30-connector";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
@@ -69,7 +69,7 @@
 	};
 
 	dcmi_camera_connector: connector_dcmi_camera {
-		compatible = "st,stm32-dcmi-camera-fpu-330zh";
+		compatible = "st,dvp-cam-zif-30-connector";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
@@ -91,7 +91,7 @@
 	};
 
 	dsi_lcd_qsh_030: connector_dsi_lcd {
-		compatible = "st,dsi-lcd-qsh-030";
+		compatible = "st,dsi-lcd-qsh-030-connector";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
+++ b/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
@@ -46,7 +46,7 @@
 	};
 
 	dsi_lcd_qsh_030: connector_dsi_lcd {
-		compatible = "st,dsi-lcd-qsh-030";
+		compatible = "st,dsi-lcd-qsh-030-connector";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
+++ b/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
@@ -58,7 +58,7 @@
 	};
 
 	dsi_lcd_qsh_030: connector_dsi_lcd {
-		compatible = "st,dsi-lcd-qsh-030";
+		compatible = "st,dsi-lcd-qsh-030-connector";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -143,6 +143,8 @@ These describe connections to cameras and displays (strictly speaking not shield
 - :dtcompatible:`nxp,cam-44pins-connector`
 - :dtcompatible:`nxp,parallel-lcd-connector`
 - :dtcompatible:`raspberrypi,csi-connector`
+- :dtcompatible:`st,dsi-lcd-qsh-030-connector`
+- :dtcompatible:`st,dvp-cam-zif-30-connector`
 - :dtcompatible:`weact,dcmi-camera-connector`
 
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -477,6 +477,10 @@ STM32
   boards which modified the ``interrupts`` property on either node must be updated
   to set the property on the top-level ``&radio`` node instead. (:github:`110546`)
 
+* Renamed ST gpio-nexus for camera and display connectors as follow:
+  ``st,dsi-lcd-qsh-030`` is renamed into :dtcompatible:`st,dsi-lcd-qsh-030-connector`
+  ``st,stm32-dcmi-camera-fpu-330zh`` is renamed into :dtcompatible:`st,dvp-cam-zif-30-connector`
+
 Syscon
 ======
 

--- a/dts/bindings/gpio/st,dsi-lcd-qsh-030-connector.yaml
+++ b/dts/bindings/gpio/st,dsi-lcd-qsh-030-connector.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2023 bytes at work AG
+# Copyright (c) 2026 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -37,6 +38,6 @@ description: |
      57   RESET                           -  (58)
     (59)  -                               -  (60)
 
-compatible: "st,dsi-lcd-qsh-030"
+compatible: "st,dsi-lcd-qsh-030-connector"
 
 include: [gpio-nexus.yaml, base.yaml]

--- a/dts/bindings/gpio/st,dvp-cam-zif-30-connector.yaml
+++ b/dts/bindings/gpio/st,dvp-cam-zif-30-connector.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2025 Charles Dias
+# Copyright (c) 2026 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -35,6 +36,6 @@ description: |
     (29)  SPI_CLK
     (30)  GND
 
-compatible: "st,dcmi-camera-fpu-330zh"
+compatible: "st,dvp-cam-zif-30-connector"
 
 include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
Added the 2 missing ST camera / display connectors description in the shield porting doc.

While doing so, I noticed that the dcmi (camera) binding file didn't match the compatible used in the boards.
While for boards st,stm32-dcmi-camera-fpu-330zh compatible was beings used, the bindings file was refering to st,dcmi-camera-fpu-330zh.
I chose to update the bindings file since doing so it won't break any board device-tree, however the demerit of doing so is that the compatible naming isn't well aligned with others:

```
- :dtcompatible:`arducam,dvp-20pin-connector`
- :dtcompatible:`nxp,cam-44pins-connector`
- :dtcompatible:`nxp,parallel-lcd-connector`
- :dtcompatible:`raspberrypi,csi-connector`
- :dtcompatible:`st,stm32-dcmi-camera-fpu-330zh
- :dtcompatible:`st,dsi-lcd-qsh-030`
- :dtcompatible:`weact,dcmi-camera-connector`
```

So, maybe it should be better to keep the current bindings file (st,dcmi-camera-fpu-330zh) and instead update the compatible on all occurence within boards dts (in which case add an entry into the migration-guide probably). @erwango ?