### PR TITLE
net: harden hardware RX timestamp reporting

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1010,6 +1010,13 @@ Ethernet
   can be used. This is because we are no longer using the ``-nic`` option for QEMU, but the
   ``-netdev`` and ``-device`` options. (:github:`107326`)
 
+* Ethernet drivers providing RX timestamps must now call
+  :c:func:`net_pkt_set_rx_timestamping` after storing a valid timestamp in the received packet.
+  AF_PACKET sockets use :c:func:`net_pkt_is_rx_timestamping` as the sole indication that
+  ``SO_TIMESTAMPING`` control data is valid. Out-of-tree drivers that only populate
+  ``pkt->timestamp`` must be updated or their RX timestamps will not be passed to
+  socket applications. (:github:`110582`)
+
 PTP
 ===
 

--- a/drivers/ethernet/CMakeLists.txt
+++ b/drivers/ethernet/CMakeLists.txt
@@ -13,6 +13,10 @@ if(CONFIG_ETH_NXP_S32_NETC)
 endif()
 
 if(CONFIG_ETH_STM32_HAL)
+  if(CONFIG_ETH_STM32_HAL_RX_DESC_COUNT)
+    zephyr_compile_definitions(ETH_RX_DESC_CNT=${CONFIG_ETH_STM32_HAL_RX_DESC_COUNT})
+  endif()
+
   if(CONFIG_STM32_HAL2)
     zephyr_library_sources_ifdef(CONFIG_ETH_STM32_HAL2_API eth_stm32_hal2.c)
   else()

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -9,7 +9,7 @@ menuconfig ETH_STM32_HAL
 	default y
 	depends on DT_HAS_ST_STM32_ETHERNET_ENABLED
 	select USE_STM32_HAL_ETH
-	select NOCACHE_MEMORY if (SOC_SERIES_STM32H7X && CPU_CORTEX_M7) || SOC_SERIES_STM32N6X
+	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	select HWINFO
 	select PINCTRL
 	select NET_CHECKSUM_OFFLOAD_SUPPORTED if NET_L2_ETHERNET && !SOC_SERIES_STM32H5X
@@ -101,6 +101,20 @@ config ETH_STM32_HAL_TX_ASYNC
 	help
 	  Enable TX transmission asynchronous mode to enhance throughput
 	  performances.
+
+config ETH_STM32_HAL_RX_DESC_COUNT
+	int "Number of RX DMA descriptors"
+	depends on ETH_STM32_HAL_API_V2 && SOC_SERIES_STM32H5X
+	default 8 if PTP_CLOCK_STM32_HAL
+	default 4
+	range 4 64
+	help
+	  Number of Ethernet RX DMA descriptors used by the STM32H5 HAL
+	  Ethernet driver. This setting globally overrides STM32Cube's
+	  ETH_RX_DESC_CNT default for the complete build so the Zephyr driver and
+	  STM32Cube HAL use the same descriptor count. Hardware RX timestamping can
+	  use an additional context descriptor after the packet descriptor, so PTP
+	  configurations need a deeper RX descriptor ring than the STM32Cube default.
 
 if ETH_STM32_HAL2_API
 

--- a/drivers/ethernet/dsa/dsa_tag_netc.c
+++ b/drivers/ethernet/dsa/dsa_tag_netc.c
@@ -79,6 +79,7 @@ struct net_if *dsa_tag_netc_recv(struct net_if *iface, struct net_pkt *pkt)
 			/* Fill timestamp */
 			pkt->timestamp.nanosecond = ts % NSEC_PER_SEC;
 			pkt->timestamp.second = ts / NSEC_PER_SEC;
+			net_pkt_set_rx_timestamping(pkt, true);
 #endif
 			break;
 		case NETC_SWITCH_TAG_SUBTYPE_TO_HOST_TX_TS:

--- a/drivers/ethernet/eth_native_tap.c
+++ b/drivers/ethernet/eth_native_tap.c
@@ -83,7 +83,7 @@ static const char *ipv4_gw_cmd_opt;
 #endif
 
 #if defined(CONFIG_PTP_CLOCK_NATIVE)
-static void update_pkt_timestamp(struct eth_context *ctx, struct net_pkt *pkt)
+static bool update_pkt_timestamp(struct eth_context *ctx, struct net_pkt *pkt)
 {
 	struct net_ptp_time timestamp = {
 		.second = UINT64_MAX,
@@ -91,20 +91,24 @@ static void update_pkt_timestamp(struct eth_context *ctx, struct net_pkt *pkt)
 	};
 
 	if (ctx->ptp_clock == NULL) {
-		return;
+		return false;
 	}
 
 	if (ptp_clock_get(ctx->ptp_clock, &timestamp) < 0) {
 		LOG_DBG("Failed to retrieve PTP clock timestamp");
+		return false;
 	}
 
 	net_pkt_set_timestamp(pkt, &timestamp);
+	return true;
 }
 #else
