### PR TITLE
drivers: can: switch to using `LOG_ERR_DEVICE_NOT_READY()`

### DIFF
--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -170,7 +170,7 @@ static int can_esp32_twai_init(const struct device *dev)
 	int err;
 
 	if (!device_is_ready(twai_config->clock_dev)) {
-		LOG_ERR("clock control device not ready");
+		LOG_ERR_DEVICE_NOT_READY(twai_config->clock_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_infineon.c
+++ b/drivers/can/can_infineon.c
@@ -112,7 +112,7 @@ static int can_infineon_init(const struct device *dev)
 
 	/* Ensure the parent controller (MRAM + channel clocks) is ready */
 	if (!device_is_ready(infineon_cfg->ctrl_dev)) {
-		LOG_ERR("CAN FD controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(infineon_cfg->ctrl_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_max32.c
+++ b/drivers/can/can_max32.c
@@ -614,13 +614,13 @@ static int can_max32_init(const struct device *dev)
 
 	if (dev_cfg->common.phy != NULL) {
 		if (!device_is_ready(dev_cfg->common.phy)) {
-			LOG_ERR("CAN transceiver not ready");
+			LOG_ERR_DEVICE_NOT_READY(dev_cfg->common.phy);
 			return -ENODEV;
 		}
 	}
 
 	if (!device_is_ready(dev_cfg->clock)) {
-		LOG_ERR("CAN clock is not ready");
+		LOG_ERR_DEVICE_NOT_READY(dev_cfg->clock);
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1422,7 +1422,7 @@ int can_mcan_init(const struct device *dev)
 	k_sem_init(&data->tx_sem, cbs->num_tx, cbs->num_tx);
 
 	if (config->common.phy != NULL && !device_is_ready(config->common.phy)) {
-		LOG_ERR("CAN transceiver not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->common.phy);
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -930,12 +930,12 @@ static int mcp2515_init(const struct device *dev)
 	k_sem_init(&dev_data->tx_sem, MCP2515_TX_CNT, MCP2515_TX_CNT);
 
 	if (dev_cfg->common.phy != NULL && !device_is_ready(dev_cfg->common.phy)) {
-		LOG_ERR("CAN transceiver not ready");
+		LOG_ERR_DEVICE_NOT_READY(dev_cfg->common.phy);
 		return -ENODEV;
 	}
 
 	if (!spi_is_ready_dt(&dev_cfg->bus)) {
-		LOG_ERR("SPI bus %s not ready", dev_cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(dev_cfg->bus.bus);
 		return -ENODEV;
 	}
 
@@ -947,7 +947,7 @@ static int mcp2515_init(const struct device *dev)
 
 	/* Initialize interrupt handling  */
 	if (!gpio_is_ready_dt(&dev_cfg->int_gpio)) {
-		LOG_ERR("Interrupt GPIO port not ready");
+		LOG_ERR_DEVICE_NOT_READY(dev_cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_mcp251xfd.c
+++ b/drivers/can/can_mcp251xfd.c
@@ -1527,7 +1527,7 @@ static int mcp251xfd_init(const struct device *dev)
 		uint32_t clk_id = dev_cfg->clk_id;
 
 		if (!device_is_ready(dev_cfg->clk_dev)) {
-			LOG_ERR("Clock controller not ready");
+			LOG_ERR_DEVICE_NOT_READY(dev_cfg->clk_dev);
 			return -ENODEV;
 		}
 
@@ -1544,12 +1544,12 @@ static int mcp251xfd_init(const struct device *dev)
 	k_mutex_init(&dev_data->mutex);
 
 	if (!spi_is_ready_dt(&dev_cfg->bus)) {
-		LOG_ERR("SPI bus %s not ready", dev_cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(dev_cfg->bus.bus);
 		return -ENODEV;
 	}
 
 	if (!gpio_is_ready_dt(&dev_cfg->int_gpio_dt)) {
-		LOG_ERR("GPIO port not ready");
+		LOG_ERR_DEVICE_NOT_READY(dev_cfg->int_gpio_dt.port);
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1163,13 +1163,13 @@ static int mcux_flexcan_init(const struct device *dev)
 
 	if (config->common.phy != NULL) {
 		if (!device_is_ready(config->common.phy)) {
-			LOG_ERR("CAN transceiver not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->common.phy);
 			return -ENODEV;
 		}
 	}
 
 	if (!device_is_ready(config->clock_dev)) {
-		LOG_ERR("clock device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->clock_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -121,12 +121,12 @@ static int can_numaker_init(const struct device *dev)
 	int rc;
 
 	if (!device_is_ready(config->reset.dev)) {
-		LOG_ERR("reset controller not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->reset.dev);
 		return -ENODEV;
 	}
 
 	if (!device_is_ready(config->clk_dev)) {
-		LOG_ERR("clock controller not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->clk_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_nxp_lpc_mcan.c
+++ b/drivers/can/can_nxp_lpc_mcan.c
@@ -98,12 +98,12 @@ static int nxp_lpc_mcan_init(const struct device *dev)
 	int err;
 
 	if (!device_is_ready(nxp_lpc_config->clock_dev)) {
-		LOG_ERR("clock control device not ready");
+		LOG_ERR_DEVICE_NOT_READY(nxp_lpc_config->clock_dev);
 		return -ENODEV;
 	}
 
 	if (!device_is_ready(nxp_lpc_config->reset.dev)) {
-		LOG_ERR("Reset device not ready");
+		LOG_ERR_DEVICE_NOT_READY(nxp_lpc_config->reset.dev);
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -1121,13 +1121,13 @@ static int can_nxp_s32_init(const struct device *dev)
 
 	if (config->common.phy != NULL) {
 		if (!device_is_ready(config->common.phy)) {
-			LOG_ERR("CAN transceiver not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->common.phy);
 			return -ENODEV;
 		}
 	}
 
 	if (!device_is_ready(config->clock_dev)) {
-		LOG_ERR("Clock control device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->clock_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -1024,12 +1024,12 @@ static int can_rcar_init(const struct device *dev)
 	data->common.state_change_cb_user_data = NULL;
 
 	if (config->common.phy != NULL && !device_is_ready(config->common.phy)) {
-		LOG_ERR("CAN transceiver not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->common.phy);
 		return -ENODEV;
 	}
 
 	if (!device_is_ready(config->clock_dev)) {
-		LOG_ERR("clock control device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->clock_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -741,7 +741,7 @@ int can_sja1000_init(const struct device *dev)
 
 	if (config->common.phy != NULL) {
 		if (!device_is_ready(config->common.phy)) {
-			LOG_ERR("CAN transceiver not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->common.phy);
 			return -ENODEV;
 		}
 	}

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -607,7 +607,7 @@ static int can_stm32_init(const struct device *dev)
 
 	if (cfg->common.phy != NULL) {
 		if (!device_is_ready(cfg->common.phy)) {
-			LOG_ERR("CAN transceiver not ready");
+			LOG_ERR_DEVICE_NOT_READY(cfg->common.phy);
 			return -ENODEV;
 		}
 	}

--- a/drivers/can/can_stm32_fdcan.c
+++ b/drivers/can/can_stm32_fdcan.c
@@ -519,7 +519,7 @@ static int can_stm32fd_init(const struct device *dev)
 #ifdef CONFIG_CAN_RX_TIMESTAMP
 	if (stm32fd_cfg->external_timestamp_counter_dev != NULL) {
 		if (!device_is_ready(stm32fd_cfg->external_timestamp_counter_dev)) {
-			LOG_ERR("Timestamp counter device not ready");
+			LOG_ERR_DEVICE_NOT_READY(stm32fd_cfg->external_timestamp_counter_dev);
 			return -ENODEV;
 		}
 

--- a/drivers/can/can_tcan4x5x.c
+++ b/drivers/can/can_tcan4x5x.c
@@ -728,14 +728,14 @@ static int tcan4x5x_init(const struct device *dev)
 	k_sem_init(&tcan_data->int_sem, 1, 1);
 
 	if (!spi_is_ready_dt(&tcan_config->spi)) {
-		LOG_ERR("SPI bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(tcan_config->spi.bus);
 		return -ENODEV;
 	}
 
 #if TCAN4X5X_RST_GPIO_SUPPORT
 	if (tcan_config->rst_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&tcan_config->rst_gpio)) {
-			LOG_ERR("RST GPIO not ready");
+			LOG_ERR_DEVICE_NOT_READY(tcan_config->rst_gpio.port);
 			return -ENODEV;
 		}
 
@@ -750,7 +750,7 @@ static int tcan4x5x_init(const struct device *dev)
 #if TCAN4X5X_NWKRQ_GPIO_SUPPORT
 	if (tcan_config->nwkrq_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&tcan_config->nwkrq_gpio)) {
-			LOG_ERR("nWKRQ GPIO not ready");
+			LOG_ERR_DEVICE_NOT_READY(tcan_config->nwkrq_gpio.port);
 			return -ENODEV;
 		}
 
@@ -765,7 +765,7 @@ static int tcan4x5x_init(const struct device *dev)
 #if TCAN4X5X_WAKE_GPIO_SUPPORT
 	if (tcan_config->wake_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&tcan_config->wake_gpio)) {
-			LOG_ERR("WAKE GPIO not ready");
+			LOG_ERR_DEVICE_NOT_READY(tcan_config->wake_gpio.port);
 			return -ENODEV;
 		}
 
@@ -778,7 +778,7 @@ static int tcan4x5x_init(const struct device *dev)
 #endif /* TCAN4X5X_WAKE_GPIO_SUPPORT */
 
 	if (!gpio_is_ready_dt(&tcan_config->int_gpio)) {
-		LOG_ERR("nINT GPIO not ready");
+		LOG_ERR_DEVICE_NOT_READY(tcan_config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/can/transceiver/can_transceiver_gpio.c
+++ b/drivers/can/transceiver/can_transceiver_gpio.c
@@ -78,7 +78,7 @@ static int can_transceiver_gpio_init(const struct device *dev)
 #if ANY_INST_HAS_ENABLE_GPIOS
 	if (config->enable_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&config->enable_gpio)) {
-			LOG_ERR("enable pin GPIO device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->enable_gpio.port);
 			return -EINVAL;
 		}
 
@@ -94,7 +94,7 @@ static int can_transceiver_gpio_init(const struct device *dev)
 #if ANY_INST_HAS_STANDBY_GPIOS
 	if (config->standby_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&config->standby_gpio)) {
-			LOG_ERR("standby pin GPIO device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->standby_gpio.port);
 			return -EINVAL;
 		}
 


### PR DESCRIPTION
Switch to using `LOG_ERR_DEVICE_NOT_READY()` to reduce flash footprint.