### PR TITLE
Bluetooth: CAP: Handover: Shell: Use unicast_to_broadcast_created

### DIFF
--- a/subsys/bluetooth/audio/shell/cap_handover.c
+++ b/subsys/bluetooth/audio/shell/cap_handover.c
@@ -39,18 +39,49 @@
 #include "host/shell/bt.h"
 #include "audio.h"
 
+static void unicast_to_broadcast_created_cb(struct bt_cap_broadcast_source *broadcast_source)
+{
+	bt_shell_info("Broadcast source %p created for broadcast id 0x%06X ."
+		      "Execute \"bt per-adv-data\" to set the BASE",
+		      broadcast_source, default_source.broadcast_id);
+
+	if (default_source.cap_source == NULL) {
+		default_source.cap_source = broadcast_source;
+		default_source.is_cap = true;
+	} else {
+		bt_shell_warn("Unexpected broadcast source %p already exists for CAP",
+			      default_source.cap_source);
+	}
+}
+
 static void unicast_to_broadcast_complete_cb(int err, struct bt_conn *conn,
 					     struct bt_cap_unicast_group *unicast_group,
 					     struct bt_cap_broadcast_source *broadcast_source)
 {
-	if (err == -ECANCELED) {
-		bt_shell_print("Unicast to broadcast handover was cancelled for conn %p", conn);
+	default_source.handover_in_progress = false;
 
-		default_source.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
-		default_source.adv_sid = BT_GAP_SID_INVALID;
-	} else if (err != 0) {
-		bt_shell_error("Unicast to broadcast handover failed for conn %p (%d)", conn, err);
+	if (err != 0) {
+		const char *unicast_group_del_str =
+			unicast_group != NULL ? " without deleting the unicast_group" : "";
 
+		if (err == -ECANCELED) {
+			bt_shell_print("Unicast to broadcast handover was cancelled for conn %p%s",
+				       conn, unicast_group_del_str);
+		} else {
+			bt_shell_error("Unicast to broadcast handover failed for conn %p (%d)%s",
+				       conn, err, unicast_group_del_str);
+		}
+
+		if (broadcast_source != NULL) {
+			err = bt_cap_initiator_broadcast_audio_delete(broadcast_source);
+
+			if (err != 0) {
+				bt_shell_error("Failed to delete broadcast source: %d", err);
+			}
+		}
+
+		default_source.cap_source = NULL;
+		default_source.is_cap = false;
 		default_source.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 		default_source.adv_sid = BT_GAP_SID_INVALID;
 	} else {
@@ -63,13 +94,6 @@ static void unicast_to_broadcast_complete_cb(int err, struct bt_conn *conn,
 		default_unicast_group.is_cap = false;
 		default_unicast_group.cap_group = NULL;
 	}
-
-	if (broadcast_source != NULL) {
-		default_source.cap_source = broadcast_source;
-		default_source.is_cap = true;
-	}
-
-	default_source.handover_in_progress = false;
 }
 
 static void broadcast_to_unicast_complete_cb(int err, struct bt_conn *conn,
@@ -143,6 +167,7 @@ static int register_callbacks(void)
 
 	if (!registered) {
 		static const struct bt_cap_handover_cb cbs = {
+			.unicast_to_broadcast_created = unicast_to_broadcast_created_cb,
 			.unicast_to_broadcast_complete = unicast_to_broadcast_complete_cb,
 			.broadcast_to_unicast_complete = broadcast_to_unicast_complete_cb,
 		};

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -1337,6 +1337,12 @@ static int cmd_broadcast_start(const struct shell *sh, size_t argc, char *argv[]
 		return -ENOEXEC;
 	}
 
+	if (default_source.handover_in_progress) {
+		shell_info(sh, "CAP Handover in progress");
+
+		return -ENOEXEC;
+	}
+
 	if (default_source.cap_source == NULL || !default_source.is_cap) {
 		shell_info(sh, "CAP Broadcast source not created");
 
@@ -1361,6 +1367,12 @@ static int cmd_broadcast_update(const struct shell *sh, size_t argc, char *argv[
 	int err;
 
 	ARG_UNUSED(argc);
+
+	if (default_source.handover_in_progress) {
+		shell_info(sh, "CAP Handover in progress");
+
+		return -ENOEXEC;
+	}
 
 	if (default_source.cap_source == NULL || !default_source.is_cap) {
 		shell_info(sh, "CAP Broadcast source not created");
@@ -1396,6 +1408,12 @@ static int cmd_broadcast_stop(const struct shell *sh, size_t argc, char *argv[])
 
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
+
+	if (default_source.handover_in_progress) {
+		shell_info(sh, "CAP Handover in progress");
+
+		return -ENOEXEC;
+	}
 
 	if (default_source.cap_source == NULL || !default_source.is_cap) {
 		shell_info(sh, "CAP Broadcast source not created");


### PR DESCRIPTION
Use the unicast_to_broadcast_created callback to properly handle the creation and potentional deletion of the broadcast source.