### PR TITLE
ci: Set Twister job timeout to 2 hours

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         subset: [1, 2]
+    timeout-minutes: 120
     env:
       CCACHE_DIR: /node-cache/ccache-zephyr
       CCACHE_REMOTE_STORAGE: "redis://cache-*.keydb-cache.svc.cluster.local|shards=1,2,3"

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -133,7 +133,7 @@ jobs:
       fail-fast: false
       matrix:
         subset: ${{fromJSON(needs.twister-build-prep.outputs.subset)}}
-    timeout-minutes: 1440
+    timeout-minutes: ${{ github.event_name == 'schedule' && 1440 || 120 }}
     env:
       CCACHE_DIR: /node-cache/ccache-zephyr
       CCACHE_REMOTE_STORAGE: "redis://cache-*.keydb-cache.svc.cluster.local|shards=1,2,3"


### PR DESCRIPTION
Set the non-weekly GNU and LLVM Twister workflow individual job timeouts to 2 hours in order to keep the CI run time sane.

If a single job run time exceeds 2 hours, the workflow test strategy ought to be fixed.