### PR TITLE
kernel: Amalgamation build with CMake

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -809,20 +809,23 @@ extern struct k_mem_partition k_log_partition;
 	extern struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(GET_ARG_N(1, __VA_ARGS__));    \
                                                                                                    \
 	Z_LOG_MODULE_PARTITION(K_APP_DMEM)                                                         \
-	static const struct log_source_const_data *__log_current_const_data __unused =             \
+	static const struct log_source_const_data *\
+		Z_LOG_UNITY_SYM(__log_current_const_data) __unused = \
 		Z_DO_LOG_MODULE_REGISTER(__VA_ARGS__)                                              \
 			? &Z_LOG_ITEM_CONST_DATA(GET_ARG_N(1, __VA_ARGS__))                        \
 			: NULL;                                                                    \
                                                                                                    \
 	Z_LOG_MODULE_PARTITION(K_APP_DMEM)                                                         \
-	static struct log_source_dynamic_data *__log_current_dynamic_data __unused =               \
+	static struct log_source_dynamic_data *\
+		Z_LOG_UNITY_SYM(__log_current_dynamic_data) __unused = \
 		(Z_DO_LOG_MODULE_REGISTER(__VA_ARGS__) &&                                          \
 		 IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING))                                         \
 			? &LOG_ITEM_DYNAMIC_DATA(GET_ARG_N(1, __VA_ARGS__))                        \
 			: NULL;                                                                    \
                                                                                                    \
 	Z_LOG_MODULE_PARTITION(K_APP_BMEM)                                                         \
-	static const uint32_t __log_level __unused = _LOG_LEVEL_RESOLVE(__VA_ARGS__)
+	static const uint32_t Z_LOG_UNITY_SYM(__log_level) __unused = \
+		_LOG_LEVEL_RESOLVE(__VA_ARGS__)
 
 /**
  * @brief Macro for setting log level in the file or function where instance
@@ -832,7 +835,7 @@ extern struct k_mem_partition k_log_partition;
  *
  */
 #define LOG_LEVEL_SET(level)                                                                       \
-	static const uint32_t __log_level __unused = Z_LOG_RESOLVED_LEVEL(level, 0)
+	static const uint32_t Z_LOG_UNITY_SYM(__log_level) __unused = Z_LOG_RESOLVED_LEVEL(level, 0)
 
 #ifdef CONFIG_LOG_CUSTOM_HEADER
 /* This include must always be at the end of log.h */

--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -13,6 +13,20 @@
 #include <stdarg.h>
 #include <zephyr/sys/util.h>
 
+/* Unity build support: give each kernel source file a unique suffix for
+ * file-scope statics defined by LOG_MODULE_DECLARE / LOG_LEVEL_SET so
+ * that combining multiple files in one translation unit does not produce
+ * duplicate-symbol errors.  ZEPHYR_KERNEL_UNITY_ID is defined (per source
+ * file) by CMake when building the kernel target with UNITY_BUILD enabled.
+ */
+#ifdef ZEPHYR_KERNEL_UNITY_ID
+#define Z_LOG_UNITY_SYM_PASTE(sym, id) sym##_##id
+#define Z_LOG_UNITY_SYM_EXPAND(sym, id) Z_LOG_UNITY_SYM_PASTE(sym, id)
+#define Z_LOG_UNITY_SYM(sym) Z_LOG_UNITY_SYM_EXPAND(sym, ZEPHYR_KERNEL_UNITY_ID)
+#else
+#define Z_LOG_UNITY_SYM(sym) sym
+#endif
+
 /* This header file keeps all macros and functions needed for creating logging
  * messages (macros like @ref LOG_ERR).
  */
@@ -88,8 +102,8 @@ extern "C" {
  *
  * @brief Macro for getting ID of current module.
  */
-#define LOG_CURRENT_MODULE_ID() (__log_level != 0 ? \
-	log_const_source_id(__log_current_const_data) : 0U)
+#define LOG_CURRENT_MODULE_ID() (Z_LOG_UNITY_SYM(__log_level) != 0 ? \
+	log_const_source_id(Z_LOG_UNITY_SYM(__log_current_const_data)) : 0U)
 
 /* Set of defines that are set to 1 if function name prefix is enabled for given level. */
 #define Z_LOG_FUNC_PREFIX_0 0
@@ -148,7 +162,7 @@ extern "C" {
 	(Z_LOG_LEVEL_CHECK(_level, CONFIG_LOG_OVERRIDE_LEVEL, LOG_LEVEL_NONE) \
 	||								    \
 	((IS_ENABLED(CONFIG_LOG_OVERRIDE_LEVEL) == false) &&		    \
-	((_level) <= __log_level) &&					    \
+	((_level) <= Z_LOG_UNITY_SYM(__log_level)) &&					    \
 	((_level) <= CONFIG_LOG_MAX_LEVEL)				    \
 	)								    \
 	))
@@ -231,7 +245,8 @@ extern "C" {
  */
 #define Z_LOG_CURRENT_DATA()                                                                       \
 	COND_CODE_1(CONFIG_LOG_RUNTIME_FILTERING, \
-			(__log_current_dynamic_data), (__log_current_const_data))
+			(Z_LOG_UNITY_SYM(__log_current_dynamic_data)), \
+			(Z_LOG_UNITY_SYM(__log_current_const_data)))
 
 /*****************************************************************************/
 /****************** Definitions used by minimal logging *********************/

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -192,6 +192,42 @@ target_include_directories(kernel PRIVATE
 
 target_link_libraries(kernel zephyr_interface)
 
+if(CONFIG_KERNEL_UNITY_BUILD)
+  set_target_properties(kernel PROPERTIES
+    UNITY_BUILD ON
+    UNITY_BUILD_UNIQUE_ID "ZEPHYR_KERNEL_UNITY_ID"
+    UNITY_BUILD_BATCH_SIZE 0
+  )
+endif()
+
+# userspace.c includes the bulk-generated syscall_dispatch.c which defines
+# every z_mrsh_* function; batching it with any other file that includes an
+# individual *_mrsh.c produces duplicate-definition errors in a unity build.
+set_source_files_properties(
+  ${ZEPHYR_BASE}/kernel/userspace/userspace.c
+  PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+)
+
+# main_weak.c must remain its own translation unit so linkers correctly resolve
+# the weak main() symbol. When batched with init.c under CONFIG_BOOTARGS the
+# two conflicting signatures for main() (void vs int/char**) also cause a
+# compile error.
+set_source_files_properties(
+  ${ZEPHYR_BASE}/kernel/main_weak.c
+  PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+)
+
+# mailbox.c must remain its own translation unit. The kernel library is not
+# --whole-archive'd, so in a normal build the linker only pulls in mailbox.c
+# if something references k_mbox_* symbols. Merging it into the unity TU
+# forces it into every link, adding ~1 KB of noinit RAM (async_msg_free stack
+# buffer + async_msg array) even when no mailbox API is used, overflowing
+# RAM-constrained targets.
+set_source_files_properties(
+  ${ZEPHYR_BASE}/kernel/mailbox.c
+  PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+)
+
 endif()
 
 # Optionally build kernel sources without LTO

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1002,6 +1002,17 @@ config KERNEL_NO_LTO
 	  Running kernel code from RAM can improve execution performance, especially
 	  for timing-critical routines or context switch paths.
 
+config KERNEL_UNITY_BUILD
+	bool "Unity build for the kernel"
+	help
+	  Combine kernel C source files into a single translation unit before
+	  compilation. This can reduce footprint and improve inlining across
+	  kernel sources by giving the compiler a wider view.
+
+	  Disable this option if you need per-file compiler diagnostics, are
+	  debugging symbol-visibility issues, or encounter toolchain problems
+	  with the combined translation unit.
+
 rsource "Kconfig.device"
 rsource "Kconfig.vm"
 rsource "Kconfig.init"

--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -16,7 +16,7 @@
 static struct k_obj_type obj_type_condvar;
 #endif /* CONFIG_OBJ_CORE_CONDVAR */
 
-static struct k_spinlock lock;
+static struct k_spinlock condvar_lock;
 
 int z_impl_k_condvar_init(struct k_condvar *condvar)
 {
@@ -43,15 +43,15 @@ int z_vrfy_k_condvar_init(struct k_condvar *condvar)
 
 int z_impl_k_condvar_signal(struct k_condvar *condvar)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&condvar_lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_condvar, signal, condvar);
 
 	if (z_sched_wake(&condvar->wait_q, 0, NULL)) {
 		SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_condvar, signal, condvar, K_FOREVER);
-		z_reschedule(&lock, key);
+		z_reschedule(&condvar_lock, key);
 	} else {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&condvar_lock, key);
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_condvar, signal, condvar, 0);
@@ -73,7 +73,7 @@ int z_impl_k_condvar_broadcast(struct k_condvar *condvar)
 	k_spinlock_key_t key;
 	int woken = 0;
 
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&condvar_lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_condvar, broadcast, condvar);
 
