### PR TITLE
include: battery: dt-bindings: update OCV curve for LiPo batteries

### DIFF
--- a/include/zephyr/dt-bindings/battery/battery.h
+++ b/include/zephyr/dt-bindings/battery/battery.h
@@ -65,10 +65,11 @@
 /**
  * @brief Default open-circuit voltage curve for lithium-ion polymer (Li-ion) batteries.
  *
- * Based on Panasonic NCR18650BF.
+ * Based on Analog Devices OCV characterization data for a typical Li+ cell (Application Note 4189,
+ * Table 1).
  */
 #define BATTERY_OCV_CURVE_LITHIUM_ION_POLYMER_DEFAULT                                              \
-	2502000 3146000 3372000 3449000 3532000 3602000 3680000 3764000 3842000 3936000 4032000
+	3305545 3686654 3741018 3775129 3793250 3820965 3884009 3945074 4008118 4085934 4177454
 
 /**
  * @brief Default open-circuit voltage curve for lithium iron phosphate (LiFePO4) batteries.


### PR DESCRIPTION
Replaced the open-circuit voltage curve values for lithium-ion polymer batteries with data corresponding to actual OCV - the previous table was most likely a discharge curve under load (0.2C?) so was pretty off from typically observed voltages in "Zephyr" conditions (i.e. rather light load on the battery).

There is by definition no perfect curve but at least this one should be slightly less off (only issue with it is that it's maybe never really hitting 100% even with a full battery, but I'd rather stick to this nonetheless "proven" table rather than coming up with my own half made-up numbers).