### PR TITLE
tests: timer_behavior: fix cycle counter overflow in ramp test

### DIFF
--- a/tests/kernel/timer/timer_behavior/src/ramp.c
+++ b/tests/kernel/timer/timer_behavior/src/ramp.c
@@ -12,13 +12,25 @@
 #include <zephyr/ztest.h>
 
 
+#ifdef CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
+typedef uint64_t cycle_t;
+#define ramp_cycle_get()         k_cycle_get_64()
+#define ramp_cyc_to_ticks(c)     k_cyc_to_ticks_floor64(c)
+#define CYCLE_FMT                "%llu"
+#else
+typedef uint32_t cycle_t;
+#define ramp_cycle_get()         k_cycle_get_32()
+#define ramp_cyc_to_ticks(c)     k_cyc_to_ticks_floor32(c)
+#define CYCLE_FMT                "%u"
+#endif
+
 K_SEM_DEFINE(ramp_sem, 0, 1);
-static uint32_t start_cycle;
-static uint32_t end_cycle;
+static cycle_t start_cycle;
+static cycle_t end_cycle;
 
 static void tm_fn(struct k_timer *tm)
 {
-	end_cycle = k_cycle_get_32();
+	end_cycle = ramp_cycle_get();
 	k_sem_give(&ramp_sem);
 }
 
@@ -43,20 +55,20 @@ ZTEST(timer_ramp, test_timer_ramp)
 	k_timer_init(&tm, tm_fn, NULL);
 
 	while ((delay/CONFIG_SYS_CLOCK_TICKS_PER_SEC) < 10) {
-		start_cycle = k_cycle_get_32();
+		start_cycle = ramp_cycle_get();
 		k_timer_start(&tm, K_TICKS(delay), K_NO_WAIT);
 		k_sem_take(&ramp_sem, K_FOREVER);
 
-		uint32_t delta_cycles = end_cycle - start_cycle;
-		uint32_t delta_ticks = k_cyc_to_ticks_floor32(delta_cycles);
+		cycle_t delta_cycles = end_cycle - start_cycle;
+		uint32_t delta_ticks = ramp_cyc_to_ticks(delta_cycles);
 
 		if (delta_ticks > (delay + 1) || delta_ticks < delay) {
-			TC_PRINT("failed: delay of %d ticks , actual %d (%d cycles)\n", delay,
-				 delta_ticks, delta_cycles);
+			TC_PRINT("failed: delay of %d ticks , actual %d (" CYCLE_FMT " cycles)\n",
+				 delay, delta_ticks, delta_cycles);
 			failed = true;
 		} else {
-			TC_PRINT("passed: delay of %d ticks, actual %d (%d cycles)\n", delay,
-				 delta_ticks, delta_cycles);
+			TC_PRINT("passed: delay of %d ticks, actual %d (" CYCLE_FMT " cycles)\n",
+				 delay, delta_ticks, delta_cycles);
 		}
 		delay = delay*2;
 	}


### PR DESCRIPTION
On platforms with a high-frequency hardware clock (e.g. RT1170 CM7 at 996 MHz), the ramp test fails with a false assertion. The test measures elapsed time using k_cycle_get_32(), but the ramp runs up to ~10 seconds. At 996 MHz, 10 seconds requires ~9.96e9 cycles, which overflows uint32_t (~4.29e9). The wrapped delta is then converted to ticks, yielding a value far below the expected count, triggering a spurious test failure. The timer itself fires at the correct time; only the measurement is wrong.

Fix by using 64-bit counter when it available,
CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER.

Fixes #110238