### PR TITLE
include: gnss: add missing doxygen comments

### DIFF
--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -473,7 +473,7 @@ static inline int z_impl_gnss_get_latest_timepulse(const struct device *dev,
  * @brief Register a callback structure for GNSS data published
  *
  * @param _dev Device pointer
- * @param _callback The callback function
+ * @param _callback The callback function (see @ref gnss_data_callback_t)
  */
 #if CONFIG_GNSS
 #define GNSS_DATA_CALLBACK_DEFINE(_dev, _callback)                                              \
@@ -483,6 +483,12 @@ static inline int z_impl_gnss_get_latest_timepulse(const struct device *dev,
 		.callback = _callback,                                                          \
 	}
 
+/**
+ * @brief Register a callback structure for GNSS data published, by devicetree node.
+ *
+ * @param _node_id Devicetree node identifier of the GNSS device
+ * @param _callback The callback function (see @ref gnss_data_callback_t)
+ */
 #define GNSS_DT_DATA_CALLBACK_DEFINE(_node_id, _callback)                                          \
 	static const STRUCT_SECTION_ITERABLE(                                                      \
 		gnss_data_callback,                                                                \
@@ -499,7 +505,7 @@ static inline int z_impl_gnss_get_latest_timepulse(const struct device *dev,
  * @brief Register a callback structure for GNSS satellites published
  *
  * @param _dev Device pointer
- * @param _callback The callback function
+ * @param _callback The callback function (see @ref gnss_satellites_callback_t)
  */
 #if CONFIG_GNSS_SATELLITES
 #define GNSS_SATELLITES_CALLBACK_DEFINE(_dev, _callback)                                        \
@@ -509,6 +515,12 @@ static inline int z_impl_gnss_get_latest_timepulse(const struct device *dev,
 		.callback = _callback,                                                          \
 	}
 
+/**
+ * @brief Register a callback structure for GNSS satellites published, by devicetree node.
+ *
+ * @param _node_id Devicetree node identifier of the GNSS device
+ * @param _callback The callback function (see @ref gnss_satellites_callback_t)
+ */
 #define GNSS_DT_SATELLITES_CALLBACK_DEFINE(_node_id, _callback)                                    \
 	static const STRUCT_SECTION_ITERABLE(                                                      \
 		gnss_satellites_callback,                                                          \


### PR DESCRIPTION
Add missing trivial doxygen documentation to a couple of DT macros