### PR TITLE
drivers: ethernet: Add BCM2711 GENET driver for Raspberry Pi 4

### DIFF
--- a/boards/raspberrypi/rpi_4b/rpi_4b.dts
+++ b/boards/raspberrypi/rpi_4b/rpi_4b.dts
@@ -25,6 +25,7 @@
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &dram0;
 		zephyr,entropy = &rng;
+		zephyr,ethernet = &genet;
 	};
 
 	leds {
@@ -80,4 +81,9 @@
 	pinctrl-0 = <&uart1_gpio14>;
 	current-speed = <115200>;
 	status = "okay";
+};
+
+&genet {
+	status = "okay";
+	local-mac-address = [dc a6 32 eb 17 24];
 };

--- a/drivers/ethernet/CMakeLists.txt
+++ b/drivers/ethernet/CMakeLists.txt
@@ -75,4 +75,5 @@ zephyr_library_sources_ifdef(CONFIG_ETH_XLNX_GEM eth_xlnx_gem.c)
 zephyr_library_sources_ifdef(CONFIG_ETH_XLNX_GEM phy_xlnx_gem.c)
 zephyr_library_sources_ifdef(CONFIG_ETH_XMC4XXX eth_xmc4xxx.c)
 zephyr_library_sources_ifdef(CONFIG_SLIP_TAP eth_slip_tap.c)
+zephyr_library_sources_ifdef(CONFIG_ETH_BCM_GENET eth_bcm_genet.c)
 # zephyr-keep-sorted-stop

--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -118,3 +118,4 @@ config ETH_NET_IF_NO_AUTO_START
 	  bring the interface up.
 
 source "drivers/ethernet/mdio/Kconfig"
+source "drivers/ethernet/Kconfig.bcm_genet"

--- a/drivers/ethernet/Kconfig.bcm_genet
+++ b/drivers/ethernet/Kconfig.bcm_genet
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 Khaled Abdalla <khaled.3bdulaziz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig ETH_BCM_GENET
+	bool "Broadcom GENET v5 Ethernet driver (BCM2711 / Raspberry Pi 4)"
+	default y
+	depends on DT_HAS_BRCM_BCM2711_GENET_ENABLED
+	help
+	  Enable the Broadcom GENET v5 Gigabit Ethernet driver for the
+	  BCM2711 SoC (Raspberry Pi 4 Model B).
+
+	  The driver supports:
+	    - 10/100/1000 Mbps via RGMII / RGMII-RXID
+	    - Interrupt-driven RX (ring 0) and TX (ring 16)
+	    - MDIO-based PHY management (BCM54213PE default)
+	    - Static MAC address or random locally-administered address
+
+if ETH_BCM_GENET
+
+config ETH_BCM_GENET_LOG_LEVEL
+	int "GENET driver log level"
+	default 3
+	range 0 4
+	help
+	  Log verbosity: 0=off 1=error 2=warning 3=info 4=debug.
+
+endif # ETH_BCM_GENET

