### PR TITLE
drivers: usb_c: tcpc: stm32: drop usage of LL_UCPD_Init()

### DIFF
--- a/drivers/usb_c/tcpc/Kconfig.tcpc_stm32
+++ b/drivers/usb_c/tcpc/Kconfig.tcpc_stm32
@@ -8,7 +8,6 @@ config USBC_TCPC_STM32
 	default y
 	depends on DT_HAS_ST_STM32_UCPD_ENABLED
 	select PINCTRL
-	select USE_STM32_LL_UCPD
 	help
 	  Enable USB-C TCPC support on the STM32 G0, G4, L5, and U5 family of
 	  processors.

--- a/drivers/usb_c/tcpc/ucpd_stm32.c
+++ b/drivers/usb_c/tcpc/ucpd_stm32.c
@@ -1405,8 +1405,6 @@ static void config_tcpc_irq(void)
 	}
 }
 
-BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 0, "No compatible STM32 TCPC instance found");
-
 #define TCPC_DRIVER_INIT(inst)                                                                     \
 	PINCTRL_DT_INST_DEFINE(inst);                                                              \
 	static struct tcpc_data drv_data_##inst;                                                   \

--- a/drivers/usb_c/tcpc/ucpd_stm32.c
+++ b/drivers/usb_c/tcpc/ucpd_stm32.c
@@ -1310,6 +1310,7 @@ static void ucpd_isr_init(const struct device *dev)
  */
 static int ucpd_init(const struct device *dev)
 {
+	const struct device *const rcc = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct tcpc_config *const config = dev->config;
 	struct tcpc_data *data = dev->data;
 	uint32_t cfg1;
@@ -1322,14 +1323,13 @@ static int ucpd_init(const struct device *dev)
 		return ret;
 	}
 
-	/*
-	 * The UCPD port is disabled in the LL_UCPD_Init function
-	 *
-	 * NOTE: For proper Power Management operation, this function
-	 *       should not be used because it circumvents the zephyr
-	 *	 clock API. Instead, DTS clock settings and the zephyr
-	 *	 clock API should be used to enable clocks.
-	 */
+	ret = clock_control_on(rcc, (clock_control_subsys_t *)&config->pclken);
+	if (ret != 0) {
+		LOG_ERR("UCPD clock enable failed (%d)", ret);
+		return ret;
+	}
+
+	/* N.B.: The UCPD port is disabled in the LL_UCPD_Init function */
 	ret = LL_UCPD_Init(config->ucpd_port, (LL_UCPD_InitTypeDef *)&config->ucpd_params);
 
 	if (ret == SUCCESS) {
@@ -1411,6 +1411,7 @@ static void config_tcpc_irq(void)
 	static const struct tcpc_config drv_config_##inst = {                                      \
 		.ucpd_pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                 \
 		.ucpd_port = (UCPD_TypeDef *)DT_INST_REG_ADDR(inst),                               \
+		.pclken = STM32_DT_INST_CLOCKS(inst),                                              \
 		.ucpd_params.psc_ucpdclk =                                                         \
 			(ilog2(DT_INST_PROP(inst, psc_ucpdclk)) << UCPD_CFG1_PSC_UCPDCLK_Pos),     \
 		.ucpd_params.transwin = DT_INST_PROP(inst, transwin) - 1,                          \

--- a/drivers/usb_c/tcpc/ucpd_stm32.c
+++ b/drivers/usb_c/tcpc/ucpd_stm32.c
@@ -1329,41 +1329,42 @@ static int ucpd_init(const struct device *dev)
 		return ret;
 	}
 
-	/* N.B.: The UCPD port is disabled in the LL_UCPD_Init function */
-	ret = LL_UCPD_Init(config->ucpd_port, (LL_UCPD_InitTypeDef *)&config->ucpd_params);
+	/* Disable the UCPD port before configuration */
+	LL_UCPD_Disable(config->ucpd_port);
+	LL_UCPD_SetPSCClk(config->ucpd_port,
+		config->ucpd_clk_prescaler << UCPD_CFG1_PSC_UCPDCLK_Pos);
+	LL_UCPD_SetTransWin(config->ucpd_port, config->transition_window);
+	LL_UCPD_SetIfrGap(config->ucpd_port, config->interframe_gap);
+	LL_UCPD_SetHbitClockDiv(config->ucpd_port, config->halfbit_clock_div);
 
