### PR TITLE
kernel: timeout: micro-optimize elapsed() on UP

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -95,7 +95,8 @@ static int32_t elapsed(void)
 	if (this_cpu_announcing()) {
 		return 0U;
 	}
-	return sys_clock_elapsed() + announce_remaining;
+	return sys_clock_elapsed() +
+	       (IS_ENABLED(CONFIG_SMP) ? announce_remaining : 0);
 }
 
 static int32_t next_timeout(int32_t ticks_elapsed)


### PR DESCRIPTION
The `+ announce_remaining` introduced by #108540 forced `elapsed()` to push an 8-byte stack frame, as the compiler can no longer tail-call into `sys_clock_elapsed()`. On UP, `announce_remaining` is always 0 when `this_cpu_announcing()` is false, so the addition is gratuitous there.

Gate it on `CONFIG_SMP`: with `CONFIG_SMP=n` the compiler folds the addition away and the tail call is restored — restoring the pre-#108540 codegen for this hot path (it's called from `z_add_timeout()`, `sys_clock_tick_get()`, `z_get_next_timeout_expiry()`, `sys_timepoint_calc()`).