### PR TITLE
[Backport v4.3-branch] net: {icmpv4/icmpv6/igmp/mld/nbr}: fix use-after-free

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -420,6 +420,7 @@ static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
 {
 	struct net_pkt *reply = NULL;
 	struct net_ipv4_hdr *ip_hdr = hdr->ipv4;
+	struct net_if *iface = net_pkt_iface(pkt);
 	struct in_addr req_src, req_dst;
 	const struct in_addr *src;
 	int16_t payload_len;
@@ -447,7 +448,7 @@ static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	reply = net_pkt_alloc_with_buffer(net_pkt_iface(pkt),
+	reply = net_pkt_alloc_with_buffer(iface,
 					  net_pkt_ipv4_opts_len(pkt) +
 					  payload_len,
 					  AF_INET, IPPROTO_ICMP,
@@ -458,8 +459,8 @@ static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
 	}
 
 	if (net_ipv4_is_addr_mcast(&req_dst) ||
-	    net_ipv4_is_addr_bcast(net_pkt_iface(pkt), &req_dst)) {
-		src = net_if_ipv4_select_src_addr(net_pkt_iface(pkt), &req_src);
+	    net_ipv4_is_addr_bcast(iface, &req_dst)) {
+		src = net_if_ipv4_select_src_addr(iface, &req_src);
 
 		if (net_ipv4_is_addr_unspecified(src)) {
 			NET_DBG("DROP: No src address match");
@@ -499,7 +500,7 @@ static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	net_stats_update_icmp_sent(net_pkt_iface(reply));
+	net_stats_update_icmp_sent(iface);
 
 	return 0;
 drop:
@@ -507,7 +508,7 @@ drop:
 		net_pkt_unref(reply);
 	}
 
-	net_stats_update_icmp_drop(net_pkt_iface(pkt));
+	net_stats_update_icmp_drop(iface);
 
 	return -EIO;
 }
@@ -516,6 +517,7 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv4_access, struct net_ipv4_hdr);
 	int err = -EIO;
+	struct net_if *iface = net_pkt_iface(orig);
 	struct net_ipv4_hdr *ip_hdr;
 	struct in_addr orig_src, orig_dst;
 	struct net_pkt *pkt;
@@ -545,7 +547,7 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 	net_ipv4_addr_copy_raw(orig_src.s4_addr, ip_hdr->src);
 	net_ipv4_addr_copy_raw(orig_dst.s4_addr, ip_hdr->dst);
 
-	if (net_ipv4_is_addr_bcast(net_pkt_iface(orig), &orig_dst)) {
+	if (net_ipv4_is_addr_bcast(iface, &orig_dst)) {
 		/* We should not send an error to packet that
 		 * were sent to broadcast
 		 */
@@ -565,7 +567,7 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 		copy_len = 0;
 	}
 
-	pkt = net_pkt_alloc_with_buffer(net_pkt_iface(orig),
+	pkt = net_pkt_alloc_with_buffer(iface,
 					copy_len + NET_ICMPV4_UNUSED_LEN,
 					AF_INET, IPPROTO_ICMP,
 					PKT_WAIT_TIME);
@@ -594,7 +596,7 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 		net_sprint_ipv4_addr(&orig_src));
 
 	if (net_try_send_data(pkt, K_NO_WAIT) >= 0) {
-		net_stats_update_icmp_sent(net_pkt_iface(orig));
+		net_stats_update_icmp_sent(iface);
 		return 0;
 	}
 
@@ -602,7 +604,7 @@ drop:
 	net_pkt_unref(pkt);
 
 drop_no_pkt:
-	net_stats_update_icmp_drop(net_pkt_iface(orig));
+	net_stats_update_icmp_drop(iface);
 
 	return err;
 

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -104,6 +104,7 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 {
 	struct net_pkt *reply = NULL;
 	struct net_ipv6_hdr *ip_hdr = hdr->ipv6;
+	struct net_if *iface = net_pkt_iface(pkt);
 	struct in6_addr req_src, req_dst;
 	const struct in6_addr *src;
 	int16_t payload_len;
@@ -125,7 +126,7 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	reply = net_pkt_alloc_with_buffer(net_pkt_iface(pkt), payload_len,
+	reply = net_pkt_alloc_with_buffer(iface, payload_len,
 					  AF_INET6, IPPROTO_ICMPV6,
 					  PKT_WAIT_TIME);
 	if (!reply) {
@@ -134,8 +135,7 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 	}
 
 	if (net_ipv6_is_addr_mcast_raw(ip_hdr->dst)) {
-		src = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),
-						  &req_src);
+		src = net_if_ipv6_select_src_addr(iface, &req_src);
 
 		if (net_ipv6_is_addr_unspecified(src)) {
 			NET_DBG("DROP: No src address match");
@@ -177,7 +177,7 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	net_stats_update_icmp_sent(net_pkt_iface(reply));
+	net_stats_update_icmp_sent(iface);
 
 	return 0;
 
@@ -186,7 +186,7 @@ drop:
 		net_pkt_unref(reply);
 	}
 
-	net_stats_update_icmp_drop(net_pkt_iface(pkt));
+	net_stats_update_icmp_drop(iface);
 
 	return -EIO;
 }
@@ -196,6 +196,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv6_access, struct net_ipv6_hdr);
 	int err = -EIO;
+	struct net_if *iface = net_pkt_iface(orig);
 	struct in6_addr orig_src, orig_dst;
 	struct net_ipv6_hdr *ip_hdr;
 	const struct in6_addr *src;
@@ -241,7 +242,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 		copy_len = net_pkt_get_len(orig);
 	}
 
