### PR TITLE
samples: net: quic: fix stream direction enum in echo service

### DIFF
--- a/samples/net/quic/echo_client/src/main.c
+++ b/samples/net/quic/echo_client/src/main.c
@@ -568,7 +568,7 @@ skip_ipv6:
 	}
 
 	ret = setup_quic(net_sad(&remote_addr), net_sad(&local_addr),
-			 QUIC_STREAM_CLIENT,
+			 QUIC_STREAM_BIDIRECTIONAL,
 			 sec_tag_list, sizeof(sec_tag_list),
 			 (const char **)alpn_list, sizeof(alpn_list));
 	if (ret < 0) {

--- a/samples/net/quic/echo_service/src/main.c
+++ b/samples/net/quic/echo_service/src/main.c
@@ -351,7 +351,7 @@ static int setup_quic_socket(struct sockaddr_in6 *addr)
 	};
 
 	/* Common socket setup for QUIC can be found in samples/net/common/quic.c */
-	sock = setup_quic(NULL, (struct sockaddr *)addr, QUIC_STREAM_SERVER,
+	sock = setup_quic(NULL, (struct sockaddr *)addr, QUIC_STREAM_BIDIRECTIONAL,
 			  sec_tag_list, sizeof(sec_tag_list),
 			  (const char **)alpn_list, sizeof(alpn_list));
 	if (sock < 0) {


### PR DESCRIPTION
Pass QUIC_STREAM_BIDIRECTIONAL to setup_quic() instead of
QUIC_STREAM_SERVER.

setup_quic() expects enum quic_stream_direction, while
QUIC_STREAM_SERVER is from enum quic_stream_initiator. This fixes
Clang's -Wenum-conversion warning in the echo service sample.

