### PR TITLE
boards: nxp: mimxrt1180_evk: enable lpuart per core, not in common

### DIFF
--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
@@ -146,7 +146,6 @@
 };
 
 &lpuart1 {
-	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_lpuart1>;
 	pinctrl-1 = <&pinmux_lpuart1_sleep>;
@@ -154,7 +153,6 @@
 };
 
 &lpuart12 {
-	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_lpuart12>;
 	pinctrl-1 = <&pinmux_lpuart12_sleep>;

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.dts
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.dts
@@ -71,7 +71,6 @@
 
 &lpuart1 {
 	status = "okay";
-	current-speed = <115200>;
 };
 
 &lpadc1 {

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.dts
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.dts
@@ -61,7 +61,6 @@
 
 &lpuart12 {
 	status = "okay";
-	current-speed = <115200>;
 };
 
 &lpadc1 {


### PR DESCRIPTION
Both lpuart1 and lpuart12 were unconditionally marked status = "okay" in the board common dtsi, which is included by both the CM33 and CM7 .dts files. As a result, each core's image instantiated drivers for both UART instances and IRQ-connected to the peripheral interrupt lines that are delivered to both cores' NVIC. Characters arriving on the LPUART12 RX FIFO could be stolen by the CM33 ISR (or vice versa), causing the CM7 shell to appear unresponsive to keyboard input even though TX worked normally.

Move "status = okay" into each core's .dts so that only the owning core instantiates its console UART. Keep current-speed and pinctrl in the common dtsi as board-level hardware properties.

After this change:
  CM33 build: lpuart1 = okay, lpuart12 = disabled
  CM7 build : lpuart1 = disabled, lpuart12 = okay