### PR TITLE
MAX32 SPI half duplex support

### DIFF
--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -56,7 +56,8 @@ struct max32_spi_data {
 	struct spi_context ctx;
 	const struct device *dev;
 	mxc_spi_req_t req;
-	uint8_t dummy[2];
+	uint8_t tx_dummy[2];
+	uint8_t rx_dummy[2];
 
 #ifdef CONFIG_SPI_MAX32_DMA
 	volatile uint8_t dma_stat;
@@ -266,8 +267,9 @@ static int spi_max32_transceive_sync(mxc_spi_regs_t *spi, struct max32_spi_data 
 		remain = tx_len - req->txCnt;
 		if (remain > 0) {
 			if (!data->req.txData) {
-				req->txCnt += MXC_SPI_WriteTXFIFO(spi, data->dummy,
-								  MIN(remain, sizeof(data->dummy)));
+				req->txCnt += MXC_SPI_WriteTXFIFO(spi, data->tx_dummy,
+								  MIN(remain,
+								      sizeof(data->tx_dummy)));
 			} else {
 				req->txCnt +=
 					MXC_SPI_WriteTXFIFO(spi, &req->txData[req->txCnt], remain);
@@ -321,11 +323,7 @@ static int spi_max32_transceive(const struct device *dev)
 	uint8_t dfs_shift;
 
 	dfs_shift = spi_max32_get_dfs_shift(ctx);
-
 	len = spi_context_max_continuous_chunk(ctx);
-
-	/* Make sure dummy is zero'd in case it's re-used as a TX buffer in a later request. */
-	memset(data->dummy, 0, sizeof(data->dummy));
 
 #ifdef CONFIG_SPI_RTIO
 	switch (sqe->op) {
@@ -336,7 +334,7 @@ static int spi_max32_transceive(const struct device *dev)
 		if (data->req.rxData == NULL &&
 		    (COND_CODE_1(IS_ENABLED(CONFIG_SPI_MAX32_DMA),
 				 (cfg->rx_dma.channel == 0xFF), (true)))) {
-			data->req.rxData = data->dummy;
+			data->req.rxData = data->rx_dummy;
 			data->req.rxLen = 0;
 		}
 		data->req.txData = NULL;
@@ -345,14 +343,14 @@ static int spi_max32_transceive(const struct device *dev)
 	case RTIO_OP_TX:
 		len = sqe->tx.buf_len;
 		data->req.rxLen = 0;
-		data->req.rxData = data->dummy;
+		data->req.rxData = data->rx_dummy;
 		data->req.txData = (uint8_t *)sqe->tx.buf;
 		data->req.txLen = len;
 		break;
 	case RTIO_OP_TINY_TX:
 		len = sqe->tiny_tx.buf_len;
 		data->req.txData = (uint8_t *)sqe->tiny_tx.buf;
-		data->req.rxData = data->dummy;
+		data->req.rxData = data->rx_dummy;
 		data->req.txLen = len;
 		data->req.rxLen = 0;
 		break;
@@ -365,7 +363,7 @@ static int spi_max32_transceive(const struct device *dev)
 		if (data->req.rxData == NULL &&
 		    (COND_CODE_1(IS_ENABLED(CONFIG_SPI_MAX32_DMA),
 				 (cfg->rx_dma.channel == 0xFF), (true)))) {
-			data->req.rxData = data->dummy;
+			data->req.rxData = data->rx_dummy;
 			data->req.rxLen = 0;
 		}
 		break;
@@ -395,7 +393,7 @@ static int spi_max32_transceive(const struct device *dev)
 		/* Pass a dummy buffer to HAL if receive buffer is NULL, otherwise
 		 * corrupt data is read during subsequent transactions.
 		 */
-		data->req.rxData = data->dummy;
+		data->req.rxData = data->rx_dummy;
 		data->req.rxLen = 0;
 
 		if (!data->req.txData && !data->req.txLen) {
@@ -491,8 +489,8 @@ dma_rtio_exit:
 		MXC_SPI_SetTXThreshold(cfg->regs, 1 << dfs_shift);
 		MXC_SPI_EnableInt(cfg->regs, ADI_MAX32_SPI_INT_EN_TX_THD);
 		if (!data->req.txData) {
-			data->req.txCnt = MXC_SPI_WriteTXFIFO(cfg->regs, data->dummy,
-							      MIN(len, sizeof(data->dummy)));
+			data->req.txCnt = MXC_SPI_WriteTXFIFO(cfg->regs, data->tx_dummy,
+							      MIN(len, sizeof(data->tx_dummy)));
 		} else {
 			data->req.txCnt = MXC_SPI_WriteTXFIFO(cfg->regs,
 							      data->req.txData, data->req.txLen);
@@ -713,7 +711,7 @@ static int spi_max32_tx_dma_load(const struct device *dev, const uint8_t *buf, u
 		dma_blk.source_address = (uint32_t)buf;
 	} else {
 		dma_blk.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
-		dma_blk.source_address = (uint32_t)data->dummy;
+		dma_blk.source_address = (uint32_t)data->tx_dummy;
 	}
 
 	ret = dma_config(config->tx_dma.dev, config->tx_dma.channel, &dma_cfg);
@@ -773,7 +771,7 @@ static int spi_max32_rx_dma_load(const struct device *dev, const uint8_t *buf, u
 		dma_blk.dest_address = (uint32_t)buf;
 	} else {
 		dma_blk.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
-		dma_blk.dest_address = (uint32_t)data->dummy;
+		dma_blk.dest_address = (uint32_t)data->rx_dummy;
 	}
 	ret = dma_config(config->rx_dma.dev, config->rx_dma.channel, &dma_cfg);
 	if (ret < 0) {
@@ -1150,8 +1148,9 @@ static void spi_max32_isr(const struct device *dev)
 	if (flags & ADI_MAX32_SPI_INT_FL_TX_THD) {
 		if (remain) {
 			if (!data->req.txData) {
-				req->txCnt += MXC_SPI_WriteTXFIFO(cfg->regs, data->dummy,
-								  MIN(remain, sizeof(data->dummy)));
+				req->txCnt += MXC_SPI_WriteTXFIFO(cfg->regs, data->tx_dummy,
+								  MIN(remain,
+								      sizeof(data->tx_dummy)));
 			} else {
 				req->txCnt +=
 					MXC_SPI_WriteTXFIFO(spi, &req->txData[req->txCnt], remain);

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -134,25 +134,35 @@ static int spi_configure(const struct device *dev, const struct spi_config *conf
 		return -ENOTSUP;
 	}
 
-#if defined(CONFIG_SPI_EXTENDED_MODES)
-	switch (config->operation & SPI_LINES_MASK) {
-	case SPI_LINES_QUAD:
-		ret = MXC_SPI_SetWidth(regs, SPI_WIDTH_QUAD);
-		break;
-	case SPI_LINES_DUAL:
-		ret = MXC_SPI_SetWidth(regs, SPI_WIDTH_DUAL);
-		break;
-	case SPI_LINES_OCTAL:
-		ret = -ENOTSUP;
-		break;
-	case SPI_LINES_SINGLE:
-	default:
-		ret = MXC_SPI_SetWidth(regs, SPI_WIDTH_STANDARD);
-		break;
+	if (config->operation & SPI_HALF_DUPLEX) {
+		ret = MXC_SPI_SetWidth(regs, SPI_WIDTH_3WIRE);
+		if (ret) {
+			LOG_ERR("Failed to set half duplex mode (%d)", ret);
+			return -EINVAL;
+		}
 	}
+#if defined(CONFIG_SPI_EXTENDED_MODES)
+	else {
+		switch (config->operation & SPI_LINES_MASK) {
+		case SPI_LINES_QUAD:
+			ret = MXC_SPI_SetWidth(regs, SPI_WIDTH_QUAD);
+			break;
+		case SPI_LINES_DUAL:
+			ret = MXC_SPI_SetWidth(regs, SPI_WIDTH_DUAL);
+			break;
+		case SPI_LINES_OCTAL:
+			ret = -ENOTSUP;
+			break;
+		case SPI_LINES_SINGLE:
+		default:
+			ret = MXC_SPI_SetWidth(regs, SPI_WIDTH_STANDARD);
+			break;
+		}
 
-	if (ret) {
-		return -EINVAL;
+		if (ret) {
+			LOG_ERR("Failed to set data width (%d)", ret);
+			return -EINVAL;
+		}
 	}
 #endif
 
@@ -461,20 +471,25 @@ dma_rtio_exit:
 #endif
 
 #if defined(CONFIG_SPI_MAX32_INTERRUPT)
-	MXC_SPI_SetTXThreshold(cfg->regs, 1 << dfs_shift);
+	MXC_SPI_ClearTXFIFO(cfg->regs);
+	MXC_SPI_ClearRXFIFO(cfg->regs);
+
 	if (data->req.rxLen) {
 		MXC_SPI_SetRXThreshold(cfg->regs, 2 << dfs_shift);
 		MXC_SPI_EnableInt(cfg->regs, ADI_MAX32_SPI_INT_EN_RX_THD);
 	}
-	MXC_SPI_EnableInt(cfg->regs, ADI_MAX32_SPI_INT_EN_TX_THD | ADI_MAX32_SPI_INT_EN_MST_DONE);
 
-	MXC_SPI_ClearTXFIFO(cfg->regs);
-	MXC_SPI_ClearRXFIFO(cfg->regs);
-	if (!data->req.txData) {
-		data->req.txCnt =
-			MXC_SPI_WriteTXFIFO(cfg->regs, data->dummy, MIN(len, sizeof(data->dummy)));
-	} else {
-		data->req.txCnt = MXC_SPI_WriteTXFIFO(cfg->regs, data->req.txData, len);
+	MXC_SPI_EnableInt(cfg->regs, ADI_MAX32_SPI_INT_EN_MST_DONE);
+
+	if (data->req.txLen) {
+		MXC_SPI_SetTXThreshold(cfg->regs, 1 << dfs_shift);
+		MXC_SPI_EnableInt(cfg->regs, ADI_MAX32_SPI_INT_EN_TX_THD);
+		if (!data->req.txData) {
+			data->req.txCnt = MXC_SPI_WriteTXFIFO(cfg->regs, data->dummy,
+							      MIN(len, sizeof(data->dummy)));
+		} else {
+			data->req.txCnt = MXC_SPI_WriteTXFIFO(cfg->regs, data->req.txData, len);
+		}
 	}
 
 	MXC_SPI_StartTransmission(cfg->regs);

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -169,6 +169,17 @@ static int spi_configure(const struct device *dev, const struct spi_config *conf
 	return ret;
 }
 
+#ifdef CONFIG_SPI_MAX32_DMA
+
+static inline bool spi_max32_has_dma_channels(const struct device *dev)
+{
+	const struct max32_spi_config *cfg = dev->config;
+
+	return cfg->tx_dma.channel != 0xFF && cfg->rx_dma.channel != 0xFF;
+}
+
+#endif
+
 static inline int spi_max32_get_dfs_shift(const struct spi_context *ctx)
 {
 	if (SPI_WORD_SIZE_GET(ctx->config->operation) < 9) {
@@ -417,7 +428,7 @@ static int spi_max32_transceive(const struct device *dev)
 #if defined(CONFIG_SPI_MAX32_DMA) && defined(CONFIG_SPI_MAX32_RTIO)
 	struct dma_status status;
 
-	if (cfg->tx_dma.channel != 0xFF && cfg->rx_dma.channel != 0xFF) {
+	if (spi_max32_has_dma_channels(dev)) {
 		MXC_SPI_ClearTXFIFO(cfg->regs);
 		MXC_SPI_ClearRXFIFO(cfg->regs);
 
@@ -1016,9 +1027,7 @@ static int api_transceive(const struct device *dev, const struct spi_config *con
 			  const struct spi_buf_set *tx_bufs, const struct spi_buf_set *rx_bufs)
 {
 #if defined(CONFIG_SPI_MAX32_DMA) && !defined(CONFIG_SPI_MAX32_RTIO)
-	const struct max32_spi_config *cfg = dev->config;
-
-	if (cfg->tx_dma.channel != 0xFF && cfg->rx_dma.channel != 0xFF) {
+	if (spi_max32_has_dma_channels(dev)) {
 		return transceive_dma(dev, config, tx_bufs, rx_bufs, false, NULL, NULL);
 	}
 #endif /* CONFIG_SPI_MAX32_DMA */
@@ -1032,9 +1041,7 @@ static int api_transceive_async(const struct device *dev, const struct spi_confi
 				void *userdata)
 {
 #ifdef CONFIG_SPI_MAX32_DMA
-	const struct max32_spi_config *cfg = dev->config;
-
-	if (cfg->tx_dma.channel != 0xFF && cfg->rx_dma.channel != 0xFF) {
+	if (spi_max32_has_dma_channels(dev)) {
 		return transceive_dma(dev, config, tx_bufs, rx_bufs, true, cb, userdata);
 	}
 #endif /* CONFIG_SPI_MAX32_DMA */

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -98,11 +98,8 @@ static int spi_configure(const struct device *dev, const struct spi_config *conf
 	}
 #endif
 
-	if (SPI_OP_MODE_GET(config->operation) & SPI_OP_MODE_SLAVE) {
-		return -ENOTSUP;
-	}
 
-	int master_mode = 1;
+	int master_mode = !(SPI_OP_MODE_GET(config->operation) & SPI_OP_MODE_SLAVE);
 	int quad_mode = 0;
 	int num_slaves = 1;
 	int ss_polarity = (config->operation & SPI_CS_ACTIVE_HIGH) ? 1 : 0;
@@ -219,6 +216,10 @@ static void spi_cs_assert(const struct device *dev)
 	struct max32_spi_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
 
+	if (spi_context_is_slave(ctx)) {
+		return;
+	}
+
 	if (spi_cs_is_gpio(ctx->config)) {
 		MXC_SPI_HWSSControl(cfg->regs, false);
 		spi_context_cs_control(ctx, true);
@@ -234,6 +235,10 @@ static void spi_cs_deassert(const struct device *dev)
 	const struct max32_spi_config *cfg = dev->config;
 	struct max32_spi_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
+
+	if (spi_context_is_slave(ctx)) {
+		return;
+	}
 
 	if (spi_cs_is_gpio(ctx->config)) {
 		spi_context_cs_control(ctx, false);
@@ -369,14 +374,15 @@ static int spi_max32_transceive(const struct device *dev)
 	}
 #else
 	if ((ctx->config->operation & SPI_HALF_DUPLEX)
+	    || (SPI_OP_MODE_GET(data->ctx.config->operation) & SPI_OP_MODE_SLAVE)
 #if defined(CONFIG_SPI_EXTENDED_MODES)
-		|| (ctx->config->operation & SPI_LINES_DUAL)
-		|| (ctx->config->operation & SPI_LINES_QUAD)
-		|| (ctx->config->operation & SPI_LINES_OCTAL)
+	    || (ctx->config->operation & SPI_LINES_DUAL)
+	    || (ctx->config->operation & SPI_LINES_QUAD)
+	    || (ctx->config->operation & SPI_LINES_OCTAL)
 #endif
 		) {
 		/* Half duplex mode, tx should be set only if no rx */
-		data->req.txLen = ctx->tx_buf ? len : 0;
+		data->req.txLen = ctx->tx_buf ? ctx->tx_len : 0;
 	} else {
 		/* Full duplex mode, tx and rx can be set independently */
 		data->req.txLen = len;
@@ -488,7 +494,8 @@ dma_rtio_exit:
 			data->req.txCnt = MXC_SPI_WriteTXFIFO(cfg->regs, data->dummy,
 							      MIN(len, sizeof(data->dummy)));
 		} else {
-			data->req.txCnt = MXC_SPI_WriteTXFIFO(cfg->regs, data->req.txData, len);
+			data->req.txCnt = MXC_SPI_WriteTXFIFO(cfg->regs,
+							      data->req.txData, data->req.txLen);
 		}
 	}
 
@@ -516,6 +523,13 @@ static int transceive(const struct device *dev, const struct spi_config *config,
 
 #ifndef CONFIG_SPI_MAX32_INTERRUPT
 	if (async) {
+		return -ENOTSUP;
+	}
+#endif
+
+#ifdef CONFIG_SPI_SLAVE
+	if ((SPI_OP_MODE_GET(config->operation) & SPI_OP_MODE_SLAVE) &&
+	    ((tx_bufs && tx_bufs->count > 1) || (rx_bufs && rx_bufs->count > 1))) {
 		return -ENOTSUP;
 	}
 #endif
@@ -585,6 +599,12 @@ static void spi_max32_iodev_complete(const struct device *dev, int status);
 #endif
 
 #ifdef CONFIG_SPI_MAX32_DMA
+
+static inline bool spi_max32_dma_is_half_duplex_op(spi_operation_t operation)
+{
+	return (operation & SPI_HALF_DUPLEX) || (operation & SPI_LINES_MASK) != SPI_LINES_SINGLE;
+}
+
 static void spi_max32_dma_callback(const struct device *dev, void *arg, uint32_t channel,
 				   int status)
 {
@@ -644,7 +664,9 @@ static void spi_max32_dma_callback(const struct device *dev, void *arg, uint32_t
 	uint32_t len;
 	uint8_t dfs = spi_max32_get_dfs_shift(ctx) ? 2 : 1;
 
-	if ((data->dma_stat & SPI_MAX32_DMA_DONE_FLAG) == SPI_MAX32_DMA_DONE_FLAG) {
+	if ((data->dma_stat & SPI_MAX32_DMA_DONE_FLAG) == SPI_MAX32_DMA_DONE_FLAG ||
+	    (spi_max32_dma_is_half_duplex_op(ctx->config->operation) && data->dma_stat) ||
+	    (!ctx->rx_len && (data->dma_stat & SPI_MAX32_DMA_RX_DONE_FLAG))) {
 		len = spi_context_max_continuous_chunk(ctx);
 		spi_context_update_tx(ctx, dfs, len);
 		spi_context_update_rx(ctx, dfs, len);
@@ -682,7 +704,7 @@ static int spi_max32_tx_dma_load(const struct device *dev, const uint8_t *buf, u
 	dma_cfg.dma_slot = config->tx_dma.slot;
 	dma_cfg.block_count = 1;
 	dma_cfg.source_data_size = 1U << dfs_shift;
-	dma_cfg.source_burst_length = 1U << dfs_shift;
+	dma_cfg.source_burst_length = dfs_shift ? 4 : 3;
 	dma_cfg.dest_data_size = 1U << dfs_shift;
 	dma_cfg.head_block = &dma_blk;
 	dma_blk.block_size = len;
@@ -709,14 +731,20 @@ static int spi_max32_tx_dma_setup(const struct device *dev, const uint8_t *buf, 
 	struct max32_spi_data *data = dev->data;
 	mxc_spi_regs_t *spi = cfg->regs;
 
+	data->dma_stat = 0;
+
+	if (!len) {
+		spi->ctrl1 &= ~MXC_F_SPI_CTRL1_TX_NUM_CHAR;
+		spi->dma &= ~MXC_F_SPI_DMA_TX_FIFO_EN;
+		return 0;
+	}
+
 	MXC_SETFIELD(spi->ctrl1, MXC_F_SPI_CTRL1_TX_NUM_CHAR,
 		     word_count << MXC_F_SPI_CTRL1_TX_NUM_CHAR_POS);
 	spi->dma |= ADI_MAX32_SPI_DMA_TX_FIFO_CLEAR;
 	spi->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
 	spi->dma |= ADI_MAX32_SPI_DMA_TX_DMA_EN;
-	MXC_SPI_SetTXThreshold(spi, 2);
-
-	data->dma_stat = 0;
+	MXC_SPI_SetTXThreshold(spi, dfs_shift ? 3 : 2);
 
 	return spi_max32_tx_dma_load(dev, buf, len, dfs_shift);
 }
@@ -759,13 +787,22 @@ static int spi_max32_rx_dma_setup(const struct device *dev, const uint8_t *buf, 
 				  uint32_t word_count, uint8_t dfs_shift)
 {
 	const struct max32_spi_config *cfg = dev->config;
+	struct max32_spi_data *data = dev->data;
 	mxc_spi_regs_t *spi = cfg->regs;
+
+	data->dma_stat = 0;
+
+	if (!len) {
+		spi->ctrl1 &= ~MXC_F_SPI_CTRL1_RX_NUM_CHAR;
+		spi->dma &= ~MXC_F_SPI_DMA_RX_FIFO_EN;
+		return 0;
+	}
 
 	MXC_SETFIELD(spi->ctrl1, MXC_F_SPI_CTRL1_RX_NUM_CHAR,
 		     word_count << MXC_F_SPI_CTRL1_RX_NUM_CHAR_POS);
 	spi->dma |= ADI_MAX32_SPI_DMA_RX_FIFO_CLEAR;
-	spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
 	spi->dma |= ADI_MAX32_SPI_DMA_RX_DMA_EN;
+	spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
 	MXC_SPI_SetRXThreshold(spi, dfs_shift ? 1 : 0);
 
 	return spi_max32_rx_dma_load(dev, buf, len, dfs_shift);
@@ -805,12 +842,16 @@ static int spi_max32_transceive_dma(const struct device *dev)
 		return ret;
 	}
 
-	ret = spi_max32_rx_dma_setup(dev, ctx->rx_buf, len, word_count, dfs_shift);
+	ret = spi_max32_rx_dma_setup(dev, ctx->rx_buf,
+				     (ctx->config->operation & SPI_HALF_DUPLEX) ? ctx->rx_len : len,
+				     word_count, dfs_shift);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = spi_max32_tx_dma_setup(dev, ctx->tx_buf, len, word_count, dfs_shift);
+	ret = spi_max32_tx_dma_setup(dev, ctx->tx_buf,
+				     (ctx->config->operation & SPI_HALF_DUPLEX) ? ctx->tx_len : len,
+				     word_count, dfs_shift);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1027,14 +1068,28 @@ static void spi_max32_callback(mxc_spi_req_t *req, int error)
 	uint8_t dfs;
 
 	dfs = spi_max32_get_dfs_shift(ctx) ? 2 : 1;
-	len = spi_context_max_continuous_chunk(ctx);
-	spi_context_update_tx(ctx, dfs, len);
-	spi_context_update_rx(ctx, dfs, len);
+	if (spi_context_is_slave(ctx)) {
+		if (spi_context_tx_on(ctx)) {
+			spi_context_update_tx(ctx, dfs, data->req.txCnt);
+		}
+
+		if (spi_context_rx_on(ctx)) {
+			spi_context_update_rx(ctx, dfs, data->req.rxCnt);
+		}
+	} else {
+		/* Master connections always assume matching TX/RX */
+		len = spi_context_max_continuous_chunk(ctx);
+		spi_context_update_tx(ctx, dfs, len);
+		spi_context_update_rx(ctx, dfs, len);
+	}
+
 #ifdef CONFIG_SPI_ASYNC
 	if (ctx->asynchronous && ((spi_context_tx_on(ctx) || spi_context_rx_on(ctx)))) {
 		k_work_submit(&data->async_work);
 	} else {
-		spi_cs_deassert(dev);
+		if (!(spi_context_tx_on(ctx) || spi_context_rx_on(ctx))) {
+			spi_cs_deassert(dev);
+		}
 		spi_context_complete(ctx, dev, error == E_NO_ERROR ? 0 : -EIO);
 	}
 #else
@@ -1061,21 +1116,34 @@ void spi_max32_async_work_handler(struct k_work *work)
 static void spi_max32_isr(const struct device *dev)
 {
 	const struct max32_spi_config *cfg = dev->config;
+	struct max32_spi_data *data = dev->data;
 	mxc_spi_regs_t *spi = cfg->regs;
+	mxc_spi_req_t *req = &data->req;
 	uint32_t flags;
 
 	flags = MXC_SPI_GetAndClearFlags(spi);
 
-#if defined(CONFIG_SPI_MAX32_DMA) && defined(CONFIG_SPI_MAX32_RTIO)
-	if (cfg->tx_dma.channel != 0xFF && cfg->rx_dma.channel != 0xFF) {
-		MXC_SPI_DisableInt(spi, ADI_MAX32_SPI_INT_EN_TX_EMPTY);
-		spi_max32_iodev_complete(dev, 0);
+#if defined(CONFIG_SPI_MAX32_DMA)
+	if (spi_max32_has_dma_channels(dev)) {
+#ifdef CONFIG_SPI_MAX32_RTIO
+		struct spi_rtio *rtio_ctx = data->rtio_ctx;
+		struct rtio_sqe *sqe = &rtio_ctx->txn_curr->sqe;
+
+		if ((sqe->op == RTIO_OP_TX || sqe->op == RTIO_OP_TINY_TX) &&
+		    (flags & ADI_MAX32_SPI_INT_FL_MST_DONE)) {
+#else
+		struct spi_context *ctx = &data->ctx;
+
+		if (ctx->tx_len && !ctx->rx_len && (flags & ADI_MAX32_SPI_INT_FL_MST_DONE)) {
+#endif
+			MXC_SPI_DisableInt(spi, ADI_MAX32_SPI_INT_EN_MST_DONE
+						| ADI_MAX32_SPI_INT_EN_TX_EMPTY);
+			spi_max32_callback(req, 0);
+		}
 		return;
 	}
 #endif
 
-	struct max32_spi_data *data = dev->data;
-	mxc_spi_req_t *req = &data->req;
 	uint32_t remain;
 
 	remain = req->txLen - req->txCnt;
@@ -1100,7 +1168,7 @@ static void spi_max32_isr(const struct device *dev)
 		if (remain >= MXC_SPI_FIFO_DEPTH) {
 			MXC_SPI_SetRXThreshold(spi, 2);
 		} else {
-			MXC_SPI_SetRXThreshold(spi, remain);
+			MXC_SPI_SetRXThreshold(spi, remain / 2);
 		}
 	} else {
 		MXC_SPI_DisableInt(spi, ADI_MAX32_SPI_INT_EN_RX_THD);
@@ -1108,8 +1176,9 @@ static void spi_max32_isr(const struct device *dev)
 
 	if ((req->txLen == req->txCnt) && (req->rxLen == req->rxCnt)) {
 		MXC_SPI_DisableInt(spi, ADI_MAX32_SPI_INT_EN_TX_THD | ADI_MAX32_SPI_INT_EN_RX_THD);
-		if (flags & ADI_MAX32_SPI_INT_FL_MST_DONE) {
-			MXC_SPI_DisableInt(spi, ADI_MAX32_SPI_INT_EN_MST_DONE);
+		if (spi_context_is_slave(&data->ctx) || (flags & ADI_MAX32_SPI_INT_FL_MST_DONE)) {
+			MXC_SPI_DisableInt(spi, ADI_MAX32_SPI_INT_EN_MST_DONE
+						| ADI_MAX32_SPI_INT_EN_TX_EMPTY);
 			spi_max32_callback(req, 0);
 		}
 	}

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -1220,6 +1220,7 @@ static int spi_max32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	MXC_SPI_InitState(regs);
 	MXC_SPI_Shutdown(regs);
 
 	ret = clock_control_on(cfg->clock, (clock_control_subsys_t)&cfg->perclk);

--- a/tests/drivers/spi/spi_controller_peripheral/Kconfig
+++ b/tests/drivers/spi/spi_controller_peripheral/Kconfig
@@ -18,4 +18,16 @@ config PREALLOC_BUFFERS
 		Preallocate buffers used for transaction
 		using `memory-region` property.
 
+config SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_STACK_SIZE
+	int "Test workqueue stack size"
+	default 1024
+	help
+	    Stack size for thread used to perform async API checks
+
+config SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_PRIORITY
+	int "Test workqueue priority"
+	default 10
+	help
+	    Priority for the work queue used for async testing
+
 source "Kconfig.zephyr"

--- a/tests/drivers/spi/spi_controller_peripheral/boards/apard32690_max32690_m4.conf
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/apard32690_max32690_m4.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2023-2024 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_MAX32_DMA=y
+CONFIG_SPI_MAX32_INTERRUPT=y

--- a/tests/drivers/spi/spi_controller_peripheral/boards/apard32690_max32690_m4.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/apard32690_max32690_m4.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023-2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Requires the following connections between the Uno(P5) and PMOD(P8) connectors
+ * P1.26 - P1.03 - CLK
+ * P1.28 - P1.02 - MISO
+ * P1.29 - P1.01 - MOSI
+ * P1.23 - P1.00 - CS
+ */
+
+/ {
+	zephyr,user {
+		peripheral-cs = <1>;
+	};
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&arduino_spi {
+	status = "okay";
+	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI1_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI1_RX>;
+	dma-names = "tx", "rx";
+	pinctrl-0 = <&spi1a_miso_p1_28 &spi1a_mosi_p1_29 &spi1a_sck_p1_26>;
+	cs-gpios = <&gpio1 23 (GPIO_ACTIVE_LOW | MAX32_GPIO_VSEL_VDDIOH)>;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+	};
+};
+
+dut_spis: &spi4 {
+	pinctrl-0 = <&spi4a_miso_p1_2 &spi4a_mosi_p1_1 &spi4a_sck_p1_3
+		     &spi4a_ss0_p1_0>;
+	pinctrl-names = "default";
+
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/half-duplex.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/half-duplex.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/spi/spi.h>
+
+&dut_spi_dt {
+	duplex = <SPI_HALF_DUPLEX>;
+};

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -68,6 +68,11 @@ struct test_data {
 
 static struct test_data tdata;
 
+struct k_work_q spim_spis_work_q;
+
+static K_KERNEL_STACK_DEFINE(spim_spis_work_q_stack,
+			CONFIG_SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_STACK_SIZE);
+
 /* Allocate buffer from spim or spis space. */
 static uint8_t *buf_alloc(size_t len, bool spim)
 {
@@ -209,7 +214,7 @@ static void run_test(bool m_same_size, bool s_same_size, bool async)
 	int srx_len;
 
 	tdata.async = async;
-	rv = k_work_schedule(&tdata.test_work, K_MSEC(10));
+	rv = k_work_schedule_for_queue(&spim_spis_work_q, &tdata.test_work, K_MSEC(10));
 	zassert_equal(rv, 1);
 
 	if (!async) {
@@ -543,6 +548,16 @@ static void after(void *not_used)
 
 static void *suite_setup(void)
 {
+	struct k_work_queue_config cfg = {
+		.name = "spim_spis_work",
+		.no_yield = false,
+	};
+
+	k_work_queue_start(&spim_spis_work_q,
+			   spim_spis_work_q_stack,
+			   K_KERNEL_STACK_SIZEOF(spim_spis_work_q_stack),
+			   CONFIG_SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_PRIORITY, &cfg);
+
 	return NULL;
 }
 

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -55,6 +55,7 @@ static uint8_t spis_buffer[32] MEMORY_SECTION(DT_NODELABEL(dut_spis));
 struct test_data {
 	struct k_work_delayable test_work;
 	struct k_sem sem;
+	struct k_sem half_duplex_sem;
 	int spim_alloc_idx;
 	int spis_alloc_idx;
 	struct spi_buf_set sets[4];
@@ -99,7 +100,24 @@ static void work_handler(struct k_work *work)
 	struct test_data *td = CONTAINER_OF(dwork, struct test_data, test_work);
 	int rv;
 
-	if (!td->async) {
+	if (spim.config.operation & SPI_HALF_DUPLEX) {
+		spim.config.operation |= SPI_HOLD_ON_CS;
+
+		rv = spi_write_dt(&spim, td->mtx_set);
+		spim.config.operation &= ~SPI_HOLD_ON_CS;
+		zassert_equal(rv, 0);
+
+		rv = k_sem_take(&td->half_duplex_sem, K_MSEC(1));
+		if (rv) {
+			return;
+		}
+
+		rv = spi_read_dt(&spim, td->mrx_set);
+
+		if (rv == 0) {
+			k_sem_give(&td->sem);
+		}
+	} else if (!td->async) {
 		rv = spi_transceive_dt(&spim, td->mtx_set, td->mrx_set);
 		if (rv == 0) {
 			k_sem_give(&td->sem);
@@ -213,6 +231,11 @@ static void run_test(bool m_same_size, bool s_same_size, bool async)
 	int periph_rv;
 	int srx_len;
 
+	if (spim.config.operation & SPI_HALF_DUPLEX) {
+		ztest_test_skip();
+		return;
+	}
+
 	tdata.async = async;
 	rv = k_work_schedule_for_queue(&spim_spis_work_q, &tdata.test_work, K_MSEC(10));
 	zassert_equal(rv, 1);
@@ -255,6 +278,7 @@ static void run_test(bool m_same_size, bool s_same_size, bool async)
 	zassert_equal(rv, 0);
 
 	rv = check_buffers(tdata.stx_set, tdata.mrx_set, s_same_size);
+	TC_PRINT("stx check same size? %d is %d\n", s_same_size, rv);
 	zassert_equal(rv, 0);
 }
 
@@ -523,6 +547,158 @@ ZTEST(spi_controller_peripheral, test_only_rx_in_chunks_async)
 	test_only_rx_in_chunks(true);
 }
 
+static void run_half_duplex_test(int len)
+{
+	int rv;
+	int periph_rv;
+	struct spi_config spis_half_duplex_config = spis_config;
+
+	if (!(spim.config.operation & SPI_HALF_DUPLEX)) {
+		ztest_test_skip();
+		return;
+	}
+
+	spis_half_duplex_config.operation |= (SPI_HOLD_ON_CS | SPI_HALF_DUPLEX);
+
+	tdata.async = false;
+	rv = k_work_schedule_for_queue(&spim_spis_work_q, &tdata.test_work, K_MSEC(10));
+	zassert_equal(rv, 1);
+
+	periph_rv = spi_read(spis_dev, &spis_half_duplex_config, tdata.srx_set);
+
+	TC_PRINT("Read %d\n", periph_rv);
+
+	if (periph_rv == -ENOTSUP) {
+		ztest_test_skip();
+		return;
+	}
+
+	zassert_equal(periph_rv, len);
+
+	k_sem_give(&tdata.half_duplex_sem);
+
+	TC_PRINT("WRITING!\n");
+
+	periph_rv = spi_write(spis_dev, &spis_half_duplex_config, tdata.stx_set);
+
+	TC_PRINT("Write %d\n", periph_rv);
+
+	if (periph_rv == -ENOTSUP) {
+		ztest_test_skip();
+		return;
+	}
+
+	rv = k_sem_take(&tdata.sem, K_MSEC(100));
+	zassert_equal(rv, 0);
+
+	zassert_equal(periph_rv, 0);
+
+	rv = check_buffers(tdata.mtx_set, tdata.srx_set, true);
+	zassert_equal(rv, 0);
+
+	rv = check_buffers(tdata.stx_set, tdata.mrx_set, true);
+	zassert_equal(rv, 0);
+
+}
+
+ZTEST(spi_controller_peripheral, test_half_duplex)
+{
+	size_t len = 16;
+
+	for (int i = 0; i < 4; i++) {
+		tdata.bufs[i].buf = buf_alloc(len, i < 2);
+		tdata.bufs[i].len = len;
+		tdata.sets[i].buffers = &tdata.bufs[i];
+		tdata.sets[i].count = 1;
+	}
+
+	tdata.mtx_set = &tdata.sets[0];
+	tdata.mrx_set = &tdata.sets[1];
+	tdata.stx_set = &tdata.sets[2];
+	tdata.srx_set = &tdata.sets[3];
+
+	run_half_duplex_test(len);
+}
+
+static void setup_split_buffer(uint8_t len)
+{
+	tdata.bufs[0].buf = buf_alloc(len / 2, true);
+	tdata.bufs[0].len = len / 2;
+	tdata.bufs[1].buf = buf_alloc(len / 2, true);
+	tdata.bufs[1].len = len / 2;
+	tdata.bufs[2].buf = buf_alloc(len, true);
+	tdata.bufs[2].len = len;
+	tdata.bufs[3].buf = buf_alloc(len, false);
+	tdata.bufs[3].len = len;
+	tdata.bufs[4].buf = buf_alloc(len, false);
+	tdata.bufs[4].len = len;
+
+	tdata.sets[0].buffers = &tdata.bufs[0];
+	tdata.sets[0].count = 2;
+
+	for (int i = 1; i < 4; i++) {
+		tdata.sets[i].buffers = &tdata.bufs[i+1];
+		tdata.sets[i].count = 1;
+	}
+}
+
+ZTEST(spi_controller_peripheral, test_half_duplex_split_controller_tx_buffers)
+{
+	size_t len = 16;
+
+	setup_split_buffer(len);
+
+	tdata.mtx_set = &tdata.sets[0];
+	tdata.mrx_set = &tdata.sets[1];
+	tdata.stx_set = &tdata.sets[2];
+	tdata.srx_set = &tdata.sets[3];
+
+	run_half_duplex_test(len);
+}
+
+ZTEST(spi_controller_peripheral, test_half_duplex_split_controller_rx_buffers)
+{
+	size_t len = 16;
+
+	setup_split_buffer(len);
+
+	tdata.mtx_set = &tdata.sets[1];
+	tdata.mrx_set = &tdata.sets[0];
+	tdata.stx_set = &tdata.sets[2];
+	tdata.srx_set = &tdata.sets[3];
+
+	run_half_duplex_test(len);
+}
+
+
+ZTEST(spi_controller_peripheral, test_half_duplex_split_peripheral_tx_buffers)
+{
+	size_t len = 16;
+
+	setup_split_buffer(len);
+
+	tdata.mtx_set = &tdata.sets[1];
+	tdata.mrx_set = &tdata.sets[2];
+	tdata.stx_set = &tdata.sets[0];
+	tdata.srx_set = &tdata.sets[3];
+
+	run_half_duplex_test(len);
+}
+
+ZTEST(spi_controller_peripheral, test_half_duplex_split_peripheral_rx_buffers)
+{
+	size_t len = 16;
+
+	setup_split_buffer(len);
+
+	tdata.mtx_set = &tdata.sets[1];
+	tdata.mrx_set = &tdata.sets[2];
+	tdata.stx_set = &tdata.sets[3];
+	tdata.srx_set = &tdata.sets[0];
+
+	run_half_duplex_test(len);
+}
+
 static void before(void *not_used)
 {
 	ARG_UNUSED(not_used);
@@ -537,6 +713,7 @@ static void before(void *not_used)
 
 	k_work_init_delayable(&tdata.test_work, work_handler);
 	k_sem_init(&tdata.sem, 0, 1);
+	k_sem_init(&tdata.half_duplex_sem, 0, 1);
 }
 
 static void after(void *not_used)

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -81,6 +81,20 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
 
+  drivers.spi.spi_half_duplex:
+    extra_args: EXTRA_DTC_OVERLAY_FILE="half-duplex.overlay"
+    platform_exclude:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+      - nrf54h20dk/nrf54h20/cpuppr
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
+      - ophelia4ev/nrf54l15/cpuapp
+
   drivers.spi.spi_fast:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     platform_exclude:

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -7,6 +7,7 @@ common:
   harness_config:
     fixture: gpio_spi_loopback
   platform_allow:
+    - apard32690/max32690/m4
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
@@ -83,6 +84,7 @@ tests:
   drivers.spi.spi_fast:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     platform_exclude:
+      - apard32690/max32690/m4
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
@@ -100,6 +102,7 @@ tests:
     build_only: true
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_spis.overlay"
     platform_exclude:
+      - apard32690/max32690/m4
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
@@ -127,6 +130,7 @@ tests:
       - CONFIG_POWER_DOMAIN=n
     extra_args: DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_cross_domain.overlay"
     platform_exclude:
+      - apard32690/max32690/m4
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: c8aa8d545635a5821045ab500c70b878bd55f15d
+      revision: 35d874ccfb8fb062ca8bdf096764b8d34c6d608e
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Adding proper half duplex support for various permutations, including DMA, for the MAX32 SPI driver. Additions/changes have been made to the existing `spi_controller_peripheral` test to help validate this work, which by necessity, also means implementing *target* support in the MAX32 SPI driver as well.

Tested several targets, e.g. APARD32690 and the MAX32651EVKIT (by pulling in #104245 locally) with the correct fixture in place, e.g.:

```
west twister --device-testing --west-flash --west-runner jlink --device-serial /dev/tty.usbserial-D30DXZU1 -p max32651evkit/max32651 --timeout-multiplier 5 -T tests/drivers/spi/spi_controller_peripheral -X gpio_spi_loopback --extra-args CONFIG_SOC_FAMILY_MAX32_SECURE_SOC_SIGNING=y --extra-args
CONFIG_SOC_FAMILY_MAX32_SECURE_SOC_KEY_PATH=\"/Users/petejohanson/source/sbt/devices/MAX32651/keys/maximtestcrk.key\"
Renaming previous output directory to /Users/petejohanson/source/upstream-zephyr-workspace/zephyr/twister-out.52
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-3594-g3bc82abcef39
INFO    - Using 'zephyr/gnu' toolchain variant.
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.03 seconds
INFO    - Writing JSON report /Users/petejohanson/source/upstream-zephyr-workspace/zephyr/twister-out/testplan.json

Device testing on:

| Platform               | ID   | Serial device               |
|------------------------|------|-----------------------------|
| max32651evkit/max32651 |      | /dev/tty.usbserial-D30DXZU1 |

INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:   12/  12  100%  built (not run):    0, filtered:    6, failed:    0, error:    0
INFO    - 15 test scenarios (15 configurations) selected, 6 configurations filtered (3 by static filter, 3 at runtime).
INFO    - 9 of 9 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 219.17 seconds.
INFO    - 83 of 83 executed test cases passed (100.00%) on 1 out of total 1533 platforms (0.07%).
INFO    - 88 selected test cases not executed: 88 skipped.
INFO    - 9 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board                  | ID   |   Counter |   Failures |
|------------------------|------|-----------|------------|
| max32651evkit/max32651 |      |         9 |          0 |
INFO    - Saving reports...
INFO    - Writing JSON report /Users/petejohanson/source/upstream-zephyr-workspace/zephyr/twister-out/twister.json
INFO    - Writing xunit report /Users/petejohanson/source/upstream-zephyr-workspace/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /Users/petejohanson/source/upstream-zephyr-workspace/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```