### PR TITLE
drivers: can: add Bouffalo Lab BL61x CAN (ISO11898) support

### DIFF
--- a/boards/bflb/bl61x/bl618g0/bl618g0-pinctrl.dtsi
+++ b/boards/bflb/bl61x/bl618g0/bl618g0-pinctrl.dtsi
@@ -5,6 +5,15 @@
  */
 
 &pinctrl {
+	can0_default: can0_default {
+		group1 {
+			pinmux = <GPIO16_CAN0_TX>,
+				 <GPIO17_CAN0_RX>;
+			bias-pull-up;
+			input-schmitt-enable;
+		};
+	};
+
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <GPIO22_UART0_RX>,

--- a/boards/bflb/bl61x/bl618g0/bl618g0.dts
+++ b/boards/bflb/bl61x/bl618g0/bl618g0.dts
@@ -23,6 +23,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,entropy = &sec_eng_trng;
 		zephyr,bt-hci = &bt_hci_bflb;
+		zephyr,canbus = &can0;
 	};
 
 	aliases {
@@ -128,6 +129,13 @@
 	pinctrl-0 = <&uart0_default>;
 	pinctrl-1 = <&uart0_sleep>;
 	pinctrl-names = "default", "sleep";
+};
+
+&can0 {
+	status = "okay";
+
+	pinctrl-0 = <&can0_default>;
+	pinctrl-names = "default";
 };
 
 &gpio0 {

--- a/boards/bflb/bl61x/bl618g0/bl618g0.yaml
+++ b/boards/bflb/bl61x/bl618g0/bl618g0.yaml
@@ -28,4 +28,5 @@ supported:
   - crypto
   - counter
   - sdhc
+  - can
 vendor: bflb

--- a/drivers/can/CMakeLists.txt
+++ b/drivers/can/CMakeLists.txt
@@ -19,6 +19,7 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE can_handlers.c)
 
 # CAN subsystem driver files
 # zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_CAN_BFLB_BL61X can_bflb_bl61x.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_ESP32_TWAI can_esp32_twai.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_ESP32_TWAIFD can_esp32_twaifd.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_FAKE can_fake.c)

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -121,6 +121,7 @@ config CAN_QEMU_IFACE_NAME
 source "drivers/can/transceiver/Kconfig"
 
 # zephyr-keep-sorted-start
+source "drivers/can/Kconfig.bflb"
 source "drivers/can/Kconfig.esp32"
 source "drivers/can/Kconfig.fake"
 source "drivers/can/Kconfig.infineon"

--- a/drivers/can/Kconfig.bflb
+++ b/drivers/can/Kconfig.bflb
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config CAN_BFLB_BL61X
+	bool "Bouffalo Lab BL61x CAN driver"
+	default y
+	depends on DT_HAS_BFLB_BL61X_CAN_ENABLED
+	select CAN_SJA1000
+	select PINCTRL
+	help
+	  Enable support for the Bouffalo Lab BL61x ISO11898 (SJA1000 compatible)
+	  classic CAN 2.0 controller.

