### PR TITLE
dts: bindings: cpu: Add VexiiRiscv

### DIFF
--- a/dts/bindings/cpu/spinalhdl,vexiiriscv.yaml
+++ b/dts/bindings/cpu/spinalhdl,vexiiriscv.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: VexiiRiscv RISC-V CPU
+
+compatible: "spinalhdl,vexiiriscv"
+
+include: riscv-common.yaml


### PR DESCRIPTION
VexiiRiscv is a RISC-V CPU core written in SpinalHDL, the successor to VexRiscv. It features a configurable pipeline architecture and stretches from very small RV32 to large RV64 dual issue cores.

https://github.com/SpinalHDL/VexiiRiscv