### PR TITLE
dts: bindings: add nordic,nrf-micr compatible

### DIFF
--- a/dts/bindings/misc/nordic,nrf-micr.yaml
+++ b/dts/bindings/misc/nordic,nrf-micr.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nordic MICR (Module Information Configuration Registers)
+
+compatible: "nordic,nrf-micr"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true


### PR DESCRIPTION
- Binding for Nordic MICR register block.