### PR TITLE
boards: rpi_pico2: Add led dtsi to supported board targets

### DIFF
--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_hazard3.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_hazard3.dts
@@ -16,3 +16,4 @@
 #include <raspberrypi/rpi_pico/rp2350a.dtsi>
 #include <riscv/raspberrypi/hazard3.dtsi>
 #include "rpi_pico2.dtsi"
+#include "../common/rpi_pico-led.dtsi"

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_mcuboot.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_mcuboot.dts
@@ -20,6 +20,7 @@
  * implemented) Hazard3 cores.
  */
 #include "rpi_pico2.dtsi"
+#include "../common/rpi_pico-led.dtsi"
 
 /* Partitioning for the RP2350A-M33 board using 4M flash.
  */


### PR DESCRIPTION
The `rpi_pico2/rp2350a/hazard3/` and `rpi_pico2/rp2350a/m33/mcuboot` board targets should be able to use the on-board led to build and run the blinky and pwm-led samples. The common rpi_pico-led.dtsi was previously included in the rpi_pico2.dtsi file, but was removed because the wifi variants of the rpi_pico2 do not have the on-board led. See commit: d28a755c028

Include the common rpi_pico-led.dtsi for the board variants that should have it.