### PR TITLE
interrupt_controller: wch: add MIE-based nesting and priority support

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -716,6 +716,20 @@ is_interrupt:
 
 on_irq_stack:
 
+#ifdef CONFIG_WCH_PFIC_NESTING
+	/*
+	 * Context is fully saved and the interrupt stack is active.
+	 * Re-enable MIE so a higher-priority interrupt from the PFIC
+	 * can preempt this ISR.  MIE will be cleared automatically by
+	 * the hardware on the next trap entry.
+	 *
+	 * PFIC priority values written via WCH_PFIC_PRIORITY() in DTS
+	 * control which IRQ wins arbitration:
+	 *   bit[7]=0 (group 0) can preempt bit[7]=1 (group 1).
+	 */
+	csrs RV_STATUS, STATUS_IE
+#endif /* CONFIG_WCH_PFIC_NESTING */
+
 #ifdef CONFIG_RISCV_SOC_HAS_CUSTOM_IRQ_HANDLING
 	call __soc_handle_all_irqs
 #else
@@ -764,6 +778,16 @@ on_irq_stack:
 #endif
 
 #endif
+
+#ifdef CONFIG_WCH_PFIC_NESTING
+	/*
+	 * Disable MIE before restoring the exception frame.
+	 * We must not be preempted during the register-restore
+	 * sequence, as the restore is not atomic and a nested
+	 * interrupt at this point would corrupt the saved state.
+	 */
+	csrc RV_STATUS, STATUS_IE
+#endif /* CONFIG_WCH_PFIC_NESTING */
 
 irq_done:
 	/* Decrement _current_cpu->nested */

--- a/drivers/interrupt_controller/Kconfig.wch_pfic
+++ b/drivers/interrupt_controller/Kconfig.wch_pfic
@@ -6,4 +6,38 @@ config WCH_PFIC
 	default y
 	depends on DT_HAS_WCH_PFIC_ENABLED
 	help
-	  Interrupt controller for WCH PFIC.
+	  Driver for the WCH PFIC found on QingKe RISC-V cores.
+
+if WCH_PFIC
+
+config WCH_PFIC_HPE
+	bool "Enable QingKe Hardware Prologue/Epilogue (HPE)"
+	default n
+	help
+	  Enable the Hardware Prologue/Epilogue (HPE) feature of the
+	  QingKe PFIC.
+
+	  When enabled, the hardware automatically saves mepc, mstatus,
+	  ra, t0, and a0-a7 to a dedicated hardware FIFO on ISR entry
+	  and restores them on mret.  This reduces ISR latency on
+	  compatible cores.
+
+	  Not yet supported.  Enabling this option requires additional
+	  changes to _isr_wrapper (arch/riscv/core/isr.S).
+
+config WCH_PFIC_NESTING
+	bool "Enable QingKe interrupt preemption nesting"
+	default y
+	help
+	  Enable MIE-based interrupt preemption nesting for QingKe PFIC.
+
+	  When enabled, _isr_wrapper re-enables mstatus.MIE after the
+	  full context save and interrupt-stack switch, allowing a
+	  higher-priority interrupt to preempt the current ISR.  MIE
+	  is cleared before context restore.
+
+	  Priority values are configured via the WCH_PFIC_PRIORITY
+	  macro in Device Tree and written to PFIC->IPRIOR[] at init
+	  time.
+
+endif # WCH_PFIC

--- a/drivers/interrupt_controller/intc_wch_pfic.c
+++ b/drivers/interrupt_controller/intc_wch_pfic.c
@@ -14,8 +14,30 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 
+/* PFIC SCTLR bits */
 #define SEVONPEND BIT(4)
 #define WFITOWFE  BIT(3)
+
+/*
+ * INESTCTRL (CSR 0x804) bit definitions.
+ *
+ * This driver currently writes 0x0 to INESTCTRL (neither HPE nor hardware
+ * nesting are enabled).  The bits are defined here for reference and for
+ * future HPE support.
+ *
+ *   bit 0 (HWSTKEN)  - Hardware stack (HPE).  When set, the PFIC auto-saves
+ *                       mepc, mstatus, ra, t0, and a0-a7 to a hardware FIFO
+ *                       on ISR entry and restores them on mret.
+ *   bit 1 (INESTEN)  - Hardware interrupt nesting.  When set, the PFIC can
+ *                       preempt ISRs at hardware level without consulting
+ *                       mstatus.MIE.  Not used; MIE-based nesting instead.
+ *   bit 4 (HWSTKOV)  - Read-only hardware stack overflow flag.
+ */
+#define INESTCTRL_HWSTKEN  BIT(0)
+#define INESTCTRL_INESTEN  BIT(1)
+#define INESTCTRL_HWSTKOV  BIT(4)
+
+#define CSR_INESTCTRL  0x804
 
 void arch_irq_enable(unsigned int irq)
 {
@@ -32,12 +54,67 @@ int arch_irq_is_enabled(unsigned int irq)
 	return ((PFIC->ISR[irq >> 5] & BIT(irq & 0x1F)) != 0);
 }
 
