### PR TITLE
include: drivers: clock_control: improve Doxygen documentation

### DIFF
--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -22,6 +22,11 @@
  * @version 1.0.0
  * @ingroup io_interfaces
  * @{
+ *
+ * @defgroup clock_control_interface_ext Device-specific Clock Control API extensions
+ *
+ * @{
+ * @}
  */
 
 #include <errno.h>
@@ -38,7 +43,7 @@ extern "C" {
 
 /* Clock control API */
 
-/* Used to select all subsystem of a clock controller */
+/** @brief Subsystem selector representing all subsystems of a clock controller. */
 #define CLOCK_CONTROL_SUBSYS_ALL	NULL
 
 /**
@@ -52,17 +57,18 @@ enum clock_control_status {
 };
 
 /**
- * clock_control_subsys_t is a type to identify a clock controller sub-system.
- * Such data pointed is opaque and relevant only to the clock controller
- * driver instance being used.
+ * @brief Opaque handle identifying a clock controller subsystem.
+ *
+ * The pointed-to data is opaque and only meaningful to the clock controller driver instance
+ * being used.
  */
 typedef void *clock_control_subsys_t;
 
 /**
- * clock_control_subsys_rate_t is a type to identify a clock
- * controller sub-system rate.  Such data pointed is opaque and
- * relevant only to set the clock controller rate of the driver
- * instance being used.
+ * @brief Opaque handle identifying the rate of a clock controller subsystem.
+ *
+ * The pointed-to data is opaque and only meaningful when setting the rate of the clock
+ * controller driver instance being used.
  */
 typedef void *clock_control_subsys_rate_t;
 

--- a/include/zephyr/drivers/clock_control/adi_max32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/adi_max32_clock_control.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock control definitions for Analog Devices MAX32 devices.
+ * @ingroup clock_control_adi_max32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ADI_MAX32_CLOCK_CONTROL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ADI_MAX32_CLOCK_CONTROL_H_
 
@@ -13,42 +19,49 @@
 
 #include <wrap_max32_sys.h>
 
-/** Driver structure definition */
+/**
+ * @defgroup clock_control_adi_max32 Analog Devices MAX32
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
 
+/** @brief Peripheral clock descriptor for MAX32 devices. */
 struct max32_perclk {
-	uint32_t bus;
-	uint32_t bit;
-
-	/* Peripheral clock source:
-	 * Can be (see: adi_max32_clock.h file):
+	uint32_t bus; /**< Peripheral clock bus index. */
+	uint32_t bit; /**< Peripheral enable bit within the bus register. */
+	/**
+	 * @brief Peripheral clock source.
 	 *
-	 *   ADI_MAX32_PRPH_CLK_SRC_PCLK
-	 *   ADI_MAX32_PRPH_CLK_SRC_EXTCLK
-	 *   ADI_MAX32_PRPH_CLK_SRC_IBRO
-	 *   ADI_MAX32_PRPH_CLK_SRC_ERFO
-	 *   ADI_MAX32_PRPH_CLK_SRC_ERTCO
-	 *   ADI_MAX32_PRPH_CLK_SRC_INRO
-	 *   ADI_MAX32_PRPH_CLK_SRC_ISO
-	 *   ADI_MAX32_PRPH_CLK_SRC_IBRO_DIV8
-	 *   ADI_MAX32_PRPH_CLK_SRC_IPLL
-	 *   ADI_MAX32_PRPH_CLK_SRC_EBO
+	 * One of the @c ADI_MAX32_PRPH_CLK_SRC_* constants defined in
+	 * @c <zephyr/dt-bindings/clock/adi_max32_clock.h> (e.g. @c ADI_MAX32_PRPH_CLK_SRC_PCLK,
+	 * @c ADI_MAX32_PRPH_CLK_SRC_IBRO, @c ADI_MAX32_PRPH_CLK_SRC_IPLL).
 	 */
 	uint32_t clk_src;
 };
 
-/** Get prescaler value if it defined  */
+/** @brief System clock prescaler (defaults to 1 when not set in Devicetree). */
 #define ADI_MAX32_SYSCLK_PRESCALER DT_PROP_OR(DT_NODELABEL(gcr), sysclk_prescaler, 1)
 
+/** @brief Internal primary oscillator (IPO) frequency, in Hz. */
 #define ADI_MAX32_CLK_IPO_FREQ    DT_PROP(DT_NODELABEL(clk_ipo), clock_frequency)
+/** @brief External RF oscillator (ERFO) frequency, in Hz (0 if absent). */
 #define ADI_MAX32_CLK_ERFO_FREQ   DT_PROP_OR(DT_NODELABEL(clk_erfo), clock_frequency, 0)
+/** @brief Internal baud-rate oscillator (IBRO) frequency, in Hz (0 if absent). */
 #define ADI_MAX32_CLK_IBRO_FREQ   DT_PROP_OR(DT_NODELABEL(clk_ibro), clock_frequency, 0)
+/** @brief Internal secondary oscillator (ISO) frequency, in Hz (0 if absent). */
 #define ADI_MAX32_CLK_ISO_FREQ    DT_PROP_OR(DT_NODELABEL(clk_iso), clock_frequency, 0)
+/** @brief Internal nano-ring oscillator (INRO) frequency, in Hz. */
 #define ADI_MAX32_CLK_INRO_FREQ   DT_PROP(DT_NODELABEL(clk_inro), clock_frequency)
+/** @brief External RTC oscillator (ERTCO) frequency, in Hz. */
 #define ADI_MAX32_CLK_ERTCO_FREQ  DT_PROP(DT_NODELABEL(clk_ertco), clock_frequency)
+/** @brief Internal PLL (IPLL) frequency, in Hz (0 if absent). */
 #define ADI_MAX32_CLK_IPLL_FREQ   DT_PROP_OR(DT_NODELABEL(clk_ipll), clock_frequency, 0)
+/** @brief External BLE oscillator (EBO) frequency, in Hz (0 if absent). */
 #define ADI_MAX32_CLK_EBO_FREQ    DT_PROP_OR(DT_NODELABEL(clk_ebo), clock_frequency, 0)
-/* External clock may not be defined so _OR is used */
+/** @brief External clock input frequency, in Hz (0 if absent). */
 #define ADI_MAX32_CLK_EXTCLK_FREQ DT_PROP_OR(DT_NODELABEL(clk_extclk), clock_frequency, 0)
+
+/** @cond INTERNAL_HIDDEN */
 
 #define DT_GCR_CLOCKS_CTRL DT_CLOCKS_CTLR(DT_NODELABEL(gcr))
 
@@ -108,5 +121,9 @@ struct max32_perclk {
 	 : (clk_src) == ADI_MAX32_PRPH_CLK_SRC_IPLL      ? ADI_MAX32_CLK_IPLL_FREQ                 \
 	 : (clk_src) == ADI_MAX32_PRPH_CLK_SRC_EBO       ? ADI_MAX32_CLK_EBO_FREQ                  \
 							 : 0)
+
+/** @endcond */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ADI_MAX32_CLOCK_CONTROL_H_ */

--- a/include/zephyr/drivers/clock_control/ameba_clock_control.h
+++ b/include/zephyr/drivers/clock_control/ameba_clock_control.h
@@ -10,6 +10,7 @@
  *
  * This header selects the SoC-specific clock Devicetree bindings for
  * Ameba family SoCs based on the active SoC series configuration.
+ * @ingroup clock_control_ameba
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_AMEBA_CLOCK_CONTROL_H_
@@ -20,7 +21,8 @@ extern "C" {
 #endif
 
 /**
- * @name Ameba SoC clock Devicetree bindings
+ * @defgroup clock_control_ameba Realtek Ameba
+ * @ingroup clock_control_interface_ext
  * @{
  */
 

--- a/include/zephyr/drivers/clock_control/arm_clock_control.h
+++ b/include/zephyr/drivers/clock_control/arm_clock_control.h
@@ -4,37 +4,43 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock subsystem definitions for ARM CMSDK-based SoCs.
+ * @ingroup clock_control_arm
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ARM_CLOCK_CONTROL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ARM_CLOCK_CONTROL_H_
 
 #include <zephyr/drivers/clock_control.h>
 
 /**
- * @file
- *
- * @brief Clock subsystem IDs for ARM family SoCs
+ * @defgroup clock_control_arm ARM CMSDK
+ * @ingroup clock_control_interface_ext
+ * @{
  */
 
-/* CMSDK BUS Mapping */
+/** @brief CMSDK peripheral bus type. */
 enum arm_bus_type_t {
-	CMSDK_AHB = 0,
-	CMSDK_APB,
+	CMSDK_AHB = 0, /**< AHB peripheral bus. */
+	CMSDK_APB,     /**< APB peripheral bus. */
 };
 
-/* CPU States */
+/** @brief CPU power state for which a clock can be configured. */
 enum arm_soc_state_t {
-	SOC_ACTIVE = 0,
-	SOC_SLEEP,
-	SOC_DEEPSLEEP,
+	SOC_ACTIVE = 0,  /**< Active (run) state. */
+	SOC_SLEEP,       /**< Sleep state. */
+	SOC_DEEPSLEEP,   /**< Deep sleep state. */
 };
 
+/** @brief Clock control subsystem descriptor for ARM CMSDK SoCs. */
 struct arm_clock_control_t {
-	/* ARM family SoCs supported Bus types */
-	enum arm_bus_type_t bus;
-	/* Clock can be configured for 3 states: Active, Sleep, Deep Sleep */
-	enum arm_soc_state_t state;
-	/* Identifies the device on the bus */
-	uint32_t device;
+	enum arm_bus_type_t bus;     /**< Peripheral bus the device sits on. */
+	enum arm_soc_state_t state;  /**< CPU state the clock setting applies to. */
+	uint32_t device;             /**< Identifies the device on the bus. */
 };
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ARM_CLOCK_CONTROL_H_ */

--- a/include/zephyr/drivers/clock_control/atmel_sam_pmc.h
+++ b/include/zephyr/drivers/clock_control/atmel_sam_pmc.h
@@ -4,34 +4,71 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Power Management Controller (PMC) clock helpers for Atmel SAM devices.
+ * @ingroup clock_control_atmel_sam_pmc
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ATMEL_SAM_PMC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ATMEL_SAM_PMC_H_
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/atmel_sam_pmc.h>
 
+/**
+ * @defgroup clock_control_atmel_sam_pmc Atmel SAM PMC
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
+
+/** @brief Device pointer to the PMC clock controller. */
 #define SAM_DT_PMC_CONTROLLER DEVICE_DT_GET(DT_NODELABEL(pmc))
 
+/** @brief PMC clock configuration for a single peripheral clock. */
 struct atmel_sam_pmc_config {
-	uint32_t clock_type;
-	uint32_t peripheral_id;
+	uint32_t clock_type;    /**< Clock type (see atmel_sam_pmc.h DT bindings). */
+	uint32_t peripheral_id; /**< Peripheral identifier within the PMC. */
 };
 
+/**
+ * @brief Initialize an @ref atmel_sam_pmc_config from a clock specifier.
+ *
+ * @param clock_id Index of the clock specifier within the node's @c clocks property.
+ * @param node_id Devicetree node identifier owning the @c clocks property.
+ */
 #define SAM_DT_CLOCK_PMC_CFG(clock_id, node_id)					\
 	{									\
 	.clock_type = DT_CLOCKS_CELL_BY_IDX(node_id, clock_id, clock_type),	\
 	.peripheral_id = DT_CLOCKS_CELL_BY_IDX(node_id, clock_id, peripheral_id)\
 	}
 
+/**
+ * @brief Equivalent to SAM_DT_CLOCK_PMC_CFG() for the first clock of a DT instance.
+ *
+ * @param inst DT instance number.
+ */
 #define SAM_DT_INST_CLOCK_PMC_CFG(inst) SAM_DT_CLOCK_PMC_CFG(0, DT_DRV_INST(inst))
 
+/**
+ * @brief Initialize an array of @ref atmel_sam_pmc_config for all clocks of a node.
+ *
+ * @param node_id Devicetree node identifier owning the @c clocks property.
+ */
 #define SAM_DT_CLOCKS_PMC_CFG(node_id)						\
 	{									\
 		LISTIFY(DT_NUM_CLOCKS(node_id),					\
 			SAM_DT_CLOCK_PMC_CFG, (,), node_id)			\
 	}
 
+/**
+ * @brief Equivalent to SAM_DT_CLOCKS_PMC_CFG() for a DT instance.
+ *
+ * @param inst DT instance number.
+ */
 #define SAM_DT_INST_CLOCKS_PMC_CFG(inst)					\
 	SAM_DT_CLOCKS_PMC_CFG(DT_DRV_INST(inst))
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ATMEL_SAM_PMC_H_ */

--- a/include/zephyr/drivers/clock_control/bee_clock_control.h
+++ b/include/zephyr/drivers/clock_control/bee_clock_control.h
@@ -4,15 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_BEE_H_
-#define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_BEE_H_
-
 /**
  * @file
  * @brief Realtek BEE Clock Control Driver Header
+ * @ingroup clock_control_bee
  */
 
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_BEE_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_BEE_H_
+
 #include <zephyr/device.h>
+
+/**
+ * @defgroup clock_control_bee Realtek BEE
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
 
 /**
  * @brief Global device handle for the BEE clock controller.
@@ -23,5 +30,7 @@
  * @return const struct device* Pointer to the clock controller device structure.
  */
 #define BEE_CLOCK_CONTROLLER DEVICE_DT_GET(DT_NODELABEL(cctl))
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_BEE_H_ */

--- a/include/zephyr/drivers/clock_control/clock_control_adsp.h
+++ b/include/zephyr/drivers/clock_control/clock_control_adsp.h
@@ -3,9 +3,26 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Clock control definitions for Intel ADSP devices.
+ *
+ * This header pulls in the SoC-specific Intel ADSP clock definitions.
+ * @ingroup clock_control_adsp
+ */
+
 #ifndef CLOCK_CONTROL_ADSP_H_
 #define CLOCK_CONTROL_ADSP_H_
 
+/**
+ * @defgroup clock_control_adsp Intel ADSP
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
+
 #include <adsp_clk.h>
+
+/** @} */
 
 #endif /* CLOCK_CONTROL_ADSP_H_ */

--- a/include/zephyr/drivers/clock_control/clock_control_ambiq.h
+++ b/include/zephyr/drivers/clock_control/clock_control_ambiq.h
@@ -4,8 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock subsystem identifiers for Ambiq devices.
+ * @ingroup clock_control_ambiq
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_CLOCK_CONTROL_AMBIQ_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_CLOCK_CONTROL_AMBIQ_H_
+
+/**
+ * @defgroup clock_control_ambiq Ambiq
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,25 +25,27 @@ extern "C" {
 
 /** @brief Clocks handled by the CLOCK peripheral.
  *
- * Enum shall be used as a sys argument in clock_control API.
+ * Used as the @c sys argument to the clock_control API.
  */
 enum clock_control_ambiq_type {
-	CLOCK_CONTROL_AMBIQ_TYPE_HFXTAL_BLE,
-	CLOCK_CONTROL_AMBIQ_TYPE_HFXTAL_USB,
-	CLOCK_CONTROL_AMBIQ_TYPE_HFXTAL_ADC,
-	CLOCK_CONTROL_AMBIQ_TYPE_HFXTAL_AUADC,
-	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_DBGCTRL,
-	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_CLKGEN_MISC,
-	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_CLKGEN_CLKOUT,
-	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_PDM,
-	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_IIS,
-	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_IOM,
-	CLOCK_CONTROL_AMBIQ_TYPE_LFXTAL,
-	CLOCK_CONTROL_AMBIQ_TYPE_MAX
+	CLOCK_CONTROL_AMBIQ_TYPE_HFXTAL_BLE,         /**< HFXTAL for the BLE controller. */
+	CLOCK_CONTROL_AMBIQ_TYPE_HFXTAL_USB,         /**< HFXTAL for USB. */
+	CLOCK_CONTROL_AMBIQ_TYPE_HFXTAL_ADC,         /**< HFXTAL for the ADC. */
+	CLOCK_CONTROL_AMBIQ_TYPE_HFXTAL_AUADC,       /**< HFXTAL for the audio ADC. */
+	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_DBGCTRL,     /**< HCXTAL for debug control. */
+	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_CLKGEN_MISC, /**< HCXTAL for clock generator misc. */
+	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_CLKGEN_CLKOUT, /**< HCXTAL for the clock output. */
+	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_PDM,         /**< HCXTAL for PDM. */
+	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_IIS,         /**< HCXTAL for I2S. */
+	CLOCK_CONTROL_AMBIQ_TYPE_HCXTAL_IOM,         /**< HCXTAL for the I/O master. */
+	CLOCK_CONTROL_AMBIQ_TYPE_LFXTAL,             /**< Low-frequency crystal oscillator. */
+	CLOCK_CONTROL_AMBIQ_TYPE_MAX                 /**< Number of clock subsystem types. */
 };
 
 #ifdef __cplusplus
 }
 #endif
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_CLOCK_CONTROL_AMBIQ_H_ */

--- a/include/zephyr/drivers/clock_control/clock_control_bflb_common.h
+++ b/include/zephyr/drivers/clock_control/clock_control_bflb_common.h
@@ -4,27 +4,45 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Contains short functions relevant to timing and clocks common to all Bouffalolab platforms */
+/**
+ * @file
+ * @brief Timing and clock helpers common to all Bouffalo Lab platforms.
+ * @ingroup clock_control_bflb
+ */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_BFLB_COMMON_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_BFLB_COMMON_H_
 
-/* Common main clock mux (clock_bflb_set_root_clock) */
-/* XCLK is RC32M, main clock is XCLK */
-#define BFLB_MAIN_CLOCK_RC32M     0
-/* XCLK is Crystal, main clock is XCLK */
-#define BFLB_MAIN_CLOCK_XTAL      1
-/* XCLK is RC32M, main clock is PLL */
-#define BFLB_MAIN_CLOCK_PLL_RC32M 2
-/* XCLK is Crystal, main clock is PLL */
-#define BFLB_MAIN_CLOCK_PLL_XTAL  3
+/**
+ * @defgroup clock_control_bflb Bouffalo Lab
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
 
-/* Function that busy waits for a few cycles */
+/** @name Main clock mux selections (see clock_bflb_set_root_clock()) */
+/** @{ */
+/** XCLK is RC32M, main clock is XCLK. */
+#define BFLB_MAIN_CLOCK_RC32M     0
+/** XCLK is the crystal, main clock is XCLK. */
+#define BFLB_MAIN_CLOCK_XTAL      1
+/** XCLK is RC32M, main clock is the PLL. */
+#define BFLB_MAIN_CLOCK_PLL_RC32M 2
+/** XCLK is the crystal, main clock is the PLL. */
+#define BFLB_MAIN_CLOCK_PLL_XTAL  3
+/** @} */
+
+/** @brief Busy-wait for a few CPU cycles to let a clock change settle. */
 static inline void clock_bflb_settle(void)
 {
 	__asm__ volatile (".rept 20 ; nop ; .endr");
 }
 
+/**
+ * @brief Select the root (main) clock source.
+ *
+ * @param clock One of the @c BFLB_MAIN_CLOCK_* selections. Out-of-range values fall back to
+ *              @ref BFLB_MAIN_CLOCK_RC32M.
+ */
 static inline void clock_bflb_set_root_clock(uint32_t clock)
 {
 	uint32_t tmp;
@@ -40,6 +58,11 @@ static inline void clock_bflb_set_root_clock(uint32_t clock)
 	clock_bflb_settle();
 }
 
+/**
+ * @brief Get the currently selected root (main) clock source.
+ *
+ * @return One of the @c BFLB_MAIN_CLOCK_* selections.
+ */
 static inline uint32_t clock_bflb_get_root_clock(void)
 {
 	uint32_t tmp;
@@ -56,5 +79,7 @@ static inline uint32_t clock_bflb_get_root_clock(void)
 	(((uint64_t)(_value) * (uint64_t)(_top)) / (uint64_t)(_base))
 
 /** @endcond */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_BFLB_COMMON_H_ */

--- a/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
+++ b/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
@@ -5,8 +5,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock control definitions for Infineon CAT1 (PSoC 6 family) devices.
+ * @ingroup clock_control_ifx_cat1
+ */
+
 #include <cy_sysclk.h>
 #include <cy_systick.h>
+
+/**
+ * @defgroup clock_control_ifx_cat1 Infineon CAT1
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 #define IFX_CAT1_PERIPHERAL_GROUP_GET_DIVIDER_TYPE(block) ((cy_en_divider_types_t)((block) & 0x03))
 
@@ -43,22 +57,27 @@
 		IFX_CAT1_PERIPHERAL_GROUP_ADJUST((instance), (gr), CY_SYSCLK_DIV_24_5_BIT)
 #endif
 
-/* High frequency clock indices. */
-#define CLK_HF0  (0U)
-#define CLK_HF1  (1U)
-#define CLK_HF2  (2U)
-#define CLK_HF3  (3U)
-#define CLK_HF4  (4U)
-#define CLK_HF5  (5U)
-#define CLK_HF6  (6U)
-#define CLK_HF7  (7U)
-#define CLK_HF8  (8U)
-#define CLK_HF9  (9U)
-#define CLK_HF10 (10U)
-#define CLK_HF11 (11U)
-#define CLK_HF12 (12U)
-#define CLK_HF13 (13U)
+/** @endcond */
 
+/** @name High frequency (HF) clock indices */
+/** @{ */
+#define CLK_HF0  (0U)  /**< HF clock 0. */
+#define CLK_HF1  (1U)  /**< HF clock 1. */
+#define CLK_HF2  (2U)  /**< HF clock 2. */
+#define CLK_HF3  (3U)  /**< HF clock 3. */
+#define CLK_HF4  (4U)  /**< HF clock 4. */
+#define CLK_HF5  (5U)  /**< HF clock 5. */
+#define CLK_HF6  (6U)  /**< HF clock 6. */
+#define CLK_HF7  (7U)  /**< HF clock 7. */
+#define CLK_HF8  (8U)  /**< HF clock 8. */
+#define CLK_HF9  (9U)  /**< HF clock 9. */
+#define CLK_HF10 (10U) /**< HF clock 10. */
+#define CLK_HF11 (11U) /**< HF clock 11. */
+#define CLK_HF12 (12U) /**< HF clock 12. */
+#define CLK_HF13 (13U) /**< HF clock 13. */
+/** @} */
+
+/** @brief CAT1 clock block (source or domain) selector. */
 enum ifx_cat1_clock_block {
 #if defined(CONFIG_SOC_FAMILY_INFINEON_CAT1A)
 	/* The first four items are here for backwards compatibility with old clock APIs */
@@ -381,18 +400,20 @@ enum ifx_cat1_clock_block {
 #endif
 };
 
+/** @brief CAT1 clock descriptor. */
 struct ifx_cat1_clock {
-	enum ifx_cat1_clock_block block; /*!< Clock block type */
-	uint8_t channel;                 /*!< Clock channel number */
-	uint8_t instance;                /*!< Peripheral clock instance number */
-	uint8_t group;                   /*!< Peripheral clock group number */
-	bool reserved;                   /*!< Reserved for future use */
-	const void *funcs;               /*!< Clock-specific functions */
+	enum ifx_cat1_clock_block block; /**< Clock block type. */
+	uint8_t channel;                 /**< Clock channel number. */
+	uint8_t instance;                /**< Peripheral clock instance number. */
+	uint8_t group;                   /**< Peripheral clock group number. */
+	bool reserved;                   /**< Reserved for future use. */
+	const void *funcs;               /**< Clock-specific functions. */
 };
 
+/** @brief CAT1 resource instance descriptor. */
 struct ifx_cat1_resource_inst {
-	uint8_t type;      /* !< The resource block type */
-	uint8_t block_num; /* !< The resource block index */
+	uint8_t type;      /**< The resource block type. */
+	uint8_t block_num; /**< The resource block index. */
 	/**
 	 * The channel number, if the resource type defines multiple channels
 	 * per block instance. Otherwise, 0
@@ -400,8 +421,24 @@ struct ifx_cat1_resource_inst {
 	uint8_t channel_num;
 };
 
+/**
+ * @brief Get the frequency of a clock identified by its Devicetree ordinal.
+ *
+ * @param dt_ord Devicetree ordinal (dependency ordinal) of the clock node.
+ * @param[out] frequency Resulting clock frequency, in Hz.
+ *
+ * @retval 0 on success.
+ * @retval -errno Negative error code on failure.
+ */
 int ifx_cat1_clock_control_get_frequency(uint32_t dt_ord, uint32_t *frequency);
 
+/**
+ * @brief Get the frequency of a peripheral clock divider.
+ *
+ * @param clk_dest Peripheral clock destination.
+ * @param _clock Clock descriptor.
+ * @return Clock frequency, in Hz.
+ */
 static inline uint32_t ifx_cat1_utils_peri_pclk_get_frequency(en_clk_dst_t clk_dest,
 							      const struct ifx_cat1_clock *_clock)
 {
@@ -416,6 +453,13 @@ static inline uint32_t ifx_cat1_utils_peri_pclk_get_frequency(en_clk_dst_t clk_d
 #endif
 }
 
+/**
+ * @brief Enable the divider associated with a peripheral clock.
+ *
+ * @param clk_dest Peripheral clock destination.
+ * @param _clock Clock descriptor.
+ * @return Result code from the underlying PDL call.
+ */
 static inline cy_rslt_t ifx_cat1_utils_peri_pclk_enable_divider(en_clk_dst_t clk_dest,
 								const struct ifx_cat1_clock *_clock)
 {
@@ -430,6 +474,14 @@ static inline cy_rslt_t ifx_cat1_utils_peri_pclk_enable_divider(en_clk_dst_t clk
 #endif
 }
 
+/**
+ * @brief Set the integer divider for a peripheral clock.
+ *
+ * @param clk_dest Peripheral clock destination.
+ * @param _clock Clock descriptor.
+ * @param div Integer divider value.
+ * @return Result code from the underlying PDL call.
+ */
 static inline cy_rslt_t ifx_cat1_utils_peri_pclk_set_divider(en_clk_dst_t clk_dest,
 							     const struct ifx_cat1_clock *_clock,
 							     uint32_t div)
@@ -445,6 +497,15 @@ static inline cy_rslt_t ifx_cat1_utils_peri_pclk_set_divider(en_clk_dst_t clk_de
 #endif
 }
 
+/**
+ * @brief Set the fractional divider for a peripheral clock.
+ *
+ * @param clk_dest Peripheral clock destination.
+ * @param _clock Clock descriptor.
+ * @param div_int Integer part of the divider.
+ * @param div_frac Fractional part of the divider.
+ * @return Result code from the underlying PDL call.
+ */
 static inline cy_rslt_t
 ifx_cat1_utils_peri_pclk_set_frac_divider(en_clk_dst_t clk_dest,
 					  const struct ifx_cat1_clock *_clock, uint32_t div_int,
@@ -462,6 +523,13 @@ ifx_cat1_utils_peri_pclk_set_frac_divider(en_clk_dst_t clk_dest,
 #endif
 }
 
+/**
+ * @brief Assign a divider to a peripheral clock destination.
+ *
+ * @param clk_dest Peripheral clock destination.
+ * @param _clock Clock descriptor.
+ * @return Result code from the underlying PDL call.
+ */
 static inline cy_rslt_t ifx_cat1_utils_peri_pclk_assign_divider(en_clk_dst_t clk_dest,
 								const struct ifx_cat1_clock *_clock)
 {
@@ -576,3 +644,5 @@ static inline uint8_t ifx_cat1_utils_peri_pclk_get_hfclk(uint8_t peri_group)
 	return -EINVAL;
 }
 #endif
+
+/** @} */

--- a/include/zephyr/drivers/clock_control/clock_control_litex.h
+++ b/include/zephyr/drivers/clock_control/clock_control_litex.h
@@ -6,39 +6,34 @@
 
 /**
  * @file
- * @brief LiteX Clock Control driver interface
+ * @brief Clock control helpers for LiteX MMCM clock generators.
+ * @ingroup clock_control_litex
  */
 
 #ifndef CLK_CTRL_LITEX_H
 #define CLK_CTRL_LITEX_H
 
 /**
- * @brief LiteX Clock Control driver interface
- * @defgroup clock_control_litex_interface LiteX Clock Control driver interface
- * @brief LiteX Clock Control driver interface
- * @ingroup clock_control_interface
+ * @defgroup clock_control_litex LiteX
+ * @ingroup clock_control_interface_ext
  * @{
  */
 
 #include <zephyr/types.h>
 
+/** @brief Devicetree node identifier of the LiteX MMCM clock generator. */
 #define MMCM			DT_NODELABEL(clock0)
+/** @brief Number of clock outputs provided by the MMCM. */
 #define NCLKOUT			DT_PROP_LEN(MMCM, clock_output_names)
 
 /**
- * @brief Structure for interfacing with clock control API
- *
- * @param clkout_nr Number of clock output to be changed
- * @param rate Frequency to set given in Hz
- * @param phase Phase offset in degrees
- * @param duty Duty cycle of clock signal in percent
- *
+ * @brief Configuration for a single MMCM clock output.
  */
 struct litex_clk_setup {
-	uint8_t clkout_nr;
-	uint32_t rate;
-	uint16_t phase;
-	uint8_t duty;
+	uint8_t clkout_nr; /**< Index of the clock output to configure. */
+	uint32_t rate;     /**< Frequency to set, in Hz. */
+	uint16_t phase;    /**< Phase offset, in degrees. */
+	uint8_t duty;      /**< Duty cycle of the clock signal, in percent. */
 };
 
 /**

--- a/include/zephyr/drivers/clock_control/clock_control_numaker.h
+++ b/include/zephyr/drivers/clock_control/clock_control_numaker.h
@@ -4,69 +4,73 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock control definitions for Nuvoton NuMaker devices.
+ * @ingroup clock_control_numaker
+ */
+
 #include <stdint.h>
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NUMAKER_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NUMAKER_H_
 
 /**
- * @brief Enable/disable oscillators or other clocks
+ * @defgroup clock_control_numaker Nuvoton NuMaker
+ * @ingroup clock_control_interface_ext
+ * @{
  */
-#define NUMAKER_SCC_CLKSW_UNTOUCHED 0
-#define NUMAKER_SCC_CLKSW_ENABLE    1
-#define NUMAKER_SCC_CLKSW_DISABLE   2
 
-/**
- * @brief SCC subsystem ID
- */
+/** @name Oscillator/clock switch actions */
+/** @{ */
+#define NUMAKER_SCC_CLKSW_UNTOUCHED 0 /**< Leave the clock switch unchanged. */
+#define NUMAKER_SCC_CLKSW_ENABLE    1 /**< Enable the oscillator/clock. */
+#define NUMAKER_SCC_CLKSW_DISABLE   2 /**< Disable the oscillator/clock. */
+/** @} */
+
+/** @brief SCC subsystem ID for peripheral clock control (PCC). */
 #define NUMAKER_SCC_SUBSYS_ID_PCC 1
 
-/* Peripheral clock control configuration structure
- *
- * clk_modidx is virtual of u32ModuleIdx/u64ModuleIdx in BSP CLK_SetModuleClock().
- * clk_src is same as u32ClkSrc in BSP CLK_SetModuleClock().
- * clk_div is same as u32ClkDiv in BSP CLK_SetModuleClock().
- */
+/** @brief Peripheral clock control configuration. */
 struct numaker_scc_subsys_pcc {
+	/** @brief Module index (u32ModuleIdx/u64ModuleIdx in BSP CLK_SetModuleClock()). */
 	uint32_t clk_modidx;
+	/** @brief Clock source (u32ClkSrc in BSP CLK_SetModuleClock()). */
 	uint32_t clk_src;
+	/** @brief Clock divider (u32ClkDiv in BSP CLK_SetModuleClock()). */
 	uint32_t clk_div;
 };
 
-/* Peripheral clock control rate structure
- *
- * clk_modidx_real is real of u32ModuleIdx/u64ModuleIdx in BSP CLK_SetModuleClock().
- * clk_src_idx is decoded clock source index of clk_src.
- * clk_src_rate is clock source rate of clk_src_idx.
- * clk_div_value is decoded clock divider value of clk_div.
- * clk_div_value_max is supported maximum divider value of clk_div_value.
- * clk_mod_rate is module rate.
- */
+/** @brief Peripheral clock control rate information. */
 struct numaker_scc_subsys_pcc_rate {
 #if defined(CONFIG_SOC_SERIES_M55M1X)
-	uint64_t clk_modidx_real;
+	uint64_t clk_modidx_real; /**< Resolved module index. */
 #else
-	uint32_t clk_modidx_real;
+	uint32_t clk_modidx_real; /**< Resolved module index. */
 #endif
-	uint32_t clk_src_idx;
-	uint32_t clk_src_rate;
-	uint32_t clk_div_value;
-	uint32_t clk_div_value_max;
-	uint32_t clk_mod_rate;
+	uint32_t clk_src_idx;       /**< Decoded clock source index of @c clk_src. */
+	uint32_t clk_src_rate;      /**< Clock source rate, in Hz. */
+	uint32_t clk_div_value;     /**< Decoded clock divider value. */
+	uint32_t clk_div_value_max; /**< Maximum supported divider value. */
+	uint32_t clk_mod_rate;      /**< Resulting module clock rate, in Hz. */
 };
 
+/** @brief NuMaker clock subsystem selector. */
 struct numaker_scc_subsys {
-	uint32_t subsys_id; /* SCC subsystem ID */
+	uint32_t subsys_id; /**< SCC subsystem ID (see @ref NUMAKER_SCC_SUBSYS_ID_PCC). */
 
 	union {
-		struct numaker_scc_subsys_pcc pcc;
+		struct numaker_scc_subsys_pcc pcc; /**< Peripheral clock configuration. */
 	};
 };
 
+/** @brief NuMaker clock subsystem rate selector. */
 struct numaker_scc_subsys_rate {
 	union {
-		struct numaker_scc_subsys_pcc_rate pcc;
+		struct numaker_scc_subsys_pcc_rate pcc; /**< Peripheral clock rate information. */
 	};
 };
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NUMAKER_H_ */

--- a/include/zephyr/drivers/clock_control/clock_control_numicro.h
+++ b/include/zephyr/drivers/clock_control/clock_control_numicro.h
@@ -7,19 +7,24 @@
 #include <stdint.h>
 
 /**
- * @file clock_control_numicro.h
- * @brief Clock control header file for Nuvoton Numicro family.
+ * @file
+ * @brief Clock control header file for the Nuvoton NuMicro family.
  *
  * This file provides clock driver interface definitions and structures
- * fur Nuvoton Numicro family.
+ * for the Nuvoton NuMicro family.
+ * @ingroup clock_control_numicro
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVER_CLOCK_CONTROL_NUMICRO_H_
 #define ZEPHYR_INCLUDE_DRIVER_CLOCK_CONTROL_NUMICRO_H_
 
 /**
- * @brief SCC Subsystem ID
+ * @defgroup clock_control_numicro Nuvoton NuMicro
+ * @ingroup clock_control_interface_ext
+ * @{
  */
+
+/** @brief SCC subsystem ID for peripheral clock control (PCC). */
 #define NUMICRO_SCC_SUBSYS_ID_PCC 1
 
 /** @brief Peripheral clock control configuration structure */
@@ -58,5 +63,7 @@ struct numicro_scc_subsys {
 
 /** @brief Create Numicro peripheral clock subsystem configuration from device tree */
 #define DT_NUMICRO_CLOCK_PCC_SUBSYSTEM_INST(inst) DT_NUMICRO_CLOCK_PCC_SUBSYSTEM(DT_DRV_INST(inst))
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVER_CLOCK_CONTROL_NUMICRO_H_ */

--- a/include/zephyr/drivers/clock_control/clock_control_rts5912.h
+++ b/include/zephyr/drivers/clock_control/clock_control_rts5912.h
@@ -5,16 +5,31 @@
  * Author: Lin Yu-Cheng <lin_yu_cheng@realtek.com>
  */
 
+/**
+ * @file
+ * @brief Clock control definitions for Realtek RTS5912 devices.
+ * @ingroup clock_control_rts5912
+ */
+
 #include <stdint.h>
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RTS5912_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RTS5912_H_
 
+/**
+ * @defgroup clock_control_rts5912 Realtek RTS5912
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
+
+/** @brief RTS5912 system clock controller (SCCON) subsystem selector. */
 struct rts5912_sccon_subsys {
-	uint32_t clk_grp;
-	uint32_t clk_idx;
-	uint32_t clk_src;
-	uint32_t clk_div;
+	uint32_t clk_grp; /**< Clock group. */
+	uint32_t clk_idx; /**< Clock index within the group. */
+	uint32_t clk_src; /**< Clock source. */
+	uint32_t clk_div; /**< Clock divider. */
 };
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RTS591X_H_ */
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RTS5912_H_ */

--- a/include/zephyr/drivers/clock_control/clock_control_silabs.h
+++ b/include/zephyr/drivers/clock_control/clock_control_silabs.h
@@ -4,10 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock control definitions for Silicon Labs devices.
+ * @ingroup clock_control_silabs
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_SILABS_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_SILABS_H_
 
 #include <zephyr/drivers/clock_control.h>
+
+/**
+ * @defgroup clock_control_silabs Silicon Labs
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
 
 #if defined(CONFIG_SOC_SILABS_XG21)
 #include <zephyr/dt-bindings/clock/silabs/xg21-clock.h>
@@ -27,21 +39,34 @@
 #include <zephyr/dt-bindings/clock/silabs/xg29-clock.h>
 #endif
 
+/** @brief Clock Management Unit (CMU) clock configuration for a peripheral. */
 struct silabs_clock_control_cmu_config {
-	uint32_t bus_clock;
-	uint8_t branch;
+	uint32_t bus_clock; /**< Bus clock enable identifier. */
+	uint8_t branch;     /**< Clock branch the peripheral is sourced from. */
 };
 
+/**
+ * @brief Initialize a @ref silabs_clock_control_cmu_config from a DT node.
+ *
+ * @param node_id Devicetree node identifier with a @c clocks property.
+ */
 #define SILABS_DT_CLOCK_CFG(node_id)                                                               \
 	{                                                                                          \
 		.bus_clock = DT_CLOCKS_CELL(node_id, enable),                                      \
 		.branch = DT_CLOCKS_CELL(node_id, branch),                                         \
 	}
 
+/**
+ * @brief Equivalent to SILABS_DT_CLOCK_CFG() for a DT instance.
+ *
+ * @param inst DT instance number.
+ */
 #define SILABS_DT_INST_CLOCK_CFG(inst)                                                             \
 	{                                                                                          \
 		.bus_clock = DT_INST_CLOCKS_CELL(inst, enable),                                    \
 		.branch = DT_INST_CLOCKS_CELL(inst, branch),                                       \
 	}
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_SILABS_H_ */

--- a/include/zephyr/drivers/clock_control/esp32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/esp32_clock_control.h
@@ -4,8 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock control definitions for Espressif ESP32 devices.
+ * @ingroup clock_control_esp32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ESP32_CLOCK_CONTROL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ESP32_CLOCK_CONTROL_H_
+
+/**
+ * @defgroup clock_control_esp32 Espressif ESP32
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
 
 #if defined(CONFIG_SOC_SERIES_ESP32)
 #include <zephyr/dt-bindings/clock/esp32_clock.h>
@@ -27,26 +39,34 @@
 #include <zephyr/dt-bindings/clock/esp32p4_clock.h>
 #endif /* CONFIG_SOC_SERIES_ESP32xx */
 
-#define ESP32_CLOCK_CONTROL_SUBSYS_CPU 50
-#define ESP32_CLOCK_CONTROL_SUBSYS_RTC_FAST 51
-#define ESP32_CLOCK_CONTROL_SUBSYS_RTC_SLOW 52
-#define ESP32_CLOCK_CONTROL_SUBSYS_RTC_FAST_NOMINAL 53
-#define ESP32_CLOCK_CONTROL_SUBSYS_RTC_SLOW_NOMINAL 54
+/** @name ESP32 clock control subsystem identifiers */
+/** @{ */
+#define ESP32_CLOCK_CONTROL_SUBSYS_CPU 50              /**< CPU clock. */
+#define ESP32_CLOCK_CONTROL_SUBSYS_RTC_FAST 51         /**< RTC fast clock. */
+#define ESP32_CLOCK_CONTROL_SUBSYS_RTC_SLOW 52         /**< RTC slow clock. */
+#define ESP32_CLOCK_CONTROL_SUBSYS_RTC_FAST_NOMINAL 53 /**< RTC fast clock at nominal rate. */
+#define ESP32_CLOCK_CONTROL_SUBSYS_RTC_SLOW_NOMINAL 54 /**< RTC slow clock at nominal rate. */
+/** @} */
 
+/** @brief ESP32 CPU clock configuration. */
 struct esp32_cpu_clock_config {
-	int clk_src;
-	uint32_t cpu_freq;
-	uint32_t xtal_freq;
+	int clk_src;        /**< CPU clock source. */
+	uint32_t cpu_freq;  /**< Target CPU frequency, in MHz. */
+	uint32_t xtal_freq; /**< External crystal frequency, in MHz. */
 };
 
+/** @brief ESP32 RTC clock configuration. */
 struct esp32_rtc_clock_config {
-	uint32_t rtc_fast_clock_src;
-	uint32_t rtc_slow_clock_src;
+	uint32_t rtc_fast_clock_src; /**< RTC fast clock source. */
+	uint32_t rtc_slow_clock_src; /**< RTC slow clock source. */
 };
 
+/** @brief ESP32 aggregate clock configuration. */
 struct esp32_clock_config {
-	struct esp32_cpu_clock_config cpu;
-	struct esp32_rtc_clock_config rtc;
+	struct esp32_cpu_clock_config cpu; /**< CPU clock configuration. */
+	struct esp32_rtc_clock_config rtc; /**< RTC clock configuration. */
 };
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ESP32_CLOCK_CONTROL_H_ */

--- a/include/zephyr/drivers/clock_control/gd32.h
+++ b/include/zephyr/drivers/clock_control/gd32.h
@@ -4,10 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock control definitions for GigaDevice GD32 devices.
+ * @ingroup clock_control_gd32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_GD32_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_GD32_H_
 
 #include <zephyr/device.h>
+
+/**
+ * @defgroup clock_control_gd32 GigaDevice GD32
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
 
 /**
  * @brief Obtain a reference to the GD32 clock controller.
@@ -17,5 +29,7 @@
  * code subject to failures.
  */
 #define GD32_CLOCK_CONTROLLER DEVICE_DT_GET(DT_NODELABEL(cctl))
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_GD32_H_ */

--- a/include/zephyr/drivers/clock_control/lpc11u6x_clock_control.h
+++ b/include/zephyr/drivers/clock_control/lpc11u6x_clock_control.h
@@ -3,10 +3,27 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Clock control definitions for NXP LPC11U6x devices.
+ *
+ * This header pulls in the LPC11U6x clock Devicetree bindings.
+ * @ingroup clock_control_lpc11u6x
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_LPC11U6X_CLOCK_CONTROL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_LPC11U6X_CLOCK_CONTROL_H_
 
+/**
+ * @defgroup clock_control_lpc11u6x NXP LPC11U6x
+ * @ingroup clock_control_nxp
+ * @{
+ */
+
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/lpc11u6x_clock.h>
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_LPC11U6X_CLOCK_CONTROL_H_ */

--- a/include/zephyr/drivers/clock_control/mchp_clock_control.h
+++ b/include/zephyr/drivers/clock_control/mchp_clock_control.h
@@ -5,15 +5,22 @@
  */
 
 /**
- * @file mchp_clock_control.h
- * @brief Clock control header file for Microchip soc devices.
+ * @file
+ * @brief Clock control header file for Microchip SoC devices.
  *
- * This file provides clock driver interface definitions and structures
- * for microchip soc families
+ * This header selects the SoC-family-specific Microchip clock definitions based on the
+ * active Kconfig selection.
+ * @ingroup clock_control_mchp
  */
 
 #ifndef INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_CONTROL_H_
 #define INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_CONTROL_H_
+
+/**
+ * @defgroup clock_control_mchp Microchip
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/clock_control.h>
@@ -33,5 +40,7 @@
 #if CONFIG_CLOCK_CONTROL_MCHP_PIC32CZ_CA
 #include <zephyr/drivers/clock_control/mchp_clock_pic32cz_ca.h>
 #endif /* CONFIG_CLOCK_CONTROL_MCHP_PIC32CZ_CA */
+
+/** @} */
 
 #endif /* INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_CONTROL_H_ */

--- a/include/zephyr/drivers/clock_control/mchp_clock_pic32cm_jh.h
+++ b/include/zephyr/drivers/clock_control/mchp_clock_pic32cm_jh.h
@@ -5,11 +5,12 @@
  */
 
 /**
- * @file mchp_clock_pic32cm_jh.h
- * @brief Clock control header file for Microchip pic32cm_jh family.
+ * @file
+ * @brief Clock control header file for the Microchip PIC32CM JH family.
  *
  * This file provides clock driver interface definitions and structures
- * for pic32cm_jh family
+ * for the PIC32CM JH family.
+ * @ingroup clock_control_mchp_pic32cm_jh
  */
 
 #ifndef INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_PIC32CM_JH_H_
@@ -17,183 +18,205 @@
 
 #include <zephyr/dt-bindings/clock/mchp_pic32cm_jh_clock.h>
 
+/**
+ * @defgroup clock_control_mchp_pic32cm_jh Microchip PIC32CM JH
+ * @ingroup clock_control_mchp
+ * @{
+ */
+
+/** @brief External oscillator (XOSC) configuration. */
 struct clock_mchp_subsys_xosc_config {
-	/** @brief configure oscillator to ON, when a peripheral is requesting it as a source */
+	/** @brief Turn the oscillator ON when a peripheral requests it as a source. */
 	bool on_demand_en;
 
-	/** @brief configure oscillator to ON in standby sleep mode, unless on_demand_en is set */
+	/** @brief Keep the oscillator ON in standby sleep mode, unless on_demand_en is set. */
 	bool run_in_standby_en;
 };
 
-/** @brief Control the oscillator frequency range by adjusting the division ratio */
+/** @brief Control the OSC48M oscillator frequency range by adjusting the division ratio. */
 enum clock_mchp_osc48m_divider_freq {
-	CLOCK_MCHP_DIVIDER_48_MHZ,
-	CLOCK_MCHP_DIVIDER_24_MHZ,
-	CLOCK_MCHP_DIVIDER_16_MHZ,
-	CLOCK_MCHP_DIVIDER_12_MHZ,
-	CLOCK_MCHP_DIVIDER_9_6_MHZ,
-	CLOCK_MCHP_DIVIDER_8_MHZ,
-	CLOCK_MCHP_DIVIDER_6_86_MHZ,
-	CLOCK_MCHP_DIVIDER_6_MHZ,
-	CLOCK_MCHP_DIVIDER_5_33_MHZ,
-	CLOCK_MCHP_DIVIDER_4_8_MHZ,
-	CLOCK_MCHP_DIVIDER_4_36_MHZ,
-	CLOCK_MCHP_DIVIDER_4_MHZ,
-	CLOCK_MCHP_DIVIDER_3_69_MHZ,
-	CLOCK_MCHP_DIVIDER_3_43_MHZ,
-	CLOCK_MCHP_DIVIDER_3_2_MHZ,
-	CLOCK_MCHP_DIVIDER_3_MHZ
+	CLOCK_MCHP_DIVIDER_48_MHZ,   /**< 48 MHz output. */
+	CLOCK_MCHP_DIVIDER_24_MHZ,   /**< 24 MHz output. */
+	CLOCK_MCHP_DIVIDER_16_MHZ,   /**< 16 MHz output. */
+	CLOCK_MCHP_DIVIDER_12_MHZ,   /**< 12 MHz output. */
+	CLOCK_MCHP_DIVIDER_9_6_MHZ,  /**< 9.6 MHz output. */
+	CLOCK_MCHP_DIVIDER_8_MHZ,    /**< 8 MHz output. */
+	CLOCK_MCHP_DIVIDER_6_86_MHZ, /**< 6.86 MHz output. */
+	CLOCK_MCHP_DIVIDER_6_MHZ,    /**< 6 MHz output. */
+	CLOCK_MCHP_DIVIDER_5_33_MHZ, /**< 5.33 MHz output. */
+	CLOCK_MCHP_DIVIDER_4_8_MHZ,  /**< 4.8 MHz output. */
+	CLOCK_MCHP_DIVIDER_4_36_MHZ, /**< 4.36 MHz output. */
+	CLOCK_MCHP_DIVIDER_4_MHZ,    /**< 4 MHz output. */
+	CLOCK_MCHP_DIVIDER_3_69_MHZ, /**< 3.69 MHz output. */
+	CLOCK_MCHP_DIVIDER_3_43_MHZ, /**< 3.43 MHz output. */
+	CLOCK_MCHP_DIVIDER_3_2_MHZ,  /**< 3.2 MHz output. */
+	CLOCK_MCHP_DIVIDER_3_MHZ     /**< 3 MHz output. */
 };
 
+/** @brief Internal 48 MHz oscillator (OSC48M) configuration. */
 struct clock_mchp_subsys_osc48m_config {
-	/** @brief configure oscillator to ON, when a peripheral is requesting it as a source */
+	/** @brief Turn the oscillator ON when a peripheral requests it as a source. */
 	bool on_demand_en;
 
-	/** @brief configure oscillator to ON in standby sleep mode, unless on_demand_en is set */
+	/** @brief Keep the oscillator ON in standby sleep mode, unless on_demand_en is set. */
 	bool run_in_standby_en;
 
-	/** @brief Control the oscillator frequency range by adjusting the division ratio */
+	/** @brief Control the oscillator frequency range by adjusting the division ratio. */
 	enum clock_mchp_osc48m_divider_freq post_divider_freq;
 };
 
-/** @brief FDPLL source clocks */
+/** @brief FDPLL source clocks. */
 enum clock_mchp_fdpll_src_clock {
-	CLOCK_MCHP_FDPLL_SRC_GCLK0,
-	CLOCK_MCHP_FDPLL_SRC_GCLK1,
-	CLOCK_MCHP_FDPLL_SRC_GCLK2,
-	CLOCK_MCHP_FDPLL_SRC_GCLK3,
-	CLOCK_MCHP_FDPLL_SRC_GCLK4,
-	CLOCK_MCHP_FDPLL_SRC_GCLK5,
-	CLOCK_MCHP_FDPLL_SRC_GCLK6,
-	CLOCK_MCHP_FDPLL_SRC_GCLK7,
-	CLOCK_MCHP_FDPLL_SRC_GCLK8,
-	CLOCK_MCHP_FDPLL_SRC_XOSC32K,
-	CLOCK_MCHP_FDPLL_SRC_XOSC,
+	CLOCK_MCHP_FDPLL_SRC_GCLK0,   /**< GCLK generator 0. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK1,   /**< GCLK generator 1. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK2,   /**< GCLK generator 2. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK3,   /**< GCLK generator 3. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK4,   /**< GCLK generator 4. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK5,   /**< GCLK generator 5. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK6,   /**< GCLK generator 6. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK7,   /**< GCLK generator 7. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK8,   /**< GCLK generator 8. */
+	CLOCK_MCHP_FDPLL_SRC_XOSC32K, /**< 32 kHz external oscillator. */
+	CLOCK_MCHP_FDPLL_SRC_XOSC,    /**< External oscillator. */
 
-	CLOCK_MCHP_FDPLL_SRC_MAX = CLOCK_MCHP_FDPLL_SRC_XOSC
+	CLOCK_MCHP_FDPLL_SRC_MAX = CLOCK_MCHP_FDPLL_SRC_XOSC /**< Highest valid source. */
 };
 
+/** @brief Fractional DPLL (FDPLL) configuration. */
 struct clock_mchp_subsys_fdpll_config {
-	/** @brief configure oscillator to ON, when a peripheral is requesting it as a source */
+	/** @brief Turn the oscillator ON when a peripheral requests it as a source. */
 	bool on_demand_en;
 
-	/** @brief configure oscillator to ON in standby sleep mode, unless on_demand_en is set */
+	/** @brief Keep the oscillator ON in standby sleep mode, unless on_demand_en is set. */
 	bool run_in_standby_en;
 
-	/** @brief Set the fractional part of the frequency multiplier. (0 - 31) */
+	/** @brief Fractional part of the frequency multiplier (0 - 31). */
 	uint32_t divider_ratio_frac;
 
-	/** @brief Set the integer part of the frequency multiplier. (0 - 4095) */
+	/** @brief Integer part of the frequency multiplier (0 - 4095). */
 	uint32_t divider_ratio_int;
 
-	/** @brief Set the XOSC clock division factor (0 - 2047) */
+	/** @brief XOSC clock division factor (0 - 2047). */
 	uint32_t xosc_clock_divider;
 
-	/** @brief Reference source clock selection */
+	/** @brief Reference source clock selection. */
 	enum clock_mchp_fdpll_src_clock src;
 };
 
-/** @brief RTC source clocks */
+/** @brief RTC source clocks. */
 enum clock_mchp_rtc_src_clock {
+	/** Ultra-low-power 1 kHz. */
 	CLOCK_MCHP_RTC_SRC_ULP1K = OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K,
+	/** Ultra-low-power 32 kHz. */
 	CLOCK_MCHP_RTC_SRC_ULP32K = OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K,
+	/** Internal 1 kHz. */
 	CLOCK_MCHP_RTC_SRC_OSC1K = OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K,
+	/** Internal 32 kHz. */
 	CLOCK_MCHP_RTC_SRC_OSC32K = OSC32KCTRL_RTCCTRL_RTCSEL_OSC32K,
+	/** External 1 kHz. */
 	CLOCK_MCHP_RTC_SRC_XOSC1K = OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K,
+	/** External 32 kHz. */
 	CLOCK_MCHP_RTC_SRC_XOSC32K = OSC32KCTRL_RTCCTRL_RTCSEL_XOSC32K
 };
 
+/** @brief RTC clock configuration. */
 struct clock_mchp_subsys_rtc_config {
-	/** @brief RTC source clock selection */
+	/** @brief RTC source clock selection. */
 	enum clock_mchp_rtc_src_clock src;
 };
 
+/** @brief 32 kHz external oscillator (XOSC32K) configuration. */
 struct clock_mchp_subsys_xosc32k_config {
-	/** @brief configure oscillator to ON, when a peripheral is requesting it as a source */
+	/** @brief Turn the oscillator ON when a peripheral requests it as a source. */
 	bool on_demand_en;
 
-	/** @brief configure oscillator to ON in standby sleep mode, unless on_demand_en is set */
+	/** @brief Keep the oscillator ON in standby sleep mode, unless on_demand_en is set. */
 	bool run_in_standby_en;
 };
 
+/** @brief 32 kHz internal oscillator (OSC32K) configuration. */
 struct clock_mchp_subsys_osc32k_config {
-	/** @brief configure oscillator to ON, when a peripheral is requesting it as a source */
+	/** @brief Turn the oscillator ON when a peripheral requests it as a source. */
 	bool on_demand_en;
 
-	/** @brief configure oscillator to ON in standby sleep mode, unless on_demand_en is set */
+	/** @brief Keep the oscillator ON in standby sleep mode, unless on_demand_en is set. */
 	bool run_in_standby_en;
 };
 
-/** @brief Gclk Generator source clocks */
+/** @brief GCLK generator source clocks. */
 enum clock_mchp_gclk_src_clock {
-	CLOCK_MCHP_GCLK_SRC_XOSC,
-	CLOCK_MCHP_GCLK_SRC_GCLKPIN,
-	CLOCK_MCHP_GCLK_SRC_GCLKGEN1,
-	CLOCK_MCHP_GCLK_SRC_OSCULP32K,
-	CLOCK_MCHP_GCLK_SRC_OSC32K,
-	CLOCK_MCHP_GCLK_SRC_XOSC32K,
-	CLOCK_MCHP_GCLK_SRC_OSC48M,
-	CLOCK_MCHP_GCLK_SRC_FDPLL,
+	CLOCK_MCHP_GCLK_SRC_XOSC,      /**< External oscillator. */
+	CLOCK_MCHP_GCLK_SRC_GCLKPIN,   /**< GCLK input pin. */
+	CLOCK_MCHP_GCLK_SRC_GCLKGEN1,  /**< GCLK generator 1. */
+	CLOCK_MCHP_GCLK_SRC_OSCULP32K, /**< Ultra-low-power 32 kHz oscillator. */
+	CLOCK_MCHP_GCLK_SRC_OSC32K,    /**< Internal 32 kHz oscillator. */
+	CLOCK_MCHP_GCLK_SRC_XOSC32K,   /**< External 32 kHz oscillator. */
+	CLOCK_MCHP_GCLK_SRC_OSC48M,    /**< Internal 48 MHz oscillator. */
+	CLOCK_MCHP_GCLK_SRC_FDPLL,     /**< Fractional DPLL. */
 
-	CLOCK_MCHP_GCLK_SRC_MAX = CLOCK_MCHP_GCLK_SRC_FDPLL
+	CLOCK_MCHP_GCLK_SRC_MAX = CLOCK_MCHP_GCLK_SRC_FDPLL /**< Highest valid source. */
 };
 
+/** @brief GCLK generator configuration. */
 struct clock_mchp_subsys_gclkgen_config {
-	/** @brief Represent a division value for the corresponding Generator. The actual division
-	 * factor is dependent on the state of div_select (gclk1 0 - 65535, others 0 - 255)
+	/** @brief Division value for the generator. The actual division factor depends on the
+	 * state of div_select (gclk1: 0 - 65535, others: 0 - 255).
 	 */
 	uint16_t div_factor;
 
-	/** @brief configure oscillator to ON in standby sleep mode, unless on_demand_en is set */
+	/** @brief Keep the generator running in standby sleep mode, unless on_demand_en is set. */
 	bool run_in_standby_en;
 
-	/** @brief Generator source clock selection */
+	/** @brief Generator source clock selection. */
 	enum clock_mchp_gclk_src_clock src;
 };
 
-/** @brief GCLK generator numbers */
+/** @brief GCLK generator numbers. */
 enum clock_mchp_gclkgen {
-	CLOCK_MCHP_GCLKGEN_GEN0,
-	CLOCK_MCHP_GCLKGEN_GEN1,
-	CLOCK_MCHP_GCLKGEN_GEN2,
-	CLOCK_MCHP_GCLKGEN_GEN3,
-	CLOCK_MCHP_GCLKGEN_GEN4,
-	CLOCK_MCHP_GCLKGEN_GEN5,
-	CLOCK_MCHP_GCLKGEN_GEN6,
-	CLOCK_MCHP_GCLKGEN_GEN7,
-	CLOCK_MCHP_GCLKGEN_GEN8
+	CLOCK_MCHP_GCLKGEN_GEN0, /**< Generator 0. */
+	CLOCK_MCHP_GCLKGEN_GEN1, /**< Generator 1. */
+	CLOCK_MCHP_GCLKGEN_GEN2, /**< Generator 2. */
+	CLOCK_MCHP_GCLKGEN_GEN3, /**< Generator 3. */
+	CLOCK_MCHP_GCLKGEN_GEN4, /**< Generator 4. */
+	CLOCK_MCHP_GCLKGEN_GEN5, /**< Generator 5. */
+	CLOCK_MCHP_GCLKGEN_GEN6, /**< Generator 6. */
+	CLOCK_MCHP_GCLKGEN_GEN7, /**< Generator 7. */
+	CLOCK_MCHP_GCLKGEN_GEN8  /**< Generator 8. */
 };
 
+/** @brief Peripheral GCLK channel configuration. */
 struct clock_mchp_subsys_gclkperiph_config {
-	/** @brief gclk generator source of a peripheral clock */
+	/** @brief GCLK generator that sources the peripheral clock. */
 	enum clock_mchp_gclkgen src;
 };
 
-/** @brief division ratio of mclk prescaler for CPU */
+/** @brief Division ratio of the MCLK prescaler for the CPU. */
 enum clock_mchp_mclk_cpu_div {
-	CLOCK_MCHP_MCLK_CPU_DIV_1 = 1,
-	CLOCK_MCHP_MCLK_CPU_DIV_2 = 2,
-	CLOCK_MCHP_MCLK_CPU_DIV_4 = 4,
-	CLOCK_MCHP_MCLK_CPU_DIV_8 = 8,
-	CLOCK_MCHP_MCLK_CPU_DIV_16 = 16,
-	CLOCK_MCHP_MCLK_CPU_DIV_32 = 32,
-	CLOCK_MCHP_MCLK_CPU_DIV_64 = 64,
-	CLOCK_MCHP_MCLK_CPU_DIV_128 = 128
+	CLOCK_MCHP_MCLK_CPU_DIV_1 = 1,     /**< Divide by 1. */
+	CLOCK_MCHP_MCLK_CPU_DIV_2 = 2,     /**< Divide by 2. */
+	CLOCK_MCHP_MCLK_CPU_DIV_4 = 4,     /**< Divide by 4. */
+	CLOCK_MCHP_MCLK_CPU_DIV_8 = 8,     /**< Divide by 8. */
+	CLOCK_MCHP_MCLK_CPU_DIV_16 = 16,   /**< Divide by 16. */
+	CLOCK_MCHP_MCLK_CPU_DIV_32 = 32,   /**< Divide by 32. */
+	CLOCK_MCHP_MCLK_CPU_DIV_64 = 64,   /**< Divide by 64. */
+	CLOCK_MCHP_MCLK_CPU_DIV_128 = 128  /**< Divide by 128. */
 };
 
-/** @brief MCLK configuration structure
+/** @brief MCLK configuration structure.
  *
- * Used for CLOCK_MCHP_SUBSYS_TYPE_MCLKCPU
+ * Used for CLOCK_MCHP_SUBSYS_TYPE_MCLKCPU.
  */
 struct clock_mchp_subsys_mclkcpu_config {
-	/** @brief division ratio of mclk prescaler for CPU */
+	/** @brief Division ratio of the MCLK prescaler for the CPU. */
 	enum clock_mchp_mclk_cpu_div division_factor;
 };
 
-/** @brief clock rate datatype
+/** @brief Clock rate datatype.
  *
- * Used for setting a clock rate
+ * Used for setting a clock rate.
  */
 typedef uint32_t *clock_mchp_rate_t;
+
+/** @} */
 
 #endif /* INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_PIC32CM_JH_H_ */

--- a/include/zephyr/drivers/clock_control/mchp_clock_pic32cm_pl.h
+++ b/include/zephyr/drivers/clock_control/mchp_clock_pic32cm_pl.h
@@ -5,17 +5,24 @@
  */
 
 /**
- * @file mchp_clock_pic32cm_pl.h
- * @brief Clock control header file for Microchip pic32cm_pl family.
+ * @file
+ * @brief Clock control header file for the Microchip PIC32CM PL family.
  *
  * This file provides clock driver interface definitions and structures
- * for pic32cm_pl family
+ * for the PIC32CM PL family.
+ * @ingroup clock_control_mchp_pic32cm_pl
  */
 
 #ifndef INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_PIC32CM_PL_H_
 #define INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_PIC32CM_PL_H_
 
 #include <zephyr/dt-bindings/clock/mchp_pic32cm_pl_clock.h>
+
+/**
+ * @defgroup clock_control_mchp_pic32cm_pl Microchip PIC32CM PL
+ * @ingroup clock_control_mchp
+ * @{
+ */
 
 /** @brief OSCHF (high-frequency oscillator) subsystem configuration. */
 struct clock_mchp_subsys_oschf_config {
@@ -82,5 +89,7 @@ enum clock_mchp_gclkgen {
  * Used for setting a clock rate
  */
 typedef uint32_t *clock_mchp_rate_t;
+
+/** @} */
 
 #endif /* INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_PIC32CM_PL_H_ */

--- a/include/zephyr/drivers/clock_control/mchp_clock_pic32cz_ca.h
+++ b/include/zephyr/drivers/clock_control/mchp_clock_pic32cz_ca.h
@@ -5,17 +5,24 @@
  */
 
 /**
- * @file mchp_clock_pic32cz_ca.h
- * @brief Clock control header file for Microchip pic32cz_ca family.
+ * @file
+ * @brief Clock control header file for the Microchip PIC32CZ CA family.
  *
  * This file provides clock driver interface definitions and structures
- * for pic32cz_ca family
+ * for the PIC32CZ CA family.
+ * @ingroup clock_control_mchp_pic32cz_ca
  */
 
 #ifndef INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_PIC32CZ_CA_H_
 #define INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_PIC32CZ_CA_H_
 
 #include <zephyr/dt-bindings/clock/mchp_pic32cz_ca_clock.h>
+
+/**
+ * @defgroup clock_control_mchp_pic32cz_ca Microchip PIC32CZ CA
+ * @ingroup clock_control_mchp
+ * @{
+ */
 
 /** @brief External Crystal Oscillator configuration structure */
 struct clock_mchp_subsys_xosc_config {
@@ -200,5 +207,7 @@ struct clock_mchp_subsys_mclkcpu_config {
  * Used for setting a clock rate
  */
 typedef uint32_t *clock_mchp_rate_t;
+
+/** @} */
 
 #endif /* INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_PIC32CZ_CA_H_ */

--- a/include/zephyr/drivers/clock_control/mchp_clock_sam_d5x_e5x.h
+++ b/include/zephyr/drivers/clock_control/mchp_clock_sam_d5x_e5x.h
@@ -5,11 +5,12 @@
  */
 
 /**
- * @file mchp_clock_sam_d5x_e5x.h
- * @brief Clock control header file for Microchip sam_d5x_e5x family.
+ * @file
+ * @brief Clock control header file for the Microchip SAM D5x/E5x family.
  *
  * This file provides clock driver interface definitions and structures
- * for sam_d5x_e5x family
+ * for the SAM D5x/E5x family.
+ * @ingroup clock_control_mchp_sam_d5x_e5x
  */
 
 #ifndef INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_SAM_D5X_E5X_H_
@@ -17,169 +18,188 @@
 
 #include <zephyr/dt-bindings/clock/mchp_sam_d5x_e5x_clock.h>
 
+/**
+ * @defgroup clock_control_mchp_sam_d5x_e5x Microchip SAM D5x/E5x
+ * @ingroup clock_control_mchp
+ * @{
+ */
+
+/** @brief External oscillator (XOSC) configuration. */
 struct clock_mchp_subsys_xosc_config {
-	/** @brief configure oscillator to ON, when a peripheral is requesting it as a source */
+	/** @brief Turn the oscillator ON when a peripheral requests it as a source. */
 	bool on_demand_en;
 
-	/** @brief configure oscillator to ON in standby sleep mode, unless on_demand_en is set */
+	/** @brief Keep the oscillator ON in standby sleep mode, unless on_demand_en is set. */
 	bool run_in_standby_en;
 };
 
-/** @brief GCLK generator numbers */
+/** @brief GCLK generator numbers. */
 enum clock_mchp_gclkgen {
-	CLOCK_MCHP_GCLKGEN_GEN0,
-	CLOCK_MCHP_GCLKGEN_GEN1,
-	CLOCK_MCHP_GCLKGEN_GEN2,
-	CLOCK_MCHP_GCLKGEN_GEN3,
-	CLOCK_MCHP_GCLKGEN_GEN4,
-	CLOCK_MCHP_GCLKGEN_GEN5,
-	CLOCK_MCHP_GCLKGEN_GEN6,
-	CLOCK_MCHP_GCLKGEN_GEN7,
-	CLOCK_MCHP_GCLKGEN_GEN8,
-	CLOCK_MCHP_GCLKGEN_GEN9,
-	CLOCK_MCHP_GCLKGEN_GEN10,
-	CLOCK_MCHP_GCLKGEN_GEN11
+	CLOCK_MCHP_GCLKGEN_GEN0,  /**< Generator 0. */
+	CLOCK_MCHP_GCLKGEN_GEN1,  /**< Generator 1. */
+	CLOCK_MCHP_GCLKGEN_GEN2,  /**< Generator 2. */
+	CLOCK_MCHP_GCLKGEN_GEN3,  /**< Generator 3. */
+	CLOCK_MCHP_GCLKGEN_GEN4,  /**< Generator 4. */
+	CLOCK_MCHP_GCLKGEN_GEN5,  /**< Generator 5. */
+	CLOCK_MCHP_GCLKGEN_GEN6,  /**< Generator 6. */
+	CLOCK_MCHP_GCLKGEN_GEN7,  /**< Generator 7. */
+	CLOCK_MCHP_GCLKGEN_GEN8,  /**< Generator 8. */
+	CLOCK_MCHP_GCLKGEN_GEN9,  /**< Generator 9. */
+	CLOCK_MCHP_GCLKGEN_GEN10, /**< Generator 10. */
+	CLOCK_MCHP_GCLKGEN_GEN11  /**< Generator 11. */
 };
 
+/** @brief DFLL configuration. */
 struct clock_mchp_subsys_dfll_config {
-	/** @brief configure oscillator to ON, when a peripheral is requesting it as a source */
+	/** @brief Turn the oscillator ON when a peripheral requests it as a source. */
 	bool on_demand_en;
 
-	/** @brief configure oscillator to ON in standby sleep mode, unless on_demand_en is set */
+	/** @brief Keep the oscillator ON in standby sleep mode, unless on_demand_en is set. */
 	bool run_in_standby_en;
 
-	/** @brief Enable closed-loop operation */
+	/** @brief Enable closed-loop operation. */
 	bool closed_loop_en;
 
-	/** @brief Reference source clock selection */
+	/** @brief Reference source clock selection. */
 	enum clock_mchp_gclkgen src;
 
-	/** @brief Determines the ratio of the CLK_DFLL output frequency to the CLK_DFLL_REF input
-	 * frequency (0 - 65535)
+	/** @brief Ratio of the CLK_DFLL output frequency to the CLK_DFLL_REF input
+	 * frequency (0 - 65535).
 	 */
 	uint32_t multiply_factor;
 };
 
-/** @brief FDPLL source clocks */
+/** @brief FDPLL source clocks. */
 enum clock_mchp_fdpll_src_clock {
-	CLOCK_MCHP_FDPLL_SRC_GCLK0,
-	CLOCK_MCHP_FDPLL_SRC_GCLK1,
-	CLOCK_MCHP_FDPLL_SRC_GCLK2,
-	CLOCK_MCHP_FDPLL_SRC_GCLK3,
-	CLOCK_MCHP_FDPLL_SRC_GCLK4,
-	CLOCK_MCHP_FDPLL_SRC_GCLK5,
-	CLOCK_MCHP_FDPLL_SRC_GCLK6,
-	CLOCK_MCHP_FDPLL_SRC_GCLK7,
-	CLOCK_MCHP_FDPLL_SRC_GCLK8,
-	CLOCK_MCHP_FDPLL_SRC_GCLK9,
-	CLOCK_MCHP_FDPLL_SRC_GCLK10,
-	CLOCK_MCHP_FDPLL_SRC_GCLK11,
-	CLOCK_MCHP_FDPLL_SRC_XOSC32K,
-	CLOCK_MCHP_FDPLL_SRC_XOSC0,
-	CLOCK_MCHP_FDPLL_SRC_XOSC1,
+	CLOCK_MCHP_FDPLL_SRC_GCLK0,   /**< GCLK generator 0. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK1,   /**< GCLK generator 1. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK2,   /**< GCLK generator 2. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK3,   /**< GCLK generator 3. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK4,   /**< GCLK generator 4. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK5,   /**< GCLK generator 5. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK6,   /**< GCLK generator 6. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK7,   /**< GCLK generator 7. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK8,   /**< GCLK generator 8. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK9,   /**< GCLK generator 9. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK10,  /**< GCLK generator 10. */
+	CLOCK_MCHP_FDPLL_SRC_GCLK11,  /**< GCLK generator 11. */
+	CLOCK_MCHP_FDPLL_SRC_XOSC32K, /**< 32 kHz external oscillator. */
+	CLOCK_MCHP_FDPLL_SRC_XOSC0,   /**< External oscillator 0. */
+	CLOCK_MCHP_FDPLL_SRC_XOSC1,   /**< External oscillator 1. */
 
-	CLOCK_MCHP_FDPLL_SRC_MAX = CLOCK_MCHP_FDPLL_SRC_XOSC1
+	CLOCK_MCHP_FDPLL_SRC_MAX = CLOCK_MCHP_FDPLL_SRC_XOSC1 /**< Highest valid source. */
 };
 
+/** @brief Fractional DPLL (FDPLL) configuration. */
 struct clock_mchp_subsys_fdpll_config {
-	/** @brief configure oscillator to ON, when a peripheral is requesting it as a source */
+	/** @brief Turn the oscillator ON when a peripheral requests it as a source. */
 	bool on_demand_en;
 
-	/** @brief configure oscillator to ON in standby sleep mode, unless on_demand_en is set */
+	/** @brief Keep the oscillator ON in standby sleep mode, unless on_demand_en is set. */
 	bool run_in_standby_en;
 
-	/** @brief Reference source clock selection */
+	/** @brief Reference source clock selection. */
 	enum clock_mchp_fdpll_src_clock src;
 
-	/** @brief Set the XOSC clock division factor (0 - 2047) */
+	/** @brief XOSC clock division factor (0 - 2047). */
 	uint32_t xosc_clock_divider;
 
-	/** @brief Set the integer part of the frequency multiplier. (0 - 4095) */
+	/** @brief Integer part of the frequency multiplier (0 - 4095). */
 	uint32_t divider_ratio_int;
 
-	/** @brief Set the fractional part of the frequency multiplier. (0 - 31) */
+	/** @brief Fractional part of the frequency multiplier (0 - 31). */
 	uint32_t divider_ratio_frac;
 };
 
-/** @brief RTC source clocks */
+/** @brief RTC source clocks. */
 enum clock_mchp_rtc_src_clock {
+	/** Ultra-low-power 1 kHz. */
 	CLOCK_MCHP_RTC_SRC_ULP1K = OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K,
+	/** Ultra-low-power 32 kHz. */
 	CLOCK_MCHP_RTC_SRC_ULP32K = OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K,
+	/** External 1 kHz. */
 	CLOCK_MCHP_RTC_SRC_XOSC1K = OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K,
+	/** External 32 kHz. */
 	CLOCK_MCHP_RTC_SRC_XOSC32K = OSC32KCTRL_RTCCTRL_RTCSEL_XOSC32K
 };
 
+/** @brief RTC clock configuration. */
 struct clock_mchp_subsys_rtc_config {
-	/** @brief RTC source clock selection */
+	/** @brief RTC source clock selection. */
 	enum clock_mchp_rtc_src_clock src;
 };
 
+/** @brief 32 kHz external oscillator (XOSC32K) configuration. */
 struct clock_mchp_subsys_xosc32k_config {
-	/** @brief configure oscillator to ON, when a peripheral is requesting it as a source */
+	/** @brief Turn the oscillator ON when a peripheral requests it as a source. */
 	bool on_demand_en;
 
-	/** @brief configure oscillator to ON in standby sleep mode, unless on_demand_en is set */
+	/** @brief Keep the oscillator ON in standby sleep mode, unless on_demand_en is set. */
 	bool run_in_standby_en;
 };
 
-/** @brief Gclk Generator source clocks */
+/** @brief GCLK generator source clocks. */
 enum clock_mchp_gclk_src_clock {
-	CLOCK_MCHP_GCLK_SRC_XOSC0,
-	CLOCK_MCHP_GCLK_SRC_XOSC1,
-	CLOCK_MCHP_GCLK_SRC_GCLKPIN,
-	CLOCK_MCHP_GCLK_SRC_GCLKGEN1,
-	CLOCK_MCHP_GCLK_SRC_OSCULP32K,
-	CLOCK_MCHP_GCLK_SRC_XOSC32K,
-	CLOCK_MCHP_GCLK_SRC_DFLL,
-	CLOCK_MCHP_GCLK_SRC_FDPLL0,
-	CLOCK_MCHP_GCLK_SRC_FDPLL1,
+	CLOCK_MCHP_GCLK_SRC_XOSC0,     /**< External oscillator 0. */
+	CLOCK_MCHP_GCLK_SRC_XOSC1,     /**< External oscillator 1. */
+	CLOCK_MCHP_GCLK_SRC_GCLKPIN,   /**< GCLK input pin. */
+	CLOCK_MCHP_GCLK_SRC_GCLKGEN1,  /**< GCLK generator 1. */
+	CLOCK_MCHP_GCLK_SRC_OSCULP32K, /**< Ultra-low-power 32 kHz oscillator. */
+	CLOCK_MCHP_GCLK_SRC_XOSC32K,   /**< External 32 kHz oscillator. */
+	CLOCK_MCHP_GCLK_SRC_DFLL,      /**< DFLL. */
+	CLOCK_MCHP_GCLK_SRC_FDPLL0,    /**< Fractional DPLL 0. */
+	CLOCK_MCHP_GCLK_SRC_FDPLL1,    /**< Fractional DPLL 1. */
 
-	CLOCK_MCHP_GCLK_SRC_MAX = CLOCK_MCHP_GCLK_SRC_FDPLL1
+	CLOCK_MCHP_GCLK_SRC_MAX = CLOCK_MCHP_GCLK_SRC_FDPLL1 /**< Highest valid source. */
 };
 
+/** @brief GCLK generator configuration. */
 struct clock_mchp_subsys_gclkgen_config {
-	/** @brief configure oscillator to ON in standby sleep mode, unless on_demand_en is set */
+	/** @brief Keep the generator running in standby sleep mode, unless on_demand_en is set. */
 	bool run_in_standby_en;
 
-	/** @brief Generator source clock selection */
+	/** @brief Generator source clock selection. */
 	enum clock_mchp_gclk_src_clock src;
 
-	/** @brief Represent a division value for the corresponding Generator. The actual division
-	 * factor is dependent on the state of div_select (gclk1 0 - 65535, others 0 - 255)
+	/** @brief Division value for the generator. The actual division factor depends on the
+	 * state of div_select (gclk1: 0 - 65535, others: 0 - 255).
 	 */
 	uint16_t div_factor;
 };
 
+/** @brief Peripheral GCLK channel configuration. */
 struct clock_mchp_subsys_gclkperiph_config {
-	/** @brief gclk generator source of a peripheral clock */
+	/** @brief GCLK generator that sources the peripheral clock. */
 	enum clock_mchp_gclkgen src;
 };
 
-/** @brief division ratio of mclk prescaler for CPU */
+/** @brief Division ratio of the MCLK prescaler for the CPU. */
 enum clock_mchp_mclk_cpu_div {
-	CLOCK_MCHP_MCLK_CPU_DIV_1 = 1,
-	CLOCK_MCHP_MCLK_CPU_DIV_2 = 2,
-	CLOCK_MCHP_MCLK_CPU_DIV_4 = 4,
-	CLOCK_MCHP_MCLK_CPU_DIV_8 = 8,
-	CLOCK_MCHP_MCLK_CPU_DIV_16 = 16,
-	CLOCK_MCHP_MCLK_CPU_DIV_32 = 32,
-	CLOCK_MCHP_MCLK_CPU_DIV_64 = 64,
-	CLOCK_MCHP_MCLK_CPU_DIV_128 = 128
+	CLOCK_MCHP_MCLK_CPU_DIV_1 = 1,    /**< Divide by 1. */
+	CLOCK_MCHP_MCLK_CPU_DIV_2 = 2,    /**< Divide by 2. */
+	CLOCK_MCHP_MCLK_CPU_DIV_4 = 4,    /**< Divide by 4. */
+	CLOCK_MCHP_MCLK_CPU_DIV_8 = 8,    /**< Divide by 8. */
+	CLOCK_MCHP_MCLK_CPU_DIV_16 = 16,  /**< Divide by 16. */
+	CLOCK_MCHP_MCLK_CPU_DIV_32 = 32,  /**< Divide by 32. */
+	CLOCK_MCHP_MCLK_CPU_DIV_64 = 64,  /**< Divide by 64. */
+	CLOCK_MCHP_MCLK_CPU_DIV_128 = 128 /**< Divide by 128. */
 };
 
-/** @brief MCLK configuration structure
+/** @brief MCLK configuration structure.
  *
- * Used for CLOCK_MCHP_SUBSYS_TYPE_MCLKCPU
+ * Used for CLOCK_MCHP_SUBSYS_TYPE_MCLKCPU.
  */
 struct clock_mchp_subsys_mclkcpu_config {
-	/** @brief division ratio of mclk prescaler for CPU */
+	/** @brief Division ratio of the MCLK prescaler for the CPU. */
 	enum clock_mchp_mclk_cpu_div division_factor;
 };
 
-/** @brief clock rate datatype
+/** @brief Clock rate datatype.
  *
- * Used for setting a clock rate
+ * Used for setting a clock rate.
  */
 typedef uint32_t *clock_mchp_rate_t;
+
+/** @} */
 
 #endif /* INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_MCHP_CLOCK_SAM_D5X_E5X_H_ */

--- a/include/zephyr/drivers/clock_control/mchp_sam_pmc.h
+++ b/include/zephyr/drivers/clock_control/mchp_sam_pmc.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Power Management Controller (PMC) clock helpers for Microchip SAM devices.
+ * @ingroup clock_control_mchp_sam_pmc
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_MICROCHIP_SAM_PMC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_MICROCHIP_SAM_PMC_H_
 
@@ -11,31 +17,45 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/microchip_sam_pmc.h>
 
+/**
+ * @defgroup clock_control_mchp_sam_pmc Microchip SAM PMC
+ * @ingroup clock_control_mchp
+ * @{
+ */
+
+/** @brief Slow Clock Controller (SCKC) configuration. */
 struct sam_sckc_config {
-	uint32_t crystal_osc: 1;
-	uint32_t reserved: 31;
+	uint32_t crystal_osc: 1; /**< Use the external crystal oscillator instead of the RC. */
+	uint32_t reserved: 31;   /**< Reserved. */
 };
 
+/** @brief PMC clock configuration for a single peripheral clock. */
 struct sam_clk_cfg {
-	uint32_t clock_type;
-	uint32_t clock_id;
+	uint32_t clock_type; /**< Clock type (see microchip_sam_pmc.h DT bindings). */
+	uint32_t clock_id;   /**< Peripheral identifier within the PMC. */
 };
 
-/* Device constant configuration parameters */
+/** @brief PMC device constant configuration parameters. */
 struct sam_pmc_cfg {
-	uint32_t *const reg;
-	const struct device *td_slck;
-	const struct device *md_slck;
-	const struct device *main_xtal;
-	const struct sam_sckc_config td_slck_cfg;
-	const struct sam_sckc_config md_slck_cfg;
+	uint32_t *const reg;                       /**< PMC register base address. */
+	const struct device *td_slck;              /**< Timing-domain slow clock device. */
+	const struct device *md_slck;              /**< Main-domain slow clock device. */
+	const struct device *main_xtal;            /**< Main crystal oscillator device. */
+	const struct sam_sckc_config td_slck_cfg;  /**< Timing-domain slow clock configuration. */
+	const struct sam_sckc_config md_slck_cfg;  /**< Main-domain slow clock configuration. */
 };
 
-/* Device run time data */
+/** @brief PMC device run-time data. */
 struct sam_pmc_data {
-	struct pmc_data *pmc;
+	struct pmc_data *pmc; /**< Backend PMC instance data. */
 };
 
+/**
+ * @brief Initialize a @ref sam_clk_cfg from a clock specifier.
+ *
+ * @param clock Index of the clock specifier within the node's @c clocks property.
+ * @param node_id Devicetree node identifier owning the @c clocks property.
+ */
 #define SAM_DT_CLOCK_PMC_CFG(clock, node_id) {						\
 		.clock_type = DT_CLOCKS_CELL_BY_IDX(node_id,				\
 						    clock,				\
@@ -45,13 +65,30 @@ struct sam_pmc_data {
 						  peripheral_id)			\
 	}
 
+/**
+ * @brief Equivalent to SAM_DT_CLOCK_PMC_CFG() for the first clock of a DT instance.
+ *
+ * @param inst DT instance number.
+ */
 #define SAM_DT_INST_CLOCK_PMC_CFG(inst) SAM_DT_CLOCK_PMC_CFG(0, DT_DRV_INST(inst))
 
+/**
+ * @brief Initialize an array of @ref sam_clk_cfg for all clocks of a node.
+ *
+ * @param node_id Devicetree node identifier owning the @c clocks property.
+ */
 #define SAM_DT_CLOCKS_PMC_CFG(node_id) {						\
 		LISTIFY(DT_NUM_CLOCKS(node_id),						\
 		SAM_DT_CLOCK_PMC_CFG, (,), node_id)					\
 	}
 
+/**
+ * @brief Equivalent to SAM_DT_CLOCKS_PMC_CFG() for a DT instance.
+ *
+ * @param inst DT instance number.
+ */
 #define SAM_DT_INST_CLOCKS_PMC_CFG(inst) SAM_DT_CLOCKS_PMC_CFG(DT_DRV_INST(inst))
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_MICROCHIP_SAM_PMC_H_ */

--- a/include/zephyr/drivers/clock_control/mchp_xec_clock_control.h
+++ b/include/zephyr/drivers/clock_control/mchp_xec_clock_control.h
@@ -3,11 +3,26 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Clock control helpers for Microchip XEC devices.
+ * @ingroup clock_control_mchp_xec
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_MCHP_XEC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_MCHP_XEC_H_
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/mchp_xec_pcr.h>
+
+/**
+ * @defgroup clock_control_mchp_xec Microchip XEC
+ * @ingroup clock_control_mchp
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /*
  * Set/clear Microchip XEC peripheral sleep enable.
@@ -18,9 +33,25 @@ int z_mchp_xec_pcr_periph_sleep(uint8_t slp_idx, uint8_t slp_pos,
 
 int z_mchp_xec_pcr_periph_reset(uint8_t slp_idx, uint8_t slp_pos);
 
+/** @endcond */
+
 #if defined(CONFIG_PM)
+/**
+ * @brief Enable system sleep for the XEC clock controller.
+ *
+ * @param is_deep True to request deep sleep, false for light sleep.
+ * @kconfig_dep{CONFIG_PM}
+ */
 void mchp_xec_clk_ctrl_sys_sleep_enable(bool is_deep);
+
+/**
+ * @brief Disable system sleep for the XEC clock controller.
+ *
+ * @kconfig_dep{CONFIG_PM}
+ */
 void mchp_xec_clk_ctrl_sys_sleep_disable(void);
 #endif
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_LPC11U6X_CLOCK_CONTROL_H_ */
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_MCHP_XEC_H_ */

--- a/include/zephyr/drivers/clock_control/mspm0_clock_control.h
+++ b/include/zephyr/drivers/clock_control/mspm0_clock_control.h
@@ -4,15 +4,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock control definitions for Texas Instruments MSPM0 devices.
+ * @ingroup clock_control_mspm0
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_MSPM0_CLOCK_CONTROL
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_MSPM0_CLOCK_CONTROL
 
 #include <zephyr/dt-bindings/clock/mspm0_clock.h>
 
+/**
+ * @defgroup clock_control_mspm0 Texas Instruments MSPM0
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
+
+/** @brief MSPM0 system clock subsystem selector. */
 struct mspm0_sys_clock {
-	uint32_t clk;
+	uint32_t clk; /**< Clock identifier (see mspm0_clock.h DT bindings). */
 };
 
+/**
+ * @brief Initialize a @ref mspm0_sys_clock from a DT instance clock specifier.
+ *
+ * @param index DT instance number.
+ */
 #define MSPM0_CLOCK_SUBSYS_FN(index) {.clk = DT_INST_CLOCKS_CELL(index, clk)}
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_MSPM0_CLOCK_CONTROL */

--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -4,12 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock control definitions for Nordic nRF devices.
+ * @ingroup clock_control_nrf
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NRF_CLOCK_CONTROL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NRF_CLOCK_CONTROL_H_
 
 #include <zephyr/device.h>
 #include <zephyr/sys/onoff.h>
 #include <zephyr/drivers/clock_control.h>
+
+/**
+ * @defgroup clock_control_nrf Nordic nRF
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,43 +33,54 @@ extern "C" {
 
 /** @brief Clocks handled by the CLOCK peripheral.
  *
- * Enum shall be used as a sys argument in clock_control API.
+ * Used as the @c sys argument to the clock_control API.
  */
 enum clock_control_nrf_type {
-	CLOCK_CONTROL_NRF_TYPE_HFCLK,
-	CLOCK_CONTROL_NRF_TYPE_LFCLK,
+	CLOCK_CONTROL_NRF_TYPE_HFCLK, /**< High-frequency clock. */
+	CLOCK_CONTROL_NRF_TYPE_LFCLK, /**< Low-frequency clock. */
 #if NRF_CLOCK_HAS_HFCLK24M
-	CLOCK_CONTROL_NRF_TYPE_HFCLK24M,
+	CLOCK_CONTROL_NRF_TYPE_HFCLK24M, /**< 24 MHz high-frequency clock. */
 #endif
 #if NRF_CLOCK_HAS_HFCLK192M
-	CLOCK_CONTROL_NRF_TYPE_HFCLK192M,
+	CLOCK_CONTROL_NRF_TYPE_HFCLK192M, /**< 192 MHz high-frequency clock. */
 #endif
 #if NRF_CLOCK_HAS_HFCLKAUDIO
-	CLOCK_CONTROL_NRF_TYPE_HFCLKAUDIO,
+	CLOCK_CONTROL_NRF_TYPE_HFCLKAUDIO, /**< High-frequency audio clock. */
 #endif
-	CLOCK_CONTROL_NRF_TYPE_COUNT
+	CLOCK_CONTROL_NRF_TYPE_COUNT /**< Number of clock types. */
 };
 
-/* Define can be used with clock control API instead of enum directly to
- * increase code readability.
+/** @name Clock control subsystem identifiers
+ *
+ * These can be used with the clock control API instead of casting the
+ * @ref clock_control_nrf_type enumerators directly, to improve readability.
+ * @{
  */
+/** @brief High-frequency clock subsystem. */
 #define CLOCK_CONTROL_NRF_SUBSYS_HF \
 	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLK)
+/** @brief Low-frequency clock subsystem. */
 #define CLOCK_CONTROL_NRF_SUBSYS_LF \
 	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_LFCLK)
+/** @brief 24 MHz high-frequency clock subsystem. */
 #define CLOCK_CONTROL_NRF_SUBSYS_HF24M \
 	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLK24M)
+/** @brief 192 MHz high-frequency clock subsystem. */
 #define CLOCK_CONTROL_NRF_SUBSYS_HF192M \
 	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLK192M)
+/** @brief High-frequency audio clock subsystem. */
 #define CLOCK_CONTROL_NRF_SUBSYS_HFAUDIO \
 	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLKAUDIO)
+/** @} */
 
 /** @brief LF clock start modes. */
 enum nrf_lfclk_start_mode {
-	CLOCK_CONTROL_NRF_LF_START_NOWAIT,
-	CLOCK_CONTROL_NRF_LF_START_AVAILABLE,
-	CLOCK_CONTROL_NRF_LF_START_STABLE,
+	CLOCK_CONTROL_NRF_LF_START_NOWAIT,    /**< Return without waiting for the clock. */
+	CLOCK_CONTROL_NRF_LF_START_AVAILABLE, /**< Wait until the clock is available. */
+	CLOCK_CONTROL_NRF_LF_START_STABLE,    /**< Wait until the clock is stable. */
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Define 32KHz clock source */
 #ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC
@@ -173,26 +196,39 @@ void z_nrf_clock_bt_ctlr_hf_release(void);
  */
 uint32_t z_nrf_clock_bt_ctlr_hf_get_startup_time_us(void);
 
+/** @endcond */
+
 #endif /* defined(CONFIG_CLOCK_CONTROL_NRF) */
 
-/* Specifies to use the maximum available frequency for a given clock. */
+/** @brief Specifies to use the maximum available frequency for a given clock. */
 #define NRF_CLOCK_CONTROL_FREQUENCY_MAX UINT32_MAX
 
-/* Specifies to use the maximum available accuracy for a given clock. */
+/** @brief Specifies to use the maximum available accuracy for a given clock. */
 #define NRF_CLOCK_CONTROL_ACCURACY_MAX      1
-/* Specifies the required clock accuracy in parts-per-million. */
+/** @brief Specifies the required clock accuracy in parts-per-million. */
 #define NRF_CLOCK_CONTROL_ACCURACY_PPM(ppm) (ppm)
 
-/* Specifies that high precision of the clock is required. */
+/** @brief Specifies that high precision of the clock is required. */
 #define NRF_CLOCK_CONTROL_PRECISION_HIGH    1
-/* Specifies that default precision of the clock is sufficient. */
+/** @brief Specifies that default precision of the clock is sufficient. */
 #define NRF_CLOCK_CONTROL_PRECISION_DEFAULT 0
 
-/* AUXPLL devicetree takes in raw register values, these are the actual frequencies outputted */
+/** @name AUXPLL output frequencies
+ *
+ * The AUXPLL Devicetree takes in raw register values; these are the actual output frequencies.
+ * @{
+ */
+/** @brief Minimum AUXPLL output frequency, in Hz. */
 #define CLOCK_CONTROL_NRF_AUXPLL_FREQ_OUT_MIN_HZ        80000000
+/** @brief AUXPLL output frequency for 44.1 kHz audio, in Hz. */
 #define CLOCK_CONTROL_NRF_AUXPLL_FREQ_OUT_AUDIO_44K1_HZ 11289591
+/** @brief AUXPLL output frequency for 24 MHz USB, in Hz. */
 #define CLOCK_CONTROL_NRF_AUXPLL_FREQ_OUT_USB24M_HZ     24000000
+/** @brief AUXPLL output frequency for 48 kHz audio, in Hz. */
 #define CLOCK_CONTROL_NRF_AUXPLL_FREQ_OUT_AUDIO_48K_HZ  12287963
+/** @} */
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Internal helper macro to map DT property value to output frequency */
 #define _CLOCK_CONTROL_NRF_AUXPLL_MAP_FREQ(freq_val)			  \
@@ -205,7 +241,14 @@ uint32_t z_nrf_clock_bt_ctlr_hf_get_startup_time_us(void);
 	 (freq_val) == NRF_AUXPLL_FREQ_DIV_AUDIO_48K ?			  \
 		       CLOCK_CONTROL_NRF_AUXPLL_FREQ_OUT_AUDIO_48K_HZ : 0)
 
-/* Public macro to get output frequency of AUXPLL */
+/** @endcond */
+
+/**
+ * @brief Get the output frequency of an AUXPLL Devicetree node.
+ *
+ * @param node Devicetree node identifier of the AUXPLL.
+ * @return Output frequency in Hz, or 0 if the node has no @c nordic,frequency property.
+ */
 #define CLOCK_CONTROL_NRF_AUXPLL_GET_FREQ(node) \
 	COND_CODE_1(DT_NODE_HAS_PROP(node, nordic_frequency), \
 		(_CLOCK_CONTROL_NRF_AUXPLL_MAP_FREQ(DT_PROP(node, nordic_frequency))), \
@@ -428,5 +471,7 @@ void nrf_clock_control_hfxo_release(void);
 #ifdef __cplusplus
 }
 #endif
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NRF_CLOCK_CONTROL_H_ */

--- a/include/zephyr/drivers/clock_control/nxp_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nxp_clock_control.h
@@ -4,50 +4,88 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock control configuration helpers for NXP devices.
+ * @ingroup clock_control_nxp
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NXP_CLOCK_CONTROL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NXP_CLOCK_CONTROL_H_
 
 #include <zephyr/drivers/clock_control.h>
+
+/**
+ * @defgroup clock_control_nxp NXP
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(mc_cgm), nxp_mc_cgm, okay)
 #include <zephyr/dt-bindings/clock/nxp_mc_cgm.h>
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(firc), nxp_firc, okay)
+/** @brief FIRC output divider selection index. */
 #define NXP_FIRC_DIV DT_ENUM_IDX(DT_NODELABEL(firc), firc_div)
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(fxosc), nxp_fxosc, okay)
+/** @brief FXOSC frequency, in Hz. */
 #define NXP_FXOSC_FREQ DT_PROP(DT_NODELABEL(fxosc), freq)
+/** @brief FXOSC work mode (crystal or bypass). */
 #define NXP_FXOSC_WORKMODE                                                                         \
 	(DT_ENUM_IDX(DT_NODELABEL(fxosc), workmode) == 0 ? kFXOSC_ModeCrystal : kFXOSC_ModeBypass)
+/** @brief FXOSC startup delay. */
 #define NXP_FXOSC_DELAY     DT_PROP(DT_NODELABEL(fxosc), delay)
+/** @brief FXOSC overdrive setting. */
 #define NXP_FXOSC_OVERDRIVE DT_PROP(DT_NODELABEL(fxosc), overdrive)
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), nxp_plldig, okay)
+/** @brief PLL work mode selection index. */
 #define NXP_PLL_WORKMODE       DT_ENUM_IDX(DT_NODELABEL(pll), workmode)
+/** @brief PLL pre-divider. */
 #define NXP_PLL_PREDIV         DT_PROP(DT_NODELABEL(pll), prediv)
+/** @brief PLL post-divider. */
 #define NXP_PLL_POSTDIV        DT_PROP(DT_NODELABEL(pll), postdiv)
+/** @brief PLL loop multiplier. */
 #define NXP_PLL_MULTIPLIER     DT_PROP(DT_NODELABEL(pll), multiplier)
+/** @brief PLL fractional loop divider. */
 #define NXP_PLL_FRACLOOPDIV    DT_PROP(DT_NODELABEL(pll), fracloopdiv)
+/** @brief PLL modulation step size. */
 #define NXP_PLL_STEPSIZE       DT_PROP(DT_NODELABEL(pll), stepsize)
+/** @brief PLL modulation step count. */
 #define NXP_PLL_STEPNUM        DT_PROP(DT_NODELABEL(pll), stepnum)
+/** @brief PLL accuracy selection index. */
 #define NXP_PLL_ACCURACY       DT_ENUM_IDX(DT_NODELABEL(pll), accuracy)
+/** @brief PLL output divider table pointer. */
 #define NXP_PLL_OUTDIV_POINTER DT_PROP(DT_NODELABEL(pll), outdiv)
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(mc_cgm), nxp_mc_cgm, okay)
+/** @brief Maximum input duty-cycle change for the PLL. */
 #define NXP_PLL_MAXIDOCHANGE   DT_PROP(DT_NODELABEL(mc_cgm), max_ido_change)
+/** @brief PLL step duration. */
 #define NXP_PLL_STEPDURATION   DT_PROP(DT_NODELABEL(mc_cgm), step_duration)
+/** @brief Clock source frequency feeding the MC_CGM, in Hz. */
 #define NXP_PLL_CLKSRCFREQ     DT_PROP(DT_NODELABEL(mc_cgm), clk_src_freq)
+/** @brief MC_CGM mux 0 divider 0 value. */
 #define NXP_PLL_MUX_0_DC_0_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_0_dc_0_div)
+/** @brief MC_CGM mux 0 divider 1 value. */
 #define NXP_PLL_MUX_0_DC_1_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_0_dc_1_div)
+/** @brief MC_CGM mux 0 divider 2 value. */
 #define NXP_PLL_MUX_0_DC_2_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_0_dc_2_div)
+/** @brief MC_CGM mux 0 divider 3 value. */
 #define NXP_PLL_MUX_0_DC_3_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_0_dc_3_div)
+/** @brief MC_CGM mux 0 divider 4 value. */
 #define NXP_PLL_MUX_0_DC_4_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_0_dc_4_div)
+/** @brief MC_CGM mux 0 divider 5 value. */
 #define NXP_PLL_MUX_0_DC_5_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_0_dc_5_div)
+/** @brief MC_CGM mux 0 divider 6 value. */
 #define NXP_PLL_MUX_0_DC_6_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_0_dc_6_div)
 #endif
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NXP_CLOCK_CONTROL_H_ */

--- a/include/zephyr/drivers/clock_control/nxp_clock_controller_sources.h
+++ b/include/zephyr/drivers/clock_control/nxp_clock_controller_sources.h
@@ -4,33 +4,61 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock source configuration helpers for NXP devices.
+ * @ingroup clock_control_nxp_sources
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NXP_CLOCK_CONTROLLER_SOURCES_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NXP_CLOCK_CONTROLLER_SOURCES_H_
 
 #include <zephyr/drivers/clock_control.h>
 
+/**
+ * @defgroup clock_control_nxp_sources NXP clock sources
+ * @ingroup clock_control_nxp
+ * @{
+ */
+
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(firc), nxp_firc, okay)
+/** @brief FIRC output divider selection index. */
 #define NXP_FIRC_DIV DT_ENUM_IDX(DT_NODELABEL(firc), firc_div)
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(fxosc), nxp_fxosc, okay)
+/** @brief FXOSC frequency, in Hz. */
 #define NXP_FXOSC_FREQ DT_PROP(DT_NODELABEL(fxosc), freq)
+/** @brief FXOSC work mode (crystal or bypass). */
 #define NXP_FXOSC_WORKMODE                                                                         \
 	(DT_ENUM_IDX(DT_NODELABEL(fxosc), workmode) == 0 ? kFXOSC_ModeCrystal : kFXOSC_ModeBypass)
+/** @brief FXOSC startup delay. */
 #define NXP_FXOSC_DELAY     DT_PROP(DT_NODELABEL(fxosc), delay)
+/** @brief FXOSC overdrive setting. */
 #define NXP_FXOSC_OVERDRIVE DT_PROP(DT_NODELABEL(fxosc), overdrive)
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), nxp_plldig, okay)
+/** @brief PLL work mode selection index. */
 #define NXP_PLL_WORKMODE       DT_ENUM_IDX(DT_NODELABEL(pll), workmode)
