### PR TITLE
scripts: runners: fix flashing with minichlink

### DIFF
--- a/boards/muselab/nano_ch32v317/board.cmake
+++ b/boards/muselab/nano_ch32v317/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 James Bennion-Pedley
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(minichlink "--dt-flash=y")
+board_runner_args(minichlink)
 board_runner_args(wlink "--chip=CH32V317")
 board_runner_args(wchisp)
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)

--- a/boards/wch/ch32v303vct6_evt/board.cmake
+++ b/boards/wch/ch32v303vct6_evt/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Bootlin
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(minichlink "--dt-flash=y")
+board_runner_args(minichlink)
 board_runner_args(wlink "--chip=CH32V30X")
 board_runner_args(wchisp)
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)

--- a/boards/wch/ch32v305f_evt_r0/board.cmake
+++ b/boards/wch/ch32v305f_evt_r0/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 James Bennion-Pedley
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(minichlink "--dt-flash=y")
+board_runner_args(minichlink)
 board_runner_args(wlink "--chip=CH32V30X")
 board_runner_args(wchisp)
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)

--- a/boards/wch/ch32v307v_evt_r1/board.cmake
+++ b/boards/wch/ch32v307v_evt_r1/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Michael Hope
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(minichlink "--dt-flash=y")
+board_runner_args(minichlink)
 board_runner_args(wlink "--chip=CH32V30X")
 board_runner_args(wchisp)
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)

--- a/dts/riscv/wch/ch32v0/ch32v003.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v003.dtsi
@@ -55,9 +55,9 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			flash0: flash@0 {
+			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
-				reg = <0 DT_SIZE_K(16)>;
+				reg = <0x8000000 DT_SIZE_K(16)>;
 			};
 		};
 

--- a/dts/riscv/wch/ch32v0/ch32v006.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v006.dtsi
@@ -55,9 +55,9 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			flash0: flash@0 {
+			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
-				reg = <0 DT_SIZE_K(62)>;
+				reg = <0x8000000 DT_SIZE_K(62)>;
 			};
 		};
 

--- a/scripts/west_commands/runners/minichlink.py
+++ b/scripts/west_commands/runners/minichlink.py
@@ -18,7 +18,6 @@ class MiniChLinkBinaryRunner(ZephyrBinaryRunner):
         minichlink: str,
         erase: bool,
         reset: bool,
-        dt_flash: bool,
         terminal: bool,
     ):
         super().__init__(cfg)
@@ -26,7 +25,6 @@ class MiniChLinkBinaryRunner(ZephyrBinaryRunner):
         self.minichlink = minichlink
         self.erase = erase
         self.reset = reset
-        self.dt_flash = dt_flash
         self.terminal = terminal
 
     @classmethod
@@ -57,7 +55,6 @@ class MiniChLinkBinaryRunner(ZephyrBinaryRunner):
             minichlink=args.minichlink,
             erase=args.erase,
             reset=args.reset,
-            dt_flash=args.dt_flash,
             terminal=args.terminal,
         )
 
@@ -77,10 +74,7 @@ class MiniChLinkBinaryRunner(ZephyrBinaryRunner):
         if self.erase:
             cmd.append("-E")
 
-        flash_addr = 0
-        if self.dt_flash:
-            flash_addr = self.flash_address_from_build_conf(self.build_conf)
-
+        flash_addr = self.flash_address_from_build_conf(self.build_conf)
         cmd.extend(["-w", self.cfg.bin_file or "", f"0x{flash_addr:x}"])
 
         if self.reset or self.terminal:


### PR DESCRIPTION
The flash on the ch32v series starts at 0x8000000 and, depending on
the system configuration, is aliased to 0x0. When the ch32v003 support
was first submitted, `minichlink` would accept either the real or the
alised address, but became stricter sometime in the last two years.

Fix the base address in the ch32v00{3,6}.dtsi, change
`minichlink.py` to always use the flash address from the build
configuration, and remove the `--dt-flash=y` work-arounds from the
more recent board configurations.

Tested by building `hello_world` for `ch32v003evt`, `ch32v006evt`,
`bluepillplus_ch32v203`, `ch32v303vct6_evt`, and `ch32v307v_evt_r1`;
running `west -v flash` and checking the command uses `0x8000000`.