### PR TITLE
kernel: remove redundant kernel_structs.h includes

### DIFF
--- a/arch/arc/core/fault.c
+++ b/arch/arc/core/fault.c
@@ -17,7 +17,6 @@
 
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/arch/common/exc_handle.h>
 #include <zephyr/logging/log.h>
 

--- a/arch/arc/core/mpu/arc_core_mpu.c
+++ b/arch/arc/core/mpu/arc_core_mpu.c
@@ -8,7 +8,6 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/arch/arc/v2/mpu/arc_core_mpu.h>
-#include <zephyr/kernel_structs.h>
 
 /*
  * @brief Configure MPU for the thread

--- a/arch/arc/core/smp.c
+++ b/arch/arc/core/smp.c
@@ -12,7 +12,6 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/irq.h>
-#include <zephyr/kernel_structs.h>
 #include <ipi.h>
 #include <zephyr/init.h>
 #include <zephyr/platform/hooks.h>

--- a/arch/arc/core/timestamp.c
+++ b/arch/arc/core/timestamp.c
@@ -13,7 +13,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/toolchain.h>
-#include <zephyr/kernel_structs.h>
 
 /*
  * @brief Read 64-bit timestamp value

--- a/arch/arc/core/tls.c
+++ b/arch/arc/core/tls.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
 #include <zephyr/sys/util.h>

--- a/arch/arc/include/swap_macros.h
+++ b/arch/arc/include/swap_macros.h
@@ -9,7 +9,6 @@
 #ifndef ZEPHYR_ARCH_ARC_INCLUDE_SWAP_MACROS_H_
 #define ZEPHYR_ARCH_ARC_INCLUDE_SWAP_MACROS_H_
 
-#include <zephyr/kernel_structs.h>
 #include <offsets_short.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/arch/cpu.h>

--- a/arch/arm/core/mpu/arm_core_mpu.c
+++ b/arch/arm/core/mpu/arm_core_mpu.c
@@ -8,7 +8,6 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 #include "arm_core_mpu_dev.h"
 #include <zephyr/linker/linker-defs.h>

--- a/arch/arm/core/stacktrace.c
+++ b/arch/arm/core/stacktrace.c
@@ -8,7 +8,6 @@
 #include <zephyr/debug/symtab.h>
 #include <zephyr/kernel.h>
 #include <zephyr/arch/exception.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/linker/linker-defs.h>
 #include <kernel_internal.h>
 #include <zephyr/logging/log.h>

--- a/arch/arm/core/tls.c
+++ b/arch/arm/core/tls.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
 #include <zephyr/app_memory/app_memdomain.h>

--- a/arch/arm64/core/fpu.c
+++ b/arch/arm64/core/fpu.c
@@ -6,7 +6,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_arch_interface.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/barrier.h>

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -14,7 +14,6 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_arch_interface.h>
 #include <ipi.h>
 #include <zephyr/init.h>

--- a/arch/arm64/core/tls.c
+++ b/arch/arm64/core/tls.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
 #include <zephyr/app_memory/app_memdomain.h>

--- a/arch/mips/core/irq_offload.c
+++ b/arch/mips/core/irq_offload.c
@@ -7,7 +7,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <zephyr/irq.h>
 #include <zephyr/irq_offload.h>

--- a/arch/openrisc/core/tls.c
+++ b/arch/openrisc/core/tls.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
 #include <zephyr/app_memory/app_memdomain.h>

--- a/arch/posix/core/fatal.c
+++ b/arch/posix/core/fatal.c
@@ -7,7 +7,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/sys/printk.h>
 #include <inttypes.h>
 #include <zephyr/logging/log_ctrl.h>

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -14,7 +14,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include "posix_core.h"
 #include <zephyr/irq.h>
 #include "kswap.h"

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <inttypes.h>
 #include <zephyr/arch/common/exc_handle.h>

--- a/arch/riscv/core/fpu.c
+++ b/arch/riscv/core/fpu.c
@@ -6,7 +6,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_arch_interface.h>
 #include <zephyr/sys/atomic.h>
 

--- a/arch/riscv/core/stacktrace.c
+++ b/arch/riscv/core/stacktrace.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/debug/symtab.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/linker/linker-defs.h>
 #include <kernel_internal.h>
 #include <zephyr/logging/log.h>

--- a/arch/riscv/core/tls.c
+++ b/arch/riscv/core/tls.c
@@ -6,7 +6,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
 #include <zephyr/app_memory/app_memdomain.h>

--- a/arch/sparc/core/irq_offload.c
+++ b/arch/sparc/core/irq_offload.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/irq.h>
 #include <zephyr/irq_offload.h>
 

--- a/arch/sparc/core/tls.c
+++ b/arch/sparc/core/tls.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
 #include <zephyr/app_memory/app_memdomain.h>

--- a/arch/x86/core/cpuid.c
+++ b/arch/x86/core/cpuid.c
@@ -6,7 +6,6 @@
 
 #include <cpuid.h> /* Header provided by the toolchain. */
 
