### PR TITLE
drivers: can: mcux: flexcan: Fix off-by-one error in MB IRQ handling

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1149,7 +1149,7 @@ static void mcux_flexcan_isr(const struct device *dev)
 	CAN_Type *base = get_base(dev);
 
 	FLEXCAN_BusoffErrorHandleIRQ(base, &data->handle);
-	FLEXCAN_MbHandleIRQ(base, &data->handle, 0U, config->number_of_mb);
+	FLEXCAN_MbHandleIRQ(base, &data->handle, 0U, config->number_of_mb - 1U);
 }
 
 static int mcux_flexcan_init(const struct device *dev)


### PR DESCRIPTION
The FLEXCAN_MbHandleIRQ function expects the last mailbox index as a parameter, not the total number of mailboxes. Mailbox indices are zero-based (0 to N-1), so passing the mailbox count directly causes an off-by-one error that could lead to accessing an invalid mailbox index during interrupt handling.

This fix changes the fourth parameter from `config->number_of_mb` to `config->number_of_mb - 1U`, ensuring the correct last mailbox index is passed to the IRQ handler.

The issue could manifest as incorrect interrupt handling or potential memory access violations when processing CAN mailbox interrupts, particularly when all available mailboxes are configured in classical CAN.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/109759