### PR TITLE
drivers: counter: fix multiple bugs in counter_timer_shell

### DIFF
--- a/drivers/counter/counter_timer_shell.c
+++ b/drivers/counter/counter_timer_shell.c
@@ -74,7 +74,6 @@ static int cmd_timer_free_running(const struct shell *shctx, size_t argc, char *
 
 static int cmd_timer_stop(const struct shell *shctx, size_t argc, char **argv)
 {
-	uint32_t ticks1 = 0, ticks2 = 0;
 	const struct device *timer_dev;
 	int err = parse_device(shctx, argc, argv, &timer_dev);
 
@@ -82,16 +81,12 @@ static int cmd_timer_stop(const struct shell *shctx, size_t argc, char **argv)
 		return err;
 	}
 
-	counter_stop(timer_dev);
-
-	counter_get_value(timer_dev, &ticks1);
-	counter_get_value(timer_dev, &ticks2);
-
-	if (ticks1 == ticks2) {
+	err = counter_stop(timer_dev);
+	if (err == 0) {
 		shell_info(shctx, "Timer Stopped");
 	} else {
-		shell_error(shctx, "Failed to stop timer");
-		return -EIO;
+		shell_error(shctx, "Failed to stop timer, err: %d", err);
+		return err;
 	}
 
 	return 0;

--- a/drivers/counter/counter_timer_shell.c
+++ b/drivers/counter/counter_timer_shell.c
@@ -124,8 +124,16 @@ static int cmd_timer_oneshot(const struct shell *shctx, size_t argc, char **argv
 		return -ERANGE;
 	}
 
+	/* Validate ticks against hardware maximum to prevent truncation issues */
+	uint32_t ticks = counter_us_to_ticks(timer_dev, delay);
+
+	if (ticks > counter_get_max_top_value(timer_dev)) {
+		shell_error(shctx, "%s: delay exceeds hardware maximum", argv[ARGV_DEV]);
+		return -ERANGE;
+	}
+
 	alarm_cfg.flags = 0;
-	alarm_cfg.ticks = counter_us_to_ticks(timer_dev, (uint64_t)delay);
+	alarm_cfg.ticks = ticks;
 	alarm_cfg.callback = timer_alarm_handler;
 	alarm_cfg.user_data = NULL;
 
@@ -167,8 +175,16 @@ static int cmd_timer_periodic(const struct shell *shctx, size_t argc, char **arg
 		return -ERANGE;
 	}
 
+	/* Validate ticks against hardware maximum to prevent truncation issues */
+	uint32_t ticks = counter_us_to_ticks(timer_dev, delay);
+
+	if (ticks > counter_get_max_top_value(timer_dev)) {
+		shell_error(shctx, "%s: delay exceeds hardware maximum", argv[ARGV_DEV]);
+		return -ERANGE;
+	}
+
 	top_cfg.flags = 0;
-	top_cfg.ticks = counter_us_to_ticks(timer_dev, (uint64_t)delay);
+	top_cfg.ticks = ticks;
 	/* interrupt will be triggered periodically */
 	top_cfg.callback = timer_top_handler;
 	top_cfg.user_data = NULL;

--- a/drivers/counter/counter_timer_shell.c
+++ b/drivers/counter/counter_timer_shell.c
@@ -210,8 +210,9 @@ static int cmd_timer_periodic(const struct shell *shctx, size_t argc, char **arg
 
 	/* Checking periodic interrupt for PERIODIC_CYCLES times and then unblocking shell.
 	 * Timer is still running and interrupt is triggered periodically.
+	 * Wait for the exact number of periodic cycles configured
 	 */
-	while (++count < PERIODIC_CYCLES) {
+	for (count = 0; count < PERIODIC_CYCLES; count++) {
 		k_sem_take(&timer_sem, K_FOREVER);
 	}
 

--- a/drivers/counter/counter_timer_shell.c
+++ b/drivers/counter/counter_timer_shell.c
@@ -137,6 +137,12 @@ static int cmd_timer_oneshot(const struct shell *shctx, size_t argc, char **argv
 	alarm_cfg.callback = timer_alarm_handler;
 	alarm_cfg.user_data = NULL;
 
+	err = counter_start(timer_dev);
+	if (err != 0 && err != -EALREADY) {
+		shell_error(shctx, "%s: failed to start counter, err: %d", argv[ARGV_DEV], err);
+		return err;
+	}
+
 	/* set an alarm */
 	err = counter_set_channel_alarm(timer_dev, (uint8_t)channel, &alarm_cfg);
 	if (err != 0) {
@@ -188,6 +194,12 @@ static int cmd_timer_periodic(const struct shell *shctx, size_t argc, char **arg
 	/* interrupt will be triggered periodically */
 	top_cfg.callback = timer_top_handler;
 	top_cfg.user_data = NULL;
+
+	err = counter_start(timer_dev);
+	if (err != 0 && err != -EALREADY) {
+		shell_error(shctx, "%s: failed to start counter, err: %d", argv[ARGV_DEV], err);
+		return err;
+	}
 
 	/* set top value */
 	err = counter_set_top_value(timer_dev, &top_cfg);

--- a/drivers/counter/counter_timer_shell.c
+++ b/drivers/counter/counter_timer_shell.c
@@ -100,11 +100,11 @@ static int cmd_timer_oneshot(const struct shell *shctx, size_t argc, char **argv
 	int err = parse_device(shctx, argc, argv, &timer_dev);
 	struct counter_alarm_cfg alarm_cfg;
 
-	k_sem_init(&timer_sem, 0, 1);
-
 	if (err != 0) {
 		return err;
 	}
+
+	k_sem_init(&timer_sem, 0, 1);
 
 	delay = shell_strtoul(argv[ARGV_ONESHOT_TIME], 10, &err);
 	if (err != 0) {
@@ -152,11 +152,11 @@ static int cmd_timer_periodic(const struct shell *shctx, size_t argc, char **arg
 	int err = parse_device(shctx, argc, argv, &timer_dev);
 	struct counter_top_cfg top_cfg;
 
-	k_sem_init(&timer_sem, 0, 1);
-
 	if (err != 0) {
 		return err;
 	}
+
+	k_sem_init(&timer_sem, 0, 1);
 
 	delay = shell_strtoul(argv[ARGV_PERIODIC_TIME], 10, &err);
 	if (err != 0) {


### PR DESCRIPTION
This PR fixes multiple bugs across four shell commands in `drivers/counter/counter_shell.c`. 
The most critical defects left the counter hardware completely idle during oneshot and periodic configurations. As a result, the kernel semaphore k_sem_take() would block indefinitely waiting for a hardware event that never fired, causing the entire shell interface to hang. This patch properly activates the hardware during these configurations, ensuring the semaphore unblocks and the shell remains responsive.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/109915