### PR TITLE
dts: bindings: renesas,rcar-mfis-mbox: update dts snippet

### DIFF
--- a/dts/bindings/mbox/renesas,rcar-mfis-mbox.yaml
+++ b/dts/bindings/mbox/renesas,rcar-mfis-mbox.yaml
@@ -44,19 +44,19 @@ examples:
         interrupt-parent = <&gic>;
         interrupts = <GIC_SPI 54 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,  /* AP_00 */
                      <GIC_SPI 56 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,  /* AP_01 */
-                     [...]
+                     /* ... */
                      <GIC_SPI 180 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>, /* AP_63 */
                      <GIC_SPI 182 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>, /* SCP_00 */
                      <GIC_SPI 183 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>, /* SCP_01 */
-                     [...]
+                     /* ... */
                      <GIC_SPI 193 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>; /* SCP_11 */
         #mbox-cells = <1>;
       };
 
       /* Consumer using MFIS channel 64 (SCP_00) */
       scmi {
-        [...]
+        /* ... */
         mboxes = <&mfis 64>;
-        [...]
+        /* ... */
       };
     };


### PR DESCRIPTION
The "examples" section of the renesas,rcar-mfis-mbox.yaml was containing an invalid dts fragment. Fix it.

And yes, some linting/code compliance check would be nice to have -- I'll look into it at some point but luckily issues like this seldom happen (in fact it's the first time since `examples:` was introduced 😃)