+/** @brief PLL pre-divider. */
 #define NXP_PLL_PREDIV         DT_PROP(DT_NODELABEL(pll), prediv)
+/** @brief PLL post-divider. */
 #define NXP_PLL_POSTDIV        DT_PROP(DT_NODELABEL(pll), postdiv)
+/** @brief PLL loop multiplier. */
 #define NXP_PLL_MULTIPLIER     DT_PROP(DT_NODELABEL(pll), multiplier)
+/** @brief PLL fractional loop divider. */
 #define NXP_PLL_FRACLOOPDIV    DT_PROP(DT_NODELABEL(pll), fracloopdiv)
+/** @brief PLL modulation step size. */
 #define NXP_PLL_STEPSIZE       DT_PROP(DT_NODELABEL(pll), stepsize)
+/** @brief PLL modulation step count. */
 #define NXP_PLL_STEPNUM        DT_PROP(DT_NODELABEL(pll), stepnum)
+/** @brief PLL accuracy selection index. */
 #define NXP_PLL_ACCURACY       DT_ENUM_IDX(DT_NODELABEL(pll), accuracy)
+/** @brief PLL output divider table pointer. */
 #define NXP_PLL_OUTDIV_POINTER DT_PROP(DT_NODELABEL(pll), outdiv)
 #endif
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NXP_CLOCK_CONTROLLER_SOURCES_H_ */

