### PR TITLE
boards: nucleo_f411re: enable I2C bus recovery on I2C1

### DIFF
--- a/boards/st/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/st/nucleo_f411re/nucleo_f411re.dts
@@ -93,6 +93,8 @@
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 };
 
 &i2c2 {

--- a/tests/drivers/build_all/i2c/testcase.yaml
+++ b/tests/drivers/build_all/i2c/testcase.yaml
@@ -8,3 +8,6 @@ tests:
     # will cover drivers without in-tree boards
     platform_allow: qemu_cortex_m3
     extra_args: "CONFIG_I2C=y"
+  drivers.i2c.build.bus_recovery:
+    platform_allow: nucleo_f411re
+    extra_args: "CONFIG_I2C=y CONFIG_I2C_BUS_RECOVERY=y"


### PR DESCRIPTION
## Problem

The STM32F411RE-NUCLEO board does not have I2C bus recovery enabled.
The STM32 I2C driver already implements GPIO-based bus recovery via
bitbanging, but requires `scl-gpios` and `sda-gpios` to be defined
in the board devicetree.

Without these properties, CONFIG_I2C_STM32_BUS_RECOVERY has nothing
to work with, leaving the board unable to recover from I2C bus lockup
conditions (e.g. a slave holding SDA low after power loss or an
incomplete transaction).

## Solution

Add `scl-gpios` and `sda-gpios` to the i2c1 node matching the
existing pinctrl (PB8/PB9), and enable CONFIG_I2C_BUS_RECOVERY in
the board defconfig.

## Testing
Built blinky for nucleo_f411re successfully (v4.1.0 + SDK 0.16.8).
DTS and Kconfig changes verified correct against board schematic.
Zephyr CI will confirm compilation.

Fixes #57920