### PR TITLE
bluetooth: mesh: extend statistic module with lpn friendship measurements

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -131,6 +131,12 @@ New APIs and options
     * :c:func:`bt_ascs_register`
     * :c:func:`bt_ascs_unregister`
 
+  * Mesh
+
+    * :c:struct:`bt_mesh_lpn_timing`
+    * :c:func:`bt_mesh_stat_lpn_timing_get`
+    * :c:func:`bt_mesh_stat_lpn_timing_reset`
+
 * Devicetree
 
   * :c:macro:`DT_IRQN_BY_NAME`

--- a/doc/services/connectivity/bluetooth/api/mesh/shell.rst
+++ b/doc/services/connectivity/bluetooth/api/mesh/shell.rst
@@ -2009,17 +2009,33 @@ The Solicitation PDU RPL Client model is an optional mesh subsystem that can be 
 	* ``RngLen``: Range length for the SSRC addresses to be cleared from the solicitiation RPL list. This parameter is optional; if absent, only a single SSRC address will be cleared.
 
 
-Frame statistic
-===============
+Statistic
+=========
 
-``mesh stat get``
------------------
+The statistic is an optional mesh module that can be enabled through the :kconfig:option:`CONFIG_BT_MESH_STATISTIC` configuration option.
+
+``mesh stat adv_get``
+---------------------
 
 	Get the frame statistic. The command prints numbers of received frames, as well as numbers
 	of planned and succeeded transmission attempts.
 
 
-``mesh stat clear``
--------------------
+``mesh stat adv_clear``
+-----------------------
 
-	Clear all statistics collected before.
+	Clear frame statistics collected before.
+
+
+``mesh stat lpn_get``
+---------------------
+
+	Get the measured LPN friendship timing parameters.
+	The command prints ReceiveDelay and ReceiveWindow values derived from timestamps taken during poll cycles.
+	Requires :kconfig:option:`CONFIG_BT_MESH_LOW_POWER`.
+
+
+``mesh stat lpn_clear``
+-----------------------
+
+	Clear LPN timing statistics collected before. Requires :kconfig:option:`CONFIG_BT_MESH_LOW_POWER`.

--- a/doc/services/connectivity/bluetooth/api/mesh/statistic.rst
+++ b/doc/services/connectivity/bluetooth/api/mesh/statistic.rst
@@ -1,7 +1,12 @@
 .. _bluetooth_mesh_stat:
 
+Mesh Statistic
+##############
+
+The statistic API provides runtime monitoring of Bluetooth Mesh communication.
+
 Frame statistic
-###############
+***************
 
 The frame statistic API allows monitoring the number of received frames over
 different interfaces, and the number of planned and succeeded transmission and
@@ -11,7 +16,22 @@ The API helps the user to estimate the efficiency of the advertiser configuratio
 parameters and the scanning ability of the device. The number of the monitored
 parameters can be easily extended by customer values.
 
-An application can read out and clean up statistics at any time.
+LPN timing measurement
+**********************
+
+When :kconfig:option:`CONFIG_BT_MESH_LOW_POWER` is enabled, the statistic module
+measures LPN friendship timing parameters by timestamping protocol events:
+
+* T1: Poll TX complete
+* T2: Scanner enabled (ReceiveDelay elapsed)
+* T3: Friend response received or ReceiveWindow expired
+
+From these timestamps the module computes the measured ReceiveDelay (T2 - T1)
+and ReceiveWindow (T3 - T2) in microseconds. The application can use these
+values to evaluate the actual on-air timing against configured friendship
+parameters.
+
+An application can read out and reset statistics at any time.
 
 API reference
 *************

--- a/include/zephyr/bluetooth/mesh/statistic.h
+++ b/include/zephyr/bluetooth/mesh/statistic.h
@@ -59,6 +59,63 @@ void bt_mesh_stat_get(struct bt_mesh_statistic *st);
  */
 void bt_mesh_stat_reset(void);
 
