### PR TITLE
include: drivers: sensor: enhance Doxygen documentation for ICM42X70

### DIFF
--- a/include/zephyr/drivers/sensor/icm42x70.h
+++ b/include/zephyr/drivers/sensor/icm42x70.h
@@ -12,13 +12,22 @@
 /**
  * @file
  * @brief Extended public API for ICM42X70 MEMS sensor
+ * @ingroup icm42x70_interface
  *
  * Some capabilities and operational requirements for this sensor
  * cannot be expressed within the sensor driver abstraction.
  */
 
-/** ICM42X70 power mode */
+/**
+ * @brief TDK InvenSense ICM42X70 MEMS motion sensor
+ * @defgroup icm42x70_interface ICM42X70
+ * @ingroup sensor_interface_ext
+ * @{
+ */
+
+/** ICM42X70 low-noise power mode */
 #define ICM42X70_LOW_NOISE_MODE (0)
+/** ICM42X70 low-power power mode */
 #define ICM42X70_LOW_POWER_MODE (1)
 
 /**
@@ -47,4 +56,9 @@ enum sensor_attribute_icm42x70 {
 	/** Averaging configuration */
 	SENSOR_ATTR_AVERAGING,
 };
+
+/**
+ * @}
+ */
+
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_ICM42X70_H_ */


### PR DESCRIPTION
Complete the Doxygen documentation for this sensor driver, put in sensor_interface_ext group.