### PR TITLE
drivers: cache: stm32: implement cache_data_flush_all

### DIFF
--- a/drivers/cache/cache_stm32.c
+++ b/drivers/cache/cache_stm32.c
@@ -128,6 +128,11 @@ int cache_data_invd_all(void)
 	return 0;
 }
 
+int cache_data_flush_all(void)
+{
+	return cache_data_flush_range(0, UINT32_MAX);
+}
+
 int cache_data_flush_and_invd_all(void)
 {
 	return cache_data_flush_and_invd_range(0, UINT32_MAX);


### PR DESCRIPTION
The STM32 cache driver implemented cache_data_invd_all() and cache_data_flush_and_invd_all() but not cache_data_flush_all(). With CONFIG_DCACHE enabled (the default on STM32U5), cache.h references cache_data_flush_all(), so any image pulling in the full data-cache API (e.g. tests/kernel/cache) fails to link with an undefined reference on every stm32u5 board.

Implement it as a full-range clean (CLEAN_BY_ADDR over the whole address space), mirroring how cache_data_flush_and_invd_all() delegates to its range op.

While working on this PR: https://github.com/zephyrproject-rtos/zephyr/pull/110137 I exposed a pre-existing STM32U5 gap.