### PR TITLE
bluetooth: audio: fix incorrect @retval usage (2/2)

### DIFF
--- a/include/zephyr/bluetooth/audio/aics.h
+++ b/include/zephyr/bluetooth/audio/aics.h
@@ -186,7 +186,7 @@ struct bt_aics_discover_param {
 /**
  * @brief Get a free instance of Audio Input Control Service from the pool.
  *
- * @return Audio Input Control Service instance in case of success or NULL in case of error.
+ * @return Audio Input Control Service instance on success, or NULL on failure.
  */
 struct bt_aics *bt_aics_free_instance_get(void);
 
@@ -210,7 +210,7 @@ void *bt_aics_svc_decl_get(struct bt_aics *aics);
  * @param aics    Audio Input Control Service client instance pointer.
  * @param conn    Connection pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_client_conn_get(const struct bt_aics *aics, struct bt_conn **conn);
 
@@ -220,7 +220,7 @@ int bt_aics_client_conn_get(const struct bt_aics *aics, struct bt_conn **conn);
  * @param aics      Audio Input Control Service instance.
  * @param param     Audio Input Control Service register parameters.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_register(struct bt_aics *aics, struct bt_aics_register_param *param);
 
@@ -366,7 +366,7 @@ struct bt_aics_cb {
  * @param inst      The instance pointer.
  * @param param     Pointer to the parameters.
  *
- * @return 0 on success, errno on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_discover(struct bt_conn *conn, struct bt_aics *inst,
 		     const struct bt_aics_discover_param *param);
@@ -379,7 +379,7 @@ int bt_aics_discover(struct bt_conn *conn, struct bt_aics *inst,
  *
  * @param inst         The instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_deactivate(struct bt_aics *inst);
 
@@ -392,7 +392,7 @@ int bt_aics_deactivate(struct bt_aics *inst);
  *
  * @param inst         The instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_activate(struct bt_aics *inst);
 
@@ -401,7 +401,7 @@ int bt_aics_activate(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_state_get(struct bt_aics *inst);
 
@@ -410,7 +410,7 @@ int bt_aics_state_get(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_gain_setting_get(struct bt_aics *inst);
 
@@ -419,7 +419,7 @@ int bt_aics_gain_setting_get(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_type_get(struct bt_aics *inst);
 
@@ -428,7 +428,7 @@ int bt_aics_type_get(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_status_get(struct bt_aics *inst);
 
@@ -440,7 +440,7 @@ int bt_aics_status_get(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_disable_mute(struct bt_aics *inst);
 
@@ -449,7 +449,7 @@ int bt_aics_disable_mute(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_unmute(struct bt_aics *inst);
 
@@ -458,7 +458,7 @@ int bt_aics_unmute(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_mute(struct bt_aics *inst);
 
@@ -467,7 +467,7 @@ int bt_aics_mute(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_gain_set_manual_only(struct bt_aics *inst);
 
@@ -479,7 +479,7 @@ int bt_aics_gain_set_manual_only(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_aics_gain_set_auto_only(struct bt_aics *inst);
 
@@ -488,7 +488,7 @@ int bt_aics_gain_set_auto_only(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_manual_gain_set(struct bt_aics *inst);
 
@@ -497,7 +497,7 @@ int bt_aics_manual_gain_set(struct bt_aics *inst);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_automatic_gain_set(struct bt_aics *inst);
 
@@ -508,7 +508,7 @@ int bt_aics_automatic_gain_set(struct bt_aics *inst);
  * @param gain          The gain to set (-128 to 127) in gain setting units
  *                      (see @ref bt_aics_gain_setting_cb).
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_gain_set(struct bt_aics *inst, int8_t gain);
 
@@ -517,7 +517,7 @@ int bt_aics_gain_set(struct bt_aics *inst, int8_t gain);
  *
  * @param inst          The instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_description_get(struct bt_aics *inst);
 
@@ -527,7 +527,7 @@ int bt_aics_description_get(struct bt_aics *inst);
  * @param inst          The instance pointer.
  * @param description   The description as an UTF-8 encoded string.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_aics_description_set(struct bt_aics *inst, const char *description);
 

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -500,7 +500,7 @@ struct bt_bap_scan_delegator_cb {
 	 *                   the change was caused by it, otherwise NULL.
 	 * @param recv_state Pointer to the receive state that was updated.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	void (*recv_state_updated)(struct bt_conn *conn,
 				   const struct bt_bap_scan_delegator_recv_state *recv_state);
@@ -536,7 +536,7 @@ struct bt_bap_scan_delegator_cb {
 	 * @param recv_state  Pointer to the receive state that is being
 	 *                    requested for periodic advertising sync.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*pa_sync_term_req)(struct bt_conn *conn,
 				const struct bt_bap_scan_delegator_recv_state *recv_state);
@@ -672,8 +672,8 @@ struct bt_bap_ep_info {
  * @param ep   The audio stream endpoint object.
  * @param info The structure object to be filled with the info.
  *
- * @retval 0 in case of success
- * @retval -EINVAL if @p ep or @p info are NULL
+ * @retval 0 on success.
+ * @retval -EINVAL @p ep or @p info are NULL.
  */
 int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info);
 
@@ -689,7 +689,7 @@ int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info);
  *         - @p ep is NULL
  *         - @p ep is a broadcast endpoint
  *         - @p ep is a Unicast Server endpoint not yet configured by a remote client
- *         - @p ep is a Unicast Client endpoint not yet discovered on a remote server
+ *         - @p ep is a Unicast Client endpoint not yet discovered on a remote server.
  */
 struct bt_conn *bt_bap_ep_get_conn(const struct bt_bap_ep *ep);
 
@@ -929,7 +929,7 @@ void bt_bap_stream_cb_register(struct bt_bap_stream *stream, struct bt_bap_strea
  * @param ep Remote Audio Endpoint being configured
  * @param codec_cfg Codec configuration
  *
- * @return Allocated Audio Stream object or NULL in case of error.
+ * @return Allocated Audio Stream object on success, or NULL on failure.
  */
 int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
 			 const struct bt_audio_codec_cfg *codec_cfg);
@@ -945,7 +945,7 @@ int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, str
  * @param stream Stream object being reconfigured
  * @param codec_cfg Codec configuration
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_reconfig(struct bt_bap_stream *stream,
 			   const struct bt_audio_codec_cfg *codec_cfg);
@@ -960,7 +960,7 @@ int bt_bap_stream_reconfig(struct bt_bap_stream *stream,
  * @param conn  Connection object
  * @param group Unicast group object
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group);
 
@@ -976,7 +976,7 @@ int bt_bap_stream_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group);
  * @param meta Metadata
  * @param meta_len Metadata length
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len);
 
@@ -989,7 +989,7 @@ int bt_bap_stream_enable(struct bt_bap_stream *stream, const uint8_t meta[], siz
  * @param meta Metadata
  * @param meta_len Metadata length
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_metadata(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len);
 
@@ -1003,7 +1003,7 @@ int bt_bap_stream_metadata(struct bt_bap_stream *stream, const uint8_t meta[], s
  *
  * @param stream Stream object
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_disable(struct bt_bap_stream *stream);
 
@@ -1022,13 +1022,13 @@ int bt_bap_stream_disable(struct bt_bap_stream *stream);
  *
  * @param stream Stream object
  *
- * @retval 0 in case of success
- * @retval -EINVAL if the stream, endpoint, ISO channel or connection is NULL
- * @retval -EBADMSG if the stream or ISO channel is in an invalid state for connection
- * @retval -EOPNOTSUPP if the role of the stream is not @ref BT_CONN_ROLE_CENTRAL
- * @retval -EALREADY if the ISO channel is already connecting or connected
- * @retval -EBUSY if another ISO channel is connecting
- * @retval -ENOEXEC if otherwise rejected by the ISO layer
+ * @retval 0 on success.
+ * @retval -EINVAL The stream, endpoint, ISO channel or connection is NULL.
+ * @retval -EBADMSG The stream or ISO channel is in an invalid state for connection.
+ * @retval -EOPNOTSUPP The role of the stream is not @ref BT_CONN_ROLE_CENTRAL.
+ * @retval -EALREADY The ISO channel is already connecting or connected.
+ * @retval -EBUSY Another ISO channel is connecting.
+ * @retval -ENOEXEC Otherwise rejected by the ISO layer.
  */
 int bt_bap_stream_connect(struct bt_bap_stream *stream);
 
@@ -1052,7 +1052,7 @@ int bt_bap_stream_connect(struct bt_bap_stream *stream);
  *
  * @param stream Stream object
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_start(struct bt_bap_stream *stream);
 
@@ -1067,17 +1067,16 @@ int bt_bap_stream_start(struct bt_bap_stream *stream);
  *
  * @param stream Stream object
  *
- * @retval 0 Success
- * @retval -EINVAL The @p stream does not have an endpoint or a connection, of the stream's
- *                 connection's role is not @p BT_CONN_ROLE_CENTRAL
- * @retval -EBADMSG The state of the @p stream endpoint is not @ref BT_BAP_EP_STATE_DISABLING
- * @retval -EALREADY The CIS state of the @p is not in a connected state, and thus is already
- *                   stopping
- * @retval -EBUSY The @p stream is busy with another operation
- * @retval -ENOTCONN The @p stream ACL connection is not connected
- * @retval -ENOMEM No memory to send request
- * @retval -ENOEXEC The request was rejected by GATT
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 on success.
+ * @retval -EINVAL The @p stream does not have an endpoint or a connection, or the stream's
+ *                 connection's role is not @p BT_CONN_ROLE_CENTRAL.
+ * @retval -EBADMSG The state of the @p stream endpoint is not @ref BT_BAP_EP_STATE_DISABLING.
+ * @retval -EALREADY The CIS state of the @p stream is not in a connected state, and thus is already
+ *                   stopping.
+ * @retval -EBUSY The @p stream is busy with another operation.
+ * @retval -ENOTCONN The @p stream ACL connection is not connected.
+ * @retval -ENOMEM No memory to send request.
+ * @retval -ENOEXEC The request was rejected by GATT.
  */
 int bt_bap_stream_stop(struct bt_bap_stream *stream);
 
@@ -1092,7 +1091,7 @@ int bt_bap_stream_stop(struct bt_bap_stream *stream);
  *
  * @param stream Stream object
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_stream_release(struct bt_bap_stream *stream);
 
@@ -1108,7 +1107,7 @@ int bt_bap_stream_release(struct bt_bap_stream *stream);
  * @param seq_num  Packet Sequence number. This value shall be incremented for each call to this
  *                 function and at least once per SDU interval for a specific channel.
  *
- * @return Bytes sent in case of success or negative value in case of error.
+ * @return Bytes sent on success, negative errno value on failure.
  */
 int bt_bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf, uint16_t seq_num);
 
@@ -1126,7 +1125,7 @@ int bt_bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf, uint16
  * @param ts       Timestamp of the SDU in microseconds (us). This value can be used to transmit
  *                 multiple SDUs in the same SDU interval in a CIG or BIG.
  *
- * @return Bytes sent in case of success or negative value in case of error.
+ * @return Bytes sent on success, negative errno value on failure.
  */
 int bt_bap_stream_send_ts(struct bt_bap_stream *stream, struct net_buf *buf, uint16_t seq_num,
 			  uint32_t ts);
@@ -1144,10 +1143,10 @@ int bt_bap_stream_send_ts(struct bt_bap_stream *stream, struct net_buf *buf, uin
  * @param[in]  stream Stream object.
  * @param[out] info   Transmit info object.
  *
- * @retval 0 on success
- * @retval -EINVAL if the stream is invalid, if the stream is not configured for sending or if it is
- *         not connected with a isochronous stream
- * @retval Any return value from bt_iso_chan_get_tx_sync()
+ * @retval 0 on success.
+ * @retval -EINVAL The stream is invalid, the stream is not configured for sending, or it is
+ *         not connected with an isochronous stream.
+ * @return Any return value from bt_iso_chan_get_tx_sync().
  */
 int bt_bap_stream_get_tx_sync(struct bt_bap_stream *stream, struct bt_iso_tx_info *info);
 
@@ -1175,7 +1174,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp       Object for the ASE operation response. Only used if the return
 	 *                       value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*config)(struct bt_conn *conn, const struct bt_bap_ep *ep, enum bt_audio_dir dir,
 		      const struct bt_audio_codec_cfg *codec_cfg, struct bt_bap_stream **stream,
@@ -1195,7 +1194,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp       Object for the ASE operation response. Only used if the return
 	 *                       value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*reconfig)(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 			const struct bt_audio_codec_cfg *codec_cfg,
@@ -1212,7 +1211,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp     Object for the ASE operation response. Only used if the return
 	 *                     value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*qos)(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 		   struct bt_bap_ascs_rsp *rsp);
@@ -1228,7 +1227,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp         Object for the ASE operation response. Only used if the return
 	 *                         value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*enable)(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 		      struct bt_bap_ascs_rsp *rsp);
@@ -1242,7 +1241,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*start)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -1257,7 +1256,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp          Object for the ASE operation response. Only used if the return
 	 *                          value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*metadata)(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 			struct bt_bap_ascs_rsp *rsp);
@@ -1271,7 +1270,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*disable)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -1284,7 +1283,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*stop)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 
@@ -1298,7 +1297,7 @@ struct bt_bap_unicast_server_cb {
 	 * @param[out] rsp    Object for the ASE operation response. Only used if the return
 	 *                    value is non-zero.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @return 0 on success, negative errno value on failure.
 	 */
 	int (*release)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 };
@@ -1311,7 +1310,7 @@ struct bt_bap_unicast_server_cb {
  *
  * @param param  Registration parameters for ascs.
  *
- * @return 0 in case of success, negative error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_server_register(const struct bt_bap_unicast_server_register_param *param);
 
@@ -1327,7 +1326,7 @@ int bt_bap_unicast_server_register(const struct bt_bap_unicast_server_register_p
  * Calling this function will issue an release operation on any ASE
  * in a non-idle state.
  *
- * @return 0 in case of success, negative error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_server_unregister(void);
 
@@ -1339,7 +1338,7 @@ int bt_bap_unicast_server_unregister(void);
  *
  * @param cb  Unicast server callback structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_server_register_cb(const struct bt_bap_unicast_server_cb *cb);
 
@@ -1351,7 +1350,7 @@ int bt_bap_unicast_server_register_cb(const struct bt_bap_unicast_server_cb *cb)
  *
  * @param cb  Unicast server callback structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_server_unregister_cb(const struct bt_bap_unicast_server_cb *cb);
 
@@ -1374,7 +1373,7 @@ typedef bool (*bt_bap_ep_func_t)(struct bt_bap_ep *ep, void *user_data);
  * @param func Function to call for each endpoint.
  * @param user_data Data to pass to the callback function.
  *
- * @retval 0 Success
+ * @retval 0 on success.
  * @retval -ECANCELED Iteration was stopped by the callback function before complete.
  * @retval -EINVAL @p conn or @p func were NULL.
  */
@@ -1388,7 +1387,7 @@ int bt_bap_unicast_server_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func
  * @param codec_cfg Codec configuration
  * @param qos_pref Audio Stream Quality of Service Preference
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_server_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 				     const struct bt_audio_codec_cfg *codec_cfg,
@@ -1485,7 +1484,7 @@ struct bt_bap_unicast_group_param {
  * @param[in]  param          The unicast group create parameters.
  * @param[out] unicast_group  Pointer to the unicast group created.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_group_create(struct bt_bap_unicast_group_param *param,
 				struct bt_bap_unicast_group **unicast_group);
@@ -1503,7 +1502,7 @@ int bt_bap_unicast_group_create(struct bt_bap_unicast_group_param *param,
  * @param unicast_group  Pointer to the unicast group created.
  * @param param          The unicast group reconfigure parameters.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_group_reconfig(struct bt_bap_unicast_group *unicast_group,
 				  const struct bt_bap_unicast_group_param *param);
@@ -1525,7 +1524,7 @@ int bt_bap_unicast_group_reconfig(struct bt_bap_unicast_group *unicast_group,
  * @param params         Array of stream parameters with streams being added to the group.
  * @param num_param      Number of parameters in @p params.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_group_add_streams(struct bt_bap_unicast_group *unicast_group,
 				     struct bt_bap_unicast_group_stream_pair_param params[],
@@ -1539,7 +1538,7 @@ int bt_bap_unicast_group_add_streams(struct bt_bap_unicast_group *unicast_group,
  *
  * @param unicast_group  Pointer to the unicast group to delete
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_unicast_group_delete(struct bt_bap_unicast_group *unicast_group);
 
@@ -1561,7 +1560,7 @@ typedef bool (*bt_bap_unicast_group_foreach_stream_func_t)(struct bt_bap_stream 
  * @param func           The callback function
  * @param user_data      User specified data that sent to the callback function
  *
- * @retval 0 Success (even if no streams exists in the group).
+ * @retval 0 on success (even if no streams exists in the group).
  * @retval -ECANCELED Iteration was stopped by the callback function before complete.
  * @retval -EINVAL @p unicast_group or @p func were NULL.
  */
@@ -1594,8 +1593,8 @@ struct bt_bap_unicast_group_info {
  * @param unicast_group The unicast group object.
  * @param info          The structure object to be filled with the info.
  *
- * @retval 0 Success
- * @retval -EINVAL  @p unicast_group or @p info are NULL
+ * @retval 0 on success.
+ * @retval -EINVAL @p unicast_group or @p info are NULL.
  */
 int bt_bap_unicast_group_get_info(const struct bt_bap_unicast_group *unicast_group,
 				  struct bt_bap_unicast_group_info *info);
@@ -1804,7 +1803,7 @@ struct bt_bap_unicast_client_cb {
  *
  * @param cb  Unicast client callback structure to register.
  *
- * @retval 0 Success
+ * @retval 0 on success.
  * @retval -EINVAL @p cb is NULL.
  * @retval -EEXIST @p cb is already registered.
  */
@@ -1815,8 +1814,8 @@ int bt_bap_unicast_client_register_cb(struct bt_bap_unicast_client_cb *cb);
  *
  * @param cb  Unicast client callback structure to unregister.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cb is NULL or @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL or @p cb was not registered.
  */
 int bt_bap_unicast_client_unregister_cb(struct bt_bap_unicast_client_cb *cb);
 
@@ -1830,13 +1829,13 @@ int bt_bap_unicast_client_unregister_cb(struct bt_bap_unicast_client_cb *cb);
  *               requirements of the Basic Audio Profile.
  * @param dir    The type of remote endpoints and capabilities to discover.
  *
- * @retval 0 Success
+ * @retval 0 on success.
  * @retval -EINVAL @p conn is NULL, not a central connection or does not conform to security
  *                 requirements, or @p dir is invalid.
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocate memory for the request
- * @retval -ENOEXEC Unexpected GATT error
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected GATT error.
  */
 int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir);
 
@@ -1878,8 +1877,7 @@ struct bt_bap_base_subgroup_bis {
  *
  * @param ad The periodic advertising data
  *
- * @retval NULL if the data does not contain a BASE
- * @retval Pointer to a bt_bap_base structure
+ * @return Pointer to a bt_bap_base structure, or NULL if the data does not contain a BASE.
  */
 const struct bt_bap_base *bt_bap_base_get_base_from_ad(const struct bt_data *ad);
 
@@ -1888,8 +1886,8 @@ const struct bt_bap_base *bt_bap_base_get_base_from_ad(const struct bt_data *ad)
  *
  * @param base The BASE pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The size of the BASE
+ * @return The size of the BASE on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_size(const struct bt_bap_base *base);
 
@@ -1898,8 +1896,8 @@ int bt_bap_base_get_size(const struct bt_bap_base *base);
  *
  * @param base The BASE pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The 24-bit presentation delay value
+ * @return The 24-bit presentation delay value on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_pres_delay(const struct bt_bap_base *base);
 
@@ -1908,8 +1906,8 @@ int bt_bap_base_get_pres_delay(const struct bt_bap_base *base);
  *
  * @param base The BASE pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The 8-bit subgroup count value
+ * @return The 8-bit subgroup count value on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_subgroup_count(const struct bt_bap_base *base);
 
@@ -1919,8 +1917,8 @@ int bt_bap_base_get_subgroup_count(const struct bt_bap_base *base);
  * @param[in]  base        The BASE pointer
  * @param[out] bis_indexes 32-bit BIS index bitfield that will be populated
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_bis_indexes(const struct bt_bap_base *base, uint32_t *bis_indexes);
 
@@ -1931,9 +1929,9 @@ int bt_bap_base_get_bis_indexes(const struct bt_bap_base *base, uint32_t *bis_in
  * @param func      Callback function. Return true to continue iterating, or false to stop.
  * @param user_data Userdata supplied to @p func
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ECANCELED if iterating over the subgroups stopped prematurely by @p func
- * @retval 0 if all subgroups were iterated
+ * @retval 0 All subgroups were iterated.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ECANCELED Iterating over the subgroups stopped prematurely by @p func.
  */
 int bt_bap_base_foreach_subgroup(const struct bt_bap_base *base,
 				 bool (*func)(const struct bt_bap_base_subgroup *subgroup,
@@ -1946,8 +1944,8 @@ int bt_bap_base_foreach_subgroup(const struct bt_bap_base *base,
  * @param[in]  subgroup The subgroup pointer
  * @param[out] codec_id Pointer to the struct where the results are placed
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_subgroup_codec_id(const struct bt_bap_base_subgroup *subgroup,
 				      struct bt_bap_base_codec_id *codec_id);
@@ -1958,8 +1956,8 @@ int bt_bap_base_get_subgroup_codec_id(const struct bt_bap_base_subgroup *subgrou
  * @param[in]  subgroup The subgroup pointer
  * @param[out] data     Pointer that will point to the resulting codec configuration data
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_subgroup_codec_data(const struct bt_bap_base_subgroup *subgroup,
 					uint8_t **data);
@@ -1970,8 +1968,8 @@ int bt_bap_base_get_subgroup_codec_data(const struct bt_bap_base_subgroup *subgr
  * @param[in]  subgroup The subgroup pointer
  * @param[out] meta     Pointer that will point to the resulting codec metadata
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_subgroup_codec_meta(const struct bt_bap_base_subgroup *subgroup,
 					uint8_t **meta);
@@ -1982,9 +1980,9 @@ int bt_bap_base_get_subgroup_codec_meta(const struct bt_bap_base_subgroup *subgr
  * @param[in]  subgroup  The subgroup pointer
  * @param[out] codec_cfg Pointer to the struct where the results are placed
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the @p codec_cfg cannot store the @p subgroup codec data
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The @p codec_cfg cannot store the @p subgroup codec data.
  */
 int bt_bap_base_subgroup_codec_to_codec_cfg(const struct bt_bap_base_subgroup *subgroup,
 					    struct bt_audio_codec_cfg *codec_cfg);
@@ -1994,8 +1992,8 @@ int bt_bap_base_subgroup_codec_to_codec_cfg(const struct bt_bap_base_subgroup *s
  *
  * @param subgroup The subgroup pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The 8-bit BIS count value
+ * @return The 8-bit BIS count value on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_get_subgroup_bis_count(const struct bt_bap_base_subgroup *subgroup);
 
@@ -2005,8 +2003,8 @@ int bt_bap_base_get_subgroup_bis_count(const struct bt_bap_base_subgroup *subgro
  * @param[in]  subgroup    The subgroup pointer
  * @param[out] bis_indexes 32-bit BIS index bitfield that will be populated
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
  */
 int bt_bap_base_subgroup_get_bis_indexes(const struct bt_bap_base_subgroup *subgroup,
 					 uint32_t *bis_indexes);
@@ -2018,9 +2016,9 @@ int bt_bap_base_subgroup_get_bis_indexes(const struct bt_bap_base_subgroup *subg
  * @param func      Callback function. Return true to continue iterating, or false to stop.
  * @param user_data Userdata supplied to @p func
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ECANCELED if iterating over the subgroups stopped prematurely by @p func
- * @retval 0 if all BIS were iterated
+ * @retval 0 All BIS were iterated.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ECANCELED Iterating over the subgroups stopped prematurely by @p func.
  */
 int bt_bap_base_subgroup_foreach_bis(const struct bt_bap_base_subgroup *subgroup,
 				     bool (*func)(const struct bt_bap_base_subgroup_bis *bis,
@@ -2036,9 +2034,9 @@ int bt_bap_base_subgroup_foreach_bis(const struct bt_bap_base_subgroup *subgroup
  * @param[in]  bis       The BIS pointer
  * @param[out] codec_cfg Pointer to the struct where the results are placed
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the @p codec_cfg cannot store the @p subgroup codec data
- * @retval 0 on success
+ * @retval 0 on success.
+ * @retval -EINVAL Arguments are invalid.
+ * @retval -ENOMEM The @p codec_cfg cannot store the @p subgroup codec data.
  */
 int bt_bap_base_subgroup_bis_codec_to_codec_cfg(const struct bt_bap_base_subgroup_bis *bis,
 						struct bt_audio_codec_cfg *codec_cfg);
@@ -2084,9 +2082,9 @@ struct bt_bap_broadcast_source_cb {
  *
  * @param cb Pointer to the callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EEXIST if @p cb is already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EEXIST @p cb is already registered.
  */
 int bt_bap_broadcast_source_register_cb(struct bt_bap_broadcast_source_cb *cb);
 
@@ -2095,9 +2093,9 @@ int bt_bap_broadcast_source_register_cb(struct bt_bap_broadcast_source_cb *cb);
  *
  * @param cb Pointer to the callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -ENOENT if @p cb is not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -ENOENT @p cb is not registered.
  */
 int bt_bap_broadcast_source_unregister_cb(struct bt_bap_broadcast_source_cb *cb);
 
@@ -2210,7 +2208,7 @@ struct bt_bap_broadcast_source_param {
  * @param[in]  param       Pointer to parameters used to create the broadcast source.
  * @param[out] source      Pointer to the broadcast source created
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_create(struct bt_bap_broadcast_source_param *param,
 				   struct bt_bap_broadcast_source **source);
@@ -2232,7 +2230,7 @@ int bt_bap_broadcast_source_create(struct bt_bap_broadcast_source_param *param,
  * @param source      Pointer to the broadcast source
  * @param param       Pointer to parameters used to reconfigure the broadcast source.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
 				     struct bt_bap_broadcast_source_param *param);
@@ -2247,7 +2245,7 @@ int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
  * @param meta        Metadata.
  * @param meta_len    Length of metadata.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_update_metadata(struct bt_bap_broadcast_source *source,
 					    const uint8_t meta[], size_t meta_len);
@@ -2261,7 +2259,7 @@ int bt_bap_broadcast_source_update_metadata(struct bt_bap_broadcast_source *sour
  * @param source      Pointer to the broadcast source
  * @param adv         Pointer to an extended advertising set with periodic advertising configured.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_start(struct bt_bap_broadcast_source *source,
 				  struct bt_le_ext_adv *adv);
@@ -2274,7 +2272,7 @@ int bt_bap_broadcast_source_start(struct bt_bap_broadcast_source *source,
  *
  * @param source      Pointer to the broadcast source
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_stop(struct bt_bap_broadcast_source *source);
 
@@ -2286,7 +2284,7 @@ int bt_bap_broadcast_source_stop(struct bt_bap_broadcast_source *source);
  *
  * @param source      Pointer to the broadcast source
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_delete(struct bt_bap_broadcast_source *source);
 
@@ -2302,7 +2300,7 @@ int bt_bap_broadcast_source_delete(struct bt_bap_broadcast_source *source);
  * @param source        Pointer to the broadcast source.
  * @param base_buf      Pointer to a buffer where the BASE will be inserted.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_source_get_base(struct bt_bap_broadcast_source *source,
 				     struct net_buf_simple *base_buf);
@@ -2326,9 +2324,9 @@ typedef bool (*bt_bap_broadcast_source_foreach_stream_func_t)(struct bt_bap_stre
  * @param func           The callback function
  * @param user_data      User specified data that is sent to the callback function
  *
- * @retval 0          Success (even if no streams exists in the broadcast source).
+ * @retval 0 on success (even if no streams exists in the broadcast source).
  * @retval -ECANCELED The @p func returned false and stopped the iteration.
- * @retval -EINVAL    @p source or @p func were NULL.
+ * @retval -EINVAL @p source or @p func were NULL.
  */
 int bt_bap_broadcast_source_foreach_stream(struct bt_bap_broadcast_source *source,
 					   bt_bap_broadcast_source_foreach_stream_func_t func,
@@ -2402,9 +2400,9 @@ struct bt_bap_broadcast_sink_cb {
 
  * @param cb  Broadcast sink callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb was already registered.
  */
 int bt_bap_broadcast_sink_register_cb(struct bt_bap_broadcast_sink_cb *cb);
 
@@ -2424,7 +2422,7 @@ int bt_bap_broadcast_sink_register_cb(struct bt_bap_broadcast_sink_cb *cb);
  * @param      broadcast_id  24-bit broadcast ID.
  * @param[out] sink          Pointer to the Broadcast Sink created.
  *
- * @return 0 in case of success or errno value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_sink_create(struct bt_le_per_adv_sync *pa_sync, uint32_t broadcast_id,
 				 struct bt_bap_broadcast_sink **sink);
@@ -2446,7 +2444,7 @@ int bt_bap_broadcast_sink_create(struct bt_le_per_adv_sync *pa_sync, uint32_t br
  *                           The string "Broadcast Code" shall be
  *                           [42 72 6F 61 64 63 61 73 74 20 43 6F 64 65 00 00]
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t indexes_bitfield,
 			       struct bt_bap_stream *streams[],
@@ -2460,7 +2458,7 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
  *
  * @param sink      Pointer to the broadcast sink
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_sink_stop(struct bt_bap_broadcast_sink *sink);
 
@@ -2473,7 +2471,7 @@ int bt_bap_broadcast_sink_stop(struct bt_bap_broadcast_sink *sink);
  *
  * @param sink Pointer to the sink object to delete.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_broadcast_sink_delete(struct bt_bap_broadcast_sink *sink);
 
@@ -2490,7 +2488,7 @@ int bt_bap_broadcast_sink_delete(struct bt_bap_broadcast_sink *sink);
  *
  * @param cb Pointer to the callback struct
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_register(struct bt_bap_scan_delegator_cb *cb);
 
@@ -2500,7 +2498,7 @@ int bt_bap_scan_delegator_register(struct bt_bap_scan_delegator_cb *cb);
  * Unregister the scan delegator and Broadcast Audio Scan Service (BASS)
  * dynamically at runtime.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_unregister(void);
 
@@ -2513,7 +2511,7 @@ int bt_bap_scan_delegator_unregister(void);
  * @param src_id    The source id used to identify the receive state.
  * @param pa_state  The Periodic Advertising sync state to set.
  *
- * @return int    Error value. 0 on success, errno on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_set_pa_state(uint8_t src_id,
 				       enum bt_bap_pa_state pa_state);
@@ -2524,7 +2522,7 @@ int bt_bap_scan_delegator_set_pa_state(uint8_t src_id,
  * @param src_id         The source id used to identify the receive state.
  * @param bis_synced     Array of bitfields to set the BIS sync state for each
  *                       subgroup.
- * @return int           Error value. 0 on success, ERRNO on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_set_bis_sync_state(uint8_t src_id,
 					     uint32_t bis_synced[BT_BAP_BASS_MAX_SUBGROUPS]);
@@ -2569,7 +2567,7 @@ struct bt_bap_scan_delegator_add_src_param {
  *
  * @param param The parameters for adding the new source
  *
- * @return int  errno on failure, or source ID on success.
+ * @return Source ID on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_add_src(const struct bt_bap_scan_delegator_add_src_param *param);
 
@@ -2607,7 +2605,7 @@ struct bt_bap_scan_delegator_mod_src_param {
  *
  * @param param The parameters for adding the new source
  *
- * @return int  errno on failure, or source ID on success.
+ * @return Source ID on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_mod_src(const struct bt_bap_scan_delegator_mod_src_param *param);
 
@@ -2622,7 +2620,7 @@ int bt_bap_scan_delegator_mod_src(const struct bt_bap_scan_delegator_mod_src_par
  *
  * @param src_id The source ID to remove
  *
- * @return int   Error value. 0 on success, errno on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_bap_scan_delegator_rem_src(uint8_t src_id);
 
@@ -2633,8 +2631,8 @@ int bt_bap_scan_delegator_rem_src(uint8_t src_id);
  *
  * @retval true to stop iterating. If this is used in the context of
  *         bt_bap_scan_delegator_find_state(), the recv_state will be returned by
- *         bt_bap_scan_delegator_find_state()
- * @retval false to continue iterating
+ *         bt_bap_scan_delegator_find_state().
+ * @retval false to continue iterating.
  */
 typedef bool (*bt_bap_scan_delegator_state_func_t)(
 	const struct bt_bap_scan_delegator_recv_state *recv_state, void *user_data);
@@ -2654,7 +2652,7 @@ void bt_bap_scan_delegator_foreach_state(bt_bap_scan_delegator_state_func_t func
  * @param func      The compare callback function
  * @param user_data User specified data that sent to the callback function
  *
- * @return The first receive state where the @p func returned true, or NULL
+ * @return The first receive state where the @p func returned true, or NULL.
  */
 const struct bt_bap_scan_delegator_recv_state *bt_bap_scan_delegator_find_state(
 	bt_bap_scan_delegator_state_func_t func, void *user_data);
@@ -2783,12 +2781,12 @@ struct bt_bap_broadcast_assistant_cb {
  * @param conn  The ACL connection. The connection must already conform to the security requirements
  *              of the Basic Audio Profile.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL, does not conform to security requirements
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocate memory for the request
- * @retval -ENOEXEC Unexpected GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL, does not conform to security requirements.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected GATT error.
  */
 int bt_bap_broadcast_assistant_discover(struct bt_conn *conn);
 
@@ -2808,13 +2806,13 @@ int bt_bap_broadcast_assistant_discover(struct bt_conn *conn);
  * @param start_scan    Start scanning if true. If false, the application should
  *                      enable scan itself.
 
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL of if @p conn has not done discovery
- * @retval -EBUSY Another operation is already in progress for this @p conn
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL or @p conn has not done discovery.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
  * @retval -EAGAIN Bluetooth has not been enabled.
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn,
 					  bool start_scan);
@@ -2824,13 +2822,13 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn,
  *
  * @param conn   Connection to the server.
 
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL of if @p conn has not done discovery
- * @retval -EBUSY Another operation is already in progress for this @p conn
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL or @p conn has not done discovery.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
  * @retval -EAGAIN Bluetooth has not been enabled.
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn);
 
@@ -2839,9 +2837,9 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn);
  *
  * @param cb	The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb was already registered.
  */
 int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb *cb);
 
@@ -2850,9 +2848,9 @@ int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb 
  *
  * @param cb   The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb was not registered.
  */
 int bt_bap_broadcast_assistant_unregister_cb(struct bt_bap_broadcast_assistant_cb *cb);
 
@@ -2895,12 +2893,12 @@ struct bt_bap_broadcast_assistant_add_src_param {
  * @param conn          Connection to the server.
  * @param param         Parameter struct.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL or %p conn has not done discovery or if @p param is invalid
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL, @p conn has not done discovery, or @p param is invalid.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_add_src(
 	struct bt_conn *conn, const struct bt_bap_broadcast_assistant_add_src_param *param);
@@ -2933,12 +2931,12 @@ struct bt_bap_broadcast_assistant_mod_src_param {
  * @param conn          Connection to the server.
  * @param param         Parameter struct.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL or %p conn has not done discovery or if @p param is invalid
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL, @p conn has not done discovery, or @p param is invalid.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_mod_src(
 	struct bt_conn *conn, const struct bt_bap_broadcast_assistant_mod_src_param *param);
@@ -2950,12 +2948,12 @@ int bt_bap_broadcast_assistant_mod_src(
  * @param src_id          Source ID of the receive state.
  * @param broadcast_code  The broadcast code.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL or %p conn has not done discovery or @p src_id is invalid
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL or @p conn has not done discovery or @p src_id is invalid.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_set_broadcast_code(
 	struct bt_conn *conn, uint8_t src_id,
@@ -2967,12 +2965,12 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
  * @param conn            Connection to the server.
  * @param src_id          Source ID of the receive state.
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL or %p conn has not done discovery or @p src_id is invalid
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL or @p conn has not done discovery or @p src_id is invalid.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id);
 
@@ -2983,12 +2981,12 @@ int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id);
  * @param idx      The index of the receive start (0 up to the value from
  *                 bt_bap_broadcast_assistant_discover_cb)
  *
- * @retval 0 Success
- * @retval -EINVAL @p conn is NULL or %p conn has not done discovery or @p src_id is invalid
- * @retval -EBUSY Another operation is already in progress for this @p conn
- * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
- * @retval -ENOEXEC Unexpected scan or GATT error
+ * @retval 0 on success.
+ * @retval -EINVAL @p conn is NULL or @p conn has not done discovery or @p src_id is invalid.
+ * @retval -EBUSY Another operation is already in progress for this @p conn.
+ * @retval -ENOTCONN @p conn is not connected.
+ * @retval -ENOMEM Could not allocate memory for the request.
+ * @retval -ENOEXEC Unexpected scan or GATT error.
  */
 int bt_bap_broadcast_assistant_read_recv_state(struct bt_conn *conn, uint8_t idx);
 

--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -217,7 +217,7 @@ void *bt_csip_set_member_svc_decl_get(const struct bt_csip_set_member_svc_inst *
  * @param[out] svc_inst  Pointer to the registered Coordinated Set
  *                       Identification Service.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_member_register(const struct bt_csip_set_member_register_param *param,
 				struct bt_csip_set_member_svc_inst **svc_inst);
@@ -229,7 +229,7 @@ int bt_csip_set_member_register(const struct bt_csip_set_member_register_param *
  *
  * @param svc_inst  Pointer to the registered Coordinated Set Identification Service.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_member_unregister(struct bt_csip_set_member_svc_inst *svc_inst);
 
@@ -266,7 +266,7 @@ int bt_csip_set_member_sirk(struct bt_csip_set_member_svc_inst *svc_inst,
  * @retval -EINVAL @p svc_inst is NULL, @p size is less than 1, @p rank is less than 1 or higher
  *                 than @p size for a lockable @p svc_inst.
  * @retval -EALREADY @p size is already set.
- * @retval 0 Success.
+ * @retval 0 on success.
  */
 int bt_csip_set_member_set_size_and_rank(struct bt_csip_set_member_svc_inst *svc_inst, uint8_t size,
 					 uint8_t rank);
@@ -323,7 +323,7 @@ struct bt_csip_set_member_set_info {
  * @param info Pointer to a struct to store the information in.
  *
  * @retval -EINVAL @p svc_inst or @p info is NULL.
- * @retval 0 Success.
+ * @retval 0 on success.
  */
 int bt_csip_set_member_get_info(const struct bt_csip_set_member_svc_inst *svc_inst,
 				struct bt_csip_set_member_set_info *info);
@@ -336,7 +336,7 @@ int bt_csip_set_member_get_info(const struct bt_csip_set_member_svc_inst *svc_in
  * @param svc_inst  Pointer to the Coordinated Set Identification Service.
  * @param rsi       Pointer to the 6-octet newly generated RSI data in little-endian.
  *
- * @return int		0 if on success, errno on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_member_generate_rsi(const struct bt_csip_set_member_svc_inst *svc_inst,
 				    uint8_t rsi[BT_CSIP_RSI_SIZE]);
@@ -352,7 +352,7 @@ int bt_csip_set_member_generate_rsi(const struct bt_csip_set_member_svc_inst *sv
  *                  (release) and will force release the lock, regardless of who
  *                  took the lock.
  *
- * @return 0 on success, GATT error on error.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_csip_set_member_lock(struct bt_csip_set_member_svc_inst *svc_inst,
 			    bool lock, bool force);
@@ -425,7 +425,7 @@ typedef void (*bt_csip_set_coordinator_discover_cb)(
  *
  * @param conn Pointer to remote device to perform discovery on.
  *
- * @return int Return 0 on success, or an errno value on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_coordinator_discover(struct bt_conn *conn);
 
@@ -438,8 +438,8 @@ int bt_csip_set_coordinator_discover(struct bt_conn *conn);
  *
  * @param conn     Connection pointer.
  *
- * @retval Pointer to a Coordinated Set Identification Profile Set Coordinator instance
- * @retval NULL if @p conn is NULL or if the connection has not done discovery yet
+ * @return Pointer to a Coordinated Set Identification Profile Set Coordinator instance,
+ *         or NULL if @p conn is NULL or if the connection has not done discovery yet.
  */
 struct bt_csip_set_coordinator_set_member *
 bt_csip_set_coordinator_set_member_by_conn(const struct bt_conn *conn);
@@ -460,7 +460,7 @@ typedef void (*bt_csip_set_coordinator_lock_set_cb)(int err);
  *                changed.
  * @param locked  Whether the lock is locked or release.
  *
- * @return int Return 0 on success, or an errno value on error.
+ * @return 0 on success, negative errno value on failure.
  */
 typedef void (*bt_csip_set_coordinator_lock_changed_cb)(
 	struct bt_csip_set_coordinator_csis_inst *inst, bool locked);
@@ -545,7 +545,7 @@ struct bt_csip_set_coordinator_cb {
  * @param sirk The SIRK of the set to check against
  * @param data The advertising data
  *
- * @return true if the advertising data indicates a set member, false otherwise
+ * @return true if the advertising data indicates a set member, false otherwise.
  */
 bool bt_csip_set_coordinator_is_set_member(const uint8_t sirk[BT_CSIP_SIRK_SIZE],
 					   struct bt_data *data);
@@ -555,7 +555,7 @@ bool bt_csip_set_coordinator_is_set_member(const uint8_t sirk[BT_CSIP_SIRK_SIZE]
  *
  * @param cb   Pointer to the callback structure.
  *
- * @return Return 0 on success, or an errno value on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_coordinator_register_cb(struct bt_csip_set_coordinator_cb *cb);
 
@@ -618,7 +618,7 @@ int bt_csip_set_coordinator_ordered_access(
  * @param set_info  Pointer to the a specific set_info struct, as a member may
  *                  be part of multiple sets.
  *
- * @return Return 0 on success, or an errno value on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_coordinator_lock(const struct bt_csip_set_coordinator_set_member **members,
 				 uint8_t count,
@@ -636,7 +636,7 @@ int bt_csip_set_coordinator_lock(const struct bt_csip_set_coordinator_set_member
  * @param set_info  Pointer to the a specific set_info struct, as a member may
  *                  be part of multiple sets.
  *
- * @return Return 0 on success, or an errno value on error.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_csip_set_coordinator_release(const struct bt_csip_set_coordinator_set_member **members,
 				    uint8_t count,

--- a/include/zephyr/bluetooth/audio/mcc.h
+++ b/include/zephyr/bluetooth/audio/mcc.h
@@ -636,7 +636,7 @@ struct bt_mcc_cb {
  *
  * @param cb    Callbacks to be used
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_init(struct bt_mcc_cb *cb);
 
@@ -653,7 +653,7 @@ int bt_mcc_init(struct bt_mcc_cb *cb);
  * @param conn  Connection to the peer device
  * @param subscribe   Whether to subscribe to notifications
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe);
 
@@ -662,7 +662,7 @@ int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_player_name(struct bt_conn *conn);
 
@@ -671,7 +671,7 @@ int bt_mcc_read_player_name(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_icon_obj_id(struct bt_conn *conn);
 
@@ -680,7 +680,7 @@ int bt_mcc_read_icon_obj_id(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_icon_url(struct bt_conn *conn);
 
@@ -689,7 +689,7 @@ int bt_mcc_read_icon_url(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_track_title(struct bt_conn *conn);
 
@@ -698,7 +698,7 @@ int bt_mcc_read_track_title(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_track_duration(struct bt_conn *conn);
 
@@ -707,7 +707,7 @@ int bt_mcc_read_track_duration(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_track_position(struct bt_conn *conn);
 
@@ -717,7 +717,7 @@ int bt_mcc_read_track_position(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param pos   Track position
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos);
 
@@ -726,7 +726,7 @@ int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_playback_speed(struct bt_conn *conn);
 
@@ -736,7 +736,7 @@ int bt_mcc_read_playback_speed(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param speed Playback speed
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed);
 
@@ -745,7 +745,7 @@ int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_seeking_speed(struct bt_conn *conn);
 
@@ -754,7 +754,7 @@ int bt_mcc_read_seeking_speed(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_segments_obj_id(struct bt_conn *conn);
 
@@ -763,7 +763,7 @@ int bt_mcc_read_segments_obj_id(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_current_track_obj_id(struct bt_conn *conn);
 
@@ -775,7 +775,7 @@ int bt_mcc_read_current_track_obj_id(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param id    Object Transfer Service ID (UINT48) of the track to set as the current track
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t id);
 
@@ -784,7 +784,7 @@ int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t id);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_next_track_obj_id(struct bt_conn *conn);
 
@@ -796,7 +796,7 @@ int bt_mcc_read_next_track_obj_id(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param id   Object Transfer Service ID (UINT48) of the track to set as the next track
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_next_track_obj_id(struct bt_conn *conn, uint64_t id);
 
@@ -805,7 +805,7 @@ int bt_mcc_set_next_track_obj_id(struct bt_conn *conn, uint64_t id);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_current_group_obj_id(struct bt_conn *conn);
 
@@ -817,7 +817,7 @@ int bt_mcc_read_current_group_obj_id(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param id   Object Transfer Service ID (UINT48) of the group to set as the current group
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t id);
 
@@ -826,7 +826,7 @@ int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t id);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_parent_group_obj_id(struct bt_conn *conn);
 
@@ -835,7 +835,7 @@ int bt_mcc_read_parent_group_obj_id(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_playing_order(struct bt_conn *conn);
 
@@ -845,7 +845,7 @@ int bt_mcc_read_playing_order(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param order Playing order
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order);
 
@@ -854,7 +854,7 @@ int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_playing_orders_supported(struct bt_conn *conn);
 
@@ -863,7 +863,7 @@ int bt_mcc_read_playing_orders_supported(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_media_state(struct bt_conn *conn);
 
@@ -875,7 +875,7 @@ int bt_mcc_read_media_state(struct bt_conn *conn);
  * @param conn  Connection to the peer device
  * @param cmd   The command to send
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd);
 
@@ -884,7 +884,7 @@ int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_opcodes_supported(struct bt_conn *conn);
 
@@ -896,7 +896,7 @@ int bt_mcc_read_opcodes_supported(struct bt_conn *conn);
  * @param conn   Connection to the peer device
  * @param search The search
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search);
 
@@ -905,7 +905,7 @@ int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_search_results_obj_id(struct bt_conn *conn);
 
@@ -914,7 +914,7 @@ int bt_mcc_read_search_results_obj_id(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_read_content_control_id(struct bt_conn *conn);
 
@@ -923,7 +923,7 @@ int bt_mcc_read_content_control_id(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_object_metadata(struct bt_conn *conn);
 
@@ -932,7 +932,7 @@ int bt_mcc_otc_read_object_metadata(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_icon_object(struct bt_conn *conn);
 
@@ -941,7 +941,7 @@ int bt_mcc_otc_read_icon_object(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_track_segments_object(struct bt_conn *conn);
 
@@ -950,7 +950,7 @@ int bt_mcc_otc_read_track_segments_object(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_current_track_object(struct bt_conn *conn);
 
@@ -959,7 +959,7 @@ int bt_mcc_otc_read_current_track_object(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_next_track_object(struct bt_conn *conn);
 
@@ -968,7 +968,7 @@ int bt_mcc_otc_read_next_track_object(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_current_group_object(struct bt_conn *conn);
 
@@ -977,7 +977,7 @@ int bt_mcc_otc_read_current_group_object(struct bt_conn *conn);
  *
  * @param conn  Connection to the peer device
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_mcc_otc_read_parent_group_object(struct bt_conn *conn);
 

--- a/include/zephyr/bluetooth/audio/media_proxy.h
+++ b/include/zephyr/bluetooth/audio/media_proxy.h
@@ -847,7 +847,7 @@ struct media_proxy_ctrl_cbs {
  *
  * @param ctrl_cbs   Callbacks to the controller
  *
- * @return 0 if success, errno on failure
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_register(struct media_proxy_ctrl_cbs *ctrl_cbs);
 
@@ -866,7 +866,7 @@ int media_proxy_ctrl_register(struct media_proxy_ctrl_cbs *ctrl_cbs);
  *
  * @param conn   The connection to do discovery for
  *
- * @return 0 if success, errno on failure
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_discover_player(struct bt_conn *conn);
 
@@ -875,7 +875,7 @@ int media_proxy_ctrl_discover_player(struct bt_conn *conn);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_player_name(struct media_player *player);
 
@@ -892,7 +892,7 @@ int media_proxy_ctrl_get_player_name(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_icon_id(struct media_player *player);
 
@@ -910,7 +910,7 @@ int media_proxy_ctrl_get_icon_url(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_track_title(struct media_player *player);
 
@@ -922,7 +922,7 @@ int media_proxy_ctrl_get_track_title(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_track_duration(struct media_player *player);
 
@@ -935,7 +935,7 @@ int media_proxy_ctrl_get_track_duration(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_track_position(struct media_player *player);
 
@@ -951,7 +951,7 @@ int media_proxy_ctrl_get_track_position(struct media_player *player);
  * @param player     Media player instance pointer
  * @param position   The track position to set
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_track_position(struct media_player *player, int32_t position);
 
@@ -970,7 +970,7 @@ int media_proxy_ctrl_set_track_position(struct media_player *player, int32_t pos
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_playback_speed(struct media_player *player);
 
@@ -991,7 +991,7 @@ int media_proxy_ctrl_get_playback_speed(struct media_player *player);
  * @param player   Media player instance pointer
  * @param speed    The playback speed parameter to set
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_playback_speed(struct media_player *player, int8_t speed);
 
@@ -1009,7 +1009,7 @@ int media_proxy_ctrl_set_playback_speed(struct media_player *player, int8_t spee
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_seeking_speed(struct media_player *player);
 
@@ -1026,7 +1026,7 @@ int media_proxy_ctrl_get_seeking_speed(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_track_segments_id(struct media_player *player);
 
@@ -1043,7 +1043,7 @@ int media_proxy_ctrl_get_track_segments_id(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_current_track_id(struct media_player *player);
 
@@ -1058,7 +1058,7 @@ int media_proxy_ctrl_get_current_track_id(struct media_player *player);
  * @param player   Media player instance pointer
  * @param id       The ID of a track object
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_current_track_id(struct media_player *player, uint64_t id);
 
@@ -1072,7 +1072,7 @@ int media_proxy_ctrl_set_current_track_id(struct media_player *player, uint64_t 
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_next_track_id(struct media_player *player);
 
@@ -1086,7 +1086,7 @@ int media_proxy_ctrl_get_next_track_id(struct media_player *player);
  * @param player   Media player instance pointer
  * @param id       The ID of a track object
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_next_track_id(struct media_player *player, uint64_t id);
 
@@ -1105,7 +1105,7 @@ int media_proxy_ctrl_set_next_track_id(struct media_player *player, uint64_t id)
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_parent_group_id(struct media_player *player);
 
@@ -1122,7 +1122,7 @@ int media_proxy_ctrl_get_parent_group_id(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_current_group_id(struct media_player *player);
 
@@ -1137,7 +1137,7 @@ int media_proxy_ctrl_get_current_group_id(struct media_player *player);
  * @param player   Media player instance pointer
  * @param id       The ID of a group object
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_current_group_id(struct media_player *player, uint64_t id);
 
@@ -1146,7 +1146,7 @@ int media_proxy_ctrl_set_current_group_id(struct media_player *player, uint64_t 
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_playing_order(struct media_player *player);
 
@@ -1158,7 +1158,7 @@ int media_proxy_ctrl_get_playing_order(struct media_player *player);
  * @param player   Media player instance pointer
  * @param order    The playing order to set
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_set_playing_order(struct media_player *player, uint8_t order);
 
@@ -1170,7 +1170,7 @@ int media_proxy_ctrl_set_playing_order(struct media_player *player, uint8_t orde
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_playing_orders_supported(struct media_player *player);
 
@@ -1181,7 +1181,7 @@ int media_proxy_ctrl_get_playing_orders_supported(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_media_state(struct media_player *player);
 
@@ -1196,7 +1196,7 @@ int media_proxy_ctrl_get_media_state(struct media_player *player);
  * @param player      Media player instance pointer
  * @param command     The command to send
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_send_command(struct media_player *player, const struct mpl_cmd *command);
 
@@ -1208,7 +1208,7 @@ int media_proxy_ctrl_send_command(struct media_player *player, const struct mpl_
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_commands_supported(struct media_player *player);
 
@@ -1229,7 +1229,7 @@ int media_proxy_ctrl_get_commands_supported(struct media_player *player);
  * @param player   Media player instance pointer
  * @param search   The search to write
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_send_search(struct media_player *player, const struct mpl_search *search);
 
@@ -1247,7 +1247,7 @@ int media_proxy_ctrl_send_search(struct media_player *player, const struct mpl_s
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_ctrl_get_search_results_id(struct media_player *player);
 
@@ -1260,7 +1260,7 @@ int media_proxy_ctrl_get_search_results_id(struct media_player *player);
  *
  * @param player   Media player instance pointer
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 uint8_t media_proxy_ctrl_get_content_ctrl_id(struct media_player *player);
 
@@ -1274,7 +1274,7 @@ struct media_proxy_pl_calls {
 	/**
 	 * @brief Read Media Player Name
 	 *
-	 * @return The name of the media player
+	 * @return The name of the media player.
 	 */
 	const char *(*get_player_name)(void);
 
@@ -1287,7 +1287,7 @@ struct media_proxy_pl_calls {
 	 * See the Media Control Service spec v1.0 sections 3.2 and
 	 * 4.1 for a description of the Icon Object.
 	 *
-	 * @return The Icon Object ID
+	 * @return The Icon Object ID.
 	 */
 	uint64_t (*get_icon_id)(void);
 
@@ -1296,14 +1296,14 @@ struct media_proxy_pl_calls {
 	 *
 	 * Get a URL to the media player's icon.
 	 *
-	 * @return The URL of the Icon
+	 * @return The URL of the Icon.
 	 */
 	const char *(*get_icon_url)(void);
 
 	/**
 	 * @brief Read Track Title
 	 *
-	 * @return The title of the current track
+	 * @return The title of the current track.
 	 */
 	const char *(*get_track_title)(void);
 
@@ -1313,7 +1313,7 @@ struct media_proxy_pl_calls {
 	 * The duration of a track is measured in hundredths of a
 	 * second.
 	 *
-	 * @return The duration of the current track
+	 * @return The duration of the current track.
 	 */
 	int32_t (*get_track_duration)(void);
 
@@ -1324,7 +1324,7 @@ struct media_proxy_pl_calls {
 	 * measured in hundredths of a second from the beginning of
 	 * the track
 	 *
-	 * @return The position of the player in the current track
+	 * @return The position of the player in the current track.
 	 */
 	int32_t (*get_track_position)(void);
 
@@ -1354,7 +1354,7 @@ struct media_proxy_pl_calls {
 	 * 127 corresponds to playback at almost four times the normal
 	 * speed.
 	 *
-	 * @return The playback speed parameter
+	 * @return The playback speed parameter.
 	 */
 	int8_t (*get_playback_speed)(void);
 
@@ -1388,7 +1388,7 @@ struct media_proxy_pl_calls {
 	 * The seeking speed is not settable - a non-zero seeking speed
 	 * is the result of "fast rewind" of "fast forward" commands.
 	 *
-	 * @return The seeking speed factor
+	 * @return The seeking speed factor.
 	 */
 	int8_t (*get_seeking_speed)(void);
 
@@ -1401,7 +1401,7 @@ struct media_proxy_pl_calls {
 	 * See the Media Control Service spec v1.0 sections 3.10 and
 	 * 4.2 for a description of the Track Segments Object.
 	 *
-	 * @return Current The Track Segments Object ID
+	 * @return The Current Track Segments Object ID.
 	 */
 	uint64_t (*get_track_segments_id)(void);
 
@@ -1414,7 +1414,7 @@ struct media_proxy_pl_calls {
 	 * See the Media Control Service spec v1.0 sections 3.11 and
 	 * 4.3 for a description of the Current Track Object.
 	 *
-	 * @return The Current Track Object ID
+	 * @return The Current Track Object ID.
 	 */
 	uint64_t (*get_current_track_id)(void);
 
@@ -1434,7 +1434,7 @@ struct media_proxy_pl_calls {
 	 * Get an ID (48 bit) that can be used to retrieve the Next
 	 * Track Object from an Object Transfer Service
 	 *
-	 * @return The Next Track Object ID
+	 * @return The Next Track Object ID.
 	 */
 	uint64_t (*get_next_track_id)(void);
 
@@ -1458,7 +1458,7 @@ struct media_proxy_pl_calls {
 	 * See the Media Control Service spec v1.0 sections 3.14 and
 	 * 4.4 for a description of the Current Track Object.
 	 *
-	 * @return The Current Group Object ID
+	 * @return The Current Group Object ID.
 	 */
 	uint64_t (*get_parent_group_id)(void);
 
@@ -1471,7 +1471,7 @@ struct media_proxy_pl_calls {
 	 * See the Media Control Service spec v1.0 sections 3.14 and
 	 * 4.4 for a description of the Current Group Object.
 	 *
-	 * @return The Current Group Object ID
+	 * @return The Current Group Object ID.
 	 */
 	uint64_t (*get_current_group_id)(void);
 
@@ -1509,7 +1509,7 @@ struct media_proxy_pl_calls {
 	 * playing orders.
 	 * See the MEDIA_PROXY_PLAYING_ORDERS_SUPPORTED_* defines.
 	 *
-	 * @return The media player's supported playing orders
+	 * @return The media player's supported playing orders.
 	 */
 	uint16_t (*get_playing_orders_supported)(void);
 
@@ -1519,7 +1519,7 @@ struct media_proxy_pl_calls {
 	 * Read the media player's state
 	 * See the MEDIA_PROXY_MEDIA_STATE_* defines.
 	 *
-	 * @return The media player's state
+	 * @return The media player's state.
 	 */
 	uint8_t (*get_media_state)(void);
 
@@ -1541,7 +1541,7 @@ struct media_proxy_pl_calls {
 	 * command opcodes.
 	 * See the MEDIA_PROXY_OP_SUP_* defines.
 	 *
-	 * @return The media player's supported command opcodes
+	 * @return The media player's supported command opcodes.
 	 */
 	uint32_t (*get_commands_supported)(void);
 
@@ -1566,7 +1566,7 @@ struct media_proxy_pl_calls {
 	 * The search results object only exists if a successful
 	 * search operation has been done.
 	 *
-	 * @return The Search Results Object ID
+	 * @return The Search Results Object ID.
 	 */
 	uint64_t (*get_search_results_id)(void);
 
@@ -1577,7 +1577,7 @@ struct media_proxy_pl_calls {
 	 * on a device, and links it to the corresponding audio
 	 * stream.
 	 *
-	 * @return The content control ID for the media player
+	 * @return The content control ID for the media player.
 	 */
 	uint8_t (*get_content_ctrl_id)(void);
 };
@@ -1593,7 +1593,7 @@ struct media_proxy_pl_calls {
  *
  * @param pl_calls	Function pointers to the media player's calls
  *
- * @return 0 if success, errno on failure
+ * @return 0 on success, negative errno value on failure.
  */
 int media_proxy_pl_register(struct media_proxy_pl_calls *pl_calls);
 

--- a/include/zephyr/bluetooth/audio/micp.h
+++ b/include/zephyr/bluetooth/audio/micp.h
@@ -104,7 +104,7 @@ struct bt_micp_included {
  *
  * @param param Pointer to an initialization structure.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_micp_mic_dev_register(struct bt_micp_mic_dev_register_param *param);
 
@@ -118,7 +118,7 @@ int bt_micp_mic_dev_register(struct bt_micp_mic_dev_register_param *param);
  *
  * @param included Pointer to store the result in.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_micp_mic_dev_included_get(struct bt_micp_included *included);
 
@@ -143,14 +143,14 @@ struct bt_micp_mic_dev_cb {
 /**
  * @brief Unmute the Microphone Device.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_dev_unmute(void);
 
 /**
  * @brief Mute the Microphone Device.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_dev_mute(void);
 
@@ -159,14 +159,14 @@ int bt_micp_mic_dev_mute(void);
  *
  * Can be reenabled by called @ref bt_micp_mic_dev_mute or @ref bt_micp_mic_dev_unmute.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_dev_mute_disable(void);
 
 /**
  * @brief Read the mute state on the Microphone Device.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_dev_mute_get(void);
 
@@ -240,7 +240,7 @@ struct bt_micp_mic_ctlr_cb {
  * @param      mic_ctlr Microphone Controller instance pointer.
  * @param[out] included Pointer to store the result in.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_micp_mic_ctlr_included_get(struct bt_micp_mic_ctlr *mic_ctlr,
 				  struct bt_micp_included *included);
@@ -253,7 +253,7 @@ int bt_micp_mic_ctlr_included_get(struct bt_micp_mic_ctlr *mic_ctlr,
  * @param mic_ctlr    Microphone Controller instance pointer.
  * @param conn        Connection pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_micp_mic_ctlr_conn_get(const struct bt_micp_mic_ctlr *mic_ctlr,
 			      struct bt_conn **conn);
@@ -267,8 +267,8 @@ int bt_micp_mic_ctlr_conn_get(const struct bt_micp_mic_ctlr *mic_ctlr,
  *
  * @param conn     Connection pointer.
  *
- * @retval Pointer to a Microphone Control Profile Microphone Controller instance
- * @retval NULL if @p conn is NULL or if the connection has not done discovery yet
+ * @return Pointer to a Microphone Control Profile Microphone Controller instance,
+ *         or NULL if @p conn is NULL or if the connection has not done discovery yet.
  */
 struct bt_micp_mic_ctlr *bt_micp_mic_ctlr_get_by_conn(const struct bt_conn *conn);
 
@@ -283,7 +283,7 @@ struct bt_micp_mic_ctlr *bt_micp_mic_ctlr_get_by_conn(const struct bt_conn *conn
  * @param conn          The connection to initialize the profile for.
  * @param[out] mic_ctlr Valid remote instance object on success.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_ctlr_discover(struct bt_conn *conn,
 			      struct bt_micp_mic_ctlr **mic_ctlr);
@@ -293,7 +293,7 @@ int bt_micp_mic_ctlr_discover(struct bt_conn *conn,
  *
  * @param mic_ctlr  Microphone Controller instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_ctlr_unmute(struct bt_micp_mic_ctlr *mic_ctlr);
 
@@ -302,7 +302,7 @@ int bt_micp_mic_ctlr_unmute(struct bt_micp_mic_ctlr *mic_ctlr);
  *
  * @param mic_ctlr  Microphone Controller instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_ctlr_mute(struct bt_micp_mic_ctlr *mic_ctlr);
 
@@ -311,7 +311,7 @@ int bt_micp_mic_ctlr_mute(struct bt_micp_mic_ctlr *mic_ctlr);
  *
  * @param mic_ctlr  Microphone Controller instance pointer.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_micp_mic_ctlr_mute_get(struct bt_micp_mic_ctlr *mic_ctlr);
 
@@ -322,7 +322,7 @@ int bt_micp_mic_ctlr_mute_get(struct bt_micp_mic_ctlr *mic_ctlr);
  *
  * @param cb    The callback structure.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_micp_mic_ctlr_cb_register(struct bt_micp_mic_ctlr_cb *cb);
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/audio/pbp.h
+++ b/include/zephyr/bluetooth/audio/pbp.h
@@ -69,7 +69,7 @@ enum bt_pbp_announcement_feature {
  * @param pba_data_buf	Pointer to store the PBA advertising data. Buffer size needs to be
  *			meta_len + @ref BT_PBP_MIN_PBA_SIZE.
  *
- * @return 0 on success or an appropriate error code.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_pbp_get_announcement(const uint8_t meta[], size_t meta_len,
 			    enum bt_pbp_announcement_feature features,
@@ -83,12 +83,12 @@ int bt_pbp_get_announcement(const uint8_t meta[], size_t meta_len,
  * @param[out] features Pointer to public broadcast source features to store the parsed features in
  * @param[out] meta     Pointer to the metadata present in the advertising data
  *
- * @return parsed metadata length on success.
- * @retval -EINVAL if @p data, @p features or @p meta are NULL.
- * @retval -ENOENT if @p data is not of type @ref BT_DATA_SVC_DATA16 or if the UUID in the service
+ * @return Parsed metadata length on success, negative errno value on failure.
+ * @retval -EINVAL @p data, @p features or @p meta are NULL.
+ * @retval -ENOENT @p data is not of type @ref BT_DATA_SVC_DATA16, or the UUID in the service
  * data is not @ref BT_UUID_PBA.
- * @retval -EMSGSIZE if @p data is not large enough to contain a PBP announcement.
- * @retval -EBADMSG if the @p data contains invalid data.
+ * @retval -EMSGSIZE @p data is not large enough to contain a PBP announcement.
+ * @retval -EBADMSG @p data contains invalid data.
  */
 int bt_pbp_parse_announcement(struct bt_data *data, enum bt_pbp_announcement_feature *features,
 			      uint8_t **meta);

--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -243,7 +243,7 @@ typedef void (*bt_tbs_call_change_cb)(struct bt_conn *conn,
  *
  * @param conn         The connection used.
  *
- * @return true if authorized, false otherwise
+ * @return true if authorized, false otherwise.
  */
 typedef bool (*bt_tbs_authorize_cb)(struct bt_conn *conn);
 
@@ -274,8 +274,7 @@ struct bt_tbs_cb {
  *
  * @param call_index    The index of the call that will be accepted.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_accept(uint8_t call_index);
 
@@ -284,8 +283,7 @@ int bt_tbs_accept(uint8_t call_index);
  *
  * @param call_index    The index of the call that will be held.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_hold(uint8_t call_index);
 
@@ -294,8 +292,7 @@ int bt_tbs_hold(uint8_t call_index);
  *
  * @param call_index    The index of the call that will be retrieved.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_retrieve(uint8_t call_index);
 
@@ -304,8 +301,7 @@ int bt_tbs_retrieve(uint8_t call_index);
  *
  * @param call_index    The index of the call that will be terminated.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_terminate(uint8_t call_index);
 
@@ -317,8 +313,7 @@ int bt_tbs_terminate(uint8_t call_index);
  * @param[out] call_index    Pointer to a value where the new call_index will be
  *                           stored.
  *
- * @return int          A call index on success (positive value),
- *                      errno value on fail.
+ * @return A call index on success (positive value), negative errno value on failure.
  */
 int bt_tbs_originate(uint8_t bearer_index, char *uri, uint8_t *call_index);
 
@@ -328,8 +323,7 @@ int bt_tbs_originate(uint8_t bearer_index, char *uri, uint8_t *call_index);
  * @param call_index_cnt   The number of call indexes to join
  * @param call_indexes     Array of call indexes to join.
  *
- * @return int             BT_TBS_RESULT_CODE_* if positive or 0,
- *                         errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_join(uint8_t call_index_cnt, uint8_t *call_indexes);
 
@@ -338,8 +332,7 @@ int bt_tbs_join(uint8_t call_index_cnt, uint8_t *call_indexes);
  *
  * @param call_index    The index of the call that was answered.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_remote_answer(uint8_t call_index);
 
@@ -348,8 +341,7 @@ int bt_tbs_remote_answer(uint8_t call_index);
  *
  * @param call_index    The index of the call that was held.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_remote_hold(uint8_t call_index);
 
@@ -358,8 +350,7 @@ int bt_tbs_remote_hold(uint8_t call_index);
  *
  * @param call_index    The index of the call that was retrieved.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_remote_retrieve(uint8_t call_index);
 
@@ -368,8 +359,7 @@ int bt_tbs_remote_retrieve(uint8_t call_index);
  *
  * @param call_index    The index of the call that was terminated.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_remote_terminate(uint8_t call_index);
 
@@ -381,8 +371,7 @@ int bt_tbs_remote_terminate(uint8_t call_index);
  * @param from            The URI of the remote caller.
  * @param friendly_name   The  friendly name of the remote caller.
  *
- * @return int            New call index if positive or 0,
- *                        errno value if negative.
+ * @return New call index on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_remote_incoming(uint8_t bearer_index, const char *to,
 			   const char *from, const char *friendly_name);
@@ -394,8 +383,7 @@ int bt_tbs_remote_incoming(uint8_t bearer_index, const char *to,
  *                      for GTBS.
  * @param name          The new bearer provider name.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_set_bearer_provider_name(uint8_t bearer_index, const char *name);
 
@@ -406,8 +394,7 @@ int bt_tbs_set_bearer_provider_name(uint8_t bearer_index, const char *name);
  *                       for GTBS.
  * @param new_technology The new bearer technology.
  *
- * @return int           BT_TBS_RESULT_CODE_* if positive or 0,
- *                       errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_set_bearer_technology(uint8_t bearer_index, enum bt_bearer_tech new_technology);
 
@@ -418,8 +405,7 @@ int bt_tbs_set_bearer_technology(uint8_t bearer_index, enum bt_bearer_tech new_t
  *                            BT_TBS_GTBS_INDEX for GTBS.
  * @param new_signal_strength The new signal strength.
  *
- * @return int                BT_TBS_RESULT_CODE_* if positive or 0,
- *                            errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_set_signal_strength(uint8_t bearer_index,
 			       uint8_t new_signal_strength);
@@ -431,8 +417,7 @@ int bt_tbs_set_signal_strength(uint8_t bearer_index,
  *                      for GTBS.
  * @param status_flags  The new feature and status value.
  *
- * @return int          BT_TBS_RESULT_CODE_* if positive or 0,
- *                      errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_set_status_flags(uint8_t bearer_index, uint16_t status_flags);
 
@@ -442,7 +427,7 @@ int bt_tbs_set_status_flags(uint8_t bearer_index, uint16_t status_flags);
  * @param bearer_index  The index of the Telephone Bearer.
  * @param uri_scheme_list Comma-separated list of URI prefixes (e.g. "skype,tel").
  *
- * @return BT_TBS_RESULT_CODE_* if positive or 0, errno value if negative.
+ * @return BT_TBS_RESULT_CODE_* value on success (0 or positive), negative errno value on failure.
  */
 int bt_tbs_set_uri_scheme_list(uint8_t bearer_index, const char *uri_scheme_list);
 /**
@@ -511,13 +496,13 @@ struct bt_tbs_register_param {
  *
  * @param param The parameters to initialize the bearer.
 
- * @retval index The bearer index if return value is >= 0
- * @retval -EINVAL @p param contains invalid data
- * @retval -EALREADY @p param.gtbs is true and GTBS has already been registered
- * @retval -EAGAIN @p param.gtbs is false and GTBS has not been registered
+ * @return The bearer index on success (>= 0), or one of the error codes below.
+ * @retval -EINVAL @p param contains invalid data.
+ * @retval -EALREADY @p param.gtbs is true and GTBS has already been registered.
+ * @retval -EAGAIN @p param.gtbs is false and GTBS has not been registered.
  * @retval -ENOMEM @p param.gtbs is false and no more TBS can be registered (see
- *         @kconfig{CONFIG_BT_TBS_BEARER_COUNT})
- * @retval -ENOEXEC The service failed to be registered
+ *         @kconfig{CONFIG_BT_TBS_BEARER_COUNT}).
+ * @retval -ENOEXEC The service failed to be registered.
  */
 int bt_tbs_register_bearer(const struct bt_tbs_register_param *param);
 
@@ -532,12 +517,12 @@ int bt_tbs_register_bearer(const struct bt_tbs_register_param *param);
  *
  * @param bearer_index The index of the bearer to unregister.
  *
- * @retval 0 Success
- * @retval -EINVAL @p bearer_index is invalid
- * @retval -EALREADY The bearer identified by @p bearer_index is not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p bearer_index is invalid.
+ * @retval -EALREADY The bearer identified by @p bearer_index is not registered.
  * @retval -EAGAIN The bearer identified by @p bearer_index is GTBS and there are TBS instances
  *                 registered.
- * @retval -ENOEXEC The service failed to be unregistered
+ * @retval -ENOEXEC The service failed to be unregistered.
  */
 int bt_tbs_unregister_bearer(uint8_t bearer_index);
 
@@ -781,7 +766,7 @@ struct bt_tbs_client_cb {
  *
  * @param conn          The connection to discover TBS for.
  *
- * @return int          0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_tbs_client_discover(struct bt_conn *conn);
 
@@ -792,7 +777,7 @@ int bt_tbs_client_discover(struct bt_conn *conn);
  * @param inst_index    The index of the TBS instance.
  * @param uri           The Null-terminated URI string.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_tbs_client_set_outgoing_uri(struct bt_conn *conn, uint8_t inst_index,
 				   const char *uri);
@@ -804,7 +789,7 @@ int bt_tbs_client_set_outgoing_uri(struct bt_conn *conn, uint8_t inst_index,
  * @param inst_index    The index of the TBS instance.
  * @param interval      The interval to write (0-255 seconds).
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL} must be set
  * for this function to be effective.
@@ -820,7 +805,7 @@ int bt_tbs_client_set_signal_strength_interval(struct bt_conn *conn,
  * @param inst_index    The index of the TBS instance.
  * @param uri           The URI of the callee.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL} must be set
  * for this function to be effective.
@@ -835,7 +820,7 @@ int bt_tbs_client_originate_call(struct bt_conn *conn, uint8_t inst_index,
  * @param inst_index    The index of the TBS instance.
  * @param call_index    The call index to terminate.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_TERMINATE_CALL} must be set
  * for this function to be effective.
@@ -850,7 +835,7 @@ int bt_tbs_client_terminate_call(struct bt_conn *conn, uint8_t inst_index,
  * @param inst_index    The index of the TBS instance.
  * @param call_index    The call index to place on hold.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_HOLD_CALL} must be set
  * for this function to be effective.
@@ -865,7 +850,7 @@ int bt_tbs_client_hold_call(struct bt_conn *conn, uint8_t inst_index,
  * @param inst_index    The index of the TBS instance.
  * @param call_index    The call index to accept.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_ACCEPT_CALL} must be set
  * for this function to be effective.
@@ -880,7 +865,7 @@ int bt_tbs_client_accept_call(struct bt_conn *conn, uint8_t inst_index,
  * @param inst_index    The index of the TBS instance.
  * @param call_index    The call index to retrieve.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL} must be set
  * for this function to be effective.
@@ -896,7 +881,7 @@ int bt_tbs_client_retrieve_call(struct bt_conn *conn, uint8_t inst_index,
  * @param call_indexes  Array of call indexes.
  * @param count         Number of call indexes in the call_indexes array.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_JOIN_CALLS} must be set
  * for this function to be effective.
@@ -910,7 +895,7 @@ int bt_tbs_client_join_calls(struct bt_conn *conn, uint8_t inst_index,
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME} must be set
  * for this function to be effective.
@@ -924,7 +909,7 @@ int bt_tbs_client_read_bearer_provider_name(struct bt_conn *conn,
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_UCI} must be set
  * for this function to be effective.
@@ -937,7 +922,7 @@ int bt_tbs_client_read_bearer_uci(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY} must be set
  * for this function to be effective.
@@ -950,7 +935,7 @@ int bt_tbs_client_read_technology(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return int          0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST} must be set
  * for this function to be effective.
@@ -963,7 +948,7 @@ int bt_tbs_client_read_uri_list(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH} must be set
  * for this function to be effective.
@@ -977,7 +962,7 @@ int bt_tbs_client_read_signal_strength(struct bt_conn *conn,
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL} must be set
  * for this function to be effective.
@@ -991,7 +976,7 @@ int bt_tbs_client_read_signal_interval(struct bt_conn *conn,
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS} must be set
  * for this function to be effective.
@@ -1004,7 +989,7 @@ int bt_tbs_client_read_current_calls(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_CCID} must be set
  * for this function to be effective.
@@ -1017,7 +1002,7 @@ int bt_tbs_client_read_ccid(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_INCOMING_URI} must be set
  * for this function to be effective.
@@ -1030,7 +1015,7 @@ int bt_tbs_client_read_call_uri(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_STATUS_FLAGS} must be set
  * for this function to be effective.
@@ -1043,7 +1028,7 @@ int bt_tbs_client_read_status_flags(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_tbs_client_read_call_state(struct bt_conn *conn, uint8_t inst_index);
 
@@ -1053,7 +1038,7 @@ int bt_tbs_client_read_call_state(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_INCOMING_CALL} must be set
  * for this function to be effective.
@@ -1066,7 +1051,7 @@ int bt_tbs_client_read_remote_uri(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME} must be set
  * for this function to be effective.
@@ -1079,7 +1064,7 @@ int bt_tbs_client_read_friendly_name(struct bt_conn *conn, uint8_t inst_index);
  * @param conn          The connection to the TBS server.
  * @param inst_index    The index of the TBS instance.
  *
- * @return              int 0 on success, errno value on fail.
+ * @return 0 on success, negative errno value on failure.
  *
  * @note @kconfig{CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES} must be set
  * for this function to be effective.
@@ -1092,9 +1077,9 @@ int bt_tbs_client_read_optional_opcodes(struct bt_conn *conn,
  *
  * @param cbs Pointer to the callback structure.
  *
- * @retval 0 Success
- * @retval -EINVAL @p cbs is NULL
- * @retval -EEXIST @p cbs is already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cbs is NULL.
+ * @retval -EEXIST @p cbs is already registered.
  */
 int bt_tbs_client_register_cb(struct bt_tbs_client_cb *cbs);
 

--- a/include/zephyr/bluetooth/audio/tmap.h
+++ b/include/zephyr/bluetooth/audio/tmap.h
@@ -99,7 +99,7 @@ struct bt_tmap_cb {
  *
  * @param role TMAP role(s) of the device (one or multiple).
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_tmap_register(enum bt_tmap_role role);
 
@@ -109,7 +109,7 @@ int bt_tmap_register(enum bt_tmap_role role);
  * @param conn     Pointer to the connection.
  * @param tmap_cb  Pointer to struct of TMAP callbacks.
  *
- * @return 0 on success or negative error value on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_tmap_discover(struct bt_conn *conn, const struct bt_tmap_cb *tmap_cb);
 

--- a/include/zephyr/bluetooth/audio/vcp.h
+++ b/include/zephyr/bluetooth/audio/vcp.h
@@ -137,7 +137,7 @@ struct bt_vcp_included {
  *
  * @param[out] included Pointer to store the result in.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_included_get(struct bt_vcp_included *included);
 
@@ -149,7 +149,7 @@ int bt_vcp_vol_rend_included_get(struct bt_vcp_included *included);
  *
  * @param      param  Volume Control Service register parameters.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_register(struct bt_vcp_vol_rend_register_param *param);
 
@@ -201,49 +201,49 @@ struct bt_vcp_vol_rend_cb {
  *
  * @param volume_step  The volume step size (1-255).
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_set_step(uint8_t volume_step);
 
 /**
  * @brief Get the Volume Control Service volume state.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_get_state(void);
 
 /**
  * @brief Get the Volume Control Service flags.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_get_flags(void);
 
 /**
  * @brief Turn the volume down by one step on the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_vol_down(void);
 
 /**
  * @brief Turn the volume up by one step on the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_vol_up(void);
 
 /**
  * @brief Turn the volume down and unmute the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_unmute_vol_down(void);
 
 /**
  * @brief Turn the volume up and unmute the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_unmute_vol_up(void);
 
@@ -252,21 +252,21 @@ int bt_vcp_vol_rend_unmute_vol_up(void);
  *
  * @param volume The absolute volume to set.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_set_vol(uint8_t volume);
 
 /**
  * @brief Unmute the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_unmute(void);
 
 /**
  * @brief Mute the server.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_rend_mute(void);
 
@@ -419,9 +419,9 @@ struct bt_vcp_vol_ctlr_cb {
  *
  * @param cb   The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was already registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb was already registered.
  */
 int bt_vcp_vol_ctlr_cb_register(struct bt_vcp_vol_ctlr_cb *cb);
 
@@ -430,9 +430,9 @@ int bt_vcp_vol_ctlr_cb_register(struct bt_vcp_vol_ctlr_cb *cb);
  *
  * @param cb   The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was not registered
+ * @retval 0 on success.
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EALREADY @p cb was not registered.
  */
 int bt_vcp_vol_ctlr_cb_unregister(struct bt_vcp_vol_ctlr_cb *cb);
 
@@ -450,7 +450,7 @@ int bt_vcp_vol_ctlr_cb_unregister(struct bt_vcp_vol_ctlr_cb *cb);
  * @param      conn      The connection to discover Volume Control Service for.
  * @param[out] vol_ctlr  Valid remote instance object on success.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_discover(struct bt_conn *conn,
 			     struct bt_vcp_vol_ctlr **vol_ctlr);
@@ -464,8 +464,8 @@ int bt_vcp_vol_ctlr_discover(struct bt_conn *conn,
  *
  * @param conn     Connection pointer.
  *
- * @retval Pointer to a Volume Control Profile Volume Controller instance
- * @retval NULL if @p conn is NULL or if the connection has not done discovery yet
+ * @return Pointer to a Volume Control Profile Volume Controller instance,
+ *         or NULL if @p conn is NULL or if the connection has not done discovery yet.
  */
 struct bt_vcp_vol_ctlr *bt_vcp_vol_ctlr_get_by_conn(const struct bt_conn *conn);
 
@@ -478,7 +478,7 @@ struct bt_vcp_vol_ctlr *bt_vcp_vol_ctlr_get_by_conn(const struct bt_conn *conn);
  * @param      vol_ctlr Volume Controller instance pointer.
  * @param[out] conn     Connection pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_conn_get(const struct bt_vcp_vol_ctlr *vol_ctlr,
 			     struct bt_conn **conn);
@@ -497,7 +497,7 @@ int bt_vcp_vol_ctlr_conn_get(const struct bt_vcp_vol_ctlr *vol_ctlr,
  * @param      vol_ctlr Volume Controller instance pointer.
  * @param[out] included Pointer to store the result in.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_included_get(struct bt_vcp_vol_ctlr *vol_ctlr,
 				 struct bt_vcp_included *included);
@@ -507,7 +507,7 @@ int bt_vcp_vol_ctlr_included_get(struct bt_vcp_vol_ctlr *vol_ctlr,
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_read_state(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -516,7 +516,7 @@ int bt_vcp_vol_ctlr_read_state(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_read_flags(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -525,7 +525,7 @@ int bt_vcp_vol_ctlr_read_flags(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_vol_down(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -534,7 +534,7 @@ int bt_vcp_vol_ctlr_vol_down(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_vol_up(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -543,7 +543,7 @@ int bt_vcp_vol_ctlr_vol_up(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_unmute_vol_down(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -552,7 +552,7 @@ int bt_vcp_vol_ctlr_unmute_vol_down(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_unmute_vol_up(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -562,7 +562,7 @@ int bt_vcp_vol_ctlr_unmute_vol_up(struct bt_vcp_vol_ctlr *vol_ctlr);
  * @param vol_ctlr  Volume Controller instance pointer.
  * @param volume    The absolute volume to set.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_set_vol(struct bt_vcp_vol_ctlr *vol_ctlr, uint8_t volume);
 
@@ -571,7 +571,7 @@ int bt_vcp_vol_ctlr_set_vol(struct bt_vcp_vol_ctlr *vol_ctlr, uint8_t volume);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_unmute(struct bt_vcp_vol_ctlr *vol_ctlr);
 
@@ -580,7 +580,7 @@ int bt_vcp_vol_ctlr_unmute(struct bt_vcp_vol_ctlr *vol_ctlr);
  *
  * @param vol_ctlr  Volume Controller instance pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vcp_vol_ctlr_mute(struct bt_vcp_vol_ctlr *vol_ctlr);
 

--- a/include/zephyr/bluetooth/audio/vocs.h
+++ b/include/zephyr/bluetooth/audio/vocs.h
@@ -112,7 +112,7 @@ struct bt_vocs_discover_param {
 /**
  * @brief Get a free service instance of Volume Offset Control Service from the pool.
  *
- * @return Volume Offset Control Service instance in case of success or NULL in case of error.
+ * @return Volume Offset Control Service instance on success, or NULL on failure.
  */
 struct bt_vocs *bt_vocs_free_instance_get(void);
 
@@ -136,7 +136,7 @@ void *bt_vocs_svc_decl_get(struct bt_vocs *vocs);
  * @param vocs    Audio Input Control Service client instance pointer.
  * @param conn    Connection pointer.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vocs_client_conn_get(const struct bt_vocs *vocs, struct bt_conn **conn);
 
@@ -146,7 +146,7 @@ int bt_vocs_client_conn_get(const struct bt_vocs *vocs, struct bt_conn **conn);
  * @param vocs      Volume Offset Control Service instance.
  * @param param     Volume Offset Control Service register parameters.
  *
- * @return 0 if success, errno on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vocs_register(struct bt_vocs *vocs,
 		     const struct bt_vocs_register_param *param);
@@ -252,7 +252,7 @@ struct bt_vocs_cb {
  *
  * @param inst          Pointer to the Volume Offset Control Service instance.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_state_get(struct bt_vocs *inst);
 
@@ -262,7 +262,7 @@ int bt_vocs_state_get(struct bt_vocs *inst);
  * @param inst          Pointer to the Volume Offset Control Service instance.
  * @param offset        The offset to set (-255 to 255).
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_state_set(struct bt_vocs *inst, int16_t offset);
 
@@ -273,7 +273,7 @@ int bt_vocs_state_set(struct bt_vocs *inst, int16_t offset);
  *
  * @param inst          Pointer to the Volume Offset Control Service instance.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_location_get(struct bt_vocs *inst);
 
@@ -283,7 +283,7 @@ int bt_vocs_location_get(struct bt_vocs *inst);
  * @param inst          Pointer to the Volume Offset Control Service instance.
  * @param location      The location to set.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_location_set(struct bt_vocs *inst, uint32_t location);
 
@@ -294,7 +294,7 @@ int bt_vocs_location_set(struct bt_vocs *inst, uint32_t location);
  *
  * @param inst          Pointer to the Volume Offset Control Service instance.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_description_get(struct bt_vocs *inst);
 
@@ -304,7 +304,7 @@ int bt_vocs_description_get(struct bt_vocs *inst);
  * @param inst          Pointer to the Volume Offset Control Service instance.
  * @param description   The UTF-8 encoded string description to set.
  *
- * @return 0 on success, GATT error value on fail.
+ * @return 0 on success, or a GATT error code on failure.
  */
 int bt_vocs_description_set(struct bt_vocs *inst, const char *description);
 
@@ -332,7 +332,7 @@ struct bt_vocs *bt_vocs_client_free_instance_get(void);
  * @param inst  Pointer to the Volume Offset Control Service client instance.
  * @param param Pointer to the parameters.
  *
- * @return 0 on success, errno on fail.
+ * @return 0 on success, negative errno value on failure.
  */
 int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *inst,
 		     const struct bt_vocs_discover_param *param);


### PR DESCRIPTION
Apply the @retval/@return cleanup following the conventions documented in PR #107458.

Part 2/2: aics, bap, csip, mcc, media_proxy, micp, pbp, tbs, tmap, vcp, vocs headers.

Fixes parts of: #65974