### PR TITLE
usb: host: uhc: max3421e: add interrupt transfers, multipacket transactions & remote wakeup support

### DIFF
--- a/drivers/usb/uhc/Kconfig.max3421e
+++ b/drivers/usb/uhc/Kconfig.max3421e
@@ -24,4 +24,11 @@ config MAX3421E_OSC_WAIT_RETRIES
 	help
 	  Specify the number of retries for oscillator ready event.
 
+config MAX3421E_MAX_TIMEOUT_RETRIES
+	int "Maximum retries when receiving a TIMEOUT from the device"
+	default 3
+	range 0 255
+	help
+	  Specify the number of retries when the device returns TIMEOUT when trying to communicate.
+
 endif #UHC_MAX3421E

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -93,6 +93,7 @@ void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf)
 struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
+				    const size_t rec_len,
 				    void *const cb,
 				    void *const cb_priv)
 {
@@ -147,6 +148,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	xfer->udev = udev;
 	xfer->cb = cb;
 	xfer->priv = cb_priv;
+	xfer->expected_data_len = rec_len;
 
 xfer_alloc_error:
 	api->unlock(dev);
@@ -169,7 +171,7 @@ struct uhc_transfer *uhc_xfer_alloc_with_buf(const struct device *dev,
 		return NULL;
 	}
 
-	xfer = uhc_xfer_alloc(dev, ep, udev, cb, cb_priv);
+	xfer = uhc_xfer_alloc(dev, ep, udev, size, cb, cb_priv);
 	if (xfer == NULL) {
 		net_buf_unref(buf);
 		return NULL;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -94,6 +94,8 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 	} while (xfer_seq_cmp(xfer->start_frame, frame_number) <= 0);
 
 	sys_dlist_remove(&xfer->node);
+	/* Reset active flag, in case the interrupt was in the active list */
+	xfer->active = 0;
 	uhc_xfer_add_periodic(dev, xfer);
 
 	LOG_DBG("Periodic transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
@@ -149,6 +151,57 @@ static struct uhc_transfer *uhc_xfer_get_next_non_periodic(const struct device *
 	return NULL;
 }
 
+static void uhc_xfer_set_in_progress(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	struct uhc_data *data = dev->data;
+
+	sys_dlist_remove(&xfer->node);
+	sys_dlist_append(&data->active_xfers, &xfer->node);
+	xfer->active = 1;
+}
+
+int uhc_xfer_defer_active(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	sys_dlist_remove(&xfer->node);
+	xfer->active = 0;
+
+	struct uhc_data *data = dev->data;
+
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+		sys_dlist_prepend(&data->ctrl_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_BULK:
+		sys_dlist_prepend(&data->bulk_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_ISO:
+	case USB_EP_TYPE_INTERRUPT:
+		uhc_xfer_add_periodic(dev, xfer);
+		break;
+	default:
+		LOG_ERR("Invalid xfer type: %d", xfer->type);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int uhc_xfer_defer_all_active(const struct device *dev)
+{
+	struct uhc_data *data = dev->data;
+	struct uhc_transfer *current, *next;
+	int ret;
+
+	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(&data->active_xfers, current, next, node) {
+		ret = uhc_xfer_defer_active(dev, current);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
 struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number,
 				       enum uhc_xfer_mask mask, uhc_xfer_filter_func_t filter,
 				       void *priv)
@@ -166,6 +219,10 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
 
 	if (xfer == NULL && mask & UHC_XFER_MASK_BULK) {
 		xfer = uhc_xfer_get_next_non_periodic(dev, &data->bulk_xfers, filter, priv);
+	}
+
+	if (xfer) {
+		uhc_xfer_set_in_progress(dev, xfer);
 	}
 
 	return xfer;
@@ -206,6 +263,7 @@ int uhc_xfer_append(const struct device *dev, struct uhc_transfer *const xfer,
 		return uhc_xfer_add_new_periodic(dev, xfer, frame_number);
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
+		return -EINVAL;
 	}
 
 	return 0;
@@ -229,6 +287,7 @@ void uhc_xfer_cleanup_cancelled(const struct device *dev)
 	uhc_xfer_dlist_cleanup_cancelled(dev, &data->ctrl_xfers);
 	uhc_xfer_dlist_cleanup_cancelled(dev, &data->bulk_xfers);
 	uhc_xfer_dlist_cleanup_cancelled(dev, &data->periodic_xfers);
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->active_xfers);
 }
 
 int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
@@ -253,14 +312,18 @@ int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
 		return -EINVAL;
 	}
 
+	if (xfer->active) {
+		dlist = &data->active_xfers;
+	}
+
 	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
 		if (xfer == tmp) {
 			tmp->err = -ECONNRESET;
-			break;
+			return 0;
 		}
 	}
 
-	return 0;
+	return -ENOENT;
 }
 
 struct net_buf *uhc_xfer_buf_alloc(const struct device *dev,
@@ -561,6 +624,7 @@ int uhc_init(const struct device *dev,
 	sys_dlist_init(&data->ctrl_xfers);
 	sys_dlist_init(&data->bulk_xfers);
 	sys_dlist_init(&data->periodic_xfers);
+	sys_dlist_init(&data->active_xfers);
 
 	ret = api->init(dev);
 	if (ret == 0) {

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -19,6 +19,13 @@ USB_BUF_POOL_VAR_DEFINE(uhc_ep_pool,
 			CONFIG_UHC_BUF_COUNT, CONFIG_UHC_BUF_POOL_SIZE,
 			0, NULL);
 
+int uhc_common_init(const struct device *dev)
+{
+	struct uhc_data *data = dev->data;
+
+	return k_mutex_init(&data->mutex);
+}
+
 int uhc_submit_event(const struct device *dev,
 		     const enum uhc_event_type type,
 		     const int status)
@@ -182,6 +189,58 @@ int uhc_xfer_append(const struct device *dev,
 		break;
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
+	}
+
+	return 0;
+}
+
+static void uhc_xfer_dlist_cleanup_cancelled(const struct device *dev, sys_dlist_t *dlist)
+{
+	struct uhc_transfer *tmp;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
+		if (tmp->err == -ECONNRESET) {
+			uhc_xfer_return(dev, tmp, -ECONNRESET);
+		}
+	}
+}
+
+void uhc_xfer_cleanup_cancelled(const struct device *dev)
+{
+	struct uhc_data *data = dev->data;
+
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->ctrl_xfers);
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->bulk_xfers);
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->periodic_xfers);
+}
+
+int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	struct uhc_data *data = dev->data;
+	struct uhc_transfer *tmp;
+	sys_dlist_t *dlist;
+
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+		dlist = &data->ctrl_xfers;
+		break;
+	case USB_EP_TYPE_BULK:
+		dlist = &data->bulk_xfers;
+		break;
+	case USB_EP_TYPE_ISO:
+	case USB_EP_TYPE_INTERRUPT:
+		dlist = &data->periodic_xfers;
+		break;
+	default:
+		LOG_ERR("Invalid xfer type: %d", xfer->type);
+		return -EINVAL;
+	}
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
+		if (xfer == tmp) {
+			tmp->err = -ECONNRESET;
+			break;
+		}
 	}
 
 	return 0;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -171,8 +171,26 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
 	return xfer;
 }
 
-int uhc_xfer_append(const struct device *dev,
-		    struct uhc_transfer *const xfer)
+static int uhc_xfer_add_new_periodic(const struct device *dev, struct uhc_transfer *const xfer,
+				     uint32_t frame_number)
+{
+	if (xfer->interval == 0) {
+		LOG_ERR("Tried to schedule a periodic xfer that has interval equal to 0");
+		return -EINVAL;
+	}
+
+	xfer->start_frame = frame_number + xfer->interval;
+
+	LOG_DBG("New periodic transfer s.f. %u f.n. %u interval %u", xfer->start_frame,
+		frame_number, xfer->interval);
+
+	uhc_xfer_add_periodic(dev, xfer);
+
+	return 0;
+}
+
+int uhc_xfer_append(const struct device *dev, struct uhc_transfer *const xfer,
+		    uint32_t frame_number)
 {
 	struct uhc_data *data = dev->data;
 
@@ -185,8 +203,7 @@ int uhc_xfer_append(const struct device *dev,
 		break;
 	case USB_EP_TYPE_ISO:
 	case USB_EP_TYPE_INTERRUPT:
-		uhc_xfer_add_periodic(dev, xfer);
-		break;
+		return uhc_xfer_add_new_periodic(dev, xfer, frame_number);
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
 	}

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -92,21 +93,72 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
 }
 
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number)
+static enum uhc_xfer_mask uhc_xfer_type_to_mask(const struct uhc_transfer *xfer)
+{
+	return BIT(xfer->type);
+}
+
+static struct uhc_transfer *uhc_xfer_get_next_periodic(const struct device *dev,
+						       uint32_t frame_number,
+						       enum uhc_xfer_mask mask,
+						       uhc_xfer_filter_func_t filter, void *priv)
 {
 	struct uhc_data *data = dev->data;
-	struct uhc_transfer *xfer;
+	struct uhc_transfer *xfer = NULL;
+	sys_dnode_t *node;
 
-	/* Draft, WIP */
+	for (node = sys_dlist_peek_tail(&data->int_xfers); node != NULL;
+	     node = sys_dlist_peek_prev(&data->int_xfers, node)) {
+		xfer = SYS_DLIST_CONTAINER(node, xfer, node);
 
-	xfer = SYS_DLIST_CONTAINER(sys_dlist_peek_tail(&data->int_xfers), xfer, node);
-	if (xfer && xfer_seq_cmp(xfer->start_frame, frame_number) <= 0) {
-		return xfer;
+		if (xfer_seq_cmp(xfer->start_frame, frame_number) > 0) {
+			break;
+		}
+
+		if (uhc_xfer_type_to_mask(xfer) & ~mask) {
+			continue;
+		}
+
+		if (filter == NULL || filter(xfer, priv)) {
+			return xfer;
+		}
 	}
 
-	xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->ctrl_xfers, xfer, node);
-	if (xfer == NULL) {
-		xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->bulk_xfers, xfer, node);
+	return NULL;
+}
+
+static struct uhc_transfer *uhc_xfer_get_next_non_periodic(const struct device *dev,
+						       sys_dlist_t *dlist,
+						       uhc_xfer_filter_func_t filter, void *priv)
+{
+	struct uhc_transfer *xfer = NULL;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, xfer, node) {
+		if (filter == NULL || filter(xfer, priv)) {
+			return xfer;
+		}
+	}
+
+	return NULL;
+}
+
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number,
+				       enum uhc_xfer_mask mask, uhc_xfer_filter_func_t filter,
+				       void *priv)
+{
+	struct uhc_data *data = dev->data;
+	struct uhc_transfer *xfer = NULL;
+
+	if (mask & UHC_XFER_MASK_PERIODIC) {
+		xfer = uhc_xfer_get_next_periodic(dev, frame_number, mask, filter, priv);
+	}
+
+	if (xfer == NULL && mask & UHC_XFER_MASK_CONTROL) {
+		xfer = uhc_xfer_get_next_non_periodic(dev, &data->ctrl_xfers, filter, priv);
+	}
+
+	if (xfer == NULL && mask & UHC_XFER_MASK_BULK) {
+		xfer = uhc_xfer_get_next_non_periodic(dev, &data->bulk_xfers, filter, priv);
 	}
 
 	return xfer;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -72,9 +72,9 @@ void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xf
 }
 
 void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
