### PR TITLE
drivers: mfd: npm13xx: use dedicated event callback struct

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -448,6 +448,22 @@ Interrupt Controllers
 * Deprecate ``GIC_NUM_CPU_IF`` from GIC header file :file:`gic.h`. One shall use
   instead.:kconfig:option:`CONFIG_MP_MAX_NUM_CPUS` instead.
 
+MFD
+===
+
+* The nPM13xx (nPM1300/nPM1304) MFD event callback API no longer reuses ``struct gpio_callback``,
+  which was misused to dispatch non-GPIO PMIC events. Applications registering for PMIC events via
+  :c:func:`mfd_npm13xx_add_callback` / :c:func:`mfd_npm13xx_remove_callback` must now use the
+  dedicated :c:struct:`mfd_npm13xx_event_callback` instead of :c:struct:`gpio_callback`. Set its
+  ``event_mask`` field (a bitwise-OR of ``BIT(NPM13XX_EVENT_*)`` values) and ``handler`` field
+  directly instead of calling ``gpio_init_callback()``. The handler signature changed from
+  ``void handler(const struct device *dev, struct gpio_callback *cb, uint32_t events)`` to
+  ``void handler(const struct device *dev, struct mfd_npm13xx_event_callback *cb,
+  npm13xx_event_t events)``. Event callbacks are now invoked once per dispatch with a
+  combined event mask (the handler receives ``cb->event_mask & fired_events``), rather than
+  once per individual event bit as in the previous ``gpio_fire_callbacks`` based
+  implementation. (:github:`101800`)
+
 MSPI
 ====
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -531,6 +531,13 @@ MFD
   than before it, so a clear that fails ambiguously may deliver an event a second time
   instead of dropping it. (:github:`110454`)
 
+* :c:func:`mfd_npm13xx_add_callback` now rejects a callback that is ``NULL``, has a ``NULL``
+  handler, has an empty ``event_mask``, or sets mask bits at or above ``NPM13XX_EVENT_MAX``,
+  returning ``-EINVAL``. The previous ``gpio_callback`` based implementation asserted on the
+  first two and silently accepted the rest. Registering a callback that is already registered
+  also returns ``-EINVAL``, where ``gpio_manage_callback()`` removed the node, re-inserted it
+  and returned success. (:github:`110454`)
+
 MSPI
 ====
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -527,7 +527,9 @@ MFD
   npm13xx_event_t events)``. Event callbacks are now invoked once per dispatch with a
   combined event mask (the handler receives ``cb->event_mask & fired_events``), rather than
   once per individual event bit as in the previous ``gpio_fire_callbacks`` based
-  implementation. (:github:`101800`)
+  implementation. Handlers also run after the event has been acknowledged in the PMIC rather
+  than before it, so a clear that fails ambiguously may deliver an event a second time
+  instead of dropping it. (:github:`110454`)
 
 MSPI
 ====

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -538,6 +538,17 @@ MFD
   also returns ``-EINVAL``, where ``gpio_manage_callback()`` removed the node, re-inserted it
   and returned success. (:github:`110454`)
 
+* :c:func:`mfd_npm13xx_add_callback` and :c:func:`mfd_npm13xx_remove_callback` now change the
+  hardware subscription transactionally, which alters three observable behaviours. Registration
+  on a device whose devicetree node has no ``host-int-gpios`` returns ``-ENOTSUP``, because
+  nothing would dispatch the events; it previously returned success and enabled interrupts that
+  could never be delivered. Registration clears and enables only the event bits that no other
+  registered callback already covers, so adding a second subscriber for an event no longer
+  discards a pending occurrence the first one has not received. And removal disables the
+  interrupts left with no remaining subscriber before unlinking the callback, keeping it
+  registered if that write fails, rather than leaving an enabled event source with no handler.
+  (:github:`110454`)
+
 MSPI
 ====
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -513,6 +513,22 @@ Interrupt Controllers
 * Deprecate ``GIC_NUM_CPU_IF`` from GIC header file :file:`gic.h`. One shall use
   instead.:kconfig:option:`CONFIG_MP_MAX_NUM_CPUS` instead.
 
