### PR TITLE
Bluetooth: Add bt_conn_take() and bt_conn_drop() APIs and adopt treewide

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -131,6 +131,11 @@ New APIs and options
     * :c:func:`bt_ascs_register`
     * :c:func:`bt_ascs_unregister`
 
+  * Host
+
+    * :c:func:`bt_conn_take`
+    * :c:func:`bt_conn_drop`
+
   * Mesh
 
     * :c:struct:`bt_mesh_lpn_timing`

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1010,7 +1010,9 @@ struct bt_conn *bt_conn_ref(struct bt_conn *conn);
 
 /** @brief Decrement a connection's reference count.
  *
- *  Decrement the reference count of a connection object.
+ *  Decrement the reference count of a connection object. Unless the pointer variable is
+ *  immediately going out of scope, it's recommended to use @ref bt_conn_drop instead, which
+ *  will also set the pointer to NULL to prevent accidental reuse.
  *
  *  @param conn Connection object.
  */

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1034,6 +1034,16 @@ static inline struct bt_conn *__must_check bt_conn_take(struct bt_conn **orig)
 	return (struct bt_conn *)atomic_ptr_clear((atomic_ptr_t *)orig);
 }
 
+/** @brief Drop a connection reference and clear the pointer.
+ *
+ *  This performs an atomic exchange on @p orig, setting it to NULL and
+ *  unreferencing the previous value if it was not NULL.
+ *
+ *  @param orig Pointer to the connection pointer to drop (must not be NULL).
+ *              On return, @p *orig is set to NULL.
+ */
+void bt_conn_drop(struct bt_conn **orig);
+
 /** @brief Iterate through all bt_conn objects.
  *
  * Iterates through all bt_conn objects that are alive in the Host allocator.

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -27,6 +27,7 @@
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util_macro.h>
@@ -1014,6 +1015,24 @@ struct bt_conn *bt_conn_ref(struct bt_conn *conn);
  *  @param conn Connection object.
  */
 void bt_conn_unref(struct bt_conn *conn);
