### PR TITLE
dts: nxp: lpc55s6x: fix dmas phandle-array format in flexcomms

### DIFF
--- a/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
@@ -266,7 +266,7 @@
 		interrupts = <15 0>;
 		clocks = <&syscon MCUX_FLEXCOMM1_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 12)>;
-		dmas = <&dma0 6 &dma0 7>;
+		dmas = <&dma0 6>, <&dma0 7>;
 		dma-names = "rx", "tx";
 		status = "disabled";
 	};
@@ -277,7 +277,7 @@
 		interrupts = <16 0>;
 		clocks = <&syscon MCUX_FLEXCOMM2_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 13)>;
-		dmas = <&dma0 10 &dma0 11>;
+		dmas = <&dma0 10>, <&dma0 11>;
 		dma-names = "rx", "tx";
 		status = "disabled";
 	};
@@ -288,7 +288,7 @@
 		interrupts = <17 0>;
 		clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 14)>;
-		dmas = <&dma0 8 &dma0 9>;
+		dmas = <&dma0 8>, <&dma0 9>;
 		dma-names = "rx", "tx";
 		status = "disabled";
 	};
@@ -299,7 +299,7 @@
 		interrupts = <18 0>;
 		clocks = <&syscon MCUX_FLEXCOMM4_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 15)>;
-		dmas = <&dma0 12 &dma0 13>;
+		dmas = <&dma0 12>, <&dma0 13>;
 		dma-names = "rx", "tx";
 		status = "disabled";
 	};
@@ -310,7 +310,7 @@
 		interrupts = <19 0>;
 		clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 16)>;
-		dmas = <&dma0 14 &dma0 15>;
+		dmas = <&dma0 14>, <&dma0 15>;
 		dma-names = "rx", "tx";
 		status = "disabled";
 	};
@@ -327,7 +327,7 @@
 		interrupts = <20 0>;
 		clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 17)>;
-		dmas = <&dma0 16 &dma0 17>;
+		dmas = <&dma0 16>, <&dma0 17>;
 		dma-names = "rx", "tx";
 		status = "disabled";
 	};
@@ -338,7 +338,7 @@
 		interrupts = <21 0>;
 		clocks = <&syscon MCUX_FLEXCOMM7_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 18)>;
-		dmas = <&dma0 18 &dma0 19>;
+		dmas = <&dma0 18>, <&dma0 19>;
 		dma-names = "rx", "tx";
 		status = "disabled";
 	};
@@ -365,7 +365,7 @@
 		interrupts = <59 0>;
 		clocks = <&syscon MCUX_HS_SPI_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(2, 28)>;
-		dmas = <&dma0 2 &dma0 3>;
+		dmas = <&dma0 2>, <&dma0 3>;
 		dma-names = "rx", "tx";
 		status = "disabled";
 		#address-cells = <1>;


### PR DESCRIPTION
The dmas property in flexcomm1-7 and hs_lspi nodes was using an invalid phandle-array format, missing the required comma separator between entries:

  dmas = <&dma0 6 &dma0 7>;   /* incorrect */

Correct it to use the valid comma-separated form, consistent with flexcomm0 which already had the right format:

  dmas = <&dma0 6>, <&dma0 7>;   /* correct */

Affected nodes: flexcomm1, flexcomm2, flexcomm3, flexcomm4, flexcomm5, flexcomm6, flexcomm7, and hs_lspi.

Build-tested with tests/drivers/dma/loop_transfer, tests/drivers/i2s/i2s_api, and samples/drivers/i2s/i2s_codec on lpcxpresso55s69/lpc55s69/cpu0.