### PR TITLE
ci: set_assignee: overhaul script and fix few issues

### DIFF
--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -751,13 +751,18 @@ def process_pr(gh, args, maintainer_file, number: int):
 
     assignees = _pick_assignees(pr, area_counter, all_maintainers, num_files)
 
-    # Apply labels.
+    # Apply labels — skip any that are already present, then add the rest in
+    # a single API call to avoid per-label timeline noise.
     if labels:
         if len(labels) <= MAX_LABELS:
-            for label in labels:
-                logger.info("Adding label '%s'", label)
+            current_label_names = {lbl.name for lbl in pr.labels}
+            new_labels = sorted(labels - current_label_names)
+            if new_labels:
+                logger.info("Adding labels: %s", new_labels)
                 if not args.dry_run:
-                    pr.add_to_labels(label)
+                    pr.add_to_labels(*new_labels)
+            else:
+                logger.info("All labels already present on PR #%d; skipping", pr.number)
         else:
             logger.warning(
                 "Too many labels (%d) for PR #%d; skipping label assignment",

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -5,11 +5,141 @@
 
 """Assign reviewers, maintainers, and labels to new PRs based on MAINTAINERS.yml.
 
-Uses the GitHub API to:
-  - Add area-based labels to pull requests.
-  - Request reviews from relevant collaborators and maintainers.
-  - Assign maintainers to pull requests and issues.
-  - Process module PRs across all active west projects.
+Overview
+--------
+This script automates three housekeeping tasks on newly opened GitHub pull
+requests (and issues):
+
+  1. Apply area labels derived from MAINTAINERS.yml.
+  2. Request reviews from the relevant maintainers and collaborators.
+  3. Assign a primary maintainer as the PR assignee.
+
+It reads MAINTAINERS.yml (or a custom file via -M) to map file paths to named
+areas.  Each area carries a list of maintainers, collaborators, labels, and
+file/path patterns.  The script uses the PyGithub library to interact with the
+GitHub API and requires a personal access token in the GITHUB_TOKEN environment
+variable.
+
+Labeling strategy
+-----------------
+For every file changed in the PR, MAINTAINERS.yml is consulted to find the
+matching areas.  The union of all area labels across all matched areas is
+collected and applied to the PR, subject to a cap of MAX_LABELS (10).  If more
+than MAX_LABELS distinct labels would be applied, the entire label step is
+skipped to avoid polluting PRs that touch very broad cross-cutting areas.
+
+A special lightweight "size: XS" label is managed separately:
+  - Added when: the PR has exactly one commit AND at most one line added AND
+    at most one line deleted AND does not touch any manifest file
+    (west.yml, submanifests/optional.yaml).
+  - Removed when: the PR already carries "size: XS" but no longer qualifies
+    (e.g. after a rebase that added more commits or lines).
+
+Area weighting
+--------------
+Each changed file contributes a weight of 1 to the areas it belongs to, with
+two exceptions that contribute 0:
+
+  - CMakeLists.txt files: build-system boilerplate present in nearly every
+    directory, not a reliable signal for area ownership.
+  - Meta-areas (Documentation, Samples, Tests, Release Notes, Release): used
+    only for assignee selection when they are the *sole* area touched (see
+    below); not weighted for mixed PRs.
+
+Platform (driver/board) areas receive a weight of 1 for the first file that
+maps to them.  Subsequent files that also map to the *same* Platform area
+score 0 to avoid double-counting.  This is controlled by the is_instance flag:
+once a Platform area has been seen for a given file's sorted_areas list, all
+further areas for that file score 0.
+
+The resulting per-area weights drive both reviewer selection (ordered by
+weight) and assignee selection.
+
+Reviewer selection
+------------------
+The ordered reviewer candidate list is built as follows:
+
+  1. For each area in descending weight order: add the area's maintainers,
+     then its collaborators.
+  2. Append any path-specific collaborators returned by
+     get_collaborators_for_path() for each matched file.
+  3. Append any extra reviewers identified from MAINTAINERS.yml diff (see
+     Manifest / MAINTAINERS.yml change handling below).
+  4. Deduplicate while preserving insertion order.
+
+Candidates are then filtered:
+  - The PR author is skipped.
+  - Users who already submitted a review or are already on the review-request
+    list are skipped.
+  - Users who are not repository collaborators are skipped (GitHub requires
+    collaborator status to receive a review request).
+  - Users who previously self-removed themselves from the review request list
+    are skipped.
+
+If the PR already has MAX_REVIEWERS (15) or more reviewers, the normal
+candidate list is discarded and only the maintainers of *all* matched areas
+are requested instead (a smaller, higher-signal set).
+
+Otherwise the candidate list is capped at the remaining vacancy
+(MAX_REVIEWERS - existing reviewer count) before the review request is created.
+
+Assignee selection
+------------------
+Assignees are selected from area_counter (areas sorted by descending file
+weight) using the following priority rules:
+
+  1. If exactly one area is matched and it is a meta-area (Documentation,
+     Samples, Tests, Release Notes, Release), that area's maintainers are
+     assigned directly.  Meta-areas are not considered in mixed PRs.
+  2. Areas with a weight of 0 or no maintainers are skipped.
+  3. If the PR author is the area's only maintainer, the area is skipped
+     (to avoid self-assignment).  If the author is one of several maintainers,
+     they are excluded from the candidate list and the remaining maintainers
+     are used.
+  4. Non-platform areas (no "Platform" in the area name) take highest
+     priority: the first such area's maintainers are inserted at the front
+     of the ranked list, and the search stops.
+  5. Platform areas (drivers, boards) are appended as lower-priority
+     fallbacks.
+
+After iterating all areas, the first entry in the ranked list is chosen.
+If the ranking process yielded nothing (e.g. all areas had the author as sole
+maintainer), the maintainer with the highest cumulative file-weight score is
+used as a last resort.
+
+Assignees are only set when the PR currently has no assignee.
+
+Manifest / MAINTAINERS.yml change handling
+-------------------------------------------
+west.yml and submanifests/optional.yaml:
+  If --updated-manifest is provided, the old and new manifest files are
+  compared to find added, removed, and updated west projects.  Each changed
+  project is looked up in MAINTAINERS.yml under "West project: <name>" and
+  the corresponding collaborators are added to the reviewer candidate list.
+
+MAINTAINERS.yml:
+  If --updated-maintainer-file is provided, the old and new versions of
+  MAINTAINERS.yml are diffed field-by-field (maintainers, collaborators,
+  labels, files, files-regex, status).  Maintainers of every area that
+  changed are appended to the reviewer candidate list so that the people
+  responsible for each changed area are automatically notified.
+
+Issue assignment
+----------------
+When run with -I/--issue, the script matches the issue's GitHub labels against
+the area labels in MAINTAINERS.yml and assigns the maintainers of the matching
+area.  A single unambiguous label is sufficient for a match; multi-label areas
+require all their labels to be present.  If no match is found, or the issue
+already has assignees, the script exits without making changes.
+
+Module PR assignment
+--------------------
+When run with -m/--modules, the script reads the active west manifest,
+locates every active non-manifest project that has a "West project: <name>"
+entry in MAINTAINERS.yml with at least one maintainer, and searches GitHub for
+open, non-draft, unassigned PRs across all those repos.  Each PR is assigned
+to the project maintainers and review requests are created for both maintainers
+and collaborators.
 """
 
 import argparse

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -3,8 +3,18 @@
 # Copyright (c) 2022 Intel Corp.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Assign reviewers, maintainers, and labels to new PRs based on MAINTAINERS.yml.
+
+Uses the GitHub API to:
+  - Add area-based labels to pull requests.
+  - Request reviews from relevant collaborators and maintainers.
+  - Assign maintainers to pull requests and issues.
+  - Process module PRs across all active west projects.
+"""
+
 import argparse
 import datetime
+import logging
 import os
 import sys
 import time
@@ -28,14 +38,25 @@ else:
     # Propagate this decision to child processes.
     os.environ['ZEPHYR_BASE'] = str(ZEPHYR_BASE)
 
+logger = logging.getLogger(__name__)
 
-def log(s):
-    if args.verbose > 0:
-        print(s, file=sys.stdout)
+# Maximum number of changed files to process; larger PRs are skipped.
+MAX_FILES = 500
+
+# Maximum number of reviewers on a PR before switching to maintainer-only strategy.
+MAX_REVIEWERS = 15
+
+# Maximum number of labels to apply; more than this is likely noise from over-broad matches.
+MAX_LABELS = 10
+
+# Courtesy sleep between consecutive GitHub API calls to avoid secondary rate limits.
+API_SLEEP_SECONDS = 1
+
+# Areas where assignee selection only fires when they are the sole area affected.
+META_AREAS = frozenset(['Release Notes', 'Documentation', 'Samples', 'Tests', 'Release'])
 
 
 def parse_args():
-    global args
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -85,12 +106,39 @@ def parse_args():
         help="Updated maintainer file to compare against current MAINTAINERS.yml",
     )
 
-    parser.add_argument("-v", "--verbose", action="count", default=0, help="Verbose Output")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Verbose output. Use -v for INFO, -vv for DEBUG.",
+    )
 
-    args = parser.parse_args()
+    return parser.parse_args()
 
 
-def load_areas(filename: str):
+def setup_logging(verbose: int):
+    """Configure logging verbosity.
+
+    -v   -> INFO level (operational progress)
+    -vv  -> DEBUG level (per-file and per-area detail)
+    """
+    if verbose >= 2:
+        level = logging.DEBUG
+    elif verbose == 1:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+
+    logging.basicConfig(
+        format="%(levelname)s: %(message)s",
+        level=level,
+        stream=sys.stdout,
+    )
+
+
+def load_areas(filename: str) -> dict:
+    """Load MAINTAINERS YAML and return only areas that define file-matching patterns."""
     with open(filename) as f:
         doc = yaml.safe_load(f)
     return {
@@ -98,530 +146,550 @@ def load_areas(filename: str):
     }
 
 
-def process_manifest(old_manifest_file):
-    log("Processing manifest changes")
-    if not os.path.isfile("west.yml") or not os.path.isfile(old_manifest_file):
-        log("No west.yml found, skipping...")
+def process_manifest(old_manifest_file: str) -> list:
+    """Return area name strings for projects that changed between two west.yml files."""
+    logger.info("Processing manifest changes")
+
+    if not os.path.isfile("west.yml"):
+        logger.warning("west.yml not found; skipping manifest processing")
         return []
+    if not os.path.isfile(old_manifest_file):
+        logger.warning("Old manifest '%s' not found; skipping manifest processing", old_manifest_file)
+        return []
+
     old_manifest = Manifest.from_file(old_manifest_file)
     new_manifest = Manifest.from_file("west.yml")
-    old_projs = set((p.name, p.revision) for p in old_manifest.projects)
-    new_projs = set((p.name, p.revision) for p in new_manifest.projects)
-    # Removed projects
-    rprojs = set(filter(lambda p: p[0] not in list(p[0] for p in new_projs), old_projs - new_projs))
-    # Updated projects
-    uprojs = set(filter(lambda p: p[0] in list(p[0] for p in old_projs), new_projs - old_projs))
-    # Added projects
-    aprojs = new_projs - old_projs - uprojs
 
-    # All projs
-    projs = rprojs | uprojs | aprojs
-    projs_names = [name for name, rev in projs]
+    old_projs = {(p.name, p.revision) for p in old_manifest.projects}
+    new_projs = {(p.name, p.revision) for p in new_manifest.projects}
 
-    log(f"found modified projects: {projs_names}")
-    areas = []
-    for p in projs_names:
-        areas.append(f'West project: {p}')
+    old_names = {name for name, _ in old_projs}
+    new_names = {name for name, _ in new_projs}
 
-    log(f'manifest areas: {areas}')
+    # Projects whose name no longer appears in the new manifest.
+    removed = {(n, r) for n, r in old_projs if n not in new_names}
+    # Projects that exist in both manifests but with a different revision.
+    updated = {(n, r) for n, r in new_projs if n in old_names and (n, r) not in old_projs}
+    # Entirely new projects.
+    added = {(n, r) for n, r in new_projs if n not in old_names}
+
+    changed_names = sorted({n for n, _ in removed | updated | added})
+    logger.info("Modified west projects: %s", changed_names)
+
+    areas = [f"West project: {name}" for name in changed_names]
+    logger.debug("Manifest areas: %s", areas)
     return areas
 
 
-def set_or_empty(d, key):
+def set_or_empty(d: dict, key: str) -> set:
     return set(d.get(key, []) or [])
 
 
-def compare_areas(old, new, repo_fullname=None, token=None):
+def _diff_area_entry(old_entry: dict, new_entry: dict) -> list:
+    """Return human-readable change strings between two MAINTAINERS area entries."""
+    changes = []
+    fields = [
+        ("maintainers",   "Maintainers"),
+        ("collaborators", "Collaborators"),
+        ("labels",        "Labels"),
+        ("files",         "Files"),
+        ("files-regex",   "files-regex"),
+    ]
+    for key, label in fields:
+        added   = set_or_empty(new_entry, key) - set_or_empty(old_entry, key)
+        removed = set_or_empty(old_entry, key) - set_or_empty(new_entry, key)
+        if added:
+            changes.append(f"{label} added: {', '.join(sorted(added))}")
+        if removed:
+            changes.append(f"{label} removed: {', '.join(sorted(removed))}")
+
+    old_status = old_entry.get("status")
+    new_status = new_entry.get("status")
+    if old_status != new_status:
+        changes.append(f"Status changed: {old_status} -> {new_status}")
+
+    return changes
+
+
+def compare_areas(old: dict, new: dict) -> set:
+    """Compare two MAINTAINERS area dicts; return the set of added, removed, or changed names."""
     old_areas = set(old.keys())
     new_areas = set(new.keys())
 
-    changed_areas = set()
-    added_areas = new_areas - old_areas
+    added_areas   = new_areas - old_areas
     removed_areas = old_areas - new_areas
-    common_areas = old_areas & new_areas
+    common_areas  = old_areas & new_areas
 
-    print("=== Areas Added ===")
-    for area in sorted(added_areas):
-        print(f"+ {area}")
+    if added_areas:
+        logger.info("Areas added (%d):", len(added_areas))
+        for area in sorted(added_areas):
+            logger.info("  + %s", area)
 
-    print("\n=== Areas Removed ===")
-    for area in sorted(removed_areas):
-        print(f"- {area}")
+    if removed_areas:
+        logger.info("Areas removed (%d):", len(removed_areas))
+        for area in sorted(removed_areas):
+            logger.info("  - %s", area)
 
-    print("\n=== Area Changes ===")
+    changed_areas = set()
     for area in sorted(common_areas):
-        changes = []
-        old_entry = old[area]
-        new_entry = new[area]
-
-        # Compare maintainers
-        old_maint = set_or_empty(old_entry, "maintainers")
-        new_maint = set_or_empty(new_entry, "maintainers")
-        added_maint = new_maint - old_maint
-        removed_maint = old_maint - new_maint
-        if added_maint:
-            changes.append(f"  Maintainers added: {', '.join(sorted(added_maint))}")
-        if removed_maint:
-            changes.append(f"  Maintainers removed: {', '.join(sorted(removed_maint))}")
-
-        # Compare collaborators
-        old_collab = set_or_empty(old_entry, "collaborators")
-        new_collab = set_or_empty(new_entry, "collaborators")
-        added_collab = new_collab - old_collab
-        removed_collab = old_collab - new_collab
-        if added_collab:
-            changes.append(f"  Collaborators added: {', '.join(sorted(added_collab))}")
-        if removed_collab:
-            changes.append(f"  Collaborators removed: {', '.join(sorted(removed_collab))}")
-
-        # Compare status
-        old_status = old_entry.get("status")
-        new_status = new_entry.get("status")
-        if old_status != new_status:
-            changes.append(f"  Status changed: {old_status} -> {new_status}")
-
-        # Compare labels
-        old_labels = set_or_empty(old_entry, "labels")
-        new_labels = set_or_empty(new_entry, "labels")
-        added_labels = new_labels - old_labels
-        removed_labels = old_labels - new_labels
-        if added_labels:
-            changes.append(f"  Labels added: {', '.join(sorted(added_labels))}")
-        if removed_labels:
-            changes.append(f"  Labels removed: {', '.join(sorted(removed_labels))}")
-
-        # Compare files
-        old_files = set_or_empty(old_entry, "files")
-        new_files = set_or_empty(new_entry, "files")
-        added_files = new_files - old_files
-        removed_files = old_files - new_files
-        if added_files:
-            changes.append(f"  Files added: {', '.join(sorted(added_files))}")
-        if removed_files:
-            changes.append(f"  Files removed: {', '.join(sorted(removed_files))}")
-
-        # Compare files-regex
-        old_regex = set_or_empty(old_entry, "files-regex")
-        new_regex = set_or_empty(new_entry, "files-regex")
-        added_regex = new_regex - old_regex
-        removed_regex = old_regex - new_regex
-        if added_regex:
-            changes.append(f"  files-regex added: {', '.join(sorted(added_regex))}")
-        if removed_regex:
-            changes.append(f"  files-regex removed: {', '.join(sorted(removed_regex))}")
-
+        changes = _diff_area_entry(old[area], new[area])
         if changes:
             changed_areas.add(area)
-            print(f"area changed: {area}")
+            logger.info("Area changed: %s", area)
+            for change in changes:
+                logger.debug("  %s", change)
 
     return added_areas | removed_areas | changed_areas
 
 
-def process_pr(gh, maintainer_file, number):
-    gh_repo = gh.get_repo(f"{args.org}/{args.repo}")
-    pr = gh_repo.get_pull(number)
+def _pick_assignees(pr, area_counter: dict, all_maintainers: dict, num_files: int):
+    """Select the best assignee list for *pr* from area and file-coverage data.
 
-    log(f"working on https://github.com/{args.org}/{args.repo}/pull/{pr.number} : {pr.title}")
-
-    labels = set()
-    area_counter = defaultdict(int)
-    found_maintainers = defaultdict(int)
-
-    num_files = 0
-    fn = list(pr.get_files())
-
-    # Check if PR currently has 'size: XS' label
-    current_labels = [label.name for label in pr.labels]
-    has_size_xs_label = 'size: XS' in current_labels
-
-    # Determine if PR qualifies for 'size: XS' label
-    qualifies_for_xs = pr.commits == 1 and (pr.additions <= 1 and pr.deletions <= 1)
-
-    if qualifies_for_xs:
-        labels = {'size: XS'}
-    elif has_size_xs_label and not qualifies_for_xs:
-        # Remove 'size: XS' label if PR no longer qualifies
-        log(
-            f"removing 'size: XS' label (commits: {pr.commits}, "
-            f"additions: {pr.additions}, deletions: {pr.deletions})..."
-        )
-        if not args.dry_run:
-            pr.remove_from_labels('size: XS')
-
-    if len(fn) > 500:
-        log(f"Too many files changed ({len(fn)}), skipping....")
-        return
-
-    # areas where assignment happens if only said areas are affected
-    meta_areas = ['Release Notes', 'Documentation', 'Samples', 'Tests', 'Release']
-
-    collab_per_path = set()
-    additional_reviews = set()
-    for changed_file in fn:
-        num_files += 1
-        log(f"file: {changed_file.filename}")
-
-        areas = []
-        if changed_file.filename in ['west.yml', 'submanifests/optional.yaml']:
-            if not args.updated_manifest:
-                log("No updated manifest, cannot process west.yml changes, skipping...")
-                continue
-            parsed_areas = process_manifest(old_manifest_file=args.updated_manifest)
-            for _area in parsed_areas:
-                area_match = maintainer_file.name2areas(_area)
-                if area_match:
-                    _area_obj = area_match[0]
-                    collabs_for_area = _area_obj.get_collaborators_for_path(changed_file.filename)
-                    collab_per_path.update(collabs_for_area)
-                    areas.extend(area_match)
-        elif changed_file.filename in ['MAINTAINERS.yml']:
-            areas = maintainer_file.path2areas(changed_file.filename)
-            if args.updated_maintainer_file:
-                log("cannot process MAINTAINERS.yml changes, skipping...")
-
-                old_areas = load_areas(args.updated_maintainer_file)
-                new_areas = load_areas('MAINTAINERS.yml')
-                changed_areas = compare_areas(old_areas, new_areas)
-                for _area in changed_areas:
-                    area_match = maintainer_file.name2areas(_area)
-                    if area_match:
-                        # get list of maintainers for changed area
-                        additional_reviews.update(maintainer_file.areas[_area].maintainers)
-                log(f"MAINTAINERS.yml changed, adding reviewrs: {additional_reviews}")
-        else:
-            areas = maintainer_file.path2areas(changed_file.filename)
-            for _area in areas:
-                collab_per_path.update(_area.get_collaborators_for_path(changed_file.filename))
-
-        log(f"  areas: {areas}")
-
-        if not areas:
-            continue
-
-        # instance of an area, for example a driver or a board, not APIs or subsys code.
-        is_instance = False
-        sorted_areas = sorted(areas, key=lambda x: 'Platform' in x.name, reverse=True)
-        for area in sorted_areas:
-            # do not count cmake file changes, i.e. when there are changes to
-            # instances of an area listed in both the subsystem and the
-            # platform implementing it
-            if 'CMakeLists.txt' in changed_file.filename or area.name in meta_areas:
-                c = 0
-            else:
-                c = 1 if not is_instance else 0
-
-            area_counter[area] += c
-            log(f"area counter: {area_counter}")
-            labels.update(area.labels)
-            # FIXME: Here we count the same file multiple times if it exists in
-            # multiple areas with same maintainer
-            for area_maintainer in area.maintainers:
-                found_maintainers[area_maintainer] += c
-
-            if 'Platform' in area.name:
-                is_instance = True
-
-            for _area in sorted_areas:
-                collab_per_path.update(_area.get_collaborators_for_path(changed_file.filename))
-
-    area_counter = dict(sorted(area_counter.items(), key=lambda item: item[1], reverse=True))
-    log(f"Area matches: {area_counter}")
-    log(f"labels: {labels}")
-
-    # Create a list of collaborators ordered by the area match
-    collab = list()
-    for area in area_counter:
-        collab += maintainer_file.areas[area.name].maintainers
-        collab += maintainer_file.areas[area.name].collaborators
-        collab += collab_per_path
-
-    collab = list(dict.fromkeys(collab))
-    # add more reviewers based on maintainer file changes.
-    collab += list(additional_reviews)
-    log(f"collab: {collab}")
-
-    _all_maintainers = dict(
-        sorted(found_maintainers.items(), key=lambda item: item[1], reverse=True)
-    )
-
-    log(f"Submitted by: {pr.user.login}")
-    log(f"candidate maintainers: {_all_maintainers}")
-
+    Iterates areas in descending file-change count.  Non-platform areas take
+    priority; platform (driver/board) areas are only used as a fallback.
+    Returns a list of login strings, or None if no suitable assignee is found.
+    """
     ranked_assignees = []
     assignees = None
 
-    # we start with areas with most files changed and pick the maintainer from the first one.
-    # if the first area is an implementation, i.e. driver or platform, we
-    # continue searching for any other areas involved
     for area, count in area_counter.items():
-        # if only meta area is affected, assign one of the maintainers of that area
-        if area.name in meta_areas and len(area_counter) == 1:
-            assignees = area.maintainers
-            break
-        # if no maintainers, skip
-        if count == 0 or len(area.maintainers) == 0:
+        if count == 0 or not area.maintainers:
             continue
-        # if there are maintainers, but no assignees yet, set them
-        if len(area.maintainers) > 0:
-            if pr.user.login in area.maintainers:
-                # If submitter = assignee, try to pick next area and assign
-                # someone else other than the submitter, otherwise when there
-                # are other maintainers for the area, assign them.
-                if len(area.maintainers) > 1:
-                    assignees = area.maintainers.copy()
-                    assignees.remove(pr.user.login)
-                else:
-                    continue
-            else:
-                assignees = area.maintainers
 
-        # found a non-platform area that was changed, pick assignee from this
-        # area and put them on top of the list, otherwise just append.
-        if 'Platform' not in area.name:
-            ranked_assignees.insert(0, area.maintainers)
-            break
+        if pr.user.login in area.maintainers:
+            # Author is a maintainer; try to assign someone else from the same area.
+            if len(area.maintainers) > 1:
+                candidates = area.maintainers.copy()
+                candidates.remove(pr.user.login)
+                assignees = candidates
+            else:
+                # Author is the sole maintainer; skip this area.
+                continue
         else:
-            ranked_assignees.append(area.maintainers)
+            assignees = area.maintainers
+
+        # FIXME: identify platform areas and other areas using some flag in the
+        # MAINTAINERS.yml data instead of relying on the name containing "Platform".
+        if 'platform' in area.name.lower():
+            logger.debug("Platform area '%s' with maintainers %s added as fallback for assignment", area.name, assignees)
+            ranked_assignees.append(assignees)
+        elif area.name not in META_AREAS:
+            logger.debug("Non-platform area '%s' with maintainers %s takes priority for assignment", area.name, assignees)
+            # Non-platform area: highest priority — insert at front and stop.
+            ranked_assignees.insert(0, assignees)
+            break
 
     if ranked_assignees:
         assignees = ranked_assignees[0]
 
     if assignees:
-        prop = (found_maintainers[assignees[0]] / num_files) * 100
-        log(f"Picked assignees: {assignees} ({prop:.2f}% ownership)")
-        log("+++++++++++++++++++++++++")
-    elif len(_all_maintainers) > 0:
-        # if we have maintainers found, but could not pick one based on area,
-        # then pick the one with most changes
-        assignees = [next(iter(_all_maintainers))]
+        coverage = (all_maintainers.get(assignees[0], 0) / num_files) * 100 if num_files else 0
+        logger.info("Picked assignees: %s (%.2f%% file coverage)", assignees, coverage)
+    elif all_maintainers:
+        # No area-based pick succeeded; fall back to the maintainer with most file changes.
+        assignees = [next(iter(all_maintainers))]
+        logger.info("Fallback assignee (highest file count): %s", assignees)
 
-    # Set labels
-    if labels:
-        if len(labels) < 10:
-            for label in labels:
-                log(f"adding label {label}...")
-                if not args.dry_run:
-                    pr.add_to_labels(label)
-        else:
-            log("Too many labels to be applied")
+    return assignees
 
-    if collab:
+
+def _add_reviewers(gh, gh_repo, pr, args, collab: list, all_maintainers: dict):
+    """Request reviews from eligible collaborators on *pr*.
+
+    Skips the PR author, existing reviewers, non-collaborators, and users
+    who previously removed themselves from the review request.
+    """
+    existing_reviewers = set()
+    for review in pr.get_reviews():
+        existing_reviewers.add(review.user)
+
+    # get_review_requests() returns (PaginatedList[NamedUser], PaginatedList[Team]).
+    review_users, _review_teams = pr.get_review_requests()
+    existing_reviewers.update(review_users)
+
+    logger.debug("Existing reviewers: %s", [u.login for u in existing_reviewers if hasattr(u, 'login')])
+
+    # Track users who removed themselves; do not re-add them.
+    self_removed = set()
+    for event in pr.get_issue_events():
+        if event.event == 'review_request_removed' and event.actor == event.requested_reviewer:
+            self_removed.add(event.actor)
+
+    if len(existing_reviewers) >= MAX_REVIEWERS:
+        logger.info(
+            "PR already has %d reviewer(s) (limit %d); adding area maintainers as reviewers instead",
+            len(existing_reviewers),
+            MAX_REVIEWERS,
+        )
+        reviewers = list(all_maintainers.keys())
+    else:
+        vacancy = MAX_REVIEWERS - len(existing_reviewers)
         reviewers = []
-        existing_reviewers = set()
-
-        revs = pr.get_reviews()
-        for review in revs:
-            existing_reviewers.add(review.user)
-
-        rl = pr.get_review_requests()
-        for page, r in enumerate(rl):
-            existing_reviewers |= set(r.get_page(page))
-
-        # check for reviewers that remove themselves from list of reviewer and
-        # do not attempt to add them again based on MAINTAINERS file.
-        self_removal = []
-        for event in pr.get_issue_events():
-            if event.event == 'review_request_removed' and event.actor == event.requested_reviewer:
-                self_removal.append(event.actor)
 
         for collaborator in collab:
             try:
                 gh_user = gh.get_user(collaborator)
-                if pr.user == gh_user or gh_user in existing_reviewers:
-                    continue
-                if not gh_repo.has_in_collaborators(gh_user):
-                    log(f"Skip '{collaborator}': not in collaborators")
-                    continue
-                if gh_user in self_removal:
-                    log(f"Skip '{collaborator}': self removed")
-                    continue
-                reviewers.append(collaborator)
-            except UnknownObjectException as e:
-                log(f"Can't get user '{collaborator}', account does not exist anymore? ({e})")
+            except UnknownObjectException:
+                logger.warning("User '%s' not found; account may have been deleted", collaborator)
+                continue
 
-        if len(existing_reviewers) < 15:
-            reviewer_vacancy = 15 - len(existing_reviewers)
-            reviewers = reviewers[:reviewer_vacancy]
-        else:
-            log(
-                "not adding reviewers because the existing reviewer count is greater than or "
-                "equal to 15. Adding maintainers of all areas as reviewers instead."
-            )
-            # FIXME: Here we could also add collaborators of the areas most
-            # affected, i.e. the one with the final assigne.
-            reviewers = list(_all_maintainers.keys())
+            if pr.user == gh_user:
+                logger.debug("Skipping PR author '%s'", collaborator)
+                continue
+            if gh_user in existing_reviewers:
+                logger.debug("Skipping existing reviewer '%s'", collaborator)
+                continue
+            if not gh_repo.has_in_collaborators(gh_user):
+                logger.info("Skipping '%s': not a repository collaborator", collaborator)
+                continue
+            if gh_user in self_removed:
+                logger.info("Skipping '%s': previously self-removed from reviewers", collaborator)
+                continue
 
-        if reviewers:
+            reviewers.append(collaborator)
+
+        reviewers = reviewers[:vacancy]
+
+    if reviewers:
+        logger.info("Requesting reviews from: %s", reviewers)
+        if not args.dry_run:
             try:
-                log(f"adding reviewers {reviewers}...")
-                if not args.dry_run:
-                    pr.create_review_request(reviewers=reviewers)
-            except GithubException:
-                log("can't add reviewer")
+                pr.create_review_request(reviewers=reviewers)
+            except GithubException as exc:
+                logger.error("Failed to add reviewers %s: %s", reviewers, exc)
 
-    ms = []
-    # assignees
-    if assignees and (not pr.assignee or args.dry_run):
+
+def _assign_maintainers(gh, pr, args, assignees: list):
+    """Add *assignees* (login strings) to *pr*, logging any unknown-user errors."""
+    users = []
+    for login in assignees:
         try:
-            for assignee in assignees:
-                u = gh.get_user(assignee)
-                ms.append(u)
-        except GithubException:
-            log("Error: Unknown user")
+            users.append(gh.get_user(login))
+        except GithubException as exc:
+            logger.error("Unknown user '%s': %s", login, exc)
 
-        for mm in ms:
-            log(f"Adding assignee {mm}...")
-            if not args.dry_run:
-                pr.add_to_assignees(mm)
+    for user in users:
+        logger.info("Adding assignee: %s", user.login)
+        if not args.dry_run:
+            pr.add_to_assignees(user)
+
+
+def process_pr(gh, args, maintainer_file, number: int):
+    gh_repo = gh.get_repo(f"{args.org}/{args.repo}")
+    pr = gh_repo.get_pull(number)
+    pr_url = f"https://github.com/{args.org}/{args.repo}/pull/{pr.number}"
+
+    logger.info("Processing PR #%d: %s  (%s)", pr.number, pr.title, pr_url)
+
+    labels = set()
+    area_counter = defaultdict(int)
+    found_maintainers = defaultdict(int)
+    collab_per_path = set()
+    additional_reviews = set()
+
+    changed_files = list(pr.get_files())
+    num_files = len(changed_files)
+
+    if num_files > MAX_FILES:
+        logger.warning(
+            "PR #%d has %d changed files (limit %d); skipping",
+            pr.number, num_files, MAX_FILES,
+        )
+        return
+
+    # Handle the 'size: XS' label: single-commit PRs with at most one line changed,
+    # but only when no manifest file is among the changed files.  Manifest bumps
+    # (west.yml, submanifests/optional.yaml) are never trivial regardless of line count.
+    manifest_files = {'west.yml', 'submanifests/optional.yaml'}
+    touches_manifest = any(f.filename in manifest_files for f in changed_files)
+    current_label_names = {label.name for label in pr.labels}
+    qualifies_for_xs = (
+        pr.commits == 1
+        and pr.additions <= 1
+        and pr.deletions <= 1
+        and not touches_manifest
+    )
+
+    if qualifies_for_xs:
+        labels.add('size: XS')
+    elif 'size: XS' in current_label_names:
+        logger.info(
+            "Removing 'size: XS' label from PR #%d (commits=%d, +%d/-%d)",
+            pr.number, pr.commits, pr.additions, pr.deletions,
+        )
+        if not args.dry_run:
+            pr.remove_from_labels('size: XS')
+
+    for changed_file in changed_files:
+        filename = changed_file.filename
+        logger.debug("Processing file: %s", filename)
+
+        areas = []
+        if filename in ('west.yml', 'submanifests/optional.yaml'):
+            if not args.updated_manifest:
+                logger.debug(
+                    "No --updated-manifest provided; skipping manifest diff for %s", filename
+                )
+                continue
+            parsed_areas = process_manifest(old_manifest_file=args.updated_manifest)
+            for area_name in parsed_areas:
+                area_matches = maintainer_file.name2areas(area_name)
+                if area_matches:
+                    collab_per_path.update(area_matches[0].get_collaborators_for_path(filename))
+                    areas.extend(area_matches)
+
+        elif filename == 'MAINTAINERS.yml':
+            areas = maintainer_file.path2areas(filename)
+            if args.updated_maintainer_file:
+                old_areas = load_areas(args.updated_maintainer_file)
+                new_areas = load_areas('MAINTAINERS.yml')
+                changed_area_names = compare_areas(old_areas, new_areas)
+                for area_name in changed_area_names:
+                    area_matches = maintainer_file.name2areas(area_name)
+                    if area_matches:
+                        additional_reviews.update(maintainer_file.areas[area_name].maintainers)
+                logger.info(
+                    "MAINTAINERS.yml changed; adding extra reviewers: %s",
+                    sorted(additional_reviews),
+                )
+
+        else:
+            areas = maintainer_file.path2areas(filename)
+            for area in areas:
+                collab_per_path.update(area.get_collaborators_for_path(filename))
+
+        logger.debug("  areas for %s: %s", filename, [a.name for a in areas])
+
+        if not areas:
+            continue
+
+        # Sort so that Platform (driver/board) areas are processed first.  This
+        # sets is_instance=True early, preventing the same file from being
+        # counted again for the corresponding subsystem area.
+        sorted_areas = sorted(areas, key=lambda x: 'Platform' in x.name, reverse=True)
+        is_instance = False
+
+        for area in sorted_areas:
+            # CMakeLists.txt changes and meta-area files do not count toward
+            # the area weight used for assignee selection.
+            if 'CMakeLists.txt' in filename or area.name in META_AREAS:
+                count = 0
+            else:
+                # Once an instance (Platform) area has been seen, subsequent
+                # areas for this file score 0 to avoid double-counting.
+                count = 1 if not is_instance else 0
+
+            area_counter[area] += count
+            logger.debug("  area weight update: %s += %d", area.name, count)
+            labels.update(area.labels)
+
+            # NOTE: a file appearing in multiple areas with the same maintainer
+            # will over-count that maintainer's file coverage score.
+            for maintainer in area.maintainers:
+                found_maintainers[maintainer] += count
+
+            if 'Platform' in area.name:
+                is_instance = True
+
+        # Collect path-specific collaborators for all areas that matched this file.
+        for area in sorted_areas:
+            collab_per_path.update(area.get_collaborators_for_path(filename))
+
+    area_counter = dict(sorted(area_counter.items(), key=lambda item: item[1], reverse=True))
+    logger.info("Area weights: %s", {a.name: c for a, c in area_counter.items()})
+    logger.debug("Collected labels: %s", labels)
+
+    # Build the ordered collaborator/reviewer list by area priority.
+    collab = []
+    for area in area_counter:
+        collab += maintainer_file.areas[area.name].maintainers
+        collab += maintainer_file.areas[area.name].collaborators
+    collab += list(collab_per_path)
+    collab += list(additional_reviews)
+    # Deduplicate while preserving insertion order.
+    collab = list(dict.fromkeys(collab))
+    logger.debug("Reviewer candidates: %s", collab)
+
+    all_maintainers = dict(
+        sorted(found_maintainers.items(), key=lambda item: item[1], reverse=True)
+    )
+    logger.info("PR submitted by: %s", pr.user.login)
+    logger.info("Maintainer file-coverage scores: %s", all_maintainers)
+
+    assignees = _pick_assignees(pr, area_counter, all_maintainers, num_files)
+
+    # Apply labels.
+    if labels:
+        if len(labels) <= MAX_LABELS:
+            for label in labels:
+                logger.info("Adding label '%s'", label)
+                if not args.dry_run:
+                    pr.add_to_labels(label)
+        else:
+            logger.warning(
+                "Too many labels (%d) for PR #%d; skipping label assignment",
+                len(labels), pr.number,
+            )
+
+    # Request reviews.
+    if collab:
+        _add_reviewers(gh, gh_repo, pr, args, collab, all_maintainers)
+
+    # Set assignees (only when none are set yet, unless doing a dry run).
+    if assignees and (not pr.assignee or args.dry_run):
+        _assign_maintainers(gh, pr, args, assignees)
     else:
-        log("not setting assignee")
+        reason = "already has assignee" if pr.assignee else "no assignees found"
+        logger.info("Not setting assignee for PR #%d: %s", pr.number, reason)
 
-    time.sleep(1)
+    time.sleep(API_SLEEP_SECONDS)
 
 
-def process_issue(gh, maintainer_file, number):
+def process_issue(gh, args, maintainer_file, number: int):
     gh_repo = gh.get_repo(f"{args.org}/{args.repo}")
     issue = gh_repo.get_issue(number)
 
-    log(f"Working on {issue.url}: {issue.title}")
+    logger.info("Processing issue #%d: %s  (%s)", issue.number, issue.title, issue.html_url)
 
     if issue.assignees:
-        print(f"Already assigned {issue.assignees}, bailing out")
+        logger.warning(
+            "Issue #%d already has assignees (%s); skipping",
+            issue.number,
+            [a.login for a in issue.assignees],
+        )
         return
 
+    # Build a mapping from sorted label-name tuples to maintainer sets.
     label_to_maintainer = defaultdict(set)
     for _, area in maintainer_file.areas.items():
         if not area.labels:
             continue
-
-        labels = set()
-        for label in area.labels:
-            labels.add(label.lower())
-        labels = tuple(sorted(labels))
-
+        label_tuple = tuple(sorted(label.lower() for label in area.labels))
         for maintainer in area.maintainers:
-            label_to_maintainer[labels].add(maintainer)
+            label_to_maintainer[label_tuple].add(maintainer)
 
-    # Add extra entries for areas with multiple labels so they match with just
-    # one label if it's specific enough.
-    for areas, maintainers in dict(label_to_maintainer).items():
-        for area in areas:
-            if tuple([area]) not in label_to_maintainer:
-                label_to_maintainer[tuple([area])] = maintainers
+    # Also allow matching on a single label when it is unambiguous enough.
+    for label_tuple, maintainers in dict(label_to_maintainer).items():
+        for label in label_tuple:
+            single = (label,)
+            if single not in label_to_maintainer:
+                label_to_maintainer[single] = maintainers
 
-    issue_labels = set()
+    valid_labels = []
     for label in issue.labels:
         label_name = label.name.lower()
-        if tuple([label_name]) not in label_to_maintainer:
-            print(f"Ignoring label: {label}")
-            continue
-        issue_labels.add(label_name)
-    issue_labels = tuple(sorted(issue_labels))
+        if (label_name,) not in label_to_maintainer:
+            logger.debug("Ignoring label '%s': no area match", label.name)
+        else:
+            valid_labels.append(label_name)
+    issue_labels = tuple(sorted(valid_labels))
 
-    print(f"Using labels: {issue_labels}")
+    logger.info("Matched labels: %s", issue_labels)
 
-    if issue_labels not in label_to_maintainer:
-        print("no match for the label set, not assigning")
+    if not issue_labels or issue_labels not in label_to_maintainer:
+        logger.warning(
+            "No matching label set found for issue #%d; not assigning", issue.number
+        )
         return
 
     for maintainer in label_to_maintainer[issue_labels]:
-        log(f"Adding {maintainer} to {issue.html_url}")
+        logger.info("Assigning '%s' to issue #%d (%s)", maintainer, issue.number, issue.html_url)
         if not args.dry_run:
             issue.add_to_assignees(maintainer)
 
 
-def process_modules(gh, maintainers_file):
+def process_modules(gh, args, maintainers_file):
     manifest = Manifest.from_file()
 
     repos = {}
     for project in manifest.get_projects([]):
-        if not manifest.is_active(project):
+        if not manifest.is_active(project) or isinstance(project, ManifestProject):
             continue
 
-        if isinstance(project, ManifestProject):
+        area_name = f"West project: {project.name}"
+        if area_name not in maintainers_file.areas:
+            logger.debug("No area defined for project '%s'; skipping", project.name)
             continue
 
-        area = f"West project: {project.name}"
-        if area not in maintainers_file.areas:
-            log(f"No area for: {area}")
+        area = maintainers_file.areas[area_name]
+        if not area.maintainers:
+            logger.info("No maintainers for project '%s'; skipping", project.name)
             continue
 
-        maintainers = maintainers_file.areas[area].maintainers
-        if not maintainers:
-            log(f"No maintainers for: {area}")
-            continue
+        logger.debug(
+            "Project '%s': maintainers=%s, collaborators=%s",
+            project.name, area.maintainers, area.collaborators,
+        )
+        repos[f"{args.org}/{project.name}"] = area
 
-        collaborators = maintainers_file.areas[area].collaborators
+    if not repos:
+        logger.warning("No active module repos with maintainers found in manifest")
+        return
 
-        log(f"Found {area}, maintainers={maintainers}, collaborators={collaborators}")
+    query = "is:open is:pr no:assignee " + " ".join(f"repo:{repo}" for repo in repos)
+    logger.info("Searching for unassigned module PRs with query: %s", query)
 
-        repo_name = f"{args.org}/{project.name}"
-        repos[repo_name] = maintainers_file.areas[area]
-
-    query = "is:open is:pr no:assignee"
-    if repos:
-        query += ' ' + ' '.join(f"repo:{repo}" for repo in repos)
-
-    issues = gh.search_issues(query=query)
-    for issue in issues:
+    for issue in gh.search_issues(query=query):
         pull = issue.as_pull_request()
 
         if pull.draft:
+            logger.debug("Skipping draft PR: %s", pull.html_url)
             continue
 
         if pull.assignees:
-            log(f"ERROR: {pull.html_url} should have no assignees, found {pull.assignees}")
+            logger.error(
+                "PR %s unexpectedly has assignees %s despite no:assignee filter",
+                pull.html_url, pull.assignees,
+            )
             continue
 
-        repo_name = f"{args.org}/{issue.repository.name}"
-        area = repos[repo_name]
+        area = repos[f"{args.org}/{issue.repository.name}"]
 
         for maintainer in area.maintainers:
-            log(f"Assigning {maintainer} to {pull.html_url}")
+            logger.info("Assigning '%s' to %s", maintainer, pull.html_url)
             if not args.dry_run:
                 pull.add_to_assignees(maintainer)
                 pull.create_review_request(maintainer)
 
         for collaborator in area.collaborators:
-            log(f"Adding {collaborator} to {pull.html_url}")
+            logger.info("Adding reviewer '%s' to %s", collaborator, pull.html_url)
             if not args.dry_run:
                 pull.create_review_request(collaborator)
 
 
 def main():
-    parse_args()
+    args = parse_args()
+    setup_logging(args.verbose)
 
-    token = os.environ.get('GITHUB_TOKEN', None)
+    token = os.environ.get('GITHUB_TOKEN')
     if not token:
         sys.exit(
-            'Github token not set in environment, please set the '
-            'GITHUB_TOKEN environment variable and retry.'
+            'GITHUB_TOKEN environment variable is not set. '
+            'Please set it and retry.'
         )
 
     gh = Github(auth=Auth.Token(token))
     maintainer_file = Maintainers(args.maintainer_file)
 
     if args.pull_request:
-        process_pr(gh, maintainer_file, args.pull_request)
+        process_pr(gh, args, maintainer_file, args.pull_request)
     elif args.issue:
-        process_issue(gh, maintainer_file, args.issue)
+        process_issue(gh, args, maintainer_file, args.issue)
     elif args.modules:
-        process_modules(gh, maintainer_file)
+        process_modules(gh, args, maintainer_file)
     else:
         if args.since:
             since = args.since
         else:
-            today = datetime.date.today()
-            since = today - datetime.timedelta(days=1)
+            since = datetime.date.today() - datetime.timedelta(days=1)
 
-        common_prs = (
+        query = (
             f'repo:{args.org}/{args.repo} is:open is:pr base:main '
             f'-is:draft no:assignee created:>{since}'
         )
-        pulls = gh.search_issues(query=f'{common_prs}')
-
-        for issue in pulls:
-            process_pr(gh, maintainer_file, issue.number)
+        logger.info("Searching for unassigned PRs with query: %s", query)
+        for issue in gh.search_issues(query=query):
+            process_pr(gh, args, maintainer_file, issue.number)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -543,6 +543,10 @@ def process_pr(gh, args, maintainer_file, number: int):
 
     logger.info("Processing PR #%d: %s  (%s)", pr.number, pr.title, pr_url)
 
+    if pr.draft:
+        logger.info("PR #%d is a draft; skipping", pr.number)
+        return
+
     labels = set()
     area_counter = defaultdict(int)
     found_maintainers = defaultdict(int)

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -28,12 +28,26 @@ collected and applied to the PR, subject to a cap of MAX_LABELS (10).  If more
 than MAX_LABELS distinct labels would be applied, the entire label step is
 skipped to avoid polluting PRs that touch very broad cross-cutting areas.
 
-A special lightweight "size: XS" label is managed separately:
+A special lightweight "size: XS" label is managed by default:
   - Added when: the PR has exactly one commit AND at most one line added AND
     at most one line deleted AND does not touch any manifest file
     (west.yml, submanifests/optional.yaml).
   - Removed when: the PR already carries "size: XS" but no longer qualifies
     (e.g. after a rebase that added more commits or lines).
+
+When --size-labels is given, the full size label suite is managed instead
+of only "size: XS".  The suite maps total changed lines (additions +
+deletions) to one of five mutually exclusive labels:
+
+  size: XS  -- 1 commit, ≤1 line changed, no manifest file touched
+  size: S   -- ≤9 lines changed
+  size: M   -- ≤49 lines changed
+  size: L   -- ≤499 lines changed
+  size: XL  -- >499 lines changed
+
+Any existing size label that does not match the computed bucket is removed
+before the new label is applied, keeping exactly one size label on the PR
+at all times.
 
 Area weighting
 --------------
@@ -242,6 +256,16 @@ def parse_args():
         action="count",
         default=0,
         help="Verbose output. Use -v for INFO, -vv for DEBUG.",
+    )
+
+    parser.add_argument(
+        "--size-labels",
+        action="store_true",
+        default=False,
+        help=(
+            "Manage the full size label suite (size: XS/S/M/L/XL) instead of "
+            "only the default size: XS label."
+        ),
     )
 
     return parser.parse_args()
@@ -507,6 +531,17 @@ def _assign_maintainers(gh, pr, args, assignees: list):
 # Manifest files are never considered trivial regardless of line count.
 _MANIFEST_FILES = frozenset({'west.yml', 'submanifests/optional.yaml'})
 
+# All size labels managed by this script; used to remove stale buckets.
+_SIZE_LABELS = frozenset({'size: XS', 'size: S', 'size: M', 'size: L', 'size: XL'})
+
+# (max total lines changed inclusive, label name) in ascending order.
+# XS is handled separately by update_size_xs_label / update_size_labels.
+_SIZE_THRESHOLDS = (
+    (9,   'size: S'),
+    (49,  'size: M'),
+    (499, 'size: L'),
+)
+
 
 def update_size_xs_label(pr, args, changed_files: list, labels: set):
     """Add or remove the 'size: XS' label based on PR size and changed files.
@@ -534,6 +569,52 @@ def update_size_xs_label(pr, args, changed_files: list, labels: set):
         )
         if not args.dry_run:
             pr.remove_from_labels('size: XS')
