### PR TITLE
drivers: haptics: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/haptics/cs40l5x.h
+++ b/include/zephyr/drivers/haptics/cs40l5x.h
@@ -126,8 +126,9 @@ enum cs40l5x_trigger_edge {
  *
  * @param[in] dev Pointer to the device structure for haptic device instance
  *
- * @retval 0 if success
- * @retval <0 if failed
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EAGAIN ReDC or F0 estimation timed out.
+ * @retval -EIO A control port transaction failed.
  */
 int cs40l5x_calibrate(const struct device *const dev);
 
@@ -142,8 +143,8 @@ int cs40l5x_calibrate(const struct device *const dev);
  * @param[in] level Amplitude of haptic effect, where UINT8_MAX is 100% (default: 0x1B)
  * @param[in] duration Playback duration in milliseconds, where 0 is indefinite (default: 0x32)
  *
- * @retval 0 if success
- * @retval <0 if failed
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EIO A control port transaction failed.
  */
 int cs40l5x_configure_buzz(const struct device *const dev, const uint32_t frequency,
 			   const uint8_t level, const uint32_t duration);
@@ -158,8 +159,9 @@ int cs40l5x_configure_buzz(const struct device *const dev, const uint32_t freque
  * @param[in] attenuation Attenuation in dB for desired haptic effect, see @ref cs40l5x_attenuation
  * @param[in] edge Specify edge (rising or falling) to trigger haptic effects
  *
- * @retval 0 if success
- * @retval <0 if failed
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Invalid wavetable source and index provided (e.g., index out of bounds).
+ * @retval -EIO A control port transaction failed.
  */
 int cs40l5x_configure_trigger(const struct device *const dev, const struct gpio_dt_spec *const gpio,
 			      const enum cs40l5x_bank bank, const uint8_t index,
@@ -172,8 +174,10 @@ int cs40l5x_configure_trigger(const struct device *const dev, const struct gpio_
  * @param[in] dev Pointer to the device structure for haptic device instance
  * @param[in] logger_state See @ref cs40l5x_logger
  *
- * @retval 0 if success
- * @retval <0 if failed
+ * @retval 1 Logging is enabled.
+ * @retval 0 Logging is disabled.
+ * @retval -EINVAL Invalid wavetable source or trigger GPIO provided.
+ * @retval -EIO A control port transaction failed.
  */
 int cs40l5x_logger(const struct device *const dev, enum cs40l5x_logger logger_state);
 
@@ -185,8 +189,8 @@ int cs40l5x_logger(const struct device *const dev, enum cs40l5x_logger logger_st
  * @param[in] type See @ref cs40l5x_logger_source_type
  * @param[out] value Unsigned 32-bit integer to store the retrieved data
  *
- * @retval 0 if success
- * @retval <0 if failed
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EIO A control port transaction failed.
  */
 int cs40l5x_logger_get(const struct device *const dev, enum cs40l5x_logger_source source,
 		       enum cs40l5x_logger_source_type type, uint32_t *const value);
@@ -198,8 +202,8 @@ int cs40l5x_logger_get(const struct device *const dev, enum cs40l5x_logger_sourc
  * @param[in] bank Wavetable source for desired haptic effect, see @ref cs40l5x_bank
  * @param[in] index Wavetable index for desired haptic effect
  *
- * @retval 0 if success
- * @retval <0 if failed
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Invalid wavetable source and index provided (e.g., index out of bounds).
  */
 int cs40l5x_select_output(const struct device *const dev, const enum cs40l5x_bank bank,
 			  const uint8_t index);
@@ -210,8 +214,9 @@ int cs40l5x_select_output(const struct device *const dev, const enum cs40l5x_ban
  * @param[in] dev Pointer to the device structure for haptic device instance
  * @param[in] gain Gain setting (valid values between 0 and 100)
  *
- * @retval 0 if success
- * @retval <0 if failed
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Provided gain is greater than 100%.
+ * @retval -EIO A control port transaction failed.
  */
 int cs40l5x_set_gain(const struct device *const dev, const uint8_t gain);
 
@@ -225,8 +230,9 @@ int cs40l5x_set_gain(const struct device *const dev, const uint8_t gain);
  * @param[in] samples Array of signed 8-bit PCM samples
  * @param[in] num_samples Number of PCM samples
  *
- * @retval 0 if success
- * @retval <0 if failed
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Invalid index provided (e.g., index out of bounds).
+ * @retval -EIO A control port transaction failed.
  */
 int cs40l5x_upload_pcm(const struct device *const dev, const enum cs40l5x_custom_index index,
 		       const uint16_t redc, const uint16_t f0, const int8_t *const samples,
@@ -240,8 +246,9 @@ int cs40l5x_upload_pcm(const struct device *const dev, const enum cs40l5x_custom
  * @param[in] sections Array of @ref cs40l5x_pwle_section
  * @param[in] num_sections Number of PWLE sections
  *
- * @retval 0 if success
- * @retval <0 if failed
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Invalid index provided (e.g., index out of bounds).
+ * @retval -EIO A control port transaction failed.
  */
 int cs40l5x_upload_pwle(const struct device *const dev, const enum cs40l5x_custom_index index,
 			const struct cs40l5x_pwle_section *const sections,


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974