### PR TITLE
MAINTAINERS: Add Logging collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3647,6 +3647,7 @@ Logging:
     - nordic-krch
   collaborators:
     - dcpleung
+    - ldab
   files:
     - include/zephyr/logging/
     - include/zephyr/sys/mpsc_pbuf.h


### PR DESCRIPTION
Add ldab as a collaborator for the logging subsystem, we are working on adding COBS or encoding to dictionary logging.

open PRs:

https://github.com/zephyrproject-rtos/zephyr/pull/109221
https://github.com/zephyrproject-rtos/zephyr/pull/109148
https://github.com/zephyrproject-rtos/zephyr/pull/109136

This merged from the team:
#92197
#93107
#94644
#106638
#94324
#97267