### PR TITLE
boards: drivers: rpi_pico2: Prepare for rp2350 AMP

### DIFF
--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_common.dtsi
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_common.dtsi
@@ -6,26 +6,9 @@
 
 #include <freq.h>
 
-#include <zephyr/dt-bindings/i2c/i2c.h>
-#include <zephyr/dt-bindings/pwm/pwm.h>
-#include <raspberrypi/partitions_0x0_default.dtsi>
-
 #include "rpi_pico2-pinctrl.dtsi"
 
 / {
-	chosen {
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-		zephyr,flash-controller = &qmi;
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
-		zephyr,code-partition = &code_partition;
-	};
-
-	aliases {
-		watchdog0 = &wdt0;
-	};
-
 	pico_header: connector {
 		compatible = "raspberrypi,pico-header";
 		#gpio-cells = <2>;
@@ -65,62 +48,7 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 };
 
-&uart0 {
-	current-speed = <115200>;
-	status = "okay";
-	pinctrl-0 = <&uart0_default>;
-	pinctrl-names = "default";
-};
-
 gpio0_lo: &gpio0 {
-	status = "okay";
-};
-
-&spi0 {
-	clock-frequency = <DT_FREQ_M(8)>;
-	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
-};
-
-&i2c0 {
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	pinctrl-0 = <&i2c0_default>;
-	pinctrl-names = "default";
-	status = "okay";
-};
-
-&i2c1 {
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	pinctrl-0 = <&i2c1_default>;
-	pinctrl-names = "default";
-	status = "okay";
-};
-
-&adc {
-	pinctrl-0 = <&adc_default>;
-	pinctrl-names = "default";
-	status = "okay";
-};
-
-&pwm {
-	pinctrl-0 = <&pwm_ch4b_default>;
-	pinctrl-names = "default";
-	divider-int-0 = <255>;
-};
-
-&timer0 {
-	status = "okay";
-};
-
-&wdt0 {
-	status = "okay";
-};
-
-&rng {
-	status = "okay";
-};
-
-zephyr_udc0: &usbd {
 	status = "okay";
 };
 

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_cpu0_common.dtsi
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_cpu0_common.dtsi
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <freq.h>
+
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <raspberrypi/partitions_0x0_default.dtsi>
+
+#include "rpi_pico2_common.dtsi"
+
+/ {
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,flash-controller = &qmi;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
+	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
+};
+
+&uart0 {
+	current-speed = <115200>;
+	status = "okay";
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-names = "default";
+};
+
+&spi0 {
+	clock-frequency = <DT_FREQ_M(8)>;
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-names = "default";
+};
+
+&i2c0 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&i2c1 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&adc {
+	pinctrl-0 = <&adc_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&pwm {
+	pinctrl-0 = <&pwm_ch4b_default>;
+	pinctrl-names = "default";
+	divider-int-0 = <255>;
+};
+
+&timer0 {
+	status = "okay";
+};
+
+&wdt0 {
+	status = "okay";
+};
+
+&rng {
+	status = "okay";
+};
+
+zephyr_udc0: &usbd {
+	status = "okay";
+};

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_hazard3.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_hazard3.dts
@@ -15,5 +15,5 @@
  */
 #include <raspberrypi/rpi_pico/rp2350a.dtsi>
 #include <riscv/raspberrypi/hazard3.dtsi>
-#include "rpi_pico2.dtsi"
+#include "rpi_pico2_cpu0_common.dtsi"
 #include "../common/rpi_pico-led.dtsi"

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33.dts
@@ -15,5 +15,5 @@
  */
 #include <raspberrypi/rpi_pico/rp2350a.dtsi>
 #include <raspberrypi/rpi_pico/m33.dtsi>
-#include "rpi_pico2.dtsi"
+#include "rpi_pico2_cpu0_common.dtsi"
 #include "../common/rpi_pico-led.dtsi"

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_mcuboot.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_mcuboot.dts
@@ -15,11 +15,7 @@
  */
 #include <raspberrypi/rpi_pico/rp2350a.dtsi>
 #include <raspberrypi/rpi_pico/m33.dtsi>
-
-/* there's nothing specific to the Cortex-M33 cores vs the (not yet
- * implemented) Hazard3 cores.
- */
-#include "rpi_pico2.dtsi"
+#include "rpi_pico2_cpu0_common.dtsi"
 #include "../common/rpi_pico-led.dtsi"
 
 /* Partitioning for the RP2350A-M33 board using 4M flash.

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w.dts
@@ -15,11 +15,7 @@
  */
 #include <raspberrypi/rpi_pico/rp2350a.dtsi>
 #include <raspberrypi/rpi_pico/m33.dtsi>
-
-/* there's nothing specific to the Cortex-M33 cores vs the (not yet
- * implemented) Hazard3 cores.
- */
-#include "rpi_pico2.dtsi"
+#include "rpi_pico2_cpu0_common.dtsi"
 
 &pinctrl {
 	pio0_spi0_default: pio0_spi0_default {

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w_mcuboot.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w_mcuboot.dts
@@ -15,11 +15,7 @@
  */
 #include <raspberrypi/rpi_pico/rp2350a.dtsi>
 #include <raspberrypi/rpi_pico/m33.dtsi>
-
-/* there's nothing specific to the Cortex-M33 cores vs the (not yet
- * implemented) Hazard3 cores.
- */
-#include "rpi_pico2.dtsi"
+#include "rpi_pico2_cpu0_common.dtsi"
 
 &pinctrl {
 	pio0_spi0_default: pio0_spi0_default {

--- a/drivers/clock_control/Kconfig.rpi_pico
+++ b/drivers/clock_control/Kconfig.rpi_pico
@@ -14,7 +14,13 @@ if CLOCK_CONTROL_RPI_PICO
 config RPI_PICO_ROSC_USE_MEASURED_FREQ
 	bool "Use measured frequency for ring oscillator"
 	help
-	 Instead of the dts value, use the value measured by
-	 the frequency counter as the rosc frequency.
+	  Instead of the dts value, use the value measured by
+	  the frequency counter as the rosc frequency.
+
+config RPI_PICO_SKIP_CLOCK_INIT
+	bool
+	help
+	  Skip clock initialisation - which is needed when running Zephyr
+	  on the second CPU core.
 
 endif # CLOCK_CONTROL_RPI_PICO

--- a/drivers/clock_control/clock_control_rpi_pico.c
+++ b/drivers/clock_control/clock_control_rpi_pico.c
@@ -278,7 +278,8 @@ uint64_t rpi_pico_frequency_count(const struct device *dev, clock_control_subsys
 	       ((fc0->result & CLOCKS_FC0_RESULT_FRAC_BITS) * 1000 / CLOCKS_FC0_RESULT_FRAC_BITS);
 }
 
-static int rpi_pico_rosc_write(const struct device *dev, io_rw_32 *addr, uint32_t value)
+__maybe_unused static int rpi_pico_rosc_write(const struct device *dev, io_rw_32 *addr,
+					      uint32_t value)
 {
 	hw_clear_bits(&rosc_hw->status, ROSC_STATUS_BADWRITE_BITS);
 
@@ -621,14 +622,16 @@ static int clock_control_rpi_pico_get_rate(const struct device *dev, clock_contr
 	return 0;
 }
 
-void rpi_pico_clkid_tuple_swap(struct rpi_pico_clkid_tuple *lhs, struct rpi_pico_clkid_tuple *rhs)
+__maybe_unused static void rpi_pico_clkid_tuple_swap(struct rpi_pico_clkid_tuple *lhs,
+						     struct rpi_pico_clkid_tuple *rhs)
 {
 	struct rpi_pico_clkid_tuple tmp = *lhs;
 	*lhs = *rhs;
 	*rhs = tmp;
 }
 
-void rpi_pico_clkid_tuple_reorder_by_dependencies(struct rpi_pico_clkid_tuple *tuples, size_t len)
+__maybe_unused static void
+rpi_pico_clkid_tuple_reorder_by_dependencies(struct rpi_pico_clkid_tuple *tuples, size_t len)
 {
 	uint32_t sorted_idx = 0;
 	uint32_t checked_idx = 0;
@@ -647,6 +650,7 @@ void rpi_pico_clkid_tuple_reorder_by_dependencies(struct rpi_pico_clkid_tuple *t
 
 static int clock_control_rpi_pico_init(const struct device *dev)
 {
+#if !defined(CONFIG_RPI_PICO_SKIP_CLOCK_INIT)
 	const uint32_t cycles_per_tick = CLOCK_FREQ_xosc / 1000000;
 	const struct clock_control_rpi_pico_config *config = dev->config;
 	struct clock_control_rpi_pico_data *data = dev->data;
@@ -778,6 +782,7 @@ static int clock_control_rpi_pico_init(const struct device *dev)
 		return ret;
 	}
 
+#endif /* CONFIG_RPI_PICO_SKIP_CLOCK_INIT */
 	return 0;
 }
 

--- a/drivers/mbox/mbox_rpi_pico.c
+++ b/drivers/mbox/mbox_rpi_pico.c
@@ -10,7 +10,7 @@
 #include <zephyr/irq.h>
 /* pico-sdk includes */
 #include <hardware/structs/sio.h>
-
+#include <zephyr/drivers/misc/mbox_rpi_pico/mbox_rpi_pico.h>
 
 #define DT_DRV_COMPAT raspberrypi_pico_mbox
 
@@ -43,32 +43,6 @@ static inline void fifo_clear_status(void)
 	mbox_sio_hw->fifo_st = 0xff;
 }
 
-/*
- * Returns true if the write FIFO isn't full. Returns false otherwise.
- */
-static inline bool fifo_write_ready(void)
-{
-	return mbox_sio_hw->fifo_st & SIO_FIFO_ST_RDY_BITS;
-}
-
-/*
- * Returns true if the read FIFO has data available, ie. sent by the
- * other core. Returns false otherwise.
- */
-static inline bool fifo_read_valid(void)
-{
-	return mbox_sio_hw->fifo_st & SIO_FIFO_ST_VLD_BITS;
-}
-
-/*
- * Discard any data in the read FIFO.
- */
-static inline void fifo_drain(void)
-{
-	while (fifo_read_valid()) {
-		(void)mbox_sio_hw->fifo_rd;
-	}
-}
 
 static int rpi_pico_mbox_send(const struct device *dev,
 				mbox_channel_id_t channel,
@@ -77,13 +51,13 @@ static int rpi_pico_mbox_send(const struct device *dev,
 	ARG_UNUSED(dev);
 	ARG_UNUSED(channel);
 
-	if (!fifo_write_ready()) {
+	if (!rpi_pico_mbox_write_ready(mbox_sio_hw)) {
 		return -EBUSY;
 	}
 	/* Signalling mode: send 0 as dummy data. */
 	if (msg == NULL) {
 		LOG_DBG("CPU %d: send IP signal", mbox_sio_hw->cpuid);
-		mbox_sio_hw->fifo_wr = 0;
+		rpi_pico_mbox_write(mbox_sio_hw, 0);
 		__SEV();
 		return 0;
 	}
@@ -92,7 +66,7 @@ static int rpi_pico_mbox_send(const struct device *dev,
 		return -EMSGSIZE;
 	}
 	LOG_DBG("CPU %d: send IP data: %d", mbox_sio_hw->cpuid, *((int *)msg->data));
-	mbox_sio_hw->fifo_wr = *((uint32_t *)(msg->data));
+	rpi_pico_mbox_write(mbox_sio_hw, *((uint32_t *)(msg->data)));
 	__SEV();
 
 	return 0;
@@ -157,19 +131,19 @@ static void rpi_pico_mbox_isr(const struct device *dev)
 	 * NOTE: the interrupt seems to be triggered when it's first
 	 * enabled even when the FIFO is empty.
 	 */
-	if (!fifo_read_valid()) {
+	if (!rpi_pico_mbox_read_valid(mbox_sio_hw)) {
 		LOG_DBG("Interrupt received on empty FIFO: ignored.");
 		return;
 	}
 
 	if (data->cb != NULL) {
-		uint32_t d = mbox_sio_hw->fifo_rd;
+		uint32_t d = rpi_pico_mbox_read(mbox_sio_hw);
 		struct mbox_msg msg = {
 			.data = &d,
 			.size = sizeof(d)};
 		data->cb(dev, 0, data->user_data, &msg);
 	}
-	fifo_drain();
+	rpi_pico_mbox_drain(mbox_sio_hw);
 }
 
 static int rpi_pico_mbox_init(const struct device *dev)
@@ -179,7 +153,7 @@ static int rpi_pico_mbox_init(const struct device *dev)
 	LOG_DBG("Initial FIFO status: 0x%x", mbox_sio_hw->fifo_st);
 	LOG_DBG("FIFO depth: %d", DT_INST_PROP(0, fifo_depth));
 	irq_disable(DT_INST_IRQ_BY_NAME(0, MAILBOX_DEV_NAME, irq));
-	fifo_drain();
+	rpi_pico_mbox_drain(mbox_sio_hw);
 	fifo_clear_status();
 	LOG_DBG("FIFO status after setup: 0x%x", mbox_sio_hw->fifo_st);
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, MAILBOX_DEV_NAME, irq),

--- a/include/zephyr/drivers/misc/mbox_rpi_pico/mbox_rpi_pico.h
+++ b/include/zephyr/drivers/misc/mbox_rpi_pico/mbox_rpi_pico.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025 Igalia S.L.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for Raspberry Pi Pico mailbox
+ * @ingroup mbox_rpi_pico_interface
+ */
+
+#ifndef ZEPHYR_DRIVERS_MISC_MBOX_PICO_RPI_PIO_PICO_RPI_H_
+#define ZEPHYR_DRIVERS_MISC_MBOX_PICO_RPI_PIO_PICO_RPI_H_
+
+/**
+ * @brief Interfaces for Raspberry Pi Pico SIO FIFO mailbox.
+ * @defgroup mbox_rpi_pico_interface Raspberry Pi Pico mailbox
+ * @ingroup misc_interfaces
+ *
+ * @{
+ */
+
+#include <hardware/structs/sio.h>
+
+/**
+ * Check if FIFO is writeable
+ *
+ * @param sio_block pointer to sio struct
+ * @retval true if the write FIFO isn't full
+ * @retval false if there is no space to write to FIFO.
+ */
+static inline bool rpi_pico_mbox_write_ready(sio_hw_t *const sio_block)
+{
+	return sio_block->fifo_st & SIO_FIFO_ST_RDY_BITS;
+}
+
+/**
+ * Check if FIFO is readable
+ *
+ * @param sio_block pointer to sio struct
+ * @retval true if the read FIFO has data available
+ * @retval false otherwise
+ */
+static inline bool rpi_pico_mbox_read_valid(sio_hw_t *const sio_block)
+{
+	return sio_block->fifo_st & SIO_FIFO_ST_VLD_BITS;
+}
+
+/**
+ * Discard pending messages in FIFO
+ *
+ * @param sio_block pointer to sio struct
+ */
+static inline void rpi_pico_mbox_drain(sio_hw_t *const sio_block)
+{
+	while (rpi_pico_mbox_read_valid(sio_block)) {
+		(void)sio_block->fifo_rd;
+	}
+}
+
+/**
+ * Check if FIFO is writeable
+ *
+ * @param sio_block pointer to sio struct
+ * @param value to be pushed
+ */
+static inline void rpi_pico_mbox_write(sio_hw_t *const sio_block, uint32_t value)
+{
+	sio_block->fifo_wr = value;
+}
+
+/**
+ * Check if FIFO is readable
+ *
+ * @param sio_block pointer to sio struct
+ * @retval value received from the FIFO
+ */
+static inline uint32_t rpi_pico_mbox_read(sio_hw_t *const sio_block)
+{
+	return sio_block->fifo_rd;
+}
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_DRIVERS_MISC_MBOX_PICO_RPI_PIO_PICO_RPI_H_ */


### PR DESCRIPTION
Before we support using the second core of the rpi_pico2's rp2350 SoC, we must:
- Move the low level SIO mbox access functions to a driver header
- Add hidden Kconfig option that will skip clock initialization in the clock controller driver.
- In preparation for adding the `rpi_pico2/.../cpu1` board target, factor out the board devicetree files to  common between CPU0 and CPU1 board variants and common to CPU0 board variants.

Created from discussion in https://github.com/zephyrproject-rtos/zephyr/pull/109953#issuecomment-4585086100