### PR TITLE
ci: compliance: add support for loading linters from directory

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2975,6 +2975,13 @@ def _main(args):
     global COMMIT_RANGE
     COMMIT_RANGE = args.commits
 
+    # Populate the shared context so linter modules in compliance/ can access
+    # these values without reaching into sys.modules['__main__'] directly.
+    _ctx = sys.modules.get('_compliance_context')
+    if _ctx is not None:
+        _ctx.GIT_TOP = GIT_TOP
+        _ctx.COMMIT_RANGE = COMMIT_RANGE
+
     init_logs(args.loglevel)
 
     logger.info(f'Running tests on commit range {COMMIT_RANGE}')
@@ -3115,6 +3122,56 @@ def err(msg):
         cmd += ": "
     sys.exit(f"{cmd} error: {msg}")
 
+
+# Auto-load all compliance linter modules from the compliance/ sub-directory.
+# Each module is expected to define one or more ComplianceTest subclasses,
+# which are auto-discovered by the inheritors() walk used by the runner.
+#
+# This block must come after all built-in ComplianceTest subclasses are
+# defined so the linter modules can access ComplianceTest via
+# sys.modules['check_compliance'] / sys.modules['__main__'].
+def _load_compliance_linters():
+    import importlib.util
+
+    compliance_dir = Path(__file__).resolve().parent / 'compliance'
+
+    # Load the shared context module first so linter modules can import it.
+    context_path = compliance_dir / '_context.py'
+    if context_path.exists():
+        spec = importlib.util.spec_from_file_location('_compliance_context', context_path)
+        ctx_mod = importlib.util.module_from_spec(spec)
+        sys.modules['_compliance_context'] = ctx_mod
+        spec.loader.exec_module(ctx_mod)
+
+        # Populate static symbols — these are all defined at module level in
+        # check_compliance.py by the time this function runs, so they are safe
+        # to use at linter class-definition time (e.g. as class attributes).
+        _main_mod = sys.modules['__main__']
+        for _attr in (
+            'ComplianceTest',
+            'EndTest',
+            'get_files',
+            'get_shas',
+            'git',
+            'get_set_from_file',
+            'zephyr_doc_detail_builder',
+            'ZEPHYR_BASE',
+            'magic',
+        ):
+            setattr(ctx_mod, _attr, getattr(_main_mod, _attr))
+
+    for linter_path in sorted(compliance_dir.glob('*.py')):
+        if linter_path.name.startswith('_'):
+            continue
+        mod_name = f'_compliance_{linter_path.stem}'
+        spec = importlib.util.spec_from_file_location(mod_name, linter_path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        spec.loader.exec_module(mod)
+
+
+_load_compliance_linters()
+del _load_compliance_linters
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -18,7 +18,6 @@ import sys
 import tempfile
 import textwrap
 import traceback
-from collections.abc import Iterable
 from itertools import takewhile
 from pathlib import Path, PurePath
 
@@ -45,8 +44,6 @@ import unidiff
 import yaml
 from dotenv import load_dotenv
 from junitparser import Error, Failure, JUnitXml, Skipped, TestCase, TestSuite
-from reuse.project import Project
-from reuse.report import ProjectSubsetReport
 from west.manifest import Manifest, ManifestProject
 from yamllint import config, linter
 
@@ -1803,70 +1800,6 @@ class GitDiffCheck(ComplianceTest):
 
         if len(offending_lines) > 0:
             self.failure("\n".join(offending_lines))
-
-
-class LicenseAndCopyrightCheck(ComplianceTest):
-    """
-    Verify that every file touched by the patch set has correct SPDX headers and uses allowed
-    license.
-    """
-
-    name = "LicenseAndCopyrightCheck"
-    doc = "Check SPDX headers and copyright lines with the reuse Python API."
-
-    def _report_violations(
-        self,
-        paths: Iterable[Path],
-        title: str,
-        severity: str,
-        desc: str | None = None,
-    ) -> None:
-        for p in paths:
-            rel_path = os.path.relpath(str(p), GIT_TOP)
-            self.fmtd_failure(severity, title, rel_path, desc=desc or "", line=1)
-
-    def run(self) -> None:
-        changed_files = get_files(filter="d")
-        if not changed_files:
-            return
-
-        # Only scan text files for now, in the future we may want to leverage REUSE standard's
-        # ability to also associate license/copyright info with binary files.
-        filtered_files = []
-        for file in changed_files:
-            full_path = GIT_TOP / file
-            mime_type = magic.from_file(os.fspath(full_path), mime=True)
-            if mime_type.startswith("text/"):
-                filtered_files.append(file)
-        changed_files = filtered_files
-
-        project = Project.from_directory(GIT_TOP)
-        report = ProjectSubsetReport.generate(project, changed_files, multiprocessing=False)
-
-        self._report_violations(
-            report.files_without_licenses,
-            "License missing",
-            "warning",
-            "File has no SPDX-License-Identifier header, consider adding one.",
-        )
-
-        self._report_violations(
-            report.files_without_copyright,
-            "Copyright missing",
-            "warning",
-            "File has no SPDX-FileCopyrightText header, consider adding one.",
-        )
-
-        for lic_id, paths in getattr(report, "missing_licenses", {}).items():
-            self._report_violations(
-                paths,
-                "License may not be allowed",
-                "warning",
-                (
-                    f"License file for '{lic_id}' not found in /LICENSES. Please check "
-                    "https://docs.zephyrproject.org/latest/contribute/guidelines.html#components-using-other-licenses."
-                ),
-            )
 
 
 class GitLint(ComplianceTest):

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -9,7 +9,6 @@ import collections
 import json
 import logging
 import os
-import platform
 import re
 import shlex
 import shutil
@@ -40,7 +39,6 @@ except ImportError:
         if dll_dir.is_dir():
             os.environ['PATH'] = str(dll_dir) + os.pathsep + os.environ.get('PATH', '')
     import magic
-import unidiff
 import yaml
 from dotenv import load_dotenv
 from junitparser import Error, Failure, JUnitXml, Skipped, TestCase, TestSuite
@@ -417,58 +415,6 @@ class BoardYmlCheck(ComplianceTest):
 
         for file in path.glob("**/board.yml"):
             self.check_board_file(file, vendor_prefixes)
-
-
-class ClangFormatCheck(ComplianceTest):
-    """
-    Check if clang-format reports any issues
-    """
-
-    name = "ClangFormat"
-    doc = zephyr_doc_detail_builder("/contribute/guidelines.html#clang-format")
-
-    def _process_patch_error(self, file: str, patch: unidiff.PatchedFile):
-        for hunk in patch:
-            # Strip the before and after context
-            before = next(i for i, v in enumerate(hunk) if str(v).startswith(('-', '+')))
-            after = next(i for i, v in enumerate(reversed(hunk)) if str(v).startswith(('-', '+')))
-            msg = "".join([str(line) for line in hunk[before : -after or None]])
-
-            # show the hunk at the last line
-            self.fmtd_failure(
-                "notice",
-                "You may want to run clang-format on this change",
-                file,
-                line=hunk.source_start + hunk.source_length - after,
-                desc=f'\r\n{msg}',
-            )
-
-    def run(self):
-        exe = f"clang-format-diff.{'exe' if platform.system() == 'Windows' else 'py'}"
-
-        for file in get_files():
-            if Path(file).suffix not in ['.c', '.h']:
-                continue
-
-            diff = subprocess.Popen(
-                ('git', 'diff', '-U0', '--no-color', COMMIT_RANGE, '--', file),
-                stdout=subprocess.PIPE,
-                cwd=GIT_TOP,
-            )
-            try:
-                subprocess.run(
-                    (exe, '-p1'),
-                    check=True,
-                    stdin=diff.stdout,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    cwd=GIT_TOP,
-                )
-
-            except subprocess.CalledProcessError as ex:
-                patchset = unidiff.PatchSet.from_string(ex.output, encoding="utf-8")
-                for patch in patchset:
-                    self._process_patch_error(file, patch)
 
 
 class DevicetreeBindingsCheck(ComplianceTest):

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -3030,6 +3030,8 @@ def _main(args):
             test.run()
         except EndTest:
             pass
+        except KeyboardInterrupt:
+            raise
         except BaseException:
             test.failure(f"An exception occurred in {test.name}:\n{traceback.format_exc()}")
 

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1987,45 +1987,6 @@ def filter_py(root, fnames):
     ]
 
 
