### PR TITLE
compiler: clang: Override LTO flags with Clang-compatible forms

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -22,6 +22,11 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp23 "-std=c++23"
 
 set_compiler_property(PROPERTY optimization_fast -O3 -ffast-math)
 
+# Clang uses -flto=thin (parallel) and -flto=full (single-threaded) instead
+# of the GCC-specific -flto=auto and -flto=1 forms.
+set_compiler_property(PROPERTY optimization_lto -flto=thin)
+set_compiler_property(PROPERTY optimization_lto_st -flto=full)
+
 #######################################################
 # This section covers flags related to warning levels #
 #######################################################


### PR DESCRIPTION
Clang does not support the GCC-specific -flto=auto and -flto=1
flag forms, causing build failures when LTO is enabled with the
LLVM toolchain:

  clang: error: unsupported argument '1' to option '-flto='

Override optimization_lto and optimization_lto_st in the Clang
compiler flags to use the Clang-supported equivalents:

  - optimization_lto:    -flto=thin  (parallel, replaces -flto=auto)
  - optimization_lto_st: -flto=full  (single-threaded, replaces -flto=1)

