### PR TITLE
Sensors: use min max

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -652,12 +652,6 @@ static int adxl345_pm_action(const struct device *dev,
 		     DT_INST_NODE_HAS_PROP(inst, fifo_watermark),				   \
 		     "Streaming requires fifo-watermark property. Please set it in the"		   \
 		     "device-tree node properties");						   \
-	BUILD_ASSERT(COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, fifo_watermark),			   \
-				 ((DT_INST_PROP(inst, fifo_watermark) > 0) &&			   \
-				  (DT_INST_PROP(inst, fifo_watermark) < 32)),			   \
-				 (true)),							   \
-		     "fifo-watermark must be between 1 and 32. Please set it in "		   \
-		     "the device-tree node properties");					   \
 												   \
 	IF_ENABLED(CONFIG_ADXL345_STREAM, (ADXL345_RTIO_DEFINE(inst)));				   \
 	static struct adxl345_dev_data adxl345_data_##inst = {					   \

--- a/drivers/sensor/adi/adxl355/adxl355.c
+++ b/drivers/sensor/adi/adxl355/adxl355.c
@@ -1459,7 +1459,6 @@ static int adxl355_pm_action(const struct device *dev, enum pm_device_action act
 						(ADXL355_CFG_IRQ(inst)), ()) }
 
 #define ADXL355_DEFINE(inst)                                                                       \
