### PR TITLE
scripts: footprint: fix symbol double-counting in size_report

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -169,6 +169,18 @@ def get_symbols(elf, addr_ranges):
                 if get_symbol_size(sym) == 0:
                     continue
 
+                # Skip symbols not bound to a loadable section (ELF SHN_*
+                # reserved indices, System V ABI ch.4 "Symbol Table"):
+                #   SHN_UNDEF  (0x0000) - external symbol resolved at link time
+                #   SHN_ABS    (0xfff1) - absolute value, no section backing
+                #   SHN_COMMON (0xfff2) - pre-link COMMON block; in the final
+                #                         ELF it is already assigned to .bss
+                # All three report a non-zero st_size but represent no actual
+                # bytes in ROM or RAM, so including them inflates the tree.
+                # Ref: https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.symtab.html
+                if sym['st_shndx'] in ('SHN_ABS', 'SHN_UNDEF', 'SHN_COMMON'):
+                    continue
+
                 # TLS sections (e.g. .tdata/.tbss) use addresses as TLS offsets
                 # and can overlap normal VMA ranges. Don't classify based on
                 # address ranges for TLS.
@@ -494,6 +506,8 @@ def mark_address_aliases(symbol_dict, processed):
 
     mapped_symbols = mapped_symbols.union(already_mapped_syms)
     unmapped_symbols = unmapped_symbols.difference(already_mapped_syms)
+    for ums in already_mapped_syms:
+        del symbol_dict[ums]
 
     processed['mapped_symbols'] = mapped_symbols
     processed['mapped_addr'] = mapped_addresses


### PR DESCRIPTION
Two sources of over-counting caused (hidden) to go negative, breaking the dashboard sunburst chart:

1. Symbols with SHN_ABS/SHN_UNDEF/SHN_COMMON section indices have a non-zero st_size but occupy no actual ROM/RAM bytes. Skip them in get_symbols() before address-range classification.

2. Address aliases were not removed from symbol_dict after mark_address_aliases() identified them, so generate_any_tree() counted their size a second time. Remove them from symbol_dict to match the documented intent of the function.

Fixes #110380