### PR TITLE
net: http: server: echo Sec-WebSocket-Protocol on WS upgrade

### DIFF
--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -347,6 +347,7 @@ enum http1_parser_state {
 
 #define HTTP_SERVER_INITIAL_WINDOW_SIZE 65536
 #define HTTP_SERVER_WS_MAX_SEC_KEY_LEN 32
+#define HTTP_SERVER_WS_MAX_SEC_PROTOCOL_LEN 64
 
 /** @brief HTTP/2 stream representation. */
 struct http2_stream_ctx {
@@ -510,6 +511,14 @@ struct http_client_ctx {
 	/** Websocket security key. */
 	IF_ENABLED(CONFIG_WEBSOCKET, (uint8_t ws_sec_key[HTTP_SERVER_WS_MAX_SEC_KEY_LEN]));
 
+	/** Websocket subprotocol selected from the client's
+	 *  Sec-WebSocket-Protocol request header. NUL-terminated; empty
+	 *  if the client did not list any subprotocol. Echoed back in
+	 *  the 101 Switching Protocols response per RFC 6455.
+	 */
+	IF_ENABLED(CONFIG_WEBSOCKET,
+		   (char ws_sec_protocol[HTTP_SERVER_WS_MAX_SEC_PROTOCOL_LEN]));
+
 	/** Client supported compression. */
 	IF_ENABLED(CONFIG_HTTP_SERVER_COMPRESSION, (uint8_t supported_compression));
 
@@ -569,6 +578,9 @@ struct http_client_ctx {
 /** @cond INTERNAL_HIDDEN */
 	/** Flag indicating Websocket key is being processed. */
 	bool websocket_sec_key_next : 1;
+
+	/** Flag indicating Websocket subprotocol list is being processed. */
+	bool websocket_sec_protocol_next : 1;
 
 	/** Flag indicating accept encoding is being processed. */
 	IF_ENABLED(CONFIG_HTTP_SERVER_COMPRESSION, (bool accept_encoding_next: 1));

--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -896,6 +896,9 @@ static int on_header_field(struct http_parser *parser, const char *at,
 				ctx->has_upgrade_header = true;
 			} else if (strcasecmp(ctx->header_buffer, "Sec-WebSocket-Key") == 0) {
 				ctx->websocket_sec_key_next = true;
+			} else if (strcasecmp(ctx->header_buffer,
+					     "Sec-WebSocket-Protocol") == 0) {
+				ctx->websocket_sec_protocol_next = true;
 			}
 #ifdef CONFIG_HTTP_SERVER_COMPRESSION
 			else if (strcasecmp(ctx->header_buffer, "Accept-Encoding") == 0) {
@@ -991,6 +994,40 @@ static int on_header_value(struct http_parser *parser,
 				ctx->ws_sec_key[offset] = '\0';
 #endif
 				ctx->websocket_sec_key_next = false;
+			}
+
+			if (ctx->websocket_sec_protocol_next) {
+#if defined(CONFIG_WEBSOCKET)
+				/* Select the first subprotocol in the
+				 * client's comma-separated list. Per RFC
+				 * 6455 the server picks one of the listed
+				 * subprotocols and echoes it back; if the
+				 * client list overflows our buffer, drop
+				 * the header rather than truncate to a
+				 * partial token.
+				 */
+				const char *comma = memchr(ctx->header_buffer,
+							   ',', offset);
+				size_t token_len = comma ?
+					(size_t)(comma - (char *)ctx->header_buffer) :
+					offset;
+
+				while (token_len > 0 &&
+				       (ctx->header_buffer[token_len - 1] == ' ' ||
+					ctx->header_buffer[token_len - 1] == '\t')) {
+					token_len--;
+				}
+
+				if (token_len >= sizeof(ctx->ws_sec_protocol)) {
+					LOG_WRN("Sec-WebSocket-Protocol token too long, ignoring");
+					ctx->ws_sec_protocol[0] = '\0';
+				} else {
+					memcpy(ctx->ws_sec_protocol,
+					       ctx->header_buffer, token_len);
+					ctx->ws_sec_protocol[token_len] = '\0';
+				}
+#endif
+				ctx->websocket_sec_protocol_next = false;
 			}
 #ifdef CONFIG_HTTP_SERVER_COMPRESSION
 			if (ctx->accept_encoding_next) {

--- a/subsys/net/lib/http/http_server_ws.c
+++ b/subsys/net/lib/http/http_server_ws.c
@@ -42,7 +42,7 @@ int handle_http1_to_websocket_upgrade(struct http_client_ctx *client)
 	char key_accept[HTTP_SERVER_WS_MAX_SEC_KEY_LEN + sizeof(WS_MAGIC)];
 	char accept[20];
 	size_t accept_len;
-	char tmp[64];
+	char tmp[128];
 	size_t key_len;
 	size_t olen;
 	int ret;
@@ -87,8 +87,20 @@ int handle_http1_to_websocket_upgrade(struct http_client_ctx *client)
 		goto error;
 	}
 
-	ret = snprintk(tmp, sizeof(tmp), "\r\nUser-Agent: %s\r\n\r\n",
-		       ZEPHYR_USER_AGENT);
+	/* RFC 6455 sec. 4.2.2: if the client offered subprotocols via
+	 * Sec-WebSocket-Protocol, echo the one we selected. The HTTP/1
+	 * parser stores the first token from the client's list in
+	 * ws_sec_protocol; an empty value means the client did not
+	 * negotiate a subprotocol, in which case we omit the header.
+	 */
+	if (client->ws_sec_protocol[0] != '\0') {
+		ret = snprintk(tmp, sizeof(tmp),
+			       "\r\nSec-WebSocket-Protocol: %s\r\nUser-Agent: %s\r\n\r\n",
+			       client->ws_sec_protocol, ZEPHYR_USER_AGENT);
+	} else {
+		ret = snprintk(tmp, sizeof(tmp), "\r\nUser-Agent: %s\r\n\r\n",
+			       ZEPHYR_USER_AGENT);
+	}
 	if (ret < 0 || ret >= sizeof(tmp)) {
 		goto error;
 	}


### PR DESCRIPTION
Echo the requested `Sec-WebSocket-Protocol` header on the WebSocket upgrade response in the HTTP server, per RFC 6455 §4.2.2. Without this, browsers that send a subprotocol list during the upgrade handshake see the server respond without one, which makes the handshake fail (per RFC: "If the response lacks an `Sec-WebSocket-Protocol` header field … the client MUST … fail the WebSocket connection").

Independent of the board enablement series; included here because it surfaced during PiZZa's WebREPL Binary Protocol work on the Pi Zero 2 W.

---

Part of the rpi_zero_2w board enablement series (RFC #109880). Related parallel work: #110379 (Pi Zero W / BCM2835 / ARMv6).
