### PR TITLE
tests: bsim: bluetooth: audio: migrate printk to logging macros

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_bass_broadcaster_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_bass_broadcaster_test.c
@@ -14,11 +14,13 @@
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(bap_bass_broadcaster_test);
 
 extern enum bst_result_t bst_result;
 
@@ -41,7 +43,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	setup_broadcast_adv(&adv);
 
@@ -54,7 +56,7 @@ static void test_main(void)
 
 	start_broadcast_adv(adv);
 
-	printk("Advertising successfully started\n");
+	LOG_INF("Advertising successfully started");
 
 	k_sleep(K_SECONDS(10));
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -23,7 +23,7 @@
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/net_buf.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -33,6 +33,8 @@
 #include "bap_common.h"
 #include "bstests.h"
 #include <zephyr/syscalls/kernel.h>
+
+LOG_MODULE_REGISTER(bap_broadcast_assistant_test);
 
 #ifdef CONFIG_BT_BAP_BROADCAST_ASSISTANT
 
@@ -86,7 +88,7 @@ static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("BASS discover done with %u recv states\n", recv_state_count);
+	LOG_INF("BASS discover done with %u recv states", recv_state_count);
 	g_recv_state_count = recv_state_count;
 	SET_FLAG(flag_discovery_complete);
 }
@@ -94,10 +96,10 @@ static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
 static void bap_broadcast_assistant_scan_cb(const struct bt_le_scan_recv_info *info,
 				uint32_t broadcast_id)
 {
-	printk("Scan Recv: [DEVICE]: %s, broadcast_id 0x%06X, "
-	       "interval (ms) %u), SID 0x%x, RSSI %i\n",
-	       bt_addr_le_str(info->addr), broadcast_id, info->interval * 5 / 4,
-	       info->sid, info->rssi);
+	LOG_DBG("Scan Recv: [DEVICE]: %s, broadcast_id 0x%06X, "
+		"interval (ms) %u), SID 0x%x, RSSI %i",
+		bt_addr_le_str(info->addr), broadcast_id, info->interval * 5 / 4,
+		info->sid, info->rssi);
 
 	(void)memcpy(&g_broadcaster_info, info, sizeof(g_broadcaster_info));
 	bt_addr_le_copy(&g_broadcaster_addr, info->addr);
@@ -113,8 +115,8 @@ static bool metadata_entry(struct bt_data *data, void *user_data)
 
 	(void)bin2hex(data->data, data->data_len, metadata, sizeof(metadata));
 
-	printk("\t\tMetadata length %u, type %u, data: %s\n",
-	       data->data_len, data->type, metadata);
+	LOG_DBG("\t\tMetadata length %u, type %u, data: %s",
+		data->data_len, data->type, metadata);
 
 	return true;
 }
@@ -138,11 +140,11 @@ static void bap_broadcast_assistant_recv_state_cb(
 	}
 
 	(void)bin2hex(state->bad_code, BT_ISO_BROADCAST_CODE_SIZE, bad_code, sizeof(bad_code));
-	printk("BASS recv state: src_id %u, addr %s, sid %u, sync_state %u, encrypt_state %u%s%s\n",
-	       state->src_id, bt_addr_le_str(&state->addr), state->adv_sid, state->pa_sync_state,
-	       state->encrypt_state,
-	       state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE ? ", bad code: " : "",
-	       state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE ? bad_code : "");
+	LOG_DBG("BASS recv state: src_id %u, addr %s, sid %u, sync_state %u, encrypt_state %u%s%s",
+		state->src_id, bt_addr_le_str(&state->addr), state->adv_sid, state->pa_sync_state,
+		state->encrypt_state,
+		state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE ? ", bad code: " : "",
+		state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE ? bad_code : "");
 
 	if (state->encrypt_state == BT_BAP_BIG_ENC_STATE_BCODE_REQ) {
 		SET_FLAG(flag_broadcast_code_requested);
@@ -169,8 +171,8 @@ static void bap_broadcast_assistant_recv_state_cb(
 		const struct bt_bap_bass_subgroup *subgroup = &state->subgroups[i];
 		struct net_buf_simple buf;
 
-		printk("\t[%d]: BIS sync %u, metadata_len %u\n",
-		       i, subgroup->bis_sync, subgroup->metadata_len);
+		LOG_DBG("\t[%d]: BIS sync %u, metadata_len %u",
+			i, subgroup->bis_sync, subgroup->metadata_len);
 
 		net_buf_simple_init_with_data(&buf, (void *)subgroup->metadata,
 					      subgroup->metadata_len);
@@ -183,7 +185,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 
 #if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)
 	if (state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
-		printk("Sending PAST %p to %p\n", g_pa_sync, conn);
+		LOG_INF("Sending PAST %p to %p", g_pa_sync, conn);
 		err = bt_le_per_adv_sync_transfer(g_pa_sync, conn,
 						  BT_UUID_BASS_VAL);
 		if (err != 0) {
@@ -202,7 +204,7 @@ static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, 
 {
 	ARG_UNUSED(conn);
 
-	printk("BASS recv state %u removed\n", src_id);
+	LOG_INF("BASS recv state %u removed", src_id);
 	SET_FLAG(flag_cb_called);
 
 	SET_FLAG(flag_recv_state_removed);
@@ -217,7 +219,7 @@ static void bap_broadcast_assistant_scan_start_cb(struct bt_conn *conn, int err)
 		return;
 	}
 
-	printk("BASS scan start successful\n");
+	LOG_INF("BASS scan start successful");
 	SET_FLAG(flag_write_complete);
 }
 
@@ -230,7 +232,7 @@ static void bap_broadcast_assistant_scan_stop_cb(struct bt_conn *conn, int err)
 		return;
 	}
 
-	printk("BASS scan stop successful\n");
+	LOG_INF("BASS scan stop successful");
 	SET_FLAG(flag_write_complete);
 }
 
@@ -243,7 +245,7 @@ static void bap_broadcast_assistant_add_src_cb(struct bt_conn *conn, int err)
 		return;
 	}
 
-	printk("BASS add source successful\n");
+	LOG_INF("BASS add source successful");
 	SET_FLAG(flag_write_complete);
 }
 
@@ -256,7 +258,7 @@ static void bap_broadcast_assistant_mod_src_cb(struct bt_conn *conn, int err)
 		return;
 	}
 
-	printk("BASS modify source successful\n");
+	LOG_INF("BASS modify source successful");
 	SET_FLAG(flag_write_complete);
 }
 
@@ -269,7 +271,7 @@ static void bap_broadcast_assistant_broadcast_code_cb(struct bt_conn *conn, int 
 		return;
 	}
 
-	printk("BASS broadcast code successful\n");
+	LOG_INF("BASS broadcast code successful");
 	SET_FLAG(flag_write_complete);
 }
 
@@ -282,7 +284,7 @@ static void bap_broadcast_assistant_rem_src_cb(struct bt_conn *conn, int err)
 	if (err != 0) {
 		if (err == BT_ATT_ERR_WRITE_REQ_REJECTED) {
 			SET_FLAG(flag_remove_source_rejected);
-			printk("Remove source rejected (expected): err=%d\n", err);
+			LOG_INF("Remove source rejected (expected): err=%d", err);
 			return;
 		}
 
@@ -290,7 +292,7 @@ static void bap_broadcast_assistant_rem_src_cb(struct bt_conn *conn, int err)
 		return;
 	}
 
-	printk("BASS remove source successful\n");
+	LOG_INF("BASS remove source successful");
 	SET_FLAG(flag_write_complete);
 }
 
@@ -323,10 +325,10 @@ static struct bt_gatt_cb gatt_callbacks = {
 static void sync_cb(struct bt_le_per_adv_sync *sync,
 		    struct bt_le_per_adv_sync_synced_info *info)
 {
-	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
-	       "Interval 0x%04x (%u ms), PHY %s\n",
-	       bt_le_per_adv_sync_get_index(sync), bt_addr_le_str(info->addr), info->interval,
-	       info->interval * 5 / 4, phy2str(info->phy));
+	LOG_INF("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
+		"Interval 0x%04x (%u ms), PHY %s",
+		bt_le_per_adv_sync_get_index(sync), bt_addr_le_str(info->addr), info->interval,
+		info->interval * 5 / 4, phy2str(info->phy));
 
 	SET_FLAG(flag_pa_synced);
 }
@@ -334,8 +336,8 @@ static void sync_cb(struct bt_le_per_adv_sync *sync,
 static void term_cb(struct bt_le_per_adv_sync *sync,
 		    const struct bt_le_per_adv_sync_term_info *info)
 {
-	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
-	       bt_le_per_adv_sync_get_index(sync), bt_addr_le_str(info->addr));
+	LOG_INF("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated",
+		bt_le_per_adv_sync_get_index(sync), bt_addr_le_str(info->addr));
 
 	SET_FLAG(flag_pa_terminated);
 }
@@ -348,7 +350,7 @@ static struct bt_le_per_adv_sync_cb sync_callbacks = {
 static void test_exchange_mtu(void)
 {
 	WAIT_FOR_FLAG(flag_mtu_exchanged);
-	printk("MTU exchanged\n");
+	LOG_INF("MTU exchanged");
 }
 
 static void update_conn_params(void)
@@ -378,7 +380,7 @@ static void test_bass_discover(void)
 {
 	int err;
 
-	printk("Discovering BASS\n");
+	LOG_INF("Discovering BASS");
 	UNSET_FLAG(flag_discovery_complete);
 	err = bt_bap_broadcast_assistant_discover(default_conn);
 	if (err != 0) {
@@ -397,7 +399,7 @@ static void test_bass_discover(void)
 	}
 
 	WAIT_FOR_FLAG(flag_discovery_complete);
-	printk("Discovery complete\n");
+	LOG_INF("Discovery complete");
 }
 
 static void test_bass_read_receive_states(void)
@@ -416,14 +418,14 @@ static void test_bass_read_receive_states(void)
 		WAIT_FOR_FLAG(flag_recv_state_read);
 	}
 
-	printk("Receive state read complete\n");
+	LOG_INF("Receive state read complete");
 }
 
 static void test_bass_scan_start(void)
 {
 	int err;
 
-	printk("Starting scan\n");
+	LOG_INF("Starting scan");
 	UNSET_FLAG(flag_write_complete);
 	err = bt_bap_broadcast_assistant_scan_start(default_conn, true);
 	if (err != 0) {
@@ -433,14 +435,14 @@ static void test_bass_scan_start(void)
 
 	WAIT_FOR_FLAG(flag_write_complete);
 	WAIT_FOR_FLAG(flag_broadcaster_found);
-	printk("Scan started\n");
+	LOG_INF("Scan started");
 }
 
 static void test_bass_scan_stop(void)
 {
 	int err;
 
-	printk("Stopping scan\n");
+	LOG_INF("Stopping scan");
 	UNSET_FLAG(flag_write_complete);
 	err = bt_bap_broadcast_assistant_scan_stop(default_conn);
 	if (err != 0) {
@@ -449,7 +451,7 @@ static void test_bass_scan_stop(void)
 	}
 
 	WAIT_FOR_FLAG(flag_write_complete);
-	printk("Scan stopped\n");
+	LOG_INF("Scan stopped");
 }
 
 static void test_bass_create_pa_sync(void)
@@ -457,7 +459,7 @@ static void test_bass_create_pa_sync(void)
 	int err;
 	struct bt_le_per_adv_sync_param sync_create_param = { 0 };
 
-	printk("Creating Periodic Advertising Sync...\n");
+	LOG_INF("Creating Periodic Advertising Sync...");
 	bt_addr_le_copy(&sync_create_param.addr, &g_broadcaster_addr);
 	sync_create_param.sid = g_broadcaster_info.sid;
 	sync_create_param.timeout = 0xa;
@@ -468,7 +470,7 @@ static void test_bass_create_pa_sync(void)
 	}
 
 	WAIT_FOR_FLAG(flag_pa_synced);
-	printk("PA synced\n");
+	LOG_INF("PA synced");
 }
 
 static void test_bass_add_source(void)
@@ -477,7 +479,7 @@ static void test_bass_add_source(void)
 	struct bt_bap_broadcast_assistant_add_src_param add_src_param = { 0 };
 	struct bt_bap_bass_subgroup subgroup = { 0 };
 
-	printk("Adding source\n");
+	LOG_INF("Adding source");
 	UNSET_FLAG(flag_write_complete);
 	UNSET_FLAG(flag_cb_called);
 	bt_addr_le_copy(&add_src_param.addr, &g_broadcaster_addr);
@@ -532,7 +534,7 @@ static void test_bass_add_source(void)
 	WAIT_FOR_FLAG(flag_cb_called);
 	WAIT_FOR_FLAG(flag_write_complete);
 
-	printk("Source added\n");
+	LOG_INF("Source added");
 }
 
 static void test_bass_mod_source(bool pa_sync, uint32_t bis_sync)
@@ -542,7 +544,7 @@ static void test_bass_mod_source(bool pa_sync, uint32_t bis_sync)
 	struct bt_bap_bass_subgroup subgroup = {0};
 	uint32_t remote_bis_sync;
 
-	printk("Modify source\n");
+	LOG_INF("Modify source");
 	UNSET_FLAG(flag_cb_called);
 	UNSET_FLAG(flag_write_complete);
 	UNSET_FLAG(flag_recv_state_updated);
@@ -564,14 +566,14 @@ static void test_bass_mod_source(bool pa_sync, uint32_t bis_sync)
 	}
 
 	if (recv_state.pa_sync_state == BT_BAP_PA_STATE_NOT_SYNCED) {
-		printk("Source modified, waiting for server to PA sync\n");
+		LOG_INF("Source modified, waiting for server to PA sync");
 
 		WAIT_FOR_AND_CLEAR_FLAG(flag_recv_state_updated);
 	}
 
 	if (recv_state.pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
 		/* Wait for PAST to finish and then a new receive state */
-		printk("Waiting for PAST sync\n");
+		LOG_INF("Waiting for PAST sync");
 		WAIT_FOR_AND_CLEAR_FLAG(flag_recv_state_updated);
 	}
 
@@ -594,13 +596,13 @@ static void test_bass_mod_source(bool pa_sync, uint32_t bis_sync)
 
 	/* Wait for another notification that updates the metadata of the subgroups */
 	if (recv_state.subgroups[0].metadata_len == 0U) {
-		printk("Waiting for another receive state update with metadata\n");
+		LOG_INF("Waiting for another receive state update with metadata");
 		WAIT_FOR_AND_CLEAR_FLAG(flag_recv_state_updated);
 	}
 
 	if (bis_sync != 0) {
 		remote_bis_sync = recv_state.subgroups[0].bis_sync;
-		printk("Waiting for BIS sync\n");
+		LOG_INF("Waiting for BIS sync");
 
 		if (remote_bis_sync == 0U &&
 		    recv_state.encrypt_state == BT_BAP_BIG_ENC_STATE_NO_ENC) {
@@ -608,19 +610,19 @@ static void test_bass_mod_source(bool pa_sync, uint32_t bis_sync)
 			 * broadcast code for encrypted broadcasts, or have the BIS sync
 			 * values set
 			 */
-			printk("Waiting for another receive state update with BIS sync\n");
+			LOG_INF("Waiting for another receive state update with BIS sync");
 			WAIT_FOR_AND_CLEAR_FLAG(flag_recv_state_updated);
 			remote_bis_sync = recv_state.subgroups[0].bis_sync;
 		}
 
 		if (recv_state.encrypt_state == BT_BAP_BIG_ENC_STATE_BCODE_REQ) {
-			printk("Remote is requesting broadcast code\n");
+			LOG_INF("Remote is requesting broadcast code");
 			if (remote_bis_sync != 0U) {
 				FAIL("Unexpected BIS sync value: %u", remote_bis_sync);
 				return;
 			}
 		} else if (recv_state.encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE) {
-			printk("Remote responded with bad code\n");
+			LOG_INF("Remote responded with bad code");
 			if (remote_bis_sync != 0U) {
 				FAIL("Unexpected BIS sync value: %u", remote_bis_sync);
 				return;
@@ -637,7 +639,7 @@ static void test_bass_mod_source(bool pa_sync, uint32_t bis_sync)
 
 	WAIT_FOR_FLAG(flag_cb_called);
 	WAIT_FOR_FLAG(flag_write_complete);
-	printk("Source modified\n");
+	LOG_INF("Source modified");
 }
 
 static void test_bass_mod_source_long_meta(void)
@@ -647,7 +649,7 @@ static void test_bass_mod_source_long_meta(void)
 	struct bt_bap_bass_subgroup subgroup = { 0 };
 	uint32_t remote_bis_sync;
 
-	printk("Long write\n");
+	LOG_INF("Long write");
 	UNSET_FLAG(flag_cb_called);
 	UNSET_FLAG(flag_write_complete);
 	UNSET_FLAG(flag_recv_state_updated);
@@ -665,7 +667,7 @@ static void test_bass_mod_source_long_meta(void)
 		FAIL("Could not modify source (err %d)\n", err);
 		return;
 	}
-	printk("Source modified, waiting for receive state\n");
+	LOG_INF("Source modified, waiting for receive state");
 
 	WAIT_FOR_FLAG(flag_recv_state_updated);
 
@@ -699,14 +701,14 @@ static void test_bass_mod_source_long_meta(void)
 
 	WAIT_FOR_FLAG(flag_cb_called);
 	WAIT_FOR_FLAG(flag_write_complete);
-	printk("Source modified with long meta\n");
+	LOG_INF("Source modified with long meta");
 }
 
 static void test_bass_broadcast_code(const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	int err;
 
-	printk("Adding broadcast code\n");
+	LOG_INF("Adding broadcast code");
 	UNSET_FLAG(flag_write_complete);
 
 	do {
@@ -721,14 +723,14 @@ static void test_bass_broadcast_code(const uint8_t broadcast_code[BT_ISO_BROADCA
 	} while (err == -EBUSY);
 
 	WAIT_FOR_FLAG(flag_write_complete);
-	printk("Broadcast code added\n");
+	LOG_INF("Broadcast code added");
 }
 
 static void test_bass_remove_source(void)
 {
 	int err;
 
-	printk("Removing source\n");
+	LOG_INF("Removing source");
 	UNSET_FLAG(flag_cb_called);
 	UNSET_FLAG(flag_write_complete);
 	UNSET_FLAG(flag_remove_source_cb_called);
@@ -744,13 +746,13 @@ static void test_bass_remove_source(void)
 	WAIT_FOR_FLAG(flag_remove_source_cb_called);
 
 	if (TEST_FLAG(flag_remove_source_rejected)) {
-		printk("Remove source was rejected as expected\n");
+		LOG_INF("Remove source was rejected as expected");
 		return;
 	}
 
 	WAIT_FOR_FLAG(flag_cb_called);
 	WAIT_FOR_FLAG(flag_write_complete);
-	printk("Source removed\n");
+	LOG_INF("Source removed");
 }
 
 static int common_init(void)
@@ -769,14 +771,14 @@ static int common_init(void)
 	bt_le_per_adv_sync_cb_register(&sync_callbacks);
 	bt_le_scan_cb_register(&common_scan_cb);
 
-	printk("Starting scan\n");
+	LOG_INF("Starting scan");
 	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
 	if (err != 0) {
 		FAIL("Scanning failed to start (err %d)\n", err);
 		return err;
 	}
 
-	printk("Scanning successfully started\n");
+	LOG_INF("Scanning successfully started");
 
 	WAIT_FOR_FLAG(flag_connected);
 
@@ -832,7 +834,7 @@ static void test_main_client_sync(void)
 	test_bass_mod_source(true, BT_ISO_BIS_INDEX_BIT(1U) | BT_ISO_BIS_INDEX_BIT(2U));
 	test_bass_broadcast_code(BROADCAST_CODE);
 
-	printk("Waiting for receive state with BIS sync\n");
+	LOG_INF("Waiting for receive state with BIS sync");
 	WAIT_FOR_FLAG(flag_recv_state_updated_with_bis_sync);
 
 	test_bass_mod_source(false, 0);
@@ -892,15 +894,15 @@ static void test_main_server_sync_client_rem(void)
 
 	test_bass_broadcast_code(BROADCAST_CODE);
 
-	printk("Waiting for receive state with BIS sync\n");
+	LOG_INF("Waiting for receive state with BIS sync");
 	WAIT_FOR_FLAG(flag_recv_state_updated_with_bis_sync);
 
-	printk("Attempting to remove source for the first time\n");
+	LOG_INF("Attempting to remove source for the first time");
 	test_bass_mod_source(false, 0);
 	test_bass_remove_source();
 
 	WAIT_FOR_FLAG(flag_remove_source_rejected);
-	printk("First remove source attempt was rejected as expected\n");
+	LOG_INF("First remove source attempt was rejected as expected");
 
 	test_bass_remove_source();
 
@@ -927,7 +929,7 @@ static void test_main_server_sync_server_rem(void)
 
 	test_bass_broadcast_code(BROADCAST_CODE);
 
-	printk("Waiting for receive state with BIS sync\n");
+	LOG_INF("Waiting for receive state with BIS sync");
 	WAIT_FOR_FLAG(flag_recv_state_updated_with_bis_sync);
 
 	WAIT_FOR_FLAG(flag_recv_state_removed);

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -27,7 +27,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -36,6 +36,8 @@
 #include "bap_stream_rx.h"
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(bap_broadcast_sink_test);
 
 #if defined(CONFIG_BT_BAP_BROADCAST_SINK)
 extern enum bst_result_t bst_result;
@@ -104,7 +106,7 @@ static bool valid_base_subgroup(const struct bt_bap_base_subgroup *subgroup)
 
 	ret = bt_bap_base_subgroup_codec_to_codec_cfg(subgroup, &codec_cfg);
 	if (ret < 0) {
-		printk("Could not get subgroup codec_cfg: %d\n", ret);
+		LOG_ERR("Could not get subgroup codec_cfg: %d", ret);
 
 		return false;
 	}
@@ -118,12 +120,12 @@ static bool valid_base_subgroup(const struct bt_bap_base_subgroup *subgroup)
 		const int freq = bt_audio_codec_cfg_freq_to_freq_hz(ret);
 
 		if (freq < 0) {
-			printk("Invalid subgroup frequency value: %d (%d)\n", ret, freq);
+			LOG_ERR("Invalid subgroup frequency value: %d (%d)", ret, freq);
 
 			return false;
 		}
 	} else {
-		printk("Could not get subgroup frequency: %d\n", ret);
+		LOG_ERR("Could not get subgroup frequency: %d", ret);
 
 		return false;
 	}
@@ -133,13 +135,13 @@ static bool valid_base_subgroup(const struct bt_bap_base_subgroup *subgroup)
 		const int frame_duration_us = bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret);
 
 		if (frame_duration_us < 0) {
-			printk("Invalid subgroup frame duration value: %d (%d)\n", ret,
-			       frame_duration_us);
+			LOG_ERR("Invalid subgroup frame duration value: %d (%d)", ret,
+				frame_duration_us);
 
 			return false;
 		}
 	} else {
-		printk("Could not get subgroup frame duration: %d\n", ret);
+		LOG_ERR("Could not get subgroup frame duration: %d", ret);
 
 		return false;
 	}
@@ -148,13 +150,13 @@ static bool valid_base_subgroup(const struct bt_bap_base_subgroup *subgroup)
 	if (ret == 0) {
 		chan_cnt = bt_audio_get_chan_count(chan_allocation);
 	} else {
-		FAIL("Could not get subgroup channel allocation: %d\n", ret);
+		LOG_ERR("Could not get subgroup channel allocation: %d", ret);
 
 		return false;
 	}
 
 	if (chan_cnt == 0U || (BIT(chan_cnt - 1U) & SUPPORTED_CHAN_COUNTS) == 0U) {
-		printk("Unsupported channel count: %u\n", chan_cnt);
+		LOG_ERR("Unsupported channel count: %u", chan_cnt);
 
 		return false;
 	}
@@ -163,14 +165,14 @@ static bool valid_base_subgroup(const struct bt_bap_base_subgroup *subgroup)
 	if (ret > 0) {
 		octets_per_frame = (uint16_t)ret;
 	} else {
-		printk("Could not get subgroup octets per frame: %d\n", ret);
+		LOG_ERR("Could not get subgroup octets per frame: %d", ret);
 
 		return false;
 	}
 
 	if (!IN_RANGE(octets_per_frame, SUPPORTED_MIN_OCTETS_PER_FRAME,
 		      SUPPORTED_MAX_OCTETS_PER_FRAME)) {
-		printk("Unsupported octets per frame: %u\n", octets_per_frame);
+		LOG_ERR("Unsupported octets per frame: %u", octets_per_frame);
 
 		return false;
 	}
@@ -179,7 +181,7 @@ static bool valid_base_subgroup(const struct bt_bap_base_subgroup *subgroup)
 	if (ret > 0) {
 		frames_blocks_per_sdu = (uint8_t)ret;
 	} else {
-		FAIL("Could not get frame blocks per SDU: %d\n", ret);
+		LOG_ERR("Could not get frame blocks per SDU: %d", ret);
 
 		return false;
 	}
@@ -189,10 +191,10 @@ static bool valid_base_subgroup(const struct bt_bap_base_subgroup *subgroup)
 	 */
 	min_sdu_size_required = chan_cnt * octets_per_frame * frames_blocks_per_sdu;
 	if (min_sdu_size_required > SUPPORTED_MAX_SDU_SIZE) {
-		printk("With %zu channels and %u octets per frame and %u frames per block, SDUs "
-		       "shall be at minimum %zu, we only support %d\n",
-		       chan_cnt, octets_per_frame, frames_blocks_per_sdu, min_sdu_size_required,
-		       SUPPORTED_MAX_SDU_SIZE);
+		LOG_ERR("With %zu channels and %u octets per frame and %u frames per block, SDUs "
+			"shall be at minimum %zu, we only support %d",
+			chan_cnt, octets_per_frame, frames_blocks_per_sdu, min_sdu_size_required,
+			SUPPORTED_MAX_SDU_SIZE);
 
 		return false;
 	}
@@ -211,13 +213,13 @@ static bool base_subgroup_cb(const struct bt_bap_base_subgroup *subgroup, void *
 
 	ret = bt_bap_base_get_subgroup_codec_meta(subgroup, &meta);
 	if (ret < 0) {
-		FAIL("Could not get subgroup meta: %d\n", ret);
+		LOG_ERR("Could not get subgroup meta: %d", ret);
 		return false;
 	}
 
 	if (TEST_FLAG(flag_base_received) &&
 	    ((size_t)ret != metadata_size || memcmp(meta, metadata, metadata_size) != 0)) {
-		printk("Metadata updated\n");
+		LOG_INF("Metadata updated");
 		SET_FLAG(flag_base_metadata_updated);
 	}
 
@@ -225,7 +227,7 @@ static bool base_subgroup_cb(const struct bt_bap_base_subgroup *subgroup, void *
 	(void)memcpy(metadata, meta, metadata_size);
 
 	if (!valid_base_subgroup(subgroup)) {
-		printk("Invalid or unsupported subgroup\n");
+		LOG_ERR("Invalid or unsupported subgroup");
 		return false;
 	}
 
@@ -240,8 +242,8 @@ static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap
 
 	ARG_UNUSED(base_size);
 
-	printk("Received BASE with %d subgroups from broadcast sink %p\n",
-	       bt_bap_base_get_subgroup_count(base), sink);
+	LOG_INF("Received BASE with %d subgroups from broadcast sink %p",
+		bt_bap_base_get_subgroup_count(base), sink);
 
 	ret = bt_bap_base_foreach_subgroup(base, base_subgroup_cb, NULL);
 	if (ret != 0) {
@@ -273,20 +275,20 @@ static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap
 
 static void syncable_cb(struct bt_bap_broadcast_sink *sink, const struct bt_iso_biginfo *biginfo)
 {
-	printk("Broadcast sink %p syncable with%s encryption\n",
-	       sink, biginfo->encryption ? "" : "out");
+	LOG_INF("Broadcast sink %p syncable with%s encryption",
+		sink, biginfo->encryption ? "" : "out");
 	SET_FLAG(flag_syncable);
 }
 
 static void broadcast_sink_started_cb(struct bt_bap_broadcast_sink *sink)
 {
-	printk("Broadcast sink %p started\n", sink);
+	LOG_INF("Broadcast sink %p started", sink);
 	SET_FLAG(flag_sink_started);
 }
 
 static void broadcast_sink_stopped_cb(struct bt_bap_broadcast_sink *sink, uint8_t reason)
 {
-	printk("Broadcast sink %p stopped with reason 0x%02X\n", sink, reason);
+	LOG_INF("Broadcast sink %p stopped with reason 0x%02X", sink, reason);
 	UNSET_FLAG(flag_sink_started);
 
 	if (reason == BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL) {
@@ -330,8 +332,8 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 
 	broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
 
-	printk("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X\n", broadcast_id,
-	       bt_addr_le_str(info->addr), info->sid);
+	LOG_INF("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X", broadcast_id,
+		bt_addr_le_str(info->addr), info->sid);
 
 	SET_FLAG(flag_broadcaster_found);
 
@@ -361,8 +363,8 @@ static void bap_pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 	ARG_UNUSED(info);
 
 	if (sync == pa_sync) {
-		printk("PA sync %p synced for broadcast sink with broadcast ID 0x%06X\n", sync,
-		       broadcaster_broadcast_id);
+		LOG_INF("PA sync %p synced for broadcast sink with broadcast ID 0x%06X", sync,
+			broadcaster_broadcast_id);
 
 		SET_FLAG(flag_pa_synced);
 	}
@@ -372,7 +374,7 @@ static void bap_pa_sync_terminated_cb(struct bt_le_per_adv_sync *sync,
 				      const struct bt_le_per_adv_sync_term_info *info)
 {
 	if (sync == pa_sync) {
-		printk("PA sync %p lost with reason %u\n", sync, info->reason);
+		LOG_INF("PA sync %p lost with reason %u", sync, info->reason);
 		pa_sync = NULL;
 
 		SET_FLAG(flag_pa_sync_lost);
@@ -430,7 +432,7 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 
 	req_recv_state = recv_state;
 
-	printk("BIS sync request received for %p: 0x%08x\n", recv_state, bis_sync_req[0]);
+	LOG_INF("BIS sync request received for %p: 0x%08x", recv_state, bis_sync_req[0]);
 	/* We only care about a single subgroup in this test */
 	requested_bis_sync = bis_sync_req[0];
 	broadcaster_broadcast_id = recv_state->broadcast_id;
@@ -458,7 +460,7 @@ static void scanning_state_cb(struct bt_conn *conn, bool is_scanning)
 {
 	ARG_UNUSED(conn);
 
-	printk("Assistant scanning %s\n", is_scanning ? "started" : "stopped");
+	LOG_INF("Assistant scanning %s", is_scanning ? "started" : "stopped");
 
 }
 
@@ -626,7 +628,7 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 		return;
 	}
 
-	printk("Stream %p started\n", stream);
+	LOG_INF("Stream %p started", stream);
 	k_sem_give(&sem_stream_started);
 
 	validate_stream_codec_cfg(stream);
@@ -634,7 +636,7 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 
 static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
-	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stream %p stopped with reason 0x%02X", stream, reason);
 	k_sem_give(&sem_stream_stopped);
 }
 
@@ -666,7 +668,7 @@ static int init(void)
 		return err;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	err = bt_pacs_register(&pacs_param);
 	if (err != 0) {
@@ -749,7 +751,7 @@ static void test_scan_and_pa_sync(void)
 {
 	int err;
 
-	printk("Scanning for broadcast sources\n");
+	LOG_INF("Scanning for broadcast sources");
 	err = bt_le_scan_start(BT_LE_SCAN_ACTIVE, NULL);
 	if (err != 0) {
 		FAIL("Unable to start scan for broadcast sources: %d", err);
@@ -758,22 +760,22 @@ static void test_scan_and_pa_sync(void)
 
 	WAIT_FOR_FLAG(flag_broadcaster_found);
 
-	printk("Broadcast source found, stopping scan\n");
+	LOG_INF("Broadcast source found, stopping scan");
 	err = bt_le_scan_stop();
 	if (err != 0) {
 		FAIL("bt_le_scan_stop failed with %d\n", err);
 		return;
 	}
 
-	printk("Scan stopped, attempting to PA sync to the broadcaster with id 0x%06X\n",
-	       broadcaster_broadcast_id);
+	LOG_INF("Scan stopped, attempting to PA sync to the broadcaster with id 0x%06X",
+		broadcaster_broadcast_id);
 	err = pa_sync_create();
 	if (err != 0) {
 		FAIL("Could not create Broadcast PA sync: %d\n", err);
 		return;
 	}
 
-	printk("Waiting for PA sync\n");
+	LOG_INF("Waiting for PA sync");
 	WAIT_FOR_FLAG(flag_pa_synced);
 }
 
@@ -781,14 +783,14 @@ static void test_broadcast_sink_create(void)
 {
 	int err;
 
-	printk("Creating the broadcast sink\n");
+	LOG_INF("Creating the broadcast sink");
 	err = bt_bap_broadcast_sink_create(pa_sync, broadcaster_broadcast_id, &g_sink);
 	if (err != 0) {
 		FAIL("Unable to create the sink: %d\n", err);
 		return;
 	}
 
-	printk("Created broadcast sink %p\n", g_sink);
+	LOG_INF("Created broadcast sink %p", g_sink);
 }
 
 static void test_broadcast_sink_create_inval(void)
@@ -818,7 +820,7 @@ static void test_broadcast_sync(const uint8_t broadcast_code[BT_ISO_BROADCAST_CO
 {
 	int err;
 
-	printk("Syncing sink %p to 0x%08x\n", g_sink, bis_index_bitfield);
+	LOG_INF("Syncing sink %p to 0x%08x", g_sink, bis_index_bitfield);
 	err = bt_bap_broadcast_sink_sync(g_sink, bis_index_bitfield, streams, broadcast_code);
 	if (err != 0) {
 		FAIL("Unable to sync the sink: %d\n", err);
@@ -892,7 +894,7 @@ static void test_broadcast_stop(void)
 {
 	int err;
 
-	printk("Stopping broadcast sink %p\n", g_sink);
+	LOG_INF("Stopping broadcast sink %p", g_sink);
 
 	err = bt_bap_broadcast_sink_stop(g_sink);
 	if (err != 0) {
@@ -900,7 +902,7 @@ static void test_broadcast_stop(void)
 		return;
 	}
 
-	printk("Waiting for %zu streams to be stopped\n", stream_sync_cnt);
+	LOG_INF("Waiting for %zu streams to be stopped", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
 		err = k_sem_take(&sem_stream_stopped, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
@@ -947,13 +949,13 @@ static void test_broadcast_delete_inval(void)
 
 static void wait_for_data(void)
 {
-	printk("Waiting for data\n");
+	LOG_INF("Waiting for data");
 	ARRAY_FOR_EACH_PTR(broadcast_sink_streams, test_stream) {
 		if (audio_test_stream_is_streaming(test_stream)) {
 			WAIT_FOR_FLAG(test_stream->flag_audio_received);
 		}
 	}
-	printk("Data received\n");
+	LOG_INF("Data received");
 }
 
 static void test_common(void)
@@ -971,11 +973,11 @@ static void test_common(void)
 	test_broadcast_sink_create_inval();
 	test_broadcast_sink_create();
 
-	printk("Broadcast source PA synced, waiting for BASE\n");
+	LOG_INF("Broadcast source PA synced, waiting for BASE");
 	WAIT_FOR_FLAG(flag_base_received);
-	printk("BASE received\n");
+	LOG_INF("BASE received");
 
-	printk("Waiting for BIG syncable\n");
+	LOG_INF("Waiting for BIG syncable");
 	WAIT_FOR_FLAG(flag_syncable);
 
 	test_broadcast_sync_inval();
@@ -984,7 +986,7 @@ static void test_common(void)
 	WAIT_FOR_FLAG(flag_sink_started);
 
 	/* Wait for all to be started */
-	printk("Waiting for %zu streams to be started\n", stream_sync_cnt);
+	LOG_INF("Waiting for %zu streams to be started", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
 		err = k_sem_take(&sem_stream_started, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
@@ -1004,10 +1006,10 @@ static void test_main(void)
 	 * and depend on timeout parameters. We just wait for PA first, but
 	 * either way will work.
 	 */
-	printk("Waiting for PA disconnected\n");
+	LOG_INF("Waiting for PA disconnected");
 	WAIT_FOR_FLAG(flag_pa_sync_lost);
 
-	printk("Waiting for %zu streams to be stopped\n", stream_sync_cnt);
+	LOG_INF("Waiting for %zu streams to be stopped", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
 		__maybe_unused int err;
 
@@ -1024,7 +1026,7 @@ static void test_main_update(void)
 	test_common();
 
 	/* Ensure that we also see the metadata update */
-	printk("Waiting for metadata update\n");
+	LOG_INF("Waiting for metadata update");
 	WAIT_FOR_FLAG(flag_base_metadata_updated)
 
 	backchannel_sync_send_all(); /* let other devices know we have received what we wanted */
@@ -1035,10 +1037,10 @@ static void test_main_update(void)
 	 * and depend on timeout parameters. We just wait for PA first, but
 	 * either way will work.
 	 */
-	printk("Waiting for PA disconnected\n");
+	LOG_INF("Waiting for PA disconnected");
 	WAIT_FOR_FLAG(flag_pa_sync_lost);
 
-	printk("Waiting for %zu streams to be stopped\n", stream_sync_cnt);
+	LOG_INF("Waiting for %zu streams to be stopped", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
 		__maybe_unused int err = k_sem_take(&sem_stream_stopped, K_FOREVER);
 
@@ -1062,7 +1064,7 @@ static void test_sink_disconnect(void)
 	WAIT_FOR_FLAG(flag_sink_started);
 
 	/* Wait for all to be started */
-	printk("Waiting for %zu streams to be started\n", stream_sync_cnt);
+	LOG_INF("Waiting for %zu streams to be started", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
 		__maybe_unused int err = k_sem_take(&sem_stream_started, K_FOREVER);
 
@@ -1093,11 +1095,11 @@ static void test_sink_encrypted(void)
 
 	test_broadcast_sink_create();
 
-	printk("Broadcast source PA synced, waiting for BASE\n");
+	LOG_INF("Broadcast source PA synced, waiting for BASE");
 	WAIT_FOR_FLAG(flag_base_received);
-	printk("BASE received\n");
+	LOG_INF("BASE received");
 
-	printk("Waiting for BIG syncable\n");
+	LOG_INF("Waiting for BIG syncable");
 	WAIT_FOR_FLAG(flag_syncable);
 
 	test_broadcast_sync(BROADCAST_CODE);
@@ -1105,7 +1107,7 @@ static void test_sink_encrypted(void)
 	WAIT_FOR_FLAG(flag_sink_started);
 
 	/* Wait for all to be started */
-	printk("Waiting for %zu streams to be started\n", stream_sync_cnt);
+	LOG_INF("Waiting for %zu streams to be started", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
 		err = k_sem_take(&sem_stream_started, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
@@ -1121,10 +1123,10 @@ static void test_sink_encrypted(void)
 	 * and depend on timeout parameters. We just wait for PA first, but
 	 * either way will work.
 	 */
-	printk("Waiting for PA disconnected\n");
+	LOG_INF("Waiting for PA disconnected");
 	WAIT_FOR_FLAG(flag_pa_sync_lost);
 
-	printk("Waiting for %zu streams to be stopped\n", stream_sync_cnt);
+	LOG_INF("Waiting for %zu streams to be stopped", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
 		err = k_sem_take(&sem_stream_stopped, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
@@ -1147,11 +1149,11 @@ static void test_sink_encrypted_incorrect_code(void)
 
 	test_broadcast_sink_create();
 
-	printk("Broadcast source PA synced, waiting for BASE\n");
+	LOG_INF("Broadcast source PA synced, waiting for BASE");
 	WAIT_FOR_FLAG(flag_base_received);
-	printk("BASE received\n");
+	LOG_INF("BASE received");
 
-	printk("Waiting for BIG syncable\n");
+	LOG_INF("Waiting for BIG syncable");
 	WAIT_FOR_FLAG(flag_syncable);
 
 	test_broadcast_sync(INCORRECT_BROADCAST_CODE);
@@ -1161,7 +1163,7 @@ static void test_sink_encrypted_incorrect_code(void)
 	test_broadcast_sync(BROADCAST_CODE);
 
 	/* Wait for all to be started */
-	printk("Waiting for %zu streams to be started\n", stream_sync_cnt);
+	LOG_INF("Waiting for %zu streams to be started", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
 		err = k_sem_take(&sem_stream_started, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
@@ -1189,27 +1191,27 @@ static void broadcast_sink_with_assistant(void)
 	setup_connectable_adv(&ext_adv);
 	WAIT_FOR_FLAG(flag_connected);
 
-	printk("Waiting for PA sync request\n");
+	LOG_INF("Waiting for PA sync request");
 	WAIT_FOR_FLAG(flag_pa_request);
 
 	test_scan_and_pa_sync();
 	test_broadcast_sink_create();
 
-	printk("Broadcast source PA synced, waiting for BASE\n");
+	LOG_INF("Broadcast source PA synced, waiting for BASE");
 	WAIT_FOR_FLAG(flag_base_received);
-	printk("BASE received\n");
+	LOG_INF("BASE received");
 
-	printk("Waiting for BIG syncable\n");
+	LOG_INF("Waiting for BIG syncable");
 	WAIT_FOR_FLAG(flag_syncable);
 
-	printk("Waiting for BIG sync request\n");
+	LOG_INF("Waiting for BIG sync request");
 	WAIT_FOR_FLAG(flag_bis_sync_requested);
 	test_broadcast_sync(NULL);
 
 	WAIT_FOR_FLAG(flag_sink_started);
 
 	/* Wait for all to be started */
-	printk("Waiting for %zu streams to be started\n", stream_sync_cnt);
+	LOG_INF("Waiting for %zu streams to be started", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
 		err = k_sem_take(&sem_stream_started, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
@@ -1218,11 +1220,11 @@ static void broadcast_sink_with_assistant(void)
 	wait_for_data();
 	backchannel_sync_send_all(); /* let other devices know we have received what we wanted */
 
-	printk("Waiting for BIG sync terminate request\n");
+	LOG_INF("Waiting for BIG sync terminate request");
 	WAIT_FOR_UNSET_FLAG(flag_bis_sync_requested);
 	test_broadcast_stop();
 
-	printk("Waiting for PA sync terminate request\n");
+	LOG_INF("Waiting for PA sync terminate request");
 	WAIT_FOR_UNSET_FLAG(flag_pa_request);
 	test_pa_sync_delete();
 	test_broadcast_delete();
@@ -1246,20 +1248,20 @@ static void broadcast_sink_with_assistant_incorrect_code(void)
 	setup_connectable_adv(&ext_adv);
 	WAIT_FOR_FLAG(flag_connected);
 
-	printk("Waiting for PA sync request\n");
+	LOG_INF("Waiting for PA sync request");
 	WAIT_FOR_FLAG(flag_pa_request);
 
 	test_scan_and_pa_sync();
 	test_broadcast_sink_create();
 
-	printk("Broadcast source PA synced, waiting for BASE\n");
+	LOG_INF("Broadcast source PA synced, waiting for BASE");
 	WAIT_FOR_FLAG(flag_base_received);
-	printk("BASE received\n");
+	LOG_INF("BASE received");
 
-	printk("Waiting for BIG syncable\n");
+	LOG_INF("Waiting for BIG syncable");
 	WAIT_FOR_FLAG(flag_syncable);
 
-	printk("Waiting for BIG sync request\n");
+	LOG_INF("Waiting for BIG sync request");
 	WAIT_FOR_FLAG(flag_bis_sync_requested);
 	test_broadcast_sync(recv_state_broadcast_code);
 	/* Wait for MIC failure */
@@ -1267,7 +1269,7 @@ static void broadcast_sink_with_assistant_incorrect_code(void)
 
 	backchannel_sync_send_all(); /* let other devices know we have received data */
 
-	printk("Waiting for PA sync terminate request\n");
+	LOG_INF("Waiting for PA sync terminate request");
 	WAIT_FOR_UNSET_FLAG(flag_pa_request);
 	test_pa_sync_delete();
 	test_broadcast_delete();

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
@@ -26,7 +26,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -35,6 +35,8 @@
 #include "bap_stream_tx.h"
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(bap_broadcast_source_test);
 
 #define SUPPORTED_CHAN_COUNTS          BT_AUDIO_CODEC_CAP_CHAN_COUNT_SUPPORT(1, 2)
 #define SUPPORTED_MIN_OCTETS_PER_FRAME 30U
@@ -229,7 +231,7 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 		return;
 	}
 
-	printk("Stream %p started\n", stream);
+	LOG_INF("Stream %p started", stream);
 	validate_stream_codec_cfg(stream);
 	k_sem_give(&sem_stream_started);
 }
@@ -238,7 +240,7 @@ static void steam_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
 	int err;
 
-	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stream %p stopped with reason 0x%02X", stream, reason);
 
 	err = bap_stream_tx_unregister(stream);
 	if (err != 0) {
@@ -257,13 +259,13 @@ static struct bt_bap_stream_ops stream_ops = {
 
 static void source_started_cb(struct bt_bap_broadcast_source *source)
 {
-	printk("Broadcast source %p started\n", source);
+	LOG_INF("Broadcast source %p started", source);
 	SET_FLAG(flag_source_started);
 }
 
 static void source_stopped_cb(struct bt_bap_broadcast_source *source, uint8_t reason)
 {
-	printk("Broadcast source %p stopped with reason 0x%02X\n", source, reason);
+	LOG_INF("Broadcast source %p stopped with reason 0x%02X", source, reason);
 	UNSET_FLAG(flag_source_started);
 }
 
@@ -278,9 +280,9 @@ static int setup_broadcast_source(struct bt_bap_broadcast_source **source, bool 
 	int err;
 
 	if (stream_cnt > ARRAY_SIZE(stream_params)) {
-		printk("Unable to create broadcast source with %lu subgroups with %lu streams each "
-		       "(%lu total)\n",
-		       subgroup_cnt_arg, streams_per_subgroup_cnt_arg, stream_cnt);
+		LOG_ERR("Unable to create broadcast source with %lu subgroups "
+			"with %lu streams each (%lu total)",
+			subgroup_cnt_arg, streams_per_subgroup_cnt_arg, stream_cnt);
 		return -ENOMEM;
 	}
 
@@ -310,11 +312,11 @@ static int setup_broadcast_source(struct bt_bap_broadcast_source **source, bool 
 		memcpy(create_param.broadcast_code, BROADCAST_CODE, sizeof(BROADCAST_CODE));
 	}
 
-	printk("Creating broadcast source with %lu subgroups and %lu streams\n", subgroup_cnt_arg,
-	       stream_cnt);
+	LOG_INF("Creating broadcast source with %lu subgroups and %lu streams", subgroup_cnt_arg,
+		stream_cnt);
 	err = bt_bap_broadcast_source_create(&create_param, source);
 	if (err != 0) {
-		printk("Unable to create broadcast source: %d\n", err);
+		LOG_ERR("Unable to create broadcast source: %d", err);
 		return err;
 	}
 
@@ -353,7 +355,7 @@ static int setup_extended_adv(struct bt_bap_broadcast_source *source, struct bt_
 
 	err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
 	if (err != 0) {
-		printk("Unable to generate broadcast ID: %d\n", err);
+		LOG_ERR("Unable to generate broadcast ID: %d", err);
 		return err;
 	}
 
@@ -365,7 +367,7 @@ static int setup_extended_adv(struct bt_bap_broadcast_source *source, struct bt_
 	ext_ad.data = ad_buf.data;
 	err = bt_le_ext_adv_set_data(*adv, &ext_ad, 1, NULL, 0);
 	if (err != 0) {
-		printk("Failed to set extended advertising data: %d\n", err);
+		LOG_ERR("Failed to set extended advertising data: %d", err);
 		return err;
 	}
 
@@ -377,7 +379,7 @@ static int setup_extended_adv(struct bt_bap_broadcast_source *source, struct bt_
 	per_ad.data = base_buf.data;
 	err = bt_le_per_adv_set_data(*adv, &per_ad, 1);
 	if (err != 0) {
-		printk("Failed to set periodic advertising data: %d\n", err);
+		LOG_ERR("Failed to set periodic advertising data: %d", err);
 		return err;
 	}
 
@@ -419,7 +421,7 @@ static void test_broadcast_source_reconfig(struct bt_bap_broadcast_source *sourc
 	reconfig_param.packing = BT_ISO_PACKING_SEQUENTIAL;
 	reconfig_param.encryption = false;
 
-	printk("Reconfiguring broadcast source\n");
+	LOG_INF("Reconfiguring broadcast source");
 	err = bt_bap_broadcast_source_reconfig(source, &reconfig_param);
 	if (err != 0) {
 		FAIL("Unable to reconfigure broadcast source: %d\n", err);
@@ -450,7 +452,7 @@ static void test_broadcast_source_start(struct bt_bap_broadcast_source *source,
 	const unsigned long stream_cnt = subgroup_cnt_arg * streams_per_subgroup_cnt_arg;
 	int err;
 
-	printk("Starting broadcast source\n");
+	LOG_INF("Starting broadcast source");
 	err = bt_bap_broadcast_source_start(source, adv);
 	if (err != 0) {
 		FAIL("Unable to start broadcast source: %d\n", err);
@@ -458,7 +460,7 @@ static void test_broadcast_source_start(struct bt_bap_broadcast_source *source,
 	}
 
 	/* Wait for all to be started */
-	printk("Waiting for %lu streams to be started\n", stream_cnt);
+	LOG_INF("Waiting for %lu streams to be started", stream_cnt);
 	for (size_t i = 0U; i < stream_cnt; i++) {
 		err = k_sem_take(&sem_stream_started, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
@@ -476,7 +478,7 @@ static void test_broadcast_source_update_metadata(struct bt_bap_broadcast_source
 
 	NET_BUF_SIMPLE_DEFINE(base_buf, 128);
 
-	printk("Updating metadata\n");
+	LOG_INF("Updating metadata");
 	err = bt_bap_broadcast_source_update_metadata(source, new_metadata,
 						      ARRAY_SIZE(new_metadata));
 	if (err != 0) {
@@ -502,7 +504,7 @@ static void test_broadcast_source_stop(struct bt_bap_broadcast_source *source)
 	const unsigned long stream_cnt = subgroup_cnt_arg * streams_per_subgroup_cnt_arg;
 	int err;
 
-	printk("Stopping broadcast source\n");
+	LOG_INF("Stopping broadcast source");
 
 	err = bt_bap_broadcast_source_stop(source);
 	if (err != 0) {
@@ -511,7 +513,7 @@ static void test_broadcast_source_stop(struct bt_bap_broadcast_source *source)
 	}
 
 	/* Wait for all to be stopped */
-	printk("Waiting for %lu streams to be stopped\n", stream_cnt);
+	LOG_INF("Waiting for %lu streams to be stopped", stream_cnt);
 	for (size_t i = 0U; i < stream_cnt; i++) {
 		err = k_sem_take(&sem_stream_stopped, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
@@ -524,7 +526,7 @@ static void test_broadcast_source_delete(struct bt_bap_broadcast_source *source)
 {
 	int err;
 
-	printk("Deleting broadcast source\n");
+	LOG_INF("Deleting broadcast source");
 
 	err = bt_bap_broadcast_source_delete(source);
 	if (err != 0) {
@@ -539,19 +541,19 @@ static int stop_extended_adv(struct bt_le_ext_adv *adv)
 
 	err = bt_le_per_adv_stop(adv);
 	if (err != 0) {
-		printk("Failed to stop periodic advertising: %d\n", err);
+		LOG_ERR("Failed to stop periodic advertising: %d", err);
 		return err;
 	}
 
 	err = bt_le_ext_adv_stop(adv);
 	if (err != 0) {
-		printk("Failed to stop extended advertising: %d\n", err);
+		LOG_ERR("Failed to stop extended advertising: %d", err);
 		return err;
 	}
 
 	err = bt_le_ext_adv_delete(adv);
 	if (err != 0) {
-		printk("Failed to delete extended advertising: %d\n", err);
+		LOG_ERR("Failed to delete extended advertising: %d", err);
 		return err;
 	}
 
@@ -572,7 +574,7 @@ static void init(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 	bap_stream_tx_init();
 
 	err = bt_bap_broadcast_source_register_cb(&broadcast_source_cb);
@@ -623,14 +625,14 @@ static void test_main(void)
 	adv = NULL;
 
 	/* Recreate broadcast source to verify that it's possible */
-	printk("Recreating broadcast source\n");
+	LOG_INF("Recreating broadcast source");
 	err = setup_broadcast_source(&source, false);
 	if (err != 0) {
 		FAIL("Unable to setup broadcast source: %d\n", err);
 		return;
 	}
 
-	printk("Deleting broadcast source\n");
+	LOG_INF("Deleting broadcast source");
 	test_broadcast_source_delete(source);
 	source = NULL;
 

--- a/tests/bsim/bluetooth/audio/src/bap_common.c
+++ b/tests/bsim/bluetooth/audio/src/bap_common.c
@@ -17,10 +17,12 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 
 #include "bap_common.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(bap_common);
 
 #define VS_CODEC_CID 0x05F1 /* Linux foundation*/
 #define VS_CODEC_VID 0x1234 /* any value*/
@@ -57,15 +59,6 @@ struct bt_audio_codec_cap vs_codec_cap = {
 #endif                                /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0 */
 };
 
-void print_hex(const uint8_t *ptr, size_t len)
-{
-	while (len != 0U) {
-		printk("%02x", *ptr);
-		ptr++;
-		len--;
-	}
-}
-
 struct print_ltv_info {
 	const char *str;
 	size_t cnt;
@@ -75,10 +68,9 @@ static bool print_ltv_elem(struct bt_data *data, void *user_data)
 {
 	struct print_ltv_info *ltv_info = user_data;
 
-	printk("%s #%zu: type 0x%02x value_len %u", ltv_info->str, ltv_info->cnt, data->type,
-	       data->data_len);
-	print_hex(data->data, data->data_len);
-	printk("\n");
+	LOG_DBG("%s #%zu: type 0x%02x value_len %u", ltv_info->str, ltv_info->cnt, data->type,
+		data->data_len);
+	LOG_HEXDUMP_DBG(data->data, data->data_len, "data");
 
 	ltv_info->cnt++;
 
@@ -97,15 +89,13 @@ static void print_ltv_array(const char *str, const uint8_t *ltv_data, size_t ltv
 
 void print_codec_cap(const struct bt_audio_codec_cap *codec_cap)
 {
-	printk("codec_cap ID 0x%02x cid 0x%04x vid 0x%04x count %u\n", codec_cap->id,
-	       codec_cap->cid, codec_cap->vid, codec_cap->data_len);
+	LOG_DBG("codec_cap ID 0x%02x cid 0x%04x vid 0x%04x count %u", codec_cap->id,
+		codec_cap->cid, codec_cap->vid, codec_cap->data_len);
 
 	if (codec_cap->id == BT_HCI_CODING_FORMAT_LC3) {
 		print_ltv_array("data", codec_cap->data, codec_cap->data_len);
 	} else { /* If not LC3, we cannot assume it's LTV */
-		printk("data: ");
-		print_hex(codec_cap->data, codec_cap->data_len);
-		printk("\n");
+		LOG_HEXDUMP_DBG(codec_cap->data, codec_cap->data_len, "data");
 	}
 
 	print_ltv_array("meta", codec_cap->meta, codec_cap->meta_len);
@@ -113,15 +103,13 @@ void print_codec_cap(const struct bt_audio_codec_cap *codec_cap)
 
 void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 {
-	printk("codec_cfg ID 0x%02x cid 0x%04x vid 0x%04x count %u\n", codec_cfg->id,
-	       codec_cfg->cid, codec_cfg->vid, codec_cfg->data_len);
+	LOG_DBG("codec_cfg ID 0x%02x cid 0x%04x vid 0x%04x count %u", codec_cfg->id,
+		codec_cfg->cid, codec_cfg->vid, codec_cfg->data_len);
 
 	if (codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
 		print_ltv_array("data", codec_cfg->data, codec_cfg->data_len);
 	} else { /* If not LC3, we cannot assume it's LTV */
-		printk("data: ");
-		print_hex(codec_cfg->data, codec_cfg->data_len);
-		printk("\n");
+		LOG_HEXDUMP_DBG(codec_cfg->data, codec_cfg->data_len, "data");
 	}
 
 	print_ltv_array("meta", codec_cfg->meta, codec_cfg->meta_len);
@@ -129,9 +117,9 @@ void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 
 void print_qos(const struct bt_bap_qos_cfg *qos)
 {
-	printk("QoS: interval %u framing 0x%02x phy 0x%02x sdu %u "
-	       "rtn %u latency %u pd %u\n",
-	       qos->interval, qos->framing, qos->phy, qos->sdu, qos->rtn, qos->latency, qos->pd);
+	LOG_DBG("QoS: interval %u framing 0x%02x phy 0x%02x sdu %u "
+		"rtn %u latency %u pd %u",
+		qos->interval, qos->framing, qos->phy, qos->sdu, qos->rtn, qos->latency, qos->pd);
 }
 
 void copy_unicast_stream_preset(struct unicast_stream *stream,

--- a/tests/bsim/bluetooth/audio/src/bap_common.h
+++ b/tests/bsim/bluetooth/audio/src/bap_common.h
@@ -69,7 +69,6 @@ struct named_lc3_preset {
 extern struct bt_audio_codec_cfg vs_codec_cfg;
 extern struct bt_audio_codec_cap vs_codec_cap;
 
-void print_hex(const uint8_t *ptr, size_t len);
 void print_codec_cap(const struct bt_audio_codec_cap *codec_cap);
 void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg);
 void print_qos(const struct bt_bap_qos_cfg *qos);

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -23,13 +23,15 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(bap_scan_delegator_test);
 
 #ifdef CONFIG_BT_BAP_SCAN_DELEGATOR
 extern enum bst_result_t bst_result;
@@ -152,10 +154,10 @@ static int pa_sync_past(struct bt_conn *conn,
 	param.skip = PA_SYNC_SKIP;
 	param.timeout = interval_to_sync_timeout(pa_interval);
 
-	printk("Subscribing to PAST from %p\n", conn);
+	LOG_INF("Subscribing to PAST from %p", conn);
 	err = bt_le_per_adv_sync_transfer_subscribe(conn, &param);
 	if (err != 0) {
-		printk("Could not do PAST subscribe: %d\n", err);
+		LOG_DBG("Could not do PAST subscribe: %d", err);
 	} else {
 		state->pa_syncing = true;
 		k_work_init_delayable(&state->pa_timer, pa_timer_handler);
@@ -185,9 +187,9 @@ static int pa_sync_no_past(struct sync_state *state,
 	 */
 	err = bt_le_per_adv_sync_create(&param, &state->pa_sync);
 	if (err != 0) {
-		printk("Could not sync per adv: %d\n", err);
+		LOG_DBG("Could not sync per adv: %d", err);
 	} else {
-		printk("PA sync pending for addr %s\n", bt_addr_le_str(&recv_state->addr));
+		LOG_INF("PA sync pending for addr %s", bt_addr_le_str(&recv_state->addr));
 		state->pa_syncing = true;
 		k_work_init_delayable(&state->pa_timer, pa_timer_handler);
 		(void)k_work_reschedule(&state->pa_timer, K_MSEC(param.timeout * 10U));
@@ -206,7 +208,7 @@ static int pa_sync_term(struct sync_state *state)
 		return -1;
 	}
 
-	printk("Deleting PA sync\n");
+	LOG_INF("Deleting PA sync");
 
 	UNSET_FLAG(flag_pa_terminated);
 
@@ -230,7 +232,7 @@ static void recv_state_updated_cb(struct bt_conn *conn,
 
 	ARG_UNUSED(conn);
 
-	printk("Receive state with ID %u updated\n", recv_state->src_id);
+	LOG_INF("Receive state with ID %u updated", recv_state->src_id);
 
 	state = sync_state_get_by_src_id(recv_state->src_id);
 	if (state == NULL) {
@@ -266,7 +268,7 @@ static int pa_sync_req_cb(struct bt_conn *conn,
 	int err;
 
 	reset_cp_flags();
-	printk("PA Sync request: past_avail %u, pa_interval 0x%04x: %p\n", past_avail, pa_interval,
+	LOG_INF("PA Sync request: past_avail %u, pa_interval 0x%04x: %p", past_avail, pa_interval,
 	       recv_state);
 
 	state = sync_state_get_or_new(recv_state);
@@ -309,7 +311,7 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 
 	ARG_UNUSED(conn);
 
-	printk("PA Sync term request for %p\n", recv_state);
+	LOG_INF("PA Sync term request for %p", recv_state);
 
 	state = sync_state_get(recv_state);
 	if (state == NULL) {
@@ -328,7 +330,7 @@ static void broadcast_code_cb(struct bt_conn *conn,
 
 	ARG_UNUSED(conn);
 
-	printk("Broadcast code received for %p\n", recv_state);
+	LOG_INF("Broadcast code received for %p", recv_state);
 
 	state = sync_state_get(recv_state);
 	if (state == NULL) {
@@ -350,13 +352,13 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 
 	ARG_UNUSED(conn);
 
-	printk("BIS sync request received for %p\n", recv_state);
+	LOG_INF("BIS sync request received for %p", recv_state);
 	for (int i = 0; i < CONFIG_BT_BAP_BASS_MAX_SUBGROUPS; i++) {
 		if (bis_sync_req[i]) {
 			sync_bis = true;
 		}
 
-		printk("  [%d]: 0x%08x\n", i, bis_sync_req[i]);
+		LOG_DBG("  [%d]: 0x%08x", i, bis_sync_req[i]);
 	}
 
 	state = sync_state_get(recv_state);
@@ -382,7 +384,7 @@ static int add_source_cb(struct bt_conn *conn,
 {
 	ARG_UNUSED(conn);
 
-	printk("Add Source callback: src_id=%u\n", recv_state->src_id);
+	LOG_INF("Add Source callback: src_id=%u", recv_state->src_id);
 	SET_FLAG(flag_broadcast_source_added);
 	return 0;
 }
@@ -392,7 +394,7 @@ static int modify_source_cb(struct bt_conn *conn,
 {
 	ARG_UNUSED(conn);
 
-	printk("Modify Source callback: src_id=%u\n", recv_state->src_id);
+	LOG_INF("Modify Source callback: src_id=%u", recv_state->src_id);
 	SET_FLAG(flag_broadcast_source_modified);
 	return 0;
 }
@@ -401,7 +403,7 @@ static int remove_source_cb(struct bt_conn *conn, uint8_t src_id)
 {
 	ARG_UNUSED(conn);
 
-	printk("Remove Source callback: src_id=%u\n", src_id);
+	LOG_INF("Remove Source callback: src_id=%u", src_id);
 
 	if (reject_control_op) {
 		SET_FLAG(flag_remove_source_rejected);
@@ -428,7 +430,7 @@ static void pa_synced_cb(struct bt_le_per_adv_sync *sync,
 {
 	struct sync_state *state;
 
-	printk("PA %p synced\n", sync);
+	LOG_INF("PA %p synced", sync);
 
 	if (info->conn) { /* if from PAST */
 		for (size_t i = 0U; i < ARRAY_SIZE(sync_states); i++) {
@@ -466,7 +468,7 @@ static void pa_term_cb(struct bt_le_per_adv_sync *sync,
 
 	ARG_UNUSED(info);
 
-	printk("PA %p sync terminated\n", sync);
+	LOG_INF("PA %p sync terminated", sync);
 
 	state = sync_state_get_by_pa(sync);
 	if (state == NULL) {
@@ -521,7 +523,7 @@ static bool broadcast_source_found(struct bt_data *data, void *user_data)
 
 	g_broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
 
-	printk("Found BAP broadcast source with address %s and ID 0x%06X\n",
+	LOG_INF("Found BAP broadcast source with address %s and ID 0x%06X",
 	       bt_addr_le_str(info->addr), g_broadcast_id);
 
 	state = sync_state_get_or_new(NULL);
@@ -530,7 +532,7 @@ static bool broadcast_source_found(struct bt_data *data, void *user_data)
 		return true;
 	}
 
-	printk("Creating Periodic Advertising Sync\n");
+	LOG_INF("Creating Periodic Advertising Sync");
 	bt_addr_le_copy(&sync_create_param.addr, info->addr);
 	sync_create_param.sid = info->sid;
 	sync_create_param.timeout = 0xa;
@@ -612,7 +614,7 @@ static void add_all_sources(void)
 		if (state->pa_sync != NULL) {
 			int res;
 
-			printk("[%zu]: Adding source\n", i);
+			LOG_INF("[%zu]: Adding source", i);
 
 			res = add_source(state);
 			if (res < 0) {
@@ -620,7 +622,7 @@ static void add_all_sources(void)
 				return;
 			}
 
-			printk("[%zu]: Source added with id %u\n",
+			LOG_INF("[%zu]: Source added with id %u",
 			       i, state->src_id);
 		}
 	}
@@ -670,7 +672,7 @@ static void mod_all_sources(void)
 		if (state->pa_sync != NULL) {
 			int err;
 
-			printk("[%zu]: Modifying source\n", i);
+			LOG_INF("[%zu]: Modifying source", i);
 
 			err = mod_source(state);
 			if (err < 0) {
@@ -678,7 +680,7 @@ static void mod_all_sources(void)
 				return;
 			}
 
-			printk("[%zu]: Source id modified %u\n",
+			LOG_INF("[%zu]: Source id modified %u",
 			       i, state->src_id);
 		}
 	}
@@ -711,7 +713,7 @@ static void remove_all_sources(void)
 		if (state->recv_state != NULL) {
 			int err;
 
-			printk("[%zu]: Removing source\n", i);
+			LOG_INF("[%zu]: Removing source", i);
 
 			err = remove_source(state);
 			if (err != 0) {
@@ -719,7 +721,7 @@ static void remove_all_sources(void)
 				return;
 			}
 
-			printk("[%zu]: Source removed with id %u\n",
+			LOG_INF("[%zu]: Source removed with id %u",
 			       i, state->src_id);
 		}
 	}
@@ -761,7 +763,7 @@ static void set_all_bis_sync_states(uint32_t bis_sync_req[CONFIG_BT_BAP_BASS_MAX
 		struct sync_state *state = &sync_states[i];
 
 		if (state->recv_state != NULL) {
-			printk("[%zu]: Setting BIS sync state\n", i);
+			LOG_INF("[%zu]: Setting BIS sync state", i);
 			set_bis_sync_state(state, bis_sync_req);
 		}
 	}
@@ -799,7 +801,7 @@ static void sync_all_broadcasts(void)
 		if (state->pa_sync != NULL) {
 			int res;
 
-			printk("[%zu]: Setting broadcast sync state\n", i);
+			LOG_INF("[%zu]: Setting broadcast sync state", i);
 
 			res = sync_broadcast(state);
 			if (res < 0) {
@@ -807,7 +809,7 @@ static void sync_all_broadcasts(void)
 				return;
 			}
 
-			printk("[%zu]: Broadcast sync state set\n", i);
+			LOG_INF("[%zu]: Broadcast sync state set", i);
 		}
 	}
 }
@@ -823,7 +825,7 @@ static int common_init(void)
 		return err;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	err = bt_bap_scan_delegator_register(&scan_delegator_cb);
 	if (err != 0) {
@@ -852,7 +854,7 @@ static void test_main_client_sync(void)
 
 	WAIT_FOR_FLAG(flag_broadcast_source_added);
 	/* Wait for broadcast assistant to request us to sync to PA */
-	printk("Waiting for flag_pa_synced\n");
+	LOG_INF("Waiting for flag_pa_synced");
 	WAIT_FOR_FLAG(flag_pa_synced);
 
 	/* Mod all sources by modifying the metadata */
@@ -860,18 +862,18 @@ static void test_main_client_sync(void)
 
 	WAIT_FOR_FLAG(flag_broadcast_source_modified);
 	/* Wait for broadcast assistant to tell us to BIS sync */
-	printk("Waiting for flag_bis_sync_requested\n");
+	LOG_INF("Waiting for flag_bis_sync_requested");
 	WAIT_FOR_FLAG(flag_bis_sync_requested);
 
 	/* Set the BIS sync state */
 	sync_all_broadcasts();
 
 	/* Wait for broadcast assistant to send us broadcast code */
-	printk("Waiting for flag_broadcast_code_received\n");
+	LOG_INF("Waiting for flag_broadcast_code_received");
 	WAIT_FOR_FLAG(flag_broadcast_code_received);
 
 	/* Wait for broadcast assistant to remove source and terminate PA sync */
-	printk("Waiting for flag_pa_terminated\n");
+	LOG_INF("Waiting for flag_pa_terminated");
 	WAIT_FOR_FLAG(flag_pa_terminated);
 
 	WAIT_FOR_FLAG(flag_broadcast_source_removed);
@@ -897,14 +899,14 @@ static void test_main_server_sync_client_rem(void)
 	}
 
 	/* Wait for PA to sync */
-	printk("Waiting for flag_pa_synced\n");
+	LOG_INF("Waiting for flag_pa_synced");
 	WAIT_FOR_FLAG(flag_pa_synced);
 
 	/* Add PAs as receive state sources */
 	add_all_sources();
 
 	/* Wait for broadcast assistant to send us broadcast code */
-	printk("Waiting for flag_broadcast_code_received\n");
+	LOG_INF("Waiting for flag_broadcast_code_received");
 	WAIT_FOR_FLAG(flag_broadcast_code_received);
 
 	/* Mod all sources by modifying the metadata */
@@ -921,7 +923,7 @@ static void test_main_server_sync_client_rem(void)
 	/* Disable rejection for subsequent remove source requests */
 	reject_control_op = false;
 	/* For for client to remove source and thus terminate the PA */
-	printk("Waiting for flag_pa_terminated\n");
+	LOG_INF("Waiting for flag_pa_terminated");
 	WAIT_FOR_FLAG(flag_pa_terminated);
 
 	PASS("BAP Scan Delegator Server Sync Client Remove passed\n");
@@ -946,14 +948,14 @@ static void test_main_server_sync_server_rem(void)
 	}
 
 	/* Wait for PA to sync */
-	printk("Waiting for flag_pa_synced\n");
+	LOG_INF("Waiting for flag_pa_synced");
 	WAIT_FOR_FLAG(flag_pa_synced);
 
 	/* Add PAs as receive state sources */
 	add_all_sources();
 
 	/* Wait for broadcast assistant to send us broadcast code */
-	printk("Waiting for flag_broadcast_code_received\n");
+	LOG_INF("Waiting for flag_broadcast_code_received");
 	WAIT_FOR_FLAG(flag_broadcast_code_received);
 
 	/* Mod all sources by modifying the metadata */
@@ -971,7 +973,7 @@ static void test_main_server_sync_server_rem(void)
 	remove_all_sources();
 
 	/* Wait for PA sync to be terminated */
-	printk("Waiting for flag_pa_terminated\n");
+	LOG_INF("Waiting for flag_pa_terminated");
 	WAIT_FOR_FLAG(flag_pa_terminated);
 
 	PASS("BAP Scan Delegator Server Sync Server Remove passed\n");

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -28,7 +28,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/atomic_types.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
@@ -37,6 +37,8 @@
 #include "bstests.h"
 #include "common.h"
 #include "bap_common.h"
+
+LOG_MODULE_REGISTER(bap_unicast_client_test);
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 
@@ -85,7 +87,7 @@ static void stream_codec_configured(struct bt_bap_stream *stream,
 
 	ARG_UNUSED(pref);
 
-	printk("Configured stream %p\n", stream);
+	LOG_INF("Configured stream %p", stream);
 
 	/* TODO: The preference should be used/taken into account when
 	 * setting the QoS
@@ -105,7 +107,7 @@ static void stream_qos_configured(struct bt_bap_stream *stream)
 {
 	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
 
-	printk("QoS set stream %p\n", stream);
+	LOG_INF("QoS set stream %p", stream);
 
 	test_stream->tx_sdu_size = stream->qos->sdu;
 
@@ -114,14 +116,14 @@ static void stream_qos_configured(struct bt_bap_stream *stream)
 
 static void stream_enabled(struct bt_bap_stream *stream)
 {
-	printk("Enabled stream %p\n", stream);
+	LOG_INF("Enabled stream %p", stream);
 
 	SET_FLAG(flag_stream_enabled);
 }
 
 static void stream_started(struct bt_bap_stream *stream)
 {
-	printk("Started stream %p\n", stream);
+	LOG_INF("Started stream %p", stream);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -138,35 +140,35 @@ static void stream_started(struct bt_bap_stream *stream)
 
 static void stream_connected(struct bt_bap_stream *stream)
 {
-	printk("Connected stream %p\n", stream);
+	LOG_INF("Connected stream %p", stream);
 
 	SET_FLAG(flag_stream_connected);
 }
 
 static void stream_disconnected(struct bt_bap_stream *stream, uint8_t reason)
 {
-	printk("Disconnected stream %p with reason %u\n", stream, reason);
+	LOG_INF("Disconnected stream %p with reason %u", stream, reason);
 
 	SET_FLAG(flag_stream_disconnected);
 }
 
 static void stream_metadata_updated(struct bt_bap_stream *stream)
 {
-	printk("Metadata updated stream %p\n", stream);
+	LOG_INF("Metadata updated stream %p", stream);
 
 	SET_FLAG(flag_stream_metadata);
 }
 
 static void stream_disabled(struct bt_bap_stream *stream)
 {
-	printk("Disabled stream %p\n", stream);
+	LOG_INF("Disabled stream %p", stream);
 
 	SET_FLAG(flag_stream_disabled);
 }
 
 static void stream_stopped(struct bt_bap_stream *stream, uint8_t reason)
 {
-	printk("Stopped stream %p with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stopped stream %p with reason 0x%02X", stream, reason);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -183,7 +185,7 @@ static void stream_stopped(struct bt_bap_stream *stream, uint8_t reason)
 
 static void stream_released(struct bt_bap_stream *stream)
 {
-	printk("Released stream %p\n", stream);
+	LOG_INF("Released stream %p", stream);
 
 	SET_FLAG(flag_stream_released);
 }
@@ -209,7 +211,7 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 {
 	ARG_UNUSED(conn);
 
-	printk("dir %u loc %X\n", dir, loc);
+	LOG_DBG("dir %u loc %X", dir, loc);
 }
 
 static void supported_contexts_cb(struct bt_conn *conn, enum bt_audio_context snk_ctx,
@@ -217,8 +219,8 @@ static void supported_contexts_cb(struct bt_conn *conn, enum bt_audio_context sn
 {
 	ARG_UNUSED(conn);
 
-	printk("Supported snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
-	printk("cached %d %d\n", cached_supp_snk_ctx, cached_supp_src_ctx);
+	LOG_DBG("Supported snk ctx %u src ctx %u", snk_ctx, src_ctx);
+	LOG_DBG("cached %d %d", cached_supp_snk_ctx, cached_supp_src_ctx);
 
 	if (snk_ctx != cached_supp_snk_ctx) {
 		cached_supp_snk_ctx = snk_ctx;
@@ -237,8 +239,8 @@ static void available_contexts_cb(struct bt_conn *conn,
 {
 	ARG_UNUSED(conn);
 
-	printk("Available snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
-	printk("cached %d %d\n", cached_avail_snk_ctx, cached_avail_src_ctx);
+	LOG_DBG("Available snk ctx %u src ctx %u", snk_ctx, src_ctx);
+	LOG_DBG("cached %d %d", cached_avail_snk_ctx, cached_avail_src_ctx);
 
 	if (snk_ctx != cached_avail_snk_ctx) {
 		cached_avail_snk_ctx = snk_ctx;
@@ -254,7 +256,7 @@ static void available_contexts_cb(struct bt_conn *conn,
 static void config_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		      enum bt_bap_ascs_reason reason)
 {
-	printk("stream %p config operation rsp_code %u reason %u\n", stream, rsp_code, reason);
+	LOG_INF("stream %p config operation rsp_code %u reason %u", stream, rsp_code, reason);
 
 	if (rsp_code == BT_BAP_ASCS_RSP_CODE_SUCCESS) {
 		SET_FLAG(flag_operation_success);
@@ -264,7 +266,7 @@ static void config_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rs
 static void qos_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		   enum bt_bap_ascs_reason reason)
 {
-	printk("stream %p qos operation rsp_code %u reason %u\n", stream, rsp_code, reason);
+	LOG_INF("stream %p qos operation rsp_code %u reason %u", stream, rsp_code, reason);
 
 	if (rsp_code == BT_BAP_ASCS_RSP_CODE_SUCCESS) {
 		SET_FLAG(flag_operation_success);
@@ -274,7 +276,7 @@ static void qos_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_c
 static void enable_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		      enum bt_bap_ascs_reason reason)
 {
-	printk("stream %p enable operation rsp_code %u reason %u\n", stream, rsp_code, reason);
+	LOG_INF("stream %p enable operation rsp_code %u reason %u", stream, rsp_code, reason);
 
 	if (rsp_code == BT_BAP_ASCS_RSP_CODE_SUCCESS) {
 		SET_FLAG(flag_operation_success);
@@ -284,7 +286,7 @@ static void enable_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rs
 static void start_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		     enum bt_bap_ascs_reason reason)
 {
-	printk("stream %p start operation rsp_code %u reason %u\n", stream, rsp_code, reason);
+	LOG_INF("stream %p start operation rsp_code %u reason %u", stream, rsp_code, reason);
 
 	if (rsp_code == BT_BAP_ASCS_RSP_CODE_SUCCESS) {
 		SET_FLAG(flag_operation_success);
@@ -294,7 +296,7 @@ static void start_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp
 static void stop_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		    enum bt_bap_ascs_reason reason)
 {
-	printk("stream %p stop operation rsp_code %u reason %u\n", stream, rsp_code, reason);
+	LOG_INF("stream %p stop operation rsp_code %u reason %u", stream, rsp_code, reason);
 
 	if (rsp_code == BT_BAP_ASCS_RSP_CODE_SUCCESS) {
 		SET_FLAG(flag_operation_success);
@@ -304,7 +306,7 @@ static void stop_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_
 static void disable_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		       enum bt_bap_ascs_reason reason)
 {
-	printk("stream %p disable operation rsp_code %u reason %u\n", stream, rsp_code, reason);
+	LOG_INF("stream %p disable operation rsp_code %u reason %u", stream, rsp_code, reason);
 
 	if (rsp_code == BT_BAP_ASCS_RSP_CODE_SUCCESS) {
 		SET_FLAG(flag_operation_success);
@@ -314,7 +316,7 @@ static void disable_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code r
 static void metadata_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 			enum bt_bap_ascs_reason reason)
 {
-	printk("stream %p metadata operation rsp_code %u reason %u\n", stream, rsp_code, reason);
+	LOG_INF("stream %p metadata operation rsp_code %u reason %u", stream, rsp_code, reason);
 
 	if (rsp_code == BT_BAP_ASCS_RSP_CODE_SUCCESS) {
 		SET_FLAG(flag_operation_success);
@@ -324,7 +326,7 @@ static void metadata_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code 
 static void release_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		       enum bt_bap_ascs_reason reason)
 {
-	printk("stream %p release operation rsp_code %u reason %u\n", stream, rsp_code, reason);
+	LOG_INF("stream %p release operation rsp_code %u reason %u", stream, rsp_code, reason);
 
 	if (rsp_code == BT_BAP_ASCS_RSP_CODE_SUCCESS) {
 		SET_FLAG(flag_operation_success);
@@ -335,7 +337,7 @@ static void add_remote_sink(struct bt_bap_ep *ep)
 {
 	for (size_t i = 0U; i < ARRAY_SIZE(g_sinks); i++) {
 		if (g_sinks[i] == NULL) {
-			printk("Sink #%zu: ep %p\n", i, ep);
+			LOG_DBG("Sink #%zu: ep %p", i, ep);
 			g_sinks[i] = ep;
 			return;
 		}
@@ -348,7 +350,7 @@ static void add_remote_source(struct bt_bap_ep *ep)
 {
 	for (size_t i = 0U; i < ARRAY_SIZE(g_sources); i++) {
 		if (g_sources[i] == NULL) {
-			printk("Source #%u: ep %p\n", i, ep);
+			LOG_DBG("Source #%u: ep %p", i, ep);
 			g_sources[i] = ep;
 			return;
 		}
@@ -360,7 +362,7 @@ static void add_remote_source(struct bt_bap_ep *ep)
 static void print_remote_codec_cap(const struct bt_audio_codec_cap *codec_cap,
 				   enum bt_audio_dir dir)
 {
-	printk("codec %p dir 0x%02x\n", codec_cap, dir);
+	LOG_DBG("codec %p dir 0x%02x", codec_cap, dir);
 
 	print_codec_cap(codec_cap);
 }
@@ -375,7 +377,7 @@ static void discover_sinks_cb(struct bt_conn *conn, int err, enum bt_audio_dir d
 		return;
 	}
 
-	printk("Discover complete\n");
+	LOG_INF("Discover complete");
 
 	SET_FLAG(flag_sink_discovered);
 }
@@ -390,7 +392,7 @@ static void discover_sources_cb(struct bt_conn *conn, int err, enum bt_audio_dir
 		return;
 	}
 
-	printk("Sources discover complete\n");
+	LOG_INF("Sources discover complete");
 
 	SET_FLAG(flag_source_discovered);
 }
@@ -439,7 +441,7 @@ static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 	ARG_UNUSED(tx);
 	ARG_UNUSED(rx);
 
-	printk("MTU exchanged\n");
+	LOG_INF("MTU exchanged");
 	SET_FLAG(flag_mtu_exchanged);
 }
 
@@ -486,10 +488,10 @@ static bool parse_ascs_ad_data(struct bt_data *data, void *user_data)
 	available_sink_context = net_buf_simple_pull_le16(&net_buf);
 	available_source_context = net_buf_simple_pull_le16(&net_buf);
 
-	printk("Found ASCS with announcement type 0x%02X, sink ctx 0x%04X, source ctx 0x%04X\n",
+	LOG_INF("Found ASCS with announcement type 0x%02X, sink ctx 0x%04X, source ctx 0x%04X",
 	       announcement_type, available_sink_context, available_source_context);
 
-	printk("Stopping scan\n");
+	LOG_INF("Stopping scan");
 	if (bt_le_scan_stop()) {
 		FAIL("Could not stop scan");
 		return false;
@@ -521,7 +523,7 @@ static void broadcast_scan_recv(const struct bt_le_scan_recv_info *info, struct 
 		return;
 	}
 
-	printk("Device found: %s (RSSI %d)\n", bt_addr_le_str(info->addr), info->rssi);
+	LOG_INF("Device found: %s (RSSI %d)", bt_addr_le_str(info->addr), info->rssi);
 
 	bt_data_parse(ad, parse_ascs_ad_data, (void *)info);
 }
@@ -540,7 +542,7 @@ static void init(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 	bap_stream_tx_init();
 
 	for (size_t i = 0U; i < ARRAY_SIZE(test_streams); i++) {
@@ -589,7 +591,7 @@ static void scan_and_connect(void)
 		return;
 	}
 
-	printk("Scanning successfully started\n");
+	LOG_INF("Scanning successfully started");
 	WAIT_FOR_FLAG(flag_connected);
 
 	update_security(default_conn);
@@ -631,7 +633,7 @@ static void discover_sinks(void)
 
 	err = bt_bap_unicast_client_discover(default_conn, BT_AUDIO_DIR_SINK);
 	if (err != 0) {
-		printk("Failed to discover sink: %d\n", err);
+		LOG_ERR("Failed to discover sink: %d", err);
 		return;
 	}
 
@@ -660,7 +662,7 @@ static void discover_sources(void)
 
 	err = bt_bap_unicast_client_discover(default_conn, BT_AUDIO_DIR_SOURCE);
 	if (err != 0) {
-		printk("Failed to discover sink: %d\n", err);
+		LOG_ERR("Failed to discover sink: %d", err);
 		return;
 	}
 
@@ -957,7 +959,7 @@ static void transceive_streams(void)
 		struct audio_test_stream *test_stream =
 			audio_test_stream_from_bap_stream(source_stream);
 
-		printk("Waiting for data\n");
+		LOG_INF("Waiting for data");
 		WAIT_FOR_FLAG(test_stream->flag_audio_received);
 	}
 }
@@ -1164,43 +1166,43 @@ static void test_main(void)
 		struct bt_bap_unicast_group *unicast_group;
 		size_t stream_cnt;
 
-		printk("\n########### Running iteration #%u\n\n", i);
+		LOG_INF("########### Running iteration #%u", i);
 
-		printk("Creating unicast group\n");
+		LOG_INF("Creating unicast group");
 		stream_cnt = create_unicast_group(&unicast_group);
 
-		printk("Codec configuring streams\n");
+		LOG_INF("Codec configuring streams");
 		codec_configure_streams(stream_cnt);
 
-		printk("QoS configuring streams\n");
+		LOG_INF("QoS configuring streams");
 		qos_configure_streams(unicast_group, stream_cnt);
 
-		printk("Enabling streams\n");
+		LOG_INF("Enabling streams");
 		enable_streams(stream_cnt);
 
-		printk("Metadata update streams\n");
+		LOG_INF("Metadata update streams");
 		metadata_update_streams(stream_cnt);
 
-		printk("Connecting streams\n");
+		LOG_INF("Connecting streams");
 		connect_streams();
 
-		printk("Starting streams\n");
+		LOG_INF("Starting streams");
 		start_streams();
 
-		printk("Starting transceiving\n");
+		LOG_INF("Starting transceiving");
 		transceive_streams();
 
-		printk("Disabling streams\n");
+		LOG_INF("Disabling streams");
 		disable_streams(stream_cnt);
 
-		printk("Stopping streams\n");
+		LOG_INF("Stopping streams");
 		stop_streams(stream_cnt);
 
-		printk("Releasing streams\n");
+		LOG_INF("Releasing streams");
 		release_streams(stream_cnt);
 
 		/* Test removing streams from group after creation */
-		printk("Deleting unicast group\n");
+		LOG_INF("Deleting unicast group");
 		delete_unicast_group(unicast_group);
 		unicast_group = NULL;
 	}
@@ -1229,30 +1231,30 @@ static void test_main_acl_disconnect(void)
 
 	discover_sources();
 
-	printk("Creating unicast group\n");
+	LOG_INF("Creating unicast group");
 	stream_cnt = create_unicast_group(&unicast_group);
 
-	printk("Codec configuring streams\n");
+	LOG_INF("Codec configuring streams");
 	codec_configure_streams(stream_cnt);
 
-	printk("QoS configuring streams\n");
+	LOG_INF("QoS configuring streams");
 	qos_configure_streams(unicast_group, stream_cnt);
 
-	printk("Enabling streams\n");
+	LOG_INF("Enabling streams");
 	enable_streams(stream_cnt);
 
-	printk("Metadata update streams\n");
+	LOG_INF("Metadata update streams");
 	metadata_update_streams(stream_cnt);
 
-	printk("Connecting streams\n");
+	LOG_INF("Connecting streams");
 	connect_streams();
 
-	printk("Starting streams\n");
+	LOG_INF("Starting streams");
 	start_streams();
 
 	disconnect_acl();
 
-	printk("Deleting unicast group\n");
+	LOG_INF("Deleting unicast group");
 	delete_unicast_group(unicast_group);
 	unicast_group = NULL;
 

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -25,7 +25,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -35,6 +35,8 @@
 #include "bap_stream_tx.h"
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(bap_unicast_server_test);
 
 #if defined(CONFIG_BT_BAP_UNICAST_SERVER)
 
@@ -88,7 +90,7 @@ static bool print_ase_info(struct bt_bap_ep *ep, void *user_data)
 	err = bt_bap_ep_get_info(ep, &info);
 	__ASSERT_NO_MSG(err == 0);
 
-	printk("ASE info: id %u state %u dir %u\n", info.id, info.state, info.dir);
+	LOG_INF("ASE info: id %u state %u dir %u", info.id, info.state, info.dir);
 
 	return true;
 }
@@ -112,18 +114,18 @@ static int lc3_config(struct bt_conn *conn, const struct bt_bap_ep *ep, enum bt_
 {
 	int err;
 
-	printk("ASE Codec Config: conn %p ep %p dir %u\n", conn, ep, dir);
+	LOG_INF("ASE Codec Config: conn %p ep %p dir %u", conn, ep, dir);
 
 	print_codec_cfg(codec_cfg);
 
 	*stream = stream_alloc();
 	if (*stream == NULL) {
-		printk("No test_streams available\n");
+		LOG_ERR("No test_streams available");
 		*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_NO_MEM, BT_BAP_ASCS_REASON_NONE);
 		return -ENOMEM;
 	}
 
-	printk("ASE Codec Config stream %p\n", *stream);
+	LOG_INF("ASE Codec Config stream %p", *stream);
 
 	err = bt_bap_unicast_server_foreach_ep(conn, print_ase_info, NULL);
 	if (err != 0) {
@@ -142,7 +144,7 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 	ARG_UNUSED(dir);
 	ARG_UNUSED(pref);
 
-	printk("ASE Codec Reconfig: stream %p\n", stream);
+	LOG_INF("ASE Codec Reconfig: stream %p", stream);
 
 	print_codec_cfg(codec_cfg);
 	*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_CONF_UNSUPPORTED, BT_BAP_ASCS_REASON_NONE);
@@ -158,7 +160,7 @@ static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qo
 
 	ARG_UNUSED(rsp);
 
-	printk("QoS: stream %p qos %p\n", stream, qos);
+	LOG_INF("QoS: stream %p qos %p", stream, qos);
 
 	print_qos(qos);
 
@@ -173,7 +175,7 @@ static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t
 	ARG_UNUSED(meta);
 	ARG_UNUSED(rsp);
 
-	printk("Enable: stream %p meta_len %zu\n", stream, meta_len);
+	LOG_INF("Enable: stream %p meta_len %zu", stream, meta_len);
 
 	return 0;
 }
@@ -182,7 +184,7 @@ static int lc3_start(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
 	ARG_UNUSED(rsp);
 
-	printk("Start: stream %p\n", stream);
+	LOG_INF("Start: stream %p", stream);
 
 	return 0;
 }
@@ -192,7 +194,7 @@ static bool data_func_cb(struct bt_data *data, void *user_data)
 	struct bt_bap_ascs_rsp *rsp = (struct bt_bap_ascs_rsp *)user_data;
 
 	if (!BT_AUDIO_METADATA_TYPE_IS_KNOWN(data->type)) {
-		printk("Invalid metadata type %u or length %u\n", data->type, data->data_len);
+		LOG_ERR("Invalid metadata type %u or length %u", data->type, data->data_len);
 		*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_METADATA_REJECTED, data->type);
 		return false;
 	}
@@ -203,7 +205,7 @@ static bool data_func_cb(struct bt_data *data, void *user_data)
 static int lc3_metadata(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 			struct bt_bap_ascs_rsp *rsp)
 {
-	printk("Metadata: stream %p meta_len %zu\n", stream, meta_len);
+	LOG_INF("Metadata: stream %p meta_len %zu", stream, meta_len);
 
 	return bt_audio_data_parse(meta, meta_len, data_func_cb, rsp);
 }
@@ -212,7 +214,7 @@ static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 {
 	ARG_UNUSED(rsp);
 
-	printk("Disable: stream %p\n", stream);
+	LOG_INF("Disable: stream %p", stream);
 
 	return 0;
 }
@@ -221,7 +223,7 @@ static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
 	ARG_UNUSED(rsp);
 
-	printk("Stop: stream %p\n", stream);
+	LOG_INF("Stop: stream %p", stream);
 
 	return 0;
 }
@@ -230,7 +232,7 @@ static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 {
 	ARG_UNUSED(rsp);
 
-	printk("Release: stream %p\n", stream);
+	LOG_INF("Release: stream %p", stream);
 
 	return 0;
 }
@@ -259,7 +261,7 @@ static void stream_codec_configured_cb(struct bt_bap_stream *stream,
 
 	ARG_UNUSED(pref);
 
-	printk("Configured stream %p\n", stream);
+	LOG_INF("Configured stream %p", stream);
 
 	ep_conn = bt_bap_ep_get_conn(stream->ep);
 	if (ep_conn == NULL || stream->conn != ep_conn) {
@@ -276,7 +278,7 @@ static void stream_enabled_cb(struct bt_bap_stream *stream)
 	struct bt_bap_ep_info ep_info;
 	int err;
 
-	printk("Enabled: stream %p\n", stream);
+	LOG_INF("Enabled: stream %p", stream);
 
 	err = bt_bap_ep_get_info(stream->ep, &ep_info);
 	if (err != 0) {
@@ -297,7 +299,7 @@ static void stream_enabled_cb(struct bt_bap_stream *stream)
 
 static void stream_started_cb(struct bt_bap_stream *stream)
 {
-	printk("Started: stream %p\n", stream);
+	LOG_INF("Started: stream %p", stream);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -314,7 +316,7 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 
 static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
-	printk("Stopped stream %p with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stopped stream %p with reason 0x%02X", stream, reason);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -389,7 +391,7 @@ static void transceive_test_streams(void)
 		struct audio_test_stream *test_stream =
 			audio_test_stream_from_bap_stream(sink_stream);
 
-		printk("Waiting for data\n");
+		LOG_INF("Waiting for data");
 		WAIT_FOR_FLAG(test_stream->flag_audio_received);
 	}
 }
@@ -415,7 +417,7 @@ static void set_location(void)
 		}
 	}
 
-	printk("Location successfully set\n");
+	LOG_INF("Location successfully set");
 }
 
 static void set_contexts(void)
@@ -455,7 +457,7 @@ static void set_contexts(void)
 		}
 	}
 
-	printk("Contexts successfully set\n");
+	LOG_INF("Contexts successfully set");
 }
 
 static void update_contexts(void)
@@ -500,7 +502,7 @@ static void update_contexts(void)
 		}
 	}
 
-	printk("Contexts successfully updated\n");
+	LOG_INF("Contexts successfully updated");
 }
 
 static void init(void)
@@ -530,7 +532,7 @@ static void init(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	err = bt_pacs_register(&pacs_param);
 	if (err != 0) {
@@ -625,7 +627,7 @@ static void restart_adv_cb(struct k_work *work)
 
 	ARG_UNUSED(work);
 
-	printk("Restarting ext_adv after disconnect\n");
+	LOG_INF("Restarting ext_adv after disconnect");
 
 	err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -32,7 +32,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -42,6 +42,8 @@
 #include "bstests.h"
 #include "common.h"
 #include "bap_common.h"
+
+LOG_MODULE_REGISTER(cap_acceptor_test);
 
 #if defined(CONFIG_BT_CAP_ACCEPTOR)
 extern enum bst_result_t bst_result;
@@ -128,7 +130,7 @@ static void sync_sink(void)
 		return;
 	}
 
-	printk("Syncing the sink to 0x%08x\n", bis_sync_bitfield);
+	LOG_INF("Syncing the sink to 0x%08x", bis_sync_bitfield);
 
 	err = bt_bap_broadcast_sink_sync(g_broadcast_sink, bis_sync_bitfield, bap_streams, NULL);
 	if (err != 0) {
@@ -180,7 +182,7 @@ static void update_sink_state(void)
 	if (TEST_FLAG(flag_bis_sync_requested)) {
 		if (g_broadcast_sink == NULL && TEST_FLAG(flag_pa_synced) &&
 		    broadcaster_broadcast_id != BT_BAP_INVALID_BROADCAST_ID) {
-			printk("Creating sink\n");
+			LOG_INF("Creating sink");
 			create_sink();
 		}
 
@@ -188,13 +190,13 @@ static void update_sink_state(void)
 		if (g_broadcast_sink != NULL && TEST_FLAG(flag_base_received) &&
 		    TEST_FLAG(flag_syncable) && !TEST_FLAG(flag_broadcaster_synced) &&
 		    bis_sync_bitfield == 0U) {
-			printk("Syncing sink %p\n", g_broadcast_sink);
+			LOG_INF("Syncing sink %p", g_broadcast_sink);
 			sync_sink();
 		}
 	} else {
 		if (g_broadcast_sink != NULL && bis_sync_bitfield != 0U &&
 		    g_total_bis_sync_req == 0U) {
-			printk("Stopping sink %p\n", g_broadcast_sink);
+			LOG_INF("Stopping sink %p", g_broadcast_sink);
 			stop_sink(); /* calls this recursively */
 		}
 
@@ -202,7 +204,7 @@ static void update_sink_state(void)
 		 */
 		if (g_broadcast_sink != NULL && bis_sync_bitfield == 0U &&
 		    g_total_bis_sync_req == 0U && !TEST_FLAG(flag_broadcaster_synced)) {
-			printk("Deleting sink %p\n", g_broadcast_sink);
+			LOG_INF("Deleting sink %p", g_broadcast_sink);
 			delete_sink();
 		}
 	}
@@ -212,7 +214,7 @@ static bool subgroup_data_func_cb(struct bt_data *data, void *user_data)
 {
 	bool *stream_context_found = (bool *)user_data;
 
-	printk("type %u len %u\n", data->type, data->data_len);
+	LOG_DBG("type %u len %u", data->type, data->data_len);
 
 	if (!valid_metadata_type(data->type, data->data_len)) {
 		return false;
@@ -248,7 +250,7 @@ static bool valid_subgroup_metadata_cb(const struct bt_bap_base_subgroup *subgro
 
 	if (TEST_FLAG(flag_base_received) &&
 	    ((size_t)ret != metadata_size || memcmp(meta, metadata, metadata_size) != 0)) {
-		printk("Metadata updated\n");
+		LOG_INF("Metadata updated");
 		SET_FLAG(flag_base_metadata_updated);
 	}
 
@@ -260,7 +262,7 @@ static bool valid_subgroup_metadata_cb(const struct bt_bap_base_subgroup *subgro
 	}
 
 	if (!stream_context_found) {
-		printk("Subgroup did not have streaming context\n");
+		LOG_INF("Subgroup did not have streaming context");
 	}
 
 	/* if this is false, the iterator will return early with an error */
@@ -280,7 +282,7 @@ static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap
 		return;
 	}
 
-	printk("Received BASE with %d subgroups from broadcast sink %p\n", ret, sink);
+	LOG_INF("Received BASE with %d subgroups from broadcast sink %p", ret, sink);
 
 	if (ret == 0) {
 		FAIL("subgroup_count was 0");
@@ -306,7 +308,7 @@ static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap
 
 static void syncable_cb(struct bt_bap_broadcast_sink *sink, const struct bt_iso_biginfo *biginfo)
 {
-	printk("Broadcast sink %p syncable with%s encryption\n",
+	LOG_INF("Broadcast sink %p syncable with%s encryption",
 	       sink, biginfo->encryption ? "" : "out");
 	SET_FLAG(flag_syncable);
 
@@ -320,7 +322,7 @@ static void broadcast_started_cb(struct bt_bap_broadcast_sink *sink)
 		return;
 	}
 
-	printk("Broadcast sink %p started\n", sink);
+	LOG_INF("Broadcast sink %p started", sink);
 
 	SET_FLAG(flag_broadcaster_synced);
 
@@ -336,7 +338,7 @@ static void broadcast_stopped_cb(struct bt_bap_broadcast_sink *sink, uint8_t rea
 		return;
 	}
 
-	printk("Broadcast sink %p stopped\n", sink);
+	LOG_INF("Broadcast sink %p stopped", sink);
 
 	UNSET_FLAG(flag_broadcaster_synced);
 
@@ -379,7 +381,7 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 
 	broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
 
-	printk("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X\n", broadcast_id,
+	LOG_INF("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X", broadcast_id,
 	       bt_addr_le_str(info->addr), info->sid);
 
 	/* Store info for PA sync parameters */
@@ -410,7 +412,7 @@ static void bap_pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 	ARG_UNUSED(info);
 
 	if (sync == pa_sync) {
-		printk("PA sync %p synced for broadcast sink with broadcast ID 0x%06X\n", sync,
+		LOG_INF("PA sync %p synced for broadcast sink with broadcast ID 0x%06X", sync,
 		       broadcaster_broadcast_id);
 
 		SET_FLAG(flag_pa_synced);
@@ -428,7 +430,7 @@ static void bap_pa_sync_terminated_cb(struct bt_le_per_adv_sync *sync,
 				      const struct bt_le_per_adv_sync_term_info *info)
 {
 	if (sync == pa_sync) {
-		printk("PA sync %p lost with reason 0x%02X\n", sync, info->reason);
+		LOG_INF("PA sync %p lost with reason 0x%02X", sync, info->reason);
 		pa_sync = NULL;
 
 		UNSET_FLAG(flag_pa_synced);
@@ -459,12 +461,12 @@ static void started_cb(struct bt_bap_stream *stream)
 	test_stream->tx_cnt = 0U;
 	UNSET_FLAG(test_stream->flag_audio_received);
 
-	printk("Stream %p started\n", stream);
+	LOG_INF("Stream %p started", stream);
 }
 
 static void stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
-	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stream %p stopped with reason 0x%02X", stream, reason);
 }
 
 static struct bt_bap_stream_ops broadcast_stream_ops = {
@@ -478,7 +480,7 @@ static void unicast_stream_enabled_cb(struct bt_bap_stream *stream)
 	struct bt_bap_ep_info ep_info;
 	int err;
 
-	printk("Enabled: stream %p (auto_start_sink_streams %d)\n", stream,
+	LOG_INF("Enabled: stream %p (auto_start_sink_streams %d)", stream,
 	       auto_start_sink_streams);
 
 	err = bt_bap_ep_get_info(stream->ep, &ep_info);
@@ -509,7 +511,7 @@ static void unicast_stream_started(struct bt_bap_stream *stream)
 	test_stream->tx_cnt = 0U;
 	UNSET_FLAG(test_stream->flag_audio_received);
 
-	printk("Started stream %p\n", stream);
+	LOG_INF("Started stream %p", stream);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -526,7 +528,7 @@ static void unicast_stream_started(struct bt_bap_stream *stream)
 
 static void unicast_stream_stopped(struct bt_bap_stream *stream, uint8_t reason)
 {
-	printk("Stopped stream %p with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stopped stream %p with reason 0x%02X", stream, reason);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -598,7 +600,7 @@ static int pa_sync_req_cb(struct bt_conn *conn,
 		return -EALREADY;
 	}
 
-	printk("PA sync request\n");
+	LOG_INF("PA sync request");
 
 	bt_addr_le_copy(&broadcaster_addr, &recv_state->addr);
 	broadcaster_info.sid = recv_state->adv_sid;
@@ -618,7 +620,7 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 
 	ARG_UNUSED(conn);
 
-	printk("PA sync term request\n");
+	LOG_INF("PA sync term request");
 
 	if (recv_state != g_recv_state) {
 		FAIL("Unexpected receive state: %p != %p", recv_state, g_recv_state);
@@ -658,7 +660,7 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 		g_total_bis_sync_req |= bis_sync_req[i];
 	}
 
-	printk("BIS sync request: 0x%08x\n", g_total_bis_sync_req);
+	LOG_INF("BIS sync request: 0x%08x", g_total_bis_sync_req);
 
 	if (g_total_bis_sync_req != 0U) {
 		SET_FLAG(flag_bis_sync_requested);
@@ -682,7 +684,7 @@ static void broadcast_code_cb(struct bt_conn *conn,
 		return;
 	}
 
-	printk("Broadcast code received for %p\n", recv_state);
+	LOG_INF("Broadcast code received for %p", recv_state);
 
 	if (memcmp(broadcast_code, BROADCAST_CODE, sizeof(BROADCAST_CODE)) != 0) {
 		FAIL("Failed to receive correct broadcast code\n");
@@ -744,19 +746,19 @@ static int unicast_server_config(struct bt_conn *conn, const struct bt_bap_ep *e
 				 struct bt_bap_qos_cfg_pref *const pref,
 				 struct bt_bap_ascs_rsp *rsp)
 {
-	printk("ASE Codec Config: conn %p ep %p dir %u\n", conn, ep, dir);
+	LOG_INF("ASE Codec Config: conn %p ep %p dir %u", conn, ep, dir);
 
 	print_codec_cfg(codec_cfg);
 
 	*stream = unicast_stream_alloc();
 	if (*stream == NULL) {
-		printk("No streams available\n");
+		LOG_INF("No streams available");
 		*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_NO_MEM, BT_BAP_ASCS_REASON_NONE);
 
 		return -ENOMEM;
 	}
 
-	printk("ASE Codec Config stream %p\n", *stream);
+	LOG_INF("ASE Codec Config stream %p", *stream);
 
 	SET_FLAG(flag_unicast_stream_configured);
 
@@ -772,7 +774,7 @@ static int unicast_server_reconfig(struct bt_bap_stream *stream, enum bt_audio_d
 {
 	ARG_UNUSED(dir);
 
-	printk("ASE Codec Reconfig: stream %p\n", stream);
+	LOG_INF("ASE Codec Reconfig: stream %p", stream);
 
 	print_codec_cfg(codec_cfg);
 
@@ -789,7 +791,7 @@ static int unicast_server_qos(struct bt_bap_stream *stream, const struct bt_bap_
 {
 	ARG_UNUSED(rsp);
 
-	printk("QoS: stream %p qos %p\n", stream, qos);
+	LOG_INF("QoS: stream %p qos %p", stream, qos);
 
 	print_qos(qos);
 
@@ -801,7 +803,7 @@ static bool ascs_data_func_cb(struct bt_data *data, void *user_data)
 	struct bt_bap_ascs_rsp *rsp = (struct bt_bap_ascs_rsp *)user_data;
 
 	if (!BT_AUDIO_METADATA_TYPE_IS_KNOWN(data->type)) {
-		printk("Invalid metadata type %u or length %u\n", data->type, data->data_len);
+		LOG_ERR("Invalid metadata type %u or length %u", data->type, data->data_len);
 		*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_METADATA_REJECTED, data->type);
 		return false;
 	}
@@ -812,7 +814,7 @@ static bool ascs_data_func_cb(struct bt_data *data, void *user_data)
 static int unicast_server_enable(struct bt_bap_stream *stream, const uint8_t meta[],
 				 size_t meta_len, struct bt_bap_ascs_rsp *rsp)
 {
-	printk("Enable: stream %p meta_len %zu\n", stream, meta_len);
+	LOG_INF("Enable: stream %p meta_len %zu", stream, meta_len);
 
 	return bt_audio_data_parse(meta, meta_len, ascs_data_func_cb, rsp);
 }
@@ -821,7 +823,7 @@ static int unicast_server_start(struct bt_bap_stream *stream, struct bt_bap_ascs
 {
 	ARG_UNUSED(rsp);
 
-	printk("Start: stream %p\n", stream);
+	LOG_INF("Start: stream %p", stream);
 
 	return 0;
 }
@@ -829,7 +831,7 @@ static int unicast_server_start(struct bt_bap_stream *stream, struct bt_bap_ascs
 static int unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t meta[],
 				   size_t meta_len, struct bt_bap_ascs_rsp *rsp)
 {
-	printk("Metadata: stream %p meta_len %zu\n", stream, meta_len);
+	LOG_INF("Metadata: stream %p meta_len %zu", stream, meta_len);
 
 	return bt_audio_data_parse(meta, meta_len, ascs_data_func_cb, rsp);
 }
@@ -838,7 +840,7 @@ static int unicast_server_disable(struct bt_bap_stream *stream, struct bt_bap_as
 {
 	ARG_UNUSED(rsp);
 
-	printk("Disable: stream %p\n", stream);
+	LOG_INF("Disable: stream %p", stream);
 
 	return 0;
 }
@@ -847,7 +849,7 @@ static int unicast_server_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_
 {
 	ARG_UNUSED(rsp);
 
-	printk("Stop: stream %p\n", stream);
+	LOG_INF("Stop: stream %p", stream);
 
 	return 0;
 }
@@ -856,7 +858,7 @@ static int unicast_server_release(struct bt_bap_stream *stream, struct bt_bap_as
 {
 	ARG_UNUSED(rsp);
 
-	printk("Release: stream %p\n", stream);
+	LOG_INF("Release: stream %p", stream);
 
 	return 0;
 }
@@ -901,7 +903,7 @@ static void set_location(void)
 		}
 	}
 
-	printk("Location successfully set\n");
+	LOG_INF("Location successfully set");
 }
 
 static int set_supported_contexts(void)
@@ -911,7 +913,7 @@ static int set_supported_contexts(void)
 	if (IS_ENABLED(CONFIG_BT_PAC_SNK)) {
 		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK, SINK_CONTEXT);
 		if (err != 0) {
-			printk("Failed to set sink supported contexts (err %d)\n",
+			LOG_ERR("Failed to set sink supported contexts (err %d)",
 			       err);
 
 			return err;
@@ -921,14 +923,14 @@ static int set_supported_contexts(void)
 	if (IS_ENABLED(CONFIG_BT_PAC_SRC)) {
 		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SOURCE, SOURCE_CONTEXT);
 		if (err != 0) {
-			printk("Failed to set source supported contexts (err %d)\n",
+			LOG_ERR("Failed to set source supported contexts (err %d)",
 			       err);
 
 			return err;
 		}
 	}
 
-	printk("Supported contexts successfully set\n");
+	LOG_INF("Supported contexts successfully set");
 
 	return 0;
 }
@@ -956,7 +958,7 @@ static void set_available_contexts(void)
 		return;
 	}
 
-	printk("Available contexts successfully set\n");
+	LOG_INF("Available contexts successfully set");
 }
 
 static void init(void)
@@ -994,7 +996,7 @@ static void init(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 	bap_stream_tx_init();
 
 	err = bt_pacs_register(&pacs_param);
@@ -1166,13 +1168,13 @@ static void init(void)
 
 static void wait_for_data(void)
 {
-	printk("Waiting for data\n");
+	LOG_INF("Waiting for data");
 	ARRAY_FOR_EACH_PTR(broadcast_sink_streams, test_stream) {
 		if (audio_test_stream_is_streaming(test_stream)) {
 			WAIT_FOR_FLAG(test_stream->flag_audio_received);
 		}
 	}
-	printk("Data received\n");
+	LOG_INF("Data received");
 }
 
 static void test_cap_acceptor_unicast(void)
@@ -1214,7 +1216,7 @@ static void pa_sync_to_broadcaster(void)
 {
 	int err;
 
-	printk("Scanning for broadcast sources\n");
+	LOG_INF("Scanning for broadcast sources");
 	err = bt_le_scan_start(BT_LE_SCAN_ACTIVE, NULL);
 	if (err != 0) {
 		FAIL("Unable to start scan for broadcast sources: %d", err);
@@ -1223,14 +1225,14 @@ static void pa_sync_to_broadcaster(void)
 
 	WAIT_FOR_FLAG(flag_broadcaster_found);
 
-	printk("Broadcast source found, stopping scan\n");
+	LOG_INF("Broadcast source found, stopping scan");
 	err = bt_le_scan_stop();
 	if (err != 0) {
 		FAIL("bt_le_scan_stop failed with %d\n", err);
 		return;
 	}
 
-	printk("Scan stopped, attempting to PA sync to the broadcaster with id 0x%06X\n",
+	LOG_INF("Scan stopped, attempting to PA sync to the broadcaster with id 0x%06X",
 	       broadcaster_broadcast_id);
 
 	pa_sync_create();
@@ -1243,16 +1245,16 @@ static void test_cap_acceptor_broadcast(void)
 	pa_sync_to_broadcaster();
 	create_sink();
 
-	printk("Broadcast source PA synced, waiting for BASE\n");
+	LOG_INF("Broadcast source PA synced, waiting for BASE");
 	WAIT_FOR_FLAG(flag_base_received);
-	printk("BASE received\n");
+	LOG_INF("BASE received");
 
-	printk("Waiting for BIG syncable\n");
+	LOG_INF("Waiting for BIG syncable");
 	WAIT_FOR_FLAG(flag_syncable);
 
 	sync_sink();
 
-	printk("Waiting for sink synced\n");
+	LOG_INF("Waiting for sink synced");
 	WAIT_FOR_FLAG(flag_broadcaster_synced);
 
 	wait_for_data();
@@ -1271,21 +1273,21 @@ static void test_cap_acceptor_broadcast_update(void)
 	pa_sync_to_broadcaster();
 	create_sink();
 
-	printk("Broadcast source PA synced, waiting for BASE\n");
+	LOG_INF("Broadcast source PA synced, waiting for BASE");
 	WAIT_FOR_FLAG(flag_base_received);
-	printk("BASE received\n");
+	LOG_INF("BASE received");
 
-	printk("Waiting for BIG syncable\n");
+	LOG_INF("Waiting for BIG syncable");
 	WAIT_FOR_FLAG(flag_syncable);
 
 	sync_sink();
 
-	printk("Waiting for sink synced\n");
+	LOG_INF("Waiting for sink synced");
 	WAIT_FOR_FLAG(flag_broadcaster_synced);
 
 	wait_for_data();
 
-	printk("Waiting for metadata update");
+	LOG_INF("Waiting for metadata update");
 	WAIT_FOR_FLAG(flag_base_metadata_updated);
 	backchannel_sync_send_all(); /* let other devices know we have received metadata */
 	/* let other devices know we have received what we wanted */
@@ -1302,26 +1304,26 @@ static void test_cap_acceptor_broadcast_reception(void)
 
 	test_start_adv();
 
-	printk("Waiting for PA sync request\n");
+	LOG_INF("Waiting for PA sync request");
 	WAIT_FOR_FLAG(flag_pa_request);
 
-	printk("Waiting for BIS sync request\n");
+	LOG_INF("Waiting for BIS sync request");
 	WAIT_FOR_FLAG(flag_bis_sync_requested);
 
-	printk("Waiting for PA synced\n");
+	LOG_INF("Waiting for PA synced");
 	WAIT_FOR_FLAG(flag_pa_synced);
 
-	printk("Broadcast source PA synced, waiting for BASE\n");
+	LOG_INF("Broadcast source PA synced, waiting for BASE");
 	WAIT_FOR_FLAG(flag_base_received);
-	printk("BASE received\n");
+	LOG_INF("BASE received");
 
-	printk("Waiting for BIG syncable\n");
+	LOG_INF("Waiting for BIG syncable");
 	WAIT_FOR_FLAG(flag_syncable);
 
-	printk("Waiting for broadcast code\n");
+	LOG_INF("Waiting for broadcast code");
 	WAIT_FOR_FLAG(flag_broadcast_code);
 
-	printk("Waiting for sink synced\n");
+	LOG_INF("Waiting for sink synced");
 	WAIT_FOR_FLAG(flag_broadcaster_synced);
 
 	wait_for_data();

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -30,7 +30,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -38,6 +38,8 @@
 #include "bstests.h"
 #include "common.h"
 #include "bap_common.h"
+
+LOG_MODULE_REGISTER(cap_commander_test);
 
 #if defined(CONFIG_BT_CAP_COMMANDER)
 
@@ -103,9 +105,9 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 			return;
 		}
 
-		printk("Found CAS on %p with CSIS %p\n", (void *)conn, csis_inst);
+		LOG_INF("Found CAS on %p with CSIS %p", (void *)conn, csis_inst);
 	} else {
-		printk("Found CAS on %p\n", (void *)conn);
+		LOG_INF("Found CAS on %p", (void *)conn);
 	}
 
 	k_sem_give(&sem_cas_discovered);
@@ -115,7 +117,7 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 static void cap_volume_changed_cb(struct bt_conn *conn, int err)
 {
 	if (err == -ECANCELED) {
-		printk("CAP command cancelled for conn %p\n", conn);
+		LOG_INF("CAP command cancelled for conn %p", conn);
 		SET_FLAG(flag_cap_canceled);
 		return;
 	}
@@ -131,7 +133,7 @@ static void cap_volume_changed_cb(struct bt_conn *conn, int err)
 static void cap_volume_mute_changed_cb(struct bt_conn *conn, int err)
 {
 	if (err == -ECANCELED) {
-		printk("CAP command cancelled for conn %p\n", conn);
+		LOG_INF("CAP command cancelled for conn %p", conn);
 		SET_FLAG(flag_cap_canceled);
 		return;
 	}
@@ -148,7 +150,7 @@ static void cap_volume_mute_changed_cb(struct bt_conn *conn, int err)
 static void cap_volume_offset_changed_cb(struct bt_conn *conn, int err)
 {
 	if (err == -ECANCELED) {
-		printk("CAP command cancelled for conn %p\n", conn);
+		LOG_INF("CAP command cancelled for conn %p", conn);
 		SET_FLAG(flag_cap_canceled);
 		return;
 	}
@@ -167,7 +169,7 @@ static void cap_volume_offset_changed_cb(struct bt_conn *conn, int err)
 static void cap_microphone_mute_changed_cb(struct bt_conn *conn, int err)
 {
 	if (err == -ECANCELED) {
-		printk("CAP command cancelled for conn %p\n", conn);
+		LOG_INF("CAP command cancelled for conn %p", conn);
 		SET_FLAG(flag_cap_canceled);
 		return;
 	}
@@ -184,7 +186,7 @@ static void cap_microphone_mute_changed_cb(struct bt_conn *conn, int err)
 static void cap_microphone_gain_changed_cb(struct bt_conn *conn, int err)
 {
 	if (err == -ECANCELED) {
-		printk("CAP command cancelled for conn %p\n", conn);
+		LOG_INF("CAP command cancelled for conn %p", conn);
 		SET_FLAG(flag_cap_canceled);
 		return;
 	}
@@ -203,13 +205,13 @@ static void cap_microphone_gain_changed_cb(struct bt_conn *conn, int err)
 static void cap_broadcast_reception_start_cb(struct bt_conn *conn, int err)
 {
 	if (err == -ECANCELED) {
-		printk("CAP command cancelled for conn %p\n", conn);
+		LOG_INF("CAP command cancelled for conn %p", conn);
 		SET_FLAG(flag_cap_canceled);
 	} else if (err != 0) {
-		printk("Failed to perform broadcast reception start for conn %p: %d\n", conn, err);
+		LOG_ERR("Failed to perform broadcast reception start for conn %p: %d", conn, err);
 		SET_FLAG(flag_broadcast_reception_start_failed);
 	} else {
-		printk("CAP broadcast reception started\n");
+		LOG_INF("CAP broadcast reception started");
 		SET_FLAG(flag_broadcast_reception_started);
 	}
 }
@@ -217,13 +219,13 @@ static void cap_broadcast_reception_start_cb(struct bt_conn *conn, int err)
 static void cap_broadcast_reception_stop_cb(struct bt_conn *conn, int err)
 {
 	if (err == -ECANCELED) {
-		printk("CAP command cancelled for conn %p\n", conn);
+		LOG_INF("CAP command cancelled for conn %p", conn);
 		SET_FLAG(flag_cap_canceled);
 	} else if (err != 0) {
-		printk("Failed to perform broadcast reception stop for conn %p: %d\n", conn, err);
+		LOG_ERR("Failed to perform broadcast reception stop for conn %p: %d", conn, err);
 		SET_FLAG(flag_broadcast_reception_stop_failed);
 	} else {
-		printk("CAP broadcast reception stopped\n");
+		LOG_INF("CAP broadcast reception stopped");
 		SET_FLAG(flag_broadcast_reception_stopped);
 	}
 }
@@ -231,12 +233,12 @@ static void cap_broadcast_reception_stop_cb(struct bt_conn *conn, int err)
 static void distribute_broadcast_code_cb(struct bt_conn *conn, int err)
 {
 	if (err == -ECANCELED) {
-		printk("CAP command cancelled for conn %p\n", conn);
+		LOG_INF("CAP command cancelled for conn %p", conn);
 		SET_FLAG(flag_cap_canceled);
 	} else if (err != 0) {
 		FAIL("Failed to perform distribute broadcast code for conn %p: %d\n", conn, err);
 	} else {
-		printk("CAP broadcast code distributed\n");
+		LOG_INF("CAP broadcast code distributed");
 		SET_FLAG(flag_broadcast_code_distributed);
 	}
 }
@@ -273,7 +275,7 @@ static void cap_vcp_discover_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err, uint8
 		return;
 	}
 
-	printk("VCS for %p found with %u VOCS and %u AICS\n", vol_ctlr, vocs_count, aics_count);
+	LOG_INF("VCS for %p found with %u VOCS and %u AICS", vol_ctlr, vocs_count, aics_count);
 	k_sem_give(&sem_vcs_discovered);
 }
 
@@ -285,7 +287,7 @@ static void cap_vcp_state_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err, uint8_t 
 		return;
 	}
 
-	printk("State for %p: volume %u, mute %u\n", vol_ctlr, volume, mute);
+	LOG_INF("State for %p: volume %u, mute %u", vol_ctlr, volume, mute);
 }
 
 static struct bt_vcp_vol_ctlr_cb vcp_cb = {
@@ -301,7 +303,7 @@ static void cap_micp_discover_cb(struct bt_micp_mic_ctlr *mic_ctlr, int err, uin
 		return;
 	}
 
-	printk("MICS for %p found with %u AICS\n", mic_ctlr, aics_count);
+	LOG_INF("MICS for %p found with %u AICS", mic_ctlr, aics_count);
 	k_sem_give(&sem_mics_discovered);
 }
 
@@ -315,7 +317,7 @@ static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 	ARG_UNUSED(tx);
 	ARG_UNUSED(rx);
 
-	printk("MTU exchanged\n");
+	LOG_INF("MTU exchanged");
 	SET_FLAG(flag_mtu_exchanged);
 }
 
@@ -354,7 +356,7 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 
 	if (TEST_FLAG(flag_broadcaster_found)) {
 		/* no-op*/
-		printk("NO OP\n");
+		LOG_DBG("NO OP");
 		return false;
 	}
 
@@ -376,9 +378,9 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 
 	broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
 
-	printk("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X\n", broadcast_id,
+	LOG_INF("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X", broadcast_id,
 	       bt_addr_le_str(info->addr), info->sid);
-	printk("Adv type %02X interval %u\n", info->adv_type, info->interval);
+	LOG_DBG("Adv type %02X interval %u", info->adv_type, info->interval);
 
 	SET_FLAG(flag_broadcaster_found);
 
@@ -408,7 +410,7 @@ static void bap_pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 	ARG_UNUSED(info);
 
 	if (sync == g_pa_sync) {
-		printk("PA sync %p synced for broadcast sink with broadcast ID 0x%06X\n", sync,
+		LOG_INF("PA sync %p synced for broadcast sink with broadcast ID 0x%06X", sync,
 		       broadcaster_broadcast_id);
 		SET_FLAG(flag_pa_synced);
 	}
@@ -418,7 +420,7 @@ static void bap_pa_sync_terminated_cb(struct bt_le_per_adv_sync *sync,
 				      const struct bt_le_per_adv_sync_term_info *info)
 {
 	if (sync == g_pa_sync) {
-		printk("CAP commander test PA sync %p lost with reason %u\n", sync, info->reason);
+		LOG_INF("CAP commander test PA sync %p lost with reason %u", sync, info->reason);
 		g_pa_sync = NULL;
 
 		SET_FLAG(flag_pa_sync_lost);
@@ -441,7 +443,7 @@ static bool base_store(struct bt_data *data, void *user_data)
 	/* Can not fit all the received subgroups with the size CONFIG_BT_BAP_BASS_MAX_SUBGROUPS */
 	base_subgroup_count = bt_bap_base_get_subgroup_count(base);
 	if (base_subgroup_count < 0 || base_subgroup_count > CONFIG_BT_BAP_BASS_MAX_SUBGROUPS) {
-		printk("Got invalid subgroup count: %d\n", base_subgroup_count);
+		LOG_ERR("Got invalid subgroup count: %d", base_subgroup_count);
 		return true;
 	}
 
@@ -481,9 +483,9 @@ static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
 						uint8_t recv_state_count)
 {
 	if (err == 0) {
-		printk("BASS discover done with %u recv states\n", recv_state_count);
+		LOG_INF("BASS discover done with %u recv states", recv_state_count);
 	} else {
-		printk("BASS discover failed on %p (%d)\n", conn, err);
+		LOG_ERR("BASS discover failed on %p (%d)", conn, err);
 	}
 
 	k_sem_give(&sem_bass_discovered);
@@ -492,9 +494,9 @@ static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
 static void bap_broadcast_assistant_add_src_cb(struct bt_conn *conn, int err)
 {
 	if (err == 0) {
-		printk("BASS add source successful\n");
+		LOG_INF("BASS add source successful");
 	} else {
-		printk("BASS add source failed on %p (%d)\n", conn, err);
+		LOG_ERR("BASS add source failed on %p (%d)", conn, err);
 	}
 }
 
@@ -506,7 +508,7 @@ static bool metadata_entry(struct bt_data *data, void *user_data)
 
 	(void)bin2hex(data->data, data->data_len, metadata, sizeof(metadata));
 
-	printk("\t\tMetadata length %u, type %u, data: %s\n", data->data_len, data->type, metadata);
+	LOG_DBG("\t\tMetadata length %u, type %u, data: %s", data->data_len, data->type, metadata);
 
 	return true;
 }
@@ -530,8 +532,8 @@ bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
 	}
 
 	(void)bin2hex(state->bad_code, BT_ISO_BROADCAST_CODE_SIZE, bad_code, sizeof(bad_code));
-	printk("BASS recv state from %p: src_id %u, addr %s, sid %u, sync_state %u, "
-	       "encrypt_state %u%s%s\n",
+	LOG_INF("BASS recv state from %p: src_id %u, addr %s, sid %u, sync_state %u, "
+	       "encrypt_state %u%s%s",
 	       conn, state->src_id, bt_addr_le_str(&state->addr), state->adv_sid,
 	       state->pa_sync_state, state->encrypt_state,
 	       state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE ? ", bad code" : "",
@@ -549,7 +551,7 @@ bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
 		const struct bt_bap_bass_subgroup *subgroup = &state->subgroups[i];
 		struct net_buf_simple buf;
 
-		printk("\t[%d]: BIS sync %u, metadata_len %u\n", i, subgroup->bis_sync,
+		LOG_DBG("\t[%d]: BIS sync %u, metadata_len %u", i, subgroup->bis_sync,
 		       subgroup->metadata_len);
 
 		net_buf_simple_init_with_data(&buf, (void *)subgroup->metadata,
@@ -588,7 +590,7 @@ static bool check_audio_support_and_connect_cb(struct bt_data *data, void *user_
 	uint16_t uuid_val;
 	int err;
 
-	printk("data->type %u\n", data->type);
+	LOG_DBG("data->type %u", data->type);
 
 	if (data->type != BT_DATA_SVC_DATA16) {
 		return true; /* Continue parsing to next AD data type */
@@ -605,9 +607,9 @@ static bool check_audio_support_and_connect_cb(struct bt_data *data, void *user_
 		return true; /* Continue parsing to next AD data type */
 	}
 
-	printk("Device found: %s\n", bt_addr_le_str(addr));
+	LOG_INF("Device found: %s", bt_addr_le_str(addr));
 
-	printk("Stopping scan\n");
+	LOG_INF("Stopping scan");
 	if (bt_le_scan_stop()) {
 		FAIL("Could not stop scan");
 		return false;
@@ -759,7 +761,7 @@ static void scan_and_connect(void)
 		return;
 	}
 
-	printk("Scanning successfully started\n");
+	LOG_INF("Scanning successfully started");
 	WAIT_FOR_FLAG(flag_connected);
 	connected_conn_cnt++;
 }
@@ -772,7 +774,7 @@ static void disconnect_acl(struct bt_conn *conns[], size_t conn_cnt)
 		struct bt_conn *conn = conns[i];
 		int err;
 
-		printk("Disconnecting %p\n", (void *)conn);
+		LOG_INF("Disconnecting %p", (void *)conn);
 
 		err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 		if (err != 0) {
@@ -804,7 +806,7 @@ static void discover_cas(size_t acceptor_cnt)
 		struct bt_conn *conn = connected_conns[i];
 		int err;
 
-		printk("Discovering CAS on %p\n", (void *)conn);
+		LOG_INF("Discovering CAS on %p", (void *)conn);
 
 		err = bt_cap_commander_discover(conn);
 		if (err != 0) {
@@ -858,7 +860,7 @@ static void pa_sync_to_broadcaster(void)
 		return;
 	}
 
-	printk("Searching for a broadcaster\n");
+	LOG_INF("Searching for a broadcaster");
 	WAIT_FOR_FLAG(flag_broadcaster_found);
 
 	err = bt_le_scan_stop();
@@ -867,7 +869,7 @@ static void pa_sync_to_broadcaster(void)
 		return;
 	}
 
-	printk("Scan stopped, attempting to PA sync to the broadcaster with id 0x%06X\n",
+	LOG_INF("Scan stopped, attempting to PA sync to the broadcaster with id 0x%06X",
 	       broadcaster_broadcast_id);
 	err = pa_sync_create();
 	if (err != 0) {
@@ -877,7 +879,7 @@ static void pa_sync_to_broadcaster(void)
 
 	WAIT_FOR_FLAG(flag_pa_synced); /* todo from bap_pa_sync_synced_cb, bap_pa_sync_cb */
 
-	printk("Broadcast source PA synced, waiting for BASE\n");
+	LOG_INF("Broadcast source PA synced, waiting for BASE");
 	WAIT_FOR_FLAG(flag_base_received);
 }
 
@@ -891,7 +893,7 @@ static void discover_vcs(size_t acceptor_cnt)
 		struct bt_vcp_vol_ctlr *vol_ctlr;
 		int err;
 
-		printk("Discovering VCS on %p\n", (void *)conn);
+		LOG_INF("Discovering VCS on %p", (void *)conn);
 
 		err = bt_vcp_vol_ctlr_discover(conn, &vol_ctlr);
 		if (err != 0) {
@@ -948,7 +950,7 @@ static void init_change_volume(void)
 	};
 	int err;
 
-	printk("Changing volume to %u\n", param.volume);
+	LOG_INF("Changing volume to %u", param.volume);
 
 	for (size_t i = 0U; i < param.count; i++) {
 		param.members[i].member = connected_conns[i];
@@ -979,7 +981,7 @@ static void test_change_volume_mute(bool mute)
 	};
 	int err;
 
-	printk("Changing volume mute state to %d\n", param.mute);
+	LOG_INF("Changing volume mute state to %d", param.mute);
 	UNSET_FLAG(flag_volume_mute_changed);
 
 	for (size_t i = 0U; i < param.count; i++) {
@@ -993,7 +995,7 @@ static void test_change_volume_mute(bool mute)
 	}
 
 	WAIT_FOR_FLAG(flag_volume_mute_changed);
-	printk("Volume mute state changed to %d\n", param.mute);
+	LOG_INF("Volume mute state changed to %d", param.mute);
 }
 
 static void test_change_volume_offset(void)
@@ -1006,7 +1008,7 @@ static void test_change_volume_offset(void)
 	};
 	int err;
 
-	printk("Changing volume offset\n");
+	LOG_INF("Changing volume offset");
 	UNSET_FLAG(flag_volume_offset_changed);
 
 	for (size_t i = 0U; i < param.count; i++) {
@@ -1021,7 +1023,7 @@ static void test_change_volume_offset(void)
 	}
 
 	WAIT_FOR_FLAG(flag_volume_offset_changed);
-	printk("Volume offset changed\n");
+	LOG_INF("Volume offset changed");
 }
 
 static void test_change_microphone_mute(bool mute)
@@ -1035,7 +1037,7 @@ static void test_change_microphone_mute(bool mute)
 	};
 	int err;
 
-	printk("Changing microphone mute state to %d\n", param.mute);
+	LOG_INF("Changing microphone mute state to %d", param.mute);
 	UNSET_FLAG(flag_microphone_mute_changed);
 
 	for (size_t i = 0U; i < param.count; i++) {
@@ -1049,7 +1051,7 @@ static void test_change_microphone_mute(bool mute)
 	}
 
 	WAIT_FOR_FLAG(flag_microphone_mute_changed);
-	printk("Microphone mute state changed to %d\n", param.mute);
+	LOG_INF("Microphone mute state changed to %d", param.mute);
 }
 
 static void test_change_microphone_gain(void)
@@ -1063,7 +1065,7 @@ static void test_change_microphone_gain(void)
 	};
 	int err;
 
-	printk("Changing microphone gain\n");
+	LOG_INF("Changing microphone gain");
 	UNSET_FLAG(flag_microphone_gain_changed);
 
 	for (size_t i = 0U; i < param.count; i++) {
@@ -1078,7 +1080,7 @@ static void test_change_microphone_gain(void)
 	}
 
 	WAIT_FOR_FLAG(flag_microphone_gain_changed);
-	printk("Microphone gain changed\n");
+	LOG_INF("Microphone gain changed");
 }
 
 static void test_broadcast_reception_start(struct bt_conn *conns[], size_t conn_cnt)
@@ -1249,7 +1251,7 @@ static void test_main_cap_commander_broadcast_reception(void)
 	 * This leaves N - 2 devices for the acceptor
 	 */
 	acceptor_count = get_dev_cnt() - 2;
-	printk("Acceptor count: %d\n", acceptor_count);
+	LOG_DBG("Acceptor count: %d", acceptor_count);
 
 	init(acceptor_count);
 
@@ -1300,7 +1302,7 @@ static void test_main_cap_commander_broadcast_reception_error(void)
 	 * This leaves N - 2 devices for the acceptor
 	 */
 	acceptor_count = get_dev_cnt() - 2;
-	printk("Acceptor count: %d\n", acceptor_count);
+	LOG_DBG("Acceptor count: %d", acceptor_count);
 
 	init(acceptor_count);
 
@@ -1318,7 +1320,7 @@ static void test_main_cap_commander_broadcast_reception_error(void)
 
 	/* Expect each acceptor to reject the first request */
 	for (size_t i = 0U; i < connected_conn_cnt; i++) {
-		printk("Attempting reception start on %zu connections, expecting failure on #%zu\n",
+		LOG_INF("Attempting reception start on %zu connections, expecting failure on #%zu",
 		       connected_conn_cnt, i + 1);
 		test_broadcast_reception_start(connected_conns, connected_conn_cnt);
 		WAIT_FOR_AND_CLEAR_FLAG(flag_broadcast_reception_start_failed);
@@ -1334,7 +1336,7 @@ static void test_main_cap_commander_broadcast_reception_error(void)
 		 * connected_conns
 		 */
 		if (i > 0U && connected_conn_cnt > 1U) {
-			printk("Attempting reception stop on %zu connections\n",
+			LOG_INF("Attempting reception stop on %zu connections",
 			       connected_conn_cnt - i);
 			test_broadcast_reception_stop(connected_conns, connected_conn_cnt - i);
 			WAIT_FOR_AND_CLEAR_FLAG(flag_broadcast_reception_stopped);
@@ -1342,7 +1344,7 @@ static void test_main_cap_commander_broadcast_reception_error(void)
 	}
 
 	/* Expect success */
-	printk("Attempting reception start on %zu connections, expecting success\n",
+	LOG_INF("Attempting reception start on %zu connections, expecting success",
 	       connected_conn_cnt);
 	test_broadcast_reception_start(connected_conns, connected_conn_cnt);
 	WAIT_FOR_FLAG(flag_broadcast_reception_started);
@@ -1383,7 +1385,7 @@ static void test_main_cap_commander_cancel(void)
 	 * This leaves N - 2 devices for the acceptor
 	 */
 	acceptor_count = get_dev_cnt() - 1;
-	printk("Acceptor count: %d\n", acceptor_count);
+	LOG_DBG("Acceptor count: %d", acceptor_count);
 
 	init(acceptor_count);
 

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -25,7 +25,7 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -34,6 +34,8 @@
 #include "bap_stream_tx.h"
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(cap_initiator_broadcast_test);
 
 #if defined(CONFIG_BT_CAP_INITIATOR) && defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
 CREATE_FLAG(flag_source_started);
@@ -105,7 +107,7 @@ static void broadcast_stream_started_cb(struct bt_bap_stream *stream)
 	test_stream->seq_num = 0U;
 	test_stream->tx_cnt = 0U;
 
-	printk("Stream %p started\n", stream);
+	LOG_INF("Stream %p started", stream);
 
 	err = bap_stream_tx_register(stream);
 	if (err != 0) {
@@ -120,7 +122,7 @@ static void broadcast_stream_stopped_cb(struct bt_bap_stream *stream, uint8_t re
 {
 	int err;
 
-	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stream %p stopped with reason 0x%02X", stream, reason);
 
 	err = bap_stream_tx_unregister(stream);
 	if (err != 0) {
@@ -139,14 +141,14 @@ static struct bt_bap_stream_ops broadcast_stream_ops = {
 
 static void broadcast_source_started_cb(struct bt_cap_broadcast_source *broadcast_source)
 {
-	printk("Broadcast source %p started\n", broadcast_source);
+	LOG_INF("Broadcast source %p started", broadcast_source);
 	SET_FLAG(flag_source_started);
 }
 
 static void broadcast_source_stopped_cb(struct bt_cap_broadcast_source *broadcast_source,
 					uint8_t reason)
 {
-	printk("Broadcast source %p stopped with reason 0x%02X\n", broadcast_source, reason);
+	LOG_INF("Broadcast source %p stopped with reason 0x%02X", broadcast_source, reason);
 	UNSET_FLAG(flag_source_started);
 }
 
@@ -164,7 +166,7 @@ static void init(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 	bap_stream_tx_init();
 
 	(void)memset(broadcast_source_streams, 0, sizeof(broadcast_source_streams));
@@ -194,7 +196,7 @@ static void init(void)
 			return;
 		}
 
-		printk("Registered GTBS\n");
+		LOG_INF("Registered GTBS");
 	}
 
 	err = bt_cap_initiator_register_cb(&broadcast_cbs);
@@ -393,7 +395,7 @@ static void test_broadcast_audio_create(struct bt_cap_broadcast_source **broadca
 	create_param.packing = BT_ISO_PACKING_SEQUENTIAL;
 	create_param.encryption = false;
 
-	printk("Creating broadcast source with %zu broadcast_streams\n",
+	LOG_INF("Creating broadcast source with %zu broadcast_streams",
 	       ARRAY_SIZE(broadcast_streams));
 
 	err = bt_cap_initiator_broadcast_audio_create(&create_param, broadcast_source);
@@ -408,7 +410,7 @@ static void test_broadcast_audio_create(struct bt_cap_broadcast_source **broadca
 		test_stream->tx_sdu_size = create_param.qos->sdu;
 	}
 
-	printk("Broadcast source created with %zu broadcast_streams\n",
+	LOG_INF("Broadcast source created with %zu broadcast_streams",
 	       ARRAY_SIZE(broadcast_streams));
 
 	stream_count = ARRAY_SIZE(broadcast_streams);
@@ -445,7 +447,7 @@ static void test_broadcast_audio_start(struct bt_cap_broadcast_source *broadcast
 		return;
 	}
 
-	printk("Broadcast source created with %zu broadcast_streams\n",
+	LOG_INF("Broadcast source created with %zu broadcast_streams",
 	       ARRAY_SIZE(broadcast_streams));
 }
 
@@ -494,7 +496,7 @@ static void test_broadcast_audio_update_inval(struct bt_cap_broadcast_source *br
 		return;
 	}
 
-	printk("Broadcast metadata updated\n");
+	LOG_INF("Broadcast metadata updated");
 }
 
 static void test_broadcast_audio_update(struct bt_cap_broadcast_source *broadcast_source)
@@ -514,7 +516,7 @@ static void test_broadcast_audio_update(struct bt_cap_broadcast_source *broadcas
 	};
 	int err;
 
-	printk("Updating broadcast metadata\n");
+	LOG_INF("Updating broadcast metadata");
 
 	err = bt_cap_initiator_broadcast_audio_update(broadcast_source, new_metadata,
 						      ARRAY_SIZE(new_metadata));
@@ -523,7 +525,7 @@ static void test_broadcast_audio_update(struct bt_cap_broadcast_source *broadcas
 		return;
 	}
 
-	printk("Broadcast metadata updated\n");
+	LOG_INF("Broadcast metadata updated");
 }
 
 static void test_broadcast_audio_stop_inval(void)
@@ -553,7 +555,7 @@ static void test_broadcast_audio_tx_sync(void)
 		}
 
 		if (info.seq_num != 0) {
-			printk("stream[%zu]: %p seq_num: %u\n", i, cap_stream, info.seq_num);
+			LOG_DBG("stream[%zu]: %p seq_num: %u", i, cap_stream, info.seq_num);
 		} else {
 			FAIL("stream[%zu]: %p seq_num was 0\n", i, cap_stream);
 			return;
@@ -565,7 +567,7 @@ static void test_broadcast_audio_stop(struct bt_cap_broadcast_source *broadcast_
 {
 	int err;
 
-	printk("Stopping broadcast source\n");
+	LOG_INF("Stopping broadcast source");
 
 	err = bt_cap_initiator_broadcast_audio_stop(broadcast_source);
 	if (err != 0) {
@@ -574,7 +576,7 @@ static void test_broadcast_audio_stop(struct bt_cap_broadcast_source *broadcast_
 	}
 
 	/* Wait for all to be stopped */
-	printk("Waiting for broadcast_streams to be stopped\n");
+	LOG_INF("Waiting for broadcast_streams to be stopped");
 	for (size_t i = 0U; i < stream_count; i++) {
 		err = k_sem_take(&sem_broadcast_stream_stopped, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
@@ -582,7 +584,7 @@ static void test_broadcast_audio_stop(struct bt_cap_broadcast_source *broadcast_
 
 	WAIT_FOR_UNSET_FLAG(flag_source_started);
 
-	printk("Broadcast source stopped\n");
+	LOG_INF("Broadcast source stopped");
 
 	/* Verify that it cannot be stopped twice */
 	err = bt_cap_initiator_broadcast_audio_stop(broadcast_source);
@@ -610,7 +612,7 @@ static void test_broadcast_audio_delete(struct bt_cap_broadcast_source *broadcas
 {
 	int err;
 
-	printk("Deleting broadcast source\n");
+	LOG_INF("Deleting broadcast source");
 
 	err = bt_cap_initiator_broadcast_audio_delete(broadcast_source);
 	if (err != 0) {
@@ -618,7 +620,7 @@ static void test_broadcast_audio_delete(struct bt_cap_broadcast_source *broadcas
 		return;
 	}
 
-	printk("Broadcast source deleted\n");
+	LOG_INF("Broadcast source deleted");
 
 	/* Verify that it cannot be deleted twice */
 	err = bt_cap_initiator_broadcast_audio_delete(broadcast_source);
@@ -649,7 +651,7 @@ static void test_main_cap_initiator_broadcast(void)
 	start_broadcast_adv(adv);
 
 	/* Wait for all to be started */
-	printk("Waiting for broadcast_streams to be started\n");
+	LOG_INF("Waiting for broadcast_streams to be started");
 	for (size_t i = 0U; i < stream_count; i++) {
 		__maybe_unused int err = k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
 
@@ -659,7 +661,7 @@ static void test_main_cap_initiator_broadcast(void)
 	WAIT_FOR_FLAG(flag_source_started);
 
 	/* Wait for other devices to have received the data they wanted */
-	printk("Waiting for broadcast stop signal");
+	LOG_INF("Waiting for broadcast stop signal");
 	backchannel_sync_wait_all();
 
 	test_broadcast_audio_tx_sync();
@@ -697,7 +699,7 @@ static void test_main_cap_initiator_broadcast_inval(void)
 	start_broadcast_adv(adv);
 
 	/* Wait for all to be started */
-	printk("Waiting for broadcast_streams to be started\n");
+	LOG_INF("Waiting for broadcast_streams to be started");
 	for (size_t i = 0U; i < stream_count; i++) {
 		__maybe_unused int err = k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
 
@@ -745,7 +747,7 @@ static void test_main_cap_initiator_broadcast_update(void)
 	start_broadcast_adv(adv);
 
 	/* Wait for all to be started */
-	printk("Waiting for broadcast_streams to be started\n");
+	LOG_INF("Waiting for broadcast_streams to be started");
 	for (size_t i = 0U; i < stream_count; i++) {
 		__maybe_unused int err = k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
 
@@ -841,7 +843,7 @@ static int test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 	start_broadcast_adv(adv);
 
 	/* Wait for all to be started */
-	printk("Waiting for broadcast_streams to be started\n");
+	LOG_INF("Waiting for broadcast_streams to be started");
 	for (size_t i = 0U; i < stream_count; i++) {
 		err = k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -31,7 +31,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/clock.h>
@@ -42,6 +42,8 @@
 #include "bstests.h"
 #include "common.h"
 #include "bap_common.h"
+
+LOG_MODULE_REGISTER(cap_initiator_unicast_test);
 
 #if defined(CONFIG_BT_CAP_INITIATOR_UNICAST)
 #define UNICAST_SINK_SUPPORTED (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0)
@@ -143,7 +145,7 @@ static void unicast_stream_codec_configured(struct bt_bap_stream *stream,
 
 	ARG_UNUSED(pref);
 
-	printk("Configured stream %p\n", stream);
+	LOG_INF("Configured stream %p", stream);
 
 	for (size_t i = 0U; i < ARRAY_SIZE(non_idle_streams); i++) {
 		if (non_idle_streams[i] == NULL) {
@@ -162,12 +164,12 @@ static void unicast_stream_codec_configured(struct bt_bap_stream *stream,
 
 static void unicast_stream_qos_configured(struct bt_bap_stream *stream)
 {
-	printk("QoS set stream %p\n", stream);
+	LOG_INF("QoS set stream %p", stream);
 }
 
 static void unicast_stream_enabled(struct bt_bap_stream *stream)
 {
-	printk("Enabled stream %p\n", stream);
+	LOG_INF("Enabled stream %p", stream);
 }
 
 static void unicast_stream_started(struct bt_bap_stream *stream)
@@ -181,7 +183,7 @@ static void unicast_stream_started(struct bt_bap_stream *stream)
 	test_stream->tx_cnt = 0U;
 	UNSET_FLAG(test_stream->flag_audio_received);
 
-	printk("Started stream %p\n", stream);
+	LOG_INF("Started stream %p", stream);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -196,17 +198,17 @@ static void unicast_stream_started(struct bt_bap_stream *stream)
 
 static void unicast_stream_metadata_updated(struct bt_bap_stream *stream)
 {
-	printk("Metadata updated stream %p\n", stream);
+	LOG_INF("Metadata updated stream %p", stream);
 }
 
 static void unicast_stream_disabled(struct bt_bap_stream *stream)
 {
-	printk("Disabled stream %p\n", stream);
+	LOG_INF("Disabled stream %p", stream);
 }
 
 static void unicast_stream_stopped(struct bt_bap_stream *stream, uint8_t reason)
 {
-	printk("Stopped stream %p with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stopped stream %p with reason 0x%02X", stream, reason);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -223,7 +225,7 @@ static void unicast_stream_released(struct bt_bap_stream *stream)
 {
 	struct bt_cap_stream *cap_stream = cap_stream_from_bap_stream(stream);
 
-	printk("Released stream %p\n", stream);
+	LOG_INF("Released stream %p", stream);
 
 	for (size_t i = 0U; i < ARRAY_SIZE(non_idle_streams); i++) {
 		if (non_idle_streams[i] == cap_stream) {
@@ -269,9 +271,9 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 			return;
 		}
 
-		printk("Found CAS with CSIS %p\n", csis_inst);
+		LOG_INF("Found CAS with CSIS %p", csis_inst);
 	} else {
-		printk("Found CAS\n");
+		LOG_INF("Found CAS");
 	}
 
 	SET_FLAG(flag_discovered);
@@ -282,7 +284,7 @@ static void unicast_start_complete_cb(int err, struct bt_conn *conn)
 	if (err == -ECANCELED) {
 		SET_FLAG(flag_start_timeout);
 	} else if (err != 0) {
-		printk("Failed to start (failing conn %p): %d\n", conn, err);
+		LOG_ERR("Failed to start (failing conn %p): %d", conn, err);
 		SET_FLAG(flag_start_failed);
 	} else {
 		SET_FLAG(flag_started);
@@ -324,7 +326,7 @@ static void add_remote_sink(const struct bt_conn *conn, struct bt_bap_ep *ep)
 
 	for (size_t i = 0U; i < ARRAY_SIZE(unicast_sink_eps[conn_index]); i++) {
 		if (unicast_sink_eps[conn_index][i] == NULL) {
-			printk("Conn[%u] %p: Sink #%zu: ep %p\n", conn_index, conn, i, ep);
+			LOG_DBG("Conn[%u] %p: Sink #%zu: ep %p", conn_index, conn, i, ep);
 			unicast_sink_eps[conn_index][i] = ep;
 			return;
 		}
@@ -339,7 +341,7 @@ static void add_remote_source(const struct bt_conn *conn, struct bt_bap_ep *ep)
 
 	for (size_t i = 0U; i < ARRAY_SIZE(unicast_source_eps[conn_index]); i++) {
 		if (unicast_source_eps[conn_index][i] == NULL) {
-			printk("Conn[%u] %p: Source #%zu: ep %p\n", conn_index, conn, i, ep);
+			LOG_DBG("Conn[%u] %p: Source #%zu: ep %p", conn_index, conn, i, ep);
 			unicast_source_eps[conn_index][i] = ep;
 			return;
 		}
@@ -350,7 +352,7 @@ static void add_remote_source(const struct bt_conn *conn, struct bt_bap_ep *ep)
 
 static void print_remote_codec(const struct bt_audio_codec_cap *codec_cap, enum bt_audio_dir dir)
 {
-	printk("codec_cap %p dir 0x%02x\n", codec_cap, dir);
+	LOG_DBG("codec_cap %p dir 0x%02x", codec_cap, dir);
 
 	print_codec_cap(codec_cap);
 }
@@ -374,11 +376,11 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 	}
 
 	if (dir == BT_AUDIO_DIR_SINK) {
-		printk("Sink discover complete\n");
+		LOG_INF("Sink discover complete");
 
 		SET_FLAG(flag_sink_discovered);
 	} else if (dir == BT_AUDIO_DIR_SOURCE) {
-		printk("Source discover complete\n");
+		LOG_INF("Source discover complete");
 
 		SET_FLAG(flag_source_discovered);
 	} else {
@@ -411,7 +413,7 @@ static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 	ARG_UNUSED(tx);
 	ARG_UNUSED(rx);
 
-	printk("MTU exchanged\n");
+	LOG_INF("MTU exchanged");
 	SET_FLAG(flag_mtu_exchanged);
 }
 
@@ -426,7 +428,7 @@ static bool check_audio_support_and_connect_cb(struct bt_data *data, void *user_
 	uint16_t uuid_val;
 	int err;
 
-	printk("data->type %u\n", data->type);
+	LOG_DBG("data->type %u", data->type);
 
 	if (data->type != BT_DATA_SVC_DATA16) {
 		return true; /* Continue parsing to next AD data type */
@@ -443,9 +445,9 @@ static bool check_audio_support_and_connect_cb(struct bt_data *data, void *user_
 		return true; /* Continue parsing to next AD data type */
 	}
 
-	printk("Device found: %s\n", bt_addr_le_str(addr));
+	LOG_INF("Device found: %s", bt_addr_le_str(addr));
 
-	printk("Stopping scan\n");
+	LOG_INF("Stopping scan");
 	if (bt_le_scan_stop()) {
 		FAIL("Could not stop scan");
 		return false;
@@ -492,7 +494,7 @@ static void init(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 	bap_stream_tx_init();
 
 	bt_gatt_cb_register(&gatt_callbacks);
@@ -545,7 +547,7 @@ static void scan_and_connect(void)
 		return;
 	}
 
-	printk("Scanning successfully started\n");
+	LOG_INF("Scanning successfully started");
 	WAIT_FOR_FLAG(flag_connected);
 	connected_conn_cnt++;
 }
@@ -561,7 +563,7 @@ static void discover_sink(struct bt_conn *conn)
 
 	err = bt_bap_unicast_client_discover(conn, BT_AUDIO_DIR_SINK);
 	if (err != 0) {
-		printk("Failed to discover sink: %d\n", err);
+		LOG_ERR("Failed to discover sink: %d", err);
 		return;
 	}
 
@@ -583,7 +585,7 @@ static void discover_source(struct bt_conn *conn)
 
 	err = bt_bap_unicast_client_discover(conn, BT_AUDIO_DIR_SOURCE);
 	if (err != 0) {
-		printk("Failed to discover sink: %d\n", err);
+		LOG_ERR("Failed to discover sink: %d", err);
 		return;
 	}
 
@@ -603,7 +605,7 @@ static void discover_cas_inval(struct bt_conn *conn)
 
 	err = bt_cap_initiator_unicast_discover(conn);
 	if (err != 0) {
-		printk("Failed to discover CAS: %d\n", err);
+		LOG_ERR("Failed to discover CAS: %d", err);
 		return;
 	}
 
@@ -625,7 +627,7 @@ static void discover_cas(struct bt_conn *conn)
 
 	err = bt_cap_initiator_unicast_discover(conn);
 	if (err != 0) {
-		printk("Failed to discover CAS: %d\n", err);
+		LOG_ERR("Failed to discover CAS: %d", err);
 		return;
 	}
 
@@ -842,7 +844,7 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 
 	/* Stop without release first to verify that we enter the QoS Configured state */
 	UNSET_FLAG(flag_stopped);
-	printk("Stopping without releasing\n");
+	LOG_INF("Stopping without releasing");
 
 	err = bt_cap_initiator_unicast_audio_stop(&param);
 	if (err != 0) {
@@ -863,7 +865,7 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 	/* Stop with release first to verify that we enter the idle state */
 	UNSET_FLAG(flag_stopped);
 	param.release = true;
-	printk("Releasing\n");
+	LOG_INF("Releasing");
 
 	err = bt_cap_initiator_unicast_audio_stop(&param);
 	if (err != 0) {
@@ -925,13 +927,13 @@ static void unicast_group_delete(struct bt_cap_unicast_group *unicast_group)
 
 static void wait_for_data(void)
 {
-	printk("Waiting for data\n");
+	LOG_INF("Waiting for data");
 	ARRAY_FOR_EACH_PTR(unicast_client_source_streams, test_stream) {
 		if (audio_test_stream_is_streaming(test_stream)) {
 			WAIT_FOR_FLAG(test_stream->flag_audio_received);
 		}
 	}
-	printk("Data received\n");
+	LOG_INF("Data received");
 }
 
 static void test_main_cap_initiator_unicast(void)
@@ -954,12 +956,12 @@ static void test_main_cap_initiator_unicast(void)
 	discover_source(default_conn);
 
 	for (size_t i = 0U; i < iterations; i++) {
-		printk("\nRunning iteration i=%zu\n\n", i);
+		LOG_INF("Running iteration i=%zu", i);
 
 		unicast_group_create(&unicast_group);
 
 		for (size_t j = 0U; j < iterations; j++) {
-			printk("\nRunning iteration j=%zu\n\n", i);
+			LOG_INF("Running iteration j=%zu", j);
 
 			ARRAY_FOR_EACH_PTR(unicast_client_sink_streams, test_stream) {
 				UNSET_FLAG(test_stream->flag_audio_received);
@@ -1051,7 +1053,7 @@ static void test_cap_initiator_unicast_timeout(void)
 	unicast_group_create(&unicast_group);
 
 	for (size_t j = 0U; j < iterations; j++) {
-		printk("\nRunning iteration #%zu\n\n", j);
+		LOG_INF("Running iteration #%zu", j);
 		unicast_audio_start(unicast_group, false);
 
 		k_sleep(timeout);
@@ -1450,7 +1452,7 @@ static int cap_initiator_ac_unicast(const struct cap_initiator_ac_param *param,
 
 	UNSET_FLAG(flag_started);
 
-	printk("Starting %zu streams for %s\n", snk_cnt + src_cnt, param->name);
+	LOG_INF("Starting %zu streams for %s", snk_cnt + src_cnt, param->name);
 	err = cap_initiator_ac_cap_unicast_start(param, snk_uni_streams, snk_cnt, src_uni_streams,
 						 src_cnt, *unicast_group);
 	if (err != 0) {
@@ -1471,7 +1473,7 @@ static void test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 	bool expect_tx = false;
 	bool expect_rx = false;
 
-	printk("Running test for %s with Sink Preset %s and Source Preset %s\n", param->name,
+	LOG_INF("Running test for %s with Sink Preset %s and Source Preset %s", param->name,
 	       param->snk_named_preset != NULL ? param->snk_named_preset->name : "None",
 	       param->src_named_preset != NULL ? param->src_named_preset->name : "None");
 
@@ -1494,7 +1496,7 @@ static void test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 
 		WAIT_FOR_FLAG(flag_mtu_exchanged);
 
-		printk("Connected %zu/%zu\n", i + 1, param->conn_cnt);
+		LOG_INF("Connected %zu/%zu", i + 1, param->conn_cnt);
 	}
 
 	if (connected_conn_cnt < param->conn_cnt) {
@@ -1528,7 +1530,7 @@ static void test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 	}
 
 	if (expect_rx) {
-		printk("Waiting for data\n");
+		LOG_INF("Waiting for data");
 		wait_for_data();
 	}
 

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -25,7 +25,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic_types.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -38,6 +38,8 @@
 #include "bsim_args_runner.h"
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(common);
 
 extern enum bst_result_t bst_result;
 struct bt_conn *default_conn;
@@ -95,7 +97,7 @@ static void device_found(const struct bt_le_scan_recv_info *info, struct net_buf
 		return;
 	}
 
-	printk("Device found: %s (RSSI %d)\n", bt_addr_le_str(info->addr), info->rssi);
+	LOG_INF("Device found: %s (RSSI %d)", bt_addr_le_str(info->addr), info->rssi);
 
 	/* connect only to devices in close proximity */
 	if (info->rssi < -70) {
@@ -103,7 +105,7 @@ static void device_found(const struct bt_le_scan_recv_info *info, struct net_buf
 		return;
 	}
 
-	printk("Stopping scan\n");
+	LOG_INF("Stopping scan");
 	if (bt_le_scan_stop()) {
 		FAIL("Could not stop scan");
 		return;
@@ -133,7 +135,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		return;
 	}
 
-	printk("Connected to %s (%p)\n", bt_conn_dst_str(conn), conn);
+	LOG_INF("Connected to %s (%p)", bt_conn_dst_str(conn), conn);
 	SET_FLAG(flag_connected);
 }
 
@@ -143,7 +145,7 @@ void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
+	LOG_INF("Disconnected: %s (reason 0x%02x)", bt_conn_dst_str(conn), reason);
 
 	bt_conn_drop(&default_conn);
 	UNSET_FLAG(flag_connected);
@@ -156,7 +158,7 @@ void disconnected(struct bt_conn *conn, uint8_t reason)
 static void conn_param_updated_cb(struct bt_conn *conn, uint16_t interval, uint16_t latency,
 				  uint16_t timeout)
 {
-	printk("Connection parameter updated: %p 0x%04X (%u us), 0x%04X, 0x%04X\n", conn, interval,
+	LOG_INF("Connection parameter updated: %p 0x%04X (%u us), 0x%04X, 0x%04X", conn, interval,
 	       BT_CONN_INTERVAL_TO_US(interval), latency, timeout);
 
 	SET_FLAG(flag_conn_updated);
@@ -164,7 +166,7 @@ static void conn_param_updated_cb(struct bt_conn *conn, uint16_t interval, uint1
 
 static void security_changed_cb(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
-	printk("Security changed: %p level %d err %d\n", conn, level, err);
+	LOG_INF("Security changed: %p level %d err %d", conn, level, err);
 
 	if (err == BT_SECURITY_ERR_SUCCESS) {
 		security_level = level;
@@ -189,7 +191,7 @@ void update_security(struct bt_conn *conn)
 	__ASSERT(err == 0, "Failed to get conn info: %d", err);
 
 	if (info.security.level >= BT_SECURITY_L2) {
-		printk("Skipping security update for %p\n", conn);
+		LOG_WRN("Skipping security update for %p", conn);
 		return;
 	}
 
@@ -238,7 +240,7 @@ void setup_connectable_adv(struct bt_le_ext_adv **ext_adv)
 		return;
 	}
 
-	printk("Advertising started\n");
+	LOG_INF("Advertising started");
 }
 
 void setup_broadcast_adv(struct bt_le_ext_adv **adv)
@@ -303,7 +305,7 @@ void start_broadcast_adv(struct bt_le_ext_adv *adv)
 		}
 	}
 
-	printk("Started advertising with addr %s\n", bt_addr_le_str(info.addr));
+	LOG_INF("Started advertising with addr %s", bt_addr_le_str(info.addr));
 }
 
 void test_tick(bs_time_t HW_device_time)
@@ -444,7 +446,7 @@ void backchannel_sync_send(uint dev)
 	const uint chan_id = get_chan_id_from_chan_num(get_chan_num((uint16_t)dev));
 	uint8_t sync_msg[SYNC_MSG_SIZE] = {0};
 
-	printk("Sending sync to %u\n", chan_id);
+	LOG_INF("Sending sync to %u", chan_id);
 	bs_bc_send_msg(chan_id, sync_msg, ARRAY_SIZE(sync_msg));
 }
 
@@ -463,7 +465,7 @@ void backchannel_sync_wait(uint dev)
 {
 	const uint chan_id = get_chan_id_from_chan_num(get_chan_num((uint16_t)dev));
 
-	printk("Waiting for sync to %u\n", chan_id);
+	LOG_INF("Waiting for sync to %u", chan_id);
 
 	while (true) {
 		if (bs_bc_is_msg_received(chan_id) > 0) {

--- a/tests/bsim/bluetooth/audio/src/csip_notify_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_client_test.c
@@ -12,12 +12,14 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/hci_types.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
 #include "common/bt_str.h"
+
+LOG_MODULE_REGISTER(csip_notify_client_test);
 
 extern enum bst_result_t bst_result;
 
@@ -58,7 +60,7 @@ static void test_main(void)
 {
 	int err;
 
-	printk("Enabling Bluetooth\n");
+	LOG_INF("Enabling Bluetooth");
 	err = bt_enable(NULL);
 	if (err != 0) {
 		FAIL("Bluetooth enable failed (err %d)\n", err);
@@ -71,21 +73,20 @@ static void test_main(void)
 		FAIL("Failed to register CSIP callbacks (err %d)\n", err);
 		return;
 	}
-
-	printk("Starting scan\n");
+	LOG_INF("Starting scan");
 	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
 	if (err != 0) {
 		FAIL("Could not start scanning (err %d)\n", err);
 		return;
 	}
 
-	printk("Waiting for connect\n");
+	LOG_INF("Waiting for connect");
 	WAIT_FOR_FLAG(flag_connected);
 
-	printk("Raising security\n");
+	LOG_INF("Raising security");
 	update_security(default_conn);
 
-	printk("Starting Discovery\n");
+	LOG_INF("Starting Discovery");
 	err = bt_csip_set_coordinator_discover(default_conn);
 	if (err != 0) {
 		FAIL("Could not start discovery (err %d)\n", err);
@@ -93,7 +94,7 @@ static void test_main(void)
 	}
 	WAIT_FOR_FLAG(flag_csip_set_lock_discovered);
 
-	printk("Waiting for all notifications to be received\n");
+	LOG_INF("Waiting for all notifications to be received");
 
 	WAIT_FOR_FLAG(flag_all_notifications_received);
 
@@ -106,23 +107,23 @@ static void test_main(void)
 	UNSET_FLAG(flag_all_notifications_received);
 	UNSET_FLAG(flag_csip_set_lock_discovered);
 
-	printk("Waiting for disconnect\n");
+	LOG_INF("Waiting for disconnect");
 	WAIT_FOR_UNSET_FLAG(flag_connected);
 
-	printk("Starting scan\n");
+	LOG_INF("Starting scan");
 	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
 	if (err != 0) {
 		FAIL("Could not start scanning (err %d)\n", err);
 		return;
 	}
 
-	printk("Waiting for reconnect\n");
+	LOG_INF("Waiting for reconnect");
 	WAIT_FOR_FLAG(flag_connected);
 
-	printk("Raising security\n");
+	LOG_INF("Raising security");
 	update_security(default_conn);
 
-	printk("Starting Discovery\n");
+	LOG_INF("Starting Discovery");
 	err = bt_csip_set_coordinator_discover(default_conn);
 	if (err != 0) {
 		FAIL("Could not start discovery (err %d)\n", err);
@@ -130,7 +131,7 @@ static void test_main(void)
 	}
 	WAIT_FOR_FLAG(flag_csip_set_lock_discovered);
 
-	printk("Waiting for all notifications to be received\n");
+	LOG_INF("Waiting for all notifications to be received");
 	WAIT_FOR_FLAG(flag_all_notifications_received);
 
 	err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
@@ -15,12 +15,14 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(csip_notify_server_test);
 
 extern enum bst_result_t bst_result;
 
@@ -32,7 +34,7 @@ static bool is_peer_subscribed(struct bt_conn *conn)
 
 	attr = bt_gatt_find_by_uuid(NULL, 0, BT_UUID_CSIS_SET_LOCK);
 	if (!attr) {
-		printk("No BT_UUID_PACS_SNK attribute found\n");
+		LOG_INF("No BT_UUID_CSIS_SET_LOCK attribute found");
 		return false;
 	}
 
@@ -45,7 +47,7 @@ static void csip_set_member_lock_changed_cb(struct bt_conn *conn,
 {
 	ARG_UNUSED(svc_inst);
 
-	printk("Client %p %s the lock\n", conn, locked ? "locked" : "released");
+	LOG_INF("Client %p %s the lock", conn, locked ? "locked" : "released");
 }
 
 static struct bt_csip_set_member_cb csip_cb = {
@@ -63,32 +65,32 @@ static void test_main(void)
 	};
 	struct bt_le_ext_adv *ext_adv;
 
-	printk("Enabling Bluetooth\n");
+	LOG_INF("Enabling Bluetooth");
 	err = bt_enable(NULL);
 	if (err != 0) {
 		FAIL("Bluetooth enable failed (err %d)\n", err);
 		return;
 	}
 
-	printk("Registering CSIP Set Member\n");
+	LOG_INF("Registering CSIP Set Member");
 
 	err = bt_cap_acceptor_register(&csip_params, &svc_inst);
 	if (err != 0) {
-		printk("Failed to register csip\n");
+		LOG_ERR("Failed to register csip");
 		return;
 	}
 
 	setup_connectable_adv(&ext_adv);
 
-	printk("Waiting to be connected\n");
+	LOG_INF("Waiting to be connected");
 	WAIT_FOR_FLAG(flag_connected);
-	printk("Connected\n");
-	printk("Waiting to be subscribed\n");
+	LOG_INF("Connected");
+	LOG_INF("Waiting to be subscribed");
 
 	while (!is_peer_subscribed(default_conn)) {
 		(void)k_sleep(K_MSEC(10U));
 	}
-	printk("Subscribed\n");
+	LOG_INF("Subscribed");
 
 	err = bt_csip_set_member_lock(svc_inst, true, false);
 	if (err != 0) {
@@ -97,9 +99,9 @@ static void test_main(void)
 	}
 
 	/* Now wait for client to disconnect */
-	printk("Wait for client disconnect\n");
+	LOG_INF("Wait for client disconnect");
 	WAIT_FOR_UNSET_FLAG(flag_connected);
-	printk("Client disconnected\n");
+	LOG_INF("Client disconnected");
 
 	/* Trigger changes while device is disconnected */
 	err = bt_csip_set_member_lock(svc_inst, false, false);
@@ -108,7 +110,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Start Advertising\n");
+	LOG_INF("Start Advertising");
 	err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err != 0) {
 		FAIL("Failed to start advertising set (err %d)\n", err);

--- a/tests/bsim/bluetooth/audio/src/csip_set_coordinator_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_coordinator_test.c
@@ -19,12 +19,14 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(csip_set_coordinator_test);
 
 #ifdef CONFIG_BT_CSIP_SET_COORDINATOR
 
@@ -54,7 +56,7 @@ static void csip_set_coordinator_lock_set_cb(int err);
 
 static void csip_set_coordinator_lock_release_cb(int err)
 {
-	printk("%s\n", __func__);
+	LOG_DBG("");
 
 	if (err != 0) {
 		FAIL("Release sets failed (%d)\n", err);
@@ -66,7 +68,7 @@ static void csip_set_coordinator_lock_release_cb(int err)
 
 static void csip_set_coordinator_lock_set_cb(int err)
 {
-	printk("%s\n", __func__);
+	LOG_DBG("");
 
 	if (err != 0) {
 		FAIL("Lock sets failed (%d)\n", err);
@@ -82,7 +84,7 @@ static void csip_discover_cb(struct bt_conn *conn,
 {
 	uint8_t conn_index;
 
-	printk("%s\n", __func__);
+	LOG_DBG("");
 
 	if (err != 0 || set_count == 0U) {
 		FAIL("Discover failed (%d)\n", err);
@@ -96,10 +98,10 @@ static void csip_discover_cb(struct bt_conn *conn,
 		const uint8_t set_size = member->insts[i].info.set_size;
 		const uint8_t lockable = member->insts[i].info.lockable;
 
-		printk("CSIS[%zu]: %p\n", i, &member->insts[i]);
-		printk("\tRank: %u\n", rank);
-		printk("\tSet Size: %u\n", set_size);
-		printk("\tLockable: %u\n", lockable);
+		LOG_DBG("CSIS[%zu]: %p", i, &member->insts[i]);
+		LOG_DBG("\tRank: %u", rank);
+		LOG_INF("\tSet Size: %u", set_size);
+		LOG_DBG("\tLockable: %u", lockable);
 
 		if ((expect_rank && rank == 0U) || (!expect_rank && rank != 0U)) {
 			FAIL("Unexpected rank: %u %u", expect_rank, rank);
@@ -131,12 +133,12 @@ static void csip_discover_cb(struct bt_conn *conn,
 static void csip_lock_changed_cb(struct bt_csip_set_coordinator_csis_inst *inst,
 				 bool locked)
 {
-	printk("inst %p %s\n", inst, locked ? "locked" : "released");
+	LOG_INF("inst %p %s", inst, locked ? "locked" : "released");
 }
 
 static void csip_sirk_changed_cb(struct bt_csip_set_coordinator_csis_inst *inst)
 {
-	printk("Inst %p SIRK changed\n", inst);
+	LOG_INF("Inst %p SIRK changed", inst);
 
 	SET_FLAG(flag_sirk_changed);
 }
@@ -146,7 +148,7 @@ static void csip_size_changed_cb(struct bt_conn *conn,
 {
 	ARG_UNUSED(conn);
 
-	printk("Inst %p size changed: %u\n", inst, inst->info.set_size);
+	LOG_INF("Inst %p size changed: %u", inst, inst->info.set_size);
 
 	SET_FLAG(flag_size_changed);
 }
@@ -160,10 +162,10 @@ static void csip_set_coordinator_ordered_access_cb(
 	if (err != 0) {
 		FAIL("Ordered access failed with err %d\n", err);
 	} else if (locked) {
-		printk("Ordered access procedure locked member %p\n", member);
+		LOG_INF("Ordered access procedure locked member %p", member);
 		ordered_access_locked = true;
 	} else {
-		printk("Ordered access procedure finished\n");
+		LOG_INF("Ordered access procedure finished");
 		ordered_access_unlocked = true;
 	}
 }
@@ -185,7 +187,7 @@ static bool csip_set_coordinator_oap_cb(const struct bt_csip_set_coordinator_set
 	ARG_UNUSED(set_info);
 
 	for (size_t i = 0U; i < count; i++) {
-		printk("Ordered access for members[%zu]: %p\n", i, members[i]);
+		LOG_DBG("Ordered access for members[%zu]: %p", i, members[i]);
 	}
 
 	return true;
@@ -207,10 +209,10 @@ static bool csip_found(struct bt_data *data, void *user_data)
 	    bt_csip_set_coordinator_is_set_member(primary_inst->info.sirk, data)) {
 		const bt_addr_le_t *addr = user_data;
 
-		printk("Found CSIP advertiser with address %s\n", bt_addr_le_str(addr));
+		LOG_INF("Found CSIP advertiser with address %s", bt_addr_le_str(addr));
 
 		if (is_discovered(addr)) {
-			printk("Set member already found\n");
+			LOG_INF("Set member already found");
 			/* Stop parsing */
 			return false;
 		}
@@ -219,10 +221,10 @@ static bool csip_found(struct bt_data *data, void *user_data)
 		members_found++;
 
 		if (primary_inst == NULL || primary_inst->info.set_size == 0U) {
-			printk("Found member %u\n", members_found);
+			LOG_INF("Found member %u", members_found);
 		} else {
-			printk("Found member (%u / %u)\n", members_found,
-			       primary_inst->info.set_size);
+			LOG_INF("Found member (%u / %u)", members_found,
+				primary_inst->info.set_size);
 		}
 
 		/* Stop parsing */
@@ -263,8 +265,8 @@ static void ordered_access(const struct bt_csip_set_coordinator_set_member **mem
 {
 	int err;
 
-	printk("Performing ordered access, expecting %s\n",
-	       expect_locked ? "locked" : "unlocked");
+	LOG_INF("Performing ordered access, expecting %s",
+		expect_locked ? "locked" : "unlocked");
 
 	if (expect_locked) {
 		ordered_access_locked = false;
@@ -312,7 +314,7 @@ static void init(void)
 		return;
 	}
 
-	printk("Audio Client: Bluetooth initialized\n");
+	LOG_INF("Audio Client: Bluetooth initialized");
 
 	err = bt_csip_set_coordinator_register_cb(&cbs);
 	if (err != 0) {
@@ -337,11 +339,11 @@ static void connect_set(void)
 		return;
 	}
 
-	printk("Scanning successfully started\n");
+	LOG_INF("Scanning successfully started");
 
 	WAIT_FOR_COND(members_found == 1U);
 
-	printk("Stopping scan\n");
+	LOG_INF("Stopping scan");
 	err = bt_le_scan_stop();
 	if (err != 0) {
 		FAIL("Could not stop scan");
@@ -356,7 +358,7 @@ static void connect_set(void)
 
 		return;
 	}
-	printk("Connecting to %s\n", bt_conn_dst_str(conns[0]));
+	LOG_INF("Connecting to %s", bt_conn_dst_str(conns[0]));
 
 	WAIT_FOR_FLAG(flag_connected);
 	connected_member_count++;
@@ -396,7 +398,7 @@ static void connect_set(void)
 
 	for (uint8_t i = 1U; i < members_found; i++) {
 		UNSET_FLAG(flag_connected);
-		printk("Connecting to member[%d] (%s)", i, bt_addr_le_str(&addr_found[i]));
+		LOG_INF("Connecting to member[%d] (%s)", i, bt_addr_le_str(&addr_found[i]));
 		err = bt_conn_le_create(&addr_found[i], BT_CONN_LE_CREATE_CONN,
 					BT_LE_CONN_PARAM_DEFAULT, &conns[i]);
 		if (err != 0) {
@@ -405,11 +407,11 @@ static void connect_set(void)
 			return;
 		}
 
-		printk("Connected to %s\n", bt_conn_dst_str(conns[i]));
+		LOG_INF("Connected to %s", bt_conn_dst_str(conns[i]));
 		WAIT_FOR_FLAG(flag_connected);
 		connected_member_count++;
 
-		printk("Doing discovery on member[%u]", i);
+		LOG_INF("Doing discovery on member[%u]", i);
 		discover_csis(conns[i]);
 	}
 }
@@ -419,7 +421,7 @@ static void disconnect_set(void)
 	for (uint8_t i = 0U; i < connected_member_count; i++) {
 		int err;
 
-		printk("Disconnecting member[%u] (%s)", i, bt_addr_le_str(&addr_found[i]));
+		LOG_INF("Disconnecting member[%u] (%s)", i, bt_addr_le_str(&addr_found[i]));
 		err = bt_conn_disconnect(conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 		(void)memset(&set_members[i], 0, sizeof(set_members[i]));
 		if (err != 0) {
@@ -446,7 +448,7 @@ static void test_main(void)
 	}
 
 	if (primary_inst->info.lockable) {
-		printk("Locking set\n");
+		LOG_INF("Locking set");
 		err = bt_csip_set_coordinator_lock(locked_members, connected_member_count,
 						   &primary_inst->info);
 		if (err != 0) {
@@ -464,7 +466,7 @@ static void test_main(void)
 	k_sleep(K_MSEC(1000U)); /* Simulate doing stuff */
 
 	if (primary_inst->info.lockable) {
-		printk("Releasing set\n");
+		LOG_INF("Releasing set");
 		err = bt_csip_set_coordinator_release(locked_members, connected_member_count,
 						      &primary_inst->info);
 		if (err != 0) {
@@ -484,7 +486,7 @@ static void test_main(void)
 		set_locked = false;
 		set_unlocked = false;
 
-		printk("Locking set\n");
+		LOG_INF("Locking set");
 		err = bt_csip_set_coordinator_lock(locked_members, connected_member_count,
 						   &primary_inst->info);
 		if (err != 0) {
@@ -498,7 +500,7 @@ static void test_main(void)
 	k_sleep(K_MSEC(1000U)); /* Simulate doing stuff */
 
 	if (primary_inst->info.lockable) {
-		printk("Releasing set\n");
+		LOG_INF("Releasing set");
 		err = bt_csip_set_coordinator_release(locked_members, connected_member_count,
 						      &primary_inst->info);
 		if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -13,13 +13,16 @@
 #include <zephyr/bluetooth/audio/csip.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gap.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
 #include "bs_tracing.h"
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(csip_set_member_test);
+
 #ifdef CONFIG_BT_CSIP_SET_MEMBER
 static struct bt_csip_set_member_svc_inst *svc_inst;
 extern enum bst_result_t bst_result;
@@ -37,7 +40,7 @@ static void csip_lock_changed_cb(struct bt_conn *conn,
 {
 	ARG_UNUSED(svc_inst);
 
-	printk("Client %p %s the lock\n", conn, locked ? "locked" : "released");
+	LOG_INF("Client %p %s the lock", conn, locked ? "locked" : "released");
 	g_locked = locked;
 }
 
@@ -64,7 +67,7 @@ static void bt_ready(int err)
 		return;
 	}
 
-	printk("Audio Server: Bluetooth initialized\n");
+	LOG_INF("Audio Server: Bluetooth initialized");
 
 	param.cb = &csip_cbs;
 
@@ -90,14 +93,14 @@ static void test_sirk(void)
 	struct bt_csip_set_member_set_info info;
 	int err;
 
-	printk("Setting new SIRK\n");
+	LOG_INF("Setting new SIRK");
 	err = bt_csip_set_member_sirk(svc_inst, new_sirk);
 	if (err != 0) {
 		FAIL("Failed to set SIRK: %d\n", err);
 		return;
 	}
 
-	printk("Getting new SIRK\n");
+	LOG_INF("Getting new SIRK");
 	err = bt_csip_set_member_get_info(svc_inst, &info);
 	if (err != 0) {
 		FAIL("Failed to get SIRK: %d\n", err);
@@ -109,7 +112,7 @@ static void test_sirk(void)
 		return;
 	}
 
-	printk("New SIRK correctly set and retrieved\n");
+	LOG_INF("New SIRK correctly set and retrieved");
 }
 
 static void update_set_size_and_rank(void)
@@ -135,14 +138,14 @@ static void update_set_size_and_rank(void)
 	new_set_size = old_set_size + 1U;
 	new_rank = old_rank + 1U;
 
-	printk("Setting new SIRK\n");
+	LOG_INF("Setting new SIRK");
 	err = bt_csip_set_member_set_size_and_rank(svc_inst, new_set_size, new_rank);
 	if (err != 0) {
 		FAIL("Failed to set new size and rank: %d\n", err);
 		return;
 	}
 
-	printk("Getting new SIRK\n");
+	LOG_INF("Getting new SIRK");
 	err = bt_csip_set_member_get_info(svc_inst, &info);
 	if (err != 0) {
 		FAIL("Failed to get SIRK: %d\n", err);
@@ -159,7 +162,7 @@ static void update_set_size_and_rank(void)
 		return;
 	}
 
-	printk("New size correctly set and retrieved\n");
+	LOG_INF("New size correctly set and retrieved");
 }
 
 static void test_main(void)
@@ -212,7 +215,7 @@ static void test_force_release(void)
 	WAIT_FOR_FLAG(flag_connected);
 
 	WAIT_FOR_COND(g_locked);
-	printk("Force releasing set\n");
+	LOG_INF("Force releasing set");
 	err = bt_csip_set_member_lock(svc_inst, false, true);
 	if (err != 0) {
 		FAIL("Could not force release set (err %d)\n", err);
@@ -233,7 +236,7 @@ static void test_force_release(void)
 
 static void test_csip_enc(void)
 {
-	printk("Running %s\n", __func__);
+	LOG_INF("Running %s", __func__);
 	sirk_read_req_rsp = BT_CSIP_READ_SIRK_REQ_RSP_ACCEPT_ENC;
 	test_main();
 }
@@ -305,7 +308,7 @@ static void test_register(void)
 			*svc_insts[CONFIG_BT_CSIP_SET_MEMBER_MAX_INSTANCE_COUNT];
 		int err;
 
-		printk("Running iteration %zu\n", iteration + 1);
+		LOG_INF("Running iteration %zu", iteration + 1);
 
 		/* Run with different parameters for each iteration */
 		param.lockable = !param.lockable;

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -33,7 +33,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -43,6 +43,8 @@
 #include "bstests.h"
 #include "common.h"
 #include "bap_common.h"
+
+LOG_MODULE_REGISTER(gmap_ugg_test);
 
 #if defined(CONFIG_BT_GMAP)
 
@@ -166,7 +168,7 @@ static void stream_codec_configured_cb(struct bt_bap_stream *stream,
 {
 	ARG_UNUSED(pref);
 
-	printk("Configured stream %p\n", stream);
+	LOG_INF("Configured stream %p", stream);
 
 	/* TODO: The preference should be used/taken into account when
 	 * setting the QoS
@@ -175,12 +177,12 @@ static void stream_codec_configured_cb(struct bt_bap_stream *stream,
 
 static void stream_qos_configured_cb(struct bt_bap_stream *stream)
 {
-	printk("QoS set stream %p\n", stream);
+	LOG_INF("QoS set stream %p", stream);
 }
 
 static void stream_enabled_cb(struct bt_bap_stream *stream)
 {
-	printk("Enabled stream %p\n", stream);
+	LOG_INF("Enabled stream %p", stream);
 }
 
 static void stream_started_cb(struct bt_bap_stream *stream)
@@ -194,7 +196,7 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 	test_stream->tx_cnt = 0U;
 	UNSET_FLAG(test_stream->flag_audio_received);
 
-	printk("Started stream %p\n", stream);
+	LOG_INF("Started stream %p", stream);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -211,17 +213,17 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 
 static void stream_metadata_updated_cb(struct bt_bap_stream *stream)
 {
-	printk("Metadata updated stream %p\n", stream);
+	LOG_INF("Metadata updated stream %p", stream);
 }
 
 static void stream_disabled_cb(struct bt_bap_stream *stream)
 {
-	printk("Disabled stream %p\n", stream);
+	LOG_INF("Disabled stream %p", stream);
 }
 
 static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
-	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stream %p stopped with reason 0x%02X", stream, reason);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -238,7 +240,7 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 
 static void stream_released_cb(struct bt_bap_stream *stream)
 {
-	printk("Released stream %p\n", stream);
+	LOG_INF("Released stream %p", stream);
 }
 
 static struct bt_bap_stream_ops stream_ops = {
@@ -274,9 +276,9 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 			return;
 		}
 
-		printk("Found CAS with CSIS %p\n", csis_inst);
+		LOG_INF("Found CAS with CSIS %p", csis_inst);
 	} else {
-		printk("Found CAS\n");
+		LOG_INF("Found CAS");
 	}
 
 	SET_FLAG(flag_cas_discovered);
@@ -326,7 +328,7 @@ static void add_remote_sink_ep(struct bt_conn *conn, struct bt_bap_ep *ep)
 {
 	for (size_t i = 0U; i < ARRAY_SIZE(sink_eps[bt_conn_index(conn)]); i++) {
 		if (sink_eps[bt_conn_index(conn)][i] == NULL) {
-			printk("Conn %p: Sink #%zu: ep %p\n", conn, i, ep);
+			LOG_DBG("Conn %p: Sink #%zu: ep %p", conn, i, ep);
 			sink_eps[bt_conn_index(conn)][i] = ep;
 			break;
 		}
@@ -337,7 +339,7 @@ static void add_remote_source_ep(struct bt_conn *conn, struct bt_bap_ep *ep)
 {
 	for (size_t i = 0U; i < ARRAY_SIZE(source_eps[bt_conn_index(conn)]); i++) {
 		if (source_eps[bt_conn_index(conn)][i] == NULL) {
-			printk("Conn %p: Source #%zu: ep %p\n", conn, i, ep);
+			LOG_DBG("Conn %p: Source #%zu: ep %p", conn, i, ep);
 			source_eps[bt_conn_index(conn)][i] = ep;
 			break;
 		}
@@ -347,7 +349,7 @@ static void add_remote_source_ep(struct bt_conn *conn, struct bt_bap_ep *ep)
 static void bap_pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 			      const struct bt_audio_codec_cap *codec_cap)
 {
-	printk("conn %p codec_cap %p dir 0x%02x\n", conn, codec_cap, dir);
+	LOG_DBG("conn %p codec_cap %p dir 0x%02x", conn, codec_cap, dir);
 
 	print_codec_cap(codec_cap);
 }
@@ -371,10 +373,10 @@ static void bap_discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir
 	}
 
 	if (dir == BT_AUDIO_DIR_SINK) {
-		printk("Sink discover complete\n");
+		LOG_INF("Sink discover complete");
 		SET_FLAG(flag_sink_discovered);
 	} else if (dir == BT_AUDIO_DIR_SOURCE) {
-		printk("Source discover complete\n");
+		LOG_INF("Source discover complete");
 		SET_FLAG(flag_source_discovered);
 	}
 }
@@ -391,7 +393,7 @@ static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 	ARG_UNUSED(tx);
 	ARG_UNUSED(rx);
 
-	printk("MTU exchanged\n");
+	LOG_INF("MTU exchanged");
 	SET_FLAG(flag_mtu_exchanged);
 }
 
@@ -409,8 +411,8 @@ static void gmap_discover_cb(struct bt_conn *conn, int err, enum bt_gmap_role ro
 		return;
 	}
 
-	printk("GMAP discovered for conn %p:\n\trole 0x%02x\n\tugg_feat 0x%02x\n\tugt_feat "
-	       "0x%02x\n\tbgs_feat 0x%02x\n\tbgr_feat 0x%02x\n",
+	LOG_INF("GMAP discovered for conn %p:\trole 0x%02x\tugg_feat 0x%02x\tugt_feat "
+	       "0x%02x\tbgs_feat 0x%02x\tbgr_feat 0x%02x",
 	       conn, role, features.ugg_feat, features.ugt_feat, features.bgs_feat,
 	       features.bgr_feat);
 
@@ -458,7 +460,7 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info, struct net_buf
 		return;
 	}
 
-	printk("Device found: %s (RSSI %d)\n", bt_addr_le_str(info->addr), info->rssi);
+	LOG_INF("Device found: %s (RSSI %d)", bt_addr_le_str(info->addr), info->rssi);
 
 	/* connect only to devices in close proximity */
 	if (info->rssi < -70) {
@@ -466,7 +468,7 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info, struct net_buf
 		return;
 	}
 
-	printk("Stopping scan\n");
+	LOG_INF("Stopping scan");
 	if (bt_le_scan_stop()) {
 		FAIL("Could not stop scan");
 		return;
@@ -499,7 +501,7 @@ static void init(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 	bap_stream_tx_init();
 
 	bt_gatt_cb_register(&gatt_callbacks);
@@ -581,7 +583,7 @@ static void scan_and_connect(void)
 		return;
 	}
 
-	printk("Scanning successfully started\n");
+	LOG_INF("Scanning successfully started");
 	WAIT_FOR_FLAG(flag_connected);
 	connected_conn_cnt++;
 }
@@ -594,7 +596,7 @@ static void discover_sink(struct bt_conn *conn)
 
 	err = bt_bap_unicast_client_discover(conn, BT_AUDIO_DIR_SINK);
 	if (err != 0) {
-		printk("Failed to discover sink: %d\n", err);
+		LOG_ERR("Failed to discover sink: %d", err);
 		return;
 	}
 
@@ -609,7 +611,7 @@ static void discover_source(struct bt_conn *conn)
 
 	err = bt_bap_unicast_client_discover(conn, BT_AUDIO_DIR_SOURCE);
 	if (err != 0) {
-		printk("Failed to discover source: %d\n", err);
+		LOG_ERR("Failed to discover source: %d", err);
 		return;
 	}
 
@@ -624,7 +626,7 @@ static void discover_gmas(struct bt_conn *conn)
 
 	err = bt_gmap_discover(conn);
 	if (err != 0) {
-		printk("Failed to discover GMAS: %d\n", err);
+		LOG_ERR("Failed to discover GMAS: %d", err);
 		return;
 	}
 
@@ -639,7 +641,7 @@ static void discover_cas(struct bt_conn *conn)
 
 	err = bt_cap_initiator_unicast_discover(conn);
 	if (err != 0) {
-		printk("Failed to discover CAS: %d\n", err);
+		LOG_ERR("Failed to discover CAS: %d", err);
 		return;
 	}
 
@@ -927,7 +929,7 @@ static int gmap_ac_unicast(const struct gmap_unicast_ac_param *param,
 
 	UNSET_FLAG(flag_started);
 
-	printk("Starting %zu streams for %s\n", snk_cnt + src_cnt, param->name);
+	LOG_INF("Starting %zu streams for %s", snk_cnt + src_cnt, param->name);
 	err = gmap_ac_cap_unicast_start(param, snk_uni_streams, snk_cnt, src_uni_streams, src_cnt,
 					*unicast_group);
 	if (err != 0) {
@@ -983,7 +985,7 @@ static void unicast_group_delete(struct bt_cap_unicast_group *unicast_group)
 
 static void wait_for_data(void)
 {
-	printk("Waiting for data\n");
+	LOG_INF("Waiting for data");
 
 	ARRAY_FOR_EACH_PTR(unicast_streams, unicast_stream) {
 		if (bap_stream_rx_can_recv(&unicast_stream->stream.stream.bap_stream) &&
@@ -992,7 +994,7 @@ static void wait_for_data(void)
 		}
 	}
 
-	printk("Data received\n");
+	LOG_INF("Data received");
 }
 
 static void test_gmap_ugg_unicast_ac(const struct gmap_unicast_ac_param *param)
@@ -1001,7 +1003,7 @@ static void test_gmap_ugg_unicast_ac(const struct gmap_unicast_ac_param *param)
 	bool expect_tx = false;
 	bool expect_rx = false;
 
-	printk("Running test for %s with Sink Preset %s and Source Preset %s\n", param->name,
+	LOG_INF("Running test for %s with Sink Preset %s and Source Preset %s", param->name,
 	       param->snk_named_preset != NULL ? param->snk_named_preset->name : "None",
 	       param->src_named_preset != NULL ? param->src_named_preset->name : "None");
 
@@ -1019,7 +1021,7 @@ static void test_gmap_ugg_unicast_ac(const struct gmap_unicast_ac_param *param)
 
 		WAIT_FOR_FLAG(flag_mtu_exchanged);
 
-		printk("Connected %zu/%zu\n", i + 1, param->conn_cnt);
+		LOG_INF("Connected %zu/%zu", i + 1, param->conn_cnt);
 	}
 
 	if (connected_conn_cnt < param->conn_cnt) {
@@ -1163,7 +1165,7 @@ static void broadcast_audio_start(struct bt_cap_broadcast_source *broadcast_sour
 		return;
 	}
 
-	printk("Broadcast source created\n");
+	LOG_INF("Broadcast source created");
 }
 
 static void broadcast_audio_stop(struct bt_cap_broadcast_source *broadcast_source,
@@ -1171,7 +1173,7 @@ static void broadcast_audio_stop(struct bt_cap_broadcast_source *broadcast_sourc
 {
 	int err;
 
-	printk("Stopping broadcast source\n");
+	LOG_INF("Stopping broadcast source");
 
 	err = bt_cap_initiator_broadcast_audio_stop(broadcast_source);
 	if (err != 0) {
@@ -1180,20 +1182,20 @@ static void broadcast_audio_stop(struct bt_cap_broadcast_source *broadcast_sourc
 	}
 
 	/* Wait for all to be stopped */
-	printk("Waiting for broadcast_streams to be stopped\n");
+	LOG_INF("Waiting for broadcast_streams to be stopped");
 	for (size_t i = 0U; i < stream_count; i++) {
 		err = k_sem_take(&sem_stream_stopped, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
 	}
 
-	printk("Broadcast source stopped\n");
+	LOG_INF("Broadcast source stopped");
 }
 
 static void broadcast_audio_delete(struct bt_cap_broadcast_source *broadcast_source)
 {
 	int err;
 
-	printk("Deleting broadcast source\n");
+	LOG_INF("Deleting broadcast source");
 
 	err = bt_cap_initiator_broadcast_audio_delete(broadcast_source);
 	if (err != 0) {
@@ -1201,7 +1203,7 @@ static void broadcast_audio_delete(struct bt_cap_broadcast_source *broadcast_sou
 		return;
 	}
 
-	printk("Broadcast source deleted\n");
+	LOG_INF("Broadcast source deleted");
 }
 
 static int test_gmap_ugg_broadcast_ac(const struct gmap_broadcast_ac_param *param)
@@ -1269,7 +1271,7 @@ static int test_gmap_ugg_broadcast_ac(const struct gmap_broadcast_ac_param *para
 	start_broadcast_adv(adv);
 
 	/* Wait for all to be started */
-	printk("Waiting for broadcast_streams to be started\n");
+	LOG_INF("Waiting for broadcast_streams to be started");
 	for (size_t i = 0U; i < param->stream_cnt; i++) {
 		err = k_sem_take(&sem_stream_started, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);

--- a/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
@@ -25,7 +25,7 @@
 #include <zephyr/bluetooth/data.h>
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/uuid.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -35,6 +35,8 @@
 #include "bstests.h"
 #include "common.h"
 #include "bap_common.h"
+
+LOG_MODULE_REGISTER(gmap_ugt_test);
 
 #if defined(CONFIG_BT_CAP_ACCEPTOR)
 extern enum bst_result_t bst_result;
@@ -66,7 +68,7 @@ static void unicast_stream_enabled_cb(struct bt_bap_stream *stream)
 	struct bt_bap_ep_info ep_info;
 	int err;
 
-	printk("Enabled: stream %p\n", stream);
+	LOG_INF("Enabled: stream %p", stream);
 
 	err = bt_bap_ep_get_info(stream->ep, &ep_info);
 	if (err != 0) {
@@ -96,7 +98,7 @@ static void unicast_stream_started_cb(struct bt_bap_stream *stream)
 	test_stream->tx_cnt = 0U;
 	UNSET_FLAG(test_stream->flag_audio_received);
 
-	printk("Started stream %p\n", stream);
+	LOG_INF("Started stream %p", stream);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -115,7 +117,7 @@ static void unicast_stream_started_cb(struct bt_bap_stream *stream)
 
 static void unicast_stream_stopped(struct bt_bap_stream *stream, uint8_t reason)
 {
-	printk("Stopped stream %p with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stopped stream %p with reason 0x%02X", stream, reason);
 
 	if (bap_stream_tx_can_send(stream)) {
 		int err;
@@ -158,19 +160,19 @@ static int unicast_server_config(struct bt_conn *conn, const struct bt_bap_ep *e
 				 struct bt_bap_qos_cfg_pref *const pref,
 				 struct bt_bap_ascs_rsp *rsp)
 {
-	printk("ASE Codec Config: conn %p ep %p dir %u\n", conn, ep, dir);
+	LOG_INF("ASE Codec Config: conn %p ep %p dir %u", conn, ep, dir);
 
 	print_codec_cfg(codec_cfg);
 
 	*stream = unicast_stream_alloc();
 	if (*stream == NULL) {
-		printk("No streams available\n");
+		LOG_INF("No streams available");
 		*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_NO_MEM, BT_BAP_ASCS_REASON_NONE);
 
 		return -ENOMEM;
 	}
 
-	printk("ASE Codec Config stream %p\n", *stream);
+	LOG_INF("ASE Codec Config stream %p", *stream);
 
 	*pref = unicast_qos_pref;
 
@@ -184,7 +186,7 @@ static int unicast_server_reconfig(struct bt_bap_stream *stream, enum bt_audio_d
 {
 	ARG_UNUSED(dir);
 
-	printk("ASE Codec Reconfig: stream %p\n", stream);
+	LOG_INF("ASE Codec Reconfig: stream %p", stream);
 
 	print_codec_cfg(codec_cfg);
 
@@ -201,7 +203,7 @@ static int unicast_server_qos(struct bt_bap_stream *stream, const struct bt_bap_
 {
 	ARG_UNUSED(rsp);
 
-	printk("QoS: stream %p qos %p\n", stream, qos);
+	LOG_INF("QoS: stream %p qos %p", stream, qos);
 
 	print_qos(qos);
 
@@ -213,7 +215,7 @@ static bool data_func_cb(struct bt_data *data, void *user_data)
 	struct bt_bap_ascs_rsp *rsp = (struct bt_bap_ascs_rsp *)user_data;
 
 	if (!BT_AUDIO_METADATA_TYPE_IS_KNOWN(data->type)) {
-		printk("Invalid metadata type %u or length %u\n", data->type, data->data_len);
+		LOG_ERR("Invalid metadata type %u or length %u", data->type, data->data_len);
 		*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_METADATA_REJECTED, data->type);
 
 		return -EINVAL;
@@ -225,7 +227,7 @@ static bool data_func_cb(struct bt_data *data, void *user_data)
 static int unicast_server_enable(struct bt_bap_stream *stream, const uint8_t meta[],
 				 size_t meta_len, struct bt_bap_ascs_rsp *rsp)
 {
-	printk("Enable: stream %p meta_len %zu\n", stream, meta_len);
+	LOG_INF("Enable: stream %p meta_len %zu", stream, meta_len);
 
 	return bt_audio_data_parse(meta, meta_len, data_func_cb, rsp);
 }
@@ -234,7 +236,7 @@ static int unicast_server_start(struct bt_bap_stream *stream, struct bt_bap_ascs
 {
 	ARG_UNUSED(rsp);
 
-	printk("Start: stream %p\n", stream);
+	LOG_INF("Start: stream %p", stream);
 
 	return 0;
 }
@@ -242,7 +244,7 @@ static int unicast_server_start(struct bt_bap_stream *stream, struct bt_bap_ascs
 static int unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t meta[],
 				   size_t meta_len, struct bt_bap_ascs_rsp *rsp)
 {
-	printk("Metadata: stream %p meta_len %zu\n", stream, meta_len);
+	LOG_INF("Metadata: stream %p meta_len %zu", stream, meta_len);
 
 	return bt_audio_data_parse(meta, meta_len, data_func_cb, rsp);
 }
@@ -251,7 +253,7 @@ static int unicast_server_disable(struct bt_bap_stream *stream, struct bt_bap_as
 {
 	ARG_UNUSED(rsp);
 
-	printk("Disable: stream %p\n", stream);
+	LOG_INF("Disable: stream %p", stream);
 
 	return 0;
 }
@@ -260,7 +262,7 @@ static int unicast_server_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_
 {
 	ARG_UNUSED(rsp);
 
-	printk("Stop: stream %p\n", stream);
+	LOG_INF("Stop: stream %p", stream);
 
 	return 0;
 }
@@ -269,7 +271,7 @@ static int unicast_server_release(struct bt_bap_stream *stream, struct bt_bap_as
 {
 	ARG_UNUSED(rsp);
 
-	printk("Release: stream %p\n", stream);
+	LOG_INF("Release: stream %p", stream);
 
 	return 0;
 }
@@ -311,7 +313,7 @@ static void set_location(void)
 		}
 	}
 
-	printk("Location successfully set\n");
+	LOG_INF("Location successfully set");
 }
 
 static int set_supported_contexts(void)
@@ -321,7 +323,7 @@ static int set_supported_contexts(void)
 	if (IS_ENABLED(CONFIG_BT_PAC_SNK)) {
 		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK, CONTEXT);
 		if (err != 0) {
-			printk("Failed to set sink supported contexts (err %d)\n", err);
+			LOG_ERR("Failed to set sink supported contexts (err %d)", err);
 
 			return err;
 		}
@@ -330,13 +332,13 @@ static int set_supported_contexts(void)
 	if (IS_ENABLED(CONFIG_BT_PAC_SRC)) {
 		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SOURCE, CONTEXT);
 		if (err != 0) {
-			printk("Failed to set source supported contexts (err %d)\n", err);
+			LOG_ERR("Failed to set source supported contexts (err %d)", err);
 
 			return err;
 		}
 	}
 
-	printk("Supported contexts successfully set\n");
+	LOG_INF("Supported contexts successfully set");
 
 	return 0;
 }
@@ -357,7 +359,7 @@ static void set_available_contexts(void)
 		return;
 	}
 
-	printk("Available contexts successfully set\n");
+	LOG_INF("Available contexts successfully set");
 }
 
 static void gmap_discover_cb(struct bt_conn *conn, int err, enum bt_gmap_role role,
@@ -370,10 +372,10 @@ static void gmap_discover_cb(struct bt_conn *conn, int err, enum bt_gmap_role ro
 		return;
 	}
 
-	printk("GMAP discovered for conn %p:\n\trole 0x%02x\n\tugg_feat 0x%02x\n\tugt_feat "
-	       "0x%02x\n\tbgs_feat 0x%02x\n\tbgr_feat 0x%02x\n",
-	       conn, role, features.ugg_feat, features.ugt_feat, features.bgs_feat,
-	       features.bgr_feat);
+	LOG_INF("GMAP discovered for conn %p:\trole 0x%02x\tugg_feat 0x%02x\tugt_feat "
+		"0x%02x\tbgs_feat 0x%02x\tbgr_feat 0x%02x",
+		conn, role, features.ugg_feat, features.ugt_feat, features.bgs_feat,
+		features.bgr_feat);
 
 	if ((role & BT_GMAP_ROLE_UGG) == 0) {
 		FAIL("Remote GMAP device is not a UGG\n");
@@ -403,7 +405,7 @@ static void discover_gmas(struct bt_conn *conn)
 
 	err = bt_gmap_discover(conn);
 	if (err != 0) {
-		printk("Failed to discover GMAS: %d\n", err);
+		LOG_ERR("Failed to discover GMAS: %d", err);
 		return;
 	}
 
@@ -412,7 +414,7 @@ static void discover_gmas(struct bt_conn *conn)
 
 static void wait_for_data(void)
 {
-	printk("Waiting for data\n");
+	LOG_INF("Waiting for data");
 
 	ARRAY_FOR_EACH_PTR(unicast_streams, test_stream) {
 		if (bap_stream_rx_can_recv(&test_stream->stream.bap_stream) &&
@@ -421,7 +423,7 @@ static void wait_for_data(void)
 		}
 	}
 
-	printk("Data received\n");
+	LOG_INF("Data received");
 	/* let initiator know we have received what we wanted */
 	backchannel_sync_send(GMAP_UGG_DEV_ID);
 }
@@ -462,7 +464,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 	bap_stream_tx_init();
 
 	err = bt_pacs_register(&pacs_param);

--- a/tests/bsim/bluetooth/audio/src/ias_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/ias_client_test.c
@@ -10,11 +10,13 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/services/ias.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(ias_client_test);
 
 #ifdef CONFIG_BT_IAS_CLIENT
 
@@ -31,7 +33,7 @@ static void discover_cb(struct bt_conn *conn, int err)
 		return;
 	}
 
-	printk("IAS discovered\n");
+	LOG_INF("IAS discovered");
 	SET_FLAG(g_service_discovered);
 }
 
@@ -45,7 +47,7 @@ static void test_alert_high(struct bt_conn *conn)
 
 	err = bt_ias_client_alert_write(conn, BT_IAS_ALERT_LVL_HIGH_ALERT);
 	if (err == 0) {
-		printk("High alert sent\n");
+		LOG_INF("High alert sent");
 	} else {
 		FAIL("Failed to send high alert\n");
 	}
@@ -57,7 +59,7 @@ static void test_alert_mild(struct bt_conn *conn)
 
 	err = bt_ias_client_alert_write(conn, BT_IAS_ALERT_LVL_MILD_ALERT);
 	if (err == 0) {
-		printk("Mild alert sent\n");
+		LOG_INF("Mild alert sent");
 	} else {
 		FAIL("Failed to send mild alert\n");
 	}
@@ -69,7 +71,7 @@ static void test_alert_stop(struct bt_conn *conn)
 
 	err = bt_ias_client_alert_write(conn, BT_IAS_ALERT_LVL_NO_ALERT);
 	if (err == 0) {
-		printk("Stop alert sent\n");
+		LOG_INF("Stop alert sent");
 	} else {
 		FAIL("Failed to send no alert\n");
 	}
@@ -100,7 +102,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	err = bt_ias_client_cb_register(&ias_client_cb);
 	if (err < 0) {
@@ -116,7 +118,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Scanning successfully started\n");
+	LOG_INF("Scanning successfully started");
 
 	WAIT_FOR_FLAG(flag_connected);
 

--- a/tests/bsim/bluetooth/audio/src/ias_test.c
+++ b/tests/bsim/bluetooth/audio/src/ias_test.c
@@ -13,11 +13,13 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/services/ias.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/types.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(ias_test);
 
 #ifdef CONFIG_BT_IAS
 extern enum bst_result_t bst_result;
@@ -63,7 +65,7 @@ static void test_main(void)
 	WAIT_FOR_FLAG(flag_connected);
 
 	WAIT_FOR_FLAG(g_high_alert_received);
-	printk("High alert received\n");
+	LOG_INF("High alert received");
 
 	err = bt_ias_local_alert_stop();
 	if (err != 0) {
@@ -73,10 +75,10 @@ static void test_main(void)
 	WAIT_FOR_FLAG(g_stop_alert_received);
 
 	WAIT_FOR_FLAG(g_mild_alert_received);
-	printk("Mild alert received\n");
+	LOG_INF("Mild alert received");
 
 	WAIT_FOR_FLAG(g_stop_alert_received);
-	printk("Stop alert received\n");
+	LOG_INF("Stop alert received");
 
 	PASS("IAS test passed\n");
 }

--- a/tests/bsim/bluetooth/audio/src/mcc_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcc_test.c
@@ -19,11 +19,13 @@
 #include <zephyr/bluetooth/services/ots.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(mcc_test);
 
 #ifdef CONFIG_BT_MCC
 extern enum bst_result_t bst_result;
@@ -708,7 +710,7 @@ static void test_select_obj_id(uint64_t id)
 	}
 
 	WAIT_FOR_FLAG(object_selected);
-	printk("Selecting object succeeded\n");
+	LOG_INF("Selecting object succeeded");
 }
 
 static void test_read_object_meta(void)
@@ -732,7 +734,7 @@ static void test_read_object_meta(void)
 	}
 
 	WAIT_FOR_FLAG(metadata_read);
-	printk("Reading object metadata succeeded\n");
+	LOG_INF("Reading object metadata succeeded");
 }
 
 /* Helper function to read the media state and verify that it is as expected
@@ -783,7 +785,7 @@ static void test_read_supported_opcodes(void)
 	}
 
 	WAIT_FOR_FLAG(supported_opcodes_read);
-	printk("Supported opcodes read succeeded\n");
+	LOG_INF("Supported opcodes read succeeded");
 }
 
 /* This will only test invalid behavior for send_cmd as valid behavior is
@@ -865,7 +867,7 @@ static void test_cp_play(void)
 	}
 
 	if (test_verify_media_state_wait_flags(BT_MCS_MEDIA_STATE_PLAYING)) {
-		printk("PLAY command succeeded\n");
+		LOG_INF("PLAY command succeeded");
 	}
 }
 
@@ -884,7 +886,7 @@ static void test_cp_pause(void)
 	}
 
 	if (test_verify_media_state_wait_flags(BT_MCS_MEDIA_STATE_PAUSED)) {
-		printk("PAUSE command succeeded\n");
+		LOG_INF("PAUSE command succeeded");
 	}
 }
 
@@ -906,7 +908,7 @@ static void test_cp_fast_rewind(void)
 	}
 
 	if (test_verify_media_state_wait_flags(BT_MCS_MEDIA_STATE_SEEKING)) {
-		printk("FAST REWIND command succeeded\n");
+		LOG_INF("FAST REWIND command succeeded");
 	}
 
 	/* Wait for the track position to change during rewinding */
@@ -935,7 +937,7 @@ static void test_cp_fast_forward(void)
 	}
 
 	if (test_verify_media_state_wait_flags(BT_MCS_MEDIA_STATE_SEEKING)) {
-		printk("FAST FORWARD command succeeded\n");
+		LOG_INF("FAST FORWARD command succeeded");
 	}
 
 	/* Wait for the track position to change during fast forwarding */
@@ -962,7 +964,7 @@ static void test_cp_stop(void)
 
 	/* There is no "STOPPED" state in the spec - STOP goes to PAUSED */
 	if (test_verify_media_state_wait_flags(BT_MCS_MEDIA_STATE_PAUSED)) {
-		printk("STOP command succeeded\n");
+		LOG_INF("STOP command succeeded");
 	}
 }
 
@@ -1011,7 +1013,7 @@ static void test_cp_move_relative(void)
 		return;
 	}
 
-	printk("MOVE RELATIVE command succeeded\n");
+	LOG_INF("MOVE RELATIVE command succeeded");
 }
 
 static void test_cp_prev_segment(void)
@@ -1041,7 +1043,7 @@ static void test_cp_prev_segment(void)
 		return;
 	}
 
-	printk("PREV SEGMENT command succeeded\n");
+	LOG_INF("PREV SEGMENT command succeeded");
 }
 
 static void test_cp_next_segment(void)
@@ -1058,7 +1060,7 @@ static void test_cp_next_segment(void)
 		return;
 	}
 
-	printk("NEXT SEGMENT command succeeded\n");
+	LOG_INF("NEXT SEGMENT command succeeded");
 }
 
 static void test_cp_first_segment(void)
@@ -1075,7 +1077,7 @@ static void test_cp_first_segment(void)
 		return;
 	}
 
-	printk("FIRST SEGMENT command succeeded\n");
+	LOG_INF("FIRST SEGMENT command succeeded");
 }
 
 static void test_cp_last_segment(void)
@@ -1092,7 +1094,7 @@ static void test_cp_last_segment(void)
 		return;
 	}
 
-	printk("LAST SEGMENT command succeeded\n");
+	LOG_INF("LAST SEGMENT command succeeded");
 }
 
 static void test_cp_goto_segment(void)
@@ -1110,7 +1112,7 @@ static void test_cp_goto_segment(void)
 		return;
 	}
 
-	printk("GOTO SEGMENT command succeeded\n");
+	LOG_INF("GOTO SEGMENT command succeeded");
 }
 
 /* Helper function to read the current track object ID, including flag handling
@@ -1165,7 +1167,7 @@ static void test_cp_prev_track(void)
 		return;
 	}
 
-	printk("PREV TRACK command succeeded\n");
+	LOG_INF("PREV TRACK command succeeded");
 }
 
 static void test_cp_next_track_and_track_changed(void)
@@ -1190,7 +1192,7 @@ static void test_cp_next_track_and_track_changed(void)
 	}
 
 	WAIT_FOR_FLAG(track_change_notified);
-	printk("Track change notified\n");
+	LOG_INF("Track change notified");
 
 	test_read_current_track_object_id_wait_flags();
 
@@ -1199,7 +1201,7 @@ static void test_cp_next_track_and_track_changed(void)
 		return;
 	}
 
-	printk("NEXT TRACK command succeeded\n");
+	LOG_INF("NEXT TRACK command succeeded");
 }
 
 static void test_cp_first_track(void)
@@ -1227,7 +1229,7 @@ static void test_cp_first_track(void)
 		return;
 	}
 
-	printk("FIRST TRACK command succeeded\n");
+	LOG_INF("FIRST TRACK command succeeded");
 }
 
 static void test_cp_last_track(void)
@@ -1255,7 +1257,7 @@ static void test_cp_last_track(void)
 		return;
 	}
 
-	printk("LAST TRACK command succeeded\n");
+	LOG_INF("LAST TRACK command succeeded");
 }
 
 static void test_cp_goto_track(void)
@@ -1284,7 +1286,7 @@ static void test_cp_goto_track(void)
 		return;
 	}
 
-	printk("GOTO TRACK command succeeded\n");
+	LOG_INF("GOTO TRACK command succeeded");
 }
 
 /* Helper function to read the current group object ID, including flag handling
@@ -1339,7 +1341,7 @@ static void test_cp_prev_group(void)
 		return;
 	}
 
-	printk("PREV GROUP command succeeded\n");
+	LOG_INF("PREV GROUP command succeeded");
 }
 
 static void test_cp_next_group(void)
@@ -1367,7 +1369,7 @@ static void test_cp_next_group(void)
 		return;
 	}
 
-	printk("NEXT GROUP command succeeded\n");
+	LOG_INF("NEXT GROUP command succeeded");
 }
 
 static void test_cp_first_group(void)
@@ -1395,7 +1397,7 @@ static void test_cp_first_group(void)
 		return;
 	}
 
-	printk("FIRST GROUP command succeeded\n");
+	LOG_INF("FIRST GROUP command succeeded");
 }
 
 static void test_cp_last_group(void)
@@ -1423,7 +1425,7 @@ static void test_cp_last_group(void)
 		return;
 	}
 
-	printk("LAST GROUP command succeeded\n");
+	LOG_INF("LAST GROUP command succeeded");
 }
 
 static void test_cp_goto_group(void)
@@ -1452,7 +1454,7 @@ static void test_cp_goto_group(void)
 		return;
 	}
 
-	printk("GOTO GROUP command succeeded\n");
+	LOG_INF("GOTO GROUP command succeeded");
 }
 
 static void test_search(void)
@@ -1561,7 +1563,7 @@ static void test_search(void)
 		return;
 	}
 
-	printk("SEARCH operation succeeded\n");
+	LOG_INF("SEARCH operation succeeded");
 }
 
 static void test_discover(void)
@@ -1584,7 +1586,7 @@ static void test_discover(void)
 	}
 
 	WAIT_FOR_FLAG(discovery_done);
-	printk("Discovery of MCS succeeded\n");
+	LOG_INF("Discovery of MCS succeeded");
 }
 
 static void test_read_player_name(void)
@@ -1608,7 +1610,7 @@ static void test_read_player_name(void)
 	}
 
 	WAIT_FOR_FLAG(player_name_read);
-	printk("Player Name read succeeded\n");
+	LOG_INF("Player Name read succeeded");
 }
 
 static void test_read_icon_obj_id(void)
@@ -1632,7 +1634,7 @@ static void test_read_icon_obj_id(void)
 	}
 
 	WAIT_FOR_FLAG(icon_object_id_read);
-	printk("Icon Object ID read succeeded\n");
+	LOG_INF("Icon Object ID read succeeded");
 }
 
 static void test_read_icon_obj(void)
@@ -1657,7 +1659,7 @@ static void test_read_icon_obj(void)
 	}
 
 	WAIT_FOR_FLAG(object_read);
-	printk("Reading Icon Object succeeded\n");
+	LOG_INF("Reading Icon Object succeeded");
 }
 
 static void test_read_icon_url(void)
@@ -1681,7 +1683,7 @@ static void test_read_icon_url(void)
 	}
 
 	WAIT_FOR_FLAG(icon_url_read);
-	printk("Icon URL read succeeded\n");
+	LOG_INF("Icon URL read succeeded");
 }
 
 static void test_read_track_title(void)
@@ -1705,7 +1707,7 @@ static void test_read_track_title(void)
 	}
 
 	WAIT_FOR_FLAG(track_title_read);
-	printk("Track title read succeeded\n");
+	LOG_INF("Track title read succeeded");
 }
 
 static void test_read_track_duration(void)
@@ -1729,7 +1731,7 @@ static void test_read_track_duration(void)
 	}
 
 	WAIT_FOR_FLAG(track_duration_read);
-	printk("Track duration read succeeded\n");
+	LOG_INF("Track duration read succeeded");
 }
 
 static void test_read_track_position(void)
@@ -1753,7 +1755,7 @@ static void test_read_track_position(void)
 	}
 
 	WAIT_FOR_FLAG(track_position_read);
-	printk("Track position read succeeded\n");
+	LOG_INF("Track position read succeeded");
 }
 
 static void test_write_track_position(int32_t pos)
@@ -1783,7 +1785,7 @@ static void test_write_track_position(int32_t pos)
 		FAIL("Track position set failed: Incorrect position\n");
 	}
 
-	printk("Track position set succeeded\n");
+	LOG_INF("Track position set succeeded");
 }
 
 static void test_read_playback_speed(void)
@@ -1807,7 +1809,7 @@ static void test_read_playback_speed(void)
 	}
 
 	WAIT_FOR_FLAG(playback_speed_read);
-	printk("Playback speed read succeeded\n");
+	LOG_INF("Playback speed read succeeded");
 }
 
 static void test_set_playback_speed(int8_t pb_speed)
@@ -1835,7 +1837,7 @@ static void test_set_playback_speed(int8_t pb_speed)
 		FAIL("Playback speed failed: Incorrect playback speed\n");
 	}
 
-	printk("Playback speed set succeeded\n");
+	LOG_INF("Playback speed set succeeded");
 }
 
 static void test_read_seeking_speed(void)
@@ -1859,7 +1861,7 @@ static void test_read_seeking_speed(void)
 	}
 
 	WAIT_FOR_FLAG(seeking_speed_read);
-	printk("Seeking speed read succeeded\n");
+	LOG_INF("Seeking speed read succeeded");
 }
 
 static void test_read_track_segments_obj_id(void)
@@ -1883,7 +1885,7 @@ static void test_read_track_segments_obj_id(void)
 	}
 
 	WAIT_FOR_FLAG(track_segments_object_id_read);
-	printk("Track Segments Object ID read succeeded\n");
+	LOG_INF("Track Segments Object ID read succeeded");
 }
 
 static void test_read_track_segments_object(void)
@@ -1907,7 +1909,7 @@ static void test_read_track_segments_object(void)
 	}
 
 	WAIT_FOR_FLAG(object_read);
-	printk("Reading Track Segments Object succeeded\n");
+	LOG_INF("Reading Track Segments Object succeeded");
 }
 
 static void test_set_current_track_obj_id(uint64_t id)
@@ -1962,7 +1964,7 @@ static void test_set_current_track_obj_id(uint64_t id)
 		return;
 	}
 
-	printk("Current Track Object ID set succeeded\n");
+	LOG_INF("Current Track Object ID set succeeded");
 }
 
 static void test_read_current_track_obj_id(void)
@@ -1987,7 +1989,7 @@ static void test_read_current_track_obj_id(void)
 
 	WAIT_FOR_FLAG(current_track_object_id_read);
 
-	printk("Current Track Object ID read succeeded\n");
+	LOG_INF("Current Track Object ID read succeeded");
 }
 
 static void test_read_current_track_obj_id_with_expect(uint64_t expected_id)
@@ -1999,7 +2001,7 @@ static void test_read_current_track_obj_id_with_expect(uint64_t expected_id)
 		return;
 	}
 
-	printk("Current Track Object ID read succeeded\n");
+	LOG_INF("Current Track Object ID read succeeded");
 }
 
 static void test_read_current_track_object(void)
@@ -2024,7 +2026,7 @@ static void test_read_current_track_object(void)
 	}
 
 	WAIT_FOR_FLAG(object_read);
-	printk("Current Track Object read succeeded\n");
+	LOG_INF("Current Track Object read succeeded");
 }
 
 static void test_set_next_track_obj_id(uint64_t id)
@@ -2078,7 +2080,7 @@ static void test_set_next_track_obj_id(uint64_t id)
 		return;
 	}
 
-	printk("Next Track Object ID set succeeded\n");
+	LOG_INF("Next Track Object ID set succeeded");
 }
 
 static void test_read_next_track_obj_id(void)
@@ -2103,7 +2105,7 @@ static void test_read_next_track_obj_id(void)
 
 	WAIT_FOR_FLAG(next_track_object_id_read);
 
-	printk("Next Track Object ID read succeeded\n");
+	LOG_INF("Next Track Object ID read succeeded");
 }
 
 static void test_read_next_track_obj_id_with_expect(uint64_t expected_id)
@@ -2115,7 +2117,7 @@ static void test_read_next_track_obj_id_with_expect(uint64_t expected_id)
 		return;
 	}
 
-	printk("Next Track Object ID read succeeded\n");
+	LOG_INF("Next Track Object ID read succeeded");
 }
 
 static void test_read_next_track_object(void)
@@ -2139,7 +2141,7 @@ static void test_read_next_track_object(void)
 	}
 
 	WAIT_FOR_FLAG(object_read);
-	printk("Next Track Object read succeeded\n");
+	LOG_INF("Next Track Object read succeeded");
 }
 
 static void test_read_parent_group_obj_id(void)
@@ -2163,7 +2165,7 @@ static void test_read_parent_group_obj_id(void)
 	}
 
 	WAIT_FOR_FLAG(parent_group_object_id_read);
-	printk("Parent Group Object ID read succeeded\n");
+	LOG_INF("Parent Group Object ID read succeeded");
 }
 
 static void test_read_parent_group_object(void)
@@ -2187,7 +2189,7 @@ static void test_read_parent_group_object(void)
 	}
 
 	WAIT_FOR_FLAG(object_read);
-	printk("Parent Group Object read succeeded\n");
+	LOG_INF("Parent Group Object read succeeded");
 }
 
 static void test_set_current_group_obj_id(uint64_t id)
@@ -2240,7 +2242,7 @@ static void test_set_current_group_obj_id(uint64_t id)
 		return;
 	}
 
-	printk("Current Group Object ID set succeeded\n");
+	LOG_INF("Current Group Object ID set succeeded");
 }
 
 static void test_read_current_group_obj_id(void)
@@ -2265,7 +2267,7 @@ static void test_read_current_group_obj_id(void)
 
 	WAIT_FOR_FLAG(current_group_object_id_read);
 
-	printk("Current Group Object ID read succeeded\n");
+	LOG_INF("Current Group Object ID read succeeded");
 }
 
 static void test_read_current_group_obj_id_with_expect(uint64_t expected_id)
@@ -2277,7 +2279,7 @@ static void test_read_current_group_obj_id_with_expect(uint64_t expected_id)
 		return;
 	}
 
-	printk("Current Group Object ID read succeeded\n");
+	LOG_INF("Current Group Object ID read succeeded");
 }
 
 static void test_read_current_group_object(void)
@@ -2301,7 +2303,7 @@ static void test_read_current_group_object(void)
 	}
 
 	WAIT_FOR_FLAG(object_read);
-	printk("Current Group Object read succeeded\n");
+	LOG_INF("Current Group Object read succeeded");
 }
 
 static void test_read_playing_order(void)
@@ -2325,7 +2327,7 @@ static void test_read_playing_order(void)
 	}
 
 	WAIT_FOR_FLAG(playing_order_read);
-	printk("Playing order read succeeded\n");
+	LOG_INF("Playing order read succeeded");
 }
 
 static void test_set_playing_order(void)
@@ -2377,7 +2379,7 @@ static void test_set_playing_order(void)
 	if (g_playing_order != new_playing_order) {
 		FAIL("Playing order set failed: Incorrect playing_order\n");
 	}
-	printk("Playing order set succeeded\n");
+	LOG_INF("Playing order set succeeded");
 }
 
 static void test_read_playing_orders_supported(void)
@@ -2401,7 +2403,7 @@ static void test_read_playing_orders_supported(void)
 	}
 
 	WAIT_FOR_FLAG(playing_orders_supported_read);
-	printk("Playing orders supported read succeeded\n");
+	LOG_INF("Playing orders supported read succeeded");
 }
 
 static void test_read_media_state(void)
@@ -2425,7 +2427,7 @@ static void test_read_media_state(void)
 	}
 
 	WAIT_FOR_FLAG(media_state_read);
-	printk("Media state read succeeded\n");
+	LOG_INF("Media state read succeeded");
 }
 
 static void test_read_content_control_id(void)
@@ -2449,7 +2451,7 @@ static void test_read_content_control_id(void)
 	}
 
 	WAIT_FOR_FLAG(ccid_read);
-	printk("Content control ID read succeeded\n");
+	LOG_INF("Content control ID read succeeded");
 }
 
 static void reset_test_iteration(unsigned int i)
@@ -2458,7 +2460,7 @@ static void reset_test_iteration(unsigned int i)
 
 	ARG_UNUSED(i);
 
-	printk("Resetting test iteration\n");
+	LOG_INF("Resetting test iteration");
 
 	g_icon_object_id = 0U;
 	g_track_segments_object_id = 0U;
@@ -2502,7 +2504,7 @@ static void reset_test_iteration(unsigned int i)
 		return;
 	}
 
-	printk("Test iteration reset\n");
+	LOG_INF("Test iteration reset");
 }
 
 /* This function tests all commands in the API in sequence
@@ -2514,7 +2516,7 @@ void test_main(void)
 	const unsigned int iterations = 3;
 	int err;
 
-	printk("Media Control Client test application.  Board: %s\n", CONFIG_BOARD);
+	LOG_INF("Media Control Client test application.  Board: %s", CONFIG_BOARD);
 
 	err = bt_enable(NULL);
 	if (err != 0) {
@@ -2522,7 +2524,7 @@ void test_main(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	bt_le_scan_cb_register(&common_scan_cb);
 
@@ -2531,7 +2533,7 @@ void test_main(void)
 	if (err != 0) {
 		FAIL("Could not initialize MCC (err %d\n)", err);
 	} else {
-		printk("MCC init succeeded\n");
+		LOG_INF("MCC init succeeded");
 	}
 
 	/* Connect ******************************************/
@@ -2541,19 +2543,19 @@ void test_main(void)
 		const uint64_t new_current_track_object_id = 0x103U;
 		const uint64_t new_next_track_object = 0x102U;
 
-		printk("\n########### Running iteration #%u\n\n", i);
+		LOG_INF("########### Running iteration #%u", i);
 
 		UNSET_FLAG(flag_connected);
 		err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
 		if (err != 0) {
 			FAIL("Failed to start scanning (err %d\n)", err);
 		} else {
-			printk("Scanning started successfully\n");
+			LOG_INF("Scanning started successfully");
 		}
 
 		WAIT_FOR_FLAG(flag_connected);
 
-		printk("Connected: %s\n", bt_conn_dst_str(default_conn));
+		LOG_INF("Connected: %s", bt_conn_dst_str(default_conn));
 
 		bt_conn_le_param_update(default_conn,
 					BT_LE_CONN_PARAM(BT_GAP_US_TO_CONN_INTERVAL(7500),
@@ -2689,7 +2691,7 @@ void test_main(void)
 		/* Search control point */
 		test_search();
 
-		printk("Disconnecting\n");
+		LOG_INF("Disconnecting");
 		err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 		if (err != 0) {
 			FAIL("Failed to disconnect: %d", err);
@@ -2697,7 +2699,7 @@ void test_main(void)
 		}
 		WAIT_FOR_COND(default_conn == NULL);
 		k_sleep(K_SECONDS(1));
-		printk("Disconnected\n");
+		LOG_INF("Disconnected");
 	}
 
 	/* TEST IS COMPLETE */

--- a/tests/bsim/bluetooth/audio/src/mcs_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcs_test.c
@@ -8,10 +8,12 @@
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/media_proxy.h>
 #include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(mcs_test);
 
 #ifdef CONFIG_BT_MCS
 extern enum bst_result_t bst_result;
@@ -21,7 +23,7 @@ static void test_main(void)
 	struct bt_le_ext_adv *ext_adv;
 	int err;
 
-	printk("Media Control Server test application.  Board: %s\n", CONFIG_BOARD);
+	LOG_INF("Media Control Server test application.  Board: %s", CONFIG_BOARD);
 
 	/* Initialize media player */
 	err = media_proxy_pl_init();
@@ -36,7 +38,7 @@ static void test_main(void)
 		FAIL("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	setup_connectable_adv(&ext_adv);
 

--- a/tests/bsim/bluetooth/audio/src/media_controller_test.c
+++ b/tests/bsim/bluetooth/audio/src/media_controller_test.c
@@ -14,11 +14,13 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/services/ots.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(media_controller_test);
 
 #ifdef CONFIG_BT_MCS
 extern enum bst_result_t bst_result;
@@ -572,7 +574,7 @@ void initialize_media(void)
 	}
 
 	WAIT_FOR_FLAG(local_player_instance);
-	printk("media init and local player instance succeeded\n");
+	LOG_INF("media init and local player instance succeeded");
 }
 
 /* Callback after Bluetooth initialization attempt */
@@ -651,7 +653,7 @@ static void test_cp_play(void)
 	}
 
 	if (test_verify_media_state_wait_flags(MEDIA_PROXY_STATE_PLAYING)) {
-		printk("PLAY command succeeded\n");
+		LOG_INF("PLAY command succeeded");
 	}
 }
 
@@ -670,7 +672,7 @@ static void test_cp_pause(void)
 	}
 
 	if (test_verify_media_state_wait_flags(MEDIA_PROXY_STATE_PAUSED)) {
-		printk("PAUSE command succeeded\n");
+		LOG_INF("PAUSE command succeeded");
 	}
 }
 
@@ -689,7 +691,7 @@ static void test_cp_fast_rewind(void)
 	}
 
 	if (test_verify_media_state_wait_flags(MEDIA_PROXY_STATE_SEEKING)) {
-		printk("FAST REWIND command succeeded\n");
+		LOG_INF("FAST REWIND command succeeded");
 	}
 }
 
@@ -708,7 +710,7 @@ static void test_cp_fast_forward(void)
 	}
 
 	if (test_verify_media_state_wait_flags(MEDIA_PROXY_STATE_SEEKING)) {
-		printk("FAST FORWARD command succeeded\n");
+		LOG_INF("FAST FORWARD command succeeded");
 	}
 }
 
@@ -728,7 +730,7 @@ static void test_cp_stop(void)
 
 	/* There is no "STOPPED" state in the spec - STOP goes to PAUSED */
 	if (test_verify_media_state_wait_flags(MEDIA_PROXY_STATE_PAUSED)) {
-		printk("STOP command succeeded\n");
+		LOG_INF("STOP command succeeded");
 	}
 }
 
@@ -777,7 +779,7 @@ static void test_cp_move_relative(void)
 		return;
 	}
 
-	printk("MOVE RELATIVE command succeeded\n");
+	LOG_INF("MOVE RELATIVE command succeeded");
 }
 
 static void test_cp_prev_segment(void)
@@ -807,7 +809,7 @@ static void test_cp_prev_segment(void)
 		return;
 	}
 
-	printk("PREV SEGMENT command succeeded\n");
+	LOG_INF("PREV SEGMENT command succeeded");
 }
 
 static void test_cp_next_segment(void)
@@ -824,7 +826,7 @@ static void test_cp_next_segment(void)
 		return;
 	}
 
-	printk("NEXT SEGMENT command succeeded\n");
+	LOG_INF("NEXT SEGMENT command succeeded");
 }
 
 static void test_cp_first_segment(void)
@@ -841,7 +843,7 @@ static void test_cp_first_segment(void)
 		return;
 	}
 
-	printk("FIRST SEGMENT command succeeded\n");
+	LOG_INF("FIRST SEGMENT command succeeded");
 }
 
 static void test_cp_last_segment(void)
@@ -858,7 +860,7 @@ static void test_cp_last_segment(void)
 		return;
 	}
 
-	printk("LAST SEGMENT command succeeded\n");
+	LOG_INF("LAST SEGMENT command succeeded");
 }
 
 static void test_cp_goto_segment(void)
@@ -876,7 +878,7 @@ static void test_cp_goto_segment(void)
 		return;
 	}
 
-	printk("GOTO SEGMENT command succeeded\n");
+	LOG_INF("GOTO SEGMENT command succeeded");
 }
 
 /* Helper function to read the current track object ID, including flag handling
@@ -931,7 +933,7 @@ static void test_cp_prev_track(void)
 		return;
 	}
 
-	printk("PREV TRACK command succeeded\n");
+	LOG_INF("PREV TRACK command succeeded");
 }
 
 static void test_cp_next_track(void)
@@ -959,7 +961,7 @@ static void test_cp_next_track(void)
 		return;
 	}
 
-	printk("NEXT TRACK command succeeded\n");
+	LOG_INF("NEXT TRACK command succeeded");
 }
 
 static void test_cp_first_track(void)
@@ -987,7 +989,7 @@ static void test_cp_first_track(void)
 		return;
 	}
 
-	printk("FIRST TRACK command succeeded\n");
+	LOG_INF("FIRST TRACK command succeeded");
 }
 
 static void test_cp_last_track(void)
@@ -1015,7 +1017,7 @@ static void test_cp_last_track(void)
 		return;
 	}
 
-	printk("LAST TRACK command succeeded\n");
+	LOG_INF("LAST TRACK command succeeded");
 }
 
 static void test_cp_goto_track(void)
@@ -1044,7 +1046,7 @@ static void test_cp_goto_track(void)
 		return;
 	}
 
-	printk("GOTO TRACK command succeeded\n");
+	LOG_INF("GOTO TRACK command succeeded");
 }
 
 /* Helper function to read the current group object ID, including flag handling
@@ -1099,7 +1101,7 @@ static void test_cp_prev_group(void)
 		return;
 	}
 
-	printk("PREV GROUP command succeeded\n");
+	LOG_INF("PREV GROUP command succeeded");
 }
 
 static void test_cp_next_group(void)
@@ -1127,7 +1129,7 @@ static void test_cp_next_group(void)
 		return;
 	}
 
-	printk("NEXT GROUP command succeeded\n");
+	LOG_INF("NEXT GROUP command succeeded");
 }
 
 static void test_cp_first_group(void)
@@ -1155,7 +1157,7 @@ static void test_cp_first_group(void)
 		return;
 	}
 
-	printk("FIRST GROUP command succeeded\n");
+	LOG_INF("FIRST GROUP command succeeded");
 }
 
 static void test_cp_last_group(void)
@@ -1183,7 +1185,7 @@ static void test_cp_last_group(void)
 		return;
 	}
 
-	printk("LAST GROUP command succeeded\n");
+	LOG_INF("LAST GROUP command succeeded");
 }
 
 static void test_cp_goto_group(void)
@@ -1212,7 +1214,7 @@ static void test_cp_goto_group(void)
 		return;
 	}
 
-	printk("GOTO GROUP command succeeded\n");
+	LOG_INF("GOTO GROUP command succeeded");
 }
 
 static void test_scp(void)
@@ -1290,7 +1292,7 @@ static void test_scp(void)
 		return;
 	}
 
-	printk("SEARCH operation succeeded\n");
+	LOG_INF("SEARCH operation succeeded");
 }
 
 /* This function tests all commands in the API in sequence for the provided player.
@@ -1312,7 +1314,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(player_name_read);
-	printk("Player Name read succeeded\n");
+	LOG_INF("Player Name read succeeded");
 
 	/* Read icon object id  ******************************************/
 	UNSET_FLAG(icon_object_id_read);
@@ -1323,7 +1325,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(icon_object_id_read);
-	printk("Icon Object ID read succeeded\n");
+	LOG_INF("Icon Object ID read succeeded");
 
 	/* Read icon url *************************************************/
 	UNSET_FLAG(icon_url_read);
@@ -1334,7 +1336,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(icon_url_read);
-	printk("Icon URL read succeeded\n");
+	LOG_INF("Icon URL read succeeded");
 
 	/* Read track_title ******************************************/
 	UNSET_FLAG(track_title_read);
@@ -1345,7 +1347,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(track_title_read);
-	printk("Track title read succeeded\n");
+	LOG_INF("Track title read succeeded");
 
 	/* Read track_duration ******************************************/
 	UNSET_FLAG(track_duration_read);
@@ -1356,7 +1358,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(track_duration_read);
-	printk("Track duration read succeeded\n");
+	LOG_INF("Track duration read succeeded");
 
 	/* Read and set track_position *************************************/
 	UNSET_FLAG(track_position);
@@ -1367,7 +1369,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(track_position);
-	printk("Track position read succeeded\n");
+	LOG_INF("Track position read succeeded");
 
 	int32_t pos = g_pos + 1200; /*12 seconds further into the track */
 
@@ -1384,7 +1386,7 @@ void test_media_controller_player(struct media_player *player)
 		/* position is the position given in the set command */
 		FAIL("Track position set failed: Incorrect position\n");
 	}
-	printk("Track position set succeeded\n");
+	LOG_INF("Track position set succeeded");
 
 	/* Read and set playback speed *************************************/
 	UNSET_FLAG(playback_speed);
@@ -1395,7 +1397,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(playback_speed);
-	printk("Playback speed read succeeded\n");
+	LOG_INF("Playback speed read succeeded");
 
 	int8_t pb_speed = g_pb_speed + 8; /* 2^(8/64) faster than current speed */
 
@@ -1410,7 +1412,7 @@ void test_media_controller_player(struct media_player *player)
 	if (g_pb_speed != pb_speed) {
 		FAIL("Playback speed failed: Incorrect playback speed\n");
 	}
-	printk("Playback speed set succeeded\n");
+	LOG_INF("Playback speed set succeeded");
 
 	/* Read seeking speed *************************************/
 	UNSET_FLAG(seeking_speed_read);
@@ -1421,7 +1423,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(seeking_speed_read);
-	printk("Seeking speed read succeeded\n");
+	LOG_INF("Seeking speed read succeeded");
 
 	/* Read track segments object *****************************************/
 	UNSET_FLAG(track_segments_object_id_read);
@@ -1432,7 +1434,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(track_segments_object_id_read);
-	printk("Track Segments Object ID read succeeded\n");
+	LOG_INF("Track Segments Object ID read succeeded");
 
 	/* Read current track object ******************************************/
 	UNSET_FLAG(current_track_object_id_read);
@@ -1443,7 +1445,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(current_track_object_id_read);
-	printk("Current Track Object ID read succeeded\n");
+	LOG_INF("Current Track Object ID read succeeded");
 
 	/* Read next track object ******************************************/
 	UNSET_FLAG(next_track_object_id_read);
@@ -1454,7 +1456,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(next_track_object_id_read);
-	printk("Next Track Object ID read succeeded\n");
+	LOG_INF("Next Track Object ID read succeeded");
 
 	/* Read parent group object ******************************************/
 	UNSET_FLAG(parent_group_object_id_read);
@@ -1465,7 +1467,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(parent_group_object_id_read);
-	printk("Parent Group Object ID read succeeded\n");
+	LOG_INF("Parent Group Object ID read succeeded");
 
 	/* Read current group object ******************************************/
 	UNSET_FLAG(current_group_object_id_read);
@@ -1476,7 +1478,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(current_group_object_id_read);
-	printk("Current Group Object ID read succeeded\n");
+	LOG_INF("Current Group Object ID read succeeded");
 
 	/* Read and set playing order *************************************/
 	UNSET_FLAG(playing_order_flag);
@@ -1487,7 +1489,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(playing_order_flag);
-	printk("Playing order read succeeded\n");
+	LOG_INF("Playing order read succeeded");
 
 	uint8_t playing_order;
 
@@ -1508,7 +1510,7 @@ void test_media_controller_player(struct media_player *player)
 	if (g_playing_order != playing_order) {
 		FAIL("Playing order set failed: Incorrect playing_order\n");
 	}
-	printk("Playing order set succeeded\n");
+	LOG_INF("Playing order set succeeded");
 
 	/* Read playing orders supported  *************************************/
 	UNSET_FLAG(playing_orders_supported_read);
@@ -1519,7 +1521,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(playing_orders_supported_read);
-	printk("Playing orders supported read succeeded\n");
+	LOG_INF("Playing orders supported read succeeded");
 
 	/* Read media state  ***************************************************/
 	UNSET_FLAG(media_state_read);
@@ -1530,7 +1532,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(media_state_read);
-	printk("Media state read succeeded\n");
+	LOG_INF("Media state read succeeded");
 
 	/* Read content control ID  *******************************************/
 	UNSET_FLAG(ccid_read);
@@ -1541,7 +1543,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(ccid_read);
-	printk("Content control ID read succeeded\n");
+	LOG_INF("Content control ID read succeeded");
 
 	/* Control point - "state" opcodes */
 
@@ -1611,7 +1613,7 @@ void initialize_bluetooth(void)
 	}
 
 	WAIT_FOR_FLAG(ble_is_initialized);
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	bt_le_scan_cb_register(&common_scan_cb);
 }
@@ -1626,11 +1628,11 @@ void scan_and_connect(void)
 		return;
 	}
 
-	printk("Scanning started successfully\n");
+	LOG_INF("Scanning started successfully");
 
 	WAIT_FOR_FLAG(flag_connected);
 
-	printk("Connected: %s\n", bt_conn_dst_str(default_conn));
+	LOG_INF("Connected: %s", bt_conn_dst_str(default_conn));
 }
 
 void discover_remote_player(void)
@@ -1650,12 +1652,12 @@ void discover_remote_player(void)
 /* BabbleSim entry point for local player test */
 void test_media_controller_local_player(void)
 {
-	printk("Media Control local player test application.  Board: %s\n", CONFIG_BOARD);
+	LOG_INF("Media Control local player test application.  Board: %s", CONFIG_BOARD);
 
 	initialize_bluetooth();
 	initialize_media();  /* Sets local_player global variable */
 
-	printk("Local player instance: %p\n", local_player);
+	LOG_INF("Local player instance: %p", local_player);
 
 	test_media_controller_player(local_player);
 
@@ -1668,7 +1670,7 @@ void test_media_controller_remote_player(void)
 {
 	struct bt_le_ext_adv *ext_adv;
 
-	printk("Media Control remote player test application.  Board: %s\n", CONFIG_BOARD);
+	LOG_INF("Media Control remote player test application.  Board: %s", CONFIG_BOARD);
 
 	initialize_bluetooth();
 	initialize_media();
@@ -1678,7 +1680,7 @@ void test_media_controller_remote_player(void)
 	WAIT_FOR_FLAG(flag_connected);
 
 	discover_remote_player(); /* Sets global variable */
-	printk("Remote player instance: %p\n", remote_player);
+	LOG_INF("Remote player instance: %p", remote_player);
 
 	test_media_controller_player(remote_player);
 
@@ -1690,7 +1692,7 @@ void test_media_controller_remote_player(void)
 void test_media_controller_server(void)
 {
 
-	printk("Media Control server test application.  Board: %s\n", CONFIG_BOARD);
+	LOG_INF("Media Control server test application.  Board: %s", CONFIG_BOARD);
 
 	initialize_bluetooth();
 	initialize_media();
@@ -1698,7 +1700,7 @@ void test_media_controller_server(void)
 	/* The server side will also get callbacks, from its local player.
 	 * And if the current player is not set, the callbacks will fail the test.
 	 */
-	printk("Local player instance: %p\n", local_player);
+	LOG_INF("Local player instance: %p", local_player);
 	current_player = local_player;
 
 	scan_and_connect();

--- a/tests/bsim/bluetooth/audio/src/micp_mic_ctlr_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_ctlr_test.c
@@ -12,11 +12,13 @@
 #include <zephyr/bluetooth/audio/aics.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/audio/micp.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(micp_mic_ctlr_test);
 
 #ifdef CONFIG_BT_MICP_MIC_CTLR
 #define AICS_DESC_SIZE 64U
@@ -116,7 +118,7 @@ static void aics_description_cb(struct bt_aics *inst, int err,
 	}
 
 	if (strlen(description) > sizeof(g_aics_desc) - 1) {
-		printk("Warning: AICS description (%zu) is larger than buffer (%zu)\n",
+		LOG_WRN("AICS description (%zu) is larger than buffer (%zu)",
 		       strlen(description), sizeof(g_aics_desc) - 1);
 	}
 
@@ -232,7 +234,7 @@ static int test_aics(void)
 	char expected_aics_desc[AICS_DESC_SIZE];
 	struct bt_conn *cached_conn;
 
-	printk("Getting AICS client conn\n");
+	LOG_INF("Getting AICS client conn");
 	err = bt_aics_client_conn_get(micp_included.aics[0], &cached_conn);
 	if (err != 0) {
 		FAIL("Could not get AICS client conn (err %d)\n", err);
@@ -243,7 +245,7 @@ static int test_aics(void)
 		return -ENOTCONN;
 	}
 
-	printk("Getting AICS state\n");
+	LOG_INF("Getting AICS state");
 	g_cb = false;
 	err = bt_aics_state_get(micp_included.aics[0]);
 	if (err != 0) {
@@ -251,9 +253,9 @@ static int test_aics(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb);
-	printk("AICS state get\n");
+	LOG_INF("AICS state get");
 
-	printk("Getting AICS gain setting\n");
+	LOG_INF("Getting AICS gain setting");
 	g_cb = false;
 	err = bt_aics_gain_setting_get(micp_included.aics[0]);
 	if (err != 0) {
@@ -261,9 +263,9 @@ static int test_aics(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb);
-	printk("AICS gain setting get\n");
+	LOG_INF("AICS gain setting get");
 
-	printk("Getting AICS input type\n");
+	LOG_INF("Getting AICS input type");
 	expected_input_type = BT_AICS_INPUT_TYPE_UNSPECIFIED;
 	g_cb = false;
 	err = bt_aics_type_get(micp_included.aics[0]);
@@ -273,9 +275,9 @@ static int test_aics(void)
 	}
 	/* Expect and wait for input_type from init */
 	WAIT_FOR_COND(g_cb && expected_input_type == g_aics_input_type);
-	printk("AICS input type get\n");
+	LOG_INF("AICS input type get");
 
-	printk("Getting AICS status\n");
+	LOG_INF("Getting AICS status");
 	g_cb = false;
 	err = bt_aics_status_get(micp_included.aics[0]);
 	if (err != 0) {
@@ -283,9 +285,9 @@ static int test_aics(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb);
-	printk("AICS status get\n");
+	LOG_INF("AICS status get");
 
-	printk("Getting AICS description\n");
+	LOG_INF("Getting AICS description");
 	g_cb = false;
 	err = bt_aics_description_get(micp_included.aics[0]);
 	if (err != 0) {
@@ -293,9 +295,9 @@ static int test_aics(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb);
-	printk("AICS description get\n");
+	LOG_INF("AICS description get");
 
-	printk("Setting AICS mute\n");
+	LOG_INF("Setting AICS mute");
 	expected_input_mute = BT_AICS_STATE_MUTED;
 	g_write_complete = g_cb = false;
 	err = bt_aics_mute(micp_included.aics[0]);
@@ -305,9 +307,9 @@ static int test_aics(void)
 	}
 	WAIT_FOR_COND(g_aics_input_mute == expected_input_mute &&
 		 g_cb && g_write_complete);
-	printk("AICS mute set\n");
+	LOG_INF("AICS mute set");
 
-	printk("Setting AICS unmute\n");
+	LOG_INF("Setting AICS unmute");
 	expected_input_mute = BT_AICS_STATE_UNMUTED;
 	g_write_complete = g_cb = false;
 	err = bt_aics_unmute(micp_included.aics[0]);
@@ -317,9 +319,9 @@ static int test_aics(void)
 	}
 	WAIT_FOR_COND(g_aics_input_mute == expected_input_mute &&
 		 g_cb && g_write_complete);
-	printk("AICS unmute set\n");
+	LOG_INF("AICS unmute set");
 
-	printk("Setting AICS auto mode\n");
+	LOG_INF("Setting AICS auto mode");
 	expected_mode = BT_AICS_MODE_AUTO;
 	g_write_complete = g_cb = false;
 	err = bt_aics_automatic_gain_set(micp_included.aics[0]);
@@ -328,9 +330,9 @@ static int test_aics(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_aics_mode == expected_mode && g_cb && g_write_complete);
-	printk("AICS auto mode set\n");
+	LOG_INF("AICS auto mode set");
 
-	printk("Setting AICS manual mode\n");
+	LOG_INF("Setting AICS manual mode");
 	expected_mode = BT_AICS_MODE_MANUAL;
 	g_write_complete = g_cb = false;
 	err = bt_aics_manual_gain_set(micp_included.aics[0]);
@@ -339,9 +341,9 @@ static int test_aics(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_aics_mode == expected_mode && g_cb && g_write_complete);
-	printk("AICS manual mode set\n");
+	LOG_INF("AICS manual mode set");
 
-	printk("Setting AICS gain\n");
+	LOG_INF("Setting AICS gain");
 	expected_gain = g_aics_gain_max - 1;
 	g_write_complete = g_cb = false;
 	err = bt_aics_gain_set(micp_included.aics[0], expected_gain);
@@ -350,9 +352,9 @@ static int test_aics(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_aics_gain == expected_gain && g_cb && g_write_complete);
-	printk("AICS gain set\n");
+	LOG_INF("AICS gain set");
 
-	printk("Setting AICS Description\n");
+	LOG_INF("Setting AICS Description");
 	strncpy(expected_aics_desc, "New Input Description",
 		sizeof(expected_aics_desc));
 	expected_aics_desc[sizeof(expected_aics_desc) - 1] = '\0';
@@ -366,9 +368,9 @@ static int test_aics(void)
 	WAIT_FOR_COND(g_cb &&
 		      (strncmp(expected_aics_desc, g_aics_desc,
 			       sizeof(expected_aics_desc)) == 0));
-	printk("AICS Description set\n");
+	LOG_INF("AICS Description set");
 
-	printk("AICS passed\n");
+	LOG_INF("AICS passed");
 	return 0;
 }
 
@@ -415,7 +417,7 @@ static void test_main(void)
 		FAIL("Scanning failed to start (err %d)\n", err);
 		return;
 	}
-	printk("Scanning successfully started\n");
+	LOG_INF("Scanning successfully started");
 	WAIT_FOR_FLAG(flag_connected);
 
 	discover_mics(&mic_ctlr);
@@ -427,7 +429,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Getting mic_ctlr conn\n");
+	LOG_INF("Getting mic_ctlr conn");
 	err = bt_micp_mic_ctlr_conn_get(mic_ctlr, &cached_conn);
 	if (err != 0) {
 		FAIL("Failed to get mic_ctlr conn (err %d)\n", err);
@@ -438,7 +440,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Getting mic_ctlr mute state\n");
+	LOG_INF("Getting mic_ctlr mute state");
 	g_cb = false;
 	err = bt_micp_mic_ctlr_mute_get(mic_ctlr);
 	if (err != 0) {
@@ -446,9 +448,9 @@ static void test_main(void)
 		return;
 	}
 	WAIT_FOR_COND(g_cb);
-	printk("mic_ctlr mute state received\n");
+	LOG_INF("mic_ctlr mute state received");
 
-	printk("Muting mic_ctlr\n");
+	LOG_INF("Muting mic_ctlr");
 	expected_mute = 1U;
 	g_write_complete = g_cb = false;
 	err = bt_micp_mic_ctlr_mute(mic_ctlr);
@@ -457,9 +459,9 @@ static void test_main(void)
 		return;
 	}
 	WAIT_FOR_COND(g_mute == expected_mute && g_cb && g_write_complete);
-	printk("mic_ctlr muted\n");
+	LOG_INF("mic_ctlr muted");
 
-	printk("Unmuting mic_ctlr\n");
+	LOG_INF("Unmuting mic_ctlr");
 	expected_mute = 0U;
 	g_write_complete = g_cb = false;
 	err = bt_micp_mic_ctlr_unmute(mic_ctlr);
@@ -468,7 +470,7 @@ static void test_main(void)
 		return;
 	}
 	WAIT_FOR_COND(g_mute == expected_mute && g_cb && g_write_complete);
-	printk("mic_ctlr unmuted\n");
+	LOG_INF("mic_ctlr unmuted");
 
 	if (CONFIG_BT_MICP_MIC_CTLR_MAX_AICS_INST > 0 && g_aics_count > 0U) {
 		if (test_aics()) {

--- a/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
@@ -12,13 +12,15 @@
 #include <zephyr/bluetooth/audio/aics.h>
 #include <zephyr/bluetooth/audio/micp.h>
 #include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(micp_mic_dev_test);
 
 #ifdef CONFIG_BT_MICP_MIC_DEV
 extern enum bst_result_t bst_result;
@@ -148,7 +150,7 @@ static int test_aics_server_only(void)
 	bool expected_aics_active;
 	char expected_aics_desc[AICS_DESC_SIZE];
 
-	printk("Deactivating AICS\n");
+	LOG_INF("Deactivating AICS");
 	expected_aics_active = false;
 	err = bt_aics_deactivate(micp_included.aics[0]);
 	if (err != 0) {
@@ -156,9 +158,9 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	WAIT_FOR_COND(expected_aics_active == g_aics_active);
-	printk("AICS deactivated\n");
+	LOG_INF("AICS deactivated");
 
-	printk("Activating AICS\n");
+	LOG_INF("Activating AICS");
 	expected_aics_active = true;
 	err = bt_aics_activate(micp_included.aics[0]);
 	if (err != 0) {
@@ -166,9 +168,9 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	WAIT_FOR_COND(expected_aics_active == g_aics_active);
-	printk("AICS activated\n");
+	LOG_INF("AICS activated");
 
-	printk("Getting AICS state\n");
+	LOG_INF("Getting AICS state");
 	g_cb = false;
 	err = bt_aics_state_get(micp_included.aics[0]);
 	if (err != 0) {
@@ -176,9 +178,9 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb);
-	printk("AICS state get\n");
+	LOG_INF("AICS state get");
 
-	printk("Getting AICS gain setting\n");
+	LOG_INF("Getting AICS gain setting");
 	g_cb = false;
 	err = bt_aics_gain_setting_get(micp_included.aics[0]);
 	if (err != 0) {
@@ -186,9 +188,9 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb);
-	printk("AICS gain setting get\n");
+	LOG_INF("AICS gain setting get");
 
-	printk("Getting AICS input type\n");
+	LOG_INF("Getting AICS input type");
 	g_cb = false;
 	expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
 	err = bt_aics_type_get(micp_included.aics[0]);
@@ -198,9 +200,9 @@ static int test_aics_server_only(void)
 	}
 	/* Expect and wait for input_type from init */
 	WAIT_FOR_COND(g_cb && expected_input_type == g_aics_input_type);
-	printk("AICS input type get\n");
+	LOG_INF("AICS input type get");
 
-	printk("Getting AICS status\n");
+	LOG_INF("Getting AICS status");
 	g_cb = false;
 	err = bt_aics_status_get(micp_included.aics[0]);
 	if (err != 0) {
@@ -208,9 +210,9 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb);
-	printk("AICS status get\n");
+	LOG_INF("AICS status get");
 
-	printk("Getting AICS description\n");
+	LOG_INF("Getting AICS description");
 	g_cb = false;
 	err = bt_aics_description_get(micp_included.aics[0]);
 	if (err != 0) {
@@ -218,9 +220,9 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb);
-	printk("AICS description get\n");
+	LOG_INF("AICS description get");
 
-	printk("Setting AICS mute\n");
+	LOG_INF("Setting AICS mute");
 	g_cb = false;
 	expected_input_mute = BT_AICS_STATE_MUTED;
 	err = bt_aics_mute(micp_included.aics[0]);
@@ -229,9 +231,9 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb && expected_input_mute == g_aics_input_mute);
-	printk("AICS mute set\n");
+	LOG_INF("AICS mute set");
 
-	printk("Setting AICS unmute\n");
+	LOG_INF("Setting AICS unmute");
 	g_cb = false;
 	expected_input_mute = BT_AICS_STATE_UNMUTED;
 	err = bt_aics_unmute(micp_included.aics[0]);
@@ -240,9 +242,9 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb && expected_input_mute == g_aics_input_mute);
-	printk("AICS unmute set\n");
+	LOG_INF("AICS unmute set");
 
-	printk("Setting AICS auto mode\n");
+	LOG_INF("Setting AICS auto mode");
 	g_cb = false;
 	expected_mode = BT_AICS_MODE_AUTO;
 	err = bt_aics_automatic_gain_set(micp_included.aics[0]);
@@ -251,9 +253,9 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb && expected_mode == g_aics_mode);
-	printk("AICS auto mode set\n");
+	LOG_INF("AICS auto mode set");
 
-	printk("Setting AICS manual mode\n");
+	LOG_INF("Setting AICS manual mode");
 	g_cb = false;
 	expected_mode = BT_AICS_MODE_MANUAL;
 	err = bt_aics_manual_gain_set(micp_included.aics[0]);
@@ -262,9 +264,9 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb && expected_mode == g_aics_mode);
-	printk("AICS manual mode set\n");
+	LOG_INF("AICS manual mode set");
 
-	printk("Setting AICS gain\n");
+	LOG_INF("Setting AICS gain");
 	g_cb = false;
 	expected_gain = g_aics_gain_max - 1;
 	err = bt_aics_gain_set(micp_included.aics[0], expected_gain);
@@ -273,9 +275,9 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	WAIT_FOR_COND(g_cb && expected_gain == g_aics_gain);
-	printk("AICS gain set\n");
+	LOG_INF("AICS gain set");
 
-	printk("Setting AICS Description\n");
+	LOG_INF("Setting AICS Description");
 	g_cb = false;
 	strncpy(expected_aics_desc, "New Input Description",
 		sizeof(expected_aics_desc));
@@ -287,7 +289,7 @@ static int test_aics_server_only(void)
 	}
 	WAIT_FOR_COND(g_cb && !strncmp(expected_aics_desc, g_aics_desc,
 				  sizeof(expected_aics_desc)));
-	printk("AICS Description set\n");
+	LOG_INF("AICS Description set");
 
 	return 0;
 }
@@ -304,7 +306,7 @@ static void test_mic_dev_only(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	(void)memset(&micp_param, 0, sizeof(micp_param));
 
@@ -341,9 +343,9 @@ static void test_mic_dev_only(void)
 		}
 	}
 
-	printk("MICP initialized\n");
+	LOG_INF("MICP initialized");
 
-	printk("Getting MICP mute\n");
+	LOG_INF("Getting MICP mute");
 	g_cb = false;
 	err = bt_micp_mic_dev_mute_get();
 	if (err != 0) {
@@ -351,9 +353,9 @@ static void test_mic_dev_only(void)
 		return;
 	}
 	WAIT_FOR_COND(g_cb);
-	printk("MICP mute get\n");
+	LOG_INF("MICP mute get");
 
-	printk("Setting MICP mute\n");
+	LOG_INF("Setting MICP mute");
 	expected_mute = BT_MICP_MUTE_MUTED;
 	err = bt_micp_mic_dev_mute();
 	if (err != 0) {
@@ -361,9 +363,9 @@ static void test_mic_dev_only(void)
 		return;
 	}
 	WAIT_FOR_COND(expected_mute == g_mute);
-	printk("MICP mute set\n");
+	LOG_INF("MICP mute set");
 
-	printk("Setting MICP unmute\n");
+	LOG_INF("Setting MICP unmute");
 	expected_mute = BT_MICP_MUTE_UNMUTED;
 	err = bt_micp_mic_dev_unmute();
 	if (err != 0) {
@@ -371,9 +373,9 @@ static void test_mic_dev_only(void)
 		return;
 	}
 	WAIT_FOR_COND(expected_mute == g_mute);
-	printk("MICP unmute set\n");
+	LOG_INF("MICP unmute set");
 
-	printk("Setting MICP disable\n");
+	LOG_INF("Setting MICP disable");
 	expected_mute = BT_MICP_MUTE_DISABLED;
 	err = bt_micp_mic_dev_mute_disable();
 	if (err != 0) {
@@ -381,7 +383,7 @@ static void test_mic_dev_only(void)
 		return;
 	}
 	WAIT_FOR_COND(expected_mute == g_mute);
-	printk("MICP disable set\n");
+	LOG_INF("MICP disable set");
 
 	if (CONFIG_BT_MICP_MIC_DEV_AICS_INSTANCE_COUNT > 0) {
 		if (test_aics_server_only()) {
@@ -404,7 +406,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	(void)memset(&micp_param, 0, sizeof(micp_param));
 
@@ -442,7 +444,7 @@ static void test_main(void)
 		}
 	}
 
-	printk("MICP initialized\n");
+	LOG_INF("MICP initialized");
 	setup_connectable_adv(&ext_adv);
 
 	WAIT_FOR_FLAG(flag_connected);

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
@@ -27,7 +27,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -36,6 +36,8 @@
 #include "bap_stream_rx.h"
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(pbp_public_broadcast_sink_test);
 
 #if defined(CONFIG_BT_PBP)
 
@@ -93,7 +95,7 @@ static void syncable_cb(struct bt_bap_broadcast_sink *sink, const struct bt_iso_
 {
 	ARG_UNUSED(biginfo);
 
-	printk("Broadcast sink %p is now syncable\n", sink);
+	LOG_INF("Broadcast sink %p is now syncable", sink);
 	k_sem_give(&sem_syncable);
 }
 
@@ -111,12 +113,12 @@ static void started_cb(struct bt_bap_stream *stream)
 	test_stream->valid_rx_cnt = 0U;
 	UNSET_FLAG(test_stream->flag_audio_received);
 
-	printk("Stream %p started\n", stream);
+	LOG_INF("Stream %p started", stream);
 }
 
 static void stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
-	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stream %p stopped with reason 0x%02X", stream, reason);
 }
 
 static bool pa_decode_base(struct bt_data *data, void *user_data)
@@ -159,7 +161,7 @@ static void broadcast_pa_synced(struct bt_le_per_adv_sync *sync,
 	ARG_UNUSED(sync);
 	ARG_UNUSED(info);
 
-	printk("PA synced\n");
+	LOG_INF("PA synced");
 	k_sem_give(&sem_pa_synced);
 }
 
@@ -167,7 +169,7 @@ static void broadcast_pa_terminated(struct bt_le_per_adv_sync *sync,
 				    const struct bt_le_per_adv_sync_term_info *info)
 {
 	if (sync == bcast_pa_sync) {
-		printk("PA sync %p lost with reason %u\n", sync, info->reason);
+		LOG_INF("PA sync %p lost with reason %u", sync, info->reason);
 		bcast_pa_sync = NULL;
 
 		k_sem_give(&sem_pa_sync_lost);
@@ -202,7 +204,7 @@ static int reset(void)
 	if (broadcast_sink != NULL) {
 		err = bt_bap_broadcast_sink_delete(broadcast_sink);
 		if (err != 0) {
-			printk("Deleting broadcast sink failed (err %d)\n", err);
+			LOG_ERR("Deleting broadcast sink failed (err %d)", err);
 
 			return err;
 		}
@@ -230,7 +232,7 @@ static int init(void)
 		return err;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	err = bt_pacs_register(&pacs_param);
 	if (err != 0) {
@@ -243,7 +245,7 @@ static int init(void)
 
 	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap);
 	if (err != 0) {
-		printk("Capability register failed (err %d)\n", err);
+		LOG_ERR("Capability register failed (err %d)", err);
 
 		return err;
 	}
@@ -265,7 +267,7 @@ static void sync_broadcast_pa(const struct bt_le_scan_recv_info *info)
 	bt_le_scan_cb_unregister(&broadcast_scan_cb);
 	err = bt_le_scan_stop();
 	if (err != 0) {
-		printk("Could not stop scan: %d\n", err);
+		LOG_WRN("Could not stop scan: %d", err);
 	}
 
 	bt_addr_le_copy(&param.addr, info->addr);
@@ -275,7 +277,7 @@ static void sync_broadcast_pa(const struct bt_le_scan_recv_info *info)
 	param.timeout = interval_to_sync_timeout(info->interval);
 	err = bt_le_per_adv_sync_create(&param, &bcast_pa_sync);
 	if (err != 0) {
-		printk("Could not sync to PA: %d\n", err);
+		LOG_ERR("Could not sync to PA: %d", err);
 	}
 }
 
@@ -310,8 +312,8 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 
 	ret = bt_pbp_parse_announcement(data, &source_features, &tmp_meta);
 	if (ret >= 0) {
-		printk("Found Suitable Public Broadcast Announcement with %d octets of metadata\n",
-		       ret);
+		LOG_INF("Found Suitable Public Broadcast Announcement with %d octets of metadata",
+			ret);
 		pbs_found = true;
 
 		/* Continue parsing if Broadcast Audio Announcement Service was not found */
@@ -346,13 +348,13 @@ static void broadcast_scan_recv(const struct bt_le_scan_recv_info *info,
 
 static void wait_for_data(void)
 {
-	printk("Waiting for data\n");
+	LOG_INF("Waiting for data");
 	ARRAY_FOR_EACH_PTR(test_streams, test_stream) {
 		if (audio_test_stream_is_streaming(test_stream)) {
 			WAIT_FOR_FLAG(test_stream->flag_audio_received);
 		}
 	}
-	printk("Data received\n");
+	LOG_INF("Data received");
 }
 
 static void test_main(void)
@@ -363,10 +365,10 @@ static void test_main(void)
 	init();
 
 	while (count < PBP_STREAMS_TO_SEND) {
-		printk("Resetting for iteration %d\n", count);
+		LOG_INF("Resetting for iteration %d", count);
 		err = reset();
 		if (err != 0) {
-			printk("Resetting failed: %d\n", err);
+			LOG_ERR("Resetting failed: %d", err);
 			break;
 		}
 
@@ -374,51 +376,52 @@ static void test_main(void)
 		bt_le_scan_cb_register(&broadcast_scan_cb);
 
 		/* Start scanning */
-		printk("Starting scan\n");
+		LOG_INF("Starting scan");
 		err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
 		if (err != 0) {
-			printk("Scan start failed (err %d)\n", err);
+			LOG_ERR("Scan start failed (err %d)", err);
 			break;
 		}
 
 		/* Wait for PA sync */
-		printk("Waiting for PA Sync\n");
+		LOG_INF("Waiting for PA Sync");
 		err = k_sem_take(&sem_pa_synced, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
 
 		/* Wait for BASE decode */
-		printk("Waiting for BASE\n");
+		LOG_INF("Waiting for BASE");
 		err = k_sem_take(&sem_base_received, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
 
 		/* Create broadcast sink */
-		printk("Creating broadcast sink\n");
+		LOG_INF("Creating broadcast sink");
 		err = bt_bap_broadcast_sink_create(bcast_pa_sync, broadcast_id, &broadcast_sink);
 		if (err != 0) {
-			printk("Sink not created!\n");
+			LOG_ERR("Sink not created!");
 			break;
 		}
 
-		printk("Waiting for syncable\n");
+		LOG_INF("Waiting for syncable");
+
 		err = k_sem_take(&sem_syncable, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
 
 		/* Sync to broadcast source */
-		printk("Syncing broadcast sink\n");
+		LOG_INF("Syncing broadcast sink");
 		err = bt_bap_broadcast_sink_sync(broadcast_sink, bis_index_bitfield,
 						 streams_p, NULL);
 		if (err != 0) {
-			printk("Unable to sync to broadcast source: %d\n", err);
+			LOG_ERR("Unable to sync to broadcast source: %d", err);
 			break;
 		}
 
 		wait_for_data();
 
-		printk("Sending signal to broadcaster to stop\n");
+		LOG_INF("Sending signal to broadcaster to stop");
 		backchannel_sync_send_all(); /* let the broadcast source know it can stop */
 
 		/* Wait for the stream to end */
-		printk("Waiting for sync lost\n");
+		LOG_INF("Waiting for sync lost");
 		err = k_sem_take(&sem_pa_sync_lost, K_FOREVER);
 		__ASSERT_NO_MSG(err == 0);
 

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
@@ -23,13 +23,15 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
 #include "bap_stream_tx.h"
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(pbp_public_broadcast_source_test);
 
 #if defined(CONFIG_BT_PBP)
 /* PBS ASCII text */
@@ -70,7 +72,7 @@ static void started_cb(struct bt_bap_stream *stream)
 	test_stream->seq_num = 0U;
 	test_stream->tx_cnt = 0U;
 
-	printk("Stream %p started\n", stream);
+	LOG_INF("Stream %p started", stream);
 
 	err = bap_stream_tx_register(stream);
 	if (err != 0) {
@@ -85,7 +87,7 @@ static void stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
 	int err;
 
-	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
+	LOG_INF("Stream %p stopped with reason 0x%02X", stream, reason);
 
 	err = bap_stream_tx_unregister(stream);
 	if (err != 0) {
@@ -129,17 +131,17 @@ static int setup_extended_adv_data(struct bt_cap_broadcast_source *source,
 	if (pba_params & BT_PBP_ANNOUNCEMENT_FEATURE_HIGH_QUALITY) {
 		pba_params = 0;
 		pba_params |= BT_PBP_ANNOUNCEMENT_FEATURE_STANDARD_QUALITY;
-		printk("Starting stream with standard quality!\n");
+		LOG_INF("Starting stream with standard quality!");
 	} else {
 		pba_params = 0;
 		pba_params |= BT_PBP_ANNOUNCEMENT_FEATURE_HIGH_QUALITY;
-		printk("Starting stream with high quality!\n");
+		LOG_INF("Starting stream with high quality!");
 	}
 
 	err = bt_pbp_get_announcement(pba_metadata, ARRAY_SIZE(pba_metadata), pba_params,
 				      &pbp_ad_buf);
 	if (err != 0) {
-		printk("Failed to create public broadcast announcement!: %d\n", err);
+		LOG_ERR("Failed to create public broadcast announcement!: %d", err);
 
 		return err;
 	}
@@ -149,7 +151,7 @@ static int setup_extended_adv_data(struct bt_cap_broadcast_source *source,
 
 	err = bt_le_ext_adv_set_data(adv, ext_ad, ARRAY_SIZE(ext_ad), NULL, 0);
 	if (err != 0) {
-		printk("Failed to set extended advertising data: %d\n", err);
+		LOG_ERR("Failed to set extended advertising data: %d", err);
 
 		return err;
 	}
@@ -157,7 +159,7 @@ static int setup_extended_adv_data(struct bt_cap_broadcast_source *source,
 	/* Setup periodic advertising data */
 	err = bt_cap_initiator_broadcast_get_base(source, &base_buf);
 	if (err != 0) {
-		printk("Failed to get encoded BASE: %d\n", err);
+		LOG_ERR("Failed to get encoded BASE: %d", err);
 
 		return err;
 	}
@@ -167,7 +169,7 @@ static int setup_extended_adv_data(struct bt_cap_broadcast_source *source,
 	per_ad.data = base_buf.data;
 	err = bt_le_per_adv_set_data(adv, &per_ad, 1);
 	if (err != 0) {
-		printk("Failed to set periodic advertising data: %d\n", err);
+		LOG_ERR("Failed to set periodic advertising data: %d", err);
 
 		return err;
 	}
@@ -181,21 +183,21 @@ static int stop_extended_adv(struct bt_le_ext_adv *adv)
 
 	err = bt_le_per_adv_stop(adv);
 	if (err != 0) {
-		printk("Failed to stop periodic advertising: %d\n", err);
+		LOG_ERR("Failed to stop periodic advertising: %d", err);
 
 		return err;
 	}
 
 	err = bt_le_ext_adv_stop(adv);
 	if (err != 0) {
-		printk("Failed to stop extended advertising: %d\n", err);
+		LOG_ERR("Failed to stop extended advertising: %d", err);
 
 		return err;
 	}
 
 	err = bt_le_ext_adv_delete(adv);
 	if (err != 0) {
-		printk("Failed to delete extended advertising: %d\n", err);
+		LOG_ERR("Failed to delete extended advertising: %d", err);
 
 		return err;
 	}
@@ -221,7 +223,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 	bap_stream_tx_init();
 
 	broadcast_stream = &broadcast_source_stream.stream;
@@ -250,19 +252,19 @@ static void test_main(void)
 
 		err = bt_cap_initiator_broadcast_audio_create(&create_param, &broadcast_source);
 		if (err != 0) {
-			printk("Unable to create broadcast source: %d\n", err);
+			LOG_ERR("Unable to create broadcast source: %d", err);
 			FAIL("Public Broadcast source failed\n");
 		}
 
 		err = bt_cap_initiator_broadcast_audio_start(broadcast_source, adv);
 		if (err != 0) {
-			printk("Unable to start broadcast source: %d\n", err);
+			LOG_ERR("Unable to start broadcast source: %d", err);
 			FAIL("Public Broadcast source failed\n");
 		}
 
 		err = setup_extended_adv_data(broadcast_source, adv);
 		if (err != 0) {
-			printk("Unable to setup extended advertising data: %d\n", err);
+			LOG_ERR("Unable to setup extended advertising data: %d", err);
 			FAIL("Public Broadcast source failed\n");
 		}
 
@@ -270,31 +272,31 @@ static void test_main(void)
 
 		err = k_sem_take(&sem_started, SEM_TIMEOUT);
 		if (err != 0) {
-			printk("sem_started timed out: %d\n", err);
+			LOG_ERR("sem_started timed out: %d", err);
 			FAIL("Public Broadcast source failed\n");
 			return;
 		}
 
 		/* Wait for other devices to let us know when we can stop the source */
-		printk("Waiting for signal from receiver to stop\n");
+		LOG_INF("Waiting for signal from receiver to stop");
 		backchannel_sync_wait_any();
 
-		printk("Stopping broadcast source\n");
+		LOG_INF("Stopping broadcast source");
 		err = bt_cap_initiator_broadcast_audio_stop(broadcast_source);
 		if (err != 0) {
-			printk("Failed to stop broadcast source: %d\n", err);
+			LOG_ERR("Failed to stop broadcast source: %d", err);
 			FAIL("Public Broadcast source failed\n");
 		}
 
 		err = k_sem_take(&sem_stopped, SEM_TIMEOUT);
 		if (err != 0) {
-			printk("sem_stopped timed out: %d\n", err);
+			LOG_ERR("sem_stopped timed out: %d", err);
 			FAIL("Public Broadcast source failed\n");
 			return;
 		}
 		err = bt_cap_initiator_broadcast_audio_delete(broadcast_source);
 		if (err != 0) {
-			printk("Failed to stop broadcast source: %d\n", err);
+			LOG_ERR("Failed to stop broadcast source: %d", err);
 			FAIL("Public Broadcast source failed\n");
 		}
 
@@ -302,7 +304,7 @@ static void test_main(void)
 
 		err = stop_extended_adv(adv);
 		if (err != 0) {
-			printk("Failed to stop and delete extended advertising: %d\n", err);
+			LOG_ERR("Failed to stop and delete extended advertising: %d", err);
 			FAIL("Public Broadcast source failed\n");
 		}
 

--- a/tests/bsim/bluetooth/audio/src/tbs_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_client_test.c
@@ -14,11 +14,13 @@
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(tbs_client_test);
 
 #ifdef CONFIG_BT_TBS_CLIENT
 static struct bt_conn_cb conn_callbacks;
@@ -59,7 +61,7 @@ static void tbs_client_call_states_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("Index %u\n", index);
+	LOG_DBG("Index %u", index);
 	if (err != 0) {
 		FAIL("Call could not read call states (%d)\n", err);
 		return;
@@ -67,7 +69,7 @@ static void tbs_client_call_states_cb(struct bt_conn *conn, int err,
 
 	call_index = call_states[0].index;
 	call_state = call_states[0].state;
-	printk("call index %u - state %u\n", call_index, call_state);
+	LOG_INF("call index %u - state %u", call_index, call_state);
 }
 
 static void tbs_client_read_bearer_provider_name(struct bt_conn *conn, int err,
@@ -81,9 +83,9 @@ static void tbs_client_read_bearer_provider_name(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("Index %u\n", index);
-	printk("Bearer name pointer: %p\n", value);
-	printk("Bearer name: %s\n", value);
+	LOG_DBG("Index %u", index);
+	LOG_DBG("Bearer name pointer: %p", value);
+	LOG_DBG("Bearer name: %s", value);
 	read_complete = true;
 	SET_FLAG(provider_name);
 }
@@ -94,7 +96,7 @@ static void tbs_client_discover_cb(struct bt_conn *conn, int err,
 	ARG_UNUSED(conn);
 	ARG_UNUSED(gtbs_found);
 
-	printk("%s\n", __func__);
+	LOG_DBG("");
 
 	if (err != 0) {
 		FAIL("TBS_CLIENT could not be discovered (%d)\n", err);
@@ -121,7 +123,7 @@ static void tbs_client_read_ccid_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("Read CCID %u on index %u\n", value, inst_index);
+	LOG_INF("Read CCID %u on index %u", value, inst_index);
 
 	inst = bt_tbs_client_get_by_ccid(conn, (uint8_t)value);
 	if (inst == NULL) {
@@ -140,7 +142,7 @@ static void tbs_client_originate_call_cb(struct bt_conn *conn, int err,
 	ARG_UNUSED(err);
 	ARG_UNUSED(inst_index);
 
-	printk("%s %u:\n", __func__, call_index);
+	LOG_DBG("%u:", call_index);
 	call_placed = true;
 }
 
@@ -155,8 +157,7 @@ static void tbs_client_hold_call_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("%s Instance: %u Call index: %u\n", __func__, inst_index,
-						  call_index);
+	LOG_DBG("Instance: %u Call index: %u", inst_index, call_index);
 }
 
 static void tbs_client_retrieve_call_cb(struct bt_conn *conn, int err,
@@ -170,8 +171,7 @@ static void tbs_client_retrieve_call_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("%s Instance: %u Call index: %u\n", __func__, inst_index,
-						  call_index);
+	LOG_DBG("Instance: %u Call index: %u", inst_index, call_index);
 }
 
 static void tbs_client_technology_cb(struct bt_conn *conn, int err, uint8_t inst_index,
@@ -184,7 +184,7 @@ static void tbs_client_technology_cb(struct bt_conn *conn, int err, uint8_t inst
 		return;
 	}
 
-	printk("%s Instance: %u Technology: %d\n", __func__, inst_index, technology);
+	LOG_DBG("Instance: %u Technology: %d", inst_index, technology);
 
 	SET_FLAG(flag_technology);
 }
@@ -200,7 +200,7 @@ static void tbs_client_signal_strength_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("%s Instance: %u, Strength: %u\n", __func__, inst_index, value);
+	LOG_DBG("Instance: %u, Strength: %u", inst_index, value);
 
 	SET_FLAG(signal_strength);
 }
@@ -216,7 +216,7 @@ static void tbs_client_signal_interval_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("%s Instance: %u Interval: %u\n", __func__, inst_index, value);
+	LOG_DBG("Instance: %u Interval: %u", inst_index, value);
 
 	SET_FLAG(signal_interval);
 }
@@ -232,7 +232,7 @@ static void tbs_client_status_flags_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("%s Instance: %u Flags: %u\n", __func__, inst_index, value);
+	LOG_DBG("Instance: %u Flags: %u", inst_index, value);
 
 	SET_FLAG(status_flags);
 }
@@ -247,8 +247,7 @@ static void tbs_client_terminate_call_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("%s Instance: %u Call index: %u\n", __func__, inst_index,
-						  call_index);
+	LOG_DBG("Instance: %u Call index: %u", inst_index, call_index);
 
 	SET_FLAG(call_terminated);
 }
@@ -263,8 +262,7 @@ static void tbs_client_accept_call_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("%s Instance: %u Call index: %u\n", __func__, inst_index,
-						  call_index);
+	LOG_DBG("Instance: %u Call index: %u", inst_index, call_index);
 
 	SET_FLAG(call_accepted);
 }
@@ -280,7 +278,7 @@ static void tbs_client_bearer_uci_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("%s Instance: %u UCI: %s\n", __func__, inst_index, value);
+	LOG_DBG("Instance: %u UCI: %s", inst_index, value);
 
 	SET_FLAG(bearer_uci);
 }
@@ -295,7 +293,7 @@ static void tbs_client_uri_list_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("%s Instance: %u URI list: %s\n", __func__, inst_index, value);
+	LOG_DBG("Instance: %u URI list: %s", inst_index, value);
 
 	SET_FLAG(uri_list);
 }
@@ -313,8 +311,7 @@ static void tbs_client_current_calls_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("%s Instance: %u Call count: %u\n", __func__, inst_index,
-						  call_count);
+	LOG_DBG("Instance: %u Call count: %u", inst_index, call_count);
 
 	SET_FLAG(current_calls);
 }
@@ -330,8 +327,8 @@ static void tbs_client_call_uri_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	printk("Incoming URI callback\n");
-	printk("%s Instance: %u URI: %s\n", __func__, inst_index, value);
+	LOG_INF("Incoming URI callback");
+	LOG_DBG("Instance: %u URI: %s", inst_index, value);
 
 	SET_FLAG(uri_inc);
 }
@@ -345,7 +342,7 @@ static void tbs_client_term_reason_cb(struct bt_conn *conn,
 	ARG_UNUSED(err);
 	ARG_UNUSED(call_index);
 
-	printk("%s Instance: %u Reason: %u\n", __func__, inst_index, reason);
+	LOG_DBG("Instance: %u Reason: %u", inst_index, reason);
 
 	SET_FLAG(term_reason);
 }
@@ -379,7 +376,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		return;
 	}
 
-	printk("Connected to %s\n", bt_conn_dst_str(conn));
+	LOG_INF("Connected to %s", bt_conn_dst_str(conn));
 	is_connected = true;
 }
 
@@ -404,7 +401,7 @@ static void test_ccid(void)
 		int err;
 
 		UNSET_FLAG(ccid_read_flag);
-		printk("Reading GTBS CCID\n");
+		LOG_INF("Reading GTBS CCID");
 
 		err = bt_tbs_client_read_ccid(default_conn, BT_TBS_GTBS_INDEX);
 		if (err != 0) {
@@ -419,7 +416,7 @@ static void test_ccid(void)
 		int err;
 
 		UNSET_FLAG(ccid_read_flag);
-		printk("Reading bearer CCID on index %u\n", i);
+		LOG_INF("Reading bearer CCID on index %u", i);
 
 		err = bt_tbs_client_read_ccid(default_conn, i);
 		if (err != 0) {
@@ -437,7 +434,7 @@ static void test_signal_strength(uint8_t index)
 
 	UNSET_FLAG(signal_strength);
 
-	printk("%s\n", __func__);
+	LOG_DBG("");
 
 	err = bt_tbs_client_read_signal_strength(default_conn, index);
 	if (err != 0) {
@@ -447,7 +444,7 @@ static void test_signal_strength(uint8_t index)
 
 	WAIT_FOR_FLAG(signal_strength);
 
-	printk("Client read signal strength test success\n");
+	LOG_INF("Client read signal strength test success");
 }
 
 static void test_technology(uint8_t index)
@@ -456,7 +453,7 @@ static void test_technology(uint8_t index)
 
 	UNSET_FLAG(flag_technology);
 
-	printk("%s\n", __func__);
+	LOG_DBG("");
 
 	err = bt_tbs_client_read_technology(default_conn, index);
 	if (err != 0) {
@@ -466,7 +463,7 @@ static void test_technology(uint8_t index)
 
 	WAIT_FOR_FLAG(flag_technology);
 
-	printk("Client read technology test success\n");
+	LOG_INF("Client read technology test success");
 }
 
 static void test_status_flags(uint8_t index)
@@ -475,7 +472,7 @@ static void test_status_flags(uint8_t index)
 
 	UNSET_FLAG(status_flags);
 
-	printk("%s\n", __func__);
+	LOG_DBG("");
 
 	err = bt_tbs_client_read_status_flags(default_conn, index);
 	if (err != 0) {
@@ -485,7 +482,7 @@ static void test_status_flags(uint8_t index)
 
 	WAIT_FOR_FLAG(status_flags);
 
-	printk("Client read status flags test success\n");
+	LOG_INF("Client read status flags test success");
 }
 
 static void test_signal_interval(uint8_t index)
@@ -494,7 +491,7 @@ static void test_signal_interval(uint8_t index)
 
 	UNSET_FLAG(signal_interval);
 
-	printk("%s\n", __func__);
+	LOG_DBG("");
 
 	err = bt_tbs_client_read_signal_interval(default_conn, index);
 	if (err != 0) {
@@ -504,7 +501,7 @@ static void test_signal_interval(uint8_t index)
 
 	WAIT_FOR_FLAG(signal_interval);
 
-	printk("Client signal interval test success\n");
+	LOG_INF("Client signal interval test success");
 }
 
 static void discover_tbs(void)
@@ -545,20 +542,20 @@ static void test_main(void)
 
 	WAIT_FOR_COND(bt_init);
 
-	printk("Audio Server: Bluetooth discovered\n");
+	LOG_INF("Audio Server: Bluetooth discovered");
 
 	setup_connectable_adv(&ext_adv);
 
-	printk("Advertising successfully started\n");
+	LOG_INF("Advertising successfully started");
 
 	WAIT_FOR_COND(is_connected);
 
 	discover_tbs();
 	discover_tbs(); /* test that we can discover twice */
 
-	printk("GTBS %sfound\n", is_gtbs_found ? "" : "not ");
+	LOG_INF("GTBS %sfound", is_gtbs_found ? "" : "not ");
 
-	printk("Placing call\n");
+	LOG_INF("Placing call");
 	err = bt_tbs_client_originate_call(default_conn, 0, "tel:123456789012");
 	if (err != 0) {
 		FAIL("Originate call failed (%d)\n", err);
@@ -570,10 +567,10 @@ static void test_main(void)
 	 * 3) Active
 	 * 4) Remotely Held
 	 */
-	printk("Waiting for remotely held\n");
+	LOG_INF("Waiting for remotely held");
 	WAIT_FOR_COND(call_state == BT_TBS_CALL_STATE_REMOTELY_HELD);
 
-	printk("Holding call\n");
+	LOG_INF("Holding call");
 	err = bt_tbs_client_hold_call(default_conn, index, call_index);
 	if (err != 0) {
 		FAIL("Hold call failed (%d)\n", err);
@@ -585,7 +582,7 @@ static void test_main(void)
 	 */
 	WAIT_FOR_COND(call_state == BT_TBS_CALL_STATE_LOCALLY_HELD);
 
-	printk("Retrieving call\n");
+	LOG_INF("Retrieving call");
 	err = bt_tbs_client_retrieve_call(default_conn, index, call_index);
 	if (err != 0) {
 		FAIL("Retrieve call failed (%d)\n", err);
@@ -593,7 +590,7 @@ static void test_main(void)
 
 	WAIT_FOR_COND(call_state == BT_TBS_CALL_STATE_ACTIVE);
 
-	printk("Reading bearer provider name\n");
+	LOG_INF("Reading bearer provider name");
 	UNSET_FLAG(provider_name);
 	err = bt_tbs_client_read_bearer_provider_name(default_conn, index);
 	if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/tbs_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_test.c
@@ -16,11 +16,13 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(tbs_test);
 
 #ifdef CONFIG_BT_TBS
 extern enum bst_result_t bst_result;
@@ -48,7 +50,7 @@ static bool tbs_originate_call_cb(struct bt_conn *conn, uint8_t call_index,
 {
 	ARG_UNUSED(conn);
 
-	printk("Placing call to remote with id %u to %s\n", call_index, caller_id);
+	LOG_INF("Placing call to remote with id %u to %s", call_index, caller_id);
 	g_call_index = call_index;
 	SET_FLAG(call_placed);
 	return true;
@@ -64,7 +66,7 @@ static void tbs_terminate_call_cb(struct bt_conn *conn, uint8_t call_index,
 {
 	ARG_UNUSED(conn);
 
-	printk("Terminating call with id %u reason: %u", call_index, reason);
+	LOG_INF("Terminating call with id %u reason: %u", call_index, reason);
 	SET_FLAG(call_terminated);
 	UNSET_FLAG(call_placed);
 }
@@ -73,7 +75,7 @@ static void tbs_accept_call_cb(struct bt_conn *conn, uint8_t call_index)
 {
 	ARG_UNUSED(conn);
 
-	printk("Accepting call with index %u\n", call_index);
+	LOG_INF("Accepting call with index %u", call_index);
 	SET_FLAG(call_accepted);
 }
 
@@ -81,7 +83,7 @@ static void tbs_retrieve_call_cb(struct bt_conn *conn, uint8_t call_index)
 {
 	ARG_UNUSED(conn);
 
-	printk("Retrieve call with index %u\n", call_index);
+	LOG_INF("Retrieve call with index %u", call_index);
 	SET_FLAG(call_retrieved);
 }
 
@@ -92,7 +94,7 @@ static void tbs_join_calls_cb(struct bt_conn *conn,
 	ARG_UNUSED(conn);
 
 	for (size_t i = 0U; i < call_index_count; i++) {
-		printk("Call index: %u joined\n", call_indexes[i]);
+		LOG_INF("Call index: %u joined", call_indexes[i]);
 	}
 	SET_FLAG(call_joined);
 }
@@ -114,7 +116,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		return;
 	}
 
-	printk("Connected to %s\n", bt_conn_dst_str(conn));
+	LOG_INF("Connected to %s", bt_conn_dst_str(conn));
 
 	default_conn = bt_conn_ref(conn);
 	SET_FLAG(is_connected);
@@ -129,14 +131,14 @@ static int test_provider_name(uint8_t bearer_index)
 {
 	int err;
 
-	printk("%s\n", __func__);
+	LOG_DBG("%s", __func__);
 	err = bt_tbs_set_bearer_provider_name(bearer_index, "BabblesimTBS");
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not set bearer provider name: %d\n", err);
 		return err;
 	}
 
-	printk("Set bearer provider name test success\n");
+	LOG_INF("Set bearer provider name test success");
 
 	return err;
 }
@@ -145,14 +147,14 @@ static int test_set_signal_strength(uint8_t bearer_index)
 {
 	int err;
 
-	printk("%s\n", __func__);
+	LOG_DBG("%s", __func__);
 	err = bt_tbs_set_signal_strength(bearer_index, 6);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not set bearer provider name: %d\n", err);
 		return err;
 	}
 
-	printk("Set signal strength test success\n");
+	LOG_INF("Set signal strength test success");
 
 	return err;
 }
@@ -161,14 +163,14 @@ static int test_set_bearer_technology(uint8_t bearer_index)
 {
 	int err;
 
-	printk("%s\n", __func__);
+	LOG_DBG("%s", __func__);
 	err = bt_tbs_set_bearer_technology(bearer_index, BT_BEARER_TECH_GSM);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not set bearer technology: %d\n", err);
 		return err;
 	}
 
-	printk("Set bearer technology test success\n");
+	LOG_INF("Set bearer technology test success");
 
 	return err;
 }
@@ -177,14 +179,14 @@ static int test_set_status_flags(uint8_t bearer_index)
 {
 	int err;
 
-	printk("%s\n", __func__);
+	LOG_DBG("%s", __func__);
 	err = bt_tbs_set_status_flags(bearer_index, 3);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not set status flags: %d\n", err);
 		return err;
 	}
 
-	printk("Set status flags test success\n");
+	LOG_INF("Set status flags test success");
 
 	return err;
 }
@@ -193,29 +195,29 @@ static int test_answer_terminate(uint8_t bearer_index)
 {
 	int err;
 
-	printk("%s\n", __func__);
-	printk("Placing call\n");
+	LOG_DBG("%s", __func__);
+	LOG_INF("Placing call");
 	err = bt_tbs_originate(bearer_index, "tel:000000000001", &g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not originate call: %d\n", err);
 		return err;
 	}
 
-	printk("Answering call\n");
+	LOG_INF("Answering call");
 	err = bt_tbs_remote_answer(g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not remote answer: %d\n", err);
 		return err;
 	}
 
-	printk("Terminating call\n");
+	LOG_INF("Terminating call");
 	err = bt_tbs_terminate(g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not terminate call: %d\n", err);
 		return err;
 	}
 
-	printk("Test answer & terminate successful\n");
+	LOG_INF("Test answer & terminate successful");
 
 	return err;
 }
@@ -224,7 +226,7 @@ static int test_hold_retrieve(uint8_t bearer_index)
 {
 	int err;
 
-	printk("%s\n", __func__);
+	LOG_DBG("%s", __func__);
 	err = bt_tbs_originate(bearer_index, "tel:000000000001", &g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not originate call: %d\n", err);
@@ -237,28 +239,28 @@ static int test_hold_retrieve(uint8_t bearer_index)
 		return err;
 	}
 
-	printk("Holding call\n");
+	LOG_INF("Holding call");
 	err = bt_tbs_hold(g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not terminate call: %d\n", err);
 		return err;
 	}
 
-	printk("Retrieving call\n");
+	LOG_INF("Retrieving call");
 	err = bt_tbs_retrieve(g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not retrieve call: %d\n", err);
 		return err;
 	}
 
-	printk("Terminating call\n");
+	LOG_INF("Terminating call");
 	err = bt_tbs_terminate(g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not terminate call: %d\n", err);
 		return err;
 	}
 
-	printk("Hold & retrieve test successful\n");
+	LOG_INF("Hold & retrieve test successful");
 
 	return err;
 }
@@ -268,42 +270,42 @@ static int test_join(uint8_t bearer_index)
 	int err;
 	uint8_t call_indexes[2];
 
-	printk("%s\n", __func__);
-	printk("Placing first call\n");
+	LOG_DBG("%s", __func__);
+	LOG_INF("Placing first call");
 	err = bt_tbs_originate(bearer_index, "tel:000000000001", &g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not originate first call: %d\n", err);
 		return err;
 	}
 
-	printk("Answering first call\n");
+	LOG_INF("Answering first call");
 	err = bt_tbs_remote_answer(g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not answer first call: %d\n", err);
 		return err;
 	}
-	printk("First call answered\n");
+	LOG_INF("First call answered");
 
 	call_indexes[0] = (uint8_t)g_call_index;
 
-	printk("Placing second call\n");
+	LOG_INF("Placing second call");
 	err = bt_tbs_originate(bearer_index, "tel:000000000002", &g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not originate second call: %d\n", err);
 		return err;
 	}
 
-	printk("Answering second call\n");
+	LOG_INF("Answering second call");
 	err = bt_tbs_remote_answer(g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not answer second call: %d\n", err);
 		return err;
 	}
-	printk("Second call answered\n");
+	LOG_INF("Second call answered");
 
 	call_indexes[1] = (uint8_t)g_call_index;
 
-	printk("Joining calls\n");
+	LOG_INF("Joining calls");
 	err = bt_tbs_join(2, call_indexes);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not join calls: %d\n", err);
@@ -322,7 +324,7 @@ static int test_join(uint8_t bearer_index)
 		return err;
 	}
 
-	printk("Join calls test successful\n");
+	LOG_INF("Join calls test successful");
 
 	return err;
 }
@@ -358,7 +360,7 @@ static void init(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	err = bt_conn_cb_register(&conn_callbacks);
 	if (err != 0) {
@@ -383,7 +385,7 @@ static void init(void)
 		return;
 	}
 
-	printk("Registered GTBS\n");
+	LOG_INF("Registered GTBS");
 
 	for (int i = 0; i < CONFIG_BT_TBS_BEARER_COUNT; i++) {
 		char prov_name[22]; /* Enough to store "Telephone Bearer #255" */
@@ -408,7 +410,7 @@ static void init(void)
 			return;
 		}
 
-		printk("Registered TBS[%d] with index %u\n", i, (uint8_t)err);
+		LOG_INF("Registered TBS[%d] with index %u", i, (uint8_t)err);
 	}
 }
 
@@ -424,7 +426,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Scanning successfully started\n");
+	LOG_INF("Scanning successfully started");
 
 	WAIT_FOR_COND(is_connected);
 
@@ -435,13 +437,13 @@ static void test_main(void)
 		FAIL("Remote could not answer call: %d\n", err);
 		return;
 	}
-	printk("Remote answered %u\n", g_call_index);
+	LOG_INF("Remote answered %u", g_call_index);
 
 	err = bt_tbs_remote_hold(g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Remote could not hold call: %d\n", err);
 	}
-	printk("Remote held %u\n", g_call_index);
+	LOG_INF("Remote held %u", g_call_index);
 
 	WAIT_FOR_COND(call_held);
 
@@ -450,7 +452,7 @@ static void test_main(void)
 		FAIL("Remote could not answer call: %d\n", err);
 		return;
 	}
-	printk("Remote retrieved %u\n", g_call_index);
+	LOG_INF("Remote retrieved %u", g_call_index);
 
 	PASS("TBS Passed\n");
 }

--- a/tests/bsim/bluetooth/audio/src/tmap_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_client_test.c
@@ -20,13 +20,15 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/net_buf.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(tmap_client_test);
 
 #ifdef CONFIG_BT_TMAP
 extern enum bst_result_t bst_result;
@@ -43,7 +45,7 @@ void tmap_discovery_complete_cb(enum bt_tmap_role role, struct bt_conn *conn, in
 		return;
 	}
 
-	printk("TMAS discovery done\n");
+	LOG_INF("TMAS discovery done");
 	SET_FLAG(flag_tmap_discovered);
 }
 
@@ -60,14 +62,14 @@ static bool check_audio_support_and_connect(struct bt_data *data, void *user_dat
 	uint16_t peer_tmap_role = 0U;
 	int err;
 
-	printk("[AD]: %u data_len %u\n", data->type, data->data_len);
+	LOG_DBG("[AD]: %u data_len %u", data->type, data->data_len);
 
 	if (data->type != BT_DATA_SVC_DATA16) {
 		return true; /* Continue parsing to next AD data type */
 	}
 
 	if (data->data_len < sizeof(uuid_val)) {
-		printk("AD invalid size %u\n", data->data_len);
+		LOG_ERR("AD invalid size %u", data->data_len);
 		return true; /* Continue parsing to next AD data type */
 	}
 
@@ -79,22 +81,22 @@ static bool check_audio_support_and_connect(struct bt_data *data, void *user_dat
 		return true; /* Continue parsing to next AD data type */
 	}
 
-	printk("Found TMAS in peer adv data!\n");
+	LOG_INF("Found TMAS in peer adv data!");
 	if (tmas_svc_data.len < sizeof(peer_tmap_role)) {
-		printk("AD invalid size %u\n", data->data_len);
+		LOG_ERR("AD invalid size %u", data->data_len);
 		return false; /* Stop parsing */
 	}
 
 	peer_tmap_role = net_buf_simple_pull_le16(&tmas_svc_data);
 	if (!(peer_tmap_role & BT_TMAP_ROLE_UMR)) {
-		printk("No TMAS UMR support!\n");
+		LOG_DBG("No TMAS UMR support!");
 		return false; /* Stop parsing */
 	}
 
-	printk("Attempt to connect!\n");
+	LOG_DBG("Attempt to connect!");
 	err = bt_le_scan_stop();
 	if (err != 0) {
-		printk("Failed to stop scan: %d\n", err);
+		LOG_ERR("Failed to stop scan: %d", err);
 		return false;
 	}
 
@@ -111,12 +113,12 @@ static bool check_audio_support_and_connect(struct bt_data *data, void *user_dat
 static void scan_recv(const struct bt_le_scan_recv_info *info,
 		      struct net_buf_simple *buf)
 {
-	printk("SCAN RCV CB\n");
+	LOG_DBG("");
 
 	/* Check for connectable, extended advertising */
 	if (((info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0) ||
 		((info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE)) != 0) {
-		printk("[DEVICE]: %s, ", bt_addr_le_str(info->addr));
+		LOG_DBG("[DEVICE]: %s", bt_addr_le_str(info->addr));
 		/* Check for TMAS support in advertising data */
 		bt_data_parse(buf, check_audio_support_and_connect, (void *)info->addr);
 	}
@@ -139,7 +141,7 @@ static void discover_tmas(void)
 		return;
 	}
 
-	printk("TMAP Central Starting Service Discovery...\n");
+	LOG_INF("TMAP Central Starting Service Discovery...");
 	WAIT_FOR_FLAG(flag_tmap_discovered);
 }
 
@@ -153,7 +155,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 	/* Initialize TMAP */
 	err = bt_tmap_register(BT_TMAP_ROLE_CG | BT_TMAP_ROLE_UMS);
 	if (err != 0) {
@@ -161,7 +163,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("TMAP initialized. Start scanning...\n");
+	LOG_INF("TMAP initialized. Start scanning...");
 	/* Scan for peer */
 	bt_le_scan_cb_register(&scan_callbacks);
 	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
@@ -170,7 +172,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Scanning successfully started\n");
+	LOG_INF("Scanning successfully started");
 	WAIT_FOR_FLAG(flag_connected);
 
 	discover_tmas();

--- a/tests/bsim/bluetooth/audio/src/tmap_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_server_test.c
@@ -14,12 +14,14 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(tmap_server_test);
 
 #ifdef CONFIG_BT_TMAP
 extern enum bst_result_t bst_result;
@@ -35,18 +37,18 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 	/* Initialize TMAP */
 	err = bt_tmap_register(TMAP_ROLE_SUPPORTED);
 	if (err != 0) {
 		FAIL("Failed to register TMAP (err %d)\n", err);
 		return;
 	}
-	printk("TMAP initialized. Start advertising...\n");
+	LOG_INF("TMAP initialized. Start advertising...");
 	setup_connectable_adv(&ext_adv);
 
 	WAIT_FOR_FLAG(flag_connected);
-	printk("Connected!\n");
+	LOG_INF("Connected!");
 
 	PASS("TMAP test passed\n");
 }

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_ctlr_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_ctlr_test.c
@@ -14,11 +14,13 @@
 #include <zephyr/bluetooth/audio/vcp.h>
 #include <zephyr/bluetooth/audio/vocs.h>
 #include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(vcp_vol_ctlr_test);
 
 #ifdef CONFIG_BT_VCP_VOL_CTLR
 #define VOCS_DESC_SIZE 64U
@@ -118,7 +120,7 @@ static void vocs_description_cb(struct bt_vocs *inst, int err,
 	}
 
 	if (strlen(description) > sizeof(g_vocs_desc) - 1) {
-		printk("Warning: VOCS description (%zu) is larger than buffer (%zu)\n",
+		LOG_WRN("VOCS description (%zu) is larger than buffer (%zu)",
 		       strlen(description), sizeof(g_vocs_desc) - 1);
 	}
 
@@ -214,7 +216,7 @@ static void aics_description_cb(struct bt_aics *inst, int err,
 	}
 
 	if (strlen(description) > sizeof(g_aics_desc) - 1) {
-		printk("Warning: AICS description (%zu) is larger than buffer (%zu)\n",
+		LOG_WRN("AICS description (%zu) is larger than buffer (%zu)",
 		       strlen(description), sizeof(g_aics_desc) - 1);
 	}
 
@@ -275,7 +277,7 @@ static void test_aics_deactivate(void)
 	}
 
 	/* Valid behavior */
-	printk("Attempting to deactivate AICS\n");
+	LOG_INF("Attempting to deactivate AICS");
 	err = bt_aics_deactivate(vcp_included.aics[0]);
 	if (err == 0) {
 		FAIL("bt_aics_deactivate as client instance did not fail");
@@ -295,7 +297,7 @@ static void test_aics_activate(void)
 	}
 
 	/* Valid behavior */
-	printk("Attempting to activate AICS\n");
+	LOG_INF("Attempting to activate AICS");
 	err = bt_aics_activate(vcp_included.aics[0]);
 	if (err == 0) {
 		FAIL("bt_aics_activate as client instance did not fail");
@@ -315,7 +317,7 @@ static void test_aics_state_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting AICS state\n");
+	LOG_INF("Getting AICS state");
 	g_cb = false;
 
 	err = bt_aics_state_get(vcp_included.aics[0]);
@@ -325,7 +327,7 @@ static void test_aics_state_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("AICS state get\n");
+	LOG_INF("AICS state get");
 }
 
 static void aics_gain_setting_get(void)
@@ -340,7 +342,7 @@ static void aics_gain_setting_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting AICS gain setting\n");
+	LOG_INF("Getting AICS gain setting");
 	g_cb = false;
 
 	err = bt_aics_gain_setting_get(vcp_included.aics[0]);
@@ -350,7 +352,7 @@ static void aics_gain_setting_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("AICS gain setting get\n");
+	LOG_INF("AICS gain setting get");
 }
 
 static void aics_type_get(void)
@@ -366,7 +368,7 @@ static void aics_type_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting AICS input type\n");
+	LOG_INF("Getting AICS input type");
 
 	err = bt_aics_type_get(vcp_included.aics[0]);
 	if (err != 0) {
@@ -376,7 +378,7 @@ static void aics_type_get(void)
 
 	/* Expect and wait for input_type from init */
 	WAIT_FOR_COND(expected_input_type == g_aics_input_type);
-	printk("AICS input type get\n");
+	LOG_INF("AICS input type get");
 }
 
 static void aics_status_get(void)
@@ -391,7 +393,7 @@ static void aics_status_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting AICS status\n");
+	LOG_INF("Getting AICS status");
 	g_cb = false;
 
 	err = bt_aics_status_get(vcp_included.aics[0]);
@@ -401,7 +403,7 @@ static void aics_status_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("AICS status get\n");
+	LOG_INF("AICS status get");
 }
 
 static void aics_get_description(void)
@@ -416,7 +418,7 @@ static void aics_get_description(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting AICS description\n");
+	LOG_INF("Getting AICS description");
 	g_cb = false;
 
 	err = bt_aics_description_get(vcp_included.aics[0]);
@@ -426,7 +428,7 @@ static void aics_get_description(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("AICS description get\n");
+	LOG_INF("AICS description get");
 }
 
 static void test_aics_mute(void)
@@ -442,7 +444,7 @@ static void test_aics_mute(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS mute\n");
+	LOG_INF("Setting AICS mute");
 	g_write_complete = false;
 
 	err = bt_aics_mute(vcp_included.aics[0]);
@@ -452,7 +454,7 @@ static void test_aics_mute(void)
 	}
 
 	WAIT_FOR_COND(g_write_complete && expected_input_mute == g_aics_input_mute);
-	printk("AICS mute set\n");
+	LOG_INF("AICS mute set");
 }
 
 static void test_aics_unmute(void)
@@ -468,7 +470,7 @@ static void test_aics_unmute(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS unmute\n");
+	LOG_INF("Setting AICS unmute");
 	g_write_complete = false;
 
 	err = bt_aics_unmute(vcp_included.aics[0]);
@@ -478,7 +480,7 @@ static void test_aics_unmute(void)
 	}
 
 	WAIT_FOR_COND(g_write_complete && expected_input_mute == g_aics_input_mute);
-	printk("AICS unmute set\n");
+	LOG_INF("AICS unmute set");
 }
 
 static void test_aics_automatic_gain_set(void)
@@ -494,7 +496,7 @@ static void test_aics_automatic_gain_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS auto mode\n");
+	LOG_INF("Setting AICS auto mode");
 	g_write_complete = false;
 
 	err = bt_aics_automatic_gain_set(vcp_included.aics[0]);
@@ -504,7 +506,7 @@ static void test_aics_automatic_gain_set(void)
 	}
 
 	WAIT_FOR_COND(g_write_complete && expected_mode == g_aics_mode);
-	printk("AICS auto mode set\n");
+	LOG_INF("AICS auto mode set");
 }
 
 static void test_aics_manual_gain_set(void)
@@ -520,7 +522,7 @@ static void test_aics_manual_gain_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS manual mode\n");
+	LOG_INF("Setting AICS manual mode");
 	g_write_complete = false;
 
 	err = bt_aics_manual_gain_set(vcp_included.aics[0]);
@@ -530,7 +532,7 @@ static void test_aics_manual_gain_set(void)
 	}
 
 	WAIT_FOR_COND(g_write_complete && expected_mode == g_aics_mode);
-	printk("AICS manual mode set\n");
+	LOG_INF("AICS manual mode set");
 }
 
 static void test_aics_gain_set(void)
@@ -546,7 +548,7 @@ static void test_aics_gain_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS gain\n");
+	LOG_INF("Setting AICS gain");
 	g_write_complete = false;
 
 	err = bt_aics_gain_set(vcp_included.aics[0], expected_gain);
@@ -556,7 +558,7 @@ static void test_aics_gain_set(void)
 	}
 
 	WAIT_FOR_COND(g_write_complete && expected_gain == g_aics_gain);
-	printk("AICS gain set\n");
+	LOG_INF("AICS gain set");
 }
 
 static void test_aics_description_set(void)
@@ -578,7 +580,7 @@ static void test_aics_description_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS Description\n");
+	LOG_INF("Setting AICS Description");
 	g_cb = false;
 
 	err = bt_aics_description_set(vcp_included.aics[0], expected_aics_desc);
@@ -589,7 +591,7 @@ static void test_aics_description_set(void)
 
 	WAIT_FOR_COND(g_cb &&
 		      strncmp(expected_aics_desc, g_aics_desc, strlen(expected_aics_desc)) == 0);
-	printk("AICS Description set\n");
+	LOG_INF("AICS Description set");
 }
 
 static void test_aics(void)
@@ -621,7 +623,7 @@ static void test_vocs_state_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting VOCS state\n");
+	LOG_INF("Getting VOCS state");
 	g_cb = false;
 
 	err = bt_vocs_state_get(vcp_included.vocs[0]);
@@ -631,7 +633,7 @@ static void test_vocs_state_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("VOCS state get\n");
+	LOG_INF("VOCS state get");
 }
 
 static void test_vocs_location_get(void)
@@ -646,7 +648,7 @@ static void test_vocs_location_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting VOCS location\n");
+	LOG_INF("Getting VOCS location");
 	g_cb = false;
 
 	err = bt_vocs_location_get(vcp_included.vocs[0]);
@@ -656,7 +658,7 @@ static void test_vocs_location_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("VOCS location get\n");
+	LOG_INF("VOCS location get");
 }
 
 static void test_vocs_description_get(void)
@@ -671,7 +673,7 @@ static void test_vocs_description_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting VOCS description\n");
+	LOG_INF("Getting VOCS description");
 	g_cb = false;
 
 	err = bt_vocs_description_get(vcp_included.vocs[0]);
@@ -681,7 +683,7 @@ static void test_vocs_description_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("VOCS description get\n");
+	LOG_INF("VOCS description get");
 }
 
 static void test_vocs_location_set(void)
@@ -706,7 +708,7 @@ static void test_vocs_location_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting VOCS location\n");
+	LOG_INF("Setting VOCS location");
 
 	err = bt_vocs_location_set(vcp_included.vocs[0], expected_location);
 	if (err != 0) {
@@ -715,7 +717,7 @@ static void test_vocs_location_set(void)
 	}
 
 	WAIT_FOR_COND(expected_location == g_vocs_location);
-	printk("VOCS location set\n");
+	LOG_INF("VOCS location set");
 }
 
 static void test_vocs_state_set(void)
@@ -748,7 +750,7 @@ static void test_vocs_state_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting VOCS state\n");
+	LOG_INF("Setting VOCS state");
 	g_write_complete = false;
 
 	err = bt_vocs_state_set(vcp_included.vocs[0], expected_offset);
@@ -758,7 +760,7 @@ static void test_vocs_state_set(void)
 	}
 
 	WAIT_FOR_COND(g_write_complete && expected_offset == g_vocs_offset);
-	printk("VOCS state set\n");
+	LOG_INF("VOCS state set");
 }
 
 static void test_vocs_description_set(void)
@@ -780,7 +782,7 @@ static void test_vocs_description_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting VOCS description\n");
+	LOG_INF("Setting VOCS description");
 	g_cb = false;
 
 	err = bt_vocs_description_set(vcp_included.vocs[0], expected_vocs_desc);
@@ -791,7 +793,7 @@ static void test_vocs_description_set(void)
 
 	WAIT_FOR_COND(g_cb &&
 		      strncmp(expected_vocs_desc, g_vocs_desc, strlen(expected_vocs_desc)) == 0);
-	printk("VOCS description set\n");
+	LOG_INF("VOCS description set");
 }
 
 static void test_vocs(void)
@@ -918,7 +920,7 @@ static void test_conn_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting VCP volume controller conn\n");
+	LOG_INF("Getting VCP volume controller conn");
 
 	err = bt_vcp_vol_ctlr_conn_get(vol_ctlr, &cached_conn);
 	if (err != 0) {
@@ -931,7 +933,7 @@ static void test_conn_get(void)
 		return;
 	}
 
-	printk("Got VCP volume controller conn\n");
+	LOG_INF("Got VCP volume controller conn");
 }
 
 static void test_read_state(void)
@@ -946,7 +948,7 @@ static void test_read_state(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting VCP volume state\n");
+	LOG_INF("Getting VCP volume state");
 	g_cb = false;
 
 	err = bt_vcp_vol_ctlr_read_state(vol_ctlr);
@@ -956,7 +958,7 @@ static void test_read_state(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("VCP volume get\n");
+	LOG_INF("VCP volume get");
 }
 
 static void test_read_flags(void)
@@ -971,7 +973,7 @@ static void test_read_flags(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting VCP flags\n");
+	LOG_INF("Getting VCP flags");
 	g_cb = false;
 
 	err = bt_vcp_vol_ctlr_read_flags(vol_ctlr);
@@ -981,7 +983,7 @@ static void test_read_flags(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("VCP flags get\n");
+	LOG_INF("VCP flags get");
 }
 
 static void test_set_vol(void)
@@ -1006,7 +1008,7 @@ static void test_set_vol(void)
 	}
 
 	WAIT_FOR_COND(g_volume == expected_volume && g_cb && g_write_complete);
-	printk("VCP volume set\n");
+	LOG_INF("VCP volume set");
 }
 
 static void test_vol_down(void)
@@ -1022,7 +1024,7 @@ static void test_vol_down(void)
 	}
 
 	/* Valid behavior */
-	printk("Downing VCP volume\n");
+	LOG_INF("Downing VCP volume");
 	g_write_complete = g_cb = false;
 
 	err = bt_vcp_vol_ctlr_vol_down(vol_ctlr);
@@ -1033,7 +1035,7 @@ static void test_vol_down(void)
 
 	WAIT_FOR_COND(previous_volume == 0U ||
 		      (g_volume < previous_volume && g_cb && g_write_complete));
-	printk("VCP volume downed\n");
+	LOG_INF("VCP volume downed");
 }
 
 static void test_vol_up(void)
@@ -1049,7 +1051,7 @@ static void test_vol_up(void)
 	}
 
 	/* Valid behavior */
-	printk("Upping VCP volume\n");
+	LOG_INF("Upping VCP volume");
 	g_write_complete = g_cb = false;
 
 	err = bt_vcp_vol_ctlr_vol_up(vol_ctlr);
@@ -1060,7 +1062,7 @@ static void test_vol_up(void)
 
 	WAIT_FOR_COND(previous_volume == UINT8_MAX ||
 		      (g_volume > previous_volume && g_cb && g_write_complete));
-	printk("VCP volume upped\n");
+	LOG_INF("VCP volume upped");
 }
 
 static void test_mute(void)
@@ -1076,7 +1078,7 @@ static void test_mute(void)
 	}
 
 	/* Valid behavior */
-	printk("Muting VCP\n");
+	LOG_INF("Muting VCP");
 	g_write_complete = g_cb = false;
 
 	err = bt_vcp_vol_ctlr_mute(vol_ctlr);
@@ -1086,7 +1088,7 @@ static void test_mute(void)
 	}
 
 	WAIT_FOR_COND(g_mute == expected_mute && g_cb && g_write_complete);
-	printk("VCP muted\n");
+	LOG_INF("VCP muted");
 }
 
 static void test_unmute_vol_down(void)
@@ -1103,7 +1105,7 @@ static void test_unmute_vol_down(void)
 	}
 
 	/* Valid behavior */
-	printk("Downing and unmuting VCP\n");
+	LOG_INF("Downing and unmuting VCP");
 	g_write_complete = g_cb = false;
 
 	err = bt_vcp_vol_ctlr_unmute_vol_down(vol_ctlr);
@@ -1116,7 +1118,7 @@ static void test_unmute_vol_down(void)
 		      expected_mute == g_mute &&
 		      g_cb &&
 		      g_write_complete);
-	printk("VCP volume downed and unmuted\n");
+	LOG_INF("VCP volume downed and unmuted");
 }
 
 static void test_unmute_vol_up(void)
@@ -1133,7 +1135,7 @@ static void test_unmute_vol_up(void)
 	}
 
 	/* Valid behavior */
-	printk("Upping and unmuting VCP\n");
+	LOG_INF("Upping and unmuting VCP");
 	g_write_complete = g_cb = false;
 
 	err = bt_vcp_vol_ctlr_unmute_vol_up(vol_ctlr);
@@ -1146,7 +1148,7 @@ static void test_unmute_vol_up(void)
 		      g_mute == expected_mute &&
 		      g_cb &&
 		      g_write_complete);
-	printk("VCP volume upped and unmuted\n");
+	LOG_INF("VCP volume upped and unmuted");
 }
 
 static void test_unmute(void)
@@ -1162,7 +1164,7 @@ static void test_unmute(void)
 	}
 
 	/* Valid behavior */
-	printk("Unmuting VCP\n");
+	LOG_INF("Unmuting VCP");
 	g_write_complete = g_cb = false;
 
 	err = bt_vcp_vol_ctlr_unmute(vol_ctlr);
@@ -1172,7 +1174,7 @@ static void test_unmute(void)
 	}
 
 	WAIT_FOR_COND(g_mute == expected_mute && g_cb && g_write_complete);
-	printk("VCP volume unmuted\n");
+	LOG_INF("VCP volume unmuted");
 }
 
 static void test_main(void)
@@ -1194,7 +1196,7 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Scanning successfully started\n");
+	LOG_INF("Scanning successfully started");
 
 	WAIT_FOR_FLAG(flag_connected);
 

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
@@ -16,12 +16,14 @@
 #include <zephyr/bluetooth/audio/vcp.h>
 #include <zephyr/bluetooth/audio/vocs.h>
 #include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
+
+LOG_MODULE_REGISTER(vcp_vol_rend_test);
 
 #ifdef CONFIG_BT_VCP_VOL_REND
 extern enum bst_result_t bst_result;
@@ -231,7 +233,7 @@ static void test_aics_deactivate(void)
 	}
 
 	/* Valid behavior */
-	printk("Deactivating AICS\n");
+	LOG_INF("Deactivating AICS");
 	err = bt_aics_deactivate(vcp_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not deactivate AICS (err %d)\n", err);
@@ -239,7 +241,7 @@ static void test_aics_deactivate(void)
 	}
 
 	WAIT_FOR_COND(expected_aics_active == g_aics_active);
-	printk("AICS deactivated\n");
+	LOG_INF("AICS deactivated");
 }
 
 static void test_aics_activate(void)
@@ -255,7 +257,7 @@ static void test_aics_activate(void)
 	}
 
 	/* Valid behavior */
-	printk("Activating AICS\n");
+	LOG_INF("Activating AICS");
 	err = bt_aics_activate(vcp_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not activate AICS (err %d)\n", err);
@@ -263,7 +265,7 @@ static void test_aics_activate(void)
 	}
 
 	WAIT_FOR_COND(expected_aics_active == g_aics_active);
-	printk("AICS activated\n");
+	LOG_INF("AICS activated");
 }
 
 static void test_aics_state_get(void)
@@ -278,7 +280,7 @@ static void test_aics_state_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting AICS state\n");
+	LOG_INF("Getting AICS state");
 	g_cb = false;
 
 	err = bt_aics_state_get(vcp_included.aics[0]);
@@ -288,7 +290,7 @@ static void test_aics_state_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("AICS state get\n");
+	LOG_INF("AICS state get");
 }
 
 static void aics_gain_setting_get(void)
@@ -303,7 +305,7 @@ static void aics_gain_setting_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting AICS gain setting\n");
+	LOG_INF("Getting AICS gain setting");
 	g_cb = false;
 
 	err = bt_aics_gain_setting_get(vcp_included.aics[0]);
@@ -313,7 +315,7 @@ static void aics_gain_setting_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("AICS gain setting get\n");
+	LOG_INF("AICS gain setting get");
 }
 
 static void aics_type_get(void)
@@ -329,7 +331,7 @@ static void aics_type_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting AICS input type\n");
+	LOG_INF("Getting AICS input type");
 
 	err = bt_aics_type_get(vcp_included.aics[0]);
 	if (err != 0) {
@@ -339,7 +341,7 @@ static void aics_type_get(void)
 
 	/* Expect and wait for input_type from init */
 	WAIT_FOR_COND(expected_input_type == g_aics_input_type);
-	printk("AICS input type get\n");
+	LOG_INF("AICS input type get");
 }
 
 static void aics_status_get(void)
@@ -354,7 +356,7 @@ static void aics_status_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting AICS status\n");
+	LOG_INF("Getting AICS status");
 	g_cb = false;
 
 	err = bt_aics_status_get(vcp_included.aics[0]);
@@ -364,7 +366,7 @@ static void aics_status_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("AICS status get\n");
+	LOG_INF("AICS status get");
 }
 
 static void aics_get_description(void)
@@ -379,7 +381,7 @@ static void aics_get_description(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting AICS description\n");
+	LOG_INF("Getting AICS description");
 	g_cb = false;
 
 	err = bt_aics_description_get(vcp_included.aics[0]);
@@ -389,7 +391,7 @@ static void aics_get_description(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("AICS description get\n");
+	LOG_INF("AICS description get");
 }
 
 static void test_aics_mute(void)
@@ -405,7 +407,7 @@ static void test_aics_mute(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS mute\n");
+	LOG_INF("Setting AICS mute");
 
 	err = bt_aics_mute(vcp_included.aics[0]);
 	if (err != 0) {
@@ -414,7 +416,7 @@ static void test_aics_mute(void)
 	}
 
 	WAIT_FOR_COND(expected_input_mute == g_aics_input_mute);
-	printk("AICS mute set\n");
+	LOG_INF("AICS mute set");
 }
 
 static void test_aics_unmute(void)
@@ -430,7 +432,7 @@ static void test_aics_unmute(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS unmute\n");
+	LOG_INF("Setting AICS unmute");
 
 	err = bt_aics_unmute(vcp_included.aics[0]);
 	if (err != 0) {
@@ -439,7 +441,7 @@ static void test_aics_unmute(void)
 	}
 
 	WAIT_FOR_COND(expected_input_mute == g_aics_input_mute);
-	printk("AICS unmute set\n");
+	LOG_INF("AICS unmute set");
 }
 
 static void test_aics_automatic_gain_set(void)
@@ -455,7 +457,7 @@ static void test_aics_automatic_gain_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS auto mode\n");
+	LOG_INF("Setting AICS auto mode");
 
 	err = bt_aics_automatic_gain_set(vcp_included.aics[0]);
 	if (err != 0) {
@@ -464,7 +466,7 @@ static void test_aics_automatic_gain_set(void)
 	}
 
 	WAIT_FOR_COND(expected_mode == g_aics_mode);
-	printk("AICS auto mode set\n");
+	LOG_INF("AICS auto mode set");
 }
 
 static void test_aics_manual_gain_set(void)
@@ -480,7 +482,7 @@ static void test_aics_manual_gain_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS manual mode\n");
+	LOG_INF("Setting AICS manual mode");
 
 	err = bt_aics_manual_gain_set(vcp_included.aics[0]);
 	if (err != 0) {
@@ -489,7 +491,7 @@ static void test_aics_manual_gain_set(void)
 	}
 
 	WAIT_FOR_COND(expected_mode == g_aics_mode);
-	printk("AICS manual mode set\n");
+	LOG_INF("AICS manual mode set");
 }
 
 static void test_aics_gain_set(void)
@@ -505,7 +507,7 @@ static void test_aics_gain_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS gain\n");
+	LOG_INF("Setting AICS gain");
 
 	err = bt_aics_gain_set(vcp_included.aics[0], expected_gain);
 	if (err != 0) {
@@ -514,7 +516,7 @@ static void test_aics_gain_set(void)
 	}
 
 	WAIT_FOR_COND(expected_gain == g_aics_gain);
-	printk("AICS gain set\n");
+	LOG_INF("AICS gain set");
 }
 
 static void test_aics_description_set(void)
@@ -536,7 +538,7 @@ static void test_aics_description_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting AICS Description\n");
+	LOG_INF("Setting AICS Description");
 	g_cb = false;
 
 	err = bt_aics_description_set(vcp_included.aics[0], expected_aics_desc);
@@ -547,7 +549,7 @@ static void test_aics_description_set(void)
 
 	WAIT_FOR_COND(g_cb &&
 		      strncmp(expected_aics_desc, g_aics_desc, strlen(expected_aics_desc)) == 0);
-	printk("AICS Description set\n");
+	LOG_INF("AICS Description set");
 }
 
 static void test_aics_standalone(void)
@@ -579,7 +581,7 @@ static void test_vocs_state_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting VOCS state\n");
+	LOG_INF("Getting VOCS state");
 	g_cb = false;
 
 	err = bt_vocs_state_get(vcp_included.vocs[0]);
@@ -589,7 +591,7 @@ static void test_vocs_state_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("VOCS state get\n");
+	LOG_INF("VOCS state get");
 }
 
 static void test_vocs_location_get(void)
@@ -604,7 +606,7 @@ static void test_vocs_location_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting VOCS location\n");
+	LOG_INF("Getting VOCS location");
 	g_cb = false;
 
 	err = bt_vocs_location_get(vcp_included.vocs[0]);
@@ -614,7 +616,7 @@ static void test_vocs_location_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("VOCS location get\n");
+	LOG_INF("VOCS location get");
 }
 
 static void test_vocs_description_get(void)
@@ -629,7 +631,7 @@ static void test_vocs_description_get(void)
 	}
 
 	/* Valid behavior */
-	printk("Getting VOCS description\n");
+	LOG_INF("Getting VOCS description");
 	g_cb = false;
 
 	err = bt_vocs_description_get(vcp_included.vocs[0]);
@@ -639,7 +641,7 @@ static void test_vocs_description_get(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("VOCS description get\n");
+	LOG_INF("VOCS description get");
 }
 
 static void test_vocs_location_set(void)
@@ -664,7 +666,7 @@ static void test_vocs_location_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting VOCS location\n");
+	LOG_INF("Setting VOCS location");
 
 	err = bt_vocs_location_set(vcp_included.vocs[0], expected_location);
 	if (err != 0) {
@@ -673,7 +675,7 @@ static void test_vocs_location_set(void)
 	}
 
 	WAIT_FOR_COND(expected_location == g_vocs_location);
-	printk("VOCS location set\n");
+	LOG_INF("VOCS location set");
 }
 
 static void test_vocs_state_set(void)
@@ -706,7 +708,7 @@ static void test_vocs_state_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting VOCS state\n");
+	LOG_INF("Setting VOCS state");
 
 	err = bt_vocs_state_set(vcp_included.vocs[0], expected_offset);
 	if (err != 0) {
@@ -715,7 +717,7 @@ static void test_vocs_state_set(void)
 	}
 
 	WAIT_FOR_COND(expected_offset == g_vocs_offset);
-	printk("VOCS state set\n");
+	LOG_INF("VOCS state set");
 }
 
 static void test_vocs_description_set(void)
@@ -737,7 +739,7 @@ static void test_vocs_description_set(void)
 	}
 
 	/* Valid behavior */
-	printk("Setting VOCS description\n");
+	LOG_INF("Setting VOCS description");
 	g_cb = false;
 
 	err = bt_vocs_description_set(vcp_included.vocs[0], expected_vocs_desc);
@@ -748,7 +750,7 @@ static void test_vocs_description_set(void)
 
 	WAIT_FOR_COND(g_cb &&
 		      strncmp(expected_vocs_desc, g_vocs_desc, strlen(expected_vocs_desc)) == 0);
-	printk("VOCS description set\n");
+	LOG_INF("VOCS description set");
 }
 
 static void test_vocs_standalone(void)
@@ -844,7 +846,7 @@ static void test_set_step(uint8_t volume_step)
 	}
 
 	/* Valid behavior */
-	printk("Setting VCP step\n");
+	LOG_INF("Setting VCP step");
 
 	err = bt_vcp_vol_rend_set_step(volume_step);
 	if (err != 0) {
@@ -852,14 +854,14 @@ static void test_set_step(uint8_t volume_step)
 		return;
 	}
 
-	printk("VCP step set\n");
+	LOG_INF("VCP step set");
 }
 
 static void test_get_state(void)
 {
 	int err;
 
-	printk("Getting VCP volume state\n");
+	LOG_INF("Getting VCP volume state");
 	g_cb = false;
 
 	err = bt_vcp_vol_rend_get_state();
@@ -869,14 +871,14 @@ static void test_get_state(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("VCP volume get\n");
+	LOG_INF("VCP volume get");
 }
 
 static void test_get_flags(void)
 {
 	int err;
 
-	printk("Getting VCP flags\n");
+	LOG_INF("Getting VCP flags");
 	g_cb = false;
 
 	err = bt_vcp_vol_rend_get_flags();
@@ -886,7 +888,7 @@ static void test_get_flags(void)
 	}
 
 	WAIT_FOR_COND(g_cb);
-	printk("VCP flags get\n");
+	LOG_INF("VCP flags get");
 }
 
 static void test_vol_down(uint8_t volume_step)
@@ -894,7 +896,7 @@ static void test_vol_down(uint8_t volume_step)
 	const uint8_t expected_volume = g_volume > volume_step ? g_volume - volume_step : 0;
 	int err;
 
-	printk("Downing VCP volume\n");
+	LOG_INF("Downing VCP volume");
 
 	err = bt_vcp_vol_rend_vol_down();
 	if (err != 0) {
@@ -903,7 +905,7 @@ static void test_vol_down(uint8_t volume_step)
 	}
 
 	WAIT_FOR_COND(expected_volume == g_volume);
-	printk("VCP volume downed\n");
+	LOG_INF("VCP volume downed");
 }
 
 static void test_vol_up(uint8_t volume_step)
@@ -911,7 +913,7 @@ static void test_vol_up(uint8_t volume_step)
 	const uint8_t expected_volume = MIN((uint16_t)g_volume + volume_step, UINT8_MAX);
 	int err;
 
-	printk("Upping VCP volume\n");
+	LOG_INF("Upping VCP volume");
 
 	err = bt_vcp_vol_rend_vol_up();
 	if (err != 0) {
@@ -920,7 +922,7 @@ static void test_vol_up(uint8_t volume_step)
 	}
 
 	WAIT_FOR_COND(expected_volume == g_volume);
-	printk("VCP volume upped\n");
+	LOG_INF("VCP volume upped");
 }
 
 static void test_mute(void)
@@ -928,7 +930,7 @@ static void test_mute(void)
 	const uint8_t expected_mute = BT_VCP_STATE_MUTED;
 	int err;
 
-	printk("Muting VCP\n");
+	LOG_INF("Muting VCP");
 
 	err = bt_vcp_vol_rend_mute();
 	if (err != 0) {
@@ -937,7 +939,7 @@ static void test_mute(void)
 	}
 
 	WAIT_FOR_COND(expected_mute == g_mute);
-	printk("VCP muted\n");
+	LOG_INF("VCP muted");
 }
 
 static void test_unmute_vol_down(uint8_t volume_step)
@@ -946,7 +948,7 @@ static void test_unmute_vol_down(uint8_t volume_step)
 	const uint8_t expected_mute = BT_VCP_STATE_UNMUTED;
 	int err;
 
-	printk("Downing and unmuting VCP\n");
+	LOG_INF("Downing and unmuting VCP");
 
 	err = bt_vcp_vol_rend_unmute_vol_down();
 	if (err != 0) {
@@ -955,7 +957,7 @@ static void test_unmute_vol_down(uint8_t volume_step)
 	}
 
 	WAIT_FOR_COND(expected_volume == g_volume && expected_mute == g_mute);
-	printk("VCP volume downed and unmuted\n");
+	LOG_INF("VCP volume downed and unmuted");
 }
 
 static void test_unmute_vol_up(uint8_t volume_step)
@@ -964,7 +966,7 @@ static void test_unmute_vol_up(uint8_t volume_step)
 	const uint8_t expected_mute = BT_VCP_STATE_UNMUTED;
 	int err;
 
-	printk("Upping and unmuting VCP\n");
+	LOG_INF("Upping and unmuting VCP");
 
 	err = bt_vcp_vol_rend_unmute_vol_up();
 	if (err != 0) {
@@ -973,7 +975,7 @@ static void test_unmute_vol_up(uint8_t volume_step)
 	}
 
 	WAIT_FOR_COND(expected_volume == g_volume && expected_mute == g_mute);
-	printk("VCP volume upped and unmuted\n");
+	LOG_INF("VCP volume upped and unmuted");
 }
 
 static void test_unmute(void)
@@ -981,7 +983,7 @@ static void test_unmute(void)
 	const uint8_t expected_mute = BT_VCP_STATE_UNMUTED;
 	int err;
 
-	printk("Unmuting VCP\n");
+	LOG_INF("Unmuting VCP");
 
 	err = bt_vcp_vol_rend_unmute();
 	if (err != 0) {
@@ -990,7 +992,7 @@ static void test_unmute(void)
 	}
 
 	WAIT_FOR_COND(expected_mute == g_mute);
-	printk("VCP volume unmuted\n");
+	LOG_INF("VCP volume unmuted");
 }
 
 static void test_set_vol(void)
@@ -1005,7 +1007,7 @@ static void test_set_vol(void)
 	}
 
 	WAIT_FOR_COND(expected_volume == g_volume);
-	printk("VCP volume set\n");
+	LOG_INF("VCP volume set");
 }
 
 static void test_standalone(void)
@@ -1019,12 +1021,12 @@ static void test_standalone(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	test_register();
 	test_included_get();
 
-	printk("VCP initialized\n");
+	LOG_INF("VCP initialized");
 	test_set_step(volume_step);
 	test_get_state();
 	test_get_flags();
@@ -1060,12 +1062,12 @@ static void test_main(void)
 		return;
 	}
 
-	printk("Bluetooth initialized\n");
+	LOG_INF("Bluetooth initialized");
 
 	test_register();
 	test_included_get();
 
-	printk("VCP initialized\n");
+	LOG_INF("VCP initialized");
 
 	setup_connectable_adv(&ext_adv);
 


### PR DESCRIPTION
Migrates all direct usage of `printk()` to Zephyr's logging subsystem (`<zephyr/logging/log.h>`) across the Bluetooth LE Audio BSIM tests.

- Major test progression steps (e.g., "Starting scan", "Discovering BASS") are mapped to `LOG_INF`, ensuring they remain visible by default.
- Data-heavy callbacks and frequent state dumping are mapped to `LOG_DBG` to declutter the standard test output.
- Trailing newlines originally present in `printk` strings have been stripped, as they are automatically appended by `LOG_*` macros.
- Core test layout macros like `PASS()` and `FAIL()` are kept intact.

Fixes #71302