### PR TITLE
drivers: sensor: tmp112: add one-shot conversion mode

### DIFF
--- a/drivers/sensor/ti/tmp112/Kconfig
+++ b/drivers/sensor/ti/tmp112/Kconfig
@@ -1,6 +1,7 @@
 # TMP112 temperature sensor configuration options
 
 # Copyright (c) 2016 Firmwave
+# Copyright (c) 2026 HARDWARIO a.s.
 # SPDX-License-Identifier: Apache-2.0
 
 config TMP112
@@ -29,6 +30,7 @@ config TMP112_SAMPLING_FREQUENCY_RUNTIME
 	default y
 	help
 	  When set conversion rate can be set at runtime using sensor_attr_set
-	  with SENSOR_ATTR_SAMPLING_FREQUENCY
+	  with SENSOR_ATTR_SAMPLING_FREQUENCY. Setting the rate to 0 Hz at
+	  runtime puts the sensor into shutdown / one-shot mode.
 
 endif # TMP112

--- a/drivers/sensor/ti/tmp112/tmp112.c
+++ b/drivers/sensor/ti/tmp112/tmp112.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Firmwave
+ * Copyright (c) 2026 HARDWARIO a.s.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -81,9 +82,49 @@ static int tmp112_set_threshold(const struct device *dev, uint8_t reg, int64_t m
 	return tmp112_reg_write(dev->config, reg, reg_value);
 }
 
