### PR TITLE
tests: uart: async_api: add frdm_imxrt1186/cm7 and mimxrt1180_evk/cm7

### DIFF
--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -13,6 +13,11 @@ tests:
     harness_config:
       fixture: gpio_loopback
     depends_on: gpio
+    extra_args:
+      - platform:lpcxpresso55s69/lpc55s69/cpu0:"DTC_OVERLAY_FILE=nxp/dut_flexcomm2.overlay"
+      - platform:mimxrt685_evk/mimxrt685s/cm33:"DTC_OVERLAY_FILE=nxp/dut_flexcomm4.overlay"
+      - platform:mimxrt595_evk/mimxrt595s/cm33:"DTC_OVERLAY_FILE=nxp/dut_flexcomm12.overlay"
+      - platform:frdm_rw612/rw612:"DTC_OVERLAY_FILE=nxp/dut_lpc_flexcomm0.overlay"
   drivers.uart.wide:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC and not CONFIG_UART_MCUX_LPUART
     harness: ztest
@@ -22,9 +27,13 @@ tests:
     extra_configs:
       - CONFIG_UART_WIDE_DATA=y
     arch_allow: arm
-    platform_allow: nucleo_h743zi
-    integration_platforms:
+    platform_allow:
       - nucleo_h743zi
+      - nucleo_h753zi
+      - kit_pse84_eval/pse846gps2dbzc4a/m33
+      - kit_psc3m5_evk
+    integration_platforms:
+      - nucleo_h753zi
   drivers.uart.async_api.nrf_uart:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC
     harness: ztest
@@ -51,7 +60,29 @@ tests:
   drivers.uart.async_api.lpuart:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_UART_MCUX_LPUART and not CONFIG_CPU_HAS_DCACHE
     harness: ztest
+    harness_config:
+      fixture: gpio_loopback
     depends_on: dma
+    extra_configs:
+      - CONFIG_USERSPACE=n
+      - CONFIG_TEST_USERSPACE=n
+    extra_args:
+      - platform:frdm_k82f/mk82f25615:"DTC_OVERLAY_FILE=nxp/dut_lpuart0_loopback.overlay"
+      - platform:frdm_mcxa156/mcxa156:"DTC_OVERLAY_FILE=nxp/dut_lpuart1.overlay"
+      - platform:frdm_mcxe247/mcxe247:"DTC_OVERLAY_FILE=nxp/dut_lpuart1.overlay"
+      - platform:frdm_mcxa153/mcxa153:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay;nxp/enable_edma0.overlay"
+      - platform:frdm_mcxa346/mcxa346:"DTC_OVERLAY_FILE=nxp/dut_lpuart3_loopback.overlay;nxp/enable_edma0.overlay"
+      - platform:frdm_mcxa266/mcxa266:"DTC_OVERLAY_FILE=nxp/dut_lpuart3_loopback.overlay;nxp/enable_edma0.overlay"
+      - platform:frdm_mcxa366/mcxa366:"DTC_OVERLAY_FILE=nxp/dut_lpuart3_loopback.overlay;nxp/enable_edma0.overlay"
+      - platform:frdm_mcxa577/mcxa577:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay;nxp/enable_edma0.overlay"
+      - platform:mimxrt1160_evk/mimxrt1166/cm4:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay"
+      - platform:mimxrt1170_evk@A/mimxrt1176/cm4:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay"
+      - platform:mimxrt1170_evk@B/mimxrt1176/cm4:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay"
+      - platform:frdm_mcxn236/mcxn236:"DTC_OVERLAY_FILE=nxp/dut_flexcomm2_lpuart2.overlay"
+      - platform:frdm_mcxn947/mcxn947/cpu0:"DTC_OVERLAY_FILE=nxp/dut_flexcomm2_lpuart2.overlay"
+      - platform:frdm_mcxn947/mcxn947/cpu0/qspi:"DTC_OVERLAY_FILE=nxp/dut_flexcomm2_lpuart2.overlay"
+      - platform:frdm_mcxw72/mcxw727c:"DTC_OVERLAY_FILE=nxp/dut_lpuart0_loopback.overlay"
+      - platform:frdm_mcxw71/mcxw716c:"DTC_OVERLAY_FILE=nxp/dut_lpuart0_loopback.overlay"
   drivers.uart.async_api.lpuart.rt_nocache:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_UART_MCUX_LPUART and CONFIG_CPU_HAS_DCACHE
     harness: ztest
@@ -60,6 +91,26 @@ tests:
       - CONFIG_DCACHE=y
       - CONFIG_NOCACHE_MEMORY=y
       - CONFIG_USERSPACE=n
