### PR TITLE
boards: nxp: fix mcu target name formatting in yaml

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_imxrt1186/mimxrt1186/cm33
-name: FRDM-iMXRT1186 CM33
+name: NXP FRDM-iMXRT1186 (CM33)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: frdm_imxrt1186/mimxrt1186/cm7
-name: FRDM-iMXRT1186 CM7
+name: NXP FRDM-iMXRT1186 (CM7)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7_extmem.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7_extmem.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: frdm_imxrt1186/mimxrt1186/cm7/extmem
-name: FRDM-iMXRT1186 CM7 (Onboard External Memory)
+name: NXP FRDM-iMXRT1186 (CM7) (HyperFlash, HyperRAM)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: frdm_mcxl255/mcxl255/cpu0
-name: NXP FRDM MCXL255 (CPU0)
+name: NXP FRDM-MCXL255 (CPU0)
 type: mcu
 arch: arm
 ram: 128

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: frdm_mcxl255/mcxl255/cpu1
-name: NXP FRDM MCXL255 (CPU1)
+name: NXP FRDM-MCXL255 (CPU1)
 type: mcu
 arch: arm
 ram: 32

--- a/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.yaml
+++ b/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.yaml
@@ -1,5 +1,5 @@
 identifier: lpcxpresso11u68
-name: NXP LPCxpresso11U68
+name: NXP LPCXpresso11U68
 type: mcu
 arch: arm
 ram: 32


### PR DESCRIPTION
No functional changes.
Fixes board target name strings in YAML metadata, to be consistent with other NXP MCU board targets, visible in MCUx VSCode:
- frdm_imxrt1186: add "NXP" prefix and parentheses around core designations (CM33, CM7)
- frdm_imxrt1186/cm7/extmem: replace generic "Onboard External Memory" description with specific "HyperFlash, HyperRAM"
- frdm_mcxl255: fix hyphenation (FRDM MCXL255 -> FRDM-MCXL255)
- lpcxpresso11u68: fix capitalization (LPCxpresso -> LPCXpresso)