### PR TITLE
input: replace a bunch of BUILD_ASSERT with min/max

### DIFF
--- a/drivers/input/input_adafruit_seesaw_gamepad.c
+++ b/drivers/input/input_adafruit_seesaw_gamepad.c
@@ -251,7 +251,6 @@ static int seesaw_gamepad_init(const struct device *dev)
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.polling_interval_ms = DT_INST_PROP(inst, polling_interval_ms),                    \
 	};                                                                                         \
-	BUILD_ASSERT(DT_INST_PROP(inst, polling_interval_ms) > 8);                                 \
                                                                                                    \
 	static struct seesaw_gamepad_data seesaw_data_##inst;                                      \
 	DEVICE_DT_INST_DEFINE(inst, &seesaw_gamepad_init, NULL, &seesaw_data_##inst,               \

--- a/drivers/input/input_bee_keyscan.c
+++ b/drivers/input/input_bee_keyscan.c
@@ -35,11 +35,7 @@ LOG_MODULE_REGISTER(bee_keyscan, CONFIG_INPUT_LOG_LEVEL);
 #error "Unsupported Realtek Bee SoC series"
 #endif
 
-#define BEE_KEYSCAN_MAX_ROWS      12
-#define BEE_KEYSCAN_MAX_COLS      20
 #define BEE_KEYSCAN_SRC_CLK       5000000
-#define BEE_KEYSCAN_MAX_SCAN_DIV  65535
-#define BEE_KEYSCAN_MAX_DELAY_DIV 255
 #define BEE_KEYSCAN_MAX_TICKS     511
 
 #define BEE_KEYSCAN_DEFAULT_PRE_GUARD_CNT 6
@@ -350,14 +346,6 @@ static int bee_keyscan_init(const struct device *dev)
 #endif
 
 #define BEE_KEYSCAN_INIT(index)                                                                    \
-	BUILD_ASSERT(DT_INST_PROP(index, row_size) <= BEE_KEYSCAN_MAX_ROWS,                        \
-		     "DT error: 'row-size' exceeds hardware limit (12)");                          \
-	BUILD_ASSERT(DT_INST_PROP(index, col_size) <= BEE_KEYSCAN_MAX_COLS,                        \
-		     "DT error: 'col-size' exceeds hardware limit (20)");                          \
-	BUILD_ASSERT(DT_INST_PROP(index, scan_div) <= BEE_KEYSCAN_MAX_SCAN_DIV,                    \
-		     "DT error: 'scan-div' exceeds limit (65535)");                                \
-	BUILD_ASSERT(DT_INST_PROP(index, delay_div) <= BEE_KEYSCAN_MAX_DELAY_DIV,                  \
-		     "DT error: 'delay-div' exceeds limit (255)");                                 \
 	BEE_INPUT_KEYSCAN_ASSERT_SCAN_INTERVAL(index);                                             \
 	BUILD_ASSERT(BEE_KEYSCAN_CALC_US_TO_TICKS(index, release_time_us, 0) <=                    \
 			     BEE_KEYSCAN_MAX_TICKS,                                                \

--- a/drivers/input/input_crsf.c
+++ b/drivers/input/input_crsf.c
@@ -508,8 +508,6 @@ static int input_crsf_init(const struct device *dev)
 }
 
 #define INPUT_CHANNEL_CHECK(input_channel_id)                                                      \
-	BUILD_ASSERT(IN_RANGE(DT_PROP(input_channel_id, channel), 1, 16),                          \
-		     "invalid channel number");                                                    \
 	BUILD_ASSERT(DT_PROP(input_channel_id, type) == INPUT_EV_ABS ||                            \
 			     DT_PROP(input_channel_id, type) == INPUT_EV_KEY ||                    \
 			     DT_PROP(input_channel_id, type) == INPUT_EV_MSC,                      \

--- a/drivers/input/input_cst8xx.c
+++ b/drivers/input/input_cst8xx.c
@@ -402,19 +402,6 @@ static int cst8xx_pm_action(const struct device *dev, enum pm_device_action acti
 
 /* clang-format off */
 #define CST8XX_DEFINE(index)                                                                       \
-	IF_ENABLED(CONFIG_PM_DEVICE, (                                                             \
-		BUILD_ASSERT(DT_INST_PROP(index, scan_th) >= 1 &&                                  \
-				DT_INST_PROP(index, scan_th) <= 255,                               \
-				"scan_th must be >= 1 and <= 255");                                \
-		BUILD_ASSERT(DT_INST_PROP(index, scan_freq) >= 1 &&                                \
-				DT_INST_PROP(index, scan_freq) <= 255,                             \
-				"scan_freq must be >= 1 and <= 255");                              \
-		BUILD_ASSERT(DT_INST_PROP(index, scan_win) <= 255,                                 \
-				"scan_win must be <= 255");                                        \
-		BUILD_ASSERT(DT_INST_PROP(index, scan_i_dac) >= 1 &&                               \
-				DT_INST_PROP(index, scan_i_dac) <= 255,                            \
-				"scan_i_dac must be >= 1 and <= 255");                             \
-	))                                                                                         \
 	static struct cst8xx_data cst8xx_data_##index;                                             \
 	static const struct cst8xx_config cst8xx_config_##index = {                                \
 		.i2c = I2C_DT_SPEC_INST_GET(index),                                                \

--- a/drivers/input/input_ite_it51xxx_kbd.c
+++ b/drivers/input/input_ite_it51xxx_kbd.c
@@ -244,8 +244,6 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_PM_DEVICE_SYSTEM_MANAGED) || IS_ENABLED(CONFIG_P
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "only one ite,it51xxx-kbd compatible node can be supported");
-BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, row_size), 1, 8), "invalid row-size");
-BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, col_size), 1, 18), "invalid col-size");
 BUILD_ASSERT(DT_INST_PROP(0, col_size) < 17 ||
 	     DT_INST_NODE_HAS_PROP(0, kso16_gpios),
 	     "kso16-gpios must be defined in dts when col-size is 17 or 18");

