### PR TITLE
dts: bindings: *: stm32: use min/max properties

### DIFF
--- a/boards/rakwireless/rak11160/rak11160.dts
+++ b/boards/rakwireless/rak11160/rak11160.dts
@@ -51,9 +51,9 @@
 
 &pll {
 	div-m = <1>;
-	mul-n = <3>;
-	div-r = <2>;
-	div-q = <2>;
+	mul-n = <6>;
+	div-r = <4>;
+	div-q = <4>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };

--- a/boards/rakwireless/rak3172/rak3172.dts
+++ b/boards/rakwireless/rak3172/rak3172.dts
@@ -49,9 +49,9 @@ stm32_lp_tick_source: &lptim1 {
 
 &pll {
 	div-m = <1>;
-	mul-n = <3>;
-	div-r = <2>;
-	div-q = <2>;
+	mul-n = <6>;
+	div-r = <4>;
+	div-q = <4>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -2650,9 +2650,7 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 #ifdef CONFIG_PM
 #define STM32_UART_PM_WAKEUP(index)						\
 	.wakeup_source = DT_INST_PROP(index, wakeup_source),			\
-	.wakeup_line = COND_CODE_1(DT_INST_NODE_HAS_PROP(index, wakeup_line),	\
-			(DT_INST_PROP(index, wakeup_line)),			\
-			(STM32_WAKEUP_LINE_NONE)),
+	.wakeup_line = DT_INST_PROP_OR(index, wakeup_line, STM32_WAKEUP_LINE_NONE),
 #else
 #define STM32_UART_PM_WAKEUP(index) /* Not used */
 #endif

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -561,7 +561,7 @@ static int sys_clock_driver_init(void)
 	}
 #endif
 
-#if DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout)
+#if DT_NODE_HAS_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout)
 	uint32_t timeout = DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout);
 
 	if (timeout > (lptim_clock_presc * 0xFFFF) / lptim_clock_freq) {

--- a/dts/bindings/clock/st,stm32f0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f0-pll-clock.yaml
@@ -38,4 +38,5 @@ properties:
     required: true
     description: |
         PLL multiplication factor for output clock
-        Valid range: 2 - 16
+    min: 2
+    max: 16

--- a/dts/bindings/clock/st,stm32f1-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f1-pll-clock.yaml
@@ -30,7 +30,8 @@ properties:
     required: true
     description: |
         Main PLL multiplication factor for VCO
-        Valid range: 2 - 16
+    min: 2
+    max: 16
 
   xtpre:
     type: boolean

--- a/dts/bindings/clock/st,stm32f100-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f100-pll-clock.yaml
@@ -33,4 +33,5 @@ properties:
     required: true
     description: |
         PLL multiplication factor for output clock
-        Valid range: 2 - 16
+    min: 2
+    max: 16

--- a/dts/bindings/clock/st,stm32f105-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f105-pll-clock.yaml
@@ -50,7 +50,8 @@ properties:
     required: true
     description: |
         Configurable prescaler
-        Valid range: 1 - 16
+    min: 1
+    max: 16
 
   otgfspre:
     type: boolean

--- a/dts/bindings/clock/st,stm32fx-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32fx-pll-clock.yaml
@@ -46,7 +46,8 @@ properties:
         On all other SoCs, the division factor M is shared between
         PLL, PLLSAI and PLLI2S, hence same value must be used
         for those PLLs when used together.
-        Valid range: 2 - 63
+    min: 2
+    max: 63
 
   mul-n:
     type: int
@@ -79,7 +80,8 @@ properties:
         and on all STM32F7x for PLLI2S.
         Available only on STM32F427, F429, F437, F439, F446, F469, F479
         and on all STM32F7x for PLLSAI.
-        Valid range: 2 - 15
+    min: 2
+    max: 15
 
   post-div-q:
     type: int
@@ -91,7 +93,8 @@ properties:
         and on all STM32F7x for PLLSAI.
         If the div-q property is used and this property is applicable for the SoC, then it is
         required to define it.
-        Valid range: 1 - 32
+    min: 1
+    max: 32
 
   div-r:
     type: int
@@ -101,7 +104,8 @@ properties:
         Available on all SoCs except STM32F410 for PLLI2S.
         Available only on STM32F427, F429, F437, F439, F469, F479
         and on STM32F74x and higher for PLLSAI.
-        Valid range: 2 - 7
+    min: 2
+    max: 7
 
   post-div-r:
     type: int

--- a/dts/bindings/clock/st,stm32g0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32g0-pll-clock.yaml
@@ -35,30 +35,35 @@ properties:
     required: true
     description: |
         Division factor for PLL input clock
-        Valid range: 1 - 8
+    min: 1
+    max: 8
 
   mul-n:
     type: int
     required: true
     description: |
         Main PLL multiplication factor for VCO
-        Valid range: 8 - 86
+    min: 8
+    max: 86
 
   div-p:
     type: int
     description: |
         PLL division factor for PLL P output
-        Valid range: 2 - 32
+    min: 2
+    max: 32
 
   div-q:
     type: int
     description: |
         PLL division factor for PLL Q output
-        Valid range: 2 - 8
+    min: 2
+    max: 8
 
   div-r:
     type: int
     required: true
     description: |
         PLL division factor for PLLCLK (system clock)
-        Valid range: 2 - 8
+    min: 2
+    max: 8

--- a/dts/bindings/clock/st,stm32g4-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32g4-pll-clock.yaml
@@ -35,17 +35,20 @@ properties:
     required: true
     description: |
         Division factor for PLL input clock
-        Valid range: 1 - 16
+    min: 1
+    max: 16
 
   mul-n:
     type: int
     required: true
     description: |
         Main PLL multiplication factor for VCO
-        Valid range: 8 - 127
+    min: 8
+    max: 127
 
   div-p:
     type: int
     description: |
         Main PLL division factor for ADC
-        Valid range: 2 - 31
+    min: 2
+    max: 31

--- a/dts/bindings/clock/st,stm32h7-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32h7-pll-clock.yaml
@@ -39,35 +39,41 @@ properties:
     description: |
         Division factor for PLLx
         input clock
-        Valid range: 1 - 63
+    min: 1
+    max: 63
 
   mul-n:
     type: int
     required: true
     description: |
         Main PLL multiplication factor for VCOx
-        Valid range: 4 - 512
+    min: 4
+    max: 512
 
   div-p:
     type: int
     description: |
         PLL division factor for pllx_p_ck
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-q:
     type: int
     description: |
         PLL division factor for pllx_q_ck
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-r:
     type: int
     description: |
         PLL division factor for pllx_r_ck
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   fracn:
     type: int
     description: |
         PLLx FRACN value
-        Valid range: 0 - 8191
+    min: 0
+    max: 8191

--- a/dts/bindings/clock/st,stm32h7rs-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32h7rs-pll-clock.yaml
@@ -31,10 +31,12 @@ properties:
     type: int
     description: |
         PLL division factor for pllx_s_ck : valid for PLL1, 2, 3
-        Valid range: 1 - 8
+    min: 1
+    max: 8
 
   div-t:
     type: int
     description: |
         PLL division factor for pllx_t_ck : valid for PLL2
-        Valid range: 1 - 8
+    min: 1
+    max: 8

--- a/dts/bindings/clock/st,stm32mp13-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32mp13-pll-clock.yaml
@@ -53,35 +53,41 @@ properties:
     required: true
     description: |
         PLLx division factor (aka DIVM1 + 1) of the input clock divider
-        Valid range: 1 - 64
+    min: 1
+    max: 64
 
   mul-n:
     type: int
     required: true
     description: |
         PLLx multiplication factor (aka DIVN + 1) for VCO
-        Valid range: 25 - 200
+    min: 25
+    max: 200
 
   div-p:
     type: int
     description: |
         PLLx_P division factor (aka DIVP + 1)
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-q:
     type: int
     description: |
         PLLx_Q division factor (aka DIVQ + 1)
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-r:
     type: int
     description: |
         PLLx_R division factor (aka DIVR + 1)
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   fracn:
     type: int
     description: |
         PLLx FRACV fractional latch
-        Valid range: 0 - 8191
+    min: 0
+    max: 8191

--- a/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
@@ -33,4 +33,5 @@ properties:
     description: |
         ICx integer division factor
         The input ICx frequency is divided by the specified value
-        Valid range: 1 - 256
+    min: 1
+    max: 256

--- a/dts/bindings/clock/st,stm32n6-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32n6-pll-clock.yaml
@@ -40,23 +40,27 @@ properties:
     description: |
         Prescaler for PLLx
         input clock
-        Valid range: 1 - 63
+    min: 1
+    max: 63
 
   mul-n:
     type: int
     required: true
     description: |
         PLLx multiplication factor for VCO
-        Valid range: 16 - 2500
+    min: 16
+    max: 2500
 
   div-p1:
     type: int
     description: |
         PLLx DIVP1 division factor
-        Valid range: 1 - 7
+    min: 1
+    max: 7
 
   div-p2:
     type: int
     description: |
         PLLx DIVP2 division factor
-        Valid range: 1 - 7
+    min: 1
+    max: 7

--- a/dts/bindings/clock/st,stm32u0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32u0-pll-clock.yaml
@@ -36,30 +36,35 @@ properties:
     description: |
         Division factor M of the PLL
         input clock divider
-        Valid range: 1 - 8
+    min: 1
+    max: 8
 
   mul-n:
     type: int
     required: true
     description: |
         PLL frequency multiplication factor N
-        Valid range: 4 - 127
+    min: 4
+    max: 127
 
   div-p:
     type: int
     description: |
         PLL VCO division factor P
-        Valid range: 2 - 32
+    min: 2
+    max: 32
 
   div-q:
     type: int
     description: |
         PLL VCO division factor Q
-        Valid range: 2 - 8
+    min: 2
+    max: 8
 
   div-r:
     type: int
     required: true
     description: |
         PLL VCO division factor R
-        Valid range: 2 - 8
+    min: 2
+    max: 8

--- a/dts/bindings/clock/st,stm32u5-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32u5-pll-clock.yaml
@@ -42,26 +42,30 @@ properties:
     description: |
         Prescaler for PLLx
         input clock
-        Valid range: 1 - 16
+    min: 1
+    max: 16
 
   mul-n:
     type: int
     required: true
     description: |
         PLLx multiplication factor for VCO
-        Valid range: 4 - 512
+    min: 4
+    max: 512
 
   div-p:
     type: int
     description: |
         PLLx DIVP division factor
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-q:
     type: int
     description: |
         PLLx DIVQ division factor
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-r:
     type: int
@@ -70,10 +74,12 @@ properties:
         PLLx DIVR division factor
         On PLL1, only division by 1 and even division values are allowed.
         No restrictions for PLL2 and PLL3
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   fracn:
     type: int
     description: |
         PLLx FRACN value
-        Valid range: 0 - 8191
+    min: 0
+    max: 8191

--- a/dts/bindings/clock/st,stm32wb-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32wb-pll-clock.yaml
@@ -40,30 +40,35 @@ properties:
     required: true
     description: |
         Main PLL division factor for PLL input clock
-        Valid range: 1 - 8
+    min: 1
+    max: 8
 
   mul-n:
     type: int
     required: true
     description: |
         Main PLL multiplication factor for VCO
-        Valid range: 6 - 127
+    min: 6
+    max: 127
 
   div-p:
     type: int
     description: |
         Main PLL division factor for PLLPCLK
-        Valid range: 2 - 32
+    min: 2
+    max: 32
 
   div-q:
     type: int
     description: |
         Main PLL division factor for PLLQCLK
-        Valid range: 2 - 8
+    min: 2
+    max: 8
 
   div-r:
     type: int
     required: true
     description: |
         Main PLL division factor for PLLRCLK (system clock)
-        Valid range: 2 - 8
+    min: 2
+    max: 8

--- a/dts/bindings/clock/st,stm32wba-hse-clock.yaml
+++ b/dts/bindings/clock/st,stm32wba-hse-clock.yaml
@@ -18,4 +18,5 @@ properties:
     type: int
     description: |
         HSE clock trimming
-        Valid range: 0 - 63
+    min: 0
+    max: 63

--- a/dts/bindings/clock/st,stm32wba-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32wba-pll-clock.yaml
@@ -42,31 +42,36 @@ properties:
     description: |
         Prescaler for PLLx
         input clock
-        Valid range: 1 - 8
+    min: 1
+    max: 8
 
   mul-n:
     type: int
     required: true
     description: |
         PLLx multiplication factor for VCO
-        Valid range: 4 - 512
+    min: 4
+    max: 512
 
   div-p:
     type: int
     required: true
     description: |
         PLLx DIVP division factor
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-q:
     type: int
     description: |
         PLLx DIVQ division factor
-        Valid range: 1 - 128
+    min: 1
+    max: 128
 
   div-r:
     type: int
     required: true
     description: |
         PLLx DIVR division factor
-        Valid range: 1 - 128
+    min: 1
+    max: 128

--- a/dts/bindings/opamp/st,stm32g4-opamp.yaml
+++ b/dts/bindings/opamp/st,stm32g4-opamp.yaml
@@ -245,7 +245,8 @@ properties:
       If value is present and self-calibration is enabled, this value will overwrite values
       calculated during self-calibration.
       Please refer to RM0440 Rev 9, pp. 789/2140 for more details.
-      NOTE: Acceptable range is 0x00 to 0x1f.
+    min: 0
+    max: 0x1f
 
   st,nmos-trimming-value:
     type: int
@@ -255,4 +256,5 @@ properties:
       If value is present and self-calibration is enabled, this value will overwrite values
       calculated during self-calibration.
       Please refer to RM0440 Rev 9, pp. 789/2140 for more details.
-      NOTE: Acceptable range is 0x00 to 0x1f.
+    min: 0
+    max: 0x1f

--- a/dts/bindings/rtc/st,stm32-rtc.yaml
+++ b/dts/bindings/rtc/st,stm32-rtc.yaml
@@ -58,4 +58,5 @@ properties:
       Not required, since RTC Alarm interrupt could be routed directly to Nested
       Vectored Interrupt Controller (NVIC) and to Power Control (PWR) wake-up
       pins on some series.
-      Valid range: 0 - 31
+    min: 0
+    max: 31

--- a/dts/bindings/sensor/st,iis2dlpc-common.yaml
+++ b/dts/bindings/sensor/st,iis2dlpc-common.yaml
@@ -98,30 +98,33 @@ properties:
     default: 0x0
     description: |
       Tap shock value. Default is power-up configuration.
-      (values range from 0x0 to 0x3)
       This register represents the maximum time of an over-threshold signal
       detection to be recognized as a tap event. Where 0 equals 4*1/ODR and
       1LSB = 8*1/ODR.
+    min: 0
+    max: 3
 
   tap-latency:
     type: int
     default: 0x0
     description: |
       Tap latency. Default is power-up configuration.
-      (values range from 0x0 to 0xF)
       When double-tap recognition is enabled, this register expresses the
       maximum time between two successive detected taps to determine a
       double-tap event. Where 0 equals 16*1/ODR and 1LSB = 32*1/ODR.
+    min: 0
+    max: 0xf
 
   tap-quiet:
     type: int
     default: 0x0
     description: |
       Expected quiet time after a tap detection. Default is power-up configuration.
-      (values range from 0x0 to 0x3)
       This register represents the time after the first detected tap in which
       there must not be any overthreshold event. Where 0 equals 2*1/ODR
       and 1LSB = 4*1/ODR.
+    min: 0
+    max: 3
 
 examples:
   - |

--- a/dts/bindings/sensor/st,iis3dwb.yaml
+++ b/dts/bindings/sensor/st,iis3dwb.yaml
@@ -108,9 +108,9 @@ properties:
     default: 32
     description: |
       Specify the default FIFO watermark threshold. Every unit indicates a FIFO row (1 byte of TAG +
-      6 bytes of data). (min 0; max 255)
-      A typical threshold value is 32 which is then used as default.
-      Valid range: 0 - 511
+      6 bytes of data). A typical threshold value is 32 which is then used as default.
+    min: 0
+    max: 511
 
   accel-fifo-batch-rate:
     type: int

