### PR TITLE
manifest: tf-m-tests: do not download qcbor and t_cose when not required

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -383,7 +383,7 @@ manifest:
       groups:
         - debug
     - name: tf-m-tests
-      revision: 46b82fabd35eced75d6efbd219ccb26f1818b4d3
+      revision: 2f9d323198329cc3df0d6145ec924222cf4ae440
       path: modules/tee/tf-m/tf-m-tests
       groups:
         - testing


### PR DESCRIPTION
Include a fix that prevents downloading qcbor and t_cose libraries at build time. This solution clones what was done in the past for the tf-m repo.