### PR TITLE
hal: realtek: register west extension for toolchain management

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -230,6 +230,7 @@ manifest:
     - name: hal_realtek
       path: modules/hal/realtek
       revision: 29d365ccfbceb9f42ce666d75463fbe2c83b8e29
+      west-commands: west/west-commands.yml
       groups:
         - hal
     - name: hal_renesas

--- a/west.yml
+++ b/west.yml
@@ -230,6 +230,7 @@ manifest:
     - name: hal_realtek
       path: modules/hal/realtek
       revision: ba5032a9e47b6ad9e9488665c1e990ed0f434734
+      west-commands: west/west-commands.yml
       groups:
         - hal
     - name: hal_renesas


### PR DESCRIPTION
## Summary

Register the `west realtek` extension for the hal_realtek module in the
west manifest, following the same pattern used by `hal_espressif`.

This enables users to install the Realtek GNU Arm Embedded toolchain
required for Ameba series Zephyr builds with a single west command:

```sh
west realtek ameba install -t asdk-12.3.1-4568
```

## Changes

`west.yml`: add `west-commands: west/west-commands.yml` to the
`hal_realtek` project entry, and update the revision to include the
west extension implementation (see
https://github.com/zephyrproject-rtos/hal_realtek/pull/36).

The extension itself lives entirely in `hal_realtek` — no Zephyr tree
sources are added or modified beyond `west.yml`.

## New west command (provided by hal_realtek PR #36)

```
west realtek ameba install                        # install all toolchains
west realtek ameba install -t asdk-12.3.1-4568   # AmebaG2 (RTL8721F)
west realtek ameba install -t asdk-10.3.1-4523   # AmebaDplus/AmebaD/AmebaSmart
west realtek ameba install -t <id> --aliyun      # use Aliyun CDN mirror
```

| Toolchain ID | Chips | Boards |
|---|---|---|
| `asdk-12.3.1-4568` | AmebaG2 | rtl8721f_evb |
| `asdk-10.3.1-4523` | AmebaDplus, AmebaD, AmebaSmart | rtl872xda_evb, rtl872xd_evb, rtl8730e_evb |

## Test plan

- [x] `west realtek --help` shows command description and examples
- [x] `west realtek ameba install --help` lists all supported toolchains
- [x] Command resolves correctly after `west update` with this manifest
