### PR TITLE
dirvers: firmware: scmi: remove system message definition into system.h

### DIFF
--- a/drivers/firmware/scmi/reboot.c
+++ b/drivers/firmware/scmi/reboot.c
@@ -15,24 +15,11 @@ static int scmi_reboot_handler(int type)
 {
 	struct scmi_system_power_state_config cfg;
 	int ret;
-	uint32_t mesg_attr;
 
 	cfg.flags = SCMI_SYSTEM_POWER_FLAG_FORCEFUL;
 
 	switch (type) {
 	case SYS_REBOOT_WARM:
-		ret = scmi_system_protocol_message_attributes(SCMI_SYSTEM_MSG_POWER_STATE_SET,
-							      &mesg_attr);
-		if (ret < 0) {
-			LOG_ERR("Failed to query SCMI system capabilities: %d", ret);
-			return ret;
-		}
-
-		if (!(mesg_attr & SCMI_SYSTEM_MSG_ATTR_WARM_RESET)) {
-			LOG_WRN("Warm reset not supported by platform");
-			return -ENOTSUP;
-		}
-
 		cfg.system_state = SCMI_SYSTEM_POWER_STATE_WARM_RESET;
 		break;
 
@@ -47,7 +34,7 @@ static int scmi_reboot_handler(int type)
 
 	ret = scmi_system_power_state_set(&cfg);
 	if (ret < 0) {
-		LOG_ERR("System reboot failed with error: %d", ret);
+		LOG_ERR("Failed to request power state 0x%x: %d", cfg.system_state, ret);
 	}
 
 	return ret;


### PR DESCRIPTION
remove system message definition into system.h to fix build issue as scmi reboot interface also use it
Fixes #109736