### PR TITLE
drivers: ethernet: stm32: make MAC address array size consistent

### DIFF
--- a/drivers/ethernet/eth_stm32_hal2.c
+++ b/drivers/ethernet/eth_stm32_hal2.c
@@ -58,7 +58,7 @@ static const struct device *eth_stm32_phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0,
 
 struct eth_stm32_hal_dev_data {
 	struct net_if *iface;
-	uint8_t mac_addr[6];
+	uint8_t mac_addr[NET_ETH_ADDR_LEN];
 	hal_eth_handle_t heth;
 	struct k_event rx_event;
 	struct k_sem tx_int_sem;
@@ -563,6 +563,7 @@ static int eth_initialize(const struct device *dev)
 		return ret;
 	}
 
+	BUILD_ASSERT(sizeof(config_eth.mac_addr) == sizeof(dev_data->mac_addr));
 	memcpy(config_eth.mac_addr, dev_data->mac_addr, sizeof(dev_data->mac_addr));
 
 	config_eth.media_interface = HAL_ETH_MEDIA_IF_RMII;
@@ -607,7 +608,8 @@ static int eth_stm32_hal_set_config(const struct device *dev,
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		HAL_ETH_GetConfig(heth, &eth_cfg);
-		memcpy(eth_cfg.mac_addr, dev_data->mac_addr, 6);
+		BUILD_ASSERT(sizeof(eth_cfg.mac_addr) == sizeof(dev_data->mac_addr));
+		memcpy(eth_cfg.mac_addr, dev_data->mac_addr, sizeof(dev_data->mac_addr));
 
 		if (HAL_ETH_SetConfig(heth, &eth_cfg) != HAL_OK) {
 			return -EIO;

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -115,7 +115,7 @@ struct eth_stm32_hal_dev_cfg {
 /* Device run time data */
 struct eth_stm32_hal_dev_data {
 	struct net_if *iface;
-	uint8_t mac_addr[6];
+	uint8_t mac_addr[NET_ETH_ADDR_LEN];
 	ETH_HandleTypeDef heth;
 	struct k_sem rx_int_sem;
 #if defined(CONFIG_ETH_STM32_HAL_API_V2)

--- a/drivers/ethernet/eth_stm32_hal_v1.c
+++ b/drivers/ethernet/eth_stm32_hal_v1.c
@@ -264,7 +264,8 @@ int eth_stm32_hal_set_config(const struct device *dev,
 
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
-		memcpy(dev_data->mac_addr, config->mac_address.addr, 6);
+		BUILD_ASSERT(sizeof(dev_data->mac_addr) == sizeof(config->mac_address.addr));
+		memcpy(dev_data->mac_addr, config->mac_address.addr, sizeof(dev_data->mac_addr));
 		heth->Instance->MACA0HR = (dev_data->mac_addr[5] << 8) |
 			dev_data->mac_addr[4];
 		heth->Instance->MACA0LR = (dev_data->mac_addr[3] << 24) |

--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -757,7 +757,9 @@ int eth_stm32_hal_set_config(const struct device *dev,
 
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
-		memcpy(dev_data->mac_addr, config->mac_address.addr, 6);
+		BUILD_ASSERT(sizeof(dev_data->mac_addr) == sizeof(config->mac_address.addr));
+		memcpy(dev_data->mac_addr, config->mac_address.addr,
+		       sizeof(dev_data->mac_addr));
 		heth->Instance->MACA0HR = (dev_data->mac_addr[5] << 8) |
 			dev_data->mac_addr[4];
 		heth->Instance->MACA0LR = (dev_data->mac_addr[3] << 24) |


### PR DESCRIPTION
Use NET_ETH_ADDR_LEN instead of raw 6 value to define MAC address byte array size in STM32 ethernet drivers.

Assert at build time that the MAC address array size in HAL do match those in Zephyr.