### PR TITLE
dts: bindings: dma: stm32u5: don't include irrelevant properties

### DIFF
--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -293,7 +293,6 @@
 			interrupts = <23 0>, <24 0>, <25 0>, <26 0>;
 			dma-channels = <4>;
 			dma-requests = <94>;
-			dma-offset = <0>;
 			status = "disabled";
 		};
 
@@ -305,7 +304,6 @@
 			interrupts = <78 0>, <79 0>, <80 0>, <81 0>;
 			dma-channels = <4>;
 			dma-requests = <94>;
-			dma-offset = <0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -615,7 +615,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-channels = <8>;
 			dma-requests = <140>;
-			dma-offset = <0>;
 			status = "disabled";
 		};
 
@@ -627,7 +626,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			dma-channels = <8>;
 			dma-requests = <140>;
-			dma-offset = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1032,7 +1032,6 @@
 				      133 0 134 0 135 0 136 0 137 0 138 0 139 0 140 0>;
 			dma-channels = <16>;
 			dma-requests = <109>;
-			dma-offset = <0>;
 			status = "disabled";
 		};
 
@@ -1047,7 +1046,6 @@
 				     <145 0>, <146 0>, <147 0>, <148 0>;
 			dma-channels = <16>;
 			dma-requests = <20>;
-			dma-offset = <0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -868,7 +868,6 @@
 					      92 0 93 0 94 0 95 0 96 0 97 0 98 0 99 0>;
 				dma-channels = <16>;
 				dma-requests = <144>;
-				dma-offset = <0>;
 				status = "disabled";
 			};
 

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -416,7 +416,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-channels = <12>;
 			dma-requests = <114>;
-			dma-offset = <0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -949,7 +949,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-channels = <16>;
 			dma-requests = <114>;
-			dma-offset = <0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/wba/stm32wba23.dtsi
+++ b/dts/arm/st/wba/stm32wba23.dtsi
@@ -27,7 +27,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-channels = <8>;
 			dma-requests = <52>;
-			dma-offset = <0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/wba/stm32wba52.dtsi
+++ b/dts/arm/st/wba/stm32wba52.dtsi
@@ -94,7 +94,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-channels = <8>;
 			dma-requests = <52>;
-			dma-offset = <0>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/dma/st,stm32u5-dma.yaml
+++ b/dts/bindings/dma/st,stm32u5-dma.yaml
@@ -52,7 +52,11 @@ description: |
 
 compatible: "st,stm32u5-dma"
 
-include: st,stm32-dma.yaml
+include:
+  - name: st,stm32-dma.yaml
+    property-blocklist:
+      - st,mem2mem
+      - dma-offset
 
 properties:
   "#dma-cells":


### PR DESCRIPTION
When including the `st,stm32-dma.yaml` binding, filter out properties that are only relevant for dma-v1 / dma-v2. Also update all DTSI files that contained properties which no longer exist in `st,stm32u5-dma`.

The only places where the `dma-offset` property is consumed are:
https://github.com/zephyrproject-rtos/zephyr/blob/c9a40340e8e3b94d6660beb98f4d9a858cfd937e/drivers/dma/dma_stm32.c#L732
https://github.com/zephyrproject-rtos/zephyr/blob/c9a40340e8e3b94d6660beb98f4d9a858cfd937e/drivers/dma/dma_stm32_bdma.c#L857
https://github.com/zephyrproject-rtos/zephyr/blob/c9a40340e8e3b94d6660beb98f4d9a858cfd937e/drivers/dma/dmamux_stm32.c#L306-L318

Note that since the `st,stm32-dma` compatible is never used, it would be wiser to simply move all these properties to the relevant bindings and delete the base `st,stm32-dma` binding instead (no need for a common file - once you get rid of the device-specific properties, there isn't much left to share). However, this is a larger effort and needs careful consideration so it is left as a future task.