### PR TITLE
net: l2: ethernet: Restore pointer cast in net_eth_get_hw_config with dsa

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -872,9 +872,9 @@ enum ethernet_hw_caps net_eth_get_hw_capabilities(struct net_if *iface)
 	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 
 	if (eth_ctx->dsa_port == DSA_CONDUIT_PORT) {
-		caps |= ETHERNET_DSA_CONDUIT_PORT;
+		caps = ETHERNET_DSA_CONDUIT_PORT;
 	} else if (eth_ctx->dsa_port == DSA_USER_PORT) {
-		caps |= ETHERNET_DSA_USER_PORT;
+		caps = ETHERNET_DSA_USER_PORT;
 	}
 #endif
 	if (api == NULL || api->get_capabilities == NULL) {


### PR DESCRIPTION
Added explicit cast when updating ethernet_hw_caps values. Implicit conversion breaks building C++ files that include ethernet.h if CONFIG_NET_DSA is defined

Error is:
`error: invalid conversion from 'int' to 'ethernet_hw_caps' [-fpermissive]`

Fix by adding explicit cast to enum type ethernet_hw_caps_values