### PR TITLE
drivers: gpio: allow drivers without pin_get_config to return -ENOSYS

### DIFF
--- a/drivers/gpio/gpio_handlers.c
+++ b/drivers/gpio/gpio_handlers.c
@@ -21,7 +21,7 @@ static inline int z_vrfy_gpio_pin_get_config(const struct device *port,
 					     gpio_pin_t pin,
 					     gpio_flags_t *flags)
 {
-	K_OOPS(K_SYSCALL_DRIVER_GPIO(port, pin_get_config));
+	K_OOPS(K_SYSCALL_OBJ(port, K_OBJ_DRIVER_GPIO));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(flags, sizeof(gpio_flags_t)));
 
 	return z_impl_gpio_pin_get_config(port, pin, flags);


### PR DESCRIPTION
## Summary

`z_vrfy_gpio_pin_get_config()` currently uses
`K_SYSCALL_DRIVER_GPIO(port, pin_get_config)`, which expands to a check
that `port->api->pin_get_config != NULL` and triggers a `K_OOPS` when
it is not. This defeats the contract documented at
`z_impl_gpio_pin_get_config()` (and at `gpio_pin_get_config()` in
`include/zephyr/drivers/gpio.h`):

```c
int z_impl_gpio_pin_get_config(const struct device *port,
			       gpio_pin_t pin,
			       gpio_flags_t *flags)
{
	const struct gpio_driver_api *api = (const struct gpio_driver_api *)port->api;

	if (api->pin_get_config == NULL)
		return -ENOSYS;
	...
}
```

Under `CONFIG_USERSPACE=y` with `CONFIG_GPIO_GET_CONFIG=y`, a user-mode
call to `gpio_pin_get_config()` on a GPIO driver that does not
implement the optional `pin_get_config` callback K_OOPSes the kernel
instead of returning `-ENOSYS`. Supervisor-mode callers correctly get
`-ENOSYS`, so the behavior is inconsistent depending on the caller.

## Fix

Replace the strict driver-op check with a generic kernel-object check:

```diff
- K_OOPS(K_SYSCALL_DRIVER_GPIO(port, pin_get_config));
+ K_OOPS(K_SYSCALL_OBJ(port, K_OBJ_DRIVER_GPIO));
```

`K_SYSCALL_OBJ` validates that `port` is an initialized GPIO device
object the caller has access to, without requiring any particular API
slot to be populated. Control then reaches `z_impl_gpio_pin_get_config()`,
whose existing `api->pin_get_config == NULL` check returns `-ENOSYS`
exactly as documented, mirroring the supervisor path.

## Notes

Spotted while reviewing #110673 (which implements `pin_get_config` for
the Infineon CAT1 and Cypress PSoC 6 GPIO drivers so the K_OOPS does
not trigger today). Per discussion on that PR with @parthitce, this
verifier fix is filed separately so it can land independently and
benefit any other GPIO driver that does not implement the optional
`pin_get_config` callback.

## Test Coverage

- `tests/drivers/gpio/gpio_basic_api` on `kit_pse84_eval/pse846gps2dbzc4a/m33`
  with `CONFIG_USERSPACE=y` + `CONFIG_GPIO_GET_CONFIG=y` (P15.2↔P15.3
  loopback), with #110673 applied on top: all four suites pass,
  including the `gpio_port` suite that exercises
  `gpio_pin_get_config()` from a user thread.
- Without #110673 applied (driver omits the callback), the same user-mode
  invocation now returns `-ENOSYS` instead of K_OOPSing.