-				  uint16_t frame_number)
+				  uint32_t frame_number)
 {
-	uint16_t old_start_frame = xfer->start_frame;
+	uint32_t old_start_frame = xfer->start_frame;
 
 	if (unlikely(xfer->interval == 0)) {
 		/* Prevent a infinite loop if somehow interval equals 0 */
@@ -92,7 +92,7 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
 }
 
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number)
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number)
 {
 	struct uhc_data *data = dev->data;
 	struct uhc_transfer *xfer;
@@ -147,6 +147,40 @@ void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf)
 	net_buf_unref(buf);
 }
 
+static uint32_t uhc_xfer_bInterval_to_microframe(const struct usb_device *const udev,
+					       uint16_t bInterval, uint8_t ep_type)
+{
+	if (bInterval == 0) {
+		return 0;
+	}
+
+	switch (udev->speed) {
+	case USB_SPEED_SPEED_SS:
+	case USB_SPEED_SPEED_HS:
+		bInterval = CLAMP(bInterval, 1, 16);
+		return 1U << (bInterval - 1);
+	case USB_SPEED_SPEED_FS:
+		/*
+		 * ISO FS uses 2^(bInterval - 1) * 1ms
+		 * unlike ISO HS which uses 2^(bInterval - 1) * 125microseconds
+		 * INT FS does it the same as INT LS
+		 * See USB 2.0 Specification 5.6.4 and 5.7.4
+		 */
+		if (ep_type == USB_EP_TYPE_ISO) {
+			bInterval = CLAMP(bInterval, 1, 16);
+			return (1U << (bInterval - 1)) * 8;
+		}
+		bInterval = CLAMP(bInterval, 1, 255);
+		return bInterval * 8;
+	case USB_SPEED_SPEED_LS:
+	case USB_SPEED_UNKNOWN:
+		bInterval = CLAMP(bInterval, 10, 255);
+		return bInterval * 8;
+	}
+
+	return 0;
+}
+
 struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
@@ -158,7 +192,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
 	struct uhc_transfer *xfer = NULL;
 	uint16_t mps;
-	uint16_t interval;
+	uint16_t bInterval;
 	uint8_t type;
 
 	api->lock(dev);
@@ -168,7 +202,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	}
 
 	if (ep_idx == 0) {
-		interval = 0;
+		bInterval = 0;
 		type = USB_EP_TYPE_CONTROL;
 		mps = udev->dev_desc.bMaxPacketSize0;
 	} else {
@@ -186,7 +220,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 		}
 
 		mps = ep_desc->wMaxPacketSize;
-		interval = ep_desc->bInterval;
+		bInterval = ep_desc->bInterval;
 		type = ep_desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
 	}
 
@@ -200,7 +234,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	memset(xfer, 0, sizeof(struct uhc_transfer));
 	xfer->ep = ep;
 	xfer->mps = mps;
-	xfer->interval = interval;
+	xfer->interval = uhc_xfer_bInterval_to_microframe(udev, bInterval, type);
+	xfer->bInterval = bInterval;
 	xfer->type = type;
 	xfer->udev = udev;
 	xfer->cb = cb;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -55,13 +55,13 @@ void uhc_xfer_return(const struct device *dev,
 	data->event_cb(dev, &drv_evt);
 }
 
-void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xfer)
+void uhc_xfer_add_periodic(const struct device *dev, struct uhc_transfer *const xfer)
 {
 	struct uhc_data *data = dev->data;
-	sys_dlist_t *int_list = &data->int_xfers;
+	sys_dlist_t *periodic_list = &data->periodic_xfers;
 	struct uhc_transfer *curr;
 
-	SYS_DLIST_FOR_EACH_CONTAINER(int_list, curr, node) {
+	SYS_DLIST_FOR_EACH_CONTAINER(periodic_list, curr, node) {
 		if (xfer_seq_cmp(xfer->start_frame, curr->start_frame) < 0) {
 			continue;
 		}
@@ -69,7 +69,7 @@ void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xf
 		return;
 	}
 
-	sys_dlist_append(int_list, &xfer->node);
+	sys_dlist_append(periodic_list, &xfer->node);
 }
 
 void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
@@ -87,9 +87,9 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 	} while (xfer_seq_cmp(xfer->start_frame, frame_number) <= 0);
 
 	sys_dlist_remove(&xfer->node);
-	uhc_xfer_add_to_int(dev, xfer);
+	uhc_xfer_add_periodic(dev, xfer);
 
