### PR TITLE
samples: blinky: fail early when led0 alias is missing

### DIFF
--- a/samples/basic/blinky/CMakeLists.txt
+++ b/samples/basic/blinky/CMakeLists.txt
@@ -4,4 +4,23 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(blinky)
 
+# Resolve required led0 alias
+dt_alias(led0_path PROPERTY "led0")
+if(NOT DEFINED led0_path)
+  message(FATAL_ERROR
+    "\n"
+    "Blinky requires a devicetree `led0` alias. Add an overlay;\n"
+    "See `samples/basic/blinky/README.rst` (Adding board support).\n"
+  )
+endif()
+
+# Check if alias node is enabled
+dt_node_has_status(led0_ok PATH "${led0_path}" STATUS okay)
+if(NOT led0_ok)
+  message(FATAL_ERROR
+    "\n"
+    "Blinky requires the `led0` node to have status \"okay\".\n"
+  )
+endif()
+
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/blinky/CMakeLists.txt
+++ b/samples/basic/blinky/CMakeLists.txt
@@ -4,4 +4,26 @@ cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(blinky)
 
+# Resolve required led0 alias
+dt_alias(led0_path PROPERTY "led0")
+if(NOT DEFINED led0_path)
+  message(FATAL_ERROR
+    "\n"
+    "Blinky requires a devicetree 'led0' alias, which this board does not define.\n"
+    "Define it in the board devicetree or in an overlay. See the sample\n"
+    "documentation, section 'Adding board support'.\n"
+  )
+endif()
+
+# Check if led0 alias node is enabled
+dt_node_has_status(led0_ok PATH "${led0_path}" STATUS okay)
+if(NOT led0_ok)
+  message(FATAL_ERROR
+    "\n"
+    "The node behind the devicetree 'led0' alias, ${led0_path}, is not enabled.\n"
+    "Set its status to \"okay\" in an overlay. See the sample documentation,\n"
+    "section 'Adding board support'.\n"
+  )
+endif()
+
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -14,9 +14,10 @@
 /* The devicetree node identifier for the "led0" alias. */
 #define LED0_NODE DT_ALIAS(led0)
 
-/*
- * A build error on this line means your board is unsupported.
- * See the sample documentation for information on how to fix this.
+/* A missing or disabled "led0" alias is rejected at configuration time.
+ * A build error on this line means the alias resolves to a node without
+ * a usable "gpios" property. See the sample documentation for information
+ * on how to fix this.
  */
 static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
 


### PR DESCRIPTION
The `sample/basic/blinky` is often used by Zephyr newcomers, who are sometimes trying to build using a board without the actual LED assembled. Currently, the build fails on the missing devicetree symbol, which is difficult to decode for those with limited knowledge of the system - the usual users of this sample - judging by the number of questions we get on our public forums.

```
/home/zephyrproject/zephyr/include/zephyr/device.h:102:41: error: '__device_dts_ord_DT_N_ALIAS_led0_P_gpios_IDX_0_PH_ORD' undeclared here (not in a function)
  102 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)
      |                                         ^~~~~~~~~
/home/zephyrproject/zephyr/include/zephyr/toolchain/common.h:188:26: note: in definition of macro '_DO_CONCAT'
  188 | #define _DO_CONCAT(x, y) x ## y
      |                          ^
/home/zephyrproject/zephyr/include/zephyr/device.h:102:33: note: in expansion of macro '_CONCAT'
  102 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)
      |                                 ^~~~~~~
```

With that said, failing early at the configuration phase when we already know there is no `led0` node available in the system and producing a comprehensible message to the user could help such users to move on with their first steps.