+MFD
+===
+
+* The nPM13xx (nPM1300/nPM1304) MFD event callback API no longer reuses ``struct gpio_callback``,
+  which was misused to dispatch non-GPIO PMIC events. Applications registering for PMIC events via
+  :c:func:`mfd_npm13xx_add_callback` / :c:func:`mfd_npm13xx_remove_callback` must now use the
+  dedicated :c:struct:`mfd_npm13xx_event_callback` instead of :c:struct:`gpio_callback`. Set its
+  ``event_mask`` field (a bitwise-OR of ``BIT(NPM13XX_EVENT_*)`` values) and ``handler`` field
+  directly instead of calling ``gpio_init_callback()``. The handler signature changed from
+  ``void handler(const struct device *dev, struct gpio_callback *cb, uint32_t events)`` to
+  ``void handler(const struct device *dev, struct mfd_npm13xx_event_callback *cb,
+  npm13xx_event_t events)``. Event callbacks are now invoked once per dispatch with a
+  combined event mask (the handler receives ``cb->event_mask & fired_events``), rather than
+  once per individual event bit as in the previous ``gpio_fire_callbacks`` based
+  implementation. (:github:`101800`)
+
 MSPI
 ====
 

--- a/drivers/mfd/mfd_npm13xx.c
+++ b/drivers/mfd/mfd_npm13xx.c
@@ -8,8 +8,8 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/slist.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/drivers/gpio/gpio_utils.h>
 #include <zephyr/drivers/mfd/npm13xx.h>
 
 #define NPM13XX_TIME_BASE 0x07U
@@ -53,7 +53,8 @@ struct mfd_npm13xx_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 	struct k_work work;
-	sys_slist_t callbacks;
+	sys_slist_t user_callbacks;
+	struct k_mutex event_lock;
 };
 
 struct event_reg_t {
@@ -89,7 +90,11 @@ static void work_callback(struct k_work *work)
 {
 	struct mfd_npm13xx_data *data = CONTAINER_OF(work, struct mfd_npm13xx_data, work);
 	const struct mfd_npm13xx_config *config = data->dev->config;
+	struct mfd_npm13xx_event_callback *cb;
+	struct mfd_npm13xx_event_callback *tmp;
 	uint8_t buf[MAIN_SIZE];
+	npm13xx_event_t events = 0U;
+	bool resubmit = false;
 	int ret;
 
 	/* Read all MAIN registers into temporary buffer */
@@ -99,23 +104,43 @@ static void work_callback(struct k_work *work)
 		return;
 	}
 
+	/* Accumulate the set of fired events and clear them in the device */
 	for (int i = 0; i < NPM13XX_EVENT_MAX; i++) {
 		int offset = event_reg[i].offset + MAIN_OFFSET_CLR;
 
 		if ((buf[offset] & event_reg[i].mask) != 0U) {
-			gpio_fire_callbacks(&data->callbacks, data->dev, BIT(i));
-
 			ret = mfd_npm13xx_reg_write(data->dev, NPM13XX_MAIN_BASE, offset,
 						    event_reg[i].mask);
 			if (ret < 0) {
-				k_work_submit(&data->work);
-				return;
+				/*
+				 * Stop clearing on failure, but still dispatch the
+				 * events already cleared below; a later read will no
+				 * longer see them, so returning here would drop them.
+				 * Resubmit to retry the events not yet cleared.
+				 */
+				resubmit = true;
+				break;
 			}
+
+			events |= BIT(i);
 		}
 	}
 
-	/* Resubmit handler to queue if interrupt is still active */
-	if (gpio_pin_get_dt(&config->host_int_gpios) != 0) {
+	/*
+	 * Dispatch the fired events to the registered user callbacks. event_lock
+	 * guards only callback list modification (add/remove) and is deliberately
+	 * NOT held here, so a handler may re-enter the driver. The _SAFE walk
+	 * caches the next node, so a handler that removes its own callback does
+	 * not truncate the dispatch. Mirrors mfd_npm10xx.
+	 */
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&data->user_callbacks, cb, tmp, node) {
+		if ((cb->event_mask & events) != 0U) {
+			cb->handler(data->dev, cb, cb->event_mask & events);
+		}
+	}
+
+	/* Resubmit if a clear failed above, or the interrupt is still active */
+	if (resubmit || gpio_pin_get_dt(&config->host_int_gpios) != 0) {
 		k_work_submit(&data->work);
 	}
 }
