### PR TITLE
tests: i2c: at24: exclude kv260_r5 platform

### DIFF
--- a/tests/drivers/i2c/i2c_at24/testcase.yaml
+++ b/tests/drivers/i2c/i2c_at24/testcase.yaml
@@ -6,6 +6,8 @@ common:
     - drivers
     - i2c
   filter: dt_compat_enabled("atmel,at24")
+  platform_exclude:
+    - kv260_r5/zynqmp_rpu
   harness: ztest
   harness_config:
     fixture: i2c_at24


### PR DESCRIPTION
- kv260_r5 has read-only AT24 EEPROMs which triggers a build-time assertion.
- Add platform_exclude to filter it at twister level instead of erroring.