### PR TITLE
drivers: i2c: stm32: fix minor coding style issues

### DIFF
--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -434,7 +434,7 @@ void i2c_stm32_set_smbus_mode(const struct device *dev, enum i2c_stm32_mode mode
 		return;
 	}
 }
-#endif
+#endif /* I2C_CR1_SMBUS || I2C_CR1_SMBDEN || I2C_CR1_SMBHEN */
 
 #ifdef CONFIG_SMBUS_STM32
 void i2c_stm32_smbalert_enable(const struct device *dev)

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -25,7 +25,7 @@
 typedef void (*irq_config_func_t)(const struct device *port);
 
 #ifdef CONFIG_I2C_STM32_V2
-/*  Private I2C_MSG_* flags for STM32 I2C */
+/* Private I2C_MSG_* flags for STM32 I2C */
 #define I2C_MSG_STM32_USE_RELOAD_MODE	BIT(7)
 #endif
 

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -141,7 +141,7 @@ static int i2c_stm32_configure(const struct device *dev,
 #define OPERATION(msg)	((msg)->flags & I2C_MSG_RW_MASK)
 
 static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msgs,
-				   uint8_t num_msgs, uint16_t addr)
+			      uint8_t num_msgs, uint16_t addr)
 {
 	struct i2c_stm32_data *data = dev->data;
 	struct i2c_rtio *const ctx = data->ctx;

--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -117,7 +117,6 @@ static void i2c_stm32_reset(const struct device *dev)
 #endif
 }
 
-
 static void i2c_stm32_controller_finish(const struct device *dev)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
@@ -436,7 +435,6 @@ static inline void handle_btf(const struct device *dev)
 		}
 	}
 }
-
 
 #if defined(CONFIG_I2C_TARGET)
 static void i2c_stm32_target_event(const struct device *dev)

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -475,6 +475,7 @@ static bool i2c_stm32_target_preempt_controller_event(const struct device *dev, 
 
 	return false;
 }
+
 /* Attach and start I2C as target */
 int i2c_stm32_target_register(const struct device *dev,
 			      struct i2c_target_config *config)
@@ -514,7 +515,7 @@ int i2c_stm32_target_register(const struct device *dev,
 		LOG_DBG("i2c: enabling wakeup from stop");
 		LL_I2C_EnableWakeUpFromStop(cfg->i2c);
 	}
-#endif /* CONFIG_SOC_SERIES_STM32F7X */
+#endif /* !CONFIG_SOC_SERIES_STM32F7X */
 
 	LL_I2C_Enable(i2c);
 
@@ -603,7 +604,7 @@ int i2c_stm32_target_unregister(const struct device *dev,
 		LOG_DBG("i2c: disabling wakeup from stop");
 		LL_I2C_DisableWakeUpFromStop(i2c);
 	}
-#endif /* CONFIG_SOC_SERIES_STM32F7X */
+#endif /* !CONFIG_SOC_SERIES_STM32F7X */
 
 	/* Release the device */
 	(void)pm_device_runtime_put(dev);
@@ -1045,7 +1046,7 @@ static int stm32_i2c_irq_xfer(const struct device *dev, struct i2c_msg *msg,
 	return stm32_i2c_irq_msg_finish(dev, msg);
 }
 
-#else /* !CONFIG_I2C_STM32_INTERRUPT */
+#else /* CONFIG_I2C_STM32_INTERRUPT */
 static inline int check_errors(const struct device *dev, const char *funcname)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
@@ -1220,7 +1221,7 @@ static int i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 
 	return msg_done(dev, msg->flags);
 }
-#endif
+#endif /* CONFIG_I2C_STM32_INTERRUPT */
 
 #ifdef CONFIG_I2C_STM32_V2_TIMING
 /*
@@ -1228,7 +1229,7 @@ static int i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
  * "DEEP_INDENTATION: Too many leading tabs - consider code refactoring
  * in the i2c_compute_scll_sclh() function below
  */
-#define I2C_LOOP_SCLH();						\
+#define I2C_LOOP_SCLH()							\
 	if ((tscl >= clk_min) &&					\
 	    (tscl <= clk_max) &&					\
 	    (tscl_h >= i2c_stm32_charac[i2c_speed].hscl_min) &&		\
@@ -1307,7 +1308,7 @@ uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t i2c_speed)
 					/* tSCL = tf + tLOW + tr + tHIGH */
 					uint32_t tscl = tscl_l +
 						tscl_h + i2c_stm32_charac[i2c_speed].trise +
