### PR TITLE
cmake: improve genex stripping from flags

### DIFF
--- a/cmake/compiler/target_template.cmake
+++ b/cmake/compiler/target_template.cmake
@@ -16,20 +16,13 @@ function(compiler_simple_options simple_options_out)
   get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_COMPILE_OPTIONS)
 
   set(simple_options "")
+  string(GENEX_STRIP "${flags}" flags)
 
-  foreach(flag ${flags})
-
-    # Include this flag if GENEX_STRIP has no effect,
-    # otherwise skip the whole thing
-
-    string(GENEX_STRIP "${flag}" sflag)
-    if(flag STREQUAL sflag)
-      if(flag MATCHES "^SHELL:[ ]*(.*)")
-        separate_arguments(flag UNIX_COMMAND ${CMAKE_MATCH_1})
-      endif()
-      list(APPEND simple_options ${flag})
+  foreach(flag IN LISTS flags)
+    if(flag MATCHES "^SHELL:[ ]*(.*)")
+      separate_arguments(flag UNIX_COMMAND ${CMAKE_MATCH_1})
     endif()
-
+    list(APPEND simple_options ${flag})
   endforeach()
 
   set(${simple_options_out} "${simple_options}" PARENT_SCOPE)


### PR DESCRIPTION
Move `string(GENEX_STRIP ...)` before the loop.

We want to strip generator expressions from INTERFACE_COMPILE_OPTIONS. This needs to be done before looping the list so that a compile  option list like this: `--arg1;$<1:--genarg1;--genarg2>;--arg2` are correctly processed as a list of
- --arg1
- --arg2

and not an invalid list of
- --arg1
- $<1:--genarg1
- --genarg2>
- --arg2

Fixes: #109611