### PR TITLE
drivers: mipi_dbi: spi: configure GPIO CS inactive

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -82,6 +82,28 @@ struct mipi_dbi_spi_data {
 	uint16_t spi_byte;
 };
 
+static int mipi_dbi_spi_configure_cs_gpio(const struct mipi_dbi_config *dbi_config)
+{
+	int ret = 0;
+
+	if (!spi_cs_is_gpio(&dbi_config->config)) {
+		return 0;
+	}
+
+	if (!gpio_is_ready_dt(&dbi_config->config.cs.gpio)) {
+		LOG_ERR("SPI CS GPIO is not ready");
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&dbi_config->config.cs.gpio,
+				    GPIO_OUTPUT_INACTIVE);
+	if (ret < 0) {
+		LOG_ERR("Could not configure SPI CS GPIO (%d)", ret);
+	}
+
+	return ret;
+}
+
 #if MIPI_DBI_SPI_TE_REQUIRED
 
 static void mipi_dbi_spi_te_cb(const struct device *dev,
@@ -304,6 +326,11 @@ static int mipi_dbi_spi_write_helper(const struct device *dev,
 	ret = k_mutex_lock(&data->lock, K_FOREVER);
 	if (ret < 0) {
 		return ret;
+	}
+
+	ret = mipi_dbi_spi_configure_cs_gpio(dbi_config);
+	if (ret < 0) {
+		goto out;
 	}
 
 	if (dbi_config->mode == MIPI_DBI_MODE_SPI_3WIRE &&


### PR DESCRIPTION
## Summary

Configure GPIO chip-select as inactive before MIPI DBI SPI transfers when
the SPI configuration uses GPIO CS.

## Problem

Some SPI display panels are sensitive to the chip-select line being left
in an undefined state during reset and initialization.

On an ESP32-WROOM-32 board with an ST7789-compatible 170x320 SPI display,
the panel did not initialize through `zephyr,mipi-dbi-spi` and
`display_st7789v` unless the CS GPIO was configured as inactive before the
first transfer.

The same panel worked with direct SPI transfers when the application
configured CS inactive first.

## Fix

Initialize GPIO CS to the inactive state in the MIPI DBI SPI transport
before performing transfers when `spi_cs_is_gpio()` reports that the SPI
configuration uses GPIO chip-select.

This keeps native chip-select configurations unchanged.

## Testing

Tested on ESP32-WROOM-32 with an ST7789-compatible 170x320 SPI display.

Display connections:

- MOSI: GPIO23
- SCLK: GPIO18
- CS: GPIO15
- DC: GPIO2
- RST: GPIO4
- BL: GPIO32

Tested configurations:

- direct SPI transfer with GPIO CS configured inactive by the application:
  works
- raw `zephyr,mipi-dbi-spi` without CS preconfiguration before this change:
  fails
- raw `zephyr,mipi-dbi-spi` after this change:
  works
- `display_st7789v` over `zephyr,mipi-dbi-spi` after this change:
  works

Build tested with:

```sh
west build -b esp32_devkitc/esp32/procpu -p always \
  $HOME/zephyrproject/personal_projects/spi_screen -- \
  -DDTC_OVERLAY_FILE=$HOME/zephyrproject/personal_projects/spi_screen/boards/esp32_lcd_st7789.overlay