### PR TITLE
drivers: timer: leon_gptimer: convert to a tickless driver

### DIFF
--- a/drivers/timer/Kconfig.leon_gptimer
+++ b/drivers/timer/Kconfig.leon_gptimer
@@ -8,6 +8,7 @@ config LEON_GPTIMER
 	default y
 	depends on DT_HAS_GAISLER_GPTIMER_ENABLED
 	select DYNAMIC_INTERRUPTS
+	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the GRLIB
 	  GPTIMER which is common in LEON systems.

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -5,10 +5,21 @@
  */
 
 /*
- * This driver uses two independent GPTIMER subtimers in the following way:
- * - subtimer 0 generates periodic interrupts and the ISR announces ticks.
- * - subtimer 1 is used as up-counter.
+ * This driver uses two independent GPTIMER subtimers:
+ * - subtimer 1 is a free-running up-counter clocked at the system cycle rate
+ *   divided by the shared prescaler, the definitive time base used for both
+ *   tick accounting and sys_clock_cycle_get_32().
+ * - subtimer 0 is programmed as a one-shot down-counter for the next deadline
+ *   in tickless mode, or as a periodic source when CONFIG_TICKLESS_KERNEL=n.
+ *
+ * GPTIMER has no absolute compare register, so a tick-aligned absolute
+ * deadline is computed against the free-running counter and programmed as a
+ * relative delay (subtimer 0 reload). The ISR derives the number of elapsed
+ * ticks from the free-running counter, so a late or coalesced interrupt
+ * announces every elapsed tick rather than dropping it.
  */
+
+#include <limits.h>
 
 #define DT_DRV_COMPAT gaisler_gptimer
 
@@ -17,8 +28,32 @@
 #include <zephyr/irq.h>
 #include <zephyr/sys_clock.h>
 
