### PR TITLE
drivers: spi: stm32: add log level config

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT st_stm32_spi
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(spi_stm32);
+LOG_MODULE_REGISTER(spi_stm32, CONFIG_SPI_LOG_LEVEL);
 
 #include <zephyr/cache.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>


### PR DESCRIPTION
When CONFIG_LOG_DEFAULT_LEVEL is set to 4 and SPI driver is used, it will log debug messages idependently of CONFIG_SPI_LOG_LEVEL. This allows disabling debug logs with the SPI log level config.