### PR TITLE
samples: display: move rw612 runtime-PM to shield

### DIFF
--- a/boards/shields/lcd_par_s035/boards/frdm_rw612.overlay
+++ b/boards/shields/lcd_par_s035/boards/frdm_rw612.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,4 +11,8 @@
 	nxp,timer0-ratio = <15>;
 	/* Lower timer1 ratio to enable shorter TE delay */
 	nxp,timer1-ratio = <0>;
+};
+
+&st7796s {
+	zephyr,pm-device-runtime-auto;
 };

--- a/samples/drivers/display/boards/frdm_rw612.overlay
+++ b/samples/drivers/display/boards/frdm_rw612.overlay
@@ -1,13 +1,9 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 &standby {
 	status = "okay";
-};
-
-&st7796s {
-	zephyr,pm-device-runtime-auto;
 };


### PR DESCRIPTION
The zephyr,pm-device-runtime-auto override on st7796s was in the sample's always-applied frdm_rw612 overlay, which references a label only the lcd_par_s035 shield defines. Shieldless configures such as sample.display.builtin failed to parse and errored under twister.

Move it to the shield's frdm_rw612 overlay so it applies only with the shield. The PM Kconfig stays in the sample.

Fixes #110310