### PR TITLE
soc: nxp: rw61x: add configuration for rw61x zigbee

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk-ng/components/components.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/components/components.cmake
@@ -23,6 +23,11 @@ if(${MCUX_DEVICE} MATCHES "RW61")
     set(CONFIG_MCUX_COMPONENT_driver.cache_cache64 ON)
     set(CONFIG_MCUX_COMPONENT_driver.flexspi ON)
   endif()
+  if(CONFIG_NXP_IEEE802154_MAC)
+    set(CONFIG_MCUX_COMPONENT_driver.conn_fwloader ON)
+    set(CONFIG_MCUX_COMPONENT_component.mflash_offchip ON)
+  endif()
+
 endif()
 
 if(CONFIG_USB_DEVICE_DRIVER OR CONFIG_UDC_DRIVER OR CONFIG_UHC_DRIVER OR CONFIG_BT)

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/connectivity_framework.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/connectivity_framework.cmake
@@ -8,6 +8,10 @@ if(CONFIG_SOC_SERIES_RW6XX)
         set(CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform.coex ON)
         set(CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform.rw61x ON)
 
+        if(CONFIG_NXP_IEEE802154_MAC)
+            set(CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform.zb ON)
+        endif()
+
         zephyr_compile_definitions(
             gPlatformDisableVendorSpecificInit=1U
             gPlatformUseTimerManager_d=0

--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -15,7 +15,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 260000000 if CORTEX_M_SYSTICK
 
 config NXP_MONOLITHIC_NBU
-	default y if (BT || IEEE802154)
+	default y if (BT || IEEE802154 || NXP_IEEE802154_MAC)
 
 configdefault NXP_COMPRESSED_WIFI_NB_FW
 	default y

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 138761d5c6f9b852950f22df41f18047a9fba3a7
+      revision: 0f7ae59e08fc5a0c43561c495488483aa506ab4e
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Enable MONOLITHIC_NBU for NXP_IEEE802154_MAC for rw61x
Update hal_nxp ieee_802_15_4 module to 26.06.00-pvw2