### PR TITLE
drivers: eeprom: fake: make fake_eeprom_size_delegate() private

### DIFF
--- a/drivers/eeprom/eeprom_fake.c
+++ b/drivers/eeprom/eeprom_fake.c
@@ -40,7 +40,7 @@ static int fake_eeprom_read_delegate(const struct device *dev, off_t offset, voi
 	return 0;
 }
 
-size_t fake_eeprom_size_delegate(const struct device *dev)
+static size_t fake_eeprom_size_delegate(const struct device *dev)
 {
 	const struct fake_eeprom_config *config = dev->config;
 

--- a/include/zephyr/drivers/eeprom/eeprom_fake.h
+++ b/include/zephyr/drivers/eeprom/eeprom_fake.h
@@ -20,8 +20,6 @@ DECLARE_FAKE_VALUE_FUNC(int, fake_eeprom_write, const struct device *, off_t, co
 
 DECLARE_FAKE_VALUE_FUNC(size_t, fake_eeprom_size, const struct device *);
 
-size_t fake_eeprom_size_delegate(const struct device *dev);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Make the internal fake_eeprom_size_delegate() function private.