### PR TITLE
bflb: boards: Update ai_m61_32s_kit OC to use AUPLL

### DIFF
--- a/boards/aithinker/ai_m61_32s_kit/ai_m61_32s_kit_bl618m05q2i_safe_overclock.dts
+++ b/boards/aithinker/ai_m61_32s_kit/ai_m61_32s_kit_bl618m05q2i_safe_overclock.dts
@@ -9,9 +9,9 @@
 #include "ai_m61_32s.dtsi"
 #include "ai_m61_32s_kit_common.dtsi"
 
-&clk_wifipll {
+&clk_aupll {
 	/* Increased PLL top output frequency to 480 MHz */
-	top-frequency = <BL61X_WIFIPLL_TOP_FREQ_OC1>;
+	top-frequency = <BL61X_TOP_FREQ_OC1>;
 };
 
 &clk_bclk {

--- a/boards/aithinker/ai_m61_32s_kit/ai_m61_32s_kit_bl618m05q2i_unsafe_overclock.dts
+++ b/boards/aithinker/ai_m61_32s_kit/ai_m61_32s_kit_bl618m05q2i_unsafe_overclock.dts
@@ -9,9 +9,9 @@
 #include "ai_m61_32s.dtsi"
 #include "ai_m61_32s_kit_common.dtsi"
 
-&clk_wifipll {
+&clk_aupll {
 	/* Increased PLL top output frequency to 640MHz */
-	top-frequency = <BL61X_WIFIPLL_TOP_FREQ_OC2>;
+	top-frequency = <BL61X_TOP_FREQ_OC2>;
 };
 
 &reg_soc {

--- a/include/zephyr/dt-bindings/clock/bflb_bl61x_clock.h
+++ b/include/zephyr/dt-bindings/clock/bflb_bl61x_clock.h
@@ -57,9 +57,9 @@
 #define BL61X_AUPLL_TOP_FREQ	(DT_FREQ_M(320))
 
 /** Overclocked PLL example 1, standard voltages can be used */
-#define BL61X_WIFIPLL_TOP_FREQ_OC1	(DT_FREQ_M(480))
+#define BL61X_TOP_FREQ_OC1	(DT_FREQ_M(480))
 
 /** Overclocked PLL example 2, increased voltages (1.25v) must be used */
-#define BL61X_WIFIPLL_TOP_FREQ_OC2	(DT_FREQ_M(640))
+#define BL61X_TOP_FREQ_OC2	(DT_FREQ_M(640))
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_BFLB_BL61X_CLOCK_H_ */


### PR DESCRIPTION
The board was not updated when BL61x was switched to AUPLL