### PR TITLE
FLPR example usage documentation

### DIFF
--- a/boards/ezurio/bl54l15_dvk/doc/bl54l15_dvk.rst
+++ b/boards/ezurio/bl54l15_dvk/doc/bl54l15_dvk.rst
@@ -69,7 +69,7 @@ Enter the following command to compile ``hello_world`` for the FLPR core:
 
 .. code-block:: console
 
-   west build -p -b bl54l15_dvk/nrf54l15/cpuflpr --sysbuild
+   west build -p -b bl54l15_dvk/nrf54l15/cpuflpr samples/hello_world --sysbuild
 
 Flashing
 ========

--- a/boards/ezurio/bl54l15u_dvk/doc/bl54l15u_dvk.rst
+++ b/boards/ezurio/bl54l15u_dvk/doc/bl54l15u_dvk.rst
@@ -64,7 +64,7 @@ Enter the following command to compile ``hello_world`` for the FLPR core:
 
 .. code-block:: console
 
-   west build -p -b bl54l15u_dvk/nrf54l15/cpuflpr --sysbuild
+   west build -p -b bl54l15u_dvk/nrf54l15/cpuflpr samples/hello_world --sysbuild
 
 Flashing
 ========

--- a/boards/nordic/nrf54l15dk/doc/index.rst
+++ b/boards/nordic/nrf54l15dk/doc/index.rst
@@ -44,7 +44,7 @@ Enter the following command to compile ``hello_world`` for the FLPR core:
 
 .. code-block:: console
 
-   west build -p -b nrf54l15dk/nrf54l15/cpuflpr --sysbuild
+   west build -p -b nrf54l15dk/nrf54l15/cpuflpr samples/hello_world --sysbuild
 
 
 Flashing

--- a/boards/nordic/nrf54lm20dk/doc/index.rst
+++ b/boards/nordic/nrf54lm20dk/doc/index.rst
@@ -44,7 +44,7 @@ Enter the following command to compile ``hello_world`` for the FLPR core:
 
 .. code-block:: console
 
-   west build -p -b nrf54lm20dk/nrf54lm20b/cpuflpr --sysbuild
+   west build -p -b nrf54lm20dk/nrf54lm20b/cpuflpr samples/hello_world --sysbuild
 
 
 Flashing

--- a/boards/nordic/nrf7120dk/doc/index.rst
+++ b/boards/nordic/nrf7120dk/doc/index.rst
@@ -39,7 +39,7 @@ Enter the following command to compile ``hello_world`` for the FLPR core:
 
 .. code-block:: console
 
-   west build -p -b nrf7120dk/nrf7120/cpuflpr --sysbuild
+   west build -p -b nrf7120dk/nrf7120/cpuflpr samples/hello_world --sysbuild
 
 
 Flashing

--- a/boards/u-blox/ubx_evknorab2/doc/index.rst
+++ b/boards/u-blox/ubx_evknorab2/doc/index.rst
@@ -40,7 +40,7 @@ to be built using sysbuild to include the ``vpr_launcher`` image for the
 application core.
 
 Enter the following command to compile ``hello_world`` for the FLPR core::
- west build -p -b ubx_evknorab2/nrf54l15/cpuflpr --sysbuild
+ west build -p -b ubx_evknorab2/nrf54l15/cpuflpr samples/hello_world --sysbuild
 
 Flashing
 ========

--- a/boards/we/ophelia4ev/doc/index.rst
+++ b/boards/we/ophelia4ev/doc/index.rst
@@ -43,7 +43,7 @@ Enter the following command to compile ``hello_world`` for the FLPR core:
 
 .. code-block:: console
 
-   west build -p -b ophelia4ev/nrf54l15/cpuflpr --sysbuild
+   west build -p -b ophelia4ev/nrf54l15/cpuflpr samples/hello_world --sysbuild
 
 
 Flashing

--- a/samples/sysbuild/hello_world/README.rst
+++ b/samples/sysbuild/hello_world/README.rst
@@ -27,7 +27,8 @@ to boot a remote core.
 .. note::
    It is recommended to use sample setups from
    :zephyr_file:`samples/sysbuild/hello_world/sample.yaml` using the
-   ``-T`` option.
+   ``-T`` option. This will ensure any additional settings (remote board, snippets, etc.)
+   are automatically applied.
 
 Here's an example to build and flash the sample for the
 :zephyr:board:`nrf54h20dk`, using application and radio cores:


### PR DESCRIPTION
Minor FLPR documentation updates:
- Updates `west` build command to include application in example usage docs
- Adds a further note to `-T` preferred usage

Fixes: #110397