### PR TITLE
net: tests: fix build warnings/errors on 64-bit

### DIFF
--- a/samples/net/quic/echo_client/src/main.c
+++ b/samples/net/quic/echo_client/src/main.c
@@ -282,7 +282,7 @@ static int process_stream(struct config *cfg, struct stream_ctx *stream)
 
 	if (stream->received < stream->expecting) {
 		/* More data still expected for this round. */
-		LOG_DBG("%s QUIC: stream fd=%d expecting %zd more data, missing %zd",
+		LOG_DBG("%s QUIC: stream fd=%d expecting %u more data, missing %d",
 			cfg->proto, stream->fd, stream->expecting,
 			stream->expecting - stream->received);
 		goto out;

--- a/subsys/net/lib/dns/dns_cache.c
+++ b/subsys/net/lib/dns/dns_cache.c
@@ -36,7 +36,7 @@ int dns_cache_add(struct dns_cache *cache, char const *query, struct dns_addrinf
 	}
 
 	if (strlen(query) >= CONFIG_DNS_RESOLVER_MAX_QUERY_LEN) {
-		NET_WARN("Query string to big to be processed %zu >= "
+		NET_WARN("Query string too big to be processed %zu >= "
 			 "CONFIG_DNS_RESOLVER_MAX_QUERY_LEN",
 			 strlen(query));
 		return -EINVAL;
@@ -82,7 +82,7 @@ int dns_cache_remove(struct dns_cache *cache, char const *query)
 
 	NET_DBG("Remove all entries with query \"%s\"", query);
 	if (strlen(query) >= CONFIG_DNS_RESOLVER_MAX_QUERY_LEN) {
-		NET_WARN("Query string to big to be processed %zu >= "
+		NET_WARN("Query string too big to be processed %zu >= "
 			 "CONFIG_DNS_RESOLVER_MAX_QUERY_LEN",
 			 strlen(query));
 		return -EINVAL;
@@ -121,7 +121,7 @@ int dns_cache_find(struct dns_cache const *cache, const char *query, enum dns_qu
 		return -EINVAL;
 	}
 	if (strlen(query) >= CONFIG_DNS_RESOLVER_MAX_QUERY_LEN) {
-		NET_WARN("Query string to big to be processed %zu >= "
+		NET_WARN("Query string too big to be processed %zu >= "
 			 "CONFIG_DNS_RESOLVER_MAX_QUERY_LEN",
 			 strlen(query));
 		return -EINVAL;

--- a/subsys/net/lib/dns/dns_cache.c
+++ b/subsys/net/lib/dns/dns_cache.c
@@ -36,7 +36,7 @@ int dns_cache_add(struct dns_cache *cache, char const *query, struct dns_addrinf
 	}
 
 	if (strlen(query) >= CONFIG_DNS_RESOLVER_MAX_QUERY_LEN) {
-		NET_WARN("Query string to big to be processed %u >= "
+		NET_WARN("Query string to big to be processed %zu >= "
 			 "CONFIG_DNS_RESOLVER_MAX_QUERY_LEN",
 			 strlen(query));
 		return -EINVAL;
@@ -82,7 +82,7 @@ int dns_cache_remove(struct dns_cache *cache, char const *query)
 
 	NET_DBG("Remove all entries with query \"%s\"", query);
 	if (strlen(query) >= CONFIG_DNS_RESOLVER_MAX_QUERY_LEN) {
-		NET_WARN("Query string to big to be processed %u >= "
+		NET_WARN("Query string to big to be processed %zu >= "
 			 "CONFIG_DNS_RESOLVER_MAX_QUERY_LEN",
 			 strlen(query));
 		return -EINVAL;
@@ -121,7 +121,7 @@ int dns_cache_find(struct dns_cache const *cache, const char *query, enum dns_qu
 		return -EINVAL;
 	}
 	if (strlen(query) >= CONFIG_DNS_RESOLVER_MAX_QUERY_LEN) {
-		NET_WARN("Query string to big to be processed %u >= "
+		NET_WARN("Query string to big to be processed %zu >= "
 			 "CONFIG_DNS_RESOLVER_MAX_QUERY_LEN",
 			 strlen(query));
 		return -EINVAL;

--- a/subsys/net/lib/midi2/netmidi2.c
+++ b/subsys/net/lib/midi2/netmidi2.c
@@ -205,7 +205,7 @@ static inline struct netmidi2_session *netmidi2_match_session(struct netmidi2_ep
 	for (size_t i = 0; i < CONFIG_NETMIDI2_HOST_MAX_CLIENTS; i++) {
 		if (ep->peers[i].addr_len == peer_addr_len &&
 		    memcmp(&ep->peers[i].addr, peer_addr, peer_addr_len) == 0) {
-			LOG_DBG("Found matching client session %d", i);
+			LOG_DBG("Found matching client session %zu", i);
 			return &ep->peers[i];
 		}
 	}
@@ -243,7 +243,7 @@ static inline struct netmidi2_session *netmidi2_try_alloc_session(struct netmidi
 			sess->addr_len = peer_addr_len;
 			sess->ep = ep;
 			memcpy(&sess->addr, peer_addr, peer_addr_len);
-			SESS_LOG_INF(sess, "new client session (%d)", i);
+			SESS_LOG_INF(sess, "new client session (%zu)", i);
 			return sess;
 		}
 	}

--- a/subsys/net/lib/mqtt/mqtt_decoder.c
+++ b/subsys/net/lib/mqtt/mqtt_decoder.c
@@ -151,7 +151,7 @@ static int unpack_raw_data(uint32_t length, struct buf_ctx *buf,
 		str->data = NULL;
 	}
 
-	NET_DBG("<< bin len:%08x", GET_BINSTR_BUFFER_SIZE(str));
+	NET_DBG("<< bin len:%08zx", GET_BINSTR_BUFFER_SIZE(str));
 
 	return 0;
 }
@@ -272,7 +272,7 @@ static int unpack_binary_data(struct buf_ctx *buf, struct mqtt_binstr *bin)
 		bin->data = NULL;
 	}
 
-	NET_DBG("<< bin len:%08x", GET_BINSTR_BUFFER_SIZE(bin));
+	NET_DBG("<< bin len:%08zx", GET_BINSTR_BUFFER_SIZE(bin));
 
 	return 0;
 }

--- a/subsys/net/lib/shell/ftp.c
+++ b/subsys/net/lib/shell/ftp.c
@@ -354,7 +354,7 @@ static int file_data_input(const struct shell *sh)
 
 	file_len = 0;
 
-	PR_INFO("Input mode (max %d characters). End the line with \\ to start a new one:\n",
+	PR_INFO("Input mode (max %zu characters). End the line with \\ to start a new one:\n",
 		sizeof(file_buf) - 1);
 
 	while (nextline) {

--- a/subsys/net/lib/shell/http_client.c
+++ b/subsys/net/lib/shell/http_client.c
@@ -383,10 +383,13 @@ static int http_client_handler(struct http_response *rsp, enum http_final_call f
 		return -ENODATA;
 	}
 
+	/* For use of .* we need to cast it to an int, on 64 bit platforms a size_t is bigger than
+	 * an int.
+	 */
 	if (ctx->verbose) {
-		shell_print(sh, "%.*s", rsp->recv_buf_len, rsp->recv_buf);
+		shell_print(sh, "%.*s", (int)rsp->recv_buf_len, rsp->recv_buf);
 	} else {
-		shell_print(sh, "%.*s", rsp->body_frag_len, rsp->body_frag_start);
+		shell_print(sh, "%.*s", (int)rsp->body_frag_len, rsp->body_frag_start);
 	}
 
 	return 0;

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -538,7 +538,7 @@ static void test_eth_setup(void)
 	net_if_foreach(iface_cb, &ud);
 
 	zassert_equal(ud.eth_if_count, sizeof(eth_interfaces) / sizeof(void *),
-		      "Invalid number of interfaces (%d vs %d)\n",
+		      "Invalid number of interfaces (%d vs %zu)\n",
 		      ud.eth_if_count,
 		      sizeof(eth_interfaces) / sizeof(void *));
 }

--- a/tests/net/conn_mgr_conn/src/main.c
+++ b/tests/net/conn_mgr_conn/src/main.c
@@ -683,7 +683,7 @@ ZTEST(conn_mgr_conn, test_conn_opt)
 	buf_len = sizeof(buf);
 	zassert_equal(conn_mgr_if_get_opt(ifa1, TEST_CONN_OPT_X, &buf, &buf_len),
 		       0, "conn_mgr_if_get_opt should succeed for valid parameters");
-	printk("%d, %d", buf_len, strlen(buf) + 1);
+	printk("%zu, %zu", buf_len, strlen(buf) + 1);
 	zassert_equal(buf_len, strlen(buf) + 1, "conn_mgr_if_get_opt should return valid optlen");
 	zassert_str_equal(buf, "A",
 			  "conn_mgr_if_get_opt should retrieve \"A\"");

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -1351,7 +1351,7 @@ ZTEST(net_iface, test_interface_name)
 	zassert_equal(ret, -ERANGE, "Unexpected value (%d) returned", ret);
 
 	ret = net_if_get_name(iface, buf, sizeof(buf) - 1);
-	zassert_equal(ret, strlen(name), "Unexpected value (%d) returned, expected %d",
+	zassert_equal(ret, strlen(name), "Unexpected value (%d) returned, expected %zu",
 		      ret, strlen(name));
 
 	ret = net_if_get_by_name(name);

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -2021,11 +2021,11 @@ ZTEST(coap, test_response_matching)
 		if (response->match != NULL) {
 			zassert_not_null(match, "Did not found a response match when expected");
 			zassert_equal_ptr(response->match, match,
-					  "Wrong response match, test %d match %d",
+					  "Wrong response match, test %td match %td",
 					  response - test_responses, match - matches);
 		} else {
 			zassert_is_null(match,
-					"Found unexpected response match, test %d match %d",
+					"Found unexpected response match, test %td match %td",
 					response - test_responses, match - matches);
 		}
 	}

--- a/tests/net/lib/dns_sd/src/main.c
+++ b/tests/net/lib/dns_sd/src/main.c
@@ -123,7 +123,7 @@ static uint8_t *create_query(const struct dns_sd_rec *inst,
 	offs += sizeof(struct dns_query);
 
 	zassert_equal(expected_req_buf_size, offs,
-		      "sz: %zu offs: %u", expected_req_buf_size, offs);
+		      "sz: %u offs: %u", expected_req_buf_size, offs);
 
 	*size = offs;
 

--- a/tests/net/lib/http_client/src/main.c
+++ b/tests/net/lib/http_client/src/main.c
@@ -382,9 +382,9 @@ ZTEST(http_client, test_http1_client_post_payload_cb)
 	zassert_true(ctx.final, "No final event received");
 	zassert_equal(ctx.status, 200, "Unexpected HTTP status code");
 	zassert_equal(dynamic_len, LOREM_IPSUM_SHORT_STRLEN,
-		      "Invalid payload length uploaded %d", dynamic_len);
+		      "Invalid payload length uploaded %zu", dynamic_len);
 	zassert_mem_equal(dynamic_buf, LOREM_IPSUM_SHORT, dynamic_len,
-			  "Invalid payload uploaded %d", dynamic_len);
+			  "Invalid payload uploaded %zu", dynamic_len);
 }
 
 static void client_tests_before(void *fixture)

--- a/tests/net/lib/mqtt/v5_0/mqtt_packet/src/mqtt_packet.c
+++ b/tests/net/lib/mqtt/v5_0/mqtt_packet/src/mqtt_packet.c
@@ -54,7 +54,7 @@ static void run_packet_tests(struct mqtt_test *tests, size_t count)
 	for (size_t i = 0; i < count; i++) {
 		struct mqtt_test *test = &tests[i];
 
-		TC_PRINT("Test #%u - %s\n", i + 1, test->test_name != NULL ?
+		TC_PRINT("Test #%zu - %s\n", i + 1, test->test_name != NULL ?
 			test->test_name : "");
 
 		test->test_fcn(test);

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -713,7 +713,7 @@ ZTEST(net_pkt_test_suite, test_net_pkt_pull)
 	zassert_equal(net_pkt_get_len(dummy_pkt),
 		      PULL_TEST_PKT_DATA_SIZE - PULL_AMOUNT -
 		      LARGE_PULL_AMOUNT,
-		      "Large pull failed to set new size (%d vs %d)",
+		      "Large pull failed to set new size (%zu vs %d)",
 		      net_pkt_get_len(dummy_pkt),
 		      PULL_TEST_PKT_DATA_SIZE - PULL_AMOUNT -
 		      LARGE_PULL_AMOUNT);
@@ -721,14 +721,14 @@ ZTEST(net_pkt_test_suite, test_net_pkt_pull)
 	net_pkt_cursor_init(dummy_pkt);
 	net_pkt_pull(dummy_pkt, net_pkt_get_len(dummy_pkt));
 	zassert_equal(net_pkt_get_len(dummy_pkt), 0,
-		      "Full pull failed to set new size (%d)",
+		      "Full pull failed to set new size (%zu)",
 		      net_pkt_get_len(dummy_pkt));
 
 	net_pkt_cursor_init(dummy_pkt);
 	ret = net_pkt_pull(dummy_pkt, 1);
 	zassert_equal(ret, -ENOBUFS, "Did not return error");
 	zassert_equal(net_pkt_get_len(dummy_pkt), 0,
-		      "Empty pull set new size (%d)",
+		      "Empty pull set new size (%zu)",
 		      net_pkt_get_len(dummy_pkt));
 
 	net_pkt_unref(dummy_pkt);
@@ -749,7 +749,7 @@ ZTEST(net_pkt_test_suite, test_net_pkt_pull)
 	ret = net_pkt_pull(dummy_pkt, net_pkt_get_len(dummy_pkt) + 1);
 	zassert_equal(ret, -ENOBUFS, "Did not return error");
 	zassert_equal(net_pkt_get_len(dummy_pkt), 0,
-		      "Not empty after full pull (%d)",
+		      "Not empty after full pull (%zu)",
 		      net_pkt_get_len(dummy_pkt));
 
 	net_pkt_unref(dummy_pkt);

--- a/tests/net/socket/af_inet_raw/src/main.c
+++ b/tests/net/socket/af_inet_raw/src/main.c
@@ -331,7 +331,7 @@ static void verify_raw_recv_success(int sock, net_sa_family_t family)
 
 	ret = zsock_recv(sock, rx_buf, sizeof(rx_buf), 0);
 	zassert_not_equal(ret, -1, "Failed to receive RAW packet (%d)", errno);
-	zassert_equal(ret, expected_len, "Invalid data size received (%d, expected %d)",
+	zassert_equal(ret, expected_len, "Invalid data size received (%d, expected %zu)",
 		      ret, expected_len);
 
 	validate_ip_udp_hdr(family, &src_addr, &dst_addr, rx_buf, ret);
@@ -416,7 +416,7 @@ static void test_raw_sock_send(net_sa_family_t family, enum net_ip_protocol prot
 	ret = zsock_recv(udp_sock, rx_buf, sizeof(rx_buf), 0);
 	zassert_not_equal(ret, -1, "Failed to receive UDP packet (%d)", errno);
 	zassert_equal(ret, sizeof(test_payload),
-		     "Invalid data size received (%d, expected %d)",
+		     "Invalid data size received (%d, expected %zu)",
 		      ret, sizeof(test_payload));
 	zassert_mem_equal(rx_buf, test_payload, sizeof(test_payload),
 			  "Invalid payload received");
@@ -466,7 +466,7 @@ static void test_raw_sock_sendto(net_sa_family_t family)
 	ret = zsock_recv(udp_sock, rx_buf, sizeof(rx_buf), 0);
 	zassert_not_equal(ret, -1, "Failed to receive UDP packet (%d)", errno);
 	zassert_equal(ret, sizeof(test_payload),
-		     "Invalid data size received (%d, expected %d)",
+		     "Invalid data size received (%d, expected %zu)",
 		      ret, sizeof(test_payload));
 	zassert_mem_equal(rx_buf, test_payload, sizeof(test_payload),
 			  "Invalid payload received");
@@ -505,7 +505,7 @@ static void test_raw_sock_sendmsg(net_sa_family_t family)
 	ret = zsock_recv(udp_sock, rx_buf, sizeof(rx_buf), 0);
 	zassert_not_equal(ret, -1, "Failed to receive UDP packet (%d)", errno);
 	zassert_equal(ret, sizeof(test_payload),
-		     "Invalid data size received (%d, expected %d)",
+		     "Invalid data size received (%d, expected %zu)",
 		      ret, sizeof(test_payload));
 	zassert_mem_equal(rx_buf, test_payload, sizeof(test_payload),
 			  "Invalid payload received");
@@ -600,7 +600,7 @@ static void test_raw_sock_recvfrom(net_sa_family_t family)
 	ret = zsock_recvfrom(raw_sock, rx_buf, sizeof(rx_buf), 0,
 			     &recv_addr, &recv_addrlen);
 	zassert_not_equal(ret, -1, "Failed to receive RAW packet (%d)", errno);
-	zassert_equal(ret, expected_len, "Invalid data size received (%d, expected %d)",
+	zassert_equal(ret, expected_len, "Invalid data size received (%d, expected %zu)",
 		      ret, expected_len);
 	validate_ip_udp_hdr(family, &src_addr, &dst_addr, rx_buf, ret);
 	zassert_mem_equal(rx_buf + headers_len, test_payload, sizeof(test_payload),
@@ -655,7 +655,7 @@ static void test_raw_sock_recvmsg(net_sa_family_t family)
 
 	ret = zsock_recvmsg(raw_sock, &msg, 0);
 	zassert_not_equal(ret, -1, "Failed to receive RAW packet (%d)", errno);
-	zassert_equal(ret, expected_len, "Invalid data size received (%d, expected %d)",
+	zassert_equal(ret, expected_len, "Invalid data size received (%d, expected %zu)",
 		      ret, expected_len);
 	validate_ip_udp_hdr(family, &src_addr, &dst_addr, rx_buf, ret);
 	zassert_mem_equal(rx_buf + headers_len, test_payload, sizeof(test_payload),
@@ -826,7 +826,7 @@ static void test_raw_and_udp_socks_recv(net_sa_family_t family)
 	ret = zsock_recv(raw_sock, rx_buf, sizeof(rx_buf), 0);
 	zassert_not_equal(ret, -1, "Failed to receive RAW packet (%d)", errno);
 	zassert_equal(ret, expected_len,
-		      "Invalid data size received (%d, expected %d)",
+		      "Invalid data size received (%d, expected %zu)",
 		      ret, expected_len);
 
 	validate_ip_udp_hdr(family, &src_addr, &dst_addr, rx_buf, ret);
@@ -836,7 +836,7 @@ static void test_raw_and_udp_socks_recv(net_sa_family_t family)
 	ret = zsock_recv(udp_sock_2, rx_buf, sizeof(rx_buf), 0);
 	zassert_not_equal(ret, -1, "Failed to receive UDP packet (%d)", errno);
 	zassert_equal(ret, sizeof(test_payload),
-		     "Invalid data size received (%d, expected %d)",
+		     "Invalid data size received (%d, expected %zu)",
 		      ret, sizeof(test_payload));
 	zassert_mem_equal(rx_buf, test_payload, sizeof(test_payload),
 			  "Invalid payload received");
@@ -872,7 +872,7 @@ static void test_packet_and_raw_socks_recv(net_sa_family_t family, uint16_t pack
 	ret = zsock_recv(packet_sock, rx_buf, sizeof(rx_buf), 0);
 	zassert_not_equal(ret, -1, "Failed to receive packet (%d)", errno);
 	zassert_equal(ret, expected_len,
-		      "Invalid data size received (%d, expected %d)",
+		      "Invalid data size received (%d, expected %zu)",
 		      ret, expected_len);
 
 	validate_ip_udp_hdr(family, &src_addr, &dst_addr, rx_buf, ret);
@@ -884,7 +884,7 @@ static void test_packet_and_raw_socks_recv(net_sa_family_t family, uint16_t pack
 	ret = zsock_recv(raw_sock, rx_buf, sizeof(rx_buf), 0);
 	zassert_not_equal(ret, -1, "Failed to receive RAW packet (%d)", errno);
 	zassert_equal(ret, expected_len,
-		      "Invalid data size received (%d, expected %d)",
+		      "Invalid data size received (%d, expected %zu)",
 		      ret, expected_len);
 
 	validate_ip_udp_hdr(family, &src_addr, &dst_addr, rx_buf, ret);

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -689,7 +689,7 @@ static void test_sendto_common(int sock_type, int proto, bool do_bind,
 		ret = zsock_recv(udp_sock_1, rx_buf, sizeof(rx_buf), 0);
 		zassert_not_equal(ret, -1, "Failed to receive UDP packet (%d)", errno);
 		zassert_equal(ret, sizeof(test_payload),
-			     "Invalid data size received (%d, expected %d)",
+			     "Invalid data size received (%d, expected %zu)",
 			      ret, sizeof(test_payload));
 		zassert_mem_equal(rx_buf, test_payload, sizeof(test_payload),
 				  "Invalid payload received");
@@ -747,7 +747,7 @@ static void test_sendmsg_common(int sock_type, int proto)
 	ret = zsock_recv(udp_sock_1, rx_buf, sizeof(rx_buf), 0);
 	zassert_not_equal(ret, -1, "Failed to receive UDP packet (%d)", errno);
 	zassert_equal(ret, sizeof(test_payload),
-		      "Invalid data size received (%d, expected %d)",
+		      "Invalid data size received (%d, expected %zu)",
 		      ret, sizeof(test_payload));
 	zassert_mem_equal(rx_buf, test_payload, sizeof(test_payload),
 			  "Invalid payload received");

--- a/tests/net/socket/misc/src/main.c
+++ b/tests/net/socket/misc/src/main.c
@@ -821,7 +821,7 @@ void test_ipv4_mapped_to_ipv6_server(void)
 	/* Note that we should get IPv6 address here (mapped from IPv4) */
 	zassert_equal(addr.sa_family, NET_AF_INET6, "wrong family");
 	zassert_equal(addrlen, sizeof(struct net_sockaddr_in6),
-		      "wrong addrlen (%d, expecting %d)", addrlen,
+		      "wrong addrlen (%d, expecting %zu)", addrlen,
 		      sizeof(struct net_sockaddr_in6));
 	zassert_mem_equal(&mapped.sin6_addr, &net_sin6(&addr)->sin6_addr,
 			  sizeof(struct net_in6_addr),

--- a/tests/net/socket/socketpair/src/closed_ends.c
+++ b/tests/net/socket/socketpair/src/closed_ends.c
@@ -11,7 +11,7 @@ ZTEST_USER_F(net_socketpair, test_close_one_end_and_write_to_the_other)
 
 	for (size_t i = 0; i < 2; ++i) {
 		res = zsock_close(fixture->sv[i]);
-		zassert_equal(res, 0, "close(fixture->sv[%u]) failed: %d", i, errno);
+		zassert_equal(res, 0, "close(fixture->sv[%zu]) failed: %d", i, errno);
 		fixture->sv[i] = -1;
 
 		res = zsock_send(fixture->sv[(!i) & 1], "x", 1, 0);
@@ -20,7 +20,7 @@ ZTEST_USER_F(net_socketpair, test_close_one_end_and_write_to_the_other)
 			errno);
 
 		res = zsock_close(fixture->sv[(!i) & 1]);
-		zassert_equal(res, 0, "close(fixture->sv[%u]) failed: %d", i, errno);
+		zassert_equal(res, 0, "close(fixture->sv[%zu]) failed: %d", i, errno);
 		fixture->sv[(!i) & 1] = -1;
 
 		res = zsock_socketpair(NET_AF_UNIX, NET_SOCK_STREAM, 0, fixture->sv);
@@ -44,7 +44,7 @@ ZTEST_USER_F(net_socketpair, test_close_one_end_and_read_from_the_other)
 		zassert_equal(res, 2, "write() failed to write 2 bytes");
 
 		res = zsock_close(fixture->sv[i]);
-		zassert_equal(res, 0, "close(fixture->sv[%u]) failed: %d", i, errno);
+		zassert_equal(res, 0, "close(fixture->sv[%zu]) failed: %d", i, errno);
 		fixture->sv[i] = -1;
 
 		memset(xx, 0, sizeof(xx));
@@ -57,7 +57,7 @@ ZTEST_USER_F(net_socketpair, test_close_one_end_and_read_from_the_other)
 		zassert_equal(res, 0, "expected read() to succeed but read 0 bytes");
 
 		res = zsock_close(fixture->sv[(!i) & 1]);
-		zassert_equal(res, 0, "close(fixture->sv[%u]) failed: %d", i, errno);
+		zassert_equal(res, 0, "close(fixture->sv[%zu]) failed: %d", i, errno);
 		fixture->sv[(!i) & 1] = -1;
 
 		res = zsock_socketpair(NET_AF_UNIX, NET_SOCK_STREAM, 0, fixture->sv);

--- a/tests/net/socket/socketpair/src/nonblock.c
+++ b/tests/net/socket/socketpair/src/nonblock.c
@@ -20,10 +20,10 @@ ZTEST_USER_F(net_socketpair, test_write_nonblock)
 
 		/* then set the ZVFS_O_NONBLOCK flag */
 		res = zsock_fcntl(fixture->sv[i], ZVFS_F_GETFL, 0);
-		zassert_not_equal(res, -1, "zsock_fcntl() %d failed: %d", i, errno);
+		zassert_not_equal(res, -1, "zsock_fcntl() %zu failed: %d", i, errno);
 
 		res = zsock_fcntl(fixture->sv[i], ZVFS_F_SETFL, res | ZVFS_O_NONBLOCK);
-		zassert_not_equal(res, -1, "zsock_fcntl() %d failed: %d", i, errno);
+		zassert_not_equal(res, -1, "zsock_fcntl() %zu failed: %d", i, errno);
 
 		/* then, try to write one more byte */
 		res = zsock_send(fixture->sv[i], "x", 1, 0);
@@ -41,10 +41,10 @@ ZTEST_USER_F(net_socketpair, test_read_nonblock)
 	for (size_t i = 0; i < 2; ++i) {
 		/* set the O_NONBLOCK flag */
 		res = zsock_fcntl(fixture->sv[i], ZVFS_F_GETFL, 0);
-		zassert_not_equal(res, -1, "zsock_fcntl() %d failed: %d", i, errno);
+		zassert_not_equal(res, -1, "zsock_fcntl() %zu failed: %d", i, errno);
 
 		res = zsock_fcntl(fixture->sv[i], ZVFS_F_SETFL, res | ZVFS_O_NONBLOCK);
-		zassert_not_equal(res, -1, "zsock_fcntl() %d failed: %d", i, errno);
+		zassert_not_equal(res, -1, "zsock_fcntl() %zu failed: %d", i, errno);
 
 		/* then, try to read one byte */
 		res = zsock_recv(fixture->sv[i], &c, 1, 0);

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -158,7 +158,7 @@ static void test_recvmsg(int sock,
 	recved = zsock_recvmsg(sock, msg, flags);
 
 	zassert_equal(recved, expected,
-		      "line %d, unexpected received bytes (%d vs %d)",
+		      "line %d, unexpected received bytes (%zd vs %zu)",
 		      line, recved, expected);
 }
 
@@ -352,8 +352,9 @@ void tcp_server_block_thread(void *vps_sock, void *unused2, void *unused3)
 		recved = zsock_recv(new_sock, buffer, chunk_size, 0);
 
 		zassert(recved > 0, "received bigger then 0",
-			"Error receiving bytes %i bytes, got %i on top of %i in iteration %i, errno %i",
-			chunk_size,	recved, total_received, iteration, errno);
+			"Error receiving bytes %zu bytes, got %zu on top of %zu in iteration %i, "
+			"errno %i",
+			chunk_size, recved, total_received, iteration, errno);
 
 		/* Validate the contents */
 		for (int i = 0; i < recved; i++) {
@@ -438,7 +439,7 @@ void test_send_recv_large_common(int tcp_nodelay, int family)
 		int send_bytes = zsock_send(c_sock, buffer, chunk_size, 0);
 
 		zassert(send_bytes > 0, "send_bytes bigger then 0",
-			"Error sending %i bytes on top of %i, got %i in iteration %i, errno %i",
+			"Error sending %zu bytes on top of %zu, got %i in iteration %i, errno %i",
 			chunk_size, total_send, send_bytes, iteration, errno);
 		total_send += send_bytes;
 		iteration++;
@@ -2331,7 +2332,7 @@ static void test_ioctl_fionread_common(int af)
 		zassert_equal(1, write(fd[i], "\x73", 1));
 		k_msleep(100);
 		zassert_ok(zsock_ioctl(fd[j], ZFD_IOCTL_FIONREAD, &avail));
-		zassert_equal(ARRAY_SIZE(bytes), avail, "exp: %d: act: %d", ARRAY_SIZE(bytes),
+		zassert_equal(ARRAY_SIZE(bytes), avail, "exp: %zd: act: %d", ARRAY_SIZE(bytes),
 			      avail);
 	}
 
@@ -2399,7 +2400,7 @@ static void test_ioctl_fionwrite_common(int af)
 	/* With all loopback packets dropped, sent bytes remain queued */
 	avail = -1;
 	zassert_ok(zsock_ioctl(fd[CLIENT], ZFD_IOCTL_FIONWRITE, &avail));
-	zassert_equal(strlen(TEST_STR_SMALL), avail, "exp: %d: act: %d",
+	zassert_equal(strlen(TEST_STR_SMALL), avail, "exp: %zd: act: %d",
 		      strlen(TEST_STR_SMALL), avail);
 
 	/* Once packets are delivered, FIONWRITE returns 0 again */

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -386,7 +386,7 @@ static void comm_sendmsg_recvfrom(int client_sock,
 		len += client_msg->msg_iov[i].iov_len;
 	}
 
-	zassert_equal(sent, len, "iovec len (%d) vs sent (%d)", len, sent);
+	zassert_equal(sent, len, "iovec len (%d) vs sent (%zd)", len, sent);
 
 	/* Test recvfrom(MSG_PEEK) */
 	addrlen = sizeof(addr);
@@ -396,7 +396,7 @@ static void comm_sendmsg_recvfrom(int client_sock,
 	zassert_true(recved >= 0, "recvfrom fail");
 	zassert_equal(recved, strlen(TEST_STR_SMALL),
 		      "unexpected received bytes");
-	zassert_equal(sent, recved, "sent(%d)/received(%d) mismatch",
+	zassert_equal(sent, recved, "sent(%zd)/received(%zd) mismatch",
 		      sent, recved);
 
 	zassert_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL),
@@ -763,14 +763,14 @@ ZTEST(net_socket_udp, test_so_txtime)
 	optlen = sizeof(optval);
 	rv = zsock_getsockopt(sock1, ZSOCK_SOL_SOCKET, ZSOCK_SO_TXTIME, &optval, &optlen);
 	zassert_equal(rv, 0, "getsockopt failed (%d)", errno);
-	zassert_equal(optlen, sizeof(optval), "invalid optlen %d vs %d",
+	zassert_equal(optlen, sizeof(optval), "invalid optlen %d vs %zu",
 		      optlen, sizeof(optval));
 	zassert_equal(optval, true, "getsockopt txtime");
 
 	optlen = sizeof(optval);
 	rv = zsock_getsockopt(sock2, ZSOCK_SOL_SOCKET, ZSOCK_SO_TXTIME, &optval, &optlen);
 	zassert_equal(rv, 0, "getsockopt failed (%d)", errno);
-	zassert_equal(optlen, sizeof(optval), "invalid optlen %d vs %d",
+	zassert_equal(optlen, sizeof(optval), "invalid optlen %d vs %zu",
 		      optlen, sizeof(optval));
 	zassert_equal(optval, false, "getsockopt txtime");
 
@@ -924,7 +924,7 @@ static void comm_sendmsg_with_txtime(int client_sock,
 		len += client_msg->msg_iov[i].iov_len;
 	}
 
-	zassert_equal(sent, len, "iovec len (%d) vs sent (%d)", len, sent);
+	zassert_equal(sent, len, "iovec len (%d) vs sent (%zd)", len, sent);
 }
 
 /* In order to verify that the network device driver is able to receive
@@ -1466,7 +1466,7 @@ static void comm_sendmsg_recvmsg(int client_sock,
 		len += client_msg->msg_iov[i].iov_len;
 	}
 
-	zassert_equal(sent, len, "iovec len (%d) vs sent (%d)", len, sent);
+	zassert_equal(sent, len, "iovec len (%d) vs sent (%zd)", len, sent);
 
 	/* Test first with one iovec */
 	io_vector[0].iov_base = buf;
@@ -1486,9 +1486,9 @@ static void comm_sendmsg_recvmsg(int client_sock,
 	/* Test recvmsg(MSG_PEEK) */
 	recved = zsock_recvmsg(server_sock, msg, ZSOCK_MSG_PEEK);
 	zassert_true(recved > 0, "recvmsg fail, %s (%d)", strerror(errno), -errno);
-	zassert_equal(recved, len, "unexpected received bytes (%d vs %d)",
+	zassert_equal(recved, len, "unexpected received bytes (%zd vs %d)",
 		      recved, len);
-	zassert_equal(sent, recved, "sent(%d)/received(%d) mismatch",
+	zassert_equal(sent, recved, "sent(%zd)/received(%zd) mismatch",
 		      sent, recved);
 	zassert_equal(msg->msg_iovlen, 1, "recvmsg should not modify msg_iovlen");
 	zassert_equal(msg->msg_iov[0].iov_len, sizeof(buf),
@@ -1543,7 +1543,7 @@ static void comm_sendmsg_recvmsg(int client_sock,
 		len += client_msg->msg_iov[i].iov_len;
 	}
 
-	zassert_equal(sent, len, "iovec len (%d) vs sent (%d)", len, sent);
+	zassert_equal(sent, len, "iovec len (%d) vs sent (%zd)", len, sent);
 
 	/* and then test with two iovec */
 	io_vector[0].iov_base = buf2;
@@ -1566,8 +1566,8 @@ static void comm_sendmsg_recvmsg(int client_sock,
 	recved = zsock_recvmsg(server_sock, msg, ZSOCK_MSG_PEEK);
 	zassert_true(recved >= 0, "recvfrom fail (errno %d)", errno);
 	zassert_equal(recved, len,
-		      "unexpected received bytes (%d vs %d)", recved, len);
-	zassert_equal(sent, recved, "sent(%d)/received(%d) mismatch",
+		      "unexpected received bytes (%zd vs %d)", recved, len);
+	zassert_equal(sent, recved, "sent(%zd)/received(%zd) mismatch",
 		      sent, recved);
 
 	zassert_equal(msg->msg_iovlen, 2, "recvmsg should not modify msg_iovlen");
@@ -1586,8 +1586,8 @@ static void comm_sendmsg_recvmsg(int client_sock,
 	recved = zsock_recvmsg(server_sock, msg, ZSOCK_MSG_PEEK);
 	zassert_true(recved >= 0, "recvfrom fail (errno %d)", errno);
 	zassert_equal(recved, len,
-		      "unexpected received bytes (%d vs %d)", recved, len);
-	zassert_equal(sent, recved, "sent(%d)/received(%d) mismatch",
+		      "unexpected received bytes (%zu vs %d)", recved, len);
+	zassert_equal(sent, recved, "sent(%zu)/received(%zu) mismatch",
 		      sent, recved);
 
 	zassert_equal(msg->msg_iovlen, 2, "recvmsg should not modify msg_iovlen");
@@ -1617,7 +1617,7 @@ static void comm_sendmsg_recvmsg(int client_sock,
 		len += client_msg->msg_iov[i].iov_len;
 	}
 
-	zassert_equal(sent, len, "iovec len (%d) vs sent (%d)", len, sent);
+	zassert_equal(sent, len, "iovec len (%d) vs sent (%zd)", len, sent);
 
 	/* Test first with one iovec */
 	io_vector[0].iov_base = buf2;
@@ -1638,7 +1638,7 @@ static void comm_sendmsg_recvmsg(int client_sock,
 	recved = zsock_recvmsg(server_sock, msg, 0);
 	zassert_true(recved > 0, "recvmsg fail, %s (%d)", strerror(errno), errno);
 	zassert_equal(recved, sizeof(buf2),
-		      "unexpected received bytes (%d vs %d)",
+		      "unexpected received bytes (%zu vs %zu)",
 		      recved, sizeof(buf2));
 	zassert_true(msg->msg_flags & ZSOCK_MSG_TRUNC, "Message not truncated");
 
@@ -2529,7 +2529,7 @@ static void check_ipv6_address_preferences(struct net_if *iface,
 	ret = zsock_getsockopt(sock, NET_IPPROTO_IPV6, ZSOCK_IPV6_ADDR_PREFERENCES,
 			       &optval, &optlen);
 	zassert_equal(ret, 0, "setsockopt failed (%d)", errno);
-	zassert_equal(optlen, sizeof(optval), "invalid optlen %d vs %d",
+	zassert_equal(optlen, sizeof(optval), "invalid optlen %d vs %zu",
 		      optlen, sizeof(optval));
 	zassert_equal(optval, preference,
 		      "getsockopt address preferences");
@@ -2629,7 +2629,7 @@ ZTEST(net_socket_udp, test_ipv6_multicast_ifindex)
 	ret = zsock_getsockopt(sock, NET_IPPROTO_IPV6, ZSOCK_IPV6_MULTICAST_IF,
 			       &optval, &optlen);
 	zexpect_equal(ret, 0, "setsockopt failed (%d)", errno);
-	zexpect_equal(optlen, sizeof(optval), "invalid optlen %d vs %d",
+	zexpect_equal(optlen, sizeof(optval), "invalid optlen %d vs %zu",
 		      optlen, sizeof(optval));
 	ifindex = net_if_get_by_iface(net_if_get_default());
 	zexpect_equal(optval, ifindex,
@@ -2664,7 +2664,7 @@ ZTEST(net_socket_udp, test_ipv6_multicast_ifindex)
 			       &optval, optlen);
 	err = -errno;
 	zexpect_equal(ret, 0, "setsockopt failed (%d)", err);
-	zexpect_equal(optlen, sizeof(optval), "invalid optlen %d vs %d",
+	zexpect_equal(optlen, sizeof(optval), "invalid optlen %d vs %zu",
 		      optlen, sizeof(optval));
 
 	/* Set the output multicast packet interface to the default interface */
@@ -2672,7 +2672,7 @@ ZTEST(net_socket_udp, test_ipv6_multicast_ifindex)
 	ret = zsock_setsockopt(sock, NET_IPPROTO_IPV6, ZSOCK_IPV6_MULTICAST_IF,
 			       &optval, optlen);
 	zexpect_equal(ret, 0, "setsockopt failed (%d)", errno);
-	zexpect_equal(optlen, sizeof(optval), "invalid optlen %d vs %d",
+	zexpect_equal(optlen, sizeof(optval), "invalid optlen %d vs %zu",
 		      optlen, sizeof(optval));
 
 	optval = 0; optlen = 0U;
@@ -2694,7 +2694,7 @@ ZTEST(net_socket_udp, test_ipv6_multicast_ifindex)
 	ret = zsock_sendto(sock, TEST_STR_SMALL, sizeof(TEST_STR_SMALL) - 1, 0,
 			   (struct net_sockaddr *)&saddr6, sizeof(saddr6));
 	zexpect_equal(ret, STRLEN(TEST_STR_SMALL),
-		      "invalid send len (was %d expected %d) (%d)",
+		      "invalid send len (was %d expected %zu) (%d)",
 		      ret, STRLEN(TEST_STR_SMALL), -errno);
 
 	/* Test that the sent data is received from default interface and
@@ -2774,7 +2774,7 @@ ZTEST(net_socket_udp, test_ipv4_multicast_ifindex)
 	ret = zsock_getsockopt(sock, NET_IPPROTO_IP, ZSOCK_IP_MULTICAST_IF,
 			       &addr, &optlen);
 	zexpect_equal(ret, 0, "setsockopt failed (%d)", errno);
-	zexpect_equal(optlen, sizeof(addr), "invalid optlen %d vs %d",
+	zexpect_equal(optlen, sizeof(addr), "invalid optlen %d vs %zu",
 		      optlen, sizeof(addr));
 	ifindex = net_if_get_by_iface(net_if_get_default());
 	ret = net_if_ipv4_addr_lookup_by_index(&addr);
@@ -2869,7 +2869,7 @@ ZTEST(net_socket_udp, test_ipv4_multicast_ifindex)
 	ret = zsock_sendto(sock, TEST_STR_SMALL, sizeof(TEST_STR_SMALL) - 1, 0,
 			   (struct net_sockaddr *)&dst_addr, sizeof(dst_addr));
 	zexpect_equal(ret, STRLEN(TEST_STR_SMALL),
-		      "invalid send len (was %d expected %d) (%d)",
+		      "invalid send len (was %d expected %zu) (%d)",
 		      ret, STRLEN(TEST_STR_SMALL), -errno);
 
 	/* Test that the sent data is received from Ethernet interface. */
@@ -2930,7 +2930,7 @@ ZTEST(net_socket_udp, test_ipv4_multicast_ifindex)
 	ret = zsock_sendto(sock, TEST_STR_SMALL, sizeof(TEST_STR_SMALL) - 1, 0,
 			   (struct net_sockaddr *)&dst_addr, sizeof(dst_addr));
 	zexpect_equal(ret, STRLEN(TEST_STR_SMALL),
-		      "invalid send len (was %d expected %d) (%d)",
+		      "invalid send len (was %d expected %zu) (%d)",
 		      ret, STRLEN(TEST_STR_SMALL), -errno);
 
 	/* Test that the sent data is received from default interface. */
@@ -2957,7 +2957,7 @@ ZTEST(net_socket_udp, test_ipv4_multicast_ifindex)
 	ret = zsock_sendto(sock, TEST_STR_SMALL, sizeof(TEST_STR_SMALL) - 1, 0,
 			   (struct net_sockaddr *)&dst_addr, sizeof(dst_addr));
 	zexpect_equal(ret, STRLEN(TEST_STR_SMALL),
-		      "invalid send len (was %d expected %d) (%d)",
+		      "invalid send len (was %d expected %zu) (%d)",
 		      ret, STRLEN(TEST_STR_SMALL), -errno);
 
 	/* Test that the sent data is received from default interface. */
@@ -3284,7 +3284,7 @@ static void comm_sendmsg_recvmsg_hop_limit(int client_sock,
 		len += client_msg->msg_iov[i].iov_len;
 	}
 
-	zassert_equal(sent, len, "iovec len (%d) vs sent (%d)", len, sent);
+	zassert_equal(sent, len, "iovec len (%d) vs sent (%zu)", len, sent);
 
 	/* Test first with one iovec */
 	io_vector[0].iov_base = buf;
@@ -3572,7 +3572,7 @@ static void sendto_recvfrom(int client_sock,
 		/* We should not receive anything as the socket is shutdown for
 		 * receiving.
 		 */
-		zassert_equal(recved, -1, "recvfrom should fail (got %d)", recved);
+		zassert_equal(recved, -1, "recvfrom should fail (got %zu)", recved);
 	}
 }
 
@@ -3667,7 +3667,7 @@ void test_ipv4_mapped_to_ipv6_send_common(enum ipv4_mapped_to_ipv6_send_mode tes
 	ret = zsock_sendto(sock_c, TEST_STR_SMALL, sizeof(TEST_STR_SMALL) - 1, 0,
 			   (struct net_sockaddr *)&addr_s4, sizeof(addr_s4));
 	zexpect_equal(ret, sizeof(TEST_STR_SMALL) - 1,
-		      "invalid send len (was %d expected %d) (%d)",
+		      "invalid send len (was %d expected %zu) (%d)",
 		      ret, sizeof(TEST_STR_SMALL) - 1, errno);
 
 	/* Give the packet a chance to go through the net stack */
@@ -3693,7 +3693,7 @@ void test_ipv4_mapped_to_ipv6_send_common(enum ipv4_mapped_to_ipv6_send_mode tes
 		ret = zsock_sendto(sock_s, TEST_STR_SMALL, sizeof(TEST_STR_SMALL) - 1, 0,
 				   (struct net_sockaddr *)&addr_recv, addrlen);
 		zexpect_equal(ret, sizeof(TEST_STR_SMALL) - 1,
-			      "invalid send len (was %d expected %d) (%d)",
+			      "invalid send len (was %d expected %zu) (%d)",
 			      ret, sizeof(TEST_STR_SMALL) - 1, errno);
 	} else if (test_mode == IPV4_MAPPED_TO_IPV6_SENDMSG) {
 		struct net_msghdr msg = { 0 };
@@ -3709,7 +3709,7 @@ void test_ipv4_mapped_to_ipv6_send_common(enum ipv4_mapped_to_ipv6_send_mode tes
 
 		ret = zsock_sendmsg(sock_s, &msg, 0);
 		zexpect_equal(ret, sizeof(TEST_STR_SMALL) - 1,
-			      "invalid send len (was %d expected %d) (%d)",
+			      "invalid send len (was %d expected %zu) (%d)",
 			      ret, sizeof(TEST_STR_SMALL) - 1, errno);
 	} else {
 		zassert_unreachable("invalid test mode");

--- a/tests/net/socket/websocket/src/main.c
+++ b/tests/net/socket/websocket/src/main.c
@@ -259,7 +259,7 @@ static void test_recv_2(int count)
 
 	memcpy(feed_buf, &frame2, sizeof(frame2));
 
-	NET_DBG("Reading %d bytes at a time, frame %zd hdr %zd", count,
+	NET_DBG("Reading %d bytes at a time, frame %zu hdr %zu", count,
 		sizeof(frame2), FRAME1_HDR_SIZE);
 
 	total_read = test_recv_buf(&feed_buf[0], count, &ctx, &msg_type,
@@ -341,17 +341,17 @@ int verify_sent_and_received_msg(struct net_msghdr *msg, bool split_msg)
 					"Received message should be");
 			LOG_HEXDUMP_ERR(recv_buf, ret, "but it was instead");
 			zassert_true(false, "Invalid received message "
-				     "after %d bytes", total_read);
+				     "after %zu bytes", total_read);
 		}
 
 		total_read += ret;
 	}
 
 	zassert_equal(total_read, test_msg_len,
-		      "Msg body not valid, received %d instead of %zd",
+		      "Msg body not valid, received %zu instead of %zu",
 		      total_read, test_msg_len);
 
-	NET_DBG("Received %zd header and %zd body",
+	NET_DBG("Received %zu header and %zu body",
 		msg->msg_iov[0].iov_len, total_read);
 
 	return msg->msg_iov[0].iov_len + total_read;

--- a/tests/net/utils/src/main.c
+++ b/tests/net/utils/src/main.c
@@ -914,7 +914,7 @@ static const char *check_ipaddr(const char *addresses)
 
 		zassert_mem_equal(addr_str, expecting,
 				  *addresses == '\0' ? strlen(orig) : addresses - orig - 1,
-				  "Address mismatch, expecing %s, got %s (len %d)\n",
+				  "Address mismatch, expecing %s, got %s (len %td)\n",
 				  expecting, addr_str, addresses - orig - 1);
 	} while (addresses != NULL && *addresses != '\0');
 

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -909,7 +909,7 @@ static void comm_sendto_recvfrom(int client_sock,
 
 	sent = zsock_sendto(client_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL),
 			    0, server_addr, server_addrlen);
-	zassert_equal(sent, strlen(TEST_STR_SMALL), "sendto failed (%d vs %d)",
+	zassert_equal(sent, strlen(TEST_STR_SMALL), "sendto failed (%zd vs %zu)",
 		      sent, strlen(TEST_STR_SMALL));
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
@@ -1046,7 +1046,7 @@ ZTEST(net_vlan, test_zz_vlan_embed_ll_hdr)
 
 	sent = zsock_sendto(client_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL),
 			    0, (struct net_sockaddr *)&dest_addr, sizeof(dest_addr));
-	zassert_equal(sent, strlen(TEST_STR_SMALL), "send (%d) failed %d/%s",
+	zassert_equal(sent, strlen(TEST_STR_SMALL), "send (%zd) failed %d/%s",
 		      sent, -errno, strerror(errno));
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {


### PR DESCRIPTION
in https://github.com/zephyrproject-rtos/zephyr/pull/109423 I noticed a lot of net tests failed on 64 bit platforms this fixes that