### PR TITLE
driver: ethernet: DM9051 process return value of SPI calls

### DIFF
--- a/drivers/ethernet/eth_dm9051.c
+++ b/drivers/ethernet/eth_dm9051.c
@@ -508,6 +508,7 @@ static struct net_pkt *eth_dm9051_recv_pkt(const struct device *dev)
 	ret = eth_dm9051_spi_read_mem(data->dev, DM9051_MRCMD, (void *)&rxhdr,
 				      sizeof(rxhdr));
 	if (ret < 0) {
+		LOG_ERR("%s: Failed to read RX header (err %d)", dev->name, ret);
 		return NULL;
 	}
 
@@ -524,7 +525,10 @@ static struct net_pkt *eth_dm9051_recv_pkt(const struct device *dev)
 				rx_len, NET_ETH_MAX_FRAME_SIZE);
 		}
 
-		(void)eth_dm9051_hw_start(dev, data->iface);
+		ret = eth_dm9051_hw_start(dev, data->iface);
+		if (ret < 0) {
+			LOG_ERR("%s: Failed to restart HW after RX error (err %d)", dev->name, ret);
+		}
 		return NULL;
 	}
 
@@ -533,13 +537,17 @@ static struct net_pkt *eth_dm9051_recv_pkt(const struct device *dev)
 					   K_MSEC(CONFIG_ETH_DM9051_TIMEOUT));
 	if (!pkt) {
 		/* Discard received data */
-		(void)eth_dm9051_spi_read_mem(dev, DM9051_MRCMD, NULL, rx_len);
+		ret = eth_dm9051_spi_read_mem(dev, DM9051_MRCMD, NULL, rx_len);
+		if (ret < 0) {
+			LOG_ERR("%s: Failed to discard RX data (err %d)", dev->name, ret);
+		}
 		return NULL;
 	}
 
 	/* Read RX data from RX SRAM */
 	ret = eth_dm9051_spi_read_mem(dev, DM9051_MRCMD, data->rx_buf, rx_len);
 	if (ret < 0) {
+		LOG_ERR("%s: Failed to read RX data (err %d)", dev->name, ret);
 		goto out_net_pkt_unref;
 	}
 
@@ -569,6 +577,7 @@ static int eth_dm9051_rx(const struct device *dev)
 		/* Read RX flag */
 		ret = eth_dm9051_spi_read_mem(data->dev, DM9051_MRCMDX, (void *)&flag, 2);
 		if (ret < 0) {
+			LOG_ERR("%s: Failed to read RX flag (err %d)", dev->name, ret);
 			goto out_update_errors_rx;
 		}
 
@@ -612,19 +621,22 @@ out_spi_unlock:
 	return ret;
 }
 
-static void eth_dm9051_update_link_status(const struct device *dev)
+static int eth_dm9051_update_link_status(const struct device *dev)
 {
 	struct eth_dm9051_data *data = dev->data;
 	enum phy_link_speed speed;
 	uint8_t nsr;
 	uint8_t ncr;
+	int ret;
 
-	if (eth_dm9051_spi_read_reg(dev, DM9051_NSR, &nsr) < 0) {
-		return;
+	ret = eth_dm9051_spi_read_reg(dev, DM9051_NSR, &nsr);
+	if (ret < 0) {
+		return ret;
 	}
 
-	if (eth_dm9051_spi_read_reg(dev, DM9051_NCR, &ncr) < 0) {
-		return;
+	ret = eth_dm9051_spi_read_reg(dev, DM9051_NCR, &ncr);
+	if (ret < 0) {
+		return ret;
 	}
 
 	if ((nsr & DM9051_NSR_LINKST) > 0) {
@@ -656,6 +668,8 @@ static void eth_dm9051_update_link_status(const struct device *dev)
 			net_eth_carrier_off(data->iface);
 		}
 	}
+
+	return 0;
 }
 
 static void eth_dm9051_rx_thread(void *p1, void *p2, void *p3)
@@ -666,6 +680,7 @@ static void eth_dm9051_rx_thread(void *p1, void *p2, void *p3)
 	struct eth_dm9051_data *data;
 	struct device *dev;
 	uint8_t isr = 0;
+	int ret;
 
 	dev = p1;
 	data = dev->data;
@@ -673,8 +688,19 @@ static void eth_dm9051_rx_thread(void *p1, void *p2, void *p3)
 	while (true) {
 		k_sem_take(&data->int_event, K_FOREVER);
 
-		(void)eth_dm9051_spi_read_reg(dev, DM9051_ISR, &isr);
-		(void)eth_dm9051_spi_write_reg(dev, DM9051_ISR, isr);
+		ret = eth_dm9051_spi_read_reg(dev, DM9051_ISR, &isr);
+		if (ret < 0) {
+			LOG_ERR("%s: Failed to read ISR (err %d)", dev->name, ret);
+			eth_stats_update_errors_rx(data->iface);
+			continue;
+		}
+
+		ret = eth_dm9051_spi_write_reg(dev, DM9051_ISR, isr);
+		if (ret < 0) {
+			LOG_ERR("%s: Failed to write ISR (err %d)", dev->name, ret);
+			eth_stats_update_errors_rx(data->iface);
+			continue;
+		}
 
 		if ((isr & DM9051_ISR_PT) > 0) {
 			k_sem_give(&data->tx_done);
@@ -682,12 +708,19 @@ static void eth_dm9051_rx_thread(void *p1, void *p2, void *p3)
 		}
 
 		if ((isr & DM9051_ISR_PR) > 0) {
-			(void)eth_dm9051_rx(dev);
+			ret = eth_dm9051_rx(dev);
+			if (ret < 0) {
+				LOG_ERR("%s: RX failed (err %d)", dev->name, ret);
+			}
 			LOG_DBG("%s: Packet Received", dev->name);
 		}
 
 		if ((isr & DM9051_ISR_LNKCHG) > 0) {
-			eth_dm9051_update_link_status(dev);
+			ret = eth_dm9051_update_link_status(dev);
+			if (ret < 0) {
+				LOG_ERR("%s: Link status update failed (err %d)", dev->name, ret);
+				eth_stats_update_errors_rx(data->iface);
+			}
 			LOG_DBG("%s: Link changed", dev->name);
 		}
 	}


### PR DESCRIPTION
Previously, not all of the SPI return values are verified.
Here we add checks after calling the SPI functions.
