### PR TITLE
cmake: linker: iar: fix empty elseif()

### DIFF
--- a/cmake/linker/iar/config_file_script.cmake
+++ b/cmake/linker/iar/config_file_script.cmake
@@ -800,7 +800,6 @@ function(section_to_string)
     if(${length} GREATER 0)
       if(NOT "${idx}" STREQUAL "${last_index}")
         set(TEMP "${TEMP},")
-      elseif()
       endif()
     endif()
 


### PR DESCRIPTION
An empty `elseif()` branch was causing a recurrent warning when building with IAR using the latest CMake.

```
CMake Warning (author) at /home/felipeto/zephyrproject/zephyr/cmake/linker/iar/config_file_script.cmake:803 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  /home/felipeto/zephyrproject/zephyr/cmake/linker/linker_script_common.cmake:654 (section_to_string)
  /home/felipeto/zephyrproject/zephyr/cmake/linker/iar/config_file_script.cmake:371 (to_string)
  /home/felipeto/zephyrproject/zephyr/cmake/linker/linker_script_common.cmake:652 (group_to_string)
  /home/felipeto/zephyrproject/zephyr/cmake/linker/iar/config_file_script.cmake:365 (to_string)
  /home/felipeto/zephyrproject/zephyr/cmake/linker/linker_script_common.cmake:652 (group_to_string)
  /home/felipeto/zephyrproject/zephyr/cmake/linker/iar/config_file_script.cmake:365 (to_string)
  /home/felipeto/zephyrproject/zephyr/cmake/linker/linker_script_common.cmake:652 (group_to_string)
  /home/felipeto/zephyrproject/zephyr/cmake/linker/iar/config_file_script.cmake:259 (to_string)
  /home/felipeto/zephyrproject/zephyr/cmake/linker/linker_script_common.cmake:650 (system_to_string)
  /home/felipeto/zephyrproject/zephyr/cmake/linker/linker_script_common.cmake:814 (to_string)
  /home/felipeto/zephyrproject/zephyr/cmake/linker/iar/config_file_script.cmake:968 (include)
```

This PR removes the empty `elseif()` so that the build log comes clean when building with the IAR toolchain.

CC @RobinKastberg @bjorniuppsala