### PR TITLE
Add DAC driver support for microchip pic32cm jh01 family

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro-pinctrl.dtsi
@@ -53,4 +53,10 @@
 				 <PA5F_TC5_WO1>;
 		};
 	};
+
+	dac_default: dac_default {
+		group1 {
+			pinmux = <PA2B_DAC_VOUT>;
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
@@ -158,6 +158,12 @@
 			gclkperiph-src = "gclk1";
 			gclkperiph-en = <0>;
 		};
+
+		dac {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_DAC>;
+			gclkperiph-src = "gclk1";
+			gclkperiph-en = <0>;
+		};
 	};
 };
 
@@ -229,5 +235,11 @@
 	compatible = "microchip,tc-g1-counter";
 	max-bit-width = <32>;
 	prescaler = <8>;
+	status = "okay";
+};
+
+&dac {
+	pinctrl-0 = <&dac_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
@@ -13,6 +13,7 @@ supported:
   - adc
   - clock_control
   - counter
+  - dac
   - dma
   - gpio
   - i2c

--- a/drivers/dac/CMakeLists.txt
+++ b/drivers/dac/CMakeLists.txt
@@ -25,6 +25,7 @@ zephyr_library_sources_ifdef(CONFIG_DAC_INFINEON_AUTANALOG dac_infineon_autanalo
 zephyr_library_sources_ifdef(CONFIG_DAC_LTC166X dac_ltc166x.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_MAX22017 dac_max22017.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_MCHP_G1 dac_mchp_g1.c)
+zephyr_library_sources_ifdef(CONFIG_DAC_MCHP_G2 dac_mchp_g2.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_MCP4725 dac_mcp4725.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_MCP4728 dac_mcp4728.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_MCUX_DAC dac_mcux_dac.c)

--- a/drivers/dac/Kconfig.mchp
+++ b/drivers/dac/Kconfig.mchp
@@ -35,3 +35,11 @@ config DAC_MCHP_G1_OVERSAMPLING_RATIO
 	  Enable Oversampling Ratio support for G1 DAC
 
 endif # DAC_MCHP_G1
+
+config DAC_MCHP_G2
+	bool "Microchip G2 DAC Driver"
+	depends on DT_HAS_MICROCHIP_DAC_G2_ENABLED
+	default y
+	select PINCTRL
+	help
+	  Enable support for the Microchip DAC driver on G2 DAC peripherals.

--- a/drivers/dac/dac_mchp_g2.c
+++ b/drivers/dac/dac_mchp_g2.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/dac.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/mchp_clock_control.h>
+#include <soc.h>
+
+#define DT_DRV_COMPAT microchip_dac_g2
+LOG_MODULE_REGISTER(dac_mchp_g2, CONFIG_DAC_LOG_LEVEL);
+
+#define DAC_RESOLUTION      10
+#define DAC_10BIT_DATA_MASK (0x03FFU)
+#define TIMEOUT_VALUE_US    1000
+#define DELAY_US            2
+
+struct dac_mchp_clock {
+	const struct device *clock_dev;
+	clock_control_subsys_t mclk_sys;
+	clock_control_subsys_t gclk_sys;
+};
+
+struct dac_mchp_dev_config {
+	dac_registers_t *regs;
+	uint8_t refsel;
+	bool external_pin_en;
+	bool run_in_standby;
+	bool volt_pump_disable;
+	uint8_t max_channels;
+	const struct pinctrl_dev_config *pcfg;
+	struct dac_mchp_clock dac_clock;
+};
+
+static inline void dac_wait_sync(dac_registers_t *dac_reg, uint32_t sync_flag)
+{
+	if (WAIT_FOR(((dac_reg->DAC_SYNCBUSY & sync_flag) == 0U), TIMEOUT_VALUE_US,
+		     k_busy_wait(DELAY_US)) == false) {
+		LOG_ERR("Timeout waiting for DAC_SYNCBUSY bits to clear");
+	}
+}
+
+static int dac_mchp_channel_setup(const struct device *dev,
+				  const struct dac_channel_cfg *channel_cfg)
+{
+	const struct dac_mchp_dev_config *dev_cfg = dev->config;
+	dac_registers_t *dac_reg = dev_cfg->regs;
+
+	if ((channel_cfg->resolution != DAC_RESOLUTION) || (channel_cfg->buffered) ||
+	    (channel_cfg->internal)) {
+		LOG_ERR("Unsupported configuration!");
+		return -ENOTSUP;
+	}
+
+	/* Channel ID validity */
+	if (channel_cfg->channel_id >= dev_cfg->max_channels) {
+		LOG_ERR("Invalid Channel!");
+		return -EINVAL;
+	}
+
+	/* Enable the DAC */
+	dac_reg->DAC_CTRLA |= DAC_CTRLA_ENABLE_Msk;
+	dac_wait_sync(dac_reg, DAC_SYNCBUSY_ENABLE_Msk);
+
+	/* Wait for ready state */
+	if (WAIT_FOR(((dac_reg->DAC_STATUS & DAC_STATUS_READY_Msk) == DAC_STATUS_READY_Msk),
+		     TIMEOUT_VALUE_US, k_busy_wait(DELAY_US)) == false) {
+		LOG_ERR("Timeout waiting for DAC_STATUS_READY (DAC_STATUS_READY_Msk=0x%x)",
+			DAC_STATUS_READY_Msk);
+		return -ETIMEDOUT;
+	}
+
+	return 0;
+}
+
+static int dac_mchp_write_value(const struct device *dev, uint8_t channel, uint32_t value)
+{
+	/* DAC consists of Single Channel */
+	ARG_UNUSED(channel);
+
+	const struct dac_mchp_dev_config *dev_cfg = dev->config;
+
+	dev_cfg->regs->DAC_DATA = (uint16_t)(DAC_10BIT_DATA_MASK & DAC_DATA_DATA(value));
+	dac_wait_sync(dev_cfg->regs, DAC_SYNCBUSY_DATA_Msk);
+
+	return 0;
+}
+
+static int dac_mchp_init(const struct device *dev)
+{
+	const struct dac_mchp_dev_config *dev_cfg = dev->config;
+	dac_registers_t *dac_reg = dev_cfg->regs;
+	uint8_t regval;
+	int ret;
+
+	/* Enable GCLK */
+	ret = clock_control_on(dev_cfg->dac_clock.clock_dev, dev_cfg->dac_clock.gclk_sys);
+	if ((ret != 0) && (ret != -EALREADY)) {
+		LOG_ERR("Failed to enable the GCLK for DAC: %d", ret);
+		return ret;
+	}
+
+	/* Enable MCLK */
+	ret = clock_control_on(dev_cfg->dac_clock.clock_dev, dev_cfg->dac_clock.mclk_sys);
+	if ((ret != 0) && (ret != -EALREADY)) {
+		LOG_ERR("Failed to enable the MCLK for DAC: %d", ret);
+		return ret;
+	}
+
+	pinctrl_apply_state(dev_cfg->pcfg, PINCTRL_STATE_DEFAULT);
+
+	/* DAC Reset */
+	dac_reg->DAC_CTRLA = DAC_CTRLA_SWRST_Msk;
+	dac_wait_sync(dac_reg, DAC_SYNCBUSY_SWRST_Msk);
+
+	regval = dac_reg->DAC_CTRLB & ~DAC_CTRLB_REFSEL_Msk;
+
+	/* Config DAC External pin */
+	regval = (dev_cfg->external_pin_en) ? (regval | DAC_CTRLB_EOEN_Msk) : regval;
+
+	/* Disable DAC Voltage Pump */
+	regval = (dev_cfg->volt_pump_disable) ? (regval | DAC_CTRLB_VPD_Msk) : regval;
+
+	/* DAC Reference voltage selection */
+	dac_reg->DAC_CTRLB = regval | DAC_CTRLB_REFSEL(dev_cfg->refsel);
+
+	/* Enable DAC RUN IN STANDBY Mode */
+	if (dev_cfg->run_in_standby) {
+		dac_reg->DAC_CTRLA |= DAC_CTRLA_RUNSTDBY_Msk;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(dac, dac_mchp_api) = {.channel_setup = dac_mchp_channel_setup,
+					.write_value = dac_mchp_write_value};
+
+/* clang-format off */
+#define DAC_MCHP_CONFIG_DEFN(n)                                                                    \
+	static const struct dac_mchp_dev_config dac_mchp_config_##n = {                            \
+		.regs = (dac_registers_t *)DT_INST_REG_ADDR(n),                                    \
+		.refsel = DT_ENUM_IDX(DT_DRV_INST(n), refsel),                                     \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
+		.external_pin_en = DT_INST_PROP(n, external_pin_en),                               \
+		.run_in_standby = DT_INST_PROP(n, run_in_standby),                                 \
+		.volt_pump_disable = DT_INST_PROP(n, volt_pump_disable),                           \
+		.max_channels = DT_INST_PROP(n, max_channels),                                     \
+		.dac_clock.clock_dev = DEVICE_DT_GET(DT_NODELABEL(clock)),                         \
+		.dac_clock.mclk_sys = (void *)(DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, subsystem)),   \
+		.dac_clock.gclk_sys = (void *)(DT_INST_CLOCKS_CELL_BY_NAME(n, gclk, subsystem)),   \
+	}
+/* clang-format on */
+
+#define DAC_MCHP_DEVICE_INIT(n)                                                                    \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+	DAC_MCHP_CONFIG_DEFN(n);                                                                   \
+	DEVICE_DT_INST_DEFINE(n, dac_mchp_init, NULL, NULL, &dac_mchp_config_##n, POST_KERNEL,     \
+			      CONFIG_DAC_INIT_PRIORITY, &dac_mchp_api);
+
+DT_INST_FOREACH_STATUS_OKAY(DAC_MCHP_DEVICE_INIT)

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_2532_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_2532_jh.dtsi
@@ -100,5 +100,18 @@
 			channels = <2>;
 			status = "disabled";
 		};
+
+		dac: dac@42005000 {
+			compatible = "microchip,dac-g2";
+			reg = <0x42005000 0x15>;
+			interrupts = <28 0>;
+			interrupt-names = "source-0-1";
+			#io-channel-cells = <1>;
+			external-pin-en = <1>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_DAC>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_DAC>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_5164_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_5164_jh.dtsi
@@ -100,5 +100,18 @@
 			channels = <2>;
 			status = "disabled";
 		};
+
+		dac: dac@42005000 {
+			compatible = "microchip,dac-g2";
+			reg = <0x42005000 0x15>;
+			interrupts = <28 0>;
+			interrupt-names = "source-0-1";
+			#io-channel-cells = <1>;
+			external-pin-en = <1>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_DAC>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_DAC>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
 	};
 };