+/**
+ * @brief Write an interrupt priority to the PFIC IPRIOR register.
+ *
+ * Called indirectly by IRQ_CONNECT() through the generated interrupt
+ * controller initialisation code.  The @p prio value is written to
+ * PFIC->IPRIOR[irq] as-is; it should use the WCH_PFIC_PRIORITY()
+ * macro from dt-bindings/wch-pfic.h:
+ *
+ *   bit[7]     = preemption group  (0 = higher priority, can preempt group 1)
+ *   bits[6:5]  = sub-priority      (0 = highest, 3 = lowest within the group)
+ *   bits[4:0]  = reserved
+ *
+ * When CONFIG_WCH_PFIC_NESTING=y, the PFIC uses these priority values
+ * to arbitrate between pending interrupts when MIE is re-enabled in
+ * _isr_wrapper.
+ */
+void z_riscv_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+{
+	ARG_UNUSED(flags);
+
+	if (irq < 256) {
+		PFIC->IPRIOR[irq] = (uint8_t)(prio & 0xFF);
+	}
+}
+
+/**
+ * @brief Initialise the PFIC at PRE_KERNEL_1 priority.
+ *
+ * Configures the WFI wake-up behaviour (SEVONPEND so any event including
+ * interrupts wakes the core from WFI) and leaves INESTCTRL at its reset
+ * value (0x0 -- HPE and hardware nesting both disabled).
+ *
+ * HPE and INESTEN are controlled by Kconfig options CONFIG_WCH_PFIC_HPE
+ * and CONFIG_WCH_PFIC_NESTING respectively.  Currently both are effectively
+ * unused: HPE is experimental and INESTEN is superseded by the MIE-based
+ * nesting mechanism in _isr_wrapper.  The #ifdef blocks are kept so the
+ * options can be tested without code changes.
+ */
 static int pfic_init(void)
 {
 	/* `wfi` is called with interrupts disabled. Configure the PFIC to wake up on any event,
 	 * including any interrupt.
 	 */
+	uint32_t inest_val;
+
 	PFIC->SCTLR = SEVONPEND | WFITOWFE;
+
+	inest_val = 0;
+
+#ifdef CONFIG_WCH_PFIC_HPE
+	inest_val |= INESTCTRL_HWSTKEN;
+#endif
+
+#ifdef CONFIG_WCH_PFIC_NESTING
+	inest_val |= INESTCTRL_INESTEN;
+#endif
+
+	if (inest_val != 0) {
+		__asm__ volatile ("csrw %0, %1" :: "i"(CSR_INESTCTRL), "r"(inest_val));
+	}
+
 	return 0;
 }
 

--- a/drivers/timer/wch_systick_ch32v00x.c
+++ b/drivers/timer/wch_systick_ch32v00x.c
@@ -50,7 +50,8 @@ uint32_t sys_clock_elapsed(void)
 
 static int ch32v00x_systick_init(void)
 {
-	IRQ_CONNECT(DT_INST_IRQN(0), 0, ch32v00x_systick_irq, NULL, 0);
+	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
+		    ch32v00x_systick_irq, NULL, 0);
 
 	SYSTICK->SR = 0;
 	SYSTICK->CMP = CYCLES_PER_TICK;

--- a/dts/bindings/interrupt-controller/wch,pfic.yaml
+++ b/dts/bindings/interrupt-controller/wch,pfic.yaml
@@ -12,7 +12,8 @@ properties:
     required: true
 
   "#interrupt-cells":
-    const: 1
+    const: 2
 
 interrupt-cells:
   - irq
+  - priority

--- a/dts/riscv/wch/ch32v0/ch32v003.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v003.dtsi
@@ -79,7 +79,7 @@
 			reg = <0x40010400 16>;
 			interrupt-parent = <&pfic>;
 			num-lines = <8>;
