### PR TITLE
ci: testplan: various fixes

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -89,7 +89,9 @@ jobs:
         run: |
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          python3 ./scripts/ci/test_plan_v2.py -c origin/${BASE_REF}.. --tests-per-builder $TESTS_PER_BUILDER
+          python3 ./scripts/ci/test_plan_v2.py -c origin/${BASE_REF}.. \
+            --tests-per-builder $TESTS_PER_BUILDER \
+            --disable-strategy  BoilerplateFilter
           if [ -s .testplan ]; then
             cat .testplan >> $GITHUB_ENV
           else
@@ -253,7 +255,9 @@ jobs:
           rm -f testplan.json
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          python3 ./scripts/ci/test_plan_v2.py -c origin/${BASE_REF}..
+          python3 ./scripts/ci/test_plan_v2.py -c origin/${BASE_REF}.. \
+            --disable-strategy  BoilerplateFilter
+
           if [ -f testplan.json ]; then
             ./scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} --load-tests testplan.json ${TWISTER_COMMON} ${PR_OPTIONS}
             if [ "${{matrix.subset}}" = "1" -a ${{needs.twister-build-prep.outputs.fullrun}} = 'True' ]; then

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -229,6 +229,8 @@ ARC arch:
     - "area: ARC"
   tests:
     - arch.arc
+    - arch
+    - kernel
 
 ARM Platforms:
   status: maintained
@@ -285,6 +287,8 @@ ARM arch:
     - "area: ARM"
   tests:
     - arch.arm
+    - arch
+    - kernel
 
 ARM64 arch:
   status: maintained
@@ -305,6 +309,8 @@ ARM64 arch:
     - "area: ARM64"
   tests:
     - arch.arm64
+    - arch
+    - kernel
 
 ASPEED Platforms:
   status: odd fixes
@@ -1080,6 +1086,7 @@ Common Architecture Interface:
     - tests/arch/common/acpi/
   tests:
     - arch
+    - kernel
 
 Console:
   status: odd fixes
@@ -3740,6 +3747,8 @@ MIPS arch:
     - boards/qemu/malta/
   labels:
     - "area: MIPS"
+    - arch
+    - kernel
 
 Memory Management:
   status: maintained
@@ -5000,6 +5009,8 @@ RISCV arch:
   tests:
     - arch.riscv
     - arch.riscv64
+    - arch
+    - kernel
 
 RTIO:
   status: maintained
@@ -5036,6 +5047,8 @@ RX arch:
     - "area: RX"
   tests:
     - arch.rx
+    - arch
+    - kernel
 
 Random:
   status: maintained
@@ -5309,6 +5322,9 @@ SPARC arch:
     - boards/qemu/leon3/
   labels:
     - "area: SPARC"
+  tests:
+    - arch
+    - kernel
 
 SPDX Tooling:
   status: maintained
@@ -7261,6 +7277,8 @@ Xtensa arch:
     - "area: Xtensa"
   tests:
     - arch.xtensa
+    - arch
+    - kernel
 
 hawkBit:
   status: maintained
@@ -7406,6 +7424,8 @@ x86 arch:
   tests:
     - arch.interrupt
     - arch.x86
+    - arch
+    - kernel
 
 zbus:
   status: maintained

--- a/scripts/ci/test_plan_v2.py
+++ b/scripts/ci/test_plan_v2.py
@@ -2609,6 +2609,7 @@ class RiskClassifierStrategy(SelectionStrategy):
             ".jpg",
             ".svg",
             ".gif",
+            ".webp",
         }
     )
 

--- a/scripts/ci/test_plan_v2.py
+++ b/scripts/ci/test_plan_v2.py
@@ -3477,7 +3477,12 @@ class BoilerplateFilter(SelectionStrategy):
     def _is_boilerplate_only(self, filepath):
         """Return ``True`` if every diff hunk in *filepath* is boilerplate.
 
-        Two-phase check:
+        Binary files (images, compiled objects, archives, …) are never
+        considered boilerplate: git reports them as ``"Binary files … differ"``
+        with no text content lines, so the absence of ``+``/``-`` lines must
+        not be misread as an empty/boilerplate change.
+
+        Two-phase check for text files:
 
         1. ``git diff -w --ignore-blank-lines`` — if this produces no output,
            the entire diff is whitespace / blank-line changes only.
@@ -3494,6 +3499,13 @@ class BoilerplateFilter(SelectionStrategy):
                 filepath,
             )
         except Exception:  # noqa: BLE001
+            return False
+
+        # git signals binary content with a "Binary files … differ" line.
+        # Binary files are not boilerplate; let them fall through to other
+        # strategies (e.g. IgnoreStrategy) for proper handling.
+        if "Binary files" in diff_no_ws:
+            log.debug("[%s] '%s' is a binary file - not boilerplate.", self.name, filepath)
             return False
 
         if not diff_no_ws.strip():

--- a/scripts/ci/test_plan_v2.py
+++ b/scripts/ci/test_plan_v2.py
@@ -3095,6 +3095,13 @@ class ManifestStrategy(SelectionStrategy):
        ``--tag <name> --integration``.  This lets twister select only tests
        whose ``tags:`` field lists the module (e.g. ``tags: mbedtls``).
 
+    6. Additionally, look up the ``"West project: <name>"`` area in
+       ``MAINTAINERS.yml``.  If the area carries a ``tests:`` list, emit a
+       second :class:`TwisterCall` with ``--test-pattern`` arguments built
+       from those names (same as :class:`MaintainerAreaStrategy`).  This
+       covers tests that are explicitly catalogued for the module but may not
+       carry a ``tags:`` field matching the project name.
+
     This strategy **consumes** all matched manifest files so they do not
     reach :class:`MaintainerAreaStrategy`.
 
@@ -3114,7 +3121,9 @@ class ManifestStrategy(SelectionStrategy):
     def name(self):
         return "ManifestStrategy"
 
-    def __init__(self, zephyr_base, repo=None, commits=None, platform_filter=None):
+    def __init__(
+        self, zephyr_base, repo=None, commits=None, platform_filter=None, maintainers_file=None
+    ):
         """
         Parameters
         ----------
