### PR TITLE
Infineon: get latest platform implementation for tf-m

### DIFF
--- a/modules/hal_infineon/zephyr-ifx-cycfg/CMakeLists.txt
+++ b/modules/hal_infineon/zephyr-ifx-cycfg/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 if(CONFIG_SOC_FAMILY_INFINEON_EDGE)
 if(CONFIG_BUILD_WITH_TFM)
-  set(zephyr_ifx_cycfg_dir ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/platform/ext/target/infineon/pse84/epc2/board/KIT_PSOCE84_EVK/shared/design/default/GeneratedSource)
+  set(zephyr_ifx_cycfg_dir ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/platform/ext/target/infineon/pse84/epc2/board/shared/design/default/GeneratedSource)
 
   zephyr_include_directories(${zephyr_ifx_cycfg_dir})
   zephyr_library_sources(${zephyr_ifx_cycfg_dir}/cycfg_qspi_memslot.c)

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -279,22 +279,6 @@ if(CONFIG_BUILD_WITH_TFM)
     )
   endif()
 
-  if(CONFIG_SOC_SERIES_PSE84)
-    include(${ZEPHYR_BASE}/soc/infineon/edge/pse84/pse84_metadata.cmake)
-    list(APPEND TFM_CMAKE_ARGS -DIFX_EPC=epc2)
-
-    # Use local hal_infineon assets instead of fetching from GitHub
-    list(APPEND TFM_CMAKE_ARGS
-      -DIFX_CORE_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/core-lib
-      -DIFX_DEV_SUPPORT_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-dsl-pse8xxgp
-      -DIFX_MTB_SRF_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-srf
-      -DIFX_ABSTRACTION_RTOS_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/abstraction-rtos
-      -DIFX_MTB_IPC_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-ipc
-      -DIFX_DEVICE_DB_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/device-db
-      -DIFX_BSP_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-template-pse8xxgp/files
-    )
-  endif()
-
   # By default TF-M installs TF-PSA-Crypto include files in the build directory,
   # but this will duplicate what's already provided by the TF-PSA-Crypto library
   # itself. Disable this, unless CONFIG_TFM_USE_NS_APP is set because in that

--- a/soc/infineon/edge/pse84/CMakeLists.txt
+++ b/soc/infineon/edge/pse84/CMakeLists.txt
@@ -5,6 +5,21 @@
 
 include(${ZEPHYR_BASE}/soc/infineon/edge/pse84/pse84_metadata.cmake)
 
+if(CONFIG_BUILD_WITH_TFM)
+  set_property(TARGET zephyr_property_target APPEND PROPERTY TFM_CMAKE_OPTIONS
+    -DIFX_EPC=epc2
+    -DIFX_UART_ENABLED=OFF
+    # Use local hal_infineon assets instead of fetching from GitHub
+    -DIFX_CORE_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/core-lib
+    -DIFX_DEV_SUPPORT_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-dsl-pse8xxgp
+    -DIFX_MTB_SRF_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-srf
+    -DIFX_ABSTRACTION_RTOS_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/abstraction-rtos
+    -DIFX_MTB_IPC_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-ipc
+    -DIFX_DEVICE_DB_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/device-db
+    -DIFX_BSP_LIB_PATH=${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-template-pse8xxgp/files
+  )
+endif()
+
 if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
   zephyr_sources(soc_pse84_m33_s.c)
 

--- a/west.yml
+++ b/west.yml
@@ -399,7 +399,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: fc9c70171ae43bfd99c57a7ca6374d7f4fa8e894
+      revision: ee0acbb142d27ea3eb829d8da217dfd41af462be
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Update west.yml to point to the tf-m PR bringing in the updates to the Infineon platform. 

Additionally correct CMakeLists.txt to the updated path for the pre generated files in the tf-m module.