### PR TITLE
soc: nxp: mcxn: set wakeup delay for deep sleep

### DIFF
--- a/soc/nxp/mcx/mcxn/power.c
+++ b/soc/nxp/mcx/mcxn/power.c
@@ -52,6 +52,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		break;
 
 	case PM_STATE_SUSPEND_TO_IDLE:
+		SPC_SetLowPowerWakeUpDelay(SPC0, MCXN_WAKEUP_DELAY);
 		CMC_SetClockMode(MCXN_CMC_ADDR, kCMC_GateAllSystemClocksEnterLowPowerMode);
 		CMC_SetMAINPowerMode(MCXN_CMC_ADDR, kCMC_DeepSleepMode);
 		CMC_SetWAKEPowerMode(MCXN_CMC_ADDR, kCMC_DeepSleepMode);


### PR DESCRIPTION
Waking from PM_STATE_SUSPEND_TO_IDLE reset the SoC with a brownout (hwinfo RESET_BROWNOUT) because SPC_SetLowPowerWakeUpDelay() ran only on the STANDBY path. Call it on the SUSPEND_TO_IDLE path as well.

Fixes: https://github.com/zephyrproject-rtos/zephyr/commit/3114d7751b62aa6ccb28a9aa5a482a91512b73b4