### PR TITLE
Add frdm imxrt1186 kpp feature

### DIFF
--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -32,6 +32,5 @@ supported:
   - usbd
   - sdhc
   - dac
-  - kpp
   - i2s
 vendor: nxp

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.yaml
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -29,6 +29,5 @@ supported:
   - spi
   - uart
   - dac
-  - kpp
   - i2s
 vendor: nxp

--- a/samples/subsys/input/input_dump/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/samples/subsys/input/input_dump/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * External 2x2 keypad wiring on FRDM-IMXRT1186 Arduino headers:
+ *
+ *   Keypad term    SoC pin         Arduino socket    KPP signal
+ *   -----------    -------------   --------------    ----------
+ *   R1             GPIO_EMC_B1_14  J1-10             KPP_ROW0
+ *   R2             GPIO_AD_16      J51-4             KPP_ROW5
+ *   C1             GPIO_EMC_B1_15  J1-12             KPP_COL0
+ *   C2             GPIO_AD_17      J51-6             KPP_COL5
+ *
+ * Required jumper settings (default is ECAT route, switch to Arduino):
+ *   J28 = 2-3  (route GPIO_AD_16 to Arduino J51-4)
+ *   J32 = 2-3  (route GPIO_AD_17 to Arduino J51-6)
+ */
+
+&pinctrl {
+	kpp_default: kpp_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_16_kpp_row5>,
+				 <&iomuxc_gpio_emc_b1_14_kpp_row0>,
+				 <&iomuxc_gpio_ad_17_kpp_col5>,
+				 <&iomuxc_gpio_emc_b1_15_kpp_col0>;
+			drive-strength = "high";
+			bias-pull-up;
+			slew-rate = "fast";
+		};
+	};
+};
+
+&kpp {
+	pinctrl-0 = <&kpp_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/samples/subsys/input/input_dump/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/samples/subsys/input/input_dump/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "frdm_imxrt1186_mimxrt1186_cm33.overlay"

--- a/samples/subsys/input/input_dump/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/samples/subsys/input/input_dump/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -1,14 +1,8 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-/ {
-	aliases {
-		kpp = &kpp;
-	};
-};
 
 &pinctrl {
 	kpp_default: kpp_default {

--- a/samples/subsys/input/input_dump/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/samples/subsys/input/input_dump/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -1,14 +1,8 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-/ {
-	aliases {
-		kpp = &kpp;
-	};
-};
 
 &pinctrl {
 	kpp_default: kpp_default {

--- a/samples/subsys/input/input_dump/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/samples/subsys/input/input_dump/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -4,22 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&pinctrl {
-	kpp_default: kpp_default {
-		group0 {
-			pinmux = <&iomuxc_gpio_sd_b1_00_kpp_row7
-				  &iomuxc_gpio_sd_b1_01_kpp_col7
-				  &iomuxc_gpio_sd_b1_02_kpp_row6
-				  &iomuxc_gpio_sd_b1_03_kpp_col6>;
-			drive-strength = "high";
-			bias-pull-up;
-			slew-rate = "fast";
-		};
-	};
-};
-
-&kpp {
-	pinctrl-0 = <&kpp_default>;
-	pinctrl-names = "default";
-	status = "okay";
-};
+#include "mimxrt1180_evk_mimxrt1189_cm33.overlay"


### PR DESCRIPTION
- Add overlay enabling the KPP controller for an external 2x2 keypad wired to the Arduino headers. The overlay header documents pin wiring and J28/J32 jumper position. 
- Declare the kpp capability in both core variants' YAML.
- Remove the redundant configurations from the mimxrt1180-evk
- Replace the cm7 overlay body with #include "..._cm33.overlay" to remove the duplicated KPP config across cores (addresses review feedback).