### PR TITLE
sys: iterable_sections: add reverse iteration variants

### DIFF
--- a/include/zephyr/sys/iterable_sections.h
+++ b/include/zephyr/sys/iterable_sections.h
@@ -113,6 +113,26 @@ extern "C" {
 	     iterator++)
 
 /**
+ * @brief Iterate over a specified iterable section for a generic type, in
+ * reverse order.
+ *
+ * @details
+ * Reverse iterator for structure instances gathered by TYPE_SECTION_ITERABLE().
+ * Iteration runs from the last element down to the first. The linker must
+ * provide a _<SECNAME>_list_start symbol and a _<SECNAME>_list_end symbol to
+ * mark the start and the end of the list of struct objects to iterate over.
+ * This is normally done using ITERABLE_SECTION_ROM() or ITERABLE_SECTION_RAM()
+ * in the linker script.
+ */
+#define TYPE_SECTION_FOREACH_REVERSE(type, secname, iterator)			\
+	TYPE_SECTION_START_EXTERN(type, secname);				\
+	TYPE_SECTION_END_EXTERN(type, secname);					\
+	for (type *iterator = TYPE_SECTION_END(secname);			\
+	     (uintptr_t)iterator > (uintptr_t)TYPE_SECTION_START(secname) &&	\
+	     (iterator = (type *)((uintptr_t)iterator - sizeof(type)), true);	\
+	     )
+
+/**
  * @brief Get element from section for a generic type.
  *
  * @note There is no protection against reading beyond the section.
@@ -269,6 +289,35 @@ extern "C" {
  */
 #define STRUCT_SECTION_FOREACH(struct_type, iterator) \
 	STRUCT_SECTION_FOREACH_ALTERNATE(struct_type, struct_type, iterator)
+
+/**
+ * @brief Iterate over a specified iterable section (alternate), in reverse
+ * order.
+ *
+ * @details
+ * Reverse iterator for structure instances gathered by STRUCT_SECTION_ITERABLE().
+ * Iteration runs from the last element down to the first. The linker must
+ * provide a _<SECNAME>_list_start symbol and a _<SECNAME>_list_end symbol to
+ * mark the start and the end of the list of struct objects to iterate over.
+ * This is normally done using ITERABLE_SECTION_ROM() or ITERABLE_SECTION_RAM()
+ * in the linker script.
+ */
+#define STRUCT_SECTION_FOREACH_ALTERNATE_REVERSE(secname, struct_type, iterator) \
+	TYPE_SECTION_FOREACH_REVERSE(struct struct_type, secname, iterator)
+
+/**
+ * @brief Iterate over a specified iterable section, in reverse order.
+ *
+ * @details
+ * Reverse iterator for structure instances gathered by STRUCT_SECTION_ITERABLE().
+ * Iteration runs from the last element down to the first. The linker must
+ * provide a _<struct_type>_list_start symbol and a _<struct_type>_list_end
+ * symbol to mark the start and the end of the list of struct objects to
+ * iterate over. This is normally done using ITERABLE_SECTION_ROM() or
+ * ITERABLE_SECTION_RAM() in the linker script.
+ */
+#define STRUCT_SECTION_FOREACH_REVERSE(struct_type, iterator) \
+	STRUCT_SECTION_FOREACH_ALTERNATE_REVERSE(struct_type, struct_type, iterator)
 
 /**
  * @brief Get element from section.

--- a/subsys/sensing/sensor_mgmt.h
+++ b/subsys/sensing/sensor_mgmt.h
@@ -21,15 +21,8 @@ extern "C" {
 #define for_each_sensor(sensor)							\
 	STRUCT_SECTION_FOREACH(sensing_sensor, sensor)
 
-#define for_each_sensor_reverse(sensor)					\
-	STRUCT_SECTION_START_EXTERN(sensing_sensor);				\
-	STRUCT_SECTION_END_EXTERN(sensing_sensor);				\
-	for (struct sensing_sensor *sensor = STRUCT_SECTION_END(sensing_sensor)	\
-		- 1;								\
-	     ({ __ASSERT(sensor >= STRUCT_SECTION_START(sensing_sensor),	\
-		"unexpected list start location");				\
-		sensor >= STRUCT_SECTION_START(sensing_sensor); });		\
-	     sensor--)
+#define for_each_sensor_reverse(sensor)						\
+	STRUCT_SECTION_FOREACH_REVERSE(sensing_sensor, sensor)
 
 
 #define for_each_client_conn(sensor, client)				\

--- a/tests/misc/iterable_sections/src/main.c
+++ b/tests/misc/iterable_sections/src/main.c
@@ -28,6 +28,7 @@ STRUCT_SECTION_ITERABLE(test_ram, ram4) = {0x04};
 STRUCT_SECTION_ITERABLE(test_ram, ram1) = {0x01};
 
 #define RAM_EXPECT 0x01020304
+#define RAM_EXPECT_REVERSE 0x04030201
 
 /* iterable section items can also be static */
 static const STRUCT_SECTION_ITERABLE_ALTERNATE(test_ram2, test_ram, ram5) = {RAM_EXPECT};
