### PR TITLE
soc: nxp: mcxa: fix NUM_IRQS for MCXAXX7 series

### DIFF
--- a/soc/nxp/mcx/mcxa/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig.defconfig
@@ -10,7 +10,7 @@ config NUM_IRQS
 	default 80 if SOC_SERIES_MCXA1X3
 	default 89 if SOC_SERIES_MCXA1X6
 	default 122 if SOC_SERIES_MCXAXX6
-	default 164 if SOC_SERIES_MCXAXX7
+	default 146 if SOC_SERIES_MCXAXX7
 	default 88
 
 # Default offset 0x200 is not enough with higher ISR count


### PR DESCRIPTION
The MCXA577 CMSIS header defines NUMBER_OF_INT_VECTORS=162, which corresponds to 16 ARM exceptions + 146 device IRQs (IRQ 0-145, with DMA1_CH3 as the last valid IRQ). The previous value of 164 was incorrect, causing TEST_IRQ_NUM (= NUM_IRQS - 1 = 163) to reference a non-existent NVIC line, so NVIC_SetPendingIRQ(163) had no effect and any test relying on the last IRQ slot would silently fail.

Fixes: #110244