### PR TITLE
cmake: improve diagnostics when west is broken or modules are unavailable

### DIFF
--- a/cmake/modules/west.cmake
+++ b/cmake/modules/west.cmake
@@ -86,7 +86,7 @@ if(WEST_VERSION)
     execute_process(
       COMMAND ${WEST} topdir
       OUTPUT_VARIABLE WEST_TOPDIR
-      ERROR_QUIET
+      ERROR_VARIABLE west_topdir_err
       RESULT_VARIABLE west_topdir_result
       OUTPUT_STRIP_TRAILING_WHITESPACE
       WORKING_DIRECTORY ${ZEPHYR_BASE}
@@ -95,6 +95,16 @@ if(WEST_VERSION)
     if(west_topdir_result)
       # west topdir is undefined.
       # That's fine; west is optional, so could be custom Zephyr project.
+      # Print a warning so the user knows west was found but is not functional,
+      # which can cause cryptic Kconfig failures (e.g. 'depends on 0') if the
+      # project relies on west modules.
+      message(WARNING
+        "'west topdir' failed even though west ${WEST_VERSION} was found.\n"
+        "Zephyr modules will not be loaded — this will likely cause build errors.\n"
+        "Hint: a broken west installation (e.g. a missing dependency such as "
+        "colorama) can cause this. Run 'west topdir' manually to diagnose.\n"
+        "'west topdir' error output:\n${west_topdir_err}"
+      )
       set(WEST WEST-NOTFOUND CACHE INTERNAL "West")
     endif()
   endif()

--- a/cmake/modules/zephyr_module.cmake
+++ b/cmake/modules/zephyr_module.cmake
@@ -168,6 +168,14 @@ ${MODULE_NAME_UPPER} is a restricted name for Zephyr modules as it is used for \
   endforeach()
 else()
 
+  message(WARNING
+    "west is not available and ZEPHYR_MODULES is not set.\n"
+    "No Zephyr modules will be loaded. If your project depends on modules "
+    "(e.g. hal_nordic, hostap, mbedtls), the build will likely fail or "
+    "produce a silently broken configuration. "
+    "Check that west is installed and 'west topdir' succeeds."
+  )
+
   file(WRITE ${kconfig_modules_file}
     "# No west and no Zephyr modules\n"
     )


### PR DESCRIPTION
When 'west topdir' fails (e.g. due to a missing Python dependency in a
broken west installation), the build previously silenced the error and
continued with no modules loaded. This produced deeply cryptic Kconfig
warnings like:

  warning: HAS_NORDIC_DRIVERS has direct dependencies 0 with value n,
  but is currently being y-selected by ...

with no indication of the real cause. The same silent fallback occurred
when neither west nor ZEPHYR_MODULES was set.

This PR makes both failure paths loud:
- cmake/modules/west.cmake: capture 'west topdir' stderr and emit a
  WARNING with the error output and an actionable hint when it fails
  despite west being importable.
- cmake/modules/zephyr_module.cmake: emit a WARNING when falling back
  to no modules, so users know the build configuration is incomplete.

A real-world example: a user with a toolchain-bundled Python that
leaks user site-packages will pick up a newer user-installed west whose
dependencies (e.g. colorama, added in west 1.4) are not present at the
user level. 'west topdir' crashes, modules are silently dropped, and
the only symptom is a wall of 'depends on 0' Kconfig warnings. With
this fix the output immediately points to the broken west installation.

Found in NCS but these fixes are generic and helpful.