### PR TITLE
STM32: cleanup board overlays / shields with GPIO hogs

### DIFF
--- a/boards/shields/st_b_cams_imx_mb1854/Kconfig.defconfig
+++ b/boards/shields/st_b_cams_imx_mb1854/Kconfig.defconfig
@@ -3,18 +3,15 @@
 # Copyright (c) 2025 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-if VIDEO_STM32_DCMIPP
-
-config VIDEO_STM32_DCMIPP_SENSOR_PIXEL_FORMAT
+configdefault VIDEO_STM32_DCMIPP_SENSOR_PIXEL_FORMAT
 	default "pRAA"
 
-config VIDEO_STM32_DCMIPP_SENSOR_WIDTH
+configdefault VIDEO_STM32_DCMIPP_SENSOR_WIDTH
 	default 2592
 
-config VIDEO_STM32_DCMIPP_SENSOR_HEIGHT
+configdefault VIDEO_STM32_DCMIPP_SENSOR_HEIGHT
 	default 1944
 
-config GPIO_HOGS
-	default y
-
-endif # VIDEO_STM32_DCMIPP
+# GPIO driver is needed for the shield's GPIO hogs
+configdefault GPIO
+	default y if VIDEO_STM32_DCMIPP

--- a/samples/subsys/usb_c/sink/boards/nucleo_h563zi.conf
+++ b/samples/subsys/usb_c/sink/boards/nucleo_h563zi.conf
@@ -4,4 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_GPIO_HOGS=y
+# GPIO driver is needed for the board's GPIO hogs
+CONFIG_GPIO=y


### PR DESCRIPTION
A few overlays/shields still enable GPIO hogs the wrong way. Fix them.

cc @avolmat-st for st_b_cams_imx_mb1854