### PR TITLE
boards: st: stm32n6: add STMod+ connector include for STM32N6570-DK

### DIFF
--- a/boards/shields/mb1280_stmod_plus/Kconfig.shield
+++ b/boards/shields/mb1280_stmod_plus/Kconfig.shield
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_MB1280_STMOD_PLUS
+	def_bool $(shields_list_contains,mb1280_stmod_plus)
+
+config SHIELD_MB1280_STMOD_PLUS_ADC
+	def_bool $(shields_list_contains,mb1280_stmod_plus_adc)
+
+config SHIELD_MB1280_STMOD_PLUS_I2C
+	def_bool $(shields_list_contains,mb1280_stmod_plus_i2c)
+
+config SHIELD_MB1280_STMOD_PLUS_PWM
+	def_bool $(shields_list_contains,mb1280_stmod_plus_pwm)
+
+config SHIELD_MB1280_STMOD_PLUS_SERIAL
+	def_bool $(shields_list_contains,mb1280_stmod_plus_serial)
+
+config SHIELD_MB1280_STMOD_PLUS_SPI
+	def_bool $(shields_list_contains,mb1280_stmod_plus_spi)

--- a/boards/shields/mb1280_stmod_plus/doc/index.rst
+++ b/boards/shields/mb1280_stmod_plus/doc/index.rst
@@ -1,0 +1,47 @@
+.. _mb1280_stmod_plus:
+
+MB1280 STMod+ fan-out shield
+############################
+
+Overview
+********
+
+The MB1280 STMod+ fan-out board converts an STMod+ connector to Grove UART,
+Grove I2C, ESP-01, and mikroBUS-compatible connectors.
+
+The shield exposes the MB1280 fan-out connectors through the board's
+``stmod_plus_connector`` GPIO nexus.
+
+All GPIO-capable pins on the MB1280 mikroBUS-compatible connector are exposed
+through ``mikrobus_header``.
+
+Interface aliases are provided by stackable shield variants:
+
+- ``mb1280_stmod_plus_adc`` maps ``mikrobus_adc`` to ``stmod_adc``.
+- ``mb1280_stmod_plus_i2c`` maps ``grove_i2c`` and ``mikrobus_i2c`` to
+  ``stmod_i2c``.
+- ``mb1280_stmod_plus_pwm`` maps ``mikrobus_pwm`` to ``stmod_pwm``.
+- ``mb1280_stmod_plus_serial`` maps ``grove_serial``, ``esp_01_serial``, and
+  ``mikrobus_serial`` to ``stmod_serial``.
+- ``mb1280_stmod_plus_spi`` maps ``mikrobus_spi`` to ``stmod_spi``.
+
+Requirements
+************
+
+This shield can be used with a board that exposes an STMod+ connector with the
+``stmod_plus_connector`` node label. The board should also provide matching
+``stmod_adc``, ``stmod_i2c``, ``stmod_pwm``, ``stmod_serial``, or
+``stmod_spi`` labels for the stackable variants used with this shield.
+
+Programming
+***********
+
+Include ``--shield mb1280_stmod_plus`` when invoking ``west build``. Add the
+stackable variants that match the STMod+ interfaces provided by the board. For
+example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: stm32n6570_dk/stm32n657xx/sb
+   :shield: mb1280_stmod_plus,mb1280_stmod_plus_i2c,mb1280_stmod_plus_serial
+   :goals: build