--- a/include/zephyr/drivers/clock_control/renesas_cpg_mssr.h
+++ b/include/zephyr/drivers/clock_control/renesas_cpg_mssr.h
@@ -6,16 +6,32 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Clock control definitions for the Renesas R-Car CPG/MSSR controller.
+ * @ingroup clock_control_renesas_cpg_mssr
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RCAR_CLOCK_CONTROL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RCAR_CLOCK_CONTROL_H_
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/renesas_cpg_mssr.h>
 
+/**
+ * @defgroup clock_control_renesas_cpg_mssr Renesas R-Car CPG/MSSR
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
+
+/** @brief R-Car CPG/MSSR clock subsystem selector. */
 struct rcar_cpg_clk {
-	uint32_t domain;
-	uint32_t module;
-	uint32_t rate;
+	uint32_t domain; /**< Clock domain. */
+	uint32_t module; /**< Module (MSSR) identifier within the domain. */
+	uint32_t rate;   /**< Requested clock rate, in Hz. */
 };
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RCAR_CLOCK_CONTROL_H_ */

--- a/include/zephyr/drivers/clock_control/renesas_ra_cgc.h
+++ b/include/zephyr/drivers/clock_control/renesas_ra_cgc.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Renesas RA Clock Generator Circuit (CGC) header file
+ * @ingroup clock_control_renesas_ra
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RA_CGC_H_
@@ -16,8 +17,8 @@
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 
 /**
- * @name Clock source and divider helpers for Renesas RA devices.
- *
+ * @defgroup clock_control_renesas_ra Renesas RA CGC
+ * @ingroup clock_control_interface_ext
  * @{
  */
 
