### PR TITLE
doc: wifi: siwx91x: Document twt_capable limitation

### DIFF
--- a/boards/silabs/radio_boards/siwx917/doc/wifi.rst
+++ b/boards/silabs/radio_boards/siwx917/doc/wifi.rst
@@ -242,6 +242,9 @@ Bugs and Limitations
    - The device supports bandwidth of 20 MHz only and 1 spatial stream.
    - 802.11r is not supported.
    - WMM power save mode is not supported.
+   - For Wi-Fi status (``wifi_iface_status``), the ``twt_capable`` field may be
+     set to ``true`` even if the AP does not support TWT. This will happen when
+     the connection is in 802.11ax mode, but the AP has disabled TWT.
 
 
 Soft-AP Mode Features


### PR DESCRIPTION
Note in the Wi-Fi documentation that the twt_capable field of wifi_iface_status may report true in 802.11ax mode even when the AP has TWT disabled.