### PR TITLE
drivers: wifi: nrf_wifi: control nRF70 device supply during power sequencing

### DIFF
--- a/dts/bindings/wifi/nordic,nrf70.yaml
+++ b/dts/bindings/wifi/nordic,nrf70.yaml
@@ -1,6 +1,11 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+# Includes the generic supply-gpios/vin-supply properties so they are available
+# on both the SPI and QSPI variants (the SPI variant also pulls power.yaml in
+# via spi-device.yaml; duplicate includes are harmless).
+include: [power.yaml]
+
 properties:
   iovdd-ctrl-gpios:
     type: phandle-array
@@ -13,6 +18,14 @@ properties:
     description: |
       Regulator controlling IO_VDD of the nRF70, either this or iovdd-ctrl-gpios
       needs to be set.
+
+  supply-power-up-delay-ms:
+    type: int
+    default: 6
+    description: |
+      Duration to wait after asserting supply-gpios before asserting BUCK_EN.
+      The nRF70 supply sequencing requires at least 6 ms between supplying
+      VBAT and asserting BUCK_EN.
 
   bucken-gpios:
     type: phandle-array

--- a/modules/nrf_wifi/bus/rpu_hw_if.c
+++ b/modules/nrf_wifi/bus/rpu_hw_if.c
@@ -49,6 +49,23 @@ DEVICE_DT_GET(DT_PHANDLE(NRF7002_NODE, iovdd_regulator));
 static const struct gpio_dt_spec bucken_spec =
 GPIO_DT_SPEC_GET(NRF7002_NODE, bucken_gpios);
 
+#if DT_NODE_HAS_PROP(NRF7002_NODE, supply_gpios)
+#define NRF70_SUPPLY_GPIO 1
+static const struct gpio_dt_spec supply_spec =
+GPIO_DT_SPEC_GET(NRF7002_NODE, supply_gpios);
+#endif
+
+#if DT_NODE_HAS_PROP(NRF7002_NODE, vin_supply)
+#define NRF70_VIN_SUPPLY 1
+#include <zephyr/drivers/regulator.h>
+static const struct device *vin_supply =
+DEVICE_DT_GET(DT_PHANDLE(NRF7002_NODE, vin_supply));
+#endif
+
+#if defined(NRF70_VIN_SUPPLY) || defined(NRF70_SUPPLY_GPIO)
+#define NRF70_HAS_SUPPLY 1
+#endif
+
 char blk_name[][15] = { "SysBus",   "ExtSysBus",	   "PBus",	   "PKTRAM",
 			       "GRAM",	   "LMAC_ROM",	   "LMAC_RET_RAM", "LMAC_SRC_RAM",
 			       "UMAC_ROM", "UMAC_RET_RAM", "UMAC_SRC_RAM" };
@@ -212,6 +229,22 @@ static int rpu_gpio_config_early(void)
 		return -ENODEV;
 	}
 
+#ifdef NRF70_SUPPLY_GPIO
+	if (!device_is_ready(supply_spec.port)) {
+		LOG_ERR("supply GPIO %s is not ready", supply_spec.port->name);
+		return -ENODEV;
+	}
+
+	/* Configure supply as output in inactive state to prevent a floating
+	 * pin from accidentally powering the module.
+	 */
+	ret = gpio_pin_configure_dt(&supply_spec, GPIO_OUTPUT_INACTIVE);
+	if (ret) {
+		LOG_ERR("supply GPIO configuration failed...");
+		return ret;
+	}
+#endif
+
 	/* Configure BUCKEN as output in inactive (low) state to prevent
 	 * floating pin from accidentally powering the module.
 	 */
@@ -291,6 +324,19 @@ static int rpu_gpio_config(void)
 		return -ENODEV;
 	}
 
+#ifdef NRF70_SUPPLY_GPIO
+	if (!device_is_ready(supply_spec.port)) {
+		LOG_ERR("supply GPIO %s is not ready", supply_spec.port->name);
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&supply_spec, GPIO_OUTPUT_INACTIVE);
+	if (ret) {
+		LOG_ERR("supply GPIO configuration failed...");
+		return ret;
+	}
+#endif
+
 	ret = gpio_pin_configure_dt(&bucken_spec, (GPIO_OUTPUT | NRF_GPIO_DRIVE_H0H1));
 	if (ret) {
 		LOG_ERR("BUCKEN GPIO configuration failed...");
@@ -329,17 +375,83 @@ static int rpu_gpio_remove(void)
 	}
 #endif
 
+#ifdef NRF70_SUPPLY_GPIO
+	ret = gpio_pin_configure_dt(&supply_spec, GPIO_DISCONNECTED);
+	if (ret) {
+		LOG_ERR("supply GPIO remove failed...");
+		return ret;
+	}
+#endif
+
 	LOG_DBG("GPIO remove done...\n");
 	return ret;
 }
