### PR TITLE
doc: doxygen: exclude arch-specific headers except common

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1038,7 +1038,6 @@ WARN_LOGFILE           =
 INPUT                  = @ZEPHYR_BASE@/doc/_doxygen/mainpage.md \
                          @ZEPHYR_BASE@/doc/_doxygen/groups.dox \
                          @ZEPHYR_BASE@/kernel/include/kernel_arch_interface.h \
-                         @ZEPHYR_BASE@/include/zephyr/arch/cache.h \
                          @ZEPHYR_BASE@/include/zephyr/sys/atomic.h \
                          @ZEPHYR_BASE@/include/ \
                          @ZEPHYR_BASE@/lib/libc/minimal/include/ \
@@ -1107,6 +1106,17 @@ RECURSIVE              = YES
 
 EXCLUDE                = @ZEPHYR_BASE@/include/zephyr/portability/cmsis_os.h \
                          @ZEPHYR_BASE@/include/zephyr/portability/cmsis_os2.h \
+                         @ZEPHYR_BASE@/include/zephyr/arch/arc/ \
+                         @ZEPHYR_BASE@/include/zephyr/arch/arm/ \
+                         @ZEPHYR_BASE@/include/zephyr/arch/arm64/ \
+                         @ZEPHYR_BASE@/include/zephyr/arch/mips/ \
+                         @ZEPHYR_BASE@/include/zephyr/arch/openrisc/ \
+                         @ZEPHYR_BASE@/include/zephyr/arch/posix/ \
+                         @ZEPHYR_BASE@/include/zephyr/arch/riscv/ \
+                         @ZEPHYR_BASE@/include/zephyr/arch/rx/ \
+                         @ZEPHYR_BASE@/include/zephyr/arch/sparc/ \
+                         @ZEPHYR_BASE@/include/zephyr/arch/x86/ \
+                         @ZEPHYR_BASE@/include/zephyr/arch/xtensa/ \
                          @ZEPHYR_BASE@/include/zephyr/toolchain/ \
                          @ZEPHYR_BASE@/include/zephyr/drivers/wifi/nrf_wifi
 

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -96,6 +96,9 @@ static inline uint64_t arch_k_cycle_get_64(void);
  *
  * @see K_THREAD_STACK_RESERVED
  */
+#ifdef __DOXYGEN__
+#define ARCH_THREAD_STACK_RESERVED
+#endif
 
 /**
  * @def ARCH_STACK_PTR_ALIGN
@@ -115,6 +118,9 @@ static inline uint64_t arch_k_cycle_get_64(void);
  *
  * @see Z_THREAD_STACK_OBJ_ALIGN
  */
+#ifdef __DOXYGEN__
+#define ARCH_THREAD_STACK_OBJ_ALIGN(size)
+#endif
 
 /**
  * @def ARCH_THREAD_STACK_SIZE_ADJUST(size)
@@ -136,8 +142,14 @@ static inline uint64_t arch_k_cycle_get_64(void);
  *   with an MPU that requires such alignment
  * - Rounded up to ARCH_STACK_PTR_ALIGN
  *
+ * @param size Requested size of the stack buffer
+ * @return Adjusted size of the stack object
+ *
  * @see Z_THREAD_STACK_SIZE_ADJUST
  */
+#ifdef __DOXYGEN__
+#define ARCH_THREAD_STACK_SIZE_ADJUST(size)
+#endif
 
 /**
  * @def ARCH_KERNEL_STACK_RESERVED
@@ -152,11 +164,20 @@ static inline uint64_t arch_k_cycle_get_64(void);
  *
  * @see K_KERNEL_STACK_RESERVED
  */
+#ifdef __DOXYGEN__
+#define ARCH_KERNEL_STACK_RESERVED
+#endif
 
 /**
  * @def ARCH_KERNEL_STACK_OBJ_ALIGN
  * @brief Required alignment of the lowest address of a kernel-only stack.
+ *
+ * @param size Requested size of the stack buffer
+ * @return Alignment of the kernel-only stack object
  */
+#ifdef __DOXYGEN__
+#define ARCH_KERNEL_STACK_OBJ_ALIGN(size)
+#endif
 
 /** @} */
 
@@ -410,6 +431,9 @@ int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
  *
  * @see IRQ_CONNECT()
  */
+#ifdef __DOXYGEN__
+#define ARCH_IRQ_CONNECT(irq, pri, isr, arg, flags)
+#endif
 
 #ifdef CONFIG_PCIE
 /**
@@ -424,30 +448,45 @@ int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
  *
  * @see IRQ_DIRECT_CONNECT()
  */
