### PR TITLE
dts: xilinx: zynq7000: add SPI device nodes

### DIFF
--- a/dts/arm/xilinx/zynq7000.dtsi
+++ b/dts/arm/xilinx/zynq7000.dtsi
@@ -118,6 +118,32 @@
 			interrupt-names = "irq_0";
 		};
 
+		spi0: spi@e0006000 {
+			compatible = "cdns,spi";
+			reg = <0xe0006000 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 26 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			fifo-width = <8>;
+			rx-fifo-depth = <128>;
+			tx-fifo-depth = <128>;
+		};
+
+		spi1: spi@e0007000 {
+			compatible = "cdns,spi";
+			reg = <0xe0007000 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 49 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			fifo-width = <8>;
+			rx-fifo-depth = <128>;
+			tx-fifo-depth = <128>;
+		};
+
 		psgpio: gpio@e000a000 {
 			compatible = "xlnx,ps-gpio";
 			status = "disabled";


### PR DESCRIPTION
Add device tree nodes for the Zynq-7000 Processing System SPI controllers.

Reference: https://docs.amd.com/r/en-US/ug585-zynq-7000-SoC-TRM/PS-I/O-Peripherals
<img width="1007" height="346" alt="image" src="https://github.com/user-attachments/assets/bf09d82b-f18e-4254-a6cb-4a17d1828afd" />