### PR TITLE
firmware: scmi: introduce and switch to using "struct scmi_xfer"

### DIFF
--- a/drivers/firmware/scmi/base.c
+++ b/drivers/firmware/scmi/base.c
@@ -39,25 +39,21 @@ struct scmi_msg_base_attributes {
 
 /* BASE_DISCOVER_VENDOR */
 struct scmi_msg_base_vendor_id_reply {
-	int32_t status;
 	char vendor_id[SCMI_SHORT_NAME_MAX_SIZE];
 } __packed;
 
 /* BASE_DISCOVER_SUB_VENDOR */
 struct scmi_msg_base_subvendor_id_reply {
-	int32_t status;
 	char subvendor_id[SCMI_SHORT_NAME_MAX_SIZE];
 } __packed;
 
 /* BASE_DISCOVER_IMPLEMENTATION_VERSION */
 struct scmi_msg_base_impl_ver_reply {
-	int32_t status;
 	uint32_t impl_ver;
 } __packed;
 
 /* BASE_DISCOVER_AGENT */
 struct scmi_msg_base_discover_agent_reply {
-	int32_t status;
 	uint32_t agent_id;
 	char name[SCMI_SHORT_NAME_MAX_SIZE];
 } __packed;
@@ -257,7 +253,6 @@ int scmi_base_discover_agent(uint32_t agent_id, struct scmi_agent_info *agent_in
 int scmi_base_device_permission(uint32_t agent_id, uint32_t device_id, bool allow)
 {
 	struct scmi_msg_base_set_device_permissions_config cfg;
-	int32_t status;
 	struct scmi_xfer xfer;
 	struct scmi_protocol *proto;
 	int ret;
@@ -275,7 +270,7 @@ int scmi_base_device_permission(uint32_t agent_id, uint32_t device_id, bool allo
 	cfg.flags = allow ? SCMI_BASE_DEVICE_ACCESS_ALLOW : 0;
 
 	ret = scmi_xfer_init(proto, &xfer, SET_DEVICE_PERMISSIONS,
-			     &cfg, sizeof(cfg), &status, sizeof(status));
+			     &cfg, sizeof(cfg), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}
@@ -296,7 +291,6 @@ int scmi_base_device_permission(uint32_t agent_id, uint32_t device_id, bool allo
 int scmi_base_reset_agent_cfg(uint32_t agent_id, bool reset_perm)
 {
 	struct scmi_msg_base_reset_agent_cfg_config cfg;
-	int32_t status;
 	struct scmi_xfer xfer;
 	struct scmi_protocol *proto;
 	int ret;
@@ -312,7 +306,7 @@ int scmi_base_reset_agent_cfg(uint32_t agent_id, bool reset_perm)
 	cfg.flags = reset_perm ? SCMI_BASE_AGENT_PERMISSIONS_RESET : 0;
 
 	ret = scmi_xfer_init(proto, &xfer, RESET_AGENT_CONFIGURATION,
-			     &cfg, sizeof(cfg), &status, sizeof(status));
+			     &cfg, sizeof(cfg), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/base.c
+++ b/drivers/firmware/scmi/base.c
@@ -85,7 +85,7 @@ struct scmi_msg_base_reset_agent_cfg_config {
 
 static int scmi_base_xfer_no_tx(uint8_t msg_id, void *rx_buf, size_t rx_len)
 {
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	struct scmi_protocol *proto;
 	int ret;
 
@@ -94,16 +94,13 @@ static int scmi_base_xfer_no_tx(uint8_t msg_id, void *rx_buf, size_t rx_len)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(msg_id,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = 0;
-	msg.content = NULL;
+	ret = scmi_xfer_init(proto, &xfer, msg_id,
+			     NULL, 0x0, rx_buf, rx_len);
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = rx_len;
-	reply.content = rx_buf;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		LOG_ERR("base xfer failed (%d)", ret);
 		return ret;
@@ -239,7 +236,7 @@ int scmi_base_get_revision_info(struct scmi_revision_info *rev)
 int scmi_base_discover_agent(uint32_t agent_id, struct scmi_agent_info *agent_inf)
 {
 	struct scmi_msg_base_discover_agent_reply reply_buffer;
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	struct scmi_protocol *proto;
 	int ret;
 
@@ -248,15 +245,14 @@ int scmi_base_discover_agent(uint32_t agent_id, struct scmi_agent_info *agent_in
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(DISCOVER_AGENT, SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(agent_id);
-	msg.content = &agent_id;
+	ret = scmi_xfer_init(proto, &xfer, DISCOVER_AGENT,
+			     &agent_id, sizeof(agent_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(struct scmi_msg_base_discover_agent_reply);
-	reply.content = &reply_buffer;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		LOG_ERR("base proto discover agent failed (%d)", ret);
 		return ret;
@@ -278,7 +274,7 @@ int scmi_base_device_permission(uint32_t agent_id, uint32_t device_id, bool allo
 {
 	struct scmi_msg_base_set_device_permissions_config cfg;
 	int32_t status;
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	struct scmi_protocol *proto;
 	int ret;
 
@@ -294,16 +290,13 @@ int scmi_base_device_permission(uint32_t agent_id, uint32_t device_id, bool allo
 	cfg.device_id = device_id;
 	cfg.flags = allow ? SCMI_BASE_DEVICE_ACCESS_ALLOW : 0;
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SET_DEVICE_PERMISSIONS, SCMI_COMMAND, proto->id,
-					0x0);
-	msg.len = sizeof(cfg);
-	msg.content = &cfg;
+	ret = scmi_xfer_init(proto, &xfer, SET_DEVICE_PERMISSIONS,
+			     &cfg, sizeof(cfg), &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		LOG_ERR("base agent:%u device:%u permission allow:%d failed (%d)", agent_id,
 			device_id, allow, ret);
@@ -324,7 +317,7 @@ int scmi_base_reset_agent_cfg(uint32_t agent_id, bool reset_perm)
 {
 	struct scmi_msg_base_reset_agent_cfg_config cfg;
 	int32_t status;
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	struct scmi_protocol *proto;
 	int ret;
 
@@ -338,16 +331,13 @@ int scmi_base_reset_agent_cfg(uint32_t agent_id, bool reset_perm)
 	cfg.agent_id = agent_id;
 	cfg.flags = reset_perm ? SCMI_BASE_AGENT_PERMISSIONS_RESET : 0;
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(RESET_AGENT_CONFIGURATION, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(cfg);
-	msg.content = &cfg;
+	ret = scmi_xfer_init(proto, &xfer, RESET_AGENT_CONFIGURATION,
+			     &cfg, sizeof(cfg), &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		LOG_ERR("base agent:%u reset cfg failed (%d)", agent_id, ret);
 		return ret;

--- a/drivers/firmware/scmi/base.c
+++ b/drivers/firmware/scmi/base.c
@@ -200,10 +200,6 @@ int scmi_base_get_revision_info(struct scmi_revision_info *rev)
 		return ret;
 	}
 
-	if (msgs.vendor_id.status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(msgs.vendor_id.status);
-	}
-
 	memcpy(rev->vendor_id, msgs.vendor_id.vendor_id, SCMI_SHORT_NAME_MAX_SIZE);
 
 	ret = scmi_base_subvendor_id_get(&msgs.subvendor_id);
@@ -211,19 +207,11 @@ int scmi_base_get_revision_info(struct scmi_revision_info *rev)
 		return ret;
 	}
 
-	if (msgs.subvendor_id.status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(msgs.subvendor_id.status);
-	}
-
 	memcpy(rev->sub_vendor_id, msgs.subvendor_id.subvendor_id, SCMI_SHORT_NAME_MAX_SIZE);
 
 	ret = scmi_base_implementation_version_get(&msgs.impl_ver);
 	if (ret) {
 		return ret;
-	}
-
-	if (msgs.impl_ver.status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(msgs.impl_ver.status);
 	}
 
 	LOG_DBG("scmi base revision info vendor '%s:%s' fw version 0x%x protocols:%d agents:%d",
@@ -256,10 +244,6 @@ int scmi_base_discover_agent(uint32_t agent_id, struct scmi_agent_info *agent_in
 	if (ret < 0) {
 		LOG_ERR("base proto discover agent failed (%d)", ret);
 		return ret;
-	}
-
-	if (reply_buffer.status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(reply_buffer.status);
 	}
 
 	agent_inf->agent_id = reply_buffer.agent_id;
@@ -303,10 +287,6 @@ int scmi_base_device_permission(uint32_t agent_id, uint32_t device_id, bool allo
 		return ret;
 	}
 
-	if (status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(status);
-	}
-
 	LOG_DBG("base  agent:%u device:%u permission set allow:%d done", agent_id, device_id,
 		allow);
 
@@ -341,10 +321,6 @@ int scmi_base_reset_agent_cfg(uint32_t agent_id, bool reset_perm)
 	if (ret < 0) {
 		LOG_ERR("base agent:%u reset cfg failed (%d)", agent_id, ret);
 		return ret;
-	}
-
-	if (status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(status);
 	}
 
 	LOG_DBG("base agent:%u reset cfg reset_perm:%d done", agent_id, reset_perm);

--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -29,37 +29,17 @@ enum scmi_clock_message {
 	CLOCK_GET_PERMISSIONS = 0xf,
 };
 
-struct scmi_clock_attributes_reply {
-	int32_t status;
-	uint32_t attributes;
-};
-
-struct scmi_clock_rate_set_reply {
-	int32_t status;
-	uint32_t rate[2];
-};
-
-struct scmi_clock_parent_get_reply {
-	int32_t status;
-	uint32_t parent_id;
-};
-
 struct scmi_clock_parent_config {
 	uint32_t clk_id;
 	uint32_t parent_id;
-};
-
-struct scmi_clock_get_permissions_reply {
-	int32_t status;
-	uint32_t permissions;
 };
 
 int scmi_clock_rate_get(struct scmi_protocol *proto,
 			uint32_t clk_id, uint32_t *rate)
 {
 	struct scmi_xfer xfer;
+	uint64_t clk_rate;
 	int ret;
-	struct scmi_clock_rate_set_reply reply_buffer;
 
 	/* input validation */
 	if (!proto || !rate) {
@@ -72,7 +52,7 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 
 	ret = scmi_xfer_init(proto, &xfer, CLOCK_RATE_GET,
 			     &clk_id, sizeof(clk_id),
-			     &reply_buffer, sizeof(reply_buffer));
+			     &clk_rate, sizeof(clk_rate));
 	if (ret < 0) {
 		return ret;
 	}
@@ -82,7 +62,7 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 		return ret;
 	}
 
-	*rate = reply_buffer.rate[0];
+	*rate = (uint32_t)clk_rate;
 
 	return 0;
 }
@@ -90,7 +70,7 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_config *cfg)
 {
 	struct scmi_xfer xfer;
-	int status, ret;
+	int ret;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -107,7 +87,7 @@ int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_conf
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, CLOCK_RATE_SET,
-			     cfg, sizeof(*cfg), &status, sizeof(status));
+			     cfg, sizeof(*cfg), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}
@@ -119,7 +99,6 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 {
 	struct scmi_xfer xfer;
 	int ret;
-	struct scmi_clock_parent_get_reply reply_buffer;
 
 	/* input validation */
 	if (!proto || !parent_id) {
@@ -132,26 +111,19 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 
 	ret = scmi_xfer_init(proto, &xfer, CLOCK_PARENT_GET,
 			     &clk_id, sizeof(clk_id),
-			     &reply_buffer, sizeof(reply_buffer));
+			     parent_id, sizeof(*parent_id));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	*parent_id = reply_buffer.parent_id;
-
-	return 0;
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t parent_id)
 {
 	struct scmi_clock_parent_config cfg = {.clk_id = clk_id, .parent_id = parent_id};
 	struct scmi_xfer xfer;
-	int status, ret;
+	int ret;
 
 	/* input validation */
 	if (!proto) {
@@ -163,7 +135,7 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, CLOCK_PARENT_SET,
-			     &cfg, sizeof(cfg), &status, sizeof(status));
+			     &cfg, sizeof(cfg), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}
@@ -175,7 +147,7 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 			  struct scmi_clock_config *cfg)
 {
 	struct scmi_xfer xfer;
-	int status, ret;
+	int ret;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -202,7 +174,7 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, CLOCK_CONFIG_SET,
-			     cfg, sizeof(*cfg), &status, sizeof(status));
+			     cfg, sizeof(*cfg), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}
@@ -237,7 +209,6 @@ int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
 int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,
 			       uint32_t *permissions)
 {
-	struct scmi_clock_get_permissions_reply reply_buffer;
 	struct scmi_xfer xfer;
 	int ret;
 
@@ -251,17 +222,10 @@ int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,
 
 	ret = scmi_xfer_init(proto, &xfer, CLOCK_GET_PERMISSIONS,
 			     &clk_id, sizeof(clk_id),
-			     &reply_buffer, sizeof(reply_buffer));
+			     permissions, sizeof(*permissions));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	*permissions = reply_buffer.permissions;
-
-	return 0;
+	return scmi_send_message(proto, &xfer);
 }

--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -82,10 +82,6 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 		return ret;
 	}
 
-	if (reply_buffer.status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(reply_buffer.status);
-	}
-
 	*rate = reply_buffer.rate[0];
 
 	return 0;
@@ -116,12 +112,7 @@ int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_conf
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(status);
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t *parent_id)
@@ -151,10 +142,6 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 		return ret;
 	}
 
-	if (reply_buffer.status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(reply_buffer.status);
-	}
-
 	*parent_id = reply_buffer.parent_id;
 
 	return 0;
@@ -181,12 +168,7 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(status);
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_clock_config_set(struct scmi_protocol *proto,
@@ -225,12 +207,7 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(status);
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
@@ -254,12 +231,7 @@ int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(attributes->status);
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,
@@ -287,10 +259,6 @@ int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,
 	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
-	}
-
-	if (reply_buffer.status < 0) {
-		return scmi_status_to_errno(reply_buffer.status);
 	}
 
 	*permissions = reply_buffer.permissions;

--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -57,7 +57,7 @@ struct scmi_clock_get_permissions_reply {
 int scmi_clock_rate_get(struct scmi_protocol *proto,
 			uint32_t clk_id, uint32_t *rate)
 {
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int ret;
 	struct scmi_clock_rate_set_reply reply_buffer;
 
@@ -70,16 +70,14 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_RATE_GET,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(clk_id);
-	msg.content = &clk_id;
+	ret = scmi_xfer_init(proto, &xfer, CLOCK_RATE_GET,
+			     &clk_id, sizeof(clk_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -95,7 +93,7 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 
 int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_config *cfg)
 {
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int status, ret;
 
 	/* input validation */
@@ -112,15 +110,13 @@ int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_conf
 		return -ENOTSUP;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_RATE_SET, SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
+	ret = scmi_xfer_init(proto, &xfer, CLOCK_RATE_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -130,7 +126,7 @@ int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_conf
 
 int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t *parent_id)
 {
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int ret;
 	struct scmi_clock_parent_get_reply reply_buffer;
 
@@ -143,16 +139,14 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 		return -EINVAL;
 	}
 
-	msg.hdr =
-		SCMI_MESSAGE_HDR_MAKE(CLOCK_PARENT_GET, SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(clk_id);
-	msg.content = &clk_id;
+	ret = scmi_xfer_init(proto, &xfer, CLOCK_PARENT_GET,
+			     &clk_id, sizeof(clk_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -169,7 +163,7 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t parent_id)
 {
 	struct scmi_clock_parent_config cfg = {.clk_id = clk_id, .parent_id = parent_id};
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int status, ret;
 
 	/* input validation */
@@ -181,16 +175,13 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 		return -EINVAL;
 	}
 
-	msg.hdr =
-		SCMI_MESSAGE_HDR_MAKE(CLOCK_PARENT_SET, SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(cfg);
-	msg.content = &cfg;
+	ret = scmi_xfer_init(proto, &xfer, CLOCK_PARENT_SET,
+			     &cfg, sizeof(cfg), &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -201,7 +192,7 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 int scmi_clock_config_set(struct scmi_protocol *proto,
 			  struct scmi_clock_config *cfg)
 {
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int status, ret;
 
 	/* input validation */
@@ -228,16 +219,13 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_CONFIG_SET,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
+	ret = scmi_xfer_init(proto, &xfer, CLOCK_CONFIG_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -248,7 +236,7 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
 			  struct scmi_clock_attributes *attributes)
 {
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int ret;
 
 	if (!proto || !attributes) {
@@ -259,16 +247,14 @@ int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_ATTRIBUTES,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(clk_id);
-	msg.content = &clk_id;
+	ret = scmi_xfer_init(proto, &xfer, CLOCK_ATTRIBUTES,
+			     &clk_id, sizeof(clk_id),
+			     attributes, sizeof(*attributes));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(*attributes);
-	reply.content = attributes;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -280,7 +266,7 @@ int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,
 			       uint32_t *permissions)
 {
 	struct scmi_clock_get_permissions_reply reply_buffer;
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int ret;
 
 	if (!proto || !permissions) {
@@ -291,16 +277,14 @@ int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_GET_PERMISSIONS,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(clk_id);
-	msg.content = &clk_id;
+	ret = scmi_xfer_init(proto, &xfer, CLOCK_GET_PERMISSIONS,
+			     &clk_id, sizeof(clk_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/common.c
+++ b/drivers/firmware/scmi/common.c
@@ -76,7 +76,7 @@ int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version)
 
 	*version = reply_buffer.version;
 
-	return scmi_status_to_errno(reply_buffer.status);
+	return 0;
 }
 
 int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attributes)
@@ -102,7 +102,7 @@ int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attribut
 
 	*attributes = reply_buffer.attributes;
 
-	return scmi_status_to_errno(reply_buffer.status);
+	return 0;
 }
 
 int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
@@ -132,7 +132,7 @@ int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
 
 	*attributes = reply_buffer.attributes;
 
-	return scmi_status_to_errno(reply_buffer.status);
+	return 0;
 }
 
 int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t version)
@@ -152,10 +152,5 @@ int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t versio
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(status);
+	return scmi_send_message(proto, &xfer);
 }

--- a/drivers/firmware/scmi/common.c
+++ b/drivers/firmware/scmi/common.c
@@ -38,24 +38,8 @@ enum scmi_common_cmd {
 	NEGOTIATE_PROTOCOL_VERSION = 0x10,
 };
 
-struct scmi_protocol_version_reply {
-	int32_t status;
-	uint32_t version;
-};
-
-struct scmi_protocol_attributes_reply {
-	int32_t status;
-	uint32_t attributes;
-};
-
-struct scmi_protocol_message_attributes_reply {
-	int32_t status;
-	uint32_t attributes;
-};
-
 int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version)
 {
-	struct scmi_protocol_version_reply reply_buffer;
 	struct scmi_xfer xfer;
 	int ret;
 
@@ -64,24 +48,16 @@ int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version)
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, PROTOCOL_VERSION,
-			     NULL, 0x0, &reply_buffer, sizeof(reply_buffer));
+			     NULL, 0x0, version, sizeof(*version));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	*version = reply_buffer.version;
-
-	return 0;
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attributes)
 {
-	struct scmi_protocol_attributes_reply reply_buffer;
 	struct scmi_xfer xfer;
 	int ret;
 
@@ -90,25 +66,17 @@ int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attribut
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, PROTOCOL_ATTRIBUTES,
-			     NULL, 0x0, &reply_buffer, sizeof(reply_buffer));
+			     NULL, 0x0, attributes, sizeof(*attributes));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	*attributes = reply_buffer.attributes;
-
-	return 0;
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
 					uint32_t message_id, uint32_t *attributes)
 {
-	struct scmi_protocol_message_attributes_reply reply_buffer;
 	struct scmi_xfer xfer;
 	int ret;
 
@@ -118,27 +86,19 @@ int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
 
 	ret = scmi_xfer_init(proto, &xfer, PROTOCOL_MESSAGE_ATTRIBUTES,
 			     &message_id, sizeof(message_id),
-			     &reply_buffer, sizeof(reply_buffer));
+			     attributes, sizeof(*attributes));
 	if (ret < 0) {
 		return ret;
 	}
 
 	xfer.use_polling = true;
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	*attributes = reply_buffer.attributes;
-
-	return 0;
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t version)
 {
 	struct scmi_xfer xfer;
-	int32_t status;
 	int ret;
 
 	if (!proto) {
@@ -146,8 +106,7 @@ int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t versio
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, NEGOTIATE_PROTOCOL_VERSION,
-			     &version, sizeof(version),
-			     &status, sizeof(status));
+			     &version, sizeof(version), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/common.c
+++ b/drivers/firmware/scmi/common.c
@@ -56,23 +56,20 @@ struct scmi_protocol_message_attributes_reply {
 int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version)
 {
 	struct scmi_protocol_version_reply reply_buffer;
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int ret;
 
 	if (!proto || !version) {
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PROTOCOL_VERSION, SCMI_COMMAND,
-			proto->id, 0x0);
-	msg.len = 0;
-	msg.content = NULL;
+	ret = scmi_xfer_init(proto, &xfer, PROTOCOL_VERSION,
+			     NULL, 0x0, &reply_buffer, sizeof(reply_buffer));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -85,23 +82,20 @@ int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version)
 int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attributes)
 {
 	struct scmi_protocol_attributes_reply reply_buffer;
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int ret;
 
 	if (!proto || !attributes) {
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PROTOCOL_ATTRIBUTES, SCMI_COMMAND,
-			proto->id, 0x0);
-	msg.len = 0;
-	msg.content = NULL;
+	ret = scmi_xfer_init(proto, &xfer, PROTOCOL_ATTRIBUTES,
+			     NULL, 0x0, &reply_buffer, sizeof(reply_buffer));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -115,23 +109,23 @@ int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
 					uint32_t message_id, uint32_t *attributes)
 {
 	struct scmi_protocol_message_attributes_reply reply_buffer;
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int ret;
 
 	if (!proto || !attributes) {
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PROTOCOL_MESSAGE_ATTRIBUTES, SCMI_COMMAND,
-			proto->id, 0x0);
-	msg.len = sizeof(message_id);
-	msg.content = &message_id;
+	ret = scmi_xfer_init(proto, &xfer, PROTOCOL_MESSAGE_ATTRIBUTES,
+			     &message_id, sizeof(message_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
+	xfer.use_polling = true;
 
-	ret = scmi_send_message(proto, &msg, &reply, true);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -143,7 +137,7 @@ int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
 
 int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t version)
 {
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int32_t status;
 	int ret;
 
@@ -151,16 +145,14 @@ int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t versio
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(NEGOTIATE_PROTOCOL_VERSION, SCMI_COMMAND,
-			proto->id, 0x0);
-	msg.len = sizeof(version);
-	msg.content = &version;
+	ret = scmi_xfer_init(proto, &xfer, NEGOTIATE_PROTOCOL_VERSION,
+			     &version, sizeof(version),
+			     &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -132,8 +132,7 @@ int scmi_send_message(struct scmi_protocol *proto, struct scmi_xfer *xfer)
 		}
 	}
 
-	ret = scmi_transport_send_message(proto->transport, proto->tx,
-					  &xfer->tx, xfer->use_polling);
+	ret = scmi_transport_send_message(proto->transport, proto->tx, xfer);
 	if (ret < 0) {
 		LOG_ERR("failed to send message at transport layer: %d", ret);
 		goto out_release_mutex;
@@ -145,7 +144,7 @@ int scmi_send_message(struct scmi_protocol *proto, struct scmi_xfer *xfer)
 		goto out_release_mutex;
 	}
 
-	ret = scmi_transport_read_message(proto->transport, proto->tx, &xfer->rx);
+	ret = scmi_transport_read_message(proto->transport, proto->tx, xfer);
 	if (ret < 0) {
 		LOG_ERR("failed to read message reply: %d", ret);
 		goto out_release_mutex;

--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -99,8 +99,7 @@ static int scmi_core_wait_reply(struct scmi_protocol *proto, bool use_polling)
 	return 0;
 }
 
-int scmi_send_message(struct scmi_protocol *proto, struct scmi_message *msg,
-		      struct scmi_message *reply, bool use_polling)
+int scmi_send_message(struct scmi_protocol *proto, struct scmi_xfer *xfer)
 {
 	int ret;
 
@@ -121,9 +120,9 @@ int scmi_send_message(struct scmi_protocol *proto, struct scmi_message *msg,
 	 *    and potentially even interrupts, based on the architecture.
 	 * Otherwise, use the caller's requested polling mode.
 	 */
-	use_polling = (IS_ENABLED(CONFIG_ARM_SCMI_POLLING_ONLY) ||
-		       proto->tx->polling_only ||
-		       k_is_pre_kernel()) ? true : use_polling;
+	xfer->use_polling = (IS_ENABLED(CONFIG_ARM_SCMI_POLLING_ONLY) ||
+			     proto->tx->polling_only ||
+			     k_is_pre_kernel()) ? true : xfer->use_polling;
 
 	if (!k_is_pre_kernel()) {
 		ret = k_mutex_lock(&proto->tx->lock, K_USEC(SCMI_CHAN_LOCK_TIMEOUT_USEC));
@@ -133,19 +132,20 @@ int scmi_send_message(struct scmi_protocol *proto, struct scmi_message *msg,
 		}
 	}
 
-	ret = scmi_transport_send_message(proto->transport, proto->tx, msg, use_polling);
+	ret = scmi_transport_send_message(proto->transport, proto->tx,
+					  &xfer->tx, xfer->use_polling);
 	if (ret < 0) {
 		LOG_ERR("failed to send message at transport layer: %d", ret);
 		goto out_release_mutex;
 	}
 
-	ret = scmi_core_wait_reply(proto, use_polling);
+	ret = scmi_core_wait_reply(proto, xfer->use_polling);
 	if (ret < 0) {
 		LOG_ERR("failed to wait for message reply: %d", ret);
 		goto out_release_mutex;
 	}
 
-	ret = scmi_transport_read_message(proto->transport, proto->tx, reply);
+	ret = scmi_transport_read_message(proto->transport, proto->tx, &xfer->rx);
 	if (ret < 0) {
 		LOG_ERR("failed to read message reply: %d", ret);
 		goto out_release_mutex;

--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -150,6 +150,11 @@ int scmi_send_message(struct scmi_protocol *proto, struct scmi_xfer *xfer)
 		goto out_release_mutex;
 	}
 
+	ret = scmi_status_to_errno(xfer->status);
+	if (ret < 0) {
+		LOG_ERR("reply has negative status: %d (%d)", ret, xfer->status);
+	}
+
 out_release_mutex:
 	if (!k_is_pre_kernel()) {
 		k_mutex_unlock(&proto->tx->lock);

--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -240,3 +240,24 @@ int scmi_core_transport_init(const struct device *transport)
 
 	return scmi_core_protocol_setup(transport);
 }
+
+int scmi_xfer_init(struct scmi_protocol *proto,
+		   struct scmi_xfer *xfer, uint8_t msg_id,
+		   void *tx_buf, uint32_t tx_len,
+		   void *rx_buf, uint32_t rx_len)
+{
+	/* TODO: add token generation logic here whenever needed */
+	xfer->tx.hdr = SCMI_MESSAGE_HDR_MAKE(msg_id, SCMI_COMMAND, proto->id, 0x0);
+	xfer->tx.len = tx_len;
+	xfer->tx.content = tx_buf;
+
+	xfer->rx.hdr = xfer->tx.hdr;
+	xfer->rx.len = rx_len;
+	xfer->rx.content = rx_buf;
+
+	xfer->status = SCMI_SUCCESS;
+	/* can be overwritten by caller whenever necessary */
+	xfer->use_polling = false;
+
+	return 0;
+}

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -23,15 +23,14 @@ static void scmi_mbox_cb(const struct device *mbox,
 
 static int scmi_mbox_send_message(const struct device *transport,
 				  struct scmi_channel *chan,
-				  struct scmi_message *msg,
-				  bool use_polling)
+				  struct scmi_xfer *xfer)
 {
 	struct scmi_mbox_channel *mbox_chan;
 	int ret;
 
 	mbox_chan = chan->data;
 
-	ret = scmi_shmem_write_message(mbox_chan->shmem, msg, use_polling);
+	ret = scmi_shmem_write_message(mbox_chan->shmem, xfer);
 	if (ret < 0) {
 		LOG_ERR("failed to write message to shmem: %d", ret);
 		return ret;
@@ -48,13 +47,13 @@ static int scmi_mbox_send_message(const struct device *transport,
 
 static int scmi_mbox_read_message(const struct device *transport,
 				  struct scmi_channel *chan,
-				  struct scmi_message *msg)
+				  struct scmi_xfer *xfer)
 {
 	struct scmi_mbox_channel *mbox_chan;
 
 	mbox_chan = chan->data;
 
-	return scmi_shmem_read_message(mbox_chan->shmem, msg);
+	return scmi_shmem_read_message(mbox_chan->shmem, xfer);
 }
 
 static bool scmi_mbox_channel_is_free(const struct device *transport,

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -55,12 +55,7 @@ int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg)
 	 */
 	xfer.use_polling = true;
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(status);
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg)
@@ -86,12 +81,7 @@ int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg)
 
 	xfer.use_polling = true;
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(status);
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg)
@@ -117,12 +107,7 @@ int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg)
 
 	xfer.use_polling = true;
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(status);
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg)
@@ -148,12 +133,7 @@ int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg)
 
 	xfer.use_polling = true;
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(status);
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg)
@@ -188,5 +168,5 @@ int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg)
 
 	*cfg = reply_buffer.data;
 
-	return scmi_status_to_errno(reply_buffer.status);
+	return 0;
 }

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -32,9 +32,8 @@ struct scmi_nxp_cpu_info_get_reply {
 int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int status, ret;
-	bool use_polling;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -45,21 +44,18 @@ int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CPU_SLEEP_MODE_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	ret = scmi_xfer_init(proto, &xfer, CPU_SLEEP_MODE_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
 	/* Set the PM-related scmi api to use poll mode to ensure that
 	 * the CPU is not woken up by unnecessary scmi interrupts
 	 */
-	use_polling = true;
+	xfer.use_polling = true;
 
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -70,9 +66,8 @@ int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg)
 int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int status, ret;
-	bool use_polling;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -83,18 +78,15 @@ int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CPU_PD_LPM_CONFIG_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
+	ret = scmi_xfer_init(proto, &xfer, CPU_PD_LPM_CONFIG_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	xfer.use_polling = true;
 
-	use_polling = true;
-
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -105,7 +97,7 @@ int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg)
 int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int status, ret;
 
 	/* input validation */
@@ -117,16 +109,15 @@ int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CPU_IRQ_WAKE_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
+	ret = scmi_xfer_init(proto, &xfer, CPU_IRQ_WAKE_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	xfer.use_polling = true;
 
-	ret = scmi_send_message(proto, &msg, &reply, true);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -137,7 +128,7 @@ int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg)
 int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int status, ret;
 
 	/* input validation */
@@ -149,16 +140,15 @@ int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CPU_RESET_VECTOR_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
+	ret = scmi_xfer_init(proto, &xfer, CPU_RESET_VECTOR_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
+	xfer.use_polling = true;
 
-	ret = scmi_send_message(proto, &msg, &reply, true);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -169,7 +159,7 @@ int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg)
 int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	struct scmi_nxp_cpu_info_get_reply reply_buffer;
 	int ret;
 
@@ -182,16 +172,16 @@ int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CPU_INFO_GET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(uint32_t);
-	msg.content = &cpu_id;
+	ret = scmi_xfer_init(proto, &xfer, CPU_INFO_GET,
+			     &cpu_id, sizeof(cpu_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
+	xfer.use_polling = true;
 
-	ret = scmi_send_message(proto, &msg, &reply, true);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -24,16 +24,11 @@ enum scmi_nxp_cpu_domain_message {
 	CPU_INFO_GET = 0xC,
 };
 
-struct scmi_nxp_cpu_info_get_reply {
-	int32_t status;
-	struct scmi_nxp_cpu_info data;
-};
-
 int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
 	struct scmi_xfer xfer;
-	int status, ret;
+	int ret;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -45,7 +40,7 @@ int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg)
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, CPU_SLEEP_MODE_SET,
-			     cfg, sizeof(*cfg), &status, sizeof(status));
+			     cfg, sizeof(*cfg), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}
@@ -62,7 +57,7 @@ int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
 	struct scmi_xfer xfer;
-	int status, ret;
+	int ret;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -74,7 +69,7 @@ int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg)
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, CPU_PD_LPM_CONFIG_SET,
-			     cfg, sizeof(*cfg), &status, sizeof(status));
+			     cfg, sizeof(*cfg), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}
@@ -88,7 +83,7 @@ int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
 	struct scmi_xfer xfer;
-	int status, ret;
+	int ret;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -100,7 +95,7 @@ int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg)
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, CPU_IRQ_WAKE_SET,
-			     cfg, sizeof(*cfg), &status, sizeof(status));
+			     cfg, sizeof(*cfg), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}
@@ -114,7 +109,7 @@ int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
 	struct scmi_xfer xfer;
