### PR TITLE
[Backport v3.7-branch] Bluetooth: controller: Correct validation for CONNECT_IND interval

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -2729,6 +2729,10 @@ struct bt_hci_evt_le_advertising_report {
 	struct bt_hci_evt_le_advertising_info adv_info[0];
 } __packed;
 
+/** All limits according to BT Core Spec v5.4 [Vol 4, Part E]. */
+#define BT_HCI_LE_INTERVAL_MIN                  0x0006
+#define BT_HCI_LE_INTERVAL_MAX                  0x0c80
+
 #define BT_HCI_EVT_LE_CONN_UPDATE_COMPLETE      0x03
 struct bt_hci_evt_le_conn_update_complete {
 	uint8_t  status;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -155,7 +155,7 @@ void ull_periph_setup(struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 	if ((lll->data_chan_count < CHM_USED_COUNT_MIN) ||
 	    (lll->data_chan_hop < CHM_HOP_COUNT_MIN) ||
 	    (lll->data_chan_hop > CHM_HOP_COUNT_MAX) ||
-	    !lll->interval) {
+	    !IN_RANGE(lll->interval, BT_HCI_LE_INTERVAL_MIN, BT_HCI_LE_INTERVAL_MAX)) {
 		invalid_release(&adv->ull, lll, link, rx);
 
 		return;


### PR DESCRIPTION
Backport 91b7204dc140e100041018cdbed22f0ecb9fe679 from #89955.

Fixes  CVE-2025-12890 (GHSA-8hrf-pfww-83v9) on Zephyr v3.7.

The fix is logically identical to the upstream commit. The only adaptation is adding two spec-constant macros from   2f50e26c4054. No behavioral change beyond what the upstream PR introduces.

cc: @babrsn

---

Previously, the interval was only checked for non-zero. Now it is validated to be within the allowed range (BT_HCI_LE_INTERVAL_MIN to BT_HCI_LE_INTERVAL_MAX) to avoid invalid values.

Fixes: #109942