### PR TITLE
include dt-bindings: ra-elc: improvide doxygen documentation

### DIFF
--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra2a1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra2a1-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA2A1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA2A1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra2a1_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA2A1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA2A1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA2A1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra2a1_elc Renesas RA2A1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA2A1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra2a1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA2A1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -159,12 +197,7 @@
 #define RA_ELC_EVENT_AES_RDREQ              0x08C /**< AES Read Request. */
 #define RA_ELC_EVENT_TRNG_RDREQ             0x08D /**< TRNG Read Request. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -178,6 +211,8 @@
 #define RA_ELC_PERIPHERAL_DA8_0   19 /**< DA8_0 */
 #define RA_ELC_PERIPHERAL_DA8_1   20 /**< DA8_1 */
 #define RA_ELC_PERIPHERAL_SDADC0  22 /**< SDADC0 */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra2l1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra2l1-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA2L1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA2L1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra2l1_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA2L1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA2L1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA2L1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra2l1_elc Renesas RA2L1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA2L1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra2l1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA2L1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -181,12 +219,7 @@
 #define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW  0x0A8 /**< Overflow. */
 #define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW 0x0A9 /**< Underflow. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -197,6 +230,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
 #define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
 #define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4e1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4e1-elc.h
@@ -6,15 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA4E1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA4E1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra4e1_elc
  */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4E1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4E1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA4E1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra4e1_elc Renesas RA4E1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA4E1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra4e1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA4E1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -162,12 +201,7 @@
 #define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
 #define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -183,6 +217,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4e2-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4e2-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA4E2 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA4E2 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra4e2_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4E2_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4E2_ELC_H_
 
 /**
- * @name Event codes for Renesas RA4E2 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra4e2_elc Renesas RA4E2 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA4E2 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra4e2-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA4E2 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -187,12 +225,7 @@
 #define RA_ELC_EVENT_I3C0_WU                0x1EC /**< Wake-up Condition Detection interrupt. */
 #define RA_ELC_EVENT_TRNG_RDREQ             0x1F3 /**< TRNG Read Request. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -209,6 +242,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_I3C     23 /**< I3C */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4l1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4l1-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA4L1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA4L1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra4l1_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4L1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4L1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA4L1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra4l1_elc Renesas RA4L1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA4L1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra4l1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA4L1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE               0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0           0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1           0x002 /**< External pin interrupt 1. */
@@ -231,12 +269,7 @@
 #define RA_ELC_EVENT_I3C0_WU                0x1EC /**< Wake-up Condition Detection interrupt. */
 #define RA_ELC_EVENT_RSIP_TADI              0x1EE /**< RSIP Tamper Detection. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -253,6 +286,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m1-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA4M1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA4M1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra4m1_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA4M1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra4m1_elc Renesas RA4M1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA4M1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra4m1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA4M1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -198,12 +236,7 @@
 #define RA_ELC_EVENT_SPI1_ERI               0x0B5 /**< Error. */
 #define RA_ELC_EVENT_SPI1_TEI               0x0B6 /**< Transmission complete event. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -220,6 +253,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m2-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m2-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA4M2 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA4M2 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra4m2_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M2_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M2_ELC_H_
 
 /**
- * @name Event codes for Renesas RA4M2 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra4m2_elc Renesas RA4M2 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA4M2 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra4m2-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA4M2 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -244,12 +282,7 @@
 #define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
 #define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -267,6 +300,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m3-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m3-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA4M3 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA4M3 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra4m3_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M3_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M3_ELC_H_
 
 /**
- * @name Event codes for Renesas RA4M3 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra4m3_elc Renesas RA4M3 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA4M3 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra4m3-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA4M3 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -255,12 +293,7 @@
 #define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
 #define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -280,6 +313,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4t1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4t1-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA4T1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA4T1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra4t1_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4T1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4T1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA4T1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra4t1_elc Renesas RA4T1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA4T1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra4t1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA4T1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -199,12 +237,7 @@
 #define RA_ELC_EVENT_I3C0_WU                0x1EC /**< Wake-up Condition Detection interrupt. */
 #define RA_ELC_EVENT_TRNG_RDREQ             0x1F3 /**< TRNG Read Request. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -222,6 +255,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_I3C     23 /**< I3C */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4w1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4w1-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA4W1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA4W1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra4w1_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4W1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4W1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA4W1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra4w1_elc Renesas RA4W1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA4W1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra4w1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA4W1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -183,12 +221,7 @@
 #define RA_ELC_EVENT_SPI1_ERI               0x0D3 /**< Error. */
 #define RA_ELC_EVENT_SPI1_TEI               0x0D4 /**< Transmission complete event. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -205,6 +238,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6e1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6e1-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA6E1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA6E1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra6e1_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6E1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6E1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA6E1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra6e1_elc Renesas RA6E1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA6E1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra6e1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA6E1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -221,12 +259,7 @@
 #define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
 #define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -242,6 +275,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6e2-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6e2-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA6E2 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA6E2 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra6e2_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6E2_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6E2_ELC_H_
 
 /**
- * @name Event codes for Renesas RA6E2 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra6e2_elc Renesas RA6E2 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA6E2 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra6e2-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA6E2 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -208,12 +246,7 @@
 #define RA_ELC_EVENT_I3C0_WU                0x1EC /**< Wake-up Condition Detection interrupt. */
 #define RA_ELC_EVENT_TRNG_RDREQ             0x1F3 /**< TRNG Read Request. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -231,6 +264,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_I3C     23 /**< I3C */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m1-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA6M1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA6M1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra6m1_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA6M1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra6m1_elc Renesas RA6M1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA6M1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra6m1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA6M1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                      0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0                  0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1                  0x002 /**< External pin interrupt 1. */
