### PR TITLE
Add ssh channel support

### DIFF
--- a/include/zephyr/net/ssh/client.h
+++ b/include/zephyr/net/ssh/client.h
@@ -63,6 +63,53 @@ int ssh_client_start(struct ssh_client *ssh,
  */
 int ssh_client_stop(struct ssh_client *ssh);
 
+/**
+ * @brief Register a callback function for getting the transport
+ *        associated with a server connection.
+ *
+ * The registered callback is invoked for client-side transport events.
+ * On the client role only the following event types are emitted:
+ *  - @ref SSH_TRANSPORT_EVENT_SERVICE_ACCEPTED when the requested SSH
+ *    service was accepted by the server.
+ *  - @ref SSH_TRANSPORT_EVENT_AUTHENTICATE_RESULT when an authentication
+ *    attempt completes.
+ *  - @ref SSH_TRANSPORT_EVENT_CLOSED when the transport is torn down.
+ *
+ * The callback return value is ignored; the callback acts as an observer
+ * and cannot influence the transport flow.
+ *
+ * @param conf Configuration data for the transport callback. The structure
+ *        must remain valid until it is unregistered.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int ssh_client_register_transport_callback(struct ssh_transport_conf *conf);
+
+/**
+ * @brief Unregister a callback function for getting the transport
+ *        associated with a server connection.
+ *
+ * @param conf Configuration data for the transport callback
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int ssh_client_unregister_transport_callback(struct ssh_transport_conf *conf);
+
+/**
+ * @brief Get the SSH client instance that owns a given transport.
+ *
+ * This is useful inside a registered transport callback, which is invoked
+ * globally for events from all client instances, to determine which client
+ * instance a transport belongs to. It must only be called for a transport
+ * obtained from a client transport callback.
+ *
+ * @param transport Transport to get the owning client for.
+ *
+ * @return Pointer to the owning SSH client instance, or NULL if the transport
+ *         is NULL.
+ */
+struct ssh_client *ssh_transport_get_client(struct ssh_transport *transport);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/net/ssh/common.h
+++ b/include/zephyr/net/ssh/common.h
@@ -324,6 +324,19 @@ int ssh_channel_read_stderr(struct ssh_channel *channel, void *data, uint32_t le
 int ssh_channel_write_stderr(struct ssh_channel *channel, const void *data, uint32_t len);
 
 /**
+ * @brief Close an SSH channel.
+ *
+ * Send a channel close message to the peer and release the channel. On success,
+ * the channel handle must no longer be used. The associated channel callback
+ * (if any) receives a @ref SSH_CHANNEL_EVENT_CLOSED event.
+ *
+ * @param channel Pointer to the SSH channel.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int ssh_channel_close(struct ssh_channel *channel);
+
+/**
  * @typedef ssh_service_client_cb_t
  * @brief Callback used while iterating over SSH client connections
  *

--- a/include/zephyr/net/ssh/common.h
+++ b/include/zephyr/net/ssh/common.h
@@ -20,6 +20,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/sys/slist.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -138,7 +139,7 @@ typedef int (*ssh_channel_event_callback_t)(struct ssh_channel *channel,
 /** Types of events emitted for an SSH transport. */
 enum ssh_transport_event_type {
 	/** Transport has been closed. */
-	SSH_TRANSPORT_EVENT_CLOSED,
+	SSH_TRANSPORT_EVENT_CLOSED,			/* Server and client */
 	/** Requested SSH service was accepted by the peer. */
 	SSH_TRANSPORT_EVENT_SERVICE_ACCEPTED,		/* Client only */
 	/** Authentication attempt result. */
@@ -186,6 +187,20 @@ struct ssh_transport_event {
 typedef int (*ssh_transport_event_callback_t)(struct ssh_transport *transport,
 					      const struct ssh_transport_event *event,
 					      void *user_data);
+
+/** SSH transport callback configuration */
+struct ssh_transport_conf {
+	/** List node */
+	sys_snode_t node;
+
+	/** Callback function to be called by the server to retrieve
+	 * the transport for a client connection.
+	 */
+	ssh_transport_event_callback_t cb;
+
+	/** User data to be passed to the callback function */
+	void *user_data;
+};
 
 /** Extended data type for standard error channel data. */
 #define SSH_EXTENDED_DATA_STDERR 1
@@ -347,6 +362,28 @@ typedef void (*ssh_service_server_cb_t)(struct ssh_server *sshd,
  * @param user_data User specified data
  */
 void ssh_server_foreach(ssh_service_server_cb_t cb, void *user_data);
+
+/**
+ * @brief Call user configured callbacks for a given transport.
+ *
+ * @details This function is used to call user configured callbacks for a given
+ *          transport. It is used by the SSH transport to notify the user of
+ *          events such as authentication results, channel open requests, and
+ *          channel data. The function will traverse the list of configured
+ *          callbacks and call each one with the provided transport and event
+ *          information. Note that the callbacks must not call the transport
+ *          register or unregister API as that could lead to a deadlock.
+ *
+ * @param is_server If set to true, then traverse configured server callbacks.
+ *        If set to false, then traverse configured client callbacks.
+ * @param transport Transport to pass to user specified callback.
+ * @param event Event information to pass to user callback.
+ *
+ * @return 0 on success, or -EINVAL if the transport role does not match the
+ *         dispatch role (server vs client).
+ */
+int ssh_transport_traverse_callbacks(bool is_server, struct ssh_transport *transport,
+				     const struct ssh_transport_event *event);
 
 
 #ifdef __cplusplus

--- a/include/zephyr/net/ssh/server.h
+++ b/include/zephyr/net/ssh/server.h
@@ -152,6 +152,51 @@ int ssh_server_stop(struct ssh_server *sshd);
  */
 int ssh_server_transport_close(struct ssh_server *sshd, int idx);
 
+/**
+ * @brief Register a callback function for getting the transport
+ *        associated with a client connection.
+ *
+ * The registered callback is invoked for server-side transport events.
+ * On the server role only the following event types are emitted:
+ *  - @ref SSH_TRANSPORT_EVENT_CHANNEL_OPEN when a client requests a new
+ *    channel to be opened.
+ *  - @ref SSH_TRANSPORT_EVENT_CLOSED when the transport is torn down.
+ *
+ * The callback return value is ignored; the callback acts as an observer
+ * and cannot influence the transport flow.
+ *
+ * @param conf Configuration data for the transport callback. The structure
+ *        must remain valid until it is unregistered.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int ssh_server_register_transport_callback(struct ssh_transport_conf *conf);
+
+/**
+ * @brief Unregister a callback function for getting the transport
+ *        associated with a client connection.
+ *
+ * @param conf Configuration data for the transport callback
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int ssh_server_unregister_transport_callback(struct ssh_transport_conf *conf);
+
+/**
+ * @brief Get the SSH server instance that owns a given transport.
+ *
+ * This is useful inside a registered transport callback, which is invoked
+ * globally for events from all server instances, to determine which server
+ * instance a transport belongs to. It must only be called for a transport
+ * obtained from a server transport callback.
+ *
+ * @param transport Transport to get the owning server for.
+ *
+ * @return Pointer to the owning SSH server instance, or NULL if the transport
+ *         is NULL.
+ */
+struct ssh_server *ssh_transport_get_server(struct ssh_transport *transport);
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/net/ssh/README.rst
+++ b/samples/net/ssh/README.rst
@@ -173,3 +173,45 @@ In host computer shell, connect to the Zephyr SSH server, no password needed.
    ssh -i ~/.ssh/id_rsa root@192.0.2.1
 
 To exit press 'Enter' then '~' then '.' (i.e. enter tilde dot).
+
+
+Creating SSH Channels
+*********************
+
+In addition to the built-in ``net ssh`` and ``net sshd`` shell commands, the
+sample registers a small ``sample`` command set that shows how an application
+can create and remove SSH channels on top of an existing client connection.
+Connection management itself is left to the SSH client shell commands described
+above.
+
+First establish a client connection, which authenticates and opens an
+interactive session channel:
+
+.. code-block:: console
+
+   net ssh start username@192.0.2.2
+
+Press ``Ctrl+d`` or type ``exit`` to return to the Zephyr shell while keeping
+the connection open. Then create an additional channel on that connection:
+
+.. code-block:: console
+
+   sample open
+
+The opened channels and the active server and client connections can be listed
+with:
+
+.. code-block:: console
+
+   sample info
+
+Finally, remove a channel by its number (as shown by ``sample info``):
+
+.. code-block:: console
+
+   sample close 1
+
+The ``sample`` commands rely on the SSH transport callbacks: the sample
+registers a server and a client transport callback to track the connections,
+and uses :c:func:`ssh_transport_channel_open` and :c:func:`ssh_channel_close`
+to create and remove channels.

--- a/samples/net/ssh/src/main.c
+++ b/samples/net/ssh/src/main.c
@@ -9,6 +9,11 @@
 LOG_MODULE_REGISTER(net_ssh_sample, LOG_LEVEL_INF);
 
 #include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/net/conn_mgr_monitor.h>
+#include <zephyr/net/ssh/common.h>
+#include <zephyr/net/ssh/server.h>
+#include <zephyr/net/ssh/client.h>
 #include <zephyr/net/net_config.h>
 
 #if defined(CONFIG_NET_SAMPLE_SSH_USE_PASSWORD)
@@ -36,13 +41,419 @@ NET_CONFIG_SSH_PASSWORD_AUTH_DEFINE_STATIC(my_password_auth,
 					   CONFIG_NET_SAMPLE_SSH_USERNAME,
 					   SSH_PASSWORD);
 
+static bool connected;
+static struct net_mgmt_event_callback mgmt_cb;
+
+/* Protects the transport and channel bookkeeping below. It is updated from the
+ * SSH server/client threads (the event callbacks) and read from the shell
+ * thread (the sample commands).
+ */
+static K_MUTEX_DEFINE(sample_lock);
+
+#if defined(CONFIG_SSH_SERVER) || defined(CONFIG_SSH_CLIENT)
+/* Store a transport into the first free slot of an array. Returns the slot
+ * index, or -1 if the array is full. If the transport is already stored its
+ * existing index is returned.
+ */
+static int transport_track(struct ssh_transport **arr, size_t count,
+			   struct ssh_transport *transport)
+{
+	int free_slot = -1;
+
+	for (size_t i = 0; i < count; i++) {
+		if (arr[i] == transport) {
+			return (int)i;
+		}
+
+		if (arr[i] == NULL && free_slot < 0) {
+			free_slot = (int)i;
+		}
+	}
+
+	if (free_slot >= 0) {
+		arr[free_slot] = transport;
+	}
+
+	return free_slot;
+}
+
+static void transport_untrack(struct ssh_transport **arr, size_t count,
+			      struct ssh_transport *transport)
+{
+	for (size_t i = 0; i < count; i++) {
+		if (arr[i] == transport) {
+			arr[i] = NULL;
+		}
+	}
+}
+#endif /* CONFIG_SSH_SERVER || CONFIG_SSH_CLIENT */
+
+#if defined(CONFIG_SSH_SERVER)
+/* Transports of the clients connected to our server. */
+static struct ssh_transport *server_transport[CONFIG_SSH_SERVER_MAX_CLIENTS];
+
+static int server_transport_event_handler(struct ssh_transport *transport,
+					  const struct ssh_transport_event *event,
+					  void *user_data);
+
+/* The server transport configuration. This must not be allocated from the
+ * stack as it is used by the SSH server until it is unregistered.
+ */
+static struct ssh_transport_conf server_transport_conf = {
+	.cb = server_transport_event_handler,
+};
+
+static int server_transport_event_handler(struct ssh_transport *transport,
+					  const struct ssh_transport_event *event,
+					  void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	switch (event->type) {
+	case SSH_TRANSPORT_EVENT_CHANNEL_OPEN:
+		k_mutex_lock(&sample_lock, K_FOREVER);
+		if (transport_track(server_transport, ARRAY_SIZE(server_transport),
+				    transport) < 0) {
+			LOG_WRN("No free server transport slots");
+		}
+		k_mutex_unlock(&sample_lock);
+		break;
+
+	case SSH_TRANSPORT_EVENT_CLOSED:
+		k_mutex_lock(&sample_lock, K_FOREVER);
+		transport_untrack(server_transport, ARRAY_SIZE(server_transport),
+				  transport);
+		k_mutex_unlock(&sample_lock);
+		break;
+
+	default:
+		break;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_SSH_SERVER */
+
+#if defined(CONFIG_SSH_CLIENT)
+/* Transports of our client connections. The connection itself is managed by
+ * the SSH shell ("net ssh start"/"net ssh stop"); here we just record the
+ * authenticated transports so that a channel can be opened on them.
+ */
+static struct ssh_transport *client_transport[CONFIG_SSH_CLIENT_MAX_CLIENTS];
+
+/* Channels we have opened on our client connections. */
+static struct ssh_channel *client_channels[CONFIG_SSH_MAX_CHANNELS];
+
+static int client_transport_event_handler(struct ssh_transport *transport,
+					  const struct ssh_transport_event *event,
+					  void *user_data);
+
+/* The client transport configuration. This must not be allocated from the
+ * stack as it is used by the SSH client until it is unregistered.
+ */
+static struct ssh_transport_conf client_transport_conf = {
+	.cb = client_transport_event_handler,
+};
+
+static int client_transport_event_handler(struct ssh_transport *transport,
+					  const struct ssh_transport_event *event,
+					  void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	switch (event->type) {
+	case SSH_TRANSPORT_EVENT_AUTHENTICATE_RESULT:
+		if (!event->authenticate_result.success) {
+			break;
+		}
+
+		/* The connection is authenticated, so remember the transport
+		 * to be able to open a channel on it later.
+		 */
+		k_mutex_lock(&sample_lock, K_FOREVER);
+		if (transport_track(client_transport, ARRAY_SIZE(client_transport),
+				    transport) < 0) {
+			LOG_WRN("No free client transport slots");
+		}
+		k_mutex_unlock(&sample_lock);
+		break;
+
+	case SSH_TRANSPORT_EVENT_CLOSED:
+		k_mutex_lock(&sample_lock, K_FOREVER);
+		transport_untrack(client_transport, ARRAY_SIZE(client_transport),
+				  transport);
+		k_mutex_unlock(&sample_lock);
+		break;
+
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+static int channel_track(struct ssh_channel *channel)
+{
+	int free_slot = -1;
+
+	for (size_t i = 0; i < ARRAY_SIZE(client_channels); i++) {
+		if (client_channels[i] == channel) {
+			return (int)i;
+		}
+
+		if (client_channels[i] == NULL && free_slot < 0) {
+			free_slot = (int)i;
+		}
+	}
+
+	if (free_slot >= 0) {
+		client_channels[free_slot] = channel;
+	}
+
+	return free_slot;
+}
+
+static void channel_untrack(struct ssh_channel *channel)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(client_channels); i++) {
+		if (client_channels[i] == channel) {
+			client_channels[i] = NULL;
+		}
+	}
+}
+
+/* Channel event callback. The channel is created with "sample open" and
+ * removed with "sample close".
+ */
+static int channel_event_handler(struct ssh_channel *channel,
+				 const struct ssh_channel_event *event,
+				 void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	switch (event->type) {
+	case SSH_CHANNEL_EVENT_OPEN_RESULT: {
+		int i;
+
+		k_mutex_lock(&sample_lock, K_FOREVER);
+		i = channel_track(channel);
+		k_mutex_unlock(&sample_lock);
+
+		if (i < 0) {
+			LOG_WRN("No free channel slots");
+			return 0;
+		}
+
+		LOG_INF("Channel %d opened", i);
+		break;
+	}
+
+	case SSH_CHANNEL_EVENT_RX_DATA_READY: {
+		uint8_t buf[64];
+		int len;
+
+		while ((len = ssh_channel_read(channel, buf, sizeof(buf))) > 0) {
+			LOG_INF("Channel RX: %.*s", len, buf);
+		}
+		break;
+	}
+
+	case SSH_CHANNEL_EVENT_CLOSED:
+		k_mutex_lock(&sample_lock, K_FOREVER);
+		channel_untrack(channel);
+		k_mutex_unlock(&sample_lock);
+
+		LOG_INF("Channel closed");
+		break;
+
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+static int cmd_sample_open(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct ssh_transport *transport = NULL;
+	int ret;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	/* Use the first authenticated client connection. Establish one first
+	 * with the SSH shell, e.g. "net ssh start <user>@<host>".
+	 */
+	k_mutex_lock(&sample_lock, K_FOREVER);
+	for (size_t i = 0; i < ARRAY_SIZE(client_transport); i++) {
+		if (client_transport[i] != NULL) {
+			transport = client_transport[i];
+			break;
+		}
+	}
+	k_mutex_unlock(&sample_lock);
+
+	if (transport == NULL) {
+		shell_error(sh, "No client connection, use \"net ssh start\" first");
+		return -ENOTCONN;
+	}
+
+	ret = ssh_transport_channel_open(transport, channel_event_handler, NULL);
+	if (ret < 0) {
+		shell_error(sh, "Failed to open SSH channel: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "Channel open requested");
+
+	return 0;
+}
+
+static int cmd_sample_close(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct ssh_channel *channel;
+	int ch;
+	int err = 0;
+
+	ARG_UNUSED(argc);
+
+	ch = shell_strtol(argv[1], 10, &err);
+	if (err != 0 || ch < 0 || ch >= (int)ARRAY_SIZE(client_channels)) {
+		shell_error(sh, "Invalid channel number: %s", argv[1]);
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&sample_lock, K_FOREVER);
+	channel = client_channels[ch];
+	k_mutex_unlock(&sample_lock);
+
+	if (channel == NULL) {
+		shell_error(sh, "Channel %d not open", ch);
+		return -ENOENT;
+	}
+
+	err = ssh_channel_close(channel);
+	if (err < 0) {
+		shell_error(sh, "Failed to close channel %d: %d", ch, err);
+		return err;
+	}
+
+	shell_print(sh, "Channel %d close requested", ch);
+
+	return 0;
+}
+#endif /* CONFIG_SSH_CLIENT */
+
+static int cmd_sample_info(const struct shell *sh, size_t argc, char *argv[])
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(sh, "Network %sconnected", connected ? "" : "dis");
+
+	k_mutex_lock(&sample_lock, K_FOREVER);
+
+#if defined(CONFIG_SSH_SERVER)
+	for (size_t i = 0; i < ARRAY_SIZE(server_transport); i++) {
+		if (server_transport[i] != NULL) {
+			shell_print(sh, "Server transport %zu: %p", i,
+				    (void *)server_transport[i]);
+		}
+	}
+#endif
+
+#if defined(CONFIG_SSH_CLIENT)
+	for (size_t i = 0; i < ARRAY_SIZE(client_transport); i++) {
+		if (client_transport[i] != NULL) {
+			shell_print(sh, "Client transport %zu: %p", i,
+				    (void *)client_transport[i]);
+		}
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(client_channels); i++) {
+		if (client_channels[i] != NULL) {
+			shell_print(sh, "Channel %zu: %p", i,
+				    (void *)client_channels[i]);
+		}
+	}
+#endif
+
+	k_mutex_unlock(&sample_lock);
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sample_commands,
+#if defined(CONFIG_SSH_CLIENT)
+	SHELL_CMD(open, NULL,
+		  SHELL_HELP("Create a channel on the client connection", ""),
+		  cmd_sample_open),
+	SHELL_CMD_ARG(close, NULL,
+		      SHELL_HELP("Remove a channel", "<channel>"),
+		      cmd_sample_close, 2, 0),
+#endif /* CONFIG_SSH_CLIENT */
+	SHELL_CMD(info, NULL,
+		  SHELL_HELP("List connections and channels", ""),
+		  cmd_sample_info),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(sample, &sample_commands,
+		   "Sample application commands", NULL);
+
+#define EVENT_MASK (NET_EVENT_L4_CONNECTED | NET_EVENT_L4_DISCONNECTED)
+
+static void event_handler(struct net_mgmt_event_callback *cb,
+			  uint64_t mgmt_event, struct net_if *iface)
+{
+	ARG_UNUSED(cb);
+	ARG_UNUSED(iface);
+
+	if ((mgmt_event & EVENT_MASK) != mgmt_event) {
+		return;
+	}
+
+	if (mgmt_event == NET_EVENT_L4_CONNECTED) {
+		LOG_INF("Network connected");
+		connected = true;
+		return;
+	}
+
+	if (mgmt_event == NET_EVENT_L4_DISCONNECTED) {
+		LOG_INF("Network disconnected");
+		connected = false;
+		return;
+	}
+}
+
 int main(void)
 {
+	int ret;
+
 	LOG_INF("SSH sample for %s", CONFIG_BOARD_TARGET);
 
 #if defined(CONFIG_SSH_SERVER)
-	int ret;
+	ret = ssh_server_register_transport_callback(&server_transport_conf);
+	if (ret < 0) {
+		LOG_WRN("Failed to register SSH server transport callback: %d", ret);
+	}
+#endif
 
+#if defined(CONFIG_SSH_CLIENT)
+	ret = ssh_client_register_transport_callback(&client_transport_conf);
+	if (ret < 0) {
+		LOG_WRN("Failed to register SSH client transport callback: %d", ret);
+	}
+#endif
+
+	if (IS_ENABLED(CONFIG_NET_CONNECTION_MANAGER)) {
+		net_mgmt_init_event_callback(&mgmt_cb,
+					     event_handler, EVENT_MASK);
+		net_mgmt_add_event_callback(&mgmt_cb);
+		conn_mgr_mon_resend_status();
+	}
+
+#if defined(CONFIG_SSH_SERVER)
 	ret = net_config_init_sshd(NULL, &my_priv_key_config,
 				   &my_pub_key_config, &my_password_auth, 0);
 	if (ret != 0) {

--- a/subsys/net/lib/config/CMakeLists.txt
+++ b/subsys/net/lib/config/CMakeLists.txt
@@ -15,4 +15,4 @@ if(CONFIG_NET_CONFIG_SETTINGS)
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_NET_CONFIG_CLOCK_SNTP_INIT init_clock_sntp.c)
-zephyr_library_sources_ifdef(CONFIG_SSH_SHELL init_sshd.c)
+zephyr_library_sources_ifdef(CONFIG_SSH_SERVER init_sshd.c)

--- a/subsys/net/lib/ssh/ssh_auth.c
+++ b/subsys/net/lib/ssh/ssh_auth.c
@@ -377,12 +377,21 @@ int ssh_auth_process_msg(struct ssh_transport *transport, uint8_t msg_id,
 				transport, sshc->user_name, sshc->host_key_index);
 			transport->auths_allowed_mask &= ~BIT(SSH_AUTH_PUBKEY);
 
-		} else if ((transport->auths_allowed_mask & BIT(SSH_AUTH_PASSWORD)) != 0 &&
-			   transport->callback != NULL) {
+		} else if ((transport->auths_allowed_mask & BIT(SSH_AUTH_PASSWORD)) != 0) {
 			struct ssh_transport_event event;
 
 			event.type = SSH_TRANSPORT_EVENT_SERVICE_ACCEPTED;
-			ret = transport->callback(transport, &event, transport->callback_user_data);
+
+			ret = ssh_transport_traverse_callbacks(false, transport, &event);
+			if (ret < 0) {
+				return ret;
+			}
+
+			if (transport->callback != NULL) {
+				ret = transport->callback(transport, &event,
+							  transport->callback_user_data);
+			}
+
 			transport->auths_allowed_mask &= ~BIT(SSH_AUTH_PASSWORD);
 		} else {
 			NET_DBG("No available auth methods");
@@ -392,6 +401,8 @@ int ssh_auth_process_msg(struct ssh_transport *transport, uint8_t msg_id,
 		break;
 	}
 	case SSH_MSG_USERAUTH_SUCCESS: {
+		struct ssh_transport_event event;
+
 		NET_DBG("USERAUTH_SUCCESS");
 
 		/* Client only */
@@ -406,12 +417,17 @@ int ssh_auth_process_msg(struct ssh_transport *transport, uint8_t msg_id,
 
 		transport->authenticated = true;
 
-		if (transport->callback != NULL) {
-			struct ssh_transport_event event;
+		event.type = SSH_TRANSPORT_EVENT_AUTHENTICATE_RESULT;
+		event.authenticate_result.success = true;
 
-			event.type = SSH_TRANSPORT_EVENT_AUTHENTICATE_RESULT;
-			event.authenticate_result.success = true;
-			ret = transport->callback(transport, &event, transport->callback_user_data);
+		ret = ssh_transport_traverse_callbacks(false, transport, &event);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (transport->callback != NULL) {
+			ret = transport->callback(transport, &event,
+						  transport->callback_user_data);
 		}
 		break;
 	}

--- a/subsys/net/lib/ssh/ssh_client.c
+++ b/subsys/net/lib/ssh/ssh_client.c
@@ -233,3 +233,22 @@ int ssh_client_stop(struct ssh_client *sshc)
 
 	return ret;
 }
+
+int ssh_client_register_transport_callback(struct ssh_transport_conf *conf)
+{
+	return ssh_transport_register_callback(conf, false);
+}
+
+int ssh_client_unregister_transport_callback(struct ssh_transport_conf *conf)
+{
+	return ssh_transport_unregister_callback(conf, false);
+}
+
+struct ssh_client *ssh_transport_get_client(struct ssh_transport *transport)
+{
+	if (transport == NULL) {
+		return NULL;
+	}
+
+	return transport->sshc;
+}

--- a/subsys/net/lib/ssh/ssh_connection.c
+++ b/subsys/net/lib/ssh/ssh_connection.c
@@ -215,6 +215,24 @@ int ssh_channel_write_stderr(struct ssh_channel *channel, const void *data, uint
 	return (int)len;
 }
 
+int ssh_channel_close(struct ssh_channel *channel)
+{
+	struct ssh_transport_user_request request;
+
+	if (channel == NULL || !channel->in_use || !channel->open ||
+	    channel->remote_channel == UINT32_MAX || channel->transport == NULL) {
+		return -EINVAL;
+	}
+
+	/* The CHANNEL_CLOSE message is sent and the channel freed from the
+	 * transport thread, so just queue the request here.
+	 */
+	request.type = SSH_TRANSPORT_USER_REQUEST_CHANNEL_CLOSE;
+	request.channel_close.channel = channel;
+
+	return ssh_transport_queue_user_request(channel->transport, &request);
+}
+
 int ssh_connection_process_msg(struct ssh_transport *transport, uint8_t msg_id,
 			       struct ssh_payload *rx_pkt)
 {
@@ -700,8 +718,12 @@ int ssh_connection_process_msg(struct ssh_transport *transport, uint8_t msg_id,
 
 		channel = ssh_connection_get_channel(transport, recipient_channel);
 		if (channel == NULL) {
-			NET_ERR("Invalid channel");
-			return -1;
+			/* The channel may already have been freed if we
+			 * initiated the close ourselves; this is the peer's
+			 * acknowledging CHANNEL_CLOSE, so just ignore it.
+			 */
+			NET_DBG("Channel %u already closed", recipient_channel);
+			return 0;
 		}
 
 		ssh_connection_free_channel(channel);
@@ -956,6 +978,27 @@ int ssh_connection_send_channel_result(struct ssh_transport *transport, bool suc
 	ret = ssh_transport_send_packet(transport, &payload);
 	if (ret < 0) {
 		NET_DBG("Failed to send %s (%d)", "CHANNEL_SUCCESS", ret);
+	}
+
+	return ret;
+}
+
+int ssh_connection_send_channel_close(struct ssh_transport *transport,
+				      uint32_t recipient_channel)
+{
+	int ret;
+
+	SSH_PAYLOAD_BUF(payload, transport->tx_buf);
+
+	if (!ssh_payload_skip_bytes(&payload, SSH_PKT_MSG_ID_OFFSET) ||
+	    !ssh_payload_write_byte(&payload, SSH_MSG_CHANNEL_CLOSE) ||
+	    !ssh_payload_write_u32(&payload, recipient_channel)) {
+		return -ENOBUFS;
+	}
+
+	ret = ssh_transport_send_packet(transport, &payload);
+	if (ret < 0) {
+		NET_DBG("Failed to send %s (%d)", "CHANNEL_CLOSE", ret);
 	}
 
 	return ret;

--- a/subsys/net/lib/ssh/ssh_connection.c
+++ b/subsys/net/lib/ssh/ssh_connection.c
@@ -255,6 +255,7 @@ int ssh_connection_process_msg(struct ssh_transport *transport, uint8_t msg_id,
 		struct ssh_string channel_type;
 		uint32_t sender_channel, initial_window_size, maximum_packet_size;
 		struct ssh_channel *channel;
+		struct ssh_transport_event event;
 
 		NET_DBG("CHANNEL_OPEN");
 
@@ -291,14 +292,19 @@ int ssh_connection_process_msg(struct ssh_transport *transport, uint8_t msg_id,
 		/* TODO: MTU = sizeof(transport->rx_buf) - HEADER_LEN - MAX_PADDING - MAC_LEN? */
 		channel->rx_mtu = sizeof(channel->rx_ring_buf_data);
 
-		if (transport->callback != NULL) {
-			struct ssh_transport_event event;
+		event.type = SSH_TRANSPORT_EVENT_CHANNEL_OPEN;
+		event.channel_open.channel = channel;
 
-			event.type = SSH_TRANSPORT_EVENT_CHANNEL_OPEN;
-			event.channel_open.channel = channel;
+		ret = ssh_transport_traverse_callbacks(true, transport, &event);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (transport->callback != NULL) {
 			ret = transport->callback(transport, &event,
 						  transport->callback_user_data);
 		}
+
 		break;
 	}
 #endif

--- a/subsys/net/lib/ssh/ssh_connection.h
+++ b/subsys/net/lib/ssh/ssh_connection.h
@@ -38,6 +38,9 @@ int ssh_connection_send_channel_open_confirmation(struct ssh_transport *transpor
 int ssh_connection_send_channel_result(struct ssh_transport *transport, bool success,
 				       uint32_t recipient_channel);
 
+int ssh_connection_send_channel_close(struct ssh_transport *transport,
+				      uint32_t recipient_channel);
+
 struct ssh_channel *ssh_connection_allocate_channel(struct ssh_transport *transport);
 void ssh_connection_free_channel(struct ssh_channel *channel);
 struct ssh_channel *ssh_connection_get_channel(struct ssh_transport *transport,

--- a/subsys/net/lib/ssh/ssh_kex_ecdh.c
+++ b/subsys/net/lib/ssh/ssh_kex_ecdh.c
@@ -306,7 +306,7 @@ static int gen_shared_secret(struct ssh_transport *transport,
 		return -ENOMEM;
 	}
 
-	NET_DBG("shared_secret %zu", transport->shared_secret->len);
+	NET_DBG("shared_secret %zu", (size_t)transport->shared_secret->len);
 	NET_HEXDUMP_DBG(transport->shared_secret->data,
 			transport->shared_secret->len, "shared_secret");
 

--- a/subsys/net/lib/ssh/ssh_server.c
+++ b/subsys/net/lib/ssh/ssh_server.c
@@ -412,3 +412,22 @@ int ssh_server_transport_close(struct ssh_server *sshd, int idx)
 
 	return 0;
 }
+
+int ssh_server_register_transport_callback(struct ssh_transport_conf *conf)
+{
+	return ssh_transport_register_callback(conf, true);
+}
+
+int ssh_server_unregister_transport_callback(struct ssh_transport_conf *conf)
+{
+	return ssh_transport_unregister_callback(conf, true);
+}
+
+struct ssh_server *ssh_transport_get_server(struct ssh_transport *transport)
+{
+	if (transport == NULL) {
+		return NULL;
+	}
+
+	return transport->sshd;
+}

--- a/subsys/net/lib/ssh/ssh_transport.c
+++ b/subsys/net/lib/ssh/ssh_transport.c
@@ -65,6 +65,11 @@ static const struct ssh_string supported_server_sig_algs[] = {
 };
 BUILD_ASSERT(ARRAY_SIZE(supported_server_sig_algs) > 0);
 
+/* User registered transport callbacks that are pending to be called. */
+static sys_slist_t ssh_server_transport_callbacks;
+static sys_slist_t ssh_client_transport_callbacks;
+static K_MUTEX_DEFINE(lock);
+
 static ssize_t sendall(int sock, const void *buf, size_t len)
 {
 	while (len) {
@@ -163,6 +168,29 @@ int ssh_transport_start(struct ssh_transport *transport, bool server, void *pare
 
 void ssh_transport_close(struct ssh_transport *transport)
 {
+	/* Notify any listeners that the transport is going down. Only emit the
+	 * event for a transport that actually started running, and only once,
+	 * so that error and cleanup paths that may call this function more than
+	 * once do not generate duplicate notifications. The event is dispatched
+	 * before any transport resources are released so that the callback can
+	 * still inspect the transport.
+	 */
+	if (transport->running) {
+		struct ssh_transport_event event = {
+			.type = SSH_TRANSPORT_EVENT_CLOSED,
+		};
+
+		/* The dispatch role always matches the transport role here, so
+		 * the call cannot fail with a role mismatch.
+		 */
+		(void)ssh_transport_traverse_callbacks(transport->server, transport, &event);
+
+		if (transport->callback != NULL) {
+			(void)transport->callback(transport, &event,
+						  transport->callback_user_data);
+		}
+	}
+
 	for (int i = 0; i < ARRAY_SIZE(transport->channels); i++) {
 		struct ssh_channel *channel = &transport->channels[i];
 
@@ -1389,4 +1417,77 @@ static int mac_verify(struct ssh_transport *transport, psa_key_id_t mac_key,
 exit:
 	psa_mac_abort(&op);
 	return -EIO;
+}
+
+int ssh_transport_register_callback(struct ssh_transport_conf *conf, bool is_server)
+{
+	if (conf == NULL) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&lock, K_FOREVER);
+
+	if (is_server) {
+		sys_slist_find_and_remove(&ssh_server_transport_callbacks, &conf->node);
+		sys_slist_prepend(&ssh_server_transport_callbacks, &conf->node);
+	} else {
+		sys_slist_find_and_remove(&ssh_client_transport_callbacks, &conf->node);
+		sys_slist_prepend(&ssh_client_transport_callbacks, &conf->node);
+	}
+
+	k_mutex_unlock(&lock);
+
+	return 0;
+}
+
+int ssh_transport_unregister_callback(struct ssh_transport_conf *conf, bool is_server)
+{
+	bool ret;
+
+	if (conf == NULL) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&lock, K_FOREVER);
+
+	if (is_server) {
+		ret = sys_slist_find_and_remove(&ssh_server_transport_callbacks, &conf->node);
+	} else {
+		ret = sys_slist_find_and_remove(&ssh_client_transport_callbacks, &conf->node);
+	}
+
+	k_mutex_unlock(&lock);
+
+	return ret ? 0 : -ENOENT;
+}
+
+int ssh_transport_traverse_callbacks(bool is_server, struct ssh_transport *transport,
+				     const struct ssh_transport_event *event)
+{
+	sys_slist_t *callbacks = is_server ? &ssh_server_transport_callbacks :
+					    &ssh_client_transport_callbacks;
+	struct ssh_transport_conf *conf;
+
+	/* The list to dispatch to is determined by the role that emits the
+	 * event, which must always match the role of the transport itself.
+	 * Bail out if they disagree so that an event is never delivered to the
+	 * wrong (server vs client) set of callbacks.
+	 */
+	if (transport != NULL && transport->server != is_server) {
+		NET_ERR("Transport role (%d) does not match dispatch role (%d)",
+			transport->server, is_server);
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&lock, K_FOREVER);
+
+	SYS_SLIST_FOR_EACH_CONTAINER(callbacks, conf, node) {
+		if (conf->cb != NULL) {
+			conf->cb(transport, event, conf->user_data);
+		}
+	}
+
+	k_mutex_unlock(&lock);
+
+	return 0;
 }

--- a/subsys/net/lib/ssh/ssh_transport.c
+++ b/subsys/net/lib/ssh/ssh_transport.c
@@ -885,6 +885,19 @@ static int process_user_request(struct ssh_transport *transport,
 
 		return ret;
 	}
+	case SSH_TRANSPORT_USER_REQUEST_CHANNEL_CLOSE: {
+		struct ssh_channel *channel = request->channel_close.channel;
+		int ret = 0;
+
+		if (channel->open && channel->remote_channel != UINT32_MAX) {
+			ret = ssh_connection_send_channel_close(transport,
+								channel->remote_channel);
+		}
+
+		ssh_connection_free_channel(channel);
+
+		return ret;
+	}
 #ifdef CONFIG_SSH_CLIENT
 	case SSH_TRANSPORT_USER_REQUEST_AUTHENTICATE:
 		if (!transport->encrypted || transport->authenticated) {

--- a/subsys/net/lib/ssh/ssh_transport.h
+++ b/subsys/net/lib/ssh/ssh_transport.h
@@ -35,6 +35,7 @@ struct ssh_transport_user_request {
 		SSH_TRANSPORT_USER_REQUEST_OPEN_CHANNEL_RESULT,		/* Server only */
 		SSH_TRANSPORT_USER_REQUEST_CHANNEL_REQUEST,
 		SSH_TRANSPORT_USER_REQUEST_CHANNEL_REQUEST_RESULT,
+		SSH_TRANSPORT_USER_REQUEST_CHANNEL_CLOSE,
 	} type;
 	union {
 		struct ssh_transport_user_request_authenticate {
@@ -63,6 +64,9 @@ struct ssh_transport_user_request {
 			struct ssh_channel *channel;
 			bool success;
 		} channel_request_result;
+		struct ssh_transport_user_request_channel_close {
+			struct ssh_channel *channel;
+		} channel_close;
 	};
 };
 

--- a/subsys/net/lib/ssh/ssh_transport.h
+++ b/subsys/net/lib/ssh/ssh_transport.h
@@ -229,4 +229,7 @@ int ssh_transport_send_service_request(struct ssh_transport *transport,
 int ssh_transport_send_server_sig_algs(struct ssh_transport *transport);
 #endif
 
+int ssh_transport_register_callback(struct ssh_transport_conf *conf, bool is_server);
+int ssh_transport_unregister_callback(struct ssh_transport_conf *conf, bool is_server);
+
 #endif


### PR DESCRIPTION
The SSH shell ("net ssh start"/"net ssh stop") already provides client connection management, so the sample does not duplicate it. Instead it shows how an application can create and remove SSH channels on top of an existing connection.

Register a global client transport callback to record the authenticated client connections, and add a "sample" shell command set:

* `open`  creates a channel on the client connection.
* `close <channel>` removes a channel.
* `info` lists the active transports and open channels.
 
A global server transport callback records the connected clients so they can be shown by the info command as well. The transport and channel bookkeeping is updated from the SSH server and client threads and read from the shell thread, and is protected by a mutex. The server and client specific parts are guarded by CONFIG_SSH_SERVER and CONFIG_SSH_CLIENT so that the sample builds with either or both roles enabled.