--- a/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus.overlay
+++ b/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus.overlay
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/stmod-plus-connector.h>
+
+/ {
+	grove_uart_header: grove-uart-connector {
+		compatible = "grove-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <0 0 &stmod_plus_connector STMOD_PLUS_MISO_RX 0>, /* RX */
+			   <1 0 &stmod_plus_connector STMOD_PLUS_MOSI_TX 0>; /* TX */
+	};
+
+	grove_i2c_header: grove-i2c-connector {
+		compatible = "grove-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <0 0 &stmod_plus_connector STMOD_PLUS_SCL 0>, /* SCL */
+			   <1 0 &stmod_plus_connector STMOD_PLUS_SDA 0>; /* SDA */
+	};
+
+	esp_01_header: esp-01-connector {
+		compatible = "esp-01-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <2 0 &stmod_plus_connector STMOD_PLUS_MISO_RX 0>, /* RXD */
+			   <3 0 &stmod_plus_connector STMOD_PLUS_PWM 0>,     /* GPIO2 */
+			   <4 0 &stmod_plus_connector STMOD_PLUS_ADC 0>,     /* CH_PD */
+			   <5 0 &stmod_plus_connector STMOD_PLUS_INT 0>,     /* GPIO0 */
+			   <6 0 &stmod_plus_connector STMOD_PLUS_RESET 0>,   /* RST */
+			   <7 0 &stmod_plus_connector STMOD_PLUS_MOSI_TX 0>; /* TXD */
+	};
+
+	mikrobus_header: mikrobus-connector {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <0 0 &stmod_plus_connector STMOD_PLUS_ADC 0>,     /* AN */
+			   <1 0 &stmod_plus_connector STMOD_PLUS_RESET 0>,   /* RST */
+			   <2 0 &stmod_plus_connector STMOD_PLUS_NSS_CTS 0>, /* CS */
+			   <3 0 &stmod_plus_connector STMOD_PLUS_SCK_RTS 0>, /* SCK */
+			   <4 0 &stmod_plus_connector STMOD_PLUS_MISOS 0>,   /* MISO */
+			   <5 0 &stmod_plus_connector STMOD_PLUS_MOSIS 0>,   /* MOSI */
+			   <6 0 &stmod_plus_connector STMOD_PLUS_PWM 0>,     /* PWM */
+			   <7 0 &stmod_plus_connector STMOD_PLUS_INT 0>,     /* INT */
+			   <8 0 &stmod_plus_connector STMOD_PLUS_MISO_RX 0>, /* RX */
+			   <9 0 &stmod_plus_connector STMOD_PLUS_MOSI_TX 0>, /* TX */
+			   <10 0 &stmod_plus_connector STMOD_PLUS_SCL 0>,    /* SCL */
+			   <11 0 &stmod_plus_connector STMOD_PLUS_SDA 0>;    /* SDA */
+	};
+};

--- a/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus_adc.overlay
+++ b/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus_adc.overlay
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+mikrobus_adc: &stmod_adc {};

--- a/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus_i2c.overlay
+++ b/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus_i2c.overlay
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+grove_i2c: &stmod_i2c {};
+
+mikrobus_i2c: &stmod_i2c {};

--- a/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus_pwm.overlay
+++ b/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus_pwm.overlay
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+mikrobus_pwm: &stmod_pwm {};

--- a/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus_serial.overlay
+++ b/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus_serial.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+grove_serial: &stmod_serial {};
+
+esp_01_serial: &stmod_serial {};
+
+/*
+ * Hardware flow control stays disabled here. Boards may still include CTS/RTS
+ * pins in stmod_serial pinctrl-0 so enabling it only requires a user overlay
+ * that adds hw-flow-control.
+ */
+mikrobus_serial: &stmod_serial {};

--- a/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus_spi.overlay
+++ b/boards/shields/mb1280_stmod_plus/mb1280_stmod_plus_spi.overlay
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+mikrobus_spi: &stmod_spi {};

--- a/boards/shields/mb1280_stmod_plus/shield.yml
+++ b/boards/shields/mb1280_stmod_plus/shield.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+shields:
+  - name: mb1280_stmod_plus
+    full_name: MB1280 STMod+ Fan-Out
+    vendor: st
+    supported_features:
+      - gpio
+
+  - name: mb1280_stmod_plus_adc
+    full_name: MB1280 STMod+ Fan-Out ADC
+    vendor: st
+    supported_features:
+      - adc
+
+  - name: mb1280_stmod_plus_i2c
+    full_name: MB1280 STMod+ Fan-Out I2C
+    vendor: st
+    supported_features:
+      - i2c
+
+  - name: mb1280_stmod_plus_pwm
+    full_name: MB1280 STMod+ Fan-Out PWM
+    vendor: st
+    supported_features:
+      - pwm
+
+  - name: mb1280_stmod_plus_serial
+    full_name: MB1280 STMod+ Fan-Out Serial
+    vendor: st
+    supported_features:
+      - uart
+
+  - name: mb1280_stmod_plus_spi
+    full_name: MB1280 STMod+ Fan-Out SPI
+    vendor: st
+    supported_features:
+      - spi

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/video/video-interfaces.h>
 #include "arduino_r3_connector.dtsi"
