### PR TITLE
manifest: update hal_nordic revision aa969cd

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 19f742b45acb7e660ed3673cab819c103de5e856
+      revision: aa969cd8a4e1a3af411026e1520059be77f76444
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
New Ironside version release 23.7.1+32 for 9220.

Doxygen documentation and header fixes.