### PR TITLE
drivers: firmware: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/firmware/scmi/transport.h
+++ b/include/zephyr/drivers/firmware/scmi/transport.h
@@ -105,8 +105,7 @@ struct scmi_transport_api {
 	 *
 	 * @param transport transport device
 	 *
-	 * @retval 0 is successful
-	 * @retval <0 negative errno code if failure
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*init)(const struct device *transport);
 
@@ -124,8 +123,7 @@ struct scmi_transport_api {
 	 * @param msg message to send
 	 * @param use_polling true if polling should be enabled, false otherwise
 	 *
-	 * @retval 0 if successful
-	 * @retval <0 negative errno code if failure
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*send_message)(const struct device *transport,
 			    struct scmi_channel *chan,
@@ -142,8 +140,7 @@ struct scmi_transport_api {
 	 * @param chan channel to prepare
 	 * @param tx true if channel is TX, false if channel is RX
 	 *
-	 * @retval 0 if successful
-	 * @retval <0 negative errno code if failure
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*setup_chan)(const struct device *transport,
 			  struct scmi_channel *chan,
@@ -159,8 +156,7 @@ struct scmi_transport_api {
 	 * @param chan channel used to receive the message
 	 * @param msg message to receive
 	 *
-	 * @retval 0 if successful
-	 * @retval <0 negative errno code if failure
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*read_message)(const struct device *transport,
 			    struct scmi_channel *chan,
@@ -177,8 +173,7 @@ struct scmi_transport_api {
 	 * @param transport device
 	 * @param chan TX channel to query
 	 *
-	 * @retval 0 if successful
-	 * @retval <0 negative errno code if failure
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	bool (*channel_is_free)(const struct device *transport,
 				struct scmi_channel *chan);
@@ -312,8 +307,7 @@ static inline bool scmi_transport_channel_is_free(const struct device *transport
  * @param transport pointer to the device structure for
  * the transport layer
  *
- * @retval 0 if successful
- * @retval negative errno code if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_core_transport_init(const struct device *transport);
 


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974