### PR TITLE
MAINTAINERS: add area:DALI and nominate SvenHaedrich as maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1645,6 +1645,19 @@ Documentation Infrastructure:
   labels:
     - "area: DAI"
 
+"Drivers: DALI":
+  status: maintained
+  maintainers:
+    - svenhaedrich
+  files:
+    - doc/hardware/peripherals/dali.rst
+    - drivers/dali/
+    - dts/bindings/dali/
+    - include/zephyr/drivers/dali.h
+    - samples/drivers/dali/
+  labels:
+    - "area: DALI"
+
 "Drivers: DMA":
   status: maintained
   maintainers:


### PR DESCRIPTION
Add an area for the recently added DALI (digital addressable lighting interface) driver.
Nominate @SvenHaedrich as maintainer for the area.