-#include <zephyr/kernel_structs.h>
 #include <zephyr/arch/x86/cpuid.h>
 #include <zephyr/kernel.h>
 

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -4,7 +4,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <zephyr/arch/common/exc_handle.h>
 #include <zephyr/logging/log.h>

--- a/arch/x86/core/ia32/irq_manage.c
+++ b/arch/x86/core/ia32/irq_manage.c
@@ -16,7 +16,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/irq.h>
 #include <zephyr/tracing/tracing.h>

--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -8,7 +8,6 @@
 #include <zephyr/arch/cpu.h>
 #include <kernel_arch_data.h>
 #include <kernel_arch_func.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <zephyr/arch/x86/multiboot.h>
 #include <x86_mmu.h>

--- a/arch/x86/core/intel64/fatal.c
+++ b/arch/x86/core/intel64/fatal.c
@@ -4,7 +4,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);

--- a/arch/x86/core/intel64/thread.c
+++ b/arch/x86/core/intel64/thread.c
@@ -4,7 +4,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <offsets_short.h>
 #include <x86_mmu.h>

--- a/arch/x86/core/tls.c
+++ b/arch/x86/core/tls.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
 #include <zephyr/sys/util.h>

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -5,7 +5,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/kernel_structs.h>
 #include <inttypes.h>
 #include <xtensa/config/specreg.h>
 #include <xtensa_backtrace.h>

--- a/arch/xtensa/core/tls.c
+++ b/arch/xtensa/core/tls.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
 #include <zephyr/app_memory/app_memdomain.h>

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -7,7 +7,6 @@
 #include <string.h>
 #include <xtensa_asm2_context.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kswap.h>
 #include <zephyr/toolchain.h>

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -11,7 +11,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/types.h>

--- a/drivers/power_domain/power_domain_soc_state_change.c
+++ b/drivers/power_domain/power_domain_soc_state_change.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/pm/pm.h>

--- a/drivers/wifi/eswifi/eswifi.h
+++ b/drivers/wifi/eswifi/eswifi.h
@@ -9,7 +9,6 @@
 
 #include <zephyr/kernel.h>
 #include <stdio.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/drivers/gpio.h>
 
 #include <zephyr/net/wifi_mgmt.h>

--- a/include/zephyr/arch/x86/cpuid.h
+++ b/include/zephyr/arch/x86/cpuid.h
@@ -6,6 +6,8 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_X86_CPUID_H_
 #define ZEPHYR_INCLUDE_ARCH_X86_CPUID_H_
 
