### PR TITLE
net_buf : Add net_buf_take api 

### DIFF
--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -400,8 +400,7 @@ static void h5_process_complete_packet(const struct device *dev, uint8_t *hdr)
 
 	process_unack(h5);
 
-	buf = h5->rx_buf;
-	h5->rx_buf = NULL;
+	buf = net_buf_take(&h5->rx_buf);
 
 	switch (H5_HDR_PKT_TYPE(hdr)) {
 	case HCI_3WIRE_ACK_PKT:

--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -1659,6 +1659,22 @@ void net_buf_unref(struct net_buf *buf);
 struct net_buf * __must_check net_buf_ref(struct net_buf *buf);
 
 /**
+ * @brief Move a buffer pointer, setting the orig to NULL.
+ *
+ * This performs an atomic exchange on @p orig. setting it to NULL and
+ * returning the previous value.
+ *
+ * @param orig Pointer to the buffer pointer to transfer. Will be set to NULL
+ *		on return.
+ *
+ * @return The buffer originally pointed to by @p orig
+ */
+static inline struct net_buf *__must_check net_buf_take(struct net_buf **orig)
+{
+	return (struct net_buf *)atomic_ptr_clear((atomic_ptr_t *)orig);
+}
+
+/**
  * @brief Clone buffer
  *
  * Duplicate given buffer including any (user) data and headers currently stored.

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -617,8 +617,7 @@ static int bt_att_chan_req_send(struct bt_att_chan *chan, struct bt_att_req *req
 	chan->req = req;
 
 	/* Release since bt_l2cap_send_cb takes ownership of the buffer */
-	buf = req->buf;
-	req->buf = NULL;
+	buf = net_buf_take(&req->buf);
 
 	/* This lock makes sure the value of `bt_att_mtu(chan)` does not
 	 * change.

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -5778,8 +5778,7 @@ static int bt_l2cap_br_recv_seg(struct bt_l2cap_br_chan *br_chan, struct net_buf
 			return -ESHUTDOWN;
 		}
 
-		buf = br_chan->_sdu;
-		br_chan->_sdu = NULL;
+		buf = net_buf_take(&br_chan->_sdu);
 		br_chan->_sdu_len = 0;
 
 		/* Receiving complete SDU, notify channel and reset SDU buf */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -477,8 +477,7 @@ static void bt_acl_recv(struct bt_conn *conn, struct net_buf *buf,
 	}
 
 	/* L2CAP frame complete. */
-	buf = conn->rx;
-	conn->rx = NULL;
+	buf = net_buf_take(&conn->rx);
 
 	LOG_DBG("Successfully parsed %u byte L2CAP packet", buf->len);
 	if (bt_conn_is_br(conn)) {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2526,7 +2526,7 @@ static void hci_cmd_done(uint16_t opcode, uint8_t status, struct net_buf *evt_bu
 	}
 
 	/* Take the original command buffer reference. */
-	buf = atomic_ptr_clear((atomic_ptr_t *)&bt_dev.sent_cmd);
+	buf = net_buf_take(&bt_dev.sent_cmd);
 
 	if (!buf) {
 		LOG_ERR("No command sent for cmd complete 0x%04x", opcode);

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2648,8 +2648,7 @@ static void l2cap_chan_le_recv_seg(struct bt_l2cap_le_chan *chan,
 		return;
 	}
 
-	buf = chan->_sdu;
-	chan->_sdu = NULL;
+	buf = net_buf_take(&chan->_sdu);
 	chan->_sdu_len = 0U;
 
 	l2cap_chan_le_recv_sdu(chan, buf, seg);

--- a/tests/lib/net_buf/buf/src/main.c
+++ b/tests/lib/net_buf/buf/src/main.c
@@ -1163,4 +1163,42 @@ ZTEST(net_buf_tests, test_net_buf_var_pool_aligned)
 	zassert_equal(destroy_called, 3, "Incorrect destroy callback count");
 }
 
+ZTEST(net_buf_tests, test_net_buf_take)
+{
+	struct net_buf *buf, *moved;
+
+	destroy_called = 0;
+
+	buf = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
+	zassert_not_null(buf, "Failed to get buffer");
+	zassert_equal(buf->ref, 1, "Unexpected ref count");
+
+	/* Buf should become NULL, moved should hold the buffer */
+	moved = net_buf_take(&buf);
+	zassert_is_null(buf, "Original pointer not NULLed after move");
+	zassert_not_null(moved, "Moved pointer should not be NULL");
+	zassert_equal(moved->ref, 1, "Ref count should remain 1 after move");
+
+	net_buf_unref(moved);
+
+	zassert_equal(destroy_called, 1, "Incorrect destroy callback count");
+
+	/* Move a buffer that has multiple references (ref > 1) */
+	destroy_called = 0;
+	buf = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
+	zassert_not_null(buf, "Failed to get buffer");
+	zassert_not_null(net_buf_ref(buf), "Failed to reference buffer");
+	zassert_equal(buf->ref, 2, "Unexpected ref count");
+
+	moved = net_buf_take(&buf);
+	zassert_is_null(buf, "Original pointer not NULLed after move");
+	zassert_not_null(moved, "Moved pointer should not be NULL");
+	zassert_equal(moved->ref, 2, "Ref count should remain 2 after move");
+
+	net_buf_unref(moved);
+	zassert_equal(destroy_called, 0, "Buffer should not be destroyed yet");
+	net_buf_unref(moved);
+	zassert_equal(destroy_called, 1, "Buffer should be destroyed now");
+}
+
 ZTEST_SUITE(net_buf_tests, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Function to atomically move a buffer reference using `atomic_ptr_clear()` and add a test case to the net_buf test.