### PR TITLE
kernel: timeslicing: restore full slice rearm

### DIFF
--- a/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54.dts
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54.dts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /dts-v1/;
 #include "mpfs_icicle_common.dtsi"
 
@@ -6,6 +12,18 @@
 
 	cpus {
 		cpu@0 {
+			status = "disabled";
+		};
+
+		cpu@2 {
+			status = "disabled";
+		};
+
+		cpu@3 {
+			status = "disabled";
+		};
+
+		cpu@4 {
 			status = "disabled";
 		};
 	};

--- a/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54_smp.dts
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54_smp.dts
@@ -1,8 +1,20 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /dts-v1/;
-#include "mpfs_icicle_polarfire_u54.dts"
+#include "mpfs_icicle_common.dtsi"
 
 / {
 	compatible = "microchip,mpfs-icicle-kit", "microchip,mpfs";
+
+	cpus {
+		cpu@0 {
+			status = "disabled";
+		};
+	};
 
 	chosen {
 		zephyr,console = &uart1;

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -79,18 +79,11 @@ void z_time_slice_reset(struct k_thread *thread)
 	int slice_size = z_time_slice_size(thread);
 
 	z_abort_timeout(&slice_timeouts[cpu]);
-	if (slice_size != 0) {
-		/* When invoked because the slicer just fired (this CPU or
-		 * via IPI from another), we're at a tick edge but past the
-		 * announce window, so subtract 1 to cancel z_add_timeout()'s
-		 * "+1" round-up and land at exactly slice_size ticks.
-		 */
-		int delay = slice_expired[cpu] ? slice_size - 1 : slice_size;
-
-		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
-			      K_TICKS(delay));
-	}
 	slice_expired[cpu] = false;
+	if (slice_size != 0) {
+		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
+			      K_TICKS(slice_size));
+	}
 }
 
 static ALWAYS_INLINE bool thread_defines_time_slice_size(struct k_thread *thread)
@@ -162,25 +155,8 @@ void z_time_slice(void)
 #endif
 		if (!z_is_thread_prevented_from_running(curr)) {
 			move_current_to_end_of_prio_q();
-			/* If the rotation kept curr at the front (no other
-			 * runnable thread of equal-or-higher priority is
-			 * waiting), no swap will happen and we must rearm
-			 * here. Otherwise the dispatch path will rearm for
-			 * the new thread with slice_expired still set,
-			 * picking up the tick-aligned delay.
-			 */
-#ifdef CONFIG_SMP
-			struct k_thread *next = runq_best();
-
-			if (next == NULL || z_is_idle_thread_object(next)) {
-				z_time_slice_reset(curr);
-			}
-#else
-			if (_kernel.ready_q.cache == curr) {
-				z_time_slice_reset(curr);
-			}
-#endif
 		}
+		z_time_slice_reset(curr);
 	}
 	k_spin_unlock(&_sched_spinlock, key);
 }


### PR DESCRIPTION
Revert the slice_size - 1 rearm optimization from c3f2a6a.

On SMP, carrying slice_expired into later scheduler paths is not a reliable indication that the next timeout is still being armed at the original tick edge and the shortened rearm can destabilize scheduling.

Restore the previous full-slice rearm behavior.