### PR TITLE
STM32 SPI: rework FIFO usage

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -361,6 +361,10 @@ SPI
   They are replaced by ``SPI_SILABS_SIWX91X_GSPI_DMA_DESCR_COUNT`` which allow to enable DMA and
   configure the descriptor count.
 
+* The ``fifo-enable`` property of :dtcompatible:`st,stm32h7-spi` has been removed.
+  FIFO is now always used in polling and interrupt mode to enhance performance. A new property
+  ``st,fifo-threshold`` can be used to configure the FIFO threshold (default = 1). (:github:`110265`)
+
 Stepper
 =======
 

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1792,7 +1792,7 @@ static int wait_dma_rx_tx_done(const struct device *dev)
 			return -EIO;
 		}
 
-		if ((data->status_flags & SPI_STM32_DMA_DONE_FLAG) != 0U) {
+		if ((data->status_flags & SPI_STM32_DMA_DONE_FLAG) == SPI_STM32_DMA_DONE_FLAG) {
 			return 0;
 		}
 	}

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -357,10 +357,8 @@ static void spi_rtio_dma_complete_transaction(const struct device *dev)
 		LL_SPI_ClearFlag_EOT(cfg->spi);
 	}
 	/* Clear the interrupt flags */
-	if (cfg->fifo_enabled) {
-		LL_SPI_ClearFlag_TXTF(cfg->spi);
-		LL_SPI_ClearFlag_OVR(cfg->spi);
-	}
+	LL_SPI_ClearFlag_TXTF(cfg->spi);
+	LL_SPI_ClearFlag_OVR(cfg->spi);
 #else
 	LL_SPI_DisableDMAReq_TX(cfg->spi);
 	LL_SPI_DisableDMAReq_RX(cfg->spi);
@@ -774,32 +772,31 @@ static int spi_stm32_shift_fifo(SPI_TypeDef *spi, struct spi_stm32_data *data)
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 /* Shift a SPI frame as master. */
-static int spi_stm32_shift_m(const struct spi_stm32_config *cfg, struct spi_stm32_data *data)
+static int spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
-	if (cfg->fifo_enabled) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		return spi_stm32_shift_fifo(cfg->spi, data);
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-	} else {
-		uint32_t transfer_dir = ll_get_transfer_direction(cfg->spi);
+	return spi_stm32_shift_fifo(spi, data);
+#else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+	uint32_t transfer_dir = ll_get_transfer_direction(spi);
 
-		if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX) {
-			while (!ll_tx_is_not_full(cfg->spi)) {
-				/* NOP */
-			}
-
-			spi_stm32_send_next_frame(cfg->spi, data, 0U);
+	if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX) {
+		while (!ll_tx_is_not_full(spi)) {
+			/* NOP */
 		}
 
-		if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX) {
-			while (!ll_rx_is_not_empty(cfg->spi)) {
-				/* NOP */
-			}
-
-			spi_stm32_read_next_frame(cfg->spi, data, 0U);
-		}
+		spi_stm32_send_next_frame(spi, data, 0U);
 	}
+
+	if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX) {
+		while (!ll_rx_is_not_empty(spi)) {
+			/* NOP */
+		}
+
+		spi_stm32_read_next_frame(spi, data, 0U);
+	}
+
 	return 0;
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 }
 
 /* Shift a SPI frame as slave. */
@@ -824,21 +821,21 @@ static void spi_stm32_shift_s(SPI_TypeDef *spi, struct spi_stm32_data *data)
  * Without a FIFO, we can only shift out one frame's worth of SPI
  * data, and read the response back.
  */
-static int spi_stm32_shift_frames(const struct spi_stm32_config *cfg, struct spi_stm32_data *data)
+static int spi_stm32_shift_frames(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
 	spi_operation_t operation = data->ctx.config->operation;
 	int ret;
 
 	if (SPI_OP_MODE_GET(operation) == SPI_OP_MODE_MASTER) {
-		ret = spi_stm32_shift_m(cfg, data);
+		ret = spi_stm32_shift_m(spi, data);
 		if (ret != 0) {
 			return ret;
 		}
 	} else {
-		spi_stm32_shift_s(cfg->spi, data);
+		spi_stm32_shift_s(spi, data);
 	}
 
-	return spi_stm32_get_err(cfg->spi);
+	return spi_stm32_get_err(spi);
 }
 
 static void spi_stm32_cs_control(const struct device *dev, bool on __maybe_unused)
@@ -903,10 +900,8 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	if (cfg->fifo_enabled) {
-		LL_SPI_EnableIT_EOT(spi);
-		LL_SPI_EnableIT_DXP(spi);
-	}
+	LL_SPI_EnableIT_EOT(spi);
+	LL_SPI_EnableIT_DXP(spi);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	ll_enable_int_errors(spi);
 	ll_enable_int_rx_not_empty(spi);
