### PR TITLE
[PoC] drivers: wifi: nrf_wifi: Optional MAC configuration from devicetree

### DIFF
--- a/drivers/wifi/nrf_wifi/CMakeLists.txt
+++ b/drivers/wifi/nrf_wifi/CMakeLists.txt
@@ -13,6 +13,8 @@ zephyr_include_directories(
   inc
   # for net_sprint_ll_addr
   ${ZEPHYR_BASE}/subsys/net/ip
+  # for net_eth_mac_load
+  ${ZEPHYR_BASE}/drivers/ethernet
 )
 
 zephyr_include_directories_ifdef(CONFIG_NRF70_OFFLOADED_RAW_TX

--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -540,37 +540,6 @@ config NRF70_RPU_EXTEND_TWT_SP
 	  mechanism is not used.
 endif # NRF_WIFI_LOW_POWER
 
-config WIFI_FIXED_MAC_ADDRESS
-	string "Wi-Fi Fixed MAC address in format XX:XX:XX:XX:XX:XX"
-	help
-	  This option overrides the MAC address read from OTP. It is strictly for testing purposes only.
-
-choice WIFI_MAC_ADDRESS
-	prompt "Wi-Fi MAC address type"
-	default WIFI_FIXED_MAC_ADDRESS_ENABLED if WIFI_FIXED_MAC_ADDRESS != ""
-	default WIFI_OTP_MAC_ADDRESS
-	help
-	  Select the type of MAC address to be used by the Wi-Fi driver
-
-config WIFI_OTP_MAC_ADDRESS
-	bool "Use MAC address from OTP"
-	help
-	  This option uses the MAC address stored in the OTP memory of the nRF70.
-
-config WIFI_FIXED_MAC_ADDRESS_ENABLED
-	bool "fixed MAC address"
-	help
-	  Enable fixed MAC address
-
-config WIFI_RANDOM_MAC_ADDRESS
-	bool "Random MAC address generation at runtime"
-	depends on ENTROPY_GENERATOR
-	help
-	  This option enables random MAC address generation at runtime.
-	  The random MAC address is generated using the entropy device random generator.
-
-endchoice
-
 config NRF70_RSSI_STALE_TIMEOUT_MS
 	int "RSSI stale timeout in milliseconds"
 	default 1000

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -983,6 +983,8 @@ static const struct net_wifi_mgmt_offload wifi_offload_ops = {
 	.wifi_drv_ops = &wpa_supp_ops,
 #endif /* CONFIG_NRF70_STA_MODE */
 };
+
+static struct net_eth_mac_config mcfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
 #endif /* CONFIG_NET_L2_ETHERNET */
 
 
@@ -992,7 +994,7 @@ ETH_NET_DEVICE_DT_INST_DEFINE(0,
 		    nrf_wifi_drv_main_zep, /* init_fn */
 		    NULL, /* pm_action_cb */
 		    &rpu_drv_priv_zep.rpu_ctx_zep.vif_ctx_zep[0], /* data */
-		    NULL, /* cfg */
+		    &mcfg, /* cfg */
 		    CONFIG_WIFI_INIT_PRIORITY, /* prio */
 		    &wifi_offload_ops, /* api */
 		    CONFIG_NRF_WIFI_IFACE_MTU); /*mtu */

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -11,10 +11,6 @@
 
 #include <stdlib.h>
 
-#ifdef CONFIG_WIFI_RANDOM_MAC_ADDRESS
-#include <zephyr/random/random.h>
-#endif
-
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF70_LOG_LEVEL);
 
@@ -592,16 +588,12 @@ unlock:
 }
 #endif /* CONFIG_NRF70_STA_MODE */
 
-#ifdef CONFIG_WIFI_FIXED_MAC_ADDRESS_ENABLED
-BUILD_ASSERT(sizeof(CONFIG_WIFI_FIXED_MAC_ADDRESS) - 1 == ((WIFI_MAC_ADDR_LEN * 2) + 5),
-					"Invalid fixed MAC address length");
-#endif
-
 enum nrf_wifi_status nrf_wifi_get_mac_addr(struct nrf_wifi_vif_ctx_zep *vif_ctx_zep)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = NULL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
