### PR TITLE
boards: others: add support for esp32h2_supermini board

### DIFF
--- a/boards/others/esp32h2_supermini/Kconfig
+++ b/boards/others/esp32h2_supermini/Kconfig
@@ -1,0 +1,8 @@
+# ESP32H2 supermini board configuration
+
+# Copyright (c) 2024 Arrel Neumiller
+# SPDX-License-Identifier: Apache-2.0
+
+config HEAP_MEM_POOL_ADD_SIZE_BOARD
+	int
+	default 4096

--- a/boards/others/esp32h2_supermini/Kconfig.esp32h2_supermini
+++ b/boards/others/esp32h2_supermini/Kconfig.esp32h2_supermini
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Arrel Neumiller
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ESP32H2_SUPERMINI
+	select SOC_ESP32_H2_MINI_H4

--- a/boards/others/esp32h2_supermini/Kconfig.sysbuild
+++ b/boards/others/esp32h2_supermini/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Arrel Neumiller
+# SPDX-License-Identifier: Apache-2.0
+
+choice BOOTLOADER
+	default BOOTLOADER_MCUBOOT
+endchoice
+
+choice BOOT_SIGNATURE_TYPE
+	default BOOT_SIGNATURE_TYPE_NONE
+endchoice

--- a/boards/others/esp32h2_supermini/board.cmake
+++ b/boards/others/esp32h2_supermini/board.cmake
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Arrel Neumiller
+# SPDX-License-Identifier: Apache-2.0
+
+if(NOT "${OPENOCD}" MATCHES "^${ESPRESSIF_TOOLCHAIN_PATH}/.*")
+  set(OPENOCD OPENOCD-NOTFOUND)
+endif()
+find_program(OPENOCD openocd PATHS ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/bin NO_DEFAULT_PATH)
+
+include(${ZEPHYR_BASE}/boards/common/esp32.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/others/esp32h2_supermini/board.yml
+++ b/boards/others/esp32h2_supermini/board.yml
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Arrel Neumiller
+# SPDX-License-Identifier: Apache-2.0
+
+board:
+  name: esp32h2_supermini
+  full_name: ESP32-H2-SUPERMINI
+  vendor: others
+  socs:
+  - name: esp32h2

--- a/boards/others/esp32h2_supermini/doc/index.rst
+++ b/boards/others/esp32h2_supermini/doc/index.rst
@@ -1,0 +1,62 @@
+.. zephyr:board:: esp32h2_supermini
+
+ESP32-H2 SuperMini
+##################
+
+Overview
+********
+
+The ESP32-H2 SuperMini is a compact development board based on the Espressif ESP32-H2 RISC-V SoC.
+It features ultra-low power consumption and supports IEEE 802.15.4 (Thread/Zigbee) and Bluetooth 5 (LE).
+The board is extremely small, making it ideal for compact IoT devices, wearables, and battery-powered applications.
+
+Hardware
+********
+
+.. include:: ../../../espressif/common/soc-esp32h2-features.rst
+   :start-after: espressif-soc-esp32h2-features
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+System Requirements
+*******************
+
+.. include:: ../../../espressif/common/system-requirements.rst
+   :start-after: espressif-system-requirements
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+.. include:: ../../../espressif/common/building-flashing.rst
+   :start-after: espressif-building-flashing
+
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
+Debugging
+=========
+
+.. include:: ../../../espressif/common/openocd-debugging.rst
+   :start-after: espressif-openocd-debugging
+
+WS2812 RGB LED
+**************
+
+The board features an onboard WS2812 RGB LED connected to GPIO 8.
+This board uses the ``i2s`` peripheral to drive the LED natively without bit-banging, ensuring perfect timing even under heavy interrupt load from the Bluetooth stack.
+
+To control the LED, enable the ``led_strip`` API in your project configuration by adding the following flags to your ``prj.conf``:
+
+.. code-block:: kconfig
+
+   CONFIG_LED_STRIP=y
+   CONFIG_WS2812_STRIP_I2S=y
+   CONFIG_I2S=y
+
+.. note::
+   There is no need to manually enable ``CONFIG_DMA=y``. The Zephyr I2S driver for ESP32 automatically selects the required General DMA (GDMA) dependencies.

--- a/boards/others/esp32h2_supermini/esp32h2_supermini-pinctrl.dtsi
+++ b/boards/others/esp32h2_supermini/esp32h2_supermini-pinctrl.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Ivan Shautsou
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pinctrl/esp32h2-pinctrl.h>
+
+&pinctrl {
+	uart0_default: uart0_default {
+		group1 {
+			pinmux = <UART0_TX_GPIO24>;
+			output-high;
+		};
+
+		group2 {
+			pinmux = <UART0_RX_GPIO23>;
+			bias-pull-up;
+		};
+	};
+
+	i2s0_default: i2s0_default {
+		group1 {
+			pinmux = <I2S_O_SD_GPIO8>;
+			output-enable;
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_GPIO22>,
+				 <I2C0_SCL_GPIO25>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
+	};
+};

--- a/boards/others/esp32h2_supermini/esp32h2_supermini.dts
+++ b/boards/others/esp32h2_supermini/esp32h2_supermini.dts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Ivan Shautsou
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <espressif/esp32h2/esp32h2_mini_h4.dtsi>
+#include "esp32h2_supermini-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/led/led.h>
+#include <espressif/partitions_0x0_default.dtsi>
+
+/ {
+	model = "ESP32H2-SUPERMINI";
+	compatible = "espressif,esp32h2_supermini";
+
+	chosen {
+		zephyr,sram = &sramhp;
+		zephyr,console = &usb_serial;
+		zephyr,shell-uart = &usb_serial;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,ieee802154 = &ieee802154;
+	};
+
+	aliases {
+		led0 = &blue_led;
+		sw0 = &user_button1;
+		watchdog0 = &wdt0;
+		led-strip = &ws2812;
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		user_button1: button_1 {
+			label = "User SW1";
+			gpios = <&gpio0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		blue_led: led_0 {
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+			label = "Blue LED 0";
+		};
+	};
+};
+
+&i2s {
+	pinctrl-0 = <&i2s0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	dmas = <&dma 1>;
+	dma-names = "tx";
+
+	ws2812: ws2812_strip@0 {
+		compatible = "worldsemi,ws2812-i2s";
+		reg = <0>;
+		chain-length = <1>;
+		color-mapping = <LED_COLOR_ID_GREEN
+				 LED_COLOR_ID_RED
+				 LED_COLOR_ID_BLUE>;
+	};
+};
+
+&usb_serial {
+	status = "okay";
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+};
+
+&trng0 {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&wdt0 {
+	status = "okay";
+};
+
+&uart0 {
+	status = "disabled";
+};
+
+&dma {
+	status = "okay";
+};
+
+&uart1 {
+	status = "disabled";
+};
+
+&esp32_bt_hci {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+};

--- a/boards/others/esp32h2_supermini/esp32h2_supermini.yaml
+++ b/boards/others/esp32h2_supermini/esp32h2_supermini.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Ivan Shautsou
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: esp32h2_supermini
+name: ESP32-H2-SUPERMINI
+type: mcu
+arch: riscv
+ram: 320
+flash: 4096
+toolchain:
+  - zephyr
+supported:
+  - adc
+  - gpio
+  - i2c
+  - watchdog
+  - uart
+  - dma
+  - spi
+  - counter
+  - entropy
+  - i2s
+  - pwm
+  - netif:openthread
+  - crypto
+  - retained_mem
+  - zigbee
+vendor: others

--- a/boards/others/esp32h2_supermini/esp32h2_supermini_defconfig
+++ b/boards/others/esp32h2_supermini/esp32h2_supermini_defconfig
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CONSOLE=y
+CONFIG_SERIAL=y
+CONFIG_UART_CONSOLE=y
+CONFIG_GPIO=y

--- a/boards/others/esp32h2_supermini/support/openocd.cfg
+++ b/boards/others/esp32h2_supermini/support/openocd.cfg
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 Arrel Neumiller
+# SPDX-License-Identifier: Apache-2.0
+
+set ESP_RTOS Zephyr
+
+# ESP32-H2 has built-in JTAG interface over USB port.
+# Uncomment the line below to enable USB debugging.
+#source [find interface/esp_usb_jtag.cfg]
+
+# Otherwise, use external JTAG programmer
+source [find interface/ftdi/esp32_devkitj_v1.cfg]
+
+source [find target/esp32h2.cfg]
+adapter speed 5000

--- a/drivers/i2s/i2s_esp32.c
+++ b/drivers/i2s/i2s_esp32.c
@@ -874,7 +874,7 @@ static int i2s_esp32_restart_dma(const struct device *dev, enum i2s_dir dir)
 	}
 
 #if SOC_GDMA_SUPPORTED
-	uint16_t chunk_len;
+	uint16_t chunk_len = 0;
 	void *src = NULL, *dst = NULL;
 
 #if I2S_ESP32_IS_DIR_EN(rx)


### PR DESCRIPTION
This commit introduces support for the esp32h2_supermini board. It includes the default configuration, devicetree, and pinctrl definitions.