### PR TITLE
subsys: net: l2: wifi: Add SSID protection parameter for STA and AP.

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -787,6 +787,11 @@ struct wifi_connect_req_params {
 	const uint8_t *server_cert_domain_suffix;
 	/** Length of the server_cert_domain_suffix string, maximum 64 bytes */
 	uint8_t server_cert_domain_suffix_len;
+	/** SSID protection in 4-way handshake (needs RSNXE support)
+	 * 0: Disable (default)
+	 * 1: Enable
+	 */
+	uint8_t ssid_protection;
 };
 
 /** @brief Wi-Fi disconnect reason codes. To be overlaid on top of \ref wifi_status

--- a/modules/hostap/src/hapd_api.c
+++ b/modules/hostap/src/hapd_api.c
@@ -637,6 +637,10 @@ int hapd_config_network(struct hostapd_iface *iface,
 		goto out;
 	}
 
+	if (!hostapd_cli_cmd_v("set ssid_protection %d", params->ssid_protection)) {
+		goto out;
+	}
+
 	return ret;
 out:
 	return -1;

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1230,6 +1230,12 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 		}
 	}
 
+	if (!wpa_cli_cmd_v("set_network %d ssid_protection %d",
+			   resp.network_id, params->ssid_protection)) {
+		goto out;
+	}
+
+
 	memcpy((void *)&mac, params->bssid, WIFI_MAC_ADDR_LEN);
 	if (net_eth_is_addr_broadcast(&mac) ||
 	    net_eth_is_addr_multicast(&mac)) {

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -675,6 +675,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 		{"iface", sys_getopt_required_argument, 0, 'i'},
 		{"server-cert-domain-exact", sys_getopt_required_argument, 0, 'e'},
 		{"server-cert-domain-suffix", sys_getopt_required_argument, 0, 'x'},
+		{"ssid-protection", sys_getopt_required_argument, 0, 'C'},
 		{"help", sys_getopt_no_argument, 0, 'h'},
 		{0, 0, 0, 0}};
 	char *endptr;
@@ -703,7 +704,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 	params->bandwidth = WIFI_FREQ_BANDWIDTH_20MHZ;
 	params->verify_peer_cert = false;
 
-	while ((opt = sys_getopt_long(argc, argv, "s:p:k:e:x:w:b:c:m:t:a:B:K:S:T:A:V:I:P:g:Rh:i:",
+	while ((opt = sys_getopt_long(argc, argv, "s:p:k:e:x:w:b:c:m:t:a:B:K:S:C:T:A:V:I:P:g:Rh:i:",
 				  long_options, &opt_index)) != -1) {
 		state = sys_getopt_state_get();
 		switch (opt) {
@@ -931,6 +932,13 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			break;
 		case 'R':
 			params->ft_used = true;
+			break;
+		case 'C':
+			params->ssid_protection = atoi(state->optarg);
+			if (params->ssid_protection != 0U && params->ssid_protection != 1U) {
+				PR_WARNING("ssid_protection error %d\n", params->ssid_protection);
+				return -EINVAL;
+			}
 			break;
 		case 'g':
 			params->ignore_broadcast_ssid = shell_strtol(state->optarg, 10, &ret);
@@ -4471,8 +4479,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 				 "[-V, --eap-version]: 0 or 1. Default 1: eap version 1\n"
 				 "[-I, --eap-id1...--eap-id8]: Client Identity. Default no eap identity\n"
 				 "[-P, --eap-pwd1...--eap-pwd8]: Client Password\n"
-				 "Default no password for eap user"),
-		      cmd_wifi_ap_enable, 2, 47),
+				 "Default no password for eap user\n"
+				 "[-C, --ssid-protection]: Whether to use SSID protection in\n"
+				 "4-way handshake: 0:Disable, 1:Enable"),
+		      cmd_wifi_ap_enable, 2, 49),
 	SHELL_CMD_ARG(stations, NULL,
 		      SHELL_HELP("List stations connected to the AP",
 				 "[-i, --iface=<interface index>]"),
@@ -4613,9 +4623,11 @@ SHELL_SUBCMD_ADD((wifi), connect, NULL,
 			    "[-e, --server-cert-domain-exact]: Full domain names for "
 			    "server certificate match\n"
 			    "[-x, --server-cert-domain-suffix]: Domain name suffixes for "
-			    "server certificate match"),
+			    "server certificate match\n"
+			    "[-C, --ssid-protection]: Whether to use SSID protection in\n"
+			    "4-way handshake: 0:Disable, 1:Enable"),
 		 cmd_wifi_connect,
-		 2, 46);
+		 2, 48);
 
 SHELL_SUBCMD_ADD((wifi), disconnect, NULL,
 		 SHELL_HELP("Disconnect from the Wi-Fi AP",


### PR DESCRIPTION
Add new parameter -C to enable or disable SSID protection in wifi connect and wifi ap enable commands. The SSID protection is disabled by default.