### PR TITLE
dts: raspberrypi: rpi_pico: add rp2354a and rp2354b variants

### DIFF
--- a/dts/vendor/raspberrypi/rpi_pico/rp2354a.dtsi
+++ b/dts/vendor/raspberrypi/rpi_pico/rp2354a.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../partitions_2M_default.dtsi"
+#include "rp2350a.dtsi"
+
+/ {
+	chosen {
+		zephyr,flash = &flash0;
+		zephyr,flash-controller = &qmi;
+		zephyr,code-partition = &code_partition;
+	};
+};
+
+&flash0 {
+	status = "okay";
+	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
+};

--- a/dts/vendor/raspberrypi/rpi_pico/rp2354b.dtsi
+++ b/dts/vendor/raspberrypi/rpi_pico/rp2354b.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../partitions_2M_default.dtsi"
+#include "rp2350b.dtsi"
+
+/ {
+	chosen {
+		zephyr,flash = &flash0;
+		zephyr,flash-controller = &qmi;
+		zephyr,code-partition = &code_partition;
+	};
+};
+
+&flash0 {
+	status = "okay";
+	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
+};


### PR DESCRIPTION
Add RP2354A and RP2354B SoC DTSI files for Raspberry Pi Pico platforms. These variants integrate 2 MiB of Winbond flash in-package.

Reference: https://pip-assets.raspberrypi.com/categories/1214-rp2350/documents/RP-008374-DS-1-rp2350-product-brief.pdf
<img width="722" height="224" alt="Screenshot From 2026-05-31 18-34-38" src="https://github.com/user-attachments/assets/358d4881-749a-4d86-9e39-0686b315a654" />
