### PR TITLE
twister: subsets: when creating subsets, sort by tests

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -313,17 +313,8 @@ class TestPlan:
             self.generate_subset(subset, int(sets))
 
     def generate_subset(self, subset, sets):
-        # Test instances are sorted depending on the context. For CI runs
-        # the execution order is: "plat1-testA, plat1-testB, ...,
-        # plat1-testZ, plat2-testA, ...". For hardware tests
-        # (device_testing), were multiple physical platforms can run the tests
-        # in parallel, it is more efficient to run in the order:
-        # "plat1-testA, plat2-testA, ..., plat1-testB, plat2-testB, ..."
-        if self.options.device_testing:
-            self.instances = OrderedDict(sorted(self.instances.items(),
-                                key=lambda x: x[0][x[0].find("/") + 1:]))
-        else:
-            self.instances = OrderedDict(sorted(self.instances.items()))
+        self.instances = OrderedDict(sorted(self.instances.items(),
+                                key=lambda x: (x[1].testsuite.name, x[0])))
 
         if self.options.shuffle_tests:
             seed_value = int.from_bytes(os.urandom(8), byteorder="big")

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -959,13 +959,13 @@ def test_testplan_load(
 
 TESTDATA_5 = [
     (False, False, None, 1, 2,
-     ['plat1/testA', 'plat1/testB', 'plat1/testC',
+     ['plat1/testA', 'plat2/testA', 'plat1/testB',
       'plat3/testA', 'plat3/testB', 'plat3/testC']),
     (False, False, None, 1, 5,
      ['plat1/testA',
       'plat3/testA', 'plat3/testB', 'plat3/testC']),
     (False, False, None, 2, 2,
-     ['plat2/testA', 'plat2/testB']),
+     ['plat2/testB', 'plat1/testC']),
     (True, False, None, 1, 2,
      ['plat1/testA', 'plat2/testA', 'plat1/testB',
       'plat3/testA', 'plat3/testB', 'plat3/testC']),
@@ -1000,15 +1000,20 @@ def test_testplan_generate_subset(
         shuffle_tests=shuffle,
         shuffle_tests_seed=seed
     )
+    def make_inst(ts_name, status):
+        inst = mock.Mock(status=status)
+        inst.testsuite.name = ts_name
+        return inst
+
     testplan.instances = {
-        'plat1/testA': mock.Mock(status=TwisterStatus.NONE),
-        'plat1/testB': mock.Mock(status=TwisterStatus.NONE),
-        'plat1/testC': mock.Mock(status=TwisterStatus.NONE),
-        'plat2/testA': mock.Mock(status=TwisterStatus.NONE),
-        'plat2/testB': mock.Mock(status=TwisterStatus.NONE),
-        'plat3/testA': mock.Mock(status=TwisterStatus.SKIP),
-        'plat3/testB': mock.Mock(status=TwisterStatus.SKIP),
-        'plat3/testC': mock.Mock(status=TwisterStatus.ERROR),
+        'plat1/testA': make_inst('testA', TwisterStatus.NONE),
+        'plat1/testB': make_inst('testB', TwisterStatus.NONE),
+        'plat1/testC': make_inst('testC', TwisterStatus.NONE),
+        'plat2/testA': make_inst('testA', TwisterStatus.NONE),
+        'plat2/testB': make_inst('testB', TwisterStatus.NONE),
+        'plat3/testA': make_inst('testA', TwisterStatus.SKIP),
+        'plat3/testB': make_inst('testB', TwisterStatus.SKIP),
+        'plat3/testC': make_inst('testC', TwisterStatus.ERROR),
     }
 
     testplan.generate_subset(subset, sets)

--- a/scripts/tests/twister_blackbox/test_shuffle.py
+++ b/scripts/tests/twister_blackbox/test_shuffle.py
@@ -32,16 +32,16 @@ class TestShuffle:
     @pytest.mark.parametrize(
         'seed, ratio, expected_order',
         [
-            ('123', '1/2', ['dummy.device.group', 'dummy.agnostic.group1.subgroup2']),
+            ('123', '1/2', ['dummy.agnostic.group1.subgroup2', 'dummy.device.group']),
             ('123', '2/2', ['dummy.agnostic.group2', 'dummy.agnostic.group1.subgroup1']),
-            ('321', '1/2', ['dummy.agnostic.group2', 'dummy.agnostic.group1.subgroup2']),
-            ('321', '2/2', ['dummy.device.group', 'dummy.agnostic.group1.subgroup1']),
-            ('123', '1/3', ['dummy.device.group', 'dummy.agnostic.group1.subgroup2']),
+            ('321', '1/2', ['dummy.agnostic.group1.subgroup2', 'dummy.agnostic.group1.subgroup1']),
+            ('321', '2/2', ['dummy.agnostic.group2', 'dummy.device.group']),
+            ('123', '1/3', ['dummy.agnostic.group1.subgroup2', 'dummy.device.group']),
             ('123', '2/3', ['dummy.agnostic.group2']),
             ('123', '3/3', ['dummy.agnostic.group1.subgroup1']),
-            ('321', '1/3', ['dummy.agnostic.group2', 'dummy.agnostic.group1.subgroup2']),
-            ('321', '2/3', ['dummy.device.group']),
-            ('321', '3/3', ['dummy.agnostic.group1.subgroup1'])
+            ('321', '1/3', ['dummy.agnostic.group1.subgroup2', 'dummy.agnostic.group1.subgroup1']),
+            ('321', '2/3', ['dummy.agnostic.group2']),
+            ('321', '3/3', ['dummy.device.group'])
         ],
         ids=['first half, 123', 'second half, 123', 'first half, 321', 'second half, 321',
              'first third, 123', 'middle third, 123', 'last third, 123',


### PR DESCRIPTION
Do not have different sorting based on mode, always sort the same and
run all tests in the same subsets or runnings. A test failing on
multiple platforms should not cause majority of runners to fail.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
