### PR TITLE
scripts: twister: increase coverage by decreasing the default min_ram

### DIFF
--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -64,7 +64,7 @@ class TwisterConfigParser:
         "skip": {"type": "bool", "default": False},
         "slow": {"type": "bool", "default": False},
         "timeout": {"type": "int", "default": 60},
-        "min_ram": {"type": "int", "default": 16},
+        "min_ram": {"type": "int", "default": 8},
         "modules": {"type": "list", "default": []},
         "depends_on": {"type": "set"},
         "min_flash": {"type": "int", "default": 32},
@@ -91,7 +91,7 @@ class TwisterConfigParser:
         "harness_config": {"type": "map", "default": {}},
         "sidecar": {"type": "str", "default": None},
         "seed": {"type": "int", "default": 0},
-        "sysbuild": {"type": "bool", "default": False}
+        "sysbuild": {"type": "bool", "default": False},
     }
 
     def __init__(self, filename: str, schema: dict[str, Any]) -> None:


### PR DESCRIPTION
Twister filters tests based on how much RAM the test needs. The
default is 16 KiB, which filters the vast majority of tests for the 8
KiB ch32v006 and 21 other boards.

Decrease the default to 8 KiB which increases the ch32v006 test
coverage from 5 to 599.