### PR TITLE
drivers: ethernet: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/ethernet/eth_adin2111.h
+++ b/include/zephyr/drivers/ethernet/eth_adin2111.h
@@ -49,8 +49,7 @@ int eth_adin2111_unlock(const struct device *dev);
  * @note The caller is responsible for device lock.
  *       Shall not be called from ISR.
  *
- * @retval 0 Successful write.
- * @retval <0 Error, a negative errno code.
+ * @return 0 on success, negative errno value on failure.
  */
 int eth_adin2111_sw_reset(const struct device *dev, uint16_t delay);
 
@@ -63,8 +62,7 @@ int eth_adin2111_sw_reset(const struct device *dev, uint16_t delay);
  *
  * @param[in] dev ADIN2111 device.
  *
- * @retval 0 Successful write.
- * @retval <0 Error, a negative errno code.
+ * @return 0 on success, negative errno value on failure.
  */
 int eth_adin2111_mac_reset(const struct device *dev);
 
@@ -78,8 +76,7 @@ int eth_adin2111_mac_reset(const struct device *dev);
  * @param[in] dev ADIN2111 device.
  * @param enable Set to 0 to disable and to nonzero to enable.
  *
- * @retval 0 Successful write.
- * @retval <0 Error, a negative errno code.
+ * @return 0 on success, negative errno value on failure.
  */
 int eth_adin2111_broadcast_filter(const struct device *dev, bool enable);
 


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974