### PR TITLE
boards: nucode: add NU40 Arduino bus labels

### DIFF
--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840.yaml
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840.yaml
@@ -9,8 +9,12 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - usbd
   - ble
+  - i2c
   - pwm
   - spi
   - watchdog

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_bare.yaml
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_bare.yaml
@@ -9,8 +9,12 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - usbd
   - ble
+  - i2c
   - pwm
   - spi
   - watchdog

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_common.dtsi
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_common.dtsi
@@ -150,7 +150,7 @@
 	pinctrl-names = "default", "sleep";
 };
 
-&uart1 {
+arduino_serial: &uart1 {
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
@@ -159,10 +159,10 @@
 	pinctrl-names = "default", "sleep";
 };
 
-&i2c0 {
+arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi0. */
-	/* status = "okay"; */
+	status = "okay";
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-1 = <&i2c0_sleep>;
 	pinctrl-names = "default", "sleep";
@@ -192,9 +192,10 @@
 	pinctrl-names = "default", "sleep";
 };
 
-&spi3 {
+arduino_spi: &spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
+	cs-gpios = <&gpio1 12 GPIO_ACTIVE_LOW>; /* D10 */
 	pinctrl-0 = <&spi3_default>;
 	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";


### PR DESCRIPTION
Expose the NU40 Arduino-compatible UART, I2C, and SPI buses with standard devicetree labels.

Enable I2C0 by default because it is the documented Arduino I2C bus. Add the SPI D10 chip select used by Arduino shield overlays, and update both NU40 board variants to advertise the corresponding supported features.

Build-tested `hello_world` on both NU40 variants and Arduino I2C/SPI shield samples.