### PR TITLE
soc: nordic: opt-in deprecated platform symbols

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -48,9 +48,9 @@ Boards
   :kconfig:option:`CONFIG_SOC_SERIES_NRF54L` and
   :kconfig:option:`CONFIG_SOC_SERIES_NRF71` checks. Both symbols are kept
   as deprecated stubs that default to ``y`` when the corresponding SoC
-  series is selected, so existing ``CONFIG_NRF_PLATFORM_*=y`` lines and
-  ``depends on NRF_PLATFORM_*`` clauses keep building with a Kconfig
-  deprecation warning. Out-of-tree Kconfig, CMake and code using these
+  series is selected and :kconfig:option:`CONFIG_NRF_PLATFORM_DEPRECATED_SYMBOLS` is enabled,
+  so existing ``CONFIG_NRF_PLATFORM_*=y`` lines and ``depends on NRF_PLATFORM_*`` clauses keep
+  building with a Kconfig deprecation warning. Out-of-tree Kconfig, CMake and code using these
   symbols should be updated:
 
   * The ``CONFIG_NRF_PLATFORM_HALTIUM`` with

--- a/soc/nordic/Kconfig
+++ b/soc/nordic/Kconfig
@@ -252,9 +252,13 @@ config NRF_CUSTOM_ON_ENTER_CPU_IDLE_HOOK
 # Backward-compatibility aliases for symbols removed during the Haltium / Lumos
 # Kconfig cleanup. Slated for removal in a future release.
 
+config NRF_PLATFORM_DEPRECATED_SYMBOLS
+	bool "Generate the deprecated HALTIUM/LUMOS symbols for downstream compatibility"
+
 config NRF_PLATFORM_HALTIUM
 	bool "[DEPRECATED] Replaced by SOC_SERIES_NRF54H / SOC_SERIES_NRF92"
 	default y if SOC_SERIES_NRF54H || SOC_SERIES_NRF92
+	depends on NRF_PLATFORM_DEPRECATED_SYMBOLS
 	select DEPRECATED
 	help
 	  This option has been removed. Use SOC_SERIES_NRF54H or SOC_SERIES_NRF92
@@ -264,6 +268,7 @@ config NRF_PLATFORM_HALTIUM
 config NRF_PLATFORM_LUMOS
 	bool "[DEPRECATED] Replaced by SOC_SERIES_NRF54L / SOC_SERIES_NRF71"
 	default y if SOC_SERIES_NRF54L || SOC_SERIES_NRF71
+	depends on NRF_PLATFORM_DEPRECATED_SYMBOLS
 	select DEPRECATED
 	help
 	  This option has been removed. Use SOC_SERIES_NRF54L or SOC_SERIES_NRF71


### PR DESCRIPTION
Force users to explicitly opt-in to the deprecated platform symbols, instead of enabling `DEPRECATED` symbols by default for all nRF54, nRF71, and nRF92 builds.

Downstream libraries that actually need the deprecated symbols can opt-in by default on behalf of their applications with
```
configdefault NRF_PLATFORM_DEPRECATED_SYMBOLS
     default y
```

Fixes #109802.