### PR TITLE
dts: arm: st: add stm32u375Xe dtsi files

### DIFF
--- a/dts/arm/st/u3/stm32u375Xe.dtsi
+++ b/dts/arm/st/u3/stm32u375Xe.dtsi
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/u3/stm32u375.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		/* SRAM1 + SRAM2 */
+		/* 192K + 64K */
+		reg = <0x20000000 DT_SIZE_K(256)>;
+		zephyr,memory-region = "SRAM0";
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(512)>;
+				ranges = <0x0 0x08000000 DT_SIZE_K(512)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
### Description:
Provide support for the ST32U375xE series.

w.r.t this dts file, I believe it's the same as the xG STMs but wit 512K flash available. [Source on pg6.](https://www.st.com/resource/en/datasheet/stm32u375ce.pdf)

### Tests:

Tenstorrent's Device Manager application building with this board, currently still on a development branch.