### PR TITLE
Add I2C bus recovery GPIOs in DTS files for STM32 SoC based boards

### DIFF
--- a/boards/96boards/aerocore2/96b_aerocore2.dts
+++ b/boards/96boards/aerocore2/96b_aerocore2.dts
@@ -146,6 +146,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/96boards/argonkey/96b_argonkey.dts
+++ b/boards/96boards/argonkey/96b_argonkey.dts
@@ -143,6 +143,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -150,6 +152,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -173,6 +177,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pb4>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/96boards/carbon/96b_carbon_stm32f401xe.dts
+++ b/boards/96boards/carbon/96b_carbon_stm32f401xe.dts
@@ -110,6 +110,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -117,6 +119,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb3>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/96boards/neonkey/96b_neonkey.dts
+++ b/boards/96boards/neonkey/96b_neonkey.dts
@@ -97,6 +97,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -104,6 +106,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb3>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -111,6 +115,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pb4>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 

--- a/boards/96boards/stm32_sensor_mez/96b_stm32_sensor_mez.dts
+++ b/boards/96boards/stm32_sensor_mez/96b_stm32_sensor_mez.dts
@@ -105,6 +105,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -124,6 +126,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pc12>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 12 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/96boards/wistrio/96b_wistrio.dts
+++ b/boards/96boards/wistrio/96b_wistrio.dts
@@ -97,6 +97,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	lis3dh: lis3dh@32 {

--- a/boards/adafruit/feather_stm32f405/adafruit_feather_stm32f405.dts
+++ b/boards/adafruit/feather_stm32f405/adafruit_feather_stm32f405.dts
@@ -71,6 +71,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.dts
+++ b/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.dts
@@ -177,6 +177,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pg14 &i2c1_sda_pg13>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiog 14 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiog 13 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -184,6 +186,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pg7 &i2c3_sda_pg8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiog 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiog 8 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.dts
+++ b/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.dts
@@ -107,6 +107,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	bme280@76 {

--- a/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
+++ b/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
@@ -112,6 +112,8 @@
 	status = "okay";
 	pinctrl-0 = <&i2c4_scl_pb6 &i2c4_sda_ph12>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 12 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
@@ -119,6 +121,8 @@
 	status = "disabled";
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
@@ -126,6 +130,8 @@
 	status = "disabled";
 	pinctrl-0 = <&i2c2_scl_ph4 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 4 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 

--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -96,6 +96,8 @@ zephyr_i2c: &i2c1 {
 	status = "disabled";
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
@@ -103,6 +105,8 @@ zephyr_i2c: &i2c1 {
 	status = "okay";
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	vl53l1x: vl53l1x@29 {
@@ -202,6 +206,8 @@ zephyr_udc0: &usbotg_hs {
 	status = "okay";
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pc9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	gc2145: gc2145@3c {

--- a/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
@@ -88,6 +88,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_ph7 &i2c3_sda_ph8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 8 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
@@ -95,6 +97,8 @@
 zephyr_i2c: &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
@@ -102,6 +106,8 @@ zephyr_i2c: &i2c1 {
 &i2c4 {
 	pinctrl-0 = <&i2c4_scl_ph11 &i2c4_sda_ph12>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 11 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 12 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
@@ -109,6 +115,8 @@ zephyr_i2c: &i2c1 {
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_ph7 &i2c3_sda_ph8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 8 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 

--- a/boards/arduino/uno_q/arduino_uno_q-common.dtsi
+++ b/boards/arduino/uno_q/arduino_uno_q-common.dtsi
@@ -116,6 +116,8 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
@@ -124,6 +126,8 @@ stm32_lp_tick_source: &lptim1 {
 	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pd13>;
 	/* use      <&i2c4_scl_pf14 &i2c4_sda_pf15> for the JMISC connector */
 	pinctrl-names = "default";
+	scl-gpios = <&gpiod 12 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 

--- a/boards/blues/cygnet/cygnet.dts
+++ b/boards/blues/cygnet/cygnet.dts
@@ -109,6 +109,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/blues/swan_r5/swan_r5.dts
+++ b/boards/blues/swan_r5/swan_r5.dts
@@ -122,18 +122,24 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pc0 &i2c3_sda_pc9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioc 0 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/cirrus/crd40l50/crd40l50.dts
+++ b/boards/cirrus/crd40l50/crd40l50.dts
@@ -113,6 +113,8 @@
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-1 = <&analog_pb6 &analog_pb7>;
 	pinctrl-names = "default", "sleep";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 
 	haptic_0: haptic@30 {
 		compatible = "cirrus,cs40l50";

--- a/boards/embedsky/tq_h503a/tq_h503a.dts
+++ b/boards/embedsky/tq_h503a/tq_h503a.dts
@@ -82,6 +82,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb5>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/eurovibes/sertest-ng/eurovibes_stm32g431_sertest-ng.dts
+++ b/boards/eurovibes/sertest-ng/eurovibes_stm32g431_sertest-ng.dts
@@ -140,6 +140,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa9 &i2c2_sda_pa8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	atecc608a@60 {

--- a/boards/flysky/fs_i6s/fs_i6s.dts
+++ b/boards/flysky/fs_i6s/fs_i6s.dts
@@ -326,6 +326,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/iar/stm32f429ii_aca/stm32f429ii_aca.dts
+++ b/boards/iar/stm32f429ii_aca/stm32f429ii_aca.dts
@@ -186,6 +186,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -193,6 +195,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_ph4 &i2c2_sda_ph5>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 4 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 5 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/mikroe/clicker_2/mikroe_clicker_2.dts
+++ b/boards/mikroe/clicker_2/mikroe_clicker_2.dts
@@ -183,12 +183,16 @@ zephyr_udc0: &usbotg_fs {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pc9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/mikroe/mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
+++ b/boards/mikroe/mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
@@ -76,6 +76,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/mikroe/quail/mikroe_quail.dts
+++ b/boards/mikroe/quail/mikroe_quail.dts
@@ -303,6 +303,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/mikroe/stm32_m4_clicker/mikroe_stm32_m4_clicker.dts
+++ b/boards/mikroe/stm32_m4_clicker/mikroe_stm32_m4_clicker.dts
@@ -114,6 +114,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/mxchip/az3166_iotdevkit/az3166_iotdevkit.dts
+++ b/boards/mxchip/az3166_iotdevkit/az3166_iotdevkit.dts
@@ -147,6 +147,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 

--- a/boards/oct/osd32mp1_brk/osd32mp1_brk.dts
+++ b/boards/oct/osd32mp1_brk/osd32mp1_brk.dts
@@ -78,6 +78,8 @@
 &i2c5 {
 	pinctrl-0 = <&i2c5_scl_pd1 &i2c5_sda_pd0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiod 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiod 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/olimex/lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
+++ b/boards/olimex/lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
@@ -92,6 +92,8 @@ uext_serial: &lpuart1 {
 uext_i2c: &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pa9 &i2c1_sda_pa10>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/olimex/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/olimex/olimexino_stm32/olimexino_stm32.dts
@@ -109,6 +109,8 @@ uext_serial: &usart1 {};
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -116,6 +118,8 @@ uext_serial: &usart1 {};
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/olimex/stm32_h103/olimex_stm32_h103.dts
+++ b/boards/olimex/stm32_h103/olimex_stm32_h103.dts
@@ -89,6 +89,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -96,6 +98,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/others/stm32_min_dev/stm32_min_dev.dts
+++ b/boards/others/stm32_min_dev/stm32_min_dev.dts
@@ -79,12 +79,16 @@
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	status = "okay";
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/others/stm32f401_mini/stm32f401_mini.dts
+++ b/boards/others/stm32f401_mini/stm32f401_mini.dts
@@ -101,6 +101,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/rakwireless/rak11160/rak11160.dts
+++ b/boards/rakwireless/rak11160/rak11160.dts
@@ -115,6 +115,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa12 &i2c2_sda_pa11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/rakwireless/rak3172/rak3172.dts
+++ b/boards/rakwireless/rak3172/rak3172.dts
@@ -82,6 +82,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa12 &i2c2_sda_pa11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/ronoth/lodev/ronoth_lodev.dts
+++ b/boards/ronoth/lodev/ronoth_lodev.dts
@@ -148,6 +148,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/ruiside/art_pi/art_pi.dts
+++ b/boards/ruiside/art_pi/art_pi.dts
@@ -220,6 +220,8 @@
 	clock-frequency = <100000>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 
 	gt911: touchscreen@5d {
 		compatible = "goodix,gt911";

--- a/boards/seagate/legend/legend.dts
+++ b/boards/seagate/legend/legend.dts
@@ -57,6 +57,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	status = "okay";
 };

--- a/boards/seco/stm32f3_seco_d23/stm32f3_seco_d23.dts
+++ b/boards/seco/stm32f3_seco_d23/stm32f3_seco_d23.dts
@@ -139,6 +139,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };
@@ -147,6 +149,8 @@
 	/* alternate config usart1 */
 	pinctrl-0 = <&i2c2_scl_pa9 &i2c2_sda_pa10>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 

--- a/boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -130,6 +130,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb15 &i2c2_sda_pa15>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 15 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 15 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/seeed/lora_e5_mini/lora_e5_mini.dts
+++ b/boards/seeed/lora_e5_mini/lora_e5_mini.dts
@@ -81,6 +81,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb15 &i2c2_sda_pa15>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 15 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 15 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/shields/arduino_giga_display_shield/boards/arduino_giga_r1_m7.overlay
+++ b/boards/shields/arduino_giga_display_shield/boards/arduino_giga_r1_m7.overlay
@@ -74,6 +74,8 @@
 &i2c4 {
 	pinctrl-0 = <&i2c4_scl_pb6 &i2c4_sda_ph12>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 12 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 

--- a/boards/st/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/st/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -149,6 +149,8 @@ arduino_i2c: &i2c1 {};
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -102,6 +102,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -109,6 +111,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -195,6 +195,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -202,6 +204,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_ph4 &i2c2_sda_ph5>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 4 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 5 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.dts
@@ -138,6 +138,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -145,6 +147,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -180,6 +184,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pc0 &i2c3_sda_pc1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioc 0 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 1 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_c031c6/nucleo_c031c6.dts
+++ b/boards/st/nucleo_c031c6/nucleo_c031c6.dts
@@ -123,6 +123,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_c071rb/nucleo_c071rb.dts
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.dts
@@ -144,6 +144,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_c092rc/nucleo_c092rc.dts
+++ b/boards/st/nucleo_c092rc/nucleo_c092rc.dts
@@ -150,6 +150,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_c542rc/nucleo_c542rc.dts
+++ b/boards/st/nucleo_c542rc/nucleo_c542rc.dts
@@ -93,6 +93,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -93,6 +93,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -176,12 +176,16 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb4>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/st/nucleo_f030r8/nucleo_f030r8.dts
@@ -97,6 +97,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -104,6 +106,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f031k6/nucleo_f031k6.dts
+++ b/boards/st/nucleo_f031k6/nucleo_f031k6.dts
@@ -96,6 +96,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f042k6/nucleo_f042k6.dts
+++ b/boards/st/nucleo_f042k6/nucleo_f042k6.dts
@@ -87,6 +87,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/st/nucleo_f070rb/nucleo_f070rb.dts
@@ -93,6 +93,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -100,6 +102,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f072rb/nucleo_f072rb.dts
+++ b/boards/st/nucleo_f072rb/nucleo_f072rb.dts
@@ -91,6 +91,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -98,6 +100,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/st/nucleo_f091rc/nucleo_f091rc.dts
@@ -105,6 +105,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -113,6 +115,8 @@
 	/* Pin conflict with can1. Enable only with can1 disabled. */
 	pinctrl-0 = <&i2c2_scl_pa11 &i2c2_sda_pa12>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.dts
@@ -125,6 +125,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -132,6 +134,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/st/nucleo_f302r8/nucleo_f302r8.dts
@@ -77,6 +77,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f303k8/nucleo_f303k8.dts
+++ b/boards/st/nucleo_f303k8/nucleo_f303k8.dts
@@ -88,6 +88,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/st/nucleo_f303re/nucleo_f303re.dts
@@ -103,6 +103,8 @@
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	status = "okay";
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 

--- a/boards/st/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/st/nucleo_f334r8/nucleo_f334r8.dts
@@ -96,6 +96,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/st/nucleo_f401re/nucleo_f401re.dts
@@ -107,6 +107,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -114,6 +116,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pc9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/st/nucleo_f410rb/nucleo_f410rb.dts
@@ -91,6 +91,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -98,6 +100,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb3>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/st/nucleo_f411re/nucleo_f411re.dts
@@ -91,21 +91,25 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
 	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb3>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pb4>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 

--- a/boards/st/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/st/nucleo_f412zg/nucleo_f412zg.dts
@@ -102,6 +102,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/st/nucleo_f413zh/nucleo_f413zh.dts
@@ -103,6 +103,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/st/nucleo_f429zi/nucleo_f429zi.dts
@@ -113,6 +113,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -120,6 +122,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f439zi/nucleo_f439zi.dts
+++ b/boards/st/nucleo_f439zi/nucleo_f439zi.dts
@@ -112,6 +112,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -119,6 +121,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/st/nucleo_f446re/nucleo_f446re.dts
@@ -101,6 +101,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -108,6 +110,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb3>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -115,6 +119,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pb4>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/st/nucleo_f446ze/nucleo_f446ze.dts
@@ -126,6 +126,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -133,6 +135,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f722ze/nucleo_f722ze.dts
+++ b/boards/st/nucleo_f722ze/nucleo_f722ze.dts
@@ -117,6 +117,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -144,6 +146,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg.dts
@@ -130,6 +130,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -137,6 +139,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.dts
@@ -121,6 +121,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi.dts
@@ -131,6 +131,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_g031k8/nucleo_g031k8.dts
+++ b/boards/st/nucleo_g031k8/nucleo_g031k8.dts
@@ -78,6 +78,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pa9 &i2c1_sda_pa10>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };
@@ -85,6 +87,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa11 &i2c2_sda_pa12>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/nucleo_g070rb/nucleo_g070rb.dts
+++ b/boards/st/nucleo_g070rb/nucleo_g070rb.dts
@@ -113,6 +113,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -120,6 +122,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa11 &i2c2_sda_pa12>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/st/nucleo_g071rb/nucleo_g071rb.dts
@@ -121,6 +121,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -128,6 +130,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa11 &i2c2_sda_pa12>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -139,6 +139,8 @@ zephyr_udc0: &usb {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -146,6 +148,8 @@ zephyr_udc0: &usb {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa11 &i2c2_sda_pa12>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_g431kb/nucleo_g431kb.dts
+++ b/boards/st/nucleo_g431kb/nucleo_g431kb.dts
@@ -97,6 +97,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa9 &i2c2_sda_pa8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/st/nucleo_g431rb/nucleo_g431rb.dts
@@ -117,6 +117,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/st/nucleo_g474re/nucleo_g474re.dts
@@ -113,6 +113,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_g491re/nucleo_g491re.dts
+++ b/boards/st/nucleo_g491re/nucleo_g491re.dts
@@ -117,6 +117,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_h503rb/nucleo_h503rb.dts
+++ b/boards/st/nucleo_h503rb/nucleo_h503rb.dts
@@ -116,6 +116,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -98,6 +98,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.dts
@@ -165,6 +165,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -147,6 +147,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
@@ -98,6 +98,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -146,6 +146,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -153,6 +155,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
@@ -115,6 +115,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
@@ -166,6 +166,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_l011k4/nucleo_l011k4.dts
+++ b/boards/st/nucleo_l011k4/nucleo_l011k4.dts
@@ -74,6 +74,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pa4 &i2c1_sda_pa10>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 4 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_l031k6/nucleo_l031k6.dts
+++ b/boards/st/nucleo_l031k6/nucleo_l031k6.dts
@@ -64,6 +64,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pa9 &i2c1_sda_pa10>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/st/nucleo_l053r8/nucleo_l053r8.dts
@@ -95,6 +95,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/st/nucleo_l073rz/nucleo_l073rz.dts
@@ -119,6 +119,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -126,6 +128,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/st/nucleo_l152re/nucleo_l152re.dts
@@ -86,6 +86,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.dts
+++ b/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.dts
@@ -96,6 +96,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/st/nucleo_l432kc/nucleo_l432kc.dts
@@ -84,6 +84,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
+++ b/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
@@ -106,6 +106,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
+++ b/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
@@ -86,6 +86,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/st/nucleo_l476rg/nucleo_l476rg.dts
@@ -107,6 +107,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -114,6 +116,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pc0 &i2c3_sda_pc1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioc 0 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 1 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/st/nucleo_l496zg/nucleo_l496zg.dts
@@ -162,6 +162,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_l4a6zg/nucleo_l4a6zg.dts
+++ b/boards/st/nucleo_l4a6zg/nucleo_l4a6zg.dts
@@ -125,6 +125,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -135,6 +135,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -198,6 +198,8 @@
 		 <&rcc STM32_SRC_CKPER I2C1_SEL(1)>;
 	pinctrl-0 = <&i2c1_scl_ph9 &i2c1_sda_pc1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 9 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 1 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	status = "okay";
 };
@@ -207,6 +209,8 @@ csi_i2c: &i2c2 {
 		 <&rcc STM32_SRC_CKPER I2C2_SEL(1)>;
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	status = "okay";
 };
@@ -216,6 +220,8 @@ csi_i2c: &i2c2 {
 		 <&rcc STM32_SRC_CKPER I2C4_SEL(1)>;
 	pinctrl-0 = <&i2c4_scl_pe13 &i2c4_sda_pe14>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioe 13 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioe 14 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	status = "okay";
 };

--- a/boards/st/nucleo_u031r8/nucleo_u031r8.dts
+++ b/boards/st/nucleo_u031r8/nucleo_u031r8.dts
@@ -90,6 +90,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -97,6 +99,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa7 &i2c2_sda_pa6>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.dts
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.dts
@@ -107,6 +107,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -170,12 +170,16 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb13 &i2c2_sda_pb14>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q.dts
+++ b/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q.dts
@@ -171,6 +171,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_u545re_q/nucleo_u545re_q.dts
+++ b/boards/st/nucleo_u545re_q/nucleo_u545re_q.dts
@@ -156,6 +156,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -163,6 +165,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb14>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -106,6 +106,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -113,6 +115,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
@@ -106,6 +106,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -113,6 +115,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
@@ -143,6 +143,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
+++ b/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
@@ -142,6 +142,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb6 &i2c2_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
@@ -176,6 +176,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -128,6 +128,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -135,6 +137,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pc0 &i2c3_sda_pc1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioc 0 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 1 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
+++ b/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
@@ -142,6 +142,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pb2 &i2c3_sda_pa11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -168,6 +168,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb2 &i2c1_sda_pb1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -140,6 +140,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb2 &i2c1_sda_pb1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -125,6 +125,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa12 &i2c2_sda_pa11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/sensortile_box/sensortile_box.dts
+++ b/boards/st/sensortile_box/sensortile_box.dts
@@ -105,6 +105,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -124,6 +126,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pg7 &i2c3_sda_pg8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiog 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiog 8 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.dts
@@ -230,6 +230,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -258,6 +260,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_ph4 &i2c2_sda_ph5>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 4 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 5 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
+++ b/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
@@ -149,6 +149,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/steval_fcu001v1/steval_fcu001v1.dts
+++ b/boards/st/steval_fcu001v1/steval_fcu001v1.dts
@@ -69,6 +69,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_sda_pb3 &i2c2_scl_pb10>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/steval_stwinbx1/steval_stwinbx1.dts
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.dts
@@ -205,6 +205,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_ph4 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 4 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/st/stm32f072b_disco/stm32f072b_disco.dts
@@ -105,6 +105,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -112,6 +114,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/st/stm32f3_disco/stm32f3_disco.dts
@@ -140,6 +140,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -159,6 +161,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa9 &i2c2_sda_pa10>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/st/stm32f411e_disco/stm32f411e_disco.dts
@@ -140,6 +140,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/st/stm32f412g_disco/stm32f412g_disco.dts
@@ -132,6 +132,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/stm32f413h_disco/stm32f413h_disco.dts
+++ b/boards/st/stm32f413h_disco/stm32f413h_disco.dts
@@ -85,6 +85,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -150,6 +150,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -157,6 +159,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -164,6 +168,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pc9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/stm32f469i_disco/stm32f469i_disco_common.dtsi
+++ b/boards/st/stm32f469i_disco/stm32f469i_disco_common.dtsi
@@ -129,6 +129,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/st/stm32f4_disco/stm32f4_disco.dts
@@ -220,6 +220,8 @@ zephyr_udc0: &usbotg_fs {
 	clock-frequency = <I2C_BITRATE_FAST>;
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	audio_codec: cs43l22@4a {

--- a/boards/st/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/st/stm32f723e_disco/stm32f723e_disco.dts
@@ -98,18 +98,24 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_ph4 &i2c2_sda_ph5>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 4 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 5 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_ph8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 8 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -107,6 +107,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -114,6 +116,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_ph7 &i2c3_sda_ph8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 8 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -98,6 +98,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -105,6 +107,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_ph7 &i2c3_sda_ph8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 8 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -151,6 +151,8 @@ arduino_serial: &usart6 {};
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -158,6 +160,8 @@ arduino_serial: &usart6 {};
 qsh_030_i2c: &i2c4 {
 	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiod 12 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/st/stm32g071b_disco/stm32g071b_disco.dts
@@ -143,6 +143,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
@@ -187,6 +187,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };
@@ -194,6 +196,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };
@@ -201,6 +205,8 @@
 &i2c4 {
 	pinctrl-0 = <&i2c4_scl_pb8 &i2c4_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 

--- a/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
+++ b/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
@@ -119,6 +119,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_ph7 &i2c3_sda_ph8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 8 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -122,6 +122,8 @@
 &i2c4 {
 	pinctrl-0 = <&i2c4_scl_pf14 &i2c4_sda_pf15>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 14 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 15 GPIO_ACTIVE_HIGH>;
 };
 
 &rng {

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -228,6 +228,8 @@
 	status = "okay";
 	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pd13>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiod 12 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	/* FT5336 capacitive touch on the on-board LCD module.

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -291,6 +291,8 @@ arduino_spi: &spi5 {};
 qsh_030_i2c: &i2c4 {
 	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pd13>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiod 12 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
@@ -306,6 +306,8 @@ zephyr_udc0: &usbotg_hs {
 qsh_030_i2c: &i2c4 {
 	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pd13>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiod 12 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -164,6 +164,8 @@
 st_cam_i2c: &i2c4 {
 	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pd13>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiod 12 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -241,6 +241,8 @@
 st_cam_i2c: &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	/*
 	 * Make sure FDCAN and i2c1 are not enabled at the same time
 	 * because they share the pb9 pin

--- a/boards/st/stm32l1_disco/stm32l152c_disco.dts
+++ b/boards/st/stm32l1_disco/stm32l152c_disco.dts
@@ -99,6 +99,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -106,6 +108,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/stm32l1_disco/stm32l1_disco.dts
+++ b/boards/st/stm32l1_disco/stm32l1_disco.dts
@@ -101,6 +101,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -108,6 +110,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/st/stm32l496g_disco/stm32l496g_disco.dts
@@ -141,6 +141,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
@@ -229,6 +229,8 @@ st_cam_i2c: &i2c1 {
 	status = "okay";
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pg13>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiog 13 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 
 	mfx: gpio@42 {
@@ -248,6 +250,8 @@ qsh_030_i2c: &i2c1 {};
 	status = "okay";
 	pinctrl-0 = <&i2c3_scl_pg7 &i2c3_sda_pg8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiog 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiog 8 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -174,6 +174,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -159,6 +159,8 @@
 &i2c1 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c1_scl_pd12 &i2c1_sda_pe8>;
+	scl-gpios = <&gpiod 12 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioe 8 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	mcp23017: pinctrl@21 {
@@ -173,12 +175,16 @@
 &i2c4 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c4_scl_pe15 &i2c4_sda_pb9>;
+	scl-gpios = <&gpioe 15 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 
 csi_i2c: &i2c5 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c5_scl_pd1 &i2c5_sda_ph6>;
+	scl-gpios = <&gpiod 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 6 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	mipid02: bridge@14 {

--- a/boards/st/stm32mp157c_dk2/stm32mp157c_dk2.dts
+++ b/boards/st/stm32mp157c_dk2/stm32mp157c_dk2.dts
@@ -105,6 +105,8 @@
 &i2c5 {
 	pinctrl-0 = <&i2c5_scl_pa11 &i2c5_sda_pa12>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/stm32mp257f_dk/stm32mp257f_dk_stm32mp257fxx_m33.dts
+++ b/boards/st/stm32mp257f_dk/stm32mp257f_dk_stm32mp257fxx_m33.dts
@@ -80,6 +80,8 @@
 	/* Pin conflict with i3c4. Enable only with i3c4 disabled */
 	pinctrl-0 = <&i2c8_scl_pz4 &i2c8_sda_pz3>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioz 4 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioz 3 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.dts
+++ b/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.dts
@@ -106,6 +106,8 @@
 	/* Pin conflict with i3c4. Enable only with i3c4 disabled */
 	pinctrl-0 = <&i2c8_scl_pz4 &i2c8_sda_pz3>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioz 4 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioz 3 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -107,6 +107,8 @@
 		 <&rcc STM32_SRC_CKPER I2C2_SEL(1)>;
 	pinctrl-0 = <&i2c2_scl_pd14 &i2c2_sda_pd4>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiod 14 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiod 4 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	gt911: gt911@5d {
@@ -278,6 +280,8 @@ csi_i2c: &i2c1 {
 		 <&rcc STM32_SRC_CKPER I2C1_SEL(1)>;
 	pinctrl-0 = <&i2c1_scl_ph9 &i2c1_sda_pc1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 9 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 1 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	status = "okay";
 };
@@ -287,6 +291,8 @@ csi_i2c: &i2c1 {
 		 <&rcc STM32_SRC_CKPER I2C4_SEL(1)>;
 	pinctrl-0 = <&i2c4_scl_pe13 &i2c4_sda_pe14>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioe 13 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioe 14 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	status = "okay";
 };

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -106,6 +106,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -119,6 +121,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa7 &i2c2_sda_pa6>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
+++ b/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
@@ -139,6 +139,8 @@ uart0: &usart3 {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pg14 &i2c1_sda_pg13>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiog 14 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiog 13 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
@@ -146,6 +148,8 @@ uart0: &usart3 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
@@ -153,6 +157,8 @@ uart0: &usart3 {
 &i2c6 {
 	pinctrl-0 = <&i2c6_scl_pd1 &i2c6_sda_pd0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiod 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiod 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
@@ -326,6 +332,8 @@ zephyr_udc0: &usbotg_hs {
 qsh_030_i2c: &i2c5 {
 	pinctrl-0 = <&i2c5_scl_ph5 &i2c5_sda_ph4>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 5 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 4 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
+++ b/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
@@ -132,6 +132,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pg14 &i2c1_sda_pg13>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiog 14 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiog 13 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
@@ -139,6 +141,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
@@ -146,6 +150,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_ph7 &i2c3_sda_ph8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 8 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -160,6 +166,8 @@
 &i2c6 {
 	pinctrl-0 = <&i2c6_scl_pd1 &i2c6_sda_pd0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiod 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiod 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
@@ -333,6 +341,8 @@ zephyr_udc0: &usbotg_hs {
 qsh_030_i2c: &i2c5 {
 	pinctrl-0 = <&i2c5_scl_ph5 &i2c5_sda_ph4>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 5 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 4 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -179,6 +179,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pg14 &i2c1_sda_pg13>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiog 14 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiog 13 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
@@ -186,6 +188,8 @@
 &i2c2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/stm32vl_disco/stm32vl_disco.dts
+++ b/boards/st/stm32vl_disco/stm32vl_disco.dts
@@ -94,6 +94,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -101,6 +103,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
+++ b/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
@@ -190,6 +190,8 @@ zephyr_udc0: &usb {
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pb13 &i2c3_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
@@ -142,6 +142,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb2 &i2c1_sda_pb1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/waveshare/open103z/waveshare_open103z.dts
+++ b/boards/waveshare/open103z/waveshare_open103z.dts
@@ -146,6 +146,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_sda_pb7 &i2c1_scl_pb6>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -153,6 +155,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_sda_pb11 &i2c2_scl_pb10>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/we/oceanus1ev/we_oceanus1ev.dts
+++ b/boards/we/oceanus1ev/we_oceanus1ev.dts
@@ -101,6 +101,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/weact/blackpill_f401cc/blackpill_f401cc.dts
+++ b/boards/weact/blackpill_f401cc/blackpill_f401cc.dts
@@ -106,6 +106,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/weact/blackpill_f401ce/blackpill_f401ce.dts
+++ b/boards/weact/blackpill_f401ce/blackpill_f401ce.dts
@@ -106,6 +106,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/weact/blackpill_f411ce/blackpill_f411ce.dts
+++ b/boards/weact/blackpill_f411ce/blackpill_f411ce.dts
@@ -107,6 +107,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/weact/blackpill_h523ce/blackpill_h523ce.dts
+++ b/boards/weact/blackpill_h523ce/blackpill_h523ce.dts
@@ -68,6 +68,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
+++ b/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
@@ -142,6 +142,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb3>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -149,6 +151,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb14>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/weact/mini_stm32h743/mini_stm32h743.dts
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.dts
@@ -256,6 +256,8 @@ zephyr_udc0: &usbotg_fs {
 zephyr_camera_i2c: &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 };
 
 zephyr_camera_dvp: &dcmi {

--- a/boards/weact/stm32f405_core/weact_stm32f405_core.dts
+++ b/boards/weact/stm32f405_core/weact_stm32f405_core.dts
@@ -91,6 +91,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/weact/stm32f446_core/weact_stm32f446_core.dts
+++ b/boards/weact/stm32f446_core/weact_stm32f446_core.dts
@@ -90,6 +90,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/weact/stm32g030_core/weact_stm32g030_core.dts
+++ b/boards/weact/stm32g030_core/weact_stm32g030_core.dts
@@ -74,6 +74,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa11 &i2c2_sda_pa12>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/weact/stm32wb55_core/weact_stm32wb55_core.dts
+++ b/boards/weact/stm32wb55_core/weact_stm32wb55_core.dts
@@ -100,6 +100,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -209,6 +209,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_ph7 &i2c3_sda_ph8>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioh 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioh 8 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/samples/drivers/haptics/cs40l26/boards/nucleo_f401re.overlay
+++ b/samples/drivers/haptics/cs40l26/boards/nucleo_f401re.overlay
@@ -20,6 +20,8 @@
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-1 = <&analog_pb6 &analog_pb7>;
 	pinctrl-names = "default", "sleep";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 
 	cs40l26_0: cs40l26@40 {
 		compatible = "cirrus,cs40l26";

--- a/samples/drivers/haptics/cs40l5x/boards/nucleo_f401re.overlay
+++ b/samples/drivers/haptics/cs40l5x/boards/nucleo_f401re.overlay
@@ -20,6 +20,8 @@
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-1 = <&analog_pb6 &analog_pb7>;
 	pinctrl-names = "default", "sleep";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 
 	cs40l50_0: cs40l50@34 {
 		compatible = "cirrus,cs40l50";

--- a/samples/drivers/i2c/rtio_loopback/boards/nucleo_h503rb.overlay
+++ b/samples/drivers/i2c/rtio_loopback/boards/nucleo_h503rb.overlay
@@ -20,6 +20,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };
@@ -27,6 +29,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb5 &i2c2_sda_pb4>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/samples/sensor/accel_trig/boards/stm32f3_disco.overlay
+++ b/samples/sensor/accel_trig/boards/stm32f3_disco.overlay
@@ -15,6 +15,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa9 &i2c2_sda_pa10>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/samples/sensor/thermometer/boards/nucleo_h7a3zi_q.overlay
+++ b/samples/sensor/thermometer/boards/nucleo_h7a3zi_q.overlay
@@ -17,6 +17,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_sda_pb7 &i2c1_scl_pb6>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	compatible = "st,stm32-i2c-v2";
 	status = "okay";
 

--- a/samples/sensor/veml6031/boards/olimex_stm32_e407.overlay
+++ b/samples/sensor/veml6031/boards/olimex_stm32_e407.overlay
@@ -21,6 +21,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	light: light@29 {

--- a/samples/sensor/veml6046/boards/olimex_stm32_e407.overlay
+++ b/samples/sensor/veml6046/boards/olimex_stm32_e407.overlay
@@ -21,6 +21,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	rgbir: rgbir@29 {

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_hsi_lptim1_lse_adc1_pllp.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_hsi_lptim1_lse_adc1_pllp.overlay
@@ -85,6 +85,8 @@
 		 <&rcc STM32_SRC_HSI I2C1_SEL(2)>;
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_sysclk_lptim1_lsi.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_sysclk_lptim1_lsi.overlay
@@ -71,6 +71,8 @@
 		 <&rcc STM32_SRC_SYSCLK I2C1_SEL(1)>;
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_c071rb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_c071rb.overlay
@@ -24,6 +24,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa7 &i2c2_sda_pa6>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.overlay
@@ -21,6 +21,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pc8 &i2c3_sda_pc9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	eeprom1: eeprom@56 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_h503rb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_h503rb.overlay
@@ -16,6 +16,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -30,6 +32,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb5 &i2c2_sda_pb4>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.overlay
@@ -16,6 +16,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	eeprom0: eeprom@54 {
@@ -29,6 +31,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	eeprom1: eeprom@56 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l152re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l152re.overlay
@@ -21,6 +21,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	eeprom1: eeprom@56 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_u083rc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_u083rc.overlay
@@ -24,6 +24,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa7 &i2c2_sda_pa6>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_u385rg_q.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_u385rg_q.overlay
@@ -16,6 +16,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa7 &i2c3_sda_pc1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioc 1 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	eeprom0: eeprom@54 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.overlay
@@ -21,6 +21,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa7 &i2c3_sda_pb14>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wba55cg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wba55cg.overlay
@@ -24,6 +24,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa6 &i2c3_sda_pa7>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.overlay
@@ -21,6 +21,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pb13 &i2c3_sda_pb14>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32l562e_dk.overlay
@@ -24,6 +24,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb13 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
 	eeprom1: eeprom@56 {

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32u083c_dk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32u083c_dk.overlay
@@ -15,6 +15,8 @@
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pa9 &i2c1_sda_pa10>;
+	scl-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
 
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";


### PR DESCRIPTION
Define the I2C bus recovery GPIO DT properties for all boards based on an STM32 SoC.
All DTS files (DTS/DTSI and overlay) are considered to make sure the GPIOs for I2C bus recovery is consistent with the pinctrl default state used, being in the board DTS or the sample overlay file.

The changes (but last commit) were made running the below script (awk command developed by assistance of *GPT-5.4 Mini*). To run the script successfully, an DT overlay file name must be fixed (see https://github.com/zephyrproject-rtos/zephyr/pull/110458).
<details>
<summary>(shell script used for the biggest commit, click to expand)</summary>

The below script greps (using awk) DTS files for `pinctrl-0 = <&i2c_scl_pWX &i2c_sda_pYZ>;` (or swapped phandles) and adds `scl-gpios = <&gpioW X ...>`/`sda-gpios = <&gpioY Z ...>` in the node (possibly replacing existing occurrence in the node). It leverages STM32 SoC based DTS files use these pinctrl labels and all uses this single line format for I2C nodes defining their pinctrl default state (as shown running output from shell command `grep -rs _scl_p boards/ samples/ tests/ | grep -v _sda_p`).

The properties are printed after `pinctrl-names = ...`, to make the DTS files more readable.


```shell
#!/bin/bash
# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
# SPDX-License-Identifier: Apache-2.0

set -o nounset
set -o errexit

tempfile=$(mktemp)
trap 'rm -f "$tempfile"' EXIT

awk_cmd() {
  awk '
{
  # in case pinctrl-names is placed before pinctrl-0 in the node
  if ($0 ~ /^([[:space:]]*)pinctrl-names =/) {
    name_found = 1
  }

  if ($0 ~ /^([[:space:]]*)(scl|sda)-gpios =/) {
      props_present = 1
      # skip the line, it will be printed later
      if (props_added == 1) { next }
  }

  # Closing node: wipe our state
  if ($0 ~ /^([[:space:]]*)}/) {
    props_present = 0
    props_added = 0
    name_found = 0
  }

  # Matching pinctrl-0 = <&i2c1_scl_pXX &i2c1_sda_pXX>;
  if (match($0, /^([[:space:]]*)pinctrl-0[[:space:]]*=[[:space:]]*<&i2c([[:digit:]]+)_scl_p([[:alpha:]])([[:digit:]]+)[[:space:]]+&i2c([[:digit:]]+)_sda_p([[:alpha:]])([[:digit:]]+)>;/, m)) {
    desc_indent = m[1]
    P1 = m[3]
    B1 = m[4]
    P2 = m[6]
    B2 = m[7]
    pinctrl_found = 1
  }

  # Matching pinctrl-0 = <&i2c1_sda_pXX &i2c1_scl_pXX>;
  if (match($0, /^([[:space:]]*)pinctrl-0[[:space:]]*=[[:space:]]*<&i2c([[:digit:]]+)_sda_p([[:alpha:]])([[:digit:]]+)[[:space:]]+&i2c([[:digit:]]+)_scl_p([[:alpha:]])([[:digit:]]+)>;/, m)) {
    desc_indent = m[1]
    P2 = m[3]
    B2 = m[4]
    P1 = m[6]
    B1 = m[7]
    pinctrl_found = 1
  }

  print

  if (pinctrl_found == 1 && name_found == 1) {
    if (props_present != 1) {
      print desc_indent "scl-gpios = <&gpio" P1 " " B1 " GPIO_ACTIVE_HIGH>;"
      print desc_indent "sda-gpios = <&gpio" P2 " " B2 " GPIO_ACTIVE_HIGH>;"
      props_added = 1
    }
    pinctrl_found = 0
    name_found = 0
  }
}
' "$1" > "$2"
}

cnt=0
# Consider .dts, .dtsi and .overlay files that have a "_scl_p" occurrence
echo "Find matching files..."
files=`find boards/ samples/ tests/ \( -name "*.dts*" -o -name "*.overlay" \) -exec grep -l _scl_p {} \;`
echo "Process " `echo $files | wc -w` "matching files"

for f in $files; do
  awk_cmd "$f" "$tempfile"
  cmp -s "$f" "$tempfile" && continue
  echo $f
  cnt=$(($cnt+1))
  cat "$tempfile" > "$f"
done

echo "Done, $cnt files modified"
```
</details>
