### PR TITLE
boards: espressif: remove "can" as supported feature

### DIFF
--- a/boards/espressif/esp32s2_devkitc/esp32s2_devkitc.yaml
+++ b/boards/espressif/esp32s2_devkitc/esp32s2_devkitc.yaml
@@ -18,7 +18,6 @@ supported:
   - counter
   - entropy
   - input
-  - can
   - dma
   - crypto
   - retained_mem

--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.yaml
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.yaml
@@ -10,7 +10,6 @@ supported:
   - i2c
   - i2s
   - spi
-  - can
   - counter
   - watchdog
   - entropy

--- a/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.yaml
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.yaml
@@ -9,7 +9,6 @@ supported:
   - uart
   - i2c
   - spi
-  - can
   - counter
   - watchdog
   - entropy


### PR DESCRIPTION
Remove "can" as a supported feature of Espressif ESP32 boards where no CAN controller is enabled in the default board configuration.