### PR TITLE
drivers: i2c: stm32: Fix and add PM where applicable

### DIFF
--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -198,7 +198,11 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 	k_sem_take(&data->bus_mutex, K_FOREVER);
 
 	/* Prevent driver from being suspended by PM until I2C transaction is complete */
-	(void)pm_device_runtime_get(dev);
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		LOG_ERR("i2c: PM runtime failure: %d", ret);
+		goto out_sem;
+	}
 
 	/* Prevent the clocks to be stopped during the i2c transaction */
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
@@ -224,6 +228,7 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 
 	(void)pm_device_runtime_put(dev);
 
+out_sem:
 	k_sem_give(&data->bus_mutex);
 
 	return ret;

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -140,9 +140,9 @@ struct i2c_stm32_data {
 };
 
 #ifdef CONFIG_I2C_RTIO
-bool i2c_stm32_start(const struct device *dev);
 int i2c_stm32_msg_start(const struct device *dev, uint8_t flags,
 			uint8_t *buf, size_t buf_len, uint16_t i2c_addr);
+void i2c_stm32_rtio_complete(const struct device *dev, int status);
 #else /* CONFIG_I2C_RTIO */
 int i2c_stm32_transaction(const struct device *dev,
 			  struct i2c_msg msg, uint8_t *next_msg_flags,

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -140,8 +140,8 @@ struct i2c_stm32_data {
 };
 
 #ifdef CONFIG_I2C_RTIO
-int i2c_stm32_msg_start(const struct device *dev, uint8_t flags,
-			uint8_t *buf, size_t buf_len, uint16_t i2c_addr);
+void i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, size_t buf_len,
+			 uint16_t i2c_addr);
 void i2c_stm32_rtio_complete(const struct device *dev, int status);
 #else /* CONFIG_I2C_RTIO */
 int i2c_stm32_transaction(const struct device *dev,

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -16,6 +16,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/policy.h>
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/sys/util.h>
 
@@ -147,6 +148,8 @@ static void i2c_stm32_start_or_complete(const struct device *dev)
 	 */
 	while (!i2c_stm32_start(dev, &status)) {
 		if (!i2c_rtio_complete(data->ctx, status)) {
+			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+			(void)pm_device_runtime_put(dev);
 			return;
 		}
 	}
@@ -158,6 +161,9 @@ void i2c_stm32_rtio_complete(const struct device *dev, int status)
 
 	if (i2c_rtio_complete(data->ctx, status)) {
 		i2c_stm32_start_or_complete(dev);
+	} else {
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+		(void)pm_device_runtime_put(dev);
 	}
 }
 
@@ -231,12 +237,22 @@ int i2c_stm32_get_config(const struct device *dev, uint32_t *config)
 static void i2c_stm32_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
 	struct i2c_stm32_data *data = dev->data;
+	int ret;
 
 	/* Always set I2C_MSG_RESTART flag on first message in order to send start condition */
 	iodev_sqe->sqe.iodev_flags |= RTIO_IODEV_I2C_RESTART;
 
 	if (i2c_rtio_submit(data->ctx, iodev_sqe)) {
-		i2c_stm32_start_or_complete(dev);
+		ret = pm_device_runtime_get(dev);
+		if (ret < 0) {
+			/* Flush pending requests since we failed to get the device */
+			do {
+			} while (i2c_rtio_complete(data->ctx, ret));
+		} else {
+			/* Prevent the clocks to be stopped during the i2c transaction */
+			pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+			i2c_stm32_start_or_complete(dev);
+		}
 	}
 }
 

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -91,14 +91,16 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 	return ret;
 }
 
-static void i2c_stm32_start(const struct device *dev)
+/* Return true when message is started and will complete from an interrupt
+ * handler, otherwise return false and set return status in @param status.
+ */
+static bool i2c_stm32_start(const struct device *dev, int *status)
 {
 	struct i2c_stm32_data *data = dev->data;
 	struct i2c_rtio *ctx = data->ctx;
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
 	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
 	uint8_t flags = sqe->iodev_flags;
-	int res = 0;
 
 #ifdef CONFIG_I2C_STM32_V2
 	struct rtio_iodev_sqe *iodev_sqe_next = rtio_txn_next(ctx->txn_curr);
@@ -124,22 +126,38 @@ static void i2c_stm32_start(const struct device *dev)
 				    dt_spec->addr);
 		break;
 	case RTIO_OP_I2C_CONFIGURE:
-		res = i2c_stm32_runtime_configure(dev, sqe->i2c_config);
-		(void)i2c_rtio_complete(data->ctx, res);
-		break;
+		*status = i2c_stm32_runtime_configure(dev, sqe->i2c_config);
+		return false;
 	default:
 		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);
