### PR TITLE
drivers: i2c: stm32: Add DMA support in RTIO i2c_stm32_v2 driver

### DIFF
--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/drivers/dma.h>
-#include <zephyr/drivers/dma/dma_stm32.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/pm/device.h>
@@ -31,12 +29,6 @@ LOG_MODULE_REGISTER(i2c_stm32);
 
 #include "i2c_stm32.h"
 #include "i2c-priv.h"
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
-#define DT_DRV_COMPAT st_stm32_i2c_v2
-#else
-#define DT_DRV_COMPAT st_stm32_i2c_v1
-#endif
 
 /* This symbol takes the value 1 if one of the device instances */
 /* is configured in dts with a domain clock */
@@ -325,7 +317,7 @@ restore:
 }
 #endif /* CONFIG_I2C_STM32_BUS_RECOVERY */
 
-static DEVICE_API(i2c, api_funcs) = {
+DEVICE_API(i2c, i2c_stm32_driver_api) = {
 	.configure = i2c_stm32_runtime_configure,
 	.transfer = i2c_stm32_transfer,
 	.get_config = i2c_stm32_get_config,
@@ -341,7 +333,7 @@ static DEVICE_API(i2c, api_funcs) = {
 #endif
 };
 
-static int i2c_stm32_init(const struct device *dev)
+int i2c_stm32_init(const struct device *dev)
 {
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct i2c_stm32_config *cfg = dev->config;
@@ -470,117 +462,3 @@ void i2c_stm32_smbalert_disable(const struct device *dev)
 	LL_I2C_Disable(cfg->i2c);
 }
 #endif /* CONFIG_SMBUS_STM32 */
-
-/* Macros for I2C instance declaration */
-
-#ifdef CONFIG_I2C_STM32_V2_DMA
-
-#define I2C_DMA_INIT(index, dir)								\
-	.dir##_dma = {										\
-		.dev_dma = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),			\
-				(DEVICE_DT_GET(STM32_DMA_CTLR(index, dir))), (NULL)),		\
-		.dma_channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),			\
-				(DT_INST_DMAS_CELL_BY_NAME(index, dir, channel)), (-1)),	\
-	},
-
-void i2c_stm32_dma_tx_cb(const struct device *dma_dev, void *user_data,
-			 uint32_t channel, int status)
-{
-	ARG_UNUSED(dma_dev);
-	ARG_UNUSED(user_data);
-	ARG_UNUSED(channel);
-
-	/* log DMA TX error */
-	if (status != 0) {
-		LOG_ERR("DMA error %d", status);
-	}
-}
-
-void i2c_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
-			 uint32_t channel, int status)
-{
-	ARG_UNUSED(dma_dev);
-	ARG_UNUSED(user_data);
-	ARG_UNUSED(channel);
-
-	/* log DMA RX error */
-	if (status != 0) {
-		LOG_ERR("DMA error %d", status);
-	}
-}
-
-#define I2C_DMA_DATA_INIT(index, dir, src, dest)						\
-	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, dir),						\
-		(.dma_##dir##_cfg = {								\
-			.dma_slot = STM32_DMA_SLOT(index, dir, slot),				\
-			.channel_direction = STM32_DMA_CONFIG_DIRECTION(			\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.cyclic =  STM32_DMA_CONFIG_CYCLIC(					\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.channel_priority = STM32_DMA_CONFIG_PRIORITY(				\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.source_data_size = STM32_DMA_CONFIG_##src##_DATA_SIZE(			\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.dest_data_size = STM32_DMA_CONFIG_##dest##_DATA_SIZE(			\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			/* single transfers (burst length = data size) */			\
-			.source_burst_length = STM32_DMA_CONFIG_##src##_DATA_SIZE(		\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.dest_burst_length = STM32_DMA_CONFIG_##dest##_DATA_SIZE(		\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.dma_callback = i2c_stm32_dma_##dir##_cb,				\
-		},))
-
-#else /* CONFIG_I2C_STM32_V2_DMA */
-
-#define I2C_DMA_INIT(index, dir)
-#define I2C_DMA_DATA_INIT(index, dir, src, dest)
-
-#endif /* CONFIG_I2C_STM32_V2_DMA */
-
-#define I2C_STM32_INIT(index)									\
-	I2C_STM32_IRQ_HANDLER_DECL(index);							\
-												\
-	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),					\
-		(static const uint32_t i2c_timings_##index[] =					\
-			DT_INST_PROP_OR(index, timings, {});))					\
-												\
-	PINCTRL_DT_INST_DEFINE(index);								\
-												\
-	static const struct stm32_pclken pclken_##index[] = STM32_DT_INST_CLOCKS(index);	\
-												\
-	static const struct i2c_stm32_config i2c_stm32_cfg_##index = {				\
-		.i2c = (I2C_TypeDef *)DT_INST_REG_ADDR(index),					\
-		.pclken = pclken_##index,							\
-		.pclk_len = DT_INST_NUM_CLOCKS(index),						\
-		I2C_STM32_IRQ_HANDLER_FUNCTION(index)						\
-		.bitrate = DT_INST_PROP(index, clock_frequency),				\
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),					\
-		IF_ENABLED(CONFIG_I2C_STM32_BUS_RECOVERY,					\
-			   (.scl = GPIO_DT_SPEC_INST_GET_OR(index, scl_gpios, {0}),		\
-			    .sda = GPIO_DT_SPEC_INST_GET_OR(index, sda_gpios, {0}),))		\
-		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),				\
-			   (.timings = (const struct i2c_config_timing *)i2c_timings_##index,	\
-			    .n_timings =							\
-			sizeof(i2c_timings_##index) / (sizeof(struct i2c_config_timing)),))	\
-		I2C_DMA_INIT(index, tx)								\
-		I2C_DMA_INIT(index, rx)								\
-	};											\
-												\
-	static struct i2c_stm32_data i2c_stm32_dev_data_##index = {				\
-		I2C_DMA_DATA_INIT(index, tx, MEMORY, PERIPHERAL)				\
-		I2C_DMA_DATA_INIT(index, rx, PERIPHERAL, MEMORY)				\
-	};											\
-												\
-	PM_DEVICE_DT_INST_DEFINE(index, i2c_stm32_pm_action);					\
-												\
-	I2C_DEVICE_DT_INST_DEFINE(index, i2c_stm32_init,					\
-				  PM_DEVICE_DT_INST_GET(index),					\
-				  &i2c_stm32_dev_data_##index,					\
-				  &i2c_stm32_cfg_##index,					\
-				  POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,			\
-				  &api_funcs);							\
-												\
-	I2C_STM32_IRQ_HANDLER(index)
-
-DT_INST_FOREACH_STATUS_OKAY(I2C_STM32_INIT)

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -122,12 +122,17 @@ struct i2c_stm32_data {
 	i2c_stm32_smbalert_cb_func_t smbalert_cb_func;
 	const struct device *smbalert_cb_dev;
 #endif /* CONFIG_SMBUS_STM32_SMBALERT */
+#endif /* CONFIG_I2C_RTIO */
+
 #ifdef CONFIG_I2C_STM32_V2_DMA
 	struct dma_config dma_tx_cfg;
 	struct dma_config dma_rx_cfg;
 	struct dma_block_config dma_blk_cfg;
-#endif /* CONFIG_I2C_STM32_V2_DMA */
+#ifdef CONFIG_I2C_RTIO
+	uint8_t *dma_buf;	/* Base address of the Rx buffer fed by DMA */
+	size_t dma_len;		/* Byte size of the Rx buffer fed by DMA */
 #endif /* CONFIG_I2C_RTIO */
+#endif /* CONFIG_I2C_STM32_V2_DMA */
 
 #ifdef CONFIG_I2C_TARGET
 	bool controller_active;

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -140,8 +140,8 @@ struct i2c_stm32_data {
 };
 
 #ifdef CONFIG_I2C_RTIO
-void i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, size_t buf_len,
-			 uint16_t i2c_addr);
+int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, size_t buf_len,
+			uint16_t i2c_addr);
 void i2c_stm32_rtio_complete(const struct device *dev, int status);
 #else /* CONFIG_I2C_RTIO */
 int i2c_stm32_transaction(const struct device *dev,

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -144,6 +144,10 @@ struct i2c_stm32_data {
 #endif /* CONFIG_I2C_TARGET */
 };
 
+extern const struct i2c_driver_api i2c_stm32_driver_api;
+
+int i2c_stm32_init(const struct device *dev);
+
 #ifdef CONFIG_I2C_RTIO
 int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, size_t buf_len,
 			uint16_t i2c_addr);

