### PR TITLE
dts: arm: st: add DFSDM peripheral for stm32l4xx series

### DIFF
--- a/boards/st/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/st/stm32l476g_disco/stm32l476g_disco.dts
@@ -17,6 +17,10 @@
 	model = "STMicroelectronics STM32L476G-DISCO board";
 	compatible = "st,stm32l476g-disco";
 
+	aliases {
+		i2s-codec-tx = &sai1_a;
+	};
+
 	chosen {
 		zephyr,console = &usart2;
 		zephyr,shell-uart = &usart2;
@@ -96,6 +100,14 @@
 	status = "okay";
 };
 
+&pllsai1 {
+	div-m = <1>;
+	mul-n = <22>;
+	div-p = <7>;
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
 &rcc {
 	clocks = <&pll>;
 	clock-frequency = <DT_FREQ_M(80)>;
@@ -119,4 +131,50 @@
 	backup_regs {
 		status = "okay";
 	};
+};
+
+&sai1_a {
+	pinctrl-0 = <&sai1_mclk_a_pe2 &sai1_sd_a_pe6
+		     &sai1_fs_a_pe4 &sai1_sck_a_pe5>;
+	pinctrl-names = "default";
+	mclk-enable;
+	mclk-divider = "div-256";
+	dma-names = "tx";
+	status = "okay";
+};
+
+&i2c1 {
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	audio_codec: cs43l22@4a {
+		compatible = "cirrus,cs43l22";
+		reg = <0x4a>;
+		reset-gpios = <&gpioe 3 0>;
+	};
+};
+
+&dfsdm {
+	dmic_dev: filter@0 {
+		pinctrl-0 = <&dfsdm1_ckout_pe9
+			     &dfsdm1_datin2_pe7>;
+		pinctrl-names = "default";
+		status = "okay";
+
+		channel@2 {
+			reg = <2>;
+		};
+	};
+
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&sai1 {
+	status = "okay";
 };

--- a/boards/st/stm32l476g_disco/stm32l476g_disco.yaml
+++ b/boards/st/stm32l476g_disco/stm32l476g_disco.yaml
@@ -10,4 +10,5 @@ flash: 1024
 supported:
   - gpio
   - counter
+  - dmic
 vendor: st

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -171,6 +171,38 @@
 				status = "disabled";
 			};
 		};
+
+		dfsdm: dfsdm@40016000 {
+			compatible = "st,stm32-dfsdm";
+			reg = <0x40016000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 24)>,
+				 <&rcc STM32_SRC_PLLSAI1_P NO_SEL>;
+			clock-names = "pclk", "aclk";
+			resets = <&rctl STM32_RESET(APB2, 24)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+
+			pdm0: filter@0 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <0>;
+				interrupts = <61 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm1: filter@1 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <1>;
+				interrupts = <62 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
 	};
 
 	smbus2: smbus2 {

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -328,6 +328,58 @@
 				status = "disabled";
 			};
 		};
+
+		dfsdm: dfsdm@40016000 {
+			compatible = "st,stm32-dfsdm";
+			reg = <0x40016000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 24)>,
+				 <&rcc STM32_SRC_PLLSAI1_P NO_SEL>;
+			clock-names = "pclk", "aclk";
+			resets = <&rctl STM32_RESET(APB2, 24)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+
+			pdm0: filter@0 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <0>;
+				interrupts = <61 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm1: filter@1 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <1>;
+				interrupts = <62 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm2: filter@2 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <2>;
+				interrupts = <63 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm3: filter@3 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <3>;
+				interrupts = <42 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
 	};
 
 	die_temp: dietemp {

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -471,6 +471,38 @@
 			health-test-magic = <0x17590abc>;
 			health-test-config = <0xaa74>;
 		};
+
+		dfsdm: dfsdm@40016000 {
+			compatible = "st,stm32-dfsdm";
+			reg = <0x40016000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 24)>,
+				 <&rcc STM32_SRC_PLLSAI1_P NO_SEL>;
+			clock-names = "pclk", "aclk";
+			resets = <&rctl STM32_RESET(APB2, 24)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+
+			pdm0: filter@0 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <0>;
+				interrupts = <61 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm1: filter@1 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <1>;
+				interrupts = <62 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
 	};
 
 	otgfs_phy: otgfs_phy {

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -50,5 +50,27 @@
 			/delete-property/ health-test-magic;
 			/delete-property/ health-test-config;
 		};
+
+		dfsdm: dfsdm@40016000 {
+			pdm2: filter@2 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <2>;
+				interrupts = <63 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm3: filter@3 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <3>;
+				interrupts = <42 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
 	};
 };

--- a/samples/drivers/audio/dmic/boards/stm32l476g_disco.conf
+++ b/samples/drivers/audio/dmic/boards/stm32l476g_disco.conf
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SAMPLE_HW_CHANNEL_INDEX=2


### PR DESCRIPTION
This PR aims to add support of DFSDM on STM32L4xx series, and specifically on `stm32l476g_disco` board.

Fortunately this board possesses a Cirrus CS43L22 audio codec, which is already supported on Zephyr.  This means that on this board, `dmic` and `i2s_codec` samples can be enabled.