### PR TITLE
drivers: sensor: Implement i2c adapter layer

### DIFF
--- a/drivers/sensor/sensirion/CMakeLists.txt
+++ b/drivers/sensor/sensirion/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # zephyr-keep-sorted-start
+add_subdirectory(common)
 add_subdirectory_ifdef(CONFIG_SCD4X scd4x)
 add_subdirectory_ifdef(CONFIG_SGP40 sgp40)
 add_subdirectory_ifdef(CONFIG_SHT3XD sht3xd)

--- a/drivers/sensor/sensirion/common/CMakeLists.txt
+++ b/drivers/sensor/sensirion/common/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Sensirion
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+zephyr_library()
+
+zephyr_library_sources(conversions.c)
+zephyr_library_sources(i2c_packet.c)
+zephyr_library_sources(i2c_general_call_reset.c)

--- a/drivers/sensor/sensirion/common/conversions.c
+++ b/drivers/sensor/sensirion/common/conversions.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Sensirion
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "conversions.h"
+
+float sensirion_conversions_bytes_to_float(const uint8_t *const bytes)
+{
+	union {
+		uint32_t u32_value;
+		float float32;
+	} tmp;
+
+	tmp.u32_value = sys_get_be32(bytes);
+	return tmp.float32;
+}
+
+void sensirion_conversions_to_integer(const uint8_t *const source, uint8_t *const destination,
+				      size_t destination_size, uint8_t data_length)
+{
+	if (data_length > destination_size) {
+		memset(destination, 0xFF, destination_size);
+		return;
+	}
+	/* set all bytes in destination to 0 to make sure that the value is correct even if the
+	 * data_length is smaller than the size of the integer type
+	 */
+	memset(destination, 0, destination_size);
+
+	/* copy the bytes from source to destination. The source is in big-endian/MSB-first format,
+	 * so the first byte of the source is the most significant byte. The destination should be
+	 * filled in the correct order for the system endianness.
+	 */
+	if (IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
+		for (uint8_t i = 1; i <= data_length; i++) {
+			destination[data_length - i] = source[i - 1u];
+		}
+	} else {
+		memcpy(&destination[destination_size - data_length], source, data_length);
+	}
+}