+/** Measured LPN friendship timing derived from timestamps.
+ *
+ *  Values are computed by timestamping protocol events on the LPN side:
+ *  - T1: Poll TX complete
+ *  - T2: Scanner enabled (ReceiveDelay elapsed)
+ *  - T3: Friend response received
+ *
+ *  Measured ReceiveDelay = T2 - T1 (actual time before LPN starts listening).
+ *  Measured ReceiveWindow = T3 - T2 (actual listening time until response).
+ */
+struct bt_mesh_lpn_timing {
+	/** Measured ReceiveDelay for the last poll cycle in microseconds.
+	 *  Time from poll TX end to scanner enable.
+	 */
+	uint32_t recv_delay_us;
+	/** Minimum measured ReceiveDelay in microseconds. */
+	uint32_t recv_delay_min_us;
+	/** Maximum measured ReceiveDelay in microseconds. */
+	uint32_t recv_delay_max_us;
+	/** Measured ReceiveWindow for the last poll cycle in microseconds.
+	 *  Time from scanner enable to scanner disable after Friend response RX.
+	 *  Retains the last successful measurement; not updated on timeout.
+	 */
+	uint32_t recv_win_us;
+	/** Minimum measured ReceiveWindow in microseconds. */
+	uint32_t recv_win_min_us;
+	/** Maximum measured ReceiveWindow in microseconds. */
+	uint32_t recv_win_max_us;
+	/** Expected ReceiveWindow in microseconds. Time from scanner enable
+	 *  to scanner disable when no Friend response arrived (full window).
+	 *  Zero if no timeout has occurred yet.
+	 */
+	uint32_t recv_win_expected_us;
+	/** Total number of completed poll-response cycles. */
+	uint32_t cnt;
+	/** Total number of failed poll-response cycles (no response within window). */
+	uint32_t cnt_failed;
+};
+
+/** @brief Get measured LPN friendship poll timing.
+ *
+ *  Returns timestamp-derived measurements of actual ReceiveDelay and
+ *  ReceiveWindow observed on-air. Timestamps are captured using
+ *  k_uptime_get() at poll TX completion, scanner enable, and response RX.
+ *
+ *  @param timing  Pointer to structure to populate.
+ *
+ *  @retval 0        Success.
+ *  @retval -ENOTSUP LPN or statistic feature not enabled.
+ *  @retval -EINVAL  NULL pointer.
+ */
+int bt_mesh_stat_lpn_timing_get(struct bt_mesh_lpn_timing *timing);
+
+/** @brief Reset measured LPN friendship poll timing statistics.
+ */
+void bt_mesh_stat_lpn_timing_reset(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1948,11 +1948,15 @@ config BT_MESH_SELF_TEST
 	  mesh networking is initialized.
 
 config BT_MESH_STATISTIC
-	bool "The frame handling statistics [EXPERIMENTAL]"
+	bool "Mesh communication statistics [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  The module gathers statistics of received, relayed, and transmitted
 	  frames. This helps to estimate the quality of the communication and
 	  the sufficiency of configured advertiser instances.
+
+	  When LPN functionality is enabled, the module also measures
+	  LPN friendship timing parameters (ReceiveDelay, ReceiveWindow) by
+	  timestamping protocol events during each poll cycle.
 
 endif # BT_MESH

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -20,6 +20,7 @@
 #include "beacon.h"
 #include "foundation.h"
 #include "lpn.h"
+#include "statistic.h"
 
 #define LOG_LEVEL CONFIG_BT_MESH_LOW_POWER_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -419,6 +420,10 @@ static void req_send_end(int err, void *user_data)
 
 	lpn->req_attempts++;
 
+	if (IS_ENABLED(CONFIG_BT_MESH_STATISTIC)) {
+		bt_mesh_stat_lpn_timing_update_poll_tx();
+	}
+
 	if (lpn->established || IS_ENABLED(CONFIG_BT_MESH_LPN_ESTABLISHMENT)) {
 		lpn_set_state(BT_MESH_LPN_RECV_DELAY);
 		/* We start scanning a bit early to eliminate risk of missing
@@ -580,6 +585,9 @@ static void friend_response_received(struct bt_mesh_lpn *lpn)
 
 	k_work_reschedule(&lpn->timer, K_MSEC(timeout));
 	bt_mesh_scan_disable();
+	if (IS_ENABLED(CONFIG_BT_MESH_STATISTIC)) {
+		bt_mesh_stat_lpn_timing_update_response_rx();
+	}
 }
 
 void bt_mesh_lpn_msg_received(struct bt_mesh_net_rx *rx)
@@ -859,6 +867,9 @@ static void update_timeout(struct bt_mesh_lpn *lpn)
 		lpn_set_state(BT_MESH_LPN_ESTABLISHED);
 		k_work_reschedule(&lpn->timer, K_MSEC(POLL_RETRY_TIMEOUT));
 		bt_mesh_scan_disable();
+		if (IS_ENABLED(CONFIG_BT_MESH_STATISTIC)) {
+			bt_mesh_stat_lpn_timing_update_win_expired();
+		}
 	} else {
 		if (IS_ENABLED(CONFIG_BT_MESH_LPN_ESTABLISHMENT)) {
 			bt_mesh_scan_disable();
@@ -940,6 +951,9 @@ static void lpn_timeout(struct k_work *work)
 				  K_MSEC(SCAN_LATENCY + lpn->recv_win + RX_DELAY_CORRECTION(lpn)));
 		lpn_set_state(BT_MESH_LPN_WAIT_UPDATE);
 		bt_mesh_scan_enable();
+		if (IS_ENABLED(CONFIG_BT_MESH_STATISTIC)) {
+			bt_mesh_stat_lpn_timing_update_scan_start();
+		}
 		break;
 	case BT_MESH_LPN_WAIT_UPDATE:
 		update_timeout(lpn);

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -1680,7 +1680,7 @@ static int cmd_appidx(const struct shell *sh, size_t argc, char *argv[])
 }
 
 #if defined(CONFIG_BT_MESH_STATISTIC)
-static int cmd_stat_get(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_adv_stat_get(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_mesh_statistic st;
 
@@ -1700,12 +1700,42 @@ static int cmd_stat_get(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
-static int cmd_stat_clear(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_adv_stat_clear(const struct shell *sh, size_t argc, char *argv[])
 {
 	bt_mesh_stat_reset();
 
 	return 0;
 }
+
+#if defined(CONFIG_BT_MESH_LOW_POWER)
+static int cmd_lpn_stat_get(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct bt_mesh_lpn_timing timing;
+
+	bt_mesh_stat_lpn_timing_get(&timing);
+
+	shell_print(sh, "LPN timing parameters:");
+	shell_print(sh, "ReceiveDelay:  %d us", timing.recv_delay_us);
+	shell_print(sh, "ReceiveDelay (min): %d us", timing.recv_delay_min_us);
+	shell_print(sh, "ReceiveDelay (max): %d us", timing.recv_delay_max_us);
+	shell_print(sh, "ReceiveWindow: %d us", timing.recv_win_us);
+	shell_print(sh, "ReceiveWindow (min): %d us", timing.recv_win_min_us);
+	shell_print(sh, "ReceiveWindow (max): %d us", timing.recv_win_max_us);
+	shell_print(sh, "ReceiveWindow (expected): %d us", timing.recv_win_expected_us);
+	shell_print(sh, "Poll-response cycles: %d", timing.cnt);
+	shell_print(sh, "Failed poll-response cycles: %d", timing.cnt_failed);
+
+	return 0;
+}
+
+static int cmd_lpn_stat_clear(const struct shell *sh, size_t argc, char *argv[])
+{
+	bt_mesh_stat_lpn_timing_reset();
+
+	return 0;
+}
+#endif /* CONFIG_BT_MESH_LOW_POWER */
+
 #endif
 
 #if defined(CONFIG_BT_MESH_SHELL_CDB)
@@ -1838,8 +1868,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(target_cmds,
 
 #if defined(CONFIG_BT_MESH_STATISTIC)
 SHELL_STATIC_SUBCMD_SET_CREATE(stat_cmds,
-	SHELL_CMD_ARG(get, NULL, NULL, cmd_stat_get, 1, 0),
-	SHELL_CMD_ARG(clear, NULL, NULL, cmd_stat_clear, 1, 0),
+	SHELL_CMD_ARG(adv_get, NULL, NULL, cmd_adv_stat_get, 1, 0),
+	SHELL_CMD_ARG(adv_clear, NULL, NULL, cmd_adv_stat_clear, 1, 0),
+#if defined(CONFIG_BT_MESH_LOW_POWER)
+	SHELL_CMD_ARG(lpn_get, NULL, NULL, cmd_lpn_stat_get, 1, 0),
+	SHELL_CMD_ARG(lpn_clear, NULL, NULL, cmd_lpn_stat_clear, 1, 0),
+#endif
 	SHELL_SUBCMD_SET_END);
 #endif
 

--- a/subsys/bluetooth/mesh/statistic.c
+++ b/subsys/bluetooth/mesh/statistic.c
@@ -61,3 +61,112 @@ void bt_mesh_stat_rx(enum bt_mesh_net_if net_if)
 		break;
 	}
 }
+
+#if defined(CONFIG_BT_MESH_LOW_POWER)
+
+static struct bt_mesh_lpn_timing lpn_timing;
+
+static int64_t poll_tx_end_ts;
+static int64_t scan_start_ts;
+
+void bt_mesh_stat_lpn_timing_update_poll_tx(void)
+{
+	poll_tx_end_ts = k_uptime_ticks();
+}
+
+void bt_mesh_stat_lpn_timing_update_scan_start(void)
+{
+	int64_t now = k_uptime_ticks();
+	uint32_t delay;
+
+	scan_start_ts = now;
+
+	if (poll_tx_end_ts == 0) {
+		return;
+	}
+
+	delay = k_ticks_to_us_floor32(now - poll_tx_end_ts);
+	lpn_timing.recv_delay_us = delay;
+
+	if (lpn_timing.cnt == 0 && lpn_timing.recv_delay_min_us == 0) {
+		lpn_timing.recv_delay_min_us = delay;
+		lpn_timing.recv_delay_max_us = delay;
+	} else {
+		if (delay < lpn_timing.recv_delay_min_us) {
+			lpn_timing.recv_delay_min_us = delay;
+		}
+		if (delay > lpn_timing.recv_delay_max_us) {
+			lpn_timing.recv_delay_max_us = delay;
+		}
+	}
+}
+
+void bt_mesh_stat_lpn_timing_update_response_rx(void)
+{
+	int64_t now = k_uptime_ticks();
+	uint32_t win;
+
+	if (scan_start_ts == 0) {
+		return;
+	}
+
+	win = k_ticks_to_us_floor32(now - scan_start_ts);
+	lpn_timing.recv_win_us = win;
+
+	if (lpn_timing.cnt == 0) {
+		lpn_timing.recv_win_min_us = win;
+		lpn_timing.recv_win_max_us = win;
+	} else {
+		if (win < lpn_timing.recv_win_min_us) {
+			lpn_timing.recv_win_min_us = win;
+		}
+		if (win > lpn_timing.recv_win_max_us) {
+			lpn_timing.recv_win_max_us = win;
+		}
+	}
+
+	lpn_timing.cnt++;
+}
+
+void bt_mesh_stat_lpn_timing_update_win_expired(void)
+{
+	int64_t now = k_uptime_ticks();
+
+	if (scan_start_ts == 0) {
+		return;
+	}
+
+	lpn_timing.recv_win_expected_us = k_ticks_to_us_floor32(now - scan_start_ts);
+	lpn_timing.cnt_failed++;
+}
+
+int bt_mesh_stat_lpn_timing_get(struct bt_mesh_lpn_timing *timing)
+{
+	if (timing == NULL) {
+		return -EINVAL;
+	}
+
+	memcpy(timing, &lpn_timing, sizeof(*timing));
+	return 0;
+}
+
+void bt_mesh_stat_lpn_timing_reset(void)
+{
+	memset(&lpn_timing, 0, sizeof(lpn_timing));
+	poll_tx_end_ts = 0;
+	scan_start_ts = 0;
+}
+
+#else /* !CONFIG_BT_MESH_LOW_POWER */
+
+int bt_mesh_stat_lpn_timing_get(struct bt_mesh_lpn_timing *timing)
+{
+	ARG_UNUSED(timing);
+	return -ENOTSUP;
+}
+
+void bt_mesh_stat_lpn_timing_reset(void)
+{
+}
+
+#endif /* CONFIG_BT_MESH_LOW_POWER */

--- a/subsys/bluetooth/mesh/statistic.h
+++ b/subsys/bluetooth/mesh/statistic.h
@@ -11,4 +11,11 @@ void bt_mesh_stat_planned_count(struct bt_mesh_adv_ctx *ctx);
 void bt_mesh_stat_succeeded_count(struct bt_mesh_adv_ctx *ctx);
 void bt_mesh_stat_rx(enum bt_mesh_net_if net_if);
 
+#if defined(CONFIG_BT_MESH_LOW_POWER)
+void bt_mesh_stat_lpn_timing_update_poll_tx(void);
+void bt_mesh_stat_lpn_timing_update_scan_start(void);
+void bt_mesh_stat_lpn_timing_update_response_rx(void);
+void bt_mesh_stat_lpn_timing_update_win_expired(void);
+#endif
+
 #endif /* ZEPHYR_SUBSYS_BLUETOOTH_MESH_STATISTIC_H_ */


### PR DESCRIPTION
This PR extends the mesh statistic module with timestamp-based measurement of LPN friendship timing parameters (ReceiveDelay and ReceiveWindow).

Timestamps are captured at protocol events during each poll cycle:

T1: Poll TX complete
T2: Scanner enabled (ReceiveDelay elapsed)
T3: Friend response received / ReceiveWindow expired
From these, the module computes actual on-air ReceiveDelay (T2 - T1) and ReceiveWindow (T3 - T2) in microseconds, along with min/max tracking and cycle counters.

Shell commands mesh stat lpn_get / mesh stat lpn_clear are added for runtime access. Existing frame statistic commands are renamed to mesh stat adv_get / mesh stat adv_clear.

Documentation is updated accordingly.