### PR TITLE
MAINTAINERS: add Harini-T as Xilinx collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -7192,6 +7192,7 @@ Xilinx Platforms:
   maintainers:
     - michalsimek
   collaborators:
+    - Harini-T
     - henrikbrixandersen
     - ibirnbaum
     - kedareswararao


### PR DESCRIPTION
Add Harini-T as a collaborator for the Xilinx Platforms area.
## Contributions
Merged PRs:
- #90147 - Add support for Xilinx Window Watchdog driver (v4.3.0)
- #100738 - dts: arm: xilinx: fix zynqmp RPU IPI mailbox base addresses
- #104983 - watchdog: wdt_xilinx_wwdt: Add explicit state validation in feed
- #105420 - samples: mbox_data: Add support for variable MTU sizes
- #107167 - drivers: mbox: xlnx_ipi: Fix RX buffer offset and cleanup

Open PRs (active work):
- #107705, #107697, #107684 - Counter/RTC driver and calibration API for ZynqMP
- #104373 - samples: mbox_data: Add support for versalnet_rpu and versal2_rpu
- #101531 - tests: wdt_basic_api: Add magic number for noinit initialization

## Areas of contribution
- Watchdog drivers (Xilinx WWDT - new driver + fixes)
- Mailbox drivers (xlnx_ipi - bug fixes, buffer offset, formatting)
- Counter/RTC drivers (Xilinx ZynqMP RTC - new driver + calibration API)
- Board support (AMD kv260_r5, Versal platforms)
- Device tree bindings (Xilinx-related)
- Samples and tests

CC: @kedareswararao 
