### PR TITLE
net: shell: quiet ping with statistics

### DIFF
--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -49,6 +49,14 @@ static enum net_verdict handle_echo_reply_common(struct net_pkt *pkt, uint16_t s
 						 uint16_t bytes, const char *src, const char *dst,
 						 uint8_t ttl);
 
+#ifdef CONFIG_FPU
+#define PING_PRI_MSEC             "%.2f"
+#define PING_CYCLES_MSEC(_cycles) ((double)((uint32_t)k_cyc_to_ns_floor64(_cycles) / 1e6f))
+#else
+#define PING_PRI_MSEC             "%u"
+#define PING_CYCLES_MSEC(_cycles) ((uint32_t)k_cyc_to_ns_floor64(_cycles) / 1000000)
+#endif
+
 #if defined(CONFIG_NET_NATIVE_IPV6)
 
 static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
@@ -175,13 +183,8 @@ static enum net_verdict handle_echo_reply_common(struct net_pkt *pkt, uint16_t s
 		}
 
 		cycles = k_cycle_get_32() - cycles;
-		snprintf(time_buf, sizeof(time_buf),
-#ifdef CONFIG_FPU
-			 "time=%.2f ms", (double)((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000.f)
-#else
-			 "time=%d ms", ((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000)
-#endif
-		);
+		snprintf(time_buf, sizeof(time_buf), "time=" PING_PRI_MSEC " ms",
+				 PING_CYCLES_MSEC(cycles));
 	}
 
 	PR_SHELL(ping_ctx.sh,

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -12,6 +12,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include <stdio.h>
 #include <zephyr/random/random.h>
 #include <zephyr/net/icmp.h>
+#include <zephyr/net/net_linkaddr.h>
 
 #include "net_shell_private.h"
 
@@ -246,17 +247,19 @@ static enum net_verdict handle_echo_reply_common(struct net_pkt *pkt, uint16_t s
 	ping_ctx.stats.pkt_recv++;
 
 	if (!ping_ctx.quiet) {
-		PR_SHELL(ping_ctx.sh,
-			 "%d bytes from %s to %s: icmp_seq=%u ttl=%u "
 #ifdef CONFIG_IEEE802154
-			 "rssi=%d "
+		char rssi_buf[16] = {0};
+		struct net_linkaddr *link_addr = net_if_get_link_addr(pkt->iface);
+
+		if (link_addr && link_addr->type == NET_LINK_IEEE802154) {
+			snprintf(rssi_buf, sizeof(rssi_buf), "rssi=%d ",
+				 net_pkt_ieee802154_rssi_dbm(pkt));
+		}
+#else
+		const char rssi_buf[1] = {0};
 #endif
-			 "%s\n",
-			 bytes, src, dst, sequence, ttl,
-#ifdef CONFIG_IEEE802154
-			 net_pkt_ieee802154_rssi_dbm(pkt),
-#endif
-			 time_buf);
+		PR_SHELL(ping_ctx.sh, "%d bytes from %s to %s: icmp_seq=%u ttl=%u %s%s\n", bytes,
+			 src, dst, sequence, ttl, rssi_buf, time_buf);
 	}
 
 	if (sequence == ping_ctx.count) {

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -45,6 +45,9 @@ static struct ping_context {
 } ping_ctx;
 
 static void ping_done(struct ping_context *ctx);
+static enum net_verdict handle_echo_reply_common(struct net_pkt *pkt, uint16_t sequence,
+						 uint16_t bytes, const char *src, const char *dst,
+						 uint8_t ttl);
 
 #if defined(CONFIG_NET_NATIVE_IPV6)
 
@@ -58,8 +61,6 @@ static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 					      struct net_icmpv6_echo_req);
 	struct net_ipv6_hdr *ip_hdr = hdr->ipv6;
 	struct net_icmpv6_echo_req *icmp_echo;
-	uint32_t cycles;
-	char time_buf[16] = { 0 };
 
 	icmp_echo = (struct net_icmpv6_echo_req *)net_pkt_get_data(pkt,
 								&icmp_access);
@@ -76,45 +77,11 @@ static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 		return NET_DROP;
 	}
 
-	if (net_pkt_remaining_data(pkt) >= sizeof(uint32_t)) {
-		if (net_pkt_read_be32(pkt, &cycles)) {
-			return NET_DROP;
-		}
-
-		cycles = k_cycle_get_32() - cycles;
-
-		snprintf(time_buf, sizeof(time_buf),
-#ifdef CONFIG_FPU
-			 "time=%.2f ms",
-			 (double)((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000.f)
-#else
-			 "time=%d ms",
-			 ((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000)
-#endif
-			);
-	}
-
-	PR_SHELL(ping_ctx.sh, "%d bytes from %s to %s: icmp_seq=%d ttl=%d "
-#ifdef CONFIG_IEEE802154
-		 "rssi=%d "
-#endif
-		 "%s\n",
-		 net_ntohs(ip_hdr->len) - net_pkt_ipv6_ext_len(pkt) -
-								NET_ICMPH_LEN,
-		 net_sprint_ipv6_addr(&ip_hdr->src),
-		 net_sprint_ipv6_addr(&ip_hdr->dst),
-		 net_ntohs(icmp_echo->sequence),
-		 ip_hdr->hop_limit,
-#ifdef CONFIG_IEEE802154
-		 net_pkt_ieee802154_rssi_dbm(pkt),
-#endif
-		 time_buf);
-
-	if (net_ntohs(icmp_echo->sequence) == ping_ctx.count) {
-		ping_done(&ping_ctx);
-	}
-
-	return NET_OK;
+	return handle_echo_reply_common(pkt, net_ntohs(icmp_echo->sequence),
+					net_ntohs(ip_hdr->len) - net_pkt_ipv6_ext_len(pkt) -
+						NET_ICMPH_LEN,
+					net_sprint_ipv6_addr(&ip_hdr->src),
+					net_sprint_ipv6_addr(&ip_hdr->dst), ip_hdr->hop_limit);
 }
 #else
 static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
@@ -144,9 +111,7 @@ static enum net_verdict handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(icmp_access,
 					      struct net_icmpv4_echo_req);
 	struct net_ipv4_hdr *ip_hdr = hdr->ipv4;
-	uint32_t cycles;
 	struct net_icmpv4_echo_req *icmp_echo;
-	char time_buf[16] = { 0 };
 
 	icmp_echo = (struct net_icmpv4_echo_req *)net_pkt_get_data(pkt,
 								&icmp_access);
@@ -163,46 +128,16 @@ static enum net_verdict handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 		return NET_DROP;
 	}
 
-	if (net_pkt_remaining_data(pkt) >= sizeof(uint32_t)) {
-		if (net_pkt_read_be32(pkt, &cycles)) {
-			return NET_DROP;
-		}
-
-		cycles = k_cycle_get_32() - cycles;
-
-		snprintf(time_buf, sizeof(time_buf),
-#ifdef CONFIG_FPU
-			 "time=%.2f ms",
-			 (double)((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000.f)
-#else
-			 "time=%d ms",
-			 ((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000)
-#endif
-			);
-	}
-
-	PR_SHELL(ping_ctx.sh, "%d bytes from %s to %s: icmp_seq=%d ttl=%d "
-		 "%s\n",
-		 net_ntohs(ip_hdr->len) - net_pkt_ipv6_ext_len(pkt) -
-								NET_ICMPH_LEN,
-		 net_sprint_ipv4_addr(&ip_hdr->src),
-		 net_sprint_ipv4_addr(&ip_hdr->dst),
-		 net_ntohs(icmp_echo->sequence),
-		 ip_hdr->ttl,
-		 time_buf);
-
-	if (net_ntohs(icmp_echo->sequence) == ping_ctx.count) {
-		ping_done(&ping_ctx);
-	}
-
-	return NET_OK;
+	return handle_echo_reply_common(pkt, net_ntohs(icmp_echo->sequence),
+					net_ntohs(ip_hdr->len) - net_pkt_ipv6_ext_len(pkt) -
+						NET_ICMPH_LEN,
+					net_sprint_ipv4_addr(&ip_hdr->src),
+					net_sprint_ipv4_addr(&ip_hdr->dst), ip_hdr->ttl);
 }
 #else
-static enum net_verdict handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
-					       struct net_pkt *pkt,
+static enum net_verdict handle_ipv4_echo_reply(struct net_icmp_ctx *ctx, struct net_pkt *pkt,
 					       struct net_icmp_ip_hdr *hdr,
-					       struct net_icmp_hdr *icmp_hdr,
-					       void *user_data)
+					       struct net_icmp_hdr *icmp_hdr, void *user_data)
 {
 	ARG_UNUSED(ctx);
 	ARG_UNUSED(pkt);
@@ -213,6 +148,61 @@ static enum net_verdict handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 	return NET_CONTINUE;
 }
 #endif /* CONFIG_NET_IPV4 */
+
+#if defined(CONFIG_NET_IPV4) || defined(CONFIG_NET_IPV6)
+
+/** Calculating the round-trip time and printing the result.
+ *
+ * @param pkt The packet containing the echo reply
+ * @param sequence Sequence number
+ * @param bytes Ping data length
+ * @param src Source address
+ * @param dst Destination address
+ * @param ttl Time-to-live
+ * @retval NET_OK on success
+ * @retval NET_DROP on failure
+ */
+static enum net_verdict handle_echo_reply_common(struct net_pkt *pkt, uint16_t sequence,
+						 uint16_t bytes, const char *src, const char *dst,
+						 uint8_t ttl)
+{
+	uint32_t cycles = 0;
+	char time_buf[16] = {0};
+
+	if (net_pkt_remaining_data(pkt) >= sizeof(uint32_t)) {
+		if (net_pkt_read_be32(pkt, &cycles)) {
+			return NET_DROP;
+		}
+
+		cycles = k_cycle_get_32() - cycles;
+		snprintf(time_buf, sizeof(time_buf),
+#ifdef CONFIG_FPU
+			 "time=%.2f ms", (double)((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000.f)
+#else
+			 "time=%d ms", ((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000)
+#endif
+		);
+	}
+
+	PR_SHELL(ping_ctx.sh,
+		 "%d bytes from %s to %s: icmp_seq=%u ttl=%u "
+#ifdef CONFIG_IEEE802154
+		 "rssi=%d "
+#endif
+		 "%s\n",
+		 bytes, src, dst, sequence, ttl,
+#ifdef CONFIG_IEEE802154
+		 net_pkt_ieee802154_rssi_dbm(pkt),
+#endif
+		 time_buf);
+
+	if (sequence == ping_ctx.count) {
+		ping_done(&ping_ctx);
+	}
+
+	return NET_OK;
+}
+#endif
 
 static int parse_arg(size_t *i, size_t argc, char *argv[])
 {

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -42,6 +42,14 @@ static struct ping_context {
 	uint16_t payload_size;
 	uint8_t tos;
 	int priority;
+	struct ping_stats {
+		uint64_t cycle_sum;
+		uint32_t pkt_sent;
+		uint32_t pkt_recv;
+		uint32_t rtt_count;
+		uint32_t rtt_min;
+		uint32_t rtt_max;
+	} stats;
 } ping_ctx;
 
 static void ping_done(struct ping_context *ctx);
@@ -56,6 +64,51 @@ static enum net_verdict handle_echo_reply_common(struct net_pkt *pkt, uint16_t s
 #define PING_PRI_MSEC             "%u"
 #define PING_CYCLES_MSEC(_cycles) ((uint32_t)k_cyc_to_ns_floor64(_cycles) / 1000000)
 #endif
+
+/** Print the ping statistics.
+ *
+ * @param ctx The ping context
+ */
+static void stats_print(struct ping_context *ctx)
+{
+	uint_fast8_t pkt_loss_percent = 100;
+
+	PR_SHELL(ctx->sh, "--- ping statistics ---\n");
+
+	if (ctx->stats.pkt_sent > 0) {
+		if (ctx->stats.pkt_recv < ctx->stats.pkt_sent) {
+			pkt_loss_percent = (ctx->stats.pkt_sent - ctx->stats.pkt_recv) * 100 /
+					   ctx->stats.pkt_sent;
+		} else {
+			pkt_loss_percent = 0;
+		}
+	}
+	PR_SHELL(ctx->sh, "%u packets transmitted, %u received, %u%% packet loss\n",
+		 ctx->stats.pkt_sent, ctx->stats.pkt_recv, pkt_loss_percent);
+
+	if (ctx->stats.rtt_count > 0) {
+		/* rtt = round-trip-time */
+		PR_SHELL(ctx->sh,
+			 "rtt min/avg/max = " PING_PRI_MSEC "/" PING_PRI_MSEC "/" PING_PRI_MSEC
+			 " ms\n",
+			 PING_CYCLES_MSEC(ctx->stats.rtt_min),
+			 PING_CYCLES_MSEC(ctx->stats.cycle_sum / ctx->stats.rtt_count),
+			 PING_CYCLES_MSEC(ctx->stats.rtt_max));
+	}
+}
+
+/** Update ping statistics.
+ *
+ * @param ctx The ping context.
+ * @param cycles The round-trip time in ticks.
+ */
+static void stats_update(struct ping_context *ctx, uint32_t cycles)
+{
+	ctx->stats.rtt_count++;
+	ctx->stats.cycle_sum += cycles;
+	ctx->stats.rtt_min = MIN(ctx->stats.rtt_min, cycles);
+	ctx->stats.rtt_max = MAX(ctx->stats.rtt_max, cycles);
+}
 
 #if defined(CONFIG_NET_NATIVE_IPV6)
 
@@ -185,7 +238,9 @@ static enum net_verdict handle_echo_reply_common(struct net_pkt *pkt, uint16_t s
 		cycles = k_cycle_get_32() - cycles;
 		snprintf(time_buf, sizeof(time_buf), "time=" PING_PRI_MSEC " ms",
 				 PING_CYCLES_MSEC(cycles));
+		stats_update(&ping_ctx, cycles);
 	}
+	ping_ctx.stats.pkt_recv++;
 
 	PR_SHELL(ping_ctx.sh,
 		 "%d bytes from %s to %s: icmp_seq=%u ttl=%u "
@@ -242,6 +297,7 @@ static void ping_cleanup(struct ping_context *ctx)
 {
 	(void)net_icmp_cleanup_ctx(&ctx->icmp);
 	shell_set_bypass(ctx->sh, NULL, NULL);
+	stats_print(ctx);
 }
 
 static void ping_done(struct ping_context *ctx)
@@ -276,6 +332,8 @@ static void ping_work(struct k_work *work)
 		k_work_reschedule(&ctx->work, K_SECONDS(2));
 	}
 
+	ctx->stats.pkt_sent++;
+
 	params.identifier = ctx->identifier;
 	params.sequence = ctx->sequence;
 	params.tc_tos = ctx->tos;
@@ -290,6 +348,7 @@ static void ping_work(struct k_work *work)
 						 ctx);
 	if (ret != 0) {
 		PR_WARNING("Failed to send ping, err: %d\n", ret);
+		ctx->stats.pkt_sent--;
 		ping_done(ctx);
 		return;
 	}
@@ -475,6 +534,7 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 	ping_ctx.priority = priority;
 	ping_ctx.tos = tos;
 	ping_ctx.payload_size = payload_size;
+	ping_ctx.stats = (struct ping_stats){.rtt_min = UINT32_MAX};
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    net_addr_pton(NET_AF_INET6, host, &ping_ctx.addr6.sin6_addr) == 0) {

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -41,6 +41,7 @@ static struct ping_context {
 	uint32_t sequence;
 	uint16_t payload_size;
 	uint8_t tos;
+	bool quiet;
 	int priority;
 	struct ping_stats {
 		uint64_t cycle_sum;
@@ -236,23 +237,27 @@ static enum net_verdict handle_echo_reply_common(struct net_pkt *pkt, uint16_t s
 		}
 
 		cycles = k_cycle_get_32() - cycles;
-		snprintf(time_buf, sizeof(time_buf), "time=" PING_PRI_MSEC " ms",
+		if (!ping_ctx.quiet) {
+			snprintf(time_buf, sizeof(time_buf), "time=" PING_PRI_MSEC " ms",
 				 PING_CYCLES_MSEC(cycles));
+		}
 		stats_update(&ping_ctx, cycles);
 	}
 	ping_ctx.stats.pkt_recv++;
 
-	PR_SHELL(ping_ctx.sh,
-		 "%d bytes from %s to %s: icmp_seq=%u ttl=%u "
+	if (!ping_ctx.quiet) {
+		PR_SHELL(ping_ctx.sh,
+			 "%d bytes from %s to %s: icmp_seq=%u ttl=%u "
 #ifdef CONFIG_IEEE802154
-		 "rssi=%d "
+			 "rssi=%d "
 #endif
-		 "%s\n",
-		 bytes, src, dst, sequence, ttl,
+			 "%s\n",
+			 bytes, src, dst, sequence, ttl,
 #ifdef CONFIG_IEEE802154
-		 net_pkt_ieee802154_rssi_dbm(pkt),
+			 net_pkt_ieee802154_rssi_dbm(pkt),
 #endif
-		 time_buf);
+			 time_buf);
+	}
 
 	if (sequence == ping_ctx.count) {
 		ping_done(&ping_ctx);
@@ -321,7 +326,9 @@ static void ping_work(struct k_work *work)
 	ctx->sequence++;
 
 	if (ctx->sequence > ctx->count) {
-		PR_INFO("Ping timeout\n");
+		if (!ctx->quiet) {
+			PR_INFO("Ping timeout\n");
+		}
 		ping_done(ctx);
 		return;
 	}
@@ -451,6 +458,7 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 	int tos = 0;
 	int payload_size = 4;
 	int priority = -1;
+	bool quiet = false;
 	int ret;
 
 	for (size_t i = 1; i < argc; ++i) {
@@ -513,6 +521,10 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 
 			break;
 
+		case 'q':
+			quiet = true;
+			break;
+
 		default:
 			PR_WARNING("Unrecognized argument: %s\n", argv[i]);
 			return -ENOEXEC;
@@ -535,6 +547,7 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 	ping_ctx.tos = tos;
 	ping_ctx.payload_size = payload_size;
 	ping_ctx.stats = (struct ping_stats){.rtt_min = UINT32_MAX};
+	ping_ctx.quiet = quiet;
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    net_addr_pton(NET_AF_INET6, host, &ping_ctx.addr6.sin6_addr) == 0) {
@@ -572,14 +585,14 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 #endif
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_ping,
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	net_cmd_ping,
 	SHELL_CMD(ping, NULL,
 		  SHELL_HELP("Send ICMPv4 or ICMPv6 Echo-Request to a network host",
-			     "[-c count] [-i interval ms] [-I <iface index>]\n"
-			     "[-Q tos] [-s payload size] [-p priority] <host>"),
+			     "[-c <count>] [-i <interval ms>] [-I <iface index>]\n"
+			     "[-Q <tos>] [-s <payload size>] [-p <priority>] [-q] <host>"),
 		  cmd_net_ping),
-	SHELL_SUBCMD_SET_END
-);
+	SHELL_SUBCMD_SET_END);
 
 SHELL_SUBCMD_ADD((net), ping, &net_cmd_ping,
 		 "Ping a network host.",


### PR DESCRIPTION
**Issue**
When the underlying UART is shared with the logging subsystem, extensive logging can prevent `net ping` from printing its response for over 100 ms. The network stack then appears unresponsive to subsequent pings, which looks like a network stack bug but is not — logging is contending with `shell_print()`.

**Solution**
The Linux ping command supports a quiet mode and end-of-session statistics.
- Add `-q` flag to suppress per-reply output
- Add end-of-session statistics printed on termination
```
--- ping statistics ---
3 packets transmitted, 3 received, 0% packet loss
rtt min/avg/max = 87/91/93 ms
```

**Pre-work for the above**
The shell print functions for IPv4 and IPv6 are unified to reduce code duplication, which is required to implement the statistics without repeating logic.

**Spotted bug while fixing the initial issue**
Fixed incorrect RSSI reporting on multi-interface devices: when CONFIG_IEEE802154 is enabled, RSSI was previously read regardless of interface type. It is now only read for IEEE 802.15.4 links, checked at runtime.