### PR TITLE
Bluetooth: Host: Fix use-after-free in bt_att_sent on disconnect

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3407,6 +3407,18 @@ static void bt_att_released(struct bt_l2cap_chan *ch)
 
 	LOG_DBG("chan %p", chan);
 
+	/* Drop any pending/in-flight ATT TX metadata still referencing this
+	 * channel, so the deferred att_on_sent_cb()/bt_att_sent() work cannot
+	 * dereference the channel after it is freed here. Bluetooth uses a
+	 * cooperative system workqueue, so this runs serialized with
+	 * att_tx_destroy_work_handler() and aligned pointer writes are atomic.
+	 */
+	ARRAY_FOR_EACH(tx_meta_data_storage, i) {
+		if (tx_meta_data_storage[i].att_chan == chan) {
+			tx_meta_data_storage[i].att_chan = NULL;
+		}
+	}
+
 	k_mem_slab_free(&chan_slab, (void *)chan);
 }
 


### PR DESCRIPTION
## Summary

Fix a use-after-free of the ATT context in the deferred "sent" callback path when an unenhanced ATT bearer disconnects mid-transfer.

> Supersedes #110070 (auto-closed for losing common history). An earlier revision of this PR wrapped `bt_att_sent()` in `k_sched_lock()`; as noted in review that is a no-op — Bluetooth forces a cooperative system workqueue, so the handler is already non-preemptible. This revision takes a different approach.

## Problem

When the peer disconnects, the teardown runs on the system workqueue: `att_chan_detach()` + `att_reset()` free the `bt_att`, then `bt_att_released()` frees the `bt_att_chan`. The channel TX drain queues the ATT TX buffer destroy work (`att_tx_destroy_work`) on the **same** system workqueue without awaiting it.

Later, `att_tx_destroy_work_handler()` calls `att_on_sent_cb()` → (for UATT) `bt_att_sent()`. By then the `bt_att`/`bt_att_chan` are freed. `att_on_sent_cb()` does guard against a detached bearer, but it does so by dereferencing `meta->att_chan`, which is now a dangling pointer — it faults once the channel slab slot has been reused (the real-world trigger: disconnect, then reconnect). Observed as a bus fault on `sysworkq` in `sys_slist_get(&att->reqs)`.

## Fix

Null any pending ATT TX metadata that still references the channel in `bt_att_released()`, immediately before the channel is freed. The existing `att_on_sent_cb()` guard (its `!meta->att_chan` check) then drops the deferred callback instead of dereferencing freed memory. Teardown and the destroy work both run on the cooperative system workqueue, so this is serialized with the handler and needs no lock; aligned pointer writes are atomic.

## Testing

This is a cross-thread timing race: it is not deterministically reproducible in a host/`bsim` test, and on hardware it only fires intermittently (the deferred sent-work has to land in the window after the channel is freed/reused). I therefore can't offer a clean automated before/after, and want to be upfront that the low hit-rate is also why the earlier (no-op) `k_sched_lock` revision *appeared* to help. The fix is justified primarily by the lifetime/ordering reasoning above and in the commit message; it is being exercised on nRF52840 HIL with disconnect and disconnect-then-reconnect mid file-transfer, and I'll follow up here with results. Suggestions for a reliable repro (or a `bsim` angle that can force the interleaving) are welcome.

## Notes

- Targets the UATT deferred path (the reported fault). For EATT, `bt_att_sent` is L2CAP's direct `.sent` callback rather than the `meta`-based path; whether it needs separate handling is a question for maintainers.
- AI-assisted; disclosed via the `Assisted-by:` trailer in the commit per the contribution guidelines. The human author reviewed the change and is accountable for it.

Fixes: #112430