### PR TITLE
scripts: west_commands: Fix missing dummy config in test_build.py

### DIFF
--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -196,6 +196,7 @@ def test_test_item_updates_source_dir(tmp_path, monkeypatch):
     )
 
     b = Build()
+    b.config = _FakeConfig()
 
     parser = argparse.ArgumentParser(allow_abbrev=False)
     subparser = parser.add_subparsers()


### PR DESCRIPTION
Attach a fake config to the test build command.