### PR TITLE
led: shell: Fix size_t specifier warnings with arm64

### DIFF
--- a/drivers/led/led_shell.c
+++ b/drivers/led/led_shell.c
@@ -239,7 +239,7 @@ static int cmd_set_color(const struct shell *sh, size_t argc, char **argv)
 	num_colors = argc - arg_idx_value;
 	if (num_colors > MAX_CHANNEL_ARGS) {
 		shell_error(sh,
-			    "Invalid number of colors %d (max %d)",
+			    "Invalid number of colors %zu (max %d)",
 			     num_colors, MAX_CHANNEL_ARGS);
 		return -EINVAL;
 	}
@@ -332,7 +332,7 @@ cmd_write_channels(const struct shell *sh, size_t argc, char **argv)
 	num_channels = argc - arg_idx_value;
 	if (num_channels > MAX_CHANNEL_ARGS) {
 		shell_error(sh,
-			    "Can't write %d channels (max %d)",
+			    "Can't write %zu channels (max %d)",
 			     num_channels, MAX_CHANNEL_ARGS);
 		return -EINVAL;
 	}


### PR DESCRIPTION
use correct length sub-specifier when printing a size_t.