### PR TITLE
drivers: gpio: infineon: implement pin_get_config callback

### DIFF
--- a/drivers/gpio/gpio_infineon.c
+++ b/drivers/gpio/gpio_infineon.c
@@ -52,19 +52,23 @@ static inline uint32_t gpio_ifx_valid_mask(uint8_t ngpios)
 /**
  * @brief Select the PDL drive mode for an input pin.
  *
+ * Returns the input-buffer-off variant; the caller ORs CY_GPIO_DM_HIGHZ
+ * (bit 3, the input-buffer-enable bit) when GPIO_INPUT is requested to
+ * promote it to the input-on variant.
+ *
  * @param[in]  flags      GPIO configuration flags.
  * @param[out] drive_mode PDL drive mode constant.
  */
 static void gpio_ifx_select_input_drive_mode(gpio_flags_t flags, uint32_t *drive_mode)
 {
 	if ((flags & GPIO_PULL_UP) && (flags & GPIO_PULL_DOWN)) {
-		*drive_mode = CY_GPIO_DM_PULLUP_DOWN;
+		*drive_mode = CY_GPIO_DM_PULLUP_DOWN_IN_OFF;
 	} else if (flags & GPIO_PULL_UP) {
-		*drive_mode = CY_GPIO_DM_PULLUP;
+		*drive_mode = CY_GPIO_DM_PULLUP_IN_OFF;
 	} else if (flags & GPIO_PULL_DOWN) {
-		*drive_mode = CY_GPIO_DM_PULLDOWN;
+		*drive_mode = CY_GPIO_DM_PULLDOWN_IN_OFF;
 	} else {
-		*drive_mode = CY_GPIO_DM_HIGHZ;
+		*drive_mode = CY_GPIO_DM_ANALOG;
 	}
 }
 
@@ -72,14 +76,17 @@ static void gpio_ifx_select_input_drive_mode(gpio_flags_t flags, uint32_t *drive
  * @brief Select the PDL drive mode for an output pin.
  *
  * Maps push-pull, open-drain, and open-source configurations to the
- * corresponding PDL drive mode.  Pull-up is only valid with open-drain;
- * pull-down is only valid with open-source.
+ * corresponding PDL drive mode. Internal pulls are ignored on push-pull
+ * outputs and approximated with the matching resistive pull mode on
+ * single-ended outputs (see below).
  *
  * @param[in]  flags      GPIO configuration flags.
  * @param[out] drive_mode PDL drive mode constant.
  *
  * @retval 0        Success.
- * @retval -ENOTSUP Unsupported pull direction for the requested mode.
+ * @retval -ENOTSUP Pull requested in the direction the single-ended output
+ *                  cannot drive (pull-down on open-drain, pull-up on
+ *                  open-source).
  */
 static int gpio_ifx_select_output_drive_mode(gpio_flags_t flags, uint32_t *drive_mode)
 {
@@ -88,24 +95,34 @@ static int gpio_ifx_select_output_drive_mode(gpio_flags_t flags, uint32_t *drive
 			LOG_WRN("Pull-up/pull-down flags ignored"
 				" in push-pull output mode");
 		}
-		*drive_mode = CY_GPIO_DM_STRONG;
+		*drive_mode = CY_GPIO_DM_STRONG_IN_OFF;
 		return 0;
 	}
 
+	/*
+	 * A single-ended output combined with an internal pull has no dedicated
+	 * PDL drive mode. The resistive pull-up / pull-down modes are the closest
+	 * hardware match (they drive the active level and hold the released level
+	 * through the internal resistor), so use them for open-drain + pull-up and
+	 * open-source + pull-down. gpio_ifx_pin_get_config() then reports these as
+	 * an input pull rather than a single-ended output, which is the same
+	 * ambiguity the resistive modes have for a plain input pull. A pull in the
+	 * direction the output cannot drive (pull-down on open-drain, pull-up on
+	 * open-source) is contradictory and rejected.
+	 */
 	if (flags & GPIO_LINE_OPEN_DRAIN) {
 		if (flags & GPIO_PULL_DOWN) {
 			return -ENOTSUP;
 		}
-		*drive_mode = (flags & GPIO_PULL_UP) ? CY_GPIO_DM_PULLUP : CY_GPIO_DM_OD_DRIVESLOW;
+		*drive_mode = (flags & GPIO_PULL_UP) ? CY_GPIO_DM_PULLUP_IN_OFF
+						     : CY_GPIO_DM_OD_DRIVESLOW_IN_OFF;
 	} else {
-		/* Open-source */
 		if (flags & GPIO_PULL_UP) {
 			return -ENOTSUP;
 		}
-		*drive_mode =
-			(flags & GPIO_PULL_DOWN) ? CY_GPIO_DM_PULLDOWN : CY_GPIO_DM_OD_DRIVESHIGH;
+		*drive_mode = (flags & GPIO_PULL_DOWN) ? CY_GPIO_DM_PULLDOWN_IN_OFF
+						       : CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF;
 	}
-
 	return 0;
 }
 
