### PR TITLE
usb: device_next: fix the possible null pointer dereferences

### DIFF
--- a/subsys/usb/device_next/class/bt_hci.c
+++ b/subsys/usb/device_next/class/bt_hci.c
@@ -439,7 +439,12 @@ static int bt_hci_ctd(struct usbd_class_data *const c_data,
 		return 0;
 	}
 
-	if (setup->wLength && (buf == NULL)) {
+	if (setup->wLength == 0) {
+		errno = -ENOTSUP;
+		return 0;
+	}
+
+	if (buf == NULL) {
 		/* Data OUT can be received */
 		return 0;
 	}

--- a/subsys/usb/device_next/class/bt_hci.c
+++ b/subsys/usb/device_next/class/bt_hci.c
@@ -437,7 +437,11 @@ static int bt_hci_ctd(struct usbd_class_data *const c_data,
 		return -ENOTSUP;
 	}
 
-	if (setup->wLength && (buf == NULL)) {
+	if (setup->wLength == 0) {
+		return -ENOTSUP;
+	}
+
+	if (buf == NULL) {
 		/* Data OUT can be received */
 		return 0;
 	}

--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -236,7 +236,12 @@ static int lb_control_to_dev(struct usbd_class_data *c_data,
 		return 0;
 	}
 
-	if (setup->wLength && (buf == NULL)) {
+	if (setup->wLength == 0) {
+		errno = -ENOTSUP;
+		return 0;
+	}
+
+	if (buf == NULL) {
 		/* Data OUT can be received */
 		return 0;
 	}

--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -238,7 +238,11 @@ static int lb_control_to_dev(struct usbd_class_data *c_data,
 		return -ENOTSUP;
 	}
 
-	if (setup->wLength && (buf == NULL)) {
+	if (setup->wLength == 0) {
+		return -ENOTSUP;
+	}
+
+	if (buf == NULL) {
 		/* Data OUT can be received */
 		return 0;
 	}

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -407,13 +407,15 @@ static int usbd_hid_ctd(struct usbd_class_data *const c_data,
 	const struct device *dev = usbd_class_get_private(c_data);
 	int ret = 0;
 
-	if (setup->wLength && (buf == NULL)) {
-		if (setup->bRequest == USB_HID_SET_REPORT) {
-			return verify_set_report(dev, setup);
+	if (setup->bRequest == USB_HID_SET_REPORT) {
+		if (setup->wLength == 0) {
+			errno = -ENOTSUP;
+			return 0;
 		}
 
-		errno = -ENOTSUP;
-		return 0;
+		if (buf == NULL) {
+			return verify_set_report(dev, setup);
+		}
 	}
 
 	switch (setup->bRequest) {

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -402,12 +402,18 @@ static int usbd_hid_ctd(struct usbd_class_data *const c_data,
 	const struct device *dev = usbd_class_get_private(c_data);
 	int ret = 0;
 
-	if (setup->wLength && (buf == NULL)) {
-		if (setup->bRequest == USB_HID_SET_REPORT) {
-			return verify_set_report(dev, setup);
+	if (setup->bRequest == USB_HID_SET_REPORT) {
+		if (setup->wLength == 0) {
+			return -ENOTSUP;
 		}
 
-		return -ENOTSUP;
+		if (buf == NULL) {
+			return verify_set_report(dev, setup);
+		}
+	} else {
+		if (setup->wLength != 0) {
+			return -ENOTSUP;
+		}
 	}
 
 	switch (setup->bRequest) {

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -1076,7 +1076,12 @@ static int uvc_control_to_dev(struct usbd_class_data *const c_data,
 		goto end;
 	}
 
-	if (setup->wLength && (buf == NULL)) {
+	if (setup->wLength == 0) {
+		errno = -ENOTSUP;
+		return 0;
+	}
+
+	if (buf == NULL) {
 		/* Data OUT can be received */
 		return 0;
 	}

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -1087,7 +1087,12 @@ static int uvc_control_to_dev(struct usbd_class_data *const c_data,
 		goto end;
 	}
 
-	if (setup->wLength && (buf == NULL)) {
+	if (setup->wLength == 0) {
+		err = -ENOTSUP;
+		goto end;
+	}
+
+	if (buf == NULL) {
 		/* Data OUT can be received */
 		return 0;
 	}


### PR DESCRIPTION
In the to-device callbacks implementation, explicitly check the wLength value where a data stage is required. The host may submit a control transfer without a data stage. In that case, the buf parameter will always be NULL.