@@ -963,7 +958,7 @@ static void spi_stm32_iodev_msg_start(const struct device *dev, struct spi_confi
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 
-	if (cfg->fifo_enabled && SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
+	if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
 		if (LL_SPI_IsEnabled(spi)) {
 			/* SPI needs to be disabled to set the transfer size */
 			ll_disable_spi(spi);
@@ -1141,10 +1136,8 @@ static void spi_stm32_complete(const struct device *dev, int status)
 #ifdef CONFIG_SPI_RTIO
 	if (data->rtio_ctx->txn_head != NULL) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		if (cfg->fifo_enabled) {
-			LL_SPI_ClearFlag_TXTF(spi);
-			LL_SPI_ClearFlag_OVR(spi);
-		}
+		LL_SPI_ClearFlag_TXTF(spi);
+		LL_SPI_ClearFlag_OVR(spi);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 		spi_stm32_iodev_complete(dev, status);
 		return;
@@ -1157,10 +1150,8 @@ static void spi_stm32_complete(const struct device *dev, int status)
 	ll_disable_int_errors(spi);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	if (cfg->fifo_enabled) {
-		LL_SPI_DisableIT_EOT(spi);
-		LL_SPI_DisableIT_DXP(spi);
-	}
+	LL_SPI_DisableIT_EOT(spi);
+	LL_SPI_DisableIT_DXP(spi);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 #endif /* CONFIG_SPI_STM32_INTERRUPT */
@@ -1200,16 +1191,10 @@ static void spi_stm32_complete(const struct device *dev, int status)
 	}
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	uint32_t transfer_dir = ll_get_transfer_direction(spi);
-
-	if (cfg->fifo_enabled) {
-		LL_SPI_ClearFlag_TXTF(spi);
-		LL_SPI_ClearFlag_OVR(spi);
-		LL_SPI_ClearFlag_EOT(spi);
-		LL_SPI_SetTransferSize(spi, 0);
-	} else if (transfer_dir == STM32_SPI_HALF_DUPLEX_RX) {
-		LL_SPI_SetTransferSize(spi, 0);
-	}
+	LL_SPI_ClearFlag_TXTF(spi);
+	LL_SPI_ClearFlag_OVR(spi);
+	LL_SPI_ClearFlag_EOT(spi);
+	LL_SPI_SetTransferSize(spi, 0);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 #ifdef CONFIG_SPI_SLAVE
@@ -1257,12 +1242,9 @@ static void spi_stm32_isr(const struct device *dev)
 #endif /* CONFIG_SPI_RTIO */
 
 	/* Some spurious interrupts are triggered when SPI is not enabled; ignore them.
-	 * Do it only when fifo is enabled to leave non-fifo functionality untouched for now
 	 */
-	if (cfg->fifo_enabled) {
-		if (!LL_SPI_IsEnabled(spi)) {
-			return;
-		}
+	if (!LL_SPI_IsEnabled(spi)) {
+		return;
 	}
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) && defined(CONFIG_SPI_RTIO) &&                       \
@@ -1281,7 +1263,7 @@ static void spi_stm32_isr(const struct device *dev)
 	}
 
 	if (spi_stm32_transfer_ongoing(data)) {
-		err = spi_stm32_shift_frames(cfg, data);
+		err = spi_stm32_shift_frames(spi, data);
 		if (err) {
 			spi_stm32_complete(dev, err);
 			return;
@@ -1470,7 +1452,7 @@ static int spi_stm32_configure(const struct device *dev,
 	use_dma = (data->dma_tx.dma_dev != NULL) && (data->dma_rx.dma_dev != NULL);
 #endif /* CONFIG_SPI_STM32_DMA */
 
-	if (cfg->fifo_enabled && !use_dma) {
+	if (!use_dma) {
 		/* Configure the FIFO threshold if not using DMA */
 		/* Do not use bits2bytes here, we want to get 3 for 24-bit operation */
 		uint8_t dfs = DIV_ROUND_UP(SPI_WORD_SIZE_GET(config->operation), 8U);
@@ -1649,9 +1631,7 @@ static int spi_stm32_half_duplex_switch_to_receive(const struct spi_stm32_config
 
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		if (cfg->fifo_enabled) {
-			LL_SPI_EnableIT_EOT(spi);
-		}
+		LL_SPI_EnableIT_EOT(spi);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 		ll_enable_int_errors(spi);
@@ -1707,7 +1687,7 @@ static int transceive(const struct device *dev,
 	uint32_t transfer_dir = ll_get_transfer_direction(spi);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	if (cfg->fifo_enabled && SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
+	if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
 		ret = spi_stm32_set_transfer_size(dev, config, tx_bufs, rx_bufs);
 		if (ret != 0) {
 			goto end;
@@ -1730,7 +1710,7 @@ static int transceive(const struct device *dev,
 		 transfer_dir != STM32_SPI_FULL_DUPLEX);
 #else /* CONFIG_SPI_STM32_INTERRUPT */
 	while (ret == 0 && spi_stm32_transfer_ongoing(data)) {
-		ret = spi_stm32_shift_frames(cfg, data);
+		ret = spi_stm32_shift_frames(spi, data);
 
 		if (ret == 0 && transfer_dir == STM32_SPI_HALF_DUPLEX_TX) {
 			ret = spi_stm32_half_duplex_switch_to_receive(cfg, data);
@@ -1960,7 +1940,7 @@ static void dma_callback_sync(const struct device *spi_dev, uint32_t channel, in
 #endif /* SPI_SR_FTLVL */
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		if (cfg->fifo_enabled && !LL_SPI_IsActiveFlag_EOT(cfg->spi)) {
+		if (!LL_SPI_IsActiveFlag_EOT(cfg->spi)) {
 			LL_SPI_EnableIT_EOT(cfg->spi);
 			return;
 		}
@@ -2389,10 +2369,6 @@ static int spi_stm32_init(const struct device *dev)
 #define SPI_DMA_STATUS_SEM(id)
 #endif /* CONFIG_SPI_STM32_DMA */
 
-#define SPI_SUPPORTS_FIFO(id)	DT_INST_NODE_HAS_PROP(id, fifo_enable)
-#define SPI_GET_FIFO_PROP(id)	DT_INST_PROP(id, fifo_enable)
-#define SPI_FIFO_ENABLED(id)	COND_CODE_1(SPI_SUPPORTS_FIFO(id), (SPI_GET_FIFO_PROP(id)), (0))
-
 #define SPI_STM32_CHECK_FIFO(id)								\
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi),					\
 		(BUILD_ASSERT(DT_INST_PROP(id, st_fifo_threshold) <= DT_INST_PROP(id, fifo_size),\
@@ -2415,7 +2391,6 @@ static int spi_stm32_init(const struct device *dev)
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),			\
 		.datawidth = CONCAT(STM32_SPI_DATA_WIDTH_,			\
 			DT_INST_STRING_UPPER_TOKEN(id, st_spi_data_width)),	\
-		.fifo_enabled = SPI_FIFO_ENABLED(id),				\
 		.ioswp = DT_INST_PROP(id, ioswp),				\
 		STM32_SPI_IRQ_HANDLER_FUNC(id)					\
 		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz),	\

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -597,7 +597,8 @@ static void spi_stm32_dma_rx_done(const struct device *dev, const struct spi_con
 /* Value to shift out when no application data needs transmitting. */
 #define SPI_STM32_TX_NOP 0x00
 
-static uint8_t spi_stm32_send_next_frame(SPI_TypeDef *spi, struct spi_stm32_data *data)
+static uint8_t spi_stm32_send_next_frame(SPI_TypeDef *spi, struct spi_stm32_data *data,
+					 uint8_t fifo_space)
 {
 	const uint8_t dfs = bits2bytes(data->ctx.config->operation);
 	uint32_t tx_frame = SPI_STM32_TX_NOP;
@@ -605,8 +606,8 @@ static uint8_t spi_stm32_send_next_frame(SPI_TypeDef *spi, struct spi_stm32_data
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (dfs == 4U ||
-	    (dfs == 2U && data->fifo_threshold >= 2U && data->tx_len >= 2) ||
-	    (dfs == 1U && data->fifo_threshold >= 4U && data->tx_len >= 4)) {
+	    (dfs == 2U && fifo_space >= 2U && data->ctx.tx_len >= 2) ||
+	    (dfs == 1U && fifo_space >= 4U && data->ctx.tx_len >= 4)) {
 		if (spi_context_tx_buf_on(&data->ctx)) {
 			tx_frame = UNALIGNED_GET((uint32_t *)(data->ctx.tx_buf));
 		}
@@ -615,7 +616,7 @@ static uint8_t spi_stm32_send_next_frame(SPI_TypeDef *spi, struct spi_stm32_data
 	} else {
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 		if (dfs == 2U ||
-		    (dfs == 1U && data->fifo_threshold >= 2U && data->tx_len >= 2)) {
+		    (dfs == 1U && fifo_space >= 2U && data->ctx.tx_len >= 2)) {
 			if (spi_context_tx_buf_on(&data->ctx)) {
 				tx_frame = UNALIGNED_GET((uint16_t *)(data->ctx.tx_buf));
 			}
@@ -632,11 +633,14 @@ static uint8_t spi_stm32_send_next_frame(SPI_TypeDef *spi, struct spi_stm32_data
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
-	spi_context_update_tx(&data->ctx, dfs, len);
+	if (spi_context_tx_on(&data->ctx)) {
+		spi_context_update_tx(&data->ctx, dfs, len);
+	}
 	return len;
 }
 
-static uint8_t spi_stm32_read_next_frame(SPI_TypeDef *spi, struct spi_stm32_data *data)
+static uint8_t spi_stm32_read_next_frame(SPI_TypeDef *spi, struct spi_stm32_data *data,
+					 uint8_t fifo_space)
 {
 	const uint8_t dfs = bits2bytes(data->ctx.config->operation);
 	uint32_t rx_frame = 0;
@@ -644,8 +648,8 @@ static uint8_t spi_stm32_read_next_frame(SPI_TypeDef *spi, struct spi_stm32_data
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (dfs == 4U ||
-	    (dfs == 2U && data->fifo_threshold >= 2U && data->rx_len >= 2) ||
-	    (dfs == 1U && data->fifo_threshold >= 4U && data->rx_len >= 4)) {
+	    (dfs == 2U && fifo_space >= 2U && data->ctx.rx_len >= 2) ||
+	    (dfs == 1U && fifo_space >= 4U && data->ctx.rx_len >= 4)) {
 		rx_frame = LL_SPI_ReceiveData32(spi);
 		if (spi_context_rx_buf_on(&data->ctx)) {
 			UNALIGNED_PUT(rx_frame, (uint32_t *)data->ctx.rx_buf);
@@ -654,7 +658,7 @@ static uint8_t spi_stm32_read_next_frame(SPI_TypeDef *spi, struct spi_stm32_data
 	} else {
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 		if (dfs == 2U ||
-		    (dfs == 1U && data->fifo_threshold >= 2U && data->rx_len >= 2)) {
+		    (dfs == 1U && fifo_space >= 2U && data->ctx.rx_len >= 2)) {
 			rx_frame = LL_SPI_ReceiveData16(spi);
 			if (spi_context_rx_buf_on(&data->ctx)) {
 				UNALIGNED_PUT(rx_frame, (uint16_t *)data->ctx.rx_buf);
@@ -671,7 +675,9 @@ static uint8_t spi_stm32_read_next_frame(SPI_TypeDef *spi, struct spi_stm32_data
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
-	spi_context_update_rx(&data->ctx, dfs, len);
+	if (spi_context_rx_on(&data->ctx)) {
+		spi_context_update_rx(&data->ctx, dfs, len);
+	}
 	return len;
 }
 
@@ -702,30 +708,29 @@ static int spi_stm32_get_err(SPI_TypeDef *spi)
 static void spi_stm32_send_fifo(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
 	uint8_t nb_sent;
-	uint8_t nb_fifo = 0U;
+	uint8_t fifo_space = data->fifo_threshold;
 
 	do {
-		nb_sent = spi_stm32_send_next_frame(spi, data);
+		nb_sent = spi_stm32_send_next_frame(spi, data, fifo_space);
 		data->tx_len -= nb_sent;
-		nb_fifo += nb_sent;
-	} while (nb_fifo < data->fifo_threshold && data->tx_len);
+		fifo_space -= nb_sent;
+	} while (fifo_space > 0U && data->tx_len > 0U);
 }
 
 static void spi_stm32_read_fifo(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
 	uint8_t nb_read;
-	uint8_t nb_fifo = 0U;
+	uint8_t fifo_space = data->fifo_threshold;
 
 	do {
-		nb_read = spi_stm32_read_next_frame(spi, data);
+		nb_read = spi_stm32_read_next_frame(spi, data, fifo_space);
 		data->rx_len -= nb_read;
-		nb_fifo += nb_read;
-	} while (nb_fifo < data->fifo_threshold && data->rx_len);
+		fifo_space -= nb_read;
+	} while (fifo_space > 0U && data->rx_len > 0U);
 }
 
-static int spi_stm32_shift_fifo(const struct spi_stm32_config *cfg, struct spi_stm32_data *data)
+static int spi_stm32_shift_fifo(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
-	SPI_TypeDef *spi = cfg->spi;
 	uint32_t transfer_dir = ll_get_transfer_direction(spi);
 
 	if (transfer_dir == STM32_SPI_FULL_DUPLEX && LL_SPI_IsActiveFlag_DXP(spi) &&
@@ -761,29 +766,7 @@ static int spi_stm32_shift_fifo(const struct spi_stm32_config *cfg, struct spi_s
 			/* Some data may remain in the RxFIFO at the end of transfer if transfer
 			 * size is not a multiple of FIFO threshold. Read them here.
 			 */
-			data->rx_len -= spi_stm32_read_next_frame(spi, data);
-		}
-		data->tx_len = data->rx_len = spi_context_max_continuous_chunk(&data->ctx);
-		if (data->tx_len != 0U) {
-			/* If another transfer should take place, set the new transfer size.
-			 * SPI instance should be disabled to change the TSIZE register.
-			 */
-			LL_SPI_ClearFlag_TXTF(spi);
-			LL_SPI_ClearFlag_EOT(spi);
-			ll_disable_spi(spi);
-			if (data->tx_len > cfg->fifo_max_transfer_size) {
-				LOG_ERR("Buffer size exceeds maximal supported value");
-				return -EINVAL;
-			}
-			LL_SPI_SetTransferSize(spi, data->tx_len);
-			LL_SPI_Enable(spi);
-			LL_SPI_StartMasterTransfer(spi);
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-			/* These flags are cleared when TXTF is set. Set them again. */
-			LL_SPI_EnableIT_DXP(spi);
-			LL_SPI_EnableIT_TXP(spi);
-#endif /* CONFIG_SPI_STM32_INTERRUPT */
-			spi_stm32_send_fifo(spi, data);
+			data->rx_len -= spi_stm32_read_next_frame(spi, data, 0U);
 		}
 	}
 	return 0;
@@ -795,7 +778,7 @@ static int spi_stm32_shift_m(const struct spi_stm32_config *cfg, struct spi_stm3
 {
 	if (cfg->fifo_enabled) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		return spi_stm32_shift_fifo(cfg, data);
+		return spi_stm32_shift_fifo(cfg->spi, data);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	} else {
 		uint32_t transfer_dir = ll_get_transfer_direction(cfg->spi);
@@ -805,7 +788,7 @@ static int spi_stm32_shift_m(const struct spi_stm32_config *cfg, struct spi_stm3
 				/* NOP */
 			}
 
-			spi_stm32_send_next_frame(cfg->spi, data);
+			spi_stm32_send_next_frame(cfg->spi, data, 0U);
 		}
 
 		if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX) {
@@ -813,7 +796,7 @@ static int spi_stm32_shift_m(const struct spi_stm32_config *cfg, struct spi_stm3
 				/* NOP */
 			}
 
-			spi_stm32_read_next_frame(cfg->spi, data);
+			spi_stm32_read_next_frame(cfg->spi, data, 0U);
 		}
 	}
 	return 0;
@@ -822,15 +805,19 @@ static int spi_stm32_shift_m(const struct spi_stm32_config *cfg, struct spi_stm3
 /* Shift a SPI frame as slave. */
 static void spi_stm32_shift_s(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+	spi_stm32_shift_fifo(spi, data);
+#else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	if (ll_tx_is_not_full(spi) && spi_context_tx_on(&data->ctx)) {
-		spi_stm32_send_next_frame(spi, data);
+		spi_stm32_send_next_frame(spi, data, 0U);
 	} else {
 		ll_disable_int_tx_empty(spi);
 	}
 
 	if (ll_rx_is_not_empty(spi) && spi_context_rx_buf_on(&data->ctx)) {
-		spi_stm32_read_next_frame(spi, data);
+		spi_stm32_read_next_frame(spi, data, 0U);
 	}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 }
 
 /*
@@ -922,11 +909,7 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	ll_enable_int_errors(spi);
-
-	if (!is_rx_empty) {
-		ll_enable_int_rx_not_empty(spi);
-	}
-
+	ll_enable_int_rx_not_empty(spi);
 	ll_enable_int_tx_empty(spi);
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
@@ -1492,8 +1475,7 @@ static int spi_stm32_configure(const struct device *dev,
 		/* Do not use bits2bytes here, we want to get 3 for 24-bit operation */
 		uint8_t dfs = DIV_ROUND_UP(SPI_WORD_SIZE_GET(config->operation), 8U);
 
-		/* FIFO threshold should not exceed half the FIFO size */
-		data->fifo_threshold = cfg->fifo_size / (dfs * 2U);
+		data->fifo_threshold = MAX(1, cfg->fifo_byte_threshold / dfs);
 	} else {
 		/* When using DMA, set the threshold to 1. A higher value doesn't bring better
 		 * performance, and is complicated to handle without using the TSIZE register.
@@ -1575,7 +1557,12 @@ static int32_t spi_stm32_set_transfer_size(const struct device *dev,
 	int32_t frames;
 
 	if (transfer_dir == STM32_SPI_FULL_DUPLEX) {
-		frames = spi_context_max_continuous_chunk(&data->ctx);
+#ifdef CONFIG_SPI_RTIO
+		frames = spi_context_longest_current_buf(&data->ctx);
+#else /* CONFIG_SPI_RTIO*/
+		frames = MAX(spi_stm32_count_bufset_frames(config, tx_bufs),
+			     spi_stm32_count_bufset_frames(config, rx_bufs));
+#endif /* CONFIG_SPI_RTIO */
 	} else if (transfer_dir == STM32_SPI_HALF_DUPLEX_TX) {
 		frames = spi_stm32_count_bufset_frames(config, tx_bufs);
 	} else {
@@ -1712,6 +1699,10 @@ static int transceive(const struct device *dev,
 
 	/* Set buffers info */
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, bits2bytes(config->operation));
+
+	if (!spi_stm32_transfer_ongoing(data)) {
+		goto end;
+	}
 
 	uint32_t transfer_dir = ll_get_transfer_direction(spi);
 
@@ -2380,7 +2371,7 @@ static int spi_stm32_init(const struct device *dev)
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),		\
 	.dst_addr_increment = STM32_DMA_CONFIG_##dest_dev##_ADDR_INC(		\
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),		\
-	.fifo_threshold = STM32_DMA_FEATURES_FIFO_THRESHOLD(			\
+	.fifo_threshold = STM32_DMA_FEATURES_FIFO_THRESHOLD(		\
 				STM32_DMA_FEATURES(index, dir)),		\
 
 
@@ -2402,7 +2393,14 @@ static int spi_stm32_init(const struct device *dev)
 #define SPI_GET_FIFO_PROP(id)	DT_INST_PROP(id, fifo_enable)
 #define SPI_FIFO_ENABLED(id)	COND_CODE_1(SPI_SUPPORTS_FIFO(id), (SPI_GET_FIFO_PROP(id)), (0))
 
+#define SPI_STM32_CHECK_FIFO(id)								\
+	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi),					\
+		(BUILD_ASSERT(DT_INST_PROP(id, st_fifo_threshold) <= DT_INST_PROP(id, fifo_size),\
+		     "FIFO threshold should be less than or equal to FIFO size.")))
+
 #define STM32_SPI_INIT(id)							\
+	SPI_STM32_CHECK_FIFO(id);						\
+										\
 	STM32_SPI_IRQ_HANDLER_DECL(id);						\
 										\
 	PINCTRL_DT_INST_DEFINE(id);						\
@@ -2428,6 +2426,7 @@ static int spi_stm32_init(const struct device *dev)
 			.mssi_clocks = DT_INST_PROP(id, mssi_clock),		\
 			.fifo_size = DT_INST_PROP(id, fifo_size),		\
 			.fifo_max_transfer_size = DT_INST_PROP(id, fifo_max_transfer_size),	\
+			.fifo_byte_threshold = DT_INST_PROP(id, st_fifo_threshold),		\
 		))								\
 		.soft_nss = DT_INST_PROP(id, st_soft_nss),			\
 	};									\

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -400,7 +400,7 @@ static int spi_stm32_dma_tx_load(const struct device *dev, const uint8_t *buf, s
 	blk_cfg->block_size = len;
 
 	/* tx direction has memory as source and periph as dest. */
-	if (buf == NULL) {
+	if (buf == NULL || len == 0) {
 		/* if tx buff is null, then sends NOP on the line. */
 		dummy_rx_tx_buffer = 0;
 #if SPI_STM32_MANUAL_CACHE_COHERENCY_REQUIRED
@@ -461,7 +461,7 @@ static int spi_stm32_dma_rx_load(const struct device *dev, uint8_t *buf, size_t 
 
 
 	/* rx direction has periph as source and mem as dest. */
-	if (buf == NULL) {
+	if (buf == NULL || len == 0) {
 		/* if rx buff is null, then write data to dummy address. */
 		blk_cfg->dest_address = (uint32_t)&dummy_rx_tx_buffer;
 		blk_cfg->dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
@@ -555,10 +555,6 @@ static void spi_stm32_dma_tx_done(const struct device *dev)
 	while (LL_SPI_GetTxFIFOLevel(spi) > 0) {
 	}
 #endif /* SPI_SR_FTLVL */
-
-#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	LL_SPI_DisableDMAReq_TX(spi);
-#endif /* ! st_stm32h7_spi */
 }
 
 static void spi_stm32_dma_rx_done(const struct device *dev, const struct spi_config *config)
@@ -566,8 +562,7 @@ static void spi_stm32_dma_rx_done(const struct device *dev, const struct spi_con
 	const struct spi_stm32_config *cfg = dev->config;
 	struct spi_stm32_data *data = dev->data;
 	SPI_TypeDef *spi = cfg->spi;
-	uint8_t frame_size_bytes = bits2bytes(config->operation);
-	size_t dma_len = spi_context_max_continuous_chunk(&data->ctx);
+	uint8_t dfs = bits2bytes(config->operation);
 	uint32_t transfer_dir = LL_SPI_GetTransferDirection(spi);
 
 #ifdef CONFIG_SPI_STM32_ERRATA_BUSY
@@ -577,28 +572,23 @@ static void spi_stm32_dma_rx_done(const struct device *dev, const struct spi_con
 	while (ll_spi_dma_busy(spi) && LL_SPI_IsEnabled(spi)) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 		uint32_t width = SPI_WORD_SIZE_GET(data->ctx.config->operation);
-		/* The TXC flag is not raised at the end of 9, 17 or 25
-		 * bit transfer, so disable the SPI in these cases to avoid being stuck.
+		/* The TXC flag is not raised at the end of a 9, 17 or 25 bit transfer.
+		 * In that case, just break the loop, transfer should be done anyway.
 		 */
-		if (!cfg->fifo_enabled &&
-		    ((width == 9U) || (width == 17U) || (width == 25U))) {
-			ll_disable_spi(spi);
+		if ((width == 9U) || (width == 17U) || (width == 25U)) {
+			break;
 		}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	}
 #endif /* CONFIG_SPI_STM32_ERRATA_BUSY */
 
-#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	LL_SPI_DisableDMAReq_RX(spi);
-#endif /* ! st_stm32h7_spi */
-
 	if (transfer_dir == STM32_SPI_FULL_DUPLEX) {
-		spi_context_update_tx(&data->ctx, frame_size_bytes, dma_len);
-		spi_context_update_rx(&data->ctx, frame_size_bytes, dma_len);
+		spi_context_update_tx(&data->ctx, dfs, data->tx_len);
+		spi_context_update_rx(&data->ctx, dfs, data->rx_len);
 	} else if (transfer_dir == STM32_SPI_HALF_DUPLEX_TX) {
-		spi_context_update_tx(&data->ctx, frame_size_bytes, dma_len);
+		spi_context_update_tx(&data->ctx, dfs, data->tx_len);
 	} else {
-		spi_context_update_rx(&data->ctx, frame_size_bytes, dma_len);
+		spi_context_update_rx(&data->ctx, dfs, data->rx_len);
 	}
 }
 #endif /* !CONFIG_SPI_RTIO */
@@ -1204,10 +1194,11 @@ static void spi_stm32_complete(const struct device *dev, int status)
 		while (ll_spi_is_busy(spi) && LL_SPI_IsEnabled(spi)) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 			uint32_t width = SPI_WORD_SIZE_GET(data->ctx.config->operation);
-			/* In non-FIFO mode, the TXC flag is not raised at the end of 9, 17 or 25
-			 * bit transfer, so disable the SPI in these cases to avoid being stuck.
+			/* In non-FIFO mode (TSIZE == 0), the TXC flag is not raised at the end
+			 * of 9, 17 or 25 bit transfer, so disable the SPI in these cases to
+			 * avoid being stuck.
 			 */
-			if (!cfg->fifo_enabled &&
+			if (LL_SPI_GetTransferSize(spi) == 0 &&
 			    ((width == 9U) || (width == 17U) || (width == 25U))) {
 				ll_disable_spi(spi);
 			}
@@ -1490,13 +1481,25 @@ static int spi_stm32_configure(const struct device *dev,
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	if (cfg->fifo_enabled) {
+	bool use_dma = false;
+
+#if defined(CONFIG_SPI_STM32_DMA)
+	use_dma = (data->dma_tx.dma_dev != NULL) && (data->dma_rx.dma_dev != NULL);
+#endif /* CONFIG_SPI_STM32_DMA */
+
+	if (cfg->fifo_enabled && !use_dma) {
+		/* Configure the FIFO threshold if not using DMA */
 		/* Do not use bits2bytes here, we want to get 3 for 24-bit operation */
 		uint8_t dfs = DIV_ROUND_UP(SPI_WORD_SIZE_GET(config->operation), 8U);
 
 		/* FIFO threshold should not exceed half the FIFO size */
 		data->fifo_threshold = cfg->fifo_size / (dfs * 2U);
 	} else {
+		/* When using DMA, set the threshold to 1. A higher value doesn't bring better
+		 * performance, and is complicated to handle without using the TSIZE register.
+		 * And using TSIZE requires to disable and re-enable the SPI for each new buffer
+		 * in the DMA transaction.
+		 */
 		data->fifo_threshold = 1;
 	}
 	LL_SPI_SetFIFOThreshold(spi, table_fifo_threshold[data->fifo_threshold - 1]);
@@ -1866,7 +1869,7 @@ static void dma_callback_async(const struct device *dma_dev, const struct device
 		}
 
 		spi_stm32_dma_tx_done(spi_dev);
-		data->tx_dma_done = true;
+		data->status_flags |= SPI_STM32_DMA_TX_DONE_FLAG;
 	} else if (channel == data->dma_rx.channel) {
 		/* this part of the transfer ends */
 		if (status == DMA_STATUS_BLOCK) {
@@ -1876,47 +1879,24 @@ static void dma_callback_async(const struct device *dma_dev, const struct device
 		}
 
 		spi_stm32_dma_rx_done(spi_dev, config);
-		data->rx_dma_done = true;
+		data->status_flags |= SPI_STM32_DMA_RX_DONE_FLAG;
 	} else {
 		LOG_ERR("DMA callback channel %d is not valid.", channel);
 		ret = -EINVAL;
 	}
 
-	if (data->tx_dma_done && data->rx_dma_done) {
-		data->tx_dma_done = data->rx_dma_done = false;
-		if (spi_stm32_transfer_ongoing(data)) {
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-			uint32_t transfer_dir = LL_SPI_GetTransferDirection(spi);
-
-			if (cfg->fifo_enabled && transfer_dir == STM32_SPI_FULL_DUPLEX &&
-			    SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
-				LL_SPI_ClearFlag_TXTF(spi);
-				LL_SPI_Disable(spi);
-			}
-#endif /* st_stm32h7_spi */
-
-			dma_len = spi_context_max_continuous_chunk(&data->ctx);
+	if ((data->status_flags & SPI_STM32_DMA_DONE_FLAG) == SPI_STM32_DMA_DONE_FLAG) {
+		dma_len = spi_context_max_continuous_chunk(&data->ctx);
+		if (dma_len != 0U) {
+			data->tx_len = data->ctx.tx_len;
+			data->rx_len = data->ctx.rx_len;
+			data->status_flags = 0U;
 			ret = spi_dma_move_buffers(spi_dev, dma_len);
 
 			if (ret != 0) {
 				LOG_ERR("spi_dma_move_buffers err %d", ret);
 				goto end;
 			}
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-			if (cfg->fifo_enabled && transfer_dir == STM32_SPI_FULL_DUPLEX &&
-			    SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
-				ret = spi_stm32_set_transfer_size(spi_dev, NULL, NULL, NULL);
-				if (ret != 0) {
-					goto end;
-				}
-				LL_SPI_Enable(spi);
-				LL_SPI_StartMasterTransfer(spi);
-			}
-#else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-			/* Toggle the DMA request to restart the transfer */
-			spi_dma_enable_requests(spi);
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 			goto unlock;
 		}
@@ -2043,8 +2023,10 @@ static int transceive_dma(const struct device *dev,
 	const struct spi_stm32_config *cfg = dev->config;
 	struct spi_stm32_data *data = dev->data;
 	SPI_TypeDef *spi = cfg->spi;
+	struct dma_config *rx_cfg = &data->dma_rx.dma_cfg, *tx_cfg = &data->dma_tx.dma_cfg;
 	int ret;
 	int err;
+	uint8_t dfs = bits2bytes(config->operation);
 
 	if (tx_bufs == NULL && rx_bufs == NULL) {
 		return 0;
@@ -2071,90 +2053,41 @@ static int transceive_dma(const struct device *dev,
 
 	uint32_t transfer_dir = ll_get_transfer_direction(spi);
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	if (transfer_dir == STM32_SPI_HALF_DUPLEX_RX) {
-		ret = spi_stm32_set_transfer_size(dev, config, tx_bufs, rx_bufs);
-
-		if (ret < 0) {
-			goto end;
-		}
-	}
-#endif /* st_stm32h7_spi */
-
 	/* Set buffers info */
-	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, bits2bytes(config->operation));
+	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, dfs);
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	/* set request before enabling (else SPI CFG1 reg is write protected) */
-	spi_dma_enable_requests(spi);
-
-	if (!cfg->fifo_enabled || transfer_dir != STM32_SPI_FULL_DUPLEX ||
-	    SPI_OP_MODE_GET(config->operation) != SPI_OP_MODE_MASTER) {
-		LL_SPI_Enable(spi);
+	if (!spi_stm32_transfer_ongoing(data)) {
+		goto end;
 	}
-
-	/* In half-duplex rx mode, start transfer after
-	 * setting DMA configurations
-	 */
-	if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX && LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
-		LL_SPI_StartMasterTransfer(spi);
-	}
-#else
-	LL_SPI_Enable(spi);
-#endif /* st_stm32h7_spi */
-
-	/* This is turned off in spi_stm32_complete(). */
-	spi_stm32_cs_control(dev, true);
-
-	uint8_t dfs = bits2bytes(config->operation);
-	struct dma_config *rx_cfg = &data->dma_rx.dma_cfg, *tx_cfg = &data->dma_tx.dma_cfg;
 
 	rx_cfg->source_data_size = rx_cfg->source_burst_length = dfs;
 	rx_cfg->dest_data_size = rx_cfg->dest_burst_length = dfs;
 	tx_cfg->source_data_size = tx_cfg->source_burst_length = dfs;
 	tx_cfg->dest_data_size = tx_cfg->dest_burst_length = dfs;
 
-	while (data->ctx.rx_len > 0 || data->ctx.tx_len > 0) {
-		size_t dma_len;
+	/* Set request before enabling (otherwise SPI CFG1 reg may be write protected) */
+	spi_dma_enable_requests(spi);
+	LL_SPI_Enable(spi);
+	spi_stm32_cs_control(dev, true);
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+	if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
+		LL_SPI_StartMasterTransfer(spi);
+	}
+#endif /* st_stm32h7_spi */
 
+	do {
 		data->status_flags = 0;
 
 		if (transfer_dir == STM32_SPI_FULL_DUPLEX) {
-			dma_len = spi_context_max_continuous_chunk(&data->ctx);
-			ret = spi_dma_move_buffers(dev, dma_len);
+			data->tx_len = data->rx_len = spi_context_max_continuous_chunk(&data->ctx);
+			ret = spi_dma_move_buffers(dev, data->tx_len);
 		} else if (transfer_dir == STM32_SPI_HALF_DUPLEX_TX) {
-			dma_len = data->ctx.tx_len;
-			ret = spi_dma_move_tx_buffers(dev, dma_len);
+			data->tx_len = data->ctx.tx_len;
+			ret = spi_dma_move_tx_buffers(dev, data->tx_len);
 		} else {
-			dma_len = data->ctx.rx_len;
-			ret = spi_dma_move_rx_buffers(dev, dma_len);
+			data->rx_len = data->ctx.rx_len;
+			ret = spi_dma_move_rx_buffers(dev, data->rx_len);
 		}
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		if (cfg->fifo_enabled && transfer_dir == STM32_SPI_FULL_DUPLEX &&
-		    SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
-			ret = spi_stm32_set_transfer_size(dev, config, tx_bufs, rx_bufs);
-			if (ret != 0) {
-				break;
-			}
-			LL_SPI_Enable(spi);
-			LL_SPI_StartMasterTransfer(spi);
-		}
-
-		if (transfer_dir == STM32_SPI_HALF_DUPLEX_RX &&
-		    LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
-			LL_SPI_StartMasterTransfer(spi);
-		}
-#endif /* st_stm32h7_spi */
-
-		if (ret != 0) {
-			break;
-		}
-
-#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		/* toggle the DMA request to restart the transfer */
-		spi_dma_enable_requests(spi);
-#endif /* ! st_stm32h7_spi */
 
 #ifdef CONFIG_SPI_ASYNC
 		if (asynchronous) {
@@ -2171,35 +2104,20 @@ static int transceive_dma(const struct device *dev,
 		spi_stm32_dma_tx_done(dev);
 		spi_stm32_dma_rx_done(dev, config);
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		if (cfg->fifo_enabled && transfer_dir == STM32_SPI_FULL_DUPLEX &&
-		    SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
-			LL_SPI_ClearFlag_TXTF(spi);
-			LL_SPI_Disable(spi);
-		}
-#endif /* st_stm32h7_spi */
-
 		if (transfer_dir == STM32_SPI_HALF_DUPLEX_TX &&
 		    !spi_context_tx_on(&data->ctx) &&
 		    spi_context_rx_on(&data->ctx)) {
 			LL_SPI_Disable(spi);
 			ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
-
 			transfer_dir = STM32_SPI_HALF_DUPLEX_RX;
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-			ret = spi_stm32_set_transfer_size(dev, config, tx_bufs, rx_bufs);
-
-			if (ret < 0) {
-				break;
-			}
-
-			spi_dma_enable_requests(spi);
-#endif /* st_stm32h7_spi */
-
 			LL_SPI_Enable(spi);
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+			if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
+				LL_SPI_StartMasterTransfer(spi);
+			}
+#endif /* st_stm32h7_spi */
 		}
-	}
+	} while (spi_stm32_transfer_ongoing(data));
 
 	/* spi complete relies on SPI Status Reg which cannot be disabled */
 	spi_stm32_complete(dev, ret);

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1134,6 +1134,13 @@ static void spi_stm32_complete(const struct device *dev, int status)
 	struct spi_stm32_data *data = dev->data;
 
 #ifdef CONFIG_SPI_RTIO
+#if defined(CONFIG_SPI_STM32_INTERRUPT) && defined(CONFIG_SOC_SERIES_STM32H7X)
+	/* On H7, with SPI still enabled, the ISR is always called, even if the interrupt
+	 * enable register is cleared.
+	 * As a workaround, disable the IRQ at NVIC level to prevent any spurious interrupt.
+	 */
+	irq_disable(cfg->irq_line);
+#endif /* CONFIG_SPI_STM32_INTERRUPT && CONFIG_SOC_SERIES_STM32H7X */
 	if (data->rtio_ctx->txn_head != NULL) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 		LL_SPI_ClearFlag_TXTF(spi);

--- a/drivers/spi/spi_stm32.h
+++ b/drivers/spi/spi_stm32.h
@@ -38,7 +38,6 @@ struct spi_stm32_config {
 	uint32_t fifo_max_transfer_size;
 	uint8_t fifo_size;
 #endif
-	bool fifo_enabled: 1;
 	bool ioswp: 1;
 	bool soft_nss: 1;
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)

--- a/drivers/spi/spi_stm32.h
+++ b/drivers/spi/spi_stm32.h
@@ -81,8 +81,6 @@ struct spi_stm32_data {
 	volatile uint32_t status_flags;
 	struct stream dma_rx;
 	struct stream dma_tx;
-	bool tx_dma_done;
-	bool rx_dma_done;
 #endif /* CONFIG_SPI_STM32_DMA */
 	bool pm_policy_state_on;
 };

--- a/drivers/spi/spi_stm32.h
+++ b/drivers/spi/spi_stm32.h
@@ -25,6 +25,7 @@ struct spi_stm32_config {
 	const struct stm32_pclken *pclken;
 	size_t pclk_len;
 	int datawidth;
+	int fifo_byte_threshold; /* Threshold value (in bytes) */
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 	irq_config_func_t irq_config;
 #ifdef CONFIG_SOC_SERIES_STM32H7X
@@ -75,7 +76,7 @@ struct spi_stm32_data {
 	struct spi_context ctx;
 	uint32_t tx_len;
 	uint32_t rx_len;
-	uint8_t fifo_threshold;
+	uint8_t fifo_threshold; /* Threshold value (in number of data frames) */
 #ifdef CONFIG_SPI_STM32_DMA
 	struct k_sem status_sem;
 	volatile uint32_t status_flags;

--- a/dts/bindings/spi/st,stm32h7-spi.yaml
+++ b/dts/bindings/spi/st,stm32h7-spi.yaml
@@ -29,10 +29,6 @@ properties:
       (Master SS Idleness) minimum clock inserted between
       start and first data transaction.
 
-  fifo-enable:
-    type: boolean
-    description: Enable the SPI FIFO usage for performance improvement.
-
   fifo-size:
     type: int
     required: true

--- a/dts/bindings/spi/st,stm32h7-spi.yaml
+++ b/dts/bindings/spi/st,stm32h7-spi.yaml
@@ -42,3 +42,13 @@ properties:
     type: int
     required: true
     description: Maximal transfer size (in bytes) when FIFO is used.
+
+  st,fifo-threshold:
+    type: int
+    default: 1
+    min: 1
+    max: 16
+    description: |
+      Threshold level for the Tx and Rx FIFOs (in bytes).
+      This value defines the maximum number of bytes in a single packet. It is
+      recommended that the size of a packet does not exceed half of the FIFO size.

--- a/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
@@ -12,7 +12,6 @@
 	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-	fifo-enable;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
@@ -12,6 +12,7 @@
 	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
+	st,fifo-threshold = <8>;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_c5a3zg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_c5a3zg.overlay
@@ -8,7 +8,6 @@
 	dmas = <&lpdma1 0 5 STM32_DMA_PERIPH_TX
 		&lpdma1 1 4 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-	fifo-enable;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_c5a3zg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_c5a3zg.overlay
@@ -8,6 +8,7 @@
 	dmas = <&lpdma1 0 5 STM32_DMA_PERIPH_TX
 		&lpdma1 1 4 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
+	st,fifo-threshold = <8>;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
@@ -18,7 +18,6 @@
 	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-	fifo-enable;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
@@ -18,6 +18,7 @@
 	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
+	st,fifo-threshold = <8>;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.overlay
@@ -8,7 +8,6 @@
 	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-	fifo-enable;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.overlay
@@ -8,6 +8,7 @@
 	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
+	st,fifo-threshold = <8>;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.overlay
@@ -12,7 +12,6 @@
 	dmas = <&gpdma1 0 2 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 1 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-	fifo-enable;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.overlay
@@ -12,6 +12,7 @@
 	dmas = <&gpdma1 0 2 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 1 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
+	st,fifo-threshold = <8>;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
@@ -12,7 +12,6 @@
 	dmas = <&gpdma1 0 9 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 8 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-	fifo-enable;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
@@ -12,6 +12,7 @@
 	dmas = <&gpdma1 0 9 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 8 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
+	st,fifo-threshold = <8>;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -8,7 +8,6 @@
 	dmas = <&gpdma1 0 88 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 87 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-	fifo-enable;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -8,6 +8,7 @@
 	dmas = <&gpdma1 0 88 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 87 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
+	st,fifo-threshold = <4>;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";


### PR DESCRIPTION
This PR brings some modifications in the use of FIFO for SPI transfers on `st,stm32h7-spi` compatible:
- Using FIFO for DMA transfer doesn't bring performance improvement but forces the driver to disable and enable the SPI instance for each new buffer. For simplicity, it is removed.
- In interrupt mode, using FIFO brings performance improvement compared to not using it. It is now the default and only mode. A new property is now available to set the desired FIFO threshold.