### PR TITLE
Cpu freq/scmi perf backend

### DIFF
--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -123,9 +123,10 @@ int scmi_send_message(struct scmi_protocol *proto, struct scmi_message *msg,
 	 */
 	use_polling = (IS_ENABLED(CONFIG_ARM_SCMI_POLLING_ONLY) ||
 		       proto->tx->polling_only ||
+		       k_is_in_isr() ||
 		       k_is_pre_kernel()) ? true : use_polling;
 
-	if (!k_is_pre_kernel()) {
+	if (!k_is_pre_kernel() && !k_is_in_isr()) {
 		ret = k_mutex_lock(&proto->tx->lock, K_USEC(SCMI_CHAN_LOCK_TIMEOUT_USEC));
 		if (ret < 0) {
 			LOG_ERR("failed to acquire TX channel lock: %d", ret);
@@ -152,7 +153,7 @@ int scmi_send_message(struct scmi_protocol *proto, struct scmi_message *msg,
 	}
 
 out_release_mutex:
-	if (!k_is_pre_kernel()) {
+	if (!k_is_pre_kernel() && !k_is_in_isr()) {
 		k_mutex_unlock(&proto->tx->lock);
 	}
 

--- a/dts/arm/nxp/imx/nxp_imx943_m33.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx943_m33.dtsi
@@ -54,6 +54,36 @@
 		};
 	};
 
+	performance-states {
+		m33_pstate_odv: pstate-odv {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <70>;
+			scmi-perf-domain = <1>;
+			scmi-perf-level-khz = <266667>;
+		};
+
+		m33_pstate_nom: pstate-nom {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <40>;
+			scmi-perf-domain = <1>;
+			scmi-perf-level-khz = <250000>;
+		};
+
+		m33_pstate_low: pstate-low {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <10>;
+			scmi-perf-domain = <1>;
+			scmi-perf-level-khz = <142857>;
+		};
+
+		m33_pstate_prk: pstate-prk {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <0>;
+			scmi-perf-domain = <1>;
+			scmi-perf-level-khz = <24000>;
+		};
+	};
+
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/dts/arm/nxp/imx/nxp_imx943_m7_0.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx943_m7_0.dtsi
@@ -56,6 +56,36 @@
 		};
 	};
 
+	performance-states {
+		m70_pstate_odv: pstate-odv {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <70>;
+			scmi-perf-domain = <3>;
+			scmi-perf-level-khz = <800000>;
+		};
+
+		m70_pstate_nom: pstate-nom {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <40>;
+			scmi-perf-domain = <3>;
+			scmi-perf-level-khz = <666667>;
+		};
+
+		m70_pstate_low: pstate-low {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <10>;
+			scmi-perf-domain = <3>;
+			scmi-perf-level-khz = <400000>;
+		};
+
+		m70_pstate_prk: pstate-prk {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <0>;
+			scmi-perf-domain = <3>;
+			scmi-perf-level-khz = <24000>;
+		};
+	};
+
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/dts/arm/nxp/imx/nxp_imx943_m7_1.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx943_m7_1.dtsi
@@ -56,6 +56,36 @@
 		};
 	};
 
+	performance-states {
+		m71_pstate_odv: pstate-odv {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <70>;
+			scmi-perf-domain = <4>;
+			scmi-perf-level-khz = <800000>;
+		};
+
+		m71_pstate_nom: pstate-nom {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <40>;
+			scmi-perf-domain = <4>;
+			scmi-perf-level-khz = <666667>;
+		};
+
+		m71_pstate_low: pstate-low {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <10>;
+			scmi-perf-domain = <4>;
+			scmi-perf-level-khz = <400000>;
+		};
+
+		m71_pstate_prk: pstate-prk {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <0>;
+			scmi-perf-domain = <4>;
+			scmi-perf-level-khz = <24000>;
+		};
+	};
+
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -113,6 +113,36 @@
 		};
 	};
 
