### PR TITLE
cmake: linker: armlink: fix empty NOINPUT scatter syntax

### DIFF
--- a/cmake/linker/armlink/scatter_script.cmake
+++ b/cmake/linker/armlink/scatter_script.cmake
@@ -356,6 +356,11 @@ function(section_to_string)
     endif()
   endforeach()
 
+  if(empty)
+    set(TEMP "${TEMP} EMPTY 0x0\n  {")
+    set(empty FALSE)
+  endif()
+
   if(section_close OR DEFINED endalign)
     set(section_close)
     set(TEMP "${TEMP}\n  }")

--- a/tests/cmake/armlink_scatter/CMakeLists.txt
+++ b/tests/cmake/armlink_scatter/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(armlink_scatter)
+
+include(${CMAKE_CURRENT_LIST_DIR}/armlink_scatter.cmake)
+
+target_sources(app PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c)

--- a/tests/cmake/armlink_scatter/armlink_scatter.cmake
+++ b/tests/cmake/armlink_scatter/armlink_scatter.cmake
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CMAKE_SCRIPT_MODE_FILE)
+  set(ZEPHYR_BASE ${CMAKE_CURRENT_LIST_DIR}/../../..)
+endif()
+
+set(FORMAT armlink)
+set(ENTRY __start)
+list(APPEND MEMORY_REGIONS "{NAME\;FLASH\;START\;0x0\;SIZE\;64K}")
+list(APPEND SECTIONS "{NAME\;.text\;GROUP\;FLASH}")
+list(APPEND SECTIONS "{NAME\;.empty_noinput\;GROUP\;FLASH\;NOINPUT\;TRUE}")
+
+include(${ZEPHYR_BASE}/cmake/linker/armlink/scatter_script.cmake)
+
+set(expected_empty_noinput "empty_noinput +0 EMPTY 0x0\n  {\n  }")
+string(FIND "${OUT}" "${expected_empty_noinput}" empty_noinput_pos)
+if(empty_noinput_pos EQUAL -1)
+  message(FATAL_ERROR
+    "Empty NOINPUT section did not generate a valid empty scatter block.\n"
+    "Expected to find:\n${expected_empty_noinput}\n"
+    "Generated scatter output:\n${OUT}"
+  )
+endif()

--- a/tests/cmake/armlink_scatter/prj.conf
+++ b/tests/cmake/armlink_scatter/prj.conf
@@ -1,0 +1,1 @@
+# Empty test configuration

--- a/tests/cmake/armlink_scatter/testcase.yaml
+++ b/tests/cmake/armlink_scatter/testcase.yaml
@@ -1,0 +1,7 @@
+common:
+  tags: cmake
+  build_only: true
+  platform_allow: native_sim
+tests:
+  buildsystem.cmake.armlink_scatter.empty_noinput:
+    sysbuild: false


### PR DESCRIPTION
`section_to_string()` in `cmake/linker/armlink/scatter_script.cmake` emits a closing `}` without a matching opening `{` when a section has `NOINPUT=TRUE` and an empty `SETTINGS_INDICIES`, producing invalid scatter syntax that armlink rejects:

```
  bt_l2cap_fixed_chan_area +0
  }
```

Emit the missing ` EMPTY 0x0\n  {` header after the `foreach()` when `empty` is still `TRUE`, mirroring the existing offset / sort branches.

A new `tests/cmake/armlink_scatter/` regression test drives `section_to_string()` with a `NOINPUT=TRUE` section and checks the generated block. Runs under Twister and `cmake -P`.

Fixes #109008