### PR TITLE
modules: lvgl: add `lvgl_timer_handler_pause/_resume` API

### DIFF
--- a/modules/lvgl/include/lvgl_zephyr.h
+++ b/modules/lvgl/include/lvgl_zephyr.h
@@ -40,9 +40,34 @@ int lvgl_init(void);
  * by LVGL core, allowing user to submit their own
  * work items to it.
  *
+ * @kconfig_dep{CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE}
+ *
  * @return pointer to LVGL's workqueue instance
  */
 struct k_work_q *lvgl_get_workqueue(void);
+
+/**
+ * @brief Pause periodic invocation of the LVGL timer handler.
+ *
+ * Inhibits further invocations of the LVGL timer handler on the internal
+ * workqueue until @ref lvgl_timer_handler_resume is called. An
+ * already-scheduled tick may still wake the workqueue once but will return
+ * without performing any LVGL work. Safe to call from any context,
+ * including interrupt handlers and LVGL event callbacks.
+ *
+ * @kconfig_dep{CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE}
+ */
+void lvgl_timer_handler_pause(void);
+
+/**
+ * @brief Resume periodic invocation of the LVGL timer handler.
+ *
+ * Re-enables the periodic LVGL timer handler and submits it for immediate
+ * execution. Safe to call from any context, including interrupt handlers.
+ *
+ * @kconfig_dep{CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE}
+ */
+void lvgl_timer_handler_resume(void);
 
 #endif /* CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE */
 

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -228,15 +228,25 @@ static int lvgl_allocate_rendering_buffers(lv_display_t *display)
 
 static K_THREAD_STACK_DEFINE(lvgl_workqueue_stack, CONFIG_LV_Z_LVGL_WORKQUEUE_STACK_SIZE);
 static struct k_work_q lvgl_workqueue;
+static atomic_t lvgl_paused;
 
 static void lvgl_timer_handler_work(struct k_work *work)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	uint32_t wait_time;
 
+	if (atomic_get(&lvgl_paused) != 0) {
+		return;
+	}
+
 	lvgl_lock();
 	wait_time = lv_timer_handler();
 	lvgl_unlock();
+
+	/* Re-check in case a callback called lvgl_timer_handler_pause() during the tick. */
+	if (atomic_get(&lvgl_paused) != 0) {
+		return;
+	}
 
 	/* schedule next timer verification */
 	if (wait_time == LV_NO_TIMER_READY) {
@@ -251,6 +261,18 @@ struct k_work_q *lvgl_get_workqueue(void)
 {
 	return &lvgl_workqueue;
 }
+
+void lvgl_timer_handler_pause(void)
+{
+	(void)atomic_set(&lvgl_paused, 1);
+}
+
+void lvgl_timer_handler_resume(void)
+{
+	(void)atomic_set(&lvgl_paused, 0);
+	(void)k_work_schedule_for_queue(&lvgl_workqueue, &lvgl_work, K_NO_WAIT);
+}
+
 #endif /* CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE */
 
 #if defined(CONFIG_LV_Z_LVGL_MUTEX) && !defined(CONFIG_LV_Z_USE_OSAL)


### PR DESCRIPTION
Provide explicit control over the LVGL timer handler running on the internal workqueue, allowing applications to halt rendering activity (e.g. while the display is off) and resume it later.