### PR TITLE
modules: hal_atmel: bump to fix AFEC pins

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -162,7 +162,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: 8cd575049f04131e333558072484bfc6334c19c4
+      revision: 8f95c79f2a80427ef446563cc9addefa959e92a9
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
The pinconfig YAML for the s70, e70 and v7x has some typos for the AFEC. In particular, pin PE4 extra and PE5 extra should be AFEC0 instead of AFEC1.

PR for zephyrproject-rtos/hal_atmel#54.
Opened in favor of #100916.