### PR TITLE
MAINTAINERS: add RISC-V collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4954,6 +4954,7 @@ RISCV arch:
     - maass-hamburg
     - lstnl
     - meijemac
+    - AFOliveira
   files:
     - arch/riscv/
     - boards/enjoydigital/litex_vexriscv/


### PR DESCRIPTION
After talking with @kartben at FOSDEM, I realized I can possibly help out RISC-V on Zephyr.

Hope maintainers agree :)