### PR TITLE
drivers: timer: stm32: lptim: select CONFIG_RESET

### DIFF
--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -12,6 +12,7 @@ menuconfig STM32_LPTIM_TIMER
 	depends on $(dt_nodelabel_exists,stm32_lp_tick_source)
 	depends on DT_HAS_ST_STM32_LPTIM_ENABLED
 	depends on CLOCK_CONTROL && PM
+	select RESET
 	select TICKLESS_CAPABLE
 	select EXPERIMENTAL
 	help


### PR DESCRIPTION
Select CONFIG_RESET as the STM32 Low Power Timer (LPTIM) driver depends on it.

```
$ west build -b mks_canable_v20/stm32g431xx tests/lib/cpp/cxx/
...
/opt/zephyr-sdk/zephyr-sdk-1.0.1/gnu/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/14.3.0/../../../../arm-zephyr-eabi/bin/ld.bfd: drivers/timer/libdrivers__timer.a(stm32_lptim_timer.c.obj): in function `sys_clock_driver_init':
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/drivers/clock_control.h:338:(.text.sys_clock_driver_init+0x168): undefined reference to `__device_dts_ord_48'
collect2: error: ld returned 1 exit status
...
```