### PR TITLE
mctp: usb: add doxygen docs for mctp_usb_class_inst

### DIFF
--- a/include/zephyr/pmci/mctp/mctp_usb.h
+++ b/include/zephyr/pmci/mctp/mctp_usb.h
@@ -48,9 +48,18 @@ struct mctp_binding_usb {
 	/** @endcond INTERNAL_HIDDEN */
 };
 
+/**
+ * @brief MCTP USB class instance configuration
+ *
+ * Holds the USB interface descriptor parameters and the associated MCTP
+ * bus binding for a single MCTP USB class instance.
+ */
 struct mctp_usb_class_inst {
+	/** MCTP subclass used in the USB interface descriptor */
 	uint8_t subclass;
+	/** MCTP protocol version used in the USB interface descriptor */
 	uint8_t mctp_protocol;
+	/** Pointer to the associated MCTP USB bus binding */
 	struct mctp_binding_usb *mctp_binding;
 };
 

--- a/include/zephyr/pmci/mctp/mctp_usb.h
+++ b/include/zephyr/pmci/mctp/mctp_usb.h
@@ -49,7 +49,7 @@ struct mctp_binding_usb {
 };
 
 struct mctp_usb_class_inst {
-	uint8_t sublcass;
+	uint8_t subclass;
 	uint8_t mctp_protocol;
 	struct mctp_binding_usb *mctp_binding;
 };
@@ -85,7 +85,7 @@ int mctp_usb_tx(struct mctp_binding *binding, struct mctp_pktbuf *pkt);
 	};											\
 												\
 	const STRUCT_SECTION_ITERABLE(mctp_usb_class_inst, mctp_usb_class_inst_##_name) = {	\
-		.sublcass = _subclass,								\
+		.subclass = _subclass,								\
 		.mctp_protocol = _protocol,							\
 		.mctp_binding = &_name,								\
 	};


### PR DESCRIPTION
- **mctp: usb: fix typo in struct member name**
- **mctp: usb: add doxygen docs for mctp_usb_class_inst**
