### PR TITLE
tests: drivers: flash: Verify that data was actually copied

### DIFF
--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -479,10 +479,9 @@ static void test_flash_copy_inner(const struct device *src_dev, off_t src_offset
 
 	if ((expected_result == 0) && (size != 0) && (src_offset != dst_offset)) {
 		/* prepare for successful copy */
-		zassert_ok(flash_flatten(flash_dev, page_info.start_offset, page_info.size));
-		zassert_ok(flash_fill(flash_dev, 0xaa, page_info.start_offset, page_info.size));
-		zassert_ok(flash_flatten(flash_dev, page_info.start_offset + page_info.size,
-					 page_info.size));
+		zassert_ok(flash_flatten(src_dev, src_offset, (size_t)size));
+		zassert_ok(flash_fill(src_dev, 0xaa, src_offset, (size_t)size));
+		zassert_ok(flash_flatten(dst_dev, dst_offset, (size_t)size));
 	}
 
 	/* perform copy (if args are valid) */

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -475,6 +475,7 @@ static void test_flash_copy_inner(const struct device *src_dev, off_t src_offset
 				  const struct device *dst_dev, off_t dst_offset, off_t size,
 				  uint8_t *buf, size_t buf_size, int expected_result)
 {
+	off_t remaining = size;
 	int actual_result;
 
 	if ((expected_result == 0) && (size != 0) && (src_offset != dst_offset)) {
@@ -493,11 +494,16 @@ static void test_flash_copy_inner(const struct device *src_dev, off_t src_offset
 
 	if ((expected_result == 0) && (size != 0) && (src_offset != dst_offset)) {
 		/* verify a successful copy */
-		off_t copy_size = MIN(size, EXPECTED_SIZE);
+		while (remaining > 0) {
+			size_t read_size = MIN((size_t)remaining, buf_size);
 
-		zassert_ok(flash_read(flash_dev, TEST_AREA_OFFSET, expected, copy_size));
-		for (int i = 0; i < copy_size; i++) {
-			zassert_equal(buf[i], 0xaa, "incorrect data (%02x) at %d", buf[i], i);
+			zassert_ok(flash_read(dst_dev, dst_offset, buf, read_size));
+			for (size_t i = 0; i < read_size; i++) {
+				zassert_equal(buf[i], 0xaa, "incorrect data (%02x) at %zu", buf[i],
+					      (size_t)(size - remaining + i));
+			}
+			remaining -= (off_t)read_size;
+			dst_offset += (off_t)read_size;
 		}
 	}
 }


### PR DESCRIPTION
The test_flash_copy testcase did not verify that the copy operation was successful. Verifying the copied data was done by reading from the source range, not the destination range, using a buffer that was too small to hold the full size of the operation under test on many devices. The assert was then done using a different buffer previously used as a temporary buffer for the copy operation, not the buffer used for the verification read.

Refactor the implementation to verify that every byte requested to be copied makes its way all the way to the destination. Consistently use the supplied arguments instead of accessing globals.