@@ -52,8 +53,9 @@
 	(RA_CGC_PROP_HAS_STATUS_OKAY_OR(clk, prop, default_value))
 
 /**
- * @defgroup ra_cgc_div Renesas RA Clock Divider Generators
+ * @defgroup clock_control_renesas_ra_div Renesas RA Clock Divider Generators
  * @brief Divider generator macros for multiple clock domains.
+ * @ingroup clock_control_renesas_ra
  * @{
  */
 
@@ -164,11 +166,12 @@
 #define RA_CGC_DIV_TAU_CK03(n)    UTIL_CAT(TIMER_SOURCE_DIV_, n)
 /** TAU_CK04 divider. */
 #define RA_CGC_DIV_TAU_CK04(n)    UTIL_CAT(TIMER_SOURCE_DIV_, n)
-/** @} end of ra_cgc_div group */
+/** @} end of clock_control_renesas_ra_div group */
 
 /**
- *  @defgroup bsp_clock_source Renesas RA BSP Clock Source Constants
+ *  @defgroup clock_control_renesas_ra_source Renesas RA BSP Clock Source Constants
  *  @brief Renesas RA BSP clock source constants.
+ *  @ingroup clock_control_renesas_ra
  *  @{
  */
 
@@ -229,11 +232,12 @@
 #error "Invalid fsxp source clock"
 #endif /* DT_SAME_NODE(DT_CLOCKS_CTLR(DT_NODELABEL(fsxp)), DT_NODELABEL(loco)) */
 #endif /* DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(fsxp)) */