--- a/dts/bindings/sensor/st,lis2dw12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-common.yaml
@@ -123,30 +123,33 @@ properties:
     default: 0x0
     description: |
       Tap shock value. Default is power-up configuration.
-      (values range from 0x0 to 0x3)
       This register represents the maximum time of an over-threshold signal
       detection to be recognized as a tap event. Where 0 equals 4*1/ODR and
       1LSB = 8*1/ODR.
+    min: 0
+    max: 3
 
   tap-latency:
     type: int
     default: 0x0
     description: |
       Tap latency. Default is power-up configuration.
-      (values range from 0x0 to 0xF)
       When double-tap recognition is enabled, this register expresses the
       maximum time between two successive detected taps to determine a
       double-tap event. Where 0 equals 16*1/ODR and 1LSB = 32*1/ODR.
+    min: 0
+    max: 0xf
 
   tap-quiet:
     type: int
     default: 0x0
     description: |
       Expected quiet time after a tap detection. Default is power-up configuration.
-      (values range from 0x0 to 0x3)
       This register represents the time after the first detected tap in which
       there must not be any overthreshold event. Where 0 equals 2*1/ODR
       and 1LSB = 4*1/ODR.
+    min: 0
+    max: 3
 
   low-noise:
     type: boolean

--- a/dts/bindings/sensor/st,stts22h-i2c.yaml
+++ b/dts/bindings/sensor/st,stts22h-i2c.yaml
@@ -24,21 +24,22 @@ properties:
     default: 0
     description: |
       HIGH temperature threshold above which an alarm is triggered.
