### PR TITLE
arch/xtensa: Add CPU load support for Xtensa

### DIFF
--- a/arch/xtensa/core/cpu_idle.c
+++ b/arch/xtensa/core/cpu_idle.c
@@ -13,6 +13,10 @@ void arch_cpu_idle(void)
 	sys_trace_idle();
 #endif
 	__asm__ volatile ("waiti 0");
+
+#if defined(CONFIG_TRACING)
+	sys_trace_idle_exit();
+#endif
 }
 #endif
 
@@ -25,5 +29,9 @@ void arch_cpu_atomic_idle(unsigned int key)
 	__asm__ volatile ("waiti 0\n\t"
 			  "wsr.ps %0\n\t"
 			  "rsync" :: "a"(key));
+
+#if defined(CONFIG_TRACING)
+	sys_trace_idle_exit();
+#endif
 }
 #endif

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -363,7 +363,7 @@ config CS_TRACE_DEFMT
 
 config CPU_LOAD
 	select TRACING
-	depends on CPU_CORTEX_M || RISCV || CPU_CORTEX_A
+	depends on CPU_CORTEX_M || RISCV || CPU_CORTEX_A || XTENSA
 	depends on !SMP
 	bool "CPU load measurement"
 


### PR DESCRIPTION
Add cpu_load support for Xtensa.

Fix an issue in Xtensa tracing where sys_trace_idle_exit was not called, causing idle time to be collected incorrectly.