-		(void)i2c_rtio_complete(data->ctx, -EINVAL);
+		*status = -EINVAL;
+		return false;
+	}
+
+	return true;
+}
+
+static void i2c_stm32_start_or_complete(const struct device *dev)
+{
+	struct i2c_stm32_data *data = dev->data;
+	int status;
+
+	/* Process all synchronous sequences until an async one is started (which will complete
+	 * from an asynchronous handler) or the synchronous sequence is the last queued one.
+	 */
+	while (!i2c_stm32_start(dev, &status)) {
+		if (!i2c_rtio_complete(data->ctx, status)) {
+			return;
+		}
 	}
 }
 
 void i2c_stm32_rtio_complete(const struct device *dev, int status)
 {
 	struct i2c_stm32_data *data = dev->data;
-	struct i2c_rtio *const ctx = data->ctx;
 
-	if (i2c_rtio_complete(ctx, status)) {
-		i2c_stm32_start(dev);
+	if (i2c_rtio_complete(data->ctx, status)) {
+		i2c_stm32_start_or_complete(dev);
 	}
 }
 
@@ -213,13 +231,12 @@ int i2c_stm32_get_config(const struct device *dev, uint32_t *config)
 static void i2c_stm32_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
 	struct i2c_stm32_data *data = dev->data;
-	struct i2c_rtio *const ctx = data->ctx;
 
 	/* Always set I2C_MSG_RESTART flag on first message in order to send start condition */
 	iodev_sqe->sqe.iodev_flags |= RTIO_IODEV_I2C_RESTART;
 
-	if (i2c_rtio_submit(ctx, iodev_sqe)) {
-		i2c_stm32_start(dev);
+	if (i2c_rtio_submit(data->ctx, iodev_sqe)) {
+		i2c_stm32_start_or_complete(dev);
 	}
 }
 

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -91,7 +91,7 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 	return ret;
 }
 
-bool i2c_stm32_start(const struct device *dev)
+static bool i2c_stm32_start(const struct device *dev)
 {
 	struct i2c_stm32_data *data = dev->data;
 	struct i2c_rtio *ctx = data->ctx;
@@ -126,6 +126,16 @@ bool i2c_stm32_start(const struct device *dev)
 	default:
 		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);
 		return i2c_rtio_complete(data->ctx, -EINVAL);
+	}
+}
+
+void i2c_stm32_rtio_complete(const struct device *dev, int status)
+{
+	struct i2c_stm32_data *data = dev->data;
+	struct i2c_rtio *const ctx = data->ctx;
+
+	if (i2c_rtio_complete(ctx, status)) {
+		i2c_stm32_start(dev);
 	}
 }
 

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -91,7 +91,7 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 	return ret;
 }
 
-static bool i2c_stm32_start(const struct device *dev)
+static void i2c_stm32_start(const struct device *dev)
 {
 	struct i2c_stm32_data *data = dev->data;
 	struct i2c_rtio *ctx = data->ctx;
@@ -112,20 +112,24 @@ static bool i2c_stm32_start(const struct device *dev)
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
-		return i2c_stm32_msg_start(dev, I2C_MSG_READ | flags, sqe->rx.buf,
-					   sqe->rx.buf_len, dt_spec->addr);
+		i2c_stm32_msg_start(dev, I2C_MSG_READ | flags, sqe->rx.buf, sqe->rx.buf_len,
+				    dt_spec->addr);
+		break;
 	case RTIO_OP_TINY_TX:
-		return i2c_stm32_msg_start(dev, flags, sqe->tiny_tx.buf,
-					   sqe->tiny_tx.buf_len, dt_spec->addr);
+		i2c_stm32_msg_start(dev, flags, sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
+				    dt_spec->addr);
+		break;
 	case RTIO_OP_TX:
-		return i2c_stm32_msg_start(dev, flags, (uint8_t *)sqe->tx.buf,
-					   sqe->tx.buf_len, dt_spec->addr);
+		i2c_stm32_msg_start(dev, flags, (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
+				    dt_spec->addr);
+		break;
 	case RTIO_OP_I2C_CONFIGURE:
 		res = i2c_stm32_runtime_configure(dev, sqe->i2c_config);
-		return i2c_rtio_complete(data->ctx, res);
+		(void)i2c_rtio_complete(data->ctx, res);
+		break;
 	default:
 		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);
-		return i2c_rtio_complete(data->ctx, -EINVAL);
+		(void)i2c_rtio_complete(data->ctx, -EINVAL);
 	}
 }
 

--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -520,6 +520,12 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 		return ret;
 	}
 
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		LOG_ERR("i2c: PM runtime failure: %d", ret);
+		return ret;
+	}
+
 	data->target_cfg = config;
 
 	LL_I2C_Enable(i2c);
