### PR TITLE
i3c: rework attach/detach state management across rstdaa, setdasa, setaasa, and do_daa

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -1812,6 +1812,53 @@ static int cdns_i3c_do_ccc_cb(const struct device *dev, struct i3c_ccc_payload *
 }
 #endif
 
+static void cdns_i3c_daa_attach_known_target(const struct device *dev,
+					     struct i3c_device_desc *target,
+					     uint8_t rr_idx, uint8_t dyn_addr,
+					     uint8_t bcr, uint8_t dcr, uint64_t pid)
+{
+	struct cdns_i3c_data *data = dev->data;
+
+	/* If RSTDAA detached this desc, the slist no longer carries it.
+	 * Re-attach so the caller's desc continues to track this device
+	 * on the bus.
+	 */
+	target->dynamic_addr = dyn_addr;
+	target->bcr = bcr;
+	target->dcr = dcr;
+
+	int aret = i3c_attach_i3c_device(target);
+
+	if (aret != 0 && aret != -EALREADY) {
+		LOG_ERR("%s: attach for PID 0x%012llx failed: %d",
+			dev->name, pid, aret);
+	}
+
+	data->cdns_i3c_i2c_priv_data[rr_idx].id = rr_idx;
+	target->controller_priv = &(data->cdns_i3c_i2c_priv_data[rr_idx]);
+
+	LOG_DBG("%s: PID 0x%012llx assigned dynamic address 0x%02x",
+		dev->name, pid, dyn_addr);
+
+	/* The Cadence I3C IP does not allow the controller to assign a
+	 * specific DA during ENTDAA -- it picks the next address from the
+	 * pre-programmed RR slots. If the DT requested a particular
+	 * init_dynamic_addr and the hardware assigned a different one,
+	 * issue SETNEWDA to move the target to the preferred address.
+	 * This may fail if the preferred address is already in use, in
+	 * which case the target keeps the ENTDAA-assigned DA.
+	 */
+	if (target->init_dynamic_addr != 0 &&
+	    target->init_dynamic_addr != dyn_addr) {
+		int sret = i3c_bus_setnewda(target, target->init_dynamic_addr);
+
+		if (sret != 0) {
+			LOG_WRN("%s: SETNEWDA to 0x%02x failed (%d), keeping DA 0x%02x",
+				dev->name, target->init_dynamic_addr, sret, dyn_addr);
+		}
+	}
+}
+
 /**
  * @brief Perform Dynamic Address Assignment.
  *
@@ -1912,58 +1959,9 @@ static int cdns_i3c_do_daa(const struct device *dev)
 						"list, given DA 0x%02x",
 						dev->name, pid, dyn_addr);
 				} else {
-					/* If RSTDAA detached this desc, the slist
-					 * no longer carries it. Re-attach so the
-					 * caller's desc continues to track this
-					 * device on the bus. The DA we just got
-					 * from DAA is already free in the address
-					 * pool (RSTDAA freed it), so the attach
-					 * succeeds and re-marks it.
-					 */
-					target->dynamic_addr = dyn_addr;
-					target->bcr = bcr;
-					target->dcr = dcr;
-
-					int aret = i3c_attach_i3c_device(target);
-
-					if (aret != 0 && aret != -EALREADY) {
-						LOG_ERR("%s: attach for PID 0x%012llx failed: %d",
-							dev->name, pid, aret);
-					}
-
-					data->cdns_i3c_i2c_priv_data[rr_idx].id = rr_idx;
-					target->controller_priv =
-						&(data->cdns_i3c_i2c_priv_data[rr_idx]);
-
-					LOG_DBG("%s: PID 0x%012llx assigned dynamic address 0x%02x",
-						dev->name, pid, dyn_addr);
-
-					/* The Cadence I3C IP does not allow the
-					 * controller to assign a specific DA
-					 * during ENTDAA -- it picks the next
-					 * address from the pre-programmed RR
-					 * slots. If the DT requested a particular
-					 * init_dynamic_addr and the hardware
-					 * assigned a different one, issue SETNEWDA
-					 * to move the target to the preferred
-					 * address. This may fail if the preferred
-					 * address is already in use, in which case
-					 * the target keeps the ENTDAA-assigned DA.
-					 */
-					if (target->init_dynamic_addr != 0 &&
-					    target->init_dynamic_addr != dyn_addr) {
-						int sret = i3c_bus_setnewda(target,
-							target->init_dynamic_addr);
-
-						if (sret != 0) {
-							LOG_WRN("%s: SETNEWDA to 0x%02x "
-								"failed (%d), keeping "
-								"DA 0x%02x",
-								dev->name,
-								target->init_dynamic_addr,
-								sret, dyn_addr);
-						}
-					}
+					cdns_i3c_daa_attach_known_target(dev,
+						target, rr_idx, dyn_addr,
+						bcr, dcr, pid);
 				}
 				i3c_addr_slots_mark_i3c(&data->common.attached_dev.addr_slots,
 							target ? target->dynamic_addr : dyn_addr);

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -1924,7 +1924,7 @@ static int cdns_i3c_do_daa(const struct device *dev)
 						dev->name, pid, dyn_addr);
 				}
 				i3c_addr_slots_mark_i3c(&data->common.attached_dev.addr_slots,
-							dyn_addr);
+							target ? target->dynamic_addr : dyn_addr);
 			}
 		}
 	} else {
@@ -2443,6 +2443,16 @@ static int cdns_i3c_master_get_rr_slot(const struct device *dev, uint8_t dyn_add
 				return rr_idx;
 			}
 		}
