### PR TITLE
drivers: dma: dmamux_stm32: dispatch operations using the DMA API

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -279,9 +279,9 @@ static int dma_stm32_disable_stream(DMA_TypeDef *dma, uint32_t id)
 	return 0;
 }
 
-DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
-					     uint32_t id,
-					     struct dma_config *config)
+static int dma_stm32_configure(const struct device *dev,
+			       uint32_t id,
+			       struct dma_config *config)
 {
 	const struct dma_stm32_config *dev_config = dev->config;
 	DMA_TypeDef *dma = (DMA_TypeDef *)dev_config->base;
@@ -536,9 +536,9 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	return ret;
 }
 
-DMA_STM32_EXPORT_API int dma_stm32_reload(const struct device *dev, uint32_t id,
-					  uint32_t src, uint32_t dst,
-					  size_t size)
+static int dma_stm32_reload(const struct device *dev, uint32_t id,
+			    uint32_t src, uint32_t dst,
+			    size_t size)
 {
 	const struct dma_stm32_config *config = dev->config;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
@@ -587,7 +587,7 @@ DMA_STM32_EXPORT_API int dma_stm32_reload(const struct device *dev, uint32_t id,
 	return 0;
 }
 
-DMA_STM32_EXPORT_API int dma_stm32_start(const struct device *dev, uint32_t id)
+static int dma_stm32_start(const struct device *dev, uint32_t id)
 {
 	const struct dma_stm32_config *config = dev->config;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
@@ -616,7 +616,7 @@ DMA_STM32_EXPORT_API int dma_stm32_start(const struct device *dev, uint32_t id)
 	return 0;
 }
 
-DMA_STM32_EXPORT_API int dma_stm32_stop(const struct device *dev, uint32_t id)
+static int dma_stm32_stop(const struct device *dev, uint32_t id)
 {
 	const struct dma_stm32_config *config = dev->config;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
@@ -687,7 +687,7 @@ static int dma_stm32_init(const struct device *dev)
 	return 0;
 }
 
-DMA_STM32_EXPORT_API int dma_stm32_get_status(const struct device *dev,
+static int dma_stm32_get_status(const struct device *dev,
 				uint32_t id, struct dma_status *stat)
 {
 	const struct dma_stm32_config *config = dev->config;

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -106,19 +106,4 @@ uint32_t stm32_dma_get_mburst(struct dma_config *config, bool source_periph);
 uint32_t stm32_dma_get_pburst(struct dma_config *config, bool source_periph);
 #endif
 
-#ifdef CONFIG_DMAMUX_STM32
-/* dma_stm32_ api functions are exported to the dmamux_stm32 */
-#define DMA_STM32_EXPORT_API
-int dma_stm32_configure(const struct device *dev, uint32_t id,
-				struct dma_config *config);
-int dma_stm32_reload(const struct device *dev, uint32_t id,
-			uint32_t src, uint32_t dst, size_t size);
-int dma_stm32_start(const struct device *dev, uint32_t id);
-int dma_stm32_stop(const struct device *dev, uint32_t id);
-int dma_stm32_get_status(const struct device *dev, uint32_t id,
-				struct dma_status *stat);
-#else
-#define DMA_STM32_EXPORT_API static
-#endif /* CONFIG_DMAMUX_STM32 */
-
 #endif /* DMA_STM32_H_*/

--- a/drivers/dma/dma_stm32_bdma.c
+++ b/drivers/dma/dma_stm32_bdma.c
@@ -477,9 +477,9 @@ static bool bdma_stm32_is_valid_memory_address(const uint32_t address, const uin
 }
 
 
-BDMA_STM32_EXPORT_API int bdma_stm32_configure(const struct device *dev,
-					     uint32_t id,
-					     struct dma_config *config)
+static int bdma_stm32_configure(const struct device *dev,
+				uint32_t id,
+				struct dma_config *config)
 {
 	const struct bdma_stm32_config *dev_config = dev->config;
 	struct bdma_stm32_channel *channel =
@@ -674,9 +674,9 @@ BDMA_STM32_EXPORT_API int bdma_stm32_configure(const struct device *dev,
 	return ret;
 }
 
-BDMA_STM32_EXPORT_API int bdma_stm32_reload(const struct device *dev, uint32_t id,
-					  uint32_t src, uint32_t dst,
-					  size_t size)
+static int bdma_stm32_reload(const struct device *dev, uint32_t id,
+			     uint32_t src, uint32_t dst,
+			     size_t size)
 {
 	const struct bdma_stm32_config *config = dev->config;
 	BDMA_TypeDef *bdma = (BDMA_TypeDef *)(config->base);
@@ -722,7 +722,7 @@ BDMA_STM32_EXPORT_API int bdma_stm32_reload(const struct device *dev, uint32_t i
 	return 0;
 }
 
-BDMA_STM32_EXPORT_API int bdma_stm32_start(const struct device *dev, uint32_t id)
+static int bdma_stm32_start(const struct device *dev, uint32_t id)
 {
 	const struct bdma_stm32_config *config = dev->config;
 	BDMA_TypeDef *bdma = (BDMA_TypeDef *)(config->base);
@@ -748,7 +748,7 @@ BDMA_STM32_EXPORT_API int bdma_stm32_start(const struct device *dev, uint32_t id
 	return 0;
 }
 
-BDMA_STM32_EXPORT_API int bdma_stm32_stop(const struct device *dev, uint32_t id)
+static int bdma_stm32_stop(const struct device *dev, uint32_t id)
 {
 	const struct bdma_stm32_config *config = dev->config;
 	struct bdma_stm32_channel *channel = &config->channels[id];
@@ -825,7 +825,7 @@ static int bdma_stm32_init(const struct device *dev)
 	return 0;
 }
 
-BDMA_STM32_EXPORT_API int bdma_stm32_get_status(const struct device *dev,
+static int bdma_stm32_get_status(const struct device *dev,
 				uint32_t id, struct dma_status *stat)
 {
 	const struct bdma_stm32_config *config = dev->config;

--- a/drivers/dma/dma_stm32_bdma.h
+++ b/drivers/dma/dma_stm32_bdma.h
@@ -73,19 +73,4 @@ bool stm32_bdma_is_irq_happened(BDMA_TypeDef *dma, uint32_t id);
 void stm32_bdma_enable_channel(BDMA_TypeDef *dma, uint32_t id);
 int stm32_bdma_disable_channel(BDMA_TypeDef *dma, uint32_t id);
 
-#ifdef CONFIG_DMAMUX_STM32
-/* bdma_stm32_ api functions are exported to the bdmamux_stm32 */
-#define BDMA_STM32_EXPORT_API
-int bdma_stm32_configure(const struct device *dev, uint32_t id,
-				struct dma_config *config);
-int bdma_stm32_reload(const struct device *dev, uint32_t id,
-			uint32_t src, uint32_t dst, size_t size);
-int bdma_stm32_start(const struct device *dev, uint32_t id);
-int bdma_stm32_stop(const struct device *dev, uint32_t id);
-int bdma_stm32_get_status(const struct device *dev, uint32_t id,
-				struct dma_status *stat);
-#else
-#define BDMA_STM32_EXPORT_API static
-#endif /* CONFIG_DMAMUX_STM32 */
-
 #endif /* BDMA_STM32_H_*/

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -19,11 +19,6 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
-#include "dma_stm32.h"
-#ifdef CONFIG_DMA_STM32_BDMA
-#include "dma_stm32_bdma.h"
-#endif
-
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dmamux_stm32, CONFIG_DMA_LOG_LEVEL);
 
@@ -56,67 +51,13 @@ struct dmamux_stm32_config {
 	const struct dmamux_stm32_channel *mux_channels;
 };
 
-typedef int (*dma_configure_fn)(const struct device *dev, uint32_t id, struct dma_config *config);
-typedef int (*dma_start_fn)(const struct device *dev, uint32_t id);
-typedef int (*dma_stop_fn)(const struct device *dev, uint32_t id);
-typedef int (*dma_reload_fn)(const struct device *dev, uint32_t id,
-			uint32_t src, uint32_t dst, size_t size);
-typedef int (*dma_status_fn)(const struct device *dev, uint32_t id,
-				struct dma_status *stat);
-
-struct dmamux_stm32_dma_fops {
-	dma_configure_fn configure;
-	dma_start_fn start;
-	dma_stop_fn stop;
-	dma_reload_fn reload;
-	dma_status_fn get_status;
-};
-
-#if (defined(CONFIG_DMA_STM32_V1) || defined(CONFIG_DMA_STM32_V2)) && \
-	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dmamux1))
-static const struct dmamux_stm32_dma_fops dmamux1 = {
-	dma_stm32_configure,
-	dma_stm32_start,
-	dma_stm32_stop,
-	dma_stm32_reload,
-	dma_stm32_get_status,
-};
-#endif
-
-#if defined(CONFIG_DMA_STM32_BDMA) && DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dmamux2))
-static const struct dmamux_stm32_dma_fops dmamux2 = {
-	bdma_stm32_configure,
-	bdma_stm32_start,
-	bdma_stm32_stop,
-	bdma_stm32_reload,
-	bdma_stm32_get_status
-};
-#endif /* CONFIG_DMA_STM32_BDMA */
-
-const struct dmamux_stm32_dma_fops *get_dma_fops(const struct dmamux_stm32_config *dev_config)
-{
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dmamux1))
-	if (dev_config->base == DT_REG_ADDR(DT_NODELABEL(dmamux1))) {
-		return &dmamux1;
-	}
-#endif /* DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dmamux1)) */
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dmamux2))
-	if (dev_config->base == DT_REG_ADDR(DT_NODELABEL(dmamux2))) {
-		return &dmamux2;
-	}
-#endif /* DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dmamux2)) */
-
-	__ASSERT(false, "Unknown dma base address %x", dev_config->base);
-	return (void *)0;
-}
-
 int dmamux_stm32_configure(const struct device *dev, uint32_t id,
 				struct dma_config *config)
 {
 	/* device is the dmamux, id is the dmamux channel from 0 */
 	const struct dmamux_stm32_config *dev_config = dev->config;
-	const struct dmamux_stm32_dma_fops *dma_device = get_dma_fops(dev_config);
+	const struct device *dmac;
+	uint32_t dmac_channel;
 
 	/*
 	 * request line ID for this mux channel is stored
@@ -135,6 +76,9 @@ int dmamux_stm32_configure(const struct device *dev, uint32_t id,
 		return -EINVAL;
 	}
 
+	dmac = dev_config->mux_channels[id].dev_dma;
+	dmac_channel = dev_config->mux_channels[id].dma_id;
+
 	/*
 	 * Also configures the corresponding dma channel
 	 * instance is given by the dev_dma
@@ -146,8 +90,7 @@ int dmamux_stm32_configure(const struct device *dev, uint32_t id,
 	 * This dmamux channel 'id' is now used for this peripheral request
 	 * It gives this mux request ID to the dma through the config.dma_slot
 	 */
-	if (dma_device->configure(dev_config->mux_channels[id].dev_dma,
-			dev_config->mux_channels[id].dma_id, config) != 0) {
+	if (dma_config(dmac, dmac_channel, config) != 0) {
 		LOG_ERR("cannot configure the dmamux.");
 		return -EINVAL;
 	}
@@ -165,7 +108,8 @@ int dmamux_stm32_configure(const struct device *dev, uint32_t id,
 int dmamux_stm32_start(const struct device *dev, uint32_t id)
 {
 	const struct dmamux_stm32_config *dev_config = dev->config;
-	const struct dmamux_stm32_dma_fops *dma_device = get_dma_fops(dev_config);
+	const struct device *dmac;
+	uint32_t dmac_channel;
 
 	/* check if this channel is valid */
 	if (id >= dev_config->channel_nb) {
@@ -173,8 +117,10 @@ int dmamux_stm32_start(const struct device *dev, uint32_t id)
 		return -EINVAL;
 	}
 
-	if (dma_device->start(dev_config->mux_channels[id].dev_dma,
-		dev_config->mux_channels[id].dma_id) != 0) {
+	dmac = dev_config->mux_channels[id].dev_dma;
+	dmac_channel = dev_config->mux_channels[id].dma_id;
+
+	if (dma_start(dmac, dmac_channel) != 0) {
 		LOG_ERR("cannot start the dmamux channel %d.", id);
 		return -EINVAL;
 	}
@@ -185,7 +131,8 @@ int dmamux_stm32_start(const struct device *dev, uint32_t id)
 int dmamux_stm32_stop(const struct device *dev, uint32_t id)
 {
 	const struct dmamux_stm32_config *dev_config = dev->config;
-	const struct dmamux_stm32_dma_fops *dma_device = get_dma_fops(dev_config);
+	const struct device *dmac;
+	uint32_t dmac_channel;
 
 	/* check if this channel is valid */
 	if (id >= dev_config->channel_nb) {
@@ -193,8 +140,10 @@ int dmamux_stm32_stop(const struct device *dev, uint32_t id)
 		return -EINVAL;
 	}
 
-	if (dma_device->stop(dev_config->mux_channels[id].dev_dma,
-		dev_config->mux_channels[id].dma_id) != 0) {
+	dmac = dev_config->mux_channels[id].dev_dma;
+	dmac_channel = dev_config->mux_channels[id].dma_id;
+
+	if (dma_stop(dmac, dmac_channel) != 0) {
 		LOG_ERR("cannot stop the dmamux channel %d.", id);
 		return -EINVAL;
 	}
@@ -206,7 +155,8 @@ int dmamux_stm32_reload(const struct device *dev, uint32_t id,
 			    uint32_t src, uint32_t dst, size_t size)
 {
 	const struct dmamux_stm32_config *dev_config = dev->config;
-	const struct dmamux_stm32_dma_fops *dma_device = get_dma_fops(dev_config);
+	const struct device *dmac;
+	uint32_t dmac_channel;
 
 	/* check if this channel is valid */
 	if (id >= dev_config->channel_nb) {
@@ -214,9 +164,10 @@ int dmamux_stm32_reload(const struct device *dev, uint32_t id,
 		return -EINVAL;
 	}
 
-	if (dma_device->reload(dev_config->mux_channels[id].dev_dma,
-		dev_config->mux_channels[id].dma_id,
-		src, dst, size) != 0) {
+	dmac = dev_config->mux_channels[id].dev_dma;
+	dmac_channel = dev_config->mux_channels[id].dma_id;
+
+	if (dma_reload(dmac, dmac_channel, src, dst, size) != 0) {
 		LOG_ERR("cannot reload the dmamux channel %d.", id);
 		return -EINVAL;
 	}
@@ -228,7 +179,8 @@ int dmamux_stm32_get_status(const struct device *dev, uint32_t id,
 				struct dma_status *stat)
 {
 	const struct dmamux_stm32_config *dev_config = dev->config;
-	const struct dmamux_stm32_dma_fops *dma_device = get_dma_fops(dev_config);
+	const struct device *dmac;
+	uint32_t dmac_channel;
 
 	/* check if this channel is valid */
 	if (id >= dev_config->channel_nb) {
@@ -236,8 +188,10 @@ int dmamux_stm32_get_status(const struct device *dev, uint32_t id,
 		return -EINVAL;
 	}
 
-	if (dma_device->get_status(dev_config->mux_channels[id].dev_dma,
-		dev_config->mux_channels[id].dma_id, stat) != 0) {
+	dmac = dev_config->mux_channels[id].dev_dma;
+	dmac_channel = dev_config->mux_channels[id].dma_id;
+
+	if (dma_get_status(dmac, dmac_channel, stat) != 0) {
 		LOG_ERR("cannot get the status of dmamux channel %d.", id);
 		return -EINVAL;
 	}


### PR DESCRIPTION
The DMAMUX driver used direct calls to functions in the drivers for the actual DMA controllers... but was doing so using a dispatch table, which was effectively a duplicate of the existing DMA API.

Use the DMA API directly and drop the handrolled dispatch table, while also cleaning up the DMA drivers which don't need to export functions anymore when the DMAMUX driver is enabled.