### PR TITLE
drivers: crc: nxp: accept reflected CRC-16 polynomial

### DIFF
--- a/drivers/crc/crc_nxp.c
+++ b/drivers/crc/crc_nxp.c
@@ -57,7 +57,24 @@ static int crc_nxp_prepare_config(const struct device *dev, const struct crc_ctx
 
 	switch (ctx->type) {
 	case CRC16:
-		if (ctx->polynomial != CRC16_POLY) {
+		/*
+		 * The CRC engine takes the polynomial in normal (MSBit-first) form
+		 * and performs input/output reflection through reflectIn/reflectOut.
+		 * crc16() passes the normal CRC-16 polynomial (0x8005), while
+		 * crc16_reflect()/crc16_ansi() pass its reflected form (0xA001) with
+		 * both reflect flags set. The reflected form is only accepted when
+		 * both input and output are reflected -- the only case where it can
+		 * be honored by programming the equivalent normal-form polynomial;
+		 * accepting it otherwise would silently compute a different CRC.
+		 */
+		if (ctx->polynomial == CRC16_REFLECT_POLY) {
+			if ((ctx->reversed & (CRC_FLAG_REVERSE_INPUT | CRC_FLAG_REVERSE_OUTPUT)) !=
+			    (CRC_FLAG_REVERSE_INPUT | CRC_FLAG_REVERSE_OUTPUT)) {
+				return -EINVAL;
+			}
+			/* Program the equivalent normal-form polynomial. */
+			cfg->polynomial = CRC16_POLY;
+		} else if (ctx->polynomial != CRC16_POLY) {
 			return -EINVAL;
 		}
 		cfg->seed &= 0xFFFFU;


### PR DESCRIPTION
crc16_reflect() and crc16_ansi() pass a CRC16 context with the reflected polynomial 0xA001 and both reflect flags set. The driver only accepted the normal-form 0x8005 and rejected 0xA001 with -EINVAL, so those helpers returned 0 and the subsys.crc Ztest suite failed on NXP parts such as frdm_mcxn947.

The CRC engine takes the polynomial in normal (MSBit-first) form and reflects via reflectIn/reflectOut, so 0xA001 and 0x8005 describe the same CRC-16. Accept 0xA001 only when both reflect flags are set and always program 0x8005; a non-reflected 0xA001 is still rejected.

Tested with tests/subsys/crc on frdm_mcxn947: pass = 14, fail = 0.

Fix: #110229 