### PR TITLE
dts: vendor: nordic: Fix sram node names

### DIFF
--- a/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
@@ -16,7 +16,7 @@
  */
 
 &cpuapp_sram {
-	sram0_s: image_s@0 {
+	sram0_s: sram@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Secure image memory */
@@ -24,7 +24,7 @@
 		ranges = <0x0 0x0 DT_SIZE_K(96)>;
 	};
 
-	sram0_ns: image_ns@18000 {
+	sram0_ns: sram@18000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Non-Secure image memory */

--- a/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
@@ -15,7 +15,7 @@
  * needs to happen both in the flash_layout.h and in this file at the same time.
  */
 &cpuapp_sram {
-	sram0_s: image_s@0 {
+	sram0_s: sram@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Secure image memory */
@@ -23,7 +23,7 @@
 		ranges = <0x0 0x0 DT_SIZE_K(128)>;
 	};
 
-	sram0_ns: image_ns@20000 {
+	sram0_ns: sram@20000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Non-Secure image memory */

--- a/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
@@ -17,7 +17,7 @@
  * needs to happen both in the flash_layout.h and in this file at the same time.
  */
 &cpuapp_sram {
-	sram0_s: image_s@0 {
+	sram0_s: sram@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Secure image memory */
@@ -25,7 +25,7 @@
 		ranges = <0x0 0x0 DT_SIZE_K(256)>;
 	};
 
-	sram0_ns: image_ns@40000 {
+	sram0_ns: sram@40000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Non-Secure image memory */

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -17,7 +17,7 @@
  * needs to happen both in the flash_layout.h and in this file at the same time.
  */
 &cpuapp_sram {
-	sram0_s: image_s@0 {
+	sram0_s: sram@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Secure image memory */
@@ -25,7 +25,7 @@
 		ranges = <0x0 0x0 DT_SIZE_K(256)>;
 	};
 
-	sram0_ns: image_ns@40000 {
+	sram0_ns: sram@40000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Non-Secure image memory */

--- a/samples/tfm_integration/psa_crypto/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/tfm_integration/psa_crypto/boards/nrf9160dk_nrf9160_ns.overlay
@@ -4,34 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Modify the SRAM partitioning to accommodate the requirements
- * for the Secure (TF-M) firmware for the configuration that is
- * used in this sample.
- */
-
-/* Increase the size of the Secure Firmware (TF-M).
- * This modification is not required at the moment,
- * since TF-M region definitions are configured
- * statically in the TF-M project.
- */
-&sram0_s {
-	reg = <0x20000000 DT_SIZE_K(88)>;
-};
-
-/* Decrease the size of the Non-Secure Firmware (Zephyr),
- * and move its starting address to the offset expected by
- * TF-M.
- */
-/delete-node/ &sram0_ns;
-
-/ {
-	reserved-memory {
-		sram0_ns: image_ns@20016000 {
-			reg = <0x20016000 DT_SIZE_K(168)>;
-		};
-	};
-};
-
 /* Disable UART1, because it is used by default in TF-M */
 &uart1 {
 	status = "disabled";


### PR DESCRIPTION
    Fixes wrong sram node names to properly be sram instead of
    image_[n]s

also

    samples: tfm_integration: psa_crypto: Remove wrong dts overlay bits
    
    Removes wrong dts changing bits in the overlay for the
    nrf9160dk/nrf9160/ns board target, which use an old (wrong) way of
    using reserved-memory, and even ignoring that are superfluous
    because it matches the default dts values anyhow