-	LOG_DBG("Interrupt transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
+	LOG_DBG("Periodic transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
 		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
 }
 
@@ -107,8 +107,8 @@ static struct uhc_transfer *uhc_xfer_get_next_periodic(const struct device *dev,
 	struct uhc_transfer *xfer = NULL;
 	sys_dnode_t *node;
 
-	for (node = sys_dlist_peek_tail(&data->int_xfers); node != NULL;
-	     node = sys_dlist_peek_prev(&data->int_xfers, node)) {
+	for (node = sys_dlist_peek_tail(&data->periodic_xfers); node != NULL;
+	     node = sys_dlist_peek_prev(&data->periodic_xfers, node)) {
 		xfer = SYS_DLIST_CONTAINER(node, xfer, node);
 
 		if (xfer_seq_cmp(xfer->start_frame, frame_number) > 0) {
@@ -177,9 +177,8 @@ int uhc_xfer_append(const struct device *dev,
 		sys_dlist_append(&data->bulk_xfers, &xfer->node);
 		break;
 	case USB_EP_TYPE_ISO:
-		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
 	case USB_EP_TYPE_INTERRUPT:
-		uhc_xfer_add_to_int(dev, xfer);
+		uhc_xfer_add_periodic(dev, xfer);
 		break;
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
@@ -485,7 +484,7 @@ int uhc_init(const struct device *dev,
 	data->event_ctx = event_ctx;
 	sys_dlist_init(&data->ctrl_xfers);
 	sys_dlist_init(&data->bulk_xfers);
-	sys_dlist_init(&data->int_xfers);
+	sys_dlist_init(&data->periodic_xfers);
 
 	ret = api->init(dev);
 	if (ret == 0) {

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -54,19 +54,62 @@ void uhc_xfer_return(const struct device *dev,
 	data->event_cb(dev, &drv_evt);
 }
 
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev)
+void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	struct uhc_data *data = dev->data;
+	sys_dlist_t *int_list = &data->int_xfers;
+	struct uhc_transfer *curr;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(int_list, curr, node) {
+		if (xfer_seq_cmp(xfer->start_frame, curr->start_frame) < 0) {
+			continue;
+		}
+		sys_dlist_insert(&curr->node, &xfer->node);
+		return;
+	}
+
+	sys_dlist_append(int_list, &xfer->node);
+}
+
+void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
+				  uint16_t frame_number)
+{
+	uint16_t old_start_frame = xfer->start_frame;
+
+	if (unlikely(xfer->interval == 0)) {
+		/* Prevent a infinite loop if somehow interval equals 0 */
+		xfer->interval = 1;
+	}
+
+	do {
+		xfer->start_frame += xfer->interval;
+	} while (xfer_seq_cmp(xfer->start_frame, frame_number) <= 0);
+
+	sys_dlist_remove(&xfer->node);
+	uhc_xfer_add_to_int(dev, xfer);
+
+	LOG_DBG("Interrupt transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
+		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
+}
+
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number)
 {
 	struct uhc_data *data = dev->data;
 	struct uhc_transfer *xfer;
-	sys_dnode_t *node;
 
 	/* Draft, WIP */
-	node = sys_dlist_peek_head(&data->ctrl_xfers);
-	if (node == NULL) {
-		node = sys_dlist_peek_head(&data->bulk_xfers);
+
+	xfer = SYS_DLIST_CONTAINER(sys_dlist_peek_tail(&data->int_xfers), xfer, node);
+	if (xfer && xfer_seq_cmp(xfer->start_frame, frame_number) <= 0) {
+		return xfer;
 	}
 
-	return (node == NULL) ? NULL : SYS_DLIST_CONTAINER(node, xfer, node);
+	xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->ctrl_xfers, xfer, node);
+	if (xfer == NULL) {
+		xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->bulk_xfers, xfer, node);
+	}
+
+	return xfer;
 }
 
 int uhc_xfer_append(const struct device *dev,
@@ -74,7 +117,21 @@ int uhc_xfer_append(const struct device *dev,
 {
 	struct uhc_data *data = dev->data;
 
-	sys_dlist_append(&data->ctrl_xfers, &xfer->node);
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+		sys_dlist_append(&data->ctrl_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_BULK:
+		sys_dlist_append(&data->bulk_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_ISO:
+		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
+	case USB_EP_TYPE_INTERRUPT:
+		uhc_xfer_add_to_int(dev, xfer);
+		break;
+	default:
+		LOG_ERR("Invalid xfer type: %d", xfer->type);
+	}
 
 	return 0;
 }
@@ -341,6 +398,7 @@ int uhc_init(const struct device *dev,
 	data->event_ctx = event_ctx;
 	sys_dlist_init(&data->ctrl_xfers);
 	sys_dlist_init(&data->bulk_xfers);
+	sys_dlist_init(&data->int_xfers);
 
 	ret = api->init(dev);
 	if (ret == 0) {

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -51,6 +51,18 @@ static inline void *uhc_get_private(const struct device *dev)
 }
 
 /**
+ * @brief Initialize UHC common data
+ *
+ * UHC drivers using the common helpers must call this function during
+ * driver initialization.
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_common_init(const struct device *dev);
+
+/**
  * @brief Locking function for the drivers.
  *
  * @param[in] dev     Pointer to device struct of the driver instance
@@ -161,6 +173,29 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
  */
 int uhc_xfer_append(const struct device *dev,
 		    struct uhc_transfer *const xfer);
+
+/**
+ * @brief Cleans up canceled transfer in the internal queues.
+ *
+ * A canceled transfer is marked by having the err field set to `-ECONNRESET`
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ */
+void uhc_xfer_cleanup_cancelled(const struct device *dev);
+
+/**
+ * @brief Marks a queued transfer as canceled
+ *
+ * This function does not fully remove the transfer.
+ * To fully delete the transfer, call `uhc_xfer_cleanup_cancelled()`
+ * after marking a transfer as canceled.
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ * @param[in] xfer   Pointer to UHC transfer that should be canceled
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer);
 
 /**
  * @brief Helper function to send UHC event to a higher level.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -131,6 +131,33 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 				  uint32_t frame_number);
 
 /**
+ * @brief Defer a UHC transfer for the next frame.
+ *
+ * Puts back the UHC transfer at the top of list.
+ * Periodic transfers get put at their exact place in the queue,
+ * so it is allowed to defer periodic transfer in any order.
+ *
+ * @param[in] dev      Pointer to device struct of the driver instance
+ * @param[in] xfer     Pointer to UHC transfer that should be deferred.
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_xfer_defer_active(const struct device *dev, struct uhc_transfer *const xfer);
+
+/**
+ * @brief Defer all UHC transfers for a later time.
+ *
+ * Puts back all UHC transfers at the top of list.
+ * Periodic transfers get put at their exact place in the queue,
+ * so it is allowed to defer periodic transfer in any order.
+ *
+ * @param[in] dev      Pointer to device struct of the driver instance
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_xfer_defer_all_active(const struct device *dev);
+
+/**
  * @brief Helper to get next transfer to process.
  *
  * Return the next transfer that matches the provided mask and is accepted by

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -59,6 +59,22 @@ static inline int uhc_unlock_internal(const struct device *dev)
 }
 
 /**
+ * @brief Compare frame numbers of xfers to determine which one should be sent first.
+ *
+ * @return Negative value if a < b, positive if a > b, 0 if a == b
+ */
+static inline int16_t xfer_seq_cmp(uint16_t a, uint16_t b)
+{
+	/*
+	 * Use serial-number arithmetic for the unsigned 16-bit frame counter. The
+	 * wrapped subtraction is interpreted as a signed delta, so values just
+	 * after rollover compare newer than values just before it. Comparisons
+	 * are meaningful only within half the counter range.
+	 */
+	return (int16_t)(a - b);
+}
+
+/**
  * @brief Helper function to return UHC transfer to a higher level.
  *
  * Function to dequeue transfer and send UHC event to a higher level.
@@ -72,15 +88,26 @@ void uhc_xfer_return(const struct device *dev,
 		     const int err);
 
 /**
+ * @brief Reschedules the periodic UHC transfer to it's next valid frame.
+ *
+ * @param[inout] xfer   Pointer to UHC transfer
+ * @param frame_number The current USB frame number
+ */
+void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
+				  uint16_t frame_number);
+
+/**
  * @brief Helper to get next transfer to process.
  *
  * This is currently a draft, and simple picks a transfer
  * from the lists.
  *
- * @param[in] dev    Pointer to device struct of the driver instance
+ * @param[in] dev    Pointer to device struct of the driver instance.
+ * @param[in] frame_number Current USB frame number used to determine periodic transfer eligibility.
+ *
  * @return pointer to the next transfer or NULL on error.
  */
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev);
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number);
 
 /**
  * @brief Helper to append a transfer to internal list.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -63,15 +63,15 @@ static inline int uhc_unlock_internal(const struct device *dev)
  *
  * @return Negative value if a < b, positive if a > b, 0 if a == b
  */
-static inline int16_t xfer_seq_cmp(uint16_t a, uint16_t b)
+static inline int32_t xfer_seq_cmp(uint32_t a, uint32_t b)
 {
 	/*
-	 * Use serial-number arithmetic for the unsigned 16-bit frame counter. The
+	 * Use serial-number arithmetic for the unsigned 32-bit frame counter. The
 	 * wrapped subtraction is interpreted as a signed delta, so values just
 	 * after rollover compare newer than values just before it. Comparisons
 	 * are meaningful only within half the counter range.
 	 */
-	return (int16_t)(a - b);
+	return (int32_t)(a - b);
 }
 
 /**
@@ -94,7 +94,7 @@ void uhc_xfer_return(const struct device *dev,
  * @param frame_number The current USB frame number
  */
 void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
-				  uint16_t frame_number);
+				  uint32_t frame_number);
 
 /**
  * @brief Helper to get next transfer to process.
@@ -107,7 +107,7 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
  *
  * @return pointer to the next transfer or NULL on error.
  */
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number);
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number);
 
 /**
  * @brief Helper to append a transfer to internal list.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +14,27 @@
 #define ZEPHYR_INCLUDE_UHC_COMMON_H
 
 #include <zephyr/drivers/usb/uhc.h>
+
+/**
+ * @brief Transfer types selectable by uhc_xfer_get_next().
+ *
+ * Combine values with bitwise OR to select multiple transfer types.
+ */
+enum uhc_xfer_mask {
+	UHC_XFER_MASK_CONTROL = BIT(USB_EP_TYPE_CONTROL),     /**< Control transfers. */
+	UHC_XFER_MASK_ISO = BIT(USB_EP_TYPE_ISO),             /**< Isochronous transfers. */
+	UHC_XFER_MASK_BULK = BIT(USB_EP_TYPE_BULK),           /**< Bulk transfers. */
+	UHC_XFER_MASK_INTERRUPT = BIT(USB_EP_TYPE_INTERRUPT), /**< Interrupt transfers. */
+	/** Periodic transfers: interrupt or isochronous. */
+	UHC_XFER_MASK_PERIODIC = UHC_XFER_MASK_INTERRUPT | UHC_XFER_MASK_ISO,
+	/** Non-periodic transfers: control or bulk. */
+	UHC_XFER_MASK_NON_PERIODIC = UHC_XFER_MASK_CONTROL | UHC_XFER_MASK_BULK,
+	/** All transfer types. */
+	UHC_XFER_MASK_ALL = UHC_XFER_MASK_PERIODIC | UHC_XFER_MASK_NON_PERIODIC,
+};
+
+/** Transfer filtering function used in uhc_xfer_get_next(). */
+typedef bool (*uhc_xfer_filter_func_t)(const struct uhc_transfer *xfer, void *priv);
 
 /**
  * @brief Get driver's private data
@@ -99,15 +121,34 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 /**
  * @brief Helper to get next transfer to process.
  *
- * This is currently a draft, and simple picks a transfer
- * from the lists.
+ * Return the next transfer that matches the provided mask and is accepted by
+ * the optional filter function. Move the selected transfer to the active list.
  *
- * @param[in] dev    Pointer to device struct of the driver instance.
+ * If the mask matches more than one transfer type, prioritize transfers in this order:
+ *
+ * -# Most-overdue eligible periodic transfer, either interrupt or isochronous.
+ * -# Control transfer.
+ * -# Bulk transfer.
+ *
+ * To use a different priority order, call this function multiple times with masks that each
+ * match only one transfer type.
+ *
+ * @param[in] dev          Pointer to device struct of the driver instance.
  * @param[in] frame_number Current USB frame number used to determine periodic transfer eligibility.
+ * @param[in] mask         Bitmask of transfer types to consider. Combine UHC_XFER_MASK_* values
+ *                         with bitwise OR to select multiple transfer types.
+ * @param[in] filter       Optional function for further filtering transfers selected by @p mask.
+ *                         Return `true` to accept a transfer or `false` to skip it. Set to `NULL`
+ *                         to accept the first transfer selected by @p mask.
+ * @param[in] priv         Private data passed unchanged to @p filter. May be `NULL`.
  *
- * @return pointer to the next transfer or NULL on error.
+ * @return Next eligible transfer, or `NULL` if there are no pending matching non-periodic
+ *         transfers, no matching periodic transfer is due, or all otherwise eligible transfers
+ *         are rejected by @p filter.
  */
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number);
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number,
+				       enum uhc_xfer_mask mask, uhc_xfer_filter_func_t filter,
+				       void *priv);
 
 /**
  * @brief Helper to append a transfer to internal list.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -165,14 +165,16 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
 /**
  * @brief Helper to append a transfer to internal list.
  *
- * @param[in] dev    Pointer to device struct of the driver instance
- * @param[in] xfer   Pointer to UHC transfer
+ * @param[in] dev      Pointer to device struct of the driver instance
+ * @param[in] xfer     Pointer to UHC transfer
+ * @param[in] frame_number The current USB frame number, used to schedule periodic transfers
  *
  * @return 0 on success, all other values should be treated as error.
+ * @retval -EINVAL if the provided xfers is periodic and has interval equal to 0
  * @retval -ENOMEM if there is no buffer in the queue
  */
