### PR TITLE
Bluetooth: audio: check bt_conn_ref return value in LE Audio APIs

### DIFF
--- a/include/zephyr/bluetooth/audio/gmap.h
+++ b/include/zephyr/bluetooth/audio/gmap.h
@@ -201,6 +201,7 @@ int bt_gmap_cb_register(const struct bt_gmap_cb *cb);
  *
  * @retval -EINVAL if @p conn is NULL
  * @retval -EBUSY if discovery is already in progress for @p conn
+ * @retval -ENOTCONN if @p conn is not connected
  * @retval -ENOEXEC if discovery failed to initiate
  * @retval 0 on success
  */

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -703,6 +703,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 int bt_aics_discover(struct bt_conn *conn, struct bt_aics *inst,
 		     const struct bt_aics_discover_param *param)
 {
+	struct bt_conn *ref;
 	int err = 0;
 
 	if (!inst || !conn || !param) {
@@ -728,6 +729,12 @@ int bt_aics_discover(struct bt_conn *conn, struct bt_aics *inst,
 		return -EBUSY;
 	}
 
+	ref = bt_conn_ref(conn);
+	if (ref == NULL) {
+		err = -ENOTCONN;
+		goto cleanup;
+	}
+
 	aics_client_reset(inst);
 
 	(void)memset(&inst->cli.discover_params, 0, sizeof(inst->cli.discover_params));
@@ -737,14 +744,20 @@ int bt_aics_discover(struct bt_conn *conn, struct bt_aics *inst,
 	inst->cli.discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 	inst->cli.discover_params.func = aics_discover_func;
 
+	inst->cli.conn = ref;
+
 	err = bt_gatt_discover(conn, &inst->cli.discover_params);
 	if (err != 0) {
-		atomic_clear_bit(inst->cli.flags, BT_AICS_CLIENT_FLAG_BUSY);
 		LOG_DBG("Discover failed (err %d)", err);
-	} else {
-		inst->cli.conn = bt_conn_ref(conn);
+		bt_conn_unref(ref);
+		inst->cli.conn = NULL;
+		goto cleanup;
 	}
 
+	return 0;
+
+cleanup:
+	atomic_clear_bit(inst->cli.flags, BT_AICS_CLIENT_FLAG_BUSY);
 	return err;
 }
 

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -991,8 +991,9 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 
 int bt_bap_broadcast_assistant_discover(struct bt_conn *conn)
 {
-	int err;
 	struct bap_broadcast_assistant_instance *inst;
+	struct bt_conn *ref;
+	int err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1014,16 +1015,19 @@ int bt_bap_broadcast_assistant_discover(struct bt_conn *conn)
 		return -EBUSY;
 	}
 
-	err = broadcast_assistant_reset(inst);
-	if (err != 0) {
-		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
-
-		LOG_DBG("Failed to reset broadcast assistant: %d", err);
-
-		return -ENOEXEC;
+	ref = bt_conn_ref(conn);
+	if (ref == NULL) {
+		err = -ENOTCONN;
+		goto cleanup;
 	}
 
-	inst->conn = bt_conn_ref(conn);
+	err = broadcast_assistant_reset(inst);
+	if (err != 0) {
+		LOG_DBG("Failed to reset broadcast assistant: %d", err);
+		bt_conn_unref(ref);
+		err = -ENOEXEC;
+		goto cleanup;
+	}
 
 	/* Discover BASS on peer, setup handles and notify */
 	discover_init(inst);
@@ -1033,22 +1037,28 @@ int bt_bap_broadcast_assistant_discover(struct bt_conn *conn)
 	inst->disc_params.type = BT_GATT_DISCOVER_PRIMARY;
 	inst->disc_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 	inst->disc_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
+
+	inst->conn = ref;
+
 	err = bt_gatt_discover(conn, &inst->disc_params);
 	if (err != 0) {
-		atomic_clear_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
-		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
-
 		/* Report expected possible errors */
-		if (err == -ENOTCONN || err == -ENOMEM) {
-			return err;
+		if (err != -ENOTCONN && err != -ENOMEM) {
+			LOG_DBG("Unexpected err %d from bt_gatt_discover", err);
+			err = -ENOEXEC;
 		}
 
-		LOG_DBG("Unexpected err %d from bt_gatt_discover", err);
-
-		return -ENOEXEC;
+		bt_conn_unref(ref);
+		inst->conn = NULL;
+		goto cleanup;
 	}
 
 	return 0;
+
+cleanup:
+	atomic_clear_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
+	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
+	return err;
 }
 
 /* TODO: naming is different from e.g. bt_vcp_vol_ctrl_cb_register */

--- a/subsys/bluetooth/audio/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/ccp_call_control_client.c
@@ -202,6 +202,7 @@ int bt_ccp_call_control_client_discover(struct bt_conn *conn,
 					struct bt_ccp_call_control_client **out_client)
 {
 	struct bt_ccp_call_control_client *client;
+	struct bt_conn *ref;
 	int err;
 
 	if (conn == NULL) {
@@ -228,24 +229,35 @@ int bt_ccp_call_control_client_discover(struct bt_conn *conn,
 
 	tbs_client_cbs.discover = tbs_client_discover_cb;
 
+	ref = bt_conn_ref(conn);
+	if (ref == NULL) {
+		err = -ENOTCONN;
+		goto cleanup;
+	}
+
+	client->conn = ref;
+
 	err = bt_tbs_client_discover(conn);
 	if (err != 0) {
 		LOG_DBG("Failed to discover TBS for %p: %d", (void *)conn, err);
 
-		atomic_clear_bit(client->flags, CCP_CALL_CONTROL_CLIENT_FLAG_BUSY);
-
 		/* Return known errors */
-		if (err == -EBUSY || err == -ENOTCONN) {
-			return err;
+		if (err != -EBUSY && err != -ENOTCONN) {
+			err = -ENOEXEC;
 		}
 
-		return -ENOEXEC;
+		bt_conn_unref(ref);
+		client->conn = NULL;
+		goto cleanup;
 	}
 
-	client->conn = bt_conn_ref(conn);
 	*out_client = client;
 
 	return 0;
+
+cleanup:
+	atomic_clear_bit(client->flags, CCP_CALL_CONTROL_CLIENT_FLAG_BUSY);
+	return err;
 }
 
 int bt_ccp_call_control_client_register_cb(struct bt_ccp_call_control_client_cb *cb)

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -1460,8 +1460,9 @@ int bt_csip_set_coordinator_register_cb(struct bt_csip_set_coordinator_cb *cb)
 
 int bt_csip_set_coordinator_discover(struct bt_conn *conn)
 {
-	int err;
 	struct bt_csip_set_coordinator_inst *client;
+	struct bt_conn *ref;
+	int err;
 
 	if (conn == NULL) {
 		LOG_DBG("NULL conn");
@@ -1471,6 +1472,12 @@ int bt_csip_set_coordinator_discover(struct bt_conn *conn)
 	client = &client_insts[bt_conn_index(conn)];
 	if (atomic_test_and_set_bit(client->flags, SET_COORDINATOR_FLAG_BUSY)) {
 		return -EBUSY;
+	}
+
+	ref = bt_conn_ref(conn);
+	if (ref == NULL) {
+		err = -ENOTCONN;
+		goto cleanup;
 	}
 
 	csip_set_coordinator_reset(client);
@@ -1485,15 +1492,20 @@ int bt_csip_set_coordinator_discover(struct bt_conn *conn)
 	client->discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 
 	err = bt_gatt_discover(conn, &client->discover_params);
-	if (err == 0) {
-		for (size_t i = 0U; i < ARRAY_SIZE(client->set_member.insts); i++) {
-			client->set_member.insts[i].svc_inst = (void *)&client->svc_insts[i];
-		}
-		client->conn = bt_conn_ref(conn);
-	} else {
-		atomic_clear_bit(client->flags, SET_COORDINATOR_FLAG_BUSY);
+	if (err != 0) {
+		bt_conn_unref(ref);
+		goto cleanup;
 	}
 
+	for (size_t i = 0U; i < ARRAY_SIZE(client->set_member.insts); i++) {
+		client->set_member.insts[i].svc_inst = (void *)&client->svc_insts[i];
+	}
+	client->conn = ref;
+
+	return 0;
+
+cleanup:
+	atomic_clear_bit(client->flags, SET_COORDINATOR_FLAG_BUSY);
 	return err;
 }
 

--- a/subsys/bluetooth/audio/gmap_client.c
+++ b/subsys/bluetooth/audio/gmap_client.c
@@ -646,6 +646,7 @@ static uint8_t gmas_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 int bt_gmap_discover(struct bt_conn *conn)
 {
 	struct bt_gmap_client *gmap_cli;
+	struct bt_conn *ref;
 	int err;
 
 	if (conn == NULL) {
@@ -662,6 +663,12 @@ int bt_gmap_discover(struct bt_conn *conn)
 		return -EBUSY;
 	}
 
+	ref = bt_conn_ref(conn);
+	if (ref == NULL) {
+		err = -ENOTCONN;
+		goto cleanup;
+	}
+
 	gmap_reset(gmap_cli);
 
 	gmap_cli->params.discover.func = gmas_discover_func;
@@ -670,18 +677,22 @@ int bt_gmap_discover(struct bt_conn *conn)
 	gmap_cli->params.discover.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 	gmap_cli->params.discover.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 
+	gmap_cli->conn = ref;
+
 	err = bt_gatt_discover(conn, &gmap_cli->params.discover);
 	if (err != 0) {
 		LOG_DBG("Failed to initiate discovery: %d", err);
-
-		atomic_clear_bit(gmap_cli->flags, GMAP_CLIENT_FLAG_BUSY);
-
-		return -ENOEXEC;
+		bt_conn_unref(ref);
+		gmap_cli->conn = NULL;
+		err = -ENOEXEC;
+		goto cleanup;
 	}
 
-	gmap_cli->conn = bt_conn_ref(conn);
-
 	return 0;
+
+cleanup:
+	atomic_clear_bit(gmap_cli->flags, GMAP_CLIENT_FLAG_BUSY);
+	return err;
 }
 
 int bt_gmap_cb_register(const struct bt_gmap_cb *cb)

--- a/subsys/bluetooth/audio/has_client.c
+++ b/subsys/bluetooth/audio/has_client.c
@@ -839,6 +839,7 @@ int bt_has_client_cb_register(const struct bt_has_client_cb *cb)
 int bt_has_client_discover(struct bt_conn *conn)
 {
 	struct bt_has_client *inst;
+	struct bt_conn *ref;
 	int err;
 
 	LOG_DBG("conn %p", (void *)conn);
@@ -858,13 +859,25 @@ int bt_has_client_discover(struct bt_conn *conn)
 		return -EALREADY;
 	}
 
-	inst->conn = bt_conn_ref(conn);
+	ref = bt_conn_ref(conn);
+	if (ref == NULL) {
+		err = -ENOTCONN;
+		goto cleanup;
+	}
+
+	inst->conn = ref;
 
 	err = features_discover(inst);
 	if (err != 0) {
-		atomic_clear_bit(inst->flags, HAS_CLIENT_DISCOVER_IN_PROGRESS);
+		bt_conn_unref(inst->conn);
+		inst->conn = NULL;
+		goto cleanup;
 	}
 
+	return 0;
+
+cleanup:
+	atomic_clear_bit(inst->flags, HAS_CLIENT_DISCOVER_IN_PROGRESS);
 	return err;
 }
 

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -2108,6 +2108,7 @@ int bt_mcc_init(struct bt_mcc_cb *cb)
 int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe)
 {
 	struct mcs_instance_t *mcs_inst;
+	struct bt_conn *ref;
 	int err;
 
 	if (!conn) {
@@ -2124,14 +2125,18 @@ int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe)
 		return -EBUSY;
 	}
 
+	ref = bt_conn_ref(conn);
+	if (ref == NULL) {
+		err = -ENOTCONN;
+		goto cleanup;
+	}
+
 	subscribe_all = subscribe;
 	err = reset_mcs_inst(mcs_inst);
 	if (err != 0) {
 		LOG_DBG("Failed to reset MCS instance %p: %d", mcs_inst, err);
-
-		atomic_clear_bit(mcs_inst->flags, MCC_FLAG_BUSY);
-
-		return err;
+		bt_conn_unref(ref);
+		goto cleanup;
 	}
 	(void)memcpy(&uuid, BT_UUID_GMCS, sizeof(uuid));
 
@@ -2144,13 +2149,17 @@ int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe)
 	LOG_DBG("start discovery of GMCS primary service");
 	err = bt_gatt_discover(conn, &mcs_inst->discover_params);
 	if (err != 0) {
-		atomic_clear_bit(mcs_inst->flags, MCC_FLAG_BUSY);
-		return err;
+		bt_conn_unref(ref);
+		goto cleanup;
 	}
 
-	mcs_inst->conn = bt_conn_ref(conn);
+	mcs_inst->conn = ref;
 
 	return 0;
+
+cleanup:
+	atomic_clear_bit(mcs_inst->flags, MCC_FLAG_BUSY);
+	return err;
 }
 
 int bt_mcc_read_player_name(struct bt_conn *conn)

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -752,6 +752,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 
 int media_proxy_ctrl_discover_player(struct bt_conn *conn)
 {
+	struct bt_conn *ref;
 	int err;
 
 	CHECKIF(!conn) {
@@ -831,17 +832,23 @@ int media_proxy_ctrl_discover_player(struct bt_conn *conn)
 		return err;
 	}
 
+	ref = bt_conn_ref(conn);
+	if (ref == NULL) {
+		return -ENOTCONN;
+	}
+
 	/* Start discovery of remote MCS, subscribe to notifications */
 	err = bt_mcc_discover_mcs(conn, 1);
 	if (err != 0) {
 		LOG_ERR("Discovery failed");
+		bt_conn_unref(ref);
 		return err;
 	}
 
 	if (mprx.remote_player.conn != NULL) {
 		bt_conn_unref(mprx.remote_player.conn);
 	}
-	mprx.remote_player.conn = bt_conn_ref(conn);
+	mprx.remote_player.conn = ref;
 	mprx.remote_player.registered = true;  /* TODO: Do MCC init and "registration" at startup */
 
 	return 0;

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -525,6 +525,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 int bt_micp_mic_ctlr_discover(struct bt_conn *conn, struct bt_micp_mic_ctlr **mic_ctlr_out)
 {
 	struct bt_micp_mic_ctlr *mic_ctlr;
+	struct bt_conn *ref;
 	int err;
 
 	/*
@@ -547,6 +548,12 @@ int bt_micp_mic_ctlr_discover(struct bt_conn *conn, struct bt_micp_mic_ctlr **mi
 		LOG_DBG("Instance is busy");
 
 		return -EBUSY;
+	}
+
+	ref = bt_conn_ref(conn);
+	if (ref == NULL) {
+		err = -ENOTCONN;
+		goto cleanup;
 	}
 
 	(void)memset(&mic_ctlr->discover_params, 0,
@@ -576,7 +583,9 @@ int bt_micp_mic_ctlr_discover(struct bt_conn *conn, struct bt_micp_mic_ctlr **mi
 				mic_ctlrs[i].aics[j] = bt_aics_client_free_instance_get();
 
 				if (mic_ctlrs[i].aics[j] == NULL) {
-					return -ENOMEM;
+					bt_conn_unref(ref);
+					err = -ENOMEM;
+					goto cleanup;
 				}
 
 				bt_aics_client_cb_register(mic_ctlrs[i].aics[j], &aics_cb);
@@ -587,20 +596,27 @@ int bt_micp_mic_ctlr_discover(struct bt_conn *conn, struct bt_micp_mic_ctlr **mi
 	}
 #endif /* CONFIG_BT_MICP_MIC_CTLR_AICS */
 
-	mic_ctlr->conn = bt_conn_ref(conn);
 	mic_ctlr->discover_params.func = primary_discover_func;
 	mic_ctlr->discover_params.uuid = mics_uuid;
 	mic_ctlr->discover_params.type = BT_GATT_DISCOVER_PRIMARY;
 	mic_ctlr->discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 	mic_ctlr->discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 
+	mic_ctlr->conn = ref;
+
 	err = bt_gatt_discover(conn, &mic_ctlr->discover_params);
-	if (err == 0) {
-		*mic_ctlr_out = mic_ctlr;
-	} else {
-		atomic_clear_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY);
+	if (err != 0) {
+		bt_conn_unref(ref);
+		mic_ctlr->conn = NULL;
+		goto cleanup;
 	}
 
+	*mic_ctlr_out = mic_ctlr;
+
+	return 0;
+
+cleanup:
+	atomic_clear_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY);
 	return err;
 }
 

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -934,6 +934,7 @@ int bt_vcp_vol_ctlr_discover(struct bt_conn *conn, struct bt_vcp_vol_ctlr **out_
 {
 	static bool initialized;
 	struct bt_vcp_vol_ctlr *vol_ctlr;
+	struct bt_conn *ref;
 	int err;
 
 	/*
@@ -968,24 +969,37 @@ int bt_vcp_vol_ctlr_discover(struct bt_conn *conn, struct bt_vcp_vol_ctlr **out_
 		initialized = true;
 	}
 
+	ref = bt_conn_ref(conn);
+	if (ref == NULL) {
+		err = -ENOTCONN;
+		goto cleanup;
+	}
+
 	vcp_vol_ctlr_reset(vol_ctlr);
 
 	memcpy(&vol_ctlr->uuid, BT_UUID_VCS, sizeof(vol_ctlr->uuid));
 
-	vol_ctlr->conn = bt_conn_ref(conn);
 	vol_ctlr->discover_params.func = primary_discover_func;
 	vol_ctlr->discover_params.uuid = &vol_ctlr->uuid.uuid;
 	vol_ctlr->discover_params.type = BT_GATT_DISCOVER_PRIMARY;
 	vol_ctlr->discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 	vol_ctlr->discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 
+	vol_ctlr->conn = ref;
+
 	err = bt_gatt_discover(conn, &vol_ctlr->discover_params);
-	if (err == 0) {
-		*out_vol_ctlr = vol_ctlr;
-	} else {
-		atomic_clear_bit(vol_ctlr->flags, BT_VCP_VOL_CTLR_FLAG_BUSY);
+	if (err != 0) {
+		bt_conn_unref(ref);
+		vol_ctlr->conn = NULL;
+		goto cleanup;
 	}
 
+	*out_vol_ctlr = vol_ctlr;
+
+	return 0;
+
+cleanup:
+	atomic_clear_bit(vol_ctlr->flags, BT_VCP_VOL_CTLR_FLAG_BUSY);
 	return err;
 }
 

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -717,6 +717,7 @@ int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *vocs,
 		     const struct bt_vocs_discover_param *param)
 {
 	struct bt_vocs_client *inst;
+	struct bt_conn *ref;
 	int err = 0;
 
 	if (!vocs || !conn || !param) {
@@ -747,20 +748,33 @@ int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *vocs,
 		return -EBUSY;
 	}
 
+	ref = bt_conn_ref(conn);
+	if (ref == NULL) {
+		err = -ENOTCONN;
+		goto cleanup;
+	}
+
 	vocs_client_reset(inst);
 
-	inst->conn = bt_conn_ref(conn);
 	inst->discover_params.start_handle = param->start_handle;
 	inst->discover_params.end_handle = param->end_handle;
 	inst->discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 	inst->discover_params.func = vocs_discover_func;
 
+	inst->conn = ref;
+
 	err = bt_gatt_discover(conn, &inst->discover_params);
 	if (err != 0) {
 		LOG_DBG("Discover failed (err %d)", err);
-		atomic_clear_bit(inst->flags, BT_VOCS_CLIENT_FLAG_BUSY);
+		bt_conn_unref(ref);
+		inst->conn = NULL;
+		goto cleanup;
 	}
 
+	return 0;
+
+cleanup:
+	atomic_clear_bit(inst->flags, BT_VOCS_CLIENT_FLAG_BUSY);
 	return err;
 }
 


### PR DESCRIPTION
Fixes #95148 

bt_conn_ref can return NULL if the application passes a stale conn pointer. Check the return value in all public LE Audio discover APIs and return -ENOTCONN on failure.