### PR TITLE
drivers: dma: stm32: v1: interpret burst size parameter correctly

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -467,6 +467,18 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	stream->source_periph = (stream->direction == PERIPHERAL_TO_MEMORY);
 
 #if defined(CONFIG_DMA_STM32_V1)
+	if ((config->source_burst_length % config->source_data_size) != 0) {
+		LOG_ERR("Source burst length %d is not aligned to source data size %d",
+			config->source_burst_length, config->source_data_size);
+		return -EINVAL;
+	}
+
+	if ((config->dest_burst_length % config->dest_data_size) != 0) {
+		LOG_ERR("Destination burst length %d is not aligned to destination data size %d",
+			config->dest_burst_length, config->dest_data_size);
+		return -EINVAL;
+	}
+
 	DMA_InitStruct.MemBurst = stm32_dma_get_mburst(config,
 						       stream->source_periph);
 	DMA_InitStruct.PeriphBurst = stm32_dma_get_pburst(config,

--- a/drivers/dma/dma_stm32_v1.c
+++ b/drivers/dma/dma_stm32_v1.c
@@ -344,15 +344,24 @@ void stm32_dma_disable_fifo_irq(DMA_TypeDef *dma, uint32_t id)
 
 uint32_t stm32_dma_get_mburst(struct dma_config *config, bool source_periph)
 {
-	uint32_t memory_burst;
+	uint32_t mem_data_size, mem_burst_size;
 
 	if (source_periph) {
-		memory_burst = config->dest_burst_length;
+		mem_data_size = config->dest_data_size;
+		mem_burst_size = config->dest_burst_length;
 	} else {
-		memory_burst = config->source_burst_length;
+		mem_data_size = config->source_data_size;
+		mem_burst_size = config->source_burst_length;
 	}
 
-	switch (memory_burst) {
+	/* Should be checked beforehand by caller; assert to be sure */
+	__ASSERT((mem_burst_size % mem_data_size) == 0,
+		"Burst length %u should be multiple of data size %u",
+		mem_burst_size, mem_data_size);
+
+	const uint32_t beats_in_burst = mem_burst_size / mem_data_size;
+
+	switch (beats_in_burst) {
 	case 1:
 		return LL_DMA_MBURST_SINGLE;
 	case 4:
@@ -362,23 +371,32 @@ uint32_t stm32_dma_get_mburst(struct dma_config *config, bool source_periph)
 	case 16:
 		return LL_DMA_MBURST_INC16;
 	default:
-		LOG_ERR("Memory burst size error,"
-			"using single burst as default");
+		LOG_ERR("%u bursts per beat is unsupported; falling back to single-beat burst",
+			beats_in_burst);
 		return LL_DMA_MBURST_SINGLE;
 	}
 }
 
 uint32_t stm32_dma_get_pburst(struct dma_config *config, bool source_periph)
 {
-	uint32_t periph_burst;
+	uint32_t per_data_size, per_burst_size;
 
 	if (source_periph) {
-		periph_burst = config->source_burst_length;
+		per_data_size = config->source_data_size;
+		per_burst_size = config->source_burst_length;
 	} else {
-		periph_burst = config->dest_burst_length;
+		per_data_size = config->dest_data_size;
+		per_burst_size = config->dest_burst_length;
 	}
 
-	switch (periph_burst) {
+	/* Should be checked beforehand by caller; assert to be sure */
+	__ASSERT((per_burst_size % per_data_size) == 0,
+		"Burst length %u should be multiple of data size %u",
+		per_burst_size, per_data_size);
+
+	const uint32_t beats_in_burst = per_burst_size / per_data_size;
+
+	switch (beats_in_burst) {
 	case 1:
 		return LL_DMA_PBURST_SINGLE;
 	case 4:
@@ -388,8 +406,8 @@ uint32_t stm32_dma_get_pburst(struct dma_config *config, bool source_periph)
 	case 16:
 		return LL_DMA_PBURST_INC16;
 	default:
-		LOG_ERR("Peripheral burst size error,"
-			"using single burst as default");
+		LOG_ERR("%u bursts per beat is unsupported; falling back to single-beat burst",
+			beats_in_burst);
 		return LL_DMA_PBURST_SINGLE;
 	}
 }


### PR DESCRIPTION
Per DMA API, the `<dir>_burst_length` parameters are number of bytes; however, the burst size for STM32 DMAv1 is in number of beats per burst, not in number of bytes (where each "beat" = `<dir>_data_size` bytes).

Update driver to compute burst sizes properly instead of using the raw `<dir>_burst_length` value as number of beats.