### PR TITLE
[Backport v3.7-branch] net: {icmpv4/icmpv6/igmp/mld/nbr}: fix use-after-free

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -419,6 +419,7 @@ static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
 {
 	struct net_pkt *reply = NULL;
 	struct net_ipv4_hdr *ip_hdr = hdr->ipv4;
+	struct net_if *iface = net_pkt_iface(pkt);
 	const struct in_addr *src;
 	int16_t payload_len;
 
@@ -442,7 +443,7 @@ static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	reply = net_pkt_alloc_with_buffer(net_pkt_iface(pkt),
+	reply = net_pkt_alloc_with_buffer(iface,
 					  net_pkt_ipv4_opts_len(pkt) +
 					  payload_len,
 					  AF_INET, IPPROTO_ICMP,
@@ -453,9 +454,9 @@ static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
 	}
 
 	if (net_ipv4_is_addr_mcast((struct in_addr *)ip_hdr->dst) ||
-	    net_ipv4_is_addr_bcast(net_pkt_iface(pkt),
+	    net_ipv4_is_addr_bcast(iface,
 				   (struct in_addr *)ip_hdr->dst)) {
-		src = net_if_ipv4_select_src_addr(net_pkt_iface(pkt),
+		src = net_if_ipv4_select_src_addr(iface,
 						  (struct in_addr *)ip_hdr->src);
 
 		if (net_ipv4_is_addr_unspecified(src)) {
@@ -496,7 +497,7 @@ static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	net_stats_update_icmp_sent(net_pkt_iface(reply));
+	net_stats_update_icmp_sent(iface);
 
 	return 0;
 drop:
@@ -504,7 +505,7 @@ drop:
 		net_pkt_unref(reply);
 	}
 
-	net_stats_update_icmp_drop(net_pkt_iface(pkt));
+	net_stats_update_icmp_drop(iface);
 
 	return -EIO;
 }
@@ -513,6 +514,7 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv4_access, struct net_ipv4_hdr);
 	int err = -EIO;
+	struct net_if *iface = net_pkt_iface(orig);
 	struct net_ipv4_hdr *ip_hdr;
 	struct net_pkt *pkt;
 	size_t copy_len;
@@ -538,7 +540,7 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 		}
 	}
 
-	if (net_ipv4_is_addr_bcast(net_pkt_iface(orig),
+	if (net_ipv4_is_addr_bcast(iface,
 				   (struct in_addr *)ip_hdr->dst)) {
 		/* We should not send an error to packet that
 		 * were sent to broadcast
@@ -559,7 +561,7 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 		copy_len = 0;
 	}
 
-	pkt = net_pkt_alloc_with_buffer(net_pkt_iface(orig),
+	pkt = net_pkt_alloc_with_buffer(iface,
 					copy_len + NET_ICMPV4_UNUSED_LEN,
 					AF_INET, IPPROTO_ICMP,
 					PKT_WAIT_TIME);
@@ -588,7 +590,7 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 		net_sprint_ipv4_addr(&ip_hdr->src));
 
 	if (net_send_data(pkt) >= 0) {
-		net_stats_update_icmp_sent(net_pkt_iface(orig));
+		net_stats_update_icmp_sent(iface);
 		return 0;
 	}
 
@@ -596,7 +598,7 @@ drop:
 	net_pkt_unref(pkt);
 
 drop_no_pkt:
-	net_stats_update_icmp_drop(net_pkt_iface(orig));
+	net_stats_update_icmp_drop(iface);
 
 	return err;
 

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -104,6 +104,7 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 {
 	struct net_pkt *reply = NULL;
 	struct net_ipv6_hdr *ip_hdr = hdr->ipv6;
+	struct net_if *iface = net_pkt_iface(pkt);
 	const struct in6_addr *src;
 	int16_t payload_len;
 
@@ -121,7 +122,7 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	reply = net_pkt_alloc_with_buffer(net_pkt_iface(pkt), payload_len,
+	reply = net_pkt_alloc_with_buffer(iface, payload_len,
 					  AF_INET6, IPPROTO_ICMPV6,
 					  PKT_WAIT_TIME);
 	if (!reply) {
@@ -130,7 +131,7 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 	}
 
 	if (net_ipv6_is_addr_mcast((struct in6_addr *)ip_hdr->dst)) {
-		src = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),
+		src = net_if_ipv6_select_src_addr(iface,
 						  (struct in6_addr *)ip_hdr->src);
 
 		if (net_ipv6_is_addr_unspecified(src)) {
@@ -173,7 +174,7 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	net_stats_update_icmp_sent(net_pkt_iface(reply));
+	net_stats_update_icmp_sent(iface);
 
 	return 0;
 
@@ -182,7 +183,7 @@ drop:
 		net_pkt_unref(reply);
 	}
 
-	net_stats_update_icmp_drop(net_pkt_iface(pkt));
+	net_stats_update_icmp_drop(iface);
 
 	return -EIO;
 }
@@ -192,6 +193,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv6_access, struct net_ipv6_hdr);
 	int err = -EIO;
+	struct net_if *iface = net_pkt_iface(orig);
 	struct net_ipv6_hdr *ip_hdr;
 	const struct in6_addr *src;
 	struct net_pkt *pkt;
@@ -233,7 +235,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 		copy_len = net_pkt_get_len(orig);
 	}
 
-	pkt = net_pkt_alloc_with_buffer(net_pkt_iface(orig),
+	pkt = net_pkt_alloc_with_buffer(iface,
 					net_pkt_lladdr_src(orig)->len * 2 +
 					copy_len + NET_ICMPV6_UNUSED_LEN,
 					AF_INET6, IPPROTO_ICMPV6,
@@ -283,7 +285,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 	net_pkt_lladdr_dst(pkt)->len = net_pkt_lladdr_src(orig)->len;
 
 	if (net_ipv6_is_addr_mcast((struct in6_addr *)ip_hdr->dst)) {
-		src = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),
+		src = net_if_ipv6_select_src_addr(iface,
 						  (struct in6_addr *)ip_hdr->dst);
 	} else {
 		src = (struct in6_addr *)ip_hdr->dst;
@@ -320,7 +322,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 		net_sprint_ipv6_addr(&ip_hdr->src));
 
 	if (net_send_data(pkt) >= 0) {
-		net_stats_update_icmp_sent(net_pkt_iface(pkt));
+		net_stats_update_icmp_sent(iface);
 		return 0;
 	}
 
@@ -328,7 +330,7 @@ drop:
 	net_pkt_unref(pkt);
 
 drop_no_pkt:
-	net_stats_update_icmp_drop(net_pkt_iface(orig));
+	net_stats_update_icmp_drop(iface);
 
 	return err;
 }

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -244,6 +244,7 @@ static int igmp_v3_create_packet(struct net_pkt *pkt, const struct in_addr *dst,
 
 static int igmp_send(struct net_pkt *pkt)
 {
+	__maybe_unused struct net_if *iface = net_pkt_iface(pkt);
 	int ret;
 
 	net_pkt_cursor_init(pkt);
@@ -251,11 +252,11 @@ static int igmp_send(struct net_pkt *pkt)
 
 	ret = net_send_data(pkt);
 	if (ret < 0) {
-		net_stats_update_ipv4_igmp_drop(net_pkt_iface(pkt));
+		net_stats_update_ipv4_igmp_drop(iface);
 		return ret;
 	}
 
-	net_stats_update_ipv4_igmp_sent(net_pkt_iface(pkt));
+	net_stats_update_ipv4_igmp_sent(iface);
 
 	return 0;
 }

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -123,6 +123,7 @@ static int mld_create_packet(struct net_pkt *pkt, uint16_t count)
 
 static int mld_send(struct net_pkt *pkt)
 {
+	__maybe_unused struct net_if *iface = net_pkt_iface(pkt);
 	int ret;
 
 	net_pkt_cursor_init(pkt);
@@ -130,16 +131,16 @@ static int mld_send(struct net_pkt *pkt)
 
 	ret = net_send_data(pkt);
 	if (ret < 0) {
-		net_stats_update_icmp_drop(net_pkt_iface(pkt));
-		net_stats_update_ipv6_mld_drop(net_pkt_iface(pkt));
+		net_stats_update_icmp_drop(iface);
+		net_stats_update_ipv6_mld_drop(iface);
 
 		net_pkt_unref(pkt);
 
 		return ret;
 	}
 
-	net_stats_update_icmp_sent(net_pkt_iface(pkt));
-	net_stats_update_ipv6_mld_sent(net_pkt_iface(pkt));
+	net_stats_update_icmp_sent(iface);
+	net_stats_update_ipv6_mld_sent(iface);
 
 	return 0;
 }

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1135,7 +1135,7 @@ int net_ipv6_send_na(struct net_if *iface, const struct in6_addr *src,
 		goto drop;
 	}
 
-	net_stats_update_icmp_sent(net_pkt_iface(pkt));
+	net_stats_update_icmp_sent(iface);
 	net_stats_update_ipv6_nd_sent(iface);
 
 	return 0;
@@ -2063,7 +2063,7 @@ int net_ipv6_send_ns(struct net_if *iface,
 
 	net_ipv6_nbr_unlock();
 
-	net_stats_update_icmp_sent(net_pkt_iface(pkt));
+	net_stats_update_icmp_sent(iface);
 	net_stats_update_ipv6_nd_sent(iface);
 
 	return 0;
@@ -2135,7 +2135,7 @@ int net_ipv6_send_rs(struct net_if *iface)
 		goto drop;
 	}
 
-	net_stats_update_icmp_sent(net_pkt_iface(pkt));
+	net_stats_update_icmp_sent(iface);
 	net_stats_update_ipv6_nd_sent(iface);
 
 	return 0;


### PR DESCRIPTION
Backport aaed8332a62b0490a2f3c2cbabe272f575068eaa~5..aaed8332a62b0490a2f3c2cbabe272f575068eaa from #107100.

Fixes #107920

_Original PR description:_

---

Avoid accessing the packet after sending it, as the driver may have already unreferenced or freed it. Store the iface before sending instead of calling `net_pkt_iface()` on a potentially freed packet when updating packet statistics.

This fixes a few crashes due to use-after-free with `CONFIG_NET_STATISTICS=y`.