### PR TITLE
drivers: modem: cellular: change default init priority to 91

### DIFF
--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -37,7 +37,7 @@ if MODEM_CELLULAR
 
 config MODEM_CELLULAR_INIT_PRIORITY
 	int "Cellular modem driver initialization priority"
-	default 79
+	default 91
 	range 0 99
 	help
 	  Driver initialization priority for cellular modem drivers.


### PR DESCRIPTION
The cellular modem driver default initialization priority of 79 causes it to initialize before the network stack, which initializes at priority 90 (CONFIG_NET_INIT_PRIO). If network stacks does not get enough time to initialize/assign ppp interface, which cellular modem driver uses -> Hard Fault. 

<img width="719" height="198" alt="image" src="https://github.com/user-attachments/assets/1c8899d4-7707-4ea6-8ca3-cab8153e7bea" />

Change the default priority of cellular modem init to 91 to ensure correct initialization order.