### PR TITLE
include: uart: add missing doxygen comments for uart_event#data

### DIFF
--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -303,7 +303,7 @@ struct uart_event {
 		struct uart_event_rx_buf rx_buf;
 		/** @brief #UART_RX_STOPPED event data. */
 		struct uart_event_rx_stop rx_stop;
-	} data;
+	} data; /**< Event data; the valid field depends on @ref type. */
 };
 
 /**


### PR DESCRIPTION
Document uart_event's union field correctly.
https://builds.zephyrproject.io/zephyr/pr/110478/docs/doxygen/html/structuart__event.html