### PR TITLE
ESP32 ADC fixes and improvements: adc_read_async, adc_stream

### DIFF
--- a/drivers/adc/Kconfig.esp32
+++ b/drivers/adc/Kconfig.esp32
@@ -1,4 +1,5 @@
 # Copyright (c) 2022 Wolter HV <wolterhv@gmx.de>
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -16,5 +17,79 @@ config ADC_ESP32_DMA
 	select DMA if DT_HAS_ESPRESSIF_ESP32_GDMA_ENABLED
 	help
 	  Enable the ADC DMA mode
+
+config ADC_ESP32_DMA_BUFFER_SIZE
+	int "ESP32 ADC DMA capture buffer size (bytes)"
+	depends on ADC_ESP32_DMA
+	default 8192 if ADC_ESP32_STREAM
+	default 4092
+	range 4092 32768
+	help
+	  Internal DMA buffer for ADC continuous captures. Must be large enough
+	  for the largest sequence:
+	  (1 + extra_samplings) x channels x capture_factor x bytes_per_conv.
+	  Values above 4092 use multiple linked DMA descriptors.
+
+choice ADC_ESP32_DMA_DECODE
+	prompt "DMA sample decoding"
+	depends on ADC_ESP32_DMA
+	default ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED
+	help
+	  How DMA captures are packed for adc_read/adc_read_async and adc_stream.
+
+config ADC_ESP32_DMA_DECODE_COUNTS
+	bool "Raw ADC counts with no calibration and no voltage conversion"
+	help
+	  Store raw ADC counts in the application buffer. The stream decoder
+	  passes counts through as q31 values without calibration, channel
+	  attenuation scaling, or internal reference conversion.
+
+config ADC_ESP32_DMA_DECODE_VOLTAGE_LINEAR
+	bool "Linear pin voltage with attenuation scaling, but no calibration"
+	help
+	  Store raw ADC counts in the application buffer. The stream decoder
+	  scales the internal reference by the channel attenuation before
+	  converting to q31 voltage. adc_read applications use
+	  adc_raw_to_millivolts_dt() with the channel gain from devicetree.
+
+config ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED
+	bool "Calibrated pin voltage with calibration and attenuation scaling"
+	help
+	  Convert each raw sample to calibrated pin voltage when the DMA buffer
+	  is packed using adc_cali_raw_to_voltage, then normalize counts the
+	  same way as oneshot reads. The stream decoder scales the internal
+	  reference by channel attenuation before converting to q31 voltage.
+
+endchoice
+
+config ADC_ESP32_STREAM
+	bool "ESP32 ADC RTIO streaming (adc_stream)"
+	depends on ADC_STREAM
+	select ADC_ESP32_DMA
+	default y
+	help
+	  Enable adc_stream()/RTIO submissions using DMA bursts. Each multishot
+	  iteration completes one SAR pattern cycle (hardware schedule of selected
+	  channels).
+
+if ADC_ESP32_STREAM
+
+config ADC_ESP32_STREAM_RTIO_WQ_STACK_SIZE
+	int "ESP32 ADC stream RTIO workqueue stack size"
+	default 8192
+	range 1024 32768
+	help
+	  Stack size for the dedicated workqueue that completes RTIO stream
+	  frames.
+
+config ADC_ESP32_STREAM_RTIO_WQ_PRIORITY
+	int "ESP32 ADC stream RTIO workqueue priority"
+	default -1
+	range -256 -1
+	help
+	  Thread priority for the stream RTIO workqueue. Must be a cooperative
+	  priority in the range -NUM_COOP_PRIORITIES through -1.
+
+endif # ADC_ESP32_STREAM
 
 endif

--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -16,6 +16,14 @@
 
 #include <zephyr/sys/util.h>
 
+#ifdef CONFIG_ADC_ESP32_STREAM
+#include <string.h>
+
+#include <zephyr/dsp/types.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/byteorder.h>
+#endif /* CONFIG_ADC_ESP32_STREAM */
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_esp32, CONFIG_ADC_LOG_LEVEL);
 
@@ -67,7 +75,7 @@ static inline int gain_to_atten(enum adc_gain gain, adc_atten_t *atten)
 	return 0;
 }
 
-#ifndef CONFIG_ADC_ESP32_DMA
+#if !defined(CONFIG_ADC_ESP32_DMA) || defined(CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED)
 
 /* Convert voltage by inverted attenuation to support zephyr gain values */
 static void atten_to_gain(adc_atten_t atten, uint32_t *val_mv)
@@ -100,8 +108,45 @@ static void atten_to_gain(adc_atten_t atten, uint32_t *val_mv)
 
 	*val_mv = (*val_mv * num) / den;
 }
+#endif /* !CONFIG_ADC_ESP32_DMA || CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED */
 
