### PR TITLE
llext: misc fixes and error checking

### DIFF
--- a/include/zephyr/llext/llext_internal.h
+++ b/include/zephyr/llext/llext_internal.h
@@ -32,6 +32,10 @@ const void *llext_loaded_sect_ptr(struct llext_loader *ldr, struct llext *ext, u
 static inline const char *llext_string(const struct llext_loader *ldr, const struct llext *ext,
 	enum llext_mem mem_idx, unsigned int idx)
 {
+	if (idx >= ext->mem_size[mem_idx]) {
+		return NULL;
+	}
+
 	return (const char *)ext->mem[mem_idx] + idx;
 }
 

--- a/include/zephyr/llext/llext_internal.h
+++ b/include/zephyr/llext/llext_internal.h
@@ -59,6 +59,9 @@ static inline const char *llext_symbol_name(const struct llext_loader *ldr,
 					    const elf_sym_t *sym)
 {
 	if (ELF_ST_TYPE(sym->st_info) == STT_SECTION) {
+		if (sym->st_shndx >= ext->sect_cnt) {
+			return NULL;
+		}
 		return llext_section_name(ldr, ext, ext->sect_hdrs + sym->st_shndx);
 	} else {
 		return llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym->st_name);

--- a/include/zephyr/llext/loader.h
+++ b/include/zephyr/llext/loader.h
@@ -122,7 +122,7 @@ struct llext_loader {
 	 * @param[in] ldr Loader
 	 * @param[in] pos Position to obtain a pointer to
 	 *
-	 * @returns a pointer into the buffer or `NULL` if not supported
+	 * @returns a pointer into the buffer or `NULL` if not supported or pointer out of bounds.
 	 */
 	void *(*peek)(struct llext_loader *ldr, size_t pos);
 

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -237,6 +237,16 @@ config LLEXT_VENEERS
 	  Disable only if all external symbol calls are known to be in range
 	  or if -mlong-calls is used.
 
+config LLEXT_MAX_INIT_FINI_FUNCTION_TABLE_ENTRIES
+	int "Maximum number of entries in init / fini function pointer table"
+	default 8
+	help
+	  A function pointer table is used to hold preinitialization /
+	  initialization function pointers during bringup and finalization
+	  function pointers during teardown. This option sets the maximum number
+	  of entries in that table. If the number of function pointers for
+	  bringup or teardown exceeds this value, bringup or teardown will fail.
+
 config LLEXT_EXPERIMENTAL
 	bool "LLEXT experimental functionality"
 	help

--- a/subsys/llext/buf_loader.c
+++ b/subsys/llext/buf_loader.c
@@ -34,5 +34,9 @@ void *llext_buf_peek(struct llext_loader *l, size_t pos)
 {
 	struct llext_buf_loader *buf_l = CONTAINER_OF(l, struct llext_buf_loader, loader);
 
+	if (pos >= buf_l->len) {
+		return NULL;
+	}
+
 	return (void *)(buf_l->buf + pos);
 }

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -63,14 +63,20 @@ ssize_t llext_find_section(struct llext_loader *ldr, const char *search_name)
 	     i < ldr->hdr.e_shnum;
 	     i++, pos += ldr->hdr.e_shentsize) {
 		shdr = llext_peek(ldr, pos);
-		if (!shdr) {
-			/* The peek() method isn't supported */
+		if (shdr == NULL) {
+			/* The peek() method isn't supported, or - less likely - shdr is
+			 * out of bounds
+			 */
 			return -ENOTSUP;
 		}
 
 		const char *name = llext_peek(ldr,
 					      ldr->sects[LLEXT_MEM_SHSTRTAB].sh_offset +
 					      shdr->sh_name);
+
+		if (name == NULL) {
+			return -ENOEXEC;
+		}
 
 		if (!strcmp(name, search_name)) {
 			return shdr->sh_offset;

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -286,7 +286,17 @@ static int call_fn_table(struct llext *ext, bool is_init)
 	typedef void (*elf_void_fn_t)(void);
 
 	int fn_count = ret / sizeof(elf_void_fn_t);
-	elf_void_fn_t fn_table[fn_count];
+
+	if (fn_count == 0) {
+		return 0;
+	} else if (fn_count > CONFIG_LLEXT_MAX_INIT_FINI_FUNCTION_TABLE_ENTRIES) {
+		LOG_ERR("%s function table too large: %d entries (max %d)",
+			is_init ? "Bringup" : "Teardown", fn_count,
+			CONFIG_LLEXT_MAX_INIT_FINI_FUNCTION_TABLE_ENTRIES);
+		return -ENOEXEC;
+	}
+
+	elf_void_fn_t fn_table[CONFIG_LLEXT_MAX_INIT_FINI_FUNCTION_TABLE_ENTRIES];
 
 	ret = llext_get_fn_table(ext, is_init, &fn_table, sizeof(fn_table));
 	if (ret < 0) {

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -31,7 +31,12 @@ int llext_section_shndx(const struct llext_loader *ldr, const struct llext *ext,
 	for (i = 1; i < ext->sect_cnt; i++) {
 		const char *name = llext_section_name(ldr, ext, ext->sect_hdrs + i);
 
-		if (!strcmp(name, sect_name)) {
+		if (name == NULL) {
+			LOG_ERR("Out of bounds string table index %u "
+				"for section name of section %d",
+				ext->sect_hdrs[i].sh_name, i);
+			return -ENOEXEC;
+		} else if (strcmp(name, sect_name) == 0) {
 			return i;
 		}
 	}

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -259,9 +259,16 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 	uint8_t *text = ext->mem[LLEXT_MEM_TEXT];
 	int link_err = 0;
 
-	LOG_DBG("Found %p in PLT %u size %zu cnt %u text %p",
-		(void *)llext_section_name(ldr, ext, shdr),
-		shdr->sh_type, (size_t)shdr->sh_entsize, sh_cnt, (void *)text);
+	const char *sect_name = llext_section_name(ldr, ext, shdr);
+
+	if (sect_name == NULL) {
+		LOG_WRN("PLT: out of bounds string table index %u for section name, "
+			"trying to continue",
+			shdr->sh_name);
+	}
+
+	LOG_DBG("Found %p in PLT %u size %zu cnt %u text %p", (void *)sect_name, shdr->sh_type,
+		(size_t)shdr->sh_entsize, sh_cnt, (void *)text);
 
 	const elf_shdr_t *sym_shdr = ldr->sects + LLEXT_MEM_SYMTAB;
 	unsigned int sym_cnt = sym_shdr->sh_size / sym_shdr->sh_entsize;
@@ -311,6 +318,13 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 		}
 
 		const char *name = llext_symbol_name(ldr, ext, &sym);
+
+		if (name == NULL) {
+			LOG_ERR("PLT: out of bounds string table index %u for symbol name",
+				sym.st_name);
+			link_err = -ENOEXEC;
+			continue;
+		}
 
 		/*
 		 * Both r_offset and sh_addr are addresses for which the extension
@@ -460,6 +474,13 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 
 		name = llext_section_name(ldr, ext, shdr);
 
+		if (name == NULL) {
+			LOG_ERR("Section %d has out of bounds string table index %d "
+				"for section name",
+				shdr->sh_name, i);
+			return -ENOEXEC;
+		}
+
 		/*
 		 * FIXME: The Xtensa port is currently using a different way of
 		 * handling relocations that ultimately results in separate
@@ -528,8 +549,16 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 			ret = llext_read_symbol(ldr, ext, &rel, &sym);
 			if (ret == 0) {
 				name = llext_symbol_name(ldr, ext, &sym);
-				ret = llext_lookup_symbol(ldr, ext, &link_addr, &rel, &sym,
-							  name, shdr);
+				if (name == NULL) {
+					LOG_ERR("out of bounds string table index %u "
+						"for symbol name",
+						sym.st_name);
+					name = "<out of bounds>";
+					ret = -ENOEXEC;
+				} else {
+					ret = llext_lookup_symbol(ldr, ext, &link_addr, &rel, &sym,
+								  name, shdr);
+				}
 			} else {
 				name = "<unknown>";
 			}

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -276,7 +276,7 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 		}
 
 		if (ret != 0) {
-			LOG_ERR("PLT: failed to read RELA #%u, trying to continue", i);
+			LOG_WRN("PLT: failed to read RELA #%u, trying to continue", i);
 			continue;
 		}
 
@@ -296,7 +296,7 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 		}
 
 		if (ret != 0) {
-			LOG_ERR("PLT: failed to read symbol table #%u RELA #%u, trying to continue",
+			LOG_WRN("PLT: failed to read symbol table #%u RELA #%u, trying to continue",
 				j, i);
 			continue;
 		}
@@ -324,7 +324,7 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 		 * since the buffer will be directly modified.
 		 */
 		if (ldr->storage != LLEXT_STORAGE_WRITABLE) {
-			LOG_ERR("PLT: cannot link read-only ELF file");
+			LOG_WRN("PLT: cannot link read-only ELF file");
 			continue;
 		}
 
@@ -333,13 +333,19 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 
 		if (tgt) {
 			/* Relocatable / partially linked ELF. */
+			if (rela.r_offset >= tgt->sh_size) {
+				LOG_WRN("PLT: r_offset %#zx out of target section "
+					"(size %#zx), skipping",
+					(size_t)rela.r_offset, (size_t)tgt->sh_size);
+				continue;
+			}
 			rel_addr += rela.r_offset + tgt->sh_offset;
 		} else {
 			/* Shared / dynamically linked ELF */
 			ssize_t offset = llext_file_offset(ldr, rela.r_offset);
 
 			if (offset < 0) {
-				LOG_ERR("Offset %#zx not found in ELF, trying to continue",
+				LOG_WRN("Offset %#zx not found in ELF, trying to continue",
 					(size_t)rela.r_offset);
 				continue;
 			}

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -580,6 +580,10 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 			if (ldr_parm->section_detached(shdr)) {
 				void *base = llext_peek(ldr, shdr->sh_offset);
 
+				if (base == NULL) {
+					return -ENOEXEC;
+				}
+
 				sys_cache_data_flush_range(base, shdr->sh_size);
 				if (shdr->sh_flags & SHF_EXECINSTR && !ldr_parm->pre_located) {
 					sys_cache_instr_invd_range(base, shdr->sh_size);

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -327,14 +327,22 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 		 * regions.
 		 */
 		if (ldr_parm->section_detached && ldr_parm->section_detached(shdr)) {
+			void *detached_sect_ptr = llext_peek(ldr, shdr->sh_offset);
+
+			if (detached_sect_ptr == NULL) {
+				LOG_ERR("Peek of detached text section %s at ELF offset %p "
+					"unsupported or out of bounds",
+					name, (void *)shdr->sh_offset);
+				return -ENOTSUP;
+			}
+
 			if (mem_idx == LLEXT_MEM_TEXT &&
-			    !INSTR_FETCHABLE(llext_peek(ldr, shdr->sh_offset), shdr->sh_size)) {
+			    !INSTR_FETCHABLE(detached_sect_ptr, shdr->sh_size)) {
 #ifdef CONFIG_ARC
 				LOG_ERR("ELF buffer's detached text section %s not in instruction "
 					"memory: %p-%p",
-					name, (void *)(llext_peek(ldr, shdr->sh_offset)),
-					(void *)((char *)llext_peek(ldr, shdr->sh_offset) +
-						 shdr->sh_size));
+					name, detached_sect_ptr,
+					(void *)((char *)detached_sect_ptr + shdr->sh_size));
 				return -ENOEXEC;
 #else
 				LOG_WRN("Unknown if ELF buffer's detached text section %s is in "

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -531,6 +531,12 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 		enum llext_mem mem_idx = ldr->sect_map[i].mem_idx;
 
 		if (shdr->sh_type == SHT_REL || shdr->sh_type == SHT_RELA) {
+			if (shdr->sh_info >= ext->sect_cnt) {
+				LOG_ERR("Relocation section %d has invalid "
+					"target section index %zd",
+					i, (size_t)shdr->sh_info);
+				return -ENOEXEC;
+			}
 			enum llext_mem target_region = ldr->sect_map[shdr->sh_info].mem_idx;
 
 			if (target_region != LLEXT_MEM_COUNT) {

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -730,6 +730,11 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 
 		if ((stt == STT_FUNC || stt == STT_OBJECT) &&
 		    stb == STB_GLOBAL && shndx != SHN_UNDEF) {
+			if (shndx >= ext->sect_cnt) {
+				LOG_ERR("Symbol %d has invalid section index %u", i, shndx);
+				return -ENOEXEC;
+			}
+
 			const char *name = llext_symbol_name(ldr, ext, &sym);
 
 			__ASSERT(j <= sym_tab->sym_cnt, "Miscalculated symbol number %u\n", j);

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -249,6 +249,13 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 
 		name = llext_section_name(ldr, ext, shdr);
 
+		if (name == NULL) {
+			LOG_ERR("section %d has out of bounds string table index %d "
+				"for section name",
+				shdr->sh_name, i);
+			return -ENOEXEC;
+		}
+
 		if (ldr->sect_map[i].mem_idx != LLEXT_MEM_COUNT) {
 			LOG_DBG("section %d name %s already mapped to region %d",
 				i, name, ldr->sect_map[i].mem_idx);
@@ -572,8 +579,6 @@ static int llext_count_export_syms(struct llext_loader *ldr, struct llext *ext)
 	size_t ent_size = ldr->sects[LLEXT_MEM_SYMTAB].sh_entsize;
 	size_t syms_size = ldr->sects[LLEXT_MEM_SYMTAB].sh_size;
 	int sym_cnt = syms_size / sizeof(elf_sym_t);
-	elf_shdr_t *str_region = ldr->sects + LLEXT_MEM_STRTAB;
-	size_t str_reg_size = str_region->sh_size;
 	const char *name;
 	elf_sym_t sym;
 	int i, ret;
@@ -600,17 +605,17 @@ static int llext_count_export_syms(struct llext_loader *ldr, struct llext *ext)
 			return ret;
 		}
 
-		if (sym.st_name >= str_reg_size) {
-			LOG_ERR("Invalid symbol name index %d in symbol %d",
-				sym.st_name, i);
-			return -ENOEXEC;
-		}
-
 		uint32_t stt = ELF_ST_TYPE(sym.st_info);
 		uint32_t stb = ELF_ST_BIND(sym.st_info);
 		uint32_t sect = sym.st_shndx;
 
 		name = llext_symbol_name(ldr, ext, &sym);
+
+		if (name == NULL) {
+			LOG_ERR("Out of bounds string table index for symbol name %d in symbol %d",
+				sym.st_name, i);
+			return -ENOEXEC;
+		}
 
 		if ((stt == STT_FUNC || stt == STT_OBJECT) && stb == STB_GLOBAL) {
 			LOG_DBG("function symbol %d, name %s, type tag %d, bind %d, sect %d",
@@ -737,6 +742,13 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 
 			const char *name = llext_symbol_name(ldr, ext, &sym);
 
+			if (name == NULL) {
+				LOG_ERR("Symbol %d has out of bounds string table index %d for "
+					"symbol name",
+					i, sym.st_name);
+				return -ENOEXEC;
+			}
+
 			__ASSERT(j <= sym_tab->sym_cnt, "Miscalculated symbol number %u\n", j);
 
 			sym_tab->syms[j].name = name;
@@ -773,25 +785,6 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 			LOG_DBG("function symbol %d name %s addr %p",
 				j, name, sym_tab->syms[j].addr);
 			j++;
-		}
-	}
-
-	return 0;
-}
-
-static int llext_validate_sections_name(struct llext_loader *ldr, struct llext *ext)
-{
-	const elf_shdr_t *shstrtab = ldr->sects + LLEXT_MEM_SHSTRTAB;
-	size_t shstrtab_size = shstrtab->sh_size;
-	int i;
-
-	for (i = 0; i < ext->sect_cnt; i++) {
-		elf_shdr_t *shdr = ext->sect_hdrs + i;
-
-		if (shdr->sh_name >= shstrtab_size) {
-			LOG_ERR("Invalid section name index %d in section %d",
-				shdr->sh_name, i);
-			return -ENOEXEC;
 		}
 	}
 
@@ -841,12 +834,6 @@ int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 	ret = llext_copy_strings(ldr, ext, ldr_parm);
 	if (ret != 0) {
 		LOG_ERR("Failed to copy ELF string sections, ret %d", ret);
-		goto out;
-	}
-
-	ret = llext_validate_sections_name(ldr, ext);
-	if (ret != 0) {
-		LOG_ERR("Failed to validate ELF section names, ret %d", ret);
 		goto out;
 	}
 

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -272,8 +272,16 @@ int llext_copy_regions(struct llext_loader *ldr, struct llext *ext,
 
 			/* only show sections mapped to program memory */
 			if (mem_idx < LLEXT_MEM_EXPORT) {
-				LOG_DBG("-s %s %#zx", name,
-					(size_t)ext->mem[mem_idx] + ldr->sect_map[i].offset);
+				if (name == NULL) {
+					LOG_WRN("-s (out of bounds section name string table "
+						"index) %#zx",
+						(size_t)ext->mem[mem_idx] +
+							ldr->sect_map[i].offset);
+				} else {
+					LOG_DBG("-s %s %#zx", name,
+						(size_t)ext->mem[mem_idx] +
+							ldr->sect_map[i].offset);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
A variety of fixes and error checking from me and @nashif:

* Cap variable length array in call_fn_table
* Add bounds checking assert to llext_string
* Validate st_shndx in llext_symbol_name for STT_SECTION symbols
* Bound-check r_offset in Xtensa PLT relocatable branch
* Validate st_shndx before indexing sect_hdrs in copy_symbols
* Validate pos in llext_buf_peek and guard NULL callers
* Validate sh_info before indexing sect_map

More details in commit messages

Fixes: #112621