### PR TITLE
arch: x86: add dt dep for X86_VERY_EARLY_CONSOLE

### DIFF
--- a/soc/intel/intel_ish/Kconfig.defconfig
+++ b/soc/intel/intel_ish/Kconfig.defconfig
@@ -11,9 +11,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 96000000 if APIC_TIMER_TSC && SOC_INTEL_ISH_5_4_1
 	default 100000000 if APIC_TIMER_TSC && !SOC_INTEL_ISH_5_4_1
 
-config X86_VERY_EARLY_CONSOLE
-	default n
-
 config SRAM_OFFSET
 	hex
 	default 0x0

--- a/soc/intel/lakemont/Kconfig.defconfig
+++ b/soc/intel/lakemont/Kconfig.defconfig
@@ -7,11 +7,6 @@ if SOC_LAKEMONT
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768
 
-# Can be enabled once UART is defined in board
-# configuration.
-config X86_VERY_EARLY_CONSOLE
-	default n
-
 # Target platforms are usually not PC-compatible
 # (e.g. without BIOS, ACPI, etc.).
 config X86_PC_COMPATIBLE


### PR DESCRIPTION
X86_VERY_EARLY_CONSOLE only works when
the compatible of the chosen zephyr,console is
ns16550. Add this add a dependency to the
Kconfig.

