### PR TITLE
soc: wch: ch32v: add zero-wait flash section support

### DIFF
--- a/soc/wch/ch32v/CMakeLists.txt
+++ b/soc/wch/ch32v/CMakeLists.txt
@@ -4,4 +4,4 @@
 add_subdirectory(common)
 add_subdirectory(${SOC_SERIES})
 
-set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")
+set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/common/linker.ld CACHE INTERNAL "")

--- a/soc/wch/ch32v/common/CMakeLists.txt
+++ b/soc/wch/ch32v/common/CMakeLists.txt
@@ -5,3 +5,4 @@ zephyr_library_sources_ifdef(CONFIG_PM power.c)
 zephyr_library_sources_ifdef(CONFIG_ARCH_HAS_CUSTOM_CPU_IDLE soc_idle.c)
 
 zephyr_include_directories(.)
+zephyr_include_directories(include)

--- a/soc/wch/ch32v/common/include/zero_wait.h
+++ b/soc/wch/ch32v/common/include/zero_wait.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Colt Ma <fae@coltsmart.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Macros for placing code and data in the zero-wait flash region
+ * (first 128 KB of CH32V flash, 0x00000-0x20000).
+ *
+ *   ZERO_WAIT_TEXT   — place a function in zero-wait flash
+ *   ZERO_WAIT_RODATA — place read-only data in zero-wait flash
+ *
+ * Typical usage:
+ *
+ *   #include <soc/zero_wait.h>
+ *
+ *   ZERO_WAIT_TEXT void my_isr_handler(const void *arg) { ... }
+ *
+ *   ZERO_WAIT_RODATA static const int table[] = { 1, 2, 3 };
+ */
+
+#ifndef ZERO_WAIT_H
+#define ZERO_WAIT_H
+
+#ifdef __ASSEMBLER__
+#define ZERO_WAIT_TEXT   .section .zero_wait_text, "ax"
+#define ZERO_WAIT_RODATA .section .zero_wait_rodata, "a"
+#else
+#define ZERO_WAIT_TEXT \
+	__attribute__((section(".zero_wait_text")))
+#define ZERO_WAIT_RODATA \
+	__attribute__((section(".zero_wait_rodata")))
+#endif
+
+#endif /* ZERO_WAIT_H */

