### PR TITLE
drivers: dma: stm32u5: fix dma_suspend() not being isr-ok

### DIFF
--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -726,21 +726,41 @@ static int dma_stm32_suspend(const struct device *dev, uint32_t id)
 {
 	const struct dma_stm32_config *config = dev->config;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
-	const struct dma_stm32_stream *stream = &config->streams[id];
 
 	if (id >= config->max_streams) {
 		return -EINVAL;
 	}
 
-	/* Suspend the channel and wait for suspend Flag set */
+	/* Request channel suspension */
 	LL_DMA_SuspendChannel(STM32_DMA_GET_CHANNEL(dma, id));
-	/* It's not enough to wait for the SUSPF bit with LL_DMA_IsActiveFlag_SUSP */
-	do {
-		k_busy_wait(800); /* A delay is needed (800us is valid) */
-	} while (LL_DMA_IsActiveFlag_SUSP(STM32_DMA_GET_CHANNEL(dma, id)) != 1 &&
-			stream->busy == true);
 
-	/* Do not Reset the channel to allow resuming later */
+	/*
+	 * Wait until the channel becomes effectively suspended (SUSPF).
+	 * Also handle the case where the channel was/has become idle:
+	 * the suspension request has no effect on idle channels and
+	 * SUSPF will never be set in such cases.
+	 *
+	 * Note that this function is isr-ok so we MUST NOT rely on
+	 * metadata updated by the ISR (such as stream->busy); only
+	 * the hardware status flags are trustworthy here.
+	 */
+	do {
+		/*
+		 * It's not enough to wait for the SUSPF bit with
+		 * LL_DMA_IsActiveFlag_SUSP - a delay is needed.
+		 */
+		k_busy_wait(800);
+	} while (!LL_DMA_IsActiveFlag_SUSP(STM32_DMA_GET_CHANNEL(dma, id))
+		 && !LL_DMA_IsActiveFlag_IDLE(STM32_DMA_GET_CHANNEL(dma, id)));
+
+	/*
+	 * Don't bother clearing the suspension request if the channel was idle
+	 * (and has thus NOT been suspended) as only dma_resume() and dma_stop()
+	 * are allowed to be called by the DMA API on "suspended" channels, and
+	 * both of these functions will clear the suspension request.
+	 *
+	 * Obviously, also don't reset the channel to allow resuming it later.
+	 */
 	return 0;
 }
 


### PR DESCRIPTION
The `dma_suspend()` implementation detected end-of-transfer based on a software flag (`stream->busy`) rather than hardware status flags. This is an issue because `dma_suspend()` is `isr-ok` and may thus be called while IRQs are suspended; this prevents the DMA ISR from running and updating software flags to reflect the actual hardware state.

This causes a deadlock if, while IRQs are suspended, a transfer on a channel N completes then `dma_suspend()` is called to suspend channel N while IRQs are still suspended. In this situation, the channel is idle but `stream->busy` is still `true` because the DMA ISR could not execute. Since suspending an idle channel has no effect, the SUSPF flag will never become set and a deadlock occurs because both of the conditions for exiting the loop in `dma_suspend()` will never be met.

Modify the function to rely exclusively on hardware flags to detect the channel's current state, such that the loop will not deadlock even if the DMA ISR cannot run because IRQs are suspended.