-			interrupts = <20>;
+			interrupts = <20 WCH_PFIC_PRIORITY(1, 3)>;
 			line-ranges = <0 8>;
 			interrupt-names = "line0-7";
 			status = "disabled";
@@ -129,7 +129,7 @@
 			reg = <0x40005400 0x400>;
 			clocks = <&rcc CH32V00X_CLOCK_I2C1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <30>, <31>;
+			interrupts = <30 WCH_PFIC_PRIORITY(1, 3)>, <31 WCH_PFIC_PRIORITY(1, 3)>;
 		};
 
 		usart1: uart@40013800 {
@@ -137,7 +137,7 @@
 			reg = <0x40013800 0x10>;
 			clocks = <&rcc CH32V00X_CLOCK_USART1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <32>;
+			interrupts = <32 WCH_PFIC_PRIORITY(1, 3)>;
 		};
 
 		rcc: rcc@40021000 {
@@ -153,7 +153,13 @@
 			clocks = <&rcc CH32V00X_CLOCK_DMA1>;
 			#dma-cells = <1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <22>, <23>, <24>, <25>, <26>, <27>, <28>;
+			interrupts = <22 WCH_PFIC_PRIORITY(1, 3)>,
+				     <23 WCH_PFIC_PRIORITY(1, 3)>,
+				     <24 WCH_PFIC_PRIORITY(1, 3)>,
+				     <25 WCH_PFIC_PRIORITY(1, 3)>,
+				     <26 WCH_PFIC_PRIORITY(1, 3)>,
+				     <27 WCH_PFIC_PRIORITY(1, 3)>,
+				     <28 WCH_PFIC_PRIORITY(1, 3)>;
 			dma-channels = <7>;
 		};
 
@@ -164,7 +170,7 @@
 			channels = <4>;
 			clocks = <&rcc CH32V00X_CLOCK_TIM2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <38>;
+			interrupts = <38 WCH_PFIC_PRIORITY(1, 3)>;
 			interrupt-names = "global";
 			status = "disabled";
 
@@ -181,7 +187,7 @@
 			reg = <0x40013000 0x24>;
 			clocks = <&rcc CH32V00X_CLOCK_SPI1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <33>;
+			interrupts = <33 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -192,7 +198,7 @@
 			reg = <0x40012400 16>;
 			clocks = <&rcc CH32V00X_CLOCK_ADC1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <29>;
+			interrupts = <29 WCH_PFIC_PRIORITY(1, 3)>;
 			#io-channel-cells = <1>;
 			status = "disabled";
 		};

--- a/dts/riscv/wch/ch32v0/ch32v006.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v006.dtsi
@@ -79,7 +79,7 @@
 			reg = <0x40010400 16>;
 			interrupt-parent = <&pfic>;
 			num-lines = <8>;
-			interrupts = <20>;
+			interrupts = <20 WCH_PFIC_PRIORITY(1, 3)>;
 			line-ranges = <0 8>;
 			interrupt-names = "line0-7";
 			status = "disabled";
@@ -137,7 +137,7 @@
 			reg = <0x40005400 0x400>;
 			clocks = <&rcc CH32V00X_CLOCK_I2C1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <30>, <31>;
+			interrupts = <30 WCH_PFIC_PRIORITY(1, 3)>, <31 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -146,7 +146,7 @@
 			reg = <0x40013800 0x10>;
 			clocks = <&rcc CH32V00X_CLOCK_USART1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <32>;
+			interrupts = <32 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -155,7 +155,7 @@
 			reg = <0x40004400 0x10>;
 			clocks = <&rcc CH32V00X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <39>;
+			interrupts = <39 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -172,7 +172,13 @@
 			clocks = <&rcc CH32V00X_CLOCK_DMA1>;
 			#dma-cells = <1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <22>, <23>, <24>, <25>, <26>, <27>, <28>;
+			interrupts = <22 WCH_PFIC_PRIORITY(1, 3)>,
+				     <23 WCH_PFIC_PRIORITY(1, 3)>,
+				     <24 WCH_PFIC_PRIORITY(1, 3)>,
+				     <25 WCH_PFIC_PRIORITY(1, 3)>,
+				     <26 WCH_PFIC_PRIORITY(1, 3)>,
+				     <27 WCH_PFIC_PRIORITY(1, 3)>,
+				     <28 WCH_PFIC_PRIORITY(1, 3)>;
 			dma-channels = <7>;
 		};
 
