### PR TITLE
twister: accept empty-soc board target form

### DIFF
--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -241,12 +241,21 @@ def generate_platforms(board_roots, soc_roots, arch_roots):
                             if rev.name == board.revision_default:
                                 alias2target[f"{board.name}"] = target
                             alias2target[f"{board.name}@{rev.name}"] = target
+                        elif '/' in qual and len(board.socs) == 1:
+                            cluster = qual.partition('/')[2]
+                            alias2target[f"{board.name}@{rev.name}//{cluster}"] = target
+                            if rev.name == board.revision_default:
+                                alias2target[f"{board.name}//{cluster}"] = target
                     else:
                         target = f"{board.name}/{qual}"
                         alias2target[target] = target
                         if '/' not in qual and len(board.socs) == 1 \
                                 and rev.name == board.revision_default:
                             alias2target[f"{board.name}"] = target
+                        elif '/' in qual and len(board.socs) == 1 \
+                                and rev.name == board.revision_default:
+                            cluster = qual.partition('/')[2]
+                            alias2target[f"{board.name}//{cluster}"] = target
 
                     target2board[target] = board
             else:
@@ -254,6 +263,9 @@ def generate_platforms(board_roots, soc_roots, arch_roots):
                 alias2target[target] = target
                 if '/' not in qual and len(board.socs) == 1:
                     alias2target[board.name] = target
+                elif '/' in qual and len(board.socs) == 1:
+                    cluster = qual.partition('/')[2]
+                    alias2target[f"{board.name}//{cluster}"] = target
                 target2board[target] = board
 
     for board_dir, data in dir2data.items():

--- a/scripts/tests/twister/test_platform.py
+++ b/scripts/tests/twister/test_platform.py
@@ -396,7 +396,7 @@ board:
             'type': 'native',
         },
         'p1e1/s1/v1': {
-            'aliases': ['p1e1/s1/v1'],
+            'aliases': ['p1e1/s1/v1', 'p1e1//v1'],
             # m0/boards/zephyr/p1/board.yml
             'vendor': 'zephyr',
             # m0/boards/zephyr/p1/twister.yaml (base)
@@ -406,7 +406,7 @@ board:
             'type': 'native',
         },
         'p1e1/s1/v2': {
-            'aliases': ['p1e1/s1/v2'],
+            'aliases': ['p1e1/s1/v2', 'p1e1//v2'],
             # m0/boards/zephyr/p1/board.yml
             'vendor': 'zephyr',
             # m0/boards/zephyr/p1/twister.yaml (base)
@@ -414,7 +414,7 @@ board:
             'type': 'native',
         },
         'p1e2/s1/v1': {
-            'aliases': ['p1e2/s1/v1'],
+            'aliases': ['p1e2/s1/v1', 'p1e2//v1'],
             # m0/boards/zephyr/p1/board.yml
             'vendor': 'zephyr',
             # m0/boards/zephyr/p1/twister.yaml (base)
@@ -431,13 +431,13 @@ board:
             'type': 'sim',
         },
         'p2/s1/v1': {
-            'aliases': ['p2/s1/v1'],
+            'aliases': ['p2/s1/v1', 'p2//v1'],
             # m0/boards/zephyr/p2/board.yml
             'vendor': 'zephyr',
             # m1/boards/zephyr/p2/p2_s1_v1.yaml
         },
         'p3@A/s2/c1': {
-            'aliases': ['p3@A/s2/c1', 'p3/s2/c1'],
+            'aliases': ['p3@A/s2/c1', 'p3/s2/c1', 'p3@A//c1', 'p3//c1'],
             # m0/boards/arm/p3/board.yml
             'vendor': 'arm',
             # m0/boards/arm/p3/twister.yaml (base + variant)
@@ -447,7 +447,7 @@ board:
             'type': 'unit',
         },
         'p3@B/s2/c1': {
-            'aliases': ['p3@B/s2/c1'],
+            'aliases': ['p3@B/s2/c1', 'p3@B//c1'],
             # m0/boards/arm/p3/board.yml
             'vendor': 'arm',
             # m0/boards/arm/p3/twister.yaml (base + variant)
@@ -457,7 +457,7 @@ board:
             'type': 'unit',
         },
         'p3@A/s2/c2': {
-            'aliases': ['p3@A/s2/c2', 'p3/s2/c2'],
+            'aliases': ['p3@A/s2/c2', 'p3/s2/c2', 'p3@A//c2', 'p3//c2'],
             # m0/boards/arm/p3/board.yml
             'vendor': 'arm',
             # m0/boards/arm/p3/twister.yaml (base)
@@ -467,7 +467,7 @@ board:
             'type': 'unit',
         },
         'p3@B/s2/c2': {
-            'aliases': ['p3@B/s2/c2'],
+            'aliases': ['p3@B/s2/c2', 'p3@B//c2'],
             # m0/boards/arm/p3/board.yml
             'vendor': 'arm',
             # m0/boards/arm/p3/twister.yaml (base)


### PR DESCRIPTION
Register board//cluster aliases for single-soc boards so twister resolves the same empty-soc form that west build already accepts.