### PR TITLE
Bluetooth: ASCS: Use is_valid_num_ases for is_valid_stop_len

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -2825,8 +2825,6 @@ static bool is_valid_stop_len(struct bt_conn *conn, struct net_buf_simple *buf)
 	const struct bt_ascs_stop_op *op;
 	struct net_buf_simple_state state;
 
-	ARG_UNUSED(conn);
-
 	net_buf_simple_save(buf, &state);
 
 	if (buf->len < sizeof(*op)) {
@@ -2835,8 +2833,7 @@ static bool is_valid_stop_len(struct bt_conn *conn, struct net_buf_simple *buf)
 	}
 
 	op = net_buf_simple_pull_mem(buf, sizeof(*op));
-	if (op->num_ases < 1U) {
-		LOG_WRN("Number_of_ASEs parameter value is less than 1");
+	if (!is_valid_num_ases(conn, op->num_ases)) {
 		return false;
 	}
 


### PR DESCRIPTION
Instead of just checking the lower limit, use
is_valid_num_ases to also test the upper limit.
This approach is used by all other control point operations.