### PR TITLE
manifest: tf-m: include fixes for STM32 platform

### DIFF
--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -32,6 +32,7 @@ tests:
   sample.tfm.tfm_ipc.bl2.rsa2048:
     platform_allow:
       - mps2/an521/cpu0/ns
+      - stm32h573i_dk/stm32h573xx/ns
     extra_configs:
       - CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE="RSA-2048"
   sample.tfm.tfm_ipc.bl2.rsa3072:
@@ -52,10 +53,12 @@ tests:
       - bl5340_dvk/nrf5340/cpuapp/ns
       - frdm_mcxn947/mcxn947/cpu0/ns
       - frdm_mcxa577/mcxa577/ns
+      - stm32h573i_dk/stm32h573xx/ns
     extra_configs:
       - CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE="EC-P256"
   sample.tfm.tfm_ipc.bl2.ecp384:
     platform_allow:
       - mps2/an521/cpu0/ns
+      - stm32h573i_dk/stm32h573xx/ns
     extra_configs:
       - CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE="EC-P384"

--- a/west.yml
+++ b/west.yml
@@ -399,7 +399,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 35210614ac5ab8b3334a385a4f07dbd209390a05
+      revision: fc9c70171ae43bfd99c57a7ca6374d7f4fa8e894
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
This includes now fixed support for ECDSA signatures in BL2. Enable the respective tests.