### PR TITLE
ADIS1647x driver support

### DIFF
--- a/drivers/sensor/adi/CMakeLists.txt
+++ b/drivers/sensor/adi/CMakeLists.txt
@@ -4,6 +4,7 @@
 # zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_AD2S1210 ad2s1210)
 add_subdirectory_ifdef(CONFIG_ADE7978 ade7978)
+add_subdirectory_ifdef(CONFIG_ADIS1647X adis1647x)
 add_subdirectory_ifdef(CONFIG_ADLTC2990 adltc2990)
 add_subdirectory_ifdef(CONFIG_ADT7310 adt7310)
 add_subdirectory_ifdef(CONFIG_ADT7420 adt7420)

--- a/drivers/sensor/adi/Kconfig
+++ b/drivers/sensor/adi/Kconfig
@@ -4,6 +4,7 @@
 # zephyr-keep-sorted-start
 source "drivers/sensor/adi/ad2s1210/Kconfig"
 source "drivers/sensor/adi/ade7978/Kconfig"
+source "drivers/sensor/adi/adis1647x/Kconfig"
 source "drivers/sensor/adi/adltc2990/Kconfig"
 source "drivers/sensor/adi/adt7310/Kconfig"
 source "drivers/sensor/adi/adt7420/Kconfig"

--- a/drivers/sensor/adi/adis1647x/CMakeLists.txt
+++ b/drivers/sensor/adi/adis1647x/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(adis1647x.c)
+zephyr_library_sources(adis1647x_decoder.c)
+zephyr_library_sources(adis1647x_spi.c)
+zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API adis1647x_rtio.c)
+zephyr_library_sources_ifdef(CONFIG_ADIS1647X_TRIGGER adis1647x_trigger.c)
+zephyr_library_sources_ifdef(CONFIG_ADIS1647X_STREAM adis1647x_stream.c)

--- a/drivers/sensor/adi/adis1647x/Kconfig
+++ b/drivers/sensor/adi/adis1647x/Kconfig
@@ -1,0 +1,70 @@
+# ADIS1647x, 6-DoF MEMS IMU
+
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig ADIS1647X
+	bool "ADIS1647x 6-DoF MEMS IMU"
+	default y
+	depends on DT_HAS_ADI_ADIS1647X_ENABLED
+	select SPI
+	select SPI_RTIO if SENSOR_ASYNC_API
+	select RTIO if SENSOR_ASYNC_API
+	help
+	  Enable driver for ADIS1647x 6-DoF MEMS IMU.
+
+if ADIS1647X
+
+choice ADIS1647X_TRIGGER_MODE
+	prompt "Trigger mode"
+	default ADIS1647X_TRIGGER_NONE
+	help
+	  Specify the type of triggering used by the driver.
+
+config ADIS1647X_TRIGGER_NONE
+	bool "No trigger"
+
+config ADIS1647X_TRIGGER_GLOBAL_THREAD
+	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADIS1647X),drdy-gpios)
+	select ADIS1647X_TRIGGER
+
+config ADIS1647X_TRIGGER_OWN_THREAD
+	bool "Use own thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADIS1647X),drdy-gpios)
+	select ADIS1647X_TRIGGER
+
+endchoice
+
+config ADIS1647X_STREAM
+	bool "Stream IMU data via RTIO"
+	depends on SPI_RTIO
+	depends on SENSOR_ASYNC_API
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADIS1647X),drdy-gpios)
+	depends on ADIS1647X_TRIGGER_GLOBAL_THREAD || ADIS1647X_TRIGGER_OWN_THREAD
+	select ADIS1647X_TRIGGER
+	help
+	  Use this configuration option to enable streaming sensor data via RTIO
+	  on the DRDY interrupt. Requires SPI_RTIO, a drdy-gpios pin in
+	  devicetree, and a trigger thread mode selected.
+
+config ADIS1647X_TRIGGER
+	bool
+
+config ADIS1647X_THREAD_PRIORITY
+	int "Thread priority"
+	depends on ADIS1647X_TRIGGER_OWN_THREAD && ADIS1647X_TRIGGER
+	default 10
+	help
+	  Priority of thread used by the driver to handle interrupts.
+
+config ADIS1647X_THREAD_STACK_SIZE
+	int "Thread stack size"
+	depends on ADIS1647X_TRIGGER_OWN_THREAD && ADIS1647X_TRIGGER
+	default 1024
+	help
+	  Stack size of thread used by the driver to handle interrupts.
+
+endif # ADIS1647X

