### PR TITLE
pmci: mctp: Add libmctp logger bridge

### DIFF
--- a/subsys/pmci/mctp/CMakeLists.txt
+++ b/subsys/pmci/mctp/CMakeLists.txt
@@ -1,5 +1,6 @@
 zephyr_library()
 zephyr_library_sources(mctp_memory.c)
+zephyr_library_sources_ifdef(CONFIG_MCTP_LOG_CUSTOM_ZEPHYR mctp_log.c)
 zephyr_library_sources_ifdef(CONFIG_MCTP_UART mctp_uart.c)
 zephyr_library_sources_ifdef(CONFIG_MCTP_I2C_GPIO_CONTROLLER mctp_i2c_gpio_controller.c)
 zephyr_library_sources_ifdef(CONFIG_MCTP_I2C_GPIO_TARGET mctp_i2c_gpio_target.c)

--- a/subsys/pmci/mctp/Kconfig
+++ b/subsys/pmci/mctp/Kconfig
@@ -33,6 +33,13 @@ config MCTP_MAX_MESSAGE_SIZE
 	  so CONFIG_MCTP_HEAP_SIZE must be large enough to hold at least one
 	  such buffer per concurrently-active reassembly context.
 
+config MCTP_LOG_CUSTOM_ZEPHYR
+	bool "Bridge libmctp logs into Zephyr logging"
+	depends on LOG
+	help
+	  Compile support that routes libmctp logs through Zephyr's logging
+	  subsystem using the configured MCTP log level.
+
 config MCTP_UART
 	bool "MCTP UART Binding"
 	depends on UART_ASYNC_API

--- a/subsys/pmci/mctp/mctp_log.c
+++ b/subsys/pmci/mctp/mctp_log.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
+#include <libmctp.h>
+
+LOG_MODULE_REGISTER(libmctp, CONFIG_MCTP_LOG_LEVEL);
+
+static int mctp_log_level;
+
+static void mctp_zephyr_log(int level, const char *fmt, va_list ap)
+{
+	char buf[160];
+	int rc;
+
+	if (level > mctp_log_level) {
+		return;
+	}
+
+	rc = vsnprintk(buf, sizeof(buf), fmt, ap);
+	if (rc < 0) {
+		return;
+	}
+
+	switch (level) {
+	case MCTP_LOG_ERR:
+		LOG_ERR("%s", buf);
+		break;
+	case MCTP_LOG_WARNING:
+		LOG_WRN("%s", buf);
+		break;
+	case MCTP_LOG_NOTICE:
+	case MCTP_LOG_INFO:
+		LOG_INF("%s", buf);
+		break;
+	default:
+		LOG_DBG("%s", buf);
+		break;
+	}
+}
+
+static int mctp_log_level_from_config(void)
+{
+	if (IS_ENABLED(CONFIG_MCTP_LOG_LEVEL_DBG)) {
+		return MCTP_LOG_DEBUG;
+	}
+
+	if (IS_ENABLED(CONFIG_MCTP_LOG_LEVEL_INF)) {
+		return MCTP_LOG_INFO;
+	}
+
+	if (IS_ENABLED(CONFIG_MCTP_LOG_LEVEL_WRN)) {
+		return MCTP_LOG_WARNING;
+	}
+
+	if (IS_ENABLED(CONFIG_MCTP_LOG_LEVEL_ERR)) {
+		return MCTP_LOG_ERR;
+	}
+
+	return -1;
+}
+
+int mctp_log_init(void)
+{
+	mctp_log_level = mctp_log_level_from_config();
+	if (mctp_log_level >= 0) {
+		mctp_set_log_custom(mctp_zephyr_log);
+	}
+
+	return 0;
+}
+
+SYS_INIT_NAMED(mctp_log, mctp_log_init, POST_KERNEL, 0);


### PR DESCRIPTION
Bridge MCTP logs to zephyr logs, conditionally based on KCONFIG.

Tests:

