### PR TITLE
drivers: mipi_dbi: populate color_coding in MIPI_DBI_CONFIG_DT

### DIFF
--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -99,8 +99,10 @@ extern "C" {
  * @brief Initialize a MIPI DBI configuration from devicetree
  *
  * This helper allows drivers to initialize a MIPI DBI configuration
- * structure from devicetree. It sets the MIPI DBI mode, as well
- * as configuration fields in the SPI configuration structure
+ * structure from devicetree. It sets the MIPI DBI mode and color
+ * coding, as well as configuration fields in the SPI configuration
+ * structure. If the color-coding property is absent the color coding
+ * field is left at zero, meaning no Type A/B coding was specified.
  * @param node_id Devicetree node identifier for the MIPI DBI device to
  *                initialize
  * @param operation_ the desired operation field in the struct spi_config
@@ -110,6 +112,7 @@ extern "C" {
 #define MIPI_DBI_CONFIG_DT(node_id, operation_, delay_)			\
 	{								\
 		.mode = DT_STRING_UPPER_TOKEN(node_id, mipi_mode),	\
+		.color_coding = DT_STRING_UPPER_TOKEN_OR(node_id, color_coding, 0), \
 		.config = MIPI_DBI_SPI_CONFIG_DT(node_id, operation_, delay_), \
 	}
 

--- a/tests/drivers/mipi_dbi/api/boards/native_sim.overlay
+++ b/tests/drivers/mipi_dbi/api/boards/native_sim.overlay
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025 Hsiu-Chi Tsai
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Devicetree overlay that exercises MIPI_DBI_CONFIG_DT() reading the
+ * optional "color-coding" property of a mipi-dbi-device child node.
+ *
+ * testdev sets a value (RGB888_1) so the test proves the property is really
+ * read; testdev_unset omits it so the field stays unset.
+ *
+ * Both nodes use a Mode C mipi-mode because they hang off a
+ * zephyr,mipi-dbi-spi controller, which is what MIPI_DBI_CONFIG_DT()
+ * builds its spi_config from. The macro reads "color-coding" whatever the
+ * mode is, and that expansion is all this test covers.
+ *
+ * The GPIO and SPI devices are stubs. The MIPI DBI controller and display
+ * compatibles are the production ones, because they carry the bindings the
+ * macro expands against, but their drivers are left out of this build.
+ */
+
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+
+/ {
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_gpio: gpio@deadbeef {
+			compatible = "vnd,gpio";
+			gpio-controller;
+			reg = <0xdeadbeef 0x1000>;
+			#gpio-cells = <0x2>;
+			status = "okay";
+		};
+
+		test_mipi_dbi: test_mipi_dbi {
+			compatible = "zephyr,mipi-dbi-spi";
+			status = "okay";
+			dc-gpios = <&test_gpio 0 0>;
+			spi-dev = <&test_spi>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			testdev: testdev@0 {
+				compatible = "sitronix,st7796s";
+				reg = <0x0>;
+				mipi-max-frequency = <25000000>;
+				mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
+				color-coding = "MIPI_DBI_MODE_RGB888_1";
+				height = <320>;
+				width = <480>;
+				/* Dummy values, this won't drive a real panel */
+				pgc = [f0 06 0b 07 06 05 2e 33 47 3a 17 16 2e 31];
+				ngc = [f0 09 0d 09 08 23 2e 33 46 38 13 13 2c 32];
+			};
+
+			/* Omits color-coding, so the field stays unset. */
+			testdev_unset: testdev@1 {
+				compatible = "sitronix,st7796s";
+				reg = <0x1>;
+				mipi-max-frequency = <25000000>;
+				mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
+				height = <320>;
+				width = <480>;
+				/* Dummy values, this won't drive a real panel */
+				pgc = [f0 06 0b 07 06 05 2e 33 47 3a 17 16 2e 31];
+				ngc = [f0 09 0d 09 08 23 2e 33 46 38 13 13 2c 32];
+			};
+		};
+
+		test_spi: spi@33334444 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,spi";
+			reg = <0x33334444 0x1000>;
+			status = "okay";
+			clock-frequency = <2000000>;
+			cs-gpios = <&test_gpio 0 0>, <&test_gpio 1 0>;
+		};
+	};
+};

