### PR TITLE
samples: ipc: icmsg: Remove extra enabling of cpunet on nRF5340

### DIFF
--- a/samples/subsys/ipc/ipc_service/icmsg/src/main.c
+++ b/samples/subsys/ipc/ipc_service/icmsg/src/main.c
@@ -147,11 +147,6 @@ int main(void)
 
 	LOG_INF("IPC-service HOST demo started");
 
-#if defined(CONFIG_SOC_NRF5340_CPUAPP)
-	LOG_INF("Run network core");
-	nrf53_cpunet_enable(true);
-#endif
-
 	ipc0_instance = DEVICE_DT_GET(DT_NODELABEL(ipc0));
 
 	ret = ipc_service_open_instance(ipc0_instance);


### PR DESCRIPTION
This effectively reverts commit b5e5aa333570c5de7eeaa8acd1071f2a965380a4, which provided a fix for unbalanced cpunet enable calls. That fix worked because the nRF5340 DK board initialization routine was enabling cpunet with a direct call to the related HAL function, so the onoff service was unaware of it.

After the sample has been switched to use the SOC_NRF53_CPUNET_ENABLE Kconfig option (see commit d9a5a220b7c81d7064df51f98bdd6acace9ec9a8), the fix should have been reverted, as the common initial enabling of cpunet already informed the onoff service and in consequence that extra enabling caused that the sample could not restart cpunet as expected later on.

Revert this fix now to restore the inteded behavior of the sample.

Fixes #76683.