### PR TITLE
ci: add full coding guideline scan workflow using eclair

### DIFF
--- a/.github/workflows/coding_guidelines_full.yml
+++ b/.github/workflows/coding_guidelines_full.yml
@@ -1,0 +1,177 @@
+name: Coding Guidelines Scanning
+on:
+  push:
+    branches:
+      - main
+      - v*-branch
+      - collab-*
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coding_guideline_scan:
+    if: github.repository_owner == 'zephyrproject-rtos'
+    runs-on:
+      group: zephyr-runner-v2-linux-x64-4xlarge
+    container:
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
+      options: '--entrypoint /bin/bash'
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Print cloud service information
+        run: |
+          echo "ZEPHYR_RUNNER_CLOUD_PROVIDER = ${ZEPHYR_RUNNER_CLOUD_PROVIDER}"
+          echo "ZEPHYR_RUNNER_CLOUD_NODE = ${ZEPHYR_RUNNER_CLOUD_NODE}"
+          echo "ZEPHYR_RUNNER_CLOUD_POD = ${ZEPHYR_RUNNER_CLOUD_POD}"
+
+      - name: Apply container owner mismatch workaround
+        run: |
+          # FIXME: The owner UID of the GITHUB_WORKSPACE directory may not
+          #        match the container user UID because of the way GitHub
+          #        Actions runner is implemented. Remove this workaround when
+          #        GitHub comes up with a fundamental fix for this problem.
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+      - name: Clone cached Zephyr repository
+        continue-on-error: true
+        run: |
+          git clone --shared /repo-cache/zephyrproject/zephyr .
+          git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Environment Setup
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+          west init -l . || true
+          west config manifest.group-filter -- +ci,+optional
+          west config --global update.narrow true
+          west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
+          west forall -c 'git reset --hard HEAD'
+
+          echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
+
+      - name: Check Environment
+        run: |
+          cmake --version
+          gcc --version
+          cargo --version
+          rustup target list --installed
+          ls -la
+          echo "github.ref: ${{ github.ref }}"
+          echo "github.base_ref: ${{ github.base_ref }}"
+          echo "github.ref_name: ${{ github.ref_name }}"
+
+      - name: SCA Setup
+        uses: zephyrproject-rtos/action-sca-setup@681d9f46f28d391eb57e6f15fdb76af25d6c46bc
+        with:
+          tool-name: eclair
+          tool-version: 3.15.0
+          install-dir: eclair
+          s3-access-key-id: ${{ secrets.TOOLDIST_ACCESS_KEY }}
+          s3-secret-access-key: ${{ secrets.TOOLDIST_SECRET_ACCESS_KEY }}
+          license-server: ${{ secrets.TOOLDIST_ECLAIR_LICENSE_SERVER }}
+          license-key-ttl: 480
+
+      - name: Set Up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.12
+          cache: pip
+          cache-dependency-path: scripts/requirements-actions.txt
+
+      - name: install-packages
+        run: |
+          pip install -r scripts/requirements-actions.txt --require-hashes
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Scan code with Eclair
+        run: |
+          #./scripts/twister -j 16 -p qemu_x86  -T samples/synchronization -i --build-only -v  \
+          #  -xZEPHYR_SCA_VARIANT=eclair \
+          #  -xUSE_CCACHE=0 \
+          #  -xECLAIR_REPORTS_SARIF=1 \
+          #  -xECLAIR_RULESET_ZEPHYR_GUIDELINES=ON \
+          #  -xECLAIR_RULESET_FIRST_ANALYSIS=OFF
+
+          # Initially we use west to build just one single application on one
+          # platform and address rules with large number of findings. This is
+          # to make sure we can complete the scan within the time limit of
+          # GitHub Actions and also to make sure we can get the results in
+          # SARIF format without running into any issues. Once we have that
+          # working, we can expand the scan to cover more applications and
+          # platforms and start posting findings to GitHub Security tab.
+          export ZEPHYR_BASE=${PWD}
+          west -v build -p -b qemu_x86 tests/integration/kernel/ -- \
+            -DZEPHYR_SCA_VARIANT=eclair \
+            -DUSE_CCACHE=0 \
+            -DECLAIR_REPORTS_SARIF=1 \
+            -DECLAIR_RULESET_ZEPHYR_GUIDELINES=ON \
+            -DECLAIR_RULESET_FIRST_ANALYSIS=OFF
+
+          cp build/sca/eclair/reports.sarif .
+          cp build/sca/eclair/DIAGNOSTIC.txt .
+
+          jq -s '{ "$schema": "https://json.schemastore.org/sarif-2.1.0", "version": "2.1.0", "runs": map(.runs) | add }'  $(find build -name "reports.sarif")  > results.sarif
+          cp results.sarif results_${GITHUB_SHA}.sarif
+          jq --arg basepath "file://${GITHUB_WORKSPACE}/" '
+            .runs[].results[] |= (
+             # Remove partialFingerprints if it exists
+             del(.partialFingerprints)
+             |
+            .locations[]? |= (
+            .physicalLocation.artifactLocation.uri
+            |= if type == "string" then ($basepath + .) else . end
+            )
+            | .relatedLocations[]? |= (
+            .physicalLocation.artifactLocation.uri
+            |= if type == "string" then ($basepath + .) else . end
+            )
+            )
+            ' results.sarif > results_tmp.sarif
+          mv results_tmp.sarif results.sarif
+
+          ver=`git describe`
+          echo "PAYLOAD_VERSION=${ver}" >> $GITHUB_ENV
+          echo "PAYLOAD_DESC=${ver}" >> $GITHUB_ENV
+      - name: Clean up
+        if: always()
+        run: |
+          eclair_licman -c 57350
+
+      - name: Upload SARIF as artifact
+        if: always() && github.event_name == 'push'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sarif
+          if-no-files-found: ignore
+          path: |
+            DIAGNOSTIC.txt
+            results_*.sarif
+
+      - name: Summarize SARIF results
+        if: always()
+        run: |
+          if [ -s results_${GITHUB_SHA}.sarif ]; then
+            python3 scripts/ci/sarif_summary.py results_${GITHUB_SHA}.sarif
+          fi
+
+      # disabled for now
+      # - name: Upload Analysis Results
+      #   if: always()
+      #   uses: github/codeql-action/upload-sarif@v4
+      #   with:
+      #     sarif_file: results.sarif

