### PR TITLE
tests: vector_table_relocation: exclude rt1180 cm7 from dtcm/itcm variants

### DIFF
--- a/tests/application_development/vector_table_relocation/testcase.yaml
+++ b/tests/application_development/vector_table_relocation/testcase.yaml
@@ -19,11 +19,21 @@ tests:
     # As such, the vector table can't be relocated to CCM.
     filter: CONFIG_CPU_CORTEX_M_HAS_VTOR and dt_chosen_enabled("zephyr,dtcm")
             and not CONFIG_SOC_SERIES_STM32F4X
+    # Exclude RAM-target boards where DTCM aliases SRAM: .sram_vt and .data
+    # then overlap due to independent linker counters at the same address.
+    platform_exclude:
+      - frdm_imxrt1186/mimxrt1186/cm7
+      - mimxrt1180_evk/mimxrt1189/cm7
     extra_configs:
       - CONFIG_ARM_VECTOR_TABLE_DTCM=y
 
   application_development.vector_table_relocation.itcm:
     arch_allow: arm
     filter: CONFIG_CPU_CORTEX_M_HAS_VTOR and dt_chosen_enabled("zephyr,itcm")
+    # Exclude RAM-target boards where ITCM aliases flash: .sram_vt and
+    # .rom_start then overlap due to independent linker counters.
+    platform_exclude:
+      - frdm_imxrt1186/mimxrt1186/cm7
+      - mimxrt1180_evk/mimxrt1189/cm7
     extra_configs:
       - CONFIG_ARM_VECTOR_TABLE_ITCM=y


### PR DESCRIPTION
On i.MX RT1180 CM7 (RAM target with `zephyr,sram = &dtcm` and `zephyr,flash = &itcm`), the DTCM/ITCM and SRAM/FLASH linker regions share the same physical address but use independent location counters. .sram_vt placed in the DTCM/ITCM region then collides with .data/.rom_start at the same physical address, silently corrupting the relocated vector table and crashing before the boot banner.

The DTCM and ITCM placement variants are also semantically meaningless on this RAM target since the boot vectors are already in TCM SRAM and the .arm variant already covers the only useful placement.

Fixes #110249