### PR TITLE
zvfs: Implement POSIX read/write on stdio

### DIFF
--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -113,6 +113,27 @@ size_t fwrite(const void *ZRESTRICT ptr, size_t size, size_t nitems,
 	return zephyr_fwrite(ptr, size, nitems, stream);
 }
 
+int z_impl_zephyr_write_stdout(const void *buffer, int nbytes)
+{
+	const char *buf = buffer;
+
+	for (int i = 0; i < nbytes; i++) {
+		if (*(buf + i) == '\n') {
+			_stdout_hook('\r');
+		}
+		_stdout_hook(*(buf + i));
+	}
+	return nbytes;
+}
+
+#ifdef CONFIG_USERSPACE
+static inline int z_vrfy_zephyr_write_stdout(const void *buf, int nbytes)
+{
+	K_OOPS(K_SYSCALL_MEMORY_READ(buf, nbytes));
+	return z_impl_zephyr_write_stdout((const void *)buf, nbytes);
+}
+#include <zephyr/syscalls/zephyr_write_stdout_mrsh.c>
+#endif
 
 int puts(const char *s)
 {

--- a/lib/libc/picolibc/stdio.c
+++ b/lib/libc/picolibc/stdio.c
@@ -6,15 +6,23 @@
 
 #include "picolibc-hooks.h"
 
-static LIBC_DATA int (*_stdout_hook)(int);
+static int _stdout_hook_default(int c)
+{
+	ARG_UNUSED(c);
+
+	return EOF;
+}
+
+static LIBC_DATA int (*_stdout_hook)(int) = _stdout_hook_default;
 
 int z_impl_zephyr_fputc(int a, FILE *out)
 {
-	(*_stdout_hook)(a);
+	if ((out == stdout) || (out == stderr)) {
+		_stdout_hook(a);
+	}
 	return 0;
 }
 
-#ifdef CONFIG_POSIX_DEVICE_IO
 int z_impl_zephyr_write_stdout(const void *buffer, int nbytes)
 {
 	const char *buf = buffer;
@@ -27,7 +35,6 @@ int z_impl_zephyr_write_stdout(const void *buffer, int nbytes)
 	}
 	return nbytes;
 }
-#endif
 
 #ifdef CONFIG_USERSPACE
 static inline int z_vrfy_zephyr_fputc(int c, FILE *stream)
@@ -67,3 +74,12 @@ void __stdin_hook_install(unsigned char (*hook)(void))
 	__stdin.get = (int (*)(FILE *)) hook;
 	__stdin.flags |= _FDEV_SETUP_READ;
 }
+
+#ifdef CONFIG_USERSPACE
+static inline int z_vrfy_zephyr_write_stdout(const void *buf, int nbytes)
+{
+	K_OOPS(K_SYSCALL_MEMORY_READ(buf, nbytes));
+	return z_impl_zephyr_write_stdout((const void *)buf, nbytes);
+}
+#include <zephyr/syscalls/zephyr_write_stdout_mrsh.c>
+#endif

--- a/lib/os/zvfs/Kconfig
+++ b/lib/os/zvfs/Kconfig
@@ -1,5 +1,6 @@
 # Copyright (c) 2020 Tobias Svehagen
 # Copyright (c) 2023 Meta
+# Copyright (c) 2026 Antmicro
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -28,6 +29,15 @@ config ZVFS_DEFAULT_FILE_VMETHODS
 	help
 	  Provide typical file operations, which can be referenced in a struct fd_op_vtable
 	  and subsequently called by ZVFS functions.
+
+config ZVFS_STDIO_CONSOLE
+	bool "read() and write() to/from stdio use console subsystem"
+	default y
+	depends on CONSOLE_SUBSYS && UART_CONSOLE
+	depends on !(CONSOLE_GETCHAR || CONSOLE_GETLINE)
+	help
+	  Enable to use UART console whenever read() or write() is called
+	  on stdin, stdout or stderr.
 
 endif
 

--- a/lib/os/zvfs/zvfs_fdtable.c
+++ b/lib/os/zvfs/zvfs_fdtable.c
@@ -25,6 +25,10 @@
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/fs/fs.h>
+#include <zephyr/device.h>
+#include <zephyr/console/console.h>
+#include <zephyr/console/tty.h>
+#include <zephyr/drivers/uart.h>
 
 K_MEM_SLAB_DEFINE_TYPE(file_desc_slab, struct fs_file_t, ZVFS_OPEN_SIZE);
 
@@ -44,27 +48,40 @@ static const struct fd_op_vtable stdinout_fd_op_vtable;
 BUILD_ASSERT(ZVFS_OPEN_SIZE >= 3, "ZVFS_OPEN_SIZE >= 3 for CONFIG_POSIX_DEVICE_IO");
 #endif /* defined(CONFIG_POSIX_DEVICE_IO) */
 
