### PR TITLE
soc: espressif: drop custom FLASH_SIZE and FLASH_BASE_ADDRESS

### DIFF
--- a/boards/dfrobot/beetle_esp32c3/beetle_esp32c3.dts
+++ b/boards/dfrobot/beetle_esp32c3/beetle_esp32c3.dts
@@ -21,7 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
-		zehpyr,flash = &flash0;
+		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,canbus = &twai;
 		zephyr,bt-hci = &esp32_bt_hci;

--- a/soc/espressif/common/CMakeLists.txt
+++ b/soc/espressif/common/CMakeLists.txt
@@ -57,8 +57,12 @@ else()
   file(WRITE "${_extram_inc}" "")
 endif()
 
-# Get flash size to use in esptool as string
-math(EXPR esptoolpy_flashsize "${CONFIG_FLASH_SIZE} / 0x100000")
+if(NOT (CONFIG_SOC_ESP32C5_LPCORE OR CONFIG_SOC_ESP32C6_LPCORE))
+  # Get flash size in MB for esptool from the chosen zephyr,flash node
+  dt_chosen(dts_flash PROPERTY "zephyr,flash")
+  dt_reg_size(flash_size_bytes PATH ${dts_flash})
+  math(EXPR esptoolpy_flashsize "${flash_size_bytes} / 0x100000")
+endif()
 
 # Get UART baudrate from DT
 dt_chosen(dts_shell_uart PROPERTY "zephyr,shell-uart")

--- a/soc/espressif/common/Kconfig
+++ b/soc/espressif/common/Kconfig
@@ -1,12 +1,6 @@
 # Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config FLASH_SIZE
-	int
-
-config FLASH_BASE_ADDRESS
-	hex
-
 config ESP32_USE_UNSUPPORTED_REVISION
 	bool "Use unsupported ESP32 revision (Rev 0/1)"
 	help

--- a/soc/espressif/esp32/Kconfig.defconfig
+++ b/soc/espressif/esp32/Kconfig.defconfig
@@ -3,12 +3,6 @@
 
 if SOC_SERIES_ESP32
 
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/flash-controller@3ff42000/flash@0,0)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flash-controller@3ff42000/flash@0)
-
 config BOOTLOADER_MCUBOOT
 	default y if SOC_ESP32_APPCPU
 

--- a/soc/espressif/esp32/memory.h
+++ b/soc/espressif/esp32/memory.h
@@ -118,8 +118,5 @@
 #define CACHE_ALIGN        CONFIG_MMU_PAGE_SIZE
 
 /* Flash */
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE          CONFIG_FLASH_SIZE
-#else
-#define FLASH_SIZE          0x400000
-#endif
+#define FLASH_SIZE         DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+#define FLASH_BASE_ADDRESS DT_REG_ADDR(DT_CHOSEN(zephyr_flash))

--- a/soc/espressif/esp32c2/Kconfig.defconfig
+++ b/soc/espressif/esp32c2/Kconfig.defconfig
@@ -6,12 +6,6 @@ if SOC_SERIES_ESP32C2
 config NUM_IRQS
 	default 32
 
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/flash-controller@60002000/flash@0,0)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flash-controller@60002000/flash@0)
-
 config MAIN_STACK_SIZE
 	default 2048
 

--- a/soc/espressif/esp32c2/memory.h
+++ b/soc/espressif/esp32c2/memory.h
@@ -73,11 +73,8 @@
 	(BOOTLOADER_IRAM_SEG_START - IRAM_DRAM_OFFSET - BOOTLOADER_DRAM_SEG_LEN)
 
 /* Flash */
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE         CONFIG_FLASH_SIZE
-#else
-#define FLASH_SIZE         0x400000
-#endif
+#define FLASH_SIZE         DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+#define FLASH_BASE_ADDRESS DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
 
 /* Cached memory */
 #define CACHE_ALIGN        CONFIG_MMU_PAGE_SIZE

--- a/soc/espressif/esp32c3/Kconfig.defconfig
+++ b/soc/espressif/esp32c3/Kconfig.defconfig
@@ -6,12 +6,6 @@ if SOC_SERIES_ESP32C3
 config NUM_IRQS
 	default 32
 
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/flash-controller@60002000/flash@0,0)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flash-controller@60002000/flash@0)
-
 config MAIN_STACK_SIZE
 	default 2048
 

--- a/soc/espressif/esp32c3/memory.h
+++ b/soc/espressif/esp32c3/memory.h
@@ -75,11 +75,8 @@
 	(BOOTLOADER_IRAM_SEG_START - IRAM_DRAM_OFFSET - BOOTLOADER_DRAM_SEG_LEN)
 
 /* Flash */
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE         CONFIG_FLASH_SIZE
-#else
-#define FLASH_SIZE         0x400000
-#endif
+#define FLASH_SIZE         DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+#define FLASH_BASE_ADDRESS DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
 
 /* Cached memory */
 #define CACHE_ALIGN        CONFIG_MMU_PAGE_SIZE

--- a/soc/espressif/esp32c5/Kconfig.defconfig
+++ b/soc/espressif/esp32c5/Kconfig.defconfig
@@ -35,12 +35,6 @@ config PMP_SLOTS
 config PMP_NO_LOCK_GLOBAL
 	default y
 
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/flash-controller@60002000/flash@0,0)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flash-controller@60002000/flash@0)
-
 config MAIN_STACK_SIZE
 	default 2048
 

