### PR TITLE
logging: frontend: stmesp: Fixes and improvements to increase the stability of the Coresight STM logging on nrf54h20

### DIFF
--- a/drivers/debug/debug_nrf_etr.c
+++ b/drivers/debug/debug_nrf_etr.c
@@ -75,10 +75,9 @@ LOG_MODULE_REGISTER(cs_etr_tbm);
 	} while (0)
 
 static const uint32_t wsize_mask = DT_REG_SIZE(ETR_BUFFER_NODE) / sizeof(int) - 1;
-static const uint32_t wsize_inc = DT_REG_SIZE(ETR_BUFFER_NODE) / sizeof(int) - 1;
+static atomic_t wsize_inc;
 
 static int oosync_cnt;
-static volatile bool tbm_full;
 static volatile uint32_t base_wr_idx;
 static uint32_t etr_rd_idx;
 /* Counts number of new messages completed in the current formatter frame decoding. */
@@ -550,13 +549,14 @@ static uint32_t get_wr_idx(void)
 {
 	uint32_t cnt = nrfx_tbm_count_get();
 
-	if (tbm_full && (cnt < wsize_mask)) {
+	if (wsize_inc && (cnt < wsize_mask)) {
 		/* TBM full event is generated when max value is reached and not when
 		 * overflow occurs. We cannot increment base_wr_idx just after the
 		 * event but only when counter actually wraps.
 		 */
-		base_wr_idx += wsize_inc;
-		tbm_full = false;
+		uint32_t inc = atomic_set(&wsize_inc, 0);
+
+		base_wr_idx += inc;
 	}
 
 	return cnt + base_wr_idx;
@@ -858,7 +858,7 @@ static void tbm_event_handler(nrf_tbm_event_t event)
 	ARG_UNUSED(event);
 
 	if (event == NRF_TBM_EVENT_FULL) {
-		tbm_full = true;
+		wsize_inc += DT_REG_SIZE(ETR_BUFFER_NODE) / sizeof(int);
 	}
 
 #ifdef CONFIG_DEBUG_NRF_ETR_SHELL
@@ -884,7 +884,9 @@ int etr_process_init(void)
 		use_blocking = (err != 0);
 		k_sem_init(&uart_sem, 1, 1);
 	}
-	static const nrfx_tbm_config_t config = {.size = wsize_mask};
+	static const nrfx_tbm_config_t config = {
+		.size = DT_REG_SIZE(ETR_BUFFER_NODE) / sizeof(int)
+	};
 
 	nrfx_tbm_init(&config, tbm_event_handler);
 	IRQ_CONNECT(DT_IRQN(DT_NODELABEL(tbm)), DT_IRQ(DT_NODELABEL(tbm), priority),

--- a/drivers/debug/debug_nrf_etr.c
+++ b/drivers/debug/debug_nrf_etr.c
@@ -399,7 +399,7 @@ static void on_resync(void)
 	}
 }
 