@@ -303,12 +341,7 @@
 #define RA_ELC_EVENT_SDHIMMC1_CARD             0x1CD /**< Card detect. */
 #define RA_ELC_EVENT_SDHIMMC1_DMA_REQ          0x1CE /**< DMA transfer request. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -328,6 +361,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m2-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m2-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA6M2 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA6M2 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra6m2_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M2_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M2_ELC_H_
 
 /**
- * @name Event codes for Renesas RA6M2 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra6m2_elc Renesas RA6M2 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA6M2 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra6m2-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA6M2 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                      0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0                  0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1                  0x002 /**< External pin interrupt 1. */
@@ -336,12 +374,7 @@
 #define RA_ELC_EVENT_SDHIMMC1_CARD             0x1CD /**< Card detect. */
 #define RA_ELC_EVENT_SDHIMMC1_DMA_REQ          0x1CE /**< DMA transfer request. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -361,6 +394,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m3-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m3-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA6M3 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA6M3 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra6m3_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M3_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M3_ELC_H_
 
 /**
- * @name Event codes for Renesas RA6M3 Event Link Controller.
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra6m3_elc Renesas RA6M3 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA6M3 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra6m3-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA6M3 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                      0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0                  0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1                  0x002 /**< External pin interrupt 1. */
@@ -364,12 +402,7 @@
 #define RA_ELC_EVENT_JPEG_JEDI                 0x1FE /**< Compression/decompression interrupt. */
 #define RA_ELC_EVENT_JPEG_JDTI                 0x1FF /**< Data transfer interrupt. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -389,6 +422,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m4-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m4-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA6M4 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA6M4 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra6m4_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M4_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M4_ELC_H_
 
 /**
- * @name Event codes for Renesas RA6M4 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra6m4_elc Renesas RA6M4 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA6M4 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra6m4-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA6M4 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -298,12 +336,7 @@
 #define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
 #define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -323,6 +356,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m5-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m5-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA6M5 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA6M5 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra6m5_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M5_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M5_ELC_H_
 
 /**
- * @name Event codes for Renesas RA6M5 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra6m5_elc Renesas RA6M5 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA6M5 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra6m5-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA6M5 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
@@ -319,12 +357,7 @@
 #define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
 #define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -344,6 +377,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8d1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8d1-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA8D1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA8D1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra8d1_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8D1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8D1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA8D1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra8d1_elc Renesas RA8D1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA8D1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra8d1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA8D1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                    0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0                0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1                0x002 /**< External pin interrupt 1. */
@@ -348,12 +386,7 @@
 #define RA_ELC_EVENT_MIPIDSI_PPI             0x1D8 /**< MIPI DSI PPI. */
 #define RA_ELC_EVENT_CEU_CEUI                0x1DA /**< CEU interrupt. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -373,6 +406,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_I3C     30 /**< I3C */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8e1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8e1-elc.h
@@ -4,18 +4,56 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree macros for the Renesas RA8E1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra8e1_elc
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8E1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8E1_ELC_H_
 
 /**
- * @file
- * @brief Renesas RA8E1 Event Link Controller (ELC) definitions
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
  */
 
 /**
- * @name Event codes for Renesas RA Event Link Controller (ELC).
+ * @defgroup dt_renesas_ra8e1_elc Renesas RA8E1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA8E1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra8e1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA8E1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                    0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0                0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1                0x002 /**< External pin interrupt 1. */
@@ -270,12 +308,7 @@
 #define RA_ELC_EVENT_RSIP_TADI               0x1BC /**< RSIP Tamper Detection. */
 #define RA_ELC_EVENT_CEU_CEUI                0x1DA /**< CEU Interrupt. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -293,6 +326,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8m1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8m1-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA8M1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA8M1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra8m1_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8M1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8M1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA8M1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra8m1_elc Renesas RA8M1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA8M1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra8m1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA8M1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                    0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0                0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1                0x002 /**< External pin interrupt 1. */
