### PR TITLE
stm32: Make the RNG HW managed by PM

### DIFF
--- a/drivers/entropy/Kconfig.stm32
+++ b/drivers/entropy/Kconfig.stm32
@@ -64,4 +64,21 @@ config ENTROPY_STM32_CLK_CHECK
 	  available, CED is enabled by default). Disable this check if CED is
 	  disabled.
 
+config ENTROPY_STM32_RNG_FORCE_CLOCKON
+	bool
+	depends on SOC_SERIES_STM32U5X
+	default y if DT_HAS_ST_STM32_SAES_ENABLED
+	select ENTROPY_STM32_ALWAYS_CLOCKON
+
+config ENTROPY_STM32_ALWAYS_CLOCKON
+	bool "Disable RNG self-suspend/resume management"
+	help
+	  Disable the STM32 RNG self-suspend/resume management.
+	  When enabled, the RNG peripheral will remain powered and clocked at
+	  all times, regardless of whether it is actively being used or not.
+	  This can be useful for other drivers that rely on the RNG
+	  peripheral for their own operations, such as PKA (Public Key
+	  Accelerator) or SAES (Secure AES), ensuring that the RNG peripheral
+	  is active and ready to provide random numbers when required.
+
 endif # ENTROPY_STM32_RNG

--- a/drivers/entropy/Kconfig.stm32
+++ b/drivers/entropy/Kconfig.stm32
@@ -64,21 +64,4 @@ config ENTROPY_STM32_CLK_CHECK
 	  available, CED is enabled by default). Disable this check if CED is
 	  disabled.
 
-config ENTROPY_STM32_RNG_FORCE_CLOCKON
-	bool
-	depends on SOC_SERIES_STM32U5X
-	default y if DT_HAS_ST_STM32_SAES_ENABLED
-	select ENTROPY_STM32_ALWAYS_CLOCKON
-
-config ENTROPY_STM32_ALWAYS_CLOCKON
-	bool "Disable RNG self-suspend/resume management"
-	help
-	  Disable the STM32 RNG self-suspend/resume management.
-	  When enabled, the RNG peripheral will remain powered and clocked at
-	  all times, regardless of whether it is actively being used or not.
-	  This can be useful for other drivers that rely on the RNG
-	  peripheral for their own operations, such as PKA (Public Key
-	  Accelerator) or SAES (Secure AES), ensuring that the RNG peripheral
-	  is active and ready to provide random numbers when required.
-
 endif # ENTROPY_STM32_RNG

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -154,7 +154,8 @@ static int entropy_stm32_suspend(void)
  * LL_PKA_IsEnabled(). Since RNG clock is not required by PKA, we can
  * ignore the check on this series.
  */
-#if defined(PKA) && !defined(CONFIG_SOC_SERIES_STM32WB0X)
+#if (defined(CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON) || defined(PKA)) && \
+	!defined(CONFIG_SOC_SERIES_STM32WB0X)
 #if defined(CONFIG_STM32_HAL2)
 	uint32_t pka_clock_enabled = HAL_RCC_PKA_IsEnabledClock();
 #else /* CONFIG_STM32_HAL2 */
@@ -169,7 +170,7 @@ static int entropy_stm32_suspend(void)
 		/* PKA needs RNG clock, so exit here if in use */
 		return 0;
 	}
-#endif /* PKA && !CONFIG_SOC_SERIES_STM32WB0X */
+#endif /* (CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON || PKA) && !CONFIG_SOC_SERIES_STM32WB0X */
 
 #ifdef CONFIG_SOC_SERIES_STM32WBAX
 	uint32_t wait_cycles, rng_rate;

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -143,34 +143,30 @@ static int entropy_stm32_suspend(void)
 	LL_RNG_SetAesReset(rng, 1);
 #endif /* CONFIG_SOC_STM32WB09XX */
 
