### PR TITLE
drivers: peci: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -270,8 +270,7 @@ __subsystem struct peci_driver_api {
  * @param dev Pointer to the device structure for the driver instance.
  * @param bitrate the selected bitrate expressed in Kbps.
  *
- * @retval 0 If successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 __syscall int peci_config(const struct device *dev, uint32_t bitrate);
 
@@ -289,8 +288,7 @@ static inline int z_impl_peci_config(const struct device *dev,
  *
  * @param dev Pointer to the device structure for the driver instance.
  *
- * @retval 0 If successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 __syscall int peci_enable(const struct device *dev);
 
@@ -307,8 +305,7 @@ static inline int z_impl_peci_enable(const struct device *dev)
  *
  * @param dev Pointer to the device structure for the driver instance.
  *
- * @retval 0 If successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 __syscall int peci_disable(const struct device *dev);
 
@@ -326,8 +323,7 @@ static inline int z_impl_peci_disable(const struct device *dev)
  * @param dev Pointer to the device structure for the driver instance.
  * @param msg Structure representing a PECI transaction.
  *
- * @retval 0 If successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 
 __syscall int peci_transfer(const struct device *dev, struct peci_msg *msg);


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974