### PR TITLE
dts: nxp: mcxw7x: add hwinfo uid support

### DIFF
--- a/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
@@ -541,6 +541,11 @@
 		interrupts = <18 0>;
 		clk-divider = <0x0>;
 	};
+
+	uid: uid@1f068 {
+		compatible = "nxp,lpc-uid";
+		reg = <0x1f068 0x10>;
+	};
 };
 
 &pbridge2 {

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -181,6 +181,11 @@
 		interrupts = <1 0>;
 	};
 
+	uid: uid@14810 {
+		compatible = "nxp,lpc-uid";
+		reg = <0x14810 0x10>;
+	};
+
 	spc: system-modules@16000 {
 		compatible = "nxp,spc";
 		reg = <0x16000 0x1000>;


### PR DESCRIPTION
The existing hwinfo_mcux_syscon driver handles the 128-bit UID read with no driver changes required