### PR TITLE
stm32: clean up SAI integration at DTSI level

### DIFF
--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -1006,14 +1006,12 @@ static DEVICE_API(i2s, i2s_stm32_sai_api) = {
 		.queue_drop = queue_drop,                                                          \
 	}
 
-#define SAI_SUB_REG_ADDR(node) (DT_REG_ADDR(DT_PARENT(node)) + DT_REG_ADDR(node))
-
 #define SAI_SUB_INIT(node)                                                                         \
 	PINCTRL_DT_DEFINE(node);                                                                   \
                                                                                                    \
 	static struct stm32_sai_sub_data sub_data_##node = {                                       \
 		.hsai = {                                                                          \
-			.Instance = (SAI_Block_TypeDef *)SAI_SUB_REG_ADDR(node),                   \
+			.Instance = (SAI_Block_TypeDef *)DT_REG_ADDR(node),                        \
 			.Init.OutputDrive = SAI_OUTPUTDRIVE_DISABLE,                               \
 			.Init.FIFOThreshold = SAI_FIFO_THRESHOLD(node),                            \
 			.Init.SynchroExt = SAI_SYNCEXT_DISABLE,                                    \

--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -85,13 +85,14 @@
 		sai1: sai1@40015800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015800 0x400>;
+			ranges = <0x0 0x40015800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -99,7 +100,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -93,12 +93,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -127,12 +127,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -119,13 +119,14 @@
 		sai1: sai1@40015800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015800 0x400>;
+			ranges = <0x0 0x40015800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -133,7 +134,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -175,13 +175,14 @@
 		sai1: sai1@40015800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015800 0x400>;
+			ranges = <0x0 0x40015800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -189,7 +190,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -183,12 +183,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -1082,12 +1082,16 @@
 		sai1_a: sai1a@4 {
 			reg = <0x4>;
 			dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 
 		sai1_b: sai1b@24 {
 			reg = <0x24>;
 			dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -1074,13 +1074,14 @@
 	sai1: sai1@40015800 {
 		compatible = "st,stm32-sai";
 		#address-cells = <1>;
-		#size-cells = <0>;
+		#size-cells = <1>;
 		reg = <0x40015800 0x400>;
+		ranges = <0x0 0x40015800 0x400>;
 		clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 		status = "disabled";
 
 		sai1_a: sai1a@4 {
-			reg = <0x4>;
+			reg = <0x4 0x20>;
 			dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -1088,7 +1089,7 @@
 		};
 
 		sai1_b: sai1b@24 {
-			reg = <0x24>;
+			reg = <0x24 0x20>;
 			dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -779,13 +779,14 @@
 		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
+			ranges = <0x0 0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&dma1 1 108 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -793,7 +794,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&dma1 2 109 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -787,12 +787,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&dma1 1 108 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&dma1 2 109 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -129,14 +129,15 @@
 		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
+			ranges = <0x0 0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL1_Q SAI1_SEL(0)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&gpdma1 1 53 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -144,7 +145,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&gpdma1 0 54 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -155,21 +156,26 @@
 		sai2: sai2@40015800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015800 0x400>;
+			ranges = <0x0 0x40015800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL1_Q SAI2_SEL(0)>;
 			status = "disabled";
 
 			sai2_a: sai2a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&gpdma1 1 55 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai2_b: sai2b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&gpdma1 0 56 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -138,12 +138,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&gpdma1 1 53 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&gpdma1 0 54 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1293,14 +1293,15 @@
 		sai1: sai1@40015800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015800 0x400>;
+			ranges = <0x0 0x40015800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&dma1 2 87 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -1308,7 +1309,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&dma1 3 88 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1302,12 +1302,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&dma1 2 87 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&dma1 3 88 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1054,14 +1054,15 @@
 		sai1: sai1@42005800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
+			ranges = <0x0 0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL3_P SAI1_SEL(0)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&gpdma1 1 63 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -1069,7 +1070,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&gpdma1 0 64 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1063,12 +1063,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&gpdma1 1 63 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&gpdma1 0 64 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/l4/stm32l4_sai.dtsi
+++ b/dts/arm/st/l4/stm32l4_sai.dtsi
@@ -18,12 +18,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&dma2 1 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&dma2 2 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/l4/stm32l4_sai.dtsi
+++ b/dts/arm/st/l4/stm32l4_sai.dtsi
@@ -9,14 +9,15 @@
 		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
+			ranges = <0x0 0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&dma2 1 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -24,7 +25,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&dma2 2 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -844,14 +844,15 @@
 		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
+			ranges = <0x0 0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&dma1 1 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -859,7 +860,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&dma1 2 38 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -853,12 +853,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&dma1 1 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&dma1 2 38 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1483,6 +1483,8 @@
 					reg = <0x4>;
 					dmas = <&gpdma1 1 91
 						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+					#address-cells = <1>;
+					#size-cells = <0>;
 					status = "disabled";
 				};
 
@@ -1490,6 +1492,8 @@
 					reg = <0x24>;
 					dmas = <&gpdma1 0 92
 						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+					#address-cells = <1>;
+					#size-cells = <0>;
 					status = "disabled";
 				};
 			};

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1474,13 +1474,14 @@
 			sai1: sai1@2005800 {
 				compatible = "st,stm32-sai";
 				#address-cells = <1>;
-				#size-cells = <0>;
+				#size-cells = <1>;
 				reg = <0x2005800 0x400>;
+				ranges = <0x0 0x2005800 0x400>;
 				clocks = <&rcc STM32_CLOCK(APB2, 21)>;
 				status = "disabled";
 
 				sai1_a: sai1a@4 {
-					reg = <0x4>;
+					reg = <0x4 0x20>;
 					dmas = <&gpdma1 1 91
 						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 					#address-cells = <1>;
@@ -1489,7 +1490,7 @@
 				};
 
 				sai1_b: sai1b@24 {
-					reg = <0x24>;
+					reg = <0x24 0x20>;
 					dmas = <&gpdma1 0 92
 						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 					#address-cells = <1>;
@@ -1501,22 +1502,27 @@
 			sai2: sai2@2005c00 {
 				compatible = "st,stm32-sai";
 				#address-cells = <1>;
-				#size-cells = <0>;
+				#size-cells = <1>;
 				reg = <0x2005c00 0x400>;
+				ranges = <0x0 0x2005c00 0x400>;
 				clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 				status = "disabled";
 
 				sai2_a: sai2a@4 {
-					reg = <0x4>;
+					reg = <0x4 0x20>;
 					dmas = <&gpdma1 3 93
 						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+					#address-cells = <1>;
+					#size-cells = <0>;
 					status = "disabled";
 				};
 
 				sai2_b: sai2b@24 {
-					reg = <0x24>;
+					reg = <0x24 0x20>;
 					dmas = <&gpdma1 2 94
 						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+					#address-cells = <1>;
+					#size-cells = <0>;
 					status = "disabled";
 				};
 			};

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -487,13 +487,14 @@
 		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
+			ranges = <0x0 0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&gpdma1 1 36 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -501,7 +502,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&gpdma1 0 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -495,12 +495,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&gpdma1 1 36 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&gpdma1 0 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -532,14 +532,15 @@
 		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
+			ranges = <0x0 0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&gpdma1 1 36 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -547,7 +548,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&gpdma1 0 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -541,12 +541,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&gpdma1 1 36 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&gpdma1 0 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/wba/stm32wba55.dtsi
+++ b/dts/arm/st/wba/stm32wba55.dtsi
@@ -22,12 +22,16 @@
 			sai1_a: sai1a@4 {
 				reg = <0x4>;
 				dmas = <&gpdma1 1 17 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 
 			sai1_b: sai1b@24 {
 				reg = <0x24>;
 				dmas = <&gpdma1 0 18 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				#address-cells = <1>;
+				#size-cells = <0>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/wba/stm32wba55.dtsi
+++ b/dts/arm/st/wba/stm32wba55.dtsi
@@ -13,14 +13,15 @@
 		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
+			ranges = <0x0 0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL1_P SAI1_SEL(0)>;
 			status = "disabled";
 
 			sai1_a: sai1a@4 {
-				reg = <0x4>;
+				reg = <0x4 0x20>;
 				dmas = <&gpdma1 1 17 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -28,7 +29,7 @@
 			};
 
 			sai1_b: sai1b@24 {
-				reg = <0x24>;
+				reg = <0x24 0x20>;
 				dmas = <&gpdma1 0 18 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/bindings/i2s/st,stm32-sai.yaml
+++ b/dts/bindings/i2s/st,stm32-sai.yaml
@@ -5,7 +5,7 @@ description: STM32 SAI Block controller
 
 compatible: "st,stm32-sai"
 
-include: i2s-controller.yaml
+include: base.yaml
 
 properties:
   reg:
@@ -14,28 +14,28 @@ properties:
 child-binding:
   description: SAI Sub-Block instances linked to SAI Block Controller
 
+  include:
+    - name: pinctrl-device.yaml
+    - name: i2s-controller.yaml
+      property-blocklist: [compatible]
+
   properties:
     reg:
-      type: int
       required: true
 
     dmas:
-      type: phandle-array
       required: true
 
     dma-names:
-      type: string-array
       required: true
       description: |
         DMA channel name: "tx" or "rx", depending of expected device behavior.
       enum: [tx, rx]
 
     pinctrl-0:
-      type: phandles
       required: true
 
     pinctrl-names:
-      type: string-array
       required: true
 
     mclk-enable:

--- a/dts/bindings/i2s/st,stm32-sai.yaml
+++ b/dts/bindings/i2s/st,stm32-sai.yaml
@@ -11,6 +11,16 @@ properties:
   reg:
     required: true
 
+  ranges:
+    type: array
+    required: true
+
+  "#address-cells":
+    const: 1
+
+  "#size-cells":
+    const: 1
+
 child-binding:
   description: SAI Sub-Block instances linked to SAI Block Controller
 


### PR DESCRIPTION
Follow-up to #104423.

1. Since the SAI top-level node is now an almost empty shell, the SAI sub-blocks are what should be the `i2s-controller`s now.
2. The binding should reuse existing base files instead of declaring the type of standard properties.
3. The SAI sub-block nodes should be mapped in the top-level address space because they are MMIO. If done properly, this removes the need for math to compute their actual address: `DT_REG_ADDR()` will return the correct value.