### PR TITLE
stm32: Add shsi support

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -149,6 +149,7 @@ int enabled_clock(uint32_t src_clk)
 	    ((src_clk == STM32_SRC_LSI) && IS_ENABLED(STM32_LSI_ENABLED)) ||
 	    ((src_clk == STM32_SRC_MSIS) && IS_ENABLED(STM32_MSIS_ENABLED)) ||
 	    ((src_clk == STM32_SRC_MSIK) && IS_ENABLED(STM32_MSIK_ENABLED)) ||
+	    ((src_clk == STM32_SRC_SHSI) && IS_ENABLED(STM32_SHSI_ENABLED)) ||
 	    ((src_clk == STM32_SRC_PLL1_P) && IS_ENABLED(STM32_PLL_P_ENABLED)) ||
 	    ((src_clk == STM32_SRC_PLL1_Q) && IS_ENABLED(STM32_PLL_Q_ENABLED)) ||
 	    ((src_clk == STM32_SRC_PLL1_R) && IS_ENABLED(STM32_PLL_R_ENABLED)) ||
@@ -313,6 +314,11 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 		*rate = STM32_HSI48_FREQ;
 		break;
 #endif /* STM32_HSI48_ENABLED */
+#if defined(STM32_SHSI_ENABLED)
+	case STM32_SRC_SHSI:
+		*rate = STM32_SHSI_FREQ;
+		break;
+#endif /* STM32_SHSI_ENABLED */
 #if defined(STM32_PLL_ENABLED)
 	case STM32_SRC_PLL1_P:
 		*rate = get_pllout_frequency(get_pllsrc_frequency(PLL1_ID),
@@ -890,6 +896,12 @@ static void set_up_fixed_clock_sources(void)
 	if (IS_ENABLED(STM32_HSI48_ENABLED)) {
 		LL_RCC_HSI48_Enable();
 		while (LL_RCC_HSI48_IsReady() != 1) {
+		}
+	}
+
+	if (IS_ENABLED(STM32_SHSI_ENABLED)) {
+		LL_RCC_SHSI_Enable();
+		while (LL_RCC_SHSI_IsReady() != 1) {
 		}
 	}
 }

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -136,6 +136,13 @@
 			status = "disabled";
 		};
 
+		clk_shsi: clk-shsi {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+
 		pll1: pll: pll {
 			#clock-cells = <0>;
 			compatible = "st,stm32u5-pll-clock";

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -729,6 +729,13 @@
 #define STM32_PSIK_FREQ		0
 #endif
 
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_shsi), fixed_clock, okay)
+#define STM32_SHSI_ENABLED	1
+#define STM32_SHSI_FREQ	DT_PROP(DT_NODELABEL(clk_shsi), clock_frequency)
+#else
+#define STM32_SHSI_FREQ	0
+#endif
+
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(perck), st_stm32_clock_mux, okay)
 #define STM32_CKPER_ENABLED	1
 #endif

--- a/include/zephyr/dt-bindings/clock/stm32u5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u5_clock.h
@@ -11,7 +11,7 @@
 
 /** Domain clocks */
 
-/* RM0456, Figure 36 Clock tree for STM32U5 Series */
+/* RM0456 Rev 6, Figure 38 Clock tree for STM32U5 Series */
 
 /** System clock */
 /* defined in stm32_common_clocks.h */

--- a/include/zephyr/dt-bindings/clock/stm32u5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u5_clock.h
@@ -21,8 +21,10 @@
 #define STM32_SRC_HSI48		(STM32_SRC_HSI16 + 1)
 #define STM32_SRC_MSIS		(STM32_SRC_HSI48 + 1)
 #define STM32_SRC_MSIK		(STM32_SRC_MSIS + 1)
+/** 48 MHz Secure High Speed Internal (SHSI) clock */
+#define STM32_SRC_SHSI		(STM32_SRC_MSIK + 1)
 /** Bus clock */
-#define STM32_SRC_HCLK		(STM32_SRC_MSIK + 1)
+#define STM32_SRC_HCLK		(STM32_SRC_SHSI + 1)
 #define STM32_SRC_PCLK1		(STM32_SRC_HCLK + 1)
 #define STM32_SRC_PCLK2		(STM32_SRC_PCLK1 + 1)
 #define STM32_SRC_PCLK3		(STM32_SRC_PCLK2 + 1)

--- a/include/zephyr/dt-bindings/clock/stm32u5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u5_clock.h
@@ -16,29 +16,49 @@
 /** System clock */
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
+/** High Speed External (HSE) clock */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** 16 MHz High Speed Internal (HSI16) clock */
 #define STM32_SRC_HSI16		(STM32_SRC_HSE + 1)
+/** 48 MHz High Speed Internal (HSI48) clock */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI16 + 1)
+/** Multi-Speed Internal RC oscillator System (MSIS) clock */
 #define STM32_SRC_MSIS		(STM32_SRC_HSI48 + 1)
+/** Multi-Speed Internal RC oscillator peripheral Kernel (MSIK) clock */
 #define STM32_SRC_MSIK		(STM32_SRC_MSIS + 1)
 /** 48 MHz Secure High Speed Internal (SHSI) clock */
 #define STM32_SRC_SHSI		(STM32_SRC_MSIK + 1)
 /** Bus clock */
+/** AHB (hclk) clock */
 #define STM32_SRC_HCLK		(STM32_SRC_SHSI + 1)
+/** APB1 (pclk1) clock */
 #define STM32_SRC_PCLK1		(STM32_SRC_HCLK + 1)
+/** APB2 (pclk2) clock */
 #define STM32_SRC_PCLK2		(STM32_SRC_PCLK1 + 1)
+/** APB3 (pclk3) clock */
 #define STM32_SRC_PCLK3		(STM32_SRC_PCLK2 + 1)
+/** APB1 timer clock */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK3 + 1)
+/** APB2 timer clock */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
 /** PLL outputs */
+/** pll1_p_ck clock */
 #define STM32_SRC_PLL1_P	(STM32_SRC_TIMPCLK2 + 1)
+/** pll1_q_ck clock */
 #define STM32_SRC_PLL1_Q	(STM32_SRC_PLL1_P + 1)
+/** pll1_r_ck clock */
 #define STM32_SRC_PLL1_R	(STM32_SRC_PLL1_Q + 1)
+/** pll2_p_ck clock */
 #define STM32_SRC_PLL2_P	(STM32_SRC_PLL1_R + 1)
+/** pll2_q_ck clock */
 #define STM32_SRC_PLL2_Q	(STM32_SRC_PLL2_P + 1)
+/** pll2_r_ck clock */
 #define STM32_SRC_PLL2_R	(STM32_SRC_PLL2_Q + 1)
+/** pll3_p_ck clock */
 #define STM32_SRC_PLL3_P	(STM32_SRC_PLL2_R + 1)
+/** pll3_q_ck clock */
 #define STM32_SRC_PLL3_Q	(STM32_SRC_PLL3_P + 1)
+/** pll3_r_ck clock */
 #define STM32_SRC_PLL3_R	(STM32_SRC_PLL3_Q + 1)
 /** DSI PHY clock */
 #define STM32_SRC_DSIPHY	(STM32_SRC_PLL3_R + 1)


### PR DESCRIPTION
This short series adds the SHSI clock support to the stm32u5 series.

This PR is extracted from #110432.