### PR TITLE
drivers: sensor: ti: ina2xx: fix INA228 SHUNT_CAL integer truncation

### DIFF
--- a/drivers/sensor/ti/ina2xx/ina237.c
+++ b/drivers/sensor/ti/ina2xx/ina237.c
@@ -360,9 +360,9 @@ static DEVICE_API(sensor, ina228_driver_api) = {
 	(DT_INST_ENUM_IDX(inst, temp_conversion_time_us) << 3) |   \
 	(DT_INST_ENUM_IDX(inst, avg_count))
 
-#define INA237_DT_CAL(inst)                               \
-	CAL_PRECISION_MULTIPLIER(inst) * INA237_CAL_SCALING * \
-	DT_INST_PROP(inst, current_lsb_microamps) *           \
+#define INA2XX_DT_CAL(inst, scaling)             \
+	CAL_PRECISION_MULTIPLIER(inst) * (scaling) * \
+	DT_INST_PROP(inst, current_lsb_microamps) *  \
 	DT_INST_PROP(inst, rshunt_micro_ohms) / 10000000ULL
 
 #define INA237_DRIVER_INIT(inst)                                               \
@@ -373,7 +373,7 @@ static DEVICE_API(sensor, ina228_driver_api) = {
 			.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),          \
 			.config = INA237_DT_CONFIG(inst),                                  \
 			.adc_config = INA237_DT_ADC_CONFIG(inst),                          \
-			.cal = INA237_DT_CAL(inst),                                        \
+			.cal = INA2XX_DT_CAL(inst, INA237_CAL_SCALING),                    \
 			.id_reg = &ina237_mfr_id,                                          \
 			.config_reg = &ina237_config,                                      \
 			.adc_config_reg = &ina237_adc_config,                              \
@@ -394,7 +394,7 @@ static DEVICE_API(sensor, ina228_driver_api) = {
 			.bus = I2C_DT_SPEC_INST_GET(inst),                                 \
 			.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),          \
 			.adc_config = INA237_DT_ADC_CONFIG(inst),                          \
-			.cal = (INA237_DT_CAL(inst) * 16),                                 \
+			.cal = INA2XX_DT_CAL(inst, INA228_CAL_SCALING),                    \
 			.id_reg = &ina237_mfr_id,                                          \
 			.config_reg = &ina237_config,                                      \
 			.adc_config_reg = &ina237_adc_config,                              \


### PR DESCRIPTION
## Bug

`INA228_DRIVER_INIT` sets CAL with `.cal = (INA237_DT_CAL(inst) * 16)`, where `INA237_DT_CAL` ends in `/ 10000000ULL`. C operator precedence runs the divide **before** the `*16`, so the truncation residual gets amplified 16×. For small `current_lsb * rshunt` products the numerator falls below `1e7` and CAL collapses to **0**.

## Fix

Unify the two CAL macros into `INA2XX_DT_CAL(inst, scaling)`. The `*16` is folded into `INA228_CAL_SCALING` (already defined as `INA237_CAL_SCALING << 4`) so it happens inside the product, and the divide is the last operation. INA237 path is functionally unchanged.

