### PR TITLE
MAINTAINERS.yml: add target_riscv.cmake to RISCV area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4955,6 +4955,7 @@ RISCV arch:
     - boards/sifive/
     - boards/sparkfun/red_v_things_plus/
     - boards/starfive/
+    - cmake/compiler/*/target_riscv.cmake
     - doc/hardware/arch/risc-v.rst
     - drivers/interrupt_controller/intc_plic.c
     - drivers/interrupt_controller/intc_riscv_imsic.c


### PR DESCRIPTION
Add the target_riscv.cmake file
to the RISCV arch area.