### PR TITLE
shell: Reject zero terminal size from VT100 reply

### DIFF
--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -200,7 +200,7 @@ static int terminal_size_get(const struct shell *sh)
 	/* Move to last row. */
 	z_shell_op_cursor_horiz_move(sh, SHELL_MAX_TERMINAL_SIZE);
 
-	if (cursor_position_get(sh, &x, &y) == 0) {
+	if ((cursor_position_get(sh, &x, &y) == 0) && (x != 0U) && (y != 0U)) {
 		sh->ctx->vt100_ctx.cons.terminal_wid = x;
 		sh->ctx->vt100_ctx.cons.terminal_hei = y;
 	} else {


### PR DESCRIPTION
A peer replying to the ESC[6n cursor-position query with ESC[0;0R causes terminal_size_get() to store terminal_wid = 0. Any later shell-core helper that divides or moduloes by terminal_wid then faults with a divide-by-zero.

Validate the parsed coordinates and treat zero as a parsing failure. cmd_resize() already restores CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH/ HEIGHT on error, so a forged reply now behaves the same as a terminal-response timeout.