### PR TITLE
soc: nxp: derive CONFIG_NUM_IRQS from DT

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -347,6 +347,18 @@ NXP
   ``zephyr,system-timer`` chosen property, so boards that added the overlay
   described in the Zephyr 4.4 migration guide can remove it.
 
+* :kconfig:option:`CONFIG_NUM_IRQS` for NXP Cortex-M SoCs is now derived from
+  the NVIC devicetree node via ``dt_highest_controller_irq_number()`` instead
+  of a hardcoded per-SoC default. The new value is ``max(NVIC IRQn) + 1`` of
+  the IRQs actually present in the devicetree. This affects ``mcx``, ``imxrt``,
+  ``kinetis``, ``lpc``, ``rw``, ``s32`` (Cortex-M cores) and the i.MX8M
+  Cortex-M cores; boards/applications that need a different value can still
+  override the symbol explicitly in ``Kconfig.defconfig`` or ``prj.conf``.
+  Out-of-tree boards that use ``IRQ_CONNECT(n, ...)`` for a peripheral whose
+  devicetree node is disabled (``status = "disabled"``) will now fail the
+  build with ``gen_isr_tables.py: error: IRQ <n> ... exceeds the maximum``;
+  enable the node or set :kconfig:option:`CONFIG_NUM_IRQS` explicitly.
+
 PWM
 ===
 

--- a/soc/nxp/common/Kconfig.defconfig.nvic
+++ b/soc/nxp/common/Kconfig.defconfig.nvic
@@ -1,0 +1,17 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Compute NUM_IRQS automatically from the Arm v6/7/8-M NVIC devicetree
+# node. dt_highest_controller_irq_number() returns the zero-based IRQn;
+# increment it to obtain the table size (= max IRQn + 1).
+#
+# Only rsource this snippet from a Cortex-M Kconfig.defconfig: the
+# "nvic" label is provided by dts/arm/armv{6,7,8,8.1}-m.dtsi, so if
+# the snippet is sourced on a non-Cortex-M target the label resolves
+# to an empty path and the build will fail loudly instead of silently
+# defaulting NUM_IRQS to 0.
+DT_NVIC_PATH := $(dt_nodelabel_path,nvic)
+DT_NVIC_MAX_IRQN := $(dt_highest_controller_irq_number,$(DT_NVIC_PATH),irq)
+
+configdefault NUM_IRQS
+	default $(inc,$(DT_NVIC_MAX_IRQN))

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_m7
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_m7
@@ -6,6 +6,8 @@
 
 if SOC_MIMX8ML8_M7
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 800000000
 
@@ -35,9 +37,5 @@ config FLASH_BASE_ADDRESS
 	default $(dt_node_reg_addr_hex,/soc/code@80000000)
 
 endif # CODE_DDR
-
-config NUM_IRQS
-	# must be >= the highest interrupt number used
-	default 159
 
 endif # SOC_MIMX8ML8_M7

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_m4
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_m4
@@ -6,15 +6,13 @@
 
 if SOC_MIMX8MM6_M4
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 400000000
 
 config IPM_IMX
 	default y
 	depends on IPM
-
-config NUM_IRQS
-	# must be >= the highest interrupt number used
-	default 127
 
 endif # SOC_MIMX8MM6_M4

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mq6_m4
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mq6_m4
@@ -6,11 +6,9 @@
 
 if SOC_MIMX8MQ6_M4
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 266000000
-
-config NUM_IRQS
-	# must be >= the highest interrupt number used
-	default 127
 
 endif # SOC_MIMX8MQ6_M4

--- a/soc/nxp/imxrt/imxrt10xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt10xx/Kconfig.defconfig
@@ -4,16 +4,7 @@
 
 if SOC_SERIES_IMXRT10XX
 
-config NUM_IRQS
-	default 80 if SOC_MIMXRT1011
-	default 142 if SOC_MIMXRT1015 ||	\
-			SOC_MIMXRT1021 ||	\
-			SOC_MIMXRT1024
-	default 157 if SOC_MIMXRT1041 ||	\
-			SOC_MIMXRT1042
-	default 160 if SOC_MIMXRT1052 ||	\
-			SOC_MIMXRT1062 ||	\
-			SOC_MIMXRT1064
+rsource "../../common/Kconfig.defconfig.nvic"
 
 config DCDC_VALUE
 	default 0x12 if SOC_MIMXRT1011 ||	\