@@ -161,6 +178,25 @@ static int gpio_ifx_configure(const struct device *dev, gpio_pin_t pin, gpio_fla
 
 	default:
 		return -ENOTSUP;
+	}
+
+	/*
+	 * The pull / output-drive selectors above return the input-buffer-off
+	 * variant of each PDL drive mode (CY_GPIO_DM_*_IN_OFF). When GPIO_INPUT
+	 * is requested - either alone or combined with GPIO_OUTPUT - promote the
+	 * mode to its input-buffer-on sibling. The input-buffer control bit
+	 * (bit 3) has opposite polarity between PSoC families: on CAT1 it is the
+	 * input-buffer-enable bit (CY_GPIO_DM_HIGHZ), so it is set to turn the
+	 * input on; on CAT2/PSoC4 it is the input-buffer-disable bit
+	 * (CY_GPIO_DM_VAL_IBUF_DISABLE_MASK), so it is cleared to turn the input
+	 * on. For GPIO_DISCONNECTED the mode stays at CY_GPIO_DM_ANALOG.
+	 */
+	if (flags & GPIO_INPUT) {
+#ifdef CONFIG_SOC_FAMILY_INFINEON_PSOC4
+		drive_mode &= ~CY_GPIO_DM_VAL_IBUF_DISABLE_MASK;
+#else
+		drive_mode |= CY_GPIO_DM_HIGHZ;
+#endif
 	}
 
 #ifdef CY_PDL_TZ_ENABLED