--- a/dts/bindings/dac/microchip,dac-g2.yaml
+++ b/dts/bindings/dac/microchip,dac-g2.yaml
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+title: Microchip G2 DAC
+
+description: |
+  Microchip G2 DAC peripherals.
+
+  Group G2 DAC includes the following hardware peripherals:
+    - module name="DAC" id="U2214" version="2.1.0"
+
+compatible: "microchip,dac-g2"
+
+include:
+  - name: dac-controller.yaml
+  - name: pinctrl-device.yaml
+
+properties:
+  reg:
+    required: true
+
+  clocks:
+    required: true
+
+  clock-names:
+    required: true
+
+  "#io-channel-cells":
+    type: int
+    required: true
+    const: 1
+    description: |
+      Number of cells needed to represent a channel.
+
+  refsel:
+    type: string
+    enum:
+      - "int_ref"
+      - "a_vdd"
+      - "v_ext"
+    default: a_vdd
+    description: |
+      Reference Voltage selection.
+
+      Must be one of:
+      - "int_ref" (0x0) - Internal Bandgap Reference
+      - "a_vdd"   (0x1) - Analog Voltage Supply
+      - "v_ext"   (0x2) - External Voltage Reference
+
+  max-channels:
+    type: int
+    default: 1
+    description: |
+      Maximum number of channels.
+
+  external-pin-en:
+    type: int
+    required: true
+    enum:
+      - 0
+      - 1
+    description: |
+      Enable external output pin for the channel.
+
+  volt-pump-disable:
+    type: int
+    enum:
+      - 0
+      - 1
+    default: 0
+    description: |
+      Voltage pump provides power when dac supply voltage
+      is less than 3.3v, writing 1 will disable it.
+
+  run-in-standby:
+    type: int
+    enum:
+      - 0
+      - 1
+    default: 0
+    description: |
+      The Run in Standby controls the DAC in standby mode.
+
+      when bit is reset, the output buffer is disabled and when set, the DAC output
+      buffer will keep its value in Standby Sleep mode.
+
+examples:
+  - |
+    dac: dac@42005000 {
+      compatible = "microchip,dac-g2";
+      reg = <0x42005000 0x15>;
+      pinctrl-0 = <&dac_default>;
+      pinctrl-names = "default";
+      external_pin_en = <1>;
+    };
+
+io-channel-cells:
+  - output

