### PR TITLE
Bluetooth: Audio: Shell: Fix various print issues

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -32,7 +32,6 @@
 #include <zephyr/sys/atomic_types.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/clock.h>
-#include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys_clock.h>

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -349,7 +349,7 @@ static int init_lc3_encoder(struct shell_stream *sh_stream)
 				  IS_ENABLED(CONFIG_USBD_AUDIO2_CLASS) ? USB_SAMPLE_RATE : 0,
 				  &sh_stream->tx.lc3_encoder_mem);
 	if (sh_stream->tx.lc3_encoder == NULL) {
-		bt_shell_error("Failed to setup LC3 encoder - wrong parameters?\n");
+		bt_shell_error("Failed to setup LC3 encoder - wrong parameters?");
 		return -EINVAL;
 	}
 
@@ -738,7 +738,7 @@ static bool meta_data_func_cb(struct bt_data *data, void *user_data)
 	struct bt_bap_ascs_rsp *rsp = (struct bt_bap_ascs_rsp *)user_data;
 
 	if (!BT_AUDIO_METADATA_TYPE_IS_KNOWN(data->type)) {
-		printk("Invalid metadata type %u or length %u\n", data->type, data->data_len);
+		bt_shell_print("Invalid metadata type %u or length %u", data->type, data->data_len);
 		*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_METADATA_REJECTED, data->type);
 		return false;
 	}
