### PR TITLE
runners: esp32: auto-select serial port by build soc

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -824,6 +824,52 @@ class ZephyrBinaryRunner(abc.ABC):
                 raise ValueError('Required devicetree chosen node `zephyr,sram` is not set')
             return sram_node.regs[0].addr
 
+    @staticmethod
+    def normalize_chip(name: str) -> str:
+        '''Normalize a chip name for case- and dash-insensitive matching.'''
+        return name.lower().replace('-', '')
+
+    @staticmethod
+    def resolve_port_by_chip(detect_func, target, logger, priority_vids=None):
+        '''Probe serial ports and return the first one whose connected chip
+        matches the normalized target name.
+
+        :param detect_func: callable taking a port device path and returning
+                             the chip name reported by that port, or None if
+                             no chip could be identified. It is responsible
+                             for opening and closing the port.
+        :param target:      normalized chip name to match against.
+        :param logger:      logger for progress and diagnostics.
+        :param priority_vids: optional list of USB VIDs whose ports are
+                             probed first, to avoid resetting unrelated
+                             serial adapters.
+
+        Returns the matching port device path, or None when no match is
+        found.'''
+        try:
+            import serial.tools.list_ports
+        except ImportError as err:
+            logger.debug(f'port matching unavailable: {err}')
+            return None
+
+        priority_vids = priority_vids or []
+        ports = sorted(serial.tools.list_ports.comports(),
+                       key=lambda p: (p.vid not in priority_vids, p.device))
+
+        for info in ports:
+            port = info.device
+            try:
+                name = detect_func(port)
+            except Exception as err:
+                logger.debug(f'{port}: skipped ({err})')
+                continue
+            if name is not None and ZephyrBinaryRunner.normalize_chip(name) == target:
+                logger.info(f'Auto-selected {port} for {target}')
+                return port
+
+        logger.debug(f'no port with a {target} chip found')
+        return None
+
     def run(self, command: str, **kwargs):
         '''Runs command ('flash', 'debug', 'debugserver', 'attach').
 

--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -93,6 +93,41 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
         except FileNotFoundError:
             return 'esp32'
 
+    @staticmethod
+    def _detect_chip_name(port):
+        '''Connect to port and return the chip name esptool reports.'''
+        from esptool import detect_chip
+        esp = None
+        try:
+            esp = detect_chip(port, connect_attempts=2)
+            return esp.CHIP_NAME
+        finally:
+            if esp is not None and esp._port:
+                esp._port.close()
+
+    def _resolve_port_by_soc(self):
+        '''Probe serial ports and return the first one whose connected chip
+        matches CONFIG_SOC. Returns None to let esptool auto-detect when no
+        matching port is found.'''
+        try:
+            import esptool  # noqa: F401
+        except ImportError as err:
+            self.logger.debug(f'SoC port matching unavailable: {err}')
+            return None
+
+        # Native Espressif USB devices use VID 0x303A; probe them first.
+        ESPRESSIF_VID = 0x303A
+        port = self.resolve_port_by_chip(
+            self._detect_chip_name,
+            self.normalize_chip(self._get_soc_name()),
+            self.logger,
+            priority_vids=[ESPRESSIF_VID])
+        if port is None:
+            self.logger.warning(
+                f'No port with a {self._get_soc_name()} chip found; '
+                'falling back to esptool auto-detection')
+        return port
+
     def _append_flash_opts(self, cmd_flash):
         if self.no_progress:
             cmd_flash.append('-p')
@@ -119,6 +154,9 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
     def do_run(self, command, **kwargs):
 
         cmd_flash = ['esptool']
+
+        if self.device is None:
+            self.device = self._resolve_port_by_soc()
 
         if self.device is not None:
             cmd_flash.extend(['--port', self.device])


### PR DESCRIPTION
When no port is given, probe attached devices and flash the first one whose chip matches CONFIG_SOC.

Example when you have 4 different Espressif's board plugged and build/flash targets `esp32s3`:

```c
west flash; west espressif monitor                          
-- west flash: rebuilding
ninja: no work to do.
-- west flash: using runner esp32
runners.esp32: INFO: reset after flashing requested
Connecting....
Detecting chip type... ESP32-C3
Connecting....
Detecting chip type... ESP32-H2
Connecting....
Detecting chip type... ESP32-C5
Connecting....
Detecting chip type... ESP32-S3
runners.esp32: INFO: Auto-selected /dev/ttyUSB3 for esp32s3
runners.esp32: INFO: Flashing esp32s3 chip on /dev/ttyUSB3 (921600bps)
esptool v5.3.0
Connected to ESP32-S3 on /dev/ttyUSB3:
Chip type:          ESP32-S3 (QFN56) (revision v0.0)
Features:           Wi-Fi, BT 5 (LE), Dual Core + LP Core, 240MHz, Embedded PSRAM 4MB ()
Crystal frequency:  40MHz
MAC:                34:b4:72:70:01:3c
...
```
