### PR TITLE
include: drivers: sensor: enhance Doxygen documentation for LSM6DSVXXX

### DIFF
--- a/include/zephyr/drivers/sensor/lsm6dsvxxx.h
+++ b/include/zephyr/drivers/sensor/lsm6dsvxxx.h
@@ -27,14 +27,17 @@
  */
 enum sensor_attribute_lsm6dsvxxx {
 	/**
-	 * Gets the self-test mode result in sensor_value.val1 field.
+	 * Gets the self-test mode result.
+	 * The result is stored in the sensor_value.val1 field.
+	 * See @ref lsm6dsvxxx_self_test_result for possible values.
 	 */
 	SENSOR_ATTR_GET_SELF_TEST_RESULT = SENSOR_ATTR_PRIV_START,
 };
 
+/** @brief Self-test result for the LSM6DSVXXX. */
 enum lsm6dsvxxx_self_test_result {
-	LSM6DSVXXX_ST_OK = 0,
-	LSM6DSVXXX_ST_FAIL = 1,
+	LSM6DSVXXX_ST_OK = 0,   /**< Self-test passed. */
+	LSM6DSVXXX_ST_FAIL = 1, /**< Self-test failed. */
 };
 
 /**


### PR DESCRIPTION
Document self-test result enum and cross-reference it from the extended sensor attribute.