### PR TITLE
drivers: sensor: ms5637: Add async sensor API support

### DIFF
--- a/drivers/sensor/meas/ms5637/CMakeLists.txt
+++ b/drivers/sensor/meas/ms5637/CMakeLists.txt
@@ -7,3 +7,4 @@
 zephyr_library()
 
 zephyr_library_sources(ms5637.c)
+zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API ms5637_rtio.c)

--- a/drivers/sensor/meas/ms5637/Kconfig
+++ b/drivers/sensor/meas/ms5637/Kconfig
@@ -6,6 +6,8 @@ config MS5637
 	default y
 	depends on DT_HAS_MEAS_MS5637_ENABLED
 	select I2C
+	select I2C_RTIO if SENSOR_ASYNC_API
+	select RTIO_OP_DELAY if SENSOR_ASYNC_API
 	help
 	  Enable driver for the TE Connectivity MS5637 digital
 	  pressure and temperature sensor over I2C.

--- a/drivers/sensor/meas/ms5637/ms5637.c
+++ b/drivers/sensor/meas/ms5637/ms5637.c
@@ -125,8 +125,10 @@ static int ms5637_convert_and_read(const struct device *dev, uint8_t conv_cmd, u
  *
  * Second order corrections are applied per datasheet flowchart.
  */
-static void ms5637_compensate(struct ms5637_data *data, uint32_t adc_temperature,
-			      uint32_t adc_pressure)
+void ms5637_compensate(const struct ms5637_calibration *cal,
+			      uint32_t adc_temperature,
+			      uint32_t adc_pressure,
+			      struct ms5637_reading *reading)
 {
 	int64_t dT;
 	int64_t OFF;
@@ -137,22 +139,22 @@ static void ms5637_compensate(struct ms5637_data *data, uint32_t adc_temperature
 	int64_t SENS2;
 
 	/* First order compensation */
-	dT = (int64_t)adc_temperature - ((int64_t)data->t_ref << 8);
-	data->temperature = (int32_t)(2000 + (dT * data->tempsens) / (1LL << 23));
-	OFF = ((int64_t)data->off_t1 << 17) + (dT * data->tco) / (1LL << 6);
-	SENS = ((int64_t)data->sens_t1 << 16) + (dT * data->tcs) / (1LL << 7);
+	dT = (int64_t)adc_temperature - ((int64_t)cal->t_ref << 8);
+	reading->temperature = (int32_t)(2000 + (dT * cal->tempsens) / (1LL << 23));
+	OFF = ((int64_t)cal->off_t1 << 17) + (dT * cal->tco) / (1LL << 6);
+	SENS = ((int64_t)cal->sens_t1 << 16) + (dT * cal->tcs) / (1LL << 7);
 
 	/* Second order compensation */
-	temp_sq = (int64_t)(data->temperature - 2000) * (int64_t)(data->temperature - 2000);
+	temp_sq = (int64_t)(reading->temperature - 2000) * (int64_t)(reading->temperature - 2000);
 
-	if (data->temperature < 2000) {
+	if (reading->temperature < 2000) {
 		T2 = (3LL * dT * dT) / (1LL << 33);
 		OFF2 = (61LL * temp_sq) / (1LL << 4);
 		SENS2 = (29LL * temp_sq) / (1LL << 4);
 
-		if (data->temperature < -1500) {
-			temp_sq = (int64_t)(data->temperature + 1500) *
-				  (int64_t)(data->temperature + 1500);
+		if (reading->temperature < -1500) {
+			temp_sq = (int64_t)(reading->temperature + 1500) *
+				  (int64_t)(reading->temperature + 1500);
 			OFF2 += 17LL * temp_sq;
 			SENS2 += 9LL * temp_sq;
 		}
@@ -165,8 +167,8 @@ static void ms5637_compensate(struct ms5637_data *data, uint32_t adc_temperature
 	OFF -= OFF2;
 	SENS -= SENS2;
 
-	data->temperature -= (int32_t)T2;
-	data->pressure =
+	reading->temperature -= (int32_t)T2;
+	reading->pressure =
 		(int32_t)((SENS * (int64_t)adc_pressure / (1LL << 21) - OFF) / (1LL << 15));
 }
 
@@ -196,7 +198,7 @@ static int ms5637_sample_fetch(const struct device *dev, enum sensor_channel cha
 		return ret;
 	}
 
-	ms5637_compensate(data, adc_temperature, adc_pressure);
+	ms5637_compensate(&data->cal, adc_temperature, adc_pressure, &data->reading);
 
 	return 0;
 }
@@ -210,11 +212,11 @@ static int ms5637_channel_get(const struct device *dev, enum sensor_channel chan
 	case SENSOR_CHAN_AMBIENT_TEMP:
 		/* Compensated temperature is in centidegrees Celsius */
 		sensor_value_from_micro(val,
-					(int64_t)data->temperature * MS5637_MICRO_PER_CENTIDEG);
+				(int64_t)data->reading.temperature * MS5637_MICRO_PER_CENTIDEG);
 		break;
 	case SENSOR_CHAN_PRESS:
 		/* Compensated pressure is in Pa; channel unit is kPa */
-		sensor_value_from_milli(val, (int64_t)data->pressure);
+		sensor_value_from_milli(val, (int64_t)data->reading.pressure);
 		break;
 	default:
 		return -ENOTSUP;
@@ -343,15 +345,16 @@ static int ms5637_init(const struct device *dev)
 	}
 
 	/* Store calibration coefficients */
-	data->sens_t1 = prom[MS5637_PROM_C1_IDX];
-	data->off_t1 = prom[MS5637_PROM_C2_IDX];
-	data->tcs = prom[MS5637_PROM_C3_IDX];
-	data->tco = prom[MS5637_PROM_C4_IDX];
-	data->t_ref = prom[MS5637_PROM_C5_IDX];
-	data->tempsens = prom[MS5637_PROM_C6_IDX];
+	data->cal.sens_t1 = prom[MS5637_PROM_C1_IDX];
+	data->cal.off_t1 = prom[MS5637_PROM_C2_IDX];
+	data->cal.tcs = prom[MS5637_PROM_C3_IDX];
+	data->cal.tco = prom[MS5637_PROM_C4_IDX];
+	data->cal.t_ref = prom[MS5637_PROM_C5_IDX];
+	data->cal.tempsens = prom[MS5637_PROM_C6_IDX];
 
-	LOG_DBG("PROM: C1=%u C2=%u C3=%u C4=%u C5=%u C6=%u", data->sens_t1, data->off_t1, data->tcs,
-		data->tco, data->t_ref, data->tempsens);
+	LOG_DBG("PROM: C1=%u C2=%u C3=%u C4=%u C5=%u C6=%u",
+		data->cal.sens_t1, data->cal.off_t1, data->cal.tcs,
+		data->cal.tco, data->cal.t_ref, data->cal.tempsens);
 
 	/* Set default oversampling from devicetree */
 	osr.val1 = cfg->osr_pressure;
@@ -366,6 +369,11 @@ static int ms5637_init(const struct device *dev)
 		return ret;
 	}
 
+#ifdef CONFIG_SENSOR_ASYNC_API
+	data->dev = dev;
+	mpsc_init(&data->io_q);
+#endif
+
 	return 0;
 }
 
@@ -373,14 +381,32 @@ static DEVICE_API(sensor, ms5637_api) = {
 	.attr_set = ms5637_attr_set,
 	.sample_fetch = ms5637_sample_fetch,
 	.channel_get = ms5637_channel_get,
+#ifdef CONFIG_SENSOR_ASYNC_API
+	.submit = ms5637_submit,
+	.get_decoder = ms5637_get_decoder,
+#endif
 };
 
+#ifdef CONFIG_SENSOR_ASYNC_API
+#define MS5637_RTIO_DEFINE(inst)                                                                   \
+	I2C_DT_IODEV_DEFINE(ms5637_iodev_##inst, DT_DRV_INST(inst));                               \
+	RTIO_DEFINE(ms5637_rtio_ctx_##inst, 16, 8)
+#define MS5637_ASYNC_CONFIG(inst)                                                                  \
+	.r         = &ms5637_rtio_ctx_##inst,                                                      \
+	.bus_iodev = &ms5637_iodev_##inst,
+#else
+#define MS5637_RTIO_DEFINE(inst)
+#define MS5637_ASYNC_CONFIG(inst)
+#endif
+
 #define MS5637_INIT(inst)                                                                          \
+	MS5637_RTIO_DEFINE(inst);                                                                  \
 	static struct ms5637_data ms5637_data_##inst;                                              \
 	static const struct ms5637_config ms5637_config_##inst = {                                 \
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.osr_pressure = DT_INST_PROP(inst, osr_press),                                     \
 		.osr_temperature = DT_INST_PROP(inst, osr_temp),                                   \
+		MS5637_ASYNC_CONFIG(inst)                                                          \
 	};                                                                                         \
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, ms5637_init, NULL, &ms5637_data_##inst,                 \
 				     &ms5637_config_##inst, POST_KERNEL,                           \

--- a/drivers/sensor/meas/ms5637/ms5637.h
+++ b/drivers/sensor/meas/ms5637/ms5637.h
@@ -1,5 +1,6 @@
 /*
  * Copyright The Zephyr Project Contributors
+ * Copyright (c) 2026 Alif Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +8,14 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_MS5637_MS5637_H_
 #define ZEPHYR_DRIVERS_SENSOR_MS5637_MS5637_H_
 
+#include <zephyr/drivers/sensor_data_types.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/sys/mpsc_lockfree.h>
+#include <zephyr/kernel.h>
+#ifdef CONFIG_SENSOR_ASYNC_API
+#include <zephyr/rtio/rtio.h>
+#endif
 
 /* I2C commands (MS5637-02BA03 datasheet) */
 #define MS5637_CMD_RESET    0x1EU
@@ -72,20 +79,32 @@ struct ms5637_config {
 	struct i2c_dt_spec bus;
 	uint16_t osr_pressure;
 	uint16_t osr_temperature;
+#ifdef CONFIG_SENSOR_ASYNC_API
+	struct rtio *r;
+	struct rtio_iodev *bus_iodev;
+#endif /* CONFIG_SENSOR_ASYNC_API */
 };
 
-struct ms5637_data {
-	/* PROM calibration coefficients */
+struct ms5637_calibration {
 	uint16_t sens_t1;
 	uint16_t off_t1;
 	uint16_t tcs;
 	uint16_t tco;
 	uint16_t t_ref;
 	uint16_t tempsens;
+};
+
+struct ms5637_reading {
+	int32_t pressure;     /* mbar * 100 (i.e. Pascals) */
+	int32_t temperature;  /* centidegrees Celsius */
+};
+
+struct ms5637_data {
+	/* PROM calibration coefficients */
+	struct ms5637_calibration cal;
 
 	/* Compensated measurement results */
-	int32_t pressure;    /* mbar * 100 (i.e. Pascals) */
-	int32_t temperature; /* centidegrees Celsius */
+	struct ms5637_reading reading;
 
 	/* Active conversion commands */
 	uint8_t pressure_conv_cmd;
@@ -94,6 +113,38 @@ struct ms5637_data {
 	/* Conversion delays in ms */
 	uint8_t pressure_conv_delay;
 	uint8_t temperature_conv_delay;
+
+#ifdef CONFIG_SENSOR_ASYNC_API
+	const struct device *dev;
+	struct k_spinlock mpsc_lock;
+	struct mpsc io_q;
+	struct rtio_iodev_sqe *pending_sqe;
+	/*
+	 * DMA-safe read buffers (must stay valid until callback fires):
+	 *   [0..2] = pressure ADC result (24-bit big-endian)
+	 *   [3..5] = temperature ADC result (24-bit big-endian)
+	 */
+	uint8_t raw_buffer[6];
+#endif /* CONFIG_SENSOR_ASYNC_API */
 };
+
+void ms5637_compensate(const struct ms5637_calibration *calibration,
+		       uint32_t adc_temperature,
+		       uint32_t adc_pressure,
+		       struct ms5637_reading *reading);
+
+#ifdef CONFIG_SENSOR_ASYNC_API
+
+struct ms5637_encoded_data {
+	struct sensor_data_header header;
+	uint32_t adc_pressure;
+	uint32_t adc_temperature;
+	struct ms5637_calibration calibration;
+};
+
+void ms5637_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+int ms5637_get_decoder(const struct device *dev,
+			const struct sensor_decoder_api **decoder);
+#endif /* CONFIG_SENSOR_ASYNC_API */
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_MS5637_MS5637_H_ */

--- a/drivers/sensor/meas/ms5637/ms5637_rtio.c
+++ b/drivers/sensor/meas/ms5637/ms5637_rtio.c
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2026 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT meas_ms5637
+
+#include <stdint.h>
+
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor_clock.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/mpsc_lockfree.h>
+
+#include "ms5637.h"
+
+LOG_MODULE_DECLARE(MS5637, CONFIG_SENSOR_LOG_LEVEL);
+
+#define MS5637_TEMP_SHIFT  16
+#define MS5637_PRESS_SHIFT 16
+
+static void ms5637_start_transfer(struct rtio_iodev_sqe *iodev_sqe,
+				  const struct device *dev);
+
+/* ------------------------------------------------------------------ */
+/* MPSC dispatcher                                                     */
+/* ------------------------------------------------------------------ */
+
+static void ms5637_start_next(const struct device *dev)
+{
+	struct ms5637_data *data = dev->data;
+	k_spinlock_key_t key = k_spin_lock(&data->mpsc_lock);
+
+	if (data->pending_sqe != NULL) {
+		k_spin_unlock(&data->mpsc_lock, key);
+		return;
+	}
+
+	struct mpsc_node *node = mpsc_pop(&data->io_q);
+
+	if (node == NULL) {
+		k_spin_unlock(&data->mpsc_lock, key);
+		return;
+	}
+
+	struct rtio_iodev_sqe *next_sqe = CONTAINER_OF(node, struct rtio_iodev_sqe, q);
+
+	data->pending_sqe = next_sqe;
+	k_spin_unlock(&data->mpsc_lock, key);
+
+	ms5637_start_transfer(next_sqe, dev);
+}
+
+/* ------------------------------------------------------------------ */
+/* Completion callback                                                 */
+/* ------------------------------------------------------------------ */
+
+static void ms5637_complete_cb(struct rtio *r, const struct rtio_sqe *sqe,
+				int res, void *arg)
+{
+	const struct device *dev = arg;
+	struct ms5637_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = sqe->userdata;
+	struct ms5637_encoded_data *edata;
+	uint8_t *buf;
+	uint32_t buf_len;
+	uint64_t cycles;
+	k_spinlock_key_t key;
+	int rc;
+
+	ARG_UNUSED(r);
+
+	if (res < 0) {
+		LOG_ERR("RTIO read failed: %d", res);
+		rtio_iodev_sqe_err(iodev_sqe, res);
+		goto check_next;
+	}
+
+	rc = rtio_sqe_rx_buf(iodev_sqe, sizeof(*edata), sizeof(*edata), &buf, &buf_len);
+	if (rc != 0) {
+		LOG_ERR("rx buf alloc failed: %d", rc);
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		goto check_next;
+	}
+
+	rc = sensor_clock_get_cycles(&cycles);
+	if (rc != 0) {
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		goto check_next;
+	}
+
+	edata = (struct ms5637_encoded_data *)buf;
+	edata->header.base_timestamp_ns = sensor_clock_cycles_to_ns(cycles);
+	edata->header.reading_count = 1U;
+	edata->adc_pressure    = ((uint32_t)data->raw_buffer[0] << 16) |
+				 ((uint32_t)data->raw_buffer[1] << 8) |
+				 (uint32_t)data->raw_buffer[2];
+	edata->adc_temperature = ((uint32_t)data->raw_buffer[3] << 16) |
+				 ((uint32_t)data->raw_buffer[4] << 8) |
+				 (uint32_t)data->raw_buffer[5];
+	edata->calibration = data->cal;
+
+	rtio_iodev_sqe_ok(iodev_sqe, 0);
+
+check_next:
+	{
+		key = k_spin_lock(&data->mpsc_lock);
+		data->pending_sqe = NULL;
+		k_spin_unlock(&data->mpsc_lock, key);
+	}
+	ms5637_start_next(dev);
+}
+
+static void ms5637_prep_conv_chain(struct rtio_sqe *conv,
+				   struct rtio_sqe *delay,
+				   struct rtio_sqe *adc_cmd,
+				   struct rtio_sqe *adc_rd,
+				   struct rtio_iodev *iodev,
+				   const uint8_t *conv_cmd,
+				   uint8_t delay_ms,
+				   uint8_t *raw_buf)
+{
+	rtio_sqe_prep_tiny_write(conv, iodev, RTIO_PRIO_NORM, conv_cmd, 1, NULL);
+	conv->iodev_flags = RTIO_IODEV_I2C_STOP;
+	conv->flags       = RTIO_SQE_CHAINED;
+
+	rtio_sqe_prep_delay(delay, K_MSEC(delay_ms), NULL);
+	delay->flags = RTIO_SQE_CHAINED;
+
+	rtio_sqe_prep_tiny_write(adc_cmd, iodev, RTIO_PRIO_NORM,
+				 (uint8_t[]){MS5637_CMD_READ_ADC}, 1, NULL);
+	adc_cmd->flags = RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_read(adc_rd, iodev, RTIO_PRIO_NORM,
+			   raw_buf, MS5637_ADC_READ_LEN, NULL);
+	adc_rd->iodev_flags = RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	adc_rd->flags       = RTIO_SQE_CHAINED;
+}
+
+/* ------------------------------------------------------------------ */
+/* Build and submit the full 9-SQE chain (no workqueue, no blocking)  */
+/*                                                                     */
+/* p_conv → delay_p → p_adc_cmd → p_adc_rd →                         */
+/* t_conv → delay_t → t_adc_cmd → t_adc_rd → cb                      */
+/* ------------------------------------------------------------------ */
+
+static void ms5637_start_transfer(struct rtio_iodev_sqe *iodev_sqe,
+				  const struct device *dev)
+{
+	struct ms5637_data *data = dev->data;
+	const struct ms5637_config *cfg = dev->config;
+	struct rtio_sqe *p_conv, *delay_p, *p_adc_cmd, *p_adc_rd;
+	struct rtio_sqe *t_conv, *delay_t, *t_adc_cmd, *t_adc_rd, *cb;
+	k_spinlock_key_t key;
+	int rc;
+
+	p_conv    = rtio_sqe_acquire(cfg->r);
+	delay_p   = rtio_sqe_acquire(cfg->r);
+	p_adc_cmd = rtio_sqe_acquire(cfg->r);
+	p_adc_rd  = rtio_sqe_acquire(cfg->r);
+	t_conv    = rtio_sqe_acquire(cfg->r);
+	delay_t   = rtio_sqe_acquire(cfg->r);
+	t_adc_cmd = rtio_sqe_acquire(cfg->r);
+	t_adc_rd  = rtio_sqe_acquire(cfg->r);
+	cb        = rtio_sqe_acquire(cfg->r);
+
+	if (!p_conv || !delay_p || !p_adc_cmd || !p_adc_rd ||
+	    !t_conv || !delay_t || !t_adc_cmd || !t_adc_rd || !cb) {
+		rtio_sqe_drop_all(cfg->r);
+		key = k_spin_lock(&data->mpsc_lock);
+		data->pending_sqe = NULL;
+		k_spin_unlock(&data->mpsc_lock, key);
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		ms5637_start_next(dev);
+		return;
+	}
+
+	/* Pressure: SQEs 1-4 */
+	ms5637_prep_conv_chain(p_conv, delay_p, p_adc_cmd, p_adc_rd,
+			       cfg->bus_iodev,
+			       &data->pressure_conv_cmd,
+			       data->pressure_conv_delay,
+			       &data->raw_buffer[0]);
+
+	/* Temperature: SQEs 5-8 */
+	ms5637_prep_conv_chain(t_conv, delay_t, t_adc_cmd, t_adc_rd,
+			       cfg->bus_iodev,
+			       &data->temperature_conv_cmd,
+			       data->temperature_conv_delay,
+			       &data->raw_buffer[3]);
+
+	/* SQE 9: completion callback */
+	rtio_sqe_prep_callback_no_cqe(cb, ms5637_complete_cb, (void *)dev, iodev_sqe);
+
+	rc = rtio_submit(cfg->r, 0);
+	if (rc < 0) {
+		key = k_spin_lock(&data->mpsc_lock);
+		data->pending_sqe = NULL;
+		k_spin_unlock(&data->mpsc_lock, key);
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		ms5637_start_next(dev);
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* submit                                                              */
+/* ------------------------------------------------------------------ */
+
+static int ms5637_validate_request(const struct sensor_read_config *cfg)
+{
+	if (cfg->is_streaming) {
+		return -ENOTSUP;
+	}
+
+	for (size_t i = 0; i < cfg->count; i++) {
+		if (cfg->channels[i].chan_idx != 0) {
+			return -ENOTSUP;
+		}
+
+		switch (cfg->channels[i].chan_type) {
+		case SENSOR_CHAN_ALL:
+		case SENSOR_CHAN_PRESS:
+		case SENSOR_CHAN_AMBIENT_TEMP:
+			break;
+		default:
+			return -ENOTSUP;
+		}
+	}
+
+	return 0;
+}
+
+void ms5637_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+	struct ms5637_data *data = dev->data;
+	int ret;
+
+	ret = ms5637_validate_request(cfg);
+	if (ret < 0) {
+		rtio_iodev_sqe_err(iodev_sqe, ret);
+		return;
+	}
+
+	mpsc_push(&data->io_q, &iodev_sqe->q);
+
+	ms5637_start_next(dev);
+}
+
+/* ------------------------------------------------------------------ */
+/* Decoder                                                             */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Q31 fixed-point conversions.
+ *
+ * Temperature is in centidegrees C:  q31 = centideg * 2^(31-shift) / 100
+ * Pressure is in Pascals → kPa:      q31 = Pa * 2^(31-shift) / 1000
+ *
+ * Shift is fixed at 16 (Q15.16), giving ±2^15 range with ~0.0015°C
+ * and ~0.015 Pa resolution — sufficient for the MS5637's 24-bit ADC.
+ */
+static q31_t ms5637_centi_to_q31(int32_t val)
+{
+	return (q31_t)(((int64_t)val * (INT64_C(1) << (31 - MS5637_TEMP_SHIFT))) / 100);
+}
+
+static q31_t ms5637_pa_to_kpa_q31(int32_t val)
+{
+	return (q31_t)(((int64_t)val * (INT64_C(1) << (31 - MS5637_PRESS_SHIFT))) / 1000);
+}
+
+static int ms5637_decoder_get_frame_count(const uint8_t *buffer,
+					  struct sensor_chan_spec chan_spec,
+					  uint16_t *frame_count)
+{
+	ARG_UNUSED(buffer);
+
+	if (chan_spec.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_PRESS:
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		*frame_count = 1;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int ms5637_decoder_get_size_info(struct sensor_chan_spec chan_spec,
+					size_t *base_size, size_t *frame_size)
+{
+	if (chan_spec.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_PRESS:
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		*base_size = sizeof(struct sensor_q31_data);
+		*frame_size = sizeof(struct sensor_q31_sample_data);
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int ms5637_decoder_decode(const uint8_t *buffer,
+				 struct sensor_chan_spec chan_spec,
+				 uint32_t *fit, uint16_t max_count, void *data_out)
+{
+	const struct ms5637_encoded_data *edata = (const struct ms5637_encoded_data *)buffer;
+	struct ms5637_reading reading;
+	struct sensor_q31_data *out = data_out;
+
+	if ((max_count == 0U) || (*fit != 0U)) {
+		return 0;
+	}
+	if (chan_spec.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	ms5637_compensate(&edata->calibration, edata->adc_temperature,
+			  edata->adc_pressure, &reading);
+
+	out->header.base_timestamp_ns = edata->header.base_timestamp_ns;
+	out->header.reading_count = 1U;
+	out->readings[0].timestamp_delta = 0U;
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_PRESS:
+		out->shift = MS5637_PRESS_SHIFT;
+		out->readings[0].pressure =
+			ms5637_pa_to_kpa_q31(reading.pressure);
+		break;
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		out->shift = MS5637_TEMP_SHIFT;
+		out->readings[0].temperature =
+			ms5637_centi_to_q31(reading.temperature);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	*fit = 1;
+	return 1;
+}
+
+SENSOR_DECODER_API_DT_DEFINE() = {
+	.get_frame_count = ms5637_decoder_get_frame_count,
+	.get_size_info   = ms5637_decoder_get_size_info,
+	.decode          = ms5637_decoder_decode,
+};
+
+int ms5637_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder)
+{
+	ARG_UNUSED(dev);
+	*decoder = &SENSOR_DECODER_NAME();
+	return 0;
+}


### PR DESCRIPTION
Implement SENSOR_ASYNC_API for the MS5637 driver using RTIO submission chains for non-blocking pressure/temperature reads.

- Add RTIO SQE chain helper (ms5637_prep_conv_chain) to reduce duplication between pressure and temperature paths
- Add sensor data decoder with q31 output format
- Refactor ms5637_compensate to accept calibration struct and output reading pointer, eliminating dependency on the full ms5637_data struct for use in decoder context
- Add Kconfig selections for I2C_RTIO and RTIO_OP_DELAY when SENSOR_ASYNC_API is enabled
- Fix CMakeLists.txt to use CONFIG_SENSOR_ASYNC_API