### PR TITLE
dts: arm: rpi_pico: Split mailbox interrupts into separate nodes

### DIFF
--- a/drivers/mbox/mbox_rpi_pico.c
+++ b/drivers/mbox/mbox_rpi_pico.c
@@ -24,7 +24,7 @@
 LOG_MODULE_REGISTER(mbox_rpi_pico, CONFIG_MBOX_LOG_LEVEL);
 
 #define MAILBOX_MBOX_SIZE sizeof(uint32_t)
-#define MAILBOX_DEV_NAME mbox0
+#define MAILBOX_DEV_NAME mbox
 
 struct rpi_pico_mailbox_data {
 	const struct device *dev;

--- a/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
@@ -443,11 +443,23 @@
 			compatible = "raspberrypi,pico-sio";
 			reg = <0xd0000000 0x180>;
 
-			mbox: mbox {
+			/*
+			 * Interrupt numbers are core-specific, so enable the correct
+			 * one for the respective IPM instance below.
+			 */
+			mbox0: mbox-core-0 {
 				compatible = "raspberrypi,pico-mbox";
-				interrupts = <15 RPI_PICO_DEFAULT_IRQ_PRIORITY>,
-					     <16 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
-				interrupt-names = "mbox0", "mbox1";
+				interrupts = <15 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
+				interrupt-names = "mbox";
+				fifo-depth = <8>;
+				#mbox-cells = <0>;
+				status = "disabled";
+			};
+
+			mbox1: mbox-core-1 {
+				compatible = "raspberrypi,pico-mbox";
+				interrupts = <16 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
+				interrupt-names = "mbox";
 				fifo-depth = <8>;
 				#mbox-cells = <0>;
 				status = "disabled";
@@ -455,15 +467,22 @@
 		};
 	};
 
-	ipm_mbox: ipm-mbox {
-		/*
-		 * The zephyr,mbox-ipm driver expects two mailbox
-		 * channels, but the mailbox block in the RP2040
-		 * implements a single instance per core. Point the
-		 * two driver channels to the same single mbox.
-		 */
+	/*
+	 * The zephyr,mbox-ipm driver expects two mailbox
+	 * channels, but the mailbox block in the RP2040
+	 * implements a single instance per core. Point the
+	 * two driver channels to the same single mbox.
+	 */
+	ipm_mbox0: ipm-mbox-core-0 {
 		compatible = "zephyr,mbox-ipm";
-		mboxes = <&mbox>, <&mbox>;
+		mboxes = <&mbox0>, <&mbox0>;
+		mbox-names = "tx", "rx";
+		status = "disabled";
+	};
+
+	ipm_mbox1: ipm-mbox-core-1 {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox1>, <&mbox1>;
 		mbox-names = "tx", "rx";
 		status = "disabled";
 	};

--- a/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi
+++ b/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi
@@ -487,7 +487,7 @@
 			mbox: mbox {
 				compatible = "raspberrypi,pico-mbox";
 				interrupts = <25 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
-				interrupt-names = "mbox0";
+				interrupt-names = "mbox";
 				fifo-depth = <4>;
 				#mbox-cells = <0>;
 				status = "disabled";


### PR DESCRIPTION
On the RP2040, interrupt 15 is used for the RX FIFO on core 0, and interrupt 16 is used for the RX FIFO on core 1. By splitting the mailbox node into separate ones for each core, the correct interrupt for each core can be selectively enabled in an overlay.

This benefits AMP use cases with the RP2040 where each core runs its own distinct application. Without this, only the interrupt for core 0 would be enabled.

In practice, the device tree overlay for the core 0 application would look like:
```
&mbox0 {
	status = "okay";
};

&ipm_mbox0 {
	status = "okay";
};
```
and the core 1 application:
```
&mbox1 {
	status = "okay";
};

&ipm_mbox1 {
	status = "okay";
};
```