### PR TITLE
stm32wba: Add BLE Basic Plus configuration support

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.stm32
+++ b/drivers/bluetooth/hci/Kconfig.stm32
@@ -16,12 +16,14 @@ config BT_STM32WBA_USE_TEMP_BASED_CALIB
 choice BT_STM32WBA_LIB_CONFIG
 	prompt "STM32WBA Bluetooth library configuration"
 	default BT_STM32WBA_FULL_LIB if \
-		BT_EXT_ADV || BT_PER_ADV || BT_PER_ADV_SYNC || BT_SCA_UPDATE || BT_DF_CTE_RX_AOA \
+		BT_PER_ADV || BT_PER_ADV_SYNC || BT_SCA_UPDATE || BT_DF_CTE_RX_AOA \
 		|| BT_CTLR_DF_ANT_SWITCH_RX || BT_CTLR_DF_ANT_SWITCH_TX || BT_DF_CTE_TX_AOD \
 		|| BT_PER_ADV_SYNC_TRANSFER_RECEIVER || BT_PER_ADV_SYNC_TRANSFER_SENDER \
 		|| BT_CTLR_SYNC_PERIODIC || BT_ISO_UNICAST || BT_ISO_BROADCASTER \
-		|| BT_ISO_SYNC_RECEIVER || BT_TRANSMIT_POWER_CONTROL || BT_SUBRATING \
-		|| BT_CTLR_ADV_PERIODIC_ADI_SUPPORT || BT_EXT_ADV_CODING_SELECTION
+		|| BT_ISO_SYNC_RECEIVER || BT_CTLR_ADV_PERIODIC_ADI_SUPPORT \
+		|| BT_EXT_ADV_CODING_SELECTION
+	default BT_STM32WBA_BASIC_PLUS_LIB if \
+		BT_EXT_ADV || BT_TRANSMIT_POWER_CONTROL || BT_SUBRATING
 	default BT_STM32WBA_BASIC_LIB
 	help
 	  Sets the library configuration according to the required Bluetooth features.
@@ -33,6 +35,15 @@ config BT_STM32WBA_BASIC_LIB
 	  Advertising, Scanning, Connection Peripheral and Central, Privacy,
 	  Channel Selection Algorithm #2, Data Length Extension, LE Encryption,
 	  Legacy Pairing, LE secure connections, LE 2Mbit PHY, LE Coded PHY.
+
+config BT_STM32WBA_BASIC_PLUS_LIB
+	bool "STM32WBA Bluetooth library basic plus configuration"
+	help
+	  Embed basic Plus Bluetooth features support in STM32WBA:
+	  Advertising, Scanning, Connection Peripheral and Central, Privacy,
+	  Channel Selection Algorithm #2, Data Length Extension, LE Encryption,
+	  Legacy Pairing, LE secure connections, LE 2Mbit PHY, LE Coded PHY,
+	  Extended Advertising, LE Power Control, Connection Subrating.
 
 config BT_STM32WBA_FULL_LIB
 	bool "STM32WBA Bluetooth library full configuration"

--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: ad6ac613bb4552d5a2849a10440004a17a606625
+      revision: 8b66f0b68f40686f117179e6976f16c8103fe17f
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Add new KConfig BT_STM32WBA_BASIC_PLUS_LIB specifying the configuration of the stm32wba ble library for bluetooth
basic plus features.
This KConfig is used in hal_stm32 and/or upper layer to select associated libraries for BLE only or BLE-802154 concurrent mode

FYI: @asm5878 , @erwango