### PR TITLE
include: cpu_freq: add missing doxygen @file tags

### DIFF
--- a/include/zephyr/cpu_freq/cpu_freq.h
+++ b/include/zephyr/cpu_freq/cpu_freq.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup subsys_cpu_freq
+ * @brief Main header file for CPU frequency scaling API.
+ */
+
 #ifndef ZEPHYR_SUBSYS_CPU_FREQ_H_
 #define ZEPHYR_SUBSYS_CPU_FREQ_H_
 

--- a/include/zephyr/cpu_freq/policy.h
+++ b/include/zephyr/cpu_freq/policy.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup subsys_cpu_freq_policy
+ * @brief Header file for CPU frequency scaling policy.
+ */
+
 #ifndef ZEPHYR_SUBSYS_CPU_FREQ_POLICY_H_
 #define ZEPHYR_SUBSYS_CPU_FREQ_POLICY_H_
 

--- a/include/zephyr/cpu_freq/pstate.h
+++ b/include/zephyr/cpu_freq/pstate.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup subsys_cpu_freq_pstate
+ * @brief Header file for CPU frequency scaling performance state (P-state).
+ */
+
 #ifndef ZEPHYR_SUBSYS_CPU_FREQ_PSTATE_H_
 #define ZEPHYR_SUBSYS_CPU_FREQ_PSTATE_H_
 


### PR DESCRIPTION
Add missing doxygen `@file` tags to the CPU frequency scaling policy header files.