-class CMakeStyle(ComplianceTest):
-    """
-    Checks cmake style added/modified files
-    """
-
-    name = "CMakeStyle"
-    doc = zephyr_doc_detail_builder("/contribute/style/cmake.html")
-
-    def run(self):
-        # Loop through added/modified files
-        for fname in get_files(filter="d"):
-            if fname.endswith(".cmake") or fname.endswith("CMakeLists.txt"):
-                self.check_style(fname)
-
-    def check_style(self, fname):
-        SPACE_BEFORE_OPEN_BRACKETS_CHECK = re.compile(r"^\s*if\s+\(")
-        TAB_INDENTATION_CHECK = re.compile(r"^\t+")
-
-        with open(fname, encoding="utf-8") as f:
-            for line_num, line in enumerate(f.readlines(), start=1):
-                if TAB_INDENTATION_CHECK.match(line):
-                    self.fmtd_failure(
-                        "error",
-                        "CMakeStyle",
-                        fname,
-                        line_num,
-                        "Use spaces instead of tabs for indentation",
-                    )
-
-                if SPACE_BEFORE_OPEN_BRACKETS_CHECK.match(line):
-                    self.fmtd_failure(
-                        "error",
-                        "CMakeStyle",
-                        fname,
-                        line_num,
-                        "Remove space before '(' in if() statements",
-                    )
-
-
 class Identity(ComplianceTest):
     """
     Checks if Emails of author and signed-off messages are consistent.

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -43,7 +43,6 @@ import yaml
 from dotenv import load_dotenv
 from junitparser import Error, Failure, JUnitXml, Skipped, TestCase, TestSuite
 from west.manifest import Manifest, ManifestProject
-from yamllint import config, linter
 
 try:
     from yaml import CSafeLoader as SafeLoader
@@ -2052,37 +2051,6 @@ class ZephyrModuleFile(ComplianceTest):
             if os.path.exists(file):
                 self.failure("A zephyr module file has been added to the Zephyr repository")
                 break
-
-
-class YAMLLint(ComplianceTest):
-    """
-    YAMLLint
-    """
-
-    name = "YAMLLint"
-    doc = "Check YAML files with YAMLLint."
-
-    def run(self):
-        config_file = ZEPHYR_BASE / ".yamllint"
-
-        for file in get_files(filter="d"):
-            if Path(file).suffix not in ['.yaml', '.yml']:
-                continue
-
-            yaml_config = config.YamlLintConfig(file=config_file)
-
-            if file.startswith(".github/"):
-                # Tweak few rules for workflow files.
-                yaml_config.rules["line-length"] = False
-                yaml_config.rules["truthy"]["allowed-values"].extend(['on', 'off'])
-            elif file == ".codecov.yml":
-                yaml_config.rules["truthy"]["allowed-values"].extend(['yes', 'no'])
-
-            with open(file) as fp:
-                for p in linter.run(fp, yaml_config):
-                    self.fmtd_failure(
-                        'warning', f'YAMLLint ({p.rule})', file, p.line, col=p.column, desc=p.desc
-                    )
 
 
 class SphinxLint(ComplianceTest):

--- a/scripts/ci/compliance/_context.py
+++ b/scripts/ci/compliance/_context.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2018,2020 Intel Corporation
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared API for compliance linter modules loaded from the compliance/
+# sub-directory.  Linter modules import this module as:
+#
+#   import _compliance_context as _ctx
+#
+# Two categories of symbols are exposed:
+#
+# Static symbols — populated by the loader (_load_compliance_linters in
+# check_compliance.py) immediately after this module is registered in
+# sys.modules, before any linter module is imported.  They are safe to
+# use at class-definition time (e.g. as default arguments or class
+# attributes).
+#
+# Dynamic symbols — populated by _main() after the argument parser runs.
+# They must only be accessed inside method bodies, not at module or
+# class-definition time.
+
+# --- Static symbols (available at linter import time) ---
+
+# Base class all linter checks must subclass.
+ComplianceTest = None
+
+# Exception raised by ComplianceTest.error() / .skip().
+EndTest = None
+
+# Returns the list of files added/modified by the commit range.
+get_files = None
+
+# Returns the list of Git SHAs for a refspec.
+get_shas = None
+
+# Runs a git command and returns stdout.
+git = None
+
+# Loads a file into a set, one element per line (comments stripped).
+get_set_from_file = None
+
+# Builds a "See <url> for more details." documentation string.
+zephyr_doc_detail_builder = None
+
+# Absolute path to the Zephyr base directory.
+ZEPHYR_BASE = None
+
+# python-magic file-type detection library (may be the bundled Windows shim).
+magic = None
+
+# --- Dynamic symbols (available only inside method bodies at run time) ---
+
+# Absolute path of the top-level git directory (set by _main()).
+GIT_TOP = None
+
+# Commit range passed via --commits, e.g. "HEAD~3" (set by _main()).
+COMMIT_RANGE = None

--- a/scripts/ci/compliance/_context.py
+++ b/scripts/ci/compliance/_context.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2018,2020 Intel Corporation
 # Copyright (c) 2022 Nordic Semiconductor ASA
+# Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # Shared API for compliance linter modules loaded from the compliance/

--- a/scripts/ci/compliance/clang_format.py
+++ b/scripts/ci/compliance/clang_format.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2018,2020 Intel Corporation
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+import platform
+import subprocess
+from pathlib import Path
+
+import _compliance_context as _ctx
+import unidiff
+
+
+class ClangFormatCheck(_ctx.ComplianceTest):
+    """
+    Check if clang-format reports any issues
+    """
+
+    name = "ClangFormat"
+    doc = _ctx.zephyr_doc_detail_builder("/contribute/guidelines.html#clang-format")
+
+    def _process_patch_error(self, file: str, patch: unidiff.PatchedFile):
+        for hunk in patch:
+            # Strip the before and after context
+            before = next(i for i, v in enumerate(hunk) if str(v).startswith(('-', '+')))
+            after = next(i for i, v in enumerate(reversed(hunk)) if str(v).startswith(('-', '+')))
+            msg = "".join([str(line) for line in hunk[before : -after or None]])
+
+            # show the hunk at the last line
+            self.fmtd_failure(
+                "notice",
+                "You may want to run clang-format on this change",
+                file,
+                line=hunk.source_start + hunk.source_length - after,
+                desc=f'\r\n{msg}',
+            )
+
+    def run(self):
+        exe = f"clang-format-diff.{'exe' if platform.system() == 'Windows' else 'py'}"
+
+        for file in _ctx.get_files():
+            if Path(file).suffix not in ['.c', '.h']:
+                continue
+
+            diff = subprocess.Popen(
+                ('git', 'diff', '-U0', '--no-color', _ctx.COMMIT_RANGE, '--', file),
+                stdout=subprocess.PIPE,
+                cwd=_ctx.GIT_TOP,
+            )
+            try:
+                subprocess.run(
+                    (exe, '-p1'),
+                    check=True,
+                    stdin=diff.stdout,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    cwd=_ctx.GIT_TOP,
+                )
+
+            except subprocess.CalledProcessError as ex:
+                patchset = unidiff.PatchSet.from_string(ex.output, encoding="utf-8")
+                for patch in patchset:
+                    self._process_patch_error(file, patch)

--- a/scripts/ci/compliance/cmake_style.py
+++ b/scripts/ci/compliance/cmake_style.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2018,2020 Intel Corporation
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+import _compliance_context as _ctx
+
+
+class CMakeStyle(_ctx.ComplianceTest):
+    """
+    Checks cmake style added/modified files
+    """
+
+    name = "CMakeStyle"
+    doc = _ctx.zephyr_doc_detail_builder("/contribute/style/cmake.html")
+
+    def run(self):
+        # Loop through added/modified files
+        for fname in _ctx.get_files(filter="d"):
+            if fname.endswith(".cmake") or fname.endswith("CMakeLists.txt"):
+                self.check_style(fname)
+
+    def check_style(self, fname):
+        SPACE_BEFORE_OPEN_BRACKETS_CHECK = re.compile(r"^\s*if\s+\(")
+        TAB_INDENTATION_CHECK = re.compile(r"^\t+")
+
+        with open(fname, encoding="utf-8") as f:
+            for line_num, line in enumerate(f.readlines(), start=1):
+                if TAB_INDENTATION_CHECK.match(line):
+                    self.fmtd_failure(
+                        "error",
+                        "CMakeStyle",
+                        fname,
+                        line_num,
+                        "Use spaces instead of tabs for indentation",
+                    )
+
+                if SPACE_BEFORE_OPEN_BRACKETS_CHECK.match(line):
+                    self.fmtd_failure(
+                        "error",
+                        "CMakeStyle",
+                        fname,
+                        line_num,
+                        "Remove space before '(' in if() statements",
+                    )

--- a/scripts/ci/compliance/license_and_copyright.py
+++ b/scripts/ci/compliance/license_and_copyright.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2018,2020 Intel Corporation
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from collections.abc import Iterable
+from pathlib import Path
+
+import _compliance_context as _ctx
+from reuse.project import Project
+from reuse.report import ProjectSubsetReport
+
+
+class LicenseAndCopyrightCheck(_ctx.ComplianceTest):
+    """
+    Verify that every file touched by the patch set has correct SPDX headers and uses allowed
+    license.
+    """
+
+    name = "LicenseAndCopyrightCheck"
+    doc = "Check SPDX headers and copyright lines with the reuse Python API."
+
+    def _report_violations(
+        self,
+        paths: Iterable[Path],
+        title: str,
+        severity: str,
+        desc: str | None = None,
+    ) -> None:
+        for p in paths:
+            rel_path = os.path.relpath(str(p), _ctx.GIT_TOP)
+            self.fmtd_failure(severity, title, rel_path, desc=desc or "", line=1)
+
+    def run(self) -> None:
+        changed_files = _ctx.get_files(filter="d")
+        if not changed_files:
+            return
+
+        # Only scan text files for now, in the future we may want to leverage REUSE standard's
+        # ability to also associate license/copyright info with binary files.
+        filtered_files = []
+        for file in changed_files:
+            full_path = _ctx.GIT_TOP / file
+            mime_type = _ctx.magic.from_file(os.fspath(full_path), mime=True)
+            if mime_type.startswith("text/"):
+                filtered_files.append(file)
+        changed_files = filtered_files
+
+        project = Project.from_directory(_ctx.GIT_TOP)
+        report = ProjectSubsetReport.generate(project, changed_files, multiprocessing=False)
+
+        self._report_violations(
+            report.files_without_licenses,
+            "License missing",
+            "warning",
+            "File has no SPDX-License-Identifier header, consider adding one.",
+        )
+
+        self._report_violations(
+            report.files_without_copyright,
+            "Copyright missing",
+            "warning",
+            "File has no SPDX-FileCopyrightText header, consider adding one.",
+        )
+
+        for lic_id, paths in getattr(report, "missing_licenses", {}).items():
+            self._report_violations(
+                paths,
+                "License may not be allowed",
+                "warning",
+                (
+                    f"License file for '{lic_id}' not found in /LICENSES. Please check "
+                    "https://docs.zephyrproject.org/latest/contribute/guidelines.html#components-using-other-licenses."
+                ),
+            )

--- a/scripts/ci/compliance/yaml_lint.py
+++ b/scripts/ci/compliance/yaml_lint.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2018,2020 Intel Corporation
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import _compliance_context as _ctx
+from yamllint import config, linter
+
+
+class YAMLLint(_ctx.ComplianceTest):
+    """
+    YAMLLint
+    """
+
+    name = "YAMLLint"
+    doc = "Check YAML files with YAMLLint."
+
+    def run(self):
+        config_file = _ctx.ZEPHYR_BASE / ".yamllint"
+
+        for file in _ctx.get_files(filter="d"):
+            if Path(file).suffix not in ['.yaml', '.yml']:
+                continue
+
+            yaml_config = config.YamlLintConfig(file=config_file)
+
+            if file.startswith(".github/"):
+                # Tweak few rules for workflow files.
+                yaml_config.rules["line-length"] = False
+                yaml_config.rules["truthy"]["allowed-values"].extend(['on', 'off'])
+            elif file == ".codecov.yml":
+                yaml_config.rules["truthy"]["allowed-values"].extend(['yes', 'no'])
+
+            with open(file) as fp:
+                for p in linter.run(fp, yaml_config):
+                    self.fmtd_failure(
+                        'warning', f'YAMLLint ({p.rule})', file, p.line, col=p.column, desc=p.desc
+                    )

--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -38,6 +38,7 @@ doc/*
 scripts/ci/test_plan.py
 scripts/ci/twister_ignore.txt
 scripts/ci/check_compliance.py
+scripts/ci/compliance/*.py
 scripts/ci/errno.py
 scripts/ci/upload_test_results_es.py
 scripts/ci/what_changed.py


### PR DESCRIPTION
The compliance_check.py is becoming increasingly complex as more linters are
added, and the number of shared utilities and globals grows.

Auto-load all compliance linter modules from the compliance/ sub-directory.
Each module is expected to define one or more ComplianceTest subclasses,
which are auto-discovered by the inheritors() walk used by the runner.

Introduce scripts/ci/compliance/_context.py as a shared namespace for
runtime globals (GIT_TOP, COMMIT_RANGE) that linter modules in the
compliance/ directory need but which are only available after _main()
runs.

The loader in check_compliance.py now loads _context.py first (before
any linter module) and registers it in sys.modules as
'_compliance_context'.  _main() populates the context immediately after
setting its own globals.

_context.py now exposes all symbols that linter modules need,
split into two categories:

  Static symbols — populated by the loader before any linter module
  is imported (ComplianceTest, EndTest, get_files, get_shas, git,
  get_set_from_file, zephyr_doc_detail_builder, ZEPHYR_BASE, magic).
  Safe to use at class-definition time.

  Dynamic symbols — populated by _main() after argument parsing
  (GIT_TOP, COMMIT_RANGE). Must only be accessed inside method bodies.

The loader (_load_compliance_linters) now populates all static symbols
into _ctx immediately after registering _context.py in sys.modules,
before any linter module is imported.

The canonical pattern for a new linter module is now:

  import _compliance_context as _ctx

  class MyChecker(_ctx.ComplianceTest):
      doc = _ctx.zephyr_doc_detail_builder("...")

      def run(self):
          for f in _ctx.get_files():
              ...

This PR moves a few of the linters with the goal of moving everything out in the next step.