### PR TITLE
boards: adi: max32660evsys: Fix led gpio polarity

### DIFF
--- a/boards/adi/max32660evsys/max32660evsys.dts
+++ b/boards/adi/max32660evsys/max32660evsys.dts
@@ -26,7 +26,7 @@
 		compatible = "gpio-leds";
 
 		led1: led_1 {
-			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
 			label = "Red LED";
 		};
 	};


### PR DESCRIPTION
The led gpio was incorrectly configured as active low, when it's really active high.