### PR TITLE
drivers: ethernet: remove logs for link up and down

### DIFF
--- a/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
+++ b/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
@@ -1044,13 +1044,11 @@ static void phy_link_state_change_callback(const struct device *phy_dev,
 		eth_dwc_xgmac_update_link_speed(mac_dev, dev_data->link_speed);
 		/* Set up link */
 		net_eth_carrier_on(dev_data->iface);
-		LOG_DBG("%s: Link up", mac_dev->name);
 
 	} else {
 		dev_data->link_speed = LINK_DOWN;
 		/* Announce link down status */
 		net_eth_carrier_off(dev_data->iface);
-		LOG_DBG("%s: Link down", mac_dev->name);
 	}
 }
 

--- a/drivers/ethernet/eth_dm9051.c
+++ b/drivers/ethernet/eth_dm9051.c
@@ -642,7 +642,6 @@ static void eth_dm9051_update_link_status(const struct device *dev)
 
 	if ((nsr & DM9051_NSR_LINKST) > 0) {
 		if (data->state.is_up != true) {
-			LOG_INF("%s: Link up", dev->name);
 			data->state.is_up = true;
 			net_eth_carrier_on(data->iface);
 		}
@@ -663,7 +662,6 @@ static void eth_dm9051_update_link_status(const struct device *dev)
 		}
 	} else {
 		if (data->state.is_up != false) {
-			LOG_INF("%s: Link down", dev->name);
 			data->state.is_up = false;
 			data->state.speed = 0;
 			net_eth_carrier_off(data->iface);

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -715,10 +715,8 @@ static void eth_enc28j60_rx_thread(void *p1, void *p2, void *p3)
 			eth_enc28j60_read_phy(dev, ENC28J60_PHY_PHIR, &phir);
 			eth_enc28j60_read_phy(dev, ENC28J60_PHY_PHSTAT2, &phstat2);
 			if (phstat2 & ENC28J60_BIT_PHSTAT2_LSTAT) {
-				LOG_INF("%s: Link up", dev->name);
 				net_eth_carrier_on(context->iface);
 			} else {
-				LOG_INF("%s: Link down", dev->name);
 				net_eth_carrier_off(context->iface);
 			}
 		}

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -475,11 +475,9 @@ static void enc424j600_rx_thread(void *p1, void *p2, void *p3)
 					      ENC424J600_SFRX_EIRL,
 					      ENC424J600_EIR_LINKIF);
 			if (estat & ENC424J600_ESTAT_PHYLNK) {
-				LOG_INF("Link up");
 				enc424j600_setup_mac(context->dev);
 				net_eth_carrier_on(context->iface);
 			} else {
-				LOG_INF("Link down");
 				net_eth_carrier_off(context->iface);
 			}
 		} else {

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -342,7 +342,6 @@ static void rx_thread(void *arg1, void *unused1, void *unused2)
 		if (res == 0) {
 			if (dev_data->link_up != true) {
 				dev_data->link_up = true;
-				LOG_INF("Link up");
 				eth_gecko_setup_mac(dev);
 				net_eth_carrier_on(dev_data->iface);
 			}
@@ -353,14 +352,12 @@ static void rx_thread(void *arg1, void *unused1, void *unused2)
 			if (phy_gecko_is_linked(&cfg->phy)) {
 				if (dev_data->link_up != true) {
 					dev_data->link_up = true;
-					LOG_INF("Link up");
 					eth_gecko_setup_mac(dev);
 					net_eth_carrier_on(dev_data->iface);
 				}
 			} else   {
 				if (dev_data->link_up != false) {
 					dev_data->link_up = false;
-					LOG_INF("Link down");
 					net_eth_carrier_off(dev_data->iface);
 				}
 			}

--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -761,10 +761,8 @@ static void lan9250_thread(void *p1, void *p2, void *p3)
 			/* Read PHY interrupt source register */
 			lan9250_read_phy_reg(dev, LAN9250_PHY_INTERRUPT_SOURCE, &tmp);
 			if (tmp & LAN9250_PHY_INTERRUPT_SOURCE_LINK_UP) {
-				LOG_DBG("LINK UP");
 				net_eth_carrier_on(context->iface);
 			} else if (tmp & LAN9250_PHY_INTERRUPT_SOURCE_LINK_DOWN) {
-				LOG_DBG("LINK DOWN");
 				net_eth_carrier_off(context->iface);
 			}
 		}

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -482,8 +482,6 @@ static void nxp_enet_phy_cb(const struct device *phy,
 	} else {
 		net_eth_carrier_off(data->iface);
 	}
-
-	LOG_INF("Link is %s", state->is_up ? "up" : "down");
 }
 
 static void eth_nxp_enet_iface_init(struct net_if *iface)

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -68,8 +68,6 @@ static void eth_nxp_enet_qos_phy_cb(const struct device *phy,
 		net_eth_carrier_off(data->iface);
 	}
 
