### PR TITLE
scripts: dts: Add min-len/max-len properties to edtlib spec.

### DIFF
--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -245,6 +245,8 @@ Property entries in ``properties:`` are written in this syntax:
      const: <string | int | array | uint8-array | string-array>
      min: <int>
      max: <int>
+     min-len: <int>
+     max-len: <int>
      specifier-space: <space-name>
 
 .. _dt-bindings-example-properties:
@@ -470,6 +472,37 @@ Example:
        type: int
        min: 1
        description: Timeout in milliseconds
+
+.. _dt-bindings-min-len-max-len:
+
+min-len and max-len
+===================
+
+The ``min-len:`` and ``max-len:`` keys constrain the number of elements (length)
+for array-type properties (``array``, ``uint8-array``, ``string-array``,
+``phandles``, and ``phandle-array``). If the length of a property value in DTS
+is outside the ``[min-len, max-len]`` range, an error is raised.
+
+Both keys are optional and independent; you may specify just ``min-len:``, just
+``max-len:``, or both.
+
+Example:
+
+.. code-block:: YAML
+
+   properties:
+     # An array of exactly 3 integers
+     coordinates:
+       type: array
+       min-len: 3
+       max-len: 3
+       description: 3D coordinates
+
+     # A list of up to 4 GPIO phandles
+     gpios:
+       type: phandle-array
+       max-len: 4
+       description: Up to 4 GPIOs
 
 const
 =====

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -495,7 +495,7 @@ class Binding:
 
         ok_prop_keys = {"description", "type", "required",
                         "enum", "const", "default", "deprecated",
-                        "specifier-space", "min", "max"}
+                        "specifier-space", "min", "max", "min-len", "max-len"}
 
         for prop_name, options in raw["properties"].items():
             for key in options:
@@ -593,6 +593,16 @@ class PropertySpec:
     max:
       The maximum value the property may take as given in the binding, or None.
       Only applicable to 'int' and 'array' type properties.
