### PR TITLE
bluetooth: audio: fix incorrect @retval usage

### DIFF
--- a/include/zephyr/bluetooth/audio/aics.h
+++ b/include/zephyr/bluetooth/audio/aics.h
@@ -186,7 +186,7 @@ struct bt_aics_discover_param {
 /**
  * @brief Get a free instance of Audio Input Control Service from the pool.
  *
- * @return Audio Input Control Service instance in case of success or NULL in case of error.
+ * @return Audio Input Control Service instance on success, or NULL on failure.
  */
 struct bt_aics *bt_aics_free_instance_get(void);
 
@@ -210,7 +210,7 @@ void *bt_aics_svc_decl_get(struct bt_aics *aics);
  * @param aics    Audio Input Control Service client instance pointer.
  * @param conn    Connection pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_client_conn_get(const struct bt_aics *aics, struct bt_conn **conn);
 
@@ -220,7 +220,7 @@ int bt_aics_client_conn_get(const struct bt_aics *aics, struct bt_conn **conn);
  * @param aics      Audio Input Control Service instance.
  * @param param     Audio Input Control Service register parameters.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_register(struct bt_aics *aics, struct bt_aics_register_param *param);
 
@@ -366,7 +366,7 @@ struct bt_aics_cb {
  * @param inst      The instance pointer.
  * @param param     Pointer to the parameters.
  *
- * @return 0 on success, errno on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_discover(struct bt_conn *conn, struct bt_aics *inst,
 		     const struct bt_aics_discover_param *param);
@@ -379,7 +379,7 @@ int bt_aics_discover(struct bt_conn *conn, struct bt_aics *inst,
  *
  * @param inst         The instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_deactivate(struct bt_aics *inst);
 
@@ -392,7 +392,7 @@ int bt_aics_deactivate(struct bt_aics *inst);
  *
  * @param inst         The instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_activate(struct bt_aics *inst);
 
@@ -401,7 +401,7 @@ int bt_aics_activate(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_state_get(struct bt_aics *inst);
 
@@ -410,7 +410,7 @@ int bt_aics_state_get(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_gain_setting_get(struct bt_aics *inst);
 
@@ -419,7 +419,7 @@ int bt_aics_gain_setting_get(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_type_get(struct bt_aics *inst);
 
@@ -428,7 +428,7 @@ int bt_aics_type_get(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_status_get(struct bt_aics *inst);
 
@@ -440,7 +440,7 @@ int bt_aics_status_get(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_disable_mute(struct bt_aics *inst);
 
@@ -449,7 +449,7 @@ int bt_aics_disable_mute(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_unmute(struct bt_aics *inst);
 
@@ -458,7 +458,7 @@ int bt_aics_unmute(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_mute(struct bt_aics *inst);
 
@@ -467,7 +467,7 @@ int bt_aics_mute(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_gain_set_manual_only(struct bt_aics *inst);
 
@@ -479,7 +479,7 @@ int bt_aics_gain_set_manual_only(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_gain_set_auto_only(struct bt_aics *inst);
 
@@ -488,7 +488,7 @@ int bt_aics_gain_set_auto_only(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_manual_gain_set(struct bt_aics *inst);
 
@@ -497,7 +497,7 @@ int bt_aics_manual_gain_set(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_automatic_gain_set(struct bt_aics *inst);
 
@@ -508,7 +508,7 @@ int bt_aics_automatic_gain_set(struct bt_aics *inst);
  * @param gain          The gain to set (-128 to 127) in gain setting units
  *                      (see @ref bt_aics_gain_setting_cb).
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_gain_set(struct bt_aics *inst, int8_t gain);
 
@@ -517,7 +517,7 @@ int bt_aics_gain_set(struct bt_aics *inst, int8_t gain);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_description_get(struct bt_aics *inst);
 
@@ -527,7 +527,7 @@ int bt_aics_description_get(struct bt_aics *inst);
  * @param inst          The instance pointer.
  * @param description   The description as an UTF-8 encoded string.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_description_set(struct bt_aics *inst, const char *description);
 

--- a/include/zephyr/bluetooth/audio/ascs.h
+++ b/include/zephyr/bluetooth/audio/ascs.h
@@ -292,7 +292,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp       Object for the ASE operation response. Only used if the return
 	 *                       value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*config)(struct bt_conn *conn, const struct bt_bap_ep *ep, enum bt_audio_dir dir,
 		      const struct bt_audio_codec_cfg *codec_cfg, struct bt_bap_stream **stream,
@@ -312,7 +312,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp       Object for the ASE operation response. Only used if the return
 	 *                       value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*reconfig)(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 			const struct bt_audio_codec_cfg *codec_cfg,
@@ -329,7 +329,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp     Object for the ASE operation response. Only used if the return
 	 *                     value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*qos)(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 		   struct bt_bap_ascs_rsp *rsp);
@@ -345,7 +345,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp         Object for the ASE operation response. Only used if the return
 	 *                         value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*enable)(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 		      struct bt_bap_ascs_rsp *rsp);
@@ -359,7 +359,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*start)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -374,7 +374,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp          Object for the ASE operation response. Only used if the return
 	 *                          value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*metadata)(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 			struct bt_bap_ascs_rsp *rsp);
@@ -388,7 +388,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*disable)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -401,7 +401,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*stop)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -415,7 +415,7 @@ struct bt_ascs_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*release)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 };
@@ -450,7 +450,7 @@ struct bt_ascs_register_param {
  *
  * @param param Parameters for the service
  *
- * @retval 0 Success.
+ * @retval 0 on success.
  * @retval -EINVAL @p param is NULL or contains invalid values, or bt_gatt_service_register()
  *                failed.
  * @retval -EALREADY ASCS already registered.
@@ -464,8 +464,8 @@ int bt_ascs_register(const struct bt_ascs_register_param *param);
  *
  * This will release all streams and remove the service from the GATT database.
  *
- * @retval 0 Success.
- * @retval -ENOENT if bt_gatt_service_unregister() failed to unregister the service.
+ * @retval 0 on success.
+ * @retval -ENOENT bt_gatt_service_unregister() failed to unregister the service.
  * @retval -EALREADY ASCS already unregistered.
  */
 int bt_ascs_unregister(void);

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -281,8 +281,8 @@ struct bt_audio_codec_cfg {
  * @param user_data User data to be passed to the callback.
  *
  * @retval 0 All entries were parsed.
- * @retval -EINVAL The data is incorrectly encoded
- * @retval -ECANCELED Parsing was prematurely cancelled by the callback
+ * @retval -EINVAL The data is incorrectly encoded.
+ * @retval -ECANCELED Parsing was prematurely cancelled by the callback.
  */
 int bt_audio_data_parse(const uint8_t ltv[], size_t size,
 			bool (*func)(struct bt_data *data, void *user_data), void *user_data);
@@ -298,9 +298,9 @@ int bt_audio_data_parse(const uint8_t ltv[], size_t size,
  * @param[out] data Pointer to the data-pointer to update when item is found.
  *                  Any found data will be little endian.
  *
- * @retval length The length of found @p data (may be 0).
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of found @p data (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_data_get_val(const uint8_t ltv_data[], size_t size, uint8_t type,
 			  const uint8_t **data);
@@ -310,7 +310,7 @@ int bt_audio_data_get_val(const uint8_t ltv_data[], size_t size, uint8_t type,
  *
  * @param chan_allocation The channel allocation
  *
- * @return The number of channels
+ * @return The number of channels.
  */
 uint8_t bt_audio_get_chan_count(enum bt_audio_location chan_allocation);
 
@@ -346,7 +346,7 @@ enum bt_audio_dir {
  *
  * @param freq The assigned numbers frequency to convert.
  *
- * @retval frequency The converted frequency value in Hz.
+ * @return The converted frequency value in Hz on success.
  * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_freq_to_freq_hz(enum bt_audio_codec_cfg_freq freq);
@@ -356,7 +356,7 @@ int bt_audio_codec_cfg_freq_to_freq_hz(enum bt_audio_codec_cfg_freq freq);
  *
  * @param freq_hz The frequency value to convert.
  *
- * @retval frequency The assigned numbers frequency (@ref bt_audio_codec_cfg_freq).
+ * @return The assigned numbers frequency (@ref bt_audio_codec_cfg_freq) on success.
  * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_freq_hz_to_freq(uint32_t freq_hz);
@@ -366,10 +366,10 @@ int bt_audio_codec_cfg_freq_hz_to_freq(uint32_t freq_hz);
  *
  * @param codec_cfg The codec configuration to extract data from.
  *
- * @retval frequency A @ref bt_audio_codec_cfg_freq value
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return A @ref bt_audio_codec_cfg_freq value on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cfg_get_freq(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -379,9 +379,9 @@ int bt_audio_codec_cfg_get_freq(const struct bt_audio_codec_cfg *codec_cfg);
  * @param codec_cfg The codec configuration to set data for.
  * @param freq      The assigned numbers frequency to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_freq(struct bt_audio_codec_cfg *codec_cfg,
 				enum bt_audio_codec_cfg_freq freq);
@@ -391,7 +391,7 @@ int bt_audio_codec_cfg_set_freq(struct bt_audio_codec_cfg *codec_cfg,
  *
  * @param frame_dur The assigned numbers frame duration to convert.
  *
- * @retval duration The converted frame duration value in microseconds.
+ * @return The converted frame duration value in microseconds on success.
  * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_frame_dur_to_frame_dur_us(enum bt_audio_codec_cfg_frame_dur frame_dur);
@@ -401,7 +401,7 @@ int bt_audio_codec_cfg_frame_dur_to_frame_dur_us(enum bt_audio_codec_cfg_frame_d
  *
  * @param frame_dur_us The frame duration in microseconds to convert.
  *
- * @retval duration The assigned numbers frame duration (@ref bt_audio_codec_cfg_frame_dur).
+ * @return The assigned numbers frame duration (@ref bt_audio_codec_cfg_frame_dur) on success.
  * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_frame_dur_us_to_frame_dur(uint32_t frame_dur_us);
@@ -411,10 +411,10 @@ int bt_audio_codec_cfg_frame_dur_us_to_frame_dur(uint32_t frame_dur_us);
  *
  * @param codec_cfg The codec configuration to extract data from.
  *
- * @retval frequency A @ref bt_audio_codec_cfg_frame_dur value
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return A @ref bt_audio_codec_cfg_frame_dur value on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cfg_get_frame_dur(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -424,9 +424,9 @@ int bt_audio_codec_cfg_get_frame_dur(const struct bt_audio_codec_cfg *codec_cfg)
  * @param codec_cfg  The codec configuration to set data for.
  * @param frame_dur  The assigned numbers frame duration to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_frame_dur(struct bt_audio_codec_cfg *codec_cfg,
 				     enum bt_audio_codec_cfg_frame_dur frame_dur);
@@ -446,10 +446,10 @@ int bt_audio_codec_cfg_set_frame_dur(struct bt_audio_codec_cfg *codec_cfg,
  *        @ref BT_AUDIO_LOCATION_MONO_AUDIO if the type is not found when @p codec_cfg.id is @ref
  *        BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval 0 Value is found and stored in the pointer provided
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @retval 0 Value is found and stored in the pointer provided.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cfg_get_chan_allocation(const struct bt_audio_codec_cfg *codec_cfg,
 					   enum bt_audio_location *chan_allocation,
@@ -461,9 +461,9 @@ int bt_audio_codec_cfg_get_chan_allocation(const struct bt_audio_codec_cfg *code
  * @param codec_cfg       The codec configuration to set data for.
  * @param chan_allocation The channel allocation to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_chan_allocation(struct bt_audio_codec_cfg *codec_cfg,
 					   enum bt_audio_location chan_allocation);
@@ -482,10 +482,10 @@ int bt_audio_codec_cfg_set_chan_allocation(struct bt_audio_codec_cfg *codec_cfg,
  *
  * @param codec_cfg The codec configuration to extract data from.
  *
- * @retval frame_length Frame length in octets
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return Frame length in octets on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cfg_get_octets_per_frame(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -495,9 +495,9 @@ int bt_audio_codec_cfg_get_octets_per_frame(const struct bt_audio_codec_cfg *cod
  * @param codec_cfg        The codec configuration to set data for.
  * @param octets_per_frame The octets per codec frame to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_octets_per_frame(struct bt_audio_codec_cfg *codec_cfg,
 					    uint16_t octets_per_frame);
@@ -517,10 +517,10 @@ int bt_audio_codec_cfg_set_octets_per_frame(struct bt_audio_codec_cfg *codec_cfg
  * @param fallback_to_default If true this function will return the default value of 1
  *         if the type is not found when @p codec_cfg.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval frame_blocks_per_sdu The count of codec frame blocks in each SDU.
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return The count of codec frame blocks in each SDU on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg *codec_cfg,
 						bool fallback_to_default);
@@ -531,9 +531,9 @@ int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg 
  * @param codec_cfg    The codec configuration to set data for.
  * @param frame_blocks The frame blocks per SDU to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_frame_blocks_per_sdu(struct bt_audio_codec_cfg *codec_cfg,
 						uint8_t frame_blocks);
@@ -545,9 +545,9 @@ int bt_audio_codec_cfg_set_frame_blocks_per_sdu(struct bt_audio_codec_cfg *codec
  * @param[in] type The type id to look for
  * @param[out] data Pointer to the data-pointer to update when item is found
  *
- * @retval len Length of found @p data (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return Length of found @p data (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
 			       enum bt_audio_codec_cfg_type type, const uint8_t **data);
@@ -560,9 +560,9 @@ int bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
  * @param data       Pointer to the data-pointer to set
  * @param data_len   Length of @p data
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_set_val(struct bt_audio_codec_cfg *codec_cfg,
 			       enum bt_audio_codec_cfg_type type, const uint8_t *data,
@@ -576,8 +576,8 @@ int bt_audio_codec_cfg_set_val(struct bt_audio_codec_cfg *codec_cfg,
  * @param codec_cfg  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_unset_val(struct bt_audio_codec_cfg *codec_cfg,
 				 enum bt_audio_codec_cfg_type type);
@@ -590,9 +590,9 @@ int bt_audio_codec_cfg_unset_val(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  type      The type id to look for
  * @param[out] data      Pointer to the data-pointer to update when item is found
  *
- * @retval len Length of found @p data (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return Length of found @p data (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_val(const struct bt_audio_codec_cfg *codec_cfg, uint8_t type,
 				    const uint8_t **data);
@@ -605,9 +605,9 @@ int bt_audio_codec_cfg_meta_get_val(const struct bt_audio_codec_cfg *codec_cfg, 
  * @param data       Pointer to the data-pointer to set.
  * @param data_len   Length of @p data.
  *
- * @retval meta_len The @p codec_cfg.meta_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.meta_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_val(struct bt_audio_codec_cfg *codec_cfg,
 				    enum bt_audio_metadata_type type, const uint8_t *data,
@@ -621,8 +621,8 @@ int bt_audio_codec_cfg_meta_set_val(struct bt_audio_codec_cfg *codec_cfg,
  * @param codec_cfg  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval meta_len The of @p codec_cfg.meta_len success
- * @retval -EINVAL Arguments are invalid
+ * @return The @p codec_cfg.meta_len on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cfg_meta_unset_val(struct bt_audio_codec_cfg *codec_cfg,
 				      enum bt_audio_metadata_type type);
@@ -636,10 +636,10 @@ int bt_audio_codec_cfg_meta_unset_val(struct bt_audio_codec_cfg *codec_cfg,
  *        @ref BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED if the type is not found when @p codec_cfg.id is
  *        @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval context The preferred context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The preferred context type on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_pref_context(const struct bt_audio_codec_cfg *codec_cfg,
 					     bool fallback_to_default);
@@ -650,9 +650,9 @@ int bt_audio_codec_cfg_meta_get_pref_context(const struct bt_audio_codec_cfg *co
  * @param codec_cfg The codec configuration to set data for.
  * @param ctx       The preferred context to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_pref_context(struct bt_audio_codec_cfg *codec_cfg,
 					     enum bt_audio_context ctx);
@@ -664,10 +664,10 @@ int bt_audio_codec_cfg_meta_set_pref_context(struct bt_audio_codec_cfg *codec_cf
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval context The stream context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The stream context type on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_stream_context(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -677,9 +677,9 @@ int bt_audio_codec_cfg_meta_get_stream_context(const struct bt_audio_codec_cfg *
  * @param codec_cfg The codec configuration to set data for.
  * @param ctx       The stream context to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_stream_context(struct bt_audio_codec_cfg *codec_cfg,
 					       enum bt_audio_context ctx);
@@ -692,9 +692,9 @@ int bt_audio_codec_cfg_meta_set_stream_context(struct bt_audio_codec_cfg *codec_
  * @param[in]  codec_cfg    The codec data to search in.
  * @param[out] program_info Pointer to the UTF-8 formatted program info.
  *
- * @retval len The length of the @p program_info (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p program_info (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_program_info(const struct bt_audio_codec_cfg *codec_cfg,
 					     const uint8_t **program_info);
@@ -706,9 +706,9 @@ int bt_audio_codec_cfg_meta_get_program_info(const struct bt_audio_codec_cfg *co
  * @param program_info     The program info to set.
  * @param program_info_len The length of @p program_info.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_program_info(struct bt_audio_codec_cfg *codec_cfg,
 					     const uint8_t *program_info, size_t program_info_len);
@@ -721,10 +721,10 @@ int bt_audio_codec_cfg_meta_set_program_info(struct bt_audio_codec_cfg *codec_cf
  * @param[in]  codec_cfg The codec data to search in.
  * @param[out] lang      Pointer to the language bytes (of length BT_AUDIO_LANG_SIZE)
  *
- * @retval 0 Success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_lang(const struct bt_audio_codec_cfg *codec_cfg,
 				     const uint8_t **lang);
@@ -735,9 +735,9 @@ int bt_audio_codec_cfg_meta_get_lang(const struct bt_audio_codec_cfg *codec_cfg,
  * @param codec_cfg   The codec configuration to set data for.
  * @param lang        The 24-bit language to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_lang(struct bt_audio_codec_cfg *codec_cfg,
 				     const uint8_t lang[BT_AUDIO_LANG_SIZE]);
@@ -750,9 +750,9 @@ int bt_audio_codec_cfg_meta_set_lang(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  codec_cfg The codec data to search in.
  * @param[out] ccid_list Pointer to the array containing 8-bit CCIDs.
  *
- * @retval len The length of the @p ccid_list (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p ccid_list (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_ccid_list(const struct bt_audio_codec_cfg *codec_cfg,
 					  const uint8_t **ccid_list);
@@ -764,9 +764,9 @@ int bt_audio_codec_cfg_meta_get_ccid_list(const struct bt_audio_codec_cfg *codec
  * @param ccid_list     The program info to set.
  * @param ccid_list_len The length of @p ccid_list.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_ccid_list(struct bt_audio_codec_cfg *codec_cfg,
 					  const uint8_t *ccid_list, size_t ccid_list_len);
@@ -778,10 +778,10 @@ int bt_audio_codec_cfg_meta_set_ccid_list(struct bt_audio_codec_cfg *codec_cfg,
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval parental_rating The parental rating if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The parental rating on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_parental_rating(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -791,9 +791,9 @@ int bt_audio_codec_cfg_meta_get_parental_rating(const struct bt_audio_codec_cfg 
  * @param codec_cfg       The codec configuration to set data for.
  * @param parental_rating The parental rating to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_parental_rating(struct bt_audio_codec_cfg *codec_cfg,
 						enum bt_audio_parental_rating parental_rating);
@@ -806,9 +806,9 @@ int bt_audio_codec_cfg_meta_set_parental_rating(struct bt_audio_codec_cfg *codec
  * @param[in]  codec_cfg The codec data to search in.
  * @param[out] program_info_uri Pointer to the UTF-8 formatted program info URI.
  *
- * @retval len The length of the @p program_info_uri (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p program_info_uri (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_program_info_uri(const struct bt_audio_codec_cfg *codec_cfg,
 						 const uint8_t **program_info_uri);
@@ -820,9 +820,9 @@ int bt_audio_codec_cfg_meta_get_program_info_uri(const struct bt_audio_codec_cfg
  * @param program_info_uri     The program info URI to set.
  * @param program_info_uri_len The length of @p program_info_uri.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_program_info_uri(struct bt_audio_codec_cfg *codec_cfg,
 						 const uint8_t *program_info_uri,
@@ -835,10 +835,10 @@ int bt_audio_codec_cfg_meta_set_program_info_uri(struct bt_audio_codec_cfg *code
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval context The preferred context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The audio active state on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_audio_active_state(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -848,9 +848,9 @@ int bt_audio_codec_cfg_meta_get_audio_active_state(const struct bt_audio_codec_c
  * @param codec_cfg The codec configuration to set data for.
  * @param state     The audio active state to set.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_audio_active_state(struct bt_audio_codec_cfg *codec_cfg,
 						   enum bt_audio_active_state state);
@@ -862,9 +862,9 @@ int bt_audio_codec_cfg_meta_set_audio_active_state(struct bt_audio_codec_cfg *co
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval 0 The flag was found
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA The flag was not found
+ * @retval 0 The flag was found.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA The flag was not found.
  */
 int bt_audio_codec_cfg_meta_get_bcast_audio_immediate_rend_flag(
 	const struct bt_audio_codec_cfg *codec_cfg);
@@ -874,9 +874,9 @@ int bt_audio_codec_cfg_meta_get_bcast_audio_immediate_rend_flag(
  *
  * @param codec_cfg The codec configuration to set data for.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_bcast_audio_immediate_rend_flag(
 	struct bt_audio_codec_cfg *codec_cfg);
@@ -888,10 +888,10 @@ int bt_audio_codec_cfg_meta_set_bcast_audio_immediate_rend_flag(
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval value The assisted listening stream value if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The assisted listening stream value on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cfg_meta_get_assisted_listening_stream(
 	const struct bt_audio_codec_cfg *codec_cfg);
@@ -902,9 +902,9 @@ int bt_audio_codec_cfg_meta_get_assisted_listening_stream(
  * @param codec_cfg The codec configuration to set data for.
  * @param val       The assisted listening stream value to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_assisted_listening_stream(
 	struct bt_audio_codec_cfg *codec_cfg, enum bt_audio_assisted_listening_stream val);
@@ -917,10 +917,10 @@ int bt_audio_codec_cfg_meta_set_assisted_listening_stream(
  * @param[in]  codec_cfg      The codec data to search in.
  * @param[out] broadcast_name Pointer to the UTF-8 formatted broadcast name.
  *
- * @retval length The length of the @p broadcast_name (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG Data found, but Invalid broadcast name
+ * @return The length of the @p broadcast_name (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG Data found, but Invalid broadcast name.
  */
 int bt_audio_codec_cfg_meta_get_broadcast_name(const struct bt_audio_codec_cfg *codec_cfg,
 					       const uint8_t **broadcast_name);
@@ -936,9 +936,9 @@ int bt_audio_codec_cfg_meta_get_broadcast_name(const struct bt_audio_codec_cfg *
  *                           @ref BT_AUDIO_BROADCAST_NAME_LEN_MIN and
  *                           @ref BT_AUDIO_BROADCAST_NAME_LEN_MAX.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_broadcast_name(struct bt_audio_codec_cfg *codec_cfg,
 					       const uint8_t *broadcast_name,
@@ -952,9 +952,9 @@ int bt_audio_codec_cfg_meta_set_broadcast_name(struct bt_audio_codec_cfg *codec_
  * @param[in]  codec_cfg     The codec data to search in.
  * @param[out] extended_meta Pointer to the extended metadata.
  *
- * @retval len The length of the @p extended_meta (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p extended_meta (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_extended(const struct bt_audio_codec_cfg *codec_cfg,
 					 const uint8_t **extended_meta);
@@ -966,9 +966,9 @@ int bt_audio_codec_cfg_meta_get_extended(const struct bt_audio_codec_cfg *codec_
  * @param extended_meta     The extended metadata to set.
  * @param extended_meta_len The length of @p extended_meta.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_extended(struct bt_audio_codec_cfg *codec_cfg,
 					 const uint8_t *extended_meta, size_t extended_meta_len);
@@ -981,9 +981,9 @@ int bt_audio_codec_cfg_meta_set_extended(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  codec_cfg   The codec data to search in.
  * @param[out] vendor_meta Pointer to the vendor specific metadata.
  *
- * @retval len The length of the @p vendor_meta (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p vendor_meta (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cfg_meta_get_vendor(const struct bt_audio_codec_cfg *codec_cfg,
 				       const uint8_t **vendor_meta);
@@ -995,9 +995,9 @@ int bt_audio_codec_cfg_meta_get_vendor(const struct bt_audio_codec_cfg *codec_cf
  * @param vendor_meta     The vendor specific metadata to set.
  * @param vendor_meta_len The length of @p vendor_meta.
  *
- * @retval data_len The @p codec_cfg.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cfg.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cfg_meta_set_vendor(struct bt_audio_codec_cfg *codec_cfg,
 				       const uint8_t *vendor_meta, size_t vendor_meta_len);
@@ -1020,9 +1020,9 @@ int bt_audio_codec_cfg_meta_set_vendor(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  type The type id to look for
  * @param[out] data Pointer to the data-pointer to update when item is found
  *
- * @retval len Length of found @p data (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return Length of found @p data (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
 			       enum bt_audio_codec_cap_type type, const uint8_t **data);
@@ -1035,9 +1035,9 @@ int bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
  * @param data       Pointer to the data-pointer to set
  * @param data_len   Length of @p data
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_val(struct bt_audio_codec_cap *codec_cap,
 			       enum bt_audio_codec_cap_type type, const uint8_t *data,
@@ -1051,8 +1051,8 @@ int bt_audio_codec_cap_set_val(struct bt_audio_codec_cap *codec_cap,
  * @param codec_cap  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cap_unset_val(struct bt_audio_codec_cap *codec_cap,
 				 enum bt_audio_codec_cap_type type);
@@ -1062,11 +1062,11 @@ int bt_audio_codec_cap_unset_val(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec capabilities to extract data from.
  *
- * @retval frequencies Bitfield of supported frequencies (@ref bt_audio_codec_cap_freq) if 0 or
- *                     positive
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return Bitfield of supported frequencies (@ref bt_audio_codec_cap_freq) on success
+ *         (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cap_get_freq(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1076,9 +1076,9 @@ int bt_audio_codec_cap_get_freq(const struct bt_audio_codec_cap *codec_cap);
  * @param codec_cap The codec capabilities to set data for.
  * @param freq      The supported frequencies to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_freq(struct bt_audio_codec_cap *codec_cap,
 				enum bt_audio_codec_cap_freq freq);
@@ -1088,10 +1088,10 @@ int bt_audio_codec_cap_set_freq(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec capabilities to extract data from.
  *
- * @retval durations Bitfield of supported frame durations if 0 or positive
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return Bitfield of supported frame durations on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cap_get_frame_dur(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1101,9 +1101,9 @@ int bt_audio_codec_cap_get_frame_dur(const struct bt_audio_codec_cap *codec_cap)
  * @param codec_cap The codec capabilities to set data for.
  * @param frame_dur The frame duration to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_frame_dur(struct bt_audio_codec_cap *codec_cap,
 				     enum bt_audio_codec_cap_frame_dur frame_dur);
@@ -1115,10 +1115,10 @@ int bt_audio_codec_cap_set_frame_dur(struct bt_audio_codec_cap *codec_cap,
  * @param fallback_to_default If true this function will provide the default value of 1
  *        if the type is not found when @p codec_cap.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval channel_counts Number of supported channel counts if 0 or positive
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return Number of supported channel counts on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cap_get_supported_audio_chan_counts(const struct bt_audio_codec_cap *codec_cap,
 						       bool fallback_to_default);
@@ -1129,9 +1129,9 @@ int bt_audio_codec_cap_get_supported_audio_chan_counts(const struct bt_audio_cod
  * @param codec_cap The codec capabilities to set data for.
  * @param chan_count The channel count frequency to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_supported_audio_chan_counts(
 	struct bt_audio_codec_cap *codec_cap, enum bt_audio_codec_cap_chan_count chan_count);
@@ -1142,10 +1142,10 @@ int bt_audio_codec_cap_set_supported_audio_chan_counts(
  * @param[in]  codec_cap   The codec capabilities to extract data from.
  * @param[out] codec_frame Struct to place the resulting values in
  *
- * @retval 0 Success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cap_get_octets_per_frame(
 	const struct bt_audio_codec_cap *codec_cap,
@@ -1157,9 +1157,9 @@ int bt_audio_codec_cap_get_octets_per_frame(
  * @param codec_cap   The codec capabilities to set data for.
  * @param codec_frame The octets per codec frame to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_octets_per_frame(
 	struct bt_audio_codec_cap *codec_cap,
@@ -1172,10 +1172,10 @@ int bt_audio_codec_cap_set_octets_per_frame(
  * @param fallback_to_default If true this function will provide the default value of 1
  *        if the type is not found when @p codec_cap.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval codec_frames_per_sdu Maximum number of codec frames per SDU supported
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size or value
+ * @return Maximum number of codec frames per SDU supported on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size or value.
  */
 int bt_audio_codec_cap_get_max_codec_frames_per_sdu(const struct bt_audio_codec_cap *codec_cap,
 						    bool fallback_to_default);
@@ -1186,9 +1186,9 @@ int bt_audio_codec_cap_get_max_codec_frames_per_sdu(const struct bt_audio_codec_
  * @param codec_cap            The codec capabilities to set data for.
  * @param codec_frames_per_sdu The maximum codec frames per SDU to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_set_max_codec_frames_per_sdu(struct bt_audio_codec_cap *codec_cap,
 						    uint8_t codec_frames_per_sdu);
@@ -1200,9 +1200,9 @@ int bt_audio_codec_cap_set_max_codec_frames_per_sdu(struct bt_audio_codec_cap *c
  * @param[in]  type      The type id to look for
  * @param[out] data      Pointer to the data-pointer to update when item is found
  *
- * @retval len Length of found @p data (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return Length of found @p data (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_val(const struct bt_audio_codec_cap *codec_cap, uint8_t type,
 				    const uint8_t **data);
@@ -1215,9 +1215,9 @@ int bt_audio_codec_cap_meta_get_val(const struct bt_audio_codec_cap *codec_cap, 
  * @param data       Pointer to the data-pointer to set.
  * @param data_len   Length of @p data.
  *
- * @retval meta_len The @p codec_cap.meta_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.meta_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_val(struct bt_audio_codec_cap *codec_cap,
 				    enum bt_audio_metadata_type type, const uint8_t *data,
@@ -1231,8 +1231,8 @@ int bt_audio_codec_cap_meta_set_val(struct bt_audio_codec_cap *codec_cap,
  * @param codec_cap  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval meta_len The of @p codec_cap.meta_len on success
- * @retval -EINVAL Arguments are invalid
+ * @return The @p codec_cap.meta_len on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_audio_codec_cap_meta_unset_val(struct bt_audio_codec_cap *codec_cap,
 				      enum bt_audio_metadata_type type);
@@ -1244,10 +1244,10 @@ int bt_audio_codec_cap_meta_unset_val(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval The preferred context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The preferred context type on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_pref_context(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1257,9 +1257,9 @@ int bt_audio_codec_cap_meta_get_pref_context(const struct bt_audio_codec_cap *co
  * @param codec_cap The codec capability to set data for.
  * @param ctx       The preferred context to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_pref_context(struct bt_audio_codec_cap *codec_cap,
 					     enum bt_audio_context ctx);
@@ -1271,10 +1271,10 @@ int bt_audio_codec_cap_meta_set_pref_context(struct bt_audio_codec_cap *codec_ca
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval context The stream context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The stream context type on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_stream_context(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1284,9 +1284,9 @@ int bt_audio_codec_cap_meta_get_stream_context(const struct bt_audio_codec_cap *
  * @param codec_cap The codec capability to set data for.
  * @param ctx       The stream context to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_stream_context(struct bt_audio_codec_cap *codec_cap,
 					       enum bt_audio_context ctx);
@@ -1299,9 +1299,9 @@ int bt_audio_codec_cap_meta_set_stream_context(struct bt_audio_codec_cap *codec_
  * @param[in]  codec_cap    The codec data to search in.
  * @param[out] program_info Pointer to the UTF-8 formatted program info.
  *
- * @retval len The length of the @p program_info (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p program_info (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_program_info(const struct bt_audio_codec_cap *codec_cap,
 					     const uint8_t **program_info);
@@ -1313,9 +1313,9 @@ int bt_audio_codec_cap_meta_get_program_info(const struct bt_audio_codec_cap *co
  * @param program_info     The program info to set.
  * @param program_info_len The length of @p program_info.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_program_info(struct bt_audio_codec_cap *codec_cap,
 					     const uint8_t *program_info, size_t program_info_len);
@@ -1328,10 +1328,10 @@ int bt_audio_codec_cap_meta_set_program_info(struct bt_audio_codec_cap *codec_ca
  * @param[in]  codec_cap The codec data to search in.
  * @param[out] lang      Pointer to the language bytes (of length BT_AUDIO_LANG_SIZE)
  *
- * @retval 0 Success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_lang(const struct bt_audio_codec_cap *codec_cap,
 				     const uint8_t **lang);
@@ -1342,9 +1342,9 @@ int bt_audio_codec_cap_meta_get_lang(const struct bt_audio_codec_cap *codec_cap,
  * @param codec_cap   The codec capability to set data for.
  * @param lang        The 24-bit language to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_lang(struct bt_audio_codec_cap *codec_cap,
 				     const uint8_t lang[BT_AUDIO_LANG_SIZE]);
@@ -1357,9 +1357,9 @@ int bt_audio_codec_cap_meta_set_lang(struct bt_audio_codec_cap *codec_cap,
  * @param[in]  codec_cap The codec data to search in.
  * @param[out] ccid_list Pointer to the array containing 8-bit CCIDs.
  *
- * @retval len The length of the @p ccid_list (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p ccid_list (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_ccid_list(const struct bt_audio_codec_cap *codec_cap,
 					  const uint8_t **ccid_list);
@@ -1371,9 +1371,9 @@ int bt_audio_codec_cap_meta_get_ccid_list(const struct bt_audio_codec_cap *codec
  * @param ccid_list     The program info to set.
  * @param ccid_list_len The length of @p ccid_list.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_ccid_list(struct bt_audio_codec_cap *codec_cap,
 					  const uint8_t *ccid_list, size_t ccid_list_len);
@@ -1385,10 +1385,10 @@ int bt_audio_codec_cap_meta_set_ccid_list(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval The parental rating if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The parental rating on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_parental_rating(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1398,9 +1398,9 @@ int bt_audio_codec_cap_meta_get_parental_rating(const struct bt_audio_codec_cap 
  * @param codec_cap       The codec capability to set data for.
  * @param parental_rating The parental rating to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_parental_rating(struct bt_audio_codec_cap *codec_cap,
 						enum bt_audio_parental_rating parental_rating);
@@ -1413,9 +1413,9 @@ int bt_audio_codec_cap_meta_set_parental_rating(struct bt_audio_codec_cap *codec
  * @param[in]  codec_cap        The codec data to search in.
  * @param[out] program_info_uri Pointer to the UTF-8 formatted program info URI.
  *
- * @retval len The length of the @p program_info_uri (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p program_info_uri (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_program_info_uri(const struct bt_audio_codec_cap *codec_cap,
 						 const uint8_t **program_info_uri);
@@ -1427,9 +1427,9 @@ int bt_audio_codec_cap_meta_get_program_info_uri(const struct bt_audio_codec_cap
  * @param program_info_uri     The program info URI to set.
  * @param program_info_uri_len The length of @p program_info_uri.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_program_info_uri(struct bt_audio_codec_cap *codec_cap,
 						 const uint8_t *program_info_uri,
@@ -1442,10 +1442,10 @@ int bt_audio_codec_cap_meta_set_program_info_uri(struct bt_audio_codec_cap *code
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval context The preferred context type if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The audio active state on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_audio_active_state(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1455,9 +1455,9 @@ int bt_audio_codec_cap_meta_get_audio_active_state(const struct bt_audio_codec_c
  * @param codec_cap The codec capability to set data for.
  * @param state     The audio active state to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_audio_active_state(struct bt_audio_codec_cap *codec_cap,
 						   enum bt_audio_active_state state);
@@ -1469,9 +1469,9 @@ int bt_audio_codec_cap_meta_set_audio_active_state(struct bt_audio_codec_cap *co
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval 0 The flag was found
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA The flag was not found
+ * @retval 0 The flag was found.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA The flag was not found.
  */
 int bt_audio_codec_cap_meta_get_bcast_audio_immediate_rend_flag(
 	const struct bt_audio_codec_cap *codec_cap);
@@ -1481,9 +1481,9 @@ int bt_audio_codec_cap_meta_get_bcast_audio_immediate_rend_flag(
  *
  * @param codec_cap The codec capability to set data for.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_bcast_audio_immediate_rend_flag(
 	struct bt_audio_codec_cap *codec_cap);
@@ -1495,10 +1495,10 @@ int bt_audio_codec_cap_meta_set_bcast_audio_immediate_rend_flag(
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval value The assisted listening stream value if positive or 0
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
- * @retval -EBADMSG The found value has invalid size
+ * @return The assisted listening stream value on success (0 or positive value).
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
+ * @retval -EBADMSG The found value has invalid size.
  */
 int bt_audio_codec_cap_meta_get_assisted_listening_stream(
 	const struct bt_audio_codec_cap *codec_cap);
@@ -1509,9 +1509,9 @@ int bt_audio_codec_cap_meta_get_assisted_listening_stream(
  * @param codec_cap The codec capability to set data for.
  * @param val       The assisted listening stream value to set.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_assisted_listening_stream(
 	struct bt_audio_codec_cap *codec_cap, enum bt_audio_assisted_listening_stream val);
@@ -1524,9 +1524,9 @@ int bt_audio_codec_cap_meta_set_assisted_listening_stream(
  * @param[in]  codec_cap      The codec data to search in.
  * @param[out] broadcast_name Pointer to the UTF-8 formatted broadcast name.
  *
- * @retval length The length of the @p broadcast_name (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p broadcast_name (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_broadcast_name(const struct bt_audio_codec_cap *codec_cap,
 					       const uint8_t **broadcast_name);
@@ -1542,9 +1542,9 @@ int bt_audio_codec_cap_meta_get_broadcast_name(const struct bt_audio_codec_cap *
  *                           @ref BT_AUDIO_BROADCAST_NAME_LEN_MIN and
  *                           @ref BT_AUDIO_BROADCAST_NAME_LEN_MAX.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_broadcast_name(struct bt_audio_codec_cap *codec_cap,
 					       const uint8_t *broadcast_name,
@@ -1557,9 +1557,9 @@ int bt_audio_codec_cap_meta_set_broadcast_name(struct bt_audio_codec_cap *codec_
  * @param[in]  codec_cap     The codec data to search in.
  * @param[out] extended_meta Pointer to the extended metadata.
  *
- * @retval len The length of the @p extended_meta (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p extended_meta (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_extended(const struct bt_audio_codec_cap *codec_cap,
 					 const uint8_t **extended_meta);
@@ -1571,9 +1571,9 @@ int bt_audio_codec_cap_meta_get_extended(const struct bt_audio_codec_cap *codec_
  * @param extended_meta     The extended metadata to set.
  * @param extended_meta_len The length of @p extended_meta.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_extended(struct bt_audio_codec_cap *codec_cap,
 					 const uint8_t *extended_meta, size_t extended_meta_len);
@@ -1586,9 +1586,9 @@ int bt_audio_codec_cap_meta_set_extended(struct bt_audio_codec_cap *codec_cap,
  * @param[in]  codec_cap   The codec data to search in.
  * @param[out] vendor_meta Pointer to the vendor specific metadata.
  *
- * @retval len The length of the @p vendor_meta (may be 0)
- * @retval -EINVAL Arguments are invalid
- * @retval -ENODATA Data not found
+ * @return The length of the @p vendor_meta (may be 0) on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENODATA Data not found.
  */
 int bt_audio_codec_cap_meta_get_vendor(const struct bt_audio_codec_cap *codec_cap,
 				       const uint8_t **vendor_meta);
@@ -1600,9 +1600,9 @@ int bt_audio_codec_cap_meta_get_vendor(const struct bt_audio_codec_cap *codec_ca
  * @param vendor_meta     The vendor specific metadata to set.
  * @param vendor_meta_len The length of @p vendor_meta.
  *
- * @retval data_len The @p codec_cap.data_len on success
- * @retval -EINVAL Arguments are invalid
- * @retval -ENOMEM The new value could not be set or added due to lack of memory
+ * @return The @p codec_cap.data_len on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The new value could not be set or added due to lack of memory.
  */
 int bt_audio_codec_cap_meta_set_vendor(struct bt_audio_codec_cap *codec_cap,
 				       const uint8_t *vendor_meta, size_t vendor_meta_len);
@@ -1625,7 +1625,7 @@ int bt_audio_codec_cap_meta_set_vendor(struct bt_audio_codec_cap *codec_cap,
  *
  * @param context A single context bit
  *
- * @return String representation of the supplied bit
+ * @return String representation of the supplied bit.
  */
 static inline char *bt_audio_context_bit_to_str(enum bt_audio_context context)
 {
@@ -1666,7 +1666,7 @@ static inline char *bt_audio_context_bit_to_str(enum bt_audio_context context)
  *
  * @param parental_rating The parental rating value
  *
- * @return String representation of the supplied parental rating value
+ * @return String representation of the supplied parental rating value.
  */
 static inline char *bt_audio_parental_rating_to_str(enum bt_audio_parental_rating parental_rating)
 {
@@ -1713,7 +1713,7 @@ static inline char *bt_audio_parental_rating_to_str(enum bt_audio_parental_ratin
  *
  * @param state The active state value
  *
- * @return String representation of the supplied active state value
+ * @return String representation of the supplied active state value.
  */
 static inline char *bt_audio_active_state_to_str(enum bt_audio_active_state state)
 {
@@ -1734,7 +1734,7 @@ static inline char *bt_audio_active_state_to_str(enum bt_audio_active_state stat
  *
  * @param freq A single frequency bit
  *
- * @return String representation of the supplied bit
+ * @return String representation of the supplied bit.
  */
 static inline char *bt_audio_codec_cap_freq_bit_to_str(enum bt_audio_codec_cap_freq freq)
 {
@@ -1777,7 +1777,7 @@ static inline char *bt_audio_codec_cap_freq_bit_to_str(enum bt_audio_codec_cap_f
  *
  * @param frame_dur A single frame duration bit
  *
- * @return String representation of the supplied bit
+ * @return String representation of the supplied bit.
  */
 static inline char *
 bt_audio_codec_cap_frame_dur_bit_to_str(enum bt_audio_codec_cap_frame_dur frame_dur)
@@ -1803,7 +1803,7 @@ bt_audio_codec_cap_frame_dur_bit_to_str(enum bt_audio_codec_cap_frame_dur frame_
  *
  * @param chan_count A single frame channel count bit
  *
- * @return String representation of the supplied bit
+ * @return String representation of the supplied bit.
  */
 static inline char *
 bt_audio_codec_cap_chan_count_bit_to_str(enum bt_audio_codec_cap_chan_count chan_count)
@@ -1837,7 +1837,7 @@ bt_audio_codec_cap_chan_count_bit_to_str(enum bt_audio_codec_cap_chan_count chan
  *
  * @param location A single location bit
  *
- * @return String representation of the supplied bit
+ * @return String representation of the supplied bit.
  */
 static inline char *bt_audio_location_bit_to_str(enum bt_audio_location location)
 {

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -500,7 +500,7 @@ struct bt_bap_scan_delegator_cb {
 	 *                   the change was caused by it, otherwise NULL.
 	 * @param recv_state Pointer to the receive state that was updated.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	void (*recv_state_updated)(struct bt_conn *conn,
 				   const struct bt_bap_scan_delegator_recv_state *recv_state);
@@ -536,7 +536,7 @@ struct bt_bap_scan_delegator_cb {
 	 * @param recv_state  Pointer to the receive state that is being
 	 *                    requested for periodic advertising sync.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*pa_sync_term_req)(struct bt_conn *conn,
 				const struct bt_bap_scan_delegator_recv_state *recv_state);
@@ -672,8 +672,8 @@ struct bt_bap_ep_info {
  * @param ep   The audio stream endpoint object.
  * @param info The structure object to be filled with the info.
  *
- * @retval 0 in case of success
- * @retval -EINVAL if @p ep or @p info are NULL
+ * @retval 0 on success.
+ * @retval -EINVAL @p ep or @p info are NULL.
  */
 int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info);
 
@@ -689,7 +689,7 @@ int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info);
  *         - @p ep is NULL
  *         - @p ep is a broadcast endpoint
  *         - @p ep is a Unicast Server endpoint not yet configured by a remote client
- *         - @p ep is a Unicast Client endpoint not yet discovered on a remote server
+ *         - @p ep is a Unicast Client endpoint not yet discovered on a remote server.
  */
 struct bt_conn *bt_bap_ep_get_conn(const struct bt_bap_ep *ep);
 
@@ -929,7 +929,7 @@ void bt_bap_stream_cb_register(struct bt_bap_stream *stream, struct bt_bap_strea
  * @param ep Remote Audio Endpoint being configured
  * @param codec_cfg Codec configuration
  *
- * @return Allocated Audio Stream object or NULL in case of error.
+ * @return Allocated Audio Stream object on success, or NULL on failure.
  */
 int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
 			 const struct bt_audio_codec_cfg *codec_cfg);
@@ -945,7 +945,7 @@ int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, str
  * @param stream Stream object being reconfigured
  * @param codec_cfg Codec configuration
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_reconfig(struct bt_bap_stream *stream,
 			   const struct bt_audio_codec_cfg *codec_cfg);
@@ -960,7 +960,7 @@ int bt_bap_stream_reconfig(struct bt_bap_stream *stream,
  * @param conn  Connection object
  * @param group Unicast group object
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group);
 
@@ -976,7 +976,7 @@ int bt_bap_stream_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group);
  * @param meta Metadata
  * @param meta_len Metadata length
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len);
 
@@ -989,7 +989,7 @@ int bt_bap_stream_enable(struct bt_bap_stream *stream, const uint8_t meta[], siz
  * @param meta Metadata
  * @param meta_len Metadata length
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_metadata(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len);
 
@@ -1003,7 +1003,7 @@ int bt_bap_stream_metadata(struct bt_bap_stream *stream, const uint8_t meta[], s
  *
  * @param stream Stream object
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_disable(struct bt_bap_stream *stream);
 
@@ -1022,13 +1022,13 @@ int bt_bap_stream_disable(struct bt_bap_stream *stream);
  *
  * @param stream Stream object
  *
- * @retval 0 in case of success
- * @retval -EINVAL if the stream, endpoint, ISO channel or connection is NULL
- * @retval -EBADMSG if the stream or ISO channel is in an invalid state for connection
- * @retval -EOPNOTSUPP if the role of the stream is not @ref BT_CONN_ROLE_CENTRAL
- * @retval -EALREADY if the ISO channel is already connecting or connected
- * @retval -EBUSY if another ISO channel is connecting
- * @retval -ENOEXEC if otherwise rejected by the ISO layer
+ * @retval 0 on success.
+ * @retval -EINVAL The stream, endpoint, ISO channel or connection is NULL.
+ * @retval -EBADMSG The stream or ISO channel is in an invalid state for connection.
+ * @retval -EOPNOTSUPP The role of the stream is not @ref BT_CONN_ROLE_CENTRAL.
+ * @retval -EALREADY The ISO channel is already connecting or connected.
+ * @retval -EBUSY Another ISO channel is connecting.
+ * @retval -ENOEXEC Otherwise rejected by the ISO layer.
  */
 int bt_bap_stream_connect(struct bt_bap_stream *stream);
 
@@ -1052,7 +1052,7 @@ int bt_bap_stream_connect(struct bt_bap_stream *stream);
  *
  * @param stream Stream object
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_start(struct bt_bap_stream *stream);
 
@@ -1067,17 +1067,16 @@ int bt_bap_stream_start(struct bt_bap_stream *stream);
  *
  * @param stream Stream object
  *
- * @retval 0 Success
- * @retval -EINVAL The @p stream does not have an endpoint or a connection, of the stream's
- *                 connection's role is not @p BT_CONN_ROLE_CENTRAL
- * @retval -EBADMSG The state of the @p stream endpoint is not @ref BT_BAP_EP_STATE_DISABLING
- * @retval -EALREADY The CIS state of the @p is not in a connected state, and thus is already
- *                   stopping
- * @retval -EBUSY The @p stream is busy with another operation
- * @retval -ENOTCONN The @p stream ACL connection is not connected
- * @retval -ENOMEM No memory to send request
- * @retval -ENOEXEC The request was rejected by GATT
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 on success.
+ * @retval -EINVAL The @p stream does not have an endpoint or a connection, or the stream's
+ *                 connection's role is not @p BT_CONN_ROLE_CENTRAL.
+ * @retval -EBADMSG The state of the @p stream endpoint is not @ref BT_BAP_EP_STATE_DISABLING.
+ * @retval -EALREADY The CIS state of the @p stream is not in a connected state, and thus is already
+ *                   stopping.
+ * @retval -EBUSY The @p stream is busy with another operation.
+ * @retval -ENOTCONN The @p stream ACL connection is not connected.
+ * @retval -ENOMEM No memory to send request.
+ * @retval -ENOEXEC The request was rejected by GATT.
  */
 int bt_bap_stream_stop(struct bt_bap_stream *stream);
 
@@ -1092,7 +1091,7 @@ int bt_bap_stream_stop(struct bt_bap_stream *stream);
  *
  * @param stream Stream object
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_release(struct bt_bap_stream *stream);
 
@@ -1108,7 +1107,7 @@ int bt_bap_stream_release(struct bt_bap_stream *stream);
  * @param seq_num  Packet Sequence number. This value shall be incremented for each call to this
  *                 function and at least once per SDU interval for a specific channel.
  *
- * @return Bytes sent in case of success or negative value in case of error.
+ * @return Bytes sent on success, negative errno value on failure.
  */
 int bt_bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf, uint16_t seq_num);
 
@@ -1126,7 +1125,7 @@ int bt_bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf, uint16
  * @param ts       Timestamp of the SDU in microseconds (us). This value can be used to transmit
  *                 multiple SDUs in the same SDU interval in a CIG or BIG.
  *
- * @return Bytes sent in case of success or negative value in case of error.
+ * @return Bytes sent on success, negative errno value on failure.
  */
 int bt_bap_stream_send_ts(struct bt_bap_stream *stream, struct net_buf *buf, uint16_t seq_num,
 			  uint32_t ts);
@@ -1144,10 +1143,10 @@ int bt_bap_stream_send_ts(struct bt_bap_stream *stream, struct net_buf *buf, uin
  * @param[in]  stream Stream object.
  * @param[out] info   Transmit info object.
  *
- * @retval 0 on success
- * @retval -EINVAL if the stream is invalid, if the stream is not configured for sending or if it is
- *         not connected with a isochronous stream
- * @retval Any return value from bt_iso_chan_get_tx_sync()
+ * @retval 0 on success.
+ * @retval -EINVAL The stream is invalid, the stream is not configured for sending, or it is
+ *         not connected with an isochronous stream.
+ * @return Any return value from bt_iso_chan_get_tx_sync().
  */
 int bt_bap_stream_get_tx_sync(struct bt_bap_stream *stream, struct bt_iso_tx_info *info);
 
@@ -1175,7 +1174,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp       Object for the ASE operation response. Only used if the return
 	 *                       value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*config)(struct bt_conn *conn, const struct bt_bap_ep *ep, enum bt_audio_dir dir,
 		      const struct bt_audio_codec_cfg *codec_cfg, struct bt_bap_stream **stream,
@@ -1195,7 +1194,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp       Object for the ASE operation response. Only used if the return
 	 *                       value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*reconfig)(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 			const struct bt_audio_codec_cfg *codec_cfg,
@@ -1212,7 +1211,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp     Object for the ASE operation response. Only used if the return
 	 *                     value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*qos)(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 		   struct bt_bap_ascs_rsp *rsp);
@@ -1228,7 +1227,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp         Object for the ASE operation response. Only used if the return
 	 *                         value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*enable)(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 		      struct bt_bap_ascs_rsp *rsp);
@@ -1242,7 +1241,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*start)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -1257,7 +1256,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp          Object for the ASE operation response. Only used if the return
 	 *                          value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*metadata)(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 			struct bt_bap_ascs_rsp *rsp);
@@ -1271,7 +1270,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*disable)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -1284,7 +1283,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*stop)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -1298,7 +1297,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*release)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 };
@@ -1311,7 +1310,7 @@ struct bt_bap_unicast_server_cb {
  *
  * @param param  Registration parameters for ascs.
  *
- * @return 0 in case of success, negative error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_server_register(const struct bt_bap_unicast_server_register_param *param);
 
@@ -1327,7 +1326,7 @@ int bt_bap_unicast_server_register(const struct bt_bap_unicast_server_register_p
  * Calling this function will issue an release operation on any ASE
  * in a non-idle state.
  *
- * @return 0 in case of success, negative error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_server_unregister(void);
 
@@ -1339,7 +1338,7 @@ int bt_bap_unicast_server_unregister(void);
  *
  * @param cb  Unicast server callback structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_server_register_cb(const struct bt_bap_unicast_server_cb *cb);
 
@@ -1351,7 +1350,7 @@ int bt_bap_unicast_server_register_cb(const struct bt_bap_unicast_server_cb *cb)
  *
  * @param cb  Unicast server callback structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_server_unregister_cb(const struct bt_bap_unicast_server_cb *cb);
 
@@ -1374,7 +1373,7 @@ typedef bool (*bt_bap_ep_func_t)(struct bt_bap_ep *ep, void *user_data);
  * @param func Function to call for each endpoint.
  * @param user_data Data to pass to the callback function.
  *
- * @retval 0 Success
+ * @retval 0 on success.
  * @retval -ECANCELED Iteration was stopped by the callback function before complete.
  * @retval -EINVAL @p conn or @p func were NULL.
  */
@@ -1388,7 +1387,7 @@ int bt_bap_unicast_server_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func
  * @param codec_cfg Codec configuration
  * @param qos_pref Audio Stream Quality of Service Preference
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_server_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 				     const struct bt_audio_codec_cfg *codec_cfg,
@@ -1485,7 +1484,7 @@ struct bt_bap_unicast_group_param {
  * @param[in]  param          The unicast group create parameters.
  * @param[out] unicast_group  Pointer to the unicast group created.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_group_create(struct bt_bap_unicast_group_param *param,
 				struct bt_bap_unicast_group **unicast_group);
@@ -1503,7 +1502,7 @@ int bt_bap_unicast_group_create(struct bt_bap_unicast_group_param *param,
  * @param unicast_group  Pointer to the unicast group created.
  * @param param          The unicast group reconfigure parameters.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_group_reconfig(struct bt_bap_unicast_group *unicast_group,
 				  const struct bt_bap_unicast_group_param *param);
@@ -1525,7 +1524,7 @@ int bt_bap_unicast_group_reconfig(struct bt_bap_unicast_group *unicast_group,
  * @param params         Array of stream parameters with streams being added to the group.
  * @param num_param      Number of parameters in @p params.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_group_add_streams(struct bt_bap_unicast_group *unicast_group,
 				     struct bt_bap_unicast_group_stream_pair_param params[],
@@ -1539,7 +1538,7 @@ int bt_bap_unicast_group_add_streams(struct bt_bap_unicast_group *unicast_group,
  *
  * @param unicast_group  Pointer to the unicast group to delete
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_group_delete(struct bt_bap_unicast_group *unicast_group);
 
@@ -1561,7 +1560,7 @@ typedef bool (*bt_bap_unicast_group_foreach_stream_func_t)(struct bt_bap_stream 
  * @param func           The callback function
  * @param user_data      User specified data that sent to the callback function
  *
- * @retval 0 Success (even if no streams exists in the group).
+ * @retval 0 on success (even if no streams exists in the group).
  * @retval -ECANCELED Iteration was stopped by the callback function before complete.
  * @retval -EINVAL @p unicast_group or @p func were NULL.
  */
@@ -1594,8 +1593,8 @@ struct bt_bap_unicast_group_info {
  * @param unicast_group The unicast group object.
  * @param info          The structure object to be filled with the info.
  *
- * @retval 0 Success
- * @retval -EINVAL  @p unicast_group or @p info are NULL
+ * @retval 0 on success.
+ * @retval -EINVAL @p unicast_group or @p info are NULL.
  */
 int bt_bap_unicast_group_get_info(const struct bt_bap_unicast_group *unicast_group,
 				  struct bt_bap_unicast_group_info *info);
@@ -1804,7 +1803,7 @@ struct bt_bap_unicast_client_cb {
  *
  * @param cb  Unicast client callback structure to register.
  *
- * @retval 0 Success
+ * @retval 0 on success.
  * @retval -EINVAL @p cb is NULL.
  * @retval -EEXIST @p cb is already registered.
  */
@@ -1815,8 +1814,8 @@ int bt_bap_unicast_client_register_cb(struct bt_bap_unicast_client_cb *cb);
  *
  * @param cb  Unicast client callback structure to unregister.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL or @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL or @p cb was not registered.
  */
 int bt_bap_unicast_client_unregister_cb(struct bt_bap_unicast_client_cb *cb);
 
@@ -1830,13 +1829,13 @@ int bt_bap_unicast_client_unregister_cb(struct bt_bap_unicast_client_cb *cb);
  *               requirements of the Basic Audio Profile.
  * @param dir    The type of remote endpoints and capabilities to discover.
  *
- * @retval 0 Success
+ * @retval 0 on success.
  * @retval -EINVAL @p conn is NULL, not a central connection or does not conform to security
  *                 requirements, or @p dir is invalid.
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocate memory for the request
- * @retval -ENOEXEC Unexpected GATT error
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected GATT error.
  */
 int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir);
 
@@ -1878,8 +1877,7 @@ struct bt_bap_base_subgroup_bis {
  *
  * @param ad The periodic advertising data
  *
- * @retval NULL if the data does not contain a BASE
- * @retval Pointer to a bt_bap_base structure
+ * @return Pointer to a bt_bap_base structure, or NULL if the data does not contain a BASE.
  */
 const struct bt_bap_base *bt_bap_base_get_base_from_ad(const struct bt_data *ad);
 
@@ -1888,8 +1886,8 @@ const struct bt_bap_base *bt_bap_base_get_base_from_ad(const struct bt_data *ad)
  *
  * @param base The BASE pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The size of the BASE
+ * @return The size of the BASE on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_size(const struct bt_bap_base *base);
 
@@ -1898,8 +1896,8 @@ int bt_bap_base_get_size(const struct bt_bap_base *base);
  *
  * @param base The BASE pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The 24-bit presentation delay value
+ * @return The 24-bit presentation delay value on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_pres_delay(const struct bt_bap_base *base);
 
@@ -1908,8 +1906,8 @@ int bt_bap_base_get_pres_delay(const struct bt_bap_base *base);
  *
  * @param base The BASE pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The 8-bit subgroup count value
+ * @return The 8-bit subgroup count value on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_subgroup_count(const struct bt_bap_base *base);
 
@@ -1919,8 +1917,8 @@ int bt_bap_base_get_subgroup_count(const struct bt_bap_base *base);
  * @param[in]  base        The BASE pointer
  * @param[out] bis_indexes 32-bit BIS index bitfield that will be populated
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_bis_indexes(const struct bt_bap_base *base, uint32_t *bis_indexes);
 
@@ -1931,9 +1929,9 @@ int bt_bap_base_get_bis_indexes(const struct bt_bap_base *base, uint32_t *bis_in
  * @param func      Callback function. Return true to continue iterating, or false to stop.
  * @param user_data Userdata supplied to @p func
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ECANCELED if iterating over the subgroups stopped prematurely by @p func
- * @retval 0 if all subgroups were iterated
+ * @retval 0 All subgroups were iterated.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ECANCELED Iterating over the subgroups stopped prematurely by @p func.
  */
 int bt_bap_base_foreach_subgroup(const struct bt_bap_base *base,
 				 bool (*func)(const struct bt_bap_base_subgroup *subgroup,
@@ -1946,8 +1944,8 @@ int bt_bap_base_foreach_subgroup(const struct bt_bap_base *base,
  * @param[in]  subgroup The subgroup pointer
  * @param[out] codec_id Pointer to the struct where the results are placed
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_subgroup_codec_id(const struct bt_bap_base_subgroup *subgroup,
 				      struct bt_bap_base_codec_id *codec_id);
@@ -1958,8 +1956,8 @@ int bt_bap_base_get_subgroup_codec_id(const struct bt_bap_base_subgroup *subgrou
  * @param[in]  subgroup The subgroup pointer
  * @param[out] data     Pointer that will point to the resulting codec configuration data
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_subgroup_codec_data(const struct bt_bap_base_subgroup *subgroup,
 					uint8_t **data);
@@ -1970,8 +1968,8 @@ int bt_bap_base_get_subgroup_codec_data(const struct bt_bap_base_subgroup *subgr
  * @param[in]  subgroup The subgroup pointer
  * @param[out] meta     Pointer that will point to the resulting codec metadata
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_subgroup_codec_meta(const struct bt_bap_base_subgroup *subgroup,
 					uint8_t **meta);
@@ -1982,9 +1980,9 @@ int bt_bap_base_get_subgroup_codec_meta(const struct bt_bap_base_subgroup *subgr
  * @param[in]  subgroup  The subgroup pointer
  * @param[out] codec_cfg Pointer to the struct where the results are placed
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the @p codec_cfg cannot store the @p subgroup codec data
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The @p codec_cfg cannot store the @p subgroup codec data.
  */
 int bt_bap_base_subgroup_codec_to_codec_cfg(const struct bt_bap_base_subgroup *subgroup,
 					    struct bt_audio_codec_cfg *codec_cfg);
@@ -1994,8 +1992,8 @@ int bt_bap_base_subgroup_codec_to_codec_cfg(const struct bt_bap_base_subgroup *s
  *
  * @param subgroup The subgroup pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The 8-bit BIS count value
+ * @return The 8-bit BIS count value on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_subgroup_bis_count(const struct bt_bap_base_subgroup *subgroup);
 
@@ -2005,8 +2003,8 @@ int bt_bap_base_get_subgroup_bis_count(const struct bt_bap_base_subgroup *subgro
  * @param[in]  subgroup    The subgroup pointer
  * @param[out] bis_indexes 32-bit BIS index bitfield that will be populated
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_subgroup_get_bis_indexes(const struct bt_bap_base_subgroup *subgroup,
 					 uint32_t *bis_indexes);
@@ -2018,9 +2016,9 @@ int bt_bap_base_subgroup_get_bis_indexes(const struct bt_bap_base_subgroup *subg
  * @param func      Callback function. Return true to continue iterating, or false to stop.
  * @param user_data Userdata supplied to @p func
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ECANCELED if iterating over the subgroups stopped prematurely by @p func
- * @retval 0 if all BIS were iterated
+ * @retval 0 All BIS were iterated.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ECANCELED Iterating over the subgroups stopped prematurely by @p func.
  */
 int bt_bap_base_subgroup_foreach_bis(const struct bt_bap_base_subgroup *subgroup,
 				     bool (*func)(const struct bt_bap_base_subgroup_bis *bis,
@@ -2036,9 +2034,9 @@ int bt_bap_base_subgroup_foreach_bis(const struct bt_bap_base_subgroup *subgroup
  * @param[in]  bis       The BIS pointer
  * @param[out] codec_cfg Pointer to the struct where the results are placed
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the @p codec_cfg cannot store the @p subgroup codec data
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The @p codec_cfg cannot store the @p subgroup codec data.
  */
 int bt_bap_base_subgroup_bis_codec_to_codec_cfg(const struct bt_bap_base_subgroup_bis *bis,
 						struct bt_audio_codec_cfg *codec_cfg);
@@ -2084,9 +2082,9 @@ struct bt_bap_broadcast_source_cb {
  *
  * @param cb Pointer to the callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EEXIST if @p cb is already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EEXIST @p cb is already registered.
  */
 int bt_bap_broadcast_source_register_cb(struct bt_bap_broadcast_source_cb *cb);
 
@@ -2095,9 +2093,9 @@ int bt_bap_broadcast_source_register_cb(struct bt_bap_broadcast_source_cb *cb);
  *
  * @param cb Pointer to the callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -ENOENT if @p cb is not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -ENOENT @p cb is not registered.
  */
 int bt_bap_broadcast_source_unregister_cb(struct bt_bap_broadcast_source_cb *cb);
 
@@ -2210,7 +2208,7 @@ struct bt_bap_broadcast_source_param {
  * @param[in]  param       Pointer to parameters used to create the broadcast source.
  * @param[out] source      Pointer to the broadcast source created
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_create(struct bt_bap_broadcast_source_param *param,
 				   struct bt_bap_broadcast_source **source);
@@ -2232,7 +2230,7 @@ int bt_bap_broadcast_source_create(struct bt_bap_broadcast_source_param *param,
  * @param source      Pointer to the broadcast source
  * @param param       Pointer to parameters used to reconfigure the broadcast source.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
 				     struct bt_bap_broadcast_source_param *param);
@@ -2247,7 +2245,7 @@ int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
  * @param meta        Metadata.
  * @param meta_len    Length of metadata.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_update_metadata(struct bt_bap_broadcast_source *source,
 					    const uint8_t meta[], size_t meta_len);
@@ -2261,7 +2259,7 @@ int bt_bap_broadcast_source_update_metadata(struct bt_bap_broadcast_source *sour
  * @param source      Pointer to the broadcast source
  * @param adv         Pointer to an extended advertising set with periodic advertising configured.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_start(struct bt_bap_broadcast_source *source,
 				  struct bt_le_ext_adv *adv);
@@ -2274,7 +2272,7 @@ int bt_bap_broadcast_source_start(struct bt_bap_broadcast_source *source,
  *
  * @param source      Pointer to the broadcast source
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_stop(struct bt_bap_broadcast_source *source);
 
@@ -2286,7 +2284,7 @@ int bt_bap_broadcast_source_stop(struct bt_bap_broadcast_source *source);
  *
  * @param source      Pointer to the broadcast source
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_delete(struct bt_bap_broadcast_source *source);
 
@@ -2302,7 +2300,7 @@ int bt_bap_broadcast_source_delete(struct bt_bap_broadcast_source *source);
  * @param source        Pointer to the broadcast source.
  * @param base_buf      Pointer to a buffer where the BASE will be inserted.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_get_base(struct bt_bap_broadcast_source *source,
 				     struct net_buf_simple *base_buf);
@@ -2326,9 +2324,9 @@ typedef bool (*bt_bap_broadcast_source_foreach_stream_func_t)(struct bt_bap_stre
  * @param func           The callback function
  * @param user_data      User specified data that is sent to the callback function
  *
- * @retval 0          Success (even if no streams exists in the broadcast source).
+ * @retval 0 on success (even if no streams exists in the broadcast source).
  * @retval -ECANCELED The @p func returned false and stopped the iteration.
- * @retval -EINVAL    @p source or @p func were NULL.
+ * @retval -EINVAL @p source or @p func were NULL.
  */
 int bt_bap_broadcast_source_foreach_stream(struct bt_bap_broadcast_source *source,
 					   bt_bap_broadcast_source_foreach_stream_func_t func,
@@ -2402,9 +2400,9 @@ struct bt_bap_broadcast_sink_cb {
 
  * @param cb  Broadcast sink callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb was already registered.
  */
 int bt_bap_broadcast_sink_register_cb(struct bt_bap_broadcast_sink_cb *cb);
 
@@ -2424,7 +2422,7 @@ int bt_bap_broadcast_sink_register_cb(struct bt_bap_broadcast_sink_cb *cb);
  * @param      broadcast_id  24-bit broadcast ID.
  * @param[out] sink          Pointer to the Broadcast Sink created.
  *
- * @return 0 in case of success or errno value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_sink_create(struct bt_le_per_adv_sync *pa_sync, uint32_t broadcast_id,
 				 struct bt_bap_broadcast_sink **sink);
@@ -2446,7 +2444,7 @@ int bt_bap_broadcast_sink_create(struct bt_le_per_adv_sync *pa_sync, uint32_t br
  *                           The string "Broadcast Code" shall be
  *                           [42 72 6F 61 64 63 61 73 74 20 43 6F 64 65 00 00]
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t indexes_bitfield,
 			       struct bt_bap_stream *streams[],
@@ -2460,7 +2458,7 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
  *
  * @param sink      Pointer to the broadcast sink
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_sink_stop(struct bt_bap_broadcast_sink *sink);
 
@@ -2473,7 +2471,7 @@ int bt_bap_broadcast_sink_stop(struct bt_bap_broadcast_sink *sink);
  *
  * @param sink Pointer to the sink object to delete.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_sink_delete(struct bt_bap_broadcast_sink *sink);
 
@@ -2490,7 +2488,7 @@ int bt_bap_broadcast_sink_delete(struct bt_bap_broadcast_sink *sink);
  *
  * @param cb Pointer to the callback struct
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_register(struct bt_bap_scan_delegator_cb *cb);
 
@@ -2500,7 +2498,7 @@ int bt_bap_scan_delegator_register(struct bt_bap_scan_delegator_cb *cb);
  * Unregister the scan delegator and Broadcast Audio Scan Service (BASS)
  * dynamically at runtime.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_unregister(void);
 
@@ -2513,7 +2511,7 @@ int bt_bap_scan_delegator_unregister(void);
  * @param src_id    The source id used to identify the receive state.
  * @param pa_state  The Periodic Advertising sync state to set.
  *
- * @return int    Error value. 0 on success, errno on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_set_pa_state(uint8_t src_id,
 				       enum bt_bap_pa_state pa_state);
@@ -2524,7 +2522,7 @@ int bt_bap_scan_delegator_set_pa_state(uint8_t src_id,
  * @param src_id         The source id used to identify the receive state.
  * @param bis_synced     Array of bitfields to set the BIS sync state for each
  *                       subgroup.
- * @return int           Error value. 0 on success, ERRNO on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_set_bis_sync_state(uint8_t src_id,
 					     uint32_t bis_synced[BT_BAP_BASS_MAX_SUBGROUPS]);
@@ -2569,7 +2567,7 @@ struct bt_bap_scan_delegator_add_src_param {
  *
  * @param param The parameters for adding the new source
  *
- * @return int  errno on failure, or source ID on success.
+ * @return Source ID on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_add_src(const struct bt_bap_scan_delegator_add_src_param *param);
 
@@ -2607,7 +2605,7 @@ struct bt_bap_scan_delegator_mod_src_param {
  *
  * @param param The parameters for adding the new source
  *
- * @return int  errno on failure, or source ID on success.
+ * @return Source ID on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_mod_src(const struct bt_bap_scan_delegator_mod_src_param *param);
 
@@ -2622,7 +2620,7 @@ int bt_bap_scan_delegator_mod_src(const struct bt_bap_scan_delegator_mod_src_par
  *
  * @param src_id The source ID to remove
  *
- * @return int   Error value. 0 on success, errno on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_rem_src(uint8_t src_id);
 
@@ -2633,8 +2631,8 @@ int bt_bap_scan_delegator_rem_src(uint8_t src_id);
  *
  * @retval true to stop iterating. If this is used in the context of
  *         bt_bap_scan_delegator_find_state(), the recv_state will be returned by
- *         bt_bap_scan_delegator_find_state()
- * @retval false to continue iterating
+ *         bt_bap_scan_delegator_find_state().
+ * @retval false to continue iterating.
  */
 typedef bool (*bt_bap_scan_delegator_state_func_t)(
 	const struct bt_bap_scan_delegator_recv_state *recv_state, void *user_data);
@@ -2654,7 +2652,7 @@ void bt_bap_scan_delegator_foreach_state(bt_bap_scan_delegator_state_func_t func
  * @param func      The compare callback function
  * @param user_data User specified data that sent to the callback function
  *
- * @return The first receive state where the @p func returned true, or NULL
+ * @return The first receive state where the @p func returned true, or NULL.
  */
 const struct bt_bap_scan_delegator_recv_state *bt_bap_scan_delegator_find_state(
 	bt_bap_scan_delegator_state_func_t func, void *user_data);
@@ -2783,12 +2781,12 @@ struct bt_bap_broadcast_assistant_cb {
  * @param conn  The ACL connection. The connection must already conform to the security requirements
  *              of the Basic Audio Profile.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL, does not conform to security requirements
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocate memory for the request
- * @retval -ENOEXEC Unexpected GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL, does not conform to security requirements.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected GATT error.
  */
 int bt_bap_broadcast_assistant_discover(struct bt_conn *conn);
 
@@ -2808,13 +2806,13 @@ int bt_bap_broadcast_assistant_discover(struct bt_conn *conn);
  * @param start_scan    Start scanning if true. If false, the application should
  *                      enable scan itself.
 
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL of if @p conn has not done discovery
- * @retval -EBUSY Another operation is already in progress for this @p conn
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL or @p conn has not done discovery.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
  * @retval -EAGAIN Bluetooth has not been enabled.
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn,
 					  bool start_scan);
@@ -2824,13 +2822,13 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn,
  *
  * @param conn   Connection to the server.
 
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL of if @p conn has not done discovery
- * @retval -EBUSY Another operation is already in progress for this @p conn
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL or @p conn has not done discovery.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
  * @retval -EAGAIN Bluetooth has not been enabled.
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn);
 
@@ -2839,9 +2837,9 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn);
  *
  * @param cb	The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb was already registered.
  */
 int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb *cb);
 
@@ -2850,9 +2848,9 @@ int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb 
  *
  * @param cb   The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb was not registered.
  */
 int bt_bap_broadcast_assistant_unregister_cb(struct bt_bap_broadcast_assistant_cb *cb);
 
@@ -2895,12 +2893,12 @@ struct bt_bap_broadcast_assistant_add_src_param {
  * @param conn          Connection to the server.
  * @param param         Parameter struct.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL or %p conn has not done discovery or if @p param is invalid
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL, @p conn has not done discovery, or @p param is invalid.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_add_src(
 	struct bt_conn *conn, const struct bt_bap_broadcast_assistant_add_src_param *param);
@@ -2933,12 +2931,12 @@ struct bt_bap_broadcast_assistant_mod_src_param {
  * @param conn          Connection to the server.
  * @param param         Parameter struct.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL or %p conn has not done discovery or if @p param is invalid
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL, @p conn has not done discovery, or @p param is invalid.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_mod_src(
 	struct bt_conn *conn, const struct bt_bap_broadcast_assistant_mod_src_param *param);
@@ -2950,12 +2948,12 @@ int bt_bap_broadcast_assistant_mod_src(
  * @param src_id          Source ID of the receive state.
  * @param broadcast_code  The broadcast code.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL or %p conn has not done discovery or @p src_id is invalid
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL or @p conn has not done discovery or @p src_id is invalid.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_set_broadcast_code(
 	struct bt_conn *conn, uint8_t src_id,
@@ -2967,12 +2965,12 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
  * @param conn            Connection to the server.
  * @param src_id          Source ID of the receive state.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL or %p conn has not done discovery or @p src_id is invalid
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL or @p conn has not done discovery or @p src_id is invalid.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id);
 
@@ -2983,12 +2981,12 @@ int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id);
  * @param idx      The index of the receive start (0 up to the value from
  *                 bt_bap_broadcast_assistant_discover_cb)
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL or %p conn has not done discovery or @p src_id is invalid
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL or @p conn has not done discovery or @p src_id is invalid.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_read_recv_state(struct bt_conn *conn, uint8_t idx);
 

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -75,7 +75,7 @@ struct bt_cap_unicast_group;
  * @param[out] svc_inst  Pointer to the registered Coordinated Set
  *                       Identification Service.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_acceptor_register(const struct bt_csip_set_member_register_param *param,
 			     struct bt_csip_set_member_svc_inst **svc_inst);
@@ -191,10 +191,10 @@ struct bt_cap_initiator_cb {
  *
  * @param conn Connection to a remote server.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
  */
 int bt_cap_initiator_unicast_discover(struct bt_conn *conn);
 
@@ -251,8 +251,8 @@ void bt_cap_stream_ops_register(struct bt_cap_stream *stream, struct bt_bap_stre
  * @param seq_num  Packet Sequence number. This value shall be incremented for each call to this
  *                 function and at least once per SDU interval for a specific channel.
  *
- * @retval -EINVAL if stream object is NULL
- * @retval Any return value from bt_bap_stream_send()
+ * @retval -EINVAL Stream object is NULL.
+ * @return Any return value from bt_bap_stream_send().
  */
 int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num);
 
@@ -270,8 +270,8 @@ int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16
  * @param ts       Timestamp of the SDU in microseconds (us). This value can be used to transmit
  *                 multiple SDUs in the same SDU interval in a CIG or BIG.
  *
- * @retval -EINVAL if stream object is NULL
- * @retval Any return value from bt_bap_stream_send()
+ * @retval -EINVAL Stream object is NULL.
+ * @return Any return value from bt_bap_stream_send().
  */
 int bt_cap_stream_send_ts(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num,
 			  uint32_t ts);
@@ -286,8 +286,8 @@ int bt_cap_stream_send_ts(struct bt_cap_stream *stream, struct net_buf *buf, uin
  * @param[in]  stream Stream object.
  * @param[out] info   Transmit info object.
  *
- * @retval -EINVAL if stream object is NULL
- * @retval Any return value from bt_bap_stream_get_tx_sync()
+ * @retval -EINVAL Stream object is NULL.
+ * @return Any return value from bt_bap_stream_get_tx_sync().
  */
 int bt_cap_stream_get_tx_sync(struct bt_cap_stream *stream, struct bt_iso_tx_info *info);
 
@@ -374,7 +374,7 @@ struct bt_cap_unicast_group_param {
  * @param[in]  param          The unicast group create parameters.
  * @param[out] unicast_group  Pointer to the unicast group created.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_unicast_group_create(const struct bt_cap_unicast_group_param *param,
 				struct bt_cap_unicast_group **unicast_group);
@@ -392,7 +392,7 @@ int bt_cap_unicast_group_create(const struct bt_cap_unicast_group_param *param,
  * @param unicast_group  Pointer to the unicast group created.
  * @param param          The unicast group reconfigure parameters.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_unicast_group_reconfig(struct bt_cap_unicast_group *unicast_group,
 				  const struct bt_cap_unicast_group_param *param);
@@ -414,7 +414,7 @@ int bt_cap_unicast_group_reconfig(struct bt_cap_unicast_group *unicast_group,
  * @param params         Array of stream parameters with streams being added to the group.
  * @param num_param      Number of parameters in @p params.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_unicast_group_add_streams(struct bt_cap_unicast_group *unicast_group,
 				     const struct bt_cap_unicast_group_stream_pair_param params[],
@@ -428,7 +428,7 @@ int bt_cap_unicast_group_add_streams(struct bt_cap_unicast_group *unicast_group,
  *
  * @param unicast_group  Pointer to the unicast group to delete
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_unicast_group_delete(struct bt_cap_unicast_group *unicast_group);
 
@@ -450,7 +450,7 @@ typedef bool (*bt_cap_unicast_group_foreach_stream_func_t)(struct bt_cap_stream 
  * @param func           The callback function
  * @param user_data      User specified data that is sent to the callback function
  *
- * @retval 0 Success (even if no streams exists in the group).
+ * @retval 0 on success (even if no streams exists in the group).
  * @retval -ECANCELED The @p func returned false and stopped the iteration.
  * @retval -EINVAL @p unicast_group or @p func were NULL.
  */
@@ -470,8 +470,8 @@ struct bt_cap_unicast_group_info {
  * @param unicast_group The unicast group object.
  * @param info          The structure object to be filled with the info.
  *
- * @retval 0 Success
- * @retval -EINVAL  @p unicast_group or @p info are NULL
+ * @retval 0 on success.
+ * @retval -EINVAL @p unicast_group or @p info are NULL.
  */
 int bt_cap_unicast_group_get_info(const struct bt_cap_unicast_group *unicast_group,
 				  struct bt_cap_unicast_group_info *info);
@@ -560,7 +560,7 @@ struct bt_cap_unicast_audio_stop_param {
  *
  * @param cb   The callback structure. Shall remain static.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_register_cb(const struct bt_cap_initiator_cb *cb);
 
@@ -569,8 +569,8 @@ int bt_cap_initiator_register_cb(const struct bt_cap_initiator_cb *cb);
  *
  * @param cb   The callback structure that was previously registered.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL or @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL or @p cb was not registered.
  */
 int bt_cap_initiator_unregister_cb(const struct bt_cap_initiator_cb *cb);
 
@@ -587,10 +587,10 @@ int bt_cap_initiator_unregister_cb(const struct bt_cap_initiator_cb *cb);
  *
  * @param param Parameters to start the audio streams.
  *
- * @retval 0 on success
- * @retval -EBUSY if a CAP procedure is already in progress
- * @retval -EINVAL if any parameter is invalid
- * @retval -EALREADY All streams are already in the streaming state
+ * @retval 0 on success.
+ * @retval -EBUSY A CAP procedure is already in progress.
+ * @retval -EINVAL Any parameter is invalid.
+ * @retval -EALREADY All streams are already in the streaming state.
  */
 int bt_cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start_param *param);
 
@@ -605,7 +605,7 @@ int bt_cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start
  *
  * @param param Update parameters.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_update_param *param);
 
@@ -620,10 +620,10 @@ int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_upda
  *
  * @param param Stop parameters.
  *
- * @return 0 on success
- * @retval -EBUSY if a CAP procedure is already in progress
- * @retval -EINVAL if any parameter is invalid
- * @retval -EALREADY if no state changes will occur
+ * @retval 0 on success.
+ * @retval -EBUSY A CAP procedure is already in progress.
+ * @retval -EINVAL Any parameter is invalid.
+ * @retval -EALREADY No state changes will occur.
  */
 int bt_cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_param *param);
 
@@ -647,8 +647,8 @@ int bt_cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_p
  * The respective callbacks of the procedure will be called as part of this with the connection
  * pointer set to 0 and the err value set to -ECANCELED.
  *
- * @retval 0 on success
- * @retval -EALREADY if no procedure is active
+ * @retval 0 on success.
+ * @retval -EALREADY No procedure is active.
  */
 int bt_cap_initiator_unicast_audio_cancel(void);
 
@@ -764,12 +764,12 @@ struct bt_cap_initiator_broadcast_create_param {
  * @param[in]  param             Parameters to start the audio streams.
  * @param[out] broadcast_source  Pointer to the broadcast source created.
  *
- * @retval 0 Success
- * @retval -EINVAL @p param is invalid or @p broadcast_source is NULL
+ * @retval 0 on success.
+ * @retval -EINVAL @p param is invalid or @p broadcast_source is NULL.
  * @retval -ENOMEM Could not allocate more broadcast sources, subgroups or ISO streams, or the
  *         provided codec configuration data is too large when merging the BIS and subgroup
  *         configuration data.
- * @retval -ENOEXEC The broadcast source failed to be created for other reasons
+ * @retval -ENOEXEC The broadcast source failed to be created for other reasons.
  */
 int bt_cap_initiator_broadcast_audio_create(
 	const struct bt_cap_initiator_broadcast_create_param *param,
@@ -792,7 +792,7 @@ int bt_cap_initiator_broadcast_audio_create(
  * @param adv               Pointer to an extended advertising set with
  *                          periodic advertising configured.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_broadcast_audio_start(struct bt_cap_broadcast_source *broadcast_source,
 					   struct bt_le_ext_adv *adv);
@@ -808,7 +808,7 @@ int bt_cap_initiator_broadcast_audio_start(struct bt_cap_broadcast_source *broad
  *                         of CCIDs as well as a non-0 context bitfield.
  * @param meta_len         The length of @p meta.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_broadcast_audio_update(struct bt_cap_broadcast_source *broadcast_source,
 					    const uint8_t meta[], size_t meta_len);
@@ -823,7 +823,7 @@ int bt_cap_initiator_broadcast_audio_update(struct bt_cap_broadcast_source *broa
  * @param broadcast_source The broadcast source to stop. The audio streams
  *                         in this will be stopped and reset.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_broadcast_audio_stop(struct bt_cap_broadcast_source *broadcast_source);
 
@@ -842,7 +842,7 @@ int bt_cap_initiator_broadcast_audio_stop(struct bt_cap_broadcast_source *broadc
  * @param broadcast_source The broadcast source to delete.
  *                         The @p broadcast_source will be invalidated.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_broadcast_audio_delete(struct bt_cap_broadcast_source *broadcast_source);
 
@@ -859,7 +859,7 @@ int bt_cap_initiator_broadcast_audio_delete(struct bt_cap_broadcast_source *broa
  * @param broadcast_source  Pointer to the broadcast source.
  * @param base_buf          Pointer to a buffer where the BASE will be inserted.
  *
- * @return int		0 if on success, errno on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_initiator_broadcast_get_base(struct bt_cap_broadcast_source *broadcast_source,
 					struct net_buf_simple *base_buf);
@@ -882,9 +882,9 @@ typedef bool (*bt_cap_initiator_broadcast_foreach_stream_func_t)(struct bt_cap_s
  * @param func              The callback function.
  * @param user_data         User specified data that is sent to the callback function.
  *
- * @retval 0          Success (even if no streams exists in the group).
+ * @retval 0 on success (even if no streams exists in the group).
  * @retval -ECANCELED The @p func returned false and stopped the iteration.
- * @retval -EINVAL    @p broadcast_source or @p func were NULL.
+ * @retval -EINVAL @p broadcast_source or @p func were NULL.
  */
 int bt_cap_initiator_broadcast_foreach_stream(struct bt_cap_broadcast_source *broadcast_source,
 					      bt_cap_initiator_broadcast_foreach_stream_func_t func,
@@ -972,7 +972,7 @@ struct bt_cap_handover_cb {
  *
  * @param cb   The callback structure. Shall remain static.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_handover_register_cb(const struct bt_cap_handover_cb *cb);
 
@@ -981,8 +981,8 @@ int bt_cap_handover_register_cb(const struct bt_cap_handover_cb *cb);
  *
  * @param cb   The callback structure that was previously registered.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL or @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL or @p cb was not registered.
  */
 int bt_cap_handover_unregister_cb(const struct bt_cap_handover_cb *cb);
 
@@ -1001,7 +1001,7 @@ int bt_cap_handover_unregister_cb(const struct bt_cap_handover_cb *cb);
  *
  * @param param The parameters for the handover.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_handover_unicast_to_broadcast(
 	const struct bt_cap_handover_unicast_to_broadcast_param *param);
@@ -1060,7 +1060,7 @@ struct bt_cap_handover_broadcast_to_unicast_param {
  *
  * @param[in]  param          The parameters for the handover.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_handover_broadcast_to_unicast(
 	const struct bt_cap_handover_broadcast_to_unicast_param *param);
@@ -1192,9 +1192,9 @@ struct bt_cap_commander_cb {
  *
  * @param cb   The callback structure. Shall remain static.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL
- * @retval -EALREADY Callbacks are already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY Callbacks are already registered.
  */
 int bt_cap_commander_register_cb(const struct bt_cap_commander_cb *cb);
 
@@ -1203,8 +1203,8 @@ int bt_cap_commander_register_cb(const struct bt_cap_commander_cb *cb);
  *
  * @param cb   The callback structure that was previously registered.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL or @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL or @p cb was not registered.
  */
 int bt_cap_commander_unregister_cb(const struct bt_cap_commander_cb *cb);
 
@@ -1220,11 +1220,11 @@ int bt_cap_commander_unregister_cb(const struct bt_cap_commander_cb *cb);
  *
  * @param conn Connection to a remote server.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -EBUSY Already doing discovery for @p conn
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -EBUSY Already doing discovery for @p conn.
  */
 int bt_cap_commander_discover(struct bt_conn *conn);
 
@@ -1248,8 +1248,8 @@ int bt_cap_commander_discover(struct bt_conn *conn);
  * The respective callbacks of the procedure will be called as part of this with the connection
  * pointer set to NULL and the err value set to -ECANCELED.
  *
- * @retval 0 on success
- * @retval -EALREADY if no procedure is active
+ * @retval 0 on success.
+ * @retval -EALREADY No procedure is active.
  */
 int bt_cap_commander_cancel(void);
 
@@ -1306,7 +1306,7 @@ struct bt_cap_commander_broadcast_reception_start_param {
  *
  * @param param The parameters to start the broadcast audio
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_broadcast_reception_start(
 	const struct bt_cap_commander_broadcast_reception_start_param *param);
@@ -1341,7 +1341,7 @@ struct bt_cap_commander_broadcast_reception_stop_param {
  *
  * @param param The parameters to stop the broadcast audio
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_broadcast_reception_stop(
 	const struct bt_cap_commander_broadcast_reception_stop_param *param);
@@ -1385,7 +1385,7 @@ struct bt_cap_commander_distribute_broadcast_code_param {
  *
  * @param param The parameters for distributing the broadcast code
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_distribute_broadcast_code(
 	const struct bt_cap_commander_distribute_broadcast_code_param *param);
@@ -1410,7 +1410,7 @@ struct bt_cap_commander_change_volume_param {
  *
  * @param param The parameters for the volume change
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_change_volume(const struct bt_cap_commander_change_volume_param *param);
 
@@ -1447,7 +1447,7 @@ struct bt_cap_commander_change_volume_offset_param {
  *
  * @param param The parameters for the volume offset change
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_change_volume_offset(
 	const struct bt_cap_commander_change_volume_offset_param *param);
@@ -1476,7 +1476,7 @@ struct bt_cap_commander_change_volume_mute_state_param {
  *
  * @param param The parameters for the volume mute state change
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_change_volume_mute_state(
 	const struct bt_cap_commander_change_volume_mute_state_param *param);
@@ -1505,7 +1505,7 @@ struct bt_cap_commander_change_microphone_mute_state_param {
  *
  * @param param The parameters for the microphone mute state change
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_change_microphone_mute_state(
 	const struct bt_cap_commander_change_microphone_mute_state_param *param);
@@ -1539,7 +1539,7 @@ struct bt_cap_commander_change_microphone_gain_setting_param {
  *
  * @param param The parameters for the microphone gain setting change
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_cap_commander_change_microphone_gain_setting(
 	const struct bt_cap_commander_change_microphone_gain_setting_param *param);

--- a/include/zephyr/bluetooth/audio/ccid.h
+++ b/include/zephyr/bluetooth/audio/ccid.h
@@ -46,8 +46,8 @@ extern "C" {
  *
  * Requires that @kconfig{CONFIG_BT_CONN} is enabled.
  *
- * @retval ccid 8-bit unsigned CCID value on success
- * @retval -ENOMEM No more CCIDs can be allocated
+ * @return 8-bit unsigned CCID value on success.
+ * @retval -ENOMEM No more CCIDs can be allocated.
  */
 int bt_ccid_alloc_value(void);
 
@@ -60,8 +60,7 @@ int bt_ccid_alloc_value(void);
  *
  * @param ccid The CCID to search for
  *
- * @retval NULL None was found
- * @retval attr Pointer to a GATT attribute
+ * @return Pointer to a GATT attribute, or NULL if no such attribute was found.
  */
 const struct bt_gatt_attr *bt_ccid_find_attr(uint8_t ccid);
 

--- a/include/zephyr/bluetooth/audio/ccp.h
+++ b/include/zephyr/bluetooth/audio/ccp.h
@@ -67,13 +67,13 @@ struct bt_ccp_call_control_server_bearer;
  * @param[in]  param   The parameters to initialize the bearer.
  * @param[out] bearer  Pointer to the initialized bearer.
  *
- * @retval 0 Success
- * @retval -EINVAL @p param contains invalid data
- * @retval -EALREADY @p param.gtbs is true and GTBS has already been registered
- * @retval -EAGAIN @p param.gtbs is false and GTBS has not been registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p param contains invalid data.
+ * @retval -EALREADY @p param.gtbs is true and GTBS has already been registered.
+ * @retval -EAGAIN @p param.gtbs is false and GTBS has not been registered.
  * @retval -ENOMEM @p param.gtbs is false and no more TBS can be registered (see
- *         @kconfig{CONFIG_BT_TBS_BEARER_COUNT})
- * @retval -ENOEXEC The service failed to be registered
+ *         @kconfig{CONFIG_BT_TBS_BEARER_COUNT}).
+ * @retval -ENOEXEC The service failed to be registered.
  */
 int bt_ccp_call_control_server_register_bearer(const struct bt_tbs_register_param *param,
 					       struct bt_ccp_call_control_server_bearer **bearer);
@@ -89,10 +89,10 @@ int bt_ccp_call_control_server_register_bearer(const struct bt_tbs_register_para
  *
  * @param bearer The bearer to unregister.
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer is NULL
- * @retval -EALREADY The bearer is not registered
- * @retval -ENOEXEC The service failed to be unregistered
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer is NULL.
+ * @retval -EALREADY The bearer is not registered.
+ * @retval -ENOEXEC The service failed to be unregistered.
  */
 int bt_ccp_call_control_server_unregister_bearer(struct bt_ccp_call_control_server_bearer *bearer);
 
@@ -102,12 +102,12 @@ int bt_ccp_call_control_server_unregister_bearer(struct bt_ccp_call_control_serv
  * @param bearer  The bearer to set the name for.
  * @param name    The new bearer provider name.
  *
- * @retval 0 Success
+ * @retval 0 on success.
  * @retval -EINVAL @p bearer or @p name is NULL, or @p name is the empty string or @p name is larger
- *                 than @kconfig{CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH}
- * @retval -EFAULT @p bearer is not registered
- * @retval -EBUSY The TBS instance of @p bearer is busy
- * @retval -ENOEXEC The TBS instance of @p bearer returned unexpected error
+ *                 than @kconfig{CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH}.
+ * @retval -EFAULT @p bearer is not registered.
+ * @retval -EBUSY The TBS instance of @p bearer is busy.
+ * @retval -ENOEXEC The TBS instance of @p bearer returned unexpected error.
  */
 int bt_ccp_call_control_server_set_bearer_provider_name(
 	struct bt_ccp_call_control_server_bearer *bearer, const char *name);
@@ -121,10 +121,10 @@ int bt_ccp_call_control_server_set_bearer_provider_name(
  *                  @kconfig{CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH} + 1 to
  *                  ensure that the name always fits.
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer or @p name is NULL
- * @retval -EFAULT @p bearer is not registered
- * @retval -ENOMEM @p name_size is insufficient to hold the bearer name (including null terminator)
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer or @p name is NULL.
+ * @retval -EFAULT @p bearer is not registered.
+ * @retval -ENOMEM @p name_size is insufficient to hold the bearer name (including null terminator).
  */
 int bt_ccp_call_control_server_get_bearer_provider_name(
 	struct bt_ccp_call_control_server_bearer *bearer, char *name, size_t name_size);
@@ -136,9 +136,9 @@ int bt_ccp_call_control_server_get_bearer_provider_name(
  * @param[out] uci Pointer to a buffer of size @ref BT_TBS_MAX_UCI_SIZE that the bearer UCI will be
  *                 written to.
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer or @p uci is NULL
- * @retval -EFAULT @p bearer is not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer or @p uci is NULL.
+ * @retval -EFAULT @p bearer is not registered.
  */
 int bt_ccp_call_control_server_get_bearer_uci(struct bt_ccp_call_control_server_bearer *bearer,
 					      char uci[BT_TBS_MAX_UCI_SIZE]);
@@ -261,12 +261,12 @@ struct bt_ccp_call_control_client_cb {
  * @param conn Connection to a remote server.
  * @param out_client Pointer to client instance on success
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn or @p out_client is NULL
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -EBUSY Already doing discovery for @p conn
- * @retval -ENOEXEC Rejected by the GATT layer
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn or @p out_client is NULL.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -EBUSY Already doing discovery for @p conn.
+ * @retval -ENOEXEC Rejected by the GATT layer.
  */
 int bt_ccp_call_control_client_discover(struct bt_conn *conn,
 					struct bt_ccp_call_control_client **out_client);
@@ -276,9 +276,9 @@ int bt_ccp_call_control_client_discover(struct bt_conn *conn,
  *
  * @param cb The callback struct
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL
- * @retval -EEXISTS @p cb is already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EEXIST @p cb is already registered.
  */
 int bt_ccp_call_control_client_register_cb(struct bt_ccp_call_control_client_cb *cb);
 
@@ -287,9 +287,9 @@ int bt_ccp_call_control_client_register_cb(struct bt_ccp_call_control_client_cb 
  *
  * @param cb The callback struct
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL
- * @retval -EALREADY @p cb is not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb is not registered.
  */
 int bt_ccp_call_control_client_unregister_cb(struct bt_ccp_call_control_client_cb *cb);
 
@@ -299,8 +299,8 @@ int bt_ccp_call_control_client_unregister_cb(struct bt_ccp_call_control_client_c
  * @param[in]  client  The client to get the bearers of.
  * @param[out] bearers The bearers struct that will be populated with the bearers of @p client.
 
- * @retval 0 Success
- * @retval -EINVAL @p client or @p bearers is NULL
+ * @retval 0 on success.
+ * @retval -EINVAL @p client or @p bearers is NULL.
  */
 int bt_ccp_call_control_client_get_bearers(struct bt_ccp_call_control_client *client,
 					   struct bt_ccp_call_control_client_bearers *bearers);
@@ -312,13 +312,13 @@ int bt_ccp_call_control_client_get_bearers(struct bt_ccp_call_control_client *cl
  *
  * @param bearer The bearer to read the name from
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer is NULL
- * @retval -EFAULT @p bearer has not been discovered
- * @retval -EEXIST A @ref bt_ccp_call_control_client could not be identified for @p bearer
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer is NULL.
+ * @retval -EFAULT @p bearer has not been discovered.
+ * @retval -EEXIST A @ref bt_ccp_call_control_client could not be identified for @p bearer.
  * @retval -EBUSY The @ref bt_ccp_call_control_client identified by @p bearer is busy, or the TBS
  * instance of @p bearer is busy.
- * @retval -ENOTCONN The @ref bt_ccp_call_control_client identified by @p bearer is not connected
+ * @retval -ENOTCONN The @ref bt_ccp_call_control_client identified by @p bearer is not connected.
  */
 int bt_ccp_call_control_client_read_bearer_provider_name(
 	struct bt_ccp_call_control_client_bearer *bearer);
@@ -330,13 +330,13 @@ int bt_ccp_call_control_client_read_bearer_provider_name(
  *
  * @param bearer The bearer to read the UCI from
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer is NULL
- * @retval -EFAULT @p bearer has not been discovered
- * @retval -EEXIST A @ref bt_ccp_call_control_client could not be identified for @p bearer
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer is NULL.
+ * @retval -EFAULT @p bearer has not been discovered.
+ * @retval -EEXIST A @ref bt_ccp_call_control_client could not be identified for @p bearer.
  * @retval -EBUSY The @ref bt_ccp_call_control_client identified by @p bearer is busy, or the TBS
  * instance of @p bearer is busy.
- * @retval -ENOTCONN The @ref bt_ccp_call_control_client identified by @p bearer is not connected
+ * @retval -ENOTCONN The @ref bt_ccp_call_control_client identified by @p bearer is not connected.
  */
 int bt_ccp_call_control_client_read_bearer_uci(struct bt_ccp_call_control_client_bearer *bearer);
 /** @} */ /* End of group bt_ccp_call_control_client */

--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -217,7 +217,7 @@ void *bt_csip_set_member_svc_decl_get(const struct bt_csip_set_member_svc_inst *
  * @param[out] svc_inst  Pointer to the registered Coordinated Set
  *                       Identification Service.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_member_register(const struct bt_csip_set_member_register_param *param,
 				struct bt_csip_set_member_svc_inst **svc_inst);
@@ -229,7 +229,7 @@ int bt_csip_set_member_register(const struct bt_csip_set_member_register_param *
  *
  * @param svc_inst  Pointer to the registered Coordinated Set Identification Service.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_member_unregister(struct bt_csip_set_member_svc_inst *svc_inst);
 
@@ -266,7 +266,7 @@ int bt_csip_set_member_sirk(struct bt_csip_set_member_svc_inst *svc_inst,
  * @retval -EINVAL @p svc_inst is NULL, @p size is less than 1, @p rank is less than 1 or higher
  *                 than @p size for a lockable @p svc_inst.
  * @retval -EALREADY @p size is already set.
- * @retval 0 Success.
+ * @retval 0 on success.
  */
 int bt_csip_set_member_set_size_and_rank(struct bt_csip_set_member_svc_inst *svc_inst, uint8_t size,
 					 uint8_t rank);
@@ -323,7 +323,7 @@ struct bt_csip_set_member_set_info {
  * @param info Pointer to a struct to store the information in.
  *
  * @retval -EINVAL @p svc_inst or @p info is NULL.
- * @retval 0 Success.
+ * @retval 0 on success.
  */
 int bt_csip_set_member_get_info(const struct bt_csip_set_member_svc_inst *svc_inst,
 				struct bt_csip_set_member_set_info *info);
@@ -336,7 +336,7 @@ int bt_csip_set_member_get_info(const struct bt_csip_set_member_svc_inst *svc_in
  * @param svc_inst  Pointer to the Coordinated Set Identification Service.
  * @param rsi       Pointer to the 6-octet newly generated RSI data in little-endian.
  *
- * @return int		0 if on success, errno on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_member_generate_rsi(const struct bt_csip_set_member_svc_inst *svc_inst,
 				    uint8_t rsi[BT_CSIP_RSI_SIZE]);
@@ -352,7 +352,7 @@ int bt_csip_set_member_generate_rsi(const struct bt_csip_set_member_svc_inst *sv
  *                  (release) and will force release the lock, regardless of who
  *                  took the lock.
  *
- * @return 0 on success, GATT error on error.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_csip_set_member_lock(struct bt_csip_set_member_svc_inst *svc_inst,
 			    bool lock, bool force);
@@ -425,7 +425,7 @@ typedef void (*bt_csip_set_coordinator_discover_cb)(
  *
  * @param conn Pointer to remote device to perform discovery on.
  *
- * @return int Return 0 on success, or an errno value on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_coordinator_discover(struct bt_conn *conn);
 
@@ -438,8 +438,8 @@ int bt_csip_set_coordinator_discover(struct bt_conn *conn);
  *
  * @param conn     Connection pointer.
  *
- * @retval Pointer to a Coordinated Set Identification Profile Set Coordinator instance
- * @retval NULL if @p conn is NULL or if the connection has not done discovery yet
+ * @return Pointer to a Coordinated Set Identification Profile Set Coordinator instance,
+ *         or NULL if @p conn is NULL or if the connection has not done discovery yet.
  */
 struct bt_csip_set_coordinator_set_member *
 bt_csip_set_coordinator_set_member_by_conn(const struct bt_conn *conn);
@@ -460,7 +460,7 @@ typedef void (*bt_csip_set_coordinator_lock_set_cb)(int err);
  *                changed.
  * @param locked  Whether the lock is locked or release.
  *
- * @return int Return 0 on success, or an errno value on error.
+ * @return 0 on success, negative errno value on failure.
  */
 typedef void (*bt_csip_set_coordinator_lock_changed_cb)(
 	struct bt_csip_set_coordinator_csis_inst *inst, bool locked);
@@ -545,7 +545,7 @@ struct bt_csip_set_coordinator_cb {
  * @param sirk The SIRK of the set to check against
  * @param data The advertising data
  *
- * @return true if the advertising data indicates a set member, false otherwise
+ * @return true if the advertising data indicates a set member, false otherwise.
  */
 bool bt_csip_set_coordinator_is_set_member(const uint8_t sirk[BT_CSIP_SIRK_SIZE],
 					   struct bt_data *data);
@@ -555,7 +555,7 @@ bool bt_csip_set_coordinator_is_set_member(const uint8_t sirk[BT_CSIP_SIRK_SIZE]
  *
  * @param cb   Pointer to the callback structure.
  *
- * @return Return 0 on success, or an errno value on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_coordinator_register_cb(struct bt_csip_set_coordinator_cb *cb);
 
@@ -618,7 +618,7 @@ int bt_csip_set_coordinator_ordered_access(
  * @param set_info  Pointer to the a specific set_info struct, as a member may
  *                  be part of multiple sets.
  *
- * @return Return 0 on success, or an errno value on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_coordinator_lock(const struct bt_csip_set_coordinator_set_member **members,
 				 uint8_t count,
@@ -636,7 +636,7 @@ int bt_csip_set_coordinator_lock(const struct bt_csip_set_coordinator_set_member
  * @param set_info  Pointer to the a specific set_info struct, as a member may
  *                  be part of multiple sets.
  *
- * @return Return 0 on success, or an errno value on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_coordinator_release(const struct bt_csip_set_coordinator_set_member **members,
 				    uint8_t count,

--- a/include/zephyr/bluetooth/audio/gmap.h
+++ b/include/zephyr/bluetooth/audio/gmap.h
@@ -184,9 +184,9 @@ struct bt_gmap_cb {
  *
  * @param cb The callback structure.
  *
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if callbacks have already be registered
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY Callbacks have already been registered.
  */
 int bt_gmap_cb_register(const struct bt_gmap_cb *cb);
 
@@ -199,10 +199,10 @@ int bt_gmap_cb_register(const struct bt_gmap_cb *cb);
  *
  * @param conn Bluetooth connection object.
  *
- * @retval -EINVAL if @p conn is NULL
- * @retval -EBUSY if discovery is already in progress for @p conn
- * @retval -ENOEXEC if discovery failed to initiate
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL.
+ * @retval -EBUSY Discovery is already in progress for @p conn.
+ * @retval -ENOEXEC Discovery failed to initiate.
  */
 int bt_gmap_discover(struct bt_conn *conn);
 
@@ -213,9 +213,9 @@ int bt_gmap_discover(struct bt_conn *conn);
  * @param features Features of the roles. If a role is not in the @p role parameter, then the
  *                 feature value for that role is simply ignored.
  *
- * @retval -EINVAL on invalid arguments
- * @retval -ENOEXEC on service register failure
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Invalid arguments.
+ * @retval -ENOEXEC Service register failure.
  */
 int bt_gmap_register(enum bt_gmap_role role, struct bt_gmap_feat features);
 
@@ -230,12 +230,12 @@ int bt_gmap_register(enum bt_gmap_role role, struct bt_gmap_feat features);
  * @param features Features of the roles. If a role is not in the @p role parameter, then the
  *                 feature value for that role is simply ignored.
  *
- * @retval -ENOEXEC if the service has not yet been registered
- * @retval -EINVAL on invalid arguments
- * @retval -EALREADY if the @p role and @p features are the same as existing ones
- * @retval -ENOENT on service unregister failure
- * @retval -ECANCELED on service re-register failure
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -ENOEXEC The service has not yet been registered.
+ * @retval -EINVAL Invalid arguments.
+ * @retval -EALREADY The @p role and @p features are the same as existing ones.
+ * @retval -ENOENT Service unregister failure.
+ * @retval -ECANCELED Service re-register failure.
  */
 int bt_gmap_set_role(enum bt_gmap_role role, struct bt_gmap_feat features);
 

--- a/include/zephyr/bluetooth/audio/has.h
+++ b/include/zephyr/bluetooth/audio/has.h
@@ -225,7 +225,7 @@ struct bt_has_client_cb {
  *
  * @param cb The callback structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_cb_register(const struct bt_has_client_cb *cb);
 
@@ -238,7 +238,7 @@ int bt_has_client_cb_register(const struct bt_has_client_cb *cb);
  *
  * @param conn Bluetooth connection object.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_discover(struct bt_conn *conn);
 
@@ -251,7 +251,7 @@ int bt_has_client_discover(struct bt_conn *conn);
  * @param[in] has Pointer to the Hearing Access Service object.
  * @param[out] conn Connection object.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_conn_get(const struct bt_has *has, struct bt_conn **conn);
 
@@ -266,7 +266,7 @@ int bt_has_client_conn_get(const struct bt_has *has, struct bt_conn **conn);
  * @param index The index to start with.
  * @param max_count Maximum number of presets to read.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_presets_read(struct bt_has *has, uint8_t index, uint8_t max_count);
 
@@ -280,7 +280,7 @@ int bt_has_client_presets_read(struct bt_has *has, uint8_t index, uint8_t max_co
  * @param index Preset index to activate.
  * @param sync Request active preset synchronization in set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_preset_set(struct bt_has *has, uint8_t index, bool sync);
 
@@ -293,7 +293,7 @@ int bt_has_client_preset_set(struct bt_has *has, uint8_t index, bool sync);
  * @param has Pointer to the Hearing Access Service object.
  * @param sync Request active preset synchronization in set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_preset_next(struct bt_has *has, bool sync);
 
@@ -306,7 +306,7 @@ int bt_has_client_preset_next(struct bt_has *has, bool sync);
  * @param has Pointer to the Hearing Access Service object.
  * @param sync Request active preset synchronization in set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_client_preset_prev(struct bt_has *has, bool sync);
 
@@ -322,9 +322,9 @@ struct bt_has_preset_ops {
 	 * @param sync Whether the server must relay this change to the other member of the
 	 *             Binaural Hearing Aid Set.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
-	 * @return -EBUSY if operation cannot be performed at the time.
-	 * @return -EINPROGRESS in case where user has to confirm once the requested preset
+	 * @return 0 on success, negative errno value on failure.
+	 * @retval -EBUSY Operation cannot be performed at the time.
+	 * @retval -EINPROGRESS User has to confirm once the requested preset
 	 *                      becomes active by calling @ref bt_has_preset_active_set.
 	 */
 	int (*select)(uint8_t index, bool sync);
@@ -375,7 +375,7 @@ struct bt_has_preset_register_param {
  *
  * @param features     Hearing Access Service register parameters.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_register(const struct bt_has_features_param *features);
 
@@ -387,7 +387,7 @@ int bt_has_register(const struct bt_has_features_param *features);
  *
  * @param param Preset registration parameter.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_register(const struct bt_has_preset_register_param *param);
 
@@ -398,7 +398,7 @@ int bt_has_preset_register(const struct bt_has_preset_register_param *param);
  *
  * @param index The index of preset that's being requested to unregister.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_unregister(uint8_t index);
 
@@ -410,7 +410,7 @@ int bt_has_preset_unregister(uint8_t index);
  *
  * @param index The index of preset that's became available.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_available(uint8_t index);
 
@@ -422,7 +422,7 @@ int bt_has_preset_available(uint8_t index);
  *
  * @param index The index of preset that's became unavailable.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_unavailable(uint8_t index);
 
@@ -450,7 +450,7 @@ typedef bool (*bt_has_preset_func_t)(uint8_t index, enum bt_has_properties prope
  * @param func Callback function.
  * @param user_data Data to pass to the callback.
  *
- * @retval 0 Success
+ * @retval 0 on success.
  * @retval -ECANCELED Iteration was stopped by the callback function before complete.
  * @retval -EINVAL @p func was NULL.
  */
@@ -464,7 +464,7 @@ int bt_has_preset_foreach(uint8_t index, bt_has_preset_func_t func, void *user_d
  *
  * @param index Preset index.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_active_set(uint8_t index);
 
@@ -482,7 +482,7 @@ uint8_t bt_has_preset_active_get(void);
  *
  * Used by server to deactivate currently active preset.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 static inline int bt_has_preset_active_clear(void)
 {
@@ -497,7 +497,7 @@ static inline int bt_has_preset_active_clear(void)
  * @param index The index of the preset to change the name of.
  * @param name Name to write.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_preset_name_change(uint8_t index, const char *name);
 
@@ -508,7 +508,7 @@ int bt_has_preset_name_change(uint8_t index, const char *name);
  *
  * @param features The features to be set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_has_features_set(const struct bt_has_features_param *features);
 

--- a/include/zephyr/bluetooth/audio/mcc.h
+++ b/include/zephyr/bluetooth/audio/mcc.h
@@ -636,7 +636,7 @@ struct bt_mcc_cb {
  *
  * @param cb    Callbacks to be used
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_init(struct bt_mcc_cb *cb);
 
@@ -653,7 +653,7 @@ int bt_mcc_init(struct bt_mcc_cb *cb);
  * @param conn  Connection to the peer device
  * @param subscribe   Whether to subscribe to notifications
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe);
 
@@ -662,7 +662,7 @@ int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_player_name(struct bt_conn *conn);
 
@@ -671,7 +671,7 @@ int bt_mcc_read_player_name(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_icon_obj_id(struct bt_conn *conn);
 
@@ -680,7 +680,7 @@ int bt_mcc_read_icon_obj_id(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_icon_url(struct bt_conn *conn);
 
@@ -689,7 +689,7 @@ int bt_mcc_read_icon_url(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_track_title(struct bt_conn *conn);
 
@@ -698,7 +698,7 @@ int bt_mcc_read_track_title(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_track_duration(struct bt_conn *conn);
 
@@ -707,7 +707,7 @@ int bt_mcc_read_track_duration(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_track_position(struct bt_conn *conn);
 
@@ -717,7 +717,7 @@ int bt_mcc_read_track_position(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param pos   Track position
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos);
 
@@ -726,7 +726,7 @@ int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_playback_speed(struct bt_conn *conn);
 
@@ -736,7 +736,7 @@ int bt_mcc_read_playback_speed(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param speed Playback speed
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed);
 
@@ -745,7 +745,7 @@ int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_seeking_speed(struct bt_conn *conn);
 
@@ -754,7 +754,7 @@ int bt_mcc_read_seeking_speed(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_segments_obj_id(struct bt_conn *conn);
 
@@ -763,7 +763,7 @@ int bt_mcc_read_segments_obj_id(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_current_track_obj_id(struct bt_conn *conn);
 
@@ -775,7 +775,7 @@ int bt_mcc_read_current_track_obj_id(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param id    Object Transfer Service ID (UINT48) of the track to set as the current track
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t id);
 
@@ -784,7 +784,7 @@ int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t id);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_next_track_obj_id(struct bt_conn *conn);
 
@@ -796,7 +796,7 @@ int bt_mcc_read_next_track_obj_id(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param id   Object Transfer Service ID (UINT48) of the track to set as the next track
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_next_track_obj_id(struct bt_conn *conn, uint64_t id);
 
@@ -805,7 +805,7 @@ int bt_mcc_set_next_track_obj_id(struct bt_conn *conn, uint64_t id);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_current_group_obj_id(struct bt_conn *conn);
 
@@ -817,7 +817,7 @@ int bt_mcc_read_current_group_obj_id(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param id   Object Transfer Service ID (UINT48) of the group to set as the current group
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t id);
 
@@ -826,7 +826,7 @@ int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t id);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_parent_group_obj_id(struct bt_conn *conn);
 
@@ -835,7 +835,7 @@ int bt_mcc_read_parent_group_obj_id(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_playing_order(struct bt_conn *conn);
 
@@ -845,7 +845,7 @@ int bt_mcc_read_playing_order(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param order Playing order
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order);
 
@@ -854,7 +854,7 @@ int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_playing_orders_supported(struct bt_conn *conn);
 
@@ -863,7 +863,7 @@ int bt_mcc_read_playing_orders_supported(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_media_state(struct bt_conn *conn);
 
@@ -875,7 +875,7 @@ int bt_mcc_read_media_state(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param cmd   The command to send
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd);
 
@@ -884,7 +884,7 @@ int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_opcodes_supported(struct bt_conn *conn);
 
@@ -896,7 +896,7 @@ int bt_mcc_read_opcodes_supported(struct bt_conn *conn);
  * @param conn   Connection to the peer device
  * @param search The search
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search);
 
@@ -905,7 +905,7 @@ int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_search_results_obj_id(struct bt_conn *conn);
 
@@ -914,7 +914,7 @@ int bt_mcc_read_search_results_obj_id(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_content_control_id(struct bt_conn *conn);
 
@@ -923,7 +923,7 @@ int bt_mcc_read_content_control_id(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_object_metadata(struct bt_conn *conn);
 
@@ -932,7 +932,7 @@ int bt_mcc_otc_read_object_metadata(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_icon_object(struct bt_conn *conn);
 
@@ -941,7 +941,7 @@ int bt_mcc_otc_read_icon_object(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_track_segments_object(struct bt_conn *conn);
 
@@ -950,7 +950,7 @@ int bt_mcc_otc_read_track_segments_object(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_current_track_object(struct bt_conn *conn);
 
@@ -959,7 +959,7 @@ int bt_mcc_otc_read_current_track_object(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_next_track_object(struct bt_conn *conn);
 
@@ -968,7 +968,7 @@ int bt_mcc_otc_read_next_track_object(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_current_group_object(struct bt_conn *conn);
 
@@ -977,7 +977,7 @@ int bt_mcc_otc_read_current_group_object(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_parent_group_object(struct bt_conn *conn);
 

--- a/include/zephyr/bluetooth/audio/media_proxy.h
+++ b/include/zephyr/bluetooth/audio/media_proxy.h
@@ -847,7 +847,7 @@ struct media_proxy_ctrl_cbs {
  *
  * @param ctrl_cbs   Callbacks to the controller
  *
- * @return 0 if success, errno on failure
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_register(struct media_proxy_ctrl_cbs *ctrl_cbs);
 
@@ -866,7 +866,7 @@ int media_proxy_ctrl_register(struct media_proxy_ctrl_cbs *ctrl_cbs);
  *
  * @param conn   The connection to do discovery for
  *
- * @return 0 if success, errno on failure
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_discover_player(struct bt_conn *conn);
 
@@ -875,7 +875,7 @@ int media_proxy_ctrl_discover_player(struct bt_conn *conn);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_player_name(struct media_player *player);
 
@@ -892,7 +892,7 @@ int media_proxy_ctrl_get_player_name(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_icon_id(struct media_player *player);
 
@@ -910,7 +910,7 @@ int media_proxy_ctrl_get_icon_url(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_track_title(struct media_player *player);
 
@@ -922,7 +922,7 @@ int media_proxy_ctrl_get_track_title(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_track_duration(struct media_player *player);
 
@@ -935,7 +935,7 @@ int media_proxy_ctrl_get_track_duration(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_track_position(struct media_player *player);
 
@@ -951,7 +951,7 @@ int media_proxy_ctrl_get_track_position(struct media_player *player);
  * @param player     Media player instance pointer
  * @param position   The track position to set
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_track_position(struct media_player *player, int32_t position);
 
@@ -970,7 +970,7 @@ int media_proxy_ctrl_set_track_position(struct media_player *player, int32_t pos
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_playback_speed(struct media_player *player);
 
@@ -991,7 +991,7 @@ int media_proxy_ctrl_get_playback_speed(struct media_player *player);
  * @param player   Media player instance pointer
  * @param speed    The playback speed parameter to set
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_playback_speed(struct media_player *player, int8_t speed);
 
@@ -1009,7 +1009,7 @@ int media_proxy_ctrl_set_playback_speed(struct media_player *player, int8_t spee
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_seeking_speed(struct media_player *player);
 
@@ -1026,7 +1026,7 @@ int media_proxy_ctrl_get_seeking_speed(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_track_segments_id(struct media_player *player);
 
@@ -1043,7 +1043,7 @@ int media_proxy_ctrl_get_track_segments_id(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_current_track_id(struct media_player *player);
 
@@ -1058,7 +1058,7 @@ int media_proxy_ctrl_get_current_track_id(struct media_player *player);
  * @param player   Media player instance pointer
  * @param id       The ID of a track object
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_current_track_id(struct media_player *player, uint64_t id);
 
@@ -1072,7 +1072,7 @@ int media_proxy_ctrl_set_current_track_id(struct media_player *player, uint64_t 
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_next_track_id(struct media_player *player);
 
@@ -1086,7 +1086,7 @@ int media_proxy_ctrl_get_next_track_id(struct media_player *player);
  * @param player   Media player instance pointer
  * @param id       The ID of a track object
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_next_track_id(struct media_player *player, uint64_t id);
 
@@ -1105,7 +1105,7 @@ int media_proxy_ctrl_set_next_track_id(struct media_player *player, uint64_t id)
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_parent_group_id(struct media_player *player);
 
@@ -1122,7 +1122,7 @@ int media_proxy_ctrl_get_parent_group_id(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_current_group_id(struct media_player *player);
 
@@ -1137,7 +1137,7 @@ int media_proxy_ctrl_get_current_group_id(struct media_player *player);
  * @param player   Media player instance pointer
  * @param id       The ID of a group object
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_current_group_id(struct media_player *player, uint64_t id);
 
@@ -1146,7 +1146,7 @@ int media_proxy_ctrl_set_current_group_id(struct media_player *player, uint64_t 
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_playing_order(struct media_player *player);
 
@@ -1158,7 +1158,7 @@ int media_proxy_ctrl_get_playing_order(struct media_player *player);
  * @param player   Media player instance pointer
  * @param order    The playing order to set
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_playing_order(struct media_player *player, uint8_t order);
 
@@ -1170,7 +1170,7 @@ int media_proxy_ctrl_set_playing_order(struct media_player *player, uint8_t orde
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_playing_orders_supported(struct media_player *player);
 
@@ -1181,7 +1181,7 @@ int media_proxy_ctrl_get_playing_orders_supported(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_media_state(struct media_player *player);
 
@@ -1196,7 +1196,7 @@ int media_proxy_ctrl_get_media_state(struct media_player *player);
  * @param player      Media player instance pointer
  * @param command     The command to send
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_send_command(struct media_player *player, const struct mpl_cmd *command);
 
@@ -1208,7 +1208,7 @@ int media_proxy_ctrl_send_command(struct media_player *player, const struct mpl_
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_commands_supported(struct media_player *player);
 
@@ -1229,7 +1229,7 @@ int media_proxy_ctrl_get_commands_supported(struct media_player *player);
  * @param player   Media player instance pointer
  * @param search   The search to write
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_send_search(struct media_player *player, const struct mpl_search *search);
 
@@ -1247,7 +1247,7 @@ int media_proxy_ctrl_send_search(struct media_player *player, const struct mpl_s
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_search_results_id(struct media_player *player);
 
@@ -1260,7 +1260,7 @@ int media_proxy_ctrl_get_search_results_id(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 uint8_t media_proxy_ctrl_get_content_ctrl_id(struct media_player *player);
 
@@ -1274,7 +1274,7 @@ struct media_proxy_pl_calls {
 	/**
 	 * @brief Read Media Player Name
 	 *
-	 * @return The name of the media player
+	 * @return The name of the media player.
 	 */
 	const char *(*get_player_name)(void);
 
@@ -1287,7 +1287,7 @@ struct media_proxy_pl_calls {
 	 * See the Media Control Service spec v1.0 sections 3.2 and
 	 * 4.1 for a description of the Icon Object.
 	 *
-	 * @return The Icon Object ID
+	 * @return The Icon Object ID.
 	 */
 	uint64_t (*get_icon_id)(void);
 
@@ -1296,14 +1296,14 @@ struct media_proxy_pl_calls {
 	 *
 	 * Get a URL to the media player's icon.
 	 *
-	 * @return The URL of the Icon
+	 * @return The URL of the Icon.
 	 */
 	const char *(*get_icon_url)(void);
 
 	/**
 	 * @brief Read Track Title
 	 *
-	 * @return The title of the current track
+	 * @return The title of the current track.
 	 */
 	const char *(*get_track_title)(void);
 
@@ -1313,7 +1313,7 @@ struct media_proxy_pl_calls {
 	 * The duration of a track is measured in hundredths of a
 	 * second.
 	 *
-	 * @return The duration of the current track
+	 * @return The duration of the current track.
 	 */
 	int32_t (*get_track_duration)(void);
 
@@ -1324,7 +1324,7 @@ struct media_proxy_pl_calls {
 	 * measured in hundredths of a second from the beginning of
 	 * the track
 	 *
-	 * @return The position of the player in the current track
+	 * @return The position of the player in the current track.
 	 */
 	int32_t (*get_track_position)(void);
 
@@ -1354,7 +1354,7 @@ struct media_proxy_pl_calls {
 	 * 127 corresponds to playback at almost four times the normal
 	 * speed.
 	 *
-	 * @return The playback speed parameter
+	 * @return The playback speed parameter.
 	 */
 	int8_t (*get_playback_speed)(void);
 
@@ -1388,7 +1388,7 @@ struct media_proxy_pl_calls {
 	 * The seeking speed is not settable - a non-zero seeking speed
 	 * is the result of "fast rewind" of "fast forward" commands.
 	 *
-	 * @return The seeking speed factor
+	 * @return The seeking speed factor.
 	 */
 	int8_t (*get_seeking_speed)(void);
 
@@ -1401,7 +1401,7 @@ struct media_proxy_pl_calls {
 	 * See the Media Control Service spec v1.0 sections 3.10 and
 	 * 4.2 for a description of the Track Segments Object.
 	 *
-	 * @return Current The Track Segments Object ID
+	 * @return The Current Track Segments Object ID.
 	 */
 	uint64_t (*get_track_segments_id)(void);
 
@@ -1414,7 +1414,7 @@ struct media_proxy_pl_calls {
 	 * See the Media Control Service spec v1.0 sections 3.11 and
 	 * 4.3 for a description of the Current Track Object.
 	 *
-	 * @return The Current Track Object ID
+	 * @return The Current Track Object ID.
 	 */
 	uint64_t (*get_current_track_id)(void);
 
@@ -1434,7 +1434,7 @@ struct media_proxy_pl_calls {
 	 * Get an ID (48 bit) that can be used to retrieve the Next
 	 * Track Object from an Object Transfer Service
 	 *
-	 * @return The Next Track Object ID
+	 * @return The Next Track Object ID.
 	 */
 	uint64_t (*get_next_track_id)(void);
 
@@ -1458,7 +1458,7 @@ struct media_proxy_pl_calls {
 	 * See the Media Control Service spec v1.0 sections 3.14 and
 	 * 4.4 for a description of the Current Track Object.
 	 *
-	 * @return The Current Group Object ID
+	 * @return The Current Group Object ID.
 	 */
 	uint64_t (*get_parent_group_id)(void);
 
@@ -1471,7 +1471,7 @@ struct media_proxy_pl_calls {
 	 * See the Media Control Service spec v1.0 sections 3.14 and
 	 * 4.4 for a description of the Current Group Object.
 	 *
-	 * @return The Current Group Object ID
+	 * @return The Current Group Object ID.
 	 */
 	uint64_t (*get_current_group_id)(void);
 
@@ -1509,7 +1509,7 @@ struct media_proxy_pl_calls {
 	 * playing orders.
 	 * See the MEDIA_PROXY_PLAYING_ORDERS_SUPPORTED_* defines.
 	 *
-	 * @return The media player's supported playing orders
+	 * @return The media player's supported playing orders.
 	 */
 	uint16_t (*get_playing_orders_supported)(void);
 
@@ -1519,7 +1519,7 @@ struct media_proxy_pl_calls {
 	 * Read the media player's state
 	 * See the MEDIA_PROXY_MEDIA_STATE_* defines.
 	 *
-	 * @return The media player's state
+	 * @return The media player's state.
 	 */
 	uint8_t (*get_media_state)(void);
 
@@ -1541,7 +1541,7 @@ struct media_proxy_pl_calls {
 	 * command opcodes.
 	 * See the MEDIA_PROXY_OP_SUP_* defines.
 	 *
-	 * @return The media player's supported command opcodes
+	 * @return The media player's supported command opcodes.
 	 */
 	uint32_t (*get_commands_supported)(void);
 
@@ -1566,7 +1566,7 @@ struct media_proxy_pl_calls {
 	 * The search results object only exists if a successful
 	 * search operation has been done.
 	 *
-	 * @return The Search Results Object ID
+	 * @return The Search Results Object ID.
 	 */
 	uint64_t (*get_search_results_id)(void);
 
@@ -1577,7 +1577,7 @@ struct media_proxy_pl_calls {
 	 * on a device, and links it to the corresponding audio
 	 * stream.
 	 *
-	 * @return The content control ID for the media player
+	 * @return The content control ID for the media player.
 	 */
 	uint8_t (*get_content_ctrl_id)(void);
 };
@@ -1593,7 +1593,7 @@ struct media_proxy_pl_calls {
  *
  * @param pl_calls	Function pointers to the media player's calls
  *
- * @return 0 if success, errno on failure
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_pl_register(struct media_proxy_pl_calls *pl_calls);
 

--- a/include/zephyr/bluetooth/audio/micp.h
+++ b/include/zephyr/bluetooth/audio/micp.h
@@ -104,7 +104,7 @@ struct bt_micp_included {
  *
  * @param param Pointer to an initialization structure.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_micp_mic_dev_register(struct bt_micp_mic_dev_register_param *param);
 
@@ -118,7 +118,7 @@ int bt_micp_mic_dev_register(struct bt_micp_mic_dev_register_param *param);
  *
  * @param included Pointer to store the result in.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_micp_mic_dev_included_get(struct bt_micp_included *included);
 
@@ -143,14 +143,14 @@ struct bt_micp_mic_dev_cb {
 /**
  * @brief Unmute the Microphone Device.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_dev_unmute(void);
 
 /**
  * @brief Mute the Microphone Device.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_dev_mute(void);
 
@@ -159,14 +159,14 @@ int bt_micp_mic_dev_mute(void);
  *
  * Can be reenabled by called @ref bt_micp_mic_dev_mute or @ref bt_micp_mic_dev_unmute.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_dev_mute_disable(void);
 
 /**
  * @brief Read the mute state on the Microphone Device.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_dev_mute_get(void);
 
@@ -240,7 +240,7 @@ struct bt_micp_mic_ctlr_cb {
  * @param      mic_ctlr Microphone Controller instance pointer.
  * @param[out] included Pointer to store the result in.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_micp_mic_ctlr_included_get(struct bt_micp_mic_ctlr *mic_ctlr,
 				  struct bt_micp_included *included);
@@ -253,7 +253,7 @@ int bt_micp_mic_ctlr_included_get(struct bt_micp_mic_ctlr *mic_ctlr,
  * @param mic_ctlr    Microphone Controller instance pointer.
  * @param conn        Connection pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_micp_mic_ctlr_conn_get(const struct bt_micp_mic_ctlr *mic_ctlr,
 			      struct bt_conn **conn);
@@ -267,8 +267,8 @@ int bt_micp_mic_ctlr_conn_get(const struct bt_micp_mic_ctlr *mic_ctlr,
  *
  * @param conn     Connection pointer.
  *
- * @retval Pointer to a Microphone Control Profile Microphone Controller instance
- * @retval NULL if @p conn is NULL or if the connection has not done discovery yet
+ * @return Pointer to a Microphone Control Profile Microphone Controller instance,
+ *         or NULL if @p conn is NULL or if the connection has not done discovery yet.
  */
 struct bt_micp_mic_ctlr *bt_micp_mic_ctlr_get_by_conn(const struct bt_conn *conn);
 
@@ -283,7 +283,7 @@ struct bt_micp_mic_ctlr *bt_micp_mic_ctlr_get_by_conn(const struct bt_conn *conn
  * @param conn          The connection to initialize the profile for.
  * @param[out] mic_ctlr Valid remote instance object on success.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_ctlr_discover(struct bt_conn *conn,
 			      struct bt_micp_mic_ctlr **mic_ctlr);
@@ -293,7 +293,7 @@ int bt_micp_mic_ctlr_discover(struct bt_conn *conn,
  *
  * @param mic_ctlr  Microphone Controller instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_ctlr_unmute(struct bt_micp_mic_ctlr *mic_ctlr);
 
@@ -302,7 +302,7 @@ int bt_micp_mic_ctlr_unmute(struct bt_micp_mic_ctlr *mic_ctlr);
  *
  * @param mic_ctlr  Microphone Controller instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_ctlr_mute(struct bt_micp_mic_ctlr *mic_ctlr);
 
@@ -311,7 +311,7 @@ int bt_micp_mic_ctlr_mute(struct bt_micp_mic_ctlr *mic_ctlr);
  *
  * @param mic_ctlr  Microphone Controller instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_ctlr_mute_get(struct bt_micp_mic_ctlr *mic_ctlr);
 
@@ -322,7 +322,7 @@ int bt_micp_mic_ctlr_mute_get(struct bt_micp_mic_ctlr *mic_ctlr);
  *
  * @param cb    The callback structure.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_micp_mic_ctlr_cb_register(struct bt_micp_mic_ctlr_cb *cb);
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/audio/pacs.h
+++ b/include/zephyr/bluetooth/audio/pacs.h
@@ -92,8 +92,8 @@ struct bt_pacs_register_param {
  * @param cap Capability found.
  * @param user_data Data given.
  *
- * @return true to continue to the next capability
- * @return false to stop the iteration
+ * @return true to continue to the next capability.
+ * @return false to stop the iteration.
  */
 typedef bool (*bt_pacs_cap_foreach_func_t)(const struct bt_pacs_cap *cap,
 					   void *user_data);
@@ -116,17 +116,17 @@ void bt_pacs_cap_foreach(enum bt_audio_dir dir,
  *
  * @param param PACS register parameters.
  *
- * @retval 0 Success
- * @retval -EINVAL @p param is NULL or bad combination of values in @p param
- * @retval -EALREADY Already registered
- * @retval -ENOEXEC Request was rejected by GATT
+ * @retval 0 on success.
+ * @retval -EINVAL @p param is NULL or bad combination of values in @p param.
+ * @retval -EALREADY Already registered.
+ * @retval -ENOEXEC Request was rejected by GATT.
  */
 int bt_pacs_register(const struct bt_pacs_register_param *param);
 
 /**
  * @brief Unregister the Published Audio Capability Service instance.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_unregister(void);
 
@@ -138,7 +138,7 @@ int bt_pacs_unregister(void);
  * @param dir Direction of the endpoint to register capability for.
  * @param cap Capability structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_cap_register(enum bt_audio_dir dir, struct bt_pacs_cap *cap);
 
@@ -150,7 +150,7 @@ int bt_pacs_cap_register(enum bt_audio_dir dir, struct bt_pacs_cap *cap);
  * @param dir Direction of the endpoint to unregister capability for.
  * @param cap Capability structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_cap_unregister(enum bt_audio_dir dir, struct bt_pacs_cap *cap);
 
@@ -160,7 +160,7 @@ int bt_pacs_cap_unregister(enum bt_audio_dir dir, struct bt_pacs_cap *cap);
  * @param dir      Direction of the endpoints to change location for.
  * @param location The location to be set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_set_location(enum bt_audio_dir dir,
 			 enum bt_audio_location location);
@@ -171,7 +171,7 @@ int bt_pacs_set_location(enum bt_audio_dir dir,
  * @param dir      Direction of the endpoints to change available contexts for.
  * @param contexts The contexts to be set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_set_available_contexts(enum bt_audio_dir dir,
 				   enum bt_audio_context contexts);
@@ -198,7 +198,7 @@ enum bt_audio_context bt_pacs_get_available_contexts(enum bt_audio_dir dir);
  * @param dir      Direction of the endpoints to change available contexts for.
  * @param contexts The contexts to be set or NULL to reset to default.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_conn_set_available_contexts_for_conn(struct bt_conn *conn, enum bt_audio_dir dir,
 						 enum bt_audio_context *contexts);
@@ -214,7 +214,7 @@ int bt_pacs_conn_set_available_contexts_for_conn(struct bt_conn *conn, enum bt_a
  * @param dir      Direction of the endpoints to get contexts for.
  *
  * @return Bitmask of available contexts.
- * @retval BT_AUDIO_CONTEXT_TYPE_NONE if @p conn or @p dir are invalid
+ * @retval BT_AUDIO_CONTEXT_TYPE_NONE @p conn or @p dir are invalid.
  */
 enum bt_audio_context bt_pacs_get_available_contexts_for_conn(struct bt_conn *conn,
 							      enum bt_audio_dir dir);
@@ -225,7 +225,7 @@ enum bt_audio_context bt_pacs_get_available_contexts_for_conn(struct bt_conn *co
  * @param dir      Direction of the endpoints to change available contexts for.
  * @param contexts The contexts to be set.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pacs_set_supported_contexts(enum bt_audio_dir dir,
 				   enum bt_audio_context contexts);

--- a/include/zephyr/bluetooth/audio/pbp.h
+++ b/include/zephyr/bluetooth/audio/pbp.h
@@ -69,7 +69,7 @@ enum bt_pbp_announcement_feature {
  * @param pba_data_buf	Pointer to store the PBA advertising data. Buffer size needs to be
  *			meta_len + @ref BT_PBP_MIN_PBA_SIZE.
  *
- * @return 0 on success or an appropriate error code.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pbp_get_announcement(const uint8_t meta[], size_t meta_len,
 			    enum bt_pbp_announcement_feature features,
@@ -83,12 +83,12 @@ int bt_pbp_get_announcement(const uint8_t meta[], size_t meta_len,
  * @param[out] features Pointer to public broadcast source features to store the parsed features in
  * @param[out] meta     Pointer to the metadata present in the advertising data
  *
- * @return parsed metadata length on success.
- * @retval -EINVAL if @p data, @p features or @p meta are NULL.
- * @retval -ENOENT if @p data is not of type @ref BT_DATA_SVC_DATA16 or if the UUID in the service
+ * @return Parsed metadata length on success, negative errno value on failure.
+ * @retval -EINVAL @p data, @p features or @p meta are NULL.
+ * @retval -ENOENT @p data is not of type @ref BT_DATA_SVC_DATA16, or the UUID in the service
  * data is not @ref BT_UUID_PBA.
- * @retval -EMSGSIZE if @p data is not large enough to contain a PBP announcement.
- * @retval -EBADMSG if the @p data contains invalid data.
+ * @retval -EMSGSIZE @p data is not large enough to contain a PBP announcement.
+ * @retval -EBADMSG @p data contains invalid data.
  */
 int bt_pbp_parse_announcement(struct bt_data *data, enum bt_pbp_announcement_feature *features,
 			      uint8_t **meta);

--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -243,7 +243,7 @@ typedef void (*bt_tbs_call_change_cb)(struct bt_conn *conn,
  *
  * @param conn         The connection used.
  *
- * @return true if authorized, false otherwise
+ * @return true if authorized, false otherwise.
  */
 typedef bool (*bt_tbs_authorize_cb)(struct bt_conn *conn);
 
@@ -274,8 +274,7 @@ struct bt_tbs_cb {
  *
  * @param call_index    The index of the call that will be accepted.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_accept(uint8_t call_index);
 
@@ -284,8 +283,7 @@ int bt_tbs_accept(uint8_t call_index);
  *
  * @param call_index    The index of the call that will be held.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_hold(uint8_t call_index);
 
@@ -294,8 +292,7 @@ int bt_tbs_hold(uint8_t call_index);
  *
  * @param call_index    The index of the call that will be retrieved.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_retrieve(uint8_t call_index);
 
@@ -304,8 +301,7 @@ int bt_tbs_retrieve(uint8_t call_index);
  *
  * @param call_index    The index of the call that will be terminated.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_terminate(uint8_t call_index);
 
@@ -317,8 +313,7 @@ int bt_tbs_terminate(uint8_t call_index);
  * @param[out] call_index    Pointer to a value where the new call_index will be
  *                           stored.
  *
- * @return int          A call index on success (positive value),
- *                      errno value on fail.
+ * @return A call index on success (positive value), negative errno value on failure.
  */
 int bt_tbs_originate(uint8_t bearer_index, char *uri, uint8_t *call_index);
 
@@ -328,8 +323,7 @@ int bt_tbs_originate(uint8_t bearer_index, char *uri, uint8_t *call_index);
  * @param call_index_cnt   The number of call indexes to join
  * @param call_indexes     Array of call indexes to join.
  *
- * @return int             BT_TBS_RESULT_CODE_* if positive or 0,
- *                         errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_join(uint8_t call_index_cnt, uint8_t *call_indexes);
 
@@ -338,8 +332,7 @@ int bt_tbs_join(uint8_t call_index_cnt, uint8_t *call_indexes);
  *
  * @param call_index    The index of the call that was answered.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_remote_answer(uint8_t call_index);
 
@@ -348,8 +341,7 @@ int bt_tbs_remote_answer(uint8_t call_index);
  *
  * @param call_index    The index of the call that was held.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_remote_hold(uint8_t call_index);
 
@@ -358,8 +350,7 @@ int bt_tbs_remote_hold(uint8_t call_index);
  *
  * @param call_index    The index of the call that was retrieved.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_remote_retrieve(uint8_t call_index);
 
@@ -368,8 +359,7 @@ int bt_tbs_remote_retrieve(uint8_t call_index);
  *
  * @param call_index    The index of the call that was terminated.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_remote_terminate(uint8_t call_index);
 
@@ -381,8 +371,7 @@ int bt_tbs_remote_terminate(uint8_t call_index);
  * @param from            The URI of the remote caller.
  * @param friendly_name   The  friendly name of the remote caller.
  *
- * @return int            New call index if positive or 0,
- *                        errno value if negative.
+ * @return New call index on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_remote_incoming(uint8_t bearer_index, const char *to,
 			   const char *from, const char *friendly_name);
@@ -394,8 +383,7 @@ int bt_tbs_remote_incoming(uint8_t bearer_index, const char *to,
  *                      for GTBS.
  * @param name          The new bearer provider name.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_set_bearer_provider_name(uint8_t bearer_index, const char *name);
 
@@ -406,8 +394,7 @@ int bt_tbs_set_bearer_provider_name(uint8_t bearer_index, const char *name);
  *                       for GTBS.
  * @param new_technology The new bearer technology.
  *
- * @return int           BT_TBS_RESULT_CODE_* if positive or 0,
- *                       errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_set_bearer_technology(uint8_t bearer_index, enum bt_bearer_tech new_technology);
 
@@ -418,8 +405,7 @@ int bt_tbs_set_bearer_technology(uint8_t bearer_index, enum bt_bearer_tech new_t
  *                            BT_TBS_GTBS_INDEX for GTBS.
  * @param new_signal_strength The new signal strength.
  *
- * @return int                BT_TBS_RESULT_CODE_* if positive or 0,
- *                            errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_set_signal_strength(uint8_t bearer_index,
 			       uint8_t new_signal_strength);
@@ -431,8 +417,7 @@ int bt_tbs_set_signal_strength(uint8_t bearer_index,
  *                      for GTBS.
  * @param status_flags  The new feature and status value.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_set_status_flags(uint8_t bearer_index, uint16_t status_flags);
 
@@ -442,7 +427,7 @@ int bt_tbs_set_status_flags(uint8_t bearer_index, uint16_t status_flags);
  * @param bearer_index  The index of the Telephone Bearer.
  * @param uri_scheme_list Comma-separated list of URI prefixes (e.g. "skype,tel").
  *
- * @return BT_TBS_RESULT_CODE_* if positive or 0, errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_set_uri_scheme_list(uint8_t bearer_index, const char *uri_scheme_list);
 /**
@@ -511,13 +496,13 @@ struct bt_tbs_register_param {
  *
  * @param param The parameters to initialize the bearer.
 
- * @retval index The bearer index if return value is >= 0
- * @retval -EINVAL @p param contains invalid data
- * @retval -EALREADY @p param.gtbs is true and GTBS has already been registered
- * @retval -EAGAIN @p param.gtbs is false and GTBS has not been registered
+ * @return The bearer index on success (>= 0), or one of the error codes below.
+ * @retval -EINVAL @p param contains invalid data.
+ * @retval -EALREADY @p param.gtbs is true and GTBS has already been registered.
+ * @retval -EAGAIN @p param.gtbs is false and GTBS has not been registered.
  * @retval -ENOMEM @p param.gtbs is false and no more TBS can be registered (see
- *         @kconfig{CONFIG_BT_TBS_BEARER_COUNT})
- * @retval -ENOEXEC The service failed to be registered
+ *         @kconfig{CONFIG_BT_TBS_BEARER_COUNT}).
+ * @retval -ENOEXEC The service failed to be registered.
  */
 int bt_tbs_register_bearer(const struct bt_tbs_register_param *param);
 
@@ -532,12 +517,12 @@ int bt_tbs_register_bearer(const struct bt_tbs_register_param *param);
  *
  * @param bearer_index The index of the bearer to unregister.
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer_index is invalid
- * @retval -EALREADY The bearer identified by @p bearer_index is not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer_index is invalid.
+ * @retval -EALREADY The bearer identified by @p bearer_index is not registered.
  * @retval -EAGAIN The bearer identified by @p bearer_index is GTBS and there are TBS instances
  *                 registered.
- * @retval -ENOEXEC The service failed to be unregistered
+ * @retval -ENOEXEC The service failed to be unregistered.
  */
 int bt_tbs_unregister_bearer(uint8_t bearer_index);
 
@@ -781,7 +766,7 @@ struct bt_tbs_client_cb {
  *
  * @param conn          The connection to discover TBS for.
  *
- * @return int          0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_tbs_client_discover(struct bt_conn *conn);
 
@@ -792,7 +777,7 @@ int bt_tbs_client_discover(struct bt_conn *conn);
  * @param inst_index    The index of the TBS instance.
  * @param uri           The Null-terminated URI string.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_tbs_client_set_outgoing_uri(struct bt_conn *conn, uint8_t inst_index,
 				   const char *uri);
@@ -804,7 +789,7 @@ int bt_tbs_client_set_outgoing_uri(struct bt_conn *conn, uint8_t inst_index,
  * @param inst_index    The index of the TBS instance.
  * @param interval      The interval to write (0-255 seconds).
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL} must be set
  * for this function to be effective.
@@ -820,7 +805,7 @@ int bt_tbs_client_set_signal_strength_interval(struct bt_conn *conn,
  * @param inst_index    The index of the TBS instance.
  * @param uri           The URI of the callee.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL} must be set
  * for this function to be effective.
@@ -835,7 +820,7 @@ int bt_tbs_client_originate_call(struct bt_conn *conn, uint8_t inst_index,
  * @param inst_index    The index of the TBS instance.
  * @param call_index    The call index to terminate.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_TERMINATE_CALL} must be set
  * for this function to be effective.
@@ -850,7 +835,7 @@ int bt_tbs_client_terminate_call(struct bt_conn *conn, uint8_t inst_index,
  * @param inst_index    The index of the TBS instance.
  * @param call_index    The call index to place on hold.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_HOLD_CALL} must be set
  * for this function to be effective.
@@ -865,7 +850,7 @@ int bt_tbs_client_hold_call(struct bt_conn *conn, uint8_t inst_index,
  * @param inst_index    The index of the TBS instance.
  * @param call_index    The call index to accept.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_ACCEPT_CALL} must be set
  * for this function to be effective.
@@ -880,7 +865,7 @@ int bt_tbs_client_accept_call(struct bt_conn *conn, uint8_t inst_index,
  * @param inst_index    The index of the TBS instance.
  * @param call_index    The call index to retrieve.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL} must be set
  * for this function to be effective.
@@ -896,7 +881,7 @@ int bt_tbs_client_retrieve_call(struct bt_conn *conn, uint8_t inst_index,
  * @param call_indexes  Array of call indexes.
  * @param count         Number of call indexes in the call_indexes array.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_JOIN_CALLS} must be set
  * for this function to be effective.
@@ -910,7 +895,7 @@ int bt_tbs_client_join_calls(struct bt_conn *conn, uint8_t inst_index,
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME} must be set
  * for this function to be effective.
@@ -924,7 +909,7 @@ int bt_tbs_client_read_bearer_provider_name(struct bt_conn *conn,
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_UCI} must be set
  * for this function to be effective.
@@ -937,7 +922,7 @@ int bt_tbs_client_read_bearer_uci(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY} must be set
  * for this function to be effective.
@@ -950,7 +935,7 @@ int bt_tbs_client_read_technology(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST} must be set
  * for this function to be effective.
@@ -963,7 +948,7 @@ int bt_tbs_client_read_uri_list(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH} must be set
  * for this function to be effective.
@@ -977,7 +962,7 @@ int bt_tbs_client_read_signal_strength(struct bt_conn *conn,
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL} must be set
  * for this function to be effective.
@@ -991,7 +976,7 @@ int bt_tbs_client_read_signal_interval(struct bt_conn *conn,
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS} must be set
  * for this function to be effective.
@@ -1004,7 +989,7 @@ int bt_tbs_client_read_current_calls(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_CCID} must be set
  * for this function to be effective.
@@ -1017,7 +1002,7 @@ int bt_tbs_client_read_ccid(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_INCOMING_URI} must be set
  * for this function to be effective.
@@ -1030,7 +1015,7 @@ int bt_tbs_client_read_call_uri(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_STATUS_FLAGS} must be set
  * for this function to be effective.
@@ -1043,7 +1028,7 @@ int bt_tbs_client_read_status_flags(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_tbs_client_read_call_state(struct bt_conn *conn, uint8_t inst_index);
 
@@ -1053,7 +1038,7 @@ int bt_tbs_client_read_call_state(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_INCOMING_CALL} must be set
  * for this function to be effective.
@@ -1066,7 +1051,7 @@ int bt_tbs_client_read_remote_uri(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME} must be set
  * for this function to be effective.
@@ -1079,7 +1064,7 @@ int bt_tbs_client_read_friendly_name(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES} must be set
  * for this function to be effective.
@@ -1092,9 +1077,9 @@ int bt_tbs_client_read_optional_opcodes(struct bt_conn *conn,
  *
  * @param cbs Pointer to the callback structure.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cbs is NULL
- * @retval -EEXIST @p cbs is already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cbs is NULL.
+ * @retval -EEXIST @p cbs is already registered.
  */
 int bt_tbs_client_register_cb(struct bt_tbs_client_cb *cbs);
 

--- a/include/zephyr/bluetooth/audio/tmap.h
+++ b/include/zephyr/bluetooth/audio/tmap.h
@@ -99,7 +99,7 @@ struct bt_tmap_cb {
  *
  * @param role TMAP role(s) of the device (one or multiple).
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_tmap_register(enum bt_tmap_role role);
 
@@ -109,7 +109,7 @@ int bt_tmap_register(enum bt_tmap_role role);
  * @param conn     Pointer to the connection.
  * @param tmap_cb  Pointer to struct of TMAP callbacks.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_tmap_discover(struct bt_conn *conn, const struct bt_tmap_cb *tmap_cb);
 

--- a/include/zephyr/bluetooth/audio/vcp.h
+++ b/include/zephyr/bluetooth/audio/vcp.h
@@ -137,7 +137,7 @@ struct bt_vcp_included {
  *
  * @param[out] included Pointer to store the result in.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_included_get(struct bt_vcp_included *included);
 
@@ -149,7 +149,7 @@ int bt_vcp_vol_rend_included_get(struct bt_vcp_included *included);
  *
  * @param      param  Volume Control Service register parameters.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_register(struct bt_vcp_vol_rend_register_param *param);
 
@@ -201,49 +201,49 @@ struct bt_vcp_vol_rend_cb {
  *
  * @param volume_step  The volume step size (1-255).
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_set_step(uint8_t volume_step);
 
 /**
  * @brief Get the Volume Control Service volume state.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_get_state(void);
 
 /**
  * @brief Get the Volume Control Service flags.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_get_flags(void);
 
 /**
  * @brief Turn the volume down by one step on the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_vol_down(void);
 
 /**
  * @brief Turn the volume up by one step on the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_vol_up(void);
 
 /**
  * @brief Turn the volume down and unmute the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_unmute_vol_down(void);
 
 /**
  * @brief Turn the volume up and unmute the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_unmute_vol_up(void);
 
@@ -252,21 +252,21 @@ int bt_vcp_vol_rend_unmute_vol_up(void);
  *
  * @param volume The absolute volume to set.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_set_vol(uint8_t volume);
 
 /**
  * @brief Unmute the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_unmute(void);
 
 /**
  * @brief Mute the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_mute(void);
 
@@ -419,9 +419,9 @@ struct bt_vcp_vol_ctlr_cb {
  *
  * @param cb   The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb was already registered.
  */
 int bt_vcp_vol_ctlr_cb_register(struct bt_vcp_vol_ctlr_cb *cb);
 
@@ -430,9 +430,9 @@ int bt_vcp_vol_ctlr_cb_register(struct bt_vcp_vol_ctlr_cb *cb);
  *
  * @param cb   The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb was not registered.
  */
 int bt_vcp_vol_ctlr_cb_unregister(struct bt_vcp_vol_ctlr_cb *cb);
 
@@ -450,7 +450,7 @@ int bt_vcp_vol_ctlr_cb_unregister(struct bt_vcp_vol_ctlr_cb *cb);
  * @param      conn      The connection to discover Volume Control Service for.
  * @param[out] vol_ctlr  Valid remote instance object on success.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_discover(struct bt_conn *conn,
 			     struct bt_vcp_vol_ctlr **vol_ctlr);
@@ -464,8 +464,8 @@ int bt_vcp_vol_ctlr_discover(struct bt_conn *conn,
  *
  * @param conn     Connection pointer.
  *
- * @retval Pointer to a Volume Control Profile Volume Controller instance
- * @retval NULL if @p conn is NULL or if the connection has not done discovery yet
+ * @return Pointer to a Volume Control Profile Volume Controller instance,
+ *         or NULL if @p conn is NULL or if the connection has not done discovery yet.
  */
 struct bt_vcp_vol_ctlr *bt_vcp_vol_ctlr_get_by_conn(const struct bt_conn *conn);
 
@@ -478,7 +478,7 @@ struct bt_vcp_vol_ctlr *bt_vcp_vol_ctlr_get_by_conn(const struct bt_conn *conn);
  * @param      vol_ctlr Volume Controller instance pointer.
  * @param[out] conn     Connection pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_conn_get(const struct bt_vcp_vol_ctlr *vol_ctlr,
 			     struct bt_conn **conn);
@@ -497,7 +497,7 @@ int bt_vcp_vol_ctlr_conn_get(const struct bt_vcp_vol_ctlr *vol_ctlr,
  * @param      vol_ctlr Volume Controller instance pointer.
  * @param[out] included Pointer to store the result in.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_included_get(struct bt_vcp_vol_ctlr *vol_ctlr,
 				 struct bt_vcp_included *included);
@@ -507,7 +507,7 @@ int bt_vcp_vol_ctlr_included_get(struct bt_vcp_vol_ctlr *vol_ctlr,
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_read_state(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -516,7 +516,7 @@ int bt_vcp_vol_ctlr_read_state(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_read_flags(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -525,7 +525,7 @@ int bt_vcp_vol_ctlr_read_flags(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_vol_down(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -534,7 +534,7 @@ int bt_vcp_vol_ctlr_vol_down(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_vol_up(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -543,7 +543,7 @@ int bt_vcp_vol_ctlr_vol_up(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_unmute_vol_down(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -552,7 +552,7 @@ int bt_vcp_vol_ctlr_unmute_vol_down(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_unmute_vol_up(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -562,7 +562,7 @@ int bt_vcp_vol_ctlr_unmute_vol_up(struct bt_vcp_vol_ctlr *vol_ctlr);
  * @param vol_ctlr  Volume Controller instance pointer.
  * @param volume    The absolute volume to set.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_set_vol(struct bt_vcp_vol_ctlr *vol_ctlr, uint8_t volume);
 
@@ -571,7 +571,7 @@ int bt_vcp_vol_ctlr_set_vol(struct bt_vcp_vol_ctlr *vol_ctlr, uint8_t volume);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_unmute(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -580,7 +580,7 @@ int bt_vcp_vol_ctlr_unmute(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_mute(struct bt_vcp_vol_ctlr *vol_ctlr);
 

--- a/include/zephyr/bluetooth/audio/vocs.h
+++ b/include/zephyr/bluetooth/audio/vocs.h
@@ -112,7 +112,7 @@ struct bt_vocs_discover_param {
 /**
  * @brief Get a free service instance of Volume Offset Control Service from the pool.
  *
- * @return Volume Offset Control Service instance in case of success or NULL in case of error.
+ * @return Volume Offset Control Service instance on success, or NULL on failure.
  */
 struct bt_vocs *bt_vocs_free_instance_get(void);
 
@@ -136,7 +136,7 @@ void *bt_vocs_svc_decl_get(struct bt_vocs *vocs);
  * @param vocs    Audio Input Control Service client instance pointer.
  * @param conn    Connection pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vocs_client_conn_get(const struct bt_vocs *vocs, struct bt_conn **conn);
 
@@ -146,7 +146,7 @@ int bt_vocs_client_conn_get(const struct bt_vocs *vocs, struct bt_conn **conn);
  * @param vocs      Volume Offset Control Service instance.
  * @param param     Volume Offset Control Service register parameters.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vocs_register(struct bt_vocs *vocs,
 		     const struct bt_vocs_register_param *param);
@@ -252,7 +252,7 @@ struct bt_vocs_cb {
  *
  * @param inst          Pointer to the Volume Offset Control Service instance.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_state_get(struct bt_vocs *inst);
 
@@ -262,7 +262,7 @@ int bt_vocs_state_get(struct bt_vocs *inst);
  * @param inst          Pointer to the Volume Offset Control Service instance.
  * @param offset        The offset to set (-255 to 255).
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_state_set(struct bt_vocs *inst, int16_t offset);
 
@@ -273,7 +273,7 @@ int bt_vocs_state_set(struct bt_vocs *inst, int16_t offset);
  *
  * @param inst          Pointer to the Volume Offset Control Service instance.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_location_get(struct bt_vocs *inst);
 
@@ -283,7 +283,7 @@ int bt_vocs_location_get(struct bt_vocs *inst);
  * @param inst          Pointer to the Volume Offset Control Service instance.
  * @param location      The location to set.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_location_set(struct bt_vocs *inst, uint32_t location);
 
@@ -294,7 +294,7 @@ int bt_vocs_location_set(struct bt_vocs *inst, uint32_t location);
  *
  * @param inst          Pointer to the Volume Offset Control Service instance.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_description_get(struct bt_vocs *inst);
 
@@ -304,7 +304,7 @@ int bt_vocs_description_get(struct bt_vocs *inst);
  * @param inst          Pointer to the Volume Offset Control Service instance.
  * @param description   The UTF-8 encoded string description to set.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_description_set(struct bt_vocs *inst, const char *description);
 
@@ -332,7 +332,7 @@ struct bt_vocs *bt_vocs_client_free_instance_get(void);
  * @param inst  Pointer to the Volume Offset Control Service client instance.
  * @param param Pointer to the parameters.
  *
- * @return 0 on success, errno on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *inst,
 		     const struct bt_vocs_discover_param *param);


### PR DESCRIPTION
Apply the @retval/@return cleanup following the conventions documented in PR #107458.

Fixes parts of: #65974