-	LOG_INF("Link is %s", state->is_up ? "up" : "down");
-
 	/* handle link speed and duplex in MAC configuration register */
 	if (state->is_up) {
 		const struct nxp_enet_qos_mac_config *config = dev->config;

--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -117,10 +117,8 @@ static void phy_link_state_changed(const struct device *pdev,
 
 		cfg->base->MAC_CONFIGURATION |= GMAC_MAC_CONFIGURATION_DM(gmac_cfg.Duplex);
 
-		LOG_DBG("Link up");
 		net_eth_carrier_on(ctx->iface);
 	} else {
-		LOG_DBG("Link down");
 		net_eth_carrier_off(ctx->iface);
 	}
 }

--- a/drivers/ethernet/eth_nxp_s32_netc_psi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_psi.c
@@ -67,11 +67,9 @@ static void phy_link_state_changed(const struct device *pdev,
 	ARG_UNUSED(pdev);
 
 	if (state->is_up) {
-		LOG_DBG("Link up");
 		nxp_s32_eth_configure_port(cfg->port_idx, state->speed);
 		net_eth_carrier_on(ctx->iface);
 	} else {
-		LOG_DBG("Link down");
 		net_eth_carrier_off(ctx->iface);
 	}
 }

--- a/drivers/ethernet/eth_renesas_ra.c
+++ b/drivers/ethernet/eth_renesas_ra.c
@@ -234,7 +234,6 @@ static void phy_link_state_changed(const struct device *pdev, struct phy_link_st
 		ctx->ctrl.link_change = ETHER_LINK_CHANGE_LINK_UP;
 		ctx->ctrl.previous_link_status = ETHER_PREVIOUS_LINK_STATUS_UP;
 		ctx->ctrl.link_establish_status = ETHER_LINK_ESTABLISH_STATUS_UP;
-		LOG_DBG("Link up");
 		net_eth_carrier_on(ctx->iface);
 	} else {
 		ctx->ctrl.link_change = ETHER_LINK_CHANGE_LINK_DOWN;

--- a/drivers/ethernet/eth_renesas_ra_rmac.c
+++ b/drivers/ethernet/eth_renesas_ra_rmac.c
@@ -122,7 +122,6 @@ static void phy_link_cb(const struct device *phy_dev, struct phy_link_state *sta
 
 			data->fsp_ctrl.link_establish_status = ETHER_LINK_ESTABLISH_STATUS_DOWN;
 
-			LOG_DBG("Link down");
 			net_eth_carrier_off(data->iface);
 		}
 		return;
@@ -168,8 +167,6 @@ static void phy_link_cb(const struct device *phy_dev, struct phy_link_state *sta
 		LOG_ERR("Link MAC failed, err=%d", fsp_err);
 		return;
 	}
-
-	LOG_DBG("Link up");
 
 	net_eth_carrier_on(data->iface);
 	data->phy_link_up = true;

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1669,8 +1669,6 @@ static void phy_link_state_changed(const struct device *pdev,
 	is_up = state->is_up;
 
 	if (is_up && !dev_data->link_up) {
-		LOG_INF("%s Link up", dev->name);
-
 		/* Announce link up status */
 		dev_data->link_up = true;
 		net_eth_carrier_on(dev_data->iface);
@@ -1678,8 +1676,6 @@ static void phy_link_state_changed(const struct device *pdev,
 		/* Set up link */
 		link_configure((Gmac *)DEVICE_MMIO_GET(dev), state->speed);
 	} else if (!is_up && dev_data->link_up) {
-		LOG_INF("%s Link down", dev->name);
-
 		/* Announce link down status */
 		dev_data->link_up = false;
 		net_eth_carrier_off(dev_data->iface);

--- a/drivers/ethernet/eth_sensry_sy1xx_mac.c
+++ b/drivers/ethernet/eth_sensry_sy1xx_mac.c
@@ -272,8 +272,6 @@ static void phy_link_state_changed(const struct device *pdev, struct phy_link_st
 		data->link_is_up = is_up;
 
 		if (is_up) {
-			LOG_DBG("Link up");
-
 			/* enable mac controller */
 			en = sys_read32(cfg->ctrl_addr + SY1XX_MAC_CTRL_REG);
 			en |= BIT(SY1XX_MAC_CTRL_TX_EN_OFFS) | BIT(SY1XX_MAC_CTRL_RX_EN_OFFS);
@@ -283,8 +281,6 @@ static void phy_link_state_changed(const struct device *pdev, struct phy_link_st
 			net_eth_carrier_on(data->iface);
 
 		} else {
-			LOG_DBG("Link down");
-
 			/* disable mac controller */
 			en = sys_read32(cfg->ctrl_addr + SY1XX_MAC_CTRL_REG);
 			en &= ~(BIT(SY1XX_MAC_CTRL_TX_EN_OFFS) | BIT(SY1XX_MAC_CTRL_RX_EN_OFFS));

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -286,7 +286,6 @@ static void w5500_update_link_status(const struct device *dev)
 
 	if (IS_BIT_SET(phycfgr, W5500_PHYCFGR_LNK_BIT)) {
 		if (ctx->state.is_up != true) {
-			LOG_INF("%s: Link up", dev->name);
 			ctx->state.is_up = true;
 			net_eth_carrier_on(ctx->iface);
 		}
@@ -310,7 +309,6 @@ static void w5500_update_link_status(const struct device *dev)
 	}
 
 	if (ctx->state.is_up) {
-		LOG_INF("%s: Link down", dev->name);
 		ctx->state.is_up = false;
 		ctx->state.speed = 0;
 		net_eth_carrier_off(ctx->iface);

--- a/drivers/ethernet/eth_w6100.c
+++ b/drivers/ethernet/eth_w6100.c
@@ -262,7 +262,6 @@ static void w6100_update_link_status(const struct device *dev)
 
 	if (IS_BIT_SET(physr, W6100_PHYSR_LNK_BIT)) {
 		if (ctx->state.is_up != true) {
-			LOG_INF("%s: Link up", dev->name);
 			ctx->state.is_up = true;
 			net_eth_carrier_on(ctx->iface);
 		}
@@ -285,7 +284,6 @@ static void w6100_update_link_status(const struct device *dev)
 	}
 
 	if (ctx->state.is_up) {
-		LOG_INF("%s: Link down", dev->name);
 		ctx->state.is_up = false;
 		ctx->state.speed = 0;
 		net_eth_carrier_off(ctx->iface);

--- a/drivers/ethernet/eth_w6300.c
+++ b/drivers/ethernet/eth_w6300.c
@@ -393,7 +393,6 @@ static void w6300_update_link_status(const struct device *dev)
 
 	if (physr & W6300_PHYSR_LNK) {
 		if (!ctx->state.is_up) {
-			LOG_INF("%s: Link up", dev->name);
 			ctx->state.is_up = true;
 			net_eth_carrier_on(ctx->iface);
 		}
@@ -415,7 +414,6 @@ static void w6300_update_link_status(const struct device *dev)
 		}
 	} else {
 		if (ctx->state.is_up) {
-			LOG_INF("%s: Link down", dev->name);
 			ctx->state.is_up = false;
 			ctx->state.speed = 0;
 			net_eth_carrier_off(ctx->iface);

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -458,8 +458,6 @@ static void phy_link_state_changed(const struct device *dev __unused, struct phy
 {
 	struct net_if *iface = (struct net_if *)user_data;
 
-	LOG_INF("Link state changed to: %s (speed %x)", state->is_up ? "up" : "down", state->speed);
-
 	/* inform the L2 driver about link event */
 	if (state->is_up) {
 		net_eth_carrier_on(iface);

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -844,12 +844,10 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 	bool is_up = state->is_up;
 
 	if (is_up && !dev_data->link_up) {
-		LOG_INF("Link up");
 		dev_data->link_up = true;
 		net_eth_carrier_on(dev_data->iface);
 		eth_xmc4xxx_set_link(dev_cfg->regs, state);
 	} else if (!is_up && dev_data->link_up) {
-		LOG_INF("Link down");
 		dev_data->link_up = false;
 		net_eth_carrier_off(dev_data->iface);
 	}

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
@@ -29,14 +29,12 @@ static void netc_eth_phylink_callback(const struct device *pdev, struct phy_link
 				      void *user_data)
 {
 	const struct device *dev = (struct device *)user_data;
-	const struct netc_eth_config *cfg = dev->config;
 	struct netc_eth_data *data = dev->data;
 	status_t result;
 
 	ARG_UNUSED(pdev);
 
 	if (state->is_up) {
-		LOG_INF("ENETC%d Link up", getSiInstance(cfg->si_idx));
 		result = EP_Up(&data->handle, PHY_TO_NETC_SPEED(state->speed),
 			       PHY_TO_NETC_DUPLEX_MODE(state->speed));
 		if (result != kStatus_Success) {
@@ -44,7 +42,6 @@ static void netc_eth_phylink_callback(const struct device *pdev, struct phy_link
 		}
 		net_eth_carrier_on(data->iface);
 	} else {
-		LOG_INF("ENETC%d Link down", getSiInstance(cfg->si_idx));
 		result = EP_Down(&data->handle);
 		if (result != kStatus_Success) {
 			LOG_ERR("Failed to set MAC down");


### PR DESCRIPTION
Inside the work that is scheduled by net_eth_carrier_on and net_eth_carrier_off there is already a log message, when the carrier changes, we don't need to log the same info in the ethernet drivers.

https://github.com/zephyrproject-rtos/zephyr/blob/d0402d79b885bb3ac1afe19ecc3992436439d2d7/subsys/net/l2/ethernet/ethernet.c#L894-L895

https://github.com/zephyrproject-rtos/zephyr/blob/d0402d79b885bb3ac1afe19ecc3992436439d2d7/subsys/net/l2/ethernet/ethernet.c#L878-L923