### PR TITLE
subsys: usb: host: fix xfers free on device removal

### DIFF
--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -144,7 +144,6 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	xfer->mps = mps;
 	xfer->interval = interval;
 	xfer->type = type;
-	xfer->udev = udev;
 	xfer->cb = cb;
 	xfer->priv = cb_priv;
 

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -96,6 +96,8 @@ struct usb_device {
 	struct usb_host_ep ep_out[16];
 	/** Pointers to device IN endpoints */
 	struct usb_host_ep ep_in[16];
+	/** Internal ref count */
+	atomic_t ref;
 };
 
 /**

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -133,7 +133,7 @@ struct uvc_host_data {
 	struct uvc_ctrls ctrls;
 };
 
-static int stream_iso_req_cb(struct usb_device *const dev, struct uhc_transfer *const xfer);
+static int stream_iso_req_cb(struct usb_device *const udev, struct uhc_transfer *const xfer);
 
 /* Configure UVC device interfaces */
 static int configure_device(struct usbh_class_data *const c_data)
@@ -1544,11 +1544,23 @@ static int initiate_transfer(struct uvc_host_data *const host_data,
 	if (ret != 0) {
 		LOG_ERR("Enqueue failed: ret=%d", ret);
 		net_buf_unref(buf);
+		host_data->video_transfer[--host_data->video_transfer_count] = NULL;
 		usbh_xfer_free(host_data->udev, xfer);
 		return ret;
 	}
 
 	return 0;
+}
+
+static void clear_video_transfer(struct uvc_host_data *const host_data,
+				 struct uhc_transfer *const xfer)
+{
+	for (uint8_t i = 0; i < host_data->video_transfer_count; i++) {
+		if (host_data->video_transfer[i] == xfer) {
+			host_data->video_transfer[i] = NULL;
+			break;
+		}
+	}
 }
 
 /* Continue existing video transfer */
