### PR TITLE
drivers: i2c: fix the ch32v006 build by changing the "has TRISE" test

### DIFF
--- a/drivers/i2c/i2c_wch.c
+++ b/drivers/i2c/i2c_wch.c
@@ -274,7 +274,7 @@ static int wch_i2c_configure_timing(I2C_TypeDef *regs, uint32_t clock_rate,
 	uint16_t freq_range = (uint16_t)(clock_rate / 1000000);
 	uint16_t clock_config;
 
-#ifndef CONFIG_SOC_CH32V003
+#ifdef I2C_RTR_TRISE
 	uint16_t trise;
 
 	switch (speed) {


### PR DESCRIPTION
The I2C Rise Time Register (TRISE) is present on the CH32V20x and CH32V30x but not on the CH32V003 or CH32V00X. Change the test from "not on the CH32V003" to "only present if the HAL defines the macro".

Tested by patching the board DTS to enable i2c1 and then building `tests/drivers/i2c/i2c_api` for the ch32v003evt, ch32v006evt, and linkw.