### PR TITLE
bflb: bluetooth: Fix BL70x M16S1 blob

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.bflb
+++ b/drivers/bluetooth/hci/Kconfig.bflb
@@ -106,8 +106,19 @@ config BFLB_BL70X_BLE_M1S1
 
 config BFLB_BL70X_BLE_M16S1
 	bool "m16s1: All roles, 16 master + 1 slave"
+	help
+	  16 Central + 1 Peripheral connections.
+	  Uses 16KB exchange memory (vs 8KB for other variants).
+	  The memory size must be correctly configured in the DTS (sram0_bt_em16k).
 
 endchoice
+
+config BFLB_BL70X_BLE_EM_16K
+	bool
+	default y if BFLB_BL70X_BLE_M16S1
+	help
+	  Use 16KB exchange memory for BLE controller.
+	  Only needed for the m16s1 variant.
 
 endif # BT_BFLB_BL70X
 
@@ -231,6 +242,7 @@ config BFLB_BL70XL_BLE_M8S1P
 	help
 	  8 BLE connections, master or slave. All controller code in flash.
 	  Supports PDS. Uses 16KB exchange memory (vs 8KB for other variants).
+	  The memory size must be correctly configured in the DTS (sram0_bt_em16k).
 
 endchoice
 

--- a/dts/riscv/bflb/bl70x.dtsi
+++ b/dts/riscv/bflb/bl70x.dtsi
@@ -427,10 +427,15 @@
 			#size-cells = <1>;
 			ranges = <0x0 0x42018000 DT_SIZE_K(96)>;
 
-			/* 88 KB — top 8 KB reserved for BLE exchange memory */
+			/* 88 KB — top 8 KB or 16 KB reserved for BLE exchange memory */
 			sram0_bt: sram@0 {
 				compatible = "mmio-sram";
 				reg = <0x0 DT_SIZE_K(88)>;
+			};
+
+			sram0_bt_em16k: sram_16k@0 {
+				compatible = "mmio-sram";
+				reg = <0x0 DT_SIZE_K(80)>;
 			};
 		};
 	};

--- a/soc/bflb/bl70x/bflb_platform_shim.c
+++ b/soc/bflb/bl70x/bflb_platform_shim.c
@@ -458,6 +458,11 @@ void srandom(unsigned int seed)
 	/* TRNG-based, no seeding needed */
 }
 
+int bl_rand(void)
+{
+	return (int)sys_rand32_get();
+}
+
 /* Stack info for blob */
 
 /*

--- a/soc/bflb/bl70x/soc.c
+++ b/soc/bflb/bl70x/soc.c
@@ -32,9 +32,11 @@ void soc_early_init_hook(void)
 	tmp = tmp & HBN_REG_EN_HW_PU_PD_UMSK;
 	sys_write32(tmp, HBN_BASE + HBN_IRQ_MODE_OFFSET);
 
-	/* Configure "seam" (BLE exchange memory): 8KB with BLE, 0KB otherwise */
+	/* Configure "seam" (BLE exchange memory): 8KB or 16KB with BLE, 0KB otherwise */
 	tmp = sys_read32(GLB_BASE + GLB_SEAM_MISC_OFFSET);
-#if defined(CONFIG_BT_BFLB_BL70X)
+#if defined(CONFIG_BFLB_BL70X_BLE_EM_16K)
+	tmp = (tmp & GLB_EM_SEL_UMSK) | (0xFU << GLB_EM_SEL_POS);
+#elif defined(CONFIG_BT_BFLB_BL70X)
 	tmp = (tmp & GLB_EM_SEL_UMSK) | (3U << GLB_EM_SEL_POS);
 #else
 	tmp = (tmp & GLB_EM_SEL_UMSK) | (0U << GLB_EM_SEL_POS);


### PR DESCRIPTION
Missing bl_rand shim, use proper size of EM

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/109697