### PR TITLE
soc: espressif: fix esp32p4 isr table size

### DIFF
--- a/soc/espressif/esp32p4/Kconfig.defconfig
+++ b/soc/espressif/esp32p4/Kconfig.defconfig
@@ -7,7 +7,8 @@ config FPU
 	default y
 
 config NUM_IRQS
-	default 32
+	# 32 CPU interrupt lines plus RISCV_RESERVED_IRQ_ISR_TABLES_OFFSET.
+	default 48
 
 config RISCV_MCAUSE_EXCEPTION_MASK
 	default 0xFFF


### PR DESCRIPTION
NUM_IRQS must account for the reserved ISR table offset so every CPU interrupt line maps into the software ISR table. Size it to the 32 CPU lines plus the offset.