### PR TITLE
cmake: compiler: enhance LLVM/Clang and LLD support

### DIFF
--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -34,6 +34,8 @@ if(NOT "${ARCH}" STREQUAL "posix")
     include(${ZEPHYR_BASE}/cmake/compiler/clang/target_arm64.cmake)
   elseif("${ARCH}" STREQUAL "riscv")
     include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_riscv.cmake)
+  elseif("${ARCH}" STREQUAL "xtensa")
+    include(${ZEPHYR_BASE}/cmake/compiler/clang/target_xtensa.cmake)
   endif()
 
   foreach(file_name include/stddef.h)
@@ -102,6 +104,7 @@ if(NOT "${ARCH}" STREQUAL "posix")
 endif()
 
 # Override the default implementation in target_template.cmake.
+if(NOT COMPILER_SET_LINKER_PROPERTIES_DEFINED)
 function(compiler_set_linker_properties)
 
   compiler_simple_options(simple_options)
@@ -136,3 +139,4 @@ function(compiler_set_linker_properties)
 
   set_linker_property(PROPERTY rt_library "-l${library_name}")
 endfunction()
+endif()

--- a/cmake/compiler/clang/target_xtensa.cmake
+++ b/cmake/compiler/clang/target_xtensa.cmake
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_SOC_FAMILY_ESPRESSIF_ESP32)
+  set(LLVM_XTENSA_TARGET "xtensa-esp-elf")
+else()
+  set(LLVM_XTENSA_TARGET "xtensa-zephyr-elf")
+endif()
+
+list(APPEND TOOLCHAIN_C_FLAGS "--target=${LLVM_XTENSA_TARGET}" "-gz=none" "-Wa,--compress-debug-sections=none")
+list(APPEND TOOLCHAIN_CXX_FLAGS "--target=${LLVM_XTENSA_TARGET}" "-gz=none" "-Wa,--compress-debug-sections=none")
+list(APPEND TOOLCHAIN_ASM_FLAGS "--target=${LLVM_XTENSA_TARGET}" "-gz=none" "-Wa,--compress-debug-sections=none")
+list(APPEND TOOLCHAIN_LD_FLAGS "--target=${LLVM_XTENSA_TARGET}" "-gz=none" "-Wa,--compress-debug-sections=none")
+
+
+include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_xtensa.cmake)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1286,10 +1286,13 @@ function(zephyr_check_compiler_flag lang option check)
 endfunction()
 
 function(zephyr_check_compiler_flag_hardcoded lang option check exists)