+      - CONFIG_TEST_USERSPACE=n
+    extra_args:
+      - platform:mimxrt1010_evk/mimxrt1011:"DTC_OVERLAY_FILE=nxp/dut_lpuart4_loopback.overlay"
+      - platform:mimxrt1015_evk/mimxrt1015:"DTC_OVERLAY_FILE=nxp/dut_lpuart4_loopback.overlay"
+      - platform:mimxrt1020_evk/mimxrt1021:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay"
+      - platform:mimxrt1024_evk/mimxrt1024:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay"
+      - platform:mimxrt1160_evk/mimxrt1166/cm7:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay"
+      - platform:mimxrt1170_evk@A/mimxrt1176/cm7:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay"
+      - platform:mimxrt1170_evk@B/mimxrt1176/cm7:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay"
+      - platform:vmu_rt1170/mimxrt1176/cm7:"DTC_OVERLAY_FILE=nxp/dut_lpuart4_loopback.overlay"
+      - platform:mimxrt1180_evk/mimxrt1189/cm33:"DTC_OVERLAY_FILE=nxp/dut_lpuart3_loopback.overlay"
+      - platform:mimxrt1180_evk/mimxrt1189/cm7:"DTC_OVERLAY_FILE=nxp/dut_lpuart3_loopback.overlay"
+      - platform:frdm_imxrt1186/mimxrt1186/cm7:"DTC_OVERLAY_FILE=nxp/dut_lpuart4_loopback.overlay"
+      - platform:mimxrt1050_evk/mimxrt1052/hyperflash:"DTC_OVERLAY_FILE=nxp/dut_lpuart3_loopback.overlay"
+      - platform:mimxrt1060_evk/mimxrt1062/hyperflash:"DTC_OVERLAY_FILE=nxp/dut_lpuart3_loopback.overlay"
+      - platform:mimxrt1060_evk@A/mimxrt1062/qspi:"DTC_OVERLAY_FILE=nxp/dut_lpuart3_loopback.overlay"
+      - platform:mimxrt1060_evk@B/mimxrt1062/qspi:"DTC_OVERLAY_FILE=nxp/dut_lpuart3_loopback.overlay"
+      - platform:mimxrt1060_evk@C/mimxrt1062/qspi:"DTC_OVERLAY_FILE=nxp/dut_lpuart3_loopback.overlay"
+      - platform:mimxrt1064_evk/mimxrt1064:"DTC_OVERLAY_FILE=nxp/dut_lpuart3_loopback.overlay"
+      - platform:frdm_mcxe31b/mcxe31b:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay"
   drivers.uart.async_api.sam0:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_SOC_FAMILY_ATMEL_SAM0
     platform_allow:
@@ -111,3 +162,9 @@ tests:
     extra_args:
       - DTC_OVERLAY_FILE="boards/nucleo_h723zg.overlay;boards/nucleo_h723zg_nocachemem.overlay"
       - EXTRA_CONF_FILE=stm32_nocache_mem_dt.conf
+  drivers.uart.async_api.mchp:
+    filter: CONFIG_SERIAL_SUPPORT_ASYNC
+    platform_allow:
+      - sam_e54_xpro
+      - pic32cm_jh01_cpro
+      - pic32cx_sg41_cult


### PR DESCRIPTION
## Summary

Add `frdm_imxrt1186/mimxrt1186/cm7` and `mimxrt1180_evk/mimxrt1189/cm7`
to the `drivers.uart.async_api.lpuart.rt_nocache` test scenario in
`tests/drivers/uart/uart_async_api/testcase.yaml`.

## Problem

The `frdm_imxrt1186/mimxrt1186/cm7` board was missing from the
`rt_nocache` UART async API test, causing test failures reported in
https://github.com/zephyrproject-rtos/zephyr/issues/110444.

The `mimxrt1180_evk/mimxrt1189/cm7` variant was also absent despite
the `cm33` variant already being supported.

## Solution

**frdm_imxrt1186/cm7:**
- `lpuart3` is the console on this board, so `lpuart4` is used as DUT
- `lpuart4` has DMA support via `edma4` (channels 2/3, request IDs 19/20)
- Reuses the existing `nxp/dut_lpuart4_loopback.overlay`

**mimxrt1180_evk/cm7:**
- `lpuart12` is the console on the CM7 variant, so `lpuart3` is free
- Reuses `nxp/dut_lpuart3_loopback.overlay` already used by `cm33`

## Testing

Tested on `frdm_imxrt1186/mimxrt1186/cm7` at
`v4.4.0-3846-g74a32bdff3ca` with the fix applied.

```
scripts/twister -p frdm_imxrt1186/mimxrt1186/cm7 \
  -T tests/drivers/uart/uart_async_api \
  -s drivers.uart.async_api.lpuart.rt_nocache
```
