### PR TITLE
MAINTAINERS: add myself as bt host collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -638,6 +638,7 @@ Bluetooth Host:
     - Thalley
     - cvinayak
     - HaavardRei
+    - alxelax
   files:
     - doc/services/connectivity/bluetooth/
     - include/zephyr/bluetooth/


### PR DESCRIPTION
Add myself (alxelax) as Bluetooth Host collaborator. The main reason is as Bluetooth Mesh maintainer would like to follow up Bluetooth Host updates since it impacts Mesh significantly.
It happens from time to time when Bluetooth Host contributors add changes those impact (or even break something) on\in Bluetooth Mesh. Since I do not follow up every single Bluetooth PR I figure out about this post-factum.
So reverting of such changes becomes not trivial task since people who contributed them have strict opinion against it.
I would like to be able to be notified about Host changes and review them on aspect of the compatibility to Mesh requirements before they have been merged to main.