@@ -183,7 +189,7 @@
 			channels = <4>;
 			clocks = <&rcc CH32V00X_CLOCK_TIM2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <38>;
+			interrupts = <38 WCH_PFIC_PRIORITY(1, 3)>;
 			interrupt-names = "global";
 			status = "disabled";
 
@@ -200,7 +206,7 @@
 			reg = <0x40013000 0x24>;
 			clocks = <&rcc CH32V00X_CLOCK_SPI1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <33>;
+			interrupts = <33 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/wch/ch32v203/ch32v203c6t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203c6t.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v203/ch32v203c8t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203c8t.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -22,7 +22,7 @@
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
 			interrupt-parent = <&pfic>;
-			interrupts = <55>;
+			interrupts = <55 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -31,7 +31,7 @@
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
 			interrupt-parent = <&pfic>;
-			interrupts = <68>;
+			interrupts = <68 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -40,7 +40,7 @@
 			reg = <0x40003800 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <52>;
+			interrupts = <52 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -51,7 +51,7 @@
 			reg = <0x40005800 0x400>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <49>, <50>;
+			interrupts = <49 WCH_PFIC_PRIORITY(1, 3)>, <50 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/wch/ch32v203/ch32v203f8p.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203f8p.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v203/ch32v203f8u.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203f8u.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v203/ch32v203g6u.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203g6u.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v203/ch32v203g8r.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203g8r.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v203/ch32v203k6t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203k6t.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v203/ch32v203k8t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203k8t.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v203/ch32v203rbt.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203rbt.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -22,7 +22,7 @@
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
 			interrupt-parent = <&pfic>;
-			interrupts = <55>;
+			interrupts = <55 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -31,7 +31,7 @@
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
 			interrupt-parent = <&pfic>;
-			interrupts = <68>;
+			interrupts = <68 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -40,7 +40,7 @@
 			reg = <0x40003800 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <52>;
+			interrupts = <52 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -51,7 +51,8 @@
 			reg = <0x40005800 0x400>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <49>, <50>;
+			interrupts = <49 WCH_PFIC_PRIORITY(1, 3)>,
+						 <50 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -14,7 +14,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v208/ch32v208cbu.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208cbu.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
 			interrupt-parent = <&pfic>;
-			interrupts = <55>;
+			interrupts = <55 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -22,7 +22,7 @@
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
 			interrupt-parent = <&pfic>;
-			interrupts = <68>;
+			interrupts = <68 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -31,7 +31,7 @@
 			reg = <0x40003800 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <52>;
+			interrupts = <52 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -42,7 +42,8 @@
 			reg = <0x40005800 0x400>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <49>, <50>;
+			interrupts = <49 WCH_PFIC_PRIORITY(1, 3)>,
+				     <50 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/wch/ch32v208/ch32v208rbt.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208rbt.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
 			interrupt-parent = <&pfic>;
-			interrupts = <55>;
+			interrupts = <55 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -22,7 +22,7 @@
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
 			interrupt-parent = <&pfic>;
-			interrupts = <68>;
+			interrupts = <68 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -31,7 +31,7 @@
 			reg = <0x40003800 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <52>;
+			interrupts = <52 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -42,7 +42,7 @@
 			reg = <0x40005800 0x400>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <49>, <50>;
+			interrupts = <49 WCH_PFIC_PRIORITY(1, 3)>, <50 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/wch/ch32v208/ch32v208wbu.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208wbu.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
 			interrupt-parent = <&pfic>;
-			interrupts = <55>;
+			interrupts = <55 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -22,7 +22,7 @@
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
 			interrupt-parent = <&pfic>;
-			interrupts = <68>;
+			interrupts = <68 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -31,7 +31,7 @@
 			reg = <0x40003800 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <52>;
+			interrupts = <52 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -42,7 +42,8 @@
 			reg = <0x40005800 0x400>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <49>, <50>;
+			interrupts = <49 WCH_PFIC_PRIORITY(1, 3)>,
+				     <50 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -25,7 +25,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -34,7 +34,7 @@
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
 			interrupt-parent = <&pfic>;
-			interrupts = <55>;
+			interrupts = <55 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -43,7 +43,7 @@
 			reg = <0x40003800 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <52>;
+			interrupts = <52 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -54,7 +54,8 @@
 			reg = <0x40005800 0x400>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <49>, <50>;
+			interrupts = <49 WCH_PFIC_PRIORITY(1, 3)>,
+						 <50 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/wch/ch32v303/ch32v303rct.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303rct.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
 			interrupt-parent = <&pfic>;