@@ -1571,6 +1583,8 @@ static int continue_transfer(struct uvc_host_data *const host_data,
 	ret = usbh_xfer_enqueue(host_data->udev, xfer);
 	if (ret != 0) {
 		LOG_ERR("Enqueue failed: ret=%d", ret);
+		clear_video_transfer(host_data, xfer);
+		usbh_xfer_free(host_data->udev, xfer);
 		net_buf_unref(buf);
 		return ret;
 	}
@@ -1579,7 +1593,7 @@ static int continue_transfer(struct uvc_host_data *const host_data,
 }
 
 /* ISO transfer completion callback */
-static int stream_iso_req_cb(struct usb_device *const dev, struct uhc_transfer *const xfer)
+static int stream_iso_req_cb(struct usb_device *const udev, struct uhc_transfer *const xfer)
 {
 	struct uvc_host_data *const host_data = (void *)xfer->priv;
 	struct uvc_payload_header *payload_header = NULL;
@@ -1722,8 +1736,12 @@ static int stream_iso_req_cb(struct usb_device *const dev, struct uhc_transfer *
 
 cleanup:
 	net_buf_unref(buf);
-	if ((atomic_test_bit(&host_data->device_flags, UVC_DEVICE_FLAG_STREAMING)) &&
-	    (vbuf != NULL)) {
+	if ((!atomic_test_bit(&host_data->device_flags, UVC_DEVICE_FLAG_STREAMING)) ||
+	    (!atomic_test_bit(&host_data->device_flags, UVC_DEVICE_FLAG_CONNECTED))) {
+		LOG_INF("free xfer");
+		clear_video_transfer(host_data, xfer);
+		usbh_xfer_free(udev, xfer);
+	} else if (vbuf != NULL) {
 		continue_transfer(host_data, xfer, vbuf);
 	}
 

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -2376,7 +2376,7 @@ static int usbh_uvc_probe(struct usbh_class_data *const c_data, struct usb_devic
 
 	k_mutex_lock(&host_data->lock, K_FOREVER);
 
-	host_data->udev = udev;
+	host_data->udev = usbh_device_ref(udev);
 
 	/* Convert device-level match to interface 0 */
 	if (iface == USBH_CLASS_IFNUM_DEVICE) {
@@ -2480,6 +2480,7 @@ static int usbh_uvc_removed(struct usbh_class_data *const c_data)
 	host_data->format_caps_count = 0;
 	memset(&host_data->probe, 0, sizeof(host_data->probe));
 
+	usbh_device_unref(host_data->udev);
 	host_data->udev = NULL;
 
 	LOG_INF("UVC device removal completed");

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -30,13 +30,14 @@ struct usb_device *usbh_device_alloc(struct usbh_context *const uhs_ctx)
 
 	memset(udev, 0, sizeof(struct usb_device));
 	udev->ctx = uhs_ctx;
+	atomic_set(&udev->ref, 1);
 	sys_dlist_append(&uhs_ctx->udevs, &udev->node);
 	k_mutex_init(&udev->mutex);
 
 	return udev;
 }
 
-void usbh_device_free(struct usb_device *const udev)
+static void usbh_device_free_intl(struct usb_device *const udev)
 {
 	struct usbh_context *const uhs_ctx = udev->ctx;
 
@@ -47,6 +48,11 @@ void usbh_device_free(struct usb_device *const udev)
 	}
 
 	k_mem_slab_free(&usb_device_slab, (void *)udev);
+}
+
+void usbh_device_free(struct usb_device *const udev)
+{
+	usbh_device_unref(udev);
 }
 
 struct usb_device *usbh_device_get_any(struct usbh_context *const uhs_ctx)
@@ -602,4 +608,60 @@ error:
 	k_mutex_unlock(&udev->mutex);
 
 	return err;
+}
+
+struct usb_device *usbh_device_ref(struct usb_device *udev)
+{
+	atomic_val_t old;
+
+	__ASSERT_NO_MSG(udev);
+
+	/* Reference counter must be checked to avoid incrementing ref from
+	 * zero, then we should return NULL instead.
+	 * Loop on clear-and-set in case someone has modified the reference
+	 * count since the read, and start over again when that happens.
+	 */
+	do {
+		old = atomic_get(&udev->ref);
+
+		if (!old) {
+			return NULL;
+		}
+	} while (!atomic_cas(&udev->ref, old, old + 1));
+
+	LOG_DBG("addr %u ref %ld -> %ld", udev->addr, old, old + 1);
+
+	return udev;
+}
+
+void usbh_device_unref(struct usb_device *udev)
+{
+	atomic_val_t old;
+	bool deallocated;
+	uint8_t addr;
+
+	__ASSERT(udev, "Invalid device reference");
+
+	/* If we're removing the last reference, the device object will be
+	 * considered freed and possibly re-allocated by the USB Host stack
+	 * as soon as we decrement the counter.
+	 * To prevent inconsistencies when accessing the device's state,
+	 * we store its properties of interest before decrementing the ref-count,
+	 * then unset the local pointer.
+	 */
+	addr = udev->addr;
+	old = atomic_dec(&udev->ref);
+
+	LOG_DBG("addr %u ref %ld -> %ld", addr, old, (old - 1));
+
+	__ASSERT(old > 0, "Device reference counter is 0");
+
+	/* Whether we removed the last reference. */
+	deallocated = (old == 1);
+	if (!deallocated) {
+		return;
+	}
+
+	/* free the udev */
+	usbh_device_free_intl(udev);
 }

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -54,6 +54,10 @@ void usbh_device_connect(struct usbh_context *const ctx, struct usb_device *cons
 /* Disconnect USB device */
 void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev);
 
+struct usb_device *usbh_device_ref(struct usb_device *udev);
+
+void usbh_device_unref(struct usb_device *udev);
+
 /* Wrappers around to avoid glue UHC calls. */
 static inline struct uhc_transfer *usbh_xfer_alloc(struct usb_device *udev,
 						   const uint8_t ep,
@@ -61,8 +65,18 @@ static inline struct uhc_transfer *usbh_xfer_alloc(struct usb_device *udev,
 						   void *const cb_priv)
 {
 	struct usbh_context *const ctx = udev->ctx;
+	struct uhc_transfer *xfer;
 
-	return uhc_xfer_alloc(ctx->dev, ep, udev, cb, cb_priv);
+	xfer = uhc_xfer_alloc(ctx->dev, ep, udev, cb, cb_priv);
+	if (xfer != NULL) {
+		xfer->udev = usbh_device_ref(udev);
+		if (xfer->udev == NULL) {
+			uhc_xfer_free(ctx->dev, xfer);
+			return NULL;
+		}
+	}
+
+	return xfer;
 }
 
 static inline int usbh_xfer_buf_add(const struct usb_device *udev,
@@ -86,8 +100,16 @@ static inline int usbh_xfer_free(const struct usb_device *udev,
 				 struct uhc_transfer *const xfer)
 {
 	struct usbh_context *const ctx = udev->ctx;
+	struct usb_device *xfer_udev;
+	int err;
 
-	return uhc_xfer_free(ctx->dev, xfer);
+	xfer_udev = xfer->udev;
+	err = uhc_xfer_free(ctx->dev, xfer);
+	if (err == 0) {
+		usbh_device_unref(xfer_udev);
+	}
+
+	return err;
 }
 
 static inline void usbh_xfer_buf_free(const struct usb_device *udev,


### PR DESCRIPTION
When freeing the xfer, the udev may be removed. The callstack uses udev->ctx->dev, it is invalid because udev is freeed.

Add reference counting mechanism for USB device objects to prevent use-after-free issues when transfers hold references to devices.
The reference counting ensures that device objects remain valid while transfers are in flight, preventing potential crashes from accessing freed device memory.

Fix video xfers free issue. When the stream stops due to device removal, the interface switches to alt(0) or stream error, the xfer is dequeued and host_data->video_transfer is set to NULL. The xfer should be released in its callback to prevent memory leaks.