### PR TITLE
drivers: display: ssd135x: fix bleeding KConfig

### DIFF
--- a/drivers/display/Kconfig.ssd135x
+++ b/drivers/display/Kconfig.ssd135x
@@ -3,22 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SSD135X
-	bool "SSD135x display controllers driver"
+	bool
 	select MIPI_DBI
 	help
-	  Enable driver for SSD135x display controllers.
+	  Hidden configuration entry for all SSD135x drivers.
 
 config SSD1351
-	bool "SSD1351 display controllers driver"
+	bool "SSD1351 display controller driver"
 	default y
 	depends on DT_HAS_SOLOMON_SSD1351_ENABLED
 	select SSD135X
 	help
 	  Enable driver for SSD1351 display controller.
 
-
 config SSD1357
-	bool "SSD1357 display controllers driver"
+	bool "SSD1357 display controller driver"
 	default y
 	depends on DT_HAS_SOLOMON_SSD1357_ENABLED
 	select SSD135X


### PR DESCRIPTION
make `CONFIG_SSD135X `a hidden symbol similar to other display driver groups so that it doesn't bleed into the main display drivers menu. Fix spelling of the prompt for the actual drivers to also align with other drivers.

fixes the issue observed below in an application that has no business with ssd135x drivers

<img width="1018" height="681" alt="image" src="https://github.com/user-attachments/assets/c75166ba-0dd7-4eb4-9658-c371665ebd9f" />
