### PR TITLE
llext: various fixes to make llext buildable with llvm

### DIFF
--- a/cmake/linker/llext_relocatable.ld
+++ b/cmake/linker/llext_relocatable.ld
@@ -1,0 +1,44 @@
+/*
+ * Grouping linker script for the LLEXT partial link (-r / --relocatable) step.
+ *
+ * The LLEXT loader computes one contiguous file-offset region per llext_mem
+ * type (TEXT, RODATA, DATA, BSS ...) by spanning the min->max offsets of all
+ * sections of that type.  When lld is used without an explicit script, it
+ * places sections in encounter order without grouping by type, which can put
+ * a .data section between two .text sections in the file.  The resulting
+ * overlapping computed regions cause the loader to reject the ELF.
+ *
+ * This script groups all sections of each type together so the loader's
+ * region spans are contiguous and non-overlapping.  Sections not listed here
+ * (RELA tables, debug info, attributes, etc.) are placed as orphans after
+ * the grouped sections; the LLEXT loader ignores them.
+ *
+ * The loader classifies each input section into a region by its ELF flags
+ * (executable -> TEXT, writable -> DATA, otherwise -> RODATA), not by name.
+ * Custom-named sections created via Z_GENERIC_SECTION() therefore have to be
+ * placed here next to the other sections of matching flags, otherwise the
+ * linker emits them as orphans whose file offsets fall outside the region span
+ * the loader computes, making a region appear to overlap another.
+ *
+ * Custom sections that the LLEXT tests inspect by name (e.g. .my_rodata, or
+ * .detach looked up via llext_get_section_header()) are kept as their own
+ * output sections rather than merged into the standard one, so the section
+ * identity survives in the linked object; they are still placed adjacent to
+ * the matching type group to keep the region file-offset spans contiguous.
+ */
+
+SECTIONS
+{
+    .text          : { *(.text .text.* .TEXT .TEXT.* .literal .literal.*) }
+    .detach        : { *(.detach) }
+    .rodata        : { *(.rodata .rodata.* .rodata.str*.* *_sect_*) }
+    .my_rodata     : { *(.my_rodata) }
+    .llext.rodata.noreloc : { *(.llext.rodata.noreloc .llext.rodata.noreloc.*) }
+    .data.rel.ro   : { *(.data.rel.ro .data.rel.ro.*) }
+    .data          : { *(.data .data.* .sdata .sdata.*) }
+    .bss           : { *(.bss .bss.* .sbss .sbss.* COMMON) }
+    .preinit_array : { *(.preinit_array .preinit_array.*) }
+    .init_array    : { *(.init_array .init_array.*) }
+    .fini_array    : { *(.fini_array .fini_array.*) }
+    .exported_sym  : { *(.exported_sym) }
+}

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -6166,8 +6166,20 @@ function(add_llext_target target_name)
     # output a relocatable file. The output file suffix is changed so
     # the result looks like the object file it actually is.
     add_executable(${llext_lib_target} EXCLUDE_FROM_ALL ${source_files})
-    target_link_options(${llext_lib_target} PRIVATE
-      $<TARGET_PROPERTY:linker,partial_linking>)
+    if("${LINKER}" STREQUAL "lld")
+      # lld does not group sections by type in -r mode; an explicit grouping
+      # script is required to prevent section interleaving that would cause
+      # the LLEXT loader to see overlapping file-offset regions.
+      target_link_options(${llext_lib_target} PRIVATE
+        $<TARGET_PROPERTY:linker,partial_linking>
+        -T ${ZEPHYR_BASE}/cmake/linker/llext_relocatable.ld)
+    else()
+      # GNU ld naturally groups sections by type; no grouping script is needed.
+      # Applying the script would cause xt-ld and similar linkers to assign
+      # non-zero VMAs to sections, breaking the LLEXT Xtensa relocation handler.
+      target_link_options(${llext_lib_target} PRIVATE
+        $<TARGET_PROPERTY:linker,partial_linking>)
+    endif()
     set_target_properties(${llext_lib_target} PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/llext
       SUFFIX ${CMAKE_C_OUTPUT_EXTENSION})

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -336,13 +336,14 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 			 */
 			if (shdr->sh_entsize != 0 && shdr->sh_entsize != sizeof(void *)) {
 				LOG_ERR("Invalid %s array entry size %zu in section %d",
-					name, shdr->sh_entsize, i);
+					name, (size_t)shdr->sh_entsize, i);
 				return -ENOEXEC;
 			}
 			if (shdr->sh_entsize != 0 && (shdr->sh_size % shdr->sh_entsize != 0)) {
 				LOG_ERR("Invalid %s array size %zu not multiple of entry size %zu "
 					"in section %d",
-					name, shdr->sh_size, shdr->sh_entsize, i);
+					name, (size_t)shdr->sh_size,
+					(size_t)shdr->sh_entsize, i);
 				return -ENOEXEC;
 			}
 		default:

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -312,9 +312,21 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 		case LLEXT_MEM_PREINIT:
 		case LLEXT_MEM_INIT:
 		case LLEXT_MEM_FINI:
-			if (shdr->sh_entsize != sizeof(void *) ||
-			    shdr->sh_size % shdr->sh_entsize != 0) {
-				LOG_ERR("Invalid %s array in section %d", name, i);
+			/*
+			 * Validate that the section is a valid array of pointers.
+			 * Both GCC and Clang may set sh_entsize to 0 (variable) or
+			 * sizeof(void *). Accept both and validate size is divisible
+			 * by pointer size, or allow any size if entsize is 0.
+			 */
+			if (shdr->sh_entsize != 0 && shdr->sh_entsize != sizeof(void *)) {
+				LOG_ERR("Invalid %s array entry size %zu in section %d",
+					name, shdr->sh_entsize, i);
+				return -ENOEXEC;
+			}
+			if (shdr->sh_entsize != 0 && (shdr->sh_size % shdr->sh_entsize != 0)) {
+				LOG_ERR("Invalid %s array size %zu not multiple of entry size %zu "
+					"in section %d",
+					name, shdr->sh_size, shdr->sh_entsize, i);
 				return -ENOEXEC;
 			}
 		default:

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -157,14 +157,15 @@ static int llext_load_elf_data(struct llext_loader *ldr, struct llext *ext)
  */
 static int llext_find_tables(struct llext_loader *ldr, struct llext *ext)
 {
-	int table_cnt, i;
+	int i;
 	int shstrtab_ndx = ldr->hdr.e_shstrndx;
 	int strtab_ndx = -1;
+	int symtab_ndx = -1;
 
 	memset(ldr->sects, 0, sizeof(ldr->sects));
 
-	/* Find symbol and string tables */
-	for (i = 0, table_cnt = 0; i < ext->sect_cnt && table_cnt < 3; ++i) {
+	/* Find symbol table and section-name string table. */
+	for (i = 0; i < ext->sect_cnt; ++i) {
 		elf_shdr_t *shdr = ext->sect_hdrs + i;
 
 		LOG_DBG("section %d at %#zx: name %d, type %d, flags %#zx, "
@@ -182,26 +183,41 @@ static int llext_find_tables(struct llext_loader *ldr, struct llext *ext)
 
 		if (shdr->sh_type == SHT_SYMTAB && ldr->hdr.e_type == ET_REL) {
 			LOG_DBG("symtab at %d", i);
-			memcpy(&ldr->sects[LLEXT_MEM_SYMTAB], shdr, sizeof(*shdr));
-			ldr->sect_map[i].mem_idx = LLEXT_MEM_SYMTAB;
+			symtab_ndx = i;
 			strtab_ndx = shdr->sh_link;
-			table_cnt++;
 		} else if (shdr->sh_type == SHT_DYNSYM && ldr->hdr.e_type == ET_DYN) {
 			LOG_DBG("dynsym at %d", i);
-			memcpy(&ldr->sects[LLEXT_MEM_SYMTAB], shdr, sizeof(*shdr));
-			ldr->sect_map[i].mem_idx = LLEXT_MEM_SYMTAB;
+			symtab_ndx = i;
 			strtab_ndx = shdr->sh_link;
-			table_cnt++;
 		} else if (shdr->sh_type == SHT_STRTAB && i == shstrtab_ndx) {
 			LOG_DBG("shstrtab at %d", i);
 			memcpy(&ldr->sects[LLEXT_MEM_SHSTRTAB], shdr, sizeof(*shdr));
 			ldr->sect_map[i].mem_idx = LLEXT_MEM_SHSTRTAB;
-			table_cnt++;
-		} else if (shdr->sh_type == SHT_STRTAB && i == strtab_ndx) {
-			LOG_DBG("strtab at %d", i);
-			memcpy(&ldr->sects[LLEXT_MEM_STRTAB], shdr, sizeof(*shdr));
-			ldr->sect_map[i].mem_idx = LLEXT_MEM_STRTAB;
-			table_cnt++;
+		}
+	}
+
+	if (symtab_ndx >= 0) {
+		elf_shdr_t *symtab = ext->sect_hdrs + symtab_ndx;
+
+		memcpy(&ldr->sects[LLEXT_MEM_SYMTAB], symtab, sizeof(*symtab));
+		ldr->sect_map[symtab_ndx].mem_idx = LLEXT_MEM_SYMTAB;
+	} else {
+		LOG_WRN("ELF has no symbol table, it may have been stripped");
+	}
+
+	if (strtab_ndx >= 0) {
+		if (strtab_ndx >= (int)ext->sect_cnt) {
+			LOG_ERR("String table index %d out of bounds, section count %u",
+				strtab_ndx, ext->sect_cnt);
+			return -ENOEXEC;
+		}
+
+		elf_shdr_t *strtab = ext->sect_hdrs + strtab_ndx;
+
+		if (strtab->sh_type == SHT_STRTAB) {
+			LOG_DBG("strtab at %d", strtab_ndx);
+			memcpy(&ldr->sects[LLEXT_MEM_STRTAB], strtab, sizeof(*strtab));
+			ldr->sect_map[strtab_ndx].mem_idx = LLEXT_MEM_STRTAB;
 		}
 	}
 

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -555,6 +555,17 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 				continue;
 			}
 
+			/*
+			 * Some toolchains (e.g. Clang) merge the symbol string
+			 * table and the section header name table into a single
+			 * ELF section, making STRTAB and SHSTRTAB refer to the
+			 * same file region.  This is valid ELF; skip the check.
+			 */
+			if ((i == LLEXT_MEM_STRTAB && j == LLEXT_MEM_SHSTRTAB) ||
+			    (i == LLEXT_MEM_SHSTRTAB && j == LLEXT_MEM_STRTAB)) {
+				continue;
+			}
+
 			if (REGIONS_OVERLAP_ON(x, y, sh_offset)) {
 				LOG_ERR("Region %d ELF file range (%#zx-%#zx) "
 					"overlaps with %d (%#zx-%#zx)",


### PR DESCRIPTION
- **llext: Fix Clang compatibility for ELF section loading**
- **llext: fix table discovery order for clang**
- **llext: fix elf xword log format types**