+/*
+ * Trigger a one-shot conversion and block until the chip reports completion.
+ *
+ * The chip stays in SHUTDOWN; we write OS=1 on top of the cached config (which
+ * already has SD=1), wait the typical conversion time, then poll the OS bit
+ * which reads back as 1 once the conversion finishes.
+ */
+static int tmp112_one_shot_convert(const struct device *dev)
+{
+	const struct tmp112_config *cfg = dev->config;
+	struct tmp112_data *drv_data = dev->data;
+	uint16_t cfg_val;
+	int64_t deadline;
+	int rc;
+
+	rc = tmp112_reg_write(cfg, TMP112_REG_CONFIG, drv_data->config_reg | TMP112_ONE_SHOT);
+	if (rc < 0) {
+		return rc;
+	}
+
+	k_msleep(TMP112_ONE_SHOT_INITIAL_WAIT_MS);
+
+	deadline = k_uptime_get() + TMP112_ONE_SHOT_TIMEOUT_MS;
+	for (;;) {
+		rc = tmp112_reg_read(cfg, TMP112_REG_CONFIG, &cfg_val);
+		if (rc < 0) {
+			return rc;
+		}
+		if (cfg_val & TMP112_ONE_SHOT) {
+			return 0;
+		}
+		if (k_uptime_get() >= deadline) {
+			LOG_ERR("One-shot conversion timed out");
+			return -ETIMEDOUT;
+		}
+		k_msleep(1);
+	}
+}
+
 static int tmp112_attr_set(const struct device *dev, enum sensor_channel chan,
 			   enum sensor_attribute attr, const struct sensor_value *val)
 {
+	struct tmp112_data *drv_data = dev->data;
 	uint16_t value;
 	uint16_t cr;
 
@@ -115,10 +156,15 @@ static int tmp112_attr_set(const struct device *dev, enum sensor_channel chan,
 	case SENSOR_ATTR_SAMPLING_FREQUENCY:
 		/* conversion rate in mHz */
 		cr = val->val1 * 1000 + val->val2 / 1000;
+		drv_data->one_shot = false;
 
-		/* the sensor supports 0.25Hz, 1Hz, 4Hz and 8Hz */
-		/* conversion rate */
+		/* the sensor supports 0 (shutdown/one-shot), 0.25, 1, 4 and 8 Hz */
 		switch (cr) {
+		case 0:
+			value = TMP112_CONFIG_SD;
+			drv_data->one_shot = true;
+			break;
+
 		case 250:
 			value = TMP112_CONV_RATE(TMP112_CONV_RATE_025);
 			break;
@@ -139,7 +185,8 @@ static int tmp112_attr_set(const struct device *dev, enum sensor_channel chan,
 			return -ENOTSUP;
 		}
 
-		if (tmp112_update_config(dev, TMP112_CONV_RATE_MASK, value) < 0) {
+		if (tmp112_update_config(dev, TMP112_CONFIG_SD | TMP112_CONV_RATE_MASK, value) <
+		    0) {
 			LOG_DBG("Failed to set attribute!");
 			return -EIO;
 		}
@@ -167,6 +214,14 @@ static int tmp112_sample_fetch(const struct device *dev, enum sensor_channel cha
 	uint16_t val;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP);
+
+	if (drv_data->one_shot) {
+		int rc = tmp112_one_shot_convert(dev);
+
+		if (rc < 0) {
+			return rc;
+		}
+	}
 
 	if (tmp112_reg_read(cfg, TMP112_REG_TEMPERATURE, &val) < 0) {
 		return -EIO;
@@ -210,8 +265,10 @@ int tmp112_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	data->config_reg = TMP112_CONV_RATE(cfg->cr) | TMP112_CONV_RES_MASK |
-			   (cfg->extended_mode ? TMP112_CONFIG_EM : 0);
+	data->one_shot = (cfg->cr == 0);
+	data->config_reg = TMP112_CONV_RATE(data->one_shot ? 0 : cfg->cr - 1) |
+			   TMP112_CONV_RES_MASK | (cfg->extended_mode ? TMP112_CONFIG_EM : 0) |
+			   (data->one_shot ? TMP112_CONFIG_SD : 0);
 
 	ret = tmp112_update_config(dev, 0, 0);
 	if (ret) {

--- a/drivers/sensor/ti/tmp112/tmp112.h
+++ b/drivers/sensor/ti/tmp112/tmp112.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Innoseis BV
+ * Copyright (c) 2026 HARDWARIO a.s.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,6 +20,7 @@
 
 #define TMP112_REG_CONFIG   0x01
 #define TMP112_CONFIG_EM    BIT(4)
+#define TMP112_CONFIG_SD    BIT(8)
 
 #define TMP112_ALERT_EN_BIT     BIT(5)
 #define TMP112_CONV_RATE_SHIFT  6
@@ -51,9 +53,14 @@
 /* -55C */
 #define TMP112_TEMP_MIN_EM TMP112_TEMP_MIN
 
+/* One-shot conversion: typical 10 ms (datasheet 7.4.3) */
+#define TMP112_ONE_SHOT_INITIAL_WAIT_MS 10
+#define TMP112_ONE_SHOT_TIMEOUT_MS      50
+
 struct tmp112_data {
 	int16_t sample;
 	uint16_t config_reg;
+	bool one_shot;
 };
 
 struct tmp112_config {

--- a/dts/bindings/sensor/ti,tmp112.yaml
+++ b/dts/bindings/sensor/ti,tmp112.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2019, Linaro Limited
+# Copyright (c) 2026 HARDWARIO a.s.
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -11,10 +12,14 @@ include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
   conversion-rate:
-    description: Conversion rate in mHz (milli-Hertz)
+    description: |
+      Conversion rate in mHz (milli-Hertz). Set to 0 to keep the sensor in
+      shutdown mode and trigger a one-shot conversion on each sample_fetch
+      call (lowest idle current; ~10 ms conversion latency on fetch).
     type: int
     default: 4000
     enum:
+      - 0
       - 250
       - 1000
       - 4000


### PR DESCRIPTION

The TMP112 can stay in shutdown (SD) mode and perform a single conversion on
demand through its one-shot (OS) bit. This is the lowest idle-current mode of
the device and is useful for battery-powered designs that sample temperature
infrequently.

This PR exposes that mode through the existing `conversion-rate` device-tree
property:

- Setting `conversion-rate = <0>` keeps the sensor in shutdown and triggers a
  one-shot conversion on every `sample_fetch` call. The driver blocks until the
  OS bit reads back as `1` (typically ~10 ms per datasheet §7.4.3) or a timeout
  elapses.
- The periodic conversion rates (0.25/1/4/8 Hz) keep their previous behaviour.
- The same mode can be selected at runtime by setting a 0 Hz sampling frequency
  via `sensor_attr_set(SENSOR_ATTR_SAMPLING_FREQUENCY)`.

Because a new value (`0`) is prepended to the `conversion-rate` enum, the
device-tree enum index no longer maps directly onto the CR register field, so
the init path subtracts one for the periodic rates. The binding and driver are
therefore changed together in a single commit to keep every revision
buildable/bisectable.

## Changes

- `drivers/sensor/ti/tmp112/tmp112.c` — one-shot convert helper, shutdown
  handling in init/attr_set, one-shot trigger in `sample_fetch`
- `drivers/sensor/ti/tmp112/tmp112.h` — `TMP112_CONFIG_SD` bit, one-shot timing
  constants, `one_shot` flag in `tmp112_data`
- `drivers/sensor/ti/tmp112/Kconfig` — document the shutdown/one-shot behaviour
- `dts/bindings/sensor/ti,tmp112.yaml` — allow `conversion-rate = 0`

## Testing

Tested on an **nRF54L15-DK** with a TMP112 connected over I2C:

- Periodic rates (0.25/1/4/8 Hz) behave as before.
- `conversion-rate = <0>` returns correct temperature readings on demand while
  the sensor is held in shutdown between fetches.
- Verified via the sensor shell.

No new build warnings; `twister`/CI clean expected.


Assisted-by: Claude:claude-opus-4.8