-/*
- * The PKA IP is currently not supported by Zephyr but may be used by
- * external code, such as wireless stack for example. Since the RNG
- * clock must be enabled when PKA is used on certain series, check if
- * the PKA is in use and keep RNG clock active if so.
- *
- * A notable exception is the STM32WB0 series where PKA can operate
- * autonomously and, on certain SoCs, lacks PKA_CR.EN and corresponding
- * LL_PKA_IsEnabled(). Since RNG clock is not required by PKA, we can
- * ignore the check on this series.
- */
-#if (defined(CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON) || defined(PKA)) && \
-	!defined(CONFIG_SOC_SERIES_STM32WB0X)
-#if defined(CONFIG_STM32_HAL2)
-	uint32_t pka_clock_enabled = HAL_RCC_PKA_IsEnabledClock();
-#else /* CONFIG_STM32_HAL2 */
-	uint32_t pka_clock_enabled = __HAL_RCC_PKA_IS_CLK_ENABLED();
-#endif /* CONFIG_STM32_HAL2 */
-
-	if (pka_clock_enabled && LL_PKA_IsEnabled(PKA)) {
+#if defined(CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON) && !defined(CONFIG_SOC_SERIES_STM32WB0X)
+	do {
+		/* While the entropy driver is the primary user of the RNG
+		 * peripheral, it is possible that other drivers may also use
+		 * it as a pre-requisite for their own operations, such as the
+		 * PKA or SAES on some STM32 series.
+		 *
+		 * Such drivers, either in Zephyr or in external code, may
+		 * request the activation of the RNG peripheral to ensure it
+		 * is up-and-clocked when they need it, and release it when
+		 * they are done. The STM32 entropy driver is somehow
+		 * self-managing its suspend/resume operations, which may be
+		 * incompatible with other drivers. In such cases, the other
+		 * RNG suspend operation will be partially executed, in order
+		 * to keep the RNG peripheral clocked on.
+		 */
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
 		z_stm32_hsem_unlock(CFG_HW_RNG_SEMID);
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
 
-		/* PKA needs RNG clock, so exit here if in use */
+		/* Some other HW IPs need RNG to be clocked, so exit here. */
 		return 0;
-	}
-#endif /* (CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON || PKA) && !CONFIG_SOC_SERIES_STM32WB0X */
+	} while (0);
+#endif /* CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON && !CONFIG_SOC_SERIES_STM32WB0X */
 
 #ifdef CONFIG_SOC_SERIES_STM32WBAX
 	uint32_t wait_cycles, rng_rate;

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -143,7 +143,7 @@ static int entropy_stm32_suspend(void)
 	LL_RNG_SetAesReset(rng, 1);
 #endif /* CONFIG_SOC_STM32WB09XX */
 
-#if defined(CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON) && !defined(CONFIG_SOC_SERIES_STM32WB0X)
+#if defined(CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON)
 	do {
 		/* While the entropy driver is the primary user of the RNG
 		 * peripheral, it is possible that other drivers may also use
@@ -166,7 +166,7 @@ static int entropy_stm32_suspend(void)
 		/* Some other HW IPs need RNG to be clocked, so exit here. */
 		return 0;
 	} while (0);
-#endif /* CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON && !CONFIG_SOC_SERIES_STM32WB0X */
+#endif /* CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON */
 
 #ifdef CONFIG_SOC_SERIES_STM32WBAX
 	uint32_t wait_cycles, rng_rate;

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stddef.h>
+#include <stdbool.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
@@ -121,7 +122,7 @@ static struct entropy_stm32_rng_dev_data entropy_stm32_rng_data = {
 	.rng = (RNG_TypeDef *)DT_INST_REG_ADDR(0),
 };
 
-static int entropy_stm32_suspend(void)
+static int entropy_stm32_suspend(bool pm_caller)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
 	struct entropy_stm32_rng_dev_data *dev_data = dev->data;
@@ -143,30 +144,34 @@ static int entropy_stm32_suspend(void)
 	LL_RNG_SetAesReset(rng, 1);
 #endif /* CONFIG_SOC_STM32WB09XX */
 
-#if defined(CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON)
-	do {
-		/* While the entropy driver is the primary user of the RNG
-		 * peripheral, it is possible that other drivers may also use
-		 * it as a pre-requisite for their own operations, such as the
-		 * PKA or SAES on some STM32 series.
-		 *
-		 * Such drivers, either in Zephyr or in external code, may
-		 * request the activation of the RNG peripheral to ensure it
-		 * is up-and-clocked when they need it, and release it when
-		 * they are done. The STM32 entropy driver is somehow
-		 * self-managing its suspend/resume operations, which may be
-		 * incompatible with other drivers. In such cases, the other
-		 * RNG suspend operation will be partially executed, in order
-		 * to keep the RNG peripheral clocked on.
+	/* While the entropy driver is the primary user of the RNG
+	 * peripheral, it is possible that other drivers may also use
+	 * it as a pre-requisite for their own operations, such as the
+	 * PKA or SAES on some STM32 series.
+	 *
+	 * Such drivers, either in Zephyr or in external code, may
+	 * request the activation of the RNG peripheral to ensure it
+	 * is up-and-clocked when they need it, and release it when
+	 * they are done.
+	 */
+
+	if (!pm_caller) {
+		/* entropy_stm32_suspend() is not called from the PM callback,
+		 * so we should not release the RNG peripheral if it is still
+		 * needed by other drivers.
 		 */
+
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
 		z_stm32_hsem_unlock(CFG_HW_RNG_SEMID);
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
 
 		/* Some other HW IPs need RNG to be clocked, so exit here. */
 		return 0;
-	} while (0);
-#endif /* CONFIG_ENTROPY_STM32_ALWAYS_CLOCKON */
+	}
+
+	/* Called from the PM callback, so we can safely release the RNG
+	 * peripheral.
+	 */
 
 #ifdef CONFIG_SOC_SERIES_STM32WBAX
 	uint32_t wait_cycles, rng_rate;