-	pkt = net_pkt_alloc_with_buffer(net_pkt_iface(orig),
+	pkt = net_pkt_alloc_with_buffer(iface,
 					net_pkt_lladdr_src(orig)->len * 2 +
 					copy_len + NET_ICMPV6_UNUSED_LEN,
 					AF_INET6, IPPROTO_ICMPV6,
@@ -293,8 +294,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 	net_pkt_lladdr_dst(pkt)->len = net_pkt_lladdr_src(orig)->len;
 
 	if (net_ipv6_is_addr_mcast_raw(ip_hdr->dst)) {
-		src = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),
-						  &orig_dst);
+		src = net_if_ipv6_select_src_addr(iface, &orig_dst);
 	} else {
 		src = &orig_dst;
 	}
@@ -330,7 +330,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 		net_sprint_ipv6_addr(&orig_src));
 
 	if (net_try_send_data(pkt, K_NO_WAIT) >= 0) {
-		net_stats_update_icmp_sent(net_pkt_iface(pkt));
+		net_stats_update_icmp_sent(iface);
 		return 0;
 	}
 
@@ -338,7 +338,7 @@ drop:
 	net_pkt_unref(pkt);
 
 drop_no_pkt:
-	net_stats_update_icmp_drop(net_pkt_iface(orig));
+	net_stats_update_icmp_drop(iface);
 
 	return err;
 }

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -244,6 +244,7 @@ static int igmp_v3_create_packet(struct net_pkt *pkt, const struct in_addr *dst,
 
 static int igmp_send(struct net_pkt *pkt)
 {
+	__maybe_unused struct net_if *iface = net_pkt_iface(pkt);
 	int ret;
 
 	net_pkt_cursor_init(pkt);
@@ -251,11 +252,11 @@ static int igmp_send(struct net_pkt *pkt)
 
 	ret = net_send_data(pkt);
 	if (ret < 0) {
-		net_stats_update_ipv4_igmp_drop(net_pkt_iface(pkt));
+		net_stats_update_ipv4_igmp_drop(iface);
 		return ret;
 	}
 
-	net_stats_update_ipv4_igmp_sent(net_pkt_iface(pkt));
+	net_stats_update_ipv4_igmp_sent(iface);
 
 	return 0;
 }

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -124,6 +124,7 @@ static int mld_create_packet(struct net_pkt *pkt, uint16_t count)
 
 static int mld_send(struct net_pkt *pkt)
 {
+	__maybe_unused struct net_if *iface = net_pkt_iface(pkt);
 	int ret;
 
 	net_pkt_cursor_init(pkt);
@@ -131,16 +132,16 @@ static int mld_send(struct net_pkt *pkt)
 
 	ret = net_send_data(pkt);
 	if (ret < 0) {
-		net_stats_update_icmp_drop(net_pkt_iface(pkt));
-		net_stats_update_ipv6_mld_drop(net_pkt_iface(pkt));
+		net_stats_update_icmp_drop(iface);
+		net_stats_update_ipv6_mld_drop(iface);
 
 		net_pkt_unref(pkt);
 
 		return ret;
 	}
 
-	net_stats_update_icmp_sent(net_pkt_iface(pkt));
-	net_stats_update_ipv6_mld_sent(net_pkt_iface(pkt));
+	net_stats_update_icmp_sent(iface);
+	net_stats_update_ipv6_mld_sent(iface);
 
 	return 0;
 }

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1221,7 +1221,7 @@ int net_ipv6_send_na(struct net_if *iface, const struct in6_addr *src,
 		goto drop;
 	}
 
-	net_stats_update_icmp_sent(net_pkt_iface(pkt));
+	net_stats_update_icmp_sent(iface);
 	net_stats_update_ipv6_nd_sent(iface);
 
 	return 0;
@@ -2169,7 +2169,7 @@ int net_ipv6_send_ns(struct net_if *iface,
 
 	net_ipv6_nbr_unlock();
 
-	net_stats_update_icmp_sent(net_pkt_iface(pkt));
+	net_stats_update_icmp_sent(iface);
 	net_stats_update_ipv6_nd_sent(iface);
 
 	return 0;
@@ -2241,7 +2241,7 @@ int net_ipv6_send_rs(struct net_if *iface)
 		goto drop;
 	}
 
-	net_stats_update_icmp_sent(net_pkt_iface(pkt));
+	net_stats_update_icmp_sent(iface);
 	net_stats_update_ipv6_nd_sent(iface);
 
 	return 0;


### PR DESCRIPTION
Backport aaed8332a62b0490a2f3c2cbabe272f575068eaa~5..aaed8332a62b0490a2f3c2cbabe272f575068eaa from #107100.

Fixes #107920

_Original PR description:_

---

Avoid accessing the packet after sending it, as the driver may have already unreferenced or freed it. Store the iface before sending instead of calling `net_pkt_iface()` on a potentially freed packet when updating packet statistics.

This fixes a few crashes due to use-after-free with `CONFIG_NET_STATISTICS=y`.