### PR TITLE
manifest: tf-m: fixes STMWBA65x issues and STM32U5xx traces level

### DIFF
--- a/boards/st/nucleo_wba55cg/CMakeLists.txt
+++ b/boards/st/nucleo_wba55cg/CMakeLists.txt
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()

--- a/boards/st/nucleo_wba65ri/CMakeLists.txt
+++ b/boards/st/nucleo_wba65ri/CMakeLists.txt
@@ -1,6 +1,7 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BOARD_LATE_INIT_HOOK)
-zephyr_library()
-zephyr_library_sources(board.c)
+  zephyr_library()
+  zephyr_library_sources(board.c)
 endif()

--- a/boards/st/nucleo_wba65ri/Kconfig
+++ b/boards/st/nucleo_wba65ri/Kconfig
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_NUCLEO_WBA65RI
-	select BOARD_LATE_INIT_HOOK if !BUILD_WITH_TFM
+	select BOARD_LATE_INIT_HOOK

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri_stm32wba65xx_ns.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri_stm32wba65xx_ns.dts
@@ -65,7 +65,3 @@
 &rng {
 	status = "disabled";
 };
-
-&clk_hse {
-	hse-trimming = <0x0c>;
-};

--- a/boards/st/stm32wba65i_dk1/Kconfig
+++ b/boards/st/stm32wba65i_dk1/Kconfig
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_STM32WBA65I_DK1
-	select BOARD_LATE_INIT_HOOK if !BUILD_WITH_TFM
+	select BOARD_LATE_INIT_HOOK

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1_stm32wba65xx_ns.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1_stm32wba65xx_ns.dts
@@ -65,7 +65,3 @@
 &rng {
 	status = "disabled";
 };
-
-&clk_hse {
-	hse-trimming = <0x0c>;
-};


### PR DESCRIPTION
Update the trusted-firmware-m revision to include fixes for the STM32WBA675xx platforms and change trace message levels on STM32u5 platforms.

Also remove the workaround introduced by https://github.com/zephyrproject-rtos/zephyr/pull/107676.

While at it, fix missing copyright notices and indentation in nucleo_wba65ri and nucleo_wba55cg **CMakeLists.txt** files.