### PR TITLE
drivers: display: add RBW support for st730x + various

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -190,6 +190,9 @@ Display
   :c:enumerator:`PIXEL_FORMAT_BGR_888`, for which the LVGL glue performs the red/blue channel swap
   automatically.
 
+* The Kconfig options ``CONFIG_ST730X_POWERMODE_LOW`` for ST7305 and ST7306 displays has been
+  removed in favour of toggling the low-power-mode property on the device node.
+
 DMA
 ===
 

--- a/drivers/display/Kconfig.st730x
+++ b/drivers/display/Kconfig.st730x
@@ -6,6 +6,8 @@ config ST730X
 	default y
 	depends on DT_HAS_SITRONIX_ST7305_ENABLED || DT_HAS_SITRONIX_ST7306_ENABLED
 	select MIPI_DBI
+	imply DISPLAY_COLOR_PALETTE \
+		if $(dt_compat_any_has_prop,$(DT_COMPAT_SITRONIX_ST7306),color-mode,RBW)
 	help
 	  Enable driver for ST730X series display controllers.
 
@@ -18,9 +20,12 @@ config ST730X_CONV_BUFFER_LINE_CNT
 	help
 	  Size of the conversion buffer in lines.
 
-config ST730X_POWERMODE_LOW
-	bool "Use low power mode"
+config ST730X_DEFAULT_PALETTED
+	bool "ST730X default mode is paletted i4"
+	default y if $(dt_compat_any_has_prop,$(DT_COMPAT_SITRONIX_ST7306),color-mode,RBW)
+	depends on DT_HAS_SITRONIX_ST7306_ENABLED
+	select DISPLAY_COLOR_PALETTE
 	help
-	  Enable this to use lower framerate LPM (Low Power Mode).
+	  Sets paletted i4 mode as the default color mode
 
 endif # ST730X

--- a/drivers/display/display_st730x.c
+++ b/drivers/display/display_st730x.c
@@ -78,17 +78,35 @@ LOG_MODULE_REGISTER(st730x, CONFIG_DISPLAY_LOG_LEVEL);
 #define ST730X_RESET_DELAY 100
 #define ST730X_SLEEP_DELAY 100
 
-#ifdef CONFIG_ST730X_POWERMODE_LOW
-#define ST730X_POWER_MODE ST730X_LPM
-#else
-#define ST730X_POWER_MODE ST730X_HPM
-#endif
-
 /* ST730x controllers have an evil data format for b&w
  * where the pixels are ordered at each address as such:
  * p1  p3  p5  p7
  * p2  p4  p6  p8
+ *
+ * With data transfer order following the pixel numbering.
+ *
+ * Additionally, ST7306 supports multiple color modes:
+ *
+ * RBW format is as such in the configuration supported:
+ * p1 p1 p3 p3
+ * p2 p2 p4 p4
+ *
+ * 0: Off
+ * 1: Red
+ * 2: White
+ * 3: Black
+ *
+ * Other color modes are not supported.
+ *
  */
+
+#define RBW_PIX(_p, _color)						\
+	((((uint8_t)(_color) & 0x2) << (6U - ((_p) & 0xfe) - (_p)))	\
+	| (((uint8_t)(_color) & 0x1) << (5U - ((_p) & 0xfe) - (_p))))
+
+/* Flip bits, 0 is no flip, 1 is flip, avoids conditional */
+#define RBW_COLOR_FLIP(_color, _flipv) \
+	((((_color) & 0x2) >> (_flipv)) | (((_color) & 0x1) << (_flipv)))
 
 struct st730x_specific {
 	uint8_t column_offset;
@@ -117,10 +135,23 @@ struct st730x_config {
 	uint8_t hpm_gate_waveform[ST730X_HPM_GATE_WAVEFORM_LEN];
 	uint8_t lpm_gate_waveform[ST730X_LPM_GATE_WAVEFORM_LEN];
 	bool color_inversion;
+	bool low_power_mode;
 	uint8_t te_mode;
 	uint32_t te_delay;
+	uint32_t bppx;
+	uint32_t bppy;
+	bool is_rbw;
+	uint8_t mono_color;
+	bool flip_color_bits;
+#if defined(CONFIG_DISPLAY_COLOR_PALETTE)
+	uint32_t color_palette[CONFIG_DISPLAY_COLOR_PALETTE_MAX_SIZE];
+#endif
 	uint8_t *conversion_buf;
 	size_t conversion_buf_size;
+};
+
+struct st730x_data {
+	enum display_pixel_format current_pixel_format;
 };
 
 static int st730x_resume(const struct device *dev)
@@ -304,16 +335,21 @@ static inline int st730x_set_hardware_config(const struct device *dev)
 		return err;
 	}
 
