### PR TITLE
include: zephyr: drivers: dma: stm32: add missing header file inclusions

### DIFF
--- a/include/zephyr/drivers/dma/dma_stm32.h
+++ b/include/zephyr/drivers/dma/dma_stm32.h
@@ -7,6 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_DMA_STM32_H_
 #define ZEPHYR_INCLUDE_DRIVERS_DMA_STM32_H_
 
+#include <zephyr/devicetree.h>
+#include <zephyr/devicetree/dma.h>
+
 /* @brief linked_channel value to inform zephyr dma driver that
  * DMA channel will be handled by HAL
  */


### PR DESCRIPTION
Add missing inclusions of devicetree.h and devicetree/dma.h that are needed in dma_stm32.h header file.