### PR TITLE
kernel: work: deprecate thread field in struct k_work_q

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -135,6 +135,10 @@ Deprecated APIs and options
   * Deprecated :kconfig:option:`CONFIG_NET_L2_PTP`.
     Used :kconfig:option:`CONFIG_NET_L2_PTP_TIMESTAMPING` instead.
 
+* Work queue
+
+  * :c:member:`k_work_q.thread` has been deprecated. Use :c:member:`k_work_q.thread_id` instead.
+
 New APIs and options
 ====================
 ..

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -987,7 +987,7 @@ static int ppp_driver_init(const struct device *dev)
 	k_work_queue_start(&ppp->cb_workq, ppp_workq,
 			   K_KERNEL_STACK_SIZEOF(ppp_workq),
 			   K_PRIO_COOP(PPP_WORKQ_PRIORITY), NULL);
-	k_thread_name_set(&ppp->cb_workq.thread, "ppp_workq");
+	k_thread_name_set(ppp->cb_workq.thread_id, "ppp_workq");
 #if defined(CONFIG_NET_PPP_ASYNC_UART)
 	k_work_init_delayable(&ppp->uart_recovery_work, uart_recovery);
 #endif

--- a/drivers/sensor/lm75/lm75.c
+++ b/drivers/sensor/lm75/lm75.c
@@ -344,7 +344,7 @@ int lm75_init(const struct device *dev)
 		data->dev = dev;
 		k_work_queue_start(&data->workq, data->stack, K_THREAD_STACK_SIZEOF(data->stack),
 				CONFIG_LM75_TRIGGER_THREAD_PRIO, NULL);
-		k_thread_name_set(&data->workq.thread, "lm75_trigger");
+		k_thread_name_set(data->workq.thread_id, "lm75_trigger");
 		k_work_init(&data->work, lm75_trigger_work_handler);
 
 		if (!device_is_ready(cfg->int_gpio.port)) {

--- a/drivers/sensor/lm77/lm77.c
+++ b/drivers/sensor/lm77/lm77.c
@@ -331,7 +331,7 @@ static int lm77_init(const struct device *dev)
 	data->dev = dev;
 	k_work_queue_start(&data->workq, data->stack, K_THREAD_STACK_SIZEOF(data->stack),
 			   CONFIG_LM77_TRIGGER_THREAD_PRIO, NULL);
-	k_thread_name_set(&data->workq.thread, "lm77_trigger");
+	k_thread_name_set(data->workq.thread_id, "lm77_trigger");
 	k_work_init(&data->work, lm77_trigger_work_handler);
 
 	if (config->int_gpio.port != NULL) {

--- a/drivers/serial/uart_bt.c
+++ b/drivers/serial/uart_bt.c
@@ -303,7 +303,7 @@ static int uart_bt_workqueue_init(void)
 	k_work_queue_start(&nus_work_queue, nus_work_queue_stack,
 			   K_THREAD_STACK_SIZEOF(nus_work_queue_stack),
 			   CONFIG_UART_BT_WORKQUEUE_PRIORITY, NULL);
-	k_thread_name_set(&nus_work_queue.thread, "uart_bt");
+	k_thread_name_set(nus_work_queue.thread_id, "uart_bt");
 
 	return 0;
 }

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1921,7 +1921,7 @@ static int usb_init(void)
 			   K_KERNEL_STACK_SIZEOF(usbd_work_queue_stack),
 			   CONFIG_SYSTEM_WORKQUEUE_PRIORITY, NULL);
 
-	k_thread_name_set(&usbd_work_queue.thread, "usbd_workq");
+	k_thread_name_set(usbd_work_queue.thread_id, "usbd_workq");
 	k_work_init(&ctx->usb_work, usbd_work_handler);
 
 	return 0;

--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -966,7 +966,7 @@ static int udc_work_q_init(void)
 			   udc_work_q_stack,
 			   K_KERNEL_STACK_SIZEOF(udc_work_q_stack),
 			   CONFIG_UDC_WORKQUEUE_PRIORITY, NULL);
