### PR TITLE
drivers: i3c: clean up @retval descriptions

### DIFF
--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1401,10 +1401,10 @@ struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct device *dev,
  *                    if it matches the incoming PID (@p pid).
  * @param[out] addr Address to be assigned to target device.
  *
- * @retval 0 if successful.
- * @retval -ENODEV if no device matches the PID (@p pid) in
+ * @retval 0 on success.
+ * @retval -ENODEV No device matches the PID (@p pid) in
  *                 the device list and @p must_match is true.
- * @retval -EINVAL if the device matching PID (@p pid) already
+ * @retval -EINVAL Device matching PID (@p pid) already
  *                 has an address assigned or invalid function
  *                 arguments.
  */
@@ -1423,10 +1423,10 @@ int i3c_dev_list_daa_addr_helper(struct i3c_addr_slots *addr_slots,
  *             in @p config.
  * @param config Pointer to the configuration parameters.
  *
- * @retval 0 If successful.
- * @retval -EINVAL If invalid configure parameters.
+ * @retval 0 on success.
+ * @retval -EINVAL Invalid configure parameters.
  * @retval -EIO General Input/Output errors.
- * @retval -ENOSYS If not implemented.
+ * @retval -ENOSYS Not implemented.
  */
 static inline int i3c_configure(const struct device *dev,
 				enum i3c_config_type type, void *config)
@@ -1452,9 +1452,9 @@ static inline int i3c_configure(const struct device *dev,
  * @param config Pointer to a @ref i3c_config_controller structure
  *               where the configuration will be stored.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output errors.
- * @retval -ENOSYS If not implemented.
+ * @retval -ENOSYS Not implemented.
  */
 static inline int i3c_configure_controller(const struct device *dev,
 					   struct i3c_config_controller *config)
@@ -1474,9 +1474,9 @@ static inline int i3c_configure_controller(const struct device *dev,
  * @param config Pointer to a @ref i3c_config_target structure
  *                    where the configuration will be stored.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output errors.
- * @retval -ENOSYS If not implemented.
+ * @retval -ENOSYS Not implemented.
  */
 static inline int i3c_configure_target(const struct device *dev,
 				       struct i3c_config_target *config)
@@ -1500,9 +1500,9 @@ static inline int i3c_configure_target(const struct device *dev,
  * Note that if @p type is #I3C_CONFIG_CUSTOM, @p config must contain
  * the ID of the parameter to be retrieved.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output errors.
- * @retval -ENOSYS If not implemented.
+ * @retval -ENOSYS Not implemented.
  */
 static inline int i3c_config_get(const struct device *dev,
 				 enum i3c_config_type type, void *config)
@@ -1528,9 +1528,9 @@ static inline int i3c_config_get(const struct device *dev,
  * @param[out] config Pointer to a @ref i3c_config_controller structure
  *                    where the configuration will be used.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output errors.
- * @retval -ENOSYS If not implemented.
+ * @retval -ENOSYS Not implemented.
  */
 static inline int i3c_config_get_controller(const struct device *dev,
 					    struct i3c_config_controller *config)
@@ -1550,9 +1550,9 @@ static inline int i3c_config_get_controller(const struct device *dev,
  * @param[out] config Pointer to a @ref i3c_config_target structure
  *                    where the configuration will be used.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output errors.
- * @retval -ENOSYS If not implemented.
+ * @retval -ENOSYS Not implemented.
  */
 static inline int i3c_config_get_target(const struct device *dev,
 					struct i3c_config_target *config)
@@ -1566,8 +1566,8 @@ static inline int i3c_config_get_target(const struct device *dev,
  *
  * This routine asks the controller to attempt bus recovery.
  *
- * @retval 0 If successful.
- * @retval -EBUSY If bus recovery fails.
+ * @retval 0 on success.
+ * @retval -EBUSY Bus recovery fails.
  * @retval -EIO General input / output error.
  * @retval -ENOSYS Bus recovery is not supported by the controller driver.
  */
@@ -1598,9 +1598,9 @@ static inline int i3c_recover_bus(const struct device *dev)
  *
  * @param target Pointer to the target device descriptor
  *
- * @retval 0 If successful.
- * @retval -EINVAL If address is not available or if the device
- *     has already been attached before
+ * @retval 0 on success.
+ * @retval -EINVAL Address is not available, or the device
+ *     has already been attached before.
  */
 int i3c_attach_i3c_device(struct i3c_device_desc *target);
 
@@ -1625,8 +1625,8 @@ int i3c_attach_i3c_device(struct i3c_device_desc *target);
  * @param old_dyn_addr The old dynamic address of target device, 0 if
  *            there was no old dynamic address
  *
- * @retval 0 If successful.
- * @retval -EINVAL If address is not available
+ * @retval 0 on success.
+ * @retval -EINVAL Address is not available.
  */
 int i3c_reattach_i3c_device(struct i3c_device_desc *target, uint8_t old_dyn_addr);
 
@@ -1646,8 +1646,8 @@ int i3c_reattach_i3c_device(struct i3c_device_desc *target, uint8_t old_dyn_addr
  *
  * @param target Pointer to the target device descriptor
  *
- * @retval 0 If successful.
- * @retval -EINVAL If device is already detached
+ * @retval 0 on success.
+ * @retval -EINVAL Device is already detached.
  */
 int i3c_detach_i3c_device(struct i3c_device_desc *target);
 
@@ -1665,9 +1665,9 @@ int i3c_detach_i3c_device(struct i3c_device_desc *target);
  *
  * @param target Pointer to the target device descriptor
  *
- * @retval 0 If successful.
- * @retval -EINVAL If address is not available or if the device
- *     has already been attached before
+ * @retval 0 on success.
+ * @retval -EINVAL Address is not available, or the device
+ *     has already been attached before.
  */
 int i3c_attach_i2c_device(struct i3c_i2c_device_desc *target);
 
@@ -1685,8 +1685,8 @@ int i3c_attach_i2c_device(struct i3c_i2c_device_desc *target);
  *
  * @param target Pointer to the target device descriptor
  *
- * @retval 0 If successful.
- * @retval -EINVAL If device is already detached
+ * @retval 0 on success.
+ * @retval -EINVAL Device is already detached.
  */
 int i3c_detach_i2c_device(struct i3c_i2c_device_desc *target);
 
@@ -1704,10 +1704,10 @@ int i3c_detach_i2c_device(struct i3c_i2c_device_desc *target);
  * @param dev Pointer to the device structure for the controller driver
  *            instance.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
- * @retval -ENODEV If a provisioned ID does not match to any target devices
+ * @retval -ENODEV Provisioned ID does not match to any target devices
  *                 in the registered device list.
  * @retval -ENOSPC No more free addresses can be assigned to target.
  * @retval -ENOSYS Dynamic address assignment is not supported by
@@ -1732,7 +1732,7 @@ static inline int i3c_do_daa(const struct device *dev)
  *            instance.
  * @param payload Pointer to the structure describing the CCC payload.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General Input / output error.
  * @retval -EINVAL Invalid valid set in the payload structure.
@@ -1781,7 +1781,7 @@ static inline int z_impl_i3c_do_ccc(const struct device *dev,
  * @param msgs Array of messages to transfer.
  * @param num_msgs Number of messages to transfer.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
  */
@@ -1843,7 +1843,7 @@ struct i3c_device_desc *i3c_device_find(const struct device *dev,
  * @param dev Pointer to controller device driver instance.
  * @param ack True to ack, False to nack
  *
- * @retval 0 if operation is successful.
+ * @retval 0 on success.
  * @retval -EIO General input / output error.
  */
 static inline int i3c_ibi_hj_response(const struct device *dev,
@@ -1868,7 +1868,7 @@ static inline int i3c_ibi_hj_response(const struct device *dev,
  * @param dev Pointer to controller device driver instance.
  * @param request Pointer to the IBI request struct.
  *
- * @retval 0 if operation is successful.
+ * @retval 0 on success.
  * @retval -EIO General input / output error.
  */
 static inline int i3c_ibi_raise(const struct device *dev,
@@ -1893,9 +1893,9 @@ static inline int i3c_ibi_raise(const struct device *dev,
  *
  * @param target I3C target device descriptor.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input / output error.
- * @retval -ENOMEM If these is no more empty entries in
+ * @retval -ENOMEM There are no more empty entries in
  *                 the controller's IBI table (if the controller
  *                 uses such table).
  */
@@ -1919,9 +1919,9 @@ static inline int i3c_ibi_enable(struct i3c_device_desc *target)
  *
  * @param target I3C target device descriptor.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input / output error.
- * @retval -ENODEV If IBI is not previously enabled for @p target.
+ * @retval -ENODEV IBI is not previously enabled for @p target.
  */
 static inline int i3c_ibi_disable(struct i3c_device_desc *target)
 {
@@ -2003,7 +2003,7 @@ static inline int i3c_device_is_controller_capable(struct i3c_device_desc *targe
  * @param buf Memory pool from which the data is transferred.
  * @param num_bytes Number of bytes to write.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
  */
@@ -2030,7 +2030,7 @@ static inline int i3c_write(struct i3c_device_desc *target,
  * @param buf Memory pool that stores the retrieved data.
  * @param num_bytes Number of bytes to read.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
  */
@@ -2061,7 +2061,7 @@ static inline int i3c_read(struct i3c_device_desc *target,
  * @param read_buf Pointer to storage for read data
  * @param num_read Number of bytes to read
  *
- * @retval 0 if successful
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
  */
@@ -2099,7 +2099,7 @@ static inline int i3c_write_read(struct i3c_device_desc *target,
  * @param buf Memory pool that stores the retrieved data.
  * @param num_bytes Number of bytes being read.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
  */
@@ -2129,7 +2129,7 @@ static inline int i3c_burst_read(struct i3c_device_desc *target,
  * @param buf Memory pool from which the data is transferred.
  * @param num_bytes Number of bytes being written.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
  */
@@ -2165,7 +2165,7 @@ static inline int i3c_burst_write(struct i3c_device_desc *target,
  * @param reg_addr Address of the internal register being read.
  * @param value Memory pool that stores the retrieved register value.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
  */
@@ -2190,7 +2190,7 @@ static inline int i3c_reg_read_byte(struct i3c_device_desc *target,
  * @param reg_addr Address of the internal register being written.
  * @param value Value to be written to internal register.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
  */
@@ -2216,7 +2216,7 @@ static inline int i3c_reg_write_byte(struct i3c_device_desc *target,
  * @param mask Bitmask for updating internal register.
  * @param value Value for updating internal register.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
  */
@@ -2275,10 +2275,10 @@ void i3c_dump_msgs(const char *name, const struct i3c_msg *msgs,
  * @param dev Pointer to controller device driver instance.
  * @param i3c_dev_list Pointer to I3C device list.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
- * @retval -ENODEV If a provisioned ID does not match to any target devices
+ * @retval -ENODEV Provisioned ID does not match to any target devices
  *                 in the registered device list.
  * @retval -ENOSPC No more free addresses can be assigned to target.
  * @retval -ENOSYS Dynamic address assignment is not supported by
@@ -2301,7 +2301,7 @@ int i3c_bus_init(const struct device *dev,
  *
  * @param[in,out] target I3C target device descriptor.
  *
- * @retval 0 if successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_device_basic_info_get(struct i3c_device_desc *target);
@@ -2325,7 +2325,7 @@ int i3c_device_basic_info_get(struct i3c_device_desc *target);
  *
  * @param[in,out] target I3C target device descriptor.
  *
- * @retval 0 if successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_device_adv_info_get(struct i3c_device_desc *target);
@@ -2348,7 +2348,7 @@ int i3c_device_adv_info_get(struct i3c_device_desc *target);
  *
  * @param[in,out] target I3C target device descriptor.
  *
- * @retval 0 if successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 static inline int i3c_device_info_get(struct i3c_device_desc *target)
@@ -2394,7 +2394,7 @@ bool i3c_bus_has_sec_controller(const struct device *dev);
  *
  * @param dev Pointer to the controller device driver instance.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_rstdaa_all(const struct device *dev);
@@ -2407,8 +2407,8 @@ int i3c_bus_rstdaa_all(const struct device *dev);
  * @param desc Pointer to the target device descriptor.
  * @param dynamic_addr The dynamic address to assign to the device.
  *
- * @retval 0 If successful.
- * @retval -EADDRNOTAVAIL If the address is not available.
+ * @retval 0 on success.
+ * @retval -EADDRNOTAVAIL Address is not available.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_setdasa(struct i3c_device_desc *desc, uint8_t dynamic_addr);
@@ -2421,8 +2421,8 @@ int i3c_bus_setdasa(struct i3c_device_desc *desc, uint8_t dynamic_addr);
  * @param desc Pointer to the target device descriptor.
  * @param dynamic_addr The new dynamic address to assign to the device.
  *
- * @retval 0 If successful.
- * @retval -EADDRNOTAVAIL If the address is not available.
+ * @retval 0 on success.
+ * @retval -EADDRNOTAVAIL Address is not available.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_setnewda(struct i3c_device_desc *desc, uint8_t dynamic_addr);
@@ -2434,7 +2434,7 @@ int i3c_bus_setnewda(struct i3c_device_desc *desc, uint8_t dynamic_addr);
  *
  * @param dev Pointer to the controller device driver instance.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_setaasa(const struct device *dev);
@@ -2446,7 +2446,7 @@ int i3c_bus_setaasa(const struct device *dev);
  *
  * @param desc Pointer to the target device descriptor.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_getbcr(struct i3c_device_desc *desc);
@@ -2458,7 +2458,7 @@ int i3c_bus_getbcr(struct i3c_device_desc *desc);
  *
  * @param desc Pointer to the target device descriptor.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_getdcr(struct i3c_device_desc *desc);
@@ -2470,7 +2470,7 @@ int i3c_bus_getdcr(struct i3c_device_desc *desc);
  *
  * @param desc Pointer to the target device descriptor.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_getpid(struct i3c_device_desc *desc);
@@ -2482,7 +2482,7 @@ int i3c_bus_getpid(struct i3c_device_desc *desc);
  *
  * @param desc Pointer to the target device descriptor.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_getmrl(struct i3c_device_desc *desc);
@@ -2494,7 +2494,7 @@ int i3c_bus_getmrl(struct i3c_device_desc *desc);
  *
  * @param desc Pointer to the target device descriptor.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_getmwl(struct i3c_device_desc *desc);
@@ -2508,7 +2508,7 @@ int i3c_bus_getmwl(struct i3c_device_desc *desc);
  * @param mrl Maximum read length to set.
  * @param ibi_len Maximum IBI length to set.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_setmrl(struct i3c_device_desc *desc, uint16_t mrl, uint8_t ibi_len);
@@ -2521,7 +2521,7 @@ int i3c_bus_setmrl(struct i3c_device_desc *desc, uint16_t mrl, uint8_t ibi_len);
  * @param desc Pointer to the target device descriptor.
  * @param mwl Maximum write length to set.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_setmwl(struct i3c_device_desc *desc, uint16_t mwl);
@@ -2536,7 +2536,7 @@ int i3c_bus_setmwl(struct i3c_device_desc *desc, uint16_t mwl);
  * @param ibi_len Maximum IBI length to set.
  * @param has_ibi_size True if to transmit max ibi len
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_setmrl_all(const struct device *dev, uint16_t mrl, uint8_t ibi_len, bool has_ibi_size);
@@ -2549,7 +2549,7 @@ int i3c_bus_setmrl_all(const struct device *dev, uint16_t mrl, uint8_t ibi_len, 
  * @param dev Pointer to the controller device driver instance.
  * @param mwl Maximum write length to set.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_setmwl_all(const struct device *dev, uint16_t mwl);
@@ -2562,7 +2562,7 @@ int i3c_bus_setmwl_all(const struct device *dev, uint16_t mwl);
  *
  * @param desc Pointer to the target device descriptor.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_getacccr(struct i3c_device_desc *desc);
@@ -2574,7 +2574,7 @@ int i3c_bus_getacccr(struct i3c_device_desc *desc);
  *
  * @param dev Pointer to controller device driver instance.
  *
- * @retval 0 if successful.
+ * @retval 0 on success.
  * @retval -ENOMEM No memory to build the payload.
  * @retval -EIO General Input/Output error.
  */
@@ -2602,7 +2602,7 @@ uint8_t i3c_odd_parity(uint8_t p);
  * @param requested True if the target requested the Handoff, False if
  * the active controller is passing it to a secondary controller
  *
- * @retval 0 if successful.
+ * @retval 0 on success.
  * @retval -EIO General Input/Output error.
  * @retval -EBUSY Target cannot accept Controller Handoff
  */
@@ -2635,7 +2635,7 @@ void i3c_sec_handoffed(struct k_work *work);
  * This allocates memory from a mem slab for a i3c_device_desc
  *
  * @return Pointer to allocated i3c_device_desc
- * @retval NULL if no mem slabs available
+ * @retval NULL No mem slabs available.
  */
 struct i3c_device_desc *i3c_device_desc_alloc(void);
 


### PR DESCRIPTION
Reword the @RetVal descriptions to follow the conventions documented
in PR https://github.com/zephyrproject-rtos/zephyr/pull/107458:
drop the leading "if"/"If", use declarative phrasing, "0 on success",
and terminating periods.