### PR TITLE
subsys: debug: fix mipi stp unaligned access with clang

### DIFF
--- a/subsys/debug/mipi_stp_decoder.c
+++ b/subsys/debug/mipi_stp_decoder.c
@@ -8,7 +8,9 @@
 
 #if defined(CONFIG_CPU_CORTEX_M) && \
 	!defined(CONFIG_CPU_CORTEX_M0) && \
-	!defined(CONFIG_CPU_CORTEX_M0PLUS)
+	!defined(CONFIG_CPU_CORTEX_M0PLUS) && \
+	!defined(CONFIG_TRAP_UNALIGNED_ACCESS) && \
+	!defined(__clang__)
 #define UNALIGNED_ACCESS_SUPPORTED 1
 #else
 #define UNALIGNED_ACCESS_SUPPORTED 0


### PR DESCRIPTION
The fast nibble-copy path in the MIPI STP decoder assumes unaligned
multiword accesses are safe on Cortex-M.

With clang on mps2/an385 this can still generate unaligned accesses in
the optimized path, causing a UsageFault in debug.mipi_stp_decoder.

Disable the fast path for clang (and when unaligned trapping is enabled),
falling back to the existing byte-wise safe path.

