### PR TITLE
drivers: can: bosch: m_can: always use RX FIFO0

### DIFF
--- a/boards/shields/mikroe_can_fd_6_click/mikroe_can_fd_6_click.overlay
+++ b/boards/shields/mikroe_can_fd_6_click/mikroe_can_fd_6_click.overlay
@@ -27,7 +27,7 @@
 		device-wake-gpios = <&mikrobus_header 6 GPIO_ACTIVE_HIGH>;
 		reset-gpios = <&mikrobus_header 1 GPIO_ACTIVE_HIGH>;
 		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
-		bosch,mram-cfg = <0x0 15 15 7 7 0 10 10>;
+		bosch,mram-cfg = <0x0 15 15 14 0 0 10 10>;
 		ti,nwkrq-voltage-vio;
 		status = "okay";
 

--- a/boards/shields/tcan4550evm/tcan4550evm.overlay
+++ b/boards/shields/tcan4550evm/tcan4550evm.overlay
@@ -29,7 +29,7 @@
 		device-wake-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
 		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_HIGH>;
 		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;
-		bosch,mram-cfg = <0x0 15 15 7 7 0 10 10>;
+		bosch,mram-cfg = <0x0 15 15 14 0 0 10 10>;
 		ti,nwkrq-voltage-vio;
 		status = "okay";
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -129,6 +129,10 @@ Controller Area Network (CAN)
   controller driver backends where converted to library-specific includes. Out-of-tree drivers based
   on these backends will need to update their include directives accordingly.
 
+* The Bosch M_CAN driver now solely uses RX FIFO0 for processing received CAN frames, ensuring these
+  are processed in the order received on the bus. Out-of-tree users may want to update any
+  ``bosch,mram-cfg`` devicetree property overrides to allocate all FIFO elements to RX FIFO0.
+
 Devicetree
 ==========
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1120,8 +1120,8 @@ int can_mcan_add_rx_filter_std(const struct device *dev, can_rx_callback_t callb
 		return -ENOSPC;
 	}
 
-	/* TODO proper fifo balancing */
-	filter_element.sfec = filter_id & 0x01 ? CAN_MCAN_XFEC_FIFO1 : CAN_MCAN_XFEC_FIFO0;
+	/* Always use FIFO0 to ensure frames are delivered to callbacks in the order received */
+	filter_element.sfec = CAN_MCAN_XFEC_FIFO0;
 
 	err = can_mcan_write_mram(dev, config->mram_offsets[CAN_MCAN_MRAM_CFG_STD_FILTER] +
 				  filter_id * sizeof(struct can_mcan_std_filter),
@@ -1171,8 +1171,8 @@ static int can_mcan_add_rx_filter_ext(const struct device *dev, can_rx_callback_
 		return -ENOSPC;
 	}
 
-	/* TODO proper fifo balancing */
-	filter_element.efec = filter_id & 0x01 ? CAN_MCAN_XFEC_FIFO1 : CAN_MCAN_XFEC_FIFO0;
+	/* Always use FIFO0 to ensure frames are delivered to callbacks in the order received */
+	filter_element.efec = CAN_MCAN_XFEC_FIFO0;
 
 	err = can_mcan_write_mram(dev, config->mram_offsets[CAN_MCAN_MRAM_CFG_EXT_FILTER] +
 				  filter_id * sizeof(struct can_mcan_ext_filter),

--- a/dts/arm/atmel/samc21.dtsi
+++ b/dts/arm/atmel/samc21.dtsi
@@ -65,7 +65,7 @@
 			atmel,assigned-clock-names = "GCLK";
 			status = "disabled";
 
-			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 1 1>;
 			divider = <1>;
 		};
 
@@ -80,7 +80,7 @@
 			atmel,assigned-clock-names = "GCLK";
 			status = "disabled";
 
-			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 1 1>;
 			divider = <1>;
 		};
 

--- a/dts/arm/atmel/samx7x.dtsi
+++ b/dts/arm/atmel/samx7x.dtsi
@@ -188,7 +188,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 35>;
 			divider = <6>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 1 1>;
 			status = "disabled";
 		};
 
@@ -200,7 +200,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 37>;
 			divider = <6>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 1 1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
@@ -141,7 +141,7 @@
 				reg-names = "m_can", "message_ram";
 				clk-dst = <0x10e>;
 				status = "disabled";
