### PR TITLE
scripts: build: elf_parser: ignore non-struct _device symbols in device_deps parsing

### DIFF
--- a/scripts/build/elf_parser.py
+++ b/scripts/build/elf_parser.py
@@ -130,8 +130,18 @@ class ZephyrElf:
         self.relocatable = self.elf['e_type'] == 'ET_REL'
         self.edt = edt
         self.devices = []
+        device_end_symbol = device_start_symbol.replace('_list_start', '_list_end')
+        self._device_start_symbol = device_start_symbol
+        self._device_end_symbol = device_end_symbol
         self.ld_consts = self._symbols_find_value(
-            set([device_start_symbol, *Device.required_ld_consts, *DevicePM.required_ld_consts])
+            set(
+                [
+                    device_start_symbol,
+                    device_end_symbol,
+                    *Device.required_ld_consts,
+                    *DevicePM.required_ld_consts,
+                ]
+            )
         )
         self._device_parse_and_link()
 
@@ -246,8 +256,20 @@ class ZephyrElf:
 
         self._object_find_named('__devicedeps_', _on_ordinal)
 
-        # Find all device structs
+        # Find all device structs: real struct device instances are all
+        # allocated consecutively inside the device list section, so any
+        # symbol whose address falls outside
+        # [_device_list_start, _device_list_end) is not a real device.
+        dev_start = self.ld_consts.get(self._device_start_symbol)
+        dev_end = self.ld_consts.get(self._device_end_symbol)
+
         def _on_device(sym):
+            if (
+                dev_start is not None
+                and dev_end is not None
+                and not (dev_start <= sym.entry.st_value < dev_end)
+            ):
+                return
             self.devices.append(Device(self, sym))
 
         self._object_find_named('__device_', _on_device)


### PR DESCRIPTION
This PR fixes a crash in device dependency generation when CONFIG_DEVICE_DEPS is enabled.

### Problem:
gen_device_deps.py builds a ZephyrElf view of the kernel image and scans _device* ELF object symbols.
On some STM32 USB configurations, non-device helper objects are emitted with names that still match the `_device_` prefix (for example _device_dts_ord*__stm32_phy).
These are not struct device instances, but elf_parser currently treats them as such and reads pointer fields at struct device offsets, causing:

struct.error: unpack requires a buffer of 4 bytes

### What this PR changes:

~~In scripts/build/elf_parser.py, while collecting _device* symbols, add a minimal size guard before constructing Device objects.
The minimum valid size is derived from linker-provided struct offsets that are already used by the parser:
_DEVICE_STRUCT_HANDLES_OFFSET
_DEVICE_STRUCT_PM_OFFSET
Any _device symbol smaller than the required pointer-field coverage is skipped.~~
In scripts/build/elf_parser.py, while collecting `_device_` symbols, filter `_device_` symbols by address range. Real struct device instances are allocated consecutively inside the iterable device section, between `_device_list_start` and
`_device_list_end`.
Why this approach:

The crash occurs inside ZephyrElf construction, before gen_device_deps.py can post-filter anything: elf_parser.py is the right layer to validate symbol compatibility.

### Reproduction:

Board: stm32h747i_disco/stm32h747xx/m7
Samples: samples/subsys/usb/console and samples/subsys/usb/cdc_acm
Extra config: CONFIG_DEVICE_DEPS=y
Failure occurs at “Generating device_deps.c” with traceback in elf_parser.py.

### Fixes:
https://github.com/zephyrproject-rtos/zephyr/issues/110472