+
+
+def update_size_labels(pr, args, changed_files: list, labels: set):
+    """Manage the full size label suite (XS/S/M/L/XL) on *pr*.
+
+    Computes the correct size bucket, removes any existing size labels that
+    belong to a different bucket, and queues the correct label for addition.
+    The XS bucket inherits the same stricter qualification rules as
+    update_size_xs_label (single commit, ≤1 line, no manifest files).
+    """
+    total_lines = pr.additions + pr.deletions
+    touches_manifest = any(f.filename in _MANIFEST_FILES for f in changed_files)
+
+    qualifies_for_xs = (
+        pr.commits == 1
+        and pr.additions <= 1
+        and pr.deletions <= 1
+        and not touches_manifest
+    )
+
+    if qualifies_for_xs:
+        correct_label = 'size: XS'
+    else:
+        correct_label = 'size: XL'
+        for max_lines, label in _SIZE_THRESHOLDS:
+            if total_lines <= max_lines:
+                correct_label = label
+                break
+
+    current_label_names = {lbl.name for lbl in pr.labels}
+    stale = _SIZE_LABELS & current_label_names - {correct_label}
+
+    for label in sorted(stale):
+        logger.info(
+            "Removing stale size label '%s' from PR #%d",
+            label, pr.number,
+        )
+        if not args.dry_run:
+            pr.remove_from_labels(label)
+
+    labels.add(correct_label)
+    logger.info(
+        "PR #%d size: %s (+%d/-%d, %d total line(s), %d commit(s))",
+        pr.number, correct_label, pr.additions, pr.deletions,
+        total_lines, pr.commits,
+    )
 
 
 def process_pr(gh, args, maintainer_file, number: int):
