### PR TITLE
doc: gen_devicetree_rest: generate vendor links with `--turbo-mode`

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -395,7 +395,7 @@ def dump_content(bindings, base_binding, vnd_lookup, type_lookup, driver_sources
 
     setup_bindings_dir(bindings, out_dir)
     if turbo_mode:
-        write_dummy_index(bindings, out_dir)
+        write_dummy_index(bindings, vnd_lookup, out_dir)
     else:
         write_bindings_rst(vnd_lookup, type_lookup, out_dir)
         write_orphans(bindings, base_binding, vnd_lookup, driver_sources, out_dir)
@@ -422,13 +422,21 @@ def setup_bindings_dir(bindings, out_dir):
                 path.unlink()
 
 
-def write_dummy_index(bindings, out_dir):
+def write_dummy_index(bindings, vnd_lookup, out_dir):
     # Write out_dir / bindings.rst, with dummy anchors
 
     # header
     content = '\n'.join((
         '.. _devicetree_binding_index:',
-        '.. _dt_vendor_zephyr:',
+        ''
+    ))
+
+    content += '\n'.join(
+        f'.. _dt_vendor_{vnd}:' for vnd in vnd_lookup.vnd2bindings if isinstance(vnd, str)
+    )
+
+    content += '\n'.join((
+        '',
         '',
         'Dummy bindings index',
         '####################',


### PR DESCRIPTION
Generate `_dt_vendor_{vnd}` links for all vendors when building with `--turbo-mode`. This fixes hundreds of warnings of the form:
```
/home/jordan/code/zephyr/zephyr/doc/_build/src/build/dts/api/bindings/usb/ambiq,usb.rst:20: WARNING: undefined label: 'dt_vendor_ambiq' [ref.ref]
/home/jordan/code/zephyr/zephyr/doc/_build/src/build/dts/api/bindings/usb/atmel,sam-udp.rst:20: WARNING: undefined label: 'dt_vendor_atmel' [ref.ref]
/home/jordan/code/zephyr/zephyr/doc/_build/src/build/dts/api/bindings/usb/atmel,sam-usbc.rst:20: WARNING: undefined label: 'dt_vendor_atmel' [ref.ref]
/home/jordan/code/zephyr/zephyr/doc/_build/src/build/dts/api/bindings/usb/atmel,sam-usbhs.rst:20: WARNING: undefined label: 'dt_vendor_atmel' [ref.ref]
/home/jordan/code/zephyr/zephyr/doc/_build/src/build/dts/api/bindings/usb/atmel,sam0-usb.rst:20: WARNING: undefined label: 'dt_vendor_atmel' [ref.ref]
```
Generated `bindings.rst` has the form:
```
.. _devicetree_binding_index:
.. _dt_vendor_adafruit:
.. _dt_vendor_adh-tech:
.. _dt_vendor_amd:
.. _dt_vendor_aesc:
.. _dt_vendor_xuantie:
...
.. _dt_vendor_xlnx:
.. _dt_vendor_zephyr:
.. _dt_vendor_winsen:

Dummy bindings index
####################
.. dtcompatible:: bflb,bl70x_l-dll
.. dtcompatible:: intel,tco-wdt
```