### PR TITLE
include: dt-bindings: clock: imx952: fix doxygen group hierarchy

### DIFF
--- a/include/zephyr/dt-bindings/clock/imx952_clock.h
+++ b/include/zephyr/dt-bindings/clock/imx952_clock.h
@@ -13,8 +13,9 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_IMX952_CLOCK_H_
 
 /**
- * @defgroup imx952_clock_sources Clock Sources (0-40)
+ * @defgroup imx952_clock_sources NXP i.MX952 Clock Sources
  * @brief Root clock sources for i.MX952 SoC
+ * @ingroup devicetree-clocks
  * @{
  */
 


### PR DESCRIPTION
Add `@ingroup devicetree-clocks` so imx952 clock sources appear under the Devicetree Clocks API documentation. Rename the group title for clarity and consistency with other dt-bindings clock headers.