### PR TITLE
doc: shell: fix typo in shell documentation

### DIFF
--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -499,7 +499,7 @@ Simple command handler implementation:
 		ARG_UNUSED(argc);
 		ARG_UNUSED(argv);
 
-		shell_fprintf(shell, SHELL_INFO, "Print info message\n");
+		shell_fprintf(sh, SHELL_INFO, "Print info message\n");
 
 		shell_print(sh, "Print simple text.");
 


### PR DESCRIPTION
This commit fixes the typo in the shell module documentation to use `sh` instead of undeclared `shell` in shell_fprintf call.

Fixes #110979