### PR TITLE
Add net_eth_set_if_type_wifi() API to set ethernet interface type

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -131,6 +131,10 @@ New APIs and options
 
 * :c:struct:`sys_ringq` (see :ref:`fixed_size_ringq_api`)
 
+* Network
+
+  * Add :c:func:`net_eth_set_if_type_wifi` to set the ethernet interface type to Wi-Fi.
+
 .. zephyr-keep-sorted-stop
 
 New Boards

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -1010,10 +1010,9 @@ static void esp32_wifi_init(struct net_if *iface)
 #if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
 	struct wifi_nm_instance *nm = wifi_nm_get_instance("esp32_wifi_nm");
 #endif
-	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 	uint8_t *mac_addr;
 
-	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
+	net_eth_set_if_type_wifi(iface);
 
 #if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
 	if (iface == esp32_wifi_iface_ap) {

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -1476,6 +1476,18 @@ static inline bool net_eth_type_is_ethernet(struct net_if *iface)
 }
 
 /**
+ * @brief Set the Ethernet interface type to Wi-Fi.
+ *
+ * @param iface Network interface
+ */
+static inline void net_eth_set_if_type_wifi(struct net_if *iface)
+{
+	struct ethernet_context *ctx = (struct ethernet_context *)net_if_l2_data(iface);
+
+	ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
+}
+
+/**
  * @}
  */
 


### PR DESCRIPTION
Add net_eth_set_if_type_wifi() API to set the ethernet_context->eth_if_type type to Wi-Fi.

Use this api in esp32 driver's _**esp32_wifi_init()**_ to set the ethernet type.