### PR TITLE
soc: nordic: gen_uicr: Add support to add CUSTOMER bin file

### DIFF
--- a/soc/nordic/common/uicr/Kconfig.gen_uicr
+++ b/soc/nordic/common/uicr/Kconfig.gen_uicr
@@ -181,6 +181,7 @@ config GEN_UICR_WDTSTART_CRV
 	  Must be at least 15 (0xF) to ensure proper watchdog operation.
 	  Default value 65535 creates a 2-second timeout.
 
+
 config GEN_UICR_SECONDARY_WDTSTART
 	bool "UICR.SECONDARY.WDTSTART"
 	depends on GEN_UICR_SECONDARY
@@ -224,6 +225,22 @@ config GEN_UICR_SECONDARY_WDTSTART_CRV
 	  This value determines the watchdog timeout period.
 	  Must be at least 15 (0xF) to ensure proper watchdog operation.
 	  Default value 65535 creates a 2-second timeout.
+
+config GEN_UICR_CUSTOMER
+	bool "UICR.CUSTOMER"
+	help
+	  When enabled, the UICR generator will use a customer-provided
+	  .bin file for the CUSTOMER field.
+
+config GEN_UICR_CUSTOMER_BIN_FILE
+	string "Path to bin file for UICR customer data."
+	depends on GEN_UICR_CUSTOMER
+	help
+	  Path to binary (.bin) file. This file contains data to be stored
+	  in UICR.CUSTOMER. The size of the file must be less than the
+	  UICR.CUSTOMER area. The data will be stored starting from the start
+	  of UICR.CUSTOMER. The path can be absolute, or relative. If the
+	  path is relative, it will be relative to the gen_uicr image.
 
 config GEN_UICR_SECONDARY
 	bool "UICR.SECONDARY.ENABLE"

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -102,6 +102,7 @@ set(periphconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/periphconf.hex)
 set(secondary_periphconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/secondary_periphconf.hex)
 set(mpcconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/mpcconf.hex)
 set(secondary_mpcconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/secondary_mpcconf.hex)
+set(in_customer_bin_file ${CONFIG_GEN_UICR_CUSTOMER_BIN_FILE})
 
 # These are always output, others depend on the options
 set(gen_uicr_outputs ${merged_hex_file} ${uicr_hex_file})
@@ -262,6 +263,24 @@ if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF OR CONFIG_GEN_UICR_SECONDARY_GENERATE_PER
       list(APPEND gen_uicr_depends ${elf})
     endforeach()
   endif()
+endif()
+
+if(CONFIG_GEN_UICR_CUSTOMER)
+  if("${CONFIG_GEN_UICR_CUSTOMER_BIN_FILE}" STREQUAL "")
+    message(FATAL_ERROR
+      "CONFIG_GEN_UICR_CUSTOMER_BIN_FILE is an empty string."
+    )
+  endif()
+  if(NOT CONFIG_GEN_UICR_CUSTOMER_BIN_FILE MATCHES "\\.bin$")
+    message(FATAL_ERROR "CONFIG_GEN_UICR_CUSTOMER_BIN_FILE is not a .bin file")
+  endif()
+  if(IS_ABSOLUTE ${in_customer_bin_file})
+    set(in_customer_bin_file_path ${in_customer_bin_file})
+  else()
+    set(in_customer_bin_file_path ${APPLICATION_CONFIG_DIR}/${in_customer_bin_file})
+  endif()
+  list(APPEND customer_args --in-customer-bin ${in_customer_bin_file_path})
+  list(APPEND gen_uicr_outputs ${in_customer_bin_file_path})
 endif()
 
 if(CONFIG_GEN_UICR_SECONDARY)
@@ -463,6 +482,7 @@ add_custom_command(
           ${secondary_args}
           ${policy_args}
           ${snapshot_args}
+          ${customer_args}
   ${periphconf_validate_build_command}
   ${secondary_periphconf_validate_build_command}
   DEPENDS ${gen_uicr_depends}

--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,8 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 1a6de0af0a0e5f65b88d52df006aa8cdf29fe92f
+      url: https://github.com/hellesvik-nordic/hal_nordic
+      revision: uicr_customer
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Add CONFIG_GEN_UICR_CUSTOMER and CONFIG_GEN_UICR_CUSTOMER_BIN_FILE to let projects add a bin file with customer data that will be generated as part of the uicr.hex.

Pointing west.yml to https://github.com/hellesvik-nordic/hal_nordic/tree/uicr_customer for testing with new ironside gen_uicr feature. 

