### PR TITLE
Avoid using PSRAM related pins in other peripherals

### DIFF
--- a/boards/espressif/esp32s2_devkitc/esp32s2_devkitc-pinctrl.dtsi
+++ b/boards/espressif/esp32s2_devkitc/esp32s2_devkitc-pinctrl.dtsi
@@ -32,15 +32,16 @@
 		};
 	};
 
+	/* SPI3: GPIO33-37 are octal PSRAM interconnect — do not use */
 	spim3_default: spim3_default {
 		group1 {
-			pinmux = <SPIM3_MISO_GPIO37>,
-				 <SPIM3_SCLK_GPIO36>,
-				 <SPIM3_CSEL_GPIO34>;
+			pinmux = <SPIM3_MISO_GPIO40>,
+				 <SPIM3_SCLK_GPIO21>,
+				 <SPIM3_CSEL_GPIO14>;
 		};
 
 		group2 {
-			pinmux = <SPIM3_MOSI_GPIO35>;
+			pinmux = <SPIM3_MOSI_GPIO41>;
 			output-low;
 		};
 	};

--- a/boards/espressif/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
+++ b/boards/espressif/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
@@ -32,15 +32,16 @@
 		};
 	};
 
+	/* SPI3: GPIO33-37 are octal PSRAM interconnect — do not use */
 	spim3_default: spim3_default {
 		group1 {
-			pinmux = <SPIM3_MISO_GPIO37>,
-				 <SPIM3_SCLK_GPIO36>,
-				 <SPIM3_CSEL_GPIO34>;
+			pinmux = <SPIM3_MISO_GPIO40>,
+				 <SPIM3_SCLK_GPIO21>,
+				 <SPIM3_CSEL_GPIO14>;
 		};
 
 		group2 {
-			pinmux = <SPIM3_MOSI_GPIO35>;
+			pinmux = <SPIM3_MOSI_GPIO41>;
 			output-low;
 		};
 	};

--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc-pinctrl.dtsi
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc-pinctrl.dtsi
@@ -84,15 +84,16 @@
 		};
 	};
 
+	/* SPI3: GPIO33-37 are octal PSRAM interconnect — do not use */
 	spim3_default: spim3_default {
 		group1 {
-			pinmux = <SPIM3_MISO_GPIO37>,
-				 <SPIM3_SCLK_GPIO36>,
-				 <SPIM3_CSEL_GPIO38>;
+			pinmux = <SPIM3_MISO_GPIO40>,
+				 <SPIM3_SCLK_GPIO21>,
+				 <SPIM3_CSEL_GPIO14>;
 		};
 
 		group2 {
-			pinmux = <SPIM3_MOSI_GPIO39>;
+			pinmux = <SPIM3_MOSI_GPIO41>;
 			output-low;
 		};
 	};


### PR DESCRIPTION
Fix the Espressif board's pinctrl setup for cases when `PSRAM` and `CONFIG_SPI` are both enabled to avoid using pins that would interfere and impose an issue on the booting process.