### PR TITLE
net_buf: Use net_buf_drop() to replace unref + NULL pattern

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -355,8 +355,7 @@ static void free_rx_bufs(struct net_buf **rx_frag_list, uint16_t len)
 {
 	for (int i = 0; i < len; i++) {
 		if (rx_frag_list[i]) {
-			net_buf_unref(rx_frag_list[i]);
-			rx_frag_list[i] = NULL;
+			net_buf_drop(&rx_frag_list[i]);
 		}
 	}
 }

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -905,8 +905,7 @@ static inline void eth_xmc4xxx_free_rx_bufs(const struct device *dev)
 
 	for (int i = 0; i < NUM_RX_DMA_DESCRIPTORS; i++) {
 		if (dev_data->rx_frag_list[i]) {
-			net_buf_unref(dev_data->rx_frag_list[i]);
-			dev_data->rx_frag_list[i] = NULL;
+			net_buf_drop(&dev_data->rx_frag_list[i]);
 		}
 	}
 }

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -346,8 +346,7 @@ static void receive_state_machine(struct isotp_recv_ctx *rctx)
 		}
 
 		k_fifo_cancel_wait(&rctx->fifo);
-		net_buf_unref(rctx->buf);
-		rctx->buf = NULL;
+		net_buf_drop(&rctx->buf);
 		rctx->state = ISOTP_RX_STATE_RECYCLE;
 		__fallthrough;
 	case ISOTP_RX_STATE_RECYCLE:
