### PR TITLE
random: remove CONFIG_CTR_DRBG_CSPRNG_GENERATOR

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -579,6 +579,14 @@ Other subsystems
      ZTEST_BENCHMARK(suite, my_bench, 100, setup, teardown) { /* ... */ }
      ZTEST_BENCHMARK_TIMED(suite, my_bench, 1000, setup, teardown) { /* ... */ }
 
+Random
+======
+
+* ``CONFIG_CTR_DRBG_CSPRNG_GENERATOR`` has been removed.
+  Use :kconfig:option:`CONFIG_PSA_CSPRNG_GENERATOR` instead.
+
+* ``CONFIG_CS_CTR_DRBG_PERSONALIZATION`` has been removed. It did not have any effect.
+
 Modules
 *******
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -56,7 +56,7 @@ API Changes
 Removed APIs and options
 ========================
 
-* The following deprecated networking options and APIs have been removed:
+* Networking
 
     * ``CONFIG_NET_TC_SKIP_FOR_HIGH_PRIO``
     * ``CONFIG_NET_SOCKETS_POLL_MAX``
@@ -72,6 +72,11 @@ Removed APIs and options
     * ``openthread_api_mutex_unlock()``
     * ``struct openthread_state_changed_cb``
     * ``TLS_CREDENTIAL_SERVER_CERTIFICATE``
+
+* Random
+
+    * ``CONFIG_CTR_DRBG_CSPRNG_GENERATOR``
+    * ``CONFIG_CS_CTR_DRBG_PERSONALIZATION``
 
 * West sign support for imgtool, which was deprecated in Zephyr 4.0, has been removed.
 

--- a/doc/services/crypto/random/index.rst
+++ b/doc/services/crypto/random/index.rst
@@ -170,20 +170,6 @@ Available generators:
 
     This option provides **no cryptographic security**. Use only for testing.
 
-CTR-DRBG Personalization
-------------------------
-
-:kconfig:option:`CONFIG_CS_CTR_DRBG_PERSONALIZATION`
- A personalization string used during CTR-DRBG initialization. This string
- is mixed with the entropy source during seeding to make the DRBG state
- as unique as possible.
-
- Consider customizing this value for your application to add additional
- uniqueness to the DRBG initialization.
-
-Helper Configuration Options
-============================
-
 Devicetree Configuration
 ************************
 

--- a/subsys/random/CMakeLists.txt
+++ b/subsys/random/CMakeLists.txt
@@ -3,9 +3,9 @@
 if(CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR OR
     CONFIG_TIMER_RANDOM_GENERATOR OR
     CONFIG_XOSHIRO_RANDOM_GENERATOR)
-zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/random/random.h)
-zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_USERSPACE           random_handlers.c)
+  zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/random/random.h)
+  zephyr_library()
+  zephyr_library_sources_ifdef(CONFIG_USERSPACE           random_handlers.c)
 endif()
 
 if(CONFIG_TIMER_RANDOM_GENERATOR OR CONFIG_TEST_CSPRNG_GENERATOR)
@@ -21,10 +21,10 @@ zephyr_library_sources_ifdef(CONFIG_ARM64_RANDOM_GENERATOR          random_arm64
 zephyr_library_sources_ifdef(CONFIG_TEST_CSPRNG_GENERATOR           random_test_csprng.c)
 
 if(CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR OR CONFIG_HARDWARE_DEVICE_CS_GENERATOR)
-zephyr_library_sources(random_entropy_device.c)
+  zephyr_library_sources(random_entropy_device.c)
 endif()
 
-if(CONFIG_CTR_DRBG_CSPRNG_GENERATOR OR CONFIG_PSA_CSPRNG_GENERATOR)
-zephyr_library_sources(random_psa.c)
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedtls_iface)
+if(CONFIG_PSA_CSPRNG_GENERATOR)
+  zephyr_library_sources(random_psa.c)
+  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedtls_iface)
 endif()

--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -146,16 +146,10 @@ config CSPRNG_ENABLED
 
 
 choice CSPRNG_GENERATOR_CHOICE
-	prompt "Cryptographically secure random generator"
+	prompt "Cryptographically secure random number generator"
 	default PSA_CSPRNG_GENERATOR if ENTROPY_NEEDS_PRNG
 	default HARDWARE_DEVICE_CS_GENERATOR
 	default TEST_CSPRNG_GENERATOR
-	help
-	  Platform dependent cryptographically secure random number support.
-
-	  If the hardware entropy support of the platform has sufficient
-	  performance to support CSRNG then select that. Otherwise, select
-	  CTR-DRBG CSPRNG as that is a FIPS140-2 recommended CSPRNG.
 
 config HARDWARE_DEVICE_CS_GENERATOR
 	bool "Use hardware random driver for CS random numbers"
@@ -164,16 +158,6 @@ config HARDWARE_DEVICE_CS_GENERATOR
 	  Enables a cryptographically secure random number generator that
 	  uses the enabled hardware random number driver to generate
 	  random numbers.
-
-config CTR_DRBG_CSPRNG_GENERATOR
-	bool "Use CTR-DRBG CSPRNG"
-	depends on PSA_CRYPTO
-	select DEPRECATED
-	help
-	  Enables the CTR-DRBG pseudo-random number generator. This CSPRNG
-	  shall use the entropy API for an initialization seed. The CTR-DRBG
-	  is a FIPS140-2 recommended cryptographically secure random number
-	  generator.
 
 config PSA_CSPRNG_GENERATOR
 	bool "Use PSA CSPRNG"
@@ -187,7 +171,6 @@ config PSA_CSPRNG_GENERATOR
 	  cryptographically secure random numbers suitable for
 	  security-sensitive applications.
 
-
 config TEST_CSPRNG_GENERATOR
 	bool "Use insecure CSPRNG for testing purposes"
 	depends on TEST_RANDOM_GENERATOR
@@ -196,13 +179,5 @@ config TEST_CSPRNG_GENERATOR
 	  libraries that use the former to be tested with ZTEST.
 
 endchoice # CSPRNG_GENERATOR_CHOICE
-
-config CS_CTR_DRBG_PERSONALIZATION
-	string "CTR-DRBG Personalization string"
-	default "zephyr ctr-drbg seed"
-	depends on CTR_DRBG_CSPRNG_GENERATOR
-	help
-	  This option is deprecated (no longer needed) and will be
-	  removed in further release.
 
 endmenu


### PR DESCRIPTION
It was deprecated for Zephyr v4.4.0 (by b92d516907e850e0e099094f078dd05557f8e762) but not in a proper way.
Its implementation was removed and it was made identical to `CONFIG_PSA_CSPRNG_GENERATOR` which is deceiving.
In addition, it appears first in the choice, which means the build system defaults to using this deprecated option instead of `CONFIG_PSA_CSPRNG_GENERATOR`.

Removing it now is the best course of action to avoid deceiving users any longer or defaulting to a deprecated option.