+
+    min_len:
+      The minimum length of the array itself as given in the binding, or None.
+      Corresponds to the binding key 'min-len:'.
+      Only applicable to array type properties.
+
+    max_len:
+      The maximum length of the array itself as given in the binding, or None.
+      Corresponds to the binding key 'max-len:'.
+      Only applicable to array type properties.
     """
 
     def __init__(self, name: str, binding: Binding):
@@ -688,6 +698,16 @@ class PropertySpec:
     def max(self) -> Optional[int]:
         "See the class docstring"
         return self._raw.get("max")
+
+    @property
+    def min_len(self) -> Optional[int]:
+        "See the class docstring"
+        return self._raw.get("min-len")
+
+    @property
+    def max_len(self) -> Optional[int]:
+        "See the class docstring"
+        return self._raw.get("max-len")
 
     def _check_special_properties(self):
         # Add checks for properties which have special meaning
@@ -1795,6 +1815,24 @@ class Node:
                     _err(f"value of property '{name}' on {self.path} in "
                          f"{self.edt.dts_path} ({subval!r}) is greater than the "
                          f"'max' value in {self.binding_path} ({prop_max!r})")
+
+        prop_min_len = prop_spec.min_len
+        prop_max_len = prop_spec.max_len
+        if prop_min_len is not None or prop_max_len is not None:
+            if isinstance(val, (list, bytes)):
+                val_len = len(val)
+                if prop_min_len is not None and val_len < prop_min_len:
+                    _err(f"value of property '{name}' on {self.path} in "
+                         f"{self.edt.dts_path} has length {val_len}, which is less than the "
+                         f"'min-len' value in {self.binding_path} ({prop_min_len!r})")
+                if prop_max_len is not None and val_len > prop_max_len:
+                    _err(f"value of property '{name}' on {self.path} in "
+                         f"{self.edt.dts_path} has length {val_len}, which is greater than the "
+                         f"'max-len' value in {self.binding_path} ({prop_max_len!r})")
+            else:
+                _err(f"property '{name}' on {self.path} in "
+                     f"{self.edt.dts_path} is not an array, but "
+                     "'min-len'/'max-len' constraints are set")
 
         const = prop_spec.const
         if const is not None and val != const:
@@ -3037,6 +3075,8 @@ def _check_prop_by_type(prop_name: str,
     const = options.get("const")
     min_val = options.get("min")
     max_val = options.get("max")
+    min_len = options.get("min-len")
+    max_len = options.get("max-len")
 
     if prop_type is None:
         _err(f"missing 'type:' for '{prop_name}' in 'properties' in "
@@ -3109,6 +3149,36 @@ def _check_prop_by_type(prop_name: str,
                     _err(f"'const: {const}' for '{prop_name}' in "
                          f"'{binding_path}' is greater than 'max: {max_val}'")
 
+    if min_len is not None or max_len is not None:
+        array_types = {"array", "uint8-array", "string-array", "phandles", "phandle-array"}
+        if prop_type not in array_types:
+            _err(f"'min-len:'/'max-len:' in '{binding_path}' for '{prop_name}' "
+                 f"requires an array type, but has type '{prop_type}'")
+
+        if min_len is not None and (not _is_plain_int(min_len) or min_len < 0):
+            _err(f"'min-len:' for '{prop_name}' in '{binding_path}' "
+                 "is not a non-negative integer")
+
+        if max_len is not None and (not _is_plain_int(max_len) or max_len < 0):
+            _err(f"'max-len:' for '{prop_name}' in '{binding_path}' "
+                 "is not a non-negative integer")
+
+        if (min_len is not None and max_len is not None
+                and min_len > max_len):
+            _err(f"'min-len:' ({min_len}) > 'max-len:' ({max_len}) "
+                 f"for '{prop_name}' in '{binding_path}'")
+
+        if const is not None and isinstance(const, list | bytes):
+            const_len = len(const)
+            if min_len is not None and const_len < min_len:
+                _err(f"'const: {const!r}' for '{prop_name}' in "
+                     f"'{binding_path}' has length {const_len}, which is "
+                     f"less than 'min-len: {min_len}'")
+            if max_len is not None and const_len > max_len:
+                _err(f"'const: {const!r}' for '{prop_name}' in "
+                     f"'{binding_path}' has length {const_len}, which is "
+                     f"greater than 'max-len: {max_len}'")
+
     # Check default
 
     if default is None:
@@ -3159,6 +3229,17 @@ def _check_prop_by_type(prop_name: str,
             if max_val is not None and subval > max_val:
                 _err(f"'default: {default}' for '{prop_name}' in "
                      f"'{binding_path}' is greater than 'max: {max_val}'")
+
+    if (min_len is not None or max_len is not None) and isinstance(default, list | bytes):
+        default_len = len(default)
+        if min_len is not None and default_len < min_len:
+            _err(f"'default: {default!r}' for '{prop_name}' in "
+                 f"'{binding_path}' has length {default_len}, which is "
+                 f"less than 'min-len: {min_len}'")
+        if max_len is not None and default_len > max_len:
+            _err(f"'default: {default!r}' for '{prop_name}' in "
+                 f"'{binding_path}' has length {default_len}, which is "
+                 f"greater than 'max-len: {max_len}'")
 
 
 def _translate(addr: int, node: dtlib_Node) -> int:

--- a/scripts/dts/python-devicetree/tests/test-bindings/min-max-len.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/min-max-len.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Property min-len/max-len range test
+
+compatible: "min-max-len"
+
+properties:
+  array-with-min-len:
+    type: array
+    min-len: 2
+
+  array-with-max-len:
+    type: array
+    max-len: 4
+
+  array-with-range-len:
+    type: array
+    min-len: 2
+    max-len: 4
+
+  string-array-with-range-len:
+    type: string-array
+    min-len: 1
+    max-len: 3
+
+  uint8-array-with-range-len:
+    type: uint8-array
+    min-len: 2
+    max-len: 4

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -509,6 +509,15 @@
 		array-with-signed-range = <(-50) 0 50>;
 	};
 
+	range-len-node {
+		compatible = "min-max-len";
+		array-with-min-len = <1 2>;
+		array-with-max-len = <1 2 3>;
+		array-with-range-len = <1 2 3>;
+		string-array-with-range-len = "foo", "bar";
+		uint8-array-with-range-len = [01 02 03];
+	};
+
 	//
 	// For testing 'enum:'
 	//

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -904,6 +904,40 @@ def test_prop_ranges():
     assert array_with_signed_range.spec.min == -50
     assert array_with_signed_range.spec.max == 50
 
+def test_prop_range_len():
+    '''test properties with min-len:/max-len: in the binding'''
+
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+    props = edt.get_node('/range-len-node').props
+
+    array_with_min_len = props['array-with-min-len']
+    array_with_max_len = props['array-with-max-len']
+    array_with_range_len = props['array-with-range-len']
+    string_array_with_range_len = props['string-array-with-range-len']
+    uint8_array_with_range_len = props['uint8-array-with-range-len']
+
+    assert array_with_min_len.val == [1, 2]
+    assert array_with_max_len.val == [1, 2, 3]
+    assert array_with_range_len.val == [1, 2, 3]
+    assert string_array_with_range_len.val == ["foo", "bar"]
+    assert uint8_array_with_range_len.val == b"\x01\x02\x03"
+
+    assert array_with_min_len.spec.min_len == 2
+    assert array_with_min_len.spec.max_len is None
+
+    assert array_with_max_len.spec.min_len is None
+    assert array_with_max_len.spec.max_len == 4
+
+    assert array_with_range_len.spec.min_len == 2
+    assert array_with_range_len.spec.max_len == 4
+
+    assert string_array_with_range_len.spec.min_len == 1
+    assert string_array_with_range_len.spec.max_len == 3
+
+    assert uint8_array_with_range_len.spec.min_len == 2
+    assert uint8_array_with_range_len.spec.max_len == 4
+
 def test_prop_range_errs(tmp_path):
     '''Test errors when property values violate min:/max: constraints'''
 
@@ -979,6 +1013,62 @@ def test_prop_range_errs(tmp_path):
         f"value of property 'array-with-signed-range' on /ranges-node in "
         f"{str(dts_file)} (-51) is less than the "
         f"'min' value in {binding_path} (-50)")
+
+def test_prop_range_len_errs(tmp_path):
+    '''Test errors when property values violate min-len:/max-len: constraints'''
+
+    dts_file = tmp_path / "test_range_len_err.dts"
+
+    def write_and_check(dts_content, expected_err):
+        with open(dts_file, "w", encoding="utf-8") as f:
+            f.write(dts_content)
+            f.flush()
+        with pytest.raises(edtlib.EDTError) as e:
+            with from_here():
+                edtlib.EDT(str(dts_file), ["test-bindings"])
+        assert str(e.value) == expected_err
+
+    binding_path = hpath("test-bindings/min-max-len.yaml")
+
+    # Array length below min-len
+    write_and_check(
+        """\
+/dts-v1/;
+/ { range-len-node { compatible = "min-max-len"; array-with-min-len = <1>; }; };
+""",
+        f"value of property 'array-with-min-len' on /range-len-node in "
+        f"{str(dts_file)} has length 1, which is less than the "
+        f"'min-len' value in {binding_path} (2)")
+
+    # Array length above max-len
+    write_and_check(
+        """\
+/dts-v1/;
+/ { range-len-node { compatible = "min-max-len"; array-with-max-len = <1 2 3 4 5>; }; };
+""",
+        f"value of property 'array-with-max-len' on /range-len-node in "
+        f"{str(dts_file)} has length 5, which is greater than the "
+        f"'max-len' value in {binding_path} (4)")
+
+    # String array length above max-len
+    write_and_check(
+        """\
+/dts-v1/;
+/ { range-len-node { compatible = "min-max-len"; string-array-with-range-len = "a", "b", "c", "d"; }; };
+""",
+        f"value of property 'string-array-with-range-len' on /range-len-node in "
+        f"{str(dts_file)} has length 4, which is greater than the "
+        f"'max-len' value in {binding_path} (3)")
+
+    # Uint8-array length below min-len
+    write_and_check(
+        """\
+/dts-v1/;
+/ { range-len-node { compatible = "min-max-len"; uint8-array-with-range-len = [01]; }; };
+""",
+        f"value of property 'uint8-array-with-range-len' on /range-len-node in "
+        f"{str(dts_file)} has length 1, which is less than the "
+        f"'min-len' value in {binding_path} (2)")
 
 def test_prop_range_binding_errs(tmp_path):
     '''Test errors in binding definitions with invalid min:/max:'''
@@ -1177,6 +1267,120 @@ properties:
       - 15
 """,
         f"'const: [5, 15]' for 'foo' in '{path}' is greater than 'max: 10'")
