### PR TITLE
include: drivers: psi5: add missing doxygen comment

### DIFF
--- a/include/zephyr/drivers/psi5/psi5.h
+++ b/include/zephyr/drivers/psi5/psi5.h
@@ -47,6 +47,7 @@ struct psi5_frame {
 	/** Type of PSI5 frame */
 	enum psi5_frame_type type;
 
+	/** Frame payload. The valid member depends on @ref type. */
 	union {
 		/** Message data */
 		uint32_t data;


### PR DESCRIPTION
`psi5_frame`'s anonymous union needs a doxygen comment. This commit adds one :)