### PR TITLE
net: sockets: validate ancillary element bounds

### DIFF
--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1032,6 +1032,12 @@ static int insert_pktinfo(struct net_msghdr *msg, int level, int type,
 		return -EINVAL;
 	}
 
+	/* Ensure the full element fits at the selected location, not just a header. */
+	if (cmsg_space > (size_t)((uint8_t *)msg->msg_control + msg->msg_controllen -
+				  (uint8_t *)cmsg)) {
+		return -ENOMEM;
+	}
+
 	cmsg->cmsg_len = NET_CMSG_LEN(pktinfo_len);
 	cmsg->cmsg_level = level;
 	cmsg->cmsg_type = type;


### PR DESCRIPTION
**Description**

`NET_CMSG_NXTHDR()` only guarantees that the next control message header fits in the ancillary data buffer. It does not guarantee enough remaining space for the complete aligned element and its payload.

When appending a second or later control message, `insert_pktinfo()` could therefore write beyond `msg_control`.

Check the remaining buffer space at the selected control message location before writing the element.

This addresses review feedback from:  https://github.com/zephyrproject-rtos/zephyr/pull/110668#discussion_r3371404716

The fix is required by the existing `v4.4-branch` backport PR: https://github.com/zephyrproject-rtos/zephyr/pull/110668

Fixes: #112204