-	int status, ret;
+	int ret;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -126,7 +121,7 @@ int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg)
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, CPU_RESET_VECTOR_SET,
-			     cfg, sizeof(*cfg), &status, sizeof(status));
+			     cfg, sizeof(*cfg), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}
@@ -140,7 +135,6 @@ int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
 	struct scmi_xfer xfer;
-	struct scmi_nxp_cpu_info_get_reply reply_buffer;
 	int ret;
 
 	/* input validation */
@@ -154,19 +148,12 @@ int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg)
 
 	ret = scmi_xfer_init(proto, &xfer, CPU_INFO_GET,
 			     &cpu_id, sizeof(cpu_id),
-			     &reply_buffer, sizeof(reply_buffer));
+			     cfg, sizeof(*cfg));
 	if (ret < 0) {
 		return ret;
 	}
 
 	xfer.use_polling = true;
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	*cfg = reply_buffer.data;
-
-	return 0;
+	return scmi_send_message(proto, &xfer);
 }

--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -62,10 +62,5 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(status);
+	return scmi_send_message(proto, &xfer);
 }

--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -24,7 +24,7 @@ enum scmi_pinctrl_message {
 int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 {
 	struct scmi_protocol *proto;
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	uint32_t config_num;
 	int32_t status, ret;
 
@@ -53,17 +53,16 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PINCTRL_SETTINGS_CONFIGURE,
-					SCMI_COMMAND, proto->id, 0x0);
-	msg.len = sizeof(*settings) -
-		(ARM_SCMI_PINCTRL_MAX_CONFIG_SIZE - config_num * 2) * 4;
-	msg.content = settings;
+	ret = scmi_xfer_init(proto, &xfer, PINCTRL_SETTINGS_CONFIGURE,
+			     settings,
+			     sizeof(*settings) -
+			     (ARM_SCMI_PINCTRL_MAX_CONFIG_SIZE - config_num * 2) * 4,
+			     &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -26,7 +26,7 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 	struct scmi_protocol *proto;
 	struct scmi_xfer xfer;
 	uint32_t config_num;
-	int32_t status, ret;
+	int32_t ret;
 
 	proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PINCTRL);
 
@@ -57,7 +57,7 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 			     settings,
 			     sizeof(*settings) -
 			     (ARM_SCMI_PINCTRL_MAX_CONFIG_SIZE - config_num * 2) * 4,
-			     &status, sizeof(status));
+			     NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -29,7 +29,7 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_POWER_DOMAIN);
 	struct scmi_power_state_get_reply reply_buffer;
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int ret;
 
 	/* input validation */