-/** @} end of bsp_clock_source group */
+/** @} end of clock_control_renesas_ra_source group */
 
 /**
- *  @defgroup bsp_clock_clkout Renesas RA BSP Clock Clkout Divider Constants
+ *  @defgroup clock_control_renesas_ra_clkout Renesas RA BSP Clock Clkout Divider Constants
  *  @brief Renesas RA BSP clock clkout divider constants.
+ *  @ingroup clock_control_renesas_ra
  *  @{
  */
 
@@ -245,7 +249,7 @@
 #define BSP_CLOCKS_CLKOUT_DIV_32  (5) /**< Clkout div 32. */
 #define BSP_CLOCKS_CLKOUT_DIV_64  (6) /**< Clkout div 64. */
 #define BSP_CLOCKS_CLKOUT_DIV_128 (7) /**< Clkout div 128. */
-/** @} end of bsp_clock_clkout group */
+/** @} end of clock_control_renesas_ra_clkout group */
 
 /**
  * @brief Peripheral clock configuration.

--- a/include/zephyr/drivers/clock_control/renesas_rcar_generic.h
+++ b/include/zephyr/drivers/clock_control/renesas_rcar_generic.h
@@ -7,10 +7,17 @@
 /**
  * @file
  * @brief Renesas R-Car generic access to clocks
+ * @ingroup clock_control_renesas_rcar
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RCAR_GENERIC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RCAR_GENERIC_H_
+
+/**
+ * @defgroup clock_control_renesas_rcar Renesas R-Car
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
 
 /* Gen 5 boards deal with clocks through SCMI. */
 #ifdef CONFIG_CLOCK_CONTROL_ARM_SCMI