--- a/drivers/i2c/i2c_stm32_common.c
+++ b/drivers/i2c/i2c_stm32_common.c
@@ -9,6 +9,9 @@
 
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/dma/dma_stm32.h>
+#include <zephyr/drivers/i2c/rtio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/pm/policy.h>
@@ -16,6 +19,12 @@
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(i2c_ll_stm32_common);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
+#define DT_DRV_COMPAT st_stm32_i2c_v2
+#else
+#define DT_DRV_COMPAT st_stm32_i2c_v1
+#endif
 
 #include "i2c_stm32.h"
 
@@ -137,3 +146,123 @@ void i2c_stm32_pm_put(const struct device *dev)
 	}
 	(void)pm_device_runtime_put(dev);
 }
+
+/* I2C instances definitions */
+
+#ifdef CONFIG_I2C_STM32_V2_DMA
+
+#define I2C_DMA_INIT(index, dir)								\
+	.dir##_dma = {										\
+		.dev_dma = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),			\
+				(DEVICE_DT_GET(STM32_DMA_CTLR(index, dir))), (NULL)),		\
+		.dma_channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),			\
+				(DT_INST_DMAS_CELL_BY_NAME(index, dir, channel)), (-1)),	\
+	},
+
+void i2c_stm32_dma_tx_cb(const struct device *dma_dev __unused, void *user_data __unused,
+			 uint32_t channel __unused, int status)
+{
+	/* log DMA TX error */
+	if (status != 0) {
+		LOG_ERR("DMA error %d", status);
+	}
+}
+
+void i2c_stm32_dma_rx_cb(const struct device *dma_dev __unused, void *user_data __unused,
+			 uint32_t channel __unused, int status)
+{
+	/* log DMA RX error */
+	if (status != 0) {
+		LOG_ERR("DMA error %d", status);
+	}
+}
+
+#define I2C_DMA_DATA_INIT(index, dir, src, dest)						\
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, dir),						\
+		(.dma_##dir##_cfg = {								\
+			.dma_slot = STM32_DMA_SLOT(index, dir, slot),				\
+			.channel_direction = STM32_DMA_CONFIG_DIRECTION(			\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.cyclic =  STM32_DMA_CONFIG_CYCLIC(					\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.channel_priority = STM32_DMA_CONFIG_PRIORITY(				\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.source_data_size = STM32_DMA_CONFIG_##src##_DATA_SIZE(			\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.dest_data_size = STM32_DMA_CONFIG_##dest##_DATA_SIZE(			\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			/* single transfers (burst length = data size) */			\
+			.source_burst_length = STM32_DMA_CONFIG_##src##_DATA_SIZE(		\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.dest_burst_length = STM32_DMA_CONFIG_##dest##_DATA_SIZE(		\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.dma_callback = i2c_stm32_dma_##dir##_cb,				\
+		},))
+
+#else /* CONFIG_I2C_STM32_V2_DMA */
+
+#define I2C_DMA_INIT(index, dir)
+#define I2C_DMA_DATA_INIT(index, dir, src, dest)
+
+#endif /* CONFIG_I2C_STM32_V2_DMA */
+
+#define I2C_STM32_INIT(index)									\
+	I2C_STM32_IRQ_HANDLER_DECL(index);							\
+												\
+	BUILD_ASSERT(!IS_ENABLED(CONFIG_I2C_STM32_V2_DMA) ||					\
+		     (DT_INST_DMAS_HAS_NAME(index, tx) == DT_INST_DMAS_HAS_NAME(index, rx)),	\
+		     "STM32 I2C requires either none or both of rx and tx DMAs are used");	\
+												\
+	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2), (				\
+	static const uint32_t i2c_timings_##index[] = DT_INST_PROP_OR(index, timings, {});	\
+	))											\
+												\
+	PINCTRL_DT_INST_DEFINE(index);								\
+												\
+	static const struct stm32_pclken pclken_##index[] = STM32_DT_INST_CLOCKS(index);	\
+												\
+	static const struct i2c_stm32_config i2c_stm32_cfg_##index = {				\
+		.i2c = (I2C_TypeDef *)DT_INST_REG_ADDR(index),					\
+		.pclken = pclken_##index,							\
+		.pclk_len = DT_INST_NUM_CLOCKS(index),						\
+		I2C_STM32_IRQ_HANDLER_FUNCTION(index)						\
+		.bitrate = DT_INST_PROP(index, clock_frequency),				\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),					\
+		IF_ENABLED(CONFIG_I2C_STM32_BUS_RECOVERY, (					\
+		.scl = GPIO_DT_SPEC_INST_GET_OR(index, scl_gpios, {0}),				\
+		.sda = GPIO_DT_SPEC_INST_GET_OR(index, sda_gpios, {0}),				\
+		))										\
+		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2), (			\
+		.timings = (const struct i2c_config_timing *)i2c_timings_##index,		\
+		.n_timings = sizeof(i2c_timings_##index) / (sizeof(struct i2c_config_timing)),	\
+		))										\
+		I2C_DMA_INIT(index, tx)								\
+		I2C_DMA_INIT(index, rx)								\
+	};											\
+												\
+	IF_ENABLED(CONFIG_I2C_RTIO, (								\
+		I2C_RTIO_DEFINE(CONCAT(_i2c, index, _stm32_rtio),				\
+				DT_INST_PROP_OR(index, sq_size, CONFIG_I2C_RTIO_SQ_SIZE),	\
+				DT_INST_PROP_OR(index, cq_size, CONFIG_I2C_RTIO_CQ_SIZE));	\
+	))											\
+												\
+	static struct i2c_stm32_data i2c_stm32_dev_data_##index = {				\
+		IF_ENABLED(CONFIG_I2C_RTIO, (							\
+		.ctx = &CONCAT(_i2c, index, _stm32_rtio),					\
+		))										\
+		I2C_DMA_DATA_INIT(index, tx, MEMORY, PERIPHERAL)				\
+		I2C_DMA_DATA_INIT(index, rx, PERIPHERAL, MEMORY)				\
+	};											\
+												\
+	PM_DEVICE_DT_INST_DEFINE(index, i2c_stm32_pm_action);					\
+												\
+	I2C_DEVICE_DT_INST_DEFINE(index, i2c_stm32_init,					\
+				  PM_DEVICE_DT_INST_GET(index),					\
+				  &i2c_stm32_dev_data_##index,					\
+				  &i2c_stm32_cfg_##index,					\
+				  POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,			\
+				  &i2c_stm32_driver_api);					\
+												\
+	I2C_STM32_IRQ_HANDLER(index)
+
+DT_INST_FOREACH_STATUS_OKAY(I2C_STM32_INIT)

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -102,6 +102,7 @@ static bool i2c_stm32_start(const struct device *dev, int *status)
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
 	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
 	uint8_t flags = sqe->iodev_flags;
