### PR TITLE
boards: frdm_mcxa577: add lpcmp support

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -236,6 +236,13 @@ void board_early_init_hook(void)
 #endif
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpcmp0))
+	CLOCK_AttachClk(kFRO_LF_DIV_to_CMP0);
+	CLOCK_SetClockDiv(kCLOCK_DivCMP0_FUNC, 1U);
+	CLOCK_EnableClock(kCLOCK_GateCMP0);
+	SPC_EnableActiveModeAnalogModules(SPC0, (kSPC_controlCmp0 | kSPC_controlCmp0Dac));
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ctimer0))
 	CLOCK_SetClockDiv(kCLOCK_DivCTIMER0, 1u);
 	CLOCK_AttachClk(kPll1ClkDiv_to_CTIMER0);

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
@@ -114,6 +114,14 @@
 		};
 	};
 
+	pinmux_lpcmp0: pinmux_lpcmp0 {
+		group0 {
+			pinmux = <CMP0_IN2_P1_4>;
+			drive-strength = "low";
+			slew-rate = "fast";
+		};
+	};
+
 	pinmux_flexcan0: pinmux_flexcan0 {
 		group0 {
 			pinmux = <CAN0_TXD_P1_18>,

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -89,6 +89,14 @@
 	clock-frequency = <DT_FREQ_M(200)>;
 };
 
+&porta {
+	status = "okay";
+};
+
+&portb {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };

--- a/tests/drivers/comparator/gpio_loopback/boards/frdm_mcxa577.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/frdm_mcxa577.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/* To test this case, connect P0_19(J6-1) to P1_4(R132). */
+/ {
+	aliases {
+		test-comp = &lpcmp0;
+	};
+
+	zephyr,user {
+		test-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>; /* FRDM-MCXA577 P0_19(J6-1) */
+	};
+};
+
+&lpcmp0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpcmp0>;
+	pinctrl-names = "default";
+	positive-mux-input = "IN2"; /* FRDM-MCXA577 P1_4(R132) */
+	negative-mux-input = "DAC";
+	dac-value = <160>;
+	dac-vref-source = "VREFH0";
+};

--- a/tests/drivers/comparator/gpio_loopback/testcase.yaml
+++ b/tests/drivers/comparator/gpio_loopback/testcase.yaml
@@ -67,6 +67,7 @@ tests:
       - frdm_mcxa344
       - frdm_mcxa346
       - frdm_mcxa366
+      - frdm_mcxa577
       - frdm_mcxe31b
       - frdm_mcxn236
       - frdm_mcxn947/mcxn947/cpu0/qspi


### PR DESCRIPTION
Enable LPCMP0 on frdm_mcxa577 using CMP0_IN2 (P1_4). 
Adds clock setup in board_early_init_hook and registers the board with the mcux_lpcmp sample.

tested tests/drivers/comparator/gpio_loopback