### PR TITLE
boards: st: nucleo_g031k8: expose user LD3 as PWM LED

### DIFF
--- a/boards/st/nucleo_g031k8/nucleo_g031k8.dts
+++ b/boards/st/nucleo_g031k8/nucleo_g031k8.dts
@@ -29,8 +29,17 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+
+		green_pwm_led: green_pwm_led {
+			pwms = <&pwm3 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
 	aliases {
 		led0 = &green_led_3;
+		pwm-led0 = &green_pwm_led;
 	};
 };
 
@@ -84,4 +93,15 @@
 	pinctrl-0 = <&spi1_sck_pb3 &spi1_miso_pb4 &spi1_mosi_pb5>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&timers3 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm3: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim3_ch1_pc6>;
+		pinctrl-names = "default";
+	};
 };


### PR DESCRIPTION
LD3 on PC6 was described only as a gpio-led, so PWM samples like
samples/basic/fade_led found no pwm-led0 alias and never drove it.
PC6 routes to TIM3_CH1, so add a pwm-leds node and pwm-led0 alias on
a new pwm3 channel, keeping the existing gpio-led on the same pin as
nucleo_g431kb does.

Tested by flashing fade_led on a nucleo_g031k8: LD3 visibly fades.
