### PR TITLE
tfm: fix signing_layout_s.o path with CMake 4.2

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -315,6 +315,9 @@ if(CONFIG_BUILD_WITH_TFM)
   # keep generating a couple of object files which are required to sign
   # images.
   list(APPEND TFM_CMAKE_ARGS -DTFM_CREATE_SIGNING_LAYOUT_OBJECTS=ON)
+  # Fix for CMake 4.2+ which defaults to SHORT (hashed) intermediate dir
+  # strategy, breaking signing_layout_ns.o path lookup in wrapper.py
+  list(APPEND TFM_CMAKE_ARGS -DCMAKE_INTERMEDIATE_DIR_STRATEGY=FULL)
 
   file(MAKE_DIRECTORY ${TFM_BINARY_DIR})
   add_custom_target(tfm_cmake


### PR DESCRIPTION
Force FULL intermediate dir strategy to avoid
hashed object paths introduced by newer CMake
versions (4.2+). This ensures compatibility
with TF-M wrapper.py which expects a stable
object file path.

Fixes build failure in TF-M BL2 image signing
step when using Ninja on windows