@@ -86,9 +86,9 @@ int z_impl_k_condvar_broadcast(struct k_condvar *condvar)
 
 
 	if (woken == 0) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&condvar_lock, key);
 	} else {
-		z_reschedule(&lock, key);
+		z_reschedule(&condvar_lock, key);
 	}
 
 	return woken;
@@ -120,10 +120,10 @@ int z_impl_k_condvar_wait(struct k_condvar *condvar, struct k_mutex *mutex,
 		return ret;
 	}
 
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&condvar_lock);
 	k_mutex_unlock(mutex);
 
-	ret = z_pend_curr(&lock, key, &condvar->wait_q, timeout);
+	ret = z_pend_curr(&condvar_lock, key, &condvar->wait_q, timeout);
 
 	/* Always re-acquire the mutex before returning, even on timeout.
 	 * This matches POSIX semantics: the mutex must be locked by the

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -29,7 +29,7 @@
 static struct k_obj_type obj_type_msgq;
 #endif /* CONFIG_OBJ_CORE_MSGQ */
 
-static inline bool handle_poll_events(struct k_msgq *msgq)
+static inline bool msgq_handle_poll_events(struct k_msgq *msgq)
 {
 #ifdef CONFIG_POLL
 	return z_handle_obj_poll_events(&msgq->poll_events,
@@ -192,7 +192,7 @@ static inline int put_msg_in_queue(struct k_msgq *msgq, const void *data,
 				(void)memcpy(msgq->read_ptr, (char *)data, msgq->msg_size);
 			}
 			msgq->used_msgs++;
-			resched = handle_poll_events(msgq);
+			resched = msgq_handle_poll_events(msgq);
 		}
 		result = 0;
 	} else if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -46,7 +46,7 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
  * "part of" a single k_mutex.  Should move those bits of the API
  * under the scheduler lock so we can break this up.
  */
-static struct k_spinlock lock;
+static struct k_spinlock mutex_lock;
 
 #ifdef CONFIG_OBJ_CORE_MUTEX
 static struct k_obj_type obj_type_mutex;
@@ -116,7 +116,7 @@ int z_impl_k_mutex_lock(struct k_mutex *mutex, k_timeout_t timeout)
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_mutex, lock, mutex, timeout);
 
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&mutex_lock);
 
 	if (likely((mutex->lock_count == 0U) || (mutex->owner == _current))) {
 
@@ -138,7 +138,7 @@ int z_impl_k_mutex_lock(struct k_mutex *mutex, k_timeout_t timeout)
 			_current, mutex, mutex->lock_count);
 #endif
 
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&mutex_lock, key);
 
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mutex, lock, mutex, timeout, 0);
 
@@ -146,7 +146,7 @@ int z_impl_k_mutex_lock(struct k_mutex *mutex, k_timeout_t timeout)
 	}
 
 	if (unlikely(K_TIMEOUT_EQ(timeout, K_NO_WAIT))) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&mutex_lock, key);
 
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mutex, lock, mutex, timeout, -EBUSY);
 
@@ -166,7 +166,7 @@ int z_impl_k_mutex_lock(struct k_mutex *mutex, k_timeout_t timeout)
 	}
 #endif
 
-	int got_mutex = z_pend_curr(&lock, key, &mutex->wait_q, timeout);
+	int got_mutex = z_pend_curr(&mutex_lock, key, &mutex->wait_q, timeout);
 
 	LOG_DBG("on mutex %p got_mutex value: %d", mutex, got_mutex);
 
@@ -183,7 +183,7 @@ int z_impl_k_mutex_lock(struct k_mutex *mutex, k_timeout_t timeout)
 
 	LOG_DBG("%p timeout on mutex %p", _current, mutex);
 
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&mutex_lock);
 
 	/*
 	 * Check if mutex was unlocked after this thread was unpended.
@@ -202,9 +202,9 @@ int z_impl_k_mutex_lock(struct k_mutex *mutex, k_timeout_t timeout)
 	}
 
 	if (resched) {
-		z_reschedule(&lock, key);
+		z_reschedule(&mutex_lock, key);
 	} else {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&mutex_lock, key);
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mutex, lock, mutex, timeout, -EAGAIN);
@@ -268,7 +268,7 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 		goto k_mutex_unlock_return;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&mutex_lock);
 
 #if (CONFIG_PRIORITY_CEILING < K_LOWEST_THREAD_PRIO)
 	adjust_owner_prio(mutex, mutex->owner_orig_prio);
@@ -302,9 +302,9 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 	}
 
 	if (unlikely(new_owner != NULL)) {
-		z_reschedule(&lock, key);
+		z_reschedule(&mutex_lock, key);
 	} else {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&mutex_lock, key);
 	}
 
 

--- a/kernel/obj_core.c
+++ b/kernel/obj_core.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/kernel/obj_core.h>
 
-static struct k_spinlock  lock;
+static struct k_spinlock  obj_core_lock;
 
 sys_slist_t z_obj_type_list = SYS_SLIST_STATIC_INIT(&z_obj_type_list);
 
@@ -33,11 +33,11 @@ void k_obj_core_init(struct k_obj_core *obj_core, struct k_obj_type *type)
 
 void k_obj_core_link(struct k_obj_core *obj_core)
 {
-	k_spinlock_key_t  key = k_spin_lock(&lock);
+	k_spinlock_key_t  key = k_spin_lock(&obj_core_lock);
 
 	sys_slist_append(&obj_core->type->list, &obj_core->node);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&obj_core_lock, key);
 }
 
 void k_obj_core_init_and_link(struct k_obj_core *obj_core,
@@ -49,11 +49,11 @@ void k_obj_core_init_and_link(struct k_obj_core *obj_core,
 
 void k_obj_core_unlink(struct k_obj_core *obj_core)
 {
-	k_spinlock_key_t  key = k_spin_lock(&lock);
+	k_spinlock_key_t  key = k_spin_lock(&obj_core_lock);
 
 	sys_slist_find_and_remove(&obj_core->type->list, &obj_core->node);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&obj_core_lock, key);
 }
 
 struct k_obj_type *k_obj_type_find(uint32_t type_id)
@@ -62,7 +62,7 @@ struct k_obj_type *k_obj_type_find(uint32_t type_id)
 	struct k_obj_type *rv = NULL;
 	sys_snode_t *node;
 
-	k_spinlock_key_t  key = k_spin_lock(&lock);
+	k_spinlock_key_t  key = k_spin_lock(&obj_core_lock);
 
 	SYS_SLIST_FOR_EACH_NODE(&z_obj_type_list, node) {
 		type = CONTAINER_OF(node, struct k_obj_type, node);
@@ -72,7 +72,7 @@ struct k_obj_type *k_obj_type_find(uint32_t type_id)
 		}
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&obj_core_lock, key);
 
 	return rv;
 }
@@ -86,7 +86,7 @@ int k_obj_type_walk_locked(struct k_obj_type *type,
 	sys_snode_t *node;
 	int  status = 0;
 
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&obj_core_lock);
 
 	SYS_SLIST_FOR_EACH_NODE(&type->list, node) {
 		obj_core = CONTAINER_OF(node, struct k_obj_core, node);
@@ -96,7 +96,7 @@ int k_obj_type_walk_locked(struct k_obj_type *type,
 		}
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&obj_core_lock, key);
 
 	return status;
 }
@@ -126,7 +126,7 @@ int k_obj_core_stats_register(struct k_obj_core *obj_core, void *stats,
 			      size_t stats_len)
 {
 	int rv;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&obj_core_lock);
 
 	if (obj_core->type->stats_desc == NULL) {
 		/* Object type not configured for statistics. */
