### PR TITLE
Bluetooth: Mesh: fix PrivateBeaconKey PSA key leak on subnet delete

### DIFF
--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -202,7 +202,7 @@ static void subnet_keys_destroy(struct bt_mesh_subnet_keys *key)
 #if defined(CONFIG_BT_MESH_GATT_PROXY)
 	bt_mesh_key_destroy(&key->identity);
 #endif
-#if defined(CONFIG_BT_MESH_V1d1)
+#if defined(CONFIG_BT_MESH_PRIV_BEACONS)
 	bt_mesh_key_destroy(&key->priv_beacon);
 #endif
 }


### PR DESCRIPTION
subnet_keys_destroy() guarded the destroy of keys->priv_beacon with #if defined(CONFIG_BT_MESH_V1d1), while net_keys_create() guards the matching import with #if defined(CONFIG_BT_MESH_PRIV_BEACONS).

Commit 981c79b7ce93 ("Bluetooth: Mesh: Drop explicit support for Bluetooth Mesh 1.0.1") removed the CONFIG_BT_MESH_V1d1 Kconfig but left this stray reference behind. With V1d1 gone, the destroy branch is permanently dead code, so every successful net_keys_create() leaks one PSA key slot.

In a long-running test that repeatedly provisions and resets a node (no persistent settings, in-RAM CDB only), the leak accumulates one PSA volatile-key slot per provisioning round. With the default CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT=16, bt_mesh_private_beacon_key() fails after ~12 rounds with:

  <err> bt_mesh_net_keys: Unable to generate private beacon key
  <err> bt_mesh_net: Failed creating subnet
  <err> bt_mesh_main: Failed to create network

Align the destroy guard with the import guard so the leak goes away.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/110303