### PR TITLE
drivers: gpio: max149x6: add missing common config member

### DIFF
--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -575,6 +575,7 @@ static DEVICE_API(gpio, gpio_max14906_api) = {
 
 #define GPIO_MAX14906_DEVICE(id)                                                                   \
 	static const struct max14906_config max14906_##id##_cfg = {                                \
+		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(id),                                     \
 		.spi = SPI_DT_SPEC_INST_GET(id, SPI_OP_MODE_MASTER | SPI_WORD_SET(8U)),            \
 		.ready_gpio = GPIO_DT_SPEC_INST_GET_OR(id, drdy_gpios, {0}),                       \
 		.fault_gpio = GPIO_DT_SPEC_INST_GET_OR(id, fault_gpios, {0}),                      \

--- a/drivers/gpio/gpio_max14906.h
+++ b/drivers/gpio/gpio_max14906.h
@@ -282,6 +282,7 @@ union max14906_config2 {
 #define MAX149x6_DISABLE 0
 
 struct max149x6_config {
+	struct gpio_driver_config common;
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec fault_gpio;
 	struct gpio_dt_spec ready_gpio;

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -479,6 +479,7 @@ static DEVICE_API(gpio, gpio_max14916_api) = {
 
 #define GPIO_MAX14906_DEVICE(id, model)                                                            \
 	static const struct max14916_config max##model##_##id##_cfg = {                            \
+		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(id),                                     \
 		.spi = SPI_DT_SPEC_INST_GET(id, SPI_OP_MODE_MASTER | SPI_WORD_SET(8U)),            \
 		.ready_gpio = GPIO_DT_SPEC_INST_GET(id, drdy_gpios),                               \
 		.fault_gpio = GPIO_DT_SPEC_INST_GET(id, fault_gpios),                              \

--- a/drivers/gpio/gpio_max14916.h
+++ b/drivers/gpio/gpio_max14916.h
@@ -204,6 +204,7 @@ union max14916_sht_vdd_en {
 };
 
 struct max149x6_config {
+	struct gpio_driver_config common;
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec fault_gpio;
 	struct gpio_dt_spec ready_gpio;


### PR DESCRIPTION
Adds the missing config member that is common to all GPIO drivers and that is expected to be the first element in the object pointed to by the config field in the device structure.

Without these additions, pin configuration would assert:
ASSERTION FAIL [(cfg->port_pin_mask & (gpio_port_pins_t)(1UL << (pin))) != 0U] @ WEST_TOPDIR/zephyr/include/zephyr/drivers/gpio.h:1041
        Unsupported pin

PR was tested by building and confirming that this assert no longer triggers.