+
+/** @brief Take ownership of a connection pointer, setting the original to NULL.
+ *
+ *  This performs an atomic exchange on @p orig, setting it to NULL and
+ *  returning the previous value. The reference count is not modified; the
+ *  reference held by @p orig is transferred to the caller, who must
+ *  eventually release it with bt_conn_unref().
+ *
+ *  @param orig Pointer to the connection pointer to transfer (must not be
+ *              NULL). On return, @p *orig is set to NULL.
+ *
+ *  @return The connection originally pointed to by @p orig, which may be
+ *          NULL.
+ */
+static inline struct bt_conn *__must_check bt_conn_take(struct bt_conn **orig)
+{
+	return (struct bt_conn *)atomic_ptr_clear((atomic_ptr_t *)orig);
+}
 
 /** @brief Iterate through all bt_conn objects.
  *

--- a/modules/openthread/platform/ble.c
+++ b/modules/openthread/platform/ble.c
@@ -339,8 +339,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	LOG_INF("Disconnected, reason 0x%02x %s", reason, bt_hci_err_to_str(reason));
 
 	if (ot_plat_ble_connection) {
-		bt_conn_unref(ot_plat_ble_connection);
-		ot_plat_ble_connection = NULL;
+		bt_conn_drop(&ot_plat_ble_connection);
 
 		error = ot_plat_ble_queue_msg(NULL, PLAT_BLE_MSG_DISCONNECT, 0);
 		if (error != OT_ERROR_NONE) {

--- a/samples/bluetooth/bap_broadcast_assistant/src/main.c
+++ b/samples/bluetooth/bap_broadcast_assistant/src/main.c
@@ -467,8 +467,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		printk("Failed to connect to %s %u %s\n", bt_conn_dst_str(conn),
 		       err, bt_hci_err_to_str(err));
 
-		bt_conn_unref(broadcast_sink_conn);
-		broadcast_sink_conn = NULL;
+		bt_conn_drop(&broadcast_sink_conn);
 
 		scan_for_broadcast_sink();
 		return;
@@ -491,8 +490,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(broadcast_sink_conn);
-	broadcast_sink_conn = NULL;
+	bt_conn_drop(&broadcast_sink_conn);
 
 	k_sem_give(&sem_sink_disconnected);
 }

--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -688,8 +688,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(broadcast_assistant_conn);
-	broadcast_assistant_conn = NULL;
+	bt_conn_drop(&broadcast_assistant_conn);
 
 	k_sem_give(&sem_disconnected);
 }

--- a/samples/bluetooth/bap_unicast_client/src/main.c
+++ b/samples/bluetooth/bap_unicast_client/src/main.c
@@ -431,8 +431,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		printk("Failed to connect to %s %u %s\n", bt_conn_dst_str(conn),
 		       err, bt_hci_err_to_str(err));
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		start_scan();
 		return;
@@ -455,8 +454,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	k_sem_give(&sem_disconnected);
 }

--- a/samples/bluetooth/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/bap_unicast_server/src/main.c
@@ -565,8 +565,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	k_sem_give(&sem_disconnected);
 }

--- a/samples/bluetooth/cap_acceptor/src/main.c
+++ b/samples/bluetooth/cap_acceptor/src/main.c
@@ -90,8 +90,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 	LOG_INF("Disconnected: %s, reason 0x%02x %s", bt_conn_dst_str(conn),
 		reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(peer.conn);
-	peer.conn = NULL;
+	bt_conn_drop(&peer.conn);
 	k_sem_give(&sem_state_change);
 }
 

--- a/samples/bluetooth/cap_handover/src/main.c
+++ b/samples/bluetooth/cap_handover/src/main.c
@@ -584,8 +584,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	if (err != 0) {
 		LOG_ERR("Failed to connect to %s: %u", addr, err);
 
-		bt_conn_unref(peer.conn);
-		peer.conn = NULL;
+		bt_conn_drop(&peer.conn);
 		(void)memset(peer.unicast_eps, 0, sizeof(peer.unicast_eps));
 
 		start_scan();
@@ -612,8 +611,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 
 	LOG_INF("Disconnected: %s, reason 0x%02x %s", addr, reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(peer.conn);
-	peer.conn = NULL;
+	bt_conn_drop(&peer.conn);
 	(void)memset(peer.unicast_eps, 0, sizeof(peer.unicast_eps));
 
 	k_sem_give(&sem_state_change);

--- a/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
+++ b/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
@@ -518,8 +518,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	if (err != 0) {
 		LOG_ERR("Failed to connect to %s: %u", bt_conn_dst_str(conn), err);
 
-		bt_conn_unref(peer.conn);
-		peer.conn = NULL;
+		bt_conn_drop(&peer.conn);
 
 		start_scan();
 		return;
@@ -542,8 +541,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 	LOG_INF("Disconnected: %s, reason 0x%02x %s", bt_conn_dst_str(conn),
 		reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(peer.conn);
-	peer.conn = NULL;
+	bt_conn_drop(&peer.conn);
 
 	k_sem_give(&sem_state_change);
 }

--- a/samples/bluetooth/ccp_call_control_client/src/main.c
+++ b/samples/bluetooth/ccp_call_control_client/src/main.c
@@ -46,8 +46,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 {
 	if (err != BT_HCI_ERR_SUCCESS) {
 		LOG_INF("Failed to connect: %u", err);
-		bt_conn_unref(peer_conn);
-		peer_conn = NULL;
+		bt_conn_drop(&peer_conn);
 	} else {
 		LOG_INF("Connected: %s", bt_conn_dst_str(conn));
 	}
@@ -64,8 +63,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 	LOG_INF("Disconnected: %s (reason 0x%02x)", bt_conn_dst_str(conn),
 		reason);
 
-	bt_conn_unref(peer_conn);
-	peer_conn = NULL;
+	bt_conn_drop(&peer_conn);
 	call_control_client = NULL;
 	memset(&client_bearers, 0, sizeof(client_bearers));
 	k_sem_give(&sem_conn_state_change);

--- a/samples/bluetooth/ccp_call_control_server/src/main.c
+++ b/samples/bluetooth/ccp_call_control_server/src/main.c
@@ -64,8 +64,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 	LOG_INF("Disconnected: %s (reason 0x%02x)", bt_conn_dst_str(conn),
 		reason);
 
-	bt_conn_unref(peer_conn);
-	peer_conn = NULL;
+	bt_conn_drop(&peer_conn);
 	k_sem_give(&sem_state_change);
 }
 

--- a/samples/bluetooth/central/src/main.c
+++ b/samples/bluetooth/central/src/main.c
@@ -77,8 +77,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		printk("Failed to connect to %s %u %s\n", bt_conn_dst_str(conn),
 		       err, bt_hci_err_to_str(err));
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		start_scan();
 		return;
@@ -102,8 +101,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	start_scan();
 }

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -213,8 +213,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	if (conn_err) {
 		printk("Failed to connect to %s (%u)\n", bt_conn_dst_str(conn), conn_err);
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		start_scan();
 		return;
@@ -249,8 +248,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	start_scan();
 }

--- a/samples/bluetooth/central_ht/src/main.c
+++ b/samples/bluetooth/central_ht/src/main.c
@@ -130,8 +130,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	if (conn_err) {
 		printk("Failed to connect to %s (%u)\n", bt_conn_dst_str(conn), conn_err);
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		scan_start();
 		return;
@@ -241,8 +240,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	err = scan_start();
 	if (err) {

--- a/samples/bluetooth/central_multilink/src/central_multilink.c
+++ b/samples/bluetooth/central_multilink/src/central_multilink.c
@@ -143,8 +143,7 @@ static void connected(struct bt_conn *conn, uint8_t reason)
 	if (reason) {
 		printk("Failed to connect to %s (%u)\n", bt_conn_dst_str(conn), reason);
 
-		bt_conn_unref(conn_connecting);
-		conn_connecting = NULL;
+		bt_conn_drop(&conn_connecting);
 
 		start_scan();
 		return;

--- a/samples/bluetooth/central_otc/src/main.c
+++ b/samples/bluetooth/central_otc/src/main.c
@@ -496,8 +496,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		printk("Failed to connect to %s %u %s\n", bt_conn_dst_str(conn),
 		       err, bt_hci_err_to_str(err));
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 		start_scan();
 		return;
 	}
@@ -533,8 +532,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 	discovery_state = ATOMIC_INIT(0);
 	start_scan();
 }

--- a/samples/bluetooth/central_past/src/main.c
+++ b/samples/bluetooth/central_past/src/main.c
@@ -143,8 +143,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		printk("Failed to connect to %s %u %s\n", bt_conn_dst_str(conn),
 		       err, bt_hci_err_to_str(err));
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		bt_err = bt_le_scan_start(BT_LE_SCAN_ACTIVE, NULL);
 		if (bt_err) {
@@ -175,8 +174,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	k_sem_give(&sem_conn_lost);
 

--- a/samples/bluetooth/channel_sounding/src/connected_cs_initiator.c
+++ b/samples/bluetooth/channel_sounding/src/connected_cs_initiator.c
@@ -110,8 +110,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	__ASSERT(connection == conn, "Unexpected connected callback");
 
 	if (err) {
-		bt_conn_unref(conn);
-		connection = NULL;
+		bt_conn_drop(&connection);
 	}
 
 	static struct bt_gatt_exchange_params mtu_exchange_params = {.func = mtu_exchange_cb};
@@ -128,8 +127,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected (reason 0x%02X)\n", reason);
 
-	bt_conn_unref(conn);
-	connection = NULL;
+	bt_conn_drop(&connection);
 }
 
 static void security_changed_cb(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)

--- a/samples/bluetooth/channel_sounding/src/connected_cs_reflector.c
+++ b/samples/bluetooth/channel_sounding/src/connected_cs_reflector.c
@@ -70,8 +70,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	__ASSERT(connection == conn, "Unexpected connected callback");
 
 	if (err) {
-		bt_conn_unref(conn);
-		connection = NULL;
+		bt_conn_drop(&connection);
 	}
 
 	connection = bt_conn_ref(conn);
@@ -90,8 +89,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected (reason 0x%02X)\n", reason);
 
-	bt_conn_unref(conn);
-	connection = NULL;
+	bt_conn_drop(&connection);
 }
 
 static void remote_capabilities_cb(struct bt_conn *conn,

--- a/samples/bluetooth/channel_sounding/src/cs_test_initiator.c
+++ b/samples/bluetooth/channel_sounding/src/cs_test_initiator.c
@@ -105,8 +105,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	__ASSERT(connection == conn, "Unexpected connected callback");
 
 	if (err) {
-		bt_conn_unref(conn);
-		connection = NULL;
+		bt_conn_drop(&connection);
 	}
 
 	static struct bt_gatt_exchange_params mtu_exchange_params = {.func = mtu_exchange_cb};
@@ -123,8 +122,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected (reason 0x%02X)\n", reason);
 
-	bt_conn_unref(conn);
-	connection = NULL;
+	bt_conn_drop(&connection);
 
 	k_sem_give(&sem_disconnected);
 }

--- a/samples/bluetooth/channel_sounding/src/cs_test_reflector.c
+++ b/samples/bluetooth/channel_sounding/src/cs_test_reflector.c
@@ -71,8 +71,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	__ASSERT(connection == conn, "Unexpected connected callback");
 
 	if (err) {
-		bt_conn_unref(conn);
-		connection = NULL;
+		bt_conn_drop(&connection);
 	}
 
 	connection = bt_conn_ref(conn);
@@ -91,8 +90,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected (reason 0x%02X)\n", reason);
 
-	bt_conn_unref(conn);
-	connection = NULL;
+	bt_conn_drop(&connection);
 
 	k_sem_give(&sem_disconnected);
 }

--- a/samples/bluetooth/classic/handsfree/src/main.c
+++ b/samples/bluetooth/classic/handsfree/src/main.c
@@ -111,8 +111,7 @@ static void hf_sco_disconnected(struct bt_conn *sco_conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(active_sco_conn);
-	active_sco_conn = NULL;
+	bt_conn_drop(&active_sco_conn);
 
 	err = pcm_rx_stop();
 	if (err != 0) {

--- a/samples/bluetooth/classic/handsfree_ag/src/main.c
+++ b/samples/bluetooth/classic/handsfree_ag/src/main.c
@@ -139,8 +139,7 @@ static void ag_sco_disconnected(struct bt_conn *sco_conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(active_sco_conn);
-	active_sco_conn = NULL;
+	bt_conn_drop(&active_sco_conn);
 
 	err = pcm_rx_stop();
 	if (err != 0) {

--- a/samples/bluetooth/direction_finding_central/src/main.c
+++ b/samples/bluetooth/direction_finding_central/src/main.c
@@ -205,8 +205,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	if (conn_err) {
 		printk("Failed to connect to %s (%u)\n", bt_conn_dst_str(conn), conn_err);
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		start_scan();
 		return;
@@ -228,8 +227,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	start_scan();
 }

--- a/samples/bluetooth/encrypted_advertising/central/src/central_ead.c
+++ b/samples/bluetooth/encrypted_advertising/central/src/central_ead.c
@@ -301,8 +301,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	if (conn_err) {
 		LOG_DBG("Failed to connect to %s (err %u)", bt_conn_dst_str(conn), conn_err);
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		(void)start_scan(true);
 
@@ -323,8 +322,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 }
 
 static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)

--- a/samples/bluetooth/extended_adv/advertiser/src/main.c
+++ b/samples/bluetooth/extended_adv/advertiser/src/main.c
@@ -56,8 +56,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 
 	__ASSERT(conn == default_conn, "Unexpected disconnected callback");
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 }
 
 static void recycled_cb(void)

--- a/samples/bluetooth/extended_adv/scanner/src/main.c
+++ b/samples/bluetooth/extended_adv/scanner/src/main.c
@@ -48,8 +48,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	printk("Connected (err 0x%02X)\n", err);
 
 	if (err) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 		return;
 	}
 
@@ -58,8 +57,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	printk("Disconnected, reason 0x%02X %s\n", reason, bt_hci_err_to_str(reason));
 }

--- a/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
@@ -435,8 +435,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SRC)) {
 		/* reset data */

