### PR TITLE
drivers: gpio: ch32v00x: add output open drain support

### DIFF
--- a/drivers/gpio/wch_gpio_ch32v00x.c
+++ b/drivers/gpio/wch_gpio_ch32v00x.c
@@ -11,9 +11,12 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/irq.h>
 
+#include <errno.h>
 #include <hal_ch32fun.h>
 
 #define DT_DRV_COMPAT wch_gpio
+
+#define GPIO_CH32V00X_CFGLR_MASK 0x0FU
 
 struct gpio_ch32v00x_config {
 	struct gpio_driver_config common;
@@ -34,32 +37,59 @@ static int gpio_ch32v00x_configure(const struct device *dev, gpio_pin_t pin, gpi
 	uint32_t cnf_mode;
 	uint32_t bshr = 0;
 
-	if ((flags & GPIO_OUTPUT) != 0) {
-		cnf_mode = 0x01;
+	if (flags == GPIO_DISCONNECTED) {
+		cnf_mode = GPIO_CFGLR_IN_FLOAT;
+	} else if ((flags & GPIO_OUTPUT) != 0) {
+		if ((flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) != 0) {
+			/* Chip does not support pulls */
+			return -ENOTSUP;
+		}
+		switch (flags & (GPIO_PUSH_PULL | GPIO_OPEN_SOURCE | GPIO_OPEN_DRAIN)) {
+		case GPIO_PUSH_PULL:
+			/* Note that the actual slew rate depends on the SOC */
+			cnf_mode = GPIO_CFGLR_OUT_50Mhz_PP;
+			break;
+		case GPIO_OPEN_DRAIN:
+			cnf_mode = GPIO_CFGLR_OUT_50Mhz_OD;
+			break;
+		case GPIO_OPEN_SOURCE:
+			return -ENOTSUP;
+		default:
+			return -EINVAL;
+		}
 		if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0) {
-			bshr = 1 << pin;
+			bshr = GPIO_BSHR_BS0 << pin;
 		} else if ((flags & GPIO_OUTPUT_INIT_LOW) != 0) {
-			bshr = 1 << (16 + pin);
+			bshr = GPIO_BSHR_BR0 << pin;
 		}
 	} else if ((flags & GPIO_INPUT) != 0) {
-		if ((flags & GPIO_PULL_UP) != 0) {
-			cnf_mode = GPIO_CFGLR_IN_PUPD;
-			bshr = 1 << pin;
-		} else if ((flags & GPIO_PULL_DOWN) != 0) {
-			cnf_mode = GPIO_CFGLR_IN_PUPD;
-			bshr = 1 << (16 + pin);
-		} else {
+		switch (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
+		case 0:
 			cnf_mode = GPIO_CFGLR_IN_FLOAT;
+			break;
+		case GPIO_PULL_UP:
+			cnf_mode = GPIO_CFGLR_IN_PUPD;
+			/* Set the ODR to enable the pull up */
+			bshr = GPIO_BSHR_BS0 << pin;
+			break;
+		case GPIO_PULL_DOWN:
+			cnf_mode = GPIO_CFGLR_IN_PUPD;
+			/* Reset the ODR to enable the pull down */
+			bshr = GPIO_BSHR_BR0 << pin;
+			break;
+		default:
+			return -EINVAL;
 		}
 	} else {
-		cnf_mode = 0x00;
+		return -EINVAL;
 	}
 
 	if (pin < 8) {
-		regs->CFGLR = (regs->CFGLR & ~(0x0F << (4 * pin))) | (cnf_mode << (4 * pin));
+		regs->CFGLR = (regs->CFGLR & ~(GPIO_CH32V00X_CFGLR_MASK << (4 * pin))) |
+			      (cnf_mode << (4 * pin));
 	} else {
-		regs->CFGHR =
-			(regs->CFGHR & ~(0x0F << ((pin - 8) * 4))) | (cnf_mode << ((pin - 8) * 4));
+		regs->CFGHR = (regs->CFGHR & ~(GPIO_CH32V00X_CFGLR_MASK << ((pin - 8) * 4))) |
+			      (cnf_mode << ((pin - 8) * 4));
 	}
 	regs->BSHR = bshr;
 

--- a/tests/drivers/gpio/gpio_basic_api/boards/ch32v006evt.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/ch32v006evt.overlay
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Michael Hope <michaelh@juju.nz>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpiod 3 GPIO_ACTIVE_HIGH>;
+		in-gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;
+	};
+};


### PR DESCRIPTION
Add support for output open drain mode which is used by the tests in `tests/drivers/gpio/gpio_basic_api/`.

While there, switch some magic numbers to the corresponding HAL defines and be stricter on invalid or unsupported configurations.