### PR TITLE
drivers: stepper: step_dir_stepper_common: Fix missing include

### DIFF
--- a/drivers/stepper/step_dir/include/step_dir_stepper_common.h
+++ b/drivers/stepper/step_dir/include/step_dir_stepper_common.h
@@ -15,6 +15,8 @@
  */
 
 #include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+
 /**
  * @brief Common step direction stepper config.
  *


### PR DESCRIPTION
The file `step_dir_stepper_common.h` is missing an include for for `zephyr/drivers/gpio.h`. This PR fixes this.

Fixes #109838