### PR TITLE
net_buf: Add net_buf_drop() API

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -204,10 +204,7 @@ static inline void copy_hdr(struct h4_data *h4)
 
 static void reset_rx(struct h4_data *h4)
 {
-	if (h4->rx.buf) {
-		net_buf_unref(h4->rx.buf);
-		h4->rx.buf = NULL;
-	}
+	net_buf_drop(&h4->rx.buf);
 
 	h4->rx.type = BT_HCI_H4_NONE;
 	h4->rx.remaining = 0U;

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -148,10 +148,7 @@ NET_BUF_POOL_DEFINE(h5_pool, SIGNAL_COUNT, SIG_BUF_SIZE, 0, NULL);
 
 static void h5_reset_rx(struct h5_data *h5)
 {
-	if (h5->rx_buf) {
-		net_buf_unref(h5->rx_buf);
-		h5->rx_buf = NULL;
-	}
+	net_buf_drop(&h5->rx_buf);
 
 	h5->rx_state = START;
 }

--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -1674,6 +1674,23 @@ static inline struct net_buf *__must_check net_buf_take(struct net_buf **orig)
 	return (struct net_buf *)atomic_ptr_clear((atomic_ptr_t *)orig);
 }
 
+/** @brief Drop a buffer reference and clear the pointer.
+ *
+ * This performs an atomic exchange on @p orig, setting it to NULL and
+ * unreferencing the previous value if it was not NULL.
+ *
+ * @param orig Pointer to the buffer pointer to drop. Will be set to NULL
+ *		on return.
+ */
+static inline void net_buf_drop(struct net_buf **orig)
+{
+	struct net_buf *buf = net_buf_take(orig);
+
+	if (buf != NULL) {
+		net_buf_unref(buf);
+	}
+}
+
 /**
  * @brief Clone buffer
  *

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1174,7 +1174,7 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 	adv->tx_power = rp->tx_power;
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 
-	net_buf_unref(rsp);
+	net_buf_drop(&rsp);
 
 	atomic_set_bit(adv->flags, BT_ADV_PARAMS_SET);
 

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -4010,10 +4010,7 @@ void bt_att_req_free(struct bt_att_req *req)
 {
 	LOG_DBG("req %p", req);
 
-	if (req->buf) {
-		net_buf_unref(req->buf);
-		req->buf = NULL;
-	}
+	net_buf_drop(&req->buf);
 
 	k_mem_slab_free(&req_slab, (void *)req);
 }

--- a/subsys/bluetooth/host/classic/avctp.c
+++ b/subsys/bluetooth/host/classic/avctp.c
@@ -122,10 +122,7 @@ static void avctp_l2cap_disconnected(struct bt_l2cap_chan *chan)
 	LOG_DBG("chan %p session %p", chan, session);
 	session->br_chan.chan.conn = NULL;
 
-	if (session->reassembly_buf != NULL) {
-		net_buf_unref(session->reassembly_buf);
-		session->reassembly_buf = NULL;
-	}
+	net_buf_drop(&session->reassembly_buf);
 
 	k_sem_take(&avctp_lock, K_FOREVER);
 	bt_avctp_clear_tx(session);
@@ -446,8 +443,7 @@ static int avctp_recv_fragmented(struct bt_avctp *avctp, struct net_buf *buf)
 
 		if (avctp->reassembly_buf != NULL) {
 			LOG_WRN("Interleaving fragments not allowed (tid=%u, cr=%u)", tid, cr);
-			net_buf_unref(avctp->reassembly_buf);
-			avctp->reassembly_buf = NULL;
+			net_buf_drop(&avctp->reassembly_buf);
 		}
 
 		if (avctp->rx_pool == NULL) {
@@ -521,8 +517,7 @@ static int avctp_recv_fragmented(struct bt_avctp *avctp, struct net_buf *buf)
 
 			dispatch_avctp_packet(avctp, avctp->reassembly_buf, hdr_common,
 					      sys_be16_to_cpu(hdr_reassembly->pid));
-			net_buf_unref(avctp->reassembly_buf);
-			avctp->reassembly_buf = NULL;
+			net_buf_drop(&avctp->reassembly_buf);
 			return 0;
 		}
 		return 0;
@@ -531,10 +526,7 @@ static int avctp_recv_fragmented(struct bt_avctp *avctp, struct net_buf *buf)
 	LOG_WRN("No matching START packet found for tid=%u, cr=%u", tid, cr);
 
 failed:
-	if (avctp->reassembly_buf != NULL) {
-		net_buf_unref(avctp->reassembly_buf);
-		avctp->reassembly_buf = NULL;
-	}
+	net_buf_drop(&avctp->reassembly_buf);
 	return 0; /* Need keep L2CAP up */
 }
 
