### PR TITLE
soc: stm32: common: gpioport_mgr: always provide GPIO driver API

### DIFF
--- a/soc/st/stm32/common/gpioport_mgr.c
+++ b/soc/st/stm32/common/gpioport_mgr.c
@@ -22,6 +22,14 @@
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/__assert.h>
 
+#include <zephyr/logging/log.h>
+#ifdef CONFIG_GPIO_LOG_LEVEL
+#define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
+#else
+#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
+#endif
+LOG_MODULE_REGISTER(stm32_gpioport_mgr);
+
 /*
  * Generic macrobatic utilities used later on
  */
@@ -290,6 +298,85 @@ __maybe_unused static int stm32_gpioport_init(const struct device *dev)
 	return pm_device_driver_init(dev, stm32_gpioport_pm_action);
 }
 
+#if !defined(CONFIG_GPIO_STM32)
+/*
+ * The GPIO API is implemented entirely in the header file
+ * so it can be *called* even when CONFIG_GPIO=n. A build
+ * error would usually occur if one attempted to do that
+ * since you also need a reference to the GPIO device to
+ * use the API, and those devices are not instantiated when
+ * their driver doesn't exist... but in our case, we always
+ * instantiate the GPIO port nodes even when CONFIG_GPIO=n.
+ * We originally set the `api` pointer to NULL in this case
+ * but this is actually quite dangerous, since applications
+ * that tried to use the GPIO API without enabling CONFIG_GPIO
+ * would build fine but crash at runtime when the GPIO API
+ * functions dereference the NULL `api` pointer.
+ *
+ * Provide a dummy implementation of the GPIO API where all
+ * mandatory functions return -ENOSYS after printing a big
+ * error message such that applications don't crash anymore.
+ * Optional functions are not implemented to lower footprint.
+ *
+ * A broader rework would be necessary to allow not instancing
+ * any of the GPIO port devices when CONFIG_GPIO_STM32=n, which
+ * would restore the previous build-time-error behavior; for
+ * now, this shall suffice.
+ */
+static int illegal_gpio_api_usage(void)
+{
+	LOG_ERR("Attempting to use GPIO API without enabling it!");
+	return -ENOSYS;
+}
+
+static int dummy_gpio_pin_configure(const struct device *port, gpio_pin_t pin,
+				    gpio_flags_t flags)
+{
+	ARG_UNUSED(port); ARG_UNUSED(pin); ARG_UNUSED(flags);
+	return illegal_gpio_api_usage();
+}
+
+static int dummy_gpio_port_get_raw(const struct device *port, gpio_port_value_t *value)
+{
+	ARG_UNUSED(port); ARG_UNUSED(value);
+	return illegal_gpio_api_usage();
+}
+
+static int dummy_gpio_port_set_masked_raw(const struct device *port,
+					  gpio_port_pins_t mask, gpio_port_value_t value)
+{
+	ARG_UNUSED(port); ARG_UNUSED(mask); ARG_UNUSED(value);
+	return illegal_gpio_api_usage();
+}
+
+static int dummy_gpio_port_set_bits_raw(const struct device *port, gpio_port_pins_t pins)
+{
+	ARG_UNUSED(port); ARG_UNUSED(pins);
+	return illegal_gpio_api_usage();
+}
+
+static int dummy_gpio_port_clear_bits_raw(const struct device *port, gpio_port_pins_t pins)
+{
+	ARG_UNUSED(port); ARG_UNUSED(pins);
+	return illegal_gpio_api_usage();
+}
+
+static int dummy_gpio_port_toggle_bits(const struct device *port, gpio_port_pins_t pins)
+{
+	ARG_UNUSED(port); ARG_UNUSED(pins);
+	return illegal_gpio_api_usage();
+}
+
+static DEVICE_API(gpio, dummy_gpio_api) = {
+	.pin_configure = dummy_gpio_pin_configure,
+	.port_get_raw = dummy_gpio_port_get_raw,
+	.port_set_masked_raw = dummy_gpio_port_set_masked_raw,
+	.port_set_bits_raw = dummy_gpio_port_set_bits_raw,
+	.port_clear_bits_raw = dummy_gpio_port_clear_bits_raw,
+	.port_toggle_bits = dummy_gpio_port_toggle_bits,
+};
+#endif /* !CONFIG_GPIO_STM32 */
+
 #if defined(CONFIG_GPIO)
 #define GPIO_PORT_INIT_PRIORITY CONFIG_GPIO_INIT_PRIORITY
 #else /* CONFIG_GPIO */
