### PR TITLE
bluetooth: host: classic: fix SDP attribute parsing recursion check

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -3490,7 +3490,7 @@ static int sdp_attr_parse(struct net_buf_simple *buf,
 	}
 
 	/* The following is a data ele sequence, so recursively parse */
-	if ((buf->len > 0) && sdp_attr_is_seq(buf->data[0])) {
+	if (sdp_attr_is_seq(type) && (buf->len > 0) && sdp_attr_is_seq(buf->data[0])) {
 		LOG_DBG("Recursively parse");
 
 		return sdp_attr_parse(buf, func, user_data, nest_level + 1);


### PR DESCRIPTION
Add missing type check in sdp_attr_parse() before recursively parsing data element sequences. When checking the type of the next data if it is a sequence, it did not first check if the current type is a sequence.

It could lead to incorrect recursive parsing when the current type is not a sequence but the next byte was incorrectly identified as a sequence.

Fix the issue by checking the current data type firstly.