### PR TITLE
arch: xtensa: Add rsync to arch_cpu_irqs_are_enabled()

### DIFF
--- a/include/zephyr/arch/xtensa/irq.h
+++ b/include/zephyr/arch/xtensa/irq.h
@@ -283,7 +283,12 @@ static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
 {
 	unsigned int ps;
 
-	__asm__ volatile("rsr.ps %0" : "=r" (ps));
+	/*
+	 * Force an 'rsync' before reading PS. This ensures that we get the
+	 * current value of PS and not a stale value.
+	 */
+
+	__asm__ volatile("rsync; rsr.ps %0" : "=r" (ps));
 	return (ps & 0xf) == 0; /* INTLEVEL field */
 }
 


### PR DESCRIPTION
Before reading PS in arch_cpu_irqs_are_enabled(), issue an 'rsync' to ensure the current interrupt level is read. It was found that on at least the PTL and NVL simulators that absence of this 'rsync' was leading to occasional erroneous results in z_smp_cpu_mobile().