### PR TITLE
drivers: serial: mchp_xec: drain TX before suspend

### DIFF
--- a/drivers/serial/uart_mchp_xec.c
+++ b/drivers/serial/uart_mchp_xec.c
@@ -318,6 +318,15 @@ static int uart_xec_pm_action(const struct device *dev, enum pm_device_action ac
 		soc_set_bit8(ub + XEC_UART_LD_ACT_OFS, XEC_UART_LD_ACTIVATE_POS);
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
+		/* Drain any in-flight TX before suspend the UART. The
+		 * poll_out path returns once the byte is in THR, but the
+		 * byte may still be in the shift register. Spin only if there
+		 * is something to drain.
+		 */
+		while ((sys_read8(ub + XEC_UART_LSR_OFS) & XEC_UART_LSR_TEMT) !=
+		       XEC_UART_LSR_TEMT) {
+		}
+
 		/* Enable UART wake interrupt */
 		soc_clear_bit8(ub + XEC_UART_LD_ACT_OFS, XEC_UART_LD_ACTIVATE_POS);
 		if ((dev_cfg->wakeup_source) && (dev_cfg->wakerx_gpio.port != NULL)) {


### PR DESCRIPTION
Spin on Transmitter Empty at the top of PM_DEVICE_ACTION_SUSPEND so an in-flight byte finishes shifting before LD_ACTIVATE is cleared. Without this, poll_out callers (printk, LOG_MODE_MINIMAL) get their last byte cut off mid-shift on every suspend, producing garbled console output. No-op when TX is already idle.