### PR TITLE
dts: bindings: remove default value from required properties

### DIFF
--- a/dts/bindings/adc/silabs,siwx91x-adc.yaml
+++ b/dts/bindings/adc/silabs,siwx91x-adc.yaml
@@ -21,7 +21,6 @@ properties:
 
   silabs,adc-sampling-rate:
     type: int
-    default: 100000
     description: |
         ADC sampling rate in Hz (1-2500000 Hz).
     required: true

--- a/dts/bindings/charger/nxp,pca9422-charger.yaml
+++ b/dts/bindings/charger/nxp,pca9422-charger.yaml
@@ -11,7 +11,6 @@ properties:
   constant-charge-current-max-microamp:
     type: int
     required: true
-    default: 100000
     description: |
       Fast Charge current set at init time in uA, available range is 2.5mA to 640mA.
       The value specified will be rounded down to the closest implemented
@@ -21,7 +20,6 @@ properties:
   constant-charge-voltage-max-microvolt:
     type: int
     required: true
-    default: 4200000
     description: |
       The maximum voltage that the battery will be charged at, defaults to
       4.2V, matching the device default reset configuration.

--- a/dts/bindings/charger/silergy,sy6974b.yaml
+++ b/dts/bindings/charger/silergy,sy6974b.yaml
@@ -24,7 +24,6 @@ properties:
       Charge voltage regulation target applied at initialization.
       Range: 3.856-4.624V (32 mV steps, values are rounded down to the nearest step).
       Default value is 4.208V, matching the device default reset configuration.
-    default: 4208000
 
 examples:
   - |

--- a/dts/bindings/clock/microchip,xec-pcr.yaml
+++ b/dts/bindings/clock/microchip,xec-pcr.yaml
@@ -64,7 +64,6 @@ properties:
   xtal-enable-delay-ms:
     type: int
     required: true
-    default: 300
     description: |
       Delay in milliseconds after crystal is enabled and clock monitor is
       started.
@@ -72,7 +71,6 @@ properties:
   pll-lock-timeout-ms:
     type: int
     required: true
-    default: 30
     description: |
       Timeout in milliseconds waiting for PLL to lock to new clock source.
 

--- a/dts/bindings/clock/st,stm32-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32-msi-clock.yaml
@@ -11,7 +11,6 @@ properties:
   msi-range:
     required: true
     type: int
-    default: 6
     description: |
       MSI clock ranges:
       0: around 100 kHz

--- a/dts/bindings/clock/st,stm32l0-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32l0-msi-clock.yaml
@@ -14,7 +14,6 @@ properties:
   msi-range:
     required: true
     type: int
-    default: 5
     description: |
       MSI clock ranges:
       0: around 65.536 kHz

--- a/dts/bindings/clock/st,stm32u5-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32u5-msi-clock.yaml
@@ -13,7 +13,6 @@ include:
 properties:
 
   msi-range:
-    default: 4
     required: true
     type: int
     description: |

--- a/dts/bindings/counter/nxp,stm.yaml
+++ b/dts/bindings/counter/nxp,stm.yaml
@@ -19,7 +19,6 @@ properties:
 
   prescaler:
     type: int
-    default: 0
     required: true
     description: |
       Selects the module clock divide value for the prescaler (1–256).

--- a/dts/bindings/espi/nuvoton,npcx-espi-taf.yaml
+++ b/dts/bindings/espi/nuvoton,npcx-espi-taf.yaml
@@ -36,7 +36,6 @@ properties:
     description: |
       Erase block size of target flash. The default was 4KB Erase Block Size.
       All Intel platforms require support for at least 4 KB Erase Block Size.
-    default: "NPCX_ESPI_TAF_ERASE_BLOCK_SIZE_4KB"
     enum:
       - "NPCX_ESPI_TAF_ERASE_BLOCK_SIZE_4KB"
       - "NPCX_ESPI_TAF_ERASE_BLOCK_SIZE_32KB"
