### PR TITLE
stepper: replace a bunch of BUILD_ASSERT with min/max

### DIFF
--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_stepper_ctrl.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_stepper_ctrl.c
@@ -472,7 +472,6 @@ static DEVICE_API(stepper_ctrl, tmc50xx_stepper_ctrl_api) = {
 };
 
 #define TMC50XX_STEPPER_CTRL_DEFINE(inst)                                                         \
-	IF_ENABLED(CONFIG_STEPPER_ADI_TMC50XX_RAMP_GEN, (CHECK_RAMP_DT_DATA(DT_DRV_INST(inst))));  \
 	static const struct tmc50xx_stepper_ctrl_config tmc50xx_stepper_ctrl_cfg_##inst = {      \
 		.controller = DEVICE_DT_GET(DT_PARENT(DT_DRV_INST(inst))),                         \
 		.index = DT_INST_PROP(inst, idx),                                                  \

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_stepper_ctrl.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_stepper_ctrl.c
@@ -487,7 +487,6 @@ static DEVICE_API(stepper_ctrl, tmc51xx_stepper_ctrl_api) = {
 };
 
 #define TMC51XX_STEPPER_CTRL_DEFINE(inst)                                                         \
-	IF_ENABLED(CONFIG_STEPPER_ADI_TMC51XX_RAMP_GEN,	(CHECK_RAMP_DT_DATA(inst)));               \
 	static const struct tmc51xx_stepper_ctrl_config tmc51xx_stepper_ctrl_cfg_##inst = {      \
 		.controller = DEVICE_DT_GET(DT_PARENT(DT_DRV_INST(inst))),                         \
 		.sg_threshold_velocity = DT_INST_PROP(inst, stallguard_threshold_velocity),        \

--- a/dts/bindings/stepper/adi/adi,tmc51xx-uart.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc51xx-uart.yaml
@@ -25,7 +25,8 @@ properties:
     type: int
     description: |
         UART device address for TMC51XX in UART mode.
-        Valid range: 0 - 253
+    min: 0
+    max: 253
 
 examples:
   - |

--- a/dts/bindings/stepper/adi/adi,trinamic-ramp-generator.yaml
+++ b/dts/bindings/stepper/adi/adi,trinamic-ramp-generator.yaml
@@ -14,12 +14,16 @@ properties:
       Normally, set VSTOP ≥ VSTART! VSTART may be
       set to a higher value, when motion distance is
       sufficient to allow deceleration to VSTOP.
+    min: 0
+    max: 0x3FFFF
 
   a1:
     type: int
     default: 0
     description: |
       First acceleration between VSTART and V1 in [µsteps/ta²](unsigned)
+    min: 0
+    max: 0xFFFF
 
   v1:
     type: int
@@ -28,6 +32,8 @@ properties:
       First acceleration / deceleration phase threshold velocity in [µsteps/t] (unsigned)
 
       0: Disables A1 and D1 phase, use AMAX, DMAX only
+    min: 0
+    max: 0xFFFFF
 
   amax:
     type: int
@@ -36,6 +42,8 @@ properties:
       Second acceleration between V1 and VMAX in [µsteps/ta²](unsigned)
       This is the acceleration and deceleration value
       for velocity mode.
+    min: 0
+    max: 0xFFFF
 
   vmax:
     type: int
@@ -43,12 +51,16 @@ properties:
     description: |
       Motion ramp target velocity in [µsteps/t] (for positioning ensure VMAX ≥ VSTART) (unsigned)
       This is the target velocity in velocity mode. It can be changed any time during a motion.
+    min: 0
+    max: 0x7FFDFF
 
   dmax:
     type: int
     default: 0
     description: |
       Deceleration between VMAX and V1 in [µsteps/ta²](unsigned)
+    min: 0
+    max: 0xFFFF
 
   d1:
     type: int
@@ -58,6 +70,8 @@ properties:
 
       Attention: Do not set 0 in positioning mode,
       even if V1=0!
