### PR TITLE
modem: cmux: add cmux-no-powersave-handshake property

### DIFF
--- a/doc/services/modem/index.rst
+++ b/doc/services/modem/index.rst
@@ -375,6 +375,14 @@ When data is to be sent or received on any DLCI channel, the CMUX module
 will exit the idle state and wakes the modem up by sending flag characters
 until it receives a flag character from the modem.
 
+For modems that drive sleep and wake from a hardware line outside CMUX
+rather than via the in-band protocol, the ``cmux-no-powersave-handshake``
+property opts out of the handshake on both halves. On entry CMUX skips
+the PSC frame exchange and transitions directly to power save. On exit
+CMUX skips the flag-character exchange and transitions directly to
+connected once the pipe is re-opened. The next outgoing frame
+re-synchronises framing on its own.
+
 Some modems allow UART to be powered down only when the DTR (Data Terminal Ready)
 signal is de-asserted. In this case, a UART device with DTR support can be used
 with the CMUX module to control the DTR signal based on the power state of the UART.

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -2351,6 +2351,7 @@ int modem_cellular_init(const struct device *dev)
 			.transmit_buf_size = ARRAY_SIZE(data->cmux_transmit_buf),
 			.enable_runtime_power_management = config->cmux_enable_runtime_power_save,
 			.close_pipe_on_power_save = config->cmux_close_pipe_on_power_save,
+			.no_powersave_handshake = config->cmux_no_powersave_handshake,
 			.idle_timeout = config->cmux_idle_timeout,
 		};
 

--- a/dts/bindings/modem/zephyr,cellular-modem-device.yaml
+++ b/dts/bindings/modem/zephyr,cellular-modem-device.yaml
@@ -60,6 +60,14 @@ properties:
       When runtime power management is enabled, this closes the UART.
       This requires modem to support waking up the UART using RING signal.
 
+  cmux-no-powersave-handshake:
+    type: boolean
+    description: |
+      Skip the in-band CMUX power-save handshake on both entry to and exit
+      from power save. The framework transitions directly between connected
+      and power-save states. This requires modem to drive sleep and wake via
+      a hardware line outside CMUX rather than via an in-band response.
+
   autostarts:
     type: boolean
     description: |

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -242,6 +242,7 @@ struct modem_cellular_config {
 	bool reset_on_recovery;
 	bool cmux_enable_runtime_power_save;
 	bool cmux_close_pipe_on_power_save;
+	bool cmux_no_powersave_handshake;
 	bool use_default_pdp_context;
 	bool use_default_apn;
 	k_timeout_t cmux_idle_timeout;
@@ -424,6 +425,8 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 			DT_INST_PROP_OR(inst, cmux_enable_runtime_power_save, 0),                  \
 		.cmux_close_pipe_on_power_save =                                                   \
 			DT_INST_PROP_OR(inst, cmux_close_pipe_on_power_save, 0),                   \
+		.cmux_no_powersave_handshake =                                                     \
+			DT_INST_PROP_OR(inst, cmux_no_powersave_handshake, 0),                     \
 		.use_default_pdp_context = DT_INST_PROP_OR(inst, zephyr_use_default_pdp_ctx, 0),   \
 		.use_default_apn = DT_INST_PROP_OR(inst, zephyr_use_default_apn, 0),               \
 		.cmux_idle_timeout = K_MSEC(DT_INST_PROP_OR(inst, cmux_idle_timeout_ms, 0)),       \

--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -73,6 +73,8 @@ struct modem_cmux_config {
 	bool enable_runtime_power_management;
 	/** Close pipe on power save */
 	bool close_pipe_on_power_save;
+	/** Skip the in-band power-save handshake on both entry and exit */
+	bool no_powersave_handshake;
 	/** Idle timeout for power save */
 	k_timeout_t idle_timeout;
 };

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -1638,6 +1638,14 @@ static void modem_cmux_runtime_pm_handler(struct k_work *item)
 	if (is_active(cmux) && expired) {
 		LOG_DBG("Idle timeout, entering power saving mode");
 		set_state(cmux, MODEM_CMUX_STATE_ENTER_POWERSAVE);
+		if (cmux->config.no_powersave_handshake) {
+			set_state(cmux, MODEM_CMUX_STATE_POWERSAVE);
+			LOG_DBG("Entered power saving mode (no handshake)");
+			if (cmux->config.close_pipe_on_power_save) {
+				modem_pipe_close_async(cmux->pipe);
+			}
+			return;
+		}
 		modem_cmux_send_psc(cmux);
 		k_work_reschedule(&cmux->runtime_pm_work, MODEM_CMUX_T3_TIMEOUT);
 		return;
@@ -1690,6 +1698,12 @@ static bool powersave_wait_wakeup(struct modem_cmux *cmux)
 				modem_cmux_raise_event(cmux, MODEM_CMUX_EVENT_DISCONNECTED);
 				return true;
 			}
+		}
+
+		if (cmux->config.no_powersave_handshake) {
+			set_state(cmux, MODEM_CMUX_STATE_CONNECTED);
+			LOG_DBG("Woke up from power saving mode (no handshake)");
+			return false;
 		}
 
 		cmux->t3_timepoint = sys_timepoint_calc(MODEM_CMUX_T3_TIMEOUT);

