### PR TITLE
net: zperf: make TCP receiver buffer size configurable

### DIFF
--- a/subsys/net/lib/zperf/Kconfig
+++ b/subsys/net/lib/zperf/Kconfig
@@ -97,4 +97,15 @@ config NET_ZPERF_RAW_TX_MAX_HDR_SIZE
 	  Maximum size of the custom header that can be prepended to raw TX
 	  packets. The header is provided as hex bytes by the user.
 
+config NET_ZPERF_TCP_RECEIVER_BUF_SIZE
+	int "TCP receiver buffer size (bytes)"
+	default 1500
+	range $(inc,$(UINT8_MAX)) $(UINT16_MAX)
+	depends on NET_ZPERF_SERVER
+	help
+	  Size of the receive buffer used by the zperf TCP receiver per
+	  recv() call. A larger buffer allows more data to be read from the
+	  socket in a single call, which can increase the TCP window size
+	  and improve throughput on fast connections.
+
 endif

--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -29,8 +29,6 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 #define SOCK_ID_IPV6_LISTEN 1
 #define SOCK_ID_MAX         (CONFIG_NET_ZPERF_MAX_SESSIONS + 2)
 
-#define TCP_RECEIVER_BUF_SIZE 1500
-
 static zperf_callback tcp_session_cb;
 static void *tcp_user_data;
 static bool tcp_server_running;
@@ -124,7 +122,7 @@ static void tcp_receiver_cleanup(void)
 
 static int tcp_recv_data(struct net_socket_service_event *pev)
 {
-	static uint8_t buf[TCP_RECEIVER_BUF_SIZE];
+	static uint8_t buf[CONFIG_NET_ZPERF_TCP_RECEIVER_BUF_SIZE];
 	int i, ret = 0;
 	int family, sock, sock_error;
 	struct net_sockaddr addr_incoming_conn;


### PR DESCRIPTION
The TCP receiver buffer in zperf_tcp_receiver.c was previously hardcoded to 1500 bytes, which limited throughput on fast connections.

Introduce CONFIG_NET_ZPERF_TCP_RECEIVER_BUF_SIZE as a Kconfig integer option (default 1500, range 256 to 65535). This allows users to scale the buffer size based on their hardware capabilities and application requirements.

Fixes:https://github.com/zephyrproject-rtos/zephyr/issues/108625