@@ -193,16 +198,23 @@ static int entropy_stm32_suspend(void)
 	return res;
 }
 
-static int entropy_stm32_resume(void)
+static int entropy_stm32_resume(bool pm_caller)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
 	struct entropy_stm32_rng_dev_data *dev_data = dev->data;
 	const struct entropy_stm32_rng_dev_cfg *dev_cfg = dev->config;
 	RNG_TypeDef *rng = dev_data->rng;
-	int res;
+	int res = 0;
 
-	res = clock_control_on(dev_data->clock,
-			(clock_control_subsys_t)&dev_cfg->pclken[0]);
+	if (pm_caller) {
+		/* entropy_stm32_resume() is called from the PM callback,
+		 * so we should enable the RNG peripheral as it may still be
+		 * needed by other drivers.
+		 */
+		res = clock_control_on(dev_data->clock,
+				(clock_control_subsys_t)&dev_cfg->pclken[0]);
+	}
+
 #if defined(CONFIG_SOC_STM32WB09XX)
 	/**
 	 * STM32WB09 RNG clock domain runs at (16 MHz / CLKDIV).
@@ -290,7 +302,7 @@ static void acquire_rng(void)
 	z_stm32_hsem_lock(CFG_HW_RNG_SEMID, HSEM_LOCK_WAIT_FOREVER);
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
 
-	entropy_stm32_resume();
+	entropy_stm32_resume(false);
 
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
 	/* RNG configuration could have been changed by the other core */
@@ -298,9 +310,9 @@ static void acquire_rng(void)
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
 }
 
-static void release_rng(void)
+static void release_rng(bool pm_caller)
 {
-	entropy_stm32_suspend();
+	entropy_stm32_suspend(pm_caller);
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
 	z_stm32_hsem_unlock(CFG_HW_RNG_SEMID);
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
@@ -691,7 +703,7 @@ static int perform_pool_refill(void)
 #if !IRQLESS_TRNG
 				irq_disable(IRQN);
 #endif /* !IRQLESS_TRNG */
-				release_rng();
+				release_rng(false);
 				pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE,
 					PM_ALL_SUBSTATES);
 				if (IS_ENABLED(CONFIG_PM_S2RAM)) {
@@ -835,7 +847,7 @@ static int entropy_stm32_rng_get_entropy_isr(const struct device *dev,
 
 		/* Restore the state of the RNG lock and IRQ */
 		if (!rng_already_acquired) {
-			release_rng();
+			release_rng(false);
 		}
 
 #if IRQLESS_TRNG
@@ -956,12 +968,12 @@ static int entropy_stm32_rng_pm_action(const struct device *dev,
 		z_stm32_hsem_lock(CFG_HW_RNG_SEMID, HSEM_LOCK_WAIT_FOREVER);
 	/* Call release_rng instead of entropy_stm32_suspend to avoid double hsem_unlock */
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
-		release_rng();
+		release_rng(true);
 		break;
 	case PM_DEVICE_ACTION_RESUME:
 		if (IS_ENABLED(CONFIG_PM_S2RAM)) {
 #if DT_INST_NODE_HAS_PROP(0, health_test_config)
-			entropy_stm32_resume();
+			entropy_stm32_resume(true);
 #if DT_INST_NODE_HAS_PROP(0, health_test_magic)
 			LL_RNG_SetHealthConfig(dev_data->rng, DT_INST_PROP(0, health_test_magic));
 #endif /* health_test_magic */
@@ -978,13 +990,13 @@ static int entropy_stm32_rng_pm_action(const struct device *dev,
 				 * to avoid double hsem_unlock
 				 */
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
-				release_rng();
+				release_rng(true);
 			}
 #endif /* health_test_config */
 		} else {
 			/* Resume RNG only if it was suspended during filling pool */
 			if (entropy_stm32_rng_data.filling_pools) {
-				res = entropy_stm32_resume();
+				res = entropy_stm32_resume(true);
 			}
 		}
 		break;


### PR DESCRIPTION
This short series reworks the way the STM32 RNG HW is managed.

Instead of making the entropy driver managing the RNG HW, the entropy driver now relies on the power-management subsystem for the RNG HW.

Thus, the RNG HW now remains clocked on and available for other HW peripherals (no matter they are is zephyr or not) that may need it for their own operations.

This PR also cleans up a couple of quirks done around this need/feature.

This PR is extracted from #110432.