### PR TITLE
boards: raspberrypi: add Raspberry Pi Zero 2 W

### DIFF
--- a/boards/raspberrypi/rpi_zero_2w/Kconfig.rpi_zero_2w
+++ b/boards/raspberrypi/rpi_zero_2w/Kconfig.rpi_zero_2w
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_RPI_ZERO_2W
+	select SOC_BCM2710

--- a/boards/raspberrypi/rpi_zero_2w/board.yml
+++ b/boards/raspberrypi/rpi_zero_2w/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: rpi_zero_2w
+  full_name: Raspberry Pi Zero 2 W
+  vendor: raspberrypi
+  socs:
+  - name: bcm2710

--- a/boards/raspberrypi/rpi_zero_2w/doc/index.rst
+++ b/boards/raspberrypi/rpi_zero_2w/doc/index.rst
@@ -1,0 +1,109 @@
+.. zephyr:board:: rpi_zero_2w
+
+Overview
+********
+
+The `Raspberry Pi Zero 2 W`_ is a small single-board computer built around the
+Broadcom BCM2710A1 SoC, the same silicon as the original Raspberry Pi 3,
+packaged in an RP3A0-AU SiP together with 512 MB of LPDDR2 SDRAM.
+
+Zephyr runs the BCM2710A1 in single-core mode, using the BCM2836 ARM-local
+interrupt controller (`QA7 ARM Quad-A7 Core`_) and the BCM2835 ARMC peripheral
+interrupt controller (`BCM2837 ARM Peripherals`_) natively, as this SoC has no
+GIC. The mini-UART on GPIO 14/15 is the default console.
+
+Hardware
+********
+
+- 1GHz quad-core 64-bit Arm Cortex-A53 CPU
+- 512MB SDRAM
+- 2.4GHz 802.11 b/g/n wireless LAN
+- Bluetooth 4.2, Bluetooth Low Energy (BLE), onboard antenna
+- Mini HDMI port and micro USB On-The-Go (OTG) port
+- microSD card slot
+- CSI-2 camera connector
+- HAT-compatible 40-pin header footprint (unpopulated)
+- H.264, MPEG-4 decode (1080p30); H.264 encode (1080p30)
+- OpenGL ES 1.1, 2.0 graphics
+- Micro USB power
+- Composite video and reset pins via solder test points
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+microSD card
+============
+
+Flash a **Raspberry Pi OS Lite (64-bit)** image to a microSD card with
+Raspberry Pi Imager. This creates the FAT boot partition holding the
+firmware blobs (``bootcode.bin``, ``fixup.dat``, ``start.elf``) that the
+BCM2710A1 needs in order to bring up the ARM cores.
+
+In the root directory of that boot partition:
+
+1. Copy ``build/zephyr/zephyr.bin``
+2. Replace ``config.txt`` with:
+
+   .. code-block:: text
+
+      arm_64bit=1
+      enable_uart=1
+      core_freq=250
+      kernel_address=0x200000
+      kernel=zephyr.bin
+
+``arm_64bit=1`` is required whenever the kernel filename does not start with
+``kernel8``. ``enable_uart=1`` routes the mini-UART to GPIO 14/15, which the
+Bluetooth radio would otherwise use. ``core_freq=250`` locks the VPU clock so
+the mini-UART baud-rate divisor stays valid; ``enable_uart=1`` is supposed to
+imply this but does not always (see `raspberrypi/linux issue #4123`_).
+``kernel_address`` must match the DRAM base in the board devicetree. See the
+`config.txt reference`_ for the full set of firmware options.
+
+Eject the card and boot the Pi. The console comes up on the mini-UART at
+115200 8N1, no flow control:
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build v4.x.x-... ***
+   Hello World! rpi_zero_2w
+
+Console connection
+==================
+
+Wire a 3.3 V USB-UART adapter to the GPIO header:
+
+================== ============= =======================
+Adapter            Pi header pin Pi GPIO / function
+================== ============= =======================
+GND                6 (or 9, 14)  GND
+RX                 8             GPIO 14 / mini-UART TX
+TX                 10            GPIO 15 / mini-UART RX
+================== ============= =======================
+
+References
+**********
+
+.. target-notes::
+
+.. _Raspberry Pi Zero 2 W:
+   https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/
+
+.. _raspberrypi/linux issue #4123:
+   https://github.com/raspberrypi/linux/issues/4123
+
+.. _BCM2837 ARM Peripherals:
+   https://datasheets.raspberrypi.com/bcm2837/bcm2837-peripherals.pdf
+
+.. _QA7 ARM Quad-A7 Core:
+   https://datasheets.raspberrypi.com/bcm2836/QA7_rev3.4.pdf
+
+.. _config.txt reference:
+   https://www.raspberrypi.com/documentation/computers/config_txt.html

--- a/boards/raspberrypi/rpi_zero_2w/rpi_zero_2w.dts
+++ b/boards/raspberrypi/rpi_zero_2w/rpi_zero_2w.dts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <broadcom/bcm2710.dtsi>
+#include <broadcom/bcm2711-pinctrl.dtsi>
+
+/ {
+	model = "Raspberry Pi Zero 2 W";
+	compatible = "raspberrypi,model-zero-2-w", "brcm,bcm2710";
+
+	chosen {
+		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
+		zephyr,sram = &dram0;
+	};
+
+	/*
+	 * DRAM window the image is linked into; the base must match the
+	 * kernel_address= line in config.txt.
+	 */
+	dram0: memory@200000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = <0x200000 DT_SIZE_M(256)>;
+	};
+};
+
+&uart1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart1_gpio14>;
+	current-speed = <115200>;
+	status = "okay";
+};

--- a/boards/raspberrypi/rpi_zero_2w/rpi_zero_2w.yaml
+++ b/boards/raspberrypi/rpi_zero_2w/rpi_zero_2w.yaml
@@ -1,0 +1,7 @@
+identifier: rpi_zero_2w
+name: Raspberry Pi Zero 2 W
+type: mcu
+arch: arm64
+toolchain:
+  - zephyr
+  - cross-compile

--- a/boards/raspberrypi/rpi_zero_2w/rpi_zero_2w_defconfig
+++ b/boards/raspberrypi/rpi_zero_2w/rpi_zero_2w_defconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Jonathan Elliot Peace
+# SPDX-License-Identifier: Apache-2.0
+
+# The default 8 MMU translation tables are insufficient once the image
+# map and the SoC device regions are accounted for.
+CONFIG_MAX_XLAT_TABLES=12
+
+# Serial / console
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# ARM generic timer frequency is read at runtime.
+CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME=y

--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -22,6 +22,8 @@ zephyr_library_include_directories(${ZEPHYR_BASE}/arch/common/include)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_ARCV2_INTERRUPT_UNIT intc_arcv2_irq_unit.c)
+zephyr_library_sources_ifdef(CONFIG_BCM2835_ARMCTRL_IC intc_bcm2835_armctrl.c)
+zephyr_library_sources_ifdef(CONFIG_BCM2836_L1_INTC intc_bcm2836_l1.c)
 zephyr_library_sources_ifdef(CONFIG_CAVS_ICTL intc_cavs.c)
 zephyr_library_sources_ifdef(CONFIG_CLIC intc_clic.S)
 zephyr_library_sources_ifdef(CONFIG_CLIC intc_clic.c)

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -65,6 +65,7 @@ source "subsys/logging/Kconfig.template.log_config"
 
 # zephyr-keep-sorted-start
 source "drivers/interrupt_controller/Kconfig.acp"
+source "drivers/interrupt_controller/Kconfig.brcm"
 source "drivers/interrupt_controller/Kconfig.cavs"
 source "drivers/interrupt_controller/Kconfig.clic"
 source "drivers/interrupt_controller/Kconfig.dw"

