### PR TITLE
drivers: LIS3MDL: Fix burst read

### DIFF
--- a/drivers/sensor/st/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/st/lis3mdl/lis3mdl.c
@@ -70,8 +70,9 @@ int lis3mdl_sample_fetch(const struct device *dev, enum sensor_channel chan)
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_MAGN_XYZ);
 
 	/* fetch magnetometer sample */
-	if (i2c_burst_read_dt(&config->i2c, LIS3MDL_REG_SAMPLE_START,
-			      (uint8_t *)buf, 8) < 0) {
+	if (i2c_burst_read_dt(&config->i2c,
+			      LIS3MDL_REG_SAMPLE_START | LIS3MDL_I2C_BURST_READ,
+			      (uint8_t *)buf, 6) < 0) {
 		LOG_DBG("Failed to fetch magnetometer sample.");
 		return -EIO;
 	}
@@ -81,7 +82,8 @@ int lis3mdl_sample_fetch(const struct device *dev, enum sensor_channel chan)
 	 * the same read as magnetometer data, so do another
 	 * burst read to fetch the temperature sample
 	 */
-	if (i2c_burst_read_dt(&config->i2c, LIS3MDL_REG_SAMPLE_START + 6,
+	if (i2c_burst_read_dt(&config->i2c,
+			      (LIS3MDL_REG_SAMPLE_START + 6) | LIS3MDL_I2C_BURST_READ,
 			      (uint8_t *)(buf + 3), 2) < 0) {
 		LOG_DBG("Failed to fetch temperature sample.");
 		return -EIO;

--- a/drivers/sensor/st/lis3mdl/lis3mdl.h
+++ b/drivers/sensor/st/lis3mdl/lis3mdl.h
@@ -85,6 +85,8 @@
 #define LIS3MDL_INT_XYZ_EN              \
 	(LIS3MDL_INT_X_EN | LIS3MDL_INT_Y_EN | LIS3MDL_INT_Z_EN)
 
+#define LIS3MDL_I2C_BURST_READ		BIT(7)
+
 static const char * const lis3mdl_odr_strings[] = {
 	"0.625", "1.25", "2.5", "5", "10", "20",
 	"40", "80", "155", "300", "560", "1000"

--- a/drivers/sensor/st/lis3mdl/lis3mdl_trigger.c
+++ b/drivers/sensor/st/lis3mdl/lis3mdl_trigger.c
@@ -33,7 +33,8 @@ int lis3mdl_trigger_set(const struct device *dev,
 	__ASSERT_NO_MSG(trig->type == SENSOR_TRIG_DATA_READY);
 
 	/* dummy read: re-trigger interrupt */
-	ret = i2c_burst_read_dt(&config->i2c, LIS3MDL_REG_SAMPLE_START,
+	ret = i2c_burst_read_dt(&config->i2c,
+				LIS3MDL_REG_SAMPLE_START | LIS3MDL_I2C_BURST_READ,
 				(uint8_t *)buf, 6);
 	if (ret != 0) {
 		return ret;


### PR DESCRIPTION
LIS3MDL burst read requires high bit of address set or it will only read a single byte. 

Add a macro for the burst read bit and apply it.