### PR TITLE
drivers: eth_nxp_enet_qos: default to 10 Mbps half-duplex at MAC init

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -621,6 +621,8 @@ static inline void enet_qos_mtl_config_init(enet_qos_t *base)
 static inline void enet_qos_mac_config_init(enet_qos_t *base, struct nxp_enet_qos_mac_data *data,
 					    uint32_t clk_rate)
 {
+	uint32_t mac_configuration;
+
 	/* Set MAC address */
 	base->MAC_ADDRESS0_HIGH =
 		ENET_QOS_REG_PREP(MAC_ADDRESS0_HIGH, ADDRHI,
@@ -645,17 +647,21 @@ static inline void enet_qos_mac_config_init(enet_qos_t *base, struct nxp_enet_qo
 					(clk_rate / USEC_PER_SEC) - 1);
 #endif
 
-	base->MAC_CONFIGURATION |=
+	mac_configuration = base->MAC_CONFIGURATION;
+	mac_configuration |=
 		/* For 10/100 Mbps operation */
 		ENET_QOS_REG_PREP(MAC_CONFIGURATION, PS, 0b1) |
-		/* Full duplex mode, adjust duplex in phy callback if needed */
-		ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1) |
-		/* 100 Mbps mode, adjust link speed in phy callback if needed */
-		ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1) |
 		/* Strip CRC from Type packets before handing frames to the stack */
 		ENET_QOS_REG_PREP(MAC_CONFIGURATION, CST, 0b1) |
 		/* Don't talk unless no one else is talking */
 		ENET_QOS_REG_PREP(MAC_CONFIGURATION, ECRSFD, 0b1);
+	mac_configuration &= ~(
+		/* Half duplex mode, adjust duplex in phy callback if needed */
+		ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1) |
+		/* 10 Mbps mode, adjust link speed in phy callback if needed */
+		ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1)
+	);
+	base->MAC_CONFIGURATION = mac_configuration;
 
 #ifdef ENET_MAC_RXQ_CTRL_RXQ0EN
 	/* Enable the MAC RX channel 0 */


### PR DESCRIPTION
The MAC_CONFIGURATION register was unconditionally OR'ed with the FES (speed) and DM (duplex) bits, forcing 100 Mbps full-duplex during MAC initialization. The PHY link callback later updates these bits to match the actual link state, but on 10BASE-T1S (PLCA) links the temporary 100 Mbps/full-duplex setting causes the MAC to ignore the COL signal from the internal TENBASET_PHY block. As a result the MAC transmits during another node's transmit opportunity, producing collisions and lost data.

Initialize MAC_CONFIGURATION with FES and DM cleared (10 Mbps, half-duplex, which is also the register's reset value) and let the PHY callback set the correct speed/duplex once the link is up. Read-modify- write is done via a local variable so both the set and clear masks are applied in a single register write.

Tested with FRDM-MCXA577 in affected 10BASE-T1S scenario and also with regular ethernet (speed and duplex updated by PHY callback and communication works).

Fixes #109682