-/* GPTIMER subtimer increments each microsecond. */
-#define PRESCALER (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 1000000)
+/* Shared prescaler division factor. The GPTIMER subtimers share a single
+ * decrementer, so the minimum valid division factor is ntimers + 1 (GRLIB IP
+ * Core User's Manual, GPTIMER section). A core has at most 7 timers, so 8 is
+ * always valid; the subtimers are clocked at the system rate / PRESCALER.
+ */
+#define PRESCALER 8U
+
+/* Counter cycles per kernel tick (the subtimer clock is HW cycles / PRESCALER).
+ * Derived from CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC so it tracks the system clock.
+ */
+#define CYC_PER_TICK \
+	(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / PRESCALER / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+
+/* A programmed delay is detected as already-passed via a signed 32-bit delta
+ * in sys_clock_set_timeout() and is loaded into a 32-bit reload, so it must
+ * stay below 2^31 cycles.
+ */
+#define MAX_CYCLES 0x7FFFFFFFU
+#define MAX_TICKS  (MAX_CYCLES / CYC_PER_TICK)
+
+/* Smallest delay programmed into subtimer 0. program_subtimer0() writes
+ * reload = delay - 1, so delay must be at least 2 to avoid a reload of 0
+ * (and the wraparound for delay == 0); a deadline at or before "now" fires
+ * as soon as possible and the ISR catches up.
+ */
+#define MIN_DELAY_CYC 2U
 
 /* GPTIMER Timer instance */
 struct gptimer_timer_regs {
@@ -64,37 +99,121 @@ static int get_timer_irq(void)
 
 static uint32_t gptimer_ctrl_clear_ip;
 
+/* Free-running up-counter (subtimer 1) in cycles. Wraps every 2^32 cycles;
+ * unsigned subtraction against the announce baseline stays correct across a
+ * single wrap.
+ */
+static uint32_t announced_cyc; /* counter value at the last announce (tick-aligned) */
+static uint32_t last_elapsed;  /* ticks reported by the last sys_clock_elapsed() */
+
+static inline uint32_t up_counter(volatile struct gptimer_regs *regs)
+{
+	return 0U - regs->timer[1].counter;
+}
+
+/* Program subtimer 0 to fire delay cycles from now. Periodic (auto-restart)
+ * when the kernel is not tickless, one-shot otherwise.
+ */
+static void program_subtimer0(volatile struct gptimer_regs *regs, uint32_t delay)
+{
+	volatile struct gptimer_timer_regs *tmr = &regs->timer[0];
+	uint32_t ctrl = GPTIMER_CTRL_IE | GPTIMER_CTRL_LD | GPTIMER_CTRL_EN;
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		ctrl |= GPTIMER_CTRL_RS;
+	}
+
+	tmr->reload = delay - 1U;
+	tmr->ctrl = ctrl;
+}
+
 static void timer_isr(const void *unused)
 {
 	ARG_UNUSED(unused);
 	volatile struct gptimer_regs *regs = get_regs();
 	volatile struct gptimer_timer_regs *tmr = &regs->timer[0];
-	uint32_t ctrl;
+	uint32_t dticks;
 
-	ctrl = tmr->ctrl;
-	if ((ctrl & GPTIMER_CTRL_IP) == 0) {
+	if ((tmr->ctrl & GPTIMER_CTRL_IP) == 0) {
 		return; /* interrupt not for us */
 	}
 
-	/* Clear pending */
-	tmr->ctrl = GPTIMER_CTRL_IE | GPTIMER_CTRL_RS |
-		    GPTIMER_CTRL_EN | gptimer_ctrl_clear_ip;
+	/* Whole ticks elapsed since the last announce, taken from the
+	 * free-running counter so a late interrupt catches up every tick.
+	 */
+	dticks = (up_counter(regs) - announced_cyc) / CYC_PER_TICK;
+	announced_cyc += dticks * CYC_PER_TICK;
+	last_elapsed = 0;
 
-	sys_clock_announce(1);
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/* One-shot: stop and clear pending; sys_clock_set_timeout()
+		 * reprograms the next deadline.
+		 */
+		tmr->ctrl = gptimer_ctrl_clear_ip;
+	} else {
+		/* Periodic: clear pending and keep running. */
+		tmr->ctrl = GPTIMER_CTRL_IE | GPTIMER_CTRL_RS |
+			    GPTIMER_CTRL_EN | gptimer_ctrl_clear_ip;
+	}
+
+	sys_clock_announce(dticks);
+}
+
+void sys_clock_set_timeout(int32_t ticks, bool idle)
+{
+	ARG_UNUSED(idle);
+	volatile struct gptimer_regs *regs = get_regs();
+	uint32_t target, now;
+	int32_t delay;
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	if (ticks == K_TICKS_FOREVER || ticks > MAX_TICKS) {
+		ticks = MAX_TICKS;
+	}
+
+	/* The ISR eventually announces last_elapsed + ticks (plus IRQ-servicing
+	 * latency) and sys_clock_announce() takes an int32_t. Keep the sum
+	 * within INT32_MAX, reserving half the range for the latency.
+	 */
+	if (ticks > (INT32_MAX / 2 - last_elapsed)) {
+		ticks = INT32_MAX / 2 - last_elapsed;
+	}
+
+	/* Absolute, tick-aligned deadline from the last announce, programmed as
+	 * a relative delay. last_elapsed is the tick count already reported via
+	 * sys_clock_elapsed(), so the fire lands on the requested tick boundary
+	 * regardless of the sub-tick offset of the counter.
+	 */
+	target = announced_cyc + (last_elapsed + (uint32_t)ticks) * CYC_PER_TICK;
+	now = up_counter(regs);
+	delay = target - now;
+	if (delay < (int32_t)MIN_DELAY_CYC) {
+		delay = MIN_DELAY_CYC;
+	}
+	program_subtimer0(regs, delay);
 }
 
 uint32_t sys_clock_elapsed(void)
 {
-	return 0;
+	volatile struct gptimer_regs *regs = get_regs();
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return 0;
+	}
+
+	last_elapsed = (up_counter(regs) - announced_cyc) / CYC_PER_TICK;
+	return last_elapsed;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
 {
 	volatile struct gptimer_regs *regs = get_regs();
-	volatile struct gptimer_timer_regs *tmr = &regs->timer[1];
-	uint32_t counter = tmr->counter;
 
-	return (0 - counter) * PRESCALER;
+	/* Scale the counter back up to the system cycle rate the kernel expects. */
+	return up_counter(regs) * PRESCALER;
 }
 
 static void init_downcounter(volatile struct gptimer_timer_regs *tmr)
@@ -109,23 +228,35 @@ static int sys_clock_driver_init(void)
 	volatile struct gptimer_regs *regs = get_regs();
 	volatile struct gptimer_timer_regs *tmr = &regs->timer[0];
 
+	/* Set the shared prescaler to its minimum always-valid division factor
+	 * (reload = PRESCALER - 1), then start the free-running counter. A
+	 * reload below ntimers is rejected by the hardware because the timers
+	 * share one decrementer (GRLIB IP Core User's Manual, GPTIMER section).
+	 */
+	regs->scaler_reload = PRESCALER - 1U;
 	init_downcounter(&regs->timer[1]);
 
-	/* Stop timer and probe how CTRL_IP is cleared (write 1 or 0). */
+	/* Stop subtimer 0 and probe how CTRL_IP is cleared (write 1 or 0). */
 	tmr->ctrl = GPTIMER_CTRL_IP;
 	if ((tmr->ctrl & GPTIMER_CTRL_IP) == 0) {
 		/* IP bit is cleared by setting it to 1. */
 		gptimer_ctrl_clear_ip = GPTIMER_CTRL_IP;
 	}
 
-	/* Configure timer scaler for 1 MHz subtimer tick */
-	regs->scaler_reload = PRESCALER - 1;
-	tmr->reload = 1000000U / CONFIG_SYS_CLOCK_TICKS_PER_SEC - 1;
-	tmr->ctrl = GPTIMER_CTRL_IE | GPTIMER_CTRL_LD | GPTIMER_CTRL_RS |
-		    GPTIMER_CTRL_EN;
+	/* Anchor the announce baseline to "now" so curr_tick == 0 maps to the
+	 * current free-running counter value.
+	 */
+	announced_cyc = up_counter(regs);
 
 	irq_connect_dynamic(timer_interrupt, 0, timer_isr, NULL, 0);
 	irq_enable(timer_interrupt);
+
+	/* Program the first deadline: one tick away. In tickless mode the
+	 * kernel reprograms via sys_clock_set_timeout(); in periodic mode this
+	 * is the recurring tick.
+	 */
+	program_subtimer0(regs, CYC_PER_TICK);
+
 	return 0;
 }
 


