### PR TITLE
drivers: ethernet: dm9051: fix GPR read returns undefined

### DIFF
--- a/drivers/ethernet/eth_dm9051.c
+++ b/drivers/ethernet/eth_dm9051.c
@@ -363,26 +363,23 @@ static int eth_dm9051_hw_start(const struct device *dev, struct net_if *iface __
 	const uint8_t imr = DM9051_IMR_PRI | DM9051_IMR_PTI | DM9051_IMR_LNKCHGI | DM9051_IMR_PAR;
 	const uint8_t rcr = DM9051_RCR_RXEN | DM9051_RCR_DIS_CRC | DM9051_RCR_DIS_LONG;
 	const struct eth_dm9051_config *config = dev->config;
-	uint8_t gpr;
 	int ret;
 
-	ret = eth_dm9051_spi_read_reg(dev, DM9051_GPR, &gpr);
+	/*
+	 * GPR bit 0 is Write-Only (WO per DM9051A spec), reading returns
+	 * undefined values. Always explicitly power up the PHY to ensure it
+	 * is enabled regardless of any prior state.
+	 */
+	ret = eth_dm9051_spi_write_reg(dev, DM9051_GPR, DM9051_GPR_PHY_ON);
 	if (ret < 0) {
 		return ret;
 	}
 
-	if (gpr & DM9051_GPR_PHY_OFF) {
-		/*
-		 * If this bit is updated from ‘1’ to ‘0’, the whole MAC
-		 * and PHY Registers can not be accessed within 1 ms.
-		 */
-		ret = eth_dm9051_spi_write_reg(dev, DM9051_GPR, DM9051_GPR_PHY_ON);
-		if (ret < 0) {
-			return ret;
-		}
-
-		k_msleep(1);
-	}
+	/*
+	 * Per DM9051A spec: if GPR bit 0 is updated from '1' to '0', the
+	 * whole MAC and PHY registers cannot be accessed within 1 ms.
+	 */
+	k_msleep(1);
 
 	/* Software Reset and Auto-Clear after 10 us */
 	ret = eth_dm9051_spi_write_reg(dev, DM9051_NCR, DM9051_NCR_RST);


### PR DESCRIPTION
## Description

GPR bit 0 is Write-Only (WO per DM9051A spec), reading returns undefined values (default XXh). The previous code read GPR and only powered on the PHY if bit 0 was set to 1. If the read returned 0x00 (random undefined value), the PHY would never be powered on.

## Fix

Unconditionally write GPR = 0x00 to power up the PHY, ensuring it is always enabled regardless of any prior state.

## Testing

This bug manifests as the PHY failing to power on after boot, causing link to never establish. The issue can be triggered randomly depending on what undefined value is read from GPR.

## Checklist
- [x] I have read the Zephyr contributing guidelines
- [x] My code follows the Zephyr coding style
- [x] I have verified the fix works correctly