### PR TITLE
manifest: tf-m: fix missing __assert_no_args in BL2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -399,7 +399,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: ee0acbb142d27ea3eb829d8da217dfd41af462be
+      revision: cefbc94de2560ea597da32b1768b26aeb6de5314
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Add stub implementation for __assert_no_args() in BL2.

Alternate solution to #110462

Tested with:
1. `west build -p -b mps2/an521/cpu0/ns -T buildsystem.debug.build tests/misc/test_build`
2. `west build -p -b frdm_mcxa577/mcxa577/ns -T buildsystem.debug.build tests/misc/test_build`

(1) doesn't use libc; (2) uses libc