+#include <stdint.h>
+
 #ifndef _ASMLANGUAGE
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/debug/object_tracing.h
+++ b/include/zephyr/debug/object_tracing.h
@@ -8,7 +8,6 @@
 #define ZEPHYR_INCLUDE_THREAD_MONITOR_H_
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 /**
  * @brief Head element of the thread monitor list.

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -33,7 +33,6 @@
 #include <zephyr/app_memory/app_memdomain.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/mem_blocks.h>

--- a/include/zephyr/sys/mutex.h
+++ b/include/zephyr/sys/mutex.h
@@ -132,7 +132,6 @@ static inline int sys_mutex_unlock(struct sys_mutex *mutex)
 
 #else
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 struct sys_mutex {
 	struct k_mutex kernel_mutex;

--- a/include/zephyr/tracing/tracking.h
+++ b/include/zephyr/tracing/tracking.h
@@ -14,7 +14,6 @@
 #define ZEPHYR_INCLUDE_TRACING_TRACKING_H_
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 #if defined(CONFIG_TRACING_OBJECT_TRACKING) || defined(__DOXYGEN__)
 

--- a/kernel/compiler_stack_protect.c
+++ b/kernel/compiler_stack_protect.c
@@ -19,7 +19,6 @@
 
 #include <zephyr/toolchain.h> /* compiler specific configurations */
 
-#include <zephyr/kernel_structs.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/kernel.h>

--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/toolchain.h>
 #include <ksched.h>
 #include <wait_q.h>

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -22,7 +22,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/dlist.h>

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -7,7 +7,6 @@
 #include <zephyr/kernel.h>
 
 #include <kernel_internal.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/logging/log_ctrl.h>

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -22,7 +22,6 @@
 #include <zephyr/random/random.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/toolchain.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/linker/linker-defs.h>

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -9,7 +9,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/sections.h>

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/sections.h>

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -11,7 +11,6 @@
 
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/sections.h>

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -27,7 +27,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/toolchain.h>
 #include <ksched.h>
 #include <kthread.h>

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -16,7 +16,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <wait_q.h>
 #include <ksched.h>

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -12,7 +12,6 @@
 
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 #include <zephyr/toolchain.h>
 #include <wait_q.h>

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -18,7 +18,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 #include <zephyr/toolchain.h>
 #include <wait_q.h>

--- a/kernel/smp/smp.c
+++ b/kernel/smp/smp.c
@@ -3,7 +3,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/kernel/smp.h>
 #include <zephyr/spinlock.h>
 #include <kswap.h>

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -10,7 +10,6 @@
 
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 #include <zephyr/toolchain.h>
 #include <ksched.h>

--- a/kernel/userspace/futex.c
+++ b/kernel/userspace/futex.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/spinlock.h>
 #include <kswap.h>
 #include <zephyr/internal/syscall_handler.h>

--- a/kernel/userspace/mem_domain.c
+++ b/kernel/userspace/mem_domain.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <zephyr/sys/__assert.h>
 #include <stdbool.h>

--- a/kernel/userspace/mutex.c
+++ b/kernel/userspace/mutex.c
@@ -7,7 +7,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/mutex.h>
 #include <zephyr/internal/syscall_handler.h>