+  if((CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND ("${option}" STREQUAL "-mlongcalls"))
+    set(${check} 0 PARENT_SCOPE)
+    set(${exists} 1 PARENT_SCOPE)
   # Various flags that are not supported for CXX may not be testable
   # because they would produce a warning instead of an error during
   # the test.  Exclude them by toolchain-specific blocklist.
-  if((${lang} STREQUAL CXX) AND ("${option}" IN_LIST CXX_EXCLUDED_OPTIONS))
+  elseif((${lang} STREQUAL CXX) AND ("${option}" IN_LIST CXX_EXCLUDED_OPTIONS))
     set(${check} 0 PARENT_SCOPE)
     set(${exists} 1 PARENT_SCOPE)
   else()

--- a/cmake/toolchain/host/llvm/generic.cmake
+++ b/cmake/toolchain/host/llvm/generic.cmake
@@ -4,11 +4,48 @@ set_ifndef(LLVM_TOOLCHAIN_PATH "$ENV{CLANG_ROOT_DIR}")
 set(TOOLCHAIN_VARIANT_COMPILER llvm CACHE STRING "Variant compiler being used")
 zephyr_get(LLVM_TOOLCHAIN_PATH)
 
+if(NOT LLVM_TOOLCHAIN_PATH)
+  # Generate search paths dynamically to support LLVM versions 15 through 25
+  set(LLVM_SEARCH_PATHS
+    /opt/llvm/bin
+    /usr/bin
+    /usr/local/bin
+    /bin
+    /opt/homebrew/bin
+    /opt/homebrew/opt/llvm/bin
+    /usr/local/opt/llvm/bin
+    /usr/lib/llvm/bin
+  )
+  foreach(ver RANGE 25 15 -1)
+    list(APPEND LLVM_SEARCH_PATHS "/opt/homebrew/opt/llvm@${ver}/bin")
+    list(APPEND LLVM_SEARCH_PATHS "/usr/lib/llvm-${ver}/bin")
+  endforeach()
+
+  # Find the host LLVM toolchain directory containing clang / llvm-config
+  find_path(LLVM_BINARY_DIR
+    NAMES
+    clang
+    llvm-config
+
+    PATHS
+    ${LLVM_SEARCH_PATHS}
+
+    HINTS
+    $ENV{LLVM_TOOLCHAIN_PATH}/bin
+    $ENV{LLVM_TOOLCHAIN_PATH}
+    $ENV{LLVM_ROOT}/bin
+    $ENV{LLVM_ROOT}
+  )
+  if(LLVM_BINARY_DIR)
+    get_filename_component(LLVM_TOOLCHAIN_PATH "${LLVM_BINARY_DIR}" DIRECTORY)
+  endif()
+endif()
+
 if(LLVM_TOOLCHAIN_PATH)
   set(TOOLCHAIN_HOME ${LLVM_TOOLCHAIN_PATH}/bin/)
 endif()
 
-set(LLVM_TOOLCHAIN_PATH ${CLANG_ROOT_DIR} CACHE PATH "clang install directory")
+set(LLVM_TOOLCHAIN_PATH ${LLVM_TOOLCHAIN_PATH} CACHE PATH "clang install directory")
 
 set(COMPILER clang)
 set(BINTOOLS llvm)
@@ -25,18 +62,28 @@ set(BINTOOLS llvm)
 
 # Support for newlib is indicated by the presence of '_newlib_version.h' in the toolchain path.
 if(NOT LLVM_TOOLCHAIN_PATH STREQUAL "")
-  file(GLOB_RECURSE newlib_header ${LLVM_TOOLCHAIN_PATH}/_newlib_version.h)
+  # Use find_file() instead of GLOB_RECURSE to avoid a slow recursive scan
+  # of the entire LLVM toolchain directory tree at configure time.
+  find_file(newlib_header _newlib_version.h
+    PATHS ${LLVM_TOOLCHAIN_PATH}
+    PATH_SUFFIXES include
+    NO_DEFAULT_PATH
+    NO_CACHE
+  )
   if(newlib_header)
     set(TOOLCHAIN_HAS_NEWLIB ON CACHE BOOL "True if toolchain supports newlib")
   endif()
 
-  # Support for picolibc is indicated by the presence of 'picolibc.h' in the toolchain path.
-  file(GLOB_RECURSE picolibc_header ${LLVM_TOOLCHAIN_PATH}/picolibc.h)
-  if(picolibc_header)
+  find_file(picolibc_header picolibc.h
+    PATHS ${LLVM_TOOLCHAIN_PATH}
+    PATH_SUFFIXES include include/picolibc
+    NO_DEFAULT_PATH
+    NO_CACHE
+  )
+  if(picolibc_header OR NOT "${ARCH}" STREQUAL "posix")
     set(TOOLCHAIN_HAS_PICOLIBC ON CACHE BOOL "True if toolchain supports picolibc")
   endif()
 endif()
-
 set(TOOLCHAIN_HAS_LIBCXX ON CACHE BOOL "True if toolchain supports libc++")
 
 message(STATUS "Found toolchain: llvm (clang/ld)")

--- a/cmake/toolchain/host/llvm/target.cmake
+++ b/cmake/toolchain/host/llvm/target.cmake
@@ -6,56 +6,200 @@ elseif(CONFIG_LLVM_USE_LLD)
   set(LINKER lld)
 endif()
 
-if("${ARCH}" STREQUAL "arm")
-  if(DEFINED CONFIG_ARMV8_M_MAINLINE)
-    # ARMv8-M mainline is ARMv7-M with additional features from ARMv8-M.
-    set(triple armv8m.main-none-eabi)
-  elseif(DEFINED CONFIG_ARMV8_M_BASELINE)
-    # ARMv8-M baseline is ARMv6-M with additional features from ARMv8-M.
-    set(triple armv8m.base-none-eabi)
-  elseif(DEFINED CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-    # ARMV7_M_ARMV8_M_MAINLINE means that ARMv7-M or backward compatible ARMv8-M
-    # processor is used.
-    set(triple armv7m-none-eabi)
-  elseif(DEFINED CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-    # ARMV6_M_ARMV8_M_BASELINE means that ARMv6-M or ARMv8-M supporting the
-    # Baseline implementation processor is used.
-    set(triple armv6m-none-eabi)
+if(NOT "${ARCH}" STREQUAL "posix")
+  # Locate the Zephyr SDK directory
+  if(DEFINED ZEPHYR_SDK_INSTALL_DIR)
+      set(SDK_DIR "${ZEPHYR_SDK_INSTALL_DIR}")
+  elseif(DEFINED ENV{ZEPHYR_SDK_INSTALL_DIR})
+      set(SDK_DIR "$ENV{ZEPHYR_SDK_INSTALL_DIR}")
+  elseif(DEFINED ZEPHYR_TOOLCHAIN_PATH)
+      set(SDK_DIR "${ZEPHYR_TOOLCHAIN_PATH}")
+  elseif(DEFINED ENV{ZEPHYR_TOOLCHAIN_PATH})
+      set(SDK_DIR "$ENV{ZEPHYR_TOOLCHAIN_PATH}")
   else()
-    # Default ARM target supported by all processors.
-    set(triple arm-none-eabi)
+      # Try finding Zephyr-sdk package using find_package
+      find_package(Zephyr-sdk QUIET CONFIG)
+      if(ZEPHYR_SDK_INSTALL_DIR)
+          set(SDK_DIR "${ZEPHYR_SDK_INSTALL_DIR}")
+      elseif(Zephyr-sdk_FOUND AND Zephyr-sdk_DIR)
+          set(SDK_DIR "${Zephyr-sdk_DIR}")
+      else()
+          # Fallback search in standard directories
+          file(GLOB sdk_candidates
+              LIST_DIRECTORIES true
+              "$ENV{HOME}/zephyr-sdk-*"
+              "/opt/zephyr-sdk-*"
+              "$ENV{HOME}/.local/zephyr-sdk-*"
+              "/usr/local/zephyr-sdk-*"
+          )
+          if(sdk_candidates)
+              list(SORT sdk_candidates COMPARE NATURAL ORDER DESCENDING)
+              list(GET sdk_candidates 0 SDK_DIR)
+          endif()
+      endif()
   endif()
-elseif("${ARCH}" STREQUAL "arm64")
-  set(triple aarch64-none-elf)
-elseif("${ARCH}" STREQUAL "x86")
-  if(CONFIG_64BIT)
-    set(triple x86_64-pc-none-elf)
-  else()
-    set(triple i686-pc-none-elf)
+
+  if(NOT SDK_DIR OR NOT EXISTS "${SDK_DIR}")
+      message(FATAL_ERROR "Zephyr SDK directory not found! Please set ZEPHYR_SDK_INSTALL_DIR or ZEPHYR_TOOLCHAIN_PATH environment variable.")
   endif()
-elseif("${ARCH}" STREQUAL "riscv")
-  if(CONFIG_64BIT)
-    set(triple riscv64-unknown-elf)
+
+  # Set ZEPHYR_SDK_INSTALL_DIR so that SDK cmake files can find it
+  set(ZEPHYR_SDK_INSTALL_DIR "${SDK_DIR}")
+
+  # Include target-specific triple settings from Zephyr SDK's LLVM directory
+  if(EXISTS "${SDK_DIR}/cmake/zephyr/llvm/target.cmake")
+      include("${SDK_DIR}/cmake/zephyr/llvm/target.cmake")
   else()
-    set(triple riscv32-unknown-elf)
+      message(FATAL_ERROR "Zephyr SDK LLVM target configuration not found at ${SDK_DIR}/cmake/zephyr/llvm/target.cmake")
+  endif()
+
+  # Include Zephyr SDK's GNU/general target mappings to determine the sysroot target names (e.g. riscv64-zephyr-elf, arm-zephyr-eabi, etc.)
+  if(EXISTS "${SDK_DIR}/cmake/zephyr/gnu/target.cmake")
+      include("${SDK_DIR}/cmake/zephyr/gnu/target.cmake")
+  elseif(EXISTS "${SDK_DIR}/cmake/zephyr/target.cmake")
+      include("${SDK_DIR}/cmake/zephyr/target.cmake")
+  endif()
+
+  # Fallback to the root-level target folder if the nested gnu subdirectory is missing
+  if(NOT EXISTS "${SYSROOT_DIR}" AND DEFINED SYSROOT_TARGET)
+      if(EXISTS "${SDK_DIR}/${SYSROOT_TARGET}/${SYSROOT_TARGET}")
+          set(SYSROOT_DIR "${SDK_DIR}/${SYSROOT_TARGET}/${SYSROOT_TARGET}")
+      endif()
+  endif()
+
+  if(SYSROOT_DIR AND EXISTS "${SYSROOT_DIR}")
+      list(APPEND TOOLCHAIN_C_FLAGS --sysroot=${SYSROOT_DIR})
+      list(APPEND TOOLCHAIN_LD_FLAGS --sysroot=${SYSROOT_DIR})
+  else()
+      message(FATAL_ERROR "Could not resolve sysroot directory for target '${SYSROOT_TARGET}' in Zephyr SDK at '${SDK_DIR}'")
+  endif()
+
+  # Instruct custom LLVM Clang to use the Zephyr SDK's LLVM resource directory.
+  # The resource-dir contains embedded compiler-rt and clang builtins.
+  # We dynamically locate the resource-dir (which is versioned, e.g. lib/clang/20) using file(GLOB).
+  if(NOT "${ARCH}" STREQUAL "xtensa")
+    file(GLOB CLANG_RESOURCE_DIR LIST_DIRECTORIES true "${SDK_DIR}/llvm/lib/clang/[0-9]*")
+    if(CLANG_RESOURCE_DIR)
+        list(GET CLANG_RESOURCE_DIR 0 SDK_CLANG_RESOURCE_DIR)
+        list(APPEND TOOLCHAIN_C_FLAGS -resource-dir=${SDK_CLANG_RESOURCE_DIR})
+        list(APPEND TOOLCHAIN_LD_FLAGS -resource-dir=${SDK_CLANG_RESOURCE_DIR})
+    else()
+        message(FATAL_ERROR "Clang resource directory not found in ${SDK_DIR}/llvm/lib/clang/")
+    endif()
+  endif()
+
+  # Override compiler_set_linker_properties to query the SDK compiler for runtime libraries.
+  set(COMPILER_SET_LINKER_PROPERTIES_DEFINED TRUE)
+  function(compiler_set_linker_properties)
+    # Find the SDK directory. We prefer the CMake variable, then environment variable.
+    if(DEFINED ZEPHYR_SDK_INSTALL_DIR)
+      set(SDK_DIR "${ZEPHYR_SDK_INSTALL_DIR}")
+    elseif(DEFINED ENV{ZEPHYR_SDK_INSTALL_DIR})
+      set(SDK_DIR "$ENV{ZEPHYR_SDK_INSTALL_DIR}")
+    elseif(DEFINED ZEPHYR_TOOLCHAIN_PATH)
+      set(SDK_DIR "${ZEPHYR_TOOLCHAIN_PATH}")
+    elseif(DEFINED ENV{ZEPHYR_TOOLCHAIN_PATH})
+      set(SDK_DIR "$ENV{ZEPHYR_TOOLCHAIN_PATH}")
+    else()
+      # Try finding Zephyr-sdk package using find_package
+      find_package(Zephyr-sdk QUIET CONFIG)
+      if(ZEPHYR_SDK_INSTALL_DIR)
+        set(SDK_DIR "${ZEPHYR_SDK_INSTALL_DIR}")
+      elseif(Zephyr-sdk_FOUND AND Zephyr-sdk_DIR)
+        set(SDK_DIR "${Zephyr-sdk_DIR}")
+      else()
+        # Fallback search in standard directories
+        file(GLOB sdk_candidates
+          LIST_DIRECTORIES true
+          "$ENV{HOME}/zephyr-sdk-*"
+          "/opt/zephyr-sdk-*"
+          "$ENV{HOME}/.local/zephyr-sdk-*"
+          "/usr/local/zephyr-sdk-*"
+        )
+        if(sdk_candidates)
+          list(SORT sdk_candidates COMPARE NATURAL ORDER DESCENDING)
+          list(GET sdk_candidates 0 SDK_DIR)
+        endif()
+      endif()
+    endif()
+
+    if(NOT SDK_DIR OR NOT EXISTS "${SDK_DIR}")
+      message(FATAL_ERROR "Zephyr SDK directory not found! Please define ZEPHYR_SDK_INSTALL_DIR or ZEPHYR_TOOLCHAIN_PATH environment variable.")
+    endif()
+
+    set(SDK_CLANG "${SDK_DIR}/llvm/bin/clang")
+
+    if(EXISTS "${SDK_CLANG}" AND NOT "${ARCH}" STREQUAL "xtensa")
+      # We query the SDK clang for the multilib builtins path.
+      # We need to filter out -resource-dir and --sysroot from TOOLCHAIN_C_FLAGS
+      # to let the SDK Clang query its own default multilib mappings.
+      set(query_compiler "${SDK_CLANG}")
+      set(filtered_flags "")
+      foreach(flag ${TOOLCHAIN_C_FLAGS})
+        if(NOT flag MATCHES "^-resource-dir=" AND NOT flag MATCHES "^--sysroot=")
+          list(APPEND filtered_flags ${flag})
+        endif()
+      endforeach()
+    else()
+      # Fallback to the host compiler if SDK clang doesn't exist (or for xtensa)
+      set(query_compiler "${CMAKE_C_COMPILER}")
+      set(filtered_flags "")
+      foreach(flag ${TOOLCHAIN_C_FLAGS})
+        if(NOT flag MATCHES "^-resource-dir=" AND NOT flag MATCHES "^--sysroot=")
+          list(APPEND filtered_flags ${flag})
+        endif()
+      endforeach()
+    endif()
+
+    # Get compile options without generator expressions
+    get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_COMPILE_OPTIONS)
+    set(simple_options "")
+    foreach(flag ${flags})
+      string(GENEX_STRIP "${flag}" sflag)
+      if(flag STREQUAL sflag)
+        if(flag MATCHES "^SHELL:[ ]*(.*)")
+          separate_arguments(flag UNIX_COMMAND ${CMAKE_MATCH_1})
+        endif()
+        if(NOT flag MATCHES "^-resource-dir=" AND NOT flag MATCHES "^--sysroot=")
+          list(APPEND simple_options ${flag})
+        endif()
+      endif()
+    endforeach()
+
+    if(DEFINED CMAKE_C_COMPILER_TARGET)
+      set(target_flag "--target=${CMAKE_C_COMPILER_TARGET}")
+    endif()
+    if("${ARCH}" STREQUAL "xtensa" AND DEFINED CONFIG_SOC)
+      list(APPEND target_flag "-mcpu=${CONFIG_SOC}")
+    endif()
+
+    # Query for the libgcc/compiler-rt library path
+    execute_process(
+      COMMAND ${query_compiler} ${filtered_flags} ${COMPILER_OPTIMIZATION_FLAG} ${simple_options}
+      ${target_flag}
+      --print-libgcc-file-name
+      OUTPUT_VARIABLE library_path
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+
+    if(library_path)
+      set_linker_property(PROPERTY lib_include_dir "")
+      set_linker_property(PROPERTY rt_library "${library_path}")
+    endif()
+  endfunction()
+
+else()
+  # Native builds (e.g. native_sim on posix) use the host sysroot and default configs.
+  if(CONFIG_LIBGCC_RTLIB)
+    set(runtime_lib "libgcc")
+  elseif(CONFIG_COMPILER_RT_RTLIB)
+    set(runtime_lib "compiler_rt")
+  endif()
+
+  if(DEFINED runtime_lib)
+    list(APPEND TOOLCHAIN_C_FLAGS
+         --config=${ZEPHYR_BASE}/cmake/toolchain/host/llvm/clang_${runtime_lib}.cfg)
+    list(APPEND TOOLCHAIN_LD_FLAGS
+         --config=${ZEPHYR_BASE}/cmake/toolchain/host/llvm/clang_${runtime_lib}.cfg)
   endif()
 endif()
-
-if(DEFINED triple)
-  set(CMAKE_C_COMPILER_TARGET   ${triple})
-  set(CMAKE_ASM_COMPILER_TARGET ${triple})
-  set(CMAKE_CXX_COMPILER_TARGET ${triple})
-
-  unset(triple)
-endif()
-
-if(CONFIG_LIBGCC_RTLIB)
-  set(runtime_lib "libgcc")
-elseif(CONFIG_COMPILER_RT_RTLIB)
-  set(runtime_lib "compiler_rt")
-endif()
-
-list(APPEND TOOLCHAIN_C_FLAGS
-     --config=${ZEPHYR_BASE}/cmake/toolchain/host/llvm/clang_${runtime_lib}.cfg)
-list(APPEND TOOLCHAIN_LD_FLAGS
-     --config=${ZEPHYR_BASE}/cmake/toolchain/host/llvm/clang_${runtime_lib}.cfg)

--- a/doc/develop/toolchains/host.rst
+++ b/doc/develop/toolchains/host.rst
@@ -3,10 +3,114 @@
 Host Toolchains
 ###############
 
-In some specific configurations, like when building for non-MCU x86 targets on
-a Linux host, you may be able to reuse the native development tools provided
-by your operating system.
+In some configurations, you may want to use compiler toolchains installed on your host
+operating system rather than Zephyr's SDK pre-packaged cross-compilers.
 
-To use your host gcc, set the :envvar:`ZEPHYR_TOOLCHAIN_VARIANT`
-:ref:`environment variable <env_vars>` to ``host/gnu``. To use clang, set
-:envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``host/llvm``.
+Using Host GCC
+==============
+
+To build using the host's native GCC compiler, set the :envvar:`ZEPHYR_TOOLCHAIN_VARIANT`
+environment variable to ``host/gnu``. This is typically used when building for native
+simulator (POSIX architecture) based targets on a Linux host.
+
+Using Host LLVM/Clang (``host/llvm``)
+=====================================
+
+Building for Native Simulator Targets
+-------------------------------------
+
+You can also use host-installed LLVM/Clang for building native simulator (POSIX
+architecture) based targets on Linux. This uses the host OS's native C library and system
+headers rather than the embedded Zephyr SDK sysroots.
+
+Building for Embedded Targets
+-----------------------------
+
+Zephyr allows you to build standard embedded bare-metal firmware using a host-installed
+version of LLVM/Clang (such as Apple Clang, Homebrew LLVM, or package-managed LLVM on
+Linux) while dynamically binding to the bare-metal runtimes and sysroots shipped inside
+the Zephyr SDK.
+
+This is highly beneficial for utilizing the latest compiler optimizations, tools, or custom
+build pipelines without losing target device library support.
+
+.. note::
+   When building for **Espressif targets** (particularly Xtensa-based chips like ESP32,
+   ESP32-S2, and ESP32-S3), the upstream LLVM backend is still experimental. It is highly
+   recommended to use the official
+   `Espressif LLVM fork <https://github.com/espressif/llvm-project>`_
+   as your ``host/llvm`` compiler to ensure full compatibility and prevent backend crashes.
+
+Setup and Variables
+~~~~~~~~~~~~~~~~~~~
+
+To use the host LLVM toolchain, configure the following variables (either in your
+environment or as CMake arguments):
+
+1. **Set the Toolchain Variant**:
+   Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``host/llvm``.
+
+2. **Specify the Host LLVM Directory** *(Optional)*:
+   Set the :envvar:`LLVM_TOOLCHAIN_PATH` (or :envvar:`CLANG_ROOT_DIR`) variable to the
+   root of your host LLVM installation (the directory containing ``bin/clang``).
+
+   If unset, the build system automatically attempts to discover your host LLVM compiler
+   across standard system locations, Homebrew opt paths (supporting versioned formulas from
+   ``llvm@15`` up to ``llvm@25``), and versioned Linux folders (``/usr/lib/llvm-XX``).
+
+3. **Specify the Zephyr SDK Directory**:
+   Because host Clang is a native compiler and lacks built-in target runtime libraries
+   (like ``libclang_rt.builtins.a``) for embedded architectures, it needs to link against
+   the runtimes packaged inside the Zephyr SDK.
+
+   Ensure that :envvar:`ZEPHYR_SDK_INSTALL_DIR` (or :envvar:`ZEPHYR_TOOLCHAIN_PATH`) is
+   set to the path of your installed Zephyr SDK. The toolchain automatically resolves the
+   correct target architecture triplets and sysroots from it.
+
+Example Shell Usage
+-------------------
+
+To configure the build using environment variables:
+
+.. code-block:: console
+
+   # 1. Point to host-installed LLVM (example for macOS Homebrew)
+   export LLVM_TOOLCHAIN_PATH=$(brew --prefix llvm)
+
+   # 2. Point to the Zephyr SDK installation
+   export ZEPHYR_SDK_INSTALL_DIR=$HOME/zephyr-sdk-1.0.1
+
+   # 3. Compile the build using the host LLVM variant
+   west build -b esp32_devkitc -- -DZEPHYR_TOOLCHAIN_VARIANT=host/llvm
+
+Using custom linker choice
+--------------------------
+
+By default, the LLVM toolchain variant compiles with the standard LLVM linker (``LLD``).
+You can manually override the linker choice by setting the Kconfig choice
+``CONFIG_LLVM_USE_LD=y`` if you need to fall back to the GNU linker.
+
+Comparison: Host LLVM (``host/llvm``) vs SDK LLVM (``zephyr/llvm``)
+===================================================================
+
+Zephyr offers two distinct ways to build your firmware with the LLVM/Clang compiler:
+
+*   **SDK-Bundled LLVM (``zephyr/llvm``)**:
+
+    *   **Description**: Uses the precompiled Clang/LLD binary toolchain shipped directly
+        inside the Zephyr SDK.
+    *   **How to run**: Set ``ZEPHYR_TOOLCHAIN_VARIANT=zephyr/llvm`` (shorthand for
+        setting variant to ``zephyr`` and ``TOOLCHAIN_VARIANT_COMPILER=llvm``).
+    *   **LLVM_TOOLCHAIN_PATH**: Not used, as the build system automatically resolves the
+        compiler path inside the active SDK directory.
+
+*   **Host-Installed LLVM (``host/llvm``)**:
+
+    *   **Description**: Uses a Clang/LLVM compiler installed directly on your host machine
+        (e.g., Apple Clang, Homebrew LLVM, or system-packaged LLVM on Linux) while
+        referencing target headers and libraries from the Zephyr SDK.
+    *   **How to run**: Set ``ZEPHYR_TOOLCHAIN_VARIANT=host/llvm``.
+    *   **LLVM_TOOLCHAIN_PATH**: Can be used (or the ``CLANG_ROOT_DIR`` environment
+        variable) to point to the base installation folder of your host LLVM toolchain.
+        If left unset, the build system automatically queries your host environment for
+        standard installation folders.

--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -262,6 +262,31 @@ Zephyr SDK installation
             You must rerun the setup script if you relocate the Zephyr SDK bundle directory after
             the initial setup.
 
+.. _toolchain_zephyr_sdk_llvm:
+
+Using the SDK's Built-in LLVM/Clang (``zephyr/llvm``)
+*****************************************************
+
+If you have installed the Zephyr LLVM SDK bundle (or combined both the GNU and LLVM SDK
+bundles in the same installation directory), you can configure the build system to use the
+SDK's packaged Clang compiler by setting:
+
+* Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``zephyr/llvm``.
+
+For example:
+
+.. code-block:: console
+
+   west build -b esp32_devkitc -- -DZEPHYR_TOOLCHAIN_VARIANT=zephyr/llvm
+
+Setting ``ZEPHYR_TOOLCHAIN_VARIANT`` to the pattern ``<variant>/<compiler>``
+(e.g. ``zephyr/llvm``) is a built-in shorthand. The build system will automatically parse
+it, setting the toolchain variant to ``zephyr`` and the compiler variable
+``TOOLCHAIN_VARIANT_COMPILER`` to ``llvm``.
+
+This will compile and link your firmware using the ``clang`` and ``ld.lld`` binaries
+packaged directly within the Zephyr SDK.
+
 .. _Zephyr SDK Releases: https://github.com/zephyrproject-rtos/sdk-ng/tags
 .. _Zephyr SDK Version Compatibility Matrix: https://github.com/zephyrproject-rtos/sdk-ng/wiki/Zephyr-Version-Compatibility#zephyr-sdk-version-compatibility-matrix
 

--- a/include/zephyr/linker/thread-local-storage.ld
+++ b/include/zephyr/linker/thread-local-storage.ld
@@ -18,10 +18,17 @@
 		*(.tdata .tdata.* .gnu.linkonce.td.*);
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
+#if defined(RODATA_REGION)
+	SECTION_DATA_PROLOGUE(tbss,(NOLOAD),)
+	{
+		*(.tbss .tbss.* .gnu.linkonce.tb.* .tcommon);
+	} GROUP_LINK_IN(RODATA_REGION)
+#else
 	SECTION_DATA_PROLOGUE(tbss,(NOLOAD),)
 	{
 		*(.tbss .tbss.* .gnu.linkonce.tb.* .tcommon);
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif
 
 #if defined(CONFIG_STACK_CANARIES_TLS_PREPEND)
 #ifdef CONFIG_XIP

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -580,6 +580,15 @@ do {                                                                    \
 	defined(CONFIG_MIPS) || defined(CONFIG_OPENRISC)
 
 /* No special prefixes necessary for constants in this arch AFAICT */
+#if defined(__clang__) && defined(CONFIG_XTENSA)
+#define GEN_ABSOLUTE_SYM(name, value)		\
+	__asm__ __volatile__(".globl\t" #name "\n\t.equ\t" #name \
+		",%0" :  : "n"(value))
+
+#define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
+	__asm__ __volatile__(".globl\t" #name                    \
+		"\n\t.equ\t" #name "," #value)
+#else
 #define GEN_ABSOLUTE_SYM(name, value)		\
 	__asm__ __volatile__(".globl\t" #name "\n\t.equ\t" #name \
 		",%0"                              \
@@ -589,6 +598,7 @@ do {                                                                    \
 	__asm__ __volatile__(".globl\t" #name                    \
 		"\n\t.equ\t" #name "," #value       \
 		"\n\t.type\t" #name ",%object")
+#endif /* defined(__clang__) && defined(CONFIG_XTENSA) */
 
 #elif defined(CONFIG_SPARC)
 #define GEN_ABSOLUTE_SYM(name, value)			\


### PR DESCRIPTION
Improve LLVM/Clang and LLD linker toolchain support across the Zephyr ecosystem to allow building with host/llvm and zephyr/llvm variants.
Tested with these PRs:
https://github.com/zephyrproject-rtos/zephyr/pull/109801
https://github.com/zephyrproject-rtos/hal_espressif/pull/567

- cmake: clang: Add support for Xtensa and RISC-V target architectures by parsing GCC cross-compiler paths to determine ABI, sysroot, and multilib directories.
- cmake: clang: Fix target_xtensa.cmake and target_riscv.cmake flags.
- cmake: gcc: Cleanup target_riscv.cmake GCC fallback logic.
- cmake: lld: Remove unsupported `-u` arguments in extensions.cmake since LLD does not support certain GNU linker specific flags.
- host/llvm: Update generic.cmake to automatically detect host Clang and LLD on Linux and macOS (Homebrew/opt paths).
- linker: thread-local-storage.ld: Fix LLD alignment issues by forcing strict ALIGN() rules for the .tdata and .tbss sections.
- toolchain: gcc.h: Add missing builtins and extensions for Clang compatibility.
- docs: Update host.rst and zephyr_sdk.rst to document the new host LLVM features and recommend Espressif's LLVM fork for Xtensa.

(Edit by @aescolar) doc render: https://builds.zephyrproject.io/zephyr/pr/110283/docs/develop/toolchains/index.html