### PR TITLE
scripts: west_commands: allow several forward_logging_to_west() handlers

### DIFF
--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -23,8 +23,7 @@ import zcmake
 
 # Explicit, flat name: avoids colliding with scripts/pylib/build_helpers/
 # domains.py (which grabs `logging.getLogger('build_helpers')` at import
-# time), and avoids the `west.*` namespace whose NullHandler would defeat
-# the hasHandlers() guard in forward_logging_to_west.
+# time).
 BUILD_HELPERS_LOGGER = 'zephyr_build_helpers'
 _logger = logging.getLogger(BUILD_HELPERS_LOGGER)
 
@@ -79,18 +78,51 @@ def forward_logging_to_west(command, logger_names):
 
     ``logger_names`` may be a single logger name or an iterable of names.
 
-    Safe to call more than once: handlers are not duplicated.
+    This simply adds a custom handler to each logger. If you forget to
+    forward to any West command, then Python's ``logging.lastResort``
+    should still print warnings and higher to stderr while discarding
+    lower priorities, see the
+    https://docs.python.org/3/library/logging.html HOWTO for details.
+
+    While not tested, you could in theory forward to different West
+    commands at the same time. Forwarding multiple times to the _same_
+    West command will print an error and be ignored.
     '''
     if isinstance(logger_names, str):
         logger_names = [logger_names]
     for name in logger_names:
         logger = logging.getLogger(name)
-        # Drop DEBUG records at the logger unless the user asked for them,
-        # so they don't reach attached handlers (ours or anyone else's).
-        logger.setLevel(1 if command.verbosity >= Verbosity.DBG else logging.INFO)
-        if not logger.hasHandlers():
-            # Only add a log handler if none has been added already.
-            logger.addHandler(WestLogHandler(command))
+        _fwd_logger(logger, command)
+
+
+def _fwd_logger(logger, west_cmd):
+
+    # Note logger.handlers are only the _directly_ attached handlers,
+    # ignoring propagation up
+    for handler in logger.handlers:
+        match handler:
+            case WestLogHandler():
+                prev_cmd = handler._command
+                hdlr_print = f"WestLogHandler({prev_cmd.name})"
+                if prev_cmd == west_cmd:
+                    west_cmd.err(
+                        f"logger('{logger.name}') was already forwarded to {hdlr_print}!"
+                    )
+                    return
+            case _:
+                hdlr_print = f"{handler}"
+
+        west_cmd.dbg(f"logger('{logger.name}') already had handler: {hdlr_print}")
+
+    # Drop DEBUG records at the logger unless the user asked for them,
+    # so they don't reach attached handlers (ours or anyone else's).
+    logger.setLevel(1 if west_cmd.verbosity >= Verbosity.DBG else logging.INFO)
+
+    logger.addHandler(WestLogHandler(west_cmd))
+    # Use immediately.  This starts with "logger %(name)s" thanks
+    # to WestLogHandler.__init__() above
+    logger.debug(f"forwarded to WestLogHandler({west_cmd.name}). propagate={logger.propagate}")
+
 
 # Domains.py must be imported from the pylib directory, since
 # twister also uses the implementation

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -313,6 +313,9 @@ def do_run_common(command, user_args, user_runner_args, domain_file=None):
         if len(entry.boards) == 0:
             del used_cmds[i]
 
+    # Set up runner logging to delegate to the WestCommand logging methods.
+    forward_logging_to_west(command, 'runners')
+
     prev_runner = None
     for d in domains:
         prev_runner = do_run_common_image(command, user_args, user_runner_args, used_cmds,
@@ -341,9 +344,6 @@ def do_run_common_image(command, user_args, user_runner_args, used_cmds,
     runner_cls = use_runner_cls(command, board, user_args, runners_yaml,
                                 cache)
     runner_name = runner_cls.name()
-
-    # Set up runner logging to delegate to the WestCommand logging methods.
-    forward_logging_to_west(command, 'runners')
 
     # If the user passed -- to force the parent argument parser to stop
     # parsing, it will show up here, and needs to be filtered out.


### PR DESCRIPTION
`forward_logging_to_west()` just added by commit 5ac32bd7ddbe ("scripts: west_commands: bridge module loggers to WestCommand output") was silently doing nothing whenever the loggers already had one handler or more. This was inherited from the earlier code (which had a much narrower scope) to minimize changes in a big refactoring and migration but I can't find why it was like this. The design of https://docs.python.org/3/howto/logging.html is very clearly meant to support multiple handlers per logger and there is no reason to restrict that. Considering this new `forward_logging_to_west()` approach is likely to be used as a template for a more generic, non-Zephyr specific implementation/recommendation in
https://github.com/zephyrproject-rtos/west/issues/952, we don't want it to set the wrong example. So, remove that single-handler restriction and also add some... debug logs (!) inside forward_logging_to_west().

Print and error and return when trying to add the _same_ handler instance.