### PR TITLE
usb: host: Fix a double free when a disconnect is detected twice

### DIFF
--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -40,6 +40,10 @@ void usbh_device_free(struct usb_device *const udev)
 {
 	struct usbh_context *const uhs_ctx = udev->ctx;
 
+	if (usbh_device_is_root(uhs_ctx, udev)) {
+		uhs_ctx->root = NULL;
+	}
+
 	sys_bitarray_clear_bit(uhs_ctx->addr_ba, udev->addr);
 	sys_dlist_remove(&udev->node);
 	if (udev->cfg_desc != NULL) {


### PR DESCRIPTION
In function `dev_removed_handler()` it is assumend that if the root device pointer is not null, then it is not freed. However, during the freeing of the device the pointer is not set to null. This commit sets it to null.

Fixes: #103580