--- a/drivers/sensor/adi/adis1647x/adis1647x.c
+++ b/drivers/sensor/adi/adis1647x/adis1647x.c
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <stddef.h>
+
+#include "adis1647x.h"
+
+LOG_MODULE_REGISTER(adis1647x, CONFIG_SENSOR_LOG_LEVEL);
+
+#define DT_DRV_COMPAT adi_adis1647x
+
+int adis1647x_verify_burst(const struct adis1647x_burst_data *b)
+{
+	/* Verify checksum: sum of all bytes from diag_stat to data_cntr */
+	uint16_t sum = 0;
+	const uint8_t *base = (const uint8_t *)b;
+	const size_t start = offsetof(struct adis1647x_burst_data, diag_stat);
+	const size_t end = offsetof(struct adis1647x_burst_data, spi_chksum);
+
+	for (size_t i = start; i < end; i++) {
+		sum += base[i];
+	}
+	if (sum != sys_be16_to_cpu(b->spi_chksum)) {
+		LOG_ERR("Checksum mismatch: calc=0x%04X recv=0x%04X", sum,
+			sys_be16_to_cpu(b->spi_chksum));
+		return -EIO;
+	}
+
+	/* DIAG_STAT register logs hardware faults */
+	uint16_t diag = sys_be16_to_cpu(b->diag_stat);
+
+	if (diag != 0) {
+		LOG_ERR("DIAG_STAT: 0x%04X", diag);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+int adis1647x_get_data(const struct device *dev, struct adis1647x_sample_data *sample_data)
+{
+	struct adis1647x_data *device_data = dev->data;
+
+	sample_data->accel_scale_num = device_data->accel_scale_num;
+	sample_data->gyro_scale_num = device_data->gyro_scale_num;
+
+	int ret = adis1647x_burst_read(dev, &sample_data->burst_data);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	return adis1647x_verify_burst(&sample_data->burst_data);
+}
+
+static int adis1647x_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	ARG_UNUSED(chan);
+
+	struct adis1647x_data *data = dev->data;
+	struct adis1647x_sample_data sample = {0};
+	int ret;
+
+	ret = adis1647x_get_data(dev, &sample);
+	if (ret != 0) {
+		return ret;
+	}
+
+	data->gyro_x = (int16_t)sys_be16_to_cpu(sample.burst_data.x_gyro_out);
+	data->gyro_y = (int16_t)sys_be16_to_cpu(sample.burst_data.y_gyro_out);
+	data->gyro_z = (int16_t)sys_be16_to_cpu(sample.burst_data.z_gyro_out);
+	data->accel_x = (int16_t)sys_be16_to_cpu(sample.burst_data.x_accel_out);
+	data->accel_y = (int16_t)sys_be16_to_cpu(sample.burst_data.y_accel_out);
+	data->accel_z = (int16_t)sys_be16_to_cpu(sample.burst_data.z_accel_out);
+	data->temp = (int16_t)sys_be16_to_cpu(sample.burst_data.temp_out);
+
+	return 0;
+}
+
+static int adis1647x_channel_get(const struct device *dev, enum sensor_channel chan,
+				 struct sensor_value *val)
+{
+	struct adis1647x_data *data = dev->data;
+
+	switch (chan) {
+	case SENSOR_CHAN_ACCEL_X:
+		adis1647x_accel_convert(val, data->accel_x, data->accel_scale_num);
+		break;
+	case SENSOR_CHAN_ACCEL_Y:
+		adis1647x_accel_convert(val, data->accel_y, data->accel_scale_num);
+		break;
+	case SENSOR_CHAN_ACCEL_Z:
+		adis1647x_accel_convert(val, data->accel_z, data->accel_scale_num);
+		break;
+	case SENSOR_CHAN_ACCEL_XYZ:
+		adis1647x_accel_convert(val++, data->accel_x, data->accel_scale_num);
+		adis1647x_accel_convert(val++, data->accel_y, data->accel_scale_num);
+		adis1647x_accel_convert(val, data->accel_z, data->accel_scale_num);
+		break;
+	case SENSOR_CHAN_GYRO_X:
+		adis1647x_gyro_convert(val, data->gyro_x, data->gyro_scale_num);
+		break;
+	case SENSOR_CHAN_GYRO_Y:
+		adis1647x_gyro_convert(val, data->gyro_y, data->gyro_scale_num);
+		break;
+	case SENSOR_CHAN_GYRO_Z:
+		adis1647x_gyro_convert(val, data->gyro_z, data->gyro_scale_num);
+		break;
+	case SENSOR_CHAN_GYRO_XYZ:
+		adis1647x_gyro_convert(val++, data->gyro_x, data->gyro_scale_num);
+		adis1647x_gyro_convert(val++, data->gyro_y, data->gyro_scale_num);
+		adis1647x_gyro_convert(val, data->gyro_z, data->gyro_scale_num);
+		break;
+	case SENSOR_CHAN_DIE_TEMP: {
+		int64_t micro_celsius = (int64_t)data->temp * 100000;
+
+		val->val1 = (int32_t)(micro_celsius / 1000000);
+		val->val2 = (int32_t)(micro_celsius % 1000000);
+		break;
+	}
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(sensor, adis1647x_api) = {
+	.sample_fetch = adis1647x_sample_fetch,
+	.channel_get = adis1647x_channel_get,
+	.get_decoder = adis1647x_get_decoder,
+#ifdef CONFIG_SENSOR_ASYNC_API
+	.submit = adis1647x_submit,
+#endif
+#ifdef CONFIG_ADIS1647X_TRIGGER
+	.trigger_set = adis1647x_trigger_set,
+#endif
+};
+
+/* Order must match the enum in adi,adis1647x.yaml */
+static const struct adis1647x_model_cfg adis1647x_model_table[] = {
+	[ADIS1647X_MODEL_ADIS16470] = {.accel_scale_num = 125,
+				       .gyro_scale_num = 10000,
+				       .prod_id = 0x4056,
+				       .rang_mdl = 0x03},
+	[ADIS1647X_MODEL_ADIS16475_1] = {.accel_scale_num = 25,
+					 .gyro_scale_num = 625,
+					 .prod_id = 0x405B,
+					 .rang_mdl = 0x00},
+	[ADIS1647X_MODEL_ADIS16475_2] = {.accel_scale_num = 25,
+					 .gyro_scale_num = 2500,
+					 .prod_id = 0x405B,
+					 .rang_mdl = 0x01},
+	[ADIS1647X_MODEL_ADIS16475_3] = {.accel_scale_num = 25,
+					 .gyro_scale_num = 10000,
+					 .prod_id = 0x405B,
+					 .rang_mdl = 0x03},
+	[ADIS1647X_MODEL_ADIS16477_1] = {.accel_scale_num = 125,
+					 .gyro_scale_num = 625,
+					 .prod_id = 0x405D,
+					 .rang_mdl = 0x00},
+	[ADIS1647X_MODEL_ADIS16477_2] = {.accel_scale_num = 125,
+					 .gyro_scale_num = 2500,
+					 .prod_id = 0x405D,
+					 .rang_mdl = 0x01},
+	[ADIS1647X_MODEL_ADIS16477_3] = {.accel_scale_num = 125,
+					 .gyro_scale_num = 10000,
+					 .prod_id = 0x405D,
+					 .rang_mdl = 0x03},
+};
+
+static int adis1647x_init(const struct device *dev)
+{
+	const struct adis1647x_config *cfg = dev->config;
+	struct adis1647x_data *data = dev->data;
+	int ret;
+
+	if (!spi_is_ready_dt(&cfg->spi)) {
+		LOG_ERR_DEVICE_NOT_READY(cfg->spi.bus);
+		return -ENODEV;
+	}
+
+	/* Hardware reset if pin is wired */
+	if (cfg->reset.port != NULL) {
+		ret = gpio_pin_configure_dt(&cfg->reset, GPIO_OUTPUT_INACTIVE);
+		if (ret < 0) {
+			LOG_ERR("Failed to configure reset GPIO: %d", ret);
+			return ret;
+		}
+		gpio_pin_set_dt(&cfg->reset, 1);
+		k_msleep(ADIS1647X_HW_RESET_PULSE_MS);
+		gpio_pin_set_dt(&cfg->reset, 0);
+		k_msleep(ADIS1647X_HW_RESET_WAIT_MS);
+	}
+
+	ret = adis1647x_reg_write_no_verify(dev, ADIS1647X_REG_GLOBAL_CMD,
+					    ADIS1647X_REG_GLOBAL_CMD_SW_RESET);
+	if (ret != 0) {
+		LOG_ERR("Failed to send SW reset: %d", ret);
+		return ret;
+	}
+	k_sleep(K_MSEC(ADIS1647X_SW_RESET_MS));
+
+	const struct adis1647x_model_cfg *mcfg = &adis1647x_model_table[cfg->model_idx];
+
+	uint16_t prod_id;
+
+	ret = adis1647x_reg_read(dev, ADIS1647X_REG_PROD_ID, &prod_id);
+	if (ret != 0) {
+		LOG_ERR("Failed to read PROD_ID: %d", ret);
+		return ret;
+	}
+	if (prod_id != mcfg->prod_id) {
+		LOG_ERR("PROD_ID mismatch: expected 0x%04X got 0x%04X", mcfg->prod_id, prod_id);
+		return -ENODEV;
+	}
+
+	uint16_t rang_mdl_reg;
+
+	ret = adis1647x_reg_read(dev, ADIS1647X_REG_RANG_MDL, &rang_mdl_reg);
+	if (ret != 0) {
+		LOG_ERR("Failed to read RANG_MDL: %d", ret);
+		return ret;
+	}
+	if (((rang_mdl_reg >> 2) & 0x03) != mcfg->rang_mdl) {
+		LOG_ERR("RANG_MDL mismatch: expected 0x%02X got 0x%02X", mcfg->rang_mdl,
+			(rang_mdl_reg >> 2) & 0x03);
+		return -ENODEV;
+	}
+
+	LOG_INF("Device validated: PROD_ID=0x%04X RANG_MDL=0x%02X", prod_id, mcfg->rang_mdl);
+
+	data->accel_scale_num = mcfg->accel_scale_num;
+	data->gyro_scale_num = mcfg->gyro_scale_num;
+
+	uint16_t firm_rev;
+
+	ret = adis1647x_reg_read(dev, ADIS1647X_REG_FIRM_REV, &firm_rev);
+	if (ret == 0) {
+		LOG_INF("Firmware revision: %d.%d", (firm_rev >> 8) & 0xFF, firm_rev & 0xFF);
+	}
+
+	ret = adis1647x_reg_write(dev, ADIS1647X_REG_MSC_CTRL, ADIS1647X_REG_MSC_CTRL_DEFAULT);
+	if (ret != 0) {
+		return ret;
+	}
+
+	k_busy_wait(ADIS1647X_SPI_STALL_US);
+
+	ret = adis1647x_reg_write(dev, ADIS1647X_REG_DEC_RATE, cfg->dec_rate);
+	if (ret != 0) {
+		LOG_ERR("Failed to write decimation rate");
+		return ret;
+	}
+
+#ifdef CONFIG_ADIS1647X_TRIGGER
+	ret = adis1647x_init_interrupt(dev);
+	if (ret != 0) {
+		return ret;
+	}
+#endif
+
+	LOG_INF("initialized: accel_scale_num=%u, gyro_scale_num=%u", data->accel_scale_num,
+		data->gyro_scale_num);
+
+	return 0;
+}
+
+#define ADIS1647X_SPI_CFG                                                                          \
+	(SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_MODE_CPOL | SPI_MODE_CPHA)
+
+#ifdef CONFIG_SENSOR_ASYNC_API
+#define ADIS1647X_RTIO_DEFINE(inst)                                                                \
+	SPI_DT_IODEV_DEFINE(adis1647x_iodev_##inst, DT_DRV_INST(inst), ADIS1647X_SPI_CFG);         \
+	RTIO_DEFINE(adis1647x_rtio_ctx_##inst, 8, 8);
+
+#define ADIS1647X_RTIO_INIT(inst)                                                                  \
+	.rtio_ctx = &adis1647x_rtio_ctx_##inst,                                                    \
+	.iodev = &adis1647x_iodev_##inst,
+#else
+#define ADIS1647X_RTIO_DEFINE(inst)
+#define ADIS1647X_RTIO_INIT(inst)
+#endif /* CONFIG_SENSOR_ASYNC_API */
+
+#define ADIS1647X_DEFINE(inst)                                                                     \
+	ADIS1647X_RTIO_DEFINE(inst);                                                               \
+	static struct adis1647x_data adis1647x_data_##inst = {                                     \
+		ADIS1647X_RTIO_INIT(inst)                                                          \
+	};                                                                                        \
+	static const struct adis1647x_config adis1647x_config_##inst = {                           \
+		.model_idx = DT_INST_ENUM_IDX(inst, model),                                        \
+		.dec_rate = DT_INST_PROP(inst, dec_rate),                                          \
+		.spi = SPI_DT_SPEC_INST_GET(inst, ADIS1647X_SPI_CFG),                              \
+		.reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),                         \
+		IF_ENABLED(CONFIG_ADIS1647X_TRIGGER,                                              \
+			(.interrupt = GPIO_DT_SPEC_INST_GET_OR(inst, drdy_gpios, {0}),))          \
+	};                                                                                        \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, adis1647x_init, NULL, &adis1647x_data_##inst,           \
+				     &adis1647x_config_##inst, POST_KERNEL,                        \
+				     CONFIG_SENSOR_INIT_PRIORITY, &adis1647x_api);
+
+DT_INST_FOREACH_STATUS_OKAY(ADIS1647X_DEFINE)

--- a/drivers/sensor/adi/adis1647x/adis1647x.h
+++ b/drivers/sensor/adi/adis1647x/adis1647x.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_ADIS1647X_ADIS1647X_H_
+#define ZEPHYR_DRIVERS_SENSOR_ADIS1647X_ADIS1647X_H_
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/kernel.h>
+#include <zephyr/rtio/rtio.h>
+
+/* SPI stall times */
+#define ADIS1647X_SPI_STALL_US      16
+#define ADIS1647X_HW_RESET_PULSE_MS 10
+#define ADIS1647X_HW_RESET_WAIT_MS  310
+#define ADIS1647X_SW_RESET_MS       310
+
+#define ADIS1647X_WRITE_CMD 0x80
+#define ADIS1647X_READ_CMD  0x00
+#define ADIS1647X_BURST_CMD 0x68
+
+#define ADIS1647X_REG_PROD_ID  0x72
+#define ADIS1647X_REG_RANG_MDL 0x5E
+
+#define ADIS1647X_REG_MSC_CTRL          0x60
+#define ADIS1647X_REG_MSC_CTRL_BURST32  BIT(9)
+#define ADIS1647X_REG_MSC_CTRL_BURSTSEL BIT(8)
+#define ADIS1647X_REG_MSC_CTRL_GCOMP    BIT(7)
+#define ADIS1647X_REG_MSC_CTRL_PCOMP    BIT(6)
+#define ADIS1647X_REG_MSC_CTRL_DR_POL   BIT(0)
+#define ADIS1647X_REG_MSC_CTRL_DEFAULT                                                             \
+	(ADIS1647X_REG_MSC_CTRL_PCOMP | ADIS1647X_REG_MSC_CTRL_DR_POL)
+
+#define ADIS1647X_REG_FIRM_REV            0x6C
+#define ADIS1647X_REG_GLOBAL_CMD          0x68
+#define ADIS1647X_REG_GLOBAL_CMD_SW_RESET BIT(7)
+
+#define ADIS1647X_REG_DEC_RATE 0x64
+
+#define ADIS1647X_DIAG_Z_ACCEL_FAILURE      BIT(13)
+#define ADIS1647X_DIAG_Y_ACCEL_FAILURE      BIT(12)
+#define ADIS1647X_DIAG_X_ACCEL_FAILURE      BIT(11)
+#define ADIS1647X_DIAG_Z_GYRO_FAILURE       BIT(10)
+#define ADIS1647X_DIAG_Y_GYRO_FAILURE       BIT(9)
+#define ADIS1647X_DIAG_X_GYRO_FAILURE       BIT(8)
+#define ADIS1647X_DIAG_SELF_TEST_ERR        BIT(5)
+#define ADIS1647X_DIAG_POWER_SUPPLY         BIT(4)
+#define ADIS1647X_DIAG_SPI_COMM_ERROR       BIT(3)
+#define ADIS1647X_DIAG_FLASH_UPDATE_FAILURE BIT(2)
+#define ADIS1647X_DIAG_DATAPATH_OVERRUN     BIT(1)
+#define ADIS1647X_DIAG_SENSOR_INIT_FAILURE  BIT(0)
+
+/* Model index order must match the enum in adi,adis1647x.yaml */
+enum adis1647x_model_idx {
+	ADIS1647X_MODEL_ADIS16470 = 0,
+	ADIS1647X_MODEL_ADIS16475_1,
+	ADIS1647X_MODEL_ADIS16475_2,
+	ADIS1647X_MODEL_ADIS16475_3,
+	ADIS1647X_MODEL_ADIS16477_1,
+	ADIS1647X_MODEL_ADIS16477_2,
+	ADIS1647X_MODEL_ADIS16477_3,
+};
+
+struct adis1647x_model_cfg {
+	uint8_t accel_scale_num; /* mg/LSB * 100, e.g. 125 = 1.25 mg/LSB */
+	uint16_t gyro_scale_num; /* (max_dps / 20000) * 100000, e.g. 625 = 125 dps */
+	uint16_t prod_id;        /* expected PROD_ID register value */
+	uint8_t rang_mdl;        /* expected RANG_MDL bits [3:2] value */
+};
+
+struct adis1647x_config {
+	uint8_t model_idx;
+	int dec_rate;
+	struct spi_dt_spec spi;
+	struct gpio_dt_spec reset;
+#if defined(CONFIG_ADIS1647X_TRIGGER) || defined(CONFIG_ADIS1647X_STREAM)
+	struct gpio_dt_spec interrupt;
+#endif
+};
+
+struct adis1647x_data {
+	uint8_t accel_scale_num;
+	uint16_t gyro_scale_num;
+	int16_t accel_x, accel_y, accel_z;
+	int16_t gyro_x, gyro_y, gyro_z;
+	int16_t temp;
+
+#ifdef CONFIG_ADIS1647X_TRIGGER
+	const struct device *dev;
+	struct gpio_callback gpio_cb;
+	sensor_trigger_handler_t drdy_handler;
+	const struct sensor_trigger *drdy_trigger;
+#if defined(CONFIG_ADIS1647X_TRIGGER_OWN_THREAD)
+	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_ADIS1647X_THREAD_STACK_SIZE);
+	struct k_sem gpio_sem;
+	struct k_thread thread;
+#elif defined(CONFIG_ADIS1647X_TRIGGER_GLOBAL_THREAD)
+	struct k_work work;
+#endif
+#endif /*CONFIG_ADIS1647X_TRIGGER*/
+
+#ifdef CONFIG_SENSOR_ASYNC_API
+	struct rtio *rtio_ctx;
+	struct rtio_iodev *iodev;
+#endif /* CONFIG_SENSOR_ASYNC_API */
+
+#ifdef CONFIG_ADIS1647X_STREAM
+	struct rtio_iodev_sqe *sqe;
+	uint64_t timestamp;
+#endif /* CONFIG_ADIS1647X_STREAM */
+};
+
+struct adis1647x_burst_data {
+	uint8_t cmd[2];
+	uint16_t diag_stat;
+	uint16_t x_gyro_out;
+	uint16_t y_gyro_out;
+	uint16_t z_gyro_out;
+	uint16_t x_accel_out;
+	uint16_t y_accel_out;
+	uint16_t z_accel_out;
+	uint16_t temp_out;
+	uint16_t data_cntr;
+	uint16_t spi_chksum;
+} __packed;
+
+struct adis1647x_sample_data {
+	uint8_t accel_scale_num;
+	uint16_t gyro_scale_num;
+	uint64_t timestamp;
+	struct adis1647x_burst_data burst_data;
+};
+
+#ifdef CONFIG_ADIS1647X_TRIGGER
+int adis1647x_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			  sensor_trigger_handler_t handler);
+int adis1647x_init_interrupt(const struct device *dev);
+#endif
+
+/* SPI functions */
+int adis1647x_reg_read(const struct device *dev, uint8_t addr, uint16_t *val);
+int adis1647x_reg_write(const struct device *dev, uint8_t addr, uint16_t val);
+int adis1647x_reg_write_no_verify(const struct device *dev, uint8_t addr, uint16_t val);
+int adis1647x_burst_read(const struct device *dev, struct adis1647x_burst_data *data);
+
+/* API functions */
+#ifdef CONFIG_SENSOR_ASYNC_API
+void adis1647x_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+#endif
+int adis1647x_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);
+
+/* Conversion helpers */
+void adis1647x_accel_convert(struct sensor_value *val, int16_t raw, uint8_t accel_scale_num);
+void adis1647x_gyro_convert(struct sensor_value *val, int16_t raw, uint16_t gyro_scale_num);
+
+/* Data helpers */
+int adis1647x_get_data(const struct device *dev, struct adis1647x_sample_data *sample_data);
+int adis1647x_verify_burst(const struct adis1647x_burst_data *b);
+#ifdef CONFIG_ADIS1647X_STREAM
+void adis1647x_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+void adis1647x_stream_irq_handler(const struct device *dev);
+#endif
+#endif

