### PR TITLE
net: ethernet: check mac address when bringing a eth iface up

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -698,15 +698,8 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 	struct net_pkt *orig_pkt = pkt;
 	int ret;
 
-	if (!api) {
-		ret = -ENOENT;
-		goto error;
-	}
-
-	if (!api->send) {
-		ret = -ENOTSUP;
-		goto error;
-	}
+	NET_ASSERT(api != NULL);
+	NET_ASSERT(api->send != NULL);
 
 	/* We are trying to send a packet that is from bridge interface,
 	 * so all the bits and pieces should be there (like Ethernet header etc)
@@ -824,9 +817,7 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 	const struct device *dev = net_if_get_device(iface);
 	const struct ethernet_api *eth = dev->api;
 
-	if (!eth) {
-		return -ENOENT;
-	}
+	NET_ASSERT(eth != NULL);
 
 	if (!state) {
 		net_arp_clear_cache(iface);
@@ -879,9 +870,7 @@ static void carrier_on_off(struct k_work *work)
 						    carrier_work);
 	bool eth_carrier_up;
 
-	if (ctx->iface == NULL) {
-		return;
-	}
+	NET_ASSERT(ctx->iface != NULL);
 
 	eth_carrier_up = atomic_test_bit(&ctx->flags, ETH_CARRIER_UP);
 
@@ -926,9 +915,7 @@ const struct device *net_eth_get_phy(struct net_if *iface)
 	const struct device *dev = net_if_get_device(iface);
 	const struct ethernet_api *api = dev->api;
 
-	if (!api) {
-		return NULL;
-	}
+	NET_ASSERT(api != NULL);
 
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
 		return NULL;
@@ -947,9 +934,7 @@ const struct device *net_eth_get_ptp_clock(struct net_if *iface)
 	const struct device *dev = net_if_get_device(iface);
 	const struct ethernet_api *api = dev->api;
 
-	if (!api) {
-		return NULL;
-	}
+	NET_ASSERT(api != NULL);
 
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
 		return NULL;

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -816,6 +816,7 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 {
 	const struct device *dev = net_if_get_device(iface);
 	const struct ethernet_api *eth = dev->api;
+	struct net_linkaddr *mac_addr;
 
 	NET_ASSERT(eth != NULL);
 
@@ -825,10 +826,20 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 		if (eth->stop) {
 			return eth->stop(dev, iface);
 		}
-	} else {
-		if (eth->start) {
-			return eth->start(dev, iface);
-		}
+
+		return 0;
+	}
+
+	mac_addr = net_if_get_link_addr(iface);
+
+	if ((mac_addr->len != NET_ETH_ADDR_LEN) ||
+	    !net_eth_is_addr_valid((struct net_eth_addr *)mac_addr->addr)) {
+		NET_ERR("Invalid MAC address for iface %d (%p)", net_if_get_by_iface(iface), iface);
+		return -EINVAL;
+	}
+
+	if (eth->start) {
+		return eth->start(dev, iface);
 	}
 
 	return 0;

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -25,11 +25,10 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 
 static struct net_if *default_iface;
 
-static const uint8_t mac_addr_init[6] = { 0x01, 0x02, 0x03,
-				       0x04,  0x05,  0x06 };
-
-static const uint8_t mac_addr_change[6] = { 0x01, 0x02, 0x03,
-					 0x04,  0x05,  0x07 };
+/* 00-00-5E-00-53-xx Documentation RFC 7042 */
+static const uint8_t mac_addr_init[6] = {0x00, 0x00, 0x5e, 0x00, 0x53, 0x00};
+/* 00-00-5E-00-53-xx Documentation RFC 7042 */
+static const uint8_t mac_addr_change[6] = {0x00, 0x00, 0x5e, 0x00, 0x53, 0x01};
 
 struct eth_fake_context {
 	struct net_if *iface;

--- a/tests/net/lib/quic/src/main.c
+++ b/tests/net/lib/quic/src/main.c
@@ -149,7 +149,10 @@ struct eth_fake_context {
 	uint8_t mac_address[6];
 };
 
-static struct eth_fake_context eth_fake_data;
+static struct eth_fake_context eth_fake_data = {
+	/* 00-00-5E-00-53-xx Documentation RFC 7042 */
+	.mac_address = { 0x00, 0x00, 0x5e, 0x00, 0x53, 0x00 }
+};
 
 static struct quic_endpoint *reset_test_ep(struct quic_endpoint *ep)
 {

--- a/tests/net/npf/src/main.c
+++ b/tests/net/npf/src/main.c
@@ -130,12 +130,35 @@ static struct net_pkt *build_test_ip_pkt(void *src, void *dst,
  * Declare some fake interfaces and test their filter conditions.
  */
 
+static void eth_fake_iface_init(struct net_if *iface)
+{
+	/* 00-00-5E-00-53-xx Documentation RFC 7042 */
+	uint8_t mac_addr[6] = {0x00, 0x00, 0x5E, 0x00, 0x53, sys_rand8_get()};
+
+	net_if_set_link_addr(iface, mac_addr, sizeof(mac_addr), NET_LINK_ETHERNET);
+
+	ethernet_init(iface);
+}
+
+static int eth_fake_send(const struct device *dev, struct net_pkt *pkt)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(pkt);
+
+	return 0;
+}
+
+static struct ethernet_api eth_fake_api_funcs = {
+	.iface_api.init = eth_fake_iface_init,
+	.send = eth_fake_send,
+};
+
 ETH_NET_DEVICE_INIT(dummy_iface_a, "dummy_a", NULL, NULL,
 		    NULL, NULL, CONFIG_ETH_INIT_PRIORITY,
-		    NULL, NET_ETH_MTU);
+		    &eth_fake_api_funcs, NET_ETH_MTU);
 ETH_NET_DEVICE_INIT(dummy_iface_b, "dummy_b", NULL, NULL,
 		    NULL, NULL, CONFIG_ETH_INIT_PRIORITY,
-		    NULL, NET_ETH_MTU);
+		    &eth_fake_api_funcs, NET_ETH_MTU);
 #define dummy_iface_a NET_IF_GET(dummy_iface_a, 0)
 #define dummy_iface_b NET_IF_GET(dummy_iface_b, 0)
 