-	if (ret == SUCCESS) {
-		/* Init Rp to USB */
-		data->rp = TC_RP_USB;
+	/* Init Rp to USB */
+	data->rp = TC_RP_USB;
 
-		/*
-		 * Set RXORDSETEN field to control which types of ordered sets the PD
-		 * receiver must receive.
-		 */
-		cfg1 = stm32_reg_read(&config->ucpd_port->CFG1);
-		cfg1 |= LL_UCPD_ORDERSET_SOP | LL_UCPD_ORDERSET_SOP1 | LL_UCPD_ORDERSET_SOP2 |
-			LL_UCPD_ORDERSET_HARDRST;
-		stm32_reg_write(&config->ucpd_port->CFG1, cfg1);
+	/*
+	 * Set RXORDSETEN field to control which types of ordered sets the PD
+	 * receiver must receive.
+	 */
+	cfg1 = stm32_reg_read(&config->ucpd_port->CFG1);
+	cfg1 |= LL_UCPD_ORDERSET_SOP | LL_UCPD_ORDERSET_SOP1 | LL_UCPD_ORDERSET_SOP2 |
+		LL_UCPD_ORDERSET_HARDRST;
+	stm32_reg_write(&config->ucpd_port->CFG1, cfg1);
 
-		/* Enable UCPD port */
-		LL_UCPD_Enable(config->ucpd_port);
+	/* Enable UCPD port */
+	LL_UCPD_Enable(config->ucpd_port);
 
-		/* Enable Dead Battery Support */
-		if (config->ucpd_dead_battery) {
-			dead_battery(dev, true);
-		} else {
-			/*
-			 * Some devices have dead battery enabled by default
-			 * after power up, so disable it
-			 */
-			dead_battery(dev, false);
-		}
-
-		/* Initialize the isr */
-		ucpd_isr_init(dev);
+	/* Enable Dead Battery Support */
+	if (config->ucpd_dead_battery) {
+		dead_battery(dev, true);
 	} else {
-		return -EIO;
+		/*
+		 * Some devices have dead battery enabled by default
+		 * after power up, so disable it
+		 */
+		dead_battery(dev, false);
 	}
+
+	/* Initialize the isr */
+	ucpd_isr_init(dev);
 
 	return 0;
 }
@@ -1412,11 +1413,10 @@ static void config_tcpc_irq(void)
 		.ucpd_pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                 \
 		.ucpd_port = (UCPD_TypeDef *)DT_INST_REG_ADDR(inst),                               \
 		.pclken = STM32_DT_INST_CLOCKS(inst),                                              \
-		.ucpd_params.psc_ucpdclk =                                                         \
-			(ilog2(DT_INST_PROP(inst, psc_ucpdclk)) << UCPD_CFG1_PSC_UCPDCLK_Pos),     \
-		.ucpd_params.transwin = DT_INST_PROP(inst, transwin) - 1,                          \
-		.ucpd_params.IfrGap = DT_INST_PROP(inst, ifrgap) - 1,                              \
-		.ucpd_params.HbitClockDiv = DT_INST_PROP(inst, hbitclkdiv) - 1,                    \
+		.ucpd_clk_prescaler = ilog2(DT_INST_PROP(inst, psc_ucpdclk)),                      \
+		.transition_window = DT_INST_PROP(inst, transwin) - 1,                             \
+		.interframe_gap = DT_INST_PROP(inst, ifrgap) - 1,                                  \
+		.halfbit_clock_div = DT_INST_PROP(inst, hbitclkdiv) - 1,                           \
 		.ucpd_dead_battery = DT_INST_PROP(inst, dead_battery),                             \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, &ucpd_init, NULL, &drv_data_##inst, &drv_config_##inst,        \

--- a/drivers/usb_c/tcpc/ucpd_stm32_priv.h
+++ b/drivers/usb_c/tcpc/ucpd_stm32_priv.h
@@ -268,7 +268,10 @@ struct tcpc_config {
 	/* STM32 UCPD port */
 	UCPD_TypeDef *ucpd_port;
 	/* STM32 UCPD parameters */
-	LL_UCPD_InitTypeDef ucpd_params;
+	uint8_t ucpd_clk_prescaler;
+	uint8_t transition_window;
+	uint8_t interframe_gap;
+	uint8_t halfbit_clock_div;
 	/* STM32 UCPD dead battery support */
 	bool ucpd_dead_battery;
 };

--- a/drivers/usb_c/tcpc/ucpd_stm32_priv.h
+++ b/drivers/usb_c/tcpc/ucpd_stm32_priv.h
@@ -9,6 +9,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/usb_c/usbc_tcpc.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <stm32_ll_ucpd.h>
@@ -262,6 +263,8 @@ struct alert_info {
 struct tcpc_config {
 	/* STM32 UCPC CC pin control */
 	const struct pinctrl_dev_config *ucpd_pcfg;
+	/* STM32 UCPD clock control */
+	const struct stm32_pclken pclken[1];
 	/* STM32 UCPD port */
 	UCPD_TypeDef *ucpd_port;
 	/* STM32 UCPD parameters */


### PR DESCRIPTION
This function will not be present in STM32Cube HAL2 packages and adds a file to the build for next to no good reason. Replace it with standard clock control API calls for clock initialization and raw LL API usage for the reset.

The STM32 DTSI files already contain clock information for UCPD nodes so adding it as part of this PR is not necessary.