### PR TITLE
xtensa: userspace: support generated privilege stack

### DIFF
--- a/arch/xtensa/core/coredump.c
+++ b/arch/xtensa/core/coredump.c
@@ -200,15 +200,22 @@ uint16_t arch_coredump_tgt_code_get(void)
 #if defined(CONFIG_DEBUG_COREDUMP_DUMP_THREAD_PRIV_STACK)
 void arch_coredump_priv_stack_dump(struct k_thread *thread)
 {
-	struct xtensa_thread_stack_header *hdr_stack_obj;
 	uintptr_t start_addr, end_addr;
 
-	hdr_stack_obj = (struct xtensa_thread_stack_header *)thread->stack_obj;
+#ifdef CONFIG_GEN_PRIV_STACKS
+	char *priv_stack = (char *)z_priv_stack_find(thread->stack_obj);
+
+	start_addr = (uintptr_t)priv_stack + K_KERNEL_STACK_RESERVED;
+	end_addr = start_addr + CONFIG_PRIVILEGED_STACK_SIZE;
+#else /* CONFIG_GEN_PRIV_STACKS */
+	struct xtensa_thread_stack_header *hdr_stack_obj =
+		(struct xtensa_thread_stack_header *)thread->stack_obj;
 
 	start_addr = (uintptr_t)&hdr_stack_obj->privilege_stack[0];
 	end_addr = start_addr + sizeof(hdr_stack_obj->privilege_stack);
 
 	coredump_memory_dump(start_addr, end_addr);
+#endif /* CONFIG_GEN_PRIV_STACKS */
 }
 #endif /* CONFIG_DEBUG_COREDUMP_DUMP_THREAD_PRIV_STACK */
 

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -215,12 +215,23 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 {
 	struct k_thread *current = _current;
 	size_t stack_end;
+	uint8_t *psp_stack_start;
+	size_t psp_stack_sz;
 
+#ifdef CONFIG_GEN_PRIV_STACKS
+	psp_stack_start = z_priv_stack_find(current->stack_obj);
+	psp_stack_sz = CONFIG_PRIVILEGED_STACK_SIZE;
+
+	current->arch.psp_stack_start = psp_stack_start;
+#else /* CONFIG_GEN_PRIV_STACKS */
 	struct xtensa_thread_stack_header *header =
 		(struct xtensa_thread_stack_header *)current->stack_obj;
 
-	current->arch.psp = header->privilege_stack +
-		sizeof(header->privilege_stack);
+	psp_stack_start = header->privilege_stack;
+	psp_stack_sz = sizeof(header->privilege_stack);
+#endif /* CONFIG_GEN_PRIV_STACKS */
+
+	current->arch.psp = psp_stack_start + psp_stack_sz;
 
 #ifdef CONFIG_INIT_STACKS
 	/* setup_thread_stack() does not initialize the architecture specific
@@ -231,13 +242,11 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 	 * Note that only user threads have privileged stacks and kernel
 	 * only threads do not.
 	 */
-	(void)memset(&header->privilege_stack[0], 0xaa, sizeof(header->privilege_stack));
-
+	(void)memset(psp_stack_start, 0xaa, psp_stack_sz);
 #endif
 
 #ifdef CONFIG_KERNEL_COHERENCE
-	sys_cache_data_flush_and_invd_range(&header->privilege_stack[0],
-					    sizeof(header->privilege_stack));
+	sys_cache_data_flush_and_invd_range(psp_stack_start, psp_stack_sz);
 #endif
 
 	/* Transition will reset stack pointer to initial, discarding
@@ -248,7 +257,7 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 				      current->stack_info.delta);
 
 	xtensa_userspace_enter(user_entry, p1, p2, p3,
-			       stack_end, current->stack_info.start);
+			       stack_end, (uint32_t)current->arch.psp);
 
 	CODE_UNREACHABLE;
 }
@@ -265,16 +274,21 @@ int arch_thread_priv_stack_space_get(const struct k_thread *thread, size_t *stac
 		return -EINVAL;
 	}
 
-	struct xtensa_thread_stack_header *hdr_stack_obj;
-
 	if ((thread->base.user_options & K_USER) != K_USER) {
 		return -EINVAL;
 	}
 
-	hdr_stack_obj = (struct xtensa_thread_stack_header *)thread->stack_obj;
+#ifdef CONFIG_GEN_PRIV_STACKS
+	return z_stack_space_get(thread->arch.psp_stack_start,
+				 CONFIG_PRIVILEGED_STACK_SIZE,
+				 unused_ptr);
+#else /* CONFIG_GEN_PRIV_STACKS */
+	struct xtensa_thread_stack_header *hdr_stack_obj =
+		(struct xtensa_thread_stack_header *)thread->stack_obj;
 
 	return z_stack_space_get(&hdr_stack_obj->privilege_stack[0],
 				 sizeof(hdr_stack_obj->privilege_stack),
 				 unused_ptr);
+#endif /* CONFIG_GEN_PRIV_STACKS */
 }
 #endif /* CONFIG_USERSPACE */

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -85,14 +85,34 @@ bool xtensa_is_outside_stack_bounds(uintptr_t addr, size_t sz, uint32_t ps)
 		 */
 		start = (uintptr_t)thread->stack_obj;
 		end = Z_STACK_PTR_ALIGN(thread->stack_info.start + thread->stack_info.size);
