### PR TITLE
usb: device_next: cdc_ecm: fix shutdown runtime issue

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -480,7 +480,9 @@ static void usbd_cdc_ecm_shutdown(struct usbd_class_data *const c_data)
 	struct usbd_cdc_ecm_desc *desc = data->desc;
 
 	desc->if0_ecm.iMACAddress = 0;
-	sys_dlist_remove(&data->mac_desc_data->node);
+	if (sys_dnode_is_linked(&data->mac_desc_data->node)) {
+		sys_dlist_remove(&data->mac_desc_data->node);
+	}
 }
 
 static void *usbd_cdc_ecm_get_desc(struct usbd_class_data *const c_data,


### PR DESCRIPTION
This issue appears when USBD_SUPPORTS_HIGH_SPEED is enabled,
usbd_cdc_ecm_shutdown can be called twice, causing a double remove on
mac_desc_data->node.

Guard the list removal with a check on mac_desc_data->node being linked
to fix it.
