### PR TITLE
drivers: flash: MCUX xspi: Fix xspi flash driver issue

### DIFF
--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -388,7 +388,7 @@ nxp_8080_touch_panel_i2c: &flexcomm8_lpi2c8 {};
 			compatible = "soc-nv-flash";
 			reg = <0x0 DT_SIZE_M(64)>;
 			erase-block-size = <DT_SIZE_K(4)>;
-			write-block-size = <2>;
+			write-block-size = <4>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/drivers/flash/Kconfig.mcux
+++ b/drivers/flash/Kconfig.mcux
@@ -167,6 +167,16 @@ config FLASH_MCUX_XSPI
 	help
 	  Enable the mcux xspi flash driver.
 
+config FLASH_MCUX_XSPI_WRITE_BUFFER
+	bool "MCUX XSPI write with RAM buffer"
+	default n
+	depends on FLASH_MCUX_XSPI
+	help
+	  Copy the data to a RAM buffer before writing it to the flash.
+	  This prevents faults when the data to write would be located
+	  on the flash itself, and pads the transfer size to 4-byte
+	  alignment for the XSPI IP Tx limitation.
+
 # MCUX C40 internal flash driver
 config SOC_FLASH_MCUX_C40
 	bool "MCUX C40 flash driver"

--- a/drivers/flash/flash_mcux_xspi.c
+++ b/drivers/flash/flash_mcux_xspi.c
@@ -251,7 +251,7 @@ static int flash_mcux_xspi_write(const struct device *dev, off_t offset, const v
 	}
 
 	while (len > 0) {
-		write_size = MIN(len, SPI_NOR_PAGE_SIZE);
+		write_size = MIN(len, SPI_NOR_PAGE_SIZE - (offset % SPI_NOR_PAGE_SIZE));
 
 		ret = flash_mcux_xspi_write_enable(dev, 0, true);
 		if (ret < 0) {
@@ -540,7 +540,7 @@ static DEVICE_API(flash, flash_mcux_xspi_api) = {
 		.xspi_dev = DEVICE_DT_GET(DT_INST_BUS(n)),	\
 		.dev_name = DT_INST_PROP(n, device_name),	\
 		.flash_param = {	\
-				.write_block_size = 1,	\
+				.write_block_size = 2,	\
 				.erase_value = 0xFF,	\
 				.caps = {	\
 						.no_explicit_erase = false,	\

--- a/drivers/flash/flash_mcux_xspi.c
+++ b/drivers/flash/flash_mcux_xspi.c
@@ -18,6 +18,10 @@
 
 LOG_MODULE_REGISTER(flash_mcux_xspi);
 
+#ifdef CONFIG_FLASH_MCUX_XSPI_WRITE_BUFFER
+static uint8_t flash_xspi_write_buf[SPI_NOR_PAGE_SIZE];
+#endif
+
 #define FLASH_MCUX_XSPI_LUT_ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0][0]))
 
 #define FLASH_BUSY_STATUS_OFFSET 0
@@ -245,6 +249,17 @@ static int flash_mcux_xspi_write(const struct device *dev, off_t offset, const v
 	uint32_t key = 0;
 	int ret = 0;
 
+#if !defined(CONFIG_FLASH_MCUX_XSPI_WRITE_BUFFER)
+	/* Without write buffer, offset and len must be 4-byte aligned.
+	 * XSPI IP TX FIFO only transfers full 32-bit words, and a
+	 * non-4-aligned offset causes the page boundary split to
+	 * produce non-4-aligned chunk sizes.
+	 */
+	if ((len & 3U) || (offset & 3U)) {
+		return -EINVAL;
+	}
+#endif
+
 	if (memc_xspi_is_running_xip(xspi_dev)) {
 		key = irq_lock();
 		memc_xspi_wait_bus_idle(xspi_dev);
@@ -262,8 +277,25 @@ static int flash_mcux_xspi_write(const struct device *dev, off_t offset, const v
 		flashXfer.cmdType = kXSPI_Write;
 		flashXfer.seqIndex = FLASH_CMD_PAGEPROGRAM_OCTAL;
 		flashXfer.targetGroup = kXSPI_TargetGroup0;
+#ifdef CONFIG_FLASH_MCUX_XSPI_WRITE_BUFFER
+		/*
+		 * Copy to RAM buffer to prevent faults when source
+		 * data resides in flash, and pad to 4-byte boundary
+		 * because XSPI IP TX FIFO only transfers full words.
+		 */
+		size_t aligned_size = ROUND_UP(write_size, 4);
+
+		memcpy(flash_xspi_write_buf, p_data, write_size);
+		if (aligned_size != write_size) {
+			memset(flash_xspi_write_buf + write_size, 0xFF,
+			       aligned_size - write_size);
+		}
+		flashXfer.data = (uint32_t *)flash_xspi_write_buf;
+		flashXfer.dataSize = aligned_size;
+#else
 		flashXfer.data = (uint32_t *)p_data;
 		flashXfer.dataSize = write_size;
+#endif
 		flashXfer.lockArbitration = false;
 
 		ret = memc_mcux_xspi_transfer(xspi_dev, &flashXfer);
@@ -540,7 +572,7 @@ static DEVICE_API(flash, flash_mcux_xspi_api) = {
 		.xspi_dev = DEVICE_DT_GET(DT_INST_BUS(n)),	\
 		.dev_name = DT_INST_PROP(n, device_name),	\
 		.flash_param = {	\
-				.write_block_size = 2,	\
+				.write_block_size = DT_INST_PROP(n, write_block_size),	\
 				.erase_value = 0xFF,	\
 				.caps = {	\
 						.no_explicit_erase = false,	\

--- a/dts/bindings/mtd/nxp,xspi-device.yaml
+++ b/dts/bindings/mtd/nxp,xspi-device.yaml
@@ -25,6 +25,12 @@ properties:
     enum: [1, 2, 3, 5, 9]
     description: Sample clock source.
 
+  write-block-size:
+    type: int
+    default: 4
+    description: |
+      Minimal write alignment and size in bytes.
+
   enable-dqs-latency:
     type: boolean
     description: Enable DQS latency.


### PR DESCRIPTION
Issue
1. NOR Flash Page Boundary Wrap (Driver Layer)
NOR flash page program wraps at the 256B page boundary instead of advancing to the next page. The original driver used write_size = MIN(len, SPI_NOR_PAGE_SIZE) without clamping to the remaining space in the current page. The FlexSPI NOR drivers handle this correctly.

2. Write Alignment (Flash Chip + Controller IP Layer)
Two alignment constraints exist: OPI DTR mode requires 2-byte aligned writes (DDR bus width), and the XSPI IP TX FIFO operates in 32-bit word granularity — the hardware reads floor(IDATSZ/4) words from the TX FIFO, silently dropping trailing bytes of a non-4-aligned transfer. The original driver set write_block_size = 1, reflecting neither constraint. Since the 4-byte XSPI IP requirement is the stricter of the two, write_block_size is set to 4 via devicetree (binding default), covering both layers.

Solution
- Clamp each write to the remaining bytes in the current 256B page.
- Add write-block-size property to nxp,xspi-device.yaml binding (default 4). Default 4 matches the XSPI IP TX FIFO word granularity so all writes are naturally 4-byte aligned without extra handling, no extra handling.
- Optional write buffer. Add CONFIG_FLASH_MCUX_XSPI_WRITE_BUFFER (default n). When enabled, copies write data to a static RAM buffer and pads to 4-byte alignment with 0xFF, allowing board-level DTS to override write-block-size for finer granularity. Also prevents AHB stalls when source data resides in flash during IP commands (XIP safety). When disabled (default), rejects non-4-byte-aligned offset or length.