### PR TITLE
drivers: i2s: fix stm32 i2s dma burst length

### DIFF
--- a/drivers/i2s/i2s_stm32.c
+++ b/drivers/i2s/i2s_stm32.c
@@ -233,8 +233,14 @@ static int i2s_stm32_configure(const struct device *dev, enum i2s_dir dir,
 
 	stream->dma_cfg.source_data_size = word_size_bytes;
 	stream->dma_cfg.dest_data_size = word_size_bytes;
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v1)
+	stream->dma_cfg.source_burst_length = 1;
+	stream->dma_cfg.dest_burst_length = 1;
+#else
 	stream->dma_cfg.source_burst_length = word_size_bytes;
 	stream->dma_cfg.dest_burst_length = word_size_bytes;
+#endif
 
 	/*
 	 * set I2S Data Format


### PR DESCRIPTION
In the actual implementation burst length can be set to 2 or 4, which is not a valid value for the STM32 DMA-v1 controller. 
DMA-v1 controller accepts the beat number and not the word size.
Since SRC/DEST size is equal to the DMA length, DMA-v1 burst length should be set to 1

This caused DMA-v1 to log a burst size error and fall back to single-transfer mode.

**Devices with DMA-v1 are affected by this.**

**Tested on Nucleo H745ZI-Q:**
```
/ {
    aliases {
        i2s-tx = &i2s2;
    };
};

&dmamux1 {
    status = "okay";
};

&dma1 {
    status = "okay";
};

&i2s2 {
    pinctrl-0 = <&i2s2_mck_pc6 &i2s2_ck_pb10 &i2s2_ws_pb4 &spi2_mosi_pb15>;
    pinctrl-names = "default";
    status = "okay";
    mck-enabled;
};
```

**Before**:
```
[00:00:00.000,000] <inf> i2s_stm32: i2s@40003800 inited
*** Booting Zephyr OS build v4.4.0-3838-gab92232cfcd1 ***
[00:00:00.000,000] <dbg> i2s_stm32.i2s_stm32_set_clock: freq_in: 120000000, bit_clk_freq: 11289600
[00:00:00.000,000] <dbg>All I2S blocks written
 i2s_stm32.i2s_stm32_set_clock: i2s_div: 5 - i2s_odd: 1
[00:00:00.000,000] <err> dma_stm32_v1: Memory burst size error,using single burst as default
[00:00:00.000,000] <err> dma_stm32_v1: Peripheral burst size error,using single burst as default
```

**After**:

```
[00:00:00.000,000] <inf> i2s_stm32: i2s@40003800 inited
*** Booting Zephyr OS build v4.4.0-3839-g9496481f187a ***
[00:00:00.000,000] <dbg> i2s_stm32.i2s_stm32_set_clock: freq_in: 120000000, bit_clk_freq: 11289600
[00:00:00.000,000] <dbg>All I2S blocks written
 i2s_stm32.i2s_stm32_set_clock: i2s_div: 5 - i2s_odd: 1
```