### PR TITLE
drivers: sdhc: imx_usdhc: Replace `IMX_USDHC_NOCACHE_TAG` with `__nocache`

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -1219,16 +1219,10 @@ static DEVICE_API(sdhc, usdhc_api) = {
 	.disable_interrupt = imx_usdhc_disable_interrupt,
 };
 
-#ifdef CONFIG_NOCACHE_MEMORY
-#define IMX_USDHC_NOCACHE_TAG __attribute__((__section__(".nocache")));
-#else
-#define IMX_USDHC_NOCACHE_TAG
-#endif
-
 #ifdef CONFIG_IMX_USDHC_DMA_SUPPORT
 #define IMX_USDHC_DMA_BUFFER_DEFINE(n)                                                             \
 	static uint32_t __aligned(32)                                                              \
-	usdhc_##n##_dma_descriptor[CONFIG_IMX_USDHC_DMA_BUFFER_SIZE / 4] IMX_USDHC_NOCACHE_TAG;
+	usdhc_##n##_dma_descriptor[CONFIG_IMX_USDHC_DMA_BUFFER_SIZE / 4] __nocache;
 #define IMX_USDHC_DMA_BUFFER_INIT(n)                                                               \
 	.usdhc_dma_descriptor = usdhc_##n##_dma_descriptor,                                        \
 	.dma_descriptor_len = CONFIG_IMX_USDHC_DMA_BUFFER_SIZE / 4,


### PR DESCRIPTION
These are both gated on `CONFIG_NOCACHE_MEMORY` and both place the symbol in a non-cacheable section, so there's no reason to define our own macro. The only difference is that `__nocache` uses a file-specific section name, which helps with debugging but shouldn't affect functionality.