-			interrupts = <68>;
+			interrupts = <68 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -22,7 +22,7 @@
 			reg = <0x40005000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
 			interrupt-parent = <&pfic>;
-			interrupts = <69>;
+			interrupts = <69 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -31,7 +31,7 @@
 			reg = <0x40001800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
 			interrupt-parent = <&pfic>;
-			interrupts = <87>;
+			interrupts = <87 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -40,7 +40,7 @@
 			reg = <0x40001c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
 			interrupt-parent = <&pfic>;
-			interrupts = <88>;
+			interrupts = <88 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -49,7 +49,7 @@
 			reg = <0x40002000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
 			interrupt-parent = <&pfic>;
-			interrupts = <89>;
+			interrupts = <89 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -58,7 +58,7 @@
 			reg = <0x4003c00 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI3>;
 			interrupt-parent = <&pfic>;
-			interrupts = <67>;
+			interrupts = <67 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/wch/ch32v303/ch32v303vct.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303vct.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
 			interrupt-parent = <&pfic>;
-			interrupts = <68>;
+			interrupts = <68 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -22,7 +22,7 @@
 			reg = <0x40005000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
 			interrupt-parent = <&pfic>;
-			interrupts = <69>;
+			interrupts = <69 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -31,7 +31,7 @@
 			reg = <0x40001800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
 			interrupt-parent = <&pfic>;
-			interrupts = <87>;
+			interrupts = <87 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -40,7 +40,7 @@
 			reg = <0x40001c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
 			interrupt-parent = <&pfic>;
-			interrupts = <88>;
+			interrupts = <88 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -49,7 +49,7 @@
 			reg = <0x40002000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
 			interrupt-parent = <&pfic>;
-			interrupts = <89>;
+			interrupts = <89 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -58,7 +58,7 @@
 			reg = <0x4003c00 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI3>;
 			interrupt-parent = <&pfic>;
-			interrupts = <67>;
+			interrupts = <67 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/wch/ch32v307/ch32v307.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307.dtsi
@@ -20,7 +20,7 @@
 			mac: ethernet {
 				compatible = "wch,ethernet";
 				interrupt-parent = <&pfic>;
-				interrupts = <77>, <78>;
+				interrupts = <77 WCH_PFIC_PRIORITY(1, 3)>, <78 WCH_PFIC_PRIORITY(1, 3)>;
 				internal-phy-pllmul = "15";
 				internal-phy-prediv = "2";
 				status = "disabled";
@@ -50,7 +50,7 @@
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <54>;
+			interrupts = <54 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -59,7 +59,7 @@
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
 			interrupt-parent = <&pfic>;
-			interrupts = <55>;
+			interrupts = <55 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -68,7 +68,7 @@
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
 			interrupt-parent = <&pfic>;
-			interrupts = <68>;
+			interrupts = <68 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -77,7 +77,7 @@
 			reg = <0x40005000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
 			interrupt-parent = <&pfic>;
-			interrupts = <69>;
+			interrupts = <69 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -86,7 +86,7 @@
 			reg = <0x40001800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
 			interrupt-parent = <&pfic>;
-			interrupts = <87>;
+			interrupts = <87 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -95,7 +95,7 @@
 			reg = <0x40001c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
 			interrupt-parent = <&pfic>;
-			interrupts = <88>;
+			interrupts = <88 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -104,7 +104,7 @@
 			reg = <0x40002000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
 			interrupt-parent = <&pfic>;
-			interrupts = <89>;
+			interrupts = <89 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -113,7 +113,7 @@
 			reg = <0x40003800 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <52>;
+			interrupts = <52 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -124,7 +124,7 @@
 			reg = <0x4003c00 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI3>;
 			interrupt-parent = <&pfic>;
-			interrupts = <67>;
+			interrupts = <67 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -135,7 +135,8 @@
 			reg = <0x40005800 0x400>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
 			interrupt-parent = <&pfic>;
-			interrupts = <49>, <50>;
+			interrupts = <49 WCH_PFIC_PRIORITY(1, 3)>,
+						 <50 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
+++ b/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
@@ -7,6 +7,7 @@
 #include <freq.h>
 #include <mem.h>
 
+#include <zephyr/dt-bindings/interrupt-controller/wch-pfic.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/ch32v20x_30x-clocks.h>
@@ -88,7 +89,13 @@
 			num-lines = <16>;
 			line-ranges = <0 1>, <1 1>, <2 1>, <3 1>, <4 1>,
 				      <5 5>, <10 6>;
-			interrupts = <22 23 24 25 26 39 56>;
+			interrupts = <22 WCH_PFIC_PRIORITY(1, 3)>,
+				     <23 WCH_PFIC_PRIORITY(1, 3)>,
+				     <24 WCH_PFIC_PRIORITY(1, 3)>,
+				     <25 WCH_PFIC_PRIORITY(1, 3)>,
+				     <26 WCH_PFIC_PRIORITY(1, 3)>,
+				     <39 WCH_PFIC_PRIORITY(1, 3)>,
+				     <56 WCH_PFIC_PRIORITY(1, 3)>;
 			interrupt-names = "line0", "line1", "line2", "line3",
 					  "line4", "line5-9", "line10-15";
 			status = "disabled";
@@ -143,7 +150,7 @@
 			reg = <0x40013800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <53>;
+			interrupts = <53 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 		};
 
