### PR TITLE
usb: device_next: respect wLength in CDC NCM to-host control handler

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -946,9 +946,10 @@ static int usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
 			.wNdbOutAlignment = sys_cpu_to_le16(CDC_NCM_ALIGNMENT),
 			.wNtbOutMaxDatagrams = sys_cpu_to_le16(CDC_NCM_RECV_MAX_DATAGRAMS_PER_NTB),
 		};
+		const uint16_t len = MIN(sizeof(ntb_params), setup->wLength);
 
 		LOG_DBG("GET_NTB_PARAMETERS");
-		net_buf_add_mem(buf, &ntb_params, sizeof(ntb_params));
+		net_buf_add_mem(buf, &ntb_params, len);
 		break;
 	}
 
@@ -958,9 +959,10 @@ static int usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
 			.wNtbInMaxDatagrams = sys_cpu_to_le16(CDC_NCM_SEND_MAX_DATAGRAMS_PER_NTB),
 			.wReserved = sys_cpu_to_le16(0),
 		};
+		const uint16_t len = MIN(sizeof(input_size), setup->wLength);
 
 		LOG_DBG("GET_NTB_INPUT_SIZE");
-		net_buf_add_mem(buf, &input_size, sizeof(input_size));
+		net_buf_add_mem(buf, &input_size, len);
 		break;
 	}
 


### PR DESCRIPTION
Limit the number of bytes that will be copied to the DATA IN buffer in the CDC NCM implementation.

Fixes: #112613