### PR TITLE
drivers: hwinfo: stm32: fix reset flags handling for STM32C5

### DIFF
--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -53,13 +53,14 @@ struct stm32_uid {
 	uint32_t id[STM32_NUM_UID_WORDS];
 };
 
-static void ll_hwinfo_force_clear_reset_flags(void)
+static void ll_rcc_clear_reset_flags(void)
 {
-#ifdef CONFIG_STM32_HAL2
+#ifdef CONFIG_SOC_SERIES_STM32C5X
 	LL_RCC_ForceClearResetFlags();
-#else /* CONFIG_STM32_HAL2 */
+	LL_RCC_ReleaseClearResetFlags();
+#else /* CONFIG_SOC_SERIES_STM32C5X */
 	LL_RCC_ClearResetFlags();
-#endif /* CONFIG_STM32_HAL2 */
+#endif /* CONFIG_SOC_SERIES_STM32C5X */
 }
 
 ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
@@ -246,7 +247,7 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 
 int z_impl_hwinfo_clear_reset_cause(void)
 {
-	ll_hwinfo_force_clear_reset_flags();
+	ll_rcc_clear_reset_flags();
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CORE_CM4)
 	LL_PWR_ClearFlag_CPU2();


### PR DESCRIPTION
The LL function is named differently on STM32C5 because the hardware is different: the `RMVF` bit must be cleared by software, whereas hardware clears it automatically on all other series.

STM32C5 Reference Manual extract:
<img width="647" height="721" alt="image" src="https://github.com/user-attachments/assets/86004e1f-4ee0-4e99-93f0-d7b328182ba0" />

compare to e.g. STM32WB09 Reference Manual:
<img width="643" height="795" alt="image" src="https://github.com/user-attachments/assets/d6250f42-7497-466e-a363-ffba28ee5a52" />

Rework the implementation to be functional, and rename the function to match intent while at it. Also, switch to a series-specific #if guard since this is hardware-specific rather than related to HAL1/HAL2.