### PR TITLE
bluetooth: hci: ipc: Add config for closing HCI while keeping IPC alive

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -66,6 +66,15 @@ config BT_HCI_IPC_ENDPOINT_BOUND_TIMEOUT_MS
 	  Timeout value that HCI will wait for an IPC endpoint to be bound,
 	  in milliseconds.
 
+config BT_HCI_IPC_KEEP_ALIVE
+	bool "Keep the IPC instance bound when HCI is closed"
+	depends on BT_HCI_IPC
+	help
+	  When enabled, the HCI driver will not tear down the IPC instance
+	  when it is closed. Subsequent opens reuse the same instance while
+	  attaching the new receive callback. After closing, incoming messages
+	  over IPC will be discarded until the callback is opened again.
+
 config BT_SPI
 	bool
 	select SPI

--- a/drivers/bluetooth/hci/ipc.c
+++ b/drivers/bluetooth/hci/ipc.c
@@ -44,6 +44,7 @@ struct ipc_data {
 	struct ipc_ept_cfg hci_ept_cfg;
 	struct k_sem bound_sem;
 	const struct device *ipc;
+	bool bound;
 #if defined(CONFIG_BT_EXT_ADV)
 	struct hci_ext_adv_discard_ctx ext_adv_discard;
 #endif
@@ -309,6 +310,15 @@ static void hci_ept_bound(void *priv)
 	struct ipc_data *ipc = dev->data;
 
 	k_sem_give(&ipc->bound_sem);
+	ipc->bound = true;
+}
+
+static void hci_ept_unbound(void *priv)
+{
+	const struct device *dev = priv;
+	struct ipc_data *ipc = dev->data;
+
+	ipc->bound = false;
 }
 
 static void hci_ept_recv(const void *data, size_t len, void *priv)
@@ -334,6 +344,10 @@ static int bt_ipc_open(const struct device *dev)
 {
 	struct ipc_data *ipc = dev->data;
 	int err;
+
+	if (IS_ENABLED(CONFIG_BT_HCI_IPC_KEEP_ALIVE) && ipc->bound) {
+		return 0;
+	}
 
 	err = bt_hci_transport_setup(NULL);
 	if (err) {
@@ -369,6 +383,10 @@ static int bt_ipc_close(const struct device *dev)
 	struct ipc_data *ipc = dev->data;
 	int err;
 
+	if (IS_ENABLED(CONFIG_BT_HCI_IPC_KEEP_ALIVE)) {
+		return 0;
+	}
+
 	err = ipc_service_deregister_endpoint(&ipc->hci_ept);
 	if (err) {
 		LOG_ERR("Deregistering HCI endpoint failed with: %d", err);
@@ -387,6 +405,8 @@ static int bt_ipc_close(const struct device *dev)
 		return err;
 	}
 
+	ipc->bound = false;
+
 	return 0;
 }
 
@@ -403,6 +423,7 @@ static DEVICE_API(bt_hci, drv) = {
 			.name = DT_INST_PROP(inst, bt_hci_ipc_name), \
 			.cb = { \
 				.bound    = hci_ept_bound, \
+				.unbound  = hci_ept_unbound, \
 				.received = hci_ept_recv, \
 			}, \
 			.priv = (void *)DEVICE_DT_INST_GET(inst), \


### PR DESCRIPTION
As it currently stands, if you close an HCI connection e.g. `bt_disable()`, then `bt_hci_close()` will cause the IPC driver to deregister the IPC endpoint and close the connection. Generally, this means that we can no longer enable Bluetooth again on IPC-driven setups easily (on the nRF5340, it seems that the [net core would have to be restarted separately to re-bind](https://devzone.nordicsemi.com/f/nordic-q-a/114847/bt_enable-failed-after-bt_disable-in-nrf5340), for example).

This change poses a simpler alternative which adds a config option to allow `bt_hci_close()` to mask the IPC traffic, rather than actually closing the IPC session. The traffic can be later re-subscribed by defining a new receive callback with `bt_hci_open()`.

In my specific application, I have the use case: I switch between two uses of the HCI IPC. One is a USB HCI raw connection, where the app core just passes HCI messages through to the net core directly. Another is an SMP use, where the app core has the Bluetooth host stack to serve as a peripheral advertising SMP. These don't exist concurrently, but switch over who owns the receive callback as the current HCI authority (SMP or passthrough). Without this change, switching over the callback would inherently teardown the IPC connection and require the net core to be reset to sync the two cores again.