### PR TITLE
boards: nxp: mimxrt700_evk: enable MCUboot support

### DIFF
--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -30,8 +30,9 @@
 	};
 
 	chosen {
-		zephyr,flash-controller = &flash_controller0;
-		zephyr,flash = &ext_flash;
+		zephyr,flash-controller = &ext_flash_ctrl;
+		zephyr,flash = &mx25um51345g;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &sram0;
 		zephyr,console = &flexcomm0_lpuart0;
 		zephyr,shell-uart = &flexcomm0_lpuart0;
@@ -372,11 +373,11 @@ nxp_8080_touch_panel_i2c: &flexcomm8_lpi2c8 {};
 	ahb-buffer-write-flush;
 	ahb-prefetch;
 
-	flash_controller0: flash-controller@0 {
+	ext_flash_ctrl: flash-controller@0 {
 		status = "okay";
 		compatible = "nxp,xspi-nor";
 		device-name = "mx25um51345g";
-		/* MX25UM51245G is 64MB, 512Mbit flash part. */
+		/* MX25UM51345G is 64MB, 512Mbit flash part. */
 		size = <DT_SIZE_M(64)>;
 		reg = <0>;
 		sample-clk-source = <3>;
@@ -384,7 +385,7 @@ nxp_8080_touch_panel_i2c: &flexcomm8_lpi2c8 {};
 		#size-cells = <1>;
 		ranges = <0x0 0x38000000 DT_SIZE_M(64)>;
 
-		ext_flash: flash@0 {
+		mx25um51345g: flash@0 {
 			compatible = "soc-nv-flash";
 			reg = <0x0 DT_SIZE_M(64)>;
 			erase-block-size = <DT_SIZE_K(4)>;

--- a/soc/nxp/imxrt/imxrt7xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt7xx/Kconfig.defconfig
@@ -5,3 +5,7 @@ rsource "*/Kconfig.defconfig"
 
 config MFD
 	default y if DT_HAS_NXP_LP_FLEXCOMM_ENABLED
+
+# Default offset 0x200 is not enough with higher ISR count
+config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT

--- a/soc/nxp/imxrt/soc.yml
+++ b/soc/nxp/imxrt/soc.yml
@@ -82,6 +82,9 @@ runners:
         - mimxrt595s/f1
       - qualifiers:
         - mimxrt685s/cm33
+      - qualifiers:
+        - mimxrt798s/cm33_cpu0
+        - mimxrt798s/cm33_cpu1
     '--reset':
     - run: last
       runners:
@@ -110,3 +113,6 @@ runners:
         - mimxrt595s/f1
       - qualifiers:
         - mimxrt685s/cm33
+      - qualifiers:
+        - mimxrt798s/cm33_cpu0
+        - mimxrt798s/cm33_cpu1


### PR DESCRIPTION
- Adds zephyr,code-partition pointing to slot0_partition in the chosen node to enable MCUboot-based booting.
- Increase ROM_START_OFFSET to 0x400 for imxrt7xx when BOOTLOADER_MCUBOOT is enabled, as the default 0x200 offset is insufficient for the higher ISR count on this SoC family.
- Adds a flash runner configuration used for sysbuild multi-image projects, mainly for MCU-boot, to avoid unwanted multiple erases and resets.
- Uses unified flash node naming used by other RTs.
- Fixed ext. flash comment to MX25UM51345G (was MX25UM51245G) in dts.