### PR TITLE
xtensa: exc: give magic custom exccause names

### DIFF
--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -10,6 +10,7 @@
 #include <xtensa_backtrace.h>
 #include <zephyr/arch/common/exc_handle.h>
 
+#include <xtensa_exc.h>
 #include <xtensa_internal.h>
 
 #include <zephyr/logging/log.h>
@@ -71,10 +72,10 @@ char *xtensa_exccause(unsigned int cause_code)
 		return "store prohibited";
 	case 32: case 33: case 34: case 35: case 36: case 37: case 38: case 39:
 		return "coprocessor disabled";
-	case 63:
+	case XTENSA_EXCCAUSE_CUSTOM_ZEPHYR_EXCEPTION:
 		/* i.e. z_except_reason */
 		return "zephyr exception";
-	case 64:
+	case XTENSA_EXCCAUSE_CUSTOM_KERNEL_OOPS:
 		return "kernel oops";
 	default:
 		return "unknown/reserved";

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -15,6 +15,7 @@
 #include <zephyr/zsr.h>
 #include <zephyr/arch/common/exc_handle.h>
 
+#include <xtensa_exc.h>
 #include <xtensa_internal.h>
 #include <xtensa_stack.h>
 
@@ -661,25 +662,28 @@ void *xtensa_excint1_c(void *esf)
 		ps = bsa->ps;
 		pc = (void *)bsa->pc;
 
-		/* We need to distinguish between an ill in xtensa_arch_except,
-		 * e.g for k_panic, and any other ill. For exceptions caused by
-		 * xtensa_arch_except calls, we also need to pass the reason_p
-		 * to xtensa_fatal_error. Since the ARCH_EXCEPT frame is in the
-		 * BSA, the first arg reason_p is stored at the A2 offset.
-		 * We assign EXCCAUSE the unused, reserved code 63; this may be
-		 * problematic if the app or new boards also decide to repurpose
-		 * this code.
-		 *
-		 * Another intentionally ill is from xtensa_arch_kernel_oops.
-		 * Kernel OOPS has to be explicitly raised so we can simply
-		 * set the reason and continue.
+		/* We intentionally use "ill" (illegal instruction) as a trap for custom exceptions.
+		 * So we need to find out if the illegal instruction is legit.
 		 */
 		if (cause == EXCCAUSE_ILLEGAL) {
 			if (pc == (void *)&xtensa_arch_except_epc) {
-				cause = 63;
+				/* For exception caused by xtensa_arch_except(reason_p) call,
+				 * we also need to pass the reason_p to xtensa_fatal_error().
+				 * Since the ARCH_EXCEPT frame is in the BSA, the first arg
+				 * reason_p is stored at the saved A2 register.
+				 *
+				 * Here, we use the custom EXCCAUSE code
+				 * XTENSA_EXCCAUSE_CUSTOM_ZEPHYR_EXCEPTION to indicate
+				 * such condition.
+				 */
+				cause = XTENSA_EXCCAUSE_CUSTOM_ZEPHYR_EXCEPTION;
 				reason = bsa->a2;
 			} else if (pc == (void *)&xtensa_arch_kernel_oops_epc) {
-				cause = 64; /* kernel oops */
+				/* This intentional ill is from xtensa_arch_kernel_oops().
+				 * Kernel OOPS has to be explicitly raised so we can simply
+				 * set the reason and continue.
+				 */
+				cause = XTENSA_EXCCAUSE_CUSTOM_KERNEL_OOPS;
 				reason = K_ERR_KERNEL_OOPS;
 
 				/* A3 contains the second argument to

--- a/arch/xtensa/include/xtensa_exc.h
+++ b/arch/xtensa/include/xtensa_exc.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_EXC_H_
+#define ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_EXC_H_
+
+/**
+ * @ingroup xtensa_internal_apis
+ * @{
+ */
+
+/** Custom EXCCAUSE code used to indicate Zephyr exception (e.g. assert) */
+#define XTENSA_EXCCAUSE_CUSTOM_ZEPHYR_EXCEPTION (63)
+
+/** Custom EXCCAUSE code used to indicate Kernel OOPS */
+#define XTENSA_EXCCAUSE_CUSTOM_KERNEL_OOPS (64)
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_EXC_H_ */


### PR DESCRIPTION
We have two custom EXCCAUSE numbers to be used for raising our own custom exceptions. Instead of having magic numbers in the code, we give them names.