### PR TITLE
boards: st: *n65*: Comment out nvmem properties in DTS file

### DIFF
--- a/boards/st/nucleo_n657x0_q/doc/index.rst
+++ b/boards/st/nucleo_n657x0_q/doc/index.rst
@@ -62,6 +62,34 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
+Ethernet
+========
+
+NUCLEO-N657X0-Q features an Ethernet interface connected to an external PHY via RMII.
+
+An area of the on-chip OTP (One-Time Programmable) memory is dedicated to holding
+Ethernet MAC addresses. This area is not programmed during manufacturing and reads
+as all zeroes; it must be programmed in the field using `STM32CubeProgrammer`_.
+
+To use the OTP MAC address ``MAC_ADDR1`` in your application, add the following overlay:
+
+.. code-block:: dts
+
+   &mac {
+       nvmem-cells = <&mac_address0>;
+       nvmem-cell-names = "mac-address";
+   };
+
+.. warning::
+
+  Ethernet will not work with this overlay if the on-chip OTP has not been
+  programmed, because the unprogrammed OTP value (all zeroes) would be read
+  and used as MAC address, but 00:00:00:00:00:00 is not a valid MAC address.
+
+However, to allow running Zephyr net related samples without programming
+irreversibly your device, by default, the STM32 Ethernet driver creates a
+locally administered MAC address from the device unique ID.
+
 USB
 ===
 

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -262,8 +262,19 @@ zephyr_udc0: &usbotg_hs1 {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
-	nvmem-cells = <&mac_address0>;
-	nvmem-cell-names = "mac-address";
+	/*
+	 * An area of OTP is dedicated to holding Ethernet MAC addresses;
+	 * however, it is not programmed during manufacturing. Reading an
+	 * unprogrammed OTP returns all zeroes, which breaks Ethernet if used
+	 * as MAC address. To allow the use of Ethernet even on virgin boards,
+	 * we do not define the nvmem-cell properties below (commented out)
+	 * so that default MAC address source is not the OTP memory.
+	 *
+	 * Once a MAC address has been programmed in OTP, you can enable
+	 * its use by uncommenting the following properties:
+	 */
+	/* nvmem-cells = <&mac_address0>; */
+	/* nvmem-cell-names = "mac-address"; */
 };
 
 &mdio {

--- a/boards/st/stm32n6570_dk/doc/index.rst
+++ b/boards/st/stm32n6570_dk/doc/index.rst
@@ -80,6 +80,34 @@ STM32N6570-DK also embeds the ST Neural-ART Accelerator™ as NPU engineered for
 AI applications, such as the `Zephyr computer vision application`_ which is available as a separate
 Zephyr application.
 
+Ethernet
+========
+
+STM32N6570-DK features a 1-Gbit Ethernet interface connected to an external PHY via RGMII.
+
+An area of the on-chip OTP (One-Time Programmable) memory is dedicated to holding
+Ethernet MAC addresses. This area is not programmed during manufacturing and reads
+as all zeroes; it must be programmed in the field using `STM32CubeProgrammer`_.
+
+To use the OTP MAC address ``MAC_ADDR1`` in your application, add the following overlay:
+
+.. code-block:: dts
+
+   &mac {
+       nvmem-cells = <&mac_address0>;
+       nvmem-cell-names = "mac-address";
+   };
+
+.. warning::
+
+  Ethernet will not work with this overlay if the on-chip OTP has not been
+  programmed, because the unprogrammed OTP value (all zeroes) would be read
+  and used as MAC address, but 00:00:00:00:00:00 is not a valid MAC address.
+
+However, to allow running Zephyr net related samples without programming
+irreversibly your device, by default, the STM32 Ethernet driver creates a
+locally administered MAC address from the device unique ID.
+
 USB
 ===
 

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -489,8 +489,19 @@ zephyr_udc0: &usbotg_hs1 {
 	pinctrl-names = "default";
 	phy-connection-type = "rgmii";
 	phy-handle = <&eth_phy>;
-	nvmem-cells = <&mac_address0>;
-	nvmem-cell-names = "mac-address";
+	/*
+	 * An area of OTP is dedicated to holding Ethernet MAC addresses;
+	 * however, it is not programmed during manufacturing. Reading an
+	 * unprogrammed OTP returns all zeroes, which breaks Ethernet if used
+	 * as MAC address. To allow the use of Ethernet even on virgin boards,
+	 * we do not define the nvmem-cell properties below (commented out)
+	 * so that default MAC address source is not the OTP memory.
+	 *
+	 * Once a MAC address has been programmed in OTP, you can enable
+	 * its use by uncommenting the following properties:
+	 */
+	/* nvmem-cells = <&mac_address0>; */
+	/* nvmem-cell-names = "mac-address"; */
 };
 
 &mdio {

--- a/samples/net/zperf/boards/stm32n6570_dk_stm32n657xx_sb_otp.overlay
+++ b/samples/net/zperf/boards/stm32n6570_dk_stm32n657xx_sb_otp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Enable usage of the OTP MAC address for the Ethernet interface.
+ * A valid MAC address must have been programmed in OTP of the board for this to work.
+ */
+&mac {
+	nvmem-cells = <&mac_address0>;
+	nvmem-cell-names = "mac-address";
+};

--- a/samples/net/zperf/sample.yaml
+++ b/samples/net/zperf/sample.yaml
@@ -43,6 +43,12 @@ tests:
       - stm32h573i_dk
     integration_platforms:
       - stm32h573i_dk
+  sample.net.zperf_st.otp_mac_addr:
+    build_only: true
+    platform_allow:
+      - stm32n6570_dk/stm32n657xx/sb
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/stm32n6570_dk_stm32n657xx_sb_otp.overlay"
   sample.net.zperf_no_shell:
     harness: net
     extra_configs:


### PR DESCRIPTION
Add a fallback to make sure we are getting a non-zero MAC address for the boards that loads it from the OTP.
Also applied it to eth_stm32_hal2.c for consistency.

Fixes: #110266