### PR TITLE
drivers: ethernet: set DM9051 IMR before RCR

### DIFF
--- a/drivers/ethernet/eth_dm9051.c
+++ b/drivers/ethernet/eth_dm9051.c
@@ -406,14 +406,14 @@ static int eth_dm9051_hw_start(const struct device *dev, struct net_if *iface __
 		return ret;
 	}
 
-	/* Enable RX */
-	ret = eth_dm9051_spi_write_reg(dev, DM9051_RCR, rcr);
+	/* Enable interrupts */
+	ret = eth_dm9051_spi_write_reg(dev, DM9051_IMR, imr);
 	if (ret < 0) {
 		return ret;
 	}
 
-	/* Enable interrupts */
-	return eth_dm9051_spi_write_reg(dev, DM9051_IMR, imr);
+	/* Enable RX */
+	return eth_dm9051_spi_write_reg(dev, DM9051_RCR, rcr);
 }
 
 static int eth_dm9051_hw_stop(const struct device *dev, struct net_if *iface __unused)


### PR DESCRIPTION
## Summary

Set the Interrupt Mask Register (IMR) before the RX Control Register (RCR) when initializing the DM9051 ethernet controller in `eth_dm9051_hw_start()`.

## Problem

Previously, the code enabled RX (via RCR) before configuring the interrupt mask (via IMR). This could cause race conditions where the receiver is enabled before interrupt masking is properly configured.

According to the DM9051A datasheet, IMR bit 7 (PAR - Pointer Auto-Return Mode) affects memory read/write pointer behavior. Setting IMR first ensures the memory pointer configuration is ready before RX is enabled.

## Changes

- Reordered register writes: IMR is now configured before RCR
- Location: `drivers/ethernet/eth_dm9051.c` - `eth_dm9051_hw_start()` function

