### PR TITLE
stm32: drivers: sensor: st: add GPIO Kconfig selection for some sensors

### DIFF
--- a/drivers/sensor/st/hts221/Kconfig
+++ b/drivers/sensor/st/hts221/Kconfig
@@ -8,6 +8,7 @@ menuconfig HTS221
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_HTS221),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_HTS221),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_HTS221),drdy-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_HTS221
 	help

--- a/drivers/sensor/st/iis2dh/Kconfig
+++ b/drivers/sensor/st/iis2dh/Kconfig
@@ -10,6 +10,7 @@ menuconfig IIS2DH
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2DH),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2DH),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2DH),drdy-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_IIS2DH
 	help

--- a/drivers/sensor/st/iis2dlpc/Kconfig
+++ b/drivers/sensor/st/iis2dlpc/Kconfig
@@ -10,6 +10,7 @@ menuconfig IIS2DLPC
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2DLPC),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2DLPC),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2DLPC),drdy-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_IIS2DLPC
 	help

--- a/drivers/sensor/st/iis2iclx/Kconfig
+++ b/drivers/sensor/st/iis2iclx/Kconfig
@@ -10,6 +10,7 @@ menuconfig IIS2ICLX
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2ICLX),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2ICLX),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2ICLX),drdy-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_IIS2ICLX
 	help

--- a/drivers/sensor/st/iis2mdc/Kconfig
+++ b/drivers/sensor/st/iis2mdc/Kconfig
@@ -8,6 +8,7 @@ menuconfig IIS2MDC
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2MDC),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2MDC),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2MDC),drdy-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_IIS2MDC
 	help

--- a/drivers/sensor/st/iis328dq/Kconfig
+++ b/drivers/sensor/st/iis328dq/Kconfig
@@ -11,6 +11,8 @@ menuconfig IIS328DQ
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS328DQ),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS328DQ),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS328DQ),int1-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS328DQ),int2-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_IIS328DQ
 	help

--- a/drivers/sensor/st/iis3dhhc/Kconfig
+++ b/drivers/sensor/st/iis3dhhc/Kconfig
@@ -9,6 +9,7 @@ menuconfig IIS3DHHC
 	depends on DT_HAS_ST_IIS3DHHC_ENABLED
 	depends on ZEPHYR_HAL_ST_MODULE
 	select SPI
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS3DHHC),irq-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_IIS3DHHC
 	help

--- a/drivers/sensor/st/iis3dwb/Kconfig
+++ b/drivers/sensor/st/iis3dwb/Kconfig
@@ -10,6 +10,8 @@ menuconfig IIS3DWB
 	depends on ZEPHYR_HAL_ST_MODULE
 	select SPI
 	select SPI_RTIO if SENSOR_ASYNC_API
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS3DWB),int1-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS3DWB),int2-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_IIS3DWB
 	help

--- a/drivers/sensor/st/ism330dhcx/Kconfig
+++ b/drivers/sensor/st/ism330dhcx/Kconfig
@@ -10,6 +10,7 @@ menuconfig ISM330DHCX
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_ISM330DHCX),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_ISM330DHCX),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_ISM330DHCX),drdy-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_ISM330DHCX
 	help

--- a/drivers/sensor/st/lis2de12/Kconfig
+++ b/drivers/sensor/st/lis2de12/Kconfig
@@ -10,6 +10,8 @@ menuconfig LIS2DE12
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DE12),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DE12),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DE12),int1-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DE12),int2-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_LIS2DE12
 	help

--- a/drivers/sensor/st/lis2dh/Kconfig
+++ b/drivers/sensor/st/lis2dh/Kconfig
@@ -9,6 +9,7 @@ menuconfig LIS2DH
 	depends on DT_HAS_ST_LIS2DH_ENABLED
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DH),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DH),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DH),irq-gpios)
 	help
 	  Enable SPI/I2C-based driver for LIS2DH, LIS3DH, LSM303DLHC,
 	  LIS2DH12, LSM303AGR triaxial accelerometer sensors.

--- a/drivers/sensor/st/lis2ds12/Kconfig
+++ b/drivers/sensor/st/lis2ds12/Kconfig
@@ -10,6 +10,7 @@ menuconfig LIS2DS12
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DS12),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DS12),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DS12),irq-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_LIS2DS12
 	help