-static void decoder_cb_debug(enum mipi_stp_decoder_ctrl_type type,
+static bool decoder_cb_debug(enum mipi_stp_decoder_ctrl_type type,
 			     union mipi_stp_decoder_data data,
 			     uint64_t *ts, bool marked)
 {
@@ -457,18 +457,21 @@ static void decoder_cb_debug(enum mipi_stp_decoder_ctrl_type type,
 		DBG("OTHER\n");
 		break;
 	}
+
+	return true;
 }
 
-static void decoder_cb(enum mipi_stp_decoder_ctrl_type type,
+static bool decoder_cb(enum mipi_stp_decoder_ctrl_type type,
 		       union mipi_stp_decoder_data data, uint64_t *ts,
 		       bool marked)
 {
 	int rv = 0;
+	bool valid = true;
 
-	decoder_cb_debug(type, data, ts, marked);
+	(void)decoder_cb_debug(type, data, ts, marked);
 
 	if (!IS_ENABLED(CONFIG_DEBUG_NRF_ETR_DECODE)) {
-		return;
+		return true;
 	}
 
 	switch (type) {
@@ -544,6 +547,7 @@ static void decoder_cb(enum mipi_stp_decoder_ctrl_type type,
 
 	/* Only -ENOMEM is accepted failure. */
 	__ASSERT_NO_MSG((rv >= 0) || (rv == -ENOMEM));
+	return valid;
 }
 
 static void deformatter_cb(uint32_t id, const uint8_t *data, size_t len)

--- a/drivers/debug/debug_nrf_etr.c
+++ b/drivers/debug/debug_nrf_etr.c
@@ -77,7 +77,6 @@ LOG_MODULE_REGISTER(cs_etr_tbm);
 static const uint32_t wsize_mask = DT_REG_SIZE(ETR_BUFFER_NODE) / sizeof(int) - 1;
 static const uint32_t wsize_inc = DT_REG_SIZE(ETR_BUFFER_NODE) / sizeof(int) - 1;
 
-static bool in_sync;
 static int oosync_cnt;
 static volatile bool tbm_full;
 static volatile uint32_t base_wr_idx;
@@ -384,18 +383,6 @@ static void sync_loss(void)
 		mipi_stp_decoder_sync_loss();
 		log_frontend_stmesp_demux_reset();
 		oosync_cnt++;
-		in_sync = false;
-	}
-}
-
-/** @brief Indicate that STPv2 decoder is synchronized.
- *
- * That occurs when ASYNC opcode is found.
- */
-static void on_resync(void)
-{
-	if (IS_ENABLED(CONFIG_DEBUG_NRF_ETR_DECODE)) {
-		in_sync = true;
 	}
 }
 
@@ -476,7 +463,6 @@ static bool decoder_cb(enum mipi_stp_decoder_ctrl_type type,
 
 	switch (type) {
 	case STP_DECODER_ASYNC:
-		on_resync();
 		break;
 	case STP_DECODER_MAJOR:
 		log_frontend_stmesp_demux_major(data.id);
@@ -704,9 +690,9 @@ static bool process(bool dry_run)
 				 * then assume overwrite and sync loss.
 				 */
 				sync_loss();
+			} else {
+				process_frame((uint8_t *)frame_buf, pending);
 			}
-
-			process_frame((uint8_t *)frame_buf, pending);
 			if (IS_ENABLED(CONFIG_DEBUG_NRF_ETR_DECODE)) {
 				if (new_msg_cnt && dry_run) {
 					return true;

--- a/drivers/debug/debug_nrf_etr.c
+++ b/drivers/debug/debug_nrf_etr.c
@@ -276,7 +276,7 @@ static uint8_t log_output_buf[CORESIGHT_TRACE_FRAME_SIZE] __aligned(sizeof(uint3
 LOG_OUTPUT_DEFINE(log_output, log_output_func, log_output_buf, sizeof(log_output_buf));
 
 /** @brief Process a log message. */
-static void log_message_process(struct log_frontend_stmesp_demux_log *packet)
+static int log_message_process(struct log_frontend_stmesp_demux_log *packet)
 {
 	static const uint32_t flags = LOG_OUTPUT_FLAG_COLORS | LOG_OUTPUT_FLAG_LEVEL |
 			 LOG_OUTPUT_FLAG_TIMESTAMP | LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
@@ -287,15 +287,25 @@ static void log_message_process(struct log_frontend_stmesp_demux_log *packet)
 	const uint8_t *package = packet->data;
 	const char *sname = &packet->data[plen];
 	size_t sname_len = strlen(sname) + 1;
-	uint16_t dlen = packet->hdr.total_len - (plen + sname_len);
+	int16_t dlen = packet->hdr.total_len - (plen + sname_len);
 	uint8_t *data = dlen ? &packet->data[plen + sname_len] : NULL;
+	struct cbprintf_package_desc *desc = (struct cbprintf_package_desc *)package;
+
+	/* When ETR is overloaded glitches may appear, detect faulty packets and skip them. */
+	if ((level > LOG_LEVEL_DBG) ||
+	    ((dlen != 0) && (packet->hdr.has_data == 0)) ||
+	    ((dlen == 0) && (packet->hdr.has_data == 1)) ||
+	    (desc->ro_str_cnt != 0) || (desc->rw_str_cnt != 0)) {
+		return -EBADMSG;
+	}
 
 	log_output_process(&log_output, ts, dname, sname, NULL,
 			   0, level, package, data, dlen, flags);
+	return 0;
 }
 
 /** @brief Process a trace point message. */
-static void trace_point_process(struct log_frontend_stmesp_demux_trace_point *packet)
+static int trace_point_process(struct log_frontend_stmesp_demux_trace_point *packet)
 {
 	static const uint32_t flags = LOG_OUTPUT_FLAG_COLORS | LOG_OUTPUT_FLAG_LEVEL |
 			 LOG_OUTPUT_FLAG_TIMESTAMP | LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
@@ -319,9 +329,14 @@ static void trace_point_process(struct log_frontend_stmesp_demux_trace_point *pa
 		const char *source =
 			log_frontend_stmesp_demux_sname_get(packet->major, packet->source_id);
 
+		/* When ETR is overloaded glitches may appear, detect and skip faulty packets. */
+		if (level > LOG_LEVEL_DBG) {
+			return -EBADMSG;
+		}
+
 		log_output_process(&log_output, packet->timestamp, dname, source, NULL, 0, level,
 				   (const uint8_t *)tp_log, NULL, 0, flags);
-		return;
+		return 0;
 	} else if (packet->has_data) {
 		uint32_t id = (uint32_t)packet->id - CONFIG_LOG_FRONTEND_STMESP_TP_CHAN_BASE;
 		static const union cbprintf_package_hdr desc = {
@@ -330,7 +345,7 @@ static void trace_point_process(struct log_frontend_stmesp_demux_trace_point *pa
 
 		log_output_process(&log_output, packet->timestamp, dname, sname, NULL, 0, 1,
 				   (const uint8_t *)tp_d32_p, NULL, 0, flags);
-		return;
+		return 0;
 	}
 
 	static const union cbprintf_package_hdr desc = {.desc = {.len = 3 /* hdr + fmt + id */}};
@@ -338,10 +353,11 @@ static void trace_point_process(struct log_frontend_stmesp_demux_trace_point *pa
 
 	log_output_process(&log_output, packet->timestamp, dname, sname, NULL, 0,
 			   1, (const uint8_t *)tp_p, NULL, 0, flags);
+	return 0;
 }
 
 /** @brief Process a HW event message. */
-static void hw_event_process(struct log_frontend_stmesp_demux_hw_event *packet)
+static int hw_event_process(struct log_frontend_stmesp_demux_hw_event *packet)
 {
 	static const uint32_t flags = LOG_OUTPUT_FLAG_TIMESTAMP | LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 	static const char *tp = "%s";
@@ -353,21 +369,26 @@ static void hw_event_process(struct log_frontend_stmesp_demux_hw_event *packet)
 
 	log_output_process(&log_output, packet->timestamp, dname, sname, NULL, 0,
 			   1, (const uint8_t *)tp_p, NULL, 0, flags);
+	return 0;
 }
 
-static void message_process(union log_frontend_stmesp_demux_packet packet)
+static int message_process(union log_frontend_stmesp_demux_packet packet)
 {
+	int rv;
+
 	switch (packet.generic_packet->type) {
 	case LOG_FRONTEND_STMESP_DEMUX_TYPE_TRACE_POINT:
-		trace_point_process(packet.trace_point);
+		rv = trace_point_process(packet.trace_point);
 		break;
 	case LOG_FRONTEND_STMESP_DEMUX_TYPE_HW_EVENT:
-		hw_event_process(packet.hw_event);
+		rv = hw_event_process(packet.hw_event);
 		break;
 	default:
-		log_message_process(packet.log);
+		rv = log_message_process(packet.log);
 		break;
 	}
+
+	return rv;
 }
 
 /** @brief Function called when potential STPv2 stream data drop is detected.
@@ -472,7 +493,9 @@ static bool decoder_cb(enum mipi_stp_decoder_ctrl_type type,
 	case STP_DATA8:
 		if (marked) {
 			rv = log_frontend_stmesp_demux_packet_start((uint32_t *)&data.data, ts);
-			new_msg_cnt += rv;
+			if (rv > 0) {
+				new_msg_cnt += rv;
+			}
 		} else {
 			log_frontend_stmesp_demux_data((char *)&data.data, 1);
 		}
@@ -481,7 +504,9 @@ static bool decoder_cb(enum mipi_stp_decoder_ctrl_type type,
 		if (marked) {
 			if (ts) {
 				rv = log_frontend_stmesp_demux_log0((uint16_t)data.data, ts);
-				new_msg_cnt += rv;
+				if (rv > 0) {
+					new_msg_cnt += rv;
+				}
 			} else {
 				log_frontend_stmesp_demux_source_id((uint16_t)data.data);
 			}
@@ -492,16 +517,15 @@ static bool decoder_cb(enum mipi_stp_decoder_ctrl_type type,
 	case STP_DATA32:
 		if (marked) {
 			rv = log_frontend_stmesp_demux_packet_start((uint32_t *)&data.data, ts);
-			new_msg_cnt += rv;
+			if (rv > 0) {
+				new_msg_cnt += rv;
+			}
 		} else {
 			log_frontend_stmesp_demux_data((char *)&data.data, 4);
 			if (ts) {
 				log_frontend_stmesp_demux_timestamp(*ts);
 			}
 		}
-		break;
-	case STP_DATA64:
-		log_frontend_stmesp_demux_data((char *)&data.data, 8);
 		break;
 	case STP_DECODER_FLAG:
 		if (ts) {
@@ -522,16 +546,25 @@ static bool decoder_cb(enum mipi_stp_decoder_ctrl_type type,
 		}
 		break;
 	}
-	case STP_DECODER_MERROR: {
-		sync_loss();
+	case STP_DECODER_NULL:
 		break;
-	}
+	case STP_DECODER_VERSION:
+		break;
 	default:
+		/* Any unexpected data is considered as sync loss. */
+		valid = false;
 		break;
 	}
 
-	/* Only -ENOMEM is accepted failure. */
-	__ASSERT_NO_MSG((rv >= 0) || (rv == -ENOMEM));
+	/* Only -ENOMEM or -EBADMSG are accepted failure. */
+	__ASSERT((rv >= 0) || (rv == -ENOMEM) || (rv == -EBADMSG), "rv:%d", rv);
+	/* -EBADMSG indicates corruption. */
+	if (rv == -EBADMSG) {
+		valid = false;
+	}
+	if (!valid) {
+		sync_loss();
+	}
 	return valid;
 }
 
@@ -590,10 +623,11 @@ static void process_frame(uint8_t *buf, uint32_t pending)
 	DBG("\n");
 }
 
-static bool process_messages(void)
+static int process_messages(void)
 {
 	static union log_frontend_stmesp_demux_packet curr_msg;
-	bool processed = false;
+	int cnt = 0;
+	int rv;
 
 	/* Process any new messages. curr_msg remains the same if panic
 	 * interrupts currently ongoing processing (curr_msg is not NULL then).
@@ -608,16 +642,19 @@ static bool process_messages(void)
 			if (IS_ENABLED(CONFIG_DEBUG_NRF_ETR_BACKEND_UART)) {
 				(void)pm_device_runtime_get(uart_dev);
 			}
-			message_process(curr_msg);
-			processed = true;
+			rv = message_process(curr_msg);
 			log_frontend_stmesp_demux_free(curr_msg);
 			curr_msg.generic_packet = NULL;
+			if (rv < 0) {
+				return rv;
+			}
+			cnt++;
 		} else {
 			break;
 		}
 	}
 	new_msg_cnt = 0;
-	return processed;
+	return cnt;
 }
 
 /** @brief Dump frame over UART (using polling or async API). */
@@ -652,10 +689,11 @@ static bool process(bool dry_run)
 	static uint32_t sync_cnt = CONFIG_DEBUG_NRF_ETR_SYNC_PERIOD;
 	uint32_t pending;
 	bool processed = false;
+	int rv;
 
 	/* Attempt to process any pending message that was found during the dry run. */
 	if (!dry_run && IS_ENABLED(CONFIG_DEBUG_NRF_ETR_DECODE)) {
-		processed = process_messages();
+		processed = process_messages() > 0;
 	}
 
 	/* If function is called in panic mode then it may interrupt ongoing
@@ -697,7 +735,12 @@ static bool process(bool dry_run)
 				if (new_msg_cnt && dry_run) {
 					return true;
 				}
-				processed |= process_messages();
+				rv = process_messages();
+				if (rv < 0) {
+					sync_loss();
+				} else if (rv > 0) {
+					processed = true;
+				}
 			}
 		} else {
 			processed = true;

--- a/include/zephyr/debug/mipi_stp_decoder.h
+++ b/include/zephyr/debug/mipi_stp_decoder.h
@@ -91,8 +91,9 @@ union mipi_stp_decoder_data {
  * @param data		Data. Data associated with a given @p type.
  * @param ts		Timestamp. Present if not NULL.
  * @param marked	Set to true if opcode was marked.
+ * @return true if the data is valid, false is data indicates synchronization loss.
  */
-typedef void (*mipi_stp_decoder_cb)(enum mipi_stp_decoder_ctrl_type type,
+typedef bool (*mipi_stp_decoder_cb)(enum mipi_stp_decoder_ctrl_type type,
 				    union mipi_stp_decoder_data data,
 				    uint64_t *ts, bool marked);
 

--- a/include/zephyr/logging/log_frontend_stmesp_demux.h
+++ b/include/zephyr/logging/log_frontend_stmesp_demux.h
@@ -31,10 +31,13 @@ extern "C" {
 #define LOG_FRONTEND_STMESP_DEMUX_LEVEL_BITS 3
 
 /** @brief Bits used to store total length. */
-#define LOG_FRONTEND_STMESP_DEMUX_TLENGTH_BITS 16
+#define LOG_FRONTEND_STMESP_DEMUX_TLENGTH_BITS 15
 
 /** @brief Bits used to store package length. */
 #define LOG_FRONTEND_STMESP_DEMUX_PLENGTH_BITS 10
+
+/** @brief Bits used to indicate if hexdump is present. */
+#define LOG_FRONTEND_STMESP_DEMUX_HAS_DATA_BITS 1
 
 /** @brief Maximum number of supported majors. */
 #define LOG_FRONTEND_STMESP_DEMUX_MAJOR_MAX BIT(LOG_FRONTEND_STMESP_DEMUX_MAJOR_BITS)
@@ -59,8 +62,11 @@ struct log_frontend_stmesp_demux_log_header {
 	/** Total length excluding this header. */
 	uint32_t total_len : LOG_FRONTEND_STMESP_DEMUX_TLENGTH_BITS;
 
-	/** Hexdump data length. */
+	/** Package data length. */
 	uint32_t package_len : LOG_FRONTEND_STMESP_DEMUX_PLENGTH_BITS;
+
+	/** Hexdump data present */
+	uint32_t has_data: LOG_FRONTEND_STMESP_DEMUX_HAS_DATA_BITS;
 };
 
 /** @brief Union for writing raw data to the logging message header. */

--- a/subsys/debug/mipi_stp_decoder.c
+++ b/subsys/debug/mipi_stp_decoder.c
@@ -79,7 +79,7 @@ enum stp_id {
 
 #define STP_VAR_DATA 0xff
 
-typedef void (*stp_cb)(uint64_t data, uint64_t ts);
+typedef bool (*stp_cb)(uint64_t data, uint64_t ts);
 
 struct stp_item {
 	const char *name;
@@ -107,157 +107,157 @@ static size_t ncnt;
 static size_t noff;
 static uint16_t curr_ch;
 
-static void data4_cb(uint64_t data, uint64_t ts)
+static bool data4_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA4, d, NULL, false);
+	return cfg.cb(STP_DATA4, d, NULL, false);
 }
 
-static void data8_cb(uint64_t data, uint64_t ts)
+static bool data8_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA8, d, NULL, false);
+	return cfg.cb(STP_DATA8, d, NULL, false);
 }
 
-static void data16_cb(uint64_t data, uint64_t ts)
+static bool data16_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA16, d, NULL, false);
+	return cfg.cb(STP_DATA16, d, NULL, false);
 }
 
-static void data32_cb(uint64_t data, uint64_t ts)
+static bool data32_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA32, d, NULL, false);
+	return cfg.cb(STP_DATA32, d, NULL, false);
 }
 
-static void data64_cb(uint64_t data, uint64_t ts)
+static bool data64_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA64, d, NULL, false);
+	return cfg.cb(STP_DATA64, d, NULL, false);
 }
 
-static void data4_m_cb(uint64_t data, uint64_t ts)
+static bool data4_m_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA4, d, NULL, true);
+	return cfg.cb(STP_DATA4, d, NULL, true);
 }
 