@@ -71,5 +78,7 @@ typedef struct rcar_generic_clk rcar_generic_clk_t;
 typedef struct rcar_cpg_clk rcar_generic_clk_t;
 
 #endif /* CONFIG_CLOCK_CONTROL_ARM_SCMI */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RCAR_GENERIC_H_ */

--- a/include/zephyr/drivers/clock_control/renesas_rx_cgc.h
+++ b/include/zephyr/drivers/clock_control/renesas_rx_cgc.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Renesas RX Clock Generator Circuit (CGC) header file
+ * @ingroup clock_control_renesas_rx
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RX_CGC_H_
@@ -16,7 +17,8 @@
 #include <zephyr/dt-bindings/clock/rx_clock.h>
 
 /**
- * @name Clock source and divider helpers for Renesas RX devices.
+ * @defgroup clock_control_renesas_rx Renesas RX CGC
+ * @ingroup clock_control_interface_ext
  * @{
  */
 

--- a/include/zephyr/drivers/clock_control/renesas_rz_cgc.h
+++ b/include/zephyr/drivers/clock_control/renesas_rz_cgc.h
@@ -4,21 +4,48 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock source divider and multiplier helpers for Renesas RZ devices.
+ * @ingroup clock_control_renesas_rz
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RZ_CGC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RZ_CGC_H_
 
 #include <zephyr/drivers/clock_control.h>
 
