### PR TITLE
kernel: sched: fix EDF deadline overflow in k_thread_deadline_set()

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1111,6 +1111,10 @@ __syscall void k_thread_priority_set(k_tid_t thread, int prio);
  * above this call, which is simply input to the priority selection
  * logic.
  *
+ * @note The relative deadline is silently clamped to a maximum of
+ * INT32_MAX / 2 (2^30 cycles) to preserve the scheduler's modular
+ * comparison invariants.
+ *
  * @kconfig_dep{CONFIG_SCHED_DEADLINE}
  *
  * @param thread A thread on which to set the deadline

--- a/kernel/deadline.c
+++ b/kernel/deadline.c
@@ -63,11 +63,18 @@ void z_impl_k_thread_absolute_deadline_set(k_tid_t tid, int deadline)
 
 void z_impl_k_thread_deadline_set(k_tid_t tid, int deadline)
 {
-	deadline = clamp(deadline, 0, INT_MAX);
+	/*
+	 * Clamp the relative deadline to INT32_MAX / 2 (2^30 cycles) to
+	 * satisfy the scheduler comparator's half-modulus invariant.
+	 * This leaves a 2^30-cycle margin of tolerance for scheduler
+	 * execution skew before priority inversion can occur.
+	 */
+	deadline = clamp(deadline, 0, INT32_MAX / 2);
 
-	int32_t newdl = k_cycle_get_32() + deadline;
+	/* Use uint32_t arithmetic to avoid implementation-defined signed conversion. */
+	uint32_t newdl = k_cycle_get_32() + (uint32_t)deadline;
 
-	z_impl_k_thread_absolute_deadline_set(tid, newdl);
+	z_impl_k_thread_absolute_deadline_set(tid, (int)newdl);
 }
 
 #ifdef CONFIG_USERSPACE


### PR DESCRIPTION
The relative deadline passed to k_thread_deadline_set() was added to the 32-bit cycle counter using signed int32_t arithmetic.  On a 12 MHz CPU the counter wraps in under 6 minutes; at higher frequencies even faster.  When the sum wrapped, the stored absolute deadline appeared to be in the past, breaking EDF ordering.

Fix by:
1. Clamping the relative deadline to INT32_MAX/2 to preserve the half-modulus invariant relied upon by z_sched_prio_cmp().
2. Performing the addition with uint32_t arithmetic so wrapping is well-defined (unsigned overflow, not signed UB).


Fixes : #109477