@@ -558,6 +564,8 @@ int i2c_stm32_target_unregister(const struct device *dev, struct i2c_target_conf
 	if (!data->smbalert_active) {
 		LL_I2C_Disable(i2c);
 	}
+
+	(void)pm_device_runtime_put(dev);
 
 	data->target_attached = false;
 

--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -508,6 +508,10 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 		return -EBUSY;
 	}
 
+	if (config->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		return -ENOTSUP;
+	}
+
 	bitrate_cfg = i2c_map_dt_bitrate(cfg->bitrate);
 
 	ret = i2c_stm32_runtime_configure(dev, bitrate_cfg);
@@ -520,9 +524,6 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 
 	LL_I2C_Enable(i2c);
 
-	if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
-		return -ENOTSUP;
-	}
 	LL_I2C_SetOwnAddress1(i2c, config->address << 1U, LL_I2C_OWNADDRESS1_7BIT);
 	data->target_attached = true;
 

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -68,7 +68,6 @@ static void i2c_stm32_controller_mode_end(const struct device *dev, int status)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
-	struct i2c_rtio *ctx = data->ctx;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	i2c_stm32_disable_transfer_interrupts(dev);
@@ -83,8 +82,8 @@ static void i2c_stm32_controller_mode_end(const struct device *dev, int status)
 #endif
 
 	LL_I2C_Disable(i2c);
-	if ((data->xfer_len == 0U) && i2c_rtio_complete(ctx, status)) {
-		i2c_stm32_start(dev);
+	if (data->xfer_len == 0U) {
+		i2c_stm32_rtio_complete(dev, status);
 	}
 }
 

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -375,6 +375,12 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 		return ret;
 	}
 
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		LOG_ERR("i2c: PM runtime failure: %d", ret);
+		return ret;
+	}
+
 	data->target_cfg = config;
 
 	LL_I2C_Enable(i2c);
@@ -410,6 +416,8 @@ int i2c_stm32_target_unregister(const struct device *dev, struct i2c_target_conf
 	LL_I2C_ClearFlag_STOP(i2c);
 	LL_I2C_ClearFlag_ADDR(i2c);
 	LL_I2C_Disable(i2c);
+
+	(void)pm_device_runtime_put(dev);
 
 	data->target_attached = false;
 

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -512,8 +512,8 @@ error:
 
 }
 
-int i2c_stm32_msg_start(const struct device *dev, uint8_t flags,
-			uint8_t *buf, size_t buf_len, uint16_t i2c_addr)
+void i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, size_t buf_len,
+			 uint16_t i2c_addr)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
@@ -543,8 +543,6 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags,
 	} else {
 		LL_I2C_EnableIT_TX(i2c);
 	}
-
-	return 0;
 }
 
 int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -363,6 +363,10 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 		return -EBUSY;
 	}
 
+	if (config->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		return -ENOTSUP;
+	}
+
 	bitrate_cfg = i2c_map_dt_bitrate(cfg->bitrate);
 
 	ret = i2c_stm32_runtime_configure(dev, bitrate_cfg);
@@ -375,9 +379,6 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 
 	LL_I2C_Enable(i2c);
 
-	if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
-		return -ENOTSUP;
-	}
 	LL_I2C_SetOwnAddress1(i2c, config->address << 1U, LL_I2C_OWNADDRESS1_7BIT);
 	data->target_attached = true;
 

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -507,7 +507,11 @@ int i2c_stm32_target_register(const struct device *dev,
 	}
 
 	/* Mark device as active */
