### PR TITLE
scripts: west_commands: tests: Monkeypatch topdir

### DIFF
--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -51,12 +51,6 @@ jobs:
       run: |
         pip install -r scripts/requirements-actions.txt --require-hashes
 
-    - name: west setup
-      run: |
-        git config --global user.email "you@example.com"
-        git config --global user.name "Your Name"
-        west init -l . || true
-
     - name: run pytest-win
       if: runner.os == 'Windows'
       run: |

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -173,6 +173,7 @@ def test_cmake_args(monkeypatch, test_case):
             previous_position = current_position
 
     monkeypatch.setattr('build.run_cmake', run_cmake_mock)
+    monkeypatch.setattr('build.west_topdir', lambda start=None, fall_back=True: '/west/topdir')
     monkeypatch.setattr(b, '_banner', lambda _: True)
 
     # --- Trigger CMake run ---


### PR DESCRIPTION
Allow running the test suite locally without creating a west workspace first. Without the `monkeypatch` a `WestNotFound` exception would be raised.

Now allows to run the following locally:

```shell
python scripts/west_commands/run_tests.py
```