### PR TITLE
runners: esp32: add esptool optimizations

### DIFF
--- a/boards/espressif/common/building-flashing.rst
+++ b/boards/espressif/common/building-flashing.rst
@@ -115,6 +115,32 @@ application.
 
       west flash --reset-type watchdog-reset
 
+Faster Flashing
+===============
+
+To speed up the development cycle, ``--esp-skip-flashed`` skips writing the image
+when the binary already in flash matches the one being flashed, verified with an
+MD5 check on the device:
+
+.. code-block:: shell
+
+   west flash --esp-skip-flashed
+
+For an even faster reflash, ``--esp-diff`` writes only the regions that differ
+from the previously flashed image. It compares against a locally cached copy
+rather than reading the device, so use it only when the flash was not modified
+by another tool, board, or manual write since the last ``west flash``:
+
+.. code-block:: shell
+
+   west flash --esp-diff
+
+Progress output can be suppressed for cleaner logs, which is useful in CI:
+
+.. code-block:: shell
+
+   west flash --esp-no-progress
+
 Open the serial monitor using the following command:
 
 .. code-block:: shell

--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -6,6 +6,8 @@
 '''Runner for flashing ESP32 devices with esptool.'''
 
 import os
+import shutil
+from pathlib import Path
 
 from runners.core import RunnerCaps, ZephyrBinaryRunner
 
