### PR TITLE
net: lib: ptp: clock: Add early return on failing zvfs_eventfd()

### DIFF
--- a/subsys/net/lib/ptp/clock.c
+++ b/subsys/net/lib/ptp/clock.c
@@ -298,7 +298,12 @@ const struct ptp_clock *ptp_clock_init(void)
 		return NULL;
 	}
 
-	ptp_clk.pollfd[0].fd = zvfs_eventfd(0, ZVFS_EFD_NONBLOCK);
+	ret = zvfs_eventfd(0, ZVFS_EFD_NONBLOCK);
+	if (ret < 0) {
+		LOG_ERR("Failed to create event fd (err %d)", -errno);
+		return NULL;
+	}
+	ptp_clk.pollfd[0].fd = ret;
 	ptp_clk.pollfd[0].events = ZSOCK_POLLIN;
 
 	sys_slist_init(&ptp_clk.ports_list);


### PR DESCRIPTION
When the application already uses an event fd, and does not increase CONFIG_ZVFS_EVENTFD_MAX, zvfs_eventfd() silently fails, setting the fd to -1 during init. This causes the ptp thread to get stuck at ptp_clock_poll_sockets(), without any clear signal to the user.

The `net ptp` shell command would falsly indicate the state to be 'LISTENING', but in reality the thread was stuck waiting.