-	k_thread_name_set(&udc_work_q.thread, "udc_work_q");
+	k_thread_name_set(udc_work_q.thread_id, "udc_work_q");
 
 	return 0;
 }

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -1626,7 +1626,7 @@ static int esp_init(const struct device *dev)
 			   K_KERNEL_STACK_SIZEOF(esp_workq_stack),
 			   K_PRIO_COOP(CONFIG_WIFI_ESP_AT_WORKQ_THREAD_PRIORITY),
 			   NULL);
-	k_thread_name_set(&data->workq.thread, "esp_workq");
+	k_thread_name_set(data->workq.thread_id, "esp_workq");
 
 	/* cmd handler */
 	const struct modem_cmd_handler_config cmd_handler_config = {

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4801,7 +4801,7 @@ struct k_work_q {
  * @cond INTERNAL_HIDDEN
  */
 	/* The thread that animates the work. */
-	struct k_thread thread;
+	__deprecated struct k_thread thread;
 
 	/* The thread ID that animates the work. This may be an external thread
 	 * if k_work_queue_run() is used.

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -853,6 +853,11 @@ void k_work_queue_start(struct k_work_q *queue,
 	__ASSERT_NO_MSG(stack);
 	__ASSERT_NO_MSG(!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT));
 
+	/* In future, this whole function will be deprecated, but for now, we
+	 * have to use the `thread` field to create a new thread in it.
+	 */
+	TOOLCHAIN_DISABLE_WARNING("-Wdeprecated-declarations");
+
 	uint32_t flags = K_WORK_QUEUE_STARTED;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work_queue, start, queue);
@@ -895,6 +900,8 @@ void k_work_queue_start(struct k_work_q *queue,
 	queue->thread_id = &queue->thread;
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, start, queue);
+
+	TOOLCHAIN_ENABLE_WARNING("-Wdeprecated-declarations");
 }
 
 int k_work_queue_drain(struct k_work_q *queue,

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -955,8 +955,10 @@ int k_work_queue_stop(struct k_work_q *queue, k_timeout_t timeout)
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work_queue, stop, queue, timeout);
 
-	if (z_is_thread_essential(&queue->thread)) {
-		return -ENOTSUP;
+	if (queue->thread_id) {
+		if (z_is_thread_essential(queue->thread_id)) {
+			return -ENOTSUP;
+		}
 	}
 
 	k_spinlock_key_t key = k_spin_lock(&lock);

--- a/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal.c
+++ b/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal.c
@@ -96,7 +96,7 @@ void smtc_modem_hal_init(const struct device *transceiver)
 	k_work_queue_start(&hal_workq, hal_workq_stack,
 			   K_THREAD_STACK_SIZEOF(hal_workq_stack),
 			   HAL_WORKQ_PRIORITY, NULL);
-	k_thread_name_set(&hal_workq.thread, "lbm_hal_workq");
+	k_thread_name_set(hal_workq.thread_id, "lbm_hal_workq");
 
 	k_work_init(&prv_cb_data.work, hal_irq_work_handler);
 }

--- a/modules/nrf_wifi/os/work.c
+++ b/modules/nrf_wifi/os/work.c
@@ -82,7 +82,7 @@ static int workqueue_init(void)
 			   CONFIG_NRF70_BH_WQ_PRIORITY,
 			   NULL);
 
-	k_thread_name_set(&zep_wifi_bh_q.thread, "nrf70_bh_wq");
+	k_thread_name_set(zep_wifi_bh_q.thread_id, "nrf70_bh_wq");
 
 	k_work_queue_init(&zep_wifi_intr_q);
 
@@ -92,7 +92,7 @@ static int workqueue_init(void)
 			   CONFIG_NRF70_IRQ_WQ_PRIORITY,
 			   NULL);
 
-	k_thread_name_set(&zep_wifi_intr_q.thread, "nrf70_intr_wq");
+	k_thread_name_set(zep_wifi_intr_q.thread_id, "nrf70_intr_wq");
 #ifdef CONFIG_NRF70_TX_DONE_WQ_ENABLED
 	k_work_queue_init(&zep_wifi_tx_done_q);
 
@@ -102,7 +102,7 @@ static int workqueue_init(void)
 			   CONFIG_NRF70_TX_DONE_WQ_PRIORITY,
 			   NULL);
 
