### PR TITLE
drivers: reset: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -218,9 +218,8 @@ __subsystem struct reset_driver_api {
  * @param id Reset line.
  * @param status Where to write the reset status.
  *
- * @retval 0 On success.
- * @retval -ENOSYS If the functionality is not implemented by the driver.
- * @retval -errno Other negative errno in case of failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Functionality is not implemented by the driver.
  */
 __syscall int reset_status(const struct device *dev, uint32_t id, uint8_t *status);
 
@@ -261,9 +260,8 @@ static inline int reset_status_dt(const struct reset_dt_spec *spec, uint8_t *sta
  * @param dev Reset controller device.
  * @param id Reset line.
  *
- * @retval 0 On success.
- * @retval -ENOSYS If the functionality is not implemented by the driver.
- * @retval -errno Other negative errno in case of failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Functionality is not implemented by the driver.
  */
 __syscall int reset_line_assert(const struct device *dev, uint32_t id);
 
@@ -303,9 +301,8 @@ static inline int reset_line_assert_dt(const struct reset_dt_spec *spec)
  * @param dev Reset controller device.
  * @param id Reset line.
  *
- * @retval 0 On success.
- * @retval -ENOSYS If the functionality is not implemented by the driver.
- * @retval -errno Other negative errno in case of failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Functionality is not implemented by the driver.
  */
 __syscall int reset_line_deassert(const struct device *dev, uint32_t id);
 
@@ -344,9 +341,8 @@ static inline int reset_line_deassert_dt(const struct reset_dt_spec *spec)
  * @param dev Reset controller device.
  * @param id Reset line.
  *
- * @retval 0 On success.
- * @retval -ENOSYS If the functionality is not implemented by the driver.
- * @retval -errno Other negative errno in case of failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS Functionality is not implemented by the driver.
  */
 __syscall int reset_line_toggle(const struct device *dev, uint32_t id);
 


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974