-				bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+				bosch,mram-cfg = <0x0 15 15 16 0 0 15 15>;
 				interrupts = <64 4>, <65 4>;
 				interrupt-names = "int0", "int1";
 			};

--- a/dts/arm/infineon/cat1b/psc3/psc3.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3.dtsi
@@ -254,7 +254,7 @@
 				reg-names = "m_can", "message_ram";
 				clk-dst = <0x405>;
 				status = "disabled";
-				bosch,mram-cfg = <0x0 15 15 8 8 0 8 8>;
+				bosch,mram-cfg = <0x0 15 15 16 0 0 8 8>;
 				interrupts = <99 4>, <100 4>;
 				interrupt-names = "int0", "int1";
 			};
@@ -265,7 +265,7 @@
 				reg-names = "m_can", "message_ram";
 				clk-dst = <0x406>;
 				status = "disabled";
-				bosch,mram-cfg = <0x800 15 15 8 8 0 8 8>;
+				bosch,mram-cfg = <0x800 15 15 16 0 0 8 8>;
 				interrupts = <101 4>, <102 4>;
 				interrupt-names = "int0", "int1";
 			};

--- a/dts/arm/infineon/cat1b/psc3/psc3_s.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3_s.dtsi
@@ -184,7 +184,7 @@
 				reg-names = "m_can", "message_ram";
 				clk-dst = <0x405>;
 				status = "disabled";
-				bosch,mram-cfg = <0x0 15 15 8 8 0 8 8>;
+				bosch,mram-cfg = <0x0 15 15 16 0 0 8 8>;
 				interrupts = <99 4>, <100 4>;
 				interrupt-names = "int0", "int1";
 			};
@@ -195,7 +195,7 @@
 				reg-names = "m_can", "message_ram";
 				clk-dst = <0x406>;
 				status = "disabled";
-				bosch,mram-cfg = <0x800 15 15 8 8 0 8 8>;
+				bosch,mram-cfg = <0x800 15 15 16 0 0 8 8>;
 				interrupts = <101 4>, <102 4>;
 				interrupt-names = "int0", "int1";
 			};

--- a/dts/arm/infineon/edge/pse84/pse84.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.dtsi
@@ -559,7 +559,7 @@
 				reg-names = "m_can", "message_ram";
 				clk-dst = <0x10b>;
 				status = "disabled";
-				bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+				bosch,mram-cfg = <0x0 15 15 16 0 0 15 15>;
 				interrupts = <106 4>, <107 4>;
 				interrupt-names = "int0", "int1";
 			};
@@ -570,7 +570,7 @@
 				reg-names = "m_can", "message_ram";
 				clk-dst = <0x10c>;
 				status = "disabled";
-				bosch,mram-cfg = <0x1000 15 15 8 8 0 15 15>;
+				bosch,mram-cfg = <0x1000 15 15 16 0 0 15 15>;
 				interrupts = <108 4>, <109 4>;
 				interrupt-names = "int0", "int1";
 			};

--- a/dts/arm/infineon/edge/pse84/pse84_s.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84_s.dtsi
@@ -572,7 +572,7 @@
 				reg-names = "m_can", "message_ram";
 				clk-dst = <0x10b>;
 				status = "disabled";
-				bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+				bosch,mram-cfg = <0x0 15 15 16 0 0 15 15>;
 				interrupts = <106 4>, <107 4>;
 				interrupt-names = "int0", "int1";
 			};
@@ -583,7 +583,7 @@
 				reg-names = "m_can", "message_ram";
 				clk-dst = <0x10c>;
 				status = "disabled";
-				bosch,mram-cfg = <0x1000 15 15 8 8 0 15 15>;
+				bosch,mram-cfg = <0x1000 15 15 16 0 0 15 15>;
 				interrupts = <108 4>, <109 4>;
 				interrupt-names = "int0", "int1";
 			};

--- a/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
+++ b/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
@@ -93,7 +93,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_GCK 58>;
 			clock-names = "gck";
-			bosch,mram-cfg = <0x3400 15 15 8 8 0 15 15>;
+			bosch,mram-cfg = <0x3400 15 15 16 0 0 15 15>;
 			status = "disabled";
 		};
 
@@ -107,7 +107,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_GCK 59>;
 			clock-names = "gck";