+	}
+
+	/* No active RR slot carries this dyn_addr — the address is stale
+	 * (e.g. the desc was detached without RSTDAA, or DAA hasn't run
+	 * yet on this address). Fall back to allocating a fresh slot if
+	 * one is available; the caller will reprogram the DA via the
+	 * normal DAA / SETDASA / SETNEWDA flow before the next transfer.
+	 */
+	if (data->free_rr_slots) {
+		return find_lsb_set(data->free_rr_slots) - 1;
 	}
 
 	return -EINVAL;

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -1912,9 +1912,24 @@ static int cdns_i3c_do_daa(const struct device *dev)
 						"list, given DA 0x%02x",
 						dev->name, pid, dyn_addr);
 				} else {
+					/* If RSTDAA detached this desc, the slist
+					 * no longer carries it. Re-attach so the
+					 * caller's desc continues to track this
+					 * device on the bus. The DA we just got
+					 * from DAA is already free in the address
+					 * pool (RSTDAA freed it), so the attach
+					 * succeeds and re-marks it.
+					 */
 					target->dynamic_addr = dyn_addr;
 					target->bcr = bcr;
 					target->dcr = dcr;
+
+					int aret = i3c_attach_i3c_device(target);
+
+					if (aret != 0 && aret != -EALREADY) {
+						LOG_ERR("%s: attach for PID 0x%012llx failed: %d",
+							dev->name, pid, aret);
+					}
 
 					data->cdns_i3c_i2c_priv_data[rr_idx].id = rr_idx;
 					target->controller_priv =

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -1922,6 +1922,33 @@ static int cdns_i3c_do_daa(const struct device *dev)
 
 					LOG_DBG("%s: PID 0x%012llx assigned dynamic address 0x%02x",
 						dev->name, pid, dyn_addr);
+
+					/* The Cadence I3C IP does not allow the
+					 * controller to assign a specific DA
+					 * during ENTDAA -- it picks the next
+					 * address from the pre-programmed RR
+					 * slots. If the DT requested a particular
+					 * init_dynamic_addr and the hardware
+					 * assigned a different one, issue SETNEWDA
+					 * to move the target to the preferred
+					 * address. This may fail if the preferred
+					 * address is already in use, in which case
+					 * the target keeps the ENTDAA-assigned DA.
+					 */
+					if (target->init_dynamic_addr != 0 &&
+					    target->init_dynamic_addr != dyn_addr) {
+						int sret = i3c_bus_setnewda(target,
+							target->init_dynamic_addr);
+
+						if (sret != 0) {
+							LOG_WRN("%s: SETNEWDA to 0x%02x "
+								"failed (%d), keeping "
+								"DA 0x%02x",
+								dev->name,
+								target->init_dynamic_addr,
+								sret, dyn_addr);
+						}
+					}
 				}
 				i3c_addr_slots_mark_i3c(&data->common.attached_dev.addr_slots,
 							target ? target->dynamic_addr : dyn_addr);
@@ -2445,7 +2472,7 @@ static int cdns_i3c_master_get_rr_slot(const struct device *dev, uint8_t dyn_add
 		}
 	}
 
-	/* No active RR slot carries this dyn_addr — the address is stale
+	/* No active RR slot carries this dyn_addr -- the address is stale
 	 * (e.g. the desc was detached without RSTDAA, or DAA hasn't run
 	 * yet on this address). Fall back to allocating a fresh slot if
 	 * one is available; the caller will reprogram the DA via the

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -948,8 +948,8 @@ bool i3c_bus_has_sec_controller(const struct device *dev)
 #ifdef CONFIG_I3C_CONTROLLER
 int i3c_bus_rstdaa_all(const struct device *dev)
 {
-	struct i3c_driver_data *data = (struct i3c_driver_data *)dev->data;
 	struct i3c_device_desc *desc;
+	struct i3c_device_desc *desc_tmp;
 	int ret;
 
 	ret = i3c_ccc_do_rstdaa_all(dev);
@@ -959,18 +959,28 @@ int i3c_bus_rstdaa_all(const struct device *dev)
 	}
 
 	/* RSTDAA has cleared every target's dynamic address in hardware.
-	 * Sync software state: clear the cached dynamic_addr and return
-	 * each DA to the address-slot pool so it can be reassigned by
-	 * a subsequent DAA.
+	 * Sync software state: detach the desc (which uses the current
+	 * dynamic_addr to release the address slot), then clear the cached
+	 * dynamic_addr. Use the _safe iterator since detach removes the
+	 * node from the slist.
 	 */
