### PR TITLE
tests bsim bt: Inline twister logs

### DIFF
--- a/tests/bsim/bluetooth/host/compile.sh
+++ b/tests/bsim/bluetooth/host/compile.sh
@@ -12,4 +12,4 @@ set -ue
 #Set a default value to BOARD if it does not have one yet
 BOARD="${BOARD:-nrf52_bsim/native}"
 
-west twister -T ${ZEPHYR_BASE}/tests/bsim/bluetooth/host/ -p ${BOARD} --build-only
+west twister -T ${ZEPHYR_BASE}/tests/bsim/bluetooth/host/ -p ${BOARD} --build-only --inline-logs

--- a/tests/bsim/bluetooth/tester/compile.sh
+++ b/tests/bsim/bluetooth/tester/compile.sh
@@ -14,8 +14,8 @@ source ${ZEPHYR_BASE}/tests/bsim/compile.source
 # We only want to build the tests/bsim/bluetooth/tester/ application for the nrf52_bsim/native board
 # as we do not gain anything from running this application for the nrf5340bsim_nrf5340_cpuapp and
 # it is not worth the added complexity to run it with anything but nrf52_bsim/native
-west twister -T ${ZEPHYR_BASE}/tests/bsim/bluetooth/tester/ --build-only
+west twister -T ${ZEPHYR_BASE}/tests/bsim/bluetooth/tester/ --build-only --inline-logs
 
-west twister -p ${BOARD} -T ${ZEPHYR_BASE}/tests/bluetooth/tester/ --build-only
+west twister -p ${BOARD} -T ${ZEPHYR_BASE}/tests/bluetooth/tester/ --build-only --inline-logs
 
 wait_for_background_jobs


### PR DESCRIPTION
For apps built with twister inline the build errors if they happen. This is the same we do in the twister workflow, and in the tests built with compile.source