### PR TITLE
net: add missing k_mutex_init() uncovered by recent mutex hardening

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -69,6 +69,8 @@ LOG_MODULE_REGISTER(net_core, CONFIG_NET_CORE_LOG_LEVEL);
 
 #include "net_stats.h"
 
+#include "../l2/ethernet/arp.h"
+
 #if defined(CONFIG_NET_NATIVE)
 static inline enum net_verdict process_data(struct net_pkt *pkt)
 {
@@ -162,6 +164,9 @@ again:
 /* Things to setup after we are able to RX and TX */
 static void net_post_init(void)
 {
+#if defined(CONFIG_NET_ARP)
+	net_arp_init();
+#endif
 #if defined(CONFIG_NET_LLDP)
 	net_lldp_init();
 #endif

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -1086,7 +1086,5 @@ void ethernet_init(struct net_if *iface)
 	}
 #endif
 
-	net_arp_init();
-
 	ctx->is_init = true;
 }

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -210,6 +210,8 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 		goto out;
 	}
 
+	(void)k_mutex_init(&ctx->lock);
+
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&sockets, entry, next, node) {
 		/* Refuse to register context if we have identical context
 		 * already registered.

--- a/subsys/net/lib/tls_credentials/tls_credentials_trusted.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_trusted.c
@@ -38,7 +38,7 @@ static struct tls_credential credentials[CRED_MAX_SLOTS];
 static psa_storage_uid_t credentials_toc[CRED_MAX_SLOTS];
 
 /* A mutex for protecting access to the credentials array. */
-static struct k_mutex credential_lock;
+static K_MUTEX_DEFINE(credential_lock);
 
 /* Construct PSA PS uid from tag & type */
 static inline psa_storage_uid_t tls_credential_get_uid(uint32_t tag,

--- a/tests/net/lib/lwm2m/block_transfer/src/main.c
+++ b/tests/net/lib/lwm2m/block_transfer/src/main.c
@@ -53,6 +53,8 @@ static void net_block_transfer_before(void *f)
 	memset(&fixture->ctx, 0, sizeof(struct lwm2m_ctx));
 	memset(&fixture->msg, 0, sizeof(struct lwm2m_message));
 	fixture->msg.ctx = &fixture->ctx;
+
+	k_mutex_init(&fixture->ctx.lock);
 }
 
 static void net_block_transfer_after(void *f)

--- a/tests/net/lib/lwm2m/lwm2m_engine/src/main.c
+++ b/tests/net/lib/lwm2m/lwm2m_engine/src/main.c
@@ -100,6 +100,7 @@ ZTEST(lwm2m_engine, test_start_stop)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	ctx.remote_addr.sa_family = NET_AF_INET;
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
@@ -130,6 +131,7 @@ ZTEST(lwm2m_engine, test_pause_resume)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	ctx.remote_addr.sa_family = NET_AF_INET;
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
@@ -155,6 +157,7 @@ ZTEST(lwm2m_engine, test_engine_add_service)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	ctx.remote_addr.sa_family = NET_AF_INET;
 	ctx.load_credentials = NULL;
 
@@ -177,6 +180,7 @@ ZTEST(lwm2m_engine, test_no_sa_family)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
 
@@ -192,6 +196,7 @@ ZTEST(lwm2m_engine, test_connect_fail)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
 	ctx.remote_addr.sa_family = NET_AF_INET;
@@ -210,6 +215,7 @@ ZTEST(lwm2m_engine, test_socket_suspend_resume_connection)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
 	ctx.remote_addr.sa_family = NET_AF_INET;
@@ -233,6 +239,7 @@ ZTEST(lwm2m_engine, test_check_notifications)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
 	ctx.remote_addr.sa_family = NET_AF_INET;
@@ -266,6 +273,7 @@ ZTEST(lwm2m_engine, test_push_queued_buffers)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	sys_slist_init(&ctx.queued_messages);
 	msg.ctx = &ctx;
 	msg.pending = &pending;
@@ -285,6 +293,7 @@ ZTEST(lwm2m_engine, test_validate_write_access)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	ctx.bootstrap_mode = true;
 	msg.ctx = &ctx;
 	msg.path = LWM2M_OBJ(LWM2M_OBJECT_SECURITY_ID, 0);
@@ -345,6 +354,7 @@ ZTEST(lwm2m_engine, test_retransmit_request)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
 	ctx.remote_addr.sa_family = NET_AF_INET;
@@ -376,6 +386,7 @@ ZTEST(lwm2m_engine, test_socket_recv)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	ctx.remote_addr.sa_family = NET_AF_INET;
 	ctx.sock_fd = -1;
 
@@ -399,6 +410,7 @@ ZTEST(lwm2m_engine, test_socket_send)
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
+	k_mutex_init(&ctx.lock);
 	ctx.remote_addr.sa_family = NET_AF_INET;
 	ctx.sock_fd = -1;
 	sys_slist_init(&ctx.queued_messages);
@@ -430,6 +442,7 @@ ZTEST(lwm2m_engine, test_security)
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 	my_data_len = snprintk(my_buf, sizeof(my_buf), "-----BEGIN SOMETHING");
 
+	k_mutex_init(&ctx.lock);
 	ctx.remote_addr.sa_family = NET_AF_INET;
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
@@ -499,6 +512,7 @@ ZTEST(lwm2m_engine, test_socket_state)
 		.type = COAP_TYPE_ACK,
 	};
 
+	k_mutex_init(&ctx.lock);
 	sys_slist_init(&ctx.pending_sends);
 	ret = lwm2m_engine_start(&ctx);
 	zassert_equal(ret, 0);

--- a/tests/net/lib/quic/src/main.c
+++ b/tests/net/lib/quic/src/main.c
@@ -158,6 +158,7 @@ static struct quic_endpoint *reset_test_ep(struct quic_endpoint *ep)
 {
 	memset(ep, 0, sizeof(*ep));
 	ep->sock = -1;
+	quic_recovery_init(ep);
 
 	return ep;
 }
@@ -961,7 +962,6 @@ ZTEST(net_socket_quic, test_090_recovery_shutdown_stops_tracking)
 {
 	struct quic_endpoint *ep = reset_test_ep(&test_ep_a);
 
-	quic_recovery_init(ep);
 	quic_recovery_begin_shutdown(ep);
 	quic_recovery_on_packet_sent(ep, QUIC_SECRET_LEVEL_APPLICATION, 1, 123, true,
 				      false, 0);
@@ -974,7 +974,6 @@ ZTEST(net_socket_quic, test_090_recovery_shutdown_stops_tracking)
 static void init_test_dplpmtud_endpoint(struct quic_endpoint *ep)
 {
 	reset_test_ep(ep);
-	quic_recovery_init(ep);
 	ep->handshake.completed = true;
 	ep->peer_params.max_udp_payload_size = UINT16_MAX;
 	ep->dplpmtud.validated_payload_size = QUIC_DPLPMTUD_BASE_PLPMTU;


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/108619 introduced assertions on uninitialized mutexes, uncovering a few issues in networking code which these two commits fix.