### PR TITLE
modules: mbedtls: fix `tf-psa-crypto` includes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -324,7 +324,7 @@ manifest:
       revision: 85aa60d18b3d5e5588d7b247abf90198f07c8a63
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 6a08a7eb799853ce2a9053d24ecde31bf3a1322c
+      revision: pull/94/head
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
Use the generic path for the `tf-psa-crypto` folder in the MbedTLS module. This ensures that when an application uses `#include <psa/crypto.h>`, the real file included is `modules/crypto/tf-psa-crypto/include/psa/crypto.h`, not `modules/crypto/mbedtls/tf-psa-crypto/include/psa/crypto.h`.

Resolves #110073