--- a/drivers/sensor/adi/adis1647x/adis1647x_decoder.c
+++ b/drivers/sensor/adi/adis1647x/adis1647x_decoder.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Analog Devices Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/byteorder.h>
+#include "adis1647x.h"
+/* 1000 converts from mg to g, 100 rescales accel_scale */
+#define ADIS1647X_ACCEL_SCALE_DEN (1000LL * 100)
+/* 100000 rescales gyro_scale, 180 for PI/180 rad->deg conversion */
+#define ADIS1647X_GYRO_SCALE_DEN  (100000LL * 180)
+
+void adis1647x_accel_convert(struct sensor_value *val, int16_t raw, uint8_t accel_scale_num)
+{
+	int64_t micro_m_s2 =
+		((int64_t)raw * SENSOR_G * accel_scale_num) / ADIS1647X_ACCEL_SCALE_DEN;
+
+	val->val1 = (int32_t)(micro_m_s2 / 1000000);
+	val->val2 = (int32_t)(micro_m_s2 % 1000000);
+}
+
+void adis1647x_gyro_convert(struct sensor_value *val, int16_t raw, uint16_t gyro_scale_num)
+{
+	int64_t micro_rad_s =
+		((int64_t)raw * SENSOR_PI * gyro_scale_num) / ADIS1647X_GYRO_SCALE_DEN;
+
+	val->val1 = (int32_t)(micro_rad_s / 1000000);
+	val->val2 = (int32_t)(micro_rad_s % 1000000);
+}
+
+static int adis1647x_decoder_get_frame_count(const uint8_t *buffer,
+					     struct sensor_chan_spec chan_spec,
+					     uint16_t *frame_count)
+{
+	int32_t ret = -ENOTSUP;
+
+	if (chan_spec.chan_idx != 0) {
+		return ret;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_ACCEL_X:
+	case SENSOR_CHAN_ACCEL_Y:
+	case SENSOR_CHAN_ACCEL_Z:
+	case SENSOR_CHAN_ACCEL_XYZ:
+	case SENSOR_CHAN_GYRO_X:
+	case SENSOR_CHAN_GYRO_Y:
+	case SENSOR_CHAN_GYRO_Z:
+	case SENSOR_CHAN_GYRO_XYZ:
+	case SENSOR_CHAN_DIE_TEMP:
+		*frame_count = 1;
+		ret = 0;
+		break;
+
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+static int adis1647x_decode_sample(const struct adis1647x_sample_data *data,
+				   struct sensor_chan_spec chan_spec, uint32_t *fit,
+				   uint16_t max_count, void *data_out)
+{
+	struct sensor_value *out = (struct sensor_value *)data_out;
+	const struct adis1647x_burst_data *burst_data = &data->burst_data;
+
+	if (*fit > 0) {
+		return -ENOTSUP;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_ACCEL_X:
+		adis1647x_accel_convert(out, (int16_t)sys_be16_to_cpu(burst_data->x_accel_out),
+					data->accel_scale_num);
+		break;
+	case SENSOR_CHAN_ACCEL_Y:
+		adis1647x_accel_convert(out, (int16_t)sys_be16_to_cpu(burst_data->y_accel_out),
+					data->accel_scale_num);
+		break;
+	case SENSOR_CHAN_ACCEL_Z:
+		adis1647x_accel_convert(out, (int16_t)sys_be16_to_cpu(burst_data->z_accel_out),
+					data->accel_scale_num);
+		break;
+	case SENSOR_CHAN_ACCEL_XYZ:
+		adis1647x_accel_convert(out++, (int16_t)sys_be16_to_cpu(burst_data->x_accel_out),
+					data->accel_scale_num);
+		adis1647x_accel_convert(out++, (int16_t)sys_be16_to_cpu(burst_data->y_accel_out),
+					data->accel_scale_num);
+		adis1647x_accel_convert(out, (int16_t)sys_be16_to_cpu(burst_data->z_accel_out),
+					data->accel_scale_num);
+		break;
+	case SENSOR_CHAN_GYRO_X:
+		adis1647x_gyro_convert(out, (int16_t)sys_be16_to_cpu(burst_data->x_gyro_out),
+				       data->gyro_scale_num);
+		break;
+	case SENSOR_CHAN_GYRO_Y:
+		adis1647x_gyro_convert(out, (int16_t)sys_be16_to_cpu(burst_data->y_gyro_out),
+				       data->gyro_scale_num);
+		break;
+	case SENSOR_CHAN_GYRO_Z:
+		adis1647x_gyro_convert(out, (int16_t)sys_be16_to_cpu(burst_data->z_gyro_out),
+				       data->gyro_scale_num);
+		break;
+	case SENSOR_CHAN_GYRO_XYZ:
+		adis1647x_gyro_convert(out++, (int16_t)sys_be16_to_cpu(burst_data->x_gyro_out),
+				       data->gyro_scale_num);
+		adis1647x_gyro_convert(out++, (int16_t)sys_be16_to_cpu(burst_data->y_gyro_out),
+				       data->gyro_scale_num);
+		adis1647x_gyro_convert(out, (int16_t)sys_be16_to_cpu(burst_data->z_gyro_out),
+				       data->gyro_scale_num);
+		break;
+	case SENSOR_CHAN_DIE_TEMP: {
+		int64_t micro_celsius =
+			(int64_t)(int16_t)sys_be16_to_cpu(burst_data->temp_out) * 100000;
+
+		out->val1 = (int32_t)(micro_celsius / 1000000);
+		out->val2 = (int32_t)(micro_celsius % 1000000);
+		break;
+	}
+	default:
+		return -ENOTSUP;
+	}
+
+	*fit = 1;
+
+	return 0;
+}
+
+static int adis1647x_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
+				    uint32_t *fit, uint16_t max_count, void *data_out)
+{
+	const struct adis1647x_sample_data *sample_data =
+		(const struct adis1647x_sample_data *)buffer;
+
+	return adis1647x_decode_sample(sample_data, chan_spec, fit, max_count, data_out);
+}
+
+static bool adis1647x_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigger_type trigger)
+{
+	return trigger == SENSOR_TRIG_DATA_READY;
+}
+
+SENSOR_DECODER_API_DT_DEFINE() = {
+	.get_frame_count = adis1647x_decoder_get_frame_count,
+	.decode = adis1647x_decoder_decode,
+	.has_trigger = adis1647x_decoder_has_trigger,
+};
+
+int adis1647x_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder)
+{
+	ARG_UNUSED(dev);
+	*decoder = &SENSOR_DECODER_NAME();
+
+	return 0;
+}

