### PR TITLE
drivers: i2c: stm32: allow having only some of the instances dma enabled

### DIFF
--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -60,7 +60,8 @@ config I2C_STM32_V2_TIMING
 
 config I2C_STM32_V2_DMA
 	bool "DMA support"
-	depends on I2C_STM32_V2
+	default y
+	depends on I2C_STM32_V2 && $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_I2C_V2),dmas)
 	select DMA
 	select CACHE_MANAGEMENT if CPU_HAS_DCACHE
 	select EXPERIMENTAL

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -378,8 +378,12 @@ static void i2c_stm32_controller_abort_to_target(const struct device *dev, bool 
 
 	i2c_stm32_disable_transfer_interrupts(dev);
 #ifdef CONFIG_I2C_STM32_V2_DMA
-	LL_I2C_DisableDMAReq_RX(cfg->i2c);
-	LL_I2C_DisableDMAReq_TX(cfg->i2c);
+	if (cfg->rx_dma.dev_dma != NULL) {
+		LL_I2C_DisableDMAReq_RX(cfg->i2c);
+	}
+	if (cfg->tx_dma.dev_dma != NULL) {
+		LL_I2C_DisableDMAReq_TX(cfg->i2c);
+	}
 #endif
 	LL_I2C_ClearFlag_TXE(cfg->i2c);
 	data->controller_active = false;
@@ -657,10 +661,12 @@ void i2c_stm32_event(const struct device *dev)
 		uint32_t cr2 = stm32_reg_read(&regs->CR2);
 #ifdef CONFIG_I2C_STM32_V2_DMA
 		/* Get number of bytes bytes transferred by DMA */
-		uint32_t xfer_len = (cr2 & I2C_CR2_NBYTES_Msk) >> I2C_CR2_NBYTES_Pos;
+		if (cfg->rx_dma.dev_dma != NULL && cfg->tx_dma.dev_dma != NULL) {
+			uint32_t xfer_len = (cr2 & I2C_CR2_NBYTES_Msk) >> I2C_CR2_NBYTES_Pos;
 
-		data->current.len -= xfer_len;
-		data->current.buf += xfer_len;
+			data->current.len -= xfer_len;
+			data->current.buf += xfer_len;
+		}
 #endif
 
 		if (data->current.len == 0U) {
@@ -809,8 +815,10 @@ static int stm32_i2c_irq_msg_finish(const struct device *dev, struct i2c_msg *ms
 	ret = k_sem_take(&data->device_sync_sem, K_MSEC(CONFIG_I2C_TRANSFER_TIMEOUT_MS));
 
 #ifdef CONFIG_I2C_STM32_V2_DMA
-	/* Stop DMA and invalidate cache if needed */
-	dma_finish(dev, msg);
+	if (cfg->rx_dma.dev_dma != NULL && cfg->tx_dma.dev_dma != NULL) {
+		/* Stop DMA and invalidate cache if needed */
+		dma_finish(dev, msg);
+	}
 #endif
 
 	/* Check for transfer errors or timeout */
@@ -862,7 +870,7 @@ static int i2c_stm32_irq_prepare_start(const struct device *dev, struct i2c_msg 
 				       I2C_TypeDef *regs, uint32_t *cr2,
 				       bool starting_controller_session)
 {
-	struct i2c_stm32_data *data = dev->data;
+	__maybe_unused struct i2c_stm32_data *data = dev->data;
 
 #if !defined(CONFIG_I2C_TARGET)
 	ARG_UNUSED(starting_controller_session);
@@ -889,17 +897,23 @@ static int i2c_stm32_irq_prepare_start(const struct device *dev, struct i2c_msg 
 	__ASSERT_NO_MSG(((isr & I2C_ISR_TC) != 0U) || ((msg->flags & I2C_MSG_RESTART) != 0U));
 
 	if ((msg->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
+#ifdef CONFIG_I2C_STM32_V2_DMA
+		const struct i2c_stm32_config *cfg = dev->config;
+#endif
+
 		*cr2 &= ~I2C_CR2_RD_WRN;
-#ifndef CONFIG_I2C_STM32_V2_DMA
 		/* Prepare first byte in TX buffer before transfer start as a
 		 * workaround for errata: "Transmission stalled after first byte transfer"
 		 */
-		if (data->current.len > 0U) {
+		if (data->current.len > 0U
+#ifdef CONFIG_I2C_STM32_V2_DMA
+		    && (cfg->rx_dma.dev_dma == NULL || cfg->tx_dma.dev_dma == NULL)
+#endif
+		   ) {
 			LL_I2C_TransmitData8(regs, *data->current.buf);
 			data->current.len--;
 			data->current.buf++;
 		}
-#endif
 	} else {
 		*cr2 |= I2C_CR2_RD_WRN;
 	}
@@ -959,7 +973,8 @@ static int stm32_i2c_irq_xfer(const struct device *dev, struct i2c_msg *msg,
 	data->current.msg = msg;
 
 #if defined(CONFIG_I2C_STM32_V2_DMA)
-	if (!stm32_buf_in_nocache((uintptr_t)msg->buf, msg->len) &&
+	if (cfg->rx_dma.dev_dma != NULL && cfg->tx_dma.dev_dma != NULL &&
+	    !stm32_buf_in_nocache((uintptr_t)msg->buf, msg->len) &&
 	    ((msg->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE)) {
 		sys_cache_data_flush_range(msg->buf, msg->len);
 	}
@@ -1021,13 +1036,17 @@ static int stm32_i2c_irq_xfer(const struct device *dev, struct i2c_msg *msg,
 	uint32_t cr1 = I2C_CR1_ERRIE | I2C_CR1_STOPIE | I2C_CR1_TCIE | I2C_CR1_NACKIE;
 
 #ifdef CONFIG_I2C_STM32_V2_DMA
-	ret = i2c_stm32_irq_start_dma(dev, msg, regs);
-	if (ret != 0) {
-		return ret;
+	if (cfg->rx_dma.dev_dma != NULL && cfg->tx_dma.dev_dma != NULL) {
+		ret = i2c_stm32_irq_start_dma(dev, msg, regs);
+		if (ret != 0) {
+			return ret;
+		}
+	} else {
+#endif /* CONFIG_I2C_STM32_V2_DMA */
+		/* If not using DMA, also enable RX and TX empty interrupts */
+		cr1 |= I2C_CR1_TXIE | I2C_CR1_RXIE;
+#ifdef CONFIG_I2C_STM32_V2_DMA
 	}
-#else
-	/* If not using DMA, also enable RX and TX empty interrupts */
-	cr1 |= I2C_CR1_TXIE | I2C_CR1_RXIE;
 #endif /* CONFIG_I2C_STM32_V2_DMA */
 
 #if defined(CONFIG_I2C_TARGET)


### PR DESCRIPTION
This PR allows to have the Kconfig CONFIG_I2C_STM32_V2_DMA automatically set if an instance of i2c has the dmas property defined instead of having to manually configure the Kconfig to enable the DMA usage.
Moreover, driver is modified in order to allow having some of the instances dma enabled and some not.

I made modifications as small as possible, leading sometimes to code not always very easy to read probably due to having #ifdef within if statement somethings. This was done to avoid having duplication of code but that might be worth refactoring a bit more or adding helper functions to ease readabilty. Comments are welcomed.

This has been tested using STM32N6-DK board by adding dmas / dma-names property on i2c1 node, while leading the other i2c node without dma, and confirming that i2c scan xxx is working fine via the I2C_SHELL.