### PR TITLE
drivers: bluetooth: hci: Fix send() buffer ownership contract

### DIFF
--- a/drivers/bluetooth/hci/hci_bee.c
+++ b/drivers/bluetooth/hci/hci_bee.c
@@ -207,7 +207,6 @@ static void rtl_rx_thread(void *p1, void *p2, void *p3)
 
 static int bt_hci_bee_send(const struct device *dev, struct net_buf *buf)
 {
-	int ret = 0;
 	T_RTL_BT_HCI_BUF hci_buf = {};
 	uint8_t packet_type = net_buf_pull_u8(buf);
 
@@ -219,35 +218,27 @@ static int bt_hci_bee_send(const struct device *dev, struct net_buf *buf)
 
 	default:
 		LOG_ERR("Unknown packet type: 0x%02x", packet_type);
-		ret = -EINVAL;
-		goto done;
+		return -EINVAL;
 	}
 
 	if (rtl_bt_hci_h2c_buf_alloc(&hci_buf, packet_type, buf->len) == false) {
-		ret = -EINVAL;
-		goto done;
+		return -EINVAL;
 	}
 
 	if (rtl_bt_hci_h2c_buf_add(&hci_buf, buf->data, buf->len) == false) {
 		rtl_bt_hci_h2c_buf_rel(hci_buf);
-		ret = -EINVAL;
-		goto done;
+		return -EINVAL;
 	}
 
 	if (rtl_bt_hci_send(hci_buf) == false) {
 		rtl_bt_hci_h2c_buf_rel(hci_buf);
-		ret = -EIO;
+		return -EIO;
 	}
 
-done:
+	LOG_DBG("Sent, type %d, len %u", packet_type, buf->len);
 	net_buf_unref(buf);
-	if (ret != 0) {
-		LOG_ERR("Error, type %d, len %u, ret %d", packet_type, buf->len, ret);
-	} else {
-		LOG_DBG("Sent, type %d, len %u", packet_type, buf->len);
-	}
 
-	return ret;
+	return 0;
 }
 
 static int bt_hci_bee_open(const struct device *dev)

--- a/drivers/bluetooth/hci/hci_bflb.c
+++ b/drivers/bluetooth/hci/hci_bflb.c
@@ -230,8 +230,7 @@ static int bt_bflb_send(const struct device *dev, struct net_buf *buf)
 		struct bt_hci_cmd_hdr *chdr;
 
 		if (buf->len < sizeof(*chdr)) {
-			ret = -EINVAL;
-			goto done;
+			return -EINVAL;
 		}
 
 		chdr = (struct bt_hci_cmd_hdr *)buf->data;
@@ -248,8 +247,7 @@ static int bt_bflb_send(const struct device *dev, struct net_buf *buf)
 		uint16_t connhdl_l2cf;
 
 		if (buf->len < sizeof(*acl)) {
-			ret = -EINVAL;
-			goto done;
+			return -EINVAL;
 		}
 
 		acl = (struct bt_hci_acl_hdr *)buf->data;
@@ -265,19 +263,17 @@ static int bt_bflb_send(const struct device *dev, struct net_buf *buf)
 		break;
 	}
 	default:
-		ret = -EINVAL;
-		goto done;
+		return -EINVAL;
 	}
 
 	ret = bt_onchiphci_send(pkt_type, dest_id, &pkt);
 	if (ret != 0) {
 		LOG_ERR("bt_onchiphci_send failed: %d", ret);
-		ret = (ret < 0) ? ret : -EIO;
+		return (ret < 0) ? ret : -EIO;
 	}
 
-done:
 	net_buf_unref(buf);
-	return ret;
+	return 0;
 }
 
 static int bt_bflb_open(const struct device *dev)


### PR DESCRIPTION
The `bt_hci_driver_api` `send()` contract requires that the buffer reference is only consumed (unref'd) on success. On error, the caller retains ownership and is responsible for unref'ing the buffer.
 
Two HCI drivers were violating this contract by unconditionally calling `net_buf_unref()` at a `goto done` label, consuming the buffer on every error path:
 
 - `hci_bflb` — buffer incorrectly consumed on every error path.
 - `hci_bee` — same issue, plus a use-after-free where `buf->len` was
   accessed after the unref.
 
Both are fixed by returning early on each error path (without unref'ing) and only unref'ing on the success path.

Fixes: #112555