-static void data8_m_cb(uint64_t data, uint64_t ts)
+static bool data8_m_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA8, d, NULL, true);
+	return cfg.cb(STP_DATA8, d, NULL, true);
 }
 
-static void data16_m_cb(uint64_t data, uint64_t ts)
+static bool data16_m_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA16, d, NULL, true);
+	return cfg.cb(STP_DATA16, d, NULL, true);
 }
 
-static void data32_m_cb(uint64_t data, uint64_t ts)
+static bool data32_m_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA32, d, NULL, true);
+	return cfg.cb(STP_DATA32, d, NULL, true);
 }
 
-static void data64_m_cb(uint64_t data, uint64_t ts)
+static bool data64_m_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA64, d, NULL, true);
+	return cfg.cb(STP_DATA64, d, NULL, true);
 }
 
-static void data4_ts_cb(uint64_t data, uint64_t ts)
+static bool data4_ts_cb(uint64_t data, uint64_t ts)
 {
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA4, d, &ts, false);
+	return cfg.cb(STP_DATA4, d, &ts, false);
 }
 
-static void data8_ts_cb(uint64_t data, uint64_t ts)
+static bool data8_ts_cb(uint64_t data, uint64_t ts)
 {
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA8, d, &ts, false);
+	return cfg.cb(STP_DATA8, d, &ts, false);
 }
 