--- a/soc/nxp/imxrt/imxrt118x/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt118x/Kconfig.defconfig
@@ -3,11 +3,10 @@
 
 if SOC_SERIES_IMXRT118X
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config CORTEX_M_SYSTICK
 	default n if MCUX_LPTMR_TIMER
-
-config NUM_IRQS
-	default 239
 
 config GPIO
 	default y

--- a/soc/nxp/imxrt/imxrt11xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt11xx/Kconfig.defconfig
@@ -3,8 +3,7 @@
 
 if SOC_SERIES_IMXRT11XX
 
-config NUM_IRQS
-	default 218
+rsource "../../common/Kconfig.defconfig.nvic"
 
 config GPIO
 	default y

--- a/soc/nxp/imxrt/imxrt5xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt5xx/Kconfig.defconfig
@@ -3,6 +3,8 @@
 
 if SOC_MIMXRT595S_CM33
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config FLEXSPI_CONFIG_BLOCK_OFFSET
 	default 0x400
 
@@ -11,11 +13,6 @@ config CODE_DATA_RELOCATION_SRAM
 
 config ROM_START_OFFSET
 	default 0x1200 if NXP_IMXRT_BOOT_HEADER
-
-# The PVT Sensor uses IRQ #75.  For more details, see
-# https://www.nxp.com/design/design-center/software/embedded-software/application-software-packs/application-software-pack-dynamic-voltage-scaling-using-pvt-sensor:APP-SW-PACK-DVS-PVT-SENSOR
-config NUM_IRQS
-	default 76
 
 if MBEDTLS
 #

--- a/soc/nxp/imxrt/imxrt6xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt6xx/Kconfig.defconfig
@@ -23,6 +23,8 @@ endif # SOC_SERIES_MIMXRT6XX
 
 if SOC_MIMXRT685S_CM33
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config FLEXSPI_CONFIG_BLOCK_OFFSET
 	default 0x400
 
@@ -31,9 +33,6 @@ config CODE_DATA_RELOCATION_SRAM
 
 config ROM_START_OFFSET
 	default 0x1200 if NXP_IMXRT_BOOT_HEADER
-
-config NUM_IRQS
-	default 60
 
 if MBEDTLS
 #

--- a/soc/nxp/imxrt/imxrt7xx/cm33/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt7xx/cm33/Kconfig.defconfig
@@ -1,9 +1,7 @@
 # Copyright 2024-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-config NUM_IRQS
-	default 158 if SOC_MIMXRT798S_CM33_CPU0
-	default 93 if SOC_MIMXRT798S_CM33_CPU1
+rsource "../../../common/Kconfig.defconfig.nvic"
 
 if SOC_MIMXRT798S_CM33_CPU0
 

--- a/soc/nxp/kinetis/k2x/Kconfig.defconfig
+++ b/soc/nxp/kinetis/k2x/Kconfig.defconfig
@@ -10,15 +10,10 @@
 
 if SOC_SERIES_K2X
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config GPIO
 	default y if SOC_MK22F51212
-
-config NUM_IRQS
-	default 74
-
-config NUM_IRQS
-	default 81 if SOC_MK22F12
-	default 74 if SOC_MK22F51212
 
 config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y if SOC_MK22F12

--- a/soc/nxp/kinetis/k32lx/Kconfig.defconfig
+++ b/soc/nxp/kinetis/k32lx/Kconfig.defconfig
@@ -4,8 +4,7 @@
 
 if SOC_SERIES_K32LX
 
-config NUM_IRQS
-	default 32
+rsource "../../common/Kconfig.defconfig.nvic"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK

--- a/soc/nxp/kinetis/k6x/Kconfig.defconfig
+++ b/soc/nxp/kinetis/k6x/Kconfig.defconfig
@@ -6,12 +6,10 @@
 
 if SOC_SERIES_K6X
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y
-
-config NUM_IRQS
-	default 100 if SOC_MK66F18
-	default 86 if SOC_MK64F12
 
 config GPIO
 	default y

