### PR TITLE
UART Infineon - Revert UART IRQ update

### DIFF
--- a/drivers/serial/uart_infineon.c
+++ b/drivers/serial/uart_infineon.c
@@ -451,6 +451,25 @@ static int ifx_cat1_uart_irq_is_pending(const struct device *dev)
 	return (int)(intcause & (CY_SCB_TX_INTR | CY_SCB_RX_INTR));
 }
 
+/* Start processing interrupts in ISR.
+ * This function should be called the first thing in the ISR. Calling
+ * uart_irq_rx_ready(), uart_irq_tx_ready(), uart_irq_tx_complete()
+ * allowed only after this.
+ */
+static void ifx_cat1_uart_irq_update(const struct device *dev)
+{
+	struct ifx_cat1_uart_data *const data = dev->data;
+
+	/*
+	 * Read interrupt cause and RX FIFO count have a side effect
+	 * to clear stale interrupt flags, so that FIFO is flushed
+	 * properly and the current hardware state is reflected.
+	 * This is required for proper UART operation.
+	 */
+	(void) (ifx_cat1_uart_irq_is_pending(dev));
+	(void) (Cy_SCB_UART_GetNumInRxFifo(data->obj.base));
+}
+
 static void ifx_cat1_uart_irq_callback_set(const struct device *dev,
 					   uart_irq_callback_user_data_t cb, void *cb_data)
 {
@@ -1077,6 +1096,7 @@ static DEVICE_API(uart, ifx_cat1_uart_driver_api) = {
 	.irq_err_enable = ifx_cat1_uart_irq_err_enable,
 	.irq_err_disable = ifx_cat1_uart_irq_err_disable,
 	.irq_is_pending = ifx_cat1_uart_irq_is_pending,
+	.irq_update = ifx_cat1_uart_irq_update,
 	.irq_callback_set = ifx_cat1_uart_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 

--- a/drivers/serial/uart_infineon_pdl.c
+++ b/drivers/serial/uart_infineon_pdl.c
@@ -561,6 +561,25 @@ static int ifx_cat1_uart_irq_is_pending(const struct device *dev)
 	return (int)(intcause & (CY_SCB_TX_INTR | CY_SCB_RX_INTR));
 }
 
+/* Start processing interrupts in ISR.
+ * This function should be called the first thing in the ISR. Calling
+ * uart_irq_rx_ready(), uart_irq_tx_ready(), uart_irq_tx_complete()
+ * allowed only after this.
+ */
+static void ifx_cat1_uart_irq_update(const struct device *dev)
+{
+	const struct ifx_cat1_uart_config *const config = dev->config;
+
+	/*
+	 * Read interrupt cause and RX FIFO count have a side effect
+	 * to clear stale interrupt flags, so that FIFO is flushed
+	 * properly and the current hardware state is reflected.
+	 * This is required for proper UART operation.
+	 */
+	(void) (ifx_cat1_uart_irq_is_pending(dev));
+	(void) (Cy_SCB_UART_GetNumInRxFifo(config->reg_addr));
+}
+
 static void ifx_cat1_uart_irq_callback_set(const struct device *dev,
 					   uart_irq_callback_user_data_t cb, void *cb_data)
 {
@@ -1375,6 +1394,7 @@ static DEVICE_API(uart, ifx_cat1_uart_driver_api) = {
 	.irq_err_enable = ifx_cat1_uart_irq_err_enable,
 	.irq_err_disable = ifx_cat1_uart_irq_err_disable,
 	.irq_is_pending = ifx_cat1_uart_irq_is_pending,
+	.irq_update = ifx_cat1_uart_irq_update,
 	.irq_callback_set = ifx_cat1_uart_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 


### PR DESCRIPTION
This is reverting and adjusting what was removed in https://github.com/zephyrproject-rtos/zephyr/pull/105231
Reason: The IRQ which reads the registers for the FIFO status is required to flush correctly the UART RX FIFO