### PR TITLE
tests: mem_protect: enlarge zzz_thread stack

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -44,7 +44,7 @@ static void zzz_entry(void *p1, void *p2, void *p3)
 	k_sleep(K_FOREVER);
 }
 
-static K_THREAD_DEFINE(zzz_thread, 256 + CONFIG_TEST_EXTRA_STACK_SIZE,
+static K_THREAD_DEFINE(zzz_thread, 512 + CONFIG_TEST_EXTRA_STACK_SIZE,
 		       zzz_entry, NULL, NULL, NULL, 0, 0, 0);
 
 void *test_mem_domain_setup(void)


### PR DESCRIPTION
`zzz_thread` (mem_domain.c) has a 256-byte stack + `CONFIG_TEST_EXTRA_STACK_SIZE`, with no margin for an exception frame taken at peak stack depth. On nrf52dk/nrf52832 (Cortex-M, userspace/MPU) `kernel.memory_protection` overflows it during exception stacking when a timeslice interrupt lands while `zzz_thread` is near the top of its stack.

The overflow surfaced after the timeslice-timing correction in `c3f2a6a07ac9` ("kernel: timeslicing: rearm with slice_size-1 when slicer just fired"), which shortens each slice by a tick and shifts when the slice IRQ fires — the stack was always this tight; the timing change merely exposed it. Bumping to 512 leaves room for the exception frame rather than reverting the timing fix.

Fixes #110090