--- a/drivers/can/can_bflb_bl61x.c
+++ b/drivers/can/can_bflb_bl61x.c
@@ -1,0 +1,187 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT bflb_bl61x_can
+
+#include "can_sja1000.h"
+
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
+#include <zephyr/logging/log.h>
+
+#include <zephyr/dt-bindings/clock/bflb_clock_common.h>
+
+#include <soc.h>
+#include <bflb_soc.h>
+#include <glb_reg.h>
+
+LOG_MODULE_REGISTER(can_bflb_bl61x, CONFIG_CAN_LOG_LEVEL);
+
+/*
+ * The BL61x ISO11898 controller is an NXP SJA1000 compatible PeliCAN core. Its
+ * 8-bit registers are mapped on a 32-bit word stride and it is clocked from the
+ * shared UART peripheral clock domain. CAN TX/RX are routed to GPIO pads through
+ * the UART signal multiplexer (handled by pinctrl), and the AHB clock is gated
+ * by GLB_CGEN_CFG1.
+ */
+
+/*
+ * ISO11898 AHB clock gate bit position within GLB_CGEN_CFG1. Matches the
+ * vendor SDK PERIPHERAL_CLOCK_CAN_ENABLE() macro (BL616/BL628), which sets
+ * bit 26 of GLB_CGEN_CFG1; no named symbol exists in the HAL register headers.
+ */
+#define CAN_BFLB_CGEN1_CAN_POS       26U
+/** SJA1000 8-bit registers are mapped on a 32-bit word stride. */
+#define CAN_BFLB_REG_STRIDE          sizeof(uint32_t)
+/** Mask selecting a single 8-bit SJA1000 register value. */
+#define CAN_BFLB_REG_MASK            0xFFU
+/** Minimum CAN bitrate supported by the controller, in bits per second. */
+#define CAN_BFLB_MIN_BITRATE         25000U
+/** Fixed prescaler applied internally by the SJA1000 bit timing logic. */
+#define CAN_BFLB_SJA1000_CLK_DIVIDER 2U
+
+struct can_bflb_config {
+	mem_addr_t base;
+	const struct pinctrl_dev_config *pcfg;
+	void (*irq_config_func)(const struct device *dev);
+};
+
+static uint8_t can_bflb_read_reg(const struct device *dev, uint8_t reg)
+{
+	const struct can_sja1000_config *sja1000_config = dev->config;
+	const struct can_bflb_config *bflb_config = sja1000_config->custom;
+	mem_addr_t addr = bflb_config->base + (reg * CAN_BFLB_REG_STRIDE);
+
+	return (uint8_t)(sys_read32(addr) & CAN_BFLB_REG_MASK);
+}
+
+static void can_bflb_write_reg(const struct device *dev, uint8_t reg, uint8_t val)
+{
+	const struct can_sja1000_config *sja1000_config = dev->config;
+	const struct can_bflb_config *bflb_config = sja1000_config->custom;
+	mem_addr_t addr = bflb_config->base + (reg * CAN_BFLB_REG_STRIDE);
+
+	sys_write32((uint32_t)val & CAN_BFLB_REG_MASK, addr);
+}
+
+static int can_bflb_get_core_clock(const struct device *dev, uint32_t *rate)
+{
+	const struct device *clock_dev = DEVICE_DT_GET_ANY(bflb_clock_controller);
+	uint32_t uart_div;
+	uint32_t bclk;
+	int err;
+
+	ARG_UNUSED(dev);
+
+	if (!device_is_ready(clock_dev)) {
+		return -ENODEV;
+	}
+
+	/*
+	 * The controller is fed by the UART peripheral clock, which the clock
+	 * controller sources from BCLK at boot; this reads the live UART divider
+	 * but assumes that BCLK source selection (it does not inspect the HBN
+	 * UART clock select). As with the NXP SJA1000, the bit timing logic
+	 * divides this input clock by 2 internally, so the effective core clock
+	 * used by the timing calculation is halved.
+	 */
+	uart_div = sys_read32(GLB_BASE + GLB_UART_CFG0_OFFSET);
+	uart_div = (uart_div & GLB_UART_CLK_DIV_MSK) >> GLB_UART_CLK_DIV_POS;
+
+	err = clock_control_get_rate(clock_dev, (void *)BFLB_CLKID_CLK_BCLK, &bclk);
+	if (err < 0) {
+		return err;
+	}
+
+	*rate = (bclk / (uart_div + 1U)) / CAN_BFLB_SJA1000_CLK_DIVIDER;
+
+	return 0;
+}
+
+static int can_bflb_init(const struct device *dev)
+{
+	const struct can_sja1000_config *sja1000_config = dev->config;
+	const struct can_bflb_config *bflb_config = sja1000_config->custom;
+	uint32_t regval;
+	int err;
+
+	err = pinctrl_apply_state(bflb_config->pcfg, PINCTRL_STATE_DEFAULT);
+	if (err != 0) {
+		LOG_ERR("failed to configure CAN pins (err %d)", err);
+		return err;
+	}
+
+	/* Enable the shared UART peripheral clock feeding the controller */
+	regval = sys_read32(GLB_BASE + GLB_UART_CFG0_OFFSET);
+	regval |= GLB_UART_CLK_EN_MSK;
+	sys_write32(regval, GLB_BASE + GLB_UART_CFG0_OFFSET);
+
+	/* Ungate the ISO11898 AHB clock */
+	regval = sys_read32(GLB_BASE + GLB_CGEN_CFG1_OFFSET);
+	regval |= BIT(CAN_BFLB_CGEN1_CAN_POS);
+	sys_write32(regval, GLB_BASE + GLB_CGEN_CFG1_OFFSET);
+
+	err = can_sja1000_init(dev);
+	if (err != 0) {
+		LOG_ERR("failed to initialize controller (err %d)", err);
+		return err;
+	}
+
+	bflb_config->irq_config_func(dev);
+
+	return 0;
+}
+
+static DEVICE_API(can, can_bflb_driver_api) = {
+	.get_capabilities = can_sja1000_get_capabilities,
+	.start = can_sja1000_start,
+	.stop = can_sja1000_stop,
+	.set_mode = can_sja1000_set_mode,
+	.set_timing = can_sja1000_set_timing,
+	.send = can_sja1000_send,
+	.add_rx_filter = can_sja1000_add_rx_filter,
+	.remove_rx_filter = can_sja1000_remove_rx_filter,
+	.get_state = can_sja1000_get_state,
+	.set_state_change_callback = can_sja1000_set_state_change_callback,
+	.get_core_clock = can_bflb_get_core_clock,
+	.get_max_filters = can_sja1000_get_max_filters,
+#ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
+	.recover = can_sja1000_recover,
+#endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
+	.timing_min = CAN_SJA1000_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_SJA1000_TIMING_MAX_INITIALIZER,
+};
+
+#define CAN_BFLB_INIT(inst)                                                                        \
+	PINCTRL_DT_INST_DEFINE(inst);                                                              \
+                                                                                                   \
+	static void can_bflb_irq_config_##inst(const struct device *dev)                           \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), can_sja1000_isr,      \
+			    DEVICE_DT_INST_GET(inst), 0);                                          \
+		irq_enable(DT_INST_IRQN(inst));                                                    \
+	}                                                                                          \
+                                                                                                   \
+	static const struct can_bflb_config can_bflb_config_##inst = {                             \
+		.base = DT_INST_REG_ADDR(inst),                                                    \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                      \
+		.irq_config_func = can_bflb_irq_config_##inst,                                     \
+	};                                                                                         \
+                                                                                                   \
+	static const struct can_sja1000_config can_sja1000_config_##inst =                         \
+		CAN_SJA1000_DT_CONFIG_INST_GET(inst, &can_bflb_config_##inst, can_bflb_read_reg,   \
+					       can_bflb_write_reg, CAN_SJA1000_OCR_OCMODE_NORMAL,  \
+					       CAN_SJA1000_CDR_CLOCK_OFF, CAN_BFLB_MIN_BITRATE);   \
+                                                                                                   \
+	static struct can_sja1000_data can_sja1000_data_##inst =                                   \
+		CAN_SJA1000_DATA_INITIALIZER(NULL);                                                \
+                                                                                                   \
+	CAN_DEVICE_DT_INST_DEFINE(inst, can_bflb_init, NULL, &can_sja1000_data_##inst,             \
+				  &can_sja1000_config_##inst, POST_KERNEL,                         \
+				  CONFIG_CAN_INIT_PRIORITY, &can_bflb_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(CAN_BFLB_INIT)

--- a/drivers/clock_control/clock_control_bl61x.c
+++ b/drivers/clock_control/clock_control_bl61x.c
@@ -1548,7 +1548,11 @@ static void clock_control_bl61x_peripheral_clock_init(void)
 	regval |= (1 << 22);
 	sys_write32(regval, GLB_BASE + GLB_CGEN_CFG2_OFFSET);
 
-	clock_control_bl61x_uart_set_clock(true, 0, 2);
+	/*
+	 * BCLK / 4 = 20 MHz. Must divide evenly into standard CAN bitrates:
+	 * the BL61x CAN controller core clock is the UART clock / 2.
+	 */
+	clock_control_bl61x_uart_set_clock(true, 0, 3);
 }
 
 static int clock_control_bl61x_on(const struct device *dev, clock_control_subsys_t sys)

