### PR TITLE
drivers: mspi: stm32 ospi, xspi, qspi drivers with multiple instances

### DIFF
--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -1424,7 +1424,6 @@ static int mspi_stm32_ospi_pm_action(const struct device *dev, enum pm_device_ac
 			},                                                                         \
 		},                                                                                 \
 		.memmap_base_addr = DT_INST_REG_ADDR_BY_IDX(index, 1),                             \
-		.dev_id = index,                                                                   \
 		.lock = Z_MUTEX_INITIALIZER(mspi_stm32_dev_data_##index.lock),                     \
 		.sync = Z_SEM_INITIALIZER(mspi_stm32_dev_data_##index.sync, 0, 1),                 \
 		.dev_cfg = {0},                                                                    \

--- a/drivers/mspi/mspi_stm32_qspi.c
+++ b/drivers/mspi/mspi_stm32_qspi.c
@@ -1348,7 +1348,6 @@ static DEVICE_API(mspi, mspi_stm32_qspi_driver_api) = {
 			},                                                                     \
 		},                                                                             \
 		.memmap_base_addr = DT_INST_REG_ADDR_BY_IDX(index, 1),                         \
-		.dev_id = index,                                                               \
 		.lock = Z_MUTEX_INITIALIZER(mspi_stm32_qspi_dev_data_##index.lock),            \
 		.sync = Z_SEM_INITIALIZER(mspi_stm32_qspi_dev_data_##index.sync, 0, 1),        \
 		.dev_cfg = {0},                                                                \

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -1498,7 +1498,6 @@ static int mspi_stm32_xspi_pm_action(const struct device *dev, enum pm_device_ac
 			},                                                                        \
 		},                                                                                \
 		.memmap_base_addr = DT_INST_REG_ADDR_BY_IDX(index, 1),                            \
-		.dev_id = index,                                                                  \
 		.lock = Z_MUTEX_INITIALIZER(mspi_stm32_dev_data_##index.lock),                    \
 		.sync = Z_SEM_INITIALIZER(mspi_stm32_dev_data_##index.sync, 0, 1),                \
 		.dev_cfg = {0},                                                                   \


### PR DESCRIPTION
This PR is a replacement for #[109643](https://github.com/zephyrproject-rtos/zephyr/pull/109643).

It includes the proposed changes with fixes applied directly to the original commit (amended), addressing the issues discussed.

No changes are needed to be applied regarding OSPIM , since [109773](https://github.com/zephyrproject-rtos/zephyr/pull/109773 )  already covers it.
Thanks to @FRASTM  for the original work. Please let me know if any further adjustments are needed.