### PR TITLE
Revert "net: lwm2m: finalize CBOR output on -ENOMEM instead of aborting"

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -3299,10 +3299,6 @@ int lwm2m_perform_composite_read_op(struct lwm2m_message *msg, uint16_t content_
 
 		ret = lwm2m_perform_read_object_instance(msg, obj_inst, &num_read);
 		if (ret == -ENOMEM) {
-			if (num_read > 0) {
-				/* Return what we have read so far */
-				goto put_end;
-			}
 			return ret;
 		}
 	}
@@ -3311,7 +3307,6 @@ int lwm2m_perform_composite_read_op(struct lwm2m_message *msg, uint16_t content_
 		return -ENOENT;
 	}
 
-put_end:
 	/* Add object end mark */
 	if (engine_put_end(&msg->out, &msg->path) < 0) {
 		return -ENOMEM;


### PR DESCRIPTION
This reverts commit 9401406e6a1e818df063f34a93070981afab3f5d.

This patch was reverted due to regressions reported in #109814 (cached timeseries data loss).

Resolves #109814

CC @mwappler-dl