### PR TITLE
drivers: clock_control: stm32: H7/H7RS PLL1 DIVP can be 1 or even

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -190,6 +190,11 @@
 #define STM32H7_BUS_CLK_REG	DT_REG_ADDR(DT_NODELABEL(rcc)) + 0x60
 #endif
 
+#if IS_ENABLED(STM32_PLL_P_ENABLED)
+BUILD_ASSERT(((STM32_PLL_P_DIVISOR == 1) || (STM32_PLL_P_DIVISOR % 2) == 0),
+	     "STM32H7/H7RS PLL1 DIVP divisor factor must be 1 or even");
+#endif /* STM32_PLL_P_ENABLED */
+
 static uint32_t get_bus_clock(uint32_t clock, uint32_t prescaler)
 {
 	return clock / prescaler;

--- a/dts/bindings/clock/st,stm32h7-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32h7-pll-clock.yaml
@@ -54,6 +54,7 @@ properties:
     type: int
     description: |
         PLL division factor for pllx_p_ck
+        Note: For PLL1, P division factor must be 1 or even.
     min: 1
     max: 128
 


### PR DESCRIPTION
Add a build assertion to ensure PLL1 DIVP division factor is not an od value different from 1 since not allowed as per SoCs reference manuals.