### PR TITLE
stm32: Add stm32_backup_domain_is_enabled API

### DIFF
--- a/soc/st/stm32/common/stm32_backup_domain.c
+++ b/soc/st/stm32/common/stm32_backup_domain.c
@@ -29,13 +29,18 @@ LOG_MODULE_REGISTER(stm32_backup_domain, CONFIG_SOC_LOG_LEVEL);
 static struct k_spinlock lock;
 static size_t refcount;
 
+bool stm32_backup_domain_is_enabled(void)
+{
+	return IS_ENABLED_BKUP_ACCESS();
+}
+
 void stm32_backup_domain_enable_access(void)
 {
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	if (refcount == 0U) {
 		ENABLE_BKUP_ACCESS();
-		while (!IS_ENABLED_BKUP_ACCESS()) {
+		while (!stm32_backup_domain_is_enabled()) {
 		}
 	}
 	refcount++;

--- a/soc/st/stm32/common/stm32_backup_domain.h
+++ b/soc/st/stm32/common/stm32_backup_domain.h
@@ -7,6 +7,8 @@
 #ifndef STM32_BACKUP_DOMAIN_H_
 #define STM32_BACKUP_DOMAIN_H_
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -30,9 +32,18 @@ void stm32_backup_domain_enable_access(void);
  * stm32_backup_domain_enable_access().
  */
 void stm32_backup_domain_disable_access(void);
+
+/**
+ * @brief Check if access to protected backup domain is currently enabled
+ */
+bool stm32_backup_domain_is_enabled(void);
 #else
 static inline void stm32_backup_domain_enable_access(void) { }
 static inline void stm32_backup_domain_disable_access(void) { }
+static inline bool stm32_backup_domain_is_enabled(void)
+{
+	return false;
+}
 #endif /* CONFIG_STM32_BACKUP_PROTECTION */
 
 /** @} */


### PR DESCRIPTION
This API allow interrogating if the backup domain is enabled.

Also use it internally in the other backup domain helpers.

This PR is extracted from #110432.