### PR TITLE
drivers: gpio: fix spinlock leak in gpio_altera_pio

### DIFF
--- a/drivers/gpio/gpio_altera_pio.c
+++ b/drivers/gpio/gpio_altera_pio.c
@@ -95,6 +95,7 @@ static int gpio_altera_configure(const struct device *dev,
 	} else if (flags == GPIO_OUTPUT) {
 		sys_set_bits(addr, BIT(pin));
 	} else {
+		k_spin_unlock(&data->lock, key);
 		return -EINVAL;
 	}
 
@@ -237,6 +238,7 @@ static int gpio_altera_pin_interrupt_configure(const struct device *dev,
 		irq_enable(cfg->irq_num);
 		break;
 	default:
+		k_spin_unlock(&data->lock, key);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Add missing k_spin_unlock() calls on error return paths in gpio_altera_configure() and gpio_altera_pin_interrupt_configure(). Both functions returned -EINVAL in their default/else branches while still holding the spinlock acquired earlier.


[Clang Thread Safety Analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) yielded some cases where locks were incorrectly leaked.

See also #106847