### PR TITLE
soc: nxp: rw: fix logging module registration in power.c

### DIFF
--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -22,7 +22,7 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Active mode */
 #define POWER_MODE0		0


### PR DESCRIPTION
Replace `LOG_MODULE_DECLARE` with `LOG_MODULE_REGISTER` to properly initialize the 'soc' log module and prevent missing log output.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/109657