### PR TITLE
usb: host: align transfer allocation size to mps

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -689,11 +689,15 @@ USB
   renamed to :dtcompatible:`espressif,esp32-usb-otg-fs`. The internal PHY D+/D- pad numbers are
   now provided through the ``phy-dp-pin`` and ``phy-dm-pin`` properties. Out-of-tree devicetrees
   using the old compatible must update the node compatible and add the two pin properties.
-
 * The USB host controller API struct ``uhc_api`` got renamed to :c:struct:`uhc_driver_api`.
   It now also uses :c:macro:`DEVICE_API`. Out-of-tree USB host controller drivers must rename
   their API struct definitions and switch their API instances to ``DEVICE_API(uhc, ...)``.
   (:github:`108414`)
+* :c:func:`uhc_get_ep_properties` got introduced (:github:`110162`)
+* :c:func:`uhc_xfer_alloc` and :c:func:`uhc_xfer_buf_alloc` have an extra ``timeout`` argument.
+  (:github:`110162`)
+* :c:func:`uhc_xfer_alloc_with_buf` got removed in favor of :c:func:`usbh_xfer_alloc_with_buf`.
+  (:github:`110162`)
 
 Video
 =====
@@ -1073,6 +1077,19 @@ LoRaWAN
 
   These ordering requirements do not apply to the LoRaMac-node backend
   (:kconfig:option:`CONFIG_LORA_MODULE_BACKEND_LORAMAC_NODE`).
+
+USB
+***
+
+* :c:func:`usbh_xfer_buf_add` got introduced.
+  (:github:`110162`)
+* :c:func:`usbh_xfer_alloc`, :c:func:`usbh_xfer_buf_alloc` now take a ``timeout`` argument,
+  (:github:`110162`) Out of tree classes will need to update.
+* :c:func:`usbh_xfer_buf_alloc` now has an extra ``ep`` argument.
+  Out of tree classes will need to update to the new signature. (:github:`110162`)
+  (:github:`110162`) Out of tree classes will need to update.
+* :c:func:`usbh_xfer_alloc_with_buf` got introduced, replacing :c:func:`uhc_xfer_alloc_with_buf`.
+  (:github:`110162`) Out of tree classes will need to update.
 
 Other subsystems
 ****************

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -91,30 +91,21 @@ void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf)
 	net_buf_unref(buf);
 }
 
-struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
-				    const uint8_t ep,
-				    struct usb_device *const udev,
-				    void *const cb,
-				    void *const cb_priv,
-				    const k_timeout_t timeout)
+int uhc_get_ep_properties(struct usb_device *const udev,
+			  const uint8_t ep,
+			  uint16_t *const mps_p,
+			  uint16_t *const interval_p,
+			  uint8_t *const type_p)
 {
-	uint8_t ep_idx = USB_EP_GET_IDX(ep) & 0xF;
-	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
-	struct uhc_transfer *xfer = NULL;
+	const uint8_t ep_idx = USB_EP_GET_IDX(ep) & 0xF;
 	uint16_t mps;
 	uint16_t interval;
 	uint8_t type;
 
-	api->lock(dev);
-
-	if (!uhc_is_initialized(dev)) {
-		goto xfer_alloc_error;
-	}
-
 	if (ep_idx == 0) {
+		mps = udev->dev_desc.bMaxPacketSize0;
 		interval = 0;
 		type = USB_EP_TYPE_CONTROL;
-		mps = udev->dev_desc.bMaxPacketSize0;
 	} else {
 		struct usb_ep_descriptor *ep_desc;
 
@@ -126,12 +117,50 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 
 		if (ep_desc == NULL) {
 			LOG_ERR("Endpoint 0x%02x is not configured", ep);
-			goto xfer_alloc_error;
+			return -ENOENT;
 		}
 
 		mps = ep_desc->wMaxPacketSize;
 		interval = ep_desc->bInterval;
 		type = ep_desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
+	}
+
+	if (mps_p != NULL) {
+		*mps_p = mps;
+	}
+	if (interval_p != NULL) {
+		*interval_p = interval;
+	}
+	if (type_p != NULL) {
+		*type_p = type;
+	}
+
+	return 0;
+}
+
+struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
+				    const uint8_t ep,
+				    struct usb_device *const udev,
+				    void *const cb,
+				    void *const cb_priv,
+				    const k_timeout_t timeout)
+{
+	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
+	struct uhc_transfer *xfer = NULL;
+	uint16_t mps;
+	uint16_t interval;
+	uint8_t type;
+	int ret;
+
+	api->lock(dev);
+
+	if (!uhc_is_initialized(dev)) {
+		goto xfer_alloc_error;
+	}
+
+	ret = uhc_get_ep_properties(udev, ep, &mps, &interval, &type);
+	if (ret != 0) {
+		goto xfer_alloc_error;
 	}
 
 	LOG_DBG("Allocate xfer, ep 0x%02x mps %u cb %p", ep, mps, cb);
@@ -152,33 +181,6 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 
 xfer_alloc_error:
 	api->unlock(dev);
-
-	return xfer;
-}
-
-struct uhc_transfer *uhc_xfer_alloc_with_buf(const struct device *dev,
-					     const uint8_t ep,
-					     struct usb_device *const udev,
-					     void *const cb,
-					     void *const cb_priv,
-					     size_t size,
-					     const k_timeout_t timeout)
-{
-	struct uhc_transfer *xfer;
-	struct net_buf *buf;
-
-	buf = uhc_xfer_buf_alloc(dev, size, timeout);
-	if (buf == NULL) {
-		return NULL;
-	}
-
-	xfer = uhc_xfer_alloc(dev, ep, udev, cb, cb_priv, timeout);
-	if (xfer == NULL) {
-		net_buf_unref(buf);
-		return NULL;
-	}
-
-	xfer->buf = buf;
 
 	return xfer;
 }
@@ -212,6 +214,9 @@ int uhc_xfer_buf_add(const struct device *dev,
 	int ret = 0;
 
 	api->lock(dev);
+
+	__ASSERT(xfer->buf == NULL, "Expecting the previous buffer to be freed");
+
 	if (xfer->queued) {
 		ret = -EBUSY;
 	} else {

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -80,9 +80,10 @@ int uhc_xfer_append(const struct device *dev,
 }
 
 struct net_buf *uhc_xfer_buf_alloc(const struct device *dev,
-				   const size_t size)
+				   const size_t size,
+				   const k_timeout_t timeout)
 {
-	return net_buf_alloc_len(&uhc_ep_pool, size, K_NO_WAIT);
+	return net_buf_alloc_len(&uhc_ep_pool, size, timeout);
 }
 
 void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf)
@@ -94,7 +95,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
 				    void *const cb,
