### PR TITLE
cmake: modules: fix invalid character escape on WEST_TOPDIR

### DIFF
--- a/cmake/modules/west.cmake
+++ b/cmake/modules/west.cmake
@@ -98,4 +98,8 @@ if(WEST_VERSION)
       set(WEST WEST-NOTFOUND CACHE INTERNAL "West")
     endif()
   endif()
+
+  if(WEST_TOPDIR)
+    file(TO_CMAKE_PATH "${WEST_TOPDIR}" WEST_TOPDIR)
+  endif()
 endif()


### PR DESCRIPTION
Modified west.cmake to fix invalid character escape on WEST_TOPDIR in windows environment.

This PR is to fix below CMake Error in windows development environment:
```
CMake Error at C:/Program Files/CMake/share/cmake-3.23/Modules/CheckCCompilerFlag.cmake:40 (cmake_check_compiler_flag):
  Syntax error in cmake code at

    C:/Program Files/CMake/share/cmake-3.23/Modules/CheckCCompilerFlag.cmake:40

  when parsing string

    -fmacro-prefix-map=C:\Zephyr_rtos=WEST_TOPDIR

  Invalid character escape '\Z'.
Call Stack (most recent call first):
  C:/Zephyr_rtos/zephyr/cmake/modules/extensions.cmake:2467 (check_c_compiler_flag)
  C:/Zephyr_rtos/zephyr/cmake/modules/extensions.cmake:1245 (check_compiler_flag)
  C:/Zephyr_rtos/zephyr/cmake/modules/extensions.cmake:2506 (zephyr_check_compiler_flag)
  C:/Zephyr_rtos/zephyr/cmake/modules/extensions.cmake:2482 (target_cc_option_fallback)
  C:/Zephyr_rtos/zephyr/cmake/modules/extensions.cmake:155 (target_cc_option)
  C:/Zephyr_rtos/zephyr/CMakeLists.txt:637 (zephyr_cc_option)

```