### PR TITLE
drivers: interrupt_controller: riscv: Fix incorrect bitmask usage in intc_clic

### DIFF
--- a/drivers/interrupt_controller/intc_clic.c
+++ b/drivers/interrupt_controller/intc_clic.c
@@ -212,7 +212,7 @@ void riscv_clic_irq_priority_set(uint32_t irq, uint32_t pri, uint32_t flags)
 #endif
 
 	/* Set the IRQ operates in machine mode, non-vectoring and the trigger type. */
-	union CLICINTATTR clicattr = {.b = {.mode = 0x3, .shv = 0x0, .trg = flags & BIT_MASK(3)}};
+	union CLICINTATTR clicattr = {.b = {.mode = 0x3, .shv = 0x0, .trg = flags & BIT_MASK(2)}};
 
 #ifdef CONFIG_LEGACY_CLIC_MEMORYMAP_ACCESS
 	write_clic8(dev, CLIC_INTATTR(irq), clicattr.w);


### PR DESCRIPTION
Update drivers/interrupt_controller/intc_clic.c to use BIT_MASK(2) rather than BIT_MASK(3) in "riscv_clic_irq_priority_set". The .trg attribute of the CLICINTATTR that is initialized in this function is 2 bits while the current mask is 3 bits. To ensure only 2 bits are used, we need to correct the mask.
- Note: BIT_MASK(3) produces the mask ((1 << 3) - 1) = 111, which seems like an off-by-one error when creating the mask

Currently no side effects / issues are observed. This is a preventative change.

<img width="486" height="210" alt="image" src="https://github.com/user-attachments/assets/0a873d86-7ce8-433b-8747-83b89cb28c7a" />

<img width="713" height="70" alt="image" src="https://github.com/user-attachments/assets/7cc15287-a0c2-4b75-9735-9f37adc489fb" />
