### PR TITLE
soc: nxp: mcxl: fix CM0+ IRQ count

### DIFF
--- a/soc/nxp/mcx/mcxl/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxl/Kconfig.defconfig
@@ -13,7 +13,8 @@ config CORTEX_M_SYSTICK
 	default y
 
 config NUM_IRQS
-	default 161
+	default 32 if SOC_MCXL255_CPU1 || SOC_MCXL254_CPU1 || SOC_MCXL253_CPU1
+	default 161 if SOC_MCXL255_CPU0 || SOC_MCXL254_CPU0 || SOC_MCXL253_CPU0
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if \


### PR DESCRIPTION
Set NUM_IRQS to 32 for MCXL25x CM0+ targets. The CM0+ IRQ table uses external IRQs 0 through 31, while 161 is the CM33 interrupt range.

Tested with:
- west build -b frdm_mcxl255/mcxl255/cpu1 samples/hello_world -p always
- west build -b frdm_mcxl255/mcxl255/cpu0 samples/hello_world -p always