--- a/drivers/input/input_ite_it8801_kbd.c
+++ b/drivers/input/input_ite_it8801_kbd.c
@@ -222,7 +222,5 @@ static const struct input_kbd_matrix_api kbd_it8801_api = {
 	DEVICE_DT_INST_DEFINE(inst, &kbd_it8801_init, PM_DEVICE_DT_INST_GET(inst),                 \
 			      &kbd_it8801_data_##inst, &kbd_it8801_cfg_##inst, POST_KERNEL,        \
 			      CONFIG_MFD_INIT_PRIORITY, NULL);                                     \
-	BUILD_ASSERT(IN_RANGE(DT_INST_PROP(inst, row_size), 1, 8), "invalid row-size");            \
-	BUILD_ASSERT(IN_RANGE(DT_INST_PROP(inst, col_size), 1, 19), "invalid col-size");
 
 DT_INST_FOREACH_STATUS_OKAY(INPUT_IT8801_INIT)

--- a/drivers/input/input_ite_it8xxx2_kbd.c
+++ b/drivers/input/input_ite_it8xxx2_kbd.c
@@ -272,8 +272,6 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_PM_DEVICE_SYSTEM_MANAGED) ||
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "only one ite,it8xxx2-kbd compatible node can be supported");
-BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, row_size), 1, 8), "invalid row-size");
-BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, col_size), 1, 18), "invalid col-size");
 BUILD_ASSERT(DT_INST_PROP(0, col_size) < 17 ||
 	     DT_INST_NODE_HAS_PROP(0, kso16_gpios),
 	     "kso16-gpios must be defined in dts when col-size is 17 or 18");

--- a/drivers/input/input_modulino_buttons.c
+++ b/drivers/input/input_modulino_buttons.c
@@ -79,10 +79,6 @@ static int modulino_buttons_init(const struct device *dev)
 #define MODULINO_BUTTONS_INIT(inst)							\
 	BUILD_ASSERT(DT_INST_PROP_LEN(inst, zephyr_codes) == MODULINO_NUM_BUTTONS,	\
 		     "zephyr,codes must specify three key codes");			\
-	BUILD_ASSERT(DT_INST_PROP_BY_IDX(inst, zephyr_codes, 0) <= UINT16_MAX &&	\
-		     DT_INST_PROP_BY_IDX(inst, zephyr_codes, 1) <= UINT16_MAX &&	\
-		     DT_INST_PROP_BY_IDX(inst, zephyr_codes, 2) <= UINT16_MAX,		\
-		     "invalid input code");						\
 											\
 	static const struct modulino_buttons_config modulino_buttons_cfg_##inst = {	\
 		.bus = I2C_DT_SPEC_GET(DT_INST_PARENT(inst)),				\

