### PR TITLE
usb: host: wait bus reset completion and query the speed again

### DIFF
--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -37,6 +37,7 @@ struct max3421e_data {
 	struct uhc_transfer *last_xfer;
 	struct k_sem irq_sem;
 	atomic_t state;
+	enum usb_device_speed speed;
 	uint16_t tog_in;
 	uint16_t tog_out;
 	uint8_t addr;
@@ -574,14 +575,9 @@ static void max3421e_handle_condet(const struct device *dev)
 		type = UHC_EVT_DEV_REMOVED;
 	}
 
-	if (jk == MAX3421E_JSTATUS) {
+	if (jk == MAX3421E_JSTATUS || jk == MAX3421E_KSTATUS) {
 		/* Device connected */
-		type = UHC_EVT_DEV_CONNECTED_FS;
-	}
-
-	if (jk == MAX3421E_KSTATUS) {
-		/* Device connected */
-		type = UHC_EVT_DEV_CONNECTED_LS;
+		type = UHC_EVT_DEV_CONNECTED;
 	}
 
 	uhc_submit_event(dev, type, 0);
@@ -815,6 +811,22 @@ static int max3421e_dequeue(const struct device *dev,
 	irq_unlock(key);
 
 	return 0;
+}
+
+static enum usb_device_speed max3421e_get_speed(const struct device *dev)
+{
+	struct max3421e_data *priv = uhc_get_private(dev);
+	const uint8_t jk = priv->hrsl & MAX3421E_JKSTATUS_MASK;
+
+	if (jk == MAX3421E_JSTATUS) {
+		return USB_PORT_SPEED_FS;
+	}
+
+	if (jk == MAX3421E_KSTATUS) {
+		return USB_PORT_SPEED_LS;
+	}
+
+	return USB_PORT_SPEED_UNKNOWN;
 }
 
 static int max3421e_reset(const struct device *dev)
@@ -1113,6 +1125,8 @@ static const struct uhc_api max3421e_uhc_api = {
 	.enable = uhc_max3421e_enable,
 	.disable = uhc_max3421e_disable,
 	.shutdown = uhc_max3421e_shutdown,
+
+	.get_speed = max3421e_get_speed,
 
 	.bus_reset = max3421e_bus_reset,
 	.sof_enable  = max3421e_sof_enable,

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -37,7 +37,7 @@ struct max3421e_data {
 	struct uhc_transfer *last_xfer;
 	struct k_sem irq_sem;
 	atomic_t state;
-	enum usb_device_speed speed;
+	enum usb_port_speed speed;
 	uint16_t tog_in;
 	uint16_t tog_out;
 	uint8_t addr;
@@ -813,7 +813,7 @@ static int max3421e_dequeue(const struct device *dev,
 	return 0;
 }
 
-static enum usb_device_speed max3421e_get_speed(const struct device *dev)
+static enum usb_port_speed max3421e_get_speed(const struct device *dev)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
 	const uint8_t jk = priv->hrsl & MAX3421E_JKSTATUS_MASK;

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -92,6 +92,14 @@ int uhc_mcux_bus_reset(const struct device *dev)
 	return uhc_mcux_bus_control(dev, kUSB_HostBusReset);
 }
 
+/* Report the speed at which the port is operating */
+enum usb_device_speed uhc_mcux_get_speed(const struct device *dev)
+{
+	struct uhc_mcux_data *priv = uhc_get_private(dev);
+
+	return priv->speed;
+}
+
 /* Enable SOF generator */
 int uhc_mcux_sof_enable(const struct device *dev)
 {
@@ -131,19 +139,25 @@ usb_status_t USB_HostAttachDevice(usb_host_handle hostHandle, uint8_t speed, uin
 				  uint8_t portNumber, uint8_t level,
 				  usb_device_handle *deviceHandle)
 {
-	enum uhc_event_type type;
-	struct uhc_mcux_data *priv;
+	struct uhc_mcux_data *priv = (struct uhc_mcux_data *)(PRV_DATA_HANDLE(hostHandle));
 
-	if (speed == USB_SPEED_HIGH) {
-		type = UHC_EVT_DEV_CONNECTED_HS;
-	} else if (speed == USB_SPEED_FULL) {
-		type = UHC_EVT_DEV_CONNECTED_FS;
-	} else {
-		type = UHC_EVT_DEV_CONNECTED_LS;
+	/* Convert between NXP HAL and Zephyr variables */
+	switch (speed) {
+	case USB_SPEED_LOW:
+		priv->speed = USB_SPEED_SPEED_LS;
+		break;
+	case USB_SPEED_FULL:
+		priv->speed = USB_SPEED_SPEED_FS;
+		break;
+	case USB_SPEED_HIGH:
+		priv->speed = USB_SPEED_SPEED_HS;
+		break;
+	default:
+		priv->speed = USB_SPEED_UNKNOWN;
+		break;
 	}
 
-	priv = (struct uhc_mcux_data *)(PRV_DATA_HANDLE(hostHandle));
-	uhc_submit_event(priv->dev, type, 0);
+	uhc_submit_event(priv->dev, UHC_EVT_DEV_CONNECTED, 0);
 
 	return kStatus_USB_Success;
 }

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -93,7 +93,7 @@ int uhc_mcux_bus_reset(const struct device *dev)
 }
 
 /* Report the speed at which the port is operating */
-enum usb_device_speed uhc_mcux_get_speed(const struct device *dev)
+enum usb_port_speed uhc_mcux_get_speed(const struct device *dev)
 {
 	struct uhc_mcux_data *priv = uhc_get_private(dev);
 
@@ -144,16 +144,16 @@ usb_status_t USB_HostAttachDevice(usb_host_handle hostHandle, uint8_t speed, uin
 	/* Convert between NXP HAL and Zephyr variables */
 	switch (speed) {
 	case USB_SPEED_LOW:
-		priv->speed = USB_SPEED_SPEED_LS;
+		priv->speed = USB_PORT_SPEED_LS;
 		break;
 	case USB_SPEED_FULL:
-		priv->speed = USB_SPEED_SPEED_FS;
+		priv->speed = USB_PORT_SPEED_FS;
 		break;
 	case USB_SPEED_HIGH:
-		priv->speed = USB_SPEED_SPEED_HS;
+		priv->speed = USB_PORT_SPEED_HS;
 		break;
 	default:
-		priv->speed = USB_SPEED_UNKNOWN;
+		priv->speed = USB_PORT_SPEED_UNKNOWN;
 		break;
 	}
 
@@ -204,17 +204,17 @@ usb_status_t USB_HostHelperGetPeripheralInformation(usb_device_handle deviceHand
 
 	case kUSB_HostGetDeviceSpeed:
 		switch (udev->speed) {
-		case USB_SPEED_SPEED_LS:
+		case USB_PORT_SPEED_LS:
 			*infoValue = USB_SPEED_LOW;
 			break;
-		case USB_SPEED_SPEED_FS:
+		case USB_PORT_SPEED_FS:
 			*infoValue = USB_SPEED_FULL;
 			break;
-		case USB_SPEED_SPEED_HS:
+		case USB_PORT_SPEED_HS:
 			*infoValue = USB_SPEED_HIGH;
 			break;
-		case USB_SPEED_UNKNOWN:
-		case USB_SPEED_SPEED_SS:
+		case USB_PORT_SPEED_UNKNOWN:
+		case USB_PORT_SPEED_SS:
 		default:
 			*infoValue = USB_SPEED_HIGH;
 			/* TODO: report error */

--- a/drivers/usb/uhc/uhc_mcux_common.h
+++ b/drivers/usb/uhc/uhc_mcux_common.h
@@ -15,6 +15,7 @@ struct uhc_mcux_data {
 	uint16_t mcux_eps_interval[USB_HOST_CONFIG_MAX_PIPES];
 	usb_host_instance_t mcux_host;
 	struct k_thread drv_stack_data;
+	enum usb_device_speed speed;
 	uint8_t controller_id; /* MCUX hal controller id, 0xFF is invalid value */
 };
 
@@ -46,6 +47,9 @@ int uhc_mcux_shutdown(const struct device *dev);
 
 /* Signal bus reset, 50ms SE0 signal */
 int uhc_mcux_bus_reset(const struct device *dev);
+
+/* Report the speed at which the port is operating */
+enum usb_port_speed uhc_mcux_get_speed(const struct device *dev);
 
 /* Enable SOF generator */
 int uhc_mcux_sof_enable(const struct device *dev);

--- a/drivers/usb/uhc/uhc_mcux_common.h
+++ b/drivers/usb/uhc/uhc_mcux_common.h
@@ -15,7 +15,7 @@ struct uhc_mcux_data {
 	uint16_t mcux_eps_interval[USB_HOST_CONFIG_MAX_PIPES];
 	usb_host_instance_t mcux_host;
 	struct k_thread drv_stack_data;
-	enum usb_device_speed speed;
+	enum usb_port_speed speed;
 	uint8_t controller_id; /* MCUX hal controller id, 0xFF is invalid value */
 };
 

--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -322,6 +322,8 @@ static const struct uhc_api mcux_uhc_api = {
 	.disable = uhc_mcux_disable,
 	.shutdown = uhc_mcux_shutdown,
 
+	.get_speed = uhc_mcux_get_speed,
+
 	.bus_reset = uhc_mcux_bus_reset,
 	.sof_enable = uhc_mcux_sof_enable,
 	.bus_suspend = uhc_mcux_bus_suspend,

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -251,6 +251,8 @@ static const struct uhc_api mcux_uhc_api = {
 	.disable = uhc_mcux_disable,
 	.shutdown = uhc_mcux_shutdown,
 
+	.get_speed = uhc_mcux_get_speed,
+
 	.bus_reset = uhc_mcux_bus_reset,
 	.sof_enable = uhc_mcux_sof_enable,
 	.bus_suspend = uhc_mcux_bus_suspend,

--- a/drivers/usb/uhc/uhc_mcux_khci.c
+++ b/drivers/usb/uhc/uhc_mcux_khci.c
@@ -238,6 +238,8 @@ static const struct uhc_api mcux_uhc_api = {
 	.disable = uhc_mcux_disable,
 	.shutdown = uhc_mcux_shutdown,
 
+	.get_speed = uhc_mcux_get_speed,
+
 	.bus_reset = uhc_mcux_bus_reset,
 	.sof_enable = uhc_mcux_sof_enable,
 	.bus_suspend = uhc_mcux_bus_suspend,

--- a/drivers/usb/uhc/uhc_mcux_ohci.c
+++ b/drivers/usb/uhc/uhc_mcux_ohci.c
@@ -238,6 +238,8 @@ static const struct uhc_api mcux_uhc_api = {
 	.disable = uhc_mcux_disable,
 	.shutdown = uhc_mcux_shutdown,
 
+	.get_speed = uhc_mcux_get_speed,
+
 	.bus_reset = uhc_mcux_bus_reset,
 	.sof_enable = uhc_mcux_sof_enable,
 	.bus_suspend = uhc_mcux_bus_suspend,

--- a/drivers/usb/uhc/uhc_virtual.c
+++ b/drivers/usb/uhc/uhc_virtual.c
@@ -49,6 +49,7 @@ struct uhc_vrt_data {
 	struct uhc_transfer *last_xfer;
 	struct uhc_vrt_frame frame;
 	struct k_timer sof_timer;
+	enum usb_device_speed speed;
 	uint16_t frame_number;
 	uint8_t req;
 };
@@ -471,11 +472,13 @@ static void vrt_device_act(const struct device *dev,
 		type = UHC_EVT_RWUP;
 		break;
 	case UVB_DEVICE_ACT_FS:
-		type = UHC_EVT_DEV_CONNECTED_FS;
+		type = UHC_EVT_DEV_CONNECTED;
+		priv->speed = USB_SPEED_FULL;
 		k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
 		break;
 	case UVB_DEVICE_ACT_HS:
-		type = UHC_EVT_DEV_CONNECTED_HS;
+		type = UHC_EVT_DEV_CONNECTED;
+		priv->speed = USB_SPEED_HIGH;
 		k_timer_start(&priv->sof_timer, K_MSEC(1), K_USEC(125));
 		break;
 	case UVB_DEVICE_ACT_REMOVED:
@@ -520,6 +523,13 @@ static int uhc_vrt_bus_suspend(const struct device *dev)
 	k_timer_stop(&priv->sof_timer);
 
 	return uvb_advert(priv->host_node, UVB_EVT_SUSPEND, NULL);
+}
+
+static enum usb_device_speed uhc_vrt_get_speed(const struct device *dev)
+{
+	struct uhc_vrt_data *priv = uhc_get_private(dev);
+
+	return priv->speed;
 }
 
 static int uhc_vrt_bus_reset(const struct device *dev)
@@ -641,6 +651,8 @@ static const struct uhc_api uhc_vrt_api = {
 	.enable = uhc_vrt_enable,
 	.disable = uhc_vrt_disable,
 	.shutdown = uhc_vrt_shutdown,
+
+	.get_speed = uhc_vrt_get_speed,
 
 	.bus_reset = uhc_vrt_bus_reset,
 	.sof_enable  = uhc_vrt_sof_enable,

--- a/drivers/usb/uhc/uhc_virtual.c
+++ b/drivers/usb/uhc/uhc_virtual.c
@@ -49,7 +49,7 @@ struct uhc_vrt_data {
 	struct uhc_transfer *last_xfer;
 	struct uhc_vrt_frame frame;
 	struct k_timer sof_timer;
-	enum usb_device_speed speed;
+	enum usb_port_speed speed;
 	uint16_t frame_number;
 	uint8_t req;
 };
@@ -473,12 +473,12 @@ static void vrt_device_act(const struct device *dev,
 		break;
 	case UVB_DEVICE_ACT_FS:
 		type = UHC_EVT_DEV_CONNECTED;
-		priv->speed = USB_SPEED_FULL;
+		priv->speed = USB_PORT_SPEED_FS;
 		k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
 		break;
 	case UVB_DEVICE_ACT_HS:
 		type = UHC_EVT_DEV_CONNECTED;
-		priv->speed = USB_SPEED_HIGH;
+		priv->speed = USB_PORT_SPEED_HS;
 		k_timer_start(&priv->sof_timer, K_MSEC(1), K_USEC(125));
 		break;
 	case UVB_DEVICE_ACT_REMOVED:
@@ -525,7 +525,7 @@ static int uhc_vrt_bus_suspend(const struct device *dev)
 	return uvb_advert(priv->host_node, UVB_EVT_SUSPEND, NULL);
 }
 
-static enum usb_device_speed uhc_vrt_get_speed(const struct device *dev)
+static enum usb_port_speed uhc_vrt_get_speed(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
 

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -157,12 +157,8 @@ struct uhc_transfer {
  * @brief USB host controller event types
  */
 enum uhc_event_type {
-	/** Low speed device connected */
-	UHC_EVT_DEV_CONNECTED_LS,
-	/** Full speed device connected */
-	UHC_EVT_DEV_CONNECTED_FS,
-	/** High speed device connected */
-	UHC_EVT_DEV_CONNECTED_HS,
+	/** New device connected */
+	UHC_EVT_DEV_CONNECTED,
 	/** Device (peripheral) removed */
 	UHC_EVT_DEV_REMOVED,
 	/** Bus reset operation finished */
@@ -307,6 +303,8 @@ struct uhc_api {
 	int (*bus_suspend)(const struct device *dev);
 	int (*bus_resume)(const struct device *dev);
 
+	enum usb_device_speed (*get_speed)(const struct device *dev);
+
 	int (*ep_enqueue)(const struct device *dev,
 			  struct uhc_transfer *const xfer);
 	int (*ep_dequeue)(const struct device *dev,
@@ -405,6 +403,32 @@ static inline int uhc_bus_resume(const struct device *dev)
 	api->unlock(dev);
 
 	return ret;
+}
+
+/**
+ * @brief Get the USB speed at which the root port is operating
+ *
+ * Expected to be called after the bus reset did happen.
+ *
+ * @param[in] dev      Pointer to device struct of the driver instance
+ *
+ * @return The operating speed of the port.
+ */
+static inline enum usb_device_speed uhc_get_speed(const struct device *dev)
+{
+	const struct uhc_api *api = dev->api;
+	enum usb_port_speed speed;
+
+	if (api->get_speed == NULL) {
+		__ASSERT(false, "%s() is not implemented", __func__);
+		return USB_SPEED_UNKNOWN;
+	}
+
+	api->lock(dev);
+	speed = api->get_speed(dev);
+	api->unlock(dev);
+
+	return speed;
 }
 
 /**

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -37,19 +37,19 @@ enum usb_device_state {
 };
 
 /**
- * @brief USB device operating speed
+ * @brief USB port operating speed
  */
-enum usb_device_speed {
+enum usb_port_speed {
 	/** Device is probably not connected */
-	USB_SPEED_UNKNOWN,
-	/** Low speed */
-	USB_SPEED_SPEED_LS,
-	/** Full speed */
-	USB_SPEED_SPEED_FS,
-	/** High speed */
-	USB_SPEED_SPEED_HS,
-	/** Super speed */
-	USB_SPEED_SPEED_SS,
+	USB_PORT_SPEED_UNKNOWN,
+	/** Port at Low speed */
+	USB_PORT_SPEED_LS,
+	/** Port at Full speed */
+	USB_PORT_SPEED_FS,
+	/** Port at High speed */
+	USB_PORT_SPEED_HS,
+	/** Port at Super speed */
+	USB_PORT_SPEED_SS,
 };
 
 #define UHC_INTERFACES_MAX 32
@@ -83,7 +83,7 @@ struct usb_device {
 	/** Device state */
 	enum usb_device_state state;
 	/** Device speed */
-	enum usb_device_speed speed;
+	enum usb_port_speed speed;
 	/** Actual active device configuration */
 	uint8_t actual_cfg;
 	/** Device address */
@@ -303,7 +303,7 @@ struct uhc_api {
 	int (*bus_suspend)(const struct device *dev);
 	int (*bus_resume)(const struct device *dev);
 
-	enum usb_device_speed (*get_speed)(const struct device *dev);
+	enum usb_port_speed (*get_speed)(const struct device *dev);
 
 	int (*ep_enqueue)(const struct device *dev,
 			  struct uhc_transfer *const xfer);
@@ -414,14 +414,14 @@ static inline int uhc_bus_resume(const struct device *dev)
  *
  * @return The operating speed of the port.
  */
-static inline enum usb_device_speed uhc_get_speed(const struct device *dev)
+static inline enum usb_port_speed uhc_get_speed(const struct device *dev)
 {
 	const struct uhc_api *api = dev->api;
 	enum usb_port_speed speed;
 
 	if (api->get_speed == NULL) {
 		__ASSERT(false, "%s() is not implemented", __func__);
-		return USB_SPEED_UNKNOWN;
+		return USB_PORT_SPEED_UNKNOWN;
 	}
 
 	api->lock(dev);

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -782,7 +782,7 @@ static int find_format(struct uvc_host_data *const host_data,
 /* Check if an endpoint has enough bandwidth for the given transfer parameters */
 static bool ep_has_enough_bandwidth(const struct usb_ep_descriptor *ep_desc,
 				    const struct usb_if_descriptor *const if_desc,
-				    const enum usb_device_speed device_speed,
+				    const enum usb_port_speed device_speed,
 				    const uint32_t required_bandwidth,
 				    const uint32_t max_tpl)
 {
@@ -810,7 +810,7 @@ static bool ep_has_enough_bandwidth(const struct usb_ep_descriptor *ep_desc,
 	interval = BIT(ep_desc->bInterval - 1);
 	ep_mps = USB_MPS_EP_SIZE(ep_desc->wMaxPacketSize);
 
-	if (device_speed == USB_SPEED_SPEED_HS) {
+	if (device_speed == USB_PORT_SPEED_HS) {
 		ep_tpl = USB_MPS_TO_TPL(ep_desc->wMaxPacketSize);
 		/* High-speed: interval in microframes (125µs), 8000 microframes per second. */
 		ep_bandwidth = (ep_tpl * 8000) / interval;
@@ -823,7 +823,7 @@ static bool ep_has_enough_bandwidth(const struct usb_ep_descriptor *ep_desc,
 	LOG_DBG("Iface %u Alt %u EP 0x%02x: mps=%u, payload=%u, interval=%u (%s), bw=%u B/s",
 		if_desc->bInterfaceNumber, if_desc->bAlternateSetting, ep_desc->bEndpointAddress,
 		ep_mps, ep_tpl, interval,
-		(device_speed == USB_SPEED_SPEED_HS) ? "uframes" : "frames", ep_bandwidth);
+		(device_speed == USB_PORT_SPEED_HS) ? "uframes" : "frames", ep_bandwidth);
 
 	/* Check if this endpoint meets requirements */
 	if (ep_bandwidth >= required_bandwidth && ep_tpl >= max_tpl) {
@@ -835,7 +835,7 @@ static bool ep_has_enough_bandwidth(const struct usb_ep_descriptor *ep_desc,
 
 /* Calculate endpoint bandwidth */
 static uint32_t get_endpoint_bandwidth(const struct usb_ep_descriptor *ep_desc,
-				       const enum usb_device_speed device_speed)
+				       const enum usb_port_speed device_speed)
 {
 	uint32_t ep_tpl;
 	uint16_t ep_mps;
@@ -844,7 +844,7 @@ static uint32_t get_endpoint_bandwidth(const struct usb_ep_descriptor *ep_desc,
 	interval = BIT(ep_desc->bInterval - 1);
 	ep_mps = USB_MPS_EP_SIZE(ep_desc->wMaxPacketSize);
 
-	if (device_speed == USB_SPEED_SPEED_HS) {
+	if (device_speed == USB_PORT_SPEED_HS) {
 		ep_tpl = USB_MPS_TO_TPL(ep_desc->wMaxPacketSize);
 		/* High-speed: interval in microframes (125µs), 8000 microframes per second. */
 		return (ep_tpl * 8000) / interval;
@@ -856,11 +856,11 @@ static uint32_t get_endpoint_bandwidth(const struct usb_ep_descriptor *ep_desc,
 
 /* Get endpoint payload size */
 static uint32_t get_endpoint_payload_size(const struct usb_ep_descriptor *ep_desc,
-					  const enum usb_device_speed device_speed)
+					  const enum usb_port_speed device_speed)
 {
 	uint16_t ep_mps = USB_MPS_EP_SIZE(ep_desc->wMaxPacketSize);
 
-	if (device_speed == USB_SPEED_SPEED_HS) {
+	if (device_speed == USB_PORT_SPEED_HS) {
 		return USB_MPS_TO_TPL(ep_desc->wMaxPacketSize);
 	}
 
@@ -870,7 +870,7 @@ static uint32_t get_endpoint_payload_size(const struct usb_ep_descriptor *ep_des
 /* Scan endpoints in an interface for suitable bandwidth */
 static const struct usb_ep_descriptor *
 scan_interface_endpoints(const struct usb_if_descriptor *const if_desc,
-			 const enum usb_device_speed device_speed,
+			 const enum usb_port_speed device_speed,
 			 uint32_t required_bandwidth, uint32_t max_tpl,
 			 uint32_t *found_bandwidth)
 {
@@ -926,7 +926,7 @@ static int select_streaming_alternate(struct uvc_host_data *const host_data,
 {
 	struct uvc_stream_iface_info *const stream_info = &host_data->current_stream_iface_info;
 	uint32_t max_tpl = sys_le32_to_cpu(host_data->probe.dwMaxPayloadTransferSize);
-	const enum usb_device_speed device_speed = host_data->udev->speed;
+	const enum usb_port_speed device_speed = host_data->udev->speed;
 	const struct usb_if_descriptor *selected_interface = NULL;
 	const struct usb_ep_descriptor *selected_endpoint = NULL;
 	const struct usb_if_descriptor *if_desc;
@@ -937,7 +937,7 @@ static int select_streaming_alternate(struct uvc_host_data *const host_data,
 
 	LOG_DBG("Required bandwidth: %u bytes/sec, Max payload: %u bytes (device speed: %s)",
 		required_bandwidth, max_tpl,
-		(device_speed == USB_SPEED_SPEED_HS) ? "High Speed" : "Full Speed");
+		(device_speed == USB_PORT_SPEED_HS) ? "High Speed" : "Full Speed");
 
 	/* Scan all streaming interfaces */
 	for (uint8_t i = 0;

--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -44,8 +44,7 @@ static int usbh_event_carrier(const struct device *dev,
 	return err;
 }
 
-static void dev_connected_handler(struct usbh_context *const ctx,
-				  const struct uhc_event *const event)
+static void dev_connected_handler(struct usbh_context *const ctx)
 {
 	struct usb_device *udev;
 
@@ -54,12 +53,6 @@ static void dev_connected_handler(struct usbh_context *const ctx,
 	if (udev == NULL) {
 		LOG_ERR("Failed allocate new device");
 		return;
-	}
-
-	if (event->type == UHC_EVT_DEV_CONNECTED_HS) {
-		udev->speed = USB_SPEED_SPEED_HS;
-	} else {
-		udev->speed = USB_SPEED_SPEED_FS;
 	}
 
 	usbh_device_connect(ctx, udev);
@@ -96,12 +89,8 @@ static ALWAYS_INLINE int usbh_event_handler(struct usbh_context *const ctx,
 	int ret = 0;
 
 	switch (event->type) {
-	case UHC_EVT_DEV_CONNECTED_LS:
-		LOG_ERR("Low speed device not supported (connected event)");
-		break;
-	case UHC_EVT_DEV_CONNECTED_FS:
-	case UHC_EVT_DEV_CONNECTED_HS:
-		dev_connected_handler(ctx, event);
+	case UHC_EVT_DEV_CONNECTED:
+		dev_connected_handler(ctx);
 		break;
 	case UHC_EVT_DEV_REMOVED:
 		dev_removed_handler(ctx);

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -76,19 +76,19 @@ static int validate_device_mps0(const struct usb_device *const udev)
 {
 	const uint8_t mps0 = udev->dev_desc.bMaxPacketSize0;
 
-	if (udev->speed == USB_SPEED_SPEED_SS || udev->speed == USB_SPEED_SPEED_LS) {
+	if (udev->speed == USB_PORT_SPEED_SS || udev->speed == USB_PORT_SPEED_LS) {
 		LOG_ERR("USB device speed not supported");
 		return -ENOTSUP;
 	}
 
-	if (udev->speed == USB_SPEED_SPEED_HS) {
+	if (udev->speed == USB_PORT_SPEED_HS) {
 		if (mps0 != 64) {
 			LOG_ERR("HS device has wrong bMaxPacketSize0 %u", mps0);
 			return -EINVAL;
 		}
 	}
 
-	if (udev->speed == USB_SPEED_SPEED_FS) {
+	if (udev->speed == USB_PORT_SPEED_FS) {
 		if (mps0 != 8 && mps0 != 16 && mps0 != 32 && mps0 != 64) {
 			LOG_ERR("FS device has wrong bMaxPacketSize0 %u", mps0);
 			return -EINVAL;
@@ -594,9 +594,9 @@ int usbh_device_init(struct usb_device *const udev)
 	}
 
 	LOG_INF("New %s-speed device with address %u state %u",
-		udev->speed == USB_SPEED_SPEED_LS ? "low" :
-		udev->speed == USB_SPEED_SPEED_FS ? "full" :
-		udev->speed == USB_SPEED_SPEED_HS ? "high" : "unknown",
+		udev->speed == USB_PORT_SPEED_LS ? "low" :
+		udev->speed == USB_PORT_SPEED_FS ? "full" :
+		udev->speed == USB_PORT_SPEED_HS ? "high" : "unknown",
 		udev->addr, udev->state);
 
 	err = usbh_device_set_configuration(udev, 1);

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -550,6 +550,8 @@ int usbh_device_init(struct usb_device *const udev)
 			LOG_ERR("Failed to signal bus reset");
 			return err;
 		}
+
+		udev->speed = uhc_get_speed(uhs_ctx->dev);
 	}
 
 	/*
@@ -591,7 +593,11 @@ int usbh_device_init(struct usb_device *const udev)
 		goto error;
 	}
 
-	LOG_INF("New device with address %u state %u", udev->addr, udev->state);
+	LOG_INF("New %s-speed device with address %u state %u",
+		udev->speed == USB_SPEED_SPEED_LS ? "low" :
+		udev->speed == USB_SPEED_SPEED_FS ? "full" :
+		udev->speed == USB_SPEED_SPEED_HS ? "high" : "unknown",
+		udev->addr, udev->state);
 
 	err = usbh_device_set_configuration(udev, 1);
 	if (err) {


### PR DESCRIPTION
- https://github.com/zephyrproject-rtos/zephyr/issues/102931

A high-speed capable device is required to initially attach as a full-speed device and must transition to high-speed during Bus reset as described in usb 2.0 specification, Section 7.1.7.5 Reset signaling

This means devices need to report their operating speed after the reset, and not at connection time.

A new `api->get_speed()` is introduced to query the operating speed of the port after the rest happened.

Tested with DWC2 here:

- https://github.com/zephyrproject-rtos/zephyr/pull/108069