### PR TITLE
SCMI pinctrl protocol fixes

### DIFF
--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -45,7 +45,7 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 
 	config_num = SCMI_PINCTRL_ATTRIBUTES_CONFIG_NUM(settings->attributes);
 
-	if (!config_num) {
+	if (config_num == 0U && SCMI_PINCTRL_ATTRIBUTES_FID_VALID(settings->attributes) == 0U) {
 		return -EINVAL;
 	}
 

--- a/include/zephyr/drivers/firmware/scmi/pinctrl.h
+++ b/include/zephyr/drivers/firmware/scmi/pinctrl.h
@@ -49,6 +49,13 @@
 #define SCMI_PINCTRL_ATTRIBUTES_CONFIG_NUM(attributes)\
 	(((attributes) & GENMASK(9, 2)) >> 2)
 
+/**
+ * Extract the fid_valid value (1 if the function ID field is valid, 0 otherwise)
+ * from an attributes word
+ */
+#define SCMI_PINCTRL_ATTRIBUTES_FID_VALID(attributes)\
+	FIELD_GET(BIT(10), attributes)
+
 /** Version of the SCMI pin control protocol supported by this driver */
 #define SCMI_PIN_CONTROL_PROTOCOL_SUPPORTED_VERSION	0x10000
 

--- a/include/zephyr/drivers/firmware/scmi/pinctrl.h
+++ b/include/zephyr/drivers/firmware/scmi/pinctrl.h
@@ -36,7 +36,7 @@
  * @param selector Selects what is being configured (see SCMI_PINCTRL_SELECTOR_*)
  */
 #define SCMI_PINCTRL_CONFIG_ATTRIBUTES(fid_valid, cfg_num, selector)	\
-	(SCMI_FIELD_MAKE(fid_valid, BIT(1), 10) |			\
+	(SCMI_FIELD_MAKE(fid_valid, BIT(0), 10) |			\
 	 SCMI_FIELD_MAKE(cfg_num, GENMASK(7, 0), 2) |			\
 	 SCMI_FIELD_MAKE(selector, GENMASK(1, 0), 0))
 


### PR DESCRIPTION
This PR fixes 2 bugs in SCMI pinctrl protocol.

This follows [a discussion](https://github.com/zephyrproject-rtos/zephyr/pull/108871#discussion_r3363561955) with @xakep-amatop while reviewing another PR related to R-Car Gen5 pinctrl support.