--- a/tests/subsys/modem/modem_cmux/src/main.c
+++ b/tests/subsys/modem/modem_cmux/src/main.c
@@ -1334,6 +1334,82 @@ ZTEST(modem_cmux, test_modem_cmux_power_save_close_pipe)
 }
 
 /*
+ * Test: no_powersave_handshake.
+ *
+ * When no_powersave_handshake is set, CMUX must skip the in-band handshake
+ * on both halves of power save: enter POWERSAVE directly after the idle
+ * timeout (no PSC frame on the bus, no T3 wait) and exit POWERSAVE directly
+ * once the bus pipe re-opens on transmit (no wakeup pattern, no
+ * STATE_RESYNC wait). The queued data frame is the first thing that appears
+ * on the bus after resume.
+ */
+ZTEST(modem_cmux, test_modem_cmux_power_save_no_powersave_handshake)
+{
+	bool saved_rpm = cmux.config.enable_runtime_power_management;
+	bool saved_cpp = cmux.config.close_pipe_on_power_save;
+	bool saved_nwh = cmux.config.no_powersave_handshake;
+	k_timeout_t saved_timeout = cmux.config.idle_timeout;
+	int ret;
+
+	/* Enable runtime power management with close_pipe + no_powersave_handshake */
+	cmux.config.enable_runtime_power_management = true;
+	cmux.config.close_pipe_on_power_save = true;
+	cmux.config.no_powersave_handshake = true;
+	cmux.config.idle_timeout = K_MSEC(100);
+
+	/* Arm idle timer via empty transmit. The bus mock is intentionally not
+	 * primed for a PSC reply; no_powersave_handshake expects CMUX not to
+	 * send one.
+	 */
+	zassert_ok(modem_pipe_transmit(dlci1_pipe, NULL, 0),
+		   "Empty transmit to arm idle timer should succeed");
+
+	/* Wait for idle timeout and POWERSAVE state */
+	zassert_true(wait_cmux_state(MODEM_CMUX_STATE_POWERSAVE, K_MSEC(300)),
+		     "CMUX should enter POWERSAVE directly without an in-band handshake");
+
+	/* Bus pipe must have been closed */
+	zassert_true(k_event_test(&bus_mock_pipe->event, BIT(1)),
+		     "Bus pipe should be closed when close_pipe_on_power_save is set");
+
+	/* Bus must be empty on entry; no PSC frame should have been sent */
+	ret = modem_backend_mock_get(&bus_mock, buffer1, sizeof(buffer1));
+	zassert_equal(ret, 0,
+		      "Bus must be empty on entry; no PSC frame was expected");
+
+	/* Transmitting data during POWERSAVE re-opens the pipe and resumes */
+	zassert_equal(modem_pipe_transmit(dlci2_pipe, cmux_frame_data_dlci2_ppp_18,
+					  sizeof(cmux_frame_data_dlci2_ppp_18)),
+		      (int)sizeof(cmux_frame_data_dlci2_ppp_18),
+		      "Transmit during POWERSAVE should queue data");
+
+	/* With no_powersave_handshake, CMUX reaches CONNECTED without an in-band exchange */
+	zassert_true(wait_cmux_state(MODEM_CMUX_STATE_CONNECTED, TRANSMISSION_DELAY),
+		     "CMUX should return to CONNECTED without sending a wakeup pattern");
+
+	/* Bus pipe must have been re-opened */
+	zassert_true(k_event_test(&bus_mock_pipe->event, BIT(0)),
+		     "Bus pipe should be re-opened during wakeup");
+
+	k_msleep(TRANSMISSION_DELAY_MS);
+
+	/* The queued data frame should be the only thing on the bus */
+	ret = modem_backend_mock_get(&bus_mock, buffer1, sizeof(buffer1));
+	zassert_equal(ret, (int)sizeof(cmux_frame_dlci2_ppp_18),
+		      "Bus should contain only the data frame; no wakeup pattern was sent");
+	zassert_mem_equal(buffer1, cmux_frame_dlci2_ppp_18,
+			  sizeof(cmux_frame_dlci2_ppp_18),
+			  "Incorrect data frame transmitted after wakeup");
+
+	/* Restore config */
+	cmux.config.enable_runtime_power_management = saved_rpm;
+	cmux.config.close_pipe_on_power_save = saved_cpp;
+	cmux.config.no_powersave_handshake = saved_nwh;
+	cmux.config.idle_timeout = saved_timeout;
+	k_work_cancel_delayable(&cmux.runtime_pm_work);
+}
+
+/*
  * Test: disconnect while in power save with close_pipe_on_power_save.
  *
  * CMUX module should re-open pipe and wakeup the peer before


### PR DESCRIPTION
3GPP TS 27.010 section 5.4.6.3.2 specifies a PSC frame exchange when entering power save and section 5.4.7 specifies a flag-byte exchange when exiting. `modem_cmux` blocks at T3 timeout on either half if the peer does not implement the exchange, which is the case for modems that manage sleep and wake out-of-band (hardware lines or modem-control AT commands).

Add an opt-in DT property cmux-no-powersave-handshake (default off) on the cellular-modem common binding. When set, `modem_cmux_runtime_pm_handler` skips `modem_cmux_send_psc` and the T3 reschedule on entry and transitions directly to `STATE_POWERSAVE`. `powersave_wait_wakeup` skips the wake-pattern transmission and the `STATE_RESYNC` wait on exit and transitions directly to `STATE_CONNECTED`.