### PR TITLE
include: drivers: sent: add missing Doxygen comment for frame payload

### DIFF
--- a/include/zephyr/drivers/sent/sent.h
+++ b/include/zephyr/drivers/sent/sent.h
@@ -55,6 +55,7 @@ struct sent_frame {
 	/** Type of SENT frame */
 	enum sent_frame_type type;
 
+	/** Frame payload. The valid member depends on @ref type. */
 	union {
 		/**
 		 * @brief Serial message


### PR DESCRIPTION
Add missing doxygen comment to the union field in the sent_frame structure.