### PR TITLE
subsys: shell: add command chaining

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -159,6 +159,16 @@ config SHELL_WILDCARD
 	help
 	  Enables using wildcards: * and ? in the shell.
 
+config SHELL_CMD_AND
+	bool "'&&' conditional command chaining in shell"
+	default y if !SHELL_MINIMAL
+	help
+	  Enables chaining commands on a single line with the '&&' operator,
+	  e.g. "cmd1 && cmd2 && cmd3". Each command is executed only if the
+	  preceding one succeeded (returned 0). Execution of the chain stops
+	  at the first command that fails. Tab completion is supported for
+	  the command following an '&&'.
+
 config SHELL_MSG_CMD_NOT_FOUND
 	bool "': command not found' message in the shell"
 	default y

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -339,6 +339,7 @@ static bool tab_prepare(const struct shell *sh,
 	size_t search_argc;
 	bool select_cmd;
 	bool strip_select_cmd = false;
+	char *cmd_compl;
 	int space;
 	int ret;
 
@@ -351,6 +352,14 @@ static bool tab_prepare(const struct shell *sh,
 			sh->ctx->cmd_buff_pos);
 	sh->ctx->temp_buff[sh->ctx->cmd_buff_pos] = '\0';
 
+	/* Completion always operates on the command currently being typed. With
+	 * "&&" chaining enabled that is the segment following the last operator.
+	 */
+	cmd_compl = sh->ctx->temp_buff;
+#ifdef CONFIG_SHELL_CMD_AND
+	cmd_compl = z_shell_and_last_segment(cmd_compl);
+#endif
+
 	/* If last command is not completed (followed by space) it is treated
 	 * as uncompleted one.
 	 */
@@ -360,19 +369,20 @@ static bool tab_prepare(const struct shell *sh,
 	select_cmd = (IS_ENABLED(CONFIG_SHELL_CMDS_SELECT) ||
 		      (CONFIG_SHELL_CMD_ROOT[0] != 0)) &&
 		     !z_shell_in_select_mode(sh) &&
-		     command_starts_with(sh->ctx->temp_buff, "select");
+		     command_starts_with(cmd_compl, "select");
 
 	*alias_completion = !select_cmd;
 
 	if (*alias_completion &&
-	    alias_expansion_needed(sh->ctx->temp_buff, space)) {
-		ret = z_shell_expand_alias(sh->ctx->temp_buff,
-					   sizeof(sh->ctx->temp_buff));
+	    alias_expansion_needed(cmd_compl, space)) {
+		ret = z_shell_expand_alias(cmd_compl,
+					   sizeof(sh->ctx->temp_buff) -
+						   (cmd_compl - sh->ctx->temp_buff));
 		ARG_UNUSED(ret);
 	}
 
 	/* Create argument list. */
-	(void)z_shell_make_argv(argc, *argv, sh->ctx->temp_buff,
+	(void)z_shell_make_argv(argc, *argv, cmd_compl,
 				CONFIG_SHELL_ARGC_MAX);
 
 	if (*argc > CONFIG_SHELL_ARGC_MAX) {
@@ -1046,7 +1056,7 @@ static bool wildcard_check_report(const struct shell *sh, bool found,
  * Because of that feature, command buffer is processed argument by argument and
  * decision on further processing is based on currently processed command.
  */
-static int execute(const struct shell *sh)
+static int execute_cmd_buff(const struct shell *sh)
 {
 	struct shell_static_entry dloc = {0}; /* Memory for dynamic commands. */
 	const char *argv[CONFIG_SHELL_ARGC_MAX + 1] = {0}; /* +1 reserved for NULL */
@@ -1062,18 +1072,7 @@ static int execute(const struct shell *sh)
 	char *cmd_buf = sh->ctx->cmd_buff;
 	bool has_last_handler = false;
 
-	z_shell_op_cursor_end_move(sh);
-	if (!z_shell_cursor_in_empty_line(sh)) {
-		z_cursor_next_line_move(sh);
-	}
-
 	memset(&sh->ctx->active_cmd, 0, sizeof(sh->ctx->active_cmd));
-
-	if (IS_ENABLED(CONFIG_SHELL_HISTORY)) {
-		z_shell_cmd_trim(sh);
-		history_put(sh, sh->ctx->cmd_buff,
-			    sh->ctx->cmd_buff_len);
-	}
 
 	if (IS_ENABLED(CONFIG_SHELL_WILDCARD)) {
 		z_shell_wildcard_prepare(sh);
@@ -1246,6 +1245,55 @@ static int execute(const struct shell *sh)
 
 	/* Executing the deepest found handler. */
 	return exec_cmd(sh, cmd_lvl, argv, cmd_with_handler_lvl, &help_entry);
+}
+
+static int execute(const struct shell *sh)
+{
+	int ret_val;
+
+	z_shell_op_cursor_end_move(sh);
+	if (!z_shell_cursor_in_empty_line(sh)) {
+		z_cursor_next_line_move(sh);
+	}
+
+	if (IS_ENABLED(CONFIG_SHELL_HISTORY)) {
+		z_shell_cmd_trim(sh);
+		history_put(sh, sh->ctx->cmd_buff, sh->ctx->cmd_buff_len);
+	}
+
+#ifdef CONFIG_SHELL_CMD_AND
+	/* Execute each command in a "cmd1 && cmd2 && ..." chain in turn,
+	 * stopping as soon as one of them fails (returns non-zero). The
+	 * remaining chain is copied out before execution because alias
+	 * expansion and wildcard finalization may rewrite the command buffer.
+	 */
+	while (true) {
+		char next_cmd[CONFIG_SHELL_CMD_BUFF_SIZE];
+		char *next = z_shell_and_split(sh->ctx->cmd_buff);
+		size_t len = 0U;
+
+		if (next != NULL) {
+			len = z_shell_strlen(next);
+			memcpy(next_cmd, next, len + 1);
+		}
+
+		ret_val = execute_cmd_buff(sh);
+
+		if ((next == NULL) || (ret_val != 0)) {
+			break;
+		}
+
+		memcpy(sh->ctx->cmd_buff, next_cmd, len + 1);
+		sh->ctx->cmd_buff_len = len;
+		sh->ctx->cmd_buff_pos = len;
+	}
+
+	return ret_val;
+#else
+	ret_val = execute_cmd_buff(sh);
+
+	return ret_val;
+#endif /* CONFIG_SHELL_CMD_AND */
 }
 
 static void toggle_logs_output(const struct shell *sh)

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -239,6 +239,77 @@ char z_shell_make_argv(size_t *argc, const char **argv, char *cmd,
 	return quote;
 }
 
+#ifdef CONFIG_SHELL_CMD_AND
+/* Scan a command string for the first unquoted "&&" operator. If one is found,
+ * it is replaced with a string terminator so that the preceding command can be
+ * executed on its own, and a pointer to the start of the remaining chain (the
+ * part following "&&") is returned. Returns NULL when no "&&" is present.
+ */
+char *z_shell_and_split(char *cmd)
+{
+	char quote = 0;
+
+	while (*cmd != '\0') {
+		char c = *cmd;
+
+		if (quote != 0) {
+			if (c == quote) {
+				quote = 0;
+			}
+		} else if (c == '\\') {
+			/* Escaped character - skip whatever follows it. */
+			if (cmd[1] != '\0') {
+				cmd++;
+			}
+		} else if ((c == '\'') || (c == '"')) {
+			quote = c;
+		} else if ((c == '&') && (cmd[1] == '&')) {
+			*cmd = '\0';
+			return cmd + 2;
+		}
+
+		cmd++;
+	}
+
+	return NULL;
+}
+
+/* Return a pointer to the start of the last command in a "cmd1 && cmd2 && ..."
+ * chain, i.e. the text following the last unquoted "&&" operator. When no
+ * operator is present the original string is returned. Used so that tab
+ * completion operates on the command currently being typed after an "&&".
+ */
+char *z_shell_and_last_segment(char *cmd)
+{
+	char quote = 0;
+	char *segment = cmd;
+
+	while (*cmd != '\0') {
+		char c = *cmd;
+
+		if (quote != 0) {
+			if (c == quote) {
+				quote = 0;
+			}
+		} else if (c == '\\') {
+			if (cmd[1] != '\0') {
+				cmd++;
+			}
+		} else if ((c == '\'') || (c == '"')) {
+			quote = c;
+		} else if ((c == '&') && (cmd[1] == '&')) {
+			cmd += 2;
+			segment = cmd;
+			continue;
+		}
+
+		cmd++;
+	}
+
+	return segment;
+}
+#endif /* CONFIG_SHELL_CMD_AND */
+
 void z_shell_pattern_remove(char *buff, uint16_t *buff_len, const char *pattern)
 {
 	char *pattern_addr = strstr(buff, pattern);

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -39,6 +39,11 @@ static inline uint16_t z_shell_strlen(const char *str)
 char z_shell_make_argv(size_t *argc, const char **argv,
 		       char *cmd, uint8_t max_argc);
 
+#ifdef CONFIG_SHELL_CMD_AND
+char *z_shell_and_split(char *cmd);
+char *z_shell_and_last_segment(char *cmd);
+#endif
+
 /** @brief Removes pattern and following space
  *
  */

--- a/tests/subsys/shell/shell/src/main.c
+++ b/tests/subsys/shell/shell/src/main.c
@@ -22,6 +22,10 @@ static char dynamic_cmd_buffer[][MAX_CMD_SYNTAX_LEN] = {
 		"command"
 };
 
+/* Number of times the test_and command handler has been invoked. */
+static int and_test_count;
+static int and_wildcard_test_count;
+
 static void test_shell_execute_cmd(const char *cmd, int result)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
@@ -332,6 +336,83 @@ ZTEST(sh, test_shell_module)
 	test_shell_execute_cmd("not existing command", -ENOEXEC);
 }
 
+/* test '&&' conditional command chaining */
+ZTEST(sh, test_cmd_and)
+{
+	if (!IS_ENABLED(CONFIG_SHELL_CMD_AND)) {
+		ztest_test_skip();
+	}
+
+	/* Whole chain succeeds: every command runs. */
+	and_test_count = 0;
+	test_shell_execute_cmd("test_and && test_and && test_and", 0);
+	zassert_equal(and_test_count, 3, "All commands in the chain should run");
+
+	/* First command fails: the rest of the chain is skipped. */
+	and_test_count = 0;
+	test_shell_execute_cmd("test_and fail && test_and", -EINVAL);
+	zassert_equal(and_test_count, 1, "Chain must stop after a failure");
+
+	/* Failure in the middle stops the remaining commands. */
+	and_test_count = 0;
+	test_shell_execute_cmd("test_and && test_and fail && test_and", -EINVAL);
+	zassert_equal(and_test_count, 2, "Chain must stop at the failing command");
+
+	/* An unknown command also stops the chain. */
+	and_test_count = 0;
+	test_shell_execute_cmd("not_a_command && test_and", -ENOEXEC);
+	zassert_equal(and_test_count, 0, "Nothing runs after a failed lookup");
+
+	/* A quoted "&&" is a literal argument, not an operator. */
+	and_test_count = 0;
+	test_shell_execute_cmd("test_and \"&&\" test_and", 0);
+	zassert_equal(and_test_count, 1, "Quoted && must not split the command");
+}
+
+ZTEST(sh, test_cmd_and_alias_expansion)
+{
+	if (!IS_ENABLED(CONFIG_SHELL_CMD_AND) ||
+	    !IS_ENABLED(CONFIG_SHELL_ALIASES) || !SHELL_ALIASES_FILE) {
+		ztest_test_skip();
+	}
+
+	and_test_count = 0;
+	test_shell_execute_cmd("zzcmd && test_and", 0);
+	zassert_equal(and_test_count, 1,
+		      "Command after alias expansion should still run");
+}
+
+ZTEST(sh, test_cmd_and_wildcard_expansion)
+{
+	if (!IS_ENABLED(CONFIG_SHELL_CMD_AND) ||
+	    !IS_ENABLED(CONFIG_SHELL_WILDCARD)) {
+		ztest_test_skip();
+	}
+
+	and_test_count = 0;
+	and_wildcard_test_count = 0;
+	test_shell_execute_cmd("test_and_wildcard a* && test_and", 0);
+	zassert_equal(and_wildcard_test_count, 1,
+		      "Wildcard command before && should run once");
+	zassert_equal(and_test_count, 1,
+		      "Command after wildcard expansion should still run");
+}
+
+/* test tab completion of the command following an '&&' */
+ZTEST(sh, test_and_tab_completion)
+{
+	const struct shell *sh = shell_backend_dummy_get_ptr();
+
+	if (!IS_ENABLED(CONFIG_SHELL_CMD_AND) ||
+	    !IS_ENABLED(CONFIG_SHELL_TAB_AUTOCOMPLETION)) {
+		ztest_test_skip();
+	}
+
+	test_shell_reset_state(sh);
+	test_shell_push_input(sh, "test_and && test_wild\t");
+	test_shell_wait_for_cmd(sh, "test_and && test_wildcard ");
+}
+
 /* test wildcard and static subcommands */
 ZTEST(sh, test_shell_wildcards_static)
 {
@@ -394,6 +475,27 @@ SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_test_shell_cmdl,
 );
 SHELL_CMD_REGISTER(test_wildcard, &m_sub_test_shell_cmdl, NULL, cmd_wildcard);
 
+static int cmd_and_wildcard(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+
+	and_wildcard_test_count++;
+
+	if ((argc < 2) || (strcmp(argv[1], "alpha") != 0)) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_test_and_wildcard,
+	SHELL_CMD(alpha, NULL, NULL, NULL),
+	SHELL_CMD(beta, NULL, NULL, NULL),
+	SHELL_SUBCMD_SET_END
+);
+SHELL_CMD_REGISTER(test_and_wildcard, &m_sub_test_and_wildcard, NULL,
+		   cmd_and_wildcard);
+
 
 static int cmd_dynamic(const struct shell *sh, size_t argc, char **argv)
 {
@@ -433,6 +535,23 @@ static void dynamic_cmd_get(size_t idx, struct shell_static_entry *entry)
 
 SHELL_DYNAMIC_CMD_CREATE(m_sub_test_dynamic, dynamic_cmd_get);
 SHELL_CMD_REGISTER(test_dynamic, &m_sub_test_dynamic, NULL, cmd_dynamic);
+
+/* Counts how many times it has been invoked so command chaining can be
+ * verified. Returns failure when the first argument is "fail".
+ */
+static int cmd_and_test(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+
+	and_test_count++;
+
+	if ((argc > 1) && (strcmp(argv[1], "fail") == 0)) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+SHELL_CMD_REGISTER(test_and, NULL, NULL, cmd_and_test);
 
 static void unselect_cmd(void)
 {


### PR DESCRIPTION
Adds conditional '&&' operator for chaining shell commands, gated by CONFIG_SHELL_CMD_AND