+
+#ifdef CONFIG_GEN_PRIV_STACKS
+		invalid = (addr <= start) || ((addr + sz) >= end);
+
+		/* With generated privilege stack, we also need to check the bound of
+		 * the separate privilege stack.
+		 */
+		if (invalid && (ps == UINT32_MAX)) {
+			start = (uintptr_t)thread->arch.psp_stack_start;
+			end = start + CONFIG_PRIVILEGED_STACK_SIZE;
+
+			invalid = (addr <= start) || ((addr + sz) >= end);
+		}
+#endif /* CONFIG_GEN_PRIV_STACKS */
+
 	} else if (((ps & PS_RING_MASK) == 0U) &&
 		   ((thread->base.user_options & K_USER) == K_USER)) {
 		/* Check if this is a user thread, and that it was running in
 		 * kernel mode. If so, we must have been doing a syscall, so
 		 * check with privileged stack bounds.
 		 */
+#ifdef CONFIG_GEN_PRIV_STACKS
+		start = (uintptr_t)thread->arch.psp_stack_start;
+		end = start + CONFIG_PRIVILEGED_STACK_SIZE;
+#else /* CONFIG_GEN_PRIV_STACKS */
 		start = thread->stack_info.start - CONFIG_PRIVILEGED_STACK_SIZE;
 		end = thread->stack_info.start;
+#endif /* CONFIG_GEN_PRIV_STACKS */
 #endif
 	} else {
 		start = thread->stack_info.start;

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -730,3 +730,8 @@ Architectures
 
 * ``xtensa_soc_mpu_ranges[]`` and ``xtensa_soc_mpu_ranges_num`` are removed. If SoC or board
   needs its own memory regions at boot, override :c:var:`xtensa_mpu_ranges` instead.
+
+* The Xtensa MPU (:kconfig:option:`CONFIG_XTENSA_MPU`) userspace port can now support
+  generated privileged stacks (:kconfig:option:`CONFIG_GEN_PRIV_STACKS`) instead of
+  embedding the privilege stack inside each thread stack object. Linker scripts and
+  ``xtensa_soc_mpu_ranges[]`` may need to be modified to accommodate this if enabled.

--- a/include/zephyr/arch/xtensa/thread.h
+++ b/include/zephyr/arch/xtensa/thread.h
@@ -42,6 +42,10 @@ struct _thread_arch {
 	struct xtensa_mpu_map *mpu_map;
 #endif
 
+#ifdef CONFIG_GEN_PRIV_STACKS
+	uint8_t *psp_stack_start;
+#endif /* CONFIG_GEN_PRIV_STACKS */
+
 	/* Initial privilege mode stack pointer when doing a system call.
 	 * Un-set for surpervisor threads.
 	 */

--- a/include/zephyr/arch/xtensa/thread_stack.h
+++ b/include/zephyr/arch/xtensa/thread_stack.h
@@ -52,16 +52,20 @@
 #ifndef _ASMLANGUAGE
 
 /* thread stack */
+
+#if defined(CONFIG_USERSPACE) && !defined(CONFIG_GEN_PRIV_STACKS)
+
+/** Struct describing the reserved thread stack space */
 struct xtensa_thread_stack_header {
-#if defined(CONFIG_XTENSA_MMU) || defined(CONFIG_XTENSA_MPU)
+	/** Privilege stack */
 	char privilege_stack[CONFIG_PRIVILEGED_STACK_SIZE];
-#endif /* CONFIG_XTENSA_MPU */
 } __packed __aligned(XTENSA_STACK_BASE_ALIGN);
 
-#if defined(CONFIG_XTENSA_MMU) || defined(CONFIG_XTENSA_MPU)
+/** Size of reserved thread stack space */
 #define ARCH_THREAD_STACK_RESERVED		\
 	sizeof(struct xtensa_thread_stack_header)
-#endif /* CONFIG_XTENSA_MMU || CONFIG_XTENSA_MPU */
+
+#endif /* CONFIG_USERSPACE && !CONFIG_GEN_PRIV_STACKS */
 
 #define ARCH_THREAD_STACK_OBJ_ALIGN(size)	XTENSA_STACK_BASE_ALIGN
 #define ARCH_THREAD_STACK_SIZE_ADJUST(size)	\

--- a/kernel/userspace/userspace.c
+++ b/kernel/userspace/userspace.c
@@ -56,14 +56,15 @@ static struct k_spinlock lists_lock;       /* kobj dlist */
  * stack and other for the user stack, so we need to account the
  * worst alignment scenario and reserve space for that.
  */
-#if defined(CONFIG_ARM_MPU) || defined(CONFIG_ARC_MPU) || defined(CONFIG_RISCV_PMP)
+#if defined(CONFIG_ARM_MPU) || defined(CONFIG_ARC_MPU) || defined(CONFIG_RISCV_PMP) || \
+    defined(CONFIG_XTENSA_MPU)
 #define STACK_ELEMENT_DATA_SIZE(size) \
 	(sizeof(struct z_stack_data) + CONFIG_PRIVILEGED_STACK_SIZE + \
 	Z_THREAD_STACK_OBJ_ALIGN(size) + K_THREAD_STACK_LEN(size))
 #else
 #define STACK_ELEMENT_DATA_SIZE(size) (sizeof(struct z_stack_data) + \
 	K_THREAD_STACK_LEN(size))
-#endif /* CONFIG_ARM_MPU || CONFIG_ARC_MPU || CONFIG_RISCV_PMP */
+#endif /* CONFIG_ARM_MPU || CONFIG_ARC_MPU || CONFIG_RISCV_PMP || CONFIG_XTENSA_MPU */
 #else
 #define STACK_ELEMENT_DATA_SIZE(size) K_THREAD_STACK_LEN(size)
 #endif /* CONFIG_GEN_PRIV_STACKS */
@@ -388,12 +389,13 @@ static struct k_object *dynamic_object_create(enum k_objects otype, size_t align
 #ifdef CONFIG_GEN_PRIV_STACKS
 		struct z_stack_data *stack_data = (struct z_stack_data *)
 			((uint8_t *)dyn->data + adjusted_size - sizeof(*stack_data));
-#if defined(CONFIG_ARM_MPU) || defined(CONFIG_ARC_MPU) || defined(CONFIG_RISCV_PMP)
+#if defined(CONFIG_ARM_MPU) || defined(CONFIG_ARC_MPU) || defined(CONFIG_RISCV_PMP) || \
+    defined(CONFIG_XTENSA_MPU)
 		stack_data->priv = (void *)ROUND_UP(((uint8_t *)dyn->data + size),
 			  Z_THREAD_STACK_OBJ_ALIGN(size));
 #else
 		stack_data->priv = (uint8_t *)dyn->data;
-#endif /* CONFIG_ARM_MPU || CONFIG_ARC_MPU || CONFIG_RISCV_PMP */
+#endif /* CONFIG_ARM_MPU || CONFIG_ARC_MPU || CONFIG_RISCV_PMP || CONFIG_XTENSA_MPU */
 		stack_data->size = adjusted_size;
 		dyn->kobj.data.stack_data = stack_data;
 		dyn->kobj.name = dyn->data;

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -777,7 +777,7 @@ ZTEST(userspace_domain, test_1st_init_and_access_other_memdomain)
 	spawn_user(&default_bool);
 }
 
-#if (defined(CONFIG_ARM) || (defined(CONFIG_GEN_PRIV_STACKS) && defined(CONFIG_RISCV)))
+#if defined(CONFIG_GEN_PRIV_STACKS)
 extern uint8_t *z_priv_stack_find(void *obj);
 #endif
 extern k_thread_stack_t ztest_thread_stack[];
@@ -1203,11 +1203,15 @@ void *userspace_setup(void)
 				  Z_RISCV_STACK_GUARD_SIZE);
 #endif
 #elif defined(CONFIG_XTENSA)
