### PR TITLE
Enable frdm-imxrt1186 i3c feature

### DIFF
--- a/boards/nxp/frdm_imxrt1186/doc/index.rst
+++ b/boards/nxp/frdm_imxrt1186/doc/index.rst
@@ -124,6 +124,20 @@ by the board for the default configuration:
 +---------------+-----------------+---------------------------+
 | GPIO_AD_16    | ADC             | ADC1 Channel 0            |
 +---------------+-----------------+---------------------------+
+| GPIO_AD_17    | I3C2_PUR        | I3C2 Pull-up (Arduino)    |
++---------------+-----------------+---------------------------+
+| GPIO_AD_18    | I3C2_SCL        | I3C2 SCL (Arduino D15)    |
++---------------+-----------------+---------------------------+
+| GPIO_AD_19    | I3C2_SDA        | I3C2 SDA (Arduino D14)    |
++---------------+-----------------+---------------------------+
+
+.. note::
+   Using I3C2 on the Arduino header requires hardware rework:
+   solder R30/R31 to route Arduino D14/D15 to GPIO_AD_18/19, and move
+   R297/R299 to position 1-3 to disconnect GPIO_EMC_B2_19/20 from the
+   Arduino header. Refer to the FRDM-iMXRT1186 schematic for details.
+   I3C2 shares GPIO_AD_18/19 with LPI2C3 (board EEPROM), so LPI2C3 and
+   the EEPROM must be disabled in overlays that enable I3C2.
 
 System Clock
 ============

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
@@ -98,6 +98,23 @@
 		};
 	};
 
+	pinmux_i3c2: pinmux_i3c2 {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_18_i3c2_scl>,
+				 <&iomuxc_gpio_ad_19_i3c2_sda>;
+			drive-strength = "normal";
+			drive-open-drain;
+			slew-rate = "fast";
+			input-enable;
+		};
+
+		group1 {
+			pinmux = <&iomuxc_gpio_ad_17_i3c2_pur>;
+			slew-rate = "fast";
+			drive-strength = "high";
+		};
+	};
+
 	/* QSPI Flash on FlexSPI2 - GPIO_AON_22/23/24/25/26/27 */
 	pinmux_flexspi2: pinmux_flexspi2 {
 		group0 {

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
@@ -138,6 +138,19 @@
 	pinctrl-names = "default";
 };
 
+&i3c2 {
+	pinctrl-0 = <&pinmux_i3c2>;
+	pinctrl-names = "default";
+};
+
+/*
+ * I3C2 shares GPIO_AD_18/19 with LPI2C3 (board EEPROM). lpi2c3 is enabled by
+ * default; overlays that need i3c2 must disable lpi2c3 and eeprom0.
+ */
+p3t1755dp_ard_i3c_interface: &i3c2 {};
+
+p3t1755dp_ard_i2c_interface: &lpi2c3 {};
+
 &systick {
 	status = "okay";
 };

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -27,6 +27,7 @@ supported:
   - mbox
   - netif:eth
   - i2c
+  - i3c
   - watchdog
   - pwm
 vendor: nxp

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
@@ -23,6 +23,7 @@ supported:
   - hwinfo
   - mbox
   - i2c
+  - i3c
   - watchdog
   - pwm
 vendor: nxp

--- a/boards/shields/p3t1755dp_ard_i3c/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/boards/shields/p3t1755dp_ard_i3c/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The p3t1755 shield board is plugged into the Arduino interface on the
+ * FRDM-iMXRT1186 board.
+ *
+ * Hardware rework required before using this shield (see board schematic):
+ *   - Solder R30/R31 to route Arduino D14/D15 to GPIO_AD_18/19
+ *     (LPI2C3/I3C2 signals).
+ *   - Move R297/R299 to position 1-3 to disconnect GPIO_EMC_B2_19/20
+ *     from the Arduino header, avoiding contention on D14/D15.
+ *
+ * LPI2C3 and the on-board EEPROM share GPIO_AD_18/19 with I3C2, so they
+ * are disabled here.
+ */
+
+#include <freq.h>
+
+&lpi2c3 {
+	status = "disabled";
+};
+
+&eeprom0 {
+	status = "disabled";
+};
+
+&i3c2 {
+	status = "okay";
+
+	i2c-scl-hz = <DT_FREQ_K(400)>;
+	i3c-scl-hz = <DT_FREQ_K(400)>;
+	i3c-od-scl-hz = <DT_FREQ_K(100)>;
+};

--- a/boards/shields/p3t1755dp_ard_i3c/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/boards/shields/p3t1755dp_ard_i3c/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * I3C2 shield enablement is identical for CM33 and CM7 cores.
+ */
+
+#include "frdm_imxrt1186_mimxrt1186_cm33.overlay"

--- a/samples/sensor/thermometer/sample.yaml
+++ b/samples/sensor/thermometer/sample.yaml
@@ -42,4 +42,6 @@ tests:
     extra_args:
       - platform:mimxrt1180_evk/mimxrt1189/cm33:SHIELD=p3t1755dp_ard_i3c
       - platform:mimxrt1180_evk/mimxrt1189/cm7:SHIELD=p3t1755dp_ard_i3c
+      - platform:frdm_imxrt1186/mimxrt1186/cm33:SHIELD=p3t1755dp_ard_i3c
+      - platform:frdm_imxrt1186/mimxrt1186/cm7:SHIELD=p3t1755dp_ard_i3c
       - platform:frdm_mcxn236/mcxn236:SHIELD=p3t1755dp_ard_i3c


### PR DESCRIPTION
Enables I3C2 on the FRDM-iMXRT1186 board, wired to the Arduino header (D14/D15), and brings the existing p3t1755 I3C shield + build_all/i3c coverage onto this board for both CM33 and CM7 cores.