@@ -49,7 +48,6 @@ properties:
     description: |
       Maximum read request size of flash access channel. The default was 64 bytes.
       This value is recommended in datasheet.
-    default: "NPCX_ESPI_TAF_MAX_READ_REQ_64B"
     enum:
       - "NPCX_ESPI_TAF_MAX_READ_REQ_64B"
       - "NPCX_ESPI_TAF_MAX_READ_REQ_128B"

--- a/dts/bindings/gpio/adi,max14906-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14906-gpio.yaml
@@ -40,7 +40,6 @@ properties:
     type: boolean
   spi-addr:
     type: int
-    default: 0
     required: true
     enum:
       - 0

--- a/dts/bindings/gpio/adi,max14916-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14916-gpio.yaml
@@ -40,7 +40,6 @@ properties:
     type: boolean
   spi-addr:
     type: int
-    default: 0
     required: true
     enum:
       - 0

--- a/dts/bindings/gpio/nxp,pcal9722.yaml
+++ b/dts/bindings/gpio/nxp,pcal9722.yaml
@@ -16,7 +16,6 @@ properties:
     required: true
     type: int
     enum: [0x40, 0x42]
-    default: 0x40
     description:
       Address used to address device on the SPI bus. Two PCAL9722 devices can be connected to the
       same SPI chip select by pulling the ADDR pin high or low. If pulled low, the address should

--- a/dts/bindings/i2c/ambiq,ios-i2c.yaml
+++ b/dts/bindings/i2c/ambiq,ios-i2c.yaml
@@ -11,6 +11,5 @@ properties:
   fifo-threshold:
     type: int
     required: true
-    default: 16
     description: |
         Set the FIFO threshold to the middle by default

--- a/dts/bindings/i2c/ti,omap-i2c.yaml
+++ b/dts/bindings/i2c/ti,omap-i2c.yaml
@@ -16,5 +16,4 @@ properties:
     required: true
   clock-frequency:
     description: The frequency of the I2C bus.
-    default: 100000
     required: true

--- a/dts/bindings/input/realtek,bee-keyscan.yaml
+++ b/dts/bindings/input/realtek,bee-keyscan.yaml
@@ -31,14 +31,12 @@ properties:
 
   row-size:
     required: true
-    default: 2
     description: |
       Actual row size of the external keyscan matrix.
       Hardware supports up to 12 rows.
 
   col-size:
     required: true
-    default: 2
     description: |
       Actual column size of the external keyscan matrix.
       Hardware supports up to 20 columns.

--- a/dts/bindings/mfd/rohm,bd8lb600fs.yaml
+++ b/dts/bindings/mfd/rohm,bd8lb600fs.yaml
@@ -21,7 +21,6 @@ properties:
   instance-count:
     type: int
     required: true
-    default: 1
     enum:
       - 1
       - 2

--- a/dts/bindings/mspi/ambiq,mspi-device.yaml
+++ b/dts/bindings/mspi/ambiq,mspi-device.yaml
@@ -17,7 +17,6 @@ properties:
   mspi-hardware-ce-num:
     type: int
     required: true
-    default: 0
     description: |
       It can be only CE0 or CE1,
       but there could be multiple of CE0 or CE1 for a controller

--- a/dts/bindings/mtd/nxp,s32-xspi-hyperram.yaml
+++ b/dts/bindings/mtd/nxp,s32-xspi-hyperram.yaml
@@ -32,7 +32,6 @@ properties:
     type: int
     required: true
     enum: [19, 22, 27, 34, 46, 67, 115]
-    default: 34
     description: |
       Specifies the output drive strength in ohm, which based on the operating device VCC.
       The supported typical impedance settings:

--- a/dts/bindings/mtd/st,stm32f4-nv-flash.yaml
+++ b/dts/bindings/mtd/st,stm32f4-nv-flash.yaml
@@ -14,7 +14,6 @@ properties:
       - 2
       - 4
       - 8
-    default: 1
     description: |
       Number of bytes used in write operations. Default value is based on the
       reset value of Flash Control Register (FLASH_CR).

