### PR TITLE
soc: espressif: fix psram boot paths and extend coverage

### DIFF
--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -710,6 +710,17 @@ static const struct flash_parameters *flash_esp32_get_parameters(const struct de
 
 static int flash_esp32_init(const struct device *dev)
 {
+#ifndef CONFIG_MCUBOOT
+	/*
+	 * Switch the main flash chip to OS-aware functions now that the
+	 * scheduler is running. These were left as the no-OS (cache-suspend)
+	 * functions during early boot in esp_flash_config(), because the
+	 * OS-aware path can guard flash access with a mutex. MCUboot runs
+	 * single-threaded and keeps the no-OS functions.
+	 */
+	esp_flash_app_init();
+#endif
+
 #ifdef CONFIG_MULTITHREADING
 	struct flash_esp32_dev_data *const data = dev->data;
 

--- a/samples/boards/espressif/spiram_test/README.rst
+++ b/samples/boards/espressif/spiram_test/README.rst
@@ -19,6 +19,8 @@ The following SoCs are supported by this sample code so far:
 * ESP32
 * ESP32-S2
 * ESP32-S3
+* ESP32-C5
+* ESP32-P4
 
 Building and Running
 ********************

--- a/samples/boards/espressif/spiram_test/sample.yaml
+++ b/samples/boards/espressif/spiram_test/sample.yaml
@@ -12,9 +12,18 @@ tests:
   sample.boards.esp32.spiram:
     platform_allow: esp32_devkitc/esp32/procpu
     tags: esp32
+  sample.boards.esp32s2.spiram:
+    platform_allow: esp32s2_devkitc
+    tags: esp32s2
   sample.boards.esp32s3.spiram:
     platform_allow: esp32s3_devkitc/esp32s3/procpu
     tags: esp32s3
+  sample.boards.esp32c5.spiram:
+    platform_allow: esp32c5_devkitc/esp32c5/hpcore
+    tags: esp32c5
+  sample.boards.esp32p4.spiram:
+    platform_allow: esp32p4_function_ev_board/esp32p4/hpcore
+    tags: esp32p4
   sample.boards.esp32s3.spiram.octal_80m:
     platform_allow: esp32s3_devkitc/esp32s3/procpu
     tags: esp32s3

--- a/soc/espressif/common/Kconfig.esptool
+++ b/soc/espressif/common/Kconfig.esptool
@@ -6,6 +6,12 @@ if SOC_FAMILY_ESPRESSIF_ESP32
 config ESPTOOLPY_OCT_FLASH
 	bool "Use Octal Flash"
 	depends on SOC_SERIES_ESP32S3
+	default y if SPIRAM_MODE_OCT
+	help
+	  Octal PSRAM modules are paired with octal flash. Enable octal flash
+	  by default in this case so its MSPI timing is tuned (DTR sample mode).
+	  Without it the flash falls back to untuned STR timing and can corrupt
+	  at high speeds. Disable manually if the board uses quad flash.
 
 config ESPTOOLPY_FLASH_MODE_AUTO_DETECT
 	depends on SOC_SERIES_ESP32S3

--- a/soc/espressif/common/Kconfig.spiram
+++ b/soc/espressif/common/Kconfig.spiram
@@ -19,7 +19,7 @@ menu "SPI RAM config"
 
 config ESP_SPIRAM_HEAP_SIZE
 	int "Size of SPIRAM heap"
-	default 262134 if SYS_HEAP_SMALL_ONLY
+	default 262128 if SYS_HEAP_SMALL_ONLY
 	default 1048576 if !SYS_HEAP_SMALL_ONLY
 	help
 	  Specify size of SPIRAM heap.

--- a/soc/espressif/common/Kconfig.spiram
+++ b/soc/espressif/common/Kconfig.spiram
@@ -132,7 +132,7 @@ config SPIRAM_CS_IO
 
 config SPIRAM_FETCH_INSTRUCTIONS
 	bool "Move Instructions in Flash to PSRAM"
-	depends on SOC_SERIES_ESP32C5 || SOC_SERIES_ESP32S2 || SOC_SERIES_ESP32S3 || SOC_SERIES_ESP32P4
+	depends on SOC_SERIES_ESP32S2 || SOC_SERIES_ESP32S3
 	help
 	  If enabled, instructions in flash will be moved into PSRAM on startup.
 	  If SPIRAM_RODATA is also enabled, code that requires execution during an SPI1 Flash operation
@@ -141,7 +141,7 @@ config SPIRAM_FETCH_INSTRUCTIONS
 
 config SPIRAM_RODATA
 	bool "Move Read-Only Data in Flash to PSRAM"
-	depends on SOC_SERIES_ESP32C5 || SOC_SERIES_ESP32S2 || SOC_SERIES_ESP32S3 || SOC_SERIES_ESP32P4
+	depends on SOC_SERIES_ESP32S2 || SOC_SERIES_ESP32S3
 	help
 	  If enabled, rodata in flash will be moved into PSRAM on startup.
 	  If SPIRAM_FETCH_INSTRUCTIONS is also enabled, code that requires execution during an SPI1 Flash operation

--- a/tests/boards/espressif/cache_coex/boards/esp32s3_devkitc_esp32s3_procpu.conf
+++ b/tests/boards/espressif/cache_coex/boards/esp32s3_devkitc_esp32s3_procpu.conf
@@ -1,2 +1,4 @@
-# The esp32s3_devkitc used in CI is the 8MB octal PSRAM variant.
+# The esp32s3_devkitc used in CI is the 8MB octal PSRAM variant. Selecting
+# octal PSRAM mode also enables octal flash by default, so its MSPI timing
+# is tuned and stays reliable at high PSRAM speeds.
 CONFIG_SPIRAM_MODE_OCT=y

--- a/tests/boards/espressif/cache_coex/boards/esp32s3_devkitc_esp32s3_procpu.conf
+++ b/tests/boards/espressif/cache_coex/boards/esp32s3_devkitc_esp32s3_procpu.conf
@@ -1,0 +1,2 @@
+# The esp32s3_devkitc used in CI is the 8MB octal PSRAM variant.
+CONFIG_SPIRAM_MODE_OCT=y

--- a/tests/boards/espressif/cache_coex/testcase.yaml
+++ b/tests/boards/espressif/cache_coex/testcase.yaml
@@ -1,10 +1,45 @@
+common:
+  tags:
+    - spiram
+    - spiflash
+    - cache
+  harness: ztest
 tests:
   boards.esp32.cache_coex:
     platform_allow:
       - esp32_devkitc/esp32/procpu
       - esp32s2_devkitc
       - esp32s3_devkitc/esp32s3/procpu
-    tags:
-      - spiram
-      - spiflash
-      - cache
+      - esp32c5_devkitc/esp32c5/hpcore
+      - esp32p4_function_ev_board/esp32p4/hpcore
+    integration_platforms:
+      - esp32s3_devkitc/esp32s3/procpu
+  boards.esp32.cache_coex.octal_80m:
+    platform_allow:
+      - esp32s3_devkitc/esp32s3/procpu
+    integration_platforms:
+      - esp32s3_devkitc/esp32s3/procpu
+    extra_configs:
+      - CONFIG_SPIRAM_SPEED_80M=y
+  boards.esp32.cache_coex.reloc:
+    platform_allow:
+      - esp32s2_devkitc
+      - esp32s3_devkitc/esp32s3/procpu
+    integration_platforms:
+      - esp32s3_devkitc/esp32s3/procpu
+    extra_args:
+      - SNIPPET="espressif-psram-reloc"
+  boards.esp32.cache_coex.mcuboot:
+    platform_allow:
+      - esp32s3_devkitc/esp32s3/procpu
+    integration_platforms:
+      - esp32s3_devkitc/esp32s3/procpu
+    sysbuild: true
+  boards.esp32.cache_coex.reloc_mcuboot:
+    platform_allow:
+      - esp32s3_devkitc/esp32s3/procpu
+    integration_platforms:
+      - esp32s3_devkitc/esp32s3/procpu
+    sysbuild: true
+    extra_args:
+      - SNIPPET="espressif-psram-reloc"

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: f3be21f2bb27535d4ac58364018cb6491d52f5dd
+      revision: 8b30e4e3d11e467bfdc04658a02f5afc3d15bd2f
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Defer flash OS-func switch to post-kernel so the psram-reloc boot path
no longer hangs, enable octal flash with octal psram for tuned timing,
and fix the small-heap psram size. Adds cache_coex and spiram test
coverage across esp32/s2/s3/c5/p4.

Fixes #110630