### PR TITLE
dts: arm: st: g4: Add comp3 to comp7 nodes to stm32g4x

### DIFF
--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -858,6 +858,24 @@
 			status = "disabled";
 		};
 
+		comp3: comparator@40010208 {
+			compatible = "st,stm32g4-comp", "st,stm32-comp";
+			reg = <0x40010208 0x4>;
+			interrupts = <64 0>;
+			st,exti-line = <29>;
+			clocks = <&rcc STM32_CLOCK(APB2, 0)>;
+			status = "disabled";
+		};
+
+		comp4: comparator@4001020c {
+			compatible = "st,stm32g4-comp", "st,stm32-comp";
+			reg = <0x4001020c 0x4>;
+			interrupts = <65 0>;
+			st,exti-line = <30>;
+			clocks = <&rcc STM32_CLOCK(APB2, 0)>;
+			status = "disabled";
+		};
+
 		crc: crc@40023000 {
 			compatible = "st,stm32-crc";
 			reg = <0x40023000 0x400>;

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -125,6 +125,33 @@
 			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};
+
+		comp5: comparator@40010210 {
+			compatible = "st,stm32g4-comp", "st,stm32-comp";
+			reg = <0x40010210 0x4>;
+			interrupts = <65 0>;
+			st,exti-line = <31>;
+			clocks = <&rcc STM32_CLOCK(APB2, 0)>;
+			status = "disabled";
+		};
+
+		comp6: comparator@40010214 {
+			compatible = "st,stm32g4-comp", "st,stm32-comp";
+			reg = <0x40010214 0x4>;
+			interrupts = <65 0>;
+			st,exti-line = <32>;
+			clocks = <&rcc STM32_CLOCK(APB2, 0)>;
+			status = "disabled";
+		};
+
+		comp7: comparator@40010218 {
+			compatible = "st,stm32g4-comp", "st,stm32-comp";
+			reg = <0x40010218 0x4>;
+			interrupts = <66 0>;
+			st,exti-line = <33>;
+			clocks = <&rcc STM32_CLOCK(APB2, 0)>;
+			status = "disabled";
+		};
 	};
 
 	smbus4: smbus4 {

--- a/soc/st/stm32/stm32g4x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32g4x/Kconfig.defconfig
@@ -5,10 +5,23 @@
 
 if SOC_SERIES_STM32G4X
 
+configdefault SHARED_IRQ_MAX_NUM_CLIENTS
+	# COMP1/2/3 or COMP4/5/6 instances are all enabled
+	default 3 if $(dt_nodelabel_enabled,comp1) && $(dt_nodelabel_enabled,comp2) && $(dt_nodelabel_enabled,comp3)
+	default 3 if $(dt_nodelabel_enabled,comp4) && $(dt_nodelabel_enabled,comp5) && $(dt_nodelabel_enabled,comp6)
+
 configdefault SHARED_INTERRUPTS
 	default y if $(dt_nodelabel_enabled,timers1) && $(dt_nodelabel_enabled,timers15)
 	default y if $(dt_nodelabel_enabled,timers1) && $(dt_nodelabel_enabled,timers16)
 	default y if $(dt_nodelabel_enabled,timers1) && $(dt_nodelabel_enabled,timers17)
+	# COMP1 - COMP2 - COMP3 : irq 64
+	default y if $(dt_nodelabel_enabled,comp1) && $(dt_nodelabel_enabled,comp2)
+	default y if $(dt_nodelabel_enabled,comp1) && $(dt_nodelabel_enabled,comp3)
+	default y if $(dt_nodelabel_enabled,comp2) && $(dt_nodelabel_enabled,comp3)
+	# COMP4 - COMP5 - COMP6 : irq 65
+	default y if $(dt_nodelabel_enabled,comp4) && $(dt_nodelabel_enabled,comp5)
+	default y if $(dt_nodelabel_enabled,comp4) && $(dt_nodelabel_enabled,comp6)
+	default y if $(dt_nodelabel_enabled,comp5) && $(dt_nodelabel_enabled,comp6)
 
 if PM
 config PM_DEVICE


### PR DESCRIPTION
While working on a stm32g474 I noticed only comp1 and comp2 are defined in the dts, but the g474 has 7 of them.

My board includes [`stm32g474Xe.dtsi`](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/arm/st/g4/stm32g474Xe.dtsi) which has following include-chain:

- [`stm32g474.dtsi`](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/arm/st/g4/stm32g474.dtsi)
- [`stm32g473.dtsi`](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/arm/st/g4/stm32g473.dtsi)
- [`stm32g491.dtsi`](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/arm/st/g4/stm32g491.dtsi)
- [`stm32g4.dtsi`](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/arm/st/g4/stm32g4.dtsi) (here are comp1 and comp2 defined)

Looking for the number of comparators of each sub-family by using the [ST product selector](https://www.st.com/en/microcontrollers-microprocessors/stm32g4-series/products.html), it seems like every g4 has at least 4 comparators and  following the include-chain beginning with g473 the have 7.

This PR
* adds missing comp3 & comp4 node to stm32g4x (all g4 have 4 comparators). 
* adds missing comp5, comp6 & comp7 to stm32g473 (all g473 and derived types have 7 comparators).