+#ifdef __DOXYGEN__
+#define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p)
+#endif
 
 /**
  * @def ARCH_ISR_DIRECT_PM()
  *
  * @see ISR_DIRECT_PM()
  */
+#ifdef __DOXYGEN__
+#define ARCH_ISR_DIRECT_PM()
+#endif
 
 /**
  * @def ARCH_ISR_DIRECT_HEADER()
  *
  * @see ISR_DIRECT_HEADER()
  */
+#ifdef __DOXYGEN__
+#define ARCH_ISR_DIRECT_HEADER()
+#endif
 
 /**
  * @def ARCH_ISR_DIRECT_FOOTER(swap)
  *
  * @see ISR_DIRECT_FOOTER()
  */
+#ifdef __DOXYGEN__
+#define ARCH_ISR_DIRECT_FOOTER(swap)
+#endif
 
 /**
  * @def ARCH_ISR_DIRECT_DECLARE(name)
  *
  * @see ISR_DIRECT_DECLARE()
  */
+#ifdef __DOXYGEN__
+#define ARCH_ISR_DIRECT_DECLARE(name)
+#endif
 
 #ifndef CONFIG_PCIE_CONTROLLER
 /**
@@ -496,6 +535,9 @@ bool arch_irq_is_used(unsigned int irq);
  *
  * @param reason_p K_ERR_ scoped reason code for the fatal error.
  */
+#ifdef __DOXYGEN__
+#define ARCH_EXCEPT(reason_p)
+#endif
 
 #ifdef CONFIG_IRQ_OFFLOAD
 /**

--- a/include/zephyr/arch/common/sys_bitops.h
+++ b/include/zephyr/arch/common/sys_bitops.h
@@ -6,8 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Memory bits manipulation functions in non-arch-specific C code */
-
 #ifndef ZEPHYR_INCLUDE_ARCH_COMMON_SYS_BITOPS_H_
 #define ZEPHYR_INCLUDE_ARCH_COMMON_SYS_BITOPS_H_
 
@@ -20,6 +18,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @cond INTERNAL_HIDDEN
+ * Memory bits manipulation functions in non-arch-specific C code.
+ */
 
 static ALWAYS_INLINE void sys_set_bit(mem_addr_t addr, unsigned int bit)
 {
@@ -120,6 +123,10 @@ static ALWAYS_INLINE
 
 	return ret;
 }
