### PR TITLE
twister: keep edt.pickle for device testing

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1368,6 +1368,7 @@ class ProjectBuilder(FilterBuilder):
 
         files_to_keep = self._get_binaries()
         files_to_keep.append(os.path.join('zephyr', 'runners.yaml'))
+        files_to_keep.append(os.path.join('zephyr', 'edt.pickle'))
 
         if self.instance.sysbuild and self.instance.domains:
             files_to_keep.append('domains.yaml')
@@ -1388,7 +1389,8 @@ class ProjectBuilder(FilterBuilder):
             os.path.join(domain, 'CMakeFiles', 'rules.ninja'),
             os.path.join(domain, 'Makefile'),
             os.path.join(domain, 'zephyr', '.config'),
-            os.path.join(domain, 'zephyr', 'runners.yaml')
+            os.path.join(domain, 'zephyr', 'runners.yaml'),
+            os.path.join(domain, 'zephyr', 'edt.pickle')
             ]
         return allow
 

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -1767,7 +1767,8 @@ def test_projectbuilder_cleanup_device_testing_artifacts(
 
     pb.cleanup_artifacts.assert_called_once_with(
         [os.path.join('zephyr', 'file.bin'),
-         os.path.join('zephyr', 'runners.yaml')]
+         os.path.join('zephyr', 'runners.yaml'),
+         os.path.join('zephyr', 'edt.pickle')]
     )
     pb._sanitize_files.assert_called_once()
 
@@ -1806,6 +1807,7 @@ def test_projectbuilder_cleanup_device_testing_artifacts_sysbuild(
         [
             os.path.join('zephyr', 'file.bin'),
             os.path.join('zephyr', 'runners.yaml'),
+            os.path.join('zephyr', 'edt.pickle'),
             'domains.yaml',
             os.path.join('main', 'build.ninja'),
             os.path.join('main', 'CMakeCache.txt'),
@@ -1813,12 +1815,14 @@ def test_projectbuilder_cleanup_device_testing_artifacts_sysbuild(
             os.path.join('main', 'Makefile'),
             os.path.join('main', 'zephyr', '.config'),
             os.path.join('main', 'zephyr', 'runners.yaml'),
+            os.path.join('main', 'zephyr', 'edt.pickle'),
             os.path.join('ipc_radio', 'build.ninja'),
             os.path.join('ipc_radio', 'CMakeCache.txt'),
             os.path.join('ipc_radio', 'CMakeFiles', 'rules.ninja'),
             os.path.join('ipc_radio', 'Makefile'),
             os.path.join('ipc_radio', 'zephyr', '.config'),
             os.path.join('ipc_radio', 'zephyr', 'runners.yaml'),
+            os.path.join('ipc_radio', 'zephyr', 'edt.pickle'),
         ]
     )
     pb._sanitize_files.assert_called_once()


### PR DESCRIPTION
Keep zephyr/edt.pickle when cleaning artifacts for test-only packages.

Add edt.pickle to the single-domain and multi-domain allow-lists used by cleanup_device_testing_artifacts().

Some runners need edt.pickle at flash time to resolve the code partition from the EDT, so removing it breaks flashing from packaged device-testing artifacts.