### PR TITLE
scripts: gen_relocate_app: fix for LLEXT heap sections

### DIFF
--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -56,6 +56,14 @@ from elftools.elf.sections import SymbolTableSection
 
 MemoryRegion = NewType('MemoryRegion', str)
 
+LLEXT_HEAP_SECTIONS = (
+    ".llext_heap",
+    ".llext_ext_heap",
+    ".llext_data_heap",
+    ".llext_instr_heap",
+    ".llext_metadata_heap",
+)
+
 
 class SectionKind(Enum):
     TEXT = "text"
@@ -86,7 +94,7 @@ class SectionKind(Enum):
             return cls.DATA
         elif ".bss." in name:
             return cls.BSS
-        elif ".noinit." in name:
+        elif ".noinit." in name or name in LLEXT_HEAP_SECTIONS:
             return cls.NOINIT
         elif ".literal." in name:
             return cls.LITERAL


### PR DESCRIPTION
Since #104918, heaps used by LLEXT are placed in dedicated sections that are no longer named with a ".noinit." prefix. This causes the gen_relocate_app.py script to fail to recognize these as usable for relocation, so the CMake function zephyr_code_relocate() cannot be used on those.

This change adds the LLEXT heap sections to the list of sections that are categorized by that script as NOINIT, ensuring they are available for the relocation process.