### PR TITLE
drivers: counter: infineon_tcpwm: fix set_top_value HW counter reset

### DIFF
--- a/drivers/counter/counter_infineon_tcpwm.c
+++ b/drivers/counter/counter_infineon_tcpwm.c
@@ -243,25 +243,13 @@ static int ifx_tcpwm_counter_set_top_value(const struct device *dev,
 
 	struct ifx_tcpwm_counter_data *const data = dev->data;
 	const struct ifx_tcpwm_counter_config *const config = dev->config;
+	int ret = 0;
 
-	data->top_value_cfg_counter = *cfg;
-
-	/* Check new top value limit */
 	if (cfg->ticks > config->counter_info.max_top_value) {
 		return -ENOTSUP;
 	}
 
-	/* Checks if new period value is not less then old period value */
-	if (!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
-		data->value = 0u;
-	} else {
-		/* timer_configure resets timer counter register to value
-		 * defined in config structure 'data->value', so update
-		 * counter value with current value of counter (read by
-		 * Cy_TCPWM_Counter_GetCounter function).
-		 */
-		data->value = Cy_TCPWM_Counter_GetCounter(config->reg_base, config->index);
-	}
+	data->top_value_cfg_counter = *cfg;
 
 #if defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
 	Cy_TCPWM_Counter_SetPeriod(config->reg_base, config->index, cfg->ticks);
@@ -269,16 +257,32 @@ static int ifx_tcpwm_counter_set_top_value(const struct device *dev,
 	Cy_TCPWM_Block_SetPeriod(config->reg_base, config->index, cfg->ticks);
 #endif
 
-	/* Register an top_value terminal count event callback handler if
-	 * callback is not NULL.
-	 */
+	if (!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
+		data->value = 0u;
+		Cy_TCPWM_Counter_SetCounter(config->reg_base, config->index, 0u);
+	} else {
+		uint32_t current =
+			Cy_TCPWM_Counter_GetCounter(config->reg_base, config->index);
+
+		if (current >= cfg->ticks) {
+			if (cfg->flags & COUNTER_TOP_CFG_RESET_WHEN_LATE) {
+				data->value = 0u;
+				Cy_TCPWM_Counter_SetCounter(config->reg_base,
+							    config->index, 0u);
+			}
+			ret = -ETIME;
+		} else {
+			data->value = current;
+		}
+	}
+
 	if (cfg->callback != NULL) {
 		counter_enable_event(dev, COUNTER_IRQ_TERMINAL_COUNT, true);
 	} else {
 		counter_enable_event(dev, COUNTER_IRQ_TERMINAL_COUNT, false);
 	}
 
-	return 0;
+	return ret;
 }
 
 static uint32_t ifx_tcpwm_counter_get_top_value(const struct device *dev)

--- a/tests/drivers/counter/counter_basic_api/boards/cyw920829m2evk_02_common.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/cyw920829m2evk_02_common.overlay
@@ -7,16 +7,16 @@
 
 #include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
 
-&tcpwm0_0 {
+&tcpwm0_1 {
 	status = "okay";
 
-	counter0_0 {
+	counter0_1 {
 		status = "okay";
-		clocks = <&peri0_group4_16bit_0>;
+		clocks = <&peri0_group1_16bit_0>;
 	};
 };
 
-&peri0_group4_16bit_0 {
+&peri0_group1_16bit_0 {
 	status = "okay";
-	clock-div = <9600>;
+	clock-div = <9599>;
 };

--- a/tests/drivers/counter/counter_basic_api/boards/cyw920829m2evk_02_cyw20829b0lkml.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/cyw920829m2evk_02_cyw20829b0lkml.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cyw920829m2evk_02_common.overlay"

--- a/tests/drivers/counter/counter_basic_api/boards/cyw920829m2evk_02_cyw20829b1010.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/cyw920829m2evk_02_cyw20829b1010.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cyw920829m2evk_02_common.overlay"

--- a/tests/drivers/counter/counter_basic_api/boards/cyw920829m2evk_02_cyw20829b1340.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/cyw920829m2evk_02_cyw20829b1340.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cyw920829m2evk_02_common.overlay"

--- a/tests/drivers/counter/counter_basic_api/boards/kit_pse84_ai_common.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/kit_pse84_ai_common.overlay
@@ -12,11 +12,11 @@
 
 	counter0_0 {
 		status = "okay";
-		clocks = <&peri0_group4_16bit_0>;
+		clocks = <&peri0_group1_16bit_2>;
 	};
 };
 
-&peri0_group4_16bit_0 {
+&peri0_group1_16bit_2 {
 	status = "okay";
 	clock-div = <9600>;
 };

--- a/tests/drivers/counter/counter_basic_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_ai_common.overlay"

--- a/tests/drivers/counter/counter_basic_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_ai_common.overlay"

--- a/tests/drivers/counter/counter_basic_api/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/kit_pse84_eval_common.overlay
@@ -12,11 +12,11 @@
 
 	counter0_0 {
 		status = "okay";
-		clocks = <&peri0_group4_16bit_0>;
+		clocks = <&peri0_group1_16bit_2>;
 	};
 };
 
-&peri0_group4_16bit_0 {
+&peri0_group1_16bit_2 {
 	status = "okay";
 	clock-div = <9600>;
 };

--- a/tests/drivers/counter/counter_basic_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/tests/drivers/counter/counter_basic_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"


### PR DESCRIPTION
## Summary

Fix `ifx_tcpwm_counter_set_top_value()` so that it actually resets the
TCPWM hardware counter when a new top value is configured, and add the
test overlays needed to exercise this on Infineon TCPWM boards.

## Driver fix

Previously the function only updated the software cache
(`data->value`) and the TCPWM `PERIOD` register; the hardware `CNT`
register was never written. When the new top value was smaller than
the current counter value, the counter had to roll over the full
16-bit / 32-bit range before terminal count, instead of the new
period. On a 16-bit counter clocked at 10 kHz this took about 6 s,
which broke `test_set_top_value_with_alarm` in
`tests/drivers/counter/counter_basic_api`.

The patch:

- writes `0` to the HW counter via `Cy_TCPWM_Counter_SetCounter()`
  when `COUNTER_TOP_CFG_DONT_RESET` is **not** set,
- returns `-ETIME` when `DONT_RESET` is set but the current counter
  value is already past the new top (matching the counter API
  contract), and additionally resets the counter to `0` in that case
  when `COUNTER_TOP_CFG_RESET_WHEN_LATE` is set,
- reorders the write so the new period is programmed before the
  reset-vs-late comparison.

## Test overlays

`counter_basic_api` previously had no overlay for the PSE84 or
CYW20829 boards, so it never ran on the affected hardware. New
overlays are added for:

- `cyw920829m2evk_02` (b0lkml, b1010, b1340)
- `kit_pse84_ai/pse846gps2dbzc4a/m33` and `/m55`
- `kit_pse84_eval/pse846gps2dbzc4a/m33` and `/m55`

The existing `kit_psc3m5_evk` overlay is updated to use the unified
`clock-div` property and drop legacy properties
(`divider-type`/`divider-sel`/`divider-val`/`clock-frequency`/
`scb-block`/`div-value`) that are not declared by the current
`infineon,tcpwm` / `infineon,peri-div` bindings.

## Verification

`tests/drivers/counter/counter_basic_api` was run on real hardware
with the driver fix applied. All subtests pass on:

| Board | Result |
|-------|--------|
| `kit_pse84_eval/pse846gps2dbzc4a/m33` | 8 PASS, 2 SKIP |
| `kit_pse84_eval/pse846gps2dbzc4a/m55` | 8 PASS, 2 SKIP |
| `kit_pse84_ai/pse846gps2dbzc4a/m33`   | 8 PASS, 2 SKIP |
| `kit_pse84_ai/pse846gps2dbzc4a/m55`   | 8 PASS, 2 SKIP |
| `cyw920829m2evk_02/cyw20829b0lkml`    | 8 PASS, 2 SKIP |

(The two skips are the existing `test_multiple_alarms` /
`test_cancelled_alarm_does_not_expire` cases that are already gated
on driver capabilities not provided by `infineon,tcpwm-counter`.)
