### PR TITLE
logging: Fix use of Coresight STM logging on nrf54h20 in C++

### DIFF
--- a/drivers/debug/debug_nrf_etr.c
+++ b/drivers/debug/debug_nrf_etr.c
@@ -335,8 +335,9 @@ static void trace_point_process(struct log_frontend_stmesp_demux_trace_point *pa
 		return;
 	}
 
+	uint32_t id = (uint32_t)packet->id - CONFIG_LOG_FRONTEND_STMESP_TP_CHAN_BASE;
 	static const union cbprintf_package_hdr desc = {.desc = {.len = 3 /* hdr + fmt + id */}};
-	uint32_t tp_p[] = {(uint32_t)desc.raw, (uint32_t)tp, packet->id};
+	uint32_t tp_p[] = {(uint32_t)desc.raw, (uint32_t)tp, id};
 
 	log_output_process(&log_output, packet->timestamp, dname, sname, NULL, 0,
 			   1, (const uint8_t *)tp_p, NULL, 0, flags);

--- a/include/zephyr/logging/log_frontend_stmesp.h
+++ b/include/zephyr/logging/log_frontend_stmesp.h
@@ -109,12 +109,12 @@ TYPE_SECTION_START_EXTERN(const char *, log_stmesp_ptr);
 
 #define LOG_FRONTEND_STMESP_LOG0(_source, ...)                                                     \
 	do {                                                                                       \
-		static const char _str[] __in_section(_log_stmesp_str, static, _)                  \
+		static const char _str[] __in_section(_log_stmesp_str, static, __COUNTER__)        \
 			__used __noasan __aligned(sizeof(uint32_t)) = GET_ARG_N(1, __VA_ARGS__);   \
-		static const char *_str_ptr __in_section(_log_stmesp_ptr, static, _)               \
+		static const char *str_ptr __in_section(_log_stmesp_ptr, static, __COUNTER__)      \
 			__used __noasan = _str;                                                    \
 		uint32_t _idx =                                                                    \
-			((uintptr_t)&_str_ptr - (uintptr_t)TYPE_SECTION_START(log_stmesp_ptr)) /   \
+			((uintptr_t)&str_ptr - (uintptr_t)TYPE_SECTION_START(log_stmesp_ptr)) /    \
 			sizeof(void *);                                                            \
 		log_frontend_stmesp_log0(_source, _idx);                                           \
 	} while (0)