@@ -658,8 +657,7 @@ int isotp_bind(struct isotp_recv_ctx *rctx, const struct device *can_dev,
 	ret = add_ff_sf_filter(rctx);
 	if (ret) {
 		LOG_ERR("Can't add filter for binding");
-		net_buf_unref(rctx->buf);
-		rctx->buf = NULL;
+		net_buf_drop(&rctx->buf);
 		return ret;
 	}
 
@@ -1040,8 +1038,7 @@ static inline int send_cf(struct isotp_send_ctx *sctx)
 static inline void free_send_ctx(struct isotp_send_ctx **sctx)
 {
 	if ((*sctx)->is_net_buf) {
-		net_buf_unref((*sctx)->buf);
-		(*sctx)->buf = NULL;
+		net_buf_drop(&(*sctx)->buf);
 	}
 
 	if ((*sctx)->is_ctx_slab) {

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_usb.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_usb.c
@@ -254,7 +254,7 @@ static int handle_out_transfer(struct usbd_class_data *const c_data)
 		}
 		ret = usbd_ep_enqueue(c_data, ctx->usb_rx_buf);
 		if (ret) {
-			net_buf_unref(ctx->usb_rx_buf);
+			net_buf_drop(&ctx->usb_rx_buf);
 			k_work_reschedule(&ctx->reset_work, K_NO_WAIT);
 			LOG_ERR("Failed to enqueue EP OUT: %d", ret);
 			return 0;
@@ -334,7 +334,7 @@ static int ec_host_cmd_request(struct usbd_class_data *const c_data, struct net_
 		ret = usbd_ep_enqueue(c_data, ctx->usb_rx_buf);
 		if (ret) {
 			LOG_ERR("Failed to enqueue EP OUT: %d", ret);
-			net_buf_unref(ctx->usb_rx_buf);
+			net_buf_drop(&ctx->usb_rx_buf);
 			k_work_schedule(&ctx->reset_work, K_NO_WAIT);
 			return 0;
 		}
@@ -390,7 +390,7 @@ static void ec_host_cmd_enable(struct usbd_class_data *const c_data)
 	if (ret) {
 		ctx->state = USB_EC_HOST_CMD_STATE_DISABLED;
 		LOG_ERR("Failed to enqueue EP OUT: %d", ret);
-		net_buf_unref(ctx->usb_rx_buf);
+		net_buf_drop(&ctx->usb_rx_buf);
 		return;
 	}
 	ctx->state = USB_EC_HOST_CMD_STATE_READY_TO_RX;

--- a/subsys/mgmt/mcumgr/transport/src/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_shell.c
@@ -73,8 +73,7 @@ static void smp_shell_input_timeout_handler(struct k_timer *timer)
 
 	if (data->buf) {
 		net_buf_reset(data->buf);
-		net_buf_unref(data->buf);
-		data->buf = NULL;
+		net_buf_drop(&data->buf);
 	}
 }
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -891,8 +891,7 @@ static void tcp_conn_release(struct k_work *work)
 
 	if (CONFIG_NET_TCP_RECV_QUEUE_TIMEOUT) {
 		if (conn->queue_recv_data != NULL) {
-			net_buf_unref(conn->queue_recv_data);
-			conn->queue_recv_data = NULL;
+			net_buf_drop(&conn->queue_recv_data);
 		}
 	}
 
@@ -1280,8 +1279,7 @@ static size_t tcp_check_pending_data(struct tcp *conn, struct net_pkt *pkt,
 		} else {
 			/* Check if the queued data is just a section of the incoming data */
 			if (gap_size <= 0) {
-				net_buf_unref(conn->queue_recv_data);
-				conn->queue_recv_data = NULL;
+				net_buf_drop(&conn->queue_recv_data);
 
 				k_work_cancel_delayable(&conn->recv_queue_timer);
 			}
@@ -1937,8 +1935,7 @@ static void tcp_cleanup_recv_queue(struct k_work *work)
 		net_buf_frags_len(conn->queue_recv_data),
 		tcp_get_seq(conn->queue_recv_data));
 
-	net_buf_unref(conn->queue_recv_data);
-	conn->queue_recv_data = NULL;
+	net_buf_drop(&conn->queue_recv_data);
 
 	k_mutex_unlock(&conn->lock);
 }
@@ -2796,8 +2793,7 @@ static void tcp_queue_recv_data(struct tcp *conn, struct net_pkt *pkt,
 				NET_ERR("Incorrect order in out of order sequence for conn %p",
 					conn);
 				/* error in sequence list, drop it */
-				net_buf_unref(conn->queue_recv_data);
-				conn->queue_recv_data = NULL;
+				net_buf_drop(&conn->queue_recv_data);
 			}
 		} else {
 			NET_DBG("[%p] Cannot add new data to queue", conn);

--- a/subsys/usb/device/class/bluetooth.c
+++ b/subsys/usb/device/class/bluetooth.c
@@ -231,14 +231,12 @@ static void acl_read_cb(uint8_t ep, int size, void *priv)
 
 		if (pkt_len == 0) {
 			LOG_ERR("Failed to get packet length");
-			net_buf_unref(buf);
-			buf = NULL;
+			net_buf_drop(&buf);
 		}
 	} else {
 		if (net_buf_tailroom(buf) < size) {
 			LOG_ERR("Buffer tailroom too small");
-			net_buf_unref(buf);
-			buf = NULL;
+			net_buf_drop(&buf);
 			goto restart_out_transfer;
 		}
 

--- a/subsys/usb/device_next/class/bt_hci.c
+++ b/subsys/usb/device_next/class/bt_hci.c
@@ -341,14 +341,12 @@ static int bt_hci_acl_out_cb(struct usbd_class_data *const c_data,
 
 		if (hci_data->acl_len == 0) {
 			LOG_ERR("Failed to get packet length");
-			net_buf_unref(hci_data->acl_buf);
-			hci_data->acl_buf = NULL;
+			net_buf_drop(&hci_data->acl_buf);
 		}
 	} else {
 		if (net_buf_tailroom(hci_data->acl_buf) < buf->len) {
 			LOG_ERR("Buffer tailroom too small");
-			net_buf_unref(hci_data->acl_buf);
-			hci_data->acl_buf = NULL;
+			net_buf_drop(&hci_data->acl_buf);
 			goto restart_out_transfer;
 		}
 

--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -294,8 +294,7 @@ static void usbd_free_preallocated(struct usbd_context *const uds_ctx)
 {
 	/* Release reference to pre-allocated setup buffer */
 	if (uds_ctx->setup_buf != NULL) {
-		net_buf_unref(uds_ctx->setup_buf);
-		uds_ctx->setup_buf = NULL;
+		net_buf_drop(&uds_ctx->setup_buf);
 	}
 }
 


### PR DESCRIPTION
Replace the recurring two-line pattern:
```
     net_buf_unref(buf);
     buf = NULL;
``` 
with `net_buf_drop(&buf)`, which performs both operations atomically in a single step. This is a pure refactor with no functional change, just fewer lines and less room for the pointer-zeroing step to be forgotten.
 
 Affected areas:
 - `drivers/ethernet` (eth_sam_gmac, eth_xmc4xxx)
 - `subsys/mgmt/mcumgr/transport` (smp_shell)
 - `subsys/net/ip/tcp`
 - `subsys/usb/device_next` (bt_hci, usbd_device)
 - `subsys/usb/device/class/bluetooth` (legacy USB)
 - `subsys/canbus/isotp`
 - `subsys/mgmt/ec_host_cmd` USB backend — here `net_buf_drop()` also fixes a dangling pointer on the persistent `ctx->usb_rx_buf` field on error paths.