### PR TITLE
drivers: flash: add device validation in flash_copy syscall

### DIFF
--- a/drivers/flash/flash_util.c
+++ b/drivers/flash/flash_util.c
@@ -195,6 +195,8 @@ int z_impl_flash_copy(const struct device *src_dev, off_t src_offset, const stru
 int z_vrfy_flash_copy(const struct device *src_dev, off_t src_offset, const struct device *dst_dev,
 		      off_t dst_offset, off_t size, uint8_t *buf, size_t buf_size)
 {
+	K_OOPS(K_SYSCALL_DRIVER_FLASH(src_dev, read));
+	K_OOPS(K_SYSCALL_DRIVER_FLASH(dst_dev, write));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(buf, buf_size));
 	return z_impl_flash_copy(src_dev, src_offset, dst_dev, dst_offset, size, buf, buf_size);
 }


### PR DESCRIPTION
Add K_SYSCALL_DRIVER_FLASH checks for src_dev and dst_dev in z_vrfy_flash_copy() to ensure both devices implement the required flash driver API before proceeding with the copy operation.