### PR TITLE
drivers: ramdisk: add MMU support for ramdisk mapping

### DIFF
--- a/drivers/disk/ramdisk.c
+++ b/drivers/disk/ramdisk.c
@@ -16,10 +16,7 @@
 LOG_MODULE_REGISTER(ramdisk, CONFIG_RAMDISK_LOG_LEVEL);
 
 struct ram_disk_data {
-	struct disk_info info;
-	const size_t sector_size;
-	const size_t sector_count;
-	uint8_t *const buf;
+	struct disk_info *info;
 };
 
 struct ram_disk_config {
@@ -128,7 +125,8 @@ static int disk_ram_access_init(struct disk_info *disk)
 
 static int disk_ram_init(const struct device *dev)
 {
-	struct disk_info *info = dev->data;
+	struct ram_disk_data *data = dev->data;
+	struct disk_info *info = data->info;
 
 	info->dev = dev;
 
@@ -184,10 +182,14 @@ static const struct disk_operations ram_disk_ops = {
 		.ops = &ram_disk_ops,							\
 	};										\
 											\
+	static struct ram_disk_data ram_disk_data_##n = {				\
+		.info = &disk_info_##n,							\
+	};										\
+											\
 	RAMDISK_DEVICE_CONFIG_DEFINE(n);						\
 											\
 	DEVICE_DT_INST_DEFINE(n, disk_ram_init, NULL,					\
-			      &disk_info_##n, &disk_config_##n,				\
+			      &ram_disk_data_##n, &disk_config_##n,			\
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			      &ram_disk_ops);
 

--- a/drivers/disk/ramdisk.c
+++ b/drivers/disk/ramdisk.c
@@ -17,6 +17,9 @@ LOG_MODULE_REGISTER(ramdisk, CONFIG_RAMDISK_LOG_LEVEL);
 
 struct ram_disk_data {
 	struct disk_info *info;
+#if defined(CONFIG_MMU)
+	uint8_t *ramdisk_buf;
+#endif
 };
 
 struct ram_disk_config {
@@ -26,11 +29,29 @@ struct ram_disk_config {
 	uint8_t *const buf;
 };
 
+#if defined(CONFIG_MMU)
+static uint8_t *disk_ram_external_map(const struct ram_disk_config *conf)
+{
+	uint8_t *virt_start;
+
+	k_mem_map_phys_bare(&virt_start, POINTER_TO_UINT(conf->buf),
+				conf->size, K_MEM_CACHE_WB | K_MEM_PERM_RW);
+
+	return virt_start;
+}
+#endif
+
 static void *lba_to_address(const struct device *dev, uint32_t lba)
 {
 	const struct ram_disk_config *config = dev->config;
+#if defined(CONFIG_MMU)
+	struct ram_disk_data *data = dev->data;
+	uint8_t *ramdisk_buf = data->ramdisk_buf;
+#else
+	uint8_t *ramdisk_buf = config->buf;
+#endif
 
-	return &config->buf[lba * config->sector_size];
+	return &ramdisk_buf[lba * config->sector_size];
 }
 
 static int disk_ram_access_status(struct disk_info *disk)
@@ -130,6 +151,11 @@ static int disk_ram_init(const struct device *dev)
 
 	info->dev = dev;
 
+#if defined(CONFIG_MMU)
+	const struct ram_disk_config *config = dev->config;
+
+	data->ramdisk_buf = disk_ram_external_map(config);
+#endif
 	return disk_access_register(info);
 }
 


### PR DESCRIPTION
Ramdisk access fails with data abort when MMU is enabled, due to using a physical address for the buffer instead of a mapped virtual address.

Add support for MMU configurations by mapping the ramdisk buffer to a virtual address space and updating all accesses to use this virtual address.

With MMU disabled, the ramdisk continues to use
the original physical addressing as before. This change retains backward compatibility and only affects builds where CONFIG_MMU is enabled.