+	int error;
 
 #ifdef CONFIG_I2C_STM32_V2
 	struct rtio_iodev_sqe *iodev_sqe_next = rtio_txn_next(ctx->txn_curr);
@@ -115,16 +116,16 @@ static bool i2c_stm32_start(const struct device *dev, int *status)
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
-		i2c_stm32_msg_start(dev, I2C_MSG_READ | flags, sqe->rx.buf, sqe->rx.buf_len,
-				    dt_spec->addr);
+		error = i2c_stm32_msg_start(dev, I2C_MSG_READ | flags, sqe->rx.buf, sqe->rx.buf_len,
+					    dt_spec->addr);
 		break;
 	case RTIO_OP_TINY_TX:
-		i2c_stm32_msg_start(dev, flags, sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
-				    dt_spec->addr);
+		error = i2c_stm32_msg_start(dev, flags, sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
+					    dt_spec->addr);
 		break;
 	case RTIO_OP_TX:
-		i2c_stm32_msg_start(dev, flags, (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
-				    dt_spec->addr);
+		error = i2c_stm32_msg_start(dev, flags, (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
+					    dt_spec->addr);
 		break;
 	case RTIO_OP_I2C_CONFIGURE:
 		*status = i2c_stm32_runtime_configure(dev, sqe->i2c_config);
@@ -132,6 +133,12 @@ static bool i2c_stm32_start(const struct device *dev, int *status)
 	default:
 		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);
 		*status = -EINVAL;
+		return false;
+	}
+
+	/* Reaching this point, no asynchronous sequence is started only if an error was reported */
+	if (error != 0) {
+		*status = error;
 		return false;
 	}
 

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -8,6 +8,7 @@
 #include <soc.h>
 #include <stm32_ll_i2c.h>
 #include <stm32_ll_rcc.h>
