### PR TITLE
FRDM-MCXL255: LPSPI support for CM33

### DIFF
--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -146,6 +146,22 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_GateAonQTMR1);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpspi0))
+	/* Switch PERIPH_GROUP0 to FRO12M for LPSPI0 */
+	CLOCK_AttachClk(kFRO12M_to_PERIPH_GROUP0);
+	/* Set PERIPH_GROUP0 clock divider to value 1 */
+	CLOCK_SetClockDiv(kCLOCK_DivPeriphGroup0, 1u);
+	CLOCK_EnableClock(kCLOCK_GatePERIPH_GROUP0);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpspi1))
+	/* Switch PERIPH_GROUP1 to FRO12M for LPSPI1 */
+	CLOCK_AttachClk(kFRO12M_to_PERIPH_GROUP1);
+	/* Set PERIPH_GROUP1 clock divider to value 1 */
+	CLOCK_SetClockDiv(kCLOCK_DivPeriphGroup1, 1u);
+	CLOCK_EnableClock(kCLOCK_GatePERIPH_GROUP1);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(rtc))
 	if (!CLOCK_IsRoscInitialized()) {
 		rosc_init_config_t rosc_init_config;

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
@@ -25,4 +25,28 @@
 			input-enable;
 		};
 	};
+
+	pinmux_lpspi0: pinmux_lpspi0 {
+		group0 {
+			pinmux = <LPSPI0_SDO_P2_0>,
+				 <LPSPI0_SCK_P2_1>,
+				 <LPSPI0_SDI_P2_2>,
+				 <LPSPI0_PCS0_P2_3>;
+			drive-strength = "low";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
+
+	pinmux_lpspi1: pinmux_lpspi1 {
+		group0 {
+			pinmux = <LPSPI1_SDO_P1_17>,
+				 <LPSPI1_SCK_P1_18>,
+				 <LPSPI1_SDI_P1_19>,
+				 <LPSPI1_PCS0_P1_20>;
+			drive-strength = "low";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -28,6 +28,8 @@
 		sw1 = &user_button_3;
 		rtc = &rtc;
 		watchdog0 = &wwdt0;
+		spi-0 = &lpspi0;
+		spi-1 = &lpspi1;
 	};
 
 	leds {
@@ -97,6 +99,18 @@
 	status = "disabled";
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_aon_lpuart0>;
+	pinctrl-names = "default";
+};
+
+&lpspi0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpspi0>;
+	pinctrl-names = "default";
+};
+
+&lpspi1 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpspi1>;
 	pinctrl-names = "default";
 };
 

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -13,6 +13,7 @@ toolchain:
 supported:
   - uart
   - gpio
+  - spi
   - rtc
   - crc
   - watchdog

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -926,6 +926,15 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 		break;
 #endif /* defined(CONFIG_SPI_NXP_LPSPI) */
 
+#if (defined(CONFIG_SPI_NXP_LPSPI) && defined(CONFIG_SOC_FAMILY_MCXL))
+	case MCUX_LPSPI0_CLK:
+		*rate = CLOCK_GetLpspiClkFreq(0);
+		break;
+	case MCUX_LPSPI1_CLK:
+		*rate = CLOCK_GetLpspiClkFreq(1);
+		break;
+#endif /* defined(CONFIG_SPI_NXP_LPSPI) && defined(CONFIG_SOC_FAMILY_MCXL) */
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(micfil))
 	case MCUX_MICFIL_CLK:
 		*rate = CLOCK_GetMicfilClkFreq();

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
@@ -26,6 +26,32 @@
 #include "nxp_mcxl.dtsi"
 #include "nxp_mcxl_aon.dtsi"
 
+&peripheral {
+	lpspi0: spi@9c000 {
+		compatible = "nxp,lpspi";
+		reg = <0x9c000 0x1000>;
+		interrupts = <28 0>;
+		clocks = <&syscon MCUX_LPSPI0_CLK>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+		rx-fifo-size = <4>;
+		tx-fifo-size = <4>;
+	};
+
+	lpspi1: spi@9d000 {
+		compatible = "nxp,lpspi";
+		reg = <0x9d000 0x1000>;
+		interrupts = <29 0>;
+		clocks = <&syscon MCUX_LPSPI1_CLK>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+		rx-fifo-size = <4>;
+		tx-fifo-size = <4>;
+	};
+};
+
 &fmu {
 	flash: flash@0 {
 		compatible = "soc-nv-flash";


### PR DESCRIPTION
Add LPSPI support for the FRDM-MCXL255 CPU0 target.

This adds the MCXL255 LPSPI0 and LPSPI1 devicetree nodes, enables them on
the FRDM-MCXL255 CPU0 board, and configures the required pinctrl and clock
setup.

Tested with:
- tests/drivers/spi/spi_loopback on frdm_mcxl255/mcxl255/cpu0 with local overlay