-      Valid range is 0 to 255. It defaults to 0 (alarm off) which is
-      the configuration at power-up. This threshold must be calculated
-      from a temperature T in Celsius using the formula
-      temperature-hi-threshold = 63 + T/0.64 C.
-
+      It defaults to 0 (alarm off) which is the configuration at power-up.
+      This threshold must be calculated from a temperature T in Celsius
+      using the formula temperature-hi-threshold = 63 + T/0.64 C.
+    min: 0
+    max: 255
 
   temperature-lo-threshold:
     type: int
     default: 0
     description: |
       LOW temperature threshold below which an alarm is triggered.
-      Valid range is 0 to 255. It defaults to 0 (alarm off) which is
-      the configuration at power-up. This threshold must be calculated
-      from a temperature T in Celsius using the formula
-      temperature-lo-threshold = 63 + T/0.64 C.
+      It defaults to 0 (alarm off) which is the configuration at power-up.
+      This threshold must be calculated from a temperature T in Celsius
+      using the formula temperature-lo-threshold = 63 + T/0.64 C.
+    min: 0
+    max: 255
 
   sampling-rate:
     type: int

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -66,7 +66,8 @@ properties:
       This property is required on stm32 devices where the wakeup interrupt signal could be
       configured masked at boot (sm32wl55 for instance), preventing the device to wakeup
       the core from stop mode(s).
