### PR TITLE
tests: arch/common/timing: fix build error with cpu masks

### DIFF
--- a/tests/arch/common/timing/src/main.c
+++ b/tests/arch/common/timing/src/main.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/arch/arch_interface.h>
 
-#if defined(CONFIG_SMP) && CONFIG_MP_MAX_NUM_CPUS > 1
+#if defined(CONFIG_SCHED_CPU_MASK) && (CONFIG_MP_MAX_NUM_CPUS > 1)
 #define SMP_TEST
 #endif
 


### PR DESCRIPTION
After commit c4b50e3bf37ca1279b21541b9653863bf4eec6ed, CONFIG_SCHED_CPU_MASK is no longer explicitly enabled. This results in build error where k_thread_cpu_mask_enable() was not defined with the disabled kconfig. So we need to be explicit when the SMP_TEST macro is defined, and it should only be enabled if CONFIG_SCHED_CPU_MASK is also defined. So add it.