### PR TITLE
Bluetooth: Host: Add bt_le_per_adv_update_did() API

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -145,6 +145,7 @@ New APIs and options
 
     * :c:func:`bt_conn_take`
     * :c:func:`bt_conn_drop`
+    * :c:func:`bt_le_per_adv_update_did`
 
   * Mesh
 

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1556,6 +1556,27 @@ int bt_le_per_adv_set_data(const struct bt_le_ext_adv *adv,
 			   const struct bt_data *ad, size_t ad_len);
 
 /**
+ * @brief Update the Advertising Data Identifier (DID) for periodic advertising
+ *        without changing the data.
+ *
+ * This sends a HCI command with operation set to "unchanged data" which causes
+ * the controller to update the ADI field (DID) in the periodic advertising PDU
+ * without modifying the advertising data payload.
+ *
+ * @kconfig_dep{CONFIG_BT_PER_ADV}
+ *
+ * @note The advertising set must have periodic advertising started
+ *       (via @ref bt_le_per_adv_start), must contain data, and ADI inclusion
+ *       must have been enabled via @ref BT_LE_PER_ADV_OPT_INCLUDE_ADI
+ *       before calling this function.
+ *
+ * @param adv       Advertising set object.
+ *
+ * @return 0 on success, negative errno value on failure.
+ */
+int bt_le_per_adv_update_did(const struct bt_le_ext_adv *adv);
+
+/**
  * @brief Parameters for setting data for a specific periodic advertising with response subevent.
  *
  * @details This struct provides the necessary information to set the data for a specific subevent

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1831,6 +1831,41 @@ int bt_le_per_adv_set_data(const struct bt_le_ext_adv *adv,
 	return hci_set_per_adv_data(adv, ad, ad_len);
 }
 
+int bt_le_per_adv_update_did(const struct bt_le_ext_adv *adv)
+{
+	struct bt_hci_cp_le_set_per_adv_data *cp;
+	struct net_buf *buf;
+
+	if (!BT_FEAT_LE_PER_ADV_ADI_SUPP(bt_dev.le.features)) {
+		return -ENOTSUP;
+	}
+
+	if (adv == NULL) {
+		return -EINVAL;
+	}
+
+	if (!atomic_test_bit(adv->flags, BT_PER_ADV_ENABLED)) {
+		return -EINVAL;
+	}
+
+	if (!atomic_test_bit(adv->flags, BT_PER_ADV_INCLUDE_ADI)) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_alloc(K_FOREVER);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	(void)memset(cp, 0, sizeof(*cp));
+
+	cp->handle = adv->handle;
+	cp->op = BT_HCI_LE_EXT_ADV_OP_UNCHANGED_DATA;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_PER_ADV_DATA, buf, NULL);
+}
+
 int bt_le_per_adv_set_subevent_data(const struct bt_le_ext_adv *adv, uint8_t num_subevents,
 				    const struct bt_le_per_adv_subevent_data_params *params)
 {

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -2934,6 +2934,28 @@ static int cmd_per_adv_data(const struct shell *sh, size_t argc,
 
 	return 0;
 }
+
+static int cmd_per_adv_update_did(const struct shell *sh, size_t argc, char *argv[])
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	const struct bt_le_ext_adv *adv = adv_sets[selected_adv];
+	int err;
+
+	if (adv == NULL) {
+		shell_error(sh, "No extended advertisement set selected");
+		return -EINVAL;
+	}
+
+	err = bt_le_per_adv_update_did(adv);
+	if (err != 0) {
+		shell_error(sh, "Failed to update periodic advertising DID (%d)", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
 #endif /* CONFIG_BT_PER_ADV */
 #endif /* CONFIG_BT_EXT_ADV */
 #endif /* CONFIG_BT_BROADCASTER */
@@ -5413,6 +5435,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 		      "[<interval-min> [<interval-max> [tx_power]]]",
 		      cmd_per_adv_param, 1, 3),
 	SHELL_CMD_ARG(per-adv-data, NULL, "[data]", cmd_per_adv_data, 1, 1),