@@ -139,7 +139,7 @@ int k_obj_core_stats_register(struct k_obj_core *obj_core, void *stats,
 		rv = 0;
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&obj_core_lock, key);
 
 	return rv;
 }
@@ -147,7 +147,7 @@ int k_obj_core_stats_register(struct k_obj_core *obj_core, void *stats,
 int k_obj_core_stats_deregister(struct k_obj_core *obj_core)
 {
 	int rv;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&obj_core_lock);
 
 	if (obj_core->type->stats_desc == NULL) {
 		/* Object type not configured  for statistics. */
@@ -157,7 +157,7 @@ int k_obj_core_stats_deregister(struct k_obj_core *obj_core)
 		rv = 0;
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&obj_core_lock, key);
 
 	return rv;
 }
@@ -168,7 +168,7 @@ int k_obj_core_stats_raw(struct k_obj_core *obj_core, void *stats,
 	int rv;
 	struct k_obj_core_stats_desc *desc;
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&obj_core_lock);
 
 	desc = obj_core->type->stats_desc;
 	if ((desc == NULL) || (desc->raw == NULL)) {
@@ -184,7 +184,7 @@ int k_obj_core_stats_raw(struct k_obj_core *obj_core, void *stats,
 		rv = desc->raw(obj_core, stats);
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&obj_core_lock, key);
 
 	return rv;
 }
@@ -195,7 +195,7 @@ int k_obj_core_stats_query(struct k_obj_core *obj_core, void *stats,
 	int rv;
 	struct k_obj_core_stats_desc *desc;
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&obj_core_lock);
 
 	desc = obj_core->type->stats_desc;
 	if ((desc == NULL) || (desc->query == NULL)) {
@@ -211,7 +211,7 @@ int k_obj_core_stats_query(struct k_obj_core *obj_core, void *stats,
 		rv = desc->query(obj_core, stats);
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&obj_core_lock, key);
 
 	return rv;
 }
@@ -221,7 +221,7 @@ int k_obj_core_stats_reset(struct k_obj_core *obj_core)
 	int rv;
 	struct k_obj_core_stats_desc *desc;
 
-	k_spinlock_key_t  key = k_spin_lock(&lock);
+	k_spinlock_key_t  key = k_spin_lock(&obj_core_lock);
 
 	desc = obj_core->type->stats_desc;
 	if ((desc == NULL) || (desc->reset == NULL)) {
@@ -234,7 +234,7 @@ int k_obj_core_stats_reset(struct k_obj_core *obj_core)
 		rv = desc->reset(obj_core);
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&obj_core_lock, key);
 
 	return rv;
 }
@@ -244,7 +244,7 @@ int k_obj_core_stats_disable(struct k_obj_core *obj_core)
 	int rv;
 	struct k_obj_core_stats_desc *desc;
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&obj_core_lock);
 
 	desc = obj_core->type->stats_desc;
 	if ((desc == NULL) || (desc->disable == NULL)) {
@@ -257,7 +257,7 @@ int k_obj_core_stats_disable(struct k_obj_core *obj_core)
 		rv = desc->disable(obj_core);
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&obj_core_lock, key);
 
 	return rv;
 }
@@ -267,7 +267,7 @@ int k_obj_core_stats_enable(struct k_obj_core *obj_core)
 	int rv;
 	struct k_obj_core_stats_desc *desc;
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&obj_core_lock);
 
 	desc = obj_core->type->stats_desc;
 	if ((desc == NULL) || (desc->enable == NULL)) {
@@ -280,7 +280,7 @@ int k_obj_core_stats_enable(struct k_obj_core *obj_core)
 		rv = desc->enable(obj_core);
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&obj_core_lock, key);
 
 	return rv;
 }

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -32,7 +32,7 @@
  * "inside" a given critical section).  Do the synchronization port
  * later as an optimization.
  */
-static struct k_spinlock lock;
+static struct k_spinlock poll_lock;
 
 enum POLL_MODE { MODE_NONE, MODE_POLL, MODE_TRIGGERED };
 
@@ -214,8 +214,8 @@ static inline void clear_event_registrations(struct k_poll_event *events,
 {
 	while (num_events--) {
 		clear_event_registration(&events[num_events]);
-		k_spin_unlock(&lock, key);
-		key = k_spin_lock(&lock);
+		k_spin_unlock(&poll_lock, key);
+		key = k_spin_lock(&poll_lock);
 	}
 }
 
@@ -236,7 +236,7 @@ static inline int register_events(struct k_poll_event *events,
 		k_spinlock_key_t key;
 		uint32_t state;
 
-		key = k_spin_lock(&lock);
+		key = k_spin_lock(&poll_lock);
 		if (is_condition_met(&events[ii], &state)) {
 			set_event_ready(&events[ii], state);
 			poller->is_polling = false;
@@ -250,7 +250,7 @@ static inline int register_events(struct k_poll_event *events,
 			 */
 			;
 		}
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&poll_lock, key);
 	}
 
 	return events_registered;
@@ -298,7 +298,7 @@ int z_impl_k_poll(struct k_poll_event *events, int num_events,
 	events_registered = register_events(events, num_events, poller,
 					    K_TIMEOUT_EQ(timeout, K_NO_WAIT));
 
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&poll_lock);
 
 	/*
 	 * If we're not polling anymore, it means that at least one event
@@ -307,7 +307,7 @@ int z_impl_k_poll(struct k_poll_event *events, int num_events,
 	 */
 	if (!poller->is_polling) {
 		clear_event_registrations(events, events_registered, key);
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&poll_lock, key);
 
 		SYS_PORT_TRACING_FUNC_EXIT(k_poll_api, poll, events, 0);
 
@@ -317,7 +317,7 @@ int z_impl_k_poll(struct k_poll_event *events, int num_events,
 	poller->is_polling = false;
 
 	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&poll_lock, key);
 
 		SYS_PORT_TRACING_FUNC_EXIT(k_poll_api, poll, events, -EAGAIN);
 
@@ -326,7 +326,7 @@ int z_impl_k_poll(struct k_poll_event *events, int num_events,
 
 	static _wait_q_t wait_q = Z_WAIT_Q_INIT(&wait_q);
 
-	int swap_rc = z_pend_curr(&lock, key, &wait_q, timeout);
+	int swap_rc = z_pend_curr(&poll_lock, key, &wait_q, timeout);
 
 	/*
 	 * Clear all event registrations. If events happen while we're in this
@@ -337,9 +337,9 @@ int z_impl_k_poll(struct k_poll_event *events, int num_events,
 	 * added to the list of events that occurred, the user has to check the
 	 * return code first, which invalidates the whole list of event states.
 	 */
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&poll_lock);
 	clear_event_registrations(events, events_registered, key);
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&poll_lock, key);
 
 	SYS_PORT_TRACING_FUNC_EXIT(k_poll_api, poll, events, swap_rc);
 
