### PR TITLE
drivers: audio: codec: make audio codec a proper driver class

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -113,6 +113,17 @@ ADC
   replaced by encoded ``girqs`` (using ``MCHP_XEC_ECIA_GIRQ_ENC`` macros) and ``pcr-scr`` (int type)
   for encoded PCR register index and bit position (:github:`105658`).
 
+Audio Codec
+===========
+
+* The audio codec driver backend API now uses :c:struct:`audio_codec_driver_api` instead of
+  ``struct audio_codec_api``.
+
+  Out-of-tree audio codec drivers must rename their backend API struct definitions and switch
+  their API instances to ``DEVICE_API(audio_codec, ...)``. See :github:`110631` for examples of how
+  in-tree drivers have been updated. Application code using the ``audio_codec_...`` APIs is not
+  impacted.
+
 Clock Control
 =============
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -83,6 +83,11 @@ Removed APIs and options
 Deprecated APIs and options
 ===========================
 
+* Audio Codec
+
+  * The :c:struct:`audio_codec_api` struct has been deprecated. Audio codec drivers are now
+    expected to use the :c:macro:`DEVICE_API` macro to declare their driver API.
+
 * :abbr:`DMIC (Digital Microphone Interface)`
 
   * The :c:struct:`_dmic_ops` struct has been deprecated. DMIC drivers are now expected to use the

--- a/drivers/audio/aw88298.c
+++ b/drivers/audio/aw88298.c
@@ -426,7 +426,7 @@ static int aw88298_apply_properties(const struct device *dev)
 	return 0;
 }
 
