### PR TITLE
scripts: runners: nrf_common: support old build folders

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -219,21 +219,26 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
         if self.family is not None:
             return
 
-        if self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF51'):
+        def build_conf_any(*configs):
+            # Are any of the list of booleans set
+            return any([self.build_conf.getboolean(c) for c in configs])
+
+        # Legacy 'X' suffix supported to allow flashing build folders from previous releases
+        if build_conf_any('CONFIG_SOC_SERIES_NRF51', 'CONFIG_SOC_SERIES_NRF51X'):
             self.family = 'nrf51'
-        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF52'):
+        elif build_conf_any('CONFIG_SOC_SERIES_NRF52', 'CONFIG_SOC_SERIES_NRF52X'):
             self.family = 'nrf52'
-        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF53'):
+        elif build_conf_any('CONFIG_SOC_SERIES_NRF53', 'CONFIG_SOC_SERIES_NRF53X'):
             self.family = 'nrf53'
-        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF54L'):
+        elif build_conf_any('CONFIG_SOC_SERIES_NRF54L', 'CONFIG_SOC_SERIES_NRF54LX'):
             self.family = 'nrf54l'
-        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF54H'):
+        elif build_conf_any('CONFIG_SOC_SERIES_NRF54H', 'CONFIG_SOC_SERIES_NRF54HX'):
             self.family = 'nrf54h'
-        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF71'):
+        elif build_conf_any('CONFIG_SOC_SERIES_NRF71'):
             self.family = 'nrf71'
-        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF91'):
+        elif build_conf_any('CONFIG_SOC_SERIES_NRF91', 'CONFIG_SOC_SERIES_NRF91X'):
             self.family = 'nrf91'
-        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF92'):
+        elif build_conf_any('CONFIG_SOC_SERIES_NRF92'):
             self.family = 'nrf92'
         else:
             raise RuntimeError(f'unknown nRF; update {__file__}')


### PR DESCRIPTION
One mechanism of creating a software release is preserving a subset of the build folder and flashing through west via
`west flash -d ./release-folder --no-rebuild`.

The change in a7e099f2 to handle the new `SOC_SERIES` values is fine, but does mean that the above command no longer works for build folders from earlier releases, as they used the `X` suffix.

This change means that no matter whether the old or new `SOC_SERIES` value is present, `nrfutil` will still be able to flash the folder.

Both nRF71 and nRF92 are not commercially available products, and therefore there shouldn't be any proper releases in the wild.