### PR TITLE
bluetooth: audio: vocs_client: dynamically discover CCC handle

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -758,6 +758,12 @@ Bluetooth Audio
     :zephyr:code-sample:`ble_peripheral_tmap_peripheral` have been moved from
     ``samples/bluetooth/`` to ``samples/bluetooth/audio``.
 
+* VOCS
+
+  * The VOCS client now requires automatic CCC (Client Characteristic Configuration) discovery.
+    :kconfig:option:`BT_VOCS_CLIENT` now depends on :kconfig:option:`BT_GATT_AUTO_DISCOVER_CCC`.
+    Applications using VOCS client must ensure that CCC auto-discovery support is enabled. (:github:`110607`)
+
 .. zephyr-keep-sorted-stop
 
 Bluetooth Classic

--- a/subsys/bluetooth/audio/Kconfig.vocs
+++ b/subsys/bluetooth/audio/Kconfig.vocs
@@ -47,5 +47,6 @@ config BT_VOCS_CLIENT_MAX_INSTANCE_COUNT
 config BT_VOCS_CLIENT
 	bool # hidden
 	default y if BT_VOCS_CLIENT_MAX_INSTANCE_COUNT > 0
+	depends on BT_GATT_AUTO_DISCOVER_CCC
 	help
 	  This hidden option enables support for Volume Offset Control Service.

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -382,16 +382,17 @@ static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 			inst->start_handle = chrc->value_handle;
 		}
 		inst->end_handle = chrc->value_handle;
-
 		if (!bt_uuid_cmp(chrc->uuid, BT_UUID_VOCS_STATE)) {
 			LOG_DBG("Volume offset state");
 			inst->state_handle = chrc->value_handle;
 			sub_params = &inst->state_sub_params;
+			sub_params->disc_params = &inst->state_ccc_disc_params;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_VOCS_LOCATION)) {
 			LOG_DBG("Location");
 			inst->location_handle = chrc->value_handle;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				sub_params = &inst->location_sub_params;
+				sub_params->disc_params = &inst->location_ccc_disc_params;
 			}
 			if (chrc->properties & BT_GATT_CHRC_WRITE_WITHOUT_RESP) {
 				atomic_set_bit(inst->flags, BT_VOCS_CLIENT_FLAG_LOC_WRITABLE);
@@ -404,6 +405,7 @@ static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 			inst->desc_handle = chrc->value_handle;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				sub_params = &inst->desc_sub_params;
+				sub_params->disc_params = &inst->desc_ccc_disc_params;
 			}
 			if (chrc->properties & BT_GATT_CHRC_WRITE_WITHOUT_RESP) {
 				atomic_set_bit(inst->flags, BT_VOCS_CLIENT_FLAG_DESC_WRITABLE);
@@ -415,11 +417,12 @@ static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 
 			sub_params->value = BT_GATT_CCC_NOTIFY;
 			sub_params->value_handle = chrc->value_handle;
-			/*
-			 * TODO: Don't assume that CCC is at handle + 2;
-			 * do proper discovery;
-			 */
-			sub_params->ccc_handle = attr->handle + 2;
+
+			/* Use auto-discovery with the DEDICATED params we assigned above */
+			sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
+
+			/* Set the end handle to the end of the ENTIRE service discovery */
+			sub_params->end_handle = inst->discover_params.end_handle;
 			sub_params->notify = vocs_client_notify_handler;
 			atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 

--- a/subsys/bluetooth/audio/vocs_internal.h
+++ b/subsys/bluetooth/audio/vocs_internal.h
@@ -67,6 +67,11 @@ struct bt_vocs_client {
 	struct bt_gatt_subscribe_params location_sub_params;
 	struct bt_gatt_subscribe_params desc_sub_params;
 
+	/* Dedicated discovery params for concurrent CCC auto-discovery */
+	struct bt_gatt_discover_params state_ccc_disc_params;
+	struct bt_gatt_discover_params location_ccc_disc_params;
+	struct bt_gatt_discover_params desc_ccc_disc_params;
+
 	struct bt_vocs_control cp;
 	struct bt_gatt_write_params write_params;
 	struct bt_gatt_read_params read_params;

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -41,7 +41,7 @@
 
 #if defined(CONFIG_BT_CAP_COMMANDER)
 
-#define SEM_TIMEOUT K_SECONDS(5)
+#define SEM_TIMEOUT K_SECONDS(10)
 
 extern enum bst_result_t bst_result;
 


### PR DESCRIPTION
Currently, the VOCS client subscribes to characteristics by hardcoding the CCC handle offset to `attr->handle + 2.` While common, this layout is not strictly guaranteed by the Bluetooth specification and can fail if a server structures its GATT table differently. This commit updates the characteristic discovery callback to use the `CONFIG_BT_GATT_AUTO_DISCOVER_CCC` feature to dynamically locate the CCC. To support concurrent CCC discoveries safely, dedicated discovery parameter structures are added to the VOCS client instance. This prevents in-flight characteristic discoveries from clobbering each other's memory state. Additionally, the auto-discovery boundary is corrected to use the end of the service, rather than prematurely shrinking to the characteristic value handle. The hardcoded fallback and conditional compilation directives have been removed, as VOCS inherently relies on CCC auto-discovery being enabled via Kconfig.

Assisted-by:  Gemini:gemini-3.1-pro
Fixes zephyrproject-rtos/zephyr#81132