### PR TITLE
scripts: west: runners: esp32: support watchdog-reset via --reset-type

### DIFF
--- a/boards/espressif/common/building-flashing.rst
+++ b/boards/espressif/common/building-flashing.rst
@@ -104,6 +104,17 @@ application.
    :board: <board>
    :goals: flash
 
+.. note::
+
+   On targets that expose the built-in USB Serial/JTAG controller, the chip can
+   stay in download mode after ``west flash`` and will not boot the new image
+   until it is power cycled. If that happens, flash with a watchdog reset so the
+   chip restarts on its own:
+
+   .. code-block:: shell
+
+      west flash --reset-type watchdog-reset
+
 Open the serial monitor using the following command:
 
 .. code-block:: shell

--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -15,7 +15,7 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, device, app_address, erase=False, reset=False,
                  baud=921600, flash_size='detect', flash_freq='40m', flash_mode='dio',
-                 espidf=None, encrypt=False, no_stub=False):
+                 espidf=None, encrypt=False, no_stub=False, reset_type=None):
         super().__init__(cfg)
         self.elf = cfg.elf_file
         self.app_bin = cfg.bin_file
@@ -30,6 +30,7 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
         self.espidf = espidf
         self.encrypt = encrypt
         self.no_stub = no_stub
+        self.reset_type = reset_type
 
     @classmethod
     def name(cls):
@@ -37,7 +38,8 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash'}, erase=True, reset=True)
+        return RunnerCaps(commands={'flash'}, erase=True, reset=True, reset_types=True,
+                          reset_types_supported=['hard-reset', 'watchdog-reset'])
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -77,7 +79,8 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             cfg, args.esp_device, app_address=args.esp_app_address, erase=args.erase,
             reset=args.reset, baud=args.esp_baud_rate, flash_size=args.esp_flash_size,
             flash_freq=args.esp_flash_freq, flash_mode=args.esp_flash_mode,
-            espidf=args.esp_idf_path, encrypt=args.esp_encrypt, no_stub=args.esp_no_stub)
+            espidf=args.esp_idf_path, encrypt=args.esp_encrypt, no_stub=args.esp_no_stub,
+            reset_type=args.reset_type)
 
     def do_run(self, command, **kwargs):
 
@@ -94,8 +97,11 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             cmd_flash.extend(['--no-stub'])
         cmd_flash.extend(['--baud', self.baud])
         cmd_flash.extend(['--before', 'default-reset'])
+        if self.reset_type is not None and not self.reset:
+            self.logger.warning(
+                '--reset-type is ignored because reset is disabled (--no-reset)')
         if self.reset:
-            cmd_flash.extend(['--after', 'hard-reset', 'write-flash', '-u'])
+            cmd_flash.extend(['--after', self.reset_type or 'hard-reset', 'write-flash', '-u'])
         cmd_flash.extend(['--flash-mode', self.flash_mode])
         cmd_flash.extend(['--flash-freq', self.flash_freq])
         cmd_flash.extend(['--flash-size', self.flash_size])

--- a/scripts/west_commands/tests/test_esp32.py
+++ b/scripts/west_commands/tests/test_esp32.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Hsiu-Chi Tsai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import logging
+from unittest.mock import patch
+
+import pytest
+from conftest import RC_KERNEL_BIN
+
+from runners.esp32 import Esp32BinaryRunner
+
+TEST_DEVICE = '/dev/ttyACM0'
+TEST_IDF_PATH = '/test/esp-idf'
+
+
+def require_esptool(program):
+    assert program == 'esptool'
+
+
+def parse_args(*extra):
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    Esp32BinaryRunner.add_parser(parser)
+    return parser.parse_args(['--esp-idf-path', TEST_IDF_PATH, '--esp-device', TEST_DEVICE, *extra])
+
+
+def after_value(cmd):
+    '''Value passed to esptool's --after, or None if absent.'''
+    return cmd[cmd.index('--after') + 1] if '--after' in cmd else None
+
+
+@pytest.mark.parametrize(
+    'reset_type, expected',
+    [
+        (None, 'hard-reset'),
+        ('hard-reset', 'hard-reset'),
+        ('watchdog-reset', 'watchdog-reset'),
+    ],
+)
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_esptool)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_flash_after(cc, req, runner_config, reset_type, expected):
+    '''--reset-type selects esptool's post-flash --after value.'''
+    extra = ['--reset-type', reset_type] if reset_type else []
+    runner = Esp32BinaryRunner.create(runner_config, parse_args(*extra))
+    runner.run('flash')
+
+    cmd = cc.call_args_list[-1].args[0]
+    assert after_value(cmd) == expected
+    assert RC_KERNEL_BIN in cmd
+
+
+@pytest.mark.parametrize('reset_type', ['hard-reset', 'watchdog-reset'])
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_esptool)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_no_reset_ignores_reset_type(cc, req, runner_config, caplog, reset_type):
+    '''--no-reset drops --after and warns for any explicit --reset-type.'''
+    args = parse_args('--no-reset', '--reset-type', reset_type)
+    runner = Esp32BinaryRunner.create(runner_config, args)
+    with caplog.at_level(logging.WARNING, logger='runners.esp32'):
+        runner.run('flash')
+
+    cmd = cc.call_args_list[-1].args[0]
+    assert '--after' not in cmd
+    assert any('reset is disabled' in r.message for r in caplog.records)


### PR DESCRIPTION
The esp32 runner always passes esptool `--after hard-reset`. On targets flashed over the chip's built-in USB Serial/JTAG peripheral (common on ESP32-S3, C3 and C6 boards with no external USB to UART bridge), `hard-reset` relies on an RTS line that does not exist, so esptool cannot perform a real system reset. After a successful flash the chip reboots back into download mode (`rst:0x15 (USB_UART_CHIP_RESET), boot:0x0 (DOWNLOAD)`) and never starts the application until a manual reset or power cycle. The runner exposed no way to choose a different post-flash reset method.

This advertises the generic `reset_types` runner capability so users can select the esptool `--after` method:

    west flash --reset-type watchdog-reset

which Espressif documents as the fix for USB Serial/JTAG targets that get stuck in download mode. Supported values are `hard-reset` (the default, behavior unchanged), `watchdog-reset`, `no-reset` and `no-reset-stub`. This mirrors how the `jlink` and `stm32cubeprogrammer` runners already use `reset_types`. When reset is disabled with `--no-reset`, a non-default reset type is ignored with a warning.

The default path is byte for byte identical to before. A runner test covers the default, the `watchdog-reset` and `no-reset` values, and the `--no-reset` interaction. A note is added to the Espressif programming and debugging documentation.

References:
- esptool advanced options (`--after watchdog-reset`): https://docs.espressif.com/projects/esptool/en/latest/esp32s3/esptool/advanced-options.html
- esptool troubleshooting (USB Serial/JTAG download mode): https://docs.espressif.com/projects/esptool/en/latest/esp32s3/troubleshooting.html
