### PR TITLE
bluetooth: hci: NXP: drain TX FIFO before uart_configure() in fw_upload

### DIFF
--- a/drivers/bluetooth/hci/hci_nxp_setup.c
+++ b/drivers/bluetooth/hci/hci_nxp_setup.c
@@ -751,6 +751,7 @@ static int fw_upload_uart_reconfig(uint32_t speed, bool flow_control)
 {
 	struct uart_config config;
 	int err;
+	int64_t tx_drain_deadline;
 
 	config.baudrate = speed;
 	config.data_bits = UART_CFG_DATA_BITS_8;
@@ -760,6 +761,21 @@ static int fw_upload_uart_reconfig(uint32_t speed, bool flow_control)
 
 	uart_irq_rx_disable(uart_dev);
 	uart_irq_tx_disable(uart_dev);
+
+	/*
+	 * Wait for the TX FIFO and shift register to drain before reconfiguring
+	 * the baud rate.  Disabling the TX IRQ does not flush in-flight bytes;
+	 * calling uart_configure() while the FIFO still has data causes the
+	 * tail bytes to be clocked out at the wrong speed, corrupting the last
+	 * bytes of any command just sent (e.g. CMD5).  Poll uart_irq_tx_complete()
+	 * up to 20 ms (> worst-case drain time of a 64-byte FIFO at 115200 baud
+	 * ~ 5.6 ms) then fall through regardless.
+	 */
+	tx_drain_deadline = k_uptime_get() + 20;
+	do {
+		uart_irq_update(uart_dev);
+	} while (!uart_irq_tx_complete(uart_dev) && (k_uptime_get() < tx_drain_deadline));
+
 	fw_upload_read_to_clear();
 	err = uart_configure(uart_dev, &config);
 	uart_irq_rx_enable(uart_dev);


### PR DESCRIPTION
This PR fixes a regression issue n FW download code. Below is the details:

> **Root cause:** Commit `f56935c46fdf` (`serial: uart_mcux_lpuart: remove call of LPUART_Deinit()`) replaced `LPUART_Deinit()` in `mcux_lpuart_configure()` with a bare `CTRL &= ~(TE|RE)` register write. `LPUART_Deinit()` had internally polled the TC (Transmission Complete) hardware flag and waited for the TX FIFO **and** shift register to fully drain before disabling the peripheral — providing an implicit TX drain every time `uart_configure()` was called. After the commit, `uart_configure()` immediately clears the TE bit and reprograms the baud-rate dividers with no drain wait.
>
> This exposed a pre-existing timing hazard in `fw_upload_change_speed()`: CMD5 is written with `fw_upload_write_data()`, which only guarantees bytes are accepted into the TX FIFO — not that they have been clocked out on the wire. `fw_upload_uart_reconfig()` is called immediately after, which calls `uart_configure()` to switch to 3 Mbaud. Before `f56935c46fdf` the implicit `LPUART_Deinit()` drain inside `uart_configure()` masked this race; after the commit the tail bytes of CMD5 are clocked out at 3 Mbaud instead of 115200 baud, corrupting the handshake. The IW612 controller never receives a valid CMD5, never switches to 3 Mbaud, and the host times out waiting for HDR SIG.
>
> **Fix:** In `fw_upload_uart_reconfig()`, after disabling TX IRQs, poll `uart_irq_tx_complete()` (with `uart_irq_update()`) for up to 20 ms before calling `uart_configure()`. This explicitly waits for the hardware TC flag — restoring the drain guarantee that `LPUART_Deinit()` previously provided implicitly.