### PR TITLE
kernel: work: raise fatal error on work handler timeout

### DIFF
--- a/doc/kernel/services/other/fatal.rst
+++ b/doc/kernel/services/other/fatal.rst
@@ -181,6 +181,14 @@ Threads running in user mode are not permitted to invoke :c:func:`k_panic()`,
 and doing so will generate a kernel oops instead. Otherwise, the fatal error
 reason code generated will be ``K_ERR_KERNEL_PANIC``.
 
+Work Queue Timeout
+===================
+
+If :kconfig:option:`CONFIG_WORKQUEUE_WORK_TIMEOUT` is enabled and a work
+queue's handler runs longer than its configured timeout, the work queue
+thread is aborted and a fatal error is raised with a reason code of
+``K_ERR_WORK_TIMEOUT``.
+
 Exceptions
 **********
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -124,6 +124,17 @@ Kernel
   be used as futex address. The error -EINVAL can no longer happen on futex
   operations.
 
+* When :kconfig:option:`CONFIG_WORKQUEUE_WORK_TIMEOUT` is enabled and a work
+  item's handler exceeds its configured timeout, the work queue thread is
+  aborted and a fatal error with reason :c:enumerator:`K_ERR_WORK_TIMEOUT` is
+  now also raised. Previously, a non-essential queue's thread was aborted
+  silently, with no fatal error and no effect on the rest of the system.
+  Applications that relied on that silent behavior must now either accept the
+  new fatal-error escalation (optionally handling it with a
+  :c:func:`k_sys_fatal_error_handler` override) or enable
+  :kconfig:option:`CONFIG_RESET_ON_FATAL_ERROR` if a reboot rather than a halt
+  is desired.
+
 Boards
 ******
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -492,6 +492,7 @@ New APIs and options
 
 * Kernel
 
+  * :c:enumerator:`K_ERR_WORK_TIMEOUT`
   * :c:func:`k_thread_runtime_stats_is_enabled`
   * :c:func:`atomic_test_and_set_bit_to`
   * :c:macro:`K_MSGQ_DEFINE_STATIC`

--- a/include/zephyr/fatal_types.h
+++ b/include/zephyr/fatal_types.h
@@ -37,6 +37,9 @@ enum k_fatal_error_reason {
 	/** High severity software error */
 	K_ERR_KERNEL_PANIC,
 
+	/** A work queue handler exceeded its configured timeout */
+	K_ERR_WORK_TIMEOUT,
+
 	/** Arch specific fatal errors */
 	K_ERR_ARCH_START = 16
 };

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4834,6 +4834,30 @@ struct k_work_q {
  */
 };
 
+#if defined(CONFIG_WORKQUEUE_WORK_TIMEOUT)
+/**
+ * @brief Work queue timeout policy handler.
+ *
+ * Called from ISR context when a work handler exceeds its configured
+ * timeout. The culprit queue, work item, and handler function pointer
+ * are logged before this function is called.
+ *
+ * The default implementation either aborts the work queue thread
+ * (when @kconfig{CONFIG_WORKQUEUE_WORK_TIMEOUT_ABORT} is set) or
+ * performs a cold system reboot via sys_reboot()
+ * (when @kconfig{CONFIG_WORKQUEUE_WORK_TIMEOUT_REBOOT} is set).
+ *
+ * Applications may override this function to implement custom policy.
+ * As this is called from ISR context, only ISR-safe functions may be
+ * used (such as k_thread_abort() or sys_reboot()), and ISR-unsafe
+ * functions may not be used (such as sleep or block).
+ *
+ * @param queue  The work queue whose handler timed out.
+ * @param work   The work item whose handler timed out.
+ */
+void k_work_queue_timeout_cb(struct k_work_q *queue, struct k_work *work);
+#endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
+
 /* Provide the implementation for inline functions declared above */
 
 static inline bool k_work_is_pending(const struct k_work *work)

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4820,8 +4820,9 @@ struct k_work_queue_config {
 	 * If non-zero, and CONFIG_WORKQUEUE_WORK_TIMEOUT is enabled,
 	 * the work queue will monitor the duration of each work item.
 	 * If the work item handler takes longer than the specified
-	 * time to execute, the work queue thread will be aborted, and
-	 * an error will be logged if CONFIG_LOG is enabled.
+	 * time to execute, an error will be logged if CONFIG_LOG is
+	 * enabled, the work queue thread will be aborted, and a fatal
+	 * error with reason K_ERR_WORK_TIMEOUT will be raised.
 	 */
 	uint32_t work_timeout_ms;
 };

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -490,9 +490,35 @@ config WORKQUEUE_WORK_TIMEOUT
 	bool "Support workqueue work timeout monitoring"
 	help
 	  If enabled, the workqueue will monitor the duration of each work item.