Loopback and Sample code using Nucleo U385RG-Q PRs:

https://github.com/zephyrproject-rtos/zephyr/pull/108755
https://github.com/zephyrproject-rtos/zephyr/pull/110111

Loopback test with the KCONFIG enabled:
 
```
*** Booting Zephyr OS build v4.4.0-3681-gbbbb70db7b00 ***
Running TESTSUITE mctp_i3c_test_suite
===================================================================
START - test_mctp_i3c_ping_pong
MCTP Endpoint EID:11 on nucleo_u385rg_q@D/stm32u385xx
I: libmctp: core: mctp_i3c_target binding started
MCTP Host EID:20 on nucleo_u385rg_q@D/stm32u385xx
I: libmctp: core: mctp_i3c_ctrl binding started
D: Started
Sending message "ping" to endpoint 11
D: libmctp: core: mctp_message_tx_on_bus: Generating packets for transmission of 5 byte message from 20 to 11
D: libmctp: core: tx dst 11 tag 0 payload len 5 seq 0. msg pos 0 len 5
Target received message "ping" from endpoint 20, queueing reply
Target replying to endpoint 20
D: libmctp: core: mctp_message_tx_on_bus: Generating packets for transmission of 5 byte message from 11 to 20
D: libmctp: core: tx dst 20 tag 0 payload len 5 seq 0. msg pos 0 len 5
D: Read 9 bytes from endpoint 0
Received message "pong" from endpoint 11 to 20, msg_tag 0, len 5
 PASS - test_mctp_i3c_ping_pong in 0.072 seconds
===================================================================
START - test_mctp_i3c_ping_pong_big_message
MCTP Endpoint EID:11 on nucleo_u385rg_q@D/stm32u385xx
I: libmctp: core: mctp_i3c_target binding started
MCTP Host EID:20 on nucleo_u385rg_q@D/stm32u385xx
I: libmctp: core: mctp_i3c_ctrl binding started
D: Started
Sending big message to endpoint 11
D: libmctp: core: mctp_message_tx_on_bus: Generating packets for transmission of 800 byte message from 20 to 11
D: libmctp: core: tx dst 11 tag 0 payload len 251 seq 0. msg pos 0 len 800
D: libmctp: core: tx dst 11 tag 0 payload len 251 seq 1. msg pos 251 len 800
D: libmctp: core: tx dst 11 tag 0 payload len 251 seq 2. msg pos 502 len 800
D: libmctp: core: tx dst 11 tag 0 payload len 47 seq 3. msg pos 753 len 800
Target received big message from endpoint 20, queueing reply
Target replying to endpoint 20
D: libmctp: core: mctp_message_tx_on_bus: Generating packets for transmission of 800 byte message from 11 to 20
D: libmctp: core: tx dst 20 tag 0 payload len 251 seq 0. msg pos 0 len 800
D: libmctp: core: tx dst 20 tag 0 payload len 251 seq 1. msg pos 251 len 800
D: Read 255 bytes from endpoint 0
D: libmctp: core: tx dst 20 tag 0 payload len 251 seq 2. msg pos 502 len 800
D: Read 255 bytes from endpoint 0
D: libmctp: core: tx dst 20 tag 0 payload len 47 seq 3. msg pos 753 len 800
D: Read 255 bytes from endpoint 0
D: Read 51 bytes from endpoint 0
Received big message from endpoint 11 to 20, len 800
 PASS - test_mctp_i3c_ping_pong_big_message in 0.136 seconds
===================================================================
TESTSUITE mctp_i3c_test_suite succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [mctp_i3c_test_suite]: pass = 2, fail = 0, skip = 0, total = 2 duration = 0.208 seconds
 - PASS - [mctp_i3c_test_suite.test_mctp_i3c_ping_pong] duration = 0.072 seconds
 - PASS - [mctp_i3c_test_suite.test_mctp_i3c_ping_pong_big_message] duration = 0.136 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL

```