### PR TITLE
drivers: cache: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -47,9 +47,8 @@ void cache_data_disable(void);
  *
  * Flush the whole data cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_flush_all(void);
 
@@ -58,9 +57,8 @@ int cache_data_flush_all(void);
  *
  * Invalidate the whole data cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_invd_all(void);
 
@@ -69,9 +67,8 @@ int cache_data_invd_all(void);
  *
  * Flush and Invalidate the whole data cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_flush_and_invd_all(void);
 
@@ -90,9 +87,8 @@ int cache_data_flush_and_invd_all(void);
  * @param addr Starting address to flush.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_flush_range(void *addr, size_t size);
 
@@ -112,9 +108,8 @@ int cache_data_flush_range(void *addr, size_t size);
  * @param addr Starting address to invalidate.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_invd_range(void *addr, size_t size);
 
@@ -134,9 +129,8 @@ int cache_data_invd_range(void *addr, size_t size);
  * @param addr Starting address to flush and invalidate.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_data_flush_and_invd_range(void *addr, size_t size);
 
@@ -152,7 +146,7 @@ int cache_data_flush_and_invd_range(void *addr, size_t size);
  * defined.
  *
  * @retval size Size of the d-cache line.
- * @retval 0 If the d-cache is not enabled.
+ * @retval 0 The d-cache is not enabled.
  */
 size_t cache_data_line_size_get(void);
 
@@ -181,9 +175,8 @@ void cache_instr_disable(void);
  *
  * Flush the whole instruction cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_flush_all(void);
 
@@ -192,9 +185,8 @@ int cache_instr_flush_all(void);
  *
  * Invalidate the whole instruction cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_invd_all(void);
 
@@ -203,9 +195,8 @@ int cache_instr_invd_all(void);
  *
  * Flush and Invalidate the whole instruction cache.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_flush_and_invd_all(void);
 
@@ -224,9 +215,8 @@ int cache_instr_flush_and_invd_all(void);
  * @param addr Starting address to flush.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_flush_range(void *addr, size_t size);
 
@@ -246,9 +236,8 @@ int cache_instr_flush_range(void *addr, size_t size);
  * @param addr Starting address to invalidate.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_invd_range(void *addr, size_t size);
 
@@ -268,9 +257,8 @@ int cache_instr_invd_range(void *addr, size_t size);
  * @param addr Starting address to flush and invalidate.
  * @param size Range size.
  *
- * @retval 0 If succeeded.
- * @retval -ENOTSUP If not supported.
- * @retval -errno Negative errno for other failures.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Not supported.
  */
 int cache_instr_flush_and_invd_range(void *addr, size_t size);
 
@@ -286,7 +274,7 @@ int cache_instr_flush_and_invd_range(void *addr, size_t size);
  * defined.
  *
  * @retval size Size of the d-cache line.
- * @retval 0 If the d-cache is not enabled.
+ * @retval 0 The d-cache is not enabled.
  */
 size_t cache_instr_line_size_get(void);
 


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974