### PR TITLE
xtensa: Fix NMI handling for custom approach

### DIFF
--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -504,28 +504,38 @@ __unused static void xtensa_handle_irq_lvl(int irq_lvl)
 		return return_to(interrupted_stack);                                               \
 	}
 
-#if MAX_INTR_LEVEL >= 2
+#if MAX_INTR_LEVEL >= 2 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 2)
 DEF_INT_C_HANDLER(2)
 #endif
 
-#if MAX_INTR_LEVEL >= 3
+#if MAX_INTR_LEVEL >= 3 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 3)
 DEF_INT_C_HANDLER(3)
 #endif
 
-#if MAX_INTR_LEVEL >= 4
+#if MAX_INTR_LEVEL >= 4 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 4)
 DEF_INT_C_HANDLER(4)
 #endif
 
-#if MAX_INTR_LEVEL >= 5
+#if MAX_INTR_LEVEL >= 5 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 5)
 DEF_INT_C_HANDLER(5)
 #endif
 
-#if MAX_INTR_LEVEL >= 6
+#if MAX_INTR_LEVEL >= 6 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 6)
 DEF_INT_C_HANDLER(6)
 #endif
 
-#if MAX_INTR_LEVEL >= 7
+#if MAX_INTR_LEVEL >= 7 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 7)
 DEF_INT_C_HANDLER(7)
+#endif
+
+#if XCHAL_HAVE_NMI
+__unused void *xtensa_nmi_c(void *interrupted_stack)
+{
+	usage_stop();
+	_sw_isr_table[XCHAL_NMI_INTERRUPT].isr(
+		_sw_isr_table[XCHAL_NMI_INTERRUPT].arg);
+	return return_to(interrupted_stack);
+}
 #endif
 
 static inline DEF_INT_C_HANDLER(1)

--- a/arch/xtensa/core/xtensa_asm2_util.S
+++ b/arch/xtensa/core/xtensa_asm2_util.S
@@ -383,40 +383,44 @@ DEF_EXCINT 1, _handle_excint, xtensa_excint1_c
 #define MAX_INTR_LEVEL 0
 #endif
 
-#if MAX_INTR_LEVEL >= 2
+#if MAX_INTR_LEVEL >= 2 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 2)
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 2))
 DEF_EXCINT 2, _handle_excint, xtensa_int2_c
 #endif
 #endif
 
-#if MAX_INTR_LEVEL >= 3
+#if MAX_INTR_LEVEL >= 3 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 3)
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 3))
 DEF_EXCINT 3, _handle_excint, xtensa_int3_c
 #endif
 #endif
 
-#if MAX_INTR_LEVEL >= 4
+#if MAX_INTR_LEVEL >= 4 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 4)
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 4))
 DEF_EXCINT 4, _handle_excint, xtensa_int4_c
 #endif
 #endif
 
-#if MAX_INTR_LEVEL >= 5
+#if MAX_INTR_LEVEL >= 5 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 5)
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 5))
 DEF_EXCINT 5, _handle_excint, xtensa_int5_c
 #endif
 #endif
 
-#if MAX_INTR_LEVEL >= 6
+#if MAX_INTR_LEVEL >= 6 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 6)
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 6))
 DEF_EXCINT 6, _handle_excint, xtensa_int6_c
 #endif
 #endif
 
-#if MAX_INTR_LEVEL >= 7
+#if MAX_INTR_LEVEL >= 7 && (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != 7)
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 7))
 DEF_EXCINT 7, _handle_excint, xtensa_int7_c
 #endif
+#endif
+
+#if XCHAL_HAVE_NMI
+DEF_EXCINT XCHAL_NMILEVEL, _handle_excint, xtensa_nmi_c
 #endif
 
 #if defined(CONFIG_GDBSTUB)


### PR DESCRIPTION
## Problem

The current level 7 interrupt handler uses `rsr.interrupt` dispatch with `intenable` masking. According to Xtensa ISA section 4.4.6.4, NMI uses a direct `NMIinput` hardware signal and explicitly ignores INTERRUPT/INTENABLE registers and CINTLEVEL masking and NMI is typically at level 7 (NLEVEL=6 + NNMI=1) in most Xtensa cores.

## Solution

Exclude the NMI level from the generic level-based handlers in both vector_handlers.c and xtensa_asm2_util.S using (!XCHAL_HAVE_NMI || XCHAL_NMILEVEL != N) guards. Add a dedicated xtensa_nmi_c() that skips register inspection and directly calls _sw_isr_table[XCHAL_NMI_INTERRUPT].