@@ -126,12 +126,12 @@ TYPE_SECTION_START_EXTERN(const char *, log_stmesp_ptr);
  */
 #define LOG_FRONTEND_STMESP_LOG1(_source, ...)                                                     \
 	do {                                                                                       \
-		static const char _str[] __in_section(_log_stmesp_str, static, _)                  \
+		static const char _str[] __in_section(_log_stmesp_str, static, __COUNTER__)        \
 			__used __noasan __aligned(sizeof(uint32_t)) = GET_ARG_N(1, __VA_ARGS__);   \
-		static const char *_str_ptr __in_section(_log_stmesp_ptr, static, _)               \
+		static const char *str_ptr __in_section(_log_stmesp_ptr, static, __COUNTER__)      \
 			__used __noasan = _str;                                                    \
 		uint32_t _idx =                                                                    \
-			((uintptr_t)&_str_ptr - (uintptr_t)TYPE_SECTION_START(log_stmesp_ptr)) /   \
+			((uintptr_t)&str_ptr - (uintptr_t)TYPE_SECTION_START(log_stmesp_ptr)) /    \
 			sizeof(void *);                                                            \
 		log_frontend_stmesp_log1(_source, _idx, (uintptr_t)(GET_ARG_N(2, __VA_ARGS__)));   \
 	} while (0)

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -455,7 +455,8 @@ do { \
 	COND_CODE_0(NUM_VA_ARGS_LESS_1(_, ##__VA_ARGS__), \
 		    (/* No args provided, no variable */), \
 		    (static const char _name[] \
-		     __in_section(_log_strings, static, _CONCAT(_name, _)) __used __noasan = \
+		     __in_section(_log_strings, static, _CONCAT(_name, __COUNTER__)) \
+		     __used __noasan = \
 			GET_ARG_N(1, __VA_ARGS__);))
 
 /** @brief Create variable in the dedicated memory section (if enabled).

--- a/samples/boards/nordic/coresight_stm/CMakeLists.txt
+++ b/samples/boards/nordic/coresight_stm/CMakeLists.txt
@@ -15,3 +15,8 @@ endif()
 project(nrf_coresight_stm)
 
 target_sources(app PRIVATE src/main.c)
+
+if(CONFIG_CPP)
+  # When testing for C++ force test file C++ compilation
+  set_source_files_properties(src/main.c PROPERTIES LANGUAGE CXX)
+endif()

--- a/samples/boards/nordic/coresight_stm/sample.yaml
+++ b/samples/boards/nordic/coresight_stm/sample.yaml
@@ -22,6 +22,19 @@ tests:
       - SB_CONFIG_APP_CPUPPR_RUN=y
       - SB_CONFIG_APP_CPUFLPR_RUN=y
 
+  sample.boards.nrf.coresight_stm.dict.cpp:
+    harness: pytest
+    harness_config:
+      pytest_dut_scope: session
+      pytest_root:
+        - "pytest/test_stm.py::test_sample_STM_dictionary_mode"
+    required_snippets:
+      - nordic-log-stm-dict
+    extra_args:
+      - SB_CONFIG_APP_CPUPPR_RUN=y
+      - SB_CONFIG_APP_CPUFLPR_RUN=y
+      - CONFIG_CPP=y
+
   sample.boards.nrf.coresight_stm.tpiu.dict:
     harness: console
     harness_config:
@@ -43,6 +56,19 @@ tests:
     extra_args:
       - SB_CONFIG_APP_CPUPPR_RUN=y
       - SB_CONFIG_APP_CPUFLPR_RUN=y
+
+  sample.boards.nrf.coresight_stm.cpp:
+    harness: pytest
+    harness_config:
+      pytest_dut_scope: session
+      pytest_root:
+        - "pytest/test_stm.py::test_sample_STM_decoded"
+    required_snippets:
+      - nordic-log-stm
+    extra_args:
+      - SB_CONFIG_APP_CPUPPR_RUN=y
+      - SB_CONFIG_APP_CPUFLPR_RUN=y
+      - CONFIG_CPP=y
 
   sample.boards.nrf.coresight_stm.rtt:
     harness: pytest

--- a/samples/boards/nordic/coresight_stm/src/cpp_logger.hpp
+++ b/samples/boards/nordic/coresight_stm/src/cpp_logger.hpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CPP_LOGGER_H_
+#define CPP_LOGGER_H_
+
+#ifdef __cplusplus
+
+#include <zephyr/logging/log.h>
+
+class CppLogger
+{
+public:
+	void log_test(void)
+	{
+		LOG_MODULE_DECLARE(app);
+
+		LOG_INF("test from C++ class");
+	}
+};
+
+#endif /* __cplusplus */
+
+#endif /* CPP_LOGGER_H_ */

--- a/samples/boards/nordic/coresight_stm/src/main.c
+++ b/samples/boards/nordic/coresight_stm/src/main.c
@@ -14,6 +14,10 @@
 
 LOG_MODULE_REGISTER(app);
 
+#ifdef CONFIG_CPP
+#include "cpp_logger.hpp"
+#endif
+
 #define TEST_LOG(rpt, item)                                                                        \
 	({                                                                                         \
 		uint32_t key = irq_lock();                                                         \
@@ -28,18 +32,27 @@ LOG_MODULE_REGISTER(app);
 		t;                                                                                 \
 	})
 
-static char *core_name = "unknown";
+static const char *core_name;
 
 static void get_core_name(void)
 {
-	if (strstr(CONFIG_BOARD_TARGET, "cpuapp")) {
-		core_name = "app";
-	} else if (strstr(CONFIG_BOARD_TARGET, "cpurad")) {
-		core_name = "rad";
-	} else if (strstr(CONFIG_BOARD_TARGET, "cpuppr")) {
-		core_name = "ppr";
-	} else if (strstr(CONFIG_BOARD_TARGET, "cpuflpr")) {
-		core_name = "flpr";
+	static const char app[] = "cpuapp";
+	static const char rad[] = "cpurad";
+	static const char ppr[] = "cpuppr";
+	static const char flpr[] = "cpuflpr";
+	static const char unknown[] = "unknown";
+	static const char board[] = CONFIG_BOARD_TARGET;
+
+	if ((uintptr_t)strstr(board, app) != 0) {
+		core_name = app;
+	} else if ((uintptr_t)strstr(board, rad) != 0) {
+		core_name = rad;
+	} else if ((uintptr_t)strstr(board, ppr) != 0) {
+		core_name = ppr;
+	} else if ((uintptr_t)strstr(board, flpr) != 0) {
+		core_name = flpr;
+	} else {
+		core_name = unknown;
 	}
 }
 
@@ -65,6 +78,12 @@ int main(void)
 	int load;
 
 	get_core_name();
+
+#ifdef CONFIG_CPP
+	CppLogger cpp_logger;
+
+	cpp_logger.log_test();
+#endif
 
 	if (IS_ENABLED(CONFIG_CPU_LOAD)) {
 		(void)cpu_load_get(true);


### PR DESCRIPTION
Fix compilation errors when using Coresight STM logging in C++ environment.
Extended `samples/boards/nordic/coresight_stm` to use C++ configuration for Dictionary and Standalone logging.