### PR TITLE
drivers: flash_mspi_nor: fix io mode used by mspi_xip_config()

### DIFF
--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -1310,6 +1310,15 @@ static int flash_chip_init(const struct device *dev)
 				sfdp_signature, JESD216_SFDP_MAGIC);
 			return -ENODEV;
 		}
+
+		/* sfdp_read() may have changed io mode, so make sure
+		 * to switch back to target io mode.
+		 */
+		rc = switch_to_target_io_mode(dev);
+		if (rc < 0) {
+			LOG_ERR("Failed to switch to target io mode: %d", rc);
+			return rc;
+		}
 	}
 
 #if defined(CONFIG_MSPI_XIP)


### PR DESCRIPTION
Switch back to target io mode after `sfdp_read()`.

If target io mode is not single, `sfdp_read()` will switch to single and leave it that way. This would cause the subsequent `mspi_xip_config()` call to be issued in the wrong io mode. This change makes sure the target io mode is switched to again after the sfdp_read().