### PR TITLE
drivers: serial: wch: only report TX ready if the interrupt is enabled

### DIFF
--- a/drivers/serial/uart_wch_usart.c
+++ b/drivers/serial/uart_wch_usart.c
@@ -187,7 +187,7 @@ static int usart_wch_irq_tx_ready(const struct device *dev)
 	const struct usart_wch_config *config = dev->config;
 	USART_TypeDef *regs = config->regs;
 
-	return (regs->STATR & USART_STATR_TXE) > 0;
+	return (regs->STATR & USART_STATR_TXE) != 0 && (regs->CTLR1 & USART_CTLR1_TXEIE) != 0;
 }
 
 static void usart_wch_irq_rx_enable(const struct device *dev)


### PR DESCRIPTION
`uart_irq_tx_ready` should report true if transmit is empty and the transmit interrupt is enabled. This isn't documented in drivers/uart.h but is required by code such
`subsys/modules/modbus_serial.c` and implemented in drivers such as `uart_sam.c` and `uart_stm32.c`.

Fix.