### PR TITLE
CI: Fix filtering of non-text files in `check_compliance.py`

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1830,11 +1830,13 @@ class LicenseAndCopyrightCheck(ComplianceTest):
 
         # Only scan text files for now, in the future we may want to leverage REUSE standard's
         # ability to also associate license/copyright info with binary files.
+        filtered_files = []
         for file in changed_files:
             full_path = GIT_TOP / file
             mime_type = magic.from_file(os.fspath(full_path), mime=True)
-            if not mime_type.startswith("text/"):
-                changed_files.remove(file)
+            if mime_type.startswith("text/"):
+                filtered_files.append(file)
+        changed_files = filtered_files
 
         project = Project.from_directory(GIT_TOP)
         report = ProjectSubsetReport.generate(project, changed_files, multiprocessing=False)


### PR DESCRIPTION
The `LicenseAndCopyrightCheck` test was reporting warnings for some image files while ignoring others. This was caused by modifying the changed_files list during iteration, leading to inconsistent filtering of files.

This aligns the implementation with the intended behavior and avoids spurious warnings on binary files.