### PR TITLE
boards: infineon: pse84: --cmd-erase for OpenOCD

### DIFF
--- a/boards/infineon/kit_pse84_ai/board.cmake
+++ b/boards/infineon/kit_pse84_ai/board.cmake
@@ -16,6 +16,12 @@ else()
 endif()
 
 board_runner_args(openocd --no-load --no-targets --no-halt)
+# 'west flash --erase' invokes the vendor 'erase_all' OpenOCD proc, which
+# erases the on-die CM33 main_ns RRAM bank (which includes the non-reserved
+# memory portion) and every external SMIF/QSPI bank attached to the device. The
+# 'main_s' bank is a virtual alias of 'main_ns' so a single sector erase
+# covers both secure and non-secure views.
+board_runner_args(openocd "--cmd-erase=erase_all")
 board_runner_args(openocd "--gdb-init=maint flush register-cache")
 board_runner_args(openocd "--gdb-init=tb main")
 board_runner_args(openocd "--gdb-init=continue")

--- a/boards/infineon/kit_pse84_eval/board.cmake
+++ b/boards/infineon/kit_pse84_eval/board.cmake
@@ -16,6 +16,12 @@ else()
 endif()
 
 board_runner_args(openocd --no-load --no-targets --no-halt)
+# 'west flash --erase' invokes the vendor 'erase_all' OpenOCD proc, which
+# erases the on-die CM33 main_ns RRAM bank (which includes the non-reserved
+# memory portion) and every external SMIF/QSPI bank attached to the device. The
+# 'main_s' bank is a virtual alias of 'main_ns' so a single sector erase
+# covers both secure and non-secure views.
+board_runner_args(openocd "--cmd-erase=erase_all")
 board_runner_args(openocd "--gdb-init=maint flush register-cache")
 board_runner_args(openocd "--gdb-init=tb main")
 board_runner_args(openocd "--gdb-init=continue")


### PR DESCRIPTION
Add a `--cmd-erase` runner argument to the kit_pse84_eval and kit_pse84_ai board.cmake files so that `west flash --erase` works on these boards. Without it the OpenOCD runner aborts with "--erase not supported for target without --cmd-erase".

`--cmd-erase` only wires up the command that `west flash --erase` invokes; a plain `west flash` still takes the normal load path and does not erase. When `--erase` is used it runs the vendor `erase_all` OpenOCD proc, which erases the on-die `cat1d.cm33.main_ns` RRAM bank where the application image lives, along with every external SMIF/QSPI bank attached to the device. `cat1d.cm33.main_s` is a virtual alias of the same physical memory, so a single sector erase covers both secure and non-secure views.

Assisted-by: Claude:claude-opus-4.7

