### PR TITLE
drivers: esp32: align with updated hal_espressif hal apis

### DIFF
--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -383,7 +383,7 @@ static int adc_esp32_init(const struct device *dev)
 	sar_periph_ctrl_adc_oneshot_power_acquire();
 #endif /* CONFIG_ADC_ESP32_DMA */
 
-	for (uint8_t i = 0; i < SOC_ADC_MAX_CHANNEL_NUM; i++) {
+	for (uint8_t i = 0; i < ADC_LL_MAX_CHANNEL_NUM; i++) {
 		data->resolution[i] = ADC_RESOLUTION_MAX;
 		data->attenuation[i] = ADC_ATTEN_DB_0;
 		data->cal_handle[i] = NULL;

--- a/drivers/adc/adc_esp32.h
+++ b/drivers/adc/adc_esp32.h
@@ -29,9 +29,9 @@ struct adc_esp32_conf {
 
 struct adc_esp32_data {
 	adc_oneshot_hal_ctx_t hal;
-	adc_atten_t attenuation[SOC_ADC_MAX_CHANNEL_NUM];
-	uint8_t resolution[SOC_ADC_MAX_CHANNEL_NUM];
-	adc_cali_handle_t cal_handle[SOC_ADC_MAX_CHANNEL_NUM];
+	adc_atten_t attenuation[ADC_LL_MAX_CHANNEL_NUM];
+	uint8_t resolution[ADC_LL_MAX_CHANNEL_NUM];
+	adc_cali_handle_t cal_handle[ADC_LL_MAX_CHANNEL_NUM];
 	uint16_t meas_ref_internal;
 	uint16_t *buffer;
 #ifdef CONFIG_ADC_ESP32_DMA

--- a/drivers/adc/adc_esp32_dma.c
+++ b/drivers/adc/adc_esp32_dma.c
@@ -361,10 +361,10 @@ int adc_esp32_dma_read(const struct device *dev, const struct adc_sequence *seq)
 	int err = 0;
 	uint32_t adc_pattern_len, unit_attenuation;
 	adc_hal_digi_ctrlr_cfg_t adc_hal_digi_ctrlr_cfg;
-	adc_digi_pattern_config_t adc_digi_pattern_config[SOC_ADC_MAX_CHANNEL_NUM];
+	adc_digi_pattern_config_t adc_digi_pattern_config[ADC_LL_MAX_CHANNEL_NUM];
 
 	const struct adc_sequence_options *options = seq->options;
-	uint32_t sample_freq_hz = SOC_ADC_SAMPLE_FREQ_THRES_HIGH, number_of_samplings = 1;
+	uint32_t sample_freq_hz = ADC_LL_SAMPLE_FREQ_THRES_HIGH, number_of_samplings = 1;
 
 	if (options && options->callback) {
 		return -ENOTSUP;
@@ -372,8 +372,8 @@ int adc_esp32_dma_read(const struct device *dev, const struct adc_sequence *seq)
 
 	if (options && options->interval_us) {
 		sample_freq_hz = MHZ(1) / options->interval_us;
-		if (sample_freq_hz < SOC_ADC_SAMPLE_FREQ_THRES_LOW ||
-		    sample_freq_hz > SOC_ADC_SAMPLE_FREQ_THRES_HIGH) {
+		if (sample_freq_hz < ADC_LL_SAMPLE_FREQ_THRES_LOW ||
+		    sample_freq_hz > ADC_LL_SAMPLE_FREQ_THRES_HIGH) {
 			LOG_ERR("ADC sampling frequency out of range: %uHz", sample_freq_hz);
 			return -EINVAL;
 		}
@@ -444,7 +444,7 @@ int adc_esp32_dma_channel_setup(const struct device *dev, const struct adc_chann
 	__maybe_unused const struct adc_esp32_conf *conf =
 		(const struct adc_esp32_conf *)dev->config;
 
-	if (!SOC_ADC_DIG_SUPPORTED_UNIT(conf->unit)) {
+	if (!ADC_LL_DIG_SUPPORTED_UNIT(conf->unit)) {
 		LOG_ERR("ADC2 dma mode is no longer supported, please use ADC1!");
 		return -EINVAL;
 	}

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -8,7 +8,7 @@
 
 #include <string.h>
 #include <soc/rtc.h>
-#include <soc/wdev_reg.h>
+#include <hal/rng_ll.h>
 #include <esp_system.h>
 #include <soc.h>
 #include <esp_cpu.h>
@@ -61,7 +61,7 @@ static inline uint32_t entropy_esp32_get_u32(void)
 	for (size_t i = 0; i < sizeof(result); i++) {
 		do {
 			ccount = esp_cpu_get_cycle_count();
-			result ^= REG_READ(WDEV_RND_REG);
+			result ^= rng_ll_read_data();
 		} while (ccount - last_ccount < cpu_to_apb_freq_ratio * APB_CYCLE_WAIT_NUM);
 #if SOC_RTC_TIMER_SUPPORTED
 		uint32_t current_rtc_timer_counter = (rtc_timer_hal_get_cycle_count(0) & 0xFF);
@@ -70,7 +70,7 @@ static inline uint32_t entropy_esp32_get_u32(void)
 #endif
 	}
 	last_ccount = ccount;
-	return result ^ REG_READ(WDEV_RND_REG);
+	return result ^ rng_ll_read_data();
 }
 
 static int entropy_esp32_get_entropy(const struct device *dev, uint8_t *buf,
@@ -102,6 +102,8 @@ static int entropy_esp32_init(const struct device *dev)
 	}
 
 	clock_control_on(clock_dev, clock_subsys);
+
+	rng_ll_enable();
 
 	return 0;
 }

--- a/drivers/ethernet/mdio/mdio_esp32.c
+++ b/drivers/ethernet/mdio/mdio_esp32.c
@@ -20,7 +20,8 @@
 #include <soc/rtc.h>
 #include <soc/gpio_periph.h>
 #include <soc/io_mux_reg.h>
-#include <clk_ctrl_os.h>
+#include <esp_clk_tree.h>
+#include <esp_private/esp_clk_tree_common.h>
 
 #include "../eth_esp32_priv.h"
 
@@ -98,15 +99,11 @@ static int emac_config_apll_clock(void)
 {
 	uint32_t expt_freq = MHZ(50);
 	uint32_t real_freq = 0;
-	esp_err_t ret = periph_rtc_apll_freq_set(expt_freq, &real_freq);
+	esp_err_t ret = esp_clk_tree_src_set_freq_hz(SOC_MOD_CLK_APLL, expt_freq, &real_freq);
 
 	if (ret == ESP_ERR_INVALID_ARG) {
 		LOG_ERR("Set APLL clock coefficients failed");
 		return -EIO;
-	}
-
-	if (ret == ESP_ERR_INVALID_STATE) {
-		LOG_INF("APLL is occupied already, it is working at %d Hz", real_freq);
 	}
 
 	/* If the difference of real APLL frequency
@@ -187,7 +184,7 @@ static int mdio_esp32_initialize(const struct device *dev)
 	}
 
 	emac_hal_clock_enable_rmii_output(&dev_data->hal);
-	periph_rtc_apll_acquire();
+	esp_clk_tree_enable_src(SOC_MOD_CLK_APLL, true);
 	res = emac_config_apll_clock();
 	if (res != 0) {
 		goto err;

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -13,7 +13,8 @@
 #include <hal/i2c_ll.h>
 #include <hal/i2c_hal.h>
 #include <hal/gpio_hal.h>
-#include <clk_ctrl_os.h>
+#include <esp_clk_tree.h>
+#include <esp_private/esp_clk_tree_common.h>
 
 #include <soc.h>
 #include <errno.h>
@@ -135,8 +136,10 @@ static uint32_t i2c_get_src_clk_freq(i2c_clock_source_t clk_src)
 #endif
 #if SOC_I2C_SUPPORT_RTC
 	case I2C_CLK_SRC_RC_FAST:
-		periph_rtc_dig_clk8m_enable();
-		periph_src_clk_hz = periph_rtc_dig_clk8m_get_freq();
+		esp_clk_tree_enable_src(SOC_MOD_CLK_RC_FAST, true);
+		esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_RC_FAST,
+					     ESP_CLK_TREE_SRC_FREQ_PRECISION_APPROX,
+					     &periph_src_clk_hz);
 		break;
 #endif
 #if SOC_I2C_SUPPORT_REF_TICK

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -11,8 +11,8 @@
 #include <hal/ledc_ll.h>
 #include <hal/ledc_types.h>
 #include <esp_clk_tree.h>
+#include <esp_private/esp_clk_tree_common.h>
 #include <soc/rtc.h>
-#include <clk_ctrl_os.h>
 
 #include <soc.h>
 #include <errno.h>
@@ -170,16 +170,16 @@ static int pwm_led_esp32_timer_config(struct pwm_ledc_esp32_channel_config *chan
 	 */
 	for (int i = 0; i < clock_src_num; i++) {
 		if (clock_src[i] == LEDC_SLOW_CLK_RC_FAST) {
-			uint32_t rc_fast_freq = periph_rtc_dig_clk8m_get_freq();
+			uint32_t rc_fast_freq = 0;
 
-			if (!rtc_dig_8m_enabled() || rc_fast_freq == 0) {
-				/* RC_FAST requires enabling and calibrating */
-				if (!periph_rtc_dig_clk8m_enable()) {
-					/* skip RC_FAST as clock source */
-					continue;
-				}
-				rc_fast_freq = periph_rtc_dig_clk8m_get_freq();
+			/* RC_FAST requires enabling and calibrating */
+			if (esp_clk_tree_enable_src(SOC_MOD_CLK_RC_FAST, true) != ESP_OK) {
+				/* skip RC_FAST as clock source */
+				continue;
 			}
+			esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_RC_FAST,
+						     ESP_CLK_TREE_SRC_FREQ_PRECISION_APPROX,
+						     &rc_fast_freq);
 
 			channel->clock_src = clock_src[i];
 			channel->clock_src_hz = rc_fast_freq;

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -447,6 +447,7 @@ SECTIONS
     *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:sleep_cache.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
     *libzephyr.a:periph_ctrl.*(.literal .text .literal.* .text.*)
     *libzephyr.a:regi2c_ctrl.*(.literal .text .literal.* .text.*)

--- a/soc/espressif/esp32c2/default.ld
+++ b/soc/espressif/esp32c2/default.ld
@@ -300,6 +300,7 @@ SECTIONS
     *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:sleep_cache.*(.literal .literal.* .text .text.*)
     *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
     *(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
 

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -398,6 +398,7 @@ SECTIONS
     *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:sleep_cache.*(.literal .literal.* .text .text.*)
     *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
 #if defined(CONFIG_ESP32_PM_SLP_IRAM_OPT)
     *libzephyr.a:sleep_console.*(.literal .literal.* .text .text.*)

--- a/soc/espressif/esp32c5/default.ld
+++ b/soc/espressif/esp32c5/default.ld
@@ -438,6 +438,7 @@ SECTIONS
     *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:sleep_cache.*(.literal .literal.* .text .text.*)
     *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
     *(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
 

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -420,6 +420,7 @@ SECTIONS
     *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:sleep_cache.*(.literal .literal.* .text .text.*)
     *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
     *(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
 

--- a/soc/espressif/esp32h2/default.ld
+++ b/soc/espressif/esp32h2/default.ld
@@ -415,6 +415,7 @@ SECTIONS
     *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:sleep_cache.*(.literal .literal.* .text .text.*)
     *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
     *(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
 

--- a/soc/espressif/esp32p4/Kconfig.defconfig
+++ b/soc/espressif/esp32p4/Kconfig.defconfig
@@ -7,7 +7,8 @@ config FPU
 	default y
 
 config NUM_IRQS
-	default 32
+	# 32 CPU interrupt lines plus RISCV_RESERVED_IRQ_ISR_TABLES_OFFSET.
+	default 48
 
 config RISCV_MCAUSE_EXCEPTION_MASK
 	default 0xFFF

--- a/soc/espressif/esp32p4/default.ld
+++ b/soc/espressif/esp32p4/default.ld
@@ -435,6 +435,7 @@ SECTIONS
     *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:sleep_cache.*(.literal .literal.* .text .text.*)
     *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
     *(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
 

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -449,6 +449,7 @@ SECTIONS
     *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_clk_init.*(.literal .text .literal.* .text.*)
     *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:sleep_cache.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
     *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
     *libzephyr.a:periph_ctrl.*(.literal .text .literal.* .text.*)

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -464,6 +464,7 @@ SECTIONS
     *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_clk_init.*(.literal .text .literal.* .text.*)
     *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:sleep_cache.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
     *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
 #if defined(CONFIG_ESP32_PM_SLP_IRAM_OPT)

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 7dcc5bd72140379403743927e868ae00c9d9028e
+      revision: f3be21f2bb27535d4ac58364018cb6491d52f5dd
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Adopt the new HAL/LL interfaces: ADC_LL_* macros,
esp_clk_tree_* clock helpers, and rng_ll_* entropy reads across the adc, i2c, pwm, mdio and entropy drivers.