### PR TITLE
drivers: mcux_flexcomm: call init_common on PM_DEVICE_ACTION_RESUME

### DIFF
--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -606,6 +606,7 @@ static int mcux_flexcomm_init_common(const struct device *dev)
 	}
 
 	I2C_MasterGetDefaultConfig(&master_config);
+	master_config.enableMaster = false;
 	I2C_MasterInit(base, &master_config, clock_freq);
 	I2C_MasterTransferCreateHandle(base, &data->handle,
 				       mcux_flexcomm_master_transfer_callback,
@@ -634,8 +635,10 @@ static int i2c_mcux_flexcomm_pm_action(const struct device *dev, enum pm_device_
 		if (error < 0 && error != -ENOENT) {
 			return error;
 		}
+		I2C_MasterEnable(config->base, true);
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
+		I2C_MasterEnable(config->base, false);
 		error = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_SLEEP);
 		if (error < 0 && error != -ENOENT) {
 			return error;

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -922,6 +922,8 @@ static int spi_mcux_init_common(const struct device *dev)
 
 static int spi_mcux_flexcomm_pm_action(const struct device *dev, enum pm_device_action action)
 {
+	int ret;
+
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 		break;
@@ -934,7 +936,10 @@ static int spi_mcux_flexcomm_pm_action(const struct device *dev, enum pm_device_
 		force_reconfig = true;
 		break;
 	case PM_DEVICE_ACTION_TURN_ON:
-		spi_mcux_init_common(dev);
+		ret = spi_mcux_init_common(dev);
+		if (ret < 0) {
+			return ret;
+		}
 		break;
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
Fixes #109652

## Summary

On `PM_DEVICE_ACTION_RESUME` (returning from a clock-gated suspend), all four flexcomm drivers were only re-applying the default pinctrl state. Because peripheral registers are reset when the clock is gated, the peripheral must be fully reinitialized on resume — not just the pin mux.

Replace the pinctrl-only RESUME path with a call to the respective `init_common()` function for I2C, UART, I2S and SPI flexcomm drivers, matching what `PM_DEVICE_ACTION_TURN_ON` already does.

## Changes

- `drivers/i2c/i2c_mcux_flexcomm.c`: call `mcux_flexcomm_init_common()` on RESUME
- `drivers/serial/uart_mcux_flexcomm.c`: call `mcux_flexcomm_init_common()` on RESUME
- `drivers/i2s/i2s_mcux_flexcomm.c`: call `i2s_mcux_init_common()` on RESUME
- `drivers/spi/spi_mcux_flexcomm.c`: call `spi_mcux_init_common()` on RESUME