-static void data16_ts_cb(uint64_t data, uint64_t ts)
+static bool data16_ts_cb(uint64_t data, uint64_t ts)
 {
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA16, d, &ts, false);
+	return cfg.cb(STP_DATA16, d, &ts, false);
 }
 
-static void data32_ts_cb(uint64_t data, uint64_t ts)
+static bool data32_ts_cb(uint64_t data, uint64_t ts)
 {
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA32, d, &ts, false);
+	return cfg.cb(STP_DATA32, d, &ts, false);
 }
 
-static void data64_ts_cb(uint64_t data, uint64_t ts)
+static bool data64_ts_cb(uint64_t data, uint64_t ts)
 {
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA64, d, &ts, false);
+	return cfg.cb(STP_DATA64, d, &ts, false);
 }
 
-static void data4_mts_cb(uint64_t data, uint64_t ts)
+static bool data4_mts_cb(uint64_t data, uint64_t ts)
 {
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA4, d, &ts, true);
+	return cfg.cb(STP_DATA4, d, &ts, true);
 }
 
-static void data8_mts_cb(uint64_t data, uint64_t ts)
+static bool data8_mts_cb(uint64_t data, uint64_t ts)
 {
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA8, d, &ts, true);
+	return cfg.cb(STP_DATA8, d, &ts, true);
 }
 
