### PR TITLE
doc: pm: scope the IRQ-locked resume contract to maskable interrupts

### DIFF
--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -174,6 +174,13 @@ verifying correct behavior). Zero-latency interrupts may not modify any data
 inspected by kernel APIs invoked from normal Zephyr contexts and shall not
 generate exceptions that need to be handled synchronously (e.g. kernel panic).
 
+When system power management keeps interrupts locked across the resume (currently
+selected by :kconfig:option:`CONFIG_PM_STATE_SET_IRQ_LOCKED`), a zero-latency
+interrupt may also be dispatched during the PM resume window, before PM resume
+bookkeeping and SoC/device hardware restore have completed. Such an ISR must be
+PM-wake-safe: it must not rely on clocks, power, or peripherals that power
+management restores during resume.
+
 .. important::
     Zero-latency interrupts are supported on an architecture-specific basis.
     The feature is currently implemented in the ARM Cortex-M architecture

--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -174,12 +174,13 @@ verifying correct behavior). Zero-latency interrupts may not modify any data
 inspected by kernel APIs invoked from normal Zephyr contexts and shall not
 generate exceptions that need to be handled synchronously (e.g. kernel panic).
 
-When system power management keeps interrupts locked across the resume (currently
+When system power management keeps interrupts locked across PM resume (currently
 selected by :kconfig:option:`CONFIG_PM_STATE_SET_IRQ_LOCKED`), a zero-latency
-interrupt may also be dispatched during the PM resume window, before PM resume
-bookkeeping and SoC/device hardware restore have completed. Such an ISR must be
-PM-wake-safe: it must not rely on clocks, power, or peripherals that power
-management restores during resume.
+interrupt is outside the locked-resume ordering and may be dispatched during PM
+suspend/resume logic, before PM resume bookkeeping and SoC/device hardware
+restore have completed. Such an ISR must be PM-wake-safe, or the interrupt
+source must be masked or disabled while the system state does not allow the ISR
+to execute.
 
 .. important::
     Zero-latency interrupts are supported on an architecture-specific basis.

--- a/doc/services/pm/system.rst
+++ b/doc/services/pm/system.rst
@@ -144,22 +144,9 @@ before they can opt in to the kernel-owned ordering guarantee.
 
 .. note::
 
-   The ordering guarantee above applies only to interrupts that
-   :c:func:`arch_irq_lock` can mask. On architectures where that lock is a
-   priority threshold rather than a global disable -- notably the BASEPRI lock on
-   Cortex-M Mainline -- zero-latency interrupts (``IRQ_ZERO_LATENCY``) are
-   configured above the lock level and may be dispatched during the resume
-   window, including the post-wake back half of :c:func:`pm_state_set` and before
-   device resume and :c:func:`pm_state_exit_post_ops` have restored hardware.
-   This is by design: declaring an interrupt ``IRQ_ZERO_LATENCY`` is the author's
-   assertion that the handler is PM-wake-safe and may run in a half-restored
-   system; it is intentionally outside the locked-resume ordering, not an
-   unhandled gap. Consistent with this, zero-latency ISRs must not use
-   :c:macro:`ISR_DIRECT_PM` or call into the kernel. On Cortex-M Mainline the
-   architecture low-power entry hook (``arch_pm_state_set_prepare()``) briefly
-   masks even zero-latency interrupts with PRIMASK across the low-power
-   instruction when the SoC uses it, and ``arch_pm_state_set_finish()`` releases
-   that mask before PM resume bookkeeping runs.
+    The ordering guarantee above applies only to interrupts that
+    :c:func:`arch_irq_lock` can mask. Zero-latency interrupts are outside this
+    ordering. See :ref:`zlis`.
 
 
 Power States

--- a/doc/services/pm/system.rst
+++ b/doc/services/pm/system.rst
@@ -142,6 +142,25 @@ implementations that still call ``irq_unlock(0)``, ``arch_irq_unlock(0)``,
 ``__enable_irq()``, or equivalent operations from those hooks must be migrated
 before they can opt in to the kernel-owned ordering guarantee.
 
+.. note::
+
+   The ordering guarantee above applies only to interrupts that
+   :c:func:`arch_irq_lock` can mask. On architectures where that lock is a
+   priority threshold rather than a global disable -- notably the BASEPRI lock on
+   Cortex-M Mainline -- zero-latency interrupts (``IRQ_ZERO_LATENCY``) are
+   configured above the lock level and may be dispatched during the resume
+   window, including the post-wake back half of :c:func:`pm_state_set` and before
+   device resume and :c:func:`pm_state_exit_post_ops` have restored hardware.
+   This is by design: declaring an interrupt ``IRQ_ZERO_LATENCY`` is the author's
+   assertion that the handler is PM-wake-safe and may run in a half-restored
+   system; it is intentionally outside the locked-resume ordering, not an
+   unhandled gap. Consistent with this, zero-latency ISRs must not use
+   :c:macro:`ISR_DIRECT_PM` or call into the kernel. On Cortex-M Mainline the
+   architecture low-power entry hook (``arch_pm_state_set_prepare()``) briefly
+   masks even zero-latency interrupts with PRIMASK across the low-power
+   instruction when the SoC uses it, and ``arch_pm_state_set_finish()`` releases
+   that mask before PM resume bookkeeping runs.
+
 
 Power States
 ============

--- a/include/zephyr/arch/arm/irq.h
+++ b/include/zephyr/arch/arm/irq.h
@@ -107,6 +107,13 @@ extern void z_arm_interrupt_init(void);
  * in the interrupt's priority argument). If CONFIG_ZERO_LATENCY_LEVELS is
  * greater 1 it has the priority level assigned by the argument.
  * The interrupt will run even if irq_lock() is active. Be careful!
+ *
+ * This also applies when system power management keeps interrupts locked across
+ * resume (currently selected by CONFIG_PM_STATE_SET_IRQ_LOCKED): because such an
+ * interrupt runs above the interrupt-lock level, it may be dispatched before PM
+ * resume bookkeeping and SoC/device hardware restore have completed, so it must
+ * be PM-wake-safe and must not depend on PM-restored clocks, power, or
+ * peripherals.
  */
 #define IRQ_ZERO_LATENCY	BIT(0)
 

--- a/include/zephyr/arch/arm/irq.h
+++ b/include/zephyr/arch/arm/irq.h
@@ -109,11 +109,11 @@ extern void z_arm_interrupt_init(void);
  * The interrupt will run even if irq_lock() is active. Be careful!
  *
  * This also applies when system power management keeps interrupts locked across
- * resume (currently selected by CONFIG_PM_STATE_SET_IRQ_LOCKED): because such an
- * interrupt runs above the interrupt-lock level, it may be dispatched before PM
- * resume bookkeeping and SoC/device hardware restore have completed, so it must
- * be PM-wake-safe and must not depend on PM-restored clocks, power, or
- * peripherals.
+ * PM resume (currently selected by CONFIG_PM_STATE_SET_IRQ_LOCKED): because such
+ * an interrupt runs above the interrupt-lock level, it is outside the
+ * locked-resume ordering. It must be PM-wake-safe, or the interrupt source must
+ * be masked or disabled while the system state does not allow the ISR to
+ * execute.
  */
 #define IRQ_ZERO_LATENCY	BIT(0)
 

--- a/include/zephyr/pm/pm.h
+++ b/include/zephyr/pm/pm.h
@@ -174,6 +174,22 @@ void pm_system_resume(void);
  * kernel idle path restores the original interrupt state after PM resume
  * housekeeping is complete.
  *
+ * @note The locked-resume ordering guarantee (selected via
+ *       CONFIG_PM_STATE_SET_IRQ_LOCKED) covers only interrupts that
+ *       arch_irq_lock() can mask. On architectures where that lock is a
+ *       priority threshold rather than a global disable (for example the
+ *       BASEPRI lock on Cortex-M Mainline), zero-latency interrupts
+ *       (IRQ_ZERO_LATENCY) run above the lock and may be dispatched during the
+ *       resume window, before PM resume bookkeeping completes, i.e. before the
+ *       post-wake remainder of this hook, device resume, and
+ *       @ref pm_state_exit_post_ops finish restoring hardware. (NMI and faults
+ *       are likewise outside any arch_irq_lock()-based ordering; ZLIs are the
+ *       configurable case authors interact with.) This is by design: declaring
+ *       an interrupt IRQ_ZERO_LATENCY is the author's assertion that the
+ *       handler is PM-wake-safe and may run in a half-restored system, so it
+ *       must not rely on clocks, power, or peripherals that PM restores during
+ *       resume.
+ *
  * @param state Power state.
  * @param substate_id Power substate id.
  */
@@ -190,6 +206,11 @@ void pm_state_set(enum pm_state state, uint8_t substate_id);
  * interrupts or otherwise dispatch pending wake-source ISRs from this hook; the
  * kernel idle path restores the original interrupt state after PM resume
  * housekeeping is complete.
+ *
+ * @note As with @ref pm_state_set, this locked-resume ordering covers only
+ *       interrupts that arch_irq_lock() can mask. A zero-latency interrupt
+ *       (IRQ_ZERO_LATENCY) may run during the resume window before this hook
+ *       completes and must be PM-wake-safe (see @ref pm_state_set).
  *
  * @param state Power state.
  * @param substate_id Power substate id.

--- a/include/zephyr/pm/pm.h
+++ b/include/zephyr/pm/pm.h
@@ -174,21 +174,12 @@ void pm_system_resume(void);
  * kernel idle path restores the original interrupt state after PM resume
  * housekeeping is complete.
  *
- * @note The locked-resume ordering guarantee (selected via
- *       CONFIG_PM_STATE_SET_IRQ_LOCKED) covers only interrupts that
- *       arch_irq_lock() can mask. On architectures where that lock is a
- *       priority threshold rather than a global disable (for example the
- *       BASEPRI lock on Cortex-M Mainline), zero-latency interrupts
- *       (IRQ_ZERO_LATENCY) run above the lock and may be dispatched during the
- *       resume window, before PM resume bookkeeping completes, i.e. before the
- *       post-wake remainder of this hook, device resume, and
- *       @ref pm_state_exit_post_ops finish restoring hardware. (NMI and faults
- *       are likewise outside any arch_irq_lock()-based ordering; ZLIs are the
- *       configurable case authors interact with.) This is by design: declaring
- *       an interrupt IRQ_ZERO_LATENCY is the author's assertion that the
- *       handler is PM-wake-safe and may run in a half-restored system, so it
- *       must not rely on clocks, power, or peripherals that PM restores during
- *       resume.
+ * @note When system PM keeps interrupts locked across resume (currently selected
+ *       via CONFIG_PM_STATE_SET_IRQ_LOCKED), the locked-resume ordering
+ *       guarantee covers only interrupts that arch_irq_lock() can mask. A
+ *       zero-latency interrupt (IRQ_ZERO_LATENCY) is outside this ordering and
+ *       must be PM-wake-safe, or its interrupt source must be masked or disabled
+ *       while the system state does not allow the ISR to execute.
  *
  * @param state Power state.
  * @param substate_id Power substate id.
@@ -207,10 +198,11 @@ void pm_state_set(enum pm_state state, uint8_t substate_id);
  * kernel idle path restores the original interrupt state after PM resume
  * housekeeping is complete.
  *
- * @note As with @ref pm_state_set, this locked-resume ordering covers only
- *       interrupts that arch_irq_lock() can mask. A zero-latency interrupt
- *       (IRQ_ZERO_LATENCY) may run during the resume window before this hook
- *       completes and must be PM-wake-safe (see @ref pm_state_set).
+ * @note As with @ref pm_state_set, when system PM keeps interrupts locked
+ *       across resume, this ordering covers only interrupts that
+ *       arch_irq_lock() can mask. A zero-latency interrupt (IRQ_ZERO_LATENCY)
+ *       may run during the resume window before this hook completes and must be
+ *       PM-wake-safe (see @ref pm_state_set).
  *
  * @param state Power state.
  * @param substate_id Power substate id.

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -64,12 +64,8 @@ config PM_STATE_SET_IRQ_LOCKED
 	  PM implementations are migrated, this option will become the default and
 	  be removed.
 
-	  This guarantee covers only interrupts that arch_irq_lock() can mask. On
-	  Cortex-M Mainline that lock is a BASEPRI threshold, so zero-latency
-	  interrupts (IRQ_ZERO_LATENCY) run above it and may be dispatched during the
-	  resume window -- including the post-wake back half of pm_state_set()
-	  itself -- before device resume and pm_state_exit_post_ops() complete. Such
-	  zero-latency ISRs must be PM-wake-safe; this is by design, not a gap.
+	  This guarantee covers only interrupts that arch_irq_lock() can mask. See
+	  the zero-latency interrupt documentation for IRQ_ZERO_LATENCY behavior.
 
 rsource "policy/Kconfig"
 

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -64,6 +64,13 @@ config PM_STATE_SET_IRQ_LOCKED
 	  PM implementations are migrated, this option will become the default and
 	  be removed.
 
+	  This guarantee covers only interrupts that arch_irq_lock() can mask. On
+	  Cortex-M Mainline that lock is a BASEPRI threshold, so zero-latency
+	  interrupts (IRQ_ZERO_LATENCY) run above it and may be dispatched during the
+	  resume window -- including the post-wake back half of pm_state_set()
+	  itself -- before device resume and pm_state_exit_post_ops() complete. Such
+	  zero-latency ISRs must be PM-wake-safe; this is by design, not a gap.
+
 rsource "policy/Kconfig"
 
 if PM


### PR DESCRIPTION
Docs/spec-only clarification, no behavior change. This scopes the `CONFIG_PM_STATE_SET_IRQ_LOCKED` resume-ordering guarantee to interrupts that `arch_irq_lock()` can mask, and documents that zero-latency interrupts (`IRQ_ZERO_LATENCY`) are outside that guarantee on Cortex-M Mainline: `arch_irq_lock()` uses a BASEPRI threshold there, so a ZLI runs above the lock and may be dispatched during the PM resume window, before PM resume bookkeeping and SoC/device restore have completed.

Such a ZLI must be PM-wake-safe: it must not depend on clocks, power, or peripherals that PM restores later in the resume path.

### Background

The discussion in #109654 initially framed this as "direct ISRs break the locked PM contract." A plain direct ISR is still masked by `arch_irq_lock()` like any regular ISR; only a ZLI, by priority, escapes that lock. The contract can only promise to defer interrupts that are maskable by `arch_irq_lock()`, so document that boundary before making the locked contract the default.

See #110140 for the full RFC discussion and follow-ups.

### Scope

Docs / header comments / Kconfig help only:

- no source-mechanism change
- no Kconfig symbol added or removed
- no test changes
- no runtime behavior change

Part of #110140.