### PR TITLE
drivers: serial: fix spinlock leak in uart_neorv32

### DIFF
--- a/drivers/serial/uart_neorv32.c
+++ b/drivers/serial/uart_neorv32.c
@@ -427,6 +427,7 @@ static int neorv32_uart_pm_action(const struct device *dev,
 	struct neorv32_uart_data *data = dev->data;
 	k_spinlock_key_t key;
 	uint32_t ctrl;
+	int rv = 0;
 
 	key = k_spin_lock(&data->lock);
 	ctrl = neorv32_uart_read_ctrl(dev);
@@ -439,13 +440,15 @@ static int neorv32_uart_pm_action(const struct device *dev,
 		ctrl |= NEORV32_UART_CTRL_EN;
 		break;
 	default:
-		return -ENOTSUP;
+		rv = -ENOTSUP;
 	}
 
-	neorv32_uart_write_ctrl(dev, ctrl);
+	if (rv != -ENOTSUP) {
+		neorv32_uart_write_ctrl(dev, ctrl);
+	}
 	k_spin_unlock(&data->lock, key);
 
-	return 0;
+	return rv;
 }
 #endif /* CONFIG_PM_DEVICE */
 


### PR DESCRIPTION
Add missing k_spin_unlock() in neorv32_uart_pm_action() default switch case. The function returned -ENOTSUP for unsupported PM actions without releasing the spinlock acquired at function entry.

[Clang Thread Safety Analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) yielded some cases where locks were incorrectly leaked.

See also #106847