### PR TITLE
drivers: wifi: siwx91x: Restrict TX out of TWT Service Period by default

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi_ps.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_ps.c
@@ -237,6 +237,8 @@ static int siwx91x_set_twt_setup(struct wifi_twt_params *params)
 {
 	int twt_req_type = siwx91x_convert_z_sl_twt_req_type(params->setup_cmd);
 	sl_wifi_twt_request_t twt_req = {
+		/* Any Tx outside the TWT Service Period is restricted */
+		.restrict_tx_outside_tsp = 1,
 		.twt_retry_interval = 5,
 		.wake_duration_unit = 0,
 		.wake_int_mantissa = params->setup.twt_mantissa,


### PR DESCRIPTION
Currently, restrict_tx_outside_tsp is false by default, and with that, the NWP may transmit data during TWT sleep time. Many APs do not support this and thus should not be the default behavior.