### PR TITLE
stm32h5: addition of STM32H5 PLL compatible / bindings

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -35,6 +35,11 @@
 
 #define PLL_FRACN_DIVISOR 8192
 
+#if IS_ENABLED(STM32_PLL_P_ENABLED)
+BUILD_ASSERT((STM32_PLL_P_DIVISOR % 2) == 0,
+	     "STM32H5 PLL1P divisor factor must be even");
+#endif /* STM32_PLL_P_ENABLED */
+
 static uint32_t get_bus_clock(uint32_t clock, uint32_t prescaler)
 {
 	return clock / prescaler;

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -95,16 +95,15 @@
 			status = "disabled";
 		};
 
-		/* The pll scheme is similar to stm32u5 */
 		pll1: pll: pll {
 			#clock-cells = <0>;
-			compatible = "st,stm32u5-pll-clock";
+			compatible = "st,stm32h5-pll-clock";
 			status = "disabled";
 		};
 
 		pll2: pll2 {
 			#clock-cells = <0>;
-			compatible = "st,stm32u5-pll-clock";
+			compatible = "st,stm32h5-pll-clock";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h5/stm32h523.dtsi
+++ b/dts/arm/st/h5/stm32h523.dtsi
@@ -1,12 +1,21 @@
 /*
  * Copyright (c) 2024 STMicroelectronics
  * Copyright (c) 2025 Filip Stojanovic
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <st/h5/stm32h5.dtsi>
 
 / {
+	clocks {
+		pll3: pll3 {
+			#clock-cells = <0>;
+			compatible = "st,stm32h5-pll-clock";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32h523", "st,stm32h5", "simple-bus";
 

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -11,10 +11,9 @@
 
 / {
 	clocks {
-		/* The pll scheme is similar to stm32u5 */
 		pll3: pll3 {
 			#clock-cells = <0>;
-			compatible = "st,stm32u5-pll-clock";
+			compatible = "st,stm32h5-pll-clock";
 			status = "disabled";
 		};
 	};

--- a/dts/bindings/clock/st,stm32h5-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32h5-pll-clock.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+title: STM32H5 PLL.
+
+description: |
+  It can be used to describe 3 different PLLs: PLL1 (Main PLL), PLL2 and PLL3.
+
+  These PLLs could take one of clk_hse, clk_hsi or clk_csi as input clock, with
+  an input frequency from 1 to 16 MHz. PLLM factor is used to set the input
+  clock in this acceptable range.
+
+  Each PLL can have up to 3 output clocks and for each output clock, the
+  frequency can be computed with the following formulae:
+
+    f(PLL_Px) = f(VCOx clock) / PLLPx   -> pllx_p_ck ((pll1_p_ck : sys_ck))
+    f(PLL_Qx) = f(VCOx clock) / PLLQx   -> pllx_q_ck
+    f(PLL_Rx) = f(VCOx clock) / PLLRx   -> pllx_r_ck
+
+      with f(VCOx clock) = f(REFx_CK) × (PLLNx / PLLMx)
+
+  f(VCOx clock) depends on the PLL. VCO1 maximum frequency is 560 MHz while
+  VCO2 and VCO3 (if applicable) have a maximum frequency of 420 Mhz.
+
+  The PLL output frequency must not exceed 420 MHz.
+
+  PLL3 is not available on stm32h503.
+
+compatible: "st,stm32h5-pll-clock"
+
+include:
+  - name: st,stm32h7-pll-clock.yaml
+    property-blocklist:
+      - div-p
+
+properties:
+  div-p:
+    type: int
+    description: |
+        PLL division factor for pllx_p_ck
+        Note: For PLL1, P division factor must be even.
+    min: 1
+    max: 128

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -214,6 +214,7 @@
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32u5_pll_clock, okay)  || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32wb_pll_clock, okay)  || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32wba_pll_clock, okay) || \
+	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32h5_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32h7_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32h7rs_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32mp13_pll_clock, okay)
@@ -293,6 +294,7 @@
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll2), st_stm32u5_pll_clock, okay) || \
+	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll2), st_stm32h5_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll2), st_stm32h7_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll2), st_stm32h7rs_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll2), st_stm32mp13_pll_clock, okay)
@@ -313,7 +315,8 @@
 #define STM32_PLL2_FRACN_VALUE	DT_PROP_OR(DT_NODELABEL(pll2), fracn, 0)
 #endif
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll3), st_stm32h7_pll_clock, okay) || \
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll3), st_stm32h5_pll_clock, okay) || \
+	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll3), st_stm32h7_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll3), st_stm32u5_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll3), st_stm32h7rs_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll3), st_stm32mp13_pll_clock, okay)


### PR DESCRIPTION
The PR add a new compatible to fix the incorrect compatible used on stm32h5.
In term of division / multiplication factors, the stm32h5 is same as the stm32h7.
That said compatible of the stm32h7 could be used, I would also be fine with this approach which would make less modification in the code actually, simply changing the compatible.

I took in this PR the approach to introduce a new bindings, which in turn include the stm32h7 bindings, allowing to have proper stm32h5 related description.

This PR allows to fix the issue raised post merge of the PR #110660.