### PR TITLE
dts: stm32wba: add new stm32wba radio node

### DIFF
--- a/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
+++ b/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
@@ -184,10 +184,14 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 };
 
-&bt_hci_wba {
-	/* Use HASH IRQ to allocate Radio SW Low Process (Warning HASH is not used) */
+&radio {
+	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
 	interrupts = <60 0>, <55 14>;
 	interrupt-names = "radio", "radio-sw-low";
+
+	bt_hci_wba: bluetooth {
+		status = "okay";
+	};
 };
 
 &flash0 {

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -205,17 +205,18 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 };
 
-&bt_hci_wba {
-	/* Use HASH IRQ to allocate Radio SW Low Process (Warning HASH is not used) */
+&radio {
+	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
 	interrupts = <66 0>, <61 14>;
 	interrupt-names = "radio", "radio-sw-low";
-};
 
-&ieee802154 {
-	/* Use HASH IRQ to allocate Radio SW Low Process (Warning HASH is not used) */
-	interrupts = <66 0>, <61 14>;
-	interrupt-names = "radio", "radio-sw-low";
-	status = "okay";
+	bt_hci_wba: bluetooth {
+		status = "okay";
+	};
+
+	ieee802154: ieee802154 {
+		status = "okay";
+	};
 };
 
 &aes {

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -166,17 +166,18 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 };
 
-&bt_hci_wba {
-	/* Use HASH IRQ to allocate Radio SW Low Process (Warning HASH is not used) */
+&radio {
+	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
 	interrupts = <66 0>, <61 14>;
 	interrupt-names = "radio", "radio-sw-low";
-};
 
-&ieee802154 {
-	/* Use HASH IRQ to allocate Radio SW Low Process (Warning HASH is not used) */
-	interrupts = <66 0>, <61 14>;
-	interrupt-names = "radio", "radio-sw-low";
-	status = "okay";
+	bt_hci_wba: bluetooth {
+		status = "okay";
+	};
+
+	ieee802154: ieee802154 {
+		status = "okay";
+	};
 };
 
 &aes {

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
@@ -198,6 +198,20 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 };
 
+&radio {
+	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
+	interrupts = <66 0>, <61 14>;
+	interrupt-names = "radio", "radio-sw-low";
+
+	bt_hci_wba: bluetooth {
+		status = "okay";
+	};
+
+	ieee802154: ieee802154 {
+		status = "okay";
+	};
+};
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -391,6 +391,14 @@ STM32
   ``pinctrl-names``, ``mclk-enable``, ``mclk-divider``, ``synchronous``, and
   ``fifo-threshold``. (:github:`104423`)
 
+* :dtcompatible:`st,hci-stm32wba` and :dtcompatible:`st,stm32wba-ieee802154` nodes
+  (with nodelabels ``bt_hci_wba`` and ``ieee802154`` respectively) are now
+  children of a top-level :dtcompatible:`st,stm32wba-radio` node with nodelabel
+  ``radio``. The ``interrupts`` property is now set on the ``&radio`` node instead
+  of being duplicated on both ``&bt_hci_wba`` and ``&ieee802154`` nodes. Out-of-tree
+  boards which modified the ``interrupts`` property on either node must be updated
+  to set the property on the top-level ``&radio`` node instead. (:github:`110546`)
+
 Syscon
 ======
 

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -566,6 +566,26 @@
 			resets = <&rctl STM32_RESET(AHB1, 12)>;
 			status = "disabled";
 		};
+
+		radio: radio@48020000 {
+			compatible = "st,stm32wba-radio";
+			reg = <0x48020000 DT_SIZE_K(4)>;
+
+			interrupt-names = "radio";
+
+			#address-cells = <0>;
+			#size-cells = <0>;
+
+			bt_hci_wba: bluetooth {
+				compatible = "st,hci-stm32wba";
+				status = "disabled";
+			};
+
+			ieee802154: ieee802154 {
+				compatible = "st,stm32wba-ieee802154";
+				status = "disabled";
+			};
+		};
 	};
 
 	die_temp: dietemp {
@@ -576,20 +596,6 @@
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;
 		io-channels = <&adc4 13>;
-		status = "disabled";
-	};
-
-	bt_hci_wba: bt_hci_wba {
-		compatible = "st,hci-stm32wba";
-		interrupt-parent = <&nvic>;
-		interrupt-names = "radio";
-		status = "okay";
-	};
-
-	ieee802154: ieee802154 {
-		compatible = "st,stm32wba-ieee802154";
-		interrupt-parent = <&nvic>;
-		interrupt-names = "radio";
 		status = "disabled";
 	};
 

--- a/dts/arm/st/wba/stm32wba23.dtsi
+++ b/dts/arm/st/wba/stm32wba23.dtsi
@@ -82,15 +82,9 @@
 		usart1: serial@40013800 {
 			interrupts = <43 0>;
 		};
-	};
 
