### PR TITLE
usb: cdc_acm: device_next: Mitigate posix ECHO issues

### DIFF
--- a/subsys/usb/device_next/class/Kconfig.cdc_acm
+++ b/subsys/usb/device_next/class/Kconfig.cdc_acm
@@ -47,6 +47,13 @@ config USBD_CDC_ACM_BUF_POOL_SIZE
 	  be large enough to accommodate the maximum packet size for
 	  the endpoints.
 
+config USBD_CDC_ACM_TX_DELAY_MS
+	int
+	default 100
+	help
+	  Time in milliseconds to wait before sending actual payload to host.
+	  This is needed to prevent tty ECHO on Linux.
+
 module = USBD_CDC_ACM
 module-str = usbd cdc_acm
 default-count = 1

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -110,6 +110,7 @@ struct cdc_acm_uart_data {
 	 * the TX FIFO during the user callback execution.
 	 */
 	bool zlp_needed;
+	bool echo_mitigated;
 	/* UART API IRQ callback */
 	uart_irq_callback_user_data_t cb;
 	/* UART API user callback data */
@@ -330,11 +331,22 @@ static int usbd_cdc_acm_request(struct usbd_class_data *const c_data,
 
 		atomic_clear_bit(&data->state, CDC_ACM_TX_FIFO_BUSY);
 
-		if (!ring_buf_is_empty(data->tx_fifo.rb)) {
+		if (!data->echo_mitigated) {
+			/* If mitigation was not yet applied give the host some
+			 * time to disable ECHO.
+			 */
+			cdc_acm_work_schedule(&data->tx_fifo_work,
+					      K_MSEC(CONFIG_USBD_CDC_ACM_TX_DELAY_MS));
+			data->echo_mitigated = true;
+		} else if (!ring_buf_is_empty(data->tx_fifo.rb)) {
 			/* Queue pending TX data on IN endpoint */
 			cdc_acm_work_schedule(&data->tx_fifo_work, K_NO_WAIT);
+		} else {
+			/* No need to schedule if there is no data left
+			 * to send. Any new data will be scheduled either
+			 * after fifo_fill or poll_out.
+			 */
 		}
-
 	}
 
 	if (bi->ep == cdc_acm_get_int_in(c_data)) {
@@ -368,22 +380,16 @@ static void usbd_cdc_acm_enable(struct usbd_class_data *const c_data)
 		/* Allow cdc_acm_poll_in to receive */
 		cdc_acm_work_submit(&data->rx_fifo_work);
 	}
-
-	if (ring_buf_is_empty(data->tx_fifo.rb)) {
-		if (atomic_test_bit(&data->state, CDC_ACM_IRQ_TX_ENABLED)) {
-			/* Raise TX ready interrupt */
-			cdc_acm_work_submit(&data->irq_cb_work);
-		}
-	} else {
-		/* Queue pending TX data on IN endpoint */
-		cdc_acm_work_schedule(&data->tx_fifo_work, K_NO_WAIT);
-	}
+	data->zlp_needed = true;
+	cdc_acm_work_schedule(&data->tx_fifo_work, K_NO_WAIT);
 }
 
 static void usbd_cdc_acm_disable(struct usbd_class_data *const c_data)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	struct cdc_acm_uart_data *data = dev->data;
+
+	data->echo_mitigated = false;
 
 	atomic_clear_bit(&data->state, CDC_ACM_CLASS_ENABLED);
 	atomic_clear_bit(&data->state, CDC_ACM_CLASS_SUSPENDED);
@@ -639,7 +645,7 @@ static void cdc_acm_tx_fifo_handler(struct k_work *work)
 	const struct cdc_acm_uart_config *cfg;
 	struct usbd_class_data *c_data;
 	struct net_buf *buf;
-	size_t len;
+	size_t len = 0;
 	int ret;
 
 	data = CONTAINER_OF(dwork, struct cdc_acm_uart_data, tx_fifo_work);
@@ -656,6 +662,11 @@ static void cdc_acm_tx_fifo_handler(struct k_work *work)
 		return;
 	}
 
+	if (ring_buf_is_empty(data->tx_fifo.rb) && !data->zlp_needed) {
+		LOG_DBG("ZLP not needed and no data to send");
+		return;
+	}
+
 	if (atomic_test_and_set_bit(&data->state, CDC_ACM_TX_FIFO_BUSY)) {
 		LOG_DBG("TX transfer already in progress");
 		return;
@@ -668,7 +679,9 @@ static void cdc_acm_tx_fifo_handler(struct k_work *work)
 		return;
 	}
 
-	len = ring_buf_get(data->tx_fifo.rb, buf->data, buf->size);
+	if (data->echo_mitigated) {
+		len = ring_buf_get(data->tx_fifo.rb, buf->data, buf->size);
+	}
 	net_buf_add(buf, len);
 
 	data->zlp_needed = len != 0 && len % cdc_acm_get_bulk_mps(c_data) == 0;
@@ -1023,7 +1036,9 @@ static void cdc_acm_poll_out(const struct device *dev, const unsigned char c)
 	 * one byte per USB transfer. The latency increase is negligible while
 	 * the increased throughput and reduced CPU usage is easily observable.
 	 */
-	cdc_acm_work_schedule(&data->tx_fifo_work, K_MSEC(1));
+	if (data->echo_mitigated) {
+		cdc_acm_work_schedule(&data->tx_fifo_work, K_MSEC(1));
+	}
 }
 
 #ifdef CONFIG_UART_LINE_CTRL


### PR DESCRIPTION
Fixes #109717.

On linux the tty is opened in ECHO mode by default causing any data sent immidiately after boot to be looped back into rx. This was mitigated in old implementation with #64720. The mitigation works by enqueing a ZLP. When the ZLP is consumed by the host it means that it started reading. The patch then waits for some time before sending actual payload. This gives the host application time to switch off the ECHO mode.

This commit introduces analogous solution to device_next.