### PR TITLE
MAINTAINERS: Add maintainer for Microchip SAM boards

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3836,6 +3836,7 @@ Microchip SAM Platforms:
     - stephanosio
   files:
     - boards/atmel/
+    - boards/microchip/sam/
     - dts/arm/atmel/
     - dts/arm/microchip/sam/
     - soc/atmel/


### PR DESCRIPTION
- To fix the 'Not actively maintained' status in Zephyr documentation