### PR TITLE
drivers: serial: uart_mcux_lpuart: ensure TX completes

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -1422,6 +1422,10 @@ static int mcux_lpuart_config_get(const struct device *dev, struct uart_config *
 static int mcux_lpuart_configure(const struct device *dev,
 				 const struct uart_config *cfg)
 {
+	/* Wait for Transmission Complete Flag */
+	while (!(get_base(dev)->STAT & LPUART_STAT_TC_MASK)) {
+	}
+
 	/* Disable Transmitter and Receiver */
 	get_base(dev)->CTRL &= ~(LPUART_CTRL_TE_MASK | LPUART_CTRL_RE_MASK);
 


### PR DESCRIPTION
Add a wait for the Transmission Complete (TC) flag at the start of mcux_lpuart_configure(). This prevents reconfiguration while the hardware is still shifting out the final byte on the TX line.

Without this wait, uart_configure() could interrupt an ongoing transmission, causing the last byte to not be fully sent on the UART bus. This behavior was observed on NXP LPUART and tracked in issue #109807.

Fixes #109807