### PR TITLE
drivers: ethernet: phy: lan8742: handle EALREADY properly

### DIFF
--- a/drivers/ethernet/phy/phy_microchip_lan8742.c
+++ b/drivers/ethernet/phy/phy_microchip_lan8742.c
@@ -409,9 +409,9 @@ static int phy_lan8742_init(const struct device *dev)
 
 	/* Advertise default speeds */
 	ret = phy_lan8742_cfg_link(dev, cfg->default_speeds, 0);
-	if (ret < 0) {
-		LOG_ERR("Failed to configure link (%d)", ret);
-		return ret;
+	if (ret == -EALREADY) {
+		data->autoneg_in_progress = true;
+		data->autoneg_timeout = sys_timepoint_calc(K_MSEC(CONFIG_PHY_AUTONEG_TIMEOUT_MS));
 	}
 
 	/* Schedule the monitor work, if not already scheduled by phy_lan8742_cfg_link(). */


### PR DESCRIPTION
As it is done in phy_mii.c, set autoneg_in_progress for already on init.
If not done, the PHY will just fall in error at init time.