@@ -41,16 +41,14 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(POWER_STATE_GET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(domain_id);
-	msg.content = &domain_id;
+	ret = scmi_xfer_init(proto, &xfer, POWER_STATE_GET,
+			     &domain_id, sizeof(domain_id),
+			     &reply_buffer, sizeof(reply_buffer));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -67,7 +65,7 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 int scmi_power_state_set(struct scmi_power_state_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_POWER_DOMAIN);
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int status, ret;
 
 	/* input validation */
@@ -84,16 +82,13 @@ int scmi_power_state_set(struct scmi_power_state_config *cfg)
 		return -ENOTSUP;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(POWER_STATE_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
+	ret = scmi_xfer_init(proto, &xfer, POWER_STATE_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -53,10 +53,6 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 		return ret;
 	}
 
-	if (reply_buffer.status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(reply_buffer.status);
-	}
-
 	*power_state = reply_buffer.power_state;
 
 	return 0;
@@ -88,10 +84,5 @@ int scmi_power_state_set(struct scmi_power_state_config *cfg)
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(status);
+	return scmi_send_message(proto, &xfer);
 }

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -20,15 +20,9 @@ enum scmi_power_domain_message {
 	POWER_DOMAIN_GET = 0x8,
 };
 
-struct scmi_power_state_get_reply {
-	int32_t status;
-	uint32_t power_state;
-};
-
 int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_POWER_DOMAIN);
