### PR TITLE
ethernet: combine net_eth_carrier_on/off

### DIFF
--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -363,11 +363,9 @@ static void phy_link_state_changed(const struct device *phy_dev __unused,
 		}
 
 		REG_WRITE(DWMAC_MACCR, reg);
-
-		net_eth_carrier_on(p->iface);
-	} else {
-		net_eth_carrier_off(p->iface);
 	}
+
+	net_eth_carrier_set(p->iface, state->is_up);
 }
 
 static const struct device *dwmac_get_phy(const struct device *dev, struct net_if *iface __unused)

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -547,11 +547,9 @@ static void phy_link_state_changed(const struct device *phy_dev,
 		}
 
 		REG_WRITE(MAC_CONF, reg_val);
-
-		net_eth_carrier_on(p->iface);
-	} else {
-		net_eth_carrier_off(p->iface);
 	}
+
+	net_eth_carrier_set(p->iface, state->is_up);
 }
 
 static const struct device *dwmac_get_phy(const struct device *dev, struct net_if *iface __unused)

--- a/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
+++ b/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
@@ -1042,14 +1042,12 @@ static void phy_link_state_change_callback(const struct device *phy_dev,
 		}
 		/* Configure MAC link speed */
 		eth_dwc_xgmac_update_link_speed(mac_dev, dev_data->link_speed);
-		/* Set up link */
-		net_eth_carrier_on(dev_data->iface);
 
 	} else {
 		dev_data->link_speed = LINK_DOWN;
-		/* Announce link down status */
-		net_eth_carrier_off(dev_data->iface);
 	}
+
+	net_eth_carrier_set(dev_data->iface, is_up);
 }
 
 void eth_dwc_xgmac_prefill_rx_desc(const struct device *dev)

--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -656,11 +656,7 @@ static inline void adin2111_port_on_phyint(const struct device *dev)
 		return;
 	}
 
-	if (state.is_up) {
-		net_eth_carrier_on(data->iface);
-	} else {
-		net_eth_carrier_off(data->iface);
-	}
+	net_eth_carrier_set(data->iface, state.is_up);
 }
 
 static void adin2111_offload_thread(void *p1, void *p2, void *p3)

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -714,11 +714,8 @@ static void eth_enc28j60_rx_thread(void *p1, void *p2, void *p3)
 			/* Clear link change interrupt flag by PHIR reg read */
 			eth_enc28j60_read_phy(dev, ENC28J60_PHY_PHIR, &phir);
 			eth_enc28j60_read_phy(dev, ENC28J60_PHY_PHSTAT2, &phstat2);
-			if (phstat2 & ENC28J60_BIT_PHSTAT2_LSTAT) {
-				net_eth_carrier_on(context->iface);
-			} else {
-				net_eth_carrier_off(context->iface);
-			}
+			net_eth_carrier_set(context->iface,
+					    (phstat2 & ENC28J60_BIT_PHSTAT2_LSTAT) != 0);
 		}
 
 		/* We cannot rely on the PKTIF flag because of errata 6. Call

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -638,11 +638,7 @@ static void phy_link_state_changed(const struct device *phy_dev __unused,
 {
 	struct net_if *iface = (struct net_if *)user_data;
 
-	if (state->is_up) {
-		net_eth_carrier_on(iface);
-	} else {
-		net_eth_carrier_off(iface);
-	}
+	net_eth_carrier_set(iface, state->is_up);
 }
 
 int eth_esp32_initialize(const struct device *dev)

--- a/drivers/ethernet/eth_litex_liteeth.c
+++ b/drivers/ethernet/eth_litex_liteeth.c
@@ -225,11 +225,7 @@ static void phy_link_state_changed(const struct device *phy_dev __unused,
 {
 	struct net_if *iface = (struct net_if *)user_data;
 
-	if (state->is_up) {
-		net_eth_carrier_on(iface);
-	} else {
-		net_eth_carrier_off(iface);
-	}
+	net_eth_carrier_set(iface, state->is_up);
 }
 
 static void eth_iface_init(struct net_if *iface)

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -477,11 +477,9 @@ static void nxp_enet_phy_cb(const struct device *phy,
 		}
 
 		ENET_SetMII(data->base, speed, duplex);
-
-		net_eth_carrier_on(data->iface);
-	} else {
-		net_eth_carrier_off(data->iface);
 	}
+
+	net_eth_carrier_set(data->iface, state->is_up);
 }
 
 static void eth_nxp_enet_iface_init(struct net_if *iface)

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -62,11 +62,7 @@ static void eth_nxp_enet_qos_phy_cb(const struct device *phy,
 		return;
 	}
 
-	if (state->is_up) {
-		net_eth_carrier_on(data->iface);
-	} else {
-		net_eth_carrier_off(data->iface);
-	}
+	net_eth_carrier_set(data->iface, state->is_up);
 
 	/* handle link speed and duplex in MAC configuration register */
 	if (state->is_up) {

--- a/drivers/ethernet/eth_raw.c
+++ b/drivers/ethernet/eth_raw.c
@@ -19,14 +19,10 @@ __weak void ethernet_init(struct net_if *iface)
 	ARG_UNUSED(iface);
 }
 