+/**
+ * @defgroup clock_control_renesas_rz Renesas RZ CGC
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
+
+/**
+ * @brief Resolve the divider constant for a sub-clock from its Devicetree @c div property.
+ *
+ * @param subclk Devicetree node identifier of the sub-clock.
+ */
 #define RZ_CGC_SUBCLK_DIV(subclk)                                                                  \
 	UTIL_CAT(RZ_CGC_DIV_, DT_NODE_FULL_NAME_UPPER_TOKEN(subclk))                               \
 	(DT_PROP(subclk, div))
 
+/**
+ * @brief Resolve the multiplier constant for a sub-clock from its Devicetree @c mul property.
+ *
+ * @param subclk Devicetree node identifier of the sub-clock.
+ */
 #define RZ_CGC_SUBCLK_MUL(subclk)                                                                  \
 	UTIL_CAT(RZ_CGC_MUL_, DT_NODE_FULL_NAME_UPPER_TOKEN(subclk))                               \
 	(DT_PROP(subclk, mul))
 
+/** @brief CKIO clock divider helper. */
 #define RZ_CGC_DIV_CKIO(n)    UTIL_CAT(BSP_CLOCKS_CKIO_ICLK_DIV, n)
+/** @brief CPU0 clock multiplier helper. */
 #define RZ_CGC_MUL_CPU0CLK(n) UTIL_CAT(BSP_CLOCKS_FSELCPU0_ICLK_MUL, n)