-	k_thread_name_set(&zep_wifi_tx_done_q.thread, "nrf70_tx_done_wq");
+	k_thread_name_set(zep_wifi_tx_done_q.thread_id, "nrf70_tx_done_wq");
 #endif /* CONFIG_NRF70_TX_DONE_WQ_ENABLED */
 
 #ifdef CONFIG_NRF70_RX_WQ_ENABLED
@@ -114,7 +114,7 @@ static int workqueue_init(void)
 			   CONFIG_NRF70_RX_WQ_PRIORITY,
 			   NULL);
 
-	k_thread_name_set(&zep_wifi_rx_q.thread, "nrf70_rx_wq");
+	k_thread_name_set(zep_wifi_rx_q.thread_id, "nrf70_rx_wq");
 #endif /* CONFIG_NRF70_RX_WQ_ENABLED */
 
 	return 0;

--- a/modules/openthread/openthread.c
+++ b/modules/openthread/openthread.c
@@ -125,7 +125,7 @@ K_KERNEL_STACK_DEFINE(ot_stack_area, OT_STACK_SIZE);
 
 k_tid_t openthread_thread_id_get(void)
 {
-	return (k_tid_t)&openthread_work_q.thread;
+	return openthread_work_q.thread_id;
 }
 
 static int ncp_hdlc_send(const uint8_t *buf, uint16_t len)

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -371,7 +371,7 @@ void platformRadioInit(void)
 	k_work_queue_start(&ot_work_q, ot_task_stack,
 			   K_KERNEL_STACK_SIZEOF(ot_task_stack),
 			   OT_WORKER_PRIORITY, NULL);