+
+#ifdef NRF70_HAS_SUPPLY
+/* Enable the nRF70 device supply (VBAT). Per the power.yaml contract, when both
+ * a regulator (vin-supply) and a switch (supply-gpios) are present, the
+ * regulator is requested before the supply GPIO is driven active. A delay
+ * follows to satisfy the >= 6 ms supply-to-BUCKEN sequencing requirement.
+ */
+static int rpu_supply_on(void)
+{
+	int ret = 0;
+
+#ifdef NRF70_VIN_SUPPLY
+	ret = regulator_enable(vin_supply);
+	if (ret) {
+		LOG_ERR("vin-supply enable failed...");
+		return ret;
+	}
+#endif
+
+#ifdef NRF70_SUPPLY_GPIO
+	ret = gpio_pin_set_dt(&supply_spec, 1);
+	if (ret) {
+		LOG_ERR("supply GPIO set failed...");
+#ifdef NRF70_VIN_SUPPLY
+		regulator_disable(vin_supply);
+#endif
+		return ret;
+	}
+#endif
+
+	k_msleep(DT_PROP(NRF7002_NODE, supply_power_up_delay_ms));
+
+	return ret;
+}
+
+/* Disable the nRF70 device supply in reverse order: the supply GPIO is driven
+ * inactive before the regulator is released.
+ */
+static void rpu_supply_off(void)
+{
+#ifdef NRF70_SUPPLY_GPIO
+	gpio_pin_set_dt(&supply_spec, 0);
+#endif
+#ifdef NRF70_VIN_SUPPLY
+	regulator_disable(vin_supply);
+#endif
+}
+#endif /* NRF70_HAS_SUPPLY */
 
 static int rpu_pwron(void)
 {
 	int ret;
 
+#ifdef NRF70_HAS_SUPPLY
+	ret = rpu_supply_on();
+	if (ret) {
+		return ret;
+	}
+#endif
+
 	ret = gpio_pin_set_dt(&bucken_spec, 1);
 	if (ret) {
 		LOG_ERR("BUCKEN GPIO set failed...");
+#ifdef NRF70_HAS_SUPPLY
+		rpu_supply_off();
+#endif
 		return ret;
 	}
 	/* Settling time is 50us (H0) or 100us (L0) */
@@ -353,6 +465,9 @@ static int rpu_pwron(void)
 	if (ret) {
 		LOG_ERR("IOVDD enable failed...");
 		gpio_pin_set_dt(&bucken_spec, 0);
+#ifdef NRF70_HAS_SUPPLY
+		rpu_supply_off();
+#endif
 		return ret;
 	}
 	/* Settling time for IOVDD */
@@ -397,6 +512,10 @@ static int rpu_pwroff(void)
 		LOG_ERR("BUCKEN GPIO set failed...");
 		return ret;
 	}
+
+#ifdef NRF70_HAS_SUPPLY
+	rpu_supply_off();
+#endif
 
 	return ret;
 }


### PR DESCRIPTION
## Description

The nRF70 supply sequencing requires the device supply (VBAT) to be enabled,
followed by a delay of at least 6 ms, before `BUCK_EN` is asserted:

> 1. Supply VBAT/BUCKVBAT/BUCKVBATS/AFEVBAT
> 2. Wait ≥ 6 ms
> 3. Assert BUCKEN
> 4. Wait ≥ 1 ms
> 5. Supply IOVDD

Until now the driver did not handle the device supply at all. A dedicated
supply switch (`supply-gpios`) or regulator (`vin-supply`) declared in
devicetree was silently ignored — note `supply-gpios`/`vin-supply` were already
advertised on the SPI variant (inherited via `spi-device.yaml` → `power.yaml`)
but never consumed by the driver, and were not available at all on QSPI.

## Changes

- **dts**: pull the generic `power.yaml` properties into the common
  `nordic,nrf70.yaml`, so `supply-gpios`/`vin-supply` are available on both the
  SPI and QSPI variants. Add a `supply-power-up-delay-ms` property (default
  6 ms) for the supply→BUCKEN settling time.
- **driver**: enable the device supply at the start of the power-up sequence
  (supply → delay → BUCKEN → IOVDD) and disable it last on power-down. When both
  `vin-supply` and `supply-gpios` are present, the regulator is requested before
  the GPIO is driven active and released after it is driven inactive, per the
  `power.yaml` contract. Both properties are optional; boards that don't use them
  are unaffected.

## Notes

- Marked as **draft** pending hardware testing on a board that uses a switched
  nRF70 supply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
