### PR TITLE
sample: arduino due dac overlay 

### DIFF
--- a/samples/drivers/dac/boards/arduino_due.overlay
+++ b/samples/drivers/dac/boards/arduino_due.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dacc>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};


### PR DESCRIPTION
Adds the DAC feature to Arduino Due and adds it to samples.
Depends on https://github.com/zephyrproject-rtos/zephyr/pull/110663, and thus on https://github.com/zephyrproject-rtos/hal_atmel/pull/55 (and #111143)

