### PR TITLE
OpenRISC Improvements: add LLEXT support, various fixes

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -76,6 +76,7 @@ config OPENRISC
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
 	select ARCH_HAS_THREAD_LOCAL_STORAGE
+	select ARCH_HAS_CODE_DATA_RELOCATION
 	help
 	  OpenRISC architecture
 

--- a/arch/openrisc/core/CMakeLists.txt
+++ b/arch/openrisc/core/CMakeLists.txt
@@ -19,3 +19,4 @@ zephyr_library_sources(
 
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)
 zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE tls.c)
+zephyr_library_sources_ifdef(CONFIG_LLEXT elf.c)

--- a/arch/openrisc/core/elf.c
+++ b/arch/openrisc/core/elf.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2025 NVIDIA Corporation <jholdsworth@nvidia.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief OpenRISC (or1k) ELF relocation support for LLEXT.
+ *
+ * Implements arch_elf_relocate() for the OpenRISC architecture,
+ * handling the relocation types needed for statically-linked
+ * loadable extensions (ELF objects / relocatable ELFs).
+ */
+
+#include <zephyr/llext/elf.h>
+#include <zephyr/llext/llext.h>
+#include <zephyr/llext/llext_internal.h>
+#include <zephyr/llext/loader.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+#include <zephyr/arch/openrisc/elf.h>
+
+LOG_MODULE_REGISTER(elf, CONFIG_LLEXT_LOG_LEVEL);
+
+/**
+ * @brief Apply an OR1K ELF relocation.
+ *
+ * Nomenclature (following ELF specification conventions):
+ *   S = symbol value (sym_base_addr)
+ *   A = addend (rel->r_addend)
+ *   P = place / location of the relocation (loc)
+ */
+int arch_elf_relocate(struct llext_loader *ldr, struct llext *ext, elf_rela_t *rel,
+		      const elf_shdr_t *shdr)
+{
+	const elf_word reloc_type = ELF32_R_TYPE(rel->r_info);
+	const uintptr_t loc = llext_get_reloc_instruction_location(ldr, ext, shdr->sh_info, rel);
+	elf_sym_t sym;
+	uintptr_t sym_base_addr;
+	uint32_t insn;
+	intptr_t value;
+	int ret;
+
+	ret = llext_read_symbol(ldr, ext, rel, &sym);
+	if (ret != 0) {
+		return ret;
+	}
+
+	const char *const sym_name = llext_symbol_name(ldr, ext, &sym);
+
+	ret = llext_lookup_symbol(ldr, ext, &sym_base_addr, rel, &sym, sym_name, shdr);
+	if (ret != 0) {
+		LOG_ERR("Could not find symbol %s!", sym_name);
+		return ret;
+	}
+
+	LOG_DBG("Relocating symbol %s at %p with base addr %p type %" PRIu32,
+		sym_name, (void *)loc, (void *)sym_base_addr, reloc_type);
+
+	switch (reloc_type) {
+	case R_OR1K_NONE:
+		break;
+
+	/* --- Absolute data relocations --- */
+
+	case R_OR1K_32:
+	case R_OR1K_TLS_TPOFF:
+		/* S + A (32-bit absolute) */
+		*(uint32_t *)loc += sym_base_addr + rel->r_addend;
+		break;
+
+	case R_OR1K_32_PCREL:
+		/* S + A - P (32-bit PC-relative) */
+		*(uint32_t *)loc += sym_base_addr + rel->r_addend - loc;
+		break;
+
+	/* --- Instruction-immediate relocations --- */
+
+	case R_OR1K_INSN_REL_26:
+		/* (S + A - P) >> 2, placed in insn[25:0] */
+		value = (intptr_t)(sym_base_addr + rel->r_addend) - (intptr_t)loc;
+		if (value & 3) {
+			LOG_ERR("Misaligned branch target for %s: 0x%lx",
+				sym_name, (unsigned long)value);
+			return -ENOEXEC;
+		}
+		insn = *(uint32_t *)loc;
+		insn = (insn & ~R_OR1K_INSN_REL_26_MASK) |
+		       (((uint32_t)(value >> 2)) & R_OR1K_INSN_REL_26_MASK);
+		*(uint32_t *)loc = insn;
+		break;
+
+	case R_OR1K_HI_16_IN_INSN:
+	case R_OR1K_TLS_LE_HI16:
+		/* (S + A) >> 16, placed in insn[15:0] */
+		value = (intptr_t)(sym_base_addr + rel->r_addend);
+		insn = *(uint32_t *)loc;
+		insn = (insn & ~R_OR1K_IMM16_MASK) |
+		       (((uint32_t)(value >> 16)) & R_OR1K_IMM16_MASK);
+		*(uint32_t *)loc = insn;
+		break;
+
+	case R_OR1K_LO_16_IN_INSN:
+	case R_OR1K_TLS_LE_LO16:
+		/* (S + A) & 0xFFFF, placed in insn[15:0] */
+		value = (intptr_t)(sym_base_addr + rel->r_addend);
+		insn = *(uint32_t *)loc;
+		insn = (insn & ~R_OR1K_IMM16_MASK) |
+		       ((uint32_t)value & R_OR1K_IMM16_MASK);
+		*(uint32_t *)loc = insn;
+		break;
+
+	case R_OR1K_AHI16:
+	case R_OR1K_TLS_LE_AHI16:
+		/* ((S + A) + 0x8000) >> 16, placed in insn[15:0]
+		 * "Adjusted high" compensates for sign-extension of paired LO16.
+		 */
+		value = (intptr_t)(sym_base_addr + rel->r_addend) + 0x8000;
+		insn = *(uint32_t *)loc;
+		insn = (insn & ~R_OR1K_IMM16_MASK) |
+		       (((uint32_t)(value >> 16)) & R_OR1K_IMM16_MASK);
+		*(uint32_t *)loc = insn;
+		break;
+
+	case R_OR1K_SLO16:
+	case R_OR1K_TLS_LE_SLO16:
+		/* (S + A) & 0xFFFF, in split-immediate store format:
+		 *   insn[25:21] = imm[15:11]
+		 *   insn[10:0]  = imm[10:0]
+		 */
+		value = (intptr_t)(sym_base_addr + rel->r_addend);
+		insn = *(uint32_t *)loc;
+		insn = R_OR1K_SLO_PACK(insn, (uint32_t)value & R_OR1K_IMM16_MASK);
+		*(uint32_t *)loc = insn;
+		break;
+
+	/* --- Page-relative relocations (ADRP-style, 8KB pages) --- */
+
+	case R_OR1K_PCREL_PG21:
+		/* ((S + A) & PAGE_MASK) - (P & PAGE_MASK)) >> 13, placed in insn[20:0] */
+		value = (intptr_t)(((sym_base_addr + rel->r_addend) & R_OR1K_PAGE_MASK) -
+				   (loc & R_OR1K_PAGE_MASK));
+		insn = *(uint32_t *)loc;
+		insn = (insn & ~R_OR1K_PG21_MASK) |
+		       (((uint32_t)(value >> 13)) & R_OR1K_PG21_MASK);
+		*(uint32_t *)loc = insn;
+		break;
+
+	case R_OR1K_LO13:
+		/* (S + A) & 0x1FFF, placed in insn[15:0] (only 13 bits meaningful) */
+		value = (intptr_t)(sym_base_addr + rel->r_addend);
+		insn = *(uint32_t *)loc;
+		insn = (insn & ~R_OR1K_IMM16_MASK) |
+		       ((uint32_t)value & (R_OR1K_PAGE_SIZE - 1U));
+		*(uint32_t *)loc = insn;
+		break;
+
+	case R_OR1K_SLO13:
+		/* (S + A) & 0x1FFF, in split-immediate store format */
+		value = (intptr_t)(sym_base_addr + rel->r_addend);
+		insn = *(uint32_t *)loc;
+		insn = R_OR1K_SLO_PACK(insn, (uint32_t)value & (R_OR1K_PAGE_SIZE - 1U));
+		*(uint32_t *)loc = insn;
+		break;
+
+	default:
+		LOG_ERR("Unsupported relocation type %" PRIu32 " for symbol %s at %p",
+			reloc_type, sym_name, (void *)loc);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}

--- a/boards/qemu/or1k/board.cmake
+++ b/boards/qemu/or1k/board.cmake
@@ -6,7 +6,7 @@ set(QEMU_binary_suffix or1k)
 set(QEMU_CPU_TYPE_${ARCH} or1k)
 
 set(QEMU_FLAGS_${ARCH}
-  -machine or1k-sim
+  -machine virt
   -nographic
 )
 

--- a/boards/qemu/or1k/qemu_or1k.dts
+++ b/boards/qemu/or1k/qemu_or1k.dts
@@ -11,8 +11,8 @@
 
 	chosen {
 		zephyr,sram = &sram0;
-		zephyr,console = &uart3;
-		zephyr,shell-uart = &uart3;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 
 	cpus {
@@ -39,7 +39,7 @@
 		reg = <0x00000000 0x08000000>;
 	};
 
-	uart3: serial@90000000 {
+	uart0: serial@90000000 {
 		compatible = "ns16550";
 		reg = <0x90000000 0x100>;
 		reg-shift = <0>;

--- a/boards/qemu/or1k/qemu_or1k.dts
+++ b/boards/qemu/or1k/qemu_or1k.dts
@@ -5,7 +5,7 @@
 #include "skeleton.dtsi"
 
 / {
-	model = "Qemu OpenRISC 1000";
+	model = "QEMU OpenRISC 1000 virt";
 	compatible = "opencores,or1ksim";
 	interrupt-parent = <&pic>;
 

--- a/boards/qemu/or1k/qemu_or1k.yaml
+++ b/boards/qemu/or1k/qemu_or1k.yaml
@@ -7,7 +7,7 @@ arch: openrisc
 toolchain:
   - zephyr
   - cross-compile
-ram: 128
+ram: 131072
 testing:
   default: true
   ignore_tags:

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -81,6 +81,8 @@ elseif("${ARCH}" STREQUAL "xtensa")
   include(${CMAKE_CURRENT_LIST_DIR}/target_xtensa.cmake)
 elseif("${ARCH}" STREQUAL "rx")
   include(${CMAKE_CURRENT_LIST_DIR}/target_rx.cmake)
+elseif("${ARCH}" STREQUAL "openrisc")
+  include(${CMAKE_CURRENT_LIST_DIR}/target_openrisc.cmake)
 endif()
 
 if(SYSROOT_DIR)

--- a/cmake/compiler/gcc/target_openrisc.cmake
+++ b/cmake/compiler/gcc/target_openrisc.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 NVIDIA Corporation <jholdsworth@nvidia.com>
+# SPDX-License-Identifier: Apache-2.0
+
+# OpenRISC runs code from RAM (non-XIP), so the RAM region in the linker
+# script legitimately needs RWX permissions.  Suppress the ld >= 2.39
+# warning that would otherwise become an error with --fatal-warnings.
+list(APPEND TOOLCHAIN_LD_FLAGS -Wl,--no-warn-rwx-segments)

--- a/cmake/compiler/gcc/target_openrisc.cmake
+++ b/cmake/compiler/gcc/target_openrisc.cmake
@@ -5,3 +5,18 @@
 # script legitimately needs RWX permissions.  Suppress the ld >= 2.39
 # warning that would otherwise become an error with --fatal-warnings.
 list(APPEND TOOLCHAIN_LD_FLAGS -Wl,--no-warn-rwx-segments)
+
+# Flags not supported by llext linker
+# (regexps are supported and match whole word)
+set(LLEXT_REMOVE_FLAGS
+  -fno-pic
+  -fno-pie
+  -ffunction-sections
+  -fdata-sections
+  -g.*
+  -Os
+  )
+
+# Flags to be added to llext code compilation
+set(LLEXT_APPEND_FLAGS
+  )

--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -321,8 +321,8 @@ elseif(QEMU_NET_STACK)
   endif()
 endif(QEMU_PIPE_STACK)
 
-if(CONFIG_CAN AND NOT (CONFIG_SOC_LEON3))
-  # Add CAN bus 0
+if(CONFIG_CAN_KVASER_PCI)
+  # Add CAN bus 0 only when QEMU-emulated CAN hardware is actually needed
   list(APPEND QEMU_FLAGS -object can-bus,id=canbus0)
 
   if(NOT "${CONFIG_CAN_QEMU_IFACE_NAME}" STREQUAL "")
@@ -332,10 +332,8 @@ if(CONFIG_CAN AND NOT (CONFIG_SOC_LEON3))
     )
   endif()
 
-  if(CONFIG_CAN_KVASER_PCI)
-    # Emulate a single-channel Kvaser PCIcan card connected to CAN bus 0
-    list(APPEND QEMU_FLAGS -device kvaser_pci,canbus=canbus0)
-  endif()
+  # Emulate a single-channel Kvaser PCIcan card connected to CAN bus 0
+  list(APPEND QEMU_FLAGS -device kvaser_pci,canbus=canbus0)
 endif()
 
 if(CONFIG_X86_64 AND NOT CONFIG_QEMU_UEFI_BOOT)

--- a/include/zephyr/arch/openrisc/elf.h
+++ b/include/zephyr/arch/openrisc/elf.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025 NVIDIA Corporation <jholdsworth@nvidia.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief OpenRISC (or1k) ELF relocation type definitions and helpers for LLEXT.
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_OPENRISC_ELF_H_
+#define ZEPHYR_INCLUDE_ARCH_OPENRISC_ELF_H_
+
+/**
+ * @brief OpenRISC relocation types
+ *
+ * From the official OR1K ELF specification and binutils.
+ * @cond ignore
+ */
+
+/* Basic relocations */
+#define R_OR1K_NONE             0
+#define R_OR1K_32               1
+#define R_OR1K_16               2
+#define R_OR1K_8                3
+#define R_OR1K_LO_16_IN_INSN    4
+#define R_OR1K_HI_16_IN_INSN    5
+#define R_OR1K_INSN_REL_26      6
+#define R_OR1K_GNU_VTENTRY      7
+#define R_OR1K_GNU_VTINHERIT    8
+#define R_OR1K_32_PCREL         9
+#define R_OR1K_16_PCREL         10
+#define R_OR1K_8_PCREL          11
+
+/* GOT/PLT relocations */
+#define R_OR1K_GOTPC_HI16       12
+#define R_OR1K_GOTPC_LO16       13
+#define R_OR1K_GOT16            14
+#define R_OR1K_PLT26            15
+#define R_OR1K_GOTOFF_HI16      16
+#define R_OR1K_GOTOFF_LO16      17
+
+/* Dynamic relocations */
+#define R_OR1K_COPY             18
+#define R_OR1K_GLOB_DAT         19
+#define R_OR1K_JMP_SLOT         20
+#define R_OR1K_RELATIVE         21
+
+/* TLS relocations */
+#define R_OR1K_TLS_GD_HI16      22
+#define R_OR1K_TLS_GD_LO16      23
+#define R_OR1K_TLS_LDM_HI16     24
+#define R_OR1K_TLS_LDM_LO16     25
+#define R_OR1K_TLS_LDO_HI16     26
+#define R_OR1K_TLS_LDO_LO16     27
+#define R_OR1K_TLS_IE_HI16      28
+#define R_OR1K_TLS_IE_LO16      29
+#define R_OR1K_TLS_LE_HI16      30
+#define R_OR1K_TLS_LE_LO16      31
+#define R_OR1K_TLS_TPOFF        32
+#define R_OR1K_TLS_DTPOFF       33
+#define R_OR1K_TLS_DTPMOD       34
+
+/* Adjusted high / split-immediate relocations */
+#define R_OR1K_AHI16            35
+#define R_OR1K_GOTOFF_AHI16     36
+#define R_OR1K_TLS_IE_AHI16     37
+#define R_OR1K_TLS_LE_AHI16     38
+#define R_OR1K_SLO16            39
+#define R_OR1K_GOTOFF_SLO16     40
+#define R_OR1K_TLS_LE_SLO16     41
+
+/* Page-relative relocations */
+#define R_OR1K_PCREL_PG21       42
+#define R_OR1K_GOT_PG21         43
+#define R_OR1K_TLS_GD_PG21      44
+#define R_OR1K_TLS_LDM_PG21     45
+#define R_OR1K_TLS_IE_PG21      46
+#define R_OR1K_LO13             47
+#define R_OR1K_GOT_LO13         48
+#define R_OR1K_TLS_GD_LO13      49
+#define R_OR1K_TLS_LDM_LO13     50
+#define R_OR1K_TLS_IE_LO13      51
+#define R_OR1K_SLO13            52
+#define R_OR1K_PLTA26           53
+#define R_OR1K_GOT_AHI16        54
+
+/** @endcond */
+
+/**
+ * @brief OR1K instruction field masks
+ *
+ * OR1K instructions are fixed 32-bit, big-endian.
+ * Immediate fields are located in the low bits of the instruction word.
+ */
+
+/** Mask for the 26-bit jump/branch target field (bits [25:0]) */
+#define R_OR1K_INSN_REL_26_MASK   0x03ffffffU
+
+/** Mask for the 16-bit immediate field (bits [15:0]) - used by l.ori, l.addi, l.movhi, etc. */
+#define R_OR1K_IMM16_MASK         0x0000ffffU
+
+/** Mask for the 21-bit page-relative field (bits [20:0]) - used by l.adrp */
+#define R_OR1K_PG21_MASK          0x001fffffU
+
+/**
+ * @brief Split-immediate mask for OR1K store instructions.
+ *
+ * Store instructions (l.sw, l.sb, l.sh) encode a 16-bit signed immediate
+ * split across two non-contiguous fields:
+ *   - Bits [15:11] of the immediate → instruction bits [25:21]
+ *   - Bits [10:0] of the immediate → instruction bits [10:0]
+ *
+ * The combined field mask is 0x03E007FF.
+ */
+#define R_OR1K_SLO_FIELD_MASK     0x03e007ffU
+
+/**
+ * @brief Pack a 16-bit immediate into the OR1K split-immediate store format.
+ *
+ * @param insn  The existing 32-bit instruction word
+ * @param imm   The 16-bit immediate value to pack
+ * @return      The instruction word with the immediate inserted
+ */
+#define R_OR1K_SLO_PACK(insn, imm) \
+	(((insn) & ~R_OR1K_SLO_FIELD_MASK) | \
+	 (((uint32_t)(imm) & 0xf800U) << 10) | \
+	 ((uint32_t)(imm) & 0x07ffU))
+
+/** OR1K page size for PCREL_PG21 relocations (8 KB = 2^13) */
+#define R_OR1K_PAGE_SIZE          8192U
+/** OR1K page mask for PCREL_PG21 relocations (8 KB aligned) */
+#define R_OR1K_PAGE_MASK          (~(R_OR1K_PAGE_SIZE - 1U))
+
+#endif /* ZEPHYR_INCLUDE_ARCH_OPENRISC_ELF_H_ */

--- a/include/zephyr/arch/openrisc/linker.ld
+++ b/include/zephyr/arch/openrisc/linker.ld
@@ -64,6 +64,7 @@ PROVIDE (__stack = RAM_BASE + (RAM_SIZE - 1024));
 SECTIONS
 {
 #include <zephyr/linker/rel-sections.ld>
+#include <zephyr/linker/llext-sections.ld>
 
     SECTION_PROLOGUE(.plt,,)
 	{

--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -87,6 +87,8 @@ void entry_cpu_exception(void *p1, void *p2, void *p3)
 #elif defined(CONFIG_RISCV)
 	/* Illegal instruction on RISCV. */
 	__asm__ volatile (".word 0x77777777");
+#elif defined(CONFIG_OPENRISC)
+	__asm__ volatile ("l.trap 0");
 #else
 	/* Triggers usage fault on ARM, illegal instruction on
 	 * xtensa, TLB exception (instruction fetch) on MIPS.

--- a/tests/subsys/llext/tests.yaml
+++ b/tests/subsys/llext/tests.yaml
@@ -40,6 +40,7 @@ tests:
       - riscv
       - arc
       - x86
+      - openrisc
     filter: not CONFIG_MPU and not CONFIG_MMU
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
@@ -52,6 +53,7 @@ tests:
       - riscv
       - arc
       - x86
+      - openrisc
     filter: not CONFIG_MPU and not CONFIG_MMU
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
@@ -135,6 +137,7 @@ tests:
       - riscv
       - arc
       - x86
+      - openrisc
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
@@ -148,6 +151,7 @@ tests:
       - riscv
       - arc
       - x86
+      - openrisc
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
@@ -162,6 +166,7 @@ tests:
       - riscv
       - arc
       - x86
+      - openrisc
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
@@ -179,6 +184,7 @@ tests:
       - riscv
       - arc
       - x86
+      - openrisc
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
@@ -193,6 +199,7 @@ tests:
       - riscv
       - arc
       - x86
+      - openrisc
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU


### PR DESCRIPTION
  * Add OpenRISC LLEXT support
  * Fixed missing `ARCH_HAS_CODE_DATA_RELOCATION`
  * Fixed linker RWX segment warning
  * Added OpenRISC exception trigger
  * qemu_or1k board fixes
  * Only add CAN bus when QEMU CAN hardware is needed