### PR TITLE
modules: lvgl: update to latest sha1 of LVGL & update way to generate CMakeList.txt

### DIFF
--- a/modules/lvgl/CMakeLists.txt
+++ b/modules/lvgl/CMakeLists.txt
@@ -19,417 +19,46 @@ zephyr_compile_definitions(LV_CONF_INCLUDE_SIMPLE=1)
 zephyr_library_compile_definitions(_POSIX_C_SOURCE=200809L)
 zephyr_compile_definitions(LV_CONF_PATH="${CMAKE_CURRENT_SOURCE_DIR}/include/lv_conf.h")
 
+file(GLOB_RECURSE LVGL_SRC_FILES CONFIGURE_DEPENDS
+    ${LVGL_DIR}/src/*.c
+)
+
+set(LVGL_EXCLUDE_PATTERNS
+    "${LVGL_DIR}/src/osal/lv_cmsis_rtos2.c"
+    "${LVGL_DIR}/src/osal/lv_freertos.c"
+    "${LVGL_DIR}/src/osal/lv_linux.c"
+    "${LVGL_DIR}/src/osal/lv_mqx.c"
+    "${LVGL_DIR}/src/osal/lv_os_none.c"
+    "${LVGL_DIR}/src/osal/lv_pthread.c"
+    "${LVGL_DIR}/src/osal/lv_rtthread.c"
+    "${LVGL_DIR}/src/osal/lv_sdl2.c"
+    "${LVGL_DIR}/src/osal/lv_windows.c"
+
+    "${LVGL_DIR}/src/drivers/*"
+
+    # Remove libs/gltf since this leads to build warnings
+    "${LVGL_DIR}/src/libs/gltf/*"
+
+    "${LVGL_DIR}/src/stdlib/builtin/lv_mem_core_builtin.c"
+    "${LVGL_DIR}/src/stdlib/builtin/lv_sprintf_builtin.c"
+    "${LVGL_DIR}/src/stdlib/builtin/lv_string_builtin.c"
+    "${LVGL_DIR}/src/stdlib/clib/lv_mem_core_clib.c"
+
+    "${LVGL_DIR}/src/stdlib/rtthread/*"
+    "${LVGL_DIR}/src/stdlib/micropython/*"
+    "${LVGL_DIR}/src/stdlib/uefi/*"
+
+    "${LVGL_DIR}/src/debugging/test/*"
+)
+
+foreach(pattern IN LISTS LVGL_EXCLUDE_PATTERNS)
+    file(GLOB_RECURSE LVGL_EXCLUDED CONFIGURE_DEPENDS ${pattern})
+    list(REMOVE_ITEM LVGL_SRC_FILES ${LVGL_EXCLUDED})
+endforeach()
+
+zephyr_library_sources(${LVGL_SRC_FILES})
+
 zephyr_library_sources(
-
-    ${LVGL_DIR}/src/core/lv_group.c
-    ${LVGL_DIR}/src/core/lv_obj.c
-    ${LVGL_DIR}/src/core/lv_obj_class.c
-    ${LVGL_DIR}/src/core/lv_obj_draw.c
-    ${LVGL_DIR}/src/core/lv_obj_event.c
-    ${LVGL_DIR}/src/core/lv_obj_id_builtin.c
-    ${LVGL_DIR}/src/core/lv_obj_pos.c
-    ${LVGL_DIR}/src/core/lv_obj_property.c
-    ${LVGL_DIR}/src/core/lv_obj_scroll.c
-    ${LVGL_DIR}/src/core/lv_obj_style.c
-    ${LVGL_DIR}/src/core/lv_obj_style_gen.c
-    ${LVGL_DIR}/src/core/lv_obj_tree.c
-    ${LVGL_DIR}/src/core/lv_observer.c
-    ${LVGL_DIR}/src/core/lv_refr.c
-
-    ${LVGL_DIR}/src/debugging/monkey/lv_monkey.c
-    ${LVGL_DIR}/src/debugging/sysmon/lv_sysmon.c
-    ${LVGL_DIR}/src/debugging/test/lv_test_display.c
-    ${LVGL_DIR}/src/debugging/test/lv_test_fs.c
-    ${LVGL_DIR}/src/debugging/test/lv_test_helpers.c
-    ${LVGL_DIR}/src/debugging/test/lv_test_indev.c
-    ${LVGL_DIR}/src/debugging/test/lv_test_indev_gesture.c
-    ${LVGL_DIR}/src/debugging/test/lv_test_screenshot_compare.c
-    ${LVGL_DIR}/src/debugging/vg_lite_tvg/vg_lite_matrix.c
-
-    ${LVGL_DIR}/src/display/lv_display.c
-
-    ${LVGL_DIR}/src/draw/convert/lv_draw_buf_convert.c
-    ${LVGL_DIR}/src/draw/convert/helium/lv_draw_buf_convert_helium.c
-    ${LVGL_DIR}/src/draw/convert/neon/lv_draw_buf_convert_neon.c
-
-    ${LVGL_DIR}/src/draw/dma2d/lv_draw_dma2d.c
-    ${LVGL_DIR}/src/draw/dma2d/lv_draw_dma2d_fill.c
-    ${LVGL_DIR}/src/draw/dma2d/lv_draw_dma2d_img.c
-
-    ${LVGL_DIR}/src/draw/espressif/ppa/lv_draw_ppa_buf.c
-    ${LVGL_DIR}/src/draw/espressif/ppa/lv_draw_ppa.c
-    ${LVGL_DIR}/src/draw/espressif/ppa/lv_draw_ppa_fill.c
-    ${LVGL_DIR}/src/draw/espressif/ppa/lv_draw_ppa_img.c
-    ${LVGL_DIR}/src/draw/eve/lv_draw_eve_arc.c
-    ${LVGL_DIR}/src/draw/eve/lv_draw_eve.c
-    ${LVGL_DIR}/src/draw/eve/lv_draw_eve_fill.c
-    ${LVGL_DIR}/src/draw/eve/lv_draw_eve_image.c
-    ${LVGL_DIR}/src/draw/eve/lv_draw_eve_letter.c
-    ${LVGL_DIR}/src/draw/eve/lv_draw_eve_line.c
-    ${LVGL_DIR}/src/draw/eve/lv_draw_eve_ram_g.c
-    ${LVGL_DIR}/src/draw/eve/lv_draw_eve_triangle.c
-    ${LVGL_DIR}/src/draw/eve/lv_eve.c
-
-    ${LVGL_DIR}/src/draw/lv_draw_3d.c
-    ${LVGL_DIR}/src/draw/lv_draw_arc.c
-    ${LVGL_DIR}/src/draw/lv_draw_blur.c
-    ${LVGL_DIR}/src/draw/lv_draw_buf.c
-    ${LVGL_DIR}/src/draw/lv_draw.c
-    ${LVGL_DIR}/src/draw/lv_draw_image.c
-    ${LVGL_DIR}/src/draw/lv_draw_label.c
-    ${LVGL_DIR}/src/draw/lv_draw_line.c
-    ${LVGL_DIR}/src/draw/lv_draw_mask.c
-    ${LVGL_DIR}/src/draw/lv_draw_rect.c
-    ${LVGL_DIR}/src/draw/lv_draw_triangle.c
-    ${LVGL_DIR}/src/draw/lv_draw_vector.c
-    ${LVGL_DIR}/src/draw/lv_image_decoder.c
-
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_3d.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_arc.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_border.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_box_shadow.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_fill.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_grad.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_image.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_label.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_layer.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_line.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_mask_rect.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_triangle.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_draw_nanovg_vector.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_nanovg_fbo_cache.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_nanovg_image_cache.c
-    ${LVGL_DIR}/src/draw/nanovg/lv_nanovg_utils.c
-
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx_arc.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx_border.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx_layer.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx_line.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx_triangle.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx_utils.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_draw_nema_gfx_vector.c
-    ${LVGL_DIR}/src/draw/nema_gfx/lv_nema_gfx_path.c
-
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_draw_buf_g2d.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_draw_g2d.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_draw_g2d_fill.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_draw_g2d_img.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_g2d_buf_map.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_g2d_utils.c
-
-    ${LVGL_DIR}/src/draw/nxp/pxp/lv_draw_buf_pxp.c
-    ${LVGL_DIR}/src/draw/nxp/pxp/lv_draw_pxp.c
-    ${LVGL_DIR}/src/draw/nxp/pxp/lv_draw_pxp_fill.c
-    ${LVGL_DIR}/src/draw/nxp/pxp/lv_draw_pxp_img.c
-    ${LVGL_DIR}/src/draw/nxp/pxp/lv_draw_pxp_layer.c
-    ${LVGL_DIR}/src/draw/nxp/pxp/lv_pxp_cfg.c
-    ${LVGL_DIR}/src/draw/nxp/pxp/lv_pxp_osa.c
-    ${LVGL_DIR}/src/draw/nxp/pxp/lv_pxp_utils.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_draw_g2d_img.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_draw_buf_g2d.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_draw_g2d.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_draw_g2d_fill.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_draw_g2d_img.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_g2d_buf_map.c
-    ${LVGL_DIR}/src/draw/nxp/g2d/lv_g2d_utils.c
-
-    ${LVGL_DIR}/src/draw/opengles/lv_draw_opengles.c
-
-    ${LVGL_DIR}/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c
-    ${LVGL_DIR}/src/draw/renesas/dave2d/lv_draw_dave2d_border.c
-    ${LVGL_DIR}/src/draw/renesas/dave2d/lv_draw_dave2d.c
-    ${LVGL_DIR}/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c
-    ${LVGL_DIR}/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
-    ${LVGL_DIR}/src/draw/renesas/dave2d/lv_draw_dave2d_label.c
-    ${LVGL_DIR}/src/draw/renesas/dave2d/lv_draw_dave2d_line.c
-    ${LVGL_DIR}/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c
-    ${LVGL_DIR}/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c
-    ${LVGL_DIR}/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c
-
-    ${LVGL_DIR}/src/draw/snapshot/lv_snapshot.c
-
-    ${LVGL_DIR}/src/draw/sw/blend/lv_draw_sw_blend.c
-    ${LVGL_DIR}/src/draw/sw/blend/lv_draw_sw_blend_to_a8.c
-    ${LVGL_DIR}/src/draw/sw/blend/lv_draw_sw_blend_to_al88.c
-    ${LVGL_DIR}/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c
-    ${LVGL_DIR}/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888_premultiplied.c
-    ${LVGL_DIR}/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c
-    ${LVGL_DIR}/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c
-    ${LVGL_DIR}/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
-    ${LVGL_DIR}/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c
-    ${LVGL_DIR}/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c
-    ${LVGL_DIR}/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c
-    ${LVGL_DIR}/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb888.c
-    ${LVGL_DIR}/src/draw/sw/blend/riscv_v/lv_draw_sw_blend_riscv_v_to_rgb888.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_arc.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_border.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_blur.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_box_shadow.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_fill.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_grad.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_img.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_letter.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_line.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_mask.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_mask_rect.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_transform.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_triangle.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_utils.c
-    ${LVGL_DIR}/src/draw/sw/lv_draw_sw_vector.c
-
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_buf_vg_lite.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite_arc.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite_border.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite_fill.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite_img.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite_label.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite_layer.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite_line.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_draw_vg_lite_vector.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_vg_lite_bitmap_font_cache.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_vg_lite_decoder.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_vg_lite_grad.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_vg_lite_math.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_vg_lite_path.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_vg_lite_pending.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_vg_lite_stroke.c
-    ${LVGL_DIR}/src/draw/vg_lite/lv_vg_lite_utils.c
-
-    ${LVGL_DIR}/src/font/binfont_loader/lv_binfont_loader.c
-    ${LVGL_DIR}/src/font/fmt_txt/lv_font_fmt_txt.c
-    ${LVGL_DIR}/src/font/font_manager/lv_font_manager.c
-    ${LVGL_DIR}/src/font/font_manager/lv_font_manager_recycle.c
-    ${LVGL_DIR}/src/font/imgfont/lv_imgfont.c
-    ${LVGL_DIR}/src/font/lv_font.c
-    ${LVGL_DIR}/src/font/lv_font_dejavu_16_persian_hebrew.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_10.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_12.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_14_aligned.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_14.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_16.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_18.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_20.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_22.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_24.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_26.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_28.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_28_compressed.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_30.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_32.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_34.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_36.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_38.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_40.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_42.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_44.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_46.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_48.c
-    ${LVGL_DIR}/src/font/lv_font_montserrat_8.c
-    ${LVGL_DIR}/src/font/lv_font_source_han_sans_sc_14_cjk.c
-    ${LVGL_DIR}/src/font/lv_font_source_han_sans_sc_16_cjk.c
-    ${LVGL_DIR}/src/font/lv_font_unscii_16.c
-    ${LVGL_DIR}/src/font/lv_font_unscii_8.c
-
-    ${LVGL_DIR}/src/indev/lv_indev.c
-    ${LVGL_DIR}/src/indev/lv_indev_gesture.c
-    ${LVGL_DIR}/src/indev/lv_indev_scroll.c
-    ${LVGL_DIR}/src/indev/lv_gridnav.c
-
-    ${LVGL_DIR}/src/layouts/flex/lv_flex.c
-    ${LVGL_DIR}/src/layouts/grid/lv_grid.c
-    ${LVGL_DIR}/src/layouts/lv_layout.c
-
-    ${LVGL_DIR}/src/libs/barcode/code128.c
-    ${LVGL_DIR}/src/libs/barcode/lv_barcode.c
-    ${LVGL_DIR}/src/libs/bin_decoder/lv_bin_decoder.c
-    ${LVGL_DIR}/src/libs/bmp/lv_bmp.c
-    ${LVGL_DIR}/src/libs/ffmpeg/lv_ffmpeg.c
-    ${LVGL_DIR}/src/libs/freetype/lv_freetype.c
-    ${LVGL_DIR}/src/libs/freetype/lv_freetype_glyph.c
-    ${LVGL_DIR}/src/libs/freetype/lv_freetype_image.c
-    ${LVGL_DIR}/src/libs/freetype/lv_freetype_outline.c
-    ${LVGL_DIR}/src/libs/freetype/lv_ftsystem.c
-    ${LVGL_DIR}/src/libs/frogfs/src/decomp_raw.c
-    ${LVGL_DIR}/src/libs/frogfs/src/frogfs.c
-    ${LVGL_DIR}/src/libs/fsdrv/lv_fs_cbfs.c
-    ${LVGL_DIR}/src/libs/fsdrv/lv_fs_fatfs.c
-    ${LVGL_DIR}/src/libs/fsdrv/lv_fs_frogfs.c
-    ${LVGL_DIR}/src/libs/fsdrv/lv_fs_littlefs.c
-    ${LVGL_DIR}/src/libs/fsdrv/lv_fs_memfs.c
-    ${LVGL_DIR}/src/libs/fsdrv/lv_fs_posix.c
-    ${LVGL_DIR}/src/libs/fsdrv/lv_fs_stdio.c
-    ${LVGL_DIR}/src/libs/fsdrv/lv_fs_uefi.c
-    ${LVGL_DIR}/src/libs/fsdrv/lv_fs_win32.c
-    ${LVGL_DIR}/src/libs/FT800-FT813/EVE_commands.c
-    ${LVGL_DIR}/src/libs/FT800-FT813/EVE_supplemental.c
-    ${LVGL_DIR}/src/libs/gif/gif.c
-    ${LVGL_DIR}/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
-    ${LVGL_DIR}/src/libs/gltf/math/lv_3dmath.c
-    ${LVGL_DIR}/src/libs/gstreamer/lv_gstreamer.c
-    ${LVGL_DIR}/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
-    ${LVGL_DIR}/src/libs/libpng/lv_libpng.c
-    ${LVGL_DIR}/src/libs/libwebp/lv_libwebp.c
-    ${LVGL_DIR}/src/libs/lodepng/lodepng.c
-    ${LVGL_DIR}/src/libs/lodepng/lv_lodepng.c
-    ${LVGL_DIR}/src/libs/lz4/lz4.c
-    ${LVGL_DIR}/src/libs/nanovg/nanovg.c
-    ${LVGL_DIR}/src/libs/qrcode/lv_qrcode.c
-    ${LVGL_DIR}/src/libs/qrcode/qrcodegen.c
-    ${LVGL_DIR}/src/libs/rle/lv_rle.c
-    ${LVGL_DIR}/src/libs/rlottie/lv_rlottie.c
-    ${LVGL_DIR}/src/libs/svg/lv_svg.c
-    ${LVGL_DIR}/src/libs/svg/lv_svg_decoder.c
-    ${LVGL_DIR}/src/libs/svg/lv_svg_parser.c
-    ${LVGL_DIR}/src/libs/svg/lv_svg_render.c
-    ${LVGL_DIR}/src/libs/svg/lv_svg_token.c
-    ${LVGL_DIR}/src/libs/tiny_ttf/lv_tiny_ttf.c
-    ${LVGL_DIR}/src/libs/tjpgd/lv_tjpgd.c
-    ${LVGL_DIR}/src/libs/tjpgd/tjpgd.c
-    ${LVGL_DIR}/src/libs/vg_lite_driver/lv_vg_lite_hal/lv_vg_lite_hal.c
-    ${LVGL_DIR}/src/libs/vg_lite_driver/lv_vg_lite_hal/vg_lite_os.c
-    ${LVGL_DIR}/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_kernel.c
-    ${LVGL_DIR}/src/libs/vg_lite_driver/VGLite/vg_lite.c
-    ${LVGL_DIR}/src/libs/vg_lite_driver/VGLite/vg_lite_image.c
-    ${LVGL_DIR}/src/libs/vg_lite_driver/VGLite/vg_lite_matrix.c
-    ${LVGL_DIR}/src/libs/vg_lite_driver/VGLite/vg_lite_path.c
-    ${LVGL_DIR}/src/libs/vg_lite_driver/VGLite/vg_lite_stroke.c
-
-    ${LVGL_DIR}/src/lv_init.c
-
-    ${LVGL_DIR}/src/misc/cache/class/lv_cache_lru_ll.c
-    ${LVGL_DIR}/src/misc/cache/class/lv_cache_lru_rb.c
-    ${LVGL_DIR}/src/misc/cache/class/lv_cache_sc_da.c
-    ${LVGL_DIR}/src/misc/cache/instance/lv_image_cache.c
-    ${LVGL_DIR}/src/misc/cache/instance/lv_image_header_cache.c
-    ${LVGL_DIR}/src/misc/cache/lv_cache.c
-    ${LVGL_DIR}/src/misc/cache/lv_cache_entry.c
-    ${LVGL_DIR}/src/misc/lv_anim.c
-    ${LVGL_DIR}/src/misc/lv_anim_timeline.c
-    ${LVGL_DIR}/src/misc/lv_area.c
-    ${LVGL_DIR}/src/misc/lv_array.c
-    ${LVGL_DIR}/src/misc/lv_async.c
-    ${LVGL_DIR}/src/misc/lv_bidi.c
-    ${LVGL_DIR}/src/misc/lv_color.c
-    ${LVGL_DIR}/src/misc/lv_color_op.c
-    ${LVGL_DIR}/src/misc/lv_circle_buf.c
-    ${LVGL_DIR}/src/misc/lv_event.c
-    ${LVGL_DIR}/src/misc/lv_fs.c
-    ${LVGL_DIR}/src/misc/lv_grad.c
-    ${LVGL_DIR}/src/misc/lv_iter.c
-    ${LVGL_DIR}/src/misc/lv_ll.c
-    ${LVGL_DIR}/src/misc/lv_log.c
-    ${LVGL_DIR}/src/misc/lv_lru.c
-    ${LVGL_DIR}/src/misc/lv_math.c
-    ${LVGL_DIR}/src/misc/lv_matrix.c
-    ${LVGL_DIR}/src/misc/lv_palette.c
-    ${LVGL_DIR}/src/misc/lv_pending.c
-    ${LVGL_DIR}/src/misc/lv_profiler_builtin.c
-    ${LVGL_DIR}/src/misc/lv_rb.c
-    ${LVGL_DIR}/src/misc/lv_style.c
-    ${LVGL_DIR}/src/misc/lv_style_gen.c
-    ${LVGL_DIR}/src/misc/lv_templ.c
-    ${LVGL_DIR}/src/misc/lv_text_ap.c
-    ${LVGL_DIR}/src/misc/lv_text.c
-    ${LVGL_DIR}/src/misc/lv_timer.c
-    ${LVGL_DIR}/src/misc/lv_tree.c
-    ${LVGL_DIR}/src/misc/lv_utils.c
-    ${LVGL_DIR}/src/osal/lv_os.c
-
-    ${LVGL_DIR}/src/others/file_explorer/lv_file_explorer.c
-    ${LVGL_DIR}/src/others/fragment/lv_fragment.c
-    ${LVGL_DIR}/src/others/fragment/lv_fragment_manager.c
-    ${LVGL_DIR}/src/others/translation/lv_translation.c
-
-    ${LVGL_DIR}/src/stdlib/builtin/lv_tlsf.c
-    ${LVGL_DIR}/src/stdlib/clib/lv_string_clib.c
-    ${LVGL_DIR}/src/stdlib/clib/lv_sprintf_clib.c
-
-    ${LVGL_DIR}/src/stdlib/lv_mem.c
-
-    ${LVGL_DIR}/src/themes/default/lv_theme_default.c
-
-    ${LVGL_DIR}/src/themes/lv_theme.c
-    ${LVGL_DIR}/src/themes/mono/lv_theme_mono.c
-    ${LVGL_DIR}/src/themes/simple/lv_theme_simple.c
-
-    ${LVGL_DIR}/src/tick/lv_tick.c
-
-    ${LVGL_DIR}/src/widgets/3dtexture/lv_3dtexture.c
-    ${LVGL_DIR}/src/widgets/animimage/lv_animimage.c
-    ${LVGL_DIR}/src/widgets/arc/lv_arc.c
-    ${LVGL_DIR}/src/widgets/arclabel/lv_arclabel.c
-    ${LVGL_DIR}/src/widgets/bar/lv_bar.c
-    ${LVGL_DIR}/src/widgets/button/lv_button.c
-    ${LVGL_DIR}/src/widgets/buttonmatrix/lv_buttonmatrix.c
-    ${LVGL_DIR}/src/widgets/calendar/lv_calendar.c
-    ${LVGL_DIR}/src/widgets/calendar/lv_calendar_chinese.c
-    ${LVGL_DIR}/src/widgets/calendar/lv_calendar_header_arrow.c
-    ${LVGL_DIR}/src/widgets/calendar/lv_calendar_header_dropdown.c
-    ${LVGL_DIR}/src/widgets/canvas/lv_canvas.c
-    ${LVGL_DIR}/src/widgets/chart/lv_chart.c
-    ${LVGL_DIR}/src/widgets/checkbox/lv_checkbox.c
-    ${LVGL_DIR}/src/widgets/dropdown/lv_dropdown.c
-    ${LVGL_DIR}/src/widgets/imagebutton/lv_imagebutton.c
-    ${LVGL_DIR}/src/widgets/image/lv_image.c
-    ${LVGL_DIR}/src/widgets/ime/lv_ime_pinyin.c
-    ${LVGL_DIR}/src/widgets/keyboard/lv_keyboard.c
-    ${LVGL_DIR}/src/widgets/label/lv_label.c
-    ${LVGL_DIR}/src/widgets/led/lv_led.c
-    ${LVGL_DIR}/src/widgets/line/lv_line.c
-    ${LVGL_DIR}/src/widgets/list/lv_list.c
-    ${LVGL_DIR}/src/widgets/lottie/lv_lottie.c
-    ${LVGL_DIR}/src/widgets/menu/lv_menu.c
-    ${LVGL_DIR}/src/widgets/msgbox/lv_msgbox.c
-    ${LVGL_DIR}/src/widgets/objx_templ/lv_objx_templ.c
-    ${LVGL_DIR}/src/widgets/property/lv_animimage_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_arc_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_bar_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_buttonmatrix_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_chart_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_checkbox_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_dropdown_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_image_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_keyboard_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_label_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_led_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_line_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_menu_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_obj_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_roller_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_scale_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_slider_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_span_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_spinbox_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_spinner_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_style_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_switch_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_table_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_tabview_properties.c
-    ${LVGL_DIR}/src/widgets/property/lv_textarea_properties.c
-    ${LVGL_DIR}/src/widgets/roller/lv_roller.c
-    ${LVGL_DIR}/src/widgets/scale/lv_scale.c
-    ${LVGL_DIR}/src/widgets/slider/lv_slider.c
-    ${LVGL_DIR}/src/widgets/span/lv_span.c
-    ${LVGL_DIR}/src/widgets/spinbox/lv_spinbox.c
-    ${LVGL_DIR}/src/widgets/spinner/lv_spinner.c
-    ${LVGL_DIR}/src/widgets/switch/lv_switch.c
-    ${LVGL_DIR}/src/widgets/table/lv_table.c
-    ${LVGL_DIR}/src/widgets/tabview/lv_tabview.c
-    ${LVGL_DIR}/src/widgets/textarea/lv_textarea.c
-    ${LVGL_DIR}/src/widgets/tileview/lv_tileview.c
-    ${LVGL_DIR}/src/widgets/win/lv_win.c
-
     lvgl.c
     lvgl_display.c
     lvgl_display_mono.c
@@ -443,7 +72,7 @@ zephyr_library_sources(
 
 zephyr_library_sources_ifdef(CONFIG_LV_Z_USE_FILESYSTEM lvgl_fs.c)
 zephyr_library_sources_ifdef(CONFIG_LV_Z_MEM_POOL_SYS_HEAP lvgl_mem.c)
-zephyr_library_sources_ifdef(CONFIG_LV_Z_SHELL      lvgl_shell.c)
+zephyr_library_sources_ifdef(CONFIG_LV_Z_SHELL lvgl_shell.c)
 
 zephyr_library_sources(input/lvgl_common_input.c)
 zephyr_library_sources_ifdef(CONFIG_LV_Z_POINTER_INPUT input/lvgl_pointer_input.c)

--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -203,7 +203,6 @@ config LV_USE_DRAW_DAVE2D
 config LV_Z_USE_OSAL
 	bool "Use OSAL enabling parallel rendering"
 	depends on DYNAMIC_THREAD
-	select LV_USE_PRIVATE_API
 	help
 	  Use the Zephyr LVGL OSAL to enable parallel rendering
 	  pipelines.

--- a/modules/lvgl/lvgl_zephyr_osal.c
+++ b/modules/lvgl/lvgl_zephyr_osal.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/debug/cpu_load.h>
 #include <lvgl.h>
+#include <lvgl_private.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(lvgl, CONFIG_LV_Z_LOG_LEVEL);

--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       revision: fb00b383072518c918e2258b0916c996f2d4eebe
       path: modules/lib/loramac-node
     - name: lvgl
-      revision: 85aa60d18b3d5e5588d7b247abf90198f07c8a63
+      revision: bbedf2656086a93a8468a1c98168a6b36631ce9a
       path: modules/lib/gui/lvgl
     - name: mbedtls
       revision: 554163f6f7b2ec71fed9b423e81f2217a8615d29


### PR DESCRIPTION
In this PR I propose to update the CMakeList.txt to avoid having a hardcoded list of files to be compiled, but instead let CMake find all the C files and apply on the contrary an exclusion list.

On top of that, I've update the Zephyr OSAL code regarding to the private header inclusion.

At last, I propose to update the LVGL version to the latest version currently available (head of the master branch of lvgl) so that this can include several fixes or features, including DMA2D and GPU2D improvements which are needed for PRs https://github.com/zephyrproject-rtos/zephyr/pull/105970 and https://github.com/zephyrproject-rtos/zephyr/pull/103687

@faxe1008, the exlusion list provided in the CMakeFile might not be perfect, to be reviewed but at least demos app is working fine on board I have tested.