### PR TITLE
drivers: sensors: st: fix shub using 8-bit i2c_addr

### DIFF
--- a/drivers/sensor/st/iis2iclx/iis2iclx_shub.c
+++ b/drivers/sensor/st/iis2iclx/iis2iclx_shub.c
@@ -363,7 +363,7 @@ static struct iis2iclx_shub_slist {
 	{
 		/* LIS2MDL */
 		.type		= SENSOR_CHAN_MAGN_XYZ,
-		.i2c_addr       = { 0x1E },
+		.i2c_addr	= { 0x3C }, /* 8-bit address */
 		.wai_addr       = 0x4F,
 		.wai_val        = 0x40,
 		.out_data_addr  = 0x68,
@@ -377,7 +377,7 @@ static struct iis2iclx_shub_slist {
 	{
 		/* HTS221 */
 		.type		= SENSOR_CHAN_HUMIDITY,
-		.i2c_addr       = { 0x5F },
+		.i2c_addr	= { 0xBE }, /* 8-bit address */
 		.wai_addr       = 0x0F,
 		.wai_val        = 0xBC,
 		.out_data_addr  = 0x28 | HTS221_AUTOINCREMENT,
@@ -391,7 +391,7 @@ static struct iis2iclx_shub_slist {
 	{
 		/* LPS22HB */
 		.type		= SENSOR_CHAN_PRESS,
-		.i2c_addr       = { 0x5C, 0x5D },
+		.i2c_addr	= { 0xB8, 0xBA }, /* 8-bit address */
 		.wai_addr       = 0x0F,
 		.wai_val        = 0xB1,
 		.out_data_addr  = 0x28,
@@ -404,7 +404,7 @@ static struct iis2iclx_shub_slist {
 	{
 		/* LPS22HH */
 		.type		= SENSOR_CHAN_PRESS,
-		.i2c_addr       = { 0x5C, 0x5D },
+		.i2c_addr	= { 0xB8, 0xBA }, /* 8-bit address */
 		.wai_addr       = 0x0F,
 		.wai_val        = 0xB3,
 		.out_data_addr  = 0x28,

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx_shub.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx_shub.c
@@ -344,7 +344,7 @@ static struct ism330dhcx_shub_slist {
 	{
 		/* LIS2MDL */
 		.type		= SENSOR_CHAN_MAGN_XYZ,
-		.i2c_addr       = { 0x1E },
+		.i2c_addr	= { 0x3C }, /* 8-bit address */
 		.wai_addr       = 0x4F,
 		.wai_val        = 0x40,
 		.out_data_addr  = 0x68,
@@ -358,7 +358,7 @@ static struct ism330dhcx_shub_slist {
 	{
 		/* HTS221 */
 		.type		= SENSOR_CHAN_HUMIDITY,
-		.i2c_addr       = { 0x5F },
+		.i2c_addr	= { 0xBE }, /* 8-bit address */
 		.wai_addr       = 0x0F,
 		.wai_val        = 0xBC,
 		.out_data_addr  = 0x28 | HTS221_AUTOINCREMENT,
@@ -372,7 +372,7 @@ static struct ism330dhcx_shub_slist {
 	{
 		/* LPS22HB */
 		.type		= SENSOR_CHAN_PRESS,
-		.i2c_addr       = { 0x5C, 0x5D },
+		.i2c_addr	= { 0xB8, 0xBA }, /* 8-bit address */
 		.wai_addr       = 0x0F,
 		.wai_val        = 0xB1,
 		.out_data_addr  = 0x28,
@@ -385,7 +385,7 @@ static struct ism330dhcx_shub_slist {
 	{
 		/* LPS22HH */
 		.type		= SENSOR_CHAN_PRESS,
-		.i2c_addr       = { 0x5C, 0x5D },
+		.i2c_addr	= { 0xB8, 0xBA }, /* 8-bit address */
 		.wai_addr       = 0x0F,
 		.wai_val        = 0xB3,
 		.out_data_addr  = 0x28,

--- a/drivers/sensor/st/lsm6dsl/lsm6dsl_shub.c
+++ b/drivers/sensor/st/lsm6dsl/lsm6dsl_shub.c
@@ -204,7 +204,7 @@ static struct lsm6dsl_shub_sens_list {
 #ifdef CONFIG_LSM6DSL_EXT0_LIS2MDL
 	{
 		/* LIS2MDL */
-		.i2c_addr       = { 0x1E },
+		.i2c_addr	= { 0x3C }, /* 8-bit address */
 		.wai_addr       = 0x4F,
 		.wai_val        = 0x40,
 		.out_data_addr  = 0x68,
@@ -216,7 +216,7 @@ static struct lsm6dsl_shub_sens_list {
 #ifdef CONFIG_LSM6DSL_EXT0_LIS3MDL
 	{
 		/* LIS3MDL */
-		.i2c_addr       = {0x1C, 0x1E},
+		.i2c_addr	= { 0x38, 0x3C }, /* 8-bit address */
 		.wai_addr       = 0x0F,
 		.wai_val        = 0x3D,
 		.out_data_addr  = 0x28,
@@ -228,7 +228,7 @@ static struct lsm6dsl_shub_sens_list {
 #ifdef CONFIG_LSM6DSL_EXT0_LPS22HB
 	{
 		/* LPS22HB */
-		.i2c_addr       = { 0x5C, 0x5D },
+		.i2c_addr	= { 0xB8, 0xBA }, /* 8-bit address */
 		.wai_addr       = 0x0F,
 		.wai_val        = 0xB1,
 		.out_data_addr  = 0x28,

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is_shub.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is_shub.c
@@ -428,7 +428,7 @@ static struct lsm6dso16is_shub_slist {
 	{
 		/* LIS2MDL */
 		.type		= SENSOR_CHAN_MAGN_XYZ,
-		.i2c_addr	= { 0x1E },
+		.i2c_addr	= { 0x3C }, /* 8-bit address */
 		.wai_addr	= 0x4F,
 		.wai_val	= 0x40,
 		.out_data_addr  = 0x68,
@@ -442,7 +442,7 @@ static struct lsm6dso16is_shub_slist {
 	{
 		/* HTS221 */
 		.type		= SENSOR_CHAN_HUMIDITY,
-		.i2c_addr	= { 0x5F },
+		.i2c_addr	= { 0xBE }, /* 8-bit address */
 		.wai_addr	= 0x0F,
 		.wai_val	= 0xBC,
 		.out_data_addr  = 0x28 | HTS221_AUTOINCREMENT,
@@ -456,7 +456,7 @@ static struct lsm6dso16is_shub_slist {
 	{
 		/* LPS22HB */
 		.type		= SENSOR_CHAN_PRESS,
-		.i2c_addr	= { 0x5C, 0x5D },
+		.i2c_addr	= { 0xB8, 0xBA }, /* 8-bit address */
 		.wai_addr	= 0x0F,
 		.wai_val	= 0xB1,
 		.out_data_addr  = 0x28,
@@ -469,7 +469,7 @@ static struct lsm6dso16is_shub_slist {
 	{
 		/* LPS22HH */
 		.type		= SENSOR_CHAN_PRESS,
-		.i2c_addr	= { 0x5C, 0x5D },
+		.i2c_addr	= { 0xB8, 0xBA }, /* 8-bit address */
 		.wai_addr	= 0x0F,
 		.wai_val	= 0xB3,
 		.out_data_addr  = 0x28,
@@ -483,7 +483,7 @@ static struct lsm6dso16is_shub_slist {
 	{
 		/* LPS22DF */
 		.type		= SENSOR_CHAN_PRESS,
-		.i2c_addr	= { 0x5C, 0x5D },
+		.i2c_addr	= { 0xB8, 0xBA }, /* 8-bit address */
 		.wai_addr	= 0x0F,
 		.wai_val	= 0xB4,
 		.out_data_addr  = 0x28,

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_shub.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_shub.c
@@ -426,7 +426,7 @@ static struct lsm6dsv16x_shub_slist {
 	{
 		/* LIS2MDL */
 		.type		= SENSOR_CHAN_MAGN_XYZ,
-		.i2c_addr	= { 0x1E },
+		.i2c_addr	= { 0x3C }, /* 8-bit address */
 		.wai_addr	= 0x4F,
 		.wai_val	= 0x40,
 		.out_data_addr  = 0x68,
@@ -440,7 +440,7 @@ static struct lsm6dsv16x_shub_slist {
 	{
 		/* HTS221 */
 		.type		= SENSOR_CHAN_HUMIDITY,
-		.i2c_addr	= { 0x5F },
+		.i2c_addr	= { 0xBE }, /* 8-bit address */
 		.wai_addr	= 0x0F,
 		.wai_val	= 0xBC,
 		.out_data_addr  = 0x28 | HTS221_AUTOINCREMENT,
@@ -454,7 +454,7 @@ static struct lsm6dsv16x_shub_slist {
 	{
 		/* LPS22HB */
 		.type		= SENSOR_CHAN_PRESS,
-		.i2c_addr	= { 0x5C, 0x5D },
+		.i2c_addr	= { 0xB8, 0xBA }, /* 8-bit address */
 		.wai_addr	= 0x0F,
 		.wai_val	= 0xB1,
 		.out_data_addr  = 0x28,
@@ -467,7 +467,7 @@ static struct lsm6dsv16x_shub_slist {
 	{
 		/* LPS22HH */
 		.type		= SENSOR_CHAN_PRESS,
-		.i2c_addr	= { 0x5C, 0x5D },
+		.i2c_addr	= { 0xB8, 0xBA }, /* 8-bit address */
 		.wai_addr	= 0x0F,
 		.wai_val	= 0xB3,
 		.out_data_addr  = 0x28,
@@ -481,7 +481,7 @@ static struct lsm6dsv16x_shub_slist {
 	{
 		/* LPS22DF */
 		.type		= SENSOR_CHAN_PRESS,
-		.i2c_addr	= { 0x5C, 0x5D },
+		.i2c_addr	= { 0xB8, 0xBA }, /* 8-bit address */
 		.wai_addr	= 0x0F,
 		.wai_val	= 0xB4,
 		.out_data_addr  = 0x28,


### PR DESCRIPTION
Init the sensorhub targets using 8-bit i2c_addr for those drivers when their STMEMSC API requires it.

Fixes: #109784

Tested on x_nucleo_iks4a1 with following samples:

 - samples/shields/x_nucleo_iks4a1/sensorhub1
 - samples/shields/x_nucleo_iks4a1/sensorhub2