### PR TITLE
include: drivers: usb_c: enhance Doxygen documentation

### DIFF
--- a/include/zephyr/drivers/usb_c/tcpci_priv.h
+++ b/include/zephyr/drivers/usb_c/tcpci_priv.h
@@ -41,9 +41,10 @@ struct tcpci_reg_dump_map {
  */
 extern const struct tcpci_reg_dump_map tcpci_std_regs[TCPCI_STD_REGS_SIZE];
 
-/** Type-C Port Controller Interface Specification Revision */
-#define PD_INT_REV10 0x10 /* Revision 1.0 */
-#define PD_INT_REV20 0x20 /* Revision 2.0 */
+/** Type-C Port Controller Interface Specification Revision 1.0 */
+#define PD_INT_REV10 0x10
+/** Type-C Port Controller Interface Specification Revision 2.0 */
+#define PD_INT_REV20 0x20
 
 /**
  * @brief Function to read the 8-bit register of TCPCI device

--- a/include/zephyr/drivers/usb_c/usbc_tc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tc.h
@@ -383,9 +383,9 @@ enum tc_cc_pull {
  *	  Replaced by pd_power_role for SOP packets.
  */
 enum tc_cable_plug {
-	/* Message originated from a DFP or UFP */
+	/** Message originated from a DFP or UFP. */
 	PD_PLUG_FROM_DFP_UFP = 0,
-	/* Message originated from a Cable Plug or VPD */
+	/** Message originated from a Cable Plug or VPD. */
 	PD_PLUG_FROM_CABLE_VPD = 1
 };
 

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -112,6 +112,7 @@ struct tcpc_chip_info {
 	/** Firmware version number */
 	uint64_t fw_version_number;
 
+	/** Minimum required firmware version, as a string or a number. */
 	union {
 		/** Minimum Required firmware version string */
 		uint8_t min_req_fw_version_string[8];


### PR DESCRIPTION
Fix Doxygen comment style in TCPCI and Type-C headers.