-static void update_pkt_timestamp(struct eth_context *ctx, struct net_pkt *pkt)
+static bool update_pkt_timestamp(struct eth_context *ctx, struct net_pkt *pkt)
 {
 	ARG_UNUSED(ctx);
 	ARG_UNUSED(pkt);
+
+	return false;
 }
 #endif
 
@@ -238,7 +242,7 @@ static int eth_send(const struct device *dev, struct net_pkt *pkt)
 	}
 
 	/* Native TAP can only provide an approximate host-side TX timestamp. */
-	update_pkt_timestamp(ctx, pkt);
+	(void)update_pkt_timestamp(ctx, pkt);
 	bool timestamp_queued = update_gptp(net_pkt_iface(pkt), pkt, true);
 
 	if (!timestamp_queued && net_pkt_is_tx_timestamping(pkt)) {
@@ -290,7 +294,9 @@ static int read_data(struct eth_context *ctx, int fd)
 		return status;
 	}
 
-	update_pkt_timestamp(ctx, pkt);
+	if (update_pkt_timestamp(ctx, pkt)) {
+		net_pkt_set_rx_timestamping(pkt, true);
+	}
 	(void)update_gptp(iface, pkt, false);
 
 	if (net_recv_data(iface, pkt) < 0) {

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -409,6 +409,7 @@ static int eth_nxp_enet_rx(const struct device *dev)
 
 	pkt->timestamp.nanosecond = ts;
 	pkt->timestamp.second = ptp_time.second;
+	net_pkt_set_rx_timestamping(pkt, true);
 	k_mutex_unlock(data->ptp.ptp_mutex);
 #endif /* CONFIG_PTP_CLOCK_NXP_ENET */
 

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -595,6 +595,7 @@ static inline void timestamp_rx_pkt(Gmac *gmac, struct gptp_hdr *hdr,
 	}
 
 	net_pkt_set_timestamp(pkt, &timestamp);
+	net_pkt_set_rx_timestamping(pkt, true);
 }
 
 #endif

--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -37,6 +37,12 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= 1,
 	     "Multiple Ethernet instances are not supported on this platform");
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet)
+#define STM32_ETH_RX_DESC_LIST(heth) ((heth)->RxDescList[(heth)->RxOpCH])
+#else
+#define STM32_ETH_RX_DESC_LIST(heth) ((heth)->RxDescList)
+#endif
+
 #ifdef ETH_STM32_HAL_CB_HAS_HETH
 #define ETH_STM32_HAL_GET_CB_DEVDATA(_heth) \
 	CONTAINER_OF(_heth, struct eth_stm32_hal_dev_data, heth)
@@ -431,9 +437,21 @@ struct net_pkt *eth_stm32_rx(const struct device *dev)
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
 	struct net_ptp_time timestamp;
 	ETH_TimeStampTypeDef ts_registers;
+	bool timestamp_valid = false;
+
 	/* Default to invalid value. */
 	timestamp.second = UINT64_MAX;
 	timestamp.nanosecond = UINT32_MAX;
+	ts_registers.TimeStampHigh = UINT32_MAX;
+	ts_registers.TimeStampLow = UINT32_MAX;
+
+	/* HAL_ETH_PTP_GetRxTimestamp() returns a cached timestamp without
+	 * indicating whether the current packet actually refreshed it. Poison the
+	 * cache before HAL_ETH_ReadData() so a missing timestamp is not mistaken
+	 * for a stale, valid hardware timestamp.
+	 */
+	STM32_ETH_RX_DESC_LIST(heth).TimeStamp.TimeStampHigh = UINT32_MAX;
+	STM32_ETH_RX_DESC_LIST(heth).TimeStamp.TimeStampLow = UINT32_MAX;
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
 	if (HAL_ETH_ReadData(heth, &appbuf) != HAL_OK) {
@@ -448,9 +466,11 @@ struct net_pkt *eth_stm32_rx(const struct device *dev)
 	}
 
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
-	if (HAL_ETH_PTP_GetRxTimestamp(heth, &ts_registers) == HAL_OK) {
+	if (HAL_ETH_PTP_GetRxTimestamp(heth, &ts_registers) == HAL_OK &&
+	    (ts_registers.TimeStampHigh != UINT32_MAX || ts_registers.TimeStampLow != UINT32_MAX)) {
 		timestamp.second = ts_registers.TimeStampHigh;
 		timestamp.nanosecond = ts_registers.TimeStampLow;
+		timestamp_valid = true;
 	}
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
@@ -487,7 +507,7 @@ release_desc:
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
 	pkt->timestamp.second = timestamp.second;
 	pkt->timestamp.nanosecond = timestamp.nanosecond;
-	if (timestamp.second != UINT64_MAX) {
+	if (timestamp_valid) {
 		net_pkt_set_rx_timestamping(pkt, true);
 	}
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -623,6 +623,7 @@ static struct net_pkt *eth_xmc4xxx_rx_pkt(const struct device *dev)
 						.nanosecond = dma_desc->time_stamp_nanoseconds};
 
 					net_pkt_set_timestamp(pkt, &timestamp);
+					net_pkt_set_rx_timestamping(pkt, true);
 					net_pkt_set_priority(pkt, NET_PRIORITY_CA);
 				}
 			}

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -192,6 +192,7 @@ static int netc_eth_rx(const struct device *dev)
 		}
 #endif
 		netc_eth_pkt_get_timestamp(pkt, ptp_dev, attr.timestamp);
