### PR TITLE
dts: arm: st: l5: add DFSDM peripheral support

### DIFF
--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -870,6 +870,58 @@
 			resets = <&rctl STM32_RESET(AHB1, 12)>;
 			status = "disabled";
 		};
+
+		dfsdm: dfsdm@40016000 {
+			compatible = "st,stm32-dfsdm";
+			reg = <0x40016000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 24)>,
+				 <&rcc STM32_SRC_PLLSAI1_P NO_SEL>;
+			clock-names = "pclk", "aclk";
+			resets = <&rctl STM32_RESET(APB2, 24)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+
+			pdm0: filter@0 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <0>;
+				interrupts = <102 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm1: filter@1 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <1>;
+				interrupts = <103 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm2: filter@2 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <2>;
+				interrupts = <104 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm3: filter@3 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <3>;
+				interrupts = <105 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
 	};
 
 	die_temp: dietemp {


### PR DESCRIPTION
Add the DFSDM peripheral to STM32L5xx series.  The DFSDM presents 4 filters for all L5 variants and is basically the same device-tree as STM32L4 series.

This series has only been compile-tested since I don't have the hardware to test on it.