### PR TITLE
Bluetooth: Specify unit of RSSI

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1476,7 +1476,7 @@ struct bt_le_ext_adv_info {
 	/** Local identity handle. */
 	uint8_t                    id;
 
-	/** Currently selected Transmit Power (dBM). */
+	/** Currently selected Transmit Power in dBm. Range: -127 to +20. */
 	int8_t                     tx_power;
 
 	/** Advertising Set ID */
@@ -1512,7 +1512,9 @@ int bt_le_ext_adv_get_info(const struct bt_le_ext_adv *adv,
  * and will be called for any discovered LE device.
  *
  * @param addr Advertiser LE address and type.
- * @param rssi Strength of advertiser signal.
+ * @param rssi Strength of advertiser signal in dBm. Range: -127 to +20.
+ *             May be set to @ref BT_GAP_RSSI_INVALID when the value is not
+ *             available.
  * @param adv_type Type of advertising response from advertiser.
  *                 Uses the @ref bt_gap_adv_type values.
  * @param buf Buffer containing advertiser data.
@@ -1724,10 +1726,18 @@ struct bt_le_per_adv_sync_recv_info {
 	/** Advertising Set Identifier, valid range @ref BT_GAP_SID_MIN to @ref BT_GAP_SID_MAX. */
 	uint8_t sid;
 
-	/** The TX power of the advertisement. */
+	/** @brief The TX power of the advertisement in dBm.
+	 *
+	 *  Range: -127 to +20. May be set to @ref BT_GAP_TX_POWER_INVALID when the
+	 *  value is not available.
+	 */
 	int8_t tx_power;
 
-	/** The RSSI of the advertisement excluding any CTE. */
+	/** @brief The RSSI of the advertisement (excluding any CTE), in dBm.
+	 *
+	 *  Range: -127 to +20. May be set to @ref BT_GAP_RSSI_INVALID when the value
+	 *  is not available.
+	 */
 	int8_t rssi;
 
 	/** The Constant Tone Extension (CTE) of the advertisement (@ref bt_df_cte_type) */
@@ -2364,10 +2374,18 @@ struct bt_le_scan_recv_info {
 	/** Advertising Set Identifier, valid range @ref BT_GAP_SID_MIN to @ref BT_GAP_SID_MAX. */
 	uint8_t sid;
 
-	/** Strength of advertiser signal. */
+	/** @brief Strength of advertiser signal in dBm.
+	 *
+	 *  Range: -127 to +20. May be set to @ref BT_GAP_RSSI_INVALID when the value
+	 *  is not available.
+	 */
 	int8_t rssi;
 
-	/** Transmit power of the advertiser. */
+	/** @brief Transmit power of the advertiser in dBm.
+	 *
+	 *  Range: -127 to +20. May be set to @ref BT_GAP_TX_POWER_INVALID when the
+	 *  value is not available.
+	 */
 	int8_t tx_power;
 
 	/**

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -64,7 +64,7 @@ struct bt_br_discovery_result {
 	/** Remote device address */
 	bt_addr_t addr;
 
-	/** RSSI from inquiry */
+	/** RSSI from inquiry in dBm. Range: -127 to +20. */
 	int8_t rssi;
 
 	/** Class of Device */

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1285,10 +1285,20 @@ struct bt_conn_le_tx_power {
 	/** Input: 1M, 2M, Coded S2 or Coded S8 */
 	uint8_t phy;
 
-	/** Output: current transmit power level */
+	/** @brief Output: current transmit power level in dBm.
+	 *
+	 *  Range depends on which HCI command is used:
+	 *  - -30 to +20 when @p phy is 0 (HCI_Read_Transmit_Power_Level)
+	 *  - -127 to +20 when @p phy is non-zero (HCI_LE_Enhanced_Read_Transmit_Power_Level)
+	 */
 	int8_t current_level;
 
-	/** Output: maximum transmit power level */
+	/** @brief Output: maximum transmit power level in dBm.
+	 *
+	 *  Range depends on which HCI command is used:
+	 *  - -30 to +20 when @p phy is 0 (HCI_Read_Transmit_Power_Level)
+	 *  - -127 to +20 when @p phy is non-zero (HCI_LE_Enhanced_Read_Transmit_Power_Level)
+	 */
 	int8_t max_level;
 };
 

--- a/include/zephyr/bluetooth/cs.h
+++ b/include/zephyr/bluetooth/cs.h
@@ -73,8 +73,8 @@ struct bt_le_cs_set_default_settings_param {
 	/** Antenna identifier to be used for CS_SYNC packets by the local controller.
 	 */
 	enum bt_le_cs_sync_antenna_selection_opt cs_sync_antenna_selection;
-	/** Maximum output power (Effective Isotropic Radiated Power) to be used
-	 *  for all CS transmissions.
+	/** Maximum output power (Effective Isotropic Radiated Power) in dBm,
+	 *  to be used for all CS transmissions.
 	 *
 	 *  Value range is @ref BT_HCI_OP_LE_CS_MIN_MAX_TX_POWER to
 	 *  @ref BT_HCI_OP_LE_CS_MAX_MAX_TX_POWER.
@@ -278,7 +278,7 @@ struct bt_le_cs_test_param {
 	 *  A value of 0 means that this parameter is ignored.
 	 */
 	uint8_t max_num_subevents;
-	/** Desired TX power level for the CS procedure.
+	/** Desired TX power level for the CS procedure, in dBm.
 	 *
 	 *  Value range is @ref BT_HCI_OP_LE_CS_MIN_MAX_TX_POWER to
 	 *  @ref BT_HCI_OP_LE_CS_MAX_MAX_TX_POWER.

--- a/include/zephyr/bluetooth/gap.h
+++ b/include/zephyr/bluetooth/gap.h
@@ -145,9 +145,13 @@ enum bt_gap_adv_prop {
  */
 #define BT_GAP_ADV_MAX_EXT_ADV_DATA_LEN         1650
 
+/** Sentinel value indicating that the TX power level in dBm is not available or unknown. */
 #define BT_GAP_TX_POWER_INVALID                 0x7f
+/** Sentinel value indicating that the RSSI in dBm is not available or unknown. */
 #define BT_GAP_RSSI_INVALID                     0x7f
+/** Sentinel value indicating that the Advertising Set Identifier is invalid or unknown. */
 #define BT_GAP_SID_INVALID                      0xff
+/** Sentinel value indicating that no timeout is set. */
 #define BT_GAP_NO_TIMEOUT                       0x0000
 
 /* The maximum allowed high duty cycle directed advertising timeout, 1.28


### PR DESCRIPTION
The RSSI and tx_power fields in the public Bluetooth API didn't mention
their unit. Document them as dBm, including value ranges and references
to the BT_GAP_RSSI_INVALID / BT_GAP_TX_POWER_INVALID sentinels.
Also add Doxygen comments to the BT_GAP_*_INVALID and
BT_GAP_NO_TIMEOUT sentinels in gap.h.

Fixes: #55480