### PR TITLE
modules: tfm: fix BL2 stderr link error

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -77,6 +77,12 @@ if(CONFIG_BUILD_WITH_TFM)
 
     # Supply path to MCUboot for TF-M build
     list(APPEND TFM_CMAKE_ARGS -DMCUBOOT_PATH=${ZEPHYR_MCUBOOT_MODULE_DIR})
+
+    # In debug builds MCUBoot's references undefined stderr, causing a BL2 link
+    # failure. So define stderr as an absolute linker symbol (NULL).
+    if(CONFIG_DEBUG)
+      list(APPEND TFM_CMAKE_ARGS "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--defsym=stderr=0")
+    endif()
   else()
     list(APPEND TFM_CMAKE_ARGS -DBL2=FALSE)
   endif()


### PR DESCRIPTION
- Fixes TFM BL2 linker error: `in function __assert_no_args':undefined reference to stderr`
  Reproducible via: `west build -p -b frdm_mcxa577/mcxa577/ns -T buildsystem.debug.build`
- Fixed by injecting -Wl,--defsym=stderr=0 into CMAKE_EXE_LINKER_FLAGS. This defines stderr as an absolute linker symbol with value 0.
- It should fix CI Error: https://github.com/zephyrproject-rtos/zephyr/actions/runs/26822397400/job/79242919925?pr=110353