### PR TITLE
drivers: intc: it8xxx2: fix race in interrupt restoration

### DIFF
--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -115,6 +115,7 @@ void __soc_ram_code ite_intc_irq_enable(unsigned int irq)
 {
 	uint32_t g, i;
 	volatile uint8_t *en;
+	volatile uint8_t _ier __unused;
 
 	if (irq > CONFIG_NUM_IRQS) {
 		return;
@@ -126,6 +127,12 @@ void __soc_ram_code ite_intc_irq_enable(unsigned int irq)
 	/* critical section due to run a bit-wise OR operation */
 	unsigned int key = irq_lock();
 	SET_MASK(*en, BIT(i));
+	ier_setting[g] |= BIT(i);
+	/*
+	 * This load operation will guarantee the above modification of
+	 * SOC's register can be seen by any following instructions.
+	 */
+	_ier = *en;
 	irq_unlock(key);
 }
 
@@ -145,6 +152,7 @@ void __soc_ram_code ite_intc_irq_disable(unsigned int irq)
 	/* critical section due to run a bit-wise OR operation */
 	unsigned int key = irq_lock();
 	CLEAR_MASK(*en, BIT(i));
+	ier_setting[g] &= ~BIT(i);
 	/*
 	 * This load operation will guarantee the above modification of
 	 * SOC's register can be seen by any following instructions.


### PR DESCRIPTION
There is an issue (ec watchdog timeout) on the Chromebook Ciri platform during FAFT stress testing.

After our investigation, we found there is a race condition risk between disabling and restoring interrupts. During the stress test, flash erase operations [disable all interrupts](https://source.chromium.org/chromiumos/chromiumos/codesearch/+/main:src/platform/ec/zephyr/drivers/cros_flash/cros_flash_it8xxx2.c;drc=6e45855cf221b9dcadd845d2103b128579cd86b4;l=314) before execution and [restore them](https://source.chromium.org/chromiumos/chromiumos/codesearch/+/main:src/platform/ec/zephyr/drivers/cros_flash/cros_flash_it8xxx2.c;drc=6e45855cf221b9dcadd845d2103b128579cd86b4;l=335) afterward. If the adc interrupt is enabled during this window, the outdated interrupt state may be restored. As result, the adc interrupt enable bit may become unexpectedly disabled, which can eventually trigger the ec watchdog timeout.

To fix this issue, the firmware records the interrupt state to `ier_setting[]` whenever an interrupt is enabled/disabled, ensuring that the latest interrupt state is restored correctly.

Tested with: FAFT test passed on the Ciri platform
