### PR TITLE
drivers: i2c: stm32: Bus recovery is not supported if no GPIO defined

### DIFF
--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -262,6 +262,11 @@ static int i2c_stm32_recover_bus(const struct device *dev)
 
 	LOG_ERR("attempting to recover bus");
 
+	if ((config->scl.port == NULL) || (config->sda.port == NULL)) {
+		LOG_ERR("SCL and/or SDA GPIO definition(s) missing for I2C bus recovery");
+		return -ENOSYS;
+	}
+
 	if (!gpio_is_ready_dt(&config->scl)) {
 		LOG_ERR("SCL GPIO device not ready");
 		return -EIO;


### PR DESCRIPTION
Change STM32 I2C driver to report that I2C bus recovery is not supported when there are no GPIO defined for the sequence instead of returning a IO error, helper caller (possibly a tests samples) to handle this specific error case.