### PR TITLE
FRDM-MCXL255: AON LPTMR support for CM33/CM0+

### DIFF
--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -140,6 +140,12 @@ void board_early_init_hook(void)
 	}
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_lptmr0))
+	CLOCK_AttachClk(kFRO16K_to_AON_LPTMR);
+	RESET_ReleasePeripheralReset(kAonLPTMR_RST_SHIFT_RSTn);
+	CLOCK_EnableClock(kCLOCK_GateAonLPTMR);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CPU_CLOCK_FREQ;
 }

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -110,3 +110,7 @@
 &systick {
 	status = "okay";
 };
+
+&aon_lptmr0 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -15,4 +15,5 @@ supported:
   - gpio
   - rtc
   - crc
+  - counter
 vendor: nxp

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
@@ -35,3 +35,7 @@
 &systick {
 	status = "okay";
 };
+
+&aon_lptmr0 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
@@ -12,4 +12,5 @@ toolchain:
   - gnuarmemb
 supported:
   - uart
+  - counter
 vendor: nxp

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
@@ -42,3 +42,7 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&aon_lptmr0 {
+	interrupts = <155 0>;
+};

--- a/dts/arm/nxp/mcx/nxp_mcxl_aon.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl_aon.dtsi
@@ -73,4 +73,17 @@
 		alarms-count = <3>;
 		status = "disabled";
 	};
+
+	aon_lptmr0: lptmr@88000 {
+		compatible = "nxp,lptmr";
+		reg = <0x88000 0x1000>;
+		interrupts = <28 0>;
+		clock-frequency = <16000>;
+		clk-source = <1>;
+		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
+		timer-mode-sel = <0>;
+		resolution = <32>;
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
Add AON LPTMR support for the FRDM-MCXL255 CM33 and CM0PLUS.

This PR adds the MCXL255 AON LPTMR devicetree node to the shared AON
devicetree file, allowing the peripheral to be used by both cores. The
shared node uses interrupt 28 for CM0+, while the CM33 devicetree
overrides it with interrupt 155.

The AON LPTMR instance is enabled for both FRDM-MCXL255 boards.
The required AON clock source, peripheral reset, and clock gate are
configured during board initialization.

Tested with:

- tests/drivers/counter/counter_basic_api on frdm_mcxl255/mcxl255/cpu0
- custom counter test on frdm_mcxl255/mcxl255/cpu1 (counter_basic_api doesn't fit in CM0PLUS)