### PR TITLE
dts: arm: mec172x: update default interrupt priority

### DIFF
--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -12,7 +12,7 @@ pcr: pcr@40080100 {
 	compatible = "microchip,xec-pcr";
 	reg = <0x40080100 0x100 0x4000a400 0x100>;
 	reg-names = "pcrr", "vbatr";
-	interrupts = <174 0>;
+	interrupts = <174 6>;
 	core-clock-div = <1>;
 	/* MEC172x allows sources to be different */
 	pll-32k-src = <MCHP_XEC_PLL_CLK32K_SRC_SIL_OSC>;
@@ -39,7 +39,7 @@ ecia: ecia@4000e000 {
 	girq8: girq8@0 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x0 0x14>;
-		interrupts = <0 0>;
+		interrupts = <0 6>;
 		girq-id = <0>;
 		sources = <0 1 2 3 4 5 6 7
 			   8 9 10 11 12 13 14 15
@@ -51,7 +51,7 @@ ecia: ecia@4000e000 {
 	girq9: girq9@14 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x14 0x14>;
-		interrupts = <1 0>;
+		interrupts = <1 6>;
 		girq-id = <1>;
 		sources = <0 1 2 3 4 5 6 7
 			   8 9 10 11 12 13 14 15
@@ -63,7 +63,7 @@ ecia: ecia@4000e000 {
 	girq10: girq10@28 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x28 0x14>;
-		interrupts = <2 0>;
+		interrupts = <2 6>;
 		girq-id = <2>;
 		sources = <0 1 2 3 4 5 6 7
 			   8 9 10 11 12 13 14 15
@@ -75,7 +75,7 @@ ecia: ecia@4000e000 {
 	girq11: girq11@3c {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x3c 0x14>;
-		interrupts = <3 0>;
+		interrupts = <3 6>;
 		girq-id = <3>;
 		sources = <0 1 2 3 4 5 6 7
 			   8 9 10 11 12 13 14 15
@@ -87,7 +87,7 @@ ecia: ecia@4000e000 {
 	girq12: girq12@50 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x50 0x14>;
-		interrupts = <4 0>;
+		interrupts = <4 6>;
 		girq-id = <4>;
 		sources = <0 1 2 3 4 5 6 7
 			   8 9 10 11 12 13 14 15
@@ -99,7 +99,7 @@ ecia: ecia@4000e000 {
 	girq13: girq13@64 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x64 0x14>;
-		interrupts = <5 0>;
+		interrupts = <5 6>;
 		girq-id = <5>;
 		sources = <0 1 2 3 4>;
 		status = "disabled";
@@ -108,7 +108,7 @@ ecia: ecia@4000e000 {
 	girq14: girq14@78 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x78 0x14>;
-		interrupts = <6 0>;
+		interrupts = <6 6>;
 		girq-id = <6>;
 		sources = <0 1 2 3 4 5 6 7
 			   8 9 10 11 12 13 14 15>;
@@ -118,7 +118,7 @@ ecia: ecia@4000e000 {
 	girq15: girq15@8c {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x8c 0x14>;
-		interrupts = <7 0>;
+		interrupts = <7 6>;
 		girq-id = <7>;
 		sources = <0 1 2 3 4 5 6 7
 			   8 9 10 11 12 13 14 15
@@ -129,7 +129,7 @@ ecia: ecia@4000e000 {
 	girq16: girq16@a0 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0xa0 0x14>;
-		interrupts = <8 0>;
+		interrupts = <8 6>;
 		girq-id = <8>;
 		sources = <0 2 3>;
 		status = "disabled";
@@ -138,7 +138,7 @@ ecia: ecia@4000e000 {
 	girq17: girq17@b4 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0xb4 0x14>;
-		interrupts = <9 0>;
+		interrupts = <9 6>;
 		girq-id = <9>;
 		sources = <0 1 2 3 4 8 9 10 11 12 13 14 15
 			   16 17 20 21 22 23>;
@@ -148,7 +148,7 @@ ecia: ecia@4000e000 {
 	girq18: girq18@c8 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0xc8 0x14>;
-		interrupts = <10 0>;
+		interrupts = <10 6>;
 		girq-id = <10>;
 		sources = <0 1 2 3 4 5 6 7
 			   10 20 21 22 23
@@ -159,7 +159,7 @@ ecia: ecia@4000e000 {
 	girq19: girq19@dc {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0xdc 0x14>;
-		interrupts = <11 0>;
+		interrupts = <11 6>;
 		girq-id = <11>;
 		sources = <0 1 2 3 4 5 6 7 8 9 10>;
 		status = "disabled";
@@ -168,7 +168,7 @@ ecia: ecia@4000e000 {
 	girq20: girq20@f0 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0xf0 0x14>;
-		interrupts = <12 0>;
+		interrupts = <12 6>;
 		girq-id = <12>;
 		sources = <3 9>;
 		status = "disabled";
@@ -177,7 +177,7 @@ ecia: ecia@4000e000 {
 	girq21: girq21@104 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x104 0x14>;
-		interrupts = <13 0>;
+		interrupts = <13 6>;
 		girq-id = <13>;
 		sources = <2 3 4 5 6 7 8 9 10 11 12 13 14 15
 			   18 19 25 26>;
@@ -187,7 +187,7 @@ ecia: ecia@4000e000 {
 	girq22: girq22@118 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x118 0x14>;
-		interrupts = <255 0>;
+		interrupts = <255 6>;
 		girq-id = <14>;
 		sources = <0 1 2 3 4 5 9 15>;
 		status = "disabled";
@@ -196,7 +196,7 @@ ecia: ecia@4000e000 {
 	girq23: girq23@12c {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x12c 0x14>;
-		interrupts = <14 0>;
+		interrupts = <14 6>;
 		girq-id = <15>;
 		sources = <0 1 2 3 4 5 6 7 8 9 10 16 17>;
 		status = "disabled";
@@ -205,7 +205,7 @@ ecia: ecia@4000e000 {
 	girq24: girq24@140 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x140 0x14>;
-		interrupts = <15 0>;
+		interrupts = <15 6>;
 		girq-id = <16>;
 		sources = <0 1 2 3 4 5 6 7 8 9 10 11
 			   12 13 14 15 16 17 18 19
@@ -216,7 +216,7 @@ ecia: ecia@4000e000 {
 	girq25: girq25@154 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x154 0x14>;
-		interrupts = <16 0>;
+		interrupts = <16 6>;
 		girq-id = <17>;
 		sources = <0 1 2 3 4 5 6 7 8 9 10 11
 			   12 13 14 15>;
@@ -226,7 +226,7 @@ ecia: ecia@4000e000 {
 	girq26: girq26@168 {
 		compatible = "microchip,xec-ecia-girq";
 		reg = <0x168 0x14>;
-		interrupts = <17 0>;
+		interrupts = <17 6>;
 		girq-id = <18>;
 		sources = <0 1 2 3 4 5 6 12 13>;
 		status = "disabled";
@@ -243,7 +243,7 @@ pinctrl: pin-controller@40081000 {
 		compatible = "microchip,xec-gpio";
 		reg = <0x40081000 0x80 0x40081300 0x04
 		       0x40081380 0x04 0x400813fc 0x04>;
-		interrupts = <3 2>;
+		interrupts = <3 4>;
 		girqs = <MCHP_XEC_ECIA_GIRQ_ENC(11, 255)>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -253,7 +253,7 @@ pinctrl: pin-controller@40081000 {
 		compatible = "microchip,xec-gpio";
 		reg = <0x40081080 0x80 0x40081304 0x04
 		       0x40081384 0x04 0x400813f8 0x4>;
-		interrupts = <2 2>;
+		interrupts = <2 4>;
 		girqs = <MCHP_XEC_ECIA_GIRQ_ENC(10, 255)>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -264,7 +264,7 @@ pinctrl: pin-controller@40081000 {
 		reg = <0x40081100 0x80 0x40081308 0x04
 		       0x40081388 0x04 0x400813f4 0x04>;
 		gpio-controller;
-		interrupts = <1 2>;
+		interrupts = <1 4>;
 		girqs = <MCHP_XEC_ECIA_GIRQ_ENC(9, 255)>;
 		#gpio-cells = <2>;
 	};
@@ -274,7 +274,7 @@ pinctrl: pin-controller@40081000 {
 		reg = <0x40081180 0x80 0x4008130c 0x04
 		       0x4008138c 0x04 0x400813f0 0x04>;
 		gpio-controller;
-		interrupts = <0 2>;
+		interrupts = <0 4>;
 		girqs = <MCHP_XEC_ECIA_GIRQ_ENC(8, 255)>;
 		#gpio-cells = <2>;
 	};
@@ -284,7 +284,7 @@ pinctrl: pin-controller@40081000 {
 		reg = <0x40081200 0x80 0x40081310 0x04
 		       0x40081390 0x04 0x400813ec 0x04>;
 		gpio-controller;
-		interrupts = <4 2>;
+		interrupts = <4 4>;
 		girqs = <MCHP_XEC_ECIA_GIRQ_ENC(12, 255)>;
 		#gpio-cells = <2>;
 	};
@@ -294,7 +294,7 @@ pinctrl: pin-controller@40081000 {
 		reg = <0x40081280 0x80 0x40081314 0x04
 		       0x40081394 0x04 0x400813e8 0x04>;
 		gpio-controller;
-		interrupts = <17 2>;
+		interrupts = <17 4>;
 		girqs = <MCHP_XEC_ECIA_GIRQ_ENC(26, 255)>;
 		#gpio-cells = <2>;
 	};
@@ -303,7 +303,7 @@ pinctrl: pin-controller@40081000 {
 wdog: watchdog@40000400 {
 	compatible = "microchip,xec-watchdog";
 	reg = <0x40000400 0x400>;
-	interrupts = <171 0>;
+	interrupts = <171 6>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 2)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 9)>;
 };
@@ -321,7 +321,7 @@ timer0: timer@40000c00 {
 	compatible = "microchip,xec-timer";
 	clock-frequency = <48000000>;
 	reg = <0x40000c00 0x20>;
-	interrupts = <136 0>;
+	interrupts = <136 6>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(23, 0)>;
 	pcr-src = <MCHP_XEC_SCR_ENCODE(1, 30)>;
 	max-value = <0xffff>;
@@ -333,7 +333,7 @@ timer1: timer@40000c20 {
 	compatible = "microchip,xec-timer";
 	clock-frequency = <48000000>;
 	reg = <0x40000c20 0x20>;
-	interrupts = <137 0>;
+	interrupts = <137 6>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(23, 1)>;
 	pcr-src = <MCHP_XEC_SCR_ENCODE(1, 31)>;
 	max-value = <0xffff>;
@@ -345,7 +345,7 @@ timer2: timer@40000c40 {
 	compatible = "microchip,xec-timer";
 	clock-frequency = <48000000>;
 	reg = <0x40000c40 0x20>;
-	interrupts = <138 0>;
+	interrupts = <138 6>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(23, 2)>;
 	pcr-src = <MCHP_XEC_SCR_ENCODE(3, 21)>;
 	max-value = <0xffff>;
@@ -357,7 +357,7 @@ timer3: timer@40000c60 {
 	compatible = "microchip,xec-timer";
 	clock-frequency = <48000000>;
 	reg = <0x40000c60 0x20>;
-	interrupts = <139 0>;
+	interrupts = <139 6>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(23, 3)>;
 	pcr-src = <MCHP_XEC_SCR_ENCODE(3, 22)>;
 	max-value = <0xffff>;
@@ -374,7 +374,7 @@ timer4: timer@40000c80 {
 	compatible = "microchip,xec-timer";
 	clock-frequency = <48000000>;
 	reg = <0x40000c80 0x20>;
-	interrupts = <140 0>;
+	interrupts = <140 6>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(23, 4)>;
 	pcr-src = <MCHP_XEC_SCR_ENCODE(3, 23)>;
 	max-value = <0xffffffff>;
@@ -386,7 +386,7 @@ timer5: timer@40000ca0 {
 	compatible = "microchip,xec-timer";
 	clock-frequency = <48000000>;
 	reg = <0x40000ca0 0x20>;
-	interrupts = <141 0>;
+	interrupts = <141 6>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(23, 5)>;
 	pcr-src = <MCHP_XEC_SCR_ENCODE(3, 24)>;
 	max-value = <0xffffffff>;
@@ -396,7 +396,7 @@ timer5: timer@40000ca0 {
 
 cntr0: timer@40000d00 {
 	reg = <0x40000d00 0x20>;
-	interrupts = <142 0>;
+	interrupts = <142 6>;
 	girqs = <23 6>;
 	pcrs = <4 2>;
 	status = "disabled";
@@ -404,7 +404,7 @@ cntr0: timer@40000d00 {
 
 cntr1: timer@40000d20 {
 	reg = <0x40000d20 0x20>;
-	interrupts = <143 0>;
+	interrupts = <143 6>;
 	girqs = <23 7>;
 	pcrs = <4 3>;
 	status = "disabled";
@@ -412,7 +412,7 @@ cntr1: timer@40000d20 {
 
 cntr2: timer@40000d40 {
 	reg = <0x40000d40 0x20>;
-	interrupts = <144 0>;
+	interrupts = <144 6>;
 	girqs = <23 8>;
 	pcrs = <4 3>;
 	status = "disabled";
@@ -420,7 +420,7 @@ cntr2: timer@40000d40 {
 
 cntr3: timer@40000d60 {
 	reg = <0x40000d60 0x20>;
-	interrupts = <145 0>;
+	interrupts = <145 6>;
 	girqs = <23 9>;
 	pcrs = <4 4>;
 	status = "disabled";
@@ -428,9 +428,9 @@ cntr3: timer@40000d60 {
 
 cctmr0: timer@40001000 {
 	reg = <0x40001000 0x40>;
-	interrupts = <146 0>, <147 0>, <148 0>, <149 0>,
-		     <150 0>, <151 0>, <152 0>, <153 0>,
-		     <154 0>;
+	interrupts = <146 6>, <147 6>, <148 6>, <149 6>,
+		     <150 6>, <151 6>, <152 6>, <153 6>,
+		     <154 6>;
 	girqs = <18 20>, <18 21>, <18 22>, <18 23>, <18 24>,
 		<18 25>, <18 26>, <18 27>, <18 28>;
 	pcrs = <3 30>;
@@ -439,20 +439,20 @@ cctmr0: timer@40001000 {
 
 hibtimer0: timer@40009800 {
 	reg = <0x40009800 0x20>;
-	interrupts = <112 0>;
+	interrupts = <112 6>;
 	girqs = <23 16>;
 };
 
 hibtimer1: timer@40009820 {
 	reg = <0x40009820 0x20>;
-	interrupts = <113 0>;
+	interrupts = <113 6>;
 	girqs = <23 17>;
 };
 
 weektmr0: timer@4000ac80 {
 	reg = <0x4000ac80 0x80>;
-	interrupts = <114 0>, <115 0>, <116 0>,
-		     <117 0>, <118 0>;
+	interrupts = <114 6>, <115 6>, <116 6>,
+		     <117 6>, <118 6>;
 	girqs = <21 3>, <21 4>, <21 5>, <21 6>, <21 7>;
 	status = "disabled";
 };
@@ -465,8 +465,8 @@ bbram: bb-ram@4000a800 {
 
 vci0: vci@4000ae00 {
 	reg = <0x4000ae00 0x40>;
-	interrupts = <121 0>, <122 0>, <123 0>,
-		     <124 0>, <125 0>;
+	interrupts = <121 4>, <122 4>, <123 4>,
+		     <124 4>, <125 4>;
 	girqs = <21 10>, <21 11>, <21 12>, <21 13>, <21 14>;
 	status = "disabled";
 };
@@ -474,10 +474,10 @@ vci0: vci@4000ae00 {
 dmac: dmac@40002400 {
 	compatible = "microchip,xec-dmac";
 	reg = <0x40002400 0xc00>;
-	interrupts = <24 1>, <25 1>, <26 1>, <27 1>,
-		     <28 1>, <29 1>, <30 1>, <31 1>,
-		     <32 1>, <33 1>, <34 1>, <35 1>,
-		     <36 1>, <37 1>, <38 1>, <39 1>;
+	interrupts = <24 3>, <25 3>, <26 3>, <27 3>,
+		     <28 3>, <29 3>, <30 3>, <31 3>,
+		     <32 3>, <33 3>, <34 3>, <35 3>,
+		     <36 3>, <37 3>, <38 3>, <39 3>;
 	girqs = <MCHP_XEC_ECIA(14, 0, 6, 24)
 		 MCHP_XEC_ECIA(14, 1, 6, 25)
 		 MCHP_XEC_ECIA(14, 2, 6, 26)
@@ -505,7 +505,7 @@ i2c_smb_0: i2c@40004000 {
 	compatible = "microchip,xec-i2c-v2";
 	reg = <0x40004000 0x80>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	interrupts = <20 1>;
+	interrupts = <20 3>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 0)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 10)>;
 	#address-cells = <1>;
@@ -517,7 +517,7 @@ i2c_smb_1: i2c@40004400 {
 	compatible = "microchip,xec-i2c-v2";
 	reg = <0x40004400 0x80>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	interrupts = <21 1>;
+	interrupts = <21 3>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 1)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 13)>;
 	#address-cells = <1>;
@@ -529,7 +529,7 @@ i2c_smb_2: i2c@40004800 {
 	compatible = "microchip,xec-i2c-v2";
 	reg = <0x40004800 0x80>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	interrupts = <22 1>;
+	interrupts = <22 3>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 2)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 14)>;
 	#address-cells = <1>;
@@ -541,7 +541,7 @@ i2c_smb_3: i2c@40004c00 {
 	compatible = "microchip,xec-i2c-v2";
 	reg = <0x40004c00 0x80>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	interrupts = <23 1>;
+	interrupts = <23 3>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 3)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 15)>;
 	#address-cells = <1>;
@@ -553,7 +553,7 @@ i2c_smb_4: i2c@40005000 {
 	compatible = "microchip,xec-i2c-v2";
 	reg = <0x40005000 0x80>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	interrupts = <158 1>;
+	interrupts = <158 3>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 4)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 20)>;
 	#address-cells = <1>;
@@ -564,7 +564,7 @@ i2c_smb_4: i2c@40005000 {
 ps2_0: ps2@40009000 {
 	compatible = "microchip,xec-ps2";
 	reg = <0x40009000 0x40>;
-	interrupts = <100 1>;
+	interrupts = <100 3>;
 	girqs = <18 10>, <21 18>;
 	pcrs = <3 5>;
 	#address-cells = <1>;
@@ -647,7 +647,7 @@ pwm8: pwm@40005880 {
 tach0: tach@40006000 {
 	compatible = "microchip,xec-tach";
 	reg = <0x40006000 0x10>;
-	interrupts = <71 4>;
+	interrupts = <71 5>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 1)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 2)>;
 	#address-cells = <1>;
@@ -658,7 +658,7 @@ tach0: tach@40006000 {
 tach1: tach@40006010 {
 	compatible = "microchip,xec-tach";
 	reg = <0x40006010 0x10>;
-	interrupts = <72 4>;
+	interrupts = <72 5>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 2)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 11)>;
 	#address-cells = <1>;
@@ -669,7 +669,7 @@ tach1: tach@40006010 {
 tach2: tach@40006020 {
 	compatible = "microchip,xec-tach";
 	reg = <0x40006020 0x10>;
-	interrupts = <73 4>;
+	interrupts = <73 5>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 3)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 12)>;
 	#address-cells = <1>;
@@ -680,7 +680,7 @@ tach2: tach@40006020 {
 tach3: tach@40006030 {
 	compatible = "microchip,xec-tach";
 	reg = <0x40006030 0x10>;
-	interrupts = <159 4>;
+	interrupts = <159 5>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 4)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 13)>;
 	#address-cells = <1>;
@@ -690,7 +690,7 @@ tach3: tach@40006030 {
 
 rpmfan0: rpmfan@4000a000 {
 	reg = <0x4000a000 0x80>;
-	interrupts = <74 1>, <75 1>;
+	interrupts = <74 5>, <75 5>;
 	girqs = <17 20>, <17 21>;
 	pcrs = <3 12>;
 	status = "disabled";
@@ -698,7 +698,7 @@ rpmfan0: rpmfan@4000a000 {
 
 rpmfan1: rpmfan@4000a080 {
 	reg = <0x4000a080 0x80>;
-	interrupts = <76 1>, <77 1>;
+	interrupts = <76 5>, <77 5>;
 	girqs = <17 22>, <17 23>;
 	pcrs = <4 7>;
 	status = "disabled";
@@ -707,7 +707,7 @@ rpmfan1: rpmfan@4000a080 {
 adc0: adc@40007c00 {
 	compatible = "microchip,xec-adc";
 	reg = <0x40007c00 0x90>;
-	interrupts = <78 0>, <79 0>;
+	interrupts = <78 5>, <79 5>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 8)>,
 		<MCHP_XEC_ECIA_GIRQ_ENC(17, 9)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 3)>;
@@ -720,7 +720,7 @@ adc0: adc@40007c00 {
 kbd0: kbd@40009c00 {
 	compatible = "microchip,xec-kbd";
 	reg = <0x40009c00 0x18>;
-	interrupts = <135 0>;
+	interrupts = <135 5>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
 	pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 	status = "disabled";
@@ -731,7 +731,7 @@ kbd0: kbd@40009c00 {
 peci0: peci@40006400 {
 	compatible = "microchip,xec-peci";
 	reg = <0x40006400 0x80>;
-	interrupts = <70 4>;
+	interrupts = <70 5>;
 	girqs = <17 0>;
 	pcrs = <1 1>;
 	#address-cells = <1>;
@@ -740,7 +740,7 @@ peci0: peci@40006400 {
 
 qspi0: spi@40070000 {
 	reg = <0x40070000 0x400>;
-	interrupts = <91 2>;
+	interrupts = <91 3>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(18, 1)>;
 	pcr = <MCHP_XEC_SCR_ENCODE(4, 8)>;
 	clock-frequency = <12000000>;
@@ -751,7 +751,7 @@ qspi0: spi@40070000 {
 
 gpspi0: spi@40009400 {
 	reg = <0x40009400 0x80>;
-	interrupts = <92 2>, <93 2>;
+	interrupts = <92 3>, <93 3>;
 	girqs = <18 2>, <18 3>;
 	pcrs = <3 9>;
 	status = "disabled";
@@ -759,7 +759,7 @@ gpspi0: spi@40009400 {
 
 gpspi1: spi@40009480 {
 	reg = <0x40009480 0x80>;
-	interrupts = <94 2>, <95 2>;
+	interrupts = <94 3>, <95 3>;
 	girqs = <18 4>, <18 5>;
 	pcrs = <4 22>;
 	status = "disabled";
@@ -767,7 +767,7 @@ gpspi1: spi@40009480 {
 
 prochot0: prochot@40003400 {
 	reg = <0x40003400 0x20>;
-	interrupts = <87 0>;
+	interrupts = <87 1>;
 	girqs = <17 17>;
 	pcrs = <4 13>;
 	status = "disabled";
@@ -775,7 +775,7 @@ prochot0: prochot@40003400 {
 
 rcid0: rcid@40001400 {
 	reg = <0x40001400 0x80>;
-	interrupts = <80 0>;
+	interrupts = <80 6>;
 	girqs = <17 10>;
 	pcrs = <4 10>;
 	status = "disabled";
@@ -783,7 +783,7 @@ rcid0: rcid@40001400 {
 
 rcid1: rcid@40001480 {
 	reg = <0x40001480 0x80>;
-	interrupts = <81 0>;
+	interrupts = <81 6>;
 	girqs = <17 11>;
 	pcrs = <4 11>;
 	status = "disabled";
@@ -791,7 +791,7 @@ rcid1: rcid@40001480 {
 
 rcid2: rcid@40001500 {
 	reg = <0x40001500 0x80>;
-	interrupts = <82 0>;
+	interrupts = <82 6>;
 	girqs = <17 12>;
 	pcrs = <4 12>;
 	status = "disabled";
@@ -799,7 +799,7 @@ rcid2: rcid@40001500 {
 
 spip0: spip@40007000 {
 	reg = <0x40007000 0x100>;
-	interrupts = <90 0>;
+	interrupts = <90 6>;
 	girqs = <18 0>;
 	pcrs = <4 16>;
 	status = "disabled";
@@ -807,7 +807,7 @@ spip0: spip@40007000 {
 
 bbled0: bbled@4000b800 {
 	reg = <0x4000b800 0x100>;
-	interrupts = <83 0>;
+	interrupts = <83 6>;
 	girqs = <17 13>;
 	pcrs = <3 16>;
 	status = "disabled";
@@ -815,7 +815,7 @@ bbled0: bbled@4000b800 {
 
 bbled1: bbled@4000b900 {
 	reg = <0x4000b900 0x100>;
-	interrupts = <84 0>;
+	interrupts = <84 6>;
 	girqs = <17 14>;
 	pcrs = <3 17>;
 	status = "disabled";
@@ -823,7 +823,7 @@ bbled1: bbled@4000b900 {
 
 bbled2: bbled@4000ba00 {
 	reg = <0x4000ba00 0x100>;
-	interrupts = <85 0>;
+	interrupts = <85 6>;
 	girqs = <17 15>;
 	pcrs = <3 18>;
 	status = "disabled";
@@ -831,7 +831,7 @@ bbled2: bbled@4000ba00 {
 
 bbled3: bbled@4000bb00 {
 	reg = <0x4000bb00 0x100>;
-	interrupts = <86 0>;
+	interrupts = <86 6>;
 	girqs = <17 16>;
 	pcrs = <3 25>;
 	status = "disabled";
@@ -839,7 +839,7 @@ bbled3: bbled@4000bb00 {
 
 bclink0: bclink@4000cd00 {
 	reg = <0x4000cd00 0x20>;
-	interrupts = <96 0>, <97 0>;
+	interrupts = <96 4>, <97 4>;
 	girqs = <18 7>, <18 6>;
 	pcrs = <3 19>;
 	status = "disabled";
@@ -860,7 +860,7 @@ glblcfg0: glblcfg@400fff00 {
 uart0: uart@400f2400 {
 	compatible = "microchip,xec-uart";
 	reg = <0x400f2400 0x400>;
-	interrupts = <40 1>;
+	interrupts = <40 3>;
 	clock-frequency = <1843200>;
 	current-speed = <38400>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(15, 0)>;
@@ -872,7 +872,7 @@ uart0: uart@400f2400 {
 uart1: uart@400f2800 {
 	compatible = "microchip,xec-uart";
 	reg = <0x400f2800 0x400>;
-	interrupts = <41 1>;
+	interrupts = <41 3>;
 	clock-frequency = <1843200>;
 	current-speed = <38400>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(15, 1)>;
@@ -892,9 +892,9 @@ espi0: espi@400f3400 {
 	       0x400f3800 0x400
 	       0x400f9c00 0x400>;
 	reg-names = "io", "mem", "vw";
-	interrupts = <103 3>, <104 3>, <105 3>, <106 3>,
-		     <107 3>, <108 3>, <109 3>, <110 2>,
-		     <156 3>;
+	interrupts = <103 2>, <104 2>, <105 2>, <106 2>,
+		     <107 2>, <108 2>, <109 2>, <110 2>,
+		     <156 2>;
 	interrupt-names = "pc", "bm1", "bm2", "ltr", "oob_up",
 			  "oob_dn", "fc", "rst", "vw_chan_en";
 	girqs = <MCHP_XEC_ECIA(19, 0, 11, 103)
@@ -914,7 +914,7 @@ espi0: espi@400f3400 {
 		reg = <0x40008000 0x400>, <0x40070000 0x400>,
 		      <0x40071000 0x400>;
 		reg-names = "safbr", "safqspi", "safcomm";
-		interrupts = <166 3>, <167 3>;
+		interrupts = <166 2>, <167 2>;
 		interrupt-names = "done", "err";
 		girqs = <MCHP_XEC_ECIA(19, 9, 11, 166)>,
 			<MCHP_XEC_ECIA(19, 10, 11, 167)>;
@@ -925,7 +925,7 @@ espi0: espi@400f3400 {
 	mbox0: mbox@400f0000 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f0000 0x200>;
-		interrupts = <60 3>;
+		interrupts = <60 2>;
 		girqs = <MCHP_XEC_ECIA(15, 20, 7, 60)>;
 		pcrs = <2 17>;
 		ldn = <0>;
@@ -935,7 +935,7 @@ espi0: espi@400f3400 {
 	kbc0: kbc@400f0400 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f0400 0x400>;
-		interrupts = <58 3>, <59 3>;
+		interrupts = <58 2>, <59 2>;
 		interrupt-names = "kbc_obe", "kbc_ibf";
 		girqs = <MCHP_XEC_ECIA(15, 18, 7, 58)
 			 MCHP_XEC_ECIA(15, 19, 7, 59)>;
@@ -946,7 +946,7 @@ espi0: espi@400f3400 {
 	acpi_ec0: acpi_ec@400f0800 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f0800 0x400>;
-		interrupts = <45 3>, <46 3>;
+		interrupts = <45 2>, <46 2>;
 		interrupt-names = "acpi_ibf", "acpi_obe";
 		girqs = <MCHP_XEC_ECIA(15, 5, 7, 45)
 			 MCHP_XEC_ECIA(15, 6, 7, 46)>;
@@ -957,7 +957,7 @@ espi0: espi@400f3400 {
 	acpi_ec1: acpi_ec@400f0c00 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f0c00 0x400>;
-		interrupts = <47 3>, <48 3>;
+		interrupts = <47 2>, <48 2>;
 		interrupt-names = "acpi_ibf", "acpi_obe";
 		girqs = <MCHP_XEC_ECIA(15, 7, 7, 47)
 			 MCHP_XEC_ECIA(15, 8, 7, 48)>;
@@ -968,7 +968,7 @@ espi0: espi@400f3400 {
 	acpi_ec2: acpi_ec@400f1000 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f1000 0x400>;
-		interrupts = <49 3>, <50 3>;
+		interrupts = <49 2>, <50 2>;
 		interrupt-names = "acpi_ibf", "acpi_obe";
 		girqs = <MCHP_XEC_ECIA(15, 9, 7, 49)
 			 MCHP_XEC_ECIA(15, 10, 7, 50)>;
@@ -979,7 +979,7 @@ espi0: espi@400f3400 {
 	acpi_ec3: acpi_ec@400f1400 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f1400 0x400>;
-		interrupts = <51 3>, <52 3>;
+		interrupts = <51 2>, <52 2>;
 		interrupt-names = "acpi_ibf", "acpi_obe";
 		girqs = <MCHP_XEC_ECIA(15, 11, 7, 51)
 			 MCHP_XEC_ECIA(15, 12, 7, 52)>;
@@ -990,7 +990,7 @@ espi0: espi@400f3400 {
 	acpi_ec4: acpi_ec@400f1800 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f1800 0x400>;
-		interrupts = <53 3>, <54 3>;
+		interrupts = <53 2>, <54 2>;
 		interrupt-names = "acpi_ibf", "acpi_obe";
 		girqs = <MCHP_XEC_ECIA(15, 13, 7, 53)
 			 MCHP_XEC_ECIA(15, 14, 7, 54)>;
@@ -1001,7 +1001,7 @@ espi0: espi@400f3400 {
 	acpi_pm1: acpi_pm1@400f1c00 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f1c00 0x400>;
-		interrupts = <55 3>, <56 3>, <57 3>;
+		interrupts = <55 2>, <56 2>, <57 2>;
 		interrupt-names = "pm1_ctl", "pm1_en", "pm1_sts";
 		girqs = <MCHP_XEC_ECIA(15, 15, 7, 55)
 			 MCHP_XEC_ECIA(15, 16, 7, 56)
@@ -1020,7 +1020,7 @@ espi0: espi@400f3400 {
 	emi0: emi@400f4000 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f4000 0x400>;
-		interrupts = <42 3>;
+		interrupts = <42 2>;
 		girqs = <MCHP_XEC_ECIA(15, 2, 7, 42)>;
 		ldn = <16>;
 		status = "disabled";
@@ -1029,7 +1029,7 @@ espi0: espi@400f3400 {
 	emi1: emi@400f4400 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f4400 0x400>;
-		interrupts = <43 3>;
+		interrupts = <43 2>;
 		girqs = <MCHP_XEC_ECIA(15, 3, 7, 43)>;
 		ldn = <17>;
 		status = "disabled";
@@ -1038,7 +1038,7 @@ espi0: espi@400f3400 {
 	emi2: emi@400f4800 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f4800 0x400>;
-		interrupts = <44 3>;
+		interrupts = <44 2>;
 		girqs = <MCHP_XEC_ECIA(15, 4, 7, 44)>;
 		ldn = <18>;
 		status = "disabled";
@@ -1047,7 +1047,7 @@ espi0: espi@400f3400 {
 	rtc0: rtc@400f5000 {
 		compatible = "microchip,xec-rtc";
 		reg = <0x400f5000 0x100>;
-		interrupts = <119 3>, <120 3>;
+		interrupts = <119 5>, <120 5>;
 		girqs = <MCHP_XEC_ECIA(21, 8, 13, 119)
 			 MCHP_XEC_ECIA(21, 9, 13, 120)>;
 		pcr-scr = <MCHP_XEC_SCR_ENCODE(2, 18)>;
@@ -1059,7 +1059,7 @@ espi0: espi@400f3400 {
 	p80bd0: p80bd@400f8000 {
 		compatible = "microchip,xec-espi-host-dev";
 		reg = <0x400f8000 0x400>;
-		interrupts = <62 0>;
+		interrupts = <62 6>;
 		girqs = <MCHP_XEC_ECIA(15, 22, 7, 62)>;
 		pcrs = <2 25>;
 		ldn = <32>;
@@ -1081,7 +1081,7 @@ espi0: espi@400f3400 {
 symcr: symcr@40100000 {
 	compatible = "microchip,xec-symcr";
 	reg = <0x40100000 0x1000>;
-	interrupts = <68 1>;
+	interrupts = <68 3>;
 	pcr = <MCHP_XEC_SCR_ENCODE(3, 26)>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(16, 3)>;
 	status = "disabled";


### PR DESCRIPTION
Default interrupt priority for the MEC172x SOC revisited to bring host interface as high priority
<img width="553" height="431" alt="image" src="https://github.com/user-attachments/assets/ad952540-fc31-4fae-ae87-0e0ab6ffd259" />


