### PR TITLE
doc: guidelines: improve guidelines re picture formats/sizes

### DIFF
--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -736,8 +736,27 @@ Recommended image formats based on content
 * **Screenshots**: WebP or PNG.
 * **Diagrams**: Consider using Graphviz for simple diagrams (see
   `dedicated section <graphviz_diagrams>`_ below. If using an external tool, SVG is preferred.
-* **Photos** (ex. boards): WebP. Use transparency if possible/available.
+* **Photos** (ex. boards): WebP, no larger than 600 px on the largest dimension.
+  Whenever the subject can be isolated from its background (typically the case for board photos),
+  save the image with a transparent background so it blends in with both light and dark
+  documentation themes.
 
+  You can convert an existing image to a properly sized WebP using `cwebp`_ or `ImageMagick`_. For
+  example::
+
+     # Using cwebp (resize width to 600 px, height auto, ~80% quality).
+     # For a portrait image, use "-resize 0 600" to cap the height instead.
+     cwebp -resize 600 0 board_name.png -o board_name.webp
+
+     # Using ImageMagick
+     magick board_name.png -resize 600x600 -quality 80 board_name.webp
+
+  When the source already has a transparent background (e.g. a PNG with an alpha channel), both
+  tools preserve transparency in the resulting WebP. The ``-resize 600 0`` / ``600x600`` arguments
+  only scale the image down, preserving its aspect ratio.
+
+.. _cwebp: https://developers.google.com/speed/webp/download
+.. _ImageMagick: https://imagemagick.org/
 
 .. _graphviz_diagrams:
 

--- a/doc/templates/board.tmpl
+++ b/doc/templates/board.tmpl
@@ -3,9 +3,11 @@
 .. To ensure the board documentation page displays correctly, it is highly
    recommended to include a picture alongside the documentation page.
 
-   The picture should be named after the board (e.g., "board_name.webp")
-   and preferably be in webp format. Alternatively, png or jpg formats
-   are also accepted.
+   The picture must be named after the board (e.g., "board_name.webp"),
+   must be saved in WebP format, and must not exceed 600 px on its largest
+   dimension. Try to use a transparent background as this helps ensure the
+   photo looks nice with both the light and dark themes of the Zephyr
+   documentation.
 
 Overview
 ********

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2132,7 +2132,8 @@ class ImageSize(ComplianceTest):
 
             if size > limit:
                 self.failure(
-                    f"Image file too large: {file} reduce size to less than {limit >> 10}kB"
+                    f"Image file too large: {file} reduce size to less than {limit >> 10}kB.\n"
+                    "See https://docs.zephyrproject.org/latest/contribute/documentation/guidelines.html#recommended-image-formats-based-on-content"
                 )
 
 


### PR DESCRIPTION
Make the documentation guidelines and board template prescriptive about board photos: they must be WebP, capped at 600 px on their largest dimension, and preferably use a transparent background. Add conversion tips using cwebp and ImageMagick.

https://builds.zephyrproject.io/zephyr/pr/110698/docs/contribute/documentation/guidelines.html#recommended-image-formats-based-on-content