### PR TITLE
drivers: eeprom: fake: install default delegate to avoid uninitialized mem

### DIFF
--- a/drivers/eeprom/eeprom_fake.c
+++ b/drivers/eeprom/eeprom_fake.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <string.h>
+
 #include <zephyr/device.h>
 #include <zephyr/drivers/eeprom.h>
 #include <zephyr/drivers/eeprom/eeprom_fake.h>
@@ -25,6 +27,19 @@ DEFINE_FAKE_VALUE_FUNC(int, fake_eeprom_write, const struct device *, off_t, con
 
 DEFINE_FAKE_VALUE_FUNC(size_t, fake_eeprom_size, const struct device *);
 
+static int fake_eeprom_read_delegate(const struct device *dev, off_t offset, void *data, size_t len)
+{
+	const struct fake_eeprom_config *config = dev->config;
+
+	if (len > config->size) {
+		return -EINVAL;
+	}
+
+	memset(data, 0, len);
+
+	return 0;
+}
+
 size_t fake_eeprom_size_delegate(const struct device *dev)
 {
 	const struct fake_eeprom_config *config = dev->config;
@@ -42,7 +57,8 @@ static void fake_eeprom_reset_rule_before(const struct ztest_unit_test *test, vo
 	RESET_FAKE(fake_eeprom_write);
 	RESET_FAKE(fake_eeprom_size);
 
-	/* Re-install default delegate for reporting the EEPROM size */
+	/* Re-install default delegates */
+	fake_eeprom_read_fake.custom_fake = fake_eeprom_read_delegate;
 	fake_eeprom_size_fake.custom_fake = fake_eeprom_size_delegate;
 }
 
@@ -59,7 +75,8 @@ static int fake_eeprom_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	/* Install default delegate for reporting the EEPROM size */
+	/* Install default delegates */
+	fake_eeprom_read_fake.custom_fake = fake_eeprom_read_delegate;
 	fake_eeprom_size_fake.custom_fake = fake_eeprom_size_delegate;
 
 	return 0;


### PR DESCRIPTION
Install default EEPROM read API delegate to avoid unitialized "out" variable when no delegate is installed by the application/test suite.