### PR TITLE
samples: shell: exclude rx arch on robot test

### DIFF
--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -74,6 +74,8 @@ tests:
     harness: robot
     arch_exclude:
       - xtensa
+    platform_exclude:
+      - qemu_rx/r5f562n8
     extra_configs:
       - arch:posix:CONFIG_UART_NATIVE_PTY_0_ON_STDINOUT=y
     harness_config:

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -1044,7 +1044,6 @@ class TestPlan:
                     robot_targets = [
                         'renode',
                         'native',
-                        'qemu'
                     ]
                     if ts.harness == 'robot' and not (sim and sim.name in robot_targets):
                         instance.add_filter(


### PR DESCRIPTION
Exclude rx for now as it seems to get stuck in CI and never recovers,
slowing things down considerably.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