--- a/dts/bindings/can/bflb,bl61x-can.yaml
+++ b/dts/bindings/can/bflb,bl61x-can.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+title: Bouffalo Lab BL61x CAN (ISO11898) controller
+
+description: |
+  This is an NXP SJA1000 compatible PeliCAN core supporting classic CAN 2.0A/2.0B
+  (standard 11-bit and extended 29-bit identifiers). It does not support CAN FD.
+
+  CAN TX/RX are routed to GPIO pads through the UART signal multiplexer. In the
+  bflb pinctrl bindings this is the "can0" pin function (UART pad function at
+  signal-mux instance 2), which is available on every UART-capable pin.
+
+compatible: "bflb,bl61x-can"
+
+include: [can-controller.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/pinctrl/bl618x-pinctrl.h>
+
+    &pinctrl {
+        can0_default: can0_default {
+            group1 {
+                pinmux = <GPIO16_CAN0_TX>,
+                         <GPIO17_CAN0_RX>;
+                bias-pull-up;
+                input-schmitt-enable;
+            };
+        };
+    };
+
+    &can0 {
+        status = "okay";
+
+        pinctrl-0 = <&can0_default>;
+        pinctrl-names = "default";
+
+        bitrate = <125000>;
+    };

--- a/dts/riscv/bflb/bl61x.dtsi
+++ b/dts/riscv/bflb/bl61x.dtsi
@@ -360,6 +360,15 @@
 			};
 		};
 