--- a/drivers/sensor/adi/adis1647x/adis1647x_rtio.c
+++ b/drivers/sensor/adi/adis1647x/adis1647x_rtio.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Analog Devices Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/sensor.h>
+
+#include "adis1647x.h"
+
+LOG_MODULE_DECLARE(adis1647x, CONFIG_SENSOR_LOG_LEVEL);
+
+/*
+ * Burst command frame. The transfer length matches the full burst response, so
+ * the command occupies the first two bytes and the remainder is don't-care.
+ */
+static const uint8_t adis1647x_burst_tx[sizeof(struct adis1647x_burst_data)] = {
+	ADIS1647X_BURST_CMD,
+	0x00,
+};
+
+static void adis1647x_complete_result(struct rtio *ctx, const struct rtio_sqe *sqe, int result,
+				      void *arg)
+{
+	ARG_UNUSED(arg);
+	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)sqe->userdata;
+	struct rtio_cqe *cqe;
+	int err = 0;
+
+	do {
+		cqe = rtio_cqe_consume(ctx);
+		if (cqe != NULL) {
+			err = cqe->result;
+			rtio_cqe_release(ctx, cqe);
+		}
+	} while (cqe != NULL);
+
+	if (err != 0) {
+		rtio_iodev_sqe_err(iodev_sqe, err);
+		return;
+	}
+
+	uint8_t *buf;
+	uint32_t buf_len;
+
+	if (rtio_sqe_rx_buf(iodev_sqe, sizeof(struct adis1647x_sample_data),
+			    sizeof(struct adis1647x_sample_data), &buf, &buf_len) != 0) {
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	struct adis1647x_sample_data *sample = (struct adis1647x_sample_data *)buf;
+
+	err = adis1647x_verify_burst(&sample->burst_data);
+	if (err != 0) {
+		rtio_iodev_sqe_err(iodev_sqe, err);
+		return;
+	}
+
+	rtio_iodev_sqe_ok(iodev_sqe, 0);
+}
+
+static void adis1647x_submit_one_shot(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct adis1647x_data *data = dev->data;
+	uint32_t min_buffer_len = sizeof(struct adis1647x_sample_data);
+	uint8_t *buffer;
+	uint32_t buffer_len;
+	int rc;
+
+	rc = rtio_sqe_rx_buf(iodev_sqe, min_buffer_len, min_buffer_len, &buffer, &buffer_len);
+	if (rc != 0) {
+		LOG_ERR("Failed to get a read buffer of size %u bytes", min_buffer_len);
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		return;
+	}
+
+	struct adis1647x_sample_data *sample = (struct adis1647x_sample_data *)buffer;
+
+	sample->accel_scale_num = data->accel_scale_num;
+	sample->gyro_scale_num = data->gyro_scale_num;
+
+	struct rtio_sqe *xfer_sqe = rtio_sqe_acquire(data->rtio_ctx);
+	struct rtio_sqe *complete_sqe = rtio_sqe_acquire(data->rtio_ctx);
+
+	if (xfer_sqe == NULL || complete_sqe == NULL) {
+		LOG_ERR("Failed to acquire RTIO SQEs");
+		rtio_sqe_drop_all(data->rtio_ctx);
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	rtio_sqe_prep_transceive(xfer_sqe, data->iodev, RTIO_PRIO_NORM, adis1647x_burst_tx,
+				 (uint8_t *)&sample->burst_data,
+				 sizeof(struct adis1647x_burst_data), NULL);
+	xfer_sqe->flags |= RTIO_SQE_CHAINED;
+
+	rtio_sqe_prep_callback_no_cqe(complete_sqe, adis1647x_complete_result, (void *)dev,
+				      iodev_sqe);
+
+	rtio_submit(data->rtio_ctx, 0);
+}
+
+void adis1647x_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg =
+		(const struct sensor_read_config *)iodev_sqe->sqe.iodev->data;
+
+	if (!cfg->is_streaming) {
+		adis1647x_submit_one_shot(dev, iodev_sqe);
+	} else {
+#ifdef CONFIG_ADIS1647X_STREAM
+		adis1647x_submit_stream(dev, iodev_sqe);
+#else
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+#endif
+	}
+}

