### PR TITLE
scripts: twister: tolerate qemu self-cleanup of qemu.pid

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -1110,9 +1110,15 @@ class QEMUHandler(Handler):
                 logger.debug("Timed out while monitoring QEMU output")
 
             if os.path.exists(self.pid_fn):
-                with open(self.pid_fn) as pid_file:
-                    qemu_pid = int(pid_file.read())
-                os.unlink(self.pid_fn)
+                try:
+                    with open(self.pid_fn) as pid_file:
+                        qemu_pid = int(pid_file.read())
+                    os.unlink(self.pid_fn)
+                except FileNotFoundError:
+                    # QEMU may have exited and removed its own pid file
+                    # between the existence check above and the unlink
+                    # here. Don't let that crash the whole pipeline.
+                    pass
 
         logger.debug(f"return code from QEMU ({qemu_pid}): {self.returncode}")
 


### PR DESCRIPTION
QEMUHandler.handle() reads the qemu pid file at the end of a run and then unlinks it:

    if os.path.exists(self.pid_fn):
        with open(self.pid_fn) as pid_file:
            qemu_pid = int(pid_file.read())
        os.unlink(self.pid_fn)

The existence check and the unlink are not atomic. When qemu exits on its own (slow benchmark hitting a harness timeout, hostshutdown issued via the monitor, qemu killed by an external signal, ...) it removes its own pid file. If that removal lands between the os.path.exists() check and the os.unlink() call, unlink() raises FileNotFoundError. The exception escapes handle(), is caught in runner.py pipeline_mgr, and the worker process exits, aborting the whole twister run. Other tests that had not yet been scheduled never get to run, and tests still in flight on other DUTs are abandoned.

Replace the existence check with a try/except FileNotFoundError around the read + unlink. A missing pid file at cleanup time is not an error -- by definition the qemu process is gone, which is exactly the post-condition the cleanup is trying to reach.

Reproduced with a long-running benchmark on a slow qemu target where qemu hit its harness eof and exited a few ms before twister got around to the unlink. With this fix the failing test is marked FAILED and the run continues; without it the pipeline aborts on the FileNotFoundError.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>