### PR TITLE
firmware: scmi: Fix protocol version negotiation compatibility

### DIFF
--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -54,6 +54,19 @@ struct scmi_clock_get_permissions_reply {
 	uint32_t permissions;
 };
 
+struct scmi_clock_attributes_v2 {
+	int32_t status;
+	uint32_t attributes;
+	uint8_t clock_name[SCMI_CLK_NAME_LEN];
+} __packed;
+
+struct scmi_clock_attributes_v3 {
+	int32_t status;
+	uint32_t attributes;
+	uint8_t clock_name[SCMI_CLK_NAME_LEN];
+	uint32_t clock_enable_delay;
+} __packed;
+
 int scmi_clock_rate_get(struct scmi_protocol *proto,
 			uint32_t clk_id, uint32_t *rate)
 {
@@ -245,12 +258,72 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 	return scmi_status_to_errno(status);
 }
 
-int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
-			  struct scmi_clock_attributes *attributes)
+static int scmi_clock_attributes_v2(struct scmi_protocol *proto, uint32_t clk_id,
+				    struct scmi_clock_attributes *attributes)
 {
+	struct scmi_clock_attributes_v2 v2;
 	struct scmi_message msg, reply;
 	int ret;
 
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_ATTRIBUTES, SCMI_COMMAND, proto->id, 0x0);
+	msg.len = sizeof(clk_id);
+	msg.content = &clk_id;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(v2);
+	reply.content = &v2;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (v2.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(v2.status);
+	}
+	/* clock_enable_delay only available in protocol v3.0+ */
+	attributes->clock_enable_delay = 0;
+	attributes->attributes = v2.attributes;
+	memcpy(attributes->clock_name, v2.clock_name, SCMI_CLK_NAME_LEN);
+
+	return 0;
+}
+
+static int scmi_clock_attributes_v3(struct scmi_protocol *proto, uint32_t clk_id,
+				    struct scmi_clock_attributes *attributes)
+{
+	struct scmi_clock_attributes_v3 v3;
+	struct scmi_message msg, reply;
+	int ret;
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_ATTRIBUTES,
+					SCMI_COMMAND, proto->id, 0x0);
+	msg.len = sizeof(clk_id);
+	msg.content = &clk_id;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(v3);
+	reply.content = &v3;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (v3.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(v3.status);
+	}
+
+	attributes->attributes = v3.attributes;
+	attributes->clock_enable_delay = v3.clock_enable_delay;
+	memcpy(attributes->clock_name, v3.clock_name, SCMI_CLK_NAME_LEN);
+
+	return 0;
+}
+
+int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
+			  struct scmi_clock_attributes *attributes)
+{
 	if (!proto || !attributes) {
 		return -EINVAL;
 	}
@@ -259,21 +332,11 @@ int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_ATTRIBUTES,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(clk_id);
-	msg.content = &clk_id;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(*attributes);
-	reply.content = attributes;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
-	if (ret < 0) {
-		return ret;
+	if (SCMI_PROTO_VER_MAJOR(proto->version) >= 3) {
+		return scmi_clock_attributes_v3(proto, clk_id, attributes);
+	} else {
+		return scmi_clock_attributes_v2(proto, clk_id, attributes);
 	}
-
-	return scmi_status_to_errno(attributes->status);
 }
 
 int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,

--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -183,17 +183,20 @@ static int scmi_core_protocol_negotiate(struct scmi_protocol *proto)
 		return ret;
 	}
 
-	if (platform_version > agent_version) {
-		ret = scmi_protocol_version_negotiate(proto, agent_version);
-		if (ret < 0) {
-			LOG_WRN("Protocol 0x%X: Negotiation failed (%d). "
-				"Platform v0x%08x does not support downgrade to agent v0x%08x",
-				proto->id, ret, platform_version, agent_version);
-		}
+	if (platform_version <= agent_version) {
+		proto->version = platform_version;
+		return 0;
 	}
 
-	LOG_INF("Using protocol 0x%X: agent version 0x%08x, platform version 0x%08x",
-			proto->id, agent_version, platform_version);
+	ret = scmi_protocol_version_negotiate(proto, agent_version);
+	if (ret == 0) {
+		LOG_INF("protocol 0x%x: successfully negotiated to version 0x%x", proto->id,
+			agent_version);
+		return 0;
+	}
+
+	LOG_WRN("protocol 0x%x: compatibility with platform version 0x%x NOT assured", proto->id,
+		platform_version);
 
 	return 0;
 }
@@ -224,6 +227,7 @@ static int scmi_core_protocol_setup(const struct device *transport)
 			return ret;
 		}
 
+		LOG_INF("initialized protocol 0x%x version 0x%x", it->id, it->version);
 	}
 
 	return 0;

--- a/include/zephyr/drivers/firmware/scmi/clk.h
+++ b/include/zephyr/drivers/firmware/scmi/clk.h
@@ -44,6 +44,23 @@
 #define SCMI_CLK_PROTOCOL_SUPPORTED_VERSION	0x30000
 
 /** Clock name length (short version) */
+/**
+ * @brief Extract major version from SCMI protocol version
+ *
+ * @param v Combined 32-bit protocol version (major << 16 | minor)
+ * @return Major version number
+ */
+#define SCMI_PROTO_VER_MAJOR(v) ((v) >> 16)
+
+/**
+ * @brief Extract minor version from SCMI protocol version
+ *
+ * @param v Combined 32-bit protocol version (major << 16 | minor)
+ * @return Minor version number
+ */
+#define SCMI_PROTO_VER_MINOR(v) ((v) & 0xFFFF)
+
+/** clock name length (short version) */
 #define SCMI_CLK_NAME_LEN 16
 
 /** Get the clock's enabled status based on given attributes */
@@ -91,15 +108,13 @@ struct scmi_clock_rate_config {
  * @brief Describes the content of the CLOCK_ATTRIBUTES command reply
  */
 struct scmi_clock_attributes {
-	/** Reply status */
-	int32_t status;
-	/** Clock attributes */
+	/** clock attributes */
 	uint32_t attributes;
 	/** Clock name */
 	uint8_t clock_name[SCMI_CLK_NAME_LEN];
 	/** Clock enable delay incurred by platform */
 	uint32_t clock_enable_delay;
-} __packed;
+};
 
 /**
  * @brief Send the CLOCK_CONFIG_SET command and get its reply


### PR DESCRIPTION
The CLOCK_ATTRIBUTES reply structure has a clock_enable_delay field only in protocol v3.0. When the platform implements v2.0 (e.g. RK3588), the reply is 24 bytes but the driver expects 28 bytes, causing "bad message len" errors.

Store the negotiated version (MIN of agent and platform) in proto->version so that scmi_clock_attributes() can adjust the expected reply length based on the actual protocol version.