+	performance-states {
+		m7_pstate_odv: pstate-odv {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <70>;
+			scmi-perf-domain = <3>;
+			scmi-perf-level-khz = <800000>;
+		};
+
+		m7_pstate_nom: pstate-nom {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <40>;
+			scmi-perf-domain = <3>;
+			scmi-perf-level-khz = <666667>;
+		};
+
+		m7_pstate_low: pstate-low {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <10>;
+			scmi-perf-domain = <3>;
+			scmi-perf-level-khz = <400000>;
+		};
+
+		m7_pstate_prk: pstate-prk {
+			compatible = "arm,scmi-perf-pstate";
+			load-threshold = <0>;
+			scmi-perf-domain = <3>;
+			scmi-perf-level-khz = <24000>;
+		};
+	};
+
 	power-domains {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/bindings/p_state/arm,scmi-perf-pstate.yaml
+++ b/dts/bindings/p_state/arm,scmi-perf-pstate.yaml
@@ -1,0 +1,54 @@
+# Copyright 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Generic CPU performance state backed by the SCMI Performance Domain
+  Protocol.
+
+  Example (NXP i.MX95 M7, SCMI domain 3):
+
+    performance-states {
+            pstate_odv: pstate-odv {
+                    compatible = "arm,scmi-perf-pstate";
+                    load-threshold = <70>;
+                    scmi-perf-domain = <3>;
+                    scmi-perf-level-khz = <800000>;
+            };
+            pstate_nom: pstate-nom {
+                    compatible = "arm,scmi-perf-pstate";
+                    load-threshold = <40>;
+                    scmi-perf-domain = <3>;
+                    scmi-perf-level-khz = <666667>;
+            };
+            pstate_low: pstate-low {
+                    compatible = "arm,scmi-perf-pstate";
+                    load-threshold = <10>;
+                    scmi-perf-domain = <3>;
+                    scmi-perf-level-khz = <400000>;
+            };
+            pstate_prk: pstate-prk {
+                    compatible = "arm,scmi-perf-pstate";
+                    load-threshold = <0>;
+                    scmi-perf-domain = <3>;
+                    scmi-perf-level-khz = <24000>;
+            };
+    };
+
+compatible: "arm,scmi-perf-pstate"
+
+include:
+  - "zephyr,pstate.yaml"
+
+properties:
+  scmi-perf-domain:
+    type: int
+    required: true
+    description: |
+      SCMI performance domain index for this CPU.
+
+  scmi-perf-level-khz:
+    type: int
+    required: true
+    description: |
+      Target CPU frequency in kHz for this P-state.

--- a/soc/nxp/imx/imx9/imx943/Kconfig
+++ b/soc/nxp/imx/imx9/imx943/Kconfig
@@ -24,6 +24,7 @@ config SOC_MIMX94398_M33
 	select SOC_EARLY_INIT_HOOK
 	select HAS_PM
 	select SOC_EARLY_RESET_HOOK
+	select HAS_CPU_FREQ
 
 config SOC_MIMX94398_M7_0
 	select ARM
@@ -38,6 +39,7 @@ config SOC_MIMX94398_M7_0
 	select HAS_MCUX
 	select HAS_MCUX_CACHE
 	select HAS_PM
+	select HAS_CPU_FREQ
 
 config SOC_MIMX94398_M7_1
 	select ARM
@@ -52,6 +54,7 @@ config SOC_MIMX94398_M7_1
 	select HAS_MCUX
 	select HAS_MCUX_CACHE
 	select HAS_PM
+	select HAS_CPU_FREQ
 
 config SOC_IMX943_PM_MCORE
 	bool "i.MX943 multi-core PM shared logic"

--- a/soc/nxp/imx/imx9/imx95/Kconfig
+++ b/soc/nxp/imx/imx9/imx95/Kconfig
@@ -15,6 +15,7 @@ config SOC_MIMX9596_M7
 	select HAS_MCUX
 	select HAS_MCUX_CACHE
 	select HAS_PM
+	select HAS_CPU_FREQ
 
 config SOC_MIMX9596_A55
 	select ARM64

--- a/subsys/cpu_freq/CMakeLists.txt
+++ b/subsys/cpu_freq/CMakeLists.txt
@@ -13,6 +13,7 @@ if(CONFIG_CPU_FREQ_POLICY_NONE)
   message(FATAL_ERROR "No CPU frequency policy selected. Please choose a valid policy in Kconfig.")
 endif()
 
+zephyr_sources_ifdef(CONFIG_CPU_FREQ_ARM_SCMI cpu_freq_arm_scmi.c)
 zephyr_sources_ifdef(CONFIG_CPU_FREQ_POLICY_ON_DEMAND policies/on_demand/on_demand.c)
 zephyr_sources_ifdef(CONFIG_CPU_FREQ_POLICY_PRESSURE policies/pressure/pressure.c)
 zephyr_sources_ifdef(CONFIG_CPU_FREQ_PSTATE_SET_STUB cpu_freq_stub.c)

--- a/subsys/cpu_freq/Kconfig
+++ b/subsys/cpu_freq/Kconfig
@@ -20,6 +20,14 @@ module = CPU_FREQ
 module-str = CPU Frequency Scaling
 source "subsys/logging/Kconfig.template.log_config"
 
+config CPU_FREQ_ARM_SCMI
+	bool "SCMI Performance Domain cpu_freq backend"
+	default y
+	depends on ARM_SCMI_PERF
+	help
+	  Implement cpu frequency switch using the SCMI Performance Domain
+	  Protocol.
+
 config CPU_FREQ_INTERVAL_MS
 	int "CPU Freq evaluation interval"
 	default 1000

--- a/subsys/cpu_freq/cpu_freq_arm_scmi.c
+++ b/subsys/cpu_freq/cpu_freq_arm_scmi.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/cpu_freq/cpu_freq.h>
+#include <zephyr/cpu_freq/pstate.h>
+#include <zephyr/drivers/firmware/scmi/perf.h>
+#include <zephyr/drivers/timer/system_timer.h>
+#include <errno.h>
+
+LOG_MODULE_REGISTER(scmi_cpu_freq, CONFIG_CPU_FREQ_LOG_LEVEL);
+
+/**
+ * @brief Vendor config for an arm,scmi-perf-pstate DTS node.
+ *
+ * Populated at compile time from DTS properties.  The cpu_freq core
+ * stores a pointer to this struct in struct pstate::config.
+ */
+struct scmi_perf_pstate_cfg {
+	/** SCMI performance domain index. */
+	uint32_t domain_id;
+	/** Target frequency in kHz. */
+	uint32_t perf_level_khz;
+};
+
+#define SCMI_PERF_PSTATE_CFG_DEFINE(node_id)					\
+	static const struct scmi_perf_pstate_cfg				\
+		_CONCAT(scmi_perf_pstate_cfg_, DT_DEP_ORD(node_id)) = {	\
+			.domain_id      = DT_PROP(node_id, scmi_perf_domain),	\
+			.perf_level_khz = DT_PROP(node_id, scmi_perf_level_khz),\
+		};
+
+DT_FOREACH_CHILD_STATUS_OKAY(DT_PATH(performance_states),
+			     SCMI_PERF_PSTATE_CFG_DEFINE)
+
+#define SCMI_PERF_PSTATE_DEFINE(node_id)					\
+	PSTATE_DT_DEFINE(node_id,						\
+		&_CONCAT(scmi_perf_pstate_cfg_, DT_DEP_ORD(node_id)));
+
+DT_FOREACH_CHILD_STATUS_OKAY(DT_PATH(performance_states),
+			     SCMI_PERF_PSTATE_DEFINE)
+
+int cpu_freq_pstate_set(const struct pstate *state)
+{
+	const struct scmi_perf_pstate_cfg *cfg;
+	int ret;
+
+	if (state == NULL) {
+		LOG_ERR("P-state is NULL");
+		return -EINVAL;
+	}
+
+	cfg = (const struct scmi_perf_pstate_cfg *)state->config;
+
+	if (cfg == NULL) {
+		LOG_ERR("P-state vendor config is NULL");
+		return -EINVAL;
+	}
+
+	LOG_DBG("SCMI cpu_freq: domain=%u level=%u kHz (load_threshold=%u%%)",
+		cfg->domain_id, cfg->perf_level_khz, state->load_threshold);
+
+	ret = scmi_perf_level_set(cfg->domain_id, cfg->perf_level_khz);
+	if (ret < 0) {
+		LOG_ERR("SCMI PERFORMANCE_LEVEL_SET domain=%u level=%u kHz failed: %d",
+			cfg->domain_id, cfg->perf_level_khz, ret);
+		return ret;
+	}
+
+	/*
+	 * Update the system clock frequency so that SysTick and other
+	 * cycle-based timers remain accurate after the frequency change.
+	 *
+	 * Requires CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE=y
+	 * when CONFIG_CORTEX_M_SYSTICK is enabled.
+	 */
+#if defined(CONFIG_CORTEX_M_SYSTICK)
+#if !defined(CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE)
+#error "CPU_FREQ_SCMI with SysTick requires " \
+	"CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE=y"
+#endif
+	z_sys_clock_hw_cycles_per_sec_update(cfg->perf_level_khz * 1000U);
+#endif
+	return 0;
+}

--- a/tests/drivers/firmware/scmi/cpu_freq/basic/CMakeLists.txt
+++ b/tests/drivers/firmware/scmi/cpu_freq/basic/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(scmi_cpu_freq_basic)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/firmware/scmi/cpu_freq/basic/prj.conf
+++ b/tests/drivers/firmware/scmi/cpu_freq/basic/prj.conf
@@ -1,0 +1,17 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_LOG=y
+CONFIG_ZTEST=y
+CONFIG_ZTEST_STACK_SIZE=4096
+
+CONFIG_CPU_FREQ=y
+CONFIG_CPU_FREQ_LOG_LEVEL_DBG=y
+CONFIG_CPU_LOAD_LOG_LEVEL_DBG=y
+CONFIG_CPU_FREQ_POLICY_ON_DEMAND=y
+CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE=y
+
+# Timer disabled: this test suite drives frequency transitions manually.
+# A long interval ensures the timer never fires during any test case,
+# giving the test thread exclusive control over the SCMI channel.
+CONFIG_CPU_FREQ_INTERVAL_MS=1000000

--- a/tests/drivers/firmware/scmi/cpu_freq/basic/src/main.c
+++ b/tests/drivers/firmware/scmi/cpu_freq/basic/src/main.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Static SCMI cpu_freq tests.
+ *
+ * Validates the SCMI Performance Domain cpu_freq backend without relying
+ * on the cpu_freq timer.  The timer interval is set to 1000000 ms so it
+ * never fires during the test, giving the test thread exclusive control
+ * over frequency transitions.
+ *
+ * Test cases:
+ *
+ *   test_pstates_order
+ *     Verifies that /performance-states DTS children are listed in
+ *     strictly decreasing load-threshold order, as required by the
+ *     on_demand policy scanner.
+ *
+ *   test_pstate_set_get_roundtrip
+ *     Calls cpu_freq_pstate_set() for every DTS pstate and verifies
+ *     via scmi_perf_level_get() that the SCMI platform firmware actually switched
+ *     the CPU frequency.  This is the hardware-level proof that the
+ *     SCMI PERFORMANCE_LEVEL_SET command was executed correctly.
+ *
+ *   test_on_demand_policy_load_driven
+ *     Verifies that the on_demand policy selects a higher-frequency
+ *     pstate after a busy-wait period and a lower-frequency pstate
+ *     after an idle period.  Only the policy selection is tested here;
+ *     the actual frequency switch is covered by test_pstate_set_get_roundtrip.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/cpu_freq/policy.h>
+#include <zephyr/cpu_freq/cpu_freq.h>
+#include <zephyr/drivers/firmware/scmi/perf.h>
+
+LOG_MODULE_REGISTER(scmi_cpu_freq_basic, LOG_LEVEL_INF);
+
+/* 100 ms busy-wait to drive cpu_load_metric to ~100% */
+#define BUSY_WAIT_US   100000U
+
+/* 200 ms sleep to drive cpu_load_metric to ~0% */
+#define SLEEP_MS       200U
+
+/* Wait after cpu_freq_pstate_set() before reading back the currently level. */
+#define SETTLE_MS      10U
+
+extern const struct pstate *soc_pstates[];
+extern const size_t soc_pstates_count;
+
+struct scmi_perf_pstate_cfg {
+	uint32_t domain_id;
+	uint32_t perf_level_khz;
+};
+
+static uint32_t get_current_khz(uint32_t domain_id)
+{
+	uint32_t khz = 0;
+
+	zassert_ok(scmi_perf_level_get(domain_id, &khz),
+		   "scmi_perf_level_get domain=%u failed", domain_id);
+	return khz;
+}
+
+ZTEST(scmi_cpu_freq_basic, test_pstates_order)
+{
+	zassert_true(soc_pstates_count > 1,
+		     "Need at least 2 P-states to test ordering");
+
+	for (size_t i = 1; i < soc_pstates_count; i++) {
+		zassert_true(
+			soc_pstates[i]->load_threshold <
+			soc_pstates[i - 1]->load_threshold,
+			"P-state[%zu] threshold (%u) must be < "
+			"P-state[%zu] threshold (%u)",
+			i, soc_pstates[i]->load_threshold,
+			i - 1, soc_pstates[i - 1]->load_threshold);
+	}
+
+	LOG_INF("P-state order OK: %zu states in decreasing threshold order",
+		soc_pstates_count);
+}
+
+ZTEST(scmi_cpu_freq_basic, test_pstate_set_get_roundtrip)
+{
+	/* Iterate lowest → highest to minimise voltage stress */
+	for (int i = (int)soc_pstates_count - 1; i >= 0; i--) {
+		const struct pstate *state = soc_pstates[i];
+		const struct scmi_perf_pstate_cfg *cfg =
+			(const struct scmi_perf_pstate_cfg *)state->config;
+		uint32_t actual_khz;
+
+		LOG_INF("Setting P-state[%d]: domain=%u %u kHz",
+			i, cfg->domain_id, cfg->perf_level_khz);
+
+		zassert_ok(cpu_freq_pstate_set(state),
+			   "cpu_freq_pstate_set P-state[%d] failed", i);
+
+		k_sleep(K_MSEC(SETTLE_MS));
+
+		actual_khz = get_current_khz(cfg->domain_id);
+
+		zassert_equal(actual_khz, cfg->perf_level_khz,
+			      "P-state[%d]: set %u kHz but SCMI platform reports %u kHz",
+			      i, cfg->perf_level_khz, actual_khz);
+
+		LOG_INF("P-state[%d]: %u MHz confirmed by SCMI platform",
+			i, actual_khz / 1000U);
+	}
+}
+
+ZTEST(scmi_cpu_freq_basic, test_on_demand_policy_load_driven)
+{
+	const struct pstate *pstate_high_load;
+	const struct pstate *pstate_low_load;
+	int ret;
+
+	/* NULL guard */
+	zassert_equal(cpu_freq_policy_select_pstate(NULL), -EINVAL,
+		      "Expected -EINVAL for NULL pstate_out");
+
+	/* High-load scenario */
+	k_busy_wait(BUSY_WAIT_US);
+	ret = cpu_freq_policy_select_pstate(&pstate_high_load);
+	zassert_ok(ret, "policy_select_pstate (high load) failed: %d", ret);
+	LOG_INF("High load → P-state threshold=%u%%",
+		pstate_high_load->load_threshold);
+
+	/* Low-load scenario */
+	k_sleep(K_MSEC(SLEEP_MS));
+	ret = cpu_freq_policy_select_pstate(&pstate_low_load);
+	zassert_ok(ret, "policy_select_pstate (low load) failed: %d", ret);
+	LOG_INF("Low load  → P-state threshold=%u%%",
+		pstate_low_load->load_threshold);
+
+	/* Policy must select a lower pstate after idle */
+	zassert_true(
+		pstate_low_load->load_threshold <
+		pstate_high_load->load_threshold,
+		"Expected lower threshold after sleep: high=%u%% low=%u%%",
+		pstate_high_load->load_threshold,
+		pstate_low_load->load_threshold);
+}
+
+ZTEST_SUITE(scmi_cpu_freq_basic, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/firmware/scmi/cpu_freq/basic/testcase.yaml
+++ b/tests/drivers/firmware/scmi/cpu_freq/basic/testcase.yaml
@@ -1,0 +1,23 @@
+common:
+  tags:
+    - drivers
+    - firmware
+    - scmi
+    - cpu_freq
+
+tests:
+  # Static SCMI cpu_freq tests — timer disabled (interval=1000000 ms).
+  # The test thread has exclusive control over frequency transitions.
+  drivers.firmware.scmi.cpu_freq.basic:
+    harness: ztest
+    timeout: 60
+    platform_allow:
+      - imx95_evk/mimx9596/m7
+      - imx943_evk/mimx94398/m33
+      - imx943_evk/mimx94398/m7_0
+      - imx943_evk/mimx94398/m7_1
+    integration_platforms:
+      - imx95_evk/mimx9596/m7
+      - imx943_evk/mimx94398/m33
+      - imx943_evk/mimx94398/m7_0
+      - imx943_evk/mimx94398/m7_1

--- a/tests/drivers/firmware/scmi/cpu_freq/dynamic/CMakeLists.txt
+++ b/tests/drivers/firmware/scmi/cpu_freq/dynamic/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(scmi_cpu_freq_dynamic)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/firmware/scmi/cpu_freq/dynamic/prj.conf
+++ b/tests/drivers/firmware/scmi/cpu_freq/dynamic/prj.conf
@@ -1,0 +1,17 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_LOG=y
+CONFIG_ZTEST=y
+CONFIG_ZTEST_STACK_SIZE=4096
+
+CONFIG_CPU_FREQ=y
+CONFIG_CPU_FREQ_LOG_LEVEL_DBG=y
+CONFIG_CPU_LOAD_LOG_LEVEL_DBG=y
+CONFIG_CPU_FREQ_POLICY_ON_DEMAND=y
+CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE=y
+
+# Short timer interval so the policy fires frequently enough to react
+# to load changes within the test's busy/idle phases.
+# The dynamic test suite is the only place this short interval is used;
+CONFIG_CPU_FREQ_INTERVAL_MS=50

--- a/tests/drivers/firmware/scmi/cpu_freq/dynamic/src/main.c
+++ b/tests/drivers/firmware/scmi/cpu_freq/dynamic/src/main.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Dynamic (timer-driven) SCMI cpu_freq test.
+ *
+ * The test generates high and low CPU load and verifies via
+ * scmi_perf_level_get() that the scmi platform firmware actually changed the
+ * CPU frequency in response.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/cpu_freq/cpu_freq.h>
+#include <zephyr/drivers/firmware/scmi/perf.h>
+
+LOG_MODULE_REGISTER(scmi_cpu_freq_dynamic, LOG_LEVEL_INF);
+
+/*
+ * Duration of the warm-up busy phase before reading frequency.
+ * With CONFIG_CPU_FREQ_INTERVAL_MS=50 the timer fires ~8 times during
+ * 400 ms, giving the policy enough samples to reach the highest pstate.
+ */
+#define BUSY_WARMUP_MS   400U
+
+/*
+ * Duration of the tail busy phase after reading frequency.
+ * Keeps the CPU busy while the SCMI read completes, preventing the
+ * timer from triggering a frequency drop before the assertion.
+ */
+#define BUSY_TAIL_MS     100U
+
+/*
+ * Duration of the idle phase.  The timer fires ~10 times during 500 ms,
+ * giving the policy enough samples to reach the lowest pstate.
+ * Add one extra timer interval to ensure the last tick completes.
+ */
+#define IDLE_MS          600U
+
+struct scmi_perf_pstate_cfg {
+	uint32_t domain_id;
+	uint32_t perf_level_khz;
+};
+
+extern const struct pstate *soc_pstates[];
+extern const size_t soc_pstates_count;
+
+static uint32_t get_current_khz(uint32_t domain_id)
+{
+	uint32_t khz = 0;
+
+	zassert_ok(scmi_perf_level_get(domain_id, &khz),
+		   "scmi_perf_level_get domain=%u failed", domain_id);
+	return khz;
+}
+
+ZTEST(scmi_cpu_freq_dynamic, test_timer_driven)
+{
+	const struct scmi_perf_pstate_cfg *cfg_high =
+		(const struct scmi_perf_pstate_cfg *)soc_pstates[0]->config;
+	const struct scmi_perf_pstate_cfg *cfg_low =
+		(const struct scmi_perf_pstate_cfg *)
+		soc_pstates[soc_pstates_count - 1]->config;
+	uint32_t domain_id = cfg_high->domain_id;
+	uint32_t freq_after_busy, freq_after_idle;
+
+	LOG_INF("Phase 1: busy-wait %u ms warm-up + %u ms tail "
+		"(timer interval=%u ms)",
+		BUSY_WARMUP_MS, BUSY_TAIL_MS, CONFIG_CPU_FREQ_INTERVAL_MS);
+
+	k_busy_wait(BUSY_WARMUP_MS * USEC_PER_MSEC);
+
+	freq_after_busy = get_current_khz(domain_id);
+	LOG_INF("During busy: SCMI platform reports %u MHz", freq_after_busy / 1000U);
+
+	k_busy_wait(BUSY_TAIL_MS * USEC_PER_MSEC);
+
+	LOG_INF("Phase 2: idle sleep %u ms", IDLE_MS);
+
+	k_sleep(K_MSEC(IDLE_MS));
+
+	freq_after_idle = get_current_khz(domain_id);
+	LOG_INF("After idle: SCMI platform reports %u MHz", freq_after_idle / 1000U);
+
+	zassert_equal(freq_after_busy, cfg_high->perf_level_khz,
+		      "Expected highest OPP %u kHz during busy, got %u kHz",
+		      cfg_high->perf_level_khz, freq_after_busy);
+
+	zassert_true(freq_after_idle < freq_after_busy,
+		     "Expected lower freq after idle: "
+		     "busy=%u kHz idle=%u kHz",
+		     freq_after_busy, freq_after_idle);
+
+	zassert_true(freq_after_idle <= cfg_low->perf_level_khz * 2U,
+		     "Expected low freq after idle, got %u kHz "
+		     "(lowest OPP=%u kHz)",
+		     freq_after_idle, cfg_low->perf_level_khz);
+}
+
+ZTEST_SUITE(scmi_cpu_freq_dynamic, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/firmware/scmi/cpu_freq/dynamic/testcase.yaml
+++ b/tests/drivers/firmware/scmi/cpu_freq/dynamic/testcase.yaml
@@ -1,0 +1,24 @@
+common:
+  tags:
+    - drivers
+    - firmware
+    - scmi
+    - cpu_freq
+
+tests:
+  # Dynamic (timer-driven) SCMI cpu_freq test.
+  # Runs with CONFIG_CPU_FREQ_INTERVAL_MS=50 so the on_demand policy
+  # fires ~20 times per second and reacts to load changes.
+  drivers.firmware.scmi.cpu_freq.dynamic:
+    harness: ztest
+    timeout: 120
+    platform_allow:
+      - imx95_evk/mimx9596/m7
+      - imx943_evk/mimx94398/m33
+      - imx943_evk/mimx94398/m7_0
+      - imx943_evk/mimx94398/m7_1
+    integration_platforms:
+      - imx95_evk/mimx9596/m7
+      - imx943_evk/mimx94398/m33
+      - imx943_evk/mimx94398/m7_0
+      - imx943_evk/mimx94398/m7_1


### PR DESCRIPTION
As secondary PR: https://github.com/zephyrproject-rtos/zephyr/issues/110056

Add scmi perf backend into cpu_freq subsys, test on iMX95/IMX943 M33 M7 core