-				    void *const cb_priv)
+				    void *const cb_priv,
+				    const k_timeout_t timeout)
 {
 	uint8_t ep_idx = USB_EP_GET_IDX(ep) & 0xF;
 	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
@@ -134,7 +136,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 
 	LOG_DBG("Allocate xfer, ep 0x%02x mps %u cb %p", ep, mps, cb);
 
-	if (k_mem_slab_alloc(&uhc_xfer_pool, (void **)&xfer, K_NO_WAIT)) {
+	if (k_mem_slab_alloc(&uhc_xfer_pool, (void **)&xfer, timeout)) {
 		LOG_ERR("Failed to allocate transfer");
 		goto xfer_alloc_error;
 	}
@@ -159,17 +161,18 @@ struct uhc_transfer *uhc_xfer_alloc_with_buf(const struct device *dev,
 					     struct usb_device *const udev,
 					     void *const cb,
 					     void *const cb_priv,
-					     size_t size)
+					     size_t size,
+					     const k_timeout_t timeout)
 {
 	struct uhc_transfer *xfer;
 	struct net_buf *buf;
 
-	buf = uhc_xfer_buf_alloc(dev, size);
+	buf = uhc_xfer_buf_alloc(dev, size, timeout);
 	if (buf == NULL) {
 		return NULL;
 	}
 
-	xfer = uhc_xfer_alloc(dev, ep, udev, cb, cb_priv);
+	xfer = uhc_xfer_alloc(dev, ep, udev, cb, cb_priv, timeout);
 	if (xfer == NULL) {
 		net_buf_unref(buf);
 		return NULL;

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -433,29 +433,24 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const k_timeout_t timeout);
 
 /**
- * @brief Allocate UHC transfer with buffer
+ * @brief Query the properties of an endpoint, if found
  *
- * Allocate a new transfer from common transfer pool with buffer.
+ * The pointers are filled with the values from the device and configuration descriptors,
+ * only available after successful enumeration.
  *
- * @param[in] dev     Pointer to device struct of the driver instance
- * @param[in] ep      Endpoint address
- * @param[in] udev    Pointer to USB device
- * @param[in] cb      Transfer completion callback
- * @param[in] cb_priv Completion callback callback private data
- * @param[in] size    Size of the buffer
- * @param[in] timeout Waiting period to wait for allocation to complete.
- *                    Use K_NO_WAIT to return without waiting,
- *                    or K_FOREVER to wait as long as necessary.
+ * @param[in] udev        Pointer to USB device
+ * @param[in] ep          Endpoint address
+ * @param[out] mps_p      If not NULL, receives the max packet size value
+ * @param[out] interval_p If not NULL, receives the interval value
+ * @param[out] type_p     If not NULL, receives the type value
  *
- * @return pointer to allocated transfer or NULL on error.
+ * @return 0 on success, all other values should be treated as error.
  */
-struct uhc_transfer *uhc_xfer_alloc_with_buf(const struct device *dev,
-					     const uint8_t ep,
-					     struct usb_device *const udev,
-					     void *const cb,
-					     void *const cb_priv,
-					     size_t size,
-					     const k_timeout_t timeout);
+int uhc_get_ep_properties(struct usb_device *const udev,
+			  const uint8_t ep,
+			  uint16_t *const mps_p,
+			  uint16_t *const interval_p,
+			  uint8_t *const type_p);
 
 /**
  * @brief Free UHC transfer and any buffers

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -419,6 +419,9 @@ static inline int uhc_bus_resume(const struct device *dev)
  * @param[in] udev    Pointer to USB device
  * @param[in] cb      Transfer completion callback
  * @param[in] cb_priv Completion callback callback private data
+ * @param[in] timeout Waiting period to wait for allocation to complete.
+ *                    Use K_NO_WAIT to return without waiting,
+ *                    or K_FOREVER to wait as long as necessary.
  *
  * @return pointer to allocated transfer or NULL on error.
  */
@@ -426,7 +429,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
 				    void *const cb,
-				    void *const cb_priv);
+				    void *const cb_priv,
+				    const k_timeout_t timeout);
 
 /**
  * @brief Allocate UHC transfer with buffer
@@ -439,6 +443,9 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
  * @param[in] cb      Transfer completion callback
  * @param[in] cb_priv Completion callback callback private data
  * @param[in] size    Size of the buffer
+ * @param[in] timeout Waiting period to wait for allocation to complete.
+ *                    Use K_NO_WAIT to return without waiting,
+ *                    or K_FOREVER to wait as long as necessary.
  *
  * @return pointer to allocated transfer or NULL on error.
  */