@@ -152,7 +159,7 @@
 			reg = <0x40013000 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <51>;
+			interrupts = <51 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -163,7 +170,8 @@
 			reg = <0x40005400 0x400>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <47>, <48>;
+			interrupts = <47 WCH_PFIC_PRIORITY(1, 3)>,
+				     <48 WCH_PFIC_PRIORITY(1, 3)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -189,7 +197,13 @@
 			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA1>;
 			#dma-cells = <1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <27>, <28>, <29>, <30>, <31>, <32>, <33>;
+			interrupts = <27 WCH_PFIC_PRIORITY(1, 3)>,
+				     <28 WCH_PFIC_PRIORITY(1, 3)>,
+				     <29 WCH_PFIC_PRIORITY(1, 3)>,
+				     <30 WCH_PFIC_PRIORITY(1, 3)>,
+				     <31 WCH_PFIC_PRIORITY(1, 3)>,
+				     <32 WCH_PFIC_PRIORITY(1, 3)>,
+				     <33 WCH_PFIC_PRIORITY(1, 3)>;
 			dma-channels = <7>;
 		};
 
@@ -199,8 +213,17 @@
 			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA2>;
 			#dma-cells = <1>;
 			interrupt-parent = <&pfic>;
-			interrupts = <72>, <73>, <74>, <75>, <76>, <98>, <99>, <100>,
-				     <101>, <102>, <103>;
+			interrupts = <72 WCH_PFIC_PRIORITY(1, 3)>,
+				     <73 WCH_PFIC_PRIORITY(1, 3)>,
+				     <74 WCH_PFIC_PRIORITY(1, 3)>,
+				     <75 WCH_PFIC_PRIORITY(1, 3)>,
+				     <76 WCH_PFIC_PRIORITY(1, 3)>,
+				     <98 WCH_PFIC_PRIORITY(1, 3)>,
+				     <99 WCH_PFIC_PRIORITY(1, 3)>,
+				     <100 WCH_PFIC_PRIORITY(1, 3)>,
+				     <101 WCH_PFIC_PRIORITY(1, 3)>,
+				     <102 WCH_PFIC_PRIORITY(1, 3)>,
+				     <103 WCH_PFIC_PRIORITY(1, 3)>;
 			dma-channels = <11>;
 		};
 	};

--- a/dts/riscv/wch/qingke-v2a.dtsi
+++ b/dts/riscv/wch/qingke-v2a.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/interrupt-controller/wch-pfic.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -30,7 +32,7 @@
 		pfic: interrupt-controller@e000e000 {
 			compatible = "wch,pfic";
 			#address-cells = <0>;
-			#interrupt-cells = <1>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			reg = <0xe000e000 0x10>;
 			status = "okay";
@@ -41,7 +43,7 @@
 			reg = <0xe000f000 0x10>;
 			status = "okay";
 			interrupt-parent = <&pfic>;
-			interrupts = <12>;
+			interrupts = <12 WCH_PFIC_PRIORITY(1, 3)>;
 		};
 	};
 };

--- a/dts/riscv/wch/qingke-v2c.dtsi
+++ b/dts/riscv/wch/qingke-v2c.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/interrupt-controller/wch-pfic.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -30,7 +32,7 @@
 		pfic: interrupt-controller@e000e000 {
 			compatible = "wch,pfic";
 			#address-cells = <0>;
-			#interrupt-cells = <1>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			reg = <0xe000e000 0x10>;
 			status = "okay";
@@ -41,7 +43,7 @@
 			reg = <0xe000f000 0x10>;
 			status = "okay";
 			interrupt-parent = <&pfic>;
-			interrupts = <12>;
+			interrupts = <12 WCH_PFIC_PRIORITY(1, 3)>;
 		};
 	};
 };

