### PR TITLE
SCMI introduce performance protocol

### DIFF
--- a/drivers/firmware/scmi/CMakeLists.txt
+++ b/drivers/firmware/scmi/CMakeLists.txt
@@ -11,6 +11,7 @@ zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_SMC_TRANSPORT smc.c)
 # SCMI protocol helper files
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_BASE_HELPERS base.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_CLK_HELPERS clk.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_PERF perf.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_PINCTRL_HELPERS pinctrl.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_POWER_DOMAIN_HELPERS power.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_REBOOT reboot.c)

--- a/drivers/firmware/scmi/Kconfig
+++ b/drivers/firmware/scmi/Kconfig
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright 2024, 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if ARM_SCMI
@@ -29,6 +29,13 @@ config ARM_SCMI_SMC_TRANSPORT
 	help
 	  Enable support for SCMI transport based on shared memory
 	  and ARM SMC as doorbell.
+
+config ARM_SCMI_PERF
+	bool "SCMI performance domain protocol"
+	default y
+	depends on DT_HAS_ARM_SCMI_PERF_ENABLED
+	help
+	  Enable support for SCMI performance domain protocol function.
 
 config ARM_SCMI_PINCTRL_HELPERS
 	bool "Helper functions for SCMI pinctrl protocol"
@@ -108,6 +115,24 @@ config ARM_SCMI_BASE_HELPERS
 	bool "Helper functions for SCMI base protocol"
 	help
 	  Enable support for SCMI base protocol helper functions.
+
+if ARM_SCMI_PERF
+
+config ARM_SCMI_PERF_OPPS_PER_MSG
+	int "Maximum OPPs per DESCRIBE_LEVELS reply buffer"
+	default 4
+	help
+	  Size of the reply buffer for one PERFORMANCE_DESCRIBE_LEVELS
+	  exchange, expressed as the maximum number of v4 OPP entries
+	  (each 20 bytes) the buffer can hold.
+
+	  The firmware returns as many OPPs as fit in the shmem region:
+	    max_opps = floor((shmem_size - shmem_header - msg_header) / 20)
+	  Common values:
+	    128-byte shmem (i.MX95 default): floor((128 - 28 - 4) / 20) = 4
+	    256-byte shmem:                  floor((256 - 28 - 4) / 20) = 11
+
+endif # ARM_SCMI_PERF
 
 source "drivers/firmware/scmi/nxp/Kconfig"
 source "drivers/firmware/scmi/shell/Kconfig"

