### PR TITLE
drivers: sensor: ams_as7341: Add AMS AS7341 spectral sensor driver

### DIFF
--- a/drivers/sensor/CMakeLists.txt
+++ b/drivers/sensor/CMakeLists.txt
@@ -41,6 +41,8 @@ add_subdirectory(tdk)
 add_subdirectory(ti)
 add_subdirectory(vishay)
 add_subdirectory(wsen)
+add_subdirectory(ams_as7341)
+
 # zephyr-keep-sorted-stop
 
 add_subdirectory_ifdef(CONFIG_A01NYUB a01nyub)

--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -128,6 +128,8 @@ source "drivers/sensor/tdk/Kconfig"
 source "drivers/sensor/ti/Kconfig"
 source "drivers/sensor/vishay/Kconfig"
 source "drivers/sensor/wsen/Kconfig"
+source "drivers/sensor/ams_as7341/Kconfig"
+
 # zephyr-keep-sorted-stop
 
 # zephyr-keep-sorted-start

--- a/drivers/sensor/ams/CMakeLists.txt
+++ b/drivers/sensor/ams/CMakeLists.txt
@@ -4,6 +4,7 @@
 # zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_AMS_AS5048 ams_as5048)
 add_subdirectory_ifdef(CONFIG_AMS_AS5600 ams_as5600)
+add_subdirectory_ifdef(CONFIG_AMS_AS7341 ams_as7341)
 add_subdirectory_ifdef(CONFIG_AMS_IAQ_CORE ams_iAQcore)
 add_subdirectory_ifdef(CONFIG_CCS811 ccs811)
 add_subdirectory_ifdef(CONFIG_ENS210 ens210)

--- a/drivers/sensor/ams/Kconfig
+++ b/drivers/sensor/ams/Kconfig
@@ -4,6 +4,7 @@
 # zephyr-keep-sorted-start
 source "drivers/sensor/ams/ams_as5048/Kconfig"
 source "drivers/sensor/ams/ams_as5600/Kconfig"
+source "drivers/sensor/ams/ams_as7341/Kconfig"
 source "drivers/sensor/ams/ams_iAQcore/Kconfig"
 source "drivers/sensor/ams/ccs811/Kconfig"
 source "drivers/sensor/ams/ens210/Kconfig"

--- a/drivers/sensor/ams/ams_as7341/CMakeLists.txt
+++ b/drivers/sensor/ams/ams_as7341/CMakeLists.txt
@@ -1,0 +1,3 @@
+zephyr_library()
+zephyr_library_sources(ams_as7341.c)
+zephyr_include_directories(.)

--- a/drivers/sensor/ams/ams_as7341/Kconfig
+++ b/drivers/sensor/ams/ams_as7341/Kconfig
@@ -1,0 +1,7 @@
+config AMS_AS7341
+    bool "AMS AS7341 spectral sensor"
+    default y
+    depends on DT_HAS_AMS_AS7341_ENABLED
+    select I2C
+    help
+      Enable AMS AS7341 driver