--- a/dts/riscv/wch/qingke-v4b.dtsi
+++ b/dts/riscv/wch/qingke-v4b.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/interrupt-controller/wch-pfic.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -39,7 +41,7 @@
 		pfic: interrupt-controller@e000e000 {
 			compatible = "wch,pfic";
 			#address-cells = <0>;
-			#interrupt-cells = <1>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			reg = <0xe000e000 0x10>;
 			status = "okay";
@@ -50,7 +52,7 @@
 			reg = <0xe000f000 0x10>;
 			status = "okay";
 			interrupt-parent = <&pfic>;
-			interrupts = <12>;
+			interrupts = <12 WCH_PFIC_PRIORITY(1, 3)>;
 		};
 	};
 };

--- a/dts/riscv/wch/qingke-v4c.dtsi
+++ b/dts/riscv/wch/qingke-v4c.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/interrupt-controller/wch-pfic.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -39,7 +41,7 @@
 		pfic: interrupt-controller@e000e000 {
 			compatible = "wch,pfic";
 			#address-cells = <0>;
-			#interrupt-cells = <1>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			reg = <0xe000e000 0x10>;
 			status = "okay";
@@ -50,7 +52,7 @@
 			reg = <0xe000f000 0x10>;
 			status = "okay";
 			interrupt-parent = <&pfic>;
-			interrupts = <12>;
+			interrupts = <12 WCH_PFIC_PRIORITY(1, 3)>;
 		};
 	};
 };

--- a/dts/riscv/wch/qingke-v4f.dtsi
+++ b/dts/riscv/wch/qingke-v4f.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/interrupt-controller/wch-pfic.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -39,7 +41,7 @@
 		pfic: interrupt-controller@e000e000 {
 			compatible = "wch,pfic";
 			#address-cells = <0>;
-			#interrupt-cells = <1>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			reg = <0xe000e000 0x10>;
 			status = "okay";
@@ -50,7 +52,7 @@
 			reg = <0xe000f000 0x10>;
 			status = "okay";
 			interrupt-parent = <&pfic>;
-			interrupts = <12>;
+			interrupts = <12 WCH_PFIC_PRIORITY(1, 3)>;
 		};
 	};
 };

--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -59,13 +59,14 @@ extern void arch_irq_disable(unsigned int irq);
 extern int arch_irq_is_enabled(unsigned int irq);
 
 #if defined(CONFIG_RISCV_HAS_PLIC) || defined(CONFIG_RISCV_HAS_CLIC) ||                            \
-	defined(CONFIG_RISCV_HAS_AIA)
+	defined(CONFIG_RISCV_HAS_AIA) || defined(CONFIG_WCH_PFIC)
 extern void z_riscv_irq_priority_set(unsigned int irq,
 				     unsigned int prio,
 				     uint32_t flags);
 #else
 #define z_riscv_irq_priority_set(i, p, f) /* Nothing */
-#endif /* CONFIG_RISCV_HAS_PLIC || CONFIG_RISCV_HAS_CLIC */
+#endif /* CONFIG_RISCV_HAS_PLIC || CONFIG_RISCV_HAS_CLIC ||
+	* CONFIG_RISCV_HAS_AIA || CONFIG_WCH_PFIC */
 
 #ifdef CONFIG_RISCV_HAS_CLIC
 extern void z_riscv_irq_vector_set(unsigned int irq);