--- a/drivers/firmware/scmi/perf.c
+++ b/drivers/firmware/scmi/perf.c
@@ -1,0 +1,511 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/firmware/scmi/perf.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+
+DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_perf), NULL,
+		SCMI_PERF_PROTOCOL_SUPPORTED_VERSION);
+
+/* Reply buffer capacity for DESCRIBE_LEVELS. */
+#define SCMI_PERF_OPPS_PER_MSG	CONFIG_ARM_SCMI_PERF_OPPS_PER_MSG
+
+enum scmi_perf_message {
+	PERF_PROTOCOL_ATTRIBUTES = 0x1,
+	PERF_DOMAIN_ATTRIBUTES   = 0x3,
+	PERF_DESCRIBE_LEVELS     = 0x4,
+	PERF_LIMITS_SET          = 0x5,
+	PERF_LIMITS_GET          = 0x6,
+	PERF_LEVEL_SET           = 0x7,
+	PERF_LEVEL_GET           = 0x8,
+};
+
+struct scmi_perf_proto_attrs_reply {
+	int32_t  status;
+	uint32_t attributes;
+	uint32_t stats_addr_low;
+	uint32_t stats_addr_high;
+	uint32_t stats_size;
+} __packed;
+
+struct scmi_perf_domain_attrs_reply {
+	int32_t  status;
+	uint32_t flags;
+	uint32_t rate_limit;
+	uint32_t sustained_freq_khz;
+	uint32_t sustained_perf_level;
+	uint8_t  name[SCMI_SHORT_NAME_MAX_SIZE];
+} __packed;
+
+struct scmi_perf_describe_levels_req {
+	uint32_t domain_id;
+	uint32_t level_index;
+};
+
+/* v4 OPP wire format — indicative_freq and level_index appended */
+struct scmi_perf_opp_wire {
+	uint32_t perf_val;
+	uint32_t power;
+	uint16_t transition_latency_us;
+	uint16_t reserved;
+	uint32_t indicative_freq;
+	uint32_t level_index;
+} __packed;
+
+struct scmi_perf_describe_levels_reply {
+	int32_t  status;
+	uint16_t num_returned;
+	uint16_t num_remaining;
+	struct scmi_perf_opp_wire opp[SCMI_PERF_OPPS_PER_MSG];
+} __packed;
+
+struct scmi_perf_level_set_req {
+	uint32_t domain_id;
+	uint32_t performance_level;
+};
+
+struct scmi_perf_level_get_reply {
+	int32_t  status;
+	uint32_t performance_level;
+};
+
+struct scmi_perf_limits_get_reply {
+	int32_t  status;
+	uint32_t max_level;
+	uint32_t min_level;
+};
+
+struct scmi_perf_domain_cache {
+	struct scmi_perf_opp opps[SCMI_PERF_MAX_OPPS];
+	uint32_t             count;
+	bool                 level_indexing_mode;
+	bool                 valid;
+};
+
+static struct scmi_perf_domain_cache domain_cache[32];
+
+static int scmi_perf_cache_fill(uint32_t domain_id);
+
+static struct scmi_perf_domain_cache *scmi_perf_cache_get(uint32_t domain_id)
+{
+	if (domain_id >= ARRAY_SIZE(domain_cache)) {
+		return NULL;
+	}
+
+	if (!domain_cache[domain_id].valid) {
+		if (scmi_perf_cache_fill(domain_id) < 0) {
+			return NULL;
+		}
+	}
+
+	return &domain_cache[domain_id];
+}
+
+static int scmi_perf_cache_fill(uint32_t domain_id)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PERF);
+	struct scmi_perf_domain_attrs_reply attrs_reply;
+	struct scmi_perf_describe_levels_req req;
+	struct scmi_perf_describe_levels_reply lvl_reply;
+	struct scmi_message msg, reply;
+	struct scmi_perf_domain_cache *cache = &domain_cache[domain_id];
+	uint32_t total = 0, index = 0;
+	int ret;
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PERF_DOMAIN_ATTRIBUTES, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(domain_id);
+	msg.content = &domain_id;
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(attrs_reply);
+	reply.content = &attrs_reply;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (attrs_reply.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(attrs_reply.status);
+	}
+
+	/* BIT 25 = SUPPORTS_LEVEL_INDEXING (ARM SCMI spec v4, §13.4.3).
+	 * When set, LEVEL_GET returns an opaque index and LEVEL_SET expects an index.
+	 */
+	cache->level_indexing_mode = !!(attrs_reply.flags & BIT(25));
+
+	do {
+		req.domain_id   = domain_id;
+		req.level_index = index;
+
+		msg.hdr = SCMI_MESSAGE_HDR_MAKE(PERF_DESCRIBE_LEVELS, SCMI_COMMAND,
+						proto->id, 0x0);
+		msg.len = sizeof(req);
+		msg.content = &req;
+		reply.hdr = msg.hdr;
+		reply.len = sizeof(lvl_reply);
+		reply.content = &lvl_reply;
+
+		ret = scmi_send_message(proto, &msg, &reply, false);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (lvl_reply.status != SCMI_SUCCESS) {
+			return scmi_status_to_errno(lvl_reply.status);
+		}
+
+		for (uint16_t i = 0; i < lvl_reply.num_returned &&
+				      total < SCMI_PERF_MAX_OPPS; i++) {
+			cache->opps[total].perf_val_khz =
+				lvl_reply.opp[i].perf_val;
+			cache->opps[total].power_mw =
+				lvl_reply.opp[i].power;
+			cache->opps[total].transition_latency_us =
+				lvl_reply.opp[i].transition_latency_us;
+			cache->opps[total].indicative_freq_khz =
+				lvl_reply.opp[i].indicative_freq;
+			total++;
+		}
+
+		index += lvl_reply.num_returned;
+
+	} while (lvl_reply.num_remaining > 0 && total < SCMI_PERF_MAX_OPPS);
+
+	cache->count = total;
+	cache->valid = true;
+
+	return 0;
+}
+
+/* Translate level index → kHz (index mode only) */
+static int scmi_perf_idx_to_khz(const struct scmi_perf_domain_cache *cache,
+				uint32_t idx, uint32_t *khz)
+{
+	if (idx >= cache->count) {
+		return -ERANGE;
+	}
+
+	*khz = cache->opps[idx].perf_val_khz;
+	return 0;
+}
+
+/* Translate kHz → level index (index mode only) */
+static int scmi_perf_khz_to_idx(const struct scmi_perf_domain_cache *cache,
+				uint32_t khz, uint32_t *idx)
+{
+	for (uint32_t i = 0; i < cache->count; i++) {
+		if (cache->opps[i].perf_val_khz == khz) {
+			*idx = i;
+			return 0;
+		}
+	}
+
+	return -ENOENT;
+}
+
+int scmi_perf_num_domains_get(uint32_t *num_domains)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PERF);
+	struct scmi_perf_proto_attrs_reply reply_buffer;
+	struct scmi_message msg, reply;
+	int ret;
+
+	if (!proto || !num_domains) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_PERF) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PERF_PROTOCOL_ATTRIBUTES, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = 0;
+	msg.content = NULL;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (reply_buffer.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(reply_buffer.status);
+	}
+
+	*num_domains = reply_buffer.attributes & GENMASK(15, 0);
+
+	return 0;
+}
+
+int scmi_perf_domain_attributes_get(uint32_t domain_id,
+				    struct scmi_perf_domain_attrs *attrs)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PERF);
+	struct scmi_perf_domain_attrs_reply reply_buffer;
+	struct scmi_message msg, reply;
+	int ret;
+
+	if (!proto || !attrs) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_PERF) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PERF_DOMAIN_ATTRIBUTES, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(domain_id);
+	msg.content = &domain_id;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (reply_buffer.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(reply_buffer.status);
+	}
+
+	attrs->flags = reply_buffer.flags;
+	attrs->rate_limit_us = reply_buffer.rate_limit & SCMI_PERF_RATE_LIMIT_MASK;
+	attrs->sustained_freq_khz = reply_buffer.sustained_freq_khz;
+	attrs->sustained_perf_level = reply_buffer.sustained_perf_level;
+	memcpy(attrs->name, reply_buffer.name, SCMI_SHORT_NAME_MAX_SIZE);
+
+	return 0;
+}
+
+int scmi_perf_describe_levels(uint32_t domain_id,
+			      struct scmi_perf_opp *opps,
+			      uint32_t max_opps,
+			      uint32_t *num_opps)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PERF);
+	struct scmi_perf_describe_levels_req req;
+	struct scmi_perf_describe_levels_reply reply_buffer;
+	struct scmi_message msg, reply;
+	uint32_t total = 0, index = 0;
+	int ret;
+
+	if (!proto || !num_opps) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_PERF) {
+		return -EINVAL;
+	}
+
+	do {
+		req.domain_id   = domain_id;
+		req.level_index = index;
+
+		msg.hdr = SCMI_MESSAGE_HDR_MAKE(PERF_DESCRIBE_LEVELS, SCMI_COMMAND,
+						proto->id, 0x0);
+		msg.len = sizeof(req);
+		msg.content = &req;
+
+		reply.hdr = msg.hdr;
+		reply.len = sizeof(reply_buffer);
+		reply.content = &reply_buffer;
+
+		ret = scmi_send_message(proto, &msg, &reply, false);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (reply_buffer.status != SCMI_SUCCESS) {
+			return scmi_status_to_errno(reply_buffer.status);
+		}
+
+		for (uint16_t i = 0; i < reply_buffer.num_returned; i++) {
+			if (opps && total < max_opps) {
+				opps[total].perf_val_khz =
+					reply_buffer.opp[i].perf_val;
+				opps[total].power_mw =
+					reply_buffer.opp[i].power;
+				opps[total].transition_latency_us =
+					reply_buffer.opp[i].transition_latency_us;
+				opps[total].indicative_freq_khz =
+					reply_buffer.opp[i].indicative_freq;
+			}
+			total++;
+		}
+
+		index += reply_buffer.num_returned;
+
+	} while (reply_buffer.num_remaining > 0 &&
+		 (!opps || total < max_opps));
+
+	*num_opps = total;
+
+	return 0;
+}
+
+int scmi_perf_level_set(uint32_t domain_id, uint32_t perf_level_khz)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PERF);
+	struct scmi_perf_level_set_req req;
+	struct scmi_message msg, reply;
+	uint32_t wire_value;
+	int status, ret;
+
+	if (!proto) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_PERF) {
+		return -EINVAL;
+	}
+
+	/*
+	 * Translate kHz → wire value depending on the domain's mode:
+	 *
+	 *   Value mode (BIT 25 = 0): wire value = perf_val in kHz
+	 *     → pass through directly, no OPP cache needed
+	 *
+	 *   Index mode (BIT 25 = 1): wire value = level index
+	 *     → look up kHz in OPP cache to find the matching index
+	 */
+	struct scmi_perf_domain_cache *cache = scmi_perf_cache_get(domain_id);
+
+	if (!cache) {
+		return -ENODEV;
+	}
+
+	if (cache->level_indexing_mode) {
+		ret = scmi_perf_khz_to_idx(cache, perf_level_khz, &wire_value);
+		if (ret < 0) {
+			return ret;
+		}
+	} else {
+		wire_value = perf_level_khz;
+	}
+
+	req.domain_id        = domain_id;
+	req.performance_level = wire_value;
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PERF_LEVEL_SET, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(req);
+	msg.content = &req;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return scmi_status_to_errno(status);
+}
+
+int scmi_perf_level_get(uint32_t domain_id, uint32_t *perf_level_khz)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PERF);
+	struct scmi_perf_level_get_reply reply_buffer;
+	struct scmi_message msg, reply;
+	int ret;
+
+	if (!proto || !perf_level_khz) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_PERF) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PERF_LEVEL_GET, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(domain_id);
+	msg.content = &domain_id;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (reply_buffer.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(reply_buffer.status);
+	}
+
+	/*
+	 * Translate wire value → kHz depending on the domain's mode:
+	 *
+	 *   Value mode (BIT 25 = 0): wire value is already kHz
+	 *   Index mode (BIT 25 = 1): wire value is a level index
+	 */
+	struct scmi_perf_domain_cache *cache = scmi_perf_cache_get(domain_id);
+
+	if (!cache) {
+		return -ENODEV;
+	}
+
+	if (cache->level_indexing_mode) {
+		return scmi_perf_idx_to_khz(cache,
+					    reply_buffer.performance_level,
+					    perf_level_khz);
+	}
+
+	*perf_level_khz = reply_buffer.performance_level;
+
+	return 0;
+}
+
+int scmi_perf_limits_get(uint32_t domain_id, struct scmi_perf_limits *limits)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PERF);
+	struct scmi_perf_limits_get_reply reply_buffer;
+	struct scmi_message msg, reply;
+	int ret;
+
+	if (!proto || !limits) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_PERF) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PERF_LIMITS_GET, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(domain_id);
+	msg.content = &domain_id;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (reply_buffer.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(reply_buffer.status);
+	}
+
+	limits->max_level = reply_buffer.max_level;
+	limits->min_level = reply_buffer.min_level;
+
+	return 0;
+}

