### PR TITLE
dts: bindings: can: bosch: m_can: set bosch,mram-cfg prop min/max length

### DIFF
--- a/dts/bindings/can/bosch,m_can-base.yaml
+++ b/dts/bindings/can/bosch,m_can-base.yaml
@@ -6,6 +6,8 @@ properties:
   bosch,mram-cfg:
     type: array
     required: true
+    min-len: 8
+    max-len: 8
     description: |
       Bosch M_CAN message RAM configuration. The cells in the array have the following format:
 


### PR DESCRIPTION
Enforce a fixed array length of 8 for the Bosch M_CAN bosch,mram-cfg devicetree property.