### PR TITLE
dts: arm: st: l5: fix FDCAN1 message RAM base address

### DIFF
--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -754,7 +754,7 @@
 
 		fdcan1: can@4000a400 {
 			compatible = "st,stm32-fdcan";
-			reg = <0x4000a400 0x400>, <0x400ac000 0x350>;
+			reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
 			reg-names = "m_can", "message_ram";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
 			interrupts = <47 0>, <48 0>;


### PR DESCRIPTION
The message_ram reg entry for the stm32l5 fdcan1 node had a type-o digit (0x400ac000), placing it outside the peripheral memory map. The correct SRAMCAN base is 0x4000ac00 (APB1PERIPH_BASE + 0xAC00) per the STM32L5 reference manual and HAL, and it matches the identical fdcan nodes on the U3/U5/H5 SoCs that share the same m_can base at 0x4000a400.

The Bosch M_CAN driver derives the message RAM address from this reg entry and zeroes the region during init (can_mcan_sys_clear_mram), so the wrong address triggers a fault before main() on any STM32L5 board with FDCAN enabled.

Fixes: 4866cfcc9da8 ("dts: arm: st: l5: update dtsi file with fdcan node")