--- a/drivers/sensor/ams/ams_as7341/ams_as7341.c
+++ b/drivers/sensor/ams/ams_as7341/ams_as7341.c
@@ -1,0 +1,1171 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (C) 2026 Dotcom IoT LLP
+ * Author: Mahendra Sondagar <mahendra@dotcom.co.in>
+ * Author: Parin Baudhanwala <parin.baudhanwala@dnkmail.in>
+ */
+/**
+ * @file ams_as7341.c
+ * @brief AS7341 Spectral Sensor Module driver.
+ *
+ * Implements the Zephyr sensor driver API for the AS7341.
+ * Two-pass SMUX configuration is used to read all 8 spectral filters
+ * plus the clear and NIR channels over I2C.
+ */
+
+#include "ams_as7341.h"
+
+#define DT_DRV_COMPAT ams_as7341
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(ams_as7341, CONFIG_SENSOR_LOG_LEVEL);
+
+/**
+ * @brief Poll the AS7341 STATUS2 register until spectral data is valid.
+ *
+ * Reads the AVALID flag (STATUS2 bit 6) in a polling loop, sleeping 2 ms
+ * between each attempt.  The loop runs at most 250 iterations (~500 ms
+ * total) before giving up.
+ *
+ * @param dev Pointer to the sensor device structure.
+ *
+ * @retval 0          Data is ready (AVALID set).
+ * @retval -EIO       An I2C read error occurred.
+ * @retval -ETIMEDOUT AVALID was not set within the polling timeout.
+ */
+static int as7341_wait_data_ready(const struct device *dev)
+{
+	const struct as7341_config *cfg = dev->config;
+	uint8_t status;
+	int timeout = 250;
+
+	while (timeout--) {
+		if (i2c_reg_read_byte_dt(&cfg->i2c, AS7341_REG_STATUS2, &status) < 0) {
+			LOG_ERR("Failed to set time");
+			return -EIO;
+		}
+
+		if (status & BIT(6)) {
+			return 0;
+		}
+
+		k_msleep(2);
+	}
+
+	return -ETIMEDOUT;
+}
+
+/**
+ * @brief Enable or disable the AS7341 spectral measurement engine.
+ *
+ * Writes the SP_EN bit (ENABLE register bit 1).  Spectral measurement
+ * must be disabled before reconfiguring the SMUX and re-enabled
+ * afterwards to start a new integration cycle.
+ *
+ * @param dev Pointer to the sensor device structure.
+ * @param en  @c true  – enable spectral measurement.
+ *            @c false – disable spectral measurement.
+ *
+ * @return 0 on success, or a negative errno code on I2C failure.
+ */
+static int as7341_enable_spectral(const struct device *dev, bool en)
+{
+	const struct as7341_config *cfg = dev->config;
+
+	return i2c_reg_update_byte_dt(&cfg->i2c, AS7341_REG_ENABLE, BIT(1), en ? BIT(1) : 0);
+}
+
+/**
+ * @brief Set a runtime attribute on the AS7341.
+ *
+ * Maps Zephyr sensor attributes to AS7341 hardware registers:
+ *
+ * | Zephyr attribute              | AS7341 register | Description              |
+ * |-------------------------------|-----------------|--------------------------|
+ * | SENSOR_ATTR_GAIN              | CFG1            | Spectral gain (0–10)     |
+ * | SENSOR_ATTR_SAMPLING_FREQUENCY| ATIME           | Integration time steps   |
+ * | SENSOR_ATTR_RESOLUTION        | ASTEP_L/ASTEP_H | Integration step size    |
+ *
+ * The integer part of @p val (@c val->val1) is used for all attributes.
+ * The channel parameter @p chan is ignored; the setting applies globally.
+ *
+ * @param dev  Pointer to the sensor device structure.
+ * @param chan Sensor channel (ignored – applies to all channels).
+ * @param attr Attribute to set; see table above.
+ * @param val  Pointer to the sensor_value carrying the new setting.
+ *
+ * @retval 0        Attribute written successfully.
+ * @retval -ENOTSUP Attribute is not supported by this driver.
+ * @retval <0       Negative errno code on I2C write failure.
+ */
+static int as7341_attr_set(const struct device *dev, enum sensor_channel chan,
+			   enum sensor_attribute attr, const struct sensor_value *val)
+{
+	const struct as7341_config *cfg = dev->config;
+	struct as7341_data *data = dev->data;
+	int ret;
+
+	switch (attr) {
+	case SENSOR_ATTR_GAIN:
+		data->gain = (uint8_t)val->val1;
+		ret = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_CFG1, data->gain);
+		if (ret < 0) {
+			LOG_ERR("Failed to set gain");
+			return ret;
+		}
+		return 0;
+
+	case SENSOR_ATTR_SAMPLING_FREQUENCY:
+		data->atime = (uint16_t)val->val1;
+		ret = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_ATIME, (uint8_t)data->atime);
+		if (ret < 0) {
+			LOG_ERR("Failed to set ATIME");
+			return ret;
+		}
+		return 0;
+
+	case SENSOR_ATTR_RESOLUTION:
+		data->astep = (uint16_t)val->val1;
+		ret = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_ASTEP_L,
+					    (uint8_t)(data->astep & 0xFF));
+		if (ret < 0) {
+			LOG_ERR("Failed to set ASTEP LSB");
+			return ret;
+		}
+		ret = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_ASTEP_H,
+					    (uint8_t)(data->astep >> 8));
+		if (ret < 0) {
+			LOG_ERR("Failed to set ASTEP MSB");
+			return ret;
+		}
+		return 0;
+
+	default:
+		return -ENOTSUP;
+	}
+}
+
+/**
+ * @brief Read a runtime attribute from the AS7341 driver cache.
+ *
+ * Returns the value most recently written via as7341_attr_set() or set
+ * during initialisation.  No I2C transaction is performed.
+ *
+ * Supported attributes: SENSOR_ATTR_GAIN, SENSOR_ATTR_SAMPLING_FREQUENCY,
+ * SENSOR_ATTR_RESOLUTION.  @c val->val2 is always set to 0.
+ *
+ * @param dev  Pointer to the sensor device structure.
+ * @param chan Sensor channel (ignored).
+ * @param attr Attribute to read.
+ * @param val  Pointer to the sensor_value to populate.
+ *
+ * @retval 0 Attribute read successfully.
+ * @retval -ENOTSUP Attribute is not supported by this driver.
+ */
+static int as7341_attr_get(const struct device *dev, enum sensor_channel chan,
+			   enum sensor_attribute attr, struct sensor_value *val)
+{
+	struct as7341_data *data = dev->data;
+
+	switch (attr) {
+	case SENSOR_ATTR_GAIN:
+		val->val1 = data->gain;
+		val->val2 = 0;
+		return 0;
+
+	case SENSOR_ATTR_SAMPLING_FREQUENCY:
+		val->val1 = data->atime;
+		val->val2 = 0;
+		return 0;
+
+	case SENSOR_ATTR_RESOLUTION:
+		val->val1 = data->astep;
+		val->val2 = 0;
+		return 0;
+
+	default:
+		return -ENOTSUP;
+	}
+}
+
+/**
+ * @brief Write a single byte to an AS7341 SMUX configuration register.
+ *
+ * Helper used by as7341_smux_config_f1f4() and as7341_smux_config_f5f8()
+ * to program the SMUX routing table one byte at a time.
+ *
+ * @param dev Pointer to the sensor device structure.
+ * @param reg SMUX register address to write.
+ * @param val Byte value to write.
+ *
+ * @return 0 on success, or a negative errno code on I2C failure.
+ */
+static int as7341_smux_write(const struct device *dev, uint8_t reg, uint8_t val)
+{
+	const struct as7341_config *cfg = dev->config;
+
+	return i2c_reg_write_byte_dt(&cfg->i2c, reg, val);
+}
+
+/**
+ * @brief Write the SMUX routing table for the low spectral channels (F1–F4).
+ *
+ * Programs the 20-byte SMUX configuration that routes the F1 (415 nm),
+ * F2 (445 nm), F3 (480 nm), and F4 (515 nm) filters, together with the
+ * first clear and NIR channels, to the six ADC inputs.
+ *
+ * Must be called after setting the SMUX command to WRITE and before
+ * calling as7341_enable_smux().
+ *
+ * @param dev Pointer to the sensor device structure.
+ *
+ * @return 0 on success, or a negative errno code if any I2C write fails.
+ */
+static int as7341_smux_config_f1f4(const struct device *dev)
+{
+	int err;
+
+	err = as7341_smux_write(dev, 0x00, 0x30);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x01, 0x01);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x02, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x03, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x04, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x05, 0x42);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x06, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x07, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x08, 0x50);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x09, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0A, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0B, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0C, 0x20);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0D, 0x04);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0E, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0F, 0x30);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x10, 0x01);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x11, 0x50);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x12, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x13, 0x06);
+	if (err < 0) {
+		return err;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Write the SMUX routing table for the high spectral channels (F5–F8).
+ *
+ * Programs the 20-byte SMUX configuration that routes the F5 (555 nm),
+ * F6 (590 nm), F7 (630 nm), and F8 (680 nm) filters, together with the
+ * second clear and NIR channels, to the six ADC inputs.
+ *
+ * Must be called after setting the SMUX command to WRITE and before
+ * calling as7341_enable_smux().
+ *
+ * @param dev Pointer to the sensor device structure.
+ *
+ * @return 0 on success, or a negative errno code if any I2C write fails.
+ */
+static int as7341_smux_config_f5f8(const struct device *dev)
+{
+	int err;
+
+	err = as7341_smux_write(dev, 0x00, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x01, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x02, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x03, 0x40);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x04, 0x02);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x05, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x06, 0x10);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x07, 0x03);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x08, 0x50);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x09, 0x10);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0A, 0x03);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0B, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0C, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0D, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0E, 0x24);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0F, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x10, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x11, 0x50);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x12, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x13, 0x06);
+	if (err < 0) {
+		return err;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Configure SMUX for flicker detection mode.
+ *
+ * Programs the AS7341 SMUX registers to route the internal flicker
+ * detection signal to ADC channel 5. This configuration disables all
+ * spectral channel mappings and enables only the flicker detection path.
+ *
+ * The SMUX must be reconfigured before enabling flicker detection
+ * measurements. This function writes a fixed register sequence required
+ * by the device datasheet.
+ *
+ * @param dev Pointer to the device structure.
+ *
+ * @retval 0 If the configuration was successful.
+ * @retval -EIO If an I2C communication error occurs during SMUX write.
+ */
+static int as7341_smux_config_flicker(const struct device *dev)
+{
+	int err;
+
+	/* Flicker Detection SMUX config (Flicker -> ADC5) */
+
+	err = as7341_smux_write(dev, 0x00, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x01, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x02, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x03, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x04, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x05, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x06, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x07, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x08, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x09, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0A, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0B, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0C, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0D, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0E, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x0F, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x10, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x11, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x12, 0x00);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_write(dev, 0x13, 0x60);
+	if (err < 0) {
+		return err;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Set the SMUX command field in the CFG6 register.
+ *
+ * Writes bits [4:3] of register 0xAF (CFG6) with the requested SMUX
+ * command code.  The command must be set before enabling the SMUX so
+ * that the hardware knows whether to load (WRITE) or execute the
+ * routing table.
+ *
+ * @param dev Pointer to the sensor device structure.
+ * @param cmd SMUX command code (e.g. AS7341_SMUX_CMD_WRITE).
+ *            The value is shifted left by 3 to align with bits [4:3].
+ *
+ * @return 0 on success, or a negative errno code on I2C failure.
+ */
+static int as7341_set_smux_command(const struct device *dev, uint8_t cmd)
+{
+	const struct as7341_config *cfg = dev->config;
+
+	return i2c_reg_update_byte_dt(&cfg->i2c, AS7341_REG_CFG6, AS7341_CFG6_SMUX_CMD_MASK,
+				      (cmd & AS7341_SMUX_CMD_MASK) << AS7341_SMUX_CMD_SHIFT);
+}
+
+/**
+ * @brief Activate the SMUX and wait for the operation to complete.
+ *
+ * Sets bit 4 (SMUXEN) in the ENABLE register to start the SMUX
+ * operation, then polls the same bit until the hardware clears it,
+ * indicating that the SMUX routing table has been loaded into the
+ * ADC input multiplexers.
+ *
+ * The poll loop runs at most 100 iterations with a 1 ms sleep between
+ * each attempt (~100 ms total timeout).
+ *
+ * @param dev Pointer to the sensor device structure.
+ *
+ * @retval 0          SMUX operation completed successfully.
+ * @retval -EIO       An I2C read or write error occurred.
+ * @retval -ETIMEDOUT SMUXEN bit did not clear within the polling timeout.
+ */
+static int as7341_enable_smux(const struct device *dev)
+{
+	const struct as7341_config *cfg = dev->config;
+	int ret = i2c_reg_update_byte_dt(&cfg->i2c, AS7341_REG_ENABLE, BIT(4), BIT(4));
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Wait for SMUX operation to complete (bit 4 clears when done) */
+	uint8_t reg;
+	int timeout = 1000;
+
+	while (timeout--) {
+		ret = i2c_reg_read_byte_dt(&cfg->i2c, AS7341_REG_ENABLE, &reg);
+		if (ret < 0) {
+			return ret;
+		}
+		if (!(reg & BIT(4))) {
+			return 0;
+		}
+		k_msleep(1);
+	}
+	return -ETIMEDOUT;
+}
+
+/**
+ * @brief Fetch spectral samples from all AS7341 channels.
+ *
+ * Implements the Zephyr sensor_sample_fetch() API for the AS7341.
+ * Because the sensor has more spectral channels than ADC inputs, two
+ * sequential measurement passes are required:
+ *
+ * - Pass 1: Routes F1–F4 + clear + NIR (low channels) through the SMUX
+ *   and reads ADC results into ch_data[0..5].
+ * - Pass 2: Routes F5–F8 + clear + NIR (high channels) through the SMUX
+ *   and reads ADC results into ch_data[6..11].
+ *
+ * Each pass follows the sequence:
+ *   1. Disable spectral measurement (SP_EN = 0).
+ *   2. Set SMUX command to WRITE.
+ *   3. Program the SMUX routing table.
+ *   4. Enable the SMUX (SMUXEN = 1) and wait for completion.
+ *   5. Enable spectral measurement (SP_EN = 1).
+ *   6. Wait for AVALID (data ready).
+ *   7. Burst-read the six 16-bit ADC results.
+ *
+ * Only @c SENSOR_CHAN_ALL is accepted; per-channel fetch is not supported.
+ *
+ * @param dev  Pointer to the sensor device structure.
+ * @param chan Must be SENSOR_CHAN_ALL.
+ *
+ * @retval 0        All 12 channel values fetched successfully.
+ * @retval -ENOTSUP @p chan is not SENSOR_CHAN_ALL.
+ * @retval <0       Negative errno code on any I2C or timeout error.
+ */
+static int as7341_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct as7341_data *data = dev->data;
+	const struct as7341_config *cfg = dev->config;
+	uint8_t buf[2];
+	int err;
+
+	if (chan == SENSOR_CHAN_AS7341_FLICKER) {
+		return as7341_detect_flicker(dev, &data->flicker_hz);
+	}
+
+	if (chan != SENSOR_CHAN_ALL) {
+		return -ENOTSUP;
+	}
+
+	LOG_DBG("AS7341 sample fetch started");
+
+	/* Low Channels (F1-F4 + CLEAR_0 + NIR_0) */
+
+	/* Disable measurement and configure SMUX for low channels */
+	err = as7341_enable_spectral(dev, false);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_set_smux_command(dev, AS7341_SMUX_CMD_WRITE);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_config_f1f4(dev);
+	if (err < 0) {
+		LOG_ERR("SMUX F1-F4 config failed");
+		return err;
+	}
+
+	/* Enable SMUX */
+	err = as7341_enable_smux(dev);
+	if (err < 0) {
+		return err;
+	}
+
+	/* Start spectral measurement */
+	err = as7341_enable_spectral(dev, true);
+	if (err < 0) {
+		return err;
+	}
+
+	/* Wait for data ready */
+	err = as7341_wait_data_ready(dev);
+	if (err < 0) {
+		LOG_ERR("Data ready timeout - Bank 1 (F1-F4)");
+		return err;
+	}
+
+	/* Read first 6 channels */
+	for (int i = 0; i < 6; i++) {
+		err = i2c_burst_read_dt(&cfg->i2c, AS7341_REG_CH0_DATA_L_1 + (i * 2), buf, 2);
+		if (err < 0) {
+			return err;
+		}
+		data->ch_data[i] = ((uint16_t)buf[1] << 8) | buf[0];
+	}
+
+	/* High Channels (F5-F8 + CLEAR + NIR) */
+
+	/* Disable measurement and configure SMUX for high channels */
+	err = as7341_enable_spectral(dev, false);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_set_smux_command(dev, AS7341_SMUX_CMD_WRITE);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_config_f5f8(dev);
+	if (err < 0) {
+		LOG_ERR("SMUX F5-F8 config failed");
+		return err;
+	}
+
+	/* Enable SMUX */
+	err = as7341_enable_smux(dev);
+	if (err < 0) {
+		return err;
+	}
+
+	/* Start spectral measurement */
+	err = as7341_enable_spectral(dev, true);
+	if (err < 0) {
+		return err;
+	}
+
+	/* Wait for data ready */
+	err = as7341_wait_data_ready(dev);
+	if (err < 0) {
+		LOG_ERR("Data ready timeout - Bank 2 (F5-F8)");
+		return err;
+	}
+
+	/* Read next 6 channels */
+	for (int i = 0; i < 6; i++) {
+		err = i2c_burst_read_dt(&cfg->i2c, AS7341_REG_CH0_DATA_L_1 + (i * 2), buf, 2);
+		if (err < 0) {
+			return err;
+		}
+
+		data->ch_data[i + 6] = ((uint16_t)buf[1] << 8) | buf[0];
+	}
+
+	LOG_DBG("AS7341 sample fetch completed successfully");
+	return 0;
+}
+
+/**
+ * @brief Get a spectral channel reading from the AS7341 driver buffer.
+ *
+ * Implements the Zephyr sensor_channel_get() API for the AS7341.
+ * Returns the raw 16-bit ADC count most recently fetched by
+ * as7341_sample_fetch() for the requested spectral channel.
+ *
+ * The result is stored in val->val1 as an integer count.
+ * val->val2 is always set to 0 (no fractional part).
+ *
+ * This function must be called after sensor_sample_fetch() has
+ * successfully populated the internal driver buffer. It has no
+ * side effects on driver state.
+ *
+ * Channel-to-buffer index mapping:
+ *
+ * | Channel                    | Wavelength | Pass | ch_data index |
+ * |----------------------------|------------|------|---------------|
+ * | SENSOR_CHAN_AS7341_415NM_F1 | 415 nm     | 1    | 0             |
+ * | SENSOR_CHAN_AS7341_445NM_F2 | 445 nm     | 1    | 1             |
+ * | SENSOR_CHAN_AS7341_480NM_F3 | 480 nm     | 1    | 2             |
+ * | SENSOR_CHAN_AS7341_515NM_F4 | 515 nm     | 1    | 3             |
+ * | SENSOR_CHAN_AS7341_CLEAR_0  | Clear      | 1    | 4             |
+ * | SENSOR_CHAN_AS7341_NIR_0    | NIR        | 1    | 5             |
+ * | SENSOR_CHAN_AS7341_555NM_F5 | 555 nm     | 2    | 6             |
+ * | SENSOR_CHAN_AS7341_590NM_F6 | 590 nm     | 2    | 7             |
+ * | SENSOR_CHAN_AS7341_630NM_F7 | 630 nm     | 2    | 8             |
+ * | SENSOR_CHAN_AS7341_680NM_F8 | 680 nm     | 2    | 9             |
+ * | SENSOR_CHAN_AS7341_CLEAR    | Clear      | 2    | 10            |
+ * | SENSOR_CHAN_AS7341_NIR      | NIR        | 2    | 11            |
+ *
+ * @param dev  Pointer to the sensor device structure.
+ * @param chan Spectral channel to read; see table above.
+ * @param val  Pointer to the sensor_value structure to populate.
+ *             val->val1 receives the raw ADC count; val->val2 is set to 0.
+ *
+ * @retval 0        Channel value retrieved successfully.
+ * @retval -ENOTSUP The requested channel is not supported by this driver.
+ */
+static int as7341_channel_get(const struct device *dev, enum sensor_channel chan,
+			      struct sensor_value *val)
+{
+	struct as7341_data *data = dev->data;
+
+	switch (chan) {
+	case SENSOR_CHAN_AS7341_415NM_F1:
+		val->val1 = data->ch_data[0];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_445NM_F2:
+		val->val1 = data->ch_data[1];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_480NM_F3:
+		val->val1 = data->ch_data[2];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_515NM_F4:
+		val->val1 = data->ch_data[3];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_CLEAR_0:
+		val->val1 = data->ch_data[4];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_NIR_0:
+		val->val1 = data->ch_data[5];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_555NM_F5:
+		val->val1 = data->ch_data[6];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_590NM_F6:
+		val->val1 = data->ch_data[7];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_630NM_F7:
+		val->val1 = data->ch_data[8];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_680NM_F8:
+		val->val1 = data->ch_data[9];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_CLEAR:
+		val->val1 = data->ch_data[10];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_NIR:
+		val->val1 = data->ch_data[11];
+		val->val2 = 0;
+		break;
+
+	case SENSOR_CHAN_AS7341_FLICKER:
+		val->val1 = data->flicker_hz;
+		val->val2 = 0;
+		break;
+
+	default:
+		return -ENOTSUP;
+	}
+	return 0;
+}
+
+/**
+ * @brief Detect flicker frequency using AS7341 spectral sensor.
+ *
+ * This function configures the AS7341 sensor for flicker detection,
+ * starts a measurement, reads the FD_STATUS register, and decodes the
+ * result into a flicker frequency in Hz.
+ *
+ * The function uses a hard‑coded SMUX configuration for flicker detection
+ * and enables only PON and FDEN (ENABLE = 0x41). No custom timing or AGC
+ * settings are applied, so the sensor uses its default measurement window,
+ * which is optimised for 100 Hz flicker detection (50 Hz mains).
+ *
+ * The measurement is followed by a 600 ms delay (empirically determined).
+ * After obtaining the status, the function maps specific FD_STATUS values
+ * to flicker frequencies:
+ * - 0x2E (46) → 120 Hz
+ * - 0x2D (45) → 100 Hz
+ * - 0x2C (44) → unknown / weak flicker (reported as 1 Hz)
+ * - any other value → no flicker detected (0 Hz)
+ *
+ * The function cleans up by disabling FDEN and SP_EN before returning.
+ *
+ * @param dev       Pointer to the AS7341 device structure.
+ * @param flicker_hz Pointer to where the result should be stored.
+ *                   When called from sample_fetch(), this points to
+ *                   the driver's internal `flicker_hz` buffer.
+ *                   - 0  : no flicker detected
+ *                   - 1  : unknown / weak flicker
+ *                   - 100: 100 Hz flicker detected
+ *                   - 120: 120 Hz flicker detected
+ *
+ * @return 0 on success, negative errno code on failure.
+ * @retval -EINVAL if @p flicker_hz is NULL.
+ * @retval <0     I2C communication or configuration error.
+ *
+ * @note This function assumes the sensor has already been initialised
+ *       (chip ID verified) and that the I2C bus is ready.
+ * @note The 600 ms delay is a practical requirement; the datasheet
+ *       recommends at least 300 ms, but longer improves reliability.
+ * @note The FD_STATUS decoding is based on empirical values observed
+ *       with the default configuration. If custom timing (FD_TIME1/2)
+ *       is used, the status mapping may need adjustment.
+ */
+int as7341_detect_flicker(const struct device *dev, uint16_t *flicker_hz)
+{
+	const struct as7341_config *cfg = dev->config;
+	uint8_t status;
+	int err;
+
+	if (!flicker_hz) {
+		return -EINVAL;
+	}
+	*flicker_hz = 0;
+
+	LOG_DBG("Starting AS7341 Flicker Detection");
+
+	/* Power on only */
+	err = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_ENABLE, AS7341_ENABLE_PON);
+	if (err < 0) {
+		return err;
+	}
+
+	k_msleep(10);
+
+	/* SMUX config */
+	err = as7341_set_smux_command(dev, AS7341_SMUX_CMD_WRITE);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_smux_config_flicker(dev);
+	if (err < 0) {
+		return err;
+	}
+
+	err = as7341_enable_smux(dev);
+	if (err < 0) {
+		return err;
+	}
+
+	err = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_ENABLE,
+				    AS7341_ENABLE_PON | AS7341_ENABLE_FDEN);
+	if (err < 0) {
+		return err;
+	}
+
+	/* Wait for measurement */
+	k_msleep(600);
+
+	/* Read FD_STATUS (0xDB) */
+	err = i2c_reg_read_byte_dt(&cfg->i2c, AS7341_REG_FD_STATUS, &status);
+	if (err < 0) {
+		return err;
+	}
+
+	LOG_DBG("FD_STATUS = 0x%02X", status);
+
+	switch (status) {
+	case AS7341_FD_STATUS_120HZ:
+		*flicker_hz = 120;
+		LOG_DBG("120 Hz flicker detected");
+		break;
+
+	case AS7341_FD_STATUS_UNKNOWN:
+		*flicker_hz = 1;
+		LOG_DBG("Unknown flicker detected");
+		break;
+
+	case AS7341_FD_STATUS_100HZ:
+		*flicker_hz = 100;
+		LOG_DBG("100 Hz flicker detected");
+		break;
+
+	default:
+		*flicker_hz = 0;
+		LOG_DBG("No flicker detected");
+		break;
+	}
+
+	/* Clean shutdown */
+	i2c_reg_update_byte_dt(&cfg->i2c, AS7341_REG_ENABLE,
+			       AS7341_ENABLE_FDEN | AS7341_ENABLE_SP_EN, 0);
+
+	return 0;
+}
+
+/**
+ * @brief AS7341 sensor driver API.
+ *
+ * Registers the AS7341 driver callbacks with the Zephyr sensor subsystem.
+ * sample_fetch and channel_get are required; attr_set, attr_get
+ *
+ * See sensor_driver_api for the full list of available callbacks.
+ */
+static const struct sensor_driver_api as7341_api = {
+	.attr_set = as7341_attr_set,
+	.attr_get = as7341_attr_get,
+	.sample_fetch = as7341_sample_fetch,
+	.channel_get = as7341_channel_get,
+};
+
+/**
+ * @brief Initialise the AS7341 11-channel spectral sensor.
+ *
+ * Called once by the Zephyr kernel at POST_KERNEL initialisation priority.
+ * Performs the following steps in order:
+ *
+ *  1. Verifies the I2C bus is ready.
+ *  2. Reads and validates the chip ID register (expected 0x24 or 0x09).
+ *  3. Powers on the sensor by writing AS7341_ENABLE_PON to the ENABLE register.
+ *  4. Waits 10 ms for the power-on sequence to complete.
+ *  5. Enables the internal LED driver (register 0x70, bit 3).
+ *  6. Sets the LED current limit (register 0x74 = 0x80).
+ *  7. Sets ATIME = 100 (integration time steps).
+ *  8. Sets ASTEP = 999 (0x03E7) via ASTEP_L and ASTEP_H registers.
+ *  9. Sets spectral gain to 256x (CFG1 = 0x09).
+ * 10. Sets CFG0 = 0x20 (bank 0, normal operating mode).
+ *
+ * Integration time in microseconds is calculated as:
+ *   T_int = (ATIME + 1) * (ASTEP + 1) * 2.78 µs
+ * With ATIME=100 and ASTEP=999: T_int ≈ 278 ms.
+ *
+ * @param dev Pointer to the sensor device structure.
+ *
+ * @retval 0        Initialisation succeeded.
+ * @retval -ENODEV  I2C bus not ready, or chip ID does not match.
+ * @retval <0       Negative errno code on any I2C write failure
+ */
+int as7341_init(const struct device *dev)
+{
+	const struct as7341_config *cfg = dev->config;
+	uint8_t chip_id;
+	int err;
+
+	LOG_DBG("as7341_init");
+
+	if (!i2c_is_ready_dt(&cfg->i2c)) {
+		LOG_ERR("I2C bus not ready");
+		return -ENODEV;
+	}
+
+	/* Verify chip ID */
+	err = i2c_reg_read_byte_dt(&cfg->i2c, AS7341_REG_ID, &chip_id);
+	if (err < 0) {
+		LOG_ERR("Failed to read chip ID");
+		return err;
+	}
+
+	LOG_DBG("Chip ID read: 0x%02X", chip_id);
+
+	if (chip_id != AS7341_CHIP_ID_VAL && chip_id != AS7341_CHIP_ID_ALT) {
+		LOG_ERR("Unexpected chip ID: 0x%02X", chip_id);
+		return -ENODEV;
+	}
+
+	/* Power ON sensor */
+	err = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_ENABLE, AS7341_ENABLE_PON);
+	if (err < 0) {
+		LOG_ERR("Failed to power on");
+		return err;
+	}
+
+	k_msleep(10);
+
+	err = i2c_reg_update_byte_dt(&cfg->i2c, AS7341_REG_CONFIG, AS7341_CONFIG_FLICKER_MODE,
+				     AS7341_CONFIG_FLICKER_MODE);
+	if (err < 0) {
+		return err;
+	}
+
+	err = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_LED, AS7341_LED_BRIGHTNESS_DEFAULT);
+	if (err < 0) {
+		LOG_ERR("Failed to set LED brightness");
+		return err;
+	}
+
+	/* Set ATIME */
+	err = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_ATIME, AS7341_ATIME_DEFAULT);
+	if (err < 0) {
+		LOG_ERR("Error setting ATIME");
+		return err;
+	}
+
+	/* Set ASTEP = 999 */
+	err = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_ASTEP_L, AS7341_ASTEP_999_LSB);
+	if (err < 0) {
+		LOG_ERR("Error setting ASTEP LSB");
+		return err;
+	}
+	err = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_ASTEP_H, AS7341_ASTEP_999_MSB);
+	if (err < 0) {
+		LOG_ERR("Error setting ASTEP MSB");
+		return err;
+	}
+
+	/* Set gain - AS7341_GAIN_256X */
+	err = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_CFG1, AS7341_GAIN_256X);
+	if (err < 0) {
+		LOG_ERR("Error setting gain");
+		return err;
+	}
+
+	/* Configure CFG0 for normal operation, bank 0 */
+	err = i2c_reg_write_byte_dt(&cfg->i2c, AS7341_REG_CFG0, AS7341_CFG0_NORMAL_BANK0);
+	if (err < 0) {
+		LOG_ERR("Error setting CFG0");
+		return err;
+	}
+
+	LOG_DBG("AS7341 initialized successfully");
+
+	return 0;
+}
+
+#define AS7341_DEFINE(inst)                                                    \
+	static struct as7341_data as7341_data_##inst;                              \
+	static const struct as7341_config as7341_config_##inst = {                 \
+		.i2c = I2C_DT_SPEC_INST_GET(inst),                                     \
+	};                                                                         \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, as7341_init, NULL, &as7341_data_##inst, \
+								 &as7341_config_##inst, POST_KERNEL,           \
+								 CONFIG_SENSOR_INIT_PRIORITY, &as7341_api);
+
+DT_INST_FOREACH_STATUS_OKAY(AS7341_DEFINE)

