### PR TITLE
boards: alif: ensemble: remove soc-nv-flash and partitions from MRAM

### DIFF
--- a/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.dts
+++ b/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.dts
@@ -16,21 +16,6 @@
 		zephyr,sram = &dtcm;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
-		zephyr,code-partition = &slot0_partition;
-	};
-};
-
-&mram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges;
-
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0 DT_SIZE_K(1945)>;
-		};
 	};
 };
 

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.dts
@@ -17,21 +17,6 @@
 		zephyr,sram = &dtcm;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
-		zephyr,code-partition = &slot0_partition;
-	};
-};
-
-&mram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges;
-
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0 DT_SIZE_K(5632)>;
-		};
 	};
 };
 

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.dts
@@ -17,21 +17,6 @@
 		zephyr,sram = &dtcm;
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
-		zephyr,code-partition = &slot0_partition;
-	};
-};
-
-&mram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges;
-
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0 DT_SIZE_K(5632)>;
-		};
 	};
 };
 

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.dts
@@ -17,21 +17,6 @@
 		zephyr,sram = &dtcm;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
-		zephyr,code-partition = &slot0_partition;
-	};
-};
-
-&mram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges;
-
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0 DT_SIZE_K(5632)>;
-		};
 	};
 };
 

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.dts
@@ -17,21 +17,6 @@
 		zephyr,sram = &dtcm;
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
-		zephyr,code-partition = &slot0_partition;
-	};
-};
-
-&mram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges;
-
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0 DT_SIZE_K(5632)>;
-		};
 	};
 };
 

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.dts
@@ -18,20 +18,6 @@
 		zephyr,sram = &dtcm;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
-		zephyr,code-partition = &slot0_partition;
-	};
-};
-
-&mram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0 DT_SIZE_K(5632)>;
-		};
 	};
 };
 

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.dts
@@ -18,20 +18,6 @@
 		zephyr,sram = &dtcm;
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
-		zephyr,code-partition = &slot0_partition;
-	};
-};
-
-&mram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0 DT_SIZE_K(5632)>;
-		};
 	};
 };
 

--- a/dts/arm/alif/ensemble/ae1c1f4051920ph0.dtsi
+++ b/dts/arm/alif/ensemble/ae1c1f4051920ph0.dtsi
@@ -29,12 +29,8 @@
 
 &soc {
 	mram: flash@80000000 {
-		compatible = "zephyr,memory-region", "soc-nv-flash";
+		compatible = "zephyr,memory-region";
 		reg = <0x80000000 DT_SIZE_K(1945)>;
 		zephyr,memory-region = "MRAM";
-
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges = <0x0 0x80000000 DT_SIZE_K(1945)>;
 	};
 };

--- a/dts/arm/alif/ensemble/ae402fa0e5597le0.dtsi
+++ b/dts/arm/alif/ensemble/ae402fa0e5597le0.dtsi
@@ -20,12 +20,8 @@
 	};
 
 	mram: flash@80000000 {
-		compatible = "zephyr,memory-region", "soc-nv-flash";
+		compatible = "zephyr,memory-region";
 		reg = <0x80000000 DT_SIZE_K(5632)>;
 		zephyr,memory-region = "MRAM";
-
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges = <0x0 0x80000000 DT_SIZE_K(5632)>;
 	};
 };

--- a/dts/arm/alif/ensemble/ae612fa0e5597ls0.dtsi
+++ b/dts/arm/alif/ensemble/ae612fa0e5597ls0.dtsi
@@ -20,12 +20,8 @@
 	};
 
 	mram: flash@80000000 {
-		compatible = "zephyr,memory-region", "soc-nv-flash";
+		compatible = "zephyr,memory-region";
 		reg = <0x80000000 DT_SIZE_K(5632)>;
 		zephyr,memory-region = "MRAM";
-
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges = <0x0 0x80000000 DT_SIZE_K(5632)>;
 	};
 };

--- a/dts/arm/alif/ensemble/ae822fa0e5597ls0.dtsi
+++ b/dts/arm/alif/ensemble/ae822fa0e5597ls0.dtsi
@@ -21,12 +21,8 @@
 	};
 
 	mram: flash@80000000 {
-		compatible = "zephyr,memory-region", "soc-nv-flash";
+		compatible = "zephyr,memory-region";
 		reg = <0x80000000 DT_SIZE_K(5632)>;
 		zephyr,memory-region = "MRAM";
-
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges = <0x0 0x80000000 DT_SIZE_K(5632)>;
 	};
 };


### PR DESCRIPTION
Alif MRAM is a random access non-volatile memory that is directly mapped to the address space of the application core and is available from reset. A flash driver is not yet available for this device. So remove `soc-nv-flash` compatible and support for the `fixed-partitions` from the MRAM node. Fix the board dts files as per this change. This correctly makes the MRAM node simply a `zephyr,memory-region` so that the linker can place the ROM image there.

Note that this fix has already been made for the Balletto family SoC/boards.

Fixes the alif ensemble entries in #107737.