### PR TITLE
drivers: sensor: stts22h: fix threshold trigger missed after MCU reset

### DIFF
--- a/drivers/sensor/st/stts22h/stts22h.c
+++ b/drivers/sensor/st/stts22h/stts22h.c
@@ -256,7 +256,8 @@ static int stts22h_init(const struct device *dev)
 		.temp_lo = DT_INST_PROP(inst, temperature_lo_threshold),			\
 		.odr = DT_INST_PROP(inst, sampling_rate),					\
 		IF_ENABLED(CONFIG_STTS22H_TRIGGER,						\
-			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
+			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),	\
+			    .int_mode = DT_INST_PROP(inst, int_gpio_config),))			\
 	};											\
 												\
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, stts22h_init, NULL,					\

--- a/drivers/sensor/st/stts22h/stts22h.h
+++ b/drivers/sensor/st/stts22h/stts22h.h
@@ -25,6 +25,7 @@ struct stts22h_config {
 	const struct i2c_dt_spec i2c;
 #ifdef CONFIG_STTS22H_TRIGGER
 	const struct gpio_dt_spec int_gpio;
+	const uint8_t int_mode;
 #endif
 	uint8_t temp_hi;
 	uint8_t temp_lo;

--- a/drivers/sensor/st/stts22h/stts22h_trigger.c
+++ b/drivers/sensor/st/stts22h/stts22h_trigger.c
@@ -19,6 +19,11 @@
 
 LOG_MODULE_DECLARE(STTS22H, CONFIG_SENSOR_LOG_LEVEL);
 
+static const gpio_flags_t gpio_int_cfg[2] = {
+			GPIO_INT_EDGE_TO_ACTIVE,
+			GPIO_INT_LEVEL_ACTIVE,
+			};
+
 /**
  * stts22h_trigger_set - link external trigger to event data ready
  */
@@ -63,7 +68,7 @@ static void stts22h_handle_interrupt(const struct device *dev)
 		stts22h->thsld_handler(dev, stts22h->thsld_trigger);
 	}
 
-	gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	gpio_pin_interrupt_configure_dt(&cfg->int_gpio, gpio_int_cfg[cfg->int_mode]);
 }
 
 static void stts22h_gpio_callback(const struct device *dev,
@@ -158,5 +163,5 @@ int stts22h_init_interrupt(const struct device *dev)
 		return -EIO;
 	}
 
-	return gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	return gpio_pin_interrupt_configure_dt(&cfg->int_gpio, gpio_int_cfg[cfg->int_mode]);
 }

--- a/dts/bindings/sensor/st,stts22h-i2c.yaml
+++ b/dts/bindings/sensor/st,stts22h-i2c.yaml
@@ -19,6 +19,20 @@ properties:
       The property value should ensure the flags properly describe
       the signal that is presented to the driver.
 
+  int-gpio-config:
+    type: int
+    default: 1
+    description: |
+      Select the interrupt configuration for the INT gpio.
+
+      The default of 1 ensures an interrupt already pending
+      at boot is not missed.
+
+      - 0 # STTS22H_DT_GPIO_INT_EDGE_TO_ACTIVE
+      - 1 # STTS22H_DT_GPIO_INT_LEVEL_ACTIVE
+
+    enum: [0, 1]
+
   temperature-hi-threshold:
     type: int
     default: 0

--- a/include/zephyr/dt-bindings/sensor/stts22h.h
+++ b/include/zephyr/dt-bindings/sensor/stts22h.h
@@ -37,4 +37,8 @@
 
 /** @} */
 
+/* GPIO interrupt configuration */
+#define STTS22H_DT_GPIO_INT_EDGE_TO_ACTIVE 0 /*!< Edge-triggered interrupt */
+#define STTS22H_DT_GPIO_INT_LEVEL_ACTIVE   1 /*!< Level-triggered interrupt */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_STTS22H_H_ */


### PR DESCRIPTION
On a stts22h sensor, the threshold trigger can fail to fire after an MCU reset.

The INT pin is driven by two sticky bits in the STATUS register (UNDER_THL
and OVER_THH). Those bits are only cleared by reading STATUS and the value
of it is undefined at boot.

So at the moment `stts22h_init_interrupt()` runs, INT may already be asserted.
The driver then arms the gpio with `GPIO_INT_EDGE_TO_ACTIVE`.
The falling edge has already happened so the gpio controller misses it,
and since nothing ever reads STATUS the line stays asserted forever.

Fix: in `stts22h_init_interrupt()`, arm the gpio with `GPIO_INT_LEVEL_ACTIVE`
instead of `EDGE_TO_ACTIVE`. If INT is already asserted the handler fires
immediately, reads STATUS (clearing the latch), and re-arms the line in
edge mode.

Alternative considered: read STATUS at the end of `stts22h_init_interrupt()`
before arming the gpio irq. This keeps the edge_to_active, but leaves a
tiny race window, the chip can re-latch before the gpio irq is armed.