+	if (config->low_power_mode) {
+		return mipi_dbi_command_write(config->mipi_dev, &config->dbi_config,
+					      ST730X_LPM, NULL, 0);
+	}
+
 	return mipi_dbi_command_write(config->mipi_dev, &config->dbi_config,
-				     ST730X_POWER_MODE, NULL, 0);
+				      ST730X_HPM, NULL, 0);
 }
 
 /* Convert what the conversion buffer can hold to the st730x format */
-static int st730x_convert(const struct device *dev, const uint8_t *buf, uint32_t offset,
-			       const struct display_buffer_descriptor *desc)
+static int st730x_convert_mono_mono(const struct device *dev, const uint8_t *buf, uint32_t offset,
+				    const struct display_buffer_descriptor *desc)
 {
 	const struct st730x_config *config = dev->config;
-	uint32_t vertical_offset = desc->width / ST730X_PPB;
+	const uint32_t vertical_offset = desc->width / ST730X_PPB;
 	uint32_t i = 0;
 	uint32_t ipos, ipos_zeroed;
 	uint32_t max_lines = (config->conversion_buf_size / (desc->width / ST730X_PPB)) & ~0x1;
@@ -325,8 +361,8 @@ static int st730x_convert(const struct device *dev, const uint8_t *buf, uint32_t
 
 	for (; (offset + i) < desc->height && i < max_lines; i += ST730X_PPYA) {
 		ipos = (offset + i) * vertical_offset;
-		ipos_zeroed = i * vertical_offset / ST730X_PPYA;
-		for (uint32_t j = 0; j < desc->width / ST730X_PPB ; j++) {
+		ipos_zeroed = (i * vertical_offset) / ST730X_PPYA;
+		for (uint32_t j = 0; j < desc->width / ST730X_PPB; j++) {
 			config->conversion_buf[(ipos_zeroed + j) * 2 + 1] =
 				(buf[ipos + j + vertical_offset] & 0x80) >> 7
 				| (buf[ipos + j] & 0x80) >> 6
@@ -351,40 +387,151 @@ static int st730x_convert(const struct device *dev, const uint8_t *buf, uint32_t
 	return i;
 }
 
+static int st730x_convert_rbw_mono(const struct device *dev, const uint8_t *buf, uint32_t offset,
+				   const struct display_buffer_descriptor *desc)
+{
+	const struct st730x_config *config = dev->config;
+	const uint8_t color = RBW_COLOR_FLIP(config->mono_color, config->flip_color_bits ? 1 : 0);
+	const uint32_t vertical_offset = desc->width / ST730X_PPB;
+	uint32_t i = 0;
+	uint32_t ipos, ipos_zeroed, jpos_zeroed;
+	uint32_t max_lines = config->conversion_buf_size
+		/ ((desc->width * config->bppx) / ST730X_PPB);
+
+	if (max_lines < ST730X_PPYA) {
+		LOG_ERR("Buffer too small, cannot convert");
+		return -EINVAL;
+	}
+
+	for (; (offset + i) < desc->height && i < max_lines; i += ST730X_PPYA) {
+		ipos = (offset + i) * vertical_offset;
+		ipos_zeroed = i * (vertical_offset * config->bppx);
+		for (uint32_t j = 0; j < desc->width / ST730X_PPB ; j++) {
+			jpos_zeroed = ipos_zeroed + j * config->bppx * 2;
+			config->conversion_buf[jpos_zeroed + 3] =
+				RBW_PIX(0, (buf[ipos + j] & 0x40) ? color : 0)
+				| RBW_PIX(1, (buf[ipos + j + vertical_offset] & 0x40) ? color : 0)
+				| RBW_PIX(2, (buf[ipos + j] & 0x80) ? color : 0)
+				| RBW_PIX(3, (buf[ipos + j + vertical_offset] & 0x80) ? color : 0);
+			config->conversion_buf[jpos_zeroed + 2] =
+				RBW_PIX(0, (buf[ipos + j] & 0x10) ? color : 0)
+				| RBW_PIX(1, (buf[ipos + j + vertical_offset] & 0x10) ? color : 0)
+				| RBW_PIX(2, (buf[ipos + j] & 0x20) ? color : 0)
+				| RBW_PIX(3, (buf[ipos + j + vertical_offset] & 0x20) ? color : 0);
+			config->conversion_buf[jpos_zeroed + 1] =
+				RBW_PIX(0, (buf[ipos + j] & 0x4) ? color : 0)
+				| RBW_PIX(1, (buf[ipos + j + vertical_offset] & 0x4) ? color : 0)
+				| RBW_PIX(2, (buf[ipos + j] & 0x8) ? color : 0)
+				| RBW_PIX(3, (buf[ipos + j + vertical_offset] & 0x8) ? color : 0);
+			config->conversion_buf[jpos_zeroed] =
+				RBW_PIX(0, (buf[ipos + j] & 0x1) ? color : 0)
+				| RBW_PIX(1, (buf[ipos + j + vertical_offset] & 0x1) ? color : 0)
+				| RBW_PIX(2, (buf[ipos + j] & 0x2) ? color : 0)
+				| RBW_PIX(3, (buf[ipos + j + vertical_offset] & 0x2) ? color : 0);
+		}
+	}
+
+	return i;
+}
+
+static int st730x_convert_rbw_i4(const struct device *dev, const uint8_t *buf, uint32_t offset,
+				 const struct display_buffer_descriptor *desc)
+{
+	const struct st730x_config *config = dev->config;
+	const uint32_t vertical_offset = desc->width / 2;
+	const uint32_t flip = config->flip_color_bits ? 1 : 0;
+	uint32_t i = 0;
+	uint32_t jpos, ipos, ipos_zeroed, jpos_zeroed;
+	uint32_t max_lines = config->conversion_buf_size
+		/ ((desc->width * config->bppx) / ST730X_PPB);
+
+	if (max_lines < ST730X_PPYA) {
+		LOG_ERR("Buffer too small, cannot convert");
+		return -EINVAL;
+	}
+
+	for (; (offset + i) < desc->height && i < max_lines; i += ST730X_PPYA) {
+		ipos = (offset + i) * vertical_offset;
+		ipos_zeroed = i * (desc->width / ST730X_PPB) * config->bppx;
+		for (uint32_t j = 0; j < desc->width; j += 2) {
+			jpos = ipos + j / 2;
+			jpos_zeroed = ipos_zeroed + (j * config->bppx * 2) / ST730X_PPB;
+			config->conversion_buf[jpos_zeroed] =
+				RBW_PIX(0, RBW_COLOR_FLIP((buf[jpos] & 0x30) >> 4, flip))
+				| RBW_PIX(1, RBW_COLOR_FLIP(
+					(buf[jpos + vertical_offset] & 0x30) >> 4, flip))
+				| RBW_PIX(2, RBW_COLOR_FLIP(buf[jpos] & 0x3, flip))
+				| RBW_PIX(3,
+					  RBW_COLOR_FLIP(buf[jpos + vertical_offset] & 0x3, flip));
+		}
+	}
+
+	return i;
+}
+
 static int st730x_write(const struct device *dev, const uint16_t x, const uint16_t y,
 			 const struct display_buffer_descriptor *desc, const void *buf)
 {
 	const struct st730x_config *config = dev->config;
+	struct st730x_data *data = dev->data;
+	int (*convert_function)(const struct device *dev, const uint8_t *buf, uint32_t offset,
+				const struct display_buffer_descriptor *desc);
 	int err;
 	size_t buf_len;
 	uint32_t processed = 0;
 	int i;
 	struct display_buffer_descriptor mipi_desc = *desc;
-	uint8_t x_start = config->specifics->column_offset + (config->start_column + x)
-			  / ST730X_PPXA;
+	uint8_t x_start = config->specifics->column_offset
+			  + ((config->start_column + x) * config->bppx) / ST730X_PPXA;
 	uint8_t x_end = config->specifics->column_offset
-			+ (config->start_column + x + desc->width) / ST730X_PPXA - 1;
+			+ ((config->start_column + x + desc->width) * config->bppx)
+			/ ST730X_PPXA - 1;
 	uint8_t x_position[] = {x_start, x_end};
-	uint8_t y_position[] = {y / ST730X_PPYA, (y + desc->height) / ST730X_PPYA - 1};
+	uint8_t y_position[] = {(y * config->bppy) / ST730X_PPYA,
+			((y + desc->height) * config->bppy) / ST730X_PPYA - 1};
+
+	if (desc->height * desc->width == 0) {
+		return 0;
+	}
 
 	if (desc->pitch != desc->width) {
 		LOG_ERR("Pitch is not width");
 		return -EINVAL;
 	}
 
-	buf_len = MIN(desc->buf_size, desc->height * desc->width / ST730X_PPB);
-	if (buf == NULL || buf_len == 0U) {
+	if (data->current_pixel_format == PIXEL_FORMAT_MONO01) {
+		buf_len = (desc->height * desc->width) / ST730X_PPB;
+		if (config->is_rbw) {
+			convert_function = st730x_convert_rbw_mono;
+		} else {
+			convert_function = st730x_convert_mono_mono;
+		}
+	} else if (config->is_rbw && data->current_pixel_format == PIXEL_FORMAT_I_4) {
+		buf_len = (desc->height * desc->width) / 2;
+		convert_function = st730x_convert_rbw_i4;
+	} else {
+		return -ENOTSUP;
+	}
+
+	if (desc->buf_size < buf_len) {
+		LOG_ERR("Display buffer is invalid");
+		return -EINVAL;
+	}
+
+	if (buf == NULL || desc->buf_size == 0U) {
 		LOG_ERR("Display buffer is not available");
 		return -EINVAL;
 	}
 
-	if (x % ST730X_PPXA || desc->width % ST730X_PPXA) {
-		LOG_ERR("X coordinate and size must be aligned by 12 pixels");
+	if (x % (ST730X_PPXA / config->bppx) || desc->width % (ST730X_PPXA / config->bppx)) {
+		LOG_ERR("X coordinate and size must be aligned by %d pixels (got %d and %d)",
+			ST730X_PPXA / config->bppx, x, desc->width);
 		return -EINVAL;
 	}
 
-	if (y % ST730X_PPYA || desc->height % ST730X_PPYA) {
-		LOG_ERR("Y coordinate and size must be aligned by 2 pixels");
+	if (y % (ST730X_PPYA / config->bppy) || desc->height % (ST730X_PPYA / config->bppy)) {
+		LOG_ERR("Y coordinate and size must be aligned by %d pixels (got %d and %d)",
+			ST730X_PPYA / config->bppy, y, desc->height);
 		return -EINVAL;
 	}
 
@@ -411,8 +558,7 @@ static int st730x_write(const struct device *dev, const uint16_t x, const uint16
 	mipi_desc.frame_incomplete = true;
 
 	while (desc->height > processed) {
-		i = st730x_convert(dev, buf, processed, desc);
-
+		i = convert_function(dev, buf, processed, desc);
 		if (i < 0) {
 			return i;
 		}
@@ -421,7 +567,7 @@ static int st730x_write(const struct device *dev, const uint16_t x, const uint16
 			mipi_desc.frame_incomplete = false;
 		}
 
-		mipi_desc.buf_size = i * desc->width / ST730X_PPB;
+		mipi_desc.buf_size = (i * desc->width * config->bppx * config->bppy) / ST730X_PPB;
 		mipi_desc.width = desc->width;
 		mipi_desc.height = i;
 
@@ -431,6 +577,7 @@ static int st730x_write(const struct device *dev, const uint16_t x, const uint16
 		if (err < 0) {
 			return err;
 		}
+
 		processed += i;
 	}
 
@@ -440,20 +587,36 @@ static int st730x_write(const struct device *dev, const uint16_t x, const uint16
 static void st730x_get_capabilities(const struct device *dev, struct display_capabilities *caps)
 {
 	const struct st730x_config *config = dev->config;
+	struct st730x_data *data = dev->data;
 
 	memset(caps, 0, sizeof(struct display_capabilities));
 	caps->x_resolution = config->width;
 	caps->y_resolution = config->height;
-	caps->supported_pixel_formats = PIXEL_FORMAT_MONO01;
-	caps->current_pixel_format = PIXEL_FORMAT_MONO01;
+	if (config->bppx > 1 || config->bppy > 1) {
+		caps->supported_pixel_formats = PIXEL_FORMAT_MONO01 | PIXEL_FORMAT_I_4;
+#if defined(CONFIG_DISPLAY_COLOR_PALETTE)
+		memcpy(caps->color_palette, config->color_palette, sizeof(config->color_palette));
+#endif
+	} else {
+		caps->supported_pixel_formats = PIXEL_FORMAT_MONO01;
+	}
+	caps->current_pixel_format = data->current_pixel_format;
 	caps->screen_info = 0;
 }
 
 static int st730x_set_pixel_format(const struct device *dev, const enum display_pixel_format pf)
 {
+	const struct st730x_config *config = dev->config;
+	struct st730x_data *data = dev->data;
+
 	if (pf == PIXEL_FORMAT_MONO01) {
+		data->current_pixel_format = PIXEL_FORMAT_MONO01;
+		return 0;
+	} else if (pf == PIXEL_FORMAT_I_4 && config->is_rbw) {
+		data->current_pixel_format = PIXEL_FORMAT_I_4;
 		return 0;
 	}
+
 	LOG_ERR("Unsupported pixel format");
 
 	return -ENOTSUP;
@@ -549,12 +712,28 @@ static const struct st730x_specific st7306_specifics = {
 	((DT_STRING_UPPER_TOKEN(inst, mipi_mode) == MIPI_DBI_MODE_SPI_4WIRE) ? SPI_WORD_SET(8)     \
 									     : SPI_WORD_SET(9))
 
+#define ST730X_IS_RBW(node_id) IS_EQ(DT_ENUM_IDX_OR(node_id, color_mode, 0), 1)
+
+#define ST730X_BPPX(node_id) COND_CASE_1(ST730X_IS_RBW(node_id), (2), (1))
+#define ST730X_BPPY(node_id) (1)
+
 #define ST730X_CONV_BUFFER_SIZE(node_id)                                                           \
-	ROUND_UP(DT_PROP(node_id, width) * CONFIG_ST730X_CONV_BUFFER_LINE_CNT,                     \
-		     DT_PROP(node_id, width))
+	ROUND_UP((DT_PROP(node_id, width) * CONFIG_ST730X_CONV_BUFFER_LINE_CNT                     \
+	* ST730X_BPPX(node_id) * ST730X_BPPY(node_id)) / 8,                                        \
+	(DT_PROP(node_id, width) * ST730X_BPPX(node_id) * ST730X_BPPY(node_id)) / 4)
+
+#ifdef CONFIG_ST730X_DEFAULT_PALETTED
+#define ST730X_CURRENT_PIXEL_FORMAT(node_id) \
+	COND_CASE_1(ST730X_IS_RBW(node_id), (PIXEL_FORMAT_I_4), (PIXEL_FORMAT_MONO01))
+#else
+#define ST730X_CURRENT_PIXEL_FORMAT(node_id) PIXEL_FORMAT_MONO01
+#endif
 
 #define ST730X_DEFINE_MIPI(node_id, specifics_ptr)                                                 \
 	static uint8_t conversion_buf##node_id[ST730X_CONV_BUFFER_SIZE(node_id)];                  \
+	static struct st730x_data data##node_id = {                                                \
+		.current_pixel_format = ST730X_CURRENT_PIXEL_FORMAT(node_id),                      \
+	};                                                                                         \
 	static const struct st730x_config config##node_id = {                                      \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(node_id)),                                     \
 		.dbi_config = MIPI_DBI_CONFIG_DT(                                                  \
@@ -574,18 +753,36 @@ static const struct st730x_specific st7306_specifics = {
 		.multiplex_ratio = DT_PROP(node_id, multiplex_ratio),                              \
 		.source_voltage = DT_PROP(node_id, source_voltage),                                \
 		.remap_value = DT_PROP(node_id, remap_value),                                      \
+		.flip_color_bits = DT_PROP(node_id, remap_value) & 0x8,                            \
 		.panel_settings = DT_PROP(node_id, panel_settings),                                \
 		.hpm_gate_waveform = DT_PROP(node_id, hpm_gate_waveform),                          \
 		.lpm_gate_waveform = DT_PROP(node_id, lpm_gate_waveform),                          \
 		.color_inversion = DT_PROP(node_id, inversion_on),                                 \
+		.low_power_mode = DT_PROP(node_id, low_power_mode),                                \
 		.specifics = specifics_ptr,                                                        \
 		.te_mode = MIPI_DBI_TE_MODE_DT(node_id, te_mode),                                  \
 		.te_delay = DT_PROP(node_id, te_delay),                                            \
+		.is_rbw = ST730X_IS_RBW(node_id),                                                  \
+		.bppx = ST730X_BPPX(node_id),                                                      \
+		.bppy = ST730X_BPPY(node_id),                                                      \
+		.mono_color = DT_PROP_OR(node_id, mono_color, 0),                                  \
+		IF_ENABLED(CONFIG_DISPLAY_COLOR_PALETTE,                                           \
+		(.color_palette = DT_PROP_OR(DT_CHILD(node_id, color_palette), colors, {}),))      \
 		.conversion_buf = conversion_buf##node_id,                                         \
 		.conversion_buf_size = sizeof(conversion_buf##node_id),                            \
 	};                                                                                         \
-	DEVICE_DT_DEFINE(node_id, st730x_init, NULL, NULL, &config##node_id,                       \
+	DEVICE_DT_DEFINE(node_id, st730x_init, NULL, &data##node_id, &config##node_id,             \
 			 POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY, &st730x_driver_api);
 
 DT_FOREACH_STATUS_OKAY_VARGS(sitronix_st7305, ST730X_DEFINE_MIPI, &st7305_specifics)
 DT_FOREACH_STATUS_OKAY_VARGS(sitronix_st7306, ST730X_DEFINE_MIPI, &st7306_specifics)
+
+#if defined(CONFIG_DISPLAY_COLOR_PALETTE)
+
+#define ST730X_ASSERT_PALETTE(node_id)                                                             \
+	BUILD_ASSERT(CONFIG_DISPLAY_COLOR_PALETTE_MAX_SIZE >=                                      \
+		     DT_PROP_LEN_OR(DT_CHILD(node_id, color_palette), colors, 1));
+
+DT_FOREACH_STATUS_OKAY(sitronix_st7306, ST730X_ASSERT_PALETTE)
+
+#endif

--- a/drivers/display/display_st730x.c
+++ b/drivers/display/display_st730x.c
@@ -117,6 +117,8 @@ struct st730x_config {
 	uint8_t hpm_gate_waveform[ST730X_HPM_GATE_WAVEFORM_LEN];
 	uint8_t lpm_gate_waveform[ST730X_LPM_GATE_WAVEFORM_LEN];
 	bool color_inversion;
+	uint8_t te_mode;
+	uint32_t te_delay;
 	uint8_t *conversion_buf;
 	size_t conversion_buf_size;
 };
@@ -406,11 +408,17 @@ static int st730x_write(const struct device *dev, const uint16_t x, const uint16
 		return err;
 	}
 
+	mipi_desc.frame_incomplete = true;
+
 	while (desc->height > processed) {
 		i = st730x_convert(dev, buf, processed, desc);
 
 		if (i < 0) {
 			return i;
+		}
+
+		if (desc->height <= processed + i) {
+			mipi_desc.frame_incomplete = false;
 		}
 
 		mipi_desc.buf_size = i * desc->width / ST730X_PPB;
@@ -506,6 +514,14 @@ static int st730x_init(const struct device *dev)
 		return err;
 	}
 
+	if (config->te_mode != MIPI_DBI_TE_NO_EDGE) {
+		err = mipi_dbi_configure_te(config->mipi_dev, config->te_mode, config->te_delay);
+		if (err < 0) {
+			LOG_ERR("Failed to configure tearing effect! %d", err);
+			return err;
+		}
+	}
+
 	return 0;
 }
 
@@ -563,6 +579,8 @@ static const struct st730x_specific st7306_specifics = {
 		.lpm_gate_waveform = DT_PROP(node_id, lpm_gate_waveform),                          \
 		.color_inversion = DT_PROP(node_id, inversion_on),                                 \
 		.specifics = specifics_ptr,                                                        \
+		.te_mode = MIPI_DBI_TE_MODE_DT(node_id, te_mode),                                  \
+		.te_delay = DT_PROP(node_id, te_delay),                                            \
 		.conversion_buf = conversion_buf##node_id,                                         \
 		.conversion_buf_size = sizeof(conversion_buf##node_id),                            \
 	};                                                                                         \

--- a/dts/bindings/display/sitronix,st7306.yaml
+++ b/dts/bindings/display/sitronix,st7306.yaml
@@ -8,3 +8,24 @@ description: Sitronix ST7306 multi-mode 720x480 display controller
 compatible: "sitronix,st7306"
 
 include: sitronix,st730x-common.yaml
+
+properties:
+  color-mode:
+    type: string
+    enum:
+      - "MONO"
+      - "RBW"
+    description: |
+      What type of display this is.
+      MONO: Monochrome display, 1 bit per pixel.
+      RBW: Red Black White (and Off) display, with 2 bits per pixel.
+      Other color modes are not supported at the moment.
+
+      If the display is not monochrome, provide a palette.
+
+  mono-color:
+    type: int
+    default: 3
+    description: |
+      The color to use for MONO mode on multicolor displays.
+      The default is black for Red Black White displays.

--- a/dts/bindings/display/sitronix,st730x-common.yaml
+++ b/dts/bindings/display/sitronix,st730x-common.yaml
@@ -8,7 +8,8 @@ description: |
     These displays have extreme clarity and contrast, and refresh rate up to 51 Hz.
     They use a unusual data format that requires conversion from standard ones, and
     necessitate rounding X axis values to 12, including width which sometimes need
-    to be rounded to the next multiple of 12 to fill the display.
+    to be rounded to the next multiple of 12 to fill the display in the case where the width
+    can not be divided by both 12 and 8.
 
 include: [mipi-dbi-spi-device.yaml, display-controller.yaml]
 
@@ -110,6 +111,8 @@ properties:
       - [3-2]: Gate scan mode: 00: 2 line interval, 01: 1 line interval, 10: frame interval
       - [1-0]: Panel layout: 00: 2 line interlace, 01: 1 line interlace, 10: no interlacing
 
+      For this driver, the column dot inversion should likely be set to 1-Dot inversion.
+
   hpm-gate-waveform:
     type: uint8-array
     default: [0xE5, 0xF6, 0x05, 0x46, 0x77, 0x77, 0x77, 0x77, 0x76, 0x45]
@@ -131,3 +134,7 @@ properties:
   inversion-on:
     type: boolean
     description: Turn on display color inverting
+
+  low-power-mode:
+    type: boolean
+    description: Use low power mode instead of high power mode

--- a/modules/lvgl/lvgl_display_mono.c
+++ b/modules/lvgl/lvgl_display_mono.c
@@ -138,11 +138,26 @@ void lvgl_rounder_cb_mono(lv_event_t *e)
 		area->x1 = 0;
 		area->x2 = data->cap.x_resolution - 1;
 	} else {
-		area->x1 &= ~0x7;
-		area->x2 |= 0x7;
 		if (data->cap.screen_info & SCREEN_INFO_MONO_VTILED) {
 			area->y1 &= ~0x7;
 			area->y2 |= 0x7;
+#if CONFIG_LV_Z_AREA_X_ALIGNMENT_WIDTH != 1
+			__ASSERT(POPCOUNT(CONFIG_LV_Z_AREA_X_ALIGNMENT_WIDTH) == 1,
+				 "Invalid X alignment width");
+
+			area->x1 &= ~(CONFIG_LV_Z_AREA_X_ALIGNMENT_WIDTH - 1);
+			area->x2 |= (CONFIG_LV_Z_AREA_X_ALIGNMENT_WIDTH - 1);
+#endif
+		} else {
+			area->x1 &= ~0x7;
+			area->x2 |= 0x7;
+#if CONFIG_LV_Z_AREA_Y_ALIGNMENT_WIDTH != 1
+			__ASSERT(POPCOUNT(CONFIG_LV_Z_AREA_Y_ALIGNMENT_WIDTH) == 1,
+				 "Invalid Y alignment width");
+
+			area->y1 &= ~(CONFIG_LV_Z_AREA_Y_ALIGNMENT_WIDTH - 1);
+			area->y2 |= (CONFIG_LV_Z_AREA_Y_ALIGNMENT_WIDTH - 1);
+#endif
 		}
 	}
 }


### PR DESCRIPTION
Add tearing pin for st730x
add RBW support for st730x
Respect alignement in mono mode

<img width="3456" height="4608" alt="IMG_20260605_012328" src="https://github.com/user-attachments/assets/103fdfdf-a5bc-4f4b-acf7-53cf70ade7ad" />
<img width="3456" height="4608" alt="IMG_20260605_012456" src="https://github.com/user-attachments/assets/a89f39ad-a21c-4883-aeba-229df063d136" />
<img width="3456" height="4608" alt="IMG_20260605_012740~2" src="https://github.com/user-attachments/assets/679a61e4-f366-4896-a3e3-ebc9f20f8e6a" />
mono not broken after and actually fixed bad behavior of lvgl rounder: 
<img width="3456" height="4608" alt="IMG_20260605_015614" src="https://github.com/user-attachments/assets/7ef044a7-bee5-469b-9e22-2e4a125dae50" />

Config for the display:

```dts
mipi_dbi_st7306 {
	compatible = "zephyr,mipi-dbi-spi";
	spi-dev = <&spi0>;
	dc-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
	reset-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
	te-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
	write-only;
	#address-cells = <1>;
	#size-cells = <0>;

	st7306: st7306@0 {
		compatible = "sitronix,st7306";
		mipi-max-frequency = <40000000>;
		reg = <0>;
		width = <312>;
		height = <400>;
		start-line = <0>;
		start-column = <30>;
		nvm-load = [17 02];
		te-delay = <20000>;
		/* OPStek fast config */
		gate-voltages = [12 0a];
		vsh = [73 3e 3c 3c];
		vsl = [00 21 23 23];
		vshn = [50 5c 5a 5a];
		vsln = [50 35 37 37];
		//osc-settings = <0x80>;
		osc-settings = <0xA6>;
		framerate = <0x05>;
		multiplex-ratio = <0x64>;
		source-voltage = <0x0>;
		remap-value = <0x48>;
		panel-settings = <0x29>;
		hpm-gate-waveform = [e5 f6 17 77 77 77 77 77 77 71];
		/* Slower config from github */
		// gate-voltages = [08 00];
		// vsh = [2c 2c 2c 2c];
		// vsl = [26 26 26 26];
		// vshn = [42 42 42 42];
		// vsln = [32 32 32 32];
		// //osc-settings = <0x80>;
		// osc-settings = <0xA6>;
		// framerate = <0x02>;
		// multiplex-ratio = <0x64>;
		// source-voltage = <0x0>;
		// remap-value = <0x04>;
		// panel-settings = <0x29>;
		// mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
		// te-mode = "MIPI_DBI_TE_FALLING_EDGE";

		mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
		te-mode = "MIPI_DBI_TE_FALLING_EDGE";
		mono-color = <1>;
		color-mode = "RBW";

		color-palette {
			compatible = "zephyr,panel-color-palette";
			colors = <ARGB8888(200, 200, 200, 255) /* 0 = Off, sort of white */
					ARGB8888(128, 0, 0, 255) /* 1 = Dark red */
					ARGB8888(165, 200, 200, 255) /* 2 = Blueish white */
					ARGB8888(0, 0, 0, 255) /* 3 = Black */
					>;
		};
	};
};
```
