### PR TITLE
arch: riscv: Add support for Smaia and Ssaia extensions

### DIFF
--- a/arch/riscv/Kconfig.isa
+++ b/arch/riscv/Kconfig.isa
@@ -301,3 +301,30 @@ config RISCV_ISA_EXT_ZMMUL
 
 	  The Zmmul extension implements the multiplication subset of the M
 	  extension.
+
+config RISCV_ISA_EXT_SMAIA
+	bool
+	default y if $(dt_compat_all_has_prop,riscv,$(RISCV_ISA_EXT_PROP),smaia)
+	help
+	  (Smaia) - Smaia extension for AIA
+
+	  The Smaia extension encompasses all added CSRs and all modifications to
+	  interrupt response behavior that the AIA specifies for a hart, over
+	  all privilege levels. Per section 1.6 in the AIA spec the exact set of
+	  CSRs enabled depends on various factors; this extension is used to
+	  infer whether a certain CSR is enabled (e.g. if a hart implements
+	  RV32 and SMAIA the CSRs mieh/miph are enabled).
+
+config RISCV_ISA_EXT_SSAIA
+	bool
+	default y if $(dt_compat_all_has_prop,riscv,$(RISCV_ISA_EXT_PROP),ssaia)
+	help
+	  (Ssaia) - Ssaia extension for AIA
+
+	  The Ssaia extension encompasses all added CSRs and all modifications to
+	  interrupt response behavior that the AIA specifies for a hart, over
+	  all privilege levels. However, it excludes machine-level CSRs and behavior
+	  not directly visible to supervisor level. Per section 1.6 in the AIA spec
+	  the exact set of CSRs enabled depends on various factors; this extension
+	  is used to infer whether a certain CSR is enabled (e.g. if a hart
+	  implements RV32 and SSAIA the CSRs sieh/siph are enabled).

--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -177,6 +177,13 @@ if(CONFIG_RISCV_ISA_EXT_XTHEAD_VECTOR)
   string(APPEND riscv_march "_xtheadvector")
 endif()
 
+if(CONFIG_RISCV_ISA_EXT_SMAIA)
+  string(APPEND riscv_march "_smaia")
+endif()
+if(CONFIG_RISCV_ISA_EXT_SSAIA)
+  string(APPEND riscv_march "_ssaia")
+endif()
+
 if(CONFIG_RISCV_USE_MSAVE_RESTORE)
   list(APPEND RISCV_C_FLAGS -msave-restore)
 endif()

