### PR TITLE
arch: arm: cortex_m: Added Cortex-M4 erratum 838869  Workaround

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -514,6 +514,26 @@ config ARM_GCC_FP_WORKAROUND
 	  want this, but in at least one case it's necessary.  See
 	  comment in arm-m-switch.h
 
+config ARM_ERRATUM_838869
+	bool "Cortex-M4: 838869: exception return operation might vector to incorrect interrupt"
+	depends on CPU_CORTEX_M4
+	help
+	  Enable ARM's recommended workaround for erratum 838869:
+	  "Store immediate overlapping exception return operation
+	  might vector to incorrect interrupt"
+
+	  Under specific timing conditions during an exception return,
+	  while the Cortex-M4's write buffer is still in use by a store
+	  instruction, a late-arriving interrupt may cause the processor
+	  to execute an incorrect interrupt handler, which can notably
+	  result in the loss of a pulse-based interrupt request. Note
+	  that whether a given interrupt is level-based or pulse-based
+	  is implementation defined.
+
+	  The workaround depends on whether the MPU is used:
+	  - CONFIG_MPU=n: disable the Cortex-M4 write buffer entirely
+	  - CONFIG_MPU=y: execute a DSB before returning from exceptions
+
 rsource "tz/Kconfig"
 
 endif # CPU_CORTEX_M

--- a/arch/arm/core/cortex_m/exc_exit.c
+++ b/arch/arm/core/cortex_m/exc_exit.c
@@ -63,4 +63,8 @@ Z_GENERIC_SECTION(.text._HandlerModeExit) void z_arm_exc_exit(void)
 #ifdef CONFIG_STACK_SENTINEL
 	z_check_stack_sentinel();
 #endif /* CONFIG_STACK_SENTINEL */
+
+#if defined(CONFIG_ARM_ERRATUM_838869) && defined(CONFIG_MPU)
+	__DSB();
+#endif /* CONFIG_ARM_ERRATUM_838869 and CONFIG_MPU */
 }

--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -86,6 +86,18 @@ TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_NONNULL)
 
 #endif /* CONFIG_CPU_CORTEX_M_HAS_VTOR */
 
+void apply_errata_workarounds(void)
+{
+#if defined(CONFIG_ARM_ERRATUM_838869) && !defined(CONFIG_MPU)
+/*
+ * Cortex-M4 r0p1 erratum 838869 (ES0182 §2.1.3):
+ * "Store immediate overlapping exception return operation might
+ *  vector to incorrect interrupt."
+ */
+SCnSCB->ACTLR |= SCnSCB_ACTLR_DISDEFWBUF_Msk;
+#endif
+}
+
 #if defined(CONFIG_CPU_HAS_FPU)
 static inline void z_arm_floating_point_init(void)
 {
@@ -218,6 +230,7 @@ FUNC_NORETURN void z_prep_c(void)
 #ifdef CONFIG_NULL_POINTER_EXCEPTION_DETECTION_DWT
 	z_arm_debug_enable_null_pointer_detection();
 #endif
+	apply_errata_workarounds();
 	z_cstart();
 	CODE_UNREACHABLE;
 }


### PR DESCRIPTION
Fixes #109352 This pull request implementes workaround for Cortex-M4 erratum 838869. 

A new function `apply_errata_workarounds` has been created and the workaround is guarded with `CONFIG_ARM_ARCH_ERRATUM_838869`. This implementation also takes the status of MPU into account.

