### PR TITLE
drivers: tmcm3216: use correct format specifier for size_t

### DIFF
--- a/drivers/stepper/adi_tmc/bus/adi_tmc_uart.c
+++ b/drivers/stepper/adi_tmc/bus/adi_tmc_uart.c
@@ -79,7 +79,7 @@ int tmc_uart_write_register(const struct device *uart, uint8_t device_addr,
 	for (size_t i = 0; i < ADI_TMC_UART_DATAGRAM_SIZE; i++) {
 		err = tmc_uart_send_byte_with_echo(uart, buffer[i]);
 		if (err) {
-			LOG_ERR("Failed to send byte %d: 0x%02X", i, buffer[i]);
+			LOG_ERR("Failed to send byte %zu: 0x%02X", i, buffer[i]);
 			return err;
 		}
 	}
@@ -116,7 +116,7 @@ int tmc_uart_read_register(const struct device *uart, uint8_t device_addr, uint8
 	for (size_t i = 0; i < ADI_TMC_UART_READ_REQ_DATAGRAM_SIZE; i++) {
 		err = tmc_uart_send_byte_with_echo(uart, write_buffer[i]);
 		if (err) {
-			LOG_ERR("Failed to send byte %d: 0x%02X", i, write_buffer[i]);
+			LOG_ERR("Failed to send byte %zu: 0x%02X", i, write_buffer[i]);
 			return -EIO;
 		}
 	}
@@ -133,12 +133,12 @@ int tmc_uart_read_register(const struct device *uart, uint8_t device_addr, uint8
 		} while (err == -1 && !sys_timepoint_expired(end));
 
 		if (err == -1) {
-			LOG_ERR("Timeout waiting for byte %d for register 0x%x", i,
+			LOG_ERR("Timeout waiting for byte %zu for register 0x%x", i,
 				register_address);
 			return -EAGAIN;
 		}
 		if (err < 0) {
-			LOG_ERR("Error %d receiving byte %d for register 0x%x", err, i,
+			LOG_ERR("Error %d receiving byte %zu for register 0x%x", err, i,
 				register_address);
 			return -EIO;
 		}

--- a/drivers/stepper/adi_tmc/bus/adi_tmcm_rs485.c
+++ b/drivers/stepper/adi_tmc/bus/adi_tmcm_rs485.c
@@ -89,13 +89,13 @@ int tmcm_rs485_send_command(const struct device *rs485, const struct tmcm_rs485_
 		} while (err == -1 && !sys_timepoint_expired(end));
 
 		if (err == -1) {
-			LOG_ERR("Timeout waiting for echo byte %d", i);
+			LOG_ERR("Timeout waiting for echo byte %zu", i);
 			rs485_de_set(de_gpio, 0);
 			return -EAGAIN;
 		}
 
 		if (echo != write_buffer[i]) {
-			LOG_ERR("Echo mismatch byte %d: got 0x%02X expected 0x%02X", i, echo,
+			LOG_ERR("Echo mismatch byte %zu: got 0x%02X expected 0x%02X", i, echo,
 				write_buffer[i]);
 			rs485_de_set(de_gpio, 0);
 			return -EIO;
@@ -116,11 +116,11 @@ int tmcm_rs485_send_command(const struct device *rs485, const struct tmcm_rs485_
 		} while (err == -1 && !sys_timepoint_expired(end));
 
 		if (err == -1) {
-			LOG_ERR("Timeout waiting for reply byte %d", i);
+			LOG_ERR("Timeout waiting for reply byte %zu", i);
 			return -EAGAIN;
 		}
 		if (err < 0) {
-			LOG_ERR("Error %d receiving byte %d", err, i);
+			LOG_ERR("Error %d receiving byte %zu", err, i);
 			return -EIO;
 		}
 	}


### PR DESCRIPTION
incorrect format specifier for size_t leads to a bunch of compiler warnings on qemu_x86_64.