### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -358,7 +358,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: cd44ed9674d115457fd620d5a43741576f328e4b
+      revision: 309d02c0df8625c52a6abc2fd95dc77fe80c163a
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 47bd5b4ebd357ba637be0f2b092e1c0d370eea2f


### PR DESCRIPTION
Update the HW models module to:
309d02c0df8625c52a6abc2fd95dc77fe80c163a

Including the following:
309d02c RADIO: Minor Tx timing refactoring (no functional change)
40288ee RADIO: Fix CodedPhy Tx END/PHYEND timing