### PR TITLE
modules: lvgl: derive 24-bit channel swap from panel format

### DIFF
--- a/boards/m5stack/m5stack_paper_color/Kconfig.defconfig
+++ b/boards/m5stack/m5stack_paper_color/Kconfig.defconfig
@@ -33,9 +33,6 @@ choice LV_COLOR_DEPTH
 	default LV_COLOR_DEPTH_24
 endchoice
 
-config LV_Z_COLOR_24_BGR_TO_RGB
-	default n
-
 config LV_Z_FULL_REFRESH
 	default y
 

--- a/boards/seeed/reterminal_e1002/Kconfig.defconfig
+++ b/boards/seeed/reterminal_e1002/Kconfig.defconfig
@@ -21,9 +21,6 @@ choice LV_COLOR_DEPTH
 	default LV_COLOR_DEPTH_24
 endchoice
 
-config LV_Z_COLOR_24_BGR_TO_RGB
-	default n
-
 config LV_Z_FULL_REFRESH
 	default y
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -160,6 +160,13 @@ Display
   on the SDL pseudo-device node using the PANEL_PIXEL_FORMAT_* macros from
   :zephyr_file:`include/zephyr/dt-bindings/display/panel.h`. (:github:`104099`)
 
+* The LVGL ``CONFIG_LV_Z_COLOR_24_BGR_TO_RGB`` Kconfig option has been removed. LVGL's RGB888 color
+  format stores bytes in memory as blue, green, red, which matches the in-memory layout of
+  :c:enumerator:`PIXEL_FORMAT_RGB_888`, so no channel swap is performed for displays reporting that
+  format. Displays whose framebuffer instead expects a red, green, blue byte order must now report
+  :c:enumerator:`PIXEL_FORMAT_BGR_888`, for which the LVGL glue performs the red/blue channel swap
+  automatically.
+
 DMA
 ===
 

--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -101,11 +101,6 @@ config LV_Z_COLOR_MONO_HW_INVERSION
 	bool "Hardware pixel inversion (disables software pixel inversion)."
 	depends on LV_COLOR_DEPTH_1
 
-config LV_Z_COLOR_24_BGR_TO_RGB
-	bool "Convert BGR888 to RGB888 color before flushing"
-	default y
-	depends on LV_COLOR_DEPTH_24
-
 config LV_Z_FLUSH_THREAD
 	bool "Flush LVGL frames in a separate thread"
 	help

--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -84,6 +84,7 @@ int set_lvgl_rendering_cb(lv_display_t *display)
 					display);
 		break;
 	case PIXEL_FORMAT_RGB_888:
+	case PIXEL_FORMAT_BGR_888:
 		lv_display_set_color_format(display, LV_COLOR_FORMAT_RGB888);
 		lv_display_set_flush_cb(display, lvgl_flush_cb_24bit);
 		lv_display_add_event_cb(display, lvgl_rounder_cb, LV_EVENT_INVALIDATE_AREA,

--- a/modules/lvgl/lvgl_display_24bit.c
+++ b/modules/lvgl/lvgl_display_24bit.c
@@ -13,6 +13,7 @@ void lvgl_flush_cb_24bit(lv_display_t *display, const lv_area_t *area, uint8_t *
 {
 	uint16_t w = area->x2 - area->x1 + 1;
 	uint16_t h = area->y2 - area->y1 + 1;
+	struct lvgl_disp_data *data = (struct lvgl_disp_data *)lv_display_get_user_data(display);
 	struct lvgl_display_flush flush;
 
 	flush.display = display;
@@ -24,8 +25,12 @@ void lvgl_flush_cb_24bit(lv_display_t *display, const lv_area_t *area, uint8_t *
 	flush.desc.height = h;
 	flush.buf = (void *)px_map;
 
-	if (IS_ENABLED(CONFIG_LV_Z_COLOR_24_BGR_TO_RGB)) {
-		/* LVGL assumes BGR byte ordering, convert to RGB */
+	/*
+	 * LVGL's RGB888 stores bytes in memory as B, G, R, which matches Zephyr's
+	 * PIXEL_FORMAT_RGB_888. For a PIXEL_FORMAT_BGR_888 panel (R, G, B in memory)
+	 * the red and blue channels have to be swapped before flushing.
+	 */
+	if (data->cap.current_pixel_format == PIXEL_FORMAT_BGR_888) {
 		for (size_t i = 0; i < flush.desc.buf_size; i += 3) {
 			uint8_t tmp = px_map[i];
 


### PR DESCRIPTION
LVGL RGB888 and PIXEL_FORMAT_RGB_888 share the same byte order, so the default-on LV_Z_COLOR_24_BGR_TO_RGB swap actually corrupted RGB_888 displays. Swap only when the driver reports PIXEL_FORMAT_BGR_888 and drop the Kconfig option.