### PR TITLE
soc: stm32: f4x: Kconfig.soc: No stm32f401xd at CMSIS level

### DIFF
--- a/boards/cirrus/crd40l50/Kconfig.crd40l50
+++ b/boards/cirrus/crd40l50/Kconfig.crd40l50
@@ -1,10 +1,5 @@
 # Copyright (c) 2026 Cirrus Logic, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Required to select STM32F401XE instead of STM32F401XD because the STM32 HAL
-# does not provide a #define for STM32F401xD variants. Because STM32F401xD and
-# STM32F401xE microcontrollers are identical apart from the size of embedded
-# flash memory, we select SOC_STM32F401XE.
-
 config BOARD_CRD40L50
-	select SOC_STM32F401XE
+	select SOC_STM32F401XD

--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: ad6ac613bb4552d5a2849a10440004a17a606625
+      revision: pull/372/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
STM32401xD doesn't exist in STM32F4 CMSIS and STM32401xE is used instead.
Unfortunately this won't be fixed in original package so properly redirect SOC_STM32F401XD Kconfig to the HAL symbol to avoid hacks at board level.
Clean up impacted board.

