### PR TITLE
pmci: mctp_usb

### DIFF
--- a/subsys/pmci/mctp/mctp_usb.c
+++ b/subsys/pmci/mctp/mctp_usb.c
@@ -509,12 +509,12 @@ static int mctp_usb_class_init(struct usbd_class_data *const c_data)
 	k_work_init(&ctx->out_work, mctp_usb_class_out_work);
 	atomic_set(&ctx->in_pending, 0);
 
-	if (ctx->inst->sublcass == USBD_MCTP_SUBCLASS_MANAGEMENT_CONTROLLER ||
-	    ctx->inst->sublcass == USBD_MCTP_SUBCLASS_MANAGED_DEVICE_ENDPOINT ||
-	    ctx->inst->sublcass == USBD_MCTP_SUBCLASS_HOST_INTERFACE_ENDPOINT) {
-		ctx->desc->if0.bInterfaceSubClass = ctx->inst->sublcass;
+	if (ctx->inst->subclass == USBD_MCTP_SUBCLASS_MANAGEMENT_CONTROLLER ||
+	    ctx->inst->subclass == USBD_MCTP_SUBCLASS_MANAGED_DEVICE_ENDPOINT ||
+	    ctx->inst->subclass == USBD_MCTP_SUBCLASS_HOST_INTERFACE_ENDPOINT) {
+		ctx->desc->if0.bInterfaceSubClass = ctx->inst->subclass;
 	} else {
-		LOG_ERR("Invalid USB MCTP sublcass");
+		LOG_ERR("Invalid USB MCTP subclass");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Change sublcass to subclass to avoid compilation errors.