@@ -302,10 +389,9 @@ __maybe_unused static int stm32_gpioport_init(const struct device *dev)
 
 #define GPIO_PORT_DEVICE_INIT(__node, __suffix, __base_addr, __port)		\
 	static const struct gpio_stm32_config gpio_stm32_cfg_## __suffix = {	\
-		IF_ENABLED(IS_ENABLED(CONFIG_GPIO_STM32), (			\
 		.common = {							\
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(16U),	\
-		},))								\
+		},								\
 		.base = (void *)__base_addr,					\
 		.port = __port,							\
 		IF_ENABLED(DT_NODE_HAS_PROP(__node, clocks),			\
@@ -326,7 +412,7 @@ __maybe_unused static int stm32_gpioport_init(const struct device *dev)
 			 PRE_KERNEL_1,						\
 			 GPIO_PORT_INIT_PRIORITY,				\
 			 COND_CODE_1(IS_ENABLED(CONFIG_GPIO_STM32),		\
-				(&gpio_stm32_driver), (NULL)))
+				(&gpio_stm32_driver), (&dummy_gpio_api)))
 
 #define GPIO_PORT_DEVICE_INIT_STM32(__suffix, __SUFFIX)				\
 	GPIO_PORT_DEVICE_INIT(DT_NODELABEL(gpio##__suffix),			\

--- a/soc/st/stm32/common/stm32_gpio_shared.h
+++ b/soc/st/stm32/common/stm32_gpio_shared.h
@@ -29,9 +29,7 @@
  * STM32 GPIO port configuration block and data block structures
  */
 struct gpio_stm32_config {
-#if defined(CONFIG_GPIO_STM32)
 	struct gpio_driver_config common;
-#endif /* CONFIG_GPIO_STM32 */
 
 	/* GPIO port base address */
 	void *base;
@@ -44,9 +42,9 @@ struct gpio_stm32_config {
 };
 
 struct gpio_stm32_data {
-#if defined(CONFIG_GPIO_STM32)
 	struct gpio_driver_data common;
 
+#if defined(CONFIG_GPIO_STM32)
 	/*
 	 * Keeps track of pins which are used as GPIOs
 	 * and need the GPIO port clock to remain enabled.


### PR DESCRIPTION
There are some (many?) applications and drivers which use the GPIO API without making sure to enable it first. Unfortunately, it is common for boards to enable CONFIG_GPIO=y in their defconfig, which allows these applications/drivers to work fine even though they don't explicitly enable the GPIO drivers they depend on... except when the target does not enable CONFIG_GPIO=y as expected, which is now the case on STM32 platforms.

Unfortunately, due to a combination of several factors, such misuses will currently result in runtime failures on STM32 platforms that are not immediately obvious to diagnose:
- the GPIO API is implemented entirely in headers and not gated behind any symbol - as a result, consumers of the API will build fine and there will be no link error due to missing subsystem code when the GPIO subsystem is disabled

- the GPIOport manager instantiates devices regardless of CONFIG_GPIO; as such, the `undefined reference to __device_dts_ord_NNN` link error that would be expected to occur doesn't and images build just fine

- when CONFIG_GPIO=n, the GPIOport devices have NULL as `api` pointer

The GPIO API functions expect `dev->api` to be valid - as do functions in every other Zephyr API - so they don't check that `dev->api != NULL` and blindly dereference `api` which is NULL in this case. If the MPU is enabled, this should fault immediately and could be easy to diagnose; however, if the MPU is not enabled, the NULL dereference will (usually) not fault and the resulting behavior is unpredictable.

Provide a dummy implementation of the GPIO API when CONFIG_GPIO=n such that calls to the API will fail gracefully and log a clear error message instead of causing unpredictable behavior, which should help users to diagnose the issue and fix their configuration.

A broader rework of the GPIOport manager organization could solve this issue by bringing back the link-time errors, but this is a much larger effort and I'm not sure the result will be satisfactory, so let's start with this first even though it is a bit hacky.