### PR TITLE
device: make DEVICE_API_GET assert optionals

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -1424,8 +1424,10 @@ DT_FOREACH_STATUS_OKAY_NODE(Z_MAYBE_DEVICE_DECLARE_INTERNAL)
  */
 #define DEVICE_API_GET(_class, _dev)                                                               \
 	({                                                                                         \
+		IF_ENABLED(CONFIG_DEVICE_API_ASSERT, (                                             \
 		__ASSERT(_dev != NULL, "device is NULL");                                          \
 		__ASSERT(DEVICE_API_IS(_class, _dev), "device API is not %s", STRINGIFY(_class));  \
+		));                                                                                \
 		Z_DEVICE_API_GET(_class, _dev);                                                    \
 	})
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -980,6 +980,14 @@ config STATIC_INIT_GNU
 	  will emit an error if constructors are needed and this option has been
 	  disabled.
 
+config DEVICE_API_ASSERT
+	bool "Assert on DEVICE_API_GET"
+	default y
+	depends on ASSERT
+	help
+	  Enable asserts on DEVICE_API_GET checking for NULL pointers and
+	  device API type, disable to save some flash space.
+
 endmenu
 
 config KERNEL_NO_LTO


### PR DESCRIPTION
Hi, we've seen this takig up to 10k+ of flash on some projects since 5528dee556e11083376955d401e47535a5ec8adc, even keeping just the NULL check causes the flash usage to blow up so I don't think it's the strings per se, rather the optimizer not being able to do a great job with the assert enabled. Just add an option to turn these specific ones off.

--

Asserts on DEVICE_API_GET can take a significant amount of flash, to the point of making an imagine not fit the flash anymore, add an option to disable them.