### PR TITLE
doc: west: improve manifest group setup guidance

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -238,6 +238,15 @@ chosen. You'll also install Zephyr's additional Python dependencies in a
 
                west init ~/zephyrproject
                cd ~/zephyrproject
+
+            .. tip::
+
+               To reduce disk space usage and avoid downloading unnecessary
+               modules or vendor HALs during setup, configure
+               :ref:`west-manifest-groups` before running ``west update``.
+
+            .. code-block:: bash
+
                west update
 
          .. only:: release
@@ -250,6 +259,15 @@ chosen. You'll also install Zephyr's additional Python dependencies in a
 
                west init ~/zephyrproject --mr v |zephyr-version-ltrim|
                cd ~/zephyrproject
+
+            .. tip::
+
+               To reduce disk space usage and avoid downloading unnecessary
+               modules or vendor HALs during setup, configure
+               :ref:`west-manifest-groups` before running ``west update``.
+
+            .. code-block:: bash
+
                west update
 
       #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to

--- a/doc/develop/west/manifest.rst
+++ b/doc/develop/west/manifest.rst
@@ -681,6 +681,67 @@ You can think of this as if the ``manifest.group-filter`` configuration option
 is appended to the ``manifest: group-filter:`` list from YAML, with "last entry
 wins" semantics.
 
+Practical Example: Reducing Workspace Downloads
+-----------------------------------------------
+
+By default, ``west update`` fetches all active projects defined
+in the manifest. Large workspaces may include optional modules,
+vendor HALs, experimental components, or platform-specific
+dependencies and vulnerabilities that are not required for every workflow.
+
+Project groups can be used to control which grouped projects
+are considered active during ``west`` operations.
+
+For example, consider the following manifest fragment:
+
+.. code-block:: yaml
+
+  manifest:
+    projects:
+      - name: hal_nordic
+        groups:
+          - nordic
+      - name: hal_stm32
+        groups:
+          - stm32
+      - name: experimental_lib
+        groups:
+          - optional
+
+A workspace targeting Nordic devices can disable the
+``stm32`` and ``optional`` groups before running
+``west update``:
+
+.. code-block:: shell
+
+   west config manifest.group-filter -- "-stm32,-optional"
+
+After configuring the filter, running:
+
+.. code-block:: shell
+
+   west update
+
+This skips projects that belong only to disabled groups.
+
+.. note::
+
+   Project groups only affect projects explicitly assigned
+   to matching groups in the manifest. Projects without
+   matching group definitions remain active regardless of
+   the configured ``manifest.group-filter`` value.
+
+.. note::
+
+   Changing ``manifest.group-filter`` does not automatically
+   remove repositories already cloned into the workspace.
+   It affects whether projects are considered active during
+   subsequent ``west`` operations.
+
+This workflow can help reduce unnecessary downloads and
+simplify workspace management in large multi-project
+environments.
+
 .. _west-project-group-examples:
 
 Project Group Examples


### PR DESCRIPTION
## Summary

Improve the `west` manifest group-filter documentation by adding
practical workflow examples and setup guidance for reducing
unnecessary workspace downloads.

The existing documentation explains project groups and filtering
semantics, but does not clearly demonstrate how to configure
`manifest.group-filter` in a real workflow before running
`west update`.

This PR adds:

* A practical manifest group example
* Step-by-step `west config` and `west update` usage
* Clarifications about active and inactive projects
* Notes explaining that:
  * only explicitly grouped projects are affected
  * already cloned repositories are not automatically removed
* A Getting Started tip referencing
  `west-manifest-groups` before `west update`

## Motivation

Issue #108783 highlighted confusion around how
`manifest.group-filter` affects workspace downloads.

In particular, users may expect group filtering to automatically:
* reduce all workspace downloads
* skip all vendor HAL repositories
* remove repositories already cloned locally

This PR improves discoverability and provides a more
workflow-oriented explanation of manifest group filtering.

## Files Updated

* `doc/develop/west/manifest.rst`
* `doc/develop/getting_started/index.rst`

Fixes #108783