### PR TITLE
Renesas R-Car: Modernize the GPIO driver

### DIFF
--- a/drivers/gpio/Kconfig.rcar
+++ b/drivers/gpio/Kconfig.rcar
@@ -7,5 +7,6 @@ config GPIO_RCAR
 	bool "Renesas R-Car GPIO"
 	default y
 	depends on DT_HAS_RENESAS_RCAR_GPIO_ENABLED
+	select PINCTRL
 	help
 	  Enable Renesas RCAR GPIO driver.

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -44,6 +44,19 @@ struct gpio_rcar_data {
 #define IOINTSEL 0x00   /* General IO/Interrupt Switching Register */
 #define INOUTSEL 0x04   /* General Input/Output Switching Register */
 #define OUTDT    0x08   /* General Output Register */
+#ifdef CONFIG_SOC_SERIES_RCAR_GEN5
+#define INDT     0x1c   /* General Input Register */
+#define INTDT    0x80   /* Interrupt Display Register */
+#define INTCLR   0x84   /* Interrupt Clear Register */
+#define INTMSK   0x88   /* Interrupt Mask Register */
+#define MSKCLR   0x8c   /* Interrupt Mask Clear Register */
+#define POSNEG   0x90   /* Positive/Negative Logic Select Register */
+#define EDGLEVEL 0x94   /* Edge/level Select Register */
+#define FILONOFF 0x98   /* Chattering Prevention On/Off Register */
+#define OUTDTSEL 0x0c   /* Output Data Select Register */
+#define BOTHEDGE 0xbc   /* One Edge/Both Edge Select Register */
+#define INEN     0x18   /* General Input Enable Register */
+#else
 #define INDT     0x0c   /* General Input Register */
 #define INTDT    0x10   /* Interrupt Display Register */
 #define INTCLR   0x14   /* Interrupt Clear Register */
@@ -55,6 +68,7 @@ struct gpio_rcar_data {
 #define OUTDTSEL 0x40   /* Output Data Select Register */
 #define BOTHEDGE 0x4c   /* One Edge/Both Edge Select Register */
 #define INEN     0x50	/* General Input Enable Register */
+#endif /* CONFIG_SOC_SERIES_RCAR_GEN5 */
 
 static inline uint32_t gpio_rcar_read(const struct device *dev, uint32_t offs)
 {
@@ -109,8 +123,8 @@ static void gpio_rcar_config_general_input_output_mode(
 	/* Configure positive logic in POSNEG */
 	gpio_rcar_modify_bit(dev, POSNEG, gpio, false);
 
-	/* Select "Input Enable/Disable" in INEN for Gen4 SoCs */
-#ifdef CONFIG_SOC_SERIES_RCAR_GEN4
+	/* Select "Input Enable/Disable" in INEN for Gen4 and Gen5 SoCs */
+#if defined(CONFIG_SOC_SERIES_RCAR_GEN4) || defined(CONFIG_SOC_SERIES_RCAR_GEN5)
 	gpio_rcar_modify_bit(dev, INEN, gpio, !output);
 #endif
 
@@ -231,8 +245,8 @@ static int gpio_rcar_pin_interrupt_configure(const struct device *dev,
 		gpio_rcar_modify_bit(dev, BOTHEDGE, pin, true);
 	}
 
-	/* Select "Input Enable" in INEN for Gen4 SoCs */
-#ifdef CONFIG_SOC_SERIES_RCAR_GEN4
+	/* Select "Input Enable" in INEN for Gen4 and Gen5 SoCs */
+#if defined(CONFIG_SOC_SERIES_RCAR_GEN4) || defined(CONFIG_SOC_SERIES_RCAR_GEN5)
 	gpio_rcar_modify_bit(dev, INEN, pin, true);
 #endif
 

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/renesas_rcar_generic.h>
+#include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
@@ -31,6 +32,7 @@ struct gpio_rcar_cfg {
 	init_func_t init_func;
 	const struct device *clock_dev;
 	rcar_generic_clk_t mod_clk;
+	const struct pinctrl_dev_config *pcfg;
 };
 
 struct gpio_rcar_data {
@@ -255,6 +257,11 @@ static int gpio_rcar_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	if ((ret != 0) && (ret != -ENOENT)) {
+		return ret;
+	}
+
 	ret = clock_control_on(config->clock_dev, RCAR_CLOCK_SUBSYS(config->mod_clk));
 
 	if (ret < 0) {
@@ -288,13 +295,15 @@ static DEVICE_API(gpio, gpio_rcar_driver_api) = {
 
 /* Device Instantiation */
 #define GPIO_RCAR_INIT(n)					      \
+	PINCTRL_DT_INST_DEFINE(n);				      \
 	static void gpio_rcar_##n##_init(const struct device *dev);   \
 	static const struct gpio_rcar_cfg gpio_rcar_cfg_##n = {	      \
 		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)), \
 		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(n),	      \
 		.init_func = gpio_rcar_##n##_init,		      \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),   \
-		.mod_clk = RCAR_DT_INST_CLOCKS_CELL_BY_IDX(n, 0)      \
+		.mod_clk = RCAR_DT_INST_CLOCKS_CELL_BY_IDX(n, 0),     \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n)	      \
 	};							      \
 	static struct gpio_rcar_data gpio_rcar_data_##n;	      \
 								      \

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -13,7 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/clock_control.h>
-#include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
+#include <zephyr/drivers/clock_control/renesas_rcar_generic.h>
 #include <zephyr/irq.h>
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
@@ -30,7 +30,7 @@ struct gpio_rcar_cfg {
 	DEVICE_MMIO_NAMED_ROM(reg_base);
 	init_func_t init_func;
 	const struct device *clock_dev;
-	struct rcar_cpg_clk mod_clk;
+	rcar_generic_clk_t mod_clk;
 };
 
 struct gpio_rcar_data {
@@ -255,8 +255,7 @@ static int gpio_rcar_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t) &config->mod_clk);
+	ret = clock_control_on(config->clock_dev, RCAR_CLOCK_SUBSYS(config->mod_clk));
 
 	if (ret < 0) {
 		return ret;
@@ -295,10 +294,7 @@ static DEVICE_API(gpio, gpio_rcar_driver_api) = {
 		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(n),	      \
 		.init_func = gpio_rcar_##n##_init,		      \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),   \
-		.mod_clk.module =				      \
-			DT_INST_CLOCKS_CELL_BY_IDX(n, 0, module),     \
-		.mod_clk.domain =				      \
-			DT_INST_CLOCKS_CELL_BY_IDX(n, 0, domain),     \
+		.mod_clk = RCAR_DT_INST_CLOCKS_CELL_BY_IDX(n, 0)      \
 	};							      \
 	static struct gpio_rcar_data gpio_rcar_data_##n;	      \
 								      \

--- a/dts/bindings/gpio/renesas,rcar-gpio.yaml
+++ b/dts/bindings/gpio/renesas,rcar-gpio.yaml
@@ -8,7 +8,7 @@ description: Renesas RCAR GPIO
 
 compatible: "renesas,rcar-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: [gpio-controller.yaml, base.yaml, pinctrl-device.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
Allow the same GPIO driver to be used from the Gen 3 boards up to the newcoming Gen 5 boards.