### PR TITLE
Use net_eth_set_if_type_wifi() API to set ethernet context to Wi-Fi

### DIFF
--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -263,12 +263,11 @@ static void esp_hosted_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	esp_hosted_data_t *data = dev->data;
-	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 	struct wifi_nm_instance *nm = wifi_nm_get_instance("nm");
 	size_t itf = esp_hosted_get_iface(dev);
 
 	data->iface[itf] = iface;
-	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
+	net_eth_set_if_type_wifi(iface);
 
 	/* Set mac address. */
 	net_if_set_link_addr(iface, data->mac_addr[itf], 6, NET_LINK_ETHERNET);

--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -512,9 +512,8 @@ static void airoc_mgmt_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct airoc_wifi_data *data = dev->data;
-	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 
-	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
+	net_eth_set_if_type_wifi(iface);
 	data->iface = iface;
 	airoc_wifi_iface = iface;
 

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -684,7 +684,6 @@ void nrf_wifi_if_init_zep(struct net_if *iface)
 	const struct device *dev = NULL;
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
-	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 
 	if (!iface) {
 		LOG_ERR("%s: Invalid parameters",
@@ -719,7 +718,7 @@ void nrf_wifi_if_init_zep(struct net_if *iface)
 	vif_ctx_zep->zep_net_if_ctx = iface;
 	vif_ctx_zep->zep_dev_ctx = dev;
 
-	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
+	net_eth_set_if_type_wifi(iface);
 	ethernet_init(iface);
 	net_eth_carrier_on(iface);
 	net_if_dormant_on(iface);

--- a/drivers/wifi/nxp/src/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_drv.c
@@ -2008,10 +2008,9 @@ static int nxp_wifi_ap_set_rts_threshold(const struct device *dev,
 static void nxp_wifi_sta_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 	struct interface *intf = dev->data;
 
-	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
+	net_eth_set_if_type_wifi(iface);
 	intf->netif = iface;
 #ifdef CONFIG_WIFI_NM
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT
@@ -2048,11 +2047,10 @@ static void nxp_wifi_sta_init(struct net_if *iface)
 static void nxp_wifi_uap_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 	struct interface *intf = dev->data;
 	int ret;
 
-	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
+	net_eth_set_if_type_wifi(iface);
 	intf->netif = iface;
 
 #ifdef CONFIG_WIFI_NM

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -364,11 +364,8 @@ static int siwx91x_set_config(const struct device *dev,
 
 static void siwx91x_ethernet_init(struct net_if *iface)
 {
-	struct ethernet_context *eth_ctx;
-
 	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_NATIVE)) {
-		eth_ctx = net_if_l2_data(iface);
-		eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
+		net_eth_set_if_type_wifi(iface);
 		ethernet_init(iface);
 	}
 }

--- a/tests/net/wifi/wifi_nm/src/main.c
+++ b/tests/net/wifi/wifi_nm/src/main.c
@@ -47,13 +47,12 @@ static void wifi_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct wifi_drv_context *context = dev->data;
-	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 
 	net_if_set_link_addr(iface, context->mac_addr,
 			     sizeof(context->mac_addr),
 			     NET_LINK_ETHERNET);
 
-	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
+	net_eth_set_if_type_wifi(iface);
 
 	ethernet_init(iface);
 }


### PR DESCRIPTION
Replace direct ethernet context manipulation with new
net_eth_set_if_type_wifi() API across multiple Wi-Fi drivers and test suits.