### PR TITLE
dts: arm: microchip: pic32cm_jh: Adds nodes of tc peripheral

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro-pinctrl.dtsi
@@ -46,4 +46,11 @@
 			pinmux = <PC5F_TCC2_WO1>;
 		};
 	};
+
+	tc5_pwm_default: tc5_pwm_default {
+		group1 {
+			pinmux = <PA4F_TC5_WO0>,
+				 <PA5F_TC5_WO1>;
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
@@ -215,3 +215,12 @@
 	prescaler = <256>;
 	status = "okay";
 };
+
+&tc5 {
+	compatible = "microchip,tc-g1-pwm";
+	#pwm-cells = <3>;
+	pinctrl-0 = <&tc5_pwm_default>;
+	pinctrl-names = "default";
+	prescaler = <64>;
+	status = "okay";
+};

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_2532_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_2532_jh.dtsi
@@ -58,5 +58,47 @@
 			channels = <2>;
 			status = "disabled";
 		};
+
+		tc5: tc@43000800 {
+			compatible = "microchip,tc-g1";
+			reg = <0x43000800 0x400>;
+			interrupts = <20 0>;
+			interrupt-names = "mc0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TC5>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC5>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc6: tc@43000c00 {
+			compatible = "microchip,tc-g1";
+			reg = <0x43000c00 0x400>;
+			interrupts = <21 0>;
+			interrupt-names = "mc0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TC6>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC6>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc7: tc@43001000 {
+			compatible = "microchip,tc-g1";
+			reg = <0x43001000 0x400>;
+			interrupts = <22 0>;
+			interrupt-names = "mc0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TC7>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC7>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_5164_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_5164_jh.dtsi
@@ -58,5 +58,47 @@
 			channels = <2>;
 			status = "disabled";
 		};
+
+		tc5: tc@43000800 {
+			compatible = "microchip,tc-g1";
+			reg = <0x43000800 0x400>;
+			interrupts = <20 0>;
+			interrupt-names = "mc0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TC5>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC5>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc6: tc@43000c00 {
+			compatible = "microchip,tc-g1";
+			reg = <0x43000c00 0x400>;
+			interrupts = <21 0>;
+			interrupt-names = "mc0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TC6>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC6>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc7: tc@43001000 {
+			compatible = "microchip,tc-g1";
+			reg = <0x43001000 0x400>;
+			interrupts = <22 0>;
+			interrupt-names = "mc0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TC7>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC7>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
@@ -172,6 +172,78 @@
 			status = "disabled";
 		};
 
+		tc0: tc@42003000 {
+			compatible = "microchip,tc-g1";
+			reg = <0x42003000 0x400>;
+			interrupts = <20 0>;
+			interrupt-names = "mc0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC0>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC0>,
+				 <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC1>;
+			clock-names = "mclk", "gclk", "client_mclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc1: tc@42003400 {
+			compatible = "microchip,tc-g1";
+			reg = <0x42003400 0x400>;
+			interrupts = <21 0>;
+			interrupt-names = "mc0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC1>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC1>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc2: tc@42003800 {
+			compatible = "microchip,tc-g1";
+			reg = <0x42003800 0x400>;
+			interrupts = <22 0>;
+			interrupt-names = "mc0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC2>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC2>,
+				 <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC3>;
+			clock-names = "mclk", "gclk", "client_mclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc3: tc@42003c00 {
+			compatible = "microchip,tc-g1";
+			reg = <0x42003c00 0x400>;
+			interrupts = <23 0>;
+			interrupt-names = "mc0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC3>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC3>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc4: tc@42004000 {
+			compatible = "microchip,tc-g1";
+			reg = <0x42004000 0x400>;
+			interrupts = <24 0>;
+			interrupt-names = "mc0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC4>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC4>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
 		adc0: adc@42004400 {
 			compatible = "microchip,adc-g1";
 			reg = <0x42004400 0x2e>;

--- a/tests/drivers/pwm/pwm_api/boards/microchip/pic32cm_jh01_cpro_tc5.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/microchip/pic32cm_jh01_cpro_tc5.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &tc5;
+	};
+};
+
+&tc5 {
+	prescaler = <256>;
+	status = "okay";
+};

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -139,9 +139,11 @@ tests:
     extra_args:
       - platform:sam_e54_xpro/atsame54p20a:DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tc5.overlay"
       - platform:pic32cx_sg41_cult/pic32cx1025sg41128:DTC_OVERLAY_FILE="boards/microchip/pic32cx_sg41_cult_tc5.overlay"
+      - platform:pic32cm_jh01_cpro/pic32cm5164jh01100:DTC_OVERLAY_FILE="boards/microchip/pic32cm_jh01_cpro_tc5.overlay"
     platform_allow:
       - sam_e54_xpro
       - pic32cx_sg41_cult
+      - pic32cm_jh01_cpro
     filter: dt_alias_exists("pwm-test")
   drivers.pwm.mchp_tc6:
     extra_args: DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tc6.overlay"

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -137,8 +137,8 @@ tests:
     filter: dt_alias_exists("pwm-test")
   drivers.pwm.mchp_tc5:
     extra_args:
-      - DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tc5.overlay"
-      - DTC_OVERLAY_FILE="boards/microchip/pic32cx_sg41_cult_tc5.overlay"
+      - platform:sam_e54_xpro/atsame54p20a:DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tc5.overlay"
+      - platform:pic32cx_sg41_cult/pic32cx1025sg41128:DTC_OVERLAY_FILE="boards/microchip/pic32cx_sg41_cult_tc5.overlay"
     platform_allow:
       - sam_e54_xpro
       - pic32cx_sg41_cult


### PR DESCRIPTION
- Adds the tc nodes as per available per device configuration to respective device files in the device tree
- Updates testcase.yaml for the pwm_api in the scenario for testing pwm
   with tc5 instance pic32cm jh device.
- Adds overlay with tc5 instance for testing pwm_api
- Updates testcase.yaml for the pwm_api to add the test of the board