### PR TITLE
drivers: otp: stm32: Use CONFIG_OTP_LOG_LEVEL in BSEC driver

### DIFF
--- a/drivers/otp/otp_bsec_stm32.c
+++ b/drivers/otp/otp_bsec_stm32.c
@@ -12,7 +12,7 @@
 
 #define DT_DRV_COMPAT st_stm32_bsec
 
-LOG_MODULE_REGISTER(otp_bsec_stm32);
+LOG_MODULE_REGISTER(otp_bsec_stm32, CONFIG_OTP_LOG_LEVEL);
 
 #define BSEC_WORD_SIZE	4
 


### PR DESCRIPTION
Use CONFIG_OTP_LOG_LEVEL in STM32 BSEC OTP driver to rely on OTP drivers generic log level instead of the default generic log level configuration.