### PR TITLE
dts: bindings: usb|usb-c: use min/max DT properties

### DIFF
--- a/dts/bindings/usb-c/usb-c-connector.yaml
+++ b/dts/bindings/usb-c/usb-c-connector.yaml
@@ -93,7 +93,8 @@ properties:
         * PDO_BATT
         * PDO_VAR
         * PDO_PPS_APDO
-      Valid range: 1 - 7
+      The USB PD specification allows for a maximum of 7 source PDOs
+      for a Standard Power Range device.
 
   sink-pdos:
     type: array
@@ -105,7 +106,8 @@ properties:
         * PDO_BATT
         * PDO_VAR
         * PDO_PPS_APDO
-      Valid range: 1 - 7
+      The USB PD specification allows for a maximum of 7 sink PDOs
+      for a Standard Power Range device.
 
   sink-vdos:
     type: array
@@ -121,7 +123,8 @@ properties:
         * VDO_PCABLE
         * VDO_ACABLE
         * VDO_VPD
-      Valid range: 3 - 6
+      The USB-PD specification requires baseline Discovery_Identity
+      response provides at least 3 and up to 6 VDOs.
 
   sink-vdos-v1:
     type: array
@@ -134,7 +137,8 @@ properties:
         * VDO_PRODUCT
         * VDO_CABLE
         * VDO_AMA
-      Valid range: 3 - 6
+      The USB-PD specification requires baseline Discovery_Identity
+      response provides at least 3 and up to 6 VDOs.
 
   op-sink-microwatt:
     type: int

--- a/dts/bindings/usb/usb-audio-feature-volume.yaml
+++ b/dts/bindings/usb/usb-audio-feature-volume.yaml
@@ -17,7 +17,8 @@ properties:
       attention: this attribute is a signed value.
       This attribute represents the maximum volume level.
       The range from +127.9961 dB (0x7FFF) down to -127.9961 dB (0x8001).
-      Valid range: 0 - 0xFFFF
+    min: 0
+    max: 0xFFFF
   volume-min:
     type: int
     default: 0xBA00
@@ -25,7 +26,8 @@ properties:
       attention: this attribute is a signed value.
       This attribute represents the minimum volume level.
       The range from +127.9961 dB (0x7FFF) down to -127.9961 dB (0x8001).
-      Valid range: 0 - 0xFFFF
+    min: 0
+    max: 0xFFFF
   volume-res:
     type: int
     default: 0x100
@@ -34,4 +36,5 @@ properties:
       This attribute represents the volume resolution(step).
       1 = 1/256 dB or 0.00390625 dB.
       0x100(256) = 1dB.
-      Valid range: 1 - 0x7FFF
+    min: 1
+    max: 0x7FFF


### PR DESCRIPTION
Remove the description line about the value range for `source-pdos` and `sink-pdos` DT property in `usb-c-connect` DT YAML file that is not applicable.

Use `min`/`max` DT properties instead of providing an informative only range description in the related DT bindings YAML file for USB-C `sink-vdos` and `sink-vdos-v1` DT properties.

Use `min`/`max` DT properties instead of providing an informative only range description in `usb-audio-hp` and `usb-audio-hs` compatible devices YAML file.

