### PR TITLE
boards: pic32cm_jh01_cnano: add clock and UART console support

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/board.cmake
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/board.cmake
@@ -1,5 +1,5 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=pic32cm5164jh01048" "--frequency=4000")
+board_runner_args(pyocd "--target=pic32cm5164jh01048" "--frequency=400000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano-pinctrl.dtsi
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pic32c/pic32cm_jh/pic32cm_jh01/pic32cm5164jh01048-pinctrl.h>
+
+&pinctrl {
+	sercom1_uart_default: sercom1_uart_default {
+		group1 {
+			pinmux = <PA0D_SERCOM1_PAD0>,
+				 <PA1D_SERCOM1_PAD1>;
+		};
+	};
+};

--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.dts
@@ -16,6 +16,8 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,console = &sercom1;
+		zephyr,shell-uart = &sercom1;
 	};
 
 	aliases {
@@ -131,4 +133,17 @@
 			gclkperiph-en = <1>;
 		};
 	};
+};
+
+&sercom1 {
+	compatible = "microchip,sercom-g1-uart";
+	current-speed = <115200>;
+	data-bits = <8>;
+	parity = "none";
+	stop-bits = "1";
+	rxpo = <1>;
+	txpo = <0>;
+	pinctrl-0 = <&sercom1_uart_default>;
+	pinctrl-names = "default";
+	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <microchip/pic32c/pic32cm_jh/pic32cm_jh01/pic32cm5164jh01048.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include "pic32cm_jh01_cnano-pinctrl.dtsi"
 
 / {
 	model = "PIC32CM JH01 Curiosity Nano";
@@ -56,5 +57,78 @@
 };
 
 &cpu0 {
-	clock-frequency = <4000000>;
+	clock-frequency = <48000000>;
+};
+
+&clock {
+	compatible = "microchip,pic32cm-jh-clock";
+
+	/* If cpu sourced from osc48m, use 3 for CPU frequency above 24Mhz */
+	flash-wait-states = <3>;
+
+	osc48m: osc48m {
+		compatible = "microchip,pic32cm-jh-osc48m";
+		osc48m-en = <1>;
+		osc48m-post-divider-freq = "48-mhz";
+		osc48m-run-in-standby-en = <1>;
+	};
+
+	xosc: xosc {
+		compatible = "microchip,pic32cm-jh-xosc";
+		xosc-frequency = <32000000>;
+		xosc-en = <0>;
+		xosc-xtal-en = <1>;
+		xosc-run-in-standby-en = <1>;
+	};
+
+	fdpll: fdpll {
+		compatible = "microchip,pic32cm-jh-fdpll";
+		fdpll-xosc-clock-divider = <15>;
+		fdpll-divider-ratio-frac = <0>;
+		fdpll-divider-ratio-int = <95>;
+		fdpll-output-prescalar = "div2";
+		fdpll-src = "xosc";
+		fdpll-run-in-standby-en = <1>;
+		fdpll-en = <0>;
+	};
+
+	xosc32k: xosc32k {
+		compatible = "microchip,pic32cm-jh-xosc32k";
+		xosc32k-32khz-en = <1>;
+		xosc32k-xtal-en = <1>;
+		xosc32k-startup-time = "122-us";
+		xosc32k-run-in-standby-en = <1>;
+		xosc32k-en = <0>;
+	};
+
+	osc32k: osc32k {
+		compatible = "microchip,pic32cm-jh-osc32k";
+		osc32k-32khz-en = <1>;
+		osc32k-startup-time = "183-us";
+		osc32k-run-in-standby-en = <1>;
+		osc32k-en = <0>;
+	};
+
+	gclkgen: gclkgen {
+		compatible = "microchip,pic32cm-jh-gclkgen";
+
+		gclkgen0 {
+			subsystem = <CLOCK_MCHP_GCLKGEN_ID_GEN0>;
+			gclkgen-div-factor = <1>;
+			gclkgen-run-in-standby-en = <1>;
+			gclkgen-src = "osc48m";
+			gclkgen-en = <1>;
+		};
+	};
+
+	gclkperiph: gclkperiph {
+		compatible = "microchip,pic32cm-jh-gclkperiph";
+		#clock-cells = <1>;
+
+		sercom1 {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_SERCOM1_CORE>;
+			gclkperiph-src = "gclk0";
+			gclkperiph-en = <1>;
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.yaml
@@ -13,4 +13,5 @@ supported:
   - clock_control
   - gpio
   - pinctrl
+  - uart
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: pic32cm_jh01_cnano
@@ -10,6 +10,7 @@ toolchain:
 flash: 512
 ram: 64
 supported:
+  - clock_control
   - gpio
   - pinctrl
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano_defconfig
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano_defconfig
@@ -1,5 +1,8 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_BUILD_OUTPUT_HEX=y
 CONFIG_ARM_MPU=y
+CONFIG_CONSOLE=y
+CONFIG_SERIAL=y
+CONFIG_UART_CONSOLE=y


### PR DESCRIPTION
- Configure 48MHz clock tree using OSC48M as primary source
- Add UART console support on SERCOM1 (115200 8N1)
- Fix pyOCD debug frequency from 4kHz to 400kHz