--- a/tests/net/promiscuous/src/main.c
+++ b/tests/net/promiscuous/src/main.c
@@ -71,8 +71,14 @@ struct eth_fake_context {
 	bool promisc_mode;
 };
 
-static struct eth_fake_context eth_fake_data1;
-static struct eth_fake_context eth_fake_data2;
+static struct eth_fake_context eth_fake_data1 = {
+	/* 00-00-5E-00-53-xx Documentation RFC 7042 */
+	.mac_address = { 0x00, 0x00, 0x5e, 0x00, 0x53, 0x00 },
+};
+static struct eth_fake_context eth_fake_data2 = {
+	/* 00-00-5E-00-53-xx Documentation RFC 7042 */
+	.mac_address = { 0x00, 0x00, 0x5e, 0x00, 0x53, 0x01 },
+};
 
 static void eth_fake_iface_init(struct net_if *iface)
 {

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -939,7 +939,10 @@ struct eth_fake_context {
 	uint8_t mac_address[6];
 };
 
-static struct eth_fake_context eth_fake_data;
+static struct eth_fake_context eth_fake_data = {
+	/* 00-00-5E-00-53-xx Documentation RFC 7042 */
+	.mac_address = { 0x00, 0x00, 0x5e, 0x00, 0x53, 0x00 },
+};
 static ZTEST_BMEM struct net_sockaddr_in6 udp_server_addr;
 
 /* The semaphore is there to wait the data to be received. */


### PR DESCRIPTION
Don't allow bringing a iface up, that doesn't have a
valid mac address. This way net_if_up() will fail.

+ replace some not so necessary checks with asserts