### PR TITLE
drivers: wifi: siwx91x: re-seed BT coex PS profile in apply_power_save

### DIFF
--- a/drivers/bluetooth/hci/hci_silabs_siwx91x.c
+++ b/drivers/bluetooth/hci/hci_silabs_siwx91x.c
@@ -86,7 +86,7 @@ static int siwx91x_bt_setup(const struct device *dev, const struct bt_hci_setup_
 		return err;
 	}
 
-	err = siwx91x_nwp_apply_power_profile(hci_config->nwp_dev);
+	err = siwx91x_nwp_apply_power_profile(hci_config->nwp_dev, NULL);
 	if (err < 0) {
 		LOG_ERR("Failed to set power profile: %d", err);
 		return err;

--- a/drivers/wifi/siwx91x/siwx91x_wifi_ps.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_ps.c
@@ -41,10 +41,11 @@ static int siwx91x_get_connected_ap_beacon_interval_ms(void)
 
 int siwx91x_apply_power_save(struct siwx91x_dev *sidev)
 {
+	const struct device *wifi_dev = net_if_get_device(sidev->iface);
+	const struct siwx91x_config *cfg = wifi_dev->config;
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	sl_wifi_performance_profile_v2_t sl_ps_profile;
 	int beacon_interval;
-	int ret;
 
 	if (FIELD_GET(SIWX91X_INTERFACE_MASK, interface) != SL_WIFI_CLIENT_INTERFACE) {
 		LOG_ERR("Wi-Fi not in station mode");
@@ -93,8 +94,7 @@ int siwx91x_apply_power_save(struct siwx91x_dev *sidev)
 	}
 
 out:
-	ret = sl_wifi_set_performance_profile_v2(&sl_ps_profile);
-	return ret ? -EIO : 0;
+	return siwx91x_nwp_apply_power_profile(cfg->nwp_dev, &sl_ps_profile);
 }
 
 int siwx91x_set_power_save(const struct device *dev,

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
@@ -446,14 +446,15 @@ int siwx91x_nwp_mode_switch(const struct device *dev, uint8_t oper_mode, bool hi
 	return 0;
 }
 
-int siwx91x_nwp_apply_power_profile(const struct device *dev)
+int siwx91x_nwp_apply_power_profile(const struct device *dev,
+				    const sl_wifi_performance_profile_v2_t *wifi_profile)
 {
 	struct siwx91x_nwp_data *data = dev->data;
-	sl_wifi_performance_profile_v2_t performance_profile = {
-		.profile = data->power_profile
+	sl_wifi_performance_profile_v2_t default_wifi_profile = {
+		.profile = data->power_profile,
 	};
 	sl_bt_performance_profile_t bt_performance_profile = {
-		.profile = data->power_profile
+		.profile = data->power_profile,
 	};
 	int ret;
 
@@ -462,6 +463,10 @@ int siwx91x_nwp_apply_power_profile(const struct device *dev)
 		return 0;
 	}
 
+	/* WiseConnect zeros the BT half of its cached coex profile on every
+	 * sl_wifi_disconnect(). Re-seed it so the combined profile doesn't
+	 * resolve to HIGH_PERFORMANCE and silently drop the PS request.
+	 */
 	if (IS_ENABLED(CONFIG_BT_SILABS_SIWX91X)) {
 		ret = sl_si91x_bt_set_performance_profile(&bt_performance_profile);
 		if (ret) {
@@ -470,7 +475,10 @@ int siwx91x_nwp_apply_power_profile(const struct device *dev)
 		}
 	}
 
-	ret = sl_wifi_set_performance_profile_v2(&performance_profile);
+	if (!wifi_profile) {
+		wifi_profile = &default_wifi_profile;
+	}
+	ret = sl_wifi_set_performance_profile_v2(wifi_profile);
 	if (ret) {
 		return -EINVAL;
 	}
@@ -534,7 +542,7 @@ static int siwx91x_nwp_init(const struct device *dev)
 	 * bt_enable() is not called, you will never go in sleep.
 	 */
 	if (!IS_ENABLED(CONFIG_BT_SILABS_SIWX91X)) {
-		ret = siwx91x_nwp_apply_power_profile(dev);
+		ret = siwx91x_nwp_apply_power_profile(dev, NULL);
 		if (ret) {
 			return -EINVAL;
 		}

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.h
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.h
@@ -31,13 +31,20 @@ int siwx91x_nwp_mode_switch(const struct device *dev, uint8_t oper_mode, bool hi
 /*
  * @brief Apply the power profile for the NWP.
  *
- * This function applies the power profile for the NWP.
+ * Pushes both the Wi-Fi and BT halves of the NWP coex performance profile.
+ * The BT half is re-seeded from the NWP device's stored mode on every call
+ * because WiseConnect zeros it on each Wi-Fi disconnect.
  *
  * @param[in] dev           NWP device.
+ * @param[in] wifi_profile  Optional Wi-Fi performance profile to apply.
+ *                          If NULL, a default profile is built from the
+ *                          NWP device's stored mode (used by BT-only and
+ *                          init call sites).
  *
  * @return 0 on success, negative error code on failure.
  */
-int siwx91x_nwp_apply_power_profile(const struct device *dev);
+int siwx91x_nwp_apply_power_profile(const struct device *dev,
+				    const sl_wifi_performance_profile_v2_t *wifi_profile);
 
 /**
  * @brief Map an ISO/IEC 3166-1 alpha-2 country code to a Wi-Fi region code.


### PR DESCRIPTION
WiseConnect zeros the BT half of its cached coex performance profile on every Wi-Fi disconnect, leaving BT out of power save and preventing the NWP from sleeping after re-association.

Re-seed the BT performance profile to ASSOCIATED_POWER_SAVE inside siwx91x_apply_power_save() when CONFIG_BT_SILABS_SIWX91X is enabled, matching the default set by siwx91x_nwp_init().