### PR TITLE
drivers: intc_dw: fix build errors for flags not existing

### DIFF
--- a/drivers/interrupt_controller/intc_dw.c
+++ b/drivers/interrupt_controller/intc_dw.c
@@ -139,12 +139,17 @@ static const struct irq_next_level_api dw_ictl_apis = {
 	.intr_get_line_state = dw_ictl_intr_get_line_state,
 };
 
+/* Fall back to 0 when the parent interrupt controller has no "flags" cell */
+#define INTC_DW_IRQ_FLAGS0(inst) 0
+#define INTC_DW_IRQ_FLAGS1(inst) DT_INST_IRQ(inst, flags)
+#define INTC_DW_IRQ_FLAGS(inst)  _CONCAT(INTC_DW_IRQ_FLAGS, DT_INST_IRQ_HAS_CELL(inst, flags))(inst)
+
 #define INTC_DW_DEVICE_INIT(inst)                                                                  \
                                                                                                    \
 	static void dw_ictl_config_irq_##inst(void)                                                \
 	{                                                                                          \
 		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), dw_ictl_isr,          \
-			    DEVICE_DT_INST_GET(inst), DT_INST_IRQ(inst, flags));                   \
+			    DEVICE_DT_INST_GET(inst), INTC_DW_IRQ_FLAGS(inst));                    \
 		irq_enable(DT_INST_IRQN(inst));                                                    \
 	}                                                                                          \
 	IRQ_PARENT_ENTRY_DEFINE(intc_dw##inst, DEVICE_DT_INST_GET(inst), DT_INST_IRQN(inst),       \


### PR DESCRIPTION
We recently changed from "sense" to "flags", however, [snps,arcv2-intc](https://github.com/zephyrproject-rtos/zephyr/blob/ad056d5454d57002c2b330b301d1e9906dd5fd0f/dts/bindings/interrupt-controller/snps%2Carcv2-intc.yaml#L6) controller compatible never defined flags so thus it errors out in the build since it doesn't have the flag cell.

Solution (like[ i2c_dw](https://github.com/zephyrproject-rtos/zephyr/blob/ad056d5454d57002c2b330b301d1e9906dd5fd0f/drivers/i2c/i2c_dw.c#L1441-L1443)) is to fall back to 0 if the IRQ doesn't have the flags cell.

Tests:

Our [system-firmware repository](https://github.com/tenstorrent/tt-system-firmware) running our tests uses this compatible.