### PR TITLE
drivers: rtc: fix spinlock leak in rtc_ambiq

### DIFF
--- a/drivers/rtc/rtc_ambiq.c
+++ b/drivers/rtc/rtc_ambiq.c
@@ -130,6 +130,7 @@ static int ambiq_rtc_set_time(const struct device *dev, const struct rtc_time *t
 	rtc_time_to_ambiq_time_set(timeptr, &ambiq_time);
 
 	if (test_for_rollover(&ambiq_time)) {
+		k_spin_unlock(&data->lock, key);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Add missing k_spin_unlock() in ambiq_rtc_set_time() when test_for_rollover() fails. The function returned -EINVAL without releasing the spinlock acquired earlier.

[Clang Thread Safety Analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) yielded some cases where locks were incorrectly leaked.

See also #106847