### PR TITLE
manifest: hal_espressif: pull esp32s3 simple boot fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 1a2f973addcd12a660e84231dbcce1c34f3eaef4
+      revision: 22474f2034d4f9c3be20f6162b0e0f1518225827
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Pull the following fix from Espressif HAL:

"bootloader_clock_configure() switched the CPU from XTAL to PLL at CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ (240 MHz) which has been the cause of failures on some ESP32-S3 rev 0.2 chips."