### PR TITLE
west.yml: update tf-psa-crypto to fix Clang doxygen build error

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -389,7 +389,7 @@ manifest:
         - testing
         - tee
     - name: tf-psa-crypto
-      revision: efdf9e209cc3b2c7be93ac81c7c96cd2550bbe27
+      revision: pull/10/head
       path: modules/crypto/tf-psa-crypto
       groups:
         - crypto


### PR DESCRIPTION
TF-PSA-Crypto commit `e05874d67` (`[zep noup][tf-m] Re-add support for
AES Keywrap for TF-M`) added `psa_unwrap_key()` with several `\retval`
entries that have no description text. Clang 15 with `-Wdocumentation`
treats this as an error, breaking Clang builds:

```
include/psa/crypto.h:3254:41: error: empty paragraph passed to '\retval' command [-Werror,-Wdocumentation]
 3254 |  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
```

The fix adds `\emptydescription` to each bare `\retval`, matching the
pattern already used elsewhere in the file and established upstream in
[mbedtls/mbedtls#7098](https://github.com/Mbed-TLS/mbedtls/pull/7098).

Resolves #109975
