### PR TITLE
[Backport v4.4-branch] xtensa: ptables: fix dangling memory domains

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -1379,6 +1379,8 @@ int arch_mem_domain_deinit(struct k_mem_domain *domain)
 
 	domain->arch.ptables = NULL;
 
+	sys_slist_find_and_remove(&xtensa_domain_list, &domain->arch.node);
+
 	k_spin_unlock(&xtensa_mmu_lock, key);
 
 	K_SPINLOCK(&xtensa_counter_lock) {


### PR DESCRIPTION
Backport of the fix from #106923 to `v4.4-branch`.

Fixes: #110757