### PR TITLE
bluetooth: mesh: default BT_BUF_EVT_DISCARDABLE_SIZE to 58

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -201,6 +201,7 @@ config BT_BUF_EVT_DISCARDABLE_SIZE
 	default $(UINT8_MAX) if BT_CLASSIC
 	# Le Advertising Report event
 	default 43 if !BT_EXT_ADV
+	default 58 if BT_EXT_ADV && BT_MESH
 	default BT_BUF_EVT_RX_SIZE if BT_EXT_ADV
 	help
 	  Maximum support discardable HCI event size of buffers in the separate


### PR DESCRIPTION
Extended advertising reports as of
https://github.com/zephyrproject-rtos/zephyr/pull/106374 use the discardable event pool so fragmented chains can be dropped without. That raised the default discardable buffer size to BT_BUF_EVT_RX_SIZE to fit general ext-adv reassembly.

Mesh does not need that headroom. The advertising bearer uses ADV_NONCONN_IND PDUs (Mesh Protocol v1.1 3.3.1), which are legacy primary-channel advertisements, not fragmented extended advertising chains. Mesh scan only accepts BT_GAP_ADV_TYPE_ADV_NONCONN_IND, and legacy reports fit in 58 bytes, the minimum when BT_EXT_ADV is enabled.

Default to 58 for BT_MESH to save RAM.