--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -178,10 +178,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected, reason 0x%02x %s\n", reason, bt_hci_err_to_str(reason));
 
-	if (default_conn) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
-	}
+	bt_conn_drop(&default_conn);
 }
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {

--- a/samples/bluetooth/iso_central/src/main.c
+++ b/samples/bluetooth/iso_central/src/main.c
@@ -198,8 +198,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		printk("Failed to connect to %s %u %s\n", bt_conn_dst_str(conn),
 		       err, bt_hci_err_to_str(err));
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		start_scan();
 		return;
@@ -231,8 +230,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	start_scan();
 }

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -513,8 +513,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		LOG_INF("Failed to connect to %s: %u %s", bt_conn_dst_str(conn),
 			err, bt_hci_err_to_str(err));
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 		return;
 	} else if (role == ROLE_PERIPHERAL) {
 		default_conn = bt_conn_ref(conn);
@@ -530,8 +529,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	LOG_INF("Disconnected: %s, reason 0x%02x %s", bt_conn_dst_str(conn),
 		reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 	k_sem_give(&sem_disconnected);
 }
 

--- a/samples/bluetooth/l2cap_coc_initiator/src/main.c
+++ b/samples/bluetooth/l2cap_coc_initiator/src/main.c
@@ -114,10 +114,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected (reason %u)\n", reason);
-	if (default_conn) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
-	}
+	bt_conn_drop(&default_conn);
 	channel_connected = false;
 	start_scan();
 }

--- a/samples/bluetooth/mtu_update/central/src/central_mtu_update.c
+++ b/samples/bluetooth/mtu_update/central/src/central_mtu_update.c
@@ -191,8 +191,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		printk("Failed to connect to %s %u %s\n", bt_conn_dst_str(conn),
 		       err, bt_hci_err_to_str(err));
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		start_scan();
 		return;
@@ -227,8 +226,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	start_scan();
 }

--- a/samples/bluetooth/mtu_update/peripheral/src/peripheral_mtu_update.c
+++ b/samples/bluetooth/mtu_update/peripheral/src/peripheral_mtu_update.c
@@ -75,8 +75,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	bt_conn_unref(conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 	k_work_submit(&advertise_work);
 }
 

--- a/samples/bluetooth/periodic_adv_conn/src/main.c
+++ b/samples/bluetooth/periodic_adv_conn/src/main.c
@@ -125,8 +125,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	__ASSERT(conn == default_conn, "Unexpected connected callback");
 
 	if (err) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 	}
 }
 
@@ -136,8 +135,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 
 	__ASSERT(conn == default_conn, "Unexpected disconnected callback");
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 }
 
 BT_CONN_CB_DEFINE(conn_cb) = {

--- a/samples/bluetooth/periodic_adv_rsp/src/main.c
+++ b/samples/bluetooth/periodic_adv_rsp/src/main.c
@@ -114,8 +114,7 @@ void connected_cb(struct bt_conn *conn, uint8_t err)
 	__ASSERT(conn == default_conn, "Unexpected connected callback");
 
 	if (err) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 	}
 }
 
@@ -390,8 +389,7 @@ disconnect:
 disconnected:
 		k_sem_take(&sem_disconnected, K_FOREVER);
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 	}
 
 	printk("Maximum numnber of syncs onboarded\n");

--- a/samples/bluetooth/periodic_sync_conn/src/main.c
+++ b/samples/bluetooth/periodic_sync_conn/src/main.c
@@ -117,8 +117,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	printk("Disconnected, reason 0x%02X %s\n", reason, bt_hci_err_to_str(reason));
 

--- a/samples/bluetooth/periodic_sync_rsp/src/main.c
+++ b/samples/bluetooth/periodic_sync_rsp/src/main.c
@@ -183,8 +183,7 @@ void connected(struct bt_conn *conn, uint8_t err)
 
 void disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	printk("Disconnected, reason 0x%02X %s\n", reason, bt_hci_err_to_str(reason));
 }

--- a/samples/bluetooth/peripheral_past/src/main.c
+++ b/samples/bluetooth/peripheral_past/src/main.c
@@ -80,8 +80,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 }
 
 static struct bt_conn_cb conn_callbacks = {

--- a/samples/bluetooth/st_ble_sensor/src/main.c
+++ b/samples/bluetooth/st_ble_sensor/src/main.c
@@ -165,10 +165,7 @@ static void connected(struct bt_conn *connected, uint8_t err)
 
 static void disconnected(struct bt_conn *disconn, uint8_t reason)
 {
-	if (ble_conn) {
-		bt_conn_unref(ble_conn);
-		ble_conn = NULL;
-	}
+	bt_conn_drop(&ble_conn);
 
 	LOG_INF("Disconnected, reason %u %s", reason, bt_hci_err_to_str(reason));
 }

--- a/samples/bluetooth/tmap_central/src/main.c
+++ b/samples/bluetooth/tmap_central/src/main.c
@@ -95,8 +95,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		printk("Failed to connect to %s %u %s\n", bt_conn_dst_str(conn),
 		       err, bt_hci_err_to_str(err));
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		start_scan();
 		return;
@@ -119,8 +118,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	k_sem_give(&sem_disconnected);
 }

