### PR TITLE
twister: bsim: change exception handling to keep build log

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -25,7 +25,7 @@ import yaml
 from pytest import ExitCode
 from twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
 from twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
-from twisterlib.error import BuildError, ConfigurationError, StatusAttributeError
+from twisterlib.error import ConfigurationError, StatusAttributeError
 from twisterlib.handlers import DeviceHandler, Handler, terminate_process
 from twisterlib.harnessconfig import TWISTER_PYTEST_CONFIG_FILE, HarnessPytestConfig
 from twisterlib.reports import ReportStatus
@@ -1130,7 +1130,8 @@ class Bsim(Script):
 
         original_exe_path: str = os.path.join(self.instance.build_dir, 'zephyr', 'zephyr.exe')
         if not os.path.exists(original_exe_path):
-            raise BuildError('Cannot copy bsim exe - cannot find original executable.')
+            logger.warning('Cannot copy bsim exe - cannot find original executable.')
+            return
 
         bsim_out_path: str = os.getenv('BSIM_OUT_PATH', '')
         if not bsim_out_path:

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1775,7 +1775,7 @@ class ProjectBuilder(FilterBuilder):
             if harness:
                 harness.instance = self.instance
                 harness.build()
-        except (ConfigurationError, BuildError) as error:
+        except ConfigurationError as error:
             self.instance.status = TwisterStatus.ERROR
             self.instance.reason = str(error)
             logger.error(self.instance.reason)


### PR DESCRIPTION
Do not raise exception when exe file was not found, as it is related with build failure. Allow processing of exception handling in build stage to keep build.log in twister report output.