### PR TITLE
dts: atmel: add dac node to due

### DIFF
--- a/boards/arduino/due/arduino_due-pinctrl.dtsi
+++ b/boards/arduino/due/arduino_due-pinctrl.dtsi
@@ -80,4 +80,11 @@
 				 <PA16X_ADC_AD7>;
 		};
 	};
+
+	dacc_default: dacc_default {
+		group1 {
+			pinmux = <PB15X_DACC_DAC0>,
+				 <PB16X_DACC_DAC1>;
+		};
+	};
 };

--- a/boards/arduino/due/arduino_due.dts
+++ b/boards/arduino/due/arduino_due.dts
@@ -17,6 +17,7 @@
 		pwm-0 = &pwm0;
 		led0 = &yellow_led;
 		watchdog0 = &wdt;
+		dac-0 = &dacc;
 	};
 
 	chosen {
@@ -77,6 +78,13 @@
 	status = "okay";
 
 	pinctrl-0 = <&pwm0_default>;
+	pinctrl-names = "default";
+};
+
+&dacc {
+	status = "okay";
+
+	pinctrl-0 = <&dacc_default>;
 	pinctrl-names = "default";
 };
 

--- a/boards/arduino/due/arduino_due.yaml
+++ b/boards/arduino/due/arduino_due.yaml
@@ -10,6 +10,7 @@ ram: 96
 supported:
   - adc
   - arduino_i2c
+  - dac
   - gpio
   - watchdog
 vendor: arduino

--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -136,7 +136,11 @@ static int dac_sam_write_value(const struct device *dev, uint8_t channel,
 	k_sem_take(&dev_data->dac_channel.sem, K_FOREVER);
 
 	/* Select the channel */
+#if defined(CONFIG_SOC_SERIES_SAM4S) || defined(CONFIG_SOC_SERIES_SAM4E)
 	dac->DACC_MR = DACC_MR_USER_SEL(channel) | DACC_MR_ONE;
+#else
+	dac->DACC_MR = DACC_MR_USER_SEL(channel);
+#endif
 
 	/* Trigger conversion */
 	dac->DACC_CDR = DACC_CDR_DATA(value);

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -270,6 +270,15 @@
 			status = "disabled";
 		};
 
+		dacc: dacc@400c8000 {
+			compatible = "atmel,sam-dac";
+			reg = <0x400c8000 0x8000>;
+			interrupts = <38 1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 38>;
+			#io-channel-cells = <1>;
+			status = "disabled";
+		};
+
 		pwm0: pwm@40094000 {
 			compatible = "atmel,sam-pwm";
 			reg = <0x40094000 0x4000>;

--- a/samples/drivers/dac/boards/arduino_due.overlay
+++ b/samples/drivers/dac/boards/arduino_due.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dacc>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};


### PR DESCRIPTION
Add DAC0 node and associated pincontrols in sam3x and Arduino Due device trees.
This involves 2 small fixes:
* DACC_ONE bit does not exist for SAM3X / SAM3A
* DACC_MR_USER_SEL missing in the module SAM3X header (depends on https://github.com/zephyrproject-rtos/hal_atmel/pull/55 and its bump PR https://github.com/zephyrproject-rtos/zephyr/pull/111143)