### PR TITLE
samples: sensor: grove_temperature: migrate to DEVICE_DT_GET_ANY

### DIFF
--- a/samples/sensor/grove_temperature/src/main.c
+++ b/samples/sensor/grove_temperature/src/main.c
@@ -28,10 +28,9 @@ int main(void)
 	}
 
 #ifdef CONFIG_GROVE_LCD_RGB
-	const struct device *glcd;
+	const struct device *glcd = DEVICE_DT_GET_ANY(seeed_grove_lcd_rgb);
 
-	glcd = device_get_binding(GROVE_LCD_NAME);
-	if (glcd == NULL) {
+	if (!device_is_ready(glcd)) {
 		printf("Failed to get Grove LCD\n");
 		return 0;
 	}


### PR DESCRIPTION
### Minor API modernization.

This PR updates the `grove_temperature` sample application to use the modern **Devicetree API** for hardware instantiation, specifically replacing the deprecated device_get_binding() runtime string lookup with the compile-time` DEVICE_DT_GET_ANY()` macro for the optional Grove LCD.

**Testing:**
- Relying on CI/Twister to verify the build across standard configurations.