--- a/soc/espressif/esp32c5/memory.h
+++ b/soc/espressif/esp32c5/memory.h
@@ -70,11 +70,8 @@
 #define BOOTLOADER_DRAM_SEG_START (BOOTLOADER_IRAM_SEG_START - BOOTLOADER_DRAM_SEG_LEN)
 
 /* Flash */
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE CONFIG_FLASH_SIZE
-#else
-#define FLASH_SIZE 0x800000
-#endif
+#define FLASH_SIZE         DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+#define FLASH_BASE_ADDRESS DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
 
 /* Cached memory - ESP32-C5 uses unified I/D address space
  * From HAL ext_mem_defs.h: SOC_IRAM0_CACHE_ADDRESS_LOW = 0x42000000

--- a/soc/espressif/esp32c6/Kconfig.defconfig
+++ b/soc/espressif/esp32c6/Kconfig.defconfig
@@ -16,12 +16,6 @@ config PMP_SLOTS
 config PMP_NO_LOCK_GLOBAL
 	default y
 
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/flash-controller@60002000/flash@0,0)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flash-controller@60002000/flash@0)
-
 config MAIN_STACK_SIZE
 	default 2048
 

--- a/soc/espressif/esp32c6/memory.h
+++ b/soc/espressif/esp32c6/memory.h
@@ -67,11 +67,8 @@
 	(BOOTLOADER_IRAM_SEG_START - BOOTLOADER_DRAM_SEG_LEN)
 
 /* Flash */
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE CONFIG_FLASH_SIZE
-#else
-#define FLASH_SIZE 0x400000
-#endif
+#define FLASH_SIZE         DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+#define FLASH_BASE_ADDRESS DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
 
 /* Cached memory */
 #define CACHE_ALIGN  CONFIG_MMU_PAGE_SIZE

--- a/soc/espressif/esp32h2/Kconfig.defconfig
+++ b/soc/espressif/esp32h2/Kconfig.defconfig
@@ -6,12 +6,6 @@ if SOC_SERIES_ESP32H2
 config NUM_IRQS
 	default 32
 
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/flash-controller@60002000/flash@0,0)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flash-controller@60002000/flash@0)
-
 config MAIN_STACK_SIZE
 	default 2048
 

--- a/soc/espressif/esp32h2/memory.h
+++ b/soc/espressif/esp32h2/memory.h
@@ -63,11 +63,8 @@
 	(BOOTLOADER_IRAM_SEG_START - BOOTLOADER_DRAM_SEG_LEN)
 
 /* Flash */
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE CONFIG_FLASH_SIZE
-#else
-#define FLASH_SIZE 0x400000
-#endif
+#define FLASH_SIZE         DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+#define FLASH_BASE_ADDRESS DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
 
 /* Cached memory */
 #define CACHE_ALIGN  CONFIG_MMU_PAGE_SIZE

--- a/soc/espressif/esp32s2/Kconfig.defconfig
+++ b/soc/espressif/esp32s2/Kconfig.defconfig
@@ -10,12 +10,6 @@ choice CACHE_TYPE
 	default EXTERNAL_CACHE if CACHE_MANAGEMENT
 endchoice
 
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/flash-controller@3f402000/flash@0,0)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flash-controller@3f402000/flash@0)
-
 config MAIN_STACK_SIZE
 	default 2048
 

--- a/soc/espressif/esp32s2/memory.h
+++ b/soc/espressif/esp32s2/memory.h
@@ -86,8 +86,5 @@
 #define CACHE_ALIGN       CONFIG_MMU_PAGE_SIZE
 
 /* Flash */
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE        CONFIG_FLASH_SIZE
-#else
-#define FLASH_SIZE        0x400000
-#endif
+#define FLASH_SIZE         DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+#define FLASH_BASE_ADDRESS DT_REG_ADDR(DT_CHOSEN(zephyr_flash))

--- a/soc/espressif/esp32s3/Kconfig.defconfig
+++ b/soc/espressif/esp32s3/Kconfig.defconfig
@@ -10,12 +10,6 @@ choice CACHE_TYPE
 	default EXTERNAL_CACHE if CACHE_MANAGEMENT
 endchoice
 
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/flash-controller@60002000/flash@0,0)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flash-controller@60002000/flash@0)
-
 config BOOTLOADER_MCUBOOT
 	default y if SOC_ESP32S3_APPCPU
 

--- a/soc/espressif/esp32s3/memory.h
+++ b/soc/espressif/esp32s3/memory.h
@@ -136,8 +136,5 @@
 #define CACHE_ALIGN   CONFIG_MMU_PAGE_SIZE
 
 /* Flash memory */
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE         CONFIG_FLASH_SIZE
-#else
-#define FLASH_SIZE         0x800000
-#endif
+#define FLASH_SIZE         DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+#define FLASH_BASE_ADDRESS DT_REG_ADDR(DT_CHOSEN(zephyr_flash))


### PR DESCRIPTION
Stop defining custom FLASH_SIZE and FLASH_BASE_ADDRESS Kconfig symbols in the Espressif SoC tree and consume the chosen zephyr,flash node directly from devicetree.