@@ -567,7 +648,10 @@ def process_pr(gh, args, maintainer_file, number: int):
         )
         return
 
-    update_size_xs_label(pr, args, changed_files, labels)
+    if args.size_labels:
+        update_size_labels(pr, args, changed_files, labels)
+    else:
+        update_size_xs_label(pr, args, changed_files, labels)
 
     for changed_file in changed_files:
         filename = changed_file.filename

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -92,12 +92,13 @@ Candidates are then filtered:
 
 If the PR already has MAX_REVIEWERS (15) or more reviewers, the normal
 candidate list is discarded.  Only the maintainers of the *primary*
-(highest-weight) area are used as fallback candidates.  This keeps the
-fallback small and high-signal, and avoids the original behaviour of
-requesting reviews from all area maintainers across all touched files
-(which could push a broad PR even further above the reviewer cap).
-The same author / existing-reviewer / self-removed / collaborator-status
-filters are applied to the fallback candidates.
+(highest-weight) area are used as fallback candidates, plus any
+``additional_reviews`` users identified from manifest or MAINTAINERS.yml
+diff.  This keeps the fallback small and high-signal, and avoids the
+original behaviour of requesting reviews from all area maintainers across
+all touched files (which could push a broad PR even further above the
+reviewer cap).  The same author / existing-reviewer / self-removed /
+collaborator-status filters are applied to the fallback candidates.
 
 Otherwise the candidate list is capped at the remaining vacancy
 (MAX_REVIEWERS - existing reviewer count) before the review request is created.
