### PR TITLE
boards: st: Document OEMxROT module availability on compatible products

### DIFF
--- a/boards/st/nucleo_n657x0_q/doc/index.rst
+++ b/boards/st/nucleo_n657x0_q/doc/index.rst
@@ -174,6 +174,17 @@ Serial Port
 NUCLEO-N657X0-Q board has 10 U(S)ARTs. The Zephyr console output is assigned to
 USART1. Default settings are 115200 8N1.
 
+STM32 OEMuROT integration
+=========================
+
+STM32CubeN6 provides an external secure bootloader called STM32 OEMuROT
+that takes advantage of the secure features of the STM32N657X0
+microcontroller. Refer to the `OEMuRoT for STM32N6 wiki article`_ for details
+on this bootloader.
+
+Integration of this bootloader in the Zephyr build environment is available
+in the external `STM32 OEMxROT module`_.
+
 Programming and Debugging
 *************************
 
@@ -330,3 +341,9 @@ To do so, it is advised to use Twister's hardware map feature with the following
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html
+
+.. _OEMuRoT for STM32N6 wiki article:
+   https://wiki.st.com/stm32mcu/wiki/Security:OEMuRoT_for_STM32N6
+
+.. _STM32 OEMxROT module:
+   https://github.com/stm32-hotspot/zephyr-stm32-oemxrot

--- a/boards/st/nucleo_wba25ce1/doc/nucleo_wba25ce1.rst
+++ b/boards/st/nucleo_wba25ce1/doc/nucleo_wba25ce1.rst
@@ -149,6 +149,17 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
+STM32 OEMxROT integration
+=========================
+
+STM32CubeWBA provides an external secure bootloader called STM32 OEMiROT
+that takes advantage of the secure features of the STM32WBA25CE1
+microcontroller. Refer to the `OEMiRoT/OEMuRoT for STM32WBA wiki article`_ for
+details on this bootloader.
+
+Integration of this bootloader in the Zephyr build environment is available
+in the external `STM32 OEMxROT module`_.
+
 Connections and IOs
 ===================
 
@@ -251,3 +262,9 @@ For that:
 
 .. _STM32CubeCLT:
    https://www.st.com/en/development-tools/stm32cubeclt.html
+
+.. _STM32 OEMxROT module:
+   https://github.com/stm32-hotspot/zephyr-stm32-oemxrot
+
+.. _OEMiRoT/OEMuRoT for STM32WBA wiki article:
+   https://wiki.st.com/stm32mcu/wiki/Security:OEMiRoT_OEMuRoT_for_STM32WBA

--- a/boards/st/nucleo_wba65ri/doc/index.rst
+++ b/boards/st/nucleo_wba65ri/doc/index.rst
@@ -205,6 +205,17 @@ disabled system (e.g. without TF-M support).
 You can use STM32CubeProgrammer_ to disable the SoC TZEN Option Byte config. Refer
 to `How to disable STM32WBA65 TZEN Option Byte`_.
 
+STM32 OEMiROT integration
+=========================
+
+STM32CubeWBA provides an external secure bootloader called STM32 OEMiROT
+that takes advantage of the secure features of the STM32WBA65RI
+microcontroller. Refer to the `OEMiRoT/OEMuRoT for STM32WBA wiki article`_ for
+details on this bootloader.
+
+Integration of this bootloader in the Zephyr build environment is available
+in the external `STM32 OEMxROT module`_.
+
 Connections and IOs
 ===================
 
@@ -302,6 +313,12 @@ you can debug an application in the usual way using OpenOCD. Here is an example 
 
 .. _How to disable STM32WBA65 TZEN Option Byte:
    https://wiki.st.com/stm32mcu/wiki/Connectivity:STM32WBA_BLE_%26_TrustZone#How_to_disable_the_TrustZone
+
+.. _OEMiRoT/OEMuRoT for STM32WBA wiki article:
+   https://wiki.st.com/stm32mcu/wiki/Security:OEMiRoT_OEMuRoT_for_STM32WBA
+
+.. _STM32 OEMxROT module:
+   https://github.com/stm32-hotspot/zephyr-stm32-oemxrot
 
 .. _OpenOCD WBA6xx commit:
    https://github.com/openocd-org/openocd/commit/df14f586629a70878636d138ec3bffd9148aaf1b

--- a/boards/st/stm32n6570_dk/doc/index.rst
+++ b/boards/st/stm32n6570_dk/doc/index.rst
@@ -108,6 +108,17 @@ However, to allow running Zephyr net related samples without programming
 irreversibly your device, by default, the STM32 Ethernet driver creates a
 locally administered MAC address from the device unique ID.
 
+STM32 OEMuROT integration
+=========================
+
+STM32CubeN6 provides an external secure bootloader called STM32 OEMuROT
+that takes advantage of the secure features of the STM32N657X0H3Q
+microcontroller. Refer to the `OEMuRoT for STM32N6 wiki article`_ for details
+on this bootloader.
+
+Integration of this bootloader in the Zephyr build environment is available
+in the external `STM32 OEMxROT module`_.
+
 USB
 ===
 
@@ -470,6 +481,12 @@ To do so, it is advised to use Twister's hardware map feature with the following
 
 .. _STM32 ISP module:
    https://github.com/stm32-hotspot/zephyr-stm32-mw-isp
+
+.. _OEMuRoT for STM32N6 wiki article:
+   https://wiki.st.com/stm32mcu/wiki/Security:OEMuRoT_for_STM32N6
+
+.. _STM32 OEMxROT module:
+   https://github.com/stm32-hotspot/zephyr-stm32-oemxrot
 
 .. _Zephyr computer vision application:
    https://github.com/stm32-hotspot/zephyr-stm32n6-ai-people-detection

--- a/boards/st/stm32wba65i_dk1/doc/index.rst
+++ b/boards/st/stm32wba65i_dk1/doc/index.rst
@@ -206,6 +206,17 @@ disabled system (e.g. without TF-M support).
 You can use STM32CubeProgrammer_ to disable the SoC TZEN Option Byte config. Refer
 to `How to disable STM32WBA65 TZEN Option Byte`_.
 
+STM32 OEMiROT integration
+=========================
+
+STM32CubeWBA provides an external secure bootloader called STM32 OEMiROT
+that takes advantage of the secure features of the STM32WBA65RI
+microcontroller. Refer to the `OEMiRoT/OEMuRoT for STM32WBA wiki article`_ for
+details on this bootloader.
+
+Integration of this bootloader in the Zephyr build environment is available
+in the external `STM32 OEMxROT module`_.
+
 Connections and IOs
 ===================
 
@@ -295,6 +306,12 @@ you can debug an application in the usual way using OpenOCD. Here is an example 
 
 .. _How to disable STM32WBA65 TZEN Option Byte:
    https://wiki.st.com/stm32mcu/wiki/Connectivity:STM32WBA_BLE_%26_TrustZone#How_to_disable_the_TrustZone
+
+.. _OEMiRoT/OEMuRoT for STM32WBA wiki article:
+   https://wiki.st.com/stm32mcu/wiki/Security:OEMiRoT_OEMuRoT_for_STM32WBA
+
+.. _STM32 OEMxROT module:
+   https://github.com/stm32-hotspot/zephyr-stm32-oemxrot
 
 .. _OpenOCD WBA6xx commit:
    https://github.com/openocd-org/openocd/commit/df14f586629a70878636d138ec3bffd9148aaf1b


### PR DESCRIPTION
Now that Zephyr SDK for STM32 OEMxROT integration is available, document it on the platforms where it can be used.