### PR TITLE
MAX32: Non-default JLink reset type setup

### DIFF
--- a/boards/adi/apard32690/board.cmake
+++ b/boards/adi/apard32690/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=MAX32690" "--reset-after-load")
+board_runner_args(jlink "--device=MAX32690" "--reset-after-load" "--reset-type=12")
 
 # Force MAX32 openocd configuration to use M4 core, since RV32 debug pins
 # aren't exposed

--- a/boards/adi/max32666evkit/board.cmake
+++ b/boards/adi/max32666evkit/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=MAX32666" "--reset-after-load")
+board_runner_args(jlink "--device=MAX32666" "--reset-after-load" "--reset-type=12")
 
 include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/adi/max32666fthr/board.cmake
+++ b/boards/adi/max32666fthr/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=MAX32666" "--reset-after-load")
+board_runner_args(jlink "--device=MAX32666" "--reset-after-load" "--reset-type=12")
 
 include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/adi/max32690evkit/board.cmake
+++ b/boards/adi/max32690evkit/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=MAX32690" "--reset-after-load")
+board_runner_args(jlink "--device=MAX32690" "--reset-after-load" "--reset-type=12")
 
 include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/adi/max32690fthr/board.cmake
+++ b/boards/adi/max32690fthr/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=MAX32690" "--reset-after-load")
+board_runner_args(jlink "--device=MAX32690" "--reset-after-load" "--reset-type=12")
 
 include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/adi/max78002evkit/board.cmake
+++ b/boards/adi/max78002evkit/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=MAX78002" "--reset-after-load")
+board_runner_args(jlink "--device=MAX78002" "--reset-after-load" "--reset-type=12")
 
 include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/soc/adi/max32/Kconfig
+++ b/soc/adi/max32/Kconfig
@@ -45,6 +45,16 @@ config SOC_FAMILY_MAX32_RV32
 
 if SOC_FAMILY_MAX32
 
+config SOC_FAMILY_MAX32_HALT_AFTER_BOOTLOADER_SUPPORT
+	bool "Halt after bootloader integration for JLink"
+	default y if !TRUSTED_EXECUTION_NONSECURE
+	select SOC_EARLY_RESET_HOOK
+	depends on SOC_FAMILY_MAX32_M4 || SOC_FAMILY_MAX32_M33
+	help
+	  To support properly halting after a reset when using JLink to flash
+	  the MAX32 SoC, inject the small dummy read into our early reset
+	  code to trigger the set hardware breakpoint
+
 config MAX32_ON_ENTER_CPU_IDLE_HOOK
 	bool "CPU idle hook enable"
 	default y if !PM

--- a/soc/adi/max32/soc.c
+++ b/soc/adi/max32/soc.c
@@ -70,6 +70,20 @@ static ALWAYS_INLINE void soc_max32_secondary_delay(int n)
 
 #endif
 
