### PR TITLE
boards: nxp: frdm_imxrt1186: fix cm7 dtcm/itcm region overlap

### DIFF
--- a/boards/nxp/frdm_imxrt1186/CMakeLists.txt
+++ b/boards/nxp/frdm_imxrt1186/CMakeLists.txt
@@ -10,7 +10,13 @@ zephyr_library_sources(board.c)
 if(CONFIG_BOARD_NXP_SPECIFIC_MPU_SETTINGS)
   if(CONFIG_SOC_MIMXRT1186_CM7)
     zephyr_library_sources(cm7/mpu_regions.c)
-    zephyr_linker_sources(DTCM_SECTION cm7/dtcm.ld)
+    # The DTCM_SECTION snippet only applies when a dedicated DTCM region is
+    # chosen. On the internal-memory CM7 variant DTCM is itself zephyr,sram, so
+    # no separate (overlapping) DTCM section group must be emitted.
+    dt_chosen(dtcm_chosen PROPERTY "zephyr,dtcm")
+    if(dtcm_chosen)
+      zephyr_linker_sources(DTCM_SECTION cm7/dtcm.ld)
+    endif()
   endif()
 endif()
 

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.dts
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.dts
@@ -17,8 +17,6 @@
 
 	chosen {
 		zephyr,sram = &dtcm;
-		zephyr,dtcm = &dtcm;
-		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart3;
 		zephyr,shell-uart = &lpuart3;
 		zephyr,flash = &itcm;


### PR DESCRIPTION
## Summary

The internal-memory CM7 variant of `frdm_imxrt1186` aliased the same TCM node to two chosen roles: `zephyr,sram` **and** `zephyr,dtcm` both pointed at `&dtcm`, and `zephyr,flash` **and** `zephyr,itcm` both pointed at `&itcm`.

Because the DTCM/ITCM linker section groups are emitted at the TCM region origin (`GROUP_LINK_IN(DTCM/ITCM ...)`), they land on top of the regular `.data`/`.bss`/iterable sections that already start at the same origin. The boot-time `.dtcm_bss` zeroing then wipes the overlapping initialized data.

In `tests/subsys/rtio/workq` this zeroed the `rtio_iodev` iterable section, so `dummy_iodev.api` became `NULL`. `rtio_submit()` then calls `iodev->api->submit()` through the NULL `api`, jumping to a stray RAM address and taking an **MPU instruction-access-violation** in `rtio.workq.rtio_work.work_decouples_submission`.

## Fix

- Drop the redundant `zephyr,dtcm` / `zephyr,itcm` chosen entries on the internal cm7 variant — DTCM already is `zephyr,sram` and ITCM already is `zephyr,flash`, so the separate (overlapping) TCM section groups are both redundant and harmful.
- Guard the board's `DTCM_SECTION` linker snippet with a `dt_chosen()` check so it is only added when a dedicated DTCM region is actually chosen.

The `cm7/extmem` variant is unaffected (it uses HyperRAM as `zephyr,sram` and external flash, with DTCM/ITCM as genuinely separate regions).

## Testing

Verified on `frdm_imxrt1186/mimxrt1186/cm7` via `west debug`: after the fix `dummy_iodev.api` reads back non-NULL (`&r_iodev_test_api`) and the rtio workq submit path runs without faulting (no MPU fault; the workq handler is invoked correctly).

Fixes #110248
