### PR TITLE
drivers: ethernet: e1000: Don't enable automatically if QEMU uses SLIP

### DIFF
--- a/drivers/ethernet/Kconfig.e1000
+++ b/drivers/ethernet/Kconfig.e1000
@@ -5,7 +5,7 @@
 
 menuconfig ETH_E1000
 	bool "Intel(R) PRO/1000 Gigabit Ethernet driver"
-	default y
+	default y if !NET_QEMU_SLIP
 	depends on DT_HAS_INTEL_E1000_ENABLED
 	select PCIE
 	help


### PR DESCRIPTION
Enabling the driver while QEMU is configured to use SLIP driver (which is the default) causes crash on boot, making any networking sample defunct in default configuration when running on qemu_x86.

Happens since https://github.com/zephyrproject-rtos/zephyr/pull/108417, as this caused the driver to be enabled by default in QEMU. 