### PR TITLE
west: runners: openocd: Use POSIX-style paths for log files

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -131,7 +131,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         self.gdb_init = gdb_init
         self.load_arg = ['-ex', 'load'] if load else []
         self.target_handle = target_handle
-        self.log_file = log_file if log_file else str(Path(self.cfg.build_dir, 'openocd.log'))
+        self.log_file = log_file if log_file else Path(self.cfg.build_dir, 'openocd.log').as_posix()
         self.rtt_port = rtt_port
         self.rtt_server = rtt_server
 


### PR DESCRIPTION
OpenOCD cannot handle Windows-style backslash paths, so switch to POSIX-style paths for log file handling.,

```
runners.openocd: INFO: OpenOCD log file: C:\Proj\Zephyr\zephyrproject\zephyr\build\openocd.log
runners.openocd: INFO: Flashing file: C:/Proj/Zephyr/zephyrproject/zephyr/build/zephyr/zephyr.hex
Open On-Chip Debugger 0.12.0-g91bd278 (2026-03-25-02:08)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Error: failed to open output log 'C:ProjZephyrzephyrprojectzephyuildopenocd.log'
```

With the fix enabled:
```
runners.openocd: INFO: OpenOCD log file: C:/Proj/Zephyr/zephyrproject/zephyr/build/openocd.log
runners.openocd: INFO: Flashing file: C:/Proj/Zephyr/zephyrproject/zephyr/build/zephyr/zephyr.hex
Open On-Chip Debugger 0.12.0-g91bd278 (2026-03-25-02:08)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html

(.venv) PS C:\Proj\Zephyr\zephyrproject\zephyr> cat .\build\openocd.log
Info : Hardware thread awareness created
Info : CMSIS-DAP: SWD supported
Info : CMSIS-DAP: Atomic commands supported
Info : CMSIS-DAP: Test domain timer supported
...
wrote 24576 bytes from file C:/Proj/Zephyr/zephyrproject/zephyr/build/zephyr/zephyr.hex in 3.926682s (6.112 KiB/s)
shutdown command invoked
```