### PR TITLE
doc: kernel: interrupts: correct documentation around IRQ lock

### DIFF
--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -133,26 +133,8 @@ before interrupts can be once again processed by the kernel while the thread
 is running.
 
 .. important::
-    The IRQ lock is thread-specific. If thread A locks out interrupts
-    then performs an operation that puts itself to sleep (e.g. sleeping
-    for N milliseconds), the thread's IRQ lock no longer applies once
-    thread A is swapped out and the next ready thread B starts to
-    run.
-
-    This means that interrupts can be processed while thread B is
-    running unless thread B has also locked out interrupts using its own
-    IRQ lock.  (Whether interrupts can be processed while the kernel is
-    switching between two threads that are using the IRQ lock is
-    architecture-specific.)
-
-    When thread A eventually becomes the current thread once again, the kernel
-    re-establishes thread A's IRQ lock. This ensures thread A won't be
-    interrupted until it has explicitly unlocked its IRQ lock.
-
-    If thread A does not sleep but does make a higher-priority thread B
-    ready, the IRQ lock will inhibit any preemption that would otherwise
-    occur.  Thread B will not run until the next :ref:`reschedule point
-    <scheduling_v2>` reached after releasing the IRQ lock.
+    A thread is not allowed to :ref:`sleep <thread_sleeping>` while holding
+    an IRQ lock; only :ref:`isr-ok <api_term_isr-ok>` functions may be called.
 
 Alternatively, a thread may temporarily **disable** a specified IRQ
 so its associated ISR does not execute when the IRQ is signaled.


### PR DESCRIPTION
Context switching while holding the IRQ lock is illegal and will in fact trigger a kernel panic most of the time (there are some configurations under which this error will be silently ignored because the kernel is not able to reliably detect it).

Update the relevant documentation page which presented the IRQ lock in a completely different (and misleading) manner to reflect the actual behavior: you can't hold it upon context switch, so you must not call any `sleep` function while it is held.

---

This basically updates the documentation page to match the changes in #93440.