### PR TITLE
drivers: counter: fix spinlock leak in counter_renesas_ra_agt

### DIFF
--- a/drivers/counter/counter_renesas_ra_agt.c
+++ b/drivers/counter/counter_renesas_ra_agt.c
@@ -380,7 +380,8 @@ static int counter_renesas_ra_agt_cancel_alarm(const struct device *dev, uint8_t
 	int ret = 0;
 
 	if (data->agtcmai_irq == BSP_IRQ_DISABLED) {
-		return -ENOTSUP;
+		ret = -ENOTSUP;
+		goto out;
 	}
 
 	err = RP_AGT_EventSet(&data->agt_ctrl, TIMER_AGT_AGTCMAI, false);
@@ -395,7 +396,7 @@ static int counter_renesas_ra_agt_cancel_alarm(const struct device *dev, uint8_t
 	data->alarm_data = NULL;
 out:
 	counter_renesas_ra_agt_unlock(dev, key);
-	return 0;
+	return ret;
 }
 
 static uint32_t counter_renesas_ra_agt_get_guard_period(const struct device *dev, uint32_t flags)


### PR DESCRIPTION
In counter_renesas_ra_agt_cancel_alarm(), the early return when agtcmai_irq is BSP_IRQ_DISABLED skipped the spinlock release at the out: label. Convert to goto out pattern to match the style of the rest of the function. Also fix the out: label to return ret rather than 0, so FSP errors are correctly propagated.

[Clang Thread Safety Analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) yielded some cases where locks were incorrectly leaked.

See also #106847