### PR TITLE
dts: vendor: nordic: nrf54l*: Add missing ranges

### DIFF
--- a/dts/vendor/nordic/nrf54l05_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l05_cpuapp_partition.dtsi
@@ -6,6 +6,7 @@
 
 &cpuapp_rram {
 	partitions {
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 

--- a/dts/vendor/nordic/nrf54l10_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l10_cpuapp_partition.dtsi
@@ -6,6 +6,7 @@
 
 &cpuapp_rram {
 	partitions {
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 

--- a/dts/vendor/nordic/nrf54l15_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuapp_partition.dtsi
@@ -6,6 +6,7 @@
 
 &cpuapp_rram {
 	partitions {
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 


### PR DESCRIPTION
Partition nodes were wrongly omitted from having `ranges`, this fixes the issue