### PR TITLE
mailbox: userspace: Fixes for mbox_send

### DIFF
--- a/drivers/mbox/mbox_handlers.c
+++ b/drivers/mbox/mbox_handlers.c
@@ -12,6 +12,12 @@ static inline int z_vrfy_mbox_send(const struct device *dev,
 				   const struct mbox_msg *msg)
 {
 	K_OOPS(K_SYSCALL_DRIVER_MBOX(dev, send));
+
+	if (msg == NULL) {
+		/* Signalling mode: NULL msg is valid per the API contract */
+		return z_impl_mbox_send(dev, channel_id, NULL);
+	}
+
 	K_OOPS(K_SYSCALL_MEMORY_READ(msg, sizeof(struct mbox_msg)));
 	K_OOPS(K_SYSCALL_MEMORY_READ(msg->data, msg->size));
 

--- a/drivers/mbox/mbox_handlers.c
+++ b/drivers/mbox/mbox_handlers.c
@@ -11,6 +11,8 @@ static inline int z_vrfy_mbox_send(const struct device *dev,
 				   mbox_channel_id_t channel_id,
 				   const struct mbox_msg *msg)
 {
+	struct mbox_msg msg_copy;
+
 	K_OOPS(K_SYSCALL_DRIVER_MBOX(dev, send));
 
 	if (msg == NULL) {
@@ -18,10 +20,15 @@ static inline int z_vrfy_mbox_send(const struct device *dev,
 		return z_impl_mbox_send(dev, channel_id, NULL);
 	}
 
-	K_OOPS(K_SYSCALL_MEMORY_READ(msg, sizeof(struct mbox_msg)));
-	K_OOPS(K_SYSCALL_MEMORY_READ(msg->data, msg->size));
+	/* Copy the userspace struct into a kernel-stack snapshot before
+	 * validating the nested data pointer, preventing a TOCTOU race where
+	 * a concurrent thread could replace msg->data with a supervisor address
+	 * after the access check.
+	 */
+	K_OOPS(k_usermode_from_copy(&msg_copy, msg, sizeof(msg_copy)));
+	K_OOPS(K_SYSCALL_MEMORY_READ(msg_copy.data, msg_copy.size));
 
-	return z_impl_mbox_send(dev, channel_id, msg);
+	return z_impl_mbox_send(dev, channel_id, &msg_copy);
 }
 #include <zephyr/syscalls/mbox_send_mrsh.c>
 


### PR DESCRIPTION
Two fixes for mbox_send when userspace is enabled:

- Fix msg == NULL, since it is valid per API documentation
- Fix TOCTOU copying the msg to kernel memory

For more specific details look commit messages.

Fixes: #113307