### PR TITLE
scripts: ci: check_compliance: KCONFIG_ALLOWLIST error fix

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1492,14 +1492,17 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
             cwd=GIT_TOP,
         )
 
+        self_folder = Path(__file__).resolve().parent
+
         if hasattr(self, 'UNDEF_KCONFIG_ALLOWLIST'):
             # Overridden at the class level
             undef_kconfig_allowlist = self.UNDEF_KCONFIG_ALLOWLIST
+            allowlist_hint = f"{type(self).__name__}.UNDEF_KCONFIG_ALLOWLIST"
         else:
             # Load from the text file
-            self_folder = Path(__file__).resolve().parent
             default_allowlist_file = self_folder / 'undef_kconfig_allowlist.txt'
             undef_kconfig_allowlist = get_set_from_file(str(default_allowlist_file))
+            allowlist_hint = str(default_allowlist_file)
 
         # Load extensions to UNDEF_KCONFIG_ALLOWLIST
         undef_kconfig_allowlist_extra = []
@@ -1508,7 +1511,6 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
             undef_kconfig_allowlist_extra = get_set_from_file(path)
 
         # Load the per-file allowlist: files listed here are skipped entirely
-        self_folder = Path(__file__).resolve().parent
         default_files_allowlist_file = self_folder / 'undef_kconfig_files_allowlist.txt'
         undef_kconfig_files_allowlist = get_set_from_file(str(default_files_allowlist_file))
 
@@ -1555,7 +1557,7 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
 
         self.failure(f"""
 Found references to undefined Kconfig symbols. If any of these are false
-positives, then add them to {default_allowlist_file}.
+positives, then add them to {allowlist_hint}.
 
 If the reference is for a comment like /* CONFIG_FOO_* */ (or
 /* CONFIG_FOO_*_... */), then please use exactly that form (with the '*'). The


### PR DESCRIPTION
`default_allow_list_file` is not set in the case KCONFIG_ALLOWLIST is set. In the case of failure, this causes the failure msg itself to throw error.

Tests:

We use this script in our repository and monkey patch it, including the KCONFIG_ALLOWLIST. This patch here allows the error message to display properly in case a deviation is detected. 

i.e.
```
An exception occurred in Kconfig:
Traceback (most recent call last):
  File "/home/jgrowden/tt-system-firmware-work/zephyr/scripts/ci/check_compliance.py", line 3019, in _main
    test.run()
  File "/home/jgrowden/tt-system-firmware-work/zephyr/scripts/ci/check_compliance.py", line 745, in run
    self.check_no_undef_outside_kconfig(kconf)
  File "/home/jgrowden/tt-system-firmware-work/zephyr/scripts/ci/check_compliance.py", line 1558, in check_no_undef_outside_kconfig
    positives, then add them to {default_allowlist_file}.
                                 ^^^^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'default_allowlist_file' where it is not associated with a value
```

After:

```
ERROR   : Test Kconfig failed: 
Found references to undefined Kconfig symbols. If any of these are false
positives, then add them to KconfigCheck.UNDEF_KCONFIG_ALLOWLIST.

If the reference is for a comment like /* CONFIG_FOO_* */ (or
/* CONFIG_FOO_*_... */), then please use exactly that form (with the '*'). The
CI check knows not to flag it.

More generally, a reference followed by $, @, {, (, ., *, or ## will never be
flagged.

CONFIG_JG                                  app/dmc/src/main.c:273
```