-	BUILD_ASSERT(DT_INST_PROP(inst, fifo_watermark) <= 96, "FIFO watermark must be <= 96");    \
 	BUILD_ASSERT(DT_INST_PROP(inst, fifo_watermark) % 3 == 0,                                  \
 		     "FIFO watermark must be multiple of 3");                                      \
 	IF_ENABLED(CONFIG_ADXL355_STREAM,						\

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
@@ -466,10 +466,9 @@ BUILD_ASSERT(CONFIG_BMI08X_GYRO_TRIGGER_NONE,
 #define BMI08X_CREATE_INST(inst)                                                                   \
                                                                                                    \
 	IF_ENABLED(CONFIG_BMI08X_GYRO_STREAM,							   \
-		   (BUILD_ASSERT(DT_INST_PROP_OR(inst, fifo_watermark, 0) > 0 &&		   \
-				 DT_INST_PROP_OR(inst, fifo_watermark, 0) < 100,		   \
-				 "FIFO Watermark must be defined for streaming mode, and be "	   \
-				 "within 1 and 99. Please define fifo-watermark accordingly or "   \
+		   (BUILD_ASSERT(DT_INST_NODE_HAS_PROP(inst, fifo_watermark),			   \
+				 "FIFO Watermark must be defined for streaming mode. "		   \
+				 "Please define fifo-watermark accordingly or "			   \
 				 "disable CONFIG_BMI08X_GYRO_STREAM")));			   \
 												   \
 	RTIO_DEFINE(bmi08x_gyro_rtio_ctx_##inst, 16, 16);                                          \

--- a/drivers/sensor/bosch/bmp581/bmp581.c
+++ b/drivers/sensor/bosch/bmp581/bmp581.c
@@ -832,13 +832,6 @@ static DEVICE_API(sensor, bmp581_driver_api) = {
 
 #define BMP581_INIT(i)                                                                             \
                                                                                                    \
-	BUILD_ASSERT(COND_CODE_1(DT_INST_NODE_HAS_PROP(i, fifo_watermark),                         \
-				 (DT_INST_PROP(i, fifo_watermark) > 0 &&                           \
-				  DT_INST_PROP(i, fifo_watermark) < 16),                           \
-				 (true)),                                                          \
-		     "fifo-watermark must be between 1 and 15. Please set it in "                  \
-		     "the device-tree node properties");                                           \
-                                                                                                   \
 	RTIO_DEFINE(bmp581_rtio_ctx_##i, 16, 16);                                                  \
 	BMP581_BUS_IODEV_DEFINE(i);                                                                \
                                                                                                    \

--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
@@ -380,7 +380,6 @@ BUILD_ASSERT(CONFIG_MAIN_STACK_SIZE >= 4096,
 
 #define AFBR_S50_INIT(inst)									   \
 												   \
-	BUILD_ASSERT(DT_INST_PROP(inst, odr) > 0, "Please set valid ODR");			   \
 	BUILD_ASSERT(DT_INST_PROP(inst, dual_freq_mode == 0) ||					   \
 		     ((DT_INST_PROP(inst, dual_freq_mode) != 0) ^				   \
 		      ((DT_INST_PROP(inst, measurement_mode) & ARGUS_MODE_FLAG_HIGH_SPEED) != 0)), \

--- a/drivers/sensor/nxp/qdec_mcux/qdec_mcux.c
+++ b/drivers/sensor/nxp/qdec_mcux/qdec_mcux.c
@@ -149,11 +149,6 @@ static void init_inputs(const struct device *dev)
 
 #define XBAR_PHANDLE(n)	DT_INST_PHANDLE(n, xbar)
 
-#define QDEC_CHECK_COND(n, p, min, max)						\
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, p), (				\
-		    BUILD_ASSERT(IN_RANGE(DT_INST_PROP(n, p), min, max),	\
-				 STRINGIFY(p) " value is out of range")), ())
-
 #define QDEC_SET_COND(n, v, p)							\
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, p), (v = DT_INST_PROP(n, p)), ())
 
@@ -161,8 +156,6 @@ static void init_inputs(const struct device *dev)
 										\
 	BUILD_ASSERT((DT_PROP_LEN(XBAR_PHANDLE(n), xbar_maps) % 2) == 0,	\
 			"xbar_maps length must be an even number");		\
-	QDEC_CHECK_COND(n, counts_per_revolution, 1, UINT16_MAX);		\
-	QDEC_CHECK_COND(n, filter_sample_period, 0, UINT8_MAX);			\
 										\
 	static struct qdec_mcux_data qdec_mcux_##n##_data = {			\
 		.counts_per_revolution = DT_INST_PROP(n, counts_per_revolution) \

--- a/drivers/sensor/pixart/pat9136/pat9136.c
+++ b/drivers/sensor/pixart/pat9136/pat9136.c
@@ -434,9 +434,6 @@ static int pat9136_init(const struct device *dev)
 
 #define PAT9136_INIT(inst)									   \
 												   \
-	BUILD_ASSERT(DT_PROP(DT_DRV_INST(inst), resolution) >= 0 &&				   \
-		     DT_PROP(DT_DRV_INST(inst), resolution) <= 0xC7,				   \
-		     "Resolution must be in range 0-199");					   \
 	BUILD_ASSERT(DT_PROP(DT_DRV_INST(inst), cooldown_timer_ms) <				   \
 		     DT_PROP(DT_DRV_INST(inst), backup_timer_ms),				   \
 		     "Cooldown timer must be less than backup timer");				   \

--- a/dts/bindings/sensor/adi,adxl345-common.yaml
+++ b/dts/bindings/sensor/adi,adxl345-common.yaml
@@ -37,7 +37,8 @@ properties:
     type: int
     description: |
       Specify the FIFO watermark level in frame count.
-      Valid range: 1 - 31
+    min: 1
+    max: 31
 
   int1-gpios:
     type: phandle-array

--- a/dts/bindings/sensor/adi,adxl355-common.yaml
+++ b/dts/bindings/sensor/adi,adxl355-common.yaml
@@ -38,8 +38,11 @@ properties:
     type: int
     description: |
       Specify the FIFO watermark level in frame count.
-      Valid range: 1 - 96. Default value is the reset value.
+      FIFO watermark must be multiple of 3.
+      Default value is the reset value.
     default: 96
+    min: 3
+    max: 96
 
   range:
     type: int

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -50,7 +50,8 @@ properties:
     type: int
     description: |
       Specify the FIFO watermark level in frame count.
-      Valid range: 0 - 511
+    min: 0
+    max: 511
 
 examples:
   - |

--- a/dts/bindings/sensor/adi,adxl372-common.yaml
+++ b/dts/bindings/sensor/adi,adxl372-common.yaml
@@ -88,7 +88,8 @@ properties:
     type: int
     description: |
       Specify the FIFO watermark level in frame count.
-      Valid range: 0 - 512
+    min: 0
+    max: 512
 
 examples:
   - |

--- a/dts/bindings/sensor/ams,tmd2620.yaml
+++ b/dts/bindings/sensor/ams,tmd2620.yaml
@@ -39,31 +39,41 @@ properties:
   proximity-pulse-count:
     type: int
     required: true
-    description: count of IR led pulses (min. 1; max. 64)
+    description: count of IR led pulses
+    min: 1
+    max: 64
 
   proximity-high-threshold:
     type: int
-    description: high threshold for interrupt. (min. 0; max. 255)
+    description: high threshold for interrupt.
+    min: 0
+    max: 255
 
   proximity-low-threshold:
     type: int
-    description: low threshold for interrupt. (min. 0; max. 255)
+    description: low threshold for interrupt.
+    min: 0
+    max: 255
 
   proximity-led-drive-strength:
     type: int
     required: true
     description: |
-      LED drive strength in multiples of 6mA (min. 0; max. 31)
+      LED drive strength in multiples of 6mA
+    min: 0
+    max: 31
 
   proximity-interrupt-filter:
     type: int
     description: |
-      filters proximity interrupt. (min. 0; max. 15)
+      filters proximity interrupt.
 
       0-> every cycle fires an interrupt
       1-> 1 consecutive proximity value out of threshold range fires an interrupt
       2-> 2 consecutive proximity values out of threshold range fires an interrupt
       ...
+    min: 0
+    max: 15
 
   enable-wait-mode:
     type: boolean
@@ -72,8 +82,10 @@ properties:
   wait-time-factor:
     type: int
     description: |
-      time the sensor waits between proximity cycles. (min. 0; max 255).
+      time the sensor waits between proximity cycles.
       given in multiples of 2.81 starting at 0 for 2.81ms wait time.
+    min: 0
+    max: 255
 
   wait-long:
     type: boolean

--- a/dts/bindings/sensor/bosch,bmi08x-accel.yaml
+++ b/dts/bindings/sensor/bosch,bmi08x-accel.yaml
@@ -86,4 +86,6 @@ properties:
   fifo-watermark:
     type: int
     description: |
-      FIFO Watermark in number of samples. Ranges between 1 and 99
+      FIFO Watermark in number of samples.
+    min: 1
+    max: 99

--- a/dts/bindings/sensor/bosch,bmi08x-gyro.yaml
+++ b/dts/bindings/sensor/bosch,bmi08x-gyro.yaml
@@ -64,4 +64,6 @@ properties:
   fifo-watermark:
     type: int
     description: |
-      FIFO Watermark in number of frames. Ranges between 1 and 99
+      FIFO Watermark in number of frames.
+    min: 1
+    max: 99

--- a/dts/bindings/sensor/bosch,bmp581-common.yaml
+++ b/dts/bindings/sensor/bosch,bmp581-common.yaml
@@ -137,7 +137,8 @@ properties:
     description: |
       Specify the FIFO watermark level in frame count.
       Only supports frames with both Pressure and Temperature
-      Valid range: 1 - 15
+    min: 1
+    max: 15
 
   int-active-low:
     type: boolean

--- a/dts/bindings/sensor/brcm,afbr-s50.yaml
+++ b/dts/bindings/sensor/brcm,afbr-s50.yaml
@@ -59,6 +59,7 @@ properties:
       Specify the default output data rate expressed in samples per second (Hz).
       Default configuration used from all sample-codes provided by vendor.
       Please note the range is limited with Dual Frequency Mode enabled (up to 100 Hz).
+    min: 1
 
   spi-mosi-gpios:
     type: phandle-array

--- a/dts/bindings/sensor/invensense,icm45600-common.yaml
+++ b/dts/bindings/sensor/invensense,icm45600-common.yaml
@@ -117,7 +117,8 @@ properties:
     description: |
       Specify the FIFO watermark level in frame count.
       Default is power-up configuration (disabled).
-      Valid range: 0 - 104
+    min: 0
+    max: 104
 
   fifo-watermark-equals:
     type: boolean

--- a/dts/bindings/sensor/invensense,mpu9250.yaml
+++ b/dts/bindings/sensor/invensense,mpu9250.yaml
@@ -25,7 +25,8 @@ properties:
       Default gyrscope sample rate divider. This divider is only effective
       when gyro-dlpf is in range 5-184.
       rate = sample_rate / (1 + gyro-sr-div)
-      Valid range: 0 - 255
+    min: 0
+    max: 255
 
   gyro-dlpf:
     type: int

--- a/dts/bindings/sensor/nxp,mcux-qdc.yaml
+++ b/dts/bindings/sensor/nxp,mcux-qdc.yaml
@@ -17,6 +17,8 @@ properties:
     description: |
       Number of counts for one full revolution used for converting counter
       positions to rotation degrees.
+    min: 1
+    max: 65535
 
   single-phase-mode:
     type: boolean
@@ -35,7 +37,9 @@ properties:
     type: int
     description: |
       Sampling period, in IPBus clock cycles, of the decoder input signals.
-      Valid range: 0-255. If value is 0, then the input filter is bypassed.
+      If value is 0, then the input filter is bypassed.
+    min: 0
+    max: 255
 
   input-channels:
     type: array

--- a/dts/bindings/sensor/pixart,pat9136.yaml
+++ b/dts/bindings/sensor/pixart,pat9136.yaml
@@ -15,8 +15,9 @@ properties:
     description: |
       The resolution of the sensor which indirectly results in counts per inch
       (CPI), following the formula CPI = (1 + resolution) * 100.
-      Valid range is 0 to 199.
       Default is value set during Performance Optimization Settings.
+    min: 0
+    max: 199
 
   int-gpios:
     type: phandle-array

--- a/dts/bindings/sensor/rohm,bh1750.yaml
+++ b/dts/bindings/sensor/rohm,bh1750.yaml
@@ -25,6 +25,7 @@ properties:
       - 0
       - 1
       - 2
+
   mtreg:
     type: int
     default: 69
@@ -34,4 +35,5 @@ properties:
       and greater accuracy. After sensor power-on
       mtreg register is set to default value of
       this property (chosen by sensor manufacturer): 69.
-      Valid values are in range 31-254 (inclusive).
+    min: 31
+    max: 254

--- a/dts/bindings/sensor/ti,fdc2x1x.yaml
+++ b/dts/bindings/sensor/ti,fdc2x1x.yaml
@@ -183,7 +183,8 @@ child-binding:
       required: true
       description: |
         Channel X Reference Count Conversion Interval Time.
-        Valid range: 256 - 65535
+      min: 256
+      max: 65535
 
     offset:
       type: int
@@ -191,7 +192,8 @@ child-binding:
       description: |
         Channel X Conversion Offset (FDC2112 and FDC2212 only).
         The default offset value after power-on-reset is 0.
-        Valid range: 0 - 65535
+      min: 0
+      max: 65535
 
     settlecount:
       type: int
@@ -201,7 +203,8 @@ child-binding:
 
         The FDC will use this settling time to allow the LC sensor to
         stabilize before initiation of a conversion on Channel X.
-        Valid range: 0 - 65535
+      min: 0
+      max: 65535
 
     fref-divider:
       type: int
@@ -211,7 +214,8 @@ child-binding:
 
         Sets the divider for Channel X reference.
         Use this to scale the maximum conversion frequency.
-        Valid range: 1 - 1023
+      min: 1
+      max: 1023
 
     idrive:
       type: int
@@ -221,7 +225,8 @@ child-binding:
 
         This field defines the Drive Current used during the settling +
         conversion time of Channel X sensor clock.
-        Valid range: 0 - 31
+      min: 0
+      max: 31
 
     fin-sel:
       type: int


### PR DESCRIPTION
1. Replace Valid Range with min/max.
2. Drop BUILD_ASSERTs in adxl345, adxl355, afbr_s50, bmi08x_gyro and bmp581
