### PR TITLE
modules: tf-m: Honor TOOLCHAIN_VARIANT_COMPILER

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -434,6 +434,9 @@ Libraries / Subsystems
   * TF-M was updated from version 2.2.2 to version 2.3.0. Release notes can be
     found `here <https://trustedfirmware-m.readthedocs.io/en/tf-mv2.3.0/releases/2.3.0.htm>`_.
 
+  * TF-M can now be compiled using LLVM by setting ``ZEPHYR_TOOLCHAIN_VARIANT``
+    to ``zephyr/llvm``.
+
 * DFU
 
   * Added :kconfig:option:`CONFIG_IMG_CUSTOM_SECTOR_SIZE` to allow MCUboot to use a different

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -221,9 +221,17 @@ if(CONFIG_BUILD_WITH_TFM)
   # TODO: Add support for cross-compile toolchain variant
   # TODO: Enforce GCC version check against TF-M compiler requirements
   if(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "zephyr")
-    set(TFM_TOOLCHAIN_FILE "toolchain_GNUARM.cmake")
-    set(TFM_TOOLCHAIN_PREFIX "arm-zephyr-eabi")
-    set(TFM_TOOLCHAIN_PATH ${ZEPHYR_SDK_INSTALL_DIR}/gnu/arm-zephyr-eabi/bin)
+    if(${TOOLCHAIN_VARIANT_COMPILER} STREQUAL "gnu")
+      set(TFM_TOOLCHAIN_FILE "toolchain_GNUARM.cmake")
+      set(TFM_TOOLCHAIN_PREFIX "arm-zephyr-eabi")
+      set(TFM_TOOLCHAIN_PATH ${ZEPHYR_SDK_INSTALL_DIR}/gnu/arm-zephyr-eabi/bin)
+    elseif(${TOOLCHAIN_VARIANT_COMPILER} STREQUAL "llvm")
+      set(TFM_TOOLCHAIN_FILE "toolchain_ATFE.cmake")
+      set(TFM_TOOLCHAIN_PREFIX "arm-none-eabi")
+      set(TFM_TOOLCHAIN_PATH ${ZEPHYR_SDK_INSTALL_DIR}/llvm/bin)
+    else()
+      message(FATAL_ERROR "Unsupported TOOLCHAIN_VARIANT_COMPILER: ${TOOLCHAIN_VARIANT_COMPILER}")
+    endif()
   elseif(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "gnuarmemb")
     set(TFM_TOOLCHAIN_FILE "toolchain_GNUARM.cmake")
     set(TFM_TOOLCHAIN_PREFIX "arm-none-eabi")
@@ -312,7 +320,8 @@ if(CONFIG_BUILD_WITH_TFM)
     COMMAND ${CMAKE_COMMAND}
       -G${CMAKE_GENERATOR}
       -DTFM_TOOLCHAIN_FILE=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/${TFM_TOOLCHAIN_FILE}
-      -DCROSS_COMPILE=${TFM_TOOLCHAIN_PATH}/${TFM_TOOLCHAIN_PREFIX}
+      -DCMAKE_PROGRAM_PATH=${TFM_TOOLCHAIN_PATH}
+      -DCROSS_COMPILE=${TFM_TOOLCHAIN_PREFIX}
       -DCMAKE_BUILD_TYPE=${TFM_CMAKE_BUILD_TYPE}
       -DTFM_PLATFORM=${CONFIG_TFM_BOARD}
       -DCONFIG_TFM_BUILD_LOG_QUIET=ON

--- a/tests/modules/tf-m/regression/tests.yaml
+++ b/tests/modules/tf-m/regression/tests.yaml
@@ -7,6 +7,9 @@ common:
   filter: CONFIG_BUILD_WITH_TFM and not CONFIG_TFM_LOG_LEVEL_SILENCE
   integration_platforms:
     - mps2/an521/cpu0/ns
+  integration_toolchains:
+    - zephyr/llvm
+    - zephyr/gnu
   harness: console
   harness_config:
     type: multi_line


### PR DESCRIPTION
Compile TF-M with gcc or llvm toolchain based on the value of `TOOLCHAIN_VARIANT_COMPILER`. This allows TF-M to be built with the same compiler as the zephyr application.