### PR TITLE
kernel: Remove `thread` member from `struct k_work_q`

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4134,6 +4134,12 @@ void k_work_queue_start(struct k_work_q *queue, struct k_thread *thread, k_threa
  */
 void k_work_queue_run(struct k_work_q *queue, const struct k_work_queue_config *cfg);
 
+/** @brief Run system work queue using calling thread
+ *
+ * This will run the work queue forever unless stopped by @ref k_work_queue_stop.
+ */
+void k_sys_work_q_run(void);
+
 /** @brief Access the thread that animates a work queue.
  *
  * This is necessary to grant a work queue thread access to things the work

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4097,7 +4097,7 @@ bool k_work_cancel_sync(struct k_work *work, struct k_work_sync *sync);
  */
 void k_work_queue_init(struct k_work_q *queue);
 
-/** @brief Initialize a work queue.
+/** @brief Initialize a work queue on a new thread.
  *
  * This configures the work queue thread and starts it running.  The function
  * should not be re-invoked on a queue.
@@ -4105,6 +4105,9 @@ void k_work_queue_init(struct k_work_q *queue);
  * @param queue pointer to the queue structure. It must be initialized
  *        in zeroed/bss memory or with @ref k_work_queue_init before
  *        use.
+ *
+ * @param thread pointer to an unused thread structure. A new workqueue thread
+ *        will be created in it.
  *
  * @param stack pointer to the work thread stack area.
  *
@@ -4116,9 +4119,8 @@ void k_work_queue_init(struct k_work_q *queue);
  * NULL if not required, to use the defaults documented in
  * k_work_queue_config.
  */
-void k_work_queue_start(struct k_work_q *queue,
-			k_thread_stack_t *stack, size_t stack_size,
-			int prio, const struct k_work_queue_config *cfg);
+void k_work_queue_start(struct k_work_q *queue, struct k_thread *thread, k_thread_stack_t *stack,
+			size_t stack_size, int prio, const struct k_work_queue_config *cfg);
 
 /** @brief Run work queue using calling thread
  *
@@ -4760,9 +4762,6 @@ struct k_work_q {
 /**
  * @cond INTERNAL_HIDDEN
  */
-	/* The thread that animates the work. */
-	struct k_thread thread;
-
 	/* The thread ID that animates the work. This may be an external thread
 	 * if k_work_queue_run() is used.
 	 */

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -496,6 +496,18 @@ config WORKQUEUE_WORK_TIMEOUT
 	  logged.
 
 menu "System Work Queue Options"
+config SYSTEM_WORKQUEUE_CREATE_THREAD
+	bool "Creates a thread for the system work queue"
+	default y
+	help
+	  If enabled, the system work queue creates it's own thread during
+	  system initialization and starts processing work automatically.
+
+	  If disabled, the application has to call
+	  k_sys_work_q_start_on_current_thread on the thread it wants to use
+	  instead. This can be useful to reuse the main thread for the system
+	  work queue to save memory.
+
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	int "System workqueue stack size"
 	default 4096 if COVERAGE_GCOV || WIFI_NRF70

--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -18,6 +18,7 @@ static K_KERNEL_STACK_DEFINE(sys_work_q_stack,
 			     CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE);
 
 struct k_work_q k_sys_work_q;
+static struct k_thread k_sys_work_q_thread;
 
 static int k_sys_work_q_init(void)
 {
@@ -28,10 +29,9 @@ static int k_sys_work_q_init(void)
 		.work_timeout_ms = CONFIG_SYSTEM_WORKQUEUE_WORK_TIMEOUT_MS,
 	};
 
-	k_work_queue_start(&k_sys_work_q,
-			    sys_work_q_stack,
-			    K_KERNEL_STACK_SIZEOF(sys_work_q_stack),
-			    CONFIG_SYSTEM_WORKQUEUE_PRIORITY, &cfg);
+	k_work_queue_start(&k_sys_work_q, &k_sys_work_q_thread, sys_work_q_stack,
+			   K_KERNEL_STACK_SIZEOF(sys_work_q_stack),
+			   CONFIG_SYSTEM_WORKQUEUE_PRIORITY, &cfg);
 	return 0;
 }
 