-int uhc_xfer_append(const struct device *dev,
-		    struct uhc_transfer *const xfer);
+int uhc_xfer_append(const struct device *dev, struct uhc_transfer *const xfer,
+		    uint32_t frame_number);
 
 /**
  * @brief Cleans up canceled transfer in the internal queues.

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -48,7 +48,9 @@ struct max3421e_data {
 	uint8_t mode;
 	uint8_t hxfr;
 	uint8_t hrsl;
+	uint8_t retries;
 	uint8_t skip_frames;
+	bool retry;
 };
 
 struct max3421e_config {
@@ -57,6 +59,16 @@ struct max3421e_config {
 	struct gpio_dt_spec dt_rst;
 	void (*make_thread)(const struct device *dev);
 };
+
+static bool max3421e_should_retry(const struct device *dev)
+{
+	struct max3421e_data *priv = uhc_get_private(dev);
+	bool retry = priv->retry;
+
+	priv->retry = false;
+
+	return retry;
+}
 
 static int max3421e_read_hirq(const struct device *dev,
 			      const uint8_t reg,
@@ -314,11 +326,12 @@ static int max3421e_xfer_control(const struct device *dev,
 	struct net_buf *buf = xfer->buf;
 	int ret;
 
-	/* Just restart if device NAKed packet */
-	if (HRSLT_IS_NAK(hrsl)) {
+	if (max3421e_should_retry(dev)) {
+		if (HRSLT_IS_TIMEOUT(hrsl)) {
+			LOG_WRN("Control transfer retry because of timeout");
+		}
 		return max3421e_hxfr_start(dev, priv->hxfr);
 	}
-
 
 	if (xfer->stage == UHC_CONTROL_STAGE_SETUP) {
 		LOG_DBG("Handle SETUP stage");
@@ -362,8 +375,10 @@ static int max3421e_xfer_bulk(const struct device *dev,
 	struct max3421e_data *priv = uhc_get_private(dev);
 	struct net_buf *buf = xfer->buf;
 
-	/* Just restart if device NAKed packet */
-	if (HRSLT_IS_NAK(hrsl)) {
+	if (max3421e_should_retry(dev)) {
+		if (HRSLT_IS_TIMEOUT(hrsl)) {
+			LOG_WRN("Bulk transfer retry because of timeout");
+		}
 		return max3421e_hxfr_start(dev, priv->hxfr);
 	}
 
@@ -413,6 +428,9 @@ static int max3421e_schedule_xfer(const struct device *dev)
 static void max3421e_xfer_drop_active(const struct device *dev, int err)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
+
+	priv->retries = 0;
+	priv->retry = false;
 
 	if (priv->last_xfer) {
 		uhc_xfer_return(dev, priv->last_xfer, err);
@@ -548,8 +566,21 @@ static int max3421e_handle_hxfrdn(const struct device *dev)
 		return -ENODATA;
 	}
 
+	if (!HRSLT_IS_TIMEOUT(hrsl)) {
+		priv->retries = 0;
+		priv->retry = false;
+	}
+
 	switch (MAX3421E_HRSLT(hrsl)) {
 	case MAX3421E_HR_NAK:
+		priv->retry = true;
+		break;
+	case MAX3421E_HR_TIMEOUT:
+		priv->retry = priv->retries++ < CONFIG_MAX3421E_MAX_TIMEOUT_RETRIES;
+		if (!priv->retry) {
+			max3421e_xfer_drop_active(dev, -ETIMEDOUT);
+		}
+		LOG_WRN("Transfer timed out");
 		break;
 	case MAX3421E_HR_STALL:
 		max3421e_xfer_drop_active(dev, -EPIPE);

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -39,10 +39,10 @@ struct max3421e_data {
 	struct gpio_callback gpio_cb;
 	struct uhc_transfer *last_xfer;
 	struct k_sem irq_sem;
+	uint32_t frame_number;
 	atomic_t state;
 	uint16_t tog_in;
 	uint16_t tog_out;
-	uint16_t frame_number;
 	uint8_t addr;
 	uint8_t hirq;
 	uint8_t hien;
@@ -864,7 +864,11 @@ static void uhc_max3421e_thread(void *p1, void *p2, void *p3)
 
 		/* Frame Generator Interrupt */
 		if (priv->hirq & MAX3421E_FRAME) {
-			priv->frame_number++;
+			/*
+			 * 1 tick = 125 microseconds, we get a FRAMEIRQ every milisecond,
+			 * thus we increment by 1 milisecond / 125 microseconds = 8 ticks
+			 */
+			priv->frame_number += 8;
 			schedule = !HRSLT_IS_BUSY(priv->hrsl) && priv->skip_frames <= 0;
 			if (priv->skip_frames > 0) {
 				priv->skip_frames--;

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +30,10 @@ LOG_MODULE_REGISTER(max3421e, CONFIG_UHC_DRIVER_LOG_LEVEL);
 
 #define MAX3421E_STATE_BUS_RESET	0
 #define MAX3421E_STATE_BUS_RESUME	1
+#define MAX3421E_STATE_ROOT_DEV_PRESENT 2
+
+/* Section 9.2.6.2 of USB 2.0 standard */
+#define MAX3421E_RST_SKIP_FRAME_CNT 10
 
 struct max3421e_data {
 	struct gpio_callback gpio_cb;
@@ -43,6 +48,7 @@ struct max3421e_data {
 	uint8_t mode;
 	uint8_t hxfr;
 	uint8_t hrsl;
+	uint8_t skip_frames;
 };
 
 struct max3421e_config {
@@ -492,11 +498,22 @@ static int max3421e_hrslt_success(const struct device *dev)
 		if (err) {
 			break;
 		}
+		xfer->recived_data_len += len;
 
-		LOG_INF("bc %u tr %u", bc, net_buf_tailroom(buf));
+		LOG_DBG("bc %u tr %u", bc, net_buf_tailroom(buf));
+		LOG_DBG("expected_data_len: %d; recived_data_len: %d", xfer->expected_data_len,
+			xfer->recived_data_len);
 
-		if (bc < MAX3421E_MAX_EP_SIZE || !net_buf_tailroom(buf)) {
-			LOG_INF("hrslt bulk in %u, %u", bc, len);
+		/*
+		 * Per USB 2.0 Specification
+		 * A USB Transfer has finished if the endpoint transfers (one or more):
+		 * - exactly the amount of data expected
+		 * - a packet with a payload size less than wMaxPacketSize of the endpoint
+		 * - a zero-length packet
+		 */
+		if ((xfer->recived_data_len >= xfer->expected_data_len) || (bc < xfer->mps) ||
+		    !net_buf_tailroom(buf)) {
+			LOG_DBG("hrslt bulk in %u, %u", bc, len);
 			if (xfer->ep == USB_CONTROL_EP_IN) {
 				xfer->stage = UHC_CONTROL_STAGE_STATUS;
 			} else {
@@ -553,50 +570,74 @@ static int max3421e_handle_hxfrdn(const struct device *dev)
 	return ret;
 }
 
-static void max3421e_handle_condet(const struct device *dev)
+static int max3421e_handle_condet(const struct device *dev)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
 	const uint8_t jk = priv->hrsl & MAX3421E_JKSTATUS_MASK;
+	uint8_t new_mode = priv->mode;
 	enum uhc_event_type type = UHC_EVT_ERROR;
+	bool is_low_speed;
+
+	if (atomic_test_bit(&priv->state, MAX3421E_STATE_BUS_RESET) ||
+	    atomic_test_bit(&priv->state, MAX3421E_STATE_BUS_RESUME)) {
+		/* NOTE: Resetting the bus triggers a spurious condet event */
+		return 0;
+	}
 
 	/*
-	 * JSTATUS:KSTATUS 0:0 - SE0
-	 * JSTATUS:KSTATUS 0:1 - K   (Resume)
-	 * JSTATUS:KSTATUS 1:0 - J   (Idle)
+	 * JSTATUS:KSTATUS 0:0 = SE0 = No device present
+	 * JSTATUS:KSTATUS 1:1 = SE1 = illegal state
+	 * JSTATUS:KSTATUS 0:1 =  K  = Device connected at a different speed than the current one
+	 * JSTATUS:KSTATUS 1:0 =  J  = Device connected at the same speed
 	 */
-	if (jk == 0) {
-		/* Device disconnected */
+	switch (jk) {
+	case 0:
+		LOG_INF("Device disconnected");
 		type = UHC_EVT_DEV_REMOVED;
+		/* NOTE: We set SOFKAENAB in max3421e_bus_event */
+		new_mode &= ~MAX3421E_SOFKAENAB;
+		priv->skip_frames = 0;
+		atomic_clear_bit(&priv->state, MAX3421E_STATE_ROOT_DEV_PRESENT);
+		break;
+	case MAX3421E_KSTATUS:
+		/* Need to switch speed */
+		new_mode ^= MAX3421E_LOWSPEED;
+	case MAX3421E_JSTATUS:
+		is_low_speed = new_mode & MAX3421E_LOWSPEED;
+
+		type = is_low_speed ? UHC_EVT_DEV_CONNECTED_LS : UHC_EVT_DEV_CONNECTED_FS;
+		LOG_INF("%s Device connected", is_low_speed ? "LS" : "FS");
+		atomic_set_bit(&priv->state, MAX3421E_STATE_ROOT_DEV_PRESENT);
+		break;
+	case (MAX3421E_JSTATUS | MAX3421E_KSTATUS):
+		LOG_ERR("Illegal USB Bus state");
+		type = UHC_EVT_ERROR;
+		break;
 	}
 
-	if (jk == MAX3421E_JSTATUS) {
-		/* Device connected */
-		type = UHC_EVT_DEV_CONNECTED_FS;
-	}
-
-	if (jk == MAX3421E_KSTATUS) {
-		/* Device connected */
-		type = UHC_EVT_DEV_CONNECTED_LS;
+	if (priv->mode != new_mode) {
+		LOG_DBG("Changing mode. New Mode: %02x; Old Mode:%02x ", new_mode, priv->mode);
+		max3421e_write_byte(dev, MAX3421E_REG_MODE, new_mode);
+		priv->mode = new_mode;
 	}
 
 	uhc_submit_event(dev, type, 0);
+
+	return 0;
 }
 
-static void max3421e_bus_event(const struct device *dev)
+/* Enable SOF generator */
+static int max3421e_sof_enable(const struct device *dev)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
 
-	if (atomic_test_and_clear_bit(&priv->state,
-				      MAX3421E_STATE_BUS_RESUME)) {
-		/* Resume operation done event */
-		uhc_submit_event(dev, UHC_EVT_RESUMED, 0);
+	if (priv->mode & MAX3421E_SOFKAENAB) {
+		return -EALREADY;
 	}
 
-	if (atomic_test_and_clear_bit(&priv->state,
-				      MAX3421E_STATE_BUS_RESET)) {
-		/* Reset operation done event */
-		uhc_submit_event(dev, UHC_EVT_RESETED, 0);
-	}
+	priv->mode |= MAX3421E_SOFKAENAB;
+
+	return max3421e_write_byte(dev, MAX3421E_REG_MODE, priv->mode);
 }
 
 static int max3421e_update_hrsl_hirq(const struct device *dev)
@@ -610,6 +651,70 @@ static int max3421e_update_hrsl_hirq(const struct device *dev)
 	LOG_DBG("HIRQ 0x%02x HRSLT %d", priv->hirq, MAX3421E_HRSLT(priv->hrsl));
 
 	return err;
+}
+
+static int max3421e_bus_sample(const struct device *dev)
+{
+	struct max3421e_data *priv = uhc_get_private(dev);
+	int ret;
+
+	ret = max3421e_write_byte(dev, MAX3421E_REG_HCTL, MAX3421E_SAMPLEBUS);
+	if (ret) {
+		return ret;
+	}
+
+	return max3421e_read(dev, MAX3421E_REG_HRSL, &priv->hrsl, sizeof(priv->hrsl));
+}
+
+static inline bool max3421e_is_root_dev_present(const struct device *dev)
+{
+	struct max3421e_data *priv = uhc_get_private(dev);
+
+	return atomic_test_bit(&priv->state, MAX3421E_STATE_ROOT_DEV_PRESENT);
+}
+
+static int max3421e_bus_probe(const struct device *dev)
+{
+	int ret;
+
+	/*
+	 * MAX3421E does not detect connections while the bus is suspended. A newly
+	 * connected device may signal remote wakeup, causing the controller to resume,
+	 * so sample the bus manually if no root device was previously detected.
+	 *
+	 * Disconnects require no such check because they are detected during suspend.
+	 */
+	if (max3421e_is_root_dev_present(dev)) {
+		return 0;
+	}
+
+	ret = max3421e_bus_sample(dev);
+	if (ret) {
+		return ret;
+	}
+
+	return max3421e_handle_condet(dev);
+}
+
+static void max3421e_bus_event(const struct device *dev)
+{
+	struct max3421e_data *priv = uhc_get_private(dev);
+
+	if (atomic_test_and_clear_bit(&priv->state, MAX3421E_STATE_BUS_RESUME)) {
+		/* Resume operation done event */
+		LOG_DBG("Bus Resume Done");
+		uhc_submit_event(dev, UHC_EVT_RESUMED, 0);
+		max3421e_sof_enable(dev);
+		max3421e_bus_probe(dev);
+	}
+
+	if (atomic_test_and_clear_bit(&priv->state, MAX3421E_STATE_BUS_RESET)) {
+		/* Reset operation done event */
+		LOG_DBG("Bus Reset Done");
+		max3421e_sof_enable(dev);
+		priv->skip_frames = MAX3421E_RST_SKIP_FRAME_CNT;
+		uhc_submit_event(dev, UHC_EVT_RESETED, 0);
+	}
 }
 
 static int max3421e_clear_hirq(const struct device *dev, const uint8_t hirq)
@@ -684,7 +789,10 @@ static void uhc_max3421e_thread(void *p1, void *p2, void *p3)
 
 		/* Frame Generator Interrupt */
 		if (priv->hirq & MAX3421E_FRAME) {
-			schedule = HRSLT_IS_BUSY(priv->hrsl) ? false : true;
+			schedule = !HRSLT_IS_BUSY(priv->hrsl) && priv->skip_frames <= 0;
+			if (priv->skip_frames > 0) {
+				priv->skip_frames--;
+			}
 		}
 
 		/* Shorten the if path a little */
@@ -722,20 +830,6 @@ static void max3421e_gpio_cb(const struct device *dev,
 		CONTAINER_OF(cb, struct max3421e_data, gpio_cb);
 
 	k_sem_give(&priv->irq_sem);
-}
-
-/* Enable SOF generator */
-static int max3421e_sof_enable(const struct device *dev)
-{
-	struct max3421e_data *priv = uhc_get_private(dev);
-
-	if (priv->mode & MAX3421E_SOFKAENAB) {
-		return -EALREADY;
-	}
-
-	priv->mode |= MAX3421E_SOFKAENAB;
-
-	return max3421e_write_byte(dev, MAX3421E_REG_MODE, priv->mode);
 }
 
 /* Disable SOF generator and suspend bus */
@@ -1014,8 +1108,7 @@ static int uhc_max3421e_init(const struct device *dev)
 
 	priv->addr = 0;
 
-	/* Sample bus if device is already connected */
-	return max3421e_write_byte(dev, MAX3421E_REG_HCTL, MAX3421E_SAMPLEBUS);
+	return 0;
 }
 
 static int uhc_max3421e_enable(const struct device *dev)

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -433,7 +433,8 @@ static int max3421e_schedule_xfer(const struct device *dev)
 		/* Do not restart last transfer */
 		hrsl = 0;
 
-		priv->last_xfer = uhc_xfer_get_next(dev, priv->frame_number);
+		priv->last_xfer =
+			uhc_xfer_get_next(dev, priv->frame_number, UHC_XFER_MASK_ALL, NULL, NULL);
 		if (priv->last_xfer == NULL) {
 			LOG_DBG("Nothing to transfer");
 			return 0;

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -497,7 +497,7 @@ static void max3421e_xfer_cleanup_cancelled(const struct device *dev)
 
 	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->ctrl_xfers);
 	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->bulk_xfers);
-	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->int_xfers);
+	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->periodic_xfers);
 }
 
 static int max3421e_hrslt_success(const struct device *dev)
@@ -993,7 +993,7 @@ static int max3421e_dequeue(const struct device *dev,
 	case USB_EP_TYPE_ISO:
 		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
 	case USB_EP_TYPE_INTERRUPT:
-		dlist = &data->int_xfers;
+		dlist = &data->periodic_xfers;
 		break;
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -42,6 +42,7 @@ struct max3421e_data {
 	atomic_t state;
 	uint16_t tog_in;
 	uint16_t tog_out;
+	uint16_t frame_number;
 	uint8_t addr;
 	uint8_t hirq;
 	uint8_t hien;
@@ -390,6 +391,37 @@ static int max3421e_xfer_bulk(const struct device *dev,
 	return max3421e_xfer_data(dev, buf, xfer->ep);
 }
 
+static int max3421e_xfer_interrupt(const struct device *dev,
+				   struct uhc_transfer *const xfer,
+				   const uint8_t hrsl)
+{
+	struct max3421e_data *priv = uhc_get_private(dev);
+	struct net_buf *buf = xfer->buf;
+
+	/*
+	 * USB 2.0 spec section 5.7.4
+	 * If the endpoint has no interrupt data to transmit when accessed by the host,
+	 * it responds with NAK. An endpoint should only provide interrupt data
+	 * when it has an interrupt pending to avoid having a software client
+	 * erroneously notified of IRP complete.
+	 */
+	if (max3421e_should_retry(dev)) {
+		if (HRSLT_IS_TIMEOUT(hrsl)) {
+			LOG_WRN("Rescheduling interrupt after a timeout");
+		}
+		uhc_xfer_reschedule_periodic(dev, xfer, priv->frame_number);
+		priv->last_xfer = NULL;
+		return 0;
+	}
+
+	if (buf == NULL) {
+		LOG_ERR("No buffer to handle");
+		return -ENODATA;
+	}
+
+	return max3421e_xfer_data(dev, buf, xfer->ep);
+}
+
 static int max3421e_schedule_xfer(const struct device *dev)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
@@ -401,7 +433,7 @@ static int max3421e_schedule_xfer(const struct device *dev)
 		/* Do not restart last transfer */
 		hrsl = 0;
 
-		priv->last_xfer = uhc_xfer_get_next(dev);
+		priv->last_xfer = uhc_xfer_get_next(dev, priv->frame_number);
 		if (priv->last_xfer == NULL) {
 			LOG_DBG("Nothing to transfer");
 			return 0;
@@ -414,15 +446,19 @@ static int max3421e_schedule_xfer(const struct device *dev)
 		}
 	}
 
-	/*
-	 * TODO: currently we only support control transfers and
-	 * treat all others as bulk.
-	 */
-	if (USB_EP_GET_IDX(priv->last_xfer->ep) == 0) {
+	switch (priv->last_xfer->type) {
+	case USB_EP_TYPE_CONTROL:
 		return max3421e_xfer_control(dev, priv->last_xfer, hrsl);
+	case USB_EP_TYPE_BULK:
+		return max3421e_xfer_bulk(dev, priv->last_xfer, hrsl);
+	case USB_EP_TYPE_ISO:
+		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
+	case USB_EP_TYPE_INTERRUPT:
+		return max3421e_xfer_interrupt(dev, priv->last_xfer, hrsl);
+	default:
+		LOG_ERR("Invalid xfer type: %d", priv->last_xfer->type);
+		return -EINVAL;
 	}
-
-	return max3421e_xfer_bulk(dev, priv->last_xfer, hrsl);
 }
 
 static void max3421e_xfer_drop_active(const struct device *dev, int err)
@@ -438,21 +474,29 @@ static void max3421e_xfer_drop_active(const struct device *dev, int err)
 	}
 }
 
+static void max3421e_dlist_xfer_cleanup_cancelled(const struct device *dev, sys_dlist_t *dlist)
+{
+	struct uhc_transfer *tmp;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
+		if (tmp->err == -ECONNRESET) {
+			uhc_xfer_return(dev, tmp, -ECONNRESET);
+		}
+	}
+}
+
 static void max3421e_xfer_cleanup_cancelled(const struct device *dev)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
 	struct uhc_data *data = dev->data;
-	struct uhc_transfer *tmp;
 
 	if (priv->last_xfer != NULL && priv->last_xfer->err == -ECONNRESET) {
 		max3421e_xfer_drop_active(dev, -ECONNRESET);
 	}
 
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
-		if (tmp->err == -ECONNRESET) {
-			uhc_xfer_return(dev, tmp, -ECONNRESET);
-		}
-	}
+	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->ctrl_xfers);
+	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->bulk_xfers);
+	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->int_xfers);
 }
 
 static int max3421e_hrslt_success(const struct device *dev)
