### PR TITLE
FRDM-MCXL255: AON LPCMP support for CM33/CM0+

### DIFF
--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -127,6 +127,16 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_GateAonUART);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_lpcmp0))
+	CLOCK_EnableClock(kCLOCK_GateAonAPB);
+	CLOCK_AttachClk(kFROdiv4_to_AON_CMP0);
+	CLOCK_SetClockDiv(kCLOCK_DIVAonACMP0CLK0, 1U);
+	CLOCK_SetClockDiv(kCLOCK_DIVAonACMP0CLK1, 1U);
+	CLOCK_EnableClock(kCLOCK_GateAonACMP0);
+	CLOCK_EnableClock(kCLOCK_GateAonACMP0RR);
+	RESET_ReleasePeripheralReset(kAonACMP0_RST_SHIFT_RSTn);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(rtc))
 	if (!CLOCK_IsRoscInitialized()) {
 		rosc_init_config_t rosc_init_config;

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dts
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dts
@@ -12,3 +12,7 @@
 	model = "NXP FRDM_MCXL255 board";
 	compatible = "nxp,mcxl255", "nxp,mcx";
 };
+
+&aon_lpcmp0 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -15,4 +15,5 @@ supported:
   - gpio
   - rtc
   - crc
+  - comparator
 vendor: nxp

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
@@ -35,3 +35,7 @@
 &systick {
 	status = "okay";
 };
+
+&aon_lpcmp0 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
@@ -12,4 +12,5 @@ toolchain:
   - gnuarmemb
 supported:
   - uart
+  - comparator
 vendor: nxp

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
@@ -42,3 +42,7 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&aon_lpcmp0 {
+	interrupts = <157 0>;
+};

--- a/dts/arm/nxp/mcx/nxp_mcxl_aon.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl_aon.dtsi
@@ -73,4 +73,16 @@
 		alarms-count = <3>;
 		status = "disabled";
 	};
+
+	aon_lpcmp0: comparator@86000 {
+		compatible = "nxp,lpcmp";
+		reg = <0x86000 0x1000>;
+		interrupts = <30 0>;
+		positive-mux-input = "IN2";
+		negative-mux-input = "DAC";
+		dac-vref-source = "VREFH0";
+		dac-value = <127>;
+		#io-channel-cells = <2>;
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
Add AON LPCMP support for the FRDM-MCXL255 CM33 and CM0PLUS.

This PR adds the MCXL255 AON LPCMP devicetree node to the shared AON
devicetree file, allowing the peripheral to be used by both cores.

The shared node uses interrupt 30 for CM0+, while the CM33 devicetree
overrides it with interrupt 157.

Tested with:

- tests/drivers/comparator/gpio_loopback on frdm_mcxl255/mcxl255/cpu0
- custom small test app on frdm_mcxl255/mcxl255/cpu1 (gpio_loopback was too large for CM0PLUS)