### PR TITLE
drivers: counter: mcux qtmr: clear compare flag before setting alarm

### DIFF
--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -177,6 +177,9 @@ static int mcux_qtmr_set_alarm(const struct device *dev, uint8_t chan_id,
 	/* this timer always counts up. */
 	config->base->CHANNEL[config->channel].COMP1 = ticks;
 
+	/* Clear any stale compare flag to prevent alarm firing immediately */
+	QTMR_ClearStatusFlags(config->base, config->channel, kQTMR_Compare1Flag);
+
 	data->interrupt_mask |= kQTMR_Compare1InterruptEnable;
 	QTMR_EnableInterrupts(config->base, config->channel, data->interrupt_mask);
 


### PR DESCRIPTION
If the kQTMR_Compare1Flag is set when setting the alarm, the callback would fire immediately causing unwanted behaviour in the applcation. This PR clears this flag before setting an alarm to prevent this premature firing.

I encounter this issue on the mimxrt1064_evk board, where I start the counter at boot (`counter_start()`), and after a couple of seconds I schedule an alarm for 5 ms. Because `kQTMR_Compare1Flag` was set by the time I called `mcux_qtmr_set_alarm()`, the alarm fired immediately.