### PR TITLE
flash: nrf_mram: limit Ready register check only to nrf54h series

### DIFF
--- a/drivers/flash/soc_flash_nrf_mram.c
+++ b/drivers/flash/soc_flash_nrf_mram.c
@@ -177,7 +177,7 @@ static int nrf_mram_erase_and_verify_word(uint32_t addr, size_t len)
 	return -EIO;
 }
 
-#ifdef CONFIG_MRAM_LATENCY
+#if defined(CONFIG_MRAM_LATENCY) && defined(CONFIG_SOC_SERIES_NRF54H)
 static inline bool nrf_mram_ready(uint32_t addr, uint32_t ironside_se_ver)
 {
 	if (ironside_se_ver < IRONSIDE_SE_SUPPORT_READY_VER) {


### PR DESCRIPTION
Ready registers are defined for the nrf54h series but not necesssary for other soc families.
Limit the Ready register check only to this family of socs.