### PR TITLE
drivers/sensor: lsm6dsv16x: add int-gpio-config attribute in DT

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -1531,6 +1531,7 @@ static int lsm6dsv16x_pm_action(const struct device *dev, enum pm_device_action 
 	.trig_enabled = true,						\
 	.int1_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int1_gpios, { 0 }),	\
 	.int2_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int2_gpios, { 0 }),	\
+	.int_mode = DT_INST_PROP(inst, int_gpio_config),		\
 	.drdy_pulsed = DT_INST_PROP(inst, drdy_pulsed),                 \
 	.drdy_pin = DT_INST_PROP(inst, drdy_pin)
 #else

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
@@ -90,6 +90,7 @@ struct lsm6dsv16x_config {
 #ifdef CONFIG_LSM6DSV16X_TRIGGER
 	const struct gpio_dt_spec int1_gpio;
 	const struct gpio_dt_spec int2_gpio;
+	const uint8_t int_mode;
 	uint8_t drdy_pin;
 	bool trig_enabled;
 #if LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c)

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_trigger.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_trigger.c
@@ -18,6 +18,11 @@
 
 LOG_MODULE_DECLARE(LSM6DSV16X, CONFIG_SENSOR_LOG_LEVEL);
 
+static const gpio_flags_t gpio_int_cfg[2] = {
+			GPIO_INT_EDGE_TO_ACTIVE,
+			GPIO_INT_LEVEL_ACTIVE,
+			};
+
 /**
  * lsm6dsv16x_enable_xl_int - XL enable selected int pin to generate interrupt
  */
@@ -273,7 +278,7 @@ static void lsm6dsv16x_handle_interrupt(const struct device *dev)
 
 	if (!ON_I3C_BUS(cfg) || (I3C_INT_PIN(cfg))) {
 		ret = gpio_pin_interrupt_configure_dt(lsm6dsv16x->drdy_gpio,
-						GPIO_INT_EDGE_TO_ACTIVE);
+						      gpio_int_cfg[cfg->int_mode]);
 		if (ret < 0) {
 			LOG_ERR("%s: Not able to configure pin_int", dev->name);
 		}
@@ -451,7 +456,7 @@ int lsm6dsv16x_init_interrupt(const struct device *dev)
 			}
 
 			ret = gpio_pin_interrupt_configure_dt(lsm6dsv16x->drdy_gpio,
-							      GPIO_INT_EDGE_TO_ACTIVE);
+							      gpio_int_cfg[cfg->int_mode]);
 			if (ret < 0) {
 				LOG_ERR("Could not configure gpio interrupt");
 				return ret;
@@ -487,6 +492,5 @@ int lsm6dsv16x_init_interrupt(const struct device *dev)
 	}
 #endif
 
-	return gpio_pin_interrupt_configure_dt(lsm6dsv16x->drdy_gpio,
-					       GPIO_INT_EDGE_TO_ACTIVE);
+	return gpio_pin_interrupt_configure_dt(lsm6dsv16x->drdy_gpio, gpio_int_cfg[cfg->int_mode]);
 }

--- a/dts/bindings/sensor/st,lsm6dsvxxx-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dsvxxx-common.yaml
@@ -22,6 +22,20 @@ properties:
       The property value should ensure the flags properly describe
       the signal that is presented to the driver.
 
+  int-gpio-config:
+    type: int
+    default: 0
+    description: |
+      Select the interrupt configuration for INT2 gpio.
+
+      The default of 0 is the most common situation to avoid multiple interrupts
+      to be triggered by same event.
+
+      - 0 # LSM6DSVXXX_DT_GPIO_INT_EDGE_TO_ACTIVE
+      - 1 # LSM6DSVXXX_DT_GPIO_INT_LEVEL_ACTIVE
+
+    enum: [0, 1]
+
   drdy-pin:
     type: int
     default: 1

--- a/include/zephyr/dt-bindings/sensor/lsm6dsvxxx.h
+++ b/include/zephyr/dt-bindings/sensor/lsm6dsvxxx.h
@@ -6,7 +6,16 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSVXXX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSVXXX_H_
 
-/* Accel and Gyro Data rates */
+/**
+ * @name STMicroelectronics LSM6DSVXXX sensor DT Options
+ * @ingroup sensor_interface
+ * @{
+ */
+
+/**
+ * @name Accel and Gyro Data rates
+ * @{
+ */
 #define LSM6DSVXXX_DT_ODR_OFF			0x0
 #define LSM6DSVXXX_DT_ODR_AT_1Hz875		0x1
 #define LSM6DSVXXX_DT_ODR_AT_7Hz5		0x2
@@ -40,8 +49,12 @@
 #define LSM6DSVXXX_DT_ODR_HA02_AT_1600Hz	0x2A
 #define LSM6DSVXXX_DT_ODR_HA02_AT_3200Hz	0x2B
 #define LSM6DSVXXX_DT_ODR_HA02_AT_6400Hz	0x2C
+/** @} */
 
-/* Accelerometer batching rates */
+/**
+ * @name Accelerometer batching rates
+ * @{
+ */
 #define LSM6DSVXXX_DT_XL_NOT_BATCHED		0x0
 #define LSM6DSVXXX_DT_XL_BATCHED_AT_1Hz875	0x1
 #define LSM6DSVXXX_DT_XL_BATCHED_AT_7Hz5	0x2