+#if defined(CONFIG_GEN_PRIV_STACKS)
+	priv_stack_ptr = (char *)z_priv_stack_find(ztest_thread_stack);
+#else
 	struct xtensa_thread_stack_header *hdr;
 	void *vhdr = ((struct xtensa_thread_stack_header *)ztest_thread_stack);
 
 	hdr = vhdr;
 	priv_stack_ptr = (((char *)&hdr->privilege_stack) + (sizeof(hdr->privilege_stack) - 1));
+#endif /* CONFIG_GEN_PRIV_STACKS */
 #endif
 	k_thread_access_grant(k_current_get(),
 			      &test_thread, &test_stack,

--- a/tests/kernel/threads/dynamic_thread_stack/src/main.c
+++ b/tests/kernel/threads/dynamic_thread_stack/src/main.c
@@ -9,7 +9,15 @@
 
 #define TIMEOUT_MS 500
 
+#if (CONFIG_MAIN_STACK_SIZE >= 4096) && \
+	(defined(CONFIG_USERSPACE) && (CONFIG_PRIVILEGED_STACK_SIZE >= 4096))
+/* If both stack sizes are large enough, we will need a bigger memory pool
+ * to allocate from.
+ */
+#define POOL_SIZE 30720
+#else
 #define POOL_SIZE 28672
+#endif
 
 #ifdef CONFIG_USERSPACE
 #define STACK_OBJ_SIZE K_THREAD_STACK_LEN(CONFIG_DYNAMIC_THREAD_STACK_SIZE)


### PR DESCRIPTION
This adds support to have generated privilege stack. When CONFIG_GEN_PRIV_STACKS is enabled, the privilege stack is no longer places directly before the thread stack and is placed elsewhere according to linker script. This is useful for MPU as there are limited MPU slots in hardware. If there are multiple threads in a memory domain, even with stack array, there will be interleaved MPU entries covering all these stacks. If generated privlege stack is used instead, this stack array can be covered with two entries (start and end addresses), while the privilege stack will not be occupying additional entries due to them being covered by blanket kernel only R/W access through other entries. Downside of this is that thread stack no longer has stack overflow guard since now the privilege stack is elsewhere.

Assisted-by: Claude:claude-opus-4.8