### PR TITLE
drivers: sdhc: Log SDIO timing mode in more drivers

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -16,6 +16,7 @@
 #include <zephyr/logging/log.h>
 #include <soc.h>
 #include <zephyr/drivers/pinctrl.h>
+#include "sdhc_helpers.h"
 #define PINCTRL_STATE_SLOW   PINCTRL_STATE_PRIV_START
 #define PINCTRL_STATE_MED    (PINCTRL_STATE_PRIV_START + 1U)
 #define PINCTRL_STATE_FAST   (PINCTRL_STATE_PRIV_START + 2U)
@@ -344,9 +345,9 @@ static int imx_usdhc_set_io(const struct device *dev, struct sdhc_io *ios)
 	struct sdhc_io *host_io = &data->host_io;
 	USDHC_Type *base = get_base(dev);
 
-	LOG_DBG("SDHC I/O: bus width %d, clock %dHz, card power %s, voltage %s", ios->bus_width,
-		ios->clock, ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF",
-		ios->signal_voltage == SD_VOL_1_8_V ? "1.8V" : "3.3V");
+	LOG_DBG("SDHC I/O: bus width %d, clock %dHz, card power %s, timing %s, voltage %s",
+		ios->bus_width, ios->clock, ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF",
+		sdhc_timing_mode_str(ios->timing), sd_voltage_str(ios->signal_voltage));
 
 	if (clock_control_get_rate(cfg->clock_dev, cfg->clock_subsys, &src_clk_hz)) {
 		return -EINVAL;

--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -14,6 +14,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/cache.h>
 #include <zephyr/drivers/regulator.h>
+#include "sdhc_helpers.h"
 
 #include "rcar_mmc_registers.h"
 
@@ -974,45 +975,6 @@ static int rcar_mmc_request(const struct device *dev, struct sdhc_command *cmd,
 	return ret;
 }
 
-/* convert sd_voltage to string */
-static inline const char *const rcar_mmc_get_signal_voltage_str(enum sd_voltage voltage)
-{
-	static const char *const sig_vol_str[] = {
-		[0] = "Unset",		 [SD_VOL_3_3_V] = "3.3V", [SD_VOL_3_0_V] = "3.0V",
-		[SD_VOL_1_8_V] = "1.8V", [SD_VOL_1_2_V] = "1.2V",
-	};
-
-	if (voltage >= 0 && voltage < ARRAY_SIZE(sig_vol_str)) {
-		return sig_vol_str[voltage];
-	} else {
-		return "Unknown";
-	}
-}
-
-/* convert sdhc_timing_mode to string */
-static inline const char *const rcar_mmc_get_timing_str(enum sdhc_timing_mode timing)
-{
-	static const char *const timing_str[] = {
-		[0] = "Unset",
-		[SDHC_TIMING_LEGACY] = "LEGACY",
-		[SDHC_TIMING_HS] = "HS",
-		[SDHC_TIMING_SDR12] = "SDR12",
-		[SDHC_TIMING_SDR25] = "SDR25",
-		[SDHC_TIMING_SDR50] = "SDR50",
-		[SDHC_TIMING_SDR104] = "SDR104",
-		[SDHC_TIMING_DDR50] = "DDR50",
-		[SDHC_TIMING_DDR52] = "DDR52",
-		[SDHC_TIMING_HS200] = "HS200",
-		[SDHC_TIMING_HS400] = "HS400",
-	};
-
-	if (timing >= 0 && timing < ARRAY_SIZE(timing_str)) {
-		return timing_str[timing];
-	} else {
-		return "Unknown";
-	}
-}
-
 /* change voltage of MMC */
 static int rcar_mmc_change_voltage(const struct mmc_rcar_cfg *cfg, struct sdhc_io *host_io,
 				   struct sdhc_io *ios)
@@ -1399,11 +1361,9 @@ static int rcar_mmc_set_io(const struct device *dev, struct sdhc_io *ios)
 	data = dev->data;
 	host_io = &data->host_io;
 
-	LOG_DBG("SDHC I/O: bus width %d, clock %dHz, card power %s, "
-		"timing %s, voltage %s",
+	LOG_DBG("SDHC I/O: bus width %d, clock %dHz, card power %s, timing %s, voltage %s",
 		ios->bus_width, ios->clock, ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF",
-		rcar_mmc_get_timing_str(ios->timing),
-		rcar_mmc_get_signal_voltage_str(ios->signal_voltage));
+		sdhc_timing_mode_str(ios->timing), sd_voltage_str(ios->signal_voltage));
 
 	/* Set host clock */
 	ret = rcar_mmc_set_clk_rate(dev, ios);

--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#include "sdhc_helpers.h"
 
 #include <esp_clk_tree.h>
 #include <hal/sdmmc_ll.h>
@@ -947,10 +948,12 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 	uint8_t bus_width;
 	int ret = 0;
 
-	LOG_INF("SDHC I/O: slot: %d, bus width %d, clock %dHz, card power %s, voltage %s",
+	LOG_INF("SDHC I/O: slot: %d, bus width %d, clock %dHz, card power %s, "
+		"timing %s, voltage %s",
 		cfg->slot, ios->bus_width, ios->clock,
 		ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF",
-		ios->signal_voltage == SD_VOL_1_8_V ? "1.8V" : "3.3V");
+		sdhc_timing_mode_str(ios->timing),
+		sd_voltage_str(ios->signal_voltage));
 
 	if (ios->clock) {
 		/* Check for frequency boundaries supported by host */

--- a/drivers/sdhc/sdhc_helpers.h
+++ b/drivers/sdhc/sdhc_helpers.h
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SDHC_SDHC_HELPERS_H_
+#define ZEPHYR_DRIVERS_SDHC_SDHC_HELPERS_H_
+
+/**
+ * @brief Convert enum sd_voltage to a human-readable string
+ *
+ * @param voltage Enum value
+ * @return String like "1.8V" or "3.3V", or "Unknown" for out-of-range values
+ */
+static inline const char *sd_voltage_str(enum sd_voltage voltage)
+{
+	static const char *const sig_vol_str[] = {
+		[0] = "Unset",		 [SD_VOL_3_3_V] = "3.3V", [SD_VOL_3_0_V] = "3.0V",
+		[SD_VOL_1_8_V] = "1.8V", [SD_VOL_1_2_V] = "1.2V",
+	};
+
+	if (voltage >= 0 && voltage < ARRAY_SIZE(sig_vol_str)) {
+		return sig_vol_str[voltage];
+	} else {
+		return "Unknown";
+	}
+}
+
+/**
+ * @brief Convert enum timing to a human-readable string
+ *
+ * @param timing Enum value
+ * @return String like "LEGACY" or "HS200", or "Unknown" for out-of-range values
+ */
+static inline const char *sdhc_timing_mode_str(enum sdhc_timing_mode timing)
+{
+	static const char *const timing_str[] = {
+		[0] = "Unset",
+		[SDHC_TIMING_LEGACY] = "LEGACY",
+		[SDHC_TIMING_HS] = "HS",
+#ifdef CONFIG_SDHC_SUPPORTS_UHS
+		[SDHC_TIMING_SDR12] = "SDR12",
+		[SDHC_TIMING_SDR25] = "SDR25",
+		[SDHC_TIMING_SDR50] = "SDR50",
+		[SDHC_TIMING_SDR104] = "SDR104",
+		[SDHC_TIMING_DDR50] = "DDR50",
+		[SDHC_TIMING_DDR52] = "DDR52",
+		[SDHC_TIMING_HS200] = "HS200",
+		[SDHC_TIMING_HS400] = "HS400",
+#endif /* CONFIG_SDHC_SUPPORTS_UHS */
+	};
+
+	if (timing >= 0 && timing < ARRAY_SIZE(timing_str)) {
+		return timing_str[timing];
+	} else {
+		return "Unknown";
+	}
+}
+
+#endif /* ZEPHYR_DRIVERS_SDHC_SDHC_HELPERS_H_ */

--- a/drivers/sdhc/sdhc_infineon.c
+++ b/drivers/sdhc/sdhc_infineon.c
@@ -42,6 +42,7 @@
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/cache.h>
+#include "sdhc_helpers.h"
 
 #include "cy_sd_host.h"
 #include "cy_sysclk.h"
@@ -746,9 +747,9 @@ static int sdhc_infineon_set_io(const struct device *dev, struct sdhc_io *ios)
 	cy_en_sd_host_bus_speed_mode_t speed_mode;
 	int ret = 0;
 
-	LOG_INF("SDHC I/O: bus width %d, clock %dHz, card power %s, voltage %s, timing %d",
+	LOG_INF("SDHC I/O: bus width %d, clock %dHz, card power %s, voltage %s, timing %s",
 		ios->bus_width, ios->clock, ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF",
-		ios->signal_voltage == SD_VOL_1_8_V ? "1.8V" : "3.3V", ios->timing);
+		sd_voltage_str(ios->signal_voltage), sdhc_timing_mode_str(ios->timing));
 
 	/* Toggle card power supply */
 	if (sdhc_data->power_mode != ios->power_mode) {

--- a/drivers/sdhc/sdhc_numaker.c
+++ b/drivers/sdhc/sdhc_numaker.c
@@ -17,6 +17,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
 #include <soc.h>
+#include "sdhc_helpers.h"
 
 #if defined(CONFIG_SOC_SERIES_M55M1X)
 #include <zephyr/dt-bindings/clock/numaker_m55m1x_clock.h>
@@ -280,9 +281,9 @@ static int numaker_sdhc_set_io(const struct device *dev, struct sdhc_io *ios)
 	SDH_T *base = config->base;
 	int rc;
 
-	LOG_DBG("SDHC I/O: bus width %d, clock %dHz, card power %s, voltage %s", ios->bus_width,
-		ios->clock, ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF",
-		ios->signal_voltage == SD_VOL_1_8_V ? "1.8V" : "3.3V");
+	LOG_DBG("SDHC I/O: bus width %d, clock %dHz, card power %s, timing %s, voltage %s",
+		ios->bus_width, ios->clock, ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF",
+		sdhc_timing_mode_str(ios->timing), sd_voltage_str(ios->signal_voltage));
 
 	/* Note on power cycle
 	 *


### PR DESCRIPTION
rcar already had a function to map timing mode to a string. Move that function into the shared header and use it from multiple drivers. Also use a shared function to convert voltage to a string instead of open coding it everywhere.