-__weak void net_eth_carrier_on(struct net_if *iface)
+__weak void net_eth_carrier_set(struct net_if *iface, bool carrier_up)
 {
 	ARG_UNUSED(iface);
-}
-
-__weak void net_eth_carrier_off(struct net_if *iface)
-{
-	ARG_UNUSED(iface);
+	ARG_UNUSED(carrier_up);
 }
 
 __weak int net_recv_data(struct net_if *iface, struct net_pkt *pkt)

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -677,11 +677,7 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 	const struct device *dev = user_data;
 	struct eth_context *data = dev->data;
 
-	if (state->is_up) {
-		net_eth_carrier_on(data->iface);
-	} else {
-		net_eth_carrier_off(data->iface);
-	}
+	net_eth_carrier_set(data->iface, state->is_up);
 }
 
 static enum ethernet_hw_caps eth_smsc_get_caps(const struct device *dev __unused,

--- a/drivers/ethernet/eth_stm32_hal2.c
+++ b/drivers/ethernet/eth_stm32_hal2.c
@@ -223,10 +223,9 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 
 	if (state->is_up) {
 		eth_stm32_set_mac_config(dev, state);
-		net_eth_carrier_on(dev_data->iface);
-	} else {
-		net_eth_carrier_off(dev_data->iface);
 	}
+
+	net_eth_carrier_set(dev_data->iface, state->is_up);
 }
 
 static void rx_thread(void *arg1, void *unused1, void *unused2)

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -244,10 +244,9 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 	if (state->is_up) {
 		eth_stm32_set_mac_config(dev, state);
 		eth_stm32_hal_start(dev, dev_data->iface);
-		net_eth_carrier_on(dev_data->iface);
-	} else {
-		net_eth_carrier_off(dev_data->iface);
 	}
+
+	net_eth_carrier_set(dev_data->iface, state->is_up);
 }
 
 static void eth_iface_init(struct net_if *iface)

--- a/drivers/ethernet/eth_wch.c
+++ b/drivers/ethernet/eth_wch.c
@@ -472,10 +472,9 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 	if (state->is_up) {
 		set_mac_config(dev, state);
 		eth_wch_start(dev, data->iface);
-		net_eth_carrier_on(data->iface);
-	} else {
-		net_eth_carrier_off(data->iface);
 	}
+
+	net_eth_carrier_set(data->iface, state->is_up);
 }
 
 static int eth_mac_init(const struct device *dev)

