### PR TITLE
drivers: spi: nrfx_spim: chunk transfers exceeding EasyDMA MAXCNT

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -39,6 +39,7 @@ static void transfer_end(const struct device *dev, int ret)
 static void transfer_start(const struct device *dev)
 {
 	struct driver_data *dev_data = dev->data;
+	const struct driver_config *dev_config = dev->config;
 	size_t chunk_len;
 	const uint8_t *tx_buf;
 	size_t tx_buf_len;
@@ -51,6 +52,12 @@ static void transfer_start(const struct device *dev)
 		transfer_end(dev, 0);
 		return;
 	}
+
+	/* A single EasyDMA transfer cannot exceed MAXCNT, so cap the chunk to
+	 * the controller limit. The remainder is picked up by the next call to
+	 * this function from the event handler once the current chunk is done.
+	 */
+	chunk_len = MIN(chunk_len, dev_config->common.max_transfer_len);
 
 	if (spi_context_tx_buf_on(&dev_data->ctx)) {
 		tx_buf = dev_data->ctx.tx_buf;


### PR DESCRIPTION
The reworked SPIM driver passes the whole continuous chunk returned by spi_context_max_continuous_chunk() straight to the common transfer layer, which rejects anything larger than the controller MAXCNT with -EINVAL. On SoCs with a small EasyDMA MAXCNT (e.g. nRF91 SPIM with 13 bits, max 8191 bytes) a transfer of 8192 bytes or more fails outright.

The old monolithic driver used to cap the chunk to the MAXCNT limit and let the event handler walk the rest of the buffer. That behaviour was lost in the rework, so any caller pushing a buffer larger than MAXCNT now breaks. One example is the nRF70 firmware patch download, which copies the patch in 8192 byte chunks and ends up corrupting RPU memory, leading to a boot signature mismatch.

Restore the cap in transfer_start() so an oversized chunk is split across multiple EasyDMA transfers, with the remainder handled by the next call from the event handler once the current chunk completes.


Assisted-by: Cursor:Auto