### PR TITLE
net: ptp: harden PHC timestamp handling

### DIFF
--- a/subsys/net/lib/ptp/clock.c
+++ b/subsys/net/lib/ptp/clock.c
@@ -633,7 +633,12 @@ static void clock_synchronize_with_delay(uint64_t ingress, uint64_t egress,
 	uint64_t phc_now_ns;
 	uint64_t ingress_phc_delta;
 
-	ptp_clock_get(ptp_clk.phc, &current);
+	ret = ptp_clock_get(ptp_clk.phc, &current);
+	if (ret < 0) {
+		LOG_WRN("Failed to read PHC time (err %d)", ret);
+		return;
+	}
+
 	phc_now_ns = clock_ptp_time_to_ns(&current);
 	ingress_phc_delta = clock_abs_delta_u64(ingress, phc_now_ns);
 
@@ -678,7 +683,11 @@ static void clock_synchronize_with_delay(uint64_t ingress, uint64_t egress,
 			current.nanosecond,
 			clock_abs_delta_u64(ptp_clk.timestamp.t2, phc_now_ns));
 
-		ptp_clock_get(ptp_clk.phc, &current);
+		ret = ptp_clock_get(ptp_clk.phc, &current);
+		if (ret < 0) {
+			LOG_WRN("Failed to read PHC time for clock step (err %d)", ret);
+			return;
+		}
 
 		current.second = (uint64_t)(current.second - (offset / NSEC_PER_SEC));
 		dest_nsec = (int32_t)(current.nanosecond - (offset % NSEC_PER_SEC));

--- a/tests/net/ptp/clock_wakeup/src/main.c
+++ b/tests/net/ptp/clock_wakeup/src/main.c
@@ -33,6 +33,7 @@ static int fake_ptp_clock_get_calls;
 static int fake_ptp_clock_set_calls;
 static int fake_ptp_clock_rate_adjust_calls;
 static int fake_ptp_clock_get_ret;
+static int fake_ptp_clock_get_second_ret;
 static int fake_ptp_clock_set_ret;
 static int fake_ptp_clock_rate_adjust_ret;
 static double fake_ptp_clock_last_rate_ratio;
@@ -94,14 +95,18 @@ static const struct device *fake_net_eth_get_ptp_clock(struct net_if *iface)
 
 static int fake_ptp_clock_get(const struct device *dev, struct net_ptp_time *tm)
 {
+	int ret;
+
 	ARG_UNUSED(dev);
 
 	fake_ptp_clock_get_calls++;
-	if (tm) {
+	ret = fake_ptp_clock_get_calls == 2 ? fake_ptp_clock_get_second_ret
+					    : fake_ptp_clock_get_ret;
+	if (ret == 0 && tm != NULL) {
 		*tm = fake_ptp_clock_time;
 	}
 
-	return fake_ptp_clock_get_ret;
+	return ret;
 }
 
 static int fake_ptp_clock_set(const struct device *dev, struct net_ptp_time *tm)
@@ -256,6 +261,7 @@ static void reset_clock_state(void)
 	fake_ptp_clock_set_calls = 0;
 	fake_ptp_clock_rate_adjust_calls = 0;
 	fake_ptp_clock_get_ret = 0;
+	fake_ptp_clock_get_second_ret = 0;
 	fake_ptp_clock_set_ret = 0;
 	fake_ptp_clock_rate_adjust_ret = 0;
 	fake_ptp_clock_last_rate_ratio = 0.0;
@@ -472,6 +478,24 @@ ZTEST(ptp_clock_wakeup, test_synchronize_uses_phc_time_when_ingress_timestamp_ou
 	zassert_equal(ptp_clk.timestamp.t2, phc_now, "out-of-range ingress should fall back");
 }
 
+ZTEST(ptp_clock_wakeup, test_synchronize_stops_when_phc_read_fails)
+{
+	ptp_clk.phc = &fake_phc;
+	ptp_clk.current_ds.mean_delay = (ptp_timeinterval)100 << 16;
+	ptp_clk.timestamp.t1 = 1234;
+	ptp_clk.timestamp.t2 = 5678;
+	fake_ptp_clock_get_ret = -EIO;
+
+	ptp_clock_synchronize(10000, 9800, true);
+
+	zassert_equal(fake_ptp_clock_get_calls, 1, "PHC time should be sampled once");
+	zassert_equal(ptp_clk.timestamp.t1, 1234, "egress timestamp should remain unchanged");
+	zassert_equal(ptp_clk.timestamp.t2, 5678, "ingress timestamp should remain unchanged");
+	zassert_equal(fake_ptp_clock_set_calls, 0, "failed PHC read should not set the clock");
+	zassert_equal(fake_ptp_clock_rate_adjust_calls, 0,
+		      "failed PHC read should not adjust the clock");
+}
+
 ZTEST(ptp_clock_wakeup, test_synchronize_applies_pi_rate_adjustment)
 {
 	ptp_clk.phc = &fake_phc;
@@ -594,6 +618,24 @@ ZTEST(ptp_clock_wakeup, test_synchronize_hard_steps_large_offset_and_resets_dela
 	zassert_equal(ptp_clk.timestamp.t1, 0, "hard step should clear timestamps");
 	zassert_equal(fake_ptp_clock_rate_adjust_calls, 1, "hard step should reset servo rate");
 	zassert_equal(fake_ptp_clock_last_rate_ratio, 1.0, "servo reset should use nominal rate");
+}
+
+ZTEST(ptp_clock_wakeup, test_synchronize_stops_when_hard_step_phc_read_fails)
+{
+	ptp_clk.phc = &fake_phc;
+	ptp_clk.current_ds.mean_delay = (ptp_timeinterval)100 << 16;
+	fake_ptp_clock_time.second = 10;
+	fake_ptp_clock_time.nanosecond = 500;
+	fake_ptp_clock_get_second_ret = -EIO;
+
+	ptp_clock_synchronize(10ULL * NSEC_PER_SEC + 500, 8ULL * NSEC_PER_SEC, true);
+
+	zassert_equal(fake_ptp_clock_get_calls, 2, "hard step should resample PHC time");
+	zassert_equal(fake_ptp_clock_set_calls, 0, "failed PHC read should prevent hard step");
+	zassert_equal(fake_ptp_clock_rate_adjust_calls, 0,
+		      "failed hard step should not reset the servo");
+	zassert_equal(ptp_clk.current_ds.mean_delay, (ptp_timeinterval)100 << 16,
+		      "failed hard step should preserve mean delay");
 }
 
 ZTEST_SUITE(ptp_clock_wakeup, NULL, NULL, clock_wakeup_before, NULL, NULL);


### PR DESCRIPTION
Keep `rx_timestamp_valid` tied to timestamps captured by the transport.

A PHC sample taken after packet reception can still populate the fallback host timestamp, but it must not be treated as a valid RX hardware timestamp.

Also check the return value of `ptp_clock_get()` before using its output during synchronization and hard clock steps. If the PHC read fails, skip the adjustment instead of consuming uninitialized timestamp data.

This addresses review comments raised on the `v4.4-branch` backport:

- RX timestamp validity:
  https://github.com/zephyrproject-rtos/zephyr/pull/110668#discussion_r3365405224
- PHC read error handling:
  https://github.com/zephyrproject-rtos/zephyr/pull/110668#discussion_r3365405281

**Info**: The comments became outdated after the backport was reduced to a single cherry-picked socket fix, but the reported issues remain present on `main`.