### PR TITLE
scripts: runners: openocd: gate -rtos Zephyr on target arch

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -258,6 +258,9 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
     def print_gdbserver_message(self):
         if not self.thread_info_enabled:
             thread_msg = '; no thread info available'
+        elif not self.target_supports_rtos():
+            thread_msg = '; no thread info available (OpenOCD Zephyr RTOS ' \
+                         'awareness is not supported on this architecture)'
         elif self.supports_thread_info():
             thread_msg = '; thread info enabled'
         else:
@@ -285,6 +288,17 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         # Zephyr rtos was introduced after 0.11.0
         (major, minor, rev) = self.read_version()
         return (major, minor, rev) > (0, 11, 0)
+
+    def target_supports_rtos(self):
+        # OpenOCD's '-rtos Zephyr' awareness is only implemented for a
+        # subset of target architectures (cortex_m, cortex_r4, hla_target
+        # and arcv2). Appending it for any other architecture makes OpenOCD
+        # abort with "Could not find target in Zephyr compatibility list",
+        # which surfaces as a silent 'west debug' timeout. Gate on the arch
+        # so unsupported targets degrade gracefully instead.
+        return (self.build_conf.getboolean('CONFIG_CPU_CORTEX_M') or
+                self.build_conf.getboolean('CONFIG_CPU_AARCH32_CORTEX_R') or
+                self.build_conf.getboolean('CONFIG_ISA_ARCV2'))
 
     def do_run(self, command, **kwargs):
         self.require(self.openocd_cmd[0])
@@ -412,7 +426,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             pre_init_cmd.append("-c")
             pre_init_cmd.append(i)
 
-        if self.thread_info_enabled and self.supports_thread_info():
+        if (self.thread_info_enabled and self.supports_thread_info() and
+                self.target_supports_rtos()):
             pre_init_cmd.append("-c")
             rtos_command = f'${self.target_handle} configure -rtos Zephyr'
             pre_init_cmd.append(rtos_command)
@@ -510,7 +525,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             pre_init_cmd.append("-c")
             pre_init_cmd.append(i)
 
-        if self.thread_info_enabled and self.supports_thread_info():
+        if (self.thread_info_enabled and self.supports_thread_info() and
+                self.target_supports_rtos()):
             pre_init_cmd.append("-c")
             rtos_command = f'${self.target_handle} configure -rtos Zephyr'
             pre_init_cmd.append(rtos_command)

--- a/scripts/west_commands/tests/test_openocd.py
+++ b/scripts/west_commands/tests/test_openocd.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 Andrii Anoshyn
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import pytest
+from conftest import RC_GDB, RC_OPENOCD
+
+from runners.openocd import OpenOcdBinaryRunner
+
+#
+# OpenOCD's '-rtos Zephyr' target awareness is only implemented for the
+# cortex_m, cortex_r4, hla_target and arcv2 architectures. Appending the
+# command for any other architecture makes OpenOCD abort, which 'west debug'
+# surfaces as a silent timeout. The runner therefore gates the command on the
+# build's architecture in addition to the OpenOCD version (see issue #108804).
+#
+
+RTOS_COMMAND = '$_TARGETNAME configure -rtos Zephyr'
+
+# (CONFIG symbols that are 'y', architecture is RTOS-aware?)
+ARCH_CASES = [
+    ({'CONFIG_CPU_CORTEX_M': True}, True),
+    ({'CONFIG_CPU_AARCH32_CORTEX_R': True}, True),
+    ({'CONFIG_ISA_ARCV2': True}, True),
+    # RISC-V / Xtensa and friends: none of the gating symbols are set.
+    ({}, False),
+]
+
+
+class FakeBuildConf:
+    '''Minimal stand-in for runners.core.BuildConfiguration.'''
+
+    def __init__(self, options):
+        self.options = options
+
+    def getboolean(self, option):
+        return self.options.get(option, False)
+
+
+def require_patch(program):
+    assert program in [RC_OPENOCD, RC_GDB]
+
+
+@pytest.fixture
+def openocd(runner_config):
+    def _factory(enabled_configs):
+        # The shared fixture leaves a non-None cfg.file (an artifact of its
+        # positional construction); force it to None so the OpenOCD runner,
+        # which builds a Path() from it, constructs cleanly.
+        runner = OpenOcdBinaryRunner(runner_config._replace(file=None))
+        # Inject a fake build configuration so no real build dir is read.
+        # CONFIG_DEBUG_THREAD_INFO gates whether thread info is requested at
+        # all; the architecture symbols gate whether the arch supports it.
+        configs = {'CONFIG_DEBUG_THREAD_INFO': True, **enabled_configs}
+        runner._build_conf = FakeBuildConf(configs)
+        return runner
+
+    return _factory
+
+
+@pytest.mark.parametrize('enabled_configs, rtos_supported', ARCH_CASES)
+@patch('runners.openocd.OpenOcdBinaryRunner.read_version', return_value=(0, 12, 0))
+@patch('runners.openocd.OpenOcdBinaryRunner.check_call')
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
+def test_debugserver_rtos_arch_gate(
+    require, check_call, read_version, enabled_configs, rtos_supported, openocd
+):
+    '''The '-rtos Zephyr' command is only emitted for RTOS-aware archs.'''
+    openocd(enabled_configs).run('debugserver')
+
+    cmd = check_call.call_args[0][0]
+    assert (RTOS_COMMAND in cmd) == rtos_supported
+
+
+@patch('runners.openocd.OpenOcdBinaryRunner.read_version', return_value=(0, 11, 0))
+@patch('runners.openocd.OpenOcdBinaryRunner.check_call')
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
+def test_debugserver_rtos_old_openocd(require, check_call, read_version, openocd):
+    '''An OpenOCD too old for Zephyr awareness never gets the command, even
+    on an otherwise supported architecture.'''
+    openocd({'CONFIG_CPU_CORTEX_M': True}).run('debugserver')
+
+    cmd = check_call.call_args[0][0]
+    assert RTOS_COMMAND not in cmd