@@ -131,6 +156,7 @@ static int mfd_npm13xx_init(const struct device *dev)
 	}
 
 	k_mutex_init(&mfd_data->mutex);
+	k_mutex_init(&mfd_data->event_lock);
 
 	mfd_data->dev = dev;
 
@@ -279,39 +305,59 @@ int mfd_npm13xx_hibernate(const struct device *dev, uint32_t time_ms)
 	return mfd_npm13xx_reg_write(dev, NPM13XX_SHIP_BASE, SHIP_OFFSET_HIBERNATE, 1U);
 }
 
-int mfd_npm13xx_add_callback(const struct device *dev, struct gpio_callback *callback)
+int mfd_npm13xx_add_callback(const struct device *dev, struct mfd_npm13xx_event_callback *callback)
 {
 	struct mfd_npm13xx_data *data = dev->data;
+	int ret = 0;
+
+	k_mutex_lock(&data->event_lock, K_FOREVER);
+
+	if (sys_slist_find(&data->user_callbacks, &callback->node, NULL)) {
+		ret = -EINVAL;
+		goto unlock;
+	}
 
 	/* Enable interrupts for specified events */
 	for (int i = 0; i < NPM13XX_EVENT_MAX; i++) {
-		if ((callback->pin_mask & BIT(i)) != 0U) {
+		if ((callback->event_mask & BIT(i)) != 0U) {
 			/* Clear pending interrupt */
-			int ret = mfd_npm13xx_reg_write(data->dev, NPM13XX_MAIN_BASE,
-							event_reg[i].offset + MAIN_OFFSET_CLR,
-							event_reg[i].mask);
-
+			ret = mfd_npm13xx_reg_write(data->dev, NPM13XX_MAIN_BASE,
+						    event_reg[i].offset + MAIN_OFFSET_CLR,
+						    event_reg[i].mask);
 			if (ret < 0) {
-				return ret;
+				goto unlock;
 			}
 
 			ret = mfd_npm13xx_reg_write(data->dev, NPM13XX_MAIN_BASE,
 						    event_reg[i].offset + MAIN_OFFSET_INTENSET,
 						    event_reg[i].mask);
 			if (ret < 0) {
-				return ret;
+				goto unlock;
 			}
 		}
 	}
 
-	return gpio_manage_callback(&data->callbacks, callback, true);
+	sys_slist_prepend(&data->user_callbacks, &callback->node);
+
+unlock:
+	k_mutex_unlock(&data->event_lock);
+	return ret;
 }
 
-int mfd_npm13xx_remove_callback(const struct device *dev, struct gpio_callback *callback)
+int mfd_npm13xx_remove_callback(const struct device *dev,
+				struct mfd_npm13xx_event_callback *callback)
 {
 	struct mfd_npm13xx_data *data = dev->data;
+	int ret = 0;
 
-	return gpio_manage_callback(&data->callbacks, callback, false);
+	k_mutex_lock(&data->event_lock, K_FOREVER);
+
+	if (!sys_slist_find_and_remove(&data->user_callbacks, &callback->node)) {
+		ret = -EINVAL;
+	}
+
+	k_mutex_unlock(&data->event_lock);
+	return ret;
 }
 
 #define MFD_NPM13XX_DEFINE(partno, n)                                                              \

--- a/drivers/mfd/mfd_npm13xx.c
+++ b/drivers/mfd/mfd_npm13xx.c
@@ -305,6 +305,12 @@ int mfd_npm13xx_add_callback(const struct device *dev, struct mfd_npm13xx_event_
 	struct mfd_npm13xx_data *data = dev->data;
 	int ret = 0;
 
+	/* The gpio_callback helpers asserted these; nothing else does now. */
+	if ((callback == NULL) || (callback->handler == NULL) || (callback->event_mask == 0U) ||
+	    ((callback->event_mask & ~BIT_MASK(NPM13XX_EVENT_MAX)) != 0U)) {
+		return -EINVAL;
+	}
+
 	k_mutex_lock(&data->event_lock, K_FOREVER);
 
 	if (sys_slist_find(&data->user_callbacks, &callback->node, NULL)) {
@@ -344,6 +350,10 @@ int mfd_npm13xx_remove_callback(const struct device *dev,
 {
 	struct mfd_npm13xx_data *data = dev->data;
 	int ret = 0;
+
+	if (callback == NULL) {
+		return -EINVAL;
+	}
 
 	k_mutex_lock(&data->event_lock, K_FOREVER);
 

--- a/drivers/mfd/mfd_npm13xx.c
+++ b/drivers/mfd/mfd_npm13xx.c
@@ -182,7 +182,7 @@ static int mfd_npm13xx_init(const struct device *dev)
 			return ret;
 		}
 
-		mfd_data->work.handler = work_callback;
+		k_work_init(&mfd_data->work, work_callback);
 
 		ret = gpio_pin_interrupt_configure_dt(&config->host_int_gpios,
 						      GPIO_INT_EDGE_TO_ACTIVE);
@@ -300,15 +300,39 @@ int mfd_npm13xx_hibernate(const struct device *dev, uint32_t time_ms)
 	return mfd_npm13xx_reg_write(dev, NPM13XX_SHIP_BASE, SHIP_OFFSET_HIBERNATE, 1U);
 }
 
+/* Union of the event masks of every registered callback, optionally excluding one. */
+static npm13xx_event_t covered_events(struct mfd_npm13xx_data *data,
+				      const struct mfd_npm13xx_event_callback *except)
+{
+	struct mfd_npm13xx_event_callback *cb;
+	npm13xx_event_t covered = 0U;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&data->user_callbacks, cb, node) {
+		if (cb != except) {
+			covered |= cb->event_mask;
+		}
+	}
+
+	return covered;
+}
+
 int mfd_npm13xx_add_callback(const struct device *dev, struct mfd_npm13xx_event_callback *callback)
 {
+	const struct mfd_npm13xx_config *config = dev->config;
 	struct mfd_npm13xx_data *data = dev->data;
+	npm13xx_event_t new_events;
+	npm13xx_event_t enabled = 0U;
 	int ret = 0;
 
 	/* The gpio_callback helpers asserted these; nothing else does now. */
 	if ((callback == NULL) || (callback->handler == NULL) || (callback->event_mask == 0U) ||
 	    ((callback->event_mask & ~BIT_MASK(NPM13XX_EVENT_MAX)) != 0U)) {
 		return -EINVAL;
+	}
+
+	/* host-int-gpios is optional, and without it nothing dispatches an event. */
+	if (config->host_int_gpios.port == NULL) {
+		return -ENOTSUP;
 	}
 
 	k_mutex_lock(&data->event_lock, K_FOREVER);
@@ -318,27 +342,57 @@ int mfd_npm13xx_add_callback(const struct device *dev, struct mfd_npm13xx_event_
 		goto unlock;
 	}
 
-	/* Enable interrupts for specified events */
-	for (int i = 0; i < NPM13XX_EVENT_MAX; i++) {
-		if ((callback->event_mask & BIT(i)) != 0U) {
-			/* Clear pending interrupt */
-			ret = mfd_npm13xx_reg_write(data->dev, NPM13XX_MAIN_BASE,
-						    event_reg[i].offset + MAIN_OFFSET_CLR,
-						    event_reg[i].mask);
-			if (ret < 0) {
-				goto unlock;
-			}
+	/*
+	 * Only the events nobody has subscribed to yet. The status register is
+	 * write-one-to-clear, so clearing a bit another callback is already waiting on
+	 * would discard an event the work handler has not read.
+	 */
+	new_events = callback->event_mask & ~covered_events(data, NULL);
 
-			ret = mfd_npm13xx_reg_write(data->dev, NPM13XX_MAIN_BASE,
-						    event_reg[i].offset + MAIN_OFFSET_INTENSET,
-						    event_reg[i].mask);
-			if (ret < 0) {
-				goto unlock;
-			}
+	/* Linked before its interrupts are enabled, so an event cannot arrive unhandled. */
+	sys_slist_prepend(&data->user_callbacks, &callback->node);
+
+	for (int i = 0; i < NPM13XX_EVENT_MAX; i++) {
+		if ((new_events & BIT(i)) == 0U) {
+			continue;
+		}
+
+		/* Discard a stale event while this source is still disabled */
+		ret = mfd_npm13xx_reg_write(data->dev, NPM13XX_MAIN_BASE,
+					    event_reg[i].offset + MAIN_OFFSET_CLR,
+					    event_reg[i].mask);
+		if (ret < 0) {
+			goto rollback;
+		}
+
+		/* Recorded before the write, for the same reason the event path records
+		 * before its clear: a write that reports an error may still have landed.
+		 */
+		enabled |= BIT(i);
+
+		ret = mfd_npm13xx_reg_write(data->dev, NPM13XX_MAIN_BASE,
+					    event_reg[i].offset + MAIN_OFFSET_INTENSET,
+					    event_reg[i].mask);
+		if (ret < 0) {
+			goto rollback;
 		}
 	}
 
-	sys_slist_prepend(&data->user_callbacks, &callback->node);
+	goto unlock;
+
+rollback:
+	/*
+	 * A caller that gets an error may free the callback, so nothing this call
+	 * enabled may outlive it. Best effort: the bus is already misbehaving.
+	 */
+	for (int i = 0; i < NPM13XX_EVENT_MAX; i++) {
+		if ((enabled & BIT(i)) != 0U) {
+			(void)mfd_npm13xx_reg_write(data->dev, NPM13XX_MAIN_BASE,
+						    event_reg[i].offset + MAIN_OFFSET_INTENCLR,
+						    event_reg[i].mask);
+		}
+	}
+	sys_slist_find_and_remove(&data->user_callbacks, &callback->node);
 
 unlock:
 	k_mutex_unlock(&data->event_lock);
@@ -349,6 +403,8 @@ int mfd_npm13xx_remove_callback(const struct device *dev,
 				struct mfd_npm13xx_event_callback *callback)
 {
 	struct mfd_npm13xx_data *data = dev->data;
+	npm13xx_event_t orphaned;
+	sys_snode_t *prev;
 	int ret = 0;
 
 	if (callback == NULL) {
@@ -357,10 +413,32 @@ int mfd_npm13xx_remove_callback(const struct device *dev,
 
 	k_mutex_lock(&data->event_lock, K_FOREVER);
 
-	if (!sys_slist_find_and_remove(&data->user_callbacks, &callback->node)) {
+	if (!sys_slist_find(&data->user_callbacks, &callback->node, &prev)) {
 		ret = -EINVAL;
+		goto unlock;
 	}
 
+	/* The events this callback was the last subscriber to */
+	orphaned = callback->event_mask & ~covered_events(data, callback);
+
+	for (int i = 0; i < NPM13XX_EVENT_MAX; i++) {
+		if ((orphaned & BIT(i)) == 0U) {
+			continue;
+		}
+
+		ret = mfd_npm13xx_reg_write(data->dev, NPM13XX_MAIN_BASE,
+					    event_reg[i].offset + MAIN_OFFSET_INTENCLR,
+					    event_reg[i].mask);
+		if (ret < 0) {
+			/* Still registered is safer than enabled with no handler. */
+			goto unlock;
+		}
+	}
+
+	/* Unlinked only once its interrupts are off, for the same reason as above. */
+	sys_slist_remove(&data->user_callbacks, prev, &callback->node);
+
+unlock:
 	k_mutex_unlock(&data->event_lock);
 	return ret;
 }

--- a/drivers/mfd/mfd_npm13xx.c
+++ b/drivers/mfd/mfd_npm13xx.c
@@ -109,20 +109,15 @@ static void work_callback(struct k_work *work)
 		int offset = event_reg[i].offset + MAIN_OFFSET_CLR;
 
 		if ((buf[offset] & event_reg[i].mask) != 0U) {
+			/* Record before the clear: a write that errors may still have landed. */
+			events |= BIT(i);
+
 			ret = mfd_npm13xx_reg_write(data->dev, NPM13XX_MAIN_BASE, offset,
 						    event_reg[i].mask);
 			if (ret < 0) {
-				/*
-				 * Stop clearing on failure, but still dispatch the
-				 * events already cleared below; a later read will no
-				 * longer see them, so returning here would drop them.
-				 * Resubmit to retry the events not yet cleared.
-				 */
 				resubmit = true;
 				break;
 			}
-
-			events |= BIT(i);
 		}
 	}
 

--- a/include/zephyr/drivers/mfd/npm13xx.h
+++ b/include/zephyr/drivers/mfd/npm13xx.h
@@ -20,7 +20,7 @@ extern "C" {
 #include <stdint.h>
 
 #include <zephyr/device.h>
-#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/slist.h>
 
 enum mfd_npm13xx_event_t {
 	NPM13XX_EVENT_CHG_COMPLETED,
@@ -38,6 +38,45 @@ enum mfd_npm13xx_event_t {
 	NPM13XX_EVENT_GPIO3_EDGE,
 	NPM13XX_EVENT_GPIO4_EDGE,
 	NPM13XX_EVENT_MAX
+};
+
+/** @brief Identifies a set of events for the event callback */
+typedef uint32_t npm13xx_event_t;
+
+struct mfd_npm13xx_event_callback;
+
+/**
+ * @brief Define the application callback handler function signature
+ *
+ * @param dev nPM13xx MFD device
+ * @param cb Original struct mfd_npm13xx_event_callback owning this handler
+ * @param events Mask of events that triggered the callback handler
+ *
+ * Note: cb pointer can be used to retrieve private data through CONTAINER_OF() if the original
+ * struct mfd_npm13xx_event_callback is stored in another private structure. The events are
+ * encoded as a bitwise-OR of BIT(NPM13XX_EVENT_*) values.
+ */
+typedef void (*npm13xx_callback_handler_t)(const struct device *dev,
+					   struct mfd_npm13xx_event_callback *cb,
+					   npm13xx_event_t events);
+
+/**
+ * @brief nPM13xx MFD event callback structure
+ *
+ * Used to register a callback in the driver instance callback list.
+ * As many callbacks as needed can be added as long as each of them
+ * are unique pointers of struct mfd_npm13xx_event_callback.
+ */
+struct mfd_npm13xx_event_callback {
+	/** Intended for internal use by the driver. Do not use in application. */
+	sys_snode_t node;
+	/**
+	 * A set of events the callback is interested in. Constructed by a bitwise-OR of any
+	 * number of BIT(NPM13XX_EVENT_*) values.
+	 */
+	npm13xx_event_t event_mask;
+	/** Function to be called when any of the provided events occur. */
+	npm13xx_callback_handler_t handler;
 };
 
 /**
@@ -135,19 +174,20 @@ int mfd_npm13xx_hibernate(const struct device *dev, uint32_t time_ms);
  * @brief Add npm13xx event callback
  *
  * @param dev npm13xx mfd device
- * @param callback callback
+ * @param callback A pointer to the event callback to add to the list
  * @return 0 on success, -errno on failure
  */
-int mfd_npm13xx_add_callback(const struct device *dev, struct gpio_callback *callback);
+int mfd_npm13xx_add_callback(const struct device *dev, struct mfd_npm13xx_event_callback *callback);
 
 /**
  * @brief Remove npm13xx event callback
  *
  * @param dev npm13xx mfd device
- * @param callback callback
+ * @param callback A pointer to the event callback to remove from the list
  * @return 0 on success, -errno on failure
  */
-int mfd_npm13xx_remove_callback(const struct device *dev, struct gpio_callback *callback);
+int mfd_npm13xx_remove_callback(const struct device *dev,
+				struct mfd_npm13xx_event_callback *callback);
 
 /** @} */
 

--- a/samples/shields/npm13xx_ek/src/main.c
+++ b/samples/shields/npm13xx_ek/src/main.c
@@ -62,7 +62,8 @@ void configure_ui(void)
 	}
 }
 
-static void event_callback(const struct device *dev, struct gpio_callback *cb, uint32_t events)
+static void event_callback(const struct device *dev, struct mfd_npm13xx_event_callback *cb,
+			   npm13xx_event_t events)
 {
 	if (events & BIT(NPM13XX_EVENT_SHIPHOLD_PRESS)) {
 		printk("SHPHLD pressed\n");
@@ -80,10 +81,11 @@ void configure_events(void)
 	}
 
 	/* Setup callback for shiphold button press */
-	static struct gpio_callback event_cb;
+	static struct mfd_npm13xx_event_callback event_cb;
 
-	gpio_init_callback(&event_cb, event_callback, BIT(NPM13XX_EVENT_SHIPHOLD_PRESS) |
-			   BIT(NPM13XX_EVENT_SHIPHOLD_RELEASE));
+	event_cb.event_mask =
+		BIT(NPM13XX_EVENT_SHIPHOLD_PRESS) | BIT(NPM13XX_EVENT_SHIPHOLD_RELEASE);
+	event_cb.handler = event_callback;
 
 	mfd_npm13xx_add_callback(pmic, &event_cb);
 }

--- a/samples/shields/npm13xx_ek/src/main.c
+++ b/samples/shields/npm13xx_ek/src/main.c
@@ -75,6 +75,8 @@ static void event_callback(const struct device *dev, struct mfd_npm13xx_event_ca
 
 void configure_events(void)
 {
+	int ret;
+
 	if (!device_is_ready(pmic)) {
 		printk("Pmic device not ready.\n");
 		return;
@@ -87,7 +89,10 @@ void configure_events(void)
 		BIT(NPM13XX_EVENT_SHIPHOLD_PRESS) | BIT(NPM13XX_EVENT_SHIPHOLD_RELEASE);
 	event_cb.handler = event_callback;
 
-	mfd_npm13xx_add_callback(pmic, &event_cb);
+	ret = mfd_npm13xx_add_callback(pmic, &event_cb);
+	if (ret < 0) {
+		printk("Failed to add pmic event callback: %d\n", ret);
+	}
 }
 
 void read_sensors(void)


### PR DESCRIPTION
Fixes #101800.

The nPM13xx MFD driver dispatched its non-GPIO PMIC events through `struct gpio_callback`, reusing the `pin_mask` field as an arbitrary event bitmask and calling `gpio_fire_callbacks()` / `gpio_manage_callback()`. This overloads a GPIO-subsystem type for events that have nothing to do with GPIO lines and forces the public MFD header to pull in `<zephyr/drivers/gpio.h>`.

This replaces it with a dedicated `struct mfd_npm13xx_event_callback` (`sys_snode_t node`, `npm13xx_event_t event_mask`, `npm13xx_callback_handler_t handler`) stored on a `sys_slist`, following the pattern already used by `mfd_npm10xx`. Per @seov-nordic's guidance on #101800, a dedicated `event_lock` guards only list add/remove operations and is not held while the dispatch loop invokes user handlers, so a handler may call back into the driver. The real host-interrupt GPIO line (`data->gpio_cb`) remains a `struct gpio_callback`.

`mfd_npm13xx_add_callback()` / `mfd_npm13xx_remove_callback()` now take a `struct mfd_npm13xx_event_callback *`, and the public header replaces its `<zephyr/drivers/gpio.h>` dependency with `<zephyr/sys/slist.h>`. The `npm13xx_ek` sample and a 4.5 migration note are updated accordingly.

I kept the existing two add/remove entry points rather than switching to a single `manage_callback` entry point, in order to keep the public API delta small. I can switch to the `npm10xx` `manage_callback` shape if preferred.

Note: as in the pre-existing driver, `remove_callback` only unlinks the callback and does not write `INTENCLR` to disable PMIC interrupts for events that no longer have a subscriber; `npm10xx` does disable them. I left that teardown out to keep this change focused on #101800, and can add it as a follow-up if matching the `npm10xx` behavior is preferred.

`npm2100` shares this pattern and is tracked separately in #110157.

Testing:

* `checkpatch` and the Gitlint/Identity compliance checks are clean.
* Builds successfully for `nrf52dk/nrf52832` with the `npm1300_ek` and `npm1304_ek` shields (`samples/shields/npm13xx_ek`).
* I do not have nPM1300/nPM1304 hardware, so this is build-tested on my side. seov-nordic tested the callback rework on hardware on 4 June; the two later commits are build-tested only.
