### PR TITLE
dts: bindings: *: st,stm32*: use min/max instead of enums

### DIFF
--- a/dts/bindings/clock/st,stm32-lse-clock.yaml
+++ b/dts/bindings/clock/st,stm32-lse-clock.yaml
@@ -15,11 +15,8 @@ properties:
       LSE driving capability, within the range 0 to 3.
       0 represents the lowests driving capability, 3
       the highest.
-    enum:
-      - 0
-      - 1
-      - 2
-      - 3
+    min: 0
+    max: 3
 
   lse-bypass:
     type: boolean

--- a/dts/bindings/clock/st,stm32-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32-msi-clock.yaml
@@ -26,7 +26,8 @@ properties:
       9: around 24 MHz
       10: around 32 MHz
       11: around 48 MHz
-    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    min: 0
+    max: 11
 
   msi-pll-mode:
     type: boolean

--- a/dts/bindings/clock/st,stm32l0-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32l0-msi-clock.yaml
@@ -24,4 +24,5 @@ properties:
       4: around 1.048 MHz
       5: around 2.097 MHz (reset value)
       6: around 4.194 MHz
-    enum: [0, 1, 2, 3, 4, 5, 6]
+    min: 0
+    max: 6

--- a/dts/bindings/clock/st,stm32l0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32l0-pll-clock.yaml
@@ -31,10 +31,8 @@ properties:
     required: true
     description: |
         PLL output division
-    enum:
-      - 2
-      - 3
-      - 4
+    min: 2
+    max: 4
 
   mul:
     type: int

--- a/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
@@ -20,7 +20,11 @@ properties:
     type: int
     required: true
     description: |
-        PLL clock source
+      PLL clock used as source:
+        1: PLL1
+        2: PLL2
+        3: PLL3
+        4: PLL4
     min: 1
     max: 4
 

--- a/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
@@ -21,11 +21,8 @@ properties:
     required: true
     description: |
         PLL clock source
-    enum:
-      - 1
-      - 2
-      - 3
-      - 4
+    min: 1
+    max: 4
 
   ic-div:
     type: int

--- a/dts/bindings/clock/st,stm32u3-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32u3-msi-clock.yaml
@@ -25,12 +25,5 @@ properties:
         range 5 around 12 MHz from 24MHz oscillator
         range 6 around 6 MHz
         range 7 around 3 MHz
-    enum:
-      - 0
-      - 1
-      - 2
-      - 3
-      - 4
-      - 5
-      - 6
-      - 7
+    min: 0
+    max: 7

--- a/dts/bindings/clock/st,stm32u5-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32u5-msi-clock.yaml
@@ -34,4 +34,5 @@ properties:
       13: around 200 KHz
       14: around 133 KHz
       15: around 100 KHz
-    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    min: 0
+    max: 15

--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -71,15 +71,8 @@ properties:
   cs-high-time:
     type: int
     default: 8
-    enum:
-      - 1
-      - 2
-      - 3
-      - 4
-      - 5
-      - 6
-      - 7
-      - 8
+    min: 1
+    max: 8
     description: |
       Minimum number of QSPI clock cycles the chip select signal must remain
       high between commands issued to the flash memory.

--- a/dts/bindings/input/st,stm32-tsc.yaml
+++ b/dts/bindings/input/st,stm32-tsc.yaml
@@ -36,7 +36,8 @@ properties:
     description: |
       Number of cycles for the high state of the
       charge transfer pulse (1 to 16 cycles of t_pgclk).
-    enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    min: 1
+    max: 16
 
   st,charge-transfer-pulse-low:
     type: int
@@ -44,7 +45,8 @@ properties:
     description: |
       Number of cycles for the low state of the
       charge transfer pulse (1 to 16 cycles of t_pgclk).
-    enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    min: 1
+    max: 16
 
   st,spread-spectrum:
     type: boolean
@@ -95,13 +97,15 @@ child-binding:
       type: int
       required: true
       description: Group number (0 to 7)
-      enum: [0, 1, 2, 3, 4, 5, 6, 7]
+      min: 0
+      max: 7
 
     channel-ios:
       type: int
       required: true
       description: Channel I/Os to be enabled
-      enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+      min: 1
+      max: 16
 
     sampling-io:
       type: int

--- a/dts/bindings/memory-controllers/st,stm32-ospi-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-ospi-psram.yaml
@@ -158,8 +158,8 @@ properties:
       The default is the minimum recommended value in the Reference Manual. It
       is recommended to set this value according to the length of the burst wrap
       of the PSRAM device for the linear burst command.
-    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-           21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+    min: 0
+    max: 31
 
   st,refresh:
     type: int

