### PR TITLE
FRDM-MCXL255: enable FRDM-MCXL255 CM0+ AON LPTMR

### DIFF
--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -127,6 +127,12 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_GateAonUART);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lptmr0))
+	CLOCK_AttachClk(kFRO16K_to_AON_LPTMR);
+	RESET_ReleasePeripheralReset(kAonLPTMR_RST_SHIFT_RSTn);
+	CLOCK_EnableClock(kCLOCK_GateAonLPTMR);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(rtc))
 	if (!CLOCK_IsRoscInitialized()) {
 		rosc_init_config_t rosc_init_config;

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
@@ -35,3 +35,7 @@
 &systick {
 	status = "okay";
 };
+
+&lptmr0 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
@@ -12,4 +12,5 @@ toolchain:
   - gnuarmemb
 supported:
   - uart
+  - counter
 vendor: nxp

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm0.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm0.dtsi
@@ -47,3 +47,18 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&aon_peripheral {
+	lptmr0: lptmr@88000 {
+		compatible = "nxp,lptmr";
+		reg = <0x88000 0x1000>;
+		interrupts = <28 0>;
+		clock-frequency = <16000>;
+		clk-source = <1>;
+		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
+		timer-mode-sel = <0>;
+		resolution = <32>;
+		status = "disabled";
+	};
+};


### PR DESCRIPTION
Add AON LPTMR support for the FRDM-MCXL255 CM0+ target.

This adds the MCXL25x CM0+ AON LPTMR devicetree node, enables it on the
FRDM-MCXL255 CM0+ board, and configures the required AON clock and reset
setup.

Tested with:
- Custom AON LPTMR counter smoke test on frdm_mcxl255/mcxl255/cpu1

Note:
- tests/drivers/counter/counter_basic_api was not used because it does not fit into the CM0+ 32KB RAM.