### PR DESCRIPTION
The GPTIMER driver drove subtimer 0 as a fixed periodic source whose ISR always called `sys_clock_announce(1)`, with `sys_clock_elapsed()` returning 0. That has two problems:

- A periodic interrupt serviced more than one tick period late drops the missed ticks (`announce(1)` can't catch up), so uptime falls behind real time.
- With `elapsed()` pinned at 0, `k_uptime_ticks()` only advances at tick interrupts, lagging real time by a variable 0..1 tick. At a fine tick rate this makes tick-quantized measurements come up a tick short.

This surfaced on `qemu_leon3` while raising the scheduler test's tick rate (#110694): `tests/kernel/sched/schedule_api` failed at 1000 Hz (part of #109563), but the root cause is the driver, not the test.

The hardware already exposes what's needed: subtimer 1 is a free-running up-counter. This rebuild uses it as the definitive time base, clocked at the system cycle rate (the shared scaler divides by 1, so the driver follows `CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC` rather than assuming any base frequency), and makes the driver tickless following the free-running-counter pattern of `riscv_machine_timer.c` / `nrf_rtc_timer.c`:

- `sys_clock_elapsed()` reports whole ticks since the last announce.
- `sys_clock_set_timeout()` computes an absolute tick-aligned deadline and programs it as a one-shot relative delay on subtimer 0 (GPTIMER has no absolute compare), bounded so the announced count stays within `int32_t` and the delay fits the 32-bit counter.
- The ISR announces the catch-up delta from the free-running counter, so late/coalesced interrupts don't drop ticks.
- `CONFIG_TICKLESS_KERNEL=n` keeps subtimer 0 periodic from the same base, preserving the non-tickless path. `select TICKLESS_CAPABLE`.

**Behavior change:** becoming tickless-capable flips the default `SYS_CLOCK_TICKS_PER_SEC` from 100 to 10000 and enables tickless idle on LEON platforms.

Validated on `qemu_leon3`: `schedule_api` (7/7), `timer_api` (2/2), `sleep` + `tickless_concept` (3/3), each at the default tickless rate, forced 1000 Hz, and `TICKLESS_KERNEL=n`; `generic_leon3` builds.