### PR TITLE
tests: drivers: dma:  read buf align from node label tst_dma0

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
@@ -8,7 +8,7 @@
 
 #include "test_buffers.h"
 
-#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
 
 __aligned(DMA_DATA_ALIGNMENT) char tx_data[TEST_BUF_SIZE] =
 	"It is harder to be kind than to be wise........";

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -25,7 +25,7 @@
 #define TEST_DMA_CHANNEL_1 (1)
 #define GUARD_BUFF_SIZE (16)
 #define RX_BUFF_SIZE (48)
-#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
 
 #ifdef CONFIG_NOCACHE_MEMORY
 static __aligned(DMA_DATA_ALIGNMENT) char tx_data[RX_BUFF_SIZE] __used

--- a/tests/drivers/dma/cyclic/src/test_dma_cyclic.c
+++ b/tests/drivers/dma/cyclic/src/test_dma_cyclic.c
@@ -22,7 +22,7 @@
 #include <zephyr/drivers/dma.h>
 #include <zephyr/ztest.h>
 
-#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
 #define GUARD_BUF_SIZE (16)
 
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_CYCLIC_XFER_SIZE];

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -32,7 +32,7 @@
 #define SLEEPTIME 250
 
 #define TRANSFER_LOOPS (4)
-#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
 
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE];
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t

--- a/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
+++ b/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
@@ -22,7 +22,7 @@
 #include <zephyr/ztest.h>
 
 #define XFERS 4
-#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
 
 #if CONFIG_NOCACHE_MEMORY
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_SG_XFER_SIZE] __used


### PR DESCRIPTION
Replace incorrect `DT_INST_PROP_OR(tst_dma0, ...)` usage with `DT_PROP_OR(DT_NODELABEL(tst_dma0),`


Why the current implementation is incorrect:

- `DT_INST_PROP_OR` will try to resolve `DT_DRV_INST(tst_dma0)`
- That expands to`DT_N_INST_tst_dma0_DT_DRV_COMPAT`, which doesn't exist
- `DT_NODE_HAS_PROP(DT_N_INST_tst_dma0_DT_DRV_COMPAT, dma_buf_addr_alignment))` will resolve `0` 

=> essentially, `tst_dma0` is a node label, not an instance. So you'll always get 32.

Why the fix works

- `DT_NODELABEL(tst_dma0)` resolves to `DT_N_NODELABEL_tst_dma0`
- That's defined in `devicetree_generated.h` to (e.g.) `DT_N_S_noc_dma_ffb20000` since our overlay has:

```
tst_dma0: &dma0 {
```

Tests:

Our DMA tests on our device, plus some `.i` snooping  

```
*** Booting Zephyr OS build v4.4.0-17-gf1bda3e7ea7a ***
Running TESTSUITE dma_m2m
===================================================================
START - test_tst_dma0_m2m_chan0_burst16
Preparing DMA Controller: Name=noc_dma@ffb20000, Chan_ID=0, BURST_LEN=2
Starting the transfer
DMA transfer done
It is harder to be kind than to be wise........
 PASS - test_tst_dma0_m2m_chan0_burst16 in 2.001 seconds
===================================================================
START - test_tst_dma0_m2m_chan0_burst8
Preparing DMA Controller: Name=noc_dma@ffb20000, Chan_ID=0, BURST_LEN=1
Starting the transfer
DMA transfer done
It is harder to be kind than to be wise........
 PASS - test_tst_dma0_m2m_chan0_burst8 in 2.001 seconds
===================================================================
START - test_tst_dma0_m2m_chan1_burst16
Preparing DMA Controller: Name=noc_dma@ffb20000, Chan_ID=1, BURST_LEN=2
Starting the transfer
DMA transfer done
It is harder to be kind than to be wise........
 PASS - test_tst_dma0_m2m_chan1_burst16 in 2.001 seconds
===================================================================
START - test_tst_dma0_m2m_chan1_burst8
Preparing DMA Controller: Name=noc_dma@ffb20000, Chan_ID=1, BURST_LEN=1
Starting the transfer
DMA transfer done
It is harder to be kind than to be wise........
 PASS - test_tst_dma0_m2m_chan1_burst8 in 2.001 seconds
===================================================================
TESTSUITE dma_m2m succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [dma_m2m]: pass = 4, fail = 0, skip = 0, total = 4 duration = 8.004 seconds
 - PASS - [dma_m2m.test_tst_dma0_m2m_chan0_burst16] duration = 2.001 seconds
 - PASS - [dma_m2m.test_tst_dma0_m2m_chan0_burst8] duration = 2.001 seconds
 - PASS - [dma_m2m.test_tst_dma0_m2m_chan1_burst16] duration = 2.001 seconds
 - PASS - [dma_m2m.test_tst_dma0_m2m_chan1_burst8] duration = 2.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```


`test_buffers.c.i`:
```
# 13 "/home/jgrowden/tt-system-firmware-work/zephyr/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c" 3 4
__attribute__((__aligned__(
# 13 "/home/jgrowden/tt-system-firmware-work/zephyr/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c"
64
# 13 "/home/jgrowden/tt-system-firmware-work/zephyr/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c" 3 4
))) 
```