--- a/drivers/sensor/sensirion/common/conversions.h
+++ b/drivers/sensor/sensirion/common/conversions.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Sensirion
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CONVERSIONS_H
+#define CONVERSIONS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <zephyr/sys/byteorder.h>
+
+/**
+ * NO_ERROR is used as alias for 0 return values of functions to improve
+ * readability of the code.
+ */
+#define NO_ERROR 0
+
+/**
+ * @defgroup API to deserialize basic data types from a byte array
+ *
+ * Sensirion drivers follow a very strict design pattern wich is OS and
+ * platform independent. As part of this pattern, the drivers
+ * require a common API for converting byte arrays to basic data types.
+ *
+ * The following functions provide a Zephyr specific implementation of
+ * this API.
+ *
+ * The function names in this API use the pattern bytes_to_<type> to
+ * indicate conversions from byte arrays to basic data types.
+ * @{
+ */
+
+/**
+ * Convert an array of bytes to a float
+ *
+ * Convert an array of bytes received from the sensor in big-endian/MSB-first
+ * format to an float value in the correct system-endianness.
+ *
+ * @param bytes An array of at least four bytes (MSB first)
+ * @return      The byte array represented as float
+ */
+float sensirion_conversions_bytes_to_float(const uint8_t *const bytes);
+
+/**
+ * Convert an array of bytes to a 16-bit signed integer.
+ *
+ * @param bytes
+ * @return int16_t
+ */
+static inline int16_t sensirion_conversions_bytes_to_int16_t(const uint8_t bytes[2])
+{
+	return (int16_t)sys_get_be16(bytes);
+}
+
+/**
+ * Convert an array of bytes to a 16-bit unsigned integer.
+ *
+ * @param bytes
+ * @return uint16_t
+ */
+static inline uint16_t sensirion_conversions_bytes_to_uint16_t(const uint8_t bytes[2])
+{
+	return sys_get_be16(bytes);
+}
+
+/**
+ * Convert an array of bytes to a 32-bit signed integer.
+ *
+ * @param bytes
+ * @return int32_t
+ */
+static inline int32_t sensirion_conversions_bytes_to_int32_t(const uint8_t bytes[4])
+{
+	return (int32_t)sys_get_be32(bytes);
+}
+
+/**
+ * Convert an array of bytes to a 32-bit unsigned integer.
+ *
+ * @param bytes
+ * @return uint32_t
+ */
+static inline uint32_t sensirion_conversions_bytes_to_uint32_t(const uint8_t bytes[4])
+{
+	return sys_get_be32(bytes);
+}
+
+/**
+ * Convert an array of bytes to a 64-bit signed integer.
+ *
+ * @param bytes
+ * @return int64_t
+ */
+static inline int64_t sensirion_conversions_bytes_to_int64_t(const uint8_t bytes[8])
+{
+	return (int64_t)sys_get_be64(bytes);
+}
+
+/**
+ * @brief Convert an array of bytes to a 64-bit unsigned integer.
+ *
+ * @param bytes
+ * @return uint64_t
+ */
+static inline uint64_t sensirion_conversions_bytes_to_uint64_t(const uint8_t bytes[8])
+{
+	return sys_get_be64(bytes);
+}
+
+/** @} */
+
+/**
+ *  Copy bytes from byte array to an integer of the specified type.
+ *
+ * The byte array is expected to be in big-endian/MSB-first format as it is
+ * received from the sensor.
+ * The data_length specifies how many bytes are available in the source byte
+ * array to copy.
+ * This length may not match the size of the destination integer.
+ * In this case the function will fill the missing bytes with zeros or
+ * set the destination to 0 if it is smaller than the source.
+ *
+ * @param source      Array of bytes to be copied.
+ * @param destination Pointer to integer that will be filled with the copied
+ *                    data.
+ * @param destination_size Size of the destination integer in bytes.
+ * @param data_length Number of available bytes in source to copy.
+ */
+void sensirion_conversions_to_integer(const uint8_t *const source, uint8_t *const destination,
+				      size_t destination_size, uint8_t data_length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONVERSIONS_H */

--- a/drivers/sensor/sensirion/common/i2c_general_call_reset.c
+++ b/drivers/sensor/sensirion/common/i2c_general_call_reset.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Sensirion
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "i2c_general_call_reset.h"
+#include <zephyr/device.h>
+
+int sensirion_i2c_general_call_reset(const struct i2c_dt_spec *i2c_spec)
+{
+	const uint8_t data = 0x06;
+	const uint8_t i2c_address = 0x00;
+
+	return i2c_write(i2c_spec->bus, &data, sizeof(data), i2c_address);
+}

--- a/drivers/sensor/sensirion/common/i2c_general_call_reset.h
+++ b/drivers/sensor/sensirion/common/i2c_general_call_reset.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Sensirion
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef I2C_GENERAL_CALL_RESET_H
+#define I2C_GENERAL_CALL_RESET_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <zephyr/drivers/i2c.h>
+
+/**
+ * Send a general call reset on the i2c bus.
+ *
+ * This function is used in drivers that implement a call reset.
+ *
+ * @warning This will reset all attached I2C devices on the bus which support
+ *          general call reset.
+ *
+ * @param i2c_spec  Sensor I2C specification
+ *
+ * @return  0 on success, an error code otherwise
+ */
+int sensirion_i2c_general_call_reset(const struct i2c_dt_spec *i2c_spec);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* I2C_GENERAL_CALL_RESET_H */

--- a/drivers/sensor/sensirion/common/i2c_packet.c
+++ b/drivers/sensor/sensirion/common/i2c_packet.c
@@ -23,7 +23,7 @@ uint8_t sensirion_i2c_packet_get_crc(const i2c_packet_t *const i2c_packet, uint1
 bool sensirion_i2c_packet_check_crc(const i2c_packet_t *const i2c_packet, uint16_t index)
 {
 	return sensirion_i2c_packet_get_crc(i2c_packet, index) ==
-	    i2c_packet->data[index + SENSIRION_WORD_SIZE];
+	       i2c_packet->data[index + SENSIRION_WORD_SIZE];
 }
 
 uint16_t sensirion_i2c_packet_add_command16(i2c_packet_t *const i2c_packet, uint16_t offset,

--- a/drivers/sensor/sensirion/common/i2c_packet.c
+++ b/drivers/sensor/sensirion/common/i2c_packet.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Sensirion
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "i2c_packet.h"
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/sys/crc.h>
+#include <zephyr/sys/byteorder.h>
+
+#define SENSIRION_WORD_SIZE 2u
+#define SENSIRION_CRC8_LEN  1u
+
+uint8_t sensirion_i2c_packet_get_crc(const i2c_packet_t *const i2c_packet, uint16_t index)
+{
+	return crc8(&i2c_packet->data[index], SENSIRION_WORD_SIZE, i2c_packet->crc8_poly,
+		    i2c_packet->crc8_init, false);
+}
+
+bool sensirion_i2c_packet_check_crc(const i2c_packet_t *const i2c_packet, uint16_t index)
+{
+	return sensirion_i2c_packet_get_crc(i2c_packet, index) ==
+	    i2c_packet->data[index + SENSIRION_WORD_SIZE];
+}
+
+uint16_t sensirion_i2c_packet_add_command16(i2c_packet_t *const i2c_packet, uint16_t offset,
+					    uint16_t command)
+{
+	sys_put_be16(command, &i2c_packet->data[offset]);
+	offset += 2;
+	return offset;
+}
+
+uint16_t sensirion_i2c_packet_add_command8(i2c_packet_t *const i2c_packet, uint16_t offset,
+					   uint8_t command)
+{
+	i2c_packet->data[offset++] = command;
+	return offset;
+}
+
+uint16_t sensirion_i2c_packet_add_uint64_t(i2c_packet_t *const i2c_packet, uint16_t offset,
+					   uint64_t data)
+{
+	offset = sensirion_i2c_packet_add_uint32_t(i2c_packet, offset, data >> 32u);
+	offset = sensirion_i2c_packet_add_uint32_t(i2c_packet, offset, data & 0xFFFFFFFFu);
+	return offset;
+}
+
+uint16_t sensirion_i2c_packet_add_int64_t(i2c_packet_t *const i2c_packet, uint16_t offset,
+					  int64_t data)
+{
+	return sensirion_i2c_packet_add_uint64_t(i2c_packet, offset, (uint64_t)data);
+}
+
+uint16_t sensirion_i2c_packet_add_uint32_t(i2c_packet_t *const i2c_packet, uint16_t offset,
+					   uint32_t data)
+{
+	offset = sensirion_i2c_packet_add_uint16_t(i2c_packet, offset, data >> 16u);
+	offset = sensirion_i2c_packet_add_uint16_t(i2c_packet, offset, data & 0xFFFFu);
+
+	return offset;
+}
+
+uint16_t sensirion_i2c_packet_add_int32_t(i2c_packet_t *const i2c_packet, uint16_t offset,
+					  int32_t data)
+{
+	return sensirion_i2c_packet_add_uint32_t(i2c_packet, offset, (uint32_t)data);
+}
+
+uint16_t sensirion_i2c_packet_add_uint16_t(i2c_packet_t *const i2c_packet, uint16_t offset,
+					   uint16_t data)
+{
+	sys_put_be16(data, &i2c_packet->data[offset]);
+	offset += 2;
+	if (i2c_packet->crc8_poly != 0) {
+		i2c_packet->data[offset] =
+			sensirion_i2c_packet_get_crc(i2c_packet, offset - SENSIRION_WORD_SIZE);
+		offset++;
+	}
+	return offset;
+}
+
+uint16_t sensirion_i2c_packet_add_int16_t(i2c_packet_t *const i2c_packet, uint16_t offset,
+					  int16_t data)
+{
+	return sensirion_i2c_packet_add_uint16_t(i2c_packet, offset, (uint16_t)data);
+}
+
+uint16_t sensirion_i2c_packet_add_float(i2c_packet_t *const i2c_packet, uint16_t offset, float data)
+{
+	union {
+		uint32_t uint32_data;
+		float float_data;
+	} convert;
+
+	convert.float_data = data;
+	return sensirion_i2c_packet_add_uint32_t(i2c_packet, offset, convert.uint32_data);
+}
+
+uint16_t sensirion_i2c_packet_add_bytes(i2c_packet_t *const i2c_packet, uint16_t offset,
+					const uint8_t *const data, uint16_t data_length)
+{
+	if (data_length % SENSIRION_WORD_SIZE != 0u) {
+		return -EINVAL;
+	}
+
+	for (uint16_t i = 0u; i < data_length; i += SENSIRION_WORD_SIZE) {
+		memcpy(&i2c_packet->data[offset], &data[i], SENSIRION_WORD_SIZE);
+		offset += SENSIRION_WORD_SIZE;
+		if (i2c_packet->crc8_poly != 0u) {
+			i2c_packet->data[offset] = sensirion_i2c_packet_get_crc(
+				i2c_packet, offset - SENSIRION_WORD_SIZE);
+			offset++;
+		}
+	}
+	return offset;
+}
+
+int sensirion_i2c_packet_write(const i2c_packet_t *const i2c_packet, uint16_t data_length,
+			       const struct i2c_dt_spec *const i2c_spec)
+{
+	return i2c_write_dt(i2c_spec, i2c_packet->data, data_length);
+}
+
+int sensirion_i2c_packet_read(const i2c_packet_t *const i2c_packet, uint16_t expected_data_length,
+			      const struct i2c_dt_spec *const i2c_spec)
+{
+	int ret;
+	uint16_t crc_len = (i2c_packet->crc8_poly != 0u) ? SENSIRION_CRC8_LEN : 0u;
+	uint16_t size =
+		(expected_data_length / SENSIRION_WORD_SIZE) * (SENSIRION_WORD_SIZE + crc_len);
+
+	if (expected_data_length % SENSIRION_WORD_SIZE != 0u) {
+		return -EINVAL;
+	}
+
+	ret = i2c_read_dt(i2c_spec, i2c_packet->data, size);
+	if (ret != 0) {
+		return ret;
+	}
+
+	for (uint16_t i = 0u, j = 0u; i < size;
+	     i += SENSIRION_WORD_SIZE + crc_len, j += SENSIRION_WORD_SIZE) {
+
+		if (i2c_packet->crc8_poly != 0u && !sensirion_i2c_packet_check_crc(i2c_packet, i)) {
+			return -EIO;
+		}
+		memcpy(&i2c_packet->data[j], &i2c_packet->data[i], SENSIRION_WORD_SIZE);
+	}
+
+	return 0;
+}

--- a/drivers/sensor/sensirion/common/i2c_packet.h
+++ b/drivers/sensor/sensirion/common/i2c_packet.h
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2026 Sensirion
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef I2C_PACKET_H
+#define I2C_PACKET_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <zephyr/drivers/i2c.h>
+
+/**
+ * @brief Structure to define a Sensirion i2c packet.
+ *
+ * Sensirion sensors use 16-bit words on the I2C layer. Each word is usually
+ * followed by a CRC8 checksum byte.
+ * The i2c_packet structure is used to hold the data, as
+ * well as the CRC8 definition and the maximum length of the data array.
+ *
+ * The maximum length of the array is used to prevent buffer overflows
+ * when accessing the data buffer.
+ */
+typedef struct {
+
+	/** CRC8 definition data */
+	uint8_t crc8_poly; /**< CRC8 polynomial for calculating the CRC8. */
+	uint8_t crc8_init; /**< Initial value for the CRC8 calculation. */
+
+	/** Maximum length of data buffer */
+	uint8_t max_length; /**< Maximum length of the data array. */
+
+	/** Pointer to the data buffer */
+	uint8_t *data; /**< Pointer to the data array. */
+} i2c_packet_t;
+
+/**
+ * @brief Calculate the CRC8 for a word in the i2c_packet at position <index>.
+ *
+ * @param i2c_packet Pointer to the i2c_packet containing the data for which the
+ *                   CRC8 will be calculated.
+ * @param index      Index of the word in the data array for which the CRC8 will
+ *                   be calculated.
+ * @return uint8_t Calculated CRC8 value.
+ */
+uint8_t sensirion_i2c_packet_get_crc(const i2c_packet_t *const i2c_packet, uint16_t index);
+
+/**
+ * @brief Check the CRC8 for a word in the i2c_packet at position <index>.
+ *
+ * @param i2c_packet Pointer to the i2c_packet containing the data for which the
+ *                   CRC8 will be checked.
+ * @param index  Index of the word in the data array for which the CRC8 will
+ *               be checked.
+ * @return true  If the CRC8 is valid.
+ * @return false If the CRC8 is invalid.
+ */
+bool sensirion_i2c_packet_check_crc(const i2c_packet_t *const i2c_packet, uint16_t index);
+
+/**
+ * Add a command to the i2c_packet at the specified offset.
+ *
+ * Most sensirion Sensors use 16 bit commands. This function adds a 2 bytes
+ * to the i2c_packet.
+ *
+ * @param i2c_packet  Pointer to i2c_packet in which the write frame will be prepared.
+ *                Caller needs to make sure that there is enough space after
+ *                offset left to write the data into the i2c_packet.
+ * @param offset  Offset of the next free byte in the i2c_packet.
+ * @param command Command to be written into the i2c_packet.
+ *
+ * @return Offset of next free byte in the i2c_packet after writing the data.
+ */
+uint16_t sensirion_i2c_packet_add_command16(i2c_packet_t *const i2c_packet, uint16_t offset,
+					    uint16_t command);
+
+/**
+ * Add a command to the i2c_packet at the specified offset.
+ *
+ * Adds one byte command to the i2c_packet.
+ * This is used for sensors that only take one command byte such as SHT.
+ *
+ * @param i2c_packet  Pointer to i2c_packet in which the write frame will be prepared.
+ *                Caller needs to make sure that there is enough space after
+ *                offset left to write the data into the i2c_packet.
+ * @param offset  Offset of the next free byte in the i2c_packet.
+ * @param command Command to be written into the i2c_packet.
+ *
+ * @return Offset of next free byte in the i2c_packet after writing the data.
+ */
+uint16_t sensirion_i2c_packet_add_command8(i2c_packet_t *const i2c_packet, uint16_t offset,
+					   uint8_t command);
+
+/**
+ * Add a uint64_t to the i2c_packet at the specified offset.
+ *
+ * Adds 12 bytes to the i2c_packet.
+ *
+ * @param i2c_packet  Pointer to i2c_packet in which the write frame will be prepared.
+ *                Caller needs to make sure that there is enough space after
+ *                offset left to write the data into the i2c_packet.
+ * @param offset  Offset of the next free byte in the i2c_packet.
+ * @param data    uint64_t to be written into the i2c_packet.
+ *
+ * @return Offset of next free byte in the i2c_packet after writing the data.
+ */
+uint16_t sensirion_i2c_packet_add_uint64_t(i2c_packet_t *const i2c_packet, uint16_t offset,
+					   uint64_t data);
+
+/**
+ * Add a uint32_t to the i2c_packet at the specified offset.
+ *
+ * Adds 6 bytes to the i2c_packet.
+ *
+ * @param i2c_packet  Pointer to i2c_packet in which the write frame will be prepared.
+ *                Caller needs to make sure that there is enough space after
+ *                offset left to write the data into the i2c_packet.
+ * @param offset  Offset of the next free byte in the i2c_packet.
+ * @param data    uint32_t to be written into the i2c_packet.
+ *
+ * @return Offset of next free byte in the i2c_packet after writing the data.
+ */
+uint16_t sensirion_i2c_packet_add_uint32_t(i2c_packet_t *const i2c_packet, uint16_t offset,
+					   uint32_t data);
+
+/**
+ * Add a int32_t to the i2c_packet at the specified offset.
+ *
+ * Adds 6 bytes to the i2c_packet.
+ *
+ * @param i2c_packet  Pointer to i2c_packet in which the write frame will be prepared.
+ *                Caller needs to make sure that there is enough space after
+ *                offset left to write the data into the i2c_packet.
+ * @param offset  Offset of the next free byte in the i2c_packet.
+ * @param data    int32_t to be written into the i2c_packet.
+ *
+ * @return Offset of next free byte in the i2c_packet after writing the data.
+ */
+uint16_t sensirion_i2c_packet_add_int32_t(i2c_packet_t *const i2c_packet, uint16_t offset,
+					  int32_t data);
+
+/**
+ * Add a uint16_t to the i2c_packet at the specified offset. Adds 3 bytes to the i2c_packet.
+ *
+ * @param i2c_packet  Pointer to i2c_packet in which the write frame will be prepared.
+ *                Caller needs to make sure that there is enough space after
+ *                offset left to write the data into the i2c_packet.
+ * @param offset  Offset of the next free byte in the i2c_packet.
+ * @param data    uint16_t to be written into the i2c_packet.
+ *
+ * @return Offset of next free byte in the i2c_packet after writing the data.
+ */
+uint16_t sensirion_i2c_packet_add_uint16_t(i2c_packet_t *const i2c_packet, uint16_t offset,
+					   uint16_t data);
+
+/**
+ * Add a int16_t to the i2c_packet at the specified offset. Adds 3 bytes to the i2c_packet.
+ *
+ * @param i2c_packet  Pointer to i2c_packet in which the write frame will be prepared.
+ *                Caller needs to make sure that there is enough space after
+ *                offset left to write the data into the i2c_packet.
+ * @param offset  Offset of the next free byte in the i2c_packet.
+ * @param data    int16_t to be written into the i2c_packet.
+ *
+ * @return Offset of next free byte in the i2c_packet after writing the data.
+ */
+uint16_t sensirion_i2c_packet_add_int16_t(i2c_packet_t *const i2c_packet, uint16_t offset,
+					  int16_t data);
+
+/**
+ * Add a float to the i2c_packet at the specified offset. Adds 6 bytes to the i2c_packet.
+ *
+ * @param i2c_packet  Pointer to i2c_packet in which the write frame will be prepared.
+ *                Caller needs to make sure that there is enough space after
+ *                offset left to write the data into the i2c_packet.
+ * @param offset  Offset of the next free byte in the i2c_packet.
+ * @param data    float to be written into the i2c_packet.
+ *
+ * @return Offset of next free byte in the i2c_packet after writing the data.
+ */
+uint16_t sensirion_i2c_packet_add_float(i2c_packet_t *const i2c_packet, uint16_t offset,
+					float data);
+
+/**
+ * Add a byte array to the i2c_packet at the specified offset.
+ *
+ * @param i2c_packet  Pointer to i2c_packet in which the write frame will be
+ *                    prepared. Caller needs to make sure that there is
+ *                    enough space after offset left to write the data
+ *                    into the i2c_packet.
+ * @param offset      Offset of the next free byte in the i2c_packet.
+ * @param data        Pointer to data to be written into the i2c_packet.
+ * @param data_length Number of bytes to be written into the i2c_packet. Needs to
+ *                    be a multiple of SENSIRION_WORD_SIZE otherwise the
+ *                    function returns an error code.
+ *
+ * @return            Offset of next free byte in the i2c_packet after writing the
+ *                    data.
+ */
+uint16_t sensirion_i2c_packet_add_bytes(i2c_packet_t *const i2c_packet, uint16_t offset,
+					const uint8_t *const data, uint16_t data_length);
+
+/**
+ * Writes the i2c_packet to the Sensor.
+ *
+ * @param i2c_packet   Pointer to the i2c_packet containing the data to write.
+ * @param data_length  Number of bytes to send to the Sensor.
+ * @param i2c_spec     Sensor I2C specification
+ *
+ * @return        0 on success, error code otherwise
+ */
+int sensirion_i2c_packet_write(const i2c_packet_t *const i2c_packet, uint16_t data_length,
+			       const struct i2c_dt_spec *const i2c_spec);
+
+/**
+ * Reads data from the Sensor.
+ *
+ * @param i2c_packet           Pointer to i2c_packet to store data as bytes. Needs
+ *                             to be big enough to store the data including
+ *                             CRC. Twice the size of data should always
+ *                             suffice.
+ * @param expected_data_length Number of bytes to read (without CRC). Needs
+ *                             to be a multiple of SENSIRION_WORD_SIZE,
+ *                             otherwise the function returns an error code.
+ * @param i2c_spec             Sensor I2C specification
+ *
+ * @return                     0 on success, an error code otherwise
+ */
+int sensirion_i2c_packet_read(const i2c_packet_t *const i2c_packet, uint16_t expected_data_length,
+			      const struct i2c_dt_spec *const i2c_spec);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* I2C_PACKET_H */

--- a/drivers/sensor/sensirion/sts4x/Kconfig
+++ b/drivers/sensor/sensirion/sts4x/Kconfig
@@ -1,13 +1,13 @@
-# Drivers configuration options for Sensirion STS4x
+# STS4X sensor configuration options.
 
-# Copyright (c) 2024 Jan Fäh
+# Copyright (c) 2026, Sensirion AG
 # SPDX-License-Identifier: Apache-2.0
 
 config STS4X
-	bool "STS4x Temperature Sensor"
+	bool "STS4X Sensor"
 	default y
 	depends on DT_HAS_SENSIRION_STS4X_ENABLED
 	select I2C
 	select CRC
 	help
-	  Enable driver for the Sensirion STS4x temperature sensors.
+	  Enable driver for STS4X Sensor

--- a/drivers/sensor/sensirion/sts4x/sts4x.c
+++ b/drivers/sensor/sensirion/sts4x/sts4x.c
@@ -1,168 +1,252 @@
 /*
- * Copyright (c) 2024 Jan Fäh
+ * Copyright (c) 2026 Sensirion
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #define DT_DRV_COMPAT sensirion_sts4x
 
+#include "sts4x.h"
+#include "../common/conversions.h"
+#include "../common/i2c_packet.h"
+
 #include <zephyr/device.h>
-#include <zephyr/kernel.h>
-#include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys/__assert.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/crc.h>
-#include <zephyr/devicetree.h>
 
-LOG_MODULE_REGISTER(STS4X, CONFIG_SENSOR_LOG_LEVEL);
+#include <zephyr/drivers/sensor/sts4x.h>
 
-#define STS4X_CMD_RESET 0x94
+LOG_MODULE_REGISTER(STS4x, CONFIG_SENSOR_LOG_LEVEL);
 
-#define STS4X_RESET_TIME 1
+static const struct i2c_dt_spec *i2c_spec;
 
-#define STS4X_CRC_POLY 0x31
-#define STS4X_CRC_INIT 0xFF
+static uint8_t communication_buffer[6] = {0};
 
-#define STS4X_MAX_TEMP 175
-#define STS4X_MIN_TEMP -45
+static i2c_packet_t packet = {
+	.crc8_poly = 0x31, .crc8_init = 0xff, .max_length = 6, .data = communication_buffer};
 
-struct sts4x_config {
-	struct i2c_dt_spec bus;
-	uint8_t repeatability;
-};
+static uint8_t _repeatability;
 
-struct sts4x_data {
-	uint16_t temp_sample;
-};
-
-static const uint8_t measure_cmds[3] = {0xE0, 0xF6, 0xFD};
-static const uint16_t measure_time_us[3] = {1600, 4500, 8300};
-
-static int sts4x_crc_check(uint16_t value, uint8_t sensor_crc)
+int sts4x_measure_temperature_high_precision(uint16_t *temperature_ticks)
 {
-	uint8_t buf[2];
+	int ret = NO_ERROR;
+	uint16_t local_offset = 0U;
 
-	sys_put_be16(value, buf);
-
-	uint8_t calculated_crc = crc8(buf, 2, STS4X_CRC_POLY, STS4X_CRC_INIT, false);
-
-	if (calculated_crc == sensor_crc) {
-		return 0;
-	}
-
-	return -EIO;
-}
-
-static int sts4x_write_command(const struct device *dev, uint8_t cmd)
-{
-	const struct sts4x_config *cfg = dev->config;
-	uint8_t tx_buf = cmd;
-
-	return i2c_write_dt(&cfg->bus, &tx_buf, 1);
-}
-
-static int sts4x_read_sample(const struct device *dev, uint16_t *temp_sample)
-{
-	const struct sts4x_config *cfg = dev->config;
-	uint8_t rx_buf[3];
-	int ret;
-
-	ret = i2c_read_dt(&cfg->bus, rx_buf, sizeof(rx_buf));
-	if (ret < 0) {
-		LOG_ERR("Failed to read data.");
+	local_offset = sensirion_i2c_packet_add_command8(
+		&packet, local_offset, STS4X_MEASURE_TEMPERATURE_HIGH_PRECISION_CMD_ID);
+	ret = sensirion_i2c_packet_write(&packet, local_offset, i2c_spec);
+	if (ret != NO_ERROR) {
 		return ret;
 	}
-
-	*temp_sample = sys_get_be16(rx_buf);
-	ret = sts4x_crc_check(*temp_sample, rx_buf[2]);
-	if (ret < 0) {
-		LOG_ERR("Invalid CRC.");
+	k_msleep(9U);
+	ret = sensirion_i2c_packet_read(&packet, 2, i2c_spec);
+	if (ret != NO_ERROR) {
 		return ret;
 	}
+	*temperature_ticks = sensirion_conversions_bytes_to_uint16_t(&packet.data[0]);
+	return ret;
+}
 
-	return 0;
+int sts4x_measure_temperature_medium_precision(uint16_t *temperature_ticks)
+{
+	int ret = NO_ERROR;
+	uint16_t local_offset = 0U;
+
+	local_offset = sensirion_i2c_packet_add_command8(
+		&packet, local_offset, STS4X_MEASURE_TEMPERATURE_MEDIUM_PRECISION_CMD_ID);
+	ret = sensirion_i2c_packet_write(&packet, local_offset, i2c_spec);
+	if (ret != NO_ERROR) {
+		return ret;
+	}
+	k_msleep(5U);
+	ret = sensirion_i2c_packet_read(&packet, 2, i2c_spec);
+	if (ret != NO_ERROR) {
+		return ret;
+	}
+	*temperature_ticks = sensirion_conversions_bytes_to_uint16_t(&packet.data[0]);
+	return ret;
+}
+
+int sts4x_measure_temperature_low_precision(uint16_t *temperature_ticks)
+{
+	int ret = NO_ERROR;
+	uint16_t local_offset = 0U;
+
+	local_offset = sensirion_i2c_packet_add_command8(
+		&packet, local_offset, STS4X_MEASURE_TEMPERATURE_LOW_PRECISION_CMD_ID);
+	ret = sensirion_i2c_packet_write(&packet, local_offset, i2c_spec);
+	if (ret != NO_ERROR) {
+		return ret;
+	}
+	k_msleep(2U);
+	ret = sensirion_i2c_packet_read(&packet, 2, i2c_spec);
+	if (ret != NO_ERROR) {
+		return ret;
+	}
+	*temperature_ticks = sensirion_conversions_bytes_to_uint16_t(&packet.data[0]);
+	return ret;
+}
+
+int sts4x_read_serial_number(uint32_t *serial_number)
+{
+	int ret = NO_ERROR;
+	uint16_t local_offset = 0U;
+
+	local_offset = sensirion_i2c_packet_add_command8(&packet, local_offset,
+							 STS4X_READ_SERIAL_NUMBER_CMD_ID);
+	ret = sensirion_i2c_packet_write(&packet, local_offset, i2c_spec);
+	if (ret != NO_ERROR) {
+		return ret;
+	}
+	k_msleep(1U);
+	ret = sensirion_i2c_packet_read(&packet, 4, i2c_spec);
+	if (ret != NO_ERROR) {
+		return ret;
+	}
+	*serial_number = sensirion_conversions_bytes_to_uint32_t(&packet.data[0]);
+	return ret;
+}
+
+int sts4x_soft_reset(void)
+{
+	int ret = NO_ERROR;
+	uint16_t local_offset = 0U;
+
+	local_offset =
+		sensirion_i2c_packet_add_command8(&packet, local_offset, STS4X_SOFT_RESET_CMD_ID);
+	ret = sensirion_i2c_packet_write(&packet, local_offset, i2c_spec);
+	if (ret != NO_ERROR) {
+		return ret;
+	}
+	k_msleep(1U);
+	return ret;
+}
+
+float sts4x_signal_ticks_to_celsius(uint16_t temperature_ticks)
+{
+	float ticks = 0.0;
+	float ticks_to_celsius = 0.0;
+
+	ticks = (float)(temperature_ticks);
+	ticks_to_celsius = -45.0f + ((175.0f * ticks) / 65535.0f);
+	return ticks_to_celsius;
+}
+
+float sts4x_signal_ticks_to_fahrenheit(uint16_t temperature_ticks)
+{
+	float ticks = 0.0;
+	float ticks_to_fahrenheit = 0.0;
+
+	ticks = (float)(temperature_ticks);
+	ticks_to_fahrenheit = -49.0f + ((315.0f * ticks) / 65535.0f);
+	return ticks_to_fahrenheit;
+}
+
+void sts4x_set_repeatability(uint8_t rep)
+{
+	if (rep > 2) {
+		return;
+	}
+	_repeatability = rep;
+}
+
+int sts4x_read_measurement_raw(uint16_t *temperature_ticks)
+{
+	int ret = 0;
+
+	if (_repeatability == 0) {
+		ret = sts4x_measure_temperature_low_precision(temperature_ticks);
+		return ret;
+	} else if (_repeatability == 1) {
+		ret = sts4x_measure_temperature_medium_precision(temperature_ticks);
+		return ret;
+	} else if (_repeatability == 2) {
+		ret = sts4x_measure_temperature_high_precision(temperature_ticks);
+		return ret;
+	}
+	return ret;
 }
 
 static int sts4x_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct sts4x_data *data = dev->data;
-	const struct sts4x_config *cfg = dev->config;
-	int ret;
+	int ret = 0;
 
-	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP) {
-		ret = sts4x_write_command(dev, measure_cmds[cfg->repeatability]);
-		if (ret < 0) {
-			LOG_ERR("Failed to write measure command.");
-			return ret;
-		}
-
-		k_usleep(measure_time_us[cfg->repeatability]);
-
-		ret = sts4x_read_sample(dev, &data->temp_sample);
-		if (ret < 0) {
-			LOG_ERR("Failed to get temperature data.");
-			return ret;
-		}
-
-		return 0;
+	if (chan == SENSOR_CHAN_AMBIENT_TEMP || chan == SENSOR_CHAN_ALL) {
+		ret = sts4x_read_measurement_raw(&data->temperature_ticks);
 	} else {
+		LOG_ERR("Channel not supported.");
 		return -ENOTSUP;
 	}
+
+	if (ret != NO_ERROR) {
+		LOG_ERR("Failed to sample fetch.");
+		return ret;
+	}
+	return 0;
 }
 
 static int sts4x_channel_get(const struct device *dev, enum sensor_channel chan,
 			     struct sensor_value *val)
 {
-	const struct sts4x_data *data = dev->data;
+	struct sts4x_data *data = dev->data;
+	int ret = 0;
 
 	if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
-		int64_t temp;
+		float local_var = sts4x_signal_ticks_to_celsius(data->temperature_ticks);
 
-		temp = data->temp_sample * STS4X_MAX_TEMP;
-		val->val1 = (int32_t)(temp / 0xFFFF) + STS4X_MIN_TEMP;
-		val->val2 = ((temp % 0xFFFF) * 1000000) / 0xFFFF;
+		ret = sensor_value_from_float(val, local_var);
 	} else {
+		LOG_ERR("Channel not supported.");
 		return -ENOTSUP;
 	}
-	return 0;
-}
 
-static int sts4x_init(const struct device *dev)
-{
-	const struct sts4x_config *cfg = dev->config;
-	int ret;
-
-	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
-		return -ENODEV;
-	}
-
-	ret = sts4x_write_command(dev, STS4X_CMD_RESET);
-	if (ret < 0) {
-		LOG_ERR("Failed to reset the device.");
+	if (ret != NO_ERROR) {
+		LOG_ERR("Failed to convert value.");
 		return ret;
 	}
 
-	k_msleep(STS4X_RESET_TIME);
-
 	return 0;
 }
 
-static DEVICE_API(sensor, sts4x_api_funcs) = {
+int sts4x_init(const struct device *dev)
+{
+	int ret = 0;
+
+	const struct sts4x_config *cfg = dev->config;
+
+	i2c_spec = &cfg->bus;
+
+	if (!i2c_is_ready_dt(&cfg->bus)) {
+		LOG_ERR("Device not ready.");
+		return -ENODEV;
+	}
+
+	sts4x_set_repeatability(cfg->repeatability);
+	ret = sts4x_soft_reset();
+	if (ret != NO_ERROR) {
+		LOG_ERR("error executing soft_reset(): %i\n", ret);
+		return ret;
+	}
+	return 0;
+}
+
+static DEVICE_API(sensor, sts4x_api) = {
 	.sample_fetch = sts4x_sample_fetch,
 	.channel_get = sts4x_channel_get,
 };
 
-#define STS4X_INIT(inst)                                                                           \
+#define STS4x_INIT(inst)                                                                           \
 	static struct sts4x_data sts4x_data_##inst;                                                \
+                                                                                                   \
 	static const struct sts4x_config sts4x_config_##inst = {                                   \
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.repeatability = DT_INST_PROP(inst, repeatability),                                \
 	};                                                                                         \
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, sts4x_init, NULL, &sts4x_data_##inst,                   \
 				     &sts4x_config_##inst, POST_KERNEL,                            \
-				     CONFIG_SENSOR_INIT_PRIORITY, &sts4x_api_funcs);
+				     CONFIG_SENSOR_INIT_PRIORITY, &sts4x_api);
 
-DT_INST_FOREACH_STATUS_OKAY(STS4X_INIT)
+DT_INST_FOREACH_STATUS_OKAY(STS4x_INIT)

--- a/drivers/sensor/sensirion/sts4x/sts4x.h
+++ b/drivers/sensor/sensirion/sts4x/sts4x.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Sensirion
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_STS4x_STS4x_H_
+#define ZEPHYR_DRIVERS_SENSOR_STS4x_STS4x_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+
+#define STS4X_I2C_ADDR_44 0x44
+#define STS4X_I2C_ADDR_45 0x45
+#define STS4X_I2C_ADDR_46 0x46
+
+typedef enum {
+	STS4X_MEASURE_TEMPERATURE_HIGH_PRECISION_CMD_ID = 0xfd,
+	STS4X_MEASURE_TEMPERATURE_MEDIUM_PRECISION_CMD_ID = 0xf6,
+	STS4X_MEASURE_TEMPERATURE_LOW_PRECISION_CMD_ID = 0xe0,
+	STS4X_READ_SERIAL_NUMBER_CMD_ID = 0x89,
+	STS4X_SOFT_RESET_CMD_ID = 0x94,
+} STS4X_CMD_ID;
+
+struct sts4x_config {
+	struct i2c_dt_spec bus;
+	uint8_t repeatability;
+};
+
+struct sts4x_data {
+	uint16_t temperature_ticks;
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_STS4x_STS4x_H_*/

--- a/dts/bindings/sensor/sensirion,sts4x.yaml
+++ b/dts/bindings/sensor/sensirion,sts4x.yaml
@@ -1,22 +1,22 @@
-# Copyright (c) 2024, Jan Fäh
+# Copyright (c) 2026, Sensirion AG
 # SPDX-License-Identifier: Apache-2.0
-
-description: Sensirion STS4x temperature sensor
 
 compatible: "sensirion,sts4x"
 
 include: [sensor-device.yaml, i2c-device.yaml]
 
+description: |
+  The STS4x is a 4th generation, high-accuracy, ultra-low-power, fully digital
+  temperature sensor platform with a 16-bit I2C interface.
+  Learn more: https://sensirion.com/products/product-categories/
+  Supported I2C addresses: 0x44(default), 0x45, 0x46
+
 properties:
   repeatability:
     type: int
-    required: true
+    default: 0
     description: |
-      Repeatability of the T Measurement
-      0 = low -> 1.6 ms
-      1 = med -> 4.5 ms
-      2 = high -> 8.3 ms
-    enum:
-      - 0
-      - 1
-      - 2
+      Set the repeatability. Default is 0.
+      - 0 -> low repeatability
+      - 1 -> medium repeatability
+      - 2 -> high repeatability

--- a/include/zephyr/drivers/sensor/sts4x.h
+++ b/include/zephyr/drivers/sensor/sts4x.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Sensirion
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for extended sensor API of STS4X sensor
+ * @ingroup sts4x_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_STS4x_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_STS4x_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Sensirion STS4x temperature sensor
+ * @defgroup sts4x_interface STS4X
+ * @ingroup sensor_interface_ext
+ * @{
+ */
+
+#include <zephyr/drivers/sensor.h>
+
+/**
+ * @brief Set the repeatability for the next measurement.
+ *
+ *
+ * * 0 -> low repeatability
+ * * 1 -> medium repeatability
+ * * 2 -> high repeatability
+ *
+ * @param[in] rep
+ *
+ */
+void sts4x_set_repeatability(uint8_t rep);
+
+/**
+ * @brief Read the unique serial number from OTP memory.
+ *
+ * @param[out] serial_number
+ *
+ * @return error_code 0 on success, an error code otherwise.
+ */
+int sts4x_read_serial_number(uint32_t *serial_number);
+
+/**
+ * @brief Perform a soft reset and return the sensor to idle state.
+ *
+ * @return error_code 0 on success, an error code otherwise.
+ */
+int sts4x_soft_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_STS4x_H_ */


### PR DESCRIPTION
This adapter layer provides functionality commonly required by Sensirion I²C drivers.

It implements the Sensirion protocol on top of I²C (i2c_packet) and provides a consistent set of conversion functions for unmarshalling sensor data into the corresponding host data types.

The i2c_general_call reset function is included as a convenience, since many Sensirion I²C sensors support this feature and, in some cases, it is the only available reset mechanism.