### PR TITLE
soc: stm32: Deploy XSPIM driver on compatible series

### DIFF
--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
@@ -205,6 +205,10 @@
 	};
 };
 
+&xspim {
+	status = "okay";
+};
+
 &xspi2 {
 	pinctrl-0 = <&xspim_p2_clk_pn6 &xspim_p2_ncs1_pn1
 		     &xspim_p2_io0_pn2 &xspim_p2_io1_pn3

--- a/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
+++ b/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
@@ -269,6 +269,10 @@
 	status = "okay";
 };
 
+&xspim {
+	status = "okay";
+};
+
 &xspi1 {
 	pinctrl-0 = <&octospim_p1_io0_pc9 &octospim_p1_io1_pf9
 		     &octospim_p1_io2_pe2 &octospim_p1_io3_pa6

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -293,6 +293,10 @@ st_cam_i2c: &i2c1 {
 	};
 };
 
+&xspim {
+	status = "okay";
+};
+
 &xspi1 {
 	pinctrl-0 = <&xspim_p1_ncs1_po0 &xspim_p1_dqs0_po2
 		     &xspim_p1_dqs1_po3 &xspim_p1_clk_po4

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -481,6 +481,10 @@ STM32
   ``st,dsi-lcd-qsh-030`` is renamed into :dtcompatible:`st,dsi-lcd-qsh-030-connector`
   ``st,stm32-dcmi-camera-fpu-330zh`` is renamed into :dtcompatible:`st,dvp-cam-zif-30-connector`
 
+* :dtcompatible:`st,stm32-xspim` is now also used on STM32H5 and STM32H7RS series
+  to declare and configure XSPI Manager. Boards making use of XSPI must now enable
+  ``&xspim`` node in addition to the desired XSPI controller to use XSPI. (:github:`109903`)
+
 Syscon
 ======
 

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2164,15 +2164,6 @@ static int flash_stm32_xspi_init(const struct device *dev)
 		}
 	}
 
-	if (dev_cfg->has_pclken_mgr) {
-		/* Clock domain corresponding to the IO-Mgr (XSPIM) */
-		if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &dev_cfg->pclken_mgr) != 0) {
-			LOG_ERR("Could not enable XSPI Manager clock");
-			return -EIO;
-		}
-	}
-
 	for (; prescaler <= STM32_XSPI_CLOCK_PRESCALER_MAX; prescaler++) {
 		uint32_t clk = STM32_XSPI_CLOCK_COMPUTE(ahb_clock_freq, prescaler);
 
@@ -2212,27 +2203,6 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	}
 
 	LOG_DBG("XSPI Init'd");
-
-#if (defined(HAL_XSPIM_IOPORT_1) || defined(HAL_XSPIM_IOPORT_2)) && \
-	!defined(CONFIG_STM32_XSPIM)
-	/* XSPI I/O manager init Function */
-	XSPIM_CfgTypeDef xspi_mgr_cfg;
-
-	if (dev_data->hxspi.Instance == STM32_XSPI1) {
-		xspi_mgr_cfg.IOPort = HAL_XSPIM_IOPORT_1;
-	} else if (dev_data->hxspi.Instance == STM32_XSPI2) {
-		xspi_mgr_cfg.IOPort = HAL_XSPIM_IOPORT_2;
-	}
-	xspi_mgr_cfg.nCSOverride = HAL_XSPI_CSSEL_OVR_DISABLED;
-	xspi_mgr_cfg.Req2AckTime = 1;
-
-	if (HAL_XSPIM_Config(&dev_data->hxspi, &xspi_mgr_cfg,
-		HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
-		LOG_ERR("XSPI M config failed");
-		return -EIO;
-	}
-
-#endif /* (HAL_XSPIM_IOPORT_1 || HAL_XSPIM_IOPORT_2) && !(xspim node) */
 
 #if defined(XSPI_DCR1_DLYBYP)
 	/* XSPI delay block init Function */
@@ -2543,10 +2513,6 @@ static int flash_stm32_xspi_init(const struct device *dev)
 			.has_pclken_ker = true,							\
 			.pclken_ker = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE(inst), xspi_ker),\
 		))										\
-		IF_ENABLED(DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE(inst),  xspi_mgr), (		\
-			.has_pclken_mgr = true,							\
-			.pclken_mgr = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE(inst), xspi_mgr),\
-		))										\
 		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(STM32_XSPI_NODE(inst)),			\
 		.irq_config = flash_stm32_xspi_irq_config_func_##inst,				\
 		.mem_map_based_address = DT_REG_ADDR_BY_IDX(STM32_XSPI_NODE(inst), 1),		\
@@ -2597,7 +2563,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 												\
 	DEVICE_DT_INST_DEFINE(inst, &flash_stm32_xspi_init, NULL,				\
 			      &flash_stm32_xspi_dev_data_##inst, &flash_stm32_xspi_cfg_##inst,	\
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
+			      POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY,				\
 			      &flash_stm32_xspi_driver_api);
 
 #define XSPI_STM32_INIT(inst)							\