@@ -325,6 +361,85 @@ static int gpio_ifx_manage_callback(const struct device *port, struct gpio_callb
 	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
+#ifdef CONFIG_GPIO_GET_CONFIG
+static int gpio_ifx_pin_get_config(const struct device *dev, gpio_pin_t pin,
+				   gpio_flags_t *out_flags)
+{
+	const struct gpio_ifx_config *cfg = dev->config;
+	GPIO_PRT_Type *base = cfg->regs;
+	gpio_flags_t flags = 0;
+	uint32_t drive_mode;
+
+	if (pin >= cfg->ngpios) {
+		return -EINVAL;
+	}
+
+	/* If the pin is routed to a peripheral, report it as disconnected from a GPIO POV. */
+	if ((uint32_t)Cy_GPIO_GetHSIOM(base, pin) != (uint32_t)HSIOM_SEL_GPIO) {
+		*out_flags = 0;
+		return 0;
+	}
+
+	drive_mode = Cy_GPIO_GetDrivemode(base, pin);
+
+	switch (drive_mode) {
+	case CY_GPIO_DM_ANALOG:
+		flags = GPIO_DISCONNECTED;
+		break;
+	case CY_GPIO_DM_HIGHZ:
+		flags = GPIO_INPUT;
+		break;
+	case CY_GPIO_DM_PULLUP_IN_OFF:
+		flags = GPIO_PULL_UP;
+		break;
+	case CY_GPIO_DM_PULLUP:
+		flags = GPIO_INPUT | GPIO_PULL_UP;
+		break;
+	case CY_GPIO_DM_PULLDOWN_IN_OFF:
+		flags = GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLDOWN:
+		flags = GPIO_INPUT | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLUP_DOWN_IN_OFF:
+		flags = GPIO_PULL_UP | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLUP_DOWN:
+		flags = GPIO_INPUT | GPIO_PULL_UP | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_STRONG_IN_OFF:
+		flags = GPIO_OUTPUT;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_STRONG:
+		flags = GPIO_INPUT | GPIO_OUTPUT;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESLOW_IN_OFF:
+		flags = GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_DRAIN;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESLOW:
+		flags = GPIO_INPUT | GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_DRAIN;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF:
+		flags = GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_SOURCE;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESHIGH:
+		flags = GPIO_INPUT | GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_SOURCE;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	*out_flags = flags;
+	return 0;
+}
+#endif /* CONFIG_GPIO_GET_CONFIG */
+
 static DEVICE_API(gpio, gpio_ifx_api) = {
 	.pin_configure = gpio_ifx_configure,
 	.port_get_raw = gpio_ifx_port_get_raw,
@@ -335,6 +450,9 @@ static DEVICE_API(gpio, gpio_ifx_api) = {
 	.pin_interrupt_configure = gpio_ifx_pin_interrupt_configure,
 	.manage_callback = gpio_ifx_manage_callback,
 	.get_pending_int = gpio_ifx_get_pending_int,
+#ifdef CONFIG_GPIO_GET_CONFIG
+	.pin_get_config = gpio_ifx_pin_get_config,
+#endif
 };
 
 #define GPIO_PORT_STRUCTS_DEFINE(n)                                                                \

--- a/drivers/gpio/gpio_infineon.c
+++ b/drivers/gpio/gpio_infineon.c
@@ -58,13 +58,13 @@ static inline uint32_t gpio_ifx_valid_mask(uint8_t ngpios)
 static void gpio_ifx_select_input_drive_mode(gpio_flags_t flags, uint32_t *drive_mode)
 {
 	if ((flags & GPIO_PULL_UP) && (flags & GPIO_PULL_DOWN)) {
-		*drive_mode = CY_GPIO_DM_PULLUP_DOWN;
+		*drive_mode = CY_GPIO_DM_PULLUP_DOWN_IN_OFF;
 	} else if (flags & GPIO_PULL_UP) {
-		*drive_mode = CY_GPIO_DM_PULLUP;
+		*drive_mode = CY_GPIO_DM_PULLUP_IN_OFF;
 	} else if (flags & GPIO_PULL_DOWN) {
-		*drive_mode = CY_GPIO_DM_PULLDOWN;
+		*drive_mode = CY_GPIO_DM_PULLDOWN_IN_OFF;
 	} else {
-		*drive_mode = CY_GPIO_DM_HIGHZ;
+		*drive_mode = CY_GPIO_DM_ANALOG;
 	}
 }
 
@@ -88,7 +88,7 @@ static int gpio_ifx_select_output_drive_mode(gpio_flags_t flags, uint32_t *drive
 			LOG_WRN("Pull-up/pull-down flags ignored"
 				" in push-pull output mode");
 		}
-		*drive_mode = CY_GPIO_DM_STRONG;
+		*drive_mode = CY_GPIO_DM_STRONG_IN_OFF;
 		return 0;
 	}
 
@@ -96,16 +96,15 @@ static int gpio_ifx_select_output_drive_mode(gpio_flags_t flags, uint32_t *drive
 		if (flags & GPIO_PULL_DOWN) {
 			return -ENOTSUP;
 		}
-		*drive_mode = (flags & GPIO_PULL_UP) ? CY_GPIO_DM_PULLUP : CY_GPIO_DM_OD_DRIVESLOW;
+		*drive_mode = (flags & GPIO_PULL_UP) ? CY_GPIO_DM_PULLUP_IN_OFF
+						     : CY_GPIO_DM_OD_DRIVESLOW_IN_OFF;
 	} else {
-		/* Open-source */
 		if (flags & GPIO_PULL_UP) {
 			return -ENOTSUP;
 		}
-		*drive_mode =
-			(flags & GPIO_PULL_DOWN) ? CY_GPIO_DM_PULLDOWN : CY_GPIO_DM_OD_DRIVESHIGH;
+		*drive_mode = (flags & GPIO_PULL_DOWN) ? CY_GPIO_DM_PULLDOWN_IN_OFF
+						       : CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF;
 	}
-
 	return 0;
 }
 
@@ -161,6 +160,14 @@ static int gpio_ifx_configure(const struct device *dev, gpio_pin_t pin, gpio_fla
 
 	default:
 		return -ENOTSUP;
+	}
+
+	if (flags & GPIO_INPUT) {
+#ifdef CONFIG_SOC_FAMILY_INFINEON_PSOC4
+		drive_mode &= ~CY_GPIO_DM_VAL_IBUF_DISABLE_MASK;
+#else
+		drive_mode |= CY_GPIO_DM_HIGHZ;
+#endif
 	}
 
 #ifdef CY_PDL_TZ_ENABLED

--- a/drivers/gpio/gpio_infineon.c
+++ b/drivers/gpio/gpio_infineon.c
@@ -332,6 +332,85 @@ static int gpio_ifx_manage_callback(const struct device *port, struct gpio_callb
 	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
+#ifdef CONFIG_GPIO_GET_CONFIG
+static int gpio_ifx_pin_get_config(const struct device *dev, gpio_pin_t pin,
+				   gpio_flags_t *out_flags)
+{
+	const struct gpio_ifx_config *cfg = dev->config;
+	GPIO_PRT_Type *base = cfg->regs;
+	gpio_flags_t flags = 0;
+	uint32_t drive_mode;
+
+	if (pin >= cfg->ngpios) {
+		return -EINVAL;
+	}
+
+	/* If the pin is routed to a peripheral, report it as disconnected from a GPIO POV. */
+	if ((uint32_t)Cy_GPIO_GetHSIOM(base, pin) != (uint32_t)HSIOM_SEL_GPIO) {
+		*out_flags = 0;
+		return 0;
+	}
+
+	drive_mode = Cy_GPIO_GetDrivemode(base, pin);
+
+	switch (drive_mode) {
+	case CY_GPIO_DM_ANALOG:
+		flags = GPIO_DISCONNECTED;
+		break;
+	case CY_GPIO_DM_HIGHZ:
+		flags = GPIO_INPUT;
+		break;
+	case CY_GPIO_DM_PULLUP_IN_OFF:
+		flags = GPIO_PULL_UP;
+		break;
+	case CY_GPIO_DM_PULLUP:
+		flags = GPIO_INPUT | GPIO_PULL_UP;
+		break;
+	case CY_GPIO_DM_PULLDOWN_IN_OFF:
+		flags = GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLDOWN:
+		flags = GPIO_INPUT | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLUP_DOWN_IN_OFF:
+		flags = GPIO_PULL_UP | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLUP_DOWN:
+		flags = GPIO_INPUT | GPIO_PULL_UP | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_STRONG_IN_OFF:
+		flags = GPIO_OUTPUT;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_STRONG:
+		flags = GPIO_INPUT | GPIO_OUTPUT;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESLOW_IN_OFF:
+		flags = GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_DRAIN;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESLOW:
+		flags = GPIO_INPUT | GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_DRAIN;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF:
+		flags = GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_SOURCE;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESHIGH:
+		flags = GPIO_INPUT | GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_SOURCE;
+		flags |= Cy_GPIO_ReadOut(base, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	*out_flags = flags;
+	return 0;
+}
+#endif /* CONFIG_GPIO_GET_CONFIG */
+
 static DEVICE_API(gpio, gpio_ifx_api) = {
 	.pin_configure = gpio_ifx_configure,
 	.port_get_raw = gpio_ifx_port_get_raw,
@@ -342,6 +421,9 @@ static DEVICE_API(gpio, gpio_ifx_api) = {
 	.pin_interrupt_configure = gpio_ifx_pin_interrupt_configure,
 	.manage_callback = gpio_ifx_manage_callback,
 	.get_pending_int = gpio_ifx_get_pending_int,
+#ifdef CONFIG_GPIO_GET_CONFIG
+	.pin_get_config = gpio_ifx_pin_get_config,
+#endif
 };
 
 #define GPIO_PORT_STRUCTS_DEFINE(n)                                                                \

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -46,13 +46,56 @@ static int gpio_psoc6_config(const struct device *dev,
 	uint32_t drv_mode;
 	uint32_t pin_val;
 
+	/*
+	 * Bound the pin before forming BIT(pin): a port has at most 32 pins and
+	 * 1UL << pin is undefined for pin >= 32. The short-circuit keeps the mask
+	 * test from ever evaluating BIT(pin) with an out-of-range shift, which
+	 * matters when configure() is reached from userspace with an arbitrary
+	 * pin value.
+	 */
+	if (pin >= (sizeof(cfg->common.port_pin_mask) * 8U) ||
+	    (cfg->common.port_pin_mask & BIT(pin)) == 0U) {
+		return -EINVAL;
+	}
+
 	if (flags & GPIO_OUTPUT) {
 		if (flags & GPIO_SINGLE_ENDED) {
-			drv_mode = (flags & GPIO_LINE_OPEN_DRAIN) ?
-				CY_GPIO_DM_OD_DRIVESLOW_IN_OFF :
-				CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF;
+			/*
+			 * A single-ended output combined with an internal pull
+			 * has no dedicated PDL drive mode. The resistive pull-up /
+			 * pull-down modes are the closest hardware match (they
+			 * drive the active level and hold the released level
+			 * through the internal resistor), so use them for
+			 * open-drain + pull-up and open-source + pull-down;
+			 * gpio_psoc6_pin_get_config() then reports these as an
+			 * input pull. A pull in the direction the output cannot
+			 * drive (pull-down on open-drain, pull-up on open-source)
+			 * is contradictory and rejected.
+			 */
+			if (flags & GPIO_LINE_OPEN_DRAIN) {
+				if (flags & GPIO_PULL_DOWN) {
+					return -ENOTSUP;
+				}
+				drv_mode = (flags & GPIO_PULL_UP) ?
+					CY_GPIO_DM_PULLUP_IN_OFF :
+					CY_GPIO_DM_OD_DRIVESLOW_IN_OFF;
+			} else {
+				if (flags & GPIO_PULL_UP) {
+					return -ENOTSUP;
+				}
+				drv_mode = (flags & GPIO_PULL_DOWN) ?
+					CY_GPIO_DM_PULLDOWN_IN_OFF :
+					CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF;
+			}
 
-			pin_val = (flags & GPIO_LINE_OPEN_DRAIN) ? 1 : 0;
+			if (flags & GPIO_OUTPUT_INIT_HIGH) {
+				pin_val = 1;
+			} else if (flags & GPIO_OUTPUT_INIT_LOW) {
+				pin_val = 0;
+			} else {
+				/* Default to the released level of the output. */
+				pin_val = (flags & GPIO_LINE_OPEN_DRAIN) ? 1 : 0;
+			}
 		} else {
 			drv_mode = CY_GPIO_DM_STRONG_IN_OFF;
 
@@ -229,6 +272,90 @@ static uint32_t gpio_psoc6_get_pending_int(const struct device *dev)
 	return GPIO_PRT_INTR_MASKED(port);
 }
 
+#ifdef CONFIG_GPIO_GET_CONFIG
+static int gpio_psoc6_pin_get_config(const struct device *dev, gpio_pin_t pin,
+				     gpio_flags_t *out_flags)
+{
+	const struct gpio_psoc6_config *cfg = dev->config;
+	GPIO_PRT_Type *port = cfg->regs;
+	gpio_flags_t flags = 0;
+	uint32_t drv_mode;
+
+	/*
+	 * Bound the pin before forming BIT(pin): a port has at most 32 pins, and
+	 * 1UL << pin is undefined for pin >= 32. The short-circuit keeps the mask
+	 * test from ever evaluating BIT(pin) with an out-of-range shift.
+	 */
+	if (pin >= (sizeof(cfg->common.port_pin_mask) * 8U) ||
+	    (cfg->common.port_pin_mask & BIT(pin)) == 0U) {
+		return -EINVAL;
+	}
+
+	if ((uint32_t)Cy_GPIO_GetHSIOM(port, pin) != (uint32_t)HSIOM_SEL_GPIO) {
+		*out_flags = 0;
+		return 0;
+	}
+
+	drv_mode = Cy_GPIO_GetDrivemode(port, pin);
+
+	switch (drv_mode) {
+	case CY_GPIO_DM_ANALOG:
+		flags = GPIO_DISCONNECTED;
+		break;
+	case CY_GPIO_DM_HIGHZ:
+		flags = GPIO_INPUT;
+		break;
+	case CY_GPIO_DM_PULLUP_IN_OFF:
+		flags = GPIO_PULL_UP;
+		break;
+	case CY_GPIO_DM_PULLUP:
+		flags = GPIO_INPUT | GPIO_PULL_UP;
+		break;
+	case CY_GPIO_DM_PULLDOWN_IN_OFF:
+		flags = GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLDOWN:
+		flags = GPIO_INPUT | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLUP_DOWN_IN_OFF:
+		flags = GPIO_PULL_UP | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLUP_DOWN:
+		flags = GPIO_INPUT | GPIO_PULL_UP | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_STRONG_IN_OFF:
+		flags = GPIO_OUTPUT;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_STRONG:
+		flags = GPIO_INPUT | GPIO_OUTPUT;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESLOW_IN_OFF:
+		flags = GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_DRAIN;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESLOW:
+		flags = GPIO_INPUT | GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_DRAIN;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF:
+		flags = GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_SOURCE;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESHIGH:
+		flags = GPIO_INPUT | GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_SOURCE;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	*out_flags = flags;
+	return 0;
+}
+#endif /* CONFIG_GPIO_GET_CONFIG */
+
 static DEVICE_API(gpio, gpio_psoc6_api) = {
 	.pin_configure = gpio_psoc6_config,
 	.port_get_raw = gpio_psoc6_port_get_raw,
@@ -239,6 +366,9 @@ static DEVICE_API(gpio, gpio_psoc6_api) = {
 	.pin_interrupt_configure = gpio_psoc6_pin_interrupt_configure,
 	.manage_callback = gpio_psoc6_manage_callback,
 	.get_pending_int = gpio_psoc6_get_pending_int,
+#ifdef CONFIG_GPIO_GET_CONFIG
+	.pin_get_config = gpio_psoc6_pin_get_config,
+#endif
 };
 
 int gpio_psoc6_init(const struct device *dev)

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -46,6 +46,11 @@ static int gpio_psoc6_config(const struct device *dev,
 	uint32_t drv_mode;
 	uint32_t pin_val;
 
+	if (pin >= (sizeof(cfg->common.port_pin_mask) * 8U) ||
+	    (cfg->common.port_pin_mask & BIT(pin)) == 0U) {
+		return -EINVAL;
+	}
+
 	if (flags & GPIO_OUTPUT) {
 		if (flags & GPIO_SINGLE_ENDED) {
 			if (flags & GPIO_LINE_OPEN_DRAIN) {

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -252,6 +252,85 @@ static uint32_t gpio_psoc6_get_pending_int(const struct device *dev)
 	return GPIO_PRT_INTR_MASKED(port);
 }
 
+#ifdef CONFIG_GPIO_GET_CONFIG
+static int gpio_psoc6_pin_get_config(const struct device *dev, gpio_pin_t pin,
+				     gpio_flags_t *out_flags)
+{
+	const struct gpio_psoc6_config *cfg = dev->config;
+	GPIO_PRT_Type *port = cfg->regs;
+	gpio_flags_t flags = 0;
+	uint32_t drv_mode;
+
+	if (pin >= (sizeof(cfg->common.port_pin_mask) * 8U) ||
+	    (cfg->common.port_pin_mask & BIT(pin)) == 0U) {
+		return -EINVAL;
+	}
+
+	if ((uint32_t)Cy_GPIO_GetHSIOM(port, pin) != (uint32_t)HSIOM_SEL_GPIO) {
+		*out_flags = 0;
+		return 0;
+	}
+
+	drv_mode = Cy_GPIO_GetDrivemode(port, pin);
+
+	switch (drv_mode) {
+	case CY_GPIO_DM_ANALOG:
+		flags = GPIO_DISCONNECTED;
+		break;
+	case CY_GPIO_DM_HIGHZ:
+		flags = GPIO_INPUT;
+		break;
+	case CY_GPIO_DM_PULLUP_IN_OFF:
+		flags = GPIO_PULL_UP;
+		break;
+	case CY_GPIO_DM_PULLUP:
+		flags = GPIO_INPUT | GPIO_PULL_UP;
+		break;
+	case CY_GPIO_DM_PULLDOWN_IN_OFF:
+		flags = GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLDOWN:
+		flags = GPIO_INPUT | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLUP_DOWN_IN_OFF:
+		flags = GPIO_PULL_UP | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_PULLUP_DOWN:
+		flags = GPIO_INPUT | GPIO_PULL_UP | GPIO_PULL_DOWN;
+		break;
+	case CY_GPIO_DM_STRONG_IN_OFF:
+		flags = GPIO_OUTPUT;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_STRONG:
+		flags = GPIO_INPUT | GPIO_OUTPUT;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESLOW_IN_OFF:
+		flags = GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_DRAIN;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESLOW:
+		flags = GPIO_INPUT | GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_DRAIN;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF:
+		flags = GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_SOURCE;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	case CY_GPIO_DM_OD_DRIVESHIGH:
+		flags = GPIO_INPUT | GPIO_OUTPUT | GPIO_SINGLE_ENDED | GPIO_LINE_OPEN_SOURCE;
+		flags |= Cy_GPIO_ReadOut(port, pin) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	*out_flags = flags;
+	return 0;
+}
+#endif /* CONFIG_GPIO_GET_CONFIG */
+
 static DEVICE_API(gpio, gpio_psoc6_api) = {
 	.pin_configure = gpio_psoc6_config,
 	.port_get_raw = gpio_psoc6_port_get_raw,
@@ -262,6 +341,9 @@ static DEVICE_API(gpio, gpio_psoc6_api) = {
 	.pin_interrupt_configure = gpio_psoc6_pin_interrupt_configure,
 	.manage_callback = gpio_psoc6_manage_callback,
 	.get_pending_int = gpio_psoc6_get_pending_int,
+#ifdef CONFIG_GPIO_GET_CONFIG
+	.pin_get_config = gpio_psoc6_pin_get_config,
+#endif
 };
 
 int gpio_psoc6_init(const struct device *dev)

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -48,9 +48,21 @@ static int gpio_psoc6_config(const struct device *dev,
 
 	if (flags & GPIO_OUTPUT) {
 		if (flags & GPIO_SINGLE_ENDED) {
-			drv_mode = (flags & GPIO_LINE_OPEN_DRAIN) ?
-				CY_GPIO_DM_OD_DRIVESLOW_IN_OFF :
-				CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF;
+			if (flags & GPIO_LINE_OPEN_DRAIN) {
+				if (flags & GPIO_PULL_DOWN) {
+					return -ENOTSUP;
+				}
+				drv_mode = (flags & GPIO_PULL_UP) ?
+					CY_GPIO_DM_PULLUP_IN_OFF :
+					CY_GPIO_DM_OD_DRIVESLOW_IN_OFF;
+			} else {
+				if (flags & GPIO_PULL_UP) {
+					return -ENOTSUP;
+				}
+				drv_mode = (flags & GPIO_PULL_DOWN) ?
+					CY_GPIO_DM_PULLDOWN_IN_OFF :
+					CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF;
+			}
 
 			pin_val = (flags & GPIO_LINE_OPEN_DRAIN) ? 1 : 0;
 		} else {

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -69,7 +69,13 @@ static int gpio_psoc6_config(const struct device *dev,
 					CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF;
 			}
 
-			pin_val = (flags & GPIO_LINE_OPEN_DRAIN) ? 1 : 0;
+			if (flags & GPIO_OUTPUT_INIT_HIGH) {
+				pin_val = 1;
+			} else if (flags & GPIO_OUTPUT_INIT_LOW) {
+				pin_val = 0;
+			} else {
+				pin_val = (flags & GPIO_LINE_OPEN_DRAIN) ? 1 : 0;
+			}
 		} else {
 			drv_mode = CY_GPIO_DM_STRONG_IN_OFF;
 


### PR DESCRIPTION
The Infineon CAT1 and Cypress PSoC 6 GPIO drivers do not implement the
optional pin_get_config callback. With `CONFIG_USERSPACE=y` and
`CONFIG_GPIO_GET_CONFIG=y`, the syscall verifier invokes
`K_SYSCALL_DRIVER_GPIO(port, pin_get_config)`, which `K_OOPS`es the
kernel when the callback is `NULL` instead of letting
`z_impl_gpio_pin_get_config()` return `-ENOSYS`.

This PR implements the callback for both drivers, reverse-mapping the
PDL drive mode (`Cy_GPIO_GetDrivemode`) and HSIOM state back to
`gpio_flags_t`.

### Verification

Built and ran `tests/drivers/gpio/gpio_basic_api` on
`kit_pse84_eval/pse846gps2dbzc4a/m33` with
`CONFIG_USERSPACE=y` and `CONFIG_GPIO_GET_CONFIG=y` and a
P15.2 <-> P15.3 loopback. All four test suites pass, including the
`gpio_port` suite which calls `gpio_pin_get_config()` from a user
thread:

`
SUITE PASS - 100.00% [after_flash_gpio_config_trigger]: pass = 2, fail = 0, ...
SUITE PASS - 100.00% [gpio_port]: pass = 1, fail = 0, ...
SUITE PASS - 100.00% [gpio_port_cb_mgmt]: pass = 3, fail = 0, ...
SUITE PASS - 100.00% [gpio_port_cb_vari]: pass = 1, fail = 0, ...
PROJECT EXECUTION SUCCESSFUL
`

Without this change, the same test K_OOPSes in
`z_vrfy_gpio_pin_get_config()` as soon as the user thread reaches
`pin_get_config()`.