### PR TITLE
net: tests: ipv4_nat: implement required ethernet API for dummy ifaces

### DIFF
--- a/tests/net/ipv4_nat/src/main.c
+++ b/tests/net/ipv4_nat/src/main.c
@@ -34,10 +34,21 @@ static void dummy_iface_init(struct net_if *iface)
 {
 	net_if_set_link_addr(iface, dummy_mac, sizeof(struct net_eth_addr),
 			     NET_LINK_ETHERNET);
+
+	ethernet_init(iface);
+}
+
+static int dummy_iface_send(const struct device *dev, struct net_pkt *pkt)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(pkt);
+
+	return 0;
 }
 
 static struct ethernet_api dummy_iface_api = {
-	.iface_api.init = dummy_iface_init
+	.iface_api.init = dummy_iface_init,
+	.send = dummy_iface_send,
 };
 
 ETH_NET_DEVICE_INIT(dummy_iface_a, "dummy_a", NULL, NULL,


### PR DESCRIPTION
Missed by eb988315b9f. After 1196110b60a, dummy ifaces missing a send callback panic during IPv6 DAD. Add dummy_iface_send() and call ethernet_init() in dummy_iface_init().