--- a/drivers/sensor/ams/ams_as7341/ams_as7341.h
+++ b/drivers/sensor/ams/ams_as7341/ams_as7341.h
@@ -1,0 +1,360 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (C) 2026 Dotcom IoT LLP
+ * Author: Mahendra Sondagar <mahendra@dotcom.co.in>
+ * Author: Parin Baudhanwala <parin.baudhanwala@dnkmail.in>
+ */
+/**
+ * @file ams_as7341.h
+ * @brief AS7341 Spectral Sensor Module driver.
+ *
+ * Defines register addresses, bit masks, driver configuration and runtime
+ * data structures for the AS7341 Zephyr sensor driver.
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_AS7341_AS7341_H_
+#define ZEPHYR_DRIVERS_SENSOR_AS7341_AS7341_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/util.h>
+
+#define AS7341_I2C_ADDR 0x39 /* I2C address */
+
+#define AS7341_REG_ID 0x92 /* Device ID register */
+
+/* Bank 0 Registers */
+#define AS7341_REG_ASTATUS_0 0x60 /* Auxiliary status (bank 0: saturation, flags) */
+
+#define AS7341_REG_CH0_DATA_L_0 0x61 /* Channel 0 data (LSB, bank 0) */
+#define AS7341_REG_CH0_DATA_H_0 0x62 /* Channel 0 data (MSB, bank 0) */
+
+#define AS7341_REG_ITIME_L 0x63 /* Integration time (LSB) */
+#define AS7341_REG_ITIME_M 0x64 /* Integration time (mid byte) */
+#define AS7341_REG_ITIME_H 0x65 /* Integration time (MSB) */
+
+#define AS7341_REG_CH1_DATA_L_0 0x66 /* Channel 1 data (LSB, bank 0) */
+#define AS7341_REG_CH1_DATA_H_0 0x67 /* Channel 1 data (MSB, bank 0) */
+
+#define AS7341_REG_CH2_DATA_L_0 0x68 /* Channel 2 data (LSB, bank 0) */
+#define AS7341_REG_CH2_DATA_H_0 0x69 /* Channel 2 data (MSB, bank 0) */
+
+#define AS7341_REG_CH3_DATA_L_0 0x6A /* Channel 3 data (LSB, bank 0) */
+#define AS7341_REG_CH3_DATA_H_0 0x6B /* Channel 3 data (MSB, bank 0) */
+
+#define AS7341_REG_CH4_DATA_L_0 0x6C /* Channel 4 data (LSB, bank 0) */
+#define AS7341_REG_CH4_DATA_H_0 0x6D /* Channel 4 data (MSB, bank 0) */
+
+#define AS7341_REG_CH5_DATA_L_0 0x6E /* Channel 5 data (LSB, bank 0) */
+#define AS7341_REG_CH5_DATA_H_0 0x6F /* Channel 5 data (MSB, bank 0) */
+
+#define AS7341_REG_CONFIG  0x70 /* LED control and measurement mode configuration */
+#define AS7341_REG_STATUS0 0x71 /* Status register */
+#define AS7341_REG_EDGE	   0x72 /* Interrupt edge configuration */
+
+#define AS7341_REG_GPIO 0x73 /* GPIO control register */
+#define AS7341_REG_LED	0x74 /* LED control register */
+
+#define AS7341_REG_ENABLE    0x80   /* Enable register */
+#define AS7341_ENABLE_PON    BIT(0) /* Power ON */
+#define AS7341_ENABLE_SP_EN  BIT(1) /* Spectral measurement enable */
+#define AS7341_ENABLE_SMUXEN BIT(4) /* SMUX enable */
+#define AS7341_ENABLE_FDEN   BIT(6) /* Flicker detection enable */
+
+#define AS7341_REG_ATIME 0x81 /* Integration time */
+#define AS7341_REG_WTIME 0x83 /* Wait time */
+
+#define AS7341_REG_SP_TH_L_LSB 0x84 /* Spectral threshold low (LSB) */
+#define AS7341_REG_SP_TH_L_MSB 0x85 /* Spectral threshold low (MSB) */
+
+#define AS7341_REG_SP_TH_H_LSB 0x86 /* Spectral threshold high (LSB) */
+#define AS7341_REG_SP_TH_H_MSB 0x87 /* Spectral threshold high (MSB) */
+
+#define AS7341_REG_AUXID 0x90 /* Auxiliary ID register */
+#define AS7341_REG_REVID 0x91 /* Revision ID register */
+
+#define AS7341_REG_STATUS1 0x93 /* Interrupt Status register */
+
+/* Bank 1 Registers */
+#define AS7341_REG_ASTATUS_1 0x94 /* Auxiliary status (bank 1: gain status) */
+
+#define AS7341_REG_CH0_DATA_L_1 0x95 /* Channel 0 data (LSB, bank 1) */
+#define AS7341_REG_CH0_DATA_H_1 0x96 /* Channel 0 data (MSB, bank 1) */
+
+#define AS7341_REG_CH1_DATA_L_1 0x97 /* Channel 1 data (LSB, bank 1) */
+#define AS7341_REG_CH1_DATA_H_1 0x98 /* Channel 1 data (MSB, bank 1) */
+
+#define AS7341_REG_CH2_DATA_L_1 0x99 /* Channel 2 data (LSB, bank 1) */
+#define AS7341_REG_CH2_DATA_H_1 0x9A /* Channel 2 data (MSB, bank 1) */
+
+#define AS7341_REG_CH3_DATA_L_1 0x9B /* Channel 3 data (LSB, bank 1) */
+#define AS7341_REG_CH3_DATA_H_1 0x9C /* Channel 3 data (MSB, bank 1) */
+
+#define AS7341_REG_CH4_DATA_L_1 0x9D /* Channel 4 data (LSB, bank 1) */
+#define AS7341_REG_CH4_DATA_H_1 0x9E /* Channel 4 data (MSB, bank 1) */
+
+#define AS7341_REG_CH5_DATA_L_1 0x9F /* Channel 5 data (LSB, bank 1) */
+#define AS7341_REG_CH5_DATA_H_1 0xA0 /* Channel 5 data (MSB, bank 1) */
+
+#define AS7341_REG_STATUS2 0xA3 /* Status register 2 */
+#define AS7341_REG_STATUS3 0xA4 /* Status register 3 */
+#define AS7341_REG_STATUS5 0xA6 /* Status register 5 */
+#define AS7341_REG_STATUS6 0xA7 /* Status register 6 */
+
+#define AS7341_REG_CFG0	      0xA9   /* Configuration register 0 */
+#define AS7341_CFG0_REG_BANK  BIT(4) /* Register bank select */
+#define AS7341_CFG0_LOW_POWER BIT(0) /* Low power mode */
+#define AS7341_CFG0_WLONG     BIT(2) /* Wait long enable */
+
+#define AS7341_REG_CFG1 0xAA /* Configuration register 1 */
+#define AS7341_REG_CFG3 0xAC /* Configuration register 3 */
+#define AS7341_REG_CFG6 0xAF /* Configuration register 6 */
+#define AS7341_REG_CFG8 0xB1 /* Configuration register 8 */
+
+#define AS7341_REG_CFG9	 0xB2 /* Configuration register 9 */
+#define AS7341_REG_CFG10 0xB3 /* Configuration register 10 */
+#define AS7341_REG_CFG12 0xB5 /* Configuration register 12 */
+
+#define AS7341_REG_PERS 0xBD /* Interrupt persistence register */
+
+#define AS7341_REG_GPIO2 0xBE /* GPIO control register 2 */
+
+#define AS7341_REG_ASTEP_L 0xCA /* Integration step (LSB) */
+#define AS7341_REG_ASTEP_H 0xCB /* Integration step (MSB) */
+
+#define AS7341_REG_AGC_GAIN_MAX 0xCF /* AGC gain maximum register */
+
+#define AS7341_REG_AZ_CONFIG 0xD6 /* Auto-zero configuration */
+
+#define AS7341_REG_INTENAB  0xF9 /* Interrupt enable register */
+#define AS7341_INTENAB_MASK BIT(3)
+#define AS7341_INTENAB_CONF BIT(3)
+
+#define AS7341_REG_CONTROL 0xFA /* Control register */
+
+#define AS7341_REG_FIFO_MAP 0xFC /* FIFO channel mapping */
+#define AS7341_REG_FIFO_LVL 0xFD /* FIFO level */
+
+#define AS7341_REG_FDATA_L 0xFE /* FIFO data (LSB) */
+#define AS7341_REG_FDATA_H 0xFF /* FIFO data (MSB) */
+
+#define AS7341_SPECTRAL_INT_HIGH_MSK BIT(5)
+#define AS7341_SPECTRAL_INT_LOW_MSK  BIT(4)
+
+/* SMUX commands */
+#define AS7341_SMUX_CMD_ROM_INIT 0 /* ROM code initialization */
+#define AS7341_SMUX_CMD_READ	 1 /* Read SMUX config to RAM */
+#define AS7341_SMUX_CMD_WRITE	 2 /* Write SMUX config from RAM to SMUX chain */
+
+/* Flicker Detection Registers */
+#define AS7341_REG_FD_CFG0   0xD7 /* Flicker detection configuration */
+#define AS7341_REG_FD_TIME1  0xD8 /* Flicker detection time LSB */
+#define AS7341_REG_FD_TIME2  0xDA /* Flicker detection time MSB + gain */
+#define AS7341_REG_FD_STATUS 0xDB /* Flicker detection status */
+
+#define AS7341_FD_STATUS_MEAS_VALID    BIT(5)
+#define AS7341_FD_STATUS_SATURATION    BIT(4)
+#define AS7341_FD_STATUS_120HZ_VALID   BIT(3)
+#define AS7341_FD_STATUS_100HZ_VALID   BIT(2)
+#define AS7341_FD_STATUS_120HZ_FLICKER BIT(1)
+#define AS7341_FD_STATUS_100HZ_FLICKER BIT(0)
+
+/* In your register defines section */
+#define AS7341_CONFIG_FLICKER_MODE BIT(3)
+
+/* SMUX command bits in CFG6 */
+#define AS7341_CFG6_SMUX_CMD_MASK 0x18 /* bits [4:3] */
+#define AS7341_SMUX_CMD_SHIFT	  3
+#define AS7341_SMUX_CMD_MASK	  0x03 /* 2-bit command code */
+
+/* SMUX load command */
+#define AS7341_SMUX_LOAD_CMD 0x10
+
+/* CFG0 register configuration (bank select and mode) */
+#define AS7341_CFG0_NORMAL_BANK0 0x20 /* Bank 0, normal operation */
+
+/* LED brightness */
+#define AS7341_LED_BRIGHTNESS_DEFAULT 0x80
+
+/* Default integration time (ATIME) – 100 corresponds to moderate light */
+#define AS7341_ATIME_DEFAULT 100
+
+/* ASTEP value for 999 (typical integration steps) */
+#define AS7341_ASTEP_999_LSB 0xE7
+#define AS7341_ASTEP_999_MSB 0x03
+
+/**
+ * @brief Driver-specific sensor channel identifiers for the AS7341.
+ *
+ * Extends the Zephyr sensor_channel enum starting from SENSOR_CHAN_PRIV_START
+ * to avoid conflicts with the standard Zephyr sensor channels defined in
+ * <zephyr/drivers/sensor.h>.
+ *
+ * Each entry maps to one of the AS7341's eight narrowband spectral filters
+ * or to the broadband clear and near-infrared (NIR) channels. Because the
+ * sensor has more channels than ADC inputs, the channels are split across
+ * two SMUX measurement passes:
+ *
+ * Pass 1 (F1–F4, CLEAR_0, NIR_0) – low spectral channels:
+ *   - SENSOR_CHAN_AS7341_415NM_F1  – F1 filter, 415 nm (violet)
+ *   - SENSOR_CHAN_AS7341_445NM_F2  – F2 filter, 445 nm (violet/blue)
+ *   - SENSOR_CHAN_AS7341_480NM_F3  – F3 filter, 480 nm (blue)
+ *   - SENSOR_CHAN_AS7341_515NM_F4  – F4 filter, 515 nm (cyan/green)
+ *   - SENSOR_CHAN_AS7341_CLEAR_0   – clear channel (unfiltered, pass 1)
+ *   - SENSOR_CHAN_AS7341_NIR_0     – near-infrared channel (pass 1)
+ *
+ * Pass 2 (F5–F8, CLEAR, NIR) – high spectral channels:
+ *   - SENSOR_CHAN_AS7341_555NM_F5  – F5 filter, 555 nm (green)
+ *   - SENSOR_CHAN_AS7341_590NM_F6  – F6 filter, 590 nm (yellow)
+ *   - SENSOR_CHAN_AS7341_630NM_F7  – F7 filter, 630 nm (orange/red)
+ *   - SENSOR_CHAN_AS7341_680NM_F8  – F8 filter, 680 nm (red)
+ *   - SENSOR_CHAN_AS7341_CLEAR     – clear channel (unfiltered, pass 2)
+ *   - SENSOR_CHAN_AS7341_NIR       – near-infrared channel (pass 2)
+ *
+ * Use these identifiers with sensor_channel_get() after a successful
+ * sensor_sample_fetch() call.
+ */
+enum sensor_channel_as7341 {
+	SENSOR_CHAN_AS7341_415NM_F1 = SENSOR_CHAN_PRIV_START,
+	SENSOR_CHAN_AS7341_445NM_F2,
+	SENSOR_CHAN_AS7341_480NM_F3,
+	SENSOR_CHAN_AS7341_515NM_F4,
+	SENSOR_CHAN_AS7341_CLEAR_0,
+	SENSOR_CHAN_AS7341_NIR_0,
+	SENSOR_CHAN_AS7341_555NM_F5,
+	SENSOR_CHAN_AS7341_590NM_F6,
+	SENSOR_CHAN_AS7341_630NM_F7,
+	SENSOR_CHAN_AS7341_680NM_F8,
+	SENSOR_CHAN_AS7341_CLEAR,
+	SENSOR_CHAN_AS7341_NIR,
+	SENSOR_CHAN_AS7341_FLICKER,
+};
+
+/**
+ * @brief Internal ADC channel identifiers for the AS7341.
+ *
+ * The AS7341 has six internal ADC channels (0–5). Each channel is connected
+ * to a photodiode input via the SMUX multiplexer. The SMUX routing table
+ * determines which spectral filter is connected to which ADC channel for
+ * each measurement pass.
+ *
+ * These identifiers are used internally by the driver and are not exposed
+ * through the Zephyr sensor API.
+ */
+enum as7341_adc_channel {
+	AS7341_ADC_CHANNEL_0,
+	AS7341_ADC_CHANNEL_1,
+	AS7341_ADC_CHANNEL_2,
+	AS7341_ADC_CHANNEL_3,
+	AS7341_ADC_CHANNEL_4,
+	AS7341_ADC_CHANNEL_5,
+};
+
+/**
+ * @brief AS7341 flicker detection status values.
+ *
+ * These values are read from the AS7341_REG_FD_STATUS register and indicate
+ * the detected flicker frequency or an unknown pattern.
+ */
+enum as7341_fd_status {
+	AS7341_FD_STATUS_UNKNOWN = 44, /* 0x2C */
+	AS7341_FD_STATUS_100HZ = 45,   /* 0x2D */
+	AS7341_FD_STATUS_120HZ = 46,   /* 0x2E */
+};
+
+/**
+ * @brief AS7341 ADC gain settings.
+ *
+ * These values are written to the AS7341_REG_CFG1 register to set the
+ * analog gain for spectral measurements. Higher gain increases sensitivity
+ * but also amplifies noise.
+ */
+enum as7341_gain {
+	AS7341_GAIN_0_5X = 0x00,
+	AS7341_GAIN_1X = 0x01,
+	AS7341_GAIN_2X = 0x02,
+	AS7341_GAIN_4X = 0x03,
+	AS7341_GAIN_8X = 0x04,
+	AS7341_GAIN_16X = 0x05,
+	AS7341_GAIN_32X = 0x06,
+	AS7341_GAIN_64X = 0x07,
+	AS7341_GAIN_128X = 0x08,
+	AS7341_GAIN_256X = 0x09,
+	AS7341_GAIN_512X = 0x0A,
+};
+
+/**
+ * @brief AS7341 chip identification values.
+ *
+ * These values are read from the AS7341_REG_ID register to identify the
+ * sensor revision. The driver expects either the main value (0x09) or the
+ * alternative value (0x24).
+ */
+enum as7341_chip_id {
+	AS7341_CHIP_ID_VAL = 0x09,
+	AS7341_CHIP_ID_ALT = 0x24,
+};
+
+/**
+ * @brief Detect flicker frequency from AS7341 sensor.
+ *
+ * Configures sensor for flicker detection, measures, and decodes FD_STATUS
+ * into Hz (0 = none, 1 = unknown, 100, or 120).
+ *
+ * @param dev AS7341 device instance.
+ * @param flicker_hz Pointer to store detected frequency in Hz.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int as7341_detect_flicker(const struct device *dev, uint16_t *flicker_hz);
+
+/**
+ * @brief AS7341 driver compile-time configuration structure.
+ *
+ * Holds all configuration that is fixed at build time and derived from
+ * the device tree node for this AS7341 instance. Populated by the
+ * AS7341_DEFINE() macro via I2C_DT_SPEC_INST_GET().
+ *
+ * This structure is stored in read-only memory (rodata).
+ */
+struct as7341_config {
+	struct i2c_dt_spec i2c;
+};
+
+/**
+ * @brief AS7341 driver runtime data structure.
+ *
+ * Holds all mutable per-instance state for the AS7341 driver. A separate
+ * instance of this structure exists for each AS7341 device node that is
+ * enabled in the device tree.
+ *
+ * The ch_data array stores raw 16-bit ADC counts populated by
+ * as7341_sample_fetch(). The layout is:
+ *
+ * | Index | Channel              | Pass |
+ * |-------|----------------------|------|
+ * |  0    | F1 – 415 nm          | 1    |
+ * |  1    | F2 – 445 nm          | 1    |
+ * |  2    | F3 – 480 nm          | 1    |
+ * |  3    | F4 – 515 nm          | 1    |
+ * |  4    | Clear (CLEAR_0)      | 1    |
+ * |  5    | NIR   (NIR_0)        | 1    |
+ * |  6    | F5 – 555 nm          | 2    |
+ * |  7    | F6 – 590 nm          | 2    |
+ * |  8    | F7 – 630 nm          | 2    |
+ * |  9    | F8 – 680 nm          | 2    |
+ * | 10    | Clear (CLEAR)        | 2    |
+ * | 11    | NIR   (NIR)          | 2    |
+ */
+struct as7341_data {
+	uint16_t ch_data[12]; /* F1–F4, CLEAR_0, NIR_0, F5–F8, CLEAR, NIR  */
+	uint16_t flicker_hz;
+	uint8_t gain;
+	uint16_t atime;
+	uint16_t astep;
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_AS7341_AS7341_H_ */

--- a/dts/bindings/sensor/ams,as7341.yaml
+++ b/dts/bindings/sensor/ams,as7341.yaml
@@ -1,0 +1,5 @@
+description: AMS AS7341 spectral sensor
+
+compatible: "ams,as7341"
+
+include: [sensor-device.yaml, i2c-device.yaml]


### PR DESCRIPTION
This pull request adds a new driver for the AMS AS7341 11‑channel multi‑spectral sensor. The driver is implemented according to the Zephyr sensor model and provides full control over the device’s spectral measurement capabilities.

Supported Features:

Reading of all 11 spectral channels: F1–F8, Clear, Clear_0, NIR, NIR_0

Configurable analog gain (AGAIN) and integration time

Automatic and manual SMUX (sensor multiplexer) configuration for flexible ADC‑channel mapping

On‑chip flicker detection with support for 50 Hz / 60 Hz ambient light flicker, including raw data access

Standard sensor attributes: SENSOR_ATTR_SAMPLING_FREQUENCY, SENSOR_ATTR_GAIN, etc.

The driver adheres to Zephyr’s device driver model and includes a corresponding devicetree binding for the AS7341.

Hardware Tested
SoC / Module: nRF9151 (Nordic Semiconductor)

Development Kit: nRF9151 DK

SDK Version: nRF Connect SDK v3.2.2 (Zephyr based)

Interface: I²C (7‑bit slave address 0x39)

Test Setup: Custom board with AS7341 connected over I²C

Test Results:
1. Spectral Channel Readout
All 11 spectral channels are read correctly. The following output was obtained under white LED illumination:

F1 415nm : 199
F2 445nm : 448
F3 480nm : 508
F4 515nm : 687
Clear_0  : 8505
NIR_0    : 5210
F5 555nm : 875
F6 590nm : 774
F7 630nm : 1219
F8 680nm : 1711
Clear    : 8496
NIR      : 5210

Placing objects of different colours in front of the sensor produced corresponding changes in the channel values, confirming correct spectral responsivity.

2. Flicker Detection
The driver successfully detects 100 Hz ambient light flicker (tested with a fluorescent lamp). Example log output:

Flicker: 100 Hz Flicker Detected

120 Hz flicker detection was also validated using a light source with 120 Hz ripple.

3. Gain and Integration Time Adjustment
Modifying AGAIN from 0.5× to 512× scales the ADC readings proportionally.

Integration time follows the formula:
t_int = (ATIME + 1) × (ASTEP + 1) × 2.78 µs
Changes to ATIME and ASTEP produce the expected timing behaviour.

4. SMUX Remapping
Manual SMUX reconfiguration (e.g., mapping channels F5–F8 to ADC0–ADC5) operates without errors, demonstrating full flexibility of the sensor’s multiplexer.