### PR TITLE
include: drivers: stepper: document VALID_MICRO_STEP_RES macro

### DIFF
--- a/include/zephyr/drivers/stepper/stepper.h
+++ b/include/zephyr/drivers/stepper/stepper.h
@@ -64,6 +64,12 @@ enum stepper_micro_step_resolution {
  */
 #define MICRO_STEP_RES_INDEX(res) LOG2(res)
 
+/**
+ * @brief Check whether a microstep resolution is valid.
+ * @param res Microstep resolution to validate.
+ *
+ * @return Non-zero if @p res is a supported micro-step resolution, zero otherwise.
+ */
 #define VALID_MICRO_STEP_RES(res)                                                                  \
 	((res) == STEPPER_MICRO_STEP_1 || (res) == STEPPER_MICRO_STEP_2 ||                 \
 	 (res) == STEPPER_MICRO_STEP_4 || (res) == STEPPER_MICRO_STEP_8 ||                 \


### PR DESCRIPTION
Add Doxygen documentation for the micro-step resolution check macro.
https://builds.zephyrproject.io/zephyr/pr/110490/docs/doxygen/html/group__stepper__hw__driver.html#ga3196866d26d23c04313d802f2d8c61c1