### PR TITLE
kernel: Fix k_queue locking issues

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2421,6 +2421,8 @@ int k_queue_append_list(struct k_queue *queue, void *head, void *tail);
  * This routine adds a list of data items to @a queue in one operation.
  * The data items must be in a singly-linked list implemented using a
  * sys_slist_t object. Upon completion, the original list is empty.
+ * The caller is responsible for ensuring that @a list is not concurrently
+ * accessed by other threads or ISRs.
  *
  * @isr_ok
  *

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2458,8 +2458,6 @@ __syscall void *k_queue_get(struct k_queue *queue, k_timeout_t timeout);
  * data item is reserved for the kernel's use. Removing elements from k_queue
  * rely on sys_slist_find_and_remove which is not a constant time operation.
  *
- * @note @a timeout must be set to K_NO_WAIT if called from ISR.
- *
  * @isr_ok
  *
  * @param queue Address of the queue.

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -26,6 +26,7 @@ struct alloc_node {
 	void *data;
 };
 
+/* The queue must have its spinlock held before calling this function. */
 static void *z_queue_node_peek(sys_sfnode_t *node, bool needs_free)
 {
 	void *ret;
@@ -400,7 +401,10 @@ bool k_queue_unique_append(struct k_queue *queue, void *data)
 
 void *z_impl_k_queue_peek_head(struct k_queue *queue)
 {
+	k_spinlock_key_t key = k_spin_lock(&queue->lock);
 	void *ret = z_queue_node_peek(sys_sflist_peek_head(&queue->data_q), false);
+
+	k_spin_unlock(&queue->lock, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC(k_queue, peek_head, queue, ret);
 
@@ -409,7 +413,10 @@ void *z_impl_k_queue_peek_head(struct k_queue *queue)
 
 void *z_impl_k_queue_peek_tail(struct k_queue *queue)
 {
+	k_spinlock_key_t key = k_spin_lock(&queue->lock);
 	void *ret = z_queue_node_peek(sys_sflist_peek_tail(&queue->data_q), false);
+
+	k_spin_unlock(&queue->lock, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC(k_queue, peek_tail, queue, ret);
 

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -370,8 +370,10 @@ void *z_impl_k_queue_get(struct k_queue *queue, k_timeout_t timeout)
 bool k_queue_remove(struct k_queue *queue, void *data)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_queue, remove, queue);
-
+	k_spinlock_key_t key = k_spin_lock(&queue->lock);
 	bool ret = sys_sflist_find_and_remove(&queue->data_q, (sys_sfnode_t *)data);
+
+	k_spin_unlock(&queue->lock, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_queue, remove, queue, ret);
 

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -129,11 +129,15 @@ static inline void z_vrfy_k_queue_cancel_wait(struct k_queue *queue)
 #include <zephyr/syscalls/k_queue_cancel_wait_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
+/*
+ * Common code for inserting a node into the queue.
+ * The queue's spinlock must be held prior to entry.
+ * However, that same spinlock will be unlocked before it returns.
+ */
 static int32_t queue_insert(struct k_queue *queue, void *prev, void *data,
-			    bool alloc, bool is_append)
+			    bool alloc, bool is_append, k_spinlock_key_t key)
 {
 	struct k_thread *first_pending_thread;
-	k_spinlock_key_t key = k_spin_lock(&queue->lock);
 	int32_t result = 0;
 	bool resched = false;
 
@@ -187,7 +191,8 @@ void k_queue_insert(struct k_queue *queue, void *prev, void *data)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_queue, insert, queue);
 
-	(void)queue_insert(queue, prev, data, false, false);
+	(void)queue_insert(queue, prev, data, false, false,
+			   k_spin_lock(&queue->lock));
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_queue, insert, queue);
 }
@@ -196,7 +201,8 @@ void k_queue_append(struct k_queue *queue, void *data)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_queue, append, queue);
 
-	(void)queue_insert(queue, NULL, data, false, true);
+	(void)queue_insert(queue, NULL, data, false, true,
+			   k_spin_lock(&queue->lock));
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_queue, append, queue);
 }
@@ -205,7 +211,8 @@ void k_queue_prepend(struct k_queue *queue, void *data)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_queue, prepend, queue);
 
-	(void)queue_insert(queue, NULL, data, false, false);
+	(void)queue_insert(queue, NULL, data, false, false,
+			   k_spin_lock(&queue->lock));
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_queue, prepend, queue);
 }
@@ -214,7 +221,8 @@ int32_t z_impl_k_queue_alloc_append(struct k_queue *queue, void *data)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_queue, alloc_append, queue);
 
-	int32_t ret = queue_insert(queue, NULL, data, true, true);
+	int32_t ret = queue_insert(queue, NULL, data, true, true,
+				   k_spin_lock(&queue->lock));
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_queue, alloc_append, queue, ret);
 
@@ -235,7 +243,8 @@ int32_t z_impl_k_queue_alloc_prepend(struct k_queue *queue, void *data)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_queue, alloc_prepend, queue);
 
-	int32_t ret = queue_insert(queue, NULL, data, true, false);
+	int32_t ret = queue_insert(queue, NULL, data, true, false,
+				   k_spin_lock(&queue->lock));
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_queue, alloc_prepend, queue, ret);
 

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -26,7 +26,7 @@ struct alloc_node {
 	void *data;
 };
 
-void *z_queue_node_peek(sys_sfnode_t *node, bool needs_free)
+static void *z_queue_node_peek(sys_sfnode_t *node, bool needs_free)
 {
 	void *ret;
 

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -392,18 +392,20 @@ bool k_queue_remove(struct k_queue *queue, void *data)
 bool k_queue_unique_append(struct k_queue *queue, void *data)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_queue, unique_append, queue);
+	k_spinlock_key_t key = k_spin_lock(&queue->lock);
 
 	sys_sfnode_t *test;
 
 	SYS_SFLIST_FOR_EACH_NODE(&queue->data_q, test) {
 		if (test == (sys_sfnode_t *) data) {
+			k_spin_unlock(&queue->lock, key);
 			SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_queue, unique_append, queue, false);
 
 			return false;
 		}
 	}
 
-	k_queue_append(queue, data);
+	(void)queue_insert(queue, NULL, data, false, true, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_queue, unique_append, queue, true);
 


### PR DESCRIPTION
This commit set primarily fixes a number a number of race conditions in the k_queue implementation that were related to inconsistent locking practices. It also makes a couple of minor amendments to the k_queue documentation.

Fixes: #112435