### PR TITLE
wifi: don't select WIFI_OFFLOAD wrongly

### DIFF
--- a/drivers/wifi/esp_hosted/Kconfig.esp_hosted
+++ b/drivers/wifi/esp_hosted/Kconfig.esp_hosted
@@ -9,7 +9,6 @@ menuconfig WIFI_ESP_HOSTED
 	default y
 	select GPIO
 	select SPI
-	select WIFI_OFFLOAD
 	select WIFI_NM
 	select NANOPB
 	select NANOPB_ENABLE_MALLOC

--- a/drivers/wifi/infineon/Kconfig.airoc
+++ b/drivers/wifi/infineon/Kconfig.airoc
@@ -7,7 +7,6 @@ menuconfig WIFI_AIROC
 	depends on DT_HAS_INFINEON_AIROC_WIFI_ENABLED
 	default y
 	select THREAD_CUSTOM_DATA
-	select WIFI_OFFLOAD
 	select NET_L2_ETHERNET
 	select NET_L2_WIFI_MGMT
 	select GPIO


### PR DESCRIPTION
don't select WIFI_OFFLOAD, when it is a native driver without offloading.