### PR TITLE
samples: subsys: usb: mass: Add "mapped-partition" for each partitions

### DIFF
--- a/samples/subsys/usb/mass/boards/rpi_pico.overlay
+++ b/samples/subsys/usb/mass/boards/rpi_pico.overlay
@@ -8,7 +8,7 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -17,12 +17,14 @@
 		 * size is 1MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x100 (DT_SIZE_M(1) - 0x100)>;
 			read-only;
 		};
 
 		storage_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x100000 DT_SIZE_M(1)>;
 		};


### PR DESCRIPTION
Due to changes in the partition's device tree configuration, adding the "zephyr,mapped-partition" compatibility.