@@ -447,7 +454,8 @@ struct uhc_transfer *uhc_xfer_alloc_with_buf(const struct device *dev,
 					     struct usb_device *const udev,
 					     void *const cb,
 					     void *const cb_priv,
-					     size_t size);
+					     size_t size,
+					     const k_timeout_t timeout);
 
 /**
  * @brief Free UHC transfer and any buffers
@@ -482,13 +490,17 @@ int uhc_xfer_buf_add(const struct device *dev,
  * Allocate a new buffer from common request buffer pool and
  * assign it to the transfer if the xfer parameter is not NULL.
  *
- * @param[in] dev    Pointer to device struct of the driver instance
- * @param[in] size   Size of the request buffer
+ * @param[in] dev     Pointer to device struct of the driver instance
+ * @param[in] size    Size of the request buffer
+ * @param[in] timeout Waiting period to wait for allocation to complete.
+ *                    Use K_NO_WAIT to return without waiting,
+ *                    or K_FOREVER to wait as long as necessary.
  *
  * @return pointer to allocated request or NULL on error.
  */
 struct net_buf *uhc_xfer_buf_alloc(const struct device *dev,
-				   const size_t size);
+				   const size_t size,
+				   const k_timeout_t timeout);
 
 /**
  * @brief Free UHC request buffer

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -1002,7 +1002,7 @@ static int vs_get(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len);
+	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1071,7 +1071,7 @@ static int vs_set(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len);
+	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1520,13 +1520,13 @@ static int initiate_transfer(struct uvc_host_data *const host_data,
 	LOG_DBG("Initiating transfer: ep=0x%02x, vbuf=%p", stream_ep->bEndpointAddress, vbuf);
 
 	xfer = usbh_xfer_alloc(host_data->udev, stream_ep->bEndpointAddress,
-			       stream_iso_req_cb, host_data);
+			       stream_iso_req_cb, host_data, K_NO_WAIT);
 	if (xfer == NULL) {
 		LOG_ERR("Failed to allocate transfer");
 		return -ENOMEM;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult);
+	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
 		usbh_xfer_free(host_data->udev, xfer);
@@ -1558,7 +1558,7 @@ static int continue_transfer(struct uvc_host_data *const host_data,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult);
+	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
 		return -ENOMEM;
@@ -1848,7 +1848,7 @@ static int vc_get(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len);
+	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1917,7 +1917,7 @@ static int vc_set(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len);
+	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -1002,7 +1002,7 @@ static int vs_get(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, USB_CONTROL_EP_IN, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1071,7 +1071,7 @@ static int vs_set(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, USB_CONTROL_EP_OUT, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1526,7 +1526,8 @@ static int initiate_transfer(struct uvc_host_data *const host_data,
 		return -ENOMEM;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, xfer->ep, stream_info->ep_mps_mult,
+				  K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
 		usbh_xfer_free(host_data->udev, xfer);
@@ -1558,7 +1559,7 @@ static int continue_transfer(struct uvc_host_data *const host_data,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, xfer->ep, stream_info->ep_mps_mult, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
 		return -ENOMEM;
@@ -1848,7 +1849,7 @@ static int vc_get(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, USB_CONTROL_EP_IN, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1917,7 +1918,7 @@ static int vc_set(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, USB_CONTROL_EP_OUT, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;

--- a/subsys/usb/host/usbh_ch9.c
+++ b/subsys/usb/host/usbh_ch9.c
@@ -66,7 +66,7 @@ int usbh_req_setup(struct usb_device *const udev,
 	uint8_t ep = usb_reqtype_is_to_device(&req) ? 0x00 : 0x80;
 	int ret;
 
-	xfer = usbh_xfer_alloc(udev, ep, ch9_req_cb, NULL);
+	xfer = usbh_xfer_alloc(udev, ep, ch9_req_cb, NULL, K_NO_WAIT);
 	if (!xfer) {
 		return -ENOMEM;
 	}
@@ -135,7 +135,7 @@ int usbh_req_desc_dev(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, wLength, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}
@@ -164,7 +164,7 @@ int usbh_req_desc_cfg(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, len);
+	buf = usbh_xfer_buf_alloc(udev, len, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}
@@ -207,7 +207,7 @@ int usbh_req_get_cfg(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, wLength, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}

--- a/subsys/usb/host/usbh_ch9.c
+++ b/subsys/usb/host/usbh_ch9.c
@@ -135,7 +135,7 @@ int usbh_req_desc_dev(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, wLength, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, wLength, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}
@@ -164,7 +164,7 @@ int usbh_req_desc_cfg(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, len, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, len, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}
@@ -207,7 +207,7 @@ int usbh_req_get_cfg(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, wLength, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, wLength, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -58,11 +58,12 @@ void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev);
 static inline struct uhc_transfer *usbh_xfer_alloc(struct usb_device *udev,
 						   const uint8_t ep,
 						   usbh_udev_cb_t cb,
-						   void *const cb_priv)
+						   void *const cb_priv,
+						   const k_timeout_t timeout)
 {
 	struct usbh_context *const ctx = udev->ctx;
 
-	return uhc_xfer_alloc(ctx->dev, ep, udev, cb, cb_priv);
+	return uhc_xfer_alloc(ctx->dev, ep, udev, cb, cb_priv, timeout);
 }
 
 static inline int usbh_xfer_buf_add(const struct usb_device *udev,
@@ -75,11 +76,12 @@ static inline int usbh_xfer_buf_add(const struct usb_device *udev,
 }
 
 static inline struct net_buf *usbh_xfer_buf_alloc(struct usb_device *udev,
-						  const size_t size)
+						  const size_t size,
+						  k_timeout_t timeout)
 {
 	struct usbh_context *const ctx = udev->ctx;
 
-	return uhc_xfer_buf_alloc(ctx->dev, size);
+	return uhc_xfer_buf_alloc(ctx->dev, size, timeout);
 }
 
 static inline int usbh_xfer_free(const struct usb_device *udev,

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -76,12 +76,53 @@ static inline int usbh_xfer_buf_add(const struct usb_device *udev,
 }
 
 static inline struct net_buf *usbh_xfer_buf_alloc(struct usb_device *udev,
+						  const uint8_t ep,
 						  const size_t size,
 						  k_timeout_t timeout)
 {
 	struct usbh_context *const ctx = udev->ctx;
+	size_t alloc_size;
+	uint16_t mps = 0;
+	int ret;
 
-	return uhc_xfer_buf_alloc(ctx->dev, size, timeout);
+	ret = uhc_get_ep_properties(udev, ep, &mps, NULL, NULL);
+	if (ret != 0) {
+		return NULL;
+	}
+
+	if (USB_EP_DIR_IS_IN(ep)) {
+		alloc_size = ROUND_UP(size, mps);
+	} else {
+		alloc_size = size;
+	}
+
+	return uhc_xfer_buf_alloc(ctx->dev, alloc_size, timeout);
+}
+
+static inline struct uhc_transfer *usbh_xfer_alloc_with_buf(struct usb_device *const udev,
+							    const uint8_t ep,
+							    size_t size,
+							    void *const cb,
+							    void *const cb_priv,
+							    const k_timeout_t timeout)
+{
+	struct uhc_transfer *xfer;
+	struct net_buf *buf;
+
+	buf = usbh_xfer_buf_alloc(udev, ep, size, timeout);
+	if (buf == NULL) {
+		return NULL;
+	}
+
+	xfer = usbh_xfer_alloc(udev, ep, cb, cb_priv, timeout);
+	if (xfer == NULL) {
+		net_buf_unref(buf);
+		return NULL;
+	}
+
+	(void)usbh_xfer_buf_add(udev, xfer, buf);
+
+	return xfer;
 }
 
 static inline int usbh_xfer_free(const struct usb_device *udev,

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -252,7 +252,7 @@ static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 	ep = strtol(argv[2], NULL, 16);
 	len = MIN(sizeof(vreq_test_buf), strtol(argv[3], NULL, 10));
 
-	xfer = usbh_xfer_alloc(udev, ep, bulk_req_cb, NULL);
+	xfer = usbh_xfer_alloc(udev, ep, bulk_req_cb, NULL, K_NO_WAIT);
 	if (!xfer) {
 		shell_error(sh, "host: Failed to allocate transfer");
 		return -ENOMEM;

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -231,7 +231,6 @@ static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 	static struct usb_device *udev;
 	struct usbh_context *uhs_ctx;
 	struct uhc_transfer *xfer;
-	struct net_buf *buf;
 	uint8_t addr;
 	uint8_t ep;
 	size_t len;
@@ -252,22 +251,14 @@ static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 	ep = strtol(argv[2], NULL, 16);
 	len = MIN(sizeof(vreq_test_buf), strtol(argv[3], NULL, 10));
 
-	xfer = usbh_xfer_alloc(udev, ep, bulk_req_cb, NULL, K_NO_WAIT);
+	xfer = usbh_xfer_alloc_with_buf(udev, ep, len, bulk_req_cb, NULL, K_NO_WAIT);
 	if (!xfer) {
 		shell_error(sh, "host: Failed to allocate transfer");
 		return -ENOMEM;
 	}
 
-	buf = usbh_xfer_buf_alloc(udev, len);
-	if (!buf) {
-		shell_error(sh, "host: Failed to allocate buffer");
-		usbh_xfer_free(udev, xfer);
-		return -ENOMEM;
-	}
-
-	xfer->buf = buf;
 	if (USB_EP_DIR_IS_OUT(ep)) {
-		net_buf_add_mem(buf, vreq_test_buf, len);
+		net_buf_add_mem(xfer->buf, vreq_test_buf, len);
 	}
 
 	k_sem_reset(&bulk_req_sync);
@@ -321,7 +312,7 @@ static int cmd_vendor_in(const struct shell *sh,
 	}
 
 	wLength = MIN(sizeof(vreq_test_buf), strtol(argv[2], NULL, 10));
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, wLength, K_NO_WAIT);
 	if (!buf) {
 		shell_error(sh, "host: Failed to allocate buffer");
 		return -ENOMEM;
@@ -364,7 +355,7 @@ static int cmd_vendor_out(const struct shell *sh,
 	}
 
 	wLength = MIN(sizeof(vreq_test_buf), strtol(argv[2], NULL, 10));
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, wLength, K_NO_WAIT);
 	if (!buf) {
 		shell_error(sh, "host: Failed to allocate buffer");
 		return -ENOMEM;
@@ -469,7 +460,7 @@ static int cmd_desc_string(const struct shell *sh,
 	id = strtol(argv[2], NULL, 10);
 	idx = strtol(argv[3], NULL, 10);
 
-	buf = usbh_xfer_buf_alloc(udev, 128);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, 128, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}

--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -269,7 +269,7 @@ static int usbip_handle_submit(struct usbip_dev_ctx *const dev_ctx,
 	ep = cmd->hdr.ep;
 	if (cmd->submit.length != 0) {
 		if (USB_EP_GET_IDX(ep) == 0U) {
-			buf = usbh_xfer_buf_alloc(dev_ctx->udev, cmd->submit.length, K_NO_WAIT);
+			buf = usbh_xfer_buf_alloc(dev_ctx->udev, ep, cmd->submit.length, K_NO_WAIT);
 		} else {
 			buf = net_buf_alloc_len(&usbip_pool, cmd->submit.length, K_NO_WAIT);
 		}

--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -27,7 +27,7 @@ NET_BUF_POOL_VAR_DEFINE(usbip_pool,
 			CONFIG_USBIP_BUF_COUNT, CONFIG_USBIP_BUF_POOL_SIZE,
 			0, NULL);
 
-#define USBIP_SUBMIT_REQ_RETRY_COUNT	10
+#define USBIP_SUBMIT_REQ_TIMEOUT	K_MSEC(10)
 
 K_THREAD_STACK_DEFINE(usbip_thread_stack, CONFIG_USBIP_THREAD_STACK_SIZE);
 K_THREAD_STACK_ARRAY_DEFINE(dev_thread_stacks, CONFIG_USBIP_DEVICES_COUNT,
@@ -214,22 +214,13 @@ static int usbip_submit_req(struct usbip_cmd_node *const cmd_nd, const uint8_t e
 	struct usbip_dev_ctx *const dev_ctx = cmd_nd->ctx;
 	struct usbip_command *const cmd = &cmd_nd->cmd;
 	struct usb_device *const udev = dev_ctx->udev;
-	uint32_t retry = USBIP_SUBMIT_REQ_RETRY_COUNT;
 	struct uhc_transfer *xfer;
 	int ret;
 
-	/*
-	 * Depending on the server, functions, and client application, we may
-	 * get out of transfers very quickly. To throttle here may allow
-	 * submitted transfers to be finished. Perhaps usbh_xfer_alloc() should
-	 * be reworked to take a timeout argument.
-	 */
-	do {
-		xfer = usbh_xfer_alloc(udev, ep, usbip_req_cb, cmd_nd);
-		if (xfer == NULL) {
-			k_msleep(1);
-		}
-	} while (xfer == NULL && retry--);
+	xfer = usbh_xfer_alloc(udev, ep, usbip_req_cb, cmd_nd, USBIP_SUBMIT_REQ_TIMEOUT);
+	if (xfer == NULL) {
+		return -ENOMEM;
+	}
 
 	if (setup != NULL) {
 		memcpy(xfer->setup_pkt, setup, sizeof(struct usb_setup_packet));
@@ -278,7 +269,7 @@ static int usbip_handle_submit(struct usbip_dev_ctx *const dev_ctx,
 	ep = cmd->hdr.ep;
 	if (cmd->submit.length != 0) {
 		if (USB_EP_GET_IDX(ep) == 0U) {
-			buf = usbh_xfer_buf_alloc(dev_ctx->udev, cmd->submit.length);
+			buf = usbh_xfer_buf_alloc(dev_ctx->udev, cmd->submit.length, K_NO_WAIT);
 		} else {
 			buf = net_buf_alloc_len(&usbip_pool, cmd->submit.length, K_NO_WAIT);
 		}

--- a/tests/subsys/usb/device_next/src/main.c
+++ b/tests/subsys/usb/device_next/src/main.c
@@ -86,7 +86,7 @@ ZTEST(device_next, test_get_desc_string)
 	udev = usbh_device_get_any(&uhs_ctx);
 	zassert_not_null(udev, "No USB device available");
 
-	buf = usbh_xfer_buf_alloc(udev, UINT8_MAX);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, UINT8_MAX, K_NO_WAIT);
 	zassert_not_null(udev, "Failed to allocate buffer");
 
 	err = k_mutex_lock(&udev->mutex, K_MSEC(200));
@@ -131,7 +131,7 @@ ZTEST(device_next, test_vendor_control_in)
 	udev = usbh_device_get_any(&uhs_ctx);
 	zassert_not_null(udev, "No USB device available");
 
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, wLength, K_NO_WAIT);
 	zassert_not_null(udev, "Failed to allocate buffer");
 
 	err = k_mutex_lock(&udev->mutex, K_MSEC(200));
@@ -189,7 +189,7 @@ ZTEST(device_next, test_vendor_control_out)
 	udev = usbh_device_get_any(&uhs_ctx);
 	zassert_not_null(udev, "No USB device available");
 
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_OUT, wLength, K_NO_WAIT);
 	zassert_not_null(udev, "Failed to allocate buffer");
 
 	err = k_mutex_lock(&udev->mutex, K_MSEC(200));

