### PR TITLE
drivers: mfd: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/mfd/axp192.h
+++ b/include/zephyr/drivers/mfd/axp192.h
@@ -70,10 +70,9 @@ enum axp192_gpio_func {
  * @param client_dev client device the gpio is used in
  * @param gpio GPIO to be configured (0..5)
  * @param func Function to be configured (see @ref axp192_gpio_func for details)
- * @retval 0 on success
- * @retval -EINVAL if an invalid GPIO number is passed
- * @retval -ENOTSUP if the requested function is not supported by the given
- * @retval -errno in case of any bus error
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL An invalid GPIO number was passed.
+ * @retval -ENOTSUP The requested function is not supported by the given GPIO.
  */
 int mfd_axp192_gpio_func_ctrl(const struct device *dev, const struct device *client_dev,
 			      uint8_t gpio, enum axp192_gpio_func func);
@@ -84,9 +83,8 @@ int mfd_axp192_gpio_func_ctrl(const struct device *dev, const struct device *cli
  * @param dev axp192 mfd device
  * @param gpio GPIO to read configuration from
  * @param func Pointer to store current function configuration in.
- * @return 0 on success
- * @retval -EINVAL if an invalid GPIO number is passed
- * @retval -errno in case of any bus error
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL An invalid GPIO number was passed.
  */
 int mfd_axp192_gpio_func_get(const struct device *dev, uint8_t gpio, enum axp192_gpio_func *func);
 
@@ -97,10 +95,9 @@ int mfd_axp192_gpio_func_get(const struct device *dev, uint8_t gpio, enum axp192
  * @param dev axp192 mfd device
  * @param gpio GPIO to control pull-downs
  * @param enable true to enable, false to disable pull-down
- * @retval 0 on success
- * @retval -EINVAL if an invalid argument is given (e.g. invalid GPIO number)
- * @retval -ENOTSUP if pull-down is not supported by the givenn GPIO
- * @retval -errno in case of any bus error
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL An invalid argument was given (e.g. invalid GPIO number).
+ * @retval -ENOTSUP Pull-down is not supported by the given GPIO.
  */
 int mfd_axp192_gpio_pd_ctrl(const struct device *dev, uint8_t gpio, bool enable);
 
@@ -111,9 +108,9 @@ int mfd_axp192_gpio_pd_ctrl(const struct device *dev, uint8_t gpio, bool enable)
  * @param gpio GPIO to control pull-downs
  * @param enabled Pointer to current pull-down configuration (true: pull-down
  * enabled/ false: pull-down disabled)
- * @retval -EINVAL if an invalid argument is given (e.g. invalid GPIO number)
- * @retval -ENOTSUP if pull-down is not supported by the givenn GPIO
- * @retval -errno in case of any bus error
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL An invalid argument was given (e.g. invalid GPIO number).
+ * @retval -ENOTSUP Pull-down is not supported by the given GPIO.
  */
 int mfd_axp192_gpio_pd_get(const struct device *dev, uint8_t gpio, bool *enabled);
 
@@ -122,8 +119,7 @@ int mfd_axp192_gpio_pd_get(const struct device *dev, uint8_t gpio, bool *enabled
  *
  * @param dev axp192 mfd device
  * @param value Pointer to port value
- * @retval 0 on success
- * @retval -errno in case of any bus error
+ * @return 0 on success, negative errno value on failure.
  */
 int mfd_axp192_gpio_read_port(const struct device *dev, uint8_t *value);
 
@@ -133,8 +129,7 @@ int mfd_axp192_gpio_read_port(const struct device *dev, uint8_t *value);
  * @param dev axp192 mfd device
  * @param value port value
  * @param mask pin mask within the port
- * @retval 0 on success
- * @retval -errno in case of any bus error
+ * @return 0 on success, negative errno value on failure.
  */
 int mfd_axp192_gpio_write_port(const struct device *dev, uint8_t value, uint8_t mask);
 

--- a/include/zephyr/drivers/mfd/npm13xx.h
+++ b/include/zephyr/drivers/mfd/npm13xx.h
@@ -48,8 +48,7 @@ enum mfd_npm13xx_event_t {
  * @param offset Register offset address (bits 7..0 of 16-bit address)
  * @param data Pointer to buffer for received data
  * @param len Number of bytes to read
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_write_read_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_read_dt()).
  */
 int mfd_npm13xx_reg_read_burst(const struct device *dev, uint8_t base, uint8_t offset, void *data,
 			       size_t len);
@@ -61,8 +60,7 @@ int mfd_npm13xx_reg_read_burst(const struct device *dev, uint8_t base, uint8_t o
  * @param base Register base address (bits 15..8 of 16-bit address)
  * @param offset Register offset address (bits 7..0 of 16-bit address)
  * @param data Pointer to buffer for received data
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_write_read_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_read_dt()).
  */
 int mfd_npm13xx_reg_read(const struct device *dev, uint8_t base, uint8_t offset, uint8_t *data);
 
@@ -73,8 +71,7 @@ int mfd_npm13xx_reg_read(const struct device *dev, uint8_t base, uint8_t offset,
  * @param base Register base address (bits 15..8 of 16-bit address)
  * @param offset Register offset address (bits 7..0 of 16-bit address)
  * @param data data to write
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_write_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_dt()).
  */
 int mfd_npm13xx_reg_write(const struct device *dev, uint8_t base, uint8_t offset, uint8_t data);
 
@@ -86,8 +83,7 @@ int mfd_npm13xx_reg_write(const struct device *dev, uint8_t base, uint8_t offset
  * @param offset First register offset address (bits 7..0 of 16-bit address)
  * @param data Pointer to buffer to write
  * @param len Number of bytes to write
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_write_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_dt()).
  */
 int mfd_npm13xx_reg_write_burst(const struct device *dev, uint8_t base, uint8_t offset, void *data,
 				size_t len);
@@ -100,8 +96,7 @@ int mfd_npm13xx_reg_write_burst(const struct device *dev, uint8_t base, uint8_t 
  * @param offset Register offset address (bits 7..0 of 16-bit address)
  * @param data data to write
  * @param mask mask of bits to be modified
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_write_read_dt(), i2c_write_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_read_dt(), i2c_write_dt()).
  */
 int mfd_npm13xx_reg_update(const struct device *dev, uint8_t base, uint8_t offset, uint8_t data,
 			   uint8_t mask);
@@ -111,9 +106,8 @@ int mfd_npm13xx_reg_update(const struct device *dev, uint8_t base, uint8_t offse
  *
  * @param dev npm13xx mfd device
  * @param time_ms timer value in ms
- * @retval 0 If successful
- * @retval -EINVAL if time value is too large
- * @retval -errno In case of any bus error (see i2c_write_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_dt()).
+ * @retval -EINVAL Time value is too large.
  */
 int mfd_npm13xx_set_timer(const struct device *dev, uint32_t time_ms);
 
@@ -121,8 +115,7 @@ int mfd_npm13xx_set_timer(const struct device *dev, uint32_t time_ms);
  * @brief npm13xx full power reset
  *
  * @param dev npm13xx mfd device
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_write_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_dt()).
  */
 int mfd_npm13xx_reset(const struct device *dev);
 
@@ -133,9 +126,8 @@ int mfd_npm13xx_reset(const struct device *dev);
  *
  * @param dev npm13xx mfd device
  * @param time_ms timer value in ms
- * @retval 0 If successful
- * @retval -EINVAL if time value is too large
- * @retval -errno In case of any bus error (see i2c_write_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_dt()).
+ * @retval -EINVAL Time value is too large.
  */
 int mfd_npm13xx_hibernate(const struct device *dev, uint32_t time_ms);
 

--- a/include/zephyr/drivers/mfd/npm2100.h
+++ b/include/zephyr/drivers/mfd/npm2100.h
@@ -63,9 +63,8 @@ enum mfd_npm2100_timer_mode {
  * @param dev npm2100 mfd device
  * @param time_ms timer value in ms
  * @param mode timer mode
- * @retval 0 If successful
- * @retval -EINVAL if time value is too large
- * @retval -errno In case of any bus error (see i2c_write_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_dt()).
+ * @retval -EINVAL Time value is too large.
  */
 int mfd_npm2100_set_timer(const struct device *dev, uint32_t time_ms,
 			  enum mfd_npm2100_timer_mode mode);
@@ -74,8 +73,7 @@ int mfd_npm2100_set_timer(const struct device *dev, uint32_t time_ms,
  * @brief Start npm2100 timer
  *
  * @param dev npm2100 mfd device
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_write_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_dt()).
  */
 int mfd_npm2100_start_timer(const struct device *dev);
 
@@ -83,8 +81,7 @@ int mfd_npm2100_start_timer(const struct device *dev);
  * @brief npm2100 full power reset
  *
  * @param dev npm2100 mfd device
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_write_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_dt()).
  */
 int mfd_npm2100_reset(const struct device *dev);
 
@@ -98,10 +95,9 @@ int mfd_npm2100_reset(const struct device *dev);
  * @param dev npm2100 mfd device
  * @param time_ms timer value in ms. Set to 0 to disable timer.
  * @param pass_through set to use pass-through hibernate mode.
- * @retval 0 If successful
- * @retval -EINVAL if time value is too large
- * @retval -EBUSY if the timer is already in use.
- * @retval -errno In case of any bus error (see i2c_write_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_write_dt()).
+ * @retval -EINVAL Time value is too large.
+ * @retval -EBUSY The timer is already in use.
  */
 int mfd_npm2100_hibernate(const struct device *dev, uint32_t time_ms, bool pass_through);
 
@@ -110,7 +106,7 @@ int mfd_npm2100_hibernate(const struct device *dev, uint32_t time_ms, bool pass_
  *
  * @param dev npm2100 mfd device
  * @param callback callback
- * @return 0 on success, -errno on failure
+ * @return 0 on success, negative errno value on failure.
  */
 int mfd_npm2100_add_callback(const struct device *dev, struct gpio_callback *callback);
 
@@ -119,7 +115,7 @@ int mfd_npm2100_add_callback(const struct device *dev, struct gpio_callback *cal
  *
  * @param dev npm2100 mfd device
  * @param callback callback
- * @return 0 on success, -errno on failure
+ * @return 0 on success, negative errno value on failure.
  */
 int mfd_npm2100_remove_callback(const struct device *dev, struct gpio_callback *callback);
 

--- a/include/zephyr/drivers/mfd/pca9422.h
+++ b/include/zephyr/drivers/mfd/pca9422.h
@@ -52,8 +52,7 @@ void mfd_pca9422_set_irqhandler(const struct device *dev, const struct device *c
  * @param reg Register start address
  * @param value Pointer that stores the received data
  * @param len Number of bytes to read
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_burst_read_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_burst_read_dt()).
  */
 int mfd_pca9422_reg_burst_read(const struct device *dev, uint8_t reg, uint8_t *value, size_t len);
 
@@ -63,8 +62,7 @@ int mfd_pca9422_reg_burst_read(const struct device *dev, uint8_t reg, uint8_t *v
  * @param dev pca9422 mfd device
  * @param reg Register address
  * @param value Pointer that stores the received data
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_reg_read_byte_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_reg_read_byte_dt()).
  */
 int mfd_pca9422_reg_read_byte(const struct device *dev, uint8_t reg, uint8_t *value);
 
@@ -75,8 +73,7 @@ int mfd_pca9422_reg_read_byte(const struct device *dev, uint8_t reg, uint8_t *va
  * @param reg Register start address
  * @param value Pointer that stores the write data
  * @param len Number of bytes to write
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_burst_write_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_burst_write_dt()).
  */
 int mfd_pca9422_reg_burst_write(const struct device *dev, uint8_t reg, uint8_t *value, size_t len);
 
@@ -86,8 +83,7 @@ int mfd_pca9422_reg_burst_write(const struct device *dev, uint8_t reg, uint8_t *
  * @param dev pca9422 mfd device
  * @param reg Register address
  * @param value data to write
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_reg_write_byte_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_reg_write_byte_dt()).
  */
 int mfd_pca9422_reg_write_byte(const struct device *dev, uint8_t reg, uint8_t value);
 
@@ -98,8 +94,7 @@ int mfd_pca9422_reg_write_byte(const struct device *dev, uint8_t reg, uint8_t va
  * @param reg Register address
  * @param mask mask of bits to be modified
  * @param value data to write
- * @retval 0 If successful
- * @retval -errno In case of any bus error (see i2c_reg_update_byte_dt())
+ * @return 0 on success, negative errno value on failure (see i2c_reg_update_byte_dt()).
  */
 int mfd_pca9422_reg_update_byte(const struct device *dev, uint8_t reg, uint8_t mask, uint8_t value);
 


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974