### PR TITLE
Bluetooth: BAP: Use bap_stream_valid_ase_op for all ASCS ops

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1090,6 +1090,10 @@ int bt_bap_stream_stop(struct bt_bap_stream *stream);
  * Broadcast source streams cannot be released, but can be deleted by
  * bt_bap_broadcast_source_delete().
  *
+ * If the stream's endpoint is non-NULL and its state is @ref BT_BAP_EP_STATE_IDLE,
+ * the function will reset the stream and endpoint locally if the return value is 0,
+ * but will not send the release command.
+ *
  * @param stream Stream object
  *
  * @return 0 in case of success or negative value in case of error.

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -1541,6 +1541,7 @@ int bt_bap_stream_disable(struct bt_bap_stream *stream)
 
 int bt_bap_stream_release(struct bt_bap_stream *stream)
 {
+	const struct bt_bap_ep *ep;
 	struct bt_conn *conn;
 	uint8_t role;
 	int err;
@@ -1553,7 +1554,13 @@ int bt_bap_stream_release(struct bt_bap_stream *stream)
 	}
 
 	conn = stream->conn;
-	if (!bap_stream_valid_ase_op(conn, stream->ep, BT_ASCS_RELEASE_OP)) {
+	ep = stream->ep;
+
+	/* If ep->state == BT_BAP_EP_STATE_IDLE, then the stream and/or ASE will be reset even if it
+	 * is not a valid ASCS transition
+	 */
+	if (ep->state != BT_BAP_EP_STATE_IDLE &&
+	    !bap_stream_valid_ase_op(conn, ep, BT_ASCS_RELEASE_OP)) {
 		return -EBADMSG;
 	}
 

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -878,7 +878,6 @@ static bool bap_stream_valid_ase_op(const struct bt_conn *conn, const struct bt_
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {
 		valid_op = bap_stream_valid_server_ase_op(ep_dir, ep_state, ase_op);
 	} else {
-		__ASSERT(false, "Invalid conn role %u", role);
 		valid_op = false;
 	}
 

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -1312,7 +1312,6 @@ int bt_bap_stream_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group)
 
 int bt_bap_stream_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len)
 {
-	const struct bt_bap_ep *ep;
 	int err;
 
 	LOG_DBG("stream %p", stream);
@@ -1322,8 +1321,7 @@ int bt_bap_stream_enable(struct bt_bap_stream *stream, const uint8_t meta[], siz
 		return -EINVAL;
 	}
 
-	ep = stream->ep;
-	if (!bap_stream_valid_ase_op(stream->conn, ep, BT_ASCS_ENABLE_OP)) {
+	if (!bap_stream_valid_ase_op(stream->conn, stream->ep, BT_ASCS_ENABLE_OP)) {
 		return -EBADMSG;
 	}
 
@@ -1338,7 +1336,6 @@ int bt_bap_stream_enable(struct bt_bap_stream *stream, const uint8_t meta[], siz
 
 int bt_bap_stream_stop(struct bt_bap_stream *stream)
 {
-	struct bt_bap_ep *ep;
 	int err;
 
 	if (stream == NULL || stream->ep == NULL || stream->conn == NULL) {
@@ -1346,8 +1343,7 @@ int bt_bap_stream_stop(struct bt_bap_stream *stream)
 		return -EINVAL;
 	}
 
-	ep = stream->ep;
-	if (!bap_stream_valid_ase_op(stream->conn, ep, BT_ASCS_STOP_OP)) {
+	if (!bap_stream_valid_ase_op(stream->conn, stream->ep, BT_ASCS_STOP_OP)) {
 		return -EBADMSG;
 	}
 
@@ -1363,7 +1359,7 @@ int bt_bap_stream_stop(struct bt_bap_stream *stream)
 
 int bt_bap_stream_reconfig(struct bt_bap_stream *stream, const struct bt_audio_codec_cfg *codec_cfg)
 {
-	struct bt_bap_ep *ep;
+	struct bt_conn *conn;
 	uint8_t role;
 	int err;
 
@@ -1379,12 +1375,12 @@ int bt_bap_stream_reconfig(struct bt_bap_stream *stream, const struct bt_audio_c
 		return -EINVAL;
 	}
 
-	ep = stream->ep;
-	if (!bap_stream_valid_ase_op(stream->conn, ep, BT_ASCS_CONFIG_OP)) {
+	conn = stream->conn;
+	if (!bap_stream_valid_ase_op(conn, stream->ep, BT_ASCS_CONFIG_OP)) {
 		return -EBADMSG;
 	}
 
-	role = conn_get_role(stream->conn);
+	role = conn_get_role(conn);
 	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_CONN_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_config(stream, codec_cfg);
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {
@@ -1436,7 +1432,7 @@ int bt_bap_stream_connect(struct bt_bap_stream *stream)
 
 int bt_bap_stream_start(struct bt_bap_stream *stream)
 {
-	const struct bt_bap_ep *ep;
+	struct bt_conn *conn;
 	uint8_t role;
 	int err;
 
@@ -1447,12 +1443,12 @@ int bt_bap_stream_start(struct bt_bap_stream *stream)
 		return -EINVAL;
 	}
 
-	ep = stream->ep;
-	if (!bap_stream_valid_ase_op(stream->conn, ep, BT_ASCS_START_OP)) {
+	conn = stream->conn;
+	if (!bap_stream_valid_ase_op(conn, stream->ep, BT_ASCS_START_OP)) {
 		return -EBADMSG;
 	}
 
-	role = conn_get_role(stream->conn);
+	role = conn_get_role(conn);
 	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_CONN_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_start(stream);
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {
@@ -1471,7 +1467,7 @@ int bt_bap_stream_start(struct bt_bap_stream *stream)
 
 int bt_bap_stream_metadata(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len)
 {
-	const struct bt_bap_ep *ep;
+	struct bt_conn *conn;
 	uint8_t role;
 	int err;
 
@@ -1487,12 +1483,12 @@ int bt_bap_stream_metadata(struct bt_bap_stream *stream, const uint8_t meta[], s
 		return -EINVAL;
 	}
 
-	ep = stream->ep;
-	if (!bap_stream_valid_ase_op(stream->conn, ep, BT_ASCS_METADATA_OP)) {
+	conn = stream->conn;
+	if (!bap_stream_valid_ase_op(conn, stream->ep, BT_ASCS_METADATA_OP)) {
 		return -EBADMSG;
 	}
 
-	role = conn_get_role(stream->conn);
+	role = conn_get_role(conn);
 	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_CONN_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_metadata(stream, meta, meta_len);
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {
@@ -1511,7 +1507,7 @@ int bt_bap_stream_metadata(struct bt_bap_stream *stream, const uint8_t meta[], s
 
 int bt_bap_stream_disable(struct bt_bap_stream *stream)
 {
-	enum bt_bap_ep_state state;
+	struct bt_conn *conn;
 	uint8_t role;
 	int err;
 
@@ -1522,19 +1518,12 @@ int bt_bap_stream_disable(struct bt_bap_stream *stream)
 		return -EINVAL;
 	}
 
-	state = stream->ep->state;
-	switch (state) {
-	/* Valid only if ASE_State field = 0x03 (Enabling) */
-	case BT_BAP_EP_STATE_ENABLING:
-		/* or 0x04 (Streaming) */
-	case BT_BAP_EP_STATE_STREAMING:
-		break;
-	default:
-		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(state));
+	conn = stream->conn;
+	if (!bap_stream_valid_ase_op(conn, stream->ep, BT_ASCS_DISABLE_OP)) {
 		return -EBADMSG;
 	}
 
-	role = conn_get_role(stream->conn);
+	role = conn_get_role(conn);
 	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_CONN_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_disable(stream);
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {
@@ -1553,7 +1542,7 @@ int bt_bap_stream_disable(struct bt_bap_stream *stream)
 
 int bt_bap_stream_release(struct bt_bap_stream *stream)
 {
-	enum bt_bap_ep_state state;
+	struct bt_conn *conn;
 	uint8_t role;
 	int err;
 
@@ -1564,25 +1553,12 @@ int bt_bap_stream_release(struct bt_bap_stream *stream)
 		return -EINVAL;
 	}
 
-	state = stream->ep->state;
-	switch (state) {
-	/* Valid only if ASE_State field = 0x01 (Codec Configured) */
-	case BT_BAP_EP_STATE_CODEC_CONFIGURED:
-		/* or 0x02 (QoS Configured) */
-	case BT_BAP_EP_STATE_QOS_CONFIGURED:
-		/* or 0x03 (Enabling) */
-	case BT_BAP_EP_STATE_ENABLING:
-		/* or 0x04 (Streaming) */
-	case BT_BAP_EP_STATE_STREAMING:
-		/* or 0x04 (Disabling) */
-	case BT_BAP_EP_STATE_DISABLING:
-		break;
-	default:
-		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(state));
+	conn = stream->conn;
+	if (!bap_stream_valid_ase_op(conn, stream->ep, BT_ASCS_RELEASE_OP)) {
 		return -EBADMSG;
 	}
 
-	role = conn_get_role(stream->conn);
+	role = conn_get_role(conn);
 	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_CONN_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_release(stream);
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -3729,6 +3729,11 @@ int bt_bap_unicast_client_release(struct bt_bap_stream *stream)
 
 	LOG_DBG("stream %p", stream);
 
+	if (ep->state == BT_BAP_EP_STATE_IDLE) {
+		bt_bap_stream_reset(stream);
+		return 0;
+	}
+
 	if (stream->conn == NULL) {
 		LOG_DBG("Stream %p does not have a connection", stream);
 
@@ -3745,14 +3750,9 @@ int bt_bap_unicast_client_release(struct bt_bap_stream *stream)
 	req->num_ases = 0x01U;
 	len = buf->len;
 
-	/* Only attempt to release if not IDLE already */
-	if (stream->ep->state == BT_BAP_EP_STATE_IDLE) {
-		bt_bap_stream_reset(stream);
-	} else {
-		err = unicast_client_ep_release(ep, buf);
-		if (err != 0) {
-			return err;
-		}
+	err = unicast_client_ep_release(ep, buf);
+	if (err != 0) {
+		return err;
 	}
 
 	/* Check if anything needs to be send */


### PR DESCRIPTION
The release and disable operations did not use the function, but instead had their own switches. Changes to use the appropriate function.

Additionally modified some of the other calls so that they appear more similar, and avoid unncessary `struct bt_bap_ep *ep` variables but also add `struct bt_conn *conn;` variables to avoid doing `stream->conn` more often than what is needed.