-	k_thread_name_set(&ot_work_q.thread, "ot_radio_workq");
+	k_thread_name_set(ot_work_q.thread_id, "ot_radio_workq");
 
 	if ((radio_api->get_capabilities(radio_dev) &
 	     IEEE802154_HW_TX_RX_ACK) != IEEE802154_HW_TX_RX_ACK) {

--- a/samples/bluetooth/classic/a2dp_source/src/main.c
+++ b/samples/bluetooth/classic/a2dp_source/src/main.c
@@ -789,7 +789,7 @@ static void bt_ready(int err)
 	k_work_queue_start(&audio_play_work_q, audio_play_work_q_thread_stack,
 			   CONFIG_BT_A2DP_SOURCE_DATA_SEND_WORKQ_STACK_SIZE,
 			   K_PRIO_COOP(CONFIG_BT_A2DP_SOURCE_DATA_SEND_WORKQ_PRIORITY), NULL);
-	k_thread_name_set(&audio_play_work_q.thread, "audio play");
+	k_thread_name_set(audio_play_work_q.thread_id, "audio play");
 
 	k_work_init(&discover_work, discover_work_handler);
 

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -323,7 +323,7 @@ static struct bt_ag_tx *bt_ag_tx_alloc(void)
 	 * so if we're in the same workqueue but there are no immediate
 	 * contexts available, there's no chance we'll get one by waiting.
 	 */
-	if (k_current_get() == &k_sys_work_q.thread) {
+	if (k_current_get() == k_sys_work_q.thread_id) {
 		return k_fifo_get(&ag_tx_free, K_NO_WAIT);
 	}
 

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -318,7 +318,7 @@ static void l2cap_br_chan_destroy(struct bt_l2cap_chan *chan)
 	 */
 	struct k_work_q *rtx_work_queue = br_chan->rtx_work.queue;
 
-	if (rtx_work_queue == NULL || k_current_get() != &rtx_work_queue->thread) {
+	if (rtx_work_queue == NULL || k_current_get() != rtx_work_queue->thread_id) {
 		k_work_cancel_delayable_sync(&br_chan->rtx_work, &br_chan->rtx_sync);
 	} else {
 		k_work_cancel_delayable(&br_chan->rtx_work);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -453,7 +453,8 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 	 * syswq, then we cannot suspend and wait. We have to send the
 	 * command from the current context.
 	 */
-	if (!IS_ENABLED(CONFIG_BT_TX_PROCESSOR_THREAD) && k_current_get() == &k_sys_work_q.thread) {
+	if (!IS_ENABLED(CONFIG_BT_TX_PROCESSOR_THREAD) &&
+	    k_current_get() == k_sys_work_q.thread_id) {
 		/* drain the command queue until we get to send the command of interest. */
 		struct net_buf *cmd = NULL;
 
@@ -4677,7 +4678,7 @@ static void rx_work_handler(struct k_work *work)
 k_tid_t bt_testing_tx_tid_get(void)
 {
 	/* We now TX everything from the syswq */
-	return &k_sys_work_q.thread;
+	return k_sys_work_q.thread_id;
 }
 
 #if defined(CONFIG_BT_ISO)
@@ -4741,7 +4742,7 @@ int bt_enable(bt_ready_cb_t cb)
 	k_work_queue_start(&bt_workq, rx_thread_stack,
 			   CONFIG_BT_RX_STACK_SIZE,
 			   K_PRIO_COOP(CONFIG_BT_RX_PRIO), NULL);
-	k_thread_name_set(&bt_workq.thread, "BT RX WQ");
+	k_thread_name_set(bt_workq.thread_id, "BT RX WQ");
 #endif
 
 	err = bt_hci_open(bt_dev.hci, bt_recv);
@@ -4825,7 +4826,7 @@ int bt_disable(void)
 
 #if defined(CONFIG_BT_RECV_WORKQ_BT)
 	/* Abort RX thread */
-	k_thread_abort(&bt_workq.thread);
+	k_thread_abort(bt_workq.thread_id);
 #endif
 
 	/* Some functions rely on checking this bitfield */

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1366,7 +1366,7 @@ static void l2cap_chan_destroy(struct bt_l2cap_chan *chan)
 	 */
 	struct k_work_q *rtx_work_queue = le_chan->rtx_work.queue;
 
-	if (rtx_work_queue == NULL || k_current_get() != &rtx_work_queue->thread) {
+	if (rtx_work_queue == NULL || k_current_get() != rtx_work_queue->thread_id) {
 		k_work_cancel_delayable_sync(&le_chan->rtx_work, &le_chan->rtx_sync);
 	} else {
 		k_work_cancel_delayable(&le_chan->rtx_work);

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -502,7 +502,7 @@ void bt_mesh_adv_init(void)
 		k_work_queue_init(&bt_mesh_workq);
 		k_work_queue_start(&bt_mesh_workq, thread_stack, MESH_WORKQ_STACK_SIZE,
 				   K_PRIO_COOP(MESH_WORKQ_PRIORITY), NULL);
-		k_thread_name_set(&bt_mesh_workq.thread, "BT MESH WQ");
+		k_thread_name_set(bt_mesh_workq.thread_id, "BT MESH WQ");
 	}
 }
 

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -228,7 +228,7 @@ void bt_mesh_settings_init(void)
 		k_work_queue_start(&settings_work_q, settings_work_stack,
 				   K_THREAD_STACK_SIZEOF(settings_work_stack),
 				   K_PRIO_COOP(SETTINGS_WORKQ_PRIO), NULL);
-		k_thread_name_set(&settings_work_q.thread, "BT Mesh settings workq");
+		k_thread_name_set(settings_work_q.thread_id, "BT Mesh settings workq");
 	}
 
 	k_work_init_delayable(&pending_store, store_pending);

--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -339,7 +339,7 @@ static int mbox_init(const struct device *instance)
 		char name[THREAD_MAX_NAME_LEN];
 
 		snprintk(name, sizeof(name), "mbox_wq #%d", conf->id);
-		k_thread_name_set(&data->mbox_wq.thread, name);
+		k_thread_name_set(data->mbox_wq.thread_id, name);
 	}
 
 	k_work_init(&data->mbox_work, mbox_callback_process);

--- a/subsys/ipc/rpmsg_service/rpmsg_backend.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.c
@@ -206,7 +206,7 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
 	k_work_queue_start(&ipm_work_q, ipm_stack_area,
 			   K_THREAD_STACK_SIZEOF(ipm_stack_area),
 			   IPM_WORK_QUEUE_PRIORITY, NULL);
-	k_thread_name_set(&ipm_work_q.thread, "ipm_work_q");
+	k_thread_name_set(ipm_work_q.thread_id, "ipm_work_q");
 
 	/* Setup IPM workqueue item */
 	k_work_init(&ipm_work, ipm_callback_process);

--- a/subsys/lorawan/services/lorawan_services.c
+++ b/subsys/lorawan/services/lorawan_services.c
@@ -229,7 +229,7 @@ static int lorawan_services_init(void)
 
 	k_mutex_init(&session_mutex);
 
-	k_thread_name_set(&services_workq.thread, "lorawan_services");
+	k_thread_name_set(services_workq.thread_id, "lorawan_services");
 
 	return 0;
 }

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -244,7 +244,7 @@ static inline void mgmt_run_slist_callbacks(const struct mgmt_event_entry * cons
 	}
 
 #ifdef CONFIG_NET_DEBUG_MGMT_EVENT_STACK
-	log_stack_usage(&mgmt_work_q->thread);
+	log_stack_usage(mgmt_work_q->thread_id);
 #endif
 }
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -4940,6 +4940,6 @@ void net_tcp_init(void)
 		tcp_max_timeout_ms += tcp_max_timeout_ms >> 1;
 	}
 
-	k_thread_name_set(&tcp_work_q.thread, "tcp_work");
-	NET_DBG("Workq started. Thread ID: %p", &tcp_work_q.thread);
+	k_thread_name_set(tcp_work_q.thread_id, "tcp_work");
+	NET_DBG("Workq started. Thread ID: %p", tcp_work_q.thread_id);
 }

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -1952,7 +1952,7 @@ static int mdns_responder_init(void)
 				   K_KERNEL_STACK_SIZEOF(mdns_work_q_stack),
 				   THREAD_PRIORITY, NULL);
 
