### PR TITLE
ci: twister: set timeout based on event

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -133,7 +133,8 @@ jobs:
       fail-fast: false
       matrix:
         subset: ${{fromJSON(needs.twister-build-prep.outputs.subset)}}
-    timeout-minutes: 1440
+    # weekly run might take longer time, set timeout to 24 hours, for other runs set it to 2 hours
+    timeout-minutes: ${{ fromJSON(github.event_name == 'schedule' && '1440' || '120') }}
     env:
       CCACHE_DIR: /node-cache/ccache-zephyr
       CCACHE_REMOTE_STORAGE: "redis://cache-*.keydb-cache.svc.cluster.local|shards=1,2,3"


### PR DESCRIPTION
Weekly run requires more time, but the same timeout value was used for
push runs and PRs, if something goes wrong, runners will go for an
extended period of time waiting to timeout blocking all of CI, so
timeout early to expose any issues.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
