### PR TITLE
arch: riscv: core: added support for SW_ISR_TABLE_SWITCH

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -624,6 +624,7 @@ config GEN_SW_ISR_TABLE
 choice GEN_SW_ISR_TABLE_TYPE
 	prompt "Allows to chose how ISR table is implemented"
 	depends on GEN_SW_ISR_TABLE
+	default GEN_SW_ISR_TABLE_SWITCH if NRFX_CLIC
 	default GEN_SW_ISR_TABLE_ARRAY
 	help
 	  CONFIG_GEN_SW_ISR_TABLE_ARRAY is a default option.

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -42,6 +42,7 @@ config ARM
 	select BARRIER_OPERATIONS_ARCH
 	select ARCH_HAS_SEMIHOST
 	select ARCH_HAS_ISR_TABLES_LOCAL_DECLARATION
+	select GEN_SW_ISR_TABLE_SWITCH_SUPPORTED if CPU_CORTEX_M
 	select ARCH_SUPPORTS_ROM_OFFSET
 	select ARCH_HAS_CPU_IDLE_HOOKS if CPU_CORTEX_M
 	help
@@ -647,6 +648,18 @@ config GEN_SW_ISR_TABLE
 	  It can be generated as either an array or a switch-case.
 	  See CONFIG_GEN_SW_ISR_TABLE_TYPE.
 
+config GEN_SW_ISR_TABLE_SWITCH_SUPPORTED
+	bool
+	help
+	  This option is selected by architectures and interrupt controllers
+	  that dispatch interrupts through get_isr_entry(). It is a
+	  prerequisite for CONFIG_GEN_SW_ISR_TABLE_SWITCH.
+
+	  Opting in is required because the switch-case table provides no
+	  _sw_isr_table array. Second level interrupt controllers such as the
+	  PLIC keep a pointer into that array to dispatch their own IRQs, and
+	  so cannot be built against it.
+
 choice GEN_SW_ISR_TABLE_TYPE
 	prompt "Allows to chose how ISR table is implemented"
 	depends on GEN_SW_ISR_TABLE
@@ -666,6 +679,7 @@ config GEN_SW_ISR_TABLE_ARRAY
 
 config GEN_SW_ISR_TABLE_SWITCH
 	bool "Generate a function with a switch-case"
+	depends on GEN_SW_ISR_TABLE_SWITCH_SUPPORTED
 	depends on !DYNAMIC_INTERRUPTS
 	help
 	  Use a switch-case instead of an array.

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -568,7 +568,7 @@ config DYNAMIC_INTERRUPTS
 
 config SHARED_INTERRUPTS
 	bool "Set this to enable support for shared interrupts"
-	depends on GEN_SW_ISR_TABLE
+	depends on GEN_SW_ISR_TABLE_ARRAY
 	select EXPERIMENTAL
 	help
 	  Set this to enable support for shared interrupts. Use this with
@@ -666,6 +666,7 @@ config GEN_SW_ISR_TABLE_ARRAY
 
 config GEN_SW_ISR_TABLE_SWITCH
 	bool "Generate a function with a switch-case"
+	depends on !DYNAMIC_INTERRUPTS
 	help
 	  Use a switch-case instead of an array.
 	  This helps to limit binary size when most of the IRQs are not used.

--- a/arch/common/Kconfig
+++ b/arch/common/Kconfig
@@ -19,7 +19,7 @@ config SEMIHOST
 
 config ISR_TABLE_SHELL
 	bool "Shell command to dump the ISR tables"
-	depends on GEN_SW_ISR_TABLE
+	depends on GEN_SW_ISR_TABLE_ARRAY
 	depends on SHELL
 	help
 	  This option enables a shell command to dump the ISR tables.

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -140,6 +140,10 @@ GTEXT(z_riscv_custom_stack_guard_enable)
 GTEXT(z_riscv_custom_stack_guard_disable)
 #endif /* CONFIG_CUSTOM_STACK_GUARD */
 
+#ifdef CONFIG_GEN_SW_ISR_TABLE_SWITCH
+GTEXT(get_isr_entry)
+#endif /* CONFIG_GEN_SW_ISR_TABLE_SWITCH */
+
 /* exports */
 GTEXT(_isr_wrapper)
 
@@ -735,7 +739,35 @@ on_irq_stack:
 	 */
 	jal ra, __soc_handle_irq
 
