### PR TITLE
soc: espressif: flash lp core image as a sysbuild image

### DIFF
--- a/boards/arduino/nesso_n1/arduino_nesso_n1_esp32c6_lpcore.dts
+++ b/boards/arduino/nesso_n1/arduino_nesso_n1_esp32c6_lpcore.dts
@@ -14,6 +14,7 @@
 	compatible = "arduino,nesso-n1";
 
 	chosen {
+		zephyr,flash = &flash0;
 		zephyr,sram = &ulp_ram;
 		zephyr,code-partition = &slot0_lpcore_partition;
 	};

--- a/boards/espressif/esp32c5_devkitc/esp32c5_devkitc_lpcore.dts
+++ b/boards/espressif/esp32c5_devkitc/esp32c5_devkitc_lpcore.dts
@@ -13,6 +13,7 @@
 	compatible = "espressif,esp32c5";
 
 	chosen {
+		zephyr,flash = &flash0;
 		zephyr,sram = &sramlp;
 		zephyr,code-partition = &slot0_lpcore_partition;
 		zephyr,console = &lp_uart;

--- a/boards/espressif/esp32c6_devkitc/esp32c6_devkitc_lpcore.dts
+++ b/boards/espressif/esp32c6_devkitc/esp32c6_devkitc_lpcore.dts
@@ -13,6 +13,7 @@
 	compatible = "espressif,esp32c6";
 
 	chosen {
+		zephyr,flash = &flash0;
 		zephyr,sram = &ulp_ram;
 		zephyr,code-partition = &slot0_lpcore_partition;
 		zephyr,console = &lp_uart;

--- a/boards/m5stack/m5stack_nanoc6/m5stack_nanoc6_lpcore.dts
+++ b/boards/m5stack/m5stack_nanoc6/m5stack_nanoc6_lpcore.dts
@@ -14,6 +14,7 @@
 	compatible = "m5stack,nanoc6";
 
 	chosen {
+		zephyr,flash = &flash0;
 		zephyr,sram = &ulp_ram;
 		zephyr,code-partition = &slot0_lpcore_partition;
 	};

--- a/boards/pcbcupid/glyph_c6/glyph_c6_lpcore.dts
+++ b/boards/pcbcupid/glyph_c6/glyph_c6_lpcore.dts
@@ -14,6 +14,7 @@
 	compatible = "pcbcupid,glyph-c6";
 
 	chosen {
+		zephyr,flash = &flash0;
 		zephyr,sram = &ulp_ram;
 		zephyr,code-partition = &slot0_lpcore_partition;
 	};

--- a/boards/seeed/xiao_esp32c5/xiao_esp32c5_lpcore.dts
+++ b/boards/seeed/xiao_esp32c5/xiao_esp32c5_lpcore.dts
@@ -12,6 +12,7 @@
 	compatible = "seeed,xiao-esp32c5";
 
 	chosen {
+		zephyr,flash = &flash0;
 		zephyr,sram = &sramlp;
 		zephyr,code-partition = &slot0_lpcore_partition;
 		zephyr,console = &lp_uart;

--- a/boards/seeed/xiao_esp32c6/xiao_esp32c6_lpcore.dts
+++ b/boards/seeed/xiao_esp32c6/xiao_esp32c6_lpcore.dts
@@ -13,6 +13,7 @@
 	compatible = "seeed,xiao-esp32c6";
 
 	chosen {
+		zephyr,flash = &flash0;
 		zephyr,sram = &ulp_ram;
 		zephyr,code-partition = &slot0_lpcore_partition;
 	};

--- a/boards/weact/esp32c6_mini/weact_esp32c6_mini_lpcore.dts
+++ b/boards/weact/esp32c6_mini/weact_esp32c6_mini_lpcore.dts
@@ -13,6 +13,7 @@
 	compatible = "weact,esp32c6-mini";
 
 	chosen {
+		zephyr,flash = &flash0;
 		zephyr,sram = &ulp_ram;
 		zephyr,code-partition = &slot0_lpcore_partition;
 		zephyr,console = &lp_uart;

--- a/samples/boards/espressif/ulp/lp_core/debug_ulp/sysbuild.cmake
+++ b/samples/boards/espressif/ulp/lp_core/debug_ulp/sysbuild.cmake
@@ -2,21 +2,14 @@
 #
 # Copyright 2025 Espressif
 
-# Add external project
 ExternalZephyrProject_Add(
     APPLICATION debug_ulp_lpcore
     SOURCE_DIR ${APP_DIR}/remote
     BOARD ${SB_CONFIG_ULP_REMOTE_BOARD}
   )
 
-# Add dependencies so that the remote sample will be built first
-# This is required because some primary cores need information from the
-# remote core's build, such as the output image's LMA
-add_dependencies(debug_ulp debug_ulp_lpcore)
-sysbuild_add_dependencies(CONFIGURE debug_ulp debug_ulp_lpcore)
 sysbuild_add_dependencies(FLASH debug_ulp_lpcore debug_ulp)
 
 if(SB_CONFIG_BOOTLOADER_MCUBOOT)
-  # Make sure MCUboot is flashed first
   sysbuild_add_dependencies(FLASH debug_ulp mcuboot)
 endif()

--- a/samples/boards/espressif/ulp/lp_core/echo_ulp/sysbuild.cmake
+++ b/samples/boards/espressif/ulp/lp_core/echo_ulp/sysbuild.cmake
@@ -2,21 +2,14 @@
 #
 # Copyright 2024 Espressif
 
-# Add external project
 ExternalZephyrProject_Add(
     APPLICATION echo_ulp_lpcore
     SOURCE_DIR ${APP_DIR}/remote
     BOARD ${SB_CONFIG_ULP_REMOTE_BOARD}
   )
 
-# Add dependencies so that the remote sample will be built first
-# This is required because some primary cores need information from the
-# remote core's build, such as the output image's LMA
-add_dependencies(echo_ulp echo_ulp_lpcore)
-sysbuild_add_dependencies(CONFIGURE echo_ulp echo_ulp_lpcore)
 sysbuild_add_dependencies(FLASH echo_ulp_lpcore echo_ulp)
 
 if(SB_CONFIG_BOOTLOADER_MCUBOOT)
-  # Make sure MCUboot is flashed first
   sysbuild_add_dependencies(FLASH echo_ulp mcuboot)
 endif()

--- a/samples/boards/espressif/ulp/lp_core/gpio_wakeup/sysbuild.cmake
+++ b/samples/boards/espressif/ulp/lp_core/gpio_wakeup/sysbuild.cmake
@@ -2,21 +2,14 @@
 #
 # Copyright 2026 Espressif Systems (Shanghai) Co., Ltd.
 
-# Add external project
 ExternalZephyrProject_Add(
     APPLICATION gpio_wakeup_lpcore
     SOURCE_DIR ${APP_DIR}/remote
     BOARD ${SB_CONFIG_ULP_REMOTE_BOARD}
   )
 
-# Add dependencies so that the remote sample will be built first
-# This is required because some primary cores need information from the
-# remote core's build, such as the output image's LMA
-add_dependencies(gpio_wakeup gpio_wakeup_lpcore)
-sysbuild_add_dependencies(CONFIGURE gpio_wakeup gpio_wakeup_lpcore)
 sysbuild_add_dependencies(FLASH gpio_wakeup_lpcore gpio_wakeup)
 
 if(SB_CONFIG_BOOTLOADER_MCUBOOT)
-  # Make sure MCUboot is flashed first
   sysbuild_add_dependencies(FLASH gpio_wakeup mcuboot)
 endif()

--- a/samples/boards/espressif/ulp/lp_core/interrupt_ulp/sysbuild.cmake
+++ b/samples/boards/espressif/ulp/lp_core/interrupt_ulp/sysbuild.cmake
@@ -2,21 +2,14 @@
 #
 # Copyright 2024 Espressif
 
-# Add external project
 ExternalZephyrProject_Add(
     APPLICATION interrupt_ulp_lpcore
     SOURCE_DIR ${APP_DIR}/remote
     BOARD ${SB_CONFIG_ULP_REMOTE_BOARD}
   )
 
-# Add dependencies so that the remote sample will be built first
-# This is required because some primary cores need information from the
-# remote core's build, such as the output image's LMA
-add_dependencies(interrupt_ulp interrupt_ulp_lpcore)
-sysbuild_add_dependencies(CONFIGURE interrupt_ulp interrupt_ulp_lpcore)
 sysbuild_add_dependencies(FLASH interrupt_ulp_lpcore interrupt_ulp)
 
 if(SB_CONFIG_BOOTLOADER_MCUBOOT)
-  # Make sure MCUboot is flashed first
   sysbuild_add_dependencies(FLASH interrupt_ulp mcuboot)
 endif()

--- a/samples/boards/espressif/ulp/lp_core/timer_wakeup/sysbuild.cmake
+++ b/samples/boards/espressif/ulp/lp_core/timer_wakeup/sysbuild.cmake
@@ -2,21 +2,14 @@
 #
 # Copyright 2026 Espressif Systems (Shanghai) Co., Ltd.
 
-# Add external project
 ExternalZephyrProject_Add(
     APPLICATION timer_wakeup_lpcore
     SOURCE_DIR ${APP_DIR}/remote
     BOARD ${SB_CONFIG_ULP_REMOTE_BOARD}
   )
 
-# Add dependencies so that the remote sample will be built first
-# This is required because some primary cores need information from the
-# remote core's build, such as the output image's LMA
-add_dependencies(timer_wakeup timer_wakeup_lpcore)
-sysbuild_add_dependencies(CONFIGURE timer_wakeup timer_wakeup_lpcore)
 sysbuild_add_dependencies(FLASH timer_wakeup_lpcore timer_wakeup)
 
 if(SB_CONFIG_BOOTLOADER_MCUBOOT)
-  # Make sure MCUboot is flashed first
   sysbuild_add_dependencies(FLASH timer_wakeup mcuboot)
 endif()

--- a/soc/espressif/common/CMakeLists.txt
+++ b/soc/espressif/common/CMakeLists.txt
@@ -57,12 +57,10 @@ else()
   file(WRITE "${_extram_inc}" "")
 endif()
 
-if(NOT (CONFIG_SOC_ESP32C5_LPCORE OR CONFIG_SOC_ESP32C6_LPCORE OR CONFIG_SOC_ESP32P4_LPCORE))
-  # Get flash size in MB for esptool from the chosen zephyr,flash node
-  dt_chosen(dts_flash PROPERTY "zephyr,flash")
-  dt_reg_size(flash_size_bytes PATH ${dts_flash})
-  math(EXPR esptoolpy_flashsize "${flash_size_bytes} / 0x100000")
-endif()
+# Get flash size in MB for esptool from the chosen zephyr,flash node
+dt_chosen(dts_flash PROPERTY "zephyr,flash")
+dt_reg_size(flash_size_bytes PATH ${dts_flash})
+math(EXPR esptoolpy_flashsize "${flash_size_bytes} / 0x100000")
 
 # Get UART baudrate from DT
 dt_chosen(dts_shell_uart PROPERTY "zephyr,shell-uart")

--- a/soc/espressif/esp32c5/hpcore_init_ulp.c
+++ b/soc/espressif/esp32c5/hpcore_init_ulp.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/storage/flash_map.h>
 
 #include "bootloader_flash_priv.h"
@@ -13,6 +14,8 @@
 #include <esp_sleep.h>
 #include <hal/lp_core_ll.h>
 #include <esp_private/esp_pmu.h>
+
+LOG_MODULE_REGISTER(lp_core_loader, CONFIG_KERNEL_LOG_LEVEL);
 
 void IRAM_ATTR lp_core_image_init(void)
 {
@@ -30,6 +33,12 @@ void IRAM_ATTR lp_core_image_init(void)
 	const uint32_t lpcore_img_size = CONFIG_ESP32_ULP_COPROC_RESERVE_MEM;
 
 	const uint8_t *data = (const uint8_t *)bootloader_mmap(lpcore_img_off, lpcore_img_size);
+
+	if (*(const uint32_t *)data == 0xffffffff) {
+		LOG_ERR("LP core partition at 0x%x is erased; LP image not flashed",
+			lpcore_img_off);
+		return;
+	}
 
 	if (ulp_lp_core_load_binary(data, lpcore_img_size) != 0) {
 		return;

--- a/soc/espressif/esp32c6/hpcore_init_ulp.c
+++ b/soc/espressif/esp32c6/hpcore_init_ulp.c
@@ -5,11 +5,14 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/storage/flash_map.h>
 
 #include "bootloader_flash_priv.h"
 #include "ulp_lp_core.h"
 #include <esp_sleep.h>
+
+LOG_MODULE_REGISTER(lp_core_loader, CONFIG_KERNEL_LOG_LEVEL);
 
 void IRAM_ATTR lp_core_image_init(void)
 {
@@ -25,6 +28,12 @@ void IRAM_ATTR lp_core_image_init(void)
 	const uint32_t lpcore_img_size = CONFIG_ESP32_ULP_COPROC_RESERVE_MEM;
 
 	const uint8_t *data = (const uint8_t *)bootloader_mmap(lpcore_img_off, lpcore_img_size);
+
+	if (*(const uint32_t *)data == 0xffffffff) {
+		LOG_ERR("LP core partition at 0x%x is erased; LP image not flashed",
+			lpcore_img_off);
+		return;
+	}
 
 	if (ulp_lp_core_load_binary(data, lpcore_img_size) != 0) {
 		return;


### PR DESCRIPTION
Make the LP core image a regular sysbuild sub-image flashed to slot0_lpcore_partition, so west flash writes MCUboot, HP and LP in order while on-chip behavior stays unchanged.