+#if defined(CONFIG_ZVFS_STDIO_CONSOLE)
+static struct tty_serial tty;
+#endif
+
 static struct fd_entry fdtable[ZVFS_OPEN_SIZE] = {
 #if defined(CONFIG_POSIX_DEVICE_IO)
 	/*
 	 * Predefine entries for stdin/stdout/stderr.
 	 */
 	{
-		/* STDIN */
+/* STDIN */
+#if defined(CONFIG_ZVFS_STDIO_CONSOLE)
+		.obj = &tty,
+#endif
 		.vtable = &stdinout_fd_op_vtable,
 		.refcount = ATOMIC_INIT(1),
 		.lock = Z_MUTEX_INITIALIZER(fdtable[0].lock),
 		.cond = Z_CONDVAR_INITIALIZER(fdtable[0].cond),
 	},
 	{
-		/* STDOUT */
+/* STDOUT */
+#if defined(CONFIG_ZVFS_STDIO_CONSOLE)
+		.obj = &tty,
+#endif
 		.vtable = &stdinout_fd_op_vtable,
 		.refcount = ATOMIC_INIT(1),
 		.lock = Z_MUTEX_INITIALIZER(fdtable[1].lock),
 		.cond = Z_CONDVAR_INITIALIZER(fdtable[1].cond),
 	},
 	{
-		/* STDERR */
+/* STDERR */
+#if defined(CONFIG_ZVFS_STDIO_CONSOLE)
+		.obj = &tty,
+#endif
 		.vtable = &stdinout_fd_op_vtable,
 		.refcount = ATOMIC_INIT(1),
 		.lock = Z_MUTEX_INITIALIZER(fdtable[2].lock),
@@ -353,7 +370,7 @@ static ssize_t zvfs_rw(int fd, void *buf, size_t sz, bool is_write, const size_t
 		 * Seekable file types should support pread() / pwrite() and per-fd offset passing.
 		 * Otherwise, it's a bug.
 		 */
-		errno = ENOTSUP;
+		errno = ESPIPE;
 		res = -1;
 		goto unlock;
 	}
@@ -578,16 +595,64 @@ int zvfs_rename(const char *old, const char *newp)
  * fd operations for stdio/stdout/stderr
  */
 
+int z_impl_zephyr_read_stdin(char *buf, int nbytes);
 int z_impl_zephyr_write_stdout(const char *buf, int nbytes);
+
+#if defined(CONFIG_ZVFS_STDIO_CONSOLE)
+static int initialize_tty(struct tty_serial *obj)
+{
+	static bool initialized;
+	static int ret;
+
+	if (initialized) {
+		return ret;
+	}
+	ret = tty_init(obj, DEVICE_DT_GET(DT_CHOSEN(zephyr_console)));
+	initialized = true;
+	if (ret) {
+		errno = -ret;
+		ret = -1;
+		return ret;
+	}
+	return ret;
+}
+#endif
 
 static ssize_t stdinout_read_vmeth(void *obj, void *buffer, size_t count)
 {
+#if defined(CONFIG_ZVFS_STDIO_CONSOLE)
+	int ret = initialize_tty(obj);
+
+	if (ret) {
+		return ret;
+	}
+	ret = tty_read(obj, buffer, count);
+	if (ret < -1) { /* return no less than -1 as per POSIX; errno is already set */
+		return -1;
+	}
+	return ret;
+#elif defined(CONFIG_NEWLIB_LIBC)
+	return z_impl_zephyr_read_stdin(buffer, count);
+#else
 	return 0;
+#endif
 }
 
 static ssize_t stdinout_write_vmeth(void *obj, const void *buffer, size_t count)
 {
-#if defined(CONFIG_PICOLIBC) || defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_ARCMWDT_LIBC)
+#if defined(CONFIG_ZVFS_STDIO_CONSOLE)
+	int ret = initialize_tty(obj);
+
+	if (ret) {
+		return ret;
+	}
+	ret = tty_write(obj, buffer, count);
+	if (ret < -1) { /* return no less than -1 as per POSIX; errno is already set */
+		return -1;
+	}
+	return ret;
+#elif defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_NEWLIB_LIBC) ||   \
+	defined(CONFIG_ARCMWDT_LIBC)
 	return z_impl_zephyr_write_stdout(buffer, count);
 #else
 	return 0;

--- a/subsys/console/CMakeLists.txt
+++ b/subsys/console/CMakeLists.txt
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources_ifdef(CONFIG_CONSOLE_GETCHAR tty.c getchar.c)
+zephyr_sources_ifdef(CONFIG_CONSOLE_SUBSYS tty.c)
+zephyr_sources_ifdef(CONFIG_CONSOLE_GETCHAR getchar.c)
 zephyr_sources_ifdef(CONFIG_CONSOLE_GETLINE getline.c)


### PR DESCRIPTION
This PR implements more stdout hooks to allow writing to stdio using ZVFS. Likewise, it allows reading from stdin using ZVFS by utilizing the console subsystem.