--- a/drivers/sensor/adi/adis1647x/adis1647x_spi.c
+++ b/drivers/sensor/adi/adis1647x/adis1647x_spi.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+
+#include "adis1647x.h"
+
+LOG_MODULE_DECLARE(adis1647x, CONFIG_SENSOR_LOG_LEVEL);
+
+static int adis1647x_reg_access(const struct device *dev, uint8_t cmd, uint8_t addr, uint8_t data,
+				uint8_t *rx)
+{
+	const struct adis1647x_config *cfg = dev->config;
+	uint8_t addr_byte = addr | cmd;
+	uint8_t data_byte = data;
+	uint8_t rx_buf[2] = {0};
+	int ret;
+
+	const struct spi_buf tx_bufs[2] = {{.buf = &addr_byte, .len = 1},
+					   {.buf = &data_byte, .len = 1}};
+	const struct spi_buf rx_bufs[2] = {{.buf = &rx_buf[0], .len = 1},
+					   {.buf = &rx_buf[1], .len = 1}};
+
+	struct spi_buf_set tx_set = {.buffers = tx_bufs, .count = 2};
+	struct spi_buf_set rx_set = {.buffers = rx_bufs, .count = 2};
+
+	LOG_DBG("SPI TX: %02X %02X", addr_byte, data_byte);
+
+	ret = spi_transceive_dt(&cfg->spi, &tx_set, &rx_set);
+	if (ret) {
+		LOG_ERR("spi_transceive_dt failed: %d", ret);
+		return ret;
+	}
+
+	if (rx != NULL) {
+		rx[0] = rx_buf[0];
+		rx[1] = rx_buf[1];
+	}
+
+	return 0;
+}
+
+int adis1647x_reg_read(const struct device *dev, uint8_t addr, uint16_t *val)
+{
+	uint8_t rx[2];
+	int ret;
+
+	ret = adis1647x_reg_access(dev, ADIS1647X_READ_CMD, addr, 0x00, NULL);
+	if (ret) {
+		return ret;
+	}
+
+	k_busy_wait(ADIS1647X_SPI_STALL_US);
+
+	ret = adis1647x_reg_access(dev, ADIS1647X_READ_CMD, 0x00, 0x00, rx);
+	if (ret) {
+		return ret;
+	}
+
+	*val = ((uint16_t)rx[0] << 8) | rx[1];
+	return 0;
+}
+
+int adis1647x_reg_write_no_verify(const struct device *dev, uint8_t addr, uint16_t val)
+{
+	const struct adis1647x_config *cfg = dev->config;
+	int ret;
+
+	/* Ensure CS is high before starting write sequence */
+	spi_release_dt(&cfg->spi);
+	k_busy_wait(ADIS1647X_SPI_STALL_US);
+
+	/* Write low byte */
+	ret = adis1647x_reg_access(dev, ADIS1647X_WRITE_CMD, addr, val & 0xFF, NULL);
+	if (ret) {
+		return ret;
+	}
+
+	/* Force CS high between writes */
+	spi_release_dt(&cfg->spi);
+	k_busy_wait(ADIS1647X_SPI_STALL_US);
+
+	/* Write high byte */
+	ret = adis1647x_reg_access(dev, ADIS1647X_WRITE_CMD, addr + 1, (val >> 8) & 0xFF, NULL);
+	if (ret) {
+		return ret;
+	}
+
+	spi_release_dt(&cfg->spi);
+	k_busy_wait(ADIS1647X_SPI_STALL_US);
+
+	return 0;
+}
+
+int adis1647x_reg_write(const struct device *dev, uint8_t addr, uint16_t val)
+{
+	const int retries = 16;
+	int ret;
+	uint16_t readback;
+
+	LOG_DBG("reg_write: addr=0x%02X val=0x%04X (low=0x%02X high=0x%02X)", addr, val, val & 0xFF,
+		(val >> 8) & 0xFF);
+
+	for (int i = 0; i < retries; i++) {
+		ret = adis1647x_reg_write_no_verify(dev, addr, val);
+		if (ret) {
+			continue;
+		}
+
+		/* Verify write */
+		ret = adis1647x_reg_read(dev, addr, &readback);
+		if (ret == 0 && readback == val) {
+			return 0;
+		}
+
+		LOG_DBG("reg_write retry %d: wrote=0x%04X read=0x%04X", i, val, readback);
+	}
+
+	LOG_ERR("reg_write failed after %d retries: addr=0x%02X val=0x%04X", retries, addr, val);
+	return -EIO;
+}
+
+int adis1647x_burst_read(const struct device *dev, struct adis1647x_burst_data *data)
+{
+	const struct adis1647x_config *cfg = dev->config;
+	int ret;
+
+	uint8_t tx_data[sizeof(struct adis1647x_burst_data)] = {0};
+
+	tx_data[0] = ADIS1647X_BURST_CMD;
+	tx_data[1] = 0x00;
+
+	struct spi_buf tx_buf = {.buf = tx_data, .len = sizeof(tx_data)};
+	struct spi_buf rx_buf = {.buf = data, .len = sizeof(struct adis1647x_burst_data)};
+	struct spi_buf_set tx_set = {.buffers = &tx_buf, .count = 1};
+	struct spi_buf_set rx_set = {.buffers = &rx_buf, .count = 1};
+
+	ret = spi_transceive_dt(&cfg->spi, &tx_set, &rx_set);
+	if (ret) {
+		LOG_ERR("Burst read SPI error: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}

--- a/drivers/sensor/adi/adis1647x/adis1647x_stream.c
+++ b/drivers/sensor/adi/adis1647x/adis1647x_stream.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Analog Devices Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor_clock.h>
+#include <zephyr/drivers/gpio.h>
+
+#include "adis1647x.h"
+
+LOG_MODULE_DECLARE(adis1647x, CONFIG_SENSOR_LOG_LEVEL);
+
+void adis1647x_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg =
+		(const struct sensor_read_config *)iodev_sqe->sqe.iodev->data;
+	struct adis1647x_data *data = (struct adis1647x_data *)dev->data;
+	const struct adis1647x_config *cfg_adis1647x = dev->config;
+
+	bool drdy = false;
+
+	for (size_t i = 0; i < cfg->count; i++) {
+		if (cfg->triggers[i].trigger == SENSOR_TRIG_DATA_READY) {
+			drdy = true;
+		}
+	}
+
+	if (!drdy) {
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+		return;
+	}
+
+	int rc = gpio_pin_interrupt_configure_dt(&cfg_adis1647x->interrupt, GPIO_INT_DISABLE);
+
+	if (rc < 0) {
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		return;
+	}
+
+	data->sqe = iodev_sqe;
+
+	rc = gpio_pin_interrupt_configure_dt(&cfg_adis1647x->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+	if (rc < 0) {
+		data->sqe = NULL;
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		return;
+	}
+}
+
+void adis1647x_stream_irq_handler(const struct device *dev)
+{
+	struct adis1647x_data *data = (struct adis1647x_data *)dev->data;
+	const struct adis1647x_config *cfg = dev->config;
+
+	uint64_t cycles;
+	int rc;
+
+	if (data->sqe == NULL) {
+		return;
+	}
+
+	rc = sensor_clock_get_cycles(&cycles);
+	if (rc != 0) {
+		LOG_ERR("Failed to get sensor clock cycles");
+		rtio_iodev_sqe_err(data->sqe, rc);
+		return;
+	}
+
+	data->timestamp = sensor_clock_cycles_to_ns(cycles);
+
+	struct rtio_iodev_sqe *current_sqe = data->sqe;
+
+	uint8_t *buf;
+	uint32_t buf_len;
+
+	if (rtio_sqe_rx_buf(current_sqe, sizeof(struct adis1647x_sample_data),
+			    sizeof(struct adis1647x_sample_data), &buf, &buf_len) != 0) {
+		LOG_ERR("Failed to acquire buffer");
+		data->sqe = NULL;
+		rtio_iodev_sqe_err(current_sqe, -ENOMEM);
+		goto reenable;
+	}
+
+	struct adis1647x_sample_data *sample = (struct adis1647x_sample_data *)buf;
+
+	rc = adis1647x_get_data(dev, sample);
+	data->sqe = NULL;
+	if (rc != 0) {
+		rtio_iodev_sqe_err(current_sqe, rc);
+	} else {
+		sample->timestamp = data->timestamp;
+		rtio_iodev_sqe_ok(current_sqe, 0);
+	}
+
+reenable:
+	gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+}

--- a/drivers/sensor/adi/adis1647x/adis1647x_trigger.c
+++ b/drivers/sensor/adi/adis1647x/adis1647x_trigger.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Analog Devices Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT adi_adis1647x
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/sensor.h>
+#include "adis1647x.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(adis1647x, CONFIG_SENSOR_LOG_LEVEL);
+
+#if defined(CONFIG_ADIS1647X_TRIGGER_OWN_THREAD) || defined(CONFIG_ADIS1647X_TRIGGER_GLOBAL_THREAD)
+static void adis1647x_thread_cb(const struct device *dev)
+{
+	const struct adis1647x_config *cfg = dev->config;
+	struct adis1647x_data *drv_data = dev->data;
+
+#ifdef CONFIG_ADIS1647X_STREAM
+	if (drv_data->sqe != NULL) {
+		adis1647x_stream_irq_handler(dev); /* re-enables interrupt internally */
+		return;
+	}
+#endif
+
+	if (drv_data->drdy_handler != NULL) {
+		drv_data->drdy_handler(dev, drv_data->drdy_trigger);
+	}
+
+	if (gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE) < 0) {
+		LOG_ERR("Failed to re-enable interrupt");
+	}
+}
+#endif /* CONFIG_ADIS1647X_TRIGGER_OWN_THREAD || CONFIG_ADIS1647X_TRIGGER_GLOBAL_THREAD */
+
+#if defined(CONFIG_ADIS1647X_TRIGGER_OWN_THREAD)
+static void adis1647x_thread(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	struct adis1647x_data *drv_data = p1;
+
+	while (true) {
+		k_sem_take(&drv_data->gpio_sem, K_FOREVER);
+		adis1647x_thread_cb(drv_data->dev);
+	}
+}
+
+#elif defined(CONFIG_ADIS1647X_TRIGGER_GLOBAL_THREAD)
+static void adis1647x_work_cb(struct k_work *work)
+{
+	struct adis1647x_data *drv_data = CONTAINER_OF(work, struct adis1647x_data, work);
+
+	adis1647x_thread_cb(drv_data->dev);
+}
+#endif
+
+static void adis1647x_gpio_callback(const struct device *dev, struct gpio_callback *cb,
+				    uint32_t pins)
+{
+	struct adis1647x_data *drv_data = CONTAINER_OF(cb, struct adis1647x_data, gpio_cb);
+	const struct adis1647x_config *cfg = drv_data->dev->config;
+
+	gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_DISABLE);
+
+#if defined(CONFIG_ADIS1647X_TRIGGER_OWN_THREAD)
+	k_sem_give(&drv_data->gpio_sem);
+#elif defined(CONFIG_ADIS1647X_TRIGGER_GLOBAL_THREAD)
+	k_work_submit(&drv_data->work);
+#endif
+}
+
+int adis1647x_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			  sensor_trigger_handler_t handler)
+{
+	const struct adis1647x_config *cfg = dev->config;
+	struct adis1647x_data *drv_data = dev->data;
+	int ret;
+
+	ret = gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_DISABLE);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (trig->type != SENSOR_TRIG_DATA_READY) {
+		LOG_ERR("Unsupported trigger type %d", trig->type);
+		return -ENOTSUP;
+	}
+
+	drv_data->drdy_handler = handler;
+	drv_data->drdy_trigger = trig;
+
+	if (!handler) {
+		return 0;
+	}
+
+	ret = gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+int adis1647x_init_interrupt(const struct device *dev)
+{
+	const struct adis1647x_config *cfg = dev->config;
+	struct adis1647x_data *drv_data = dev->data;
+	int ret;
+
+	if (!gpio_is_ready_dt(&cfg->interrupt)) {
+		LOG_ERR_DEVICE_NOT_READY(cfg->interrupt.port);
+		return -EINVAL;
+	}
+
+	ret = gpio_pin_configure_dt(&cfg->interrupt, GPIO_INPUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	gpio_init_callback(&drv_data->gpio_cb, adis1647x_gpio_callback, BIT(cfg->interrupt.pin));
+
+	ret = gpio_add_callback(cfg->interrupt.port, &drv_data->gpio_cb);
+	if (ret < 0) {
+		LOG_ERR("Failed to set gpio callback!");
+		return ret;
+	}
+
+	drv_data->dev = dev;
+
+#if defined(CONFIG_ADIS1647X_TRIGGER_OWN_THREAD)
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
+
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_ADIS1647X_THREAD_STACK_SIZE, adis1647x_thread, drv_data, NULL, NULL,
+			K_PRIO_COOP(CONFIG_ADIS1647X_THREAD_PRIORITY), 0, K_NO_WAIT);
+
+	k_thread_name_set(&drv_data->thread, dev->name);
+#elif defined(CONFIG_ADIS1647X_TRIGGER_GLOBAL_THREAD)
+	k_work_init(&drv_data->work, adis1647x_work_cb);
+#endif
+
+	return 0;
+}

