### PR TITLE
include: disk.h: doxygen documentation refs

### DIFF
--- a/include/zephyr/drivers/disk.h
+++ b/include/zephyr/drivers/disk.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Possible Cmd Codes for disk_ioctl()
+ * @brief Possible Cmd Codes for @ref disk_access_ioctl()
  */
 
 /** Get the number of sectors in the disk  */
@@ -80,7 +80,7 @@ extern "C" {
 #define DISK_IOCTL_GET_CARD_CID			8
 
 /**
- * @brief Possible return bitmasks for disk_status()
+ * @brief Possible return bitmasks for @ref disk_access_status()
  */
 
 /** Disk status okay */


### PR DESCRIPTION
Fix up dangling references to `disk_*()` functions which are actually `disk_access_*()`.

Classic noob contribution. I'll admit that this confused me for a minute before I figured out what was going on. So I figured I'd throw a fix upstream.

Thanks for the review!