-					i2c_stm32_charac[i2c_speed].tfall;
+						i2c_stm32_charac[i2c_speed].tfall;
 
 					/* get timings with the lowest clock error */
 					I2C_LOOP_SCLH();
@@ -1324,8 +1325,7 @@ uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t i2c_speed)
  * "DEEP_INDENTATION: Too many leading tabs - consider code refactoring
  * in the i2c_compute_presc_scldel_sdadel() function below
  */
-#define I2C_LOOP_SDADEL();								\
-											\
+#define I2C_LOOP_SDADEL()								\
 	if ((tsdadel >= (uint32_t)tsdadel_min) &&					\
 	    (tsdadel <= (uint32_t)tsdadel_max)) {					\
 		if (presc != prev_presc) {						\
@@ -1351,12 +1351,12 @@ void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t i2c_speed
 {
 	uint32_t prev_presc = I2C_STM32_PRESC_MAX;
 	uint32_t ti2cclk;
-	int32_t  tsdadel_min, tsdadel_max;
-	int32_t  tscldel_min;
+	int32_t tsdadel_min, tsdadel_max;
+	int32_t tscldel_min;
 	uint32_t presc, scldel, sdadel;
 	uint32_t tafdel_min, tafdel_max;
 
-	ti2cclk   = (NSEC_PER_SEC + (clock_src_freq / 2U)) / clock_src_freq;
+	ti2cclk = (NSEC_PER_SEC + (clock_src_freq / 2U)) / clock_src_freq;
 
 	tafdel_min = (I2C_STM32_USE_ANALOG_FILTER == 1U) ?
 		I2C_STM32_ANALOG_FILTER_DELAY_MIN : 0U;
@@ -1446,18 +1446,18 @@ int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)
 	i2c_valid_timing_nbr = 0;
 
 	if ((clock != 0U) && (i2c_freq != 0U)) {
-		for (speed = 0 ; speed <= (uint32_t)I2C_STM32_SPEED_FREQ_FAST_PLUS ; speed++) {
+		for (speed = 0; speed <= (uint32_t)I2C_STM32_SPEED_FREQ_FAST_PLUS; speed++) {
 			if ((i2c_freq >= i2c_stm32_charac[speed].freq_min) &&
 			    (i2c_freq <= i2c_stm32_charac[speed].freq_max)) {
 				i2c_compute_presc_scldel_sdadel(clock, speed);
 				idx = i2c_compute_scll_sclh(clock, speed);
 				if (idx < I2C_STM32_VALID_TIMING_NBR) {
-					timing = ((i2c_valid_timing[idx].presc  &
-						0x0FU) << 28) |
-					((i2c_valid_timing[idx].tscldel & 0x0FU) << 20) |
-					((i2c_valid_timing[idx].tsdadel & 0x0FU) << 16) |
-					((i2c_valid_timing[idx].sclh & 0xFFU) << 8) |
-					((i2c_valid_timing[idx].scll & 0xFFU) << 0);
+					timing = ((i2c_valid_timing[idx].presc &
+						  0x0FU) << 28) |
+						 ((i2c_valid_timing[idx].tscldel & 0x0FU) << 20) |
+						 ((i2c_valid_timing[idx].tsdadel & 0x0FU) << 16) |
+						 ((i2c_valid_timing[idx].sclh & 0xFFU) << 8) |
+						 ((i2c_valid_timing[idx].scll & 0xFFU) << 0);
 				}
 				break;
 			}
@@ -1473,7 +1473,7 @@ int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)
 
 	return 0;
 }
-#else/* CONFIG_I2C_STM32_V2_TIMING */
+#else /* CONFIG_I2C_STM32_V2_TIMING */
 
 int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)
 {
@@ -1485,14 +1485,14 @@ int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)
 	uint32_t presc = 1U;
 	uint32_t timing = 0U;
 
-	/*  Look for an adequate preset timing value */
+	/* Look for an adequate preset timing value */
 	for (uint32_t i = 0; i < cfg->n_timings; i++) {
 		const struct i2c_config_timing *preset = &cfg->timings[i];
 		uint32_t speed = i2c_map_dt_bitrate(preset->i2c_speed);
 
 		if ((I2C_SPEED_GET(speed) == I2C_SPEED_GET(data->dev_config)) &&
 		    (preset->periph_clock == clock)) {
-			/*  Found a matching periph clock and i2c speed */
+			/* Found a matching periph clock and i2c speed */
 			LL_I2C_SetTiming(i2c, preset->timing_setting);
 			return 0;
 		}
@@ -1527,7 +1527,7 @@ int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)
 		uint32_t sdadel = i2c_hold_time_min / ns_presc;
 		uint32_t scldel = i2c_setup_time_min / ns_presc;
 
-		if ((sclh - 1) > 255 ||  (scll - 1) > 255) {
+		if ((sclh - 1) > 255 || (scll - 1) > 255) {
 			++presc;
 			continue;
 		}

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -245,7 +245,7 @@ int i2c_stm32_target_register(const struct device *dev,
 
 	if (!data->target_cfg) {
 		data->target_cfg = config;
-		if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+		if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
 			LL_I2C_SetOwnAddress1(i2c, config->address, LL_I2C_OWNADDRESS1_10BIT);
 			LOG_DBG("i2c: target #1 registered with 10-bit address");
 		} else {
@@ -259,7 +259,7 @@ int i2c_stm32_target_register(const struct device *dev,
 	} else {
 		data->target2_cfg = config;
 
-		if (data->target2_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+		if (data->target2_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
 			return -EINVAL;
 		}
 		LL_I2C_SetOwnAddress2(i2c, config->address << 1U,
@@ -306,7 +306,7 @@ int i2c_stm32_target_unregister(const struct device *dev,
 
 	/* Return if there is a target remaining */
 	if (data->target_cfg || data->target2_cfg) {
-		LOG_DBG("i2c: target#%c still registered", data->target_cfg?'1':'2');
+		LOG_DBG("i2c: target#%c still registered", data->target_cfg ? '1' : '2');
 		return 0;
 	}
 
@@ -484,7 +484,7 @@ int i2c_stm32_error(const struct device *dev)
 }
 
 int i2c_stm32_msg_start(const struct device *dev, uint8_t flags,
-	uint8_t *buf, size_t buf_len, uint16_t i2c_addr)
+			uint8_t *buf, size_t buf_len, uint16_t i2c_addr)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
@@ -564,13 +564,13 @@ int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)
 	uint32_t presc = 1U;
 	uint32_t timing = 0U;
 
-	/*  Look for an adequate preset timing value */
+	/* Look for an adequate preset timing value */
 	for (uint32_t i = 0; i < cfg->n_timings; i++) {
 		const struct i2c_config_timing *preset = &cfg->timings[i];
 		uint32_t speed = i2c_map_dt_bitrate(preset->i2c_speed);
 
-		if ((I2C_SPEED_GET(speed) == I2C_SPEED_GET(data->dev_config))
-		   && (preset->periph_clock == clock)) {
+		if ((I2C_SPEED_GET(speed) == I2C_SPEED_GET(data->dev_config)) &&
+		    (preset->periph_clock == clock)) {
 			/*  Found a matching periph clock and i2c speed */
 			LL_I2C_SetTiming(i2c, preset->timing_setting);
 			return 0;
@@ -593,7 +593,7 @@ int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)
 		break;
 	default:
 		LOG_ERR("i2c: speed above \"fast\" requires manual timing configuration, "
-				"see \"timings\" property of st,stm32-i2c-v2 devicetree binding");
+			"see \"timings\" property of st,stm32-i2c-v2 devicetree binding");
 		return -EINVAL;
 	}
 
@@ -606,7 +606,7 @@ int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)
 		uint32_t sdadel = i2c_hold_time_min / ns_presc;
 		uint32_t scldel = i2c_setup_time_min / ns_presc;
 
-		if ((sclh - 1) > 255 ||  (scll - 1) > 255) {
+		if ((sclh - 1) > 255 || (scll - 1) > 255) {
 			++presc;
 			continue;
 		}
@@ -617,7 +617,7 @@ int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)
 		}
 
 		timing = STM32_I2C_CONVERT_TIMINGS(presc - 1,
-					scldel - 1, sdadel, sclh - 1, scll - 1);
+						   scldel - 1, sdadel, sclh - 1, scll - 1);
 		break;
 	} while (presc < 16);
 


### PR DESCRIPTION
Fix and add inline comment related to #ifdef/#else/#endif directives. Add and remove some empty lines or space chars where applicable. Fix some indentation issues.
Remove spurious, yet harmless, heading semi-column in I2C_LOOP_SCLH() and I2C_LOOP_SDADEL() macros definition.