### PR TITLE
manifest: tf-psa-crypto update with fix for Clang doxygen build error

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -389,7 +389,7 @@ manifest:
         - testing
         - tee
     - name: tf-psa-crypto
-      revision: efdf9e209cc3b2c7be93ac81c7c96cd2550bbe27
+      revision: 2d881593696aec687ca2246c53de207c2b9bf782
       path: modules/crypto/tf-psa-crypto
       groups:
         - crypto


### PR DESCRIPTION
This module triggers a build warning in one function doxygen documentation which is fixed with this revision.

tf-psa-crypto PR: https://github.com/zephyrproject-rtos/TF-PSA-Crypto/pull/10 (already merged)

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/109975

Alternative to https://github.com/zephyrproject-rtos/zephyr/pull/109981 with updated sha to just get moving (109981 branch cannot be written by others)