### PR TITLE
scripts: instrumentation: zaru: drop WestAppNoRun workaround

### DIFF
--- a/scripts/instrumentation/zaru.py
+++ b/scripts/instrumentation/zaru.py
@@ -31,8 +31,7 @@ import tempfile
 import serial
 from colorama import Fore, Style
 from elftools.elf.elffile import ELFFile
-from west.app.main import WestApp
-from west.configuration import Configuration, config
+from west.configuration import Configuration
 from west.util import west_topdir
 
 STATUS_REPLY_PATTERN = r"(0|1)\s(0|1)\s(0|1)"
@@ -118,23 +117,6 @@ def get_zephyr_build_dir(args, die_if_not_set=False):
     finally:
         sys.path.pop(0)
 
-    # WestApp class only populates the config attributes if run() method is
-    # called. Since run() is used effectively to run commands -- which is not
-    # the purpose here, a new derivated class which populates the config
-    # attributes when initialized is defined below. Without config being
-    # populated method get_build_dir() won't correctly find/guess the Zephyr
-    # build dir and will simply return a default at best.
-    class WestAppNoRun(WestApp):
-        def __init__(self):
-            super().__init__()
-
-            self.config = Configuration(topdir=west_topdir())
-            self.config._copy_to_configparser(config)
-
-    # Init config attributes, so get_build_dir() works fine.
-    # pylint: disable=unused-variable
-    west_app = WestAppNoRun()  # noqa: F841
-
     # Although get_build_dir() checks args to see if build_dir is provided,
     # returning it if provided, it neither checks if the build_dir exists nor
     # checks if it is a valid Zephyr build dir, hence the checks below.
@@ -147,7 +129,11 @@ def get_zephyr_build_dir(args, die_if_not_set=False):
             return pathlib.Path(args.build_dir)
 
     # If build_dir is not given by the user, try to guess it.
-    build_dir = get_build_dir(args, die_if_none=False)
+    build_dir = get_build_dir(
+        args,
+        die_if_none=False,
+        config=Configuration(topdir=west_topdir()),
+    )
 
     if build_dir is None and die_if_not_set:
         sys.exit("Could not determine build dir. Please provide one via '--build-dir'.")


### PR DESCRIPTION
The ``WestAppNoRun`` subclass only existed to populate the deprecated ``west.configuration.config`` global so the previous ``get_build_dir()`` could read it. We can now pass a newly constructed configuration as an optional argument.

~~Depends on https://github.com/zephyrproject-rtos/zephyr/pull/109272 (only last commit is new)~~