### PR TITLE
boards: seeed: add composite fuel gauge to all reTerminal boards

### DIFF
--- a/boards/seeed/reterminal_e1001/Kconfig.defconfig
+++ b/boards/seeed/reterminal_e1001/Kconfig.defconfig
@@ -14,4 +14,16 @@ endchoice
 
 endif # LVGL
 
+if FUEL_GAUGE
+
+# Composite fuel gauge gets battery voltage from ADC-based voltage-divider sensor
+
+config ADC
+	default y
+
+config SENSOR
+	default y
+
+endif # FUEL_GAUGE
+
 endif # BOARD_RETERMINAL_E1001_ESP32S3_PROCPU

--- a/boards/seeed/reterminal_e1001/reterminal_e1001_procpu.dts
+++ b/boards/seeed/reterminal_e1001/reterminal_e1001_procpu.dts
@@ -7,6 +7,7 @@
 
 #include <espressif/esp32s3/esp32s3_r8.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/battery/battery.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <espressif/partitions_0x0_amp_32M.dtsi>
@@ -28,6 +29,7 @@
 	};
 
 	aliases {
+		fuel-gauge0 = &fuel_gauge;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 		led0 = &green_led0;
@@ -50,6 +52,14 @@
 		power-gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
 		power-on-sample-delay-us = <10000>;
 		skip-calibration;
+	};
+
+	fuel_gauge: fuel_gauge {
+		compatible = "zephyr,fuel-gauge-composite";
+		source-primary = <&vbatt>;
+		device-chemistry = "lithium-ion-polymer";
+		ocv-capacity-table-0 = <BATTERY_OCV_CURVE_LITHIUM_ION_POLYMER_DEFAULT>;
+		charge-full-design-microamp-hours = <2000000>;
 	};
 
 	buttons {

--- a/boards/seeed/reterminal_e1002/Kconfig.defconfig
+++ b/boards/seeed/reterminal_e1002/Kconfig.defconfig
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_RETERMINAL_E1002_ESP32S3_PROCPU
+
+if FUEL_GAUGE
+
+# Composite fuel gauge gets battery voltage from ADC-based voltage-divider sensor
+
+config ADC
+	default y
+
+config SENSOR
+	default y
+
+endif # FUEL_GAUGE
+
+endif # BOARD_RETERMINAL_E1002_ESP32S3_PROCPU

--- a/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.dts
+++ b/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.dts
@@ -9,6 +9,7 @@
 #include <freq.h>
 #include <espressif/esp32s3/esp32s3_r8.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/battery/battery.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/display/panel.h>
@@ -33,6 +34,7 @@
 	aliases {
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
+		fuel-gauge0 = &fuel_gauge;
 		led0 = &green_led0;
 		pwm-led0 = &buzzer0;
 		rtc = &pfc8563_rtc;
@@ -53,6 +55,14 @@
 		power-gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
 		power-on-sample-delay-us = <10000>;
 		skip-calibration;
+	};
+
+	fuel_gauge: fuel_gauge {
+		compatible = "zephyr,fuel-gauge-composite";
+		source-primary = <&vbatt>;
+		device-chemistry = "lithium-ion-polymer";
+		ocv-capacity-table-0 = <BATTERY_OCV_CURVE_LITHIUM_ION_POLYMER_DEFAULT>;
+		charge-full-design-microamp-hours = <2000000>;
 	};
 
 	buttons {

--- a/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.dts
+++ b/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.dts
@@ -121,7 +121,7 @@
 					  ARGB8888(196, 50,  58,  255) /* 0x03 = Red */
 					  PANEL_COLOR_PALETTE_NULL /* 0x04 = Unused / reserved */
 					  ARGB8888(40,  85,  180, 255) /* 0x05 = Blue */
-					  ARGB8888(60,  140, 75,  255) /* 0x06 = Green */ >;
+					  ARGB8888(60,  140, 75,  255) /* 0x06 = Green */>;
 			};
 		};
 	};

--- a/boards/seeed/reterminal_e1003/Kconfig.defconfig
+++ b/boards/seeed/reterminal_e1003/Kconfig.defconfig
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_RETERMINAL_E1003_ESP32S3_PROCPU
+
+if FUEL_GAUGE
+
+# Composite fuel gauge gets battery voltage from ADC-based voltage-divider sensor
+
+config ADC
+	default y
+
+config SENSOR
+	default y
+
+endif # FUEL_GAUGE
+
+endif # BOARD_RETERMINAL_E1003_ESP32S3_PROCPU

--- a/boards/seeed/reterminal_e1003/reterminal_e1003_procpu.dts
+++ b/boards/seeed/reterminal_e1003/reterminal_e1003_procpu.dts
@@ -7,6 +7,7 @@
 
 #include <espressif/esp32s3/esp32s3_r8.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/battery/battery.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
@@ -31,6 +32,7 @@
 
 	aliases {
 		display0 = &it8951_epd;
+		fuel-gauge0 = &fuel_gauge;
 		i2c-0 = &i2c0;
 		led0 = &green_led0;
 		pwm-led0 = &buzzer0;
@@ -53,6 +55,14 @@
 		power-gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
 		power-on-sample-delay-us = <10000>;
 		skip-calibration;
+	};
+
+	fuel_gauge: fuel_gauge {
+		compatible = "zephyr,fuel-gauge-composite";
+		source-primary = <&vbatt>;
+		device-chemistry = "lithium-ion-polymer";
+		ocv-capacity-table-0 = <BATTERY_OCV_CURVE_LITHIUM_ION_POLYMER_DEFAULT>;
+		charge-full-design-microamp-hours = <3000000>;
 	};
 
 	buttons {


### PR DESCRIPTION
The reTerminals' LiPo battery can be described in a `zephyr,composite-fuel-gauge` in Devicetree so that estimated
battery state of charge can be obtained using the fuel gauge API.