@@ -379,9 +379,9 @@ static inline int z_vrfy_k_poll(struct k_poll_event *events,
 		goto oops_free;
 	}
 
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&poll_lock);
 	(void)memcpy(events_copy, events, bounds);
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&poll_lock, key);
 
 	/* Validate what's inside events_copy */
 	for (int i = 0; i < num_events; i++) {
@@ -469,14 +469,14 @@ static int signal_poll_event(struct k_poll_event *event, uint32_t state)
 bool z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state)
 {
 	struct k_poll_event *poll_event;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&poll_lock);
 
 	poll_event = (struct k_poll_event *)sys_dlist_get(events);
 	if (poll_event != NULL) {
 		(void) signal_poll_event(poll_event, state);
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&poll_lock, key);
 
 	return (poll_event != NULL);
 }
@@ -530,7 +530,7 @@ void z_vrfy_k_poll_signal_check(struct k_poll_signal *sig,
 
 int z_impl_k_poll_signal_raise(struct k_poll_signal *sig, int result)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&poll_lock);
 	struct k_poll_event *poll_event;
 
 	sig->result = result;
@@ -538,7 +538,7 @@ int z_impl_k_poll_signal_raise(struct k_poll_signal *sig, int result)
 
 	poll_event = (struct k_poll_event *)sys_dlist_get(&sig->poll_events);
 	if (poll_event == NULL) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&poll_lock, key);
 
 		SYS_PORT_TRACING_FUNC(k_poll_api, signal_raise, sig, 0);
 
@@ -549,7 +549,7 @@ int z_impl_k_poll_signal_raise(struct k_poll_signal *sig, int result)
 
 	SYS_PORT_TRACING_FUNC(k_poll_api, signal_raise, sig, rc);
 
-	z_reschedule(&lock, key);
+	z_reschedule(&poll_lock, key);
 	return rc;
 }
 
@@ -583,10 +583,10 @@ static void triggered_work_handler(struct k_work *work)
 	if (twork->poller.mode != MODE_NONE) {
 		k_spinlock_key_t key;
 
-		key = k_spin_lock(&lock);
+		key = k_spin_lock(&poll_lock);
 		clear_event_registrations(twork->events,
 					  twork->num_events, key);
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&poll_lock, key);
 	}
 
 	/* Drop work ownership and execute real handler. */
@@ -601,14 +601,14 @@ static void triggered_work_expiration_handler(struct _timeout *timeout)
 {
 	struct k_work_poll *twork =
 		CONTAINER_OF(timeout, struct k_work_poll, timeout);
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&poll_lock);
 
 	if (!twork->poller.is_polling) {
 		/* signal_triggered_work() or triggered_work_cancel() has
 		 * already claimed this wake under the same lock; nothing
 		 * for us to do.
 		 */
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&poll_lock, key);
 		return;
 	}
 
@@ -616,7 +616,7 @@ static void triggered_work_expiration_handler(struct _timeout *timeout)
 	twork->poll_result = -EAGAIN;
 	z_work_submit_to_queue(twork->workq, &twork->work);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&poll_lock, key);
 }
 
 static int signal_triggered_work(struct k_poll_event *event, uint32_t status)
@@ -658,8 +658,8 @@ static int triggered_work_cancel(struct k_work_poll *work,
 		 * acting on the new setup.
 		 */
 		while (z_try_abort_timeout(&work->timeout) == -EAGAIN) {
-			k_spin_unlock(&lock, key);
-			key = k_spin_lock(&lock);
+			k_spin_unlock(&poll_lock, key);
+			key = k_spin_lock(&poll_lock);
 		}
 
 		/*
@@ -714,14 +714,14 @@ int k_work_poll_submit_to_queue(struct k_work_q *work_q,
 	SYS_PORT_TRACING_FUNC_ENTER(k_work_poll, submit_to_queue, work_q, work, timeout);
 
 	/* Take ownership of the work if it is possible. */
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&poll_lock);
 	if (work->workq != NULL) {
 		if (work->workq == work_q) {
 			int retval;
 
 			retval = triggered_work_cancel(work, key);
 			if (retval < 0) {
-				k_spin_unlock(&lock, key);
+				k_spin_unlock(&poll_lock, key);
 
 				SYS_PORT_TRACING_FUNC_EXIT(k_work_poll, submit_to_queue, work_q,
 					work, timeout, retval);
@@ -729,7 +729,7 @@ int k_work_poll_submit_to_queue(struct k_work_q *work_q,
 				return retval;
 			}
 		} else {
-			k_spin_unlock(&lock, key);
+			k_spin_unlock(&poll_lock, key);
 
 			SYS_PORT_TRACING_FUNC_EXIT(k_work_poll, submit_to_queue, work_q,
 				work, timeout, -EADDRINUSE);
@@ -742,7 +742,7 @@ int k_work_poll_submit_to_queue(struct k_work_q *work_q,
 	work->poller.is_polling = true;
 	work->workq = work_q;
 	work->poller.mode = MODE_NONE;
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&poll_lock, key);
 
 	/* Save list of events. */
 	work->events = events;
@@ -755,7 +755,7 @@ int k_work_poll_submit_to_queue(struct k_work_q *work_q,
 	events_registered = register_events(events, num_events,
 					    &work->poller, false);
 
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&poll_lock);
 	if (work->poller.is_polling && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
 		/*
 		 * Poller is still polling.
@@ -773,7 +773,7 @@ int k_work_poll_submit_to_queue(struct k_work_q *work_q,
 
 		/* From now, any event will result in submitted work. */
 		work->poller.mode = MODE_TRIGGERED;
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&poll_lock, key);
 
 		SYS_PORT_TRACING_FUNC_EXIT(k_work_poll, submit_to_queue, work_q, work, timeout, 0);
 
@@ -800,7 +800,7 @@ int k_work_poll_submit_to_queue(struct k_work_q *work_q,
 
 	/* Clear registrations. */
 	clear_event_registrations(events, events_registered, key);
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&poll_lock, key);
 
 	/* Submit work. */
 	k_work_submit_to_queue(work_q, &work->work);
@@ -839,9 +839,9 @@ int k_work_poll_cancel(struct k_work_poll *work)
 		return -EINVAL;
 	}
 
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&poll_lock);
 	retval = triggered_work_cancel(work, key);
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&poll_lock, key);
 
 	SYS_PORT_TRACING_FUNC_EXIT(k_work_poll, cancel, work, retval);
 

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -79,7 +79,7 @@ static inline void z_vrfy_k_queue_init(struct k_queue *queue)
 #include <zephyr/syscalls/k_queue_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-static inline bool handle_poll_events(struct k_queue *queue, uint32_t state)
