### PR TITLE
drivers: wifi: siwx91x: honor Kconfig dwell times for BG scan

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
@@ -123,17 +123,12 @@ siwx91x_configure_scan_dwell_time(sl_wifi_scan_type_t scan_type, uint16_t dwell_
 						 dwell_time_passive);
 		return ret;
 	case SL_WIFI_SCAN_TYPE_ADV_SCAN:
-		__ASSERT(advanced_scan_config, "advanced_scan_config cannot be NULL");
-
-		if (!dwell_time_active) {
-			dwell_time_active = CONFIG_WIFI_SILABS_SIWX91X_ADV_ACTIVE_SCAN_DURATION;
+		if (dwell_time_active || dwell_time_passive) {
+			LOG_DBG("Ignoring per-call dwell times for background scan; "
+				"using CONFIG_WIFI_SILABS_SIWX91X_ADV_*_SCAN_DURATION");
 		}
-		advanced_scan_config->active_channel_time = dwell_time_active;
-
-		if (!dwell_time_passive) {
-			dwell_time_passive = CONFIG_WIFI_SILABS_SIWX91X_ADV_PASSIVE_SCAN_DURATION;
-		}
-		advanced_scan_config->passive_channel_time = dwell_time_passive;
+		dwell_time_active = CONFIG_WIFI_SILABS_SIWX91X_ADV_ACTIVE_SCAN_DURATION;
+		dwell_time_passive = CONFIG_WIFI_SILABS_SIWX91X_ADV_PASSIVE_SCAN_DURATION;
 		return 0;
 	default:
 		return 0;


### PR DESCRIPTION
In the SL_WIFI_SCAN_TYPE_ADV_SCAN path, the Kconfigs ADV_ACTIVE_SCAN_DURATION / ADV_PASSIVE_SCAN_DURATION were used only as a fallback when the per-call wifi_scan_params dwell fields were 0, so any non-zero per-call value would override them and reach the radio.

BG-scan dwell is a system-tuned policy controlled by Kconfig (like trigger_level and enable_multi_probe); per-call dwell fields belong to the foreground scan path only. Always use the Kconfig values for advanced_scan_config and ignore per-call params on this path.