--- a/dts/bindings/sensor/adi,adis1647x.yaml
+++ b/dts/bindings/sensor/adi,adis1647x.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: ADIS1647x 6-DoF MEMS IMU with SPI connection
+
+compatible: "adi,adis1647x"
+
+include: spi-device.yaml
+
+properties:
+  drdy-gpios:
+    type: phandle-array
+    description: |
+      Data ready interrupt pin. Active high by default as produced by the sensor.
+
+  reset-gpios:
+    type: phandle-array
+    description: |
+      Hardware reset pin. Active low — assert (drive low) to reset, deassert
+      (drive high) for normal operation.
+
+  model:
+    type: string
+    required: true
+    enum:
+      - "adis16470"
+      - "adis16475-1"
+      - "adis16475-2"
+      - "adis16475-3"
+      - "adis16477-1"
+      - "adis16477-2"
+      - "adis16477-3"
+    description: |
+      IMU model variant. Selects accelerometer sensitivity and gyroscope
+      full-scale range at compile time without runtime register reads.
+
+  dec-rate:
+    type: int
+    default: 19
+    min: 0
+    max: 1999
+    description: |
+      Decimation rate applied to the 2000 Hz internal sample rate.
+      Output data = 2000 / (dec_rate + 1) Hz
+      0 # 2000 Hz
+      1 # 1000 Hz
+      ...
+      19 # 100 Hz (default)
+      199 # 10 Hz
+
+      Default is 19 (100 Hz output rate). This is a common output rate for
+      general motion-sensing applications (AHRS, robotics, vibration
+      monitoring) — high enough to capture typical platform dynamics while
+      keeping SPI/CPU load on the host modest.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/gpio/gpio.h>
+
+    &spi1 {
+      /* ... */
+
+      adis1647x: adis1647x@0 {
+        compatible = "adi,adis1647x";
+        reg = <0>;
+        spi-max-frequency = <421875>;
+        spi-cpol;
+        spi-cpha;
+        drdy-gpios = <&gpiof 12 GPIO_ACTIVE_HIGH>;
+        reset-gpios = <&gpiod 15 GPIO_ACTIVE_LOW>;
+        model = "adis16477-1";
+        dec-rate = <99>;
+      };
+    };

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -522,3 +522,12 @@ test_spi_bmp581: bmp581@3f {
 	spi-max-frequency = <12000000>;
 	int-gpios = <&test_gpio 0 0>;
 };
