### PR TITLE
net: wifi: shell: don't reject iface by NM role in get_iface

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -161,12 +161,14 @@ static struct net_if *get_iface(enum iface_type type, int argc, char *argv[])
 			return NULL;
 		}
 
-		/* If iface nm wifi type match input type */
-		if ((type == IFACE_TYPE_STA && !wifi_nm_iface_is_sta(iface)) ||
-			(type == IFACE_TYPE_SAP && !wifi_nm_iface_is_sap(iface))) {
-			LOG_ERR("Interface %d type does not match %d", resolved_iface_index, type);
-			return NULL;
-		}
+		/*
+		 * Don't reject the interface based on its current NM role. A
+		 * single VIF moves between STA and SoftAP at runtime, so the
+		 * stored role only reflects what the interface is doing now,
+		 * not what it is allowed to do. Matching against it here breaks
+		 * a STA->SoftAP switch on single-VIF parts. Whether the role
+		 * change is possible is decided by the driver/supplicant.
+		 */
 	}
 #endif
 


### PR DESCRIPTION
  Commit bf31fab42982 ("net: wifi: shell: Add check for iface type when
  get iface") made get_iface() reject a user supplied "-i" interface when
  its NM role did not match the requested STA/SoftAP type.
  
  That check is wrong for single-VIF parts. There the same netdev serves
  STA and SoftAP, switching role at runtime, so the NM role only tells us
  what the interface is doing now, not what it is allowed to do. Matching
  against it rejects a valid "wifi ap enable -i <sta>" before the role
  switch can even happen.
  
  Drop the role match and keep only the check that the interface is a
  managed Wi-Fi interface. Whether a STA->SoftAP switch is possible is up
  to the driver/supplicant, which already rejects unsupported requests.
  Default (no "-i") selection still picks the right netdev through
  net_if_get_wifi_sta()/sap().