### PR TITLE
drivers: can: move header files out of public include path

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -127,6 +127,13 @@ Clock Control
   RT11xx overlays should be updated using the mapping
   ``loop-div = clock-mult * 2`` and ``post-div = clock-div``.
 
+Controller Area Network (CAN)
+=============================
+
+* The header files for the NXP SJA1000 (``can_sja1000.h``) and Bosch M_CAN (``can_mcan.h``) CAN
+  controller driver backends where converted to library-specific includes. Out-of-tree drivers based
+  on these backends will need to update their include directives accordingly.
+
 Devicetree
 ==========
 

--- a/drivers/can/CMakeLists.txt
+++ b/drivers/can/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library()
 
 # CAN subsystem include paths for out-of-tree drivers
 # zephyr-keep-sorted-start
+zephyr_library_include_directories_ifdef(CONFIG_CAN_MCAN .)
 zephyr_library_include_directories_ifdef(CONFIG_CAN_SJA1000 .)
 # zephyr-keep-sorted-stop
 

--- a/drivers/can/CMakeLists.txt
+++ b/drivers/can/CMakeLists.txt
@@ -4,6 +4,11 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/can.h)
 
 zephyr_library()
 
+# CAN subsystem include paths for out-of-tree drivers
+# zephyr-keep-sorted-start
+zephyr_library_include_directories_ifdef(CONFIG_CAN_SJA1000 .)
+# zephyr-keep-sorted-stop
+
 # CAN subsystem common files
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_CAN can_common.c)

--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -7,7 +7,7 @@
 
 #define DT_DRV_COMPAT espressif_esp32_twai
 
-#include <zephyr/drivers/can/can_sja1000.h>
+#include "can_sja1000.h"
 
 #include <zephyr/drivers/can.h>
 #include <zephyr/drivers/clock_control.h>

--- a/drivers/can/can_infineon.c
+++ b/drivers/can/can_infineon.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/drivers/can.h>
-#include <zephyr/drivers/can/can_mcan.h>
+#include "can_mcan.h"
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>

--- a/drivers/can/can_kvaser_pci.c
+++ b/drivers/can/can_kvaser_pci.c
@@ -6,7 +6,7 @@
 
 #define DT_DRV_COMPAT kvaser_pcican
 
-#include <zephyr/drivers/can/can_sja1000.h>
+#include "can_sja1000.h"
 
 #include <zephyr/drivers/can.h>
 #include <zephyr/drivers/pcie/pcie.h>

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/drivers/can.h>
-#include <zephyr/drivers/can/can_mcan.h>
+#include "can_mcan.h"
 #include <zephyr/drivers/can/transceiver.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -6,8 +6,8 @@
  *
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_MCAN_H_
-#define ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_MCAN_H_
+#ifndef ZEPHYR_DRIVERS_CAN_CAN_MCAN_H_
+#define ZEPHYR_DRIVERS_CAN_CAN_MCAN_H_
 
 #include <zephyr/cache.h>
 #include <zephyr/devicetree.h>
@@ -1696,4 +1696,4 @@ int can_mcan_get_state(const struct device *dev, enum can_state *state,
 void can_mcan_set_state_change_callback(const struct device *dev,
 					can_state_change_callback_t callback, void *user_data);
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_MCAN_H_ */
+#endif /* ZEPHYR_DRIVERS_CAN_CAN_MCAN_H_ */

--- a/drivers/can/can_mspm0_canfd.c
+++ b/drivers/can/can_mspm0_canfd.c
@@ -8,7 +8,7 @@
 #include <zephyr/irq.h>
 
 #include <zephyr/drivers/can.h>
-#include <zephyr/drivers/can/can_mcan.h>
+#include "can_mcan.h"
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/mspm0_clock_control.h>

--- a/drivers/can/can_nrf.c
+++ b/drivers/can/can_nrf.c
@@ -11,7 +11,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/can.h>
-#include <zephyr/drivers/can/can_mcan.h>
+#include "can_mcan.h"
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/reset.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/can.h>
-#include <zephyr/drivers/can/can_mcan.h>
+#include "can_mcan.h"
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/clock_control_numaker.h>
 #include <zephyr/logging/log.h>

--- a/drivers/can/can_nxp_lpc_mcan.c
+++ b/drivers/can/can_nxp_lpc_mcan.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/can.h>
-#include <zephyr/drivers/can/can_mcan.h>
+#include "can_mcan.h"
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/logging/log.h>

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/drivers/can.h>
-#include <zephyr/drivers/can/can_mcan.h>
+#include "can_mcan.h"
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <soc.h>

--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -9,7 +9,7 @@
  */
 
 #include <zephyr/drivers/can.h>
-#include <zephyr/drivers/can/can_mcan.h>
+#include "can_mcan.h"
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/drivers/can/can_sja1000.h>
+#include "can_sja1000.h"
 #include "can_sja1000_priv.h"
 
 #include <zephyr/drivers/can.h>

--- a/drivers/can/can_sja1000.h
+++ b/drivers/can/can_sja1000.h
@@ -9,8 +9,8 @@
  * @brief API for NXP SJA1000 (and compatible) CAN controller frontend drivers.
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_SJA1000_H_
-#define ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_SJA1000_H_
+#ifndef ZEPHYR_DRIVERS_CAN_CAN_SJA1000_H_
+#define ZEPHYR_DRIVERS_CAN_CAN_SJA1000_H_
 
 #include <zephyr/drivers/can.h>
 
@@ -274,4 +274,4 @@ void can_sja1000_isr(const struct device *dev);
  */
 int can_sja1000_init(const struct device *dev);
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_SJA1000_H_ */
+#endif /* ZEPHYR_DRIVERS_CAN_CAN_SJA1000_H_ */

--- a/drivers/can/can_stm32_fdcan.c
+++ b/drivers/can/can_stm32_fdcan.c
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/drivers/can.h>
-#include <zephyr/drivers/can/can_mcan.h>
+#include "can_mcan.h"
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/counter.h>

--- a/drivers/can/can_stm32h7_fdcan.c
+++ b/drivers/can/can_stm32h7_fdcan.c
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/drivers/can.h>
-#include <zephyr/drivers/can/can_mcan.h>
+#include "can_mcan.h"
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/can/can_tcan4x5x.c
+++ b/drivers/can/can_tcan4x5x.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/can.h>
-#include <zephyr/drivers/can/can_mcan.h>
+#include "can_mcan.h"
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
- Move the can_sja1000.h header file out of the public include path. This file should solely be used for implementing CAN driver frontends for SJA1000-based CAN controller IPs.
- Move the can_mcan.h header file out of the public include path. This file should solely be used for implementing CAN driver frontends for Bosch M_CAN-based CAN controller IPs.

