### PR TITLE
drivers: led: leds_group_multicolor: fix brightness value

### DIFF
--- a/drivers/led/leds_group_multicolor.c
+++ b/drivers/led/leds_group_multicolor.c
@@ -38,7 +38,7 @@ static int leds_group_multicolor_set_color(const struct device *dev, uint32_t le
 	for (uint8_t i = 0; i < num_colors; i++) {
 		int err;
 
-		err = led_set_brightness_dt(&config->led[i], color[i]);
+		err = led_set_brightness_dt(&config->led[i], color[i] * LED_BRIGHTNESS_MAX / 255U);
 		if (err) {
 			return err;
 		}


### PR DESCRIPTION
Remap brightness values from the [0, 255] range to the [0, `LED_BRIGHTNESS_MAX`] range before calling
`led_set_brightness_dt()`.