--- a/soc/common/riscv-privileged/soc_common_irq.c
+++ b/soc/common/riscv-privileged/soc_common_irq.c
@@ -53,8 +53,6 @@ void z_riscv_irq_vector_set(unsigned int irq)
 
 void arch_irq_enable(unsigned int irq)
 {
-	uint32_t ie;
-
 #if defined(CONFIG_RISCV_HAS_PLIC) || defined(CONFIG_RISCV_HAS_AIA)
 	unsigned int level = irq_get_level(irq);
 #endif
@@ -72,20 +70,32 @@ void arch_irq_enable(unsigned int irq)
 #endif
 
 	/*
-	 * CSR mie/sie register is updated using atomic instruction csrrs
+	 * CSR mie/sie register is updated using atomic instruction csrs
 	 * (atomic read and set bits in CSR register)
 	 */
 #ifdef CONFIG_RISCV_S_MODE
-	ie = csr_read_set(sie, 1 << irq);
+#if !defined(CONFIG_64BIT) && defined(CONFIG_RISCV_ISA_EXT_SSAIA)
+	/* sie is 64 bits in AIA; upper 32 bits are accessed using sieh CSR for RV32 */
+	if (irq >= 32) {
+		csr_set(sieh, 1 << (irq - 32));
+		return;
+	}
+#endif
+	csr_set(sie, 1 << irq);
 #else
-	ie = csr_read_set(mie, 1 << irq);
+#if !defined(CONFIG_64BIT) && defined(CONFIG_RISCV_ISA_EXT_SMAIA)
+	/* mie is 64 bits in AIA; upper 32 bits are accessed using mieh CSR for RV32 */
+	if (irq >= 32) {
+		csr_set(mieh, 1 << (irq - 32));
+		return;
+	}
+#endif
+	csr_set(mie, 1 << irq);
 #endif
 }
 
 void arch_irq_disable(unsigned int irq)
 {
-	uint32_t ie;
-
 #if defined(CONFIG_RISCV_HAS_PLIC) || defined(CONFIG_RISCV_HAS_AIA)
 	unsigned int level = irq_get_level(irq);
 #endif
@@ -103,13 +113,27 @@ void arch_irq_disable(unsigned int irq)
 #endif
 
 	/*
-	 * Use atomic instruction csrrc to disable device interrupt in mie/sie CSR.
+	 * Use atomic instruction csrc to disable device interrupt in mie/sie CSR.
 	 * (atomic read and clear bits in CSR register)
 	 */
 #ifdef CONFIG_RISCV_S_MODE
-	ie = csr_read_clear(sie, 1 << irq);
+#if !defined(CONFIG_64BIT) && defined(CONFIG_RISCV_ISA_EXT_SSAIA)
+	/* sie is 64 bits in AIA; upper 32 bits are accessed using sieh CSR for RV32 */
+	if (irq >= 32) {
+		csr_clear(sieh, 1 << (irq - 32));
+		return;
+	}
+#endif
+	csr_clear(sie, 1 << irq);
 #else
-	ie = csr_read_clear(mie, 1 << irq);
+#if !defined(CONFIG_64BIT) && defined(CONFIG_RISCV_ISA_EXT_SMAIA)
+	/* mie is 64 bits in AIA; upper 32 bits are accessed using mieh CSR for RV32 */
+	if (irq >= 32) {
+		csr_clear(mieh, 1 << (irq - 32));
+		return;
+	}
+#endif
+	csr_clear(mie, 1 << irq);
 #endif
 }
 
@@ -132,8 +156,22 @@ int arch_irq_is_enabled(unsigned int irq)
 #endif
 
 #ifdef CONFIG_RISCV_S_MODE
+#if !defined(CONFIG_64BIT) && defined(CONFIG_RISCV_ISA_EXT_SSAIA)
+	/* sie is 64 bits in AIA; upper 32 bits are accessed using sieh CSR for RV32. */
+	if (irq >= 32) {
+		ie = csr_read(sieh);
+		return !!(ie & (1 << (irq - 32)));
+	}
+#endif
 	ie = csr_read(sie);
 #else
+#if !defined(CONFIG_64BIT) && defined(CONFIG_RISCV_ISA_EXT_SMAIA)
+	/* mie is 64 bits in AIA; upper 32 bits are accessed using mieh CSR for RV32. */
+	if (irq >= 32) {
+		ie = csr_read(mieh);
+		return !!(ie & (1 << (irq - 32)));
+	}
+#endif
 	ie = csr_read(mie);
 #endif
 
@@ -179,10 +217,18 @@ __weak void soc_interrupt_init(void)
 
 #ifdef CONFIG_RISCV_S_MODE
 	csr_write(sie, 0);
+#if !defined(CONFIG_64BIT) && defined(CONFIG_RISCV_ISA_EXT_SSAIA)
+	csr_write(sieh, 0);
+#endif
 	/* sip.STIP is read-only from S-mode; clearing sie is sufficient */
 #else
 	csr_write(mie, 0);
 	csr_write(mip, 0);
+#if !defined(CONFIG_64BIT) && defined(CONFIG_RISCV_ISA_EXT_SMAIA)
+	/* mie/mip are 64 bits in AIA; upper 32 bits are accessed using mieh/miph CSR for RV32 */
+	csr_write(mieh, 0);
+	csr_write(miph, 0);
+#endif
 #endif
 }
 #endif


### PR DESCRIPTION
As a part of the AIA specification two new extensions were introduced: Smaia (Supervisor Machine AIA) and Ssaia (Supervisor Software AIA). Support is added for these 2 extensions.

Additionally, `soc_common_irq.c` is updated to utilize the registers `mieh`, `miph`, `sieh`, and `siph` that are enabled on the condition that RV32 is enabled along with SMAIA/SSAIA.