-		k_thread_name_set(&mdns_work_q.thread, "mdns_work");
+		k_thread_name_set(mdns_work_q.thread_id, "mdns_work");
 	}
 
 	k_work_init_delayable(&init_listener_timer, do_init_listener);

--- a/subsys/net/lib/quic/quic.c
+++ b/subsys/net/lib/quic/quic.c
@@ -8358,7 +8358,7 @@ static void init_quic_recovery_service(void)
 				 K_HIGHEST_APPLICATION_THREAD_PRIO,
 				 K_LOWEST_APPLICATION_THREAD_PRIO),
 			   NULL);
-	k_thread_name_set(&quic_recovery_work_q.thread, "quic_recovery");
+	k_thread_name_set(quic_recovery_work_q.thread_id, "quic_recovery");
 }
 
 /**

--- a/subsys/net/lib/zperf/zperf_common.c
+++ b/subsys/net/lib/zperf/zperf_common.c
@@ -330,7 +330,7 @@ static int zperf_init(void)
 			   K_THREAD_STACK_SIZEOF(zperf_work_q_stack),
 			   ZPERF_WORK_Q_THREAD_PRIORITY,
 			   NULL);
-	k_thread_name_set(&zperf_work_q.thread, "zperf_work_q");
+	k_thread_name_set(zperf_work_q.thread_id, "zperf_work_q");
 
 #endif /* CONFIG_ZPERF_SESSION_PER_THREAD */
 

--- a/subsys/shell/backends/shell_mqtt.c
+++ b/subsys/shell/backends/shell_mqtt.c
@@ -670,7 +670,7 @@ static int init(const struct shell_transport *transport, const void *config,
 	k_work_queue_init(&sh->workq);
 	k_work_queue_start(&sh->workq, sh_mqtt_workq_stack,
 			   K_KERNEL_STACK_SIZEOF(sh_mqtt_workq_stack), K_PRIO_COOP(7), NULL);
-	(void)k_thread_name_set(&sh->workq.thread, "sh_mqtt_workq");
+	(void)k_thread_name_set(sh->workq.thread_id, "sh_mqtt_workq");
 	k_work_init(&sh->net_disconnected_work, net_disconnect_handler);
 	k_work_init_delayable(&sh->connect_dwork, sh_mqtt_connect_handler);
 	k_work_init_delayable(&sh->subscribe_dwork, sh_mqtt_subscribe_handler);

--- a/subsys/usb/device/usb_work_q.c
+++ b/subsys/usb/device/usb_work_q.c
@@ -21,7 +21,7 @@ static int z_usb_work_q_init(void)
 			   z_usb_work_q_stack,
 			   K_KERNEL_STACK_SIZEOF(z_usb_work_q_stack),
 			   CONFIG_USB_WORKQUEUE_PRIORITY, NULL);
