### PR TITLE
drivers: serial: fix spinlock leak in uart_renesas_rza2m_scif

### DIFF
--- a/drivers/serial/uart_renesas_rza2m_scif.c
+++ b/drivers/serial/uart_renesas_rza2m_scif.c
@@ -425,6 +425,7 @@ static int uart_rza2m_scif_configure(const struct device *dev, const struct uart
 		reg_16 |= RZA2M_SMR_PE;
 		break;
 	default:
+		k_spin_unlock(&data->lock, key);
 		return -ENOTSUP;
 	}
 	if (cfg->stop_bits == UART_CFG_STOP_BITS_2) {
@@ -438,6 +439,7 @@ static int uart_rza2m_scif_configure(const struct device *dev, const struct uart
 	/* Set baudrate */
 	err = uart_rza2m_scif_set_baudrate(dev, data->channel, cfg->baudrate);
 	if (err) {
+		k_spin_unlock(&data->lock, key);
 		return -EIO;
 	}
 


### PR DESCRIPTION
Add missing k_spin_unlock() on two error return paths in uart_rza2m_scif_configure():

- Unsupported parity mode (default switch case)
- Baudrate configuration failure

Both paths returned without releasing the spinlock acquired earlier.

[Clang Thread Safety Analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) yielded some cases where locks were incorrectly leaked.

See also #106847