### PR TITLE
drivers: wuc: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/drivers/wuc.h
+++ b/include/zephyr/drivers/wuc.h
@@ -221,8 +221,7 @@ __subsystem struct wuc_driver_api {
  * @param dev Pointer to the WUC device structure
  * @param id Wakeup source identifier
  *
- * @retval 0 If successful
- * @retval -errno Negative errno code on failure
+ * @return 0 on success, negative errno value on failure.
  */
 static inline int wuc_enable_wakeup_source(const struct device *dev, uint32_t id)
 {
@@ -234,8 +233,7 @@ static inline int wuc_enable_wakeup_source(const struct device *dev, uint32_t id
  *
  * @param spec Pointer to the WUC devicetree spec structure.
  *
- * @retval 0 If successful.
- * @retval -errno Negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 static inline int wuc_enable_wakeup_source_dt(const struct wuc_dt_spec *spec)
 {
@@ -248,8 +246,7 @@ static inline int wuc_enable_wakeup_source_dt(const struct wuc_dt_spec *spec)
  * @param dev Pointer to the WUC device structure.
  * @param id Wakeup source identifier.
  *
- * @retval 0 If successful.
- * @retval -errno Negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 static inline int wuc_disable_wakeup_source(const struct device *dev, uint32_t id)
 {
@@ -261,8 +258,7 @@ static inline int wuc_disable_wakeup_source(const struct device *dev, uint32_t i
  *
  * @param spec Pointer to the WUC devicetree spec structure.
  *
- * @retval 0 If successful.
- * @retval -errno Negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 static inline int wuc_disable_wakeup_source_dt(const struct wuc_dt_spec *spec)
 {
@@ -275,10 +271,9 @@ static inline int wuc_disable_wakeup_source_dt(const struct wuc_dt_spec *spec)
  * @param dev Pointer to the WUC device structure.
  * @param id Wakeup source identifier.
  *
- * @retval 1 If wakeup was triggered by this source.
- * @retval 0 If wakeup was not triggered by this source.
- * @retval -errno Negative errno code on failure.
- * @retval -ENOSYS if the interface is not implemented.
+ * @return 1 if wakeup was triggered by this source, 0 if not triggered, or a
+ *         negative errno value on failure.
+ * @retval -ENOSYS The interface is not implemented.
  */
 static inline int wuc_check_wakeup_source_triggered(const struct device *dev, uint32_t id)
 {
@@ -293,10 +288,9 @@ static inline int wuc_check_wakeup_source_triggered(const struct device *dev, ui
  *
  * @param spec Pointer to the WUC devicetree spec structure.
  *
- * @retval 1 If wakeup was triggered by this source.
- * @retval 0 If wakeup was not triggered by this source.
- * @retval -errno Negative errno code on failure.
- * @retval -ENOSYS if the interface is not implemented.
+ * @return 1 if wakeup was triggered by this source, 0 if not triggered, or a
+ *         negative errno value on failure.
+ * @retval -ENOSYS The interface is not implemented.
  */
 static inline int wuc_check_wakeup_source_triggered_dt(const struct wuc_dt_spec *spec)
 {
@@ -309,9 +303,8 @@ static inline int wuc_check_wakeup_source_triggered_dt(const struct wuc_dt_spec 
  * @param dev Pointer to the WUC device structure.
  * @param id Wakeup source identifier.
  *
- * @retval 0 If successful.
- * @retval -errno Negative errno code on failure.
- * @retval -ENOSYS if the interface is not implemented.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS The interface is not implemented.
  */
 static inline int wuc_clear_wakeup_source_triggered(const struct device *dev, uint32_t id)
 {
@@ -326,9 +319,8 @@ static inline int wuc_clear_wakeup_source_triggered(const struct device *dev, ui
  *
  * @param spec Pointer to the WUC devicetree spec structure.
  *
- * @retval 0 If successful.
- * @retval -errno Negative errno code on failure.
- * @retval -ENOSYS if the interface is not implemented.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS The interface is not implemented.
  */
 static inline int wuc_clear_wakeup_source_triggered_dt(const struct wuc_dt_spec *spec)
 {


### PR DESCRIPTION
Apply the same @retval/@return cleanup as in PR #107276 (pm), following the conventions documented in PR #107458.

Fixes parts of: #65974