### PR TITLE
MAINTAINERS: drop asbjornsabo collaborator status

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6796,7 +6796,6 @@ West:
     - MariuszSkamra
   collaborators:
     - thalley
-    - asbjornsabo
   files:
     - modules/liblc3/
   labels:


### PR DESCRIPTION
asbjornsabo is not currently involved with the project anymore so drop them from the collaborator list.