### PR TITLE
drivers: flash: stm32: report failure on RDP level set and option byte locking

### DIFF
--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -380,7 +380,7 @@ int flash_stm32_get_wp_sectors(const struct device *dev,
 #if defined(CONFIG_FLASH_STM32_READOUT_PROTECTION)
 uint8_t flash_stm32_get_rdp_level(const struct device *dev);
 
-void flash_stm32_set_rdp_level(const struct device *dev, uint8_t level);
+int flash_stm32_set_rdp_level(const struct device *dev, uint8_t level);
 #endif
 
 #if defined(CONFIG_FLASH_STM32_BLOCK_REGISTERS)

--- a/drivers/flash/flash_stm32_ex_op.c
+++ b/drivers/flash/flash_stm32_ex_op.c
@@ -350,7 +350,7 @@ int flash_stm32_ex_op(const struct device *dev, uint16_t code,
 		int rv2;
 
 		rv = flash_stm32_option_bytes_lock(dev, false);
-		if (rv > 0) {
+		if (rv != 0) {
 			break;
 		}
 
@@ -358,7 +358,7 @@ int flash_stm32_ex_op(const struct device *dev, uint16_t code,
 		/* returned later, we always re-lock */
 
 		rv = flash_stm32_option_bytes_lock(dev, true);
-		if (rv > 0) {
+		if (rv != 0) {
 			break;
 		}
 

--- a/drivers/flash/flash_stm32_ex_op.c
+++ b/drivers/flash/flash_stm32_ex_op.c
@@ -224,7 +224,7 @@ int flash_stm32_ex_op_update_rdp(const struct device *dev, bool enable,
 		LOG_INF("RDP changed from 0x%02x to 0x%02x", current_level,
 			target_level);
 
-		flash_stm32_set_rdp_level(dev, target_level);
+		return flash_stm32_set_rdp_level(dev, target_level);
 	}
 	return 0;
 }

--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -310,10 +310,10 @@ uint8_t flash_stm32_get_rdp_level(const struct device *dev)
 	return (regs->OPTCR & FLASH_OPTCR_RDP_Msk) >> FLASH_OPTCR_RDP_Pos;
 }
 
-void flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
+int flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
 {
-	flash_stm32_option_bytes_write(dev, FLASH_OPTCR_RDP_Msk,
-				       (uint32_t)level << FLASH_OPTCR_RDP_Pos);
+	return flash_stm32_option_bytes_write(dev, FLASH_OPTCR_RDP_Msk,
+					      (uint32_t)level << FLASH_OPTCR_RDP_Pos);
 }
 #endif /* CONFIG_FLASH_STM32_READOUT_PROTECTION */
 

--- a/drivers/flash/flash_stm32f7x.c
+++ b/drivers/flash/flash_stm32f7x.c
@@ -202,10 +202,10 @@ uint8_t flash_stm32_get_rdp_level(const struct device *dev)
 	return (regs->OPTCR & FLASH_OPTCR_RDP_Msk) >> FLASH_OPTCR_RDP_Pos;
 }
 
-void flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
+int flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
 {
-	flash_stm32_option_bytes_write(dev, FLASH_OPTCR_RDP_Msk,
-				       (uint32_t)level << FLASH_OPTCR_RDP_Pos);
+	return flash_stm32_option_bytes_write(dev, FLASH_OPTCR_RDP_Msk,
+					      (uint32_t)level << FLASH_OPTCR_RDP_Pos);
 }
 #endif /* CONFIG_FLASH_STM32_READOUT_PROTECTION */
 

--- a/drivers/flash/flash_stm32g0x.c
+++ b/drivers/flash/flash_stm32g0x.c
@@ -247,10 +247,10 @@ uint8_t flash_stm32_get_rdp_level(const struct device *dev)
 	return (regs->OPTR & FLASH_OPTR_RDP_Msk) >> FLASH_OPTR_RDP_Pos;
 }
 
-void flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
+int flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
 {
-	flash_stm32_option_bytes_write(dev, FLASH_OPTR_RDP_Msk,
-				       (uint32_t)level << FLASH_OPTR_RDP_Pos);
+	return flash_stm32_option_bytes_write(dev, FLASH_OPTR_RDP_Msk,
+					      (uint32_t)level << FLASH_OPTR_RDP_Pos);
 }
 #endif /* CONFIG_FLASH_STM32_READOUT_PROTECTION */
 

--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -334,10 +334,10 @@ uint8_t flash_stm32_get_rdp_level(const struct device *dev)
 	return (regs->OPTR & FLASH_OPTR_RDP_Msk) >> FLASH_OPTR_RDP_Pos;
 }
 
-void flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
+int flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
 {
-	flash_stm32_option_bytes_write(dev, FLASH_OPTR_RDP_Msk,
-				       (uint32_t)level << FLASH_OPTR_RDP_Pos);
+	return flash_stm32_option_bytes_write(dev, FLASH_OPTR_RDP_Msk,
+					      (uint32_t)level << FLASH_OPTR_RDP_Pos);
 }
 #endif /* CONFIG_FLASH_STM32_READOUT_PROTECTION */
 

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -144,9 +144,9 @@ uint8_t flash_stm32_get_rdp_level(const struct device *dev)
 	return (regs->OPTSR_CUR & FLASH_OPTSR_RDP_Msk) >> FLASH_OPTSR_RDP_Pos;
 }
 
-void flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
+int flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
 {
-	write_optsr(dev, FLASH_OPTSR_RDP_Msk, (uint32_t)level << FLASH_OPTSR_RDP_Pos);
+	return write_optsr(dev, FLASH_OPTSR_RDP_Msk, (uint32_t)level << FLASH_OPTSR_RDP_Pos);
 }
 #endif /* CONFIG_FLASH_STM32_READOUT_PROTECTION */
 

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -313,10 +313,10 @@ uint8_t flash_stm32_get_rdp_level(const struct device *dev)
 	return (regs->OPTR & FLASH_OPTR_RDP_Msk) >> FLASH_OPTR_RDP_Pos;
 }
 
-void flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
+int flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
 {
-	flash_stm32_option_bytes_write(dev, FLASH_OPTR_RDP_Msk,
-				       (uint32_t)level << FLASH_OPTR_RDP_Pos);
+	return flash_stm32_option_bytes_write(dev, FLASH_OPTR_RDP_Msk,
+					      (uint32_t)level << FLASH_OPTR_RDP_Pos);
 }
 #endif /* CONFIG_FLASH_STM32_READOUT_PROTECTION */
 

--- a/drivers/flash/flash_stm32l5x.c
+++ b/drivers/flash/flash_stm32l5x.c
@@ -309,10 +309,10 @@ uint8_t flash_stm32_get_rdp_level(const struct device *dev)
 	return (regs->OPTR & FLASH_OPTR_RDP_Msk) >> FLASH_OPTR_RDP_Pos;
 }
 
-void flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
+int flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
 {
-	flash_stm32_option_bytes_write(dev, FLASH_OPTR_RDP_Msk,
-				       (uint32_t)level << FLASH_OPTR_RDP_Pos);
+	return flash_stm32_option_bytes_write(dev, FLASH_OPTR_RDP_Msk,
+					      (uint32_t)level << FLASH_OPTR_RDP_Pos);
 }
 #endif /* CONFIG_FLASH_STM32_READOUT_PROTECTION */
 


### PR DESCRIPTION
Change flash_stm32_set_rdp_level() to return an error code when failing.

Correct FLASH_STM32_EX_OP_OPTB_WRITE private flash operation for stm32 internal flash drivers when unlocking or locking option bytes fails.    
    