### PR TITLE
dts: nxp: lpc55sxx: add WWDT support to S0x, S1x, S3x SoCs

### DIFF
--- a/boards/nxp/lpcxpresso55s06/lpcxpresso55s06.dts
+++ b/boards/nxp/lpcxpresso55s06/lpcxpresso55s06.dts
@@ -13,3 +13,7 @@
 	model = "NXP LPCXpresso55S06 board";
 	compatible = "nxp,lpc55xxx", "nxp,lpc";
 };
+
+&wwdt0 {
+	status = "okay";
+};

--- a/boards/nxp/lpcxpresso55s06/lpcxpresso55s06.yaml
+++ b/boards/nxp/lpcxpresso55s06/lpcxpresso55s06.yaml
@@ -18,4 +18,5 @@ supported:
   - flash
   - gpio
   - gint
+  - watchdog
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.dts
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.dts
@@ -35,3 +35,7 @@ zephyr_udc0: &usbhs {
 	tx-cal-45-dp-ohms = <10>;
 	tx-cal-45-dm-ohms = <10>;
 };
+
+&wwdt0 {
+	status = "okay";
+};

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.yaml
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.yaml
@@ -27,4 +27,5 @@ supported:
   - usb_device
   - usbd
   - gint
+  - watchdog
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
@@ -233,3 +233,7 @@ zephyr_udc0: &usbfs {
 &crc {
 	status = "okay";
 };
+
+&wwdt0 {
+	status = "okay";
+};

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -25,4 +25,5 @@ supported:
   - usbd
   - comparator
   - gint
+  - watchdog
 vendor: nxp

--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -39,6 +39,7 @@ struct mcux_wwdt_data {
 	wwdt_config_t wwdt_config;
 	bool timeout_valid;
 	bool active_before_sleep;
+	bool started;
 };
 
 static inline int mcux_wwdt_get_clock_frequency(const struct device *dev, uint32_t *freq)
@@ -99,8 +100,8 @@ static int mcux_wwdt_setup(const struct device *dev, uint8_t options)
 	}
 
 	WWDT_Init(base, &data->wwdt_config);
+	data->started = true;
 	LOG_DBG("Setup the watchdog");
-
 	return 0;
 }
 
@@ -113,6 +114,7 @@ static int mcux_wwdt_disable(const struct device *dev)
 	WWDT_Deinit(base);
 	data->timeout_valid = false;
 	data->active_before_sleep = false;
+	data->started = false;
 	LOG_DBG("Disabled the watchdog");
 
 	return 0;
@@ -223,6 +225,10 @@ static void mcux_wwdt_isr(const struct device *dev)
 	flags = WWDT_GetStatusFlags(base);
 	WWDT_ClearStatusFlags(base, flags);
 
+	if (!data->started) {
+		return;
+	}
+
 	if (data->callback) {
 		data->callback(dev, 0);
 	}
