### PR TITLE
boards: bflb: bl706_iot_dvk: add openocd runner config

### DIFF
--- a/boards/bflb/bl70x/bl706_iot_dvk/board.cmake
+++ b/boards/bflb/bl70x/bl706_iot_dvk/board.cmake
@@ -1,6 +1,14 @@
 # SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(openocd --cmd-pre-init "source [find target/bl702.cfg]")
+
+board_runner_args(openocd --file-type=elf --no-load)
+board_runner_args(openocd --gdb-init "set print asm-demangle on")
+board_runner_args(openocd --gdb-init "mem 0x21000000 0x21030000 ro")
+board_runner_args(openocd --gdb-init "mem 0x23000000 0x24000000 ro")
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+
 board_runner_args(bflb_mcu_tool --chipname bl702)
 include(${ZEPHYR_BASE}/boards/common/bflb_mcu_tool.board.cmake)
 


### PR DESCRIPTION
Adds openocd runner config for the bl706_iot_dvk. openocd uses the same configuration (`target/bl702.cfg`) for all bl70x chips.