-#endif /* CONFIG_ADC_ESP32_DMA */
+#if !defined(CONFIG_ADC_ESP32_DMA) || defined(CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED)
+static void adc_esp32_cal_handle_update(const struct adc_esp32_conf *conf,
+					struct adc_esp32_data *data, uint8_t channel_id)
+{
+#if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+	adc_cali_curve_fitting_config_t cal_config = {
+		.unit_id = conf->unit,
+		.chan = channel_id,
+		.atten = data->attenuation[channel_id],
+		.bitwidth = data->resolution[channel_id],
+	};
+
+	if (data->cal_handle[channel_id] != NULL) {
+		adc_cali_delete_scheme_curve_fitting(data->cal_handle[channel_id]);
+	}
+
+	adc_cali_create_scheme_curve_fitting(&cal_config, &data->cal_handle[channel_id]);
+#endif /* ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED */
+
+#if ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+	adc_cali_line_fitting_config_t cal_config = {
+		.unit_id = conf->unit,
+		.atten = data->attenuation[channel_id],
+		.bitwidth = data->resolution[channel_id],
+#if CONFIG_SOC_SERIES_ESP32
+		.default_vref = data->meas_ref_internal,
+#endif
+	};
+
+	if (data->cal_handle[channel_id] != NULL) {
+		adc_cali_delete_scheme_line_fitting(data->cal_handle[channel_id]);
+	}
+
+	adc_cali_create_scheme_line_fitting(&cal_config, &data->cal_handle[channel_id]);
+#endif /* ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED */
+}
+#endif /* !CONFIG_ADC_ESP32_DMA || CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED */
 
 static int adc_esp32_validate_sequence(const struct device *dev, const struct adc_sequence *seq)
 {
@@ -389,8 +434,11 @@ static int adc_esp32_channel_setup(const struct device *dev, const struct adc_ch
 		return -ENOTSUP;
 	}
 
+	adc_atten_t old_atten = data->attenuation[cfg->channel_id];
+
 	if (gain_to_atten(cfg->gain, &data->attenuation[cfg->channel_id])) {
 		LOG_ERR("Unsupported gain value '%d'", cfg->gain);
+		data->attenuation[cfg->channel_id] = old_atten;
 		return -ENOTSUP;
 	}
 
@@ -398,11 +446,17 @@ static int adc_esp32_channel_setup(const struct device *dev, const struct adc_ch
 	err = adc_esp32_dma_channel_setup(dev, cfg);
 
 	if (err < 0) {
+		data->attenuation[cfg->channel_id] = old_atten;
 		return err;
 	}
-#else
-	adc_atten_t old_atten = data->attenuation[cfg->channel_id];
 
+#if defined(CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED)
+	if ((data->cal_handle[cfg->channel_id] == NULL) ||
+	    (data->attenuation[cfg->channel_id] != old_atten)) {
+		adc_esp32_cal_handle_update(conf, data, cfg->channel_id);
+	}
+#endif /* CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED */
+#else
 	adc_oneshot_hal_chan_cfg_t config = {
 		.atten = data->attenuation[cfg->channel_id],
 		.bitwidth = data->resolution[cfg->channel_id],
@@ -412,49 +466,7 @@ static int adc_esp32_channel_setup(const struct device *dev, const struct adc_ch
 
 	if ((data->cal_handle[cfg->channel_id] == NULL) ||
 	    (data->attenuation[cfg->channel_id] != old_atten)) {
-#if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
-		adc_cali_curve_fitting_config_t cal_config = {
-			.unit_id = conf->unit,
-			.chan = cfg->channel_id,
-			.atten = data->attenuation[cfg->channel_id],
-			.bitwidth = data->resolution[cfg->channel_id],
-		};
-
-		LOG_DBG("Curve fitting calib [unit_id: %u, chan: %u, atten: %u, bitwidth: %u]",
-			conf->unit, cfg->channel_id, data->attenuation[cfg->channel_id],
-			data->resolution[cfg->channel_id]);
-
-		if (data->cal_handle[cfg->channel_id] != NULL) {
-			/* delete pre-existing calib scheme */
-			adc_cali_delete_scheme_curve_fitting(data->cal_handle[cfg->channel_id]);
-		}
-
-		adc_cali_create_scheme_curve_fitting(&cal_config,
-						     &data->cal_handle[cfg->channel_id]);
-#endif /* ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED */
-
-#if ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
-		adc_cali_line_fitting_config_t cal_config = {
-			.unit_id = conf->unit,
-			.atten = data->attenuation[cfg->channel_id],
-			.bitwidth = data->resolution[cfg->channel_id],
-#if CONFIG_SOC_SERIES_ESP32
-			.default_vref = data->meas_ref_internal
-#endif
-		};
-
-		LOG_DBG("Line fitting calib [unit_id: %u, chan: %u, atten: %u, bitwidth: %u]",
-			conf->unit, cfg->channel_id, data->attenuation[cfg->channel_id],
-			data->resolution[cfg->channel_id]);
-
-		if (data->cal_handle[cfg->channel_id] != NULL) {
-			/* delete pre-existing calib scheme */
-			adc_cali_delete_scheme_line_fitting(data->cal_handle[cfg->channel_id]);
-		}
-
-		adc_cali_create_scheme_line_fitting(&cal_config,
-						    &data->cal_handle[cfg->channel_id]);
-#endif /* ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED */
+		adc_esp32_cal_handle_update(conf, data, cfg->channel_id);
 	}
 #endif /* CONFIG_ADC_ESP32_DMA */
 
@@ -542,6 +554,376 @@ static int adc_esp32_init(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_ADC_ESP32_DMA) && defined(CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED)
+void adc_esp32_dma_calibrate_samples(struct adc_esp32_data *data, uint16_t *samples,
+				     const adc_digi_pattern_config_t *pattern, uint32_t pattern_len,
+				     unsigned int repeats, uint8_t resolution)
+{
+	uint32_t scale = (1U << resolution) - 1U;
+
+	if ((pattern == NULL) || (pattern_len == 0U) || (data->meas_ref_internal == 0U)) {
+		return;
+	}
+
+	for (unsigned int r = 0U; r < repeats; r++) {
+		for (uint32_t p = 0U; p < pattern_len; p++) {
+			uint8_t ch_id = pattern[p].channel;
+			uint16_t *sample = &samples[(r * pattern_len) + p];
+			uint32_t acq_mv;
+
+			if (data->cal_handle[ch_id] == NULL) {
+				continue;
+			}
+
+			if (adc_cali_raw_to_voltage(data->cal_handle[ch_id], *sample, &acq_mv) !=
+			    ESP_OK) {
+				continue;
+			}
+
+#if CONFIG_SOC_SERIES_ESP32
+			if ((data->attenuation[ch_id] == ADC_ATTEN_DB_12) &&
+			    (acq_mv > ADC_CLIP_MVOLT_12DB)) {
+				acq_mv = ADC_CLIP_MVOLT_12DB;
+			}
+#endif /* CONFIG_SOC_SERIES_ESP32 */
+
+			atten_to_gain(data->attenuation[ch_id], &acq_mv);
+			*sample = (uint16_t)((acq_mv * scale) / data->meas_ref_internal);
+		}
+	}
+}
+#endif /* CONFIG_ADC_ESP32_DMA && CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED */
+
+#ifdef CONFIG_ADC_ESP32_STREAM
+struct adc_esp32_stream_frame_hdr {
+	uint64_t timestamp_ns;
+	uint32_t channels_mask;
+	uint16_t vref_mv;
+	uint16_t total_samples;
+	uint8_t resolution;
+	uint8_t channel_count;
+	uint8_t channel_ids[SOC_ADC_MAX_CHANNEL_NUM];
+	uint8_t atten[SOC_ADC_MAX_CHANNEL_NUM];
+} __packed;
+
+static void adc_esp32_stream_fill_frame_meta(struct adc_esp32_stream_frame_hdr *hdr,
+					     struct adc_esp32_data *data)
+{
+	uint32_t mask = hdr->channels_mask;
+
+	for (uint8_t slot = 0U; slot < hdr->channel_count; slot++) {
+		uint8_t ch = (uint8_t)(find_lsb_set(mask) - 1U);
+
+		hdr->channel_ids[slot] = ch;
+		hdr->atten[slot] = data->attenuation[ch];
+		mask &= ~BIT(ch);
+	}
+}
+
+#if !defined(CONFIG_ADC_ESP32_DMA_DECODE_COUNTS)
+static uint16_t adc_esp32_effective_vref_mv(uint16_t vref_internal, adc_atten_t atten)
+{
+	uint32_t vref = vref_internal;
+
+	switch (atten) {
+	case ADC_ATTEN_DB_2_5:
+		vref = (vref * 5U) / 4U;
+		break;
+	case ADC_ATTEN_DB_6:
+		vref = vref * 2U;
+		break;
+	case ADC_ATTEN_DB_12:
+		vref = vref * 4U;
+		break;
+	default:
+		break;
+	}
+
+	return (uint16_t)vref;
+}
+#endif /* !CONFIG_ADC_ESP32_DMA_DECODE_COUNTS */
+
+#if defined(CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED)
+void adc_esp32_stream_calibrate_frame(struct adc_esp32_data *data)
+{
+	uint16_t *samples = (uint16_t *)data->stream_seq_snap.buffer;
+	const struct adc_esp32_stream_frame_hdr *hdr =
+		(const struct adc_esp32_stream_frame_hdr *)((const uint8_t *)samples -
+							    sizeof(*hdr));
+	unsigned int repeats;
+
+	if ((hdr->channel_count == 0U) || ((hdr->total_samples % hdr->channel_count) != 0U)) {
+		return;
+	}
+
+	repeats = hdr->total_samples / hdr->channel_count;
+
+	adc_esp32_dma_calibrate_samples(data, samples, data->stream_pattern,
+					data->stream_digi_cfg.adc_pattern_len, repeats,
+					hdr->resolution);
+}
+#endif /* CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED */
+
+static size_t adc_esp32_stream_frame_bytes(const struct adc_sequence *seq)
+{
+	unsigned int chans = POPCOUNT(seq->channels);
+	unsigned int repeats = (seq->options != NULL) ? (1U + seq->options->extra_samplings) : 1U;
+	unsigned int total_samples = chans * repeats;
+
+	return sizeof(struct adc_esp32_stream_frame_hdr) + total_samples * sizeof(uint16_t);
+}
+
+int adc_esp32_stream_arm(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct adc_esp32_data *data = dev->data;
+	const struct adc_read_config *read_cfg = iodev_sqe->sqe.iodev->data;
+	const struct adc_sequence *seq = read_cfg->sequence;
+	struct adc_sequence xfer;
+	struct adc_sequence_options opt_stack;
+	size_t frame_len;
+	uint8_t *buf = NULL;
+	uint32_t buf_len_u32 = 0;
+	unsigned int repeats;
+	unsigned int total_samples;
+	int err;
+
+	if (seq == NULL) {
+		return -EINVAL;
+	}
+
+	err = adc_esp32_validate_sequence(dev, seq);
+	if (err != 0) {
+		return err;
+	}
+
+	err = adc_esp32_dma_stream_validate(dev, seq);
+	if (err != 0) {
+		return err;
+	}
+
+	frame_len = adc_esp32_stream_frame_bytes(seq);
+	repeats = (seq->options != NULL) ? (1U + seq->options->extra_samplings) : 1U;
+	total_samples = POPCOUNT(seq->channels) * repeats;
+
+	err = rtio_sqe_rx_buf(iodev_sqe, (uint32_t)frame_len, (uint32_t)frame_len, &buf,
+			      &buf_len_u32);
+
+	if ((err != 0) || (buf == NULL) || ((size_t)buf_len_u32 < frame_len)) {
+		return err != 0 ? err : -ENOMEM;
+	}
+
+	struct adc_esp32_stream_frame_hdr *hdr = (struct adc_esp32_stream_frame_hdr *)buf;
+
+	hdr->timestamp_ns = k_ticks_to_ns_floor64(k_uptime_ticks());
+	hdr->channels_mask = seq->channels;
+	hdr->vref_mv = data->meas_ref_internal;
+	hdr->total_samples = (uint16_t)total_samples;
+	hdr->resolution = seq->resolution;
+	hdr->channel_count = (uint8_t)POPCOUNT(seq->channels);
+	adc_esp32_stream_fill_frame_meta(hdr, data);
+
+	xfer = *seq;
+	xfer.buffer = buf + sizeof(struct adc_esp32_stream_frame_hdr);
+	xfer.buffer_size = total_samples * sizeof(uint16_t);
+	if (seq->options != NULL) {
+		opt_stack = *seq->options;
+		opt_stack.callback = NULL;
+		xfer.options = &opt_stack;
+	} else {
+		xfer.options = NULL;
+	}
+
+	uint32_t chans = xfer.channels;
+
+	while (chans != 0U) {
+		uint8_t ch = find_lsb_set(chans) - 1U;
+
+		data->resolution[ch] = xfer.resolution;
+		chans &= ~BIT(ch);
+	}
+
+	adc_context_lock(&data->ctx, false, NULL);
+
+	data->stream_seq_snap = xfer;
+	if (xfer.options != NULL) {
+		data->stream_seq_opt_snap = *xfer.options;
+		data->stream_seq_snap.options = &data->stream_seq_opt_snap;
+	} else {
+		data->stream_seq_snap.options = NULL;
+	}
+
+	data->stream_iodev_sqe = iodev_sqe;
+
+	err = adc_esp32_dma_stream_queue_start(dev);
+	if (err < 0) {
+		data->dma_notify_via_work = false;
+		data->stream_iodev_sqe = NULL;
+		adc_context_release(&data->ctx, err);
+		return err;
+	}
+
+	/* k_work_submit_to_queue() returns 1 when queued, 0 if already pending. */
+	return 0;
+}
+
+static void adc_esp32_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	int err = adc_esp32_stream_arm(dev, iodev_sqe);
+
+	if (err != 0) {
+		if (err == -ENOMEM) {
+			LOG_ERR("stream rx_buf failed (%d)", err);
+		} else {
+			LOG_ERR("stream arm failed (%d)", err);
+		}
+		rtio_iodev_sqe_err(iodev_sqe, err);
+	}
+}
+
+#if defined(CONFIG_ADC_ESP32_DMA_DECODE_COUNTS)
+static int adc_esp32_stream_convert_raw_q31(q31_t *out, const uint8_t *sample_le)
+{
+	*out = (q31_t)sys_get_le16(sample_le);
+	return 0;
+}
+#else
+static int adc_esp32_stream_convert_q31(q31_t *out, const uint8_t *sample_le, uint16_t resolution,
+					uint16_t vref_mv, uint8_t adc_shift)
+{
+	int32_t data_in = sys_get_le16(sample_le);
+	unsigned int rs = resolution;
+	unsigned int sh = adc_shift;
+
+	if (rs >= 32U || sh > 31U) {
+		return -EINVAL;
+	}
+
+	uint32_t scale = BIT(rs);
+	uint32_t sensitivity = ((uint32_t)vref_mv * (scale - 1U)) / scale * 1000U / scale;
+
+	*out = BIT(31U - sh) * sensitivity / 1000000 * data_in;
+	return 0;
+}
+#endif /* CONFIG_ADC_ESP32_DMA_DECODE_COUNTS */
+
+static int adc_esp32_decoder_get_size_info(struct adc_dt_spec adc_spec, uint32_t channel,
+					   size_t *base_size, size_t *frame_size)
+{
+	ARG_UNUSED(adc_spec);
+	ARG_UNUSED(channel);
+
+	__ASSERT_NO_MSG(base_size != NULL);
+	__ASSERT_NO_MSG(frame_size != NULL);
+
+	*base_size = sizeof(struct adc_data);
+	*frame_size = sizeof(struct adc_sample_data);
+	return 0;
+}
+
+static bool adc_esp32_decoder_has_trigger(const uint8_t *buffer, enum adc_trigger_type trigger)
+{
+	ARG_UNUSED(buffer);
+	ARG_UNUSED(trigger);
+
+	return false;
+}
+
+static int adc_esp32_decoder_get_frame_count(const uint8_t *buffer, uint32_t channel,
+					     uint16_t *frame_count)
+{
+	ARG_UNUSED(buffer);
+	ARG_UNUSED(channel);
+
+	*frame_count = 1U;
+	return 0;
+}
+
+static int adc_esp32_decoder_decode(const uint8_t *buffer, uint32_t channel, uint32_t *fit,
+				    uint16_t max_count, void *data_out)
+{
+	const struct adc_esp32_stream_frame_hdr *hdr =
+		(const struct adc_esp32_stream_frame_hdr *)buffer;
+
+	ARG_UNUSED(max_count);
+
+	if (*fit != 0U) {
+		return 0;
+	}
+
+	if (hdr->channel_count == 0U) {
+		return -EINVAL;
+	}
+
+	if ((hdr->total_samples % hdr->channel_count) != 0U) {
+		return -EINVAL;
+	}
+
+	if (channel >= hdr->channel_count) {
+		return -EINVAL;
+	}
+
+	unsigned int repeats = hdr->total_samples / hdr->channel_count;
+	size_t row_off = sizeof(struct adc_esp32_stream_frame_hdr) +
+			 (size_t)(repeats - 1U) * hdr->channel_count * sizeof(uint16_t);
+	const uint8_t *sample = buffer + row_off + channel * sizeof(uint16_t);
+	struct adc_data *out_data = (struct adc_data *)data_out;
+	int err_convert;
+
+	memset(out_data, 0, sizeof(struct adc_data));
+
+	out_data->header.base_timestamp_ns = hdr->timestamp_ns;
+	out_data->header.reading_count = 1;
+	out_data->readings[0].timestamp_delta = 0U;
+
+#if defined(CONFIG_ADC_ESP32_DMA_DECODE_COUNTS)
+	out_data->shift = 0;
+	err_convert = adc_esp32_stream_convert_raw_q31(&out_data->readings[0].value, sample);
+#else
+	uint16_t vref_mv = hdr->vref_mv;
+	uint16_t shift;
+
+	if (hdr->vref_mv == 0U) {
+		return -EINVAL;
+	}
+
+	vref_mv = adc_esp32_effective_vref_mv(hdr->vref_mv, (adc_atten_t)hdr->atten[channel]);
+
+	shift = find_msb_set((uint32_t)vref_mv);
+	if (shift == 0U) {
+		return -EINVAL;
+	}
+
+	out_data->shift = (int8_t)(shift - 1U);
+	err_convert =
+		adc_esp32_stream_convert_q31(&out_data->readings[0].value, sample, hdr->resolution,
+					     vref_mv, (uint8_t)out_data->shift);
+
+#endif /* CONFIG_ADC_ESP32_DMA_DECODE_COUNTS */
+	if (err_convert != 0) {
+		return err_convert;
+	}
+
+	*fit = 1U;
+
+	return 0;
+}
+
+ADC_DECODER_API_DT_DEFINE() = {
+	.get_frame_count = adc_esp32_decoder_get_frame_count,
+	.get_size_info = adc_esp32_decoder_get_size_info,
+	.decode = adc_esp32_decoder_decode,
+	.has_trigger = adc_esp32_decoder_has_trigger,
+};
+
+static int adc_esp32_get_decoder(const struct device *dev, const struct adc_decoder_api **api)
+{
+	ARG_UNUSED(dev);
+	*api = &ADC_DECODER_NAME();
+
+	return 0;
+}
+#endif /* CONFIG_ADC_ESP32_STREAM */
+
 static DEVICE_API(adc, api_esp32_driver_api) = {
 	.channel_setup = adc_esp32_channel_setup,
 	.read = adc_esp32_read,
@@ -549,6 +931,10 @@ static DEVICE_API(adc, api_esp32_driver_api) = {
 	.read_async = adc_esp32_read_async,
 #endif /* CONFIG_ADC_ASYNC */
 	.ref_internal = ADC_ESP32_DEFAULT_VREF_INTERNAL,
+#if defined(CONFIG_ADC_ESP32_STREAM)
+	.submit = adc_esp32_submit_stream,
+	.get_decoder = adc_esp32_get_decoder,
+#endif
 };
 
 #if defined(CONFIG_ADC_ESP32_DMA) && SOC_GDMA_SUPPORTED
@@ -559,15 +945,15 @@ static DEVICE_API(adc, api_esp32_driver_api) = {
 #define ADC_ESP32_CONF_INIT(n)
 #endif /* defined(SOC_GDMA_SUPPORTED) && SOC_GDMA_SUPPORTED */
 
+#define ADC_ESP32_CHECK_CHANNEL_REF(chan)                                                          \
+	BUILD_ASSERT(DT_ENUM_HAS_VALUE(chan, zephyr_reference, adc_ref_internal),                  \
+		     "adc_esp32 only supports ADC_REF_INTERNAL as a reference");
+
 #ifndef CONFIG_ADC_ESP32_DMA
 #define ADC_ESP32_CTX_TIMER_INIT(inst) ADC_CONTEXT_INIT_TIMER(adc_esp32_data_##inst, ctx),
 #else
 #define ADC_ESP32_CTX_TIMER_INIT(inst)
 #endif
-
-#define ADC_ESP32_CHECK_CHANNEL_REF(chan)                                                          \
-	BUILD_ASSERT(DT_ENUM_HAS_VALUE(chan, zephyr_reference, adc_ref_internal),                  \
-		     "adc_esp32 only supports ADC_REF_INTERNAL as a reference");
 
 #define ESP32_ADC_INIT(inst)                                                                       \
                                                                                                    \

--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Espressif Systems (Shanghai) CO LTD
+ * Copyright (c) 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -14,6 +14,8 @@
 
 #include <zephyr/drivers/gpio.h>
 
+#include <zephyr/sys/util.h>
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_esp32, CONFIG_ADC_LOG_LEVEL);
 
@@ -101,70 +103,73 @@ static void atten_to_gain(adc_atten_t atten, uint32_t *val_mv)
 
 #endif /* CONFIG_ADC_ESP32_DMA */
 
-static int adc_esp32_read(const struct device *dev, const struct adc_sequence *seq)
+static int adc_esp32_validate_sequence(const struct device *dev, const struct adc_sequence *seq)
 {
-	struct adc_esp32_data *data = dev->data;
-
-	uint8_t channel_id = find_lsb_set(seq->channels) - 1;
-
-	if (seq->buffer_size < 2) {
-		LOG_ERR("Sequence buffer space too low '%d'", seq->buffer_size);
-		return -ENOMEM;
-	}
-
-#ifndef CONFIG_ADC_ESP32_DMA
-	if (seq->channels > BIT(channel_id)) {
-		LOG_ERR("Multi-channel readings not supported");
-		return -ENOTSUP;
-	}
-
-	if (seq->options && seq->options->extra_samplings) {
-		LOG_ERR("Extra samplings not supported");
-		return -ENOTSUP;
-	}
-
-	if (seq->options && seq->options->interval_us) {
-		LOG_ERR("Interval between samplings not supported");
-		return -ENOTSUP;
-	}
-#endif /* CONFIG_ADC_ESP32_DMA */
+	const struct adc_esp32_conf *conf = dev->config;
 
 	if (!VALID_RESOLUTION(seq->resolution)) {
-		LOG_ERR("unsupported resolution (%d)", seq->resolution);
+		LOG_ERR("Unsupported resolution (%d)", seq->resolution);
 		return -ENOTSUP;
 	}
 
 	if (seq->calibrate) {
-		/* TODO: Does this mean actual Vref measurement on selected GPIO ?*/
-		LOG_ERR("calibration is not supported");
+		LOG_ERR("Calibration is not supported");
 		return -ENOTSUP;
 	}
 
-	data->resolution[channel_id] = seq->resolution;
+	if (seq->oversampling != 0U) {
+		LOG_ERR("Oversampling is not supported");
+		return -ENOTSUP;
+	}
 
-#ifdef CONFIG_ADC_ESP32_DMA
-	int err = adc_esp32_dma_read(dev, seq);
+	if (seq->channels == 0U) {
+		return -EINVAL;
+	}
 
-	if (err < 0) {
+	uint32_t chans = seq->channels;
+
+	while (chans) {
+		uint8_t ch = find_lsb_set(chans) - 1;
+
+		if (ch >= conf->channel_count) {
+			LOG_ERR("Unsupported channel in mask");
+			return -EINVAL;
+		}
+		chans &= ~BIT(ch);
+	}
+
+	return 0;
+}
+
+#ifndef CONFIG_ADC_ESP32_DMA
+
+static int adc_esp32_validate_oneshot_sequence(const struct device *dev,
+					       const struct adc_sequence *seq)
+{
+	int err = adc_esp32_validate_sequence(dev, seq);
+
+	if (err != 0) {
 		return err;
 	}
-#else
+
+	size_t channels = POPCOUNT(seq->channels);
+	size_t sampling_count = 1U + (seq->options != NULL ? seq->options->extra_samplings : 0U);
+
+	if (seq->buffer_size < (channels * sampling_count * sizeof(uint16_t))) {
+		LOG_ERR("Sequence buffer space too low '%zu'", seq->buffer_size);
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+static uint16_t adc_esp32_oneshot_convert_channel(struct adc_esp32_data *data,
+						  const struct adc_sequence *seq,
+						  uint8_t channel_id)
+{
 	uint32_t acq_raw;
 
-	if (seq->channels > BIT(channel_id)) {
-		LOG_ERR("Multi-channel readings not supported");
-		return -ENOTSUP;
-	}
-
-	if (seq->options && seq->options->extra_samplings) {
-		LOG_ERR("Extra samplings not supported");
-		return -ENOTSUP;
-	}
-
-	if (seq->options && seq->options->interval_us) {
-		LOG_ERR("Interval between samplings not supported");
-		return -ENOTSUP;
-	}
+	data->resolution[channel_id] = seq->resolution;
 
 	adc_oneshot_hal_setup(&data->hal, channel_id);
 
@@ -175,7 +180,7 @@ static int adc_esp32_read(const struct device *dev, const struct adc_sequence *s
 	adc_oneshot_hal_convert(&data->hal, &acq_raw);
 
 	if (data->cal_handle[channel_id]) {
-		if (data->meas_ref_internal > 0) {
+		if (data->meas_ref_internal > 0U) {
 			uint32_t acq_mv;
 
 			adc_cali_raw_to_voltage(data->cal_handle[channel_id], acq_raw, &acq_mv);
@@ -190,9 +195,8 @@ static int adc_esp32_read(const struct device *dev, const struct adc_sequence *s
 			}
 #endif /* CONFIG_SOC_SERIES_ESP32 */
 
-			/* Fit according to selected attenuation */
 			atten_to_gain(data->attenuation[channel_id], &acq_mv);
-			acq_raw = acq_mv * ((1 << data->resolution[channel_id]) - 1) /
+			acq_raw = acq_mv * ((1U << data->resolution[channel_id]) - 1U) /
 				  data->meas_ref_internal;
 		} else {
 			LOG_WRN("ADC reading is uncompensated");
@@ -201,23 +205,161 @@ static int adc_esp32_read(const struct device *dev, const struct adc_sequence *s
 		LOG_WRN("ADC reading is uncompensated");
 	}
 
-	/* Store result */
-	data->buffer = (uint16_t *)seq->buffer;
-	data->buffer[0] = acq_raw;
+	return (uint16_t)acq_raw;
+}
+
+static void adc_context_update_buffer_pointer(struct adc_context *ctx, bool repeat_sampling)
+{
+	struct adc_esp32_data *data = CONTAINER_OF(ctx, struct adc_esp32_data, ctx);
+
+	if (repeat_sampling) {
+		data->seq_buf = data->repeat_buf;
+	} else {
+		data->seq_buf += POPCOUNT(ctx->sequence.channels);
+	}
+}
+
+static void adc_context_start_sampling(struct adc_context *ctx)
+{
+	struct adc_esp32_data *data = CONTAINER_OF(ctx, struct adc_esp32_data, ctx);
+	const struct adc_sequence *seq = &ctx->sequence;
+	uint32_t chan_mask = seq->channels;
+	uint16_t *out = data->seq_buf;
+
+	while (chan_mask != 0U) {
+		uint8_t channel_id = find_lsb_set(chan_mask) - 1;
+
+		*out++ = adc_esp32_oneshot_convert_channel(data, seq, channel_id);
+
+		chan_mask &= ~BIT(channel_id);
+	}
+
+	adc_context_on_sampling_done(ctx, data->dev);
+}
+
+static int adc_esp32_start_read(const struct device *dev, const struct adc_sequence *sequence)
+{
+	struct adc_esp32_data *data = dev->data;
+	int error;
+
+	data->seq_buf = sequence->buffer;
+	data->repeat_buf = sequence->buffer;
+
+	adc_context_start_read(&data->ctx, sequence);
+
+	error = adc_context_wait_for_completion(&data->ctx);
+
+	return error;
+}
+
+#else /* CONFIG_ADC_ESP32_DMA */
+
+static void __maybe_unused adc_context_update_buffer_pointer(struct adc_context *ctx,
+							     bool repeat_sampling)
+{
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(repeat_sampling);
+}
+
+static void __maybe_unused adc_context_start_sampling(struct adc_context *ctx)
+{
+	ARG_UNUSED(ctx);
+}
+
+static void __maybe_unused adc_context_enable_timer(struct adc_context *ctx)
+{
+	ARG_UNUSED(ctx);
+}
+
+static void __maybe_unused adc_context_disable_timer(struct adc_context *ctx)
+{
+	ARG_UNUSED(ctx);
+}
+
 #endif /* CONFIG_ADC_ESP32_DMA */
 
-	return 0;
+static int adc_esp32_read(const struct device *dev, const struct adc_sequence *seq)
+{
+	struct adc_esp32_data *data = dev->data;
+	int err;
+
+#ifdef CONFIG_ADC_ESP32_DMA
+	err = adc_esp32_validate_sequence(dev, seq);
+#else
+	err = adc_esp32_validate_oneshot_sequence(dev, seq);
+#endif /* CONFIG_ADC_ESP32_DMA */
+	if (err != 0) {
+		return err;
+	}
+
+	adc_context_lock(&data->ctx, false, NULL);
+#ifdef CONFIG_ADC_ESP32_DMA
+	err = adc_esp32_dma_finish_read(dev, seq);
+#else
+	err = adc_esp32_start_read(dev, seq);
+#endif /* CONFIG_ADC_ESP32_DMA */
+	adc_context_release(&data->ctx, err);
+
+	return err;
 }
 
 #ifdef CONFIG_ADC_ASYNC
+
+#if defined(CONFIG_ADC_ESP32_DMA)
+static void adc_esp32_ctx_copy_sequence_for_dma_async(struct adc_context *ctx,
+						      const struct adc_sequence *sequence)
+{
+	ctx->sequence = *sequence;
+	ctx->status = 0;
+	ctx->sampling_index = 0U;
+
+	if (sequence->options != NULL) {
+		ctx->options = *sequence->options;
+		ctx->sequence.options = &ctx->options;
+	} else {
+		ctx->sequence.options = NULL;
+	}
+}
+#endif /* CONFIG_ADC_ESP32_DMA */
+
 static int adc_esp32_read_async(const struct device *dev, const struct adc_sequence *sequence,
 				struct k_poll_signal *async)
 {
-	(void)(dev);
-	(void)(sequence);
-	(void)(async);
+	struct adc_esp32_data *data = dev->data;
+	int err;
 
-	return -ENOTSUP;
+#ifdef CONFIG_ADC_ESP32_DMA
+	err = adc_esp32_validate_sequence(dev, sequence);
+	if (err != 0) {
+		return err;
+	}
+
+	adc_context_lock(&data->ctx, true, async);
+
+	adc_esp32_ctx_copy_sequence_for_dma_async(&data->ctx, sequence);
+
+	err = adc_esp32_dma_async_submit(dev);
+	if (err != 0) {
+		LOG_ERR("ADC DMA async submit failed (%d)", err);
+		adc_context_complete(&data->ctx, err);
+		return err;
+	}
+
+	adc_context_release(&data->ctx, 0);
+
+	return 0;
+#else
+	err = adc_esp32_validate_oneshot_sequence(dev, sequence);
+	if (err != 0) {
+		return err;
+	}
+
+	adc_context_lock(&data->ctx, true, async);
+	err = adc_esp32_start_read(dev, sequence);
+	adc_context_release(&data->ctx, err);
+
+	return err;
+#endif /* CONFIG_ADC_ESP32_DMA */
 }
 #endif /* CONFIG_ADC_ASYNC */
 
@@ -347,6 +489,7 @@ static int adc_esp32_init(const struct device *dev)
 	const struct adc_esp32_conf *conf = (struct adc_esp32_conf *)dev->config;
 	uint32_t clock_src_hz;
 
+	data->dev = dev;
 
 #if SOC_ADC_DIG_CTRL_SUPPORTED && (!SOC_ADC_RTC_CTRL_SUPPORTED || CONFIG_ADC_ESP32_DMA)
 	if (!device_is_ready(conf->clock_dev)) {
@@ -394,6 +537,8 @@ static int adc_esp32_init(const struct device *dev)
 
 	adc_hw_calibration(conf->unit);
 
+	adc_context_unlock_unconditionally(&data->ctx);
+
 	return 0;
 }
 
@@ -413,6 +558,12 @@ static DEVICE_API(adc, api_esp32_driver_api) = {
 #else
 #define ADC_ESP32_CONF_INIT(n)
 #endif /* defined(SOC_GDMA_SUPPORTED) && SOC_GDMA_SUPPORTED */
+
+#ifndef CONFIG_ADC_ESP32_DMA
+#define ADC_ESP32_CTX_TIMER_INIT(inst) ADC_CONTEXT_INIT_TIMER(adc_esp32_data_##inst, ctx),
+#else
+#define ADC_ESP32_CTX_TIMER_INIT(inst)
+#endif
 
 #define ADC_ESP32_CHECK_CHANNEL_REF(chan)                                                          \
 	BUILD_ASSERT(DT_ENUM_HAS_VALUE(chan, zephyr_reference, adc_ref_internal),                  \
@@ -435,6 +586,8 @@ static DEVICE_API(adc, api_esp32_driver_api) = {
 			{                                                                          \
 				.dev = (adc_oneshot_soc_handle_t)DT_INST_REG_ADDR(inst),           \
 			},                                                                         \
+		ADC_ESP32_CTX_TIMER_INIT(inst) ADC_CONTEXT_INIT_LOCK(adc_esp32_data_##inst, ctx),  \
+		ADC_CONTEXT_INIT_SYNC(adc_esp32_data_##inst, ctx),                                 \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, adc_esp32_init, NULL, &adc_esp32_data_##inst,                  \

--- a/drivers/adc/adc_esp32.h
+++ b/drivers/adc/adc_esp32.h
@@ -16,6 +16,12 @@
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/clock_control.h>
 
+#ifndef CONFIG_ADC_ESP32_DMA
+#define ADC_CONTEXT_USES_KERNEL_TIMER
+#endif
+
+#include "adc_context.h"
+
 struct adc_esp32_conf {
 	const struct device *clock_dev;
 	const clock_control_subsys_t clock_subsys;
@@ -34,7 +40,10 @@ struct adc_esp32_data {
 	uint8_t resolution[SOC_ADC_MAX_CHANNEL_NUM];
 	adc_cali_handle_t cal_handle[SOC_ADC_MAX_CHANNEL_NUM];
 	uint16_t meas_ref_internal;
-	uint16_t *buffer;
+	struct adc_context ctx;
+	const struct device *dev;
+	uint16_t *seq_buf;
+	uint16_t *repeat_buf;
 #ifdef CONFIG_ADC_ESP32_DMA
 #include <hal/dma_types.h>
 
@@ -51,11 +60,20 @@ struct adc_esp32_data {
 #if !SOC_GDMA_SUPPORTED
 	struct intr_handle_data_t *irq_handle;
 #endif /* !SOC_GDMA_SUPPORTED */
+#if defined(CONFIG_ADC_ASYNC)
+	struct k_work dma_async_work;
+#endif /* CONFIG_ADC_ASYNC */
 	bool digi_hw_active;
 #endif /* CONFIG_ADC_ESP32_DMA */
 };
 
 int adc_esp32_dma_read(const struct device *dev, const struct adc_sequence *seq);
+
+int adc_esp32_dma_execute_read(const struct device *dev, const struct adc_sequence *seq);
+
+int adc_esp32_dma_finish_read(const struct device *dev, const struct adc_sequence *seq);
+
+int adc_esp32_dma_async_submit(const struct device *dev);
 
 int adc_esp32_dma_channel_setup(const struct device *dev, const struct adc_channel_cfg *cfg);
 

--- a/drivers/adc/adc_esp32.h
+++ b/drivers/adc/adc_esp32.h
@@ -20,6 +20,10 @@
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #endif
 
+#if defined(CONFIG_ADC_ESP32_DMA) && defined(CONFIG_ADC_ESP32_STREAM)
+struct rtio_iodev_sqe;
+#endif
+
 #include "adc_context.h"
 
 struct adc_esp32_conf {
@@ -48,13 +52,13 @@ struct adc_esp32_data {
 #include <hal/dma_types.h>
 
 #define ADC_ESP32_DMA_RX_DESC_COUNT                                                                \
-	((DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED + DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED -  \
-	  1U) / DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED +                                        \
+	((CONFIG_ADC_ESP32_DMA_BUFFER_SIZE + DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED - 1U) /     \
+		 DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED +                                       \
 	 1U)
 
 	adc_hal_dma_ctx_t adc_hal_dma_ctx;
 	dma_descriptor_t dma_rx_desc[ADC_ESP32_DMA_RX_DESC_COUNT];
-	uint8_t dma_buffer[DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED];
+	uint8_t dma_buffer[CONFIG_ADC_ESP32_DMA_BUFFER_SIZE];
 	struct k_sem dma_conv_wait_lock;
 	soc_module_clk_t digi_clk_src;
 #if !SOC_GDMA_SUPPORTED
@@ -63,6 +67,23 @@ struct adc_esp32_data {
 #if defined(CONFIG_ADC_ASYNC)
 	struct k_work dma_async_work;
 #endif /* CONFIG_ADC_ASYNC */
+#if defined(CONFIG_ADC_ESP32_STREAM)
+	struct k_work stream_done_work;
+	struct k_work stream_start_work;
+	struct k_work stream_rtio_work;
+	struct k_work_delayable stream_resubmit_dwork;
+	struct rtio_iodev_sqe *stream_rtio_sqe;
+	struct rtio_iodev_sqe *stream_iodev_sqe;
+	struct rtio_iodev_sqe *stream_resubmit_sqe;
+	int stream_rtio_err;
+	struct adc_sequence stream_seq_snap;
+	struct adc_sequence_options stream_seq_opt_snap;
+	adc_hal_digi_ctrlr_cfg_t stream_digi_cfg;
+	adc_digi_pattern_config_t stream_pattern[SOC_ADC_MAX_CHANNEL_NUM];
+	uint32_t stream_num_adc_output_samples;
+	uint32_t stream_num_adc_dma_samples;
+	bool dma_notify_via_work;
+#endif /* CONFIG_ADC_ESP32_STREAM */
 	bool digi_hw_active;
 #endif /* CONFIG_ADC_ESP32_DMA */
 };
@@ -74,6 +95,27 @@ int adc_esp32_dma_execute_read(const struct device *dev, const struct adc_sequen
 int adc_esp32_dma_finish_read(const struct device *dev, const struct adc_sequence *seq);
 
 int adc_esp32_dma_async_submit(const struct device *dev);
+
+#if defined(CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED)
+void adc_esp32_dma_calibrate_samples(struct adc_esp32_data *data, uint16_t *samples,
+				     const adc_digi_pattern_config_t *pattern, uint32_t pattern_len,
+				     unsigned int repeats, uint8_t resolution);
+#endif /* CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED */
+
+#if defined(CONFIG_ADC_ESP32_STREAM)
+int adc_esp32_dma_stream_validate(const struct device *dev, const struct adc_sequence *seq);
+
+int adc_esp32_dma_stream_start(const struct device *dev);
+
+int adc_esp32_dma_stream_queue_start(const struct device *dev);
+
+int adc_esp32_stream_arm(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+
+#if defined(CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED)
+void adc_esp32_stream_calibrate_frame(struct adc_esp32_data *data);
+#endif /* CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED */
+
+#endif /* CONFIG_ADC_ESP32_STREAM */
 
 int adc_esp32_dma_channel_setup(const struct device *dev, const struct adc_channel_cfg *cfg);
 

--- a/drivers/adc/adc_esp32.h
+++ b/drivers/adc/adc_esp32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Espressif Systems (Shanghai) CO LTD
+ * Copyright (c) 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,7 @@
 #include <hal/adc_oneshot_hal.h>
 #include <hal/adc_periph.h>
 #include <hal/adc_types.h>
+#include <soc/clk_tree_defs.h>
 #include <esp_adc/adc_cali.h>
 #include <esp_adc/adc_cali_scheme.h>
 
@@ -35,12 +36,22 @@ struct adc_esp32_data {
 	uint16_t meas_ref_internal;
 	uint16_t *buffer;
 #ifdef CONFIG_ADC_ESP32_DMA
+#include <hal/dma_types.h>
+
+#define ADC_ESP32_DMA_RX_DESC_COUNT                                                                \
+	((DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED + DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED -  \
+	  1U) / DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED +                                        \
+	 1U)
+
 	adc_hal_dma_ctx_t adc_hal_dma_ctx;
-	uint8_t *dma_buffer;
+	dma_descriptor_t dma_rx_desc[ADC_ESP32_DMA_RX_DESC_COUNT];
+	uint8_t dma_buffer[DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED];
 	struct k_sem dma_conv_wait_lock;
+	soc_module_clk_t digi_clk_src;
 #if !SOC_GDMA_SUPPORTED
 	struct intr_handle_data_t *irq_handle;
 #endif /* !SOC_GDMA_SUPPORTED */
+	bool digi_hw_active;
 #endif /* CONFIG_ADC_ESP32_DMA */
 };
 

--- a/drivers/adc/adc_esp32_dma.c
+++ b/drivers/adc/adc_esp32_dma.c
@@ -28,6 +28,33 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_esp32_dma, CONFIG_ADC_LOG_LEVEL);
 
+#if defined(CONFIG_ADC_ESP32_STREAM)
+#include <zephyr/rtio/rtio.h>
+
+K_THREAD_STACK_DEFINE(adc_esp32_stream_rtio_wq_stack, CONFIG_ADC_ESP32_STREAM_RTIO_WQ_STACK_SIZE);
+static struct k_work_q adc_esp32_stream_rtio_wq;
+static bool adc_esp32_stream_rtio_wq_started;
+
+static void adc_esp32_stream_rtio_wq_init(void)
+{
+	if (adc_esp32_stream_rtio_wq_started) {
+		return;
+	}
+
+	(void)k_work_queue_start(&adc_esp32_stream_rtio_wq, adc_esp32_stream_rtio_wq_stack,
+				 K_THREAD_STACK_SIZEOF(adc_esp32_stream_rtio_wq_stack),
+				 CONFIG_ADC_ESP32_STREAM_RTIO_WQ_PRIORITY, NULL);
+	adc_esp32_stream_rtio_wq_started = true;
+}
+
+static void adc_esp32_stream_dma_done_work_fn(struct k_work *work);
+static void adc_esp32_stream_start_work_fn(struct k_work *work);
+static void adc_esp32_stream_rtio_work_fn(struct k_work *work);
+static void adc_esp32_stream_resubmit_work_fn(struct k_work *work);
+
+#define ADC_ESP32_STREAM_RESUBMIT_RETRY_MS 2
+#endif
+
 #if SOC_GDMA_SUPPORTED
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/dma/dma_esp32.h>
@@ -47,7 +74,7 @@ LOG_MODULE_REGISTER(adc_esp32_dma, CONFIG_ADC_LOG_LEVEL);
 #define ADC_DMA_SPI_HOST SPI3_HOST
 #endif /* SOC_GDMA_SUPPORTED */
 
-#define ADC_DMA_BUFFER_SIZE        DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED
+#define ADC_DMA_BUFFER_SIZE        CONFIG_ADC_ESP32_DMA_BUFFER_SIZE
 #define ADC_DMA_MAX_CONV_DONE_TIME 1000
 
 #define UNIT_ATTEN_UNINIT UINT32_MAX
@@ -95,6 +122,13 @@ static void IRAM_ATTR adc_esp32_dma_conv_done(const struct device *dma_dev, void
 
 	const struct device *dev = user_data;
 	struct adc_esp32_data *data = dev->data;
+
+#ifdef CONFIG_ADC_ESP32_STREAM
+	if (data->dma_notify_via_work) {
+		(void)k_work_submit(&data->stream_done_work);
+		return;
+	}
+#endif /* CONFIG_ADC_ESP32_STREAM */
 
 	k_sem_give(&data->dma_conv_wait_lock);
 }
@@ -190,11 +224,23 @@ static IRAM_ATTR void adc_esp32_dma_intr_handler(void *arg)
 
 	if (i2s_ll_get_intr_status(i2s_dev) & ADC_DMA_INTR_MASK) {
 		i2s_ll_clear_intr_status(i2s_dev, ADC_DMA_INTR_MASK);
+#ifdef CONFIG_ADC_ESP32_STREAM
+		if (data->dma_notify_via_work) {
+			(void)k_work_submit(&data->stream_done_work);
+			return;
+		}
+#endif /* CONFIG_ADC_ESP32_STREAM */
 		k_sem_give(&data->dma_conv_wait_lock);
 	}
 #elif defined(CONFIG_SOC_SERIES_ESP32S2)
 	if (spi_ll_get_intr(SPI_LL_GET_HW(SPI3_HOST), ADC_DMA_INTR_MASK)) {
 		spi_ll_clear_intr(SPI_LL_GET_HW(SPI3_HOST), ADC_DMA_INTR_MASK);
+#ifdef CONFIG_ADC_ESP32_STREAM
+		if (data->dma_notify_via_work) {
+			(void)k_work_submit(&data->stream_done_work);
+			return;
+		}
+#endif /* CONFIG_ADC_ESP32_STREAM */
 		k_sem_give(&data->dma_conv_wait_lock);
 	}
 #endif /* defined(CONFIG_SOC_SERIES_ESP32) */
@@ -303,6 +349,62 @@ static void adc_esp32_dma_sample_counts(uint32_t number_of_samplings, uint32_t p
 	*dma_samples = *output_samples * ADC_ESP32_DMA_CAPTURE_FACTOR;
 	*dma_data_bytes = adc_esp32_dma_data_bytes(*dma_samples);
 }
+
+#ifdef CONFIG_ADC_ESP32_STREAM
+int adc_esp32_dma_stream_validate(const struct device *dev, const struct adc_sequence *seq)
+{
+	int err = 0;
+	uint32_t adc_pattern_len;
+	uint32_t unit_attenuation;
+	adc_hal_digi_ctrlr_cfg_t adc_hal_digi_ctrlr_cfg_placeholder;
+	adc_digi_pattern_config_t adc_digi_pattern_config[SOC_ADC_MAX_CHANNEL_NUM];
+	const struct adc_sequence_options *options = seq->options;
+	uint32_t sample_freq_hz;
+	uint32_t number_of_samplings = 1U;
+
+#if SOC_ADC_PERIPH_NUM >= 2
+	const struct adc_esp32_conf *conf = dev->config;
+
+	if (!SOC_ADC_DIG_SUPPORTED_UNIT(conf->unit)) {
+		LOG_ERR("ADC2 dma mode is no longer supported, please use ADC1!");
+		return -EINVAL;
+	}
+#endif /* SOC_ADC_PERIPH_NUM >= 2 */
+
+	err = adc_esp32_dma_sample_freq_hz(options, &sample_freq_hz);
+	if (err != 0) {
+		return err;
+	}
+
+	err = adc_esp32_fill_digi_ctrlr_cfg(dev, seq, sample_freq_hz, adc_digi_pattern_config,
+					    &adc_hal_digi_ctrlr_cfg_placeholder, &adc_pattern_len,
+					    &unit_attenuation);
+
+	if ((err != 0) || (adc_pattern_len == 0)) {
+		return err != 0 ? err : -EINVAL;
+	}
+
+	if (options != NULL) {
+		number_of_samplings = options->extra_samplings + 1U;
+	}
+
+	uint32_t number_of_adc_output_samples;
+	uint32_t number_of_adc_dma_samples;
+	uint32_t number_of_adc_dma_data_bytes;
+
+	adc_esp32_dma_sample_counts(number_of_samplings, adc_pattern_len,
+				    &number_of_adc_output_samples, &number_of_adc_dma_samples,
+				    &number_of_adc_dma_data_bytes);
+
+	if (number_of_adc_dma_data_bytes > ADC_DMA_BUFFER_SIZE) {
+		LOG_ERR("DMA buffer size insufficient (need %u, have %u)",
+			number_of_adc_dma_data_bytes, ADC_DMA_BUFFER_SIZE);
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_ADC_ESP32_STREAM */
 
 static void adc_esp32_dma_eof_ctx_config(struct adc_esp32_data *data, uint32_t sample_count)
 {
@@ -726,9 +828,203 @@ int adc_esp32_dma_read(const struct device *dev, const struct adc_sequence *seq)
 	adc_esp32_fill_seq_buffer(seq->buffer, data->dma_buffer, number_of_adc_dma_samples,
 				  number_of_adc_output_samples, adc_digi_pattern_config,
 				  adc_pattern_len);
+#if defined(CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED)
+	adc_esp32_dma_calibrate_samples(data, seq->buffer, adc_digi_pattern_config, adc_pattern_len,
+					number_of_adc_output_samples / adc_pattern_len,
+					seq->resolution);
+#endif /* CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED */
 
 	return 0;
 }
+
+#if defined(CONFIG_ADC_ESP32_STREAM)
+
+/*
+ * Pause the ADC between stream frames: same teardown as oneshot DMA reads so the
+ * next adc_esp32_digi_start() can re-acquire SAR power and locks cleanly.
+ */
+static int adc_esp32_stream_hw_stop_and_pack(struct adc_esp32_data *data, const struct device *dev)
+{
+	uint32_t dma_bytes = adc_esp32_dma_data_bytes(data->stream_num_adc_dma_samples);
+
+	adc_esp32_digi_stop(dev);
+
+	sys_cache_data_flush_and_invd_range(data->dma_buffer, dma_bytes);
+	adc_esp32_fill_seq_buffer(data->stream_seq_snap.buffer, data->dma_buffer,
+				  data->stream_num_adc_dma_samples,
+				  data->stream_num_adc_output_samples, data->stream_pattern,
+				  data->stream_digi_cfg.adc_pattern_len);
+#if defined(CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED)
+	adc_esp32_stream_calibrate_frame(data);
+#endif /* CONFIG_ADC_ESP32_DMA_DECODE_VOLTAGE_CALIBRATED */
+	return 0;
+}
+
+static void adc_esp32_stream_rtio_work_fn(struct k_work *work)
+{
+	struct adc_esp32_data *data = CONTAINER_OF(work, struct adc_esp32_data, stream_rtio_work);
+	struct rtio_iodev_sqe *sqe = data->stream_rtio_sqe;
+	int err = data->stream_rtio_err;
+
+	data->stream_rtio_sqe = NULL;
+
+	if (sqe == NULL) {
+		return;
+	}
+
+	if (err != 0) {
+		rtio_iodev_sqe_err(sqe, err);
+		return;
+	}
+
+	/*
+	 * Deliver the CQE before allocating the next mempool buffer. The default
+	 * multishot path in rtio_iodev_sqe_ok() resubmits first and can exhaust
+	 * the pool while the application still holds prior buffers.
+	 */
+	rtio_cqe_submit(sqe->r, 0, sqe->sqe.userdata, rtio_cqe_compute_flags(sqe));
+
+	if (FIELD_GET(RTIO_SQE_MEMPOOL_BUFFER, sqe->sqe.flags) == 1 && sqe->sqe.op == RTIO_OP_RX) {
+		sqe->sqe.rx.buf = NULL;
+		sqe->sqe.rx.buf_len = 0;
+	}
+
+	data->stream_resubmit_sqe = sqe;
+	(void)k_work_cancel_delayable(&data->stream_resubmit_dwork);
+	(void)k_work_schedule_for_queue(&adc_esp32_stream_rtio_wq, &data->stream_resubmit_dwork,
+					K_NO_WAIT);
+}
+
+static void adc_esp32_stream_resubmit_work_fn(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct adc_esp32_data *data =
+		CONTAINER_OF(dwork, struct adc_esp32_data, stream_resubmit_dwork);
+	const struct device *dev = data->dev;
+	struct rtio_iodev_sqe *sqe = data->stream_resubmit_sqe;
+	int err;
+
+	if (sqe == NULL) {
+		return;
+	}
+
+	err = adc_esp32_stream_arm(dev, sqe);
+	if (err == -ENOMEM) {
+		(void)k_work_schedule_for_queue(&adc_esp32_stream_rtio_wq,
+						&data->stream_resubmit_dwork,
+						K_MSEC(ADC_ESP32_STREAM_RESUBMIT_RETRY_MS));
+		return;
+	}
+
+	data->stream_resubmit_sqe = NULL;
+
+	if (err < 0) {
+		(void)k_work_cancel_delayable(&data->stream_resubmit_dwork);
+		LOG_ERR("stream resubmit failed (%d)", err);
+		rtio_iodev_sqe_err(sqe, err);
+	}
+}
+
+static void adc_esp32_stream_dma_done_work_fn(struct k_work *work)
+{
+	struct adc_esp32_data *data = CONTAINER_OF(work, struct adc_esp32_data, stream_done_work);
+	const struct device *dev = data->dev;
+	struct rtio_iodev_sqe *sqe = data->stream_iodev_sqe;
+	int err;
+
+	err = adc_esp32_stream_hw_stop_and_pack(data, dev);
+	data->dma_notify_via_work = false;
+	data->stream_iodev_sqe = NULL;
+
+	if (sqe == NULL) {
+		return;
+	}
+
+	if (err != 0) {
+		rtio_iodev_sqe_err(sqe, err);
+		return;
+	}
+
+	data->stream_rtio_sqe = sqe;
+	data->stream_rtio_err = 0;
+	(void)k_work_submit_to_queue(&adc_esp32_stream_rtio_wq, &data->stream_rtio_work);
+}
+
+static void adc_esp32_stream_start_work_fn(struct k_work *work)
+{
+	struct adc_esp32_data *data = CONTAINER_OF(work, struct adc_esp32_data, stream_start_work);
+	const struct device *dev = data->dev;
+	struct rtio_iodev_sqe *sqe = data->stream_iodev_sqe;
+	int err;
+
+	err = adc_esp32_dma_stream_start(dev);
+	if (err != 0) {
+		data->dma_notify_via_work = false;
+		data->stream_iodev_sqe = NULL;
+		adc_context_release(&data->ctx, err);
+		LOG_ERR("stream hw start failed (%d)", err);
+		if (sqe != NULL) {
+			rtio_iodev_sqe_err(sqe, err);
+		}
+		return;
+	}
+
+	adc_context_release(&data->ctx, 0);
+}
+
+int adc_esp32_dma_stream_queue_start(const struct device *dev)
+{
+	struct adc_esp32_data *data = dev->data;
+
+	adc_esp32_stream_rtio_wq_init();
+	return k_work_submit_to_queue(&adc_esp32_stream_rtio_wq, &data->stream_start_work);
+}
+
+int adc_esp32_dma_stream_start(const struct device *dev)
+{
+	struct adc_esp32_data *data = dev->data;
+	const struct adc_sequence *seq = &data->stream_seq_snap;
+	int err;
+	uint32_t adc_pattern_len, unit_attenuation;
+	uint32_t number_of_adc_output_samples;
+	uint32_t number_of_adc_dma_samples;
+	uint32_t number_of_adc_dma_data_bytes;
+
+	err = adc_esp32_dma_prep_read(dev, seq, &data->stream_digi_cfg, data->stream_pattern,
+				      &adc_pattern_len, &unit_attenuation,
+				      &number_of_adc_output_samples, &number_of_adc_dma_samples,
+				      &number_of_adc_dma_data_bytes);
+	if (err != 0) {
+		return err;
+	}
+
+	data->stream_num_adc_output_samples = number_of_adc_output_samples;
+	data->stream_num_adc_dma_samples = number_of_adc_dma_samples;
+
+	(void)k_sem_reset(&data->dma_conv_wait_lock);
+	sys_cache_data_flush_and_invd_range(data->dma_buffer, number_of_adc_dma_data_bytes);
+
+	err = adc_esp32_digi_start(dev, &data->stream_digi_cfg, number_of_adc_dma_samples,
+				   unit_attenuation, number_of_adc_dma_data_bytes);
+	if (err != 0) {
+		LOG_ERR("digi_start failed (%d)", err);
+		return err;
+	}
+
+#if !SOC_GDMA_SUPPORTED
+	err = adc_esp32_dma_intr_set(data, true);
+	if (err != 0) {
+		adc_esp32_digi_stop(dev);
+		return err;
+	}
+#endif /* !SOC_GDMA_SUPPORTED */
+
+	data->dma_notify_via_work = true;
+
+	return 0;
+}
+
+#endif /* CONFIG_ADC_ESP32_STREAM */
 
 int adc_esp32_dma_execute_read(const struct device *dev, const struct adc_sequence *seq)
 {
@@ -787,7 +1083,7 @@ int adc_esp32_dma_finish_read(const struct device *dev, const struct adc_sequenc
 int adc_esp32_dma_channel_setup(const struct device *dev, const struct adc_channel_cfg *cfg)
 {
 #if SOC_ADC_PERIPH_NUM >= 2
-	const struct adc_esp32_conf *conf = dev->config;
+	__maybe_unused const struct adc_esp32_conf *conf = dev->config;
 
 	if (!SOC_ADC_DIG_SUPPORTED_UNIT(conf->unit)) {
 		LOG_ERR("ADC2 dma mode is no longer supported, please use ADC1!");
@@ -861,6 +1157,20 @@ int adc_esp32_dma_init(const struct device *dev)
 #if defined(CONFIG_ADC_ASYNC)
 	k_work_init(&data->dma_async_work, adc_esp32_dma_async_work_fn);
 #endif /* CONFIG_ADC_ASYNC */
+
+#if defined(CONFIG_ADC_ESP32_STREAM)
+	adc_esp32_stream_rtio_wq_init();
+	k_work_init(&data->stream_done_work, adc_esp32_stream_dma_done_work_fn);
+	k_work_init(&data->stream_start_work, adc_esp32_stream_start_work_fn);
+	k_work_init(&data->stream_rtio_work, adc_esp32_stream_rtio_work_fn);
+	k_work_init_delayable(&data->stream_resubmit_dwork, adc_esp32_stream_resubmit_work_fn);
+	data->dma_notify_via_work = false;
+	data->stream_iodev_sqe = NULL;
+	data->stream_rtio_sqe = NULL;
+	data->stream_resubmit_sqe = NULL;
+	data->stream_num_adc_output_samples = 0U;
+	data->stream_num_adc_dma_samples = 0U;
+#endif /* CONFIG_ADC_ESP32_STREAM */
 
 	return 0;
 }

--- a/drivers/adc/adc_esp32_dma.c
+++ b/drivers/adc/adc_esp32_dma.c
@@ -59,6 +59,31 @@ LOG_MODULE_REGISTER(adc_esp32_dma, CONFIG_ADC_LOG_LEVEL);
 #define ADC_DMA_INTR_MASK SPI_LL_INTR_IN_SUC_EOF
 #endif
 
+/*
+ * adc_context.h forward-declares driver callbacks referenced from static inline helpers.
+ * This file only uses adc_context_* lock/complete paths; SAR samples are DMA-driven.
+ */
+static void adc_context_start_sampling(struct adc_context *ctx)
+{
+	ARG_UNUSED(ctx);
+}
+
+static void adc_context_update_buffer_pointer(struct adc_context *ctx, bool repeat_sampling)
+{
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(repeat_sampling);
+}
+
+static void adc_context_enable_timer(struct adc_context *ctx)
+{
+	ARG_UNUSED(ctx);
+}
+
+static void adc_context_disable_timer(struct adc_context *ctx)
+{
+	ARG_UNUSED(ctx);
+}
+
 #if SOC_GDMA_SUPPORTED
 
 static void IRAM_ATTR adc_esp32_dma_conv_done(const struct device *dma_dev, void *user_data,
@@ -705,6 +730,60 @@ int adc_esp32_dma_read(const struct device *dev, const struct adc_sequence *seq)
 	return 0;
 }
 
+int adc_esp32_dma_execute_read(const struct device *dev, const struct adc_sequence *seq)
+{
+	struct adc_esp32_data *data = dev->data;
+	uint32_t chans = seq->channels;
+
+	while (chans != 0U) {
+		uint8_t ch = find_lsb_set(chans) - 1;
+
+		data->resolution[ch] = seq->resolution;
+		chans &= ~BIT(ch);
+	}
+
+	return adc_esp32_dma_read(dev, seq);
+}
+
+#if defined(CONFIG_ADC_ASYNC)
+
+static void adc_esp32_dma_async_work_fn(struct k_work *work)
+{
+	struct adc_esp32_data *data = CONTAINER_OF(work, struct adc_esp32_data, dma_async_work);
+	const struct device *dev = data->dev;
+	int err;
+
+	err = adc_esp32_dma_execute_read(dev, &data->ctx.sequence);
+	adc_context_complete(&data->ctx, err);
+}
+
+int adc_esp32_dma_async_submit(const struct device *dev)
+{
+	struct adc_esp32_data *data = dev->data;
+	int ret = k_work_submit(&data->dma_async_work);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+#endif /* CONFIG_ADC_ASYNC */
+
+int adc_esp32_dma_finish_read(const struct device *dev, const struct adc_sequence *seq)
+{
+	struct adc_esp32_data *data = dev->data;
+	int err;
+
+	data->ctx.status = 0;
+	err = adc_esp32_dma_execute_read(dev, seq);
+
+	adc_context_complete(&data->ctx, err);
+
+	return adc_context_wait_for_completion(&data->ctx);
+}
+
 int adc_esp32_dma_channel_setup(const struct device *dev, const struct adc_channel_cfg *cfg)
 {
 #if SOC_ADC_PERIPH_NUM >= 2
@@ -778,6 +857,10 @@ int adc_esp32_dma_init(const struct device *dev)
 
 	data->digi_clk_src = 0U;
 	data->digi_hw_active = false;
+
+#if defined(CONFIG_ADC_ASYNC)
+	k_work_init(&data->dma_async_work, adc_esp32_dma_async_work_fn);
+#endif /* CONFIG_ADC_ASYNC */
 
 	return 0;
 }

--- a/drivers/adc/adc_esp32_dma.c
+++ b/drivers/adc/adc_esp32_dma.c
@@ -1,10 +1,12 @@
 /*
- * Copyright (c) 2025 Espressif Systems (Shanghai) CO LTD
+ * Copyright (c) 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #define DT_DRV_COMPAT espressif_esp32_adc
+
+#include <string.h>
 
 #include <esp_adc/adc_cali.h>
 #include <esp_clk_tree.h>
@@ -14,7 +16,15 @@
 
 #include "adc_esp32.h"
 
+#if SOC_GDMA_SUPPORTED || defined(CONFIG_SOC_SERIES_ESP32)
+#define ADC_ESP32_DMA_CAPTURE_FACTOR 2U
+#else
+#define ADC_ESP32_DMA_CAPTURE_FACTOR 1U
+#endif
+
 #include <zephyr/cache.h>
+#include <zephyr/sys/util.h>
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_esp32_dma, CONFIG_ADC_LOG_LEVEL);
 
@@ -55,6 +65,7 @@ static void IRAM_ATTR adc_esp32_dma_conv_done(const struct device *dma_dev, void
 					      uint32_t channel, int status)
 {
 	ARG_UNUSED(dma_dev);
+	ARG_UNUSED(channel);
 	ARG_UNUSED(status);
 
 	const struct device *dev = user_data;
@@ -63,7 +74,7 @@ static void IRAM_ATTR adc_esp32_dma_conv_done(const struct device *dma_dev, void
 	k_sem_give(&data->dma_conv_wait_lock);
 }
 
-static int adc_esp32_dma_start(const struct device *dev, uint8_t *buf, size_t len)
+static int adc_esp32_dma_config_rx(const struct device *dev, uint8_t *buf, size_t len)
 {
 	const struct adc_esp32_conf *conf = dev->config;
 	int err;
@@ -80,8 +91,17 @@ static int adc_esp32_dma_start(const struct device *dev, uint8_t *buf, size_t le
 	}
 
 	if (dma_status.busy) {
-		LOG_ERR("dma channel[%u] is busy!", (unsigned int)conf->dma_channel);
-		return -EBUSY;
+		for (int retry = 0; retry < 100 && dma_status.busy; retry++) {
+			k_busy_wait(10);
+			err = dma_get_status(conf->dma_dev, conf->dma_channel, &dma_status);
+			if (err != 0) {
+				return -EINVAL;
+			}
+		}
+		if (dma_status.busy) {
+			LOG_ERR("dma channel[%u] is busy!", (unsigned int)conf->dma_channel);
+			return -EBUSY;
+		}
 	}
 
 	dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
@@ -96,6 +116,18 @@ static int adc_esp32_dma_start(const struct device *dev, uint8_t *buf, size_t le
 	err = dma_config(conf->dma_dev, conf->dma_channel, &dma_cfg);
 	if (err) {
 		LOG_ERR("Error configuring dma (%d)", err);
+	}
+
+	return err;
+}
+
+static int adc_esp32_dma_start(const struct device *dev, uint8_t *buf, size_t len)
+{
+	const struct adc_esp32_conf *conf = dev->config;
+	int err;
+
+	err = adc_esp32_dma_config_rx(dev, buf, len);
+	if (err != 0) {
 		return err;
 	}
 
@@ -154,41 +186,36 @@ static int adc_esp32_fill_digi_ctrlr_cfg(const struct device *dev, const struct 
 	const struct adc_esp32_conf *conf = dev->config;
 	struct adc_esp32_data *data = dev->data;
 
-	adc_digi_pattern_config_t *adc_digi_pattern_config = pattern_config;
-	uint32_t channel_mask = 1, channels_copy = seq->channels;
+	uint32_t channels_copy = seq->channels;
 
 	*pattern_len = 0;
 	*unit_attenuation = UNIT_ATTEN_UNINIT;
-	for (uint8_t channel_id = 0; channel_id < conf->channel_count; channel_id++) {
-		if (channels_copy & channel_mask) {
-			if (*unit_attenuation == UNIT_ATTEN_UNINIT) {
-				*unit_attenuation = data->attenuation[channel_id];
-			}
 
-			if (*unit_attenuation != data->attenuation[channel_id]) {
-				LOG_ERR("Channel[%u] attenuation different of unit[%u] attenuation",
-					(unsigned int)channel_id, (unsigned int)conf->unit);
-				return -EINVAL;
-			}
+	while (channels_copy != 0U) {
+		uint8_t channel_id = find_lsb_set(channels_copy) - 1U;
 
-			adc_digi_pattern_config->atten = data->attenuation[channel_id];
-			adc_digi_pattern_config->channel = channel_id;
-			adc_digi_pattern_config->unit = conf->unit;
-			adc_digi_pattern_config->bit_width = seq->resolution;
-			adc_digi_pattern_config++;
+		channels_copy &= ~BIT(channel_id);
 
-			*pattern_len += 1;
-			if (*pattern_len > SOC_ADC_PATT_LEN_MAX) {
-				LOG_ERR("Max pattern len is %d", SOC_ADC_PATT_LEN_MAX);
-				return -EINVAL;
-			}
-
-			channels_copy &= ~channel_mask;
-			if (!channels_copy) {
-				break;
-			}
+		if (*unit_attenuation == UNIT_ATTEN_UNINIT) {
+			*unit_attenuation = data->attenuation[channel_id];
+		} else if (*unit_attenuation != data->attenuation[channel_id]) {
+			LOG_ERR("Channel[%u] attenuation different of unit[%u] attenuation",
+				(unsigned int)channel_id, (unsigned int)conf->unit);
+			return -EINVAL;
 		}
-		channel_mask <<= 1;
+
+		pattern_config[*pattern_len] = (adc_digi_pattern_config_t){
+			.atten = data->attenuation[channel_id],
+			.channel = channel_id,
+			.unit = conf->unit,
+			.bit_width = seq->resolution,
+		};
+
+		*pattern_len += 1;
+		if (*pattern_len > SOC_ADC_PATT_LEN_MAX) {
+			LOG_ERR("Max pattern len is %d", SOC_ADC_PATT_LEN_MAX);
+			return -EINVAL;
+		}
 	}
 
 	soc_module_clk_t clk_src = ADC_DIGI_CLK_SRC_DEFAULT;
@@ -211,20 +238,76 @@ static int adc_esp32_fill_digi_ctrlr_cfg(const struct device *dev, const struct 
 	return 0;
 }
 
+static uint32_t adc_esp32_dma_data_bytes(uint32_t dma_samples)
+{
+	return dma_samples * SOC_ADC_DIGI_DATA_BYTES_PER_CONV;
+}
+
+static int adc_esp32_dma_sample_freq_hz(const struct adc_sequence_options *options,
+					uint32_t *sample_freq_hz)
+{
+	*sample_freq_hz = SOC_ADC_SAMPLE_FREQ_THRES_HIGH;
+
+	if (options == NULL) {
+		return 0;
+	}
+
+	if (options->callback != NULL) {
+		return -ENOTSUP;
+	}
+
+	if (options->interval_us == 0U) {
+		return 0;
+	}
+
+	*sample_freq_hz = MHZ(1) / options->interval_us;
+	if ((*sample_freq_hz < SOC_ADC_SAMPLE_FREQ_THRES_LOW) ||
+	    (*sample_freq_hz > SOC_ADC_SAMPLE_FREQ_THRES_HIGH)) {
+		LOG_ERR("ADC sampling frequency out of range: %uHz", *sample_freq_hz);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static void adc_esp32_dma_sample_counts(uint32_t number_of_samplings, uint32_t pattern_len,
+					uint32_t *output_samples, uint32_t *dma_samples,
+					uint32_t *dma_data_bytes)
+{
+	*output_samples = number_of_samplings * pattern_len;
+	*dma_samples = *output_samples * ADC_ESP32_DMA_CAPTURE_FACTOR;
+	*dma_data_bytes = adc_esp32_dma_data_bytes(*dma_samples);
+}
+
+static void adc_esp32_dma_eof_ctx_config(struct adc_esp32_data *data, uint32_t sample_count)
+{
+	adc_hal_dma_config_t adc_hal_dma_config = {
+		.eof_desc_num = 1,
+		.eof_step = 1,
+		.eof_num = sample_count,
+	};
+
+	adc_hal_dma_ctx_config(&data->adc_hal_dma_ctx, &adc_hal_dma_config);
+}
+
 static int adc_esp32_digi_start(const struct device *dev,
 				adc_hal_digi_ctrlr_cfg_t *adc_hal_digi_ctrlr_cfg,
-				uint32_t number_of_adc_samples, uint32_t unit_attenuation,
+				uint32_t number_of_adc_dma_samples, uint32_t unit_attenuation,
 				uint32_t dma_buffer_size)
 {
 	const struct adc_esp32_conf *conf = dev->config;
 	struct adc_esp32_data *data = dev->data;
-	__maybe_unused int err = 0;
+#if !defined(CONFIG_SOC_SERIES_ESP32) || SOC_GDMA_SUPPORTED
+	int err;
+#endif
 
 	sar_periph_ctrl_adc_reset();
 	sar_periph_ctrl_adc_continuous_power_acquire();
 	adc_lock_acquire(conf->unit);
+	data->digi_hw_active = true;
 
 #if SOC_ADC_CALIBRATION_V1_SUPPORTED
+	adc_hal_calibration_init(conf->unit);
 	adc_set_hw_calibration_code(conf->unit, unit_attenuation);
 #endif /* SOC_ADC_CALIBRATION_V1_SUPPORTED */
 
@@ -236,19 +319,35 @@ static int adc_esp32_digi_start(const struct device *dev,
 	}
 #endif /* SOC_ADC_ARBITER_SUPPORTED */
 
-	adc_hal_dma_config_t adc_hal_dma_config = {
-		.eof_desc_num = 1,
-		.eof_step = 1,
-		.eof_num = number_of_adc_samples,
-	};
+	data->digi_clk_src = adc_hal_digi_ctrlr_cfg->clk_src;
 
-	adc_hal_dma_ctx_config(&data->adc_hal_dma_ctx, &adc_hal_dma_config);
+#if !defined(CONFIG_SOC_SERIES_ESP32)
+	err = esp_clk_tree_enable_src((soc_module_clk_t)adc_hal_digi_ctrlr_cfg->clk_src, true);
+	if (err != ESP_OK) {
+		goto digi_start_fail;
+	}
+#endif /* !CONFIG_SOC_SERIES_ESP32 */
+
+	adc_esp32_dma_eof_ctx_config(data, number_of_adc_dma_samples);
 	adc_hal_set_controller(conf->unit, ADC_HAL_CONTINUOUS_READ_MODE);
 	adc_hal_digi_init(&data->adc_hal_dma_ctx);
 	adc_hal_digi_controller_config(&data->adc_hal_dma_ctx, adc_hal_digi_ctrlr_cfg);
-
 	adc_hal_digi_enable(false);
 
+#if SOC_GDMA_SUPPORTED
+	err = adc_esp32_dma_stop(dev);
+	if (err != 0) {
+		goto digi_start_fail;
+	}
+
+	adc_hal_digi_connect(false);
+	adc_hal_digi_reset();
+
+	err = adc_esp32_dma_start(dev, data->dma_buffer, dma_buffer_size);
+	if (err != 0) {
+		goto digi_start_fail;
+	}
+#else
 #if defined(CONFIG_SOC_SERIES_ESP32)
 	i2s_dev_t *i2s_dev = I2S_LL_GET_HW(ADC_DMA_I2S_HOST);
 
@@ -268,10 +367,7 @@ static int adc_esp32_digi_start(const struct device *dev,
 #endif
 
 	adc_hal_digi_reset();
-
-#if !SOC_GDMA_SUPPORTED
 	adc_hal_digi_dma_link(&data->adc_hal_dma_ctx, data->dma_buffer);
-#endif
 
 #if defined(CONFIG_SOC_SERIES_ESP32)
 	i2s_ll_clear_intr_status(i2s_dev, ADC_DMA_INTR_MASK);
@@ -282,25 +378,52 @@ static int adc_esp32_digi_start(const struct device *dev,
 	spi_ll_clear_intr(spi_dev, ADC_DMA_INTR_MASK);
 	spi_ll_enable_intr(spi_dev, ADC_DMA_INTR_MASK);
 	spi_dma_ll_rx_start(spi_dev, 0, (lldesc_t *)data->adc_hal_dma_ctx.rx_desc);
-#elif SOC_GDMA_SUPPORTED
-	err = adc_esp32_dma_start(dev, data->dma_buffer, dma_buffer_size);
-	if (err) {
-		adc_lock_release(conf->unit);
-		sar_periph_ctrl_adc_continuous_power_release();
-		return err;
-	}
-#endif /* CONFIG_SOC_SERIES_ESP32 */
+#endif /* defined(CONFIG_SOC_SERIES_ESP32) */
+#endif /* SOC_GDMA_SUPPORTED */
 
 	adc_hal_digi_connect(true);
 	adc_hal_digi_enable(true);
 
 	return 0;
+
+#if !defined(CONFIG_SOC_SERIES_ESP32) || SOC_GDMA_SUPPORTED
+digi_start_fail:
+#if !defined(CONFIG_SOC_SERIES_ESP32)
+	if (data->digi_clk_src != 0U) {
+		(void)esp_clk_tree_enable_src((soc_module_clk_t)data->digi_clk_src, false);
+		data->digi_clk_src = 0U;
+	}
+#endif /* !CONFIG_SOC_SERIES_ESP32 */
+	if (data->digi_hw_active) {
+		data->digi_hw_active = false;
+		adc_lock_release(conf->unit);
+		sar_periph_ctrl_adc_continuous_power_release();
+	}
+	return -EIO;
+#endif /* !defined(CONFIG_SOC_SERIES_ESP32) || SOC_GDMA_SUPPORTED */
 }
 
 static void adc_esp32_digi_stop(const struct device *dev)
 {
 	const struct adc_esp32_conf *conf = dev->config;
+	struct adc_esp32_data *data = dev->data;
 
+	if (!data->digi_hw_active) {
+		return;
+	}
+
+	data->digi_hw_active = false;
+
+	adc_hal_digi_enable(false);
+	adc_hal_digi_connect(false);
+
+#if ADC_LL_WORKAROUND_CLEAR_EOF_COUNTER
+	adc_hal_digi_clr_eof();
+#endif
+
+#if SOC_GDMA_SUPPORTED
+	(void)adc_esp32_dma_stop(dev);
+#else
 #if defined(CONFIG_SOC_SERIES_ESP32)
 	i2s_dev_t *i2s_dev = I2S_LL_GET_HW(ADC_DMA_I2S_HOST);
 
@@ -314,33 +437,149 @@ static void adc_esp32_digi_stop(const struct device *dev)
 	spi_ll_clear_intr(spi_dev, ADC_DMA_INTR_MASK);
 	spi_dma_ll_rx_stop(spi_dev, 0);
 #endif /* CONFIG_SOC_SERIES_ESP32 */
-
-	adc_hal_digi_enable(false);
-	adc_hal_digi_connect(false);
-
-#if ADC_LL_WORKAROUND_CLEAR_EOF_COUNTER
-	adc_hal_digi_clr_eof();
-#endif
+#endif /* SOC_GDMA_SUPPORTED */
 
 	adc_hal_digi_deinit();
 	adc_lock_release(conf->unit);
 	sar_periph_ctrl_adc_continuous_power_release();
+
+#if !defined(CONFIG_SOC_SERIES_ESP32)
+	if (data->digi_clk_src != 0U) {
+		(void)esp_clk_tree_enable_src((soc_module_clk_t)data->digi_clk_src, false);
+		data->digi_clk_src = 0U;
+	}
+#endif /* !CONFIG_SOC_SERIES_ESP32 */
 }
 
-static void adc_esp32_fill_seq_buffer(const void *seq_buffer, const void *dma_buffer,
-				      uint32_t number_of_samples)
-{
-	uint16_t *sample = (uint16_t *)seq_buffer;
-	adc_digi_output_data_t *digi_data = (adc_digi_output_data_t *)dma_buffer;
-
-	for (uint32_t k = 0; k < number_of_samples; k++) {
 #if SOC_GDMA_SUPPORTED
-		*sample++ = (uint16_t)(digi_data++)->type2.data;
+static bool adc_esp32_digi_sample_parse(const adc_digi_output_data_t *digi_data, uint8_t *channel,
+					uint16_t *data)
+{
+	uint8_t ch = digi_data->type2.channel;
+
+#if SOC_ADC_PERIPH_NUM >= 2
+	adc_unit_t unit = digi_data->type2.unit ? ADC_UNIT_2 : ADC_UNIT_1;
+
+	if (unit == ADC_UNIT_2) {
+		ch -= ADC_LL_UNIT2_CHANNEL_SUBSTRATION;
+	}
+
+	if (ch >= SOC_ADC_CHANNEL_NUM(unit)) {
+		return false;
+	}
 #else
-		*sample++ = (uint16_t)(digi_data++)->type1.data;
+	if (ch >= SOC_ADC_CHANNEL_NUM(ADC_UNIT_1)) {
+		return false;
+	}
+#endif /* SOC_ADC_PERIPH_NUM >= 2 */
+
+	*channel = ch;
+	*data = (uint16_t)digi_data->type2.data;
+
+	return true;
+}
+
+static const adc_digi_output_data_t *adc_esp32_gdma_dma_sample(const void *dma_buffer, uint32_t idx)
+{
+	return (const adc_digi_output_data_t *)((const uint8_t *)dma_buffer +
+						(idx * SOC_ADC_DIGI_DATA_BYTES_PER_CONV));
+}
 #endif /* SOC_GDMA_SUPPORTED */
+
+#if !SOC_GDMA_SUPPORTED
+static void adc_esp32_fill_seq_buffer_type1(uint16_t *sample, const void *dma_buffer,
+					    uint32_t dma_sample_count, unsigned int repeats,
+					    uint32_t pattern_len,
+					    const adc_digi_pattern_config_t *pattern)
+{
+	uint32_t raw_samples =
+		adc_esp32_dma_data_bytes(dma_sample_count) / SOC_ADC_DIGI_RESULT_BYTES;
+	uint8_t round_counts[SOC_ADC_PATT_LEN_MAX] = {0};
+
+	for (uint32_t i = 0U; i < raw_samples; i++) {
+		const adc_digi_output_data_t *digi =
+			(const adc_digi_output_data_t *)((const uint8_t *)dma_buffer +
+							 (i * SOC_ADC_DIGI_RESULT_BYTES));
+		uint8_t ch = digi->type1.channel;
+
+		if (ch >= SOC_ADC_CHANNEL_NUM(ADC_UNIT_1)) {
+			continue;
+		}
+
+		for (uint32_t p = 0U; p < pattern_len; p++) {
+			if (pattern[p].channel != ch) {
+				continue;
+			}
+
+			unsigned int round = round_counts[p];
+
+			if (round < repeats) {
+				round_counts[p]++;
+				sample[(round * pattern_len) + p] = (uint16_t)digi->type1.data;
+			}
+			break;
+		}
 	}
 }
+#endif /* !SOC_GDMA_SUPPORTED */
+
+static void adc_esp32_fill_seq_buffer(const void *seq_buffer, const void *dma_buffer,
+				      uint32_t dma_sample_count, uint32_t output_sample_count,
+				      const adc_digi_pattern_config_t *pattern,
+				      uint32_t pattern_len)
+{
+	uint16_t *sample = (uint16_t *)seq_buffer;
+
+	if ((seq_buffer == NULL) || (dma_buffer == NULL) || (dma_sample_count == 0U) ||
+	    (output_sample_count == 0U) || (pattern == NULL) || (pattern_len == 0U) ||
+	    ((output_sample_count % pattern_len) != 0U)) {
+		return;
+	}
+
+	unsigned int repeats = output_sample_count / pattern_len;
+
+	memset(sample, 0, output_sample_count * sizeof(uint16_t));
+
+#if SOC_GDMA_SUPPORTED
+	uint32_t words_per_round = dma_sample_count / repeats;
+
+	for (unsigned int r = 0U; r < repeats; r++) {
+		uint32_t out_base = r * pattern_len;
+		uint32_t round_lo = r * words_per_round;
+		uint32_t round_hi = round_lo + words_per_round;
+
+		for (uint32_t p = 0U; p < pattern_len; p++) {
+			uint8_t want_ch = pattern[p].channel;
+
+			sample[out_base + p] = 0U;
+			for (uint32_t k = round_hi; k-- > round_lo;) {
+				uint8_t ch;
+				uint16_t val;
+				const adc_digi_output_data_t *digi =
+					adc_esp32_gdma_dma_sample(dma_buffer, k);
+
+				if (!adc_esp32_digi_sample_parse(digi, &ch, &val) ||
+				    (ch != want_ch)) {
+					continue;
+				}
+
+				sample[out_base + p] = val;
+				break;
+			}
+		}
+	}
+#else
+	adc_esp32_fill_seq_buffer_type1(sample, dma_buffer, dma_sample_count, repeats, pattern_len,
+					pattern);
+#endif /* SOC_GDMA_SUPPORTED */
+}
+
+#if !SOC_GDMA_SUPPORTED
+static int adc_esp32_dma_intr_set(struct adc_esp32_data *data, bool enable)
+{
+	return enable ? esp_intr_enable(data->irq_handle) : esp_intr_disable(data->irq_handle);
+}
+#endif /* !SOC_GDMA_SUPPORTED */
 
 static int adc_esp32_wait_for_dma_conv_done(const struct device *dev)
 {
@@ -355,34 +594,31 @@ static int adc_esp32_wait_for_dma_conv_done(const struct device *dev)
 	return err;
 }
 
-int adc_esp32_dma_read(const struct device *dev, const struct adc_sequence *seq)
+static int adc_esp32_dma_prep_read(const struct device *dev, const struct adc_sequence *seq,
+				   adc_hal_digi_ctrlr_cfg_t *adc_hal_digi_ctrlr_cfg,
+				   adc_digi_pattern_config_t *adc_digi_pattern_config,
+				   uint32_t *adc_pattern_len, uint32_t *unit_attenuation,
+				   uint32_t *number_of_adc_output_samples,
+				   uint32_t *number_of_adc_dma_samples,
+				   uint32_t *number_of_adc_dma_data_bytes)
 {
-	struct adc_esp32_data *data = dev->data;
-	int err = 0;
-	uint32_t adc_pattern_len, unit_attenuation;
-	adc_hal_digi_ctrlr_cfg_t adc_hal_digi_ctrlr_cfg;
-	adc_digi_pattern_config_t adc_digi_pattern_config[SOC_ADC_MAX_CHANNEL_NUM];
-
+	uint32_t sample_freq_hz;
+	uint32_t number_of_samplings = 1;
 	const struct adc_sequence_options *options = seq->options;
-	uint32_t sample_freq_hz = SOC_ADC_SAMPLE_FREQ_THRES_HIGH, number_of_samplings = 1;
+	int err;
 
-	if (options && options->callback) {
-		return -ENOTSUP;
-	}
-
-	if (options && options->interval_us) {
-		sample_freq_hz = MHZ(1) / options->interval_us;
-		if (sample_freq_hz < SOC_ADC_SAMPLE_FREQ_THRES_LOW ||
-		    sample_freq_hz > SOC_ADC_SAMPLE_FREQ_THRES_HIGH) {
-			LOG_ERR("ADC sampling frequency out of range: %uHz", sample_freq_hz);
-			return -EINVAL;
-		}
+	err = adc_esp32_dma_sample_freq_hz(options, &sample_freq_hz);
+	if (err != 0) {
+		return err;
 	}
 
 	err = adc_esp32_fill_digi_ctrlr_cfg(dev, seq, sample_freq_hz, adc_digi_pattern_config,
-					    &adc_hal_digi_ctrlr_cfg, &adc_pattern_len,
-					    &unit_attenuation);
-	if (err || adc_pattern_len == 0) {
+					    adc_hal_digi_ctrlr_cfg, adc_pattern_len,
+					    unit_attenuation);
+	if (err != 0) {
+		return err;
+	}
+	if (*adc_pattern_len == 0) {
 		return -EINVAL;
 	}
 
@@ -390,64 +626,97 @@ int adc_esp32_dma_read(const struct device *dev, const struct adc_sequence *seq)
 		number_of_samplings = options->extra_samplings + 1;
 	}
 
-	if (seq->buffer_size < (number_of_samplings * sizeof(uint16_t))) {
+	adc_esp32_dma_sample_counts(number_of_samplings, *adc_pattern_len,
+				    number_of_adc_output_samples, number_of_adc_dma_samples,
+				    number_of_adc_dma_data_bytes);
+
+	if (seq->buffer_size < (*number_of_adc_output_samples * sizeof(uint16_t))) {
 		LOG_ERR("buffer size is not enough to store all samples!");
 		return -EINVAL;
 	}
 
-	uint32_t number_of_adc_samples = number_of_samplings * adc_pattern_len;
-	uint32_t number_of_adc_dma_data_bytes =
-		number_of_adc_samples * SOC_ADC_DIGI_DATA_BYTES_PER_CONV;
+	if (*number_of_adc_dma_data_bytes > ADC_DMA_BUFFER_SIZE) {
+		LOG_ERR("DMA buffer size insufficient (need %u, have %u)",
+			*number_of_adc_dma_data_bytes, ADC_DMA_BUFFER_SIZE);
+		return -ENOMEM;
+	}
 
-	if (number_of_adc_dma_data_bytes > ADC_DMA_BUFFER_SIZE) {
-		LOG_ERR("dma buffer size insufficient to store a complete sequence!");
-		return -EINVAL;
+	return 0;
+}
+
+int adc_esp32_dma_read(const struct device *dev, const struct adc_sequence *seq)
+{
+	struct adc_esp32_data *data = dev->data;
+	int err = 0;
+	uint32_t adc_pattern_len, unit_attenuation;
+	uint32_t number_of_adc_output_samples;
+	uint32_t number_of_adc_dma_samples;
+	uint32_t number_of_adc_dma_data_bytes;
+	adc_hal_digi_ctrlr_cfg_t adc_hal_digi_ctrlr_cfg;
+	adc_digi_pattern_config_t adc_digi_pattern_config[SOC_ADC_MAX_CHANNEL_NUM];
+
+	err = adc_esp32_dma_prep_read(dev, seq, &adc_hal_digi_ctrlr_cfg, adc_digi_pattern_config,
+				      &adc_pattern_len, &unit_attenuation,
+				      &number_of_adc_output_samples, &number_of_adc_dma_samples,
+				      &number_of_adc_dma_data_bytes);
+	if (err != 0) {
+		return err;
+	}
+
+	err = adc_esp32_digi_start(dev, &adc_hal_digi_ctrlr_cfg, number_of_adc_dma_samples,
+				   unit_attenuation, number_of_adc_dma_data_bytes);
+	if (err != 0) {
+		return err;
 	}
 
 #if !SOC_GDMA_SUPPORTED
-	err = esp_intr_enable(data->irq_handle);
-	if (err) {
+	err = adc_esp32_dma_intr_set(data, true);
+	if (err != 0) {
+		adc_esp32_digi_stop(dev);
 		return err;
 	}
 #endif /* !SOC_GDMA_SUPPORTED */
 
-	err = adc_esp32_digi_start(dev, &adc_hal_digi_ctrlr_cfg, number_of_adc_samples,
-				   unit_attenuation, number_of_adc_dma_data_bytes);
-	if (err) {
-		return err;
-	}
-
 	err = adc_esp32_wait_for_dma_conv_done(dev);
-	if (err) {
+	if (err != 0) {
+		adc_esp32_digi_stop(dev);
+
+#if !SOC_GDMA_SUPPORTED
+		(void)adc_esp32_dma_intr_set(data, false);
+#endif /* !SOC_GDMA_SUPPORTED */
+
 		return err;
 	}
 
 	adc_esp32_digi_stop(dev);
 
-#if SOC_GDMA_SUPPORTED
-	err = adc_esp32_dma_stop(dev);
-#else
-	err = esp_intr_disable(data->irq_handle);
-#endif /* SOC_GDMA_SUPPORTED */
-	if (err) {
+#if !SOC_GDMA_SUPPORTED
+	err = adc_esp32_dma_intr_set(data, false);
+	if (err != 0) {
 		return err;
 	}
+#endif /* !SOC_GDMA_SUPPORTED */
 
-	sys_cache_data_flush_and_invd_range(data->dma_buffer, ADC_DMA_BUFFER_SIZE);
-	adc_esp32_fill_seq_buffer(seq->buffer, data->dma_buffer, number_of_adc_samples);
+	sys_cache_data_flush_and_invd_range(data->dma_buffer, number_of_adc_dma_data_bytes);
+	adc_esp32_fill_seq_buffer(seq->buffer, data->dma_buffer, number_of_adc_dma_samples,
+				  number_of_adc_output_samples, adc_digi_pattern_config,
+				  adc_pattern_len);
 
 	return 0;
 }
 
 int adc_esp32_dma_channel_setup(const struct device *dev, const struct adc_channel_cfg *cfg)
 {
-	__maybe_unused const struct adc_esp32_conf *conf =
-		(const struct adc_esp32_conf *)dev->config;
+#if SOC_ADC_PERIPH_NUM >= 2
+	const struct adc_esp32_conf *conf = dev->config;
 
 	if (!SOC_ADC_DIG_SUPPORTED_UNIT(conf->unit)) {
 		LOG_ERR("ADC2 dma mode is no longer supported, please use ADC1!");
 		return -EINVAL;
 	}
+#else
+	ARG_UNUSED(cfg);
+#endif /* SOC_ADC_PERIPH_NUM >= 2 */
 
 	return 0;
 }
@@ -461,20 +730,12 @@ int adc_esp32_dma_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	data->adc_hal_dma_ctx.rx_desc = k_aligned_alloc(sizeof(uint32_t), sizeof(dma_descriptor_t));
-	if (!data->adc_hal_dma_ctx.rx_desc) {
-		LOG_ERR("rx_desc allocation failed!");
-		return -ENOMEM;
-	}
-	LOG_DBG("rx_desc = 0x%08X", (unsigned int)data->adc_hal_dma_ctx.rx_desc);
+	data->adc_hal_dma_ctx.rx_desc = data->dma_rx_desc;
 
-	data->dma_buffer = k_aligned_alloc(sizeof(uint32_t), ADC_DMA_BUFFER_SIZE);
-	if (!data->dma_buffer) {
-		LOG_ERR("dma buffer allocation failed!");
-		k_free(data->adc_hal_dma_ctx.rx_desc);
-		return -ENOMEM;
-	}
-	LOG_DBG("data->dma_buffer = 0x%08X", (unsigned int)data->dma_buffer);
+	LOG_DBG("rx_desc = 0x%08X (%u entries)", (unsigned int)data->adc_hal_dma_ctx.rx_desc,
+		ADC_ESP32_DMA_RX_DESC_COUNT);
+	LOG_DBG("data->dma_buffer = 0x%08X (%u bytes)", (unsigned int)data->dma_buffer,
+		ADC_DMA_BUFFER_SIZE);
 
 #ifdef CONFIG_SOC_SERIES_ESP32
 	periph_module_enable(PERIPH_I2S0_MODULE);
@@ -487,8 +748,6 @@ int adc_esp32_dma_init(const struct device *dev)
 				 adc_esp32_dma_intr_handler, (void *)dev, &(data->irq_handle));
 	if (err != 0) {
 		LOG_ERR("Could not allocate interrupt (err %d)", err);
-		k_free(data->adc_hal_dma_ctx.rx_desc);
-		k_free(data->dma_buffer);
 		return err;
 	}
 #endif /* CONFIG_SOC_SERIES_ESP32 */
@@ -509,8 +768,6 @@ int adc_esp32_dma_init(const struct device *dev)
 				 adc_esp32_dma_intr_handler, (void *)dev, &(data->irq_handle));
 	if (err != 0) {
 		LOG_ERR("Could not allocate interrupt (err %d)", err);
-		k_free(data->adc_hal_dma_ctx.rx_desc);
-		k_free(data->dma_buffer);
 		return err;
 	}
 #endif /* CONFIG_SOC_SERIES_ESP32S2 */
@@ -518,6 +775,9 @@ int adc_esp32_dma_init(const struct device *dev)
 #if SOC_GDMA_SUPPORTED
 	adc_apb_periph_claim();
 #endif /* SOC_GDMA_SUPPORTED */
+
+	data->digi_clk_src = 0U;
+	data->digi_hw_active = false;
 
 	return 0;
 }

--- a/samples/drivers/adc/adc_sequence/boards/esp32c6_devkitc_hpcore.conf
+++ b/samples/drivers/adc/adc_sequence/boards/esp32c6_devkitc_hpcore.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_ADC_ESP32_DMA=y

--- a/samples/drivers/adc/adc_sequence/boards/esp32c6_devkitc_hpcore.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/esp32c6_devkitc_hpcore.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	dmas = <&dma 2>;
+};
+
+&dma {
+	status = "okay";
+};

--- a/samples/drivers/adc/adc_sequence/boards/esp32s3_devkitc_procpu.conf
+++ b/samples/drivers/adc/adc_sequence/boards/esp32s3_devkitc_procpu.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_ADC_ESP32_DMA=y

--- a/samples/drivers/adc/adc_sequence/boards/esp32s3_devkitc_procpu.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/esp32s3_devkitc_procpu.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	dmas = <&dma 2>;
+};
+
+&dma {
+	status = "okay";
+};

--- a/samples/drivers/adc/adc_stream/boards/esp32_devkitc_procpu.conf
+++ b/samples/drivers/adc/adc_stream/boards/esp32_devkitc_procpu.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096

--- a/samples/drivers/adc/adc_stream/boards/esp32_devkitc_procpu.overlay
+++ b/samples/drivers/adc/adc_stream/boards/esp32_devkitc_procpu.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+
+	zephyr,user {
+		io-channels = <&adc0 3>, <&adc0 6>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_stream/boards/esp32c3_devkitm.conf
+++ b/samples/drivers/adc/adc_stream/boards/esp32c3_devkitm.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096

--- a/samples/drivers/adc/adc_stream/boards/esp32c3_devkitm.overlay
+++ b/samples/drivers/adc/adc_stream/boards/esp32c3_devkitm.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	dmas = <&dma 2>;
+};
+
+&dma {
+	status = "okay";
+};

--- a/samples/drivers/adc/adc_stream/boards/esp32c6_devkitc_hpcore.conf
+++ b/samples/drivers/adc/adc_stream/boards/esp32c6_devkitc_hpcore.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096

--- a/samples/drivers/adc/adc_stream/boards/esp32c6_devkitc_hpcore.overlay
+++ b/samples/drivers/adc/adc_stream/boards/esp32c6_devkitc_hpcore.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+
+	zephyr,user {
+		io-channels = <&adc0 2>, <&adc0 3>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	dmas = <&dma 2>;
+};
+
+&dma {
+	status = "okay";
+};

--- a/samples/drivers/adc/adc_stream/boards/esp32h2_devkitm.conf
+++ b/samples/drivers/adc/adc_stream/boards/esp32h2_devkitm.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096

--- a/samples/drivers/adc/adc_stream/boards/esp32h2_devkitm.overlay
+++ b/samples/drivers/adc/adc_stream/boards/esp32h2_devkitm.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+
+	zephyr,user {
+		io-channels = <&adc0 2>, <&adc0 3>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	dmas = <&dma 2>;
+};
+
+&dma {
+	status = "okay";
+};

--- a/samples/drivers/adc/adc_stream/boards/esp32s2_devkitc.conf
+++ b/samples/drivers/adc/adc_stream/boards/esp32s2_devkitc.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096

--- a/samples/drivers/adc/adc_stream/boards/esp32s2_devkitc.overlay
+++ b/samples/drivers/adc/adc_stream/boards/esp32s2_devkitc.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};
+
+&spi3 {
+	status = "disabled";
+};

--- a/samples/drivers/adc/adc_stream/boards/esp32s3_devkitc_procpu.conf
+++ b/samples/drivers/adc/adc_stream/boards/esp32s3_devkitc_procpu.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096

--- a/samples/drivers/adc/adc_stream/boards/esp32s3_devkitc_procpu.overlay
+++ b/samples/drivers/adc/adc_stream/boards/esp32s3_devkitc_procpu.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	dmas = <&dma 2>;
+};
+
+&dma {
+	status = "okay";
+};

--- a/samples/drivers/adc/adc_stream/src/main.c
+++ b/samples/drivers/adc/adc_stream/src/main.c
@@ -138,7 +138,7 @@ static int print_adc_stream(const struct device *adc, struct rtio_iodev *local_i
 int main(void)
 {
 	int ret;
-	struct adc_sequence sequence;
+	struct adc_sequence sequence = {0};
 	struct adc_read_config *read_cfg = iodev.data;
 
 	read_cfg->sequence = &sequence;

--- a/tests/drivers/adc/adc_api/boards/esp32_devkitc_procpu.conf
+++ b/tests/drivers/adc/adc_api/boards/esp32_devkitc_procpu.conf
@@ -1,1 +1,0 @@
-CONFIG_ADC_ASYNC=n

--- a/tests/drivers/adc/adc_api/boards/esp32s2_devkitc.conf
+++ b/tests/drivers/adc/adc_api/boards/esp32s2_devkitc.conf
@@ -1,1 +1,0 @@
-CONFIG_ADC_ASYNC=n

--- a/tests/drivers/adc/adc_api/boards/esp32s3_devkitc_procpu.conf
+++ b/tests/drivers/adc/adc_api/boards/esp32s3_devkitc_procpu.conf
@@ -1,1 +1,0 @@
-CONFIG_ADC_ASYNC=n

--- a/tests/drivers/adc/adc_api/boards/esp32s3_luatos_core_procpu.conf
+++ b/tests/drivers/adc/adc_api/boards/esp32s3_luatos_core_procpu.conf
@@ -1,1 +1,0 @@
-CONFIG_ADC_ASYNC=n

--- a/tests/drivers/adc/adc_api/boards/esp32s3_luatos_core_procpu_usb.conf
+++ b/tests/drivers/adc/adc_api/boards/esp32s3_luatos_core_procpu_usb.conf
@@ -1,1 +1,0 @@
-CONFIG_ADC_ASYNC=n


### PR DESCRIPTION
This PR extends the ESP32 ADC driver with correct GDMA buffer packing, `adc_read_async()` support (oneshot and DMA), RTIO `adc_stream()` streaming, and a unified `ADC_ESP32_DMA_DECODE` Kconfig choice. Add Espressif board overlays for the `adc_stream` and `adc_sequence` samples, enable the `adc_api` asynchronous test on boards that previously forced `CONFIG_ADC_ASYNC=n`, and fix an `adc_stream` sample init bug.