+static inline bool queue_handle_poll_events(struct k_queue *queue, uint32_t state)
 {
 #ifdef CONFIG_POLL
 	return z_handle_obj_poll_events(&queue->poll_events, state);
@@ -102,7 +102,7 @@ void z_impl_k_queue_cancel_wait(struct k_queue *queue)
 		resched = true;
 	}
 
-	resched = handle_poll_events(queue, K_POLL_STATE_CANCELLED) || resched;
+	resched = queue_handle_poll_events(queue, K_POLL_STATE_CANCELLED) || resched;
 
 	if (resched) {
 		z_reschedule(&queue->lock, key);
@@ -160,7 +160,7 @@ static int32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 	}
 
 	sys_sflist_insert(&queue->data_q, prev, data);
-	resched = handle_poll_events(queue, K_POLL_STATE_DATA_AVAILABLE);
+	resched = queue_handle_poll_events(queue, K_POLL_STATE_DATA_AVAILABLE);
 
 out:
 	if (resched) {
@@ -273,7 +273,7 @@ int k_queue_append_list(struct k_queue *queue, void *head, void *tail)
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_queue, append_list, queue, 0);
 
-	resched = handle_poll_events(queue, K_POLL_STATE_DATA_AVAILABLE) || resched;
+	resched = queue_handle_poll_events(queue, K_POLL_STATE_DATA_AVAILABLE) || resched;
 
 	if (resched) {
 		z_reschedule(&queue->lock, key);

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -36,7 +36,7 @@
  * implementation would spin on atomic access to the count variable,
  * and not a spinlock per se.  Useful optimization for the future...
  */
-static struct k_spinlock lock;
+static struct k_spinlock sem_lock;
 
 #ifdef CONFIG_OBJ_CORE_SEM
 static struct k_obj_type obj_type_sem;
@@ -82,7 +82,7 @@ int z_vrfy_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 #include <zephyr/syscalls/k_sem_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-static inline bool handle_poll_events(struct k_sem *sem)
+static inline bool sem_handle_poll_events(struct k_sem *sem)
 {
 #ifdef CONFIG_POLL
 	return z_handle_obj_poll_events(&sem->poll_events, K_POLL_STATE_SEM_AVAILABLE);
@@ -94,7 +94,7 @@ static inline bool handle_poll_events(struct k_sem *sem)
 
 void z_impl_k_sem_give(struct k_sem *sem)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&sem_lock);
 	bool resched;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_sem, give, sem);
@@ -103,13 +103,13 @@ void z_impl_k_sem_give(struct k_sem *sem)
 		resched = true;
 	} else {
 		sem->count += (sem->count != sem->limit) ? 1U : 0U;
-		resched = handle_poll_events(sem);
+		resched = sem_handle_poll_events(sem);
 	}
 
 	if (unlikely(resched)) {
-		z_reschedule(&lock, key);
+		z_reschedule(&sem_lock, key);
 	} else {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&sem_lock, key);
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_sem, give, sem);
@@ -131,26 +131,26 @@ int z_impl_k_sem_take(struct k_sem *sem, k_timeout_t timeout)
 	__ASSERT(((arch_is_in_isr() == false) ||
 		  K_TIMEOUT_EQ(timeout, K_NO_WAIT)), "");
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&sem_lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_sem, take, sem, timeout);
 
 	if (likely(sem->count > 0U)) {
 		sem->count--;
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&sem_lock, key);
 		ret = 0;
 		goto out;
 	}
 
 	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&sem_lock, key);
 		ret = -EBUSY;
 		goto out;
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_sem, take, sem, timeout);
 
-	ret = z_pend_curr(&lock, key, &sem->wait_q, timeout);
+	ret = z_pend_curr(&sem_lock, key, &sem->wait_q, timeout);
 
 out:
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_sem, take, sem, timeout, ret);
@@ -160,7 +160,7 @@ out:
 
 void z_impl_k_sem_reset(struct k_sem *sem)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&sem_lock);
 	bool resched = false;
 
 	while (z_sched_wake(&sem->wait_q, -EAGAIN, NULL)) {
@@ -170,12 +170,12 @@ void z_impl_k_sem_reset(struct k_sem *sem)
 
 	SYS_PORT_TRACING_OBJ_FUNC(k_sem, reset, sem);
 
-	resched = handle_poll_events(sem) || resched;
+	resched = sem_handle_poll_events(sem) || resched;
 
 	if (resched) {
-		z_reschedule(&lock, key);
+		z_reschedule(&sem_lock, key);
 	} else {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&sem_lock, key);
 	}
 }
 

--- a/kernel/smp/ipi.c
+++ b/kernel/smp/ipi.c
@@ -71,22 +71,28 @@ atomic_val_t ipi_mask_create(struct k_thread *thread)
 
 void signal_pending_ipi(void)
 {
-	/* Note: with directed IPIs, arch_sched_directed_ipi() skips the
-	 * calling CPU, so if a CPU consumes its own pending bit the IPI
-	 * is silently dropped. When rescheduling, callers must ensure
-	 * that signal_pending_ipi() is invoked while the scheduler lock is
-	 * still held. Holding the lock ensures the scheduling decision and
-	 * IPI dispatch are atomic: either a concurrent flag_ipi() lands
-	 * before the lock is acquired (and the CPU sees the new thread),
-	 * or it lands after the lock is released (and the other CPU
-	 * dispatches the IPI).
+	/* Drain only the bits for other CPUs. Clearing our own bit here
+	 * would silently drop an IPI destined for us, because
+	 * arch_sched_directed_ipi() skips the calling CPU. Our own bit
+	 * is left set so the next interrupt entry on this CPU will see
+	 * it and run the scheduler.
+	 *
+	 * When rescheduling, callers must ensure that signal_pending_ipi()
+	 * is invoked while the scheduler lock is still held. Holding the
+	 * lock ensures the scheduling decision and IPI dispatch are atomic:
+	 * either a concurrent flag_ipi() lands before the lock is acquired
+	 * (and the CPU sees the new thread), or it lands after the lock is
+	 * released (and the other CPU dispatches the IPI).
 	 */
 
 #if defined(CONFIG_SCHED_IPI_SUPPORTED)
 	if (arch_num_cpus() > 1) {
-		uint32_t  cpu_bitmap;
+		uint32_t self_bit = BIT(_current_cpu->id);
+		uint32_t cpu_bitmap;
 
-		cpu_bitmap = (uint32_t)atomic_clear(&_kernel.pending_ipi);
+		cpu_bitmap = (uint32_t)atomic_and(&_kernel.pending_ipi,
+						  (atomic_val_t)self_bit);
+		cpu_bitmap &= ~self_bit;
 		if (cpu_bitmap != 0) {
 #ifdef CONFIG_ARCH_HAS_DIRECTED_IPIS
 			arch_sched_directed_ipi(cpu_bitmap);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -14,7 +14,7 @@
 #include <ksched.h>
 #include <wait_q.h>
 
-static struct k_spinlock lock;
+static struct k_spinlock timer_lock;
 
 #ifdef CONFIG_OBJ_CORE_TIMER
 static struct k_obj_type obj_type_timer;
@@ -73,7 +73,7 @@ void z_timer_expiration_handler(struct _timeout *t)
 {
 	struct k_timer *timer = CONTAINER_OF(t, struct k_timer, timeout);
 	struct k_thread *thread;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&timer_lock);
 
 	/* A same-CPU IRQ may have raced with our dispatch between
 	 * sys_clock_announce() popping us off the list and us taking
@@ -85,7 +85,7 @@ void z_timer_expiration_handler(struct _timeout *t)
 	 */
 	if (sys_dnode_is_linked(&t->node) ||
 	    z_timeout_inflight_superseded(t)) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&timer_lock, key);
 		return;
 	}
 
@@ -122,7 +122,7 @@ void z_timer_expiration_handler(struct _timeout *t)
 		k_timer_expiry_t expiry_fn = timer->expiry_fn;
 
 		/* Unlock for user handler. */
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&timer_lock, key);
 
 		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, expiry, timer);
 
