### PR TITLE
soc: st: stm32h7: fix M4 ART accelerator base address with FLASH_LOAD…

### DIFF
--- a/soc/st/stm32/stm32h7x/soc_m4.c
+++ b/soc/st/stm32/stm32h7x/soc_m4.c
@@ -29,9 +29,14 @@
  */
 void soc_early_init_hook(void)
 {
+	uint32_t art_base = DT_REG_ADDR(DT_CHOSEN(zephyr_flash));
+
+#ifdef CONFIG_FLASH_LOAD_OFFSET
+	art_base += CONFIG_FLASH_LOAD_OFFSET;
+#endif
 	/* Enable ART Flash cache accelerator */
 	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_ART);
-	LL_ART_SetBaseAddress(DT_REG_ADDR(DT_CHOSEN(zephyr_flash)));
+	LL_ART_SetBaseAddress(art_base);
 	LL_ART_Enable();
 
 	/* Enable hardware semaphore clock */


### PR DESCRIPTION
…_OFFSET

The ART (Adaptive Real-Time) flash cache accelerator base address is configured using only DT_REG_ADDR(DT_CHOSEN(zephyr_flash)) without accounting for CONFIG_FLASH_LOAD_OFFSET. When the M4 flash layout uses zephyr,flash = &flash0 with a non-zero CONFIG_FLASH_LOAD_OFFSET), the ART caches the wrong flash region.

For example, with CONFIG_FLASH_LOAD_OFFSET=0x100000 the ART points at 0x08000000 (Bank 1) while M4 code executes from 0x08100000 (Bank 2). This results in a 0% cache hit rate and every instruction fetch paying the full flash wait-state latency penalty. Since the M4 core has no I-Cache or D-Cache, the ART accelerator is its only flash caching mechanism.

Add CONFIG_FLASH_LOAD_OFFSET to the ART base address calculation so it points to the actual code execution region. This is a no-op when CONFIG_FLASH_LOAD_OFFSET=0.