-	bt_hci_wba: bt_hci_wba {
-		interrupt-parent = <&nvic>;
-		interrupts = <60 0>;
-		interrupt-names = "radio";
-	};
-
-	ieee802154: ieee802154 {
-		interrupts = <60 0>;
+		radio: radio@48020000 {
+			interrupts = <60 0>;
+		};
 	};
 };

--- a/dts/arm/st/wba/stm32wba52.dtsi
+++ b/dts/arm/st/wba/stm32wba52.dtsi
@@ -105,13 +105,9 @@
 			interrupts = <0 0>;
 			status = "disabled";
 		};
-	};
 
-	bt_hci_wba: bt_hci_wba {
-		interrupts = <66 0>;
-	};
-
-	ieee802154: ieee802154 {
-		interrupts = <66 0>;
+		radio: radio@48020000 {
+			interrupts = <66 0>;
+		};
 	};
 };

--- a/dts/bindings/net/wireless/st,stm32wba-radio.yaml
+++ b/dts/bindings/net/wireless/st,stm32wba-radio.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32WBA 2.4 GHz radio.
+  This device groups protocol frontends implemented on top of the same radio IP.
+
+compatible: "st,stm32wba-radio"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true

--- a/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
+++ b/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
@@ -17,13 +17,7 @@
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(linklayer_plat_adapt);
 
-#if defined(CONFIG_BT_STM32WBA)
-#define RADIO_NODE DT_NODELABEL(bt_hci_wba)
-#elif defined(CONFIG_IEEE802154_STM32WBA)
-#define RADIO_NODE DT_NODELABEL(ieee802154)
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(RADIO_NODE)
+#define RADIO_NODE DT_INST(0, st_stm32wba_radio)
 #define STM32WBA_RADIO_IRQ_NUM DT_IRQ_BY_NAME(RADIO_NODE, radio, irq)
 #define STM32WBA_RADIO_INTR_PRIO_HIGH DT_IRQ_BY_NAME(RADIO_NODE, radio, priority)
 #if DT_IRQ_HAS_NAME(RADIO_NODE, radio_sw_low)
@@ -31,7 +25,6 @@ LOG_MODULE_REGISTER(linklayer_plat_adapt);
 #define STM32WBA_RADIO_SW_LOW_INTR_PRIO DT_IRQ_BY_NAME(RADIO_NODE, radio_sw_low, priority)
 #else
 #error "Radio SW low interrupt is not defined in DTS"
-#endif
 #endif
 
 #define STM32WBA_RADIO_INTR_PRIO_HIGH_Z (STM32WBA_RADIO_INTR_PRIO_HIGH + _IRQ_PRIO_OFFSET)


### PR DESCRIPTION
This PR includes the implementation of a new STM32WBA 2.4 GHz radio container node including the bluetooth node and the ieee802154 node.
st,stm32wba-radio is a new compatible in dts/bindings/net/wireless

FYI: @asm5878 , @erwango , @mathieuchopstm , @etienne-lms 

