### PR TITLE
syscalls: Add K_OBJ_DRIVER_ANY

### DIFF
--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -78,7 +78,7 @@ static inline bool k_is_in_user_syscall(void)
  *
  * @param ko Kernel object metadata pointer, or NULL
  * @param otype Expected type of the kernel object, or K_OBJ_ANY if type
- *	  doesn't matter
+ *	  doesn't matter, or K_OBJ_DRIVER_ANY for any driver object
  * @param init Indicate whether the object needs to already be in initialized
  *             or uninitialized state, or that we don't care
  * @note This is an internal API. Do not use unless you are extending

--- a/include/zephyr/sys/kobject.h
+++ b/include/zephyr/sys/kobject.h
@@ -25,10 +25,11 @@ struct z_futex_data;
  *
  * This enumeration needs to be kept in sync with the lists of kernel objects
  * and subsystems in scripts/build/gen_kobject_list.py, as well as the otype_to_str()
- * function in kernel/userspace.c
+ * function in kernel/userspace/userspace.c
  */
 enum k_objects {
-	K_OBJ_ANY,
+	K_OBJ_ANY,         /**< Used for matching any object type */
+	K_OBJ_DRIVER_ANY,  /**< Used for matching any driver object type */
 
 	/** @cond
 	 *  Doxygen should ignore this build-time generated include file

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -72,7 +72,7 @@ int z_impl_device_init(const struct device *dev)
 #ifdef CONFIG_USERSPACE
 static inline int z_vrfy_device_init(const struct device *dev)
 {
-	K_OOPS(K_SYSCALL_OBJ_INIT(dev, K_OBJ_ANY));
+	K_OOPS(K_SYSCALL_OBJ_INIT(dev, K_OBJ_DRIVER_ANY));
 
 	return z_impl_device_init(dev);
 }
@@ -115,7 +115,7 @@ static inline const struct device *z_vrfy_device_get_binding(const char *name)
 
 static inline bool z_vrfy_device_is_ready(const struct device *dev)
 {
-	K_OOPS(K_SYSCALL_OBJ_INIT(dev, K_OBJ_ANY));
+	K_OOPS(K_SYSCALL_OBJ_INIT(dev, K_OBJ_DRIVER_ANY));
 
 	return z_impl_device_is_ready(dev);
 }

--- a/kernel/userspace/userspace.c
+++ b/kernel/userspace/userspace.c
@@ -95,6 +95,9 @@ const char *otype_to_str(enum k_objects otype)
 	case K_OBJ_ANY:
 		ret = "generic";
 		break;
+	case K_OBJ_DRIVER_ANY:
+		ret = "generic driver";
+		break;
 #include <zephyr/otype-to-str.h>
 	default:
 		ret = "?";
@@ -854,9 +857,16 @@ void k_object_access_all_grant(const void *object)
 int k_object_validate(struct k_object *ko, enum k_objects otype,
 		       enum _obj_init_check init)
 {
-	if (unlikely((ko == NULL) ||
-		((otype != K_OBJ_ANY) && (ko->type != otype)))) {
+	if (unlikely(ko == NULL)) {
 		return -EBADF;
+	}
+
+	if (unlikely((otype != K_OBJ_ANY) && (otype != ko->type))) {
+		if ((otype != K_OBJ_DRIVER_ANY) ||
+		    (ko->type < K_OBJ_DRIVER_FIRST) ||
+		    (ko->type > K_OBJ_DRIVER_LAST)) {
+			return -EBADF;
+		}
 	}
 
 	/* Manipulation of any kernel objects by a user thread requires that

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -954,6 +954,18 @@ def write_kobj_types_output(fp):
         subsystem = subsystem.replace("_driver_api", "").upper()
         fp.write(f"K_OBJ_DRIVER_{subsystem},\n")
 
+    if subsystems:
+        first = subsystems[0].replace("_driver_api", "").upper()
+        last = subsystems[-1].replace("_driver_api", "").upper()
+        fp.write(f"K_OBJ_DRIVER_FIRST = K_OBJ_DRIVER_{first},\n")
+        fp.write(f"K_OBJ_DRIVER_LAST = K_OBJ_DRIVER_{last},\n")
+    else:
+        # There will always be core kernel objects. In the unlikely event
+        # there are no driver subsystems, order the first and last driver
+        # entries to values that will indicate an empty set (first > last).
+        fp.write("K_OBJ_DRIVER_LAST,\n")
+        fp.write("K_OBJ_DRIVER_FIRST,\n")
+
 
 def write_kobj_otype_output(fp):
     fp.write("/* Core kernel objects */\n")


### PR DESCRIPTION
Adds a new generic kernel object type--K_OBJ_DRIVER_ANY. This is used to validate that the specified object is a known driver type. Being more restrictive than K_OBJ_ANY, it allows for better error checking in both z_vrfy_device_init() and z_vrfy_device_is_ready().