--- a/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
+++ b/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
@@ -377,8 +377,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SRC)) {
 		/* reset data */

--- a/samples/bluetooth/tmap_peripheral/src/main.c
+++ b/samples/bluetooth/tmap_peripheral/src/main.c
@@ -126,8 +126,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected: %s, reason 0x%02x %s\n", bt_conn_dst_str(conn),
 	       reason, bt_hci_err_to_str(reason));
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	k_sem_give(&sem_disconnected);
 }

--- a/samples/boards/bbc/microbit/pong/src/ble.c
+++ b/samples/boards/bbc/microbit/pong/src/ble.c
@@ -261,10 +261,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected, reason 0x%02x %s\n", reason, bt_hci_err_to_str(reason));
 
-	if (default_conn) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
-	}
+	bt_conn_drop(&default_conn);
 
 	remote_handle = 0U;
 

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -682,12 +682,7 @@ static void aics_client_reset(struct bt_aics *inst)
 	atomic_clear_bit(inst->cli.flags, BT_AICS_CLIENT_FLAG_DESC_WRITABLE);
 	atomic_clear_bit(inst->cli.flags, BT_AICS_CLIENT_FLAG_CP_RETRIED);
 
-	if (inst->cli.conn != NULL) {
-		struct bt_conn *conn = inst->cli.conn;
-
-		bt_conn_unref(conn);
-		inst->cli.conn = NULL;
-	}
+	bt_conn_drop(&inst->cli.conn);
 }
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -187,8 +187,7 @@ static void ase_free(struct bt_ascs_ase *ase)
 		bt_bap_iso_unbind_ep(ase->ep.iso, &ase->ep);
 	}
 
-	bt_conn_unref(ase->conn);
-	ase->conn = NULL;
+	bt_conn_drop(&ase->conn);
 
 	(void)k_work_cancel_delayable(&ase->disconnect_work);
 	(void)k_work_cancel_delayable(&ase->state_transition_work);

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -962,8 +962,7 @@ static int broadcast_assistant_reset(struct bap_broadcast_assistant_instance *in
 			}
 		}
 
-		bt_conn_unref(conn);
-		inst->conn = NULL;
+		bt_conn_drop(&inst->conn);
 	}
 
 	/* The subscribe parameters must remain instact so they can get cleaned up by GATT */

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -1146,10 +1146,7 @@ void bt_bap_stream_detach(struct bt_bap_stream *stream)
 {
 	LOG_DBG("stream %p conn %p ep %p", stream, (void *)stream->conn, (void *)stream->ep);
 
-	if (stream->conn != NULL) {
-		bt_conn_unref(stream->conn);
-		stream->conn = NULL;
-	}
+	bt_conn_drop(&stream->conn);
 	stream->codec_cfg = NULL;
 
 	if (stream->ep != NULL) {

--- a/subsys/bluetooth/audio/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/ccp_call_control_client.c
@@ -115,8 +115,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 
 	/* client->conn may be NULL */
 	if (client->conn == conn) {
-		bt_conn_unref(client->conn);
-		client->conn = NULL;
+		bt_conn_drop(&client->conn);
 
 		memset(client->bearers, 0, sizeof(client->bearers));
 	}

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -1369,12 +1369,7 @@ static void csip_set_coordinator_reset(struct bt_csip_set_coordinator_inst *inst
 		svc_inst->set_lock_handle = 0;
 		svc_inst->rank_handle = 0;
 
-		if (svc_inst->conn != NULL) {
-			struct bt_conn *conn = svc_inst->conn;
-
-			bt_conn_unref(conn);
-			svc_inst->conn = NULL;
-		}
+		bt_conn_drop(&svc_inst->conn);
 
 		if (svc_inst->set_info != NULL) {
 			memset(svc_inst->set_info, 0, sizeof(*svc_inst->set_info));
@@ -1382,10 +1377,7 @@ static void csip_set_coordinator_reset(struct bt_csip_set_coordinator_inst *inst
 		}
 	}
 
-	if (inst->conn) {
-		bt_conn_unref(inst->conn);
-		inst->conn = NULL;
-	}
+	bt_conn_drop(&inst->conn);
 }
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)

--- a/subsys/bluetooth/audio/gmap_client.c
+++ b/subsys/bluetooth/audio/gmap_client.c
@@ -88,8 +88,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	ARG_UNUSED(reason);
 
 	if (gmap_cli != NULL) {
-		bt_conn_unref(gmap_cli->conn);
-		gmap_cli->conn = NULL;
+		bt_conn_drop(&gmap_cli->conn);
 	}
 }
 

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -276,8 +276,7 @@ static void client_free(struct has_client *client)
 		client->context = NULL;
 	}
 
-	bt_conn_unref(client->conn);
-	client->conn = NULL;
+	bt_conn_drop(&client->conn);
 }
 
 static struct has_client *client_alloc(struct bt_conn *conn)

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -1336,8 +1336,7 @@ static int reset_mcs_inst(struct mcs_instance_t *mcs_inst)
 #endif /* CONFIG_BT_MCC_OTS */
 		}
 
-		bt_conn_unref(conn);
-		mcs_inst->conn = NULL;
+		bt_conn_drop(&mcs_inst->conn);
 	}
 
 	(void)memset(mcs_inst, 0, offsetof(struct mcs_instance_t, player_name_sub_params));

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -742,8 +742,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	ARG_UNUSED(reason);
 
 	if (mprx.remote_player.conn == conn) {
-		bt_conn_unref(mprx.remote_player.conn);
-		mprx.remote_player.conn = NULL;
+		bt_conn_drop(&mprx.remote_player.conn);
 	}
 }
 

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -504,12 +504,7 @@ static void micp_mic_ctlr_reset(struct bt_micp_mic_ctlr *mic_ctlr)
 	mic_ctlr->aics_inst_cnt = 0;
 #endif /* CONFIG_BT_MICP_MIC_CTLR_AICS */
 
-	if (mic_ctlr->conn != NULL) {
-		struct bt_conn *conn = mic_ctlr->conn;
-
-		bt_conn_unref(conn);
-		mic_ctlr->conn = NULL;
-	}
+	bt_conn_drop(&mic_ctlr->conn);
 }
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -317,10 +317,7 @@ static void recv_state_updated_cb(struct bt_conn *conn,
 	 */
 	if (util_memeq(recv_state, &(struct bt_bap_scan_delegator_recv_state){0},
 		       sizeof(*recv_state))) {
-		if (state->conn != NULL) {
-			bt_conn_unref(state->conn);
-			state->conn = NULL;
-		}
+		bt_conn_drop(&state->conn);
 
 		(void)memset(state, 0, sizeof(*state)); /* mark as unused */
 	}
@@ -455,10 +452,7 @@ static void pa_synced_cb(struct bt_le_per_adv_sync *sync,
 		}
 	}
 
-	if (state->conn != NULL) {
-		bt_conn_unref(state->conn);
-		state->conn = NULL;
-	}
+	bt_conn_drop(&state->conn);
 
 	k_work_cancel_delayable(&state->pa_timer);
 }
@@ -478,10 +472,7 @@ static void pa_term_cb(struct bt_le_per_adv_sync *sync,
 		return;
 	}
 
