### PR TITLE
samples: drivers: i2c: rtio_loopback: bus recovery may not be supported

### DIFF
--- a/samples/drivers/i2c/rtio_loopback/src/main.c
+++ b/samples/drivers/i2c/rtio_loopback/src/main.c
@@ -434,6 +434,7 @@ static int sample_rtio_write_read_async(void)
 int main(void)
 {
 	int ret, n;
+	bool recover_supported = IS_ENABLED(CONFIG_I2C_BUS_RECOVERY);
 
 	for (n = 0; n < sizeof(sample_write_data); n++) {
 		sample_write_data[n] = (0xFF - n) % 0xFF;
@@ -450,13 +451,27 @@ int main(void)
 		return 0;
 	}
 
-	printk("%s %s\n", "standard_configure_and_recover", "running");
-	ret = sample_standard_configure_and_recover();
-	if (ret) {
-		printk("%s %s (%d)\n", "standard_configure_and_recover", "failed", ret);
-		return 0;
+	if (recover_supported) {
+		ret = i2c_recover_bus(sample_i2c_controller);
+		if (ret == -ENOSYS) {
+			printk("%s\n", "I2C bus recovery is not supported");
+			recover_supported = false;
+			ret = 0;
+		}
+		if (ret) {
+			printk("%s %s (%d)\n", "test recovery support", "failed", ret);
+			return 0;
+		}
 	}
 
+	if (recover_supported) {
+		printk("%s %s\n", "standard_configure_and_recover", "running");
+		ret = sample_standard_configure_and_recover();
+		if (ret) {
+			printk("%s %s (%d)\n", "standard_configure_and_recover", "failed", ret);
+			return 0;
+		}
+	}
 	sample_reset_buffers();
 
 	printk("%s %s\n", "standard_write_read", "running");
@@ -472,11 +487,13 @@ int main(void)
 		return 0;
 	}
 
-	printk("%s %s\n", "rtio_configure_recover", "running");
-	ret = sample_rtio_configure_and_recover();
-	if (ret) {
-		printk("%s %s (%d)\n", "rtio_configure_recover", "failed", ret);
-		return 0;
+	if (recover_supported) {
+		printk("%s %s\n", "rtio_configure_recover", "running");
+		ret = sample_rtio_configure_and_recover();
+		if (ret) {
+			printk("%s %s (%d)\n", "rtio_configure_recover", "failed", ret);
+			return 0;
+		}
 	}
 
 	sample_reset_buffers();

--- a/samples/drivers/i2c/rtio_loopback/src/main.c
+++ b/samples/drivers/i2c/rtio_loopback/src/main.c
@@ -162,7 +162,6 @@ static void sample_reset_buffers(void)
 
 static int sample_standard_write_read(void)
 {
-	int ret;
 	struct i2c_msg msgs[2];
 
 	msgs[0].buf = sample_write_data;
@@ -173,15 +172,7 @@ static int sample_standard_write_read(void)
 	msgs[1].len = sizeof(sample_read_buf);
 	msgs[1].flags = I2C_MSG_RESTART | I2C_MSG_READ | I2C_MSG_STOP;
 
-	ret = i2c_transfer(sample_i2c_controller,
-			   msgs,
-			   ARRAY_SIZE(msgs),
-			   I2C_TARGET_ADDR);
-	if (ret) {
-		return -EIO;
-	}
-
-	return 0;
+	return i2c_transfer(sample_i2c_controller, msgs, ARRAY_SIZE(msgs), I2C_TARGET_ADDR);
 }
 
 static int sample_validate_write_read(void)
@@ -202,7 +193,7 @@ static int sample_validate_write_read(void)
 				       n, sample_write_buf[n], sample_write_data[n]);
 			}
 		}
-		return -EIO;
+		return ret;
 	}
 
 	ret = memcmp(sample_read_buf, sample_read_data, sizeof(sample_read_data));
@@ -213,7 +204,7 @@ static int sample_validate_write_read(void)
 				       n, sample_read_buf[n], sample_read_data[n]);
 			}
 		}
-		return -EIO;
+		return ret;
 	}
 
 	return 0;
@@ -259,14 +250,14 @@ static int sample_rtio_configure_and_recover(void)
 	/* This is the result of the i2c configure SQE */
 	cqe = rtio_cqe_consume(&sample_rtio);
 	if (cqe->result) {
-		ret = -EIO;
+		ret = cqe->result;
 	}
 	rtio_cqe_release(&sample_rtio, cqe);
 
 	/* This is the result of the i2c recover SQE */
 	cqe = rtio_cqe_consume(&sample_rtio);
 	if (cqe->result) {
-		ret = -EIO;
+		ret = cqe->result;
 	}
 	rtio_cqe_release(&sample_rtio, cqe);
 
