### PR TITLE
xtensa: mpu: one signature for xtensa_mpu_map_write()

### DIFF
--- a/arch/xtensa/core/mpu/mpu_core.c
+++ b/arch/xtensa/core/mpu/mpu_core.c
@@ -583,27 +583,12 @@ out:
  *
  * @param map Pointer to foreground MPU map.
  */
-#ifdef CONFIG_USERSPACE
-/* With userspace enabled, the pointer to per memory domain MPU map is stashed
- * inside the thread struct. If we still only take struct xtensa_mpu_map as
- * argument, a wrapper function is needed. To avoid the cost associated with
- * calling that wrapper function, takes thread pointer directly as argument
- * when userspace is enabled. Not to mention that writing the map to hardware
- * is already a costly operation per context switch. So every little bit helps.
- */
-void xtensa_mpu_map_write(struct k_thread *thread)
-#else
-void xtensa_mpu_map_write(struct xtensa_mpu_map *map)
-#endif
+static inline void mpu_map_write(struct xtensa_mpu_map *map)
 {
 	int entry;
 	k_spinlock_key_t key;
 
 	key = k_spin_lock(&xtensa_mpu_lock);
-
-#ifdef CONFIG_USERSPACE
-	struct xtensa_mpu_map *map = thread->arch.mpu_map;
-#endif
 
 	/*
 	 * Clear MPU entries first, then write MPU entries in reverse order.
@@ -626,6 +611,20 @@ void xtensa_mpu_map_write(struct xtensa_mpu_map *map)
 
 	k_spin_unlock(&xtensa_mpu_lock, key);
 }
+
+#ifdef CONFIG_USERSPACE
+/**
+ * Write the MPU map associated with the thread.
+ *
+ * @param thread Pointer to thread with MPU map.
+ */
+void xtensa_mpu_map_write(struct k_thread *thread)
+{
+	struct xtensa_mpu_map *map = thread->arch.mpu_map;
+
+	mpu_map_write(map);
+}
+#endif /* CONFIG_USERSPACE */
 
 /**
  * Perform necessary steps to enable MPU.
@@ -686,7 +685,7 @@ void xtensa_mpu_init(void)
 	dummy_map_thread.arch.mpu_map = &xtensa_mpu_map_fg_kernel;
 	xtensa_mpu_map_write(&dummy_map_thread);
 #else
-	xtensa_mpu_map_write(&xtensa_mpu_map_fg_kernel);
+	mpu_map_write(&xtensa_mpu_map_fg_kernel);
 #endif
 }
 

--- a/arch/xtensa/core/mpu/mpu_core.c
+++ b/arch/xtensa/core/mpu/mpu_core.c
@@ -1175,8 +1175,6 @@ void xtensa_user_stack_perms(struct k_thread *thread)
 				 XTENSA_MPU_ACCESS_P_RW_U_RW,
 				 NULL);
 
-	xtensa_mpu_map_write(thread);
-
 	/* Probably this fails due to no more available slots in MPU map. */
 	ARG_UNUSED(ret);
 	__ASSERT_NO_MSG(ret == 0);


### PR DESCRIPTION
Having different signature for `xtensa_mpu_map_write()` based on kconfig is error-prone. So fix that by separating it.

Also skip writing MPU map in `xtensa_mpu_map_write()` as the map is being written anyway this function finishes.