--- a/drivers/ethernet/eth_bcm_genet.c
+++ b/drivers/ethernet/eth_bcm_genet.c
@@ -1,0 +1,869 @@
+/*
+ * BCM2711 GENET v5 Ethernet driver — Zephyr / Raspberry Pi 4B
+ *
+ * Ported from Linux 5.4 drivers/net/ethernet/broadcom/genet/bcmgenet.c.
+ *
+ * Configuration: BCM2711 RPi 4B, external BCM54213PE PHY (MDIO addr 1),
+ * RGMII-RXID, bare-metal boot (VPU network-boot, no U-Boot).
+ *
+ * Key platform quirk: the VideoCore firmware sets EXT_PWR_DOWN_DLL and
+ * EXT_PWR_DOWN_BIAS in EXT_EXT_PWR_MGMT after using GENET for network-boot.
+ * Those bits gate the UMAC register bus; any UMAC access before clearing them
+ * returns SLVERR (EC=0x2F SError on Cortex-A72). genet_power_up() mirrors
+ * Linux bcmgenet_power_up(GENET_POWER_PASSIVE) to clear them before touching
+ * any UMAC, MDIO, or DMA register.
+ *
+ * DMA coherency: CONFIG_CACHE_MANAGEMENT=y is required. Cortex-A72 runs with
+ * the D-cache enabled; without explicit flush/invalidate the DMA engine reads
+ * stale zeros from physical memory while fresh data sits in L1/L2.
+ *
+ * Copyright (c) 2026 Khaled Abdalla <khaled.3bdulaziz@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT brcm_bcm2711_genet
+
+#define LOG_MODULE_NAME eth_genet
+#define LOG_LEVEL       CONFIG_ETHERNET_LOG_LEVEL
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/sys/barrier.h>
+#include <zephyr/cache.h>
+#include <zephyr/irq.h>
+#include <zephyr/random/random.h>
+#include <zephyr/net/net_pkt.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/ethernet.h>
+#include <ethernet/eth_stats.h>
+
+#include "eth_bcm_genet.h"
+
+#define GENET_BUF_ALIGN          64U
+#define GENET_PHY_POLL_INTERVAL  500U
+
+/* ───── Static DMA buffers (identity-mapped → same VA == PA on RPi4) ───── */
+static uint8_t genet_rx_buf[GENET_NUM_RX_DESC][GENET_RX_BUF_SIZE]
+	__aligned(GENET_BUF_ALIGN);
+static uint8_t genet_tx_buf[GENET_NUM_TX_DESC][GENET_TX_BUF_SIZE]
+	__aligned(GENET_BUF_ALIGN);
+
+struct genet_data {
+	mm_reg_t              base;
+	struct net_if        *iface;
+	const struct device  *dev;
+	uint8_t               mac[6];
+	uint8_t               phy_addr;
+	bool                  phy_rgmii_rxid;
+	bool                  link_up;
+
+	/* RX bookkeeping */
+	uint16_t rx_cons;
+	uint16_t rx_desc_pos;
+
+	/* TX bookkeeping (clean: PROD=CONS=0 on bare-metal boot) */
+	uint16_t tx_prod;
+	uint32_t tx_write_ptr;
+	uint32_t tx_ring_start;
+	uint32_t tx_ring_end;
+
+	struct k_work             rx_work;
+	struct k_work_delayable   phy_poll_work;
+};
+
+struct genet_config {
+	uintptr_t       phys_base;
+	size_t          phys_size;
+	void          (*irq0_config)(void);
+	void          (*irq1_config)(void);
+	uint8_t         phy_addr;
+	bool            phy_rgmii_rxid;
+	bool            has_local_mac;
+	const uint8_t  *local_mac;
+};
+
+/* ── Power management ────────────────────────────────────────────────────────
+ * Must run before any UMAC, MDIO, or DMA access.
+ * Mirrors Linux bcmgenet_power_up(GENET_POWER_PASSIVE), GENET v5 external PHY.
+ */
+static int genet_power_up(mm_reg_t base)
+{
+	uint32_t reg = EXT_RD(base, EXT_EXT_PWR_MGMT);
+
+	LOG_DBG("EXT_EXT_PWR_MGMT = 0x%08x", reg);
+
+	/* Clear UMAC DLL/bias gates (VPU sets these after network-boot). */
+	reg &= ~(EXT_PWR_DOWN_DLL | EXT_PWR_DOWN_BIAS | EXT_ENERGY_DET_MASK);
+	/* GENET v5, external non-16nm PHY: clear sub-block power-down bits. */
+	reg &= ~(EXT_PWR_DOWN_PHY_EN | EXT_PWR_DOWN_PHY_RD |
+		 EXT_PWR_DOWN_PHY_SD | EXT_PWR_DOWN_PHY_RX |
+		 EXT_PWR_DOWN_PHY_TX | EXT_IDDQ_GLBL_PWR);
+	/* Pulse PHY-IF reset per Linux (1 ms asserted). */
+	EXT_WR(base, reg | EXT_PHY_RESET, EXT_EXT_PWR_MGMT);
+	k_sleep(K_MSEC(1));
+	EXT_WR(base, reg, EXT_EXT_PWR_MGMT);
+	k_busy_wait(60);   /* DLL lock: Linux udelay(60) */
+
+	if (EXT_RD(base, EXT_EXT_PWR_MGMT) & (EXT_PWR_DOWN_DLL | EXT_PWR_DOWN_BIAS)) {
+		LOG_ERR("UMAC power-up failed: DLL/BIAS still set");
+		return -EIO;
+	}
+	return 0;
+}
+
+/* Pulse SYS_RBUF_FLUSH_CTRL bit 1 — the "Reset MAC" trigger used by Linux
+ * bcmgenet_umac_reset(). In the SYS block, always accessible regardless of
+ * UMAC power state.
+ */
+static void genet_sys_reset(mm_reg_t base)
+{
+	uint32_t reg = SYS_RD(base, SYS_RBUF_FLUSH_CTRL);
+
+	SYS_WR(base, reg |  SYS_RBUF_FLUSH_RESET, SYS_RBUF_FLUSH_CTRL);
+	k_busy_wait(10);
+	SYS_WR(base, reg & ~SYS_RBUF_FLUSH_RESET, SYS_RBUF_FLUSH_CTRL);
+	k_busy_wait(10);
+	SYS_WR(base, 0, SYS_RBUF_FLUSH_CTRL);
+	k_busy_wait(10);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * UMAC + RBUF basic setup (Linux init_umac, set_hw_addr)
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+static void genet_umac_init(mm_reg_t base)
+{
+	/* Software-reset the UMAC. The local-loop bit is set per Linux. */
+	UMAC_WR(base, 0,                              UMAC_CMD);
+	UMAC_WR(base, CMD_SW_RESET | CMD_LCL_LOOP_EN, UMAC_CMD);
+	k_busy_wait(2);
+	UMAC_WR(base, 0,                              UMAC_CMD);
+
+	/* MIB counter reset */
+	UMAC_WR(base, MIB_RESET_RX | MIB_RESET_TX | MIB_RESET_RUNT, UMAC_MIB_CTRL);
+	UMAC_WR(base, 0,                                            UMAC_MIB_CTRL);
+
+	UMAC_WR(base, GENET_MAX_MTU,  UMAC_MAX_FRAME_LEN);
+	RBUF_WR(base, RBUF_ALIGN_2B,  RBUF_CTRL);
+	RBUF_WR(base, 1,              RBUF_TBUF_SIZE_CTRL);
+
+	/* TX FIFO flush */
+	UMAC_WR(base, 1, UMAC_TX_FLUSH);
+	k_busy_wait(10);
+	UMAC_WR(base, 0, UMAC_TX_FLUSH);
+}
+
+static void genet_set_mac(mm_reg_t base, const uint8_t *mac)
+{
+	UMAC_WR(base,
+		((uint32_t)mac[0] << 24) | ((uint32_t)mac[1] << 16) |
+		((uint32_t)mac[2] << 8)  |  (uint32_t)mac[3],
+		UMAC_MAC0);
+	UMAC_WR(base, ((uint32_t)mac[4] << 8) | (uint32_t)mac[5], UMAC_MAC1);
+}
+
+static void genet_set_speed(mm_reg_t base, uint32_t mbps)
+{
+	uint32_t field = (mbps == 1000) ? CMD_SPEED_1000 :
+			 (mbps == 100)  ? CMD_SPEED_100  : CMD_SPEED_10;
+	uint32_t reg;
+
+	/* Set RGMII_LINK once link is confirmed (Linux bcmgenet_mac_config) */
+	reg  = EXT_RD(base, EXT_RGMII_OOB_CTRL) | RGMII_LINK;
+	EXT_WR(base, reg, EXT_RGMII_OOB_CTRL);
+
+	reg  = (UMAC_RD(base, UMAC_CMD) & ~CMD_SPEED_MASK) | field;
+	UMAC_WR(base, reg, UMAC_CMD);
+
+	LOG_INF("speed %u Mbps: UMAC_CMD=0x%08x RGMII=0x%08x",
+		mbps, UMAC_RD(base, UMAC_CMD), EXT_RD(base, EXT_RGMII_OOB_CTRL));
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * EXT block: external-PHY power and RGMII OOB configuration
+ * Linux bcmgenet_phy_power_set + bcmgenet_mii_setup combined.
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+static void genet_ext_init(mm_reg_t base, bool rxid)
+{
+	uint32_t reg;
+
+	/* PHY 25 MHz reference clock — must be on before any other PHY action */
+	reg  = EXT_RD(base, EXT_GPHY_CTRL);
+	reg &= ~EXT_CK25_DIS;
+	EXT_WR(base, reg, EXT_GPHY_CTRL);
+	k_sleep(K_MSEC(1));
+
+	/* Power up + assert PHY hardware reset */
+	reg &= ~(EXT_CFG_IDDQ_BIAS | EXT_CFG_PWR_DOWN | EXT_CFG_IDDQ_GLOBAL_PWR);
+	reg |=   EXT_GPHY_RESET;
+	EXT_WR(base, reg, EXT_GPHY_CTRL);
+	k_sleep(K_MSEC(1));
+
+	/* Release reset; PHY PLL needs ~60us */
+	reg &= ~EXT_GPHY_RESET;
+	EXT_WR(base, reg, EXT_GPHY_CTRL);
+	k_busy_wait(60);
+
+	/* RGMII OOB control: enable RGMII, leave RGMII_LINK off until link up */
+	reg  = EXT_RD(base, EXT_RGMII_OOB_CTRL);
+	reg |= RGMII_MODE_EN;
+	reg &= ~OOB_DISABLE;
+	if (rxid) {
+		reg |= ID_MODE_DIS;
+	} else {
+		reg &= ~ID_MODE_DIS;
+	}
+	EXT_WR(base, reg, EXT_RGMII_OOB_CTRL);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * MDIO (UMAC offset 0x614)
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+static int genet_mdio_wait(mm_reg_t base)
+{
+	for (int i = 0; i < 1000; i++) {
+		if (!(UMAC_RD(base, UMAC_MDIO_CMD) & MDIO_START_BUSY)) {
+			return 0;
+		}
+		k_busy_wait(10);
+	}
+	return -ETIMEDOUT;
+}
+
+static int genet_mdio_read(mm_reg_t base, uint8_t phy, uint8_t reg, uint16_t *val)
+{
+	uint32_t cmd = MDIO_RD | ((uint32_t)phy << MDIO_PMD_SHIFT) |
+		       ((uint32_t)reg << MDIO_REG_SHIFT);
+	int ret;
+
+	UMAC_WR(base, cmd,                    UMAC_MDIO_CMD);
+	UMAC_WR(base, cmd | MDIO_START_BUSY,  UMAC_MDIO_CMD);
+	ret = genet_mdio_wait(base);
+	if (ret) {
+		return ret;
+	}
+	cmd = UMAC_RD(base, UMAC_MDIO_CMD);
+	if (cmd & MDIO_READ_FAIL) {
+		return -EIO;
+	}
+	*val = (uint16_t)(cmd & MDIO_DATA_MASK);
+	return 0;
+}
+
+static int genet_mdio_write(mm_reg_t base, uint8_t phy, uint8_t reg, uint16_t val)
+{
+	uint32_t cmd = MDIO_WR | ((uint32_t)phy << MDIO_PMD_SHIFT) |
+		       ((uint32_t)reg << MDIO_REG_SHIFT) | val;
+
+	UMAC_WR(base, cmd,                    UMAC_MDIO_CMD);
+	UMAC_WR(base, cmd | MDIO_START_BUSY,  UMAC_MDIO_CMD);
+	return genet_mdio_wait(base);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * BCM54213PE shadow-register helpers — RGMII-RXID clock-delay configuration.
+ * Mirrors bcm54xx_config_clock_delay() from U-Boot / Linux broadcom PHY drv.
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+#define BCM54XX_SHD_REG            0x1C
+#define BCM54XX_SHD_VAL(n)         ((uint16_t)((n) << 10))
+#define BCM54XX_SHD_WRITE          0x8000U
+#define BCM54810_SHD_CLK_CTL       0x03
+#define BCM54810_GTXCLK_EN         0x0200U
+
+#define BCM54XX_AUX_CTL            0x18
+#define BCM54XX_AUXCTL_MISC        0x7
+#define BCM54XX_AUXCTL_READ_SEL(n) ((uint16_t)(0x7 | ((n) << 12)))
+#define BCM54XX_AUXCTL_WREN        0x8000U
+#define BCM54XX_AUXCTL_RGMII_SKEW  0x0100U
+
+static void genet_phy_bcm54213_config(mm_reg_t base, uint8_t phy, bool rxid)
+{
+	uint16_t val, readback;
+
+	/* AUX CTL shadow 7 — RX clock skew */
+	genet_mdio_write(base, phy, BCM54XX_AUX_CTL,
+			 BCM54XX_AUXCTL_READ_SEL(BCM54XX_AUXCTL_MISC));
+	genet_mdio_read(base, phy, BCM54XX_AUX_CTL, &val);
+	val |= BCM54XX_AUXCTL_WREN;
+	if (rxid) {
+		val |= BCM54XX_AUXCTL_RGMII_SKEW;
+	} else {
+		val &= ~BCM54XX_AUXCTL_RGMII_SKEW;
+	}
+	genet_mdio_write(base, phy, BCM54XX_AUX_CTL,
+			 (uint16_t)(BCM54XX_AUXCTL_MISC | val));
+
+	/* CLK CTL shadow 0x03 — TX clock delay */
+	genet_mdio_write(base, phy, BCM54XX_SHD_REG,
+			 BCM54XX_SHD_VAL(BCM54810_SHD_CLK_CTL));
+	genet_mdio_read(base, phy, BCM54XX_SHD_REG, &val);
+	val &= 0x03FFU;
+	if (rxid) {
+		val &= ~BCM54810_GTXCLK_EN;
+	} else {
+		val |=  BCM54810_GTXCLK_EN;
+	}
+	genet_mdio_write(base, phy, BCM54XX_SHD_REG,
+			 (uint16_t)(BCM54XX_SHD_WRITE |
+				    BCM54XX_SHD_VAL(BCM54810_SHD_CLK_CTL) | val));
+
+	/* Read-back for confirmation */
+	genet_mdio_write(base, phy, BCM54XX_SHD_REG,
+			 BCM54XX_SHD_VAL(BCM54810_SHD_CLK_CTL));
+	genet_mdio_read(base, phy, BCM54XX_SHD_REG, &readback);
+	readback &= 0x03FFU;
+
+	LOG_INF("PHY BCM54213: CLK_CTL=0x%03x (GTXCLK=%u SKEW=%u rxid=%d)",
+		readback,
+		!!(readback & BCM54810_GTXCLK_EN),
+		!!(val & BCM54XX_AUXCTL_RGMII_SKEW),
+		rxid);
+}
+
+static int genet_phy_init(mm_reg_t base, uint8_t phy, bool rxid)
+{
+	uint16_t v;
+	int ret = genet_mdio_write(base, phy, MII_BMCR, BMCR_RESET);
+
+	if (ret) {
+		return ret;
+	}
+	for (int i = 0; i < 500; i++) {
+		ret = genet_mdio_read(base, phy, MII_BMCR, &v);
+		if (ret) {
+			return ret;
+		}
+		if (!(v & BMCR_RESET)) {
+			break;
+		}
+		k_sleep(K_MSEC(1));
+	}
+
+	genet_phy_bcm54213_config(base, phy, rxid);
+
+	v = ADVERTISE_CSMA |
+	    ADVERTISE_10HALF  | ADVERTISE_10FULL |
+	    ADVERTISE_100HALF | ADVERTISE_100FULL |
+	    ADVERTISE_PAUSE;
+	genet_mdio_write(base, phy, MII_ADVERTISE, v);
+	genet_mdio_write(base, phy, MII_CTRL1000,  ADVERTISE_1000FULL);
+
+	return genet_mdio_write(base, phy, MII_BMCR,
+				BMCR_ANENABLE | BMCR_ANRESTART);
+}
+
+static int genet_phy_wait_link(mm_reg_t base, uint8_t phy, uint32_t *speed)
+{
+	uint16_t bmsr, stat1000, lpa;
+
+	LOG_INF("waiting for PHY link...");
+	for (int i = 0; i < 5000; i++) {
+		genet_mdio_read(base, phy, MII_BMSR, &bmsr);
+		genet_mdio_read(base, phy, MII_BMSR, &bmsr);   /* latch-low */
+		if ((bmsr & BMSR_LSTATUS) && (bmsr & BMSR_ANEGCOMPLETE)) {
+			break;
+		}
+		k_sleep(K_MSEC(1));
+		if (i == 4999) {
+			LOG_WRN("PHY link timeout");
+			return -ETIMEDOUT;
+		}
+	}
+
+	genet_mdio_read(base, phy, MII_STAT1000, &stat1000);
+	genet_mdio_read(base, phy, MII_LPA,      &lpa);
+
+	if (stat1000 & LPA_1000FULL) {
+		*speed = 1000;
+	} else if (lpa & (ADVERTISE_100FULL | ADVERTISE_100HALF)) {
+		*speed = 100;
+	} else {
+		*speed = 10;
+	}
+	LOG_INF("PHY link up: %u Mbps (BMSR=0x%04x LPA=0x%04x STAT1000=0x%04x)",
+		*speed, bmsr, lpa, stat1000);
+	return 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * DMA — bring rings into known state, then enable
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+static void genet_dma_disable(mm_reg_t base)
+{
+	TDMA_CTRL_WR(base, DMA_CTRL, TDMA_CTRL_RD(base, DMA_CTRL) & ~DMA_EN);
+	for (uint32_t i = 0; i < DMA_TIMEOUT_USEC; i++) {
+		if (TDMA_CTRL_RD(base, DMA_STATUS) & DMA_DISABLED) {
+			break;
+		}
+		k_busy_wait(1);
+	}
+
+	RDMA_CTRL_WR(base, DMA_CTRL, RDMA_CTRL_RD(base, DMA_CTRL) & ~DMA_EN);
+	for (uint32_t i = 0; i < DMA_TIMEOUT_USEC; i++) {
+		if (RDMA_CTRL_RD(base, DMA_STATUS) & DMA_DISABLED) {
+			break;
+		}
+		k_busy_wait(1);
+	}
+
+	TDMA_CTRL_WR(base, DMA_RING_CFG, 0);
+	TDMA_CTRL_WR(base, DMA_CTRL,     0);
+	RDMA_CTRL_WR(base, DMA_RING_CFG, 0);
+	RDMA_CTRL_WR(base, DMA_CTRL,     0);
+
+	INTRL2_0_WR(base, 0xFFFFFFFF, INTRL2_CPU_MASK_SET);
+	INTRL2_1_WR(base, 0xFFFFFFFF, INTRL2_CPU_MASK_SET);
+	INTRL2_0_WR(base, 0xFFFFFFFF, INTRL2_CPU_CLEAR);
+	INTRL2_1_WR(base, 0xFFFFFFFF, INTRL2_CPU_CLEAR);
+}
+
+static void genet_init_rx_ring(mm_reg_t base, struct genet_data *d)
+{
+	const uint32_t ring = GENET_RX_RING;
+	const uint32_t n    = GENET_NUM_RX_DESC;
+	const uint32_t s    = GENET_RX_DESC_START;
+
+	RDMA_RING_WR(base, ring, RING_HW_PTR_LO,        0);
+	RDMA_RING_WR(base, ring, RING_HW_PTR_HI,        0);
+	RDMA_RING_WR(base, ring, RING_SW_PTR_LO,        0);
+	RDMA_RING_WR(base, ring, RING_SW_PTR_HI,        0);
+	RDMA_RING_WR(base, ring, RING_HW_INDEX,         0);
+	RDMA_RING_WR(base, ring, RING_SW_INDEX,         0);
+	RDMA_RING_WR(base, ring, RING_START_ADDR_LO,    DESC_START_ADDR(s));
+	RDMA_RING_WR(base, ring, RING_START_ADDR_HI,    0);
+	RDMA_RING_WR(base, ring, RING_END_ADDR_LO,      DESC_END_ADDR(s, n));
+	RDMA_RING_WR(base, ring, RING_END_ADDR_HI,      0);
+	RDMA_RING_WR(base, ring, RING_BUF_SIZE,
+		     RING_BUF_SIZE_VAL(n, GENET_RX_BUF_SIZE));
+	RDMA_RING_WR(base, ring, RING_MBUF_DONE_THRESH, 1);
+	RDMA_RING_WR(base, ring, RING_XON_XOFF,         RDMA_XON_XOFF_VAL);
+
+	for (uint32_t i = 0; i < n; i++) {
+		uintptr_t pa = (uintptr_t)genet_rx_buf[i];
+
+		sys_cache_data_invd_range(genet_rx_buf[i],
+			ROUND_UP(GENET_RX_BUF_SIZE, GENET_BUF_ALIGN));
+		RDESC_WR(base, s + i, DMA_DESC_ADDRESS_LO, GENET_DMA_ADDR(pa));
+		RDESC_WR(base, s + i, DMA_DESC_ADDRESS_HI, 0);
+		RDESC_WR(base, s + i, DMA_DESC_LENGTH_STATUS,
+			 ((uint32_t)GENET_RX_BUF_SIZE << DMA_BUFLENGTH_SHIFT) | DMA_OWN);
+	}
+
+	d->rx_cons     = 0;
+	d->rx_desc_pos = 0;
+}
+
+static void genet_init_tx_ring(mm_reg_t base, struct genet_data *d)
+{
+	const uint32_t ring = GENET_TX_RING;
+	const uint32_t end  = GENET_TOTAL_DESC * GENET_WORDS_PER_BD - 1U;
+
+	TDMA_RING_WR(base, ring, RING_START_ADDR_LO,    0);
+	TDMA_RING_WR(base, ring, RING_START_ADDR_HI,    0);
+	TDMA_RING_WR(base, ring, RING_END_ADDR_LO,      end);
+	TDMA_RING_WR(base, ring, RING_END_ADDR_HI,      0);
+	TDMA_RING_WR(base, ring, RING_HW_PTR_LO,        0);
+	TDMA_RING_WR(base, ring, RING_HW_PTR_HI,        0);
+	TDMA_RING_WR(base, ring, RING_SW_PTR_LO,        0);
+	TDMA_RING_WR(base, ring, RING_SW_PTR_HI,        0);
+	TDMA_RING_WR(base, ring, RING_HW_INDEX,         0);   /* CONS=0 */
+	TDMA_RING_WR(base, ring, RING_SW_INDEX,         0);   /* PROD=0 */
+	TDMA_RING_WR(base, ring, RING_MBUF_DONE_THRESH, 1);
+	TDMA_RING_WR(base, ring, RING_XON_XOFF,         0);
+	TDMA_RING_WR(base, ring, RING_BUF_SIZE,
+		     RING_BUF_SIZE_VAL(GENET_TOTAL_DESC, GENET_TX_BUF_SIZE));
+
+	d->tx_prod       = 0;
+	d->tx_write_ptr  = 0;
+	d->tx_ring_start = 0;
+	d->tx_ring_end   = end;
+}
+
+static void genet_dma_enable(mm_reg_t base)
+{
+	RDMA_CTRL_WR(base, DMA_SCB_BURST_SIZE, DMA_SCB_BURST_VAL);
+	TDMA_CTRL_WR(base, DMA_SCB_BURST_SIZE, DMA_SCB_BURST_VAL);
+	TDMA_CTRL_WR(base, DMA_ARB_CTRL,       DMA_ARBITER_SP);
+
+	RDMA_CTRL_WR(base, DMA_RING_CFG, DMA_RING_CFG_EN(GENET_RX_RING));
+	RDMA_CTRL_WR(base, DMA_CTRL,     DMA_EN | DMA_RING_EN(GENET_RX_RING));
+
+	TDMA_CTRL_WR(base, DMA_RING_CFG, DMA_RING_CFG_EN(GENET_TX_RING));
+	TDMA_CTRL_WR(base, DMA_CTRL,     DMA_EN | DMA_RING_EN(GENET_TX_RING));
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * TX
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+static int genet_tx(const struct device *dev, struct net_pkt *pkt)
+{
+	struct genet_data *d   = dev->data;
+	mm_reg_t           b   = d->base;
+	size_t             len = net_pkt_get_len(pkt);
+	uint32_t           abs_desc, desc_idx, status;
+	uint16_t           target_cons;
+
+	if (len > GENET_TX_BUF_SIZE) {
+		return -EMSGSIZE;
+	}
+
+	abs_desc = d->tx_write_ptr / GENET_WORDS_PER_BD;
+	desc_idx = abs_desc % GENET_NUM_TX_DESC;
+
+	net_pkt_cursor_init(pkt);
+	if (net_pkt_read(pkt, genet_tx_buf[desc_idx], len)) {
+		return -EIO;
+	}
+
+	sys_cache_data_flush_range(genet_tx_buf[desc_idx],
+				   ROUND_UP(len, GENET_BUF_ALIGN));
+	barrier_dmem_fence_full();
+
+	status = ((uint32_t)len << DMA_BUFLENGTH_SHIFT) |
+		 (0x3F << DMA_TX_QTAG_SHIFT) |
+		 DMA_SOP | DMA_EOP | DMA_TX_APPEND_CRC;
+
+	TDESC_WR(b, abs_desc, DMA_DESC_ADDRESS_LO,
+		 GENET_DMA_ADDR(genet_tx_buf[desc_idx]));
+	TDESC_WR(b, abs_desc, DMA_DESC_ADDRESS_HI,    0);
+	TDESC_WR(b, abs_desc, DMA_DESC_LENGTH_STATUS, status);
+
+	d->tx_write_ptr += GENET_WORDS_PER_BD;
+	if (d->tx_write_ptr > d->tx_ring_end) {
+		d->tx_write_ptr = d->tx_ring_start;
+	}
+
+	d->tx_prod   = (d->tx_prod + 1) & DMA_P_INDEX_MASK;
+	target_cons  = d->tx_prod;
+	TDMA_RING_WR(b, GENET_TX_RING, RING_SW_INDEX, d->tx_prod);
+
+	for (int i = 0; i < 50000; i++) {
+		uint16_t cons = (uint16_t)(TDMA_RING_RD(b, GENET_TX_RING,
+							RING_HW_INDEX) &
+					   DMA_C_INDEX_MASK);
+		if (cons == target_cons) {
+			return 0;
+		}
+		k_busy_wait(10);
+	}
+	LOG_WRN("TX timeout prod=%u", d->tx_prod);
+	return 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * RX
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+static void genet_rx_work(struct k_work *work)
+{
+	struct genet_data *d = CONTAINER_OF(work, struct genet_data, rx_work);
+	mm_reg_t           b = d->base;
+	uint16_t prod = (uint16_t)(RDMA_RING_RD(b, GENET_RX_RING, RING_HW_INDEX)
+				   & DMA_P_INDEX_MASK);
+	uint16_t pending = (prod - d->rx_cons) & DMA_P_INDEX_MASK;
+
+	while (pending--) {
+		uint32_t idx = d->rx_desc_pos % GENET_NUM_RX_DESC;
+		uint32_t st;
+		uint16_t plen;
+		struct net_pkt *pkt;
+
+		barrier_dmem_fence_full();
+		sys_cache_data_invd_range(genet_rx_buf[idx],
+			ROUND_UP(GENET_RX_BUF_SIZE, GENET_BUF_ALIGN));
+
+		st = RDESC_RD(b, GENET_RX_DESC_START + idx, DMA_DESC_LENGTH_STATUS);
+		if (st & DMA_RX_ERROR_MASK) {
+			goto next;
+		}
+		if (!(st & DMA_EOP) || !(st & DMA_SOP)) {
+			goto next;
+		}
+		plen = (uint16_t)((st >> DMA_BUFLENGTH_SHIFT) & DMA_BUFLENGTH_MASK);
+		if (plen <= GENET_RX_DATA_OFFSET) {
+			goto next;
+		}
+		plen -= GENET_RX_DATA_OFFSET;
+
+		pkt = net_pkt_rx_alloc_with_buffer(d->iface, plen, AF_UNSPEC, 0,
+						   K_NO_WAIT);
+		if (!pkt) {
+			goto next;
+		}
+		if (net_pkt_write(pkt, genet_rx_buf[idx] + GENET_RX_DATA_OFFSET,
+				  plen)) {
+			net_pkt_unref(pkt);
+			goto next;
+		}
+		net_pkt_cursor_init(pkt);
+		if (net_recv_data(d->iface, pkt) < 0) {
+			net_pkt_unref(pkt);
+		}
+next:
+		RDESC_WR(b, GENET_RX_DESC_START + idx, DMA_DESC_LENGTH_STATUS,
+			 ((uint32_t)GENET_RX_BUF_SIZE << DMA_BUFLENGTH_SHIFT) | DMA_OWN);
+		d->rx_desc_pos++;
+		d->rx_cons = (d->rx_cons + 1) & DMA_P_INDEX_MASK;
+	}
+
+	RDMA_RING_WR(b, GENET_RX_RING, RING_SW_INDEX, d->rx_cons);
+	INTRL2_0_WR(b, UMAC_IRQ_RXDMA_MBDONE, INTRL2_CPU_MASK_CLEAR);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * PHY polling (external PHY: link-up/down interrupts don't fire)
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+static void genet_phy_poll(struct k_work *work)
+{
+	struct k_work_delayable *dw = k_work_delayable_from_work(work);
+	struct genet_data *d = CONTAINER_OF(dw, struct genet_data, phy_poll_work);
+	uint16_t bmsr;
+
+	(void)genet_mdio_read(d->base, d->phy_addr, MII_BMSR, &bmsr);
+	if (genet_mdio_read(d->base, d->phy_addr, MII_BMSR, &bmsr) == 0) {
+		bool up = !!(bmsr & BMSR_LSTATUS);
+
+		if (up != d->link_up) {
+			d->link_up = up;
+			LOG_INF("PHY link %s", up ? "UP" : "DOWN");
+			if (d->iface) {
+				if (up) {
+					uint32_t mbps;
+
+					if (genet_phy_wait_link(d->base,
+								d->phy_addr,
+								&mbps) == 0) {
+						genet_set_speed(d->base, mbps);
+					}
+					net_eth_carrier_on(d->iface);
+				} else {
+					net_eth_carrier_off(d->iface);
+				}
+			}
+		}
+	}
+	k_work_schedule(dw, K_MSEC(GENET_PHY_POLL_INTERVAL));
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * IRQ handlers
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+static void genet_irq0_handler(const struct device *dev)
+{
+	struct genet_data *d = dev->data;
+	mm_reg_t           b = d->base;
+	uint32_t stat;
+
+	barrier_dmem_fence_full();
+	stat = INTRL2_0_RD(b, INTRL2_CPU_STAT);
+	INTRL2_0_WR(b, stat, INTRL2_CPU_CLEAR);
+
+	if (stat & UMAC_IRQ_RXDMA_MBDONE) {
+		INTRL2_0_WR(b, UMAC_IRQ_RXDMA_MBDONE, INTRL2_CPU_MASK_SET);
+		k_work_submit(&d->rx_work);
+	}
+	/* TX completion polled in genet_tx; LINK_UP/DOWN don't fire on
+	 * external PHY (handled by genet_phy_poll).
+	 */
+}
+
+static void genet_irq1_handler(const struct device *dev)
+{
+	mm_reg_t b = ((struct genet_data *)dev->data)->base;
+	uint32_t stat = INTRL2_1_RD(b, INTRL2_CPU_STAT);
+
+	INTRL2_1_WR(b, stat, INTRL2_CPU_CLEAR);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Net device API
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+static void genet_iface_init(struct net_if *iface)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct genet_data   *d   = dev->data;
+
+	d->iface = iface;
+	net_if_set_link_addr(iface, d->mac, sizeof(d->mac), NET_LINK_ETHERNET);
+	ethernet_init(iface);
+
+	if (d->link_up) {
+		net_eth_carrier_on(iface);
+	} else {
+		net_eth_carrier_off(iface);
+	}
+	LOG_INF("MAC: %02x:%02x:%02x:%02x:%02x:%02x",
+		d->mac[0], d->mac[1], d->mac[2],
+		d->mac[3], d->mac[4], d->mac[5]);
+}
+
+static int genet_start(const struct device *dev)
+{
+	struct genet_data *d = dev->data;
+	mm_reg_t b = d->base;
+
+	UMAC_WR(b, UMAC_RD(b, UMAC_CMD) | CMD_TX_EN | CMD_RX_EN, UMAC_CMD);
+	INTRL2_0_WR(b, UMAC_IRQ_RXDMA_MBDONE | UMAC_IRQ_TXDMA_MBDONE,
+		    INTRL2_CPU_MASK_CLEAR);
+	return 0;
+}
+
+static int genet_stop(const struct device *dev)
+{
+	struct genet_data *d = dev->data;
+	mm_reg_t b = d->base;
+
+	UMAC_WR(b, 0, UMAC_CMD);
+	INTRL2_0_WR(b, 0xFFFFFFFF, INTRL2_CPU_MASK_SET);
+	return 0;
+}
+
+static enum ethernet_hw_caps genet_caps(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE;
+}
+
+static const struct ethernet_api genet_api = {
+	.iface_api.init   = genet_iface_init,
+	.start            = genet_start,
+	.stop             = genet_stop,
+	.get_capabilities = genet_caps,
+	.send             = genet_tx,
+};
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Driver init — runs at CONFIG_ETH_INIT_PRIORITY
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+static int genet_init(const struct device *dev)
+{
+	struct genet_data        *d = dev->data;
+	const struct genet_config *c = dev->config;
+	uint32_t mbps;
+	mm_reg_t b;
+	int ret;
+
+	d->dev            = dev;
+	d->phy_addr       = c->phy_addr;
+	d->phy_rgmii_rxid = c->phy_rgmii_rxid;
+	k_work_init(&d->rx_work, genet_rx_work);
+	k_work_init_delayable(&d->phy_poll_work, genet_phy_poll);
+
+	device_map(&d->base, c->phys_base, c->phys_size, K_MEM_CACHE_NONE);
+	b = d->base;
+
+	LOG_DBG("GENET v5 phys=0x%08lx virt=0x%08lx",
+		(unsigned long)c->phys_base, (unsigned long)b);
+
+	/* Power up UMAC before touching it (clears VPU power-down state). */
+	ret = genet_power_up(b);
+	if (ret) {
+		return ret;
+	}
+
+	/* MAC-wide reset via SYS block; clears any state from VPU's GENET use. */
+	genet_sys_reset(b);
+
+	genet_dma_disable(b);
+	genet_umac_init(b);
+
+	if (c->has_local_mac) {
+		memcpy(d->mac, c->local_mac, 6);
+	} else {
+		sys_rand_get(d->mac, 6);
+		d->mac[0] = (d->mac[0] & ~0x01) | 0x02;
+	}
+	genet_set_mac(b, d->mac);
+	SYS_WR(b, PORT_MODE_EXT_GPHY, SYS_PORT_CTRL);
+
+	genet_ext_init(b, c->phy_rgmii_rxid);
+
+	ret = genet_phy_init(b, c->phy_addr, c->phy_rgmii_rxid);
+	if (ret) {
+		LOG_ERR("PHY init failed: %d", ret);
+		return ret;
+	}
+
+	genet_init_rx_ring(b, d);
+	genet_init_tx_ring(b, d);
+	genet_dma_enable(b);
+
+	INTRL2_0_WR(b, 0xFFFFFFFF, INTRL2_CPU_MASK_SET);
+	INTRL2_0_WR(b, 0xFFFFFFFF, INTRL2_CPU_CLEAR);
+	INTRL2_0_WR(b, UMAC_IRQ_RXDMA_MBDONE | UMAC_IRQ_TXDMA_MBDONE,
+		    INTRL2_CPU_MASK_CLEAR);
+	INTRL2_1_WR(b, 0xFFFFFFFF, INTRL2_CPU_MASK_SET);
+	INTRL2_1_WR(b, 0xFFFFFFFF, INTRL2_CPU_CLEAR);
+	c->irq0_config();
+	c->irq1_config();
+
+	UMAC_WR(b, CMD_TX_EN | CMD_RX_EN, UMAC_CMD);
+
+	ret = genet_phy_wait_link(b, c->phy_addr, &mbps);
+	if (ret == 0) {
+		genet_set_speed(b, mbps);
+		d->link_up = true;
+	} else {
+		LOG_WRN("no PHY link at boot");
+	}
+
+	k_work_schedule(&d->phy_poll_work, K_MSEC(GENET_PHY_POLL_INTERVAL));
+	LOG_INF("GENET ready");
+	return 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Device-tree instantiation
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+#define GENET_DEFINE(n)                                                         \
+static const uint8_t genet_mac_##n[] =                                          \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, local_mac_address),                \
+		    (DT_INST_PROP(n, local_mac_address)),                       \
+		    ({0, 0, 0, 0, 0, 0}));                                      \
+static void genet_irq0_config_##n(void)                                         \
+{                                                                               \
+	IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, 0),                                  \
+		    DT_INST_IRQ_BY_IDX(n, 0, priority),                         \
+		    genet_irq0_handler, DEVICE_DT_INST_GET(n), 0);              \
+	irq_enable(DT_INST_IRQN_BY_IDX(n, 0));                                  \
+}                                                                               \
+static void genet_irq1_config_##n(void)                                         \
+{                                                                               \
+	IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, 1),                                  \
+		    DT_INST_IRQ_BY_IDX(n, 1, priority),                         \
+		    genet_irq1_handler, DEVICE_DT_INST_GET(n), 0);              \
+	irq_enable(DT_INST_IRQN_BY_IDX(n, 1));                                  \
+}                                                                               \
+static struct genet_data genet_data_##n;                                        \
+static const struct genet_config genet_config_##n = {                           \
+	.phys_base      = DT_INST_REG_ADDR(n),                                  \
+	.phys_size      = DT_INST_REG_SIZE(n),                                  \
+	.irq0_config    = genet_irq0_config_##n,                                \
+	.irq1_config    = genet_irq1_config_##n,                                \
+	.phy_addr       = DT_INST_PROP(n, phy_addr),                            \
+	.phy_rgmii_rxid = (DT_INST_PROP_OR(n, rx_internal_delay_ps, 0) > 0),    \
+	.has_local_mac  = DT_INST_NODE_HAS_PROP(n, local_mac_address),          \
+	.local_mac      = genet_mac_##n,                                        \
+};                                                                              \
+ETH_NET_DEVICE_DT_INST_DEFINE(n, genet_init, NULL,                              \
+			      &genet_data_##n, &genet_config_##n,               \
+			      CONFIG_ETH_INIT_PRIORITY,                         \
+			      &genet_api, NET_ETH_MTU);
+
+DT_INST_FOREACH_STATUS_OKAY(GENET_DEFINE)

--- a/drivers/ethernet/eth_bcm_genet.h
+++ b/drivers/ethernet/eth_bcm_genet.h
@@ -1,0 +1,279 @@
+/*
+ * BCM2711 GENET v5 Ethernet — register definitions.
+ *
+ * Layout and constants ported from Linux 5.4
+ *   drivers/net/ethernet/broadcom/genet/bcmgenet.h
+ *
+ *   Copyright (c) 2026 Khaled Abdalla <khaled.3bdulaziz@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ETH_BCM_GENET_H
+#define ETH_BCM_GENET_H
+
+#include <zephyr/sys/sys_io.h>
+
+/* ───── Top-level GENET block offsets ───────────────────────────────────── */
+#define GENET_SYS_OFF           0x0000
+#define GENET_GR_BRIDGE_OFF     0x0040
+#define GENET_EXT_OFF           0x0080
+#define GENET_INTRL2_0_OFF      0x0200
+#define GENET_INTRL2_1_OFF      0x0240
+#define GENET_RBUF_OFF          0x0300
+#define GENET_UMAC_OFF          0x0800
+#define GENET_HFB_OFF           0x8000
+#define GENET_HFB_REG_OFF       0xFC00
+/* DMA offsets are GENET-version dependent; v4/v5 (BCM2711): */
+#define GENET_RDMA_OFF          0x2000
+#define GENET_TDMA_OFF          0x4000
+
+/* ───── SYS block (0x0000) ──────────────────────────────────────────────── */
+#define SYS_REV_CTRL            0x00
+#define SYS_PORT_CTRL           0x04
+#define  PORT_MODE_EXT_GPHY     3
+#define SYS_RBUF_FLUSH_CTRL     0x08
+#define  SYS_RBUF_FLUSH_RESET   (1U << 1)
+#define SYS_TBUF_FLUSH_CTRL     0x0C
+
+/* ───── EXT block (0x0080) ──────────────────────────────────────────────── */
+/* EXT_EXT_PWR_MGMT gates UMAC DLL/bias — must be cleared before any UMAC reg */
+#define EXT_EXT_PWR_MGMT        0x00
+#define  EXT_PWR_DOWN_BIAS      (1U << 0)
+#define  EXT_PWR_DOWN_DLL       (1U << 1)
+#define  EXT_PWR_DOWN_PHY       (1U << 2)
+#define  EXT_PWR_DN_EN_LD       (1U << 3)
+#define  EXT_ENERGY_DET         (1U << 4)
+#define  EXT_IDDQ_FROM_PHY      (1U << 5)
+#define  EXT_IDDQ_GLBL_PWR      (1U << 7)
+#define  EXT_PHY_RESET          (1U << 8)
+#define  EXT_ENERGY_DET_MASK    (1U << 12)
+#define  EXT_PWR_DOWN_PHY_TX    (1U << 16)
+#define  EXT_PWR_DOWN_PHY_RX    (1U << 17)
+#define  EXT_PWR_DOWN_PHY_SD    (1U << 18)
+#define  EXT_PWR_DOWN_PHY_RD    (1U << 19)
+#define  EXT_PWR_DOWN_PHY_EN    (1U << 20)
+
+#define EXT_RGMII_OOB_CTRL      0x0C
+#define  RGMII_MODE_EN_V123     (1U << 0)
+#define  RGMII_LINK             (1U << 4)
+#define  OOB_DISABLE            (1U << 5)
+#define  RGMII_MODE_EN          (1U << 6)
+#define  ID_MODE_DIS            (1U << 16)
+
+#define EXT_GPHY_CTRL           0x1C
+#define  EXT_CFG_IDDQ_BIAS      (1U << 0)
+#define  EXT_CFG_PWR_DOWN       (1U << 1)
+#define  EXT_CFG_IDDQ_GLOBAL_PWR (1U << 3)
+#define  EXT_CK25_DIS           (1U << 4)
+#define  EXT_GPHY_RESET         (1U << 5)
+
+/* ───── INTRL2 (interrupt registers, two banks at 0x0200 and 0x0240) ────── */
+#define INTRL2_CPU_STAT         0x00
+#define INTRL2_CPU_SET          0x04
+#define INTRL2_CPU_CLEAR        0x08
+#define INTRL2_CPU_MASK_STATUS  0x0C
+#define INTRL2_CPU_MASK_SET     0x10
+#define INTRL2_CPU_MASK_CLEAR   0x14
+
+/* INTRL2_0 bits */
+#define UMAC_IRQ_LINK_UP        (1U << 4)
+#define UMAC_IRQ_LINK_DOWN      (1U << 5)
+#define UMAC_IRQ_RXDMA_MBDONE   (1U << 13)
+#define UMAC_IRQ_TXDMA_MBDONE   (1U << 16)
+#define UMAC_IRQ_MDIO_DONE      (1U << 23)
+#define UMAC_IRQ_MDIO_ERROR     (1U << 24)
+
+/* ───── RBUF block (0x0300) ─────────────────────────────────────────────── */
+#define RBUF_CTRL               0x00
+#define  RBUF_64B_EN            (1U << 0)
+#define  RBUF_ALIGN_2B          (1U << 1)
+#define  RBUF_BAD_DIS           (1U << 2)
+#define RBUF_CHK_CTRL           0x14
+#define RBUF_TBUF_SIZE_CTRL     0xB4
+
+/* ───── UMAC block (0x0800) ─────────────────────────────────────────────── */
+#define UMAC_CMD                0x008
+#define  CMD_TX_EN              (1U << 0)
+#define  CMD_RX_EN              (1U << 1)
+#define  CMD_SPEED_10           (0U << 2)
+#define  CMD_SPEED_100          (1U << 2)
+#define  CMD_SPEED_1000         (2U << 2)
+#define  CMD_SPEED_MASK         (3U << 2)
+#define  CMD_SW_RESET           (1U << 13)
+#define  CMD_LCL_LOOP_EN        (1U << 15)
+#define UMAC_MAC0               0x00C
+#define UMAC_MAC1               0x010
+#define UMAC_MAX_FRAME_LEN      0x014
+#define UMAC_TX_FLUSH           0x334
+#define UMAC_MIB_CTRL           0x580
+#define  MIB_RESET_RX           (1U << 0)
+#define  MIB_RESET_RUNT         (1U << 1)
+#define  MIB_RESET_TX           (1U << 2)
+#define UMAC_MDIO_CMD           0x614
+#define  MDIO_START_BUSY        (1U << 29)
+#define  MDIO_READ_FAIL         (1U << 28)
+#define  MDIO_RD                (2U << 26)
+#define  MDIO_WR                (1U << 26)
+#define  MDIO_PMD_SHIFT         21
+#define  MDIO_REG_SHIFT         16
+#define  MDIO_DATA_MASK         0xFFFF
+
+#define GENET_MAX_MTU           1536U
+
+/* ───── DMA descriptor (12 bytes for v4/v5) ─────────────────────────────── */
+#define DMA_DESC_LENGTH_STATUS  0x00
+#define DMA_DESC_ADDRESS_LO     0x04
+#define DMA_DESC_ADDRESS_HI     0x08
+#define GENET_DESC_SIZE         12U
+
+#define DMA_BUFLENGTH_MASK      0x0FFF
+#define DMA_BUFLENGTH_SHIFT     16
+#define DMA_OWN                 0x8000
+#define DMA_EOP                 0x4000
+#define DMA_SOP                 0x2000
+#define DMA_WRAP                0x1000
+#define DMA_TX_QTAG_SHIFT       7
+#define DMA_TX_APPEND_CRC       0x0040
+
+#define DMA_RX_OV               0x0001
+#define DMA_RX_CRC_ERROR        0x0002
+#define DMA_RX_RXER             0x0004
+#define DMA_RX_NO               0x0008
+#define DMA_RX_LG               0x0010
+#define DMA_RX_ERROR_MASK       (DMA_RX_OV | DMA_RX_CRC_ERROR | \
+				 DMA_RX_RXER | DMA_RX_LG)
+
+#define DMA_P_INDEX_MASK        0xFFFF
+#define DMA_C_INDEX_MASK        0xFFFF
+
+/* ───── DMA layout (v4/v5) ──────────────────────────────────────────────── */
+#define GENET_TOTAL_DESC        256U
+#define GENET_WORDS_PER_BD      3U
+#define DMA_RING_SIZE           0x40U
+#define DESC_INDEX              16U                       /* default ring */
+#define NUM_DMA_RINGS           (DESC_INDEX + 1U)
+
+#define DMA_DESC_ARRAY_SIZE     (GENET_TOTAL_DESC * GENET_WORDS_PER_BD * 4U)
+#define DMA_RINGS_SIZE          (DMA_RING_SIZE * NUM_DMA_RINGS)
+
+#define RDMA_RING_BASE(n)       (GENET_RDMA_OFF + DMA_DESC_ARRAY_SIZE + \
+				 (n) * DMA_RING_SIZE)
+#define TDMA_RING_BASE(n)       (GENET_TDMA_OFF + DMA_DESC_ARRAY_SIZE + \
+				 (n) * DMA_RING_SIZE)
+#define RDMA_CTRL_BASE          (GENET_RDMA_OFF + DMA_DESC_ARRAY_SIZE + DMA_RINGS_SIZE)
+#define TDMA_CTRL_BASE          (GENET_TDMA_OFF + DMA_DESC_ARRAY_SIZE + DMA_RINGS_SIZE)
+
+/* Per-ring control offsets (identical layout for RDMA/TDMA, semantics differ) */
+#define RING_HW_PTR_LO          0x00
+#define RING_HW_PTR_HI          0x04
+#define RING_HW_INDEX           0x08   /* RDMA: prod / TDMA: cons */
+#define RING_SW_INDEX           0x0C   /* RDMA: cons / TDMA: prod */
+#define RING_BUF_SIZE           0x10
+#define RING_START_ADDR_LO      0x14
+#define RING_START_ADDR_HI      0x18
+#define RING_END_ADDR_LO        0x1C
+#define RING_END_ADDR_HI        0x20
+#define RING_MBUF_DONE_THRESH   0x24
+#define RING_XON_XOFF           0x28
+#define RING_SW_PTR_LO          0x2C
+#define RING_SW_PTR_HI          0x30
+
+#define RING_BUF_SIZE_VAL(n, sz) (((uint32_t)(n) << 16) | (uint32_t)(sz))
+
+#define DMA_FC_THRESH_HI        (GENET_TOTAL_DESC >> 4)
+#define DMA_FC_THRESH_LO        5
+#define RDMA_XON_XOFF_VAL       (DMA_FC_THRESH_HI | (DMA_FC_THRESH_LO << 16))
+
+#define DESC_START_ADDR(idx)    ((idx) * GENET_WORDS_PER_BD)
+#define DESC_END_ADDR(idx, cnt) (((idx) + (cnt)) * GENET_WORDS_PER_BD - 1U)
+
+/* Global DMA control registers (relative to RDMA_CTRL_BASE / TDMA_CTRL_BASE) */
+#define DMA_RING_CFG            0x00
+#define DMA_CTRL                0x04
+#define  DMA_EN                 (1U << 0)
+#define  DMA_RING_BUF_EN_SHIFT  1
+#define  DMA_RING_EN(r)         (1U << ((r) + DMA_RING_BUF_EN_SHIFT))
+#define  DMA_RING_CFG_EN(r)     (1U << (r))
+#define DMA_STATUS              0x08
+#define  DMA_DISABLED           (1U << 0)
+#define DMA_SCB_BURST_SIZE      0x0C
+#define  DMA_SCB_BURST_VAL      8
+#define DMA_ARB_CTRL            0x2C
+#define  DMA_ARBITER_SP         0x02
+#define DMA_TIMEOUT_USEC        5000U
+
+/* ───── MII (standard PHY registers) ────────────────────────────────────── */
+#define MII_BMCR                0x00
+#define  BMCR_RESET             (1U << 15)
+#define  BMCR_ANENABLE          (1U << 12)
+#define  BMCR_ANRESTART         (1U << 9)
+#define MII_BMSR                0x01
+#define  BMSR_LSTATUS           (1U << 2)
+#define  BMSR_ANEGCOMPLETE      (1U << 5)
+#define MII_ADVERTISE           0x04
+#define  ADVERTISE_CSMA         0x0001
+#define  ADVERTISE_10HALF       (1U << 5)
+#define  ADVERTISE_10FULL       (1U << 6)
+#define  ADVERTISE_100HALF      (1U << 7)
+#define  ADVERTISE_100FULL      (1U << 8)
+#define  ADVERTISE_PAUSE        (1U << 10)
+#define MII_LPA                 0x05
+#define MII_CTRL1000            0x09
+#define  ADVERTISE_1000FULL     (1U << 9)
+#define MII_STAT1000            0x0A
+#define  LPA_1000FULL           (1U << 11)
+
+/* ───── DMA-buffer address translation ──────────────────────────────────── */
+/* BCM2711 GENET is on the ARM AXI bus — identity mapping, no offset needed. */
+#define GENET_DMA_ADDR(p)       ((uint32_t)(uintptr_t)(p))
+
+/* ───── Driver-side buffer configuration ────────────────────────────────── */
+#define GENET_RX_DATA_OFFSET    2U    /* RBUF_ALIGN_2B prepends 2 bytes */
+#define GENET_NUM_RX_DESC       16U
+#define GENET_NUM_TX_DESC       16U
+#define GENET_RX_BUF_SIZE       2048U
+#define GENET_TX_BUF_SIZE       2048U
+#define GENET_RX_RING           DESC_INDEX
+#define GENET_TX_RING           DESC_INDEX
+#define GENET_RX_DESC_START     0U
+#define GENET_TX_DESC_START     0U
+
+/* ───── Accessor macros (operate on the device_map'd virtual base) ──────── */
+#define GENET_RD(b, off)        sys_read32((b) + (off))
+#define GENET_WR(b, val, off)   sys_write32((val), (b) + (off))
+
+#define SYS_RD(b, r)            GENET_RD((b), GENET_SYS_OFF + (r))
+#define SYS_WR(b, v, r)         GENET_WR((b), (v), GENET_SYS_OFF + (r))
+
+#define EXT_RD(b, r)            GENET_RD((b), GENET_EXT_OFF + (r))
+#define EXT_WR(b, v, r)         GENET_WR((b), (v), GENET_EXT_OFF + (r))
+
+#define INTRL2_0_RD(b, r)       GENET_RD((b), GENET_INTRL2_0_OFF + (r))
+#define INTRL2_0_WR(b, v, r)    GENET_WR((b), (v), GENET_INTRL2_0_OFF + (r))
+#define INTRL2_1_RD(b, r)       GENET_RD((b), GENET_INTRL2_1_OFF + (r))
+#define INTRL2_1_WR(b, v, r)    GENET_WR((b), (v), GENET_INTRL2_1_OFF + (r))
+
+#define RBUF_RD(b, r)           GENET_RD((b), GENET_RBUF_OFF + (r))
+#define RBUF_WR(b, v, r)        GENET_WR((b), (v), GENET_RBUF_OFF + (r))
+
+#define UMAC_RD(b, r)           GENET_RD((b), GENET_UMAC_OFF + (r))
+#define UMAC_WR(b, v, r)        GENET_WR((b), (v), GENET_UMAC_OFF + (r))
+
+#define RDESC_WR(b, idx, woff, v) \
+	sys_write32((v), (b) + GENET_RDMA_OFF + (idx) * GENET_DESC_SIZE + (woff))
+#define RDESC_RD(b, idx, woff) \
+	sys_read32((b) + GENET_RDMA_OFF + (idx) * GENET_DESC_SIZE + (woff))
+#define TDESC_WR(b, idx, woff, v) \
+	sys_write32((v), (b) + GENET_TDMA_OFF + (idx) * GENET_DESC_SIZE + (woff))
+
+#define RDMA_RING_RD(b, r, off) sys_read32((b) + RDMA_RING_BASE(r) + (off))
+#define RDMA_RING_WR(b, r, off, v) sys_write32((v), (b) + RDMA_RING_BASE(r) + (off))
+#define TDMA_RING_RD(b, r, off) sys_read32((b) + TDMA_RING_BASE(r) + (off))
+#define TDMA_RING_WR(b, r, off, v) sys_write32((v), (b) + TDMA_RING_BASE(r) + (off))
+
+#define RDMA_CTRL_RD(b, r)      sys_read32((b) + RDMA_CTRL_BASE + (r))
+#define RDMA_CTRL_WR(b, r, v)   sys_write32((v), (b) + RDMA_CTRL_BASE + (r))
+#define TDMA_CTRL_RD(b, r)      sys_read32((b) + TDMA_CTRL_BASE + (r))
+#define TDMA_CTRL_WR(b, r, v)   sys_write32((v), (b) + TDMA_CTRL_BASE + (r))
+
+#endif /* ETH_BCM_GENET_H */

--- a/dts/arm64/broadcom/bcm2711.dtsi
+++ b/dts/arm64/broadcom/bcm2711.dtsi
@@ -169,5 +169,19 @@
 			clocks = <&clk_uart>;
 			status = "disabled";
 		};
+
+		/* Broadcom GENET v5 Gigabit Ethernet — ARM physical address */
+		genet: ethernet@fd580000 {
+			compatible = "brcm,bcm2711-genet";
+			reg = <0xfd580000 0x10000>;
+			interrupts = <GIC_SPI 157 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 158 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>;
+			phy-addr = <1>;
+			phy-connection-type = "rgmii";
+			rx-internal-delay-ps = <2000>; /* RGMII-RXID: 2 ns RX delay */
+			status = "disabled";
+		};
 	};
 };

