### PR TITLE
boards: nucode: add NU32 board support

### DIFF
--- a/boards/nucode/nucode_nu32/Kconfig.defconfig
+++ b/boards/nucode/nucode_nu32/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# NUCODE NU32 board configuration
+
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NUCODE_NU32
+
+config HW_STACK_PROTECTION
+	default ARCH_HAS_STACK_PROTECTION
+
+endif # BOARD_NUCODE_NU32

--- a/boards/nucode/nucode_nu32/Kconfig.nucode_nu32
+++ b/boards/nucode/nucode_nu32/Kconfig.nucode_nu32
@@ -1,0 +1,7 @@
+# NUCODE NU32 board configuration
+
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_NUCODE_NU32
+	select SOC_NRF52832_QFAA

--- a/boards/nucode/nucode_nu32/board.cmake
+++ b/boards/nucode/nucode_nu32/board.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52832" "--frequency=4000000")
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/nucode/nucode_nu32/board.yml
+++ b/boards/nucode/nucode_nu32/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: nucode_nu32
+  full_name: NUCODE NU32
+  vendor: nucode
+  socs:
+  - name: nrf52832

--- a/boards/nucode/nucode_nu32/doc/index.rst
+++ b/boards/nucode/nucode_nu32/doc/index.rst
@@ -1,0 +1,85 @@
+.. zephyr:board:: nucode_nu32
+
+Overview
+********
+
+The NUCODE NU32 is a compact module based on the Nordic Semiconductor
+nRF52832 ARM Cortex-M4F SoC. It supports Bluetooth Low Energy (BLE) 5.x
+and NFC-A. Unlike the NUCODE NU40, the nRF52832 has no USB device
+controller, so firmware is programmed over the SWD debug interface.
+
+More information about the board can be found at the
+`NUCODE NU32 website`_.
+
+Hardware
+********
+
+The ``nucode_nu32/nrf52832`` board target is built around the nRF52832
+(512 KB flash, 64 KB RAM, QFN48). The board uses the nRF52832 internal
+low-frequency RC oscillator by default.
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+Connections and IOs
+===================
+
+UART
+----
+
+* UART0: TX = P0.06, RX = P0.08, RTS = P0.05, CTS = P0.07
+
+NFC
+---
+
+* NFC-A antenna pins: P0.09 and P0.10
+
+Reset
+-----
+
+* RESET = P0.21 (configured through UICR as the hardware reset pin)
+
+SWD
+---
+
+* The SWDCLK and SWDIO debug pads are used for flashing and debugging.
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+Applications for the ``nucode_nu32/nrf52832`` board target can be built
+and flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
+Flashing
+========
+
+The board is programmed and debugged using an external
+:ref:`debug probe <debug-probes>` (for example a SEGGER J-Link) connected
+to the SWD pads.
+
+#. Build and flash the :zephyr:code-sample:`hello_world` sample:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: nucode_nu32/nrf52832
+      :goals: build flash
+
+#. Open a serial terminal (115200 8N1) connected to the UART0 pins and
+   reset the board to see the output.
+
+Debugging
+=========
+
+Refer to the :ref:`application_run` page for more details on debugging.
+
+References
+**********
+
+.. target-notes::
+
+.. _NUCODE NU32 website: https://nuworks.io

--- a/boards/nucode/nucode_nu32/nucode_nu32_nrf52832-pinctrl.dtsi
+++ b/boards/nucode/nucode_nu32/nucode_nu32_nrf52832-pinctrl.dtsi
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart0_default: uart0_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>,
+				<NRF_PSEL(UART_RX, 0, 8)>,
+				<NRF_PSEL(UART_RTS, 0, 5)>,
+				<NRF_PSEL(UART_CTS, 0, 7)>;
+		};
+	};
+
+	uart0_sleep: uart0_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
+				<NRF_PSEL(UART_RTS, 0, 5)>,
+				<NRF_PSEL(UART_CTS, 0, 7)>;
+			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+			low-power-enable;
+			bias-pull-up;
+		};
+	};
+};