-	k_thread_name_set(&z_usb_work_q.thread, "usbworkq");
+	k_thread_name_set(z_usb_work_q.thread_id, "usbworkq");
 
 	return 0;
 }

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -179,7 +179,7 @@ static int usbd_cdc_acm_init_wq(void)
 	k_work_queue_start(&cdc_acm_work_q, cdc_acm_stack,
 			   K_KERNEL_STACK_SIZEOF(cdc_acm_stack),
 			   CONFIG_SYSTEM_WORKQUEUE_PRIORITY, NULL);
-	k_thread_name_set(&cdc_acm_work_q.thread, "cdc_acm_work_q");
+	k_thread_name_set(cdc_acm_work_q.thread_id, "cdc_acm_work_q");
 
 	return 0;
 }

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -250,7 +250,7 @@ static void test_queue_start(void)
 	zassert_equal(preempt_queue.flags, K_WORK_QUEUE_STARTED);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
-		const char *tn = k_thread_name_get(&preempt_queue.thread);
+		const char *tn = k_thread_name_get(preempt_queue.thread_id);
 
 		zassert_true(tn != cfg.name);
 		zassert_true(tn != NULL);
@@ -264,7 +264,7 @@ static void test_queue_start(void)
 	zassert_equal(invalid_test_queue.flags, K_WORK_QUEUE_STARTED);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
-		const char *tn = k_thread_name_get(&invalid_test_queue.thread);
+		const char *tn = k_thread_name_get(invalid_test_queue.thread_id);
 
 		zassert_true(tn != cfg.name);
 		zassert_true(tn != NULL);

--- a/tests/kernel/workq/work_queue/src/work_timeout.c
+++ b/tests/kernel/workq/work_queue/src/work_timeout.c
@@ -66,7 +66,7 @@ ZTEST(workqueue_work_timeout, test_work)
 	 * Submitted items takes longer than TEST_WORK_TIMEOUT_MS, but each item takes
 	 * less time than TEST_WORK_DELAY so workqueue thread will not be aborted.
 	 */
-	zassert_equal(k_thread_join(&test_workq.thread, TEST_WORK_DELAY), -EAGAIN);
+	zassert_equal(k_thread_join(test_workq.thread_id, TEST_WORK_DELAY), -EAGAIN);
 
 	/* Submit single item which takes longer than TEST_WORK_TIMEOUT_MS */
 	zassert_equal(k_work_submit_to_queue(&test_workq, &test_work_blocking), 1);
@@ -75,7 +75,7 @@ ZTEST(workqueue_work_timeout, test_work)
 	 * Submitted item shall cause the work to time out and the workqueue thread be
 	 * aborted if CONFIG_WORKQUEUE_WORK_TIMEOUT is enabled.
 	 */
-	ret = k_thread_join(&test_workq.thread, TEST_WORK_BLOCKING_DELAY);
+	ret = k_thread_join(test_workq.thread_id, TEST_WORK_BLOCKING_DELAY);
 	if (IS_ENABLED(CONFIG_WORKQUEUE_WORK_TIMEOUT)) {
 		zassert_equal(ret, 0);
 	} else {

--- a/tests/subsys/settings/performance/settings_test_perf.c
+++ b/tests/subsys/settings/performance/settings_test_perf.c
@@ -102,7 +102,7 @@ ZTEST(settings_perf, test_performance)
 	k_work_queue_start(&settings_work_q, settings_work_stack,
 			   K_THREAD_STACK_SIZEOF(settings_work_stack),
 			   K_PRIO_COOP(TEST_SETTINGS_WORKQ_PRIO), NULL);
-	k_thread_name_set(&settings_work_q.thread, "Settings workq");
+	k_thread_name_set(settings_work_q.thread_id, "Settings workq");
 	k_work_init_delayable(&pending_store, store_pending);
 
 	if (IS_ENABLED(CONFIG_BT)) {


### PR DESCRIPTION
This migrates all users of the `thread` field and then marks it as deprecated. Since twister tests fail on deprecation warnings, a successful CI run shows that all such users within tested code were found.

A new API for creating work queue threads will be added in a different PR.

Related:
- #110255
- #110261