--- a/drivers/input/input_npcx_kbd.c
+++ b/drivers/input/input_npcx_kbd.c
@@ -244,5 +244,3 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_PM_DEVICE_SYSTEM_MANAGED) ||
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "only one nuvoton,npcx-kbd compatible node can be supported");
-BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, row_size), 1, 8), "invalid row-size");
-BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, col_size), 1, 18), "invalid col-size");

--- a/drivers/input/input_nunchuk.c
+++ b/drivers/input/input_nunchuk.c
@@ -157,7 +157,6 @@ static int nunchuk_init(const struct device *dev)
 		.i2c_bus = I2C_DT_SPEC_INST_GET(inst),                                             \
 		.polling_interval_ms = DT_INST_PROP(inst, polling_interval_ms),                    \
 	};                                                                                         \
-	BUILD_ASSERT(DT_INST_PROP(inst, polling_interval_ms) > 20);                                \
                                                                                                    \
 	static struct nunchuk_data nunchuk_data_##inst;                                            \
                                                                                                    \

--- a/drivers/input/input_pat912x.c
+++ b/drivers/input/input_pat912x.c
@@ -325,10 +325,6 @@ static int pat912x_pm_action(const struct device *dev,
 #endif
 
 #define PAT912X_INIT(n)								\
-	BUILD_ASSERT(IN_RANGE(DT_INST_PROP_OR(n, res_x_cpi, 0), 0, RES_MAX),	\
-		     "invalid res-x-cpi");					\
-	BUILD_ASSERT(IN_RANGE(DT_INST_PROP_OR(n, res_y_cpi, 0), 0, RES_MAX),	\
-		     "invalid res-y-cpi");					\
 	BUILD_ASSERT(DT_INST_PROP(n, sleep1_enable) ||				\
 		     !DT_INST_PROP(n, sleep2_enable),				\
 		     "invalid sleep configuration");				\

--- a/drivers/input/input_paw32xx.c
+++ b/drivers/input/input_paw32xx.c
@@ -443,9 +443,6 @@ static int paw32xx_pm_action(const struct device *dev,
 			  SPI_MODE_CPOL | SPI_MODE_CPHA | SPI_TRANSFER_MSB)
 
 #define PAW32XX_INIT(n)								\
-	BUILD_ASSERT(IN_RANGE(DT_INST_PROP_OR(n, res_cpi, RES_MIN),		\
-			      RES_MIN, RES_MAX), "invalid res-cpi");		\
-										\
 	static const struct paw32xx_config paw32xx_cfg_##n = {			\
 		.spi = SPI_DT_SPEC_INST_GET(n, PAW32XX_SPI_MODE),		\
 		.motion_gpio = GPIO_DT_SPEC_INST_GET(n, motion_gpios),		\

--- a/drivers/input/input_pinnacle.c
+++ b/drivers/input/input_pinnacle.c
@@ -925,12 +925,6 @@ static int pinnacle_init(const struct device *dev)
 		     "active-range-x-min must be less than active-range-x-max");                   \
 	BUILD_ASSERT(DT_INST_PROP(inst, active_range_y_min) <                                      \
 			     DT_INST_PROP(inst, active_range_y_max),                               \
-		     "active_range-y-min must be less than active_range-y-max");                   \
-	BUILD_ASSERT(DT_INST_PROP(inst, scaling_x_resolution) > 0,                                 \
-		     "scaling-x-resolution must be positive");                                     \
-	BUILD_ASSERT(DT_INST_PROP(inst, scaling_y_resolution) > 0,                                 \
-		     "scaling-y-resolution must be positive");                                     \
-	BUILD_ASSERT(IN_RANGE(DT_INST_PROP(inst, idle_packets_count), 0, UINT8_MAX),               \
-		     "idle-packets-count must be in range [0:255]");
+		     "active_range-y-min must be less than active_range-y-max");
 
 DT_INST_FOREACH_STATUS_OKAY(PINNACLE_DEFINE)

--- a/drivers/input/input_pmw3610.c
+++ b/drivers/input/input_pmw3610.c
@@ -565,9 +565,6 @@ static int pmw3610_pm_action(const struct device *dev,
 			  SPI_MODE_CPOL | SPI_MODE_CPHA | SPI_TRANSFER_MSB)
 
 #define PMW3610_INIT(n)								\
