### PR TITLE
shell: kernel thread stacks: add cpu affinity on smp

### DIFF
--- a/subsys/shell/modules/kernel_service/thread/stacks.c
+++ b/subsys/shell/modules/kernel_service/thread/stacks.c
@@ -30,9 +30,7 @@ static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 
 	ret = k_thread_stack_space_get(thread, &unused);
 	if (ret) {
-		shell_print(sh,
-			    "Unable to determine unused stack size (%d)\n",
-			    ret);
+		shell_print(sh, "Unable to determine unused stack size (%d)\n", ret);
 		return;
 	}
 
@@ -41,20 +39,29 @@ static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 	/* Calculate the real size reserved for the stack */
 	pcnt = ((size - unused) * 100U) / size;
 
+#ifdef CONFIG_SMP
 	shell_print(sh,
 		    "%p %-" STRINGIFY(THREAD_MAX_NAM_LEN) "s "
-		    "(real size %4zu):\tunused %4zu\tusage %4zu / %4zu (%2u %%)",
-		    thread, tname ? tname : "NA", size, unused, size - unused, size, pcnt);
+							  "(real size %4zu):\tunused %4zu\tusage "
+							  "%4zu / %4zu (%2u %%) CPU %d",
+				      thread, tname ? tname : "NA", size, unused, size - unused,
+				      size, pcnt, thread->base.cpu);
+#else
+	shell_print(sh, "%p %-" STRINGIFY(THREAD_MAX_NAM_LEN) "s "
+							      "(real size %4zu):\tunused "
+							      "%4zu\tusage %4zu / %4zu (%2u %%)",
+					  thread, tname ? tname : "NA", size, unused, size - unused,
+					  size, pcnt);
+#endif
 }
 
-K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
-			     CONFIG_ISR_STACK_SIZE);
+K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS, CONFIG_ISR_STACK_SIZE);
 
 static int cmd_kernel_thread_stacks(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
-	char pad[THREAD_MAX_NAM_LEN] = { 0 };
+	char pad[THREAD_MAX_NAM_LEN] = {0};
 
 	memset(pad, ' ', MAX((THREAD_MAX_NAM_LEN - strlen("IRQ 00")), 1));
 
@@ -79,10 +86,19 @@ static int cmd_kernel_thread_stacks(const struct shell *sh, size_t argc, char **
 		(void)err;
 		__ASSERT_NO_MSG(err == 0);
 
+#ifdef CONFIG_SMP
 		shell_print(sh,
-			    "%p IRQ %02d %s(real size %4zu):\tunused %4zu\tusage %4zu / %4zu (%2zu %%)",
+			    "%p IRQ %02d %s(real size %4zu):\tunused %4zu\tusage "
+			    "%4zu / %4zu (%2zu %%) CPU %d",
+			    &z_interrupt_stacks[i], i, pad, size, unused, size - unused, size,
+			    ((size - unused) * 100U) / size, i);
+#else
+		shell_print(sh,
+			    "%p IRQ %02d %s(real size %4zu):\tunused %4zu\tusage "
+			    "%4zu / %4zu (%2zu %%)",
 			    &z_interrupt_stacks[i], i, pad, size, unused, size - unused, size,
 			    ((size - unused) * 100U) / size);
+#endif
 	}
 
 	return 0;


### PR DESCRIPTION
Display which CPU each thread and interrupt stack is running on when SMP is enabled. Shows CPU ID as the last column for clarity and proper alignment. On non-SMP systems, output remains unchanged.

Ex.:

```c
uart:~$ kernel thread stacks 
0x3fcb1940 rx_q[0]                     (real size 2048):	unused 1760	usage  288 / 2048 (14 %) CPU 1
0x3fcb1848 net_mgmt                    (real size 2048):	unused 1744	usage  304 / 2048 (14 %) CPU 1
0x3fcb1b18 tcp_work                    (real size 2048):	unused 1744	usage  304 / 2048 (14 %) CPU 1
0x3fcb13e8 shell_uart                  (real size 5200):	unused 3344	usage 1856 / 5200 (35 %) CPU 0
0x3fca0bc0 wifi                        (real size 3584):	unused 3008	usage  576 / 3584 (16 %) CPU 1
0x3fcb2618 sysworkq                    (real size 1024):	unused  720	usage  304 / 1024 (29 %) CPU 0
0x3fcb1568 esp_timer                   (real size 4096):	unused 3792	usage  304 / 4096 ( 7 %) CPU 0
0x3fcb12f0 logging                     (real size 1024):	unused  736	usage  288 / 1024 (28 %) CPU 1
0x3fcb2300 idle 00                     (real size 1024):	unused  816	usage  208 / 1024 (20 %) CPU 0
0x3fcb23b8 idle 01                     (real size 1024):	unused  816	usage  208 / 1024 (20 %) CPU 1
0x3fc9b220 IRQ 00                      (real size 2048):	unused 1712	usage  336 / 2048 (16 %) CPU 0
0x3fc9ba20 IRQ 01                      (real size 2048):	unused 1536	usage  512 / 2048 (25 %) CPU 1
```