+/** @brief CPU1 clock multiplier helper. */
 #define RZ_CGC_MUL_CPU1CLK(n) UTIL_CAT(BSP_CLOCKS_FSELCPU1_ICLK_MUL, n)
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RZ_CGC_H_ */

--- a/include/zephyr/drivers/clock_control/sf32lb.h
+++ b/include/zephyr/drivers/clock_control/sf32lb.h
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock control helpers for Core Devices SF32LB devices.
+ * @ingroup clock_control_sf32lb
+ */
+
 #ifndef _INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_SF32LB_H_
 #define _INCLUDE_ZEPHYR_DRIVERS_CLOCK_CONTROL_SF32LB_H_
 
@@ -14,9 +20,8 @@
 #include <zephyr/drivers/clock_control.h>
 
 /**
- * @brief Clock Control (SF32LB specifics)
- * @defgroup clock_control_sf32lb Clock Control (SF32LB specifics)
- * @ingroup clock_control_interface
+ * @defgroup clock_control_sf32lb Core Devices SF32LB
+ * @ingroup clock_control_interface_ext
  * @{
  */
 

--- a/include/zephyr/drivers/clock_control/smartbond_clock_control.h
+++ b/include/zephyr/drivers/clock_control/smartbond_clock_control.h
@@ -4,35 +4,45 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Clock control definitions for Renesas SmartBond devices.
+ * @ingroup clock_control_smartbond
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_SMARTBOND_CLOCK_CONTROL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_SMARTBOND_CLOCK_CONTROL_H_
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
 
+/**
+ * @defgroup clock_control_smartbond Renesas SmartBond
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/** @brief Smartbond clocks
- *
- * Enum oscillators and clocks.
- */
+/** @brief SmartBond oscillators and clocks. */
 enum smartbond_clock {
-	/* Not a clock, used for error case only */
-	SMARTBOND_CLK_NONE,
-	SMARTBOND_CLK_RC32K,
-	SMARTBOND_CLK_RCX,
-	SMARTBOND_CLK_XTAL32K,
-	SMARTBOND_CLK_RC32M,
-	SMARTBOND_CLK_XTAL32M,
-	SMARTBOND_CLK_PLL96M,
-	SMARTBOND_CLK_USB,
-	SMARTBOND_CLK_DIVN_32M,
-	SMARTBOND_CLK_HCLK,
-	SMARTBOND_CLK_LP_CLK,
-	SMARTBOND_CLK_SYS_CLK,
+	SMARTBOND_CLK_NONE,     /**< Not a clock; used for the error case only. */
+	SMARTBOND_CLK_RC32K,    /**< 32 kHz RC oscillator. */
+	SMARTBOND_CLK_RCX,      /**< RCX low-power oscillator. */
+	SMARTBOND_CLK_XTAL32K,  /**< 32 kHz crystal oscillator. */
+	SMARTBOND_CLK_RC32M,    /**< 32 MHz RC oscillator. */
+	SMARTBOND_CLK_XTAL32M,  /**< 32 MHz crystal oscillator. */
+	SMARTBOND_CLK_PLL96M,   /**< 96 MHz PLL. */
+	SMARTBOND_CLK_USB,      /**< USB clock. */
+	SMARTBOND_CLK_DIVN_32M, /**< Divided 32 MHz clock. */
+	SMARTBOND_CLK_HCLK,     /**< AHB clock. */
+	SMARTBOND_CLK_LP_CLK,   /**< Low-power clock. */
+	SMARTBOND_CLK_SYS_CLK,  /**< System clock. */
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 /** @brief Selects system clock
  *
@@ -50,8 +60,12 @@ int z_smartbond_select_sys_clk(enum smartbond_clock sys_clk);
  */
 int z_smartbond_select_lp_clk(enum smartbond_clock lp_clk);
 
+/** @endcond */
+
 #ifdef __cplusplus
 }
 #endif
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_SMARTBOND_CLOCK_CONTROL_H_ */

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -7,8 +7,25 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Clock control definitions for STMicroelectronics STM32 devices.
+ *
+ * The symbols in this header are Devicetree-derived clock-configuration internals used by the
+ * STM32 clock driver; they are not part of the public application API.
+ * @ingroup clock_control_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_STM32_CLOCK_CONTROL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_STM32_CLOCK_CONTROL_H_
+
+/**
+ * @defgroup clock_control_stm32 STMicroelectronics STM32
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
+
 /** @cond INTERNAL_HIDDEN */
 
 #include <zephyr/drivers/clock_control.h>
@@ -963,4 +980,7 @@ int stm32wb0_register_lsi_update_callback(lsi_update_cb_t cb);
 #endif /* CONFIG_SOC_SERIES_STM32WB0X */
 
 /** @endcond */
+
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_STM32_CLOCK_CONTROL_H_ */

--- a/include/zephyr/drivers/clock_control/tisci_clock_control.h
+++ b/include/zephyr/drivers/clock_control/tisci_clock_control.h
@@ -3,39 +3,66 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Clock control definitions for the TI TISCI (System Controller) interface.
+ * @ingroup clock_control_tisci
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_TISCI_CLOCK_CONTROL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_TISCI_CLOCK_CONTROL_H_
 
 #include <stdint.h>
 
 /**
- * @struct tisci_clock_config
- * @brief Clock configuration structure
+ * @defgroup clock_control_tisci Texas Instruments TISCI
+ * @ingroup clock_control_interface_ext
+ * @{
+ */
+
+/**
+ * @brief Clock configuration structure.
  *
- * This structure is used to define the configuration for a clock, including
- * the device ID and clock ID.
- *
- * @param tisci_clock_config::dev_id
- * Device ID associated with the clock.
- *
- * @param tisci_clock_config::clk_id
- * Clock ID within the device.
+ * Defines the configuration for a clock, including the device ID and clock ID.
  */
 struct tisci_clock_config {
-	uint32_t dev_id;
-	uint32_t clk_id;
+	uint32_t dev_id; /**< Device ID associated with the clock. */
+	uint32_t clk_id; /**< Clock ID within the device. */
 };
 
+/**
+ * @brief Get the clock controller device referenced by a node's @c clocks phandle.
+ *
+ * @param node_id Devicetree node identifier.
+ */
 #define TISCI_GET_CLOCK(node_id) DEVICE_DT_GET(DT_PHANDLE(node_id, clocks))
 
+/**
+ * @brief Initialize a @ref tisci_clock_config from a node's clock specifier.
+ *
+ * @param node_id Devicetree node identifier.
+ */
 #define TISCI_GET_CLOCK_DETAILS(node_id)	\
 	{	\
 		.dev_id = DT_CLOCKS_CELL(node_id, devid),	\
 		.clk_id = DT_CLOCKS_CELL(node_id, clkid)	\
 	}
 
+/**
+ * @brief Equivalent to TISCI_GET_CLOCK() for a DT instance.
+ *
+ * @param inst DT instance number.
+ */
 #define TISCI_GET_CLOCK_BY_INST(inst) TISCI_GET_CLOCK(DT_DRV_INST(inst))
 
+/**
+ * @brief Equivalent to TISCI_GET_CLOCK_DETAILS() for a DT instance.
+ *
+ * @param inst DT instance number.
+ */
 #define TISCI_GET_CLOCK_DETAILS_BY_INST(inst) TISCI_GET_CLOCK_DETAILS(DT_DRV_INST(inst))
+
+/** @} */
 
 #endif

--- a/include/zephyr/dt-bindings/clock/silabs/common-clock.h
+++ b/include/zephyr/dt-bindings/clock/silabs/common-clock.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Clock branch macros for use on Silicon Labs Series 2 devices.
- * @ingroup clock_control_silabs
+ * @ingroup clock_control_dt_silabs
  */
 
  /*
@@ -14,7 +14,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_SILABS_COMMON_CLOCK_H_
 
 /**
- * @defgroup clock_control_silabs Silicon Labs Series 2 Devicetree helpers
+ * @defgroup clock_control_dt_silabs Silicon Labs Series 2 Devicetree helpers
  * @ingroup clock_control_interface
  *
  * @details Devicetree macros for clock enables and clock branches on Silicon Labs Series 2 devices,


### PR DESCRIPTION
Provide proper Doxygen documentation across all clock control vendor specific headers.

https://builds.zephyrproject.io/zephyr/pr/110556/docs/doxygen/html/group__clock__control__interface__ext.html
https://builds.zephyrproject.io/zephyr/pr/110556/api-coverage/zephyr/drivers/clock_control/index.html