@@ -452,15 +453,26 @@ def _pick_assignees(pr, area_counter: dict, all_maintainers: dict, num_files: in
     return assignees
 
 
-def _add_reviewers(gh, gh_repo, pr, args, collab: list, primary_maintainers: list):
+def _add_reviewers(
+    gh,
+    gh_repo,
+    pr,
+    args,
+    collab: list,
+    primary_maintainers: list,
+    extra_reviewers: frozenset = frozenset(),
+):
     """Request reviews from eligible collaborators on *pr*.
 
     Skips the PR author, existing reviewers, non-collaborators, and users
     who previously removed themselves from the review request.
 
     When the PR already has MAX_REVIEWERS or more reviewers, only
-    *primary_maintainers* (the maintainers of the highest-weight area) are
-    used as fallback candidates, keeping the fallback small and high-signal.
+    *primary_maintainers* (the maintainers of the highest-weight area) plus
+    *extra_reviewers* (e.g. maintainers of MAINTAINERS.yml-changed areas) are
+    used as fallback candidates.  This keeps the fallback small and
+    high-signal while ensuring that people specifically responsible for
+    changed areas are never silently dropped.
     The same filters apply in both the normal and overflow paths.
     """
     existing_reviewers = set()
@@ -485,10 +497,12 @@ def _add_reviewers(gh, gh_repo, pr, args, collab: list, primary_maintainers: lis
             "restricting candidates to primary area maintainers",
             pr.number, len(existing_reviewers), MAX_REVIEWERS,
         )
-        candidates = primary_maintainers
+        # Preserve extra_reviewers (e.g. MAINTAINERS.yml-change reviewers)
+        # even in the overflow path so they are never silently dropped.
+        candidates = list(dict.fromkeys(primary_maintainers + sorted(extra_reviewers)))
         vacancy = None
     else:
-        candidates = collab
+        candidates = collab  # extra_reviewers already included via process_pr
         vacancy = MAX_REVIEWERS - len(existing_reviewers)
 
     reviewers = []
@@ -783,13 +797,16 @@ def process_pr(gh, args, maintainer_file, number: int):
             )
 
     # Request reviews.