@@ -130,18 +130,18 @@ void z_timer_expiration_handler(struct _timeout *t)
 
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, expiry, timer);
 
-		key = k_spin_lock(&lock);
+		key = k_spin_lock(&timer_lock);
 	}
 
 	if (!IS_ENABLED(CONFIG_MULTITHREADING)) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&timer_lock, key);
 		return;
 	}
 
 	thread = z_waitq_head(&timer->wait_q);
 
 	if (thread == NULL) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&timer_lock, key);
 		return;
 	}
 
@@ -149,7 +149,7 @@ void z_timer_expiration_handler(struct _timeout *t)
 
 	arch_thread_return_value_set(thread, 0);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&timer_lock, key);
 
 	z_ready_thread(thread);
 }
@@ -172,10 +172,10 @@ int k_timer_cleanup(struct k_timer *timer)
 	 * leave dangling pended_on pointers.
 	 */
 retry:
-	key = k_spin_lock(&lock);
+	key = k_spin_lock(&timer_lock);
 
 	CHECKIF(z_waitq_head(&timer->wait_q) != NULL) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&timer_lock, key);
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, -EAGAIN);
 		return -EAGAIN;
 	}
@@ -194,11 +194,11 @@ retry:
 	 * not wait and so cannot stall.
 	 */
 	if (z_try_abort_timeout(&timer->timeout) == -EAGAIN) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&timer_lock, key);
 		goto retry;
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&timer_lock, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, 0);
 
@@ -250,7 +250,7 @@ void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,
 	 * makes a not-yet-committed handler bail too. Either way we do not
 	 * wait for it.
 	 */
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&timer_lock);
 
 	(void)z_try_abort_timeout(&timer->timeout);
 
@@ -261,7 +261,7 @@ void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,
 
 	z_timer_observer_on_start(timer, duration, period);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&timer_lock, key);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -279,7 +279,7 @@ void z_impl_k_timer_stop(struct k_timer *timer)
 {
 	SYS_PORT_TRACING_OBJ_FUNC(k_timer, stop, timer);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&timer_lock);
 
 	if (z_try_abort_timeout(&timer->timeout) != 0) {
 		/* Not removed from the queue: either the timer was not
@@ -287,7 +287,7 @@ void z_impl_k_timer_stop(struct k_timer *timer)
 		 * z_try_abort_timeout() has flagged it superseded so the
 		 * handler bails; we do not wait for it. Nothing to stop here.
 		 */
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&timer_lock, key);
 		return;
 	}
 
@@ -295,17 +295,17 @@ void z_impl_k_timer_stop(struct k_timer *timer)
 
 	if (timer->stop_fn != NULL) {
 		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, stop_fn_expiry, timer);
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&timer_lock, key);
 
 		timer->stop_fn(timer);
 
-		key = k_spin_lock(&lock);
+		key = k_spin_lock(&timer_lock);
 
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, stop_fn_expiry, timer);
 	}
 
 	if (!IS_ENABLED(CONFIG_MULTITHREADING)) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&timer_lock, key);
 		return;
 
 	}
@@ -314,9 +314,9 @@ void z_impl_k_timer_stop(struct k_timer *timer)
 
 	if (pending_thread != NULL) {
 		z_ready_thread(pending_thread);
-		z_reschedule(&lock, key);
+		z_reschedule(&timer_lock, key);
 	} else {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&timer_lock, key);
 	}
 }
 
@@ -331,11 +331,11 @@ static inline void z_vrfy_k_timer_stop(struct k_timer *timer)
 
 uint32_t z_impl_k_timer_status_get(struct k_timer *timer)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&timer_lock);
 	uint32_t result = timer->status;
 
 	timer->status = 0U;
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&timer_lock, key);
 
 	return result;
 }
@@ -379,7 +379,7 @@ uint32_t z_impl_k_timer_status_sync(struct k_timer *timer)
 		return result;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&timer_lock);
 	uint32_t result = timer->status;
 
 	if (result == 0U) {
@@ -387,10 +387,10 @@ uint32_t z_impl_k_timer_status_sync(struct k_timer *timer)
 			SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_timer, status_sync, timer, K_FOREVER);
 
 			/* wait for timer to expire or stop */
-			(void)z_pend_curr(&lock, key, &timer->wait_q, K_FOREVER);
+			(void)z_pend_curr(&timer_lock, key, &timer->wait_q, K_FOREVER);
 
 			/* get updated timer status */
-			key = k_spin_lock(&lock);
+			key = k_spin_lock(&timer_lock);
 			result = timer->status;
 		} else {
 			/* timer is already stopped */
@@ -400,7 +400,7 @@ uint32_t z_impl_k_timer_status_sync(struct k_timer *timer)
 	}
 
 	timer->status = 0U;
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&timer_lock, key);
 
 	/**
 	 * @note	New tracing hook

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -63,7 +63,7 @@ static inline uint32_t flags_get(const uint32_t *flagp)
 /* Lock to protect the internal state of all work items, work queues,
  * and pending_cancels.
  */
-static struct k_spinlock lock;
+static struct k_spinlock work_lock;
 
 /* Invoked by work thread */
 static void handle_flush(struct k_work *work) { }
@@ -168,10 +168,10 @@ static inline int work_busy_get_locked(const struct k_work *work)
 
 int k_work_busy_get(const struct k_work *work)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 	int ret = work_busy_get_locked(work);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	return ret;
 }
@@ -381,11 +381,11 @@ int z_work_submit_to_queue(struct k_work_q *queue,
 	__ASSERT_NO_MSG(work != NULL);
 	__ASSERT_NO_MSG(work->handler != NULL);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 
 	int ret = submit_to_queue_locked(work, &queue);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	return ret;
 }
@@ -469,11 +469,11 @@ bool k_work_flush(struct k_work *work,
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, flush, work);
 
 	struct z_work_flusher *flusher = &sync->flusher;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 
 	bool need_flush = work_flush_locked(work, flusher);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	/* If necessary wait until the flusher item completes */
 	if (need_flush) {
@@ -557,10 +557,10 @@ int k_work_cancel(struct k_work *work)
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, cancel, work);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 	int ret = cancel_async_locked(work);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work, cancel, work, ret);
 