+#if defined(CONFIG_SOC_FAMILY_MAX32_HALT_AFTER_BOOTLOADER_SUPPORT)
+
+void soc_early_reset_hook(void)
+{
+	__asm__ volatile (
+		"mov r0, 8\n\t"
+		"ldr r0, [r0]\n\t"
+		"nop\n\t"
+		"nop\n\t"
+	);
+}
+
+#endif
+
 /**
  * @brief Perform basic hardware initialization at boot.
  *


### PR DESCRIPTION
On JLink, several MAX32 parts do not properly automatically halt when reset with the default reset type. This is visible from `JLinkExe`, e.g. with the MAX32690:

```
J-Link>R
Reset delay: 0 ms
Reset type: NORMAL (https://kb.segger.com/J-Link_Reset_Strategies)
Reset: Halt core after reset via DEMCR.VC_CORERESET.
Reset: Reset device via AIRCR.SYSRESETREQ.
Core did not halt after reset, halting it manually.
```

This PR adds an early reset hook that supports ResetType `12` for cortex-m: https://kb.segger.com/J-Link_Reset_Strategies#Type_12:_reset_and_halt_following_bootloader_execution

And then sets that reset type in the relevant `board.cmake` files.

Without this, in `main` when using twister, you will see extra start messages, etc. from the previously flashed test executing briefly before the fallback halt:

```
west twister --device-testing --device-serial /dev/tty.usbserial-D30GP9XI -p max78002evkit/max78002/m4 -T tests/kernel --device-flash-timeout=30  --west-runner jlink --west-flash -n
Keeping artifacts untouched
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-4933-g3f9e3aa4ca68
INFO    - Using 'zephyr/gnu' toolchain variant.
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.38 seconds

Device testing on:

| Platform                  | ID   | Serial device               |
|---------------------------|------|-----------------------------|
| max78002evkit/max78002/m4 |      | /dev/tty.usbserial-D30GP9XI |

INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
WARNING - TS_START: already STARTED 'fatal_exception':{'count': 1, 'repeat': 0}, failed:    0, error:    0
WARNING - TC_START: already STARTED case 'kernel.common.stack_protection_arm_fpu_sharing.fatal_exception.fatal':{'count': 1}
WARNING - TS_START: already STARTED 'fatal_exception':{'count': 2, 'repeat': 1}
WARNING - TC_START: already STARTED case 'kernel.common.stack_protection_arm_fpu_sharing.fatal_exception.fatal':{'count': 2}
WARNING - TS_START: already STARTED 'fatal_exception':{'count': 3, 'repeat': 2}
WARNING - TC_START: already STARTED case 'kernel.common.stack_protection_arm_fpu_sharing.fatal_exception.fatal':{'count': 3}
WARNING - TS_START: already STARTED 'fatal_exception':{'count': 1, 'repeat': 0}, failed:    0, error:    0
WARNING - TC_START: already STARTED case 'kernel.events.fatal':{'count': 1}
WARNING - TS_START: already STARTED 'fatal_exception':{'count': 2, 'repeat': 1}
WARNING - TC_START: already STARTED case 'kernel.events.fatal':{'count': 2}
WARNING - A started status detected in instance max78002evkit/max78002/m4/zephyr/gnu/kernel.events, test case kernel.events.fatal.
WARNING - TS_START: already STARTED 'events_api':{'count': 1, 'repeat': 0}   61, failed:    0, error:    0
WARNING - TC_START: already STARTED case 'kernel.objects.tracking.minimallibc.event_receive':{'count': 1}
WARNING - TS_START: already STARTED 'events_api':{'count': 2, 'repeat': 1}
WARNING - TC_START: already STARTED case 'kernel.objects.tracking.minimallibc.event_receive':{'count': 2}
WARNING - A started status detected in instance max78002evkit/max78002/m4/zephyr/gnu/kernel.objects.tracking.minimallibc, test case kernel.objects.tracking.minimallibc.event_receive.
WARNING - TS_START: already STARTED 'mutex_complex':{'count': 1, 'repeat': 0}61, failed:    0, error:    0
WARNING - TC_START: already STARTED case 'kernel.events.usage.mutex':{'count': 1}
WARNING - TS_START: already STARTED 'mutex_complex':{'count': 2, 'repeat': 1}
WARNING - TC_START: already STARTED case 'kernel.events.usage.mutex':{'count': 2}
WARNING - A started status detected in instance max78002evkit/max78002/m4/zephyr/gnu/kernel.events.usage, test case kernel.events.usage.mutex.
WARNING - TS_START: already STARTED 'sys_events':{'count': 1, 'repeat': 0}   61, failed:    0, error:    0
WARNING - TC_START: already STARTED case 'kernel.fifo.event_receive':{'count': 1}
WARNING - TS_START: already STARTED 'sys_events':{'count': 2, 'repeat': 1}
WARNING - TC_START: already STARTED case 'kernel.fifo.event_receive':{'count': 2}
```

You can work around this with setting `--extra-args CONFIG_BOOT_DELAY=90` for Twister, but properly supporting reset that halts immediately avoids needing this workaround.