@@ -972,7 +972,7 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 {
 	ARG_UNUSED(conn);
 
-	bt_shell_print("dir %u loc %X\n", dir, loc);
+	bt_shell_print("dir %u loc %X", dir, loc);
 }
 
 static void supported_contexts_cb(struct bt_conn *conn, enum bt_audio_context snk_ctx,
@@ -980,7 +980,7 @@ static void supported_contexts_cb(struct bt_conn *conn, enum bt_audio_context sn
 {
 	ARG_UNUSED(conn);
 
-	bt_shell_print("Supported snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+	bt_shell_print("Supported snk ctx %u src ctx %u", snk_ctx, src_ctx);
 }
 
 static void available_contexts_cb(struct bt_conn *conn,
@@ -989,7 +989,7 @@ static void available_contexts_cb(struct bt_conn *conn,
 {
 	ARG_UNUSED(conn);
 
-	bt_shell_print("Available snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+	bt_shell_print("Available snk ctx %u src ctx %u", snk_ctx, src_ctx);
 }
 
 static void config_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
@@ -2606,7 +2606,7 @@ static int init_lc3_decoder(struct shell_stream *sh_stream)
 				  IS_ENABLED(CONFIG_USBD_AUDIO2_CLASS) ? USB_SAMPLE_RATE : 0,
 				  &sh_stream->rx.lc3_decoder_mem);
 	if (sh_stream->rx.lc3_decoder == NULL) {
-		bt_shell_error("Failed to setup LC3 decoder - wrong parameters?\n");
+		bt_shell_error("Failed to setup LC3 decoder - wrong parameters?");
 		return -EINVAL;
 	}
 
@@ -2890,7 +2890,7 @@ static void stream_started_cb(struct bt_bap_stream *bap_stream)
 	struct bt_bap_ep_info info = {0};
 	int ret;
 
-	printk("Stream %p started\n", bap_stream);
+	bt_shell_print("Stream %p started", bap_stream);
 
 	ret = bt_bap_ep_get_info(bap_stream->ep, &info);
 	if (ret != 0) {
@@ -3133,7 +3133,7 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
 	struct shell_stream *sh_stream = shell_stream_from_bap_stream(stream);
 
-	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
+	bt_shell_print("Stream %p stopped with reason 0x%02X", stream, reason);
 
 	clear_stream_data(sh_stream);
 }
@@ -3144,14 +3144,14 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 {
 	ARG_UNUSED(pref);
 
-	bt_shell_print("Stream %p configured\n", stream);
+	bt_shell_print("Stream %p configured", stream);
 }
 
 static void stream_released_cb(struct bt_bap_stream *stream)
 {
 	struct shell_stream *sh_stream = shell_stream_from_bap_stream(stream);
 
-	bt_shell_print("Stream %p released\n", stream);
+	bt_shell_print("Stream %p released", stream);
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 	if (default_unicast_group.bap_group != NULL && !default_unicast_group.is_cap) {
@@ -3177,7 +3177,7 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 		if (group_can_be_deleted) {
 			int err;
 
-			bt_shell_print("All streams released, deleting group\n");
+			bt_shell_print("All streams released, deleting group");
 
 			err = bt_bap_unicast_group_delete(default_unicast_group.bap_group);
 
@@ -3312,7 +3312,7 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 
 	err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
 	if (err != 0) {
-		bt_shell_error("Unable to generate broadcast ID: %d\n", err);
+		bt_shell_error("Unable to generate broadcast ID: %d", err);
 
 		return -ENOEXEC;
 	}
@@ -3369,7 +3369,7 @@ static int cmd_start_broadcast(const struct shell *sh, size_t argc,
 
 	err = bt_le_ext_adv_get_info(adv, &adv_info);
 	if (err != 0) {
-		shell_error(sh, "Failed to get adv info: %d\n", err);
+		shell_error(sh, "Failed to get adv info: %d", err);
 		return -ENOEXEC;
 	}
 
@@ -4193,7 +4193,7 @@ static bool print_ase_info(struct bt_bap_ep *ep, void *user_data)
 
 	err = bt_bap_ep_get_info(ep, &info);
 	if (err == 0) {
-		printk("ASE info: id %u state %u dir %u\n", info.id, info.state, info.dir);
+		bt_shell_print("ASE info: id %u state %u dir %u", info.id, info.state, info.dir);
 	}
 
 	return true;
@@ -4481,7 +4481,7 @@ size_t audio_pa_data_add(struct bt_data *data_array, const size_t data_array_siz
 
 		err = bt_bap_broadcast_source_get_base(default_source.bap_source, &base_buf);
 		if (err != 0) {
-			bt_shell_error("Unable to get BASE: %d\n", err);
+			bt_shell_error("Unable to get BASE: %d", err);
 
 			return 0U;
 		}

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -29,7 +29,6 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
@@ -411,10 +410,10 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 {
 	ARG_UNUSED(conn);
 
-	printk("BIS sync request received for %p\n", recv_state);
+	bt_shell_print("BIS sync request received for %p", recv_state);
 
 	for (int i = 0; i < CONFIG_BT_BAP_BASS_MAX_SUBGROUPS; i++) {
-		printk("  [%d]: 0x%08x\n", i, bis_sync_req[i]);
+		bt_shell_print("  [%d]: 0x%08x", i, bis_sync_req[i]);
 	}
 
 	return 0;

--- a/subsys/bluetooth/audio/shell/cap_handover.c
+++ b/subsys/bluetooth/audio/shell/cap_handover.c
@@ -26,7 +26,6 @@
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -32,7 +32,6 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
@@ -1487,13 +1486,13 @@ int cap_ac_broadcast(const struct shell *sh, size_t argc, char **argv,
 
 	err = bt_le_ext_adv_get_info(adv, &adv_info);
 	if (err != 0) {
-		shell_error(sh, "Failed to get adv info: %d\n", err);
+		shell_error(sh, "Failed to get adv info: %d", err);
 		return -ENOEXEC;
 	}
 
 	err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
 	if (err != 0) {
-		bt_shell_error("Unable to generate broadcast ID: %d\n", err);
+		bt_shell_error("Unable to generate broadcast ID: %d", err);
 
 		return -ENOEXEC;
 	}
@@ -1715,7 +1714,7 @@ size_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_a
 
 		err = bt_cap_initiator_broadcast_get_base(default_source.cap_source, &base_buf);
 		if (err != 0) {
-			bt_shell_error("Unable to get BASE: %d\n", err);
+			bt_shell_error("Unable to get BASE: %d", err);
 
 			return 0U;
 		}

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -27,7 +27,6 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
-#include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
@@ -144,24 +143,23 @@ static void csip_set_coordinator_ordered_access_cb(
 	ARG_UNUSED(set_info);
 
 	if (err != 0) {
-		printk("Ordered access failed with err %d\n", err);
+		bt_shell_print("Ordered access failed with err %d", err);
 	} else if (locked) {
-		printk("Cannot do ordered access as member %p is locked\n",
-		       member);
+		bt_shell_print("Cannot do ordered access as member %p is locked", member);
 	} else {
-		printk("Ordered access procedure finished\n");
+		bt_shell_print("Ordered access procedure finished");
 	}
 }
 
 static void csip_set_coordinator_lock_changed_cb(struct bt_csip_set_coordinator_csis_inst *inst,
 						 bool locked)
 {
-	bt_shell_print("Inst %p %s\n", inst, locked ? "locked" : "released");
+	bt_shell_print("Inst %p %s", inst, locked ? "locked" : "released");
 }
 
 static void csip_set_coordinator_sirk_changed_cb(struct bt_csip_set_coordinator_csis_inst *inst)
 {
-	bt_shell_print("Inst %p SIRK changed\n", inst);
+	bt_shell_print("Inst %p SIRK changed", inst);
 	bt_shell_hexdump(inst->info.sirk, BT_CSIP_SIRK_SIZE);
 }
 
@@ -171,7 +169,7 @@ csip_set_coordinator_size_changed_cb(struct bt_conn *conn,
 {
 	ARG_UNUSED(conn);
 
-	bt_shell_print("Inst %p size changed: %u\n", inst, inst->info.set_size);
+	bt_shell_print("Inst %p size changed: %u", inst, inst->info.set_size);
 }
 
 static struct bt_csip_set_coordinator_cb cbs = {
@@ -191,7 +189,7 @@ static bool csip_set_coordinator_oap_cb(const struct bt_csip_set_coordinator_set
 	ARG_UNUSED(set_info);
 
 	for (size_t i = 0; i < count; i++) {
-		printk("Ordered access for members[%zu]: %p\n", i, members[i]);
+		bt_shell_print("Ordered access for members[%zu]: %p", i, members[i]);
 	}
 
 	return true;

--- a/subsys/bluetooth/audio/shell/mcc.c
+++ b/subsys/bluetooth/audio/shell/mcc.c
@@ -560,7 +560,7 @@ static void mcc_otc_obj_metadata_cb(struct bt_conn *conn, int err)
 		return;
 	}
 
-	bt_shell_print("Reading object metadata succeeded\n");
+	bt_shell_print("Reading object metadata succeeded");
 }
 
 static void mcc_icon_object_read_cb(struct bt_conn *conn, int err,

--- a/subsys/bluetooth/audio/shell/tbs_client.c
+++ b/subsys/bluetooth/audio/shell/tbs_client.c
@@ -21,7 +21,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/shell/shell.h>
-#include <zephyr/sys/printk.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>


### PR DESCRIPTION
Remove the use of printk, and replace with bt_shell_print Remove any excess `\n` that seem to have been leftovers from a previous fix.