### PR TITLE
soc: espressif: add LLVM and LLD build support

### DIFF
--- a/cmake/toolchain/host/llvm/Kconfig
+++ b/cmake/toolchain/host/llvm/Kconfig
@@ -3,6 +3,7 @@
 
 choice LLVM_LINKER
 	prompt "LLVM Linker"
+	default LLVM_USE_LLD if SOC_FAMILY_ESPRESSIF_ESP32
 	default LLVM_USE_LD
 
 config LLVM_USE_LD

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -70,7 +70,11 @@ rtc_iram_len = RCT_FAST_RAM_SIZE;
 
 /* Make sure new sections have consistent alignment between input and output sections */
 #undef SECTION_DATA_PROLOGUE
+#ifndef __LLD_LINKER_CMD__
 #define SECTION_DATA_PROLOGUE(name, options, align) name options : ALIGN_WITH_INPUT
+#else
+#define SECTION_DATA_PROLOGUE(name, options, align) name options : align
+#endif
 
 #undef SECTION_PROLOGUE
 #define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
@@ -225,7 +229,11 @@ SECTIONS
   */
   .rtc.dummy :
   {
+#ifndef __LLD_LINKER_CMD__
     . = SIZEOF(.rtc.text);
+#else
+    . = MAX(., ORIGIN(rtc_data_seg) + SIZEOF(.rtc.text));
+#endif
   } GROUP_DATA_LINK_IN(rtc_data_seg, ROMABLE_REGION)
 
   /* This section located in RTC FAST Memory area.
@@ -308,6 +316,29 @@ SECTIONS
     /* Vectors go to IRAM */
     _init_start = ABSOLUTE(.);
     /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
+#ifdef __LLD_LINKER_CMD__
+    . = _init_start + 0x0;
+    KEEP(*(.WindowVectors.text));
+    . = _init_start + 0x180;
+    KEEP(*(.Level2InterruptVector.text));
+    . = _init_start + 0x1c0;
+    KEEP(*(.Level3InterruptVector.text));
+    . = _init_start + 0x200;
+    KEEP(*(.Level4InterruptVector.text));
+    . = _init_start + 0x240;
+    KEEP(*(.Level5InterruptVector.text));
+    . = _init_start + 0x280;
+    KEEP(*(.DebugExceptionVector.text));
+    . = _init_start + 0x2c0;
+    KEEP(*(.NMIExceptionVector.text));
+    . = _init_start + 0x300;
+    KEEP(*(.KernelExceptionVector.text));
+    . = _init_start + 0x340;
+    KEEP(*(.UserExceptionVector.text));
+    . = _init_start + 0x3C0;
+    KEEP(*(.DoubleExceptionVector.text));
+    . = _init_start + 0x400;
+#else
     . = 0x0;
     KEEP(*(.WindowVectors.text));
     . = 0x180;
@@ -329,6 +360,7 @@ SECTIONS
     . = 0x3C0;
     KEEP(*(.DoubleExceptionVector.text));
     . = 0x400;
+#endif
     *(.*Vector.literal)
 
     *(.UserEnter.literal);
