### PR TITLE
drivers: hwinfo: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -91,9 +91,8 @@ extern "C" {
  * @param buffer  Buffer to write the ID to.
  * @param length  Max length of the buffer.
  *
- * @return size of the device ID copied.
- * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval <0 any negative value on driver specific errors.
+ * @return Size of the device ID copied, negative errno value on failure.
+ * @retval -ENOSYS There is no implementation for the particular device.
  */
 __syscall ssize_t hwinfo_get_device_id(uint8_t *buffer, size_t length);
 
@@ -107,9 +106,8 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length);
  *
  * @param buffer  Buffer of 8 bytes to write the ID to.
  *
- * @retval 0 if successful.
- * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval <0 any negative value on driver specific errors.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS There is no implementation for the particular device.
  */
 __syscall int hwinfo_get_device_eui64(uint8_t *buffer);
 
@@ -131,9 +129,8 @@ int z_impl_hwinfo_get_device_eui64(uint8_t *buffer);
  * Successive calls to this routine will return the same value, unless
  * `hwinfo_clear_reset_cause` has been called.
  *
- * @retval 0 if successful.
- * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval <0 any negative value on driver specific errors.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS There is no implementation for the particular device.
  */
 __syscall int hwinfo_get_reset_cause(uint32_t *cause);
 
@@ -144,9 +141,8 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause);
  *
  * Clears reset cause flags.
  *
- * @retval 0 if successful.
- * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval <0 any negative value on driver specific errors.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS There is no implementation for the particular device.
  */
 __syscall int hwinfo_clear_reset_cause(void);
 
@@ -159,9 +155,8 @@ int z_impl_hwinfo_clear_reset_cause(void);
  *
  * Retrieves all `reset_cause` flags that are supported by this device.
  *
- * @retval 0 if successful.
- * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval <0 any negative value on driver specific errors.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS There is no implementation for the particular device.
  */
 __syscall int hwinfo_get_supported_reset_cause(uint32_t *supported);
 


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974