-    if collab:
+    if collab or additional_reviews:
         primary_area = next(iter(area_counter), None)
         primary_maintainers = (
             maintainer_file.areas[primary_area.name].maintainers
             if primary_area else []
         )
-        _add_reviewers(gh, gh_repo, pr, args, collab, primary_maintainers)
+        _add_reviewers(
+            gh, gh_repo, pr, args,
+            collab, primary_maintainers, frozenset(additional_reviews),
+        )
 
     # Set assignees (only when none are set yet, unless doing a dry run).
     if assignees and (not pr.assignee or args.dry_run):

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -91,8 +91,13 @@ Candidates are then filtered:
     are skipped.
 
 If the PR already has MAX_REVIEWERS (15) or more reviewers, the normal
-candidate list is discarded and only the maintainers of *all* matched areas
-are requested instead (a smaller, higher-signal set).
+candidate list is discarded.  Only the maintainers of the *primary*
+(highest-weight) area are used as fallback candidates.  This keeps the
+fallback small and high-signal, and avoids the original behaviour of
+requesting reviews from all area maintainers across all touched files
+(which could push a broad PR even further above the reviewer cap).
+The same author / existing-reviewer / self-removed / collaborator-status
+filters are applied to the fallback candidates.
 
 Otherwise the candidate list is capped at the remaining vacancy
 (MAX_REVIEWERS - existing reviewer count) before the review request is created.
