### PR TITLE
drivers: usb: uhc: mcux: fix endpoint reinitialization logic

### DIFF
--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -242,10 +242,17 @@ static usb_host_pipe_handle uhc_mcux_check_hal_ep(const struct device *dev,
 		}
 	}
 
-	if (mcux_ep != NULL && mcux_ep->pipeType == xfer->type &&
-	    (mcux_ep->maxPacketSize != xfer->mps ||
-	    priv->mcux_eps_interval[i] != xfer->interval)) {
-		/* re-initialize the ep */
+	if (mcux_ep == NULL) {
+		return NULL;
+	}
+
+	/* If the ep's attributes have changed, close the ep and return NULL.
+	 * The ep will be re-initialized with new attributes.
+	 */
+	if (mcux_ep->pipeType != xfer->type ||
+	    mcux_ep->maxPacketSize != USB_MPS_EP_SIZE(xfer->mps) ||
+	    mcux_ep->numberPerUframe != USB_MPS_ADDITIONAL_TRANSACTIONS(xfer->mps) + 1 ||
+	    priv->mcux_eps_interval[i] != xfer->interval) {
 		status = priv->mcux_if->controllerClosePipe(priv->mcux_host.controllerHandle,
 							    mcux_ep);
 		if (status != kStatus_USB_Success) {


### PR DESCRIPTION
Fix the endpoint attribute comparison logic in uhc_mcux_check_hal_ep() to properly handle USB endpoint max packet size (MPS) fields.

The previous code compared the raw MPS value against maxPacketSize, but the MPS field encodes both the packet size and the number of additional transactions per microframe for high-speed endpoints.

Extract and compare these fields separately using USB_MPS_EP_SIZE() and USB_MPS_ADDITIONAL_TRANSACTIONS() macros. This ensures endpoints are correctly reinitialized when either the packet size or transaction multiplier changes.

Also restructure the conditional logic for clarity: return early if no endpoint exists, then check if attributes have changed and close the endpoint if needed.