### PR TITLE
i2c: stm32: check if configs are defined

### DIFF
--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -58,7 +58,7 @@ int i2c_stm32_get_config(const struct device *dev, uint32_t *config)
 
 	*config = data->dev_config;
 
-#if CONFIG_I2C_STM32_V2_TIMING
+#if defined(CONFIG_I2C_STM32_V2_TIMING)
 	/* Print the timing parameter of device data */
 	LOG_INF("I2C timing value, report to the DTS :");
 
@@ -229,7 +229,7 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 	return ret;
 }
 
-#if CONFIG_I2C_STM32_BUS_RECOVERY
+#if defined(CONFIG_I2C_STM32_BUS_RECOVERY)
 static void i2c_stm32_bitbang_set_scl(void *io_context, int state)
 {
 	const struct i2c_stm32_config *config = io_context;
@@ -330,7 +330,7 @@ static DEVICE_API(i2c, api_funcs) = {
 	.configure = i2c_stm32_runtime_configure,
 	.transfer = i2c_stm32_transfer,
 	.get_config = i2c_stm32_get_config,
-#if CONFIG_I2C_STM32_BUS_RECOVERY
+#if defined(CONFIG_I2C_STM32_BUS_RECOVERY)
 	.recover_bus = i2c_stm32_recover_bus,
 #endif /* CONFIG_I2C_STM32_BUS_RECOVERY */
 #if defined(CONFIG_I2C_TARGET)


### PR DESCRIPTION
check Kconfigs with ``#if defined``.