### PR TITLE
cmake: sca: fix Unix Makefiles generator byproduct dependency

### DIFF
--- a/cmake/sca/clang/sca.cmake
+++ b/cmake/sca/clang/sca.cmake
@@ -23,20 +23,14 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(output_dir ${CMAKE_BINARY_DIR}/sca/clang)
 file(MAKE_DIRECTORY ${output_dir})
 
-# Use a dummy file to let clang static analyzer know we can start analyzing
-set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
-  ${CMAKE_COMMAND} -E touch ${output_dir}/clang-sca.ready)
-set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
-  ${output_dir}/clang-sca.ready)
-
 # Add a cmake target to run the analyzer after the build is done
 add_custom_target(clang-sca ALL
   COMMAND ${CLANG_SCA_EXE} --cdb ${CMAKE_BINARY_DIR}/compile_commands.json -o ${CMAKE_BINARY_DIR}/sca/clang/ --analyze-headers --use-analyzer ${LLVM_TOOLCHAIN_PATH}/bin/clang ${CLANG_SCA_EXTRA_OPTS}
-  DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json ${output_dir}/clang-sca.ready
+  DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
 )
 
-# Cleanup dummy file
-add_custom_command(
-  TARGET clang-sca POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E rm ${output_dir}/clang-sca.ready
-)
+# Add a dependency on the final zephyr ELF target so the analyzer runs only
+# after the build is complete. logical_target_for_zephyr_elf is not yet
+# defined when this file is included, so defer the call until the end of
+# the top-level CMakeLists.txt scope.
+cmake_language(DEFER CALL add_dependencies clang-sca ${logical_target_for_zephyr_elf})

--- a/cmake/sca/codechecker/sca.cmake
+++ b/cmake/sca/codechecker/sca.cmake
@@ -70,12 +70,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(output_dir ${CMAKE_BINARY_DIR}/sca/codechecker)
 file(MAKE_DIRECTORY ${output_dir})
 
-# Use a dummy file to let CodeChecker know we can start analyzing
-set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
-  ${CMAKE_COMMAND} -E touch ${output_dir}/codechecker.ready)
-set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
-  ${output_dir}/codechecker.ready)
-
 add_custom_target(codechecker ALL
   COMMAND ${CODECHECKER_EXE} analyze
     --keep-gcc-include-fixed
@@ -90,18 +84,17 @@ add_custom_target(codechecker ALL
     || ${CMAKE_COMMAND} -E true # allow to continue processing results
   DEPENDS
     ${CMAKE_BINARY_DIR}/compile_commands.json
-    ${output_dir}/codechecker.ready
     ${CPPCHECK_CC_HEADER}
   VERBATIM
   USES_TERMINAL
   COMMAND_EXPAND_LISTS
 )
 
-# Cleanup dummy file
-add_custom_command(
-  TARGET codechecker POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E rm ${output_dir}/codechecker.ready
-)
+# Add a dependency on the final zephyr ELF target so CodeChecker runs only
+# after the build is complete. logical_target_for_zephyr_elf is not yet
+# defined when this file is included, so defer the call until the end of
+# the top-level CMakeLists.txt scope.
+cmake_language(DEFER CALL add_dependencies codechecker ${logical_target_for_zephyr_elf})
 
 if(CODECHECKER_CLEANUP)
   add_custom_target(codechecker-cleanup ALL


### PR DESCRIPTION
With the Unix Makefiles generator, BYPRODUCTS declared in
add_custom_command(TARGET ... POST_BUILD ...) are not registered as
Make rules. The clang and codechecker SCA targets depended on sentinel
files (clang-sca.ready, codechecker.ready) that were byproducts of the
zephyr ELF POST_BUILD step, causing:

  No rule to make target 'sca/clang/clang-sca.ready'

Replace the sentinel file mechanism with cmake_language(DEFER CALL ...)
to add a direct add_dependencies() on logical_target_for_zephyr_elf
after it is defined. This works correctly with both the Ninja and Unix
Makefiles generators and preserves the same ordering guarantee: SCA
analysis runs only after the full ELF build completes.

Fixes #104755