### PR TITLE
stm32: samples: boards: st: circular_dma: fix build issue on sensortile_box_pro board

### DIFF
--- a/samples/boards/st/uart/circular_dma/sample.yaml
+++ b/samples/boards/st/uart/circular_dma/sample.yaml
@@ -8,4 +8,5 @@ tests:
       - serial
       - uart
     filter: dt_chosen_enabled("zephyr,shell-uart") and CONFIG_SOC_FAMILY_STM32
+            and not CONFIG_DT_HAS_ZEPHYR_CDC_ACM_UART_ENABLED
     harness: keyboard


### PR DESCRIPTION
This build issue was observed after the change in how the baud rate is set for sample https://github.com/zephyrproject-rtos/zephyr/commit/b39aabc7c027fa7f2f8e44897d52d97e7b5589f8

The SensorTile Box Pro board currently sets `zephyr,shell-uart = &board_cdc_acm_uart;
`

This points to a USB CDC ACM virtual UART, which:

- does not expose current-speed
- does not support UART DMA


This PR overrides the chosen UART to use USART1.

To reproduce: 
`west build -p -b sensortile_box_pro/stm32u585xx samples/boards/st/uart/circular_dma -T sample.boards.stm32.uart.circular_dma
`

