### PR TITLE
cmake: clang: Fix stack protector guard flag compatibility

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -152,3 +152,11 @@ set_compiler_property(PROPERTY no_track_macro_expansion "-fmacro-backtrace-limit
 set_compiler_property(PROPERTY no_global_merge "-mno-global-merge")
 
 set_compiler_property(PROPERTY specs)
+
+# Clang doesn't support -mstack-protector-guard flags. Override the properties
+# inherited from GCC to only include the base -fstack-protector variants.
+set_compiler_property(PROPERTY security_canaries -fstack-protector)
+set_compiler_property(PROPERTY security_canaries_strong -fstack-protector-strong)
+set_compiler_property(PROPERTY security_canaries_all -fstack-protector-all)
+set_compiler_property(PROPERTY security_canaries_explicit -fstack-protector-explicit)
+set_compiler_property(PROPERTY security_canaries_global)


### PR DESCRIPTION
Clang doesn't support -mstack-protector-guard flags that are used by GCC.
These flags are particularly problematic on RISC-V where they cause
compilation failures.

Override the security_canaries properties in Clang to only include the
base -fstack-protector variants, removing the unsupported -mstack-protector-guard
flags inherited from GCC.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