+#include <zephyr/drivers/dma/dma_stm32.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/i2c.h>
@@ -322,8 +323,77 @@ static int i2c_stm32_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_I2C_STM32_V2_DMA
+
+#define I2C_DMA_INIT(index, dir)								\
+	.dir##_dma = {										\
+		.dev_dma = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),			\
+				(DEVICE_DT_GET(STM32_DMA_CTLR(index, dir))), (NULL)),		\
+		.dma_channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),			\
+				(DT_INST_DMAS_CELL_BY_NAME(index, dir, channel)), (-1)),	\
+	},
+
+void i2c_stm32_dma_tx_cb(const struct device *dma_dev, void *user_data,
+			 uint32_t channel, int status)
+{
+	ARG_UNUSED(dma_dev);
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(channel);
+
+	/* log DMA TX error */
+	if (status != 0) {
+		LOG_ERR("DMA error %d", status);
+	}
+}
+
+void i2c_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
+			 uint32_t channel, int status)
+{
+	ARG_UNUSED(dma_dev);
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(channel);
+
+	/* log DMA RX error */
+	if (status != 0) {
+		LOG_ERR("DMA error %d", status);
+	}
+}
+
+#define I2C_DMA_DATA_INIT(index, dir, src, dest)						\
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, dir),						\
+		(.dma_##dir##_cfg = {								\
+			.dma_slot = STM32_DMA_SLOT(index, dir, slot),				\
+			.channel_direction = STM32_DMA_CONFIG_DIRECTION(			\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.cyclic =  STM32_DMA_CONFIG_CYCLIC(					\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.channel_priority = STM32_DMA_CONFIG_PRIORITY(				\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.source_data_size = STM32_DMA_CONFIG_##src##_DATA_SIZE(			\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.dest_data_size = STM32_DMA_CONFIG_##dest##_DATA_SIZE(			\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			/* single transfers (burst length = data size) */			\
+			.source_burst_length = STM32_DMA_CONFIG_##src##_DATA_SIZE(		\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.dest_burst_length = STM32_DMA_CONFIG_##dest##_DATA_SIZE(		\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.dma_callback = i2c_stm32_dma_##dir##_cb,				\
+		},))
+
+#else /* CONFIG_I2C_STM32_V2_DMA */
+
+#define I2C_DMA_INIT(index, dir)
+#define I2C_DMA_DATA_INIT(index, dir, src, dest)
+
+#endif /* CONFIG_I2C_STM32_V2_DMA */
+
 #define I2C_STM32_INIT(index)									\
 	I2C_STM32_IRQ_HANDLER_DECL(index);							\
+												\
+	BUILD_ASSERT(!IS_ENABLED(CONFIG_I2C_STM32_V2_DMA) ||					\
+		     (DT_INST_DMAS_HAS_NAME(index, tx) == DT_INST_DMAS_HAS_NAME(index, rx)),	\
+		     "STM32 I2C requires either none or both of rx and tx DMAs are used");	\
 												\
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),					\
 		   (static const uint32_t i2c_timings_##index[] =				\
@@ -344,6 +414,8 @@ static int i2c_stm32_init(const struct device *dev)
 			   (.timings = (const struct i2c_config_timing *)i2c_timings_##index,	\
 			    .n_timings =							\
 			sizeof(i2c_timings_##index) / (sizeof(struct i2c_config_timing)),))	\
+		I2C_DMA_INIT(index, tx)								\
+		I2C_DMA_INIT(index, rx)								\
 	};											\
 												\
 	I2C_RTIO_DEFINE(CONCAT(_i2c, index, _stm32_rtio),					\
@@ -352,6 +424,8 @@ static int i2c_stm32_init(const struct device *dev)
 												\
 	static struct i2c_stm32_data i2c_stm32_dev_data_##index = {				\
 		.ctx = &CONCAT(_i2c, index, _stm32_rtio),					\
+		I2C_DMA_DATA_INIT(index, tx, MEMORY, PERIPHERAL)				\
+		I2C_DMA_DATA_INIT(index, rx, PERIPHERAL, MEMORY)				\
 	};											\
 												\
 	PM_DEVICE_DT_INST_DEFINE(index, i2c_stm32_pm_action);					\

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -8,7 +8,6 @@
 #include <soc.h>
 #include <stm32_ll_i2c.h>
 #include <stm32_ll_rcc.h>
-#include <zephyr/drivers/dma/dma_stm32.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/i2c.h>
@@ -27,12 +26,6 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_rtio);
 
 #include "i2c_stm32.h"
 #include "i2c-priv.h"
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
-#define DT_DRV_COMPAT st_stm32_i2c_v2
-#else
-#define DT_DRV_COMPAT st_stm32_i2c_v1
-#endif
 
 /* This symbol takes the value 1 if one of the device instances */
 /* is configured in dts with a domain clock */
@@ -260,7 +253,7 @@ static void i2c_stm32_submit(const struct device *dev, struct rtio_iodev_sqe *io
 	}
 }
 