--- a/soc/wch/ch32v/common/linker.ld
+++ b/soc/wch/ch32v/common/linker.ld
@@ -1,0 +1,493 @@
+/*
+ * Copyright (c) 2026 Colt Ma <fae@coltsmart.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Derived from include/zephyr/arch/riscv/common/linker.ld
+ * Copyright (c) 2016-2017 Jean-Paul Etienne <fractalclone@gmail.com>
+ */
+
+/**
+ * @file
+ * @brief Linker command/script file
+ *
+ * Generic Linker script for the riscv platform
+ */
+
+#include <zephyr/devicetree.h>
+
+#include <zephyr/linker/sections.h>
+#include <zephyr/linker/devicetree_regions.h>
+
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/linker/linker-tool.h>
+
+#ifdef CONFIG_XIP
+#define ROMABLE_REGION              ROM
+#else
+#define ROMABLE_REGION              RAM
+#endif
+#define RAMABLE_REGION              RAM
+
+#define _EXCEPTION_SECTION_NAME     exceptions
+#define _RESET_SECTION_NAME         reset
+
+#if defined(CONFIG_ROM_END_OFFSET)
+#define ROM_END_OFFSET CONFIG_ROM_END_OFFSET
+#else
+#define ROM_END_OFFSET 0
+#endif
+
+#if defined(CONFIG_FLASH_USES_MAPPED_PARTITION) && defined(CONFIG_XIP)
+#define ROM_BASE (DT_REG_ADDR(DT_CHOSEN(zephyr_code_partition)))
+#define ROM_SIZE (DT_REG_SIZE(DT_CHOSEN(zephyr_code_partition)) - ROM_END_OFFSET)
+#else /* defined(CONFIG_FLASH_USES_MAPPED_PARTITION) && defined(CONFIG_XIP) */
+#if defined(CONFIG_FLASH_LOAD_OFFSET)
+#define FLASH_LOAD_OFFSET CONFIG_FLASH_LOAD_OFFSET
+#else
+#define FLASH_LOAD_OFFSET 0
+#endif
+
+#ifdef CONFIG_XIP
+
+#if CONFIG_FLASH_LOAD_SIZE > 0
+#define ROM_SIZE (CONFIG_FLASH_LOAD_SIZE - ROM_END_OFFSET)
+#endif
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_flash), soc_nv_flash, okay)
+#define ROM_BASE (DT_REG_ADDR(DT_CHOSEN(zephyr_flash)) + FLASH_LOAD_OFFSET)
+#ifndef ROM_SIZE
+#define ROM_SIZE (DT_REG_SIZE(DT_CHOSEN(zephyr_flash)) - ROM_END_OFFSET)
+#endif
+
+#elif DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_flash), jedec_spi_nor)
+/* For jedec,spi-nor we expect the spi controller to memory map the flash
+ * and for that mapping to be on the register with the name flash_mmap and if a register with that
+ * name doesn't exists, we expect it to be in the second register property of the spi controller.
+ */
+#define SPI_CTRL DT_PARENT(DT_CHOSEN(zephyr_flash))
+#define FLASH_MMAP_NAME flash_mmap
+#define ROM_BASE                                                                                   \
+	(DT_REG_ADDR_BY_NAME_OR(SPI_CTRL, FLASH_MMAP_NAME, DT_REG_ADDR_BY_IDX(SPI_CTRL, 1)) +      \
+	 FLASH_LOAD_OFFSET)
+#ifndef ROM_SIZE
+#define ROM_SIZE                                                                                   \
+	(DT_REG_SIZE_BY_NAME_OR(SPI_CTRL, FLASH_MMAP_NAME, DT_REG_SIZE_BY_IDX(SPI_CTRL, 1)) -      \
+	 ROM_END_OFFSET)
+#endif
+
+#else /* Use Kconfig to cover the remaining cases */
+#define ROM_BASE (CONFIG_FLASH_BASE_ADDRESS + FLASH_LOAD_OFFSET)
+#ifndef ROM_SIZE
+#define ROM_SIZE (CONFIG_FLASH_SIZE * 1024 - FLASH_LOAD_OFFSET - ROM_END_OFFSET)
+#endif
+
+#endif /* DT_NODE_HAS_COMPAT_STATUS */
+
+#else /* CONFIG_XIP */
+#define ROM_BASE DT_CHOSEN_SRAM_ADDR
+#define ROM_SIZE (DT_CHOSEN_SRAM_SIZE - ROM_END_OFFSET)
+#endif /* CONFIG_XIP */
+#endif /* defined(CONFIG_FLASH_USES_MAPPED_PARTITION) && defined(CONFIG_XIP) */
+
+#define RAM_BASE DT_CHOSEN_SRAM_ADDR
+#define RAM_SIZE DT_CHOSEN_SRAM_SIZE
+
+#ifdef CONFIG_RISCV_PMP
+	#define MPU_MIN_SIZE CONFIG_PMP_GRANULARITY
+	#define MPU_MIN_SIZE_ALIGN . = ALIGN(MPU_MIN_SIZE);
+	#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
+		#define MPU_ALIGN(region_size) \
+			. = ALIGN(MPU_MIN_SIZE); \
+			. = ALIGN( 1 << LOG2CEIL(region_size))
+	#else
+		#define MPU_ALIGN(region_size) \
+			. = ALIGN(MPU_MIN_SIZE)
+	#endif
+#else
+	#define MPU_MIN_SIZE_ALIGN
+	#define MPU_ALIGN(region_size) . = ALIGN(4)
+#endif
+
+#include <zephyr/linker/linker-devnull.h>
+
+MEMORY
+{
+#ifdef CONFIG_XIP
+    ROM (rx)  : ORIGIN = ROM_BASE, LENGTH = ROM_SIZE
+#endif
+    RAM (rwx) : ORIGIN = RAM_BASE, LENGTH = RAM_SIZE
+
+#if defined(CONFIG_LINKER_DEVNULL_MEMORY)
+    DEVNULL_ROM (rx) : ORIGIN = DEVNULL_ADDR, LENGTH = DEVNULL_SIZE
+#endif
+
+    LINKER_DT_REGIONS()
+
+    /* Used by and documented in include/linker/intlist.ld */
+    IDT_LIST  (wx)      : ORIGIN = 0xFFFFF000, LENGTH = 4K
+}
+
+ENTRY(CONFIG_KERNEL_ENTRY)
+
+SECTIONS
+    {
+
+#include <zephyr/linker/rel-sections.ld>
+#include <zephyr/linker/llext-sections.ld>
+
+    /*
+     * The .plt and .iplt are here according to
+     * 'riscv32-zephyr-elf-ld --verbose', before text section.
+     */
+    SECTION_PROLOGUE(.plt,,)
+	{
+		*(.plt)
+	}
+
+    SECTION_PROLOGUE(.iplt,,)
+	{
+		*(.iplt)
+	}
+
+    GROUP_START(ROMABLE_REGION)
+    __rom_region_start = ROM_BASE;
+
+    SECTION_PROLOGUE(rom_start,,)
+    {
+		. = ALIGN(16);
+/* Located in generated directory. This file is populated by calling
+ * zephyr_linker_sources(ROM_START ...).
+ */
+#include <snippets-rom-start.ld>
+    } GROUP_LINK_IN(ROMABLE_REGION)
+
+#ifdef CONFIG_CODE_DATA_RELOCATION
+#include <linker_relocate.ld>
+#endif
+
+    SECTION_PROLOGUE(_RESET_SECTION_NAME,,)
+    {
+		KEEP(*(.reset.*))
+    } GROUP_LINK_IN(ROMABLE_REGION)
+
+    SECTION_PROLOGUE(_EXCEPTION_SECTION_NAME,,)
+    {
+		 KEEP(*(".exception.entry.*"))
+		 *(".exception.other.*")
+    } GROUP_LINK_IN(ROMABLE_REGION)
+
+#ifdef CONFIG_SOC_FAMILY_CH32V
+    SECTION_PROLOGUE(.zero_wait_text,,)
+    {
+		*(.zero_wait_text*)
+		KEEP(*(SORT(.zero_wait_text*)))
+		/* Arch ISR + context switch */
+		*libarch__riscv__core.a:(.text .text.*)
+		/* Kernel scheduling / work-queue / semaphores / irq_lock */
+		*libkernel.a:(.text .text.*)
+		/* All Zephyr drivers (UART, GPIO, interrupt controller, etc.) */
+		*libdrivers__*.a:(.text .text.*)
+    } GROUP_LINK_IN(ROMABLE_REGION)
+
+    SECTION_PROLOGUE(.zero_wait_rodata,,)
+    {
+		*(.zero_wait_rodata*)
+		KEEP(*(SORT(.zero_wait_rodata*)))
+    } GROUP_LINK_IN(ROMABLE_REGION)
+#endif
+
+    SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
+	{
+		. = ALIGN(4);
+		KEEP(*(.openocd_debug))
+		KEEP(*(".openocd_debug.*"))
+
+		__text_region_start = .;
+
+		*(.text)
+		*(".text.*")
+		*(.gnu.linkonce.t.*)
+#include <zephyr/linker/kobject-text.ld>
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
+    __text_region_end = .;
+
+	__rodata_region_start = .;
+#include <zephyr/linker/common-rom.ld>
+/* Located in generated directory. This file is populated by calling
+ * zephyr_linker_sources(ROM_SECTIONS ...). Useful for grouping iterable RO structs.
+ */
+#include <snippets-rom-sections.ld>
+#include <zephyr/linker/thread-local-storage.ld>
+
+    SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
+	{
+		 . = ALIGN(4);
+		 *(.srodata)
+		 *(".srodata.*")
+		 *(.rodata)
+		 *(".rodata.*")
+		 *(.gnu.linkonce.r.*)
+		 *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-rodata.ld>
+#include <zephyr/linker/kobject-rom.ld>
+	. = ALIGN(4);
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
+#include <zephyr/linker/cplusplus-rom.ld>
+	__rodata_region_end = .;
+
+	/* For non-XIP system, __rom_region_end symbol should be set to
+	 * the end of common ROMABLE_REGIONs (text and rodata) instead of
+	 * the linker script end, so it wouldn't mistakenly contain
+	 * RAMABLE_REGION in it.
+	 */
+#ifndef CONFIG_XIP
+#ifdef CONFIG_RISCV_PMP
+	SECTION_PROLOGUE(rom_mpu_padding,,)
+	{
+		MPU_ALIGN(__rodata_region_end - __rom_region_start);
+#ifdef CONFIG_QEMU_TARGET
+		/*
+		 * QEMU doesn't vet each instruction fetch individually.
+		 * Instead, it grabs a whole page and perform dynamic
+		 * translation on it in a batch. It therefore validates
+		 * PMP permissions using page-sized and -aligned chunks.
+		 */
+		. = ALIGN(0x1000);
+#endif
+	} GROUP_LINK_IN(ROMABLE_REGION)
+#endif /* CONFIG_RISCV_PMP */
+
+	__rom_region_end = .;
+	__rom_region_size = __rom_region_end - __rom_region_start;
+#endif /* CONFIG_XIP */
+    GROUP_END(ROMABLE_REGION)
+
+    GROUP_START(RAMABLE_REGION)
+
+	. = RAM_BASE;
+	_image_ram_start = .;
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-ram-sections.ld>
+
+#if defined(CONFIG_USERSPACE)
+#define APP_SHARED_ALIGN MPU_MIN_SIZE_ALIGN
+#define SMEM_PARTITION_ALIGN MPU_ALIGN
+
+#include <app_smem.ld>
+
+	_app_smem_size = _app_smem_end - _app_smem_start;
+	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
+#endif /* CONFIG_USERSPACE */
+
+    SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
+	{
+		 . = ALIGN(4);
+		/* _image_ram_start = .; */
+		 __kernel_ram_start = .;
+		 __data_region_start = .;
+		 __data_start = .;
+
+		 *(.data)
+		 *(".data.*")
+		 *(.sdata .sdata.* .gnu.linkonce.s.*)
+#if defined(CONFIG_RISCV_GP)
+		/* RISC-V architecture has 12-bit signed immediate offsets in the
+		 * instructions. If we can put the most commonly accessed globals
+		 * in a special 4K span of memory addressed by the GP register, then
+		 * we can access those values in a single instruction, saving both
+		 * codespace and runtime.
+		 *
+		 * Since these immediate offsets are signed, place gp 0x800 past the
+		 * end of .sdata so that we can use both positive and negative
+		 * offsets.
+		 */
+		 . = ALIGN(8);
+		 PROVIDE (__global_pointer$ = . + 0x800);
+#endif
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-rwdata.ld>
+
+#ifdef CONFIG_CODE_DATA_RELOCATION
+#include <linker_sram_data_relocate.ld>
+#endif
+
+		 __data_end = .;
+
+	}  GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	__data_size = __data_end - __data_start;
+	__data_load_start = LOADADDR(_DATA_SECTION_NAME);
+
+	__data_region_load_start = LOADADDR(_DATA_SECTION_NAME);
+
+#include <zephyr/linker/common-ram.ld>
+#include <zephyr/linker/kobject-data.ld>
+#include <zephyr/linker/cplusplus-ram.ld>
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
+    __data_region_end = .;
+
+    SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
+	{
+		MPU_MIN_SIZE_ALIGN
+		/*
+		 * For performance, BSS section is assumed to be 4 byte aligned and
+		 * a multiple of 4 bytes
+		 */
+		 . = ALIGN(4);
+		 __bss_start = .;
+		 *(.sbss)
+		 *(".sbss.*")
+		 *(.bss)
+		 *(".bss.*")
+		 COMMON_SYMBOLS
+
+#ifdef CONFIG_CODE_DATA_RELOCATION
+#include <linker_sram_bss_relocate.ld>
+#endif
+
+		 /*
+		  * As memory is cleared in words only, it is simpler to ensure the BSS
+		  * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
+		  */
+		  __bss_end = ALIGN(4);
+	}  GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+#include <zephyr/linker/common-noinit.ld>
+
+	__kernel_ram_end = .;
+	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
+
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_itcm), okay)
+GROUP_START(ITCM)
+
+	SECTION_PROLOGUE(_ITCM_SECTION_NAME,,SUBALIGN(8))
+	{
+		__itcm_start = .;
+		*(.itcm)
+		*(".itcm.*")
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function. */
+#include <snippets-itcm-section.ld>
+
+		__itcm_end = .;
+	} GROUP_LINK_IN(ITCM AT> ROMABLE_REGION)
+
+	__itcm_size = __itcm_end - __itcm_start;
+	__itcm_load_start = LOADADDR(_ITCM_SECTION_NAME);
+
+GROUP_END(ITCM)
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
+GROUP_START(DTCM)
+
+	SECTION_PROLOGUE(_DTCM_BSS_SECTION_NAME, (NOLOAD),SUBALIGN(8))
+	{
+		__dtcm_start = .;
+		__dtcm_bss_start = .;
+		*(.dtcm_bss)
+		*(".dtcm_bss.*")
+		__dtcm_bss_end = .;
+	} GROUP_LINK_IN(DTCM)
+
+	SECTION_PROLOGUE(_DTCM_NOINIT_SECTION_NAME, (NOLOAD),SUBALIGN(8))
+	{
+		__dtcm_noinit_start = .;
+		*(.dtcm_noinit)
+		*(".dtcm_noinit.*")
+		__dtcm_noinit_end = .;
+	} GROUP_LINK_IN(DTCM)
+
+	SECTION_PROLOGUE(_DTCM_DATA_SECTION_NAME,,SUBALIGN(8))
+	{
+		__dtcm_data_start = .;
+		*(.dtcm_data)
+		*(".dtcm_data.*")
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function. */
+#include <snippets-dtcm-section.ld>
+
+		__dtcm_data_end = .;
+	} GROUP_LINK_IN(DTCM AT> ROMABLE_REGION)
+
+	__dtcm_end = .;
+
+	__dtcm_data_load_start = LOADADDR(_DTCM_DATA_SECTION_NAME);
+
+GROUP_END(DTCM)
+#endif
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-sections.ld>
+
+#define LAST_RAM_ALIGN MPU_MIN_SIZE_ALIGN
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
+
+#include <zephyr/linker/debug-sections.ld>
+
+    /DISCARD/ : { *(.note.GNU-stack) }
+
+    SECTION_PROLOGUE(.riscv.attributes, 0,)
+	{
+	KEEP(*(.riscv.attributes))
+	KEEP(*(.gnu.attributes))
+	}
+
+/* Output section descriptions are needed for these sections to suppress
+ * warnings when "--orphan-handling=warn" is set for lld.
+ */
+#if defined(CONFIG_LLVM_USE_LLD)
+    SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+    SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+    SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+#endif
+
+    /* Sections generated from 'zephyr,memory-region' nodes */
+    LINKER_DT_SECTIONS()
+
+/* Because ROMABLE_REGION != RAMABLE_REGION in XIP-system, it is valid
+ * to set __rom_region_end symbol at the end of linker script and
+ * doesn't mistakenly contain the RAMABLE_REGION in it.
+ */
+#ifdef CONFIG_XIP
+/* Must be last in romable region */
+SECTION_PROLOGUE(.last_section,,)
+{
+  /* .last_section contains a fixed word to ensure location counter and actual
+   * rom region data usage match when CONFIG_LINKER_LAST_SECTION_ID=y. */
+  KEEP(*(.last_section))
+  /* __rom_region_size is used when configuring the PMP entry of the ROM region.
+   * Addresses (pmpaddr) in PMP registers need to be aligned to 4. Align
+   * __rom_region_size to 4 to meet that requirement. */
+  MPU_MIN_SIZE_ALIGN
+} GROUP_LINK_IN(ROMABLE_REGION)
+
+/* To provide the image size as a const expression,
+ * calculate this value here. */
+__rom_region_end = LOADADDR(.last_section) + SIZEOF(.last_section);
+__rom_region_size = __rom_region_end - __rom_region_start;
+#endif
+
+}


