### PR TITLE
drivers: comparator: stm32: Invoke trigger cb only when EXTI is pending

### DIFF
--- a/drivers/comparator/comparator_stm32_comp.c
+++ b/drivers/comparator/comparator_stm32_comp.c
@@ -205,9 +205,11 @@ static void stm32_comp_irq_handler(const struct device *dev)
 	const struct stm32_comp_config *cfg = dev->config;
 	struct stm32_comp_data *data = dev->data;
 
-	if (stm32_exti_is_pending(cfg->exti_line_number)) {
-		stm32_exti_clear_pending(cfg->exti_line_number);
+	if (!stm32_exti_is_pending(cfg->exti_line_number)) {
+		return;
 	}
+
+	stm32_exti_clear_pending(cfg->exti_line_number);
 
 	if (data->callback == NULL) {
 		return;


### PR DESCRIPTION
On some STM32 SoCs, multiple comparators share a common NVIC interrupt line, they can only be enabled at the same time with CONFIG_SHARED_INTERRUPTS set. This means the IRQ handler can be called even though the EXTI flag is not set.

This change makes shure the comparator trigger callback is only executed if the EXTI line is pending.