@@ -563,8 +555,7 @@ static int avctp_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	if (session->reassembly_buf != NULL) {
 		LOG_WRN("AVCTP: aborting in-progress reassembly due to SINGLE pkt");
-		net_buf_unref(session->reassembly_buf);
-		session->reassembly_buf = NULL;
+		net_buf_drop(&session->reassembly_buf);
 	}
 
 	if (buf->len < BT_AVCTP_HDR_SIZE_SINGLE) {

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -1833,10 +1833,7 @@ void bt_avdtp_l2cap_disconnected(struct bt_l2cap_chan *chan)
 		}
 	}
 
-	if (session->reasm_buf != NULL) {
-		net_buf_unref(session->reasm_buf);
-		session->reasm_buf = NULL;
-	}
+	net_buf_drop(&session->reasm_buf);
 
 	k_sem_take(&avdtp_sem_lock, K_FOREVER);
 	bt_avdtp_clear_tx(session);
@@ -1882,10 +1879,7 @@ void (*rsp_handler[])(struct bt_avdtp *session, struct net_buf *buf, uint8_t msg
 
 static int avdtp_rel_and_return(struct bt_avdtp *session)
 {
-	if (session->reasm_buf != NULL) {
-		net_buf_unref(session->reasm_buf);
-		session->reasm_buf = NULL;
-	}
+	net_buf_drop(&session->reasm_buf);
 
 	return 0;
 }
@@ -1931,8 +1925,7 @@ static int bt_avdtp_l2cap_frags_recv(struct bt_avdtp *session, struct net_buf *b
 
 		if (session->reasm_buf != NULL) {
 			LOG_ERR("get start packet during reassembly");
-			net_buf_unref(session->reasm_buf);
-			session->reasm_buf = NULL;
+			net_buf_drop(&session->reasm_buf);
 		}
 
 		if ((AVDTP_MSG_GET(start_hdr->hdr) != BT_AVDTP_CMD) &&
@@ -2044,10 +2037,7 @@ static int avdtp_rel_and_rej(struct bt_avdtp *session, uint8_t sigid, uint8_t ti
 	struct net_buf *rsp_buf;
 	int err;
 
-	if (session->reasm_buf != NULL) {
-		net_buf_unref(session->reasm_buf);
-		session->reasm_buf = NULL;
-	}
+	net_buf_drop(&session->reasm_buf);
 
 	rsp_buf = avdtp_create_pdu(BT_AVDTP_GEN_REJECT, sigid, tid);
 	if (!rsp_buf) {
@@ -2097,8 +2087,7 @@ int bt_avdtp_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		if (session->reasm_buf != NULL) {
 			LOG_DBG("get single packet during reassembly");
 
-			net_buf_unref(session->reasm_buf);
-			session->reasm_buf = NULL;
+			net_buf_drop(&session->reasm_buf);
 		}
 
 		if (buf->len < sizeof(*single_hdr)) {

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -734,8 +734,7 @@ static int init_fragmentation_context(struct bt_avrcp_ct *ct, uint8_t tid, uint8
 	/* Clean up any existing reassembly buffer */
 	if (ct->reassembly_buf != NULL) {
 		LOG_WRN("Interleaving fragments not allowed (tid=%u, rsp=%u)", tid, rsp);
-		net_buf_unref(ct->reassembly_buf);
-		ct->reassembly_buf = NULL;
+		net_buf_drop(&ct->reassembly_buf);
 	}
 
 	/* Allocate reassembly buffer */
@@ -790,8 +789,7 @@ static void cleanup_fragmentation_context(struct bt_avrcp_ct *ct)
 	}
 
 	if (ct->reassembly_buf != NULL) {
-		net_buf_unref(ct->reassembly_buf);
-		ct->reassembly_buf = NULL;
+		net_buf_drop(&ct->reassembly_buf);
 	}
 }
 

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1011,7 +1011,7 @@ int bt_br_init(void)
 
 	rp = (void *)rsp->data;
 	default_link_policy_settings = rp->default_link_policy_settings;
-	net_buf_unref(rsp);
+	net_buf_drop(&rsp);
 
 	bool should_enable = IS_ENABLED(CONFIG_BT_DEFAULT_ROLE_SWITCH_ENABLE);
 	bool is_enabled = (default_link_policy_settings &

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1508,8 +1508,7 @@ done:
 	if (br_chan->_pdu_remaining > amount) {
 		br_chan->_pdu_remaining -= amount;
 	} else {
-		net_buf_unref(br_chan->_pdu_buf);
-		br_chan->_pdu_buf = NULL;
+		net_buf_drop(&br_chan->_pdu_buf);
 		br_chan->_pdu_remaining = 0;
 		if (pdu && !pdu->len) {
 			br_chan->_sdu_total_len = 0;
@@ -5733,8 +5732,7 @@ static int bt_l2cap_br_recv_seg(struct bt_l2cap_br_chan *br_chan, struct net_buf
 	if ((sar == BT_L2CAP_CONTROL_SAR_UNSEG) || (sar == BT_L2CAP_CONTROL_SAR_START)) {
 		if (br_chan->_sdu) {
 			LOG_ERR("Last SDU is not done");
-			net_buf_unref(br_chan->_sdu);
-			br_chan->_sdu = NULL;
+			net_buf_drop(&br_chan->_sdu);
 			bt_l2cap_chan_disconnect(&br_chan->chan);
 			return -ESHUTDOWN;
 		}
@@ -5764,8 +5762,7 @@ static int bt_l2cap_br_recv_seg(struct bt_l2cap_br_chan *br_chan, struct net_buf
 
 	if ((br_chan->_sdu->len + seg->len) > br_chan->_sdu_len) {
 		LOG_ERR("SDU length mismatch");
-		net_buf_unref(br_chan->_sdu);
-		br_chan->_sdu = NULL;
+		net_buf_drop(&br_chan->_sdu);
 		bt_l2cap_chan_disconnect(&br_chan->chan);
 		return -ESHUTDOWN;
 	}
@@ -5775,8 +5772,7 @@ static int bt_l2cap_br_recv_seg(struct bt_l2cap_br_chan *br_chan, struct net_buf
 				   l2cap_br_alloc_frag, br_chan);
 	if (len != seg->len) {
 		LOG_ERR("Unable to store SDU");
-		net_buf_unref(br_chan->_sdu);
-		br_chan->_sdu = NULL;
+		net_buf_drop(&br_chan->_sdu);
 		bt_l2cap_chan_disconnect(&br_chan->chan);
 		return -ESHUTDOWN;
 	}
@@ -5786,8 +5782,7 @@ static int bt_l2cap_br_recv_seg(struct bt_l2cap_br_chan *br_chan, struct net_buf
 	if ((sar == BT_L2CAP_CONTROL_SAR_UNSEG) || (sar == BT_L2CAP_CONTROL_SAR_END)) {
 		if (br_chan->_sdu->len < br_chan->_sdu_len) {
 			LOG_ERR("SDU length mismatch");
-			net_buf_unref(br_chan->_sdu);
-			br_chan->_sdu = NULL;
+			net_buf_drop(&br_chan->_sdu);
 			bt_l2cap_chan_disconnect(&br_chan->chan);
 			return -ESHUTDOWN;
 		}

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -1758,10 +1758,7 @@ static void sdp_client_params_iterator(struct bt_sdp_client *session)
 		sys_slist_remove(&session->reqs, NULL, &param->_node);
 		/* Invalidate cached param in context */
 		session->param = NULL;
-		if (session->rec_buf != NULL) {
-			net_buf_unref(session->rec_buf);
-			session->rec_buf = NULL;
-		}
+		net_buf_drop(&session->rec_buf);
 		/* Reset continuation state in current context */
 		(void)memset(&session->cstate, 0, sizeof(session->cstate));
 		/* Clear total length */
@@ -2700,10 +2697,7 @@ static void sdp_client_clean_after_disconnect(struct bt_sdp_client *session)
 	session->tid = 0U;
 	session->param = NULL;
 	memset(&session->cstate, 0, sizeof(session->cstate));
-	if (session->rec_buf) {
-		net_buf_unref(session->rec_buf);
-		session->rec_buf = NULL;
-	}
+	net_buf_drop(&session->rec_buf);
 	session->total_len = 0U;
 	session->recv_len = 0U;
 }
@@ -2741,10 +2735,7 @@ static void sdp_client_disconnected(struct bt_l2cap_chan *chan)
 		sys_slist_find_and_remove(&session->reqs, &param->_node);
 	}
 
-	if (session->rec_buf) {
-		net_buf_unref(session->rec_buf);
-		session->rec_buf = NULL;
-	}
+	net_buf_drop(&session->rec_buf);
 
 	sdp_client_clean_after_disconnect(session);
 }

--- a/subsys/bluetooth/host/classic/shell/bip.c
+++ b/subsys/bluetooth/host/classic/shell/bip.c
@@ -1577,10 +1577,7 @@ static int cmd_bip_client_get_caps(const struct shell *sh, size_t argc, char *ar
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -1648,10 +1645,7 @@ static int cmd_bip_client_get_image_list(const struct shell *sh, size_t argc, ch
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -1718,10 +1712,7 @@ static int cmd_bip_client_get_image_properties(const struct shell *sh, size_t ar
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -1785,10 +1776,7 @@ static int cmd_bip_client_get_image(const struct shell *sh, size_t argc, char *a
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -1853,10 +1841,7 @@ static int cmd_bip_client_get_linked_thumbnail(const struct shell *sh, size_t ar
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -1917,10 +1902,7 @@ static int cmd_bip_client_get_linked_attachment(const struct shell *sh, size_t a
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -1996,10 +1978,7 @@ static int cmd_bip_client_get_partial_image(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -2069,10 +2048,7 @@ static int cmd_bip_client_get_monitoring_image(const struct shell *sh, size_t ar
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -2130,10 +2106,7 @@ static int cmd_bip_client_get_status(const struct shell *sh, size_t argc, char *
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -2272,10 +2245,7 @@ static int cmd_bip_client_put_image(const struct shell *sh, size_t argc, char *a
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -2366,10 +2336,7 @@ static int cmd_bip_client_put_linked_thumbnail(const struct shell *sh, size_t ar
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -2456,10 +2423,7 @@ static int cmd_bip_client_put_linked_attachment(const struct shell *sh, size_t a
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -2555,10 +2519,7 @@ static int cmd_bip_client_remote_display(const struct shell *sh, size_t argc, ch
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -2623,10 +2584,7 @@ static int cmd_bip_client_delete_image(const struct shell *sh, size_t argc, char
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -2739,10 +2697,7 @@ static int cmd_bip_client_start_print(const struct shell *sh, size_t argc, char 
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -2829,10 +2784,7 @@ static int cmd_bip_client_start_archive(const struct shell *sh, size_t argc, cha
 		return -ENOEXEC;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3096,10 +3048,7 @@ static int cmd_bip_server_get_caps(const struct shell *sh, size_t argc, char *ar
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3178,10 +3127,7 @@ static int cmd_bip_server_get_image_list(const struct shell *sh, size_t argc, ch
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3285,10 +3231,7 @@ static int cmd_bip_server_get_image_properties(const struct shell *sh, size_t ar
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3359,10 +3302,7 @@ static int cmd_bip_server_get_image(const struct shell *sh, size_t argc, char *a
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3441,10 +3381,7 @@ static int cmd_bip_server_get_linked_thumbnail(const struct shell *sh, size_t ar
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3515,10 +3452,7 @@ static int cmd_bip_server_get_linked_attachment(const struct shell *sh, size_t a
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3589,10 +3523,7 @@ static int cmd_bip_server_get_partial_image(const struct shell *sh, size_t argc,
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3687,10 +3618,7 @@ static int cmd_bip_server_get_monitoring_image(const struct shell *sh, size_t ar
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3772,10 +3700,7 @@ static int cmd_bip_server_get_status(const struct shell *sh, size_t argc, char *
 		return SHELL_CMD_HELP_PRINTED;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3823,10 +3748,7 @@ static int cmd_bip_server_put_image(const struct shell *sh, size_t argc, char *a
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3888,10 +3810,7 @@ static int cmd_bip_server_put_linked_thumbnail(const struct shell *sh, size_t ar
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -3947,10 +3866,7 @@ static int cmd_bip_server_put_linked_attachment(const struct shell *sh, size_t a
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -4006,10 +3922,7 @@ static int cmd_bip_server_remote_display(const struct shell *sh, size_t argc, ch
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -4067,10 +3980,7 @@ static int cmd_bip_server_delete_image(const struct shell *sh, size_t argc, char
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -4121,10 +4031,7 @@ static int cmd_bip_server_start_print(const struct shell *sh, size_t argc, char 
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -4179,10 +4086,7 @@ static int cmd_bip_server_start_archive(const struct shell *sh, size_t argc, cha
 		goto error_rsp;
 	}
 
-	if (bip_app.tx_buf != NULL) {
-		net_buf_unref(bip_app.tx_buf);
-		bip_app.tx_buf = NULL;
-	}
+	net_buf_drop(&bip_app.tx_buf);
 
 	if (bip_app.tx_buf == NULL) {
 		bip_app.tx_buf = bt_goep_create_pdu(&bip_app.bip.goep, &tx_pool);
@@ -4557,8 +4461,7 @@ static int cmd_release_buf(const struct shell *sh, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	net_buf_unref(bip_app.tx_buf);
-	bip_app.tx_buf = NULL;
+	net_buf_drop(&bip_app.tx_buf);
 
 	return 0;
 }

--- a/subsys/bluetooth/host/classic/shell/goep.c
+++ b/subsys/bluetooth/host/classic/shell/goep.c
@@ -1663,8 +1663,7 @@ static int cmd_release_buf(const struct shell *sh, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	net_buf_unref(goep_app.tx_buf);
-	goep_app.tx_buf = NULL;
+	net_buf_drop(&goep_app.tx_buf);
 
 	return 0;
 }

--- a/subsys/bluetooth/host/classic/shell/pbap.c
+++ b/subsys/bluetooth/host/classic/shell/pbap.c
@@ -242,8 +242,7 @@ static int cmd_release_buf(const struct shell *sh, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	net_buf_unref(g_pbap_app->tx_buf);
-	g_pbap_app->tx_buf = NULL;
+	net_buf_drop(&g_pbap_app->tx_buf);
 
 	return 0;
 }
@@ -1173,8 +1172,7 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 
 failed:
-	net_buf_unref(g_pbap_app->tx_buf);
-	g_pbap_app->tx_buf = NULL;
+	net_buf_drop(&g_pbap_app->tx_buf);
 	return err;
 }
 
@@ -1426,8 +1424,7 @@ static int cmd_set_phone_book(const struct shell *sh, size_t argc, char **argv)
 	g_pbap_app->tx_buf = NULL;
 	return 0;
 failed:
-	net_buf_unref(g_pbap_app->tx_buf);
-	g_pbap_app->tx_buf = NULL;
+	net_buf_drop(&g_pbap_app->tx_buf);
 	return err;
 }
 

--- a/subsys/bluetooth/host/classic/shell/pbap.c
+++ b/subsys/bluetooth/host/classic/shell/pbap.c
@@ -1330,9 +1330,8 @@ static int pbap_pce_pull(char *type, char *name, bool srmp)
 	tlv_count = 0;
 	return 0;
 failed:
-	net_buf_unref(g_pbap_app->tx_buf);
+	net_buf_drop(&g_pbap_app->tx_buf);
 	tlv_count = 0;
-	g_pbap_app->tx_buf = NULL;
 	return err;
 }
 
@@ -2111,9 +2110,8 @@ static int pbap_pull_rsp(const struct shell *sh, size_t argc, char *argv[], cons
 	tlv_count = 0;
 	return err;
 failed:
-	net_buf_unref(g_pbap_app->tx_buf);
+	net_buf_drop(&g_pbap_app->tx_buf);
 	tlv_count = 0;
-	g_pbap_app->tx_buf = NULL;
 	return err;
 }
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -393,8 +393,7 @@ void bt_conn_reset_rx_state(struct bt_conn *conn)
 		return;
 	}
 
-	net_buf_unref(conn->rx);
-	conn->rx = NULL;
+	net_buf_drop(&conn->rx);
 }
 
 static void bt_acl_recv(struct bt_conn *conn, struct net_buf *buf,

--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -106,8 +106,7 @@ static void free_reassembly_buf(struct net_buf **buf)
 		LOG_WRN("The buffer was not in the list");
 	}
 
-	net_buf_unref(*buf);
-	*buf = NULL;
+	net_buf_drop(buf);
 }
 
 /** @brief Gets the reassembly buffer identified by the connection handle

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2346,10 +2346,7 @@ static void cleanup_notify(struct bt_conn *conn)
 {
 	struct net_buf **buf = &nfy_mult[bt_conn_index(conn)];
 
-	if (*buf) {
-		net_buf_unref(*buf);
-		*buf = NULL;
-	}
+	net_buf_drop(buf);
 }
 
 static void gatt_add_nfy_to_buf(struct net_buf *buf,

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3244,8 +3244,7 @@ static void hci_core_send_cmd(void)
 	/* Clear out any existing sent command */
 	if (bt_dev.sent_cmd) {
 		LOG_ERR("Uncleared pending sent_cmd");
-		net_buf_unref(bt_dev.sent_cmd);
-		bt_dev.sent_cmd = NULL;
+		net_buf_drop(&bt_dev.sent_cmd);
 	}
 
 	bt_dev.sent_cmd = net_buf_ref(buf);

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1379,8 +1379,7 @@ static void l2cap_chan_destroy(struct bt_l2cap_chan *chan)
 
 	/* Destroy segmented SDU if it exists */
 	if (le_chan->_sdu) {
-		net_buf_unref(le_chan->_sdu);
-		le_chan->_sdu = NULL;
+		net_buf_drop(&le_chan->_sdu);
 		le_chan->_sdu_len = 0U;
 	}
 }
@@ -2392,8 +2391,7 @@ static void l2cap_chan_shutdown(struct bt_l2cap_chan *chan)
 
 	/* Destroy segmented SDU if it exists */
 	if (le_chan->_sdu) {
-		net_buf_unref(le_chan->_sdu);
-		le_chan->_sdu = NULL;
+		net_buf_drop(&le_chan->_sdu);
 		le_chan->_sdu_len = 0U;
 	}
 
@@ -2759,8 +2757,7 @@ static void l2cap_chan_le_recv(struct bt_l2cap_le_chan *chan,
 		if (chan->_sdu->user_data_size < sizeof(uint16_t)) {
 			LOG_ERR("SDU buffer user_data_size %u is too small",
 				chan->_sdu->user_data_size);
-			net_buf_unref(chan->_sdu);
-			chan->_sdu = NULL;
+			net_buf_drop(&chan->_sdu);
 			bt_l2cap_chan_disconnect(&chan->chan);
 			return;
 		}
@@ -2787,8 +2784,7 @@ static void l2cap_chan_le_recv(struct bt_l2cap_le_chan *chan,
 	owned_ref = net_buf_ref(buf);
 	err = chan->chan.ops->recv(&chan->chan, owned_ref);
 	if (err != -EINPROGRESS) {
-		net_buf_unref(owned_ref);
-		owned_ref = NULL;
+		net_buf_drop(&owned_ref);
 	}
 
 	if (err < 0) {

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -177,10 +177,7 @@ static void friend_clear(struct bt_mesh_friend *frnd)
 	}
 	memset(frnd->cred, 0, sizeof(frnd->cred));
 
-	if (frnd->last) {
-		net_buf_unref(frnd->last);
-		frnd->last = NULL;
-	}
+	net_buf_drop(&frnd->last);
 
 	purge_buffers(&frnd->queue);
 
@@ -744,10 +741,7 @@ int bt_mesh_friend_poll(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 		LOG_DBG("Re-sending last PDU");
 		frnd->send_last = 1U;
 	} else {
-		if (frnd->last) {
-			net_buf_unref(frnd->last);
-			frnd->last = NULL;
-		}
+		net_buf_drop(&frnd->last);
 
 		frnd->fsn = msg->fsn;
 
@@ -1169,9 +1163,8 @@ static void buf_send_start(uint16_t duration, int err, void *user_data)
 	frnd->pending_buf = 0U;
 
 	/* Friend Offer doesn't follow the re-sending semantics */
-	if (!frnd->established && frnd->last) {
-		net_buf_unref(frnd->last);
-		frnd->last = NULL;
+	if (!frnd->established) {
+		net_buf_drop(&frnd->last);
 	}
 }
 

--- a/tests/lib/net_buf/buf/src/main.c
+++ b/tests/lib/net_buf/buf/src/main.c
@@ -1201,4 +1201,35 @@ ZTEST(net_buf_tests, test_net_buf_take)
 	zassert_equal(destroy_called, 1, "Buffer should be destroyed now");
 }
 
+ZTEST(net_buf_tests, test_net_buf_drop)
+{
+	struct net_buf *buf, *new_ref;
+
+	destroy_called = 0;
+
+	buf = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
+	zassert_not_null(buf, "Failed to get buffer");
+	zassert_equal(buf->ref, 1, "Unexpected ref count");
+
+	net_buf_drop(&buf);
+	zassert_is_null(buf, "Pointer not NULLed after drop");
+	zassert_equal(destroy_called, 1, "Incorrect destroy callback count");
+
+	destroy_called = 0;
+	buf = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
+	zassert_not_null(buf, "Failed to get buffer");
+	zassert_equal(buf->ref, 1, "Unexpected ref count");
+
+	new_ref = net_buf_ref(buf);
+	zassert_equal(new_ref->ref, 2, "Unexpected ref count");
+	net_buf_drop(&new_ref);
+	zassert_is_null(new_ref, "Pointer not NULLed after drop");
+	zassert_equal(destroy_called, 0, "Incorrect destroy callback count");
+	zassert_equal(buf->ref, 1, "Unexpected ref count");
+
+	net_buf_drop(&buf);
+	zassert_is_null(buf, "Original pointer not NULLed after drop");
+	zassert_equal(destroy_called, 1, "Incorrect destroy callback count");
+}
+
 ZTEST_SUITE(net_buf_tests, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
The following code patter occurs a lot in the source tree:
```c
      net_buf_unref(buf);
      buf = NULL;
```
Introduce a new helper API, called net_buf_clear(), which takes advantage of the recently added net_buf_take() API to perform the above in a single step:
```c
      net_buf_drop(&buf);
```