-#if defined CONFIG_GEN_SW_ISR_TABLE
+#if defined CONFIG_GEN_SW_ISR_TABLE_SWITCH
+	/*
+	 * Retrieve the corresponding ISR entry and argument for the given IRQ index.
+	 * get_isr_entry(int irq_index, struct _isr_table_entry *entry)
+	 * a0 already contains the IRQ index.
+	 * a1 will contain the pointer to a local struct _isr_table_entry on the stack.
+	 * struct _isr_table_entry layout:
+	 * +0          : arg
+	 * +RV_REGSIZE : isr
+	 */
+
+	/* space for struct _isr_table_entry on the stack, keep stack 16-byte aligned */
+	addi sp, sp, -16
+
+	/* a1 will point to struct _isr_table_entry on the stack */
+	mv a1, sp
+	/*
+	 * Call to get_isr_entry will fill the struct _isr_table_entry
+	 * with the ISR address and argument for the given IRQ index
+	 */
+	call get_isr_entry
+
+	/* Load argument in a0 register */
+	lr a0, 0(sp)
+	/* Load ISR function address in register t1 */
+	lr t1, RV_REGSIZE(sp)
+	addi sp, sp, 16
+#elif defined CONFIG_GEN_SW_ISR_TABLE
+
 	/*
 	 * Call corresponding registered function in _sw_isr_table.
 	 * (table is 2-word wide, we should shift index accordingly)

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -141,6 +141,10 @@ GTEXT(z_riscv_custom_stack_guard_enable)
 GTEXT(z_riscv_custom_stack_guard_disable)
 #endif /* CONFIG_CUSTOM_STACK_GUARD */
 
+#ifdef CONFIG_GEN_SW_ISR_TABLE_SWITCH
+GTEXT(get_isr_entry)
+#endif /* CONFIG_GEN_SW_ISR_TABLE_SWITCH */
+
 /* exports */
 GTEXT(_isr_wrapper)
 
@@ -757,7 +761,36 @@ on_irq_stack:
 	 */
 	jal ra, __soc_handle_irq
 
-#if defined CONFIG_GEN_SW_ISR_TABLE
+#if defined CONFIG_GEN_SW_ISR_TABLE_SWITCH
+	/*
+	 * Retrieve the corresponding ISR entry and argument for the given IRQ index.
+	 * get_isr_entry(int irq_index, struct _isr_table_entry *entry)
+	 * a0 already contains the IRQ index.
+	 * a1 will contain the pointer to a local struct _isr_table_entry on the stack.
+	 * struct _isr_table_entry layout:
+	 * +0          : arg
+	 * +RV_REGSIZE : isr
+	 */
+
+	/* space for struct _isr_table_entry on the stack, keep stack 16-byte aligned */
+	addi sp, sp, -__isr_table_entry_STACK_SIZEOF
+
+	/* a1 will point to struct _isr_table_entry on the stack */
+	mv a1, sp
+	/*
+	 * Call to get_isr_entry will fill the struct _isr_table_entry
+	 * with the ISR address and argument for the given IRQ index
+	 */
+	call get_isr_entry
+
+	/* Load argument in a0 register */
+	lr a0, __isr_table_entry_arg_OFFSET(sp)
+	/* Load ISR function address in register t1 */
+	lr t1, __isr_table_entry_isr_OFFSET(sp)
+	addi sp, sp, __isr_table_entry_STACK_SIZEOF
+
+#elif defined CONFIG_GEN_SW_ISR_TABLE
+
 	/*
 	 * Call corresponding registered function in _sw_isr_table.
 	 * (table is 2-word wide, we should shift index accordingly)

--- a/arch/riscv/core/offsets/offsets.c
+++ b/arch/riscv/core/offsets/offsets.c
@@ -156,4 +156,11 @@ GEN_OFFSET_SYM(_cpu_context_t, mie);
 GEN_OFFSET_SYM(_cpu_context_t, sp);
 #endif /* CONFIG_PM_S2RAM */
 
+#ifdef CONFIG_GEN_SW_ISR_TABLE_SWITCH
+GEN_ABSOLUTE_SYM(__isr_table_entry_arg_OFFSET, offsetof(struct _isr_table_entry, arg));
+GEN_ABSOLUTE_SYM(__isr_table_entry_isr_OFFSET, offsetof(struct _isr_table_entry, isr));
+GEN_ABSOLUTE_SYM(__isr_table_entry_STACK_SIZEOF,
+	ROUND_UP(sizeof(struct _isr_table_entry), ARCH_STACK_PTR_ALIGN));
+#endif /* CONFIG_GEN_SW_ISR_TABLE_SWITCH */
+
 GEN_ABS_SYM_END

--- a/drivers/interrupt_controller/Kconfig.clic
+++ b/drivers/interrupt_controller/Kconfig.clic
@@ -26,6 +26,8 @@ config NRFX_CLIC
 	default y
 	depends on DT_HAS_NORDIC_NRF_CLIC_ENABLED
 	select GEN_IRQ_VECTOR_TABLE
+	# Dispatch goes through the generic RISC-V _isr_wrapper
+	select GEN_SW_ISR_TABLE_SWITCH_SUPPORTED
 	help
 	  Interrupt controller for Nordic VPR cores.
 

