### PR TITLE
arch: riscv: csr: drop deprecated register storage class

### DIFF
--- a/include/zephyr/arch/riscv/csr.h
+++ b/include/zephyr/arch/riscv/csr.h
@@ -209,7 +209,7 @@
 
 #define csr_read(csr)						\
 ({								\
-	register unsigned long __rv;				\
+	unsigned long __rv;					\
 	__asm__ volatile ("csrr %0, " STRINGIFY(csr)		\
 				: "=r" (__rv));			\
 	__rv;							\


### PR DESCRIPTION
Clang in C++17 mode emits -Wdeprecated-register for the register
storage class, and Zephyr treats warnings as errors in this build.

Remove register from csr_read()'s temporary variable declaration.
This keeps behavior unchanged and fixes LLVM builds.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
