### PR TITLE
dfu: kconfig: always define mcuboot_update_footer_size

### DIFF
--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -52,14 +52,6 @@ config MCUBOOT_TRAILER_SWAP_TYPE
 	  Disable this option if need to be compatible with earlier version
 	  of MCUBoot.
 
-config MCUBOOT_UPDATE_FOOTER_SIZE
-	hex "Estimated update footer size"
-	default 0x0
-	help
-	  Estimated size of update image data, which is used to prevent loading of firmware updates
-	  that MCUboot cannot update due to being too large. This should be set from sysbuild, only
-	  used when MCUMGR_GRP_IMG_TOO_LARGE_SYSBUILD is enabled.
-
 config IMG_BLOCK_BUF_SIZE
 	int "Image writer buffer size"
 	default 512
@@ -117,3 +109,15 @@ config UPDATEABLE_IMAGE_NUMBER
 endif
 
 endif # IMG_MANAGER
+
+if BOOTLOADER_MCUBOOT
+
+config MCUBOOT_UPDATE_FOOTER_SIZE
+	hex "Estimated update footer size"
+	default 0x0
+	help
+	  Estimated size of update image data, which is used to prevent loading of firmware updates
+	  that MCUboot cannot update due to being too large. This should be set from sysbuild, only
+	  used when MCUMGR_GRP_IMG_TOO_LARGE_SYSBUILD is enabled.
+
+endif # BOOTLOADER_MCUBOOT


### PR DESCRIPTION
Move CONFIG_MCUBOOT_UPDATE_FOOTER_SIZE out of the inner if MCUBOOT_IMG_MANAGER block so it exists whenever mcuboot is the bootloader. The symbol is a passive size hint that sysbuild forwards to consumers, similar to ROM_END_OFFSET, so it should not be gated on the image management code being built. This silences the Kconfig warning emitted on every sysbuild build when MCUBOOT_IMG_MANAGER is not enabled:

```c
warning: MCUBOOT_UPDATE_FOOTER_SIZE (defined at subsys/dfu/Kconfig:55)
was assigned the value '0x30' but got the value ''. Check these unsatisfied
dependencies: MCUBOOT_IMG_MANAGER (=n), IMG_MANAGER (=n).
``` 