### PR TITLE
cache: stm32: restore cache_data_flush_all()

### DIFF
--- a/drivers/cache/cache_stm32.c
+++ b/drivers/cache/cache_stm32.c
@@ -102,6 +102,11 @@ int cache_data_flush_and_invd_range(void *addr, size_t size)
 	return ret;
 }
 
+int cache_data_flush_all(void)
+{
+	return cache_data_flush_range(0, UINT32_MAX);
+}
+
 int cache_data_invd_all(void)
 {
 	K_SPINLOCK(&lock) {


### PR DESCRIPTION
`cache_data_flush_all()` was accidentally removed in e17bf15 but it is still used by the cache API and needs to be present.

Fixes CI errors e.g. here, https://github.com/zephyrproject-rtos/zephyr/actions/runs/26804942542/job/79020856446?pr=109903#step:13:1560.