### PR TITLE
tests: devicetree: update assertions to use zassert_str_equal

### DIFF
--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -513,33 +513,33 @@ ZTEST(devicetree_api, test_nodelabel_c_token)
 	const char *test_nodelabel = STRINGIFY(
 		DT_NODELABEL_C_TOKEN(
 			DT_PHANDLE(TEST_PH, gpios)));
-	zassert_equal(test_nodelabel, "test_nodelabel");
+	zassert_str_equal(test_nodelabel, "test_nodelabel");
 	const char *test_i2c = STRINGIFY(
 		DT_NODELABEL_C_TOKEN(TEST_PHS_IDX(0)));
-	zassert_equal(test_i2c, "test_i2c");
+	zassert_str_equal(test_i2c, "test_i2c");
 	const char *test_spi = STRINGIFY(
 		DT_NODELABEL_C_TOKEN(TEST_PHS_IDX(1)));
-	zassert_equal(test_spi, "test_spi");
+	zassert_str_equal(test_spi, "test_spi");
 	const char *test_phandles = STRINGIFY(
 		DT_NODELABEL_C_TOKEN(TEST_PH));
-	zassert_equal(test_phandles, "test_phandles");
+	zassert_str_equal(test_phandles, "test_phandles");
 
 	/* DT_NODELABEL_C_TOKEN_BY_IDX */
 	const char *test_i2c0 = STRINGIFY(
 		DT_NODELABEL_C_TOKEN_BY_IDX(TEST_PHS_IDX(0), 0));
-	zassert_equal(test_i2c0, "test_i2c");
+	zassert_str_equal(test_i2c0, "test_i2c");
 	const char *test_spi0 = STRINGIFY(
 		DT_NODELABEL_C_TOKEN_BY_IDX(TEST_PHS_IDX(1), 0));
-	zassert_equal(test_spi0, "test_spi");
+	zassert_str_equal(test_spi0, "test_spi");
 	const char *test_i2c1 = STRINGIFY(
 		DT_NODELABEL_C_TOKEN_BY_IDX(TEST_PHS_IDX(0), 1));
-	zassert_equal(test_i2c1, "test_i2c1");
+	zassert_str_equal(test_i2c1, "test_i2c1");
 	const char *test_spi1 = STRINGIFY(
 		DT_NODELABEL_C_TOKEN_BY_IDX(TEST_PHS_IDX(1), 1));
-	zassert_equal(test_spi1, "test_spi1");
+	zassert_str_equal(test_spi1, "test_spi1");
 	const char *test_connector = STRINGIFY(
 		DT_NODELABEL_C_TOKEN_BY_IDX(DT_PHANDLE(TEST_PH, ph_conn), 2));
-	zassert_equal(test_connector, "test_connector");
+	zassert_str_equal(test_connector, "test_connector");
 
 #undef TEST_PHS_IDX
 }


### PR DESCRIPTION
Replaced zassert_equal with zassert_str_equal in recently introduced devicetree API tests (28b8d644c18) as the intent is to compare strings, and LLVM rightfully flagged that "the result of comparison against a string literal is unspecified"