--- a/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
@@ -157,8 +157,8 @@ properties:
       The default is the minimum recommended value in the Reference Manual. It
       is recommended to set this value according to the length of the burst wrap
       of the PSRAM device for the linear burst command.
-    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-           21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+    min: 0
+    max: 31
 
   st,refresh:
     type: int

--- a/dts/bindings/mipi-dsi/st,stm32u5-mipi-dsi.yaml
+++ b/dts/bindings/mipi-dsi/st,stm32u5-mipi-dsi.yaml
@@ -32,16 +32,16 @@ properties:
     max: 0x8
     description: |
       D-PHY PLL input frequency range. This is used to select the appropriate
-      frequency range for the D-PHY PLL operation.
-      0x0 : DSI_DPHY_FRANGE_80MHZ_100MHZ
-      0x1 : DSI_DPHY_FRANGE_100MHZ_120MHZ
-      0x2 : DSI_DPHY_FRANGE_120MHZ_160MHZ
-      0x3 : DSI_DPHY_FRANGE_160MHZ_200MHZ
-      0x4 : DSI_DPHY_FRANGE_200MHZ_240MHZ
-      0x5 : DSI_DPHY_FRANGE_240MHZ_320MHZ
-      0x6 : DSI_DPHY_FRANGE_320MHZ_390MHZ
-      0x7 : DSI_DPHY_FRANGE_390MHZ_450MHZ
-      0x8 : DSI_DPHY_FRANGE_450MHZ_510MHZ
+      frequency range for the D-PHY PLL operation:
+        0x0 : Frequency range 80~100 MHz
+        0x1 : Frequency range 100~120 MHz
+        0x2 : Frequency range 120~160 MHz
+        0x3 : Frequency range 160~200 MHz
+        0x4 : Frequency range 200~240 MHz
+        0x5 : Frequency range 240~320 MHz
+        0x6 : Frequency range 320~390 MHz
+        0x7 : Frequency range 390~450 MHz
+        0x8 : Frequency range 450~510 MHz
 
   phy-low-power-offset:
     required: true
@@ -73,9 +73,9 @@ properties:
     min: 0x0
     max: 0x1
     description: |
-      PLL VCO frequency range configuration for STM32U5 D-PHY.
-        0x0 : DSI_DPHY_VCO_FRANGE_500MHZ_800MHZ
-        0x1 : DSI_DPHY_VCO_FRANGE_800MHZ_1GHZ
+      PLL VCO frequency range configuration for STM32U5 D-PHY:
+        0x0 : Frequency range 500~800 MHz
+        0x1 : Frequency range 800~1000 MHz
 
   pll-charge-pump:
     required: true
@@ -83,13 +83,12 @@ properties:
     min: 0x0
     max: 0x3
     description: |
-      PLL charge pump configuration for STM32U5 D-PHY.
-      Valid values:
-        0x0 : DSI_PLL_CHARGE_PUMP_2000HZ_4400HZ
-        0x1 : DSI_PLL_CHARGE_PUMP_4400HZ_14100HZ
-        0x0 : DSI_PLL_CHARGE_PUMP_14100HZ_30900HZ
-        0x3 : DSI_PLL_CHARGE_PUMP_30900HZ_45700HZ
-        0x2 : DSI_PLL_CHARGE_PUMP_45700HZ_50000HZ
+     PLL charge pump configuration for STM32U5 D-PHY.
+     The correct value depends on the PLL charge pump frequency:
+       0x0 : Frequency in range 2.0~4.4 MHz or 14.1~30.9 MHz
+       0x1 : Frequency in range 4.4~14.1 MHz
+       0x2 : Frequency in range 45.7~50 MHz
+       0x3 : Frequency in range 30.9~45.7 MHz
 
   pll-tuning:
     required: true
@@ -98,6 +97,6 @@ properties:
     max: 0x2
     description: |
       PLL tuning parameter (loop filter) for STM32U5 D-PHY.
-        0x0 : DSI_PLL_LOOP_FILTER_2000HZ_4400HZ
-        0x1 : DSI_PLL_LOOP_FILTER_4400HZ_30900HZ
-        0x2 : DSI_PLL_LOOP_FILTER_30900HZ_50000HZ
+        0x0 : Frequency range 2000~4400 Hz
+        0x1 : Frequency range 4400~30900 Hz
+        0x2 : Frequency range 30900~50000 Hz

--- a/dts/bindings/mipi-dsi/st,stm32u5-mipi-dsi.yaml
+++ b/dts/bindings/mipi-dsi/st,stm32u5-mipi-dsi.yaml
@@ -28,16 +28,8 @@ properties:
   phy-freq-range:
     required: true
     type: int
