### PR TITLE
cpu_freq: pressure: fix policy name and code style

### DIFF
--- a/subsys/cpu_freq/policies/pressure/pressure.c
+++ b/subsys/cpu_freq/policies/pressure/pressure.c
@@ -117,8 +117,8 @@ int cpu_freq_policy_select_pstate(const struct pstate **pstate_out)
 {
 	int sys_pressure;
 
-	if (NULL == pstate_out) {
-		LOG_ERR("On-Demand Policy: pstate_out is NULL");
+	if (pstate_out == NULL) {
+		LOG_ERR("Pressure Policy: pstate_out is NULL");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Replace "On-Demand Policy" with "Pressure Policy" in error log and fix code style "pstate_out == NULL" to match project standard.