@@ -820,6 +864,7 @@ static void uhc_max3421e_thread(void *p1, void *p2, void *p3)
 
 		/* Frame Generator Interrupt */
 		if (priv->hirq & MAX3421E_FRAME) {
+			priv->frame_number++;
 			schedule = !HRSLT_IS_BUSY(priv->hrsl) && priv->skip_frames <= 0;
 			if (priv->skip_frames > 0) {
 				priv->skip_frames--;
@@ -915,6 +960,13 @@ static int max3421e_bus_resume(const struct device *dev)
 static int max3421e_enqueue(const struct device *dev,
 			    struct uhc_transfer *const xfer)
 {
+	struct max3421e_data *priv = uhc_get_private(dev);
+
+	if (xfer->interval) {
+		xfer->start_frame = priv->frame_number + xfer->interval;
+		LOG_DBG("New periodic transfer s.f. %u f.n. %u interval %u", xfer->start_frame,
+			priv->frame_number, xfer->interval);
+	}
 	return uhc_xfer_append(dev, xfer);
 }
 
@@ -923,12 +975,32 @@ static int max3421e_dequeue(const struct device *dev,
 {
 	struct uhc_data *data = dev->data;
 	struct uhc_transfer *tmp;
+	sys_dlist_t *dlist;
 	unsigned int key;
 
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+		dlist = &data->ctrl_xfers;
+		break;
+	case USB_EP_TYPE_BULK:
+		dlist = &data->bulk_xfers;
+		break;
+	case USB_EP_TYPE_ISO:
+		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
+	case USB_EP_TYPE_INTERRUPT:
+		dlist = &data->int_xfers;
+		break;
+	default:
+		LOG_ERR("Invalid xfer type: %d", xfer->type);
+		return -EINVAL;
+	}
+
 	key = irq_lock();
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
 		if (xfer == tmp) {
 			tmp->err = -ECONNRESET;
+			break;
 		}
 	}
 

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -953,12 +953,7 @@ static int max3421e_enqueue(const struct device *dev,
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
 
-	if (xfer->interval) {
-		xfer->start_frame = priv->frame_number + xfer->interval;
-		LOG_DBG("New periodic transfer s.f. %u f.n. %u interval %u", xfer->start_frame,
-			priv->frame_number, xfer->interval);
-	}
-	return uhc_xfer_append(dev, xfer);
+	return uhc_xfer_append(dev, xfer, priv->frame_number);
 }
 
 static int max3421e_dequeue(const struct device *dev,

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -475,29 +475,15 @@ static void max3421e_xfer_drop_active(const struct device *dev, int err)
 	}
 }
 
-static void max3421e_dlist_xfer_cleanup_cancelled(const struct device *dev, sys_dlist_t *dlist)
-{
-	struct uhc_transfer *tmp;
-
-	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
-		if (tmp->err == -ECONNRESET) {
-			uhc_xfer_return(dev, tmp, -ECONNRESET);
-		}
-	}
-}
-
 static void max3421e_xfer_cleanup_cancelled(const struct device *dev)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