--- a/boards/nucode/nucode_nu32/nucode_nu32_nrf52832.dts
+++ b/boards/nucode/nucode_nu32/nucode_nu32_nrf52832.dts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf52832_qfaa.dtsi>
+#include "nucode_nu32_nrf52832-pinctrl.dtsi"
+
+/ {
+	model = "NUCODE NU32 NRF52832";
+	compatible = "nucode,nucode-nu32-nrf52832";
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,bt-c2h-uart = &uart0;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
+};
+
+&reg {
+	regulator-initial-mode = <NRF5X_REG_MODE_DCDC>;
+};
+
+&uicr {
+	gpio-as-nreset;
+};
+
+&adc {
+	status = "okay";
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&nfct {
+	status = "okay";
+};
+
+&uart0 {
+	compatible = "nordic,nrf-uarte";
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-1 = <&uart0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&flash0 {
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
+			reg = <0x00000000 0xc000>;
+		};
+
+		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x0000c000 0x37000>;
+		};
+
+		slot1_partition: partition@43000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
+			reg = <0x00043000 0x37000>;
+		};
+
+		storage_partition: partition@7a000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x0007a000 0x00006000>;
+		};
+	};
+};

--- a/boards/nucode/nucode_nu32/nucode_nu32_nrf52832.yaml
+++ b/boards/nucode/nucode_nu32/nucode_nu32_nrf52832.yaml
@@ -1,0 +1,17 @@
+identifier: nucode_nu32/nrf52832
+name: NUCODE-NU32-NRF52832
+type: mcu
+arch: arm
+ram: 64
+flash: 512
+toolchain:
+  - zephyr
+  - gnuarmemb
+supported:
+  - adc
+  - ble
+  - counter
+  - gpio
+  - nfc
+  - watchdog
+vendor: nucode

--- a/boards/nucode/nucode_nu32/nucode_nu32_nrf52832_defconfig
+++ b/boards/nucode/nucode_nu32/nucode_nu32_nrf52832_defconfig
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Use the internal low-frequency RC oscillator by default.
+CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
+
+# Enable GPIO
+CONFIG_GPIO=y
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/nucode/nucode_nu32/pre_dt_board.cmake
+++ b/boards/nucode/nucode_nu32/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@40000000 & clock@40000000 & bprot@40000000
+# - acl@4001e000 & flash-controller@4001e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
## Summary

Adds initial Zephyr board support for the **NUCODE NU32** module, based on
the Nordic **nRF52832** SoC. This is the second NUCODE board after
`nucode_nu40` (nRF52840), added in #107151.

Board target: `nucode_nu32/nrf52832`

## Hardware

- ARM Cortex-M4F @ 64 MHz, 512 KB flash, 64 KB RAM (nRF52832-QFAA, QFN48)
- Bluetooth Low Energy 5.x and NFC-A
- UART console (TX P0.06 / RX P0.08 / RTS P0.05 / CTS P0.07)
- Programmed and debugged over the SWD interface

Unlike the NU40, the nRF52832 has no USB device controller, so the board is
flashed with an external SWD debug probe instead of a USB UF2 bootloader.
User LEDs and buttons are intentionally left out of this initial port and
will be added in a follow-up once validated on real carrier hardware.

## Supported features

- UART console / shell
- GPIO
- SWD flashing/debugging via the J-Link, pyOCD, nrfutil, nrfjprog and
  OpenOCD runners

## Local build

```
west build -p always -b nucode_nu32/nrf52832 samples/hello_world
```

Memory footprint: FLASH 19688 B (3.76% of 512 KB), RAM 4480 B (6.84% of 64 KB).

## Hardware validation

Built and flashed `samples/hello_world` onto a physical NU32 module
(rev NU32-B-Dev04) with a SEGGER J-Link EDU Mini V2 (S/N 802010296);
console captured over RTT:

```
*** Booting Zephyr OS build v4.4.0-3679-g43609419c807 ***
Hello World! nucode_nu32/nrf52832
```

## References

- NUCODE NU32: https://nuworks.io/wiki/software/NU32
- NUCODE NU40 board support (reference): #107151
