### PR TITLE
drivers: flash: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -523,9 +523,8 @@ void flash_page_foreach(const struct device *dev, flash_page_cb cb,
  * @param data where the data to be read will be placed
  * @param len the number of bytes of data to be read
  *
- * @retval 0 on success
- * @retval -ENOTSUP if the flash driver does not support SFDP access
- * @retval <0 negative values for other errors.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Flash driver does not support SFDP access.
  */
 __syscall int flash_sfdp_read(const struct device *dev, off_t offset,
 			      void *data, size_t len);
@@ -551,9 +550,8 @@ static inline int z_impl_flash_sfdp_read(const struct device *dev,
  * @param id pointer to a buffer of at least 3 bytes into which id
  * will be stored
  *
- * @retval 0 on successful store of 3-byte JEDEC id
- * @retval -ENOTSUP if flash driver doesn't support this function
- * @retval <0 negative values for other errors
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Flash driver doesn't support this function.
  */
 __syscall int flash_read_jedec_id(const struct device *dev, uint8_t *id);
 
@@ -634,10 +632,9 @@ static inline const struct flash_parameters *z_impl_flash_get_parameters(const s
  *  @param out Pointer to operation output data. If operation doesn't produce
  *             any output it could be NULL.
  *
- *  @retval 0 on success.
- *  @retval -ENOTSUP if given device doesn't support extended operation.
- *  @retval -ENOSYS if support for extended operations is not enabled in Kconfig
- *  @retval <0 negative value on extended operation errors.
+ *  @return 0 on success, negative errno value on failure.
+ *  @retval -ENOTSUP Given device doesn't support extended operation.
+ *  @retval -ENOSYS Support for extended operations is not enabled in Kconfig.
  */
 __syscall int flash_ex_op(const struct device *dev, uint16_t code,
 			  const uintptr_t in, void *out);


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974