### PR TITLE
drivers: fix incorrect @retval usage (1/6)

### DIFF
--- a/include/zephyr/drivers/adc/ads1x4s0x.h
+++ b/include/zephyr/drivers/adc/ads1x4s0x.h
@@ -30,8 +30,7 @@
  * @param pin Pin number.
  * @param initial_value Initial value of the pin.
  *
- * @retval 0 success.
- * @retval -errno negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int ads1x4s0x_gpio_set_output(const struct device *dev, uint8_t pin, bool initial_value);
 
@@ -41,8 +40,7 @@ int ads1x4s0x_gpio_set_output(const struct device *dev, uint8_t pin, bool initia
  * @param dev Pointer to the device structure for the driver instance.
  * @param pin Pin number.
  *
- * @retval 0 success.
- * @retval -errno negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int ads1x4s0x_gpio_set_input(const struct device *dev, uint8_t pin);
 
@@ -52,8 +50,7 @@ int ads1x4s0x_gpio_set_input(const struct device *dev, uint8_t pin);
  * @param dev Pointer to the device structure for the driver instance.
  * @param pin Pin number.
  *
- * @retval 0 success.
- * @retval -errno negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int ads1x4s0x_gpio_deconfigure(const struct device *dev, uint8_t pin);
 
@@ -64,8 +61,7 @@ int ads1x4s0x_gpio_deconfigure(const struct device *dev, uint8_t pin);
  * @param pin Pin number.
  * @param value Value to set.
  *
- * @retval 0 success.
- * @retval -errno negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int ads1x4s0x_gpio_set_pin_value(const struct device *dev, uint8_t pin,
 				bool value);
@@ -77,8 +73,7 @@ int ads1x4s0x_gpio_set_pin_value(const struct device *dev, uint8_t pin,
  * @param pin Pin number.
  * @param value Pointer to where the value will be stored.
  *
- * @retval 0 success.
- * @retval -errno negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int ads1x4s0x_gpio_get_pin_value(const struct device *dev, uint8_t pin,
 				bool *value);
@@ -89,8 +84,7 @@ int ads1x4s0x_gpio_get_pin_value(const struct device *dev, uint8_t pin,
  * @param dev Pointer to the device structure for the driver instance.
  * @param value Pointer to where the port value will be stored.
  *
- * @retval 0 success.
- * @retval -errno negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int ads1x4s0x_gpio_port_get_raw(const struct device *dev,
 			       gpio_port_value_t *value);
@@ -102,8 +96,7 @@ int ads1x4s0x_gpio_port_get_raw(const struct device *dev,
  * @param mask Mask of pins to change.
  * @param value Value to set.
  *
- * @retval 0 success.
- * @retval -errno negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int ads1x4s0x_gpio_port_set_masked_raw(const struct device *dev,
 				      gpio_port_pins_t mask,
@@ -115,8 +108,7 @@ int ads1x4s0x_gpio_port_set_masked_raw(const struct device *dev,
  * @param dev Pointer to the device structure for the driver instance.
  * @param pins Mask of pins to toggle.
  *
- * @retval 0 success.
- * @retval -errno negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int ads1x4s0x_gpio_port_toggle_bits(const struct device *dev,
 				   gpio_port_pins_t pins);

--- a/include/zephyr/drivers/biometrics.h
+++ b/include/zephyr/drivers/biometrics.h
@@ -309,8 +309,7 @@ __subsystem struct biometric_driver_api {
  * @param dev Pointer to the biometric device
  * @param caps Pointer to capabilities structure to populate
  *
- * @retval 0 Success
- * @retval -errno Negative errno code on failure
+ * @return 0 on success, negative errno value on failure.
  */
 __syscall int biometric_get_capabilities(const struct device *dev,
 					 struct biometric_capabilities *caps);
@@ -335,10 +334,9 @@ static inline int z_impl_biometric_get_capabilities(const struct device *dev,
  * @param attr The attribute to set
  * @param val The value to set
  *
- * @retval 0 Success
- * @retval -ENOSYS Not supported by device
- * @retval -EINVAL Invalid attribute or value
- * @retval -errno Negative errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Not supported by device.
+ * @retval -EINVAL Invalid attribute or value.
  */
 __syscall int biometric_attr_set(const struct device *dev, enum biometric_attribute attr,
 				 int32_t val);
@@ -366,10 +364,9 @@ static inline int z_impl_biometric_attr_set(const struct device *dev, enum biome
  * @param attr The attribute to get
  * @param val Pointer to store the attribute value
  *
- * @retval 0 Success
- * @retval -ENOSYS Not supported by device
- * @retval -EINVAL Invalid attribute
- * @retval -errno Negative errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Not supported by device.
+ * @retval -EINVAL Invalid attribute.
  */
 __syscall int biometric_attr_get(const struct device *dev, enum biometric_attribute attr,
 				 int32_t *val);
@@ -401,10 +398,9 @@ static inline int z_impl_biometric_attr_get(const struct device *dev, enum biome
  * @param dev Biometric device
  * @param template_id Template ID to assign (1-based: valid range is 1 to max_templates)
  *
- * @retval 0 on success
- * @retval -EINVAL Invalid template_id or enrollment in progress
- * @retval -ENOSPC No space for new template
- * @retval -errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Invalid template_id or enrollment in progress.
+ * @retval -ENOSPC No space for new template.
  */
 __syscall int biometric_enroll_start(const struct device *dev, uint16_t template_id);
 
@@ -431,10 +427,9 @@ static inline int z_impl_biometric_enroll_start(const struct device *dev, uint16
  * @param result Optional pointer to capture result structure for progress/quality info.
  *               Pass NULL if not needed.
  *
- * @retval 0 Sample successfully captured
- * @retval -EINVAL No enrollment started or already have enough samples
- * @retval -ETIMEDOUT Timeout waiting for sample
- * @retval -errno Other negative errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL No enrollment started or already have enough samples.
+ * @retval -ETIMEDOUT Timeout waiting for sample.
  */
 __syscall int biometric_enroll_capture(const struct device *dev, k_timeout_t timeout,
 				       struct biometric_capture_result *result);
@@ -458,10 +453,9 @@ static inline int z_impl_biometric_enroll_capture(const struct device *dev, k_ti
  *
  * @param dev Biometric device
  *
- * @retval 0 on success
- * @retval -EINVAL Insufficient samples
- * @retval -ENOSPC No space to store template
- * @retval -errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Insufficient samples.
+ * @retval -ENOSPC No space to store template.
  */
 __syscall int biometric_enroll_finalize(const struct device *dev);
 
@@ -483,10 +477,9 @@ static inline int z_impl_biometric_enroll_finalize(const struct device *dev)
  *
  * @param dev Biometric device
  *
- * @retval 0 on success
- * @retval -EALREADY No enrollment in progress
- * @retval -ENOSYS Not supported by device
- * @retval -errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EALREADY No enrollment in progress.
+ * @retval -ENOSYS Not supported by device.
  */
 __syscall int biometric_enroll_abort(const struct device *dev);
 
@@ -516,11 +509,10 @@ static inline int z_impl_biometric_enroll_abort(const struct device *dev)
  * @param data Pointer to template data
  * @param size Size of template data in bytes
  *
- * @retval 0 Success
- * @retval -EINVAL Invalid template data
- * @retval -ENOSPC Storage full
- * @retval -ENOSYS Not supported by device
- * @retval -errno Negative errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Invalid template data.
+ * @retval -ENOSPC Storage full.
+ * @retval -ENOSYS Not supported by device.
  */
 __syscall int biometric_template_store(const struct device *dev, uint16_t id, const uint8_t *data,
 				       size_t size);
@@ -553,11 +545,10 @@ static inline int z_impl_biometric_template_store(const struct device *dev, uint
  * @param data Pointer to buffer for template data
  * @param size Size of data buffer
  *
- * @retval >=0 Number of bytes written
- * @retval -EINVAL Invalid template_id or buffer too small
- * @retval -ENOENT Template not found
- * @retval -ENOSYS Not supported by device
- * @retval -errno Negative errno code on failure
+ * @return Number of bytes written on success, negative errno value on failure.
+ * @retval -EINVAL Invalid template_id or buffer too small.
+ * @retval -ENOENT Template not found.
+ * @retval -ENOSYS Not supported by device.
  */
 __syscall int biometric_template_read(const struct device *dev, uint16_t id, uint8_t *data,
 				      size_t size);
@@ -585,10 +576,9 @@ static inline int z_impl_biometric_template_read(const struct device *dev, uint1
  * @param dev Pointer to the biometric device
  * @param id Template ID to delete
  *
- * @retval 0 Success
- * @retval -EINVAL Invalid template_id
- * @retval -ENOENT Template not found
- * @retval -errno Negative errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Invalid template_id.
+ * @retval -ENOENT Template not found.
  */
 __syscall int biometric_template_delete(const struct device *dev, uint16_t id);
 
@@ -608,9 +598,8 @@ static inline int z_impl_biometric_template_delete(const struct device *dev, uin
  *
  * @param dev Pointer to the biometric device
  *
- * @retval 0 Success
- * @retval -ENOSYS Not supported by device
- * @retval -errno Negative errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Not supported by device.
  */
 __syscall int biometric_template_delete_all(const struct device *dev);
 
@@ -637,9 +626,8 @@ static inline int z_impl_biometric_template_delete_all(const struct device *dev)
  * @param max_count Maximum number of IDs array can hold
  * @param actual_count Pointer to store actual number of IDs returned
  *
- * @retval 0 Success
- * @retval -ENOSYS Not supported by device
- * @retval -errno Negative errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Not supported by device.
  */
 __syscall int biometric_template_list(const struct device *dev, uint16_t *ids, size_t max_count,
 				      size_t *actual_count);
@@ -676,10 +664,9 @@ static inline int z_impl_biometric_template_list(const struct device *dev, uint1
  * @param result Optional pointer to match result structure for detailed info.
  *               Pass NULL if only match/no-match status is needed.
  *
- * @retval 0 Match successful
- * @retval -ETIMEDOUT Timeout waiting for sample
- * @retval -ENOENT No match found
- * @retval -errno Other negative errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ETIMEDOUT Timeout waiting for sample.
+ * @retval -ENOENT No match found.
  */
 __syscall int biometric_match(const struct device *dev, enum biometric_match_mode mode,
 			      uint16_t template_id, k_timeout_t timeout,
@@ -706,10 +693,9 @@ static inline int z_impl_biometric_match(const struct device *dev, enum biometri
  * @param dev Biometric device
  * @param state Desired LED state
  *
- * @retval 0 on success
- * @retval -ENOSYS Not supported by device
- * @retval -EINVAL Invalid state
- * @retval -errno code on failure
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Not supported by device.
+ * @retval -EINVAL Invalid state.
  */
 __syscall int biometric_led_control(const struct device *dev, enum biometric_led_state state);
 

--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -47,9 +47,8 @@ void cache_data_disable(void);
  *
  * Flush the whole data cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_flush_all(void);
 
@@ -58,9 +57,8 @@ int cache_data_flush_all(void);
  *
  * Invalidate the whole data cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_invd_all(void);
 
@@ -69,9 +67,8 @@ int cache_data_invd_all(void);
  *
  * Flush and Invalidate the whole data cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_flush_and_invd_all(void);
 
@@ -90,9 +87,8 @@ int cache_data_flush_and_invd_all(void);
  * @param addr Starting address to flush.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_flush_range(void *addr, size_t size);
 
@@ -112,9 +108,8 @@ int cache_data_flush_range(void *addr, size_t size);
  * @param addr Starting address to invalidate.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_invd_range(void *addr, size_t size);
 
@@ -134,9 +129,8 @@ int cache_data_invd_range(void *addr, size_t size);
  * @param addr Starting address to flush and invalidate.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_flush_and_invd_range(void *addr, size_t size);
 
@@ -181,9 +175,8 @@ void cache_instr_disable(void);
  *
  * Flush the whole instruction cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_flush_all(void);
 
@@ -192,9 +185,8 @@ int cache_instr_flush_all(void);
  *
  * Invalidate the whole instruction cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_invd_all(void);
 
@@ -203,9 +195,8 @@ int cache_instr_invd_all(void);
  *
  * Flush and Invalidate the whole instruction cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_flush_and_invd_all(void);
 
@@ -224,9 +215,8 @@ int cache_instr_flush_and_invd_all(void);
  * @param addr Starting address to flush.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_flush_range(void *addr, size_t size);
 
@@ -246,9 +236,8 @@ int cache_instr_flush_range(void *addr, size_t size);
  * @param addr Starting address to invalidate.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_invd_range(void *addr, size_t size);
 
@@ -268,9 +257,8 @@ int cache_instr_invd_range(void *addr, size_t size);
  * @param addr Starting address to flush and invalidate.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_flush_and_invd_range(void *addr, size_t size);
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -868,7 +868,7 @@ struct can_device_state {
  * @param dev  Pointer to the device structure for the driver instance.
  * @param[out] rate CAN core clock rate in Hz.
  *
- * @return 0 on success, or a negative error code on error
+ * @return 0 on success, negative errno value on failure.
  */
 __syscall int can_get_core_clock(const struct device *dev, uint32_t *rate);
 
@@ -1062,11 +1062,11 @@ __syscall int can_calc_timing_data(const struct device *dev, struct can_timing *
  * @param dev         Pointer to the device structure for the driver instance.
  * @param timing_data Bus timings for data phase
  *
- * @retval 0 If successful.
- * @retval -EBUSY if the CAN controller is not in stopped state.
+ * @retval 0 on success.
+ * @retval -EBUSY CAN controller is not in stopped state.
  * @retval -EIO General input/output error, failed to configure device.
- * @retval -ENOTSUP if the timing parameters are not supported by the driver.
- * @retval -ENOSYS if CAN FD support is not implemented by the driver.
+ * @retval -ENOTSUP Timing parameters are not supported by the driver.
+ * @retval -ENOSYS CAN FD support is not implemented by the driver.
  */
 __syscall int can_set_timing_data(const struct device *dev,
 				  const struct can_timing *timing_data);
@@ -1091,12 +1091,12 @@ __syscall int can_set_timing_data(const struct device *dev,
  * @param dev          Pointer to the device structure for the driver instance.
  * @param bitrate_data Desired data phase bitrate.
  *
- * @retval 0 If successful.
- * @retval -EBUSY if the CAN controller is not in stopped state.
- * @retval -EINVAL if the requested bitrate is out of range.
- * @retval -ENOTSUP if the requested bitrate not supported by the CAN controller/transceiver
+ * @retval 0 on success.
+ * @retval -EBUSY CAN controller is not in stopped state.
+ * @retval -EINVAL Requested bitrate is out of range.
+ * @retval -ENOTSUP Requested bitrate not supported by the CAN controller/transceiver
  *                  combination.
- * @retval -ERANGE if the resulting sample point is off by more than +/- 5%.
+ * @retval -ERANGE Resulting sample point is off by more than +/- 5%.
  * @retval -EIO General input/output error, failed to set bitrate.
  */
 __syscall int can_set_bitrate_data(const struct device *dev, uint32_t bitrate_data);
@@ -1109,9 +1109,9 @@ __syscall int can_set_bitrate_data(const struct device *dev, uint32_t bitrate_da
  * @param dev         Pointer to the device structure for the driver instance.
  * @param timing      Bus timings.
  *
- * @retval 0 If successful.
- * @retval -EBUSY if the CAN controller is not in stopped state.
- * @retval -ENOTSUP if the timing parameters are not supported by the driver.
+ * @retval 0 on success.
+ * @retval -EBUSY CAN controller is not in stopped state.
+ * @retval -ENOTSUP Timing parameters are not supported by the driver.
  * @retval -EIO General input/output error, failed to configure device.
  */
 __syscall int can_set_timing(const struct device *dev,
@@ -1127,7 +1127,7 @@ __syscall int can_set_timing(const struct device *dev,
  * @param dev      Pointer to the device structure for the driver instance.
  * @param[out] cap Supported capabilities.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General input/output error, failed to get capabilities.
  */
 __syscall int can_get_capabilities(const struct device *dev, can_mode_t *cap);
@@ -1168,8 +1168,8 @@ static const struct device *z_impl_can_get_transceiver(const struct device *dev)
  * @see can_transceiver_enable()
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @retval 0 if successful.
- * @retval -EALREADY if the device is already started.
+ * @retval 0 on success.
+ * @retval -EALREADY Device is already started.
  * @retval -EIO General input/output error, failed to start device.
  */
 __syscall int can_start(const struct device *dev);
@@ -1190,8 +1190,8 @@ static inline int z_impl_can_start(const struct device *dev)
  * @see can_transceiver_disable()
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @retval 0 if successful.
- * @retval -EALREADY if the device is already stopped.
+ * @retval 0 on success.
+ * @retval -EALREADY Device is already stopped.
  * @retval -EIO General input/output error, failed to stop device.
  */
 __syscall int can_stop(const struct device *dev);
@@ -1207,8 +1207,8 @@ static inline int z_impl_can_stop(const struct device *dev)
  * @param dev  Pointer to the device structure for the driver instance.
  * @param mode Operation mode.
  *
- * @retval 0 If successful.
- * @retval -EBUSY if the CAN controller is not in stopped state.
+ * @retval 0 on success.
+ * @retval -EBUSY CAN controller is not in stopped state.
  * @retval -EIO General input/output error, failed to configure device.
  */
 __syscall int can_set_mode(const struct device *dev, can_mode_t mode);
@@ -1251,12 +1251,12 @@ static inline can_mode_t z_impl_can_get_mode(const struct device *dev)
  * @param dev          Pointer to the device structure for the driver instance.
  * @param bitrate      Desired arbitration phase bitrate.
  *
- * @retval 0 If successful.
- * @retval -EBUSY if the CAN controller is not in stopped state.
- * @retval -EINVAL if the requested bitrate is out of range.
- * @retval -ENOTSUP if the requested bitrate not supported by the CAN controller/transceiver
+ * @retval 0 on success.
+ * @retval -EBUSY CAN controller is not in stopped state.
+ * @retval -EINVAL Requested bitrate is out of range.
+ * @retval -ENOTSUP Requested bitrate not supported by the CAN controller/transceiver
  *                  combination.
- * @retval -ERANGE if the resulting sample point is off by more than +/- 5%.
+ * @retval -ERANGE Resulting sample point is off by more than +/- 5%.
  * @retval -EIO General input/output error, failed to set bitrate.
  */
 __syscall int can_set_bitrate(const struct device *dev, uint32_t bitrate);
@@ -1302,14 +1302,14 @@ __syscall int can_set_bitrate(const struct device *dev, uint32_t bitrate);
  *                  if called from user mode.
  * @param user_data User data to pass to callback function.
  *
- * @retval 0 if successful.
- * @retval -EINVAL if an invalid parameter was passed to the function.
- * @retval -ENOTSUP if an unsupported parameter was passed to the function.
- * @retval -ENETDOWN if the CAN controller is in stopped state.
- * @retval -ENETUNREACH if the CAN controller is in bus-off state.
- * @retval -EBUSY if CAN bus arbitration was lost (only applicable if automatic
+ * @retval 0 on success.
+ * @retval -EINVAL Invalid parameter was passed to the function.
+ * @retval -ENOTSUP Unsupported parameter was passed to the function.
+ * @retval -ENETDOWN CAN controller is in stopped state.
+ * @retval -ENETUNREACH CAN controller is in bus-off state.
+ * @retval -EBUSY CAN bus arbitration was lost (only applicable if automatic
  *                retransmissions are disabled).
- * @retval -EIO if a general transmit error occurred (e.g. missing ACK if
+ * @retval -EIO General transmit error occurred (e.g. missing ACK if
  *              automatic retransmissions are disabled).
  * @retval -EAGAIN on timeout.
  */
@@ -1421,9 +1421,9 @@ static inline void z_impl_can_remove_rx_filter(const struct device *dev, int fil
  * @param ide Get the maximum standard (11-bit) CAN ID filters if false, or extended (29-bit) CAN ID
  *            filters if true.
  *
- * @retval >=0 number of maximum concurrent filters.
+ * @return Number of maximum concurrent filters on success.
  * @retval -EIO General input/output error.
- * @retval -ENOSYS If this function is not implemented by the driver.
+ * @retval -ENOSYS Function is not implemented by the driver.
  */
 __syscall int can_get_max_filters(const struct device *dev, bool ide);
 
@@ -1456,7 +1456,7 @@ static inline int z_impl_can_get_max_filters(const struct device *dev, bool ide)
  * @param[out] state   Pointer to the state destination enum or NULL.
  * @param[out] err_cnt Pointer to the err_cnt destination structure or NULL.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General input/output error, failed to get state.
  */
 __syscall int can_get_state(const struct device *dev, enum can_state *state,

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -234,10 +234,9 @@ __subsystem struct cellular_driver_api {
  * @param networks List of cellular network configurations to apply.
  * @param size Size of list of cellular network configurations.
  *
- * @retval 0 if successful.
- * @retval -EINVAL if any provided cellular network configuration is invalid or unsupported.
- * @retval -ENOTSUP if API is not supported by cellular network device.
- * @retval <0 Negative errno-code otherwise.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Any provided cellular network configuration is invalid or unsupported.
+ * @retval -ENOTSUP API is not supported by cellular network device.
  */
 static inline int cellular_configure_networks(const struct device *dev,
 					      const struct cellular_network *networks, uint8_t size)
@@ -258,9 +257,8 @@ static inline int cellular_configure_networks(const struct device *dev,
  * @param networks Pointer to list of supported cellular network configurations.
  * @param size Size of list of cellular network configurations.
  *
- * @retval 0 if successful.
- * @retval -ENOTSUP if API is not supported by cellular network device.
- * @retval <0 Negative errno-code otherwise.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP API is not supported by cellular network device.
  */
 static inline int cellular_get_supported_networks(const struct device *dev,
 						  const struct cellular_network **networks,
@@ -282,10 +280,9 @@ static inline int cellular_get_supported_networks(const struct device *dev,
  * @param type Type of the signal information requested
  * @param value Signal strength destination (one of RSSI, RSRP, RSRQ)
  *
- * @retval 0 if successful.
- * @retval -ENOTSUP if API is not supported by cellular network device.
- * @retval -ENODATA if device is not in a state where signal can be polled
- * @retval <0 Negative errno-code otherwise.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP API is not supported by cellular network device.
+ * @retval -ENODATA Device is not in a state where signal can be polled.
  */
 static inline int cellular_get_signal(const struct device *dev,
 				      const enum cellular_signal_type type, int16_t *value)
@@ -307,10 +304,9 @@ static inline int cellular_get_signal(const struct device *dev,
  * @param info Info string destination
  * @param size Info string size
  *
- * @retval 0 if successful.
- * @retval -ENOTSUP if API is not supported by cellular network device.
- * @retval -ENODATA if modem does not provide info requested
- * @retval <0 Negative errno-code from chat module otherwise.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP API is not supported by cellular network device.
+ * @retval -ENODATA Modem does not provide the requested info.
  */
 static inline int cellular_get_modem_info(const struct device *dev,
 					  const enum cellular_modem_info_type type, char *info,
@@ -332,10 +328,9 @@ static inline int cellular_get_modem_info(const struct device *dev,
  * @param tech Which access technology to get status for
  * @param status Registration status for given access technology
  *
- * @retval 0 if successful.
- * @retval -ENOSYS if API is not supported by cellular network device.
- * @retval -ENODATA if modem does not provide info requested
- * @retval <0 Negative errno-code from chat module otherwise.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS API is not supported by cellular network device.
+ * @retval -ENODATA Modem does not provide the requested info.
  */
 static inline int cellular_get_registration_status(const struct device *dev,
 						   enum cellular_access_technology tech,
@@ -359,12 +354,11 @@ static inline int cellular_get_registration_status(const struct device *dev,
  * @param dev Cellular device
  * @param apn Zero-terminated APN string (max length is driver-specific)
  *
- * @retval 0 if successful.
- * @retval -ENOSYS if API is not supported by cellular network device.
- * @retval -EINVAL if APN string invalid or too long.
- * @retval -EALREADY if APN identical to current one, nothing to do
- * @retval -EBUSY if modem is already dialled, APN cannot be changed
- * @retval <0 Negative errno-code otherwise.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS API is not supported by cellular network device.
+ * @retval -EINVAL APN string invalid or too long.
+ * @retval -EALREADY APN identical to current one, nothing to do.
+ * @retval -EBUSY Modem is already dialled, APN cannot be changed.
  */
 static inline int cellular_set_apn(const struct device *dev, const char *apn)
 {
@@ -385,11 +379,10 @@ static inline int cellular_set_apn(const struct device *dev, const char *apn)
  * @param cb Callback to call when the event occurs, or NULL to unsubscribe
  * @param user_data Pointer to user data that will be passed to the callback
  *
- * @retval 0         Success
- * @retval -ENOSYS   Driver does not support event callbacks
- * @retval -EINVAL   Bad parameters
- * @retval -ENOMEM   No space left for another subscriber
- * @retval <0        Driver-specific error
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS   Driver does not support event callbacks.
+ * @retval -EINVAL   Bad parameters.
+ * @retval -ENOMEM   No space left for another subscriber.
  */
 static inline int cellular_set_callback(const struct device *dev, cellular_event_mask_t mask,
 					cellular_event_cb_t cb, void *user_data)


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458 .

Affected subsystems: adc, biometrics, cache, can, cellular.

Fixes parts of: #65974