### PR TITLE
include: clock_control: agilex: move clock_agilex_ll.h to drivers/

### DIFF
--- a/drivers/clock_control/clock_agilex.c
+++ b/drivers/clock_control/clock_agilex.c
@@ -6,8 +6,9 @@
  */
 
 #include <zephyr/drivers/clock_control.h>
-#include <zephyr/drivers/clock_control/clock_agilex_ll.h>
 #include <zephyr/dt-bindings/clock/intel_socfpga_clock.h>
+
+#include "clock_agilex_ll.h"
 
 static int clk_get_rate(const struct device *dev,
 			clock_control_subsys_t sub_system,

--- a/drivers/clock_control/clock_agilex_ll.c
+++ b/drivers/clock_control/clock_agilex_ll.c
@@ -6,8 +6,9 @@
 
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/common/sys_bitops.h>
-#include <zephyr/drivers/clock_control/clock_agilex_ll.h>
 #include <socfpga_system_manager.h>
+
+#include "clock_agilex_ll.h"
 
 /*
  * Intel SoC re-use Arm Trusted Firmware (ATF) driver code in Zephyr.

--- a/drivers/clock_control/clock_agilex_ll.h
+++ b/drivers/clock_control/clock_agilex_ll.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef CLOCKMANAGER_H
-#define CLOCKMANAGER_H
+#ifndef ZEPHYR_DRIVERS_CLOCK_CONTROL_CLOCK_AGILEX_LL_H
+#define ZEPHYR_DRIVERS_CLOCK_CONTROL_CLOCK_AGILEX_LL_H
 
 #include <socfpga_handoff.h>
 
@@ -123,4 +123,4 @@ uint32_t get_wdt_clk(void);
 uint32_t get_uart_clk(void);
 uint32_t get_mmc_clk(void);
 
-#endif
+#endif /* ZEPHYR_DRIVERS_CLOCK_CONTROL_CLOCK_AGILEX_LL_H */


### PR DESCRIPTION
The clock_agilex_ll.h header is not meant to be public API and only contains register definitions meant for internal use by the drivers.