### PR TITLE
tracing: uart: build fix

### DIFF
--- a/subsys/tracing/tracing_backend_uart.c
+++ b/subsys/tracing/tracing_backend_uart.c
@@ -36,7 +36,7 @@ static void uart_isr(const struct device *dev, void *user_data)
 	uart_irq_update(dev);
 
 	if (uart_irq_rx_ready(dev) <= 0) {
-		break;
+		return;
 	}
 
 	while (true) {


### PR DESCRIPTION
Change break to return in order to compile.

Tests:

[Tenstorrent's sysetm-firmware repository](https://github.com/tenstorrent/tt-system-firmware) building app/smc with KCONFIG flags for CONFIG_TRACING_BACKEND_UART etc.