+    min: 1
+    max: 0xFFFF
 
   vstop:
     type: int
@@ -69,6 +83,8 @@ properties:
 
       Attention: Do not set 0 in positioning mode,
       minimum 10 recommended!
+    min: 1
+    max: 0x3FFFF
 
   tzerowait:
     type: int
@@ -77,6 +93,8 @@ properties:
       Waiting time after ramping down to zero velocity before next movement or direction
       inversion can start and before motor power down starts. Time range is about 0 to 2
       seconds. This setting avoids excess acceleration e.g. from VSTOP to -VSTART.
+    min: 0
+    max: 0xFDFF
 
   ihold:
     type: int
@@ -86,6 +104,8 @@ properties:
       Standstill current (0=1/32…31=32/32)
       In combination with StealthChop mode, setting IHOLD=0 allows to choose freewheeling or coil
       short circuit for motor stand still
+    min: 0
+    max: 0x1F
 
   irun:
     type: int
@@ -94,6 +114,8 @@ properties:
       Motor run current (0=1/32…31=32/32)
       Hint: Choose sense resistors in a way, that normal
       IRUN is 16 to 31 for best microstep performance.
+    min: 0
+    max: 0x1F
 
   iholddelay:
     type: int
@@ -103,6 +125,8 @@ properties:
       has expired. The smooth transition avoids a motor jerk upon power down.
       0: instant power down
       1..15: Delay per current reduction step in multiple of 2^18 clocks
+    min: 0
+    max: 0x0F
 
   vcoolthrs:
     type: int
@@ -119,6 +143,8 @@ properties:
       VHIGH ≥ |VACT| ≥ VCOOLTHRS:
         - CoolStep and stop on stall are enabled, if configured
         - Voltage PWM mode StealthChop is switched off, if configured
+    min: 0
+    max: 0x7FFFFF
 
   vhigh:
     type: int
@@ -132,6 +158,8 @@ properties:
           (constant off time with slow decay, only).
         - If vhighfs is set, the motor operates in fullstep mode.
         - Voltage PWM mode StealthChop is switched off, if configured
+    min: 0
+    max: 0x7FFFFF
 
   tcoolthrs:
     type: int
@@ -151,6 +179,8 @@ properties:
       TCOOLTHRS ≥ TSTEP
       - Stop on stall is enabled, if configured
       - Stall output signal (DIAG0/1) is enabled, if configured
+    min: 0
+    max: 0xFFFFF
 
   thigh:
     type: int
@@ -171,6 +201,8 @@ properties:
       - If vhighfs is set, the motor operates in fullstep mode,
       and the stall detection becomes switched over to
       DcStep stall detection.
+    min: 0
+    max: 0xFFFFF
 
   tpwmthrs:
     type: int
@@ -180,6 +212,8 @@ properties:
       TSTEP ≥ TPWMTHRS
       - StealthChop PWM mode is enabled, if configured
       - DcStep is disabled
+    min: 0
+    max: 0xFFFFF
 
   tpowerdown:
     type: int
@@ -192,3 +226,5 @@ properties:
       automatic tuning of StealthChop PWM_OFS_AUTO.
       Reset Default = 10
       0…((2^8)-1) * 2^18 tCLK
+    min: 0
+    max: 0xFF

