### PR TITLE
Bluetooth: Controller: Use PHY_FLAGS_S2/S8 defines for Coded PHY flags

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -320,7 +320,7 @@ void lll_scan_aux_isr_aux_setup(void *param)
 	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
 	/* TODO: for passive scanning use complete_and_disable */
-	radio_switch_complete_and_tx(phy_aux, 0, phy_aux, 1);
+	radio_switch_complete_and_tx(phy_aux, PHY_FLAGS_S2, phy_aux, PHY_FLAGS_S8);
 
 	/* TODO: skip filtering if AdvA was already found in previous PDU */
 
@@ -524,7 +524,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
 	/* TODO: for passive scanning use complete_and_disable */
-	radio_switch_complete_and_tx(lll_aux->phy, 0, lll_aux->phy, 1);
+	radio_switch_complete_and_tx(lll_aux->phy, PHY_FLAGS_S2, lll_aux->phy, PHY_FLAGS_S8);
 
 	/* TODO: skip filtering if AdvA was already found in previous PDU */
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -349,7 +349,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	/* TODO: if coded we use S8? */
-	radio_phy_set(lll->phy_p, 1);
+	radio_phy_set(lll->phy_p, PHY_FLAGS_S8);
 	radio_pkt_configure(8, PDU_AC_LEG_PAYLOAD_SIZE_MAX, (lll->phy_p << 1));
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
 	radio_phy_set(0, 0);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -156,7 +156,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	/* TODO: if coded we use S8? */
-	radio_phy_set(lll->phy, 1);
+	radio_phy_set(lll->phy, PHY_FLAGS_S8);
 	radio_pkt_configure(8, PDU_AC_LEG_PAYLOAD_SIZE_MAX, (lll->phy << 1));
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
 	radio_phy_set(0, 0);


### PR DESCRIPTION
## Description

This PR addresses issue #37458 by replacing magic number literals for
S2/S8 Coded PHY flags with the defined `PHY_FLAGS_S2` and `PHY_FLAGS_S8`
constants in `pdu.h`.

This is consistent with PR #108416 which replaced magic numbers for
access_addr and crc_init array sizes.

This is a no-functional-change cleanup PR (magic number → define replacement).

### Changes (3 files, 4 replacements)

| File | Changes |
|------|---------|
| `lll_scan_aux.c` (nordic) | `0` → `PHY_FLAGS_S2`, `1` → `PHY_FLAGS_S8` (2 places) |
| `lll_adv.c` (openisa) | `1` → `PHY_FLAGS_S8` (1 place) |
| `lll_scan.c` (openisa) | `1` → `PHY_FLAGS_S8` (1 place) |


### Testing

CI build will verify compilation



Part of #37458