-			bosch,mram-cfg = <0x7800 15 15 8 8 0 15 15>;
+			bosch,mram-cfg = <0x7800 15 15 16 0 0 15 15>;
 			status = "disabled";
 		};
 
@@ -121,7 +121,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_GCK 60>;
 			clock-names = "gck";
-			bosch,mram-cfg = <0xbc00 15 15 8 8 0 15 15>;
+			bosch,mram-cfg = <0xbc00 15 15 16 0 0 15 15>;
 			status = "disabled";
 		};
 
@@ -135,7 +135,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_GCK 61>;
 			clock-names = "gck";
-			bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+			bosch,mram-cfg = <0x0 15 15 16 0 0 15 15>;
 			status = "disabled";
 		};
 
@@ -149,7 +149,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_GCK 62>;
 			clock-names = "gck";
-			bosch,mram-cfg = <0x4400 15 15 8 8 0 15 15>;
+			bosch,mram-cfg = <0x4400 15 15 16 0 0 15 15>;
 			status = "disabled";
 		};
 

--- a/dts/arm/microchip/sam/sama7/sama7g5/sama7g5.dtsi
+++ b/dts/arm/microchip/sam/sama7/sama7g5/sama7g5.dtsi
@@ -170,7 +170,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_GCK 61>;
 			clock-names = "gck";
-			bosch,mram-cfg = <0x3400 15 15 8 8 0 15 15>;
+			bosch,mram-cfg = <0x3400 15 15 16 0 0 15 15>;
 			status = "disabled";
 		};
 
@@ -184,7 +184,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_GCK 62>;
 			clock-names = "gck";
-			bosch,mram-cfg = <0x7800 15 15 8 8 0 15 15>;
+			bosch,mram-cfg = <0x7800 15 15 16 0 0 15 15>;
 			status = "disabled";
 		};
 
@@ -198,7 +198,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_GCK 63>;
 			clock-names = "gck";
-			bosch,mram-cfg = <0xbc00 15 15 8 8 0 15 15>;
+			bosch,mram-cfg = <0xbc00 15 15 16 0 0 15 15>;
 			status = "disabled";
 		};
 
@@ -212,7 +212,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_GCK 64>;
 			clock-names = "gck";
-			bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+			bosch,mram-cfg = <0x0 15 15 16 0 0 15 15>;
 			status = "disabled";
 		};
 
@@ -226,7 +226,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_GCK 65>;
 			clock-names = "gck";
-			bosch,mram-cfg = <0x4400 15 15 8 8 0 15 15>;
+			bosch,mram-cfg = <0x4400 15 15 16 0 0 15 15>;
 			status = "disabled";
 		};
 
@@ -240,7 +240,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_GCK 66>;
 			clock-names = "gck";
