### PR TITLE
boards: silabs: Add 802.15.4 support

### DIFF
--- a/boards/arduino/nano_matter/arduino_nano_matter.dts
+++ b/boards/arduino/nano_matter/arduino_nano_matter.dts
@@ -22,6 +22,8 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &usart0;
 		zephyr,flash = &flash0;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,uart-pipe = &usart0;
@@ -351,5 +353,15 @@ zephyr_i2c: &i2c0 {
 };
 
 &bt_hci_silabs {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
+&protimer {
 	status = "okay";
 };

--- a/boards/seeed/xiao_mg24/xiao_mg24.dts
+++ b/boards/seeed/xiao_mg24/xiao_mg24.dts
@@ -21,6 +21,8 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &usart0;
 		zephyr,flash = &flash0;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,uart-pipe = &usart0;
@@ -316,5 +318,15 @@ zephyr_i2c: &i2c0 {
 };
 
 &bt_hci_silabs {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
+&protimer {
 	status = "okay";
 };

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
@@ -20,6 +20,8 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &usart0;
 		zephyr,flash = &flash0;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,uart-pipe = &usart0;
@@ -335,5 +337,15 @@
 };
 
 &bt_hci_silabs {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
+&protimer {
 	status = "okay";
 };

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
@@ -22,6 +22,8 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &usart0;
 		zephyr,flash = &flash0;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,uart-pipe = &usart0;
@@ -271,5 +273,15 @@
 };
 
 &bt_hci_silabs {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
+&protimer {
 	status = "okay";
 };

--- a/boards/silabs/dev_kits/xg26_dk2608a/xg26_dk2608a.dts
+++ b/boards/silabs/dev_kits/xg26_dk2608a/xg26_dk2608a.dts
@@ -22,6 +22,8 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &usart0;
 		zephyr,flash = &flash0;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,uart-pipe = &usart0;
@@ -287,6 +289,16 @@
 };
 
 &bt_hci_silabs {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
+&protimer {
 	status = "okay";
 };
 

--- a/boards/silabs/explorer_kits/xg26/mgm260p_ek2713a.dts
+++ b/boards/silabs/explorer_kits/xg26/mgm260p_ek2713a.dts
@@ -14,6 +14,8 @@
 
 	chosen {
 		zephyr,bt-hci = &bt_hci_silabs;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 	};
 };
 
@@ -37,12 +39,22 @@
 	clock-frequency = <DT_FREQ_M(80)>;
 };
 
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
 &itm {
 	swo-ref-frequency = <DT_FREQ_M(80)>;
 };
 
 &led0 {
 	gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
+};
+
+&protimer {
+	status = "okay";
 };
 
 &timer0_default {

--- a/boards/silabs/explorer_kits/xg26/xg26_ek2709a.dts
+++ b/boards/silabs/explorer_kits/xg26/xg26_ek2709a.dts
@@ -14,6 +14,8 @@
 
 	chosen {
 		zephyr,bt-hci = &bt_hci_silabs;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 	};
 };
 
@@ -21,9 +23,19 @@
 	status = "okay";
 };
 
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;
+	status = "okay";
+};
+
+&protimer {
 	status = "okay";
 };
 

--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
@@ -23,6 +23,8 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &usart0;
 		zephyr,flash = &flash0;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,uart-pipe = &usart0;
@@ -210,6 +212,16 @@
 };
 
 &bt_hci_silabs {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
+&protimer {
 	status = "okay";
 };
 

--- a/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
+++ b/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
@@ -24,6 +24,8 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &usart0;
 		zephyr,flash = &flash0;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 	};
