### PR TITLE
MAINTAINERS: add hasheddan as collaborator on Bouffalo Lab platform

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -824,6 +824,7 @@ Bouffalolab Platforms:
   maintainers:
     - VynDragon
   collaborators:
+    - hasheddan
     - josuah
     - will-tm
   files:


### PR DESCRIPTION
Adds hasheddan as a collaborator on the Bouffalo Lab platform.


Looking forward to supporting the awesome existing team. See https://github.com/zephyrproject-rtos/zephyr/issues/110340 for list of contributions / reviews / etc.