+	const struct net_eth_mac_config *mac_cfg = NULL;
 	int ret;
 
 	if (!vif_ctx_zep) {
@@ -624,52 +616,36 @@ enum nrf_wifi_status nrf_wifi_get_mac_addr(struct nrf_wifi_vif_ctx_zep *vif_ctx_
 	}
 
 	fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
+	mac_cfg = vif_ctx_zep->zep_dev_ctx->config;
 
-#ifdef CONFIG_WIFI_FIXED_MAC_ADDRESS_ENABLED
-	char fixed_mac_addr[WIFI_MAC_ADDR_LEN];
-
-	ret = net_bytes_from_str(fixed_mac_addr,
-			WIFI_MAC_ADDR_LEN,
-			CONFIG_WIFI_FIXED_MAC_ADDRESS);
-	if (ret < 0) {
-		LOG_ERR("%s: Failed to parse MAC address: %s",
-			__func__,
-			CONFIG_WIFI_FIXED_MAC_ADDRESS);
-		goto unlock;
-	}
-
-	memcpy(vif_ctx_zep->mac_addr.addr,
-		fixed_mac_addr,
-		WIFI_MAC_ADDR_LEN);
-#elif CONFIG_WIFI_RANDOM_MAC_ADDRESS
-	char random_mac_addr[WIFI_MAC_ADDR_LEN];
-
-	sys_rand_get(random_mac_addr, WIFI_MAC_ADDR_LEN);
-	random_mac_addr[0] = (random_mac_addr[0] & UNICAST_MASK) | LOCAL_BIT;
-
-	memcpy(vif_ctx_zep->mac_addr.addr,
-		random_mac_addr,
-		WIFI_MAC_ADDR_LEN);
-#elif CONFIG_WIFI_OTP_MAC_ADDRESS
-	status = nrf_wifi_fmac_otp_mac_addr_get(fmac_dev_ctx,
-				vif_ctx_zep->vif_idx,
-				vif_ctx_zep->mac_addr.addr);
-	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: Fetching of MAC address from OTP failed",
-			__func__);
-		goto unlock;
-	}
+	ret = net_eth_mac_load(mac_cfg, vif_ctx_zep->mac_addr.addr);
+	if (ret == -ENODATA) {
+#ifndef CONFIG_NRF71_ON_IPC
+		status = nrf_wifi_fmac_otp_mac_addr_get(fmac_dev_ctx, vif_ctx_zep->vif_idx,
+							vif_ctx_zep->mac_addr.addr);
+		if (status != NRF_WIFI_STATUS_SUCCESS) {
+			LOG_ERR("%s: Fetching of MAC address from OTP failed", __func__);
+			goto unlock;
+		}
+#else
+		/* Set dummy MAC address */
+		vif_ctx_zep->mac_addr.addr[0] = 0x00;
+		vif_ctx_zep->mac_addr.addr[1] = 0x00;
+		vif_ctx_zep->mac_addr.addr[2] = 0x5E;
+		vif_ctx_zep->mac_addr.addr[3] = 0x00;
+		vif_ctx_zep->mac_addr.addr[4] = 0x10;
+		vif_ctx_zep->mac_addr.addr[5] = 0x00;
 #endif
+	} else if (ret < 0) {
+		LOG_ERR("%s: Loading of MAC address from config failed (%d)", __func__, ret);
+		goto unlock;
+	}
 
 	if (!nrf_wifi_utils_is_mac_addr_valid(vif_ctx_zep->mac_addr.addr)) {
-		LOG_ERR("%s: Invalid MAC address: %s",
-			__func__,
-			net_sprint_ll_addr(vif_ctx_zep->mac_addr.addr,
-					WIFI_MAC_ADDR_LEN));
+		LOG_ERR("%s: Invalid MAC address: %s", __func__,
+			net_sprint_ll_addr(vif_ctx_zep->mac_addr.addr, WIFI_MAC_ADDR_LEN));
 		status = NRF_WIFI_STATUS_FAIL;
-		memset(vif_ctx_zep->mac_addr.addr,
-			0,
-			WIFI_MAC_ADDR_LEN);
+		memset(vif_ctx_zep->mac_addr.addr, 0, WIFI_MAC_ADDR_LEN);
 		goto unlock;
 	}
 	status = NRF_WIFI_STATUS_SUCCESS;

--- a/dts/bindings/wifi/nordic,wlan.yaml
+++ b/dts/bindings/wifi/nordic,wlan.yaml
@@ -8,4 +8,6 @@ description: |
   Wi-Fi chips. The interface is used to identify and name Wi-Fi network
   interfaces like wlan0.
 
+include: ethernet-controller.yaml
+
 compatible: "nordic,wlan"


### PR DESCRIPTION
Allow setting the MAC address for the nRF Wi-Fi interface with a configuration derived from the devicetree.
This allows to use an NVMEM cell as MAC address storage.