### PR TITLE
drivers: dai: intel: alh: improvements to get_properties implementation

### DIFF
--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -139,6 +139,43 @@ static int dai_alh_config_set(const struct device *dev, const struct dai_config 
 	}
 }
 
+static int dai_alh_get_properties_copy(const struct device *dev,
+				       enum dai_dir dir, int stream_id,
+				       struct dai_properties *prop)
+{
+	struct dai_intel_alh *dp = (struct dai_intel_alh *)dev->data;
+	struct dai_intel_alh_pdata *alh = dai_get_drvdata(dp);
+	uint32_t offset = dir == DAI_DIR_PLAYBACK ?
+		ALH_TXDA_OFFSET : ALH_RXDA_OFFSET;
+
+	if (!prop) {
+		return -EINVAL;
+	}
+
+	if (stream_id < 0 || (size_t)stream_id >= ARRAY_SIZE(alh_handshake_map)) {
+		LOG_ERR("invalid stream_id %d", stream_id);
+		return -ENOENT;
+	}
+
+	/*
+	 * Fill the caller-provided object directly. When invoked through
+	 * dai_get_properties_copy() the destination is the (private) memory of
+	 * the calling thread, so no shared scratch object is touched and
+	 * concurrent queries from separate TX/RX threads cannot race.
+	 */
+	prop->fifo_address = dai_base(dp) + offset + ALH_STREAM_OFFSET * stream_id;
+	prop->fifo_depth = ALH_GPDMA_BURST_LENGTH;
+	prop->dma_hs_id = alh_handshake_map[stream_id];
+	prop->reg_init_delay = 0;
+	prop->stream_id = alh->params.stream_id;
+
+	LOG_DBG("dai_index %u", dp->index);
+	LOG_DBG("fifo %u", prop->fifo_address);
+	LOG_DBG("handshake %u", prop->dma_hs_id);
+
+	return 0;
+}
+
 static const struct dai_properties *dai_alh_get_properties(const struct device *dev,
 							   enum dai_dir dir, int stream_id)
 {
@@ -146,43 +183,12 @@ static const struct dai_properties *dai_alh_get_properties(const struct device *
 	struct dai_intel_alh_pdata *alh = dai_get_drvdata(dp);
 	int array_index = ALH_ARRAY_INDEX(dir);
 	struct dai_properties *prop = &alh->props[array_index];
-	uint32_t offset = dir == DAI_DIR_PLAYBACK ?
-		ALH_TXDA_OFFSET : ALH_RXDA_OFFSET;
 
-	if (stream_id < 0 || (size_t)stream_id >= ARRAY_SIZE(alh_handshake_map)) {
-		LOG_ERR("invalid stream_id %d", stream_id);
+	if (dai_alh_get_properties_copy(dev, dir, stream_id, prop) < 0) {
 		return NULL;
 	}
 
-	prop->fifo_address = dai_base(dp) + offset + ALH_STREAM_OFFSET * stream_id;
-	prop->fifo_depth = ALH_GPDMA_BURST_LENGTH;
-	prop->dma_hs_id = alh_handshake_map[stream_id];
-	prop->stream_id = alh->params.stream_id;
-
-	LOG_DBG("dai_index %u", dp->index);
-	LOG_DBG("fifo %u", prop->fifo_address);
-	LOG_DBG("handshake %u", prop->dma_hs_id);
-
 	return prop;
-}
-
-static int dai_alh_get_properties_copy(const struct device *dev,
-				       enum dai_dir dir, int stream_id,
-				       struct dai_properties *prop)
-{
-	const struct dai_properties *kernel_prop = dai_alh_get_properties(dev, dir, stream_id);
-
-	if (!prop) {
-		return -EINVAL;
-	}
-
-	if (!kernel_prop) {
-		return -ENOENT;
-	}
-
-	memcpy(prop, kernel_prop, sizeof(*kernel_prop));
-
-	return 0;
 }
 
 static int dai_alh_probe(const struct device *dev)

--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -146,6 +146,11 @@ static const struct dai_properties *dai_alh_get_properties(const struct device *
 	uint32_t offset = dir == DAI_DIR_PLAYBACK ?
 		ALH_TXDA_OFFSET : ALH_RXDA_OFFSET;
 
+	if (stream_id < 0 || (size_t)stream_id >= ARRAY_SIZE(alh_handshake_map)) {
+		LOG_ERR("invalid stream_id %d", stream_id);
+		return NULL;
+	}
+
 	prop->fifo_address = dai_base(dp) + offset + ALH_STREAM_OFFSET * stream_id;
 	prop->fifo_depth = ALH_GPDMA_BURST_LENGTH;
 	prop->dma_hs_id = alh_handshake_map[stream_id];

--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -22,6 +22,8 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 
 #include "alh.h"
 
+#define ALH_ARRAY_INDEX(dir) ((dir) == DAI_DIR_RX ? DAI_DIR_CAPTURE : DAI_DIR_PLAYBACK)
+
 /* global data shared between all alh instances */
 struct dai_alh_global_shared dai_alh_global;
 
@@ -142,7 +144,8 @@ static const struct dai_properties *dai_alh_get_properties(const struct device *
 {
 	struct dai_intel_alh *dp = (struct dai_intel_alh *)dev->data;
 	struct dai_intel_alh_pdata *alh = dai_get_drvdata(dp);
-	struct dai_properties *prop = &alh->props;
+	int array_index = ALH_ARRAY_INDEX(dir);
+	struct dai_properties *prop = &alh->props[array_index];
 	uint32_t offset = dir == DAI_DIR_PLAYBACK ?
 		ALH_TXDA_OFFSET : ALH_RXDA_OFFSET;
 

--- a/drivers/dai/intel/alh/alh.h
+++ b/drivers/dai/intel/alh/alh.h
@@ -101,7 +101,7 @@ struct dai_intel_alh_plat_data {
 
 struct dai_intel_alh_pdata {
 	struct dai_config config;
-	struct dai_properties props;
+	struct dai_properties props[2];
 	struct dai_intel_ipc3_alh_params params;
 };
 


### PR DESCRIPTION
The current implementation in alh driver forces the client to use additional locking for concurrent TX/RX use. See discussion in https://github.com/thesofproject/sof/pull/6930#issuecomment-1382089429 

This really should be handled in the dai driver implementation instead and other dai drivers already handle TX/RX separately, so proceed to make similar changes for Intel alh driver (similar to changes #110937 submitted for Intel ssp).

The series also has a fixes to stream_id validation in existing get_properties code. This did not have any input validation before.

Fixes: #112743