### PR TITLE
west: runners: bflb_mcu_tool: Change default baudrate to 2M

### DIFF
--- a/scripts/west_commands/runners/bflb_mcu_tool.py
+++ b/scripts/west_commands/runners/bflb_mcu_tool.py
@@ -7,7 +7,7 @@
 from runners.core import MissingProgram, RunnerCaps, ZephyrBinaryRunner
 
 DEFAULT_PORT = '/dev/ttyUSB0'
-DEFAULT_SPEED = '115200'
+DEFAULT_SPEED = '2000000'
 DEFAULT_CHIP = 'bl602'
 DEFAULT_EXECUTABLE = "bflb-mcu-tool-uart"
 


### PR DESCRIPTION
All boards with built-in serial adapter support this, upgrade value for convenience

Caveat: 
Makes CH9143 sad
Makes counterfeit ch340 sad