### PR TITLE
soc: nxp: mcx: enable LPCAC instruction cache support

### DIFF
--- a/soc/nxp/mcx/mcxa/Kconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig
@@ -9,17 +9,17 @@ config SOC_FAMILY_MCXA
 	select CPU_CORTEX_M_HAS_SYSTICK
 	select CPU_CORTEX_M_HAS_DWT
 	select SOC_RESET_HOOK
+	select CPU_HAS_ICACHE
+	select HAS_MCUX_SYSCON_LPCAC
 
 config SOC_SERIES_MCXA1X3
 	select CPU_CORTEX_M33
-	select HAS_MCUX_CACHE
 	select HAS_PM
 
 config SOC_SERIES_MCXA1X6
 	select CPU_CORTEX_M33
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
-	select HAS_MCUX_CACHE
 	select HAS_PM
 
 config SOC_SERIES_MCXAXX6
@@ -27,7 +27,6 @@ config SOC_SERIES_MCXAXX6
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
-	select HAS_MCUX_CACHE
 	select HAS_PM
 
 config SOC_SERIES_MCXAXX4
@@ -35,7 +34,6 @@ config SOC_SERIES_MCXAXX4
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
-	select HAS_MCUX_CACHE
 
 config SOC_SERIES_MCXAXX7
 	select CPU_CORTEX_M33
@@ -44,4 +42,3 @@ config SOC_SERIES_MCXAXX7
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select ARM_TRUSTZONE_M
-	select HAS_MCUX_CACHE

--- a/soc/nxp/mcx/mcxa/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig.defconfig
@@ -36,4 +36,18 @@ configdefault SYSTEM_TIMER_RESET_BY_LPM
 
 endif # PM
 
+if HAS_MCUX_SYSCON_LPCAC
+
+config CACHE_MANAGEMENT
+	default y
+
+choice CACHE_TYPE
+	default EXTERNAL_CACHE
+endchoice
+
+config ICACHE_LINE_SIZE
+	default 256
+
+endif # HAS_MCUX_SYSCON_LPCAC
+
 endif # SOC_FAMILY_MCXA

--- a/soc/nxp/mcx/mcxn/Kconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig
@@ -18,6 +18,8 @@ config SOC_MCXN947_CPU0
 	select SOC_RESET_HOOK
 	select ARM_TRUSTZONE_M
 	select HAS_MCUX_CACHE
+	select CPU_HAS_ICACHE
+	select HAS_MCUX_SYSCON_LPCAC
 	select HAS_PM
 
 config SOC_MCXN947_CPU1
@@ -37,6 +39,8 @@ config SOC_MCXN547_CPU0
 	select SOC_RESET_HOOK
 	select ARM_TRUSTZONE_M
 	select HAS_MCUX_CACHE
+	select CPU_HAS_ICACHE
+	select HAS_MCUX_SYSCON_LPCAC
 	select HAS_PM
 
 config SOC_MCXN547_CPU1
@@ -53,6 +57,8 @@ config SOC_MCXN236
 	select SOC_RESET_HOOK
 	select ARM_TRUSTZONE_M
 	select HAS_CPU_FREQ
+	select CPU_HAS_ICACHE
+	select HAS_MCUX_SYSCON_LPCAC
 	select HAS_PM
 
 if SOC_FAMILY_MCXN

--- a/soc/nxp/mcx/mcxn/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig.defconfig
@@ -49,4 +49,18 @@ configdefault SYSTEM_TIMER_RESET_BY_LPM
 
 endif # PM
 
+if HAS_MCUX_SYSCON_LPCAC
+
+config CACHE_MANAGEMENT
+	default y
+
+choice CACHE_TYPE
+	default EXTERNAL_CACHE
+endchoice
+
+config ICACHE_LINE_SIZE
+	default 256
+
+endif # HAS_MCUX_SYSCON_LPCAC
+
 endif # SOC_FAMILY_MCXN


### PR DESCRIPTION
Add CPU_HAS_ICACHE and HAS_MCUX_SYSCON_LPCAC selects to MCXA and MCXN SOC, and enable CACHE_MANAGEMENT with EXTERNAL_CACHE and ICACHE_LINE_SIZE=256 in Kconfig.defconfig. 

MCXA family (soc/nxp/mcx/mcxa/):
    - SOC_SERIES_MCXA1X3 (MCXA153)
    - SOC_SERIES_MCXA1X6 (MCXA156)
    - SOC_SERIES_MCXAXX4 (MCXA344)
    - SOC_SERIES_MCXAXX6 (MCXA346)
    - SOC_SERIES_MCXAXX7 (MCXA577): 

MCXN family (soc/nxp/mcx/mcxn/):
    - SOC_MCXN947_CPU0 (MCXN947)
    - SOC_MCXN547_CPU0 (MCXN547)
    - SOC_MCXN236 (MCXN236)

Tested with tests/kernel/cache on frdm_mcxa577 hardware: SUITE PASS 100% [cache_api]: pass=3, fail=0, skip=0