--- a/scripts/west_commands/tests/test_openocd.py
+++ b/scripts/west_commands/tests/test_openocd.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from conftest import RC_GDB, RC_OPENOCD
@@ -43,6 +43,13 @@ def require_patch(program):
     assert program in [RC_OPENOCD, RC_GDB]
 
 
+def openocd_cmd(command, check_call, popen_ignore_int):
+    if command == 'debugserver':
+        return check_call.call_args[0][0]
+
+    return popen_ignore_int.call_args[0][0]
+
+
 @pytest.fixture
 def openocd(runner_config):
     def _factory(enabled_configs):
@@ -60,27 +67,43 @@ def openocd(runner_config):
     return _factory
 
 
+@pytest.mark.parametrize('command', ['debugserver', 'debug'])
 @pytest.mark.parametrize('enabled_configs, rtos_supported', ARCH_CASES)
 @patch('runners.openocd.OpenOcdBinaryRunner.read_version', return_value=(0, 12, 0))
+@patch('runners.openocd.OpenOcdBinaryRunner.check_call_ignore_sigint')
+@patch('runners.openocd.OpenOcdBinaryRunner.popen_ignore_int', return_value=MagicMock())
 @patch('runners.openocd.OpenOcdBinaryRunner.check_call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 def test_debugserver_rtos_arch_gate(
-    require, check_call, read_version, enabled_configs, rtos_supported, openocd
+    require,
+    check_call,
+    popen_ignore_int,
+    check_call_ignore_sigint,
+    read_version,
+    command,
+    enabled_configs,
+    rtos_supported,
+    openocd,
 ):
     '''The '-rtos Zephyr' command is only emitted for RTOS-aware archs.'''
-    openocd(enabled_configs).run('debugserver')
+    openocd(enabled_configs).run(command)
 
-    cmd = check_call.call_args[0][0]
+    cmd = openocd_cmd(command, check_call, popen_ignore_int)
     assert (RTOS_COMMAND in cmd) == rtos_supported
 
 
+@pytest.mark.parametrize('command', ['debugserver', 'debug'])
 @patch('runners.openocd.OpenOcdBinaryRunner.read_version', return_value=(0, 11, 0))
+@patch('runners.openocd.OpenOcdBinaryRunner.check_call_ignore_sigint')
+@patch('runners.openocd.OpenOcdBinaryRunner.popen_ignore_int', return_value=MagicMock())
 @patch('runners.openocd.OpenOcdBinaryRunner.check_call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
-def test_debugserver_rtos_old_openocd(require, check_call, read_version, openocd):
+def test_debugserver_rtos_old_openocd(
+    require, check_call, popen_ignore_int, check_call_ignore_sigint, read_version, command, openocd
+):
     '''An OpenOCD too old for Zephyr awareness never gets the command, even
     on an otherwise supported architecture.'''
-    openocd({'CONFIG_CPU_CORTEX_M': True}).run('debugserver')
+    openocd({'CONFIG_CPU_CORTEX_M': True}).run(command)
 
-    cmd = check_call.call_args[0][0]
+    cmd = openocd_cmd(command, check_call, popen_ignore_int)
     assert RTOS_COMMAND not in cmd


### PR DESCRIPTION
## Summary

OpenOCD's Zephyr RTOS awareness (`$_TARGETNAME configure -rtos Zephyr`) is only implemented for the `cortex_m`, `cortex_r4`, `hla_target` and `arcv2` target architectures. The runner's `supports_thread_info()` only checked the OpenOCD **version**, so with `CONFIG_DEBUG_THREAD_INFO=y` it appended the `-rtos Zephyr` command unconditionally.

On any other architecture (e.g. RISC-V, Xtensa) OpenOCD then aborts with *"Could not find target in Zephyr compatibility list"*, which `west debug` surfaces as a silent timeout — debugging is effectively broken on those targets.

## Change

- Add `target_supports_rtos()`, which reads the build configuration for `CONFIG_CPU_CORTEX_M`, `CONFIG_CPU_AARCH32_CORTEX_R` or `CONFIG_ISA_ARCV2`, and only append the `-rtos Zephyr` command when both the OpenOCD version *and* the architecture support it.
- `print_gdbserver_message()` now reports that thread info is unavailable because of the architecture, instead of implying it is enabled.
- Add `tests/test_openocd.py` covering the new arch gate and the existing version gate.

## Scope

This makes `west debug` **degrade gracefully with a clear message** on architectures OpenOCD's `-rtos Zephyr` does not support, instead of timing out silently. Actually adding thread-aware debugging for RISC-V/Xtensa (as raised in the issue discussion) is a separate, larger OpenOCD-side effort and is intentionally **out of scope** here.

Fixes #108804

## Test

- `pytest scripts/west_commands/tests/test_openocd.py` — 5 passing.
- Mutation-checked: dropping the arch gate makes the RISC-V case fail, confirming the test guards the regression.