### PR TITLE
drivers: timer: stm32: Use kernel log level for radio timer

### DIFF
--- a/drivers/timer/stm32wb0_radio_timer.c
+++ b/drivers/timer/stm32wb0_radio_timer.c
@@ -15,7 +15,7 @@
 #include "stm32wb0x_hal_radio_timer.h"
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(radio_timer_driver);
+LOG_MODULE_REGISTER(radio_timer_driver, CONFIG_KERNEL_LOG_LEVEL);
 
 /* Max HS startup time expressed in system time (1953 us / 2.4414 us) */
 #define MAX_HS_STARTUP_TIME	DT_PROP(DT_NODELABEL(radio_timer), max_hs_startup_time)


### PR DESCRIPTION
Use CONFIG_KERNEL_LOG_LEVEL in STM32 radio timer driver to rely on kernel log level instead of the default generic log level configuration.