### PR TITLE
drivers: ps2: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/ps2.h
+++ b/include/zephyr/drivers/ps2.h
@@ -73,8 +73,7 @@ __subsystem struct ps2_driver_api {
  * @param callback_isr called when PS/2 devices reply to a configuration
  * command or when a mouse/keyboard send data to the client application.
  *
- * @retval 0 If successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 __syscall int ps2_config(const struct device *dev,
 			 ps2_callback_t callback_isr);
@@ -94,8 +93,7 @@ static inline int z_impl_ps2_config(const struct device *dev,
  * @param dev Pointer to the device structure for the driver instance.
  * @param value Data for the PS2 device.
  *
- * @retval 0 If successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 __syscall int ps2_write(const struct device *dev, uint8_t value);
 
@@ -112,8 +110,7 @@ static inline int z_impl_ps2_write(const struct device *dev, uint8_t value)
  * @param dev Pointer to the device structure for the driver instance.
  * @param value Pointer used for reading the PS/2 device.
  *
- * @retval 0 If successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 __syscall int ps2_read(const struct device *dev,  uint8_t *value);
 
@@ -129,8 +126,7 @@ static inline int z_impl_ps2_read(const struct device *dev, uint8_t *value)
  * @brief Enables callback.
  * @param dev Pointer to the device structure for the driver instance.
  *
- * @retval 0 If successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 __syscall int ps2_enable_callback(const struct device *dev);
 
@@ -150,8 +146,7 @@ static inline int z_impl_ps2_enable_callback(const struct device *dev)
  * @brief Disables callback.
  * @param dev Pointer to the device structure for the driver instance.
  *
- * @retval 0 If successful.
- * @retval <0 Negative errno code if failure.
+ * @return 0 on success, negative errno value on failure.
  */
 __syscall int ps2_disable_callback(const struct device *dev);
 


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974