### PR TITLE
drivers: serial: fix spinlock and irq leak in uart_rzt2m

### DIFF
--- a/drivers/serial/uart_rzt2m.c
+++ b/drivers/serial/uart_rzt2m.c
@@ -254,6 +254,8 @@ static int rzt2m_module_start(const struct device *dev)
 		dummy = *MSTPCRA;
 	} else {
 		LOG_ERR("SCI modules in the secure domain on RZT2M are not supported.");
+		k_spin_unlock(&data->lock, key);
+		irq_unlock(irqkey);
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
Add missing k_spin_unlock() and irq_unlock() in rzt2m_module_start() error path. When interface_id >= 5 the function returned -ENOTSUP without releasing either the spinlock or the IRQ lock.

[Clang Thread Safety Analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) yielded some cases where locks were incorrectly leaked.

See also #106847