+
+/**
+ * @endcond
+ */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/arch/common/sys_io.h
+++ b/include/zephyr/arch/common/sys_io.h
@@ -20,6 +20,11 @@
 extern "C" {
 #endif
 
+/**
+ * @cond INTERNAL_HIDDEN
+ * Memory mapped registers I/O functions in non-arch-specific C code.
+ */
+
 static ALWAYS_INLINE uint8_t sys_read8(mem_addr_t addr)
 {
 	return *(volatile uint8_t *)addr;
@@ -59,6 +64,10 @@ static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
 {
 	*(volatile uint64_t *)addr = data;
 }
+
+/**
+ * @endcond
+ */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/sys/sys_io.h
+++ b/include/zephyr/sys/sys_io.h
@@ -1,14 +1,19 @@
-/* Port and memory mapped registers I/O operations */
-
 /*
  * Copyright (c) 2015 Intel Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for port, memory-mapped register, and memory bit manipulation APIs.
+ * @ingroup sys_io_apis
+ */
+
 #ifndef ZEPHYR_INCLUDE_SYS_SYS_IO_H_
 #define ZEPHYR_INCLUDE_SYS_SYS_IO_H_
 
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <stddef.h>
 
@@ -16,14 +21,41 @@
 extern "C" {
 #endif
 
+/**
+ * @brief System I/O APIs
+ *
+ * @defgroup sys_io_apis System I/O APIs
+ * @ingroup utilities
+ *
+ * Low-level primitives for port I/O, memory-mapped register I/O, and in-memory bit manipulation.
+ * @{
+ */
+
+/** I/O port address. */
 typedef uint32_t io_port_t;
+
+/** Memory-mapped register address. */
 typedef uintptr_t mm_reg_t;
+
+/** Memory address. */
 typedef uintptr_t mem_addr_t;
 
-/* Port I/O functions */
+#ifdef __DOXYGEN__
 
 /**
- * @fn static inline void sys_out8(uint8_t data, io_port_t port);
+ * @defgroup sys_io_port_apis Port I/O APIs
+ * @ingroup sys_io_apis
+ *
+ * @internal
+ * Port I/O is optional and only implemented by a few architectures (e.g. x86), in their
+ * architecture-specific headers. Those headers are excluded from the Doxygen build, so the
+ * declarations below exist solely to give the documentation a set of symbols to attach to.
+ * @endinternal
+ *
+ * @{
+ */
+
+/**
  * @brief Output a byte to an I/O port
  *
  * This function writes a byte to the given port.
@@ -31,9 +63,9 @@ typedef uintptr_t mem_addr_t;
  * @param data the byte to write
  * @param port the port address where to write the byte
  */
+static inline void sys_out8(uint8_t data, io_port_t port);
 
 /**
- * @fn static inline uint8_t sys_in8(io_port_t port);
  * @brief Input a byte from an I/O port
  *
  * This function reads a byte from the port.
@@ -42,9 +74,9 @@ typedef uintptr_t mem_addr_t;
  *
  * @return the byte read
  */
+static inline uint8_t sys_in8(io_port_t port);
 
 /**
- * @fn static inline void sys_out16(uint16_t data, io_port_t port);
  * @brief Output a 16 bits to an I/O port
  *
  * This function writes a 16 bits to the given port.
@@ -52,9 +84,9 @@ typedef uintptr_t mem_addr_t;
  * @param data the 16 bits to write
  * @param port the port address where to write the 16 bits
  */
+static inline void sys_out16(uint16_t data, io_port_t port);
 
 /**
- * @fn static inline uint16_t sys_in16(io_port_t port);
  * @brief Input 16 bits from an I/O port
  *
  * This function reads 16 bits from the port.
@@ -63,9 +95,9 @@ typedef uintptr_t mem_addr_t;
  *
  * @return the 16 bits read
  */
+static inline uint16_t sys_in16(io_port_t port);
 
 /**
- * @fn static inline void sys_out32(uint32_t data, io_port_t port);
  * @brief Output 32 bits to an I/O port
  *
  * This function writes 32 bits to the given port.
@@ -73,9 +105,9 @@ typedef uintptr_t mem_addr_t;
  * @param data the 32 bits to write
  * @param port the port address where to write the 32 bits
  */
+static inline void sys_out32(uint32_t data, io_port_t port);
 
 /**
- * @fn static inline uint32_t sys_in32(io_port_t port);
  * @brief Input 32 bits from an I/O port
  *
  * This function reads 32 bits from the port.
@@ -84,9 +116,9 @@ typedef uintptr_t mem_addr_t;
  *
  * @return the 32 bits read
  */
+static inline uint32_t sys_in32(io_port_t port);
 
 /**
- * @fn static inline void sys_io_set_bit(io_port_t port, unsigned int bit)
  * @brief Set the designated bit from port to 1
  *
  * This functions takes the designated bit starting from port and sets it to 1.
@@ -94,9 +126,9 @@ typedef uintptr_t mem_addr_t;
  * @param port the port address from where to look for the bit
  * @param bit the designated bit to set (from 0 to n)
  */
+static inline void sys_io_set_bit(io_port_t port, unsigned int bit);
 
 /**
- * @fn static inline void sys_io_clear_bit(io_port_t port, unsigned int bit)
  * @brief Clear the designated bit from port to 0
  *
  * This functions takes the designated bit starting from port and sets it to 0.
@@ -104,9 +136,9 @@ typedef uintptr_t mem_addr_t;
  * @param port the port address from where to look for the bit
  * @param bit the designated bit to clear (from 0 to n)
  */
+static inline void sys_io_clear_bit(io_port_t port, unsigned int bit);
 
 /**
- * @fn static inline int sys_io_test_bit(io_port_t port, unsigned int bit)
  * @brief Test the bit from port if it is set or not
  *
  * This functions takes the designated bit starting from port and tests its
@@ -117,9 +149,9 @@ typedef uintptr_t mem_addr_t;
  *
  * @return 1 if it is set, 0 otherwise
  */
+static inline int sys_io_test_bit(io_port_t port, unsigned int bit);
 
 /**
- * @fn static inline int sys_io_test_and_set_bit(io_port_t port, unsigned int bit)
  * @brief Test the bit from port and set it
  *
  * This functions takes the designated bit starting from port, tests its
@@ -130,9 +162,9 @@ typedef uintptr_t mem_addr_t;
  *
  * @return 1 if it was set, 0 otherwise
  */
+static inline int sys_io_test_and_set_bit(io_port_t port, unsigned int bit);
 
 /**
- * @fn static inline int sys_io_test_and_clear_bit(io_port_t port, unsigned int bit)
  * @brief Test the bit from port and clear it
  *
  * This functions takes the designated bit starting from port, tests its
@@ -143,11 +175,24 @@ typedef uintptr_t mem_addr_t;
  *
  * @return 0 if it was clear, 1 otherwise
  */
+static inline int sys_io_test_and_clear_bit(io_port_t port, unsigned int bit);
 
-/* Memory mapped registers I/O functions */
+/** @} */
 
 /**
- * @fn static inline void sys_write8(uint8_t data, mm_reg_t addr);
+ * @defgroup sys_io_mmio_apis Memory-mapped register I/O APIs
+ * @ingroup sys_io_apis
+ *
+ * @internal
+ * Memory mapped registers I/O is optional and only implemented by a few architectures (e.g. x86),
+ * in their architecture-specific headers. Those headers are excluded from the Doxygen build, so the
+ * declarations below exist solely to give the documentation a set of symbols to attach to.
+ * @endinternal
+ *
+ * @{
+ */
+
+/**
  * @brief Write a byte to a memory mapped register
  *
  * This function writes a byte to the given memory mapped register.
@@ -155,9 +200,9 @@ typedef uintptr_t mem_addr_t;
  * @param data the byte to write
  * @param addr the memory mapped register address where to write the byte
  */
+static inline void sys_write8(uint8_t data, mm_reg_t addr);
 
 /**
- * @fn static inline uint8_t sys_read8(mm_reg_t addr);
  * @brief Read a byte from a memory mapped register
  *
  * This function reads a byte from the given memory mapped register.
@@ -166,9 +211,9 @@ typedef uintptr_t mem_addr_t;
  *
  * @return the byte read
  */
+static inline uint8_t sys_read8(mm_reg_t addr);
 
 /**
- * @fn static inline void sys_write16(uint16_t data, mm_reg_t addr);
  * @brief Write 16 bits to a memory mapped register
  *
  * This function writes 16 bits to the given memory mapped register.
@@ -176,9 +221,9 @@ typedef uintptr_t mem_addr_t;
  * @param data the 16 bits to write
  * @param addr the memory mapped register address where to write the 16 bits
  */
+static inline void sys_write16(uint16_t data, mm_reg_t addr);
 
 /**
- * @fn static inline uint16_t sys_read16(mm_reg_t addr);
  * @brief Read 16 bits from a memory mapped register
  *
  * This function reads 16 bits from the given memory mapped register.
@@ -188,9 +233,9 @@ typedef uintptr_t mem_addr_t;
  *
  * @return the 16 bits read
  */
+static inline uint16_t sys_read16(mm_reg_t addr);
 
 /**
- * @fn static inline void sys_write32(uint32_t data, mm_reg_t addr);
  * @brief Write 32 bits to a memory mapped register
  *
  * This function writes 32 bits to the given memory mapped register.
@@ -198,9 +243,9 @@ typedef uintptr_t mem_addr_t;
  * @param data the 32 bits to write
  * @param addr the memory mapped register address where to write the 32 bits
  */
+static inline void sys_write32(uint32_t data, mm_reg_t addr);
 
 /**
- * @fn static inline uint32_t sys_read32(mm_reg_t addr);
  * @brief Read 32 bits from a memory mapped register
  *
  * This function reads 32 bits from the given memory mapped register.
@@ -210,9 +255,9 @@ typedef uintptr_t mem_addr_t;
  *
  * @return the 32 bits read
  */
+static inline uint32_t sys_read32(mm_reg_t addr);
 
 /**
- * @fn static inline void sys_write64(uint64_t data, mm_reg_t addr);
  * @brief Write 64 bits to a memory mapped register
  *
  * This function writes 64 bits to the given memory mapped register.
@@ -220,9 +265,9 @@ typedef uintptr_t mem_addr_t;
  * @param data the 64 bits to write
  * @param addr the memory mapped register address where to write the 64 bits
  */
+static inline void sys_write64(uint64_t data, mm_reg_t addr);
 
 /**
- * @fn static inline uint64_t sys_read64(mm_reg_t addr);
  * @brief Read 64 bits from a memory mapped register
  *
  * This function reads 64 bits from the given memory mapped register.
@@ -232,11 +277,24 @@ typedef uintptr_t mem_addr_t;
  *
  * @return the 64 bits read
  */
+static inline uint64_t sys_read64(mm_reg_t addr);
 
-/* Memory bits manipulation functions */
+/** @} */
 
 /**
- * @fn static inline void sys_set_bit(mem_addr_t addr, unsigned int bit)
+ * @defgroup sys_io_bits_apis Memory bit manipulation APIs
+ * @ingroup sys_io_apis
+ *
+ * @internal
+ * These functions have a generic implementation in the arch/common/sys_bitops.h file and
+ * architecture-specific implementations may override them. The declarations below exist solely to
+ * give the documentation a set of symbols to attach to.
+ * @endinternal
+ *
+ * @{
+ */
+
+/**
  * @brief Set the designated bit from addr to 1
  *
  * This functions takes the designated bit starting from addr and sets it to 1.
@@ -244,9 +302,9 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to set (from 0 to 31)
  */
+static ALWAYS_INLINE void sys_set_bit(mem_addr_t addr, unsigned int bit);
 
 /**
- * @fn static inline void sys_set_bits(mem_addr_t addr, unsigned int mask)
  * @brief Masking the designated bits from addr to 1
  *
  * This functions masking designated bits from addr to 1.
@@ -254,9 +312,9 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bits
  * @param mask the bit mask of a 32 bits data to set
  */
+static ALWAYS_INLINE void sys_set_bits(mem_addr_t addr, unsigned int mask);
 
 /**
- * @fn static inline void sys_clear_bits(mem_addr_t addr, unsigned int mask)
  * @brief Masking the designated bits from addr to 0
  *
  * This functions masking designated bits from addr to 0.
@@ -264,9 +322,9 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bits
  * @param mask the bit mask of a 32 bits data to set
  */
+static ALWAYS_INLINE void sys_clear_bits(mem_addr_t addr, unsigned int mask);
 
 /**
- * @fn static inline void sys_clear_bit(mem_addr_t addr, unsigned int bit)
  * @brief Clear the designated bit from addr to 0
  *
  * This functions takes the designated bit starting from addr and sets it to 0.
@@ -274,9 +332,9 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to clear (from 0 to 31)
  */
+static ALWAYS_INLINE void sys_clear_bit(mem_addr_t addr, unsigned int bit);
 
 /**
- * @fn static inline int sys_test_bit(mem_addr_t addr, unsigned int bit)
  * @brief Test the bit if it is set or not
  *
  * This functions takes the designated bit starting from addr and tests its
@@ -288,9 +346,9 @@ typedef uintptr_t mem_addr_t;
  * @return the bitwise AND result of @p addr content and (1 << @p bit).
  * Result is 0 only if the bit is cleared otherwise result is a non-0 value.
  */
+static ALWAYS_INLINE int sys_test_bit(mem_addr_t addr, unsigned int bit);
 
 /**
- * @fn static inline int sys_test_and_set_bit(mem_addr_t addr, unsigned int bit)
  * @brief Test the bit and set it
  *
  * This functions takes the designated bit starting from addr, tests its
@@ -302,9 +360,9 @@ typedef uintptr_t mem_addr_t;
  * @return the bitwise AND result of @p addr content and (1 << @p bit) before target bit
  * is set. Result is 0 only if the bit was cleared otherwise result is a non-0 value.
  */
+static ALWAYS_INLINE int sys_test_and_set_bit(mem_addr_t addr, unsigned int bit);
 
 /**
- * @fn static inline int sys_test_and_clear_bit(mem_addr_t addr, unsigned int bit)
  * @brief Test the bit and clear it
  *
  * This functions takes the designated bit starting from addr, test its
@@ -316,9 +374,9 @@ typedef uintptr_t mem_addr_t;
  * @return the bitwise AND result of @p addr content and (1 << @p bit) before target bit
  * is cleared. Result is 0 only if the bit was cleared otherwise result is a non-0 value.
  */
+static ALWAYS_INLINE int sys_test_and_clear_bit(mem_addr_t addr, unsigned int bit);
 
 /**
- * @fn static inline void sys_bitfield_set_bit(mem_addr_t addr, unsigned int bit)
  * @brief Set the designated bit from addr to 1
  *
  * This functions takes the designated bit starting from addr and sets it to 1.
@@ -326,9 +384,9 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to set (arbitrary)
  */
+static ALWAYS_INLINE void sys_bitfield_set_bit(mem_addr_t addr, unsigned int bit);
 
 /**
- * @fn static inline void sys_bitfield_clear_bit(mem_addr_t addr, unsigned int bit)
  * @brief Clear the designated bit from addr to 0
  *
  * This functions takes the designated bit starting from addr and sets it to 0.
@@ -336,23 +394,23 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to clear (arbitrary)
  */
+static ALWAYS_INLINE void sys_bitfield_clear_bit(mem_addr_t addr, unsigned int bit);
 
 /**
- * @fn static inline int sys_bitfield_test_bit(mem_addr_t addr, unsigned int bit)
  * @brief Test the bit if it is set or not
  *
  * This functions takes the designated bit starting from addr and tests its
  * current setting. It will return the current setting.
  *
  * @param addr the memory address from where to look for the bit
- * @param bit the designated bit to test (arbitrary
+ * @param bit the designated bit to test (arbitrary)
  *
  * @return the bitwise AND result of @p addr content and (1 << @p bit). Result is 0
  * only if the bit is cleared otherwise result is a non-0 value.
  */
+static ALWAYS_INLINE int sys_bitfield_test_bit(mem_addr_t addr, unsigned int bit);
 
 /**
- * @fn static inline int sys_bitfield_test_and_set_bit(mem_addr_t addr, unsigned int bit)
  * @brief Test the bit and set it
  *
  * This functions takes the designated bit starting from addr, tests its
@@ -364,9 +422,9 @@ typedef uintptr_t mem_addr_t;
  * @return the bitwise AND result of @p addr content and (1 << @p bit) before target bit
  * is set. Result is 0 only if the bit was cleared otherwise result is a non-0 value.
  */
+static ALWAYS_INLINE int sys_bitfield_test_and_set_bit(mem_addr_t addr, unsigned int bit);
 
 /**
- * @fn static inline int sys_bitfield_test_and_clear_bit(mem_addr_t addr, unsigned int bit)
  * @brief Test the bit and clear it
  *
  * This functions takes the designated bit starting from addr, test its
@@ -378,7 +436,13 @@ typedef uintptr_t mem_addr_t;
  * @return the bitwise AND result of @p addr content and (1 << @p bit) before target bit
  * is cleared. Result is 0 only if the bit was cleared otherwise result is a non-0 value.
  */
+static ALWAYS_INLINE int sys_bitfield_test_and_clear_bit(mem_addr_t addr, unsigned int bit);
 
+/** @} */ /* sys_io_bits_apis */
+
+/** @} */ /* sys_io_apis */
+
+#endif /* __DOXYGEN__ */
 
 #ifdef __cplusplus
 }

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -503,6 +503,9 @@ enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location);
  *
  * This bit is undefined if ARCH_DATA_PAGE_LOADED is not set.
  */
+#ifdef __DOXYGEN__
+#define ARCH_DATA_PAGE_ACCESSED
+#endif
 
  /**
   * @def ARCH_DATA_PAGE_DIRTY
@@ -514,6 +517,9 @@ enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location);
   *
   * This bit is undefined if ARCH_DATA_PAGE_LOADED is not set.
   */
+#ifdef __DOXYGEN__
+#define ARCH_DATA_PAGE_DIRTY
+#endif
 
  /**
   * @def ARCH_DATA_PAGE_LOADED
@@ -522,6 +528,9 @@ enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location);
   *
   * If un-set, the data page is paged out or not mapped.
   */
+#ifdef __DOXYGEN__
+#define ARCH_DATA_PAGE_LOADED
+#endif
 
 /**
  * @def ARCH_DATA_PAGE_NOT_MAPPED
@@ -529,6 +538,9 @@ enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location);
  * If ARCH_DATA_PAGE_LOADED is un-set, this will indicate that the page
  * is not mapped at all. This bit is undefined if ARCH_DATA_PAGE_LOADED is set.
  */
+#ifdef __DOXYGEN__
+#define ARCH_DATA_PAGE_NOT_MAPPED
+#endif
 
 /**
  * Retrieve page characteristics from the page table(s)


### PR DESCRIPTION
Architecture-specific headers are not really public API so exclude them from the Doxygen documentation. 
Also a bunch of related changes to keep Doxygen API due to some symbols now not really being defined anymore (Doxygen doesn't _see_ any architecture-specific headers anymore).

As a result there is also now a proper documentation section for System I/O APIs https://builds.zephyrproject.io/zephyr/pr/110086/docs/doxygen/html/group__sys__io__apis.html

https://builds.zephyrproject.io/zephyr/pr/110086/api-coverage/