@@ -581,7 +581,7 @@ bool k_work_cancel_sync(struct k_work *work,
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, cancel_sync, work, sync);
 
 	struct z_work_canceller *canceller = &sync->canceller;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 	bool pending = (work_busy_get_locked(work) != 0U);
 	bool need_wait = false;
 
@@ -590,7 +590,7 @@ bool k_work_cancel_sync(struct k_work *work,
 		need_wait = cancel_sync_locked(work, canceller);
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	if (need_wait) {
 		SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_work, cancel_sync, work, sync);
@@ -610,7 +610,7 @@ static void work_timeout_handler(struct _timeout *record)
 	k_work_handler_t handler = NULL;
 	const char *name;
 	const char *space = " ";
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 
 	work = queue->work;
 	handler = work->handler;
@@ -627,12 +627,12 @@ static void work_timeout_handler(struct _timeout *record)
 	 * flags it superseded; bail on that too.
 	 */
 	if (queue->finished || z_timeout_inflight_superseded(record)) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&work_lock, key);
 		return;
 	}
 	queue->finished = true;
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	name = k_thread_name_get(queue->thread_id);
 	if (name == NULL) {
@@ -683,7 +683,7 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 		sys_snode_t *node;
 		struct k_work *work = NULL;
 		k_work_handler_t handler = NULL;
-		k_spinlock_key_t key = k_spin_lock(&lock);
+		k_spinlock_key_t key = k_spin_lock(&work_lock);
 		bool yield;
 
 		/* Check for and prepare any new work. */
@@ -726,7 +726,7 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 			/* User has requested that the queue stop. Clear the status flags and exit.
 			 */
 			flags_set(&queue->flags, 0);
-			k_spin_unlock(&lock, key);
+			k_spin_unlock(&work_lock, key);
 			return;
 		} else {
 			/* No work is available and no queue state requires
@@ -742,7 +742,7 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 			 * work thread will be woken and we can check again.
 			 */
 
-			(void)z_sched_wait(&lock, key, &queue->notifyq,
+			(void)z_sched_wait(&work_lock, key, &queue->notifyq,
 					   K_FOREVER, NULL);
 			continue;
 		}
@@ -751,7 +751,7 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 		work_timeout_start_locked(queue, work);
 #endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&work_lock, key);
 
 		__ASSERT_NO_MSG(handler != NULL);
 		handler(work);
@@ -761,7 +761,7 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 		 * was running.  Clear the BUSY flag and optionally
 		 * yield to prevent starving other threads.
 		 */
-		key = k_spin_lock(&lock);
+		key = k_spin_lock(&work_lock);
 
 #if defined(CONFIG_WORKQUEUE_WORK_TIMEOUT)
 		if (queue->finished) {
@@ -770,7 +770,7 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 			 * thread for taking too long and is going to abort it.
 			 * Do not proceed to the next work item.
 			 */
-			k_spin_unlock(&lock, key);
+			k_spin_unlock(&work_lock, key);
 			while (1) {
 				k_sleep(K_FOREVER);
 			}
@@ -791,7 +791,7 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 		flag_clear(&queue->flags, K_WORK_QUEUE_BUSY_BIT);
 		yield = (!flag_test(&queue->flags, K_WORK_QUEUE_NO_YIELD_BIT) &&
 			 !sys_slist_is_empty(&queue->pending));
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&work_lock, key);
 
 		/* Optionally yield to prevent the work queue from
 		 * starving other threads.
@@ -906,7 +906,7 @@ int k_work_queue_drain(struct k_work_q *queue,
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work_queue, drain, queue);
 
 	int ret = 0;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 
 	if (((flags_get(&queue->flags)
 	      & (K_WORK_QUEUE_BUSY | K_WORK_QUEUE_DRAIN)) != 0U)
@@ -918,10 +918,10 @@ int k_work_queue_drain(struct k_work_q *queue,
 		}
 
 		notify_queue_locked(queue);
-		ret = z_sched_wait(&lock, key, &queue->drainq,
+		ret = z_sched_wait(&work_lock, key, &queue->drainq,
 				   K_FOREVER, NULL);
 	} else {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&work_lock, key);
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, drain, queue, ret);
@@ -936,13 +936,13 @@ int k_work_queue_unplug(struct k_work_q *queue)
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work_queue, unplug, queue);
 
 	int ret = -EALREADY;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 
 	if (flag_test_and_clear(&queue->flags, K_WORK_QUEUE_PLUGGED_BIT)) {
 		ret = 0;
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, unplug, queue, ret);
 
@@ -959,28 +959,28 @@ int k_work_queue_stop(struct k_work_q *queue, k_timeout_t timeout)
 		return -ENOTSUP;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 
 	if (!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT)) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&work_lock, key);
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, stop, queue, timeout, -EALREADY);
 		return -EALREADY;
 	}
 
 	if (!flag_test(&queue->flags, K_WORK_QUEUE_PLUGGED_BIT)) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&work_lock, key);
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, stop, queue, timeout, -EBUSY);
 		return -EBUSY;
 	}
 
 	flag_set(&queue->flags, K_WORK_QUEUE_STOP_BIT);
 	notify_queue_locked(queue);
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 	SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_work_queue, stop, queue, timeout);
 	if (k_thread_join(queue->thread_id, timeout)) {
-		key = k_spin_lock(&lock);
+		key = k_spin_lock(&work_lock);
 		flag_clear(&queue->flags, K_WORK_QUEUE_STOP_BIT);
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&work_lock, key);
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, stop, queue, timeout, -ETIMEDOUT);
 		return -ETIMEDOUT;
 	}
@@ -1002,7 +1002,7 @@ static void work_timeout(struct _timeout *to)
 	struct k_work_delayable *dw
 		= CONTAINER_OF(to, struct k_work_delayable, timeout);
 	struct k_work *wp = &dw->work;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 	struct k_work_q *queue = NULL;
 
 	/* K_WORK_DELAYED_BIT is the wake-ownership flag: whichever side
@@ -1015,7 +1015,7 @@ static void work_timeout(struct _timeout *to)
 		(void)submit_to_queue_locked(wp, &queue);
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 }
 
 void k_work_init_delayable(struct k_work_delayable *dwork,
@@ -1040,10 +1040,10 @@ int k_work_delayable_busy_get(const struct k_work_delayable *dwork)
 {
 	__ASSERT_NO_MSG(dwork != NULL);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 	int ret = work_delayable_busy_get_locked(dwork);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 	return ret;
 }
 
@@ -1122,8 +1122,8 @@ static inline bool unschedule_locked(struct k_work_delayable *dwork,
 	 */
 	if (flag_test_and_clear(&work->flags, K_WORK_DELAYED_BIT)) {
 		while (z_try_abort_timeout(&dwork->timeout) == -EAGAIN) {
-			k_spin_unlock(&lock, *key);
-			*key = k_spin_lock(&lock);
+			k_spin_unlock(&work_lock, *key);
+			*key = k_spin_lock(&work_lock);
 		}
 		ret = true;
 	}
@@ -1160,14 +1160,14 @@ int k_work_schedule_for_queue(struct k_work_q *queue, struct k_work_delayable *d
 
 	struct k_work *work = &dwork->work;
 	int ret = 0;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 
 	/* Schedule the work item if it's idle or running. */
 	if ((work_busy_get_locked(work) & ~K_WORK_RUNNING) == 0U) {
 		ret = schedule_for_queue_locked(&queue, dwork, delay);
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work, schedule_for_queue, queue, dwork, delay, ret);
 
@@ -1194,7 +1194,7 @@ int k_work_reschedule_for_queue(struct k_work_q *queue, struct k_work_delayable 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, reschedule_for_queue, queue, dwork, delay);
 
 	int ret;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 
 	/* Remove any active scheduling. */
 	(void)unschedule_locked(dwork, &key);
@@ -1202,7 +1202,7 @@ int k_work_reschedule_for_queue(struct k_work_q *queue, struct k_work_delayable 
 	/* Schedule the work item with the new parameters. */
 	ret = schedule_for_queue_locked(&queue, dwork, delay);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work, reschedule_for_queue, queue, dwork, delay, ret);
 
@@ -1226,10 +1226,10 @@ int k_work_cancel_delayable(struct k_work_delayable *dwork)
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, cancel_delayable, dwork);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 	int ret = cancel_delayable_async_locked(dwork, &key);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work, cancel_delayable, dwork, ret);
 