--- a/tests/subsys/usb/host/src/class.c
+++ b/tests/subsys/usb/host/src/class.c
@@ -42,7 +42,7 @@ static int usbh_foo_init(struct usbh_class_data *const c_data)
 {
 	struct usbh_foo_priv *priv = c_data->priv;
 
-	LOG_DBG("initializing %p, priv value 0x%x", c_data, *priv);
+	LOG_DBG("initializing %p, priv value 0x%x", c_data, priv->state);
 
 	zassert_equal(priv->state, FOO_CLASS_PRIV_INACTIVE,
 		      "Class should be initialized only once");


### PR DESCRIPTION
In order to better support conditions when too much data received from devices, align all allocation sizes to the upper `wMaxPacketSize` (or `wMaxPacketSize0` for control endpoints).

This requires knowing the `wMaxPacketSize` from all the allocation functions so refactoring was needed.

Tested with CI and USB/IP:
```
sudo modprobe ...
sh ../tools/net-tools/net-setup.sh
```
```
west build -p -b native_sim/native/64 samples/subsys/usb/cdc_acm -- \
  -DSNIPPET=usbip-native-sim -DEXTRA_DTC_OVERLAY_FILE=app.overlay
```

Reference visible in the datasheet section 3.4, item 5 (sorry, cannot quote, NDA).