--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -14,21 +14,23 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 
+struct k_work_q k_sys_work_q;
+
+static const struct k_work_queue_config cfg = {
+	.name = "sysworkq",
+	.no_yield = IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_NO_YIELD),
+	.essential = true,
+	.work_timeout_ms = CONFIG_SYSTEM_WORKQUEUE_WORK_TIMEOUT_MS,
+};
+
+#ifdef CONFIG_SYSTEM_WORKQUEUE_CREATE_THREAD
+
 static K_KERNEL_STACK_DEFINE(sys_work_q_stack,
 			     CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE);
-
-struct k_work_q k_sys_work_q;
 static struct k_thread k_sys_work_q_thread;
 
 static int k_sys_work_q_init(void)
 {
-	static const struct k_work_queue_config cfg = {
-		.name = "sysworkq",
-		.no_yield = IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_NO_YIELD),
-		.essential = true,
-		.work_timeout_ms = CONFIG_SYSTEM_WORKQUEUE_WORK_TIMEOUT_MS,
-	};
-
 	k_work_queue_start(&k_sys_work_q, &k_sys_work_q_thread, sys_work_q_stack,
 			   K_KERNEL_STACK_SIZEOF(sys_work_q_stack),
 			   CONFIG_SYSTEM_WORKQUEUE_PRIORITY, &cfg);
@@ -36,3 +38,12 @@ static int k_sys_work_q_init(void)
 }
 
 SYS_INIT(k_sys_work_q_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
+#else /* CONFIG_SYSTEM_WORKQUEUE_CREATE_THREAD */
+
+void k_sys_work_q_run(void)
+{
+	k_work_queue_run(&k_sys_work_q, &cfg);
+}
+
+#endif /* CONFIG_SYSTEM_WORKQUEUE_CREATE_THREAD */

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -843,13 +843,11 @@ void k_work_queue_run(struct k_work_q *queue, const struct k_work_queue_config *
 	work_queue_main(queue, NULL, NULL);
 }
 
-void k_work_queue_start(struct k_work_q *queue,
-			k_thread_stack_t *stack,
-			size_t stack_size,
-			int prio,
-			const struct k_work_queue_config *cfg)
+void k_work_queue_start(struct k_work_q *queue, struct k_thread *thread, k_thread_stack_t *stack,
+			size_t stack_size, int prio, const struct k_work_queue_config *cfg)
 {
 	__ASSERT_NO_MSG(queue);
+	__ASSERT_NO_MSG(thread);
 	__ASSERT_NO_MSG(stack);
 	__ASSERT_NO_MSG(!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT));
 
@@ -871,16 +869,15 @@ void k_work_queue_start(struct k_work_q *queue,
 	 */
 	flags_set(&queue->flags, flags);
 
-	(void)k_thread_create(&queue->thread, stack, stack_size,
-			      work_queue_main, queue, NULL, NULL,
-			      prio, 0, K_FOREVER);
+	(void)k_thread_create(thread, stack, stack_size, work_queue_main, queue, NULL, NULL, prio,
+			      0, K_FOREVER);
 
 	if ((cfg != NULL) && (cfg->name != NULL)) {
-		k_thread_name_set(&queue->thread, cfg->name);
+		k_thread_name_set(thread, cfg->name);
 	}
 
 	if ((cfg != NULL) && (cfg->essential)) {
-		queue->thread.base.user_options |= K_ESSENTIAL;
+		thread->base.user_options |= K_ESSENTIAL;
 	}
 
 #if defined(CONFIG_WORKQUEUE_WORK_TIMEOUT)
@@ -891,8 +888,8 @@ void k_work_queue_start(struct k_work_q *queue,
 	}
 #endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 
-	k_thread_start(&queue->thread);
-	queue->thread_id = &queue->thread;
+	queue->thread_id = thread;
+	k_thread_start(thread);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, start, queue);
 }