-    enum:
-      - 0x0
-      - 0x1
-      - 0x2
-      - 0x3
-      - 0x4
-      - 0x5
-      - 0x6
-      - 0x7
-      - 0x8
+    min: 0x0
+    max: 0x8
     description: |
       D-PHY PLL input frequency range. This is used to select the appropriate
       frequency range for the D-PHY PLL operation.
@@ -54,23 +46,8 @@ properties:
   phy-low-power-offset:
     required: true
     type: int
-    enum:
-      - 0x0
-      - 0x1
-      - 0x2
-      - 0x3
-      - 0x4
-      - 0x5
-      - 0x6
-      - 0x7
-      - 0x8
-      - 0x9
-      - 0xA
-      - 0xB
-      - 0xC
-      - 0xD
-      - 0xE
-      - 0xF
+    min: 0x0
+    max: 0xF
     description: |
       D-PHY low power offset configuration specific to STM32U5 series.
         0x0 : PHY_LP_OFFSSET_0_CLKP        (0 CLKP)
@@ -93,9 +70,8 @@ properties:
   pll-vco-range:
     required: true
     type: int
-    enum:
-      - 0x0
-      - 0x1
+    min: 0x0
+    max: 0x1
     description: |
       PLL VCO frequency range configuration for STM32U5 D-PHY.
         0x0 : DSI_DPHY_VCO_FRANGE_500MHZ_800MHZ
@@ -104,11 +80,8 @@ properties:
   pll-charge-pump:
     required: true
     type: int
-    enum:
-      - 0x0
-      - 0x1
-      - 0x2
-      - 0x3
+    min: 0x0
+    max: 0x3
     description: |
       PLL charge pump configuration for STM32U5 D-PHY.
       Valid values:
@@ -121,10 +94,8 @@ properties:
   pll-tuning:
     required: true
     type: int
-    enum:
-      - 0x0
-      - 0x1
-      - 0x2
+    min: 0x0
+    max: 0x2
     description: |
       PLL tuning parameter (loop filter) for STM32U5 D-PHY.
         0x0 : DSI_PLL_LOOP_FILTER_2000HZ_4400HZ

--- a/dts/bindings/mspi/st,stm32-ospi-controller.yaml
+++ b/dts/bindings/mspi/st,stm32-ospi-controller.yaml
@@ -114,8 +114,8 @@ properties:
       Feature is disabled by default. It is recommended to set this value
       according to the length of the burst wrap of the PSRAM device for the
       linear burst command.
-    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-           21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+    min: 0
+    max: 31
 
   st,dqs-port:
     type: int

--- a/dts/bindings/mspi/st,stm32-xspi-controller.yaml
+++ b/dts/bindings/mspi/st,stm32-xspi-controller.yaml
@@ -53,5 +53,5 @@ properties:
       The default is the minimum recommended value in the Reference Manual. It
       is recommended to set this value according to the length of the burst wrap
       of the PSRAM device for the linear burst command.
-    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-           21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+    min: 0
+    max: 31

--- a/dts/bindings/power/st,stm32u5-pwr.yaml
+++ b/dts/bindings/power/st,stm32u5-pwr.yaml
@@ -53,8 +53,5 @@ properties:
       the selected voltage scale is not compatible with the system's clock
       configuration; in this case, clock configuration takes precedence and
       the value of this property is ignored.
-    enum:
-      - 1
-      - 2
-      - 3
-      - 4
+    min: 1
+    max: 4

--- a/dts/bindings/sensor/st,stm32-qdec.yaml
+++ b/dts/bindings/sensor/st,stm32-qdec.yaml
@@ -75,23 +75,8 @@ properties:
       15: Fs = F_clk/32, N=8
       Default value is set by hardware at reset
     default: 0
-    enum:
-      - 0  # No filter
-      - 1  # FDIV1_N2
-      - 2  # FDIV1_N4
-      - 3  # FDIV1_N8
-      - 4  # FDIV2_N6
-      - 5  # FDIV2_N8
-      - 6  # FDIV4_N6
-      - 7  # FDIV4_N8
-      - 8  # FDIV8_N6
-      - 9  # FDIV8_N8
-      - 10 # FDIV16_N5
-      - 11 # FDIV16_N6
-      - 12 # FDIV16_N8
-      - 13 # FDIV32_N5
-      - 14 # FDIV32_N6
-      - 15 # FDIV32_N8
+    min: 0
+    max: 15
 
   st,counts-per-revolution:
     type: int


### PR DESCRIPTION
Replace enumerated values with min and max properties where applicable and meaningful.

Also add a bit of information to pll-src in st,stm32n6-ic-clock-mux description and while at it, end sentences with a dot in this same file.

Also add a clarification about pll-charge-pump possible values since value 0 is listed twice in the description, to state it is not a typo.