### PR TITLE
drivers: crc: nxp_lpc: advertise CRC-16/ITU-T capability

### DIFF
--- a/drivers/crc/Kconfig.nxp
+++ b/drivers/crc/Kconfig.nxp
@@ -21,6 +21,7 @@ config CRC_DRIVER_NXP_LPC
 	default y
 	select CRC_DRIVER_HAS_CRC16
 	select CRC_DRIVER_HAS_CRC16_CCITT
+	select CRC_DRIVER_HAS_CRC16_ITU_T
 	select CRC_DRIVER_HAS_CRC32_IEEE
 	help
 	  Enable the LPC CRC driver implementation for NXP microcontrollers


### PR DESCRIPTION
- Selects CRC_DRIVER_HAS_CRC16_ITU_T for the NXP LPC CRC driver.
- The NXP LPC CRC peripheral is able to compute CRC-16/ITU-T (polynomial 0x1021, init 0x0000, noreflection, no XOR-out).
- Tested by private code (Zephyr does not test it).