### PR TITLE
boards: microchip: pic32cm_jh01_cpro: Adds tc0 node as counter

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.dts
@@ -147,3 +147,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&tc0 {
+	compatible = "microchip,tc-g1-counter";
+	max-bit-width = <32>;
+	prescaler = <8>;
+	status = "okay";
+};

--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.yaml
@@ -11,6 +11,7 @@ flash: 512
 ram: 64
 supported:
   - clock_control
+  - counter
   - gpio
   - pinctrl
   - uart

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
@@ -224,3 +224,10 @@
 	prescaler = <64>;
 	status = "okay";
 };
+
+&tc0 {
+	compatible = "microchip,tc-g1-counter";
+	max-bit-width = <32>;
+	prescaler = <8>;
+	status = "okay";
+};

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
@@ -12,6 +12,7 @@ ram: 64
 supported:
   - adc
   - clock_control
+  - counter
   - dma
   - gpio
   - i2c

--- a/samples/drivers/counter/alarm/boards/pic32cm_jh01_cnano.overlay
+++ b/samples/drivers/counter/alarm/boards/pic32cm_jh01_cnano.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		counter = &tc0;
+	};
+};
+
+&tc0 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/pic32cm_jh01_cpro.overlay
+++ b/samples/drivers/counter/alarm/boards/pic32cm_jh01_cpro.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		counter = &tc0;
+	};
+};
+
+&tc0 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -90,6 +90,8 @@ struct counter_alarm_cfg alarm_cfg;
 #define SAMPLE_TIMER DT_INST(0, renesas_rza2m_ostm_counter)
 #elif defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG)
 #define SAMPLE_TIMER DT_ALIAS(counter)
+#elif defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH)
+#define SAMPLE_TIMER DT_ALIAS(counter)
 #elif defined(CONFIG_COUNTER_ITE_IT51XXX)
 #define SAMPLE_TIMER DT_NODELABEL(counter0)
 #else

--- a/tests/drivers/counter/counter_basic_api/boards/pic32cm_jh01_cpro_tc0.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/pic32cm_jh01_cpro_tc0.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		counter = &tc0;
+	};
+};
+
+&tc0 {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -9,6 +9,7 @@ tests:
       - nucleo_f302r8
       - sam_e54_xpro
       - pic32cx_sg41_cult
+      - pic32cm_jh01_cpro
     timeout: 600
   drivers.counter.basic_api.nrf_zli:
     tags:
@@ -109,10 +110,12 @@ tests:
     platform_allow:
       - sam_e54_xpro
       - pic32cx_sg41_cult
+      - pic32cm_jh01_cpro
     timeout: 600
     extra_args:
       - platform:sam_e54_xpro/atsame54p20a:"DTC_OVERLAY_FILE=boards/microchip/sam_e54_xpro_tc0.overlay"
       - platform:pic32cx_sg41_cult/pic32cx1025sg41128:"DTC_OVERLAY_FILE=boards/microchip/pic32cx_sg41_cult_tc0.overlay"
+      - FILE_SUFFIX=tc0
   drivers.counter.basic_api.mchp_rtc:
     tags:
       - drivers


### PR DESCRIPTION
- Adds tc0 as counter in pic32cm_jh01_cpro and pic32cm_jh01_cnano boards
- Adds support for samples
- Adds test support for the counter basic api for pic32cm_jh01_cpro