### PR TITLE
drivers: can: nxp: flexcan: prevent log flooding

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1135,7 +1135,7 @@ static FLEXCAN_CALLBACK(mcux_flexcan_transfer_callback)
 		 * Unhandled status during Message Buffer processing.
 		 * If result field is 0xFF, it means no message buffer interrupt occurred.
 		 */
-		__fallthrough;
+		break;
 	default:
 		LOG_WRN("Unhandled status 0x%08x (result = 0x%016llx)",
 			status, status_flags);


### PR DESCRIPTION
Prevent flooding the log when a bus error occurs without a mailbox generating an interrupt.

Fixes: #110654