-			bosch,mram-cfg = <0x8800 15 15 8 8 0 15 15>;
+			bosch,mram-cfg = <0x8800 15 15 16 0 0 15 15>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nuvoton/m2l31x.dtsi
+++ b/dts/arm/nuvoton/m2l31x.dtsi
@@ -371,7 +371,7 @@
 			clocks = <&pcc NUMAKER_CANFD0_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD0SEL_HCLK
 				  NUMAKER_CLK_CLKDIV5_CANFD0(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 
@@ -385,7 +385,7 @@
 			clocks = <&pcc NUMAKER_CANFD1_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD1SEL_HCLK
 				  NUMAKER_CLK_CLKDIV5_CANFD1(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nuvoton/m333x.dtsi
+++ b/dts/arm/nuvoton/m333x.dtsi
@@ -223,7 +223,7 @@
 			clocks = <&pcc NUMAKER_CANFD0_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD0SEL_HCLK
 				  NUMAKER_CLK_CLKDIV1_CANFD0(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 
@@ -237,7 +237,7 @@
 			clocks = <&pcc NUMAKER_CANFD1_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD1SEL_HCLK
 				  NUMAKER_CLK_CLKDIV1_CANFD1(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nuvoton/m335x.dtsi
+++ b/dts/arm/nuvoton/m335x.dtsi
@@ -272,7 +272,7 @@
 			clocks = <&pcc NUMAKER_CANFD0_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD0SEL_HCLK
 				  NUMAKER_CLK_CLKDIV1_CANFD0(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 
@@ -286,7 +286,7 @@
 			clocks = <&pcc NUMAKER_CANFD1_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD1SEL_HCLK
 				  NUMAKER_CLK_CLKDIV1_CANFD1(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nuvoton/m46x.dtsi
+++ b/dts/arm/nuvoton/m46x.dtsi
@@ -451,7 +451,7 @@
 			clocks = <&pcc NUMAKER_CANFD0_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD0SEL_HCLK
 				  NUMAKER_CLK_CLKDIV5_CANFD0(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 
@@ -465,7 +465,7 @@
 			clocks = <&pcc NUMAKER_CANFD1_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD1SEL_HCLK
 				  NUMAKER_CLK_CLKDIV5_CANFD1(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 
@@ -479,7 +479,7 @@
 			clocks = <&pcc NUMAKER_CANFD2_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD2SEL_HCLK
 				  NUMAKER_CLK_CLKDIV5_CANFD2(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 
@@ -493,7 +493,7 @@
 			clocks = <&pcc NUMAKER_CANFD3_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD3SEL_HCLK
 				  NUMAKER_CLK_CLKDIV5_CANFD3(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nuvoton/m55m1x.dtsi
+++ b/dts/arm/nuvoton/m55m1x.dtsi
@@ -349,7 +349,7 @@
 			clocks = <&pcc NUMAKER_CANFD0_MODULE
 				  NUMAKER_CLK_CANFDSEL_CANFD0SEL_HCLK0
 				  NUMAKER_CLK_CANFDDIV_CANFD0DIV(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 
@@ -363,7 +363,7 @@
 			clocks = <&pcc NUMAKER_CANFD1_MODULE
 				  NUMAKER_CLK_CANFDSEL_CANFD1SEL_HCLK0
 				  NUMAKER_CLK_CANFDDIV_CANFD1DIV(1)>;
-			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			bosch,mram-cfg = <0x0 12 10 6 0 3 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/lpc/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S0x_common.dtsi
@@ -272,7 +272,7 @@
 		interrupt-names = "int0", "int1";
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 7)>;
-		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+		bosch,mram-cfg = <0x0 15 15 16 0 0 15 15>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/lpc/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S1x_common.dtsi
@@ -336,7 +336,7 @@
 		interrupt-names = "int0", "int1";
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 7)>;
-		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+		bosch,mram-cfg = <0x0 15 15 16 0 0 15 15>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/lpc/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S3x_common.dtsi
@@ -422,7 +422,7 @@
 		interrupt-names = "int0", "int1";
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 7)>;
-		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+		bosch,mram-cfg = <0x0 15 15 16 0 0 15 15>;
 		status = "disabled";
 	};
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -617,7 +617,7 @@
 			clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 			interrupts = <19 0>, <21 0>, <63 0>;
 			interrupt-names = "int0", "int1", "calib";
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 
@@ -628,7 +628,7 @@
 			clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 			interrupts = <20 0>, <22 0>, <63 0>;
 			interrupt-names = "int0", "int1", "calib";
-			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x350 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -124,7 +124,7 @@
 			clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 			interrupts = <159 0>, <160 0>, <63 0>;
 			interrupt-names = "int0", "int1", "calib";
-			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x6a0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/mp2/stm32mp251_m33.dtsi
+++ b/dts/arm/st/mp2/stm32mp251_m33.dtsi
@@ -38,7 +38,7 @@
 			clocks = <&rcc STM32_CLOCK(FDCAN, STM32_CLK)>;
 			interrupts = <93 0>, <96 0>;
 			interrupt-names = "int0", "int1";
-			bosch,mram-cfg = <0x1aa0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x1aa0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/mp2/stm32mp2_m33.dtsi
+++ b/dts/arm/st/mp2/stm32mp2_m33.dtsi
@@ -153,7 +153,7 @@
 			reg = <0x402d0000 0x400>, <0x40310000 0xd50>;
 			reg-names = "m_can", "message_ram";
 			clocks = <&rcc STM32_CLOCK(FDCAN, STM32_CLK)>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 
@@ -162,7 +162,7 @@
 			reg = <0x402e0000 0x400>, <0x40310000 0x1aa0>;
 			reg-names = "m_can", "message_ram";
 			clocks = <&rcc STM32_CLOCK(FDCAN, STM32_CLK)>;
-			bosch,mram-cfg = <0xd50 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0xd50 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -531,7 +531,7 @@
 				clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 				interrupts = <180 0>, <181 0>, <186 0>;
 				interrupt-names = "int0", "int1", "calib";
-				bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+				bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 				status = "disabled";
 			};
 
@@ -542,7 +542,7 @@
 				clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 				interrupts = <182 0>, <183 0>;
 				interrupt-names = "int0", "int1";
-				bosch,mram-cfg = <0xd54 28 8 3 3 0 3 3>;
+				bosch,mram-cfg = <0xd54 28 8 6 0 0 3 3>;
 				status = "disabled";
 			};
 
@@ -553,7 +553,7 @@
 				clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 				interrupts = <184 0>, <185 0>;
 				interrupt-names = "int0", "int1";
-				bosch,mram-cfg = <0x1aa8 28 8 3 3 0 3 3>;
+				bosch,mram-cfg = <0x1aa8 28 8 6 0 0 3 3>;
 				status = "disabled";
 			};
 

--- a/dts/arm/ti/mspm0/g/mspm0g310x.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g310x.dtsi
@@ -17,7 +17,7 @@
 			reg-names = "ti_canfd", "m_can", "message_ram";
 			interrupts = <6 0>;
 			clocks = <&ckm MSPM0_CLOCK_CANCLK>;
-			bosch,mram-cfg = <0x0 20 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 20 8 6 0 0 3 3>;
 			ti,divider = <1>;
 			status = "disabled";
 		};

--- a/dts/arm/ti/mspm0/g/mspm0g350x.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g350x.dtsi
@@ -49,7 +49,7 @@
 			reg-names = "ti_canfd", "m_can", "message_ram";
 			interrupts = <6 0>;
 			clocks = <&ckm MSPM0_CLOCK_CANCLK>;
-			bosch,mram-cfg = <0x0 20 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 20 8 6 0 0 3 3>;
 			ti,divider = <1>;
 			status = "disabled";
 		};

--- a/dts/arm/ti/mspm0/g/mspm0gx51x.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0gx51x.dtsi
@@ -112,7 +112,7 @@
 			reg-names = "ti_canfd", "m_can", "message_ram";
 			interrupts = <6 0>;
 			clocks = <&ckm MSPM0_CLOCK_CANCLK>;
-			bosch,mram-cfg = <0x0 20 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 20 8 6 0 0 3 3>;
 			ti,divider = <1>;
 			status = "disabled";
 		};
@@ -123,7 +123,7 @@
 			reg-names = "ti_canfd", "m_can", "message_ram";
 			interrupts = <12 0>;
 			clocks = <&ckm MSPM0_CLOCK_CANCLK>;
-			bosch,mram-cfg = <0x0 20 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 20 8 6 0 0 3 3>;
 			ti,divider = <1>;
 			status = "disabled";
 		};

