### PR TITLE
net: if: replace checks for NULL with asserts

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -833,10 +833,7 @@ static inline void net_if_tx_unlock(struct net_if *iface)
 static inline void net_if_flag_set(struct net_if *iface,
 				   enum net_if_flag value)
 {
-	if (iface == NULL) {
-		return;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	atomic_set_bit(iface->if_dev->flags, value);
@@ -853,10 +850,7 @@ static inline void net_if_flag_set(struct net_if *iface,
 static inline bool net_if_flag_test_and_set(struct net_if *iface,
 					    enum net_if_flag value)
 {
-	if (iface == NULL) {
-		return false;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return atomic_test_and_set_bit(iface->if_dev->flags, value);
@@ -871,10 +865,7 @@ static inline bool net_if_flag_test_and_set(struct net_if *iface,
 static inline void net_if_flag_clear(struct net_if *iface,
 				     enum net_if_flag value)
 {
-	if (iface == NULL) {
-		return;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	atomic_clear_bit(iface->if_dev->flags, value);
@@ -891,10 +882,7 @@ static inline void net_if_flag_clear(struct net_if *iface,
 static inline bool net_if_flag_test_and_clear(struct net_if *iface,
 					      enum net_if_flag value)
 {
-	if (iface == NULL) {
-		return false;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return atomic_test_and_clear_bit(iface->if_dev->flags, value);
@@ -911,10 +899,7 @@ static inline bool net_if_flag_test_and_clear(struct net_if *iface,
 static inline bool net_if_flag_is_set(struct net_if *iface,
 				      enum net_if_flag value)
 {
-	if (iface == NULL) {
-		return false;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return atomic_test_bit(iface->if_dev->flags, value);
@@ -931,10 +916,7 @@ static inline bool net_if_flag_is_set(struct net_if *iface,
 static inline enum net_if_oper_state net_if_oper_state_set(
 	struct net_if *iface, enum net_if_oper_state oper_state)
 {
-	if (iface == NULL) {
-		return NET_IF_OPER_UNKNOWN;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	if (oper_state <= NET_IF_OPER_UP) {
@@ -959,10 +941,7 @@ static inline enum net_if_oper_state net_if_oper_state_set(
  */
 static inline enum net_if_oper_state net_if_oper_state(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return NET_IF_OPER_UNKNOWN;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return iface->if_dev->oper_state;
@@ -983,10 +962,8 @@ static inline enum net_if_oper_state net_if_oper_state(struct net_if *iface)
 static inline int net_if_oper_state_change_time(struct net_if *iface,
 						int64_t *change_time)
 {
-	if (iface == NULL || change_time == NULL) {
-		return -EINVAL;
-	}
-
+	NET_ASSERT(iface != NULL);
+	NET_ASSERT(change_time != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	net_if_lock(iface);
@@ -1036,10 +1013,7 @@ static inline enum net_verdict net_if_send_data(struct net_if *iface,
  */
 static inline const struct net_l2 *net_if_l2(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return NULL;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return iface->if_dev->l2;
@@ -1064,10 +1038,7 @@ enum net_verdict net_if_recv_data(struct net_if *iface, struct net_pkt *pkt);
  */
 static inline void *net_if_l2_data(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return NULL;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return iface->if_dev->l2_data;
@@ -1082,10 +1053,7 @@ static inline void *net_if_l2_data(struct net_if *iface)
  */
 static inline const struct device *net_if_get_device(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return NULL;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return iface->if_dev->dev;
@@ -1124,8 +1092,10 @@ static inline void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
 static inline bool net_if_is_ip_offloaded(struct net_if *iface)
 {
 #if defined(CONFIG_NET_OFFLOAD)
-	__ASSERT_NO_MSG(iface == NULL || iface->if_dev != NULL);
-	return (iface != NULL && iface->if_dev->offload != NULL);
+	NET_ASSERT(iface != NULL);
+	NET_ASSERT(iface->if_dev != NULL);
+
+	return iface->if_dev->offload != NULL;
 #else
 	ARG_UNUSED(iface);
 
@@ -1152,10 +1122,7 @@ bool net_if_is_offloaded(struct net_if *iface);
 static inline struct net_offload *net_if_offload(struct net_if *iface)
 {
 #if defined(CONFIG_NET_OFFLOAD)
-	if (iface == NULL) {
-		return NULL;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return iface->if_dev->offload;
@@ -1175,10 +1142,7 @@ static inline struct net_offload *net_if_offload(struct net_if *iface)
 static inline void net_if_offload_set(struct net_if *iface, struct net_offload *offload)
 {
 #if defined(CONFIG_NET_OFFLOAD)
-	if (iface == NULL) {
-		return;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	iface->if_dev->offload = offload;
@@ -1198,10 +1162,7 @@ static inline void net_if_offload_set(struct net_if *iface, struct net_offload *
 static inline bool net_if_is_socket_offloaded(struct net_if *iface)
 {
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
-	if (iface == NULL) {
-		return false;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return (iface->if_dev->socket_offload != NULL);
@@ -1222,10 +1183,7 @@ static inline void net_if_socket_offload_set(
 		struct net_if *iface, net_socket_create_t socket_offload)
 {
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
-	if (iface == NULL) {
-		return;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	iface->if_dev->socket_offload = socket_offload;
@@ -1245,10 +1203,7 @@ static inline void net_if_socket_offload_set(
 static inline net_socket_create_t net_if_socket_offload(struct net_if *iface)
 {
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
-	if (iface == NULL) {
-		return NULL;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return iface->if_dev->socket_offload;
@@ -1268,10 +1223,7 @@ static inline net_socket_create_t net_if_socket_offload(struct net_if *iface)
  */
 static inline struct net_linkaddr *net_if_get_link_addr(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return NULL;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return &iface->if_dev->link_addr;
@@ -1286,9 +1238,7 @@ static inline struct net_linkaddr *net_if_get_link_addr(struct net_if *iface)
  */
 static inline struct net_if_config *net_if_get_config(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return NULL;
-	}
+	NET_ASSERT(iface != NULL);
 
 	return &iface->config;
 }
@@ -1440,10 +1390,7 @@ static inline int net_if_set_link_addr(struct net_if *iface,
  */
 static inline uint16_t net_if_get_mtu(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return 0U;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	return iface->if_dev->mtu;
@@ -1458,10 +1405,7 @@ static inline uint16_t net_if_get_mtu(struct net_if *iface)
 static inline void net_if_set_mtu(struct net_if *iface,
 				  uint16_t mtu)
 {
-	if (iface == NULL) {
-		return;
-	}
-
+	NET_ASSERT(iface != NULL);
 	NET_ASSERT(iface->if_dev != NULL);
 
 	iface->if_dev->mtu = mtu;
@@ -1476,9 +1420,7 @@ static inline void net_if_set_mtu(struct net_if *iface,
 static inline void net_if_addr_set_lf(struct net_if_addr *ifaddr,
 				      bool is_infinite)
 {
-	if (ifaddr == NULL) {
-		return;
-	}
+	NET_ASSERT(ifaddr != NULL);
 
 	ifaddr->is_infinite = is_infinite;
 }
@@ -1510,9 +1452,7 @@ struct net_if *net_if_lookup_by_dev(const struct device *dev);
  */
 static inline struct net_if_config *net_if_config_get(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return NULL;
-	}
+	NET_ASSERT(iface != NULL);
 
 	return &iface->config;
 }
@@ -2132,9 +2072,7 @@ static inline void net_if_ipv6_set_base_reachable_time(struct net_if *iface,
 						       uint32_t reachable_time)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
-	if (iface == NULL) {
-		return;
-	}
+	NET_ASSERT(iface != NULL);
 
 	if (!iface->config.ip.ipv6) {
 		return;
@@ -2158,9 +2096,7 @@ static inline void net_if_ipv6_set_base_reachable_time(struct net_if *iface,
 static inline uint32_t net_if_ipv6_get_reachable_time(struct net_if *iface)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
-	if (iface == NULL) {
-		return 0;
-	}
+	NET_ASSERT(iface != NULL);
 
 	if (!iface->config.ip.ipv6) {
 		return 0;
@@ -2191,9 +2127,7 @@ uint32_t net_if_ipv6_calc_reachable_time(struct net_if_ipv6 *ipv6);
 static inline void net_if_ipv6_set_reachable_time(struct net_if_ipv6 *ipv6)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
-	if (ipv6 == NULL) {
-		return;
-	}
+	NET_ASSERT(ipv6 != NULL);
 
 	ipv6->reachable_time = net_if_ipv6_calc_reachable_time(ipv6);
 #else
@@ -2211,9 +2145,7 @@ static inline void net_if_ipv6_set_retrans_timer(struct net_if *iface,
 						 uint32_t retrans_timer)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
-	if (iface == NULL) {
-		return;
-	}
+	NET_ASSERT(iface != NULL);
 
 	if (!iface->config.ip.ipv6) {
 		return;
@@ -2236,9 +2168,7 @@ static inline void net_if_ipv6_set_retrans_timer(struct net_if *iface,
 static inline uint32_t net_if_ipv6_get_retrans_timer(struct net_if *iface)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
-	if (iface == NULL) {
-		return 0;
-	}
+	NET_ASSERT(iface != NULL);
 
 	if (!iface->config.ip.ipv6) {
 		return 0;
@@ -2638,9 +2568,7 @@ void net_if_ipv4_maddr_leave(struct net_if *iface,
 #if defined(CONFIG_NET_NATIVE_IPV4)
 static inline struct net_in_addr *net_if_router_ipv4(struct net_if_router *router)
 {
-	if (router == NULL) {
-		return NULL;
-	}
+	NET_ASSERT(router != NULL);
 
 	return &router->address.in_addr;
 }
@@ -3098,9 +3026,7 @@ int net_if_up(struct net_if *iface);
  */
 static inline bool net_if_is_up(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return false;
-	}
+	NET_ASSERT(iface != NULL);
 
 	return net_if_flag_is_set(iface, NET_IF_UP) &&
 	       net_if_flag_is_set(iface, NET_IF_RUNNING);
@@ -3124,9 +3050,7 @@ int net_if_down(struct net_if *iface);
  */
 static inline bool net_if_is_admin_up(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return false;
-	}
+	NET_ASSERT(iface != NULL);
 
 	return net_if_flag_is_set(iface, NET_IF_UP);
 }
@@ -3160,9 +3084,7 @@ void net_if_carrier_off(struct net_if *iface);
  */
 static inline bool net_if_is_carrier_ok(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return false;
-	}
+	NET_ASSERT(iface != NULL);
 
 	return net_if_flag_is_set(iface, NET_IF_LOWER_UP);
 }
@@ -3198,9 +3120,7 @@ void net_if_dormant_off(struct net_if *iface);
  */
 static inline bool net_if_is_dormant(struct net_if *iface)
 {
-	if (iface == NULL) {
-		return false;
-	}
+	NET_ASSERT(iface != NULL);
 
 	return net_if_flag_is_set(iface, NET_IF_DORMANT);
 }

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -839,13 +839,15 @@ enum net_verdict net_ipv6_prepare_for_send(struct net_pkt *pkt)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv6_access, struct net_ipv6_hdr);
 	struct net_in6_addr *nexthop = NULL;
-	struct net_if *iface = NULL;
+	struct net_if *iface;
 	struct net_ipv6_hdr *ip_hdr;
 	struct net_in6_addr dst_ip;
 	struct net_nbr *nbr;
 	int ret;
 
 	NET_ASSERT(pkt && pkt->buffer);
+
+	iface = net_pkt_iface(pkt);
 
 	ip_hdr = (struct net_ipv6_hdr *)net_pkt_get_data(pkt, &ipv6_access);
 	if (!ip_hdr) {
@@ -877,12 +879,12 @@ enum net_verdict net_ipv6_prepare_for_send(struct net_pkt *pkt)
 			mtu = ret;
 		} else {
 use_interface_mtu:
-			mtu = net_if_get_mtu(net_pkt_iface(pkt));
+			mtu = iface != NULL ? net_if_get_mtu(iface) : 0U;
 			mtu = MAX(NET_IPV6_MTU, mtu);
 		}
 
 		if (mtu < pkt_len) {
-			ret = net_ipv6_send_fragmented_pkt(net_pkt_iface(pkt),
+			ret = net_ipv6_send_fragmented_pkt(iface,
 							   pkt, pkt_len, mtu);
 			if (ret < 0) {
 				NET_DBG("Cannot fragment IPv6 pkt (%d)", ret);
@@ -919,10 +921,12 @@ use_interface_mtu:
 	    /* Workaround Linux bug, see:
 	     * https://github.com/zephyrproject-rtos/zephyr/issues/3111
 	     */
-	    net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_POINTOPOINT) ||
-	    net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_IPV6_NO_ND)) {
+	    (iface != NULL && (net_if_flag_is_set(iface, NET_IF_POINTOPOINT) ||
+			       net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)))) {
 		return NET_OK;
 	}
+
+	iface = NULL;
 
 	if (net_if_ipv6_addr_onlink(&iface, &dst_ip)) {
 		nexthop = &dst_ip;
@@ -981,7 +985,7 @@ try_send:
 		entry = net_pmtu_get_entry((struct net_sockaddr *)&dst);
 		if (entry == NULL) {
 			ret = net_pmtu_update_mtu((struct net_sockaddr *)&dst,
-						  net_if_get_mtu(iface));
+						  iface != NULL ? net_if_get_mtu(iface) : 0U);
 			if (ret < 0) {
 				NET_DBG("Cannot update PMTU for %s (%d)",
 					net_sprint_ipv6_addr(&dst.sin6_addr),

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1138,12 +1138,11 @@ static size_t pkt_buffer_length(struct net_pkt *pkt,
 				size_t existing)
 {
 	net_sa_family_t family = net_pkt_family(pkt);
-	size_t max_len;
+	struct net_if *iface = net_pkt_iface(pkt);
+	size_t max_len = 0;
 
-	if (net_pkt_iface(pkt)) {
-		max_len = net_if_get_mtu(net_pkt_iface(pkt));
-	} else {
-		max_len = 0;
+	if (iface != NULL) {
+		max_len = net_if_get_mtu(iface);
 	}
 
 	/* Family vs iface MTU */
@@ -1165,8 +1164,7 @@ static size_t pkt_buffer_length(struct net_pkt *pkt,
 		max_len = MAX(max_len, NET_IPV4_MTU);
 	} else { /* family == NET_AF_UNSPEC */
 #if defined (CONFIG_NET_L2_ETHERNET)
-		if (net_if_l2(net_pkt_iface(pkt)) ==
-		    &NET_L2_GET_NAME(ETHERNET)) {
+		if ((iface != NULL) && (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET))) {
 			max_len += NET_ETH_MAX_HDR_SIZE;
 		} else
 #endif /* CONFIG_NET_L2_ETHERNET */

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -1331,7 +1331,11 @@ static int pre_init_listener(void)
 
 	ARRAY_FOR_EACH(v6_ctx, i) {
 		iface = net_if_get_by_index(i + 1);
-		if ((!net_if_flag_is_set(iface, NET_IF_IPV6)) || iface == NULL) {
+		if (iface == NULL) {
+			/* all indexes after this are also invalid */
+			break;
+		}
+		if (!net_if_flag_is_set(iface, NET_IF_IPV6)) {
 			continue;
 		}
 
@@ -1354,7 +1358,11 @@ static int pre_init_listener(void)
 
 	ARRAY_FOR_EACH(v4_ctx, i) {
 		iface = net_if_get_by_index(i + 1);
-		if ((!net_if_flag_is_set(iface, NET_IF_IPV4)) || iface == NULL) {
+		if (iface == NULL) {
+			/* all indexes after this are also invalid */
+			break;
+		}
+		if (!net_if_flag_is_set(iface, NET_IF_IPV4)) {
 			continue;
 		}
 
@@ -1425,7 +1433,7 @@ static int init_listener(void)
 		}
 
 		iface = net_if_get_by_index(i + 1);
-		if ((!net_if_flag_is_set(iface, NET_IF_IPV6)) || iface == NULL) {
+		if (iface == NULL || !net_if_flag_is_set(iface, NET_IF_IPV6)) {
 			zsock_close(v6);
 			continue;
 		}
@@ -1522,7 +1530,7 @@ static int init_listener(void)
 		}
 
 		iface = net_if_get_by_index(i + 1);
-		if ((!net_if_flag_is_set(iface, NET_IF_IPV4)) || iface == NULL) {
+		if (iface == NULL || !net_if_flag_is_set(iface, NET_IF_IPV4)) {
 			zsock_close(v4);
 			continue;
 		}


### PR DESCRIPTION
NULL is not a (valid) pointer to a network
interface structure, therefore replace the
checks with asserts.