### PR TITLE
arch/x86: Add x2APIC Type 9 MADT lookup with xAPIC as fallback

### DIFF
--- a/arch/common/acpi/acpi.c
+++ b/arch/common/acpi/acpi.c
@@ -544,6 +544,7 @@ int acpi_device_mmio_get(struct acpi_dev *child_dev, struct acpi_mmio_resource *
 			reg_base[mmio_cnt].mmio = (uintptr_t)res->Data.FixedMemory32.Address;
 			reg_base[mmio_cnt++].length = res->Data.FixedMemory32.AddressLength;
 			break;
+
 		case ACPI_RESOURCE_TYPE_ADDRESS64:
 			reg_base[mmio_cnt].type = ACPI_RES_TYPE_MEM;
 			reg_base[mmio_cnt].mmio = (uintptr_t)res->Data.Address64.Address.Minimum;
@@ -952,6 +953,31 @@ ACPI_MADT_LOCAL_APIC *acpi_local_apic_get(int cpu_num)
 		if (lapic[idx].LapicFlags & ACPI_CPU_FLAGS_ENABLED) {
 			if (cpu_num == 0) {
 				return &lapic[idx];
+			}
+
+			cpu_num--;
+		}
+	}
+
+	return NULL;
+}
+
+ACPI_MADT_LOCAL_X2APIC *acpi_local_x2apic_get(int cpu_num)
+{
+	ACPI_MADT_LOCAL_X2APIC *x2apic;
+	int cpu_cnt;
+	int idx;
+
+	if (acpi_madt_entry_get(ACPI_MADT_TYPE_LOCAL_X2APIC, (ACPI_SUBTABLE_HEADER **)&x2apic,
+				&cpu_cnt)) {
+		/* No x2APIC entries in MADT. */
+		return NULL;
+	}
+
+	for (idx = 0; cpu_num >= 0 && idx < cpu_cnt; idx++) {
+		if (x2apic[idx].LapicFlags & ACPI_CPU_FLAGS_ENABLED) {
+			if (cpu_num == 0) {
+				return &x2apic[idx];
 			}
 
 			cpu_num--;

--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -68,12 +68,61 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 	uint8_t apic_id;
 
 	IF_ENABLED(CONFIG_ACPI, ({
-		ACPI_MADT_LOCAL_APIC *lapic = acpi_local_apic_get(cpu_num);
+		/*
+		 * Determine the APIC ID for cpu_num and store it in
+		 * x86_cpu_loapics[].
+		 *
+		 * Lookup policy by build mode:
+		 *   CONFIG_X2APIC=y: try MADT Type 9 first, fallback to Type 0.
+		 *   CONFIG_X2APIC=n: try MADT Type 0 only.
+		 *
+		 * If no usable entry is found, assert and return.
+		 * When Type 9 is used, the ID must be <= 0xFF.
+		 */
+		bool found = false;
 
-		if (lapic != NULL) {
-			/* We update the apic_id, __start will need it. */
-			x86_cpu_loapics[cpu_num] = lapic->Id;
-		} else {
+		/*
+		 * CONFIG_X2APIC=y primary path: try MADT Type 9 first.
+		 * If this lookup succeeds, found becomes true and the later fallback
+		 * block is skipped.
+		 */
+		IF_ENABLED(CONFIG_X2APIC, ({
+			ACPI_MADT_LOCAL_X2APIC *x2apic =
+				acpi_local_x2apic_get(cpu_num);
+
+			if (x2apic != NULL) {
+				/* Guard against silent truncation in 8-bit APIC map. */
+				__ASSERT(x2apic->LocalApicId <= 0xFF,
+					 "x2APIC ID exceeds 8-bit xAPIC range");
+				x86_cpu_loapics[cpu_num] =
+					(uint8_t)x2apic->LocalApicId;
+				found = true;
+			}
+		}));
+
+		/*
+		 * Type 0 lookup.
+		 * - When CONFIG_X2APIC=y, this is the fallback if the Type 9 lookup
+		 *   above did not set found.
+		 * - When CONFIG_X2APIC=n, the Type 9 block above is compiled out, so
+		 *   this becomes the primary lookup.
+		 */
+		if (!found) {
+			ACPI_MADT_LOCAL_APIC *lapic =
+				acpi_local_apic_get(cpu_num);
+
+			if (lapic != NULL) {
+				/* We update the apic_id, __start will need it. */
+				x86_cpu_loapics[cpu_num] = lapic->Id;
+				found = true;
+			}
+		}
+
+		/*
+		 * Common failure path for both CONFIG_X2APIC=y and CONFIG_X2APIC=n.
+		 * If none of the lookup paths found a usable APIC ID, assert and stop.
+		 */
+		if (!found) {
 			/* TODO: kernel need to handle the error scenario if someone config
 			 * CONFIG_MP_MAX_NUM_CPUS more than what platform supported.
 			 */
@@ -111,8 +160,10 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 FUNC_NORETURN void z_x86_cpu_init(struct x86_cpuboot *cpuboot)
 {
 #if defined(CONFIG_ACPI) && !defined(CONFIG_ACRN_COMMON)
-	__ASSERT(z_x86_cpuid_get_current_physical_apic_id() ==
-		 x86_cpu_loapics[cpuboot->cpu_id], "APIC ID miss match!");
+		if (cpuboot->cpu_id != 0U) {
+			__ASSERT(z_x86_cpuid_get_current_physical_apic_id() ==
+			x86_cpu_loapics[cpuboot->cpu_id], "APIC ID mismatch");
+		}
 #endif
 	x86_sse_init(NULL);
 

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -151,9 +151,17 @@ x86_ap_start:
 	 * so we can locate our x86_cpuboot[] bundle. Put it in EBP.
 	 */
 
+#ifdef CONFIG_X2APIC
+	/* In x2APIC mode the MMIO registers are inaccessible; read the
+	 * 32-bit x2APIC ID from MSR 0x802 instead.
+	 */
+	movl $(X86_X2APIC_BASE_MSR + (LOAPIC_ID >> 4)), %ecx
+	rdmsr
+#else
 	movl LOAPIC_BASE_ADDRESS+LOAPIC_ID, %eax
 	shrl $24, %eax
 	andl $0xFF, %eax		/* local APIC ID -> EAX */
+#endif
 
 	movl $x86_cpuboot, %ebp
 	xorl %ebx, %ebx

--- a/include/zephyr/acpi/acpi.h
+++ b/include/zephyr/acpi/acpi.h
@@ -290,6 +290,14 @@ int acpi_dmar_ioapic_get(uint16_t *ioapic_id);
 ACPI_MADT_LOCAL_APIC *acpi_local_apic_get(int cpu_num);
 
 /**
+ * @brief Retrieve the 'n'th enabled local x2apic info (MADT Type 9).
+ *
+ * @param cpu_num the cpu number
+ * @return local x2apic info on success or NULL otherwise
+ */
+ACPI_MADT_LOCAL_X2APIC *acpi_local_x2apic_get(int cpu_num);
+
+/**
  * @brief invoke an ACPI method and return the result.
  *
  * @param path the path name of the ACPI object


### PR DESCRIPTION
This commit fixes a silent SMP hang on platforms where CPUs are
reported as MADT Type 9 (x2APIC) entries with non-sequential APIC
IDs. Zephyr only queried Type 0 (xAPIC) entries, leaving
x86_cpu_loapics[] as zero and sending the startup IPI to the wrong
CPU.

Add Type 9 (x2APIC) as the preferred MADT lookup in arch_cpu_start()
when CONFIG_X2APIC is enabled, with Type 0 (xAPIC) retained as
fallback for platforms that only publish xAPIC entries.