-	if (state->conn != NULL) {
-		bt_conn_unref(state->conn);
-		state->conn = NULL;
-	}
+	bt_conn_drop(&state->conn);
 
 	state->pa_sync = NULL;
 

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -77,8 +77,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 
 	ARG_UNUSED(reason);
 
-	bt_conn_unref(conns[conn_index]);
-	conns[conn_index] = NULL;
+	bt_conn_drop(&conns[conn_index]);
 }
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -861,12 +861,7 @@ static void vcp_vol_ctlr_reset(struct bt_vcp_vol_ctlr *vol_ctlr)
 
 	memset(&vol_ctlr->discover_params, 0, sizeof(vol_ctlr->discover_params));
 
-	if (vol_ctlr->conn != NULL) {
-		struct bt_conn *conn = vol_ctlr->conn;
-
-		bt_conn_unref(conn);
-		vol_ctlr->conn = NULL;
-	}
+	bt_conn_drop(&vol_ctlr->conn);
 }
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -710,12 +710,7 @@ static void vocs_client_reset(struct bt_vocs_client *inst)
 	inst->control_handle = 0;
 	inst->desc_handle = 0;
 
-	if (inst->conn != NULL) {
-		struct bt_conn *conn = inst->conn;
-
-		bt_conn_unref(conn);
-		inst->conn = NULL;
-	}
+	bt_conn_drop(&inst->conn);
 }
 
 int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *vocs,

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -527,10 +527,7 @@ static void avrcp_disconnected(struct bt_avctp *session)
 	memset(&ct->ct_notify, 0, sizeof(ct->ct_notify));
 	memset(&tg->tg_notify, 0, sizeof(tg->tg_notify));
 
-	if (avrcp->acl_conn != NULL) {
-		bt_conn_unref(avrcp->acl_conn);
-		avrcp->acl_conn = NULL;
-	}
+	bt_conn_drop(&avrcp->acl_conn);
 }
 
 static struct net_buf *avrcp_create_unit_pdu(struct bt_avrcp *avrcp, uint8_t ctype_or_rsp)

--- a/subsys/bluetooth/host/classic/avrcp_cover_art.c
+++ b/subsys/bluetooth/host/classic/avrcp_cover_art.c
@@ -608,18 +608,18 @@ int bt_avrcp_cover_art_ct_l2cap_connect(struct bt_avrcp_ct *ct,
 		return -ENOTCONN;
 	}
 
-	bt_conn_unref(conn);
-
 	index = bt_conn_index(conn);
 
 	if (index >= ARRAY_SIZE(avrcp_cover_art_ct)) {
 		LOG_ERR("Conn index out of bounds");
+		bt_conn_unref(conn);
 		return -EINVAL;
 	}
 
 	avrcp_cover_art_ct[index].bip.ops = &ct_bip_transport_ops;
 
 	err = bt_bip_l2cap_connect(conn, &avrcp_cover_art_ct[index].bip, psm);
+	bt_conn_unref(conn);
 	if (err != 0) {
 		LOG_ERR("Failed to connect AVRCP Cover Art L2CAP channel (err %d)", err);
 		return err;

--- a/subsys/bluetooth/host/classic/sco.c
+++ b/subsys/bluetooth/host/classic/sco.c
@@ -398,10 +398,7 @@ void bt_sco_cleanup_acl(struct bt_conn *sco)
 {
 	LOG_DBG("%p", sco);
 
-	if (sco->sco.acl) {
-		bt_conn_unref(sco->sco.acl);
-		sco->sco.acl = NULL;
-	}
+	bt_conn_drop(&sco->sco.acl);
 }
 
 static int sco_setup_sync_conn(struct bt_conn *sco_conn)

--- a/subsys/bluetooth/host/classic/shell/hfp.c
+++ b/subsys/bluetooth/host/classic/shell/hfp.c
@@ -117,8 +117,7 @@ static void hf_sco_disconnected(struct bt_conn *sco_conn, uint8_t reason)
 	bt_shell_print("HF SCO disconnected %p (reason %u)", sco_conn, reason);
 
 	if (hf_sco_conn == sco_conn) {
-		bt_conn_unref(hf_sco_conn);
-		hf_sco_conn = NULL;
+		bt_conn_drop(&hf_sco_conn);
 	} else {
 		bt_shell_warn("Unknown SCO disconnected (%p != %p)", hf_sco_conn, sco_conn);
 	}
@@ -1152,8 +1151,7 @@ static void ag_sco_disconnected(struct bt_conn *sco_conn, uint8_t reason)
 	bt_shell_print("AG SCO disconnected %p (reason %u)", sco_conn, reason);
 
 	if (hfp_ag_sco_conn == sco_conn) {
-		bt_conn_unref(hfp_ag_sco_conn);
-		hfp_ag_sco_conn = NULL;
+		bt_conn_drop(&hfp_ag_sco_conn);
 	} else {
 		bt_shell_warn("Unknown SCO disconnected (%p != %p)", hfp_ag_sco_conn, sco_conn);
 	}

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1522,6 +1522,15 @@ void bt_conn_unref(struct bt_conn *conn)
 #endif /* CONFIG_BT_CONN */
 }
 
+void bt_conn_drop(struct bt_conn **orig)
+{
+	struct bt_conn *conn = bt_conn_take(orig);
+
+	if (conn != NULL) {
+		bt_conn_unref(conn);
+	}
+}
+
 uint8_t bt_conn_index(const struct bt_conn *conn)
 {
 	ptrdiff_t index = 0;

--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -858,18 +858,12 @@ void bt_hci_le_cs_subevent_result(struct net_buf *buf)
 		goto abort;
 	}
 
-	if (conn) {
-		bt_conn_unref(conn);
-		conn = NULL;
-	}
+	bt_conn_drop(&conn);
 
 	return;
 
 abort:
-	if (conn) {
-		bt_conn_unref(conn);
-		conn = NULL;
-	}
+	bt_conn_drop(&conn);
 
 	reassembly_buf = get_reassembly_buf(conn_handle, false);
 	if (reassembly_buf) {
@@ -949,18 +943,12 @@ void bt_hci_le_cs_subevent_result_continue(struct net_buf *buf)
 		free_reassembly_buf(&reassembly_buf);
 	}
 
-	if (conn) {
-		bt_conn_unref(conn);
-		conn = NULL;
-	}
+	bt_conn_drop(&conn);
 
 	return;
 
 abort:
-	if (conn) {
-		bt_conn_unref(conn);
-		conn = NULL;
-	}
+	bt_conn_drop(&conn);
 
 	if (reassembly_buf) {
 		free_reassembly_buf(&reassembly_buf);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1533,7 +1533,6 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 	}
 
 	bt_conn_connected(conn);
-	bt_conn_unref(conn);
 
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) && conn->role == BT_HCI_ROLE_CENTRAL) {
 		int err;
@@ -1544,6 +1543,8 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 			LOG_WRN("Error while updating the scanner (%d)", err);
 		}
 	}
