### PR TITLE
net: dsa: handle phy link change internally

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -185,6 +185,15 @@ Ethernet
   :kconfig:option:`CONFIG_PTP_CLOCK_NATIVE` is enabled by default when the
   :dtcompatible:`zephyr,native-ptp-clock` compatible is present.
 
+* ``port_phylink_change`` of the :c:struct:`dsa_api` is now optional.
+  The DSA driver no longer needs to call :c:func:`net_eth_carrier_on` or
+  :c:func:`net_eth_carrier_off` on PHY link change, this is now handled by the DSA core.
+  The ``void *user_data`` argument of ``port_phylink_change`` has been changed to
+  ``const struct device *dev``, so it no longer needs to be cast to obtain the device pointer.
+  Out-of-tree DSA drivers must update their ``port_phylink_change`` callback to match the new API and
+  can remove any calls to :c:func:`net_eth_carrier_on` or :c:func:`net_eth_carrier_off` from it.
+  (:github:`109671`)
+
 Flash
 =====
 * :dtcompatible:`jedec,spi-nand` now requires a ``plane-bytes`` property, which indicates the size

--- a/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
+++ b/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
@@ -192,7 +192,6 @@ static void dsa_netc_port_phylink_change(const struct device *phydev, struct phy
 					 void *user_data)
 {
 	const struct device *dev = (struct device *)user_data;
-	struct net_if *iface = net_if_lookup_by_dev(dev);
 	const struct dsa_port_config *cfg = dev->config;
 	struct dsa_switch_context *dsa_switch_ctx = dev->data;
 	struct dsa_netc_data *prv = PRV_DATA(dsa_switch_ctx);
@@ -206,10 +205,8 @@ static void dsa_netc_port_phylink_change(const struct device *phydev, struct phy
 		if (result != kStatus_Success) {
 			LOG_ERR("DSA user port %d failed to set MAC up", cfg->port_idx);
 		}
-		net_eth_carrier_on(iface);
 	} else {
 		LOG_INF("DSA user port %d Link down", cfg->port_idx);
-		net_eth_carrier_off(iface);
 	}
 }
 

--- a/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
+++ b/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
@@ -198,15 +198,12 @@ static void dsa_netc_port_phylink_change(const struct device *phydev, struct phy
 	status_t result;
 
 	if (state->is_up) {
-		LOG_INF("DSA user port %d Link up", cfg->port_idx);
 		result = SWT_SetEthPortMII(&prv->swt_handle, cfg->port_idx,
 					   PHY_TO_NETC_SPEED(state->speed),
 					   PHY_TO_NETC_DUPLEX_MODE(state->speed));
 		if (result != kStatus_Success) {
 			LOG_ERR("DSA user port %d failed to set MAC up", cfg->port_idx);
 		}
-	} else {
-		LOG_INF("DSA user port %d Link down", cfg->port_idx);
 	}
 }
 

--- a/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
+++ b/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
@@ -188,10 +188,9 @@ static int dsa_netc_switch_setup(const struct dsa_switch_context *dsa_switch_ctx
 	return 0;
 }
 
-static void dsa_netc_port_phylink_change(const struct device *phydev, struct phy_link_state *state,
-					 void *user_data)
+static void dsa_netc_port_phylink_change(const struct device *phy_dev __unused,
+					 struct phy_link_state *state, const struct device *dev)
 {
-	const struct device *dev = (struct device *)user_data;
 	const struct dsa_port_config *cfg = dev->config;
 	struct dsa_switch_context *dsa_switch_ctx = dev->data;
 	struct dsa_netc_data *prv = PRV_DATA(dsa_switch_ctx);

--- a/include/zephyr/net/dsa_core.h
+++ b/include/zephyr/net/dsa_core.h
@@ -108,8 +108,8 @@ struct dsa_api {
 	int (*port_init)(const struct device *dev);
 
 	/** Port link change */
-	void (*port_phylink_change)(const struct device *dev, struct phy_link_state *state,
-				    void *user_data);
+	void (*port_phylink_change)(const struct device *phy_dev, struct phy_link_state *state,
+				    const struct device *dev);
 
 #if defined(CONFIG_NET_L2_PTP) || defined(__DOXYGEN__)
 	/**

--- a/subsys/net/l2/ethernet/dsa/dsa_port.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_port.c
@@ -77,7 +77,7 @@ static void dsa_port_phylink_change(const struct device *phydev, struct phy_link
 	struct dsa_switch_context *dsa_switch_ctx = dev->data;
 
 	if (dsa_switch_ctx->dapi->port_phylink_change != NULL) {
-		dsa_switch_ctx->dapi->port_phylink_change(phydev, state, (void *)dev);
+		dsa_switch_ctx->dapi->port_phylink_change(phydev, state, dev);
 	}
 
 	if (state->is_up) {

--- a/subsys/net/l2/ethernet/dsa/dsa_port.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_port.c
@@ -69,11 +69,28 @@ out:
 	return err;
 }
 
+static void dsa_port_phylink_change(const struct device *phydev, struct phy_link_state *state,
+				    void *user_data)
+{
+	struct net_if *iface = (struct net_if *)user_data;
+	const struct device *dev = net_if_get_device(iface);
+	struct dsa_switch_context *dsa_switch_ctx = dev->data;
+
+	if (dsa_switch_ctx->dapi->port_phylink_change != NULL) {
+		dsa_switch_ctx->dapi->port_phylink_change(phydev, state, (void *)dev);
+	}
+
+	if (state->is_up) {
+		net_eth_carrier_on(iface);
+	} else {
+		net_eth_carrier_off(iface);
+	}
+}
+
 static void dsa_port_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	const struct dsa_port_config *cfg = dev->config;
-	struct dsa_switch_context *dsa_switch_ctx = dev->data;
 	char name[INTERFACE_NAME_LEN];
 	uint8_t mac_addr[6] = {0};
 	int ret;
@@ -113,12 +130,7 @@ static void dsa_port_iface_init(struct net_if *iface)
 		return;
 	}
 
-	if (dsa_switch_ctx->dapi->port_phylink_change == NULL) {
-		LOG_ERR("require port_phylink_change callback");
-		return;
-	}
-
-	phy_link_callback_set(cfg->phy_dev, dsa_switch_ctx->dapi->port_phylink_change, (void *)dev);
+	phy_link_callback_set(cfg->phy_dev, dsa_port_phylink_change, (void *)iface);
 }
 
 static const struct device *dsa_port_get_phy(const struct device *dev,


### PR DESCRIPTION
handle changing the carrier inside the dsa
subsystem and make implementing
port_phylink_change optional.

This way the dsa port driver only has to do the
device specific actions.

Due to this just making setting the carrier in the port driver redundant, it can be in two separate commits as it is not breaking.