### PR TITLE
tests: workq: verify suspend/resume of work queue thread

### DIFF
--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -328,6 +328,46 @@ ZTEST(work_1cpu, test_1cpu_simple_queue)
 	zassert_equal(rc, 0);
 }
 
+/* Single CPU check that work submitted while the queue's runner
+ * thread is suspended is queued (not lost or rejected) and runs as
+ * soon as the thread is resumed.
+ */
+ZTEST(work_1cpu, test_1cpu_suspend_resume_queue)
+{
+	int rc;
+	k_tid_t wq_tid = k_work_queue_thread_get(&coophi_queue);
+
+	zassert_not_null(wq_tid);
+
+	/* Reset state and use the non-blocking handler */
+	reset_counters();
+	k_work_init(&common_work, counter_handler);
+	zassert_equal(k_work_busy_get(&common_work), 0);
+
+	/* Suspend the workqueue's runner thread. */
+	k_thread_suspend(wq_tid);
+
+	/* Submission should still succeed and the work should be queued. */
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_QUEUED);
+	zassert_equal(k_work_is_pending(&common_work), true);
+
+	/* Sleeping must not let the work run while the runner is suspended. */
+	k_sleep(K_MSEC(DELAY_MS));
+	zassert_equal(coophi_counter(), 0);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_QUEUED);
+	zassert_equal(k_sem_take(&sync_sem, K_NO_WAIT), -EBUSY);
+
+	/* Resuming the runner should drain the pending work. */
+	k_thread_resume(wq_tid);
+
+	rc = k_sem_take(&sync_sem, DELAY_TIMEOUT);
+	zassert_equal(rc, 0);
+	zassert_equal(coophi_counter(), 1);
+	zassert_equal(k_work_busy_get(&common_work), 0);
+}
+
 /* Basic SMP check submitting with a non-blocking handler. */
 ZTEST(work, test_smp_simple_queue)
 {


### PR DESCRIPTION
Add a single-CPU test that suspends the work queue's runner thread, submits work (which must queue successfully without running), then resumes the thread and verifies the pending work executes.