### PR TITLE
Bluetooth: BAP: UC: Add check for stream->group for QoS notification

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -984,13 +984,18 @@ static bool unicast_client_ep_qos_state(struct bt_bap_ep *ep, struct net_buf_sim
 	ep->receiver_ready = false;
 
 	if (buf->len < sizeof(*qos)) {
-		LOG_ERR("QoS status too short");
+		LOG_DBG("QoS status too short");
 		return false;
 	}
 
 	stream = ep->stream;
 	if (stream == NULL) {
-		LOG_ERR("No stream active for endpoint");
+		LOG_DBG("No stream active for endpoint");
+		return false;
+	}
+
+	if (stream->group == NULL) {
+		LOG_DBG("Stream %p is not configured to a group", stream);
 		return false;
 	}
 


### PR DESCRIPTION
If the server wrongly sends us a QoS state notification before the stream was ever added to a group, we should just ignore it rather than hitting the assert or dereferencing the group later.

Fixes: #112211