### PR TITLE
dts: bindings: {reset|adc}: use min/max properties

### DIFF
--- a/drivers/dac/dac_emul.c
+++ b/drivers/dac/dac_emul.c
@@ -181,8 +181,6 @@ static DEVICE_API(dac, dac_emul_driver_api) = {
 };
 
 #define DAC_EMUL_INIT(inst)                                                                        \
-	BUILD_ASSERT(DT_INST_PROP(inst, nchannels) > 0,                                            \
-		     "DAC emulator must have at least one channel");                               \
 	static struct dac_emul_channel dac_emul##inst##_channels[DT_INST_PROP(inst, nchannels)];   \
 	static struct dac_emul_data data##inst = {                                                 \
 		.channels = dac_emul##inst##_channels,                                             \

--- a/drivers/reset/reset_mmio.c
+++ b/drivers/reset/reset_mmio.c
@@ -99,8 +99,6 @@ static DEVICE_API(reset, reset_mmio_driver_api) = {
 
 #define DT_DRV_COMPAT reset_mmio
 #define RESET_MMIO_INIT(n)                                                                         \
-	BUILD_ASSERT(DT_INST_PROP(n, num_resets) > 0 && DT_INST_PROP(n, num_resets) < 32,          \
-		     "num-resets needs to be in [1, 31].");                                        \
 	static const struct reset_mmio_dev_config reset_mmio_dev_config_##n = {                    \
 		.base = DT_INST_REG_ADDR(n),                                                       \
 		.num_resets = DT_INST_PROP(n, num_resets),                                         \

--- a/dts/bindings/adc/zephyr,adc-emul.yaml
+++ b/dts/bindings/adc/zephyr,adc-emul.yaml
@@ -11,7 +11,9 @@ properties:
   nchannels:
     type: int
     required: true
-    description: Number of emulated ADC channels. Should be in 1-32 range.
+    description: Number of emulated ADC channels.
+    min: 1
+    max: 32
 
   ref-internal-mv:
     type: int

--- a/dts/bindings/reset/reset-mmio.yaml
+++ b/dts/bindings/reset/reset-mmio.yaml
@@ -17,7 +17,8 @@ properties:
     required: true
     description: |
       Number of resets controlled by the register.
-      Can be in the range [1, 31].
+    min: 1
+    max: 31
   active-low:
     description: Reset is active in low state.
     type: boolean


### PR DESCRIPTION
Use min/max DT properties for reset `num-resets` and ADC `nchannels` DT properties to factorize documentation and build time check of the property values against its valid range.