-static void data16_mts_cb(uint64_t data, uint64_t ts)
+static bool data16_mts_cb(uint64_t data, uint64_t ts)
 {
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA16, d, &ts, true);
+	return cfg.cb(STP_DATA16, d, &ts, true);
 }
 
-static void data32_mts_cb(uint64_t data, uint64_t ts)
+static bool data32_mts_cb(uint64_t data, uint64_t ts)
 {
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA32, d, &ts, true);
+	return cfg.cb(STP_DATA32, d, &ts, true);
 }
 
-static void data64_mts_cb(uint64_t data, uint64_t ts)
+static bool data64_mts_cb(uint64_t data, uint64_t ts)
 {
 	union mipi_stp_decoder_data d = {.data = data};
 
-	cfg.cb(STP_DATA64, d, &ts, true);
+	return cfg.cb(STP_DATA64, d, &ts, true);
 }
 
-static void major_cb(uint64_t id, uint64_t ts)
+static bool major_cb(uint64_t id, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	uint16_t m_id = (uint16_t)id;
@@ -265,10 +265,10 @@ static void major_cb(uint64_t id, uint64_t ts)
 
 	curr_ch = 0;
 
-	cfg.cb(STP_DECODER_MAJOR, data, NULL, false);
+	return cfg.cb(STP_DECODER_MAJOR, data, NULL, false);
 }
 
