### PR TITLE
boards: amd: versal_apu: add SMP board variant

### DIFF
--- a/boards/amd/versal_apu/board.yml
+++ b/boards/amd/versal_apu/board.yml
@@ -7,3 +7,5 @@ board:
   vendor: amd
   socs:
   - name: versal_apu
+    variants:
+    - name: smp

--- a/boards/amd/versal_apu/versal_apu_versal_apu_smp.dts
+++ b/boards/amd/versal_apu/versal_apu_versal_apu_smp.dts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "versal_apu.dts"
+
+/ {
+	cpus {
+		cpu1: cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a72";
+			reg = <0x1>;
+			enable-method = "psci";
+		};
+	};
+};

--- a/boards/amd/versal_apu/versal_apu_versal_apu_smp.yaml
+++ b/boards/amd/versal_apu/versal_apu_versal_apu_smp.yaml
@@ -1,0 +1,11 @@
+identifier: versal_apu/versal_apu/smp
+name: AMD Development board for Versal APU
+arch: arm64
+toolchain:
+  - zephyr
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
+    - fpu
+vendor: amd

--- a/boards/amd/versal_apu/versal_apu_versal_apu_smp_defconfig
+++ b/boards/amd/versal_apu/versal_apu_versal_apu_smp_defconfig
@@ -1,0 +1,35 @@
+# The Zephyr build from this defconfig is expected to boot from
+# Xilinx Arm Trusted Firmware (ATF).
+# Boot Flow is: Boot PDI -> TF-A -> Zephyr
+CONFIG_BUILD_WITH_TFA=y
+
+CONFIG_ARM64_VA_BITS_40=y
+CONFIG_ARM64_PA_BITS_40=y
+CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME=y
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable serial port
+CONFIG_UART_PL011=y
+
+# This should be commented in order to test at EL1 S (EL1 Secure)
+CONFIG_ARMV8_A_NS=y
+
+# Enable Clock Manager
+CONFIG_CLOCK_CONTROL=y
+
+# Reset Manager
+CONFIG_RESET=y
+
+# PSCI support Enable
+CONFIG_PM_CPU_OPS=y
+CONFIG_PM_CPU_OPS_PSCI=y
+
+# Enable SMP support
+CONFIG_SMP=y
+CONFIG_MP_MAX_NUM_CPUS=2


### PR DESCRIPTION
The Versal APU has a dual-core Cortex-A72 cluster. This variant exposes the second core (cpu@1) via PSCI enable-method, enabling SMP with CONFIG_SMP=y and CONFIG_MP_MAX_NUM_CPUS=2.

The board targets TF-A based boot (Boot PDI -> TF-A -> Zephyr) and runs at EL1 Non-Secure.