+
+def test_prop_range_len_binding_errs(tmp_path):
+    '''Test errors in binding definitions with invalid min-len:/max-len:'''
+
+    def check_binding_err(yaml_content, expected_err):
+        binding_file = tmp_path / "bad-range-len.yaml"
+        with open(binding_file, "w", encoding="utf-8") as f:
+            f.write(yaml_content)
+        with pytest.raises(edtlib.EDTError) as e:
+            edtlib.Binding(str(binding_file), {})
+        assert str(e.value) == expected_err
+
+    path = str(tmp_path / "bad-range-len.yaml")
+
+    # min-len on unsupported type (int)
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min-len: 2
+""",
+        f"'min-len:'/'max-len:' in '{path}' for 'foo' "
+        f"requires an array type, but has type 'int'")
+
+    # min-len > max-len
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: array
+    min-len: 5
+    max-len: 2
+""",
+        f"'min-len:' (5) > 'max-len:' (2) for 'foo' in '{path}'")
+
+    # non-integer min-len
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: array
+    min-len: "bad"
+""",
+        f"'min-len:' for 'foo' in '{path}' is not a non-negative integer")
+
+    # negative min-len
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: array
+    min-len: -1
+""",
+        f"'min-len:' for 'foo' in '{path}' is not a non-negative integer")
+
+    # boolean min-len
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: array
+    min-len: true
+""",
+        f"'min-len:' for 'foo' in '{path}' is not a non-negative integer")
+
+    # default length below min-len
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: array
+    min-len: 3
+    default: [1, 2]
+""",
+        f"'default: [1, 2]' for 'foo' in '{path}' has length 2, which is less than 'min-len: 3'")
+
+    # default length above max-len
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: array
+    max-len: 2
+    default: [1, 2, 3]
+""",
+        f"'default: [1, 2, 3]' for 'foo' in '{path}' has length 3, which is greater than 'max-len: 2'")
+
+    # const length below min-len
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: array
+    min-len: 3
+    const: [1, 2]
+""",
+        f"'const: [1, 2]' for 'foo' in '{path}' has length 2, which is less than 'min-len: 3'")
 
 def test_binding_inference():
     '''Test inferred bindings for special zephyr-specific nodes.'''


### PR DESCRIPTION
Add optional min-len/max-len properties to edtlib spec to specify a valid length range for array type values.
