### PR TITLE
arch: kconfig: fix CACHE_LINE_SIZE default value

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -1240,7 +1240,8 @@ config DCACHE_LINE_SIZE
 	depends on !DCACHE_LINE_SIZE_DETECT
 	default $(dt_node_int_prop_int,/cpus/cpu@0,d-cache-line-size) \
 		  if $(dt_node_has_prop,/cpus/cpu@0,d-cache-line-size)
-	default 0
+	default 64 if 64BIT
+	default 32
 	help
 	  Size in bytes of a CPU d-cache line.
 
@@ -1266,7 +1267,8 @@ config ICACHE_LINE_SIZE
 	depends on !ICACHE_LINE_SIZE_DETECT
 	default $(dt_node_int_prop_int,/cpus/cpu@0,i-cache-line-size) \
 		  if $(dt_node_has_prop,/cpus/cpu@0,i-cache-line-size)
-	default 0
+	default 64 if 64BIT
+	default 32
 	help
 	  Size in bytes of a CPU i-cache line.
 


### PR DESCRIPTION
Instead of defaulting to 0 in the absence of a devicetree value, set cache line size to the arch bit width which is a good proxy for cache line size, and it's safer to use in code.
This default will also eliminate the need for many redundant checks across the tree of CACHE_LINE_SIZE's value.