### PR TITLE
include: retained_mem: wrap BUILD_ASSERT in INTERNAL_HIDDEN section

### DIFF
--- a/include/zephyr/drivers/retained_mem.h
+++ b/include/zephyr/drivers/retained_mem.h
@@ -25,8 +25,10 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 BUILD_ASSERT(!(sizeof(off_t) > sizeof(size_t)),
 	     "Size of off_t must be equal or less than size of size_t");
+/** @endcond */
 
 /**
  * @brief Interfaces for retained memory.


### PR DESCRIPTION
`BUILD_ASSERT` seems to [expand to a variable](https://docs.zephyrproject.org/latest/doxygen/html/retained__mem_8h.html#a36713c339c3c5ec6d6bd481480bdb6f9) when header goes through Doxygen so ensure Doxygen does not see it.