### PR TITLE
net: dhcp: fix bounds check to use ARRAY_SIZE instead of sizeof

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1797,7 +1797,7 @@ const char *net_dhcpv4_state_name(enum net_dhcpv4_state state)
 		"decline,"
 	};
 
-	__ASSERT_NO_MSG(state >= 0 && state < sizeof(name));
+	__ASSERT_NO_MSG(state >= 0 && state < ARRAY_SIZE(name));
 	return name[state];
 }
 
@@ -1814,7 +1814,7 @@ const char *net_dhcpv4_msg_type_name(enum net_dhcpv4_msg_type msg_type)
 		"inform"
 	};
 
-	if (msg_type >= 1 && msg_type <= sizeof(name)) {
+	if (msg_type >= 1 && msg_type <= ARRAY_SIZE(name)) {
 		return name[msg_type - 1];
 	}
 

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -69,7 +69,7 @@ const char *net_dhcpv6_state_name(enum net_dhcpv6_state state)
 		"bound",
 	};
 
-	__ASSERT_NO_MSG(state >= 0 && state < sizeof(name));
+	__ASSERT_NO_MSG(state >= 0 && state < ARRAY_SIZE(name));
 	return name[state];
 }
 


### PR DESCRIPTION
Replace sizeof(name) with ARRAY_SIZE(name) in DHCPv4 and DHCPv6 state and message type name lookup functions. sizeof returns the total byte size of the pointer array not the element count, making the bounds check wrong.

Fixes: #112421