@@ -55,8 +68,12 @@
 #define LSM6DSVXXX_DT_XL_BATCHED_AT_1920Hz	0xa
 #define LSM6DSVXXX_DT_XL_BATCHED_AT_3840Hz	0xb
 #define LSM6DSVXXX_DT_XL_BATCHED_AT_7680Hz	0xc
+/** @} */
 
-/* Gyroscope batching rates */
+/**
+ * @name Gyroscope batching rates
+ * @{
+ */
 #define LSM6DSVXXX_DT_GY_NOT_BATCHED		0x0
 #define LSM6DSVXXX_DT_GY_BATCHED_AT_1Hz875	0x1
 #define LSM6DSVXXX_DT_GY_BATCHED_AT_7Hz5	0x2
@@ -70,22 +87,34 @@
 #define LSM6DSVXXX_DT_GY_BATCHED_AT_1920Hz	0xa
 #define LSM6DSVXXX_DT_GY_BATCHED_AT_3840Hz	0xb
 #define LSM6DSVXXX_DT_GY_BATCHED_AT_7680Hz	0xc
+/** @} */
 
-/* Temperature sensor batching rates */
+/**
+ * @name Temperature sensor batching rates
+ * @{
+ */
 #define LSM6DSVXXX_DT_TEMP_NOT_BATCHED		0x0
 #define LSM6DSVXXX_DT_TEMP_BATCHED_AT_1Hz875	0x1
 #define LSM6DSVXXX_DT_TEMP_BATCHED_AT_15Hz	0x2
 #define LSM6DSVXXX_DT_TEMP_BATCHED_AT_60Hz	0x3
+/** @} */
 
-/* Sensor Fusion Low Power Data rates */
+/**
+ * @name Sensor Fusion Low Power Data rates
+ * @{
+ */
 #define LSM6DSVXXX_DT_SFLP_ODR_AT_15Hz		0x0
 #define LSM6DSVXXX_DT_SFLP_ODR_AT_30Hz		0x1
 #define LSM6DSVXXX_DT_SFLP_ODR_AT_60Hz		0x2
 #define LSM6DSVXXX_DT_SFLP_ODR_AT_120Hz		0x3
 #define LSM6DSVXXX_DT_SFLP_ODR_AT_240Hz		0x4
 #define LSM6DSVXXX_DT_SFLP_ODR_AT_480Hz		0x5
+/** @} */
 
-/* Sensor Fusion Low Power FIFO enable defs */
+/**
+ * @name Sensor Fusion Low Power FIFO enable defs
+ * @{
+ */
 #define LSM6DSVXXX_DT_SFLP_FIFO_OFF				0x0
 #define LSM6DSVXXX_DT_SFLP_FIFO_GAME_ROTATION			0x1
 #define LSM6DSVXXX_DT_SFLP_FIFO_GRAVITY				0x2
@@ -94,8 +123,12 @@
 #define LSM6DSVXXX_DT_SFLP_FIFO_GAME_ROTATION_GBIAS		0x5
 #define LSM6DSVXXX_DT_SFLP_FIFO_GRAVITY_GBIAS			0x6
 #define LSM6DSVXXX_DT_SFLP_FIFO_GAME_ROTATION_GRAVITY_GBIAS	0x7
+/** @} */
 
-/* FIFO tags */
+/**
+ * @name FIFO tags
+ * @{
+ */
 #define LSM6DSVXXX_FIFO_EMPTY                    0x0
 #define LSM6DSVXXX_GY_NC_TAG                     0x1
 #define LSM6DSVXXX_XL_NC_TAG                     0x2
@@ -125,15 +158,34 @@
 #define LSM6DSVXXX_MLC_FEATURE                   0x1C
 #define LSM6DSVXXX_XL_HG_TAG                     0x1D
 #define LSM6DSVXXX_GY_ENHANCED_EIS               0x1E
+/** @} */
 
-/* status registers */
+/**
+ * @name status registers
+ * @{
+ */
 #define LSM6DSVXXX_STATUS_REG			0x1EU
 #define LSM6DSVXXX_OUTX_L_A			0x28U
 #define LSM6DSVXXX_FIFO_STATUS1			0x1BU
 #define LSM6DSVXXX_FIFO_DATA_OUT_TAG		0x78U
+/** @} */
 
-/* FIFO settings */
+/**
+ * @name FIFO settings
+ * @{
+ */
 #define LSM6DSVXXX_BYPASS_MODE			0x00U
 #define LSM6DSVXXX_FIFO_CTRL4			0x0AU
+/** @} */
+
+/**
+ * @name GPIO interrupt configuration
+ * @{
+ */
+#define LSM6DSVXXX_DT_GPIO_INT_EDGE_TO_ACTIVE	0 /*!< Edge-triggered interrupt */
+#define LSM6DSVXXX_DT_GPIO_INT_LEVEL_ACTIVE	1 /*!< Level-triggered interrupt */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSVXXX_H_ */


### PR DESCRIPTION
Add the possibility to configure the interrupt gpio in one of the following two values:

      - GPIO_INT_EDGE_TO_ACTIVE
      - GPIO_INT_LEVEL_ACTIVE

Default is GPIO_INT_EDGE_TO_ACTIVE, which matches with old fixed configuration.

This PR is intended to be a substitute of #99445