--- a/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
+++ b/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
@@ -175,14 +175,7 @@ static void axi_eth_lite_phy_link_state_changed(const struct device *phydev __un
 {
 	struct net_if *iface = (struct net_if *)user_data;
 
-	LOG_INF("Link state changed to: %s (speed %x)", state->is_up ? "up" : "down", state->speed);
-
-	/* inform the L2 driver whether we can handle packets now */
-	if (state->is_up) {
-		net_eth_carrier_on(iface);
-	} else {
-		net_eth_carrier_off(iface);
-	}
+	net_eth_carrier_set(iface, state->is_up);
 }
 
 static void axi_eth_lite_iface_init(struct net_if *iface)

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -459,11 +459,7 @@ static void phy_link_state_changed(const struct device *dev __unused, struct phy
 	struct net_if *iface = (struct net_if *)user_data;
 
 	/* inform the L2 driver about link event */
-	if (state->is_up) {
-		net_eth_carrier_on(iface);
-	} else {
-		net_eth_carrier_off(iface);
-	}
+	net_eth_carrier_set(iface, state->is_up);
 }
 
 static void xilinx_axienet_iface_init(struct net_if *iface)

--- a/drivers/ethernet/intel/eth_intel_igc.c
+++ b/drivers/ethernet/intel/eth_intel_igc.c
@@ -415,11 +415,7 @@ static void eth_intel_igc_phylink_cb(const struct device *phy __unused,
 {
 	struct net_if *iface = (struct net_if *)user_data;
 
-	if (state->is_up) {
-		net_eth_carrier_on(iface);
-	} else {
-		net_eth_carrier_off(iface);
-	}
+	net_eth_carrier_set(iface, state->is_up);
 }
 
 static void eth_intel_igc_intr_enable(const struct device *dev)

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
@@ -40,14 +40,14 @@ static void netc_eth_phylink_callback(const struct device *pdev, struct phy_link
 		if (result != kStatus_Success) {
 			LOG_ERR("Failed to set MAC up");
 		}
-		net_eth_carrier_on(data->iface);
 	} else {
 		result = EP_Down(&data->handle);
 		if (result != kStatus_Success) {
 			LOG_ERR("Failed to set MAC down");
 		}
-		net_eth_carrier_off(data->iface);
 	}
+
+	net_eth_carrier_set(data->iface, state->is_up);
 }
 
 static void netc_eth_iface_init(struct net_if *iface)

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -1357,12 +1357,24 @@ static inline int net_eth_mac_load(const struct net_eth_mac_config *cfg, uint8_t
 	NET_ETH_MAC_DT_CONFIG_INIT(DT_DRV_INST(inst))
 
 /**
+ * @brief Inform ethernet L2 driver that ethernet carrier is detected or was lost.
+ * This happens when cable is connected or disconnected.
+ *
+ * @param iface Network interface
+ * @param carrier_up true if carrier is detected, false if carrier was lost
+ */
+void net_eth_carrier_set(struct net_if *iface, bool carrier_up);
+
+/**
  * @brief Inform ethernet L2 driver that ethernet carrier is detected.
  * This happens when cable is connected.
  *
  * @param iface Network interface
  */
-void net_eth_carrier_on(struct net_if *iface);
+static inline void net_eth_carrier_on(struct net_if *iface)
+{
+	net_eth_carrier_set(iface, true);
+}
 
 /**
  * @brief Inform ethernet L2 driver that ethernet carrier was lost.
@@ -1370,7 +1382,10 @@ void net_eth_carrier_on(struct net_if *iface);
  *
  * @param iface Network interface
  */
-void net_eth_carrier_off(struct net_if *iface);
+static inline void net_eth_carrier_off(struct net_if *iface)
+{
+	net_eth_carrier_set(iface, false);
+}
 
 /**
  * @brief Set promiscuous mode either ON or OFF.

--- a/subsys/net/l2/ethernet/dsa/dsa_port.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_port.c
@@ -80,11 +80,7 @@ static void dsa_port_phylink_change(const struct device *phydev, struct phy_link
 		dsa_switch_ctx->dapi->port_phylink_change(phydev, state, dev);
 	}
 
-	if (state->is_up) {
-		net_eth_carrier_on(iface);
-	} else {
-		net_eth_carrier_off(iface);
-	}
+	net_eth_carrier_set(iface, state->is_up);
 }
 
 static void dsa_port_iface_init(struct net_if *iface)

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -903,20 +903,11 @@ static void carrier_on_off(struct k_work *work)
 	}
 }
 
-void net_eth_carrier_on(struct net_if *iface)
+void net_eth_carrier_set(struct net_if *iface, bool carrier_up)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
 
-	if (!atomic_test_and_set_bit(&ctx->flags, ETH_CARRIER_UP)) {
-		k_work_submit(&ctx->carrier_work);
-	}
-}
-
-void net_eth_carrier_off(struct net_if *iface)
-{
-	struct ethernet_context *ctx = net_if_l2_data(iface);
-
-	if (atomic_test_and_clear_bit(&ctx->flags, ETH_CARRIER_UP)) {
+	if (atomic_test_and_set_bit_to(&ctx->flags, ETH_CARRIER_UP, carrier_up)) {
 		k_work_submit(&ctx->carrier_work);
 	}
 }


### PR DESCRIPTION
add a function that combines net_eth_carrier_on/off into one function net_eth_carrier_set.


needs: https://github.com/zephyrproject-rtos/zephyr/pull/110270