### PR TITLE
tests: stream_flash: fix hardcoded buf_len in buf_size_greater_than_page_size

### DIFF
--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -319,9 +319,10 @@ ZTEST(lib_stream_flash, test_stream_flash_bytes_buffered)
 ZTEST(lib_stream_flash, test_stream_flash_buf_size_greater_than_page_size)
 {
 	int rc;
+	size_t wbs = flash_get_parameters(fdev)->write_block_size;
 
 	/* To illustrate that other params does not trigger error */
-	rc = stream_flash_init(&ctx, fdev, generic_buf, 0x10, 0, FLASH_AVAILABLE, NULL);
+	rc = stream_flash_init(&ctx, fdev, generic_buf, wbs, 0, FLASH_AVAILABLE, NULL);
 	zassert_equal(rc, 0, "expected success");
 
 	/* Only change buf_len param */


### PR DESCRIPTION
Fix `test_stream_flash_buf_size_greater_than_page_size` failing on flash
devices whose `write_block_size` does not divide 16.

`stream_flash_init()` returns `-EFAULT` when `buf_len` is not a multiple
of the device `write_block_size` (`stream_flash.c:380`).  The hardcoded
`buf_len = 0x10` only satisfies this constraint on devices with
`write_block_size` in {1, 2, 4, 8, 16}.  On hardware with larger block
sizes (32, 64, 512 bytes etc.) the "expected success" assertion spuriously
fails.

Replace the constant with `flash_get_parameters(fdev)->write_block_size` so
the test is portable across all flash devices.

Fixes: #110948
Signed-off-by: Richard Wheatley <richard.wheatley@ambiq.com>