### PR TITLE
drivers: crc: nxp: disable on variants without HAL support

### DIFF
--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
@@ -36,7 +36,6 @@
 		zephyr,console = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
 		zephyr,code-partition = &slot0_partition;
-		zephyr,crc = &crc;
 	};
 
 	leds {
@@ -233,8 +232,4 @@ zephyr_udc0: &usb {
 			reg = <0x00038000 DT_SIZE_K(32)>;
 		};
 	};
-};
-
-&crc {
-	status = "okay";
 };

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu1.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu1.dts
@@ -28,7 +28,6 @@
 		zephyr,sram = &sram3;
 		zephyr,console = &flexcomm19_lpuart19;
 		zephyr,shell-uart = &flexcomm19_lpuart19;
-		zephyr,crc = &crc;
 	};
 
 	leds {
@@ -139,9 +138,5 @@
 
 &sema420 {
 	domain-id = <5>;
-	status = "okay";
-};
-
-&crc {
 	status = "okay";
 };

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1221,6 +1221,12 @@
 		num-locks = <64>;
 		status = "disabled";
 	};
+
+	crc: crc@151000 {
+		compatible = "nxp,crc";
+		reg = <0x151000 0x1000>;
+		status = "disabled";
+	};
 };
 
 &xspi0 {

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
@@ -214,12 +214,6 @@
 		num-locks = <64>;
 		status = "disabled";
 	};
-
-	crc: crc@151000 {
-		compatible = "nxp,crc";
-		reg = <0x151000 0x1000>;
-		status = "disabled";
-	};
 };
 
 &systick {

--- a/dts/arm/nxp/mcx/nxp_mcxc444.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxc444.dtsi
@@ -18,3 +18,6 @@
 &flash0 {
 	reg = <0 DT_SIZE_K(256)>;
 };
+
+/* MCXC444 HAL does not expose CRC peripheral support. */
+/delete-node/ &crc;


### PR DESCRIPTION
Commit 454fabb1556b added nxp,crc devicetree nodes to shared dtsi files, but the NXP HAL does not expose CRC_Type for every variant that includes those files, breaking the build on MCXC444 and on MIMXRT798S cm33_core1.

Move the crc node from nxp_rt7xx_common.dtsi into
nxp_rt7xx_cm33_cpu0.dtsi so it only reaches the core that has the peripheral, and /delete-node/ &crc; in nxp_mcxc444.dtsi. Drop the stale zephyr,crc chosen and &crc overrides from those board DTS files.

Verified with twister tests/drivers/build_all -M all: the two failing targets build clean, and frdm_mcxc242 and cm33_cpu0 still keep CONFIG_CRC_DRIVER_NXP=y.

Fix #109805 