### PR TITLE
net: mqtt_sn: use sizeof instead of configs for buffer sizes

### DIFF
--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -370,7 +370,7 @@ static struct mqtt_sn_gateway *mqtt_sn_gw_create(uint8_t gw_id, short duration,
 		return NULL;
 	}
 
-	__ASSERT(gw_addr.size <= CONFIG_MQTT_SN_LIB_MAX_ADDR_SIZE,
+	__ASSERT(gw_addr.size <= sizeof(gw->addr),
 		 "Gateway address is larger than allowed by CONFIG_MQTT_SN_LIB_MAX_ADDR_SIZE");
 
 	memset(gw, 0, sizeof(*gw));
@@ -1886,7 +1886,7 @@ int mqtt_sn_input(struct mqtt_sn_client *client)
 {
 	ssize_t next_frame_size;
 	uint8_t addr[CONFIG_MQTT_SN_LIB_MAX_ADDR_SIZE];
-	struct mqtt_sn_data rx_addr = {.data = addr, .size = CONFIG_MQTT_SN_LIB_MAX_ADDR_SIZE};
+	struct mqtt_sn_data rx_addr = {.data = addr, .size = sizeof(addr)};
 	int err;
 
 	if (!client || !client->transport || !client->transport->recvfrom) {


### PR DESCRIPTION
- This is less repetitive.
- This is more resilient against changes to the buffer size.