-#include <zephyr/kernel_structs.h>
 
 static struct k_mutex *get_k_mutex(struct sys_mutex *mutex)
 {

--- a/kernel/userspace/userspace.c
+++ b/kernel/userspace/userspace.c
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/rb.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/sys/sys_io.h>
 #include <ksched.h>
 #include <zephyr/syscall.h>

--- a/kernel/userspace/userspace_handler.c
+++ b/kernel/userspace/userspace_handler.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/internal/syscall_handler.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/toolchain.h>
 
 static struct k_object *validate_kernel_object(const void *obj,

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -11,7 +11,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <wait_q.h>
 #include <zephyr/spinlock.h>
 #include <errno.h>

--- a/samples/userspace/shared_mem/src/main.h
+++ b/samples/userspace/shared_mem/src/main.h
@@ -9,7 +9,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
-#include <zephyr/kernel_structs.h>
 #include <string.h>
 #include <stdlib.h>
 

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -178,7 +178,6 @@ SOURCE_CODE_INCLUDES = """
 /* Auto generated code. Do not modify.*/
 #include <zephyr/kernel.h>
 #include <zephyr/linker/linker-defs.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <zephyr/arch/common/init.h>
 """

--- a/soc/espressif/esp32/esp32-mp.c
+++ b/soc/espressif/esp32/esp32-mp.c
@@ -8,7 +8,6 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 

--- a/soc/espressif/esp32s3/esp32s3-mp.c
+++ b/soc/espressif/esp32s3/esp32s3-mp.c
@@ -7,7 +7,6 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 

--- a/soc/intel/intel_adsp/common/multiprocessing.c
+++ b/soc/intel/intel_adsp/common/multiprocessing.c
@@ -7,7 +7,6 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/sys_io.h>

--- a/subsys/cpu_freq/policies/pressure/pressure.c
+++ b/subsys/cpu_freq/policies/pressure/pressure.c
@@ -6,7 +6,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/cpu_freq/policy.h>

--- a/subsys/instrumentation/common/instr_common.c
+++ b/subsys/instrumentation/common/instr_common.c
@@ -15,7 +15,6 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/retention/retention.h>
 #include <zephyr/sys/reboot.h>
 

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -9,7 +9,6 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
 #include <zephyr/debug/object_tracing.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
 #include <zephyr/mgmt/mcumgr/smp/smp.h>
 #include <zephyr/mgmt/mcumgr/mgmt/handlers.h>

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/init.h>
 #include <string.h>
 #include <zephyr/drivers/timer/system_timer.h>

--- a/subsys/testsuite/ztest/src/ztest_error_hook.c
+++ b/subsys/testsuite/ztest/src/ztest_error_hook.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/ztest.h>
 
 

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <ctf_top.h>
 #include <zephyr/net/net_core.h>

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -8,7 +8,6 @@
 #define _TRACE_CTF_H
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/init.h>
 
 #ifdef __cplusplus

--- a/subsys/tracing/sysview/sysview.c
+++ b/subsys/tracing/sysview/sysview.c
@@ -5,7 +5,6 @@
  */
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/init.h>
 #include <zephyr/debug/cpu_load.h>
 

--- a/tests/boards/realtek/bee_osif/src/osif_task_signal.c
+++ b/tests/boards/realtek/bee_osif/src/osif_task_signal.c
@@ -13,7 +13,6 @@
 #include <os_sched.h>
 
 #include <zephyr/irq_offload.h>
-#include <zephyr/kernel_structs.h>
 
 #define STACKSZ             512
 #define EXPECTED_NOTIFY_VAL 0x1

--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -14,7 +14,6 @@
  */
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/irq_offload.h>
 
 /**

--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -8,7 +8,6 @@
 #include <zephyr/ztest.h>
 #include <zephyr/tc_util.h>
 #include <zephyr/test_toolchain.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/irq_offload.h>
 #include <kswap.h>
 #include <assert.h>

--- a/tests/kernel/fatal/no-multithreading/src/main.c
+++ b/tests/kernel/fatal/no-multithreading/src/main.c
@@ -7,7 +7,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <zephyr/tc_util.h>
-#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <assert.h>
 

--- a/tests/kernel/ipi_cascade/src/main.c
+++ b/tests/kernel/ipi_cascade/src/main.c
@@ -35,7 +35,6 @@
 #include <zephyr/kernel.h>
 #include <ksched.h>
 #include <ipi.h>
-#include <zephyr/kernel_structs.h>
 
 #if (CONFIG_MP_MAX_NUM_CPUS != 2)
 #error "This test must have CONFIG_MP_MAX_NUM_CPUS=2"

--- a/tests/kernel/ipi_optimize/src/main.c
+++ b/tests/kernel/ipi_optimize/src/main.c
@@ -9,7 +9,6 @@
 #include <zephyr/kernel.h>
 #include <ksched.h>
 #include <ipi.h>
-#include <zephyr/kernel_structs.h>
 
 #define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
 

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -6,7 +6,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
-#include <zephyr/kernel_structs.h>
 #include <string.h>
 #include <stdlib.h>
 

--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -9,7 +9,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/sys/barrier.h>
 #include <zephyr/toolchain.h>
 #include <string.h>

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -9,7 +9,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
-#include <zephyr/kernel_structs.h>
 #include <string.h>
 #include <stdlib.h>
 #include <zephyr/app_memory/app_memdomain.h>

--- a/tests/kernel/mem_protect/userspace/src/switching.c
+++ b/tests/kernel/mem_protect/userspace/src/switching.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/app_memory/app_memdomain.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/barrier.h>

--- a/tests/kernel/pending/src/main.c
+++ b/tests/kernel/pending/src/main.c
@@ -7,7 +7,6 @@
 #include <zephyr/tc_util.h>
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <stdbool.h>
 
 #define  NUM_SECONDS(x)      ((x) * 1000)

--- a/tests/kernel/sched/preempt/src/main.c
+++ b/tests/kernel/sched/preempt/src/main.c
@@ -6,7 +6,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <zephyr/irq_offload.h>
-#include <zephyr/kernel_structs.h> /* for _THREAD_PENDING */
 
 /* Explicit preemption test.  Works by creating a set of threads in
  * each priority class (cooperative, preemptive, metairq) which all go

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -8,7 +8,6 @@
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
 #include <ksched.h>
-#include <zephyr/kernel_structs.h>
 
 #if CONFIG_MP_MAX_NUM_CPUS < 2
 #error SMP test requires at least two CPUs!

--- a/tests/kernel/smp_metairq/src/main.c
+++ b/tests/kernel/smp_metairq/src/main.c
@@ -8,7 +8,6 @@
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/barrier.h>
-#include <zephyr/kernel_structs.h>
 
 #if (CONFIG_MP_MAX_NUM_CPUS < 2)
 #error "This test requires at least 2 CPUs"

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -14,7 +14,6 @@
  */
 
 #include <zephyr/ztest.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <string.h>

--- a/tests/kernel/threads/thread_apis/src/test_essential_thread.c
+++ b/tests/kernel/threads/thread_apis/src/test_essential_thread.c
@@ -5,7 +5,6 @@
  */
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 
 /* Internal APIs */
 #include <kernel_internal.h>

--- a/tests/kernel/threads/tls/src/main.c
+++ b/tests/kernel/threads/tls/src/main.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel_structs.h>
 #include <zephyr/app_memory/app_memdomain.h>
 #include <zephyr/sys/libc-hooks.h>
 #include <zephyr/sys/util.h>

--- a/tests/subsys/portability/cmsis_rtos_v1/src/signal.c
+++ b/tests/subsys/portability/cmsis_rtos_v1/src/signal.c
@@ -9,7 +9,6 @@
 #include <cmsis_os.h>
 
 #include <zephyr/irq_offload.h>
-#include <zephyr/kernel_structs.h>
 
 #define TIMEOUT		(100)
 #define SIGNAL1		(0x00000020)

--- a/tests/subsys/portability/cmsis_rtos_v2/src/event_flags.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/event_flags.c
@@ -10,7 +10,6 @@
 #include <zephyr/portability/cmsis_types.h>
 
 #include <zephyr/irq_offload.h>
-#include <zephyr/kernel_structs.h>
 
 #define TIMEOUT_TICKS (100)
 #define FLAG1         (0x00000020)

--- a/tests/subsys/portability/cmsis_rtos_v2/src/thread_flags.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/thread_flags.c
@@ -10,7 +10,6 @@
 #include <zephyr/portability/cmsis_types.h>
 
 #include <zephyr/irq_offload.h>
-#include <zephyr/kernel_structs.h>
 
 #define TIMEOUT_TICKS (1000)
 #define FLAG1         (0x00000020)


### PR DESCRIPTION
kernel.h implies kernel_structs.h via kernel_includes.h, making
explicit inclusion of kernel_structs.h unnecessary whenever kernel.h
is already included in the same translation unit.

Remove the redundant includes across arch, boards, drivers, kernel,
lib, samples, subsys, and tests trees.

in include/zephyr/kernel_structs.h:
```
 *  2. kernel.h shall imply kernel_structs.h, such that it shall not be
 *    necessary to include kernel_structs.h explicitly when kernel.h is
 *    included.
```

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