+	SHELL_CMD_ARG(per-adv-update-did, NULL, "Update periodic advertising DID",
+		     cmd_per_adv_update_did, 1, 0),
 #endif /* CONFIG_BT_PER_ADV */
 #endif /* CONFIG_BT_EXT_ADV */
 #endif /* CONFIG_BT_BROADCASTER */

--- a/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
@@ -362,6 +362,49 @@ static void main_per_adv_long_data_advertiser(void)
 	TEST_PASS("Periodic long data advertiser passed");
 }
 
+static void main_per_adv_update_did(void)
+{
+	struct bt_le_ext_adv *per_adv;
+	int err;
+
+	common_init();
+
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, NULL, &per_adv);
+	if (err != 0) {
+		TEST_FAIL("Failed to create advertising set: %d", err);
+		return;
+	}
+
+	err = bt_le_per_adv_set_param(per_adv,
+		BT_LE_PER_ADV_PARAM(BT_GAP_PER_ADV_SLOW_INT_MIN,
+				    BT_GAP_PER_ADV_SLOW_INT_MAX,
+				    BT_LE_PER_ADV_OPT_INCLUDE_ADI));
+	if (err != 0) {
+		TEST_FAIL("Failed to set periodic advertising parameters: %d", err);
+		return;
+	}
+
+	set_per_adv_data(per_adv);
+	start_per_adv_set(per_adv);
+	start_ext_adv_set(per_adv);
+
+	err = bt_le_per_adv_update_did(per_adv);
+	if (err != 0) {
+		TEST_FAIL("bt_le_per_adv_update_did failed: %d", err);
+		return;
+	}
+
+	k_sleep(K_SECONDS(2));
+
+	stop_per_adv_set(per_adv);
+	stop_ext_adv_set(per_adv);
+
+	delete_adv_set(per_adv);
+	per_adv = NULL;
+
+	TEST_PASS("Periodic advertising update DID passed");
+}
+
 static const struct bst_test_instance per_adv_advertiser[] = {
 	{
 		.test_id = "per_adv_advertiser",
@@ -394,6 +437,12 @@ static const struct bst_test_instance per_adv_advertiser[] = {
 		.test_descr = "Periodic advertising test with a longer data length. "
 			      "To test the reassembly of large data packets",
 		.test_main_f = main_per_adv_long_data_advertiser
+	},
+	{
+		.test_id = "per_adv_update_did",
+		.test_descr = "Periodic advertising DID update test. "
+			      "Verifies bt_le_per_adv_update_did returns success.",
+		.test_main_f = main_per_adv_update_did
 	},
 	BSTEST_END_MARKER
 };

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_update_did.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_update_did.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Xiaomi Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Periodic advertising DID update test: verifies that
+# bt_le_per_adv_update_did() succeeds when periodic advertising is active
+# with ADI enabled and data set.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+simulation_id="${BOARD_TS}_per_adv_update_did"
+verbosity_level=2
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_adv_periodic_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -RealEncryption=0 \
+  -testid=per_adv_update_did -rs=23
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=1 -sim_length=10e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
This patch adds `bt_le_per_adv_update_did()` which uses the HCI "Unchanged Data" operation (op 0x04) to instruct the controller to update only the ADI field. This allows upper-layer services to signal freshness to scanners (e.g., as a heartbeat) without maintaining a copy of the advertising data.

**Changes:**
New public API `bt_le_per_adv_update_did()` in `bluetooth.h`
Implementation in `adv.c`
Shell command `per-adv-update-did` for testing
**Testing:**
Built for qemu_x86 with tests/bluetooth/shell
End-to-end verified with a BT 5.0+ USB dongle via btproxy: periodic advertising started, per-adv-update-did sent HCI command with op=0x04 len=0, controller returned success (status 0x00)