### PR TITLE
modules: mbedtls: make `MBEDTLS` depend on `PSA_CRYPTO`

### DIFF
--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -29,6 +29,7 @@ rsource "Kconfig.psa.logic"
 
 menuconfig MBEDTLS
 	bool "mbed TLS Support" if !MBEDTLS_PROMPTLESS
+	depends on PSA_CRYPTO
 	help
 	  This option enables the Mbed TLS cryptography library.
 


### PR DESCRIPTION
Even though the repos are split between Mbed TLS and TF-PSA-Crypto, successful compilation of Mbed TLS requires TF-PSA-Crypto to be available.