### PR TITLE
drivers: i2c: don't check num_msgs again

### DIFF
--- a/drivers/i2c/i2c_ambiq.c
+++ b/drivers/i2c/i2c_ambiq.c
@@ -245,10 +245,6 @@ static int i2c_ambiq_transfer(const struct device *dev, struct i2c_msg *msgs, ui
 	struct i2c_ambiq_data *data = dev->data;
 	int ret = 0;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	i2c_ambiq_pm_policy_state_lock_get(dev);
 
 	/* Send out messages */

--- a/drivers/i2c/i2c_bee.c
+++ b/drivers/i2c/i2c_bee.c
@@ -202,10 +202,6 @@ static int i2c_bee_transfer(const struct device *dev, struct i2c_msg *msgs, uint
 	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
 	int ret = 0;
 
-	if (num_msgs == 0U) {
-		return 0;
-	}
-
 	k_mutex_lock(&data->bus_mutex, K_FOREVER);
 
 	data->ctx.msgs = msgs;

--- a/drivers/i2c/i2c_bflb.c
+++ b/drivers/i2c/i2c_bflb.c
@@ -645,10 +645,6 @@ static int i2c_bflb_transfer(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (num_msgs == 0) {
-		return 0;
-	}
-
 	ret = k_mutex_lock(&data->lock, K_FOREVER);
 	if (ret < 0) {
 		return ret;

--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -210,10 +210,6 @@ int i2c_bitbang_transfer(struct i2c_bitbang *context,
 	unsigned int flags;
 	int result = -EIO;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	/* We want an initial Start condition */
 	flags = I2C_MSG_RESTART;
 

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -120,10 +120,6 @@ static int i2c_cc13xx_cc26xx_transfer(const struct device *dev, struct i2c_msg *
 	struct i2c_cc13xx_cc26xx_data *data = dev->data;
 	int ret = 0;
 
-	if (num_msgs == 0) {
-		return 0;
-	}
-
 	/* Always a start condition in the first message */
 	msgs[0].flags |= I2C_MSG_RESTART;
 

--- a/drivers/i2c/i2c_cc23x0.c
+++ b/drivers/i2c/i2c_cc23x0.c
@@ -179,10 +179,6 @@ static int i2c_cc23x0_transfer(const struct device *dev, struct i2c_msg *msgs, u
 	const struct i2c_cc23x0_config *config = dev->config;
 	int ret = 0;
 
-	if (num_msgs == 0) {
-		return 0;
-	}
-
 	k_sem_take(&data->lock, K_FOREVER);
 
 	i2c_cc23x0_pm_policy_state_lock_get();

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -843,9 +843,6 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 	uint32_t value = 0;
 
 	__ASSERT_NO_MSG(msgs);
-	if (!num_msgs) {
-		return 0;
-	}
 
 	/* semaphore to support I2C_CALLBACK */
 	ret = k_sem_take(&dw->bus_sem, K_FOREVER);

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -640,10 +640,6 @@ static int IRAM_ATTR i2c_esp32_transfer(const struct device *dev, struct i2c_msg
 	uint32_t timeout = I2C_TRANSFER_TIMEOUT_MSEC * USEC_PER_MSEC;
 	int ret = 0;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	while (i2c_ll_is_bus_busy(data->hal.dev)) {
 		k_busy_wait(1);
 		if (timeout-- == 0) {

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -94,10 +94,6 @@ static int i2c_gecko_transfer(const struct device *dev, struct i2c_msg *msgs, ui
 	I2C_TransferReturn_TypeDef ret = -EIO;
 	uint32_t timeout = 300000U;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	k_sem_take(&data->bus_lock, K_FOREVER);
 
 	seq.addr = addr << 1;

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -194,10 +194,6 @@ static int i2c_imx_transfer(const struct device *dev, struct i2c_msg *msgs,
 	uint16_t timeout = UINT16_MAX;
 	int result = -EIO;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	/* Wait until bus not busy */
 	while ((I2C_I2SR_REG(base) & i2cStatusBusBusy) && (--timeout)) {
 	}

--- a/drivers/i2c/i2c_infineon.c
+++ b/drivers/i2c/i2c_infineon.c
@@ -260,10 +260,6 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 	cy_rslt_t rslt = CY_RSLT_SUCCESS;
 	int ret;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	/* Acquire semaphore (block I2C transfer for another thread) */
 	ret = k_sem_take(&data->operation_sem, K_FOREVER);
 	if (ret) {

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -611,10 +611,6 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 	struct ifx_cat1_i2c_data *data = dev->data;
 	int ret;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	/* Acquire semaphore (block I2C transfer for another thread) */
 	ret = k_sem_take(&data->operation_sem, K_FOREVER);
 	if (ret < 0) {

--- a/drivers/i2c/i2c_infineon_xmc4.c
+++ b/drivers/i2c/i2c_infineon_xmc4.c
@@ -165,10 +165,6 @@ static int ifx_xmc4_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 	const struct ifx_xmc4_i2c_config *config = dev->config;
 	XMC_I2C_CH_CMD_t cmd_type;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	if (!data->is_configured) {
 		int ret;
 		uint32_t bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);

--- a/drivers/i2c/i2c_lpc11u6x.c
+++ b/drivers/i2c/i2c_lpc11u6x.c
@@ -79,10 +79,6 @@ static int lpc11u6x_i2c_transfer(const struct device *dev,
 	struct lpc11u6x_i2c_data *data = dev->data;
 	int ret = 0;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	k_mutex_lock(&data->mutex, K_FOREVER);
 
 	data->transfer.msgs = msgs;

--- a/drivers/i2c/i2c_mchp_sercom_g1.c
+++ b/drivers/i2c/i2c_mchp_sercom_g1.c
@@ -493,7 +493,7 @@ static void i2c_handle_error(const struct device *dev, int error_status)
 /* Validates I2C message array and sets RESTART flags */
 static int i2c_validate_msgs(struct i2c_msg *msgs, uint8_t num_msgs)
 {
-	if ((msgs == NULL) || (num_msgs == 0)) {
+	if (msgs == NULL) {
 		return -EINVAL;
 	}
 

--- a/drivers/i2c/i2c_numaker.c
+++ b/drivers/i2c/i2c_numaker.c
@@ -350,10 +350,6 @@ static int i2c_numaker_transfer(const struct device *dev, struct i2c_msg *msgs, 
 	}
 #endif
 
-	if (num_msgs == 0) {
-		goto cleanup;
-	}
-
 	/* Prepare to start transfer */
 	data->master_xfer.addr = addr;
 	data->master_xfer.msgs_beg = msgs;
@@ -395,9 +391,9 @@ i2c_stop:
 	if (data->slave_xfer.slave_config) {
 		I2C_SET_CONTROL_REG(i2c_base, I2C_CTL0_SI_Msk | I2C_CTL0_AA_Msk);
 	}
-#endif
 
 cleanup:
+#endif
 
 	irq_enable(config->irq_n);
 	k_sem_give(&data->lock);

--- a/drivers/i2c/i2c_rcar.c
+++ b/drivers/i2c/i2c_rcar.c
@@ -215,10 +215,6 @@ static int i2c_rcar_transfer(const struct device *dev,
 	uint16_t timeout = 0;
 	int ret;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	/* Wait for the bus to be available */
 	while ((i2c_rcar_read(config, RCAR_I2C_ICMCR) & RCAR_I2C_ICMCR_FSDA) && (timeout < 10)) {
 		k_busy_wait(USEC_PER_MSEC);

--- a/drivers/i2c/i2c_renesas_ra_iic.c
+++ b/drivers/i2c/i2c_renesas_ra_iic.c
@@ -174,10 +174,6 @@ static int i2c_ra_iic_transfer(const struct device *dev, struct i2c_msg *msgs, u
 	fsp_err_t fsp_err = FSP_SUCCESS;
 	int ret = 0;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	/* Check for validity of all messages before transfer */
 	current = msgs;
 

--- a/drivers/i2c/i2c_renesas_ra_sci.c
+++ b/drivers/i2c/i2c_renesas_ra_sci.c
@@ -150,10 +150,6 @@ static int renesas_ra_sci_i2c_transfer(const struct device *dev, struct i2c_msg 
 	struct i2c_msg tmp_msg;
 	uint16_t tmp_len;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	/* Handle i2c burst write, restructure message to be compatible with HAL*/
 	if (num_msgs == 2) {
 		if (msgs[0].len == 1U && !(msgs[0].flags & I2C_MSG_READ) &&

--- a/drivers/i2c/i2c_renesas_ra_sci_b.c
+++ b/drivers/i2c/i2c_renesas_ra_sci_b.c
@@ -130,10 +130,6 @@ static int renesas_ra_sci_b_i2c_transfer(const struct device *dev, struct i2c_ms
 	struct i2c_msg tmp_msg;
 	uint16_t tmp_len;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	/* Handle i2c burst write, restructure message to be compatible with HAL*/
 	if (num_msgs == 2) {
 		if (msgs[0].len == 1U && !(msgs[0].flags & I2C_MSG_READ) &&

--- a/drivers/i2c/i2c_renesas_rz_riic.c
+++ b/drivers/i2c/i2c_renesas_rz_riic.c
@@ -225,10 +225,6 @@ static int i2c_rz_riic_transfer(const struct device *dev, struct i2c_msg *msgs, 
 	fsp_err_t err;
 	int ret = 0;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	/* Check for validity of all messages before transfer */
 	current = msgs;
 

--- a/drivers/i2c/i2c_renesas_rza2m_riic.c
+++ b/drivers/i2c/i2c_renesas_rza2m_riic.c
@@ -331,10 +331,6 @@ static int i2c_rza2m_riic_validate_msgs(const struct device *dev, struct i2c_msg
 {
 	struct i2c_msg *current, *next;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	current = msgs;
 	current->flags |= I2C_MSG_RESTART;
 	for (int i = 1; i <= num_msgs; i++) {
@@ -416,10 +412,6 @@ static int i2c_rza2m_riic_transfer(const struct device *dev, struct i2c_msg *msg
 {
 	struct i2c_rza2m_riic_data *data = dev->data;
 	int ret = 0;
-
-	if (!num_msgs) {
-		return 0;
-	}
 
 	ret = i2c_rza2m_riic_validate_msgs(dev, msgs, num_msgs);
 	if (ret) {

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -414,10 +414,6 @@ static int i2c_sam0_transfer(const struct device *dev, struct i2c_msg *msgs,
 	uint32_t addr_reg;
 	int ret;
 
-	if (!num_msgs) {
-		return 0;
-	}
-
 	k_sem_take(&data->lock, K_FOREVER);
 
 	data->num_msgs = num_msgs;

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -209,9 +209,7 @@ static int i2c_sam_twi_transfer(const struct device *dev,
 	int ret;
 
 	__ASSERT_NO_MSG(msgs);
-	if (!num_msgs) {
-		return 0;
-	}
+
 	k_sem_take(&dev_data->lock, K_FOREVER);
 
 	/* Clear pending interrupts, such as NACK. */

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -196,9 +196,7 @@ static int i2c_sam_twihs_transfer(const struct device *dev,
 	int ret;
 
 	__ASSERT_NO_MSG(msgs);
-	if (!num_msgs) {
-		return 0;
-	}
+
 	k_sem_take(&dev_data->lock, K_FOREVER);
 
 	/* Clear pending interrupts, such as NACK. */

--- a/drivers/i2c/i2c_sc18im704.c
+++ b/drivers/i2c/i2c_sc18im704.c
@@ -196,10 +196,6 @@ static int i2c_sc18im_transfer(const struct device *dev,
 {
 	int ret;
 
-	if (num_msgs == 0) {
-		return 0;
-	}
-
 	ret = sc18im704_claim(dev);
 	if (ret < 0) {
 		LOG_ERR("Failed to claim I2C bridge (%d)", ret);

--- a/drivers/i2c/i2c_sedi.c
+++ b/drivers/i2c/i2c_sedi.c
@@ -83,9 +83,6 @@ static int i2c_sedi_api_full_io(const struct device *dev, struct i2c_msg *msgs, 
 	int ret = 0;
 	struct i2c_sedi_context *context = dev->data;
 
-	if (!num_msgs) {
-		return 0;
-	}
 	__ASSERT_NO_MSG(msgs);
 
 	k_mutex_lock(context->mutex, K_FOREVER);

--- a/drivers/i2c/i2c_silabs.c
+++ b/drivers/i2c/i2c_silabs.c
@@ -421,11 +421,6 @@ static int i2c_silabs_transfer_impl(const struct device *dev, struct i2c_msg *ms
 	struct i2c_silabs_dev_data *data = dev->data;
 	int ret = -EINVAL; /* Initialize ret to a default error value */
 
-	/* Check for invalid number of messages */
-	if (!num_msgs) {
-		return -EINVAL;
-	}
-
 	/* Check and set the address mode (7-bit or 10-bit) based on */
 	/* the provided address */
 	if (addr <= 0x7F) {

--- a/drivers/i2c/i2c_sy1xx.c
+++ b/drivers/i2c/i2c_sy1xx.c
@@ -349,10 +349,6 @@ static int sy1xx_i2c_transfer(const struct device *dev, struct i2c_msg *msgs, ui
 	struct sy1xx_i2c_dev_data *const data = dev->data;
 	int ret;
 
-	if (num_msgs == 0) {
-		return 0;
-	}
-
 	k_sem_take(&data->lock, K_FOREVER);
 
 	if (data->error_active) {

--- a/drivers/i2c/i2c_xilinx_axi.c
+++ b/drivers/i2c/i2c_xilinx_axi.c
@@ -557,10 +557,6 @@ static int i2c_xilinx_axi_transfer(const struct device *dev, struct i2c_msg *msg
 		goto out_unlock;
 	}
 
-	if (!num_msgs) {
-		goto out_unlock;
-	}
-
 	/**
 	 * Reinitializing before each transfer shouldn't technically be needed, but
 	 * seems to improve general reliability. The Linux driver also does this.

--- a/drivers/i3c/i3cm_it51xxx.c
+++ b/drivers/i3c/i3cm_it51xxx.c
@@ -632,10 +632,6 @@ static int it51xxx_i3cm_i2c_api_transfer(const struct device *dev, struct i2c_ms
 		return -EINVAL;
 	}
 
-	if (num_msgs == 0) {
-		return 0;
-	}
-
 	for (uint8_t i = 0; i < num_msgs; i++) {
 		if (!msgs[i].buf) {
 			return -EINVAL;
@@ -927,10 +923,6 @@ static int it51xxx_i3cm_transfer(const struct device *dev, struct i3c_device_des
 
 	if (!msgs || target->dynamic_addr == 0U) {
 		return -EINVAL;
-	}
-
-	if (num_msgs == 0) {
-		return 0;
 	}
 
 	for (uint8_t i = 0; i < num_msgs; i++) {


### PR DESCRIPTION
We already check num_msgs in i2c_transfer, we
don:t need to check it in the i2c drivers again.

see
https://github.com/zephyrproject-rtos/zephyr/blob/80d912150df5840950b59dc4433158ac4ddbc5b3/include/zephyr/drivers/i2c.h#L897-L907

https://github.com/zephyrproject-rtos/zephyr/blob/80d912150df5840950b59dc4433158ac4ddbc5b3/include/zephyr/drivers/i2c.h#L948-L964