### PR TITLE
MAINTAINERS: add zafersn as collaborator for Drivers: Modem

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2324,6 +2324,7 @@ Documentation Infrastructure:
     - rerickson1
   collaborators:
     - SeppoTakalo
+    - zafersn
   files:
     - drivers/modem/
     - tests/drivers/build_all/modem/


### PR DESCRIPTION
Add myself as a collaborator for the modem driver in the MAINTAINERS file.

I am the primary developer and maintainer of the HL78xx modem driver and would like to help monitor modem-related changes and issues. My main expertise is in standalone modem drivers and socket offloading, particularly the HL78xx driver, but I am happy to assist with reviews where appropriate.

As discussed, this primarily adds me to the notification list so I can more easily track activity affecting modem drivers and respond to issues related to the HL78xx driver.

## Motivation

* Improve visibility of modem driver changes and issues.
* Help provide timely feedback on changes affecting the HL78xx driver.
* Increase reviewer bandwidth for modem-related contributions where relevant.