@@ -1249,7 +1249,7 @@ bool k_work_cancel_delayable_sync(struct k_work_delayable *dwork,
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, cancel_delayable_sync, dwork, sync);
 
 	struct z_work_canceller *canceller = &sync->canceller;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 	bool pending = (work_delayable_busy_get_locked(dwork) != 0U);
 	bool need_wait = false;
 
@@ -1258,7 +1258,7 @@ bool k_work_cancel_delayable_sync(struct k_work_delayable *dwork,
 		need_wait = cancel_sync_locked(&dwork->work, canceller);
 	}
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	if (need_wait) {
 		k_sem_take(&canceller->sem, K_FOREVER);
@@ -1282,11 +1282,11 @@ bool k_work_flush_delayable(struct k_work_delayable *dwork,
 
 	struct k_work *work = &dwork->work;
 	struct z_work_flusher *flusher = &sync->flusher;
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&work_lock);
 
 	/* If it's idle release the lock and return immediately. */
 	if (work_busy_get_locked(work) == 0U) {
-		k_spin_unlock(&lock, key);
+		k_spin_unlock(&work_lock, key);
 
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work, flush_delayable, dwork, sync, false);
 
@@ -1305,7 +1305,7 @@ bool k_work_flush_delayable(struct k_work_delayable *dwork,
 	/* Wait for it to finish */
 	bool need_flush = work_flush_locked(work, flusher);
 
-	k_spin_unlock(&lock, key);
+	k_spin_unlock(&work_lock, key);
 
 	/* If necessary wait until the flusher item completes */
 	if (need_flush) {

--- a/subsys/portability/posix/c_lib_ext/getentropy.c
+++ b/subsys/portability/posix/c_lib_ext/getentropy.c
@@ -12,8 +12,6 @@
 
 int getentropy(void *buffer, size_t length)
 {
-	const struct device *const entropy = entropy_get_default_device();
-
 	if (!buffer) {
 		errno = EFAULT;
 		return -1;
@@ -23,6 +21,9 @@ int getentropy(void *buffer, size_t length)
 		errno = EIO;
 		return -1;
 	}
+
+#if defined(CONFIG_ENTROPY_HAS_DRIVER) || defined(CONFIG_ARCH_HAS_ENTROPY)
+	const struct device *const entropy = entropy_get_default_device();
 
 	if (entropy == NULL || !device_is_ready(entropy)) {
 		errno = EIO;
@@ -40,4 +41,8 @@ int getentropy(void *buffer, size_t length)
 	}
 
 	return 0;
+#else
+	errno = EIO;
+	return -1;
+#endif
 }

--- a/tests/kernel/mem_protect/demand_paging/mem_map/boards/qemu_cortex_a53.overlay
+++ b/tests/kernel/mem_protect/demand_paging/mem_map/boards/qemu_cortex_a53.overlay
@@ -1,3 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &sram0 {
-	reg = <0x0 0x40000000 0x0 0x72000>;
+	/* Sized so the demand_paging arena exceeds the backing store after
+	 * accounting for the kernel image (which can grow with unity builds
+	 * or future kernel changes); see test_k_mem_page_out().
+	 */
+	reg = <0x0 0x40000000 0x0 0x76000>;
 };

--- a/tests/kernel/mem_protect/demand_paging/mem_map/boards/qemu_x86_tiny.overlay
+++ b/tests/kernel/mem_protect/demand_paging/mem_map/boards/qemu_x86_tiny.overlay
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Grow DRAM beyond the qemu_x86_tiny default so the demand_paging arena
+ * computed from k_mem_free_get() still exceeds the backing store after the
+ * kernel image consumes its share. See test_k_mem_page_out() for the
+ * precondition; the tight default left no headroom for kernel growth (e.g.
+ * unity builds retain additional symbols).
+ */
+&dram0 {
+	reg = <0x100000 0x50000>;
+};

--- a/tests/kernel/mem_protect/demand_paging/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/mem_map/src/main.c
@@ -256,6 +256,18 @@ static void test_k_mem_page_out(void)
 		      "unexpected num pagefaults expected %d got %lu",
 		      HALF_PAGES, faults);
 
+	/* The -ENOMEM check below only holds if the arena exceeds the backing
+	 * store. arena_size is derived from free RAM at test start, so growth
+	 * in the kernel image (e.g. extra retained symbols under unity builds)
+	 * can shrink it below the backing store and make the call legitimately
+	 * succeed. Skip the check rather than report a spurious failure when
+	 * the test config does not guarantee the precondition.
+	 */
+	zassume_true(arena_size > (size_t)EXTRA_PAGES * CONFIG_MMU_PAGE_SIZE,
+		     "arena (%zu pages) does not exceed backing store (%d pages); "
+		     "test config has insufficient free RAM to exercise -ENOMEM",
+		     arena_size / CONFIG_MMU_PAGE_SIZE, EXTRA_PAGES);
+
 	ret = k_mem_page_out(arena, arena_size);
 	zassert_equal(ret, -ENOMEM, "k_mem_page_out should have failed");
 

--- a/tests/kernel/mem_protect/mem_map/boards/qemu_x86_tiny.overlay
+++ b/tests/kernel/mem_protect/mem_map/boards/qemu_x86_tiny.overlay
@@ -1,3 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Grow DRAM beyond the qemu_x86_tiny default so the reserved page-frame
+ * pool used by k_mem_map() still has headroom after the kernel image
+ * consumes its share. The tight default leaves no margin for kernel
+ * growth (e.g. unity builds retain additional symbols) and causes
+ * test_k_mem_map_unmap to fail at k_mem_free_get() == 0.
+ */
 &dram0 {
-	reg = <0x100000 0x50000>;
+	reg = <0x100000 0x60000>;
 };


### PR DESCRIPTION
Amalgamation (cmake calls them unity) builds in theory should allow for better compiler visibility across what would otherwise be distinct compilation/translation units allowing for better optimization.

I'm still not seeing quite the improvement I was looking for but I believe most of the changes are nice regardless of overall performance gains. I’m seeing 2-5% general benefit from this.

Likely more things using the kernel would need to be combined into the unity build to see greater benefit which I plan on exploring.
