### PR TITLE
include: drivers: mspi: add missing doxygen file tag

### DIFF
--- a/include/zephyr/drivers/mspi/devicetree.h
+++ b/include/zephyr/drivers/mspi/devicetree.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief MSPI devicetree helper macros.
+ * @ingroup mspi_devicetree
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_MSPI_DEVICETREE_H_
 #define ZEPHYR_INCLUDE_DRIVERS_MSPI_DEVICETREE_H_
 


### PR DESCRIPTION
Add missing doxygen `@file` tag to the MSPI driver to help "parent" the file to the proper section of the documentation.