### PR TITLE
kernel: timeout: subsystem-level handler-completion synchronization

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2130,6 +2130,28 @@ static inline void *z_impl_k_timer_user_data_get(const struct k_timer *timer)
 	return timer->user_data;
 }
 
+/**
+ * @brief Clean up a dynamically allocated timer before freeing it.
+ *
+ * If a k_timer object is dynamically allocated, its timeout must be
+ * cancelled and any in-flight expiration handler must complete before
+ * the storage may be freed -- otherwise the handler dereferences freed
+ * memory. This function performs both: it removes the timer from the
+ * timeout queue and waits for any in-flight handler on another CPU to
+ * finish.
+ *
+ * Unlike k_timer_stop(), this function does not invoke the user
+ * stop_fn callback and does not touch the wait queue: if the
+ * function returns 0 the caller assumes responsibility for the
+ * storage and there is no other consumer of the timer left.
+ *
+ * @param timer Address of the timer.
+ * @retval 0 on success.
+ * @retval -EAGAIN when threads are still pending on the timer's
+ *         wait queue (e.g. via k_timer_status_sync()).
+ */
+int k_timer_cleanup(struct k_timer *timer);
+
 /** @} */
 
 /**

--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -1948,6 +1948,19 @@
  */
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)
 
+/**
+ * @brief Trace Timer cleanup attempt entry
+ * @param timer Timer object
+ */
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+
+/**
+ * @brief Trace Timer cleanup outcome
+ * @param timer Timer object
+ * @param ret Return value
+ */
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
+
 /** @} */ /* end of subsys_tracing_apis_timer */
 
 /**

--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/toolchain.h>
 #include <ksched.h>
+#include <scheduler.h>
 #include <wait_q.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/init.h>
@@ -46,13 +47,8 @@ int z_impl_k_condvar_signal(struct k_condvar *condvar)
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_condvar, signal, condvar);
 
-	struct k_thread *thread = z_unpend_first_thread(&condvar->wait_q);
-
-	if (unlikely(thread != NULL)) {
+	if (z_sched_wake(&condvar->wait_q, 0, NULL)) {
 		SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_condvar, signal, condvar, K_FOREVER);
-
-		arch_thread_return_value_set(thread, 0);
-		z_ready_thread(thread);
 		z_reschedule(&lock, key);
 	} else {
 		k_spin_unlock(&lock, key);
@@ -74,7 +70,6 @@ int z_vrfy_k_condvar_signal(struct k_condvar *condvar)
 
 int z_impl_k_condvar_broadcast(struct k_condvar *condvar)
 {
-	struct k_thread *pending_thread;
 	k_spinlock_key_t key;
 	int woken = 0;
 
@@ -83,11 +78,8 @@ int z_impl_k_condvar_broadcast(struct k_condvar *condvar)
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_condvar, broadcast, condvar);
 
 	/* wake up any threads that are waiting to write */