@@ -328,7 +319,7 @@ static int sample_rtio_write_read(void)
 	 */
 	ret = rtio_submit(&sample_rtio, 2);
 	if (ret) {
-		return -EIO;
+		return ret;
 	}
 
 	/*
@@ -340,7 +331,7 @@ static int sample_rtio_write_read(void)
 	 */
 	wr_rd_cqe = rtio_cqe_consume(&sample_rtio);
 	if (wr_rd_cqe->result) {
-		return -EIO;
+		return wr_rd_cqe->result;
 	}
 
 	/* Release the CQE after having checked its result. */
@@ -421,7 +412,7 @@ static int sample_rtio_write_read_async(void)
 	 */
 	ret = rtio_submit(&sample_rtio, 0);
 	if (ret) {
-		return -EIO;
+		return ret;
 	}
 
 	/*
@@ -434,7 +425,7 @@ static int sample_rtio_write_read_async(void)
 	 */
 	ret = k_sem_take(&sample_write_read_sem, SAMPLE_TIMEOUT);
 	if (ret) {
-		return -EIO;
+		return ret;
 	}
 
 	return 0;
@@ -455,14 +446,14 @@ int main(void)
 	printk("%s %s\n", "init_i2c_target", "running");
 	ret = sample_init_i2c_target();
 	if (ret) {
-		printk("%s %s\n", "init_i2c_target", "failed");
+		printk("%s %s (%d)\n", "init_i2c_target", "failed", ret);
 		return 0;
 	}
 
 	printk("%s %s\n", "standard_configure_and_recover", "running");
 	ret = sample_standard_configure_and_recover();
 	if (ret) {
-		printk("%s %s\n", "standard_configure_and_recover", "failed");
+		printk("%s %s (%d)\n", "standard_configure_and_recover", "failed", ret);
 		return 0;
 	}
 
@@ -471,20 +462,20 @@ int main(void)
 	printk("%s %s\n", "standard_write_read", "running");
 	ret = sample_standard_write_read();
 	if (ret) {
-		printk("%s %s\n", "standard_write_read", "failed");
+		printk("%s %s (%d)\n", "standard_write_read", "failed", ret);
 		return 0;
 	}
 
 	ret = sample_validate_write_read();
 	if (ret) {
-		printk("%s %s\n", "standard_write_read", "corrupted");
+		printk("%s %s (%d)\n", "standard_write_read", "corrupted", ret);
 		return 0;
 	}
 
 	printk("%s %s\n", "rtio_configure_recover", "running");
 	ret = sample_rtio_configure_and_recover();
 	if (ret) {
-		printk("%s %s\n", "rtio_configure_recover", "failed");
+		printk("%s %s (%d)\n", "rtio_configure_recover", "failed", ret);
 		return 0;
 	}
 
@@ -493,13 +484,13 @@ int main(void)
 	printk("%s %s\n", "rtio_write_read", "running");
 	ret = sample_rtio_write_read();
 	if (ret) {
-		printk("%s %s\n", "rtio_write_read", "failed");
+		printk("%s %s (%d)\n", "rtio_write_read", "failed", ret);
 		return 0;
 	}
 
 	ret = sample_validate_write_read();
 	if (ret) {
-		printk("%s %s\n", "rtio_write_read", "corrupted");
+		printk("%s %s (%d)\n", "rtio_write_read", "corrupted", ret);
 		return 0;
 	}
 
@@ -508,13 +499,13 @@ int main(void)
 	printk("%s %s\n", "rtio_write_read_async", "running");
 	ret = sample_rtio_write_read_async();
 	if (ret) {
-		printk("%s %s\n", "rtio_write_read_async", "failed");
+		printk("%s %s (%d)\n", "rtio_write_read_async", "failed", ret);
 		return 0;
 	}
 
 	ret = sample_validate_write_read();
 	if (ret) {
-		printk("%s %s\n", "rtio_write_read_async", "corrupted");
+		printk("%s %s (%d)\n", "rtio_write_read_async", "corrupted", ret);
 		return 0;
 	}
 


### PR DESCRIPTION
If I2C bus does not support recovery, do not exercise recovery test sequences.

Also print error code upon failures in the I2C RTIO loopback test.
