### PR TITLE
[RFC] drivers: can: bosch: m_can: enforce RX FIFO1 is not used

### DIFF
--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -654,8 +654,8 @@ enum can_mcan_psr_lec {
 		     "Maximum Extended filter elements exceeded");                                 \
 	BUILD_ASSERT(CAN_MCAN_DT_MRAM_RX_FIFO0_ELEMENTS(node_id) <= 64,                            \
 		     "Maximum Rx FIFO 0 elements exceeded");                                       \
-	BUILD_ASSERT(CAN_MCAN_DT_MRAM_RX_FIFO1_ELEMENTS(node_id) <= 64,                            \
-		     "Maximum Rx FIFO 1 elements exceeded");                                       \
+	BUILD_ASSERT(CAN_MCAN_DT_MRAM_RX_FIFO1_ELEMENTS(node_id) == 0,                             \
+		     "Expect no Rx FIFO element: allocate all to Rx FIFO 0");                      \
 	BUILD_ASSERT(CAN_MCAN_DT_MRAM_RX_BUFFER_ELEMENTS(node_id) <= 64,                           \
 		     "Maximum Rx Buffer elements exceeded");                                       \
 	BUILD_ASSERT(CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEMENTS(node_id) <= 32,                       \

--- a/dts/arm/atmel/same5x.dtsi
+++ b/dts/arm/atmel/same5x.dtsi
@@ -44,7 +44,7 @@
 			atmel,assigned-clock-names = "GCLK";
 			status = "disabled";
 
-			bosch,mram-cfg = <0x0 128 64 64 64 64 32 32>;
+			bosch,mram-cfg = <0x0 128 64 64 0 64 32 32>;
 			divider = <1>;
 		};
 
@@ -59,7 +59,7 @@
 			atmel,assigned-clock-names = "GCLK";
 			status = "disabled";
 
-			bosch,mram-cfg = <0x0 128 64 64 64 64 32 32>;
+			bosch,mram-cfg = <0x0 128 64 64 0 64 32 32>;
 			divider = <1>;
 		};
 	};

--- a/dts/arm/st/c0/stm32c092.dtsi
+++ b/dts/arm/st/c0/stm32c092.dtsi
@@ -17,7 +17,7 @@
 			interrupts = <30 0>, <31 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1, 12)>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/c5/stm32c532.dtsi
+++ b/dts/arm/st/c5/stm32c532.dtsi
@@ -17,7 +17,7 @@
 			interrupts = <34 0>, <35 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 
@@ -28,7 +28,7 @@
 			interrupts = <86 0>, <87 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
-			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x350 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/c5/stm32c552.dtsi
+++ b/dts/arm/st/c5/stm32c552.dtsi
@@ -17,7 +17,7 @@
 			interrupts = <34 0>, <35 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/c5/stm32c593.dtsi
+++ b/dts/arm/st/c5/stm32c593.dtsi
@@ -17,7 +17,7 @@
 			interrupts = <34 0>, <35 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 
@@ -28,7 +28,7 @@
 			interrupts = <86 0>, <87 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
-			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x350 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -39,7 +39,7 @@
 			interrupts = <21 0>, <22 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1, 12)>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 
@@ -50,7 +50,7 @@
 			interrupts = <21 0>, <22 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1, 12)>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -443,7 +443,7 @@
 			interrupts = <21 0>, <22 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -122,7 +122,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
-			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x6a0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -18,7 +18,7 @@
 			interrupts = <86 0>, <87 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
-			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x350 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -593,7 +593,7 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>,
 				 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h523.dtsi
+++ b/dts/arm/st/h5/stm32h523.dtsi
@@ -52,7 +52,7 @@
 			/* common clock FDCAN 1 & 2 */
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>,
 				 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
-			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x350 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -49,7 +49,7 @@
 			/* common clock FDCAN 1 & 2 */
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>,
 				 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
-			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x350 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h5/stm32h5e4.dtsi
+++ b/dts/arm/st/h5/stm32h5e4.dtsi
@@ -113,7 +113,7 @@
 			/* common clock FDCAN 1 & 2 & 3 */
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>,
 				 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
-			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x6a0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -592,7 +592,7 @@
 				 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
 			interrupts = <152 0>, <153 0>;
 			interrupt-names = "int0", "int1";
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 
@@ -605,7 +605,7 @@
 				 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
 			interrupts = <154 0>, <155 0>;
 			interrupt-names = "int0", "int1";
-			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x350 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -808,7 +808,7 @@
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
 			interrupts = <47 0>, <48 0>;
 			interrupt-names = "int0", "int1";
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -331,7 +331,7 @@
 			interrupts = <39 0>, <40 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -936,7 +936,7 @@
 			interrupts = <39 0>, <40 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/can/bosch,m_can-base.yaml
+++ b/dts/bindings/can/bosch,m_can-base.yaml
@@ -20,7 +20,7 @@ properties:
       11-bit Filter	 0-128 elements / 0-128 words
       29-bit Filter	  0-64 elements / 0-128 words
       Rx FIFO 0		    0-64 elements / 0-1152 words
-      Rx FIFO 1		    0-64 elements / 0-1152 words
+      Rx FIFO 1		    0-64 elements / 0-1152 words (Value must be 0: allocate all on Rx FIFO 0)
       Rx Buffers	    0-64 elements / 0-1152 words
       Tx Event FIFO	  0-32 elements / 0-64 words
       Tx Buffers	    0-32 elements / 0-576 words

--- a/dts/bindings/can/st,stm32-fdcan.yaml
+++ b/dts/bindings/can/st,stm32-fdcan.yaml
@@ -69,6 +69,6 @@ examples:
         interrupt-names = "int0", "int1";
         clocks = <&rcc STM32_CLOCK(APB1, 12)>,
                  <&rcc STM32_SRC_PLL_Q FDCAN_SEL(1)>;
-        bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+        bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
         status = okay";
       };


### PR DESCRIPTION
This P-R complements changes from https://github.com/zephyrproject-rtos/zephyr/pull/110201

However, this reveals an issue in the same5x SoCs that must be refined since 64 elements where allocated in each Rx FIFO 0 and 1, and we cannot move to 128 element in Rx FIFO 0 as per DT bindings limits to 64 elements per FIFO. Therefore the [RFC] state is this P-R.