### PR TITLE
drivers: nxp: fix ENET QoS PTP RX timestamp races

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(eth_nxp_enet_qos_mac, CONFIG_ETHERNET_LOG_LEVEL);
 
 #include <zephyr/net/phy.h>
 #include <zephyr/kernel/thread_stack.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/sys/clock.h>
 
 #if defined(CONFIG_ETH_NXP_ENET_QOS_MAC_UNIQUE_MAC_ADDRESS)
@@ -33,6 +34,36 @@ BUILD_ASSERT((ENET_QOS_RX_BUFFER_SIZE * NUM_RX_BUFDESC) >= ENET_QOS_MAX_NORMAL_F
 
 static const uint32_t rx_desc_refresh_flags =
 	OWN_FLAG | RX_INTERRUPT_ON_COMPLETE_FLAG | BUF1_ADDR_VALID_FLAG;
+
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+#define RX_TIMESTAMP_CONTEXT_RETRIES        10U
+#define RX_TIMESTAMP_CONTEXT_RETRY_DELAY_US 1U
+
+static bool rx_timestamp_descriptors_ready(volatile union nxp_enet_qos_rx_desc *desc,
+					   volatile union nxp_enet_qos_rx_desc *ctx_desc)
+{
+	for (uint32_t retry = 0; retry <= RX_TIMESTAMP_CONTEXT_RETRIES; retry++) {
+		uint32_t context_status3 = ctx_desc->write.control3;
+
+		if (!(context_status3 & OWN_FLAG) &&
+		    (context_status3 & RECEIVE_CONTEXT_DESCRIPTOR_FLAG)) {
+			/* CTXT ownership transfer completes both descriptor writebacks. */
+			barrier_dmem_fence_full();
+
+			if ((desc->write.control3 & RX_STATUS1_VALID_FLAG) &&
+			    (desc->write.control1 & RX_TIMESTAMP_AVAILABLE_FLAG)) {
+				return true;
+			}
+		}
+
+		if (retry < RX_TIMESTAMP_CONTEXT_RETRIES) {
+			k_busy_wait(RX_TIMESTAMP_CONTEXT_RETRY_DELAY_US);
+		}
+	}
+
+	return false;
+}
+#endif
 
 K_THREAD_STACK_DEFINE(enet_qos_rx_stack, CONFIG_ETH_NXP_ENET_QOS_RX_THREAD_STACK_SIZE);
 static struct k_work_q rx_work_queue;
@@ -401,19 +432,16 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 			/*
 			 * When PTP timestamping is enabled the hardware appends a
 			 * context descriptor (RDES3 bit 30 = CTXT) immediately after
-			 * the last regular descriptor.  Peek at that slot; if it is
-			 * software-owned and carries the CTXT flag, extract the RX
-			 * timestamp (RDES0 = nanoseconds, RDES1 = seconds) and
-			 * recycle the slot as a regular RX descriptor.
+			 * the last regular descriptor.  The receive interrupt can
+			 * arrive before DMA finishes both descriptor writebacks, so
+			 * wait briefly for them before extracting the RX timestamp
+			 * (RDES0 = nanoseconds, RDES1 = seconds).
 			 */
 			{
 				uint32_t ctx_idx = rx_data->next_desc_idx;
 				volatile union nxp_enet_qos_rx_desc *ctx_desc = &desc_arr[ctx_idx];
 
-				if ((desc->write.control3 & RX_STATUS1_VALID_FLAG) &&
-				    (desc->write.control1 & RX_TIMESTAMP_AVAILABLE_FLAG) &&
-				    !(ctx_desc->write.control3 & OWN_FLAG) &&
-				    (ctx_desc->write.control3 & RECEIVE_CONTEXT_DESCRIPTOR_FLAG)) {
+				if (rx_timestamp_descriptors_ready(desc, ctx_desc)) {
 					pkt->timestamp.nanosecond = ctx_desc->write.vlan_tag;
 					pkt->timestamp.second = ctx_desc->write.control1;
 					net_pkt_set_rx_timestamping(pkt, true);

--- a/drivers/ptp_clock/ptp_clock_nxp_enet_qos.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet_qos.c
@@ -225,6 +225,9 @@ static int ptp_clock_nxp_enet_qos_init(const struct device *dev)
 	while (data->base->MAC_TIMESTAMP_CONTROL & ENET_MAC_TIMESTAMP_CONTROL_TSADDREG_MASK) {
 	}
 
+	/* Allow the timestamp configuration to propagate to the MAC clock domain. */
+	k_busy_wait(10);
+
 	return 0;
 }
 


### PR DESCRIPTION
This PR is part of a series of PTP-related PRs:
- https://github.com/zephyrproject-rtos/zephyr/pull/110580

## Overview

Fix missing PTP RX timestamps in the NXP ENET QoS driver.

The issue was observed on the FRDM-MCXN947 for both IEEE 802.3 and UDP/IPv4 PTP transports when `CONFIG_PTP_DELAY_MECHANISM_P2P=y` was set. PTP event messages were received, but discarded by the PTP stack because no valid hardware RX timestamp was attached:

```
ptp_port: Port 1 drops Sync without valid RX timestamp
ptp_port: Port 1 drops Pdelay_Req without valid RX timestamp
ptp_port: Port 1 drops Pdelay_Resp without valid RX timestamp
```

## Changes

- Add a bounded wait for the DMA-generated RX timestamp context descriptor.
- Use a memory barrier after the DMA transfers ownership of the context descriptor.
- Wait briefly after configuring the MAC timestamp registers so that the configuration can propagate to the MAC clock domain.

## Explanation

The ENET QoS DMA writes the received frame descriptor and its PTP timestamp context descriptor separately. The receive interrupt can be handled before both descriptor writebacks are complete.

Previously, the driver checked the descriptors only once. If the context descriptor was still owned by the DMA, or the timestamp status bits had not yet been written, the packet was passed to the network stack without an RX timestamp. The PTP stack then had to discard the event message.

A bounded polling loop now gives the DMA up to 10 us to finish both writebacks. Once ownership is transferred, a memory barrier ensures that the descriptor contents are visible before the timestamp is read.

UDP/IPv4 timestamping also exposed an initialization timing issue. Although the timestamp addend update had completed, timestamping was not yet reliable immediately afterward. A 10 us settling delay allows the MAC timestamp configuration to take effect before packets are processed.

## Testing

Built the PTP sample for`frdm_mcxn947/mcxn947/cpu0` with `CONFIG_PTP_DELAY_MECHANISM_P2P=y` and tested it on the board with:

- IEEE 802.3 PTP
- UDP/IPv4 PTP
- P2P delay mechanism
- E2E delay mechanism
