### PR TITLE
drivers: adc: Fix AD7124 slot allocation, current-source selection and cfg init bug

### DIFF
--- a/drivers/adc/adc_ad7124.c
+++ b/drivers/adc/adc_ad7124.c
@@ -252,6 +252,9 @@ struct ad7124_channel_config {
 	struct ad7124_config_props props;
 	uint8_t cfg_slot;
 	bool live_cfg;
+	struct ad7124_current_source_config current_source_pin[2];
+	bool current_source_pin_set;
+	uint8_t iout_idx;
 };
 
 struct adc_ad7124_config {
@@ -273,7 +276,6 @@ struct adc_ad7124_data {
 	struct adc_context ctx;
 	struct ad7124_control_status adc_control_status;
 	struct ad7124_channel_config channel_setup_cfg[AD7124_MAX_CHANNELS];
-	struct ad7124_current_source_config current_sources[2];
 	uint8_t setup_cfg_slots;
 	struct k_sem acquire_signal;
 	uint16_t channels;
@@ -854,9 +856,9 @@ static int adc_ad7124_channel_cfg(const struct device *dev, const struct adc_cha
 }
 
 static int adc_ad7124_enable_current_sources(const struct device *dev,
-					     const struct adc_channel_cfg *cfg)
+					     const struct adc_channel_cfg *cfg,
+					     struct ad7124_current_source_config *cs_config)
 {
-	struct adc_ad7124_data *data = dev->data;
 	uint8_t iout_idx;
 
 	if (cfg->current_source_pin[0] > AD7124_CURRENT_SOURCE_MASK) {
@@ -865,22 +867,23 @@ static int adc_ad7124_enable_current_sources(const struct device *dev,
 	}
 
 	iout_idx = FIELD_GET(AD7124_CURRENT_SOURCE_IOUT_MSK, cfg->current_source_pin[0]);
-	data->current_sources[iout_idx].current = (enum ad7124_iout_current)FIELD_GET(
+	cs_config[iout_idx].current = (enum ad7124_iout_current)FIELD_GET(
 		AD7124_CURRENT_SOURCE_CURRENT_MSK, cfg->current_source_pin[0]);
-	data->current_sources[iout_idx].channel = cfg->current_source_pin[1];
+	cs_config[iout_idx].channel = cfg->current_source_pin[1];
 
-	uint32_t value = FIELD_PREP(AD7124_IOUT0_CURRENT_MSK, data->current_sources[0].current) |
-			 FIELD_PREP(AD7124_IOUT0_CHANNEL_MSK, data->current_sources[0].channel) |
-			 FIELD_PREP(AD7124_IOUT1_CURRENT_MSK, data->current_sources[1].current) |
-			 FIELD_PREP(AD7124_IOUT1_CHANNEL_MSK, data->current_sources[1].channel);
+	uint32_t value = FIELD_PREP(AD7124_IOUT0_CURRENT_MSK, cs_config[0].current) |
+			 FIELD_PREP(AD7124_IOUT0_CHANNEL_MSK, cs_config[0].channel) |
+			 FIELD_PREP(AD7124_IOUT1_CURRENT_MSK, cs_config[1].current) |
+			 FIELD_PREP(AD7124_IOUT1_CHANNEL_MSK, cs_config[1].channel);
 
 	return adc_ad7124_reg_write_msk(dev, AD7124_IO_CONTROL_1, AD7124_IO_CONTROL_1_REG_LEN,
-					FIELD_PREP(AD7124_IOUT_MSK, value), AD7124_IOUT_MSK);
+					value, AD7124_IOUT_MSK);
 }
 
 static int adc_ad7124_channel_setup(const struct device *dev, const struct adc_channel_cfg *cfg)
 {
 	struct adc_ad7124_data *data = dev->data;
+	struct ad7124_current_source_config cs_config[2] = {0};
 	struct ad7124_channel_config new_cfg;
 	int new_slot;
 	int ret;
@@ -930,11 +933,16 @@ static int adc_ad7124_channel_setup(const struct device *dev, const struct adc_c
 	}
 
 	if (cfg->current_source_pin_set) {
-		ret = adc_ad7124_enable_current_sources(dev, cfg);
+		ret = adc_ad7124_enable_current_sources(dev, cfg, cs_config);
 		if (ret) {
 			LOG_ERR("Error setting up current sources");
 			return ret;
 		}
+		data->channel_setup_cfg[cfg->channel_id].current_source_pin_set = true;
+		data->channel_setup_cfg[cfg->channel_id].iout_idx =
+			FIELD_GET(AD7124_CURRENT_SOURCE_IOUT_MSK, cfg->current_source_pin[0]);
+		memcpy(data->channel_setup_cfg[cfg->channel_id].current_source_pin, cs_config,
+		       sizeof(cs_config));
 	}
 
 	/* Setup the channel */
@@ -1215,6 +1223,34 @@ static int adc_ad7124_get_read_chan_id(const struct device *dev, uint16_t *chan_
 	return 0;
 }
 
+static int adc_ad7124_apply_channel_current_source(const struct device *dev, uint8_t ch_idx)
+{
+	struct adc_ad7124_data *data = dev->data;
+	struct ad7124_channel_config *ch_cfg = &data->channel_setup_cfg[ch_idx];
+	struct ad7124_current_source_config *cs;
+	uint32_t value;
+	uint32_t mask;
+
+	if (!ch_cfg->current_source_pin_set) {
+		return 0;
+	}
+
+	cs = &ch_cfg->current_source_pin[ch_cfg->iout_idx];
+
+	if (ch_cfg->iout_idx == 0) {
+		value = FIELD_PREP(AD7124_IOUT0_CURRENT_MSK, cs->current) |
+			FIELD_PREP(AD7124_IOUT0_CHANNEL_MSK, cs->channel);
+		mask = AD7124_IOUT0_CURRENT_MSK | AD7124_IOUT0_CHANNEL_MSK;
+	} else {
+		value = FIELD_PREP(AD7124_IOUT1_CURRENT_MSK, cs->current) |
+			FIELD_PREP(AD7124_IOUT1_CHANNEL_MSK, cs->channel);
+		mask = AD7124_IOUT1_CURRENT_MSK | AD7124_IOUT1_CHANNEL_MSK;
+	}
+
+	return adc_ad7124_reg_write_msk(dev, AD7124_IO_CONTROL_1, AD7124_IO_CONTROL_1_REG_LEN,
+					value, mask);
+}
+
 static int adc_ad7124_perform_read(const struct device *dev)
 {
 	int ret = 0;
@@ -1232,6 +1268,13 @@ static int adc_ad7124_perform_read(const struct device *dev)
 		status = get_next_ch_idx(data->ctx.sequence.channels, ch_idx, &ch_idx);
 		if (!status) {
 			break;
+		}
+
+		ret = adc_ad7124_apply_channel_current_source(dev, ch_idx);
+		if (ret) {
+			LOG_ERR("applying current source for channel %d failed", ch_idx);
+			adc_context_complete(&data->ctx, ret);
+			return ret;
 		}
 
 		ret = adc_ad7124_wait_for_conv_ready(dev);

--- a/drivers/adc/adc_ad7124.c
+++ b/drivers/adc/adc_ad7124.c
@@ -884,7 +884,7 @@ static int adc_ad7124_channel_setup(const struct device *dev, const struct adc_c
 {
 	struct adc_ad7124_data *data = dev->data;
 	struct ad7124_current_source_config cs_config[2] = {0};
-	struct ad7124_channel_config new_cfg;
+	struct ad7124_channel_config new_cfg = {0};
 	int new_slot;
 	int ret;
 	int similar_channel_index;

--- a/drivers/adc/adc_ad7124.c
+++ b/drivers/adc/adc_ad7124.c
@@ -893,19 +893,21 @@ static int adc_ad7124_channel_setup(const struct device *dev, const struct adc_c
 		return ret;
 	}
 
-	/* AD7124 supports only 8 different configurations for 16 channels*/
-	new_slot = adc_ad7124_find_new_slot(dev);
+	/* AD7124 supports only 8 different configurations for 16 channels.
+	 * Reuse identical configurations instead of trying to assign a new one each time.
+	 */
+	similar_channel_index =
+		adc_ad7124_find_similar_configuration(dev, &new_cfg, cfg->channel_id);
 
-	if (new_slot == -1) {
-		similar_channel_index =
-			adc_ad7124_find_similar_configuration(dev, &new_cfg, cfg->channel_id);
-		if (similar_channel_index == -1) {
+	if (similar_channel_index == -1) {
+		new_slot = adc_ad7124_find_new_slot(dev);
+		if (new_slot == -1) {
 			return -EINVAL;
 		}
-		new_cfg.cfg_slot = data->channel_setup_cfg[similar_channel_index].cfg_slot;
-	} else {
 		new_cfg.cfg_slot = new_slot;
 		WRITE_BIT(data->setup_cfg_slots, new_slot, true);
+	} else {
+		new_cfg.cfg_slot = data->channel_setup_cfg[similar_channel_index].cfg_slot;
 	}
 
 	new_cfg.live_cfg = true;


### PR DESCRIPTION
  - Fix setup slot allocation to reuse identical configurations before
    allocating new slots, preventing premature slot exhaustion on the
    AD7124's 8 shared config slots across 16 channels.
  - Fix current-source selection by moving config from global to
    per-channel storage, allowing successive reads of different channels
    without the need of reconfiguration at application level.
  - Zero-initialize channel config structs to prevent padding bytes from
    influencing the comparison between two struct variables.