### PR TITLE
net: if: remove net_if_config_get

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -630,6 +630,9 @@ Networking
   keys. Use ``samples/net/wifi/test_certs/rsa2k_no_des`` instead, or set
   :envvar:`WIFI_TEST_CERTS_DIR` to another AES-encrypted certificate directory.
 
+* ``net_if_config_get`` was removed as it was a duplicate of :c:func:`net_if_get_config`.
+  (:github:`110930`)
+
 
 Ethernet
 ========

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1502,22 +1502,6 @@ struct net_if *net_if_get_by_link_addr(struct net_linkaddr *ll_addr);
 struct net_if *net_if_lookup_by_dev(const struct device *dev);
 
 /**
- * @brief Get network interface IP config
- *
- * @param iface Interface to use.
- *
- * @return NULL if not found or pointer to correct config settings.
- */
-static inline struct net_if_config *net_if_config_get(struct net_if *iface)
-{
-	if (iface == NULL) {
-		return NULL;
-	}
-
-	return &iface->config;
-}
-
-/**
  * @brief Remove a router from the system
  *
  * @param router Pointer to existing router


### PR DESCRIPTION
remove net_if_config_get, which is not used
in the tree, in favor of net_if_get_config.
Both did the exact same thing.