### PR TITLE
drivers: bluetooth: stm32wb0: Fix mistakenly re-introduced code

### DIFF
--- a/drivers/bluetooth/hci/hci_stm32wb0.c
+++ b/drivers/bluetooth/hci/hci_stm32wb0.c
@@ -497,9 +497,6 @@ static int bt_hci_stm32wb0_open(const struct device *dev)
 #endif /* CONFIG_BT_EXT_ADV */
 
 	aci_adv_nwk_init();
-#if defined(CONFIG_PM_DEVICE)
-	aci_hal_set_radio_activity_mask(STM32_STATE_ALL_BITMASK);
-#endif /* CONFIG_PM_DEVICE */
 	k_work_init_delayable(&ble_stack_work, blestack_process);
 	k_work_schedule(&ble_stack_work, K_NO_WAIT);
 


### PR DESCRIPTION
This code snippet was originally removed by #109163 but then incorrectly re-introduced by #107850 (most likely due to a rebasing error).