### PR TITLE
drivers: i2c: stm32: handle nul-sized RTIO transfer

### DIFF
--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -112,12 +112,21 @@ bool i2c_stm32_start(const struct device *dev)
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
+		if (sqe->rx.buf_len == 0) {
+			return i2c_rtio_complete(ctx, 0);
+		}
 		return i2c_stm32_msg_start(dev, I2C_MSG_READ | flags, sqe->rx.buf,
 					   sqe->rx.buf_len, dt_spec->addr);
 	case RTIO_OP_TINY_TX:
+		if (sqe->tiny_tx.buf_len == 0) {
+			return i2c_rtio_complete(ctx, 0);
+		}
 		return i2c_stm32_msg_start(dev, flags, sqe->tiny_tx.buf,
 					   sqe->tiny_tx.buf_len, dt_spec->addr);
 	case RTIO_OP_TX:
+		if (sqe->tx.buf_len == 0) {
+			return i2c_rtio_complete(ctx, 0);
+		}
 		return i2c_stm32_msg_start(dev, flags, (uint8_t *)sqe->tx.buf,
 					   sqe->tx.buf_len, dt_spec->addr);
 	case RTIO_OP_I2C_CONFIGURE:

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -131,10 +131,10 @@ bool i2c_stm32_start(const struct device *dev)
 					   sqe->tx.buf_len, dt_spec->addr);
 	case RTIO_OP_I2C_CONFIGURE:
 		res = i2c_stm32_runtime_configure(dev, sqe->i2c_config);
-		return i2c_rtio_complete(data->ctx, res);
+		return i2c_rtio_complete(ctx, res);
 	default:
 		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);
-		return i2c_rtio_complete(data->ctx, -EINVAL);
+		return i2c_rtio_complete(ctx, -EINVAL);
 	}
 }
 

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -100,14 +100,26 @@ static bool i2c_stm32_start(const struct device *dev, int *status)
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
+		if (sqe->rx.buf_len == 0) {
+			*status = 0;
+			return false;
+		}
 		error = i2c_stm32_msg_start(dev, I2C_MSG_READ | flags, sqe->rx.buf, sqe->rx.buf_len,
 					    dt_spec->addr);
 		break;
 	case RTIO_OP_TINY_TX:
+		if (sqe->tiny_tx.buf_len == 0) {
+			*status = 0;
+			return false;
+		}
 		error = i2c_stm32_msg_start(dev, flags, sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
 					    dt_spec->addr);
 		break;
 	case RTIO_OP_TX:
+		if (sqe->tx.buf_len == 0) {
+			*status = 0;
+			return false;
+		}
 		error = i2c_stm32_msg_start(dev, flags, (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
 					    dt_spec->addr);
 		break;


### PR DESCRIPTION
When no bytes are to be transferred, the STM32 I2C RTIO driver will not get any interrupt to notify the request completion hence handle that straight before pushing a message start sequence.