-	  If the work item handler takes longer than the specified time to
-	  execute, the work queue thread will be aborted, and an error will be
-	  logged.
+	  If the work item handler takes longer than the configured timeout,
+	  the culprit queue, work item, and handler are logged and
+	  k_work_queue_timeout_cb() is invoked. Applications may override
+	  k_work_queue_timeout_cb() for custom policy. Per-queue timeout is
+	  configured via work_timeout_ms in k_work_queue_config.
+
+choice WORKQUEUE_WORK_TIMEOUT_ACTION
+	prompt "Action on work handler timeout"
+	depends on WORKQUEUE_WORK_TIMEOUT
+	default WORKQUEUE_WORK_TIMEOUT_ABORT
+	help
+	  Selects the default action taken when a work handler exceeds its
+	  configured timeout.
+
+config WORKQUEUE_WORK_TIMEOUT_ABORT
+	bool "Abort work queue thread"
+	help
+	  Abort the work queue thread when a handler exceeds its timeout.
+
+config WORKQUEUE_WORK_TIMEOUT_REBOOT
+	bool "Reboot system"
+	select REBOOT
+	help
+	  Perform a cold system reboot via sys_reboot(SYS_REBOOT_COLD) when
+	  a handler exceeds its timeout. Only bare-metal register-level
+	  operations are safe in the callback override as it runs from ISR
+	  context.
+
+endchoice
 
 menu "System Work Queue Options"
 config SYSTEM_WORKQUEUE_STACK_SIZE

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -523,8 +523,10 @@ config WORKQUEUE_WORK_TIMEOUT
 	help
 	  If enabled, the workqueue will monitor the duration of each work item.
 	  If the work item handler takes longer than the specified time to
-	  execute, the work queue thread will be aborted, and an error will be
-	  logged.
+	  execute, an error will be logged, the work queue thread will be
+	  aborted, and a fatal error with reason K_ERR_WORK_TIMEOUT will be
+	  raised. The @kconfig{CONFIG_RESET_ON_FATAL_ERROR} option controls
+	  whether this results in a system reset or a halt.
 
 menu "System Work Queue Options"
 config SYSTEM_WORKQUEUE_STACK_SIZE

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -18,8 +18,24 @@
 #include <scheduler.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/sys/reboot.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
+
+#if defined(CONFIG_WORKQUEUE_WORK_TIMEOUT)
+__weak void k_work_queue_timeout_cb(struct k_work_q *queue, struct k_work *work)
+{
+	ARG_UNUSED(work);
+#if defined(CONFIG_WORKQUEUE_WORK_TIMEOUT_REBOOT)
+	ARG_UNUSED(queue);
+	LOG_PANIC();
+	sys_reboot(SYS_REBOOT_COLD);
+#else
+	k_thread_abort(queue->thread_id);
+#endif
+}
+#endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 
 static inline void flag_clear(uint32_t *flagp,
 			      uint32_t bit)
@@ -643,7 +659,7 @@ static void work_timeout_handler(struct _timeout *record)
 	LOG_ERR("queue %p%s%s blocked by work %p with handler %p",
 		queue, space, name, work, handler);
 
-	k_thread_abort(queue->thread_id);
+	k_work_queue_timeout_cb(queue, work);
 }
 
 static void work_timeout_start_locked(struct k_work_q *queue, struct k_work *work)

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -640,6 +640,13 @@ static void work_timeout_handler(struct _timeout *record)
 		queue, space, name, work, handler);
 
 	k_thread_abort(queue->thread_id);