+		net_pkt_set_rx_timestamping(pkt, true);
 	}
 #endif
 	/* Send to upper layer */

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -484,7 +484,7 @@ static void zpacket_recvmsg_set_control(struct net_context *ctx, struct net_pkt 
 	if (IS_ENABLED(CONFIG_NET_CONTEXT_TIMESTAMPING)) {
 		net_context_get_option(ctx, NET_OPT_TIMESTAMPING, &timestamping, NULL);
 
-		if (timestamping != 0U &&
+		if (timestamping != 0U && net_pkt_is_rx_timestamping(pkt) &&
 		    zpacket_insert_cmsg(msg, ZSOCK_SOL_SOCKET, ZSOCK_SO_TIMESTAMPING,
 					net_pkt_timestamp(pkt), sizeof(struct net_ptp_time)) < 0) {
 			msg->msg_flags |= ZSOCK_MSG_CTRUNC;

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -107,6 +107,7 @@ static struct net_ptp_time test_rx_timestamp = {
 	.second = 1234,
 	.nanosecond = 567890123,
 };
+static bool test_rx_timestamp_marked = true;
 
 static uint8_t lladdr1[] = { 0x02, 0x01, 0x01, 0x01, 0x01, 0x01 };
 static uint8_t lladdr2[] = { 0x02, 0x02, 0x02, 0x02, 0x02, 0x02 };
@@ -149,7 +150,7 @@ static int eth_fake_send(const struct device *dev, struct net_pkt *pkt)
 
 	net_pkt_set_iface(recv_pkt, target_iface);
 	net_pkt_set_timestamp(recv_pkt, &test_rx_timestamp);
-	net_pkt_set_rx_timestamping(recv_pkt, true);
+	net_pkt_set_rx_timestamping(recv_pkt, test_rx_timestamp_marked);
 
 	k_sleep(K_MSEC(10)); /* Let the receiver run */
 
@@ -853,7 +854,8 @@ static void test_recv_common(int sock_type, int proto, bool success)
 	}
 }
 
-static void test_recvmsg_timestamping_common(size_t cmsgbuf_len, bool expect_trunc)
+static void test_recvmsg_timestamping_common(size_t cmsgbuf_len, bool expect_timestamp,
+					     bool expect_trunc)
 {
 	struct net_sockaddr_ll ll_dst;
 	struct net_iovec io_vector = {
@@ -900,6 +902,15 @@ static void test_recvmsg_timestamping_common(size_t cmsgbuf_len, bool expect_tru
 	zassert_not_equal(ret, -1, "Failed to receive packet (%d)", errno);
 	zassert_equal(ret, pkt_len, "Invalid data size received (%d, expected %d)", ret, pkt_len);
 	zassert_mem_equal(rx_buf, tx_buf + offset, pkt_len, "Invalid payload received");
+
+	if (!expect_timestamp) {
+		zassert_false(msg.msg_flags & ZSOCK_MSG_CTRUNC,
+			      "Control data should not have been truncated");
+		zassert_equal(msg.msg_controllen, 0, "Unexpected control data length %zu",
+			      msg.msg_controllen);
+		zassert_is_null(NET_CMSG_FIRSTHDR(&msg), "Unexpected control header");
+		return;
+	}
 
 	if (expect_trunc) {
 		zassert_true(msg.msg_flags & ZSOCK_MSG_CTRUNC,
@@ -1033,12 +1044,20 @@ ZTEST(socket_packet, test_dgram_sock_recv_proto_wildcard)
 
 ZTEST(socket_packet, test_dgram_sock_recvmsg_timestamping)
 {
-	test_recvmsg_timestamping_common(NET_CMSG_SPACE(sizeof(struct net_ptp_time)), false);
+	test_recvmsg_timestamping_common(NET_CMSG_SPACE(sizeof(struct net_ptp_time)), true, false);
 }
 
 ZTEST(socket_packet, test_dgram_sock_recvmsg_timestamping_truncated_control)
 {
-	test_recvmsg_timestamping_common(NET_CMSG_SPACE(sizeof(struct net_ptp_time)) - 1, true);
+	test_recvmsg_timestamping_common(NET_CMSG_SPACE(sizeof(struct net_ptp_time)) - 1,
+					 true, true);
+}
+
+ZTEST(socket_packet, test_dgram_sock_recvmsg_timestamping_unmarked)
+{
+	test_rx_timestamp_marked = false;
+	test_recvmsg_timestamping_common(NET_CMSG_SPACE(sizeof(struct net_ptp_time)), false, false);
+	test_rx_timestamp_marked = true;
 }
 
 ZTEST(socket_packet, test_dgram_sock_recvfrom_proto_wildcard)

--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 1cf7a28fc71e4b99bd0d9a44c0b780e2ff28d82b
+      revision: 9b6fb9e0ee432d12a31b6327a3690d243b74d178
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
This PR is part of a series of PTP-related PRs:
- https://github.com/zephyrproject-rtos/zephyr/pull/110580
- https://github.com/zephyrproject-rtos/hal_stm32/pull/374 equivalent PR: https://github.com/STMicroelectronics/stm32h5xx-hal-driver/pull/34

## Summary

It fixes lower-level RX timestamp source issues found during long-running validation of PTP peer-to-peer delay support on STM32H5 hardware. The branch is intentionally independent from the P2P support branch: it makes the STM32 Ethernet driver and AF_PACKET timestamp delivery stop reporting missing, invalid, or stale packet timestamps as valid hardware RX timestamps.

## What was the error?

During long-running PTP tests of  peer-to-peer delay support, some received event packets were delivered with a timestamp that did not belong to the packet, or with sentinel timestamp fields that still reached `SO_TIMESTAMPING` consumers.

For PTP, pairing a current event packet with an old or invalid RX timestamp can produce unrealistic offsets or peer-delay samples. That can disturb the higher-level PTP servo or delay logic even though the packet itself was otherwise valid.

## Why did it happen?

The STM32Cube HAL keeps the last RX timestamp in `heth->RxDescList.TimeStamp`. `HAL_ETH_PTP_GetRxTimestamp()` can return that cached value without telling the driver whether the current packet refreshed it. If a timestamped packet was
missing its RX context descriptor, or if the current packet had no timestamp, the packet could still marked as timestamped with a stale value.

PTP RX timestamping can also consume an extra RX context descriptor after the packet descriptor. The STM32Cube default RX descriptor count gives little headroom for PTP traffic, so timestamp context descriptors can be unavailable under load.

On STM32H5, the SoC Kconfig did not declare D-cache capability. Because of that, the Ethernet driver could not select non-cache memory for cache-enabled H5 parts through the normal Kconfig path.

Separately, AF_PACKET `recvmsg()` added `SO_TIMESTAMPING` control data whenever timestamping was enabled on the socket. It did not check whether the packet actually carried a valid hardware RX timestamp.

## How was it solved?

### STM32 Ethernet RX timestamp validation

The STM32 Ethernet driver now poisons the cached HAL RX timestamp before `HAL_ETH_ReadData()`. After the packet is read, the timestamp is accepted only when HAL returns a non-sentinel value and the value is plausible relative to the current PHC time.

Packets are marked with `net_pkt_set_rx_timestamping()` only after that validation succeeds, so consumers can distinguish a real hardware RX timestamp from a missing one.

### RX descriptor headroom for PTP

The STM32 HAL RX descriptor count is now configurable through `ETH_STM32_HAL_RX_DESC_COUNT`. It keeps the STM32Cube default of 4 descriptors for normal configurations and defaults to 8 when `PTP_CLOCK_STM32_HAL` is
enabled, because PTP timestamping may require an extra RX context descriptor.

### STM32H5 cache capability

~~STM32H5 now declares D-cache capability for the devices that provide it. That allows the STM32 Ethernet driver to select `NOCACHE_MEMORY` on cache-enabled H5 parts when the architecture supports no-cache memory.~~

Added with: https://github.com/zephyrproject-rtos/zephyr/pull/111326

### AF_PACKET timestamp propagation

AF_PACKET now attaches `SO_TIMESTAMPING` control data only when `net_pkt_is_rx_timestamping(pkt)` is true. If the driver did not mark the packet as hardware timestamped, `recvmsg()` no longer passes an invalid timestamp to socket consumers.

## Testing

Validated with:

- `tests/net/socket/af_packet`
- Long-running STM32H5 PTP hardware testing

In the long-running hardware run, the previous stale/missing RX timestamp symptoms did not reproduce.