### PR TITLE
drivers: pwm: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -604,9 +604,8 @@ __subsystem struct pwm_driver_api {
  * @param pulse Pulse width (in clock cycles) set to the PWM. HW specific.
  * @param flags Flags for pin configuration.
  *
- * @retval 0 If successful.
- * @retval -EINVAL If pulse > period.
- * @retval -errno Negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Pulse width exceeds period.
  */
 __syscall int pwm_set_cycles(const struct device *dev, uint32_t channel,
 			     uint32_t period, uint32_t pulse,
@@ -631,8 +630,7 @@ static inline int z_impl_pwm_set_cycles(const struct device *dev,
  * @param[out] cycles Pointer to the memory to store clock rate (cycles per
  *                    sec). HW specific.
  *
- * @retval 0 If successful.
- * @retval -errno Negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 __syscall int pwm_get_cycles_per_sec(const struct device *dev, uint32_t channel,
 				     uint64_t *cycles);
@@ -656,9 +654,8 @@ static inline int z_impl_pwm_get_cycles_per_sec(const struct device *dev,
  * @param pulse Pulse width (in nanoseconds) set to the PWM.
  * @param flags Flags for pin configuration (polarity).
  *
- * @retval 0 If successful.
- * @retval -ENOTSUP If requested period or pulse cycles are not supported.
- * @retval -errno Other negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Requested period or pulse cycles are not supported.
  */
 static inline int pwm_set(const struct device *dev, uint32_t channel,
 			  uint32_t period, uint32_t pulse, pwm_flags_t flags)
@@ -742,9 +739,8 @@ static inline int pwm_set_pulse_dt(const struct pwm_dt_spec *spec,
  * @param cycles Cycles to be converted.
  * @param[out] usec Pointer to the memory to store calculated usec.
  *
- * @retval 0 If successful.
- * @retval -ERANGE If result is too large.
- * @retval -errno Other negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ERANGE Result is too large.
  */
 static inline int pwm_cycles_to_usec(const struct device *dev, uint32_t channel,
 				     uint32_t cycles, uint64_t *usec)
@@ -775,9 +771,8 @@ static inline int pwm_cycles_to_usec(const struct device *dev, uint32_t channel,
  * @param cycles Cycles to be converted.
  * @param[out] nsec Pointer to the memory to store the calculated nsec.
  *
- * @retval 0 If successful.
- * @retval -ERANGE If result is too large.
- * @retval -errno Other negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ERANGE Result is too large.
  */
 static inline int pwm_cycles_to_nsec(const struct device *dev, uint32_t channel,
 				     uint32_t cycles, uint64_t *nsec)
@@ -822,11 +817,12 @@ static inline int pwm_cycles_to_nsec(const struct device *dev, uint32_t channel,
  * @param[in] user_data User data to pass to the application callback handler
  *                      function
  *
- * @retval -EINVAL if invalid function parameters were given
- * @retval -ENOSYS if PWM capture is not supported or the given flags are not
- *                  supported
- * @retval -EIO if IO error occurred while configuring
- * @retval -EBUSY if PWM capture is already in progress
+ * @retval 0 on success.
+ * @retval -EINVAL Invalid function parameters were given.
+ * @retval -ENOSYS PWM capture is not supported or the given flags are not
+ *                 supported.
+ * @retval -EIO IO error occurred while configuring.
+ * @retval -EBUSY PWM capture is already in progress.
  */
 static inline int pwm_configure_capture(const struct device *dev,
 					uint32_t channel, pwm_flags_t flags,
@@ -856,11 +852,11 @@ static inline int pwm_configure_capture(const struct device *dev,
  * @param[in] dev PWM device instance.
  * @param channel PWM channel.
  *
- * @retval 0 If successful.
- * @retval -EINVAL if invalid function parameters were given
- * @retval -ENOSYS if PWM capture is not supported
- * @retval -EIO if IO error occurred while enabling PWM capture
- * @retval -EBUSY if PWM capture is already in progress
+ * @retval 0 on success.
+ * @retval -EINVAL Invalid function parameters were given.
+ * @retval -ENOSYS PWM capture is not supported.
+ * @retval -EIO IO error occurred while enabling PWM capture.
+ * @retval -EBUSY PWM capture is already in progress.
  */
 __syscall int pwm_enable_capture(const struct device *dev, uint32_t channel);
 
@@ -886,10 +882,10 @@ static inline int z_impl_pwm_enable_capture(const struct device *dev,
  * @param[in] dev PWM device instance.
  * @param channel PWM channel.
  *
- * @retval 0 If successful.
- * @retval -EINVAL if invalid function parameters were given
- * @retval -ENOSYS if PWM capture is not supported
- * @retval -EIO if IO error occurred while disabling PWM capture
+ * @retval 0 on success.
+ * @retval -EINVAL Invalid function parameters were given.
+ * @retval -ENOSYS PWM capture is not supported.
+ * @retval -EIO IO error occurred while disabling PWM capture.
  */
 __syscall int pwm_disable_capture(const struct device *dev, uint32_t channel);
 
@@ -927,11 +923,11 @@ static inline int z_impl_pwm_disable_capture(const struct device *dev,
  *                   (in clock cycles). HW specific.
  * @param timeout Waiting period for the capture to complete.
  *
- * @retval 0 If successful.
+ * @retval 0 on success.
  * @retval -EBUSY PWM capture already in progress.
  * @retval -EAGAIN Waiting period timed out.
  * @retval -EIO IO error while capturing.
- * @retval -ERANGE If result is too large.
+ * @retval -ERANGE Result is too large.
  */
 __syscall int pwm_capture_cycles(const struct device *dev, uint32_t channel,
 				 pwm_flags_t flags, uint32_t *period,
@@ -957,12 +953,11 @@ __syscall int pwm_capture_cycles(const struct device *dev, uint32_t channel,
  *                   (in usec).
  * @param timeout Waiting period for the capture to complete.
  *
- * @retval 0 If successful.
+ * @return 0 on success, negative errno value on failure.
  * @retval -EBUSY PWM capture already in progress.
  * @retval -EAGAIN Waiting period timed out.
  * @retval -EIO IO error while capturing.
- * @retval -ERANGE If result is too large.
- * @retval -errno Other negative errno code on failure.
+ * @retval -ERANGE Result is too large.
  */
 static inline int pwm_capture_usec(const struct device *dev, uint32_t channel,
 				   pwm_flags_t flags, uint64_t *period,
@@ -1011,12 +1006,11 @@ static inline int pwm_capture_usec(const struct device *dev, uint32_t channel,
  *                   (in nsec).
  * @param timeout Waiting period for the capture to complete.
  *
- * @retval 0 If successful.
+ * @return 0 on success, negative errno value on failure.
  * @retval -EBUSY PWM capture already in progress.
  * @retval -EAGAIN Waiting period timed out.
  * @retval -EIO IO error while capturing.
- * @retval -ERANGE If result is too large.
- * @retval -errno Other negative errno code on failure.
+ * @retval -ERANGE Result is too large.
  */
 static inline int pwm_capture_nsec(const struct device *dev, uint32_t channel,
 				   pwm_flags_t flags, uint64_t *period,
@@ -1078,9 +1072,8 @@ static inline void pwm_init_event_callback(struct pwm_event_callback *callback,
  *
  * @kconfig_dep{CONFIG_PWM_EVENT}
  *
- * @retval 0 on success.
- * @retval -ENOSYS if driver does not manage event callbacks.
- * @retval negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Driver does not manage event callbacks.
  */
 static inline int pwm_add_event_callback(const struct device *dev,
 					 struct pwm_event_callback *callback)
@@ -1102,9 +1095,8 @@ static inline int pwm_add_event_callback(const struct device *dev,
  *
  * @kconfig_dep{CONFIG_PWM_EVENT}
  *
- * @retval 0 on success.
- * @retval -ENOSYS if driver does not manage event callbacks.
- * @retval negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Driver does not manage event callbacks.
  */
 static inline int pwm_remove_event_callback(const struct device *dev,
 					    struct pwm_event_callback *callback)
@@ -1124,8 +1116,8 @@ static inline int pwm_remove_event_callback(const struct device *dev,
  *
  * @param spec PWM specification from devicetree
  *
- * @retval true If the PWM device is ready for use
- * @retval false If the PWM device is not ready for use
+ * @retval true The PWM device is ready for use.
+ * @retval false The PWM device is not ready for use.
  */
 static inline bool pwm_is_ready_dt(const struct pwm_dt_spec *spec)
 {


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974