+
+	bt_conn_unref(conn);
 }
 
 #if defined(CONFIG_BT_PER_ADV_SYNC_RSP)

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -488,8 +488,7 @@ static void bt_iso_chan_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 		bt_iso_cleanup_acl(chan->iso);
 
 		if (conn_type == BT_ISO_CHAN_TYPE_PERIPHERAL) {
-			bt_conn_unref(chan->iso);
-			chan->iso = NULL;
+			bt_conn_drop(&chan->iso);
 #if defined(CONFIG_BT_ISO_CENTRAL)
 		} else {
 			bool is_chan_connected;
@@ -2014,10 +2013,7 @@ static void cleanup_cig(struct bt_iso_cig *cig)
 	struct bt_iso_chan *cis, *tmp;
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&cig->cis_channels, cis, tmp, node) {
-		if (cis->iso != NULL) {
-			bt_conn_unref(cis->iso);
-			cis->iso = NULL;
-		}
+		bt_conn_drop(&cis->iso);
 
 		sys_slist_remove(&cig->cis_channels, NULL, &cis->node);
 	}
@@ -2259,8 +2255,7 @@ static void restore_cig(struct bt_iso_cig *cig, uint8_t existing_num_cis)
 		 * bt_iso_cig_reconfigure was called
 		 */
 		if (cis->iso != NULL && cis->iso->iso.info.unicast.cis_id >= existing_num_cis) {
-			bt_conn_unref(cis->iso);
-			cis->iso = NULL;
+			bt_conn_drop(&cis->iso);
 
 			sys_slist_remove(&cig->cis_channels, NULL, &cis->node);
 			cig->num_cis--;
@@ -2556,10 +2551,7 @@ static void cleanup_big(struct bt_iso_big *big)
 	struct bt_iso_chan *bis, *tmp;
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&big->bis_channels, bis, tmp, node) {
-		if (bis->iso != NULL) {
-			bt_conn_unref(bis->iso);
-			bis->iso = NULL;
-		}
+		bt_conn_drop(&bis->iso);
 
 		sys_slist_remove(&big->bis_channels, NULL, &bis->node);
 	}

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1175,12 +1175,10 @@ static bool bt_iso_acl_has_cis(const struct bt_conn *acl)
 
 void bt_iso_cleanup_acl(struct bt_conn *iso)
 {
-	struct bt_conn *acl = iso->iso.acl;
+	struct bt_conn *acl = bt_conn_take(&iso->iso.acl);
 	LOG_DBG("%p", iso);
 
 	if (acl != NULL) {
-		iso->iso.acl = NULL;
-
 		/* If we have removed the last ACL reference, trigger the deferred work to finalize
 		 * the ACL disconnection
 		 */

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -744,10 +744,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 
 done:
 	/* clear connection reference for sec mode 3 pairing */
-	if (pairing_conn) {
-		bt_conn_unref(pairing_conn);
-		pairing_conn = NULL;
-	}
+	bt_conn_drop(&pairing_conn);
 }
 
 static void disconnected_set_new_default_conn_cb(struct bt_conn *conn, void *user_data)
@@ -788,8 +785,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		if (err != 0) {
 			bt_shell_error("Unable to get info: conn %p (err %d)", conn, err);
 		}
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		if (err == 0) {
 			/* If we are connected to other devices, set one of them as default */
@@ -4409,10 +4405,7 @@ static void auth_cancel(struct bt_conn *conn)
 	bt_shell_print("Pairing cancelled: %s", bt_conn_dst_str(conn));
 
 	/* clear connection reference for sec mode 3 pairing */
-	if (pairing_conn) {
-		bt_conn_unref(pairing_conn);
-		pairing_conn = NULL;
-	}
+	bt_conn_drop(&pairing_conn);
 }
 
 static void auth_pairing_confirm(struct bt_conn *conn)

--- a/subsys/bluetooth/host/shell/l2cap.c
+++ b/subsys/bluetooth/host/shell/l2cap.c
@@ -185,8 +185,7 @@ static void l2cap_allowlist_remove(struct bt_conn *conn, uint8_t reason)
 
 	for (i = 0; i < ARRAY_SIZE(l2cap_allowlist); i++) {
 		if (l2cap_allowlist[i] == conn) {
-			bt_conn_unref(l2cap_allowlist[i]);
-			l2cap_allowlist[i] = NULL;
+			bt_conn_drop(&l2cap_allowlist[i]);
 		}
 	}
 }

--- a/subsys/bluetooth/mesh/gatt_cli.c
+++ b/subsys/bluetooth/mesh/gatt_cli.c
@@ -184,8 +184,7 @@ static void gatt_connected(struct bt_conn *conn, uint8_t conn_err)
 	if (conn_err) {
 		LOG_ERR("Failed to connect GATT Services(%u)", conn_err);
 
-		bt_conn_unref(server->conn);
-		server->conn = NULL;
+		bt_conn_drop(&server->conn);
 
 		(void)bt_mesh_scan_enable();
 

--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -39,10 +39,7 @@ static struct prov_link link;
 
 static void reset_state(void)
 {
-	if (link.conn) {
-		bt_conn_unref(link.conn);
-		link.conn = NULL;
-	}
+	bt_conn_drop(&link.conn);
 
 	/* If this fails, the protocol timeout handler will exit early. */
 	(void)k_work_cancel_delayable(&link.prot_timer);

--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -344,8 +344,7 @@ void bt_mesh_proxy_role_cleanup(struct bt_mesh_proxy_role *role)
 	 * there's no active connection.
 	 */
 	(void)k_work_cancel_delayable(&role->sar_timer);
-	bt_conn_unref(role->conn);
-	role->conn = NULL;
+	bt_conn_drop(&role->conn);
 
 	conn_count--;
 }

--- a/tests/bluetooth/audio/mocks/src/conn.c
+++ b/tests/bluetooth/audio/mocks/src/conn.c
@@ -45,6 +45,14 @@ void bt_conn_unref(struct bt_conn *conn)
 	ARG_UNUSED(conn);
 }
 
