### PR TITLE
usb: host: add endpoint enable/disable API and lifecycle management

### DIFF
--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -96,12 +96,9 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    void *const cb,
 				    void *const cb_priv)
 {
-	uint8_t ep_idx = USB_EP_GET_IDX(ep) & 0xF;
 	const struct uhc_api *api = dev->api;
 	struct uhc_transfer *xfer = NULL;
-	uint16_t mps;
-	uint16_t interval;
-	uint8_t type;
+	struct usb_host_ep *hep;
 
 	api->lock(dev);
 
@@ -109,30 +106,13 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 		goto xfer_alloc_error;
 	}
 
-	if (ep_idx == 0) {
-		interval = 0;
-		type = USB_EP_TYPE_CONTROL;
-		mps = udev->dev_desc.bMaxPacketSize0;
-	} else {
-		struct usb_ep_descriptor *ep_desc;
-
-		if (USB_EP_DIR_IS_IN(ep)) {
-			ep_desc = udev->ep_in[ep_idx].desc;
-		} else {
-			ep_desc = udev->ep_out[ep_idx].desc;
-		}
-
-		if (ep_desc == NULL) {
-			LOG_ERR("Endpoint 0x%02x is not configured", ep);
-			goto xfer_alloc_error;
-		}
-
-		mps = ep_desc->wMaxPacketSize;
-		interval = ep_desc->bInterval;
-		type = ep_desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
+	hep = uhc_get_udev_hep(udev, ep);
+	if ((hep == NULL) || (!hep->enabled)) {
+		LOG_ERR("Endpoint 0x%02x is not configured", ep);
+		goto xfer_alloc_error;
 	}
 
-	LOG_DBG("Allocate xfer, ep 0x%02x mps %u cb %p", ep, mps, cb);
+	LOG_DBG("Allocate xfer, ep 0x%02x cb %p", ep, cb);
 
 	if (k_mem_slab_alloc(&uhc_xfer_pool, (void **)&xfer, K_NO_WAIT)) {
 		LOG_ERR("Failed to allocate transfer");
@@ -141,9 +121,6 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 
 	memset(xfer, 0, sizeof(struct uhc_transfer));
 	xfer->ep = ep;
-	xfer->mps = mps;
-	xfer->interval = interval;
-	xfer->type = type;
 	xfer->udev = udev;
 	xfer->cb = cb;
 	xfer->priv = cb_priv;
@@ -220,15 +197,93 @@ int uhc_xfer_buf_add(const struct device *dev,
 	return ret;
 }
 
-int uhc_ep_enqueue(const struct device *dev, struct uhc_transfer *const xfer)
+int uhc_ep_enable(const struct device *dev, struct usb_device *const udev, uint8_t ep)
 {
 	const struct uhc_api *api = dev->api;
+	struct usb_host_ep *hep;
 	int ret;
 
 	api->lock(dev);
 
 	if (!uhc_is_initialized(dev)) {
 		ret = -EPERM;
+		goto ep_enable_error;
+	}
+
+	if (api->ep_enable == NULL) {
+		ret = -ENOSYS;
+		goto ep_enable_error;
+	}
+
+	hep = uhc_get_udev_hep(udev, ep);
+	if ((hep == NULL) || (hep->desc == NULL)) {
+		ret = -EINVAL;
+		goto ep_enable_error;
+	}
+
+	hep->udev = udev; /* it is needed in ep_enable */
+	ret = api->ep_enable(dev, hep);
+	hep->enabled = ret ? false : true;
+	hep->udev = ret ? NULL : udev;
+
+ep_enable_error:
+	api->unlock(dev);
+
+	return ret;
+}
+
+int uhc_ep_disable(const struct device *dev, struct usb_device *const udev, uint8_t ep)
+{
+	const struct uhc_api *api = dev->api;
+	struct usb_host_ep *hep;
+	int ret;
+
+	api->lock(dev);
+
+	if (!uhc_is_initialized(dev)) {
+		ret = -EPERM;
+		goto ep_disable_error;
+	}
+
+	if (api->ep_disable == NULL) {
+		ret = -ENOSYS;
+		goto ep_disable_error;
+	}
+
+	hep = uhc_get_udev_hep(udev, ep);
+	if (hep == NULL) {
+		ret = -EINVAL;
+		goto ep_disable_error;
+	}
+
+	ret = api->ep_disable(dev, hep);
+	if (ret == 0) {
+		hep->enabled = false;
+		hep->udev = NULL;
+	}
+
+ep_disable_error:
+	api->unlock(dev);
+
+	return ret;
+}
+
+int uhc_ep_enqueue(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	const struct uhc_api *api = dev->api;
+	struct usb_host_ep *hep;
+	int ret;
+
+	api->lock(dev);
+
+	if (!uhc_is_initialized(dev)) {
+		ret = -EPERM;
+		goto ep_enqueue_error;
+	}
+
+	hep = uhc_get_udev_hep(xfer->udev, xfer->ep);
+	if ((hep == NULL) || (!hep->enabled)) {
+		ret = -ENODEV;
 		goto ep_enqueue_error;
 	}
 
@@ -248,12 +303,19 @@ ep_enqueue_error:
 int uhc_ep_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
 {
 	const struct uhc_api *api = dev->api;
+	struct usb_host_ep *hep;
 	int ret;
 
 	api->lock(dev);
 
 	if (!uhc_is_initialized(dev)) {
 		ret = -EPERM;
+		goto ep_dequeue_error;
+	}
+
+	hep = uhc_get_udev_hep(xfer->udev, xfer->ep);
+	if (hep == NULL) {
+		ret = -ENODEV;
 		goto ep_dequeue_error;
 	}
 

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -98,7 +98,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 {
 	const struct uhc_api *api = dev->api;
 	struct uhc_transfer *xfer = NULL;
-	struct usb_host_ep *hep;
+	struct usb_host_pipe *pipe;
 
 	api->lock(dev);
 
@@ -106,8 +106,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 		goto xfer_alloc_error;
 	}
 
-	hep = uhc_get_udev_hep(udev, ep);
-	if ((hep == NULL) || (!hep->enabled)) {
+	pipe = uhc_get_udev_pipe(udev, ep);
+	if ((pipe == NULL) || (!pipe->enabled)) {
 		LOG_ERR("Endpoint 0x%02x is not configured", ep);
 		goto xfer_alloc_error;
 	}
@@ -200,7 +200,7 @@ int uhc_xfer_buf_add(const struct device *dev,
 int uhc_ep_enable(const struct device *dev, struct usb_device *const udev, uint8_t ep)
 {
 	const struct uhc_api *api = dev->api;
-	struct usb_host_ep *hep;
+	struct usb_host_pipe *pipe;
 	int ret;
 
 	api->lock(dev);
@@ -215,16 +215,16 @@ int uhc_ep_enable(const struct device *dev, struct usb_device *const udev, uint8
 		goto ep_enable_error;
 	}
 
-	hep = uhc_get_udev_hep(udev, ep);
-	if ((hep == NULL) || (hep->desc == NULL)) {
+	pipe = uhc_get_udev_pipe(udev, ep);
+	if ((pipe == NULL) || (pipe->desc == NULL)) {
 		ret = -EINVAL;
 		goto ep_enable_error;
 	}
 
-	hep->udev = udev; /* it is needed in ep_enable */
-	ret = api->ep_enable(dev, hep);
-	hep->enabled = ret ? false : true;
-	hep->udev = ret ? NULL : udev;
+	pipe->udev = udev; /* it is needed in ep_enable */
+	ret = api->ep_enable(dev, pipe);
+	pipe->enabled = ret ? false : true;
+	pipe->udev = ret ? NULL : udev;
 
 ep_enable_error:
 	api->unlock(dev);
@@ -235,7 +235,7 @@ ep_enable_error:
 int uhc_ep_disable(const struct device *dev, struct usb_device *const udev, uint8_t ep)
 {
 	const struct uhc_api *api = dev->api;
-	struct usb_host_ep *hep;
+	struct usb_host_pipe *pipe;
 	int ret;
 
 	api->lock(dev);
@@ -250,16 +250,16 @@ int uhc_ep_disable(const struct device *dev, struct usb_device *const udev, uint
 		goto ep_disable_error;
 	}
 
-	hep = uhc_get_udev_hep(udev, ep);
-	if (hep == NULL) {
+	pipe = uhc_get_udev_pipe(udev, ep);
+	if (pipe == NULL) {
 		ret = -EINVAL;
 		goto ep_disable_error;
 	}
 
-	ret = api->ep_disable(dev, hep);
+	ret = api->ep_disable(dev, pipe);
 	if (ret == 0) {
-		hep->enabled = false;
-		hep->udev = NULL;
+		pipe->enabled = false;
+		pipe->udev = NULL;
 	}
 
 ep_disable_error:
@@ -271,7 +271,7 @@ ep_disable_error:
 int uhc_ep_enqueue(const struct device *dev, struct uhc_transfer *const xfer)
 {
 	const struct uhc_api *api = dev->api;
-	struct usb_host_ep *hep;
+	struct usb_host_pipe *pipe;
 	int ret;
 
 	api->lock(dev);
@@ -281,8 +281,8 @@ int uhc_ep_enqueue(const struct device *dev, struct uhc_transfer *const xfer)
 		goto ep_enqueue_error;
 	}
 
-	hep = uhc_get_udev_hep(xfer->udev, xfer->ep);
-	if ((hep == NULL) || (!hep->enabled)) {
+	pipe = uhc_get_udev_pipe(xfer->udev, xfer->ep);
+	if ((pipe == NULL) || (!pipe->enabled)) {
 		ret = -ENODEV;
 		goto ep_enqueue_error;
 	}
@@ -303,7 +303,7 @@ ep_enqueue_error:
 int uhc_ep_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
 {
 	const struct uhc_api *api = dev->api;
-	struct usb_host_ep *hep;
+	struct usb_host_pipe *pipe;
 	int ret;
 
 	api->lock(dev);
@@ -313,8 +313,8 @@ int uhc_ep_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
 		goto ep_dequeue_error;
 	}
 
-	hep = uhc_get_udev_hep(xfer->udev, xfer->ep);
-	if (hep == NULL) {
+	pipe = uhc_get_udev_pipe(xfer->udev, xfer->ep);
+	if (pipe == NULL) {
 		ret = -ENODEV;
 		goto ep_dequeue_error;
 	}

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -197,7 +197,7 @@ int uhc_xfer_buf_add(const struct device *dev,
 	return ret;
 }
 
-int uhc_ep_enable(const struct device *dev, struct usb_device *const udev, uint8_t ep)
+int uhc_pipe_enable(const struct device *dev, struct usb_device *const udev, uint8_t ep)
 {
 	const struct uhc_api *api = dev->api;
 	struct usb_host_pipe *pipe;
@@ -207,18 +207,18 @@ int uhc_ep_enable(const struct device *dev, struct usb_device *const udev, uint8
 
 	if (!uhc_is_initialized(dev)) {
 		ret = -EPERM;
-		goto ep_enable_error;
+		goto pipe_enable_error;
 	}
 
 	if (api->pipe_enable == NULL) {
 		ret = -ENOSYS;
-		goto ep_enable_error;
+		goto pipe_enable_error;
 	}
 
 	pipe = uhc_get_udev_pipe(udev, ep);
 	if ((pipe == NULL) || (pipe->desc == NULL)) {
 		ret = -EINVAL;
-		goto ep_enable_error;
+		goto pipe_enable_error;
 	}
 
 	pipe->udev = udev; /* it is needed in pipe_enable */
@@ -226,13 +226,13 @@ int uhc_ep_enable(const struct device *dev, struct usb_device *const udev, uint8
 	pipe->enabled = ret ? false : true;
 	pipe->udev = ret ? NULL : udev;
 
-ep_enable_error:
+pipe_enable_error:
 	api->unlock(dev);
 
 	return ret;
 }
 
-int uhc_ep_disable(const struct device *dev, struct usb_device *const udev, uint8_t ep)
+int uhc_pipe_disable(const struct device *dev, struct usb_device *const udev, uint8_t ep)
 {
 	const struct uhc_api *api = dev->api;
 	struct usb_host_pipe *pipe;
@@ -242,18 +242,18 @@ int uhc_ep_disable(const struct device *dev, struct usb_device *const udev, uint
 
 	if (!uhc_is_initialized(dev)) {
 		ret = -EPERM;
-		goto ep_disable_error;
+		goto pipe_disable_error;
 	}
 
 	if (api->pipe_disable == NULL) {
 		ret = -ENOSYS;
-		goto ep_disable_error;
+		goto pipe_disable_error;
 	}
 
 	pipe = uhc_get_udev_pipe(udev, ep);
 	if (pipe == NULL) {
 		ret = -EINVAL;
-		goto ep_disable_error;
+		goto pipe_disable_error;
 	}
 
 	ret = api->pipe_disable(dev, pipe);
@@ -262,13 +262,13 @@ int uhc_ep_disable(const struct device *dev, struct usb_device *const udev, uint
 		pipe->udev = NULL;
 	}
 
-ep_disable_error:
+pipe_disable_error:
 	api->unlock(dev);
 
 	return ret;
 }
 
-int uhc_ep_enqueue(const struct device *dev, struct uhc_transfer *const xfer)
+int uhc_pipe_enqueue(const struct device *dev, struct uhc_transfer *const xfer)
 {
 	const struct uhc_api *api = dev->api;
 	struct usb_host_pipe *pipe;
@@ -278,13 +278,13 @@ int uhc_ep_enqueue(const struct device *dev, struct uhc_transfer *const xfer)
 
 	if (!uhc_is_initialized(dev)) {
 		ret = -EPERM;
-		goto ep_enqueue_error;
+		goto pipe_enqueue_error;
 	}
 
 	pipe = uhc_get_udev_pipe(xfer->udev, xfer->ep);
 	if ((pipe == NULL) || (!pipe->enabled)) {
 		ret = -ENODEV;
-		goto ep_enqueue_error;
+		goto pipe_enqueue_error;
 	}
 
 	xfer->queued = 1;
@@ -293,14 +293,13 @@ int uhc_ep_enqueue(const struct device *dev, struct uhc_transfer *const xfer)
 		xfer->queued = 0;
 	}
 
-
-ep_enqueue_error:
+pipe_enqueue_error:
 	api->unlock(dev);
 
 	return ret;
 }
 
-int uhc_ep_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
+int uhc_pipe_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
 {
 	const struct uhc_api *api = dev->api;
 	struct usb_host_pipe *pipe;
@@ -310,19 +309,19 @@ int uhc_ep_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
 
 	if (!uhc_is_initialized(dev)) {
 		ret = -EPERM;
-		goto ep_dequeue_error;
+		goto pipe_dequeue_error;
 	}
 
 	pipe = uhc_get_udev_pipe(xfer->udev, xfer->ep);
 	if (pipe == NULL) {
 		ret = -ENODEV;
-		goto ep_dequeue_error;
+		goto pipe_dequeue_error;
 	}
 
 	ret = api->pipe_dequeue(dev, xfer);
 	xfer->queued = 0;
 
-ep_dequeue_error:
+pipe_dequeue_error:
 	api->unlock(dev);
 
 	return ret;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -210,7 +210,7 @@ int uhc_ep_enable(const struct device *dev, struct usb_device *const udev, uint8
 		goto ep_enable_error;
 	}
 
-	if (api->ep_enable == NULL) {
+	if (api->pipe_enable == NULL) {
 		ret = -ENOSYS;
 		goto ep_enable_error;
 	}
@@ -221,8 +221,8 @@ int uhc_ep_enable(const struct device *dev, struct usb_device *const udev, uint8
 		goto ep_enable_error;
 	}
 
-	pipe->udev = udev; /* it is needed in ep_enable */
-	ret = api->ep_enable(dev, pipe);
+	pipe->udev = udev; /* it is needed in pipe_enable */
+	ret = api->pipe_enable(dev, pipe);
 	pipe->enabled = ret ? false : true;
 	pipe->udev = ret ? NULL : udev;
 
@@ -245,7 +245,7 @@ int uhc_ep_disable(const struct device *dev, struct usb_device *const udev, uint
 		goto ep_disable_error;
 	}
 
-	if (api->ep_disable == NULL) {
+	if (api->pipe_disable == NULL) {
 		ret = -ENOSYS;
 		goto ep_disable_error;
 	}
@@ -256,7 +256,7 @@ int uhc_ep_disable(const struct device *dev, struct usb_device *const udev, uint
 		goto ep_disable_error;
 	}
 
-	ret = api->ep_disable(dev, pipe);
+	ret = api->pipe_disable(dev, pipe);
 	if (ret == 0) {
 		pipe->enabled = false;
 		pipe->udev = NULL;
@@ -288,7 +288,7 @@ int uhc_ep_enqueue(const struct device *dev, struct uhc_transfer *const xfer)
 	}
 
 	xfer->queued = 1;
-	ret = api->ep_enqueue(dev, xfer);
+	ret = api->pipe_enqueue(dev, xfer);
 	if (ret) {
 		xfer->queued = 0;
 	}
@@ -319,7 +319,7 @@ int uhc_ep_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
 		goto ep_dequeue_error;
 	}
 
-	ret = api->ep_dequeue(dev, xfer);
+	ret = api->pipe_dequeue(dev, xfer);
 	xfer->queued = 0;
 
 ep_dequeue_error:

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -59,24 +59,24 @@ static inline int uhc_unlock_internal(const struct device *dev)
 }
 
 /**
- * @brief Get USB device endpoint context by endpoint address.
+ * @brief Get USB device pipe context by endpoint address.
  *
  * @param[in] udev Pointer to USB device instance
  * @param[in] ep   Endpoint address
  *
- * @return Pointer to IN or OUT endpoint context.
+ * @return Pointer to IN or OUT pipe context.
  */
-static inline struct usb_host_ep *uhc_get_udev_hep(struct usb_device *udev, uint8_t ep)
+static inline struct usb_host_pipe *uhc_get_udev_pipe(struct usb_device *udev, uint8_t ep)
 {
 	uint8_t idx = USB_EP_GET_IDX(ep) & 0xFU;
 
-	/* Control endpoints only need one `struct usb_host_ep`.
+	/* Control endpoints only need one `struct usb_host_pipe`.
 	 * If both directions are needed for some vendors controllers, this needs to be improved.
 	 */
 	if (USB_EP_DIR_IS_IN(ep) || (idx == 0)) {
-		return &udev->ep_in[idx];
+		return &udev->pipe_in[idx];
 	} else {
-		return &udev->ep_out[idx];
+		return &udev->pipe_out[idx];
 	}
 }
 
@@ -84,19 +84,19 @@ static inline struct usb_host_ep *uhc_get_udev_hep(struct usb_device *udev, uint
  * @brief Get USB device endpoint address by endpoint context.
  *
  * @param[in] udev Pointer to USB device instance
- * @param[in] hep  Pointer to endpoint context
+ * @param[in] pipe Pointer to pipe
  *
  * @return Endpoint address on success, negative errno code on error.
  * @retval -EINVAL if endpoint context is not found
  */
-static inline int uhc_get_udev_ep(struct usb_device *udev, struct usb_host_ep *hep)
+static inline int uhc_get_udev_ep(struct usb_device *udev, struct usb_host_pipe *pipe)
 {
 	for (size_t i = 0; i < 16; i++) {
-		if (hep == &udev->ep_in[i]) {
+		if (pipe == &udev->pipe_in[i]) {
 			return i | USB_EP_DIR_IN;
 		}
 
-		if (hep == &udev->ep_out[i]) {
+		if (pipe == &udev->pipe_out[i]) {
 			return i | USB_EP_DIR_OUT;
 		}
 	}
@@ -117,13 +117,15 @@ static inline uint16_t uhc_get_udev_ep_mps(struct usb_device *udev, uint8_t ep)
 	uint8_t idx = USB_EP_GET_IDX(ep) & 0xFU;
 
 	if (idx == 0) {
-		return udev->ep_in[0].control_mps;
+		return udev->pipe_in[0].control_mps;
 	}
 
 	if (USB_EP_DIR_IS_IN(ep)) {
-		return udev->ep_in[idx].desc != NULL ? udev->ep_in[idx].desc->wMaxPacketSize : 0;
+		return udev->pipe_in[idx].desc != NULL ?
+			udev->pipe_in[idx].desc->wMaxPacketSize : 0;
 	} else {
-		return udev->ep_out[idx].desc != NULL ? udev->ep_out[idx].desc->wMaxPacketSize : 0;
+		return udev->pipe_out[idx].desc != NULL ?
+			udev->pipe_out[idx].desc->wMaxPacketSize : 0;
 	}
 }
 
@@ -144,9 +146,9 @@ static inline uint8_t uhc_get_udev_ep_interval(struct usb_device *udev, uint8_t 
 	}
 
 	if (USB_EP_DIR_IS_IN(ep)) {
-		return udev->ep_in[idx].desc != NULL ? udev->ep_in[idx].desc->bInterval : 0;
+		return udev->pipe_in[idx].desc != NULL ? udev->pipe_in[idx].desc->bInterval : 0;
 	} else {
-		return udev->ep_out[idx].desc != NULL ? udev->ep_out[idx].desc->bInterval : 0;
+		return udev->pipe_out[idx].desc != NULL ? udev->pipe_out[idx].desc->bInterval : 0;
 	}
 }
 

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -59,6 +59,98 @@ static inline int uhc_unlock_internal(const struct device *dev)
 }
 
 /**
+ * @brief Get USB device endpoint context by endpoint address.
+ *
+ * @param[in] udev Pointer to USB device instance
+ * @param[in] ep   Endpoint address
+ *
+ * @return Pointer to IN or OUT endpoint context.
+ */
+static inline struct usb_host_ep *uhc_get_udev_hep(struct usb_device *udev, uint8_t ep)
+{
+	uint8_t idx = USB_EP_GET_IDX(ep) & 0xFU;
+
+	/* Control endpoints only need one `struct usb_host_ep`.
+	 * If both directions are needed for some vendors controllers, this needs to be improved.
+	 */
+	if (USB_EP_DIR_IS_IN(ep) || (idx == 0)) {
+		return &udev->ep_in[idx];
+	} else {
+		return &udev->ep_out[idx];
+	}
+}
+
+/**
+ * @brief Get USB device endpoint address by endpoint context.
+ *
+ * @param[in] udev Pointer to USB device instance
+ * @param[in] hep  Pointer to endpoint context
+ *
+ * @return Endpoint address on success, negative errno code on error.
+ * @retval -EINVAL if endpoint context is not found
+ */
+static inline int uhc_get_udev_ep(struct usb_device *udev, struct usb_host_ep *hep)
+{
+	for (size_t i = 0; i < 16; i++) {
+		if (hep == &udev->ep_in[i]) {
+			return i | USB_EP_DIR_IN;
+		}
+
+		if (hep == &udev->ep_out[i]) {
+			return i | USB_EP_DIR_OUT;
+		}
+	}
+
+	return -EINVAL;
+}
+
+/**
+ * @brief Get USB device endpoint maximum packet size.
+ *
+ * @param[in] udev Pointer to USB device instance
+ * @param[in] ep   Endpoint address
+ *
+ * @return Maximum packet size of the endpoint, 0 if endpoint index is invalid.
+ */
+static inline uint16_t uhc_get_udev_ep_mps(struct usb_device *udev, uint8_t ep)
+{
+	uint8_t idx = USB_EP_GET_IDX(ep) & 0xFU;
+
+	if (idx == 0) {
+		return udev->ep_in[0].control_mps;
+	}
+
+	if (USB_EP_DIR_IS_IN(ep)) {
+		return udev->ep_in[idx].desc != NULL ? udev->ep_in[idx].desc->wMaxPacketSize : 0;
+	} else {
+		return udev->ep_out[idx].desc != NULL ? udev->ep_out[idx].desc->wMaxPacketSize : 0;
+	}
+}
+
+/**
+ * @brief Get USB device endpoint interval.
+ *
+ * @param[in] udev Pointer to USB device instance
+ * @param[in] ep   Endpoint address
+ *
+ * @return Endpoint interval value, 0 if endpoint index is invalid or control endpoint.
+ */
+static inline uint8_t uhc_get_udev_ep_interval(struct usb_device *udev, uint8_t ep)
+{
+	uint8_t idx = USB_EP_GET_IDX(ep) & 0xFU;
+
+	if (idx == 0) {
+		return 0;
+	}
+
+	if (USB_EP_DIR_IS_IN(ep)) {
+		return udev->ep_in[idx].desc != NULL ? udev->ep_in[idx].desc->bInterval : 0;
+	} else {
+		return udev->ep_out[idx].desc != NULL ? udev->ep_out[idx].desc->bInterval : 0;
+	}
+}
+
+/**
  * @brief Helper function to return UHC transfer to a higher level.
  *
  * Function to dequeue transfer and send UHC event to a higher level.

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -817,18 +817,18 @@ static int max3421e_dequeue(const struct device *dev,
 	return 0;
 }
 
-static int max3421e_ep_enable(const struct device *dev, struct usb_host_ep *hep)
+static int max3421e_ep_enable(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	(void)dev;
-	(void)hep;
+	(void)pipe;
 
 	return 0;
 }
 
-static int max3421e_ep_disable(const struct device *dev, struct usb_host_ep *hep)
+static int max3421e_ep_disable(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	(void)dev;
-	(void)hep;
+	(void)pipe;
 
 	return 0;
 }

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -817,7 +817,7 @@ static int max3421e_dequeue(const struct device *dev,
 	return 0;
 }
 
-static int max3421e_ep_enable(const struct device *dev, struct usb_host_pipe *pipe)
+static int max3421e_pipe_enable(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	(void)dev;
 	(void)pipe;
@@ -825,7 +825,7 @@ static int max3421e_ep_enable(const struct device *dev, struct usb_host_pipe *pi
 	return 0;
 }
 
-static int max3421e_ep_disable(const struct device *dev, struct usb_host_pipe *pipe)
+static int max3421e_pipe_disable(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	(void)dev;
 	(void)pipe;
@@ -1135,10 +1135,10 @@ static const struct uhc_api max3421e_uhc_api = {
 	.bus_suspend = max3421e_bus_suspend,
 	.bus_resume = max3421e_bus_resume,
 
-	.ep_enable = max3421e_ep_enable,
-	.ep_disable = max3421e_ep_disable,
-	.ep_enqueue = max3421e_enqueue,
-	.ep_dequeue = max3421e_dequeue,
+	.pipe_enable = max3421e_pipe_enable,
+	.pipe_disable = max3421e_pipe_disable,
+	.pipe_enqueue = max3421e_enqueue,
+	.pipe_dequeue = max3421e_dequeue,
 };
 
 static struct max3421e_data max3421e_data = {

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -817,6 +817,22 @@ static int max3421e_dequeue(const struct device *dev,
 	return 0;
 }
 
+static int max3421e_ep_enable(const struct device *dev, struct usb_host_ep *hep)
+{
+	(void)dev;
+	(void)hep;
+
+	return 0;
+}
+
+static int max3421e_ep_disable(const struct device *dev, struct usb_host_ep *hep)
+{
+	(void)dev;
+	(void)hep;
+
+	return 0;
+}
+
 static int max3421e_reset(const struct device *dev)
 {
 	const struct max3421e_config *config = dev->config;
@@ -1119,6 +1135,8 @@ static const struct uhc_api max3421e_uhc_api = {
 	.bus_suspend = max3421e_bus_suspend,
 	.bus_resume = max3421e_bus_resume,
 
+	.ep_enable = max3421e_ep_enable,
+	.ep_disable = max3421e_ep_disable,
 	.ep_enqueue = max3421e_enqueue,
 	.ep_dequeue = max3421e_dequeue,
 };

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -274,7 +274,7 @@ static usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct us
 	return mcux_ep;
 }
 
-int uhc_mcux_ep_enable(const struct device *dev, struct usb_host_pipe *pipe)
+int uhc_mcux_pipe_enable(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	if ((pipe->desc == NULL) || (pipe->udev == NULL)) {
 		return -EINVAL;
@@ -283,7 +283,7 @@ int uhc_mcux_ep_enable(const struct device *dev, struct usb_host_pipe *pipe)
 	return uhc_mcux_init_hal_ep(dev, pipe) == NULL ? -ENOMEM : 0;
 }
 
-int uhc_mcux_ep_disable(const struct device *dev, struct usb_host_pipe *pipe)
+int uhc_mcux_pipe_disable(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	struct uhc_mcux_data *priv = uhc_get_private(dev);
 	usb_host_pipe_t *mcux_ep;

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -218,16 +218,16 @@ usb_status_t USB_HostHelperGetPeripheralInformation(usb_device_handle deviceHand
 usb_host_pipe_handle uhc_mcux_get_hal_ep(struct usb_device *udev,
 					 uint8_t ep)
 {
-	struct usb_host_ep *hep = uhc_get_udev_hep(udev, ep);
+	struct usb_host_pipe *pipe = uhc_get_udev_pipe(udev, ep);
 
-	if (hep == NULL) {
+	if (pipe == NULL) {
 		return NULL;
 	}
 
-	return hep->controller_ep;
+	return pipe->controller_pipe;
 }
 
-static usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct usb_host_ep *hep)
+static usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	usb_status_t status;
 	usb_host_pipe_t *mcux_ep;
@@ -236,31 +236,31 @@ static usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct us
 	uint8_t idx;
 	uint8_t ep;
 
-	ep = uhc_get_udev_ep(hep->udev, hep);
+	ep = uhc_get_udev_ep(pipe->udev, pipe);
 	if (ep < 0) {
 		return NULL;
 	}
 	idx = USB_EP_GET_IDX(ep) & 0xFU;
 
 	/* USB_HostHelperGetPeripheralInformation uses this value as first parameter */
-	pipe_init.devInstance = hep->udev;
+	pipe_init.devInstance = pipe->udev;
 	pipe_init.nakCount = USB_HOST_CONFIG_MAX_NAK;
 	if (idx == 0) {
-		pipe_init.maxPacketSize = hep->control_mps;
+		pipe_init.maxPacketSize = pipe->control_mps;
 		pipe_init.endpointAddress = 0;
 		pipe_init.direction = USB_OUT;
 		pipe_init.numberPerUframe = 1;
 		pipe_init.interval = 0;
 		pipe_init.pipeType = USB_EP_TYPE_CONTROL;
 	} else {
-		pipe_init.maxPacketSize = USB_MPS_EP_SIZE(hep->desc->wMaxPacketSize);
-		pipe_init.endpointAddress = USB_EP_GET_IDX(hep->desc->bEndpointAddress);
-		pipe_init.direction = USB_EP_GET_IDX(hep->desc->bEndpointAddress) == 0 ? USB_OUT :
-				USB_EP_GET_DIR(hep->desc->bEndpointAddress) ? USB_IN : USB_OUT;
+		pipe_init.maxPacketSize = USB_MPS_EP_SIZE(pipe->desc->wMaxPacketSize);
+		pipe_init.endpointAddress = USB_EP_GET_IDX(pipe->desc->bEndpointAddress);
+		pipe_init.direction = USB_EP_GET_IDX(pipe->desc->bEndpointAddress) == 0 ? USB_OUT :
+				USB_EP_GET_DIR(pipe->desc->bEndpointAddress) ? USB_IN : USB_OUT;
 		pipe_init.numberPerUframe =
-				USB_MPS_ADDITIONAL_TRANSACTIONS(hep->desc->wMaxPacketSize);
-		pipe_init.interval = hep->desc->bInterval;
-		pipe_init.pipeType = hep->desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
+				USB_MPS_ADDITIONAL_TRANSACTIONS(pipe->desc->wMaxPacketSize);
+		pipe_init.interval = pipe->desc->bInterval;
+		pipe_init.pipeType = pipe->desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
 	}
 
 	status = priv->mcux_if->controllerOpenPipe(priv->mcux_host.controllerHandle,
@@ -270,30 +270,30 @@ static usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct us
 		return NULL;
 	}
 
-	hep->controller_ep = mcux_ep;
+	pipe->controller_pipe = mcux_ep;
 	return mcux_ep;
 }
 
-int uhc_mcux_ep_enable(const struct device *dev, struct usb_host_ep *hep)
+int uhc_mcux_ep_enable(const struct device *dev, struct usb_host_pipe *pipe)
 {
-	if ((hep->desc == NULL) || (hep->udev == NULL)) {
+	if ((pipe->desc == NULL) || (pipe->udev == NULL)) {
 		return -EINVAL;
 	}
 
-	return uhc_mcux_init_hal_ep(dev, hep) == NULL ? -ENOMEM : 0;
+	return uhc_mcux_init_hal_ep(dev, pipe) == NULL ? -ENOMEM : 0;
 }
 
-int uhc_mcux_ep_disable(const struct device *dev, struct usb_host_ep *hep)
+int uhc_mcux_ep_disable(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	struct uhc_mcux_data *priv = uhc_get_private(dev);
 	usb_host_pipe_t *mcux_ep;
 	usb_status_t status;
 
-	if ((hep->desc == NULL) || (hep->udev == NULL)) {
+	if ((pipe->desc == NULL) || (pipe->udev == NULL)) {
 		return -EINVAL;
 	}
 
-	mcux_ep = hep->controller_ep;
+	mcux_ep = pipe->controller_pipe;
 	if (mcux_ep == NULL) {
 		return 0;
 	}
@@ -304,6 +304,7 @@ int uhc_mcux_ep_disable(const struct device *dev, struct usb_host_ep *hep)
 		return -EIO;
 	}
 
+	pipe->controller_pipe = NULL;
 	return 0;
 }
 

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -116,7 +116,7 @@ int uhc_mcux_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
 	usb_host_pipe_t *mcux_ep;
 	usb_host_cancel_param_t cancel_param;
 
-	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);
+	mcux_ep = uhc_mcux_get_hal_ep(xfer->udev, xfer->ep);
 	if (mcux_ep == NULL) {
 		return -ENOMEM;
 	}
@@ -215,87 +215,53 @@ usb_status_t USB_HostHelperGetPeripheralInformation(usb_device_handle deviceHand
 	return kStatus_USB_Success;
 }
 
-static usb_host_pipe_handle uhc_mcux_check_hal_ep(const struct device *dev,
-						  struct uhc_transfer *const xfer)
+usb_host_pipe_handle uhc_mcux_get_hal_ep(struct usb_device *udev,
+					 uint8_t ep)
 {
-	struct uhc_mcux_data *priv = uhc_get_private(dev);
-	usb_host_pipe_t *mcux_ep = NULL;
-	uint8_t i;
-	usb_status_t status;
+	struct usb_host_ep *hep = uhc_get_udev_hep(udev, ep);
 
-	/* if already initialized */
-	for (i = 0; i < USB_HOST_CONFIG_MAX_PIPES; i++) {
-		uint8_t direction;
-
-		if (USB_EP_GET_IDX(xfer->ep) == 0) {
-			direction = 0;
-		} else {
-			direction = USB_EP_GET_DIR(xfer->ep) ? USB_IN : USB_OUT;
-		}
-
-		if (priv->mcux_eps[i] != NULL &&
-		    priv->mcux_eps[i]->endpointAddress == USB_EP_GET_IDX(xfer->ep) &&
-		    priv->mcux_eps[i]->direction == direction &&
-		    priv->mcux_eps[i]->deviceHandle == xfer->udev) {
-			mcux_ep = priv->mcux_eps[i];
-			break;
-		}
-	}
-
-	if (mcux_ep == NULL) {
+	if (hep == NULL) {
 		return NULL;
 	}
 
-	/* If the ep's attributes have changed, close the ep and return NULL.
-	 * The ep will be re-initialized with new attributes.
-	 */
-	if (mcux_ep->pipeType != xfer->type ||
-	    mcux_ep->maxPacketSize != USB_MPS_EP_SIZE(xfer->mps) ||
-	    mcux_ep->numberPerUframe != USB_MPS_ADDITIONAL_TRANSACTIONS(xfer->mps) + 1 ||
-	    priv->mcux_eps_interval[i] != xfer->interval) {
-		status = priv->mcux_if->controllerClosePipe(priv->mcux_host.controllerHandle,
-							    mcux_ep);
-		if (status != kStatus_USB_Success) {
-			return NULL;
-		}
-
-		uhc_mcux_lock(dev);
-		priv->mcux_eps[i] = NULL;
-		priv->mcux_eps_interval[i] = 0;
-		uhc_mcux_unlock(dev);
-		mcux_ep = NULL;
-	}
-
-	return mcux_ep;
+	return hep->controller_ep;
 }
 
-usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct uhc_transfer *const xfer)
+static usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct usb_host_ep *hep)
 {
 	usb_status_t status;
 	usb_host_pipe_t *mcux_ep;
 	struct uhc_mcux_data *priv = uhc_get_private(dev);
 	usb_host_pipe_init_t pipe_init;
-	uint8_t i;
+	uint8_t idx;
+	uint8_t ep;
 
-	/* if already initialized */
-	mcux_ep = uhc_mcux_check_hal_ep(dev, xfer);
-	if (mcux_ep != NULL) {
-		return mcux_ep;
+	ep = uhc_get_udev_ep(hep->udev, hep);
+	if (ep < 0) {
+		return NULL;
 	}
+	idx = USB_EP_GET_IDX(ep) & 0xFU;
 
 	/* USB_HostHelperGetPeripheralInformation uses this value as first parameter */
-	pipe_init.devInstance = xfer->udev;
+	pipe_init.devInstance = hep->udev;
 	pipe_init.nakCount = USB_HOST_CONFIG_MAX_NAK;
-	pipe_init.maxPacketSize = USB_MPS_EP_SIZE(xfer->mps);
-	pipe_init.endpointAddress = USB_EP_GET_IDX(xfer->ep);
-	pipe_init.direction = USB_EP_GET_IDX(xfer->ep) == 0 ? USB_OUT :
-			      USB_EP_GET_DIR(xfer->ep) ? USB_IN : USB_OUT;
-	/* Current Zephyr Host stack is experimental, the endpoint's interval,
-	 * 'number per uframe' and the endpoint type cannot be got yet.
-	 */
-	pipe_init.numberPerUframe = USB_MPS_ADDITIONAL_TRANSACTIONS(xfer->mps);
-	pipe_init.interval = xfer->interval;
-	pipe_init.pipeType = xfer->type;
+	if (idx == 0) {
+		pipe_init.maxPacketSize = hep->control_mps;
+		pipe_init.endpointAddress = 0;
+		pipe_init.direction = USB_OUT;
+		pipe_init.numberPerUframe = 1;
+		pipe_init.interval = 0;
+		pipe_init.pipeType = USB_EP_TYPE_CONTROL;
+	} else {
+		pipe_init.maxPacketSize = USB_MPS_EP_SIZE(hep->desc->wMaxPacketSize);
+		pipe_init.endpointAddress = USB_EP_GET_IDX(hep->desc->bEndpointAddress);
+		pipe_init.direction = USB_EP_GET_IDX(hep->desc->bEndpointAddress) == 0 ? USB_OUT :
+				USB_EP_GET_DIR(hep->desc->bEndpointAddress) ? USB_IN : USB_OUT;
+		pipe_init.numberPerUframe =
+				USB_MPS_ADDITIONAL_TRANSACTIONS(hep->desc->wMaxPacketSize);
+		pipe_init.interval = hep->desc->bInterval;
+		pipe_init.pipeType = hep->desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
+	}
 
 	status = priv->mcux_if->controllerOpenPipe(priv->mcux_host.controllerHandle,
 						   (usb_host_pipe_handle *)&mcux_ep, &pipe_init);
@@ -304,29 +270,41 @@ usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct uhc_trans
 		return NULL;
 	}
 
-	/* Initialize mcux hal endpoint pipe
-	 * TODO: Need one way to release the pipe.
-	 * Otherwise the priv->mcux_eps will be used up after
-	 * supporting hub and connecting/disconnecting multiple times.
-	 * For example: add endpoint/pipe init and de-init controller
-	 * interface to resolve the issue.
-	 */
-	uhc_mcux_lock(dev);
-	for (i = 0; i < USB_HOST_CONFIG_MAX_PIPES; i++) {
-		if (priv->mcux_eps[i] == NULL) {
-			priv->mcux_eps[i] = mcux_ep;
-			priv->mcux_eps_interval[i] = xfer->interval;
-			break;
-		}
-	}
-	uhc_mcux_unlock(dev);
-
-	if (i >= USB_HOST_CONFIG_MAX_PIPES) {
-		priv->mcux_if->controllerClosePipe(priv->mcux_host.controllerHandle, mcux_ep);
-		mcux_ep = NULL;
-	}
-
+	hep->controller_ep = mcux_ep;
 	return mcux_ep;
+}
+
+int uhc_mcux_ep_enable(const struct device *dev, struct usb_host_ep *hep)
+{
+	if ((hep->desc == NULL) || (hep->udev == NULL)) {
+		return -EINVAL;
+	}
+
+	return uhc_mcux_init_hal_ep(dev, hep) == NULL ? -ENOMEM : 0;
+}
+
+int uhc_mcux_ep_disable(const struct device *dev, struct usb_host_ep *hep)
+{
+	struct uhc_mcux_data *priv = uhc_get_private(dev);
+	usb_host_pipe_t *mcux_ep;
+	usb_status_t status;
+
+	if ((hep->desc == NULL) || (hep->udev == NULL)) {
+		return -EINVAL;
+	}
+
+	mcux_ep = hep->controller_ep;
+	if (mcux_ep == NULL) {
+		return 0;
+	}
+
+	status = priv->mcux_if->controllerClosePipe(priv->mcux_host.controllerHandle,
+						    mcux_ep);
+	if (status != kStatus_USB_Success) {
+		return -EIO;
+	}
+
+	return 0;
 }
 
 int uhc_mcux_hal_init_transfer_common(const struct device *dev, usb_host_transfer_t *mcux_xfer,

--- a/drivers/usb/uhc/uhc_mcux_common.h
+++ b/drivers/usb/uhc/uhc_mcux_common.h
@@ -10,9 +10,6 @@
 struct uhc_mcux_data {
 	const struct device *dev;
 	const usb_host_controller_interface_t *mcux_if;
-	/* TODO: Maybe make it to link with udev->ep_in and udev->ep_out */
-	usb_host_pipe_t *mcux_eps[USB_HOST_CONFIG_MAX_PIPES];
-	uint16_t mcux_eps_interval[USB_HOST_CONFIG_MAX_PIPES];
 	usb_host_instance_t mcux_host;
 	struct k_thread drv_stack_data;
 	uint8_t controller_id; /* MCUX hal controller id, 0xFF is invalid value */
@@ -56,11 +53,13 @@ int uhc_mcux_bus_suspend(const struct device *dev);
 /* Signal bus resume event, 20ms K-state + low-speed EOP */
 int uhc_mcux_bus_resume(const struct device *dev);
 
+int uhc_mcux_ep_enable(const struct device *dev, struct usb_host_ep *hep);
+
+int uhc_mcux_ep_disable(const struct device *dev, struct usb_host_ep *hep);
+
 int uhc_mcux_dequeue(const struct device *dev, struct uhc_transfer *const xfer);
 
-/* Initialize endpoint for MCUX HAL driver */
-usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev,
-					  struct uhc_transfer *const xfer);
+usb_host_pipe_handle uhc_mcux_get_hal_ep(struct usb_device *udev, uint8_t ep);
 
 /* Initialize transfer for MCUX HAL driver */
 int uhc_mcux_hal_init_transfer_common(const struct device *dev, usb_host_transfer_t *mcux_xfer,

--- a/drivers/usb/uhc/uhc_mcux_common.h
+++ b/drivers/usb/uhc/uhc_mcux_common.h
@@ -53,9 +53,9 @@ int uhc_mcux_bus_suspend(const struct device *dev);
 /* Signal bus resume event, 20ms K-state + low-speed EOP */
 int uhc_mcux_bus_resume(const struct device *dev);
 
-int uhc_mcux_ep_enable(const struct device *dev, struct usb_host_pipe *pipe);
+int uhc_mcux_pipe_enable(const struct device *dev, struct usb_host_pipe *pipe);
 
-int uhc_mcux_ep_disable(const struct device *dev, struct usb_host_pipe *pipe);
+int uhc_mcux_pipe_disable(const struct device *dev, struct usb_host_pipe *pipe);
 
 int uhc_mcux_dequeue(const struct device *dev, struct uhc_transfer *const xfer);
 

--- a/drivers/usb/uhc/uhc_mcux_common.h
+++ b/drivers/usb/uhc/uhc_mcux_common.h
@@ -53,9 +53,9 @@ int uhc_mcux_bus_suspend(const struct device *dev);
 /* Signal bus resume event, 20ms K-state + low-speed EOP */
 int uhc_mcux_bus_resume(const struct device *dev);
 
-int uhc_mcux_ep_enable(const struct device *dev, struct usb_host_ep *hep);
+int uhc_mcux_ep_enable(const struct device *dev, struct usb_host_pipe *pipe);
 
-int uhc_mcux_ep_disable(const struct device *dev, struct usb_host_ep *hep);
+int uhc_mcux_ep_disable(const struct device *dev, struct usb_host_pipe *pipe);
 
 int uhc_mcux_dequeue(const struct device *dev, struct uhc_transfer *const xfer);
 

--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -161,7 +161,7 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 			 * So, add one flag and execute kUSB_HostUpdateControlEndpointAddress later
 			 * when there is ep0 transfer.
 			 */
-			mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);
+			mcux_ep = uhc_mcux_get_hal_ep(xfer->udev, xfer->ep);
 			if (mcux_ep != NULL) {
 				mcux_ep->update_addr = 1U;
 			}
@@ -250,7 +250,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	uhc_xfer_append(dev, xfer);
 
 	/* firstly check and init the mcux endpoint handle */
-	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);
+	mcux_ep = uhc_mcux_get_hal_ep(xfer->udev, xfer->ep);
 	if (mcux_ep == NULL) {
 		return -ENOMEM;
 	}
@@ -376,6 +376,8 @@ static const struct uhc_api mcux_uhc_api = {
 	.bus_suspend = uhc_mcux_bus_suspend,
 	.bus_resume = uhc_mcux_bus_resume,
 
+	.ep_enable = uhc_mcux_ep_enable,
+	.ep_disable = uhc_mcux_ep_disable,
 	.ep_enqueue = uhc_mcux_enqueue,
 	.ep_dequeue = uhc_mcux_dequeue,
 };

--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -376,10 +376,10 @@ static const struct uhc_api mcux_uhc_api = {
 	.bus_suspend = uhc_mcux_bus_suspend,
 	.bus_resume = uhc_mcux_bus_resume,
 
-	.ep_enable = uhc_mcux_ep_enable,
-	.ep_disable = uhc_mcux_ep_disable,
-	.ep_enqueue = uhc_mcux_enqueue,
-	.ep_dequeue = uhc_mcux_dequeue,
+	.pipe_enable = uhc_mcux_pipe_enable,
+	.pipe_disable = uhc_mcux_pipe_disable,
+	.pipe_enqueue = uhc_mcux_enqueue,
+	.pipe_dequeue = uhc_mcux_dequeue,
 };
 
 static const usb_host_controller_interface_t uhc_mcux_if = {

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -129,7 +129,7 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 			 * So, add one flag and execute kUSB_HostUpdateControlEndpointAddress later
 			 * when there is ep0 transfer.
 			 */
-			mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);
+			mcux_ep = uhc_mcux_get_hal_ep(xfer->udev, xfer->ep);
 			if (mcux_ep != NULL) {
 				mcux_ep->update_addr = 1U;
 			}
@@ -176,7 +176,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	uhc_xfer_append(dev, xfer);
 
 	/* firstly check and init the mcux endpoint handle */
-	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);
+	mcux_ep = uhc_mcux_get_hal_ep(xfer->udev, xfer->ep);
 	if (mcux_ep == NULL) {
 		return -ENOMEM;
 	}
@@ -256,6 +256,8 @@ static const struct uhc_api mcux_uhc_api = {
 	.bus_suspend = uhc_mcux_bus_suspend,
 	.bus_resume = uhc_mcux_bus_resume,
 
+	.ep_enable = uhc_mcux_ep_enable,
+	.ep_disable = uhc_mcux_ep_disable,
 	.ep_enqueue = uhc_mcux_enqueue,
 	.ep_dequeue = uhc_mcux_dequeue,
 };

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -256,10 +256,10 @@ static const struct uhc_api mcux_uhc_api = {
 	.bus_suspend = uhc_mcux_bus_suspend,
 	.bus_resume = uhc_mcux_bus_resume,
 
-	.ep_enable = uhc_mcux_ep_enable,
-	.ep_disable = uhc_mcux_ep_disable,
-	.ep_enqueue = uhc_mcux_enqueue,
-	.ep_dequeue = uhc_mcux_dequeue,
+	.pipe_enable = uhc_mcux_pipe_enable,
+	.pipe_disable = uhc_mcux_pipe_disable,
+	.pipe_enqueue = uhc_mcux_enqueue,
+	.pipe_dequeue = uhc_mcux_dequeue,
 };
 
 static const usb_host_controller_interface_t uhc_mcux_if = {

--- a/drivers/usb/uhc/uhc_mcux_khci.c
+++ b/drivers/usb/uhc/uhc_mcux_khci.c
@@ -116,7 +116,7 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 			 * So, add one flag and execute kUSB_HostUpdateControlEndpointAddress later
 			 * when there is ep0 transfer.
 			 */
-			mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);
+			mcux_ep = uhc_mcux_get_hal_ep(xfer->udev, xfer->ep);
 			if (mcux_ep != NULL) {
 				mcux_ep->update_addr = 1U;
 			}
@@ -163,7 +163,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	uhc_xfer_append(dev, xfer);
 
 	/* firstly check and init the mcux endpoint handle */
-	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);
+	mcux_ep = uhc_mcux_get_hal_ep(xfer->udev, xfer->ep);
 	if (mcux_ep == NULL) {
 		return -ENOMEM;
 	}
@@ -243,6 +243,8 @@ static const struct uhc_api mcux_uhc_api = {
 	.bus_suspend = uhc_mcux_bus_suspend,
 	.bus_resume = uhc_mcux_bus_resume,
 
+	.ep_enable = uhc_mcux_ep_enable,
+	.ep_disable = uhc_mcux_ep_disable,
 	.ep_enqueue = uhc_mcux_enqueue,
 	.ep_dequeue = uhc_mcux_dequeue,
 };

--- a/drivers/usb/uhc/uhc_mcux_khci.c
+++ b/drivers/usb/uhc/uhc_mcux_khci.c
@@ -243,10 +243,10 @@ static const struct uhc_api mcux_uhc_api = {
 	.bus_suspend = uhc_mcux_bus_suspend,
 	.bus_resume = uhc_mcux_bus_resume,
 
-	.ep_enable = uhc_mcux_ep_enable,
-	.ep_disable = uhc_mcux_ep_disable,
-	.ep_enqueue = uhc_mcux_enqueue,
-	.ep_dequeue = uhc_mcux_dequeue,
+	.pipe_enable = uhc_mcux_pipe_enable,
+	.pipe_disable = uhc_mcux_pipe_disable,
+	.pipe_enqueue = uhc_mcux_enqueue,
+	.pipe_dequeue = uhc_mcux_dequeue,
 };
 
 static const usb_host_controller_interface_t uhc_mcux_if = {

--- a/drivers/usb/uhc/uhc_mcux_ohci.c
+++ b/drivers/usb/uhc/uhc_mcux_ohci.c
@@ -116,7 +116,7 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 			 * So, add one flag and execute kUSB_HostUpdateControlEndpointAddress later
 			 * when there is ep0 transfer.
 			 */
-			mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);
+			mcux_ep = uhc_mcux_get_hal_ep(xfer->udev, xfer->ep);
 			if (mcux_ep != NULL) {
 				mcux_ep->update_addr = 1U;
 			}
@@ -163,7 +163,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	uhc_xfer_append(dev, xfer);
 
 	/* firstly check and init the mcux endpoint handle */
-	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);
+	mcux_ep = uhc_mcux_get_hal_ep(xfer->udev, xfer->ep);
 	if (mcux_ep == NULL) {
 		return -ENOMEM;
 	}
@@ -243,6 +243,8 @@ static const struct uhc_api mcux_uhc_api = {
 	.bus_suspend = uhc_mcux_bus_suspend,
 	.bus_resume = uhc_mcux_bus_resume,
 
+	.ep_enable = uhc_mcux_ep_enable,
+	.ep_disable = uhc_mcux_ep_disable,
 	.ep_enqueue = uhc_mcux_enqueue,
 	.ep_dequeue = uhc_mcux_dequeue,
 };

--- a/drivers/usb/uhc/uhc_mcux_ohci.c
+++ b/drivers/usb/uhc/uhc_mcux_ohci.c
@@ -243,10 +243,10 @@ static const struct uhc_api mcux_uhc_api = {
 	.bus_suspend = uhc_mcux_bus_suspend,
 	.bus_resume = uhc_mcux_bus_resume,
 
-	.ep_enable = uhc_mcux_ep_enable,
-	.ep_disable = uhc_mcux_ep_disable,
-	.ep_enqueue = uhc_mcux_enqueue,
-	.ep_dequeue = uhc_mcux_dequeue,
+	.pipe_enable = uhc_mcux_pipe_enable,
+	.pipe_disable = uhc_mcux_pipe_disable,
+	.pipe_enqueue = uhc_mcux_enqueue,
+	.pipe_dequeue = uhc_mcux_dequeue,
 };
 
 static const usb_host_controller_interface_t uhc_mcux_if = {

--- a/drivers/usb/uhc/uhc_virtual.c
+++ b/drivers/usb/uhc/uhc_virtual.c
@@ -592,7 +592,7 @@ static int uhc_vrt_dequeue(const struct device *dev,
 	return 0;
 }
 
-static int uhc_vrt_ep_enable(const struct device *dev, struct usb_host_pipe *pipe)
+static int uhc_vrt_pipe_enable(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	(void)dev;
 	(void)pipe;
@@ -600,7 +600,7 @@ static int uhc_vrt_ep_enable(const struct device *dev, struct usb_host_pipe *pip
 	return 0;
 }
 
-static int uhc_vrt_ep_disable(const struct device *dev, struct usb_host_pipe *pipe)
+static int uhc_vrt_pipe_disable(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	(void)dev;
 	(void)pipe;
@@ -674,10 +674,10 @@ static const struct uhc_api uhc_vrt_api = {
 	.bus_suspend = uhc_vrt_bus_suspend,
 	.bus_resume = uhc_vrt_bus_resume,
 
-	.ep_enable = uhc_vrt_ep_enable,
-	.ep_disable = uhc_vrt_ep_disable,
-	.ep_enqueue = uhc_vrt_enqueue,
-	.ep_dequeue = uhc_vrt_dequeue,
+	.pipe_enable = uhc_vrt_pipe_enable,
+	.pipe_disable = uhc_vrt_pipe_disable,
+	.pipe_enqueue = uhc_vrt_enqueue,
+	.pipe_dequeue = uhc_vrt_dequeue,
 };
 
 #define DT_DRV_COMPAT zephyr_uhc_virtual

--- a/drivers/usb/uhc/uhc_virtual.c
+++ b/drivers/usb/uhc/uhc_virtual.c
@@ -94,6 +94,7 @@ static int vrt_xfer_control(const struct device *dev,
 	struct uvb_packet *uvb_pkt;
 	uint8_t *data = NULL;
 	size_t length = 0;
+	uint16_t mps;
 
 	if (xfer->stage == UHC_CONTROL_STAGE_SETUP) {
 		LOG_DBG("Handle SETUP stage");
@@ -111,11 +112,13 @@ static int vrt_xfer_control(const struct device *dev,
 	}
 
 	if (buf != NULL && xfer->stage == UHC_CONTROL_STAGE_DATA) {
+		mps = uhc_get_udev_ep_mps(xfer->udev, xfer->ep);
+
 		if (USB_EP_DIR_IS_IN(xfer->ep)) {
-			length = MIN(net_buf_tailroom(buf), xfer->mps);
+			length = MIN(net_buf_tailroom(buf), mps);
 			data = net_buf_tail(buf);
 		} else {
-			length = MIN(buf->len, xfer->mps);
+			length = MIN(buf->len, mps);
 			data = buf->data;
 		}
 
@@ -167,12 +170,15 @@ static int vrt_xfer_bulk(const struct device *dev,
 	struct uvb_packet *uvb_pkt;
 	uint8_t *data;
 	size_t length;
+	uint16_t mps;
+
+	mps = uhc_get_udev_ep_mps(xfer->udev, xfer->ep);
 
 	if (USB_EP_DIR_IS_IN(xfer->ep)) {
-		length = MIN(net_buf_tailroom(buf), xfer->mps);
+		length = MIN(net_buf_tailroom(buf), mps);
 		data = net_buf_tail(buf);
 	} else {
-		length = MIN(buf->len, xfer->mps);
+		length = MIN(buf->len, mps);
 		data = buf->data;
 	}
 
@@ -216,6 +222,7 @@ static void vrt_assemble_frame(const struct device *dev)
 	/* TODO: add periodic transfers up to 90% */
 	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
 		uint8_t idx = get_xfer_ep_idx(tmp->ep);
+		uint8_t interval = uhc_get_udev_ep_interval(tmp->udev, tmp->ep);
 
 		/* There could be multiple transfers queued for the same
 		 * endpoint, for now we only allow one to be scheduled per frame.
@@ -224,14 +231,14 @@ static void vrt_assemble_frame(const struct device *dev)
 			continue;
 		}
 
-		if (tmp->interval) {
+		if (interval) {
 			if (tmp->start_frame != priv->frame_number) {
 				continue;
 			}
 
-			tmp->start_frame = priv->frame_number + tmp->interval;
+			tmp->start_frame = priv->frame_number + interval;
 			LOG_DBG("Interrupt transfer s.f. %u f.n. %u interval %u",
-				tmp->start_frame, priv->frame_number, tmp->interval);
+				tmp->start_frame, priv->frame_number, interval);
 		}
 
 		bm |= BIT(idx);
@@ -288,6 +295,7 @@ static void vrt_hrslt_success(const struct device *dev,
 	struct net_buf *buf = xfer->buf;
 	bool finished = false;
 	size_t length;
+	uint16_t mps;
 
 	switch (pkt->request) {
 	case UVB_REQUEST_SETUP:
@@ -309,8 +317,10 @@ static void vrt_hrslt_success(const struct device *dev,
 			break;
 		}
 
+		mps = uhc_get_udev_ep_mps(xfer->udev, xfer->ep);
+
 		if (USB_EP_DIR_IS_OUT(pkt->ep)) {
-			length = MIN(buf->len, xfer->mps);
+			length = MIN(buf->len, mps);
 			net_buf_pull(buf, length);
 			LOG_DBG("OUT chunk %zu out of %u", length, buf->len);
 			if (buf->len == 0) {
@@ -323,13 +333,13 @@ static void vrt_hrslt_success(const struct device *dev,
 		} else {
 			length = MIN(net_buf_tailroom(buf), pkt->length);
 			net_buf_add(buf, length);
-			if (pkt->length > xfer->mps) {
+			if (pkt->length > mps) {
 				LOG_ERR("Ambiguous packet with the length %zu",
 					pkt->length);
 			}
 
 			LOG_DBG("IN chunk %zu out of %zu", length, net_buf_tailroom(buf));
-			if (pkt->length < xfer->mps || !net_buf_tailroom(buf)) {
+			if (pkt->length < mps || !net_buf_tailroom(buf)) {
 				if (pkt->ep == USB_CONTROL_EP_IN && !xfer->no_status) {
 					xfer->stage = UHC_CONTROL_STAGE_STATUS;
 				} else {
@@ -549,11 +559,12 @@ static int uhc_vrt_enqueue(const struct device *dev,
 			   struct uhc_transfer *const xfer)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
+	uint8_t interval = uhc_get_udev_ep_interval(xfer->udev, xfer->ep);
 
-	if (xfer->interval) {
-		xfer->start_frame = priv->frame_number + xfer->interval;
+	if (interval) {
+		xfer->start_frame = priv->frame_number + interval;
 		LOG_DBG("New interrupt transfer s.f. %u f.n. %u interval %u",
-			xfer->start_frame, priv->frame_number, xfer->interval);
+			xfer->start_frame, priv->frame_number, interval);
 	}
 
 	uhc_xfer_append(dev, xfer);
@@ -577,6 +588,22 @@ static int uhc_vrt_dequeue(const struct device *dev,
 	}
 
 	irq_unlock(key);
+
+	return 0;
+}
+
+static int uhc_vrt_ep_enable(const struct device *dev, struct usb_host_ep *hep)
+{
+	(void)dev;
+	(void)hep;
+
+	return 0;
+}
+
+static int uhc_vrt_ep_disable(const struct device *dev, struct usb_host_ep *hep)
+{
+	(void)dev;
+	(void)hep;
 
 	return 0;
 }
@@ -647,6 +674,8 @@ static const struct uhc_api uhc_vrt_api = {
 	.bus_suspend = uhc_vrt_bus_suspend,
 	.bus_resume = uhc_vrt_bus_resume,
 
+	.ep_enable = uhc_vrt_ep_enable,
+	.ep_disable = uhc_vrt_ep_disable,
 	.ep_enqueue = uhc_vrt_enqueue,
 	.ep_dequeue = uhc_vrt_dequeue,
 };

--- a/drivers/usb/uhc/uhc_virtual.c
+++ b/drivers/usb/uhc/uhc_virtual.c
@@ -592,18 +592,18 @@ static int uhc_vrt_dequeue(const struct device *dev,
 	return 0;
 }
 
-static int uhc_vrt_ep_enable(const struct device *dev, struct usb_host_ep *hep)
+static int uhc_vrt_ep_enable(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	(void)dev;
-	(void)hep;
+	(void)pipe;
 
 	return 0;
 }
 
-static int uhc_vrt_ep_disable(const struct device *dev, struct usb_host_ep *hep)
+static int uhc_vrt_ep_disable(const struct device *dev, struct usb_host_pipe *pipe)
 {
 	(void)dev;
-	(void)hep;
+	(void)pipe;
 
 	return 0;
 }

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -316,12 +316,12 @@ struct uhc_api {
 	int (*bus_suspend)(const struct device *dev);
 	int (*bus_resume)(const struct device *dev);
 
-	int (*ep_enable)(const struct device *dev, struct usb_host_pipe *pipe);
-	int (*ep_disable)(const struct device *dev, struct usb_host_pipe *pipe);
-	int (*ep_enqueue)(const struct device *dev,
-			  struct uhc_transfer *const xfer);
-	int (*ep_dequeue)(const struct device *dev,
-			  struct uhc_transfer *const xfer);
+	int (*pipe_enable)(const struct device *dev, struct usb_host_pipe *pipe);
+	int (*pipe_disable)(const struct device *dev, struct usb_host_pipe *pipe);
+	int (*pipe_enqueue)(const struct device *dev,
+			    struct uhc_transfer *const xfer);
+	int (*pipe_dequeue)(const struct device *dev,
+			    struct uhc_transfer *const xfer);
 };
 /**
  * @endcond

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -64,8 +64,19 @@ struct usb_host_interface {
 };
 
 struct usb_host_ep {
-	/** Pointer to the endpoint descriptor */
-	struct usb_ep_descriptor *desc;
+	/** Endpoint specific info */
+	union {
+		/** Pointer to the endpoint descriptor */
+		struct usb_ep_descriptor *desc;
+		/** Control endpoint maximum packet size */
+		uint16_t control_mps;
+	};
+	/** Pointer to USB device */
+	struct usb_device *udev;
+	/** Opaque controller endpoint handle, NULL if not used */
+	void *controller_ep;
+	/** Endpoint is enabled */
+	uint32_t enabled : 1;
 };
 
 /**
@@ -126,12 +137,6 @@ struct uhc_transfer {
 	struct net_buf *buf;
 	/** Endpoint to which request is associated */
 	uint8_t ep;
-	/** Endpoint type */
-	uint8_t type;
-	/** Maximum packet size */
-	uint16_t mps;
-	/** Interval, used for periodic transfers only */
-	uint16_t interval;
 	/** Start frame, used for periodic transfers only */
 	uint16_t start_frame;
 	/** Flag marks request buffer is queued */
@@ -195,6 +200,7 @@ struct uhc_event {
 	sys_snode_t node;
 	/** Event type */
 	enum uhc_event_type type;
+	/** Event type specific info */
 	union {
 		/** Event status value, if any */
 		int status;
@@ -307,6 +313,8 @@ struct uhc_api {
 	int (*bus_suspend)(const struct device *dev);
 	int (*bus_resume)(const struct device *dev);
 
+	int (*ep_enable)(const struct device *dev, struct usb_host_ep *hep);
+	int (*ep_disable)(const struct device *dev, struct usb_host_ep *hep);
 	int (*ep_enqueue)(const struct device *dev,
 			  struct uhc_transfer *const xfer);
 	int (*ep_dequeue)(const struct device *dev,
@@ -499,6 +507,32 @@ struct net_buf *uhc_xfer_buf_alloc(const struct device *dev,
  * @param[in] buf    Pointer to UHC request buffer
  */
 void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf);
+
+/**
+ * @brief Enable host endpoint at controller level
+ *
+ * Prepare controller resources for an endpoint.
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ * @param[in] udev   Pointer to USB device
+ * @param[in] ep     Endpoint address
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_ep_enable(const struct device *dev, struct usb_device *const udev, uint8_t ep);
+
+/**
+ * @brief Disable host endpoint at controller level
+ *
+ * Release controller resources for an endpoint.
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ * @param[in] udev   Pointer to USB device
+ * @param[in] ep     Endpoint address
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_ep_disable(const struct device *dev, struct usb_device *const udev, uint8_t ep);
 
 /**
  * @brief Queue USB host controller transfer

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -63,8 +63,11 @@ struct usb_host_interface {
 	uint8_t alternate;
 };
 
-struct usb_host_ep {
-	/** Endpoint specific info */
+/**
+ * @brief USB host pipe that represents a device endpoint
+ */
+struct usb_host_pipe {
+	/** Pipe specific info */
 	union {
 		/** Pointer to the endpoint descriptor */
 		struct usb_ep_descriptor *desc;
@@ -73,9 +76,9 @@ struct usb_host_ep {
 	};
 	/** Pointer to USB device */
 	struct usb_device *udev;
-	/** Opaque controller endpoint handle, NULL if not used */
-	void *controller_ep;
-	/** Endpoint is enabled */
+	/** Opaque controller pipe handle, NULL if not used */
+	void *controller_pipe;
+	/** Pipe is enabled */
 	uint32_t enabled : 1;
 };
 
@@ -103,10 +106,10 @@ struct usb_device {
 	void *cfg_desc;
 	/** Pointers to device interfaces */
 	struct usb_host_interface ifaces[UHC_INTERFACES_MAX + 1];
-	/** Pointers to device OUT endpoints */
-	struct usb_host_ep ep_out[16];
-	/** Pointers to device IN endpoints */
-	struct usb_host_ep ep_in[16];
+	/** Pointers to device OUT pipes */
+	struct usb_host_pipe pipe_out[16];
+	/** Pointers to device IN pipes */
+	struct usb_host_pipe pipe_in[16];
 };
 
 /**
@@ -313,8 +316,8 @@ struct uhc_api {
 	int (*bus_suspend)(const struct device *dev);
 	int (*bus_resume)(const struct device *dev);
 
-	int (*ep_enable)(const struct device *dev, struct usb_host_ep *hep);
-	int (*ep_disable)(const struct device *dev, struct usb_host_ep *hep);
+	int (*ep_enable)(const struct device *dev, struct usb_host_pipe *pipe);
+	int (*ep_disable)(const struct device *dev, struct usb_host_pipe *pipe);
 	int (*ep_enqueue)(const struct device *dev,
 			  struct uhc_transfer *const xfer);
 	int (*ep_dequeue)(const struct device *dev,

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -512,9 +512,9 @@ struct net_buf *uhc_xfer_buf_alloc(const struct device *dev,
 void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf);
 
 /**
- * @brief Enable host endpoint at controller level
+ * @brief Enable host pipe at controller level
  *
- * Prepare controller resources for an endpoint.
+ * Prepare controller resources for an pipe.
  *
  * @param[in] dev    Pointer to device struct of the driver instance
  * @param[in] udev   Pointer to USB device
@@ -522,12 +522,12 @@ void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf);
  *
  * @return 0 on success, all other values should be treated as error.
  */
-int uhc_ep_enable(const struct device *dev, struct usb_device *const udev, uint8_t ep);
+int uhc_pipe_enable(const struct device *dev, struct usb_device *const udev, uint8_t ep);
 
 /**
- * @brief Disable host endpoint at controller level
+ * @brief Disable host pipe at controller level
  *
- * Release controller resources for an endpoint.
+ * Release controller resources for an pipe.
  *
  * @param[in] dev    Pointer to device struct of the driver instance
  * @param[in] udev   Pointer to USB device
@@ -535,7 +535,7 @@ int uhc_ep_enable(const struct device *dev, struct usb_device *const udev, uint8
  *
  * @return 0 on success, all other values should be treated as error.
  */
-int uhc_ep_disable(const struct device *dev, struct usb_device *const udev, uint8_t ep);
+int uhc_pipe_disable(const struct device *dev, struct usb_device *const udev, uint8_t ep);
 
 /**
  * @brief Queue USB host controller transfer
@@ -549,7 +549,7 @@ int uhc_ep_disable(const struct device *dev, struct usb_device *const udev, uint
  * @return 0 on success, all other values should be treated as error.
  * @retval -EPERM controller is not initialized
  */
-int uhc_ep_enqueue(const struct device *dev, struct uhc_transfer *const xfer);
+int uhc_pipe_enqueue(const struct device *dev, struct uhc_transfer *const xfer);
 
 /**
  * @brief Remove a USB host controller transfers from queue
@@ -562,7 +562,7 @@ int uhc_ep_enqueue(const struct device *dev, struct uhc_transfer *const xfer);
  * @return 0 on success, all other values should be treated as error.
  * @retval -EPERM controller is not initialized
  */
-int uhc_ep_dequeue(const struct device *dev, struct uhc_transfer *const xfer);
+int uhc_pipe_dequeue(const struct device *dev, struct uhc_transfer *const xfer);
 
 /**
  * @brief Initialize USB host controller

--- a/subsys/usb/host/usbh_class.c
+++ b/subsys/usb/host/usbh_class.c
@@ -11,6 +11,7 @@
 #include "usbh_class_api.h"
 #include "usbh_desc.h"
 #include "usbh_host.h"
+#include "usbh_device.h"
 
 LOG_MODULE_REGISTER(usbh_class, CONFIG_USBH_LOG_LEVEL);
 
@@ -121,6 +122,14 @@ static void usbh_class_probe_function(struct usb_device *const udev,
 		}
 
 		LOG_INF("Class '%s' matches interface %u", c_data->name, iface);
+
+		ret = usbh_device_default_interface_init(udev, iface);
+		if (ret != 0) {
+			LOG_ERR("Failed to initialize default interface for class %s (%d)",
+				c_data->name, ret);
+			continue;
+		}
+
 		c_node->state = USBH_CLASS_STATE_BOUND;
 		c_data->udev = udev;
 		c_data->iface = iface;

--- a/subsys/usb/host/usbh_desc.c
+++ b/subsys/usb/host/usbh_desc.c
@@ -140,7 +140,7 @@ const void *usbh_desc_get_endpoint(const struct usb_device *const udev, const ui
 {
 	uint8_t idx = USB_EP_GET_IDX(ep) & 0xf;
 
-	return USB_EP_DIR_IS_IN(ep) ? udev->ep_in[idx].desc : udev->ep_out[idx].desc;
+	return USB_EP_DIR_IS_IN(ep) ? udev->pipe_in[idx].desc : udev->pipe_out[idx].desc;
 }
 
 int usbh_desc_fill_filter(const struct usb_desc_header *const desc,

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -167,14 +167,14 @@ static int handle_ep_op(struct usb_device *const udev,
 		old_desc_prt = usbh_desc_get_endpoint(udev, ep);
 		assign_ep_desc_ptr(udev, ep, ep_desc);
 
-		err = uhc_ep_enable(uhs_ctx->dev, udev, ep);
+		err = uhc_pipe_enable(uhs_ctx->dev, udev, ep);
 		if (err != 0) {
 			assign_ep_desc_ptr(udev, ep, (void *const)old_desc_prt);
 			return err;
 		}
 		break;
 	case EP_OP_DOWN:
-		err = uhc_ep_disable(uhs_ctx->dev, udev, ep);
+		err = uhc_pipe_disable(uhs_ctx->dev, udev, ep);
 		if (err != 0) {
 			return err;
 		}

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -131,7 +131,7 @@ static void assign_ep_desc_ptr(struct usb_device *const udev,
 {
 	uint8_t idx = USB_EP_GET_IDX(ep) & 0xF;
 
-	/* Control endpoints only need one `struct usb_host_ep`.
+	/* Control endpoints only need one `struct usb_host_pipe`.
 	 * If both directions are needed for some vendors controllers, this needs to be improved.
 	 */
 	if (USB_EP_DIR_IS_IN(ep) || (idx == 0)) {
@@ -139,12 +139,12 @@ static void assign_ep_desc_ptr(struct usb_device *const udev,
 			uint16_t mps = ptr != NULL ?
 					((struct usb_ep_descriptor *)ptr)->wMaxPacketSize : 0;
 
-			udev->ep_in[idx].control_mps = mps;
+			udev->pipe_in[idx].control_mps = mps;
 		} else {
-			udev->ep_in[idx].desc = ptr;
+			udev->pipe_in[idx].desc = ptr;
 		}
 	} else {
-		udev->ep_out[idx].desc = ptr;
+		udev->pipe_out[idx].desc = ptr;
 	}
 }
 
@@ -219,7 +219,7 @@ static void disable_all_eps(struct usb_device *const udev)
 	k_mutex_lock(&udev->mutex, K_FOREVER);
 
 	(void)disable_control_ep(udev);
-	for (uint8_t i = 1; i < ARRAY_SIZE(udev->ep_out); i++) {
+	for (uint8_t i = 1; i < ARRAY_SIZE(udev->pipe_out); i++) {
 		(void)handle_ep_op(udev, EP_OP_DOWN, USB_EP_DIR_OUT | i, NULL);
 		(void)handle_ep_op(udev, EP_OP_DOWN, USB_EP_DIR_IN | i, NULL);
 	}
@@ -434,8 +434,8 @@ static void reset_configuration(struct usb_device *const udev)
 	disable_all_eps(udev);
 
 	/* Reset all endpoint pointers */
-	memset(udev->ep_in, 0, sizeof(udev->ep_in));
-	memset(udev->ep_out, 0, sizeof(udev->ep_out));
+	memset(udev->pipe_in, 0, sizeof(udev->pipe_in));
+	memset(udev->pipe_out, 0, sizeof(udev->pipe_out));
 
 	/* Reset all interface pointers */
 	memset(udev->ifaces, 0, sizeof(udev->ifaces));

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -120,14 +120,14 @@ static int alloc_device_address(struct usb_device *const udev, uint8_t *const ad
 	return -ENOENT;
 }
 
-enum ep_op {
-	EP_OP_TEST, /* Verify endpoint descriptor */
-	EP_OP_UP,   /* Enable endpoint and update endpoint pointers */
-	EP_OP_DOWN, /* Disable endpoint and update endpoint pointers */
+enum pipe_op {
+	PIPE_OP_TEST, /* Verify pipe descriptor */
+	PIPE_OP_UP,   /* Enable pipe and update pipe pointers */
+	PIPE_OP_DOWN, /* Disable pipe and update pipe pointers */
 };
 
-static void assign_ep_desc_ptr(struct usb_device *const udev,
-			       const uint8_t ep, void *const ptr)
+static void assign_pipe_desc_ptr(struct usb_device *const udev,
+				 const uint8_t ep, void *const ptr)
 {
 	uint8_t idx = USB_EP_GET_IDX(ep) & 0xF;
 
@@ -148,38 +148,38 @@ static void assign_ep_desc_ptr(struct usb_device *const udev,
 	}
 }
 
-static int handle_ep_op(struct usb_device *const udev,
-			const enum ep_op op, const uint8_t ep,
-			struct usb_ep_descriptor *const ep_desc)
+static int handle_pipe_op(struct usb_device *const udev,
+			  const enum pipe_op op, const uint8_t ep,
+			  struct usb_ep_descriptor *const ep_desc)
 {
 	struct usbh_context *const uhs_ctx = udev->ctx;
 	const void *old_desc_prt;
 	int err;
 
 	switch (op) {
-	case EP_OP_TEST:
+	case PIPE_OP_TEST:
 		break;
-	case EP_OP_UP:
+	case PIPE_OP_UP:
 		if (ep_desc == NULL) {
 			return -ENOTSUP;
 		}
 
 		old_desc_prt = usbh_desc_get_endpoint(udev, ep);
-		assign_ep_desc_ptr(udev, ep, ep_desc);
+		assign_pipe_desc_ptr(udev, ep, ep_desc);
 
 		err = uhc_pipe_enable(uhs_ctx->dev, udev, ep);
 		if (err != 0) {
-			assign_ep_desc_ptr(udev, ep, (void *const)old_desc_prt);
+			assign_pipe_desc_ptr(udev, ep, (void *const)old_desc_prt);
 			return err;
 		}
 		break;
-	case EP_OP_DOWN:
+	case PIPE_OP_DOWN:
 		err = uhc_pipe_disable(uhs_ctx->dev, udev, ep);
 		if (err != 0) {
 			return err;
 		}
 
-		assign_ep_desc_ptr(udev, ep, NULL);
+		assign_pipe_desc_ptr(udev, ep, NULL);
 		break;
 	}
 
@@ -187,14 +187,14 @@ static int handle_ep_op(struct usb_device *const udev,
 }
 
 
-static int enable_control_ep(struct usb_device *const udev)
+static int enable_control_pipe(struct usb_device *const udev)
 {
 	int err;
 	struct usb_ep_descriptor ep_desc;
 
 	ep_desc.wMaxPacketSize = udev->dev_desc.bMaxPacketSize0;
 
-	err = handle_ep_op(udev, EP_OP_UP, 0, &ep_desc);
+	err = handle_pipe_op(udev, PIPE_OP_UP, 0, &ep_desc);
 	if (err != 0) {
 		return err;
 	}
@@ -202,11 +202,11 @@ static int enable_control_ep(struct usb_device *const udev)
 	return 0;
 }
 
-static int disable_control_ep(struct usb_device *const udev)
+static int disable_control_pipe(struct usb_device *const udev)
 {
 	int err;
 
-	err = handle_ep_op(udev, EP_OP_DOWN, 0, NULL);
+	err = handle_pipe_op(udev, PIPE_OP_DOWN, 0, NULL);
 	if (err != 0) {
 		return err;
 	}
@@ -214,21 +214,21 @@ static int disable_control_ep(struct usb_device *const udev)
 	return 0;
 }
 
-static void disable_all_eps(struct usb_device *const udev)
+static void disable_all_pipes(struct usb_device *const udev)
 {
 	k_mutex_lock(&udev->mutex, K_FOREVER);
 
-	(void)disable_control_ep(udev);
+	(void)disable_control_pipe(udev);
 	for (uint8_t i = 1; i < ARRAY_SIZE(udev->pipe_out); i++) {
-		(void)handle_ep_op(udev, EP_OP_DOWN, USB_EP_DIR_OUT | i, NULL);
-		(void)handle_ep_op(udev, EP_OP_DOWN, USB_EP_DIR_IN | i, NULL);
+		(void)handle_pipe_op(udev, PIPE_OP_DOWN, USB_EP_DIR_OUT | i, NULL);
+		(void)handle_pipe_op(udev, PIPE_OP_DOWN, USB_EP_DIR_IN | i, NULL);
 	}
 
 	k_mutex_unlock(&udev->mutex);
 }
 
 static int device_interface_modify(struct usb_device *const udev,
-				   const enum ep_op op,
+				   const enum pipe_op op,
 				   const uint8_t iface, const uint8_t alt)
 {
 	struct usb_cfg_descriptor *cfg_desc = udev->cfg_desc;
@@ -263,7 +263,7 @@ static int device_interface_modify(struct usb_device *const udev,
 
 		if (dhp->bDescriptorType == USB_DESC_ENDPOINT && found_iface) {
 			ep_desc = (struct usb_ep_descriptor *)dhp;
-			err = handle_ep_op(udev, op, ep_desc->bEndpointAddress, ep_desc);
+			err = handle_pipe_op(udev, op, ep_desc->bEndpointAddress, ep_desc);
 			if (err) {
 				return err;
 			}
@@ -290,7 +290,7 @@ int usbh_device_default_interface_init(struct usb_device *const udev,
 		return err;
 	}
 
-	err = device_interface_modify(udev, EP_OP_UP, iface, 0);
+	err = device_interface_modify(udev, PIPE_OP_UP, iface, 0);
 
 	k_mutex_unlock(&udev->mutex);
 
@@ -331,21 +331,21 @@ int usbh_device_interface_set(struct usb_device *const udev,
 	}
 
 	/* Test if interface and interface alternate exist */
-	err = device_interface_modify(udev, EP_OP_TEST, iface, alt);
+	err = device_interface_modify(udev, PIPE_OP_TEST, iface, alt);
 	if (err) {
 		LOG_ERR("No interface %u with alternate %u", iface, alt);
 		goto error;
 	}
 
 	/* Shutdown current interface alternate */
-	err = device_interface_modify(udev, EP_OP_DOWN, iface, cur_alt);
+	err = device_interface_modify(udev, PIPE_OP_DOWN, iface, cur_alt);
 	if (err) {
 		LOG_ERR("Failed to shutdown interface %u alternate %u", iface, cur_alt);
 		goto error;
 	}
 
 	/* Setup new interface alternate */
-	err = device_interface_modify(udev, EP_OP_UP, iface, alt);
+	err = device_interface_modify(udev, PIPE_OP_UP, iface, alt);
 	if (err) {
 		LOG_ERR("Failed to setup interface %u alternate %u", iface, alt);
 		goto error;
@@ -414,7 +414,7 @@ static int parse_configuration_descriptor(struct usb_device *const udev)
 				ep_desc->bEndpointAddress, ep_desc->wMaxPacketSize);
 
 			if (if_desc != NULL && if_desc->bAlternateSetting == 0) {
-				assign_ep_desc_ptr(udev, ep_desc->bEndpointAddress, ep_desc);
+				assign_pipe_desc_ptr(udev, ep_desc->bEndpointAddress, ep_desc);
 			}
 		}
 
@@ -431,7 +431,7 @@ static int parse_configuration_descriptor(struct usb_device *const udev)
 
 static void reset_configuration(struct usb_device *const udev)
 {
-	disable_all_eps(udev);
+	disable_all_pipes(udev);
 
 	/* Reset all endpoint pointers */
 	memset(udev->pipe_in, 0, sizeof(udev->pipe_in));
@@ -595,7 +595,7 @@ void usbh_device_connect(struct usbh_context *const ctx,
 			ctx->root = NULL;
 		}
 
-		(void)disable_all_eps(udev);
+		(void)disable_all_pipes(udev);
 		usbh_device_free(udev);
 		return;
 	}
@@ -611,7 +611,7 @@ void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev)
 		ctx->root = NULL;
 	}
 
-	(void)disable_all_eps(udev);
+	(void)disable_all_pipes(udev);
 	usbh_device_free(udev);
 
 	LOG_DBG("Device removed");
@@ -647,7 +647,7 @@ int usbh_device_init(struct usb_device *const udev)
 	 * device descriptor is read.
 	 */
 	udev->dev_desc.bMaxPacketSize0 = 8;
-	err = enable_control_ep(udev);
+	err = enable_control_pipe(udev);
 	if (err != 0) {
 		LOG_ERR("Failed to enable control endpoint");
 		goto error;
@@ -665,13 +665,13 @@ int usbh_device_init(struct usb_device *const udev)
 	}
 
 	if (udev->dev_desc.bMaxPacketSize0 != 8) {
-		err = disable_control_ep(udev);
+		err = disable_control_pipe(udev);
 		if (err != 0) {
 			LOG_ERR("Failed to disable control endpoint");
 			goto error;
 		}
 
-		err = enable_control_ep(udev);
+		err = enable_control_pipe(udev);
 		if (err != 0) {
 			LOG_ERR("Failed to re-enable control endpoint");
 			goto error;

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -10,6 +10,7 @@
 #include "usbh_ch9.h"
 #include "usbh_class.h"
 #include "usbh_class_api.h"
+#include "usbh_desc.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(usbh_dev, CONFIG_USBH_LOG_LEVEL);
@@ -130,8 +131,18 @@ static void assign_ep_desc_ptr(struct usb_device *const udev,
 {
 	uint8_t idx = USB_EP_GET_IDX(ep) & 0xF;
 
-	if (USB_EP_DIR_IS_IN(ep)) {
-		udev->ep_in[idx].desc = ptr;
+	/* Control endpoints only need one `struct usb_host_ep`.
+	 * If both directions are needed for some vendors controllers, this needs to be improved.
+	 */
+	if (USB_EP_DIR_IS_IN(ep) || (idx == 0)) {
+		if (idx == 0) {
+			uint16_t mps = ptr != NULL ?
+					((struct usb_ep_descriptor *)ptr)->wMaxPacketSize : 0;
+
+			udev->ep_in[idx].control_mps = mps;
+		} else {
+			udev->ep_in[idx].desc = ptr;
+		}
 	} else {
 		udev->ep_out[idx].desc = ptr;
 	}
@@ -141,6 +152,10 @@ static int handle_ep_op(struct usb_device *const udev,
 			const enum ep_op op, const uint8_t ep,
 			struct usb_ep_descriptor *const ep_desc)
 {
+	struct usbh_context *const uhs_ctx = udev->ctx;
+	const void *old_desc_prt;
+	int err;
+
 	switch (op) {
 	case EP_OP_TEST:
 		break;
@@ -149,14 +164,67 @@ static int handle_ep_op(struct usb_device *const udev,
 			return -ENOTSUP;
 		}
 
-		assign_ep_desc_ptr(udev, ep_desc->bEndpointAddress, ep_desc);
+		old_desc_prt = usbh_desc_get_endpoint(udev, ep);
+		assign_ep_desc_ptr(udev, ep, ep_desc);
+
+		err = uhc_ep_enable(uhs_ctx->dev, udev, ep);
+		if (err != 0) {
+			assign_ep_desc_ptr(udev, ep, (void *const)old_desc_prt);
+			return err;
+		}
 		break;
 	case EP_OP_DOWN:
+		err = uhc_ep_disable(uhs_ctx->dev, udev, ep);
+		if (err != 0) {
+			return err;
+		}
+
 		assign_ep_desc_ptr(udev, ep, NULL);
 		break;
 	}
 
 	return 0;
+}
+
+
+static int enable_control_ep(struct usb_device *const udev)
+{
+	int err;
+	struct usb_ep_descriptor ep_desc;
+
+	ep_desc.wMaxPacketSize = udev->dev_desc.bMaxPacketSize0;
+
+	err = handle_ep_op(udev, EP_OP_UP, 0, &ep_desc);
+	if (err != 0) {
+		return err;
+	}
+
+	return 0;
+}
+
+static int disable_control_ep(struct usb_device *const udev)
+{
+	int err;
+
+	err = handle_ep_op(udev, EP_OP_DOWN, 0, NULL);
+	if (err != 0) {
+		return err;
+	}
+
+	return 0;
+}
+
+static void disable_all_eps(struct usb_device *const udev)
+{
+	k_mutex_lock(&udev->mutex, K_FOREVER);
+
+	(void)disable_control_ep(udev);
+	for (uint8_t i = 1; i < ARRAY_SIZE(udev->ep_out); i++) {
+		(void)handle_ep_op(udev, EP_OP_DOWN, USB_EP_DIR_OUT | i, NULL);
+		(void)handle_ep_op(udev, EP_OP_DOWN, USB_EP_DIR_IN | i, NULL);
+	}
+
+	k_mutex_unlock(&udev->mutex);
 }
 
 static int device_interface_modify(struct usb_device *const udev,
@@ -211,6 +279,24 @@ static int device_interface_modify(struct usb_device *const udev,
 	return found_iface ? 0 : -ENODATA;
 }
 
+int usbh_device_default_interface_init(struct usb_device *const udev,
+				       const uint8_t iface)
+{
+	int err;
+
+	err = k_mutex_lock(&udev->mutex, K_NO_WAIT);
+	if (err) {
+		LOG_ERR("Failed to lock USB device");
+		return err;
+	}
+
+	err = device_interface_modify(udev, EP_OP_UP, iface, 0);
+
+	k_mutex_unlock(&udev->mutex);
+
+	return err;
+}
+
 int usbh_device_interface_set(struct usb_device *const udev,
 			      const uint8_t iface, const uint8_t alt,
 			      const bool dry)
@@ -254,14 +340,14 @@ int usbh_device_interface_set(struct usb_device *const udev,
 	/* Shutdown current interface alternate */
 	err = device_interface_modify(udev, EP_OP_DOWN, iface, cur_alt);
 	if (err) {
-		LOG_ERR("Failed to shutdown interface %u alternate %u", iface, alt);
+		LOG_ERR("Failed to shutdown interface %u alternate %u", iface, cur_alt);
 		goto error;
 	}
 
 	/* Setup new interface alternate */
 	err = device_interface_modify(udev, EP_OP_UP, iface, alt);
 	if (err) {
-		LOG_ERR("Failed to setup interface %u alternate %u", iface, cur_alt);
+		LOG_ERR("Failed to setup interface %u alternate %u", iface, alt);
 		goto error;
 	}
 
@@ -345,6 +431,8 @@ static int parse_configuration_descriptor(struct usb_device *const udev)
 
 static void reset_configuration(struct usb_device *const udev)
 {
+	disable_all_eps(udev);
+
 	/* Reset all endpoint pointers */
 	memset(udev->ep_in, 0, sizeof(udev->ep_in));
 	memset(udev->ep_out, 0, sizeof(udev->ep_out));
@@ -507,6 +595,7 @@ void usbh_device_connect(struct usbh_context *const ctx,
 			ctx->root = NULL;
 		}
 
+		(void)disable_all_eps(udev);
 		usbh_device_free(udev);
 		return;
 	}
@@ -522,6 +611,7 @@ void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev)
 		ctx->root = NULL;
 	}
 
+	(void)disable_all_eps(udev);
 	usbh_device_free(udev);
 
 	LOG_DBG("Device removed");
@@ -548,7 +638,7 @@ int usbh_device_init(struct usb_device *const udev)
 		err = uhc_bus_reset(uhs_ctx->dev);
 		if (err) {
 			LOG_ERR("Failed to signal bus reset");
-			return err;
+			goto error;
 		}
 	}
 
@@ -557,6 +647,12 @@ int usbh_device_init(struct usb_device *const udev)
 	 * device descriptor is read.
 	 */
 	udev->dev_desc.bMaxPacketSize0 = 8;
+	err = enable_control_ep(udev);
+	if (err != 0) {
+		LOG_ERR("Failed to enable control endpoint");
+		goto error;
+	}
+
 	err = usbh_req_desc_dev(udev, 8, &udev->dev_desc);
 	if (err) {
 		LOG_ERR("Failed to read device descriptor");
@@ -566,6 +662,20 @@ int usbh_device_init(struct usb_device *const udev)
 	err = validate_device_mps0(udev);
 	if (err) {
 		goto error;
+	}
+
+	if (udev->dev_desc.bMaxPacketSize0 != 8) {
+		err = disable_control_ep(udev);
+		if (err != 0) {
+			LOG_ERR("Failed to disable control endpoint");
+			goto error;
+		}
+
+		err = enable_control_ep(udev);
+		if (err != 0) {
+			LOG_ERR("Failed to re-enable control endpoint");
+			goto error;
+		}
 	}
 
 	err = usbh_req_desc_dev(udev, sizeof(udev->dev_desc), &udev->dev_desc);

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -30,6 +30,10 @@ void usbh_device_free(struct usb_device *const udev);
 /* Reset and configure new USB device */
 int usbh_device_init(struct usb_device *const udev);
 
+/* Set USB device interface default alternate (0) */
+int usbh_device_default_interface_init(struct usb_device *const udev,
+				       const uint8_t iface);
+
 /* Set USB device interface alternate */
 int usbh_device_interface_set(struct usb_device *const udev,
 			      const uint8_t iface, const uint8_t alt,

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -107,7 +107,7 @@ static inline int usbh_xfer_enqueue(const struct usb_device *udev,
 {
 	struct usbh_context *const ctx = udev->ctx;
 
-	return uhc_ep_enqueue(ctx->dev, xfer);
+	return uhc_pipe_enqueue(ctx->dev, xfer);
 }
 
 static inline int usbh_xfer_dequeue(const struct usb_device *udev,
@@ -115,7 +115,7 @@ static inline int usbh_xfer_dequeue(const struct usb_device *udev,
 {
 	struct usbh_context *const ctx = udev->ctx;
 
-	return uhc_ep_dequeue(ctx->dev, xfer);
+	return uhc_pipe_dequeue(ctx->dev, xfer);
 }
 
 #endif /* ZEPHYR_INCLUDE_USBH_DEVICE_H */

--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -243,7 +243,6 @@ static int usbip_submit_req(struct usbip_cmd_node *const cmd_nd, const uint8_t e
 		}
 	}
 
-	xfer->interval = cmd->submit.interval;
 	cmd_nd->xfer = xfer;
 	ret = usbh_xfer_enqueue(dev_ctx->udev, xfer);
 	if (ret) {


### PR DESCRIPTION
Add explicit endpoint enable/disable operations to the USB host stack to properly manage controller-level endpoint resources. This addresses resource leaks and improves endpoint lifecycle management.

Fix https://github.com/zephyrproject-rtos/zephyr/issues/101159