### PR TITLE
drivers: wifi: nxp: remove unused NXP Wi-Fi configs

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -705,12 +705,6 @@ config NXP_WIFI_SOFTAP_DHCP_SERVER
 	default y
 	select NET_DHCPV4_SERVER
 
-config NXP_WIFI_CAPA
-	bool "Wi-Fi Soft AP Capability"
-	default y
-	help
-	  This option enables uAP Wi-Fi Capability in the Wi-Fi driver.
-
 config NXP_WIFI_UAP_STA_MAC_ADDR_FILTER
 	bool "Wi-Fi SoftAP clients allow/block list"
 	default y
@@ -1092,12 +1086,6 @@ config NXP_WIFI_RF_TEST_MODE
 	default y if NXP_RW610 || NXP_IW610
 	help
 	  This option enables WLAN test mode commands.
-
-config NXP_WIFI_EU_VALIDATION
-	bool "EU Validation"
-	default y
-	help
-	  This option enables EU Validation Support.
 
 if NXP_RW610 || NXP_IW61X || NXP_IW610
 


### PR DESCRIPTION
Remove obsolete Kconfig options that are no longer referenced in the codebase:
- NXP_WIFI_CAPA: uAP Wi-Fi Capability
- NXP_WIFI_EU_VALIDATION: EU Validation Support