--- a/drivers/firmware/scmi/shell/CMakeLists.txt
+++ b/drivers/firmware/scmi/shell/CMakeLists.txt
@@ -9,3 +9,4 @@ zephyr_library_sources(core.c)
 
 # protocol module - implements protocol-related sub-commands
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_CLK_HELPERS clk.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_PERF perf.c)

--- a/drivers/firmware/scmi/shell/perf.c
+++ b/drivers/firmware/scmi/shell/perf.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+#include <zephyr/drivers/firmware/scmi/perf.h>
+#include <zephyr/drivers/firmware/scmi/protocol.h>
+#include <zephyr/shell/shell.h>
+
+extern struct scmi_protocol SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PERF);
+static struct scmi_protocol *_proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PERF);
+
+static int cmd_perf_version(const struct shell *sh, size_t argc, char **argv)
+{
+	uint32_t version;
+	int ret;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	ret = scmi_protocol_get_version(_proto, &version);
+	if (ret) {
+		shell_error(sh, "failed to query protocol version: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "Performance protocol version: 0x%x", version);
+	return 0;
+}
+
+static int cmd_perf_summary(const struct shell *sh, size_t argc, char **argv)
+{
+	struct scmi_perf_domain_attrs attrs;
+	uint32_t num_domains = 0;
+	uint32_t num_opps;
+	int ret;
+
+	uint32_t current_khz = 0;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	ret = scmi_perf_num_domains_get(&num_domains);
+	if (ret) {
+		shell_error(sh, "PROTOCOL_ATTRIBUTES failed: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "Performance domains: %u", num_domains);
+	shell_print(sh, "%-4s %-16s %-12s %-12s %-10s",
+		    "ID", "Name", "Sustained", "Current", "OPPs");
+	shell_print(sh, "%-4s %-16s %-12s %-12s %-10s",
+		    "----", "----------------", "------------", "------------", "----------");
+
+	for (uint32_t id = 0; id < num_domains; id++) {
+		ret = scmi_perf_domain_attributes_get(id, &attrs);
+		if (ret) {
+			shell_warn(sh, "domain %u: DOMAIN_ATTRIBUTES failed: %d",
+				   id, ret);
+			continue;
+		}
+
+		num_opps = 0;
+		scmi_perf_describe_levels(id, NULL, 0, &num_opps);
+		scmi_perf_level_get(id, &current_khz);
+
+		shell_print(sh, "%-4u %-16s %-8u kHz  %-8u kHz  %-10u",
+				id, attrs.name, attrs.sustained_freq_khz, current_khz, num_opps);
+	}
+
+	return 0;
+}
+
+static int cmd_perf_info(const struct shell *sh, size_t argc, char **argv)
+{
+	struct scmi_perf_domain_attrs attrs;
+	struct scmi_perf_opp opps[SCMI_PERF_MAX_OPPS];
+	struct scmi_perf_limits limits;
+	uint32_t domain_id, current_level, num_opps;
+	int ret;
+
+	domain_id = (uint32_t)strtoul(argv[1], NULL, 0);
+
+	ret = scmi_perf_domain_attributes_get(domain_id, &attrs);
+	if (ret) {
+		shell_error(sh, "DOMAIN_ATTRIBUTES failed: %d", ret);
+		return ret;
+	}
+
+	ret = scmi_perf_level_get(domain_id, &current_level);
+	if (ret) {
+		shell_error(sh, "LEVEL_GET failed: %d", ret);
+		return ret;
+	}
+
+	ret = scmi_perf_describe_levels(domain_id, opps,
+					SCMI_PERF_MAX_OPPS, &num_opps);
+	if (ret) {
+		shell_error(sh, "DESCRIBE_LEVELS failed: %d", ret);
+		return ret;
+	}
+
+	ret = scmi_perf_limits_get(domain_id, &limits);
+
+	shell_print(sh, "Domain %u: %s", domain_id, attrs.name);
+	shell_print(sh, "  Flags:     0x%08x", attrs.flags);
+	shell_print(sh, "  Sustained: %u kHz", attrs.sustained_freq_khz);
+	shell_print(sh, "  Current:   %u kHz (%u MHz)",
+		    current_level, current_level / 1000U);
+
+	if (ret == 0) {
+		shell_print(sh, "  Limits:    [%u, %u] kHz",
+			    limits.min_level, limits.max_level);
+	}
+
+	shell_print(sh, "  OPPs (%u):", num_opps);
+	for (uint32_t i = 0; i < num_opps; i++) {
+		shell_print(sh, "    [%u] %u kHz (%u MHz)  latency %u us%s",
+			    i,
+			    opps[i].perf_val_khz,
+			    opps[i].perf_val_khz / 1000U,
+			    opps[i].transition_latency_us,
+			    (opps[i].perf_val_khz == current_level) ?
+				"  <-- current" : "");
+	}
+
+	return 0;
+}
+
+static int cmd_perf_set_level(const struct shell *sh, size_t argc, char **argv)
+{
+	uint32_t domain_id, perf_level_khz;
+	int ret;
+
+	domain_id      = (uint32_t)strtoul(argv[1], NULL, 0);
+	perf_level_khz = (uint32_t)strtoul(argv[2], NULL, 0);
+
+	ret = scmi_perf_level_set(domain_id, perf_level_khz);
+	if (ret) {
+		shell_error(sh,
+			    "PERFORMANCE_LEVEL_SET domain=%u level=%u kHz failed: %d",
+			    domain_id, perf_level_khz, ret);
+		return ret;
+	}
+
+	shell_print(sh, "domain %u: set to %u kHz (%u MHz)",
+		    domain_id, perf_level_khz, perf_level_khz / 1000U);
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(perf_cmds,
+	SHELL_CMD(version, NULL,
+		  "Get performance protocol version",
+		  cmd_perf_version),
+	SHELL_CMD(summary, NULL,
+		  "List all performance domains",
+		  cmd_perf_summary),
+	SHELL_CMD_ARG(info, NULL,
+		      "Show OPPs and current level\n"
+		      "Usage: scmi perf info <domain_id>",
+		      cmd_perf_info, 2, 0),
+	SHELL_CMD_ARG(set-level, NULL,
+		      "Set performance level in kHz\n"
+		      "Usage: scmi perf set-level <domain_id> <khz>",
+		      cmd_perf_set_level, 3, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_SUBCMD_ADD((scmi), perf, &perf_cmds,
+		 "Performance domain protocol commands", NULL, 0, 0);

--- a/dts/arm/nxp/imx/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx94x.dtsi
@@ -37,6 +37,11 @@
 				reg = <0x12>;
 			};
 
+			scmi_perf: protocol@13 {
+				compatible = "arm,scmi-perf";
+				reg = <0x13>;
+			};
+
 			scmi_clk: protocol@14 {
 				compatible = "arm,scmi-clock";
 				reg = <0x14>;

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -91,6 +91,11 @@
 				reg = <0x12>;
 			};
 
+			scmi_perf: protocol@13 {
+				compatible = "arm,scmi-perf";
+				reg = <0x13>;
+			};
+
 			scmi_clk: protocol@14 {
 				compatible = "arm,scmi-clock";
 				reg = <0x14>;

--- a/dts/bindings/firmware/arm,scmi-perf.yaml
+++ b/dts/bindings/firmware/arm,scmi-perf.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: SCMI (System Control and Management Interface) performance domain protocol
+
+compatible: "arm,scmi-perf"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+    const: [0x13]

--- a/include/zephyr/drivers/firmware/scmi/perf.h
+++ b/include/zephyr/drivers/firmware/scmi/perf.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup scmi_perf
+ * @brief Header file for the SCMI Performance Domain Protocol.
+ */
+
+#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PERF_H_
+#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PERF_H_
+
+#include <zephyr/drivers/firmware/scmi/protocol.h>
+
+/**
+ * @brief Performance domain management via SCMI
+ * @defgroup scmi_perf Performance Domain Protocol
+ * @ingroup scmi_protocols
+ * @{
+ */
+
+/** SCMI Performance Domain protocol supported version */
+#define SCMI_PERF_PROTOCOL_SUPPORTED_VERSION		0x40000
+
+/** Maximum number of OPPs that can be cached per performance domain */
+#define SCMI_PERF_MAX_OPPS				16
+
+/**
+ * @name SCMI performance domain attribute flags
+ * @{
+ */
+
+/** Domain supports PERFORMANCE_LIMITS_SET command */
+#define SCMI_PERF_ATTR_SET_LIMITS(f)		((f) & BIT(31))
+/** Domain supports PERFORMANCE_LEVEL_SET command */
+#define SCMI_PERF_ATTR_SET_LEVEL(f)		((f) & BIT(30))
+/** Domain supports performance limit change notifications */
+#define SCMI_PERF_ATTR_LIMIT_NOTIFY(f)		((f) & BIT(29))
+/** Domain supports performance level change notifications */
+#define SCMI_PERF_ATTR_LEVEL_NOTIFY(f)		((f) & BIT(28))
+/** Domain supports fast channels */
+#define SCMI_PERF_ATTR_FASTCHANNELS(f)		((f) & BIT(27))
+/** Domain supports extended names (v3+) */
+#define SCMI_PERF_ATTR_EXTENDED_NAME(f)		((f) & BIT(26))
+/** Domain uses level indexing mode (v4+) */
+#define SCMI_PERF_ATTR_LEVEL_INDEXING(f)	((f) & BIT(25))
+
+/** @} */
+
+/** Rate limit field mask (bits 19:0 of rate_limit field) */
+#define SCMI_PERF_RATE_LIMIT_MASK		GENMASK(19, 0)
+
+/**
+ * @struct scmi_perf_opp
+ *
+ * @brief Describes one Operating Performance Point (OPP) as returned
+ * by the PERFORMANCE_DESCRIBE_LEVELS command.
+ */
+struct scmi_perf_opp {
+	/** Performance level value. */
+	uint32_t perf_val_khz;
+	/** Power cost in mW */
+	uint32_t power_mw;
+	/** Worst-case transition latency in microseconds */
+	uint16_t transition_latency_us;
+	/** Indicative frequency in kHz */
+	uint32_t indicative_freq_khz;
+};
+
+/**
+ * @struct scmi_perf_domain_attrs
+ *
+ * @brief Describes the attributes of a performance domain as returned
+ * by the PERFORMANCE_DOMAIN_ATTRIBUTES command.
+ */
+struct scmi_perf_domain_attrs {
+	/** Domain attribute flags */
+	uint32_t flags;
+	/** Minimum interval in microseconds between successive PERFORMANCE_LEVEL_SET calls */
+	uint32_t rate_limit_us;
+	/** Frequency in kHz at the sustained performance level */
+	uint32_t sustained_freq_khz;
+	/** Performance level value at the sustained operating point */
+	uint32_t sustained_perf_level;
+	/** Short ASCII name of the domain (NUL-terminated) */
+	uint8_t name[SCMI_SHORT_NAME_MAX_SIZE];
+};
+
+/**
+ * @struct scmi_perf_limits
+ *
+ * @brief Describes the current performance limits of a domain as returned
+ * by the PERFORMANCE_LIMITS_GET command.
+ */
+struct scmi_perf_limits {
+	/** Maximum allowed performance level */
+	uint32_t max_level;
+	/** Minimum allowed performance level */
+	uint32_t min_level;
+};
+
+/**
+ * @brief Query the number of performance domains
+ *
+ * Sends the PROTOCOL_ATTRIBUTES command and extracts the domain count
+ * from bits[15:0] of the attributes field.
+ *
+ * @param num_domains pointer to be set to the number of performance domains
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_perf_num_domains_get(uint32_t *num_domains);
+
+/**
+ * @brief Query the attributes of a performance domain
+ *
+ * Sends the PERFORMANCE_DOMAIN_ATTRIBUTES command and returns the
+ * domain's capabilities, rate limit, sustained frequency and name.
+ *
+ * @param domain_id ID of the performance domain to query
+ * @param attrs pointer to structure to be filled with domain attributes
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_perf_domain_attributes_get(uint32_t domain_id,
+				    struct scmi_perf_domain_attrs *attrs);
+
+/**
+ * @brief Enumerate the OPPs of a performance domain
+ *
+ * Sends one or more PERFORMANCE_DESCRIBE_LEVELS commands.
+ *
+ * @param domain_id ID of the performance domain to query
+ * @param opps pointer to array of @ref scmi_perf_opp to be filled,
+ *             or NULL to query the count only
+ * @param max_opps maximum number of OPPs the array can hold
+ * @param num_opps pointer to be set to the actual number of OPPs returned
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_perf_describe_levels(uint32_t domain_id,
+			      struct scmi_perf_opp *opps,
+			      uint32_t max_opps,
+			      uint32_t *num_opps);
+
+/**
+ * @brief Set the performance level of a domain
+ *
+ * @param domain_id ID of the performance domain
+ * @param perf_level_khz desired frequency in kHz (e.g. 800000 for 800 MHz)
+ *
+ * @retval 0 if successful
+ * @retval -ENOENT if @p perf_level_khz is not in the OPP table
+ * @retval negative errno if failure
+ */
+int scmi_perf_level_set(uint32_t domain_id, uint32_t perf_level_khz);
+
+/**
+ * @brief Get the current performance level of a domain
+ *
+ * @param domain_id ID of the performance domain
+ * @param perf_level_khz pointer to be set to the current frequency in kHz
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_perf_level_get(uint32_t domain_id, uint32_t *perf_level_khz);
+
+/**
+ * @brief Get the current performance limits of a domain
+ *
+ * Sends the PERFORMANCE_LIMITS_GET command and returns the current
+ * minimum and maximum allowed performance levels.
+ *
+ * @param domain_id ID of the performance domain
+ * @param limits pointer to structure to be filled with current limits
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_perf_limits_get(uint32_t domain_id, struct scmi_perf_limits *limits);
+
+/**
+ * @}
+ */
+
+#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PERF_H_ */


### PR DESCRIPTION
As first part of https://github.com/zephyrproject-rtos/zephyr/issues/110056

uart:~$ scmi perf summary
Performance domains: 13
ID   Name             Sustained    Current      OPPs
---- ---------------- ------------ ------------ ----------
0    ele              250000   kHz  250000   kHz  4
1    m33              333333   kHz  333333   kHz  4
2    wakeup           400000   kHz  400000   kHz  4
3    m7               800000   kHz  800000   kHz  4
4    dram             800000   kHz  800000   kHz  4
5    hsio             500000   kHz  500000   kHz  4
6    npu              1000000  kHz  1000000  kHz  4
7    noc              800000   kHz  800000   kHz  4
8    a55              1800000  kHz  500000   kHz  4
9    gpu              1000000  kHz  1000000  kHz  4
10   vpu              666667   kHz  666667   kHz  4
11   cam              800000   kHz  800000   kHz  4
12   disp             800000   kHz  800000   kHz  4
uart:~$ scmi perf info 3
Domain 3: m7
  Flags:     0xc2000000
  Sustained: 800000 kHz
  Current:   800000 kHz (800 MHz)
  Limits:    [24000, 800000] kHz
  OPPs (4):
    [0] 24000 kHz (24 MHz)  latency 5000 us
    [1] 400000 kHz (400 MHz)  latency 5000 us
    [2] 666667 kHz (666 MHz)  latency 5000 us
    [3] 800000 kHz (800 MHz)  latency 5000 us  <-- current
uart:~$ scmi perf set-level 3 400000
domain 3: set to 400000 kHz (400 MHz)
uart:~$ scmi perf info 3
Domain 3: m7
  Flags:     0xc2000000
  Sustained: 800000 kHz
  Current:   400000 kHz (400 MHz)
  Limits:    [24000, 800000] kHz
  OPPs (4):
    [0] 24000 kHz (24 MHz)  latency 5000 us
    [1] 400000 kHz (400 MHz)  latency 5000 us  <-- current
    [2] 666667 kHz (666 MHz)  latency 5000 us
    [3] 800000 kHz (800 MHz)  latency 5000 us
uart:~$ scmi perf summary
Performance domains: 13
ID   Name             Sustained    Current      OPPs
---- ---------------- ------------ ------------ ----------
0    ele              250000   kHz  250000   kHz  4
1    m33              333333   kHz  333333   kHz  4
2    wakeup           400000   kHz  400000   kHz  4
3    m7               800000   kHz  400000   kHz  4
4    dram             800000   kHz  800000   kHz  4
5    hsio             500000   kHz  500000   kHz  4
6    npu              1000000  kHz  1000000  kHz  4
7    noc              800000   kHz  800000   kHz  4
8    a55              1800000  kHz  500000   kHz  4
9    gpu              1000000  kHz  1000000  kHz  4
10   vpu              666667   kHz  666667   kHz  4
11   cam              800000   kHz  800000   kHz  4
12   disp             800000   kHz  800000   kHz  4
