### PR TITLE
tests: tf-m: Exclude boards without dedicated secure UART

### DIFF
--- a/tests/modules/tf-m/regression/testcase.yaml
+++ b/tests/modules/tf-m/regression/testcase.yaml
@@ -4,7 +4,7 @@ common:
     - mcuboot
   modules:
     - tf-m-tests
-  filter: CONFIG_BUILD_WITH_TFM
+  filter: CONFIG_BUILD_WITH_TFM and not CONFIG_TFM_LOG_LEVEL_SILENCE
   integration_platforms:
     - mps2/an521/cpu0/ns
   harness: console


### PR DESCRIPTION
Exclude boards that do not expose secondary UART for TF-M to use.

See issue https://github.com/zephyrproject-rtos/zephyr/issues/108566