### PR TITLE
tests: littlefs: add zephyr,mapped-partition compatible on NXP overlays

### DIFF
--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -297,6 +297,10 @@ arduino_spi: &lpspi1 {
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
 				#address-cells = <1>;
 				#size-cells = <1>;

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -40,6 +40,10 @@
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
 				#address-cells = <1>;
 				#size-cells = <1>;

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -172,6 +172,10 @@ arduino_i2c: &flexcomm2 {
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
 				#address-cells = <1>;
 				#size-cells = <1>;

--- a/tests/subsys/fs/littlefs/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/subsys/fs/littlefs/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -9,16 +9,19 @@
 &w25q64jvssiq {
 	partitions {
 		large_partition: partition@400000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x00400000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@700000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x00700000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@7f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x007f0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/frdm_rw612.overlay
+++ b/tests/subsys/fs/littlefs/boards/frdm_rw612.overlay
@@ -9,16 +9,19 @@
 &w25q512jvfiq {
 	partitions {
 		large_partition: partition@3c00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x03c00000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@3f00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x03f00000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@3ff0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x03ff0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1010_evk.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1010_evk.overlay
@@ -9,16 +9,19 @@
 &at25sf128a {
 	partitions {
 		large_partition: partition@c00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x00c00000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@f00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x00f00000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@ff0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x00ff0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1015_evk.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1015_evk.overlay
@@ -9,16 +9,19 @@
 &at25sf128a {
 	partitions {
 		large_partition: partition@c00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x00c00000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@f00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x00f00000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@ff0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x00ff0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1020_evk.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1020_evk.overlay
@@ -9,16 +9,19 @@
 &is25lp064 {
 	partitions {
 		large_partition: partition@400000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x00400000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@700000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x00700000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@7f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x007f0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1024_evk.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1024_evk.overlay
@@ -9,6 +9,7 @@
 &w25q32jvwj0 {
 	partitions {
 		small_partition: partition@3f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x003f0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1040_evk.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1040_evk.overlay
@@ -9,16 +9,19 @@
 &w25q64jvssiq {
 	partitions {
 		large_partition: partition@400000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x00400000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@700000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x00700000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@7f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x007f0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -9,16 +9,19 @@
 &w25q128jw {
 	partitions {
 		large_partition: partition@c00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x00c00000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@f00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x00f00000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@ff0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x00ff0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1064_evk.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1064_evk.overlay
@@ -9,16 +9,19 @@
 &is25wp064 {
 	partitions {
 		large_partition: partition@400000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x00400000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@700000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x00700000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@7f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x007f0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
@@ -9,16 +9,19 @@
 &is25wp128 {
 	partitions {
 		large_partition: partition@c00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x00c00000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@f00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x00f00000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@ff0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x00ff0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -9,16 +9,19 @@
 &w25q512nw {
 	partitions {
 		large_partition: partition@3c00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x03c00000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@3f00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x03f00000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@3ff0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x03ff0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -9,16 +9,19 @@
 &w25q128jw {
 	partitions {
 		large_partition: partition@c00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x00c00000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@f00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x00f00000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@ff0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x00ff0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
@@ -9,16 +9,19 @@
 &mx25um51345g {
 	partitions {
 		large_partition: partition@3c00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x03c00000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@3f00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x03f00000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@3ff0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x03ff0000 DT_SIZE_K(64)>;
 		};

--- a/tests/subsys/fs/littlefs/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
@@ -9,16 +9,19 @@
 &mx25um51345g {
 	partitions {
 		large_partition: partition@3c00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x03c00000 DT_SIZE_M(3)>;
 		};
 
 		medium_partition: partition@3f00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x03f00000 DT_SIZE_K(960)>;
 		};
 
 		small_partition: partition@3ff0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x03ff0000 DT_SIZE_K(64)>;
 		};


### PR DESCRIPTION
Commit 5d0c7b8df73 ("boards: nxp: use zephyr,mapped-partition for FlexSPI XIP backings") dropped the 'fixed-partitions' compatible from the parent 'partitions' node on the FlexSPI XIP flash of several NXP board families and moved a per-partition 'zephyr,mapped-partition' compatible onto each child instead.

The littlefs test overlays that add 'large_partition', 'medium_partition' and 'small_partition' children under those same flash nodes did not get updated. They still added raw partition nodes with only label and reg.

PARTITION_ID() in include/zephyr/storage/flash_map.h dispatches on DT_NODE_HAS_COMPAT(.., zephyr_mapped_partition) of the child itself, so these overlays fall back to the fixed-partition path and break the build:

  include/zephyr/storage/flash_map.h:392: in expansion of macro
    'DT_FIXED_PARTITION_ID'
  tests/subsys/fs/littlefs/src/testfs_lfs.c:13: in expansion of macro
    'PARTITION_ID'

Add 'compatible = "zephyr,mapped-partition";' to every large/medium/small partition node in the affected NXP littlefs test overlays.

Boards verified to build tests/subsys/fs/littlefs after this change: mimxrt1060_evk@C/mimxrt1062/qspi, mimxrt1024_evk, mimxrt1064_evk, mimxrt1170_evk/mimxrt1176/cm7, frdm_rw612, mimxrt685_evk/mimxrt685s/cm33.

Fixes: #110210