-	BUILD_ASSERT(IN_RANGE(DT_INST_PROP_OR(n, res_cpi, RES_MIN),		\
-			      RES_MIN, RES_MAX), "invalid res-cpi");		\
-										\
 	static const struct pmw3610_config pmw3610_cfg_##n = {			\
 		.spi = SPI_DT_SPEC_INST_GET(n, PMW3610_SPI_MODE),		\
 		.motion_gpio = GPIO_DT_SPEC_INST_GET(n, motion_gpios),		\

--- a/drivers/input/input_realtek_rts5912_kbd.c
+++ b/drivers/input/input_realtek_rts5912_kbd.c
@@ -301,5 +301,3 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_PM_DEVICE_SYSTEM_MANAGED) || IS_ENABLED(CONFIG_P
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "only one realtek,rts5912-kbd compatible node can be supported");
-BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, row_size), 1, 9), "invalid row-size");
-BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, col_size), 1, 19), "invalid col-size");

--- a/drivers/input/input_sbus.c
+++ b/drivers/input/input_sbus.c
@@ -341,8 +341,6 @@ static int input_sbus_init(const struct device *dev)
 }
 
 #define INPUT_CHANNEL_CHECK(input_channel_id)                                                      \
-	BUILD_ASSERT(IN_RANGE(DT_PROP(input_channel_id, channel), 1, 16),                          \
-		     "invalid channel number");                                                    \
 	BUILD_ASSERT(DT_PROP(input_channel_id, type) == INPUT_EV_ABS ||                            \
 			     DT_PROP(input_channel_id, type) == INPUT_EV_KEY ||                    \
 			     DT_PROP(input_channel_id, type) == INPUT_EV_MSC,                      \

--- a/drivers/input/input_xec_kbd.c
+++ b/drivers/input/input_xec_kbd.c
@@ -212,5 +212,3 @@ DEVICE_DT_INST_DEFINE(0, xec_kbd_init,
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "only one microchip,xec-kbd compatible node can be supported");
-BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, row_size), 1, 8), "invalid row-size");
-BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, col_size), 1, 18), "invalid col-size");

--- a/drivers/input/input_xpt2046.c
+++ b/drivers/input/input_xpt2046.c
@@ -256,10 +256,5 @@ static int xpt2046_init(const struct device *dev)
 		     "min_x must be less than max_x");                                             \
 	BUILD_ASSERT(DT_INST_PROP(index, min_y) < DT_INST_PROP(index, max_y),                      \
 		     "min_y must be less than max_y");                                             \
-	BUILD_ASSERT(DT_INST_PROP(index, z_threshold) > 10, "Too small threshold");                \
-	BUILD_ASSERT(DT_INST_PROP(index, touchscreen_size_x) > 1 &&                                \
-			     DT_INST_PROP(index, touchscreen_size_y) > 1,                          \
-		     "Screen size undefined");                                                     \
-	BUILD_ASSERT(DT_INST_PROP(index, reads) > 0, "Number of reads must be at least one");
 
 DT_INST_FOREACH_STATUS_OKAY(XPT2046_INIT)

--- a/dts/bindings/input/adafruit,seesaw-gamepad.yaml
+++ b/dts/bindings/input/adafruit,seesaw-gamepad.yaml
@@ -20,3 +20,4 @@ properties:
     description: |
       Interval between consecutive polls in milliseconds.
       Defaults to 16 ms (~60 Hz).
+    min: 9

--- a/dts/bindings/input/arduino,modulino-buttons.yaml
+++ b/dts/bindings/input/arduino,modulino-buttons.yaml
@@ -12,6 +12,8 @@ properties:
     description: |
       Key codes to emit, the module has three buttons so this must specify
       three key codes.
+    min: 0
+    max: 65535
 
   poll-period-ms:
     type: int

--- a/dts/bindings/input/cirque,pinnacle-common.yaml
+++ b/dts/bindings/input/cirque,pinnacle-common.yaml
@@ -43,6 +43,8 @@ properties:
       it detected. An application can count these packets in order to detect
       taps. When set to 0, no empty packets are sent. Supported values from 0
       to 255.
+    min: 0
+    max: 255
 
   sleep-mode-enable:
     type: boolean
@@ -91,11 +93,13 @@ properties:
     type: int
     default: 1024
     description: Resolution for the X axis.
+    min: 1
 
   scaling-y-resolution:
     type: int
     default: 1024
     description: Resolution for the Y axis.
+    min: 1
 
   invert-x:
     type: boolean