+
+	/*
+	 * For an essential queue, k_thread_abort() above already panics
+	 * (via z_thread_abort()'s essential-thread check) and never returns,
+	 * so this line only runs for non-essential queues.
+	 */
+	z_except_reason(K_ERR_WORK_TIMEOUT);
 }
 
 static void work_timeout_start_locked(struct k_work_q *queue, struct k_work *work)

--- a/tests/kernel/workq/work_queue/tests.yaml
+++ b/tests/kernel/workq/work_queue/tests.yaml
@@ -4,10 +4,3 @@ tests:
     tags:
       - kernel
       - workqueue
-  kernel.workqueue.work_timeout:
-    min_flash: 34
-    tags:
-      - kernel
-      - workqueue
-    extra_configs:
-      - CONFIG_WORKQUEUE_WORK_TIMEOUT=y

--- a/tests/kernel/workq/work_timeout/CMakeLists.txt
+++ b/tests/kernel/workq/work_timeout/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(work_timeout)
+
+file(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+target_include_directories(app PRIVATE
+  ${ZEPHYR_BASE}/kernel/include
+  ${ZEPHYR_BASE}/arch/${ARCH}/include
+  )

--- a/tests/kernel/workq/work_timeout/prj.conf
+++ b/tests/kernel/workq/work_timeout/prj.conf
@@ -1,0 +1,6 @@
+CONFIG_ZTEST=y
+CONFIG_ASSERT=y
+
+# Not SMP-safe: k_sys_fatal_error_handler() assumes it's dealing with the
+# thread the timer interrupted on a single core.
+CONFIG_MP_MAX_NUM_CPUS=1

--- a/tests/kernel/workq/work_timeout/src/work_timeout.c
+++ b/tests/kernel/workq/work_timeout/src/work_timeout.c
@@ -6,6 +6,11 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
+#include <zephyr/tc_util.h>
+
+#if defined(CONFIG_WORKQUEUE_WORK_TIMEOUT)
+#include <kernel_internal.h>
+#endif
 
 #define TEST_WORK_TIMEOUT_MS     100
 #define TEST_WORK_DURATION_MS    (TEST_WORK_TIMEOUT_MS / 2)
@@ -32,6 +37,21 @@ static void test_work_handler_blocking(struct k_work *work)
 
 static K_WORK_DEFINE(test_work_blocking, test_work_handler_blocking);
 
+#if defined(CONFIG_WORKQUEUE_WORK_TIMEOUT)
+/* Fires from ISR context. Report the verdict and halt here directly. */
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf)
+{
+	int rv = (reason == K_ERR_WORK_TIMEOUT) ? TC_PASS : TC_FAIL;
+
+	ARG_UNUSED(esf);
+
+	TC_PRINT("work timeout fatal handler: reason %d\n", reason);
+	TC_END_RESULT_CUSTOM(rv, "workqueue_work_timeout_test_workq_work_timeout");
+	TC_END_REPORT(rv);
+	arch_system_halt(reason);
+}
+#endif /* CONFIG_WORKQUEUE_WORK_TIMEOUT */
+
 static void *test_setup(void)
 {
 	const struct k_work_queue_config config = {
@@ -41,11 +61,8 @@ static void *test_setup(void)
 		.work_timeout_ms = TEST_WORK_TIMEOUT_MS,
 	};
 
-	k_work_queue_start(&test_workq,
-			   test_workq_stack,
-			   K_KERNEL_STACK_SIZEOF(test_workq_stack),
-			   0,
-			   &config);
+	k_work_queue_start(&test_workq, test_workq_stack, K_KERNEL_STACK_SIZEOF(test_workq_stack),
+			   0, &config);
 
 	return NULL;
 }
@@ -66,11 +83,18 @@ ZTEST_SUITE(workqueue_work_timeout, NULL, test_setup, NULL, NULL, NULL);
  * - Submit several work items that each run for less than the timeout.
  * - Confirm the work queue thread is not aborted while processing them.
  * - Submit a work item whose handler blocks forever.
