### PR TITLE
assert: mark assertion checks as unlikely

### DIFF
--- a/include/zephyr/sys/__assert.h
+++ b/include/zephyr/sys/__assert.h
@@ -110,7 +110,7 @@ void assert_post_action(const char *file, unsigned int line);
 
 #define __ASSERT_NO_MSG(test)                                             \
 	do {                                                              \
-		if (!(test)) {                                            \
+		if (unlikely(!(test))) {                                  \
 			__ASSERT_LOC(test);                               \
 			__ASSERT_POST_ACTION();                           \
 			__ASSERT_UNREACHABLE;                             \
@@ -119,7 +119,7 @@ void assert_post_action(const char *file, unsigned int line);
 
 #define __ASSERT(test, fmt, ...)                                          \
 	do {                                                              \
-		if (!(test)) {                                            \
+		if (unlikely(!(test))) {                                  \
 			__ASSERT_LOC(test);                               \
 			__ASSERT_MSG_INFO(fmt, ##__VA_ARGS__);            \
 			__ASSERT_POST_ACTION();                           \


### PR DESCRIPTION
Wrap the failure test in `__ASSERT` and `__ASSERT_NO_MSG` with `unlikely()` so the compiler keeps the failure path off the hot path.