-static DEVICE_API(i2c, api_funcs) = {
+DEVICE_API(i2c, i2c_stm32_driver_api) = {
 	.configure = i2c_stm32_configure,
 	.transfer = i2c_stm32_transfer,
 	.get_config = i2c_stm32_get_config,
@@ -271,7 +264,7 @@ static DEVICE_API(i2c, api_funcs) = {
 #endif
 };
 
-static int i2c_stm32_init(const struct device *dev)
+int i2c_stm32_init(const struct device *dev)
 {
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct i2c_stm32_config *cfg = dev->config;
@@ -322,121 +315,3 @@ static int i2c_stm32_init(const struct device *dev)
 
 	return 0;
 }
-
-#ifdef CONFIG_I2C_STM32_V2_DMA
-
-#define I2C_DMA_INIT(index, dir)								\
-	.dir##_dma = {										\
-		.dev_dma = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),			\
-				(DEVICE_DT_GET(STM32_DMA_CTLR(index, dir))), (NULL)),		\
-		.dma_channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),			\
-				(DT_INST_DMAS_CELL_BY_NAME(index, dir, channel)), (-1)),	\
-	},
-
-void i2c_stm32_dma_tx_cb(const struct device *dma_dev, void *user_data,
-			 uint32_t channel, int status)
-{
-	ARG_UNUSED(dma_dev);
-	ARG_UNUSED(user_data);
-	ARG_UNUSED(channel);
-
-	/* log DMA TX error */
-	if (status != 0) {
-		LOG_ERR("DMA error %d", status);
-	}
-}
-
-void i2c_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
-			 uint32_t channel, int status)
-{
-	ARG_UNUSED(dma_dev);
-	ARG_UNUSED(user_data);
-	ARG_UNUSED(channel);
-
-	/* log DMA RX error */
-	if (status != 0) {
-		LOG_ERR("DMA error %d", status);
-	}
-}
-
-#define I2C_DMA_DATA_INIT(index, dir, src, dest)						\
-	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, dir),						\
-		(.dma_##dir##_cfg = {								\
-			.dma_slot = STM32_DMA_SLOT(index, dir, slot),				\
-			.channel_direction = STM32_DMA_CONFIG_DIRECTION(			\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.cyclic =  STM32_DMA_CONFIG_CYCLIC(					\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.channel_priority = STM32_DMA_CONFIG_PRIORITY(				\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.source_data_size = STM32_DMA_CONFIG_##src##_DATA_SIZE(			\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.dest_data_size = STM32_DMA_CONFIG_##dest##_DATA_SIZE(			\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			/* single transfers (burst length = data size) */			\
-			.source_burst_length = STM32_DMA_CONFIG_##src##_DATA_SIZE(		\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.dest_burst_length = STM32_DMA_CONFIG_##dest##_DATA_SIZE(		\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.dma_callback = i2c_stm32_dma_##dir##_cb,				\
-		},))
-
-#else /* CONFIG_I2C_STM32_V2_DMA */
-
-#define I2C_DMA_INIT(index, dir)
-#define I2C_DMA_DATA_INIT(index, dir, src, dest)
-
-#endif /* CONFIG_I2C_STM32_V2_DMA */
-
-#define I2C_STM32_INIT(index)									\
-	I2C_STM32_IRQ_HANDLER_DECL(index);							\
-												\
-	BUILD_ASSERT(!IS_ENABLED(CONFIG_I2C_STM32_V2_DMA) ||					\
-		     (DT_INST_DMAS_HAS_NAME(index, tx) == DT_INST_DMAS_HAS_NAME(index, rx)),	\
-		     "STM32 I2C requires either none or both of rx and tx DMAs are used");	\
-												\
-	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),					\
-		   (static const uint32_t i2c_timings_##index[] =				\
-			DT_INST_PROP_OR(index, timings, {});))					\
-												\
-	PINCTRL_DT_INST_DEFINE(index);								\
-												\
-	static const struct stm32_pclken pclken_##index[] = STM32_DT_INST_CLOCKS(index);	\
-												\
-	static const struct i2c_stm32_config i2c_stm32_cfg_##index = {				\
-		.i2c = (I2C_TypeDef *)DT_INST_REG_ADDR(index),					\
-		.pclken = pclken_##index,							\
-		.pclk_len = DT_INST_NUM_CLOCKS(index),						\
-		I2C_STM32_IRQ_HANDLER_FUNCTION(index)						\
-		.bitrate = DT_INST_PROP(index, clock_frequency),				\
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),					\
-		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),				\
-			   (.timings = (const struct i2c_config_timing *)i2c_timings_##index,	\
-			    .n_timings =							\
-			sizeof(i2c_timings_##index) / (sizeof(struct i2c_config_timing)),))	\
-		I2C_DMA_INIT(index, tx)								\
-		I2C_DMA_INIT(index, rx)								\
-	};											\
-												\
-	I2C_RTIO_DEFINE(CONCAT(_i2c, index, _stm32_rtio),					\
-			DT_INST_PROP_OR(index, sq_size, CONFIG_I2C_RTIO_SQ_SIZE),		\
-			DT_INST_PROP_OR(index, cq_size, CONFIG_I2C_RTIO_CQ_SIZE));		\
-												\
-	static struct i2c_stm32_data i2c_stm32_dev_data_##index = {				\
-		.ctx = &CONCAT(_i2c, index, _stm32_rtio),					\
-		I2C_DMA_DATA_INIT(index, tx, MEMORY, PERIPHERAL)				\
-		I2C_DMA_DATA_INIT(index, rx, PERIPHERAL, MEMORY)				\
-	};											\
-												\
-	PM_DEVICE_DT_INST_DEFINE(index, i2c_stm32_pm_action);					\
-												\
-	I2C_DEVICE_DT_INST_DEFINE(index, i2c_stm32_init,					\
-				  PM_DEVICE_DT_INST_GET(index),					\
-				  &i2c_stm32_dev_data_##index,					\
-				  &i2c_stm32_cfg_##index,					\
-				  POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,			\
-				  &api_funcs);							\
-												\
-	I2C_STM32_IRQ_HANDLER(index)
-
-DT_INST_FOREACH_STATUS_OKAY(I2C_STM32_INIT)

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -512,8 +512,8 @@ error:
 
 }
 