-static void channel16_cb(uint64_t id, uint64_t ts)
+static bool channel16_cb(uint64_t id, uint64_t ts)
 {
 	uint16_t ch = (uint16_t)id;
 
@@ -277,9 +277,9 @@ static void channel16_cb(uint64_t id, uint64_t ts)
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data data = {.id = ch};
 
-	cfg.cb(STP_DECODER_CHANNEL, data, NULL, false);
+	return cfg.cb(STP_DECODER_CHANNEL, data, NULL, false);
 }
-static void channel_cb(uint64_t id, uint64_t ts)
+static bool channel_cb(uint64_t id, uint64_t ts)
 {
 	uint16_t ch = (uint16_t)id;
 
@@ -288,43 +288,43 @@ static void channel_cb(uint64_t id, uint64_t ts)
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data data = {.id = ch};
 
-	cfg.cb(STP_DECODER_CHANNEL, data, NULL, false);
+	return cfg.cb(STP_DECODER_CHANNEL, data, NULL, false);
 }
 
-static void merror_cb(uint64_t err, uint64_t ts)
+static bool merror_cb(uint64_t err, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data data = {.err = (uint32_t)err};
 
-	cfg.cb(STP_DECODER_MERROR, data, NULL, false);
+	return cfg.cb(STP_DECODER_MERROR, data, NULL, false);
 }
 
-static void gerror_cb(uint64_t err, uint64_t ts)
+static bool gerror_cb(uint64_t err, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	union mipi_stp_decoder_data data = {.err = (uint32_t)err};
 
-	cfg.cb(STP_DECODER_GERROR, data, NULL, false);
+	return cfg.cb(STP_DECODER_GERROR, data, NULL, false);
 }
 
-static void flag_cb(uint64_t data, uint64_t ts)
+static bool flag_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	ARG_UNUSED(data);
 	union mipi_stp_decoder_data dummy = {.dummy = 0};
 
-	cfg.cb(STP_DECODER_FLAG, dummy, NULL, false);
+	return cfg.cb(STP_DECODER_FLAG, dummy, NULL, false);
 }
 
-static void flag_ts_cb(uint64_t unused, uint64_t ts)
+static bool flag_ts_cb(uint64_t unused, uint64_t ts)
 {
 	ARG_UNUSED(unused);
 	union mipi_stp_decoder_data data = {.dummy = 0};
 
-	cfg.cb(STP_DECODER_FLAG, data, &ts, false);
+	return cfg.cb(STP_DECODER_FLAG, data, &ts, false);
 }
 
-static void version_cb(uint64_t version, uint64_t ts)
+static bool version_cb(uint64_t version, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 
@@ -332,53 +332,53 @@ static void version_cb(uint64_t version, uint64_t ts)
 
 	union mipi_stp_decoder_data data = {.ver = version};
 
-	cfg.cb(STP_DECODER_VERSION, data, NULL, false);
+	return cfg.cb(STP_DECODER_VERSION, data, NULL, false);
 }
 
-static void notsup_cb(uint64_t data, uint64_t ts)
+static bool notsup_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	ARG_UNUSED(data);
 
 	union mipi_stp_decoder_data dummy = {.dummy = 0};
 
-	cfg.cb(STP_DECODER_NOT_SUPPORTED, dummy, NULL, false);
+	return cfg.cb(STP_DECODER_NOT_SUPPORTED, dummy, NULL, false);
 }
 
-static void freq_cb(uint64_t freq, uint64_t ts)
+static bool freq_cb(uint64_t freq, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 
 	union mipi_stp_decoder_data data = {.freq = freq};
 
-	cfg.cb(STP_DECODER_FREQ, data, NULL, false);
+	return cfg.cb(STP_DECODER_FREQ, data, NULL, false);
 }
 
-static void freq_ts_cb(uint64_t freq, uint64_t ts)
+static bool freq_ts_cb(uint64_t freq, uint64_t ts)
 {
 	union mipi_stp_decoder_data data = {.freq = freq};
 
-	cfg.cb(STP_DECODER_FREQ, data, &ts, false);
+	return cfg.cb(STP_DECODER_FREQ, data, &ts, false);
 }
 
-static void null_cb(uint64_t data, uint64_t ts)
+static bool null_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	ARG_UNUSED(data);
 
 	union mipi_stp_decoder_data dummy = {.dummy = 0};
 
-	cfg.cb(STP_DECODER_NULL, dummy, NULL, false);
+	return cfg.cb(STP_DECODER_NULL, dummy, NULL, false);
 }
 
