### PR TITLE
modules: hal_wch: add QingKe V3A (CH32V10x) support

### DIFF
--- a/modules/hal_wch/hal_ch32fun.h
+++ b/modules/hal_wch/hal_ch32fun.h
@@ -21,6 +21,11 @@
 #include <ch32fun.h>
 #endif /* defined(CONFIG_SOC_SERIES_QINGKE_V2C) */
 
+#if defined(CONFIG_SOC_SERIES_QINGKE_V3A)
+#define CH32V10x 1
+#include <ch32fun.h>
+#endif /* defined(CONFIG_SOC_SERIES_QINGKE_V3A) */
+
 #if defined(CONFIG_SOC_SERIES_QINGKE_V4B)
 #define CH32V20x    1
 #define CH32V20x_D6 1


### PR DESCRIPTION
Add CH32V10x chip family selection macro and include ch32fun.h for
the QingKe V3A SoC series, consistent with existing V2C and V4B
series support.

This is a prerequisite for the QingKe V3A SoC and CH32V103 board
support patches.