### PR TITLE
samples: tests: display: qualify frdm_rw612 shield

### DIFF
--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -109,7 +109,7 @@ tests:
       - platform:mcx_n9xx_evk/mcxn947/cpu0:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxn236/mcxn236:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxa156/mcxa156:SHIELD=lcd_par_s035_8080
-      - platform:frdm_rw612:SHIELD=lcd_par_s035_spi
+      - platform:frdm_rw612/rw612:SHIELD=lcd_par_s035_spi
       - platform:ek_ra8d1:SHIELD=rtkmipilcdb00000be
       - platform:ek_ra8d1:SHIELD=rtk7eka6m3b00001bu
       - platform:nucleo_g071rb/stm32g071xx:SHIELD=x_nucleo_gfx01m2

--- a/tests/drivers/display/display_check/testcase.yaml
+++ b/tests/drivers/display/display_check/testcase.yaml
@@ -97,7 +97,7 @@ tests:
       - platform:mcx_n9xx_evk/mcxn947/cpu0:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxn236/mcxn236:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxa156/mcxa156:SHIELD=lcd_par_s035_8080
-      - platform:frdm_rw612:SHIELD=lcd_par_s035_spi
+      - platform:frdm_rw612/rw612:SHIELD=lcd_par_s035_spi
       - platform:ek_ra8d1:SHIELD=rtkmipilcdb00000be
       - platform:ek_ra8d1:SHIELD=rtk7eka6m3b00001bu
       - platform:nucleo_g071rb/stm32g071xx:SHIELD=x_nucleo_gfx01m2


### PR DESCRIPTION
The `frdm_rw612` entries for the `lcd_par_s035_spi` shield used the bare board name `frdm_rw612` instead of the qualified `frdm_rw612/rw612`, in two places:

- `samples/drivers/display/sample.yaml` — `sample.display.shield`
- `tests/drivers/display/display_check/testcase.yaml` — `drivers.display.check.shield`

Twister normalizes the platform to `frdm_rw612/rw612`, so the bare scope never matches and `SHIELD=lcd_par_s035_spi` is silently dropped — both scenarios filter out instead of building on this board. Qualify both to match the sibling entries.

Verified with `--build-only` on `frdm_rw612`:

| scenario | before | after |
| --- | --- | --- |
| `sample.display.shield` | filtered, 0 built | **1 built** |
| `drivers.display.check.shield` | filtered, 0 built | **1 built** |