### PR TITLE
twister: allow kconfigs in testplan.json

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -744,6 +744,9 @@ class TestPlan:
                     if ts.get("run_id"):
                         instance.run_id = ts.get("run_id")
 
+                    if ts.get("extra_configs"):
+                        instance.testsuite.extra_configs = ts.get("extra_configs")
+
                     instance.run = instance.check_runnable(
                         self.options,
                         self.hwm


### PR DESCRIPTION
Allow passing additional kconfigs as a list in a testplan JSON file by using the key "extra_configs". These kconfigs are then propagated to its testsuite and applied to the build.