--- a/dts/bindings/can/st,stm32h7-fdcan.yaml
+++ b/dts/bindings/can/st,stm32h7-fdcan.yaml
@@ -57,6 +57,6 @@ examples:
                  <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
         interrupts = <19 0>, <21 0>, <63 0>;
         interrupt-names = "int0", "int1", "calib";
-        bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+        bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
         status = okay";
       };

--- a/dts/bindings/can/ti,tcan4x5x.yaml
+++ b/dts/bindings/can/ti,tcan4x5x.yaml
@@ -62,7 +62,7 @@ examples:
         device-wake-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
         reset-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
         int-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
-        bosch,mram-cfg = <0x0 15 15 5 5 0 10 10>;
+        bosch,mram-cfg = <0x0 15 15 10 0 0 10 10>;
         ti,nwkrq-voltage-vio;
         status = "okay";
 

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -773,7 +773,7 @@
 				interrupts = <216 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&canpll>, <&hsfll120>;
 				clock-names = "auxpll", "hsfll";
-				bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
+				bosch,mram-cfg = <0x0 28 8 6 0 0 1 1>;
 				status = "disabled";
 			};
 


### PR DESCRIPTION
Always use RX FIFO0 when adding RX filters to ensure CAN frames are processed in the order (priority) received on the bus.
With two FIFOs there is a risk that frames are processed out-of-order by the application layer.

Update SoC/shield DTS to move all dynamically allocated Bosch M_CAN RX FIFO elements to FIFO0.