### PR TITLE
Revert "drivers: regulator: npm13xx: add check for nPM1300 PMIC revis…

### DIFF
--- a/drivers/regulator/regulator_npm13xx.c
+++ b/drivers/regulator/regulator_npm13xx.c
@@ -88,11 +88,9 @@ enum npm13xx_gpio_type {
 
 #define NPM13XX_GPIO_UNUSED UINT8_MAX
 
-#define NPM1300_REV_HAS_LDO_SOFTSTART(major, minor) ((major) > 2 || ((major == 2) && (minor >= 3)))
 #define NPM1304_REV_HAS_LDO_SOFTSTART(major, minor) ((major) > 1 || ((major == 1) && (minor >= 1)))
 #define DEVICE_HAS_LDO_SOFTSTART(device, major, minor)                                             \
-	(((device) == NPM1300_DEVICE && NPM1300_REV_HAS_LDO_SOFTSTART(major, minor)) ||            \
-	 ((device) == NPM1304_DEVICE && NPM1304_REV_HAS_LDO_SOFTSTART(major, minor)))
+	((device) == NPM1304_DEVICE && NPM1304_REV_HAS_LDO_SOFTSTART(major, minor))
 
 enum npm13xx_device_variant {
 	NPM1300_DEVICE,


### PR DESCRIPTION
…ion"

LDO soft start fix will not be available in the next revision of the device but is instead pushed to a later one. The check is invalid, therefore needs to be reverted.

This reverts commit da56fe6ee0187f1104ecd8751d7debbfc8743f4f.