### PR TITLE
drivers: i2s: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -360,7 +360,7 @@ __subsystem struct i2s_driver_api {
  *            For those, the RX and TX streams need to be configured separately.
  * @param cfg Pointer to the structure containing configuration parameters.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EINVAL Invalid argument.
  * @retval -ENOSYS I2S_DIR_BOTH value is not supported.
  */
@@ -419,7 +419,7 @@ static inline const struct i2s_config *i2s_config_get(const struct device *dev,
  * @param mem_block Pointer to the RX memory block containing received data.
  * @param size Pointer to the variable storing the number of bytes read.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO The interface is in NOT_READY or ERROR state and there are no
  *         more data blocks in the RX queue.
  * @retval -EBUSY Returned without waiting.
@@ -452,7 +452,7 @@ static inline int i2s_read(const struct device *dev, void **mem_block,
  *            as large as the configured memory block size for the RX channel.
  * @param size Pointer to the variable storing the number of bytes read.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO The interface is in NOT_READY or ERROR state and there are no
  *         more data blocks in the RX queue.
  * @retval -EBUSY Returned without waiting.
@@ -481,7 +481,7 @@ __syscall int i2s_buf_read(const struct device *dev, void *buf, size_t *size);
  * @param size Number of bytes to write. This value has to be equal or smaller
  *        than the size of the memory block.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO The interface is not in READY or RUNNING state.
  * @retval -EBUSY Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
@@ -507,7 +507,7 @@ static inline int i2s_write(const struct device *dev, void *mem_block,
  * @param size Number of bytes to write. This value has to be equal or smaller
  *        than the size of the channel's TX memory block configuration.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO The interface is not in READY or RUNNING state.
  * @retval -EBUSY Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
@@ -526,7 +526,7 @@ __syscall int i2s_buf_write(const struct device *dev, void *buf, size_t size);
  *            and TX streams.
  * @param cmd Trigger command.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EINVAL Invalid argument.
  * @retval -EIO The trigger cannot be executed in the current state or a DMA
  *         channel cannot be allocated.


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974