### PR TITLE
drivers: i2c: rename i2c_is_reset_op into i2c_is_restart_op

### DIFF
--- a/drivers/i2c/i2c_bcm2711.c
+++ b/drivers/i2c/i2c_bcm2711.c
@@ -108,7 +108,7 @@ static void bcm2711_i2c_segment_len(struct bcm2711_i2c_data *data, uint32_t *seg
 
 	for (uint8_t i = data->cur_msg; i < data->num_msgs; i++) {
 		*segment_len += data->msgs[i].len;
-		if (i + 1 < data->num_msgs && i2c_is_reset_op(&data->msgs[i + 1])) {
+		if (i + 1 < data->num_msgs && i2c_is_restart_op(&data->msgs[i + 1])) {
 			*last_segment = false;
 			break;
 		}
@@ -125,7 +125,7 @@ static void bcm2711_i2c_send(const struct device *dev)
 		msg = &data->msgs[data->cur_msg];
 		if (data->tx_bytes >= msg->len) {
 			if (data->cur_msg + 1 < data->num_msgs &&
-			    !i2c_is_reset_op(&data->msgs[data->cur_msg + 1])) {
+			    !i2c_is_restart_op(&data->msgs[data->cur_msg + 1])) {
 				data->cur_msg++;
 				data->tx_bytes = 0;
 				continue;
@@ -258,7 +258,7 @@ static void bcm2711_i2c_isr(const struct device *dev)
 
 		if (data->tx_bytes >= data->msgs[data->cur_msg].len) {
 			if (data->cur_msg + 1 < data->num_msgs &&
-			    i2c_is_reset_op(&data->msgs[data->cur_msg + 1])) {
+			    i2c_is_restart_op(&data->msgs[data->cur_msg + 1])) {
 				data->cur_msg++;
 				data->tx_bytes = 0;
 				bcm2711_i2c_transaction(dev, false);

--- a/drivers/i2c/i2c_common.c
+++ b/drivers/i2c/i2c_common.c
@@ -66,11 +66,11 @@ void i2c_dump_msgs_rw(const struct device *dev, const struct i2c_msg *msgs, uint
 
 		if (msg->len == 1 && dump_data) {
 			LOG_DBG("   %c %2s %1s len=01: %02x", is_read ? 'R' : 'W',
-				i2c_is_reset_op(msg) ? "Sr" : "",
+				i2c_is_restart_op(msg) ? "Sr" : "",
 				i2c_is_stop_op(msg) ? "P" : "", msg->buf[0]);
 		} else {
 			LOG_DBG("   %c %2s %1s len=%02x: ", is_read ? 'R' : 'W',
-				i2c_is_reset_op(msg) ? "Sr" : "",
+				i2c_is_restart_op(msg) ? "Sr" : "",
 				i2c_is_stop_op(msg) ? "P" : "", msg->len);
 			if (dump_data) {
 				LOG_HEXDUMP_DBG(msg->buf, msg->len, "contents:");

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -558,7 +558,7 @@ static inline bool i2c_is_stop_op(const struct i2c_msg *msg)
  * @return true if the I2C message includes a restart
  * @return false if the I2C message includes a restart
  */
-static inline bool i2c_is_reset_op(const struct i2c_msg *msg)
+static inline bool i2c_is_restart_op(const struct i2c_msg *msg)
 {
 	return (msg->flags & I2C_MSG_RESTART) == I2C_MSG_RESTART;
 }


### PR DESCRIPTION
rename i2c_is_reset_op into i2c_is_restart_op.
restart is the right name, nothing is reset there.
this function was only added after the last release, so this is not a breaking change.
was merged as part of https://github.com/zephyrproject-rtos/zephyr/pull/106753