### PR TITLE
tests: kernel: thread_error_case: improve coverage and docs

### DIFF
--- a/tests/kernel/threads/thread_error_case/src/main.c
+++ b/tests/kernel/threads/thread_error_case/src/main.c
@@ -9,7 +9,7 @@
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define THREAD_TEST_PRIORITY 5
 
-/* use to pass case type to threads */
+/* selected negative test case, shared with the worker thread */
 static ZTEST_DMEM int case_type;
 
 static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
@@ -17,7 +17,7 @@ static K_THREAD_STACK_DEFINE(test_stack, STACK_SIZE);
 static struct k_thread tdata;
 static struct k_thread test_tdata;
 
-/* enumerate our negative case scenario */
+/* identifiers for each negative test scenario */
 enum {
 	THREAD_START,
 	FLOAT_DISABLE,
@@ -25,12 +25,19 @@ enum {
 	TIMEOUT_EXPIRES_TICKS,
 	THREAD_CREATE_NEWTHREAD_NULL,
 	THREAD_CREATE_STACK_NULL,
-	THREAD_CTEATE_STACK_SIZE_OVERFLOW
+	THREAD_CREATE_STACK_SIZE_OVERFLOW,
+	THREAD_SUSPEND_NULL,
+	THREAD_RESUME_NULL,
+	THREAD_PRIORITY_SET_NULL,
+	THREAD_PRIORITY_GET_NULL,
+	THREAD_WAKEUP_NULL,
+	THREAD_CREATE_SUPERVISOR,
+	THREAD_CREATE_ESSENTIAL
 } neg_case;
 
 static void test_thread(void *p1, void *p2, void *p3)
 {
-	/* do nothing here */
+	/* intentionally empty target thread */
 }
 
 static void tThread_entry_negative(void *p1, void *p2, void *p3)
@@ -41,10 +48,9 @@ static void tThread_entry_negative(void *p1, void *p2, void *p3)
 	int choice = *((int *)p1);
 	uint32_t perm = K_INHERIT_PERMS;
 
-	TC_PRINT("current case is %d\n", choice);
-
-	/* Set up the fault or assert are expected before we call
-	 * the target tested function.
+	/* Arm the fatal-error hook before calling the API under test.
+	 * Each case must not return; control resumes after the switch
+	 * only if the error was not detected, which fails the test.
 	 */
 	switch (choice) {
 	case THREAD_START:
@@ -85,7 +91,7 @@ static void tThread_entry_negative(void *p1, void *p2, void *p3)
 			K_PRIO_PREEMPT(THREAD_TEST_PRIORITY),
 			perm, K_NO_WAIT);
 		break;
-	case THREAD_CTEATE_STACK_SIZE_OVERFLOW:
+	case THREAD_CREATE_STACK_SIZE_OVERFLOW:
 		ztest_set_fault_valid(true);
 		if (k_is_user_context()) {
 			perm = perm | K_USER;
@@ -95,14 +101,60 @@ static void tThread_entry_negative(void *p1, void *p2, void *p3)
 			K_PRIO_PREEMPT(THREAD_TEST_PRIORITY),
 			perm, K_NO_WAIT);
 		break;
+	case THREAD_SUSPEND_NULL:
+		ztest_set_fault_valid(true);
+		k_thread_suspend(NULL);
+		break;
+	case THREAD_RESUME_NULL:
+		ztest_set_fault_valid(true);
+		k_thread_resume(NULL);
+		break;
+	case THREAD_PRIORITY_SET_NULL:
+		ztest_set_fault_valid(true);
+		k_thread_priority_set(NULL, K_PRIO_PREEMPT(THREAD_TEST_PRIORITY));
+		break;
+	case THREAD_PRIORITY_GET_NULL:
+		ztest_set_fault_valid(true);
+		k_thread_priority_get(NULL);
+		break;
+	case THREAD_WAKEUP_NULL:
+		ztest_set_fault_valid(true);
+		k_wakeup(NULL);
+		break;
+	case THREAD_CREATE_SUPERVISOR:
+		/* Creating a supervisor thread (K_USER flag absent) is
+		 * only rejected in user context; skip otherwise.
+		 */
+		if (!k_is_user_context()) {
+			ztest_test_skip();
+			break;
+		}
+		ztest_set_fault_valid(true);
+		k_thread_create(&test_tdata, test_stack, STACK_SIZE,
+			test_thread, NULL, NULL, NULL,
+			K_PRIO_PREEMPT(THREAD_TEST_PRIORITY),
+			K_INHERIT_PERMS, K_NO_WAIT);
+		break;
+	case THREAD_CREATE_ESSENTIAL:
+		/* Creating an essential thread (K_ESSENTIAL flag) is
+		 * only rejected in user context; skip otherwise.
+		 */
+		if (!k_is_user_context()) {
+			ztest_test_skip();
+			break;
+		}
+		ztest_set_fault_valid(true);
+		k_thread_create(&test_tdata, test_stack, STACK_SIZE,
+			test_thread, NULL, NULL, NULL,
+			K_PRIO_PREEMPT(THREAD_TEST_PRIORITY),
+			K_USER | K_ESSENTIAL, K_NO_WAIT);
+		break;
 	default:
 		TC_PRINT("should not be here!\n");
 		break;
 	}
 