-static void async_cb(uint64_t data, uint64_t ts)
+static bool async_cb(uint64_t data, uint64_t ts)
 {
 	ARG_UNUSED(ts);
 	ARG_UNUSED(data);
 
 	union mipi_stp_decoder_data dummy = {.dummy = 0};
 
-	cfg.cb(STP_DECODER_ASYNC, dummy, NULL, false);
+	return cfg.cb(STP_DECODER_ASYNC, dummy, NULL, false);
 }
 
 static const struct stp_item items[] = {
@@ -671,6 +671,7 @@ int mipi_stp_decoder_decode(const uint8_t *data, size_t len)
 	uint64_t *data64 = (uint64_t *)data_buf;
 	uint64_t *ts64 = (uint64_t *)ts_buf;
 	size_t nlen = 2 * len;
+	bool valid;
 
 	do {
 		switch (state) {
@@ -684,8 +685,8 @@ int mipi_stp_decoder_decode(const uint8_t *data, size_t len)
 				curr_id = STP_INVALID;
 				ncnt = 0;
 
-				items[STP_ASYNC].cb(0, 0);
-				state = STP_STATE_OP;
+				valid = items[STP_ASYNC].cb(0, 0);
+				state = valid ? STP_STATE_OP : STP_STATE_OUT_OF_SYNC;
 			} else {
 				ncnt = 0;
 			}
@@ -703,8 +704,9 @@ int mipi_stp_decoder_decode(const uint8_t *data, size_t len)
 					state = STP_STATE_TS;
 				} else {
 					/* item without data and ts, notify. */
-					items[curr_id].cb(0, 0);
+					valid = items[curr_id].cb(0, 0);
 					curr_id = STP_INVALID;
+					state = valid ? STP_STATE_OP : STP_STATE_OUT_OF_SYNC;
 				}
 			}
 			break;
@@ -724,9 +726,9 @@ int mipi_stp_decoder_decode(const uint8_t *data, size_t len)
 					ntotal = 0;
 					state = STP_STATE_TS;
 				} else {
-					items[curr_id].cb(*data64, 0);
+					valid = items[curr_id].cb(*data64, 0);
 					curr_id = STP_INVALID;
-					state = STP_STATE_OP;
+					state = valid ? STP_STATE_OP : STP_STATE_OUT_OF_SYNC;
 					ntotal = 0;
 					ncnt = 0;
 				}
@@ -765,9 +767,9 @@ int mipi_stp_decoder_decode(const uint8_t *data, size_t len)
 				if (ncnt == ntotal) {
 					swap_n(ts_buf, ntotal);
 					prev_ts = base_ts | *ts64;
-					items[curr_id].cb(*data64, prev_ts);
+					valid = items[curr_id].cb(*data64, prev_ts);
 					curr_id = STP_INVALID;
-					state = STP_STATE_OP;
+					state = valid ? STP_STATE_OP : STP_STATE_OUT_OF_SYNC;
 					ntotal = 0;
 					ncnt = 0;
 				}

--- a/subsys/logging/frontends/log_frontend_stmesp.c
+++ b/subsys/logging/frontends/log_frontend_stmesp.c
@@ -357,6 +357,7 @@ void log_frontend_msg(const void *source, const struct log_msg_desc desc, uint8_
 					       ARRAY_SIZE(strl));
 	hdr.log.total_len = total_len + package_len;
 	hdr.log.package_len = package_len;
+	hdr.log.has_data = desc.data_len > 0 ? 1 : 0;
 
 	if ((EARLY_BUF_SIZE == 0) || etr_rdy) {
 		STMESP_Type *stm_esp;

--- a/subsys/logging/frontends/log_frontend_stmesp_demux.c
+++ b/subsys/logging/frontends/log_frontend_stmesp_demux.c
@@ -374,7 +374,7 @@ int log_frontend_stmesp_demux_log0(uint16_t source_id, uint64_t *ts)
 	}
 
 	if (demux.curr_m_ch == M_CH_INVALID) {
-		return -EINVAL;
+		return -EBADMSG;
 	}
 
 	if (demux.curr != NULL) {
@@ -382,14 +382,14 @@ int log_frontend_stmesp_demux_log0(uint16_t source_id, uint64_t *ts)
 		 * mark as incompleted if not all data is received.
 		 */
 		log_frontend_stmesp_demux_packet_end();
-		return -EINVAL;
+		return -EBADMSG;
 	}
 
 	uint16_t ch = demux.curr_m_ch & C_ID_MASK;
 	uint16_t m = get_major_id(demux.curr_m_ch >> M_ID_OFF);
 
 	if (ch < CONFIG_LOG_FRONTEND_STMESP_TURBO_LOG_BASE) {
-		return -EINVAL;
+		return -EBADMSG;
 	}
 
 	store_turbo_log0(m, ch, ts, source_id);
@@ -464,14 +464,17 @@ int log_frontend_stmesp_demux_packet_start(uint32_t *data, uint64_t *ts)
 	int err;
 
 	if (demux.curr_m_ch == M_CH_INVALID) {
-		return -EINVAL;
+		return -EBADMSG;
 	}
 
 	if (demux.curr_m_ch == M_CH_HW_EVENT) {
-		/* HW event */
-		log_frontend_stmesp_demux_hw_event(ts, (uint8_t)*data);
-
-		return 1;
+		if (data) {
+			/* HW event */
+			log_frontend_stmesp_demux_hw_event(ts, (uint8_t)*data);
+			return 1;
+		} else {
+			return -EBADMSG;
+		}
 	}
 
 	uint16_t ch = demux.curr_m_ch & C_ID_MASK;
