### PR TITLE
cmake: Fix relative path calculation for linker snippets

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1469,8 +1469,11 @@ function(zephyr_linker_sources location)
       message(FATAL_ERROR "zephyr_linker_sources() was called on a directory")
     endif()
 
-    # Find the relative path to the linker file from the include folder.
-    file(RELATIVE_PATH relpath ${ZEPHYR_BASE}/include ${path})
+    # Find the relative path to the linker file from the snippets folder, which
+    # is searched first for double-quoted includes when preprocessing snippets
+    # files. This ensures the intended file is included while avoiding absolute
+    # paths for reproducibility.
+    file(RELATIVE_PATH relpath ${snippet_base} ${path})
 
     # Create strings to be written into the file
     set (include_str "/* Sort key: \"${SORT_KEY}\" */#include \"${relpath}\"")


### PR DESCRIPTION
Custom linker files passed via `zephyr_linker_sources` are #include'd from snippets*.ld files via relative paths for reproducibility (see https://github.com/zephyrproject-rtos/zephyr/pull/16368 and https://github.com/zephyrproject-rtos/zephyr/pull/21079). These relative paths were calculated relative to `ZEPHYR_BASE/include`.

If paths are structured just ~right~ wrong, it's possible for this relative path to mistakenly pick up a file outside of one's project. This change fixes this by calculating the relative path relative to the snippets base directory, which is the [first][1] header search path the preprocessor looks in when preprocessing snippets files. This guarantees that the preprocessor will first look in the intended place for the included file.

Example reproducer: https://github.com/kesyog/zephyr-relative-path-repro

[1]: https://gcc.gnu.org/onlinedocs/cpp/Search-Path.html