### PR TITLE
drivers: dma: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -390,8 +390,7 @@ __subsystem struct dma_driver_api {
  * @param config  Data structure containing the intended configuration for the
  *                selected channel
  *
- * @retval 0 if successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 static inline int dma_config(const struct device *dev, uint32_t channel,
 			     struct dma_config *config)
@@ -409,8 +408,7 @@ static inline int dma_config(const struct device *dev, uint32_t channel,
  * @param dst     destination address for the DMA transfer
  * @param size    size of DMA transfer
  *
- * @retval 0 if successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 #ifdef CONFIG_DMA_64BIT
 static inline int dma_reload(const struct device *dev, uint32_t channel,
@@ -445,8 +443,7 @@ static inline int dma_reload(const struct device *dev, uint32_t channel,
  * @param channel Numeric identification of the channel where the transfer will
  *                be processed
  *
- * @retval 0 if successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 static inline int dma_start(const struct device *dev, uint32_t channel)
 {
@@ -468,10 +465,9 @@ static inline int dma_start(const struct device *dev, uint32_t channel)
  * @param channel Numeric identification of the channel where the transfer was
  *                being processed
  *
- * @retval 0 If successful.
- * @retval -ENOSYS If not implemented.
- * @retval -EINVAL If invalid channel id.
- * @retval -errno Other negative errno code failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Not implemented.
+ * @retval -EINVAL Invalid channel id.
  */
 static inline int dma_stop(const struct device *dev, uint32_t channel)
 {
@@ -494,10 +490,9 @@ static inline int dma_stop(const struct device *dev, uint32_t channel)
  * @param dev Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel to suspend
  *
- * @retval 0 If successful.
- * @retval -ENOSYS If not implemented.
- * @retval -EINVAL If invalid channel id or state.
- * @retval -errno Other negative errno code failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Not implemented.
+ * @retval -EINVAL Invalid channel id or state.
  */
 static inline int dma_suspend(const struct device *dev, uint32_t channel)
 {
@@ -520,10 +515,9 @@ static inline int dma_suspend(const struct device *dev, uint32_t channel)
  * @param dev Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel to resume
  *
- * @retval 0 If successful.
- * @retval -ENOSYS If not implemented
- * @retval -EINVAL If invalid channel id or state.
- * @retval -errno Other negative errno code failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Not implemented.
+ * @retval -EINVAL Invalid channel id or state.
  */
 static inline int dma_resume(const struct device *dev, uint32_t channel)
 {
@@ -548,8 +542,7 @@ static inline int dma_resume(const struct device *dev, uint32_t channel)
  * @param dev Pointer to the device structure for the driver instance.
  * @param filter_param filter function parameter
  *
- * @return dma channel if successful.
- * @retval <0 Negative errno code if failure.
+ * @return DMA channel on success, negative errno value on failure.
  */
 static inline int dma_request_channel(const struct device *dev, void *filter_param)
 {
@@ -619,8 +612,7 @@ static inline void dma_release_channel(const struct device *dev, uint32_t channe
  * @param channel  channel number
  * @param filter_param filter attribute
  *
- * @retval <0 Negative errno code if not support
- *
+ * @return Non-negative value on success, negative errno value on failure.
  */
 static inline int dma_chan_filter(const struct device *dev, int channel, void *filter_param)
 {
@@ -646,8 +638,7 @@ static inline int dma_chan_filter(const struct device *dev, int channel, void *f
  *                being processed
  * @param stat   a non-NULL dma_status object for storing DMA status
  *
- * @retval >=0 non-negative if successful.
- * @retval <0 Negative errno code if failure.
+ * @return Non-negative value on success, negative errno value on failure.
  */
 static inline int dma_get_status(const struct device *dev, uint32_t channel,
 				 struct dma_status *stat)
@@ -675,8 +666,7 @@ static inline int dma_get_status(const struct device *dev, uint32_t channel,
  * @param type    Numeric identification of the attribute
  * @param value   A non-NULL pointer to the variable where the read value is to be placed
  *
- * @retval >=0 non-negative if successful.
- * @retval <0 Negative errno code if failure.
+ * @return Non-negative value on success, negative errno value on failure.
  */
 static inline int dma_get_attribute(const struct device *dev, uint32_t type, uint32_t *value)
 {

--- a/include/zephyr/drivers/dma/sf32lb.h
+++ b/include/zephyr/drivers/dma/sf32lb.h
@@ -133,9 +133,8 @@ static inline void sf32lb_dma_config_init_dt(const struct sf32lb_dma_dt_spec *sp
  * @param spec SF32LB DMA DT spec
  * @param config DMA configuration
  *
- * @retval 0 If successful.
- * @retval -ENOTSUP If the configuration is not supported.
- * @retval -errno Other negative errno code failure (see dma_config()).
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP The configuration is not supported.
  */
 static inline int sf32lb_dma_config_dt(const struct sf32lb_dma_dt_spec *spec,
 				       struct dma_config *config)
@@ -148,8 +147,7 @@ static inline int sf32lb_dma_config_dt(const struct sf32lb_dma_dt_spec *spec,
  *
  * @param spec SF32LB DMA DT spec
  *
- * @retval 0 If successful.
- * @retval -errno Negative errno code failure (see dma_start()).
+ * @return 0 on success, negative errno value on failure. (see @ref dma_start()).
  */
 static inline int sf32lb_dma_start_dt(const struct sf32lb_dma_dt_spec *spec)
 {
@@ -161,8 +159,7 @@ static inline int sf32lb_dma_start_dt(const struct sf32lb_dma_dt_spec *spec)
  *
  * @param spec SF32LB DMA DT spec
  *
- * @retval 0 If successful.
- * @retval -errno Negative errno code failure (see dma_stop()).
+ * @return 0 on success, negative errno value on failure. (see @ref dma_stop()).
  */
 static inline int sf32lb_dma_stop_dt(const struct sf32lb_dma_dt_spec *spec)
 {
@@ -177,8 +174,7 @@ static inline int sf32lb_dma_stop_dt(const struct sf32lb_dma_dt_spec *spec)
  * @param dst Destination address
  * @param size Transfer size
  *
- * @retval 0 If successful.
- * @retval -errno Negative errno code failure (see dma_reload()).
+ * @return 0 on success, negative errno value on failure. (see @ref dma_reload()).
  */
 static inline int sf32lb_dma_reload_dt(const struct sf32lb_dma_dt_spec *spec, uintptr_t src,
 				       uintptr_t dst, size_t size)
@@ -192,8 +188,7 @@ static inline int sf32lb_dma_reload_dt(const struct sf32lb_dma_dt_spec *spec, ui
  * @param spec SF32LB DMA DT spec
  * @param[out] status Status output
  *
- * @retval 0 If successful.
- * @retval -errno Negative errno code failure (see dma_get_status()).
+ * @return 0 on success, negative errno value on failure. (see @ref dma_get_status()).
  */
 static inline int sf32lb_dma_get_status_dt(const struct sf32lb_dma_dt_spec *spec,
 					   struct dma_status *status)


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974