@@ -351,6 +383,9 @@ SECTIONS
     *libarch__common.a:(.literal .text .literal.* .text.*)
     *libkernel.a:(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
+    *libatomic.a:*(.literal .text .literal.* .text.*)
+    *libclang_rt.builtins*.a:*(.literal .text .literal.* .text.*)
+    *libzephyr.a:atomic_stubs.*(.literal .text .literal.* .text.*)
     *libzephyr.a:windowspill_asm.*(.literal .text .literal.* .text.*)
     *libzephyr.a:cbprintf_complete.*(.literal .text .literal.* .text.*)
     *libzephyr.a:printk.*(.literal.printk .literal.vprintk .literal.char_out .text.printk .text.vprintk .text.char_out)
@@ -800,6 +835,11 @@ SECTIONS
     _bss_end = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
+  .dbg_thread_info : ALIGN(4)
+  {
+    KEEP(*(".dbg_thread_info"));
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
   .dram0.noinit (NOLOAD) :
   {
     . = ALIGN (4);
@@ -959,21 +999,19 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  .flash.rodata_end : ALIGN(0x10)
+    .flash.rodata_pad : ALIGN(0x10)
   {
-    /* Enforce flash segment size alignment */
     LONG(0);
-    /* This is a symbol marking the flash.rodata end, this
-     * can be used for mmu driver to maintain virtual address
-     * We don't need to include the noload rodata in this section
-     */
-    . = ALIGN(CONFIG_MMU_PAGE_SIZE);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
 
+  #include <zephyr/linker/thread-local-storage.ld>
+
+  .flash.rodata_end :
+  {
     _rodata_end = ABSOLUTE(.);
     _rodata_reserved_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
@@ -1070,6 +1108,11 @@ SECTIONS
 #include <zephyr/linker/intlist.ld>
 #endif
 
+  #if defined(CONFIG_LLVM_USE_LLD) || defined(__LLD_LINKER_CMD__)
+  SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+  SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+  SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+  #endif
 }
 
   /* --- XTENSA GLUE AND DEBUG END --- */

--- a/soc/espressif/esp32/default_appcpu.ld
+++ b/soc/espressif/esp32/default_appcpu.ld
@@ -44,7 +44,11 @@ appcpu_dram_len = APPCPU_DRAM_SIZE;
 
 /* Make sure new sections have consistent alignment between input and output sections */
 #undef SECTION_DATA_PROLOGUE
+#ifndef __LLD_LINKER_CMD__
 #define SECTION_DATA_PROLOGUE(name, options, align) name options : ALIGN_WITH_INPUT
+#else
+#define SECTION_DATA_PROLOGUE(name, options, align) name options : align
+#endif
 
 #undef SECTION_PROLOGUE
 #define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
@@ -132,6 +136,29 @@ SECTIONS
     /* Vectors go to IRAM */
     _init_start = ABSOLUTE(.);
     /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
+#ifdef __LLD_LINKER_CMD__
+    . = _init_start + 0x0;
+    KEEP(*(.WindowVectors.text));
+    . = _init_start + 0x180;
+    KEEP(*(.Level2InterruptVector.text));
+    . = _init_start + 0x1c0;
+    KEEP(*(.Level3InterruptVector.text));
+    . = _init_start + 0x200;
+    KEEP(*(.Level4InterruptVector.text));
+    . = _init_start + 0x240;
+    KEEP(*(.Level5InterruptVector.text));
+    . = _init_start + 0x280;
+    KEEP(*(.DebugExceptionVector.text));
+    . = _init_start + 0x2c0;
+    KEEP(*(.NMIExceptionVector.text));
+    . = _init_start + 0x300;
+    KEEP(*(.KernelExceptionVector.text));
+    . = _init_start + 0x340;
+    KEEP(*(.UserExceptionVector.text));
+    . = _init_start + 0x3C0;
+    KEEP(*(.DoubleExceptionVector.text));
+    . = _init_start + 0x400;
+#else
     . = 0x0;
     KEEP(*(.WindowVectors.text));
     . = 0x180;
@@ -153,6 +180,7 @@ SECTIONS
     . = 0x3C0;
     KEEP(*(.DoubleExceptionVector.text));
     . = 0x400;
+#endif
     *(.*Vector.literal)
 
     *(.UserEnter.literal);
@@ -386,7 +414,6 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.

--- a/soc/espressif/esp32/mcuboot.ld
+++ b/soc/espressif/esp32/mcuboot.ld
@@ -86,6 +86,29 @@ SECTIONS
     /* Vectors go to IRAM */
     _init_start = ABSOLUTE(.);
     /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
+#ifdef __LLD_LINKER_CMD__
+    . = _init_start + 0x0;
+    KEEP(*(.WindowVectors.text));
+    . = _init_start + 0x180;
+    KEEP(*(.Level2InterruptVector.text));
+    . = _init_start + 0x1c0;
+    KEEP(*(.Level3InterruptVector.text));
+    . = _init_start + 0x200;
+    KEEP(*(.Level4InterruptVector.text));
+    . = _init_start + 0x240;
+    KEEP(*(.Level5InterruptVector.text));
+    . = _init_start + 0x280;
+    KEEP(*(.DebugExceptionVector.text));
+    . = _init_start + 0x2c0;
+    KEEP(*(.NMIExceptionVector.text));
+    . = _init_start + 0x300;
+    KEEP(*(.KernelExceptionVector.text));
+    . = _init_start + 0x340;
+    KEEP(*(.UserExceptionVector.text));
+    . = _init_start + 0x3C0;
+    KEEP(*(.DoubleExceptionVector.text));
+    . = _init_start + 0x400;
+#else
     . = 0x0;
     KEEP(*(.WindowVectors.text));
     . = 0x180;
@@ -107,6 +130,7 @@ SECTIONS
     . = 0x3C0;
     KEEP(*(.DoubleExceptionVector.text));
     . = 0x400;
+#endif
     _invalid_pc_placeholder = ABSOLUTE(.);
     *(.*Vector.literal)
 

--- a/soc/espressif/esp32c2/default.ld
+++ b/soc/espressif/esp32c2/default.ld
@@ -49,7 +49,11 @@ user_dram_seg_len = user_idram_size;
 
 /* Make sure new sections have consistent alignment between input and output sections */
 #undef SECTION_DATA_PROLOGUE
+#ifndef __LLD_LINKER_CMD__
 #define SECTION_DATA_PROLOGUE(name, options, align) name options : ALIGN_WITH_INPUT
+#else
+#define SECTION_DATA_PROLOGUE(name, options, align) name options : align
+#endif
 
 #undef SECTION_PROLOGUE
 #define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
@@ -215,6 +219,9 @@ SECTIONS
     *libkernel.a:(.literal .text .literal.* .text.*)
     *libzephyr.a:atomic_c.*(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
+    *libatomic.a:*(.literal .text .literal.* .text.*)
+    *libclang_rt.builtins*.a:*(.literal .text .literal.* .text.*)
+    *libzephyr.a:atomic_stubs.*(.literal .text .literal.* .text.*)
     *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
     *libdrivers__timer.a:esp32c2_sys_timer.*(.literal .text .literal.* .text.*)
@@ -644,6 +651,11 @@ SECTIONS
     _bss_end = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
+  .dbg_thread_info : ALIGN(4)
+  {
+    KEEP(*(".dbg_thread_info"));
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
   /* Provide total SRAM usage, including IRAM and DRAM */
   _image_ram_start = _iram_start - IRAM_DRAM_OFFSET;
   #include <zephyr/linker/ram-end.ld>
@@ -795,15 +807,19 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  .flash.rodata_end : ALIGN(0x10)
+    .flash.rodata_pad : ALIGN(0x10)
   {
-    /* Enforce flash segment size alignment */
     LONG(0);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+
+  #include <zephyr/linker/thread-local-storage.ld>
+
+  .flash.rodata_end :
+  {
     _rodata_reserved_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
@@ -822,4 +838,10 @@ SECTIONS
     KEEP(*(.riscv.attributes))
     KEEP(*(.gnu.attributes))
     }
+
+  #if defined(CONFIG_LLVM_USE_LLD) || defined(__LLD_LINKER_CMD__)
+  SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+  SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+  SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+  #endif
 }

--- a/soc/espressif/esp32c2/mcuboot.ld
+++ b/soc/espressif/esp32c2/mcuboot.ld
@@ -216,7 +216,6 @@ SECTIONS
   #include <snippets-sections.ld>
 
   #include <zephyr/linker/cplusplus-rom.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
   #include <snippets-ram-sections.ld>

--- a/soc/espressif/esp32c2/vectors.S
+++ b/soc/espressif/esp32c2/vectors.S
@@ -23,7 +23,7 @@ GTEXT(_isr_wrapper)
 	 */
 
 	.global  _vector_table
-	.section .exception_vectors.text
+	.section .exception_vectors.text, "ax"
 	.balign   0x100
 	.type     _vector_table, @function
 

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -53,7 +53,11 @@ rtc_iram_len = RCT_FAST_RAM_SIZE;
 
 /* Make sure new sections have consistent alignment between input and output sections */
 #undef SECTION_DATA_PROLOGUE
+#ifndef __LLD_LINKER_CMD__
 #define SECTION_DATA_PROLOGUE(name, options, align) name options : ALIGN_WITH_INPUT
+#else
+#define SECTION_DATA_PROLOGUE(name, options, align) name options : align
+#endif
 
 #undef SECTION_PROLOGUE
 #define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
@@ -308,11 +312,14 @@ SECTIONS
     *libzephyr.a:hw_init.*(.literal .text .literal.* .text.*)
     *libzephyr.a:soc_random.*(.literal .text .literal.* .text.*)
 
-    *libarch__riscv__core.a:(.literal .text .literal.* .text.*)
-    *libarch__common.a:(.literal .text .literal.* .text.*)
-    *libkernel.a:(.literal .text .literal.* .text.*)
+    *libarch__riscv__core.a:*(.literal .text .literal.* .text.*)
+    *libarch__common.a:*(.literal .text .literal.* .text.*)
+    *libkernel.a:*(.literal .text .literal.* .text.*)
     *libzephyr.a:atomic_c.*(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
+    *libatomic.a:*(.literal .text .literal.* .text.*)
+    *libclang_rt.builtins*.a:*(.literal .text .literal.* .text.*)
+    *libzephyr.a:atomic_stubs.*(.literal .text .literal.* .text.*)
     *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
     *libdrivers__timer.a:esp32c3_sys_timer.*(.literal .text .literal.* .text.*)
@@ -328,9 +335,9 @@ SECTIONS
     *libzephyr.a:periph_ctrl.*(.literal .text .literal.* .text.*)
     *libzephyr.a:regi2c_ctrl.*(.literal .text .literal.* .text.*)
     *libzephyr.a:sar_periph_ctrl_common.*(.literal .text .literal.* .text.*)
-    *libgcov.a:(.literal .text .literal.* .text.*)
-    *libphy.a:( .phyiram .phyiram.*)
-    *librtc.a:(.literal .text .literal.* .text.*)
+    *libgcov.a:*(.literal .text .literal.* .text.*)
+    *libphy.a:*( .phyiram .phyiram.*)
+    *librtc.a:*(.literal .text .literal.* .text.*)
 
     /* [mapping:hal] */
     *libzephyr.a:efuse_hal.*(.literal .text .literal.* .text.*)
@@ -415,9 +422,9 @@ SECTIONS
     *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
 
 #if defined(CONFIG_ESP32_WIFI_IRAM_OPT)
-    *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiextrairam .wifiextrairam.*)
-    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiextrairam .wifiextrairam.*)
-    *libcoexist.a:(.wifi_slp_iram  .wifi_slp_iram.* .coexiram .coexiram.* .coexsleepiram .coexsleepiram.*)
+    *libnet80211.a:*( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiextrairam .wifiextrairam.*)
+    *libpp.a:*( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiextrairam .wifiextrairam.*)
+    *libcoexist.a:*(.wifi_slp_iram  .wifi_slp_iram.* .coexiram .coexiram.* .coexsleepiram .coexsleepiram.*)
 
     /* [mapping:esp_wifi] */
     *(.literal.wifi_clock_enable_wrapper .text.wifi_clock_enable_wrapper)
@@ -430,8 +437,8 @@ SECTIONS
 #endif /* CONFIG_ESP32_WIFI_IRAM_OPT */
 
 #if defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
-    *libnet80211.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
-    *libpp.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
+    *libnet80211.a:*( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
+    *libpp.a:*( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
 #endif /* CONFIG_ESP32_WIFI_RX_IRAM_OPT */
 
     . = ALIGN(4) + 16;
@@ -631,7 +638,7 @@ SECTIONS
     *(.rodata.esp_restart_noos)
     *(.rodata.esp_system_reset_modules_on_exit)
 
-    *libphy.a:(.rodata .rodata.* .srodata .srodata.*)
+    *libphy.a:*(.rodata .rodata.* .srodata .srodata.*)
 
     . = ALIGN(4);
     #include <snippets-rwdata.ld>
@@ -642,7 +649,7 @@ SECTIONS
     . = ALIGN(4);
 
     _btdm_data_start = ABSOLUTE(.);
-    *libbtdm_app.a:(.data .data.*)
+    *libbtdm_app.a:*(.data .data.*)
     . = ALIGN(4);
     _btdm_data_end = ABSOLUTE(.);
 
@@ -716,7 +723,7 @@ SECTIONS
 
     /*  bluetooth library requires this symbol to be defined */
     _btdm_bss_start = ABSOLUTE(.);
-    *libbtdm_app.a:(.bss .bss.* COMMON)
+    *libbtdm_app.a:*(.bss .bss.* COMMON)
     . = ALIGN (4);
     _btdm_bss_end = ABSOLUTE(.);
 
@@ -737,6 +744,11 @@ SECTIONS
     . = ALIGN (16);
     __bss_end = ABSOLUTE(.);
     _bss_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
+  .dbg_thread_info : ALIGN(4)
+  {
+    KEEP(*(".dbg_thread_info"));
   } GROUP_LINK_IN(RAMABLE_REGION)
 
   /* Provide total SRAM usage, including IRAM and DRAM */
@@ -769,14 +781,14 @@ SECTIONS
     __rom_region_start = ABSOLUTE(.);
 
 #if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
-    *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiextrairam .wifiextrairam.*)
-    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiextrairam .wifiextrairam.*)
-    *libcoexist.a:(.wifi_slp_iram  .wifi_slp_iram.* .coexiram .coexiram.* .coexsleepiram .coexsleepiram.*)
+    *libnet80211.a:*( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiextrairam .wifiextrairam.*)
+    *libpp.a:*( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiextrairam .wifiextrairam.*)
+    *libcoexist.a:*(.wifi_slp_iram  .wifi_slp_iram.* .coexiram .coexiram.* .coexsleepiram .coexsleepiram.*)
 #endif /* CONFIG_ESP32_WIFI_IRAM_OPT */
 
 #if !defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
-    *libnet80211.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
-    *libpp.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
+    *libnet80211.a:*( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
+    *libpp.a:*( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
 #endif /* CONFIG_ESP32_WIFI_RX_IRAM_OPT */
 
     *(.literal .text .literal.* .text.*)
@@ -832,6 +844,8 @@ SECTIONS
 
   .flash.rodata : ALIGN(0x10)
   {
+    /* Enforce flash segment size alignment */
+    LONG(0);
     _rodata_reserved_start = ABSOLUTE(.);
     _image_rodata_start = ABSOLUTE(.);
 
@@ -890,15 +904,19 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  .flash.rodata_end : ALIGN(0x10)
+    .flash.rodata_pad : ALIGN(0x10)
   {
-    /* Enforce flash segment size alignment */
     LONG(0);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+
+  #include <zephyr/linker/thread-local-storage.ld>
+
+  .flash.rodata_end :
+  {
     _rodata_reserved_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
@@ -917,4 +935,10 @@ SECTIONS
     KEEP(*(.riscv.attributes))
     KEEP(*(.gnu.attributes))
     }
+
+  #if defined(CONFIG_LLVM_USE_LLD) || defined(__LLD_LINKER_CMD__)
+  SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+  SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+  SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+  #endif
 }

--- a/soc/espressif/esp32c3/mcuboot.ld
+++ b/soc/espressif/esp32c3/mcuboot.ld
@@ -216,7 +216,6 @@ SECTIONS
   #include <snippets-sections.ld>
 
   #include <zephyr/linker/cplusplus-rom.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
   #include <snippets-ram-sections.ld>

--- a/soc/espressif/esp32c3/vectors.S
+++ b/soc/espressif/esp32c3/vectors.S
@@ -23,7 +23,7 @@ GTEXT(_isr_wrapper)
 	 */
 
 	.global  _vector_table
-	.section .exception_vectors.text
+	.section .exception_vectors.text, "ax"
 	.balign   0x100
 	.type     _vector_table, @function
 

--- a/soc/espressif/esp32c5/default.ld
+++ b/soc/espressif/esp32c5/default.ld
@@ -63,7 +63,11 @@ user_sram_size = (user_sram_end - user_sram_org);
 
 /* Make sure new sections have consistent alignment between input and output sections */
 #undef SECTION_DATA_PROLOGUE
+#ifndef __LLD_LINKER_CMD__
 #define SECTION_DATA_PROLOGUE(name, options, align) name options : ALIGN_WITH_INPUT
+#else
+#define SECTION_DATA_PROLOGUE(name, options, align) name options : align
+#endif
 
 #undef SECTION_PROLOGUE
 #define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
@@ -342,6 +346,9 @@ SECTIONS
     *libarch__common.a:(.literal .text .literal.* .text.*)
     *libkernel.a:(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
+    *libatomic.a:*(.literal .text .literal.* .text.*)
+    *libclang_rt.builtins*.a:*(.literal .text .literal.* .text.*)
+    *libzephyr.a:atomic_stubs.*(.literal .text .literal.* .text.*)
     *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
     *libdrivers__timer.a:esp32_sys_timer.*(.literal .text .literal.* .text.*)
@@ -839,6 +846,11 @@ SECTIONS
     _bss_end = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
+  .dbg_thread_info : ALIGN(4)
+  {
+    KEEP(*(".dbg_thread_info"));
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
   /* Provide total SRAM usage, including IRAM and DRAM */
   _image_ram_start = _iram_start;
 
@@ -928,18 +940,13 @@ SECTIONS
     . = ALIGN(CACHE_ALIGN);
   } GROUP_LINK_IN(ROMABLE_REGION)
 
-  /* Move drom0 after .text region to allow proper memory mapping. */
-  .flash_rodata_dummy (NOLOAD) :
-  {
-    . += ALIGN(_instruction_reserved_end - _instruction_reserved_start, CACHE_ALIGN);
-  } GROUP_LINK_IN(RODATA_REGION)
-
   /* Symbols used during the application memory mapping */
   _image_drom_start = LOADADDR(.flash.rodata);
   _image_drom_size = _image_rodata_end -  _image_rodata_start;
   _image_drom_vaddr = ADDR(.flash.rodata);
 
-  .flash.rodata : ALIGN(0x10)
+  .flash.rodata _instruction_reserved_end : ALIGN(0x10)
+
   {
     _rodata_reserved_start = ABSOLUTE(.);
     _image_rodata_start = ABSOLUTE(.);
@@ -1002,15 +1009,19 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
   #include <snippets-rom-sections.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  .flash.rodata_end : ALIGN(0x10)
+    .flash.rodata_pad : ALIGN(0x10)
   {
-    /* Enforce flash segment size alignment */
     LONG(0);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+
+  #include <zephyr/linker/thread-local-storage.ld>
+
+  .flash.rodata_end :
+  {
     _rodata_reserved_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
@@ -1091,4 +1102,10 @@ SECTIONS
     KEEP(*(.riscv.attributes))
     KEEP(*(.gnu.attributes))
     }
+
+  #if defined(CONFIG_LLVM_USE_LLD) || defined(__LLD_LINKER_CMD__)
+  SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+  SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+  SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+  #endif
 }

--- a/soc/espressif/esp32c5/mcuboot.ld
+++ b/soc/espressif/esp32c5/mcuboot.ld
@@ -215,7 +215,6 @@ SECTIONS
   #include <snippets-sections.ld>
 
   #include <zephyr/linker/cplusplus-rom.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
   #include <snippets-ram-sections.ld>

--- a/soc/espressif/esp32c5/vectors.S
+++ b/soc/espressif/esp32c5/vectors.S
@@ -18,7 +18,7 @@ GTEXT(_isr_wrapper)
  * Must be aligned to 64 bytes (mtvec[31:6] << 6).
  */
 	.global  _vector_table
-	.section .exception_vectors.text
+	.section .exception_vectors.text, "ax"
 	.balign   0x40
 	.type     _vector_table, @function
 

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -60,7 +60,11 @@ user_sram_size = (user_sram_end - user_sram_org);
 
 /* Make sure new sections have consistent alignment between input and output sections */
 #undef SECTION_DATA_PROLOGUE
+#ifndef __LLD_LINKER_CMD__
 #define SECTION_DATA_PROLOGUE(name, options, align) name options : ALIGN_WITH_INPUT
+#else
+#define SECTION_DATA_PROLOGUE(name, options, align) name options : align
+#endif
 
 #undef SECTION_PROLOGUE
 #define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
@@ -325,6 +329,9 @@ SECTIONS
     *libarch__common.a:(.literal .text .literal.* .text.*)
     *libkernel.a:(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
+    *libatomic.a:*(.literal .text .literal.* .text.*)
+    *libclang_rt.builtins*.a:*(.literal .text .literal.* .text.*)
+    *libzephyr.a:atomic_stubs.*(.literal .text .literal.* .text.*)
     *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
     *libdrivers__timer.a:esp32_sys_timer.*(.literal .text .literal.* .text.*)
@@ -794,6 +801,11 @@ SECTIONS
     _bss_end = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
+  .dbg_thread_info : ALIGN(4)
+  {
+    KEEP(*(".dbg_thread_info"));
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
   /* Provide total SRAM usage, including IRAM and DRAM */
   _image_ram_start = _iram_start;
 
@@ -949,15 +961,19 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
   #include <snippets-rom-sections.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  .flash.rodata_end : ALIGN(0x10)
+    .flash.rodata_pad : ALIGN(0x10)
   {
-    /* Enforce flash segment size alignment */
     LONG(0);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+
+  #include <zephyr/linker/thread-local-storage.ld>
+
+  .flash.rodata_end :
+  {
     _rodata_reserved_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
@@ -976,4 +992,10 @@ SECTIONS
     KEEP(*(.riscv.attributes))
     KEEP(*(.gnu.attributes))
     }
+
+  #if defined(CONFIG_LLVM_USE_LLD) || defined(__LLD_LINKER_CMD__)
+  SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+  SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+  SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+  #endif
 }

--- a/soc/espressif/esp32c6/mcuboot.ld
+++ b/soc/espressif/esp32c6/mcuboot.ld
@@ -216,7 +216,6 @@ SECTIONS
   #include <snippets-sections.ld>
 
   #include <zephyr/linker/cplusplus-rom.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
   #include <snippets-ram-sections.ld>

--- a/soc/espressif/esp32c6/vectors.S
+++ b/soc/espressif/esp32c6/vectors.S
@@ -23,7 +23,7 @@ GTEXT(_isr_wrapper)
 	 */
 
 	.global  _vector_table
-	.section .exception_vectors.text
+	.section .exception_vectors.text, "ax"
 	.balign   0x100
 	.type     _vector_table, @function
 

--- a/soc/espressif/esp32h2/default.ld
+++ b/soc/espressif/esp32h2/default.ld
@@ -44,7 +44,11 @@ user_sram_size = (user_sram_end - user_sram_org);
 
 /* Make sure new sections have consistent alignment between input and output sections */
 #undef SECTION_DATA_PROLOGUE
+#ifndef __LLD_LINKER_CMD__
 #define SECTION_DATA_PROLOGUE(name, options, align) name options : ALIGN_WITH_INPUT
+#else
+#define SECTION_DATA_PROLOGUE(name, options, align) name options : align
+#endif
 
 #undef SECTION_PROLOGUE
 #define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
@@ -320,6 +324,9 @@ SECTIONS
     *libarch__common.a:(.literal .text .literal.* .text.*)
     *libkernel.a:(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
+    *libatomic.a:*(.literal .text .literal.* .text.*)
+    *libclang_rt.builtins*.a:*(.literal .text .literal.* .text.*)
+    *libzephyr.a:atomic_stubs.*(.literal .text .literal.* .text.*)
     *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
     *libdrivers__timer.a:esp32h2_sys_timer.*(.literal .text .literal.* .text.*)
@@ -747,6 +754,11 @@ SECTIONS
     _bss_end = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
+  .dbg_thread_info : ALIGN(4)
+  {
+    KEEP(*(".dbg_thread_info"));
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
   /* Provide total SRAM usage, including IRAM and DRAM */
   _image_ram_start = _iram_start;
   #include <zephyr/linker/ram-end.ld>
@@ -882,15 +894,19 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  .flash.rodata_end : ALIGN(0x10)
+    .flash.rodata_pad : ALIGN(0x10)
   {
-    /* Enforce flash segment size alignment */
     LONG(0);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+
+  #include <zephyr/linker/thread-local-storage.ld>
+
+  .flash.rodata_end :
+  {
     _rodata_reserved_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
@@ -909,4 +925,10 @@ SECTIONS
     KEEP(*(.riscv.attributes))
     KEEP(*(.gnu.attributes))
     }
+
+  #if defined(CONFIG_LLVM_USE_LLD) || defined(__LLD_LINKER_CMD__)
+  SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+  SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+  SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+  #endif
 }

--- a/soc/espressif/esp32h2/mcuboot.ld
+++ b/soc/espressif/esp32h2/mcuboot.ld
@@ -216,7 +216,6 @@ SECTIONS
   #include <snippets-sections.ld>
 
   #include <zephyr/linker/cplusplus-rom.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
   #include <snippets-ram-sections.ld>

--- a/soc/espressif/esp32h2/vectors.S
+++ b/soc/espressif/esp32h2/vectors.S
@@ -23,7 +23,7 @@ GTEXT(_isr_wrapper)
 	 */
 
 	.global  _vector_table
-	.section .exception_vectors.text
+	.section .exception_vectors.text, "ax"
 	.balign   0x100
 	.type     _vector_table, @function
 

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -68,7 +68,11 @@ rtc_iram_len = RCT_FAST_RAM_SIZE;
 
 /* Make sure new sections have consistent alignment between input and output sections */
 #undef SECTION_DATA_PROLOGUE
+#ifndef __LLD_LINKER_CMD__
 #define SECTION_DATA_PROLOGUE(name, options, align) name options : ALIGN_WITH_INPUT
+#else
+#define SECTION_DATA_PROLOGUE(name, options, align) name options : align
+#endif
 
 #undef SECTION_PROLOGUE
 #define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
@@ -222,7 +226,11 @@ SECTIONS
   */
   .rtc.dummy :
   {
+#ifndef __LLD_LINKER_CMD__
     . = SIZEOF(.rtc.text);
+#else
+    . = MAX(., ORIGIN(rtc_data_seg) + SIZEOF(.rtc.text));
+#endif
   } GROUP_DATA_LINK_IN(rtc_data_seg, ROMABLE_REGION)
 
   /* This section located in RTC FAST Memory area.
@@ -307,6 +315,29 @@ SECTIONS
     /* Vectors go to IRAM */
     _init_start = ABSOLUTE(.);
     /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
+#ifdef __LLD_LINKER_CMD__
+    . = _init_start + 0x0;
+    KEEP(*(.WindowVectors.text));
+    . = _init_start + 0x180;
+    KEEP(*(.Level2InterruptVector.text));
+    . = _init_start + 0x1c0;
+    KEEP(*(.Level3InterruptVector.text));
+    . = _init_start + 0x200;
+    KEEP(*(.Level4InterruptVector.text));
+    . = _init_start + 0x240;
+    KEEP(*(.Level5InterruptVector.text));
+    . = _init_start + 0x280;
+    KEEP(*(.DebugExceptionVector.text));
+    . = _init_start + 0x2c0;
+    KEEP(*(.NMIExceptionVector.text));
+    . = _init_start + 0x300;
+    KEEP(*(.KernelExceptionVector.text));
+    . = _init_start + 0x340;
+    KEEP(*(.UserExceptionVector.text));
+    . = _init_start + 0x3C0;
+    KEEP(*(.DoubleExceptionVector.text));
+    . = _init_start + 0x400;
+#else
     . = 0x0;
     KEEP(*(.WindowVectors.text));
     . = 0x180;
@@ -328,6 +359,7 @@ SECTIONS
     . = 0x3C0;
     KEEP(*(.DoubleExceptionVector.text));
     . = 0x400;
+#endif
     *(.*Vector.literal)
 
     *(.UserEnter.literal);
@@ -352,6 +384,9 @@ SECTIONS
     *libkernel.a:(.literal .text .literal.* .text.*)
     *libzephyr.a:atomic_c.*(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
+    *libatomic.a:*(.literal .text .literal.* .text.*)
+    *libclang_rt.builtins*.a:*(.literal .text .literal.* .text.*)
+    *libzephyr.a:atomic_stubs.*(.literal .text .literal.* .text.*)
     *libzephyr.a:windowspill_asm.*(.literal .text .literal.* .text.*)
     *libzephyr.a:cbprintf_packaged.*(.literal .text .literal.* .text.*)
     *libzephyr.a:cbprintf_complete.*(.literal .text .literal.* .text.*)
@@ -572,7 +607,11 @@ SECTIONS
     /* This section is required to skip .iram0.text area because iram0_0_seg and
      * dram0_0_seg reflect the same address space on different buses.
      */
+#ifndef __LLD_LINKER_CMD__
     . = ORIGIN(dram0_0_seg) + MAX(_iram_end, user_iram_org) - user_iram_org;
+#else
+    . = MAX(., ORIGIN(dram0_0_seg) + MAX(_iram_end, user_iram_org) - user_iram_org);
+#endif
     . = ALIGN(4) + 16;
   } GROUP_LINK_IN(RAMABLE_REGION)
 
@@ -803,6 +842,11 @@ SECTIONS
     _bss_end = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
+  .dbg_thread_info : ALIGN(4)
+  {
+    KEEP(*(".dbg_thread_info"));
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
 #ifdef CONFIG_ESP_SPIRAM
   /* This section holds .ext_ram.bss data, and will be put in PSRAM */
   .ext_ram (NOLOAD):
@@ -992,21 +1036,23 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-net.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  .flash.rodata_end : ALIGN(0x10)
+    .flash.rodata_pad : ALIGN(0x10)
   {
-    /* Enforce flash segment size alignment */
     LONG(0);
-    . = ALIGN(CACHE_ALIGN);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+
+  #include <zephyr/linker/thread-local-storage.ld>
+
+  .flash.rodata_end :
+  {
     _rodata_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);
     _rodata_reserved_end = ABSOLUTE(.);
     __rodata_region_end = ABSOLUTE(.);
-
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
 
   /* --- END OF .rodata --- */
@@ -1052,6 +1098,12 @@ SECTIONS
     KEEP (*(.xt.profile_files))
     KEEP (*(.gnu.linkonce.xt.profile_files.*))
   }
+
+  #if defined(CONFIG_LLVM_USE_LLD) || defined(__LLD_LINKER_CMD__)
+  SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+  SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+  SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+  #endif
 }
 
   /* --- XTENSA GLUE AND DEBUG END --- */

--- a/soc/espressif/esp32s2/mcuboot.ld
+++ b/soc/espressif/esp32s2/mcuboot.ld
@@ -80,6 +80,29 @@ SECTIONS
     /* Vectors go to IRAM */
     _init_start = ABSOLUTE(.);
     /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
+#ifdef __LLD_LINKER_CMD__
+    . = _init_start + 0x0;
+    KEEP(*(.WindowVectors.text));
+    . = _init_start + 0x180;
+    KEEP(*(.Level2InterruptVector.text));
+    . = _init_start + 0x1c0;
+    KEEP(*(.Level3InterruptVector.text));
+    . = _init_start + 0x200;
+    KEEP(*(.Level4InterruptVector.text));
+    . = _init_start + 0x240;
+    KEEP(*(.Level5InterruptVector.text));
+    . = _init_start + 0x280;
+    KEEP(*(.DebugExceptionVector.text));
+    . = _init_start + 0x2c0;
+    KEEP(*(.NMIExceptionVector.text));
+    . = _init_start + 0x300;
+    KEEP(*(.KernelExceptionVector.text));
+    . = _init_start + 0x340;
+    KEEP(*(.UserExceptionVector.text));
+    . = _init_start + 0x3C0;
+    KEEP(*(.DoubleExceptionVector.text));
+    . = _init_start + 0x400;
+#else
     . = 0x0;
     KEEP(*(.WindowVectors.text));
     . = 0x180;
@@ -101,6 +124,7 @@ SECTIONS
     . = 0x3C0;
     KEEP(*(.DoubleExceptionVector.text));
     . = 0x400;
+#endif
     _invalid_pc_placeholder = ABSOLUTE(.);
     *(.*Vector.literal)
 

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -66,7 +66,11 @@ rtc_slow_len = RCT_SLOW_RAM_SIZE;
 
 /* Make sure new sections have consistent alignment between input and output sections */
 #undef SECTION_DATA_PROLOGUE
+#ifndef __LLD_LINKER_CMD__
 #define SECTION_DATA_PROLOGUE(name, options, align) name options : ALIGN_WITH_INPUT
+#else
+#define SECTION_DATA_PROLOGUE(name, options, align) name options : align
+#endif
 
 #undef SECTION_PROLOGUE
 #define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
@@ -317,6 +321,29 @@ SECTIONS
     /* Vectors go to IRAM */
     _init_start = ABSOLUTE(.);
     /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
+#ifdef __LLD_LINKER_CMD__
+    . = _init_start + 0x0;
+    KEEP(*(.WindowVectors.text));
+    . = _init_start + 0x180;
+    KEEP(*(.Level2InterruptVector.text));
+    . = _init_start + 0x1c0;
+    KEEP(*(.Level3InterruptVector.text));
+    . = _init_start + 0x200;
+    KEEP(*(.Level4InterruptVector.text));
+    . = _init_start + 0x240;
+    KEEP(*(.Level5InterruptVector.text));
+    . = _init_start + 0x280;
+    KEEP(*(.DebugExceptionVector.text));
+    . = _init_start + 0x2c0;
+    KEEP(*(.NMIExceptionVector.text));
+    . = _init_start + 0x300;
+    KEEP(*(.KernelExceptionVector.text));
+    . = _init_start + 0x340;
+    KEEP(*(.UserExceptionVector.text));
+    . = _init_start + 0x3C0;
+    KEEP(*(.DoubleExceptionVector.text));
+    . = _init_start + 0x400;
+#else
     . = 0x0;
     KEEP(*(.WindowVectors.text));
     . = 0x180;
@@ -338,6 +365,7 @@ SECTIONS
     . = 0x3C0;
     KEEP(*(.DoubleExceptionVector.text));
     . = 0x400;
+#endif
     _invalid_pc_placeholder = ABSOLUTE(.);
     *(.*Vector.literal)
 
@@ -362,6 +390,9 @@ SECTIONS
     *libarch__common.a:(.literal .text .literal.* .text.*)
     *libkernel.a:(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
+    *libatomic.a:*(.literal .text .literal.* .text.*)
+    *libclang_rt.builtins*.a:*(.literal .text .literal.* .text.*)
+    *libzephyr.a:atomic_stubs.*(.literal .text .literal.* .text.*)
     *libzephyr.a:cbprintf_packaged.*(.literal .text .literal.* .text.*)
     *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
     *libzephyr.a:windowspill_asm.*(.literal .text .literal.* .text.*)
@@ -860,6 +891,11 @@ SECTIONS
     __bss_end = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
+  .dbg_thread_info : ALIGN(4)
+  {
+    KEEP(*(".dbg_thread_info"));
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
   /* Provide total SRAM usage, including IRAM and DRAM */
   _image_ram_start = _init_start - IRAM_DRAM_OFFSET;
   #include <zephyr/linker/ram-end.ld>
@@ -998,15 +1034,19 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  .flash.rodata_end : ALIGN(0x10)
+    .flash.rodata_pad : ALIGN(0x10)
   {
-    /* Enforce flash segment size alignment */
     LONG(0);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+
+  #include <zephyr/linker/thread-local-storage.ld>
+
+  .flash.rodata_end :
+  {
     _rodata_reserved_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
@@ -1114,6 +1154,11 @@ SECTIONS
     KEEP (*(.gnu.linkonce.xt.profile_files.*))
   }
 
+  #if defined(CONFIG_LLVM_USE_LLD) || defined(__LLD_LINKER_CMD__)
+  SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+  SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+  SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+  #endif
 }
 
   /* --- XTENSA GLUE AND DEBUG END --- */

--- a/soc/espressif/esp32s3/default_appcpu.ld
+++ b/soc/espressif/esp32s3/default_appcpu.ld
@@ -52,7 +52,11 @@ appcpu_drom_len = APPCPU_ROM_SIZE;
 
 /* Make sure new sections have consistent alignment between input and output sections */
 #undef SECTION_DATA_PROLOGUE
+#ifndef __LLD_LINKER_CMD__
 #define SECTION_DATA_PROLOGUE(name, options, align) name options : ALIGN_WITH_INPUT
+#else
+#define SECTION_DATA_PROLOGUE(name, options, align) name options : align
+#endif
 
 #undef SECTION_PROLOGUE
 #define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
@@ -173,6 +177,29 @@ SECTIONS
     /* Vectors go to IRAM */
     _init_start = ABSOLUTE(.);
     /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
+#ifdef __LLD_LINKER_CMD__
+    . = _init_start + 0x0;
+    KEEP(*(.WindowVectors.text));
+    . = _init_start + 0x180;
+    KEEP(*(.Level2InterruptVector.text));
+    . = _init_start + 0x1c0;
+    KEEP(*(.Level3InterruptVector.text));
+    . = _init_start + 0x200;
+    KEEP(*(.Level4InterruptVector.text));
+    . = _init_start + 0x240;
+    KEEP(*(.Level5InterruptVector.text));
+    . = _init_start + 0x280;
+    KEEP(*(.DebugExceptionVector.text));
+    . = _init_start + 0x2c0;
+    KEEP(*(.NMIExceptionVector.text));
+    . = _init_start + 0x300;
+    KEEP(*(.KernelExceptionVector.text));
+    . = _init_start + 0x340;
+    KEEP(*(.UserExceptionVector.text));
+    . = _init_start + 0x3C0;
+    KEEP(*(.DoubleExceptionVector.text));
+    . = _init_start + 0x400;
+#else
     . = 0x0;
     KEEP(*(.WindowVectors.text));
     . = 0x180;
@@ -194,6 +221,7 @@ SECTIONS
     . = 0x3C0;
     KEEP(*(.DoubleExceptionVector.text));
     . = 0x400;
+#endif
     _invalid_pc_placeholder = ABSOLUTE(.);
     *(.*Vector.literal)
 
@@ -370,7 +398,11 @@ SECTIONS
 
   .dram0.dummy (NOLOAD):
   {
+#ifndef __LLD_LINKER_CMD__
     . = ORIGIN(dram0_1_seg) + (MAX(_iram_end, _init_start) - _init_start);
+#else
+    . = MAX(., ORIGIN(dram0_1_seg) + (MAX(_iram_end, _init_start) - _init_start));
+#endif
     . = ALIGN(16);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
@@ -732,14 +764,19 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
   #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  .flash.rodata_end : ALIGN(16)
+    .flash.rodata_pad : ALIGN(0x10)
   {
-    . = ALIGN(16);
+    LONG(0);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+
+  #include <zephyr/linker/thread-local-storage.ld>
+
+  .flash.rodata_end :
+  {
     _rodata_reserved_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)

--- a/soc/espressif/esp32s3/mcuboot.ld
+++ b/soc/espressif/esp32s3/mcuboot.ld
@@ -89,6 +89,29 @@ SECTIONS
     /* Vectors go to IRAM */
     _init_start = ABSOLUTE(.);
     /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
+#ifdef __LLD_LINKER_CMD__
+    . = _init_start + 0x0;
+    KEEP(*(.WindowVectors.text));
+    . = _init_start + 0x180;
+    KEEP(*(.Level2InterruptVector.text));
+    . = _init_start + 0x1c0;
+    KEEP(*(.Level3InterruptVector.text));
+    . = _init_start + 0x200;
+    KEEP(*(.Level4InterruptVector.text));
+    . = _init_start + 0x240;
+    KEEP(*(.Level5InterruptVector.text));
+    . = _init_start + 0x280;
+    KEEP(*(.DebugExceptionVector.text));
+    . = _init_start + 0x2c0;
+    KEEP(*(.NMIExceptionVector.text));
+    . = _init_start + 0x300;
+    KEEP(*(.KernelExceptionVector.text));
+    . = _init_start + 0x340;
+    KEEP(*(.UserExceptionVector.text));
+    . = _init_start + 0x3C0;
+    KEEP(*(.DoubleExceptionVector.text));
+    . = _init_start + 0x400;
+#else
     . = 0x0;
     KEEP(*(.WindowVectors.text));
     . = 0x180;
@@ -110,6 +133,7 @@ SECTIONS
     . = 0x3C0;
     KEEP(*(.DoubleExceptionVector.text));
     . = 0x400;
+#endif
     _invalid_pc_placeholder = ABSOLUTE(.);
     *(.*Vector.literal)
 

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: e317fb14bf61a772161b3c2913451b96e751d6dc
+      revision: pull/567/head
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
> [!IMPORTANT]
> **BLOCKED BY**: This PR is blocked by the corresponding HAL support changes in the `hal_espressif` repository: [hal_espressif PR](https://github.com/zephyrproject-rtos/hal_espressif/pull/567).
> The build requires those HAL changes to be merged or present in the module tree to compile successfully under LLVM/Clang.

### Description
This PR enables compiling and linking all Espressif SoC targets (`esp32`, `esp32c2`, `esp32c3`, `esp32c5`, `esp32c6`, `esp32h2`, `esp32s2`, `esp32s3`) out-of-the-box using the LLVM/Clang compiler and the LLD linker.

Each change addresses strict constraints enforced by the LLD linker or LLVM integrated assembler compared to the GNU toolchain:

1. **`_instruction_reserved_end` mapping**:
   - *Problem*: GNU-ld allows creating an empty dummy `.flash_rodata_dummy (NOLOAD)` section and advancing the Location Counter (`. += ALIGN(...)`) inside it to map the DROM correctly. LLD entirely discards empty `NOLOAD` sections, breaking the memory layout.
   - *Fix*: Removed `.flash_rodata_dummy` and instead directly mapped the start of the `.flash.rodata` section to `_instruction_reserved_end` (`.flash.rodata _instruction_reserved_end : ALIGN(0x10)`).

2. **`LONG(0)` extraction (`.flash.rodata_pad`)**:
   - *Problem*: GNU-ld handles `LONG(0)` alignment padding inside `NOLOAD` or `.dram0.dummy` sections without side effects. LLD strictly interprets `LONG()` directives as allocated data, erroneously creating a Write-Allocate (WA) segment. `esptool` chokes on WA segments during `.bin` image generation.
   - *Fix*: Extracted the `LONG(0)` padding into a new, dedicated `.flash.rodata_pad` section in all `default.ld`, `default_appcpu.ld`, and `mcuboot.ld` scripts.

3. **`SECTION_DATA_PROLOGUE` redefinition**:
   - *Problem*: Espressif linker scripts use the `ALIGN_WITH_INPUT` keyword for output section alignments. LLD does not support `ALIGN_WITH_INPUT`.
   - *Fix*: Redefined `SECTION_DATA_PROLOGUE` under `#ifdef __LLD_LINKER_CMD__` to simply enforce `align` instead of using the GNU-ld specific keyword.

4. **Exception Vector Absolute Offsets (`vectors.S` & linker scripts)**:
   - *Problem*: LLD processes section grouping and alignments differently, causing exception vector routines to misalign.
   - *Fix*: Added explicit absolute offsets (`. = _init_start + 0x180; KEEP(...)`) for all interrupt vectors (`WindowVectors`, `Level2InterruptVector`, etc.) inside the linker scripts when compiled with LLD. Also fixed assembler syntax in `vectors.S` to conform to Clang's stricter parser.

5. **`MAX(., ORIGIN + SIZEOF)` in `.dram0.dummy` & `.rtc.dummy`**:
   - *Problem*: GNU-ld allows advancing the Location Counter relative to its current position even in `NOLOAD` sections. LLD requires a stricter bounds definition for these placeholder regions.
   - *Fix*: Replaced `. = ORIGIN(...) + ...` with `MAX(., ORIGIN(...) + ...)` to prevent negative pointer evaluation under LLD's multi-pass evaluation.

6. **Compiler-RT Library Mapping**:
   - *Problem*: `libclang_rt.builtins.a`, `libatomic.a`, and `atomic_stubs` were not explicitly mapped.
   - *Fix*: Added these libraries to the `.literal` and `.text` rules to ensure LLVM compiler intrinsics are correctly mapped to IROM/DROM.

7. **`.dbg_thread_info` alignment**:
   - *Problem*: Debugging thread info sections were being placed without strict boundaries.
   - *Fix*: Moved `.dbg_thread_info` into its own `ALIGN(4)` group linked to `RAMABLE_REGION` to satisfy LLD's RAM alignment requirements.

8. **Orphan Sections Error**:
   - *Problem*: When `CONFIG_LINKER_ORPHAN_SECTION_ERROR=y` is active, LLD emits errors for unhandled symbol table sections.
   - *Fix*: Explicitly mapped `.symtab`, `.strtab`, and `.shstrtab` via `SECTION_PROLOGUE` if LLD is used.

### Test Matrix & Verification
- **Platforms tested**: All ESP32-* targets
- **Toolchains**:
  - Zephyr SDK Clang / LLD (`zephyr/llvm`)
  - Host Clang/LLD versions 19 through 22 (`host/llvm`)
