### PR TITLE
shell: Initialize to 0 placeholder for dynamic_get callback

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1048,7 +1048,7 @@ static bool wildcard_check_report(const struct shell *sh, bool found,
  */
 static int execute(const struct shell *sh)
 {
-	struct shell_static_entry dloc; /* Memory for dynamic commands. */
+	struct shell_static_entry dloc = {0}; /* Memory for dynamic commands. */
 	const char *argv[CONFIG_SHELL_ARGC_MAX + 1] = {0}; /* +1 reserved for NULL */
 	const struct shell_static_entry *parent = selected_cmd_get(sh);
 	const struct shell_static_entry *entry = NULL;


### PR DESCRIPTION
Instead of relaying on the dynamic_get() callback initializing the whole struct shell_static_entry *entry,
pre-initialize it to 0, so previous garbage in the stack does not cause random behaviour.

The issue can be seen when running with valgrind, for example:
```
twister -p native_sim -T tests/drivers/comparator/shell/ --enable-valgrind
# or manually with
cmake -GNinja -DBOARD=native_sim ../tests/drivers/comparator/shell/
ninja
valgrind zephyr/zephyr.exe
```