### PR TITLE
drivers: stepper: adi_tmc: remove dead stallguard asserts

### DIFF
--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_stepper_driver.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_stepper_driver.c
@@ -167,9 +167,6 @@ static DEVICE_API(stepper, tmc50xx_stepper_driver_api) = {
 };
 
 #define TMC50XX_STEPPER_DRV_DEFINE(inst)                                                           \
-	COND_CODE_1(DT_PROP_EXISTS(inst, stallguard_threshold_velocity),                           \
-	BUILD_ASSERT(DT_PROP(inst, stallguard_threshold_velocity),                                 \
-			"stallguard threshold velocity must be a positive value"), ());            \
 	static const struct tmc50xx_stepper_driver_config tmc50xx_stepper_driver_config_##inst = { \
 		.controller = DEVICE_DT_GET(DT_PARENT(DT_DRV_INST(inst))),                         \
 		.default_micro_step_res = DT_INST_PROP(inst, micro_step_res),                      \

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
@@ -525,9 +525,6 @@ static int tmc51xx_init(const struct device *dev)
 		     "clock frequency must be non-zero positive value");                           \
 	static struct tmc51xx_data tmc51xx_data_##inst = {                                         \
 		.dev = DEVICE_DT_GET(DT_DRV_INST(inst))};                                          \
-	COND_CODE_1(DT_PROP_EXISTS(inst, stallguard_threshold_velocity),			   \
-	BUILD_ASSERT(DT_PROP(inst, stallguard_threshold_velocity),				   \
-		     "stallguard threshold velocity must be a positive value"), ());               \
 	static const struct tmc51xx_config tmc51xx_config_##inst = {COND_CODE_1			   \
 		(DT_INST_ON_BUS(inst, spi),							   \
 		(TMC51XX_CONFIG_SPI(inst)),							   \

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_stepper_driver.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_stepper_driver.c
@@ -202,9 +202,6 @@ static DEVICE_API(stepper, tmc51xx_stepper_driver_api) = {
 };
 
 #define TMC51XX_STEPPER_DRIVER_DEFINE(inst)                                                        \
-	COND_CODE_1(DT_PROP_EXISTS(inst, stallguard_threshold_velocity),                           \
-	BUILD_ASSERT(DT_PROP(inst, stallguard_threshold_velocity),                                 \
-			"stallguard threshold velocity must be a positive value"), ());            \
 	static const struct tmc51xx_stepper_driver_config tmc51xx_stepper_driver_config_##inst = { \
 		.controller = DEVICE_DT_GET(DT_PARENT(DT_DRV_INST(inst))),                         \
 		.default_micro_step_res = DT_INST_PROP(inst, micro_step_res),                      \


### PR DESCRIPTION
This PR removes obsolete, dead `BUILD_ASSERT` statements from the `tmc50xx` and `tmc51xx` drivers. The assertions checked for `stallguard-threshold-velocity`, which belongs to the controller bindings rather than individual driver instances, causing the driver-level `DT_PROP_EXISTS` guards to always evaluate to false.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/109856