### PR TITLE
drivers: led: implement off for leds_group_multicolor

### DIFF
--- a/drivers/led/leds_group_multicolor.c
+++ b/drivers/led/leds_group_multicolor.c
@@ -23,6 +23,26 @@ struct leds_group_multicolor_config {
 	const struct led_dt_spec *led;
 };
 
+static int leds_group_multicolor_off(const struct device *dev, uint32_t led)
+{
+	const struct leds_group_multicolor_config *config = dev->config;
+
+	if (led != 0) {
+		return -EINVAL;
+	}
+
+	for (uint8_t i = 0; i < config->num_leds; i++) {
+		int err;
+
+		err = led_off_dt(&config->led[i]);
+		if (err) {
+			return err;
+		}
+	}
+
+	return 0;
+}
+
 static int leds_group_multicolor_set_color(const struct device *dev, uint32_t led,
 					   uint8_t num_colors, const uint8_t *color)
 {
@@ -64,6 +84,7 @@ static int leds_group_multicolor_init(const struct device *dev)
 }
 
 static DEVICE_API(led, leds_group_multicolor_api) = {
+	.off = leds_group_multicolor_off,
 	.set_color = leds_group_multicolor_set_color,
 };
 


### PR DESCRIPTION
Hey, this is my first Zephyr PR :)

The current `leds_group_multicolor` driver only implements the `set_color` API. It is possible to turn instances off by calling `set_color` with an all-zero array, but this is more cumbersome than it should be.

This commit implements `off` for `leds_group_multicolor` by calling `led_off_dt` for all monochromatic LEDs that the multicolor LED consists of. This is safe since all LEDs have `off` implemented either directly or indirectly through `set_brightness`.

The `led != 0` check and spacing are kept consistent with the rest of the driver.