@@ -955,7 +952,7 @@ int k_work_queue_stop(struct k_work_q *queue, k_timeout_t timeout)
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work_queue, stop, queue, timeout);
 
-	if (z_is_thread_essential(&queue->thread)) {
+	if (z_is_thread_essential(queue->thread_id)) {
 		return -ENOTSUP;
 	}
 

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -323,7 +323,7 @@ static struct bt_ag_tx *bt_ag_tx_alloc(void)
 	 * so if we're in the same workqueue but there are no immediate
 	 * contexts available, there's no chance we'll get one by waiting.
 	 */
-	if (k_current_get() == &k_sys_work_q.thread) {
+	if (k_current_get() == k_sys_work_q.thread_id) {
 		return k_fifo_get(&ag_tx_free, K_NO_WAIT);
 	}
 

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -318,7 +318,7 @@ static void l2cap_br_chan_destroy(struct bt_l2cap_chan *chan)
 	 */
 	struct k_work_q *rtx_work_queue = br_chan->rtx_work.queue;
 
-	if (rtx_work_queue == NULL || k_current_get() != &rtx_work_queue->thread) {
+	if (rtx_work_queue == NULL || k_current_get() != rtx_work_queue->thread_id) {
 		k_work_cancel_delayable_sync(&br_chan->rtx_work, &br_chan->rtx_sync);
 	} else {
 		k_work_cancel_delayable(&br_chan->rtx_work);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -453,7 +453,8 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 	 * syswq, then we cannot suspend and wait. We have to send the
 	 * command from the current context.
 	 */
-	if (!IS_ENABLED(CONFIG_BT_TX_PROCESSOR_THREAD) && k_current_get() == &k_sys_work_q.thread) {
+	if (!IS_ENABLED(CONFIG_BT_TX_PROCESSOR_THREAD) &&
+	    k_current_get() == k_sys_work_q.thread_id) {
 		/* drain the command queue until we get to send the command of interest. */
 		struct net_buf *cmd = NULL;
 
@@ -4673,7 +4674,7 @@ static void rx_work_handler(struct k_work *work)
 k_tid_t bt_testing_tx_tid_get(void)
 {
 	/* We now TX everything from the syswq */
-	return &k_sys_work_q.thread;
+	return k_sys_work_q.thread_id;
 }
 
 #if defined(CONFIG_BT_ISO)

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1366,7 +1366,7 @@ static void l2cap_chan_destroy(struct bt_l2cap_chan *chan)
 	 */
 	struct k_work_q *rtx_work_queue = le_chan->rtx_work.queue;
 
-	if (rtx_work_queue == NULL || k_current_get() != &rtx_work_queue->thread) {
+	if (rtx_work_queue == NULL || k_current_get() != rtx_work_queue->thread_id) {
 		k_work_cancel_delayable_sync(&le_chan->rtx_work, &le_chan->rtx_sync);
 	} else {
 		k_work_cancel_delayable(&le_chan->rtx_work);

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -82,6 +82,7 @@ static uint32_t volatile last_handle_ms;
 
 static K_THREAD_STACK_DEFINE(coophi_stack, STACK_SIZE);
 static struct k_work_q coophi_queue;
+static struct k_thread coophi_queue_thread;
 static struct k_work_q not_start_queue;
 static atomic_t coophi_ctr;
 static inline int coophi_counter(void)
@@ -107,6 +108,7 @@ static inline int coop_counter(struct k_work_q *wq)
 
 static K_THREAD_STACK_DEFINE(preempt_stack, STACK_SIZE);
 static struct k_work_q preempt_queue;
+static struct k_thread preempt_queue_thread;
 static atomic_t preempt_ctr;
 static inline int preempt_counter(void)
 {
@@ -115,6 +117,7 @@ static inline int preempt_counter(void)
 
 static K_THREAD_STACK_DEFINE(invalid_test_stack, STACK_SIZE);
 static struct k_work_q invalid_test_queue;
+static struct k_thread invalid_test_queue_thread;
 
 static atomic_t system_ctr;
 static inline int system_counter(void)
@@ -239,12 +242,12 @@ static void test_queue_start(void)
 	};
 	k_work_queue_init(&preempt_queue);
 	zassert_equal(preempt_queue.flags, 0);
-	k_work_queue_start(&preempt_queue, preempt_stack, STACK_SIZE,
-			    PREEMPT_PRIORITY, &cfg);
+	k_work_queue_start(&preempt_queue, &preempt_queue_thread, preempt_stack, STACK_SIZE,
+			   PREEMPT_PRIORITY, &cfg);
 	zassert_equal(preempt_queue.flags, K_WORK_QUEUE_STARTED);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
-		const char *tn = k_thread_name_get(&preempt_queue.thread);
+		const char *tn = k_thread_name_get(preempt_queue.thread_id);
 
 		zassert_true(tn != cfg.name);
 		zassert_true(tn != NULL);
@@ -253,12 +256,12 @@ static void test_queue_start(void)
 
 	cfg.name = NULL;
 	zassert_equal(invalid_test_queue.flags, 0);
-	k_work_queue_start(&invalid_test_queue, invalid_test_stack, STACK_SIZE,
-			    PREEMPT_PRIORITY, &cfg);
+	k_work_queue_start(&invalid_test_queue, &invalid_test_queue_thread, invalid_test_stack,
+			   STACK_SIZE, PREEMPT_PRIORITY, &cfg);
 	zassert_equal(invalid_test_queue.flags, K_WORK_QUEUE_STARTED);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
-		const char *tn = k_thread_name_get(&invalid_test_queue.thread);
+		const char *tn = k_thread_name_get(invalid_test_queue.thread_id);
 
 		zassert_true(tn != cfg.name);
 		zassert_true(tn != NULL);
@@ -267,8 +270,8 @@ static void test_queue_start(void)
 
 	cfg.name = "wq.coophi";
 	cfg.no_yield = true;
-	k_work_queue_start(&coophi_queue, coophi_stack, STACK_SIZE,
-			    COOPHI_PRIORITY, &cfg);
+	k_work_queue_start(&coophi_queue, &coophi_queue_thread, coophi_stack, STACK_SIZE,
+			   COOPHI_PRIORITY, &cfg);
 	zassert_equal(coophi_queue.flags,
 		      K_WORK_QUEUE_STARTED | K_WORK_QUEUE_NO_YIELD, NULL);
 

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -10,6 +10,17 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/ztest.h>
 
+#ifndef CONFIG_SYSTEM_WORKQUEUE_CREATE_THREAD
+static void custom_system_work_queue_entry(void *dummy1, void *dummy2, void *dummy3)
+{
+	k_sys_work_q_run();
+}
+
+static K_THREAD_DEFINE(custom_system_work_queue_thread, CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE,
+		       custom_system_work_queue_entry, NULL, NULL, NULL,
+		       CONFIG_SYSTEM_WORKQUEUE_PRIORITY, 0, 0);
+#endif
+
 #define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define COOPHI_PRIORITY K_PRIO_COOP(0) /* = -4 */
 /* SYSTEM_WORKQUEUE_PRIORITY = -3 */


### PR DESCRIPTION
I'm working with a target with 8KiB of RAM and needed to do this to be able to use the system work queue.

I changed the API without adjusting all users of it, so the CI will fail. Since that's a lot of work, I'll do that if you agree with this change and the new API.

RFC: https://github.com/zephyrproject-rtos/zephyr/issues/110261

Related:
- #90746
- #21322