--- a/subsys/tracing/sysview/sysview_config.c
+++ b/subsys/tracing/sysview/sysview_config.c
@@ -62,7 +62,8 @@ static void cbSendSystemDesc(void)
 	SEGGER_SYSVIEW_SendSysDesc("C=" CONFIG_BOARD_QUALIFIERS);
 #endif
 
-#ifdef CONFIG_SYMTAB
+/* The switch-case ISR table cannot be walked, so ISR names are not reported. */
+#if defined(CONFIG_SYMTAB) && defined(CONFIG_GEN_SW_ISR_TABLE_ARRAY)
 	char isr_desc[SEGGER_SYSVIEW_MAX_STRING_LEN];
 
 	for (int idx = 0; idx < IRQ_TABLE_SIZE; idx++) {

--- a/tests/arch/common/gen_isr_table/src/main.c
+++ b/tests/arch/common/gen_isr_table/src/main.c
@@ -284,22 +284,37 @@ static int check_vector(void *isr, int offset)
 
 #if defined(CONFIG_GEN_SW_ISR_TABLE) && \
 	(defined(ISR3_OFFSET) || defined(ISR4_OFFSET) || \
-	 defined(ISR5_OFFSET) || defined(ISR6_OFFSET))
+	 (defined(CONFIG_DYNAMIC_INTERRUPTS) && \
+	  (defined(ISR5_OFFSET) || defined(ISR6_OFFSET))))
+/* The software ISR table is either an array indexed by table index, or a
+ * generated switch-case reachable only through get_isr_entry().
+ */
+static void get_sw_isr_entry(unsigned int table_idx, struct _isr_table_entry *entry)
+{
+#if defined(CONFIG_GEN_SW_ISR_TABLE_ARRAY)
+	*entry = _sw_isr_table[table_idx];
+#else
+	get_isr_entry(table_idx, entry);
+#endif
+}
+
 static int check_sw_isr(void *isr, uintptr_t arg, int offset)
 {
-	const struct _isr_table_entry *e = &_sw_isr_table[TABLE_INDEX(offset)];
+	struct _isr_table_entry e;
 
-	TC_PRINT("Checking _sw_isr_table entry %d for irq %d\n",
+	get_sw_isr_entry(TABLE_INDEX(offset), &e);
+
+	TC_PRINT("Checking SW ISR table entry %d for irq %d\n",
 		 TABLE_INDEX(offset), IRQ_LINE(offset));
 
-	if (e->arg != (void *)arg) {
+	if (e.arg != (void *)arg) {
 		TC_PRINT("bad argument in SW isr table\n");
-		TC_PRINT("expected %p got %p\n", (void *)arg, e->arg);
+		TC_PRINT("expected %p got %p\n", (void *)arg, e.arg);
 		return -1;
 	}
-	if (e->isr != isr) {
+	if (e.isr != isr) {
 		TC_PRINT("Bad ISR in SW isr table\n");
-		TC_PRINT("expected %p got %p\n", (void *)isr, e->isr);
+		TC_PRINT("expected %p got %p\n", (void *)isr, e.isr);
 		return -1;
 	}
 #if defined(CONFIG_GEN_IRQ_VECTOR_TABLE) && !defined(CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_CODE)
@@ -380,7 +395,11 @@ ZTEST(gen_isr_table, test_build_time_interrupt)
 #ifndef CONFIG_GEN_SW_ISR_TABLE
 	ztest_test_skip();
 #else
+#ifdef CONFIG_GEN_SW_ISR_TABLE_ARRAY
 	TC_PRINT("_sw_isr_table at location %p\n", _sw_isr_table);
+#else
+	TC_PRINT("get_isr_entry at location %p\n", (void *)(uintptr_t)get_isr_entry);
+#endif
 
 #ifdef ISR3_OFFSET
 	IRQ_CONNECT(IRQ_LINE(ISR3_OFFSET), 1, isr3, ISR3_ARG, IRQ_FLAGS);
@@ -423,7 +442,7 @@ ZTEST(gen_isr_table, test_build_time_interrupt)
 ZTEST(gen_isr_table, test_run_time_interrupt)
 {
 
-#ifndef CONFIG_GEN_SW_ISR_TABLE
+#if !defined(CONFIG_GEN_SW_ISR_TABLE) || !defined(CONFIG_DYNAMIC_INTERRUPTS)
 	ztest_test_skip();
 #else
 

--- a/tests/arch/common/gen_isr_table/tests.yaml
+++ b/tests/arch/common/gen_isr_table/tests.yaml
@@ -72,6 +72,24 @@ tests:
     extra_configs:
       - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
 
+  arch.interrupt.gen_isr_table.switch.arm:
+    platform_allow: qemu_cortex_m3
+    filter: CONFIG_GEN_ISR_TABLES and CONFIG_GEN_SW_ISR_TABLE_SWITCH_SUPPORTED
+    extra_configs:
+      - CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
+      # A generated switch-case table cannot be patched at runtime
+      - CONFIG_DYNAMIC_INTERRUPTS=n
+      - CONFIG_GEN_SW_ISR_TABLE_SWITCH=y
+  arch.interrupt.gen_isr_table.switch.riscv:
+    arch_allow: riscv
+    filter: CONFIG_GEN_ISR_TABLES and CONFIG_GEN_SW_ISR_TABLE_SWITCH_SUPPORTED
+    extra_configs:
+      # A generated switch-case table cannot be patched at runtime
+      - CONFIG_DYNAMIC_INTERRUPTS=n
+      - CONFIG_GEN_SW_ISR_TABLE_SWITCH=y
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuflpr
+
   arch.interrupt.gen_isr_table.arc:
     arch_allow: arc
     filter: CONFIG_RGF_NUM_BANKS > 1

--- a/tests/arch/common/interrupt/src/nested_irq.c
+++ b/tests/arch/common/interrupt/src/nested_irq.c
@@ -169,7 +169,7 @@ ZTEST(interrupt_feature, test_nested_isr)
 #if defined(IRQ0_LINE) && defined(IRQ1_LINE)
 	IRQ_CONNECT(IRQ0_LINE, IRQ0_PRIO, isr0, 0, 0);
 	IRQ_CONNECT(IRQ1_LINE, IRQ1_PRIO, isr1, 0, 0);
-#else
+#elif defined(CONFIG_DYNAMIC_INTERRUPTS)
 	arch_irq_connect_dynamic(irq_line_0, IRQ0_PRIO, isr0, NULL, 0);
 	arch_irq_connect_dynamic(irq_line_1, IRQ1_PRIO, isr1, NULL, 0);
 #endif

--- a/tests/arch/common/interrupt/tests.yaml
+++ b/tests/arch/common/interrupt/tests.yaml
@@ -34,6 +34,21 @@ tests:
     extra_configs:
       - CONFIG_QEMU_ICOUNT=y
       - CONFIG_MINIMAL_LIBC=y
+  arch.interrupt.isr_table_switch:
+    platform_exclude:
+      - qemu_cortex_m0
+      # No trigger_irq implementation for the BCM2836 L1 + BCM2835 ARMC
+      # interrupt controller pair in interrupt_util.h yet.
+      - rpi_zero_2w
+    filter: >
+      not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_GEN_SW_ISR_TABLE_SWITCH_SUPPORTED
+    extra_configs:
+      # A generated switch-case table cannot be patched at runtime, which also
+      # rules out the shared interrupt support
+      - CONFIG_DYNAMIC_INTERRUPTS=n
+      - CONFIG_GEN_SW_ISR_TABLE_SWITCH=y
+    integration_platforms:
+      - mps2/an385
   arch.shared_interrupt:
     platform_exclude:
       # excluded because of failures during test_prevent_interruption

--- a/tests/kernel/common/tests.yaml
+++ b/tests/kernel/common/tests.yaml
@@ -68,6 +68,16 @@ tests:
     integration_platforms:
       - qemu_x86
       - mps2/an385
+  kernel.common.isr_table_switch:
+    platform_key:
+      - arch
+    filter: CONFIG_GEN_SW_ISR_TABLE_SWITCH_SUPPORTED
+    extra_configs:
+      # A generated switch-case table cannot be patched at runtime
+      - CONFIG_DYNAMIC_INTERRUPTS=n
+      - CONFIG_GEN_SW_ISR_TABLE_SWITCH=y
+    integration_platforms:
+      - mps2/an385
   kernel.common.lto:
     platform_key:
       - arch

--- a/tests/misc/test_build/tests.yaml
+++ b/tests/misc/test_build/tests.yaml
@@ -29,6 +29,15 @@ tests:
       - native_sim
     extra_configs:
       - CONFIG_KERNEL_BIN_NAME="A_kconfig_value_with_a_utf8_char_in_it_Bøe_"
+  buildsystem.isr_table_switch:
+    build_only: true
+    platform_allow:
+      - nucleo_f746zg
+      - nrf54l15dk/nrf54l15/cpuflpr
+    extra_configs:
+      # A generated switch-case table cannot be patched at runtime
+      - CONFIG_DYNAMIC_INTERRUPTS=n
+      - CONFIG_GEN_SW_ISR_TABLE_SWITCH=y
   buildsystem.lto.picolibc_module:
     build_only: true
     platform_allow:


### PR DESCRIPTION
CONFIG_GEN_SW_ISR_TABLE_SWITCH was not supported
for RISCV platform. This commit adds procedure in
isr handling that will retrive isr_table_entry data using get_isr_entry function.
Depending on platform this can provide large CODE
memory savings.