### PR TITLE
twister: add __tracebackhide__ to DeviceAdapter.readlines_until method

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
@@ -129,6 +129,7 @@ class DeviceAdapter(abc.ABC):
         :returns: List of output lines without trailing newlines
         :raises AssertionError: If timeout expires before condition is met
         """
+        __tracebackhide__ = True  # pylint: disable=unused-variable
         self.check_connection(connection_index)
         return self.connections[connection_index].readlines_until(**kwargs)
 

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_connection.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_connection.py
@@ -34,7 +34,7 @@ class DeviceConnection(abc.ABC):
         """Initialize the device connection"""
         self.log_path = log_path
         self.timeout = timeout
-        self._device_read_queue: queue.Queue = queue.Queue()
+        self._device_read_queue: queue.Queue[str] = queue.Queue()
         self._reader_thread: threading.Thread | None = None
         # Prefix for log messages to differentiate between multiple connections
         self.log_prefix: str = ''
@@ -83,7 +83,7 @@ class DeviceConnection(abc.ABC):
     def _read_from_queue(self, timeout: float) -> str:
         """Read data from internal queue"""
         try:
-            data: str | object = self._device_read_queue.get(timeout=timeout)
+            data: str = self._device_read_queue.get(timeout=timeout)
         except queue.Empty as exc:
             raise TwisterHarnessTimeoutException(
                 f'Read from device timeout occurred ({timeout}s)'
@@ -121,7 +121,6 @@ class DeviceConnection(abc.ABC):
         - Collect a fixed number of lines
         - Get all currently available lines immediately
         """
-        __tracebackhide__ = True  # pylint: disable=unused-variable
         timeout = timeout or self.timeout
         if regex:
             regex_compiled = re.compile(regex)


### PR DESCRIPTION
Hide stacktrace for method that is used in tests to wait for a message.