### PR TITLE
boards: arduino: add heap on boards with wifi

### DIFF
--- a/boards/arduino/giga_r1/Kconfig.defconfig
+++ b/boards/arduino/giga_r1/Kconfig.defconfig
@@ -19,4 +19,12 @@ endchoice
 
 endif # BT
 
+if WIFI_AIROC
+
+config HEAP_MEM_POOL_ADD_SIZE_BOARD
+	int
+	default 20480
+
+endif # WIFI_AIROC
+
 endif # BOARD_ARDUINO_GIGA_R1

--- a/boards/arduino/nicla_vision/Kconfig.defconfig
+++ b/boards/arduino/nicla_vision/Kconfig.defconfig
@@ -19,4 +19,12 @@ endchoice
 
 endif # BT
 
+if WIFI_AIROC
+
+config HEAP_MEM_POOL_ADD_SIZE_BOARD
+	int
+	default 20480
+
+endif # WIFI_AIROC
+
 endif # BOARD_ARDUINO_NICLA_VISION

--- a/boards/arduino/opta/Kconfig.defconfig
+++ b/boards/arduino/opta/Kconfig.defconfig
@@ -13,4 +13,12 @@ source "boards/common/usb/Kconfig.cdc_acm_serial.defconfig"
 
 endif # BOARD_ARDUINO_OPTA_STM32H747XX_M7
 
+if WIFI_AIROC
+
+config HEAP_MEM_POOL_ADD_SIZE_BOARD
+	int
+	default 20480
+
+endif # WIFI_AIROC
+
 endif # BOARD_ARDUINO_OPTA

--- a/boards/arduino/portenta_h7/Kconfig.defconfig
+++ b/boards/arduino/portenta_h7/Kconfig.defconfig
@@ -15,6 +15,14 @@ source "boards/common/usb/Kconfig.cdc_acm_serial.defconfig"
 
 endif # BOARD_ARDUINO_PORTENTA_H7_STM32H747XX_M7
 
+if WIFI_AIROC
+
+config HEAP_MEM_POOL_ADD_SIZE_BOARD
+	int
+	default 20480
+
+endif # WIFI_AIROC
+
 endif # BOARD_ARDUINO_PORTENTA_H7
 
 if BT


### PR DESCRIPTION
The wifi driver on these boards rely on dynamic memory, wifi samples fail to build without it. Rpi pico boards set 16k with this but some tests seems to show it uses just shy of that, set to 20k to keep some margin.