### PR TITLE
drivers: ethernet: smi: Add Microchip SMI bus support.

### DIFF
--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -116,3 +116,4 @@ config ETH_NET_IF_NO_AUTO_START
 	  bring the interface up.
 
 source "drivers/ethernet/mdio/Kconfig"
+source "drivers/ethernet/smi/Kconfig"

--- a/drivers/ethernet/smi/CMakeLists.txt
+++ b/drivers/ethernet/smi/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources_ifdef(CONFIG_SMI_SHELL smi_shell.c)
+zephyr_library_sources_ifdef(CONFIG_SMI_GPIO smi_gpio.c)

--- a/drivers/ethernet/smi/Kconfig
+++ b/drivers/ethernet/smi/Kconfig
@@ -1,0 +1,42 @@
+# SMI configuration options
+
+# Copyright (c) 2026 Bas van Loon
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# SMI options
+#
+menuconfig SMI
+	bool "Simple Management Interface (SMI) drivers"
+	help
+	  Enable SMI Driver Configuration
+
+if SMI
+
+config SMI_SHELL
+	bool "SMI Shell"
+	depends on SHELL
+	help
+	  Enable SMI Shell.
+
+	  The SMI shell currently supports scanning and device
+	  read/write.
+
+config SMI_GPIO
+	bool "GPIO bitbang SMI controller driver"
+	default y
+	depends on DT_HAS_MICROCHIP_SMI_GPIO_ENABLED
+	help
+	  Enable software driven (bit banging) SMI support using GPIO pins
+
+config SMI_INIT_PRIORITY
+	int "Init priority"
+	default ETH_INIT_PRIORITY
+	help
+	  SMI device driver initialization priority.
+
+module = SMI
+module-str = smi
+source "subsys/logging/Kconfig.template.log_config"
+
+endif # SMI

