### PR TITLE
drivers: audio: codec_shell: add codec configure shell command

### DIFF
--- a/drivers/audio/codec_shell.c
+++ b/drivers/audio/codec_shell.c
@@ -25,6 +25,11 @@
 	SHELL_HELP("Apply any cached properties",                                                  \
 		   "<device>")
 
+#define CODEC_CONFIGURE_HELP                                                                       \
+	SHELL_HELP("Configure the codec I2S DAI for a stream",                                     \
+		   "<device> <rate> <bits> <channels> <playback|capture|both> "                   \
+		   "[controller|target]")
+
 static const char *const codec_property_name[] = {
 	[AUDIO_PROPERTY_OUTPUT_VOLUME] = "volume",
 	[AUDIO_PROPERTY_OUTPUT_MUTE] = "mute",
@@ -195,6 +200,72 @@ static int cmd_apply_prop(const struct shell *sh, size_t argc, char *argv[])
 	return audio_codec_apply_properties(dev);
 }
 
+static int cmd_configure(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct device *dev;
+	struct audio_codec_cfg cfg = {0};
+	long rate;
+	long bits;
+	long channels;
+	char *endptr;
+
+	dev = shell_device_get_binding(argv[1]);
+	if (!dev) {
+		shell_error(sh, "Audio Codec device not found");
+		return -ENODEV;
+	}
+
+	rate = strtol(argv[2], &endptr, 0);
+	if (*endptr != '\0' || rate <= 0 || rate > UINT32_MAX) {
+		shell_error(sh, "Invalid rate '%s'", argv[2]);
+		return -EINVAL;
+	}
+
+	bits = strtol(argv[3], &endptr, 0);
+	if (*endptr != '\0' || bits <= 0 || bits > UINT8_MAX) {
+		shell_error(sh, "Invalid bits '%s'", argv[3]);
+		return -EINVAL;
+	}
+
+	channels = strtol(argv[4], &endptr, 0);
+	if (*endptr != '\0' || channels <= 0 || channels > UINT8_MAX) {
+		shell_error(sh, "Invalid channels '%s'", argv[4]);
+		return -EINVAL;
+	}
+
+	if (strcmp(argv[5], "playback") == 0) {
+		cfg.dai_route = AUDIO_ROUTE_PLAYBACK;
+	} else if (strcmp(argv[5], "capture") == 0) {
+		cfg.dai_route = AUDIO_ROUTE_CAPTURE;
+	} else if (strcmp(argv[5], "both") == 0) {
+		cfg.dai_route = AUDIO_ROUTE_PLAYBACK_CAPTURE;
+	} else {
+		shell_error(sh, "Route must be playback, capture or both");
+		return -EINVAL;
+	}
+
+	cfg.dai_type = AUDIO_DAI_TYPE_I2S;
+	cfg.dai_cfg.i2s.word_size = (uint8_t)bits;
+	cfg.dai_cfg.i2s.channels = (uint8_t)channels;
+	cfg.dai_cfg.i2s.format = I2S_FMT_DATA_FORMAT_I2S;
+	cfg.dai_cfg.i2s.frame_clk_freq = (uint32_t)rate;
+
+	/*
+	 * Codec's I2S clock role (optional, defaults to target).
+	 * choose the controller option if codec controls the clock
+	 */
+	if (argc <= 6 || strcmp(argv[6], "target") == 0) {
+		cfg.dai_cfg.i2s.options = I2S_OPT_BIT_CLK_TARGET | I2S_OPT_FRAME_CLK_TARGET;
+	} else if (strcmp(argv[6], "controller") == 0) {
+		cfg.dai_cfg.i2s.options = I2S_OPT_BIT_CLK_CONTROLLER | I2S_OPT_FRAME_CLK_CONTROLLER;
+	} else {
+		shell_error(sh, "Clock role must be controller or target");
+		return -EINVAL;
+	}
+
+	return audio_codec_configure(dev, &cfg);
+}
+
 /* Device name autocompletion support */
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
@@ -210,6 +281,8 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 /* clang-format off */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_codec,
+	SHELL_CMD_ARG(configure, &dsub_device_name, CODEC_CONFIGURE_HELP, cmd_configure,
+			6, 1),
 	SHELL_CMD_ARG(start, &dsub_device_name, CODEC_START_HELP, cmd_start,
 			2, 0),
 	SHELL_CMD_ARG(stop, &dsub_device_name, CODEC_STOP_HELP, cmd_stop,


### PR DESCRIPTION
## Summary

Add a `codec configure` shell command to configure codec I2S DAI parameters from the shell.

The command accepts sample rate, word size, channel count, and stream route, populates an `audio_codec_cfg` structure, and calls `audio_codec_configure()`.

This extends the existing codec shell functionality by enabling stream configuration in addition to start/stop and property operations.

This can be work with i2s shell in the PR: #110748 


```shell
codec configure tas2563@4c 48000 16 2 playback
```
