### PR TITLE
drivers: ethernet: sam_gmac: fix phy-connection-type value for rgmii

### DIFF
--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
@@ -266,7 +266,7 @@
 	status = "okay";
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_gmac0_default>;
-	phy-connection-type = "gmii";
+	phy-connection-type = "rgmii";
 	phy-handle = <&gmac0_phy>;
 
 	nvmem-cells = <&eeprom0_eui48>;

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -142,12 +142,15 @@ static inline void dcache_clean(uint32_t addr, uint32_t size)
 #endif /* !CONFIG_NET_TEST */
 
 /* if GMAC_UR_MIM_RGMII (new for sama7g5) is defined, the media interface mode
- * supported are: mii, rmii and gmii. Otherwise mii and rmii are supported.
+ * supported are: mii, rmii and rgmii. Otherwise mii and rmii are supported.
+ * The enum indexes for mii, rmii, gmii, rgmii are 0 ~ 3. As the enum index for
+ * rgmii is 3, here defines SAM_GMAC_PHY_CONNECTION_TYPE_MAX to 3 when RGMII is
+ * supported.
  */
 #ifndef GMAC_UR_MIM_RGMII
 #define SAM_GMAC_PHY_CONNECTION_TYPE_MAX 1
 #else
-#define SAM_GMAC_PHY_CONNECTION_TYPE_MAX 2
+#define SAM_GMAC_PHY_CONNECTION_TYPE_MAX 3
 #endif
 
 /* RX descriptors list */
@@ -995,7 +998,7 @@ static int gmac_init(Gmac *gmac, uint32_t gmac_ncfgr_val, const struct eth_sam_d
 		gmac->GMAC_UR = 0x0;
 		break;
 #ifdef GMAC_UR_MIM_RGMII
-	case 2: /* rgmii */
+	case 3: /* rgmii */
 		gmac->GMAC_UR = GMAC_UR_MIM_RGMII;
 		break;
 #endif


### PR DESCRIPTION
The value 2 of `phy-connection-type` is for `gmii` and it is misused for `rgmii`.
Fix the value the driver and update `phy-connection-type` from `gmii` to `rgmii` in the dts file for sama7g54-ek board.

Note: The value misused does not cause failures of the functions.
