### PR TITLE
drivers: i2c: fix spinlock leak in i2c_smartbond

### DIFF
--- a/drivers/i2c/i2c_smartbond.c
+++ b/drivers/i2c/i2c_smartbond.c
@@ -109,7 +109,6 @@ static int i2c_smartbond_apply_configure(const struct device *dev, uint32_t dev_
 	const struct i2c_smartbond_cfg *config = dev->config;
 	struct i2c_smartbond_data *data = dev->data;
 	uint32_t con_reg = 0x0UL;
-	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 	/* Configure Speed (SCL frequency) */
 	switch (I2C_SPEED_GET(dev_config)) {
@@ -138,6 +137,8 @@ static int i2c_smartbond_apply_configure(const struct device *dev, uint32_t dev_
 		LOG_ERR("Only I2C Controller mode supported");
 		return -ENOTSUP;
 	}
+
+	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 	/* Enable sending RESTART as master */
 	con_reg |= I2C_I2C_CON_REG_I2C_RESTART_EN_Msk;
@@ -422,13 +423,15 @@ static int i2c_smartbond_transfer_cb(const struct device *dev, struct i2c_msg *m
 	const struct i2c_smartbond_cfg *config = dev->config;
 	struct i2c_smartbond_data *data = dev->data;
 	int ret = 0;
-	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 	if (cb == NULL) {
 		return -EINVAL;
 	}
 
+	k_spinlock_key_t key = k_spin_lock(&data->lock);
+
 	if (data->cb != NULL) {
+		k_spin_unlock(&data->lock, key);
 		return -EWOULDBLOCK;
 	}
 


### PR DESCRIPTION
Add missing k_spin_unlock() calls on error return paths:

- i2c_smartbond_apply_configure(): returned -ENOTSUP for unsupported speed or non-controller mode without releasing lock
- i2c_smartbond_transfer_cb(): returned -EINVAL (null callback) or -EWOULDBLOCK (transfer in progress) without releasing lock

[Clang Thread Safety Analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) yielded some cases where locks were incorrectly leaked.

See also #106847