### PR TITLE
lorawan: native: add MAC command support with LinkCheck

### DIFF
--- a/samples/subsys/lorawan/class_a/README.rst
+++ b/samples/subsys/lorawan/class_a/README.rst
@@ -8,6 +8,8 @@ Overview
 ********
 
 A simple application to demonstrate the :ref:`LoRaWAN subsystem <lorawan_api>` of Zephyr.
+Every fifth uplink requests a link check, logging the demodulation margin and
+gateway count reported by the network.
 
 Building and Running
 ********************

--- a/samples/subsys/lorawan/class_a/src/main.c
+++ b/samples/subsys/lorawan/class_a/src/main.c
@@ -21,6 +21,9 @@
 
 #define DELAY K_MSEC(10000)
 
+/* Request a link check on every n-th uplink */
+#define LINK_CHECK_PERIOD 5
+
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lorawan_class_a);
@@ -30,8 +33,21 @@ char data[] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};
 static void dl_callback(uint8_t port, uint8_t flags, int16_t rssi, int8_t snr, uint8_t len,
 			const uint8_t *hex_data)
 {
-	LOG_INF("Port %d, Pending %d, RSSI %ddB, SNR %ddBm, Time %d", port,
-		flags & LORAWAN_DATA_PENDING, rssi, snr, !!(flags & LORAWAN_TIME_UPDATED));
+	LOG_INF("Port %d, RSSI %ddB, SNR %ddBm", port, rssi, snr);
+
+	if (flags & LORAWAN_TIME_UPDATED) {
+		/* The stack has synced the network time from a DeviceTimeAns. */
+		LOG_INF("Network time updated");
+	}
+
+	if (flags & LORAWAN_DATA_PENDING) {
+		/* The network server has more downlinks queued.  An application
+		 * that wants to drain them promptly can schedule another uplink
+		 * (e.g. an empty one on any port) here.
+		 */
+		LOG_INF("Network reports more data pending (FPending set)");
+	}
+
 	if (hex_data) {
 		LOG_HEXDUMP_INF(hex_data, len, "Payload: ");
 	}
@@ -43,6 +59,12 @@ static void lorwan_datarate_changed(enum lorawan_datarate dr)
 
 	lorawan_get_payload_sizes(&unused, &max_size);
 	LOG_INF("New Datarate: DR_%d, Max Payload %d", dr, max_size);
+}
+
+static void link_check_ans_cb(uint8_t demod_margin, uint8_t nb_gateways)
+{
+	LOG_INF("Link check: margin %u dB, %u gateway(s)",
+		demod_margin, nb_gateways);
 }
 
 int main(void)
@@ -84,6 +106,7 @@ int main(void)
 
 	lorawan_register_downlink_callback(&downlink_cb);
 	lorawan_register_dr_changed_callback(lorwan_datarate_changed);
+	lorawan_register_link_check_ans_callback(link_check_ans_cb);
 
 	join_cfg.mode = LORAWAN_ACT_OTAA;
 	join_cfg.dev_eui = dev_eui;
@@ -100,7 +123,19 @@ int main(void)
 	}
 
 	LOG_INF("Sending data...");