--- a/drivers/interrupt_controller/Kconfig.brcm
+++ b/drivers/interrupt_controller/Kconfig.brcm
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config BCM2836_L1_INTC
+	bool "BCM2836 ARM-local interrupt controller"
+	default y
+	depends on DT_HAS_BRCM_BCM2836_L1_INTC_ENABLED
+	help
+	  Driver for the BCM2836 ARM-local interrupt controller (also
+	  present on BCM2710 / Pi Zero 2 W). Routes per-core ARM
+	  generic timer IRQs, four mailbox IRQs per core, the per-core
+	  PMU IRQ, and the cascaded GPU IRQ to the parent controller of
+	  the ARM CPU IRQ line.
+
+config BCM2835_ARMCTRL_IC
+	bool "BCM2835 ARMC peripheral interrupt controller"
+	default y
+	depends on DT_HAS_BRCM_BCM2835_ARMCTRL_IC_ENABLED
+	help
+	  Driver for the BCM2835 ARMC peripheral interrupt controller --
+	  the "GPU IRQ" side of the BCM283x family. On BCM2710 (Pi Zero
+	  2 W) it cascades under the BCM2836 ARM-local intc; on BCM2835
+	  (Pi 1 / Pi Zero W) it is the root controller wired directly to
+	  the ARM core IRQ line.

--- a/drivers/interrupt_controller/intc_bcm2835_armctrl.c
+++ b/drivers/interrupt_controller/intc_bcm2835_armctrl.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * BCM2835 ARMC peripheral interrupt controller. Sits behind the GPU
+ * cascade line of the parent BCM2836 ARM-local intc (BCM2710 / Pi
+ * Zero 2 W). Aggregates 64 GPU IRQs (PEND1 + PEND2 banks) plus 8
+ * "basic" ARMC IRQs into the cascade line.
+ *
+ * The decode quirks documented in the BCM2835 ARM Peripherals
+ * datasheet ch. 7 are encapsulated here:
+ *
+ *   1. Bank-1/2 IRQs that have a "shortcut" in bank 0 set ONLY their
+ *      shortcut bit. Their per-bank PEND register bit is suppressed
+ *      AND the bank-0 bits 8/9 ("bank 1/2 has more pending") do NOT
+ *      fire. The decode path must therefore check shortcuts before
+ *      consulting PEND1/PEND2.
+ *   2. Bank-0 bits 8/9 cannot be masked.
+ *   3. The shortcut bits in the bank-0 enable/disable registers are
+ *      ignored; the actual bank-1/2 enable register must be used.
+ *
+ * Called from soc/brcm/bcm2710/soc_irq.c via the
+ * bcm2835_armctrl_ic_* entry points in
+ * <zephyr/drivers/interrupt_controller/intc_bcm283x.h>.
+ */
+
+#define DT_DRV_COMPAT brcm_bcm2835_armctrl_ic
+
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/interrupt_controller/intc_bcm283x.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+
+/* Register offsets from the ARMC base. */
+#define ARMC_IRQ_BASIC_PENDING_OFF  0x00
+#define ARMC_IRQ_PENDING1_OFF       0x04
+#define ARMC_IRQ_PENDING2_OFF       0x08
+#define ARMC_FIQ_CONTROL_OFF        0x0c
+#define ARMC_ENABLE_IRQS_1_OFF      0x10
+#define ARMC_ENABLE_IRQS_2_OFF      0x14
+#define ARMC_ENABLE_BASIC_IRQS_OFF  0x18
+#define ARMC_DISABLE_IRQS_1_OFF     0x1c
+#define ARMC_DISABLE_IRQS_2_OFF     0x20
+#define ARMC_DISABLE_BASIC_IRQS_OFF 0x24
+
+/* IRQ_BASIC_PENDING register layout. */
+#define BANK0_BASIC_MASK   0xffU          /* bits 0..7 = ARMC basic IRQs */
+#define BANK1_PENDING_BIT  BIT(8)         /* "bank 1 has more pending" */
+#define BANK2_PENDING_BIT  BIT(9)         /* "bank 2 has more pending" */
+#define SHORTCUT1_MASK     0x00007c00U    /* bits 10..14 -> bank 1 IRQs */
+#define SHORTCUT2_MASK     0x001f8000U    /* bits 15..20 -> bank 2 IRQs */
+#define SHORTCUT_SHIFT     10
+#define BANK0_VALID_MASK   (BANK0_BASIC_MASK | BANK1_PENDING_BIT | \
+			    BANK2_PENDING_BIT | SHORTCUT1_MASK | \
+			    SHORTCUT2_MASK)
+
+/*
+ * Bank-0 shortcut bits 10..20 each map directly to one bank-1/bank-2
+ * IRQ. Indices 0..4 hold the bank-1 IRQ numbers reachable via bits
+ * 10..14; indices 5..10 the bank-2 IRQ numbers reachable via bits
+ * 15..20.
+ */
+static const uint8_t shortcuts[] = {
+	7,  9, 10, 18, 19,               /* SHORTCUT1 (bank 1) */
+	21, 22, 23, 24, 25, 30           /* SHORTCUT2 (bank 2) */
+};
+
+#define ARMC_IRQ_ENC(bank, n) (BCM283X_ARMC_IRQ_BASE + ((bank) << 5) + (n))
+#define ARMC_IRQ_BANK(irq)    (((irq) - BCM283X_ARMC_IRQ_BASE) >> 5)
+#define ARMC_IRQ_BIT(irq)     (((irq) - BCM283X_ARMC_IRQ_BASE) & 0x1f)
+
+static mm_reg_t armc_base;
+
+static uintptr_t armc_enable_reg(unsigned int bank)
+{
+	static const uint32_t enable_off[3] = {
+		ARMC_ENABLE_BASIC_IRQS_OFF,
+		ARMC_ENABLE_IRQS_1_OFF,
+		ARMC_ENABLE_IRQS_2_OFF,
+	};
+
+	return armc_base + enable_off[bank];
+}
+
+static uintptr_t armc_disable_reg(unsigned int bank)
+{
+	static const uint32_t disable_off[3] = {
+		ARMC_DISABLE_BASIC_IRQS_OFF,
+		ARMC_DISABLE_IRQS_1_OFF,
+		ARMC_DISABLE_IRQS_2_OFF,
+	};
+
+	return armc_base + disable_off[bank];
+}
+
+void bcm2835_armctrl_ic_init(void)
+{
+	/* See the comment in bcm2836_l1_intc_init() on why we map here. */
+	device_map(&armc_base, DT_INST_REG_ADDR(0), DT_INST_REG_SIZE(0),
+		   K_MEM_CACHE_NONE);
+
+	/*
+	 * Mask everything. The DISABLE_* registers are write-1-to-clear,
+	 * not r/w masks -- there is no separate "mask" register on this
+	 * controller.
+	 */
+	sys_write32(0xffffffffU, armc_base + ARMC_DISABLE_IRQS_1_OFF);
+	sys_write32(0xffffffffU, armc_base + ARMC_DISABLE_IRQS_2_OFF);
+	sys_write32(0xffU,       armc_base + ARMC_DISABLE_BASIC_IRQS_OFF);
+
+	/* Cancel any FIQ left enabled by the boot firmware. */
+	sys_write32(0, armc_base + ARMC_FIQ_CONTROL_OFF);
+}
+
+void bcm2835_armctrl_ic_irq_enable(unsigned int irq)
+{
+	if (!BCM283X_IRQ_IS_ARMC(irq)) {
+		return;
+	}
+	sys_write32(BIT(ARMC_IRQ_BIT(irq)), armc_enable_reg(ARMC_IRQ_BANK(irq)));
+}
+
+void bcm2835_armctrl_ic_irq_disable(unsigned int irq)
+{
+	if (!BCM283X_IRQ_IS_ARMC(irq)) {
+		return;
+	}
+	sys_write32(BIT(ARMC_IRQ_BIT(irq)), armc_disable_reg(ARMC_IRQ_BANK(irq)));
+}
+
+int bcm2835_armctrl_ic_irq_is_enabled(unsigned int irq)
+{
+	if (!BCM283X_IRQ_IS_ARMC(irq)) {
+		return 0;
+	}
+	return !!(sys_read32(armc_enable_reg(ARMC_IRQ_BANK(irq)))
+		  & BIT(ARMC_IRQ_BIT(irq)));
+}
+
+unsigned int bcm2835_armctrl_ic_irq_get_active(void)
+{
+	uint32_t basic;
+	uint32_t p;
+
+	basic = sys_read32(armc_base + ARMC_IRQ_BASIC_PENDING_OFF)
+		& BANK0_VALID_MASK;
+	if (basic == 0) {
+		return CONFIG_NUM_IRQS;
+	}
+	if (basic & BANK0_BASIC_MASK) {
+		return ARMC_IRQ_ENC(0, __builtin_ctz(basic & BANK0_BASIC_MASK));
+	}
+	if (basic & SHORTCUT1_MASK) {
+		return ARMC_IRQ_ENC(1, shortcuts[__builtin_ctz(basic >> SHORTCUT_SHIFT)]);
+	}
+	if (basic & SHORTCUT2_MASK) {
+		return ARMC_IRQ_ENC(2, shortcuts[__builtin_ctz(basic >> SHORTCUT_SHIFT)]);
+	}
+	if (basic & BANK1_PENDING_BIT) {
+		p = sys_read32(armc_base + ARMC_IRQ_PENDING1_OFF);
+		if (p) {
+			return ARMC_IRQ_ENC(1, __builtin_ctz(p));
+		}
+	}
+	if (basic & BANK2_PENDING_BIT) {
+		p = sys_read32(armc_base + ARMC_IRQ_PENDING2_OFF);
+		if (p) {
+			return ARMC_IRQ_ENC(2, __builtin_ctz(p));
+		}
+	}
+	return CONFIG_NUM_IRQS;
+}