+void bt_conn_drop(struct bt_conn **orig)
+{
+	struct bt_conn *conn = *orig;
+
+	*orig = NULL;
+	bt_conn_unref(conn);
+}
+
 int bt_conn_auth_info_cb_register(struct bt_conn_auth_info_cb *cb)
 {
 	if (cb == NULL) {

--- a/tests/bluetooth/host/cs/mocks/conn.c
+++ b/tests/bluetooth/host/cs/mocks/conn.c
@@ -9,6 +9,7 @@
 #include <zephyr/kernel.h>
 
 DEFINE_FAKE_VOID_FUNC(bt_conn_unref, struct bt_conn *);
+DEFINE_FAKE_VOID_FUNC(bt_conn_drop, struct bt_conn **);
 DEFINE_FAKE_VALUE_FUNC(struct bt_conn *, bt_conn_lookup_handle, uint16_t, enum bt_conn_type);
 DEFINE_FAKE_VOID_FUNC(bt_conn_notify_remote_cs_capabilities, struct bt_conn *,
 		      uint8_t, struct bt_conn_le_cs_capabilities *);

--- a/tests/bluetooth/host/cs/mocks/conn.h
+++ b/tests/bluetooth/host/cs/mocks/conn.h
@@ -13,6 +13,7 @@
 /* List of fakes used by this unit tester */
 #define CONN_FFF_FAKES_LIST(FAKE)                                                                  \
 	FAKE(bt_conn_unref)                                                                        \
+	FAKE(bt_conn_drop)                                                                         \
 	FAKE(bt_conn_lookup_handle)                                                                \
 	FAKE(bt_conn_notify_remote_cs_capabilities)                                                \
 	FAKE(bt_conn_notify_cs_config_created)                                                     \
@@ -23,6 +24,7 @@
 	FAKE(bt_conn_notify_remote_cs_fae_table)
 
 DECLARE_FAKE_VOID_FUNC(bt_conn_unref, struct bt_conn *);
+DECLARE_FAKE_VOID_FUNC(bt_conn_drop, struct bt_conn **);
 DECLARE_FAKE_VALUE_FUNC(struct bt_conn *, bt_conn_lookup_handle, uint16_t, enum bt_conn_type);
 DECLARE_FAKE_VOID_FUNC(bt_conn_notify_remote_cs_capabilities, struct bt_conn *,
 		       uint8_t, struct bt_conn_le_cs_capabilities *);

--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -2387,10 +2387,7 @@ static uint8_t get_attr_val(const void *cmd, uint16_t cmd_len,
 
 	bt_gatt_foreach_attr(handle, handle, get_attr_val_rp, &cb_data);
 
-	if (conn != NULL) {
-		bt_conn_unref(conn);
-		cb_data.conn = NULL;
-	}
+	bt_conn_drop(&cb_data.conn);
 
 	if (buf->len) {
 		(void)memcpy(rsp, buf->data,  buf->len);

--- a/tests/bluetooth/tester/src/btp_rfcomm.c
+++ b/tests/bluetooth/tester/src/btp_rfcomm.c
@@ -73,10 +73,7 @@ static struct rfcomm_channel *alloc_channel(const bt_addr_t *dst)
 
 static void free_channel(struct rfcomm_channel *chan)
 {
-	if (chan->conn != NULL) {
-		bt_conn_unref(chan->conn);
-		chan->conn = NULL;
-	}
+	bt_conn_drop(&chan->conn);
 	chan->in_use = false;
 	chan->channel = 0;
 	bt_addr_copy(&chan->dst, &bt_addr_none);

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -1545,8 +1545,7 @@ static void test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 			FAIL("Failed to disconnect conn[%zu]: %d\n", i, err);
 		}
 
-		bt_conn_unref(connected_conns[i]);
-		connected_conns[i] = NULL;
+		bt_conn_drop(&connected_conns[i]);
 	}
 
 	PASS("CAP initiator passed for %s with Sink Preset %s and Source Preset %s\n", param->name,

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -127,8 +127,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	}
 
 	if (err != 0) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		FAIL("Failed to connect to %s (0x%02x)\n", bt_conn_dst_str(conn), err);
 		return;
@@ -146,8 +145,7 @@ void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 	UNSET_FLAG(flag_connected);
 	UNSET_FLAG(flag_conn_updated);
 	SET_FLAG(flag_disconnected);

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -1071,8 +1071,7 @@ static void test_gmap_ugg_unicast_ac(const struct gmap_unicast_ac_param *param)
 			FAIL("Failed to disconnect conn[%zu]: %d\n", i, err);
 		}
 
-		bt_conn_unref(connected_conns[i]);
-		connected_conns[i] = NULL;
+		bt_conn_drop(&connected_conns[i]);
 	}
 
 	deinit();

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
@@ -124,8 +124,7 @@ static void free_conn_object_work_fn(struct k_work *work)
 {
 	ARG_UNUSED(work);
 
-	bt_conn_unref(g_conn);
-	g_conn = NULL;
+	bt_conn_drop(&g_conn);
 }
 
 static K_WORK_DELAYABLE_DEFINE(free_conn_object_work, free_conn_object_work_fn);

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
@@ -26,8 +26,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err != BT_HCI_ERR_SUCCESS) {
 		TEST_FAIL("Failed to connect to %s: %u", bt_conn_dst_str(conn), err);
-		bt_conn_unref(g_conn);
-		g_conn = NULL;
+		bt_conn_drop(&g_conn);
 		return;
 	}
 
@@ -39,8 +38,7 @@ static void free_conn_object_work_fn(struct k_work *work)
 {
 	ARG_UNUSED(work);
 
-	bt_conn_unref(g_conn);
-	g_conn = NULL;
+	bt_conn_drop(&g_conn);
 }
 
 static K_WORK_DELAYABLE_DEFINE(free_conn_object_work, free_conn_object_work_fn);

--- a/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
@@ -42,8 +42,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected: %s (reason %u)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
-	g_conn = NULL;
+	bt_conn_drop(&g_conn);
 }
 
 static struct bt_conn_cb conn_cbs = {

--- a/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_sync.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_sync.c
@@ -48,8 +48,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected: %s (reason %u)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
-	g_conn = NULL;
+	bt_conn_drop(&g_conn);
 }
 
 static struct bt_conn_cb conn_cbs = {

--- a/tests/bsim/bluetooth/host/att/eatt/src/common.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/common.c
@@ -22,10 +22,7 @@ static volatile bool is_encrypted;
 static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	if (conn_err) {
-		if (default_conn) {
-			bt_conn_unref(default_conn);
-			default_conn = NULL;
-		}
+		bt_conn_drop(&default_conn);
 
 		TEST_FAIL("Failed to connect to %s (%u)", bt_conn_dst_str(conn), conn_err);
 		return;
@@ -43,8 +40,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 	is_connected = false;
 	is_encrypted = false;
 }

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/client_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/client_test.c
@@ -63,9 +63,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
@@ -48,9 +48,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/client/main.c
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/client/main.c
@@ -100,8 +100,7 @@ static void test_cli_main(void)
 	err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	__ASSERT_NO_MSG(!err);
 
-	bt_conn_unref(conn);
-	conn = NULL;
+	bt_conn_drop(&conn);
 
 	TEST_PASS("PASS");
 }

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/client/main.c
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/client/main.c
@@ -95,8 +95,7 @@ static void test_client(void)
 	err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	__ASSERT_NO_MSG(!err);
 
-	bt_conn_unref(conn);
-	conn = NULL;
+	bt_conn_drop(&conn);
 
 	TEST_PASS("PASS");
 }
@@ -157,8 +156,7 @@ static void test_client_security_request(void)
 	err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	__ASSERT_NO_MSG(!err);
 
-	bt_conn_unref(conn);
-	conn = NULL;
+	bt_conn_drop(&conn);
 
 	TEST_PASS("PASS");
 }

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
@@ -56,9 +56,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
@@ -45,9 +45,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 }
 
 static struct bt_conn_cb conn_callbacks = {

--- a/tests/bsim/bluetooth/host/gatt/caching/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/gatt_client_test.c
@@ -54,9 +54,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
@@ -49,9 +49,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/src/central.c
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/src/central.c
@@ -155,8 +155,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 }
 
 static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
@@ -63,9 +63,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
@@ -47,9 +47,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
@@ -50,9 +50,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
@@ -51,9 +51,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
@@ -70,9 +70,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_server_test.c
@@ -51,9 +51,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_client_test.c
@@ -48,9 +48,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_server_test.c
@@ -50,9 +50,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/settings/src/utils.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/utils.c
@@ -33,8 +33,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	__ASSERT_NO_MSG(default_conn == conn);
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	UNSET_FLAG(flag_is_connected);
 	gatt_clear_flags();