### PR DESCRIPTION
## Description

Add linker script and `ZERO_WAIT_TEXT` / `ZERO_WAIT_RODATA` section attribute macros for placing time-sensitive code and data in the zero-wait (first 128 KB) flash region of WCH CH32V series MCUs.

The CH32V flash controller inserts 1-2 wait states for addresses beyond the first 128 KB (0x20000). ISR handlers and performance-critical code placed in the zero-wait region avoid these wait states, fixing the UART RX data loss issue described in #90245.

## Changes

- Add `ZERO_WAIT_TEXT` / `ZERO_WAIT_RODATA` macros in `soc/wch/ch32v/common/include/zero_wait.h` (supports both C and assembly)
- Add custom linker script (`soc/wch/ch32v/common/linker.ld`) with `.zero_wait_text` and `.zero_wait_rodata` output sections placed at the start of ROM
- Switch `SOC_LINKER_SCRIPT` from the generic RISC-V linker to the new custom linker

## Usage

```c
#include <soc/zero_wait.h>

/* Place ISR handler in zero-wait flash for minimum latency */
ZERO_WAIT_TEXT void usart1_irq_handler(const void *arg)
{
    /* ... */
}

/* Place lookup table in zero-wait flash */
ZERO_WAIT_RODATA static const uint8_t crc_table[256] = { ... };
```

## Testing

- Verified on mj_e1s2_l (CH32V208) board
- UART RX data loss with high baud rates is resolved when handler is placed in zero-wait flash

Fixes #90245

---

## AI Disclosure

This pull request was prepared with the assistance of an AI coding assistant (WorkBuddy). The AI assisted with:/n- Generating the linker script based on the existing RISC-V generic linker
- Formatting the commit message and pull request description

All code changes were reviewed by the contributor (Colt Ma) before submission.