### PR TITLE
drivers: counter: mcux_lptmr: defer alarm stop until after callback

### DIFF
--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -322,14 +322,14 @@ static void mcux_lptmr_isr(const struct device *dev)
 		callback(dev, 0, current_count, user_data);
 
 		key = k_spin_lock(&data->lock);
-		bool rearmed = data->alarm_active;
-
-		k_spin_unlock(&data->lock, key);
-
-		if (!rearmed) {
+		/* Check re-arm and stop/restore atomically under the lock so a
+		 * concurrent set_alarm() cannot have its config clobbered.
+		 */
+		if (!data->alarm_active) {
 			LPTMR_StopTimer(config->base);
 			LPTMR_SetTimerPeriod(config->base, config->info.max_top_value);
 		}
+		k_spin_unlock(&data->lock, key);
 
 		return;
 	}

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -315,10 +315,21 @@ static void mcux_lptmr_isr(const struct device *dev)
 
 		uint32_t current_count = LPTMR_GetCurrentTimerCount(config->base);
 
-		LPTMR_StopTimer(config->base);
-		LPTMR_SetTimerPeriod(config->base, config->info.max_top_value);
-
+		/* Defer stop/restore until after callback: stop would reset the
+		 * counter and break counter_get_value() consistency with the ticks
+		 * arg; also skip when callback re-armed (set_alarm reconfigured timer).
+		 */
 		callback(dev, 0, current_count, user_data);
+
+		key = k_spin_lock(&data->lock);
+		bool rearmed = data->alarm_active;
+
+		k_spin_unlock(&data->lock, key);
+
+		if (!rearmed) {
+			LPTMR_StopTimer(config->base);
+			LPTMR_SetTimerPeriod(config->base, config->info.max_top_value);
+		}
 
 		return;
 	}


### PR DESCRIPTION
The alarm ISR was stopping and reprogramming the LPTMR before invoking the user callback. Because LPTMR_StopTimer() resets the counter back to zero, counter_get_value() called from inside the callback observed 0 while the ticks argument still reflected the pre-stop count. The single_shot_alarm scenarios in tests/drivers/counter/counter_basic_api caught this as a large diff between reported alarm and observed counter on frdm_imxrt1186/mimxrt1186/cm7.

Move LPTMR_StopTimer() and LPTMR_SetTimerPeriod() to run after the callback, and skip them when the callback re-armed a new alarm via counter_set_channel_alarm(): the counter API documents that the channel becomes available inside the expiration handler and that re-arming is allowed there.

Verified by building tests/drivers/counter/counter_basic_api for frdm_imxrt1186/mimxrt1186/cm7 with armgcc.

Fixes #110250