### PR TITLE
posix: pthread: fix mutex pool slot reuse

### DIFF
--- a/subsys/portability/posix/options/mutex.c
+++ b/subsys/portability/posix/options/mutex.c
@@ -80,9 +80,7 @@ static struct k_mutex *get_posix_mutex(pthread_mutex_t mu)
 
 struct k_mutex *to_posix_mutex(pthread_mutex_t *mu)
 {
-	int err;
 	size_t bit;
-	struct k_mutex *m;
 
 	if (*mu != PTHREAD_MUTEX_INITIALIZER) {
 		return get_posix_mutex(*mu);
@@ -97,13 +95,7 @@ struct k_mutex *to_posix_mutex(pthread_mutex_t *mu)
 	/* Record the associated posix_mutex in mu and mark as initialized */
 	*mu = mark_pthread_obj_initialized(bit);
 
-	/* Initialize the posix_mutex */
-	m = &posix_mutex_pool[bit];
-
-	err = k_mutex_init(m);
-	__ASSERT_NO_MSG(err == 0);
-
-	return m;
+	return &posix_mutex_pool[bit];
 }
 
 static int acquire_mutex(pthread_mutex_t *mu, k_timeout_t timeout)
@@ -303,9 +295,19 @@ int pthread_mutex_destroy(pthread_mutex_t *mu)
 		return EINVAL;
 	}
 
+	if (m->owner != NULL) {
+		/* Destroying a locked mutex is undefined behavior in POSIX */
+		return EBUSY;
+	}
+
+	err = k_mutex_init(m);
+	__ASSERT_NO_MSG(err == 0);
+
 	bit = to_posix_mutex_idx(*mu);
 	err = sys_bitarray_free(&posix_mutex_bitarray, 1, bit);
 	__ASSERT_NO_MSG(err == 0);
+
+	*mu = PTHREAD_MUTEX_INITIALIZER;
 
 	LOG_DBG("Destroyed mutex %p", m);
 

--- a/tests/lib/c_lib/thrd/src/mtx.c
+++ b/tests/lib/c_lib/thrd/src/mtx.c
@@ -93,11 +93,17 @@ static int mtx_timedlock_fn(void *arg)
 {
 	struct timespec time_point;
 	mtx_t *mtx = (mtx_t *)arg;
+	int ret;
 
 	zassume_ok(sys_clock_gettime(SYS_CLOCK_MONOTONIC, &time_point));
 	timespec_add_ms(&time_point, TIMEDLOCK_TIMEOUT_MS);
 
-	return mtx_timedlock(mtx, &time_point);
+	ret = mtx_timedlock(mtx, &time_point);
+	if (ret == thrd_success) {
+		(void)mtx_unlock(mtx);
+	}
+
+	return ret;
 }
 
 ZTEST(libc_mtx, test_mtx_timedlock)

--- a/tests/subsys/portability/posix/threads_base/src/mutex.c
+++ b/tests/subsys/portability/posix/threads_base/src/mutex.c
@@ -182,11 +182,17 @@ static void *test_mutex_timedlock_fn(void *arg)
 {
 	struct timespec time_point;
 	pthread_mutex_t *mtx = (pthread_mutex_t *)arg;
+	int ret;
 
 	zassume_ok(clock_gettime(CLOCK_REALTIME, &time_point));
 	timespec_add_ms(&time_point, TIMEDLOCK_TIMEOUT_MS);
 
-	return INT_TO_POINTER(pthread_mutex_timedlock(mtx, &time_point));
+	ret = pthread_mutex_timedlock(mtx, &time_point);
+	if (ret == 0) {
+		(void)pthread_mutex_unlock(mtx);
+	}
+
+	return INT_TO_POINTER(ret);
 }
 
 /** @brief Test to verify @ref pthread_mutex_timedlock returns ETIMEDOUT */


### PR DESCRIPTION
Mutex sentinel asserts reject k_mutex_init() on held mutexes. The POSIX pool was re-initializing slots on allocation while destroy could return them still held, tripping assertions in pthread and C11 thread tests.

Re-init pool slots in pthread_mutex_destroy() instead of to_posix_mutex(), and return EBUSY when destroy is called on a locked mutex. Fix timedlock tests to unlock before worker threads exit.