### PR TITLE
arch: arm: link libatomic for C++ on ARMv6-M targets

### DIFF
--- a/arch/arm/CMakeLists.txt
+++ b/arch/arm/CMakeLists.txt
@@ -6,4 +6,8 @@ else()
   set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-littlearm)
 endif()
 
+if(CONFIG_CPU_CORTEX_M0 OR CONFIG_CPU_CORTEX_M0PLUS)
+  zephyr_link_libraries_ifdef(CONFIG_CPP atomic)
+endif()
+
 add_subdirectory(core)


### PR DESCRIPTION
## Problem

On ARMv6-M targets (Cortex-M0/M0+), using std::atomic in C++ code
causes a linker failure:

    undefined reference to `__atomic_compare_exchange_4'

ARMv6-M lacks native atomic instructions. GCC provides these via
libatomic, but Zephyr's ARM CMake does not link it for C++ builds.

## Solution

Conditionally link libatomic when CONFIG_CPP is enabled on
Cortex-M0/M0+ targets. This matches the pattern used in other
architectures that lack native atomics.

## Testing

Verified by building a minimal C++ application using std::atomic
targeting nucleo_l073rz (Cortex-M0+, ARMv6-M).

Fixes #109380