+#include "stmod_connector.dtsi"
 
 / {
 	chosen {
@@ -324,7 +325,8 @@ csi_i2c: &i2c1 {
 &usart2 {
 	clocks = <&rcc STM32_CLOCK(APB1, 17)>,
 		 <&rcc STM32_SRC_CKPER USART2_SEL(1)>;
-	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pf6>;
+	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pf6
+		     &usart2_cts_pg5 &usart2_rts_pg14>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";

--- a/boards/st/stm32n6570_dk/stmod_connector.dtsi
+++ b/boards/st/stm32n6570_dk/stmod_connector.dtsi
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/stmod-plus-connector.h>
+
+/ {
+	stmod_plus_connector: stmod-plus-connector {
+		compatible = "st,stmod-plus-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 GPIO_DT_FLAGS_MASK>;
+		/*
+		 * STMod+ pin 13 is STMOD_ADC. It has a dedicated digital I/O
+		 * path to PC9 on STM32N6570-DK, so expose PC9 here for GPIO use.
+		 * In the default board configuration, this signal is also shared
+		 * with Arduino A5 / PB10 ADC12_INP8.
+		 */
+		gpio-map = <STMOD_PLUS_NSS_CTS 0 &gpiog 5 0>,   /* NSS/CTS */
+			   <STMOD_PLUS_MOSI_TX 0 &gpiod 5 0>,   /* MOSI/TX */
+			   <STMOD_PLUS_MISO_RX 0 &gpiof 6 0>,   /* MISO/RX */
+			   <STMOD_PLUS_SCK_RTS 0 &gpiog 14 0>,  /* SCK/RTS */
+			   <STMOD_PLUS_SCL 0 &gpioh 9 0>,       /* SCL */
+			   <STMOD_PLUS_MOSIS 0 &gpioh 7 0>,     /* MOSIs */
+			   <STMOD_PLUS_MISOS 0 &gpioc 6 0>,     /* MISOs/I/O */
+			   <STMOD_PLUS_SDA 0 &gpioc 1 0>,       /* SDA */
+			   <STMOD_PLUS_INT 0 &gpioc 11 0>,      /* INT */
+			   <STMOD_PLUS_RESET 0 &gpiob 3 0>,     /* RESET */
+			   <STMOD_PLUS_ADC 0 &gpioc 9 0>,       /* ADC */
+			   <STMOD_PLUS_PWM 0 &gpioc 7 0>,       /* PWM */
+			   <STMOD_PLUS_GPIO17 0 &gpiod 13 0>,   /* GPIO */
+			   <STMOD_PLUS_GPIO18 0 &gpiof 1 0>,    /* GPIO */
+			   <STMOD_PLUS_GPIO19 0 &gpiob 8 0>,    /* GPIO */
+			   <STMOD_PLUS_GPIO20 0 &gpiog 9 0>;    /* GPIO */
+	};
+
+	stmod_adc: stmod-adc-channels {
+		io-channels = <&adc1 8>;
+	};
+};
+
+stmod_i2c: &i2c1 {};
+
+stmod_serial: &usart2 {};

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -146,6 +146,18 @@ These describe connections to cameras and displays (strictly speaking not shield
 - :dtcompatible:`weact,dcmi-camera-connector`
 
 
+ESP-01
+------
+
+This is an 8-pin header for ESP-01 Wi-Fi modules.
+
+Relevant devicetree node labels:
+
+- ``esp_01_header`` See :dtcompatible:`esp-01-header` for details on GPIO pin
+  definitions and includes for use in devicetree files.
+- ``esp_01_serial``
+
+
 Feather
 -------
 

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -253,6 +253,24 @@ Relevant devicetree node labels:
 - ``st_morpho_flash_spi``
 
 
+STMod+
+------
+
+This is a 20-pin expansion connector found on some STMicroelectronics Discovery
+and Evaluation boards.
+
+Relevant devicetree node labels:
+
+- ``stmod_plus_connector`` See :dtcompatible:`st,stmod-plus-connector` for
+  details on GPIO pin definitions and includes for use in devicetree files.
+- ``stmod_adc``
+- ``stmod_i2c``
+- ``stmod_serial``
+
+Boards may expose additional interface labels when a peripheral is wired to the
+STMod+ connector and enabled in the board devicetree.
+
+
 Xiao
 ----
 

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -214,6 +214,7 @@ Relevant devicetree node labels:
   technical specifications.
 - ``mikrobus_adc``
 - ``mikrobus_i2c``
+- ``mikrobus_pwm``
 - ``mikrobus_spi``
 - ``mikrobus_serial``
 
@@ -277,7 +278,9 @@ Relevant devicetree node labels:
   details on GPIO pin definitions and includes for use in devicetree files.
 - ``stmod_adc``
 - ``stmod_i2c``
+- ``stmod_pwm``
 - ``stmod_serial``
+- ``stmod_spi``
 
 Boards may expose additional interface labels when a peripheral is wired to the
 STMod+ connector and enabled in the board devicetree.

--- a/dts/bindings/gpio/esp-01-header.yaml
+++ b/dts/bindings/gpio/esp-01-header.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    GPIO pins exposed on ESP-01 headers.
+
+    This binding provides a nexus mapping for the GPIO-capable pins on an
+    ESP-01 2x4 header. Power and ground pins are not mapped.
+
+        1  GND      2  RXD
+        3  GPIO2    4  CH_PD
+        5  GPIO0    6  RST
+        7  TXD      8  3V3
+
+compatible: "esp-01-header"
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/dts/bindings/gpio/st,stmod-plus-connector.yaml
+++ b/dts/bindings/gpio/st,stmod-plus-connector.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    GPIO pins exposed on STMod+ connectors.
+
+    STMod+ is a 20-pin expansion connector used on STMicroelectronics
+    Discovery and Evaluation boards. This binding provides a nexus mapping
+    for the GPIO-capable STMod+ pins. Power and ground pins are not mapped.
+
+    Use STMOD_PLUS_* constants in
+    <zephyr/dt-bindings/gpio/stmod-plus-connector.h> to refer to specific
+    pins using convenient constant names.
+
+compatible: "st,stmod-plus-connector"
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/include/zephyr/dt-bindings/gpio/stmod-plus-connector.h
+++ b/include/zephyr/dt-bindings/gpio/stmod-plus-connector.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief STMod+ connector pin constants
+ * @ingroup stmod-plus-connector
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_STMOD_PLUS_CONNECTOR_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_STMOD_PLUS_CONNECTOR_H_
+
+/**
+ * @defgroup stmod-plus-connector STMod+ connector
+ * @brief Constants for pins exposed on STMod+ connectors
+ * @ingroup devicetree-gpio-pin-headers
+ * @{
+ */
+
+#define STMOD_PLUS_NSS_CTS  1  /**< Pin 1: SPI NSS or UART CTS */
+#define STMOD_PLUS_MOSI_TX  2  /**< Pin 2: SPI MOSI or UART TX */
+#define STMOD_PLUS_MISO_RX  3  /**< Pin 3: SPI MISO or UART RX */
+#define STMOD_PLUS_SCK_RTS  4  /**< Pin 4: SPI SCK or UART RTS */
+#define STMOD_PLUS_SCL      7  /**< Pin 7: I2C SCL */
+#define STMOD_PLUS_MOSIS    8  /**< Pin 8: Secondary SPI MOSI */
+#define STMOD_PLUS_MISOS    9  /**< Pin 9: Secondary SPI MISO */
+#define STMOD_PLUS_SDA      10 /**< Pin 10: I2C SDA */
+#define STMOD_PLUS_INT      11 /**< Pin 11: Interrupt */
+#define STMOD_PLUS_RESET    12 /**< Pin 12: Reset */
+#define STMOD_PLUS_ADC      13 /**< Pin 13: ADC */
+#define STMOD_PLUS_PWM      14 /**< Pin 14: PWM */
+#define STMOD_PLUS_GPIO17   17 /**< Pin 17: GPIO */
+#define STMOD_PLUS_GPIO18   18 /**< Pin 18: GPIO */
+#define STMOD_PLUS_GPIO19   19 /**< Pin 19: GPIO */
+#define STMOD_PLUS_GPIO20   20 /**< Pin 20: GPIO */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_STMOD_PLUS_CONNECTOR_H_ */


### PR DESCRIPTION
Add stmod_connector.dtsi to describe the STMod+ connector pin assignment on the STM32N6570-DK board.

The include file provides the connector-level mapping needed by STMod+ expansion boards such as the MB1280 fanout board, allowing future shield overlays to reference the board connector pins instead of hard-coding MCU pins directly.