-      Valid range: 0 - 31
+    min: 0
+    max: 31
 
   de-enable:
     type: boolean
@@ -80,7 +81,8 @@ properties:
     description: |
       Defines the time between the activation of the DE signal and the beginning of the start bit.
       It is expressed in 16th of a bit time.
-      Valid range: 0 - 31
+    min: 0
+    max: 31
 
   de-deassert-time:
     type: int
@@ -88,7 +90,8 @@ properties:
     description: |
       Defines the time between the end of the stop bit and the deactivation of the DE signal.
       It is expressed in 16th of a bit time.
-      Valid range: 0 - 31
+    min: 0
+    max: 31
 
   de-invert:
     type: boolean

--- a/dts/bindings/tcpc/st,stm32-ucpd.yaml
+++ b/dts/bindings/tcpc/st,stm32-ucpd.yaml
@@ -46,7 +46,8 @@ properties:
       inter-frame gap timer clock (tInterFrameGap).
       The division ratio 15 is to apply for Tx clock at the USB PD 2.0
       specification nominal value.
-      Valid range: 2 - 32
+    min: 2
+    max: 32
 
   transwin:
     type: int
@@ -54,7 +55,8 @@ properties:
     description: |
       Determines the division ratio of a hbit_clk divider producing
       tTransitionWindow interval.
