### PR TITLE
dts: bindings: can: use min/max where possible

### DIFF
--- a/dts/bindings/can/bosch,m_can-base.yaml
+++ b/dts/bindings/can/bosch,m_can-base.yaml
@@ -27,23 +27,8 @@ properties:
 
   bosch,timestamp-counter-prescaler:
     type: int
-    enum:
-      - 1
-      - 2
-      - 3
-      - 4
-      - 5
-      - 6
-      - 7
-      - 8
-      - 9
-      - 10
-      - 11
-      - 12
-      - 13
-      - 14
-      - 15
-      - 16
+    min: 1
+    max: 16
     default: 1
     description: |
       Configures the internal timestamp counter time unit in multiples of CAN bit times. Valid range

--- a/dts/bindings/can/infineon,xmc4xxx-can.yaml
+++ b/dts/bindings/can/infineon,xmc4xxx-can.yaml
@@ -15,8 +15,10 @@ properties:
 
   clock-prescaler:
     type: int
+    min: 1
+    max: 1023
     required: true
-    description: Clock divider for the input clock. Valid range is [1, 1023].
+    description: Clock divider for the input clock.
 
   message-objects:
     type: int

--- a/dts/bindings/can/microchip,mcp251xfd.yaml
+++ b/dts/bindings/can/microchip,mcp251xfd.yaml
@@ -33,11 +33,12 @@ properties:
 
   timestamp-prescaler:
     type: int
+    min: 1
+    max: 1024
     default: 1
     description: |
       Prescaler value for computing the timestamps of received messages.
       The timestamp counter is derived from the internal clock divided by this value.
-      Valid range is [1, 1024].
 
   sof-on-clko:
     type: boolean

--- a/dts/bindings/can/renesas,ra-canfd.yaml
+++ b/dts/bindings/can/renesas,ra-canfd.yaml
@@ -20,6 +20,7 @@ properties:
 
   rx-max-filters:
     type: int
+    min: 0
+    max: 16
     description: |
       To determine the maximum rx filters can be added on this CAN device.
-      Valid range: 0 - 16

--- a/dts/bindings/can/renesas,rz-canfd.yaml
+++ b/dts/bindings/can/renesas,rz-canfd.yaml
@@ -21,6 +21,7 @@ properties:
   rx-max-filters:
     type: int
     required: true
+    min: 1
+    max: 128
     description: |
       To determine the maximum rx filters can be added on this CAN device.
-      Valid range: 1 - 128


### PR DESCRIPTION
- dts: bindings: can: bosch: m_can: use min/max instead of an enum
- dts: bindings: can: microchip: mcp251xfd: restrict timestamp-prescaler val
- dts: bindings: can: renesas: ra-canfd: restrict rx-max-filters value
- dts: bindings: can: renesas: rz-canfd: restrict rx-max-filters value
- dts: bindings: can: infineon: xmc4xxx-can: restrict clock-prescaler value

None of these require changes to the C code (no build-time asserts to be removed).