### PR TITLE
MAINTAINERS: nominate npitre as kernel maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3317,12 +3317,12 @@ Kernel:
   maintainers:
     - andyross
     - peter-mitsis
+    - npitre
   collaborators:
     - nashif
     - ceolin
     - dcpleung
     - cfriedt
-    - npitre
     - TaiJuWu
     - Mattemagikern
   files:


### PR DESCRIPTION
Nicolas is a very active collaborator in this area. Given that Peter is
right now the only active maintainer of that area, we need coverage and
backup for such a critical and busy area.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