+		can0: can@2000aa00 {
+			compatible = "bflb,bl61x-can";
+			reg = <0x2000aa00 0x100>;
+			status = "disabled";
+
+			interrupts = <46 1>;
+			interrupt-parent = <&clic>;
+		};
+
 		sf_ctrl: sf@2000b000 {
 			compatible = "bflb,sf-controller";
 			reg = <0x2000b000 0x1000>;

--- a/tests/drivers/build_all/can/tests.yaml
+++ b/tests/drivers/build_all/can/tests.yaml
@@ -6,6 +6,9 @@ common:
 tests:
   # One test definition per CAN controller driver, listed in alphanumeric order.
   # Typically only one board needed per test definition, unless driver handles multiple IP variants.
+  drivers.can.build_all.bflb_bl61x:
+    platform_allow:
+      - bl618g0
   drivers.can.build_all.esp32_twai:
     platform_allow:
       - olimex_esp32_evb/esp32/procpu

--- a/west.yml
+++ b/west.yml
@@ -168,7 +168,7 @@ manifest:
         - hal
     - name: hal_bouffalolab
       path: modules/hal/bouffalolab
-      revision: 5d80bd5e43936dc0a8530dbfff94abe3a8e10e0d
+      revision: 6de5c882b3ea55c3a57cff5ab6debfc8ef2fff7f
       groups:
         - hal
     - name: hal_espressif


### PR DESCRIPTION
Add classic CAN 2.0 controller support for the Bouffalo Lab BL61x (BL616/BL618) SoCs.

The BL61x ISO11898 peripheral is an NXP SJA1000-compatible PeliCAN core, so the driver is a thin front-end over the shared `can_sja1000` driver:

- 8-bit SJA1000 registers are mapped on a 32-bit word stride, handled by custom read/write register callbacks.
- The controller is clocked from the shared UART peripheral clock domain; the SJA1000 bit-timing logic halves it internally, so the reported core clock is UART clock / 2.
- CAN TX/RX reach the GPIO pads through the UART signal multiplexer (function 7, instance 2), routed via the existing pinctrl driver.
- The ISO11898 AHB clock gate (GLB_CGEN_CFG1 bit 26) matches the vendor SDK `PERIPHERAL_CLOCK_CAN_ENABLE()`; the BL616/BL618 reference manual does not document this peripheral.

The boot-time UART clock divider is changed from BCLK/3 to BCLK/4 (80 MHz -> 20 MHz): the previous 26.67 MHz setting cannot be divided down to any standard CAN bitrate exactly, which made bit-timing calculation (and thus driver init) fail. The resulting 10 MHz CAN core clock divides evenly into all standard bitrates. The UART driver computes its baud divisor from the live divider, so console operation is unaffected.

## Testing

Tested on a BL618G0 board against a USB-CAN adapter at 125/250/500 kbit/s and 1 Mbit/s
Build `samples/subsys/shell/shell_module` with `CONFIG_CAN=y` and `CONFIG_CAN_SHELL=y`

### pinctrl
```ruby
can0_default: can0_default {
    group1 {
	    pinmux = <GPIO18_CAN2_TX>,
			    <GPIO19_CAN2_RX>;
	    bias-pull-up;
	    input-schmitt-enable;
    };
};
```

### dts
```ruby
/ {
	chosen {
		zephyr,canbus = &can0;
	};
};

&can0 {
	status = "okay";

	pinctrl-0 = <&can0_default>;
	pinctrl-names = "default";
};
```

### device
```bash
uart:~$ can bitrate can@2000aa00 500000
uart:~$ can start can@2000aa00
uart:~$ can send can@2000aa00 123 11 22 33
enqueuing CAN frame #0 with standard (11-bit) CAN ID 0x123, RTR 0, CAN FD 0, BRS 0, DLC 3
CAN frame #0 successfully sent
```

### host
``` bash
$ slcand -o -s6 /dev/serial/by-id/usb-Openlight_Labs_CANable2_*-if00 can0 # -s6 = 500 kbit/s
$ ip link set can0 up
$ candump -tz -c can0 
(000.000000)  can0  123   [3]  11 22 33
```