### PR TITLE
manifest: update hal_nordic to have fixes for anomalies in nrfx_spim

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 1a6de0af0a0e5f65b88d52df006aa8cdf29fe92f
+      revision: 19f742b45acb7e660ed3673cab819c103de5e856
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Update hal_nordic to fix nRF54L Series Anomaly 8
and nRF54H20 Anomaly 115.
Workaround for these anomalies requires CSN duration configuration, which is conditionally applied by the driver.
Apply the workaround irrespective of these conditions.