@@ -45,6 +46,7 @@ const STRUCT_SECTION_ITERABLE(test_ram_numeric, ramn_99999) = {0x04};
 const STRUCT_SECTION_ITERABLE(test_ram_numeric, ramn_11) = {0x03};
 
 #define NAMED_ALT_EXPECT 0x4273
+#define NAMED_ALT_EXPECT_REVERSE 0x7342
 
 /* alternate naming */
 const STRUCT_SECTION_ITERABLE_NAMED_ALTERNATE(test_ram_named, ramn_alt, R, ramn_42) = {0x42};
@@ -102,6 +104,47 @@ ZTEST(iterable_sections, test_ram)
 	}
 
 	zassert_equal(out, NAMED_ALT_EXPECT, "Check value incorrect (got: 0x%x)", out);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_REVERSE(test_ram, t)
+	{
+		out = (out << 8) | (t->i & ~CHECK_BIT);
+	}
+
+	zassert_equal(out, RAM_EXPECT_REVERSE, "Reverse check value incorrect (got: 0x%08x)", out);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_ALTERNATE_REVERSE(test_ram2, test_ram, t)
+	{
+		out = (out << 8) | t->i;
+	}
+
+	zassert_equal(out, RAM_EXPECT, "Reverse check value incorrect (got: 0x%08x)", out);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_REVERSE(test_ram_named, t)
+	{
+		out = (out << 8) | t->i;
+	}
+
+	zassert_equal(out, RAM_EXPECT_REVERSE, "Reverse check value incorrect (got: 0x%x)", out);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_REVERSE(test_ram_numeric, t)
+	{
+		out = (out << 8) | t->i;
+	}
+
+	zassert_equal(out, RAM_EXPECT_REVERSE, "Reverse check value incorrect (got: 0x%x)", out);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_ALTERNATE_REVERSE(ramn_alt, test_ram_named, t)
+	{
+		out = (out << 8) | t->i;
+	}
+
+	zassert_equal(out, NAMED_ALT_EXPECT_REVERSE, "Reverse check value incorrect (got: 0x%x)",
+		      out);
 }
 
 struct test_rom {
@@ -123,6 +166,7 @@ const STRUCT_SECTION_ITERABLE(test_rom, rom4) = {0x40};
 const STRUCT_SECTION_ITERABLE(test_rom, rom2) = {0x20};
 
 #define ROM_EXPECT 0x10203040
+#define ROM_EXPECT_REVERSE 0x40302010
 
 /* iterable section items can also be static */
 static const STRUCT_SECTION_ITERABLE_ALTERNATE(test_rom2, test_rom, rom5) = {ROM_EXPECT};
@@ -185,6 +229,47 @@ ZTEST(iterable_sections, test_rom)
 	}
 
 	zassert_equal(out, NAMED_ALT_EXPECT, "Check value incorrect (got: 0x%x)", out);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_REVERSE(test_rom, t)
+	{
+		out = (out << 8) | t->i;
+	}
+
+	zassert_equal(out, ROM_EXPECT_REVERSE, "Reverse check value incorrect (got: 0x%x)", out);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_ALTERNATE_REVERSE(test_rom2, test_rom, t)
+	{
+		out = (out << 8) | t->i;
+	}
+
+	zassert_equal(out, ROM_EXPECT, "Reverse check value incorrect (got: 0x%x)", out);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_REVERSE(test_rom_named, t)
+	{
+		out = (out << 8) | t->i;
+	}
+
+	zassert_equal(out, ROM_EXPECT_REVERSE, "Reverse check value incorrect (got: 0x%x)", out);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_REVERSE(test_rom_numeric, t)
+	{
+		out = (out << 8) | t->i;
+	}
+
+	zassert_equal(out, ROM_EXPECT_REVERSE, "Reverse check value incorrect (got: 0x%x)", out);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_ALTERNATE_REVERSE(romn_alt, test_rom_named, t)
+	{
+		out = (out << 8) | t->i;
+	}
+
+	zassert_equal(out, NAMED_ALT_EXPECT_REVERSE, "Reverse check value incorrect (got: 0x%x)",
+		      out);
 }
 
 ZTEST_SUITE(iterable_sections, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Add `TYPE_SECTION_FOREACH_REVERSE`, `STRUCT_SECTION_FOREACH_REVERSE` and `STRUCT_SECTION_FOREACH_ALTERNATE_REVERSE` for iterating an iterable section from last element to first.