--- a/drivers/sensor/st/lis2du12/Kconfig
+++ b/drivers/sensor/st/lis2du12/Kconfig
@@ -10,6 +10,8 @@ menuconfig LIS2DU12
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DU12),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DU12),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DU12),int1-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DU12),int2-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_LIS2DU12
 	help

--- a/drivers/sensor/st/lis2dux12/Kconfig
+++ b/drivers/sensor/st/lis2dux12/Kconfig
@@ -12,6 +12,10 @@ menuconfig LIS2DUX12
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DUXS12),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DUX12),spi) || \
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DUXS12),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DUX12),int1-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DUX12),int2-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DUXS12),int1-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DUXS12),int2-gpios)
 
 	select I2C_RTIO if I2C && SENSOR_ASYNC_API
 	select SPI_RTIO if SPI && SENSOR_ASYNC_API

--- a/drivers/sensor/st/lis2dw12/Kconfig
+++ b/drivers/sensor/st/lis2dw12/Kconfig
@@ -10,6 +10,7 @@ menuconfig LIS2DW12
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DW12),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DW12),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DW12),irq-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_LIS2DW12
 	help

--- a/drivers/sensor/st/lis2mdl/Kconfig
+++ b/drivers/sensor/st/lis2mdl/Kconfig
@@ -8,6 +8,7 @@ menuconfig LIS2MDL
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2MDL),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2MDL),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2MDL),irq-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_LIS2MDL
 	help

--- a/drivers/sensor/st/lis3mdl/Kconfig
+++ b/drivers/sensor/st/lis3mdl/Kconfig
@@ -6,6 +6,7 @@ menuconfig LIS3MDL
 	default y
 	depends on DT_HAS_ST_LIS3MDL_MAGN_ENABLED
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS3MDL_MAGN),irq-gpios)
 	help
 	  Enable driver for LIS3MDL I2C-based magnetometer.
 

--- a/drivers/sensor/st/lps22hh/Kconfig
+++ b/drivers/sensor/st/lps22hh/Kconfig
@@ -11,6 +11,7 @@ menuconfig LPS22HH
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HH),i2c)
 	select I3C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HH),i3c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HH),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LPS22HH),drdy-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_LPS22HH
 	help

--- a/drivers/sensor/st/lps2xdf/Kconfig
+++ b/drivers/sensor/st/lps2xdf/Kconfig
@@ -18,6 +18,8 @@ menuconfig LPS2XDF
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS28DFW),i3c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22DF),spi) ||\
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_ILPS22QS),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LPS22DF),drdy-gpios) ||\
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LPS28DFW),drdy-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_ILPS22QS if DT_HAS_ST_ILPS22QS_ENABLED
 	select USE_STDC_LPS22DF if DT_HAS_ST_LPS22DF_ENABLED

--- a/drivers/sensor/st/lsm6dsl/Kconfig
+++ b/drivers/sensor/st/lsm6dsl/Kconfig
@@ -10,6 +10,7 @@ menuconfig LSM6DSL
 	depends on DT_HAS_ST_LSM6DSL_ENABLED
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSL),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSL),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSL),irq-gpios)
 	help
 	  Enable driver for LSM6DSL accelerometer and gyroscope
 	  sensor.

--- a/drivers/sensor/st/lsm6dso/Kconfig
+++ b/drivers/sensor/st/lsm6dso/Kconfig
@@ -12,6 +12,8 @@ menuconfig LSM6DSO
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO32),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO),spi) || \
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO32),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSO),irq-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSO32),irq-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_LSM6DSO
 	help

--- a/drivers/sensor/st/lsm6dso16is/Kconfig
+++ b/drivers/sensor/st/lsm6dso16is/Kconfig
@@ -10,6 +10,7 @@ menuconfig LSM6DSO16IS
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO16IS),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO16IS),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSO16IS),irq-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_LSM6DSO16IS
 	help

--- a/drivers/sensor/st/lsm6dsv16x/Kconfig
+++ b/drivers/sensor/st/lsm6dsv16x/Kconfig
@@ -14,6 +14,10 @@ menuconfig LSM6DSV16X
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSV32X),i3c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSV16X),spi) ||\
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSV32X),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV16X),int1-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV16X),int2-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV32X),int1-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV32X),int2-gpios)
 
 	select I2C_RTIO if I2C && SENSOR_ASYNC_API
 	select I3C_RTIO if I3C && SENSOR_ASYNC_API

