### PR TITLE
bclkSrcSwap is set while on some SoC's the sad_bit_clock_t struct does not have the member. 

### DIFF
--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -562,8 +562,6 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 	config.frameSync.frameSyncPolarity = kSAI_PolarityActiveLow;
 #if defined(FSL_FEATURE_SAI_HAS_BIT_CLOCK_SWAP) && FSL_FEATURE_SAI_HAS_BIT_CLOCK_SWAP
 	config.bitClock.bclkSrcSwap = true;
-#else
-	config.bitClock.bclkSrcSwap = false;
 #endif
 	/* format */
 	switch (i2s_cfg->format & I2S_FMT_DATA_FORMAT_MASK) {


### PR DESCRIPTION
The Zephyr NXP SAI driver (``i2s_mcux_sai.c``) fails to compile for MCX E-series devices (e.g., NXP FRDM-MCXE247) and other NXP SoCs that do not support the "Bit Clock Swap" hardware feature.

Affected Hardware
*****************

*   NXP MCX E-Series (E24x)
*   Any NXP SoC where ``FSL_FEATURE_SAI_HAS_BIT_CLOCK_SWAP`` is not defined or is 0.

Problem Description
*******************

In ``zephyr/drivers/i2s/i2s_mcux_sai.c``, the driver attempts to unconditionally set the ``bclkSrcSwap`` member of the ``sai_bit_clock_t`` structure when the hardware feature is not present. The driver was unconditionally trying to clear config.bitClock.bclkSrcSwap, but this member is conditionally compiled out of the HAL structure (sai_bit_clock_t) when the hardware feature is absent, leading to a compiler error.

Signed-off-by: Jan Willem Smaal <usenet@gispen.org>

---
Assisted-by: Gemini CLI: v0.43.0

AI Disclosure:
I used an AI assistant (Gemini) to help format the technical description and structure the Git commit message. The technical fix itself was identified through manual debugging of the NXP HAL header files and verified against the hardware documentation.