### PR TITLE
dts: arm: st: *: remove non-existent compatible "st,stm32-sai-sub"

### DIFF
--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -158,14 +158,12 @@
 			status = "disabled";
 
 			sai2_a: sai2a@4 {
-				compatible = "st,stm32-sai-sub";
 				reg = <0x4>;
 				dmas = <&gpdma1 1 55 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				status = "disabled";
 			};
 
 			sai2_b: sai2b@24 {
-				compatible = "st,stm32-sai-sub";
 				reg = <0x24>;
 				dmas = <&gpdma1 0 56 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				status = "disabled";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -851,14 +851,12 @@
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				compatible = "st,stm32-sai-sub";
 				reg = <0x4>;
 				dmas = <&dma1 1 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
-				compatible = "st,stm32-sai-sub";
 				reg = <0x24>;
 				dmas = <&dma1 2 38 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				status = "disabled";


### PR DESCRIPTION
Added mistakenly during the SAI rework, the presence of this property inhibits `child-binding` inheritance; as a result, these nodes don't have the proper binding and attempting to use them causes a build failure when the driver tries to obtain `DT_PROP(..., synchronous)`.