### PR TITLE
stepper: drop `ASSERT_NO_MSG(dev!=NULL)`

### DIFF
--- a/include/zephyr/drivers/stepper/stepper.h
+++ b/include/zephyr/drivers/stepper/stepper.h
@@ -169,7 +169,6 @@ __syscall int stepper_enable(const struct device *dev);
 
 static inline int z_impl_stepper_enable(const struct device *dev)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	return DEVICE_API_GET(stepper, dev)->enable(dev);
 }
 
@@ -188,7 +187,6 @@ __syscall int stepper_disable(const struct device *dev);
 
 static inline int z_impl_stepper_disable(const struct device *dev)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	return DEVICE_API_GET(stepper, dev)->disable(dev);
 }
 
@@ -209,7 +207,6 @@ __syscall int stepper_set_micro_step_res(const struct device *dev,
 static inline int z_impl_stepper_set_micro_step_res(const struct device *dev,
 							enum stepper_micro_step_resolution res)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	if (!VALID_MICRO_STEP_RES(res)) {
 		return -EINVAL;
 	}
@@ -231,7 +228,6 @@ __syscall int stepper_get_micro_step_res(const struct device *dev,
 static inline int z_impl_stepper_get_micro_step_res(const struct device *dev,
 							enum stepper_micro_step_resolution *res)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	__ASSERT_NO_MSG(res != NULL);
 	return DEVICE_API_GET(stepper, dev)->get_micro_step_res(dev, res);
 }
@@ -253,7 +249,6 @@ __syscall int stepper_set_event_cb(const struct device *dev, stepper_event_cb_t 
 static inline int z_impl_stepper_set_event_cb(const struct device *dev,
 						  stepper_event_cb_t cb, void *user_data)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	if (DEVICE_API_GET(stepper, dev)->set_event_cb == NULL) {
 		return -ENOSYS;
 	}

--- a/include/zephyr/drivers/stepper/stepper_ctrl.h
+++ b/include/zephyr/drivers/stepper/stepper_ctrl.h
@@ -227,7 +227,6 @@ __syscall int stepper_ctrl_set_reference_position(const struct device *dev, cons
 static inline int z_impl_stepper_ctrl_set_reference_position(const struct device *dev,
 							     const int32_t value)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	if (DEVICE_API_GET(stepper_ctrl, dev)->set_reference_position == NULL) {
 		return -ENOSYS;
 	}
@@ -252,8 +251,8 @@ __syscall int stepper_ctrl_get_actual_position(const struct device *dev, int32_t
 
 static inline int z_impl_stepper_ctrl_get_actual_position(const struct device *dev, int32_t *value)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	__ASSERT_NO_MSG(value != NULL);
+
 	if (DEVICE_API_GET(stepper_ctrl, dev)->get_actual_position == NULL) {
 		return -ENOSYS;
 	}
@@ -279,7 +278,6 @@ static inline int z_impl_stepper_ctrl_set_event_cb(const struct device *dev,
 						   stepper_ctrl_event_callback_t callback,
 						   void *user_data)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	if (DEVICE_API_GET(stepper_ctrl, dev)->set_event_cb == NULL) {
 		return -ENOSYS;
 	}
@@ -306,7 +304,6 @@ __syscall int stepper_ctrl_set_microstep_interval(const struct device *dev,
 static inline int z_impl_stepper_ctrl_set_microstep_interval(const struct device *dev,
 							     const uint64_t microstep_interval_ns)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	if (DEVICE_API_GET(stepper_ctrl, dev)->set_microstep_interval == NULL) {
 		return -ENOSYS;
 	}
@@ -330,7 +327,6 @@ __syscall int stepper_ctrl_configure_ramp(const struct device *dev,
 static inline int z_impl_stepper_ctrl_configure_ramp(const struct device *dev,
 	const struct stepper_ctrl_ramp *ramp)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	__ASSERT_NO_MSG(ramp != NULL);
 
 	if (DEVICE_API_GET(stepper_ctrl, dev)->configure_ramp == NULL) {
@@ -355,7 +351,6 @@ __syscall int stepper_ctrl_move_by(const struct device *dev, const int32_t micro
 
 static inline int z_impl_stepper_ctrl_move_by(const struct device *dev, const int32_t micro_steps)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	return DEVICE_API_GET(stepper_ctrl, dev)->move_by(dev, micro_steps);
 }
 
@@ -376,7 +371,6 @@ __syscall int stepper_ctrl_move_to(const struct device *dev, const int32_t micro
 
 static inline int z_impl_stepper_ctrl_move_to(const struct device *dev, const int32_t micro_steps)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	return DEVICE_API_GET(stepper_ctrl, dev)->move_to(dev, micro_steps);
 }
 
@@ -401,7 +395,6 @@ __syscall int stepper_ctrl_run(const struct device *dev,
 static inline int z_impl_stepper_ctrl_run(const struct device *dev,
 					  const enum stepper_ctrl_direction direction)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	if (DEVICE_API_GET(stepper_ctrl, dev)->run == NULL) {
 		return -ENOSYS;
 	}
@@ -422,7 +415,6 @@ __syscall int stepper_ctrl_stop(const struct device *dev);
 
 static inline int z_impl_stepper_ctrl_stop(const struct device *dev)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	if (DEVICE_API_GET(stepper_ctrl, dev)->stop == NULL) {
 		return -ENOSYS;
 	}
@@ -443,7 +435,6 @@ __syscall int stepper_ctrl_is_moving(const struct device *dev, bool *is_moving);
 
 static inline int z_impl_stepper_ctrl_is_moving(const struct device *dev, bool *is_moving)
 {
-	__ASSERT_NO_MSG(dev != NULL);
 	__ASSERT_NO_MSG(is_moving != NULL);
 	if (DEVICE_API_GET(stepper_ctrl, dev)->is_moving == NULL) {
 		return -ENOSYS;


### PR DESCRIPTION
DEVICE_API_GET macro asserts on NULL devices since #103802, hence this assert is no more necessary