### PR TITLE
docs: mcumgr: Fixed an incorrect cbor type in the mcumgr docs.

### DIFF
--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -237,7 +237,7 @@ CBOR data of request:
 .. code-block:: none
 
     {
-        (str,opt)"hash"     : (str)
+        (str,opt)"hash"     : (byte str)
         (str)"confirm"      : (bool)
     }
 


### PR DESCRIPTION
Updated the mcumgr docs with the correct cbor type for the hash field in the "set image state request." 

[should be `bstr`](https://github.com/zephyrproject-rtos/zephyr/blob/ae3a7de3e4f9c4c34d8e23e7594dca3319c66c04/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c#L803) rather than `str`.