--- a/tests/drivers/mipi_dbi/api/src/main.c
+++ b/tests/drivers/mipi_dbi/api/src/main.c
@@ -1,11 +1,18 @@
 /*
  * Copyright (c) 2025 Christoph Schnetzler
+ * Copyright (c) 2025 Hsiu-Chi Tsai
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/drivers/mipi_dbi.h>
 #include <zephyr/ztest.h>
+
+/*
+ * The API tests below drive a real MIPI DBI controller, so they are only built
+ * where the "mipi_dbi" node is enabled (see the filter in tests.yaml).
+ */
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mipi_dbi))
 
 static const uint8_t modes[] = {
 	MIPI_DBI_MODE_8080_BUS_8_BIT,
@@ -96,3 +103,35 @@ static void *mipi_dbi_setup(void)
 }
 
 ZTEST_SUITE(mipi_dbi_api, NULL, mipi_dbi_setup, NULL, NULL, NULL);
+
+#endif /* DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mipi_dbi)) */
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(testdev)) && \
+	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(testdev_unset))
+
+/*
+ * MIPI_DBI_CONFIG_DT() must populate struct mipi_dbi_config.color_coding from
+ * the optional "color-coding" devicetree property, and leave it at zero when
+ * the property is omitted. Uses stub controllers, so it runs on native_sim.
+ */
+ZTEST(mipi_dbi_config, test_color_coding_from_dt)
+{
+	struct mipi_dbi_config config = MIPI_DBI_CONFIG_DT(DT_NODELABEL(testdev), 0, 0);
+
+	zassert_equal(config.color_coding, MIPI_DBI_MODE_RGB888_1,
+		      "Expected RGB888_1 (0x%x) but was 0x%x", MIPI_DBI_MODE_RGB888_1,
+		      config.color_coding);
+}
+
+ZTEST(mipi_dbi_config, test_color_coding_unset)
+{
+	struct mipi_dbi_config config =
+		MIPI_DBI_CONFIG_DT(DT_NODELABEL(testdev_unset), 0, 0);
+
+	zassert_equal(config.color_coding, 0,
+		      "Expected an unset color coding but was 0x%x", config.color_coding);
+}
+
+ZTEST_SUITE(mipi_dbi_config, NULL, NULL, NULL, NULL, NULL);
+
+#endif /* DT_NODE_HAS_STATUS_OKAY(testdev) && DT_NODE_HAS_STATUS_OKAY(testdev_unset) */

--- a/tests/drivers/mipi_dbi/api/tests.yaml
+++ b/tests/drivers/mipi_dbi/api/tests.yaml
@@ -6,6 +6,13 @@ common:
 tests:
   drivers.mipi_dbi.api:
     filter: dt_nodelabel_enabled("mipi-dbi")
+  drivers.mipi_dbi.config:
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_GPIO=y
+      - CONFIG_SPI=y
+      - CONFIG_MIPI_DBI_SPI=n
   drivers.mipi_dbi.rpi_pico.pio0.single_split:
     platform_allow:
       - rpi_pico/rp2040


### PR DESCRIPTION
The `color-coding` devicetree property and the matching `struct mipi_dbi_config.color_coding` field were added in 68988108ee0, but the generic `MIPI_DBI_CONFIG_DT()` helper macro was never updated to read the property. The display drivers that build their config through that macro therefore always get `color_coding = 0`, so the devicetree value is silently ignored for them.

This wires the property into the macro with `DT_STRING_UPPER_TOKEN_OR(node_id, color_coding, 0)`. `MIPI_DBI_CONFIG_DT_INST()` routes through `MIPI_DBI_CONFIG_DT()`, so it inherits the change.

When `color-coding` is absent the field stays at zero, which is what those drivers get today, so nothing changes for a configuration that does not set the property, and a controller that needs a Type A or Type B coding keeps rejecting an unspecified one rather than being given a guessed value. `display_st7796s.c` is unaffected either way, since it builds its config by hand rather than through the macro.

A native_sim test under `tests/drivers/mipi_dbi/api` covers both the property-set case and the omitted case.

Fixes #98657