-	struct uhc_data *data = dev->data;
 
 	if (priv->last_xfer != NULL && priv->last_xfer->err == -ECONNRESET) {
 		max3421e_xfer_drop_active(dev, -ECONNRESET);
 	}
 
-	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->ctrl_xfers);
-	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->bulk_xfers);
-	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->periodic_xfers);
+	uhc_xfer_cleanup_cancelled(dev);
 }
 
 static int max3421e_hrslt_success(const struct device *dev)
@@ -978,40 +964,7 @@ static int max3421e_enqueue(const struct device *dev,
 static int max3421e_dequeue(const struct device *dev,
 			    struct uhc_transfer *const xfer)
 {
-	struct uhc_data *data = dev->data;
-	struct uhc_transfer *tmp;
-	sys_dlist_t *dlist;
-	unsigned int key;
-
-	switch (xfer->type) {
-	case USB_EP_TYPE_CONTROL:
-		dlist = &data->ctrl_xfers;
-		break;
-	case USB_EP_TYPE_BULK:
-		dlist = &data->bulk_xfers;
-		break;
-	case USB_EP_TYPE_ISO:
-		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
-	case USB_EP_TYPE_INTERRUPT:
-		dlist = &data->periodic_xfers;
-		break;
-	default:
-		LOG_ERR("Invalid xfer type: %d", xfer->type);
-		return -EINVAL;
-	}
-
-	key = irq_lock();
-
-	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
-		if (xfer == tmp) {
-			tmp->err = -ECONNRESET;
-			break;
-		}
-	}
-
-	irq_unlock(key);
-
-	return 0;
+	return uhc_xfer_dequeue(dev, xfer);
 }
 
 static int max3421e_reset(const struct device *dev)