--- a/dts/bindings/input/futaba,sbus.yaml
+++ b/dts/bindings/input/futaba,sbus.yaml
@@ -29,7 +29,8 @@ child-binding:
       required: true
       description: |
         SBUS input channel
-        Valid range: 1 - 16
+      min: 1
+      max: 16
     type:
       type: int
       required: true

--- a/dts/bindings/input/hynitron,cst8xx.yaml
+++ b/dts/bindings/input/hynitron,cst8xx.yaml
@@ -39,8 +39,10 @@ properties:
     type: int
     default: 48
     description:
-      Low-power scan wake-up threshold. Smaller = more sensitive. Range 1–255.
+      Low-power scan wake-up threshold. Smaller = more sensitive.
       The default value is specified in the data sheet.
+    min: 1
+    max: 255
 
   scan-win:
     type: int
@@ -50,21 +52,27 @@ properties:
       The datasheet is mentiones values from 0 to 3 as valid options with 3 as default.
       But you can go higher as it is an 8-bit register and higher values than 3 seem to
       work fine. They improve the sensitivity further at the cost of power consumption.
+    min: 0
+    max: 255
 
   scan-freq:
     type: int
     default: 7
     description:
-      Frequency for low-power scan. Smaller = more sensitive. Range 1–255.
+      Frequency for low-power scan. Smaller = more sensitive.
       The default value is specified in the data sheet.
+    min: 1
+    max: 255
 
   scan-i-dac:
     type: int
     default: 200
     description:
-      Current for low-power scan. Smaller = more sensitive. Range 1–255.
+      Current for low-power scan. Smaller = more sensitive.
       The default value is not specified in the data sheet. Instead, 200 is
       chosen as a reasonable default based on typical usage.
+    min: 1
+    max: 255
 
   auto-sleep-time:
     type: int

--- a/dts/bindings/input/ite,it51xxx-kbd.yaml
+++ b/dts/bindings/input/ite,it51xxx-kbd.yaml
@@ -49,6 +49,10 @@ properties:
 
   row-size:
     required: true
+    min: 1
+    max: 8
 
   col-size:
     required: true
+    min: 1
+    max: 18

--- a/dts/bindings/input/ite,it8801-kbd.yaml
+++ b/dts/bindings/input/ite,it8801-kbd.yaml
@@ -21,6 +21,10 @@ properties:
 
   row-size:
     required: true
+    min: 1
+    max: 8
 
   col-size:
     required: true
+    min: 1
+    max: 19

--- a/dts/bindings/input/ite,it8xxx2-kbd.yaml
+++ b/dts/bindings/input/ite,it8xxx2-kbd.yaml
@@ -49,6 +49,10 @@ properties:
 
   row-size:
     required: true
+    min: 1
+    max: 8
 
   col-size:
     required: true
+    min: 1
+    max: 18

--- a/dts/bindings/input/microchip,xec-kbd.yaml
+++ b/dts/bindings/input/microchip,xec-kbd.yaml
@@ -33,6 +33,10 @@ properties:
 
   row-size:
     required: true
+    min: 1
+    max: 8
 
   col-size:
     required: true
+    min: 1
+    max: 18

--- a/dts/bindings/input/nintendo,nunchuk.yaml
+++ b/dts/bindings/input/nintendo,nunchuk.yaml
@@ -13,3 +13,4 @@ properties:
     default: 50
     description: |
       Interval between two reads, in ms. The interval must be greater than 21 ms. Default to 50 ms.
+    min: 21

--- a/dts/bindings/input/nuvoton,npcx-kbd.yaml
+++ b/dts/bindings/input/nuvoton,npcx-kbd.yaml
@@ -32,6 +32,10 @@ properties:
 
   row-size:
     required: true
+    min: 1
+    max: 8
 
   col-size:
     required: true
+    min: 1
+    max: 18

--- a/dts/bindings/input/pixart,pat912x.yaml
+++ b/dts/bindings/input/pixart,pat912x.yaml
@@ -31,12 +31,16 @@ properties:
     description: |
       CPI resolution for the X axis, range 0 to 1275, rounded down to the
       closest supported value in increments of 5.
+    min: 0
+    max: 1275
 
   res-y-cpi:
     type: int
     description: |
       CPI resolution for the Y axis, range 0 to 1275, rounded down to the
       closest supported value in increments of 5.
+    min: 0
+    max: 1275
 
   invert-x:
     type: boolean