+	I3C_BUS_FOR_EACH_I3CDEV_SAFE(dev, desc, desc_tmp) {
+		bool pooled = i3c_device_desc_in_pool(desc);
+		int dret;
 
-	I3C_BUS_FOR_EACH_I3CDEV(dev, desc) {
-		if (desc->dynamic_addr != 0U) {
-			i3c_addr_slots_mark_free(&data->attached_dev.addr_slots,
-						 desc->dynamic_addr);
+		LOG_DBG("%s: Reset dynamic address for device %s", dev->name,
+			desc->dev->name);
+		dret = i3c_detach_i3c_device(desc);
+		if (dret != 0) {
+			LOG_ERR("%s: failed to detach %s (%d)", dev->name,
+				desc->dev->name, dret);
+		}
+		/* Pool-allocated descs are freed inside detach -- writing to
+		 * them afterwards would be use-after-free. Static descs
+		 * survive and need the DA cleared for the next ENTDAA.
+		 */
+		if (!pooled) {
 			desc->dynamic_addr = 0;
-			LOG_DBG("%s: Reset dynamic address for device %s",
-					dev->name, desc->dev->name);
 		}
 	}
 

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -991,7 +991,7 @@ int i3c_bus_setdasa(struct i3c_device_desc *desc, uint8_t dynamic_addr)
 {
 	struct i3c_driver_data *data = (struct i3c_driver_data *)desc->bus->data;
 	struct i3c_ccc_address dyn_addr;
-	int ret;
+	int ret = 0;
 
 	/* check if the addressed is free, if the requested DA is different from the SA */
 	if (desc->static_addr != dynamic_addr) {
@@ -1000,6 +1000,18 @@ int i3c_bus_setdasa(struct i3c_device_desc *desc, uint8_t dynamic_addr)
 				dynamic_addr);
 			return -EADDRNOTAVAIL;
 		}
+	}
+
+	/* Attach before sending the CCC so the controller has the
+	 * device if it was not already attached.
+	 */
+	LOG_DBG("%s: %s: attaching with SA 0x%02x for SETDASA",
+		desc->bus->name, desc->dev->name, desc->static_addr);
+	ret = i3c_attach_i3c_device(desc);
+	if (ret < 0 && ret != -EALREADY) {
+		LOG_ERR("%s: %s: unable to attach device (%d)", desc->bus->name,
+			desc->dev->name, ret);
+		return ret;
 	}
 
 	/*
@@ -1016,7 +1028,11 @@ int i3c_bus_setdasa(struct i3c_device_desc *desc, uint8_t dynamic_addr)
 
 	/* update the target's dynamic address */
 	desc->dynamic_addr = dynamic_addr;
+
 	if (desc->dynamic_addr != desc->static_addr) {
+		LOG_DBG("%s: %s: reattaching from SA 0x%02x to DA 0x%02x",
+			desc->bus->name, desc->dev->name,
+			desc->static_addr, desc->dynamic_addr);
 		ret = i3c_reattach_i3c_device(desc, desc->static_addr);
 		if (ret < 0) {
 			LOG_ERR("%s: %s: unable to reattach device (%d)", desc->bus->name,
@@ -1024,9 +1040,10 @@ int i3c_bus_setdasa(struct i3c_device_desc *desc, uint8_t dynamic_addr)
 			return ret;
 		}
 	}
+
 	LOG_DBG("%s: %s: SETDASA to 0x%02x", desc->bus->name, desc->dev->name, desc->dynamic_addr);
 
-	return ret;
+	return 0;
 }
 
 int i3c_bus_setnewda(struct i3c_device_desc *desc, uint8_t dynamic_addr)

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -537,10 +537,13 @@ void i3c_sec_handoffed(struct k_work *work)
 #endif /* CONFIG_I3C_USE_IBI */
 #endif /* CONFIG_I3C_TARGET */
 
-int i3c_dev_list_daa_addr_helper(struct i3c_addr_slots *addr_slots,
-				 const struct i3c_dev_list *dev_list, uint64_t pid, bool must_match,
+int i3c_dev_list_daa_addr_helper(const struct device *dev, uint64_t pid, bool must_match,
 				 bool assigned_okay, struct i3c_device_desc **target, uint8_t *addr)
 {
+	struct i3c_driver_data *data = (struct i3c_driver_data *)dev->data;
+	const struct i3c_driver_config *config = (const struct i3c_driver_config *)dev->config;
+	struct i3c_addr_slots *addr_slots = &data->attached_dev.addr_slots;
+	const struct i3c_dev_list *dev_list = &config->dev_list;
 	struct i3c_device_desc *desc;
 	const uint16_t vendor_id = (uint16_t)(pid >> 32);
 	const uint32_t part_no = (uint32_t)(pid & 0xFFFFFFFFU);
@@ -552,6 +555,10 @@ int i3c_dev_list_daa_addr_helper(struct i3c_addr_slots *addr_slots,
 	/* If a device was not found, try to allocate a descriptor */
 	if (desc == NULL) {
 		desc = i3c_device_desc_alloc();
+		if (desc != NULL) {
+			desc->bus = dev;
+			desc->pid = pid;
+		}
 	}
 	if (must_match && (desc == NULL)) {
 		/*

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -1090,6 +1090,8 @@ int i3c_bus_setnewda(struct i3c_device_desc *desc, uint8_t dynamic_addr)
 
 int i3c_bus_setaasa(const struct device *dev)
 {
+	const struct i3c_driver_config *config = dev->config;
+	const struct i3c_dev_list *dev_list = &config->dev_list;
 	struct i3c_device_desc *desc;
 	int ret;
 
@@ -1100,13 +1102,26 @@ int i3c_bus_setaasa(const struct device *dev)
 	}
 
 	/*
-	 * set all devices DA to SA if it is known that it supports SETAASA and doesn't currently
-	 * have a dynamic address
+	 * Set DA = SA for all devices that support SETAASA and don't
+	 * already have a DA.  Walk the static dev_list (not the slist)
+	 * because after rstdaa_all the slist may be empty.
 	 */
-	I3C_BUS_FOR_EACH_I3CDEV(dev, desc) {
+	for (int i = 0; i < dev_list->num_i3c; i++) {
+		desc = &dev_list->i3c[i];
 		if ((desc->flags & I3C_SUPPORTS_SETAASA) && (desc->dynamic_addr == 0) &&
 		    (desc->static_addr != 0)) {
 			desc->dynamic_addr = desc->static_addr;
+
+			LOG_DBG("%s: %s: attaching after SETAASA with DA 0x%02x",
+				dev->name, desc->dev->name, desc->dynamic_addr);
+			int aret = i3c_attach_i3c_device(desc);
+
+			if (aret != 0 && aret != -EALREADY) {
+				LOG_ERR("%s: %s: unable to attach after SETAASA (%d)",
+					dev->name, desc->dev->name, aret);
+				desc->dynamic_addr = 0;
+				continue;
+			}
 			LOG_DBG("%s: %s: SETAASA to 0x%02x", dev->name, desc->dev->name,
 				desc->dynamic_addr);
 		}

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -84,7 +84,6 @@ int i3c_addr_slots_init(const struct device *dev)
 	struct i3c_driver_data *data = (struct i3c_driver_data *)dev->data;
 	const struct i3c_driver_config *config = (const struct i3c_driver_config *)dev->config;
 	int i, ret = 0;
-	struct i3c_device_desc *i3c_dev;
 	struct i3c_i2c_device_desc *i2c_dev;
 
 	__ASSERT_NO_MSG(dev != NULL);
@@ -124,19 +123,12 @@ int i3c_addr_slots_init(const struct device *dev)
 	}
 
 	/*
-	 * If there is a static address for the I3C devices, check
-	 * if this address is free, and there is no other devices of
-	 * the same (pre-assigned) address on the bus.
+	 * I3C devices are not attached here -- i3c_bus_init() calls
+	 * rstdaa_all which would immediately detach them. Instead,
+	 * I3C devices are attached during the address assignment
+	 * phase (setdasa, setaasa, or entdaa) where address conflicts
+	 * are detected by i3c_attach_i3c_device().
 	 */
-	for (i = 0; i < config->dev_list.num_i3c; i++) {
-		i3c_dev = &config->dev_list.i3c[i];
-		ret = i3c_attach_i3c_device(i3c_dev);
-		if (ret != 0) {
-			/* Address slot is not free */
-			ret = -EINVAL;
-			goto out;
-		}
-	}
 
 out:
 	return ret;

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -833,7 +833,6 @@ static int i3c_bus_prepare_setdasa(const struct device *dev, const struct i3c_de
 	/* Loop through the registered I3C devices */
 	for (i = 0; i < dev_list->num_i3c; i++) {
 		struct i3c_device_desc *desc = &dev_list->i3c[i];
-		struct i3c_driver_data *bus_data = (struct i3c_driver_data *)dev->data;
 		uint8_t dynamic_addr;
 
 		/*
@@ -855,21 +854,6 @@ static int i3c_bus_prepare_setdasa(const struct device *dev, const struct i3c_de
 		     desc->init_dynamic_addr == desc->static_addr)) {
 			*need_aasa = true;
 			continue;
-		}
-
-		/*
-		 * check that initial dynamic address is free before setting it
-		 * if configured
-		 */
-		if ((desc->init_dynamic_addr != 0) &&
-		    (desc->init_dynamic_addr != desc->static_addr)) {
-			if (!i3c_addr_slots_is_free(&bus_data->attached_dev.addr_slots,
-						    desc->init_dynamic_addr)) {
-				if (i3c_detach_i3c_device(desc) != 0) {
-					LOG_ERR("Failed to detach %s", desc->dev->name);
-				}
-				continue;
-			}
 		}
 
 		/*

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -866,10 +866,6 @@ static int i3c_bus_prepare_setdasa(const struct device *dev, const struct i3c_de
 		ret = i3c_bus_setdasa(desc, dynamic_addr);
 		if (ret != 0) {
 			LOG_ERR("SETDASA error on address 0x%x (%d)", desc->static_addr, ret);
-			/* SETDASA failed, detach it from the controller */
-			if (i3c_detach_i3c_device(desc) != 0) {
-				LOG_ERR("Failed to detach %s (%d)", desc->dev->name, ret);
-			}
 		}
 	}
 
@@ -968,6 +964,7 @@ int i3c_bus_setdasa(struct i3c_device_desc *desc, uint8_t dynamic_addr)
 	struct i3c_driver_data *data = (struct i3c_driver_data *)desc->bus->data;
 	struct i3c_ccc_address dyn_addr;
 	int ret = 0;
+	int dret;
 
 	/* check if the addressed is free, if the requested DA is different from the SA */
 	if (desc->static_addr != dynamic_addr) {
@@ -999,6 +996,11 @@ int i3c_bus_setdasa(struct i3c_device_desc *desc, uint8_t dynamic_addr)
 	ret = i3c_ccc_do_setdasa(desc, dyn_addr);
 	if (ret != 0) {
 		LOG_ERR("%s: %s: SETDASA error (%d)", desc->bus->name, desc->dev->name, ret);
+		dret = i3c_detach_i3c_device(desc);
+		if (dret != 0 && dret != -EALREADY) {
+			LOG_ERR("%s: %s: failed to detach after SETDASA failure",
+				desc->bus->name, desc->dev->name);
+		}
 		return ret;
 	}
 

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -412,8 +412,9 @@ int i3c_sec_get_basic_info(const struct device *dev, uint8_t dynamic_addr, uint8
 			i3c_detach_i3c_device(&temp_desc);
 			return -ENOMEM;
 		}
+		desc->bus = dev;
 		desc->pid = id.pid;
-		temp_desc.static_addr = (uint16_t)static_addr;
+		desc->static_addr = static_addr;
 	}
 	desc->dynamic_addr = dynamic_addr;
 	desc->bcr = bcr;
@@ -448,7 +449,7 @@ int i3c_sec_i2c_attach(const struct device *dev, uint8_t static_addr, uint8_t lv
 		if (!i2c_desc) {
 			return -ENOMEM;
 		}
-		*(const struct device **)&i2c_desc->bus = dev;
+		i2c_desc->bus = dev;
 		i2c_desc->addr = (uint16_t)static_addr;
 		i2c_desc->lvr = lvr;
 	}

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -310,12 +310,8 @@ int i3c_detach_i3c_device(struct i3c_device_desc *target)
 	const struct i3c_driver_api *api = (const struct i3c_driver_api *)target->bus->api;
 	int status = 0;
 
-	if (!sys_slist_is_empty(&data->attached_dev.devices.i3c)) {
-		if (!sys_slist_find_and_remove(&data->attached_dev.devices.i3c, &target->node)) {
-			return -EINVAL;
-		}
-	} else {
-		return -EINVAL;
+	if (!sys_slist_find_and_remove(&data->attached_dev.devices.i3c, &target->node)) {
+		return -EALREADY;
 	}
 
 	if (api->detach_i3c_device != NULL) {
@@ -368,12 +364,8 @@ int i3c_detach_i2c_device(struct i3c_i2c_device_desc *target)
 	const struct i3c_driver_api *api = (const struct i3c_driver_api *)target->bus->api;
 	int status = 0;
 
-	if (!sys_slist_is_empty(&data->attached_dev.devices.i2c)) {
-		if (!sys_slist_find_and_remove(&data->attached_dev.devices.i2c, &target->node)) {
-			return -EINVAL;
-		}
-	} else {
-		return -EINVAL;
+	if (!sys_slist_find_and_remove(&data->attached_dev.devices.i2c, &target->node)) {
+		return -EALREADY;
 	}
 
 	if (api->detach_i2c_device != NULL) {

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -181,7 +181,7 @@ struct i3c_device_desc *i3c_dev_list_find(const struct i3c_dev_list *dev_list,
 	for (i = 0; i < dev_list->num_i3c; i++) {
 		struct i3c_device_desc *desc = &dev_list->i3c[i];
 
-		if (desc->pid == id->pid) {
+		if ((desc->pid & GENMASK64(47, 0)) == (id->pid & GENMASK64(47, 0))) {
 			ret = desc;
 			break;
 		}

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -378,7 +378,7 @@ int i3c_sec_get_basic_info(const struct device *dev, uint8_t dynamic_addr, uint8
 			   uint8_t bcr, uint8_t dcr)
 {
 	struct i3c_ccc_getpid getpid;
-	struct i3c_device_desc temp_desc;
+	struct i3c_device_desc temp_desc = {0};
 	struct i3c_device_desc *desc;
 	struct i3c_device_id id;
 	const struct i3c_driver_config *config = dev->config;
@@ -423,16 +423,22 @@ int i3c_sec_get_basic_info(const struct device *dev, uint8_t dynamic_addr, uint8
 	/* Detach that temporary device */
 	ret = i3c_detach_i3c_device(&temp_desc);
 	if (ret != 0) {
-		return ret;
+		goto free_desc;
 	}
 	ret = i3c_attach_i3c_device(desc);
 	if (ret != 0) {
-		return ret;
+		goto free_desc;
 	}
 
 	/* Skip reading BCR and DCR as they came from DEFTGTS */
 	ret = i3c_device_adv_info_get(desc);
 
+	return ret;
+
+free_desc:
+	if (i3c_device_desc_in_pool(desc)) {
+		i3c_device_desc_free(desc);
+	}
 	return ret;
 }
 
@@ -455,6 +461,10 @@ int i3c_sec_i2c_attach(const struct device *dev, uint8_t static_addr, uint8_t lv
 	}
 
 	ret = i3c_attach_i2c_device(i2c_desc);
+	if (ret != 0 && i3c_i2c_device_desc_in_pool(i2c_desc)) {
+		i3c_i2c_device_desc_free(i2c_desc);
+	}
+
 	return ret;
 }
 

--- a/drivers/i3c/i3c_max32.c
+++ b/drivers/i3c/i3c_max32.c
@@ -1050,9 +1050,11 @@ static int max32_i3c_do_daa(const struct device *dev)
 					target->dynamic_addr = dyn_addr;
 					target->bcr = rx_buf[6];
 					target->dcr = rx_buf[7];
-					/* attach it to the list */
-					sys_slist_append(&data->common.attached_dev.devices.i3c,
-							 &target->node);
+					int aret = i3c_attach_i3c_device(target);
+
+					if (aret != 0 && aret != -EALREADY) {
+						LOG_ERR("Failed to attach target");
+					}
 				} else {
 					/* No more free device descriptors */
 					LOG_DBG("No more free device descriptors.");
@@ -1074,6 +1076,7 @@ static int max32_i3c_do_daa(const struct device *dev)
 					LOG_ERR("Failed to attach target");
 				}
 			}
+
 			/* Mark the address as I3C device */
 			i3c_addr_slots_mark_i3c(&data->common.attached_dev.addr_slots, dyn_addr);
 

--- a/drivers/i3c/i3c_max32.c
+++ b/drivers/i3c/i3c_max32.c
@@ -1067,6 +1067,12 @@ static int max32_i3c_do_daa(const struct device *dev)
 				target->dynamic_addr = dyn_addr;
 				target->bcr = rx_buf[6];
 				target->dcr = rx_buf[7];
+
+				int aret = i3c_attach_i3c_device(target);
+
+				if (aret != 0 && aret != -EALREADY) {
+					LOG_ERR("Failed to attach target");
+				}
 			}
 			/* Mark the address as I3C device */
 			i3c_addr_slots_mark_i3c(&data->common.attached_dev.addr_slots, dyn_addr);

--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -1253,10 +1253,8 @@ static int mcux_i3c_do_daa(const struct device *dev)
 
 			LOG_DBG("DAA: Rcvd PID 0x%04x%08x", vendor_id, part_no);
 
-			ret = i3c_dev_list_daa_addr_helper(&data->common.attached_dev.addr_slots,
-							   &config->common.dev_list, pid,
-							   false, false,
-							   &target, &dyn_addr);
+			ret = i3c_dev_list_daa_addr_helper(dev, pid, false, false, &target,
+							   &dyn_addr);
 			if (ret != 0) {
 				goto out_daa;
 			}

--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -1266,6 +1266,12 @@ static int mcux_i3c_do_daa(const struct device *dev)
 			target->bcr = rx_buf[6];
 			target->dcr = rx_buf[7];
 
+			int aret = i3c_attach_i3c_device(target);
+
+			if (aret != 0 && aret != -EALREADY) {
+				LOG_ERR("Failed to attach target");
+			}
+
 			/* Mark the address as I3C device */
 			i3c_addr_slots_mark_i3c(&data->common.attached_dev.addr_slots, dyn_addr);
 

--- a/drivers/i3c/i3c_npcx.c
+++ b/drivers/i3c/i3c_npcx.c
@@ -1496,9 +1496,8 @@ static int npcx_i3c_do_daa(const struct device *dev)
 			LOG_DBG("DAA: Rcvd PID 0x%04x%08x", vendor_id, part_no);
 
 			/* Find a usable address during ENTDAA */
-			ret = i3c_dev_list_daa_addr_helper(&data->common.attached_dev.addr_slots,
-							   &config->common.dev_list, pid, false,
-							   false, &target, &dyn_addr);
+			ret = i3c_dev_list_daa_addr_helper(dev, pid, false, false, &target,
+							   &dyn_addr);
 			if (ret != 0) {
 				LOG_ERR("%s: Assign new DA error", __func__);
 				break;

--- a/drivers/i3c/i3c_npcx.c
+++ b/drivers/i3c/i3c_npcx.c
@@ -1513,6 +1513,12 @@ static int npcx_i3c_do_daa(const struct device *dev)
 				target->dynamic_addr = dyn_addr;
 				target->bcr = rx_buf[6];
 				target->dcr = rx_buf[7];
+
+				int aret = i3c_attach_i3c_device(target);
+
+				if (aret != 0 && aret != -EALREADY) {
+					LOG_ERR("Failed to attach target");
+				}
 			}
 
 			/* Mark the address as I3C device */

--- a/drivers/i3c/i3c_renesas_ra.c
+++ b/drivers/i3c/i3c_renesas_ra.c
@@ -210,7 +210,6 @@ static int i3c_renesas_ra_device_index_request(const struct device *dev, uint8_t
 static void i3c_renesas_ra_handle_address_phase(const struct device *dev,
 						i3c_slave_info_t const *daa_rx)
 {
-	const struct i3c_renesas_ra_config *config = dev->config;
 	struct i3c_renesas_ra_data *data = dev->data;
 	struct i3c_device_desc *target;
 	int target_index = -1;
@@ -223,9 +222,7 @@ static void i3c_renesas_ra_handle_address_phase(const struct device *dev,
 	fsp_err_t fsp_err = FSP_SUCCESS;
 
 	/* Find device in the device list, assign a dynamic address */
-	ret = i3c_dev_list_daa_addr_helper(&data->common.attached_dev.addr_slots,
-					   &config->common.dev_list, pid, false, false, &target,
-					   &dyn_addr);
+	ret = i3c_dev_list_daa_addr_helper(dev, pid, false, false, &target, &dyn_addr);
 	if (ret) {
 		LOG_DBG("Assign new DA error");
 		goto add_phase_exit;

--- a/drivers/i3c/i3c_renesas_ra.c
+++ b/drivers/i3c/i3c_renesas_ra.c
@@ -236,6 +236,12 @@ static void i3c_renesas_ra_handle_address_phase(const struct device *dev,
 		target->dynamic_addr = dyn_addr;
 		target->bcr = daa_rx->bcr;
 		target->dcr = daa_rx->dcr;
+
+		int aret = i3c_attach_i3c_device(target);
+
+		if (aret != 0 && aret != -EALREADY) {
+			LOG_ERR("Failed to attach target");
+		}
 	}
 
 	/* Request index for this target */

--- a/drivers/i3c/i3c_stm32.c
+++ b/drivers/i3c/i3c_stm32.c
@@ -1814,9 +1814,8 @@ static void i3c_stm32_event_isr_tx(const struct device *dev)
 		LL_I3C_DisableIT_TXFNF(i3c);
 
 		/* Find the device in the device list */
-		ret = i3c_dev_list_daa_addr_helper(&data->drv_data.attached_dev.addr_slots,
-						   &config->drv_cfg.dev_list, data->pid, false,
-						   false, &target, &dyn_addr);
+		ret = i3c_dev_list_daa_addr_helper(dev, data->pid, false, false, &target,
+						   &dyn_addr);
 		if (ret != 0) {
 			/* TODO: figure out what is the correct sequence to exit form this error
 			 * It is expected that a TX overrun error to occur which triggers err isr

--- a/drivers/i3c/i3c_stm32.c
+++ b/drivers/i3c/i3c_stm32.c
@@ -1834,6 +1834,12 @@ static void i3c_stm32_event_isr_tx(const struct device *dev)
 			target->dynamic_addr = dyn_addr;
 			target->bcr = bcr;
 			target->dcr = dcr;
+
+			int aret = i3c_attach_i3c_device(target);
+
+			if (aret != 0 && aret != -EALREADY) {
+				LOG_ERR("Failed to attach target");
+			}
 		}
 
 		/* Mark the address as used */

--- a/drivers/i3c/i3cm_it51xxx.c
+++ b/drivers/i3c/i3cm_it51xxx.c
@@ -1224,9 +1224,7 @@ static int it51xxx_daa_next_xfer(const struct device *dev)
 	pid = (uint64_t)vendor_id << 32U | (uint64_t)part_no;
 
 	/* find the device in the device list */
-	ret = i3c_dev_list_daa_addr_helper(&data->common.attached_dev.addr_slots,
-					   &cfg->common.dev_list, pid, false, false, &target,
-					   &dyn_addr);
+	ret = i3c_dev_list_daa_addr_helper(dev, pid, false, false, &target, &dyn_addr);
 	if (ret != 0) {
 		LOG_INST_ERR(cfg->log, "no dynamic address could be assigned to target");
 		return -EINVAL;

--- a/drivers/i3c/i3cm_it51xxx.c
+++ b/drivers/i3c/i3cm_it51xxx.c
@@ -1238,6 +1238,12 @@ static int it51xxx_daa_next_xfer(const struct device *dev)
 		target->dynamic_addr = dyn_addr;
 		target->bcr = data->dlm_data.rx_data[6];
 		target->dcr = data->dlm_data.rx_data[7];
+
+		int aret = i3c_attach_i3c_device(target);
+
+		if (aret != 0 && aret != -EALREADY) {
+			LOG_INST_ERR(cfg->log, "failed to attach target");
+		}
 	} else {
 		LOG_INST_INF(
 			cfg->log,

--- a/drivers/i3c/i3cm_it51xxx.c
+++ b/drivers/i3c/i3cm_it51xxx.c
@@ -1310,9 +1310,7 @@ static int it51xxx_daa_next_xfer(const struct device *dev)
 	pid = (uint64_t)vendor_id << 32U | (uint64_t)part_no;
 
 	/* find the device in the device list */
-	ret = i3c_dev_list_daa_addr_helper(&data->common.attached_dev.addr_slots,
-					   &cfg->common.dev_list, pid, false, false, &target,
-					   &dyn_addr);
+	ret = i3c_dev_list_daa_addr_helper(dev, pid, false, false, &target, &dyn_addr);
 	if (ret != 0) {
 		LOG_INST_ERR(cfg->log, "no dynamic address could be assigned to target");
 		return -EINVAL;

--- a/drivers/i3c/i3cm_it51xxx.c
+++ b/drivers/i3c/i3cm_it51xxx.c
@@ -1324,6 +1324,12 @@ static int it51xxx_daa_next_xfer(const struct device *dev)
 		target->dynamic_addr = dyn_addr;
 		target->bcr = data->dlm_data.rx_data[6];
 		target->dcr = data->dlm_data.rx_data[7];
+
+		int aret = i3c_attach_i3c_device(target);
+
+		if (aret != 0 && aret != -EALREADY) {
+			LOG_INST_ERR(cfg->log, "failed to attach target");
+		}
 	} else {
 		LOG_INST_INF(
 			cfg->log,

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1663,8 +1663,8 @@ static inline int i3c_recover_bus(const struct device *dev)
  * @param target Pointer to the target device descriptor
  *
  * @retval 0 on success.
- * @retval -EINVAL Address is not available, or the device
- *     has already been attached before.
+ * @retval -EADDRNOTAVAIL Address is not available.
+ * @retval -EALREADY Device has already been attached before.
  */
 int i3c_attach_i3c_device(struct i3c_device_desc *target);
 
@@ -1711,7 +1711,7 @@ int i3c_reattach_i3c_device(struct i3c_device_desc *target, uint8_t old_dyn_addr
  * @param target Pointer to the target device descriptor
  *
  * @retval 0 on success.
- * @retval -EINVAL Device is already detached.
+ * @retval -EALREADY Device is already detached.
  */
 int i3c_detach_i3c_device(struct i3c_device_desc *target);
 
@@ -1753,8 +1753,8 @@ static inline bool i3c_is_i3c_device_attached(struct i3c_device_desc *target)
  * @param target Pointer to the target device descriptor
  *
  * @retval 0 on success.
- * @retval -EINVAL Address is not available, or the device
- *     has already been attached before.
+ * @retval -EADDRNOTAVAIL Address is not available.
+ * @retval -EALREADY Device has already been attached before.
  */
 int i3c_attach_i2c_device(struct i3c_i2c_device_desc *target);
 
@@ -1773,7 +1773,7 @@ int i3c_attach_i2c_device(struct i3c_i2c_device_desc *target);
  * @param target Pointer to the target device descriptor
  *
  * @retval 0 on success.
- * @retval -EINVAL Device is already detached.
+ * @retval -EALREADY Device is already detached.
  */
 int i3c_detach_i2c_device(struct i3c_i2c_device_desc *target);
 

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1456,8 +1456,7 @@ struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct device *dev,
  * assigned already (that i3c_device_desc::dynamic_addr is not
  * zero). This is mainly used during the initial DAA.
  *
- * @param[in] addr_slots Pointer to address slots struct.
- * @param[in] dev_list Pointer to the device list struct.
+ * @param[in] dev Pointer to the controller device driver instance.
  * @param[in] pid Provisioned ID of device to be assigned address.
  * @param[in] must_match True if PID must match devices in
  *			 the device list. False otherwise.
@@ -1475,8 +1474,7 @@ struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct device *dev,
  *                 has an address assigned or invalid function
  *                 arguments.
  */
-int i3c_dev_list_daa_addr_helper(struct i3c_addr_slots *addr_slots,
-				 const struct i3c_dev_list *dev_list,
+int i3c_dev_list_daa_addr_helper(const struct device *dev,
 				 uint64_t pid, bool must_match,
 				 bool assigned_okay,
 				 struct i3c_device_desc **target,

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1724,8 +1724,8 @@ static inline int i3c_recover_bus(const struct device *dev)
  * @param target Pointer to the target device descriptor
  *
  * @retval 0 on success.
- * @retval -EINVAL Address is not available, or the device
- *     has already been attached before.
+ * @retval -EADDRNOTAVAIL Address is not available.
+ * @retval -EALREADY Device has already been attached before.
  */
 int i3c_attach_i3c_device(struct i3c_device_desc *target);
 
@@ -1776,7 +1776,7 @@ int i3c_reattach_i3c_device(struct i3c_device_desc *target, uint8_t old_dyn_addr
  * @param target Pointer to the target device descriptor
  *
  * @retval 0 on success.
- * @retval -EINVAL Device is already detached.
+ * @retval -EALREADY Device is already detached.
  */
 int i3c_detach_i3c_device(struct i3c_device_desc *target);
 
@@ -1822,8 +1822,8 @@ static inline bool i3c_is_i3c_device_attached(struct i3c_device_desc *target)
  * @param target Pointer to the target device descriptor
  *
  * @retval 0 on success.
- * @retval -EINVAL Address is not available, or the device
- *     has already been attached before.
+ * @retval -EADDRNOTAVAIL Address is not available.
+ * @retval -EALREADY Device has already been attached before.
  */
 int i3c_attach_i2c_device(struct i3c_i2c_device_desc *target);
 
@@ -1844,7 +1844,7 @@ int i3c_attach_i2c_device(struct i3c_i2c_device_desc *target);
  * @param target Pointer to the target device descriptor
  *
  * @retval 0 on success.
- * @retval -EINVAL Device is already detached.
+ * @retval -EALREADY Device is already detached.
  */
 int i3c_detach_i2c_device(struct i3c_i2c_device_desc *target);
 

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1498,8 +1498,7 @@ struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct device *dev,
  *
  * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
- * @param[in] addr_slots Pointer to address slots struct.
- * @param[in] dev_list Pointer to the device list struct.
+ * @param[in] dev Pointer to the controller device driver instance.
  * @param[in] pid Provisioned ID of device to be assigned address.
  * @param[in] must_match True if PID must match devices in
  *			 the device list. False otherwise.
@@ -1517,8 +1516,7 @@ struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct device *dev,
  *                 has an address assigned or invalid function
  *                 arguments.
  */
-int i3c_dev_list_daa_addr_helper(struct i3c_addr_slots *addr_slots,
-				 const struct i3c_dev_list *dev_list,
+int i3c_dev_list_daa_addr_helper(const struct device *dev,
 				 uint64_t pid, bool must_match,
 				 bool assigned_okay,
 				 struct i3c_device_desc **target,


### PR DESCRIPTION
There's been too many complaints and confusion about i3c attaching/reattaching/detaching. Rather make it more automatic with bus CCC calls.

This also gets rid of the auto attachment on startup, and now rather i3c devices are 'auto-ish' attached when they are assigned address, and detached when they are rstdaa

Also, add some precondition checks for `setnewda` and `setdasa`.