--- a/drivers/flash/flash_stm32_xspi.h
+++ b/drivers/flash/flash_stm32_xspi.h
@@ -81,7 +81,6 @@ typedef void (*irq_config_func_t)(const struct device *dev);
 struct flash_stm32_xspi_config {
 	const struct stm32_pclken pclken;
 	const struct stm32_pclken pclken_ker;
-	const struct stm32_pclken pclken_mgr;
 	irq_config_func_t irq_config;
 	size_t flash_size;
 	uint32_t max_frequency;
@@ -96,7 +95,6 @@ struct flash_stm32_xspi_config {
 	int reset_gpios_duration;
 #endif /* STM32_XSPI_RESET_GPIO */
 	bool has_pclken_ker;
-	bool has_pclken_mgr;
 };
 
 struct flash_stm32_xspi_data {

--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -75,7 +75,6 @@ struct memc_stm32_xspi_psram_config {
 	const struct pinctrl_dev_config *pcfg;
 	const struct stm32_pclken pclken;
 	const struct stm32_pclken pclken_ker;
-	const struct stm32_pclken pclken_mgr;
 	size_t memory_size;
 	uint32_t max_frequency;
 };
@@ -275,15 +274,6 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 	}
 #endif
 
-#if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_mgr)
-	/* Clock domain corresponding to the IO-Mgr (XSPIM) */
-	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &dev_cfg->pclken_mgr) != 0) {
-		LOG_ERR("Could not enable XSPI Manager clock");
-		return -EIO;
-	}
-#endif
-
 	for (; prescaler <= STM32_XSPI_CLOCK_PRESCALER_MAX; prescaler++) {
 		uint32_t clk = STM32_XSPI_CLOCK_COMPUTE(ahb_clock_freq, prescaler);
 
@@ -304,29 +294,6 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 		LOG_ERR("XSPI Init failed");
 		return -EIO;
 	}
-
-#if !defined(CONFIG_STM32_XSPIM)
-	if (!IS_ENABLED(CONFIG_STM32_APP_IN_EXT_FLASH)) {
-		/*
-		 * Do not configure the XSPIManager if running on the ext flash
-		 * since this includes stopping each XSPI instance during configuration
-		 */
-		XSPIM_CfgTypeDef cfg = {0};
-
-		if (hxspi->Instance == STM32_XSPI1) {
-			cfg.IOPort = HAL_XSPIM_IOPORT_1;
-		} else if (hxspi->Instance == STM32_XSPI2) {
-			cfg.IOPort = HAL_XSPIM_IOPORT_2;
-		} else {
-			LOG_ERR("XSPIMgr Instance failed");
-			return -EIO;
-		}
-		if (HAL_XSPIM_Config(hxspi, &cfg, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
-			LOG_ERR("XSPIMgr Init failed");
-			return -EIO;
-		}
-	}
-#endif /* !CONFIG_STM32_XSPIM */
 
 #if defined(CONFIG_SOC_SERIES_STM32H5X)
 	/* DELAYBlock Enable for the stm32H5 boards */
@@ -432,9 +399,6 @@ static const struct memc_stm32_xspi_psram_config memc_stm32_xspi_cfg = {
 	.pclken = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE, xspix),
 #if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_ker)
 	.pclken_ker = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE, xspi_ker),
-#endif
-#if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_mgr)
-	.pclken_mgr = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE, xspi_mgr),
 #endif
 	.memory_size = DT_INST_PROP(0, size) / 8, /* In Bytes */
 	.max_frequency = DT_INST_PROP(0, max_frequency),

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -1209,29 +1209,6 @@ static int mspi_configure_delay_block(struct mspi_stm32_data *dev_data)
 	return 0;
 }
 
