### PR TITLE
drivers: mspi: stm32 ospi, xspi, qspi drivers with several instances

### DIFF
--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -1409,7 +1409,13 @@ static int mspi_stm32_ospi_pm_action(const struct device *dev, enum pm_device_ac
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                     \
 		.mspicfg.num_ce_gpios = ARRAY_SIZE(ce_gpios##index),                               \
 		.dma_specified = DT_INST_NODE_HAS_PROP(index, dmas),                               \
-	};                                                                                         \
+	};                                                                                     \
+	\
+	static const struct mspi_dev_id mspi_stm32_dev_id_##index = {                \
+		.ce = {0},                                                               \
+		.dev_idx = index,                                                        \
+	};                                                                           \
+	\
 	static struct mspi_stm32_data mspi_stm32_dev_data_##index = {                              \
 		.hmspi.ospi = {                                                                    \
 			.Init = {                                                                  \
@@ -1424,7 +1430,7 @@ static int mspi_stm32_ospi_pm_action(const struct device *dev, enum pm_device_ac
 			},                                                                         \
 		},                                                                                 \
 		.memmap_base_addr = DT_INST_REG_ADDR_BY_IDX(index, 1),                             \
-		.dev_id = index,                                                                   \
+		.dev_id = &mspi_stm32_dev_id_##index,                                            \
 		.lock = Z_MUTEX_INITIALIZER(mspi_stm32_dev_data_##index.lock),                     \
 		.sync = Z_SEM_INITIALIZER(mspi_stm32_dev_data_##index.sync, 0, 1),                 \
 		.dev_cfg = {0},                                                                    \

--- a/drivers/mspi/mspi_stm32_qspi.c
+++ b/drivers/mspi/mspi_stm32_qspi.c
@@ -1330,7 +1330,12 @@ static DEVICE_API(mspi, mspi_stm32_qspi_driver_api) = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                 \
 		.dma_specified = DT_INST_NODE_HAS_PROP(index, dmas),                           \
 	};                                                                                     \
-                                                                                               \
+	\
+	static const struct mspi_dev_id mspi_stm32_dev_id_##index = {                \
+		.ce = {0},                                                               \
+		.dev_idx = index,                                                        \
+	};                                                                           \
+	\
 	static struct mspi_stm32_data mspi_stm32_qspi_dev_data_##index = {                     \
 		.hmspi.qspi = {                                                                \
 			.Instance = (QUADSPI_TypeDef *)DT_INST_REG_ADDR(index),                \
@@ -1348,7 +1353,7 @@ static DEVICE_API(mspi, mspi_stm32_qspi_driver_api) = {
 			},                                                                     \
 		},                                                                             \
 		.memmap_base_addr = DT_INST_REG_ADDR_BY_IDX(index, 1),                         \
-		.dev_id = index,                                                               \
+		.dev_id = &mspi_stm32_dev_id_##index,                                            \
 		.lock = Z_MUTEX_INITIALIZER(mspi_stm32_qspi_dev_data_##index.lock),            \
 		.sync = Z_SEM_INITIALIZER(mspi_stm32_qspi_dev_data_##index.sync, 0, 1),        \
 		.dev_cfg = {0},                                                                \

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -1481,6 +1481,12 @@ static int mspi_stm32_xspi_pm_action(const struct device *dev, enum pm_device_ac
 		.mspicfg.num_ce_gpios = ARRAY_SIZE(ce_gpios##index),                              \
 		.dma_specified = DT_INST_NODE_HAS_PROP(index, dmas),                              \
 	};                                                                                        \
+	\
+	static const struct mspi_dev_id mspi_stm32_dev_id_##index = {                \
+		.ce = {0},                                                               \
+		.dev_idx = index,                                                        \
+	};                                                                           \
+	\
 	static struct mspi_stm32_data mspi_stm32_dev_data_##index = {                             \
 		.hmspi.xspi = {                                                                   \
 			.Init = {                                                                 \
@@ -1498,7 +1504,7 @@ static int mspi_stm32_xspi_pm_action(const struct device *dev, enum pm_device_ac
 			},                                                                        \
 		},                                                                                \
 		.memmap_base_addr = DT_INST_REG_ADDR_BY_IDX(index, 1),                            \
-		.dev_id = index,                                                                  \
+		.dev_id = &mspi_stm32_dev_id_##index,                                            \
 		.lock = Z_MUTEX_INITIALIZER(mspi_stm32_dev_data_##index.lock),                    \
 		.sync = Z_SEM_INITIALIZER(mspi_stm32_dev_data_##index.sync, 0, 1),                \
 		.dev_cfg = {0},                                                                   \


### PR DESCRIPTION
Correct the dev_id when x-spi 1&2 are enabled.
Index is a structure reflecting the mspi_dev_id instance,

Authored: Sarah Younis <zephyr@exalt.ps>