-	struct scmi_power_state_get_reply reply_buffer;
 	struct scmi_xfer xfer;
 	int ret;
 
@@ -43,26 +37,19 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 
 	ret = scmi_xfer_init(proto, &xfer, POWER_STATE_GET,
 			     &domain_id, sizeof(domain_id),
-			     &reply_buffer, sizeof(reply_buffer));
+			     power_state, sizeof(*power_state));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	*power_state = reply_buffer.power_state;
-
-	return 0;
+	return scmi_send_message(proto, &xfer);
 }
 
 int scmi_power_state_set(struct scmi_power_state_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_POWER_DOMAIN);
 	struct scmi_xfer xfer;
-	int status, ret;
+	int ret;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -79,7 +66,7 @@ int scmi_power_state_set(struct scmi_power_state_config *cfg)
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, POWER_STATE_SET,
-			     cfg, sizeof(*cfg), &status, sizeof(status));
+			     cfg, sizeof(*cfg), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/shmem.c
+++ b/drivers/firmware/scmi/shmem.c
@@ -58,7 +58,7 @@ __weak int scmi_shmem_vendor_write_message(struct scmi_shmem_layout *layout)
 	return 0;
 }
 
-int scmi_shmem_read_message(const struct device *shmem, struct scmi_message *msg)
+int scmi_shmem_read_message(const struct device *shmem, struct scmi_xfer *xfer)
 {
 	struct scmi_shmem_layout *layout;
 	struct scmi_shmem_data *data;
@@ -69,31 +69,31 @@ int scmi_shmem_read_message(const struct device *shmem, struct scmi_message *msg
 	layout = (struct scmi_shmem_layout *)data->regmap;
 
 	/* some input validation first */
-	if (!msg) {
+	if (!xfer) {
 		return -EINVAL;
 	}
 
-	if (!msg->content && msg->len) {
+	if (!xfer->rx.content && xfer->rx.len) {
 		return -EINVAL;
 	}
 
-	if (cfg->size < (sizeof(*layout) + msg->len)) {
+	if (cfg->size < (sizeof(*layout) + xfer->rx.len)) {
 		LOG_ERR("message doesn't fit in shmem area");
 		return -EINVAL;
 	}
 
 	/* mismatch between expected reply size and actual size? */
-	if (msg->len != (layout->len - sizeof(layout->msg_hdr))) {
+	if (xfer->rx.len != (layout->len - sizeof(layout->msg_hdr))) {
 		LOG_ERR("bad message len. Expected 0x%x, got 0x%x",
-			msg->len,
+			xfer->rx.len,
 			(uint32_t)(layout->len - sizeof(layout->msg_hdr)));
 		return -EINVAL;
 	}
 
 	/* header match? */
-	if (layout->msg_hdr != msg->hdr) {
+	if (layout->msg_hdr != xfer->rx.hdr) {
 		LOG_ERR("bad message header. Expected 0x%x, got 0x%x",
-			msg->hdr, layout->msg_hdr);
+			xfer->rx.hdr, layout->msg_hdr);
 		return -EINVAL;
 	}
 
@@ -102,17 +102,15 @@ int scmi_shmem_read_message(const struct device *shmem, struct scmi_message *msg
 		return -EINVAL;
 	}
 
-	if (msg->content) {
-		scmi_shmem_memcpy(POINTER_TO_UINT(msg->content),
-				  data->regmap + sizeof(*layout), msg->len);
+	if (xfer->rx.content) {
+		scmi_shmem_memcpy(POINTER_TO_UINT(xfer->rx.content),
+				  data->regmap + sizeof(*layout), xfer->rx.len);
 	}
 
 	return 0;
 }
 
-int scmi_shmem_write_message(const struct device *shmem,
-			     struct scmi_message *msg,
-			     bool use_polling)
+int scmi_shmem_write_message(const struct device *shmem, struct scmi_xfer *xfer)
 {
 	struct scmi_shmem_layout *layout;
 	struct scmi_shmem_data *data;
@@ -123,15 +121,15 @@ int scmi_shmem_write_message(const struct device *shmem,
 	layout = (struct scmi_shmem_layout *)data->regmap;
 
 	/* some input validation first */
-	if (!msg) {
+	if (!xfer) {
 		return -EINVAL;
 	}
 
-	if (!msg->content && msg->len) {
+	if (!xfer->tx.content && xfer->tx.len) {
 		return -EINVAL;
 	}
 
-	if (cfg->size < (sizeof(*layout) + msg->len)) {
+	if (cfg->size < (sizeof(*layout) + xfer->tx.len)) {
 		return -EINVAL;
 	}
 
@@ -139,19 +137,19 @@ int scmi_shmem_write_message(const struct device *shmem,
 		return -EBUSY;
 	}
 
-	layout->len = sizeof(layout->msg_hdr) + msg->len;
-	layout->msg_hdr = msg->hdr;
+	layout->len = sizeof(layout->msg_hdr) + xfer->tx.len;
+	layout->msg_hdr = xfer->tx.hdr;
 
-	if (msg->content) {
+	if (xfer->tx.content) {
 		scmi_shmem_memcpy(data->regmap + sizeof(*layout),
-				  POINTER_TO_UINT(msg->content), msg->len);
+				  POINTER_TO_UINT(xfer->tx.content), xfer->tx.len);
 	}
 
 	if (scmi_shmem_vendor_write_message(layout) < 0) {
 		return -EINVAL;
 	}
 
-	layout->chan_flags = !use_polling ? SCMI_SHMEM_CHAN_FLAG_IRQ_BIT : 0;
+	layout->chan_flags = !xfer->use_polling ? SCMI_SHMEM_CHAN_FLAG_IRQ_BIT : 0;
 
 	/* done, mark channel as busy and proceed */
 	layout->chan_status &= ~SCMI_SHMEM_CHAN_STATUS_BUSY_BIT;

--- a/drivers/firmware/scmi/shmem.c
+++ b/drivers/firmware/scmi/shmem.c
@@ -102,6 +102,10 @@ int scmi_shmem_read_message(const struct device *shmem, struct scmi_xfer *xfer)
 		return -EINVAL;
 	}
 
+	/* all replies (synchronous and delayed) start with the status */
+	scmi_shmem_memcpy(POINTER_TO_UINT(&xfer->status),
+			  data->regmap + sizeof(*layout), sizeof(xfer->status));
+
 	if (xfer->rx.content) {
 		scmi_shmem_memcpy(POINTER_TO_UINT(xfer->rx.content),
 				  data->regmap + sizeof(*layout), xfer->rx.len);

--- a/drivers/firmware/scmi/shmem.c
+++ b/drivers/firmware/scmi/shmem.c
@@ -83,10 +83,10 @@ int scmi_shmem_read_message(const struct device *shmem, struct scmi_xfer *xfer)
 	}
 
 	/* mismatch between expected reply size and actual size? */
-	if (xfer->rx.len != (layout->len - sizeof(layout->msg_hdr))) {
+	if (xfer->rx.len != (layout->len - sizeof(layout->msg_hdr) - sizeof(xfer->status))) {
 		LOG_ERR("bad message len. Expected 0x%x, got 0x%x",
 			xfer->rx.len,
-			(uint32_t)(layout->len - sizeof(layout->msg_hdr)));
+			(uint32_t)(layout->len - sizeof(layout->msg_hdr) - sizeof(xfer->status)));
 		return -EINVAL;
 	}
 
@@ -108,7 +108,8 @@ int scmi_shmem_read_message(const struct device *shmem, struct scmi_xfer *xfer)
 
 	if (xfer->rx.content) {
 		scmi_shmem_memcpy(POINTER_TO_UINT(xfer->rx.content),
-				  data->regmap + sizeof(*layout), xfer->rx.len);
+				  data->regmap + sizeof(*layout) + sizeof(xfer->status),
+				  xfer->rx.len);
 	}
 
 	return 0;

--- a/drivers/firmware/scmi/smc.c
+++ b/drivers/firmware/scmi/smc.c
@@ -25,7 +25,7 @@ struct scmi_smc_channel {
 };
 
 static int scmi_smc_send_message(const struct device *transport, struct scmi_channel *chan,
-				 struct scmi_message *msg, bool use_polling)
+				 struct scmi_xfer *xfer)
 {
 	struct scmi_smc_channel *smc_chan;
 	struct arm_smccc_res res;
@@ -33,7 +33,7 @@ static int scmi_smc_send_message(const struct device *transport, struct scmi_cha
 
 	smc_chan = chan->data;
 
-	ret = scmi_shmem_write_message(smc_chan->shmem, msg, use_polling);
+	ret = scmi_shmem_write_message(smc_chan->shmem, xfer);
 	if (ret < 0) {
 		LOG_ERR("failed to write message to shmem: %d", ret);
 		return ret;
@@ -52,13 +52,13 @@ static int scmi_smc_send_message(const struct device *transport, struct scmi_cha
 }
 
 static int scmi_smc_read_message(const struct device *transport, struct scmi_channel *chan,
-				 struct scmi_message *msg)
+				 struct scmi_xfer *xfer)
 {
 	struct scmi_smc_channel *smc_chan;
 
 	smc_chan = chan->data;
 
-	return scmi_shmem_read_message(smc_chan->shmem, msg);
+	return scmi_shmem_read_message(smc_chan->shmem, xfer);
 }
 
 static bool scmi_smc_channel_is_free(const struct device *transport, struct scmi_channel *chan)

--- a/drivers/firmware/scmi/system.c
+++ b/drivers/firmware/scmi/system.c
@@ -47,7 +47,7 @@ int scmi_system_protocol_version_negotiate(uint32_t version)
 int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_SYSTEM);
-	struct scmi_message msg, reply;
+	struct scmi_xfer xfer;
 	int32_t status;
 	int ret;
 
@@ -60,16 +60,13 @@ int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SYSTEM_POWER_STATE_SET, SCMI_COMMAND,
-					proto->id, 0x0);
-	msg.len = sizeof(*cfg);
-	msg.content = cfg;
+	ret = scmi_xfer_init(proto, &xfer, SYSTEM_POWER_STATE_SET,
+			     cfg, sizeof(*cfg), &status, sizeof(status));
+	if (ret < 0) {
+		return ret;
+	}
 
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(status);
-	reply.content = &status;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
+	ret = scmi_send_message(proto, &xfer);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/system.c
+++ b/drivers/firmware/scmi/system.c
@@ -66,10 +66,5 @@ int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg)
 		return ret;
 	}
 
-	ret = scmi_send_message(proto, &xfer);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return scmi_status_to_errno(status);
+	return scmi_send_message(proto, &xfer);
 }

--- a/drivers/firmware/scmi/system.c
+++ b/drivers/firmware/scmi/system.c
@@ -48,7 +48,6 @@ int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_SYSTEM);
 	struct scmi_xfer xfer;
-	int32_t status;
 	int ret;
 
 	/* input validation */
@@ -61,7 +60,7 @@ int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg)
 	}
 
 	ret = scmi_xfer_init(proto, &xfer, SYSTEM_POWER_STATE_SET,
-			     cfg, sizeof(*cfg), &status, sizeof(status));
+			     cfg, sizeof(*cfg), NULL, 0x0);
 	if (ret < 0) {
 		return ret;
 	}

--- a/include/zephyr/drivers/firmware/scmi/clk.h
+++ b/include/zephyr/drivers/firmware/scmi/clk.h
@@ -77,8 +77,6 @@ struct scmi_clock_rate_config {
  * @brief Describes the content of the CLOCK_ATTRIBUTES command reply
  */
 struct scmi_clock_attributes {
-	/** reply status */
-	int32_t status;
 	/** clock attributes */
 	uint32_t attributes;
 	/** clock name */

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -163,22 +163,12 @@ int scmi_status_to_errno(int scmi_status);
  * a given channel and wait for its reply
  *
  * @param proto pointer to SCMI protocol
- * @param msg pointer to SCMI message to send
- * @param reply pointer to SCMI message in which the reply is to be
- * written
+ * @param xfer Transfer handle
  *
  * @retval 0 if successful
  * @retval negative errno if failure
- * @param use_polling Specifies the communication mechanism used by the scmi
- * platform to interact with agents.
- * - true: Polling mode — the platform actively checks the message status
- *   to determine if it has been processed
- * - false: Interrupt mode — the platform relies on SCMI interrupts to
- *   detect when a message has been handled.
  */
-int scmi_send_message(struct scmi_protocol *proto,
-		      struct scmi_message *msg, struct scmi_message *reply,
-		      bool use_polling);
+int scmi_send_message(struct scmi_protocol *proto, struct scmi_xfer *xfer);
 
 /**
  * @brief Prepare for an SCMI transfer

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -131,6 +131,23 @@ struct scmi_message {
 };
 
 /**
+ * @struct scmi_xfer
+ *
+ * Describes an SCMI transfer, which can be: a command followed by its synchronous reply,
+ * a notification, or a delayed reply.
+ */
+struct scmi_xfer {
+	/** Message to send (i.e. SCMI command) */
+	struct scmi_message tx;
+	/** Message to receive (i.e. reply or notification) */
+	struct scmi_message rx;
+	/** Reply status (not applicable if notification) */
+	int32_t status;
+	/** Poll for reply (only applicable to synchronous replies) */
+	bool use_polling;
+};
+
+/**
  * @brief Convert an SCMI status code to its Linux equivalent (if possible)
  *
  * @param scmi_status SCMI status code as shown in `enum scmi_status_code`
@@ -162,6 +179,26 @@ int scmi_status_to_errno(int scmi_status);
 int scmi_send_message(struct scmi_protocol *proto,
 		      struct scmi_message *msg, struct scmi_message *reply,
 		      bool use_polling);
+
+/**
+ * @brief Prepare for an SCMI transfer
+ *
+ * Initialize given SCMI transfer structure.
+ *
+ * @param proto Protocol handle
+ * @param xfer Transfer handle
+ * @param msg_id Message ID
+ * @param tx_buf TX buffer
+ * @param tx_len TX buffer length
+ * @param rx_buf RX buffer
+ * @param rx_len RX buffer length
+ *
+ * @return 0 on success, negative errno value on failure
+ */
+int scmi_xfer_init(struct scmi_protocol *proto,
+		   struct scmi_xfer *xfer, uint8_t msg_id,
+		   void *tx_buf, uint32_t tx_len,
+		   void *rx_buf, uint32_t rx_len);
 
 /**
  * @brief Get protocol version

--- a/include/zephyr/drivers/firmware/scmi/shmem.h
+++ b/include/zephyr/drivers/firmware/scmi/shmem.h
@@ -37,32 +37,31 @@ struct scmi_shmem_layout {
 };
 
 struct scmi_message;
+struct scmi_xfer;
 
 /**
  * @brief Write a message in the SHMEM area
  *
  * @param shmem pointer to shmem device
- * @param msg message to write
- * @param use_polling true if polling should be used, false otherwise
+ * @param xfer Transfer handle
  *
  * @retval 0 if successful
  * @retval negative errno if failure
  */
 int scmi_shmem_write_message(const struct device *shmem,
-			     struct scmi_message *msg,
-			     bool use_polling);
+			     struct scmi_xfer *xfer);
 
 /**
  * @brief Read a message from a SHMEM area
  *
  * @param shmem pointer to shmem device
- * @param msg message to write the data into
+ * @param xfer Transfer handle
  *
  * @retval 0 if successful
  * @retval negative errno if failure
  */
 int scmi_shmem_read_message(const struct device *shmem,
-			    struct scmi_message *msg);
+			    struct scmi_xfer *xfer);
 
 /**
  * @brief Update the channel flags

--- a/include/zephyr/drivers/firmware/scmi/transport.h
+++ b/include/zephyr/drivers/firmware/scmi/transport.h
@@ -25,6 +25,7 @@
 
 struct scmi_message;
 struct scmi_channel;
+struct scmi_xfer;
 
 /**
  *
@@ -120,16 +121,14 @@ struct scmi_transport_api {
 	 *
 	 * @param transport transport device
 	 * @param chan channel used to send the message
-	 * @param msg message to send
-	 * @param use_polling true if polling should be enabled, false otherwise
+	 * @param xfer Transfer handle
 	 *
 	 * @retval 0 if successful
 	 * @retval <0 negative errno code if failure
 	 */
 	int (*send_message)(const struct device *transport,
 			    struct scmi_channel *chan,
-			    struct scmi_message *msg,
-			    bool use_polling);
+			    struct scmi_xfer *xfer);
 
 	/**
 	 * @brief Prepare a channel for communication
@@ -156,14 +155,14 @@ struct scmi_transport_api {
 	 *
 	 * @param transport transport device
 	 * @param chan channel used to receive the message
-	 * @param msg message to receive
+	 * @param xfer Transfer handle
 	 *
 	 * @retval 0 if successful
 	 * @retval <0 negative errno code if failure
 	 */
 	int (*read_message)(const struct device *transport,
 			    struct scmi_channel *chan,
-			    struct scmi_message *msg);
+			    struct scmi_xfer *xfer);
 
 	/**
 	 * @brief Check if a TX channel is free
@@ -259,8 +258,7 @@ static inline int scmi_transport_setup_chan(const struct device *transport,
  */
 static inline int scmi_transport_send_message(const struct device *transport,
 					      struct scmi_channel *chan,
-					      struct scmi_message *msg,
-					      bool use_polling)
+					      struct scmi_xfer *xfer)
 {
 	const struct scmi_transport_api *api =
 		(const struct scmi_transport_api *)transport->api;
@@ -269,7 +267,7 @@ static inline int scmi_transport_send_message(const struct device *transport,
 		return -ENOSYS;
 	}
 
-	return api->send_message(transport, chan, msg, use_polling);
+	return api->send_message(transport, chan, xfer);
 }
 
 /**
@@ -277,7 +275,7 @@ static inline int scmi_transport_send_message(const struct device *transport,
  */
 static inline int scmi_transport_read_message(const struct device *transport,
 					      struct scmi_channel *chan,
-					      struct scmi_message *msg)
+					      struct scmi_xfer *xfer)
 {
 	const struct scmi_transport_api *api =
 		(const struct scmi_transport_api *)transport->api;
@@ -286,7 +284,7 @@ static inline int scmi_transport_read_message(const struct device *transport,
 		return -ENOSYS;
 	}
 
-	return api->read_message(transport, chan, msg);
+	return api->read_message(transport, chan, xfer);
 }
 
 /**


### PR DESCRIPTION
Hi folks,

So, in a nutshell, this PR introduces a new, higher-level structure (i.e. `struct scmi_xfer`) meant to replace `struct scmi_message` in the communication process. The aim of this is to:

1. Move the SCMI command status checking from the protocol layer to the SCMI core.
2. Give the SCMI core centralized control over the message intialization (e.g. for token generation logic)
3. Simplify the protocol layer by not having to:
a. Check the status of the issued SCMI command
b. Add the `status` field to the command reply structures
c. Manually fill in the fields of `struct scmi_message`

This PR supersedes https://github.com/zephyrproject-rtos/zephyr/pull/109395.