--- a/include/zephyr/dt-bindings/interrupt-controller/wch-pfic.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/wch-pfic.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Colt Ma
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief WCH PFIC interrupt priority encoding macros for Device Tree.
+ *
+ * QingKe PFIC (Programmable Fast Interrupt Controller) supports two
+ * priority grouping modes controlled by the INESTCTRL (CSR 0x804)
+ * hardware register.
+ *
+ * When interrupt nesting is enabled (INESTCTRL bit1 = 1):
+ *   IPRIOR[7]   = Preemption group  (0 or 1)
+ *   IPRIOR[6:5] = Sub-priority       (0..3)
+ *   IPRIOR[4:0] = Reserved
+ *
+ * When interrupt nesting is disabled (INESTCTRL bit1 = 0):
+ *   IPRIOR[7:5] = Sub-priority       (0..7)
+ *   IPRIOR[4:0] = Reserved
+ *
+ * The WCH_PFIC_PRIORITY() macro assumes nesting is enabled (the
+ * default configuration for Zephyr on QingKe targets) and packs both
+ * fields into the 8-bit IPRIOR format.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_WCH_PFIC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_WCH_PFIC_H_
+
+/**
+ * @brief Encode QingKe PFIC priority from preemption group and sub-priority.
+ *
+ * @param preempt  Preemption group: 0 (higher) or 1 (lower).
+ *                 Group-0 ISRs can preempt group-1 ISRs.
+ * @param sub      Sub-priority within the group: 0..3.
+ *
+ * @return 8-bit PFIC IPRIOR register value.
+ */
+#define WCH_PFIC_PRIORITY(preempt, sub) \
+	((((preempt) & 0x1) << 7) | (((sub) & 0x3) << 5))
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_WCH_PFIC_H_ */

--- a/soc/wch/ch32v/qingke_v2a/vector.S
+++ b/soc/wch/ch32v/qingke_v2a/vector.S
@@ -24,6 +24,7 @@ SECTION_FUNC(vectors, ivt)
 	.endr
 
 SECTION_FUNC(vectors, __start)
-	li 	a0, 3
+	la	a0, ivt
+	ori	a0, a0, 3
 	csrw	mtvec, a0
 	j	__initialize

--- a/soc/wch/ch32v/qingke_v2c/vector.S
+++ b/soc/wch/ch32v/qingke_v2c/vector.S
@@ -24,6 +24,7 @@ SECTION_FUNC(vectors, ivt)
 	.endr
 
 SECTION_FUNC(vectors, __start)
-	li 	a0, 3
+	la	a0, ivt
+	ori	a0, a0, 3
 	csrw	mtvec, a0
 	j	__initialize

--- a/soc/wch/ch32v/qingke_v4b/vector.S
+++ b/soc/wch/ch32v/qingke_v4b/vector.S
@@ -27,6 +27,7 @@ SECTION_FUNC(vectors, ivt)
 	.endr
 
 SECTION_FUNC(vectors, __start)
-	li 	a0, 0xf
+	la	a0, ivt
+	ori	a0, a0, 3
 	csrw	mtvec, a0
 	j	__initialize

--- a/soc/wch/ch32v/qingke_v4c/vector.S
+++ b/soc/wch/ch32v/qingke_v4c/vector.S
@@ -27,6 +27,7 @@ SECTION_FUNC(vectors, ivt)
 	.endr
 
 SECTION_FUNC(vectors, __start)
-	li 	a0, 0xf
+	la	a0, ivt
+	ori	a0, a0, 3
 	csrw	mtvec, a0
 	j	__initialize

--- a/soc/wch/ch32v/qingke_v4f/vector.S
+++ b/soc/wch/ch32v/qingke_v4f/vector.S
@@ -27,6 +27,7 @@ SECTION_FUNC(vectors, ivt)
 	.endr
 
 SECTION_FUNC(vectors, __start)
-	li 	a0, 0xf
+	la	a0, ivt
+	ori	a0, a0, 3
 	csrw	mtvec, a0
 	j	__initialize


### PR DESCRIPTION
## Summary

Add MIE-based interrupt priority preemption nesting for WCH QingKe v2/v4 RISC-V cores (CH32V00x/V20x/V30x MCU families).

## Changes

- **MIE-based nesting** (CONFIG_WCH_PFIC_NESTING): _isr_wrapper re-enables mstatus.MIE after context save, allowing higher-priority PFIC interrupts to preempt the current ISR
- **DTS priority encoding**: new wch-pfic.h header with WCH_PFIC_PRIORITY macro
- **SYSTICK priority fix**: driver now uses DTS-configured priority
- **All DTS files updated**: 2-cell interrupt format for all WCH boards

## Verification

- **CH32V208 (QingKe V4C)**: verified with 17-minute stress test, USART1 at 115200 baud, zero data loss, no crash
- **Other WCH MCUs** (CH32V003/006/203/303/307): compile-tested only with hello_world sample; NOT verified on hardware

## AI Assistance

This contribution was assisted by **DeepSeek V4 Pro** via the **Tencent WorkBuddy Embedded Firmware Engineer** agent. All generated code was reviewed and validated by a human contributor before submission.

Fixes #90245