### PR TITLE
boards: iar: stm32f429ii_aca documentation update

### DIFF
--- a/boards/iar/stm32f429ii_aca/doc/index.rst
+++ b/boards/iar/stm32f429ii_aca/doc/index.rst
@@ -92,9 +92,6 @@ It is connected to the on-chip OTG_HS peripheral.
 Programming and Debugging
 *************************
 
-The ``stm32f429ii_aca`` board supports the runners and associated west
-commands listed below.
-
 .. zephyr:board-supported-runners::
 
 Applications for the ``stm32f429ii_aca`` board configuration can be built
@@ -121,12 +118,13 @@ Here is an example for the :zephyr:code-sample:`blinky` application.
 
 LED1 should then begin to blink continuously with a 1-second delay.
 
-By default, the board uses the jlink runner for flashing operations.
-Alternative runners for openocd or pyocd are also available and they are
-accessible through the ``--runner`` (or ``-r``) option:
+By default, the board uses the iar runner for flashing operations.
+Alternative runners for jlink, openocd or pyocd are also available
+and they are accessible through the ``--runner`` (or ``-r``) option:
 
 .. code-block:: console
 
+   $ west flash --runner jlink
    $ west flash --runner openocd
    $ west flash --runner pyocd
 


### PR DESCRIPTION
The IAR STM32F429II-ACA board support default runner was updated in #106899 for using the IAR I-jet for flashing the target. 

This PR updates the referred documentation to match the current default runner.

CC @RobinKastberg @bjorniuppsala 