@@ -253,6 +259,7 @@ static int mcux_wwdt_driver_pm_action(const struct device *dev,
 	case PM_DEVICE_ACTION_SUSPEND:
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
+		data->started = false;
 		if (config->base->MOD & WWDT_MOD_WDEN_MASK) {
 			data->active_before_sleep = true;
 		}
@@ -322,6 +329,10 @@ static DEVICE_API(wdt, mcux_wwdt_api) = {
 	{                                                                                          \
 		IRQ_CONNECT(DT_INST_IRQN(id), DT_INST_IRQ(id, priority), mcux_wwdt_isr,            \
 			    DEVICE_DT_INST_GET(id), 0);                                            \
+		/* Defensive: clear any peripheral status and NVIC pending */                      \
+		WWDT_ClearStatusFlags((WWDT_Type *)DT_INST_REG_ADDR(id),                           \
+			      WWDT_GetStatusFlags((WWDT_Type *)DT_INST_REG_ADDR(id)));             \
+		NVIC_ClearPendingIRQ(DT_INST_IRQN(id));                                            \
 		irq_enable(DT_INST_IRQN(id));                                                      \
 	}
 

--- a/dts/arm/nxp/lpc/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S0x_common.dtsi
@@ -13,6 +13,10 @@
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 
 / {
+	aliases {
+		watchdog0 = &wwdt0;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -280,6 +284,15 @@
 		compatible = "nxp,lpc-rng";
 		reg = <0x3a000 0x1000>;
 		status = "okay";
+	};
+
+	wwdt0: watchdog@c000 {
+		compatible = "nxp,lpc-wwdt";
+		reg = <0xc000 0x1000>;
+		clocks = <&syscon MCUX_WWDT0_CLK>;
+		interrupts = <0 0>;
+		status = "disabled";
+		clk-divider = <1>;
 	};
 };
 

--- a/dts/arm/nxp/lpc/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S1x_common.dtsi
@@ -15,6 +15,10 @@
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 
 / {
+	aliases {
+		watchdog0 = &wwdt0;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -355,6 +359,15 @@
 		compatible = "nxp,lpc-rng";
 		reg = <0x3a000 0x1000>;
 		status = "okay";
+	};
+
+	wwdt0: watchdog@c000 {
+		compatible = "nxp,lpc-wwdt";
+		reg = <0xc000 0x1000>;
+		clocks = <&syscon MCUX_WWDT0_CLK>;
+		interrupts = <0 0>;
+		status = "disabled";
+		clk-divider = <1>;
 	};
 
 	usbhs: usbhs@94000 {

--- a/dts/arm/nxp/lpc/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S3x_common.dtsi
@@ -15,6 +15,10 @@
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 
 / {
+	aliases {
+		watchdog0 = &wwdt0;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -572,6 +576,15 @@
 		compatible = "nxp,crc";
 		reg = <0x95000 0x1000>;
 		status = "disabled";
+	};
+
+	wwdt0: watchdog@c000 {
+		compatible = "nxp,lpc-wwdt";
+		reg = <0xc000 0x1000>;
+		clocks = <&syscon MCUX_WWDT0_CLK>;
+		interrupts = <0 0>;
+		status = "disabled";
+		clk-divider = <1>;
 	};
 };
 

--- a/soc/nxp/lpc/lpc55xxx/soc.c
+++ b/soc/nxp/lpc/lpc55xxx/soc.c
@@ -239,6 +239,8 @@ __weak void clock_init(void)
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(wwdt0), nxp_lpc_wwdt, okay)
 	/* Enable 1 MHz FRO clock for WWDT */
 	SYSCON->CLOCK_CTRL |= SYSCON_CLOCK_CTRL_FRO1MHZ_CLK_ENA_MASK;
+	/* Set clock divider for WWDT clock source. */
+	CLOCK_SetClkDiv(kCLOCK_DivWdtClk, 1U, true);
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(mailbox0), nxp_lpc_mailbox, okay)

--- a/tests/drivers/watchdog/wdt_basic_api/boards/lpcxpresso55s06.conf
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/lpcxpresso55s06.conf
@@ -1,0 +1,9 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# lpcxpresso55s06 runs in TrustZone NS mode. The Secure Boot ROM clears
+# NS SRAM (0x20000000) on every reset, including WWDT warm resets.
+# SRAMX (0x04000000) is a separate NOLOAD region not cleared by the Boot ROM,
+# so place the noinit test variables there to survive WWDT resets.
+CONFIG_TEST_WDT_NOINIT_SECTION="SRAMX"
+CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG=10

--- a/tests/drivers/watchdog/wdt_basic_api/boards/lpcxpresso55s16.conf
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/lpcxpresso55s16.conf
@@ -1,0 +1,9 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# lpcxpresso55s16 runs in TrustZone NS mode. The Secure Boot ROM clears
+# NS SRAM (0x20000000) on every reset, including WWDT warm resets.
+# SRAMX (0x04000000) is a separate NOLOAD region not cleared by the Boot ROM,
+# so place the noinit test variables there to survive WWDT resets.
+CONFIG_TEST_WDT_NOINIT_SECTION="SRAMX"
+CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG=10

--- a/tests/drivers/watchdog/wdt_basic_api/boards/lpcxpresso55s28.conf
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/lpcxpresso55s28.conf
@@ -1,0 +1,5 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable WWDT warning interrupt to support test_wdt_callback_1.
+CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG=10

--- a/tests/drivers/watchdog/wdt_basic_api/boards/lpcxpresso55s36.conf
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/lpcxpresso55s36.conf
@@ -1,0 +1,5 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable WWDT warning interrupt to support test_wdt_callback_1.
+CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG=10

--- a/tests/drivers/watchdog/wdt_basic_api/boards/lpcxpresso55s69_lpc55s69_cpu0.conf
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/lpcxpresso55s69_lpc55s69_cpu0.conf
@@ -1,0 +1,5 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable WWDT warning interrupt to support test_wdt_callback_1.
+CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG=10

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -9,10 +9,12 @@ tests:
     filter: >
       dt_alias_exists("watchdog0") and not (CONFIG_WDT_SAM or CONFIG_WDT_SAM4L
        or dt_compat_enabled("st,stm32-window-watchdog")
-       or dt_compat_enabled("st,stm32-watchdog") or CONFIG_SOC_FAMILY_LPC or
+       or dt_compat_enabled("st,stm32-watchdog")
+       or (CONFIG_SOC_FAMILY_LPC and not CONFIG_SOC_SERIES_LPC55XXX) or
        CONFIG_SOC_SERIES_IMXRT6XX or CONFIG_SOC_SERIES_IMXRT5XX or
        CONFIG_SOC_FAMILY_GD_GD32 or SOC_SERIES_GD32VF103 or CONFIG_SOC_MAX32655)
     platform_exclude:
+      - lpcxpresso55s69/lpc55s69/cpu0/ns
       - mec15xxevb_assy6853
       - s32z2xxdc2/s32z270/rtu0
       - s32z2xxdc2/s32z270/rtu1


### PR DESCRIPTION
LPC55S0x, LPC55S1x and LPC55S3x SoC families were missing the WWDT (Windowed Watchdog Timer) peripheral node that is present in LPC55S2x and LPC55S6x. All LPC55Sxx SoCs share the same WWDT base address (0xc000) and interrupt (IRQ 0).

Add the wwdt0 node and watchdog0 alias to each common DTSI, enable the node on the corresponding boards, and declare watchdog support in the board YAML files:

  - nxp_lpc55S0x_common.dtsi -> lpcxpresso55s06
  - nxp_lpc55S1x_common.dtsi -> lpcxpresso55s16
  - nxp_lpc55S3x_common.dtsi -> lpcxpresso55s36
