### PR TITLE
soc: nxp: mcxe24x: fix watchdog reset loop when CONFIG_WATCHDOG=n

### DIFF
--- a/soc/nxp/mcx/mcxe/mcxe24x/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxe/mcxe24x/Kconfig.defconfig
@@ -33,7 +33,7 @@ choice CACHE_TYPE
 	default EXTERNAL_CACHE
 endchoice
 
-configdefault WDT_DISABLE_AT_BOOT
+config WDT_DISABLE_AT_BOOT
 	default y
 
 endif # SOC_SERIES_MCXE24X


### PR DESCRIPTION
The use of 'configdefault' for 'WDT_DISABLE_AT_BOOT' prevents the symbol from being defined when the watchdog driver is disabled.

On MCXE24x series SOCs, the NXP SDK startup code (SystemInit) uses this symbol (via the DISABLE_WDOG compiler definition) to decide whether to disable the hardware watchdog. If the symbol is missing from the Kconfig output, the build system defaults to leaving the watchdog enabled (DISABLE_WDOG=0).

Since the MCXE hardware watchdog is enabled by default after reset, this leads to an infinite reset loop approximately 1 second after boot for all applications that do not explicitly enable the watchdog driver.   Many of the samples do not run due to this.  

Reverting to 'config' ensures the symbol is always defined and the watchdog is correctly disabled at boot unless explicitly overridden.

Hardware verification on frdm_mcxe247 confirms the reset loop is resolved with this change. I have used the blinky and hello_world sample to verify. Alternatively this board.conf addition can be used as a work-around.   
CONFIG_WATCHDOG=y
CONFIG_WDT_DISABLE_AT_BOOT=y   

I also verified that in v4.4.0-rc3 this error does not occur.  

Fixes: 3a7500de7484 ("soc: nxp: mcxe24x: enable LPTMR as system timer")
Assisted-by: Gemini-CLI:0.44.1
Signed-off-by: Jan-Willem Smaal <usenet@gispen.org>