### PR TITLE
drivers: spi: mcux_flexcomm: fix DMA width for last TX word

### DIFF
--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -433,7 +433,11 @@ static int spi_mcux_dma_tx_load(const struct device *dev, const struct spi_confi
 		}
 		blk_cfg->source_address = (uint32_t)&data->last_word;
 		blk_cfg->source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
-		blk_cfg->block_size = data->word_size_bytes;
+		/* The last word is always 32 bits to include the EOT flag.
+		 * There are some special handling in the dma driver that will ensure
+		 * that the last transfer width is 32bit.
+		 */
+		blk_cfg->block_size = sizeof(uint32_t);
 		blk_cfg->next_block = NULL;
 	} else {
 		blk_cfg->block_size = len * data->word_size_bytes;


### PR DESCRIPTION
The last TX word must be written to FIFOWR as a full 32-bit write to properly set the EOT (end-of-transfer) control bit at bit 20. Commit 7cb3fca changed the DMA block_size for the last word from sizeof(uint32_t) to data->word_size_bytes, which meant only the lower data bytes were transferred, missing the EOT flag entirely.

Change the block_size af the last transfer back to sizeof(uint32_t). It seems counterintuitive that this will work, but deep down in the NXP DMA driver, there is some special handling that makes this work.
See dma_mcux_lpc.c (line 262-273)

Fixes: #107484