@@ -447,11 +452,16 @@ def _pick_assignees(pr, area_counter: dict, all_maintainers: dict, num_files: in
     return assignees
 
 
-def _add_reviewers(gh, gh_repo, pr, args, collab: list, all_maintainers: dict):
+def _add_reviewers(gh, gh_repo, pr, args, collab: list, primary_maintainers: list):
     """Request reviews from eligible collaborators on *pr*.
 
     Skips the PR author, existing reviewers, non-collaborators, and users
     who previously removed themselves from the review request.
+
+    When the PR already has MAX_REVIEWERS or more reviewers, only
+    *primary_maintainers* (the maintainers of the highest-weight area) are
+    used as fallback candidates, keeping the fallback small and high-signal.
+    The same filters apply in both the normal and overflow paths.
     """
     existing_reviewers = set()
     for review in pr.get_reviews():
@@ -471,37 +481,40 @@ def _add_reviewers(gh, gh_repo, pr, args, collab: list, all_maintainers: dict):
 
     if len(existing_reviewers) >= MAX_REVIEWERS:
         logger.info(
-            "PR already has %d reviewer(s) (limit %d); adding area maintainers as reviewers instead",
-            len(existing_reviewers),
-            MAX_REVIEWERS,
+            "PR #%d already has %d reviewer(s) (limit %d); "
+            "restricting candidates to primary area maintainers",
+            pr.number, len(existing_reviewers), MAX_REVIEWERS,
         )
-        reviewers = list(all_maintainers.keys())
+        candidates = primary_maintainers
+        vacancy = None
     else:
+        candidates = collab
         vacancy = MAX_REVIEWERS - len(existing_reviewers)
-        reviewers = []
 
-        for collaborator in collab:
-            try:
-                gh_user = gh.get_user(collaborator)
-            except UnknownObjectException:
-                logger.warning("User '%s' not found; account may have been deleted", collaborator)
-                continue
+    reviewers = []
+    for collaborator in candidates:
+        try:
+            gh_user = gh.get_user(collaborator)
+        except UnknownObjectException:
+            logger.warning("User '%s' not found; account may have been deleted", collaborator)
+            continue
 
-            if pr.user == gh_user:
-                logger.debug("Skipping PR author '%s'", collaborator)
-                continue
-            if gh_user in existing_reviewers:
-                logger.debug("Skipping existing reviewer '%s'", collaborator)
-                continue
-            if not gh_repo.has_in_collaborators(gh_user):
-                logger.info("Skipping '%s': not a repository collaborator", collaborator)
-                continue
-            if gh_user in self_removed:
-                logger.info("Skipping '%s': previously self-removed from reviewers", collaborator)
-                continue
+        if pr.user == gh_user:
+            logger.debug("Skipping PR author '%s'", collaborator)
+            continue
+        if gh_user in existing_reviewers:
+            logger.debug("Skipping existing reviewer '%s'", collaborator)
+            continue
+        if not gh_repo.has_in_collaborators(gh_user):
+            logger.info("Skipping '%s': not a repository collaborator", collaborator)
+            continue
+        if gh_user in self_removed:
+            logger.info("Skipping '%s': previously self-removed from reviewers", collaborator)
+            continue
 
-            reviewers.append(collaborator)
+        reviewers.append(collaborator)
 
+    if vacancy is not None:
         reviewers = reviewers[:vacancy]
 
     if reviewers:
@@ -771,7 +784,12 @@ def process_pr(gh, args, maintainer_file, number: int):
 
     # Request reviews.
     if collab:
-        _add_reviewers(gh, gh_repo, pr, args, collab, all_maintainers)
+        primary_area = next(iter(area_counter), None)
+        primary_maintainers = (
+            maintainer_file.areas[primary_area.name].maintainers
+            if primary_area else []
+        )
+        _add_reviewers(gh, gh_repo, pr, args, collab, primary_maintainers)
 
     # Set assignees (only when none are set yet, unless doing a dry run).
     if assignees and (not pr.assignee or args.dry_run):

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -547,6 +547,10 @@ def process_pr(gh, args, maintainer_file, number: int):
         logger.info("PR #%d is a draft; skipping", pr.number)
         return
 
+    if pr.state != 'open':
+        logger.info("PR #%d is %s; skipping", pr.number, pr.state)
+        return
+
     labels = set()
     area_counter = defaultdict(int)
     found_maintainers = defaultdict(int)

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -314,7 +314,9 @@ def process_manifest(old_manifest_file: str) -> list:
         logger.warning("west.yml not found; skipping manifest processing")
         return []
     if not os.path.isfile(old_manifest_file):
-        logger.warning("Old manifest '%s' not found; skipping manifest processing", old_manifest_file)
+        logger.warning(
+            "Old manifest '%s' not found; skipping manifest processing", old_manifest_file
+        )
         return []
 
     old_manifest = Manifest.from_file(old_manifest_file)
@@ -349,14 +351,14 @@ def _diff_area_entry(old_entry: dict, new_entry: dict) -> list:
     """Return human-readable change strings between two MAINTAINERS area entries."""
     changes = []
     fields = [
-        ("maintainers",   "Maintainers"),
+        ("maintainers", "Maintainers"),
         ("collaborators", "Collaborators"),
-        ("labels",        "Labels"),
-        ("files",         "Files"),
-        ("files-regex",   "files-regex"),
+        ("labels", "Labels"),
+        ("files", "Files"),
+        ("files-regex", "files-regex"),
     ]
     for key, label in fields:
-        added   = set_or_empty(new_entry, key) - set_or_empty(old_entry, key)
+        added = set_or_empty(new_entry, key) - set_or_empty(old_entry, key)
         removed = set_or_empty(old_entry, key) - set_or_empty(new_entry, key)
         if added:
             changes.append(f"{label} added: {', '.join(sorted(added))}")
@@ -376,9 +378,9 @@ def compare_areas(old: dict, new: dict) -> set:
     old_areas = set(old.keys())
     new_areas = set(new.keys())
 
-    added_areas   = new_areas - old_areas
+    added_areas = new_areas - old_areas
     removed_areas = old_areas - new_areas
-    common_areas  = old_areas & new_areas
+    common_areas = old_areas & new_areas
 
     if added_areas:
         logger.info("Areas added (%d):", len(added_areas))
@@ -431,10 +433,18 @@ def _pick_assignees(pr, area_counter: dict, all_maintainers: dict, num_files: in
         # FIXME: identify platform areas and other areas using some flag in the
         # MAINTAINERS.yml data instead of relying on the name containing "Platform".
         if 'platform' in area.name.lower():
-            logger.debug("Platform area '%s' with maintainers %s added as fallback for assignment", area.name, assignees)
+            logger.debug(
+                "Platform area '%s' with maintainers %s added as fallback for assignment",
+                area.name,
+                assignees,
+            )
             ranked_assignees.append(assignees)
         elif area.name not in META_AREAS:
-            logger.debug("Non-platform area '%s' with maintainers %s takes priority for assignment", area.name, assignees)
+            logger.debug(
+                "Non-platform area '%s' with maintainers %s takes priority for assignment",
+                area.name,
+                assignees,
+            )
             # Non-platform area: highest priority — insert at front and stop.
             ranked_assignees.insert(0, assignees)
             break
@@ -483,7 +493,9 @@ def _add_reviewers(
     review_users, _review_teams = pr.get_review_requests()
     existing_reviewers.update(review_users)
 
-    logger.debug("Existing reviewers: %s", [u.login for u in existing_reviewers if hasattr(u, 'login')])
+    logger.debug(
+        "Existing reviewers: %s", [u.login for u in existing_reviewers if hasattr(u, 'login')]
+    )
 
     # Track users who removed themselves; do not re-add them.
     self_removed = set()
@@ -495,7 +507,9 @@ def _add_reviewers(
         logger.info(
             "PR #%d already has %d reviewer(s) (limit %d); "
             "restricting candidates to primary area maintainers",
-            pr.number, len(existing_reviewers), MAX_REVIEWERS,
+            pr.number,
+            len(existing_reviewers),
+            MAX_REVIEWERS,
         )
         # Preserve extra_reviewers (e.g. MAINTAINERS.yml-change reviewers)
         # even in the overflow path so they are never silently dropped.
@@ -564,8 +578,8 @@ _SIZE_LABELS = frozenset({'size: XS', 'size: S', 'size: M', 'size: L', 'size: XL
 # (max total lines changed inclusive, label name) in ascending order.
 # XS is handled separately by update_size_xs_label / update_size_labels.
 _SIZE_THRESHOLDS = (
-    (9,   'size: S'),
-    (49,  'size: M'),
+    (9, 'size: S'),
+    (49, 'size: M'),
     (499, 'size: L'),
 )
 
@@ -581,10 +595,7 @@ def update_size_xs_label(pr, args, changed_files: list, labels: set):
     touches_manifest = any(f.filename in _MANIFEST_FILES for f in changed_files)
     current_label_names = {label.name for label in pr.labels}
     qualifies_for_xs = (
-        pr.commits == 1
-        and pr.additions <= 1
-        and pr.deletions <= 1
-        and not touches_manifest
+        pr.commits == 1 and pr.additions <= 1 and pr.deletions <= 1 and not touches_manifest
     )
 
     if qualifies_for_xs:
@@ -592,7 +603,10 @@ def update_size_xs_label(pr, args, changed_files: list, labels: set):
     elif 'size: XS' in current_label_names:
         logger.info(
             "Removing 'size: XS' label from PR #%d (commits=%d, +%d/-%d)",
-            pr.number, pr.commits, pr.additions, pr.deletions,
+            pr.number,
+            pr.commits,
+            pr.additions,
+            pr.deletions,
         )
         if not args.dry_run:
             pr.remove_from_labels('size: XS')
@@ -610,10 +624,7 @@ def update_size_labels(pr, args, changed_files: list, labels: set):
     touches_manifest = any(f.filename in _MANIFEST_FILES for f in changed_files)
 
     qualifies_for_xs = (
-        pr.commits == 1
-        and pr.additions <= 1
-        and pr.deletions <= 1
-        and not touches_manifest
+        pr.commits == 1 and pr.additions <= 1 and pr.deletions <= 1 and not touches_manifest
     )
 
     if qualifies_for_xs:
@@ -631,7 +642,8 @@ def update_size_labels(pr, args, changed_files: list, labels: set):
     for label in sorted(stale):
         logger.info(
             "Removing stale size label '%s' from PR #%d",
-            label, pr.number,
+            label,
+            pr.number,
         )
         if not args.dry_run:
             pr.remove_from_labels(label)
@@ -639,8 +651,12 @@ def update_size_labels(pr, args, changed_files: list, labels: set):
     labels.add(correct_label)
     logger.info(
         "PR #%d size: %s (+%d/-%d, %d total line(s), %d commit(s))",
-        pr.number, correct_label, pr.additions, pr.deletions,
-        total_lines, pr.commits,
+        pr.number,
+        correct_label,
+        pr.additions,
+        pr.deletions,
+        total_lines,
+        pr.commits,
     )
 
 
@@ -671,7 +687,9 @@ def process_pr(gh, args, maintainer_file, number: int):
     if num_files > MAX_FILES:
         logger.warning(
             "PR #%d has %d changed files (limit %d); skipping",
-            pr.number, num_files, MAX_FILES,
+            pr.number,
+            num_files,
+            MAX_FILES,
         )
         return
 
@@ -793,19 +811,24 @@ def process_pr(gh, args, maintainer_file, number: int):
         else:
             logger.warning(
                 "Too many labels (%d) for PR #%d; skipping label assignment",
-                len(labels), pr.number,
+                len(labels),
+                pr.number,
             )
 
     # Request reviews.
     if collab or additional_reviews:
         primary_area = next(iter(area_counter), None)
         primary_maintainers = (
-            maintainer_file.areas[primary_area.name].maintainers
-            if primary_area else []
+            maintainer_file.areas[primary_area.name].maintainers if primary_area else []
         )
         _add_reviewers(
-            gh, gh_repo, pr, args,
-            collab, primary_maintainers, frozenset(additional_reviews),
+            gh,
+            gh_repo,
+            pr,
+            args,
+            collab,
+            primary_maintainers,
+            frozenset(additional_reviews),
         )
 
     # Set assignees (only when none are set yet, unless doing a dry run).
@@ -860,9 +883,7 @@ def process_issue(gh, args, maintainer_file, number: int):
     logger.info("Matched labels: %s", issue_labels)
 
     if not issue_labels or issue_labels not in label_to_maintainer:
-        logger.warning(
-            "No matching label set found for issue #%d; not assigning", issue.number
-        )
+        logger.warning("No matching label set found for issue #%d; not assigning", issue.number)
         return
 
     for maintainer in label_to_maintainer[issue_labels]:
@@ -891,7 +912,9 @@ def process_modules(gh, args, maintainers_file):
 
         logger.debug(
             "Project '%s': maintainers=%s, collaborators=%s",
-            project.name, area.maintainers, area.collaborators,
+            project.name,
+            area.maintainers,
+            area.collaborators,
         )
         repos[f"{args.org}/{project.name}"] = area
 
@@ -912,7 +935,8 @@ def process_modules(gh, args, maintainers_file):
         if pull.assignees:
             logger.error(
                 "PR %s unexpectedly has assignees %s despite no:assignee filter",
-                pull.html_url, pull.assignees,
+                pull.html_url,
+                pull.assignees,
             )
             continue
 
@@ -936,10 +960,7 @@ def main():
 
     token = os.environ.get('GITHUB_TOKEN')
     if not token:
-        sys.exit(
-            'GITHUB_TOKEN environment variable is not set. '
-            'Please set it and retry.'
-        )
+        sys.exit('GITHUB_TOKEN environment variable is not set. Please set it and retry.')
 
     gh = Github(auth=Auth.Token(token))
     maintainer_file = Maintainers(args.maintainer_file)

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -374,6 +374,38 @@ def _assign_maintainers(gh, pr, args, assignees: list):
             pr.add_to_assignees(user)
 
 
+# Manifest files are never considered trivial regardless of line count.
+_MANIFEST_FILES = frozenset({'west.yml', 'submanifests/optional.yaml'})
+
+
+def update_size_xs_label(pr, args, changed_files: list, labels: set):
+    """Add or remove the 'size: XS' label based on PR size and changed files.
+
+    A PR qualifies for 'size: XS' when all of the following are true:
+      - Exactly one commit.
+      - At most one line added and one line deleted.
+      - No manifest file (west.yml, submanifests/optional.yaml) is changed.
+    """
+    touches_manifest = any(f.filename in _MANIFEST_FILES for f in changed_files)
+    current_label_names = {label.name for label in pr.labels}
+    qualifies_for_xs = (
+        pr.commits == 1
+        and pr.additions <= 1
+        and pr.deletions <= 1
+        and not touches_manifest
+    )
+
+    if qualifies_for_xs:
+        labels.add('size: XS')
+    elif 'size: XS' in current_label_names:
+        logger.info(
+            "Removing 'size: XS' label from PR #%d (commits=%d, +%d/-%d)",
+            pr.number, pr.commits, pr.additions, pr.deletions,
+        )
+        if not args.dry_run:
+            pr.remove_from_labels('size: XS')
+
+
 def process_pr(gh, args, maintainer_file, number: int):
     gh_repo = gh.get_repo(f"{args.org}/{args.repo}")
     pr = gh_repo.get_pull(number)
@@ -397,28 +429,7 @@ def process_pr(gh, args, maintainer_file, number: int):
         )
         return
 
-    # Handle the 'size: XS' label: single-commit PRs with at most one line changed,
-    # but only when no manifest file is among the changed files.  Manifest bumps
-    # (west.yml, submanifests/optional.yaml) are never trivial regardless of line count.
-    manifest_files = {'west.yml', 'submanifests/optional.yaml'}
-    touches_manifest = any(f.filename in manifest_files for f in changed_files)
-    current_label_names = {label.name for label in pr.labels}
-    qualifies_for_xs = (
-        pr.commits == 1
-        and pr.additions <= 1
-        and pr.deletions <= 1
-        and not touches_manifest
-    )
-
-    if qualifies_for_xs:
-        labels.add('size: XS')
-    elif 'size: XS' in current_label_names:
-        logger.info(
-            "Removing 'size: XS' label from PR #%d (commits=%d, +%d/-%d)",
-            pr.number, pr.commits, pr.additions, pr.deletions,
-        )
-        if not args.dry_run:
-            pr.remove_from_labels('size: XS')
+    update_size_xs_label(pr, args, changed_files, labels)
 
     for changed_file in changed_files:
         filename = changed_file.filename

--- a/scripts/tests/ci/__init__.py
+++ b/scripts/tests/ci/__init__.py
@@ -8,3 +8,4 @@ from pathlib import Path
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE", str(Path(__file__).parents[3]))
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "ci"))
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts"))

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 # Stub heavy third-party and project-local modules before the SUT is imported.
 # ---------------------------------------------------------------------------
 
+
 class _GithubException(Exception):
     pass
 
@@ -50,6 +51,7 @@ import set_assignees as sut  # noqa: E402, I001  (import after sys.modules manip
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 class _Area:
     """Lightweight hashable area stub accepted by _pick_assignees."""
@@ -89,6 +91,7 @@ def _make_args(dry_run=False):
 # ---------------------------------------------------------------------------
 # load_areas
 # ---------------------------------------------------------------------------
+
 
 class TestLoadAreas:
     def test_includes_area_with_files(self, tmp_path):
@@ -165,6 +168,7 @@ Area D:
 # set_or_empty
 # ---------------------------------------------------------------------------
 
+
 class TestSetOrEmpty:
     def test_key_present_with_list(self):
         assert sut.set_or_empty({"a": ["x", "y"]}, "a") == {"x", "y"}
@@ -182,6 +186,7 @@ class TestSetOrEmpty:
 # ---------------------------------------------------------------------------
 # _diff_area_entry
 # ---------------------------------------------------------------------------
+
 
 class TestDiffAreaEntry:
     def test_identical_entries_produce_no_changes(self):
@@ -240,6 +245,7 @@ class TestDiffAreaEntry:
 # compare_areas
 # ---------------------------------------------------------------------------
 
+
 class TestCompareAreas:
     def test_added_area_returned(self):
         old = {}
@@ -283,6 +289,7 @@ class TestCompareAreas:
 # ---------------------------------------------------------------------------
 # update_size_xs_label
 # ---------------------------------------------------------------------------
+
 
 class TestUpdateSizeXsLabel:
     def test_qualifies_adds_label(self):
@@ -362,6 +369,7 @@ class TestUpdateSizeXsLabel:
 # ---------------------------------------------------------------------------
 # _pick_assignees
 # ---------------------------------------------------------------------------
+
 
 class TestPickAssignees:
     def _pr(self, login="contributor"):
@@ -445,6 +453,7 @@ class TestPickAssignees:
 # ---------------------------------------------------------------------------
 # setup_logging
 # ---------------------------------------------------------------------------
+
 
 class TestSetupLogging:
     def test_verbose_0_sets_warning(self):

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for scripts/ci/set_assignees.py.
+
+Heavy third-party dependencies (PyGithub, west, get_maintainer) are stubbed
+out at module level so the test suite runs without a full Zephyr environment
+or a live GitHub token.
+"""
+
+import logging
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Stub heavy third-party and project-local modules before the SUT is imported.
+# ---------------------------------------------------------------------------
+
+class _GithubException(Exception):
+    pass
+
+
+class _UnknownObjectException(_GithubException):
+    pass
+
+
+_github_mod = MagicMock()
+_github_mod.GithubException = _GithubException
+_github_mod.Auth = MagicMock()
+_github_mod.Github = MagicMock()
+
+_github_exc_mod = MagicMock()
+_github_exc_mod.UnknownObjectException = _UnknownObjectException
+
+for _name, _mod in [
+    ("github", _github_mod),
+    ("github.GithubException", _github_exc_mod),
+    ("west", MagicMock()),
+    ("west.manifest", MagicMock()),
+    ("get_maintainer", MagicMock()),
+    ("yaml", __import__("yaml")),  # real yaml is available
+]:
+    sys.modules.setdefault(_name, _mod)
+
+import set_assignees as sut  # noqa: E402, I001  (import after sys.modules manipulation)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _Area:
+    """Lightweight hashable area stub accepted by _pick_assignees."""
+
+    def __init__(self, name, maintainers=None, labels=None, collaborators=None):
+        self.name = name
+        self.maintainers = list(maintainers or [])
+        self.labels = list(labels or [])
+        self.collaborators = list(collaborators or [])
+
+
+def _make_area(name, maintainers=None, labels=None, collaborators=None):
+    return _Area(name, maintainers=maintainers, labels=labels, collaborators=collaborators)
+
+
+def _make_pr(commits=1, additions=0, deletions=0, labels=None, user_login="contributor"):
+    """Return a mock GitHub PR object for update_size_xs_label / _pick_assignees."""
+    pr = MagicMock()
+    pr.commits = commits
+    pr.additions = additions
+    pr.deletions = deletions
+    pr.number = 42
+    pr.labels = [SimpleNamespace(name=lbl) for lbl in (labels or [])]
+    pr.user = SimpleNamespace(login=user_login)
+    pr.assignee = None
+    return pr
+
+
+def _make_file(filename):
+    return SimpleNamespace(filename=filename)
+
+
+def _make_args(dry_run=False):
+    return SimpleNamespace(dry_run=dry_run)
+
+
+# ---------------------------------------------------------------------------
+# load_areas
+# ---------------------------------------------------------------------------
+
+class TestLoadAreas:
+    def test_includes_area_with_files(self, tmp_path):
+        content = """
+Area A:
+  files:
+    - drivers/foo/
+  maintainers:
+    - alice
+"""
+        f = tmp_path / "M.yml"
+        f.write_text(content)
+        result = sut.load_areas(str(f))
+        assert "Area A" in result
+
+    def test_includes_area_with_files_regex(self, tmp_path):
+        content = """
+Area B:
+  files-regex:
+    - ^include/foo/
+  maintainers:
+    - bob
+"""
+        f = tmp_path / "M.yml"
+        f.write_text(content)
+        result = sut.load_areas(str(f))
+        assert "Area B" in result
+
+    def test_excludes_area_without_files_or_regex(self, tmp_path):
+        content = """
+Meta Area:
+  labels:
+    - area: meta
+  maintainers:
+    - charlie
+"""
+        f = tmp_path / "M.yml"
+        f.write_text(content)
+        result = sut.load_areas(str(f))
+        assert "Meta Area" not in result
+
+    def test_excludes_scalar_top_level_entries(self, tmp_path):
+        content = """
+version: 1
+Area C:
+  files:
+    - lib/bar/
+  maintainers:
+    - dave
+"""
+        f = tmp_path / "M.yml"
+        f.write_text(content)
+        result = sut.load_areas(str(f))
+        assert "version" not in result
+        assert "Area C" in result
+
+    def test_both_files_and_regex_included(self, tmp_path):
+        content = """
+Area D:
+  files:
+    - subsys/foo/
+  files-regex:
+    - ^include/foo/
+  maintainers:
+    - eve
+"""
+        f = tmp_path / "M.yml"
+        f.write_text(content)
+        result = sut.load_areas(str(f))
+        assert "Area D" in result
+
+
+# ---------------------------------------------------------------------------
+# set_or_empty
+# ---------------------------------------------------------------------------
+
+class TestSetOrEmpty:
+    def test_key_present_with_list(self):
+        assert sut.set_or_empty({"a": ["x", "y"]}, "a") == {"x", "y"}
+
+    def test_key_present_with_none(self):
+        assert sut.set_or_empty({"a": None}, "a") == set()
+
+    def test_key_absent(self):
+        assert sut.set_or_empty({}, "a") == set()
+
+    def test_key_present_with_empty_list(self):
+        assert sut.set_or_empty({"a": []}, "a") == set()
+
+
+# ---------------------------------------------------------------------------
+# _diff_area_entry
+# ---------------------------------------------------------------------------
+
+class TestDiffAreaEntry:
+    def test_identical_entries_produce_no_changes(self):
+        entry = {"maintainers": ["alice"], "collaborators": [], "status": "maintained"}
+        assert sut._diff_area_entry(entry, entry) == []
+
+    def test_maintainer_added(self):
+        old = {"maintainers": ["alice"]}
+        new = {"maintainers": ["alice", "bob"]}
+        changes = sut._diff_area_entry(old, new)
+        assert any("bob" in c and "added" in c for c in changes)
+
+    def test_maintainer_removed(self):
+        old = {"maintainers": ["alice", "bob"]}
+        new = {"maintainers": ["alice"]}
+        changes = sut._diff_area_entry(old, new)
+        assert any("bob" in c and "removed" in c for c in changes)
+
+    def test_collaborator_added(self):
+        old = {"collaborators": []}
+        new = {"collaborators": ["carol"]}
+        changes = sut._diff_area_entry(old, new)
+        assert any("carol" in c and "added" in c for c in changes)
+
+    def test_status_changed(self):
+        old = {"status": "maintained"}
+        new = {"status": "odd fixes"}
+        changes = sut._diff_area_entry(old, new)
+        assert any("Status changed" in c for c in changes)
+
+    def test_status_unchanged_no_entry(self):
+        changes = sut._diff_area_entry({}, {})
+        assert not any("Status" in c for c in changes)
+
+    def test_label_added(self):
+        old = {"labels": ["area: kernel"]}
+        new = {"labels": ["area: kernel", "area: drivers"]}
+        changes = sut._diff_area_entry(old, new)
+        assert any("area: drivers" in c and "added" in c for c in changes)
+
+    def test_files_regex_removed(self):
+        old = {"files-regex": ["^include/foo/"]}
+        new = {"files-regex": []}
+        changes = sut._diff_area_entry(old, new)
+        assert any("removed" in c for c in changes)
+
+    def test_multiple_changes_all_reported(self):
+        old = {"maintainers": ["alice"], "status": "maintained"}
+        new = {"maintainers": ["bob"], "status": "odd fixes"}
+        changes = sut._diff_area_entry(old, new)
+        # At least two change entries (maintainer add + remove, status change)
+        assert len(changes) >= 2
+
+
+# ---------------------------------------------------------------------------
+# compare_areas
+# ---------------------------------------------------------------------------
+
+class TestCompareAreas:
+    def test_added_area_returned(self):
+        old = {}
+        new = {"New Area": {"files": ["foo/"], "maintainers": ["alice"]}}
+        result = sut.compare_areas(old, new)
+        assert "New Area" in result
+
+    def test_removed_area_returned(self):
+        old = {"Old Area": {"files": ["bar/"], "maintainers": ["bob"]}}
+        new = {}
+        result = sut.compare_areas(old, new)
+        assert "Old Area" in result
+
+    def test_changed_area_returned(self):
+        area = {"files": ["baz/"], "maintainers": ["alice"]}
+        old = {"My Area": dict(area)}
+        new = {"My Area": {**area, "maintainers": ["alice", "carol"]}}
+        result = sut.compare_areas(old, new)
+        assert "My Area" in result
+
+    def test_unchanged_area_not_returned(self):
+        area = {"files": ["qux/"], "maintainers": ["dave"]}
+        result = sut.compare_areas({"Stable": area}, {"Stable": area})
+        assert "Stable" not in result
+
+    def test_combination_of_all_three(self):
+        old = {
+            "Removed": {"files": ["r/"]},
+            "Common": {"files": ["c/"], "maintainers": ["alice"]},
+        }
+        new = {
+            "Added": {"files": ["a/"]},
+            "Common": {"files": ["c/"], "maintainers": ["alice", "bob"]},
+        }
+        result = sut.compare_areas(old, new)
+        assert "Removed" in result
+        assert "Added" in result
+        assert "Common" in result
+
+
+# ---------------------------------------------------------------------------
+# update_size_xs_label
+# ---------------------------------------------------------------------------
+
+class TestUpdateSizeXsLabel:
+    def test_qualifies_adds_label(self):
+        pr = _make_pr(commits=1, additions=1, deletions=1)
+        labels = set()
+        sut.update_size_xs_label(pr, _make_args(), [_make_file("drivers/foo/bar.c")], labels)
+        assert "size: XS" in labels
+
+    def test_zero_changes_qualifies(self):
+        pr = _make_pr(commits=1, additions=0, deletions=0)
+        labels = set()
+        sut.update_size_xs_label(pr, _make_args(), [_make_file("lib/foo.c")], labels)
+        assert "size: XS" in labels
+
+    def test_too_many_additions_does_not_qualify(self):
+        pr = _make_pr(commits=1, additions=5, deletions=0)
+        labels = set()
+        sut.update_size_xs_label(pr, _make_args(), [_make_file("lib/foo.c")], labels)
+        assert "size: XS" not in labels
+
+    def test_too_many_deletions_does_not_qualify(self):
+        pr = _make_pr(commits=1, additions=0, deletions=3)
+        labels = set()
+        sut.update_size_xs_label(pr, _make_args(), [_make_file("lib/foo.c")], labels)
+        assert "size: XS" not in labels
+
+    def test_multiple_commits_does_not_qualify(self):
+        pr = _make_pr(commits=2, additions=1, deletions=1)
+        labels = set()
+        sut.update_size_xs_label(pr, _make_args(), [_make_file("lib/foo.c")], labels)
+        assert "size: XS" not in labels
+
+    def test_west_yml_touch_disqualifies(self):
+        pr = _make_pr(commits=1, additions=1, deletions=1)
+        labels = set()
+        sut.update_size_xs_label(pr, _make_args(), [_make_file("west.yml")], labels)
+        assert "size: XS" not in labels
+
+    def test_submanifest_touch_disqualifies(self):
+        pr = _make_pr(commits=1, additions=1, deletions=1)
+        labels = set()
+        sut.update_size_xs_label(
+            pr, _make_args(), [_make_file("submanifests/optional.yaml")], labels
+        )
+        assert "size: XS" not in labels
+
+    def test_manifest_among_multiple_files_disqualifies(self):
+        pr = _make_pr(commits=1, additions=1, deletions=1)
+        labels = set()
+        files = [_make_file("lib/foo.c"), _make_file("west.yml")]
+        sut.update_size_xs_label(pr, _make_args(), files, labels)
+        assert "size: XS" not in labels
+
+    def test_removes_stale_label_when_not_qualifying(self):
+        pr = _make_pr(commits=3, additions=10, deletions=5, labels=["size: XS"])
+        sut.update_size_xs_label(pr, _make_args(dry_run=False), [_make_file("lib/foo.c")], set())
+        pr.remove_from_labels.assert_called_once_with("size: XS")
+
+    def test_does_not_remove_label_on_dry_run(self):
+        pr = _make_pr(commits=3, additions=10, deletions=5, labels=["size: XS"])
+        sut.update_size_xs_label(pr, _make_args(dry_run=True), [_make_file("lib/foo.c")], set())
+        pr.remove_from_labels.assert_not_called()
+
+    def test_no_action_when_no_label_and_not_qualifying(self):
+        pr = _make_pr(commits=2, additions=5, deletions=0, labels=[])
+        sut.update_size_xs_label(pr, _make_args(), [_make_file("lib/foo.c")], set())
+        pr.remove_from_labels.assert_not_called()
+
+    def test_existing_labels_preserved(self):
+        pr = _make_pr(commits=1, additions=1, deletions=1)
+        labels = {"area: kernel"}
+        sut.update_size_xs_label(pr, _make_args(), [_make_file("lib/foo.c")], labels)
+        assert "area: kernel" in labels
+        assert "size: XS" in labels
+
+
+# ---------------------------------------------------------------------------
+# _pick_assignees
+# ---------------------------------------------------------------------------
+
+class TestPickAssignees:
+    def _pr(self, login="contributor"):
+        return _make_pr(user_login=login)
+
+    def test_single_non_platform_area(self):
+        area = _make_area("Networking", maintainers=["alice", "bob"])
+        pr = self._pr()
+        result = sut._pick_assignees(pr, {area: 3}, {"alice": 3, "bob": 1}, num_files=3)
+        assert result == ["alice", "bob"]
+
+    def test_author_is_sole_maintainer_falls_back_to_all_maintainers(self):
+        area = _make_area("Networking", maintainers=["contributor"])
+        pr = self._pr("contributor")
+        all_m = {"contributor": 2}
+        result = sut._pick_assignees(pr, {area: 2}, all_m, num_files=2)
+        # ranked_assignees stays empty; fallback picks first of all_maintainers
+        assert result == ["contributor"]
+
+    def test_author_is_one_of_multiple_maintainers(self):
+        area = _make_area("Networking", maintainers=["contributor", "alice"])
+        pr = self._pr("contributor")
+        result = sut._pick_assignees(pr, {area: 2}, {"contributor": 2, "alice": 1}, num_files=2)
+        assert "contributor" not in result
+        assert "alice" in result
+
+    def test_platform_area_only_is_used_as_fallback(self):
+        area = _make_area("Platform: nrf52", maintainers=["charlie"])
+        result = sut._pick_assignees(self._pr(), {area: 2}, {"charlie": 2}, num_files=2)
+        assert result == ["charlie"]
+
+    def test_non_platform_beats_platform(self):
+        platform = _make_area("Platform: nrf52", maintainers=["charlie"])
+        subsys = _make_area("Bluetooth", maintainers=["dave"])
+        # area_counter ordered: platform first (higher count), subsys second
+        pr = self._pr()
+        result = sut._pick_assignees(
+            pr, {platform: 5, subsys: 3}, {"charlie": 5, "dave": 3}, num_files=5
+        )
+        # non-platform (Bluetooth) should be inserted at front and returned
+        assert result == ["dave"]
+
+    def test_meta_area_only_assigns_meta_maintainer(self):
+        area = _make_area("Documentation", maintainers=["eve"])
+        result = sut._pick_assignees(self._pr(), {area: 2}, {"eve": 2}, num_files=2)
+        assert result == ["eve"]
+
+    def test_meta_area_not_sole_area_skips_meta_logic(self):
+        meta = _make_area("Documentation", maintainers=["eve"])
+        other = _make_area("Kernel", maintainers=["frank"])
+        # area_counter is always sorted descending by count before _pick_assignees
+        # is called; put the higher-count non-meta area first so it is visited first.
+        result = sut._pick_assignees(
+            self._pr(), {other: 2, meta: 1}, {"frank": 2, "eve": 1}, num_files=3
+        )
+        # Kernel (non-platform, non-meta, higher count) wins
+        assert result == ["frank"]
+
+    def test_zero_count_area_is_skipped(self):
+        area = _make_area("Networking", maintainers=["alice"])
+        all_m = {"alice": 0}
+        result = sut._pick_assignees(self._pr(), {area: 0}, all_m, num_files=1)
+        # count==0 → continue; all_maintainers fallback picks alice
+        assert result == ["alice"]
+
+    def test_area_without_maintainers_is_skipped(self):
+        area = _make_area("Empty Area", maintainers=[])
+        result = sut._pick_assignees(self._pr(), {area: 3}, {}, num_files=3)
+        assert result is None
+
+    def test_empty_inputs_returns_none(self):
+        result = sut._pick_assignees(self._pr(), {}, {}, num_files=0)
+        assert result is None
+
+    def test_zero_num_files_coverage_does_not_divide_by_zero(self):
+        area = _make_area("Networking", maintainers=["alice"])
+        result = sut._pick_assignees(self._pr(), {area: 1}, {"alice": 1}, num_files=0)
+        assert result == ["alice"]
+
+
+# ---------------------------------------------------------------------------
+# setup_logging
+# ---------------------------------------------------------------------------
+
+class TestSetupLogging:
+    def test_verbose_0_sets_warning(self):
+        with patch("logging.basicConfig") as mock_cfg:
+            sut.setup_logging(0)
+            mock_cfg.assert_called_once()
+            assert mock_cfg.call_args.kwargs["level"] == logging.WARNING
+
+    def test_verbose_1_sets_info(self):
+        with patch("logging.basicConfig") as mock_cfg:
+            sut.setup_logging(1)
+            assert mock_cfg.call_args.kwargs["level"] == logging.INFO
+
+    def test_verbose_2_sets_debug(self):
+        with patch("logging.basicConfig") as mock_cfg:
+            sut.setup_logging(2)
+            assert mock_cfg.call_args.kwargs["level"] == logging.DEBUG
+
+    def test_verbose_3_still_sets_debug(self):
+        with patch("logging.basicConfig") as mock_cfg:
+            sut.setup_logging(3)
+            assert mock_cfg.call_args.kwargs["level"] == logging.DEBUG


### PR DESCRIPTION
- **scripts: ci: set_assignees: overhaul for readability and correctness**
- **scripts: ci: set_assignees: extract size XS label logic into helper**
- **scripts: tests: ci: add pytest suite for set_assignees**
- **scripts: ci: set_assignees: add detailed strategy documentation**
- **scripts: ci: set_assignees: skip draft PRs in process_pr**
- **scripts: ci: set_assignees: skip closed/merged PRs in process_pr**
- **scripts: ci: set_assignees: add full size label suite via --size-labels**
- **scripts: ci: set_assignees: apply area labels in a single API call**
- **scripts: ci: set_assignees: fix reviewer overflow fallback**
- **scripts: ci: set_assignees: preserve additional_reviews in overflow path**
- **ci: set_assignee: apply ruff format**
