### PR TITLE
ci: workflows: doc-build: disable pa11y check temporarily

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -163,6 +163,7 @@ jobs:
         genhtml --no-function-coverage --no-branch-coverage new.info -o coverage-report
 
     - name: Run accessibility check (pa11y)
+      if: false # temporarily disabled due to CI issues
       run: |
         apt-get update -qq && apt-get install -y --no-install-recommends \
           libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
@@ -247,9 +248,10 @@ jobs:
         tar --use-compress-program="xz -T0" -cf html-output.tar.xz --exclude html/_sources --exclude html/doxygen/xml --directory=doc/_build html
         tar --use-compress-program="xz -T0" -cf api-output.tar.xz --directory=doc/_build html/doxygen/html
         tar --use-compress-program="xz -T0" -cf api-coverage.tar.xz coverage-report
-        tar --use-compress-program="xz -T0" -cf accessibility-report.tar.xz pa11y-ci-report
+        # tar --use-compress-program="xz -T0" -cf accessibility-report.tar.xz pa11y-ci-report # temporarily disabled due to CI issues
 
     - name: Upload accessibility report
+      if: false # temporarily disabled due to CI issues
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: accessibility-report


### PR DESCRIPTION
Disable all things pa11y due to CI issues that are taking too long to fix :|
