### PR TITLE
drivers: i2c: target: Put device driver API into iterable section

### DIFF
--- a/drivers/i2c/target/eeprom_target.c
+++ b/drivers/i2c/target/eeprom_target.c
@@ -253,7 +253,7 @@ static int eeprom_target_unregister(const struct device *dev)
 	return i2c_target_unregister(cfg->bus.bus, &data->config);
 }
 
-static const struct i2c_target_driver_api api_funcs = {
+static DEVICE_API(i2c_target, api_funcs) = {
 	.driver_register = eeprom_target_register,
 	.driver_unregister = eeprom_target_unregister,
 };


### PR DESCRIPTION
Use DEVICE_API() so DEVICE_API_GET(i2c_target, dev) passes its section-bounds assert.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/109753