### PR TITLE
boards: nucleo: add I2C bus recovery GPIO pins to STM32 boards

### DIFF
--- a/boards/st/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/st/nucleo_f303re/nucleo_f303re.dts
@@ -104,6 +104,8 @@
 	status = "okay";
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 };
 
 &spi1 {

--- a/boards/st/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/st/nucleo_f446re/nucleo_f446re.dts
@@ -103,6 +103,8 @@
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 };
 
 &i2c2 {

--- a/boards/st/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/st/nucleo_g474re/nucleo_g474re.dts
@@ -114,6 +114,8 @@
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
 	status = "okay";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 };
 
 &spi1 {

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -149,6 +149,8 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 };
 
 &timers12 {

--- a/boards/st/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/st/nucleo_l476rg/nucleo_l476rg.dts
@@ -109,6 +109,8 @@ stm32_lp_tick_source: &lptim1 {
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 };
 
 &i2c3 {


### PR DESCRIPTION
## Problem

Several STM32 Nucleo boards have I2C1 enabled on the standard Arduino
connector pins (PB8/SCL, PB9/SDA) but are missing the scl-gpios and
sda-gpios devicetree properties required for GPIO-based bus recovery.

Without these properties, CONFIG_I2C_STM32_BUS_RECOVERY has no GPIO
pins to work with, leaving the bus unable to recover from lockup
conditions where a slave holds SDA low.

## Solution

Add scl-gpios and sda-gpios to the i2c1 node on five popular Nucleo
boards, matching the existing pinctrl configuration on each board.
All five use the standard Arduino connector pinout (PB8/PB9).

## Testing

GPIO assignments verified against existing pinctrl definitions on
each board. Built blinky for nucleo_f411re (same F4 family, same
pinout) to confirm toolchain works.

Extends the work done in #109722 (nucleo_f411re) to additional
popular Nucleo boards using the same Arduino connector pinout.

Fixes  #110160