@@ -484,7 +487,7 @@ int log_frontend_stmesp_demux_packet_start(uint32_t *data, uint64_t *ts)
 
 		if (src->data_cnt >= 2) {
 			/* Unexpected packet. */
-			return -EINVAL;
+			return -EBADMSG;
 		}
 
 		src->m_id = m;
@@ -497,7 +500,7 @@ int log_frontend_stmesp_demux_packet_start(uint32_t *data, uint64_t *ts)
 		 * mark as incompleted if not all data is received.
 		 */
 		log_frontend_stmesp_demux_packet_end();
-		return -EINVAL;
+		return -EBADMSG;
 	}
 
 	if (ch >= CONFIG_LOG_FRONTEND_STMESP_TP_CHAN_BASE) {
@@ -509,6 +512,12 @@ int log_frontend_stmesp_demux_packet_start(uint32_t *data, uint64_t *ts)
 		}
 
 		return 1;
+	} else if (data == NULL) {
+		/* It may happen that FLAGTS is received but only because of postponing
+		 * of timestamp injection. In that case we can interpret is as a packet end.
+		 */
+		log_frontend_stmesp_demux_packet_end();
+		return 0;
 	}
 
 	union log_frontend_stmesp_demux_header hdr = {.raw = *data};
@@ -633,10 +642,12 @@ void log_frontend_stmesp_demux_reset(void)
 		entry->packet->content_invalid = 1;
 		mpsc_pbuf_commit(&demux.pbuf, p.generic);
 		demux.dropped++;
-		demux.curr_m_ch = M_CH_INVALID;
 
 		k_mem_slab_free(&demux.mslab, entry);
 	}
+	demux.curr_m_ch = M_CH_INVALID;
+	demux.curr = NULL;
+	skip = true;
 }
 
 bool log_frontend_stmesp_demux_is_idle(void)

--- a/tests/subsys/debug/mipi_stp_decoder/src/main.c
+++ b/tests/subsys/debug/mipi_stp_decoder/src/main.c
@@ -14,7 +14,7 @@ static uint64_t exp_ts[10];
 static bool exp_marked[10];
 static int d_cnt;
 
-static void cb(enum mipi_stp_decoder_ctrl_type type, union mipi_stp_decoder_data data, uint64_t *ts,
+static bool cb(enum mipi_stp_decoder_ctrl_type type, union mipi_stp_decoder_data data, uint64_t *ts,
 	       bool marked)
 {
 	zassert_equal(exp_type[d_cnt], type, "Expected: %d got:%d", exp_type[d_cnt], type);
@@ -30,6 +30,8 @@ static void cb(enum mipi_stp_decoder_ctrl_type type, union mipi_stp_decoder_data
 	zassert_equal(
 		memcmp((uint8_t *)&exp_data[d_cnt], (uint8_t *)&data.data, exp_data_len[d_cnt]), 0);
 	d_cnt++;
+
+	return true;
 }
 
 static const struct mipi_stp_decoder_config config = {

--- a/tests/subsys/logging/log_frontend_stmesp_demux/src/main.c
+++ b/tests/subsys/logging/log_frontend_stmesp_demux/src/main.c
@@ -334,7 +334,7 @@ ZTEST(log_frontend_stmesp_demux_test, test_drop_too_many_active)
 
 	demux_init();
 
-	PACKET_START(NULL, NULL, hdr.raw, ts, -EINVAL);
+	PACKET_START(NULL, NULL, hdr.raw, ts, -EBADMSG);
 
 	/* Start writing to 3 packets */
 	PACKET_START(&m_id0, &c_id0, hdr.raw, ts, 0);
@@ -458,7 +458,7 @@ ZTEST(log_frontend_stmesp_demux_test, test_reset)
 
 	demux_init();
 
-	PACKET_START(NULL, NULL, hdr.raw, ts, -EINVAL);
+	PACKET_START(NULL, NULL, hdr.raw, ts, -EBADMSG);
 
 	/* Start writing to 3 packets */
 	PACKET_START(&m_id0, &c_id0, hdr.raw, ts, 0);


### PR DESCRIPTION
Standalone logging with Coresight STMESP attempts to decode data stored in the ETR buffer. Size of the ETR buffer is limited to 4kB so if data is not read out on time then it can be overwritten. ETR data is a STPv2 data stream so it is corrupted (for example by an overflow) then if it is unnoticed then the decoder gets garbage data and attempt to format a string using that data may lead to fault. When overflow is detected then the decoder should reset to an out-of-sync state in which it searches for STPv2 ASYNC opcode which is periodically present it the data stream and allows re-synchronization.

PR contains set of fixes and improvements in that area as there were corner cases where overflow was not correctly handled.

While stress testing Coresight STM, it was noticed that when multiple cores writes to STMESP and generate ETR data it is possible to get some glitches (missed bytes?) in to ETR buffer which are not the result of an overflow. Decoding such logging message would lead to a fault. As log message do not have CRC some defensive measures are added to detect invalid message. If invalid message is detected then message is dropped and re-synchronization is triggered.