--- a/scripts/ci/sarif_summary.py
+++ b/scripts/ci/sarif_summary.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Generate a GitHub Actions step summary from a SARIF file.
+
+Reads the SARIF file produced by the scan tools and writes a Markdown
+table to $GITHUB_STEP_SUMMARY.  Also emits one ::notice:: workflow
+annotation per triggered rule so each rule appears in the Actions log
+with its violation count and description.
+
+Usage:
+    python3 scripts/ci/sarif_summary.py [results.sarif]
+"""
+
+import argparse
+import collections
+import json
+import os
+import sys
+
+
+def _tag_order(tag):
+    return {"mandatory": 0, "required": 1, "advisory": 2}.get(tag, 3)
+
+
+def parse_sarif(path):
+    """Return (counts, rule_meta, file_counts) from *path*.
+
+    counts      -- Counter mapping ruleId -> total violation count
+    rule_meta   -- dict mapping ruleId -> {desc, tag}
+    file_counts -- Counter mapping file URI -> total violation count
+    """
+    with open(path, encoding="utf-8") as fh:
+        sarif = json.load(fh)
+
+    counts = collections.Counter()
+    rule_meta = {}
+    file_counts = collections.Counter()
+
+    for run in sarif.get("runs", []):
+        for rule in run.get("tool", {}).get("driver", {}).get("rules", []):
+            rid = rule.get("id", "")
+            tags = rule.get("properties", {}).get("tags", [])
+            # Pick the most restrictive classification tag present.
+            tag = ""
+            for candidate in ("mandatory", "required", "advisory"):
+                if candidate in tags:
+                    tag = candidate
+                    break
+            rule_meta[rid] = {
+                "desc": rule.get("fullDescription", {}).get("text", rid),
+                "tag": tag,
+            }
+
+        for result in run.get("results", []):
+            rid = result.get("ruleId", "unknown")
+            counts[rid] += 1
+            for loc in result.get("locations", []):
+                uri = loc.get("physicalLocation", {}).get("artifactLocation", {}).get("uri", "")
+                if uri:
+                    file_counts[uri] += 1
+
+    return counts, rule_meta, file_counts
+
+
+def write_file_summary(file_counts, out):
+    """Write a Markdown table of violation counts per file."""
+    n_files = len(file_counts)
+    out.write("## :file_folder: Violations by File\n\n")
+    out.write(f"> **Files with violations:** {n_files:,}\n\n")
+    out.write("| # | File | Violations |\n")
+    out.write("|--:|------|----------:|\n")
+    for idx, (uri, cnt) in enumerate(sorted(file_counts.items(), key=lambda kv: -kv[1]), 1):
+        out.write(f"| {idx} | `{uri}` | {cnt:,} |\n")
+
+
+def write_summary(counts, rule_meta, file_counts, out):
+    total = sum(counts.values())
+    n_rules = len(counts)
+
+    out.write("## :mag: Scan Results\n\n")
+    out.write(f"> **Total violations:** {total:,} &nbsp;|&nbsp; **Rules triggered:** {n_rules}\n\n")
+
+    # Sort by tag priority then by count (descending within same tag).
+    sorted_rules = sorted(
+        counts.items(),
+        key=lambda kv: (_tag_order(rule_meta.get(kv[0], {}).get("tag", "")), -kv[1]),
+    )
+
+    out.write("| # | Rule ID | Classification | Violations | Description |\n")
+    out.write("|--:|---------|---------------|----------:|-------------|\n")
+    for idx, (rid, cnt) in enumerate(sorted_rules, 1):
+        m = rule_meta.get(rid, {})
+        tag = m.get("tag", "")
+        desc = m.get("desc", "")
+        out.write(f"| {idx} | `{rid}` | {tag} | {cnt:,} | {desc} |\n")
+
+    out.write("\n")
+    write_file_summary(file_counts, out)
+
+
+def _escape_data(value):
+    """Escape a workflow command message so it cannot break the format."""
+    return str(value).replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _escape_property(value):
+    """Escape a workflow command property value (also escapes ':' and ',')."""
+    return _escape_data(value).replace(":", "%3A").replace(",", "%2C")
+
+
+def emit_annotations(counts, rule_meta):
+    """Emit one ``::notice::`` annotation per rule for the Actions log."""
+    for rid, cnt in sorted(counts.items(), key=lambda kv: -kv[1]):
+        m = rule_meta.get(rid, {})
+        desc = m.get("desc", rid)
+        tag = m.get("tag", "")
+        prefix = f"[{tag}] " if tag else ""
+        title = _escape_property(rid)
+        message = _escape_data(f"{prefix}{desc} - {cnt} violation(s)")
+        print(f"::notice title={title}::{message}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    ap.add_argument(
+        "sarif",
+        nargs="?",
+        default="results.sarif",
+        help="Path to the SARIF file (default: results.sarif)",
+    )
+    ap.add_argument(
+        "--annotations",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Emit ::notice:: workflow command annotations",
+    )
+    args = ap.parse_args()
+
+    counts, rule_meta, file_counts = parse_sarif(args.sarif)
+
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as fh:
+            write_summary(counts, rule_meta, file_counts, fh)
+    else:
+        write_summary(counts, rule_meta, file_counts, sys.stdout)
+
+    if args.annotations:
+        emit_annotations(counts, rule_meta)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add initial workflow for scanning the code base using ECLAIR.
This is the initial step used for integration, at the moment we only
build one single application using west and enable all zephyr coding
guidelines covered by the tool.

This workflow will only run on push events only and will generate a
SARIF file with all violations that can be downloaded and evaluated
locally to help triage and fix issues.

Goal it to address some of the rules with large number of violations
first, get to a manageable number of violations and start posting those
into GH dedicated tracking backend.
Later on we will also start running this on pull requests and flag
violations introduced in PRs.


This workflow was tested here:

https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/26509230948
