### PR TITLE
bluetooth: audio: fix incorrect @retval usage (1/2)

### DIFF
--- a/include/zephyr/bluetooth/audio/ascs.h
+++ b/include/zephyr/bluetooth/audio/ascs.h
@@ -292,7 +292,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp       Object for the ASE operation response. Only used if the return
 	 *                       value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*config)(struct bt_conn *conn, const struct bt_bap_ep *ep, enum bt_audio_dir dir,
 		      const struct bt_audio_codec_cfg *codec_cfg, struct bt_bap_stream **stream,
@@ -312,7 +312,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp       Object for the ASE operation response. Only used if the return
 	 *                       value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*reconfig)(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 			const struct bt_audio_codec_cfg *codec_cfg,
@@ -329,7 +329,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp     Object for the ASE operation response. Only used if the return
 	 *                     value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*qos)(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 		   struct bt_bap_ascs_rsp *rsp);
@@ -345,7 +345,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp         Object for the ASE operation response. Only used if the return
 	 *                         value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*enable)(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 		      struct bt_bap_ascs_rsp *rsp);
@@ -359,7 +359,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*start)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -374,7 +374,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp          Object for the ASE operation response. Only used if the return
 	 *                          value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*metadata)(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 			struct bt_bap_ascs_rsp *rsp);