@@ -13,24 +15,25 @@ from runners.core import RunnerCaps, ZephyrBinaryRunner
 class Esp32BinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for espidf.'''
 
-    def __init__(self, cfg, device, app_address, erase=False, reset=False,
-                 baud=921600, flash_size='detect', flash_freq='40m', flash_mode='dio',
-                 espidf=None, encrypt=False, no_stub=False, reset_type=None):
+    def __init__(self, cfg, args):
         super().__init__(cfg)
         self.elf = cfg.elf_file
         self.app_bin = cfg.bin_file
-        self.erase = bool(erase)
-        self.reset = bool(reset)
-        self.device = device
-        self.app_address = app_address
-        self.baud = baud
-        self.flash_size = flash_size
-        self.flash_freq = flash_freq
-        self.flash_mode = flash_mode
-        self.espidf = espidf
-        self.encrypt = encrypt
-        self.no_stub = no_stub
-        self.reset_type = reset_type
+        self.erase = bool(args.erase)
+        self.reset = bool(args.reset)
+        self.device = args.esp_device
+        self.app_address = args.esp_app_address
+        self.baud = args.esp_baud_rate
+        self.flash_size = args.esp_flash_size
+        self.flash_freq = args.esp_flash_freq
+        self.flash_mode = args.esp_flash_mode
+        self.espidf = args.esp_idf_path
+        self.encrypt = args.esp_encrypt
+        self.no_stub = args.esp_no_stub
+        self.reset_type = args.reset_type
+        self.skip_flashed = bool(args.esp_skip_flashed)
+        self.diff = bool(args.esp_diff)
+        self.no_progress = bool(args.esp_no_progress)
 
     @classmethod
     def name(cls):
@@ -69,18 +72,49 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
                             help='Encrypt firmware while flashing (correct efuses required)')
         parser.add_argument('--esp-no-stub', default=False, action='store_true',
                             help='Disable launching the flasher stub, only talk to ROM bootloader')
+        parser.add_argument('--esp-skip-flashed', default=False, action='store_true',
+                            help='Skip flashing if the image is already in flash '
+                                 '(verified with an MD5 check on the device)')
+        parser.add_argument('--esp-diff', default=False, action='store_true',
+                            help='Flash only regions that differ from the previous flash. '
+                                 'Trusts the locally cached image, so use only when the '
+                                 'flash was not modified by any other tool since.')
+        parser.add_argument('--esp-no-progress', default=False, action='store_true',
+                            help='Suppress esptool progress output')
 
         parser.set_defaults(reset=True)
 
+    def _get_prev_bin_path(self):
+        return self.app_bin + '.prev'
+
+    def _get_soc_name(self):
+        try:
+            return self.build_conf.get('CONFIG_SOC', 'esp32')
+        except FileNotFoundError:
+            return 'esp32'
+
+    def _append_flash_opts(self, cmd_flash):
+        if self.no_progress:
+            cmd_flash.append('-p')
+
+        prev_bin = self._get_prev_bin_path()
+        use_diff = self.diff and not self.erase and os.path.exists(prev_bin) and not self.encrypt
+        use_skip = self.skip_flashed and not self.encrypt
+
+        if use_diff:
+            cmd_flash.extend(['--diff-with', prev_bin])
+        elif use_skip:
+            cmd_flash.append('-s')
+
+    def _cache_flashed_bin(self):
+        if self.diff and not self.encrypt and os.path.exists(self.app_bin):
+            prev_bin = self._get_prev_bin_path()
+            Path(prev_bin).parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(self.app_bin, prev_bin)
+
     @classmethod
     def do_create(cls, cfg, args):
-
-        return Esp32BinaryRunner(
-            cfg, args.esp_device, app_address=args.esp_app_address, erase=args.erase,
-            reset=args.reset, baud=args.esp_baud_rate, flash_size=args.esp_flash_size,
-            flash_freq=args.esp_flash_freq, flash_mode=args.esp_flash_mode,
-            espidf=args.esp_idf_path, encrypt=args.esp_encrypt, no_stub=args.esp_no_stub,
-            reset_type=args.reset_type)
+        return Esp32BinaryRunner(cfg, args)
 
     def do_run(self, command, **kwargs):
 
@@ -101,7 +135,8 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             self.logger.warning(
                 '--reset-type is ignored because reset is disabled (--no-reset)')
         if self.reset:
-            cmd_flash.extend(['--after', self.reset_type or 'hard-reset', 'write-flash', '-u'])
+            cmd_flash.extend(['--after', self.reset_type or 'hard-reset'])
+        cmd_flash.extend(['write-flash', '-u'])
         cmd_flash.extend(['--flash-mode', self.flash_mode])
         cmd_flash.extend(['--flash-freq', self.flash_freq])
         cmd_flash.extend(['--flash-size', self.flash_size])
@@ -109,7 +144,14 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
         if self.encrypt:
             cmd_flash.extend(['--encrypt'])
 
+        self._append_flash_opts(cmd_flash)
+
         cmd_flash.extend([self.app_address, self.app_bin])
 
-        self.logger.info(f"Flashing esp32 chip on {self.device} ({self.baud}bps)")
+        device_str = self.device if self.device else 'auto-detect'
+        self.logger.info(
+            f"Flashing {self._get_soc_name()} chip on {device_str} ({self.baud}bps)")
+
         self.check_call(cmd_flash)
+
+        self._cache_flashed_bin()

--- a/scripts/west_commands/tests/test_esp32.py
+++ b/scripts/west_commands/tests/test_esp32.py
@@ -63,4 +63,120 @@ def test_no_reset_ignores_reset_type(cc, req, runner_config, caplog, reset_type)
 
     cmd = cc.call_args_list[-1].args[0]
     assert '--after' not in cmd
+    assert 'write-flash' in cmd
     assert any('reset is disabled' in r.message for r in caplog.records)
+
+
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_esptool)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_skip_flashed_off_by_default(cc, req, runner_config):
+    '''skip-flashed is opt-in, so -s is absent unless requested.'''
+    runner = Esp32BinaryRunner.create(runner_config, parse_args())
+    runner.run('flash')
+
+    cmd = cc.call_args_list[-1].args[0]
+    assert '-s' not in cmd
+    assert '--diff-with' not in cmd
+
+
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_esptool)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_skip_flashed(cc, req, runner_config):
+    '''--esp-skip-flashed adds -s.'''
+    runner = Esp32BinaryRunner.create(runner_config, parse_args('--esp-skip-flashed'))
+    runner.run('flash')
+
+    cmd = cc.call_args_list[-1].args[0]
+    assert '-s' in cmd
+
+
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_esptool)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_skip_flashed_suppressed_when_encrypt(cc, req, runner_config):
+    '''-s is dropped under --esp-encrypt since device MD5 would never match.'''
+    runner = Esp32BinaryRunner.create(
+        runner_config, parse_args('--esp-skip-flashed', '--esp-encrypt')
+    )
+    runner.run('flash')
+
+    cmd = cc.call_args_list[-1].args[0]
+    assert '-s' not in cmd
+    assert '--encrypt' in cmd
+
+
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_esptool)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_no_progress(cc, req, runner_config):
+    '''--esp-no-progress adds -p.'''
+    runner = Esp32BinaryRunner.create(runner_config, parse_args('--esp-no-progress'))
+    runner.run('flash')
+
+    cmd = cc.call_args_list[-1].args[0]
+    assert '-p' in cmd
+
+
+@patch('runners.esp32.os.path.exists', side_effect=lambda p: p.endswith('.prev'))
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_esptool)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_diff_disabled_by_default(cc, req, exists, runner_config):
+    '''A stray previous binary does not trigger --diff-with unless --esp-diff is set.'''
+    runner = Esp32BinaryRunner.create(runner_config, parse_args())
+    runner.run('flash')
+
+    cmd = cc.call_args_list[-1].args[0]
+    assert '--diff-with' not in cmd
+
+
+@patch('runners.esp32.shutil.copy2')
+@patch('runners.esp32.os.path.exists', side_effect=lambda p: p.endswith('.prev'))
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_esptool)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_diff_supersedes_skip_flashed(cc, req, exists, copy2, runner_config):
+    '''--esp-diff with a previous binary uses --diff-with instead of -s.'''
+    runner = Esp32BinaryRunner.create(runner_config, parse_args('--esp-diff', '--esp-skip-flashed'))
+    runner.run('flash')
+
+    cmd = cc.call_args_list[-1].args[0]
+    assert '--diff-with' in cmd
+    assert '-s' not in cmd
+
+
+@patch('runners.esp32.shutil.copy2')
+@patch('runners.esp32.os.path.exists', return_value=True)
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_esptool)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_diff_does_not_cache_when_encrypt(cc, req, exists, copy2, runner_config):
+    '''Under --esp-encrypt the plaintext .prev cache is not written.'''
+    runner = Esp32BinaryRunner.create(runner_config, parse_args('--esp-diff', '--esp-encrypt'))
+    runner.run('flash')
+
+    cmd = cc.call_args_list[-1].args[0]
+    assert '--diff-with' not in cmd
+    copy2.assert_not_called()
+
+
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_esptool)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_soc_name_from_config(cc, req, runner_config, caplog, tmp_path):
+    '''The flash log reports CONFIG_SOC when .config is available.'''
+    config = tmp_path / 'zephyr' / '.config'
+    config.parent.mkdir(parents=True)
+    config.write_text('CONFIG_SOC="esp32s3"\n')
+    cfg = runner_config._replace(build_dir=str(tmp_path))
+
+    runner = Esp32BinaryRunner.create(cfg, parse_args())
+    with caplog.at_level(logging.INFO, logger='runners.esp32'):
+        runner.run('flash')
+
+    assert any('Flashing esp32s3 chip' in r.message for r in caplog.records)
+
+
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_esptool)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_soc_name_falls_back_without_config(cc, req, runner_config, caplog):
+    '''The flash log falls back to "esp32" when .config is missing.'''
+    runner = Esp32BinaryRunner.create(runner_config, parse_args())
+    with caplog.at_level(logging.INFO, logger='runners.esp32'):
+        runner.run('flash')
+
+    assert any('Flashing esp32 chip' in r.message for r in caplog.records)


### PR DESCRIPTION
Add differential flashing with --diff-with for faster iteration, enable MD5-verified skip-flashed by default to avoid redundant flashing, and add --esp-no-progress flag for cleaner CI/CD output with clear console feedback.
