### PR TITLE
include: firmware: scmi: Doxygen housekeeping

### DIFF
--- a/include/zephyr/drivers/firmware/scmi/base.h
+++ b/include/zephyr/drivers/firmware/scmi/base.h
@@ -52,9 +52,6 @@ struct scmi_revision_info {
  * @struct scmi_agent_info
  *
  * @brief SCMI base protocol agent info
- *
- * @param agent_id SCMI agent id.
- * @param name SCMI agent name.
  */
 struct scmi_agent_info {
 	/** Identifier for the agent */
@@ -67,7 +64,7 @@ struct scmi_agent_info {
  * @brief SCMI base protocol get revision information.
  *
  * @param rev pointer on revision information struct scmi_revision_info.
- * @retval 0 If successful, negative errno on an error.
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_base_get_revision_info(struct scmi_revision_info *rev);
 
@@ -77,7 +74,7 @@ int scmi_base_get_revision_info(struct scmi_revision_info *rev);
  * @param agent_id SCMI agent id. The platform will return caller SCMI agent id
  *                 if set to SCMI_BASE_AGENT_ID_OWN.
  * @param agent_inf pointer on SCMI agent information struct scmi_agent_info.
- * @retval 0 If successful, negative errno on an error.
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_base_discover_agent(uint32_t agent_id, struct scmi_agent_info *agent_inf);
 
@@ -87,7 +84,7 @@ int scmi_base_discover_agent(uint32_t agent_id, struct scmi_agent_info *agent_in
  * @param agent_id SCMI agent id.
  * @param device_id SCMI device id.
  * @param allow If set to true, allow agent access to the device.
- * @retval 0 If successful, negative errno on an error.
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_base_device_permission(uint32_t agent_id, uint32_t device_id, bool allow);
 
@@ -96,7 +93,7 @@ int scmi_base_device_permission(uint32_t agent_id, uint32_t device_id, bool allo
  *
  * @param agent_id SCMI agent id.
  * @param reset_perm If set to true, reset all access permission settings of the agent.
- * @retval 0 If successful, negative errno on an error.
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_base_reset_agent_cfg(uint32_t agent_id, bool reset_perm);
 

--- a/include/zephyr/drivers/firmware/scmi/clk.h
+++ b/include/zephyr/drivers/firmware/scmi/clk.h
@@ -22,29 +22,37 @@
  * @{
  */
 
+/** Mask of the enable/disable field in a CLOCK_CONFIG_SET attributes word */
 #define SCMI_CLK_CONFIG_DISABLE_ENABLE_MASK GENMASK(1, 0)
+/** Extract the enable/disable field from a CLOCK_CONFIG_SET value @p x */
 #define SCMI_CLK_CONFIG_ENABLE_DISABLE(x)\
 	((uint32_t)(x) & SCMI_CLK_CONFIG_DISABLE_ENABLE_MASK)
 
+/** Extract the number of clocks from a PROTOCOL_ATTRIBUTES reply @p x */
 #define SCMI_CLK_ATTRIBUTES_CLK_NUM(x) ((x) & GENMASK(15, 0))
 
+/** CLOCK_RATE_SET flag: perform the rate change asynchronously */
 #define SCMI_CLK_RATE_SET_FLAGS_ASYNC                BIT(0)
+/** CLOCK_RATE_SET flag: do not send a delayed response for async requests */
 #define SCMI_CLK_RATE_SET_FLAGS_IGNORE_DELEAYED_RESP BIT(1)
+/** CLOCK_RATE_SET flag: round the rate up (set) or down (cleared) */
 #define SCMI_CLK_RATE_SET_FLAGS_ROUNDS_UP_DOWN       BIT(2)
+/** CLOCK_RATE_SET flag: round the rate to the closest supported value */
 #define SCMI_CLK_RATE_SET_FLAGS_ROUNDS_AUTO          BIT(3)
 
+/** Version of the SCMI clock protocol supported by this driver */
 #define SCMI_CLK_PROTOCOL_SUPPORTED_VERSION	0x30000
 
-/** clock name length (short version) */
+/** Clock name length (short version) */
 #define SCMI_CLK_NAME_LEN 16
 
-/** get the clock's enabled status based on given attributes */
+/** Get the clock's enabled status based on given attributes */
 #define SCMI_CLK_ENABLED(attributes) ((attributes) & BIT(0))
 
-/** check if a clock has restrictions based on given attributes */
+/** Check if a clock has restrictions based on given attributes */
 #define SCMI_CLK_HAS_RESTRICTIONS(attributes) ((attributes) & BIT(1))
 
-/** check if clock allows gating/ungating based on its permissions */
+/** Check if clock allows gating/ungating based on its permissions */
 #define SCMI_CLK_STATE_CONTROL_ALLOWED(permissions) ((permissions) & BIT(31))
 
 /**
@@ -54,8 +62,11 @@
  * command
  */
 struct scmi_clock_config {
+	/** ID of the clock to configure */
 	uint32_t clk_id;
+	/** Configuration attributes (e.g. enable/disable, see SCMI_CLK_CONFIG_*) */
 	uint32_t attributes;
+	/** Extended configuration value (meaning depends on @ref attributes) */
 	uint32_t extended_cfg_val;
 };
 
@@ -66,8 +77,11 @@ struct scmi_clock_config {
  * command
  */
 struct scmi_clock_rate_config {
+	/** Rate set flags (see SCMI_CLK_RATE_SET_FLAGS_*) */
 	uint32_t flags;
+	/** ID of the clock whose rate is being set */
 	uint32_t clk_id;
+	/** 64-bit rate in Hz, split as { lower 32 bits, upper 32 bits } */
 	uint32_t rate[2];
 };
 
@@ -77,37 +91,35 @@ struct scmi_clock_rate_config {
  * @brief Describes the content of the CLOCK_ATTRIBUTES command reply
  */
 struct scmi_clock_attributes {
-	/** reply status */
+	/** Reply status */
 	int32_t status;
-	/** clock attributes */
+	/** Clock attributes */
 	uint32_t attributes;
-	/** clock name */
+	/** Clock name */
 	uint8_t clock_name[SCMI_CLK_NAME_LEN];
-	/** clock enable delay incurred by platform */
+	/** Clock enable delay incurred by platform */
 	uint32_t clock_enable_delay;
 } __packed;
 
 /**
  * @brief Send the CLOCK_CONFIG_SET command and get its reply
  *
- * @param proto pointer to SCMI clock protocol data
- * @param cfg pointer to structure containing configuration
+ * @param proto Pointer to SCMI clock protocol data
+ * @param cfg Pointer to structure containing configuration
  * to be set
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_clock_config_set(struct scmi_protocol *proto,
 			  struct scmi_clock_config *cfg);
 /**
  * @brief Query the rate of a clock
  *
- * @param proto pointer to SCMI clock protocol data
+ * @param proto Pointer to SCMI clock protocol data
  * @param clk_id ID of the clock for which the query is done
- * @param rate pointer to rate to be set via this command
+ * @param rate Pointer to rate to be set via this command
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_clock_rate_get(struct scmi_protocol *proto,
 			uint32_t clk_id, uint32_t *rate);
@@ -115,49 +127,45 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 /**
  * @brief Send the CLOCK_RATE_SET command and get its reply
  *
- * @param proto pointer to SCMI clock protocol data
- * @param cfg pointer to structure containing configuration
+ * @param proto Pointer to SCMI clock protocol data
+ * @param cfg Pointer to structure containing configuration
  * to be set
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_config *cfg);
 
 /**
  * @brief Query the parent of a clock
  *
- * @param proto pointer to SCMI clock protocol data
+ * @param proto Pointer to SCMI clock protocol data
  * @param clk_id ID of the clock for which the query is done
- * @param parent_id pointer to be set via this command
+ * @param parent_id Pointer to be set via this command
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t *parent_id);
 
 /**
  * @brief Send the CLOCK_PARENT_SET command and get its reply
  *
- * @param proto pointer to SCMI clock protocol data
+ * @param proto Pointer to SCMI clock protocol data
  * @param clk_id ID of the clock for which the query is done
  * @param parent_id to be set via this command
  * to be set
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t parent_id);
 
 /**
  * @brief Send the CLOCK_ATTRIBUTES command and get its reply
  *
- * @param proto pointer to SCMI clock protocol data
+ * @param proto Pointer to SCMI clock protocol data
  * @param clk_id ID of the clock for which the query is done
- * @param attributes clock attributes returned by the command
+ * @param attributes Clock attributes returned by the command
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
 			  struct scmi_clock_attributes *attributes);
@@ -165,12 +173,11 @@ int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
 /**
  * @brief Send the CLOCK_GET_PERMISSIONS command and get its reply
  *
- * @param proto pointer to SCMI clock protocol data
+ * @param proto Pointer to SCMI clock protocol data
  * @param clk_id ID of the clock for which the query is done
- * @param permissions clock permissions returned by the command
+ * @param permissions Clock permissions returned by the command
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,
 			       uint32_t *permissions);

--- a/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief SCMI power domain protocol helpers
+ * @ingroup scmi_nxp_cpu
+ * @brief Header file for the NXP SCMI CPU Domain Protocol.
  */
 
 #ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CPU_H_
@@ -17,12 +18,23 @@
 #include <scmi_cpu_soc.h>
 #endif
 
+/**
+ * @brief NXP vendor-specific CPU domain management via SCMI
+ * @defgroup scmi_nxp_cpu NXP CPU Domain Protocol
+ * @ingroup scmi_protocols
+ * @{
+ */
+
+/** CPU sleep flag: wake-up is routed through the IRQ mux */
 #define SCMI_NXP_CPU_SLEEP_FLAG_IRQ_MUX 0x1U
 
+/** Protocol ID of the NXP CPU domain protocol */
 #define SCMI_PROTOCOL_NXP_CPU_DOMAIN 130
 
+/** Maximum number of power-domain LPM configurations per request */
 #define SCMI_NXP_CPU_MAX_PDCONFIGS_T 7U
 
+/** Maximum number of IRQ wake mask words per request */
 #define SCMI_NXP_CPU_IRQ_WAKE_NUM	22U
 
 /** CPU vector flag: Boot address (cold boot/reset) */
@@ -34,6 +46,7 @@
 /** CPU vector flag: Resume address (exit from suspend) */
 #define SCMI_NXP_CPU_VEC_FLAGS_RESUME  BIT(31)
 
+/** Version of the NXP SCMI CPU domain protocol supported by this driver */
 #define SCMI_NXP_CPU_PROTOCOL_SUPPORTED_VERSION	0x10000
 
 /**
@@ -43,25 +56,39 @@
  * command
  */
 struct scmi_nxp_cpu_sleep_mode_config {
+	/** ID of the CPU to configure */
 	uint32_t cpu_id;
+	/** Sleep flags (see SCMI_NXP_CPU_SLEEP_FLAG_*) */
 	uint32_t flags;
+	/** sleep mode to enter */
 	uint32_t sleep_mode;
 };
 
+/**
+ * @struct scmi_pd_lpm_settings
+ *
+ * @brief Low power mode setting for a single power domain
+ */
 struct scmi_pd_lpm_settings {
+	/** ID of the power domain */
 	uint32_t domain_id;
+	/** Low power mode setting for the domain */
 	uint32_t lpm_setting;
+	/** Retention mask applied in low power mode */
 	uint32_t ret_mask;
 };
 
 /**
  * @struct scmi_nxp_cpu_pd_lpm_config
  *
- * @brief Describes cpu power domain low power mode setting
+ * @brief Describes CPU power domain low power mode setting
  */
 struct scmi_nxp_cpu_pd_lpm_config {
+	/** ID of the CPU to configure */
 	uint32_t cpu_id;
+	/** Number of valid entries in @ref cfgs */
 	uint32_t num_cfg;
+	/** Per power-domain low power mode settings */
 	struct scmi_pd_lpm_settings cfgs[SCMI_NXP_CPU_MAX_PDCONFIGS_T];
 };
 
@@ -71,9 +98,13 @@ struct scmi_nxp_cpu_pd_lpm_config {
  * @brief Describes the parameters for the CPU_IRQ_WAKE_SET command
  */
 struct scmi_nxp_cpu_irq_mask_config {
+	/** ID of the CPU to configure */
 	uint32_t cpu_id;
+	/** Index of the first mask word to write */
 	uint32_t mask_idx;
+	/** Number of valid entries in @ref mask */
 	uint32_t num_mask;
+	/** IRQ wake-up mask words */
 	uint32_t mask[SCMI_NXP_CPU_IRQ_WAKE_NUM];
 };
 
@@ -83,9 +114,13 @@ struct scmi_nxp_cpu_irq_mask_config {
  * @brief Describes the parameters for the CPU_RESET_VECTOR_SET command
  */
 struct scmi_nxp_cpu_vector_config {
+	/** ID of the CPU to configure */
 	uint32_t cpu_id;
+	/** Vector flags (see SCMI_NXP_CPU_VEC_FLAGS_*) */
 	uint32_t flags;
+	/** Lower 32 bits of the reset vector address */
 	uint32_t vector_low;
+	/** Upper 32 bits of the reset vector address */
 	uint32_t vector_high;
 };
 
@@ -95,9 +130,13 @@ struct scmi_nxp_cpu_vector_config {
  * @brief Describes the parameters for the CPU_INFO_GET command
  */
 struct scmi_nxp_cpu_info {
+	/** Current run mode of the CPU */
 	uint32_t run_mode;
+	/** Current sleep mode of the CPU */
 	uint32_t sleep_mode;
+	/** Lower 32 bits of the CPU reset vector address */
 	uint32_t vector_low;
+	/** Upper 32 bits of the CPU reset vector address */
 	uint32_t vector_high;
 };
 
@@ -107,8 +146,7 @@ struct scmi_nxp_cpu_info {
  * @param cfg pointer to structure containing configuration
  * to be set
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg);
 
@@ -118,8 +156,7 @@ int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg);
  * @param cfg pointer to structure containing configuration
  * to be set
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg);
 
@@ -128,8 +165,7 @@ int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg);
  *
  * @param cfg pointer to structure containing configuration to be set
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg);
 
@@ -138,8 +174,7 @@ int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg);
  *
  * @param cfg pointer to structure containing configuration to be set
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg);
 
@@ -149,8 +184,12 @@ int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg);
  * @param cpu_id CPU ID to query (input)
  * @param cfg pointer to structure to receive CPU information (output)
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg);
+
+/**
+ * @}
+ */
+
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CPU_H_ */

--- a/include/zephyr/drivers/firmware/scmi/nxp/system.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/system.h
@@ -9,6 +9,7 @@
 
 /**
  * @file
+ * @ingroup scmi_nxp_system
  * @brief NXP SCMI System Protocol Extensions
  */
 #include <stdint.h>
@@ -18,19 +19,39 @@ extern "C" {
 #endif
 
 /**
+ * @brief NXP vendor-specific extensions to the SCMI system power protocol
+ * @defgroup scmi_nxp_system NXP System Power Protocol
+ * @ingroup scmi_protocols
+ * @{
+ */
+
+/**
  * @name NXP Vendor System Power States
  * @{
  */
+/** Wake the system */
 #define SCMI_NXP_SYSTEM_POWER_STATE_WAKE           0x80000000U
+/** Full system shutdown */
 #define SCMI_NXP_SYSTEM_POWER_STATE_FULL_SHUTDOWN  0x80000001U
+/** Full system reset */
 #define SCMI_NXP_SYSTEM_POWER_STATE_FULL_RESET     0x80000002U
+/** Full system suspend */
 #define SCMI_NXP_SYSTEM_POWER_STATE_FULL_SUSPEND   0x80000003U
+/** Full system wake */
 #define SCMI_NXP_SYSTEM_POWER_STATE_FULL_WAKE      0x80000004U
+/** Group shutdown */
 #define SCMI_NXP_SYSTEM_POWER_STATE_GRP_SHUTDOWN   0x80000005U
+/** Group reset */
 #define SCMI_NXP_SYSTEM_POWER_STATE_GRP_RESET      0x80000006U
+/** Subsystem reset */
 #define SCMI_NXP_SYSTEM_POWER_STATE_SUBSYS_RESET   0x80000007U
+/** Set system mode */
 #define SCMI_NXP_SYSTEM_POWER_STATE_MODE           0xC0000000U
 /** @} */
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/firmware/scmi/pinctrl.h
+++ b/include/zephyr/drivers/firmware/scmi/pinctrl.h
@@ -22,50 +22,87 @@
  * @{
  */
 
+/** Maximum number of config words carried by a PINCTRL_SETTINGS_CONFIGURE command */
 #define ARM_SCMI_PINCTRL_MAX_CONFIG_SIZE (10 * 2)
 
+/** Sentinel @ref scmi_pinctrl_settings::function value meaning "no function" */
 #define SCMI_PINCTRL_NO_FUNCTION 0xFFFFFFFF
 
+/**
+ * @brief Build the attributes word of a PINCTRL_SETTINGS_CONFIGURE command
+ *
+ * @param fid_valid 1 if the function ID field is valid, 0 otherwise
+ * @param cfg_num Number of configurations carried by the command
+ * @param selector Selects what is being configured (see SCMI_PINCTRL_SELECTOR_*)
+ */
 #define SCMI_PINCTRL_CONFIG_ATTRIBUTES(fid_valid, cfg_num, selector)	\
 	(SCMI_FIELD_MAKE(fid_valid, BIT(1), 10) |			\
 	 SCMI_FIELD_MAKE(cfg_num, GENMASK(7, 0), 2) |			\
 	 SCMI_FIELD_MAKE(selector, GENMASK(1, 0), 0))
 
+/** Selector value: the settings apply to a single pin */
 #define SCMI_PINCTRL_SELECTOR_PIN 0x0
+/** Selector value: the settings apply to a group of pins */
 #define SCMI_PINCTRL_SELECTOR_GROUP 0x1
 
+/** Extract the number of configurations from an attributes word */
 #define SCMI_PINCTRL_ATTRIBUTES_CONFIG_NUM(attributes)\
 	(((attributes) & GENMASK(9, 2)) >> 2)
 
+/** Version of the SCMI pin control protocol supported by this driver */
 #define SCMI_PIN_CONTROL_PROTOCOL_SUPPORTED_VERSION	0x10000
 
 /**
  * @brief Pinctrl configurations
  */
 enum scmi_pinctrl_config {
+	/** Default configuration */
 	SCMI_PINCTRL_DEFAULT = 0,
+	/** Bias the pin using a bus hold (keeper) circuit */
 	SCMI_PINCTRL_BIAS_BUS_HOLD = 1,
+	/** Disable all biasing */
 	SCMI_PINCTRL_BIAS_DISABLE = 2,
+	/** High-impedance (floating) bias */
 	SCMI_PINCTRL_BIAS_HIGH_Z = 3,
+	/** Pull the pin up */
 	SCMI_PINCTRL_BIAS_PULL_UP = 4,
+	/** Apply the default pull bias */
 	SCMI_PINCTRL_BIAS_PULL_DEFAULT = 5,
+	/** Pull the pin down */
 	SCMI_PINCTRL_BIAS_PULL_DOWN = 6,
+	/** Open-drain output drive */
 	SCMI_PINCTRL_DRIVE_OPEN_DRAIN = 7,
+	/** Open-source output drive */
 	SCMI_PINCTRL_DRIVE_OPEN_SOURCE = 8,
+	/** Push-pull output drive (note: name kept for ABI compatibility) */
 	SCMI_PCINTRL_DRIVE_PUSH_PULL = 9,
+	/** Output drive strength (note: name kept for ABI compatibility) */
 	SCMI_PCINTRL_DRIVE_STRENGTH = 10,
+	/** Input debounce time */
 	SCMI_PINCTRL_INPUT_DEBOUNCE = 11,
+	/** Input mode enable */
 	SCMI_PINCTRL_INPUT_MODE = 12,
+	/** Pull mode selection */
 	SCMI_PINCTRL_PULL_MODE = 13,
+	/** Input value */
 	SCMI_PINCTRL_INPUT_VALUE = 14,
+	/** Input Schmitt-trigger enable */
 	SCMI_PINCTRL_INPUT_SCHMITT = 15,
+	/** Low-power mode */
 	SCMI_PINCTRL_LP_MODE = 16,
+	/** Output mode enable */
 	SCMI_PINCTRL_OUTPUT_MODE = 17,
+	/** Output value */
 	SCMI_PINCTRL_OUTPUT_VALUE = 18,
+	/** Power source selection */
 	SCMI_PINCTRL_POWER_SOURCE = 19,
+	/** Output slew rate */
 	SCMI_PINCTRL_SLEW_RATE = 20,
+	/** First reserved configuration type */
 	SCMI_PINCTRL_RESERVED_START = 21,
+	/** Last reserved configuration type */
 	SCMI_PINCTRL_RESERVED_END = 191,
+	/** First vendor-specific configuration type */
 	SCMI_PINCTRL_VENDOR_START = 192,
 };
 
@@ -76,19 +113,22 @@ enum scmi_pinctrl_config {
  * command
  */
 struct scmi_pinctrl_settings {
+	/** Identifier of the pin or group being configured */
 	uint32_t id;
+	/** Function to multiplex, or @ref SCMI_PINCTRL_NO_FUNCTION */
 	uint32_t function;
+	/** Attributes word (see @ref SCMI_PINCTRL_CONFIG_ATTRIBUTES) */
 	uint32_t attributes;
+	/** Array of {type, value} configuration pairs */
 	uint32_t config[ARM_SCMI_PINCTRL_MAX_CONFIG_SIZE];
 };
 
 /**
  * @brief Send the PINCTRL_SETTINGS_CONFIGURE command and get its reply
  *
- * @param settings pointer to settings to be applied
+ * @param settings Pointer to settings to be applied
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings);
 

--- a/include/zephyr/drivers/firmware/scmi/power.h
+++ b/include/zephyr/drivers/firmware/scmi/power.h
@@ -22,8 +22,10 @@
  * @{
  */
 
+/** POWER_STATE_SET flag: perform the power state change asynchronously */
 #define SCMI_POWER_STATE_SET_FLAGS_ASYNC BIT(0)
 
+/** Version of the SCMI power domain protocol supported by this driver */
 #define SCMI_POWER_DOMAIN_PROTOCOL_SUPPORTED_VERSION	0x30001
 
 /**
@@ -69,29 +71,29 @@
  * command
  */
 struct scmi_power_state_config {
+	/** Request flags (see SCMI_POWER_STATE_SET_FLAGS_*) */
 	uint32_t flags;
+	/** ID of the power domain to configure */
 	uint32_t domain_id;
+	/** Power state to set (see @ref SCMI_POWER_STATE_PARAM) */
 	uint32_t power_state;
 };
 
 /**
  * @brief Send the POWER_STATE_SET command and get its reply
  *
- * @param cfg pointer to structure containing configuration
- * to be set
+ * @param cfg Pointer to structure containing configuration to be set
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_power_state_set(struct scmi_power_state_config *cfg);
 /**
  * @brief Query the power domain state
  *
  * @param domain_id ID of the power domain for which the query is done
- * @param power_state pointer to be set via this command
+ * @param power_state Pointer to be set via this command
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state);
 

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -31,19 +31,22 @@
 /**
  * @brief Build an SCMI message header
  *
- * Builds an SCMI message header based on the
- * fields that make it up.
+ * Builds an SCMI message header based on the fields that make it up.
+ * The resulting 32-bit header is laid out as follows:
+ *
+ * - bits [7:0]   message ID
+ * - bits [9:8]   message type (see @ref scmi_message_type)
+ * - bits [17:10] protocol ID
+ * - bits [27:18] message token
  *
  * @param id message ID
  * @param type message type
  * @param proto protocol ID
  * @param token message token
  */
-#define SCMI_MESSAGE_HDR_MAKE(id, type, proto, token)	\
-	(SCMI_FIELD_MAKE(id, GENMASK(7, 0), 0)     |	\
-	 SCMI_FIELD_MAKE(type, GENMASK(1, 0), 8)   |	\
-	 SCMI_FIELD_MAKE(proto, GENMASK(7, 0), 10) |	\
-	 SCMI_FIELD_MAKE(token, GENMASK(9, 0), 18))
+#define SCMI_MESSAGE_HDR_MAKE(id, type, proto, token)                                              \
+	(SCMI_FIELD_MAKE(id, GENMASK(7, 0), 0) | SCMI_FIELD_MAKE(type, GENMASK(1, 0), 8) |         \
+	 SCMI_FIELD_MAKE(proto, GENMASK(7, 0), 10) | SCMI_FIELD_MAKE(token, GENMASK(9, 0), 18))
 
 struct scmi_channel;
 
@@ -51,11 +54,11 @@ struct scmi_channel;
  * @brief SCMI message type
  */
 enum scmi_message_type {
-	/** command message */
+	/** Command message */
 	SCMI_COMMAND = 0x0,
-	/** delayed reply message */
+	/** Delayed reply message */
 	SCMI_DELAYED_REPLY = 0x2,
-	/** notification message */
+	/** Notification message */
 	SCMI_NOTIFICATION = 0x3,
 };
 
@@ -63,17 +66,29 @@ enum scmi_message_type {
  * @brief SCMI status codes
  */
 enum scmi_status_code {
+	/** Successful completion */
 	SCMI_SUCCESS = 0,
+	/** The command is not supported */
 	SCMI_NOT_SUPPORTED = -1,
+	/** One or more parameters are invalid */
 	SCMI_INVALID_PARAMETERS = -2,
+	/** The caller is not permitted to perform the operation */
 	SCMI_DENIED = -3,
+	/** The entity referenced by the command was not found */
 	SCMI_NOT_FOUND = -4,
+	/** A parameter or value is out of the supported range */
 	SCMI_OUT_OF_RANGE = -5,
+	/** The platform is busy and cannot service the command */
 	SCMI_BUSY = -6,
+	/** A communication error occurred */
 	SCMI_COMMS_ERROR = -7,
+	/** An unspecified error occurred */
 	SCMI_GENERIC_ERROR = -8,
+	/** A hardware error occurred */
 	SCMI_HARDWARE_ERROR = -9,
+	/** A protocol error (e.g. malformed message) occurred */
 	SCMI_PROTOCOL_ERROR = -10,
+	/** The resource is already in use */
 	SCMI_IN_USE = -11,
 };
 
@@ -83,15 +98,15 @@ enum scmi_status_code {
  * @brief SCMI protocol structure
  */
 struct scmi_protocol {
-	/** protocol ID */
+	/** Protocol ID */
 	uint32_t id;
 	/** TX channel */
 	struct scmi_channel *tx;
-	/** transport layer device */
+	/** Transport layer device */
 	const struct device *transport;
-	/** protocol private data */
+	/** Protocol private data */
 	void *data;
-	/** protocol supported version */
+	/** Protocol supported version */
 	uint32_t version;
 };
 
@@ -111,9 +126,9 @@ struct scmi_protocol_version {
 		/** Raw 32-bit protocol version value */
 		uint32_t raw;
 		struct {
-			/** major protocol revision */
+			/** Minor protocol revision */
 			uint16_t minor;
-			/** minor protocol revision */
+			/** Major protocol revision */
 			uint16_t major;
 		};
 	};
@@ -125,8 +140,11 @@ struct scmi_protocol_version {
  * @brief SCMI message structure
  */
 struct scmi_message {
+	/** Message header (see @ref SCMI_MESSAGE_HDR_MAKE) */
 	uint32_t hdr;
+	/** Size in bytes of the data pointed to by @ref content */
 	uint32_t len;
+	/** Pointer to the message payload (parameters or return values) */
 	void *content;
 };
 
@@ -135,7 +153,7 @@ struct scmi_message {
  *
  * @param scmi_status SCMI status code as shown in `enum scmi_status_code`
  *
- * @retval Linux equivalent status code
+ * @return Linux (errno) equivalent of the given SCMI status code
  */
 int scmi_status_to_errno(int scmi_status);
 
@@ -149,19 +167,18 @@ int scmi_status_to_errno(int scmi_status);
  * @param msg pointer to SCMI message to send
  * @param reply pointer to SCMI message in which the reply is to be
  * written
- *
- * @retval 0 if successful
- * @retval negative errno if failure
  * @param use_polling Specifies the communication mechanism used by the scmi
  * platform to interact with agents.
+ *
  * - true: Polling mode — the platform actively checks the message status
  *   to determine if it has been processed
  * - false: Interrupt mode — the platform relies on SCMI interrupts to
  *   detect when a message has been handled.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
-int scmi_send_message(struct scmi_protocol *proto,
-		      struct scmi_message *msg, struct scmi_message *reply,
-		      bool use_polling);
+int scmi_send_message(struct scmi_protocol *proto, struct scmi_message *msg,
+		      struct scmi_message *reply, bool use_polling);
 
 /**
  * @brief Get protocol version
@@ -169,8 +186,7 @@ int scmi_send_message(struct scmi_protocol *proto,
  * @param proto Protocol instance
  * @param version Pointer to store protocol version
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version);
 
@@ -180,8 +196,7 @@ int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version);
  * @param proto Protocol instance
  * @param attributes Pointer to store protocol attributes
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attributes);
 
@@ -192,11 +207,10 @@ int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attribut
  * @param message_id Message ID to query
  * @param attributes Pointer to store message attributes
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
-int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
-					uint32_t message_id, uint32_t *attributes);
+int scmi_protocol_message_attributes_get(struct scmi_protocol *proto, uint32_t message_id,
+					 uint32_t *attributes);
 
 /**
  * @brief Negotiate protocol version
@@ -204,8 +218,7 @@ int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
  * @param proto Protocol instance
  * @param version Desired protocol version
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t version);
 

--- a/include/zephyr/drivers/firmware/scmi/shmem.h
+++ b/include/zephyr/drivers/firmware/scmi/shmem.h
@@ -24,29 +24,53 @@
  * @{
  */
 
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * Channel status: set while the channel is busy (a message has been written
+ * by the agent and not yet consumed/replied to by the platform).
+ */
 #define SCMI_SHMEM_CHAN_STATUS_BUSY_BIT BIT(0)
+/**
+ * Channel flag: when set, the platform should raise an interrupt on
+ * completion instead of relying on the agent polling the status.
+ */
 #define SCMI_SHMEM_CHAN_FLAG_IRQ_BIT BIT(0)
 
+/**
+ * @brief In-memory layout of an SCMI shared memory channel
+ *
+ * Mirrors the SCMI specification's shared memory area. Only meant to be used
+ * by the SCMI core and by transport/vendor drivers operating on the raw shared
+ * memory region.
+ */
 struct scmi_shmem_layout {
+	/** Reserved (implementation defined) */
 	volatile uint32_t res0;
+	/** Channel status (see @ref SCMI_SHMEM_CHAN_STATUS_BUSY_BIT) */
 	volatile uint32_t chan_status;
+	/** Reserved (implementation defined) */
 	volatile uint32_t res1[2];
+	/** Channel flags (see @ref SCMI_SHMEM_CHAN_FLAG_IRQ_BIT) */
 	volatile uint32_t chan_flags;
+	/** Length in bytes of @ref msg_hdr plus the payload that follows it */
 	volatile uint32_t len;
+	/** Message header (see @ref SCMI_MESSAGE_HDR_MAKE) */
 	volatile uint32_t msg_hdr;
 };
+
+/** @endcond */
 
 struct scmi_message;
 
 /**
  * @brief Write a message in the SHMEM area
  *
- * @param shmem pointer to shmem device
- * @param msg message to write
+ * @param shmem Pointer to shmem device
+ * @param msg Message to write
  * @param use_polling true if polling should be used, false otherwise
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_shmem_write_message(const struct device *shmem,
 			     struct scmi_message *msg,
@@ -55,11 +79,10 @@ int scmi_shmem_write_message(const struct device *shmem,
 /**
  * @brief Read a message from a SHMEM area
  *
- * @param shmem pointer to shmem device
- * @param msg message to write the data into
+ * @param shmem Pointer to shmem device
+ * @param msg Message to write the data into
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_shmem_read_message(const struct device *shmem,
 			    struct scmi_message *msg);
@@ -67,11 +90,9 @@ int scmi_shmem_read_message(const struct device *shmem,
 /**
  * @brief Update the channel flags
  *
- * @param shmem pointer to shmem device
- * @param mask value to negate and bitwise-and the old
- * channel flags value
- * @param val value to bitwise and with the mask and
- * bitwise-or with the masked old value
+ * @param shmem Pointer to shmem device
+ * @param mask Value to negate and bitwise-and the old channel flags value
+ * @param val Value to bitwise and with the mask and bitwise-or with the masked old value
  */
 void scmi_shmem_update_flags(const struct device *shmem,
 			     uint32_t mask, uint32_t val);
@@ -79,27 +100,25 @@ void scmi_shmem_update_flags(const struct device *shmem,
 /**
  * @brief Read a channel's status
  *
- * @param shmem pointer to shmem device
+ * @param shmem Pointer to shmem device
  */
 uint32_t scmi_shmem_channel_status(const struct device *shmem);
 
 /**
  * @brief Process vendor specific features when writing message
  *
- * @param layout layout of the message
+ * @param layout Layout of the message
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_shmem_vendor_write_message(struct scmi_shmem_layout *layout);
 
 /**
  * @brief Process vendor specific features when reading message
  *
- * @param layout layout of the message
+ * @param layout Layout of the message
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_shmem_vendor_read_message(const struct scmi_shmem_layout *layout);
 

--- a/include/zephyr/drivers/firmware/scmi/system.h
+++ b/include/zephyr/drivers/firmware/scmi/system.h
@@ -28,6 +28,7 @@
 extern "C" {
 #endif
 
+/** Version of the SCMI system power protocol supported by this driver */
 #define SCMI_SYSTEM_POWER_PROTOCOL_SUPPORTED_VERSION 0x20001
 
 /**
@@ -35,15 +36,15 @@ extern "C" {
  * @{
  */
 
-/**< Shutdown off */
+/** Shutdown off */
 #define SCMI_SYSTEM_POWER_STATE_SHUTDOWN      0x00000000U
-/**< Cold reset */
+/** Cold reset */
 #define SCMI_SYSTEM_POWER_STATE_COLD_RESET    0x00000001U
-/**< Warm reset */
+/** Warm reset */
 #define SCMI_SYSTEM_POWER_STATE_WARM_RESET    0x00000002U
-/**< Power up */
+/** Power up */
 #define SCMI_SYSTEM_POWER_STATE_POWER_UP      0x00000003U
-/**< Suspend */
+/** Suspend */
 #define SCMI_SYSTEM_POWER_STATE_SUSPEND       0x00000004U
 
 /** @} */
@@ -57,15 +58,14 @@ extern "C" {
 #define SCMI_SYSTEM_POWER_FLAG_SHIFT	(0)
 /** @endcond */
 
-/**< Forceful request */
+/** Forceful request */
 #define SCMI_SYSTEM_POWER_FLAG_FORCEFUL	(0 << SCMI_SYSTEM_POWER_FLAG_SHIFT)
-/**< Graceful request */
+/** Graceful request */
 #define SCMI_SYSTEM_POWER_FLAG_GRACEFUL	(1 << SCMI_SYSTEM_POWER_FLAG_SHIFT)
 
 /** @} */
 
-
-/*!
+/**
  * @name SCMI system message attributes
  * @{
  */
@@ -75,9 +75,9 @@ extern "C" {
 #define SCMI_SYSTEM_MSG_ATTR_WARM_RESET_SHIFT	(31U)
 /** @endcond */
 
-/*! System suspend support */
+/** System suspend support */
 #define SCMI_SYSTEM_MSG_ATTR_SUSPEND	(1 << SCMI_SYSTEM_MSG_ATTR_SUSPEND_SHIFT)
-/*! System warm reset support */
+/** System warm reset support */
 #define SCMI_SYSTEM_MSG_ATTR_WARM_RESET	(1 << SCMI_SYSTEM_MSG_ATTR_WARM_RESET_SHIFT)
 
 /** @} */
@@ -87,7 +87,9 @@ extern "C" {
  * @brief System power state configuration
  */
 struct scmi_system_power_state_config {
+	/** Request flags (see SCMI_SYSTEM_POWER_FLAG_*) */
 	uint32_t flags;
+	/** Target system power state (see SCMI_SYSTEM_POWER_STATE_*) */
 	uint32_t system_state;
 };
 
@@ -96,8 +98,7 @@ struct scmi_system_power_state_config {
  *
  * @param version Protocol version
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_system_protocol_version(uint32_t *version);
 
@@ -106,8 +107,7 @@ int scmi_system_protocol_version(uint32_t *version);
  *
  * @param attributes Protocol attributes
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_system_protocol_attributes(uint32_t *attributes);
 
@@ -117,28 +117,25 @@ int scmi_system_protocol_attributes(uint32_t *attributes);
  * @param message_id Message ID of the message
  * @param attributes Message attributes
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_system_protocol_message_attributes(uint32_t message_id, uint32_t *attributes);
 
 /**
  * @brief Negotiate protocol version
  *
- * @param version desired protocol version
+ * @param version Desired protocol version
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_system_protocol_version_negotiate(uint32_t version);
 
 /**
  * @brief Set system power state
  *
- * @param cfg pointer to power state configuration
+ * @param cfg Pointer to power state configuration
  *
- * @retval 0 if successful
- * @retval negative errno if failure
+ * @return 0 on success, negative errno value on failure.
  */
 int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg);
 

--- a/include/zephyr/drivers/firmware/scmi/transport.h
+++ b/include/zephyr/drivers/firmware/scmi/transport.h
@@ -50,10 +50,10 @@ typedef void (*scmi_channel_cb)(struct scmi_channel *chan);
  * channels is represented by a `struct scmi_channel`.
  */
 struct scmi_channel {
-	/** channel private data */
+	/** Channel private data */
 	void *data;
 	/**
-	 * callback function. This is meant to be set by
+	 * Callback function. This is meant to be set by
 	 * the SCMI core and should be called by the SCMI
 	 * transport layer driver whenever a reply has
 	 * been received.
@@ -61,7 +61,7 @@ struct scmi_channel {
 	scmi_channel_cb cb;
 	/** @cond INTERNAL_HIDDEN */
 	/**
-	 * channel lock. This is meant to be initialized
+	 * Channel lock. This is meant to be initialized
 	 * and used only by the SCMI core to assure that
 	 * only one protocol can send/receive messages
 	 * through a channel at a given moment.
@@ -69,7 +69,7 @@ struct scmi_channel {
 	struct k_mutex lock;
 
 	/**
-	 * binary semaphore. This is meant to be initialized
+	 * Binary semaphore. This is meant to be initialized
 	 * and used only by the SCMI core. Its purpose is to
 	 * signal that a reply has been received.
 	 */
@@ -79,7 +79,7 @@ struct scmi_channel {
 	bool ready;
 	/** @endcond */
 	/**
-	 * indicates if the channel requires polling-only operation.
+	 * Indicates if the channel requires polling-only operation.
 	 * When set to true, the channel cannot use interrupt-based
 	 * messaging and must always poll for responses.
 	 */
@@ -303,8 +303,7 @@ static inline bool scmi_transport_channel_is_free(const struct device *transport
 /**
  * @brief Perform SCMI core initialization
  *
- * @param transport pointer to the device structure for
- * the transport layer
+ * @param transport Pointer to the device structure for the transport layer
  *
  * @return 0 on success, negative errno value on failure.
  */

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -30,7 +30,7 @@
  * name. This is done by concatenating the scmi_protocol_
  * construct with the given protocol ID.
  *
- * @param proto protocol ID in decimal format
+ * @param proto Protocol ID in decimal format
  *
  * @return protocol name
  */
@@ -58,7 +58,7 @@
  * a compatible string matching the current transport's definition
  * (DT_SCMI_TRANSPORT_COMPATIBLE).
  *
- * @param node_id protocol node identifier
+ * @param node_id Protocol node identifier
  * @return 1 if the node is the base transport node, 0 otherwise.
  */
 #define DT_SCMI_TRANSPORT_PROTO_IS_BASE(node_id) \
@@ -71,7 +71,7 @@
  * Base protocol requires special handling since it shares
  * the same DT node with the transport.
  *
- * @param node_id protocol node identifier
+ * @param node_id Protocol node identifier
  * @return protocol ID
  */
 #define DT_SCMI_TRANSPORT_PROTOCOL_ID(node_id)					\
@@ -91,8 +91,8 @@
  * version of this macro based on the devicetree properties
  * that indicate the presence of a dedicated channel.
  *
- * @param node_id protocol node identifier
- * @idx channel index. Should be 0 for TX channels and 1 for
+ * @param node_id Protocol node identifier
+ * @param idx channel index. Should be 0 for TX channels and 1 for
  * RX channels
  */
 #define DT_SCMI_TRANSPORT_PROTO_HAS_CHAN(node_id, idx)\
@@ -103,26 +103,30 @@
  * For SMC transport, all protocols share the base channel.
  * Return 0, to make all protocols fall back to base channel.
  *
- * @param node_id protocol node identifier
- * @idx channel index
+ * @param node_id Protocol node identifier
+ * @param idx channel index
  */
 #define DT_SCMI_TRANSPORT_PROTO_HAS_CHAN(node_id, idx) 0
 #else
 #error "Transport with static channels needs to define HAS_CHAN macro"
 #endif
 
+/** @cond INTERNAL_HIDDEN */
+/* builds the symbol name of the static channel for a (proto, idx) pair */
 #define SCMI_TRANSPORT_CHAN_NAME(proto, idx) CONCAT(scmi_channel_, proto, _, idx)
+/** @endcond */
 
-/**
- * @brief Declare a TX SCMI channel
+/** @cond INTERNAL_HIDDEN */
+
+/*
+ * Declare a TX SCMI channel.
  *
  * Given a node_id for a protocol, this macro declares the SCMI
  * TX channel statically bound to said protocol via the "extern"
  * qualifier. This is useful when the transport layer driver
  * supports static channels since all channel structures are
- * defined inside the transport layer driver.
- *
- * @param node_id protocol node identifier
+ * defined inside the transport layer driver. Internal helper used
+ * by DT_SCMI_TRANSPORT_CHANNELS_DECLARE(); not meant to be used directly.
  */
 #define DT_SCMI_TRANSPORT_TX_CHAN_DECLARE(node_id)				\
 	COND_CODE_1(DT_SCMI_TRANSPORT_PROTO_HAS_CHAN(node_id, 0),		\
@@ -131,6 +135,7 @@
 			DT_SCMI_TRANSPORT_PROTOCOL_ID(node_id), 0);),		\
 		    (extern struct scmi_channel					\
 		     SCMI_TRANSPORT_CHAN_NAME(SCMI_PROTOCOL_BASE, 0);))		\
+/** @endcond */
 
 /**
  * @brief Declare SCMI TX/RX channels
@@ -165,9 +170,9 @@
  * reference to an SCMI TX channel statically bound to said
  * protocol.
  *
- * @param node_id protocol node identifier
+ * @param node_id Protocol node identifier
  *
- * @return reference to the struct scmi_channel of the TX channel
+ * @return Reference to the struct scmi_channel of the TX channel
  * bound to the protocol identifier by node_id
  */
 #define DT_SCMI_TRANSPORT_TX_CHAN(node_id)					\
@@ -183,10 +188,11 @@
  * This should be used by the transport layer driver to statically
  * define SCMI channels for the protocols.
  *
- * @param node_id protocol node identifier
+ * @param node_id Protocol node identifier
  * @param idx channel index. Should be 0 for TX channels and 1
  * for RX channels
- * @param proto protocol ID in decimal format
+ * @param proto Protocol ID in decimal format
+ * @param pdata Pointer to the channel's private data
  */
 #define DT_SCMI_TRANSPORT_CHAN_DEFINE(node_id, idx, proto, pdata)		\
 	struct scmi_channel SCMI_TRANSPORT_CHAN_NAME(proto, idx) =		\
@@ -194,8 +200,10 @@
 		.data = pdata,							\
 	}
 
-/**
- * @brief Define an SCMI protocol's data
+/** @cond INTERNAL_HIDDEN */
+
+/*
+ * Define an SCMI protocol's data.
  *
  * Each SCMI protocol is identified by a struct scmi_protocol
  * placed in a linker section called scmi_protocol. Each protocol
@@ -205,9 +213,10 @@
  * DT_SCMI_PROTOCOL_DEFINE(), which also takes care of the static
  * channel declaration (if applicable).
  *
- * @param node_id protocol node identifier
- * @param proto protocol ID in decimal format
- * @param pdata protocol private data
+ * node_id     - protocol node identifier
+ * proto       - protocol ID in decimal format
+ * pdata       - protocol private data
+ * version_val - protocol version supported by the driver
  */
 #define DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, proto, pdata, version_val)	\
 	STRUCT_SECTION_ITERABLE(scmi_protocol, SCMI_PROTOCOL_NAME(proto)) =	\
@@ -217,17 +226,22 @@
 		.data = pdata,							\
 		.version = version_val						\
 	}
+/** @endcond */
 
 #else /* CONFIG_ARM_SCMI_TRANSPORT_HAS_STATIC_CHANNELS */
 
+/** @cond INTERNAL_HIDDEN */
+/* no-op variant used when the transport does not support static channels */
 #define DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)
 
+/* variant used when the transport does not support static channels */
 #define DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, proto, pdata)			\
 	STRUCT_SECTION_ITERABLE(scmi_protocol, SCMI_PROTOCOL_NAME(proto)) =	\
 	{									\
 		.id = proto,							\
 		.data = pdata,							\
 	}
+/** @endcond */
 
 #endif /* CONFIG_ARM_SCMI_TRANSPORT_HAS_STATIC_CHANNELS */
 
@@ -251,26 +265,28 @@
  * @brief Define an SCMI protocol
  *
  * This macro performs three important functions:
- *	1) It defines a `struct scmi_protocol`, which is
- *	needed by all protocol drivers to work with the SCMI API.
  *
- *	2) It declares the static channels bound to the protocol.
- *	This is only applicable if the transport layer driver
- *	supports static channels.
+ * 1. It defines a `struct scmi_protocol`, which is
+ *    needed by all protocol drivers to work with the SCMI API.
  *
- *	3) It creates a `struct device` a sets the `data` field
- *	to the newly defined `struct scmi_protocol`. This is
- *	needed because the protocol driver needs to work with the
- *	SCMI API **and** the subsystem API.
+ * 2. It declares the static channels bound to the protocol.
+ *    This is only applicable if the transport layer driver
+ *    supports static channels.
  *
- * @param node_id protocol node identifier
- * @param init_fn pointer to protocol's initialization function
- * @param api pointer to protocol's subsystem API
- * @param pm pointer to the protocol's power management resources
- * @param data pointer to protocol's private data
- * @param config pointer to protocol's private constant data
- * @param level protocol initialization level
- * @param prio protocol's priority within its initialization level
+ * 3. It creates a `struct device` a sets the `data` field
+ *    to the newly defined `struct scmi_protocol`. This is
+ *    needed because the protocol driver needs to work with the
+ *    SCMI API **and** the subsystem API.
+ *
+ * @param node_id Protocol node identifier
+ * @param init_fn Pointer to protocol's initialization function
+ * @param api Pointer to protocol's subsystem API
+ * @param pm Pointer to the protocol's power management resources
+ * @param data Pointer to protocol's private data
+ * @param config Pointer to protocol's private constant data
+ * @param level Protocol initialization level
+ * @param prio Protocol's priority within its initialization level
+ * @param version_val Protocol version supported by the driver
  */
 #define DT_SCMI_PROTOCOL_DEFINE(node_id, init_fn, pm, data, config,		\
 				level, prio, api, version_val)			\
@@ -287,14 +303,15 @@
  * @brief Just like DT_SCMI_PROTOCOL_DEFINE(), but uses an instance
  * of a `DT_DRV_COMPAT` compatible instead of a node identifier
  *
- * @param inst instance number
- * @param init_fn pointer to protocol's initialization function
- * @param api pointer to protocol's subsystem API
- * @param pm pointer to the protocol's power management resources
- * @param data pointer to protocol's private data
- * @param config pointer to protocol's private constant data
- * @param level protocol initialization level
- * @param prio protocol's priority within its initialization level
+ * @param inst Instance number
+ * @param init_fn Pointer to protocol's initialization function
+ * @param api Pointer to protocol's subsystem API
+ * @param pm Pointer to the protocol's power management resources
+ * @param data Pointer to protocol's private data
+ * @param config Pointer to protocol's private constant data
+ * @param level Protocol initialization level
+ * @param prio Protocol's priority within its initialization level
+ * @param version Protocol version supported by the driver
  */
 #define DT_INST_SCMI_PROTOCOL_DEFINE(inst, init_fn, pm, data, config,		\
 				     level, prio, api, version)			\
@@ -309,8 +326,9 @@
  * initialization. This is useful for protocols that are not really
  * part of a subsystem with an API (e.g: pinctrl).
  *
- * @param node_id protocol node identifier
- * @param data protocol private data
+ * @param node_id Protocol node identifier
+ * @param data Protocol private data
+ * @param version Protocol version supported by the driver
  */
 #define DT_SCMI_PROTOCOL_DEFINE_NODEV(node_id, data, version)			\
 	DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
@@ -326,9 +344,11 @@
  * This comes in handy when building said parameters/
  * return values.
  *
- * @param x value to encode
- * @param mask value to perform bitwise-and with `x`
- * @param shift value to left-shift masked `x`
+ * @param x Value to encode
+ * @param mask Value to perform bitwise-and with `x`
+ * @param shift Value to left-shift masked `x`
+ *
+ * @return the encoded message field
  */
 #define SCMI_FIELD_MAKE(x, mask, shift)\
 	(((uint32_t)(x) & (mask)) << (shift))
@@ -341,16 +361,16 @@
  * might be used to build protocol and static channel
  * names.
  */
-#define SCMI_PROTOCOL_BASE 16
-#define SCMI_PROTOCOL_POWER_DOMAIN 17
-#define SCMI_PROTOCOL_SYSTEM 18
-#define SCMI_PROTOCOL_PERF 19
-#define SCMI_PROTOCOL_CLOCK 20
-#define SCMI_PROTOCOL_SENSOR 21
-#define SCMI_PROTOCOL_RESET_DOMAIN 22
-#define SCMI_PROTOCOL_VOLTAGE_DOMAIN 23
-#define SCMI_PROTOCOL_PCAP_MONITOR 24
-#define SCMI_PROTOCOL_PINCTRL 25
+#define SCMI_PROTOCOL_BASE 16           /**< Base protocol */
+#define SCMI_PROTOCOL_POWER_DOMAIN 17   /**< Power domain management protocol */
+#define SCMI_PROTOCOL_SYSTEM 18         /**< System power management protocol */
+#define SCMI_PROTOCOL_PERF 19           /**< Performance domain management protocol */
+#define SCMI_PROTOCOL_CLOCK 20          /**< Clock management protocol */
+#define SCMI_PROTOCOL_SENSOR 21         /**< Sensor management protocol */
+#define SCMI_PROTOCOL_RESET_DOMAIN 22   /**< Reset domain management protocol */
+#define SCMI_PROTOCOL_VOLTAGE_DOMAIN 23 /**< Voltage domain management protocol */
+#define SCMI_PROTOCOL_PCAP_MONITOR 24   /**< Power capping and monitoring protocol */
+#define SCMI_PROTOCOL_PINCTRL 25        /**< Pin control protocol */
 
 /**
  * @}


### PR DESCRIPTION
Fix/improve Doxygen documentation and structure of SCMI headers, i.e. add missing brief/descriptions, groups, fix incorrect comments (e.g. wrong use of `/**<`), etc.

Note that there are many headers where the comments wrap at 60 characters if not less, that's a bit disconcerting and while i fixed a few, I think it would be great to eventually make sure the wrapping is set to 100 characters like everywhere else in Zephyr :)

* https://builds.zephyrproject.io/zephyr/pr/110339/docs/doxygen/html/group__scmi__interface.html

* https://builds.zephyrproject.io/zephyr/pr/110339/api-coverage/zephyr/drivers/firmware/scmi/index.html
* https://builds.zephyrproject.io/zephyr/pr/110339/api-coverage/zephyr/drivers/firmware/scmi/nxp/index.html
