### PR TITLE
cmake: fix ARM llext module loading with clang

### DIFF
--- a/cmake/compiler/clang/target_arm.cmake
+++ b/cmake/compiler/clang/target_arm.cmake
@@ -20,7 +20,7 @@ if(CONFIG_FPU)
     set(FORCE_FP_HARDABI TRUE)
   endif()
 
-  if    (CONFIG_FP_HARDABI OR FORCE_FP_HARDABI)
+  if(CONFIG_FP_HARDABI OR FORCE_FP_HARDABI)
     list(APPEND ARM_C_FLAGS   -mfloat-abi=hard)
   elseif(CONFIG_FP_SOFTABI)
     list(APPEND ARM_C_FLAGS   -mfloat-abi=softfp)
@@ -40,3 +40,20 @@ if(CONFIG_FP16)
 endif()
 list(APPEND TOOLCHAIN_C_FLAGS ${ARM_C_FLAGS})
 list(APPEND TOOLCHAIN_GROUPED_LD_FLAGS ARM_C_FLAGS)
+
+# Flags not supported by llext linker
+# (regexps are supported and match whole word)
+set(LLEXT_REMOVE_FLAGS
+  -fno-pic
+  -fno-pie
+  -ffunction-sections
+  -fdata-sections
+  -Os
+)
+
+# Flags to be added to llext code compilation
+set(LLEXT_APPEND_FLAGS
+  -mlong-calls
+  -mthumb
+  -fno-unwind-tables
+)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -6192,6 +6192,10 @@ function(add_llext_target target_name)
             $<TARGET_PROPERTY:bintools,elfconvert_flag_strip_unneeded>
             $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>.xt.*
             $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>.xtensa.info
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>.ARM.exidx*
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>.rel.ARM.exidx*
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>.ARM.extab*
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>.rel.ARM.extab*
             $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${llext_pkg_input}
             $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${llext_pkg_output}
             $<TARGET_PROPERTY:bintools,elfconvert_flag_final>


### PR DESCRIPTION
Define ARM-specific LLEXT compile flags for the clang toolchain
configuration to match GCC behavior.

This adds long-call code generation for extension objects and disables
unwind table emission in llext builds.

Also strip ARM unwind metadata sections from packaged .llext files so
the loader does not encounter relocations against non-loaded unwind
sections (.ARM.exidx/.ARM.extab and related rel sections).

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
