### PR TITLE
drivers: gpio: update optional API vrfy handlers and gpio_basic_api test suite

### DIFF
--- a/drivers/gpio/gpio_handlers.c
+++ b/drivers/gpio/gpio_handlers.c
@@ -21,7 +21,7 @@ static inline int z_vrfy_gpio_pin_get_config(const struct device *port,
 					     gpio_pin_t pin,
 					     gpio_flags_t *flags)
 {
-	K_OOPS(K_SYSCALL_DRIVER_GPIO(port, pin_get_config));
+	K_OOPS(K_SYSCALL_OBJ(port, K_OBJ_DRIVER_GPIO));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(flags, sizeof(gpio_flags_t)));
 
 	return z_impl_gpio_pin_get_config(port, pin, flags);
@@ -164,15 +164,14 @@ static inline int z_vrfy_gpio_pin_interrupt_configure(const struct device *port,
 						      gpio_pin_t pin,
 						      gpio_flags_t flags)
 {
-	K_OOPS(K_SYSCALL_DRIVER_GPIO(port, pin_interrupt_configure));
+	K_OOPS(K_SYSCALL_OBJ(port, K_OBJ_DRIVER_GPIO));
 	return z_impl_gpio_pin_interrupt_configure(port, pin, flags);
 }
 #include <zephyr/syscalls/gpio_pin_interrupt_configure_mrsh.c>
 
 static inline int z_vrfy_gpio_get_pending_int(const struct device *dev)
 {
-	K_OOPS(K_SYSCALL_DRIVER_GPIO(dev, get_pending_int));
-
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_GPIO));
 	return z_impl_gpio_get_pending_int(dev);
 }
 #include <zephyr/syscalls/gpio_get_pending_int_mrsh.c>
@@ -182,7 +181,7 @@ static inline int z_vrfy_gpio_port_get_direction(const struct device *dev, gpio_
 						 gpio_port_pins_t *inputs,
 						 gpio_port_pins_t *outputs)
 {
-	K_OOPS(K_SYSCALL_DRIVER_GPIO(dev, port_get_direction));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_GPIO));
 
 	if (inputs != NULL) {
 		K_OOPS(K_SYSCALL_MEMORY_WRITE(inputs, sizeof(gpio_port_pins_t)));

--- a/tests/drivers/gpio/gpio_basic_api/src/main.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/main.c
@@ -59,7 +59,7 @@ static void board_setup(void)
 				IOMUXC_SW_PAD_CTL_PAD_RGMII2_RD3_DSE(6);
 #elif defined(CONFIG_GPIO_EMUL)
 	extern struct gpio_callback gpio_emul_callback;
-	const struct device *const dev = DEVICE_DT_GET(DEV);
+	const struct device *const dev = DEVICE_DT_GET(DEV_OUT);
 
 	zassert_true(device_is_ready(dev), "GPIO dev is not ready");
 	int rc = gpio_add_callback(dev, &gpio_emul_callback);
@@ -78,18 +78,22 @@ static void board_setup(void)
 static void *gpio_basic_setup(void)
 {
 	board_setup();
-	(void)pm_device_runtime_get(DEVICE_DT_GET(DEV));
+
+	(void)pm_device_runtime_get(DEVICE_DT_GET(DEV_IN));
+	(void)pm_device_runtime_get(DEVICE_DT_GET(DEV_OUT));
 #ifdef CONFIG_UART_CONSOLE
 	(void)pm_device_runtime_get(DEVICE_DT_GET(DT_CHOSEN(zephyr_console)));
 #endif
-	k_object_access_grant(DEVICE_DT_GET(DEV), k_current_get());
+	k_object_access_grant(DEVICE_DT_GET(DEV_IN), k_current_get());
+	k_object_access_grant(DEVICE_DT_GET(DEV_OUT), k_current_get());
 	return NULL;
 }
 
 void gpio_basic_teardown(void *args)
 {
 	(void)args;
-	(void)pm_device_runtime_put(DEVICE_DT_GET(DEV));
+	(void)pm_device_runtime_put(DEVICE_DT_GET(DEV_IN));
+	(void)pm_device_runtime_put(DEVICE_DT_GET(DEV_OUT));
 #ifdef CONFIG_UART_CONSOLE
 	(void)pm_device_runtime_put(DEVICE_DT_GET(DT_CHOSEN(zephyr_console)));
 #endif

--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio.h
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio.h
@@ -17,24 +17,14 @@
 /* Execution of the test requires hardware configuration described in
  * devicetree.  See the test,gpio_basic_api binding local to this test
  * for details.
- *
- * If this is not present devices that have gpio-0, gpio-1, or gpio-2
- * aliases are supported for build-only tests.
  */
 #define DEV_OUT DT_GPIO_CTLR(DT_INST(0, test_gpio_basic_api), out_gpios)
 #define DEV_IN DT_GPIO_CTLR(DT_INST(0, test_gpio_basic_api), in_gpios)
-#define DEV DEV_OUT /* DEV_OUT should equal DEV_IN, we test for this */
 #define PIN_OUT DT_GPIO_PIN(DT_INST(0, test_gpio_basic_api), out_gpios)
 #define PIN_OUT_FLAGS DT_GPIO_FLAGS(DT_INST(0, test_gpio_basic_api), out_gpios)
 #define PIN_IN DT_GPIO_PIN(DT_INST(0, test_gpio_basic_api), in_gpios)
 #define PIN_IN_FLAGS DT_GPIO_FLAGS(DT_INST(0, test_gpio_basic_api), in_gpios)
 
-#elif DT_NODE_HAS_STATUS_OKAY(DT_ALIAS(gpio_0))
-#define DEV DT_GPIO_CTLR(DT_ALIAS(gpio_0))
-#elif DT_NODE_HAS_STATUS_OKAY(DT_ALIAS(gpio_1))
-#define DEV DT_GPIO_CTLR(DT_ALIAS(gpio_1))
-#elif DT_NODE_HAS_STATUS_OKAY(DT_ALIAS(gpio_3))
-#define DEV DT_GPIO_CTLR(DT_ALIAS(gpio_3))
 #else
 #error Unsupported board
 #endif


### PR DESCRIPTION
The gpio_basic_api setup functions only manage one port, even if DEV_IN and DEV_OUT or not identical. Despite the comment and definition of #define DEV, DEV_IN and DEV_OUT are not neccesarily identical, there is no test validating this.

The setup functions and DEV definitions have been updated to correctly handle cases where DEV_IN == DEV_OUT and DEV_IN != DEV_OUT.

Additionally the z_vrfy_* handlers for the optional APIs (which have an if (api == NULL) check in their z_impl_*), have been updated to not assert that API pointer must != NULL