### PR TITLE
MAINTAINERS: add lucien-nxp as collaborator for hal_nxp

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6589,6 +6589,7 @@ West:
     - axelnxp
     - zejiang0jason
     - Holt-Sun
+    - lucien-nxp
   files:
     - modules/hal_nxp/
   labels:


### PR DESCRIPTION
I work as an NPI engineer at NXP, responsible for bringing up new NXP MCU SoCs on Zephyr. This involves frequent updates to the hal_nxp module, including pinctrl data generation, SDK sync, and SoC-specific HAL glue for newly released NXP parts (RT11xx, RT7xx, MCXE families).

Supporting materials:
[Merged PRs in hal_nxp](https://github.com/pulls?q=is%3Apr+author%3Alucien-nxp+archived%3Afalse+repo%3Azephyrproject-rtos%2Fhal_nxp+is%3Amerged)
[Open PRs in hal_nxp](https://github.com/pulls?q=is%3Apr+author%3Alucien-nxp+archived%3Afalse+repo%3Azephyrproject-rtos%2Fhal_nxp+is%3Aopen)