### PR TITLE
dts: arm: nuvoton: add adc nodes of numaker m335x

### DIFF
--- a/dts/arm/nuvoton/m335x.dtsi
+++ b/dts/arm/nuvoton/m335x.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/reset/numaker_m335x_reset.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 
 / {
 	chosen {
@@ -423,6 +424,32 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
+		};
+
+		eadc0: eadc@40043000 {
+			compatible = "nuvoton,numaker-adc";
+			reg = <0x40043000 0x1000>;
+			interrupts = <42 0>;
+			resets = <&rst NUMAKER_EADC0_RST>;
+			clocks = <&pcc NUMAKER_EADC0_MODULE
+				  NUMAKER_CLK_CLKSEL0_EADC0SEL_HCLK
+				  NUMAKER_CLK_CLKDIV0_EADC0(12)>;
+			channels = <19>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
+		eadc1: eadc@4004b000 {
+			compatible = "nuvoton,numaker-adc";
+			reg = <0x4004b000 0x1000>;
+			interrupts = <104 0>;
+			resets = <&rst NUMAKER_EADC1_RST>;
+			clocks = <&pcc NUMAKER_EADC1_MODULE
+				  NUMAKER_CLK_CLKSEL0_EADC1SEL_HCLK
+				  NUMAKER_CLK_CLKDIV2_EADC1(12)>;
+			channels = <19>;
+			status = "disabled";
+			#io-channel-cells = <1>;
 		};
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/numaker_m3351ki.overlay
+++ b/tests/drivers/adc/adc_api/boards/numaker_m3351ki.overlay
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	zephyr,user {
+		io-channels = <&eadc0 0>, <&eadc0 2>;
+	};
+};
+
+&pinctrl {
+	/* EVB's UNO Pin A4 & D0 for channel 0 & 2 --> PB0, PB2 */
+	eadc0_default: eadc0_default {
+		group0 {
+			pinmux = <PB0MFP_EADC0_CH0>, <PB2MFP_EADC0_CH2>;
+		};
+	};
+};
+
+&eadc0 {
+	status = "okay";
+	pinctrl-0 = <&eadc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <10>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <10>;
+	};
+};


### PR DESCRIPTION
This PR is to add 2 adc nodes for m335x adc driver support.