### PR TITLE
boards: infineon: kit_pse84_ai: fix QSPI size in qspi_config.cfg

### DIFF
--- a/boards/infineon/kit_pse84_ai/support/qspi_config.cfg
+++ b/boards/infineon/kit_pse84_ai/support/qspi_config.cfg
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set SMIF_BANKS {
-  1 {addr 0x60000000 size 0x1000000 psize 0x0000100 esize 0x0010000}
+  1 {addr 0x60000000 size 0x4000000 psize 0x0000100 esize 0x0010000}
 }


### PR DESCRIPTION
The board file support/qspi_config.cfg was copied from kit_pse84_eval without updating the SMIF bank size. kit_pse84_eval hosts an S25FS128S (16 MB / 0x1000000 bytes), while kit_pse84_ai hosts an S25HS512T (64 MB / 0x4000000 bytes) -- see the infineon,s25hs512t compatible and reg = <0x08000000 DT_SIZE_M(64)> in kit_pse84_ai_memory_map.dtsi.

Update the SMIF_BANKS entry so the cmsis_flash banks registered by cat1d's define_flash_banks (cat1d.cm33.smif1_ns @ 0x60000000 and cat1d.cm33.smif1_s @ 0x70000000 via the virtual mirror) cover the full 64 MB device. Without the fix, writes to QSPI offsets beyond 0x1000000 are rejected by OpenOCD as out-of-bank.

Verified on PSE846GPS2DBZC4A: after the update, flash banks reports the smif banks at size 0x04000000 and west flash programs adc_dt (61440 bytes) and the enable_cm55 signed image (49152 bytes) through PSE84_SMIF.FLM without errors.

Assisted-by: GitHub Copilot (Claude Opus 4.7)