### PR TITLE
drivers: net: nsos: fix uninitialized accepted socket

### DIFF
--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -832,7 +832,7 @@ static int nsos_accept(void *obj, struct net_sockaddr *addr, net_socklen_t *addr
 		goto close_adapt_fd;
 	}
 
-	conn_sock = nsi_host_malloc(sizeof(*conn_sock));
+	conn_sock = nsi_host_calloc(1, sizeof(*conn_sock));
 	if (!conn_sock) {
 		ret = -NSI_ERRNO_MID_ENOMEM;
 		goto free_zephyr_fd;
@@ -840,6 +840,8 @@ static int nsos_accept(void *obj, struct net_sockaddr *addr, net_socklen_t *addr
 
 	conn_sock->fd = zephyr_fd;
 	conn_sock->poll.mid.fd = adapt_fd;
+	conn_sock->recv_timeout = K_FOREVER;
+	conn_sock->send_timeout = K_FOREVER;
 
 	zvfs_finalize_typed_fd(zephyr_fd, conn_sock, &nsos_socket_fd_op_vtable.fd_vtable,
 			       ZVFS_MODE_IFSOCK);

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -212,13 +212,11 @@ static int nsos_socket_create(int family, int type, int proto)
 		return -1;
 	}
 
-	sock = nsi_host_malloc(sizeof(*sock));
+	sock = nsi_host_calloc(1, sizeof(*sock));
 	if (!sock) {
 		errno = ENOMEM;
 		goto free_fd;
 	}
-
-	memset(sock, 0, sizeof(*sock));
 
 	sock->fd = fd;
 	sock->recv_timeout = K_FOREVER;


### PR DESCRIPTION
Follow-up to https://github.com/zephyrproject-rtos/zephyr/pull/108526. Noticed an uninitialized `k_condvar` struct on native_sim with Address Sanitizer switched on which led back to the now fixed uninitialized socket in `nsos_socket_create()`, see https://github.com/zephyrproject-rtos/zephyr/pull/108526/changes#r3275043510.

This PR fixes the same uninitialized malloc pattern in `nsos_accept()`. In addition it sets the `*_timeout` settings to fixed default-values (previously undefined timeout).