### PR TITLE
drivers: stepper: fake: install default delegates

### DIFF
--- a/drivers/stepper/fake_stepper_controller.c
+++ b/drivers/stepper/fake_stepper_controller.c
@@ -81,6 +81,14 @@ static int fake_stepper_driver_get_micro_step_res_delegate(const struct device *
 	return 0;
 }
 
+static int fake_stepper_ctrl_is_moving_delegate(const struct device *dev, bool *is_moving)
+{
+	ARG_UNUSED(dev);
+	*is_moving = false;
+
+	return 0;
+}
+
 static int fake_stepper_ctrl_set_reference_position_delegate(const struct device *dev,
 							      const int32_t pos)
 {
@@ -126,6 +134,8 @@ static void fake_stepper_reset_rule_before(const struct ztest_unit_test *test, v
 		fake_stepper_driver_set_micro_step_res_delegate;
 	fake_stepper_driver_get_micro_step_res_fake.custom_fake =
 		fake_stepper_driver_get_micro_step_res_delegate;
+
+	fake_stepper_ctrl_is_moving_fake.custom_fake = fake_stepper_ctrl_is_moving_delegate;
 	fake_stepper_ctrl_set_reference_position_fake.custom_fake =
 		fake_stepper_ctrl_set_reference_position_delegate;
 	fake_stepper_ctrl_get_actual_position_fake.custom_fake =
@@ -147,6 +157,7 @@ static int fake_stepper_driver_init(const struct device *dev)
 
 static int fake_stepper_init(const struct device *dev)
 {
+	fake_stepper_ctrl_is_moving_fake.custom_fake = fake_stepper_ctrl_is_moving_delegate;
 	fake_stepper_ctrl_set_reference_position_fake.custom_fake =
 		fake_stepper_ctrl_set_reference_position_delegate;
 	fake_stepper_ctrl_get_actual_position_fake.custom_fake =


### PR DESCRIPTION
Install default stepper and stepper_ctrl API delegates to avoid valgrind warnings.

Before:
```
==10627== HEAP SUMMARY:
==10627==     in use at exit: 6,048 bytes in 6 blocks
==10627==   total heap usage: 17 allocs, 11 frees, 16,056 bytes allocated
==10627== 
==10627== LEAK SUMMARY:
==10627==    definitely lost: 0 bytes in 0 blocks
==10627==    indirectly lost: 0 bytes in 0 blocks
==10627==      possibly lost: 0 bytes in 0 blocks
==10627==    still reachable: 0 bytes in 0 blocks
==10627==         suppressed: 6,048 bytes in 6 blocks
==10627== 
==10627== For lists of detected and suppressed errors, rerun with: -s
==10627== ERROR SUMMARY: 26 errors from 22 contexts (suppressed: 3 from 3)
```

After:
```
==9228== HEAP SUMMARY:
==9228==     in use at exit: 6,048 bytes in 6 blocks
==9228==   total heap usage: 16 allocs, 10 frees, 15,768 bytes allocated
==9228== 
==9228== LEAK SUMMARY:
==9228==    definitely lost: 0 bytes in 0 blocks
==9228==    indirectly lost: 0 bytes in 0 blocks
==9228==      possibly lost: 0 bytes in 0 blocks
==9228==    still reachable: 0 bytes in 0 blocks
==9228==         suppressed: 6,048 bytes in 6 blocks
==9228== 
==9228== For lists of detected and suppressed errors, rerun with: -s
==9228== ERROR SUMMARY: 16 errors from 16 contexts (suppressed: 3 from 3)
```

https://github.com/zephyrproject-rtos/zephyr/pull/109658#issuecomment-4517731423