### PR TITLE
drivers: gpio: esp32: Handle GPIO_INT_WAKEUP in pin_interrupt_configure

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -454,6 +454,12 @@ static int gpio_esp32_pin_interrupt_configure(const struct device *port,
 {
 	const struct gpio_esp32_config *const cfg = port->config;
 	uint32_t io_pin = (uint32_t) pin + ((cfg->gpio_port == 1 && pin < 32) ? 32 : 0);
+
+	/* Wakeup is configured in gpio_esp32_config(); strip the bit so
+	 * convert_int_type() only sees edge/level trigger bits.
+	 */
+	trig &= ~GPIO_INT_WAKEUP;
+
 	int intr_trig_mode = convert_int_type(mode, trig);
 	uint32_t key;
 


### PR DESCRIPTION
The GPIO subsystem forwards GPIO_INT_WAKEUP from dt_flags into the trig argument of pin_interrupt_configure(). Wakeup source configuration is already handled in gpio_esp32_config(); strip the bit before passing trig to convert_int_type() to avoid -EINVAL return.

Similar to #90832.