--- a/drivers/sensor/st/lsm6dsvxxx/Kconfig
+++ b/drivers/sensor/st/lsm6dsvxxx/Kconfig
@@ -18,6 +18,12 @@ menuconfig LSM6DSVXXX
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSV320X),spi) ||\
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSV80X),spi) ||\
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_ISM6HG256X),spi)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV320X),int1-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV320X),int2-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV80X),int1-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV80X),int2-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_ISM6HG256X),int1-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_ISM6HG256X),int2-gpios)
 
 	select I2C_RTIO if I2C && SENSOR_ASYNC_API
 	select I3C_RTIO if I3C && SENSOR_ASYNC_API

--- a/drivers/sensor/st/lsm9ds0_gyro/Kconfig
+++ b/drivers/sensor/st/lsm9ds0_gyro/Kconfig
@@ -8,6 +8,7 @@ menuconfig LSM9DS0_GYRO
 	default y
 	depends on DT_HAS_ST_LSM9DS0_GYRO_ENABLED
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM9DS0_GYRO),irq-gpios)
 	help
 	  Enable driver for LSM9DS0 I2C-based gyroscope sensor.
 

--- a/drivers/sensor/st/lsm9ds0_mfd/Kconfig
+++ b/drivers/sensor/st/lsm9ds0_mfd/Kconfig
@@ -8,6 +8,7 @@ menuconfig LSM9DS0_MFD
 	default y
 	depends on DT_HAS_ST_LSM9DS0_MFD_ENABLED
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM9DS0_MFD),irq-gpios)
 	help
 	  Enable driver for LSM9DS0 I2C-based MFD sensor.
 

--- a/drivers/sensor/st/stts22h/Kconfig
+++ b/drivers/sensor/st/stts22h/Kconfig
@@ -9,6 +9,7 @@ menuconfig STTS22H
 	depends on DT_HAS_ST_STTS22H_ENABLED
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STTS22H),int-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_STTS22H
 	help

--- a/drivers/sensor/st/stts751/Kconfig
+++ b/drivers/sensor/st/stts751/Kconfig
@@ -9,6 +9,7 @@ menuconfig STTS751
 	depends on DT_HAS_ST_STTS751_ENABLED
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STTS751),drdy-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_STTS751
 	help

--- a/drivers/sensor/st/vl53l0x/Kconfig
+++ b/drivers/sensor/st/vl53l0x/Kconfig
@@ -9,6 +9,7 @@ menuconfig VL53L0X
 	depends on DT_HAS_ST_VL53L0X_ENABLED
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_VL53L0X),xshut-gpios)
 	select HAS_STLIB
 	help
 	  Enable driver for VL53L0X I2C-based time of flight sensor.

--- a/drivers/sensor/st/vl53l1x/Kconfig
+++ b/drivers/sensor/st/vl53l1x/Kconfig
@@ -9,6 +9,8 @@ menuconfig VL53L1X
 	depends on DT_HAS_ST_VL53L1X_ENABLED
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_VL53L1X),xshut-gpios) || \
+		       $(dt_compat_any_has_prop,$(DT_COMPAT_ST_VL53L1X),int-gpios)
 	select HAS_STLIB
 	help
 	  Enable driver for VL53L1X I2C-based time of flight sensor.


### PR DESCRIPTION
This PR aligns ST sensor Kconfig GPIO dependencies with Devicetree bindings by adding conditional GPIO selects where the bindings expose *-gpios properties. This is helpful when applications and drivers that use the GPIO API do not enable it first, as you can see below :

```
[00:00:00.042,000] <err> stm32_gpioport_mgr: Attempting to use GPIO API without enabling it!
[00:00:00.042,000] <err> VL53L0X: [vl53l0x@29] Unable to inactivate XSHUT: -88
```

It follows this PR: https://github.com/zephyrproject-rtos/zephyr/pull/109468, which disables CONFIG_GPIO by default on almost all defconfig boards.

This PR: https://github.com/zephyrproject-rtos/zephyr/pull/110017 helps highlight this situation.
