### PR TITLE
modules: openthread: Don't select UART_INTERRUPT_DRIVEN if OPENTHREAD…

### DIFF
--- a/modules/openthread/Kconfig
+++ b/modules/openthread/Kconfig
@@ -241,7 +241,7 @@ config OPENTHREAD_COPROCESSOR
 	bool "OpenThread Co-Processor"
 	select OPENTHREAD_MANUAL_START
 	select RING_BUFFER
-	select UART_INTERRUPT_DRIVEN
+	select UART_INTERRUPT_DRIVEN if !OPENTHREAD_COPROCESSOR_UART_ASYNC
 	help
 	  Enable Co-Processor in OpenThread stack.
 


### PR DESCRIPTION
…_COPROCESSOR_UART_ASYNC is set

OpenThread is currently always pulling UART_INTERRUPT_DRIVEN, even if it's not used as it's the case when OPENTHREAD_COPROCESSOR_UART_ASYNC is set.

This makes OpenThread impossible to use with a driver that only supports the async API.