--- a/drivers/interrupt_controller/intc_bcm2836_l1.c
+++ b/drivers/interrupt_controller/intc_bcm2836_l1.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * BCM2836 ARM-local interrupt controller (also present on BCM2710 /
+ * Pi Zero 2 W). Drives per-core ARM generic timer IRQs, four mailbox
+ * IRQs per core (used as IPIs in SMP-capable kernels), the per-core
+ * PMU IRQ, and the cascaded GPU IRQ that aggregates everything
+ * pending on the BCM2835 ARMC peripheral controller.
+ *
+ * Called from the SoC's z_soc_irq_* hooks via the bcm2836_l1_intc_*
+ * entry points in <zephyr/drivers/interrupt_controller/intc_bcm283x.h>.
+ * Single-core only (CORE_ID 0) until SMP arrives.
+ */
+
+#define DT_DRV_COMPAT brcm_bcm2836_l1_intc
+
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/interrupt_controller/intc_bcm283x.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+
+/* Register offsets from the L1 intc base. */
+#define L1_GPU_INT_ROUTING_OFF   0x0c
+#define L1_PMU_ROUTING_SET_OFF   0x10
+#define L1_PMU_ROUTING_CLR_OFF   0x14
+#define L1_TIMER_INT_CTRL_OFF(c) (0x40 + (c) * 4)
+#define L1_MBOX_INT_CTRL_OFF(c)  (0x50 + (c) * 4)
+#define L1_IRQ_SOURCE_OFF(c)     (0x60 + (c) * 4)
+
+/* L1 IRQ_SOURCE bit masks. */
+#define L1_SRC_TIMER_MASK 0x000fU /* bits 0..3 */
+#define L1_SRC_MBOX_MASK  0x00f0U /* bits 4..7 */
+
+/* TODO: revisit when SMP arrives. */
+#define CORE_ID 0
+
+static mm_reg_t l1_base;
+
+void bcm2836_l1_intc_init(void)
+{
+	/*
+	 * Map the L1 intc register bank. This is invoked from
+	 * z_soc_irq_init() in soc_irq.c, which runs from
+	 * z_arm64_interrupt_init() in z_prep_c -- after the MMU is up
+	 * but before any SYS_INIT priority. We can't rely on a normal
+	 * driver .init callback here. With CONFIG_KERNEL_DIRECT_MAP=y
+	 * (selected on BCM2710) device_map() identity-maps so the
+	 * physical address from the DT remains valid as a virtual one.
+	 */
+	device_map(&l1_base, DT_INST_REG_ADDR(0), DT_INST_REG_SIZE(0),
+		   K_MEM_CACHE_NONE);
+
+	/*
+	 * Mask all locally-routed sources for core 0. The GPU routing
+	 * register defaults to core 0 after reset; force it so the
+	 * value is deterministic across firmware variants.
+	 */
+	sys_write32(0, l1_base + L1_TIMER_INT_CTRL_OFF(CORE_ID));
+	sys_write32(0, l1_base + L1_MBOX_INT_CTRL_OFF(CORE_ID));
+	sys_write32(0, l1_base + L1_GPU_INT_ROUTING_OFF);
+}
+
+void bcm2836_l1_intc_irq_enable(unsigned int irq)
+{
+	if (irq <= 3) {
+		mm_reg_t reg = l1_base + L1_TIMER_INT_CTRL_OFF(CORE_ID);
+
+		sys_write32(sys_read32(reg) | BIT(irq), reg);
+	} else if (irq <= 7) {
+		mm_reg_t reg = l1_base + L1_MBOX_INT_CTRL_OFF(CORE_ID);
+
+		sys_write32(sys_read32(reg) | BIT(irq - 4), reg);
+	} else if (irq == BCM2836_L1_IRQ_PMU_BIT) {
+		sys_write32(BIT(CORE_ID), l1_base + L1_PMU_ROUTING_SET_OFF);
+	}
+	/*
+	 * IRQ 8 (GPU cascade) is implicit: the L1 routing register
+	 * already steers it to CORE_ID and no per-IRQ enable bit exists.
+	 */
+}
+
+void bcm2836_l1_intc_irq_disable(unsigned int irq)
+{
+	if (irq <= 3) {
+		mm_reg_t reg = l1_base + L1_TIMER_INT_CTRL_OFF(CORE_ID);
+
+		sys_write32(sys_read32(reg) & ~BIT(irq), reg);
+	} else if (irq <= 7) {
+		mm_reg_t reg = l1_base + L1_MBOX_INT_CTRL_OFF(CORE_ID);
+
+		sys_write32(sys_read32(reg) & ~BIT(irq - 4), reg);
+	} else if (irq == BCM2836_L1_IRQ_PMU_BIT) {
+		sys_write32(BIT(CORE_ID), l1_base + L1_PMU_ROUTING_CLR_OFF);
+	}
+}
+
+int bcm2836_l1_intc_irq_is_enabled(unsigned int irq)
+{
+	if (irq <= 3) {
+		return !!(sys_read32(l1_base + L1_TIMER_INT_CTRL_OFF(CORE_ID)) & BIT(irq));
+	}
+	if (irq <= 7) {
+		return !!(sys_read32(l1_base + L1_MBOX_INT_CTRL_OFF(CORE_ID)) & BIT(irq - 4));
+	}
+	if (irq == BCM2836_L1_IRQ_GPU_BIT) {
+		/* No mask for the cascade -- always live. */
+		return 1;
+	}
+	/* PMU has no readback path; report disabled conservatively. */
+	return 0;
+}
+
+unsigned int bcm2836_l1_intc_irq_get_active(void)
+{
+	uint32_t src = sys_read32(l1_base + L1_IRQ_SOURCE_OFF(CORE_ID));
+
+	if (src == 0) {
+		return CONFIG_NUM_IRQS;
+	}
+	if (src & L1_SRC_TIMER_MASK) {
+		return __builtin_ctz(src & L1_SRC_TIMER_MASK); /* 0..3 */
+	}
+	if (src & L1_SRC_MBOX_MASK) {
+		return __builtin_ctz(src & L1_SRC_MBOX_MASK);  /* 4..7 */
+	}
+	if (src & BIT(BCM2836_L1_IRQ_PMU_BIT)) {
+		return BCM2836_L1_IRQ_PMU_BIT;
+	}
+	if (src & BIT(BCM2836_L1_IRQ_GPU_BIT)) {
+		return BCM2836_L1_IRQ_GPU_BIT;
+	}
+	return CONFIG_NUM_IRQS;
+}

