### PR TITLE
bluetooth: classic: l2cap: Add headroom check in bt_l2cap_br_send_cb

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -850,6 +850,14 @@ int bt_l2cap_br_send_cb(struct bt_conn *conn, uint16_t cid, struct net_buf *buf,
 
 	LOG_DBG("chan %p buf %p len %u", br_chan, buf, buf->len);
 
+	if (net_buf_headroom(buf) < BT_L2CAP_CHAN_SEND_RESERVE) {
+		/* Call `net_buf_reserve(buf, BT_L2CAP_CHAN_SEND_RESERVE)`
+		 * when allocating buffers intended for bt_l2cap_chan_send().
+		 */
+		LOG_ERR("Not enough headroom in buf %p", buf);
+		return -EINVAL;
+	}
+
 #if defined(CONFIG_BT_L2CAP_RET_FC)
 	if (br_chan->tx.mode == BT_L2CAP_BR_LINK_MODE_BASIC) {
 		hdr = net_buf_push(buf, sizeof(*hdr));


### PR DESCRIPTION
Add a check to validate that the buffer has sufficient headroom (BT_L2CAP_CHAN_SEND_RESERVE) before attempting to send data over a classic L2CAP channel.

Without this validation, buffers allocated with insufficient headroom could cause buffer corruption when `net_buf_push()` is called to add the L2CAP header. In the case, the application will be asserted if the assert is enabled.

The change ensures that callers properly reserve headroom when allocating buffers for `bt_l2cap_chan_send()`.