### PR TITLE
 boards/soc: realtek: bee: migrate to zephyr,mapped-partition

### DIFF
--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjf.dts
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjf.dts
@@ -16,11 +16,13 @@
 &flash {
 	partitions {
 		app_partition: partition@15000 {
+			compatible = "zephyr,mapped-partition";
 			label = "app-image";
 			reg = <0x15000 DT_SIZE_K(924)>;
 		};
 
 		storage_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xfc000 DT_SIZE_K(16)>;
 		};

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.dts
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.dts
@@ -16,11 +16,13 @@
 &flash {
 	partitions {
 		app_partition: partition@15000 {
+			compatible = "zephyr,mapped-partition";
 			label = "app-image";
 			reg = <0x15000 DT_SIZE_K(412)>;
 		};
 
 		storage_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7c000 DT_SIZE_K(16)>;
 		};

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.dts
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.dts
@@ -16,11 +16,13 @@
 &flash {
 	partitions {
 		app_partition: partition@15000 {
+			compatible = "zephyr,mapped-partition";
 			label = "app-image";
 			reg = <0x15000 DT_SIZE_K(924)>;
 		};
 
 		storage_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xfc000 DT_SIZE_K(16)>;
 		};

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.dts
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.dts
@@ -16,11 +16,13 @@
 &flash {
 	partitions {
 		app_partition: partition@15000 {
+			compatible = "zephyr,mapped-partition";
 			label = "app-image";
 			reg = <0x15000 DT_SIZE_K(412)>;
 		};
 
 		storage_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7c000 DT_SIZE_K(16)>;
 		};

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.dts
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.dts
@@ -34,11 +34,13 @@
 	partitions {
 		/* 0x402d000-0x4100000: Free space for Zephyr */
 		app_partition: partition@2d000 {
+			compatible = "zephyr,mapped-partition";
 			label = "app-image";
 			reg = <0x2d000 DT_SIZE_K(828)>;
 		};
 
 		storage_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xfc000 DT_SIZE_K(16)>;
 		};

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.dts
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.dts
@@ -34,11 +34,13 @@
 	partitions {
 		/* 0x402d000-0x4100000: Free space for Zephyr */
 		app_partition: partition@2d000 {
+			compatible = "zephyr,mapped-partition";
 			label = "app-image";
 			reg = <0x2d000 DT_SIZE_K(828)>;
 		};
 
 		storage_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xfc000 DT_SIZE_K(16)>;
 		};

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.dts
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.dts
@@ -17,11 +17,13 @@
 	partitions {
 		/* 0x402d000-0x4080000: Free space for Zephyr */
 		app_partition: partition@2d000 {
+			compatible = "zephyr,mapped-partition";
 			label = "app-image";
 			reg = <0x2d000 DT_SIZE_K(316)>;
 		};
 
 		storage_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7c000 DT_SIZE_K(16)>;
 		};

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.dts
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.dts
@@ -17,11 +17,13 @@
 	partitions {
 		/* 0x402d000-0x4080000: Free space for Zephyr */
 		app_partition: partition@2d000 {
+			compatible = "zephyr,mapped-partition";
 			label = "app-image";
 			reg = <0x2d000 DT_SIZE_K(316)>;
 		};
 
 		storage_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7c000 DT_SIZE_K(16)>;
 		};

--- a/dts/arm/realtek/bee/rtl8752h.dtsi
+++ b/dts/arm/realtek/bee/rtl8752h.dtsi
@@ -121,38 +121,47 @@
 				erase-block-size = <4096>;
 				#address-cells = <1>;
 				#size-cells = <1>;
+				/* reg and ranges are specified in the SoC-variant dtsi
+				 * (e.g., rtl8752hjf.dtsi).
+				 */
 
 				partitions {
-					compatible = "fixed-partitions";
+					ranges;
 					#address-cells = <1>;
 					#size-cells = <1>;
 
 					rsvd_partition: partition@0 {
+						compatible = "zephyr,mapped-partition";
 						label = "rsvd-image";
 						reg = <0x0 DT_SIZE_K(4)>;
 					};
 
 					oem_cfg_partition: partition@1000 {
+						compatible = "zephyr,mapped-partition";
 						label = "oem-cfg-image";
 						reg = <0x1000 DT_SIZE_K(4)>;
 					};
 
 					ota_header_partition: partition@2000 {
+						compatible = "zephyr,mapped-partition";
 						label = "ota-header-image";
 						reg = <0x2000 DT_SIZE_K(4)>;
 					};
 
 					rom_patch_partition: partition@3000 {
+						compatible = "zephyr,mapped-partition";
 						label = "rom-patch-image";
 						reg = <0x3000 DT_SIZE_K(28)>;
 					};
 
 					fsbl_partition: partition@a000 {
+						compatible = "zephyr,mapped-partition";
 						label = "fsbl-image";
 						reg = <0xa000 DT_SIZE_K(4)>;
 					};
 
 					bt_stack_patch_partition: partition@b000 {
+						compatible = "zephyr,mapped-partition";
 						label = "bt-stack-patch-image";
 						reg = <0xb000 DT_SIZE_K(40)>;
 					};

--- a/dts/arm/realtek/bee/rtl87x2g.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2g.dtsi
@@ -125,9 +125,12 @@
 				erase-block-size = <4096>;
 				#address-cells = <1>;
 				#size-cells = <1>;
+				/* reg and ranges are specified in the SoC-variant dtsi
+				 * (e.g., rtl8762gkh_gku.dtsi).
+				 */
 
 				partitions {
-					compatible = "fixed-partitions";
+					ranges;
 					#address-cells = <1>;
 					#size-cells = <1>;
 
@@ -135,36 +138,43 @@
 					 * Do not use.
 					 */
 					reserved: partition@0 {
+						compatible = "zephyr,mapped-partition";
 						label = "reserved-image";
 						reg = <0x0 DT_SIZE_K(4)>;
 					};
 
 					config_file: partition@1000 {
+						compatible = "zephyr,mapped-partition";
 						label = "config-file-image";
 						reg = <0x1000 DT_SIZE_K(4)>;
 					};
 
 					boot_patch_0: partition@2000 {
+						compatible = "zephyr,mapped-partition";
 						label = "boot-patch-0-image";
 						reg = <0x2000 DT_SIZE_K(32)>;
 					};
 
 					boot_patch_1: partition@a000 {
+						compatible = "zephyr,mapped-partition";
 						label = "boot-patch-1-image";
 						reg = <0xa000 DT_SIZE_K(32)>;
 					};
 
 					ota_header: partition@12000 {
+						compatible = "zephyr,mapped-partition";
 						label = "ota-header-image";
 						reg = <0x12000 DT_SIZE_K(4)>;
 					};
 
 					system_patch: partition@13000 {
+						compatible = "zephyr,mapped-partition";
 						label = "system-patch-image";
 						reg = <0x13000 DT_SIZE_K(32)>;
 					};
 
 					stack_patch: partition@1b000 {
+						compatible = "zephyr,mapped-partition";
 						label = "stack-patch-image";
 						reg = <0x1b000 DT_SIZE_K(72)>;
 					};

--- a/soc/realtek/bee/rtl8752h/bee_image_header.c
+++ b/soc/realtek/bee/rtl8752h/bee_image_header.c
@@ -5,6 +5,8 @@
  */
 
 #include <stdlib.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/devicetree/mapped-partition.h>
 #include <image_header.h>
 #include <rom_uuid.h>
 #include <version.h>
@@ -35,7 +37,7 @@ const T_IMG_HEADER_FORMAT img_header __attribute__((section(".image_header"))) =
 	.load_dst = 0,
 	.exe_base = (unsigned int)z_arm_reset,
 	.load_len = 0,
-	.image_base = CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET,
+	.image_base = DT_MAPPED_PARTITION_ADDR(DT_CHOSEN(zephyr_code_partition)),
 	.git_ver = {
 			.ver_info.sub_version._version_major = KERNEL_VERSION_MAJOR,
 			.ver_info.sub_version._version_minor = KERNEL_VERSION_MINOR,

--- a/soc/realtek/bee/rtl87x2g/bee_image_header.c
+++ b/soc/realtek/bee/rtl87x2g/bee_image_header.c
@@ -5,6 +5,8 @@
  */
 
 #include <stdlib.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/devicetree/mapped-partition.h>
 #include <image_info.h>
 #include <rom_uuid.h>
 #include <version.h>
@@ -36,5 +38,5 @@ const T_IMG_HEADER_FORMAT img_header __attribute__((section(".image_header"))) =
 	},
 	.uuid = DEFINE_symboltable_uuid,
 	.exe_base = (unsigned int)&z_arm_reset,
-	.image_base = CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET,
+	.image_base = DT_MAPPED_PARTITION_ADDR(DT_CHOSEN(zephyr_code_partition)),
 };


### PR DESCRIPTION
 Fixes #107737

  Migrate Realtek Bee series boards and SoC code to use the `zephyr,mapped-partition` binding as described in the migration guide.

  ## Changes

  - Replace `compatible = "fixed-partitions"` with `ranges` and add `compatible = "zephyr,mapped-partition"` to all partitions in `rtl87x2g.dtsi` and `rtl8752h.dtsi`, as well as all `rtl87x2g_evb_a` and `rtl8752h_evb` board DTS files.
  - Replace `CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET` with `DT_MAPPED_PARTITION_ADDR(DT_CHOSEN(zephyr_code_partition))` in `bee_image_header.c` for both rtl87x2g and rtl8752h SoCs, as `CONFIG_FLASH_LOAD_OFFSET` is no longer available when `zephyr,mapped-partition` is used.