### PR TITLE
shell: name unused shell_thread parameters

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1829,10 +1829,13 @@ static void kill_handler(const struct shell *sh)
 	CODE_UNREACHABLE;
 }
 
-void shell_thread(void *shell_handle, void *, void *)
+void shell_thread(void *shell_handle, void *p2, void *p3)
 {
 	struct shell *sh = shell_handle;
 	int err;
+
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
 
 	if (IS_ENABLED(CONFIG_SHELL_AUTOSTART)) {
 		/* Enable shell and print prompt. */


### PR DESCRIPTION
Omitting the parameter name in a function definition is a C23 extension. Fix this by naming second and third parameter in shell_thread function definition to address compilation warning promoted to error in CI with LLVM.