### PR TITLE
various networking fixes detected wwith ASAN

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2455,6 +2455,7 @@ static int context_sendto(struct net_context *context,
 	const struct net_msghdr *msghdr = NULL;
 	struct net_if *iface = NULL;
 	struct net_pkt *pkt = NULL;
+	struct net_sockaddr_in mapped;
 	net_sa_family_t family;
 	size_t tmp_len;
 	int ret;
@@ -2564,7 +2565,6 @@ static int context_sendto(struct net_context *context,
 
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) && family == NET_AF_INET) {
 		const struct net_sockaddr_in *addr4 = (const struct net_sockaddr_in *)dst_addr;
-		struct net_sockaddr_in mapped;
 
 		if (msghdr) {
 			addr4 = msghdr->msg_name;

--- a/subsys/net/lib/ptp/transport.c
+++ b/subsys/net/lib/ptp/transport.c
@@ -46,7 +46,8 @@ static bool transport_is_pdelay_msg(const void *buf)
 	}
 }
 
-static int transport_socket_open(struct net_if *iface, struct net_sockaddr *addr)
+static int transport_socket_open(struct net_if *iface, net_sa_family_t family,
+				 struct net_sockaddr *addr, net_socklen_t addrlen)
 {
 	static const int feature_on = 1;
 	static const uint8_t priority = NET_PRIORITY_CA;
@@ -54,7 +55,7 @@ static int transport_socket_open(struct net_if *iface, struct net_sockaddr *addr
 		ZSOCK_SOF_TIMESTAMPING_TX_HARDWARE | ZSOCK_SOF_TIMESTAMPING_RX_HARDWARE;
 	struct net_ifreq ifreq = {0};
 	int cnt;
-	int socket = zsock_socket(addr->sa_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	int socket = zsock_socket(family, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
 
 	if (net_if_get_by_iface(iface) < 0) {
 		LOG_ERR("Failed to obtain interface index");
@@ -71,7 +72,7 @@ static int transport_socket_open(struct net_if *iface, struct net_sockaddr *addr
 		goto error;
 	}
 
-	if (zsock_bind(socket, addr, sizeof(*addr))) {
+	if (zsock_bind(socket, addr, addrlen)) {
 		LOG_ERR("Failed to bind socket");
 		goto error;
 	}
@@ -179,7 +180,8 @@ static int transport_udp_ipv4_open(struct net_if *iface, uint16_t port)
 		.sin_port = net_htons(port),
 	};
 
-	socket = transport_socket_open(iface, (struct net_sockaddr *)&addr);
+	socket = transport_socket_open(iface, NET_AF_INET, (struct net_sockaddr *)&addr,
+				       sizeof(addr));
 	if (socket < 0) {
 		return -1;
 	}
@@ -216,7 +218,8 @@ static int transport_udp_ipv6_open(struct net_if *iface, uint16_t port)
 					.sin6_addr = NET_IN6ADDR_ANY_INIT,
 					.sin6_port = net_htons(port)};
 
-	socket = transport_socket_open(iface, (struct net_sockaddr *)&addr);
+	socket = transport_socket_open(iface, NET_AF_INET6, (struct net_sockaddr *)&addr,
+				       sizeof(addr));
 	if (socket < 0) {
 		return -1;
 	}

--- a/tests/net/lib/mqtt_sn_client/src/mqtt_sn_client.c
+++ b/tests/net/lib/mqtt_sn_client/src/mqtt_sn_client.c
@@ -138,7 +138,8 @@ static ssize_t tp_recvfrom(struct mqtt_sn_client *client, void *buffer, size_t l
 {
 	if (recvfrom_data.data && recvfrom_data.sz > 0 && length >= recvfrom_data.sz) {
 		memcpy(buffer, recvfrom_data.data, recvfrom_data.sz);
-		memcpy(src_addr, recvfrom_data.src_addr, recvfrom_data.addrlen);
+		memcpy(src_addr, recvfrom_data.src_addr,
+		       MIN(*addrlen, recvfrom_data.addrlen));
 		*addrlen = recvfrom_data.addrlen;
 
 		k_sem_give(&mqtt_sn_rx_sem);

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -20,7 +20,7 @@
 
 static uint8_t mac_addr[sizeof(struct net_eth_addr)];
 static struct net_if *eth_if;
-static uint8_t small_buffer[512];
+static uint8_t small_buffer[CONFIG_NET_BUF_DATA_SIZE * 2 + 3];
 
 /************************\
  * FAKE ETHERNET DEVICE *


### PR DESCRIPTION
- **net: context: fix stack-use-after-scope in context_sendto()**
- **tests: net: mqtt_sn_client: fix stack-buffer-overflow in tp_recvfrom()**
- **tests: net: net_pkt: fix global-buffer-overflow in test_net_pkt_remove_tail()**
- **net: ptp: transport: fix array-bounds warning and incorrect bind size**