+
+test_spi_adis1647x: adis1647x@40 {
+	compatible = "adi,adis1647x";
+	reg = <0x40>;
+	spi-max-frequency = <0>;
+	model = "adis16477-1";
+	drdy-gpios = <&test_gpio 0 0>;
+	reset-gpios = <&test_gpio 0 0>;
+};


### PR DESCRIPTION
Adds driver support for the precision, miniature MEMS inertial measurement unit(IMU) family ADIS1647X. 
Supported devices: ADIS16470 - ADIS16475 - ADIS16477. 

Features: 

- SPI burst reads for data
- checksum and diagnostic status validation on every burst read
- optional hardware reset via `reset-gpios` devicetree property
- software reset during initialization
- configurable decimation rate via `dec-rate` devicetree property 
- model variant selection
- verified register writes with automatic retry

Operating modes: 

- polling(blocking sensor_sample_fetch / sensor_channel_get)
- trigger (drdy interrupt via global thread or dedicated thread)
- RTIO one-shot async (sensor_read_async_mempool)
- streaming (continuous drdy-driven data via RTIO) 

Includes:

- devicetree binding: adis,adis1647x 
- sample application with board overlay for NucleoF767ZI
- build configurations for all four operating modes
- sample documentation with wiring and build instructions 

Tested on a NucleoF767ZI with an ADIS16477-1BMLZ/PCB.