--- a/soc/nxp/kinetis/k8x/Kconfig.defconfig
+++ b/soc/nxp/kinetis/k8x/Kconfig.defconfig
@@ -6,9 +6,7 @@
 
 if SOC_SERIES_K8X
 
-config NUM_IRQS
-	# must be >= the highest interrupt number used
-	default 106
+rsource "../../common/Kconfig.defconfig.nvic"
 
 config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y

--- a/soc/nxp/kinetis/ke1xf/Kconfig.defconfig
+++ b/soc/nxp/kinetis/ke1xf/Kconfig.defconfig
@@ -6,6 +6,8 @@
 
 if SOC_SERIES_KE1XF
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config MCUX_LPTMR_TIMER
 	default y if PM
 
@@ -18,10 +20,6 @@ DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
 	default $(dt_node_int_prop_int,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH),clock-frequency) if MCUX_LPTMR_TIMER
-
-config NUM_IRQS
-	# must be >= the highest interrupt number used
-	default 91
 
 config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y

--- a/soc/nxp/kinetis/ke1xz/Kconfig.defconfig
+++ b/soc/nxp/kinetis/ke1xz/Kconfig.defconfig
@@ -6,12 +6,11 @@
 
 if SOC_SERIES_KE1XZ
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
 	default $(dt_node_int_prop_int,/soc/lptmr@40040000,clock-frequency) if MCUX_LPTMR_TIMER
-
-config NUM_IRQS
-	default 32
 
 config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y

--- a/soc/nxp/kinetis/kl2x/Kconfig.defconfig
+++ b/soc/nxp/kinetis/kl2x/Kconfig.defconfig
@@ -5,8 +5,7 @@
 
 if SOC_SERIES_KL2X
 
-config NUM_IRQS
-	default 32 if SOC_MKL25Z4
+rsource "../../common/Kconfig.defconfig.nvic"
 
 # The flash option register (FOPT) boot options
 # 0011 1011 - Boot from Internal Flash.

--- a/soc/nxp/kinetis/kv5x/Kconfig.defconfig
+++ b/soc/nxp/kinetis/kv5x/Kconfig.defconfig
@@ -6,9 +6,7 @@
 
 if SOC_SERIES_KV5X
 
-config NUM_IRQS
-	# must be >= the highest interrupt number used
-	default 121
+rsource "../../common/Kconfig.defconfig.nvic"
 
 config GPIO
 	default y

--- a/soc/nxp/kinetis/kwx/Kconfig.defconfig
+++ b/soc/nxp/kinetis/kwx/Kconfig.defconfig
@@ -5,9 +5,7 @@
 
 if SOC_SERIES_KWX
 
-config NUM_IRQS
-	default 65 if SOC_MKW22D5 || SOC_MKW24D5
-	default 32 if SOC_MKW40Z4 || SOC_MKW41Z4
+rsource "../../common/Kconfig.defconfig.nvic"
 
 config SPI
 	default y if SOC_MKW22D5 || SOC_MKW24D5

--- a/soc/nxp/lpc/lpc11u6x/Kconfig.defconfig
+++ b/soc/nxp/lpc/lpc11u6x/Kconfig.defconfig
@@ -8,8 +8,6 @@
 
 if SOC_SERIES_LPC11U6X
 
-config NUM_IRQS
-	# must be >= the highest interrupt number used
-	default 40
+rsource "../../common/Kconfig.defconfig.nvic"
 
 endif # SOC_SERIES_LPC11U6X

--- a/soc/nxp/lpc/lpc51u68/Kconfig.defconfig
+++ b/soc/nxp/lpc/lpc51u68/Kconfig.defconfig
@@ -6,9 +6,7 @@
 
 if SOC_SERIES_LPC51U68
 
-config NUM_IRQS
-	# must be >= the highest interrupt number used.
-	default 32
+rsource "../../common/Kconfig.defconfig.nvic"
 
 config SOC_FLASH_LPC
 	default y

--- a/soc/nxp/lpc/lpc54xxx/Kconfig.defconfig
+++ b/soc/nxp/lpc/lpc54xxx/Kconfig.defconfig
@@ -5,11 +5,9 @@
 
 if SOC_SERIES_LPC54XXX
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config GPIO
 	default n if SOC_LPC54114_M0
-
-config NUM_IRQS
-	# must be >= the highest interrupt number used
-	default 40
 
 endif # SOC_SERIES_LPC54XXX