--- a/drivers/ethernet/smi/smi_gpio.c
+++ b/drivers/ethernet/smi/smi_gpio.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2023 Aleksandr Senin
+ * Copyright (c) 2026 Bas van Loon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT microchip_smi_gpio
+
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/smi.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(smi_gpio, CONFIG_SMI_LOG_LEVEL);
+
+#define SMI_GPIO_READ_OP  0
+#define SMI_GPIO_WRITE_OP 1
+#define SMI_GPIO_MSB      0x80000000
+
+struct smi_gpio_data {
+	struct k_sem sem;
+};
+
+struct smi_gpio_config {
+	struct gpio_dt_spec smi_clock_gpio;
+	struct gpio_dt_spec smi_data_gpio;
+};
+
+static ALWAYS_INLINE void smi_gpio_clock_the_bit_read(const struct smi_gpio_config *dev_cfg)
+{
+	gpio_pin_set_dt(&dev_cfg->smi_clock_gpio, 1);
+	k_busy_wait(1);
+	gpio_pin_set_dt(&dev_cfg->smi_clock_gpio, 0);
+	k_busy_wait(1);
+}
+
+static ALWAYS_INLINE void smi_gpio_clock_the_bit_write(const struct smi_gpio_config *dev_cfg)
+{
+	k_busy_wait(1);
+	gpio_pin_set_dt(&dev_cfg->smi_clock_gpio, 1);
+	k_busy_wait(1);
+	gpio_pin_set_dt(&dev_cfg->smi_clock_gpio, 0);
+}
+
+static ALWAYS_INLINE void smi_gpio_dir(const struct smi_gpio_config *dev_cfg, uint8_t dir)
+{
+	gpio_pin_configure_dt(&dev_cfg->smi_data_gpio,
+			      dir == SMI_GPIO_WRITE_OP ? GPIO_OUTPUT_ACTIVE : GPIO_INPUT);
+	if (dir == SMI_GPIO_READ_OP) {
+		smi_gpio_clock_the_bit_read(dev_cfg);
+	}
+}
+
+static ALWAYS_INLINE void smi_gpio_read(const struct smi_gpio_config *dev_cfg, uint16_t *pdata,
+					uint8_t len)
+{
+	uint16_t data = 0;
+
+	for (uint16_t i = 0; i < len; i++) {
+		data <<= 1;
+		smi_gpio_clock_the_bit_read(dev_cfg);
+		if (gpio_pin_get_dt(&dev_cfg->smi_data_gpio) == 1) {
+			data |= 1;
+		}
+	}
+
+	*pdata = data;
+}
+
+static ALWAYS_INLINE void smi_gpio_write(const struct smi_gpio_config *dev_cfg, uint32_t data,
+					 uint8_t len)
+{
+	uint32_t v_data = data;
+	uint32_t v_len = len;
+
+	v_data <<= 32 - v_len;
+	for (; v_len > 0; v_len--) {
+		gpio_pin_set_dt(&dev_cfg->smi_data_gpio, (v_data & SMI_GPIO_MSB) ? 1 : 0);
+		smi_gpio_clock_the_bit_write(dev_cfg);
+		v_data <<= 1;
+	}
+}
+
+static int smi_gpio_transfer(const struct device *dev, uint8_t prtad, uint8_t devad, uint8_t rw,
+			     uint16_t data_in, uint16_t *data_out)
+{
+	const struct smi_gpio_config *const dev_cfg = dev->config;
+	struct smi_gpio_data *const dev_data = dev->data;
+
+	k_sem_take(&dev_data->sem, K_FOREVER);
+
+	/* DIR: output */
+	smi_gpio_dir(dev_cfg, SMI_GPIO_WRITE_OP);
+	/* PRE32: 32 bits '1' for sync*/
+	smi_gpio_write(dev_cfg, 0xFFFFFFFF, 32);
+	/* ST: 2 bits start of frame */
+	smi_gpio_write(dev_cfg, 0x1, 2);
+	/* OP: 2 bits opcode, fixed 0 */
+	smi_gpio_write(dev_cfg, 0, 2);
+
+	/* PA5: 5 bits PHY address. Bit 4 set for read, clear for write */
+	if (rw) {
+		smi_gpio_write(dev_cfg, prtad, 5);
+	} else {
+		smi_gpio_write(dev_cfg, prtad | BIT(4), 5);
+	}
+
+	/* RA5: 5 bits register address */
+	smi_gpio_write(dev_cfg, devad, 5);
+
+	if (rw) { /* Write data */
+		/* TA: 2 bits turn-around */
+		smi_gpio_write(dev_cfg, 0x2, 2);
+		smi_gpio_write(dev_cfg, data_in, 16);
+	} else { /* Read data */
+		/* Release the SMI line */
+		smi_gpio_dir(dev_cfg, SMI_GPIO_READ_OP);
+		smi_gpio_read(dev_cfg, data_out, 16);
+	}
+
+	/* DIR: input. Tristate SMI line */
+	smi_gpio_dir(dev_cfg, SMI_GPIO_READ_OP);
+
+	k_sem_give(&dev_data->sem);
+
+	return 0;
+}
+
+static int smi_gpio_bus_enable(const struct device *dev)
+{
+	const struct smi_gpio_config *const dev_cfg = dev->config;
+	int rc;
+
+	rc = gpio_pin_configure_dt(&dev_cfg->smi_clock_gpio, GPIO_OUTPUT_INACTIVE);
+	if (rc < 0) {
+		LOG_ERR("Couldn't configure SMI clock pin; (%d)", rc);
+		return rc;
+	}
+
+	rc = gpio_pin_configure_dt(&dev_cfg->smi_data_gpio, GPIO_INPUT);
+	if (rc < 0) {
+		LOG_ERR("Couldn't configure SMI data pin; (%d)", rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int smi_gpio_bus_disable(const struct device *dev)
+{
+	const struct smi_gpio_config *const dev_cfg = dev->config;
+	int rc;
+
+	rc = gpio_pin_configure_dt(&dev_cfg->smi_clock_gpio, GPIO_INPUT);
+	if (rc < 0) {
+		LOG_ERR("Couldn't configure SMI clock pin; (%d)", rc);
+		return rc;
+	}
+
+	rc = gpio_pin_configure_dt(&dev_cfg->smi_data_gpio, GPIO_INPUT);
+	if (rc < 0) {
+		LOG_ERR("Couldn't configure SMI data pin; (%d)", rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int smi_gpio_read_mmi(const struct device *dev, uint8_t prtad, uint8_t devad, uint16_t *data)
+{
+	return smi_gpio_transfer(dev, prtad, devad, SMI_GPIO_READ_OP, 0, data);
+}
+
+static int smi_gpio_write_mmi(const struct device *dev, uint8_t prtad, uint8_t devad, uint16_t data)
+{
+	return smi_gpio_transfer(dev, prtad, devad, SMI_GPIO_WRITE_OP, data, NULL);
+}
+
+static int smi_gpio_initialize(const struct device *dev)
+{
+	const struct smi_gpio_config *const dev_cfg = dev->config;
+	struct smi_gpio_data *const dev_data = dev->data;
+	int rc;
+
+	k_sem_init(&dev_data->sem, 1, 1);
+
+	if (!gpio_is_ready_dt(&dev_cfg->smi_clock_gpio)) {
+		LOG_ERR("GPIO port for SMI clock pin is not ready");
+		return -ENODEV;
+	}
+
+	if (!gpio_is_ready_dt(&dev_cfg->smi_data_gpio)) {
+		LOG_ERR("GPIO port for SMI data pin is not ready");
+		return -ENODEV;
+	}
+
+	rc = smi_gpio_bus_enable(dev);
+	if (rc < 0) {
+		LOG_ERR("Failed to enable SMI bus (%d)", rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(smi, smi_gpio_driver_api) = {
+	.bus_disable = smi_gpio_bus_disable,
+	.bus_enable = smi_gpio_bus_enable,
+	.read = smi_gpio_read_mmi,
+	.write = smi_gpio_write_mmi,
+};
+
+#define SMI_GPIO_CONFIG(inst)                                                                      \
+	static struct smi_gpio_config smi_gpio_dev_config_##inst = {                               \
+		.smi_clock_gpio = GPIO_DT_SPEC_INST_GET(inst, smi_clock_gpios),                    \
+		.smi_data_gpio = GPIO_DT_SPEC_INST_GET(inst, smi_data_gpios),                      \
+	};
+
+#define SMI_GPIO_DEVICE(inst)                                                                      \
+	SMI_GPIO_CONFIG(inst);                                                                     \
+	static struct smi_gpio_data smi_gpio_dev_data_##inst;                                      \
+	DEVICE_DT_INST_DEFINE(inst, &smi_gpio_initialize, NULL, &smi_gpio_dev_data_##inst,         \
+			      &smi_gpio_dev_config_##inst, POST_KERNEL, CONFIG_SMI_INIT_PRIORITY,  \
+			      &smi_gpio_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(SMI_GPIO_DEVICE)

--- a/drivers/ethernet/smi/smi_shell.c
+++ b/drivers/ethernet/smi/smi_shell.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 IP-Logix Inc.
+ * Copyright 2023 NXP
+ * Copyright 2026 Bas van Loon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/shell/shell.h>
+#include <stdlib.h>
+#include <zephyr/drivers/smi.h>
+#include <string.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/devicetree.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(smi_shell, CONFIG_LOG_DEFAULT_LEVEL);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(microchip_smi_gpio)
+#define DT_DRV_COMPAT microchip_smi_gpio
+#else
+#error "No known devicetree compatible match for SMI shell"
+#endif
+
+#define SMI_NODE_ID DT_COMPAT_GET_ANY_STATUS_OKAY(DT_DRV_COMPAT)
+
+/* smi write <port_addr> <reg_addr> <data> */
+static int cmd_smi_write(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	uint16_t data;
+	uint16_t reg_addr;
+	uint16_t port_addr;
+
+	dev = DEVICE_DT_GET(SMI_NODE_ID);
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "SMI: Device driver %s is not ready.", dev->name);
+
+		return -ENODEV;
+	}
+
+	port_addr = strtol(argv[1], NULL, 16);
+	reg_addr = strtol(argv[2], NULL, 16);
+	data = strtol(argv[3], NULL, 16);
+
+	smi_bus_enable(dev);
+
+	if (smi_write(dev, port_addr, reg_addr, data) < 0) {
+		shell_error(sh, "Failed to write to device: %s", dev->name);
+		smi_bus_disable(dev);
+
+		return -EIO;
+	}
+
+	smi_bus_disable(dev);
+
+	return 0;
+}
+
+/* smi read <port_addr> <reg_addr> */
+static int cmd_smi_read(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	uint16_t data;
+	uint16_t reg_addr;
+	uint16_t port_addr;
+
+	dev = DEVICE_DT_GET(SMI_NODE_ID);
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "SMI: Device driver %s is not ready.", dev->name);
+
+		return -ENODEV;
+	}
+
+	port_addr = strtol(argv[1], NULL, 16);
+	reg_addr = strtol(argv[2], NULL, 16);
+
+	smi_bus_enable(dev);
+
+	if (smi_read(dev, port_addr, reg_addr, &data) < 0) {
+		shell_error(sh, "Failed to read from device: %s", dev->name);
+		smi_bus_disable(dev);
+
+		return -EIO;
+	}
+
+	smi_bus_disable(dev);
+
+	shell_print(sh, "%x[%x]: 0x%x", port_addr, reg_addr, data);
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_smi_cmds,
+	SHELL_CMD_ARG(read, NULL,
+		"Read from SMI device: read <phy_addr> <reg_addr>",
+		cmd_smi_read, 3, 0),
+	SHELL_CMD_ARG(write, NULL,
+		"Write to SMI device: write <phy_addr> <reg_addr> <value>",
+		cmd_smi_write, 4, 0),
+	SHELL_SUBCMD_SET_END     /* Array terminated. */
+);
+
+SHELL_CMD_REGISTER(smi, &sub_smi_cmds, "SMI commands", NULL);

--- a/dts/bindings/binding-types.txt
+++ b/dts/bindings/binding-types.txt
@@ -123,6 +123,7 @@ serial	Serial controller
 shi	SHI (Serial Host Interface)
 sip_svc	Service in Platform
 smbus	SMbus (System Management Bus)
+smi	SMI (Simple Management Interface)
 sound	Sound
 spi	SPI (Serial Peripheral Interface)
 sram	SRAM (Static Random Access Memory)

--- a/dts/bindings/ethernet/smi/microchip,smi-gpio.yaml
+++ b/dts/bindings/ethernet/smi/microchip,smi-gpio.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 Bas van Loon
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Microchip SMI bitbang driver. This is a custom MDIO bitbang driver using GPIOs, used for
+  the SMI interface of Microchip KSZ8xxx ethernet switch.
+
+compatible: "microchip,smi-gpio"
+
+include: smi-controller.yaml
+
+properties:
+  smi-clock-gpios:
+    type: phandle-array
+    required: true
+    description: GPIO pin for the SMI clock line
+
+  smi-data-gpios:
+    type: phandle-array
+    required: true
+    description: GPIO pin for the SMI data line

--- a/dts/bindings/ethernet/smi/smi-controller.yaml
+++ b/dts/bindings/ethernet/smi/smi-controller.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Bas van Loon
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for SMI controllers
+
+include: base.yaml
+
+bus: smi

--- a/include/zephyr/drivers/smi.h
+++ b/include/zephyr/drivers/smi.h
@@ -1,0 +1,165 @@
+/**
+ * @file
+ *
+ * @brief Public APIs for SMI drivers.
+ */
+
+/*
+ * Copyright 2026 Bas van Loon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SMI_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SMI_H_
+
+/**
+ * @brief SMI Interface
+ * @defgroup smi_interface SMI Interface
+ * @ingroup io_interfaces
+ * @{
+ */
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <errno.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * These are for internal use only, so skip these in
+ * public documentation.
+ */
+__subsystem struct smi_driver_api {
+	/** Enable the SMI bus device */
+	int (*bus_enable)(const struct device *dev);
+
+	/** Disable the SMI bus device */
+	int (*bus_disable)(const struct device *dev);
+
+	/** Read data from SMI bus */
+	int (*read)(const struct device *dev, uint8_t prtad, uint8_t regad,
+		    uint16_t *data);
+
+	/** Write data to SMI bus */
+	int (*write)(const struct device *dev, uint8_t prtad, uint8_t regad,
+		     uint16_t data);
+};
+/**
+ * @endcond
+ */
+
+/**
+ * @brief      Enable SMI bus
+ *
+ * @param[in]  dev   Pointer to the device structure for the controller
+ *
+ */
+__syscall void smi_bus_enable(const struct device *dev);
+
+static inline void z_impl_smi_bus_enable(const struct device *dev)
+{
+	const struct smi_driver_api *api =
+		(const struct smi_driver_api *)dev->api;
+
+	if (api->bus_enable != NULL) {
+		api->bus_enable(dev);
+	}
+}
+
+/**
+ * @brief      Disable SMI bus and tri-state drivers
+ *
+ * @param[in]  dev   Pointer to the device structure for the controller
+ *
+ */
+__syscall void smi_bus_disable(const struct device *dev);
+
+static inline void z_impl_smi_bus_disable(const struct device *dev)
+{
+	const struct smi_driver_api *api =
+		(const struct smi_driver_api *)dev->api;
+
+	if (api->bus_disable != NULL) {
+		api->bus_disable(dev);
+	}
+}
+
+/**
+ * @brief      Read from SMI Bus
+ *
+ * This routine provides a generic interface to perform a read on the
+ * SMI bus.
+ *
+ * @param[in]  dev         Pointer to the device structure for the controller
+ * @param[in]  prtad       Port address
+ * @param[in]  regad       Register address
+ * @param      data        Pointer to receive read data
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input / output error.
+ * @retval -ETIMEDOUT If transaction timedout on the bus
+ * @retval -ENOSYS if read is not supported
+ */
+__syscall int smi_read(const struct device *dev, uint8_t prtad, uint8_t regad,
+			uint16_t *data);
+
+static inline int z_impl_smi_read(const struct device *dev, uint8_t prtad,
+				   uint8_t regad, uint16_t *data)
+{
+	const struct smi_driver_api *api =
+		(const struct smi_driver_api *)dev->api;
+
+	if (api->read == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->read(dev, prtad, regad, data);
+}
+
+
+/**
+ * @brief      Write to SMI bus
+ *
+ * This routine provides a generic interface to perform a write on the
+ * SMI bus.
+ *
+ * @param[in]  dev         Pointer to the device structure for the controller
+ * @param[in]  prtad       Port address
+ * @param[in]  regad       Register address
+ * @param[in]  data        Data to write
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input / output error.
+ * @retval -ETIMEDOUT If transaction timedout on the bus
+ * @retval -ENOSYS if write is not supported
+ */
+__syscall int smi_write(const struct device *dev, uint8_t prtad, uint8_t regad,
+			 uint16_t data);
+
+static inline int z_impl_smi_write(const struct device *dev, uint8_t prtad,
+				    uint8_t regad, uint16_t data)
+{
+	const struct smi_driver_api *api =
+		(const struct smi_driver_api *)dev->api;
+
+	if (api->write == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->write(dev, prtad, regad, data);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#include <zephyr/syscalls/smi.h>
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SMI_H_ */


### PR DESCRIPTION
Adds support for the Microchip SMI style configuration bus used in KSZxxxx Ethernet switches. It is a MDIO like protocol but differs in the way the OP field is encoded.
Due to this we cannot use standard MDIO.

The read or write operation is encoded in the port address field instead. The PHY address field and register address fields are in turn used to encode the register offset.

The reason it is necessary, besides using SPI on ie KSZ8863, is that it allows access to all the internal registers of the switch.

The normal MDIO bus only exposes the traditional PHY registers and not the switch related settings like MAC filter tables etc.