### PR TITLE
soc: bflb: support updated Bouffalo Lab BLE controller blobs

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.bflb
+++ b/drivers/bluetooth/hci/Kconfig.bflb
@@ -37,9 +37,6 @@ config BT_BFLB_BL70X
 
 if BT_BFLB
 
-config BT_BUF_ACL_TX_COUNT
-	default 2
-
 config HEAP_MEM_POOL_ADD_SIZE_BFLB_BT
 	int
 	default 8192
@@ -120,6 +117,12 @@ config BFLB_BL70X_BLE_EM_16K
 	  Use 16KB exchange memory for BLE controller.
 	  Only needed for the m16s1 variant.
 
+# ACL packet count the selected variant reports in LE Read Buffer Size
+config BT_BUF_ACL_TX_COUNT
+	default 16 if BFLB_BL70X_BLE_M16S1
+	default 10 if BFLB_BL70X_BLE_M0S1T10
+	default 2
+
 endif # BT_BFLB_BL70X
 
 if BT_BFLB_BL60X
@@ -140,6 +143,11 @@ config BFLB_BL60X_BLE_M8S1
 	bool "m8s1: 8 central + 1 peripheral"
 
 endchoice
+
+# ACL packet count the selected variant reports in LE Read Buffer Size
+config BT_BUF_ACL_TX_COUNT
+	default 8 if BFLB_BL60X_BLE_M8S1
+	default 2
 
 endif # BT_BFLB_BL60X
 
@@ -253,6 +261,14 @@ config BFLB_BL70XL_BLE_EM_16K
 	  Use 16KB exchange memory for BLE controller.
 	  Only needed for the m8s1p variant (8 connections).
 
+# ACL packet count the selected variant reports in LE Read Buffer Size
+config BT_BUF_ACL_TX_COUNT
+	default 8 if BFLB_BL70XL_BLE_M8S1P
+	default 6 if BFLB_BL70XL_BLE_M0S4P || BFLB_BL70XL_BLE_M4S1P
+	default 5 if BFLB_BL70XL_BLE_M0S1RP
+	default 4 if BFLB_BL70XL_BLE_M0S2P || BFLB_BL70XL_BLE_M2S1P
+	default 2
+
 endif # BT_BFLB_BL70XL
 
 config BT_BFLB_BL61X
@@ -291,6 +307,11 @@ config BFLB_BL61X_BLE_1M2S1BREDR1
 	bool "ble1m2s1bredr1: peripheral + central + BR/EDR, 2 connections"
 
 endchoice
+
+# ACL packet count the selected variant reports in LE Read Buffer Size
+config BT_BUF_ACL_TX_COUNT
+	default 10 if BFLB_BL61X_BLE_1M10S1
+	default 4
 
 config BFLB_BL61X_BLE_EM_64K
 	bool "Use 64 KB exchange memory (required for BR/EDR)"

--- a/soc/bflb/bl61x/ble/btblecontroller_port_hw.c
+++ b/soc/bflb/bl61x/ble/btblecontroller_port_hw.c
@@ -252,6 +252,11 @@ void btblecontroller_sys_reset(void)
 	sys_reboot(0);
 }
 
+uint64_t bflb_mtimer_get_time_us(void)
+{
+	return k_cyc_to_us_floor64(k_cycle_get_64());
+}
+
 void btblecontroller_puts(const char *str)
 {
 	ARG_UNUSED(str);

--- a/soc/bflb/bl70x/bflb_platform_shim.c
+++ b/soc/bflb/bl70x/bflb_platform_shim.c
@@ -188,7 +188,7 @@ void BL702_Delay_MS(uint32_t cnt)
 /* Wireless MAC address shims */
 
 static uint8_t wireless_mac_addr[8];
-static int8_t wireless_default_tx_power;
+static int8_t wireless_default_tx_power = 10; /* dBm */
 
 int bl_wireless_mac_addr_set(uint8_t mac[8])
 {

--- a/soc/bflb/bl70xl/bflb_platform_shim.c
+++ b/soc/bflb/bl70xl/bflb_platform_shim.c
@@ -261,6 +261,11 @@ uint32_t bl_rtc_get_aligned_counter(void)
 	return (uint32_t)bl_rtc_get_counter();
 }
 
+uint64_t bl_timer_now_us64(void)
+{
+	return k_cyc_to_us_floor64(k_cycle_get_64());
+}
+
 /* Busy-wait delay shims, called by the BLE controller blob. */
 void BL702L_Delay_US(uint32_t cnt)
 {

--- a/west.yml
+++ b/west.yml
@@ -168,7 +168,7 @@ manifest:
         - hal
     - name: hal_bouffalolab
       path: modules/hal/bouffalolab
-      revision: 6f8ee38a67b5c4a9f0b6e395d9c363fc920182a0
+      revision: f011e4337fa79e28a3d784003d8a1bcf883eb75b
       groups:
         - hal
     - name: hal_espressif


### PR DESCRIPTION
Update the Bouffalo Lab BLE support for the new controller binary blobs covering BL60x, BL70x, BL70xL and BL61x.