-static int mspi_stm32_config_xspim_ioport(struct mspi_stm32_data *dev_data)
-{
-#if (defined(HAL_XSPIM_IOPORT_1) || defined(HAL_XSPIM_IOPORT_2)) && !defined(CONFIG_STM32_XSPIM)
-	/* XSPI I/O manager config */
-	XSPIM_CfgTypeDef mspi_mgr_cfg;
-
-	if (dev_data->hmspi.xspi.Instance == XSPI1) {
-		mspi_mgr_cfg.IOPort = HAL_XSPIM_IOPORT_1;
-	}
-	if (dev_data->hmspi.xspi.Instance == XSPI2) {
-		mspi_mgr_cfg.IOPort = HAL_XSPIM_IOPORT_2;
-	}
-	mspi_mgr_cfg.nCSOverride = HAL_XSPI_CSSEL_OVR_DISABLED;
-	mspi_mgr_cfg.Req2AckTime = 1;
-	if (HAL_XSPIM_Config(&dev_data->hmspi.xspi, &mspi_mgr_cfg,
-			     HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
-		LOG_ERR("XSPI M config failed");
-		return -EIO;
-	}
-#endif /* (HAL_XSPIM_IOPORT_1 || HAL_XSPIM_IOPORT_2) && !CONFIG_STM32_XSPIM */
-	return 0;
-}
-
 /**
  * API implementation of mspi_config : controller configuration.
  *
@@ -1293,11 +1270,6 @@ static int mspi_stm32_xspi_config(const struct mspi_dt_spec *spec)
 #endif
 
 	ret = mspi_hal_init(dev_cfg, dev_data, ahb_clock_freq);
-	if (ret != 0) {
-		goto end;
-	}
-
-	ret = mspi_stm32_config_xspim_ioport(dev_data);
 	if (ret != 0) {
 		goto end;
 	}

--- a/dts/arm/st/h5/stm32h5e4.dtsi
+++ b/dts/arm/st/h5/stm32h5e4.dtsi
@@ -95,12 +95,20 @@
 			compatible = "st,stm32-xspi";
 			reg = <0x47002400 0x400>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <150 0>;
-			clock-names = "xspix", "xspi-ker", "xspi-mgr";
+			clock-names = "xspix", "xspi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB4, 21)>,
-				 <&rcc STM32_SRC_PLL1_Q OCTOSPI2_SEL(1)>,
-				 <&rcc STM32_CLOCK(AHB4, 22)>;
+				 <&rcc STM32_SRC_PLL1_Q OCTOSPI2_SEL(1)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		xspim: xspim@47003400 {
+			compatible = "st,stm32-xspim";
+			reg = <0x47003400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB4, 22)>;
+			io-port-1 = <&xspi1>;
+			io-port-2 = <&xspi2>;
 			status = "disabled";
 		};
 
@@ -151,8 +159,7 @@
 
 &xspi1 {
 	/* OCTOSPI instance has a XSPI IO manager */
-	clock-names = "xspix", "xspi-ker", "xspi-mgr";
+	clock-names = "xspix", "xspi-ker";
 	clocks = <&rcc STM32_CLOCK(AHB4, 20)>,
-		 <&rcc STM32_SRC_PLL1_Q OCTOSPI1_SEL(1)>,
-		 <&rcc STM32_CLOCK(AHB4, 22)>;
+		 <&rcc STM32_SRC_PLL1_Q OCTOSPI1_SEL(1)>;
 };

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -609,6 +609,15 @@
 			status = "disabled";
 		};
 
+		xspim: xspim@5200b400 {
+			compatible = "st,stm32-xspim";
+			reg = <0x5200b400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB5, 13)>;
+			io-port-1 = <&xspi1>;
+			io-port-2 = <&xspi2>;
+			status = "disabled";
+		};
+
 		xspi1: spi@52005000 {
 			compatible = "st,stm32-xspi";
 			reg = <0x52005000 0x1000>, <0x90000000 DT_SIZE_M(256)>;

--- a/samples/drivers/memc/sample.yaml
+++ b/samples/drivers/memc/sample.yaml
@@ -21,7 +21,6 @@ tests:
       - apollo510_evb
   sample.drivers.memc.stm32_mspi:
     tags: mspi
-    filter: dt_alias_exists("psram0")
     platform_allow:
       - b_u585i_iot02a
       - stm32h7s78_dk
@@ -29,7 +28,7 @@ tests:
       - b_u585i_iot02a
       - stm32h7s78_dk
     extra_args:
-      - platform:b_u585i_iot02a:DTC_OVERLAY_FILE=boards/b_u585i_iot02a_mspi_aps6408l.overlay
-      - platform:b_u585i_iot02a:EXTRA_CONF_FILE=boards/b_u585i_iot02a_mspi_aps6408l.conf
-      - platform:stm32h7s78_dk:CONF_FILE=boards/stm32h7s78_dk_mspi_psram.conf
-      - platform:stm32h7s78_dk:DTC_OVERLAY_FILE=boards/stm32h7s78_dk_mspi_psram.overlay
+      - platform:b_u585i_iot02a/stm32u585xx:DTC_OVERLAY_FILE=boards/b_u585i_iot02a_mspi_aps6408l.overlay
+      - platform:b_u585i_iot02a/stm32u585xx:EXTRA_CONF_FILE=boards/b_u585i_iot02a_mspi_aps6408l.conf
+      - platform:stm32h7s78_dk/stm32h7s78xx:CONF_FILE=boards/stm32h7s78_dk_mspi_psram.conf
+      - platform:stm32h7s78_dk/stm32h7s78xx:DTC_OVERLAY_FILE=boards/stm32h7s78_dk_mspi_psram.overlay


### PR DESCRIPTION
Extend the STM32 XSPIM support introduced previously to other compatible STM32 series