### PR TITLE
dts: bindings: wifi: nordic,wlan: add local-mac-address

### DIFF
--- a/dts/bindings/wifi/nordic,wlan.yaml
+++ b/dts/bindings/wifi/nordic,wlan.yaml
@@ -8,4 +8,6 @@ description: |
   Wi-Fi chips. The interface is used to identify and name Wi-Fi network
   interfaces like wlan0.
 
+include: ethernet-controller.yaml
+
 compatible: "nordic,wlan"


### PR DESCRIPTION
Include ethernet-controller.yaml so local-mac-address on wlan0 nodes is available to DT_PROP() and DT_PROP_OR(). Without this, overlays set the property in zephyr.dts but generated headers omit it and applications fall back to a zero MAC when nRF70 OTP is not programmed.


Assisted-by: Cursor:Auto