@@ -212,6 +214,16 @@
 };
 
 &bt_hci_silabs {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
+&protimer {
 	status = "okay";
 };
 

--- a/boards/silabs/radio_boards/xg24/xgm240_rb431xa.dtsi
+++ b/boards/silabs/radio_boards/xg24/xgm240_rb431xa.dtsi
@@ -18,6 +18,8 @@
 		zephyr,console = &usart0;
 		zephyr,display = &ls0xx_ls013b7dh03;
 		zephyr,flash = &flash0;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,uart-pipe = &usart0;
@@ -268,5 +270,15 @@
 };
 
 &bt_hci_silabs {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
+&protimer {
 	status = "okay";
 };

--- a/boards/silabs/radio_boards/xg26/mgm260p_rb4350a.dts
+++ b/boards/silabs/radio_boards/xg26/mgm260p_rb4350a.dts
@@ -22,6 +22,8 @@
 		zephyr,console = &usart0;
 		zephyr,display = &ls0xx_ls013b7dh03;
 		zephyr,flash = &flash0;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,uart-pipe = &usart0;
@@ -315,6 +317,16 @@
 };
 
 &bt_hci_silabs {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
+&protimer {
 	status = "okay";
 };
 

--- a/boards/silabs/radio_boards/xg26/xg26_rb41xxa.dtsi
+++ b/boards/silabs/radio_boards/xg26/xg26_rb41xxa.dtsi
@@ -19,6 +19,8 @@
 		zephyr,console = &usart0;
 		zephyr,display = &ls0xx_ls013b7dh03;
 		zephyr,flash = &flash0;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,openthread-counter = &protimer;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,uart-pipe = &usart0;
@@ -319,6 +321,16 @@
 };
 
 &bt_hci_silabs {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+	sleep-clock = <&lfxo>;
+};
+
+&protimer {
 	status = "okay";
 };
 

--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
@@ -23,8 +23,10 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &usart0;
 		zephyr,flash = &flash0;
+		zephyr,ieee802154 = &ieee802154;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
+		zephyr,openthread-counter = &protimer;
 	};
 
 	aliases {
@@ -298,5 +300,14 @@ zephyr_i2c: &i2c0 {
 };
 
 &bt_hci_silabs {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+	hfxo = <&hfxo>;
+};
+
+&protimer {
 	status = "okay";
 };

--- a/dts/arm/silabs/xg21/efr32mg21.dtsi
+++ b/dts/arm/silabs/xg21/efr32mg21.dtsi
@@ -5,3 +5,10 @@
  */
 
 #include <silabs/xg21/efr32xg21.dtsi>
+
+&radio {
+	ieee802154: ieee802154 {
+		compatible = "silabs,efr32-ieee802154";
+		status = "disabled";
+	};
+};

--- a/dts/arm/silabs/xg24/efr32mg24.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24.dtsi
@@ -5,3 +5,10 @@
  */
 
 #include <silabs/xg24/efr32xg24.dtsi>
+
+&radio {
+	ieee802154: ieee802154 {
+		compatible = "silabs,efr32-ieee802154";
+		status = "disabled";
+	};
+};

--- a/dts/arm/silabs/xg24/efr32xg24.dtsi
+++ b/dts/arm/silabs/xg24/efr32xg24.dtsi
@@ -33,11 +33,6 @@
 				status = "disabled";
 			};
 
-			ieee802154: ieee802154 {
-				compatible = "silabs,efr32-ieee802154";
-				status = "disabled";
-			};
-
 			protimer: protimer {
 				compatible = "silabs,protimer";
 				status = "disabled";

--- a/dts/arm/silabs/xg24/mgm24.dtsi
+++ b/dts/arm/silabs/xg24/mgm24.dtsi
@@ -8,4 +8,9 @@
 
 &radio {
 	pa-2p4ghz = "highest";
+
+	ieee802154: ieee802154 {
+		compatible = "silabs,efr32-ieee802154";
+		status = "disabled";
+	};
 };

--- a/dts/arm/silabs/xg26/efr32mg26.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26.dtsi
@@ -11,4 +11,9 @@
 		compatible = "silabs,bt-hci-efr32";
 		status = "disabled";
 	};
+
+	ieee802154: ieee802154 {
+		compatible = "silabs,efr32-ieee802154";
+		status = "disabled";
+	};
 };

--- a/dts/arm/silabs/xg26/mgm26.dtsi
+++ b/dts/arm/silabs/xg26/mgm26.dtsi
@@ -13,4 +13,9 @@
 		compatible = "silabs,bt-hci-efr32";
 		status = "disabled";
 	};
+
+	ieee802154: ieee802154 {
+		compatible = "silabs,efr32-ieee802154";
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
MG21, MG24 and MG26 devices support IEEE 802.15.4. Add devicetree node to these.

Enable IEEE 802.15.4 on boards that support it. Configure protimer as OT counter.