--- a/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
+++ b/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
@@ -3,10 +3,7 @@
 
 if SOC_SERIES_LPC55XXX
 
-config NUM_IRQS
-	# must be >= the highest interrupt number used
-	default 119 if SOC_LPC55S36
-	default 60
+rsource "../../common/Kconfig.defconfig.nvic"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 144000000 if INIT_PLL1

--- a/soc/nxp/mcx/mcxa/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig.defconfig
@@ -3,15 +3,10 @@
 
 if SOC_FAMILY_MCXA
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config CORTEX_M_SYSTICK
 	default n if (MCUX_LPTMR_TIMER || MCUX_OS_TIMER)
-
-config NUM_IRQS
-	default 80 if SOC_SERIES_MCXA1X3
-	default 89 if SOC_SERIES_MCXA1X6
-	default 122 if SOC_SERIES_MCXAXX6
-	default 164 if SOC_SERIES_MCXAXX7
-	default 88
 
 # Default offset 0x200 is not enough with higher ISR count
 config ROM_START_OFFSET

--- a/soc/nxp/mcx/mcxc/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxc/Kconfig.defconfig
@@ -6,6 +6,8 @@ DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM
 
 if SOC_FAMILY_MCXC
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 configdefault MCUX_LPTMR_TIMER
 	default y if PM && $(dt_chosen_enabled,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
 
@@ -22,9 +24,6 @@ choice PM_PREWAKEUP_CONV_MODE
 endchoice # PM_PREWAKEUP_CONV_MODE
 
 endif # PM && MCUX_LPTMR_TIMER
-
-configdefault NUM_IRQS
-	default 32
 
 configdefault SYS_CLOCK_TICKS_PER_SEC
 	default 1024 if MCUX_LPTMR_TIMER

--- a/soc/nxp/mcx/mcxe/mcxe24x/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxe/mcxe24x/Kconfig.defconfig
@@ -3,6 +3,8 @@
 
 if SOC_SERIES_MCXE24X
 
+rsource "../../../common/Kconfig.defconfig.nvic"
+
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_IS_NXP_LPTMR := \
@@ -21,9 +23,6 @@ configdefault SYS_CLOCK_HW_CYCLES_PER_SEC
 
 configdefault SYS_CLOCK_TICKS_PER_SEC
 	default 1000 if MCUX_LPTMR_TIMER
-
-configdefault NUM_IRQS
-	default 146
 
 configdefault CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y

--- a/soc/nxp/mcx/mcxe/mcxe31x/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxe/mcxe31x/Kconfig.defconfig
@@ -3,8 +3,7 @@
 
 if SOC_SERIES_MCXE31X
 
-config NUM_IRQS
-	default 240
+rsource "../../../common/Kconfig.defconfig.nvic"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK

--- a/soc/nxp/mcx/mcxl/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxl/Kconfig.defconfig
@@ -3,6 +3,8 @@
 
 if SOC_FAMILY_MCXL
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config MCUX_CORE_SUFFIX
 	default "_cm33" if SOC_MCXL255_CPU0 || SOC_MCXL254_CPU0 || \
 		SOC_MCXL253_CPU0
@@ -11,9 +13,6 @@ config MCUX_CORE_SUFFIX
 
 config CORTEX_M_SYSTICK
 	default y
-
-config NUM_IRQS
-	default 161
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if \

--- a/soc/nxp/mcx/mcxn/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig.defconfig
@@ -3,6 +3,8 @@
 
 if SOC_FAMILY_MCXN
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 # Ensure SysTick is not enabled by default if another system timer is selected.
 configdefault CORTEX_M_SYSTICK
 	default n if (MCUX_LPTMR_TIMER || MCUX_OS_TIMER)
@@ -16,9 +18,6 @@ configdefault SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE
 
 config MFD
 	default y if DT_HAS_NXP_LP_FLEXCOMM_ENABLED
-
-config NUM_IRQS
-	default 156
 
 config ROM_START_OFFSET
 	default 0x400 if BOOTLOADER_MCUBOOT

--- a/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig.defconfig
@@ -4,6 +4,8 @@
 
 if SOC_SERIES_MCXW2XX
 
+rsource "../../../common/Kconfig.defconfig.nvic"
+
 # MCXW23 uses SYSTICK timer as the kernel timer by default.
 # OS timer is reserved to replace SYSTICK during low power events for system wakeup.
 # This dual-timer approach maintains accurate connectivity timing while enabling
@@ -14,9 +16,6 @@ configdefault MCUX_OS_TIMER
 choice SYSTEM_TIMER_LPM_COMPANION
 	default SYSTEM_TIMER_LPM_COMPANION_HOOKS
 endchoice
-
-config NUM_IRQS
-	default 61
 
 DT_SYSCLK_PATH := $(dt_nodelabel_path,sysclk)
 

--- a/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
@@ -4,13 +4,10 @@
 
 if SOC_SERIES_MCXW7XX
 
+rsource "../../../common/Kconfig.defconfig.nvic"
+
 config MCUX_LPTMR_TIMER
 	default y if PM
-
-config NUM_IRQS
-	default 112 if SOC_MCXW70AC
-	default 77 if SOC_MCXW727C
-	default 75
 
 # LPTMR runs from a 32.768 kHz clock when PM is enabled. Using 1024 ticks/sec gives an exact
 # 32-cycle tick period (32768 / 1024), reducing jitter and keeping the timer

--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -3,12 +3,11 @@
 
 if SOC_SERIES_RW6XX
 
+rsource "../common/Kconfig.defconfig.nvic"
+
 config ROM_START_OFFSET
 	default 0x400 if BOOTLOADER_MCUBOOT
 	default 0x1300 if NXP_RW6XX_BOOT_HEADER
-
-config NUM_IRQS
-	default 129
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 1000000 if MCUX_OS_TIMER

--- a/soc/nxp/s32/s32k1/Kconfig.defconfig
+++ b/soc/nxp/s32/s32k1/Kconfig.defconfig
@@ -5,12 +5,10 @@
 
 if SOC_SERIES_S32K1
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
-
-config NUM_IRQS
-	default 239 if CPU_CORTEX_M4
-	default 47 if CPU_CORTEX_M0PLUS
 
 configdefault FPU
 	default y

--- a/soc/nxp/s32/s32k3/Kconfig.defconfig
+++ b/soc/nxp/s32/s32k3/Kconfig.defconfig
@@ -5,12 +5,10 @@
 
 if SOC_SERIES_S32K3
 
+rsource "../../common/Kconfig.defconfig.nvic"
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
-
-config NUM_IRQS
-	# must be >= the highest interrupt number used
-	default 239
 
 config FPU
 	default y

--- a/soc/nxp/s32/s32k5/Kconfig.defconfig.s32k566.m7
+++ b/soc/nxp/s32/s32k5/Kconfig.defconfig.s32k566.m7
@@ -5,7 +5,6 @@
 
 if SOC_S32K566_M7
 
-config NUM_IRQS
-	default 239
+rsource "../../common/Kconfig.defconfig.nvic"
 
 endif # SOC_S32K566_M7


### PR DESCRIPTION
1. Hard-coded `NUM_IRQS` is not easy to maintain and is prone to wasting `_sw_isr_table` space (8B x N). This PR add a small reusable Kconfig fragment that derives `CONFIG_NUM_IRQS` from devicetree by walking the Arm v6/7/8-M NVIC node at
`/soc/interrupt-controller@e000e100` and returning `max(IRQn) + 1`. It uses `configdefault`, so any SoC-level `config NUM_IRQS` with an explicit `default N` still wins, and the snippet is a no-op on boards without an NVIC (Cortex-A/R variants) thanks to the `dt_path_enabled` guard.
 
2. Removed hard-coded `NUM_IRQS` from all NXP SoC kconfig.defconfig

3. For SoCs with **multi-level** interrupts (MULTI_LEVEL_INTERRUPTS=y + irqsteer secondary aggregator), `NUM_IRQS` must equal `2ND_LVL_ISR_TBL_OFFSET + Σ(MAX_IRQ_PER_AGGREGATOR × NUM_2ND_LEVEL_AGGREGATORS)`, and cannot simply equal the number of NVIC lines. If replaced with DT-derived values, the additional 16 secondary interrupt slots will be lost, causing all peripheral interrupts under irqsteer to fail.