-	for (pending_thread = z_unpend_first_thread(&condvar->wait_q); pending_thread != NULL;
-		 pending_thread = z_unpend_first_thread(&condvar->wait_q)) {
+	while (z_sched_wake(&condvar->wait_q, 0, NULL)) {
 		woken++;
-		arch_thread_return_value_set(pending_thread, 0);
-		z_ready_thread(pending_thread);
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_condvar, broadcast, condvar, woken);

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -156,7 +156,7 @@ static int event_walk_op(struct k_thread *thread, void *data)
 		if (thread->event_options & K_EVENT_OPTION_CLEAR) {
 			event_data->clear_events |= match;
 		}
-		z_abort_thread_timeout(thread);
+		(void)z_try_abort_thread_timeout(thread);
 
 #ifndef CONFIG_WAITQ_SCALABLE
 		/*

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -238,26 +238,35 @@ static inline void unpend_thread_no_timeout(struct k_thread *thread)
 }
 
 /*
- * In a multiprocessor system, z_unpend_first_thread() must lock the scheduler
- * spinlock _sched_spinlock. However, in a uniprocessor system, that is not
- * necessary as the caller has already taken precautions (in the form of
- * locking interrupts).
+ * Pick the best-priority waiter from @p wait_q, unpend it, and abort any
+ * timeout it had pending. Returns the thread, or NULL if the wait_q was
+ * empty.
+ *
+ * Caller MUST hold _sched_spinlock and MUST complete the wake (set return
+ * value, ready the thread) under the same lock acquisition before releasing
+ * it. Otherwise a racing in-flight timeout handler can ready the thread
+ * before the caller's wake state is in place, exposing the woken thread
+ * to a stale swap_retval. The pre-1b8c7a3 dticks-cancel check used to
+ * close this window; doing all the wake work atomically under the sched
+ * lock is now the way.
+ *
+ * z_sched_wake() is the convenient wrapper for the common case of
+ * "wake one waiter with this retval and this swap_data".
  */
-static ALWAYS_INLINE struct k_thread *z_unpend_first_thread(_wait_q_t *wait_q)
+static ALWAYS_INLINE struct k_thread *z_unpend_first_thread_locked(_wait_q_t *wait_q)
 {
-	struct k_thread *thread = NULL;
+	struct k_thread *thread = _priq_wait_best(&wait_q->waitq);
 
-	__ASSERT_EVAL(, int key = arch_irq_lock(); arch_irq_unlock(key),
-		      !arch_irq_unlocked(key), "");
-
-	LOCK_SCHED_SPINLOCK {
-		thread = _priq_wait_best(&wait_q->waitq);
-		if (unlikely(thread != NULL)) {
-			unpend_thread_no_timeout(thread);
-			z_abort_thread_timeout(thread);
-		}
+	if (unlikely(thread != NULL)) {
+		unpend_thread_no_timeout(thread);
+		/* A racing in-flight handler will be blocked on the sched
+		 * lock for the duration of the caller's locked region; when
+		 * it eventually runs, the thread is already unpended and
+		 * (depending on caller flow) readied, so the handler's
+		 * z_sched_wake_thread_locked() path is a no-op.
+		 */
+		(void)z_try_abort_thread_timeout(thread);
 	}
-
 	return thread;
 }
 

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -259,11 +259,11 @@ static ALWAYS_INLINE struct k_thread *z_unpend_first_thread_locked(_wait_q_t *wa
 
 	if (unlikely(thread != NULL)) {
 		unpend_thread_no_timeout(thread);
-		/* A racing in-flight handler will be blocked on the sched
-		 * lock for the duration of the caller's locked region; when
-		 * it eventually runs, the thread is already unpended and
-		 * (depending on caller flow) readied, so the handler's
-		 * z_sched_wake_thread_locked() path is a no-op.
+		/* Abort the thread's timeout. If its handler is in flight on
+		 * another CPU it is blocked on the sched lock; the abort flags
+		 * it superseded, and z_thread_timeout() bails on that flag when
+		 * it finally runs -- so it won't wake the thread from whatever
+		 * it has since re-pended on. We don't wait for it here.
 		 */
 		(void)z_try_abort_thread_timeout(thread);
 	}

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -25,9 +25,6 @@ extern "C" {
 /* Value written to dticks when timeout is aborted. */
 #define TIMEOUT_DTICKS_ABORTED (IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? INT64_MIN : INT32_MIN)
 
-/* Value written to dticks when timeout is being announced (handler pending). */
-#define TIMEOUT_DTICKS_ANNOUNCING (TIMEOUT_DTICKS_ABORTED + 1)
-
 static inline void z_init_timeout(struct _timeout *to)
 {
 	sys_dnode_init(&to->node);
@@ -40,12 +37,10 @@ static inline void z_init_timeout(struct _timeout *to)
  */
 k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout);
 
-int z_abort_timeout(struct _timeout *to);
-
-/* Attempt to abort a timeout. Unlike z_abort_timeout(), this is safe to use
- * for callers that need to be certain the handler is not in flight (e.g. when
- * about to free the timeout's storage), as long as the caller is prepared to
- * drop any locks the handler may need and retry.
+/* Attempt to abort a timeout. Safe to use for callers that need to be
+ * certain the handler is not in flight (e.g. when about to free the
+ * timeout's storage), as long as the caller is prepared to drop any
+ * locks the handler may need and retry.
  *
  * Returns:
  *   0       — the timeout was active and has been removed from the queue.
@@ -69,24 +64,6 @@ int z_try_abort_timeout(struct _timeout *to);
  * taking their own lock, and bail if it returns true.
  */
 bool z_timeout_inflight_superseded(const struct _timeout *to);
-
-/* Determine if the timeout handler should continue.
- *
- * The routine sys_clock_announce() both removes the timeout from the timeout
- * list and unlocks interrupts prior to invoking the timeout handler. This
- * provides a small gap where another ISR (or thread on another CPU) could
- * do something that would cause the timeout handler to be canceled (e.g.
- * restarting a k_timer). This routine allows the timeout handler to check if
- * it should continue or if it should just return immediately. It assumes that
- * the handler has already locked interrupts / relevant spinlocks.
- *
- * Testing if the timeout node is linked is insufficient as the timeout node
- * could have been reused.
- */
-static inline bool z_is_timeout_handler_canceled(const struct _timeout *to)
-{
-	return (to->dticks != TIMEOUT_DTICKS_ANNOUNCING);
-}
 
 static inline bool z_is_inactive_timeout(const struct _timeout *to)
 {

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -116,6 +116,11 @@ static inline void z_abort_thread_timeout(struct k_thread *thread)
 	z_abort_timeout(&thread->base.timeout);
 }
 
+static inline int z_try_abort_thread_timeout(struct k_thread *thread)
+{
+	return z_try_abort_timeout(&thread->base.timeout);
+}
+
 static inline bool z_is_aborted_thread_timeout(struct k_thread *thread)
 {
 
@@ -131,6 +136,7 @@ k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 /* Stubs when !CONFIG_SYS_CLOCK_EXISTS */
 #define z_init_thread_timeout(thread_base) do {} while (false)
 #define z_abort_thread_timeout(to) do {} while (false)
+#define z_try_abort_thread_timeout(to) 0
 #define z_is_aborted_thread_timeout(to) false
 #define z_is_inactive_timeout(to) 1
 #define z_is_aborted_timeout(to) false

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -111,11 +111,6 @@ static inline k_ticks_t z_add_thread_timeout(struct k_thread *thread, k_timeout_
 	return z_add_timeout(&thread->base.timeout, z_thread_timeout, ticks);
 }
 
-static inline void z_abort_thread_timeout(struct k_thread *thread)
-{
-	z_abort_timeout(&thread->base.timeout);
-}
-
 static inline int z_try_abort_thread_timeout(struct k_thread *thread)
 {
 	return z_try_abort_timeout(&thread->base.timeout);
@@ -135,7 +130,6 @@ k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 
 /* Stubs when !CONFIG_SYS_CLOCK_EXISTS */
 #define z_init_thread_timeout(thread_base) do {} while (false)
-#define z_abort_thread_timeout(to) do {} while (false)
 #define z_try_abort_thread_timeout(to) 0
 #define z_is_aborted_thread_timeout(to) false
 #define z_is_inactive_timeout(to) 1

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -22,9 +22,6 @@ extern "C" {
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 
-/* Value written to dticks when timeout is aborted. */
-#define TIMEOUT_DTICKS_ABORTED (IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? INT64_MIN : INT32_MIN)
-
 static inline void z_init_timeout(struct _timeout *to)
 {
 	sys_dnode_init(&to->node);
@@ -70,12 +67,6 @@ static inline bool z_is_inactive_timeout(const struct _timeout *to)
 	return !sys_dnode_is_linked(&to->node);
 }
 
-static inline bool z_is_aborted_timeout(const struct _timeout *to)
-{
-	/* When timeout is aborted then dticks is set to special value. */
-	return to->dticks == TIMEOUT_DTICKS_ABORTED;
-}
-
 static inline void z_init_thread_timeout(struct _thread_base *thread_base)
 {
 	z_init_timeout(&thread_base->timeout);
@@ -93,12 +84,6 @@ static inline int z_try_abort_thread_timeout(struct k_thread *thread)
 	return z_try_abort_timeout(&thread->base.timeout);
 }
 
-static inline bool z_is_aborted_thread_timeout(struct k_thread *thread)
-{
-
-	return z_is_aborted_timeout(&thread->base.timeout);
-}
-
 int32_t z_get_next_timeout_expiry(void);
 
 k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
@@ -108,9 +93,7 @@ k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 /* Stubs when !CONFIG_SYS_CLOCK_EXISTS */
 #define z_init_thread_timeout(thread_base) do {} while (false)
 #define z_try_abort_thread_timeout(to) 0
-#define z_is_aborted_thread_timeout(to) false
 #define z_is_inactive_timeout(to) 1
-#define z_is_aborted_timeout(to) false
 #define z_get_next_timeout_expiry() ((int32_t) K_TICKS_FOREVER)
 #define z_set_timeout_expiry(ticks, is_idle) do {} while (false)
 

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -51,8 +51,9 @@ int z_abort_timeout(struct _timeout *to);
  *   0       — the timeout was active and has been removed from the queue.
  *   -EINVAL — the timeout was not active (never linked, already done, or
  *             a same-CPU IRQ aborted while the handler was paused on this
- *             CPU; the latter is best-effort, the handler will resume and
- *             fire).
+ *             CPU; in that case the in-flight slot is marked superseded
+ *             so handlers that need to bail may check via
+ *             z_timeout_inflight_superseded()).
  *   -EAGAIN — the handler is currently in flight on another CPU. The caller
  *             must drop any lock that the handler may need and retry. A short
  *             arch_spin_relax() has already been done before this return.
@@ -61,6 +62,13 @@ int z_abort_timeout(struct _timeout *to);
  * After a non-EAGAIN return, the handler is guaranteed not to be in flight.
  */
 int z_try_abort_timeout(struct _timeout *to);
+
+/* True if @to is the currently in-flight timeout and a same-CPU aborter
+ * has marked the slot as superseded. Handlers with non-idempotent side
+ * effects (e.g. k_timer's expiry_fn) should call this at entry, after
+ * taking their own lock, and bail if it returns true.
+ */
+bool z_timeout_inflight_superseded(const struct _timeout *to);
 
 /* Determine if the timeout handler should continue.
  *

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -42,6 +42,26 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 
 int z_abort_timeout(struct _timeout *to);
 
+/* Attempt to abort a timeout. Unlike z_abort_timeout(), this is safe to use
+ * for callers that need to be certain the handler is not in flight (e.g. when
+ * about to free the timeout's storage), as long as the caller is prepared to
+ * drop any locks the handler may need and retry.
+ *
+ * Returns:
+ *   0       — the timeout was active and has been removed from the queue.
+ *   -EINVAL — the timeout was not active (never linked, already done, or
+ *             a same-CPU IRQ aborted while the handler was paused on this
+ *             CPU; the latter is best-effort, the handler will resume and
+ *             fire).
+ *   -EAGAIN — the handler is currently in flight on another CPU. The caller
+ *             must drop any lock that the handler may need and retry. A short
+ *             arch_spin_relax() has already been done before this return.
+ *
+ * On -EAGAIN, the only correct response is to drop outer locks and call again.
+ * After a non-EAGAIN return, the handler is guaranteed not to be in flight.
+ */
+int z_try_abort_timeout(struct _timeout *to);
+
 /* Determine if the timeout handler should continue.
  *
  * The routine sys_clock_announce() both removes the timeout from the timeout

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -16,6 +16,7 @@
 #include <string.h>
 /* private kernel APIs */
 #include <ksched.h>
+#include <scheduler.h>
 #include <wait_q.h>
 
 #ifdef CONFIG_OBJ_CORE_MEM_SLAB
@@ -293,13 +294,8 @@ void k_mem_slab_free(struct k_mem_slab *slab, void *mem)
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_mem_slab, free, slab);
 	if (unlikely(slab->free_list == NULL) && IS_ENABLED(CONFIG_MULTITHREADING)) {
-		struct k_thread *pending_thread = z_unpend_first_thread(&slab->wait_q);
-
-		if (unlikely(pending_thread != NULL)) {
+		if (z_sched_wake(&slab->wait_q, 0, mem)) {
 			SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mem_slab, free, slab);
-
-			z_thread_return_value_set_with_data(pending_thread, 0, mem);
-			z_ready_thread(pending_thread);
 			z_reschedule(&slab->lock, key);
 			return;
 		}

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -16,6 +16,7 @@
 #include <zephyr/linker/sections.h>
 #include <string.h>
 #include <ksched.h>
+#include <scheduler.h>
 #include <wait_q.h>
 #include <zephyr/sys/dlist.h>
 #include <zephyr/sys/math_extras.h>
@@ -131,7 +132,7 @@ static inline int put_msg_in_queue(struct k_msgq *msgq, const void *data,
 {
 	__ASSERT(!arch_is_in_isr() || K_TIMEOUT_EQ(timeout, K_NO_WAIT), "");
 
-	struct k_thread *pending_thread;
+	struct k_thread *pending_thread = NULL;
 	k_spinlock_key_t key;
 	int result;
 	bool resched = false;
@@ -145,17 +146,24 @@ static inline int put_msg_in_queue(struct k_msgq *msgq, const void *data,
 	}
 
 	if (msgq->used_msgs < msgq->max_msgs) {
-		/* message queue isn't full */
-		pending_thread = z_unpend_first_thread(&msgq->wait_q);
-		if (unlikely(pending_thread != NULL)) {
-			resched = true;
-
-			/* give message to waiting thread */
-			(void)memcpy(pending_thread->base.swap_data, data, msgq->msg_size);
-			/* wake up waiting thread */
-			arch_thread_return_value_set(pending_thread, 0);
-			z_ready_thread(pending_thread);
-		} else {
+		/* message queue isn't full. Try to hand the message
+		 * directly to the longest-waiting receiver, atomically
+		 * under _sched_spinlock so a racing in-flight timeout
+		 * handler cannot wake the receiver before the message
+		 * has been copied into its buffer.
+		 */
+		LOCK_SCHED_SPINLOCK {
+			pending_thread = z_unpend_first_thread_locked(&msgq->wait_q);
+			if (pending_thread != NULL) {
+				/* copy into the receiver's buffer */
+				(void)memcpy(pending_thread->base.swap_data, data,
+					     msgq->msg_size);
+				arch_thread_return_value_set(pending_thread, 0);
+				z_sched_ready_locked(pending_thread);
+				resched = true;
+			}
+		}
+		if (pending_thread == NULL) {
 			__ASSERT_NO_MSG((msgq->write_ptr >= msgq->buffer_start) &&
 					(msgq->write_ptr <= (msgq->buffer_end - 1)) &&
 					((size_t)(uintptr_t)(msgq->buffer_end - msgq->write_ptr) >=
@@ -298,28 +306,36 @@ int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 		}
 		msgq->used_msgs--;
 
-		/* handle first thread waiting to write (if any) */
-		pending_thread = z_unpend_first_thread(&msgq->wait_q);
-		if (unlikely(pending_thread != NULL)) {
-			SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_msgq, get, msgq, timeout);
+		/* sanity-check write_ptr in case we hand the slot to a sender */
+		__ASSERT_NO_MSG((msgq->write_ptr >= msgq->buffer_start) &&
+				(msgq->write_ptr <= (msgq->buffer_end - 1)) &&
+				((size_t)(uintptr_t)(msgq->buffer_end - msgq->write_ptr) >=
+					msgq->msg_size));
 
-			/* add thread's message to queue */
-			__ASSERT_NO_MSG((msgq->write_ptr >= msgq->buffer_start) &&
-					(msgq->write_ptr <= (msgq->buffer_end - 1)) &&
-					((size_t)(uintptr_t)(msgq->buffer_end - msgq->write_ptr) >=
-						msgq->msg_size));
-			(void)memcpy(msgq->write_ptr, (char *)pending_thread->base.swap_data,
-			       msgq->msg_size);
-			msgq->write_ptr += msgq->msg_size;
-			if (msgq->write_ptr == msgq->buffer_end) {
-				msgq->write_ptr = msgq->buffer_start;
+		/* handle first thread waiting to write (if any).
+		 * Done atomically under _sched_spinlock so we read the
+		 * sender's swap_data and complete the wake before any
+		 * racing in-flight timeout handler can wake the sender.
+		 */
+		LOCK_SCHED_SPINLOCK {
+			pending_thread = z_unpend_first_thread_locked(&msgq->wait_q);
+			if (pending_thread != NULL) {
+				SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_msgq, get, msgq, timeout);
+
+				/* add the sender's pending message to the queue */
+				(void)memcpy(msgq->write_ptr,
+					     (char *)pending_thread->base.swap_data,
+					     msgq->msg_size);
+				msgq->write_ptr += msgq->msg_size;
+				if (msgq->write_ptr == msgq->buffer_end) {
+					msgq->write_ptr = msgq->buffer_start;
+				}
+				msgq->used_msgs++;
+
+				arch_thread_return_value_set(pending_thread, 0);
+				z_sched_ready_locked(pending_thread);
+				resched = true;
 			}
-			msgq->used_msgs++;
-
-			/* wake up waiting thread */
-			arch_thread_return_value_set(pending_thread, 0);
-			z_ready_thread(pending_thread);
-			resched = true;
 		}
 		result = 0;
 	} else if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
@@ -442,7 +458,6 @@ static inline int z_vrfy_k_msgq_peek_at(struct k_msgq *msgq, void *data, uint32_
 void z_impl_k_msgq_purge(struct k_msgq *msgq)
 {
 	k_spinlock_key_t key;
-	struct k_thread *pending_thread;
 	bool resched = false;
 
 	key = k_spin_lock(&msgq->lock);
@@ -450,11 +465,7 @@ void z_impl_k_msgq_purge(struct k_msgq *msgq)
 	SYS_PORT_TRACING_OBJ_FUNC(k_msgq, purge, msgq);
 
 	/* wake up any threads that are waiting to write */
-	for (pending_thread = z_unpend_first_thread(&msgq->wait_q);
-	     pending_thread != NULL;
-	     pending_thread = z_unpend_first_thread(&msgq->wait_q)) {
-		arch_thread_return_value_set(pending_thread, -ENOMSG);
-		z_ready_thread(pending_thread);
+	while (z_sched_wake(&msgq->wait_q, -ENOMSG, NULL)) {
 		resched = true;
 	}
 

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -29,6 +29,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/toolchain.h>
 #include <ksched.h>
+#include <scheduler.h>
 #include <kthread.h>
 #include <wait_q.h>
 #include <errno.h>
@@ -228,7 +229,7 @@ static inline int z_vrfy_k_mutex_lock(struct k_mutex *mutex,
 
 int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 {
-	struct k_thread *new_owner;
+	struct k_thread *new_owner = NULL;
 
 	__ASSERT(!arch_is_in_isr(), "mutexes cannot be used inside ISRs");
 
@@ -273,28 +274,36 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 	adjust_owner_prio(mutex, mutex->owner_orig_prio);
 #endif
 
-	/* Get the new owner, if any */
-	new_owner = z_unpend_first_thread(&mutex->wait_q);
+	/* Pick the new owner (if any) and complete the wake atomically
+	 * under _sched_spinlock, so a racing in-flight timeout handler
+	 * cannot observe a half-initialized wake-up.
+	 */
+	LOCK_SCHED_SPINLOCK {
+		new_owner = z_unpend_first_thread_locked(&mutex->wait_q);
+		mutex->owner = new_owner;
 
-	mutex->owner = new_owner;
+		LOG_DBG("new owner of mutex %p: %p (prio: %d)",
+			mutex, new_owner, new_owner ? new_owner->base.prio : -1000);
 
-	LOG_DBG("new owner of mutex %p: %p (prio: %d)",
-		mutex, new_owner, new_owner ? new_owner->base.prio : -1000);
+		if (unlikely(new_owner != NULL)) {
+			/*
+			 * new owner is already of higher or equal prio than first
+			 * waiter since the wait queue is priority-based: no need to
+			 * adjust its priority
+			 */
+#if (CONFIG_PRIORITY_CEILING < K_LOWEST_THREAD_PRIO)
+			mutex->owner_orig_prio = new_owner->base.prio;
+#endif
+			arch_thread_return_value_set(new_owner, 0);
+			z_sched_ready_locked(new_owner);
+		} else {
+			mutex->lock_count = 0U;
+		}
+	}
 
 	if (unlikely(new_owner != NULL)) {
-		/*
-		 * new owner is already of higher or equal prio than first
-		 * waiter since the wait queue is priority-based: no need to
-		 * adjust its priority
-		 */
-#if (CONFIG_PRIORITY_CEILING < K_LOWEST_THREAD_PRIO)
-		mutex->owner_orig_prio = new_owner->base.prio;
-#endif
-		arch_thread_return_value_set(new_owner, 0);
-		z_ready_thread(new_owner);
 		z_reschedule(&lock, key);
 	} else {
-		mutex->lock_count = 0U;
 		k_spin_unlock(&lock, key);
 	}
 

--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -131,18 +131,18 @@ static size_t copy_to_pending_readers(struct k_pipe *pipe, bool *need_resched,
 			} else {
 				/*
 				 * This reader has received all the data
-				 * it was waiting for: wake it up with
-				 * the scheduler lock still held.
+				 * it was waiting for. Set its return
+				 * value, unpend, abort its timeout, and
+				 * ready it, all under the scheduler lock
+				 * so a racing timeout handler cannot
+				 * observe a half-initialized wake-up.
 				 */
+				z_thread_return_value_set_with_data(reader, 0, NULL);
 				unpend_thread_no_timeout(reader);
-				z_abort_thread_timeout(reader);
+				(void)z_try_abort_thread_timeout(reader);
+				z_sched_ready_locked(reader);
+				*need_resched = true;
 			}
-		}
-		if (reader != NULL) {
-			/* rest of thread wake-up outside the scheduler lock */
-			z_thread_return_value_set_with_data(reader, 0, NULL);
-			z_ready_thread(reader);
-			*need_resched = true;
 		}
 	} while (reader != NULL && written < len);
 

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -599,19 +599,18 @@ extern int z_work_submit_to_queue(struct k_work_q *queue,
 
 static void triggered_work_expiration_handler(struct _timeout *timeout)
 {
+	struct k_work_poll *twork =
+		CONTAINER_OF(timeout, struct k_work_poll, timeout);
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	if (z_is_timeout_handler_canceled(timeout)) {
-		/*
-		 * The timeout was canceled by a thread on another CPU
-		 * or another ISR. Bail.
+	if (!twork->poller.is_polling) {
+		/* signal_triggered_work() or triggered_work_cancel() has
+		 * already claimed this wake under the same lock; nothing
+		 * for us to do.
 		 */
 		k_spin_unlock(&lock, key);
 		return;
 	}
-
-	struct k_work_poll *twork =
-		CONTAINER_OF(timeout, struct k_work_poll, timeout);
 
 	twork->poller.is_polling = false;
 	twork->poll_result = -EAGAIN;
@@ -629,7 +628,11 @@ static int signal_triggered_work(struct k_poll_event *event, uint32_t status)
 	if (poller->is_polling && twork->workq != NULL) {
 		struct k_work_q *work_q = twork->workq;
 
-		z_abort_timeout(&twork->timeout);
+		/* Claim the wake before aborting so a racing in-flight
+		 * handler observes is_polling=false and bails.
+		 */
+		poller->is_polling = false;
+		(void)z_try_abort_timeout(&twork->timeout);
 		twork->poll_result = 0;
 		z_work_submit_to_queue(work_q, &twork->work);
 	}
@@ -642,8 +645,22 @@ static int triggered_work_cancel(struct k_work_poll *work,
 {
 	/* Check if the work waits for event. */
 	if (work->poller.is_polling && work->poller.mode != MODE_NONE) {
-		/* Remove timeout associated with the work. */
-		z_abort_timeout(&work->timeout);
+		/* Claim the wake before aborting so a racing in-flight
+		 * handler observes is_polling=false and bails.
+		 */
+		work->poller.is_polling = false;
+		/* Then wait for any in-flight handler to actually complete
+		 * before we proceed. This is needed both so the caller may
+		 * safely free `work` (the handler still has a pending
+		 * dereference of work->poller.is_polling) and so that
+		 * k_work_poll_submit_to_queue() may safely re-arm the same
+		 * `work` for a new poll without the old handler eventually
+		 * acting on the new setup.
+		 */
+		while (z_try_abort_timeout(&work->timeout) == -EAGAIN) {
+			k_spin_unlock(&lock, key);
+			key = k_spin_lock(&lock);
+		}
 
 		/*
 		 * Prevent work execution if event arrives while we will be

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -16,6 +16,7 @@
 #include <zephyr/toolchain.h>
 #include <wait_q.h>
 #include <ksched.h>
+#include <scheduler.h>
 #include <zephyr/init.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <kernel_internal.h>
@@ -78,12 +79,6 @@ static inline void z_vrfy_k_queue_init(struct k_queue *queue)
 #include <zephyr/syscalls/k_queue_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-static void prepare_thread_to_run(struct k_thread *thread, void *data)
-{
-	z_thread_return_value_set_with_data(thread, 0, data);
-	z_ready_thread(thread);
-}
-
 static inline bool handle_poll_events(struct k_queue *queue, uint32_t state)
 {
 #ifdef CONFIG_POLL
@@ -101,14 +96,10 @@ void z_impl_k_queue_cancel_wait(struct k_queue *queue)
 	SYS_PORT_TRACING_OBJ_FUNC(k_queue, cancel_wait, queue);
 
 	k_spinlock_key_t key = k_spin_lock(&queue->lock);
-	struct k_thread *first_pending_thread;
 	bool resched = false;
 
-	first_pending_thread = z_unpend_first_thread(&queue->wait_q);
-
-	if (first_pending_thread != NULL) {
+	if (z_sched_wake(&queue->wait_q, 0, NULL)) {
 		resched = true;
-		prepare_thread_to_run(first_pending_thread, NULL);
 	}
 
 	resched = handle_poll_events(queue, K_POLL_STATE_CANCELLED) || resched;
@@ -137,7 +128,6 @@ static inline void z_vrfy_k_queue_cancel_wait(struct k_queue *queue)
 static int32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 			    bool alloc, bool is_append, k_spinlock_key_t key)
 {
-	struct k_thread *first_pending_thread;
 	int32_t result = 0;
 	bool resched = false;
 
@@ -146,12 +136,9 @@ static int32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 	if (is_append) {
 		prev = sys_sflist_peek_tail(&queue->data_q);
 	}
-	first_pending_thread = z_unpend_first_thread(&queue->wait_q);
 
-	if (unlikely(first_pending_thread != NULL)) {
+	if (z_sched_wake(&queue->wait_q, 0, data)) {
 		SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_queue, queue_insert, queue, alloc, K_FOREVER);
-
-		prepare_thread_to_run(first_pending_thread, data);
 		resched = true;
 		goto out;
 	}
@@ -274,17 +261,10 @@ int k_queue_append_list(struct k_queue *queue, void *head, void *tail)
 	}
 
 	k_spinlock_key_t key = k_spin_lock(&queue->lock);
-	struct k_thread *thread = NULL;
 
-	if (head != NULL) {
-		thread = z_unpend_first_thread(&queue->wait_q);
-	}
-
-	while ((head != NULL) && (thread != NULL)) {
+	while ((head != NULL) && z_sched_wake(&queue->wait_q, 0, head)) {
 		resched = true;
-		prepare_thread_to_run(thread, head);
 		head = *(void **)head;
-		thread = z_unpend_first_thread(&queue->wait_q);
 	}
 
 	if (head != NULL) {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -40,7 +40,8 @@ struct k_spinlock _sched_spinlock;
 __incoherent struct k_thread _thread_dummy;
 
 static ALWAYS_INLINE void update_cache(int preempt_ok);
-static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state);
+static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state,
+				      k_spinlock_key_t *key);
 static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q);
 
 /* Clear the halting bits (_THREAD_ABORTING and _THREAD_SUSPENDING) */
@@ -56,8 +57,13 @@ static ALWAYS_INLINE struct k_thread *next_up(void)
 {
 #ifdef CONFIG_SMP
 	if (z_is_thread_halting(_current)) {
+		/* NULL key: scheduler context, no retry possible. _current
+		 * cannot have an in-flight timeout (a running thread's
+		 * timeout already fired and its handler returned), so the
+		 * abort inside halt_thread won't see -EAGAIN.
+		 */
 		halt_thread(_current, z_is_thread_aborting(_current) ?
-				      _THREAD_DEAD : _THREAD_SUSPENDED);
+				      _THREAD_DEAD : _THREAD_SUSPENDED, NULL);
 	}
 #endif /* CONFIG_SMP */
 
@@ -263,7 +269,8 @@ static void thread_halt_spin(struct k_thread *thread, k_spinlock_key_t key)
 {
 	if (z_is_thread_halting(_current)) {
 		halt_thread(_current,
-			    z_is_thread_aborting(_current) ? _THREAD_DEAD : _THREAD_SUSPENDED);
+			    z_is_thread_aborting(_current) ? _THREAD_DEAD : _THREAD_SUSPENDED,
+			    &key);
 	}
 	k_spin_unlock(&_sched_spinlock, key);
 	while (z_is_thread_halting(thread)) {
@@ -315,8 +322,22 @@ void z_thread_halt(struct k_thread *thread, k_spinlock_key_t key,
 			add_to_waitq_locked(_current, wq);
 			z_swap(&_sched_spinlock, key);
 		}
+		/* The target's next_up self-halt path passed NULL to
+		 * halt_thread() and could not retry on -EAGAIN; an
+		 * in-flight handler on a third CPU may not have run yet
+		 * (it is blocked on _sched_spinlock and will only acquire
+		 * it after we drop it via the swap/spin above). Wait now,
+		 * outside any lock, before the caller may free the thread
+		 * storage. The handler, when it runs, sees _THREAD_DEAD /
+		 * _THREAD_SUSPENDED and either bails (killed check) or
+		 * no-ops in ready_thread() (z_is_thread_ready() rejects
+		 * suspended threads). After this loop returns, no further
+		 * dereference of thread->base will occur.
+		 */
+		while (z_try_abort_thread_timeout(thread) == -EAGAIN) {
+		}
 	} else {
-		halt_thread(thread, terminate ? _THREAD_DEAD : _THREAD_SUSPENDED);
+		halt_thread(thread, terminate ? _THREAD_DEAD : _THREAD_SUSPENDED, &key);
 		if ((thread == _current) && !arch_is_in_isr()) {
 			if (z_is_thread_essential(thread)) {
 				k_spin_unlock(&_sched_spinlock, key);
@@ -467,6 +488,13 @@ void z_thread_timeout(struct _timeout *timeout)
 		/*
 		 * The timeout handler was canceled by a thread on another
 		 * CPU or another ISR. Bail.
+		 *
+		 * NOTE: this cancel-check remains while migration to the
+		 * z_try_abort_timeout() pattern is in progress. Sites that
+		 * still call z_abort_thread_timeout() (sem.c, mutex.c, ...
+		 * via z_unpend_first_thread()) rely on it. It will be
+		 * removed in a follow-up commit once those callers have
+		 * been migrated.
 		 */
 		k_spin_unlock(&_sched_spinlock, key);
 		return;
@@ -519,12 +547,16 @@ struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q)
 
 void z_unpend_thread(struct k_thread *thread)
 {
-	K_SPINLOCK(&_sched_spinlock) {
-		if (thread->base.pended_on != NULL) {
-			unpend_thread_no_timeout(thread);
-		}
-		z_abort_thread_timeout(thread);
+	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+
+	if (thread->base.pended_on != NULL) {
+		unpend_thread_no_timeout(thread);
 	}
+	while (z_try_abort_thread_timeout(thread) == -EAGAIN) {
+		k_spin_unlock(&_sched_spinlock, key);
+		key = k_spin_lock(&_sched_spinlock);
+	}
+	k_spin_unlock(&_sched_spinlock, key);
 }
 
 /* Priority set utility that does no rescheduling, it just changes the
@@ -741,27 +773,24 @@ void *z_get_next_switch_handle(void *interrupted)
 }
 #endif /* CONFIG_USE_SWITCH */
 
-int z_unpend_all_locked(_wait_q_t *wait_q)
+int z_unpend_all(_wait_q_t *wait_q)
 {
 	int need_sched = 0;
 	struct k_thread *thread;
-
-	__ASSERT(z_spin_is_locked(&_sched_spinlock), "sched lock not held");
+	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
 
 	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
 		unpend_thread_no_timeout(thread);
-		z_abort_thread_timeout(thread);
-		ready_thread(thread);
+		/* On -EAGAIN the handler is in flight on another CPU; it is
+		 * blocked on _sched_spinlock and will ready the thread itself
+		 * once we drop the lock. The thread is already unpended, so
+		 * the handler's wake path is harmless.
+		 */
+		if (z_try_abort_thread_timeout(thread) != -EAGAIN) {
+			ready_thread(thread);
+		}
 		need_sched = 1;
 	}
-
-	return need_sched;
-}
-
-int z_unpend_all(_wait_q_t *wait_q)
-{
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
-	int need_sched = z_unpend_all_locked(wait_q);
 
 	k_spin_unlock(&_sched_spinlock, key);
 	return need_sched;
@@ -773,9 +802,14 @@ static inline void unpend_all(_wait_q_t *wait_q)
 
 	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
 		unpend_thread_no_timeout(thread);
-		z_abort_thread_timeout(thread);
 		arch_thread_return_value_set(thread, 0);
-		ready_thread(thread);
+		/* See z_unpend_all() for the -EAGAIN rationale. The return
+		 * value is set above, so an in-flight handler that later
+		 * readies this thread does not overwrite it.
+		 */
+		if (z_try_abort_thread_timeout(thread) != -EAGAIN) {
+			ready_thread(thread);
+		}
 	}
 }
 
@@ -791,7 +825,8 @@ extern void thread_abort_hook(struct k_thread *thread);
  * @param thread Identify the thread to halt
  * @param new_state New thread state (_THREAD_DEAD or _THREAD_SUSPENDED)
  */
-static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state)
+static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state,
+				      k_spinlock_key_t *key)
 {
 	bool dummify = false;
 
@@ -808,7 +843,29 @@ static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state
 			if (thread->base.pended_on != NULL) {
 				unpend_thread_no_timeout(thread);
 			}
-			z_abort_thread_timeout(thread);
+			/* Wait for any in-flight handler to complete before
+			 * we proceed: the caller may free this thread's
+			 * storage (dynamic threads), and an in-flight handler
+			 * would UAF when it eventually runs z_thread_timeout()
+			 * and dereferences thread->base. _THREAD_DEAD is
+			 * already set, so once the handler runs it bails via
+			 * z_sched_wake_thread_locked()'s killed check.
+			 *
+			 * NULL key is the next_up() self-halt path on a
+			 * running _current that has no linked timeout; there
+			 * is nothing to do here. That path is always reached
+			 * via z_thread_halt()'s IF branch, which spins on
+			 * z_try_abort_thread_timeout(thread) outside any lock
+			 * after the halt-queue wait completes, closing any
+			 * remaining in-flight window before the caller of
+			 * z_thread_halt() returns.
+			 */
+			if (key != NULL) {
+				while (z_try_abort_thread_timeout(thread) == -EAGAIN) {
+					k_spin_unlock(&_sched_spinlock, *key);
+					*key = k_spin_lock(&_sched_spinlock);
+				}
+			}
 			unpend_all(&thread->join_queue);
 
 			/* Edge case: aborting _current from within an

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -482,29 +482,21 @@ void z_sched_wake_thread_locked(struct k_thread *thread)
 /* Timeout handler for *_thread_timeout() APIs */
 void z_thread_timeout(struct _timeout *timeout)
 {
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
-
-	if (z_is_timeout_handler_canceled(timeout)) {
-		/*
-		 * The timeout handler was canceled by a thread on another
-		 * CPU or another ISR. Bail.
-		 *
-		 * NOTE: this cancel-check remains while migration to the
-		 * z_try_abort_timeout() pattern is in progress. Sites that
-		 * still call z_abort_thread_timeout() (sem.c, mutex.c, ...
-		 * via z_unpend_first_thread()) rely on it. It will be
-		 * removed in a follow-up commit once those callers have
-		 * been migrated.
-		 */
-		k_spin_unlock(&_sched_spinlock, key);
-		return;
-	}
-
 	struct k_thread *thread = CONTAINER_OF(timeout,
 					       struct k_thread, base.timeout);
 
-	z_sched_wake_thread_locked(thread);
-	k_spin_unlock(&_sched_spinlock, key);
+	K_SPINLOCK(&_sched_spinlock) {
+		/* A concurrent waker (e.g. a sem give on another CPU) may
+		 * have unpended and readied the thread, after which the
+		 * thread could run and re-pend elsewhere -- possibly with no
+		 * timeout. Such a waker aborts this timeout, flagging it
+		 * superseded; bail so we don't wake the thread from its new
+		 * wait.
+		 */
+		if (!z_timeout_inflight_superseded(timeout)) {
+			z_sched_wake_thread_locked(thread);
+		}
+	}
 }
 #endif /* CONFIG_SYS_CLOCK_EXISTS */
 

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -131,14 +131,11 @@ bool z_sched_wake(_wait_q_t *wait_q, int swap_retval, void *swap_data)
 	bool ret = false;
 
 	K_SPINLOCK(&_sched_spinlock) {
-		thread = _priq_wait_best(&wait_q->waitq);
-
+		thread = z_unpend_first_thread_locked(wait_q);
 		if (thread != NULL) {
 			z_thread_return_value_set_with_data(thread,
 							    swap_retval,
 							    swap_data);
-			unpend_thread_no_timeout(thread);
-			(void)z_try_abort_thread_timeout(thread);
 			z_sched_ready_locked(thread);
 			ret = true;
 		}

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -138,7 +138,7 @@ bool z_sched_wake(_wait_q_t *wait_q, int swap_retval, void *swap_data)
 							    swap_retval,
 							    swap_data);
 			unpend_thread_no_timeout(thread);
-			z_abort_thread_timeout(thread);
+			(void)z_try_abort_thread_timeout(thread);
 			z_sched_ready_locked(thread);
 			ret = true;
 		}

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -23,6 +23,7 @@
 #include <wait_q.h>
 #include <zephyr/sys/dlist.h>
 #include <ksched.h>
+#include <scheduler.h>
 #include <zephyr/init.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/tracing/tracing.h>
@@ -94,16 +95,11 @@ static inline bool handle_poll_events(struct k_sem *sem)
 void z_impl_k_sem_give(struct k_sem *sem)
 {
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	struct k_thread *thread;
 	bool resched;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_sem, give, sem);
 
-	thread = z_unpend_first_thread(&sem->wait_q);
-
-	if (unlikely(thread != NULL)) {
-		arch_thread_return_value_set(thread, 0);
-		z_ready_thread(thread);
+	if (z_sched_wake(&sem->wait_q, 0, NULL)) {
 		resched = true;
 	} else {
 		sem->count += (sem->count != sem->limit) ? 1U : 0U;
@@ -164,18 +160,11 @@ out:
 
 void z_impl_k_sem_reset(struct k_sem *sem)
 {
-	struct k_thread *thread;
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	bool resched = false;
 
-	while (true) {
-		thread = z_unpend_first_thread(&sem->wait_q);
-		if (thread == NULL) {
-			break;
-		}
+	while (z_sched_wake(&sem->wait_q, -EAGAIN, NULL)) {
 		resched = true;
-		arch_thread_return_value_set(thread, -EAGAIN);
-		z_ready_thread(thread);
 	}
 	sem->count = 0;
 

--- a/kernel/sleep.c
+++ b/kernel/sleep.c
@@ -68,11 +68,10 @@ static int32_t z_tick_sleep(k_timeout_t timeout)
 
 	(void)z_swap(&_sched_spinlock, key);
 
-	if (!z_is_aborted_thread_timeout(_current)) {
-		return 0;
-	}
-
-	/* We require a 32 bit unsigned subtraction to handle a wraparound */
+	/* We require a 32 bit unsigned subtraction to handle a wraparound.
+	 * A normal timeout-driven wakeup leaves zero (or a slightly negative)
+	 * remainder; only an early k_wakeup() yields a positive value.
+	 */
 	uint32_t left_ticks = expected_wakeup_ticks - sys_clock_tick_get_32();
 
 	/* Use signed comparison so past-due wakeups (negative remainder) return 0.

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -13,6 +13,7 @@
 
 #include <zephyr/toolchain.h>
 #include <ksched.h>
+#include <scheduler.h>
 #include <wait_q.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/init.h>
@@ -99,7 +100,6 @@ int k_stack_cleanup(struct k_stack *stack)
 
 int z_impl_k_stack_push(struct k_stack *stack, stack_data_t data)
 {
-	struct k_thread *first_pending_thread;
 	int ret = 0;
 	k_spinlock_key_t key = k_spin_lock(&stack->lock);
 
@@ -110,13 +110,7 @@ int z_impl_k_stack_push(struct k_stack *stack, stack_data_t data)
 		goto out;
 	}
 
-	first_pending_thread = z_unpend_first_thread(&stack->wait_q);
-
-	if (unlikely(first_pending_thread != NULL)) {
-		z_thread_return_value_set_with_data(first_pending_thread,
-						   0, (void *)data);
-
-		z_ready_thread(first_pending_thread);
+	if (z_sched_wake(&stack->wait_q, 0, (void *)data)) {
 		z_reschedule(&stack->lock, key);
 		goto end;
 	} else {

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1482,7 +1482,7 @@ void z_impl_k_wakeup(k_tid_t thread)
 	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
 
 	if (z_is_thread_sleeping(thread)) {
-		z_abort_thread_timeout(thread);
+		(void)z_try_abort_thread_timeout(thread);
 		z_mark_thread_as_not_sleeping(thread);
 		z_sched_ready_locked(thread);
 		z_reschedule(&_sched_spinlock, key);

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -212,28 +212,6 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 	return ticks;
 }
 
-int z_abort_timeout(struct _timeout *to)
-{
-	int ret = -EINVAL;
-
-	K_SPINLOCK(&timeout_lock) {
-		if (sys_dnode_is_linked(&to->node)) {
-			bool is_first = (to == first());
-
-			remove_timeout(to);
-			to->dticks = TIMEOUT_DTICKS_ABORTED;
-			ret = 0;
-			if (is_first) {
-				sys_clock_set_timeout(next_timeout(elapsed()), false);
-			}
-		} else if (to->dticks == TIMEOUT_DTICKS_ANNOUNCING) {
-			to->dticks = TIMEOUT_DTICKS_ABORTED;
-		}
-	}
-
-	return ret;
-}
-
 int z_try_abort_timeout(struct _timeout *to)
 {
 	int ret = -EINVAL;
@@ -378,7 +356,6 @@ void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
 		announce_remaining -= t->dticks;
 
 		sys_dlist_remove(&t->node);
-		t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
 		inflight_timeout = t;
 
 		k_spin_unlock(&timeout_lock, key);

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -48,6 +48,13 @@ static inline bool any_cpu_announcing(void)
 	return announcing_cpu != -1;
 }
 
+/* Timeout whose handler is currently being dispatched, or NULL when no
+ * handler is in flight. Set by the announcing CPU under timeout_lock
+ * before the handler is called, cleared after the handler returns.
+ * Only the announcing CPU writes this; other CPUs read it.
+ */
+static struct _timeout *inflight_timeout;
+
 static struct _timeout *first(void)
 {
 	sys_dnode_t *t = sys_dlist_peek_head(&timeout_list);
@@ -213,6 +220,39 @@ int z_abort_timeout(struct _timeout *to)
 	return ret;
 }
 
+int z_try_abort_timeout(struct _timeout *to)
+{
+	int ret = -EINVAL;
+
+	K_SPINLOCK(&timeout_lock) {
+		if (sys_dnode_is_linked(&to->node)) {
+			bool is_first = (to == first());
+
+			remove_timeout(to);
+			to->dticks = TIMEOUT_DTICKS_ABORTED;
+			ret = 0;
+			if (is_first) {
+				sys_clock_set_timeout(next_timeout(elapsed()), false);
+			}
+		} else if (inflight_timeout == to) {
+			if (this_cpu_announcing()) {
+				/* Same-CPU IRQ on this CPU's announce gap:
+				 * can't wait; best-effort mark ABORTED.
+				 */
+				to->dticks = TIMEOUT_DTICKS_ABORTED;
+			} else if (IS_ENABLED(CONFIG_SMP)) {
+				ret = -EAGAIN;
+			}
+		}
+	}
+
+	if (ret == -EAGAIN) {
+		arch_spin_relax();
+	}
+
+	return ret;
+}
+
 /* must be locked */
 static k_ticks_t timeout_rem(const struct _timeout *timeout)
 {
@@ -307,10 +347,12 @@ void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
 
 		sys_dlist_remove(&t->node);
 		t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
+		inflight_timeout = t;
 
 		k_spin_unlock(&timeout_lock, key);
 		handler(t);
 		key = k_spin_lock(&timeout_lock);
+		inflight_timeout = NULL;
 	}
 
 	if (t != NULL) {

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -49,11 +49,25 @@ static inline bool any_cpu_announcing(void)
 }
 
 /* Timeout whose handler is currently being dispatched, or NULL when no
- * handler is in flight. Set by the announcing CPU under timeout_lock
- * before the handler is called, cleared after the handler returns.
- * Only the announcing CPU writes this; other CPUs read it.
+ * handler is in flight. The announcing CPU sets the pointer before
+ * calling the handler and clears it afterwards; any aborter may set the
+ * low "superseded" bit (struct _timeout is pointer-aligned so bit 0 is
+ * free). Accessors below mask the bit.
  */
 static struct _timeout *inflight_timeout;
+
+#define INFLIGHT_SUPERSEDED_BIT 1UL
+
+static inline struct _timeout *inflight_ptr(void)
+{
+	return (struct _timeout *)((uintptr_t)inflight_timeout & ~INFLIGHT_SUPERSEDED_BIT);
+}
+
+static inline void inflight_mark_superseded(void)
+{
+	inflight_timeout = (struct _timeout *)((uintptr_t)inflight_timeout |
+					       INFLIGHT_SUPERSEDED_BIT);
+}
 
 static struct _timeout *first(void)
 {
@@ -234,15 +248,21 @@ int z_try_abort_timeout(struct _timeout *to)
 			if (is_first) {
 				sys_clock_set_timeout(next_timeout(elapsed()), false);
 			}
-		} else if (inflight_timeout == to) {
-			if (this_cpu_announcing()) {
-				/* Same-CPU IRQ on this CPU's announce gap:
-				 * can't wait; best-effort mark ABORTED.
-				 */
-				to->dticks = TIMEOUT_DTICKS_ABORTED;
-			} else if (IS_ENABLED(CONFIG_SMP)) {
-				ret = -EAGAIN;
-			}
+		} else if (IS_ENABLED(CONFIG_SMP) && inflight_ptr() == to &&
+			   !this_cpu_announcing()) {
+			/* Handler in flight on another CPU. Free-safety
+			 * callers retry on -EAGAIN to wait it out; others
+			 * rely on the superseded mark below and don't.
+			 */
+			ret = -EAGAIN;
+		}
+
+		/* Record that the in-flight timeout has been aborted, so a
+		 * handler that checks (z_timeout_inflight_superseded) can
+		 * tell its dispatch was overtaken.
+		 */
+		if (inflight_ptr() == to) {
+			inflight_mark_superseded();
 		}
 	}
 
@@ -251,6 +271,18 @@ int z_try_abort_timeout(struct _timeout *to)
 	}
 
 	return ret;
+}
+
+bool z_timeout_inflight_superseded(const struct _timeout *to)
+{
+	bool superseded = false;
+
+	K_SPINLOCK(&timeout_lock) {
+		superseded = inflight_timeout ==
+			     (struct _timeout *)((uintptr_t)to | INFLIGHT_SUPERSEDED_BIT);
+	}
+
+	return superseded;
 }
 
 /* must be locked */

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -221,7 +221,6 @@ int z_try_abort_timeout(struct _timeout *to)
 			bool is_first = (to == first());
 
 			remove_timeout(to);
-			to->dticks = TIMEOUT_DTICKS_ABORTED;
 			ret = 0;
 			if (is_first) {
 				sys_clock_set_timeout(next_timeout(elapsed()), false);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/internal/syscall_handler.h>
+#include <zephyr/sys/check.h>
 #include <stdbool.h>
 #include <zephyr/spinlock.h>
 #include <ksched.h>
@@ -151,6 +152,57 @@ void z_timer_expiration_handler(struct _timeout *t)
 	k_spin_unlock(&lock, key);
 
 	z_ready_thread(thread);
+}
+
+
+int k_timer_cleanup(struct k_timer *timer)
+{
+	/* Not callable from an ISR: this is the one timer path that can
+	 * spin waiting for an in-flight handler, and an ISR spinning here
+	 * could starve the very CPU the handler needs to make progress.
+	 */
+	__ASSERT(!arch_is_in_isr(), "");
+
+	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, cleanup, timer);
+
+	k_spinlock_key_t key;
+
+	/* Refuse if anyone is still pending on the timer's wait queue
+	 * (e.g. via k_timer_status_sync()): freeing the storage would
+	 * leave dangling pended_on pointers.
+	 */
+retry:
+	key = k_spin_lock(&lock);
+
+	CHECKIF(z_waitq_head(&timer->wait_q) != NULL) {
+		k_spin_unlock(&lock, key);
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, -EAGAIN);
+		return -EAGAIN;
+	}
+
+	/* Cancel the timeout AND wait for any in-flight expiration
+	 * handler on another CPU to complete before returning. Unlike
+	 * k_timer_stop(), we do not call any user stop_fn here: the
+	 * caller is about to free the storage and there is no further
+	 * consumer of the timer.
+	 *
+	 * This is the one timer path that waits on the handler (it must,
+	 * before the storage is freed). The wait can only stall if the
+	 * handler itself blocks on this CPU making progress -- e.g. an
+	 * expiry_fn that aborts a thread running here. Freeing a timer
+	 * whose handler does that is a caller bug; ordinary stop/start do
+	 * not wait and so cannot stall.
+	 */
+	if (z_try_abort_timeout(&timer->timeout) == -EAGAIN) {
+		k_spin_unlock(&lock, key);
+		goto retry;
+	}
+
+	k_spin_unlock(&lock, key);
+
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, 0);
+
+	return 0;
 }
 
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -74,7 +74,16 @@ void z_timer_expiration_handler(struct _timeout *t)
 	struct k_thread *thread;
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	if (z_is_timeout_handler_canceled(t)) {
+	/* A same-CPU IRQ may have raced with our dispatch between
+	 * sys_clock_announce() popping us off the list and us taking
+	 * timer.c::lock. Two cases:
+	 *  - The timer was restarted (z_add_timeout re-linked the node):
+	 *    sys_dnode_is_linked() is true, the new schedule fires later.
+	 *  - The timer was stopped (z_try_abort_timeout marked the
+	 *    in-flight slot superseded): bail without firing expiry_fn.
+	 */
+	if (sys_dnode_is_linked(&t->node) ||
+	    z_timeout_inflight_superseded(t)) {
 		k_spin_unlock(&lock, key);
 		return;
 	}
@@ -178,24 +187,25 @@ void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,
 {
 	SYS_PORT_TRACING_OBJ_FUNC(k_timer, start, timer, duration, period);
 
-	/* Acquire spinlock to ensure safety during concurrent calls to
-	 * k_timer_start for scheduling or rescheduling. This is necessary
-	 * since k_timer_start can be preempted, especially for the same
-	 * timer instance.
-	 */
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
 	if (K_TIMEOUT_EQ(duration, K_FOREVER)) {
-		k_spin_unlock(&lock, key);
 		return;
 	}
 
-	(void)z_abort_timeout(&timer->timeout);
+	/* Hold the timer lock across abort + add to serialize against a
+	 * concurrent k_timer_start on the same timer. An in-flight handler
+	 * (z_try_abort_timeout() returning non-zero) is flagged superseded
+	 * and will bail; the re-arm below also re-links the node, which
+	 * makes a not-yet-committed handler bail too. Either way we do not
+	 * wait for it.
+	 */
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	(void)z_try_abort_timeout(&timer->timeout);
+
 	timer->period = period;
 	timer->status = 0U;
 
-	z_add_timeout(&timer->timeout, z_timer_expiration_handler,
-		     duration);
+	z_add_timeout(&timer->timeout, z_timer_expiration_handler, duration);
 
 	z_timer_observer_on_start(timer, duration, period);
 
@@ -219,9 +229,12 @@ void z_impl_k_timer_stop(struct k_timer *timer)
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	bool inactive = (z_abort_timeout(&timer->timeout) != 0);
-
-	if (inactive) {
+	if (z_try_abort_timeout(&timer->timeout) != 0) {
+		/* Not removed from the queue: either the timer was not
+		 * active, or its handler is in flight. In the latter case
+		 * z_try_abort_timeout() has flagged it superseded so the
+		 * handler bails; we do not wait for it. Nothing to stop here.
+		 */
 		k_spin_unlock(&lock, key);
 		return;
 	}

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -78,7 +78,11 @@ void z_time_slice_reset(struct k_thread *thread)
 	int cpu = _current_cpu->id;
 	int slice_size = z_time_slice_size(thread);
 
-	z_abort_timeout(&slice_timeouts[cpu]);
+	/* Best-effort cancel: if the slice timeout is already in flight,
+	 * its handler only flips slice_expired[cpu] (which we clear below)
+	 * and possibly raises an IPI -- harmless either way.
+	 */
+	(void)z_try_abort_timeout(&slice_timeouts[cpu]);
 	if (slice_size != 0) {
 		/* When invoked because the slicer just fired (this CPU or
 		 * via IPI from another), we're at a tick edge but past the

--- a/kernel/userspace/futex.c
+++ b/kernel/userspace/futex.c
@@ -10,6 +10,7 @@
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/init.h>
 #include <ksched.h>
+#include <scheduler.h>
 
 static struct z_futex_data *k_futex_find_data(struct k_futex *futex)
 {
@@ -27,7 +28,6 @@ int z_impl_k_futex_wake(struct k_futex *futex, bool wake_all)
 {
 	k_spinlock_key_t key;
 	unsigned int woken = 0U;
-	struct k_thread *thread;
 	struct z_futex_data *futex_data;
 
 	futex_data = k_futex_find_data(futex);
@@ -38,13 +38,11 @@ int z_impl_k_futex_wake(struct k_futex *futex, bool wake_all)
 	key = k_spin_lock(&futex_data->lock);
 
 	do {
-		thread = z_unpend_first_thread(&futex_data->wait_q);
-		if (thread != NULL) {
-			woken++;
-			arch_thread_return_value_set(thread, 0);
-			z_ready_thread(thread);
+		if (!z_sched_wake(&futex_data->wait_q, 0, NULL)) {
+			break;
 		}
-	} while (thread && wake_all);
+		woken++;
+	} while (wake_all);
 
 	if (woken == 0) {
 		k_spin_unlock(&futex_data->lock, key);

--- a/kernel/userspace/userspace.c
+++ b/kernel/userspace/userspace.c
@@ -677,6 +677,16 @@ static void unref_check(struct k_object *ko, uintptr_t index)
 	case K_OBJ_STACK:
 		k_stack_cleanup((struct k_stack *)ko->name);
 		break;
+	case K_OBJ_TIMER:
+		/* k_timer_cleanup() does not check whether the timer has
+		 * been initialized; calling it on an uninitialized timer
+		 * would read garbage from an uninitialized dnode. Guard
+		 * explicitly here.
+		 */
+		if ((ko->flags & K_OBJ_FLAG_INITIALIZED) != 0U) {
+			k_timer_cleanup((struct k_timer *)ko->name);
+		}
+		break;
 	default:
 		/* Nothing to do */
 		break;

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -617,15 +617,16 @@ static void work_timeout_handler(struct _timeout *record)
 
 	/*
 	 * The work item may be running on a different CPU than the timeout
-	 * handler. This necessitates two conditions be checked.
+	 * handler. Two conditions must be checked.
 	 *  1. Did the work item finish before the timeout handler got to run?
-	 *  2. Was the timeout handler canceled while it was pending?
-	 * If the work thread starts a new work item before this handler wins
-	 * the spinlock, the finished flag is reset but the handler can still
-	 * detect if the timeout was aborted by work_timeout_stop_locked().
+	 *  2. Was the timeout aborted while the handler was in flight?
+	 * queue->finished alone is insufficient for (2): if the work thread
+	 * completes the item and starts a new one before this handler wins
+	 * <lock>, finished is reset and the stale handler would abort the
+	 * wrong worker. work_timeout_stop_locked() aborts the timeout, which
+	 * flags it superseded; bail on that too.
 	 */
-
-	if ((queue->finished) || (z_is_timeout_handler_canceled(record))) {
+	if (queue->finished || z_timeout_inflight_superseded(record)) {
 		k_spin_unlock(&lock, key);
 		return;
 	}
@@ -663,7 +664,7 @@ static void work_timeout_stop_locked(struct k_work_q *queue)
 		return;
 	}
 
-	z_abort_timeout(&queue->work_timeout_record);
+	(void)z_try_abort_timeout(&queue->work_timeout_record);
 }
 #endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 
@@ -1004,26 +1005,10 @@ static void work_timeout(struct _timeout *to)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	struct k_work_q *queue = NULL;
 
-	/*
-	 * If the timeout handler has been canceled between the point in time
-	 * when sys_clock_announce() called it and this handler wins <lock>
-	 * then there is nothing to do. As the current lock is required to be
-	 * held before _this_ timeout can be aborted, it is safe to test for
-	 * the cancellation of the handler without explicitly holding the
-	 * timeout lock.
-	 */
-
-	if (z_is_timeout_handler_canceled(to)) {
-		k_spin_unlock(&lock, key);
-		return;
-	}
-
-	/* If the work is still marked delayed (should be) then clear that
-	 * state and submit it to the queue.  If successful the queue will be
-	 * notified of new work at the next reschedule point.
-	 *
-	 * If not successful there is no notification that the work has been
-	 * abandoned.  Sorry.
+	/* K_WORK_DELAYED_BIT is the wake-ownership flag: whichever side
+	 * (this handler or unschedule_locked()) clears it via
+	 * flag_test_and_clear() first owns the outcome. If unschedule_locked
+	 * got here first, the bit is clear and we bail.
 	 */
 	if (flag_test_and_clear(&wp->flags, K_WORK_DELAYED_BIT)) {
 		queue = dw->queue;
@@ -1117,7 +1102,8 @@ static int schedule_for_queue_locked(struct k_work_q **queuep,
  * @return true if and only if work had been delayed so the timeout
  * was cancelled.
  */
-static inline bool unschedule_locked(struct k_work_delayable *dwork)
+static inline bool unschedule_locked(struct k_work_delayable *dwork,
+				     k_spinlock_key_t *key)
 {
 	bool ret = false;
 	struct k_work *work = &dwork->work;
@@ -1126,9 +1112,20 @@ static inline bool unschedule_locked(struct k_work_delayable *dwork)
 	 * callback has been dequeued and will inevitably run (or has
 	 * already run), so treat that as "undelayed" and return
 	 * false.
+	 *
+	 * Clearing K_WORK_DELAYED_BIT claims the wake from the timeout
+	 * handler (see work_timeout()). Then wait for any in-flight
+	 * handler to actually complete: callers may free dwork or
+	 * re-arm the same delayable for a new schedule once we return
+	 * true, and either is unsafe while the handler is still about
+	 * to dereference dwork->work.flags.
 	 */
 	if (flag_test_and_clear(&work->flags, K_WORK_DELAYED_BIT)) {
-		ret = z_abort_timeout(&dwork->timeout) == 0;
+		while (z_try_abort_timeout(&dwork->timeout) == -EAGAIN) {
+			k_spin_unlock(&lock, *key);
+			*key = k_spin_lock(&lock);
+		}
+		ret = true;
 	}
 
 	return ret;
@@ -1145,9 +1142,10 @@ static inline bool unschedule_locked(struct k_work_delayable *dwork)
  *
  * @return k_work_busy_get() flags
  */
-static int cancel_delayable_async_locked(struct k_work_delayable *dwork)
+static int cancel_delayable_async_locked(struct k_work_delayable *dwork,
+					 k_spinlock_key_t *key)
 {
-	(void)unschedule_locked(dwork);
+	(void)unschedule_locked(dwork, key);
 
 	return cancel_async_locked(&dwork->work);
 }
@@ -1199,7 +1197,7 @@ int k_work_reschedule_for_queue(struct k_work_q *queue, struct k_work_delayable 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	/* Remove any active scheduling. */
-	(void)unschedule_locked(dwork);
+	(void)unschedule_locked(dwork, &key);
 
 	/* Schedule the work item with the new parameters. */
 	ret = schedule_for_queue_locked(&queue, dwork, delay);
@@ -1229,7 +1227,7 @@ int k_work_cancel_delayable(struct k_work_delayable *dwork)
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, cancel_delayable, dwork);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	int ret = cancel_delayable_async_locked(dwork);
+	int ret = cancel_delayable_async_locked(dwork, &key);
 
 	k_spin_unlock(&lock, key);
 
@@ -1256,7 +1254,7 @@ bool k_work_cancel_delayable_sync(struct k_work_delayable *dwork,
 	bool need_wait = false;
 
 	if (pending) {
-		(void)cancel_delayable_async_locked(dwork);
+		(void)cancel_delayable_async_locked(dwork, &key);
 		need_wait = cancel_sync_locked(&dwork->work, canceller);
 	}
 
@@ -1298,7 +1296,7 @@ bool k_work_flush_delayable(struct k_work_delayable *dwork,
 	/* If unscheduling did something then submit it.  Ignore a
 	 * failed submission (e.g. when cancelling).
 	 */
-	if (unschedule_locked(dwork)) {
+	if (unschedule_locked(dwork, &key)) {
 		struct k_work_q *queue = dwork->queue;
 
 		(void)submit_to_queue_locked(work, &queue);

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -284,15 +284,21 @@ void k_p4wq_submit(struct k_p4wq *queue, struct k_p4wq_work *item)
 	 * error: we are breaking our promise about run order.
 	 * Complain.
 	 */
-	struct k_thread *th = z_unpend_first_thread(&queue->waitq);
+	struct k_thread *th = NULL;
+
+	LOCK_SCHED_SPINLOCK {
+		th = z_unpend_first_thread_locked(&queue->waitq);
+		if (th != NULL) {
+			set_prio(th, item);
+			z_sched_ready_locked(th);
+		}
+	}
 
 	if (th == NULL) {
 		LOG_WRN("Out of worker threads, priority guarantee violated");
 		goto out;
 	}
 
-	set_prio(th, item);
-	z_ready_thread(th);
 	z_reschedule(&queue->lock, k);
 
 	return;

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -203,6 +203,8 @@ extern "C" {
 	sys_trace_k_timer_stop_fn_expiry_enter(timer)
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)                                          \
 	sys_trace_k_timer_stop_fn_expiry_exit(timer)
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
 
 #define sys_port_trace_k_condvar_init(condvar, ret)    sys_trace_k_condvar_init(condvar, ret)
 #define sys_port_trace_k_condvar_signal_enter(condvar) sys_trace_k_condvar_signal_enter(condvar)

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -745,6 +745,9 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)                                          \
 	SEGGER_SYSVIEW_RecordEndCall(TID_TIMER_STOP_EXPIRY)
 
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
+
 #define sys_port_trace_syscall_enter(id, name, ...)                                                \
 	SEGGER_SYSVIEW_RecordString(TID_SYSCALL, (const char *)#name)
 

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -437,6 +437,8 @@
 	sys_trace_k_timer_stop_fn_expiry_enter(timer)
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)					   \
 	sys_trace_k_timer_stop_fn_expiry_exit(timer)
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
 
 #define sys_port_trace_k_event_init(event) sys_trace_k_event_init(event)
 #define sys_port_trace_k_event_post_enter(event, events, events_mask)   \

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -430,6 +430,8 @@ void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iode
 					sys_trace_timer_stop_fn_expiry_enter(timer)
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)			\
 					sys_trace_timer_stop_fn_expiry_exit(timer)
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
 
 #define sys_port_trace_k_event_init(event)
 #define sys_port_trace_k_event_post_enter(event, events, events_mask)

--- a/tests/benchmarks/sched/src/main.c
+++ b/tests/benchmarks/sched/src/main.c
@@ -16,7 +16,7 @@
  * then sleeps using z_pend_curr().  From this initial
  * state:
  *
- * 1. The main thread calls z_unpend_first_thread()
+ * 1. The main thread calls z_unpend_first_thread_locked()
  * 2. The main thread calls z_ready_thread()
  * 3. The main thread calls k_yield()
  *    (the kernel switches to the partner thread)
@@ -133,13 +133,11 @@ int main(void)
 	uint64_t tot = 0U;
 	uint32_t runs = 0U;
 
-	int key;
-
 	for (int i = 0; i < N_RUNS + N_SETTLE; i++) {
-		key = arch_irq_lock();
 		stamp(UNPENDING);
-		z_unpend_first_thread(&waitq);
-		arch_irq_unlock(key);
+		LOCK_SCHED_SPINLOCK {
+			z_unpend_first_thread_locked(&waitq);
+		}
 		stamp(UNPENDED_READYING);
 		z_ready_thread(th);
 		stamp(READIED_YIELDING);


### PR DESCRIPTION
Five hand-rolled fixes have landed for the same class of race in
kernel timeout handling — the gap between `sys_clock_announce_locked()`
releasing `timeout_lock` and the handler taking its own module lock:

  - 1b8c7a3038d9 thread timeout (fixes #106653)
  - 083629e520f4 `k_timer` re-use in handler (fixes #106654)
  - df630e09ae28 delayable work timeout
  - f9376ddde508 workqueue thread abort
  - 8509270a0e34 poll timeout

Plus a sixth pending in #109426 (`k_timer` free UAF).

Each fix re-purposed the `t->dticks == TIMEOUT_DTICKS_ANNOUNCING`
sentinel as a "popped-but-not-yet-fired" marker. Handlers check it on
entry and bail; aborters toggle it under the module's lock. The
sentinel does double duty: it marks the in-flight state *and* relies
on the magic value (`INT_MIN+1`) happening to survive a `k_free` of
the timeout's storage. The second property is a coincidence — #109426
exposed a residual UAF where storage freed between the abort and the
`sys_clock_announce_locked()` handler dispatch can be reused, the new
content at the `dticks` offset can coincidentally equal `ANNOUNCING`,
and the handler then proceeds to dereference freed/reused memory.

The bigger issue is the trend: every new timeout user has to learn
this dance. This series moves the in-flight synchronization into the
timeout subsystem so individual modules no longer need their bespoke
fix.

The new primitive is `z_try_abort_timeout()`, which returns:
  - `0`       — was active and removed from the queue.
  - `-EINVAL` — not active (never linked, already done, or same-CPU IRQ).
  - `-EAGAIN` — handler in flight on another CPU; caller must drop
              outer locks and retry.

A file-local `inflight_timeout` pointer in `kernel/timeout.c` tracks
the "popped, lock dropped, handler about to run" window. Callers
retry on `-EAGAIN` until `-EINVAL` (giving the in-flight handler a
chance to complete with the caller's lock released).

The series:
  - introduces `z_try_abort_timeout()` (timeout.c)
  - migrates timer, sched (scheduler-internal sites), wait_q callers
    (sem/mutex/mem_slab/stack/condvar/msg_q/queue/futex), timeslicing,
    poll, work
  - drops `z_abort_thread_timeout()` and the in-handler dticks-cancel
    check
  - removes the dticks-based cancel mechanism and the
    `TIMEOUT_DTICKS_ABORTED` sentinel
  - reimplements #109426 (abort timer before freeing) on top

Each migration is its own commit; old and new mechanisms coexist
through the middle of the series so it remains bisectable.

In addition to the original #109426 UAF (timer free), the poll and
work migrations close two pre-existing UAF windows the
dticks-cancel-based fixes did not address — `k_work_poll_cancel()`
returning while the handler was still about to dereference
`work->poller`, and `k_work_cancel_delayable()` returning while the
handler was still about to dereference `dwork->flags`. In both cases
a user-space caller freeing the object between cancel returning and
the handler bailing would race with the free. The migrated paths
wait for any in-flight handler to complete before returning. See the
poll/work commit messages for details.

Supersedes #109426.


Fixes: #113143
