### PR TITLE
samples: lvgl: fix demo twister console regex

### DIFF
--- a/samples/modules/lvgl/demos/sample.yaml
+++ b/samples/modules/lvgl/demos/sample.yaml
@@ -15,7 +15,9 @@ common:
     fixture: fixture_display
     type: one_line
     regex:
-      - "\\[\\w+ free bytes, \\w+ allocated bytes, overhead = \\w+ bytes | lvgl in malloc mode\\]"
+      - >-
+        (\d+ free bytes, \d+ allocated bytes, overhead = \d+
+        bytes \(\d+\.\d+%\)|lvgl in malloc mode)
 tests:
   sample.modules.lvgl.demo_music:
     platform_allow:


### PR DESCRIPTION
Fixes #110239

## What this changes
- update the LVGL demos console harness regex to match the actual
  heap info line printed by the sample
- keep matching the existing `lvgl in malloc mode` output path

## Why
Twister `one_line` console harnesses match individual output lines.
The current regex expects square brackets around the heap info line,
but `lvgl_print_heap_info(false)` prints the statistics without them.

That causes `sample.modules.lvgl.demos.rk055hdmipi4ma0` on
`mimxrt1170_evk@B/mimxrt1176/cm7` to be reported as a hang even though
the expected status line was already printed.

## Validation
- verified the new regex matches the reported heap info output from
  issue #110239
- verified it still matches `lvgl in malloc mode`
- ran `git diff --check`