-	while (1) {
+	for (uint32_t i = 0;; i++) {
+		if ((i % LINK_CHECK_PERIOD) == 0) {
+			/*
+			 * The LinkCheckReq MAC command rides the next uplink;
+			 * the answer is delivered via the registered callback.
+			 */
+			ret = lorawan_request_link_check(false);
+			if (ret < 0) {
+				LOG_ERR("lorawan_request_link_check failed: %d",
+					ret);
+			}
+		}
+
 		ret = lorawan_send(2, data, sizeof(data),
 				   LORAWAN_MSG_CONFIRMED);
 

--- a/subsys/lorawan/native/engine.h
+++ b/subsys/lorawan/native/engine.h
@@ -61,6 +61,7 @@ enum lwan_req_type {
 	LWAN_REQ_ENABLE_ADR,
 	LWAN_REQ_SET_CONF_MSG_TRIES,
 	LWAN_REQ_SET_CHANNELS_MASK,
+	LWAN_REQ_LINK_CHECK,
 };
 
 struct lwan_req {

--- a/subsys/lorawan/native/engine.h
+++ b/subsys/lorawan/native/engine.h
@@ -54,6 +54,13 @@ struct lwan_set_channels_mask_req {
 	size_t channels_mask_size;
 };
 
+struct lwan_link_check_req {
+	/* true: trigger an empty uplink so the LinkCheckReq goes out now;
+	 * false: just queue the flag for the next regular uplink
+	 */
+	bool force_request;
+};
+
 enum lwan_req_type {
 	LWAN_REQ_JOIN,
 	LWAN_REQ_SEND,

--- a/subsys/lorawan/native/lorawan.c
+++ b/subsys/lorawan/native/lorawan.c
@@ -189,6 +189,11 @@ int lorawan_send(uint8_t port, uint8_t *data, uint8_t len,
 		return -EINVAL;
 	}
 
+	/* FPort 0 is reserved for MAC commands */
+	if (port == 0 && len > 0) {
+		return -EINVAL;
+	}
+
 	if (len > LWAN_MAX_APP_PAYLOAD) {
 		return -EMSGSIZE;
 	}

--- a/subsys/lorawan/native/lorawan.c
+++ b/subsys/lorawan/native/lorawan.c
@@ -367,7 +367,20 @@ int lorawan_device_time_get(uint32_t *gps_time)
 
 int lorawan_request_link_check(bool force_request)
 {
-	ARG_UNUSED(force_request);
+	struct lwan_link_check_req lc_req = {
+		.force_request = force_request,
+	};
+	struct lwan_req msg = LWAN_REQ(LWAN_REQ_LINK_CHECK, &lc_req);
 
-	return -ENOTSUP;
+	if (!atomic_test_bit(lwan_ctx.flags, LWAN_FLAG_STARTED)) {
+		return -EPERM;
+	}
+
+	/* The forced empty uplink needs an established session */
+	if (force_request &&
+	    !atomic_test_bit(lwan_ctx.flags, LWAN_FLAG_JOINED)) {
+		return -ENETDOWN;
+	}
+
+	return engine_post_req_wait(&msg);
 }

--- a/subsys/lorawan/native/lorawan.c
+++ b/subsys/lorawan/native/lorawan.c
@@ -270,23 +270,26 @@ void lorawan_get_payload_sizes(uint8_t *max_next_payload_size,
 {
 	struct lwan_dr_params dr_params;
 	int8_t power;
-	uint8_t payload;
+	uint8_t max_next_payload;
+	uint8_t max_payload;
 
 	if (lwan_ctx.region != NULL &&
 	    lwan_ctx.region->get_tx_params((uint8_t)lwan_ctx.current_dr,
 					    lwan_ctx.mac.tx_power_idx,
 					    &dr_params, &power) == 0) {
-		payload = dr_params.max_payload;
+		max_payload = dr_params.max_payload;
 	} else {
-		payload = LWAN_DEFAULT_MAX_PAYLOAD;
+		max_payload = LWAN_DEFAULT_MAX_PAYLOAD;
 	}
 
+	max_next_payload = mac_cmd_next_payload_size(&lwan_ctx, max_payload);
+
 	if (max_next_payload_size != NULL) {
-		*max_next_payload_size = payload;
+		*max_next_payload_size = max_next_payload;
 	}
 
 	if (max_payload_size != NULL) {
-		*max_payload_size = payload;
+		*max_payload_size = max_payload;
 	}
 }
 

--- a/subsys/lorawan/native/lorawan.c
+++ b/subsys/lorawan/native/lorawan.c
@@ -12,6 +12,7 @@
 #include "engine.h"
 #include "radio.h"
 #include "crypto/crypto.h"
+#include "mac/mac_commands.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lorawan_native, CONFIG_LORAWAN_LOG_LEVEL);
@@ -344,7 +345,7 @@ void lorawan_register_dr_changed_callback(lorawan_dr_changed_cb_t cb)
 
 void lorawan_register_link_check_ans_callback(lorawan_link_check_ans_cb_t cb)
 {
-	ARG_UNUSED(cb);
+	mac_cmd_set_link_check_cb(cb);
 }
 
 int lorawan_request_device_time(bool force_request)

--- a/subsys/lorawan/native/lorawan.h
+++ b/subsys/lorawan/native/lorawan.h
@@ -65,6 +65,13 @@ struct lwan_mac_state {
 	 * leaves it queued for a retry
 	 */
 	bool ul_built_link_check_req;
+
+	/* DL: most-recent LinkCheckAns payload awaiting delivery to the
+	 * registered application callback on the system workqueue
+	 */
+	bool link_check_ans_valid;
+	uint8_t link_check_margin;
+	uint8_t link_check_gw_cnt;
 };
 
 struct lwan_ctx {

--- a/subsys/lorawan/native/lorawan.h
+++ b/subsys/lorawan/native/lorawan.h
@@ -57,6 +57,14 @@ struct lwan_mac_state {
 	bool adr_enabled;
 	/* Current TX power index (0 = region max; set by LinkADRReq) */
 	uint8_t tx_power_idx;
+
+	/* UL: a LinkCheckReq is queued and should ride on the next uplink */
+	bool link_check_pending;
+	/* UL: snapshot recorded by mac_cmd_build_ul_fopts() so a successful
+	 * TX (commit) can drop the request while a failed TX (no commit)
+	 * leaves it queued for a retry
+	 */
+	bool ul_built_link_check_req;
 };
 
 struct lwan_ctx {

--- a/subsys/lorawan/native/mac/join.c
+++ b/subsys/lorawan/native/mac/join.c
@@ -86,27 +86,61 @@ struct pkt_join_accept {
 #define JA_MIN_SIZE		(sizeof(struct pkt_join_accept) + LWAN_MIC_SIZE)
 #define JA_MAX_SIZE		(sizeof(struct pkt_join_accept) + JA_CFLIST_SIZE + LWAN_MIC_SIZE)
 
+struct join_rx_ctx {
+	psa_key_id_t nwk_cmac;
+	psa_key_id_t nwk_ecb;
+	uint16_t dev_nonce;
+};
+
+struct join_state {
+	const struct lwan_join_req *req;
+	struct join_rx_ctx rx_ctx;
+	uint8_t frame[sizeof(struct pkt_join_request)];
+	size_t frame_len;
+	uint32_t tx_freq;
+	uint8_t tx_dr_idx;
+};
+
+static void mac_write_join_request_fields(struct pkt_join_request *pkt,
+					  const struct lwan_join_req *req)
+{
+	pkt->mhdr = MHDR_JOIN_REQUEST;
+	sys_memcpy_swap(pkt->join_eui, req->join_eui, EUI_SIZE);
+	sys_memcpy_swap(pkt->dev_eui, req->dev_eui, EUI_SIZE);
+	sys_put_le16(req->dev_nonce, pkt->dev_nonce);
+}
+
+static int mac_write_join_request_mic(psa_key_id_t nwk_cmac,
+				      uint8_t *frame)
+{
+	struct pkt_join_request *pkt = (struct pkt_join_request *)frame;
+	size_t mic_off = offsetof(struct pkt_join_request, mic);
+	int ret;
+
+	/* MIC = cmac(NwkKey, MHDR | JoinEUI | DevEUI | DevNonce) */
+	ret = lwan_crypto_compute_mic(nwk_cmac, frame, mic_off, pkt->mic);
+	if (ret != 0) {
+		LOG_ERR("Failed to compute join request MIC: %d", ret);
+	}
+
+	return ret;
+}
+
 static int mac_build_join_request(const struct lwan_join_req *req,
 				  psa_key_id_t nwk_cmac,
 				  uint8_t *frame, size_t *frame_len)
 {
 	struct pkt_join_request *pkt = (struct pkt_join_request *)frame;
-	size_t mic_off = offsetof(struct pkt_join_request, mic);
 	int ret;
 
 	if (*frame_len < sizeof(*pkt)) {
 		return -ENOMEM;
 	}
 
-	pkt->mhdr = MHDR_JOIN_REQUEST;
-	sys_memcpy_swap(pkt->join_eui, req->join_eui, EUI_SIZE);
-	sys_memcpy_swap(pkt->dev_eui, req->dev_eui, EUI_SIZE);
-	sys_put_le16(req->dev_nonce, pkt->dev_nonce);
+	mac_write_join_request_fields(pkt, req);
 
-	/* MIC = cmac(NwkKey, MHDR | JoinEUI | DevEUI | DevNonce) */
-	ret = lwan_crypto_compute_mic(nwk_cmac, frame, mic_off, pkt->mic);
+	ret = mac_write_join_request_mic(nwk_cmac, frame);
 	if (ret != 0) {
-		LOG_ERR("Failed to compute join request MIC: %d", ret);
 		return ret;
 	}
 
@@ -149,31 +183,34 @@ static void mac_reset_channel_plan(struct lwan_ctx *ctx,
 	}
 }
 
-static int mac_apply_join_accept(struct lwan_ctx *ctx,
-				  const uint8_t *frame, size_t frame_len,
-				  psa_key_id_t nwk_ecb, uint16_t dev_nonce)
+static void mac_read_join_accept_session(struct lwan_session *sess,
+					 const struct pkt_join_accept *ja)
 {
-	const struct pkt_join_accept *ja =
-		(const struct pkt_join_accept *)&frame[MHDR_SIZE];
-	struct lwan_session *sess = &ctx->session;
-	int ret;
-
 	sess->dev_addr = sys_get_le32(ja->dev_addr);
 	sess->rx_delay = ja->rx_delay;
+}
 
-	ret = mac_apply_dl_settings(ctx, ja->dl_settings);
-	if (ret != 0) {
-		return ret;
-	}
-
+static void mac_log_join_accept(const struct lwan_session *sess)
+{
 	LOG_INF("Join accept: DevAddr=0x%08X RX1DRoff=%u RX2DR=%u RxDelay=%u",
 		sess->dev_addr, sess->rx1_dr_offset,
 		sess->rx2_datarate, sess->rx_delay);
+}
 
+static void mac_destroy_session_keys(struct lwan_session *sess)
+{
 	/* Destroy previous session keys if re-joining */
 	psa_destroy_key(sess->app_s_key);
 	psa_destroy_key(sess->fnwk_s_int_cmac);
 	psa_destroy_key(sess->fnwk_s_int_ecb);
+}
+
+static int mac_derive_join_session_keys(struct lwan_session *sess,
+					const struct pkt_join_accept *ja,
+					psa_key_id_t nwk_ecb,
+					uint16_t dev_nonce)
+{
+	int ret;
 
 	ret = lwan_crypto_derive_session_keys(nwk_ecb,
 					      ja->join_nonce,
@@ -184,8 +221,15 @@ static int mac_apply_join_accept(struct lwan_ctx *ctx,
 					      &sess->fnwk_s_int_ecb);
 	if (ret != 0) {
 		LOG_ERR("Session key derivation failed: %d", ret);
-		return ret;
 	}
+
+	return ret;
+}
+
+static void mac_finish_join_accept(struct lwan_ctx *ctx,
+				   const uint8_t *frame, size_t frame_len)
+{
+	struct lwan_session *sess = &ctx->session;
 
 	sess->fcnt_up = 0;
 	sess->fcnt_down = LWAN_FCNT_NONE;
@@ -193,6 +237,33 @@ static int mac_apply_join_accept(struct lwan_ctx *ctx,
 	mac_reset_channel_plan(ctx, &frame[MHDR_SIZE], frame_len - MHDR_SIZE);
 
 	atomic_set_bit(ctx->flags, LWAN_FLAG_JOINED);
+}
+
+static int mac_apply_join_accept(struct lwan_ctx *ctx,
+				  const uint8_t *frame, size_t frame_len,
+				  psa_key_id_t nwk_ecb, uint16_t dev_nonce)
+{
+	const struct pkt_join_accept *ja =
+		(const struct pkt_join_accept *)&frame[MHDR_SIZE];
+	struct lwan_session *sess = &ctx->session;
+	int ret;
+
+	mac_read_join_accept_session(sess, ja);
+
+	ret = mac_apply_dl_settings(ctx, ja->dl_settings);
+	if (ret != 0) {
+		return ret;
+	}
+
+	mac_log_join_accept(sess);
+	mac_destroy_session_keys(sess);
+
+	ret = mac_derive_join_session_keys(sess, ja, nwk_ecb, dev_nonce);
+	if (ret != 0) {
+		return ret;
+	}
+
+	mac_finish_join_accept(ctx, frame, frame_len);
 
 	return 0;
 }
@@ -218,6 +289,32 @@ static int mac_verify_join_accept_mic(psa_key_id_t nwk_cmac,
 	return 0;
 }
 
+static int mac_validate_join_accept_size(size_t rx_len, size_t *payload_len)
+{
+	*payload_len = rx_len - MHDR_SIZE;
+	if (*payload_len != JA_MIN_SIZE &&
+	    *payload_len != JA_MAX_SIZE) {
+		LOG_ERR("Invalid join accept size: %zu", rx_len);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int mac_decrypt_join_accept_frame(psa_key_id_t nwk_ecb,
+					 uint8_t *frame, size_t payload_len)
+{
+	int ret;
+
+	ret = lwan_crypto_decrypt_join_accept(nwk_ecb, &frame[MHDR_SIZE],
+					      payload_len);
+	if (ret != 0) {
+		LOG_ERR("Join accept decrypt failed: %d", ret);
+	}
+
+	return ret;
+}
+
 static int mac_parse_join_accept(struct lwan_ctx *ctx,
 				 const uint8_t *rx_buf, size_t rx_len,
 				 psa_key_id_t nwk_cmac, psa_key_id_t nwk_ecb,
@@ -227,19 +324,15 @@ static int mac_parse_join_accept(struct lwan_ctx *ctx,
 	size_t payload_len;
 	int ret;
 
-	payload_len = rx_len - MHDR_SIZE;
-	if (payload_len != JA_MIN_SIZE &&
-	    payload_len != JA_MAX_SIZE) {
-		LOG_ERR("Invalid join accept size: %zu", rx_len);
-		return -EINVAL;
+	ret = mac_validate_join_accept_size(rx_len, &payload_len);
+	if (ret != 0) {
+		return ret;
 	}
 
 	memcpy(frame, rx_buf, rx_len);
 
-	ret = lwan_crypto_decrypt_join_accept(nwk_ecb, &frame[MHDR_SIZE],
-					      payload_len);
+	ret = mac_decrypt_join_accept_frame(nwk_ecb, frame, payload_len);
 	if (ret != 0) {
-		LOG_ERR("Join accept decrypt failed: %d", ret);
 		return ret;
 	}
 
@@ -250,12 +343,6 @@ static int mac_parse_join_accept(struct lwan_ctx *ctx,
 
 	return mac_apply_join_accept(ctx, frame, rx_len, nwk_ecb, dev_nonce);
 }
-
-struct join_rx_ctx {
-	psa_key_id_t nwk_cmac;
-	psa_key_id_t nwk_ecb;
-	uint16_t dev_nonce;
-};
 
 static enum mac_rx_result join_rx_handler(struct lwan_ctx *ctx,
 					   const uint8_t *rx_buf, size_t rx_len,
@@ -304,52 +391,73 @@ static int select_join_channel_wait(struct lwan_ctx *ctx, uint32_t *freq,
 	return ret;
 }
 
-void mac_do_join(struct lwan_ctx *ctx, const struct lwan_req *req)
+static void join_state_init(struct join_state *state,
+			    const struct lwan_join_req *req)
 {
-	const struct lwan_join_req *join_req = req->data;
-	struct mac_tx_params tx_params;
-	struct join_rx_ctx jctx;
-	uint8_t tx_frame[sizeof(struct pkt_join_request)];
-	size_t tx_frame_len = sizeof(tx_frame);
-	uint32_t tx_freq;
-	uint8_t tx_dr_idx;
+	state->req = req;
+	state->rx_ctx = (struct join_rx_ctx){
+		.dev_nonce = req->dev_nonce,
+	};
+	state->frame_len = sizeof(state->frame);
+}
+
+static int join_import_nwk_key(struct join_state *state)
+{
+	state->rx_ctx.nwk_cmac =
+		lwan_crypto_import_cmac_key(state->req->nwk_key);
+	state->rx_ctx.nwk_ecb =
+		lwan_crypto_import_ecb_key(state->req->nwk_key);
+
+	if (state->rx_ctx.nwk_cmac == 0 || state->rx_ctx.nwk_ecb == 0) {
+		LOG_ERR("Failed to import NwkKey");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int join_prepare_frame(struct join_state *state)
+{
+	return mac_build_join_request(state->req, state->rx_ctx.nwk_cmac,
+				      state->frame, &state->frame_len);
+}
+
+static int join_select_channel(struct lwan_ctx *ctx, struct join_state *state)
+{
 	int ret;
 
-	/* Import NwkKey into PSA — plaintext is not stored */
-	jctx.nwk_cmac = lwan_crypto_import_cmac_key(join_req->nwk_key);
-	jctx.nwk_ecb = lwan_crypto_import_ecb_key(join_req->nwk_key);
-	jctx.dev_nonce = join_req->dev_nonce;
-
-	if (jctx.nwk_cmac == 0 || jctx.nwk_ecb == 0) {
-		LOG_ERR("Failed to import NwkKey");
-		ret = -EIO;
-		goto done;
-	}
-
-	ret = mac_build_join_request(join_req, jctx.nwk_cmac,
-				     tx_frame, &tx_frame_len);
-	if (ret != 0) {
-		goto done;
-	}
-
-	ret = select_join_channel_wait(ctx, &tx_freq, &tx_dr_idx);
+	ret = select_join_channel_wait(ctx, &state->tx_freq,
+				       &state->tx_dr_idx);
 	if (ret != 0) {
 		LOG_ERR("No join channel available: %d", ret);
-		goto done;
 	}
 
-	tx_params = (struct mac_tx_params){
-		.frame = tx_frame,
-		.frame_len = tx_frame_len,
-		.tx_freq = tx_freq,
-		.tx_dr_idx = tx_dr_idx,
+	return ret;
+}
+
+static struct mac_tx_params join_tx_params(struct join_state *state)
+{
+	return (struct mac_tx_params){
+		.frame = state->frame,
+		.frame_len = state->frame_len,
+		.tx_freq = state->tx_freq,
+		.tx_dr_idx = state->tx_dr_idx,
 		.rx1_delay_ms = JOIN_ACCEPT_DELAY1_MS,
 		.post_tx = NULL,
 		.rx_handler = join_rx_handler,
-		.user_data = &jctx,
+		.user_data = &state->rx_ctx,
 	};
+}
 
-	ret = mac_do_tx_rx(ctx, &tx_params);
+static int join_tx_rx(struct lwan_ctx *ctx, struct join_state *state)
+{
+	struct mac_tx_params tx_params = join_tx_params(state);
+
+	return mac_do_tx_rx(ctx, &tx_params);
+}
+
+static void join_log_result(int ret)
+{
 	if (ret == 0) {
 		LOG_INF("Joined successfully");
 	} else if (ret == -ETIMEDOUT) {
@@ -357,9 +465,42 @@ void mac_do_join(struct lwan_ctx *ctx, const struct lwan_req *req)
 	} else {
 		LOG_ERR("Join failed: %d", ret);
 	}
+}
+
+static void join_destroy_keys(struct join_state *state)
+{
+	psa_destroy_key(state->rx_ctx.nwk_cmac);
+	psa_destroy_key(state->rx_ctx.nwk_ecb);
+}
+
+void mac_do_join(struct lwan_ctx *ctx, const struct lwan_req *req)
+{
+	const struct lwan_join_req *join_req = req->data;
+	struct join_state state;
+	int ret;
+
+	join_state_init(&state, join_req);
+
+	/* Import NwkKey into PSA — plaintext is not stored */
+	ret = join_import_nwk_key(&state);
+	if (ret != 0) {
+		goto done;
+	}
+
+	ret = join_prepare_frame(&state);
+	if (ret != 0) {
+		goto done;
+	}
+
+	ret = join_select_channel(ctx, &state);
+	if (ret != 0) {
+		goto done;
+	}
+
+	ret = join_tx_rx(ctx, &state);
+	join_log_result(ret);
 
 done:
-	psa_destroy_key(jctx.nwk_cmac);
-	psa_destroy_key(jctx.nwk_ecb);
+	join_destroy_keys(&state);
 	engine_signal_result(req, ret);
 }

--- a/subsys/lorawan/native/mac/mac.c
+++ b/subsys/lorawan/native/mac/mac.c
@@ -229,9 +229,36 @@ signal_result:
 static void mac_do_link_check(struct lwan_ctx *ctx,
 			      const struct lwan_req *req)
 {
+	const struct lwan_link_check_req *lc_req = req->data;
+	struct lwan_send_req send_req;
+	struct lwan_req send_msg;
+
 	/* LinkCheckReq rides in the FOpts of the next uplink */
 	ctx->mac.link_check_pending = true;
-	engine_signal_result(req, 0);
+
+	if (!lc_req->force_request) {
+		engine_signal_result(req, 0);
+		return;
+	}
+
+	/* Trigger an empty unconfirmed uplink so the queued LinkCheckReq
+	 * goes out now rather than waiting for the next application send.
+	 * mac_do_send() signals the request itself.
+	 */
+	send_req = (struct lwan_send_req){
+		.data = NULL,
+		.len = 0,
+		.port = 0,
+		.type = LORAWAN_MSG_UNCONFIRMED,
+	};
+	send_msg = (struct lwan_req){
+		.type = LWAN_REQ_SEND,
+		.data = &send_req,
+		.done = req->done,
+		.result = req->result,
+	};
+
+	mac_do_send(ctx, &send_msg);
 }
 
 void mac_process_req(struct lwan_ctx *ctx, const struct lwan_req *req)

--- a/subsys/lorawan/native/mac/mac.c
+++ b/subsys/lorawan/native/mac/mac.c
@@ -226,6 +226,14 @@ signal_result:
 	engine_signal_result(req, ret);
 }
 
+static void mac_do_link_check(struct lwan_ctx *ctx,
+			      const struct lwan_req *req)
+{
+	/* LinkCheckReq rides in the FOpts of the next uplink */
+	ctx->mac.link_check_pending = true;
+	engine_signal_result(req, 0);
+}
+
 void mac_process_req(struct lwan_ctx *ctx, const struct lwan_req *req)
 {
 	switch (req->type) {
@@ -246,6 +254,9 @@ void mac_process_req(struct lwan_ctx *ctx, const struct lwan_req *req)
 		break;
 	case LWAN_REQ_SET_CHANNELS_MASK:
 		mac_do_set_channels_mask(ctx, req);
+		break;
+	case LWAN_REQ_LINK_CHECK:
+		mac_do_link_check(ctx, req);
 		break;
 	default:
 		LOG_WRN("Unknown request type: %d", req->type);

--- a/subsys/lorawan/native/mac/mac_commands.c
+++ b/subsys/lorawan/native/mac/mac_commands.c
@@ -129,6 +129,30 @@ void mac_cmd_process_dl_fopts(struct lwan_ctx *ctx,
 	}
 }
 
+size_t mac_cmd_next_ul_fopts_len(const struct lwan_ctx *ctx)
+{
+	size_t pos = 0;
+
+	if (ctx->mac.link_check_pending &&
+	    pos + MAC_CMD_LINK_CHECK_REQ_LEN <= LWAN_MAX_FOPTS_LEN) {
+		pos += MAC_CMD_LINK_CHECK_REQ_LEN;
+	}
+
+	return pos;
+}
+
+uint8_t mac_cmd_next_payload_size(const struct lwan_ctx *ctx,
+				  uint8_t max_payload)
+{
+	size_t fopts_len = mac_cmd_next_ul_fopts_len(ctx);
+
+	if (fopts_len >= max_payload) {
+		return 0;
+	}
+
+	return (uint8_t)(max_payload - fopts_len);
+}
+
 size_t mac_cmd_build_ul_fopts(struct lwan_ctx *ctx,
 			      uint8_t *buf, size_t max_len)
 {

--- a/subsys/lorawan/native/mac/mac_commands.c
+++ b/subsys/lorawan/native/mac/mac_commands.c
@@ -9,13 +9,33 @@
 #include "lorawan.h"
 #include "mac_commands.h"
 
+/* MAC command identifiers (CID) */
+#define MAC_CMD_LINK_CHECK	0x02
+
+/* LinkCheckReq on-the-wire length: CID only, no payload */
+#define MAC_CMD_LINK_CHECK_REQ_LEN	1
+
 size_t mac_cmd_build_ul_fopts(struct lwan_ctx *ctx,
 			      uint8_t *buf, size_t max_len)
 {
-	(void)ctx;
-	(void)buf;
-	(void)max_len;
+	size_t pos = 0;
 
-	/* No MAC commands are emitted yet; future commits populate this. */
-	return 0;
+	/* Reset the snapshot — the previous frame's emit state is now stale. */
+	ctx->mac.ul_built_link_check_req = false;
+
+	if (ctx->mac.link_check_pending &&
+	    pos + MAC_CMD_LINK_CHECK_REQ_LEN <= max_len) {
+		buf[pos++] = MAC_CMD_LINK_CHECK;
+		ctx->mac.ul_built_link_check_req = true;
+	}
+
+	return pos;
+}
+
+void mac_cmd_commit_ul_fopts(struct lwan_ctx *ctx)
+{
+	if (ctx->mac.ul_built_link_check_req) {
+		ctx->mac.link_check_pending = false;
+		ctx->mac.ul_built_link_check_req = false;
+	}
 }

--- a/subsys/lorawan/native/mac/mac_commands.c
+++ b/subsys/lorawan/native/mac/mac_commands.c
@@ -3,17 +3,131 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stddef.h>
-#include <stdint.h>
+#include <zephyr/kernel.h>
 
 #include "lorawan.h"
 #include "mac_commands.h"
 
-/* MAC command identifiers (CID) */
-#define MAC_CMD_LINK_CHECK	0x02
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(lorawan_native_mac, CONFIG_LORAWAN_LOG_LEVEL);
 
 /* LinkCheckReq on-the-wire length: CID only, no payload */
 #define MAC_CMD_LINK_CHECK_REQ_LEN	1
+
+/* Downlink command payload lengths in bytes, excluding the CID */
+struct mac_dl_cmd_info {
+	uint8_t cid;
+	uint8_t payload_len;
+};
+
+static const struct mac_dl_cmd_info dl_cmd_table[] = {
+	{ MAC_CMD_RESET,		1 },
+	{ MAC_CMD_LINK_CHECK,		2 },	/* Margin + GwCnt */
+	{ MAC_CMD_LINK_ADR,		4 },
+	{ MAC_CMD_DUTY_CYCLE,		1 },
+	{ MAC_CMD_RX_PARAM_SETUP,	4 },
+	{ MAC_CMD_DEV_STATUS,		0 },
+	{ MAC_CMD_NEW_CHANNEL,		5 },
+	{ MAC_CMD_RX_TIMING_SETUP,	1 },
+	{ MAC_CMD_TX_PARAM_SETUP,	1 },
+	{ MAC_CMD_DL_CHANNEL,		4 },
+	{ MAC_CMD_REKEY,		1 },
+	{ MAC_CMD_ADR_PARAM_SETUP,	1 },
+	{ MAC_CMD_DEVICE_TIME,		5 },
+	{ MAC_CMD_FORCE_REJOIN,		2 },
+	{ MAC_CMD_REJOIN_PARAM,		1 },
+	{ MAC_CMD_PING_SLOT_INFO,	0 },	/* PingSlotInfoAns is empty */
+	{ MAC_CMD_PING_SLOT_CHAN,	4 },
+	{ MAC_CMD_BEACON_TIMING,	3 },
+	{ MAC_CMD_BEACON_FREQ,		3 },
+	{ MAC_CMD_DEVICE_MODE,		1 },
+};
+
+static lorawan_link_check_ans_cb_t link_check_cb;
+
+void mac_cmd_set_link_check_cb(lorawan_link_check_ans_cb_t cb)
+{
+	link_check_cb = cb;
+}
+
+static void mac_cmd_handle_link_check_ans(struct lwan_ctx *ctx,
+					  uint8_t margin, uint8_t gw_cnt)
+{
+	ctx->mac.link_check_margin = margin;
+	ctx->mac.link_check_gw_cnt = gw_cnt;
+	ctx->mac.link_check_ans_valid = true;
+
+	LOG_INF("LinkCheckAns: margin=%u dB, gateways=%u", margin, gw_cnt);
+}
+
+void mac_cmd_deliver_link_check_ans(struct lwan_ctx *ctx)
+{
+	uint8_t margin;
+	uint8_t gw_cnt;
+
+	if (!ctx->mac.link_check_ans_valid) {
+		return;
+	}
+
+	margin = ctx->mac.link_check_margin;
+	gw_cnt = ctx->mac.link_check_gw_cnt;
+	ctx->mac.link_check_ans_valid = false;
+
+	if (link_check_cb != NULL) {
+		link_check_cb(margin, gw_cnt);
+	}
+}
+
+bool mac_cmd_has_pending_delivery(struct lwan_ctx *ctx)
+{
+	return ctx->mac.link_check_ans_valid;
+}
+
+static const struct mac_dl_cmd_info *mac_cmd_dl_info(uint8_t cid)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(dl_cmd_table); i++) {
+		if (dl_cmd_table[i].cid == cid) {
+			return &dl_cmd_table[i];
+		}
+	}
+
+	return NULL;
+}
+
+void mac_cmd_process_dl_fopts(struct lwan_ctx *ctx,
+			      const uint8_t *fopts, size_t fopts_len)
+{
+	size_t pos = 0;
+
+	while (pos < fopts_len) {
+		uint8_t cid = fopts[pos];
+		const struct mac_dl_cmd_info *info = mac_cmd_dl_info(cid);
+
+		if (info == NULL) {
+			/* Unknown CID: length unknown, cannot parse further */
+			LOG_WRN("Unknown DL MAC command 0x%02X, dropping %zu byte(s)",
+				cid, fopts_len - pos);
+			return;
+		}
+
+		if (pos + 1 + info->payload_len > fopts_len) {
+			LOG_WRN("Truncated DL MAC command 0x%02X", cid);
+			return;
+		}
+
+		switch (cid) {
+		case MAC_CMD_LINK_CHECK:
+			mac_cmd_handle_link_check_ans(ctx, fopts[pos + 1],
+						      fopts[pos + 2]);
+			break;
+		default:
+			LOG_DBG("Unhandled DL MAC command 0x%02X", cid);
+			break;
+		}
+
+		pos += 1 + info->payload_len;
+	}
+}
 
 size_t mac_cmd_build_ul_fopts(struct lwan_ctx *ctx,
 			      uint8_t *buf, size_t max_len)

--- a/subsys/lorawan/native/mac/mac_commands.h
+++ b/subsys/lorawan/native/mac/mac_commands.h
@@ -9,9 +9,6 @@
  * frame header, not in FRMPayload.  This module owns the parse/emit
  * path: the frame builder asks it for pending uplink commands, the
  * frame parser hands it incoming downlink commands.
- *
- * At present the module is a skeleton: future commits populate
- * per-command handlers.
  */
 
 #ifndef SUBSYS_LORAWAN_NATIVE_MAC_MAC_COMMANDS_H_
@@ -29,8 +26,9 @@ extern "C" {
 /**
  * @brief Build the FOpts bytes for the next uplink frame.
  *
- * Called by the frame builder before each uplink.  Drains pending
- * MAC command state from @p ctx into @p buf.
+ * Called by the frame builder before each uplink.  Records a snapshot
+ * of what was emitted so mac_cmd_commit_ul_fopts() can drain the right
+ * state once the frame is actually on the wire.
  *
  * @param ctx Stack context.
  * @param buf Output buffer for FOpts bytes.
@@ -39,6 +37,18 @@ extern "C" {
  */
 size_t mac_cmd_build_ul_fopts(struct lwan_ctx *ctx,
 			      uint8_t *buf, size_t max_len);
+
+/**
+ * @brief Commit the FOpts snapshot recorded by the last build call.
+ *
+ * Called from the post-TX hook once the frame has been transmitted
+ * successfully.  Clears the pending state for the commands that
+ * actually went on the wire so they aren't re-emitted.  A failed TX
+ * skips the commit, leaving the pending flags set for the next attempt.
+ *
+ * @param ctx Stack context.
+ */
+void mac_cmd_commit_ul_fopts(struct lwan_ctx *ctx);
 
 #ifdef __cplusplus
 }

--- a/subsys/lorawan/native/mac/mac_commands.h
+++ b/subsys/lorawan/native/mac/mac_commands.h
@@ -22,6 +22,9 @@
 
 struct lwan_ctx;
 
+/* FOpts carries up to 15 bytes of MAC commands; capped by FCtrl[3:0]. */
+#define LWAN_MAX_FOPTS_LEN	15
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -64,6 +67,28 @@ enum lwan_mac_cmd {
  */
 size_t mac_cmd_build_ul_fopts(struct lwan_ctx *ctx,
 			      uint8_t *buf, size_t max_len);
+
+/**
+ * @brief Return the FOpts length expected for the next uplink frame.
+ *
+ * This is a side-effect-free counterpart to mac_cmd_build_ul_fopts().
+ * It lets callers account for MAC command overhead before building a
+ * frame.
+ *
+ * @param ctx Stack context.
+ * @return Number of FOpts bytes the next uplink would carry.
+ */
+size_t mac_cmd_next_ul_fopts_len(const struct lwan_ctx *ctx);
+
+/**
+ * @brief Return the next application payload capacity after FOpts overhead.
+ *
+ * @param ctx Stack context.
+ * @param max_payload Maximum application payload with no FOpts.
+ * @return Maximum application payload for the next uplink.
+ */
+uint8_t mac_cmd_next_payload_size(const struct lwan_ctx *ctx,
+				  uint8_t max_payload);
 
 /**
  * @brief Commit the FOpts snapshot recorded by the last build call.

--- a/subsys/lorawan/native/mac/mac_commands.h
+++ b/subsys/lorawan/native/mac/mac_commands.h
@@ -14,14 +14,41 @@
 #ifndef SUBSYS_LORAWAN_NATIVE_MAC_MAC_COMMANDS_H_
 #define SUBSYS_LORAWAN_NATIVE_MAC_MAC_COMMANDS_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#include <zephyr/lorawan/lorawan.h>
 
 struct lwan_ctx;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* MAC command identifiers (CID) */
+enum lwan_mac_cmd {
+	MAC_CMD_RESET = 0x01,
+	MAC_CMD_LINK_CHECK = 0x02,
+	MAC_CMD_LINK_ADR = 0x03,
+	MAC_CMD_DUTY_CYCLE = 0x04,
+	MAC_CMD_RX_PARAM_SETUP = 0x05,
+	MAC_CMD_DEV_STATUS = 0x06,
+	MAC_CMD_NEW_CHANNEL = 0x07,
+	MAC_CMD_RX_TIMING_SETUP = 0x08,
+	MAC_CMD_TX_PARAM_SETUP = 0x09,
+	MAC_CMD_DL_CHANNEL = 0x0a,
+	MAC_CMD_REKEY = 0x0b,
+	MAC_CMD_ADR_PARAM_SETUP = 0x0c,
+	MAC_CMD_DEVICE_TIME = 0x0d,
+	MAC_CMD_FORCE_REJOIN = 0x0e,
+	MAC_CMD_REJOIN_PARAM = 0x0f,
+	MAC_CMD_PING_SLOT_INFO = 0x10,
+	MAC_CMD_PING_SLOT_CHAN = 0x11,
+	MAC_CMD_BEACON_TIMING = 0x12,
+	MAC_CMD_BEACON_FREQ = 0x13,
+	MAC_CMD_DEVICE_MODE = 0x20,
+};
 
 /**
  * @brief Build the FOpts bytes for the next uplink frame.
@@ -49,6 +76,49 @@ size_t mac_cmd_build_ul_fopts(struct lwan_ctx *ctx,
  * @param ctx Stack context.
  */
 void mac_cmd_commit_ul_fopts(struct lwan_ctx *ctx);
+
+/**
+ * @brief Process the MAC commands carried in a downlink FOpts field.
+ *
+ * Called by the frame parser after MIC verification and replay
+ * checks.  Known commands are dispatched to their handlers; an
+ * unknown CID terminates parsing since its length is unknown.
+ *
+ * @param ctx Stack context.
+ * @param fopts FOpts bytes from the downlink frame.
+ * @param fopts_len Length of @p fopts in bytes.
+ */
+void mac_cmd_process_dl_fopts(struct lwan_ctx *ctx,
+			      const uint8_t *fopts, size_t fopts_len);
+
+/**
+ * @brief Register the application's LinkCheckAns callback.
+ *
+ * @param cb Callback invoked on the system workqueue when a
+ *           LinkCheckAns is received; NULL clears the registration.
+ */
+void mac_cmd_set_link_check_cb(lorawan_link_check_ans_cb_t cb);
+
+/**
+ * @brief Deliver any pending LinkCheckAns to the registered callback.
+ *
+ * Called from the downlink work handler so the application callback
+ * runs on the system workqueue rather than the engine thread.
+ *
+ * @param ctx Stack context.
+ */
+void mac_cmd_deliver_link_check_ans(struct lwan_ctx *ctx);
+
+/**
+ * @brief Test whether the MAC layer has notifications pending delivery.
+ *
+ * Lets the downlink path know it must schedule the work handler even
+ * if the frame carries no FRMPayload and no ACK.
+ *
+ * @param ctx Stack context.
+ * @return true if at least one notification is pending.
+ */
+bool mac_cmd_has_pending_delivery(struct lwan_ctx *ctx);
 
 #ifdef __cplusplus
 }

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -664,6 +664,7 @@ static void send_post_tx(struct lwan_ctx *ctx, void *user_data)
 
 	tx_ctx->tx_done = true;
 	ctx->pending &= ~LWAN_PENDING_ACK;
+	mac_cmd_commit_ul_fopts(ctx);
 }
 
 static uint32_t send_rx1_delay_ms(const struct lwan_session *sess)

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -379,7 +379,8 @@ static void mac_dispatch_dl_notify(struct lwan_ctx *ctx,
 				   const struct dl_frame_info *frame_info,
 				   int16_t rssi, int8_t snr)
 {
-	if (frame_info->ack_received) {
+	/* Report an ACK or a flag (e.g. FPending) even on an empty downlink. */
+	if (frame_info->ack_received || frame_info->flags != 0) {
 		mac_dispatch_downlink(ctx, 0, frame_info->flags, rssi, snr,
 				      NULL, 0);
 	} else if (mac_cmd_has_pending_delivery(ctx)) {

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -108,6 +108,7 @@ struct dl_work_ctx {
 	int8_t snr;
 	uint8_t len;
 	uint8_t data[MAX_RX_BUF_SIZE];
+	bool notify_downlink;
 };
 
 struct send_tx_ctx {
@@ -153,6 +154,13 @@ static void dl_work_handler(struct k_work *work)
 	struct dl_work_ctx *wctx =
 		CONTAINER_OF(work, struct dl_work_ctx, work);
 	struct lorawan_downlink_cb *cb;
+
+	mac_cmd_deliver_link_check_ans(wctx->ctx);
+
+	if (!wctx->notify_downlink) {
+		k_sem_give(&dl_work_sem);
+		return;
+	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&wctx->ctx->dl_callbacks, cb, node) {
 		if (cb->port == LW_RECV_PORT_ANY || cb->port == wctx->port) {
@@ -347,12 +355,39 @@ static void mac_dispatch_downlink(struct lwan_ctx *ctx, uint8_t port,
 	dl_work_ctx.rssi = rssi;
 	dl_work_ctx.snr = snr;
 	dl_work_ctx.len = len;
+	dl_work_ctx.notify_downlink = true;
 
 	if (data != NULL && len > 0) {
 		memcpy(dl_work_ctx.data, data, len);
 	}
 
 	k_work_submit(&dl_work_ctx.work);
+}
+
+static void mac_dispatch_mac_delivery(struct lwan_ctx *ctx)
+{
+	if (k_sem_take(&dl_work_sem, K_NO_WAIT) != 0) {
+		LOG_WRN("MAC notification dispatch busy, dropping");
+		return;
+	}
+
+	dl_work_ctx.ctx = ctx;
+	dl_work_ctx.notify_downlink = false;
+
+	k_work_submit(&dl_work_ctx.work);
+}
+
+/* Dispatch payload-less notifications so callbacks run on the workqueue. */
+static void mac_dispatch_dl_notify(struct lwan_ctx *ctx,
+				   const struct dl_frame_info *frame_info,
+				   int16_t rssi, int8_t snr)
+{
+	if (frame_info->ack_received) {
+		mac_dispatch_downlink(ctx, 0, frame_info->flags, rssi, snr,
+				      NULL, 0);
+	} else if (mac_cmd_has_pending_delivery(ctx)) {
+		mac_dispatch_mac_delivery(ctx);
+	}
 }
 
 static bool mac_get_dl_payload_info(const uint8_t *rx_buf, size_t rx_len,
@@ -426,11 +461,8 @@ static int mac_process_dl_payload(struct lwan_ctx *ctx,
 
 	if (!mac_get_dl_payload_info(rx_buf, rx_len, frame_info->fopts_len,
 				     &payload)) {
-		if (frame_info->ack_received) {
-			mac_dispatch_downlink(ctx, 0, frame_info->flags,
-					      rssi, snr,
-					      NULL, 0);
-		}
+		/* No FPort/FRMPayload: only an ACK or a queued answer */
+		mac_dispatch_dl_notify(ctx, frame_info, rssi, snr);
 		return 0;
 	}
 
@@ -541,14 +573,6 @@ static int mac_read_dl_frame_info(struct lwan_ctx *ctx, const uint8_t *rx_buf,
 	return mac_validate_dl_fopts_len(rx_len, frame_info->fopts_len);
 }
 
-static void mac_log_ignored_dl_fopts(uint8_t fopts_len)
-{
-	if (fopts_len > 0) {
-		LOG_WRN("Downlink MAC commands not supported; ignoring %u byte(s)",
-			fopts_len);
-	}
-}
-
 static int mac_validate_dl_replay(struct lwan_session *sess,
 				  uint32_t fcnt_down)
 {
@@ -600,12 +624,13 @@ static int mac_parse_downlink(struct lwan_ctx *ctx, const uint8_t *rx_buf,
 		return ret;
 	}
 
-	mac_log_ignored_dl_fopts(frame_info.fopts_len);
-
 	ret = mac_validate_dl_replay(sess, frame_info.fcnt_down);
 	if (ret != 0) {
 		return ret;
 	}
+
+	mac_cmd_process_dl_fopts(ctx, &rx_buf[sizeof(struct pkt_data_hdr)],
+				 frame_info.fopts_len);
 
 	mac_apply_dl_fctrl(ctx, hdr, &frame_info);
 	sess->fcnt_down = frame_info.fcnt_down;

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -115,6 +115,37 @@ struct send_tx_ctx {
 	bool tx_done;
 };
 
+struct data_frame_layout {
+	size_t fopts_len;
+	size_t fhdr_end;
+	size_t total_len;
+};
+
+struct dl_frame_info {
+	uint32_t dev_addr;
+	uint32_t fcnt_down;
+	uint8_t fopts_len;
+	uint8_t flags;
+	bool ack_received;
+};
+
+struct dl_payload_info {
+	uint8_t port;
+	size_t start;
+	size_t len;
+};
+
+struct send_state {
+	const struct lwan_send_req *req;
+	struct send_tx_ctx tx_ctx;
+	uint8_t frame[MAX_FRAME_SIZE];
+	size_t frame_len;
+	uint32_t fcnt;
+	uint32_t rx1_delay_ms;
+	uint8_t dr_idx;
+	uint8_t tries;
+};
+
 static K_SEM_DEFINE(dl_work_sem, 1, 1);
 
 static void dl_work_handler(struct k_work *work)
@@ -175,73 +206,127 @@ static int mac_encrypt_ul_payload(struct lwan_session *sess, uint8_t port,
 					   &frame[fhdr_end + FPORT_SIZE], len);
 }
 
-static int mac_build_data_frame(struct lwan_ctx *ctx,
-				const struct lwan_send_req *req,
-				uint8_t *frame, size_t *frame_len)
+static struct data_frame_layout mac_ul_frame_layout(
+	const struct lwan_send_req *req, size_t fopts_len)
 {
-	struct pkt_data_hdr *hdr = (struct pkt_data_hdr *)frame;
-	struct lwan_session *sess = &ctx->session;
-	uint8_t fopts[LWAN_MAX_FOPTS_LEN];
-	size_t fopts_len;
-	size_t fhdr_end;
-	size_t msg_len;
-	size_t pos;
-	uint8_t fctrl;
-	int ret;
+	struct data_frame_layout layout = {
+		.fopts_len = fopts_len,
+		.fhdr_end = sizeof(struct pkt_data_hdr) + fopts_len,
+	};
 
-	fopts_len = mac_cmd_build_ul_fopts(ctx, fopts, sizeof(fopts));
-	fhdr_end = sizeof(*hdr) + fopts_len;
-
-	pos = fhdr_end + LWAN_MIC_SIZE;
+	layout.total_len = layout.fhdr_end + LWAN_MIC_SIZE;
 	if (req->len > 0) {
-		pos += FPORT_SIZE + req->len;
+		layout.total_len += FPORT_SIZE + req->len;
 	}
 
-	if (pos > *frame_len) {
-		return -EMSGSIZE;
-	}
+	return layout;
+}
 
-	fctrl = (uint8_t)FIELD_PREP(FCTRL_FOPTS_LEN_MASK, fopts_len);
+static uint8_t mac_ul_fctrl(const struct lwan_ctx *ctx, size_t fopts_len)
+{
+	uint8_t fctrl = (uint8_t)FIELD_PREP(FCTRL_FOPTS_LEN_MASK, fopts_len);
+
 	if (ctx->pending & LWAN_PENDING_ACK) {
 		fctrl |= FCTRL_ACK;
 	}
+
 	if (ctx->mac.adr_enabled) {
 		fctrl |= FCTRL_ADR;
 	}
 
+	return fctrl;
+}
+
+static void mac_write_ul_header(struct lwan_ctx *ctx,
+				const struct lwan_send_req *req,
+				uint8_t *frame, const uint8_t *fopts,
+				size_t fopts_len)
+{
+	struct pkt_data_hdr *hdr = (struct pkt_data_hdr *)frame;
+	struct lwan_session *sess = &ctx->session;
+
 	hdr->mhdr = req->type == LORAWAN_MSG_CONFIRMED
 		   ? MHDR_CONF_DATA_UP : MHDR_UNCONF_DATA_UP;
-	hdr->fctrl = fctrl;
+	hdr->fctrl = mac_ul_fctrl(ctx, fopts_len);
 	sys_put_le32(sess->dev_addr, hdr->dev_addr);
 	sys_put_le16((uint16_t)(sess->fcnt_up & FCNT_LOW_MASK), hdr->fcnt);
 
 	if (fopts_len > 0) {
 		memcpy(&frame[sizeof(*hdr)], fopts, fopts_len);
 	}
+}
 
-	if (req->len > 0) {
-		ret = mac_encrypt_ul_payload(sess, req->port, req->data,
-					     req->len, frame, fhdr_end);
-		if (ret != 0) {
-			LOG_ERR("Payload encrypt failed: %d", ret);
-			return ret;
-		}
+static int mac_write_ul_payload(struct lwan_session *sess,
+				const struct lwan_send_req *req,
+				uint8_t *frame, size_t fhdr_end)
+{
+	int ret;
+
+	if (req->len == 0) {
+		return 0;
 	}
 
-	msg_len = pos - LWAN_MIC_SIZE;
+	ret = mac_encrypt_ul_payload(sess, req->port, req->data,
+				     req->len, frame, fhdr_end);
+	if (ret != 0) {
+		LOG_ERR("Payload encrypt failed: %d", ret);
+	}
+
+	return ret;
+}
+
+static int mac_write_ul_mic(struct lwan_session *sess, uint8_t *frame,
+			    size_t msg_len)
+{
+	int ret;
 
 	ret = mac_compute_data_mic(sess->fnwk_s_int_cmac, sess->dev_addr,
 				   sess->fcnt_up, DIR_UPLINK,
 				   frame, msg_len, &frame[msg_len]);
 	if (ret != 0) {
 		LOG_ERR("Data MIC compute failed: %d", ret);
+	}
+
+	return ret;
+}
+
+static int mac_build_data_frame(struct lwan_ctx *ctx,
+				const struct lwan_send_req *req,
+				uint8_t *frame, size_t *frame_len)
+{
+	struct lwan_session *sess = &ctx->session;
+	struct data_frame_layout layout;
+	uint8_t fopts[LWAN_MAX_FOPTS_LEN];
+	size_t fopts_len;
+	size_t msg_len;
+	int ret;
+
+	fopts_len = mac_cmd_build_ul_fopts(ctx, fopts, sizeof(fopts));
+	layout = mac_ul_frame_layout(req, fopts_len);
+
+	if (layout.total_len > *frame_len) {
+		return -EMSGSIZE;
+	}
+
+	mac_write_ul_header(ctx, req, frame, fopts, layout.fopts_len);
+
+	ret = mac_write_ul_payload(sess, req, frame, layout.fhdr_end);
+	if (ret != 0) {
 		return ret;
 	}
 
-	*frame_len = pos;
+	msg_len = layout.total_len - LWAN_MIC_SIZE;
+
+	ret = mac_write_ul_mic(sess, frame, msg_len);
+	if (ret != 0) {
+		return ret;
+	}
+
+	*frame_len = layout.total_len;
 
 	LOG_DBG("Data frame built: port=%u len=%u fcnt=%u fopts=%zu total=%zu",
-		req->port, req->len, sess->fcnt_up, fopts_len, *frame_len);
+		req->port, req->len, sess->fcnt_up, layout.fopts_len,
+		*frame_len);
 
 	return 0;
 }
@@ -270,59 +355,87 @@ static void mac_dispatch_downlink(struct lwan_ctx *ctx, uint8_t port,
 	k_work_submit(&dl_work_ctx.work);
 }
 
-static int mac_process_dl_payload(struct lwan_ctx *ctx,
-				  const uint8_t *rx_buf, size_t rx_len,
-				  uint8_t fopts_len, uint32_t dev_addr,
-				  uint32_t fcnt_down, uint8_t flags,
-				  int16_t rssi, int8_t snr,
-				  bool ack_received)
+static bool mac_get_dl_payload_info(const uint8_t *rx_buf, size_t rx_len,
+				    uint8_t fopts_len,
+				    struct dl_payload_info *payload)
 {
-	struct lwan_session *sess = &ctx->session;
 	size_t fhdr_end = sizeof(struct pkt_data_hdr) + fopts_len;
 	size_t msg_len = rx_len - LWAN_MIC_SIZE;
-	size_t payload_start = fhdr_end + FPORT_SIZE;
-	size_t payload_len;
-	uint8_t port;
 
 	if (rx_len <= fhdr_end + LWAN_MIC_SIZE) {
-		/* No FPort/payload — notify ACK-only if applicable */
-		if (ack_received) {
-			mac_dispatch_downlink(ctx, 0, flags, rssi, snr,
+		return false;
+	}
+
+	payload->port = rx_buf[fhdr_end];
+	payload->start = fhdr_end + FPORT_SIZE;
+	payload->len = msg_len - payload->start;
+
+	return true;
+}
+
+static int mac_decrypt_dl_payload(struct lwan_session *sess,
+				  const struct dl_frame_info *frame_info,
+				  const struct dl_payload_info *payload,
+				  const uint8_t *rx_buf, uint8_t *dl_payload)
+{
+	psa_key_id_t ecb_key = payload->port == 0
+			       ? sess->fnwk_s_int_ecb : sess->app_s_key;
+
+	memcpy(dl_payload, &rx_buf[payload->start], payload->len);
+
+	return lwan_crypto_payload_encrypt(ecb_key, frame_info->dev_addr,
+					   frame_info->fcnt_down,
+					   DIR_DOWNLINK, dl_payload,
+					   payload->len);
+}
+
+static int mac_dispatch_dl_payload(struct lwan_ctx *ctx,
+				   const struct dl_frame_info *frame_info,
+				   const struct dl_payload_info *payload,
+				   int16_t rssi, int8_t snr,
+				   const uint8_t *rx_buf)
+{
+	uint8_t dl_payload[MAX_RX_BUF_SIZE];
+	int ret;
+
+	if (payload->len == 0) {
+		return 0;
+	}
+
+	ret = mac_decrypt_dl_payload(&ctx->session, frame_info, payload,
+				     rx_buf, dl_payload);
+	if (ret != 0) {
+		return ret;
+	}
+
+	LOG_INF("Downlink: port=%u len=%zu fcnt=%u",
+		payload->port, payload->len, frame_info->fcnt_down);
+
+	mac_dispatch_downlink(ctx, payload->port, frame_info->flags, rssi, snr,
+			      dl_payload, (uint8_t)payload->len);
+
+	return 0;
+}
+
+static int mac_process_dl_payload(struct lwan_ctx *ctx,
+				  const uint8_t *rx_buf, size_t rx_len,
+				  const struct dl_frame_info *frame_info,
+				  int16_t rssi, int8_t snr)
+{
+	struct dl_payload_info payload;
+
+	if (!mac_get_dl_payload_info(rx_buf, rx_len, frame_info->fopts_len,
+				     &payload)) {
+		if (frame_info->ack_received) {
+			mac_dispatch_downlink(ctx, 0, frame_info->flags,
+					      rssi, snr,
 					      NULL, 0);
 		}
 		return 0;
 	}
 
-	port = rx_buf[fhdr_end];
-
-	payload_len = msg_len - payload_start;
-
-	if (payload_len > 0) {
-		uint8_t dl_payload[MAX_RX_BUF_SIZE];
-		psa_key_id_t ecb_key;
-		int ret;
-
-		memcpy(dl_payload, &rx_buf[payload_start], payload_len);
-
-		ecb_key = (port == 0) ? sess->fnwk_s_int_ecb : sess->app_s_key;
-
-		ret = lwan_crypto_payload_encrypt(ecb_key, dev_addr,
-						      fcnt_down,
-						      DIR_DOWNLINK,
-						      dl_payload,
-						      payload_len);
-		if (ret != 0) {
-			return ret;
-		}
-
-		LOG_INF("Downlink: port=%u len=%zu fcnt=%u",
-			port, payload_len, fcnt_down);
-
-		mac_dispatch_downlink(ctx, port, flags, rssi, snr,
-				      dl_payload, (uint8_t)payload_len);
-	}
-
-	return 0;
+	return mac_dispatch_dl_payload(ctx, frame_info, &payload, rssi, snr,
+				       rx_buf);
 }
 
 static uint32_t mac_reconstruct_fcnt_down(uint16_t fcnt16,
@@ -396,70 +509,110 @@ static int mac_verify_data_mic(psa_key_id_t cmac_key, uint32_t dev_addr,
 	return 0;
 }
 
-static int mac_parse_downlink(struct lwan_ctx *ctx, const uint8_t *rx_buf,
-			      size_t rx_len, int16_t rssi, int8_t snr,
-			      bool *ack_received)
+static int mac_validate_dl_fopts_len(size_t rx_len, uint8_t fopts_len)
+{
+	if (rx_len < sizeof(struct pkt_data_hdr) + fopts_len + LWAN_MIC_SIZE) {
+		LOG_DBG("Invalid FOptsLen: %u for len %zu", fopts_len, rx_len);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int mac_read_dl_frame_info(struct lwan_ctx *ctx, const uint8_t *rx_buf,
+				  size_t rx_len,
+				  struct dl_frame_info *frame_info)
 {
 	const struct pkt_data_hdr *hdr = (const struct pkt_data_hdr *)rx_buf;
 	struct lwan_session *sess = &ctx->session;
-	uint32_t dev_addr;
-	uint16_t fcnt16;
-	uint32_t fcnt_down;
-	uint8_t fopts_len;
-	uint8_t flags = 0;
 	int ret;
-
-	*ack_received = false;
 
 	ret = mac_validate_dl_header(rx_buf, rx_len, sess->dev_addr);
 	if (ret != 0) {
 		return ret;
 	}
 
-	dev_addr = sys_get_le32(hdr->dev_addr);
-	fcnt16 = sys_get_le16(hdr->fcnt);
-	fcnt_down = mac_reconstruct_fcnt_down(fcnt16, sess->fcnt_down);
-	fopts_len = FIELD_GET(FCTRL_FOPTS_LEN_MASK, hdr->fctrl);
-	if (rx_len < sizeof(*hdr) + fopts_len + LWAN_MIC_SIZE) {
-		LOG_DBG("Invalid FOptsLen: %u for len %zu", fopts_len, rx_len);
-		return -EINVAL;
-	}
+	frame_info->dev_addr = sys_get_le32(hdr->dev_addr);
+	frame_info->fcnt_down =
+		mac_reconstruct_fcnt_down(sys_get_le16(hdr->fcnt),
+					   sess->fcnt_down);
+	frame_info->fopts_len = FIELD_GET(FCTRL_FOPTS_LEN_MASK, hdr->fctrl);
 
-	ret = mac_verify_data_mic(sess->fnwk_s_int_cmac, dev_addr,
-				  fcnt_down, rx_buf, rx_len);
-	if (ret != 0) {
-		return ret;
-	}
+	return mac_validate_dl_fopts_len(rx_len, frame_info->fopts_len);
+}
 
+static void mac_log_ignored_dl_fopts(uint8_t fopts_len)
+{
 	if (fopts_len > 0) {
 		LOG_WRN("Downlink MAC commands not supported; ignoring %u byte(s)",
 			fopts_len);
 	}
+}
 
+static int mac_validate_dl_replay(struct lwan_session *sess,
+				  uint32_t fcnt_down)
+{
 	if (sess->fcnt_down != LWAN_FCNT_NONE && fcnt_down <= sess->fcnt_down) {
 		LOG_WRN("Downlink replay (fcnt %u <= %u)", fcnt_down,
 			sess->fcnt_down);
 		return -EAGAIN;
 	}
 
-	if (hdr->fctrl & FCTRL_ACK) {
-		*ack_received = true;
-	}
+	return 0;
+}
+
+static void mac_apply_dl_fctrl(struct lwan_ctx *ctx,
+			       const struct pkt_data_hdr *hdr,
+			       struct dl_frame_info *frame_info)
+{
+	frame_info->ack_received = (hdr->fctrl & FCTRL_ACK) != 0;
+	frame_info->flags = 0;
 
 	if (hdr->fctrl & FCTRL_FPENDING) {
-		flags |= LORAWAN_DATA_PENDING;
+		frame_info->flags |= LORAWAN_DATA_PENDING;
 	}
-
-	sess->fcnt_down = fcnt_down;
 
 	/* Confirmed downlinks require ACK in our next uplink */
 	if ((hdr->mhdr & MHDR_TYPE_MASK) == MHDR_CONF_DATA_DOWN) {
 		ctx->pending |= LWAN_PENDING_ACK;
 	}
+}
 
-	return mac_process_dl_payload(ctx, rx_buf, rx_len, fopts_len, dev_addr,
-				      fcnt_down, flags, rssi, snr,
-				      *ack_received);
+static int mac_parse_downlink(struct lwan_ctx *ctx, const uint8_t *rx_buf,
+			      size_t rx_len, int16_t rssi, int8_t snr,
+			      bool *ack_received)
+{
+	const struct pkt_data_hdr *hdr = (const struct pkt_data_hdr *)rx_buf;
+	struct lwan_session *sess = &ctx->session;
+	struct dl_frame_info frame_info;
+	int ret;
+
+	*ack_received = false;
+
+	ret = mac_read_dl_frame_info(ctx, rx_buf, rx_len, &frame_info);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = mac_verify_data_mic(sess->fnwk_s_int_cmac, frame_info.dev_addr,
+				  frame_info.fcnt_down, rx_buf, rx_len);
+	if (ret != 0) {
+		return ret;
+	}
+
+	mac_log_ignored_dl_fopts(frame_info.fopts_len);
+
+	ret = mac_validate_dl_replay(sess, frame_info.fcnt_down);
+	if (ret != 0) {
+		return ret;
+	}
+
+	mac_apply_dl_fctrl(ctx, hdr, &frame_info);
+	sess->fcnt_down = frame_info.fcnt_down;
+	*ack_received = frame_info.ack_received;
+
+	return mac_process_dl_payload(ctx, rx_buf, rx_len, &frame_info,
+				      rssi, snr);
 }
 
 static enum mac_rx_result send_rx_handler(struct lwan_ctx *ctx,
@@ -513,105 +666,174 @@ static void send_post_tx(struct lwan_ctx *ctx, void *user_data)
 	ctx->pending &= ~LWAN_PENDING_ACK;
 }
 
-void mac_do_send(struct lwan_ctx *ctx, const struct lwan_req *req)
+static uint32_t send_rx1_delay_ms(const struct lwan_session *sess)
 {
-	const struct lwan_send_req *send_req = req->data;
-	const struct lwan_region_ops *region = ctx->region;
-	struct lwan_session *sess = &ctx->session;
-	struct mac_tx_params tx_params;
-	struct lwan_dr_params dr_params;
-	struct send_tx_ctx tx_ctx = {
-		.req = send_req,
+	return (sess->rx_delay == 0 ? 1 : sess->rx_delay) * 1000U;
+}
+
+static uint8_t send_try_count(const struct lwan_ctx *ctx,
+			      const struct lwan_send_req *req)
+{
+	return req->type == LORAWAN_MSG_CONFIRMED ? ctx->conf_tries : 1;
+}
+
+static void send_state_init(struct send_state *state, struct lwan_ctx *ctx,
+			    const struct lwan_send_req *req)
+{
+	state->req = req;
+	state->tx_ctx = (struct send_tx_ctx){
+		.req = req,
 	};
-	uint8_t tx_frame[MAX_FRAME_SIZE];
-	size_t tx_frame_len = sizeof(tx_frame);
-	uint32_t rx1_delay_ms;
-	uint32_t frame_fcnt;
-	uint32_t tx_freq;
-	uint8_t tx_dr_idx;
-	uint8_t tries;
+	state->frame_len = sizeof(state->frame);
+	state->fcnt = ctx->session.fcnt_up;
+	state->rx1_delay_ms = send_rx1_delay_ms(&ctx->session);
+	state->dr_idx = (uint8_t)ctx->current_dr;
+	state->tries = send_try_count(ctx, req);
+}
+
+static int send_validate_payload_size(struct lwan_ctx *ctx,
+				      const struct send_state *state)
+{
+	struct lwan_dr_params dr_params;
 	int8_t tx_power;
 	int ret;
 
-	tx_dr_idx = (uint8_t)ctx->current_dr;
-	frame_fcnt = sess->fcnt_up;
-
-	ret = region->get_tx_params(tx_dr_idx, ctx->mac.tx_power_idx,
-				    &dr_params, &tx_power);
+	ret = ctx->region->get_tx_params(state->dr_idx, ctx->mac.tx_power_idx,
+					 &dr_params, &tx_power);
 	if (ret != 0) {
-		LOG_ERR("Invalid datarate DR%u: %d", tx_dr_idx, ret);
-		goto done;
+		LOG_ERR("Invalid datarate DR%u: %d", state->dr_idx, ret);
+		return ret;
 	}
 
-	if (send_req->len > dr_params.max_payload) {
-		LOG_ERR("Payload too large for DR%u: %u > %u", tx_dr_idx,
-			send_req->len, dr_params.max_payload);
-		ret = -EMSGSIZE;
-		goto done;
+	if (state->req->len > dr_params.max_payload) {
+		LOG_ERR("Payload too large for DR%u: %u > %u", state->dr_idx,
+			state->req->len, dr_params.max_payload);
+		return -EMSGSIZE;
 	}
 
-	rx1_delay_ms = (sess->rx_delay == 0 ? 1 : sess->rx_delay) * 1000U;
+	return 0;
+}
 
-	tries = (send_req->type == LORAWAN_MSG_CONFIRMED) ? ctx->conf_tries : 1;
+static int send_prepare_frame(struct lwan_ctx *ctx, struct send_state *state)
+{
+	int ret;
 
-	ret = mac_build_data_frame(ctx, send_req, tx_frame, &tx_frame_len);
+	ret = send_validate_payload_size(ctx, state);
+	if (ret != 0) {
+		return ret;
+	}
+
+	return mac_build_data_frame(ctx, state->req, state->frame,
+				    &state->frame_len);
+}
+
+static struct mac_tx_params send_tx_params(struct send_state *state,
+					   uint32_t tx_freq)
+{
+	return (struct mac_tx_params){
+		.frame = state->frame,
+		.frame_len = state->frame_len,
+		.tx_freq = tx_freq,
+		.tx_dr_idx = state->dr_idx,
+		.rx1_delay_ms = state->rx1_delay_ms,
+		.post_tx = send_post_tx,
+		.rx_handler = send_rx_handler,
+		.user_data = &state->tx_ctx,
+	};
+}
+
+static void send_retry_backoff(void)
+{
+	uint32_t backoff_ms = 1000 + (sys_rand32_get() % 2001);
+
+	LOG_DBG("Retry backoff: %u ms", backoff_ms);
+	k_msleep(backoff_ms);
+}
+
+static int send_handle_attempt_result(const struct send_state *state,
+				      uint8_t attempt, int ret)
+{
+	if (ret == 0) {
+		return 0;
+	}
+
+	if (ret != -ETIMEDOUT) {
+		LOG_ERR("TX/RX transaction failed: %d", ret);
+		return ret;
+	}
+
+	if (state->req->type != LORAWAN_MSG_CONFIRMED) {
+		/* Unconfirmed: no downlink is normal */
+		return 0;
+	}
+
+	LOG_WRN("Confirmed uplink: no ACK (attempt %u/%u)",
+		attempt + 1, state->tries);
+
+	if (attempt < state->tries - 1) {
+		send_retry_backoff();
+	}
+
+	return -EAGAIN;
+}
+
+static int send_one_attempt(struct lwan_ctx *ctx, struct send_state *state,
+			    uint8_t attempt)
+{
+	struct mac_tx_params tx_params;
+	uint32_t tx_freq;
+	int ret;
+
+	LOG_INF("Send: port=%u len=%u fcnt=%u attempt=%u/%u",
+		state->req->port, state->req->len, state->fcnt,
+		attempt + 1, state->tries);
+
+	ret = select_data_channel_wait(ctx, state->dr_idx, &tx_freq);
+	if (ret != 0) {
+		LOG_ERR("No channel available for DR%u: %d",
+			state->dr_idx, ret);
+		return ret;
+	}
+
+	tx_params = send_tx_params(state, tx_freq);
+
+	ret = mac_do_tx_rx(ctx, &tx_params);
+
+	return send_handle_attempt_result(state, attempt, ret);
+}
+
+static int send_attempts(struct lwan_ctx *ctx, struct send_state *state)
+{
+	int ret;
+
+	for (uint8_t attempt = 0; attempt < state->tries; attempt++) {
+		ret = send_one_attempt(ctx, state, attempt);
+		if (ret != -EAGAIN) {
+			return ret;
+		}
+	}
+
+	return -ETIMEDOUT;
+}
+
+void mac_do_send(struct lwan_ctx *ctx, const struct lwan_req *req)
+{
+	const struct lwan_send_req *send_req = req->data;
+	struct lwan_session *sess = &ctx->session;
+	struct send_state state;
+	int ret;
+
+	send_state_init(&state, ctx, send_req);
+
+	ret = send_prepare_frame(ctx, &state);
 	if (ret != 0) {
 		goto done;
 	}
 
-	for (uint8_t attempt = 0; attempt < tries; attempt++) {
-		LOG_INF("Send: port=%u len=%u fcnt=%u attempt=%u/%u",
-			send_req->port, send_req->len, frame_fcnt, attempt + 1, tries);
-
-		ret = select_data_channel_wait(ctx, tx_dr_idx, &tx_freq);
-		if (ret != 0) {
-			LOG_ERR("No channel available for DR%u: %d",
-				tx_dr_idx, ret);
-			goto done;
-		}
-
-		tx_params = (struct mac_tx_params){
-			.frame = tx_frame,
-			.frame_len = tx_frame_len,
-			.tx_freq = tx_freq,
-			.tx_dr_idx = tx_dr_idx,
-			.rx1_delay_ms = rx1_delay_ms,
-			.post_tx = send_post_tx,
-			.rx_handler = send_rx_handler,
-			.user_data = &tx_ctx,
-		};
-
-		ret = mac_do_tx_rx(ctx, &tx_params);
-		if (ret == 0) {
-			goto done;
-		}
-
-		if (ret != -ETIMEDOUT) {
-			LOG_ERR("TX/RX transaction failed: %d", ret);
-			goto done;
-		}
-
-		if (send_req->type != LORAWAN_MSG_CONFIRMED) {
-			/* Unconfirmed: no downlink is normal */
-			ret = 0;
-			goto done;
-		}
-
-		LOG_WRN("Confirmed uplink: no ACK (attempt %u/%u)",
-			attempt + 1, tries);
-
-		if (attempt < tries - 1) {
-			uint32_t backoff_ms = 1000 + (sys_rand32_get() % 2001);
-
-			LOG_DBG("Retry backoff: %u ms", backoff_ms);
-			k_msleep(backoff_ms);
-		}
-	}
-
-	ret = -ETIMEDOUT;
+	ret = send_attempts(ctx, &state);
 
 done:
-	if (tx_ctx.tx_done) {
+	if (state.tx_ctx.tx_done) {
 		sess->fcnt_up++;
 	}
 

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -66,9 +66,6 @@ LOG_MODULE_DECLARE(lorawan_native_mac, CONFIG_LORAWAN_LOG_LEVEL);
 #define DIR_DOWNLINK		1
 #define MAX_FRAME_SIZE		256
 
-/* FOpts carries up to 15 bytes of MAC commands; capped by FCtrl[3:0]. */
-#define LWAN_MAX_FOPTS_LEN	15
-
 #define FCTRL_ADR		BIT(7)
 #define FCTRL_ACK		BIT(5)
 #define FCTRL_FPENDING		BIT(4)
@@ -721,6 +718,7 @@ static int send_validate_payload_size(struct lwan_ctx *ctx,
 				      const struct send_state *state)
 {
 	struct lwan_dr_params dr_params;
+	uint8_t max_payload;
 	int8_t tx_power;
 	int ret;
 
@@ -731,9 +729,11 @@ static int send_validate_payload_size(struct lwan_ctx *ctx,
 		return ret;
 	}
 
-	if (state->req->len > dr_params.max_payload) {
+	/* Pending MAC commands in FOpts eat into the payload budget */
+	max_payload = mac_cmd_next_payload_size(ctx, dr_params.max_payload);
+	if (state->req->len > max_payload) {
 		LOG_ERR("Payload too large for DR%u: %u > %u", state->dr_idx,
-			state->req->len, dr_params.max_payload);
+			state->req->len, max_payload);
 		return -EMSGSIZE;
 	}
 

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -750,6 +750,12 @@ static void send_retry_backoff(void)
 	k_msleep(backoff_ms);
 }
 
+/*
+ * Positive retry sentinel: cannot collide with success (0) or an
+ * errno value propagated from the layers below.
+ */
+#define SEND_ATTEMPT_RETRY	1
+
 static int send_handle_attempt_result(const struct send_state *state,
 				      uint8_t attempt, int ret)
 {
@@ -774,7 +780,7 @@ static int send_handle_attempt_result(const struct send_state *state,
 		send_retry_backoff();
 	}
 
-	return -EAGAIN;
+	return SEND_ATTEMPT_RETRY;
 }
 
 static int send_one_attempt(struct lwan_ctx *ctx, struct send_state *state,
@@ -808,7 +814,7 @@ static int send_attempts(struct lwan_ctx *ctx, struct send_state *state)
 
 	for (uint8_t attempt = 0; attempt < state->tries; attempt++) {
 		ret = send_one_attempt(ctx, state, attempt);
-		if (ret != -EAGAIN) {
+		if (ret != SEND_ATTEMPT_RETRY) {
 			return ret;
 		}
 	}

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -449,6 +449,36 @@ static int mac_dispatch_dl_payload(struct lwan_ctx *ctx,
 	return 0;
 }
 
+/* Port-0 FRMPayload is the long-form MAC command container, not application
+ * data.  Decrypt with the network key and run it through the same parser as
+ * FOpts; it is never delivered to the application.
+ */
+static int mac_process_dl_mac_payload(struct lwan_ctx *ctx,
+				      const struct dl_frame_info *frame_info,
+				      const struct dl_payload_info *payload,
+				      const uint8_t *rx_buf)
+{
+	uint8_t mac_payload[MAX_RX_BUF_SIZE];
+	int ret;
+
+	if (payload->len == 0) {
+		return 0;
+	}
+
+	ret = mac_decrypt_dl_payload(&ctx->session, frame_info, payload,
+				     rx_buf, mac_payload);
+	if (ret != 0) {
+		return ret;
+	}
+
+	LOG_DBG("Port-0 MAC commands: len=%zu fcnt=%u",
+		payload->len, frame_info->fcnt_down);
+
+	mac_cmd_process_dl_fopts(ctx, mac_payload, payload->len);
+
+	return 0;
+}
+
 static int mac_process_dl_payload(struct lwan_ctx *ctx,
 				  const uint8_t *rx_buf, size_t rx_len,
 				  const struct dl_frame_info *frame_info,
@@ -457,8 +487,11 @@ static int mac_process_dl_payload(struct lwan_ctx *ctx,
 	struct dl_payload_info payload;
 
 	if (!mac_get_dl_payload_info(rx_buf, rx_len, frame_info->fopts_len,
-				     &payload)) {
-		/* No FPort/FRMPayload: only an ACK or a queued answer */
+				     &payload) ||
+	    payload.port == 0) {
+		/* No app payload to deliver: a bare ACK/answer frame, or
+		 * port-0 MAC commands (already parsed). Notify only.
+		 */
 		mac_dispatch_dl_notify(ctx, frame_info, rssi, snr);
 		return 0;
 	}
@@ -605,7 +638,9 @@ static int mac_parse_downlink(struct lwan_ctx *ctx, const uint8_t *rx_buf,
 {
 	const struct pkt_data_hdr *hdr = (const struct pkt_data_hdr *)rx_buf;
 	struct lwan_session *sess = &ctx->session;
+	struct dl_payload_info payload;
 	struct dl_frame_info frame_info;
+	bool has_payload;
 	int ret;
 
 	*ack_received = false;
@@ -626,8 +661,27 @@ static int mac_parse_downlink(struct lwan_ctx *ctx, const uint8_t *rx_buf,
 		return ret;
 	}
 
+	has_payload = mac_get_dl_payload_info(rx_buf, rx_len,
+					      frame_info.fopts_len, &payload);
+
+	/* FPort 0 carries MAC commands in its FRMPayload; per the spec that
+	 * form cannot be combined with FOpts MAC commands in the same frame.
+	 */
+	if (frame_info.fopts_len > 0 && has_payload && payload.port == 0) {
+		LOG_WRN("Downlink with both FOpts and FPort=0");
+		return -EBADMSG;
+	}
+
 	mac_cmd_process_dl_fopts(ctx, &rx_buf[sizeof(struct pkt_data_hdr)],
 				 frame_info.fopts_len);
+
+	if (has_payload && payload.port == 0) {
+		ret = mac_process_dl_mac_payload(ctx, &frame_info, &payload,
+						 rx_buf);
+		if (ret != 0) {
+			return ret;
+		}
+	}
 
 	mac_apply_dl_fctrl(ctx, hdr, &frame_info);
 	sess->fcnt_down = frame_info.fcnt_down;


### PR DESCRIPTION
Add the first MAC command (`LinkCheckReq/Ans`, `CID 0x02`) to the native LoRaWAN stack. This is the first MAC command we add, it is the simplest one and it is used to put down the scaffolding for all the next ones.

Tested on `nucleo_wl55jc` against `TTN` (`EU868`).

```
[00:00:00.046,000] <inf> sx126x: SX126x initialized
*** Booting Zephyr OS build v4.4.0-4338-g620e7ab0a043 ***
[00:00:00.046,000] <inf> lorawan_native: Native LoRaWAN stack started
[00:00:00.046,000] <inf> lorawan_class_a: Joining network over OTAA
[00:00:00.046,000] <inf> lorawan_native_engine: Native LoRaWAN engine started
[00:00:00.048,000] <inf> lorawan_native_mac: TX: freq=868500000 dr=0 power=16
[00:00:06.503,000] <inf> lorawan_native_mac: RX1 at TX+4950 ms: freq=868500000 sf=12 bw=125
[00:00:08.396,000] <inf> lorawan_native_mac: Join accept: DevAddr=0x00171BD4 RX1DRoff=0 RX2DR=0 RxDelay=1
[00:00:08.396,000] <inf> lorawan_native_mac: Response received in RX1
[00:00:08.396,000] <inf> lorawan_native_mac: Joined successfully
[00:00:08.396,000] <inf> lorawan_native: Successfully joined network
[00:00:08.396,000] <inf> lorawan_class_a: New Datarate: DR_0, Max Payload 51
[00:00:08.396,000] <inf> lorawan_class_a: Sending data...
[00:00:08.397,000] <inf> lorawan_native_mac: Send: port=2 len=10 fcnt=0 attempt=1/1
[00:00:08.397,000] <inf> lorawan_native_mac: TX: freq=867100000 dr=0 power=16
[00:00:10.852,000] <inf> lorawan_native_mac: RX1 at TX+950 ms: freq=867100000 sf=12 bw=125
[00:00:12.251,000] <inf> lorawan_native_mac: LinkCheckAns: margin=34 dB, gateways=1
[00:00:12.251,000] <inf> lorawan_class_a: Link check: margin 34 dB, 1 gateway(s)
[00:00:12.251,000] <inf> lorawan_class_a: Port 0, RSSI -33dB, SNR 4dBm, Time 0
[00:00:12.251,000] <inf> lorawan_native_mac: Response received in RX1
```