### PR TITLE
boards: nxp: frdm_mcxa577: add DAC support

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -330,6 +330,13 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO_HF_to_FLEXCAN0);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dac0))
+	SPC_EnableActiveModeAnalogModules(SPC0, kSPC_controlDac0);
+	CLOCK_AttachClk(kFRO_LF_DIV_to_DAC0);
+	CLOCK_SetClockDiv(kCLOCK_DivDAC0, 1u);
+	CLOCK_EnableClock(kCLOCK_GateDAC0);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 }

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
@@ -123,4 +123,12 @@
 			input-enable;
 		};
 	};
+
+	pinmux_dac0: pinmux_dac0 {
+		group0 {
+			pinmux = <DAC0_OUT_P2_2>;
+			drive-strength = "low";
+			slew-rate = "fast";
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dts
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dts
@@ -25,3 +25,9 @@
 		zephyr,canbus = &flexcan0;
 	};
 };
+
+&dac0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_dac0>;
+	pinctrl-names = "default";
+};

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
@@ -27,4 +27,5 @@ supported:
   - netif:eth
   - edac
   - can
+  - dac
 vendor: nxp

--- a/samples/drivers/dac/boards/frdm_mcxa577.overlay
+++ b/samples/drivers/dac/boards/frdm_mcxa577.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/*
+	 * On the FRDM-MCXA577 board, DAC0 output signal port is J8-23 (P2_2).
+	 */
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};

--- a/tests/drivers/dac/dac_api/testcase.yaml
+++ b/tests/drivers/dac/dac_api/testcase.yaml
@@ -54,6 +54,7 @@ tests:
       - frdm_mcxn947/mcxn947/cpu0
       - mcx_n9xx_evk/mcxn947/cpu0
       - frdm_mcxa156
+      - frdm_mcxa577
       - lpcxpresso55s36
       - same54_xpro
       - bl652_dvk


### PR DESCRIPTION
Enable DAC driver for frdm_mcxa577.
Enables dac0 in board DTS with pinmux_dac0 (DAC0_OUT_P2_2), adds DAC0 clock init in board.c using kFRO_LF_DIV_to_DAC0, and adds frdm_mcxa577 to the dac_api dac0_channel0 test. Add board overlay for FRDM-MCXA577 to enable the DAC sample. Uses DAC0 channel 0 with 12-bit resolution via the DAC0_OUT_P2_2 pin.

tested tests/drivers/dac/dac_api/ and samples/drivers/dac