@@ -1240,8 +1193,7 @@ static int uhc_max3421e_shutdown(const struct device *dev)
 static int max3421e_driver_init(const struct device *dev)
 {
 	const struct max3421e_config *config = dev->config;
-	struct uhc_data *data = dev->data;
-	struct max3421e_data *priv = data->priv;
+	struct max3421e_data *priv = uhc_get_private(dev);
 	int ret;
 
 	if (config->dt_rst.port) {
@@ -1289,7 +1241,7 @@ static int max3421e_driver_init(const struct device *dev)
 		return ret;
 	}
 
-	k_mutex_init(&data->mutex);
+	uhc_common_init(dev);
 	config->make_thread(dev);
 
 	LOG_DBG("MAX3421E CPU interface initialized");

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -252,7 +252,7 @@ static usb_host_pipe_handle uhc_mcux_check_hal_ep(const struct device *dev,
 	if (mcux_ep->pipeType != xfer->type ||
 	    mcux_ep->maxPacketSize != USB_MPS_EP_SIZE(xfer->mps) ||
 	    mcux_ep->numberPerUframe != USB_MPS_ADDITIONAL_TRANSACTIONS(xfer->mps) + 1 ||
-	    priv->mcux_eps_interval[i] != xfer->interval) {
+	    priv->mcux_eps_interval[i] != xfer->bInterval) {
 		status = priv->mcux_if->controllerClosePipe(priv->mcux_host.controllerHandle,
 							    mcux_ep);
 		if (status != kStatus_USB_Success) {
@@ -294,7 +294,7 @@ usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct uhc_trans
 	 * 'number per uframe' and the endpoint type cannot be got yet.
 	 */
 	pipe_init.numberPerUframe = USB_MPS_ADDITIONAL_TRANSACTIONS(xfer->mps);
-	pipe_init.interval = xfer->interval;
+	pipe_init.interval = xfer->bInterval;
 	pipe_init.pipeType = xfer->type;
 
 	status = priv->mcux_if->controllerOpenPipe(priv->mcux_host.controllerHandle,
@@ -315,7 +315,7 @@ usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct uhc_trans
 	for (i = 0; i < USB_HOST_CONFIG_MAX_PIPES; i++) {
 		if (priv->mcux_eps[i] == NULL) {
 			priv->mcux_eps[i] = mcux_ep;
-			priv->mcux_eps_interval[i] = xfer->interval;
+			priv->mcux_eps_interval[i] = xfer->bInterval;
 			break;
 		}
 	}

--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -247,7 +247,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -173,7 +173,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_mcux_khci.c
+++ b/drivers/usb/uhc/uhc_mcux_khci.c
@@ -160,7 +160,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_mcux_ohci.c
+++ b/drivers/usb/uhc/uhc_mcux_ohci.c
@@ -160,7 +160,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_virtual.c
+++ b/drivers/usb/uhc/uhc_virtual.c
@@ -49,7 +49,8 @@ struct uhc_vrt_data {
 	struct uhc_transfer *last_xfer;
 	struct uhc_vrt_frame frame;
 	struct k_timer sof_timer;
-	uint16_t frame_number;
+	uint32_t frame_number;
+	uint8_t frame_increment;
 	uint8_t req;
 };
 
@@ -198,51 +199,53 @@ static inline uint8_t get_xfer_ep_idx(const uint8_t ep)
 	return USB_EP_GET_IDX(ep & BIT_MASK(4)) + 16U;
 }
 
+bool vrt_filter_xfers(const struct uhc_transfer *xfer, void *priv)
+{
+	uint32_t *bm = priv;
+
+	uint8_t idx = get_xfer_ep_idx(xfer->ep);
+
+	/* There could be multiple transfers queued for the same
+	 * endpoint, for now we only allow one to be scheduled per frame.
+	 */
+	if (*bm & BIT(idx)) {
+		return false;
+	}
+
+	*bm |= BIT(idx);
+
+	return true;
+}
+
 static void vrt_assemble_frame(const struct device *dev)
 {
 	struct uhc_vrt_data *const priv = uhc_get_private(dev);
 	struct uhc_vrt_frame *const frame = &priv->frame;
-	struct uhc_data *const data = dev->data;
 	struct uhc_transfer *tmp;
 	unsigned int n = 0;
 	unsigned int key;
 	uint32_t bm = 0;
 
+	key = irq_lock();
+
+	uhc_xfer_defer_all_active(dev);
+
 	sys_dlist_init(&frame->list);
 	frame->ptr = NULL;
 	frame->count = 0;
-	key = irq_lock();
 
 	/* TODO: add periodic transfers up to 90% */
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
-		uint8_t idx = get_xfer_ep_idx(tmp->ep);
-
-		/* There could be multiple transfers queued for the same
-		 * endpoint, for now we only allow one to be scheduled per frame.
-		 */
-		if (bm & BIT(idx)) {
-			continue;
+	while (n < FRAME_MAX_TRANSFERS) {
+		tmp = uhc_xfer_get_next(dev, priv->frame_number, UHC_XFER_MASK_ALL,
+					vrt_filter_xfers, &bm);
+		if (tmp == NULL) {
+			/* No pending transfers */
+			break;
 		}
 
-		if (tmp->interval) {
-			if (tmp->start_frame != priv->frame_number) {
-				continue;
-			}
-
-			tmp->start_frame = priv->frame_number + tmp->interval;
-			LOG_DBG("Interrupt transfer s.f. %u f.n. %u interval %u",
-				tmp->start_frame, priv->frame_number, tmp->interval);
-		}
-
-		bm |= BIT(idx);
 		frame->slots[n].xfer = tmp;
 		sys_dlist_append(&frame->list, &frame->slots[n].node);
 		n++;
-
-		if (n >= FRAME_MAX_TRANSFERS) {
-			/* No more free slots */
-			break;
-		}
 	}
 
 	irq_unlock(key);
@@ -398,18 +401,12 @@ handle_reply_err:
 static void vrt_xfer_cleanup_cancelled(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
-	struct uhc_data *data = dev->data;
-	struct uhc_transfer *tmp;
 
 	if (priv->last_xfer != NULL && priv->last_xfer->err == -ECONNRESET) {
 		vrt_xfer_drop_active(dev, -ECONNRESET);
 	}
 
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
-		if (tmp->err == -ECONNRESET) {
-			uhc_xfer_return(dev, tmp, -ECONNRESET);
-		}
-	}
+	uhc_xfer_cleanup_cancelled(dev);
 }
 
 static void xfer_work_handler(struct k_work *work)
@@ -424,7 +421,7 @@ static void xfer_work_handler(struct k_work *work)
 
 		switch (ev->type) {
 		case UHC_VRT_EVT_SOF:
-			priv->frame_number++;
+			priv->frame_number += priv->frame_increment;
 			vrt_xfer_cleanup_cancelled(dev);
 			vrt_assemble_frame(dev);
 			schedule = true;
@@ -472,10 +469,12 @@ static void vrt_device_act(const struct device *dev,
 		break;
 	case UVB_DEVICE_ACT_FS:
 		type = UHC_EVT_DEV_CONNECTED_FS;
+		priv->frame_increment = 8;
 		k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
 		break;
 	case UVB_DEVICE_ACT_HS:
 		type = UHC_EVT_DEV_CONNECTED_HS;
+		priv->frame_increment = 1;
 		k_timer_start(&priv->sof_timer, K_MSEC(1), K_USEC(125));
 		break;
 	case UVB_DEVICE_ACT_REMOVED:
@@ -506,8 +505,9 @@ static void uhc_vrt_uvb_cb(const void *const vrt_priv,
 static int uhc_vrt_sof_enable(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
+	k_timeout_t period = priv->frame_increment == 8 ? K_MSEC(1) : K_USEC(125);
 
-	k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
+	k_timer_start(&priv->sof_timer, K_MSEC(1), period);
 
 	return 0;
 }
@@ -525,13 +525,14 @@ static int uhc_vrt_bus_suspend(const struct device *dev)
 static int uhc_vrt_bus_reset(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
+	k_timeout_t period = priv->frame_increment == 8 ? K_MSEC(1) : K_USEC(125);
 	int ret;
 
 	k_timer_stop(&priv->sof_timer);
 	ret = uvb_advert(priv->host_node, UVB_EVT_RESET, NULL);
 	/* TDRSTR */
 	k_msleep(50);
-	k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
+	k_timer_start(&priv->sof_timer, K_MSEC(1), period);
 
 	return ret;
 }
@@ -539,8 +540,9 @@ static int uhc_vrt_bus_reset(const struct device *dev)
 static int uhc_vrt_bus_resume(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
+	k_timeout_t period = priv->frame_increment == 8 ? K_MSEC(1) : K_USEC(125);
 
-	k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
+	k_timer_start(&priv->sof_timer, K_MSEC(1), period);
 
 	return uvb_advert(priv->host_node, UVB_EVT_RESUME, NULL);
 }
@@ -550,13 +552,7 @@ static int uhc_vrt_enqueue(const struct device *dev,
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
 
-	if (xfer->interval) {
-		xfer->start_frame = priv->frame_number + xfer->interval;
-		LOG_DBG("New interrupt transfer s.f. %u f.n. %u interval %u",
-			xfer->start_frame, priv->frame_number, xfer->interval);
-	}
-
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, priv->frame_number);
 
 	return 0;
 }
@@ -564,18 +560,10 @@ static int uhc_vrt_enqueue(const struct device *dev,
 static int uhc_vrt_dequeue(const struct device *dev,
 			    struct uhc_transfer *const xfer)
 {
-	struct uhc_data *data = dev->data;
-	struct uhc_transfer *tmp;
 	unsigned int key;
 
 	key = irq_lock();
-
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
-		if (xfer == tmp) {
-			tmp->err = -ECONNRESET;
-		}
-	}
-
+	uhc_xfer_dequeue(dev, xfer);
 	irq_unlock(key);
 
 	return 0;
@@ -619,12 +607,13 @@ static int uhc_vrt_unlock(const struct device *dev)
 static int uhc_vrt_driver_preinit(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
-	struct uhc_data *data = dev->data;
 
 	priv->dev = dev;
-	k_mutex_init(&data->mutex);
+	uhc_common_init(dev);
 
 	priv->host_node->priv = dev;
+	/* Default to SOF every 1 millisecond */
+	priv->frame_increment = 8;
 	k_fifo_init(&priv->fifo);
 	k_work_init(&priv->work, xfer_work_handler);
 	k_timer_init(&priv->sof_timer, sof_timer_handler, NULL);

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -143,6 +143,10 @@ struct uhc_transfer {
 	 * This flag is optional and is mainly used for testing.
 	 */
 	unsigned int no_status : 1;
+	/** Expected length of the data that wil be recived (device to host xfers only)*/
+	size_t expected_data_len;
+	/** Length of the data that was already received (device to host xfers only)*/
+	size_t recived_data_len;
 	/** Pointer to USB device */
 	struct usb_device *udev;
 	/** Pointer to transfer completion callback (opaque for the UHC) */
@@ -414,17 +418,20 @@ static inline int uhc_bus_resume(const struct device *dev)
  * Transfer has no buffer after allocation, but can be allocated
  * and added from different pools.
  *
- * @param[in] dev     Pointer to device struct of the driver instance
- * @param[in] ep      Endpoint address
- * @param[in] udev    Pointer to USB device
- * @param[in] cb      Transfer completion callback
- * @param[in] cb_priv Completion callback callback private data
+ * @param[in] dev       Pointer to device struct of the driver instance
+ * @param[in] ep        Endpoint address
+ * @param[in] udev      Pointer to USB device
+ * @param[in] rec_len   Desired length of the response from the device in bytes.
+ *                      Set to 0 if receiving one packet or if sending data.
+ * @param[in] cb	Transfer completion callback
+ * @param[in] cb_priv   Completion callback callback private data
  *
  * @return pointer to allocated transfer or NULL on error.
  */
 struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
+				    const size_t rec_len,
 				    void *const cb,
 				    void *const cb_priv);
 

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -264,8 +264,8 @@ struct uhc_data {
 	sys_dlist_t ctrl_xfers;
 	/** dlist for bulk transfers */
 	sys_dlist_t bulk_xfers;
-	/** dlist for interrupt transfers, sorted in descending order by start_frame */
-	sys_dlist_t int_xfers;
+	/** dlist for periodic transfers, sorted in descending order by start_frame */
+	sys_dlist_t periodic_xfers;
 	/** Callback to submit an UHC event to upper layer */
 	uhc_event_cb_t event_cb;
 	/** Opaque pointer to store higher layer context */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -256,6 +256,8 @@ struct uhc_data {
 	sys_dlist_t ctrl_xfers;
 	/** dlist for bulk transfers */
 	sys_dlist_t bulk_xfers;
+	/** dlist for interrupt transfers, sorted in descending order by start_frame */
+	sys_dlist_t int_xfers;
 	/** Callback to submit an UHC event to upper layer */
 	uhc_event_cb_t event_cb;
 	/** Opaque pointer to store higher layer context */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -130,10 +130,18 @@ struct uhc_transfer {
 	uint8_t type;
 	/** Maximum packet size */
 	uint16_t mps;
-	/** Interval, used for periodic transfers only */
-	uint16_t interval;
+	/**
+	 * Tick interval converted from the bInterval, used for periodic transfers only.
+	 * For Low Speed and Full Speed interrupt endpoints its equal to bInterval * 8
+	 * For Full Speed isochronous endpoints its equal to 2^(bInterval - 1) * 8
+	 * For High Speed and Super Speed endpoints its equal to 2^(bInterval - 1)
+	 * 1 tick = 125 microseconds
+	 */
+	uint32_t interval;
+	/** Unconverted bInterval, used for periodic transfers only */
+	uint16_t bInterval;
 	/** Start frame, used for periodic transfers only */
-	uint16_t start_frame;
+	uint32_t start_frame;
 	/** Flag marks request buffer is queued */
 	unsigned int queued : 1;
 	/** Control stage status, up to the driver to use it or not */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -144,6 +144,11 @@ struct uhc_transfer {
 	uint32_t start_frame;
 	/** Flag marks request buffer is queued */
 	unsigned int queued : 1;
+	/**
+	 * Flag marks if the transfer is currently in the active xfer dlist,
+	 *  which means that it is processed by the UHC driver
+	 */
+	unsigned int active : 1;
 	/** Control stage status, up to the driver to use it or not */
 	unsigned int stage : 2;
 	/**
@@ -266,6 +271,8 @@ struct uhc_data {
 	sys_dlist_t bulk_xfers;
 	/** dlist for periodic transfers, sorted in descending order by start_frame */
 	sys_dlist_t periodic_xfers;
+	/** dlist for transfers being scheduled in hardware */
+	sys_dlist_t active_xfers;
 	/** Callback to submit an UHC event to upper layer */
 	uhc_event_cb_t event_cb;
 	/** Opaque pointer to store higher layer context */

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -1515,11 +1515,13 @@ static int initiate_transfer(struct uvc_host_data *const host_data,
 	const struct usb_ep_descriptor *const stream_ep = stream_info->ep;
 	struct net_buf *buf;
 	struct uhc_transfer *xfer;
+	size_t rec_len =
+		USB_EP_DIR_IS_IN(stream_ep->bEndpointAddress) ? stream_info->ep_mps_mult : 0;
 	int ret;
 
 	LOG_DBG("Initiating transfer: ep=0x%02x, vbuf=%p", stream_ep->bEndpointAddress, vbuf);
 
-	xfer = usbh_xfer_alloc(host_data->udev, stream_ep->bEndpointAddress,
+	xfer = usbh_xfer_alloc(host_data->udev, stream_ep->bEndpointAddress, rec_len,
 			       stream_iso_req_cb, host_data);
 	if (xfer == NULL) {
 		LOG_ERR("Failed to allocate transfer");

--- a/subsys/usb/host/usbh_ch9.c
+++ b/subsys/usb/host/usbh_ch9.c
@@ -66,7 +66,7 @@ int usbh_req_setup(struct usb_device *const udev,
 	uint8_t ep = usb_reqtype_is_to_device(&req) ? 0x00 : 0x80;
 	int ret;
 
-	xfer = usbh_xfer_alloc(udev, ep, ch9_req_cb, NULL);
+	xfer = usbh_xfer_alloc(udev, ep, wLength, ch9_req_cb, NULL);
 	if (!xfer) {
 		return -ENOMEM;
 	}

--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -56,10 +56,16 @@ static void dev_connected_handler(struct usbh_context *const ctx,
 		return;
 	}
 
-	if (event->type == UHC_EVT_DEV_CONNECTED_HS) {
+	switch (event->type) {
+	case UHC_EVT_DEV_CONNECTED_HS:
 		udev->speed = USB_SPEED_SPEED_HS;
-	} else {
+		break;
+	case UHC_EVT_DEV_CONNECTED_FS:
 		udev->speed = USB_SPEED_SPEED_FS;
+		break;
+	case UHC_EVT_DEV_CONNECTED_LS:
+	default:
+		udev->speed = USB_SPEED_SPEED_LS;
 	}
 
 	usbh_device_connect(ctx, udev);
@@ -97,8 +103,6 @@ static ALWAYS_INLINE int usbh_event_handler(struct usbh_context *const ctx,
 
 	switch (event->type) {
 	case UHC_EVT_DEV_CONNECTED_LS:
-		LOG_ERR("Low speed device not supported (connected event)");
-		break;
 	case UHC_EVT_DEV_CONNECTED_FS:
 	case UHC_EVT_DEV_CONNECTED_HS:
 		dev_connected_handler(ctx, event);
@@ -117,6 +121,7 @@ static ALWAYS_INLINE int usbh_event_handler(struct usbh_context *const ctx,
 		break;
 	case UHC_EVT_RWUP:
 		LOG_DBG("RWUP event");
+		uhc_bus_resume(ctx->dev);
 		break;
 	case UHC_EVT_ERROR:
 		LOG_DBG("Error event %d", event->status);

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -77,7 +77,7 @@ static int validate_device_mps0(const struct usb_device *const udev)
 {
 	const uint8_t mps0 = udev->dev_desc.bMaxPacketSize0;
 
-	if (udev->speed == USB_SPEED_SPEED_SS || udev->speed == USB_SPEED_SPEED_LS) {
+	if (udev->speed == USB_SPEED_SPEED_SS) {
 		LOG_ERR("USB device speed not supported");
 		return -ENOTSUP;
 	}
@@ -92,6 +92,13 @@ static int validate_device_mps0(const struct usb_device *const udev)
 	if (udev->speed == USB_SPEED_SPEED_FS) {
 		if (mps0 != 8 && mps0 != 16 && mps0 != 32 && mps0 != 64) {
 			LOG_ERR("FS device has wrong bMaxPacketSize0 %u", mps0);
+			return -EINVAL;
+		}
+	}
+
+	if (udev->speed == USB_SPEED_SPEED_LS) {
+		if (mps0 != 8) {
+			LOG_ERR("LS device has wrong bMaxPacketSize0 %u", mps0);
 			return -EINVAL;
 		}
 	}

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -57,12 +57,13 @@ void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev);
 /* Wrappers around to avoid glue UHC calls. */
 static inline struct uhc_transfer *usbh_xfer_alloc(struct usb_device *udev,
 						   const uint8_t ep,
+						   const size_t rec_len,
 						   usbh_udev_cb_t cb,
 						   void *const cb_priv)
 {
 	struct usbh_context *const ctx = udev->ctx;
 
-	return uhc_xfer_alloc(ctx->dev, ep, udev, cb, cb_priv);
+	return uhc_xfer_alloc(ctx->dev, ep, udev, rec_len, cb, cb_priv);
 }
 
 static inline int usbh_xfer_buf_add(const struct usb_device *udev,

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -252,7 +252,7 @@ static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 	ep = strtol(argv[2], NULL, 16);
 	len = MIN(sizeof(vreq_test_buf), strtol(argv[3], NULL, 10));
 
-	xfer = usbh_xfer_alloc(udev, ep, bulk_req_cb, NULL);
+	xfer = usbh_xfer_alloc(udev, ep, 0, bulk_req_cb, NULL);
 	if (!xfer) {
 		shell_error(sh, "host: Failed to allocate transfer");
 		return -ENOMEM;

--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -216,6 +216,7 @@ static int usbip_submit_req(struct usbip_cmd_node *const cmd_nd, const uint8_t e
 	struct usb_device *const udev = dev_ctx->udev;
 	uint32_t retry = USBIP_SUBMIT_REQ_RETRY_COUNT;
 	struct uhc_transfer *xfer;
+	size_t rec_len = USB_EP_DIR_IS_IN(ep) && buf != NULL ? cmd->submit.length : 0;
 	int ret;
 
 	/*
@@ -225,7 +226,7 @@ static int usbip_submit_req(struct usbip_cmd_node *const cmd_nd, const uint8_t e
 	 * be reworked to take a timeout argument.
 	 */
 	do {
-		xfer = usbh_xfer_alloc(udev, ep, usbip_req_cb, cmd_nd);
+		xfer = usbh_xfer_alloc(udev, ep, rec_len, usbip_req_cb, cmd_nd);
 		if (xfer == NULL) {
 			k_msleep(1);
 		}


### PR DESCRIPTION
This PR adds support for the following features in the MAX3421e USB host controller driver:
* interrupt transfers
* multipacket transactions
* remote wakeup

This PR introduces several fixes to the UHC subsystem as a whole to make these features work. Please see individual commit messages for more in-depth description for particular changes.