### PR TITLE
[Backport v3.7-branch] drivers: wifi: esp32: reset data->scan_cb on fail

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -493,7 +493,8 @@ static int esp32_wifi_scan(const struct device *dev,
 	ret |= esp_wifi_scan_start(&scan_config, false);
 
 	if (ret != ESP_OK) {
-		LOG_ERR("Failed to start Wi-Fi scanning");
+		LOG_ERR("Failed to start Wi-Fi scanning (%d)", ret);
+		data->scan_cb = NULL;
 		return -EAGAIN;
 	}
 


### PR DESCRIPTION
Backport 290152a9d1241b3bf32b49104433f67dc7ec53a8 from #106329.

_Original PR description:_

---

reset data->scan_cb on fail, otherwise we can't try it again, because we check it at the beginning and return when it is already set.

Manually rebased due to conflicts.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/110290