-void i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, size_t buf_len,
-			 uint16_t i2c_addr)
+int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, size_t buf_len,
+			uint16_t i2c_addr)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
@@ -543,6 +543,8 @@ void i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, 
 	} else {
 		LL_I2C_EnableIT_TX(i2c);
 	}
+
+	return 0;
 }
 
 int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -10,11 +10,13 @@
 #include <soc.h>
 #include <stm32_ll_i2c.h>
 #include <stm32_ll_rcc.h>
+#include <stm32_cache.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/i2c/rtio.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/cache.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
@@ -34,6 +36,121 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_v2_rtio);
 #define STM32_I2C_CONVERT_TIMINGS(prescaler, setup_time, hold_time, sclh_period, scll_period) \
 	__LL_I2C_CONVERT_TIMINGS(prescaler, setup_time, hold_time, sclh_period, scll_period)
 #endif /* CONFIG_STM32_HAL2 */
+
+#ifdef CONFIG_I2C_STM32_V2_DMA
+static bool using_dma(const struct device *dev)
+{
+	const struct i2c_stm32_config *cfg = dev->config;
+
+	return (cfg->rx_dma.dev_dma != NULL) && (cfg->tx_dma.dev_dma != NULL);
+}
+
+static int configure_start_dma(struct stream const *dma, struct dma_config *dma_cfg,
+			       struct dma_block_config *blk_cfg)
+{
+	if (!device_is_ready(dma->dev_dma)) {
+		LOG_ERR("DMA device not ready");
+		return -ENODEV;
+	}
+
+	dma_cfg->head_block = blk_cfg;
+	dma_cfg->block_count = 1;
+
+	int ret = dma_config(dma->dev_dma, dma->dma_channel, dma_cfg);
+
+	if (ret != 0) {
+		LOG_ERR("Problem setting up DMA: %d", ret);
+		return ret;
+	}
+
+	ret = dma_start(dma->dev_dma, dma->dma_channel);
+	if (ret != 0) {
+		LOG_ERR("Problem starting DMA: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int dma_xfer_start(const struct device *dev)
+{
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
+	I2C_TypeDef *i2c = cfg->i2c;
+	int ret;
+
+	if ((data->xfer_flags & I2C_MSG_READ) != 0U) {
+		/* Save DMA receive buffer to later invalidate cache before reading received data */
+		data->dma_buf = data->xfer_buf;
+		data->dma_len = data->xfer_len;
+
+		data->dma_blk_cfg.source_address = LL_I2C_DMA_GetRegAddr(
+			cfg->i2c, LL_I2C_DMA_REG_DATA_RECEIVE);
+		data->dma_blk_cfg.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+		data->dma_blk_cfg.dest_address = (uint32_t)data->xfer_buf;
+		data->dma_blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+		data->dma_blk_cfg.block_size = data->xfer_len;
+
+		ret = configure_start_dma(&cfg->rx_dma, &data->dma_rx_cfg, &data->dma_blk_cfg);
+		if (ret != 0) {
+			return ret;
+		}
+
+		LL_I2C_EnableDMAReq_RX(i2c);
+	} else {
+		if (!stm32_buf_in_nocache((uintptr_t)data->xfer_buf, data->xfer_len)) {
+			sys_cache_data_flush_range(data->xfer_buf, data->xfer_len);
+		}
+
+		data->dma_blk_cfg.source_address = (uint32_t)data->xfer_buf;
+		data->dma_blk_cfg.source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+		data->dma_blk_cfg.dest_address = LL_I2C_DMA_GetRegAddr(
+			cfg->i2c, LL_I2C_DMA_REG_DATA_TRANSMIT);
+		data->dma_blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+		data->dma_blk_cfg.block_size = data->xfer_len;
+
+		ret = configure_start_dma(&cfg->tx_dma, &data->dma_tx_cfg, &data->dma_blk_cfg);
+		if (ret != 0) {
+			return ret;
+		}
+
+		LL_I2C_EnableDMAReq_TX(i2c);
+	}
+
+	return 0;
+}
+
+static void dma_finish(const struct device *dev)
+{
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
+
+	if ((data->xfer_flags & I2C_MSG_READ) != 0U) {
+		dma_stop(cfg->rx_dma.dev_dma, cfg->rx_dma.dma_channel);
+		LL_I2C_DisableDMAReq_RX(cfg->i2c);
+
+		if ((data->dma_len != 0U) &&
+		    !stm32_buf_in_nocache((uintptr_t)data->dma_buf, data->dma_len)) {
+			sys_cache_data_invd_range(data->dma_buf, data->dma_len);
+		}
+	} else {
+		dma_stop(cfg->tx_dma.dev_dma, cfg->tx_dma.dma_channel);
+		LL_I2C_DisableDMAReq_TX(cfg->i2c);
+	}
+}
+#else /* CONFIG_I2C_STM32_V2_DMA */
+static bool using_dma(const struct device *dev __unused)
+{
+	return false;
+}
+static int dma_xfer_start(const struct device *dev __unused)
+{
+	return 0;
+}
+static void dma_finish(const struct device *dev __unused)
+{
+}
+#endif /* CONFIG_I2C_STM32_V2_DMA */
 
 static void i2c_stm32_disable_transfer_interrupts(const struct device *dev)
 {
@@ -63,6 +180,10 @@ static void i2c_stm32_controller_mode_end(const struct device *dev)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
+
+	if (using_dma(dev)) {
+		dma_finish(dev);
+	}
 
 	i2c_stm32_disable_transfer_interrupts(dev);
 
@@ -377,7 +498,10 @@ void i2c_stm32_event(const struct device *dev)
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
+	bool use_dma;
 	int ret = 0;
+
+	use_dma = using_dma(dev);
 
 #if defined(CONFIG_I2C_TARGET)
 	if (data->target_attached && !data->controller_active) {
@@ -387,6 +511,10 @@ void i2c_stm32_event(const struct device *dev)
 #endif
 
 	if (data->burst_len != 0U) {
+		if (use_dma) {
+			goto skip_bytewise_xfer;
+		}
+
 		/* Send next byte */
 		if (LL_I2C_IsActiveFlag_TXIS(i2c)) {
 			LL_I2C_TransmitData8(i2c, *data->xfer_buf);
@@ -402,6 +530,7 @@ void i2c_stm32_event(const struct device *dev)
 		data->burst_len--;
 	}
 
+skip_bytewise_xfer:
 	/* NACK received */
 	if (LL_I2C_IsActiveFlag_NACK(i2c)) {
 		LL_I2C_ClearFlag_NACK(i2c);
@@ -425,6 +554,12 @@ void i2c_stm32_event(const struct device *dev)
 
 	if (LL_I2C_IsActiveFlag_TC(i2c) ||
 	    LL_I2C_IsActiveFlag_TCR(i2c)) {
+		if (use_dma && (data->burst_len != 0U)) {
+			data->xfer_len -= data->burst_len;
+			data->xfer_buf += data->burst_len;
+			data->burst_len = 0U;
+		}
+
 		__ASSERT_NO_MSG(data->burst_len == 0U);
 
 		if (data->xfer_len != 0U) {
@@ -436,6 +571,10 @@ void i2c_stm32_event(const struct device *dev)
 		if ((data->burst_flags & I2C_MSG_STOP) != 0) {
 			LL_I2C_GenerateStopCondition(i2c);
 		} else {
+			if (use_dma) {
+				dma_finish(dev);
+			}
+
 			i2c_stm32_disable_transfer_interrupts(dev);
 			i2c_stm32_rtio_complete(dev, ret);
 		}
@@ -489,6 +628,9 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, s
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	uint32_t transfer;
+	bool use_dma;
+
+	use_dma = using_dma(dev);
 
 	data->xfer_buf = buf;
 	data->xfer_len = buf_len;
@@ -543,11 +685,19 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, s
 	LL_I2C_GenerateStartCondition(i2c);
 
 out:
+	if (use_dma && dma_xfer_start(dev) != 0) {
+		i2c_stm32_controller_mode_end(dev);
+		return -EIO;
+	}
+
 	i2c_stm32_enable_transfer_interrupts(dev);
-	if ((flags & I2C_MSG_READ) != 0) {
-		LL_I2C_EnableIT_RX(i2c);
-	} else {
-		LL_I2C_EnableIT_TX(i2c);
+
+	if (!use_dma) {
+		if ((flags & I2C_MSG_READ) != 0) {
+			LL_I2C_EnableIT_RX(i2c);
+		} else {
+			LL_I2C_EnableIT_TX(i2c);
+		}
 	}
 
 	return 0;

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -482,8 +482,8 @@ int i2c_stm32_error(const struct device *dev)
 	return ret;
 }
 
-void i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, size_t buf_len,
-			 uint16_t i2c_addr)
+int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, size_t buf_len,
+			uint16_t i2c_addr)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
@@ -549,6 +549,8 @@ out:
 	} else {
 		LL_I2C_EnableIT_TX(i2c);
 	}
+
+	return 0;
 }
 
 int i2c_stm32_configure_timing(const struct device *dev, uint32_t clock)


### PR DESCRIPTION
Add DMA support in the RTIO implementation of STM32 I2C v2 driver.
The implementation is based on **i2c_stm32_v2.c** DMA implementation, ported to **i2c_stm32_v2_rtio.c**.

Since devices instantiation in the RTIO and non-RTIO STM32 I2C drivers are the same, factorize them in common source file **i2c_stm32_common.c**.