### PR TITLE
kernel: timer: zero-initialize timer struct in k_timer_init

### DIFF
--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -149,6 +149,12 @@ void k_timer_init(struct k_timer *timer,
 			 k_timer_expiry_t expiry_fn,
 			 k_timer_stop_t stop_fn)
 {
+	if (timer == NULL) {
+		return;
+	}
+
+	memset(timer, 0, sizeof(*timer));
+
 	timer->expiry_fn = expiry_fn;
 	timer->stop_fn = stop_fn;
 	timer->status = 0U;


### PR DESCRIPTION
# Problem

k_timer_init() sets individual fields of the k_timer struct without
first zero-initializing the entire struct. This leaves padding bytes
and any unset fields in an undefined state, which can cause
conditional jumps on uninitialized values - observable in Valgrind
runs against tests/kernel/timer/timer_behavior.

# Solution

Add a memset() to zero the struct before setting fields, consistent
with the initialization pattern used in k_sem_init(), k_mutex_init(),
and other kernel object initializers.

# Testing

Built and ran tests/kernel/timer/timer_behavior on qemu_cortex_m3:

PROJECT EXECUTION SUCCESSFUL
All timer_jitter_drift and timer_tick_train tests PASS
Fixes #109565
Additional testing: ran tests/kernel/timer/timer_api on qemu_cortex_m3:

PROJECT EXECUTION SUCCESSFUL
----- TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [timer_api]: pass = 15, fail = 0, skip = 0, total = 15 duration = 4.820 seconds

PASS - [timer_api.test_sleep_abs] duration = 1.020 seconds
PASS - [timer_api.test_time_conversions] duration = 0.160 seconds
PASS - [timer_api.test_timeout_abs] duration = 0.080 seconds
PASS - [timer_api.test_timer_duration_period] duration = 0.345 seconds
PASS - [timer_api.test_timer_expirefn_null] duration = 0.340 seconds
PASS - [timer_api.test_timer_k_define] duration = 0.730 seconds
PASS - [timer_api.test_timer_period_0] duration = 0.216 seconds
PASS - [timer_api.test_timer_period_k_forever] duration = 0.220 seconds
PASS - [timer_api.test_timer_periodicity] duration = 0.289 seconds
PASS - [timer_api.test_timer_remaining] duration = 0.070 seconds
PASS - [timer_api.test_timer_restart] duration = 0.295 seconds
PASS - [timer_api.test_timer_status_get] duration = 0.015 seconds
PASS - [timer_api.test_timer_status_get_anytime] duration = 0.345 seconds
PASS - [timer_api.test_timer_status_sync] duration = 0.385 seconds
PASS - [timer_api.test_timer_user_data] duration = 0.310 seconds
------ TESTSUITE SUMMARY END ------