-	(void)pm_device_runtime_get(dev);
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		LOG_ERR("i2c: PM runtime failure: %d", ret);
+		return ret;
+	}
 
 #if !defined(CONFIG_SOC_SERIES_STM32F7X)
 	if (pm_device_wakeup_is_capable(dev)) {

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -533,11 +533,12 @@ int i2c_stm32_target_register(const struct device *dev,
 
 		LOG_DBG("i2c: target #1 registered");
 	} else {
-		data->target2_cfg = config;
-
-		if (data->target2_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		if (config->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
 			return -EINVAL;
 		}
+
+		data->target2_cfg = config;
+
 		LL_I2C_SetOwnAddress2(i2c, config->address << 1U,
 				      LL_I2C_OWNADDRESS2_NOMASK);
 		LL_I2C_EnableOwnAddress2(i2c);

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -534,6 +534,7 @@ int i2c_stm32_target_register(const struct device *dev,
 		LOG_DBG("i2c: target #1 registered");
 	} else {
 		if (config->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+			(void)pm_device_runtime_put(dev);
 			return -EINVAL;
 		}
 
@@ -583,6 +584,7 @@ int i2c_stm32_target_unregister(const struct device *dev,
 
 	/* Return if there is a target remaining */
 	if (data->target_cfg || data->target2_cfg) {
+		(void)pm_device_runtime_put(dev);
 		LOG_DBG("i2c: target#%c still registered", data->target_cfg?'1':'2');
 		return 0;
 	}

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -231,7 +231,11 @@ int i2c_stm32_target_register(const struct device *dev,
 	}
 
 	/* Mark device as active */
-	(void)pm_device_runtime_get(dev);
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		LOG_ERR("i2c: PM runtime failure: %d", ret);
+		return ret;
+	}
 
 #if !defined(CONFIG_SOC_SERIES_STM32F7X)
 	if (pm_device_wakeup_is_capable(dev)) {

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -258,6 +258,7 @@ int i2c_stm32_target_register(const struct device *dev,
 		LOG_DBG("i2c: target #1 registered");
 	} else {
 		if (config->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+			(void)pm_device_runtime_put(dev);
 			return -EINVAL;
 		}
 
@@ -307,6 +308,7 @@ int i2c_stm32_target_unregister(const struct device *dev,
 
 	/* Return if there is a target remaining */
 	if (data->target_cfg || data->target2_cfg) {
+		(void)pm_device_runtime_put(dev);
 		LOG_DBG("i2c: target#%c still registered", data->target_cfg ? '1' : '2');
 		return 0;
 	}

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -482,8 +482,8 @@ int i2c_stm32_error(const struct device *dev)
 	return ret;
 }
 
-int i2c_stm32_msg_start(const struct device *dev, uint8_t flags,
-			uint8_t *buf, size_t buf_len, uint16_t i2c_addr)
+void i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, size_t buf_len,
+			 uint16_t i2c_addr)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
@@ -549,8 +549,6 @@ out:
 	} else {
 		LL_I2C_EnableIT_TX(i2c);
 	}
-
-	return 0;
 }
 
 int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -257,11 +257,12 @@ int i2c_stm32_target_register(const struct device *dev,
 
 		LOG_DBG("i2c: target #1 registered");
 	} else {
-		data->target2_cfg = config;
-
-		if (data->target2_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		if (config->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
 			return -EINVAL;
 		}
+
+		data->target2_cfg = config;
+
 		LL_I2C_SetOwnAddress2(i2c, config->address << 1U,
 				      LL_I2C_OWNADDRESS2_NOMASK);
 		LL_I2C_EnableOwnAddress2(i2c);

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -376,7 +376,6 @@ void i2c_stm32_event(const struct device *dev)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
-	struct i2c_rtio *ctx = data->ctx;
 	I2C_TypeDef *i2c = cfg->i2c;
 	int ret = 0;
 
@@ -420,10 +419,8 @@ void i2c_stm32_event(const struct device *dev)
 		LL_I2C_DisableReloadMode(i2c);
 		i2c_stm32_controller_mode_end(dev);
 
-		if (i2c_rtio_complete(ctx, ret)) {
-			i2c_stm32_start(dev);
-			return;
-		}
+		i2c_stm32_rtio_complete(dev, ret);
+		return;
 	}
 
 	if (LL_I2C_IsActiveFlag_TC(i2c) ||
@@ -440,9 +437,7 @@ void i2c_stm32_event(const struct device *dev)
 			LL_I2C_GenerateStopCondition(i2c);
 		} else {
 			i2c_stm32_disable_transfer_interrupts(dev);
-			if (i2c_rtio_complete(ctx, ret)) {
-				i2c_stm32_start(dev);
-			}
+			i2c_stm32_rtio_complete(dev, ret);
 		}
 	}
 }
@@ -450,12 +445,11 @@ void i2c_stm32_event(const struct device *dev)
 int i2c_stm32_error(const struct device *dev)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
-	struct i2c_stm32_data *data = dev->data;
-	struct i2c_rtio *ctx = data->ctx;
 	I2C_TypeDef *i2c = cfg->i2c;
 	int ret = 0;
 
 #if defined(CONFIG_I2C_TARGET)
+	struct i2c_stm32_data *data = dev->data;
 	i2c_target_error_cb_t error_cb = NULL;
 
 	if (data->target_attached && !data->controller_active &&
@@ -482,9 +476,7 @@ int i2c_stm32_error(const struct device *dev)
 
 	if (ret) {
 		i2c_stm32_controller_mode_end(dev);
-		if (i2c_rtio_complete(ctx, ret)) {
-			i2c_stm32_start(dev);
-		}
+		i2c_stm32_rtio_complete(dev, ret);
 	}
 
 	return ret;


### PR DESCRIPTION
Fix an issue that could leave an I2C bus enabled in target mode while the target registration handler reports a failure.
Fix an unbalanced issue in `pm_runtime_get/put()` calls upon target registration handler failure.
Check `pm_runtime_get()` return code in existing implementation.
Add PM runtime support to stm32v1 in target tmode.
Add PM runtime support to RTIO drivers.
