### PR TITLE
tests: dma: fix dma-buf-addr-alignment property not being used in dma tests

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
@@ -8,7 +8,7 @@
 
 #include "test_buffers.h"
 
-#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
 
 __aligned(DMA_DATA_ALIGNMENT) char tx_data[TEST_BUF_SIZE] =
 	"It is harder to be kind than to be wise........";

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -25,7 +25,7 @@
 #define TEST_DMA_CHANNEL_1 (1)
 #define GUARD_BUFF_SIZE (16)
 #define RX_BUFF_SIZE (48)
-#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
 
 #ifdef CONFIG_NOCACHE_MEMORY
 static __aligned(DMA_DATA_ALIGNMENT) char tx_data[RX_BUFF_SIZE] __used

--- a/tests/drivers/dma/cyclic/src/test_dma_cyclic.c
+++ b/tests/drivers/dma/cyclic/src/test_dma_cyclic.c
@@ -22,7 +22,7 @@
 #include <zephyr/drivers/dma.h>
 #include <zephyr/ztest.h>
 
-#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
 #define GUARD_BUF_SIZE (16)
 
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_CYCLIC_XFER_SIZE];

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -32,7 +32,7 @@
 #define SLEEPTIME 250
 
 #define TRANSFER_LOOPS (4)
-#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
 
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE];
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t

--- a/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
+++ b/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
@@ -22,7 +22,7 @@
 #include <zephyr/ztest.h>
 
 #define XFERS 4
-#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
 
 #if CONFIG_NOCACHE_MEMORY
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_SG_XFER_SIZE] __used


### PR DESCRIPTION
The five test files in this PR previously incorrectly use `DT_INST_PROP_OR` by passing the node label `tst_dma0` where an instance number is expected. It silently failed by ignoring `dma-buf-addr-alignment` and using the fallback option instead. 

This commit fixes this by using `DT_PROP_OR` and `DT_NODELABEL`.

Note: This was noticed by @soburi's review of #105863. I don't own any boards that actually use a `dma-buf-addr-alignment` property, so I can't run these tests in the situation where this change affects anything.