--- a/include/zephyr/drivers/stepper/stepper_trinamic.h
+++ b/include/zephyr/drivers/stepper/stepper_trinamic.h
@@ -31,49 +31,8 @@
 extern "C" {
 #endif
 
-/**
- * @brief Trinamic stepper controller ramp generator data limits
- */
-#define TMC_RAMP_VSTART_MAX     GENMASK(17, 0)
-#define TMC_RAMP_VSTART_MIN     0
-#define TMC_RAMP_V1_MAX         GENMASK(19, 0)
-#define TMC_RAMP_V1_MIN         0
-#define TMC_RAMP_VMAX_MAX       (GENMASK(22, 0) - 512)
-#define TMC_RAMP_VMAX_MIN       0
-#define TMC_RAMP_A1_MAX         GENMASK(15, 0)
-#define TMC_RAMP_A1_MIN         0
-#define TMC_RAMP_AMAX_MAX       GENMASK(15, 0)
-#define TMC_RAMP_AMAX_MIN       0
-#define TMC_RAMP_D1_MAX         GENMASK(15, 0)
-#define TMC_RAMP_D1_MIN         1
-#define TMC_RAMP_DMAX_MAX       GENMASK(15, 0)
-#define TMC_RAMP_DMAX_MIN       0
-#define TMC_RAMP_VSTOP_MAX      GENMASK(17, 0)
-#define TMC_RAMP_VSTOP_MIN      1
-#define TMC_RAMP_TZEROWAIT_MAX  (GENMASK(15, 0) - 512)
-#define TMC_RAMP_TZEROWAIT_MIN  0
-#define TMC_RAMP_IHOLD_IRUN_MAX GENMASK(4, 0)
-#define TMC_RAMP_IHOLD_IRUN_MIN 0
-#define TMC_RAMP_IHOLDDELAY_MAX GENMASK(3, 0)
-#define TMC_RAMP_IHOLDDELAY_MIN 0
 #define TMC_RAMP_VACTUAL_SHIFT  22
 #define TMC_RAMP_XACTUAL_SHIFT  31
-
-/* TMC50XX specific */
-#define TMC_RAMP_VCOOLTHRS_MAX  GENMASK(22, 0)
-#define TMC_RAMP_VCOOLTHRS_MIN  0
-#define TMC_RAMP_VHIGH_MAX      GENMASK(22, 0)
-#define TMC_RAMP_VHIGH_MIN      0
-
-/* TMC51XX specific */
-#define TMC_RAMP_TPOWERDOWN_MAX	GENMASK(7, 0)
-#define TMC_RAMP_TPOWERDOWN_MIN	0
-#define TMC_RAMP_TPWMTHRS_MAX	GENMASK(19, 0)
-#define TMC_RAMP_TPWMTHRS_MIN	0
-#define TMC_RAMP_TCOOLTHRS_MAX	GENMASK(19, 0)
-#define TMC_RAMP_TCOOLTHRS_MIN	0
-#define TMC_RAMP_THIGH_MAX	GENMASK(19, 0)
-#define TMC_RAMP_THIGH_MIN	0
 
 /**
  * @brief Trinamic Stepper Ramp Generator data
@@ -104,67 +63,6 @@ struct tmc_ramp_generator_data {
 		};
 	};
 };
-
-/**
- * @brief Check if Ramp DT data is within limits
- */
-#define CHECK_RAMP_DT_DATA(node)							\
-	COND_CODE_1(DT_PROP_EXISTS(node, vstart),					\
-		BUILD_ASSERT(IN_RANGE(DT_PROP(node, vstart), TMC_RAMP_VSTART_MIN,	\
-			      TMC_RAMP_VSTART_MAX), "vstart out of range"), ());	\
-	COND_CODE_1(DT_PROP_EXISTS(node, v1),						\
-		BUILD_ASSERT(IN_RANGE(DT_PROP(node, v1), TMC_RAMP_V1_MIN,		\
-			      TMC_RAMP_V1_MAX), "v1 out of range"), ());		\
-	COND_CODE_1(DT_PROP_EXISTS(node, vmax),						\
-		BUILD_ASSERT(IN_RANGE(DT_PROP(node, vmax), TMC_RAMP_VMAX_MIN,		\
-			      TMC_RAMP_VMAX_MAX), "vmax out of range"), ());		\
-	COND_CODE_1(DT_PROP_EXISTS(node, a1),						\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, a1), TMC_RAMP_A1_MIN,			\
-			      TMC_RAMP_A1_MAX), "a1 out of range"), ());		\
-	COND_CODE_1(DT_PROP_EXISTS(node, amax),						\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, amax), TMC_RAMP_AMAX_MIN,			\
-			      TMC_RAMP_AMAX_MAX), "amax out of range"), ());		\
-	COND_CODE_1(DT_PROP_EXISTS(node, d1),						\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, d1), TMC_RAMP_D1_MIN,			\
-			      TMC_RAMP_D1_MAX), "d1 out of range"), ());		\
-	COND_CODE_1(DT_PROP_EXISTS(node, dmax),						\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, dmax), TMC_RAMP_DMAX_MIN,			\
-			      TMC_RAMP_DMAX_MAX), "dmax out of range"), ());		\
-	COND_CODE_1(DT_PROP_EXISTS(node, vstop),					\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, vstop), TMC_RAMP_VSTOP_MIN,			\
-			      TMC_RAMP_VSTOP_MAX), "vstop out of range"), ());		\
-	COND_CODE_1(DT_PROP_EXISTS(node, tzerowait),					\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, tzerowait), TMC_RAMP_TZEROWAIT_MIN,		\
-			      TMC_RAMP_TZEROWAIT_MAX), "tzerowait out of range"), ());	\
-	COND_CODE_1(DT_PROP_EXISTS(node, ihold),					\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, ihold), TMC_RAMP_IHOLD_IRUN_MIN,		\
-			      TMC_RAMP_IHOLD_IRUN_MAX), "ihold out of range"), ());	\
-	COND_CODE_1(DT_PROP_EXISTS(node, irun),						\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, irun), TMC_RAMP_IHOLD_IRUN_MIN,		\
-			      TMC_RAMP_IHOLD_IRUN_MAX), "irun out of range"), ());	\
-	COND_CODE_1(DT_PROP_EXISTS(node, iholddelay),					\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, iholddelay), TMC_RAMP_IHOLDDELAY_MIN,	\
-			      TMC_RAMP_IHOLDDELAY_MAX), "iholddelay out of range"), ());\
-	/* TMC50XX specific */								\
-	COND_CODE_1(DT_PROP_EXISTS(node, vcoolthrs),					\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, vcoolthrs), TMC_RAMP_VCOOLTHRS_MIN,		\
-			      TMC_RAMP_VCOOLTHRS_MAX), "vcoolthrs out of range"), ());	\
-	COND_CODE_1(DT_PROP_EXISTS(node, vhigh),					\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, vhigh), TMC_RAMP_VHIGH_MIN,			\
-			      TMC_RAMP_VHIGH_MAX), "vhigh out of range"), ());		\
-	/* TMC51XX specific */								\
-	COND_CODE_1(DT_PROP_EXISTS(node, tpowerdown),					\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, tpowerdown), TMC_RAMP_TPOWERDOWN_MIN,	\
-			      TMC_RAMP_TPOWERDOWN_MAX), "tpowerdown out of range"), ());\
-	COND_CODE_1(DT_PROP_EXISTS(node, tpwmthrs),					\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, tpwmthrs), TMC_RAMP_TPWMTHRS_MIN,		\
-			      TMC_RAMP_TPWMTHRS_MAX), "tpwmthrs out of range"), ());	\
-	COND_CODE_1(DT_PROP_EXISTS(node, tcoolthrs),					\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, tcoolthrs), TMC_RAMP_TCOOLTHRS_MIN,		\
-			      TMC_RAMP_TCOOLTHRS_MAX), "tcoolthrs out of range"), ());	\
-	COND_CODE_1(DT_PROP_EXISTS(node, thigh),					\
-	BUILD_ASSERT(IN_RANGE(DT_PROP(node, thigh), TMC_RAMP_THIGH_MIN,			\
-			      TMC_RAMP_THIGH_MAX), "thigh out of range"), ());
 
 /**
  * @brief Get Trinamic Stepper Ramp Generator data from DT


### PR DESCRIPTION
Replace most BUILD_ASSERT on property values with min/max checks on the binding itself.