- * - Join the work queue thread.
+ * - With CONFIG_WORKQUEUE_WORK_TIMEOUT disabled, join the work queue thread.
+ * - With CONFIG_WORKQUEUE_WORK_TIMEOUT enabled, wait past the timeout instead:
+ *   the resulting fatal error reports the test verdict and halts from
+ *   k_sys_fatal_error_handler() (see above), so this function never returns
+ *   in that configuration.
  *
  * Expected result:
- * - With CONFIG_WORKQUEUE_WORK_TIMEOUT enabled the thread is aborted (join
- *   returns 0); otherwise the join times out with -EAGAIN.
+ * - With CONFIG_WORKQUEUE_WORK_TIMEOUT disabled, the join times out with
+ *   -EAGAIN (the thread is never aborted).
+ * - With CONFIG_WORKQUEUE_WORK_TIMEOUT enabled, the thread is aborted and a
+ *   fatal error with reason K_ERR_WORK_TIMEOUT is raised; the test verdict is
+ *   reported from k_sys_fatal_error_handler() instead of this function.
  *
  * @see k_work_queue_start()
  * @see k_work_submit_to_queue()
@@ -78,8 +102,6 @@ ZTEST_SUITE(workqueue_work_timeout, NULL, test_setup, NULL, NULL, NULL);
  */
 ZTEST(workqueue_work_timeout, test_workq_work_timeout)
 {
-	int ret;
-
 	/* Submit multiple items which take less time than TEST_WORK_TIMEOUT_MS each */
 	zassert_equal(k_work_submit_to_queue(&test_workq, &test_work0), 1);
 	zassert_equal(k_work_submit_to_queue(&test_workq, &test_work1), 1);
@@ -95,14 +117,17 @@ ZTEST(workqueue_work_timeout, test_workq_work_timeout)
 	/* Submit single item which takes longer than TEST_WORK_TIMEOUT_MS */
 	zassert_equal(k_work_submit_to_queue(&test_workq, &test_work_blocking), 1);
 
-	/*
-	 * Submitted item shall cause the work to time out and the workqueue thread be
-	 * aborted if CONFIG_WORKQUEUE_WORK_TIMEOUT is enabled.
-	 */
-	ret = k_thread_join(test_workq.thread_id, TEST_WORK_BLOCKING_DELAY);
 	if (IS_ENABLED(CONFIG_WORKQUEUE_WORK_TIMEOUT)) {
-		zassert_equal(ret, 0);
+		/*
+		 * The blocking item's timeout raises a fatal error from ISR
+		 * context. k_sys_fatal_error_handler() above reports the verdict
+		 * and halts directly; control does not return here. If it does,
+		 * the timeout path did not fire as expected.
+		 */
+		k_sleep(TEST_WORK_BLOCKING_DELAY);
+		zassert_unreachable("work timeout did not raise a fatal error");
 	} else {
-		zassert_equal(ret, -EAGAIN);
+		zassert_equal(k_thread_join(test_workq.thread_id, TEST_WORK_BLOCKING_DELAY),
+			      -EAGAIN);
 	}
 }

--- a/tests/kernel/workq/work_timeout/tests.yaml
+++ b/tests/kernel/workq/work_timeout/tests.yaml
@@ -1,0 +1,13 @@
+tests:
+  kernel.workqueue.work_timeout.disabled:
+    min_flash: 34
+    tags:
+      - kernel
+      - workqueue
+  kernel.workqueue.work_timeout:
+    min_flash: 34
+    tags:
+      - kernel
+      - workqueue
+    extra_configs:
+      - CONFIG_WORKQUEUE_WORK_TIMEOUT=y


### PR DESCRIPTION
Essential queues already reach k_sys_fatal_error_handler() via k_thread_abort()'s panic path. Non-essential queues did not: the thread was aborted silently, with no fatal error raised. Raise one with reason K_ERR_WORK_TIMEOUT after the abort so both go through the same existing policy.

This [comment](https://github.com/zephyrproject-rtos/zephyr/issues/107133#issuecomment-4529243289) states that using task_wdt would be a layering violation so this approach solves the original issue reported

Fixes: #107133