-	/* If negative comes here, it means error condition not been
-	 * detected.
-	 */
+	/* Reaching here means the expected error was not detected. */
 	ztest_test_fail();
 }
 
@@ -125,49 +177,229 @@ static void create_negative_test_thread(int choice)
 	(void)k_thread_join(tid, K_FOREVER);
 }
 
-/* TESTPOINT: Pass a null pointer into the API k_thread_start() */
+/**
+ * @brief Test that k_thread_start() rejects a NULL thread pointer
+ *
+ * Verifies that passing a NULL pointer to k_thread_start() triggers
+ * the expected fatal error in the syscall validation layer.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_start()
+ */
 ZTEST_USER(thread_error_case, test_thread_start)
 {
 	create_negative_test_thread(THREAD_START);
 }
 
-/* TESTPOINT: Pass a null pointer into the API k_float_disable() */
+/**
+ * @brief Test that k_float_disable() rejects a NULL thread pointer
+ *
+ * Verifies that passing a NULL pointer to k_float_disable() triggers
+ * the expected fatal error in the syscall validation layer.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_float_disable()
+ */
 ZTEST_USER(thread_error_case, test_float_disable)
 {
 	create_negative_test_thread(FLOAT_DISABLE);
 }
 
-/* TESTPOINT: Pass a null pointer into the API */
+/**
+ * @brief Test that k_thread_timeout_remaining_ticks() rejects a NULL pointer
+ *
+ * Verifies that passing a NULL thread pointer to
+ * k_thread_timeout_remaining_ticks() triggers the expected fatal error
+ * in the syscall validation layer.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_timeout_remaining_ticks()
+ */
 ZTEST_USER(thread_error_case, test_timeout_remaining_ticks)
 {
 	create_negative_test_thread(TIMEOUT_REMAINING_TICKS);
 }
 
-/* TESTPOINT: Pass a null pointer into the API */
+/**
+ * @brief Test that k_thread_timeout_expires_ticks() rejects a NULL pointer
+ *
+ * Verifies that passing a NULL thread pointer to
+ * k_thread_timeout_expires_ticks() triggers the expected fatal error
+ * in the syscall validation layer.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_timeout_expires_ticks()
+ */
 ZTEST_USER(thread_error_case, test_timeout_expires_ticks)
 {
 	create_negative_test_thread(TIMEOUT_EXPIRES_TICKS);
 }
 
-/* TESTPOINT: Pass new thread with NULL into API */
+/**
+ * @brief Test that k_thread_create() rejects a NULL new-thread pointer
+ *
+ * Verifies that passing NULL as the new thread object to k_thread_create()
+ * triggers the expected fatal error. The syscall verifier requires the
+ * thread object to be a valid, uninitialized kernel object.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_create()
+ */
 ZTEST_USER(thread_error_case, test_thread_create_uninit)
 {
 	create_negative_test_thread(THREAD_CREATE_NEWTHREAD_NULL);
 }
 
-/* TESTPOINT: Pass a NULL stack into API */
+/**
+ * @brief Test that k_thread_create() rejects a NULL stack pointer
+ *
+ * Verifies that passing NULL as the stack argument to k_thread_create()
+ * triggers the expected fatal error. The syscall verifier requires the
+ * stack to be a valid, uninitialized kernel stack object.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_create()
+ */
 ZTEST_USER(thread_error_case, test_thread_create_stack_null)
 {
 	create_negative_test_thread(THREAD_CREATE_STACK_NULL);
 }
 
-/* TESTPOINT: Pass a overflow stack into API */
+/**
+ * @brief Test that k_thread_create() rejects an overflowing stack size
+ *
+ * Verifies that passing SIZE_MAX (-1 cast to size_t) as the stack size
+ * to k_thread_create() triggers the expected fatal error. The syscall
+ * verifier detects the overflow when computing
+ * K_THREAD_STACK_RESERVED + stack_size.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_create()
+ */
 ZTEST_USER(thread_error_case, test_thread_create_stack_overflow)
 {
-	create_negative_test_thread(THREAD_CTEATE_STACK_SIZE_OVERFLOW);
+	create_negative_test_thread(THREAD_CREATE_STACK_SIZE_OVERFLOW);
 }
 