--- a/dts/bindings/ethernet/brcm,bcm2711-genet.yaml
+++ b/dts/bindings/ethernet/brcm,bcm2711-genet.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 Khaled Abdalla <khaled.3bdulaziz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Broadcom BCM2711 GENET v5 Gigabit Ethernet MAC controller.
+  The GENET block includes an integrated UMAC (Unimac), Hardware Filter
+  Block (HFB), TX/RX DMA rings, and an internal MDIO bus for PHY management.
+
+compatible: "brcm,bcm2711-genet"
+
+include: [ethernet-controller.yaml]
+
+properties:
+  reg:
+    required: true
+    description: MMIO base address and size of the GENET register block.
+
+  interrupts:
+    required: true
+    description: |
+      Two interrupt lines:
+        [0] INTRL2_0 — RX DMA done, link events, MDIO done.
+        [1] INTRL2_1 — TX DMA done.
+
+  phy-addr:
+    type: int
+    required: true
+    description: MDIO address of the PHY (0-31).
+
+  rx-internal-delay-ps:
+    type: int
+    default: 0
+    description: |
+      Internal RX delay in picoseconds inserted by the MAC.
+      Set to a non-zero value to enable RGMII-RXID mode (PHY provides
+      TX delay; MAC provides RX delay). Typical value: 2000 (2 ns).
+
+  local-mac-address:
+    type: uint8-array
+    description: |
+      6-byte MAC address. If omitted the driver generates a random address
+      from the Zephyr entropy source.


### PR DESCRIPTION
## Summary
Adds Ethernet driver for the BCM2711 GENET controller on Raspberry Pi 4B.

## Changes
- `eth_bcm_genet.c/h`: driver implementation
- `Kconfig.bcm_genet`: new Kconfig option `CONFIG_ETH_BCM_GENET`
- `brcm,bcm2711-genet.yaml`: DTS binding
- `bcm2711.dtsi`: GENET node
- `rpi_4b.dts`: board-level enablement

## Testing
Tested on physical rpi_4b hardware:
- DHCP address acquisition: OK
- ping to gateway: OK

## References
Link: https://www.raspberrypi.com/documentation/computers/raspberry-pi.html