### PR TITLE
Fix DMA support in STM32 I2C driver and Add a DMA testcase in i2c_target_api

### DIFF
--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -60,10 +60,10 @@ config I2C_STM32_V2_TIMING
 
 config I2C_STM32_V2_DMA
 	bool "DMA support"
+	default y if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_I2C_V2),dmas)
 	depends on I2C_STM32_V2
 	select DMA
 	select CACHE_MANAGEMENT if DCACHE
-	select EXPERIMENTAL
 	help
 	  Enable DMA support for the STM32 I2C driver.
 

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -132,6 +132,7 @@ struct i2c_stm32_data {
 	struct dma_config dma_tx_cfg;
 	struct dma_config dma_rx_cfg;
 	struct dma_block_config dma_blk_cfg;
+	bool use_dma;
 #ifdef CONFIG_I2C_RTIO
 	uint8_t *dma_buf;	/* Base address of the Rx buffer fed by DMA */
 	size_t dma_len;		/* Byte size of the Rx buffer fed by DMA */
@@ -151,6 +152,12 @@ struct i2c_stm32_data {
 extern const struct i2c_driver_api i2c_stm32_driver_api;
 
 int i2c_stm32_init(const struct device *dev);
+
+#ifdef CONFIG_I2C_STM32_V2_DMA
+/* Return true if transfer shall use DMA. If so, also flush buffer on I2C write message */
+bool i2c_stm32_xfer_will_use_dma(const struct i2c_stm32_config *cfg, void *buf, size_t len,
+				 bool tx);
+#endif /* CONFIG_I2C_STM32_V2_DMA */
 
 #ifdef CONFIG_I2C_RTIO
 int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, size_t buf_len,

--- a/drivers/i2c/i2c_stm32_common.c
+++ b/drivers/i2c/i2c_stm32_common.c
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/cache.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/dma.h>
@@ -15,6 +16,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/pm/policy.h>
+#include <stm32_cache.h>
 
 #ifdef CONFIG_I2C_STM32_BUS_RECOVERY
 #include "i2c_bitbang.h"
@@ -32,6 +34,41 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_common);
 #endif
 
 #include "i2c_stm32.h"
+
+#ifdef CONFIG_I2C_STM32_V2_DMA
+bool i2c_stm32_xfer_will_use_dma(const struct i2c_stm32_config *cfg, void *buf, size_t len, bool tx)
+{
+	uintptr_t dest_addr = (uintptr_t)buf;
+
+	if (tx) {
+		if (cfg->tx_dma.dev_dma == NULL) {
+			return false;
+		}
+
+		if (stm32_buf_in_nocache(dest_addr, len)) {
+			return true;
+		}
+
+		return sys_cache_data_flush_range(buf, len) == 0;
+	}
+
+	if (cfg->rx_dma.dev_dma == NULL) {
+		return false;
+	}
+
+	if (stm32_buf_in_nocache(dest_addr, len)) {
+		return true;
+	}
+
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	if (((dest_addr | len) % CONFIG_DCACHE_LINE_SIZE) == 0) {
+		return true;
+	}
+#endif /* CONFIG_CACHE_MANAGEMENT && CONFIG_DCACHE */
+
+	return false;
+}
+#endif /* CONFIG_I2C_STM32_V2_DMA */
 
 #ifdef CONFIG_I2C_STM32_COMBINED_INTERRUPT
 void i2c_stm32_combined_isr(void *arg)
@@ -314,10 +351,6 @@ void i2c_stm32_dma_rx_cb(const struct device *dma_dev __unused, void *user_data 
 
 #define I2C_STM32_INIT(index)									\
 	I2C_STM32_IRQ_HANDLER_DECL(index);							\
-												\
-	BUILD_ASSERT(!IS_ENABLED(CONFIG_I2C_STM32_V2_DMA) ||					\
-		     (DT_INST_DMAS_HAS_NAME(index, tx) == DT_INST_DMAS_HAS_NAME(index, rx)),	\
-		     "STM32 I2C requires either none or both of rx and tx DMAs are used");	\
 												\
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2), (				\
 	static const uint32_t i2c_timings_##index[] = DT_INST_PROP_OR(index, timings, {});	\

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -154,6 +154,13 @@ static inline int wait_bus_idle(const struct device *dev, uint32_t timeout_us)
 #endif /* CONFIG_I2C_TARGET */
 
 #ifdef CONFIG_I2C_STM32_V2_DMA
+static bool using_dma(const struct device *dev)
+{
+	const struct i2c_stm32_config *cfg = dev->config;
+
+	return (cfg->rx_dma.dev_dma != NULL) && (cfg->tx_dma.dev_dma != NULL);
+}
+
 static int configure_dma(struct stream const *dma, struct dma_config *dma_cfg,
 			 struct dma_block_config *blk_cfg)
 {
@@ -238,7 +245,11 @@ static void dma_finish(const struct device *dev, struct i2c_msg *msg)
 		LL_I2C_DisableDMAReq_TX(cfg->i2c);
 	}
 }
-
+#else /* CONFIG_I2C_STM32_V2_DMA */
+static bool using_dma(const struct device *dev __unused)
+{
+	return false;
+}
 #endif /* CONFIG_I2C_STM32_V2_DMA */
 
 #ifdef CONFIG_I2C_STM32_INTERRUPT
@@ -376,8 +387,10 @@ static void i2c_stm32_controller_abort_to_target(const struct device *dev, bool 
 
 	i2c_stm32_disable_transfer_interrupts(dev);
 #ifdef CONFIG_I2C_STM32_V2_DMA
-	LL_I2C_DisableDMAReq_RX(cfg->i2c);
-	LL_I2C_DisableDMAReq_TX(cfg->i2c);
+	if (using_dma(dev)) {
+		LL_I2C_DisableDMAReq_RX(cfg->i2c);
+		LL_I2C_DisableDMAReq_TX(cfg->i2c);
+	}
 #endif
 	LL_I2C_ClearFlag_TXE(cfg->i2c);
 	data->controller_active = false;
@@ -661,11 +674,13 @@ void i2c_stm32_event(const struct device *dev)
 		 */
 		uint32_t cr2 = stm32_reg_read(&regs->CR2);
 #ifdef CONFIG_I2C_STM32_V2_DMA
-		/* Get number of bytes bytes transferred by DMA */
-		uint32_t xfer_len = (cr2 & I2C_CR2_NBYTES_Msk) >> I2C_CR2_NBYTES_Pos;
+		if (using_dma(dev)) {
+			/* Get number of bytes bytes transferred by DMA */
+			uint32_t xfer_len = (cr2 & I2C_CR2_NBYTES_Msk) >> I2C_CR2_NBYTES_Pos;
 
-		data->current.len -= xfer_len;
-		data->current.buf += xfer_len;
+			data->current.len -= xfer_len;
+			data->current.buf += xfer_len;
+		}
 #endif
 
 		if (data->current.len == 0U) {
@@ -818,8 +833,10 @@ static int stm32_i2c_irq_msg_finish(const struct device *dev, struct i2c_msg *ms
 	ret = k_sem_take(&data->device_sync_sem, cfg->transfer_timeout);
 
 #ifdef CONFIG_I2C_STM32_V2_DMA
-	/* Stop DMA and invalidate cache if needed */
-	dma_finish(dev, msg);
+	if (using_dma(dev)) {
+		/* Stop DMA and invalidate cache if needed */
+		dma_finish(dev, msg);
+	}
 #endif
 
 	/* Check for transfer errors or timeout */
@@ -903,7 +920,7 @@ static int i2c_stm32_irq_prepare_start(const struct device *dev, struct i2c_msg 
 		/* Prepare first byte in TX buffer before transfer start as a
 		 * workaround for errata: "Transmission stalled after first byte transfer"
 		 */
-		if (data->current.len > 0U) {
+		if (using_dma(dev) && data->current.len > 0U) {
 			LL_I2C_TransmitData8(regs, *data->current.buf);
 			data->current.len--;
 			data->current.buf++;
@@ -968,7 +985,7 @@ static int stm32_i2c_irq_xfer(const struct device *dev, struct i2c_msg *msg,
 	data->current.msg = msg;
 
 #if defined(CONFIG_I2C_STM32_V2_DMA)
-	if (!stm32_buf_in_nocache((uintptr_t)msg->buf, msg->len) &&
+	if (using_dma(dev) && !stm32_buf_in_nocache((uintptr_t)msg->buf, msg->len) &&
 	    ((msg->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE)) {
 		sys_cache_data_flush_range(msg->buf, msg->len);
 	}
@@ -1029,15 +1046,17 @@ static int stm32_i2c_irq_xfer(const struct device *dev, struct i2c_msg *msg,
 	/* Set common interrupt enable bits */
 	uint32_t cr1 = I2C_CR1_ERRIE | I2C_CR1_STOPIE | I2C_CR1_TCIE | I2C_CR1_NACKIE;
 
+	if (using_dma(dev)) {
 #ifdef CONFIG_I2C_STM32_V2_DMA
-	ret = i2c_stm32_irq_start_dma(dev, msg, regs);
-	if (ret != 0) {
-		return ret;
-	}
-#else
-	/* If not using DMA, also enable RX and TX empty interrupts */
-	cr1 |= I2C_CR1_TXIE | I2C_CR1_RXIE;
+		ret = i2c_stm32_irq_start_dma(dev, msg, regs);
+		if (ret != 0) {
+			return ret;
+		}
 #endif /* CONFIG_I2C_STM32_V2_DMA */
+	} else {
+		/* If not using DMA, also enable RX and TX empty interrupts */
+		cr1 |= I2C_CR1_TXIE | I2C_CR1_RXIE;
+	}
 
 #if defined(CONFIG_I2C_TARGET)
 	if (starting_controller_session) {

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -153,14 +153,16 @@ static inline int wait_bus_idle(const struct device *dev, uint32_t timeout_us)
 }
 #endif /* CONFIG_I2C_TARGET */
 
-#ifdef CONFIG_I2C_STM32_V2_DMA
-static bool using_dma(const struct device *dev)
+__maybe_unused static bool using_dma(struct i2c_stm32_data *dev_data __maybe_unused)
 {
-	const struct i2c_stm32_config *cfg = dev->config;
-
-	return (cfg->rx_dma.dev_dma != NULL) && (cfg->tx_dma.dev_dma != NULL);
+#ifdef CONFIG_I2C_STM32_V2_DMA
+	return dev_data->use_dma;
+#else
+	return false;
+#endif /* CONFIG_I2C_STM32_V2_DMA */
 }
 
+#ifdef CONFIG_I2C_STM32_V2_DMA
 static int configure_dma(struct stream const *dma, struct dma_config *dma_cfg,
 			 struct dma_block_config *blk_cfg)
 {
@@ -244,11 +246,6 @@ static void dma_finish(const struct device *dev, struct i2c_msg *msg)
 		dma_stop(cfg->tx_dma.dev_dma, cfg->tx_dma.dma_channel);
 		LL_I2C_DisableDMAReq_TX(cfg->i2c);
 	}
-}
-#else /* CONFIG_I2C_STM32_V2_DMA */
-static bool using_dma(const struct device *dev __unused)
-{
-	return false;
 }
 #endif /* CONFIG_I2C_STM32_V2_DMA */
 
@@ -387,7 +384,7 @@ static void i2c_stm32_controller_abort_to_target(const struct device *dev, bool 
 
 	i2c_stm32_disable_transfer_interrupts(dev);
 #ifdef CONFIG_I2C_STM32_V2_DMA
-	if (using_dma(dev)) {
+	if (using_dma(data)) {
 		LL_I2C_DisableDMAReq_RX(cfg->i2c);
 		LL_I2C_DisableDMAReq_TX(cfg->i2c);
 	}
@@ -673,15 +670,14 @@ void i2c_stm32_event(const struct device *dev)
 		 * in same direction (No RESTART or STOP)
 		 */
 		uint32_t cr2 = stm32_reg_read(&regs->CR2);
-#ifdef CONFIG_I2C_STM32_V2_DMA
-		if (using_dma(dev)) {
+
+		if (using_dma(data)) {
 			/* Get number of bytes bytes transferred by DMA */
 			uint32_t xfer_len = (cr2 & I2C_CR2_NBYTES_Msk) >> I2C_CR2_NBYTES_Pos;
 
 			data->current.len -= xfer_len;
 			data->current.buf += xfer_len;
 		}
-#endif
 
 		if (data->current.len == 0U) {
 			/* In this state all data from current message is transferred
@@ -833,7 +829,7 @@ static int stm32_i2c_irq_msg_finish(const struct device *dev, struct i2c_msg *ms
 	ret = k_sem_take(&data->device_sync_sem, cfg->transfer_timeout);
 
 #ifdef CONFIG_I2C_STM32_V2_DMA
-	if (using_dma(dev)) {
+	if (using_dma(data)) {
 		/* Stop DMA and invalidate cache if needed */
 		dma_finish(dev, msg);
 	}
@@ -916,16 +912,15 @@ static int i2c_stm32_irq_prepare_start(const struct device *dev, struct i2c_msg 
 
 	if ((msg->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
 		*cr2 &= ~I2C_CR2_RD_WRN;
-#ifndef CONFIG_I2C_STM32_V2_DMA
-		/* Prepare first byte in TX buffer before transfer start as a
+
+		/* If using DMA, prepare first byte in TX buffer before transfer start as a
 		 * workaround for errata: "Transmission stalled after first byte transfer"
 		 */
-		if (using_dma(dev) && data->current.len > 0U) {
+		if (using_dma(data) && data->current.len > 0U) {
 			LL_I2C_TransmitData8(regs, *data->current.buf);
 			data->current.len--;
 			data->current.buf++;
 		}
-#endif
 	} else {
 		*cr2 |= I2C_CR2_RD_WRN;
 	}
@@ -985,10 +980,10 @@ static int stm32_i2c_irq_xfer(const struct device *dev, struct i2c_msg *msg,
 	data->current.msg = msg;
 
 #if defined(CONFIG_I2C_STM32_V2_DMA)
-	if (using_dma(dev) && !stm32_buf_in_nocache((uintptr_t)msg->buf, msg->len) &&
-	    ((msg->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE)) {
-		sys_cache_data_flush_range(msg->buf, msg->len);
-	}
+	/* i2c_stm32_xfer_will_use_dma() flushes cache on write message if needed */
+	data->use_dma = i2c_stm32_xfer_will_use_dma(cfg, msg->buf, msg->len,
+						    (msg->flags & I2C_MSG_RW_MASK) ==
+						    I2C_MSG_WRITE);
 #endif /* CONFIG_I2C_STM32_V2_DMA */
 
 	/* Flush TX register */
@@ -1046,7 +1041,7 @@ static int stm32_i2c_irq_xfer(const struct device *dev, struct i2c_msg *msg,
 	/* Set common interrupt enable bits */
 	uint32_t cr1 = I2C_CR1_ERRIE | I2C_CR1_STOPIE | I2C_CR1_TCIE | I2C_CR1_NACKIE;
 
-	if (using_dma(dev)) {
+	if (using_dma(data)) {
 #ifdef CONFIG_I2C_STM32_V2_DMA
 		ret = i2c_stm32_irq_start_dma(dev, msg, regs);
 		if (ret != 0) {

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -38,11 +38,9 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_v2_rtio);
 #endif /* CONFIG_STM32_HAL2 */
 
 #ifdef CONFIG_I2C_STM32_V2_DMA
-static bool using_dma(const struct device *dev)
+static bool using_dma(struct i2c_stm32_data *dev_data)
 {
-	const struct i2c_stm32_config *cfg = dev->config;
-
-	return (cfg->rx_dma.dev_dma != NULL) && (cfg->tx_dma.dev_dma != NULL);
+	return dev_data->use_dma;
 }
 
 static int configure_start_dma(struct stream const *dma, struct dma_config *dma_cfg,
@@ -98,10 +96,6 @@ static int dma_xfer_start(const struct device *dev)
 
 		LL_I2C_EnableDMAReq_RX(i2c);
 	} else {
-		if (!stm32_buf_in_nocache((uintptr_t)data->xfer_buf, data->xfer_len)) {
-			sys_cache_data_flush_range(data->xfer_buf, data->xfer_len);
-		}
-
 		data->dma_blk_cfg.source_address = (uint32_t)data->xfer_buf;
 		data->dma_blk_cfg.source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
 		data->dma_blk_cfg.dest_address = LL_I2C_DMA_GetRegAddr(
@@ -139,7 +133,7 @@ static void dma_finish(const struct device *dev)
 	}
 }
 #else /* CONFIG_I2C_STM32_V2_DMA */
-static bool using_dma(const struct device *dev __unused)
+static bool using_dma(struct i2c_stm32_data *data __unused)
 {
 	return false;
 }
@@ -179,9 +173,10 @@ static void i2c_stm32_enable_transfer_interrupts(const struct device *dev)
 static void i2c_stm32_controller_mode_end(const struct device *dev)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
-	if (using_dma(dev)) {
+	if (using_dma(data)) {
 		dma_finish(dev);
 	}
 
@@ -192,8 +187,6 @@ static void i2c_stm32_controller_mode_end(const struct device *dev)
 	}
 
 #if defined(CONFIG_I2C_TARGET)
-	struct i2c_stm32_data *data = dev->data;
-
 	data->controller_active = false;
 	if (!data->target_attached) {
 		LL_I2C_Disable(i2c);
@@ -498,10 +491,7 @@ void i2c_stm32_event(const struct device *dev)
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
-	bool use_dma;
 	int ret = 0;
-
-	use_dma = using_dma(dev);
 
 #if defined(CONFIG_I2C_TARGET)
 	if (data->target_attached && !data->controller_active) {
@@ -511,7 +501,7 @@ void i2c_stm32_event(const struct device *dev)
 #endif
 
 	if (data->burst_len != 0U) {
-		if (use_dma) {
+		if (using_dma(data)) {
 			goto skip_bytewise_xfer;
 		}
 
@@ -554,7 +544,7 @@ skip_bytewise_xfer:
 
 	if (LL_I2C_IsActiveFlag_TC(i2c) ||
 	    LL_I2C_IsActiveFlag_TCR(i2c)) {
-		if (use_dma && (data->burst_len != 0U)) {
+		if (using_dma(data) && (data->burst_len != 0U)) {
 			data->xfer_len -= data->burst_len;
 			data->xfer_buf += data->burst_len;
 			data->burst_len = 0U;
@@ -571,7 +561,7 @@ skip_bytewise_xfer:
 		if ((data->burst_flags & I2C_MSG_STOP) != 0) {
 			LL_I2C_GenerateStopCondition(i2c);
 		} else {
-			if (use_dma) {
+			if (using_dma(data)) {
 				dma_finish(dev);
 			}
 
@@ -649,9 +639,12 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, s
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	uint32_t transfer;
-	bool use_dma;
 
-	use_dma = using_dma(dev);
+#if defined(CONFIG_I2C_STM32_V2_DMA)
+	/* i2c_stm32_xfer_will_use_dma() flushes cache on write message if needed */
+	data->use_dma = i2c_stm32_xfer_will_use_dma(cfg, buf, buf_len,
+						    (flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE);
+#endif /* CONFIG_I2C_STM32_V2_DMA */
 
 	data->xfer_buf = buf;
 	data->xfer_len = buf_len;
@@ -706,14 +699,14 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, s
 	LL_I2C_GenerateStartCondition(i2c);
 
 out:
-	if (use_dma && dma_xfer_start(dev) != 0) {
+	if (using_dma(data) && dma_xfer_start(dev) != 0) {
 		i2c_stm32_controller_mode_end(dev);
 		return -EIO;
 	}
 
 	i2c_stm32_enable_transfer_interrupts(dev);
 
-	if (!use_dma) {
+	if (!using_dma(data)) {
 		if ((flags & I2C_MSG_READ) != 0) {
 			LL_I2C_EnableIT_RX(i2c);
 		} else {

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -639,6 +639,7 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, s
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	uint32_t transfer;
+	bool generate_start = true;
 
 #if defined(CONFIG_I2C_STM32_V2_DMA)
 	/* i2c_stm32_xfer_will_use_dma() flushes cache on write message if needed */
@@ -653,6 +654,7 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, s
 	if (LL_I2C_IsEnabledReloadMode(i2c)) {
 		__ASSERT_NO_MSG((flags & I2C_MSG_RESTART) == 0U);
 		i2c_stm32_reload_burst(dev);
+		generate_start = false;
 		goto out;
 	}
 
@@ -696,8 +698,6 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf, s
 
 	LL_I2C_Enable(i2c);
 
-	LL_I2C_GenerateStartCondition(i2c);
-
 out:
 	if (using_dma(data) && dma_xfer_start(dev) != 0) {
 		i2c_stm32_controller_mode_end(dev);
@@ -712,6 +712,10 @@ out:
 		} else {
 			LL_I2C_EnableIT_TX(i2c);
 		}
+	}
+
+	if (generate_start) {
+		LL_I2C_GenerateStartCondition(i2c);
 	}
 
 	return 0;

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -500,27 +500,22 @@ void i2c_stm32_event(const struct device *dev)
 	}
 #endif
 
-	if (data->burst_len != 0U) {
-		if (using_dma(data)) {
-			goto skip_bytewise_xfer;
-		}
-
-		/* Send next byte */
+	if (!using_dma(data) && (data->burst_len != 0U)) {
 		if (LL_I2C_IsActiveFlag_TXIS(i2c)) {
+			/* Send next byte */
 			LL_I2C_TransmitData8(i2c, *data->xfer_buf);
-		}
-
-		/* Receive next byte */
-		if (LL_I2C_IsActiveFlag_RXNE(i2c)) {
+			data->xfer_buf++;
+			data->xfer_len--;
+			data->burst_len--;
+		} else if (LL_I2C_IsActiveFlag_RXNE(i2c)) {
+			/* Receive next byte */
 			*data->xfer_buf = LL_I2C_ReceiveData8(i2c);
+			data->xfer_buf++;
+			data->xfer_len--;
+			data->burst_len--;
 		}
-
-		data->xfer_buf++;
-		data->xfer_len--;
-		data->burst_len--;
 	}
 
-skip_bytewise_xfer:
 	/* NACK received */
 	if (LL_I2C_IsActiveFlag_NACK(i2c)) {
 		LL_I2C_ClearFlag_NACK(i2c);
@@ -542,8 +537,8 @@ skip_bytewise_xfer:
 		return;
 	}
 
-	if (LL_I2C_IsActiveFlag_TC(i2c) ||
-	    LL_I2C_IsActiveFlag_TCR(i2c)) {
+	if (LL_I2C_IsEnabledIT_TC(i2c) &&
+	    (LL_I2C_IsActiveFlag_TC(i2c) || LL_I2C_IsActiveFlag_TCR(i2c))) {
 		if (using_dma(data) && (data->burst_len != 0U)) {
 			data->xfer_len -= data->burst_len;
 			data->xfer_buf += data->burst_len;

--- a/tests/drivers/i2c/i2c_target_api/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/b_u585i_iot02a.overlay
@@ -12,7 +12,13 @@
 
 /delete-node/ &eeprom0;
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&gpdma1 0 13 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&gpdma1 1 12 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -20,7 +26,13 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&gpdma1 2 16 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&gpdma1 3 15 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/disco_l475_iot1.overlay
@@ -14,7 +14,13 @@
  * Short Pin PB9 to PC1, and PB8 to PC0, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dma1 6 3 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_0_DMA_RX <&dma1 7 3 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -22,7 +28,13 @@
 	};
 };
 
-&i2c3 {
+#define IC2_TEST_1_DMA_TX <&dma1 2 3 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_1_DMA_RX <&dma1 3 3 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_1: &i2c3 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_c071rb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_c071rb.overlay
@@ -13,7 +13,13 @@
  * Short Pin PB9 to PA6, and PB8 to PA7, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dmamux1 1 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_0_DMA_RX <&dmamux1 2 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -21,11 +27,16 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&dmamux1 3 13 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_1_DMA_RX <&dmamux1 4 12 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_1: &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa7 &i2c2_sda_pa6>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_c5a3zg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_c5a3zg.overlay
@@ -13,7 +13,13 @@
  * Short Pin PB7 to PB4, and PB6 to PB10, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&lpdma1 0 11 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&lpdma1 1 10 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -21,7 +27,13 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&lpdma1 2 65 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&lpdma1 3 64 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
@@ -10,7 +10,13 @@
  * Short Pin PB9 to PA12, and PB8 to PA11, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dma1 2 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_0_DMA_RX <&dma1 3 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -18,7 +24,12 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&dma1 4 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_1_DMA_RX <&dma1 5 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
 	/* i2c2 is disabled by default because of pin conflict with can1 */
 	status = "okay";
 
@@ -32,4 +43,8 @@
 &can1 {
 	/* can1 shares the pins with i2c2 and must be disabled */
 	status = "disabled";
+};
+
+&dma1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f746zg.overlay
@@ -13,7 +13,13 @@
  * Short Pin PB9 to PB11, and PB8 to PB10, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dma1 6 1 STM32_DMA_PERIPH_TX STM32_DMA_FIFO_FULL>
+#define IC2_TEST_0_DMA_RX <&dma1 5 1 STM32_DMA_PERIPH_RX STM32_DMA_FIFO_FULL>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -21,10 +27,20 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&dma1 7 7 STM32_DMA_PERIPH_TX STM32_DMA_FIFO_FULL>
+#define IC2_TEST_1_DMA_RX <&dma1 3 7 STM32_DMA_PERIPH_RX STM32_DMA_FIFO_FULL>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&dma1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.overlay
@@ -13,7 +13,13 @@
  * Short Pin PB9 to PA12, and PB8 to PA11, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dmamux1 2 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_0_DMA_RX <&dmamux1 1 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -21,10 +27,24 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&dmamux1 4 13 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_1_DMA_RX <&dmamux1 3 12 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.overlay
@@ -10,7 +10,13 @@
  * Short Pin PB9 to PC9, and PB8 to PC8, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dmamux1 2 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_0_DMA_RX <&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -18,11 +24,16 @@
 	};
 };
 
-&i2c3 {
+#define IC2_TEST_1_DMA_TX <&dmamux1 4 21 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_1_DMA_RX <&dmamux1 3 20 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_1: &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pc8 &i2c3_sda_pc9>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
 	status = "okay";
 
 	eeprom1: eeprom@56 {
@@ -30,4 +41,16 @@
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_h503rb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_h503rb.overlay
@@ -13,11 +13,16 @@
  * Short Pin PB7 to PB4, and PB6 to PB5, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&gpdma1 0 13 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&gpdma1 1 12 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -29,11 +34,16 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&gpdma1 2 16 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&gpdma1 3 15 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb5 &i2c2_sda_pb4>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 
@@ -43,4 +53,8 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+};
+
+&gpdma1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.overlay
@@ -13,11 +13,16 @@
  * Short Pin PB9 to PB11, and PB8 to PB10, for the test to pass.
  */
 
-&i2c2 {
+#define IC2_TEST_0_DMA_TX <&gpdma1 2 16 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&gpdma1 3 15 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiof 0 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
 	status = "okay";
 
 	eeprom0: eeprom@54 {
@@ -28,11 +33,16 @@
 	};
 };
 
-&i2c1 {
+#define IC2_TEST_1_DMA_TX <&gpdma1 0 13 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&gpdma1 1 12 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
 	status = "okay";
 
 	eeprom1: eeprom@56 {
@@ -41,4 +51,8 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+};
+
+&gpdma1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_h753zi.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_h753zi.overlay
@@ -15,7 +15,13 @@
  * Short Pin PB9 to PB11, and PB8 to PB10, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dmamux1 2 34 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_0_DMA_RX <&dmamux1 1 33 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -23,10 +29,28 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&dmamux1 4 36 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_1_DMA_RX <&dmamux1 3 35 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l073rz.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l073rz.overlay
@@ -10,7 +10,13 @@
  * Short Pin PB9 to PB11, and PB8 to PB10, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dma1 6 6 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&dma1 7 6 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -18,10 +24,20 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&dma1 4 7 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&dma1 5 7 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&dma1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.overlay
@@ -13,7 +13,13 @@
  * Short D14 to A4, and D15 to A5, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dma1 6 3 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_0_DMA_RX <&dma1 7 3 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -22,11 +28,21 @@
 	};
 };
 
-&i2c3 {
+#define IC2_TEST_1_DMA_TX <&dma1 2 3 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_1_DMA_RX <&dma1 3 3 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_1: &i2c3 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		address-width = <16>;
 		size = <1024>;
 	};
+};
+
+&dma1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_n657x0_q_stm32n657xx_sb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_n657x0_q_stm32n657xx_sb.overlay
@@ -13,7 +13,13 @@
  * Short Pin PC1 to PE14, and PH9 to PE13, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&gpdma1 0 96 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&gpdma1 1 95 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -21,10 +27,20 @@
 	};
 };
 
-&i2c4 {
+#define IC2_TEST_1_DMA_TX <&gpdma1 2 102 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&gpdma1 3 101 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c4 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&gpdma1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_u083rc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_u083rc.overlay
@@ -13,7 +13,13 @@
  * Short Pin PB9 to PA6, and PB8 to PA7, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dmamux1 0 10 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&dmamux1 1 9 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -21,11 +27,16 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&dmamux1 2 12 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&dmamux1 3 11 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa7 &i2c2_sda_pa6>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -34,4 +45,8 @@
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&dma2 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_u385rg_q.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_u385rg_q.overlay
@@ -13,11 +13,16 @@
  * Short Pin PB14 to PC1, and PB13 to PA7, for the test to pass.
  */
 
-&i2c3 {
+#define IC2_TEST_0_DMA_TX <&gpdma1 0 19 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&gpdma1 1 18 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa7 &i2c3_sda_pc1>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpioc 1 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
 	status = "okay";
 
 	eeprom0: eeprom@54 {
@@ -27,7 +32,13 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&gpdma1 0 16 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&gpdma1 1 15 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
@@ -37,4 +48,8 @@
 
 &spi1 {
 	status = "disabled";
+};
+
+&gpdma1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.overlay
@@ -10,7 +10,13 @@
  * Short Pin PB9 to PA7, and PB8 to PB14, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_0_DMA_RX <&dmamux1 1 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -18,11 +24,16 @@
 	};
 };
 
-&i2c3 {
+#define IC2_TEST_1_DMA_TX <&dmamux1 2 13 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_1_DMA_RX <&dmamux1 3 12 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_1: &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa7 &i2c3_sda_pb14>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -31,4 +42,16 @@
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wba55cg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wba55cg.overlay
@@ -13,7 +13,13 @@
  * Short Pin PB1 to PA7, and PB2 to PA6, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&gpdma1 0 6 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&gpdma1 1 5 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -21,11 +27,16 @@
 	};
 };
 
-&i2c3 {
+#define IC2_TEST_1_DMA_TX <&gpdma1 2 9 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&gpdma1 3 8 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa6 &i2c3_sda_pa7>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -34,4 +45,8 @@
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&gpdma1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.overlay
@@ -10,7 +10,13 @@
  * Short Pin PA11 to PB14, and PA12 to PB13, for the test to pass.
  */
 
-&i2c2 {
+#define IC2_TEST_0_DMA_TX <&dmamux1 0 14 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_0_DMA_RX <&dmamux1 1 13 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_0: &i2c2 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
@@ -18,11 +24,16 @@
 	};
 };
 
-&i2c3 {
+#define IC2_TEST_1_DMA_TX <&dmamux1 2 16 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_1_DMA_RX <&dmamux1 3 15 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_1: &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pb13 &i2c3_sda_pb14>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -31,4 +42,16 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
@@ -1,6 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dma1 2 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_0_DMA_RX <&dma1 3 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -8,10 +14,20 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&dma1 4 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
+#define IC2_TEST_1_DMA_RX <&dma1 5 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&dma1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.overlay
@@ -10,7 +10,13 @@
  * Short Pin PB7 to PA10, and PB6 to PA9, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dma1 6 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&dma1 7 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -18,7 +24,13 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&dma1 4 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&dma1 5 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32h573i_dk.overlay
@@ -13,7 +13,13 @@
  * Short Pin PB7 to PB11, and PB6 to PB10, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&gpdma1 2 13 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&gpdma1 3 12 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -21,7 +27,13 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&gpdma1 0 16 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&gpdma1 1 15 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32l562e_dk.overlay
@@ -13,7 +13,13 @@
  * Short Pin PB7 to PB11, and PB6 to PB13, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dmamux1 0 18 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&dmamux1 1 17 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -21,11 +27,16 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&dmamux1 2 20 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&dmamux1 3 19 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb13 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
 	scl-gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
 	status = "okay";
 
 	eeprom1: eeprom@56 {
@@ -33,4 +44,16 @@
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -13,7 +13,13 @@
  * Short Pin PC1 to PE14, and PH9 to PE13, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&gpdma1 0 96 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&gpdma1 1 95 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -21,10 +27,20 @@
 	};
 };
 
-&i2c4 {
+#define IC2_TEST_1_DMA_TX <&gpdma1 2 102 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&gpdma1 3 101 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c4 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&gpdma1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32u083c_dk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32u083c_dk.overlay
@@ -13,10 +13,15 @@
  * Short Pin PA10 to PA6, and PA9 to PA7, for the test to pass.
  */
 
-&i2c1 {
+#define IC2_TEST_0_DMA_TX <&dmamux1 0 10 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_0_DMA_RX <&dmamux1 1 9 STM32_DMA_PERIPH_RX>
+
+i2c_test_0: &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pa9 &i2c1_sda_pa10>;
 	scl-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
+	dmas = IC2_TEST_0_DMA_TX, IC2_TEST_0_DMA_RX;
+	dma-names = "tx", "rx";
 
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
@@ -25,10 +30,28 @@
 	};
 };
 
-&i2c2 {
+#define IC2_TEST_1_DMA_TX <&dmamux1 2 12 STM32_DMA_PERIPH_TX>
+#define IC2_TEST_1_DMA_RX <&dmamux1 3 11 STM32_DMA_PERIPH_RX>
+
+i2c_test_1: &i2c2 {
+	dmas = IC2_TEST_1_DMA_TX, IC2_TEST_1_DMA_RX;
+	dma-names = "tx", "rx";
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/stm32_no_dma.overlay
+++ b/tests/drivers/i2c/i2c_target_api/stm32_no_dma.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Disable use of DMAs on both I2C interfaces */
+
+&i2c_test_0 {
+	/delete-property/ dmas;
+	/delete-property/ dma-names;
+};
+
+&i2c_test_1 {
+	/delete-property/ dmas;
+	/delete-property/ dma-names;
+};

--- a/tests/drivers/i2c/i2c_target_api/stm32_one_dir_dma.overlay
+++ b/tests/drivers/i2c/i2c_target_api/stm32_one_dir_dma.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Use DMA only in 1 direction */
+
+&i2c_test_0 {
+	dmas = IC2_TEST_0_DMA_RX;
+	dma-names = "rx";
+};
+
+&i2c_test_1 {
+	dmas = IC2_TEST_1_DMA_TX;
+	dma-names = "tx";
+};

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -193,3 +193,73 @@ tests:
       - CONFIG_APP_DUAL_ROLE_I2C=y
       - CONFIG_DCACHE=y
     extra_args: EXTRA_DTC_OVERLAY_FILE="stm32_no_dma.overlay"
+  drivers.i2c.target_api.stm32.rtio.one_dir_dma:
+    filter: CONFIG_DT_HAS_ST_STM32_I2C_V2_ENABLED
+    integration_platforms:
+      - nucleo_h753zi
+    platform_allow:
+      - b_u585i_iot02a
+      - disco_l475_iot1
+      - nucleo_c071rb
+      - nucleo_c5a3zg
+      - nucleo_f091rc
+      - nucleo_f746zg
+      - nucleo_g071rb
+      - nucleo_g474re
+      - nucleo_h503rb
+      - nucleo_h563zi
+      - nucleo_h753zi
+      - nucleo_l073rz
+      - nucleo_l476rg
+      - nucleo_n657x0_q/stm32n657xx/sb
+      - nucleo_u083rc
+      - nucleo_u385rg_q
+      - nucleo_wb55rg
+      - nucleo_wba55cg
+      - nucleo_wl55jc
+      - stm32f072b_disco
+      - stm32f3_disco
+      - stm32h573i_dk
+      - stm32l562e_dk
+      - stm32n6570_dk/stm32n657xx/sb
+      - stm32u083c_dk
+    extra_configs:
+      - CONFIG_APP_DUAL_ROLE_I2C=y
+      - CONFIG_DCACHE=y
+      - CONFIG_I2C_RTIO=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="stm32_one_dir_dma.overlay"
+  drivers.i2c.target_api.stm32.rtio.no_dma:
+    filter: CONFIG_DT_HAS_ST_STM32_I2C_V2_ENABLED
+    integration_platforms:
+      - nucleo_f091rc
+    platform_allow:
+      - b_u585i_iot02a
+      - disco_l475_iot1
+      - nucleo_c071rb
+      - nucleo_c5a3zg
+      - nucleo_f091rc
+      - nucleo_f746zg
+      - nucleo_g071rb
+      - nucleo_g474re
+      - nucleo_h503rb
+      - nucleo_h563zi
+      - nucleo_h753zi
+      - nucleo_l073rz
+      - nucleo_l476rg
+      - nucleo_n657x0_q/stm32n657xx/sb
+      - nucleo_u083rc
+      - nucleo_u385rg_q
+      - nucleo_wb55rg
+      - nucleo_wba55cg
+      - nucleo_wl55jc
+      - stm32f072b_disco
+      - stm32f3_disco
+      - stm32h573i_dk
+      - stm32l562e_dk
+      - stm32n6570_dk/stm32n657xx/sb
+      - stm32u083c_dk
+    extra_configs:
+      - CONFIG_APP_DUAL_ROLE_I2C=y
+      - CONFIG_DCACHE=y
+      - CONFIG_I2C_RTIO=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="stm32_no_dma.overlay"

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -14,40 +14,50 @@ tests:
       - disco_l475_iot1
       - esp32h2_devkitm
       - esp32s3_devkitc/esp32s3/procpu
-      - nucleo_f746zg
-      - nucleo_g474re
-      - nucleo_f091rc
-      - stm32f072b_disco
-      - stm32f3_disco
-      - stm32h573i_dk
-      - stm32l562e_dk
-      - stm32n6570_dk/stm32n657xx/sb
-      - stm32u083c_dk
+      - mr_canhubk3
       - nucleo_c071rb
       - nucleo_c5a3zg
-      - nucleo_g071rb
+      - nucleo_f091rc
       - nucleo_f207zg
       - nucleo_f401re
       - nucleo_f429zi
+      - nucleo_f746zg
+      - nucleo_g071rb
+      - nucleo_g474re
       - nucleo_h503rb
       - nucleo_h753zi
       - nucleo_l073rz
       - nucleo_l152re
       - nucleo_u083rc
       - nucleo_u385rg_q
-      - nucleo_wba55cg
       - nucleo_wb55rg
+      - nucleo_wba55cg
       - nucleo_wl55jc
       - rpi_pico
       - sltb010a@0
-      - mr_canhubk3
+      - stm32f072b_disco
+      - stm32f3_disco
+      - stm32h573i_dk
+      - stm32l562e_dk
+      - stm32n6570_dk/stm32n657xx/sb
+      - stm32u083c_dk
     integration_platforms:
       - nucleo_f091rc
     extra_configs:
       - CONFIG_APP_DUAL_ROLE_I2C=y
   drivers.i2c.target_api.single_role:
     platform_allow:
+      - frdm_ke17z512
+      - frdm_mcxa156
+      - frdm_mcxa266
+      - frdm_mcxa344
+      - frdm_mcxa346
+      - frdm_mcxa366
+      - frdm_mcxa577
+      - frdm_mcxc242
+      - frdm_mcxn236
       - frdm_mcxn947/mcxn947/cpu0
+      - it51xxx_evb/it51526aw
       - mcx_n9xx_evk/mcxn947/cpu0
       - mcxw72_evk
       - mimxrt1170_evk@B/mimxrt1176/cm7
@@ -56,17 +66,8 @@ tests:
       - mimxrt1180_evk/mimxrt1189/cm7
       - mimxrt1040_evk
       - mimxrt1060_evk/mimxrt1062/qspi
-      - frdm_ke17z512
-      - frdm_mcxn236
-      - frdm_mcxa156
-      - frdm_mcxa346
-      - frdm_mcxa266
-      - frdm_mcxa366
-      - frdm_mcxa344
-      - frdm_mcxc242
-      - frdm_mcxa577
-      - max32655evkit/max32655/m4
       - max32662evkit
+      - max32655evkit/max32655/m4
       - max32666evkit/max32666/cpu0
       - max32670evkit
       - max32672evkit
@@ -81,12 +82,11 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
+      - pic32cm_jh01_cpro
+      - pic32cx_sg41_cult
       - s32k5xxcvb/s32k566/m7
       - s32k5xxcvb/s32k566/r52
-      - it51xxx_evb/it51526aw
       - sam_e54_xpro
-      - pic32cx_sg41_cult
-      - pic32cm_jh01_cpro
     integration_platforms:
       - max32690evkit/max32690/m4
       - nrf54l15dk/nrf54l15/cpuapp

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -45,7 +45,7 @@ tests:
       - stm32n6570_dk/stm32n657xx/sb
       - stm32u083c_dk
     integration_platforms:
-      - nucleo_f091rc
+      - nucleo_h753zi
     extra_configs:
       - CONFIG_APP_DUAL_ROLE_I2C=y
   drivers.i2c.target_api.single_role:
@@ -93,3 +93,71 @@ tests:
     integration_platforms:
       - max32690evkit/max32690/m4
       - nrf54l15dk/nrf54l15/cpuapp
+  drivers.i2c.target_api.stm32.one_dir_dma:
+    filter: CONFIG_DT_HAS_ST_STM32_I2C_V2_ENABLED
+    platform_allow:
+      - b_u585i_iot02a
+      - disco_l475_iot1
+      - nucleo_c071rb
+      - nucleo_c5a3zg
+      - nucleo_f091rc
+      - nucleo_f746zg
+      - nucleo_g071rb
+      - nucleo_g474re
+      - nucleo_h503rb
+      - nucleo_h563zi
+      - nucleo_h753zi
+      - nucleo_l073rz
+      - nucleo_l476rg
+      - nucleo_n657x0_q/stm32n657xx/sb
+      - nucleo_u083rc
+      - nucleo_u385rg_q
+      - nucleo_wb55rg
+      - nucleo_wba55cg
+      - nucleo_wl55jc
+      - stm32f072b_disco
+      - stm32f3_disco
+      - stm32h573i_dk
+      - stm32l562e_dk
+      - stm32n6570_dk/stm32n657xx/sb
+      - stm32u083c_dk
+    integration_platforms:
+      - nucleo_h753zi
+    extra_configs:
+      - CONFIG_APP_DUAL_ROLE_I2C=y
+      - CONFIG_DCACHE=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="stm32_one_dir_dma.overlay"
+  drivers.i2c.target_api.stm32.no_dma:
+    filter: CONFIG_DT_HAS_ST_STM32_I2C_V2_ENABLED
+    platform_allow:
+      - b_u585i_iot02a
+      - disco_l475_iot1
+      - nucleo_c071rb
+      - nucleo_c5a3zg
+      - nucleo_f091rc
+      - nucleo_f746zg
+      - nucleo_g071rb
+      - nucleo_g474re
+      - nucleo_h503rb
+      - nucleo_h563zi
+      - nucleo_h753zi
+      - nucleo_l073rz
+      - nucleo_l476rg
+      - nucleo_n657x0_q/stm32n657xx/sb
+      - nucleo_u083rc
+      - nucleo_u385rg_q
+      - nucleo_wb55rg
+      - nucleo_wba55cg
+      - nucleo_wl55jc
+      - stm32f072b_disco
+      - stm32f3_disco
+      - stm32h573i_dk
+      - stm32l562e_dk
+      - stm32n6570_dk/stm32n657xx/sb
+      - stm32u083c_dk
+    integration_platforms:
+      - nucleo_f091rc
+    extra_configs:
+      - CONFIG_APP_DUAL_ROLE_I2C=y
+      - CONFIG_DCACHE=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="stm32_no_dma.overlay"

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -93,6 +93,38 @@ tests:
     integration_platforms:
       - max32690evkit/max32690/m4
       - nrf54l15dk/nrf54l15/cpuapp
+  drivers.i2c.target_api.dual_role.rtio:
+    integration_platforms:
+      - nucleo_h753zi
+    platform_allow:
+      - b_u585i_iot02a
+      - disco_l475_iot1
+      - nucleo_c071rb
+      - nucleo_c5a3zg
+      - nucleo_f091rc
+      - nucleo_f746zg
+      - nucleo_g071rb
+      - nucleo_g474re
+      - nucleo_h503rb
+      - nucleo_h563zi
+      - nucleo_h753zi
+      - nucleo_l073rz
+      - nucleo_l476rg
+      - nucleo_n657x0_q/stm32n657xx/sb
+      - nucleo_u083rc
+      - nucleo_u385rg_q
+      - nucleo_wb55rg
+      - nucleo_wba55cg
+      - nucleo_wl55jc
+      - stm32f072b_disco
+      - stm32f3_disco
+      - stm32h573i_dk
+      - stm32l562e_dk
+      - stm32n6570_dk/stm32n657xx/sb
+      - stm32u083c_dk
+    extra_configs:
+      - CONFIG_APP_DUAL_ROLE_I2C=y
+      - CONFIG_I2C_RTIO=y
   drivers.i2c.target_api.stm32.one_dir_dma:
     filter: CONFIG_DT_HAS_ST_STM32_I2C_V2_ENABLED
     platform_allow:

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -25,9 +25,12 @@ tests:
       - nucleo_g071rb
       - nucleo_g474re
       - nucleo_h503rb
+      - nucleo_h563zi
       - nucleo_h753zi
       - nucleo_l073rz
       - nucleo_l152re
+      - nucleo_l476rg
+      - nucleo_n657x0_q/stm32n657xx/sb
       - nucleo_u083rc
       - nucleo_u385rg_q
       - nucleo_wb55rg


### PR DESCRIPTION
~~Add missing cache flush in i2c_stm32_v2 driver before starting a DMA transfer.~~

Make use of DMAs more flexible in STM32 I2C drivers:
- Now, using DMA on an I2C bus does not enforce it's used also on the other I2C buses.
- Now, using DMA for Rx (reps. Tx) transfeer on a bus does not require it's also used for Tx (resp. Rx) transfer on that bus.
- If caller provides a cachable (DCACHE) buffer that is not aligned on cache line, for a Rx transfer, don't use DMA since it would require an invalidation of a cache line that may contain data nearby that buffer.

While at it, remove CONFIG_I2C_STM32_V2_DMA config symbol. Now, DMA support in STM32 I2C drivers is embedded if at least a compatible node has a `dmas` property set.

Add testcases in **i2c_target_api** test sample to test I2C APIs when DMA is enabled, considering cache management.