### PR TITLE
drivers: pwm: mcux_sctimer: configure initial output state from DT

### DIFF
--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -40,6 +40,7 @@ typedef struct pwm_channel_config {
 struct pwm_mcux_sctimer_config {
 	SCT_Type *base;
 	uint32_t prescale;
+	uint8_t out_init_state;
 	const struct pinctrl_dev_config *pincfg;
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
@@ -722,6 +723,7 @@ static int mcux_sctimer_pwm_init_common(const struct device *dev)
 	SCTIMER_GetDefaultConfig(&pwm_config);
 
 	pwm_config.prescale_l = config->prescale - 1;
+	pwm_config.outInitState = config->out_init_state;
 
 	status = SCTIMER_Init(config->base, &pwm_config);
 	if (status != kStatus_Success) {
@@ -837,6 +839,7 @@ static DEVICE_API(pwm, pwm_mcux_sctimer_driver_api) = {
 	static const struct pwm_mcux_sctimer_config pwm_mcux_sctimer_config_##n = { \
 		.base = (SCT_Type *)DT_INST_REG_ADDR(n),				\
 		.prescale = DT_INST_PROP(n, prescaler),					\
+		.out_init_state = DT_INST_PROP(n, out_init_state),			\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),			\
 		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\

--- a/dts/bindings/pwm/nxp,sctimer-pwm.yaml
+++ b/dts/bindings/pwm/nxp,sctimer-pwm.yaml
@@ -39,6 +39,14 @@ properties:
       - 0: kINPUTMUX_SctGpioInAToSct0 (GPIO to SCT input A)
       - 1: kINPUTMUX_SctGpioInBToSct0 (GPIO to SCT input B)
 
+  out-init-state:
+    type: int
+    default: 0
+    description: |
+      Initial output state applied at init Bitmask, one bit per output.
+      8-bit value. Maps to the MCUX SCTimer outInitState field.
+      Default to 0 (all low)
+
   "#pwm-cells":
     const: 3
 


### PR DESCRIPTION
The NXP SCTimer's outInitState field defines the output levels applied at initialization, before any PWM channel is configured. Needed for active low loads to not flicker at startup