--- a/dts/arm64/broadcom/bcm2710.dtsi
+++ b/dts/arm64/broadcom/bcm2710.dtsi
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Broadcom BCM2710 SoC (Raspberry Pi 3 / Pi Zero 2 W).
+ *
+ * Interrupts are handled by the native BCM283x controller pair --
+ * brcm,bcm2836-l1-intc (per-core timers, mailboxes, PMU and the GPU
+ * cascade) and brcm,bcm2835-armctrl-ic (the peripheral aggregator) --
+ * driven through the arm64 custom-interrupt-controller hooks in
+ * soc/brcm/bcm2710/soc_irq.c.
+ */
+
+#include <mem.h>
+#include <freq.h>
+
+#include <arm64/armv8-a.dtsi>
+#include <zephyr/dt-bindings/interrupt-controller/bcm2836-l1.h>
+#include <zephyr/dt-bindings/interrupt-controller/bcm2835-armctrl.h>
+
+/ {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <0>;
+			i-cache-line-size = <64>;
+			d-cache-line-size = <64>;
+		};
+	};
+
+	interrupt-parent = <&armctrl_intc>;
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupt-parent = <&local_intc>;
+		/* 0 = secure phys, 1 = nonsec phys, 2 = virtual, 3 = hyp phys */
+		interrupts = <BCM2836_LOCAL_IRQ_CNTPSIRQ IRQ_TYPE_LEVEL 0>,
+			     <BCM2836_LOCAL_IRQ_CNTPNSIRQ IRQ_TYPE_LEVEL 0>,
+			     <BCM2836_LOCAL_IRQ_CNTVIRQ IRQ_TYPE_LEVEL 0>,
+			     <BCM2836_LOCAL_IRQ_CNTHPIRQ IRQ_TYPE_LEVEL 0>;
+	};
+
+	clocks {
+		clk_uart: clk-uart {
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			#clock-cells = <0>;
+		};
+
+		/* VPU core clock; tracks the firmware-side core_freq. */
+		clk_core: clk-core {
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(250)>;
+			#clock-cells = <0>;
+		};
+	};
+
+	soc {
+		local_intc: interrupt-controller@40000000 {
+			compatible = "brcm,bcm2836-l1-intc";
+			reg = <0x40000000 0x100>;
+			interrupt-controller;
+			#interrupt-cells = <3>;
+			status = "okay";
+		};
+
+		armctrl_intc: interrupt-controller@3f00b200 {
+			compatible = "brcm,bcm2835-armctrl-ic";
+			reg = <0x3f00b200 0x200>;
+			interrupt-parent = <&local_intc>;
+			interrupts = <BCM2836_LOCAL_IRQ_GPU IRQ_TYPE_LEVEL 0>;
+			interrupt-controller;
+			#interrupt-cells = <3>;
+			status = "okay";
+		};
+
+		pinctrl: pin-controller@3f200000 {
+			compatible = "brcm,bcm2711-pinctrl";
+			reg = <0x3f200000 0xf4>;
+			ngpios = <54>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			gpio0: gpio@0 {
+				compatible = "brcm,bcm2711-gpio";
+				reg = <0>;
+				interrupts = <BCM2835_IRQ_GPIO0 IRQ_TYPE_LEVEL 0>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <28>;
+				status = "okay";
+			};
+
+			gpio1: gpio@1c {
+				compatible = "brcm,bcm2711-gpio";
+				reg = <28>;
+				interrupts = <BCM2835_IRQ_GPIO1 IRQ_TYPE_LEVEL 0>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <18>;
+				status = "disabled";
+			};
+		};
+
+		uart0: uart@3f201000 {
+			compatible = "arm,pl011";
+			reg = <0x3f201000 0x200>;
+			interrupts = <BCM2835_IRQ_UART IRQ_TYPE_LEVEL 0>;
+			interrupt-names = "uart0";
+			clocks = <&clk_uart>;
+			status = "disabled";
+		};
+
+		uart1: uart@3f215040 {
+			compatible = "brcm,bcm283x-aux-uart", "ns16550";
+			reg = <0x3f215040 0x40>;
+			reg-shift = <2>;
+			interrupts = <BCM2835_IRQ_AUX IRQ_TYPE_LEVEL 0>;
+			clock-frequency = <DT_FREQ_M(250)>;
+			status = "disabled";
+		};
+
+		/*
+		 * The three BSC masters share BCM2835_IRQ_I2C, so enabling
+		 * more than one at a time trips a build-time IRQ_CONNECT
+		 * duplicate.
+		 */
+		i2c0: i2c@3f205000 {
+			compatible = "brcm,bcm2711-i2c";
+			reg = <0x3f205000 0x200>;
+			interrupts = <BCM2835_IRQ_I2C IRQ_TYPE_LEVEL 0>;
+			clocks = <&clk_core>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		i2c1: i2c@3f804000 {
+			compatible = "brcm,bcm2711-i2c";
+			reg = <0x3f804000 0x200>;
+			interrupts = <BCM2835_IRQ_I2C IRQ_TYPE_LEVEL 0>;
+			clocks = <&clk_core>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		i2c2: i2c@3f805000 {
+			compatible = "brcm,bcm2711-i2c";
+			reg = <0x3f805000 0x200>;
+			interrupts = <BCM2835_IRQ_I2C IRQ_TYPE_LEVEL 0>;
+			clocks = <&clk_core>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+	};
+};

--- a/dts/bindings/interrupt-controller/brcm,bcm2835-armctrl-ic.yaml
+++ b/dts/bindings/interrupt-controller/brcm,bcm2835-armctrl-ic.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  BCM2835 ARMC peripheral interrupt controller -- the "GPU IRQ" side
+  of the BCM283x family (Pi 1 / Pi 2 / Pi 3 / Pi Zero family).
+
+  Hangs off the BCM2836 ARM-local intc as a child. Aggregates 64 GPU
+  IRQs (PEND1 + PEND2 banks) plus 8 ARMC "basic" IRQs into the GPU
+  cascade line of its parent.
+
+  Zephyr exposes this controller's IRQs in a flat range offset by 32
+  (the L1 ARM-local intc occupies 0..31, only 0..9 used):
+    32..39   = basic bank   (IRQ_BASIC_PENDING bits 0..7)
+    64..95   = GPU PEND1    (PEND1 bits 0..31)
+    96..127  = GPU PEND2    (PEND2 bits 0..31)
+  (See <zephyr/dt-bindings/interrupt-controller/bcm2835-armctrl.h>
+  for the symbolic constants, and soc/brcm/bcm2710/soc_irq.c +
+  drivers/interrupt_controller/intc_bcm2835_armctrl.c for the
+  decode that maps these numbers to the bank-0 shortcut bits +
+  PEND1 / PEND2 registers.)
+
+compatible: "brcm,bcm2835-armctrl-ic"
+
+include: [interrupt-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    description: |
+      The single GPU-cascade IRQ on the parent BCM2836 ARM-local intc.
+      Present only when this controller is cascaded (BCM2836 / Pi 2+).
+      On the BCM2835 (Pi 1 / Zero / Zero W) the ARMC is the root
+      interrupt controller, wired directly to the ARM core IRQ line, so
+      it has no parent interrupt and this property is omitted.
+
+  interrupt-controller:
+    required: true
+
+  "#interrupt-cells":
+    const: 3
+    description: |
+      Cell 0: flat IRQ number from the offset-by-32 ARMC space
+              (32..39 basic / 64..95 PEND1 / 96..127 PEND2).
+      Cell 1: trigger-type flags (IRQ_TYPE_LEVEL / IRQ_TYPE_EDGE).
+      Cell 2: priority -- unused by this controller, kept as a
+              fixed third cell for parity with the parent
+              brcm,bcm2836-l1-intc binding (see its rationale).
+
+interrupt-cells:
+  - irq
+  - flags
+  - priority

--- a/dts/bindings/interrupt-controller/brcm,bcm2836-l1-intc.yaml
+++ b/dts/bindings/interrupt-controller/brcm,bcm2836-l1-intc.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  BCM2836 / BCM2710 ARM-local interrupt controller (Pi 2 / Pi 3 / Pi Zero 2 W).
+
+  Sits at physical 0x40000000, ABOVE the peripheral base. Routes per-core
+  ARM generic timer IRQs, four mailbox IRQs per core (used as IPIs), the
+  per-core PMU IRQ, and the cascaded GPU IRQ -- the latter aggregating
+  every pending source on the BCM2835 ARMC peripheral interrupt
+  controller for whichever core the firmware (or Zephyr) routes the GPU
+  IRQ to.
+
+compatible: "brcm,bcm2836-l1-intc"
+
+include: [interrupt-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupt-controller:
+    required: true
+
+  "#interrupt-cells":
+    const: 3
+    description: |
+      Cell 0: per-core source.
+        0=CNTPSIRQ (secure phys), 1=CNTPNSIRQ (nonsec phys),
+        2=CNTHPIRQ (hyp phys),    3=CNTVIRQ   (virtual),
+        4..7=MAILBOX0..3,         8=GPU IRQ,  9=PMU.
+      Cell 1: trigger-type flags (IRQ_TYPE_LEVEL / IRQ_TYPE_EDGE).
+      Cell 2: priority -- unused by this controller (no per-IRQ
+              priority register exists), kept as a fixed third cell
+              so that the canonical ARM-arch-timer driver's
+              DT_IRQ_BY_IDX(node, n, priority) macro resolves.
+
+interrupt-cells:
+  - irq
+  - flags
+  - priority

--- a/include/zephyr/drivers/interrupt_controller/intc_bcm283x.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_bcm283x.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief BCM283x interrupt-controller driver API.
+ *
+ * Two physical controllers back a single flat Zephyr IRQ space on
+ * BCM2710 (Pi 2 / Pi 3 / Pi Zero 2 W):
+ *
+ *   - IRQs 0..9    -- BCM2836 ARM-local intc (per-core timers,
+ *                     mailboxes, the GPU cascade, and the PMU).
+ *                     Driver: drivers/interrupt_controller/intc_bcm2836_l1.c.
+ *   - IRQs 32..127 -- BCM2835 ARMC peripheral aggregator (basic
+ *                     bank, GPU bank 1, GPU bank 2), cascaded under
+ *                     L1 IRQ 8.
+ *                     Driver: drivers/interrupt_controller/intc_bcm2835_armctrl.c.
+ *
+ * The SoC layer (soc/brcm/bcm2710/soc_irq.c) installs the
+ * @c z_soc_irq_* arch hooks under
+ * @kconfig{CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER} and dispatches to
+ * the two driver function families below based on which IRQ range
+ * the caller is asking about. The drivers own their own MMIO via
+ * @c device_map().
+ */
+
+#ifndef ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_BCM283X_H_
+#define ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_BCM283X_H_
+
+#include <stdint.h>
+
+/**
+ * @defgroup intc_bcm283x BCM283x interrupt controllers
+ * @ingroup io_interfaces
+ * @{
+ */
+
+/** First Zephyr IRQ number routed to the BCM2835 ARMC peripheral aggregator. */
+#define BCM283X_ARMC_IRQ_BASE   32U
+
+/** One past the last ARMC IRQ in the Zephyr IRQ space. */
+#define BCM283X_ARMC_IRQ_LIMIT  (BCM283X_ARMC_IRQ_BASE + 96U)
+
+/**
+ * @brief True when @p irq falls in the BCM2836 ARM-local intc range (0..9).
+ */
+#define BCM283X_IRQ_IS_L1(irq)    ((irq) < BCM283X_ARMC_IRQ_BASE)
+
+/**
+ * @brief True when @p irq falls in the BCM2835 ARMC peripheral range
+ *        (32..127).
+ */
+#define BCM283X_IRQ_IS_ARMC(irq)  ((irq) >= BCM283X_ARMC_IRQ_BASE && \
+				   (irq) < BCM283X_ARMC_IRQ_LIMIT)
+
+/**
+ * @brief L1 IRQ_SOURCE bit position for the GPU cascade.
+ *
+ * Also used as the Zephyr IRQ number for the cascade entry. ISRs are
+ * never registered at this index; when the L1 intc reports it,
+ * the SoC dispatcher transparently walks down into the ARMC
+ * controller to find the actual peripheral IRQ.
+ */
+#define BCM2836_L1_IRQ_GPU_BIT   8U
+
+/**
+ * @brief L1 IRQ_SOURCE bit position for the per-core PMU IRQ.
+ *
+ * Also the Zephyr IRQ number for the PMU.
+ */
+#define BCM2836_L1_IRQ_PMU_BIT   9U
+
+/**
+ * @brief Initialise the BCM2836 ARM-local interrupt controller.
+ *
+ * Maps the MMIO bank via @c device_map() and masks all locally-routed
+ * sources for core 0. Invoked by the SoC's @c z_soc_irq_init() during
+ * arch boot, before any @c SYS_INIT priority.
+ */
+void bcm2836_l1_intc_init(void);
+
+/**
+ * @brief Enable an L1 IRQ source.
+ *
+ * @param irq Zephyr IRQ number in the L1 range (0..9). IRQ 8 (GPU
+ *            cascade) is implicit and has no per-IRQ enable bit.
+ */
+void bcm2836_l1_intc_irq_enable(unsigned int irq);
+
+/**
+ * @brief Disable an L1 IRQ source.
+ *
+ * @param irq Zephyr IRQ number in the L1 range (0..9).
+ */
+void bcm2836_l1_intc_irq_disable(unsigned int irq);
+
+/**
+ * @brief Query whether an L1 IRQ source is currently enabled.
+ *
+ * @param irq Zephyr IRQ number in the L1 range.
+ *
+ * @retval 1 if enabled.
+ * @retval 0 if disabled, or for PMU (no readback path).
+ */
+int  bcm2836_l1_intc_irq_is_enabled(unsigned int irq);
+
+/**
+ * @brief Decode the firing L1 IRQ.
+ *
+ * @return The Zephyr IRQ number of the firing source, or
+ *         @kconfig{CONFIG_NUM_IRQS} if no L1 source is asserted.
+ *         When the GPU cascade bit fires the caller is expected to
+ *         walk into bcm2835_armctrl_ic_irq_get_active() next.
+ */
+unsigned int bcm2836_l1_intc_irq_get_active(void);
+
+/**
+ * @brief Initialise the BCM2835 ARMC peripheral interrupt controller.
+ *
+ * Maps the MMIO bank via @c device_map() and disables every bank-0,
+ * PEND1 and PEND2 source. Invoked by the SoC's @c z_soc_irq_init()
+ * during arch boot, before any @c SYS_INIT priority.
+ */
+void bcm2835_armctrl_ic_init(void);
+
+/**
+ * @brief Enable an ARMC peripheral IRQ source.
+ *
+ * @param irq Zephyr IRQ number in the ARMC range
+ *            (@ref BCM283X_ARMC_IRQ_BASE .. @ref BCM283X_ARMC_IRQ_LIMIT - 1).
+ *            Calls outside the range are silently ignored.
+ */
+void bcm2835_armctrl_ic_irq_enable(unsigned int irq);
+
+/**
+ * @brief Disable an ARMC peripheral IRQ source.
+ *
+ * @param irq Zephyr IRQ number in the ARMC range. Out-of-range
+ *            callers are silently ignored.
+ */
+void bcm2835_armctrl_ic_irq_disable(unsigned int irq);
+
+/**
+ * @brief Query whether an ARMC peripheral IRQ source is enabled.
+ *
+ * @param irq Zephyr IRQ number in the ARMC range.
+ *
+ * @retval 1 if enabled.
+ * @retval 0 if disabled, or @p irq is outside the ARMC range.
+ */
+int  bcm2835_armctrl_ic_irq_is_enabled(unsigned int irq);
+
+/**
+ * @brief Decode the firing ARMC peripheral IRQ.
+ *
+ * Encapsulates the bank-0 shortcut-bit decode (Quirk 1 in the
+ * BCM2835 ARM Peripherals datasheet ch. 7) and falls through to
+ * the PEND1 / PEND2 walk only when no shortcut bit is set.
+ *
+ * @return The Zephyr IRQ number of the firing peripheral, or
+ *         @kconfig{CONFIG_NUM_IRQS} if no ARMC source is asserted.
+ */
+unsigned int bcm2835_armctrl_ic_irq_get_active(void);
+
+/** @} */
+
+#endif /* ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_BCM283X_H_ */

--- a/include/zephyr/dt-bindings/interrupt-controller/bcm2835-armctrl.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/bcm2835-armctrl.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Devicetree IRQ-number bindings for the BCM2835 ARMC peripheral
+ *        interrupt controller (banks 0..2; see datasheet ch. 7).
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_BCM2835_ARMCTRL_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_BCM2835_ARMCTRL_H_
+
+/** @cond INTERNAL_HIDDEN */
+
+/*
+ * Zephyr IRQ-number layout for the BCM2710 SoC (BCM2836 L1 intc +
+ * BCM2835 ARMC peripheral intc cascaded behind it):
+ *
+ *     0..31     reserved for the L1 ARM-local intc (only 0..9 used --
+ *               see <zephyr/dt-bindings/interrupt-controller/bcm2836-l1.h>).
+ *               IRQ 8 (L1 GPU IRQ) is the cascade entry; the SoC IRQ
+ *               glue resolves it transparently inside z_soc_irq_get_active
+ *               so it is never seen by application ISRs.
+ *
+ *     32 + (bank << 5) + bit        -- ARMC peripheral IRQs:
+ *         bank 0 (basic):           32..39   (IRQ_BASIC_PENDING bits 0..7)
+ *         bank 1 (PEND1, GPU 0..31): 64..95
+ *         bank 2 (PEND2, GPU 32..63): 96..127
+ *
+ * The bank-shift encoding (offset by +32 for the L1 reservation)
+ * keeps the SoC-layer shortcut/cascade decode a straightforward
+ * arithmetic mapping of the BCM2835 ARMC pending-register layout.
+ */
+#define BCM2835_IRQ_BASE        32
+
+#define BCM2835_HWIRQ(bank, n)  (BCM2835_IRQ_BASE + ((bank) << 5) + (n))
+
+#define BCM2835_BASIC_IRQ(n)    BCM2835_HWIRQ(0, n)   /* 32..39 */
+#define BCM2835_BANK1(n)        BCM2835_HWIRQ(1, n)   /* 64..95 */
+#define BCM2835_BANK2(n)        BCM2835_HWIRQ(2, n)   /* 96..127 */
+
+/* basic bank shortcuts */
+#define BCM2835_IRQ_ARM_TIMER       BCM2835_BASIC_IRQ(0)
+#define BCM2835_IRQ_ARM_MAILBOX     BCM2835_BASIC_IRQ(1)
+#define BCM2835_IRQ_ARM_DOORBELL0   BCM2835_BASIC_IRQ(2)
+#define BCM2835_IRQ_ARM_DOORBELL1   BCM2835_BASIC_IRQ(3)
+#define BCM2835_IRQ_GPU0_HALT       BCM2835_BASIC_IRQ(4)
+#define BCM2835_IRQ_GPU1_HALT       BCM2835_BASIC_IRQ(5)
+#define BCM2835_IRQ_ILLEGAL_TYPE0   BCM2835_BASIC_IRQ(6)
+#define BCM2835_IRQ_ILLEGAL_TYPE1   BCM2835_BASIC_IRQ(7)
+
+/* GPU PEND1 (peripheral lower bank) */
+#define BCM2835_IRQ_TIMER0          BCM2835_BANK1(0)
+#define BCM2835_IRQ_TIMER1          BCM2835_BANK1(1)
+#define BCM2835_IRQ_TIMER2          BCM2835_BANK1(2)
+#define BCM2835_IRQ_TIMER3          BCM2835_BANK1(3)
+/* USB OTG (Synopsys DWC2). GPU IRQ 9 per the BCM2835 ARM Peripherals
+ * datasheet ch. 7 "ARM peripherals interrupts table".
+ */
+#define BCM2835_IRQ_USB             BCM2835_BANK1(9)  /* DWC2 USB OTG */
+/* DMA channel IRQs: channels 0..10 have dedicated lines at PEND1 bits
+ * 16..26; channels 11..14 share bit 27. (PEND1 bit 28, the "any DMA
+ * channel" line, is not exposed.)
+ */
+#define BCM2835_IRQ_DMA(n)          BCM2835_BANK1(16 + (n)) /* n = 0..10 */
+#define BCM2835_IRQ_DMA_SHARED      BCM2835_BANK1(27)       /* channels 11..14 */
+#define BCM2835_IRQ_AUX             BCM2835_BANK1(29) /* mini-UART, SPI1, SPI2 */
+
+/* GPU PEND2 (peripheral upper bank) */
+#define BCM2835_IRQ_I2C_SPI_SLV     BCM2835_BANK2(11)
+#define BCM2835_IRQ_GPIO0           BCM2835_BANK2(17)
+#define BCM2835_IRQ_GPIO1           BCM2835_BANK2(18)
+#define BCM2835_IRQ_GPIO2           BCM2835_BANK2(19)
+#define BCM2835_IRQ_GPIO3           BCM2835_BANK2(20)
+#define BCM2835_IRQ_I2C             BCM2835_BANK2(21)
+#define BCM2835_IRQ_SPI             BCM2835_BANK2(22)
+#define BCM2835_IRQ_PCM             BCM2835_BANK2(23)
+#define BCM2835_IRQ_SDHOST          BCM2835_BANK2(24) /* Legacy SDHost (microSD slot) */
+#define BCM2835_IRQ_UART            BCM2835_BANK2(25) /* PL011 UART0 */
+#define BCM2835_IRQ_ARASAN_SDIO     BCM2835_BANK2(30) /* Arasan SDHCI / EMMC */
+
+#ifndef IRQ_TYPE_LEVEL
+#define IRQ_TYPE_LEVEL  2
+#endif
+#ifndef IRQ_TYPE_EDGE
+#define IRQ_TYPE_EDGE   4
+#endif
+
+/** @endcond */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_BCM2835_ARMCTRL_H_ */

--- a/include/zephyr/dt-bindings/interrupt-controller/bcm2836-l1.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/bcm2836-l1.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Devicetree IRQ-number bindings for the BCM2836 ARM-local
+ *        interrupt controller (per-core timers, mailboxes, GPU cascade
+ *        and PMU sources).
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_BCM2836_L1_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_BCM2836_L1_H_
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Per-core sources on the BCM2836 ARM-local interrupt controller. */
+#define BCM2836_LOCAL_IRQ_CNTPSIRQ   0  /* secure physical timer */
+#define BCM2836_LOCAL_IRQ_CNTPNSIRQ  1  /* non-secure physical timer */
+#define BCM2836_LOCAL_IRQ_CNTHPIRQ   2  /* hypervisor physical timer */
+#define BCM2836_LOCAL_IRQ_CNTVIRQ    3  /* virtual timer */
+#define BCM2836_LOCAL_IRQ_MAILBOX0   4
+#define BCM2836_LOCAL_IRQ_MAILBOX1   5
+#define BCM2836_LOCAL_IRQ_MAILBOX2   6
+#define BCM2836_LOCAL_IRQ_MAILBOX3   7
+#define BCM2836_LOCAL_IRQ_GPU        8  /* cascade from BCM2835 ARMC */
+#define BCM2836_LOCAL_IRQ_PMU        9
+
+/* IRQ-flag aliases mirroring arm-gic.h, so dts entries read alike. */
+#ifndef IRQ_TYPE_LEVEL
+#define IRQ_TYPE_LEVEL  2  /* BIT(1) */
+#endif
+#ifndef IRQ_TYPE_EDGE
+#define IRQ_TYPE_EDGE   4  /* BIT(2) */
+#endif
+
+/** @endcond */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_BCM2836_L1_H_ */

--- a/soc/brcm/bcm2710/CMakeLists.txt
+++ b/soc/brcm/bcm2710/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_include_directories(. ../common)
+
+zephyr_sources(soc_irq.c)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/brcm/bcm2710/Kconfig
+++ b/soc/brcm/bcm2710/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_BCM2710
+	select ARM64
+	select CPU_CORTEX_A53
+	select ARM_ARCH_TIMER if SYS_CLOCK_EXISTS
+	select ARM_CUSTOM_INTERRUPT_CONTROLLER

--- a/soc/brcm/bcm2710/Kconfig.defconfig
+++ b/soc/brcm/bcm2710/Kconfig.defconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_BCM2710
+
+config NUM_IRQS
+	# Flat IRQ space for the BCM283x interrupt-controller pair: 0..9
+	# ARM-local intc, 32..127 ARMC peripheral banks. See
+	# <zephyr/dt-bindings/interrupt-controller/bcm2835-armctrl.h>.
+	default 128
+
+endif

--- a/soc/brcm/bcm2710/Kconfig.soc
+++ b/soc/brcm/bcm2710/Kconfig.soc
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_BCM2710
+	bool
+
+config SOC
+	default "bcm2710" if SOC_BCM2710

--- a/soc/brcm/bcm2710/soc.h
+++ b/soc/brcm/bcm2710/soc.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SOC__H_
+#define _SOC__H_
+
+#ifndef _ASMLANGUAGE
+
+/*
+ * The following definitions are required for the inclusion of the CMSIS
+ * Common Peripheral Access Layer for aarch64 Cortex-A CPUs:
+ */
+
+#define __CORTEX_A 53U
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* _SOC__H_ */

--- a/soc/brcm/bcm2710/soc.yml
+++ b/soc/brcm/bcm2710/soc.yml
@@ -1,0 +1,4 @@
+series:
+- name: bcm2710
+  socs:
+  - name: bcm2710

--- a/soc/brcm/bcm2710/soc_irq.c
+++ b/soc/brcm/bcm2710/soc_irq.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * BCM2710 SoC IRQ glue. With CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER
+ * selected the arm64 ISR wrapper calls the z_soc_irq_* hooks below
+ * instead of a GIC driver. Each hook delegates to the BCM283x intc
+ * driver (drivers/interrupt_controller/) responsible for the IRQ
+ * range:
+ *
+ *     0..9     BCM2836 ARM-local intc (per-core timers, mailboxes,
+ *              the GPU cascade hidden at IRQ 8, and the PMU)
+ *     32..127  BCM2835 ARMC peripheral aggregator (basic bank +
+ *              GPU bank 1/2), cascaded under L1 IRQ 8
+ *
+ * IRQ 8 is never registered with an ISR. When it fires, the cascade
+ * is invisible to the rest of Zephyr: z_soc_irq_get_active sees the
+ * GPU bit on the L1 controller and then walks the ARMC pending
+ * registers to return the actual 32..127 peripheral IRQ.
+ *
+ * Single-core only (CORE_ID 0). SMP would extend this to per-core
+ * mailbox IPIs and dynamic GPU-IRQ routing.
+ *
+ * The intc drivers map their own MMIO via device_map() inside the
+ * init helpers called below. Both run before any SYS_INIT priority
+ * (z_soc_irq_init is invoked from z_arm64_interrupt_init in
+ * z_prep_c, before z_cstart) -- the MMU is up, but driver model
+ * initialisation has not yet happened, so the init helpers are
+ * called directly rather than registered as SYS_INIT entries.
+ */
+
+#include <zephyr/arch/cpu.h>
+#include <zephyr/drivers/interrupt_controller/intc_bcm283x.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
+
+/*
+ * Sources masked by z_soc_irq_get_active() for the duration of their ISR
+ * (see the comment there). The record lets z_soc_irq_eoi() tell its own
+ * mask apart from a disable the ISR performed itself, so an ISR that
+ * disables its source to defer work to a thread stays disabled.
+ *
+ * A bitmap rather than a single slot because the arm64 wrapper unmasks
+ * IRQs globally around the ISR, so brackets nest.
+ */
+static ATOMIC_DEFINE(bracketed_irqs, CONFIG_NUM_IRQS);
+
+void z_soc_irq_init(void)
+{
+	bcm2836_l1_intc_init();
+	bcm2835_armctrl_ic_init();
+}
+
+void z_soc_irq_enable(unsigned int irq)
+{
+	if (BCM283X_IRQ_IS_L1(irq)) {
+		bcm2836_l1_intc_irq_enable(irq);
+	} else if (BCM283X_IRQ_IS_ARMC(irq)) {
+		bcm2835_armctrl_ic_irq_enable(irq);
+	}
+}
+
+void z_soc_irq_disable(unsigned int irq)
+{
+	if (irq < CONFIG_NUM_IRQS) {
+		/* Whoever disables the source now owns its masked state. */
+		atomic_clear_bit(bracketed_irqs, irq);
+	}
+
+	if (BCM283X_IRQ_IS_L1(irq)) {
+		bcm2836_l1_intc_irq_disable(irq);
+	} else if (BCM283X_IRQ_IS_ARMC(irq)) {
+		bcm2835_armctrl_ic_irq_disable(irq);
+	}
+}
+
+int z_soc_irq_is_enabled(unsigned int irq)
+{
+	if (BCM283X_IRQ_IS_L1(irq)) {
+		return bcm2836_l1_intc_irq_is_enabled(irq);
+	}
+	if (BCM283X_IRQ_IS_ARMC(irq)) {
+		return bcm2835_armctrl_ic_irq_is_enabled(irq);
+	}
+	return 0;
+}
+
+void z_soc_irq_priority_set(unsigned int irq, unsigned int prio,
+			    unsigned int flags)
+{
+	/* No per-IRQ priority register on either intc -- intentional no-op. */
+	ARG_UNUSED(irq);
+	ARG_UNUSED(prio);
+	ARG_UNUSED(flags);
+}
+
+unsigned int z_soc_irq_get_active(void)
+{
+	unsigned int irq = bcm2836_l1_intc_irq_get_active();
+
+	if (irq == BCM2836_L1_IRQ_GPU_BIT) {
+		/* GPU cascade: walk down into the ARMC. ISRs are never
+		 * registered at index 8, so the cascade is invisible to
+		 * the rest of Zephyr.
+		 */
+		irq = bcm2835_armctrl_ic_irq_get_active();
+	}
+
+	/*
+	 * The arm64 isr_wrapper unmasks IRQs globally (daifclr) around
+	 * the ISR call to support nested handlers. With a GIC that's
+	 * fine -- ack-on-read prevents the same source from re-entering
+	 * the handler. The BCM2835/2836 intc pair has no such ack: a
+	 * level-triggered source stays asserted until the peripheral's
+	 * own state machine clears it, so unmasking globally would
+	 * re-fire the same IRQ before its ISR has had a chance to run.
+	 *
+	 * Workaround: mask the source here, let the ISR run, then
+	 * re-enable in z_soc_irq_eoi. Brackets the ISR with a
+	 * per-source mask the way GIC's running-priority would.
+	 */
+	if (irq < CONFIG_NUM_IRQS) {
+		z_soc_irq_disable(irq);
+		atomic_set_bit(bracketed_irqs, irq);
+	}
+	return irq;
+}
+
+void z_soc_irq_eoi(unsigned int irq)
+{
+	/*
+	 * Re-enable the source masked by z_soc_irq_get_active. By now
+	 * either the ISR cleared the underlying peripheral and the
+	 * source is no longer asserted (normal case), or we're
+	 * returning from a spurious dispatch and there's nothing to
+	 * re-fire. If the ISR disabled the source itself the record is
+	 * gone and the source is left masked, as the ISR intended.
+	 */
+	if (irq < CONFIG_NUM_IRQS &&
+	    atomic_test_and_clear_bit(bracketed_irqs, irq)) {
+		z_soc_irq_enable(irq);
+	}
+}

--- a/soc/brcm/bcm2711/CMakeLists.txt
+++ b/soc/brcm/bcm2711/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_include_directories(.)
+zephyr_include_directories(. ../common)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/brcm/common/pinctrl_soc.h
+++ b/soc/brcm/common/pinctrl_soc.h
@@ -1,11 +1,18 @@
 /*
  * Copyright (c) 2025 Muhammad Waleed Badar
+ * Copyright (c) 2026 Jonathan Elliot Peace <jep@alphabetiq.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_SOC_ARM64_BCM2711_PINCTRL_SOC_H_
-#define ZEPHYR_SOC_ARM64_BCM2711_PINCTRL_SOC_H_
+/*
+ * The BCM283x GPIO/pinctrl block is register-compatible across BCM2710 and
+ * BCM2711, so both SoCs share this definition and the bcm2711-pinctrl
+ * dt-bindings.
+ */
+
+#ifndef ZEPHYR_SOC_ARM64_BRCM_COMMON_PINCTRL_SOC_H_
+#define ZEPHYR_SOC_ARM64_BRCM_COMMON_PINCTRL_SOC_H_
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
@@ -55,4 +62,4 @@ typedef struct bcm2711_pinctrl_soc_pin {
 	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop), DT_FOREACH_PROP_ELEM, pinmux,           \
 				Z_PINCTRL_STATE_PIN_INIT)}
 
-#endif /* ZEPHYR_SOC_ARM64_BCM2711_PINCTRL_SOC_H_ */
+#endif /* ZEPHYR_SOC_ARM64_BRCM_COMMON_PINCTRL_SOC_H_ */

--- a/tests/arch/common/interrupt/tests.yaml
+++ b/tests/arch/common/interrupt/tests.yaml
@@ -4,7 +4,11 @@ common:
     - interrupt
 tests:
   arch.interrupt:
-    platform_exclude: qemu_cortex_m0
+    platform_exclude:
+      - qemu_cortex_m0
+      # No trigger_irq implementation for the BCM2836 L1 + BCM2835 ARMC
+      # interrupt controller pair in interrupt_util.h yet.
+      - rpi_zero_2w
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
   arch.interrupt.qemu_cortex_m0:
     platform_allow: qemu_cortex_m0
@@ -13,7 +17,11 @@ tests:
       - CONFIG_QEMU_ICOUNT=y
   arch.interrupt.minimallibc:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_MINIMAL_LIBC_SUPPORTED
-    platform_exclude: qemu_cortex_m0
+    platform_exclude:
+      - qemu_cortex_m0
+      # No trigger_irq implementation for the BCM2836 L1 + BCM2835 ARMC
+      # interrupt controller pair in interrupt_util.h yet.
+      - rpi_zero_2w
     tags:
       - libc
     extra_configs:
@@ -44,6 +52,9 @@ tests:
       # In S-mode only SSIP (IRQ 1) can be triggered from software; the
       # shared interrupt test requires two independent triggerable IRQ lines.
       - qemu_riscv64/qemu_virt_riscv64/smode
+      # No trigger_irq implementation for the BCM2836 L1 + BCM2835 ARMC
+      # interrupt controller pair in interrupt_util.h yet.
+      - rpi_zero_2w
     arch_exclude:
       # test needs 2 working interrupt lines
       - xtensa
@@ -72,6 +83,9 @@ tests:
       # On it8xxx2_evb, current trigger_irq implementation of RISC-V architecture
       # does not trigger interrupts
       - it8xxx2_evb
+      # No trigger_irq implementation for the BCM2836 L1 + BCM2835 ARMC
+      # interrupt controller pair in interrupt_util.h yet.
+      - rpi_zero_2w
     arch_exclude:
       # test needs 2 working interrupt lines
       - xtensa

--- a/tests/kernel/threads/dynamic_thread_stack/tests.yaml
+++ b/tests/kernel/threads/dynamic_thread_stack/tests.yaml
@@ -25,6 +25,10 @@ tests:
       - CONFIG_USERSPACE=n
   kernel.threads.dynamic_thread.stack.no_pool.no_alloc.user:
     tags: userspace
+    # Userspace is not yet enabled on rpi_zero_2w (BCM2710 / cortex-a53);
+    # forcing CONFIG_USERSPACE=y on a board without USERSPACE_SUPPORTED
+    # trips a build-time _Bool[0] assertion.
+    platform_exclude: rpi_zero_2w
     extra_configs:
       # 001
       - CONFIG_DYNAMIC_THREAD_POOL_SIZE=0
@@ -39,6 +43,8 @@ tests:
       - CONFIG_USERSPACE=n
   kernel.threads.dynamic_thread.stack.no_pool.alloc.user:
     tags: userspace
+    # See kernel.threads.dynamic_thread.stack.no_pool.no_alloc.user above.
+    platform_exclude: rpi_zero_2w
     extra_configs:
       # 011
       - CONFIG_DYNAMIC_THREAD_POOL_SIZE=0
@@ -53,6 +59,8 @@ tests:
       - CONFIG_USERSPACE=n
   kernel.threads.dynamic_thread.stack.pool.no_alloc.user:
     tags: userspace
+    # See kernel.threads.dynamic_thread.stack.no_pool.no_alloc.user above.
+    platform_exclude: rpi_zero_2w
     extra_configs:
       # 101
       - CONFIG_DYNAMIC_THREAD_POOL_SIZE=2
@@ -67,6 +75,8 @@ tests:
       - CONFIG_USERSPACE=n
   kernel.threads.dynamic_thread.stack.pool.alloc.user:
     tags: userspace
+    # See kernel.threads.dynamic_thread.stack.no_pool.no_alloc.user above.
+    platform_exclude: rpi_zero_2w
     extra_configs:
       # 111
       - CONFIG_DYNAMIC_THREAD_PREFER_ALLOC=y


### PR DESCRIPTION
Add board support for the Raspberry Pi Zero 2 W (Broadcom BCM2710A1 / Cortex-A53 / AArch64), introducing the new soc/brcm/bcm2710 SoC tree, a native BCM283x interrupt-controller pair (BCM2836 ARM-local + BCM2835 ARMC peripheral aggregator), and base device tree.

The BCM2710 differs from upstream's BCM2711 (Pi 4) in MMIO base (0x3f000000 vs 0xfe000000), no GIC, and Cortex-A53 vs A72. The two intc controllers are driven via the arm64 custom-interrupt-controller hooks (z_soc_irq_*) in soc_irq.c, presenting both as one flat IRQ space.

Console is the mini-UART (uart1) on GPIO 14/15 at 115200 baud. The board boots single-core; hello_world and shell_module both run on hardware. SMP, USB, SDHCI, and Wi-Fi are wired up in follow-on PRs in this series.

The dts/bindings/interrupt-controller/brcm,bcm2835-armctrl-ic.yaml binding is contributed with the `interrupts` property optional and a dual-mode description. On BCM2710 / BCM2836 (Pi 2 / Pi 3 / Pi Zero 2 W)
the ARMC is cascaded off the ARM-local intc and has a parent IRQ; on BCM2835 (Pi Zero W) it's the root controller wired directly to the ARM core IRQ line with no parent. The same binding serves both topologies.

---

Part of the rpi_zero_2w board enablement series (RFC #109880). Related parallel work: #110379 (Pi Zero W / BCM2835 / ARMv6).