@@ -388,7 +388,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*disable)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -401,7 +401,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*stop)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -415,7 +415,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*release)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 };
@@ -450,7 +450,7 @@ struct bt_ascs_register_param {
  *
  * @param param Parameters for the service
  *
- * @retval 0 Success.
+ * @retval 0 on success.
  * @retval -EINVAL @p param is NULL or contains invalid values, or bt_gatt_service_register()
  *                failed.
  * @retval -EALREADY ASCS already registered.
@@ -464,8 +464,8 @@ int bt_ascs_register(const struct bt_ascs_register_param *param);
  *
  * This will release all streams and remove the service from the GATT database.
  *
- * @retval 0 Success.
- * @retval -ENOENT if bt_gatt_service_unregister() failed to unregister the service.
+ * @retval 0 on success.
+ * @retval -ENOENT bt_gatt_service_unregister() failed to unregister the service.
  * @retval -EALREADY ASCS already unregistered.
  */
 int bt_ascs_unregister(void);

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -281,8 +281,8 @@ struct bt_audio_codec_cfg {
  * @param user_data User data to be passed to the callback.
  *
  * @retval 0 All entries were parsed.
- * @retval -EINVAL The data is incorrectly encoded
- * @retval -ECANCELED Parsing was prematurely cancelled by the callback
+ * @retval -EINVAL The data is incorrectly encoded.
+ * @retval -ECANCELED Parsing was prematurely cancelled by the callback.
  */
 int bt_audio_data_parse(const uint8_t ltv[], size_t size,
 			bool (*func)(struct bt_data *data, void *user_data), void *user_data);
@@ -298,9 +298,9 @@ int bt_audio_data_parse(const uint8_t ltv[], size_t size,
  * @param[out] data Pointer to the data-pointer to update when item is found.
  *                  Any found data will be little endian.
  *
- * @retval length The length of found @p data (may be 0).
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of found @p data (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_data_get_val(const uint8_t ltv_data[], size_t size, uint8_t type,
 			  const uint8_t **data);
@@ -310,7 +310,7 @@ int bt_audio_data_get_val(const uint8_t ltv_data[], size_t size, uint8_t type,
  *
  * @param chan_allocation The channel allocation
  *
- * @return The number of channels
+ * @return The number of channels.
  */
 uint8_t bt_audio_get_chan_count(enum bt_audio_location chan_allocation);
 
@@ -346,7 +346,7 @@ enum bt_audio_dir {
  *
  * @param freq The assigned numbers frequency to convert.
  *
- * @retval frequency The converted frequency value in Hz.
+ * @return The converted frequency value in Hz on success.
  * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_freq_to_freq_hz(enum bt_audio_codec_cfg_freq freq);
@@ -356,7 +356,7 @@ int bt_audio_codec_cfg_freq_to_freq_hz(enum bt_audio_codec_cfg_freq freq);
  *
  * @param freq_hz The frequency value to convert.
  *
- * @retval frequency The assigned numbers frequency (@ref bt_audio_codec_cfg_freq).
+ * @return The assigned numbers frequency (@ref bt_audio_codec_cfg_freq) on success.
  * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_freq_hz_to_freq(uint32_t freq_hz);
@@ -366,10 +366,10 @@ int bt_audio_codec_cfg_freq_hz_to_freq(uint32_t freq_hz);
  *
  * @param codec_cfg The codec configuration to extract data from.
  *
- * @retval frequency A @ref bt_audio_codec_cfg_freq value
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return A @ref bt_audio_codec_cfg_freq value on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cfg_get_freq(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -379,9 +379,9 @@ int bt_audio_codec_cfg_get_freq(const struct bt_audio_codec_cfg *codec_cfg);
  * @param codec_cfg The codec configuration to set data for.
  * @param freq      The assigned numbers frequency to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_freq(struct bt_audio_codec_cfg *codec_cfg,
 				enum bt_audio_codec_cfg_freq freq);
@@ -391,7 +391,7 @@ int bt_audio_codec_cfg_set_freq(struct bt_audio_codec_cfg *codec_cfg,
  *
  * @param frame_dur The assigned numbers frame duration to convert.
  *
- * @retval duration The converted frame duration value in microseconds.
+ * @return The converted frame duration value in microseconds on success.
  * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_frame_dur_to_frame_dur_us(enum bt_audio_codec_cfg_frame_dur frame_dur);
@@ -401,7 +401,7 @@ int bt_audio_codec_cfg_frame_dur_to_frame_dur_us(enum bt_audio_codec_cfg_frame_d
  *
  * @param frame_dur_us The frame duration in microseconds to convert.
  *
- * @retval duration The assigned numbers frame duration (@ref bt_audio_codec_cfg_frame_dur).
+ * @return The assigned numbers frame duration (@ref bt_audio_codec_cfg_frame_dur) on success.
  * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_frame_dur_us_to_frame_dur(uint32_t frame_dur_us);
@@ -411,10 +411,10 @@ int bt_audio_codec_cfg_frame_dur_us_to_frame_dur(uint32_t frame_dur_us);
  *
  * @param codec_cfg The codec configuration to extract data from.
  *
- * @retval frequency A @ref bt_audio_codec_cfg_frame_dur value
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return A @ref bt_audio_codec_cfg_frame_dur value on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cfg_get_frame_dur(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -424,9 +424,9 @@ int bt_audio_codec_cfg_get_frame_dur(const struct bt_audio_codec_cfg *codec_cfg)
  * @param codec_cfg  The codec configuration to set data for.
  * @param frame_dur  The assigned numbers frame duration to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_frame_dur(struct bt_audio_codec_cfg *codec_cfg,
 				     enum bt_audio_codec_cfg_frame_dur frame_dur);
@@ -446,10 +446,10 @@ int bt_audio_codec_cfg_set_frame_dur(struct bt_audio_codec_cfg *codec_cfg,
  *        @ref BT_AUDIO_LOCATION_MONO_AUDIO if the type is not found when @p codec_cfg.id is @ref
  *        BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval 0 Value is found and stored in the pointer provided
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @retval 0 Value is found and stored in the pointer provided.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cfg_get_chan_allocation(const struct bt_audio_codec_cfg *codec_cfg,
 					   enum bt_audio_location *chan_allocation,
@@ -461,9 +461,9 @@ int bt_audio_codec_cfg_get_chan_allocation(const struct bt_audio_codec_cfg *code
  * @param codec_cfg       The codec configuration to set data for.
  * @param chan_allocation The channel allocation to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_chan_allocation(struct bt_audio_codec_cfg *codec_cfg,
 					   enum bt_audio_location chan_allocation);
@@ -482,10 +482,10 @@ int bt_audio_codec_cfg_set_chan_allocation(struct bt_audio_codec_cfg *codec_cfg,
  *
  * @param codec_cfg The codec configuration to extract data from.
  *
- * @retval frame_length Frame length in octets
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return Frame length in octets on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cfg_get_octets_per_frame(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -495,9 +495,9 @@ int bt_audio_codec_cfg_get_octets_per_frame(const struct bt_audio_codec_cfg *cod
  * @param codec_cfg        The codec configuration to set data for.
  * @param octets_per_frame The octets per codec frame to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_octets_per_frame(struct bt_audio_codec_cfg *codec_cfg,
 					    uint16_t octets_per_frame);
@@ -517,10 +517,10 @@ int bt_audio_codec_cfg_set_octets_per_frame(struct bt_audio_codec_cfg *codec_cfg
  * @param fallback_to_default If true this function will return the default value of 1
  *         if the type is not found when @p codec_cfg.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval frame_blocks_per_sdu The count of codec frame blocks in each SDU.
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return The count of codec frame blocks in each SDU on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg *codec_cfg,
 						bool fallback_to_default);
@@ -531,9 +531,9 @@ int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg 
  * @param codec_cfg    The codec configuration to set data for.
  * @param frame_blocks The frame blocks per SDU to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_frame_blocks_per_sdu(struct bt_audio_codec_cfg *codec_cfg,
 						uint8_t frame_blocks);
@@ -545,9 +545,9 @@ int bt_audio_codec_cfg_set_frame_blocks_per_sdu(struct bt_audio_codec_cfg *codec
  * @param[in] type The type id to look for
  * @param[out] data Pointer to the data-pointer to update when item is found
  *
- * @retval len Length of found @p data (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return Length of found @p data (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
 			       enum bt_audio_codec_cfg_type type, const uint8_t **data);
@@ -560,9 +560,9 @@ int bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
  * @param data       Pointer to the data-pointer to set
  * @param data_len   Length of @p data
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_val(struct bt_audio_codec_cfg *codec_cfg,
 			       enum bt_audio_codec_cfg_type type, const uint8_t *data,
@@ -576,8 +576,8 @@ int bt_audio_codec_cfg_set_val(struct bt_audio_codec_cfg *codec_cfg,
  * @param codec_cfg  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_unset_val(struct bt_audio_codec_cfg *codec_cfg,
 				 enum bt_audio_codec_cfg_type type);
@@ -590,9 +590,9 @@ int bt_audio_codec_cfg_unset_val(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  type      The type id to look for
  * @param[out] data      Pointer to the data-pointer to update when item is found
  *
- * @retval len Length of found @p data (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return Length of found @p data (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_val(const struct bt_audio_codec_cfg *codec_cfg, uint8_t type,
 				    const uint8_t **data);
@@ -605,9 +605,9 @@ int bt_audio_codec_cfg_meta_get_val(const struct bt_audio_codec_cfg *codec_cfg, 
  * @param data       Pointer to the data-pointer to set.
  * @param data_len   Length of @p data.
  *
- * @retval meta_len The @p codec_cfg.meta_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.meta_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_val(struct bt_audio_codec_cfg *codec_cfg,
 				    enum bt_audio_metadata_type type, const uint8_t *data,
@@ -621,8 +621,8 @@ int bt_audio_codec_cfg_meta_set_val(struct bt_audio_codec_cfg *codec_cfg,
  * @param codec_cfg  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval meta_len The of @p codec_cfg.meta_len success
- * @retval -EINVAL Arguments are invalid
+ * @return The @p codec_cfg.meta_len on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_meta_unset_val(struct bt_audio_codec_cfg *codec_cfg,
 				      enum bt_audio_metadata_type type);
@@ -636,10 +636,10 @@ int bt_audio_codec_cfg_meta_unset_val(struct bt_audio_codec_cfg *codec_cfg,
  *        @ref BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED if the type is not found when @p codec_cfg.id is
  *        @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval context The preferred context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The preferred context type on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_pref_context(const struct bt_audio_codec_cfg *codec_cfg,
 					     bool fallback_to_default);
@@ -650,9 +650,9 @@ int bt_audio_codec_cfg_meta_get_pref_context(const struct bt_audio_codec_cfg *co
  * @param codec_cfg The codec configuration to set data for.
  * @param ctx       The preferred context to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_pref_context(struct bt_audio_codec_cfg *codec_cfg,
 					     enum bt_audio_context ctx);
@@ -664,10 +664,10 @@ int bt_audio_codec_cfg_meta_set_pref_context(struct bt_audio_codec_cfg *codec_cf
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval context The stream context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The stream context type on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_stream_context(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -677,9 +677,9 @@ int bt_audio_codec_cfg_meta_get_stream_context(const struct bt_audio_codec_cfg *
  * @param codec_cfg The codec configuration to set data for.
  * @param ctx       The stream context to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_stream_context(struct bt_audio_codec_cfg *codec_cfg,
 					       enum bt_audio_context ctx);
@@ -692,9 +692,9 @@ int bt_audio_codec_cfg_meta_set_stream_context(struct bt_audio_codec_cfg *codec_
  * @param[in]  codec_cfg    The codec data to search in.
  * @param[out] program_info Pointer to the UTF-8 formatted program info.
  *
- * @retval len The length of the @p program_info (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p program_info (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_program_info(const struct bt_audio_codec_cfg *codec_cfg,
 					     const uint8_t **program_info);
@@ -706,9 +706,9 @@ int bt_audio_codec_cfg_meta_get_program_info(const struct bt_audio_codec_cfg *co
  * @param program_info     The program info to set.
  * @param program_info_len The length of @p program_info.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_program_info(struct bt_audio_codec_cfg *codec_cfg,
 					     const uint8_t *program_info, size_t program_info_len);
@@ -721,10 +721,10 @@ int bt_audio_codec_cfg_meta_set_program_info(struct bt_audio_codec_cfg *codec_cf
  * @param[in]  codec_cfg The codec data to search in.
  * @param[out] lang      Pointer to the language bytes (of length BT_AUDIO_LANG_SIZE)
  *
- * @retval 0 Success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_lang(const struct bt_audio_codec_cfg *codec_cfg,
 				     const uint8_t **lang);
@@ -735,9 +735,9 @@ int bt_audio_codec_cfg_meta_get_lang(const struct bt_audio_codec_cfg *codec_cfg,
  * @param codec_cfg   The codec configuration to set data for.
  * @param lang        The 24-bit language to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_lang(struct bt_audio_codec_cfg *codec_cfg,
 				     const uint8_t lang[BT_AUDIO_LANG_SIZE]);
@@ -750,9 +750,9 @@ int bt_audio_codec_cfg_meta_set_lang(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  codec_cfg The codec data to search in.
  * @param[out] ccid_list Pointer to the array containing 8-bit CCIDs.
  *
- * @retval len The length of the @p ccid_list (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p ccid_list (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_ccid_list(const struct bt_audio_codec_cfg *codec_cfg,
 					  const uint8_t **ccid_list);
@@ -764,9 +764,9 @@ int bt_audio_codec_cfg_meta_get_ccid_list(const struct bt_audio_codec_cfg *codec
  * @param ccid_list     The program info to set.
  * @param ccid_list_len The length of @p ccid_list.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_ccid_list(struct bt_audio_codec_cfg *codec_cfg,
 					  const uint8_t *ccid_list, size_t ccid_list_len);
@@ -778,10 +778,10 @@ int bt_audio_codec_cfg_meta_set_ccid_list(struct bt_audio_codec_cfg *codec_cfg,
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval parental_rating The parental rating if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The parental rating on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_parental_rating(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -791,9 +791,9 @@ int bt_audio_codec_cfg_meta_get_parental_rating(const struct bt_audio_codec_cfg 
  * @param codec_cfg       The codec configuration to set data for.
  * @param parental_rating The parental rating to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_parental_rating(struct bt_audio_codec_cfg *codec_cfg,
 						enum bt_audio_parental_rating parental_rating);
@@ -806,9 +806,9 @@ int bt_audio_codec_cfg_meta_set_parental_rating(struct bt_audio_codec_cfg *codec
  * @param[in]  codec_cfg The codec data to search in.
  * @param[out] program_info_uri Pointer to the UTF-8 formatted program info URI.
  *
- * @retval len The length of the @p program_info_uri (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p program_info_uri (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_program_info_uri(const struct bt_audio_codec_cfg *codec_cfg,
 						 const uint8_t **program_info_uri);
@@ -820,9 +820,9 @@ int bt_audio_codec_cfg_meta_get_program_info_uri(const struct bt_audio_codec_cfg
  * @param program_info_uri     The program info URI to set.
  * @param program_info_uri_len The length of @p program_info_uri.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_program_info_uri(struct bt_audio_codec_cfg *codec_cfg,
 						 const uint8_t *program_info_uri,
@@ -835,10 +835,10 @@ int bt_audio_codec_cfg_meta_set_program_info_uri(struct bt_audio_codec_cfg *code
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval context The preferred context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The audio active state on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_audio_active_state(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -848,9 +848,9 @@ int bt_audio_codec_cfg_meta_get_audio_active_state(const struct bt_audio_codec_c
  * @param codec_cfg The codec configuration to set data for.
  * @param state     The audio active state to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_audio_active_state(struct bt_audio_codec_cfg *codec_cfg,
 						   enum bt_audio_active_state state);
@@ -862,9 +862,9 @@ int bt_audio_codec_cfg_meta_set_audio_active_state(struct bt_audio_codec_cfg *co
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval 0 The flag was found
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA The flag was not found
+ * @retval 0 The flag was found.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA The flag was not found.
  */
 int bt_audio_codec_cfg_meta_get_bcast_audio_immediate_rend_flag(
 	const struct bt_audio_codec_cfg *codec_cfg);
@@ -874,9 +874,9 @@ int bt_audio_codec_cfg_meta_get_bcast_audio_immediate_rend_flag(
  *
  * @param codec_cfg The codec configuration to set data for.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_bcast_audio_immediate_rend_flag(
 	struct bt_audio_codec_cfg *codec_cfg);
@@ -888,10 +888,10 @@ int bt_audio_codec_cfg_meta_set_bcast_audio_immediate_rend_flag(
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval value The assisted listening stream value if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The assisted listening stream value on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_assisted_listening_stream(
 	const struct bt_audio_codec_cfg *codec_cfg);
@@ -902,9 +902,9 @@ int bt_audio_codec_cfg_meta_get_assisted_listening_stream(
  * @param codec_cfg The codec configuration to set data for.
  * @param val       The assisted listening stream value to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_assisted_listening_stream(
 	struct bt_audio_codec_cfg *codec_cfg, enum bt_audio_assisted_listening_stream val);
@@ -917,10 +917,10 @@ int bt_audio_codec_cfg_meta_set_assisted_listening_stream(
  * @param[in]  codec_cfg      The codec data to search in.
  * @param[out] broadcast_name Pointer to the UTF-8 formatted broadcast name.
  *
- * @retval length The length of the @p broadcast_name (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG Data found, but Invalid broadcast name
+ * @return The length of the @p broadcast_name (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG Data found, but Invalid broadcast name.
  */
 int bt_audio_codec_cfg_meta_get_broadcast_name(const struct bt_audio_codec_cfg *codec_cfg,
 					       const uint8_t **broadcast_name);
@@ -936,9 +936,9 @@ int bt_audio_codec_cfg_meta_get_broadcast_name(const struct bt_audio_codec_cfg *
  *                           @ref BT_AUDIO_BROADCAST_NAME_LEN_MIN and
  *                           @ref BT_AUDIO_BROADCAST_NAME_LEN_MAX.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_broadcast_name(struct bt_audio_codec_cfg *codec_cfg,
 					       const uint8_t *broadcast_name,
@@ -952,9 +952,9 @@ int bt_audio_codec_cfg_meta_set_broadcast_name(struct bt_audio_codec_cfg *codec_
  * @param[in]  codec_cfg     The codec data to search in.
  * @param[out] extended_meta Pointer to the extended metadata.
  *
- * @retval len The length of the @p extended_meta (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p extended_meta (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_extended(const struct bt_audio_codec_cfg *codec_cfg,
 					 const uint8_t **extended_meta);
@@ -966,9 +966,9 @@ int bt_audio_codec_cfg_meta_get_extended(const struct bt_audio_codec_cfg *codec_
  * @param extended_meta     The extended metadata to set.
  * @param extended_meta_len The length of @p extended_meta.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_extended(struct bt_audio_codec_cfg *codec_cfg,
 					 const uint8_t *extended_meta, size_t extended_meta_len);
@@ -981,9 +981,9 @@ int bt_audio_codec_cfg_meta_set_extended(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  codec_cfg   The codec data to search in.
  * @param[out] vendor_meta Pointer to the vendor specific metadata.
  *
- * @retval len The length of the @p vendor_meta (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p vendor_meta (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_vendor(const struct bt_audio_codec_cfg *codec_cfg,
 				       const uint8_t **vendor_meta);
@@ -995,9 +995,9 @@ int bt_audio_codec_cfg_meta_get_vendor(const struct bt_audio_codec_cfg *codec_cf
  * @param vendor_meta     The vendor specific metadata to set.
  * @param vendor_meta_len The length of @p vendor_meta.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_vendor(struct bt_audio_codec_cfg *codec_cfg,
 				       const uint8_t *vendor_meta, size_t vendor_meta_len);
@@ -1020,9 +1020,9 @@ int bt_audio_codec_cfg_meta_set_vendor(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  type The type id to look for
  * @param[out] data Pointer to the data-pointer to update when item is found
  *
- * @retval len Length of found @p data (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return Length of found @p data (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
 			       enum bt_audio_codec_cap_type type, const uint8_t **data);
@@ -1035,9 +1035,9 @@ int bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
  * @param data       Pointer to the data-pointer to set
  * @param data_len   Length of @p data
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_val(struct bt_audio_codec_cap *codec_cap,
 			       enum bt_audio_codec_cap_type type, const uint8_t *data,
@@ -1051,8 +1051,8 @@ int bt_audio_codec_cap_set_val(struct bt_audio_codec_cap *codec_cap,
  * @param codec_cap  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cap_unset_val(struct bt_audio_codec_cap *codec_cap,
 				 enum bt_audio_codec_cap_type type);
@@ -1062,11 +1062,11 @@ int bt_audio_codec_cap_unset_val(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec capabilities to extract data from.
  *
- * @retval frequencies Bitfield of supported frequencies (@ref bt_audio_codec_cap_freq) if 0 or
- *                     positive
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return Bitfield of supported frequencies (@ref bt_audio_codec_cap_freq) on success
+ *         (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cap_get_freq(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1076,9 +1076,9 @@ int bt_audio_codec_cap_get_freq(const struct bt_audio_codec_cap *codec_cap);
  * @param codec_cap The codec capabilities to set data for.
  * @param freq      The supported frequencies to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_freq(struct bt_audio_codec_cap *codec_cap,
 				enum bt_audio_codec_cap_freq freq);
@@ -1088,10 +1088,10 @@ int bt_audio_codec_cap_set_freq(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec capabilities to extract data from.
  *
- * @retval durations Bitfield of supported frame durations if 0 or positive
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return Bitfield of supported frame durations on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cap_get_frame_dur(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1101,9 +1101,9 @@ int bt_audio_codec_cap_get_frame_dur(const struct bt_audio_codec_cap *codec_cap)
  * @param codec_cap The codec capabilities to set data for.
  * @param frame_dur The frame duration to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_frame_dur(struct bt_audio_codec_cap *codec_cap,
 				     enum bt_audio_codec_cap_frame_dur frame_dur);
@@ -1115,10 +1115,10 @@ int bt_audio_codec_cap_set_frame_dur(struct bt_audio_codec_cap *codec_cap,
  * @param fallback_to_default If true this function will provide the default value of 1
  *        if the type is not found when @p codec_cap.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval channel_counts Number of supported channel counts if 0 or positive
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return Number of supported channel counts on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cap_get_supported_audio_chan_counts(const struct bt_audio_codec_cap *codec_cap,
 						       bool fallback_to_default);
@@ -1129,9 +1129,9 @@ int bt_audio_codec_cap_get_supported_audio_chan_counts(const struct bt_audio_cod
  * @param codec_cap The codec capabilities to set data for.
  * @param chan_count The channel count frequency to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_supported_audio_chan_counts(
 	struct bt_audio_codec_cap *codec_cap, enum bt_audio_codec_cap_chan_count chan_count);
@@ -1142,10 +1142,10 @@ int bt_audio_codec_cap_set_supported_audio_chan_counts(
  * @param[in]  codec_cap   The codec capabilities to extract data from.
  * @param[out] codec_frame Struct to place the resulting values in
  *
- * @retval 0 Success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cap_get_octets_per_frame(
 	const struct bt_audio_codec_cap *codec_cap,
@@ -1157,9 +1157,9 @@ int bt_audio_codec_cap_get_octets_per_frame(
  * @param codec_cap   The codec capabilities to set data for.
  * @param codec_frame The octets per codec frame to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_octets_per_frame(
 	struct bt_audio_codec_cap *codec_cap,
@@ -1172,10 +1172,10 @@ int bt_audio_codec_cap_set_octets_per_frame(
  * @param fallback_to_default If true this function will provide the default value of 1
  *        if the type is not found when @p codec_cap.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval codec_frames_per_sdu Maximum number of codec frames per SDU supported
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return Maximum number of codec frames per SDU supported on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cap_get_max_codec_frames_per_sdu(const struct bt_audio_codec_cap *codec_cap,
 						    bool fallback_to_default);
@@ -1186,9 +1186,9 @@ int bt_audio_codec_cap_get_max_codec_frames_per_sdu(const struct bt_audio_codec_
  * @param codec_cap            The codec capabilities to set data for.
  * @param codec_frames_per_sdu The maximum codec frames per SDU to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_max_codec_frames_per_sdu(struct bt_audio_codec_cap *codec_cap,
 						    uint8_t codec_frames_per_sdu);
@@ -1200,9 +1200,9 @@ int bt_audio_codec_cap_set_max_codec_frames_per_sdu(struct bt_audio_codec_cap *c
  * @param[in]  type      The type id to look for
  * @param[out] data      Pointer to the data-pointer to update when item is found
  *
- * @retval len Length of found @p data (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return Length of found @p data (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_val(const struct bt_audio_codec_cap *codec_cap, uint8_t type,
 				    const uint8_t **data);
@@ -1215,9 +1215,9 @@ int bt_audio_codec_cap_meta_get_val(const struct bt_audio_codec_cap *codec_cap, 
  * @param data       Pointer to the data-pointer to set.
  * @param data_len   Length of @p data.
  *
- * @retval meta_len The @p codec_cap.meta_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.meta_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_val(struct bt_audio_codec_cap *codec_cap,
 				    enum bt_audio_metadata_type type, const uint8_t *data,
@@ -1231,8 +1231,8 @@ int bt_audio_codec_cap_meta_set_val(struct bt_audio_codec_cap *codec_cap,
  * @param codec_cap  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval meta_len The of @p codec_cap.meta_len on success
- * @retval -EINVAL Arguments are invalid
+ * @return The @p codec_cap.meta_len on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cap_meta_unset_val(struct bt_audio_codec_cap *codec_cap,
 				      enum bt_audio_metadata_type type);
@@ -1244,10 +1244,10 @@ int bt_audio_codec_cap_meta_unset_val(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval The preferred context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The preferred context type on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_pref_context(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1257,9 +1257,9 @@ int bt_audio_codec_cap_meta_get_pref_context(const struct bt_audio_codec_cap *co
  * @param codec_cap The codec capability to set data for.
  * @param ctx       The preferred context to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_pref_context(struct bt_audio_codec_cap *codec_cap,
 					     enum bt_audio_context ctx);
@@ -1271,10 +1271,10 @@ int bt_audio_codec_cap_meta_set_pref_context(struct bt_audio_codec_cap *codec_ca
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval context The stream context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The stream context type on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_stream_context(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1284,9 +1284,9 @@ int bt_audio_codec_cap_meta_get_stream_context(const struct bt_audio_codec_cap *
  * @param codec_cap The codec capability to set data for.
  * @param ctx       The stream context to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_stream_context(struct bt_audio_codec_cap *codec_cap,
 					       enum bt_audio_context ctx);
@@ -1299,9 +1299,9 @@ int bt_audio_codec_cap_meta_set_stream_context(struct bt_audio_codec_cap *codec_
  * @param[in]  codec_cap    The codec data to search in.
  * @param[out] program_info Pointer to the UTF-8 formatted program info.
  *
- * @retval len The length of the @p program_info (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p program_info (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_program_info(const struct bt_audio_codec_cap *codec_cap,
 					     const uint8_t **program_info);
@@ -1313,9 +1313,9 @@ int bt_audio_codec_cap_meta_get_program_info(const struct bt_audio_codec_cap *co
  * @param program_info     The program info to set.
  * @param program_info_len The length of @p program_info.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_program_info(struct bt_audio_codec_cap *codec_cap,
 					     const uint8_t *program_info, size_t program_info_len);
@@ -1328,10 +1328,10 @@ int bt_audio_codec_cap_meta_set_program_info(struct bt_audio_codec_cap *codec_ca
  * @param[in]  codec_cap The codec data to search in.
  * @param[out] lang      Pointer to the language bytes (of length BT_AUDIO_LANG_SIZE)
  *
- * @retval 0 Success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_lang(const struct bt_audio_codec_cap *codec_cap,
 				     const uint8_t **lang);
@@ -1342,9 +1342,9 @@ int bt_audio_codec_cap_meta_get_lang(const struct bt_audio_codec_cap *codec_cap,
  * @param codec_cap   The codec capability to set data for.
  * @param lang        The 24-bit language to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_lang(struct bt_audio_codec_cap *codec_cap,
 				     const uint8_t lang[BT_AUDIO_LANG_SIZE]);
@@ -1357,9 +1357,9 @@ int bt_audio_codec_cap_meta_set_lang(struct bt_audio_codec_cap *codec_cap,
  * @param[in]  codec_cap The codec data to search in.
  * @param[out] ccid_list Pointer to the array containing 8-bit CCIDs.
  *
- * @retval len The length of the @p ccid_list (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p ccid_list (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_ccid_list(const struct bt_audio_codec_cap *codec_cap,
 					  const uint8_t **ccid_list);
@@ -1371,9 +1371,9 @@ int bt_audio_codec_cap_meta_get_ccid_list(const struct bt_audio_codec_cap *codec
  * @param ccid_list     The program info to set.
  * @param ccid_list_len The length of @p ccid_list.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_ccid_list(struct bt_audio_codec_cap *codec_cap,
 					  const uint8_t *ccid_list, size_t ccid_list_len);
@@ -1385,10 +1385,10 @@ int bt_audio_codec_cap_meta_set_ccid_list(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval The parental rating if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The parental rating on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_parental_rating(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1398,9 +1398,9 @@ int bt_audio_codec_cap_meta_get_parental_rating(const struct bt_audio_codec_cap 
  * @param codec_cap       The codec capability to set data for.
  * @param parental_rating The parental rating to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_parental_rating(struct bt_audio_codec_cap *codec_cap,
 						enum bt_audio_parental_rating parental_rating);
@@ -1413,9 +1413,9 @@ int bt_audio_codec_cap_meta_set_parental_rating(struct bt_audio_codec_cap *codec
  * @param[in]  codec_cap        The codec data to search in.
  * @param[out] program_info_uri Pointer to the UTF-8 formatted program info URI.
  *
- * @retval len The length of the @p program_info_uri (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p program_info_uri (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_program_info_uri(const struct bt_audio_codec_cap *codec_cap,
 						 const uint8_t **program_info_uri);
@@ -1427,9 +1427,9 @@ int bt_audio_codec_cap_meta_get_program_info_uri(const struct bt_audio_codec_cap
  * @param program_info_uri     The program info URI to set.
  * @param program_info_uri_len The length of @p program_info_uri.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_program_info_uri(struct bt_audio_codec_cap *codec_cap,
 						 const uint8_t *program_info_uri,
@@ -1442,10 +1442,10 @@ int bt_audio_codec_cap_meta_set_program_info_uri(struct bt_audio_codec_cap *code
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval context The preferred context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The audio active state on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_audio_active_state(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1455,9 +1455,9 @@ int bt_audio_codec_cap_meta_get_audio_active_state(const struct bt_audio_codec_c
  * @param codec_cap The codec capability to set data for.
  * @param state     The audio active state to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_audio_active_state(struct bt_audio_codec_cap *codec_cap,
 						   enum bt_audio_active_state state);
@@ -1469,9 +1469,9 @@ int bt_audio_codec_cap_meta_set_audio_active_state(struct bt_audio_codec_cap *co
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval 0 The flag was found
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA The flag was not found
+ * @retval 0 The flag was found.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA The flag was not found.
  */
 int bt_audio_codec_cap_meta_get_bcast_audio_immediate_rend_flag(
 	const struct bt_audio_codec_cap *codec_cap);
@@ -1481,9 +1481,9 @@ int bt_audio_codec_cap_meta_get_bcast_audio_immediate_rend_flag(
  *
  * @param codec_cap The codec capability to set data for.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_bcast_audio_immediate_rend_flag(
 	struct bt_audio_codec_cap *codec_cap);
@@ -1495,10 +1495,10 @@ int bt_audio_codec_cap_meta_set_bcast_audio_immediate_rend_flag(
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval value The assisted listening stream value if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The assisted listening stream value on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_assisted_listening_stream(
 	const struct bt_audio_codec_cap *codec_cap);
@@ -1509,9 +1509,9 @@ int bt_audio_codec_cap_meta_get_assisted_listening_stream(
  * @param codec_cap The codec capability to set data for.
  * @param val       The assisted listening stream value to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_assisted_listening_stream(
 	struct bt_audio_codec_cap *codec_cap, enum bt_audio_assisted_listening_stream val);
@@ -1524,9 +1524,9 @@ int bt_audio_codec_cap_meta_set_assisted_listening_stream(
  * @param[in]  codec_cap      The codec data to search in.
  * @param[out] broadcast_name Pointer to the UTF-8 formatted broadcast name.
  *
- * @retval length The length of the @p broadcast_name (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p broadcast_name (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_broadcast_name(const struct bt_audio_codec_cap *codec_cap,
 					       const uint8_t **broadcast_name);
@@ -1542,9 +1542,9 @@ int bt_audio_codec_cap_meta_get_broadcast_name(const struct bt_audio_codec_cap *
  *                           @ref BT_AUDIO_BROADCAST_NAME_LEN_MIN and
  *                           @ref BT_AUDIO_BROADCAST_NAME_LEN_MAX.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_broadcast_name(struct bt_audio_codec_cap *codec_cap,
 					       const uint8_t *broadcast_name,
@@ -1557,9 +1557,9 @@ int bt_audio_codec_cap_meta_set_broadcast_name(struct bt_audio_codec_cap *codec_
  * @param[in]  codec_cap     The codec data to search in.
  * @param[out] extended_meta Pointer to the extended metadata.
  *
- * @retval len The length of the @p extended_meta (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p extended_meta (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_extended(const struct bt_audio_codec_cap *codec_cap,
 					 const uint8_t **extended_meta);
@@ -1571,9 +1571,9 @@ int bt_audio_codec_cap_meta_get_extended(const struct bt_audio_codec_cap *codec_
  * @param extended_meta     The extended metadata to set.
  * @param extended_meta_len The length of @p extended_meta.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_extended(struct bt_audio_codec_cap *codec_cap,
 					 const uint8_t *extended_meta, size_t extended_meta_len);
@@ -1586,9 +1586,9 @@ int bt_audio_codec_cap_meta_set_extended(struct bt_audio_codec_cap *codec_cap,
  * @param[in]  codec_cap   The codec data to search in.
  * @param[out] vendor_meta Pointer to the vendor specific metadata.
  *
- * @retval len The length of the @p vendor_meta (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p vendor_meta (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_vendor(const struct bt_audio_codec_cap *codec_cap,
 				       const uint8_t **vendor_meta);
@@ -1600,9 +1600,9 @@ int bt_audio_codec_cap_meta_get_vendor(const struct bt_audio_codec_cap *codec_ca
  * @param vendor_meta     The vendor specific metadata to set.
  * @param vendor_meta_len The length of @p vendor_meta.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_vendor(struct bt_audio_codec_cap *codec_cap,
 				       const uint8_t *vendor_meta, size_t vendor_meta_len);
@@ -1625,7 +1625,7 @@ int bt_audio_codec_cap_meta_set_vendor(struct bt_audio_codec_cap *codec_cap,
  *
  * @param context A single context bit
  *
- * @return String representation of the supplied bit
+ * @return String representation of the supplied bit.
  */
 static inline char *bt_audio_context_bit_to_str(enum bt_audio_context context)
 {
@@ -1666,7 +1666,7 @@ static inline char *bt_audio_context_bit_to_str(enum bt_audio_context context)
  *
  * @param parental_rating The parental rating value
  *
- * @return String representation of the supplied parental rating value
+ * @return String representation of the supplied parental rating value.
  */
 static inline char *bt_audio_parental_rating_to_str(enum bt_audio_parental_rating parental_rating)
 {
@@ -1713,7 +1713,7 @@ static inline char *bt_audio_parental_rating_to_str(enum bt_audio_parental_ratin
  *
  * @param state The active state value
  *
- * @return String representation of the supplied active state value
+ * @return String representation of the supplied active state value.
  */
 static inline char *bt_audio_active_state_to_str(enum bt_audio_active_state state)
 {
@@ -1734,7 +1734,7 @@ static inline char *bt_audio_active_state_to_str(enum bt_audio_active_state stat
  *
  * @param freq A single frequency bit
  *
- * @return String representation of the supplied bit
+ * @return String representation of the supplied bit.
  */
 static inline char *bt_audio_codec_cap_freq_bit_to_str(enum bt_audio_codec_cap_freq freq)
 {
@@ -1777,7 +1777,7 @@ static inline char *bt_audio_codec_cap_freq_bit_to_str(enum bt_audio_codec_cap_f
  *
  * @param frame_dur A single frame duration bit
  *
- * @return String representation of the supplied bit
+ * @return String representation of the supplied bit.
  */
 static inline char *
 bt_audio_codec_cap_frame_dur_bit_to_str(enum bt_audio_codec_cap_frame_dur frame_dur)
@@ -1803,7 +1803,7 @@ bt_audio_codec_cap_frame_dur_bit_to_str(enum bt_audio_codec_cap_frame_dur frame_
  *
  * @param chan_count A single frame channel count bit
  *
- * @return String representation of the supplied bit
+ * @return String representation of the supplied bit.
  */
 static inline char *
 bt_audio_codec_cap_chan_count_bit_to_str(enum bt_audio_codec_cap_chan_count chan_count)
@@ -1837,7 +1837,7 @@ bt_audio_codec_cap_chan_count_bit_to_str(enum bt_audio_codec_cap_chan_count chan
  *
  * @param location A single location bit
  *
- * @return String representation of the supplied bit
+ * @return String representation of the supplied bit.
  */
 static inline char *bt_audio_location_bit_to_str(enum bt_audio_location location)
 {

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -75,7 +75,7 @@ struct bt_cap_unicast_group;
  * @param[out] svc_inst  Pointer to the registered Coordinated Set
  *                       Identification Service.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_acceptor_register(const struct bt_csip_set_member_register_param *param,
 			     struct bt_csip_set_member_svc_inst **svc_inst);
@@ -191,10 +191,10 @@ struct bt_cap_initiator_cb {
  *
  * @param conn Connection to a remote server.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
  */
 int bt_cap_initiator_unicast_discover(struct bt_conn *conn);
 
@@ -251,8 +251,8 @@ void bt_cap_stream_ops_register(struct bt_cap_stream *stream, struct bt_bap_stre
  * @param seq_num  Packet Sequence number. This value shall be incremented for each call to this
  *                 function and at least once per SDU interval for a specific channel.
  *
- * @retval -EINVAL if stream object is NULL
- * @retval Any return value from bt_bap_stream_send()
+ * @retval -EINVAL Stream object is NULL.
+ * @return Any return value from bt_bap_stream_send().
  */
 int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num);
 
@@ -270,8 +270,8 @@ int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16
  * @param ts       Timestamp of the SDU in microseconds (us). This value can be used to transmit
  *                 multiple SDUs in the same SDU interval in a CIG or BIG.
  *
- * @retval -EINVAL if stream object is NULL
- * @retval Any return value from bt_bap_stream_send()
+ * @retval -EINVAL Stream object is NULL.
+ * @return Any return value from bt_bap_stream_send().
  */
 int bt_cap_stream_send_ts(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num,
 			  uint32_t ts);
@@ -286,8 +286,8 @@ int bt_cap_stream_send_ts(struct bt_cap_stream *stream, struct net_buf *buf, uin
  * @param[in]  stream Stream object.
  * @param[out] info   Transmit info object.
  *
- * @retval -EINVAL if stream object is NULL
- * @retval Any return value from bt_bap_stream_get_tx_sync()
+ * @retval -EINVAL Stream object is NULL.
+ * @return Any return value from bt_bap_stream_get_tx_sync().
  */
 int bt_cap_stream_get_tx_sync(struct bt_cap_stream *stream, struct bt_iso_tx_info *info);
 
@@ -374,7 +374,7 @@ struct bt_cap_unicast_group_param {
  * @param[in]  param          The unicast group create parameters.
  * @param[out] unicast_group  Pointer to the unicast group created.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_unicast_group_create(const struct bt_cap_unicast_group_param *param,
 				struct bt_cap_unicast_group **unicast_group);
@@ -392,7 +392,7 @@ int bt_cap_unicast_group_create(const struct bt_cap_unicast_group_param *param,
  * @param unicast_group  Pointer to the unicast group created.
  * @param param          The unicast group reconfigure parameters.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_unicast_group_reconfig(struct bt_cap_unicast_group *unicast_group,
 				  const struct bt_cap_unicast_group_param *param);
@@ -414,7 +414,7 @@ int bt_cap_unicast_group_reconfig(struct bt_cap_unicast_group *unicast_group,
  * @param params         Array of stream parameters with streams being added to the group.
  * @param num_param      Number of parameters in @p params.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_unicast_group_add_streams(struct bt_cap_unicast_group *unicast_group,
 				     const struct bt_cap_unicast_group_stream_pair_param params[],
@@ -428,7 +428,7 @@ int bt_cap_unicast_group_add_streams(struct bt_cap_unicast_group *unicast_group,
  *
  * @param unicast_group  Pointer to the unicast group to delete
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_unicast_group_delete(struct bt_cap_unicast_group *unicast_group);
 
@@ -450,7 +450,7 @@ typedef bool (*bt_cap_unicast_group_foreach_stream_func_t)(struct bt_cap_stream 
  * @param func           The callback function
  * @param user_data      User specified data that is sent to the callback function
  *
- * @retval 0 Success (even if no streams exists in the group).
+ * @retval 0 on success (even if no streams exists in the group).
  * @retval -ECANCELED The @p func returned false and stopped the iteration.
  * @retval -EINVAL @p unicast_group or @p func were NULL.
  */
@@ -470,8 +470,8 @@ struct bt_cap_unicast_group_info {
  * @param unicast_group The unicast group object.
  * @param info          The structure object to be filled with the info.
  *
- * @retval 0 Success
- * @retval -EINVAL  @p unicast_group or @p info are NULL
+ * @retval 0 on success.
+ * @retval -EINVAL @p unicast_group or @p info are NULL.
  */
 int bt_cap_unicast_group_get_info(const struct bt_cap_unicast_group *unicast_group,
 				  struct bt_cap_unicast_group_info *info);
@@ -560,7 +560,7 @@ struct bt_cap_unicast_audio_stop_param {
  *
  * @param cb   The callback structure. Shall remain static.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_register_cb(const struct bt_cap_initiator_cb *cb);
 
@@ -569,8 +569,8 @@ int bt_cap_initiator_register_cb(const struct bt_cap_initiator_cb *cb);
  *
  * @param cb   The callback structure that was previously registered.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL or @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL or @p cb was not registered.
  */
 int bt_cap_initiator_unregister_cb(const struct bt_cap_initiator_cb *cb);
 
@@ -587,10 +587,10 @@ int bt_cap_initiator_unregister_cb(const struct bt_cap_initiator_cb *cb);
  *
  * @param param Parameters to start the audio streams.
  *
- * @retval 0 on success
- * @retval -EBUSY if a CAP procedure is already in progress
- * @retval -EINVAL if any parameter is invalid
- * @retval -EALREADY All streams are already in the streaming state
+ * @retval 0 on success.
+ * @retval -EBUSY A CAP procedure is already in progress.
+ * @retval -EINVAL Any parameter is invalid.
+ * @retval -EALREADY All streams are already in the streaming state.
  */
 int bt_cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start_param *param);
 
@@ -605,7 +605,7 @@ int bt_cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start
  *
  * @param param Update parameters.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_update_param *param);
 
@@ -620,10 +620,10 @@ int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_upda
  *
  * @param param Stop parameters.
  *
- * @return 0 on success
- * @retval -EBUSY if a CAP procedure is already in progress
- * @retval -EINVAL if any parameter is invalid
- * @retval -EALREADY if no state changes will occur
+ * @retval 0 on success.
+ * @retval -EBUSY A CAP procedure is already in progress.
+ * @retval -EINVAL Any parameter is invalid.
+ * @retval -EALREADY No state changes will occur.
  */
 int bt_cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_param *param);
 
@@ -647,8 +647,8 @@ int bt_cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_p
  * The respective callbacks of the procedure will be called as part of this with the connection
  * pointer set to 0 and the err value set to -ECANCELED.
  *
- * @retval 0 on success
- * @retval -EALREADY if no procedure is active
+ * @retval 0 on success.
+ * @retval -EALREADY No procedure is active.
  */
 int bt_cap_initiator_unicast_audio_cancel(void);
 
@@ -764,12 +764,12 @@ struct bt_cap_initiator_broadcast_create_param {
  * @param[in]  param             Parameters to start the audio streams.
  * @param[out] broadcast_source  Pointer to the broadcast source created.
  *
- * @retval 0 Success
- * @retval -EINVAL @p param is invalid or @p broadcast_source is NULL
+ * @retval 0 on success.
+ * @retval -EINVAL @p param is invalid or @p broadcast_source is NULL.
  * @retval -ENOMEM Could not allocate more broadcast sources, subgroups or ISO streams, or the
  *         provided codec configuration data is too large when merging the BIS and subgroup
  *         configuration data.
- * @retval -ENOEXEC The broadcast source failed to be created for other reasons
+ * @retval -ENOEXEC The broadcast source failed to be created for other reasons.
  */
 int bt_cap_initiator_broadcast_audio_create(
 	const struct bt_cap_initiator_broadcast_create_param *param,
@@ -792,7 +792,7 @@ int bt_cap_initiator_broadcast_audio_create(
  * @param adv               Pointer to an extended advertising set with
  *                          periodic advertising configured.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_broadcast_audio_start(struct bt_cap_broadcast_source *broadcast_source,
 					   struct bt_le_ext_adv *adv);
@@ -808,7 +808,7 @@ int bt_cap_initiator_broadcast_audio_start(struct bt_cap_broadcast_source *broad
  *                         of CCIDs as well as a non-0 context bitfield.
  * @param meta_len         The length of @p meta.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_broadcast_audio_update(struct bt_cap_broadcast_source *broadcast_source,
 					    const uint8_t meta[], size_t meta_len);
@@ -823,7 +823,7 @@ int bt_cap_initiator_broadcast_audio_update(struct bt_cap_broadcast_source *broa
  * @param broadcast_source The broadcast source to stop. The audio streams
  *                         in this will be stopped and reset.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_broadcast_audio_stop(struct bt_cap_broadcast_source *broadcast_source);
 
@@ -842,7 +842,7 @@ int bt_cap_initiator_broadcast_audio_stop(struct bt_cap_broadcast_source *broadc
  * @param broadcast_source The broadcast source to delete.
  *                         The @p broadcast_source will be invalidated.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_broadcast_audio_delete(struct bt_cap_broadcast_source *broadcast_source);
 
@@ -859,7 +859,7 @@ int bt_cap_initiator_broadcast_audio_delete(struct bt_cap_broadcast_source *broa
  * @param broadcast_source  Pointer to the broadcast source.
  * @param base_buf          Pointer to a buffer where the BASE will be inserted.
  *
- * @return int		0 if on success, errno on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_broadcast_get_base(struct bt_cap_broadcast_source *broadcast_source,
 					struct net_buf_simple *base_buf);
@@ -882,9 +882,9 @@ typedef bool (*bt_cap_initiator_broadcast_foreach_stream_func_t)(struct bt_cap_s
  * @param func              The callback function.
  * @param user_data         User specified data that is sent to the callback function.
  *
- * @retval 0          Success (even if no streams exists in the group).
+ * @retval 0 on success (even if no streams exists in the group).
  * @retval -ECANCELED The @p func returned false and stopped the iteration.
- * @retval -EINVAL    @p broadcast_source or @p func were NULL.
+ * @retval -EINVAL @p broadcast_source or @p func were NULL.
  */
 int bt_cap_initiator_broadcast_foreach_stream(struct bt_cap_broadcast_source *broadcast_source,
 					      bt_cap_initiator_broadcast_foreach_stream_func_t func,
@@ -972,7 +972,7 @@ struct bt_cap_handover_cb {
  *
  * @param cb   The callback structure. Shall remain static.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_handover_register_cb(const struct bt_cap_handover_cb *cb);
 
@@ -981,8 +981,8 @@ int bt_cap_handover_register_cb(const struct bt_cap_handover_cb *cb);
  *
  * @param cb   The callback structure that was previously registered.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL or @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL or @p cb was not registered.
  */
 int bt_cap_handover_unregister_cb(const struct bt_cap_handover_cb *cb);
 
@@ -1001,7 +1001,7 @@ int bt_cap_handover_unregister_cb(const struct bt_cap_handover_cb *cb);
  *
  * @param param The parameters for the handover.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_handover_unicast_to_broadcast(
 	const struct bt_cap_handover_unicast_to_broadcast_param *param);
@@ -1060,7 +1060,7 @@ struct bt_cap_handover_broadcast_to_unicast_param {
  *
  * @param[in]  param          The parameters for the handover.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_handover_broadcast_to_unicast(
 	const struct bt_cap_handover_broadcast_to_unicast_param *param);
@@ -1192,9 +1192,9 @@ struct bt_cap_commander_cb {
  *
  * @param cb   The callback structure. Shall remain static.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL
- * @retval -EALREADY Callbacks are already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY Callbacks are already registered.
  */
 int bt_cap_commander_register_cb(const struct bt_cap_commander_cb *cb);
 
@@ -1203,8 +1203,8 @@ int bt_cap_commander_register_cb(const struct bt_cap_commander_cb *cb);
  *
  * @param cb   The callback structure that was previously registered.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL or @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL or @p cb was not registered.
  */
 int bt_cap_commander_unregister_cb(const struct bt_cap_commander_cb *cb);
 
@@ -1220,11 +1220,11 @@ int bt_cap_commander_unregister_cb(const struct bt_cap_commander_cb *cb);
  *
  * @param conn Connection to a remote server.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -EBUSY Already doing discovery for @p conn
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -EBUSY Already doing discovery for @p conn.
  */
 int bt_cap_commander_discover(struct bt_conn *conn);
 
@@ -1248,8 +1248,8 @@ int bt_cap_commander_discover(struct bt_conn *conn);
  * The respective callbacks of the procedure will be called as part of this with the connection
  * pointer set to NULL and the err value set to -ECANCELED.
  *
- * @retval 0 on success
- * @retval -EALREADY if no procedure is active
+ * @retval 0 on success.
+ * @retval -EALREADY No procedure is active.
  */
 int bt_cap_commander_cancel(void);
 
@@ -1306,7 +1306,7 @@ struct bt_cap_commander_broadcast_reception_start_param {
  *
  * @param param The parameters to start the broadcast audio
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_broadcast_reception_start(
 	const struct bt_cap_commander_broadcast_reception_start_param *param);
@@ -1341,7 +1341,7 @@ struct bt_cap_commander_broadcast_reception_stop_param {
  *
  * @param param The parameters to stop the broadcast audio
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_broadcast_reception_stop(
 	const struct bt_cap_commander_broadcast_reception_stop_param *param);
@@ -1385,7 +1385,7 @@ struct bt_cap_commander_distribute_broadcast_code_param {
  *
  * @param param The parameters for distributing the broadcast code
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_distribute_broadcast_code(
 	const struct bt_cap_commander_distribute_broadcast_code_param *param);
@@ -1410,7 +1410,7 @@ struct bt_cap_commander_change_volume_param {
  *
  * @param param The parameters for the volume change
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_change_volume(const struct bt_cap_commander_change_volume_param *param);
 
@@ -1447,7 +1447,7 @@ struct bt_cap_commander_change_volume_offset_param {
  *
  * @param param The parameters for the volume offset change
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_change_volume_offset(
 	const struct bt_cap_commander_change_volume_offset_param *param);
@@ -1476,7 +1476,7 @@ struct bt_cap_commander_change_volume_mute_state_param {
  *
  * @param param The parameters for the volume mute state change
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_change_volume_mute_state(
 	const struct bt_cap_commander_change_volume_mute_state_param *param);
@@ -1505,7 +1505,7 @@ struct bt_cap_commander_change_microphone_mute_state_param {
  *
  * @param param The parameters for the microphone mute state change
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_change_microphone_mute_state(
 	const struct bt_cap_commander_change_microphone_mute_state_param *param);
@@ -1539,7 +1539,7 @@ struct bt_cap_commander_change_microphone_gain_setting_param {
  *
  * @param param The parameters for the microphone gain setting change
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_change_microphone_gain_setting(
 	const struct bt_cap_commander_change_microphone_gain_setting_param *param);

--- a/include/zephyr/bluetooth/audio/ccid.h
+++ b/include/zephyr/bluetooth/audio/ccid.h
@@ -46,8 +46,8 @@ extern "C" {
  *
  * Requires that @kconfig{CONFIG_BT_CONN} is enabled.
  *
- * @retval ccid 8-bit unsigned CCID value on success
- * @retval -ENOMEM No more CCIDs can be allocated
+ * @return 8-bit unsigned CCID value on success.
+ * @retval -ENOMEM No more CCIDs can be allocated.
  */
 int bt_ccid_alloc_value(void);
 
@@ -60,8 +60,7 @@ int bt_ccid_alloc_value(void);
  *
  * @param ccid The CCID to search for
  *
- * @retval NULL None was found
- * @retval attr Pointer to a GATT attribute
+ * @return Pointer to a GATT attribute, or NULL if no such attribute was found.
  */
 const struct bt_gatt_attr *bt_ccid_find_attr(uint8_t ccid);
 

--- a/include/zephyr/bluetooth/audio/ccp.h
+++ b/include/zephyr/bluetooth/audio/ccp.h
@@ -67,13 +67,13 @@ struct bt_ccp_call_control_server_bearer;
  * @param[in]  param   The parameters to initialize the bearer.
  * @param[out] bearer  Pointer to the initialized bearer.
  *
- * @retval 0 Success
- * @retval -EINVAL @p param contains invalid data
- * @retval -EALREADY @p param.gtbs is true and GTBS has already been registered
- * @retval -EAGAIN @p param.gtbs is false and GTBS has not been registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p param contains invalid data.
+ * @retval -EALREADY @p param.gtbs is true and GTBS has already been registered.
+ * @retval -EAGAIN @p param.gtbs is false and GTBS has not been registered.
  * @retval -ENOMEM @p param.gtbs is false and no more TBS can be registered (see
- *         @kconfig{CONFIG_BT_TBS_BEARER_COUNT})
- * @retval -ENOEXEC The service failed to be registered
+ *         @kconfig{CONFIG_BT_TBS_BEARER_COUNT}).
+ * @retval -ENOEXEC The service failed to be registered.
  */
 int bt_ccp_call_control_server_register_bearer(const struct bt_tbs_register_param *param,
 					       struct bt_ccp_call_control_server_bearer **bearer);
@@ -89,10 +89,10 @@ int bt_ccp_call_control_server_register_bearer(const struct bt_tbs_register_para
  *
  * @param bearer The bearer to unregister.
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer is NULL
- * @retval -EALREADY The bearer is not registered
- * @retval -ENOEXEC The service failed to be unregistered
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer is NULL.
+ * @retval -EALREADY The bearer is not registered.
+ * @retval -ENOEXEC The service failed to be unregistered.
  */
 int bt_ccp_call_control_server_unregister_bearer(struct bt_ccp_call_control_server_bearer *bearer);
 
@@ -102,12 +102,12 @@ int bt_ccp_call_control_server_unregister_bearer(struct bt_ccp_call_control_serv
  * @param bearer  The bearer to set the name for.
  * @param name    The new bearer provider name.
  *
- * @retval 0 Success
+ * @retval 0 on success.
  * @retval -EINVAL @p bearer or @p name is NULL, or @p name is the empty string or @p name is larger
- *                 than @kconfig{CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH}
- * @retval -EFAULT @p bearer is not registered
- * @retval -EBUSY The TBS instance of @p bearer is busy
- * @retval -ENOEXEC The TBS instance of @p bearer returned unexpected error
+ *                 than @kconfig{CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH}.
+ * @retval -EFAULT @p bearer is not registered.
+ * @retval -EBUSY The TBS instance of @p bearer is busy.
+ * @retval -ENOEXEC The TBS instance of @p bearer returned unexpected error.
  */
 int bt_ccp_call_control_server_set_bearer_provider_name(
 	struct bt_ccp_call_control_server_bearer *bearer, const char *name);
@@ -121,10 +121,10 @@ int bt_ccp_call_control_server_set_bearer_provider_name(
  *                  @kconfig{CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH} + 1 to
  *                  ensure that the name always fits.
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer or @p name is NULL
- * @retval -EFAULT @p bearer is not registered
- * @retval -ENOMEM @p name_size is insufficient to hold the bearer name (including null terminator)
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer or @p name is NULL.
+ * @retval -EFAULT @p bearer is not registered.
+ * @retval -ENOMEM @p name_size is insufficient to hold the bearer name (including null terminator).
  */
 int bt_ccp_call_control_server_get_bearer_provider_name(
 	struct bt_ccp_call_control_server_bearer *bearer, char *name, size_t name_size);
@@ -136,9 +136,9 @@ int bt_ccp_call_control_server_get_bearer_provider_name(
  * @param[out] uci Pointer to a buffer of size @ref BT_TBS_MAX_UCI_SIZE that the bearer UCI will be
  *                 written to.
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer or @p uci is NULL
- * @retval -EFAULT @p bearer is not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer or @p uci is NULL.
+ * @retval -EFAULT @p bearer is not registered.
  */
 int bt_ccp_call_control_server_get_bearer_uci(struct bt_ccp_call_control_server_bearer *bearer,
 					      char uci[BT_TBS_MAX_UCI_SIZE]);
@@ -261,12 +261,12 @@ struct bt_ccp_call_control_client_cb {
  * @param conn Connection to a remote server.
  * @param out_client Pointer to client instance on success
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn or @p out_client is NULL
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -EBUSY Already doing discovery for @p conn
- * @retval -ENOEXEC Rejected by the GATT layer
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn or @p out_client is NULL.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -EBUSY Already doing discovery for @p conn.
+ * @retval -ENOEXEC Rejected by the GATT layer.
  */
 int bt_ccp_call_control_client_discover(struct bt_conn *conn,
 					struct bt_ccp_call_control_client **out_client);
@@ -276,9 +276,9 @@ int bt_ccp_call_control_client_discover(struct bt_conn *conn,
  *
  * @param cb The callback struct
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL
- * @retval -EEXISTS @p cb is already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EEXIST @p cb is already registered.
  */
 int bt_ccp_call_control_client_register_cb(struct bt_ccp_call_control_client_cb *cb);
 
@@ -287,9 +287,9 @@ int bt_ccp_call_control_client_register_cb(struct bt_ccp_call_control_client_cb 
  *
  * @param cb The callback struct
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL
- * @retval -EALREADY @p cb is not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb is not registered.
  */
 int bt_ccp_call_control_client_unregister_cb(struct bt_ccp_call_control_client_cb *cb);
 
@@ -299,8 +299,8 @@ int bt_ccp_call_control_client_unregister_cb(struct bt_ccp_call_control_client_c
  * @param[in]  client  The client to get the bearers of.
  * @param[out] bearers The bearers struct that will be populated with the bearers of @p client.
 
- * @retval 0 Success
- * @retval -EINVAL @p client or @p bearers is NULL
+ * @retval 0 on success.
+ * @retval -EINVAL @p client or @p bearers is NULL.
  */
 int bt_ccp_call_control_client_get_bearers(struct bt_ccp_call_control_client *client,
 					   struct bt_ccp_call_control_client_bearers *bearers);
@@ -312,13 +312,13 @@ int bt_ccp_call_control_client_get_bearers(struct bt_ccp_call_control_client *cl
  *
  * @param bearer The bearer to read the name from
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer is NULL
- * @retval -EFAULT @p bearer has not been discovered
- * @retval -EEXIST A @ref bt_ccp_call_control_client could not be identified for @p bearer
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer is NULL.
+ * @retval -EFAULT @p bearer has not been discovered.
+ * @retval -EEXIST A @ref bt_ccp_call_control_client could not be identified for @p bearer.
  * @retval -EBUSY The @ref bt_ccp_call_control_client identified by @p bearer is busy, or the TBS
  * instance of @p bearer is busy.
- * @retval -ENOTCONN The @ref bt_ccp_call_control_client identified by @p bearer is not connected
+ * @retval -ENOTCONN The @ref bt_ccp_call_control_client identified by @p bearer is not connected.
  */
 int bt_ccp_call_control_client_read_bearer_provider_name(
 	struct bt_ccp_call_control_client_bearer *bearer);
@@ -330,13 +330,13 @@ int bt_ccp_call_control_client_read_bearer_provider_name(
  *
  * @param bearer The bearer to read the UCI from
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer is NULL
- * @retval -EFAULT @p bearer has not been discovered
- * @retval -EEXIST A @ref bt_ccp_call_control_client could not be identified for @p bearer
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer is NULL.
+ * @retval -EFAULT @p bearer has not been discovered.
+ * @retval -EEXIST A @ref bt_ccp_call_control_client could not be identified for @p bearer.
  * @retval -EBUSY The @ref bt_ccp_call_control_client identified by @p bearer is busy, or the TBS
  * instance of @p bearer is busy.
- * @retval -ENOTCONN The @ref bt_ccp_call_control_client identified by @p bearer is not connected
+ * @retval -ENOTCONN The @ref bt_ccp_call_control_client identified by @p bearer is not connected.
  */
 int bt_ccp_call_control_client_read_bearer_uci(struct bt_ccp_call_control_client_bearer *bearer);
 /** @} */ /* End of group bt_ccp_call_control_client */

--- a/include/zephyr/bluetooth/audio/gmap.h
+++ b/include/zephyr/bluetooth/audio/gmap.h
@@ -184,9 +184,9 @@ struct bt_gmap_cb {
  *
  * @param cb The callback structure.
  *
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if callbacks have already be registered
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY Callbacks have already been registered.
  */
 int bt_gmap_cb_register(const struct bt_gmap_cb *cb);
 
@@ -199,10 +199,10 @@ int bt_gmap_cb_register(const struct bt_gmap_cb *cb);
  *
  * @param conn Bluetooth connection object.
  *
- * @retval -EINVAL if @p conn is NULL
- * @retval -EBUSY if discovery is already in progress for @p conn
- * @retval -ENOEXEC if discovery failed to initiate
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL.
+ * @retval -EBUSY Discovery is already in progress for @p conn.
+ * @retval -ENOEXEC Discovery failed to initiate.
  */
 int bt_gmap_discover(struct bt_conn *conn);
 
@@ -213,9 +213,9 @@ int bt_gmap_discover(struct bt_conn *conn);
  * @param features Features of the roles. If a role is not in the @p role parameter, then the
  *                 feature value for that role is simply ignored.
  *
- * @retval -EINVAL on invalid arguments
- * @retval -ENOEXEC on service register failure
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Invalid arguments.
+ * @retval -ENOEXEC Service register failure.
  */
 int bt_gmap_register(enum bt_gmap_role role, struct bt_gmap_feat features);
 
@@ -230,12 +230,12 @@ int bt_gmap_register(enum bt_gmap_role role, struct bt_gmap_feat features);
  * @param features Features of the roles. If a role is not in the @p role parameter, then the
  *                 feature value for that role is simply ignored.
  *
- * @retval -ENOEXEC if the service has not yet been registered
- * @retval -EINVAL on invalid arguments
- * @retval -EALREADY if the @p role and @p features are the same as existing ones
- * @retval -ENOENT on service unregister failure
- * @retval -ECANCELED on service re-register failure
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -ENOEXEC The service has not yet been registered.
+ * @retval -EINVAL Invalid arguments.
+ * @retval -EALREADY The @p role and @p features are the same as existing ones.
+ * @retval -ENOENT Service unregister failure.
+ * @retval -ECANCELED Service re-register failure.
  */
 int bt_gmap_set_role(enum bt_gmap_role role, struct bt_gmap_feat features);
 

--- a/include/zephyr/bluetooth/audio/has.h
+++ b/include/zephyr/bluetooth/audio/has.h
@@ -225,7 +225,7 @@ struct bt_has_client_cb {
  *
  * @param cb The callback structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_cb_register(const struct bt_has_client_cb *cb);
 
@@ -238,7 +238,7 @@ int bt_has_client_cb_register(const struct bt_has_client_cb *cb);
  *
  * @param conn Bluetooth connection object.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_discover(struct bt_conn *conn);
 
@@ -251,7 +251,7 @@ int bt_has_client_discover(struct bt_conn *conn);
  * @param[in] has Pointer to the Hearing Access Service object.
  * @param[out] conn Connection object.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_conn_get(const struct bt_has *has, struct bt_conn **conn);
 
@@ -266,7 +266,7 @@ int bt_has_client_conn_get(const struct bt_has *has, struct bt_conn **conn);
  * @param index The index to start with.
  * @param max_count Maximum number of presets to read.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_presets_read(struct bt_has *has, uint8_t index, uint8_t max_count);
 
@@ -280,7 +280,7 @@ int bt_has_client_presets_read(struct bt_has *has, uint8_t index, uint8_t max_co
  * @param index Preset index to activate.
  * @param sync Request active preset synchronization in set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_preset_set(struct bt_has *has, uint8_t index, bool sync);
 
@@ -293,7 +293,7 @@ int bt_has_client_preset_set(struct bt_has *has, uint8_t index, bool sync);
  * @param has Pointer to the Hearing Access Service object.
  * @param sync Request active preset synchronization in set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_preset_next(struct bt_has *has, bool sync);
 
@@ -306,7 +306,7 @@ int bt_has_client_preset_next(struct bt_has *has, bool sync);
  * @param has Pointer to the Hearing Access Service object.
  * @param sync Request active preset synchronization in set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_preset_prev(struct bt_has *has, bool sync);
 
@@ -322,9 +322,9 @@ struct bt_has_preset_ops {
 	 * @param sync Whether the server must relay this change to the other member of the
 	 *             Binaural Hearing Aid Set.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
-	 * @return -EBUSY if operation cannot be performed at the time.
-	 * @return -EINPROGRESS in case where user has to confirm once the requested preset
+	 * @return 0 on success, negative errno value on failure.
+	 * @retval -EBUSY Operation cannot be performed at the time.
+	 * @retval -EINPROGRESS User has to confirm once the requested preset
 	 *                      becomes active by calling @ref bt_has_preset_active_set.
 	 */
 	int (*select)(uint8_t index, bool sync);
@@ -375,7 +375,7 @@ struct bt_has_preset_register_param {
  *
  * @param features     Hearing Access Service register parameters.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_register(const struct bt_has_features_param *features);
 
@@ -387,7 +387,7 @@ int bt_has_register(const struct bt_has_features_param *features);
  *
  * @param param Preset registration parameter.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_register(const struct bt_has_preset_register_param *param);
 
@@ -398,7 +398,7 @@ int bt_has_preset_register(const struct bt_has_preset_register_param *param);
  *
  * @param index The index of preset that's being requested to unregister.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_unregister(uint8_t index);
 
@@ -410,7 +410,7 @@ int bt_has_preset_unregister(uint8_t index);
  *
  * @param index The index of preset that's became available.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_available(uint8_t index);
 
@@ -422,7 +422,7 @@ int bt_has_preset_available(uint8_t index);
  *
  * @param index The index of preset that's became unavailable.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_unavailable(uint8_t index);
 
@@ -450,7 +450,7 @@ typedef bool (*bt_has_preset_func_t)(uint8_t index, enum bt_has_properties prope
  * @param func Callback function.
  * @param user_data Data to pass to the callback.
  *
- * @retval 0 Success
+ * @retval 0 on success.
  * @retval -ECANCELED Iteration was stopped by the callback function before complete.
  * @retval -EINVAL @p func was NULL.
  */
@@ -464,7 +464,7 @@ int bt_has_preset_foreach(uint8_t index, bt_has_preset_func_t func, void *user_d
  *
  * @param index Preset index.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_active_set(uint8_t index);
 
@@ -482,7 +482,7 @@ uint8_t bt_has_preset_active_get(void);
  *
  * Used by server to deactivate currently active preset.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 static inline int bt_has_preset_active_clear(void)
 {
@@ -497,7 +497,7 @@ static inline int bt_has_preset_active_clear(void)
  * @param index The index of the preset to change the name of.
  * @param name Name to write.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_name_change(uint8_t index, const char *name);
 
@@ -508,7 +508,7 @@ int bt_has_preset_name_change(uint8_t index, const char *name);
  *
  * @param features The features to be set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_features_set(const struct bt_has_features_param *features);
 

--- a/include/zephyr/bluetooth/audio/pacs.h
+++ b/include/zephyr/bluetooth/audio/pacs.h
@@ -92,8 +92,8 @@ struct bt_pacs_register_param {
  * @param cap Capability found.
  * @param user_data Data given.
  *
- * @return true to continue to the next capability
- * @return false to stop the iteration
+ * @return true to continue to the next capability.
+ * @return false to stop the iteration.
  */
 typedef bool (*bt_pacs_cap_foreach_func_t)(const struct bt_pacs_cap *cap,
 					   void *user_data);
@@ -116,17 +116,17 @@ void bt_pacs_cap_foreach(enum bt_audio_dir dir,
  *
  * @param param PACS register parameters.
  *
- * @retval 0 Success
- * @retval -EINVAL @p param is NULL or bad combination of values in @p param
- * @retval -EALREADY Already registered
- * @retval -ENOEXEC Request was rejected by GATT
+ * @retval 0 on success.
+ * @retval -EINVAL @p param is NULL or bad combination of values in @p param.
+ * @retval -EALREADY Already registered.
+ * @retval -ENOEXEC Request was rejected by GATT.
  */
 int bt_pacs_register(const struct bt_pacs_register_param *param);
 
 /**
  * @brief Unregister the Published Audio Capability Service instance.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_unregister(void);
 
@@ -138,7 +138,7 @@ int bt_pacs_unregister(void);
  * @param dir Direction of the endpoint to register capability for.
  * @param cap Capability structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_cap_register(enum bt_audio_dir dir, struct bt_pacs_cap *cap);
 
@@ -150,7 +150,7 @@ int bt_pacs_cap_register(enum bt_audio_dir dir, struct bt_pacs_cap *cap);
  * @param dir Direction of the endpoint to unregister capability for.
  * @param cap Capability structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_cap_unregister(enum bt_audio_dir dir, struct bt_pacs_cap *cap);
 
@@ -160,7 +160,7 @@ int bt_pacs_cap_unregister(enum bt_audio_dir dir, struct bt_pacs_cap *cap);
  * @param dir      Direction of the endpoints to change location for.
  * @param location The location to be set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_set_location(enum bt_audio_dir dir,
 			 enum bt_audio_location location);
@@ -171,7 +171,7 @@ int bt_pacs_set_location(enum bt_audio_dir dir,
  * @param dir      Direction of the endpoints to change available contexts for.
  * @param contexts The contexts to be set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_set_available_contexts(enum bt_audio_dir dir,
 				   enum bt_audio_context contexts);
@@ -198,7 +198,7 @@ enum bt_audio_context bt_pacs_get_available_contexts(enum bt_audio_dir dir);
  * @param dir      Direction of the endpoints to change available contexts for.
  * @param contexts The contexts to be set or NULL to reset to default.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_conn_set_available_contexts_for_conn(struct bt_conn *conn, enum bt_audio_dir dir,
 						 enum bt_audio_context *contexts);
@@ -214,7 +214,7 @@ int bt_pacs_conn_set_available_contexts_for_conn(struct bt_conn *conn, enum bt_a
  * @param dir      Direction of the endpoints to get contexts for.
  *
  * @return Bitmask of available contexts.
- * @retval BT_AUDIO_CONTEXT_TYPE_NONE if @p conn or @p dir are invalid
+ * @retval BT_AUDIO_CONTEXT_TYPE_NONE @p conn or @p dir are invalid.
  */
 enum bt_audio_context bt_pacs_get_available_contexts_for_conn(struct bt_conn *conn,
 							      enum bt_audio_dir dir);
@@ -225,7 +225,7 @@ enum bt_audio_context bt_pacs_get_available_contexts_for_conn(struct bt_conn *co
  * @param dir      Direction of the endpoints to change available contexts for.
  * @param contexts The contexts to be set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_set_supported_contexts(enum bt_audio_dir dir,
 				   enum bt_audio_context contexts);


### PR DESCRIPTION
Apply the @retval/@return cleanup following the conventions documented in PR #107458:

Part 1/2: audio, ascs, pacs, cap, ccp, ccid, gmap, has headers. The remaining audio headers are handled in part 2/2.

Fixes parts of: #65974