-      Valid range: 2 - 32
+    min: 2
+    max: 32
 
   hbitclkdiv:
     type: int
@@ -62,7 +64,8 @@ properties:
     description: |
       Determines the division ratio of a ucpd_clk divider producing
       half-bit clock (hbit_clk)
-      Valid range: 1 - 64
+    min: 1
+    max: 64
 
   dead-battery:
     type: boolean

--- a/dts/bindings/timer/st,stm32-lptim.yaml
+++ b/dts/bindings/timer/st,stm32-lptim.yaml
@@ -44,8 +44,10 @@ properties:
     type: int
     description: |
         Gives the LPTIM an exact counting value (s) for timeout expiration.
-        Valid range is [1, 256] and should be consistent with st,prescaler
-        pre-defined setting. If not, an error is raised.
+        Value must be consistent with st,prescaler pre-defined setting otherwise
+        driver fails to initialize for the related device.
+    min: 1
+    max: 256
 
 examples:
   - |

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -60,8 +60,8 @@ properties:
       to your product's Reference Manual for more information about this
       feature's availability. (In particular, certain series such as
       STM32L0/STM32L1 have no instance supporting this feature).
-
-      Valid range [0 ... 255].
+    min: 0
+    max: 255
 
   st,mastermode:
     type: string


### PR DESCRIPTION
Replace informative only description of valid ranges with use of min/max properties in DT bindings YAML files for ST drivers.