--- a/dts/bindings/input/pixart,paw32xx.yaml
+++ b/dts/bindings/input/pixart,paw32xx.yaml
@@ -33,6 +33,8 @@ properties:
     description: |
       CPI resolution for the sensor. This can also be changed in runtime using
       the paw32xx_set_resolution() API.
+    min: 608
+    max: 4826
 
   invert-x:
     type: boolean

--- a/dts/bindings/input/pixart,pmw3610.yaml
+++ b/dts/bindings/input/pixart,pmw3610.yaml
@@ -39,6 +39,8 @@ properties:
       CPI resolution for the sensor, range from 200 to 3200, rounded down to
       the closest supported value in increments of 200. This can also be
       changed in runtime using the pmw3610_set_resolution() API.
+    min: 200
+    max: 3200
 
   invert-x:
     type: boolean

--- a/dts/bindings/input/realtek,bee-keyscan.yaml
+++ b/dts/bindings/input/realtek,bee-keyscan.yaml
@@ -35,6 +35,8 @@ properties:
     description: |
       Actual row size of the external keyscan matrix.
       Hardware supports up to 12 rows.
+    min: 1
+    max: 12
 
   col-size:
     required: true
@@ -42,6 +44,8 @@ properties:
     description: |
       Actual column size of the external keyscan matrix.
       Hardware supports up to 20 columns.
+    min: 1
+    max: 20
 
   scan-div:
     type: int
@@ -50,7 +54,8 @@ properties:
       Clock divider for the Keyscan scanning clock.
       Formula: scan_clock = source_clock / (scan-div + 1).
       Assuming the source_clock is 5MHz, the default value 1 results in a 2.5MHz scan_clock.
-      Maximum value: 65535.
+    min: 0
+    max: 65535
 
   delay-div:
     type: int
@@ -59,12 +64,13 @@ properties:
       Clock divider for the Keyscan delay clock (used for debounce, poll interval and release).
       Formula: delay_clock = scan_clock / (delay-div + 1).
       With the default 2.5MHz scan_clock, the default value 49 results in a 50kHz delay_clock.
-      Maximum value: 255.
       poll-period-us and release-time-us each depend on the delay_clock period
       (T_delay = 1 / delay_clock), and each has its own maximum of 512 ticks.
       With the default 50kHz delay_clock (20us period), all three properties have:
         - Resolution: 20us
         - Range: 0 to 10240us
+    min: 0
+    max: 255
 
   poll-period-us:
     description: |

--- a/dts/bindings/input/realtek,rts5912-kbd.yaml
+++ b/dts/bindings/input/realtek,rts5912-kbd.yaml
@@ -22,9 +22,13 @@ properties:
 
   row-size:
     required: true
+    min: 1
+    max: 9
 
   col-size:
     required: true
+    min: 1
+    max: 19
 
   kso-ignore-mask:
     type: int

--- a/dts/bindings/input/tbs,crsf.yaml
+++ b/dts/bindings/input/tbs,crsf.yaml
@@ -67,7 +67,8 @@ child-binding:
       required: true
       description: |
         CRSF input channel
-        Valid range: 1 - 16
+      min: 1
+      max: 16
     type:
       type: int
       required: true

--- a/dts/bindings/input/xptek,xpt2046.yaml
+++ b/dts/bindings/input/xptek,xpt2046.yaml
@@ -16,11 +16,13 @@ properties:
     type: int
     required: true
     description: horizontal resolution of screen
+    min: 1
 
   touchscreen-size-y:
     type: int
     required: true
     description: vertical resolution of screen
+    min: 1
 
   min-x:
     type: int
@@ -46,8 +48,10 @@ properties:
     type: int
     description: Z value threshold to trigger a touch
     default: 100
+    min: 11
 
   reads:
     type: int
     description: How many reads per touch to average the value
     default: 1
+    min: 1

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -336,6 +336,16 @@
 				compatible = "adafruit,seesaw-gamepad";
 				reg = <0xe>;
 			};
+
+			modulino-buttons@f {
+				compatible = "i2c-device";
+				reg = <0xf>;
+
+				modulino_buttons {
+					compatible = "arduino,modulino-buttons";
+					zephyr,codes = <0>, <1>, <2>;
+				};
+			};
 		};
 
 		spi@2 {


### PR DESCRIPTION
Replace most BUILD_ASSERT on property values with min/max checks on the binding itself.

Add a missing driver to build_all as well.