-static const struct audio_codec_api aw88298_api = {
+static DEVICE_API(audio_codec, aw88298_api) = {
 	.configure = aw88298_configure,
 	.start_output = aw88298_start_output,
 	.stop_output = aw88298_stop_output,

--- a/drivers/audio/codec_dummy.c
+++ b/drivers/audio/codec_dummy.c
@@ -140,7 +140,7 @@ static int dummy_codec_init(const struct device *dev)
 	return 0;
 }
 
-static const struct audio_codec_api dummy_codec_api = {
+static DEVICE_API(audio_codec, dummy_codec_api) = {
 	.configure = dummy_codec_configure,
 	.set_property = dummy_codec_set_property,
 	.start = dummy_codec_start,

--- a/drivers/audio/codec_shell.c
+++ b/drivers/audio/codec_shell.c
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdlib.h>
-#include <zephyr/shell/shell.h>
 #include <zephyr/audio/codec.h>
+#include <zephyr/device.h>
+#include <zephyr/shell/shell.h>
+#include <stdlib.h>
 
 #define CODEC_START_HELP                                                                           \
 	SHELL_HELP("Start output audio playback",                                                  \
@@ -58,6 +59,28 @@ static const struct args_index args_indx = {
 	.value = 4,
 };
 
+static bool device_is_audio_codec(const struct device *dev)
+{
+	return DEVICE_API_IS(audio_codec, dev);
+}
+
+static int codec_shell_get_device(const struct shell *sh, const char *name,
+				  const struct device **dev)
+{
+	*dev = shell_device_get_binding(name);
+	if (*dev == NULL) {
+		shell_error(sh, "Audio Codec device not found");
+		return -ENODEV;
+	}
+
+	if (!device_is_audio_codec(*dev)) {
+		shell_error(sh, "%s is not an audio codec device", (*dev)->name);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static int parse_named_int(const char *name, const char *const keystack[], size_t count)
 {
 	char *endptr;
@@ -82,12 +105,13 @@ static int parse_named_int(const char *name, const char *const keystack[], size_
 static int cmd_start(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
+	int err;
 
-	dev = shell_device_get_binding(argv[args_indx.device]);
-	if (!dev) {
-		shell_error(sh, "Audio Codec device not found");
-		return -ENODEV;
+	err = codec_shell_get_device(sh, argv[args_indx.device], &dev);
+	if (err != 0) {
+		return err;
 	}
+
 	audio_codec_start_output(dev);
 
 	return 0;
@@ -96,12 +120,13 @@ static int cmd_start(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_stop(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
+	int err;
 
-	dev = shell_device_get_binding(argv[args_indx.device]);
-	if (!dev) {
-		shell_error(sh, "Audio Codec device not found");
-		return -ENODEV;
+	err = codec_shell_get_device(sh, argv[args_indx.device], &dev);
+	if (err != 0) {
+		return err;
 	}
+
 	audio_codec_stop_output(dev);
 
 	return 0;
@@ -112,14 +137,14 @@ static int cmd_set_prop(const struct shell *sh, size_t argc, char *argv[])
 	const struct device *dev;
 	int property;
 	int channel;
+	int err;
 	long value;
 	char *endptr;
 	audio_property_value_t property_value;
 
-	dev = shell_device_get_binding(argv[args_indx.device]);
-	if (!dev) {
-		shell_error(sh, "Audio Codec device not found");
-		return -ENODEV;
+	err = codec_shell_get_device(sh, argv[args_indx.device], &dev);
+	if (err != 0) {
+		return err;
 	}
 
 	property = parse_named_int(argv[args_indx.property], codec_property_name,
@@ -160,11 +185,11 @@ static int cmd_set_prop(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_apply_prop(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
+	int err;
 
-	dev = shell_device_get_binding(argv[args_indx.device]);
-	if (!dev) {
-		shell_error(sh, "Audio Codec device not found");
-		return -ENODEV;
+	err = codec_shell_get_device(sh, argv[args_indx.device], &dev);
+	if (err != 0) {
+		return err;
 	}
 
 	return audio_codec_apply_properties(dev);
@@ -173,7 +198,7 @@ static int cmd_apply_prop(const struct shell *sh, size_t argc, char *argv[])
 /* Device name autocompletion support */
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_filter(idx, device_is_audio_codec);
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;

--- a/drivers/audio/cs43l22.c
+++ b/drivers/audio/cs43l22.c
@@ -250,7 +250,7 @@ static int cs43l22_set_property(const struct device *dev, audio_property_t prope
 
 }
 
-static const struct audio_codec_api cs43l22_api = {
+static DEVICE_API(audio_codec, cs43l22_api) = {
 	.configure = cs43l22_configure,
 	.start_output = cs43l22_start_output,
 	.stop_output = cs43l22_stop_output,

--- a/drivers/audio/da7212.c
+++ b/drivers/audio/da7212.c
@@ -642,7 +642,7 @@ static int da7212_apply_properties(const struct device *dev)
 	return 0;
 }
 
-static const struct audio_codec_api da7212_driver_api = {
+static DEVICE_API(audio_codec, da7212_driver_api) = {
 	.configure = da7212_configure,
 	.start_output = da7212_start_output,
 	.stop_output = da7212_stop_output,

--- a/drivers/audio/max98091.c
+++ b/drivers/audio/max98091.c
@@ -301,7 +301,7 @@ static int max98091_configure(const struct device *dev, struct audio_codec_cfg *
 	return 0;
 }
 
-static const struct audio_codec_api max98091_api = {
+static DEVICE_API(audio_codec, max98091_api) = {
 	.configure = max98091_configure,
 	.start_output = max98091_start_output,
 	.stop_output = max98091_stop_output,

--- a/drivers/audio/pcm1681.c
+++ b/drivers/audio/pcm1681.c
@@ -338,7 +338,7 @@ static int pcm1681_apply_properties(const struct device *dev)
 	return 0;
 }
 
-static const struct audio_codec_api pcm1681_api = {
+static DEVICE_API(audio_codec, pcm1681_api) = {
 	.configure = pcm1681_configure,
 	.start_output = pcm1681_start_output,
 	.stop_output = pcm1681_stop_output,

--- a/drivers/audio/sf32lb_codec.c
+++ b/drivers/audio/sf32lb_codec.c
@@ -1445,7 +1445,7 @@ end:
 	return r;
 }
 
-static const struct audio_codec_api codec_driver_api = {
+static DEVICE_API(audio_codec, codec_driver_api) = {
 	.configure = codec_configure,
 	.start_output = codec_start_output,
 	.stop_output = codec_stop_output,

--- a/drivers/audio/tas2563.c
+++ b/drivers/audio/tas2563.c
@@ -292,7 +292,7 @@ unlock:
 	return ret;
 }
 
-static const struct audio_codec_api tas2563_driver_api = {
+static DEVICE_API(audio_codec, tas2563_driver_api) = {
 	.configure = tas2563_configure,
 	.start_output = tas2563_start_output,
 	.stop_output = tas2563_stop_output,

--- a/drivers/audio/tas6422dac.c
+++ b/drivers/audio/tas6422dac.c
@@ -354,7 +354,7 @@ static void codec_read_all_regs(const struct device *dev)
 }
 #endif
 
-static const struct audio_codec_api codec_driver_api = {
+static DEVICE_API(audio_codec, codec_driver_api) = {
 	.configure = codec_configure,
 	.start_output = codec_start_output,
 	.stop_output = codec_stop_output,

--- a/drivers/audio/tlv320aic26.c
+++ b/drivers/audio/tlv320aic26.c
@@ -656,7 +656,7 @@ static int aic26_init(const struct device *dev)
 	return 0;
 }
 
-static const struct audio_codec_api aic26_api = {
+DEVICE_API(audio_codec, aic26_api) = {
 	.configure        = aic26_configure,
 	.start_output     = aic26_start_output,
 	.stop_output      = aic26_stop_output,

--- a/drivers/audio/tlv320aic3110.c
+++ b/drivers/audio/tlv320aic3110.c
@@ -555,7 +555,7 @@ static void codec_read_all_regs(const struct device *dev)
 }
 #endif
 
-static const struct audio_codec_api codec_driver_api = {
+static DEVICE_API(audio_codec, codec_driver_api) = {
 	.configure = codec_configure,
 	.start_output = codec_start_output,
 	.stop_output = codec_stop_output,

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -520,7 +520,7 @@ static void codec_read_all_regs(const struct device *dev)
 }
 #endif
 
-static const struct audio_codec_api codec_driver_api = {
+static DEVICE_API(audio_codec, codec_driver_api) = {
 	.configure		= codec_configure,
 	.start_output		= codec_start_output,
 	.stop_output		= codec_stop_output,

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -672,7 +672,7 @@ static void wm8904_configure_input(const struct device *dev)
 	wm8904_in_mute_config(dev, AUDIO_CHANNEL_ALL, false);
 }
 
-static const struct audio_codec_api wm8904_driver_api = {
+static DEVICE_API(audio_codec, wm8904_driver_api) = {
 	.configure = wm8904_configure,
 	.start_output = wm8904_start_output,
 	.stop_output = wm8904_stop_output,

--- a/drivers/audio/wm8962.c
+++ b/drivers/audio/wm8962.c
@@ -706,7 +706,7 @@ static void WM8962_read_all_reg(const struct device *dev, uint16_t endAddress)
 }
 #endif
 
-static const struct audio_codec_api wm8962_driver_api = {.configure = wm8962_configure,
+static DEVICE_API(audio_codec, wm8962_driver_api) = {.configure = wm8962_configure,
 							 .start_output = wm8962_start_output,
 							 .stop_output = wm8962_stop_output,
 							 .set_property = wm8962_set_property,

--- a/include/zephyr/audio/codec.h
+++ b/include/zephyr/audio/codec.h
@@ -19,7 +19,7 @@
  *
  * @defgroup audio_codec_interface Audio Codec Interface
  * @since 1.13
- * @version 0.2.0
+ * @version 0.3.0
  * @ingroup audio_interface
  * @{
  */
@@ -233,30 +233,162 @@ typedef void (*audio_codec_rx_done_callback_t)(const struct device *dev, uint8_t
 					       void *user_data);
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * For internal use only, skip these in public documentation.
+ * @def_driverbackendgroup{Audio Codec,audio_codec_interface}
+ * @{
  */
-struct audio_codec_api {
-	int (*configure)(const struct device *dev, struct audio_codec_cfg *cfg);
-	void (*start_output)(const struct device *dev);
-	void (*stop_output)(const struct device *dev);
-	int (*set_property)(const struct device *dev, audio_property_t property,
-			    audio_channel_t channel, audio_property_value_t val);
-	int (*apply_properties)(const struct device *dev);
-	int (*clear_errors)(const struct device *dev);
-	int (*register_error_callback)(const struct device *dev, audio_codec_error_callback_t cb);
-	int (*route_input)(const struct device *dev, audio_channel_t channel, uint32_t input);
-	int (*route_output)(const struct device *dev, audio_channel_t channel, uint32_t output);
-	int (*start)(const struct device *dev, audio_dai_dir_t dir);
-	int (*stop)(const struct device *dev, audio_dai_dir_t dir);
-	int (*write)(const struct device *dev, uint8_t *data, size_t data_size);
-	int (*register_done_callback)(const struct device *dev,
-				      audio_codec_tx_done_callback_t tx_cb, void *tx_cb_user_data,
-				      audio_codec_rx_done_callback_t rx_cb, void *rx_cb_user_data);
-};
+
 /**
- * @endcond
+ * @brief Callback API to configure an audio codec device.
+ * See audio_codec_configure() for argument descriptions.
+ */
+typedef int (*audio_codec_configure_t)(const struct device *dev, struct audio_codec_cfg *cfg);
+
+/**
+ * @brief Callback API to start output audio playback.
+ * See audio_codec_start_output() for argument descriptions.
+ */
+typedef void (*audio_codec_start_output_t)(const struct device *dev);
+
+/**
+ * @brief Callback API to stop output audio playback.
+ * See audio_codec_stop_output() for argument descriptions.
+ */
+typedef void (*audio_codec_stop_output_t)(const struct device *dev);
+
+/**
+ * @brief Callback API to set an audio codec property.
+ * See audio_codec_set_property() for argument descriptions.
+ */
+typedef int (*audio_codec_set_property_t)(const struct device *dev, audio_property_t property,
+					  audio_channel_t channel, audio_property_value_t val);
+
+/**
+ * @brief Callback API to apply cached audio codec properties.
+ * See audio_codec_apply_properties() for argument descriptions.
+ */
+typedef int (*audio_codec_apply_properties_t)(const struct device *dev);
+
+/**
+ * @brief Callback API to clear audio codec errors.
+ * See audio_codec_clear_errors() for argument descriptions.
+ */
+typedef int (*audio_codec_clear_errors_t)(const struct device *dev);
+
+/**
+ * @brief Callback API to register an audio codec error callback.
+ * See audio_codec_register_error_callback() for argument descriptions.
+ */
+typedef int (*audio_codec_register_error_callback_t)(const struct device *dev,
+						     audio_codec_error_callback_t cb);
+
+/**
+ * @brief Callback API to route an audio codec input.
+ * See audio_codec_route_input() for argument descriptions.
+ */
+typedef int (*audio_codec_route_input_t)(const struct device *dev, audio_channel_t channel,
+					 uint32_t input);
+
+/**
+ * @brief Callback API to route an audio codec output.
+ * See audio_codec_route_output() for argument descriptions.
+ */
+typedef int (*audio_codec_route_output_t)(const struct device *dev, audio_channel_t channel,
+					  uint32_t output);
+
+/**
+ * @brief Callback API to start audio codec playback or capture.
+ * See audio_codec_start() for argument descriptions.
+ */
+typedef int (*audio_codec_start_t)(const struct device *dev, audio_dai_dir_t dir);
+
+/**
+ * @brief Callback API to stop audio codec playback or capture.
+ * See audio_codec_stop() for argument descriptions.
+ */
+typedef int (*audio_codec_stop_t)(const struct device *dev, audio_dai_dir_t dir);
+
+/**
+ * @brief Callback API to submit data for audio codec playback.
+ * See audio_codec_write() for argument descriptions.
+ */
+typedef int (*audio_codec_write_t)(const struct device *dev, uint8_t *data, size_t data_size);
+
+/**
+ * @brief Callback API to register audio codec DMA completion callbacks.
+ * See audio_codec_register_done_callback() for argument descriptions.
+ */
+typedef int (*audio_codec_register_done_callback_t)(
+	const struct device *dev, audio_codec_tx_done_callback_t tx_cb, void *tx_cb_user_data,
+	audio_codec_rx_done_callback_t rx_cb, void *rx_cb_user_data);
+
+/**
+ * Legacy struct tag alias for @ref audio_codec_driver_api for audio codec drivers that have not
+ * been updated to use audio_codec_driver_api for their backend struct.
+ *
+ * @deprecated Audio codec drivers should use the DEVICE_API() macro to declare their driver API.
+ */
+#define audio_codec_api audio_codec_driver_api __DEPRECATED_MACRO
+
+/**
+ * @driver_ops{Audio Codec}
+ */
+__subsystem struct audio_codec_driver_api {
+	/**
+	 * @driver_ops_mandatory @copybrief audio_codec_configure
+	 */
+	audio_codec_configure_t configure;
+	/**
+	 * @driver_ops_mandatory @copybrief audio_codec_start_output
+	 */
+	audio_codec_start_output_t start_output;
+	/**
+	 * @driver_ops_mandatory @copybrief audio_codec_stop_output
+	 */
+	audio_codec_stop_output_t stop_output;
+	/**
+	 * @driver_ops_mandatory @copybrief audio_codec_set_property
+	 */
+	audio_codec_set_property_t set_property;
+	/**
+	 * @driver_ops_mandatory @copybrief audio_codec_apply_properties
+	 */
+	audio_codec_apply_properties_t apply_properties;
+	/**
+	 * @driver_ops_optional @copybrief audio_codec_clear_errors
+	 */
+	audio_codec_clear_errors_t clear_errors;
+	/**
+	 * @driver_ops_optional @copybrief audio_codec_register_error_callback
+	 */
+	audio_codec_register_error_callback_t register_error_callback;
+	/**
+	 * @driver_ops_optional @copybrief audio_codec_route_input
+	 */
+	audio_codec_route_input_t route_input;
+	/**
+	 * @driver_ops_optional @copybrief audio_codec_route_output
+	 */
+	audio_codec_route_output_t route_output;
+	/**
+	 * @driver_ops_optional @copybrief audio_codec_start
+	 */
+	audio_codec_start_t start;
+	/**
+	 * @driver_ops_optional @copybrief audio_codec_stop
+	 */
+	audio_codec_stop_t stop;
+	/**
+	 * @driver_ops_optional @copybrief audio_codec_write
+	 */
+	audio_codec_write_t write;
+	/**
+	 * @driver_ops_optional @copybrief audio_codec_register_done_callback
+	 */
+	audio_codec_register_done_callback_t register_done_callback;
+};
+
+/**
+ * @}
  */
 
 /**
@@ -272,7 +404,7 @@ struct audio_codec_api {
  */
 static inline int audio_codec_configure(const struct device *dev, struct audio_codec_cfg *cfg)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	return api->configure(dev, cfg);
 }
@@ -286,7 +418,7 @@ static inline int audio_codec_configure(const struct device *dev, struct audio_c
  */
 static inline void audio_codec_start_output(const struct device *dev)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	api->start_output(dev);
 }
@@ -300,7 +432,7 @@ static inline void audio_codec_start_output(const struct device *dev)
  */
 static inline void audio_codec_stop_output(const struct device *dev)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	api->stop_output(dev);
 }
@@ -320,7 +452,7 @@ static inline void audio_codec_stop_output(const struct device *dev)
 static inline int audio_codec_set_property(const struct device *dev, audio_property_t property,
 					   audio_channel_t channel, audio_property_value_t val)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	return api->set_property(dev, property, channel, val);
 }
@@ -338,7 +470,7 @@ static inline int audio_codec_set_property(const struct device *dev, audio_prope
  */
 static inline int audio_codec_apply_properties(const struct device *dev)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	return api->apply_properties(dev);
 }
@@ -355,7 +487,7 @@ static inline int audio_codec_apply_properties(const struct device *dev)
  */
 static inline int audio_codec_clear_errors(const struct device *dev)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	if (api->clear_errors == NULL) {
 		return -ENOSYS;
@@ -381,7 +513,7 @@ static inline int audio_codec_clear_errors(const struct device *dev)
 static inline int audio_codec_register_error_callback(const struct device *dev,
 						      audio_codec_error_callback_t cb)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	if (api->register_error_callback == NULL) {
 		return -ENOSYS;
@@ -406,7 +538,7 @@ static inline int audio_codec_register_error_callback(const struct device *dev,
 static inline int audio_codec_route_input(const struct device *dev, audio_channel_t channel,
 					  uint32_t input)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	if (api->route_input == NULL) {
 		return -ENOSYS;
@@ -431,7 +563,7 @@ static inline int audio_codec_route_input(const struct device *dev, audio_channe
 static inline int audio_codec_route_output(const struct device *dev, audio_channel_t channel,
 					   uint32_t output)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	if (api->route_output == NULL) {
 		return -ENOSYS;
@@ -452,7 +584,7 @@ static inline int audio_codec_route_output(const struct device *dev, audio_chann
  */
 static inline int audio_codec_start(const struct device *dev, audio_dai_dir_t dir)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	if (api->start == NULL) {
 		return -ENOSYS;
@@ -473,7 +605,7 @@ static inline int audio_codec_start(const struct device *dev, audio_dai_dir_t di
  */
 static inline int audio_codec_stop(const struct device *dev, audio_dai_dir_t dir)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	if (api->stop == NULL) {
 		return -ENOSYS;
@@ -498,7 +630,7 @@ static inline int audio_codec_stop(const struct device *dev, audio_dai_dir_t dir
  */
 static inline int audio_codec_write(const struct device *dev, uint8_t *data, size_t data_size)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	if (api->write == NULL) {
 		return -ENOSYS;
@@ -533,7 +665,7 @@ static inline int audio_codec_register_done_callback(const struct device *dev,
 						     audio_codec_rx_done_callback_t rx_cb,
 						     void *rx_cb_user_data)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->api;
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
 
 	if (api->register_done_callback == NULL) {
 		return -ENOSYS;


### PR DESCRIPTION
There is no reason to not have audio codec be a proper driver class,
so make the appropriate change so that codec drivers actually populate a
driver_api struct.

A similar change was made to the DMIC driver class in commit 4f8a71f.

Now the driver ops are also properly documented: https://builds.zephyrproject.io/zephyr/pr/110631/docs/doxygen/html/structaudio__codec__driver__api.html