--- a/tests/bsim/bluetooth/host/iso/cis/src/common.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/common.c
@@ -26,8 +26,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	}
 
 	if (err != 0) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		TEST_FAIL("Failed to connect to %s (0x%02x)", bt_conn_dst_str(conn), err);
 
@@ -46,8 +45,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 	UNSET_FLAG(flag_connected);
 	UNSET_FLAG(flag_conn_updated);
 }

--- a/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
+++ b/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
@@ -329,8 +329,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	if (conn_err) {
 		TEST_FAIL("Failed to connect to %s (%u)", bt_conn_dst_str(conn), conn_err);
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 		return;
 	}
 
@@ -349,8 +348,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 	UNSET_FLAG(is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
@@ -191,8 +191,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
 		TEST_FAIL("Failed to connect (err %d)", err);
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 		return;
 	}
 
@@ -208,8 +207,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 	UNSET_FLAG(is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/l2cap/userdata/src/main_l2cap_userdata.c
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/src/main_l2cap_userdata.c
@@ -116,8 +116,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
 		TEST_FAIL("Failed to connect (err %d)", err);
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 		return;
 	}
 
@@ -133,8 +132,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 	UNSET_FLAG(is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
@@ -55,9 +55,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
+	bt_conn_drop(&g_conn);
 
-	g_conn = NULL;
 	UNSET_FLAG(flag_is_connected);
 }
 

--- a/tests/bsim/bluetooth/host/misc/hfc/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/hfc/src/main.c
@@ -330,9 +330,8 @@ static void entrypoint_dut(void)
 			bt_conn_unref(s->conn);
 
 			/* release the ref we took when starting the scanner */
-			bt_conn_unref(s->conn);
+			bt_conn_drop(&s->conn);
 
-			s->conn = NULL;
 			s->conn = connect_and_subscribe();
 		}
 	}
@@ -388,8 +387,7 @@ static void entrypoint_peer(void)
 		LOG_INF("disconnect");
 		err = disconnect(conn);
 		TEST_ASSERT(!err, "Failed to initate disconnect (err %d)", err);
-		bt_conn_unref(conn);
-		conn = NULL;
+		bt_conn_drop(&conn);
 	}
 }
 

--- a/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
@@ -45,8 +45,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("conn_callback:Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(g_conn);
-	g_conn = NULL;
+	bt_conn_drop(&g_conn);
 
 	UNSET_FLAG(flag_is_connected);
 }

--- a/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_central.c
+++ b/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_central.c
@@ -209,8 +209,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	LOG_DBG("Disconnected: %s (reason 0x%02x)", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	start_scan();
 }

--- a/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_peripheral.c
+++ b/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_peripheral.c
@@ -307,8 +307,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	LOG_DBG("Disconnected: %s (reason 0x%02x)", bt_conn_dst_str(conn), reason);
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	LOG_DBG("Disconnected");
 	SET_FLAG(wait_disconnection);

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/central.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/central.c
@@ -150,8 +150,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 }
 
 static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)

--- a/tests/bsim/bluetooth/ll/bis/src/test_past.c
+++ b/tests/bsim/bluetooth/ll/bis/src/test_past.c
@@ -135,8 +135,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 }
 
 static struct bt_conn_cb conn_callbacks = {

--- a/tests/bsim/bluetooth/ll/conn/src/test_connect1.c
+++ b/tests/bsim/bluetooth/ll/conn/src/test_connect1.c
@@ -395,8 +395,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_conn_unref(default_conn);
-	default_conn = NULL;
+	bt_conn_drop(&default_conn);
 
 	/* This demo doesn't require active scan */
 	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, device_found);

--- a/tests/bsim/bluetooth/ll/conn/src/test_connect2.c
+++ b/tests/bsim/bluetooth/ll/conn/src/test_connect2.c
@@ -116,10 +116,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Peripheral disconnected (reason 0x%02x)\n", reason);
 
-	if (default_conn) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
-	}
+	bt_conn_drop(&default_conn);
 }
 
 static int start_advertising(void)

--- a/tests/bsim/bluetooth/samples/battery_service/src/peripheral_test.c
+++ b/tests/bsim/bluetooth/samples/battery_service/src/peripheral_test.c
@@ -84,10 +84,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	LOG_DBG("Peripheral %s (reason 0x%02x)\n", __func__, reason);
 
-	if (default_conn) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
-	}
+	bt_conn_drop(&default_conn);
 }
 
 static struct bt_conn_cb conn_callbacks = {

--- a/tests/bsim/bluetooth/samples/peripheral_gap_svc/src/central.c
+++ b/tests/bsim/bluetooth/samples/peripheral_gap_svc/src/central.c
@@ -75,8 +75,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	if (conn_err != BT_HCI_ERR_SUCCESS) {
 		printk("Failed to connect to %s (%u)\n", bt_conn_dst_str(conn), conn_err);
 
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
+		bt_conn_drop(&default_conn);
 
 		TEST_FAIL("Failed to connect to %s (%u)", bt_conn_dst_str(conn), conn_err);
 		return;


### PR DESCRIPTION
This PR introduces two new bt_conn reference-management APIs — bt_conn_take() and bt_conn_drop() — and sweeps the tree to adopt them, analogous to the recent work on introducing `net_buf_take()` and `net_buf_drop()`. It also fixes two latent use-after-unref bugs uncovered while doing the cleanup.

### New APIs

 - `bt_conn_take(struct bt_conn **conn)` — atomically transfers ownership of a connection reference from a pointer variable, leaving the source pointer NULL. The reference count is unchanged; the caller takes over ownership. Mirrors the existing net_buf_take().
 - `bt_conn_drop(struct bt_conn **conn)` — atomically drops a connection reference and clears the source pointer, replacing the common two-line pattern:
```
 bt_conn_unref(conn);
 conn = NULL;
```
`NULL` is handled internally, so external guards become unnecessary.

### Treewide adoption

`bt_conn_drop()` (and `bt_conn_take()` where applicable) is applied across:

 - Bluetooth Host, Classic, Audio, Mesh, ISO
 - OpenThread BLE platform glue
 - Bluetooth samples and the BBC micro:bit pong sample
 - Bluetooth tests (unit + bsim)

These changes are purely refactoring — no behavioral change intended — but they remove a recurring boilerplate footgun and tighten ownership semantics.

### Bug fixes

While auditing call sites, two genuine use-after-unref issues were found and fixed:

 - Bluetooth: Host — `bt_hci_le_enh_conn_complete()` dropped its local reference before dereferencing conn->role in the central-role scanner restart path. The bt_conn_unref() is moved to the end of the function.
 - Bluetooth: AVRCP — `bt_avrcp_cover_art_ct_l2cap_connect()` dropped its ACL reference before using the pointer for bt_conn_index() and bt_bip_l2cap_connect(). The unref is moved past the last use on each return path.

In both cases the object happened to survive in practice thanks to other references, but the code was incorrect per the reference-counting contract.