### PR TITLE
drivers: sensor: ina237: fix sample_fetch in triggered mode

### DIFF
--- a/drivers/sensor/ti/ina2xx/ina237.c
+++ b/drivers/sensor/ti/ina2xx/ina237.c
@@ -17,6 +17,9 @@ LOG_MODULE_DECLARE(INA2XX, CONFIG_SENSOR_LOG_LEVEL);
 /** @brief INA237 calibration scaling value (scaled by 10^-5) */
 #define INA237_CAL_SCALING 8192ULL
 
+/** @brief Timeout (ms) waiting for CNVRF (conversion ready) in triggered mode */
+#define INA237_CNVRF_TIMEOUT_MS 5000
+
 /** @brief INA228 calibration scaling value (scaled by 10^-5) */
 #define INA228_CAL_SCALING (INA237_CAL_SCALING << 4)
 
@@ -236,15 +239,24 @@ static int ina237_sample_fetch(const struct device *dev, enum sensor_channel cha
 			return ret;
 		}
 
-		/* Poll DIAG_ALRT register until CNVRF (conversion ready) is set */
+		/* Poll DIAG_ALRT until CNVRF (conversion ready) is set or 5 s timeout */
 		uint16_t reg_alert;
+		int64_t deadline = k_uptime_get() + INA237_CNVRF_TIMEOUT_MS;
 
 		do {
 			ret = ina2xx_reg_read_16(&common->bus, INA237_REG_ALERT, &reg_alert);
 			if (ret < 0) {
 				return ret;
 			}
-		} while (!(reg_alert & INA237_ALERT_CNVRF));
+			if (reg_alert & INA237_ALERT_CNVRF) {
+				break;
+			}
+			if (k_uptime_get() >= deadline) {
+				LOG_ERR("INA237: conversion ready timeout");
+				return -ETIMEDOUT;
+			}
+			k_msleep(1);
+		} while (true);
 
 		ret = ina2xx_sample_fetch(dev, chan);
 	} else {

--- a/drivers/sensor/ti/ina2xx/ina237.c
+++ b/drivers/sensor/ti/ina2xx/ina237.c
@@ -226,10 +226,27 @@ static int ina237_trigg_one_shot_request(const struct device *dev, enum sensor_c
  */
 static int ina237_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
+	const struct ina237_config *config = dev->config;
+	const struct ina2xx_config *common = &config->common;
 	int ret;
 
 	if (ina237_is_triggered_mode_set(dev)) {
 		ret = ina237_trigg_one_shot_request(dev, chan);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* Poll DIAG_ALRT register until CNVRF (conversion ready) is set */
+		uint16_t reg_alert;
+
+		do {
+			ret = ina2xx_reg_read_16(&common->bus, INA237_REG_ALERT, &reg_alert);
+			if (ret < 0) {
+				return ret;
+			}
+		} while (!(reg_alert & INA237_ALERT_CNVRF));
+
+		ret = ina2xx_sample_fetch(dev, chan);
 	} else {
 		ret = ina2xx_sample_fetch(dev, chan);
 	}

--- a/drivers/sensor/ti/ina2xx/ina237.h
+++ b/drivers/sensor/ti/ina2xx/ina237.h
@@ -28,6 +28,7 @@
 #define INA237_REG_CURRENT    0x07
 #define INA237_REG_POWER      0x08
 #define INA237_REG_ALERT      0x0B
+#define INA237_ALERT_CNVRF    BIT(1) /* Conversion Ready Flag */
 #define INA237_REG_SOVL       0x0C
 #define INA237_REG_SUVL       0x0D
 #define INA237_REG_BOVL       0x0E


### PR DESCRIPTION
## Summary

In triggered mode, `ina237_sample_fetch()` called
`ina237_trigg_one_shot_request()` which only writes to the `ADC_CONFIG`
register to start a one-shot conversion and returns immediately, without
waiting for the conversion to complete.

This violates the sensor API contract documented in
`include/zephyr/drivers/sensor.h`: after `sensor_sample_fetch()` returns,
data must be ready to read via `sensor_channel_get()`.

## Fix

Poll the `DIAG_ALRT` register (`0x0B`) until `CNVRF` (Conversion Ready
Flag, bit 1) is set before calling `ina2xx_sample_fetch()` to read the
converted measurement data.

The same pattern is already used in `ina237_trigger_work_handler()` for
the interrupt-driven path — this fix brings the polling path into
compliance with the sensor API.

## Changes

- `ina237.h`: add `INA237_ALERT_CNVRF` define (bit 1 of `DIAG_ALRT`)
- `ina237.c`: poll `CNVRF` after triggering conversion before reading data

Fixes #98547