### PR TITLE
spi: nxp_lpspi: fix GPIO CS timing

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -16,6 +16,8 @@ struct lpspi_driver_data {
 	size_t words_clocked;
 	uint8_t word_size_bytes;
 	uint8_t lpspi_op_mode;
+	bool tx_only;
+	bool tx_completion_requested;
 };
 
 /* Reads a word from the RX fifo and handles writing it into the RX spi buf */
@@ -243,6 +245,7 @@ static void lpspi_isr(const struct device *dev)
 	uint8_t word_size_bytes = lpspi_data->word_size_bytes;
 	struct spi_context *ctx = &data->ctx;
 	uint32_t status_flags = base->SR;
+	bool rx_done;
 
 	if (status_flags & LPSPI_SR_RDF_MASK && base->IER & LPSPI_IER_RDIE_MASK) {
 		lpspi_handle_rx_irq(dev);
@@ -252,12 +255,34 @@ static void lpspi_isr(const struct device *dev)
 		lpspi_handle_tx_irq(dev);
 	}
 
-	if (spi_context_rx_len_left(ctx, word_size_bytes) == 0) {
+	rx_done = (spi_context_rx_len_left(ctx, word_size_bytes) == 0);
+	if (rx_done) {
 		base->IER &= ~LPSPI_IER_RDIE_MASK;
 		base->CR |= LPSPI_CR_RRF_MASK; /* flush rx fifo */
 	}
 
 	if (spi_context_tx_on(ctx)) {
+		return;
+	}
+
+	if (lpspi_data->tx_only && rx_done) {
+		base->IER &= ~(LPSPI_IER_TDIE_MASK | LPSPI_IER_RDIE_MASK);
+
+		if (!lpspi_data->tx_completion_requested) {
+			if (!(ctx->config->operation & SPI_HOLD_ON_CS)) {
+				base->TCR &= ~(LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK);
+			}
+			lpspi_data->tx_completion_requested = true;
+		}
+
+		if (base->SR & LPSPI_SR_TCF_MASK) {
+			base->SR = LPSPI_SR_TCF_MASK;
+			base->IER &= ~LPSPI_IER_TCIE_MASK;
+			lpspi_end_xfer(dev);
+			return;
+		}
+
+		base->IER |= LPSPI_IER_TCIE_MASK;
 		return;
 	}
 
@@ -374,6 +399,8 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 
 	spi_context_buffers_setup(ctx, tx_bufs, rx_bufs, lpspi_data->word_size_bytes);
 	lpspi_data->lpspi_op_mode = op_mode;
+	lpspi_data->tx_only = (spi_context_total_rx_len(ctx) == 0);
+	lpspi_data->tx_completion_requested = false;
 
 	ret = lpspi_configure(dev, spi_cfg);
 	if (ret) {

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -163,13 +163,14 @@ static inline uint32_t lpspi_set_delays(const struct device *dev,
 					uint32_t prescaled_clock)
 {
 	const struct lpspi_config *config = dev->config;
+	bool gpio_cs = spi_cs_is_gpio(spi_cfg);
 	uint32_t val = 0;
 
-	if (!spi_cs_is_gpio(spi_cfg)) {
+	if (!gpio_cs || config->pcs_sck_delay > 0 || config->sck_pcs_delay > 0) {
 		uint32_t lead_time_ns = config->pcs_sck_delay > 0 ?
-					config->pcs_sck_delay : spi_cfg->cs.setup_ns;
+					config->pcs_sck_delay : (gpio_cs ? 0 : spi_cfg->cs.setup_ns);
 		uint32_t lag_time_ns = config->sck_pcs_delay > 0 ?
-					config->sck_pcs_delay : spi_cfg->cs.hold_ns;
+					config->sck_pcs_delay : (gpio_cs ? 0 : spi_cfg->cs.hold_ns);
 
 		val |= LPSPI_CCR_PCSSCK(lpspi_calc_delay_scaler(lead_time_ns,
 								prescaled_clock, 1)) |

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_dma.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_dma.c
@@ -276,6 +276,7 @@ static void lpspi_dma_callback(const struct device *dev, void *arg, uint32_t cha
 	case LPSPI_TRANSFER_STATE_TX_DONE:
 	case LPSPI_TRANSFER_STATE_RX_DONE:
 		dma_data->state = LPSPI_TRANSFER_STATE_RX_TX_DONE;
+		base->DER &= ~(LPSPI_DER_TDDE_MASK | LPSPI_DER_RDDE_MASK);
 		/* TX and RX both done here. */
 		spi_context_complete(ctx, spi_dev, 0);
 		spi_context_cs_control(ctx, false);
@@ -291,6 +292,7 @@ static void lpspi_dma_callback(const struct device *dev, void *arg, uint32_t cha
 	return;
 error:
 	LOG_ERR("DMA callback error with channel %d.", channel);
+	base->DER &= ~(LPSPI_DER_TDDE_MASK | LPSPI_DER_RDDE_MASK);
 	spi_context_complete(ctx, spi_dev, ret);
 	spi_context_cs_control(ctx, false);
 }
@@ -332,6 +334,7 @@ static int transceive_dma(const struct device *dev, const struct spi_config *spi
 	/* Set next dma size is invalid. */
 	dma_data->synchronize_dma_size = 0;
 	dma_data->state = LPSPI_TRANSFER_STATE_NULL;
+	base->DER &= ~(LPSPI_DER_TDDE_MASK | LPSPI_DER_RDDE_MASK);
 
 	/* Load dma block */
 	ret = lpspi_dma_rxtx_load(dev);
@@ -347,6 +350,7 @@ static int transceive_dma(const struct device *dev, const struct spi_config *spi
 
 	ret = spi_context_wait_for_completion(ctx);
 	if (ret) {
+		base->DER &= ~(LPSPI_DER_TDDE_MASK | LPSPI_DER_RDDE_MASK);
 		spi_context_cs_control(ctx, false);
 	}
 out:


### PR DESCRIPTION
This PR is to demonstrate some fixes to the nxp lpspi driver when used with GPIO base chip selects.

see 

https://github.com/zephyrproject-rtos/zephyr/issues/110302

  
## What Changed

  ### GPIO CS delay handling

  The driver now honors explicit `pcs-sck-delay` and `sck-pcs-delay` values even when chip select is
  GPIO-controlled.

  The default GPIO-CS behavior is intentionally preserved unless those delay properties are explicitly
  provided.

  ### CPU/IRQ TX-only completion

  The CPU/IRQ path now detects TX-only transfers and waits for `LPSPI_SR_TCF` before completing the SPI
  context and deasserting GPIO CS.

  This prevents command-only and single byte transfers, such as a JEDEC SPI NOR `WREN`, from dropping CS before the final
  clocks have completed.

  ### DMA request cleanup

  The DMA path now clears LPSPI TX/RX DMA request-enable bits before transfer setup, on completion, on
  error, and after wait-for-completion errors.

  This prevents stale request enables from carrying into the next GPIO-CS transaction.

  ## Tests/validation

  Validated with external Saleae logic pro captures on FRDM-MCXA156

  Observed before the fix:

  - CPU/IRQ + GPIO CS: insufficient setup time between GPIO CS assertion / MOSI transition and the
  first SCK edge.  THis was an issue when the final bit of a prior transaction was differen tthat the 1st bit of the next.
  - CPU/IRQ TX-only: GPIO CS could deassert before all clocks for a one-byte command completed.
  - DMA + GPIO CS: SCK could begin before GPIO CS assertion at higher SPI speeds.

  Observed after the fix:

  - Explicit GPIO-CS delay properties produce visible setup margin before the first clock.
  - TX-only command transfers keep CS asserted until transfer complete.
  - DMA transfers no longer begin clocking before GPIO CS assertion.

  Additional tests were performed on MCXA156-based custom hardware using GPIO chip selects

  - LPSPI0 CPU/IRQ path tested @16MHz with multiple SPI devices  TI TIC12400, ST L9026 and a  ST VN9D5D20FN 
  - LPSPI1 DMA path tested@16MHz  with an  FRAM (FM25L16B-GTR) and SPI NOR (W25Q128 ).
  
Prior to this fix we had to use bitbang SPI.

  ## Notes For Reviewers

  This was validated on MCXA156. Since the NXP LPSPI driver supports multiple SoCs and LPSPI revisions,
  the intent is for maintainers to review whether this is the right common-driver sequencing or whether
  any SoC-specific handling is needed.

  No ztest is included at this stage because the failures are external signal-timing issues involving
  GPIO CS, SCK, and MOSI. A logical or internal-loopback SPI test may pass while the external setup/
  hold timing is still invalid.