@@ -3125,11 +3134,17 @@ class ManifestStrategy(SelectionStrategy):
         commits:
             The commit range string used on the CLI (e.g. ``"main..HEAD"``).
             The base commit is derived as ``commits.split("..")[0]``.
+        maintainers_file:
+            Path to ``MAINTAINERS.yml``.  When supplied, each changed project
+            name is matched against the ``"West project: <name>"`` area and
+            any ``tests:`` entries there generate additional pattern-based
+            :class:`TwisterCall` objects alongside the tag-based ones.
         """
         self._zephyr_base = Path(zephyr_base)
         self._repo = repo
         self._commits = commits
         self._platform_filter = platform_filter or []
+        self._maintainers_file = maintainers_file
 
     # ------------------------------------------------------------------
     # SelectionStrategy interface
@@ -3173,6 +3188,8 @@ class ManifestStrategy(SelectionStrategy):
             ", ".join(sorted(changed_projects)),
         )
 
+        west_project_tests = self._load_west_project_tests()
+
         calls = []
         for proj_name in sorted(changed_projects):
             extra = []
@@ -3186,11 +3203,56 @@ class ManifestStrategy(SelectionStrategy):
                 )
             )
 
+            test_names = west_project_tests.get(proj_name, [])
+            if test_names:
+                patterns = [_test_pattern(t) for t in test_names]
+                log.info(
+                    "[%s] 'West project: %s' MAINTAINERS tests → patterns: %s",
+                    self.name,
+                    proj_name,
+                    ", ".join(repr(p) for p in patterns),
+                )
+                calls.append(
+                    TwisterCall(
+                        description=f"ManifestStrategy: West project '{proj_name}' "
+                        "(MAINTAINERS tests)",
+                        test_patterns=patterns,
+                        platforms=list(self._platform_filter),
+                    )
+                )
+
         return calls, set(manifest_files)
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _load_west_project_tests(self):
+        """Return a dict mapping west project name → ``tests:`` list.
+
+        Reads all ``"West project: <name>"`` areas from ``MAINTAINERS.yml``
+        and returns only those that carry a non-empty ``tests:`` list.  When
+        no maintainers file is configured, an empty dict is returned.
+        """
+        if not self._maintainers_file:
+            return {}
+        try:
+            with open(self._maintainers_file, encoding="utf-8") as fh:
+                data = yaml.load(fh, Loader=SafeLoader)
+        except OSError as exc:
+            log.warning("[%s] Cannot read maintainers file: %s", self.name, exc)
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        prefix = "West project: "
+        result = {}
+        for key, area in data.items():
+            if not key.startswith(prefix):
+                continue
+            tests = area.get("tests", []) if isinstance(area, dict) else []
+            if tests:
+                result[key[len(prefix) :]] = tests
+        return result
 
     def _diff_manifests(self, base_commit, head_commit="HEAD"):
         """Return the set of project names whose revision changed between
@@ -3678,11 +3740,14 @@ def build_strategies(
         ),
         # 6. west.yml / submanifests changes: diff the manifest, find changed
         #    projects and run integration tests tagged with those module names.
+        #    Also emits pattern-based calls from MAINTAINERS "West project:"
+        #    areas that carry a ``tests:`` list.
         ManifestStrategy(
             zephyr_base=base,
             repo=repo,
             commits=commits,
             platform_filter=platform_filter,
+            maintainers_file=maintainers_file,
         ),
         # 7. Driver source changes: find tests via DT overlay compat matching
         #    and board-targeted area-pattern calls via the dts/ dtsi chain.

--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -31,7 +31,10 @@ doc/*
 .github/*
 *.rst
 *.jpg
+*.jpeg
 *.png
+*.webp
+*.gif
 *.md
 # if we change this file or associated script, it should not trigger a full
 # twister.


### PR DESCRIPTION
- Ignore webp files as well when processing testplan for twister
- add tests from changed west projects
- do not handle images as boilerplate
- ...

