### PR TITLE
drivers: lora: native: sx126x: fix swapped RX timeout sentinels

### DIFF
--- a/drivers/lora/native/sx126x/sx126x_regs.h
+++ b/drivers/lora/native/sx126x/sx126x_regs.h
@@ -223,9 +223,9 @@
 #define SX126X_CMD_STATUS_EXEC_FAILURE      0x05
 #define SX126X_CMD_STATUS_CMD_TX_DONE       0x06
 
-/* Timeout Special Values (in units of 15.625 us) */
-#define SX126X_RX_TIMEOUT_CONTINUOUS        0x000000
-#define SX126X_RX_TIMEOUT_SINGLE            0xFFFFFF
+/* Timeout special values for SetRx/SetTx (see SX1261/2 datasheet 13.1.12) */
+#define SX126X_RX_TIMEOUT_SINGLE            0x000000
+#define SX126X_RX_TIMEOUT_CONTINUOUS        0xFFFFFF
 #define SX126X_TX_TIMEOUT_NONE              0x000000
 
 /* Convert milliseconds to timeout ticks */


### PR DESCRIPTION
Per the SX1261/2 datasheet (13.1.12) `0x000000` selects Rx Single mode and `0xFFFFFF` Rx Continuous mode; the two defines had their values swapped.

No functional change: `SX126X_RX_TIMEOUT_SINGLE` (`0xFFFFFF`) was never referenced, and the continuous receive paths (`lora_recv_async`, and `lora_recv` with `K_FOREVER`) re-arm RX after every packet in `sx126x_rx_restart()`, so they kept receiving even with the chip wrongly in single mode. The blocking recv path needs only one packet and sleeps the radio in the RxDone handler regardless. After the swap those paths use true Rx Continuous mode, with identical observable behavior.