### PR TITLE
scripts: west: fix WEST_TOPDIR backslash path on Windows

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -702,7 +702,7 @@ class Build(Forceable):
         #
         # west build -- -DOVERLAY_CONFIG=relative-path.conf
         final_cmake_args = [f'-DWEST_PYTHON={pathlib.Path(sys.executable).as_posix()}',
-                            f'-DWEST_TOPDIR={west_topdir(self.source_dir)}',
+                            f'-DWEST_TOPDIR={pathlib.Path(str(west_topdir(self.source_dir))).as_posix()}',
                             f'-DWEST_VERSION={str(__version__)}',
                             f'-B{self.build_dir}',
                             f'-G{config_get("generator", DEFAULT_CMAKE_GENERATOR)}']


### PR DESCRIPTION
Commit bfa00dcd1f2 ("cmake: pass Python information from west build to CMake") changed WEST_TOPDIR from being obtained via execute_process(COMMAND ${WEST} topdir) to being passed directly from Python via -DWEST_TOPDIR=.

The west topdir CLI returns POSIX paths (C:/...) but the Python API west_topdir() returns native Windows paths (C:\...). When this path reaches check_c_compiler_flag via:

  zephyr_cc_option(-fmacro-prefix-map=${WEST_TOPDIR}=WEST_TOPDIR)

CMake interprets \U (from \Users) as an invalid escape sequence, breaking all Windows builds.

Use pathlib.Path.as_posix() to normalize the path, consistent with how WEST_PYTHON is already handled on the same line.