### PR TITLE
drivers: uart: bcm2711: switch to clocks phandle for platform clock

### DIFF
--- a/drivers/serial/uart_bcm2711.c
+++ b/drivers/serial/uart_bcm2711.c
@@ -53,7 +53,7 @@
 struct bcm2711_uart_config {
 	DEVICE_MMIO_ROM; /* Must be first */
 	uint32_t baud_rate;
-	uint32_t clocks;
+	uint32_t pclk;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	void (*irq_config_func)(const struct device *dev);
 #endif
@@ -141,7 +141,7 @@ static int uart_bcm2711_init(const struct device *dev)
 		return err;
 	}
 
-	bcm2711_mu_lowlevel_init(uart_data->uart_addr, 1, uart_cfg->baud_rate, uart_cfg->clocks);
+	bcm2711_mu_lowlevel_init(uart_data->uart_addr, 1, uart_cfg->baud_rate, uart_cfg->pclk);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_cfg->irq_config_func(dev);
@@ -342,7 +342,7 @@ static DEVICE_API(uart, uart_bcm2711_driver_api) = {
 	static const struct bcm2711_uart_config bcm2711_uart_##port##_config = {                   \
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(port)),                                           \
 		.baud_rate = DT_INST_PROP(port, current_speed),                                    \
-		.clocks = DT_INST_PROP(port, clock_frequency),                                     \
+		.pclk = DT_INST_PROP_BY_PHANDLE(port, clocks, clock_frequency),                    \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(port),                                    \
 		UART_BCM2711_IRQ_CONF_FUNC_SET(port)}
 

--- a/dts/arm64/broadcom/bcm2711.dtsi
+++ b/dts/arm64/broadcom/bcm2711.dtsi
@@ -130,9 +130,9 @@
 		uart1: uart@fe215040 {
 			compatible = "brcm,bcm2711-aux-uart";
 			reg = <0xfe215040 0x40>;
-			clock-frequency = <DT_FREQ_M(500)>;
 			interrupts = <GIC_SPI 93 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clk_vpu>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/serial/brcm,bcm2711-aux-uart.yaml
+++ b/dts/bindings/serial/brcm,bcm2711-aux-uart.yaml
@@ -1,4 +1,4 @@
-description: BCM2711 UART
+description: Broadcom BCM2711 UART
 
 compatible: "brcm,bcm2711-aux-uart"
 
@@ -11,5 +11,5 @@ properties:
   interrupts:
     required: true
 
-  clock-frequency:
+  clocks:
     required: true


### PR DESCRIPTION
Use the `clocks` phandle to obtain the UART peripheral clock instead of `clock-frequency` property. Update the binding and BCM2711 DTS accordingly and rename the driver configuration field from `clocks` to `pclk`.