--- a/dts/bindings/power/realtek,rts5912-ulpm.yaml
+++ b/dts/bindings/power/realtek,rts5912-ulpm.yaml
@@ -37,7 +37,6 @@ child-binding:
 
     wkup-pin-mode:
       type: string
-      default: vin
       required: true
       description: indicates a wakeup pin mode selection
       enum:

--- a/dts/bindings/rng/ti,mspm0-trng.yaml
+++ b/dts/bindings/rng/ti,mspm0-trng.yaml
@@ -19,7 +19,6 @@ properties:
   ti,clk-div:
     type: int
     required: true
-    default: 1
     enum:
       - 1
       - 2

--- a/dts/bindings/sensor/avago,apds9253.yaml
+++ b/dts/bindings/sensor/avago,apds9253.yaml
@@ -29,7 +29,6 @@ properties:
       - <APDS9253_MEASUREMENT_RATE_100MS>:  2
       - <APDS9253_MEASUREMENT_RATE_50MS>    1
       - <APDS9253_MEASUREMENT_RATE_25MS>    0
-    default: 2
     enum:
       - 6
       - 5
@@ -50,7 +49,6 @@ properties:
       - <APDS9253_GAIN_RANGE_6>:  2
       - <APDS9253_GAIN_RANGE_3>:  1
       - <APDS9253_GAIN_RANGE_1>:  0
-    default: 1
     enum:
       - 4
       - 3
@@ -70,7 +68,6 @@ properties:
       - <APDS9253_RESOLUTION_17BIT_50MS>:   48
       - <APDS9253_RESOLUTION_16BIT_25MS>:   64
       - <APDS9253_RESOLUTION_13BIT_3MS>:    80
-    default: 32
     enum:
       - 0
       - 16

--- a/dts/bindings/stepper/adi/adi,tmcm3216-stepper-driver.yaml
+++ b/dts/bindings/stepper/adi/adi,tmcm3216-stepper-driver.yaml
@@ -14,7 +14,6 @@ properties:
   micro-step-res:
     type: int
     required: true
-    default: 16
     description: |
       Default microstep resolution. Valid values are:
       1, 2, 4, 8, 16, 32, 64, 128, 256

--- a/dts/bindings/timer/sifli,sf32lb-atim.yaml
+++ b/dts/bindings/timer/sifli,sf32lb-atim.yaml
@@ -19,7 +19,6 @@ properties:
 
   sifli,prescaler:
     type: int
-    default: 0
     required: true
     description: |
       Counter prescaler from 0 to 65535. default reset value is 'not divided'

--- a/dts/bindings/timer/sifli,sf32lb-gptim.yaml
+++ b/dts/bindings/timer/sifli,sf32lb-gptim.yaml
@@ -16,7 +16,6 @@ properties:
 
   sifli,prescaler:
     type: int
-    default: 0
     required: true
     description: |
       Counter prescaler from 0 to 65535. The clock frequency to the counter

--- a/dts/bindings/timer/ti,mspm0-timer.yaml
+++ b/dts/bindings/timer/ti,mspm0-timer.yaml
@@ -24,7 +24,6 @@ properties:
   ti,clk-div:
     type: int
     required: true
-    default: 1
     enum:
       - 1
       - 2

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -3120,6 +3120,10 @@ def _check_prop_by_type(prop_name: str,
              f"'type: {prop_type}' for '{prop_name}' in "
              f"'properties:' in '{binding_path}'")
 
+    if options.get("required"):
+        _LOG.warning(f"Property '{prop_name}' is required in '{binding_path}', "
+                     "it should not have a default value")
+
     def ok_default() -> bool:
         # Returns True if 'default' is an okay default for the property's type.
         # If you change this, be sure to update the type annotation for


### PR DESCRIPTION
Remove the required property in DT bindings YAML files for DT properties that provide a default value.

Change **edtlib.py** python script to emit a warning trace message when a DT property is required but also provides a default value.