### PR TITLE
drivers: crc: nxp: fix CRC bus fault on MCXW70 and wire CRC clock

### DIFF
--- a/drivers/crc/crc_nxp.c
+++ b/drivers/crc/crc_nxp.c
@@ -6,6 +6,7 @@
 #define DT_DRV_COMPAT nxp_crc
 
 #include <zephyr/drivers/crc.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(nxp_crc, CONFIG_CRC_LOG_LEVEL);
@@ -17,6 +18,8 @@ LOG_MODULE_REGISTER(nxp_crc, CONFIG_CRC_LOG_LEVEL);
 
 struct crc_nxp_config {
 	CRC_Type *base;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
 };
 
 struct crc_nxp_data {
@@ -212,7 +215,20 @@ static DEVICE_API(crc, crc_nxp_driver_api) = {
 
 static int crc_nxp_init(const struct device *dev)
 {
+	const struct crc_nxp_config *config = dev->config;
 	struct crc_nxp_data *data = dev->data;
+
+	if (config->clock_dev != NULL) {
+		if (!device_is_ready(config->clock_dev)) {
+			return -ENODEV;
+		}
+
+		int ret = clock_control_on(config->clock_dev, config->clock_subsys);
+
+		if (ret != 0) {
+			return ret;
+		}
+	}
 
 	k_sem_init(&data->lock, 1, 1);
 	return 0;
@@ -222,6 +238,11 @@ static int crc_nxp_init(const struct device *dev)
 	static struct crc_nxp_data crc_nxp_data_##inst;                                            \
 	static const struct crc_nxp_config crc_nxp_config_##inst = {                               \
 		.base = (CRC_Type *)DT_INST_REG_ADDR(inst),                                        \
+		.clock_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clocks),                      \
+			(DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(inst))), (NULL)),                       \
+		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clocks),                   \
+			((clock_control_subsys_t)DT_INST_CLOCKS_CELL(inst, name)),                 \
+			((clock_control_subsys_t)0U)),                                             \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, crc_nxp_init, NULL, &crc_nxp_data_##inst,                      \
 			      &crc_nxp_config_##inst, POST_KERNEL,                                 \

--- a/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
@@ -381,6 +381,9 @@
 	crc: crc@18000 {
 		compatible = "nxp,crc";
 		reg = <0x18000 0x1000>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0xd8, MCXW_CLK_IP_MUX_NONE,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
@@ -378,9 +378,9 @@
 		interrupts = <97 1>;
 	};
 
-	crc: crc@23000 {
+	crc: crc@18000 {
 		compatible = "nxp,crc";
-		reg = <0x23000 0x1000>;
+		reg = <0x18000 0x1000>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -568,6 +568,9 @@
 	crc: crc@23000 {
 		compatible = "nxp,crc";
 		reg = <0x23000 0x1000>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x8c, MCXW_CLK_IP_MUX_NONE,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		status = "disabled";
 	};
 };


### PR DESCRIPTION
## Summary

Fixes a bus fault / kernel panic during `CRC_Init()` on the MCXW70 (MCXW70AC) platform, which appeared after CRC hardware was enabled on the MCXW7x parts in #109331. The root cause is a wrong CRC peripheral base address in the MCXW70 devicetree — not a clock problem.

## Background

After CRC was enabled for the MCXW7x platforms, `tests/subsys/crc` (and any CRC use) faulted during the first CRC operation on MCXW70. The original report suspected missing clock configuration, but the MCUX HAL `CRC_Init()` already ungates the CRC clock itself, so that was not the cause.

## Root cause

The MCXW70 CRC node was declared at offset `0x23000` (absolute `0x50023000`), reusing the MCXW71/MCXW72 memory map. On MCXW70AC the CRC peripheral is actually at `0x50018000` (CRC_0). With the wrong base, `CRC_GetInstance()` in the HAL cannot match the instance: in a debug build `assert(instance < ARRAY_SIZE(s_crcBases))` fires and the kernel panics, while in a release build it falls through to an invalid register access and bus-faults. MCXW71/MCXW72 use the correct address (`0x50023000` matches `CRC0_BASE`) and were never affected.

## Changes

1. **dts: arm: nxp: mcxw70: fix CRC peripheral base address** — Point the CRC node at the correct `CRC_0` base (`crc@18000` / `reg = <0x18000 0x1000>`). This is the actual fix for the bus fault.
2. **drivers: crc: nxp: manage CRC clock via clock-control** — Enable the CRC clock through the Zephyr clock-control framework when the node has a `clocks` property (mirrors `gpio_mcux`), and add that property to the MCXW7x (MCXW71/MCXW72) CRC node. This is a no-behavior-change consistency improvement — the HAL already ungates the clock — that makes the dependency explicit in devicetree. The `COND_CODE_1` guard leaves platforms without a `clocks` property (MCXN, LPC, …) unchanged.

## Validation

Ran `tests/subsys/crc` on hardware. On **frdm_mcxw71** (MCXW716C) the suite passes 14/14, and on **frdm_mcxw72** (MCXW727C) it passes 14/14. On **MCXW70AC** the suite panics / bus-faults at the first CRC operation before the fix and runs normally after it; MCXW70 runtime was exercised on top of the SoC bring-up branch (#108742), since `frdm_mcxw70` is not bootable on `main` without it. The reflected CRC-16 cases that previously failed are fixed separately by #110317, now merged.

## Related

Introduced by #109331 (enable NXP CRC platforms); complements #110317 (accept reflected CRC-16 polynomial, merged); MCXW70 runtime requires #108742 (MCXW70 SoC bring-up) to boot.
