### PR TITLE
drivers: dp: make the off state flag configurable

### DIFF
--- a/drivers/dp/Kconfig
+++ b/drivers/dp/Kconfig
@@ -28,4 +28,13 @@ config SWDP_BITBANG_DRIVER
 	help
 	  Serial Wire Debug Port bit-bang driver.
 
+config SWDP_BITBANG_NO_DISCONNECT
+	bool "Use GPIO_INPUT instead of GPIO_DISCONNECTED"
+	default y if GPIO_STM32
+	depends on SWDP_BITBANG_DRIVER
+	help
+	  When deactivating the debug port, use GPIO_INPUT instead of
+	  GPIO_DISCONNECTED. Use if the underlying gpio driver does not support
+	  the GPIO_DISCONNECTED state.
+
 endif # DP_DRIVER

--- a/drivers/dp/swdp_bitbang.c
+++ b/drivers/dp/swdp_bitbang.c
@@ -592,6 +592,8 @@ static int sw_port_off(const struct device *dev)
 {
 	const struct sw_config *config = dev->config;
 	int ret;
+	const gpio_flags_t off_flags = IS_ENABLED(CONFIG_SWDP_BITBANG_NO_DISCONNECT) ?
+		GPIO_INPUT : GPIO_DISCONNECTED;
 
 	/* If there is a transceiver connected to IO, pins should always be driven. */
 	if (config->dnoe.port) {
@@ -613,13 +615,13 @@ static int sw_port_off(const struct device *dev)
 		}
 	} else {
 		if (config->dout.port) {
-			ret = gpio_pin_configure_dt(&config->dout, GPIO_DISCONNECTED);
+			ret = gpio_pin_configure_dt(&config->dout, off_flags);
 			if (ret) {
 				return ret;
 			}
 		}
 
-		ret = gpio_pin_configure_dt(&config->dio, GPIO_DISCONNECTED);
+		ret = gpio_pin_configure_dt(&config->dio, off_flags);
 		if (ret) {
 			return ret;
 		}
@@ -638,7 +640,7 @@ static int sw_port_off(const struct device *dev)
 		}
 
 	} else {
-		ret = gpio_pin_configure_dt(&config->clk, GPIO_DISCONNECTED);
+		ret = gpio_pin_configure_dt(&config->clk, off_flags);
 		if (ret) {
 			return ret;
 		}
@@ -648,7 +650,7 @@ static int sw_port_off(const struct device *dev)
 		ret = gpio_pin_configure_dt(&config->reset,
 					    config->keep_reset_deast
 						    ? GPIO_OUTPUT_INACTIVE
-						    : GPIO_DISCONNECTED);
+						    : off_flags);
 		if (ret) {
 			return ret;
 		}


### PR DESCRIPTION
Some gpio controller do not support GPIO_DISCONNECTED, or at least when the dt flag also includes pullup/pulldowns. Add an option to allow using GPIO_INPUT instead, that'll always work.