### PR TITLE
soc: it51xxx: refine early soc initialization defaults

### DIFF
--- a/soc/ite/ec/it51xxx/chip_chipregs.h
+++ b/soc/ite/ec/it51xxx/chip_chipregs.h
@@ -95,8 +95,10 @@ struct gpio_it51xxx_regs {
 	volatile uint8_t reserved_01_c1[193];
 	/* 0xC2: General Control 35 */
 	volatile uint8_t GPIO_GCR35;
-	/* 0xC3-CF: Reserved_c3_cf */
-	volatile uint8_t reserved_c3_cf[13];
+	/* 0xC3-CE: Reserved_c3_ce */
+	volatile uint8_t reserved_c3_ce[12];
+	/* 0xCF: USB GPIO Control Register */
+	volatile uint8_t GPIO_USBGPIOCR;
 	/* 0xD0: General Control 31 */
 	volatile uint8_t GPIO_GCR31;
 	/* 0xD1: General Control 32 */
@@ -200,6 +202,10 @@ struct gpio_it51xxx_regs {
 #define ITE_EC_GPIO_LPCRSTEN              IT51XXX_GPIO_LPCRSTEN
 /* 0xC2: General Control 35 */
 #define IT51XXX_GPIO_USBPDEN              BIT(5)
+
+/* 0xCF: USB GPIO Control Register */
+#define USB_ON_GPIO_PINS_ENABLE_MSK GENMASK(3, 0)
+
 /* 0xF0: General Control 1 */
 #define IT51XXX_GPIO_U2CTRL_SIN1_SOUT1_EN BIT(2)
 #define IT51XXX_GPIO_U1CTRL_SIN0_SOUT0_EN BIT(0)

--- a/soc/ite/ec/it51xxx/chip_chipregs.h
+++ b/soc/ite/ec/it51xxx/chip_chipregs.h
@@ -209,6 +209,8 @@ struct gpio_it51xxx_regs {
 /* 0xF0: General Control 1 */
 #define IT51XXX_GPIO_U2CTRL_SIN1_SOUT1_EN BIT(2)
 #define IT51XXX_GPIO_U1CTRL_SIN0_SOUT0_EN BIT(0)
+/* 0xF7: General Control 8 */
+#define IT51XXX_GPIO_PWRSW2EN1            BIT(4)
 /* 0xE6: General Control 21 */
 #define IT51XXX_GPIO_GPH1VS               BIT(1)
 #define IT51XXX_GPIO_GPH2VS               BIT(0)

--- a/soc/ite/ec/it51xxx/soc.c
+++ b/soc/ite/ec/it51xxx/soc.c
@@ -164,6 +164,9 @@ void soc_prep_hook(void)
 	gpio_regs->GPIO_GCR1 |= IT51XXX_GPIO_U2CTRL_SIN1_SOUT1_EN;
 #endif /* DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(uart2)) */
 
+	/* disable pwrsw wdt 2 by default */
+	gpio_regs->GPIO_GCR8 &= ~IT51XXX_GPIO_PWRSW2EN1;
+
 	/*
 	 * Disable this feature that can detect pre-define hardware target A, B, C through
 	 * I2C0, I2C1, I2C2 respectively. This is for debugging use, so it can be disabled

--- a/soc/ite/ec/it51xxx/soc.c
+++ b/soc/ite/ec/it51xxx/soc.c
@@ -122,8 +122,13 @@ void soc_prep_hook(void)
 	struct gpio_ite_ec_regs *const gpio_regs = GPIO_ITE_EC_REGS_BASE;
 	struct gctrl_ite_ec_regs *const gctrl_regs = GCTRL_ITE_EC_REGS_BASE;
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(usb0), disabled)
 	/* USB pull down disable */
 	gpio_regs->GPIO_GCR35 &= ~IT51XXX_GPIO_USBPDEN;
+
+	/* disable usb host/device on gpio pins by default */
+	gpio_regs->GPIO_USBGPIOCR &= ~USB_ON_GPIO_PINS_ENABLE_MSK;
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(usb0), disabled) */
 
 	/* Set FSPI pins are tri-state */
 	sys_write8(sys_read8(IT51XXX_SMFI_FLHCTRL3R) | IT51XXX_SMFI_FFSPITRI,
@@ -136,13 +141,28 @@ void soc_prep_hook(void)
 	gctrl_regs->GCTRL_SPCTRL9 |= IT51XXX_GCTRL_ALTIE;
 
 	/* UART1 and UART2 board init */
-	/* bit3: UART1 and UART2 belong to the EC side. */
-	gctrl_regs->GCTRL_RSTDMMC |= IT51XXX_GCTRL_UART1SD | IT51XXX_GCTRL_UART2SD;
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(uart1))
+	/* bit3: UART1 belong to the EC side. */
+	gctrl_regs->GCTRL_RSTDMMC |= IT51XXX_GCTRL_UART1SD;
+#endif /* DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(uart1)) */
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(uart2))
+	/* bit2: UART2 belong to the EC side. */
+	gctrl_regs->GCTRL_RSTDMMC |= IT51XXX_GCTRL_UART2SD;
+#endif /* DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(uart2)) */
+
 	/* Reset UART before config it */
 	gctrl_regs->GCTRL_RSTC4 = IT51XXX_GCTRL_RUART;
-	/* Switch UART1 and UART2 on without hardware flow control */
-	gpio_regs->GPIO_GCR1 |=
-		IT51XXX_GPIO_U1CTRL_SIN0_SOUT0_EN | IT51XXX_GPIO_U2CTRL_SIN1_SOUT1_EN;
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(uart1))
+	/* Switch UART1 on without hardware flow control */
+	gpio_regs->GPIO_GCR1 |= IT51XXX_GPIO_U1CTRL_SIN0_SOUT0_EN;
+#endif /* DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(uart1)) */
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(uart2))
+	/* Switch UART2 on without hardware flow control */
+	gpio_regs->GPIO_GCR1 |= IT51XXX_GPIO_U2CTRL_SIN1_SOUT1_EN;
+#endif /* DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(uart2)) */
 
 	/*
 	 * Disable this feature that can detect pre-define hardware target A, B, C through


### PR DESCRIPTION
This pr improves the default early initialization behavior, including:
- disable usb host/device on gpio pins if usb interface is disabled
- update uart initialization to be devicetree-aware
- disable pwrsw wdt 2 by default