### PR TITLE
drivers: video: sw_generator: Fix 64-bit build error

### DIFF
--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -13,6 +13,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <inttypes.h>
 
 #include "video_ctrls.h"
 #include "video_device.h"
@@ -334,7 +335,8 @@ static int video_sw_generator_fill_compressed(struct video_buffer *vbuf, bool hf
 
 	/* Check if buffer is large enough */
 	if (vbuf->size < frame_size) {
-		LOG_ERR("Buffer too small (need %u, have %zu)", frame_size, vbuf->size);
+		LOG_ERR("Buffer too small (need %" PRIu32 ", have %" PRIu32 ")", frame_size,
+			vbuf->size);
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
Fix a build failure on 64-bit platforms like Cortex-A55. The compiler reports a format string error because the variable types and log specifiers do not match up perfectly.

Fixes : https://github.com/zephyrproject-rtos/zephyr/issues/109740