### PR TITLE
drivers: *_aesc: Switch to sys_{write,read}32

### DIFF
--- a/drivers/gpio/gpio_aesc.c
+++ b/drivers/gpio/gpio_aesc.c
@@ -280,7 +280,7 @@ static DEVICE_API(gpio, gpio_aesc_driver_api) = {
 			    0);						      \
 		irq_enable(DT_INST_IRQN(no));				      \
 	}								      \
-	static struct gpio_aesc_config gpio_aesc_dev_cfg_##no = {	      \
+	static const struct gpio_aesc_config gpio_aesc_dev_cfg_##no = {	      \
 		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(no),		      \
 		DEVICE_MMIO_NAMED_ROM_INIT(mmio, DT_DRV_INST(no)),	      \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(no),		      \

--- a/drivers/gpio/gpio_aesc.c
+++ b/drivers/gpio/gpio_aesc.c
@@ -35,20 +35,18 @@ struct gpio_aesc_config {
 	void (*irq_config)(const struct device *dev);
 };
 
-struct gpio_aesc_regs {
-	uint32_t info;
-	uint32_t read;
-	uint32_t write;
-	uint32_t direction;
-	uint32_t high_ip;
-	uint32_t high_ie;
-	uint32_t low_ip;
-	uint32_t low_ie;
-	uint32_t rise_ip;
-	uint32_t rise_ie;
-	uint32_t fall_ip;
-	uint32_t fall_ie;
-} __packed;
+#define GPIO_AESC_INFO		0x00
+#define GPIO_AESC_READ		0x04
+#define GPIO_AESC_WRITE		0x08
+#define GPIO_AESC_DIRECTION	0x0c
+#define GPIO_AESC_HIGH_IP	0x10
+#define GPIO_AESC_HIGH_IE	0x14
+#define GPIO_AESC_LOW_IP	0x18
+#define GPIO_AESC_LOW_IE	0x1c
+#define GPIO_AESC_RISE_IP	0x20
+#define GPIO_AESC_RISE_IE	0x24
+#define GPIO_AESC_FALL_IP	0x28
+#define GPIO_AESC_FALL_IE	0x2c
 
 struct gpio_aesc_data {
 	struct gpio_driver_data common;
@@ -62,23 +60,23 @@ struct gpio_aesc_data {
 
 #define DEV_CFG(dev) ((const struct gpio_aesc_config * const)(dev)->config)
 #define DEV_DATA(dev) ((struct gpio_aesc_data *)(dev)->data)
-#define DEV_GPIO(dev)							      \
-	((volatile struct gpio_aesc_regs *)DEV_DATA(dev)->reg_base)
 
 static int gpio_aesc_config(const struct device *dev, gpio_pin_t pin,
 			    gpio_flags_t flags)
 {
-	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
 	k_spinlock_key_t key;
+	uint32_t direction;
 
 	key = k_spin_lock(&data->lock);
 	/* Configure gpio direction */
+	direction = sys_read32(data->reg_base + GPIO_AESC_DIRECTION);
 	if (flags & GPIO_OUTPUT) {
-		gpio->direction |= BIT(pin);
+		direction |= BIT(pin);
 	} else {
-		gpio->direction &= ~BIT(pin);
+		direction &= ~BIT(pin);
 	}
+	sys_write32(direction, data->reg_base + GPIO_AESC_DIRECTION);
 	k_spin_unlock(&data->lock, key);
 
 	return 0;
@@ -87,9 +85,9 @@ static int gpio_aesc_config(const struct device *dev, gpio_pin_t pin,
 static int gpio_aesc_port_get_raw(const struct device *dev,
 				  gpio_port_value_t *value)
 {
-	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
+	struct gpio_aesc_data *data = DEV_DATA(dev);
 
-	*value = gpio->read;
+	*value = sys_read32(data->reg_base + GPIO_AESC_READ);
 
 	return 0;
 }
@@ -98,12 +96,14 @@ static int gpio_aesc_port_set_masked_raw(const struct device *dev,
 					 gpio_port_pins_t mask,
 					 gpio_port_value_t value)
 {
-	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
 	k_spinlock_key_t key;
+	uint32_t write;
 
 	key = k_spin_lock(&data->lock);
-	gpio->write = (gpio->write & ~mask) | (value & mask);
+	write = sys_read32(data->reg_base + GPIO_AESC_WRITE);
+	write = (write & ~mask) | (value & mask);
+	sys_write32(write, data->reg_base + GPIO_AESC_WRITE);
 	k_spin_unlock(&data->lock, key);
 
 	return 0;
@@ -112,12 +112,14 @@ static int gpio_aesc_port_set_masked_raw(const struct device *dev,
 static int gpio_aesc_port_set_bits_raw(const struct device *dev,
 				       gpio_port_pins_t mask)
 {
-	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
 	k_spinlock_key_t key;
+	uint32_t write;
 
 	key = k_spin_lock(&data->lock);
-	gpio->write |= mask;
+	write = sys_read32(data->reg_base + GPIO_AESC_WRITE);
+	write |= mask;
+	sys_write32(write, data->reg_base + GPIO_AESC_WRITE);
 	k_spin_unlock(&data->lock, key);
 
 	return 0;
@@ -126,12 +128,14 @@ static int gpio_aesc_port_set_bits_raw(const struct device *dev,
 static int gpio_aesc_port_clear_bits_raw(const struct device *dev,
 					 gpio_port_pins_t mask)
 {
-	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
 	k_spinlock_key_t key;
+	uint32_t write;
 
 	key = k_spin_lock(&data->lock);
-	gpio->write &= ~mask;
+	write = sys_read32(data->reg_base + GPIO_AESC_WRITE);
+	write &= ~mask;
+	sys_write32(write, data->reg_base + GPIO_AESC_WRITE);
 	k_spin_unlock(&data->lock, key);
 
 	return 0;
@@ -140,12 +144,14 @@ static int gpio_aesc_port_clear_bits_raw(const struct device *dev,
 static int gpio_aesc_port_toggle_bits(const struct device *dev,
 				      gpio_port_pins_t mask)
 {
-	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
 	k_spinlock_key_t key;
+	uint32_t write;
 
 	key = k_spin_lock(&data->lock);
-	gpio->write ^= mask;
+	write = sys_read32(data->reg_base + GPIO_AESC_WRITE);
+	write ^= mask;
+	sys_write32(write, data->reg_base + GPIO_AESC_WRITE);
 	k_spin_unlock(&data->lock, key);
 
 	return 0;
@@ -156,40 +162,45 @@ static int gpio_aesc_pin_interrupt_configure(const struct device *dev,
 					     enum gpio_int_mode mode,
 					     enum gpio_int_trig trig)
 {
-	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
-
-	gpio->rise_ie &= ~BIT(pin);
-	gpio->fall_ie &= ~BIT(pin);
-	gpio->high_ie &= ~BIT(pin);
-	gpio->low_ie  &= ~BIT(pin);
+	struct gpio_aesc_data *data = DEV_DATA(dev);
+	uintptr_t base = data->reg_base;
+	uint32_t rise_ie = sys_read32(base + GPIO_AESC_RISE_IE) & ~BIT(pin);
+	uint32_t fall_ie = sys_read32(base + GPIO_AESC_FALL_IE) & ~BIT(pin);
+	uint32_t high_ie = sys_read32(base + GPIO_AESC_HIGH_IE) & ~BIT(pin);
+	uint32_t low_ie = sys_read32(base + GPIO_AESC_LOW_IE) & ~BIT(pin);
 
 	switch (mode) {
 	case GPIO_INT_MODE_DISABLED:
 		break;
 	case GPIO_INT_MODE_LEVEL:
 		if (trig == GPIO_INT_TRIG_HIGH) {
-			gpio->high_ip = BIT(pin);
-			gpio->high_ie |= BIT(pin);
+			sys_write32(BIT(pin), base + GPIO_AESC_HIGH_IP);
+			high_ie |= BIT(pin);
 		}
 		if (trig == GPIO_INT_TRIG_LOW) {
-			gpio->low_ip = BIT(pin);
-			gpio->low_ie  |= BIT(pin);
+			sys_write32(BIT(pin), base + GPIO_AESC_LOW_IP);
+			low_ie |= BIT(pin);
 		}
 		break;
 	case GPIO_INT_MODE_EDGE:
 		if ((trig & GPIO_INT_HIGH_1) != 0) {
-			gpio->rise_ip = BIT(pin);
-			gpio->rise_ie |= BIT(pin);
+			sys_write32(BIT(pin), base + GPIO_AESC_RISE_IP);
+			rise_ie |= BIT(pin);
 		}
 		if ((trig & GPIO_INT_LOW_0) != 0) {
-			gpio->fall_ip = BIT(pin);
-			gpio->fall_ie |= BIT(pin);
+			sys_write32(BIT(pin), base + GPIO_AESC_FALL_IP);
+			fall_ie |= BIT(pin);
 		}
 		break;
 	default:
 		__ASSERT(false, "Invalid MODE %d passed to driver", mode);
 		return -ENOTSUP;
 	}
+
+	sys_write32(rise_ie, base + GPIO_AESC_RISE_IE);
+	sys_write32(fall_ie, base + GPIO_AESC_FALL_IE);
+	sys_write32(high_ie, base + GPIO_AESC_HIGH_IE);
+	sys_write32(low_ie, base + GPIO_AESC_LOW_IE);
 
 	return 0;
 }
@@ -205,19 +216,19 @@ static int gpio_aesc_manage_callback(const struct device *dev,
 
 static void gpio_aesc_isr(const struct device *dev)
 {
-	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
+	uintptr_t base = data->reg_base;
 	gpio_port_value_t pins = 0;
 
-	pins |= gpio->rise_ip;
-	pins |= gpio->fall_ip;
-	pins |= gpio->high_ip;
-	pins |= gpio->low_ip;
+	pins |= sys_read32(base + GPIO_AESC_RISE_IP);
+	pins |= sys_read32(base + GPIO_AESC_FALL_IP);
+	pins |= sys_read32(base + GPIO_AESC_HIGH_IP);
+	pins |= sys_read32(base + GPIO_AESC_LOW_IP);
 
-	gpio->rise_ip = pins;
-	gpio->fall_ip = pins;
-	gpio->high_ip = pins;
-	gpio->low_ip  = pins;
+	sys_write32(pins, base + GPIO_AESC_RISE_IP);
+	sys_write32(pins, base + GPIO_AESC_FALL_IP);
+	sys_write32(pins, base + GPIO_AESC_HIGH_IP);
+	sys_write32(pins, base + GPIO_AESC_LOW_IP);
 
 	gpio_fire_callbacks(&data->cb, dev, pins);
 }
@@ -229,7 +240,6 @@ static int gpio_aesc_init(const struct device *dev)
 	volatile uintptr_t *base_addr =
 		(volatile uintptr_t *)DEVICE_MMIO_NAMED_GET(dev, mmio);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
-	volatile struct gpio_aesc_regs *gpio;
 	int ret;
 
 	LOG_DBG("IP core version: %i.%i.%i.",
@@ -239,7 +249,6 @@ static int gpio_aesc_init(const struct device *dev)
 	);
 	data->reg_base = ip_id_relocate_driver(base_addr);
 	LOG_DBG("Relocate driver to address 0x%lx.", data->reg_base);
-	gpio = DEV_GPIO(dev);
 
 	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
@@ -247,10 +256,10 @@ static int gpio_aesc_init(const struct device *dev)
 		return ret;
 	}
 
-	gpio->high_ie = 0;
-	gpio->low_ie = 0;
-	gpio->rise_ie = 0;
-	gpio->fall_ie = 0;
+	sys_write32(0, data->reg_base + GPIO_AESC_HIGH_IE);
+	sys_write32(0, data->reg_base + GPIO_AESC_LOW_IE);
+	sys_write32(0, data->reg_base + GPIO_AESC_RISE_IE);
+	sys_write32(0, data->reg_base + GPIO_AESC_FALL_IE);
 
 	cfg->irq_config(dev);
 

--- a/drivers/pinctrl/pinctrl_aesc.c
+++ b/drivers/pinctrl/pinctrl_aesc.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/arch/cpu.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/sys/sys_io.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(aesc_pinctrl, CONFIG_PINCTRL_LOG_LEVEL);
@@ -26,10 +27,8 @@ struct pinctrl_aesc_config {
 	DEVICE_MMIO_ROM;
 };
 
-struct pinctrl_aesc_regs {
-	uint32_t info;
-	uint32_t pin[AESC_PINCTRL_MAX_PINS];
-} __packed;
+#define PINCTRL_AESC_INFO		0x00
+#define PINCTRL_AESC_PIN(pin)		(0x04 + ((pin) * 4))
 
 #define DEV_DATA(dev) ((struct pinctrl_aesc_data *)(dev)->data)
 
@@ -39,15 +38,13 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 	ARG_UNUSED(reg);
 	const struct device *dev = pins->dev;
 	struct pinctrl_aesc_data *data = DEV_DATA(dev);
-	volatile struct pinctrl_aesc_regs *regs =
-		(volatile struct pinctrl_aesc_regs *)data->reg_base;
 
 	for (uint8_t i = 0; i < pin_cnt; i++) {
 		if (pins[i].pin > AESC_PINCTRL_MAX_PINS) {
 			LOG_ERR("Pin index %u out of range", pins[i].pin);
 			return -EINVAL;
 		}
-		regs->pin[pins[i].pin] = pins[i].mux;
+		sys_write32(pins[i].mux, data->reg_base + PINCTRL_AESC_PIN(pins[i].pin));
 	}
 
 	return 0;

--- a/drivers/serial/uart_aesc.c
+++ b/drivers/serial/uart_aesc.c
@@ -311,7 +311,7 @@ static DEVICE_API(uart, uart_aesc_driver_api) = {
 	PINCTRL_DT_INST_DEFINE(no);					     \
 	AESC_UART_IRQ_INIT(no)						     \
 	static struct uart_aesc_data uart_aesc_dev_data_##no;		     \
-	static struct uart_aesc_config uart_aesc_dev_cfg_##no = {	     \
+	static const struct uart_aesc_config uart_aesc_dev_cfg_##no = {	     \
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(no)),			     \
 		.sys_clk_freq =						     \
 			DT_PROP(DT_INST(no, aesc_uart), clock_frequency),    \

--- a/drivers/serial/uart_aesc.c
+++ b/drivers/serial/uart_aesc.c
@@ -17,6 +17,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/sys_io.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(aesc_uart, CONFIG_UART_LOG_LEVEL);
@@ -40,26 +41,22 @@ struct uart_aesc_config {
 #endif
 };
 
-struct uart_aesc_regs {
-	uint32_t data_width;
-	uint32_t sampling_sizes;
-	uint32_t fifo_depths;
-	uint32_t permissions;
-	uint32_t read_write;
-	uint32_t fifo_status;
-	uint32_t clock_div;
-	uint32_t frame_cfg;
-	uint32_t tx_trigger;
-	uint32_t ip;
-	uint32_t ie;
-	uint32_t error_pending;
-	uint32_t error_enable;
-};
+#define UART_AESC_DATA_WIDTH		0x00
+#define UART_AESC_SAMPLING_SIZES	0x04
+#define UART_AESC_FIFO_DEPTHS		0x08
+#define UART_AESC_PERMISSIONS		0x0c
+#define UART_AESC_READ_WRITE		0x10
+#define UART_AESC_FIFO_STATUS		0x14
+#define UART_AESC_CLOCK_DIV		0x18
+#define UART_AESC_FRAME_CFG		0x1c
+#define UART_AESC_TX_TRIGGER		0x20
+#define UART_AESC_IP			0x24
+#define UART_AESC_IE			0x28
+#define UART_AESC_ERROR_PENDING		0x2c
+#define UART_AESC_ERROR_ENABLE		0x30
 
 #define DEV_CFG(dev) ((struct uart_aesc_config *)(dev)->config)
 #define DEV_DATA(dev) ((struct uart_aesc_data *)(dev)->data)
-#define DEV_UART(dev)							      \
-	((volatile struct uart_aesc_regs *)DEV_DATA(dev)->reg_base)
 
 #define AESC_UART_IRQ_TX_EN			BIT(0)
 #define AESC_UART_IRQ_RX_EN			BIT(1)
@@ -73,21 +70,22 @@ struct uart_aesc_regs {
 
 static void uart_aesc_poll_out(const struct device *dev, unsigned char c)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
 
-	while ((uart->fifo_status & AESC_UART_FIFO_TX_COUNT_MASK) == 0) {
+	while ((sys_read32(data->reg_base + UART_AESC_FIFO_STATUS) &
+		AESC_UART_FIFO_TX_COUNT_MASK) == 0) {
 		/* Wait until transmit fifo is empty */
 	}
 
-	uart->read_write = c;
+	sys_write32(c, data->reg_base + UART_AESC_READ_WRITE);
 }
 
 static int uart_aesc_poll_in(const struct device *dev, unsigned char *c)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
-	int val;
+	struct uart_aesc_data *data = DEV_DATA(dev);
+	uint32_t val;
 
-	val = uart->read_write;
+	val = sys_read32(data->reg_base + UART_AESC_READ_WRITE);
 	if (val & AESC_UART_READ_FIFO_VALID_BIT) {
 		*c = val & 0xFF;
 		return 0;
@@ -101,11 +99,12 @@ static int uart_aesc_poll_in(const struct device *dev, unsigned char *c)
 static int uart_aesc_fifo_fill(const struct device *dev,
 			       const uint8_t *tx_data, int size)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
 	int i = 0;
 
-	while (i < size && (uart->fifo_status & AESC_UART_FIFO_TX_COUNT_MASK)) {
-		uart->read_write = tx_data[i++];
+	while (i < size && (sys_read32(data->reg_base + UART_AESC_FIFO_STATUS) &
+			     AESC_UART_FIFO_TX_COUNT_MASK)) {
+		sys_write32(tx_data[i++], data->reg_base + UART_AESC_READ_WRITE);
 	}
 
 	return i;
@@ -114,12 +113,12 @@ static int uart_aesc_fifo_fill(const struct device *dev,
 static int uart_aesc_fifo_read(const struct device *dev, uint8_t *rx_data,
 			       const int size)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
 	int i = 0;
 	uint32_t val;
 
 	while (i < size) {
-		val = uart->read_write;
+		val = sys_read32(data->reg_base + UART_AESC_READ_WRITE);
 		if (!(val & AESC_UART_READ_FIFO_VALID_BIT)) {
 			break;
 		}
@@ -131,75 +130,86 @@ static int uart_aesc_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void uart_aesc_irq_tx_enable(const struct device *dev)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
+	uint32_t ie = sys_read32(data->reg_base + UART_AESC_IE);
 
-	uart->ie |= AESC_UART_IRQ_TX_EN;
+	sys_write32(ie | AESC_UART_IRQ_TX_EN, data->reg_base + UART_AESC_IE);
 }
 
 static void uart_aesc_irq_tx_disable(const struct device *dev)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
+	uint32_t ie = sys_read32(data->reg_base + UART_AESC_IE);
 
-	uart->ie &= ~AESC_UART_IRQ_TX_EN;
+	sys_write32(ie & ~AESC_UART_IRQ_TX_EN, data->reg_base + UART_AESC_IE);
 }
 
 static int uart_aesc_irq_tx_ready(const struct device *dev)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
 
-	return !!(uart->fifo_status & AESC_UART_FIFO_TX_COUNT_MASK);
+	return !!(sys_read32(data->reg_base + UART_AESC_FIFO_STATUS) &
+		  AESC_UART_FIFO_TX_COUNT_MASK);
 }
 
 static int uart_aesc_irq_tx_complete(const struct device *dev)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
 
-	return !!(uart->ip & AESC_UART_IRQ_TX_COMPLETE_EN);
+	return !!(sys_read32(data->reg_base + UART_AESC_IP) &
+		  AESC_UART_IRQ_TX_COMPLETE_EN);
 }
 
 static void uart_aesc_irq_rx_enable(const struct device *dev)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
+	uint32_t ie = sys_read32(data->reg_base + UART_AESC_IE);
 
-	uart->ie |= AESC_UART_IRQ_RX_EN;
+	sys_write32(ie | AESC_UART_IRQ_RX_EN, data->reg_base + UART_AESC_IE);
 }
 
 static void uart_aesc_irq_rx_disable(const struct device *dev)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
+	uint32_t ie = sys_read32(data->reg_base + UART_AESC_IE);
 
-	uart->ie &= ~AESC_UART_IRQ_RX_EN;
+	sys_write32(ie & ~AESC_UART_IRQ_RX_EN, data->reg_base + UART_AESC_IE);
 }
 
 static int uart_aesc_irq_rx_ready(const struct device *dev)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
 
-	return !!(uart->fifo_status & AESC_UART_FIFO_RX_COUNT_MASK);
+	return !!(sys_read32(data->reg_base + UART_AESC_FIFO_STATUS) &
+		  AESC_UART_FIFO_RX_COUNT_MASK);
 }
 
 static void uart_aesc_irq_err_enable(const struct device *dev)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
+	uint32_t error_enable = sys_read32(data->reg_base + UART_AESC_ERROR_ENABLE);
 
-	uart->error_enable |= AESC_UART_ERR_FRAMING | AESC_UART_ERR_PARITY |
-				AESC_UART_ERR_OVERFLOW;
+	error_enable |= AESC_UART_ERR_FRAMING | AESC_UART_ERR_PARITY |
+			 AESC_UART_ERR_OVERFLOW;
+	sys_write32(error_enable, data->reg_base + UART_AESC_ERROR_ENABLE);
 }
 
 static void uart_aesc_irq_err_disable(const struct device *dev)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
+	uint32_t error_enable = sys_read32(data->reg_base + UART_AESC_ERROR_ENABLE);
 
-	uart->error_enable &= ~(AESC_UART_ERR_FRAMING | AESC_UART_ERR_PARITY |
-				AESC_UART_ERR_OVERFLOW);
+	error_enable &= ~(AESC_UART_ERR_FRAMING | AESC_UART_ERR_PARITY |
+			   AESC_UART_ERR_OVERFLOW);
+	sys_write32(error_enable, data->reg_base + UART_AESC_ERROR_ENABLE);
 }
 
 static int uart_aesc_irq_is_pending(const struct device *dev)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
 
 	/* ip already returns pending & masks, so any set bit means active IRQ */
-	return !!(uart->ip);
+	return !!sys_read32(data->reg_base + UART_AESC_IP);
 }
 
 static void uart_aesc_irq_callback_set(const struct device *dev,
@@ -214,15 +224,14 @@ static void uart_aesc_irq_callback_set(const struct device *dev,
 
 static void uart_aesc_isr(const struct device *dev)
 {
-	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
 	struct uart_aesc_data *data = DEV_DATA(dev);
 	uint32_t pending;
 	uint32_t err_pending;
 
-	pending = uart->ip;
-	uart->ip = pending;
-	err_pending = uart->error_pending;
-	uart->error_pending = err_pending;
+	pending = sys_read32(data->reg_base + UART_AESC_IP);
+	sys_write32(pending, data->reg_base + UART_AESC_IP);
+	err_pending = sys_read32(data->reg_base + UART_AESC_ERROR_PENDING);
+	sys_write32(err_pending, data->reg_base + UART_AESC_ERROR_PENDING);
 
 	if (data->irq_cb) {
 		data->irq_cb(dev, data->irq_cb_data);
@@ -238,7 +247,6 @@ static int uart_aesc_init(const struct device *dev)
 	volatile uintptr_t *base_addr =
 		(volatile uintptr_t *)DEVICE_MMIO_GET(dev);
 	struct uart_aesc_data *data = DEV_DATA(dev);
-	volatile struct uart_aesc_regs *uart;
 	int ret;
 
 	LOG_DBG("IP core version: %i.%i.%i.",
@@ -248,7 +256,6 @@ static int uart_aesc_init(const struct device *dev)
 	);
 	data->reg_base = ip_id_relocate_driver(base_addr);
 	LOG_DBG("Relocate driver to address 0x%lx.", data->reg_base);
-	uart = DEV_UART(dev);
 
 	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
@@ -256,11 +263,12 @@ static int uart_aesc_init(const struct device *dev)
 		return ret;
 	}
 
-	uart->clock_div = cfg->sys_clk_freq / cfg->current_speed / 8;
-	uart->frame_cfg = 7;
-	uart->tx_trigger = 0;
-	uart->ie = 0;
-	uart->error_enable = 0;
+	sys_write32(cfg->sys_clk_freq / cfg->current_speed / 8,
+		    data->reg_base + UART_AESC_CLOCK_DIV);
+	sys_write32(7, data->reg_base + UART_AESC_FRAME_CFG);
+	sys_write32(0, data->reg_base + UART_AESC_TX_TRIGGER);
+	sys_write32(0, data->reg_base + UART_AESC_IE);
+	sys_write32(0, data->reg_base + UART_AESC_ERROR_ENABLE);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	cfg->irq_config(dev);


### PR DESCRIPTION
The __packed attribute causes GCC to emit byte loads/stores for register accesses. The TileLink SlaveFactory does not honor byte enables, so a byte store replicates the value across all four bytes of the register.

Remove __packed to ensure natural-width (word) accesses until the hardware is fixed

Additionally, make the config struct `static const struct` to move them into ROM.