@@ -338,12 +376,7 @@
 #define RA_ELC_EVENT_RSIP_TADI               0x1BC /**< RSIP Tamper Detection. */
 #define RA_ELC_EVENT_CEU_CEUI                0x1DA /**< CEU interrupt. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -363,6 +396,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_I3C     30 /**< I3C */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8t1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8t1-elc.h
@@ -6,16 +6,54 @@
 
 /**
  * @file
- * @brief Renesas RA8T1 Event Link Controller (ELC) definitions
+ * @brief Devicetree macros for the Renesas RA8T1 Event Link Controller (ELC).
+ * @ingroup dt_renesas_ra8t1_elc
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8T1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8T1_ELC_H_
 
 /**
- * @name Event codes for Renesas RA8T1 Event Link Controller (ELC).
+ * @addtogroup dt_renesas_ra_elc Devicetree Renesas RA ELC helpers
+ * @ingroup devicetree
+ */
+
+/**
+ * @defgroup dt_renesas_ra8t1_elc Renesas RA8T1 ELC devicetree macros
+ * @brief Devicetree event and peripheral macros for Renesas RA8T1 ELC routing.
+ * @ingroup dt_renesas_ra_elc
+ *
+ * This header provides macros for event and peripheral values used with the <tt>renesas,ra-elc</tt>
+ * devicetree binding.
+ *
+ * Use <tt>RA_ELC_EVENT_*</tt> values for the @c event cell and <tt>RA_ELC_PERIPHERAL_*</tt>
+ * values for the @c peripheral cell in the @c renesas-elcs phandle-array property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra8t1-elc.h>
+ *
+ * &pwm0 {
+ *         renesas-elcs = <&elc RA_ELC_PERIPHERAL_GPT_A RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0>,
+ *                        <&elc RA_ELC_PERIPHERAL_GPT_B RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1>;
+ *         renesas-elc-names = "start", "stop";
+ * };
+ * @endcode
+ *
+ * Valid cell values are device-specific:
+ *
+ * - @c event: any <tt>RA_ELC_EVENT_*</tt> macro from this header. Common prefixes include
+ *   <tt>RA_ELC_EVENT_ELC_SOFTWARE_EVENT_*</tt>, <tt>RA_ELC_EVENT_GPT*</tt>,
+ *   <tt>RA_ELC_EVENT_ADC*</tt>, <tt>RA_ELC_EVENT_IOPORT_EVENT_*</tt>, and serial, DMA,
+ *   or clock event names present on the device.
+ * - @c peripheral: any <tt>RA_ELC_PERIPHERAL_*</tt> macro from this header, for example
+ *   @c RA_ELC_PERIPHERAL_GPT_A, @c RA_ELC_PERIPHERAL_ADC0, etc.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Event codes for Renesas RA8T1 Event Link Controller (ELC). */
 #define RA_ELC_EVENT_NONE                    0x0   /**< Link disabled. */
 #define RA_ELC_EVENT_ICU_IRQ0                0x001 /**< External pin interrupt 0. */
 #define RA_ELC_EVENT_ICU_IRQ1                0x002 /**< External pin interrupt 1. */
@@ -321,12 +359,7 @@
 #define RA_ELC_EVENT_DOC_INT                 0x1BA /**< Data operation circuit interrupt. */
 #define RA_ELC_EVENT_RSIP_TADI               0x1BC /**< RSIP Tamper Detection. */
 
-/** @} */
-
-/**
- * @name Renesas RA ELC possible peripherals to be linked to event signals
- * @{
- */
+/* Renesas RA ELC peripherals that can be linked to event signals. */
 #define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
 #define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
 #define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
@@ -346,6 +379,8 @@
 #define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
 #define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
 #define RA_ELC_PERIPHERAL_I3C     30 /**< I3C */
+
+/** @endcond */
 
 /** @} */
 


### PR DESCRIPTION
Exposing over 5,000 very repetitive symbols in the public docs probably doesn't make sense and it's recommended to instead provide meaningful "prose" explaining the naming scheme of said symbols and then hide the symbols themselves from the public docs.

What's more, despite all these symbols actually having Doxygen documentation prior to this commit, they were not properly organized anyway, so this fixes that too. 

https://builds.zephyrproject.io/zephyr/pr/110566/docs/doxygen/html/group__dt__renesas__ra__elc.html