--- a/samples/drivers/dac/boards/pic32cm_jh01_cpro.conf
+++ b/samples/drivers/dac/boards/pic32cm_jh01_cpro.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/samples/drivers/dac/boards/pic32cm_jh01_cpro.overlay
+++ b/samples/drivers/dac/boards/pic32cm_jh01_cpro.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac>;
+		dac-channel-id = <0>;
+		dac-resolution = <10>;
+	};
+};
+
+&dac {
+	compatible = "microchip,dac-g2";
+	status = "okay";
+};

--- a/tests/drivers/dac/dac_api/boards/pic32cm_jh01_cpro.conf
+++ b/tests/drivers/dac/dac_api/boards/pic32cm_jh01_cpro.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/tests/drivers/dac/dac_api/boards/pic32cm_jh01_cpro.overlay
+++ b/tests/drivers/dac/dac_api/boards/pic32cm_jh01_cpro.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&dac 0>;
+		io-channel-names = "dac1";
+	};
+};
+
+&dac {
+	refsel = "int_ref";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,resolution = <10>;
+	};
+};

--- a/tests/drivers/dac/dac_loopback/boards/pic32cm_jh01_cpro.conf
+++ b/tests/drivers/dac/dac_loopback/boards/pic32cm_jh01_cpro.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/tests/drivers/dac/dac_loopback/boards/pic32cm_jh01_cpro.overlay
+++ b/tests/drivers/dac/dac_loopback/boards/pic32cm_jh01_cpro.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect the PA02 (DAC-OUT) to PA04 (ADC AIN4) for the test */
+
+/ {
+	zephyr,user {
+		io-channels = <&dac 0 &adc0 1>;
+		io-channel-names = "dac1", "adc1";
+	};
+};
+
+&dac {
+	refsel = "a_vdd";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,resolution = <10>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <10>;
+		zephyr,input-positive = <MCHP_ADC_AIN4>;
+	};
+};


### PR DESCRIPTION
- Add the device tree node and the binding file for microchip DAC G2 Peripherals.
- Add G2 DAC driver for Microchip DAC Peripherals.
- Add DAC pinctrl definitions and update the board metadata to list DAC as a supported feature on the PIC32CM JH01 Curiosity Pro board.
- Add board overlay for pic32cm_jh01_cpro to enable DAC test cases to run on PIC32CM_JH01 Curiosity Pro board.
- Add board-specific configuration and overlay files for running DAC Samples on the PIC32CM JH01 Curiosity Pro.