-/*test case main entry*/
+/**
+ * @brief Test that k_thread_suspend() rejects a NULL thread pointer
+ *
+ * Verifies that passing a NULL pointer to k_thread_suspend() triggers
+ * the expected fatal error in the syscall validation layer.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_suspend()
+ */
+ZTEST_USER(thread_error_case, test_thread_suspend_null)
+{
+	create_negative_test_thread(THREAD_SUSPEND_NULL);
+}
+
+/**
+ * @brief Test that k_thread_resume() rejects a NULL thread pointer
+ *
+ * Verifies that passing a NULL pointer to k_thread_resume() triggers
+ * the expected fatal error in the syscall validation layer.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_resume()
+ */
+ZTEST_USER(thread_error_case, test_thread_resume_null)
+{
+	create_negative_test_thread(THREAD_RESUME_NULL);
+}
+
+/**
+ * @brief Test that k_thread_priority_set() rejects a NULL thread pointer
+ *
+ * Verifies that passing a NULL pointer to k_thread_priority_set() triggers
+ * the expected fatal error in the syscall validation layer.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_priority_set()
+ */
+ZTEST_USER(thread_error_case, test_thread_priority_set_null)
+{
+	create_negative_test_thread(THREAD_PRIORITY_SET_NULL);
+}
+
+/**
+ * @brief Test that k_thread_priority_get() rejects a NULL thread pointer
+ *
+ * Verifies that passing a NULL pointer to k_thread_priority_get() triggers
+ * the expected fatal error in the syscall validation layer.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_priority_get()
+ */
+ZTEST_USER(thread_error_case, test_thread_priority_get_null)
+{
+	create_negative_test_thread(THREAD_PRIORITY_GET_NULL);
+}
+
+/**
+ * @brief Test that k_wakeup() rejects a NULL thread pointer
+ *
+ * Verifies that passing a NULL pointer to k_wakeup() triggers the
+ * expected fatal error in the syscall validation layer.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_wakeup()
+ */
+ZTEST_USER(thread_error_case, test_thread_wakeup_null)
+{
+	create_negative_test_thread(THREAD_WAKEUP_NULL);
+}
+
+/**
+ * @brief Test that k_thread_create() forbids creating supervisor threads
+ *        from user context
+ *
+ * Verifies that a user thread cannot create a supervisor thread by omitting
+ * the K_USER option flag. The syscall verifier in z_vrfy_k_thread_create()
+ * enforces that the K_USER flag must be set for all threads spawned from
+ * user context.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_create()
+ */
+ZTEST_USER(thread_error_case, test_thread_create_supervisor)
+{
+	create_negative_test_thread(THREAD_CREATE_SUPERVISOR);
+}
+
+/**
+ * @brief Test that k_thread_create() forbids creating essential threads
+ *        from user context
+ *
+ * Verifies that a user thread cannot create an essential thread by setting
+ * the K_ESSENTIAL option flag. The syscall verifier in
+ * z_vrfy_k_thread_create() rejects this to prevent unprivileged code from
+ * creating threads whose abort would trigger a kernel panic.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_create()
+ */
+ZTEST_USER(thread_error_case, test_thread_create_essential)
+{
+	create_negative_test_thread(THREAD_CREATE_ESSENTIAL);
+}
+
+/* Grant the test thread access to all shared kernel objects. */
 void *thread_grant_setup(void)
 {
 	k_thread_access_grant(k_current_get(), &tdata, &tstack, &test_tdata, &test_stack);


### PR DESCRIPTION
Fix a typo in the THREAD_CTEATE_STACK_SIZE_OVERFLOW enum value
and add eight new negative test cases to improve API error-path
coverage:

- k_thread_suspend(NULL)
- k_thread_resume(NULL)
- k_thread_priority_set(NULL, prio)
- k_thread_priority_get(NULL)
- k_wakeup(NULL)
- k_thread_create() without K_USER from user context
  (supervisor thread creation attempt)
- k_thread_create() with K_ESSENTIAL from user context
  (essential thread creation attempt)

Each test spawns a user thread that arms the fault hook with
ztest_set_fault_valid(true) before calling the target API, so
the expected kernel fatal error is caught and the test passes.
The supervisor and essential creation cases are skipped when
running in supervisor context because the privilege check only
applies in userspace.

Assisted-by: GitHub Copilot:claude-sonnet-4.6
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
