### PR TITLE
boards: kincony: drop unnecessary includes in dtsi file

### DIFF
--- a/boards/kincony/kincony_kc868_a8/kincony_kc868_a8-pinctrl.dtsi
+++ b/boards/kincony/kincony_kc868_a8/kincony_kc868_a8-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {


### PR DESCRIPTION
Including `zephyr/dt-bindings/pinctrl/esp32-pinctrl.h` is enough, drop other pinctrl includes as they are internal.