### PR TITLE
drivers: gpio: aesc: comply with GPIO structure

### DIFF
--- a/drivers/gpio/gpio_aesc.c
+++ b/drivers/gpio/gpio_aesc.c
@@ -22,11 +22,12 @@
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
 
-
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(aesc_gpio, CONFIG_GPIO_LOG_LEVEL);
 
 struct gpio_aesc_config {
+	/* gpio_driver_config needs to be first */
+	struct gpio_driver_config common;
 	DEVICE_MMIO_ROM;
 	const struct pinctrl_dev_config *pcfg;
 	void (*irq_config)(const struct device *dev);
@@ -48,17 +49,17 @@ struct gpio_aesc_regs {
 } __packed;
 
 struct gpio_aesc_data {
-	DEVICE_MMIO_RAM;
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common DEVICE_MMIO_RAM;
 	sys_slist_t cb;
 	struct k_spinlock lock;
 };
 
-#define DEV_CFG(dev) ((struct gpio_aesc_config *)(dev)->config)
+#define DEV_CFG(dev)  ((struct gpio_aesc_config *)(dev)->config)
 #define DEV_DATA(dev) ((struct gpio_aesc_data *)(dev)->data)
 #define DEV_GPIO(dev) ((struct gpio_aesc_regs *)DEVICE_MMIO_GET(dev))
 
-static int gpio_aesc_config(const struct device *dev, gpio_pin_t pin,
-			    gpio_flags_t flags)
+static int gpio_aesc_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
 	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
@@ -76,8 +77,7 @@ static int gpio_aesc_config(const struct device *dev, gpio_pin_t pin,
 	return 0;
 }
 
-static int gpio_aesc_port_get_raw(const struct device *dev,
-				  gpio_port_value_t *value)
+static int gpio_aesc_port_get_raw(const struct device *dev, gpio_port_value_t *value)
 {
 	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 
@@ -86,8 +86,7 @@ static int gpio_aesc_port_get_raw(const struct device *dev,
 	return 0;
 }
 
-static int gpio_aesc_port_set_masked_raw(const struct device *dev,
-					 gpio_port_pins_t mask,
+static int gpio_aesc_port_set_masked_raw(const struct device *dev, gpio_port_pins_t mask,
 					 gpio_port_value_t value)
 {
 	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
@@ -101,8 +100,7 @@ static int gpio_aesc_port_set_masked_raw(const struct device *dev,
 	return 0;
 }
 
-static int gpio_aesc_port_set_bits_raw(const struct device *dev,
-				       gpio_port_pins_t mask)
+static int gpio_aesc_port_set_bits_raw(const struct device *dev, gpio_port_pins_t mask)
 {
 	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
@@ -115,8 +113,7 @@ static int gpio_aesc_port_set_bits_raw(const struct device *dev,
 	return 0;
 }
 
-static int gpio_aesc_port_clear_bits_raw(const struct device *dev,
-					 gpio_port_pins_t mask)
+static int gpio_aesc_port_clear_bits_raw(const struct device *dev, gpio_port_pins_t mask)
 {
 	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
@@ -129,8 +126,7 @@ static int gpio_aesc_port_clear_bits_raw(const struct device *dev,
 	return 0;
 }
 
-static int gpio_aesc_port_toggle_bits(const struct device *dev,
-				      gpio_port_pins_t mask)
+static int gpio_aesc_port_toggle_bits(const struct device *dev, gpio_port_pins_t mask)
 {
 	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
@@ -143,17 +139,15 @@ static int gpio_aesc_port_toggle_bits(const struct device *dev,
 	return 0;
 }
 
-static int gpio_aesc_pin_interrupt_configure(const struct device *dev,
-					     gpio_pin_t pin,
-					     enum gpio_int_mode mode,
-					     enum gpio_int_trig trig)
+static int gpio_aesc_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
+					     enum gpio_int_mode mode, enum gpio_int_trig trig)
 {
 	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
 
 	gpio->rise_ie &= ~BIT(pin);
 	gpio->fall_ie &= ~BIT(pin);
 	gpio->high_ie &= ~BIT(pin);
-	gpio->low_ie  &= ~BIT(pin);
+	gpio->low_ie &= ~BIT(pin);
 
 	switch (mode) {
 	case GPIO_INT_MODE_DISABLED:
@@ -165,7 +159,7 @@ static int gpio_aesc_pin_interrupt_configure(const struct device *dev,
 		}
 		if (trig == GPIO_INT_TRIG_LOW) {
 			gpio->low_ip = BIT(pin);
-			gpio->low_ie  |= BIT(pin);
+			gpio->low_ie |= BIT(pin);
 		}
 		break;
 	case GPIO_INT_MODE_EDGE:
@@ -186,8 +180,7 @@ static int gpio_aesc_pin_interrupt_configure(const struct device *dev,
 	return 0;
 }
 
-static int gpio_aesc_manage_callback(const struct device *dev,
-				     struct gpio_callback *callback,
+static int gpio_aesc_manage_callback(const struct device *dev, struct gpio_callback *callback,
 				     bool set)
 {
 	struct gpio_aesc_data *data = DEV_DATA(dev);
@@ -209,7 +202,7 @@ static void gpio_aesc_isr(const struct device *dev)
 	gpio->rise_ip = pins;
 	gpio->fall_ip = pins;
 	gpio->high_ip = pins;
-	gpio->low_ip  = pins;
+	gpio->low_ip = pins;
 
 	gpio_fire_callbacks(&data->cb, dev, pins);
 }
@@ -222,11 +215,8 @@ static int gpio_aesc_init(const struct device *dev)
 	int ret;
 
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
-	LOG_DBG("IP core version: %i.%i.%i.",
-		ip_id_get_major_version(base_addr),
-		ip_id_get_minor_version(base_addr),
-		ip_id_get_patchlevel(base_addr)
-	);
+	LOG_DBG("IP core version: %i.%i.%i.", ip_id_get_major_version(base_addr),
+		ip_id_get_minor_version(base_addr), ip_id_get_patchlevel(base_addr));
 	DEVICE_MMIO_GET(dev) = ip_id_relocate_driver(base_addr);
 	LOG_DBG("Relocate driver to address 0x%lx.", DEVICE_MMIO_GET(dev));
 	gpio = DEV_GPIO(dev);
@@ -258,30 +248,21 @@ static DEVICE_API(gpio, gpio_aesc_driver_api) = {
 	.manage_callback = gpio_aesc_manage_callback,
 };
 
-#define AESC_GPIO_INIT(no)						      \
-	PINCTRL_DT_INST_DEFINE(no);					      \
-	static struct gpio_aesc_data gpio_aesc_dev_data_##no;		      \
-	static void gpio_aesc_irq_config_##no(const struct device *dev)	      \
-	{								      \
-		IRQ_CONNECT(DT_INST_IRQN(no),				      \
-			    DT_INST_IRQ(no, priority),			      \
-			    gpio_aesc_isr,				      \
-			    DEVICE_DT_INST_GET(no),			      \
-			    0);						      \
-		irq_enable(DT_INST_IRQN(no));				      \
-	}								      \
-	static struct gpio_aesc_config gpio_aesc_dev_cfg_##no = {	      \
-		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(no)),			      \
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(no),		      \
-		.irq_config = gpio_aesc_irq_config_##no,		      \
-	};								      \
-	DEVICE_DT_INST_DEFINE(no,					      \
-			      gpio_aesc_init,				      \
-			      NULL,					      \
-			      &gpio_aesc_dev_data_##no,			      \
-			      &gpio_aesc_dev_cfg_##no,			      \
-			      PRE_KERNEL_2,				      \
-			      CONFIG_GPIO_INIT_PRIORITY,		      \
-			      (void *)&gpio_aesc_driver_api);
+#define AESC_GPIO_INIT(no)                                                                         \
+	PINCTRL_DT_INST_DEFINE(no);                                                                \
+	static struct gpio_aesc_data gpio_aesc_dev_data_##no;                                      \
+	static void gpio_aesc_irq_config_##no(const struct device *dev)                            \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(no), DT_INST_IRQ(no, priority), gpio_aesc_isr,            \
+			    DEVICE_DT_INST_GET(no), 0);                                            \
+		irq_enable(DT_INST_IRQN(no));                                                      \
+	}                                                                                          \
+	static const struct gpio_aesc_config gpio_aesc_dev_cfg_##no = {
+.common = GPIO_COMMON_CONFIG_FROM_DT_INST(no), DEVICE_MMIO_ROM_INIT(DT_DRV_INST(no)),
+	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(no), .irq_config = gpio_aesc_irq_config_##no,
+}
+;
+DEVICE_DT_INST_DEFINE(no, gpio_aesc_init, NULL, &gpio_aesc_dev_data_##no, &gpio_aesc_dev_cfg_##no,
+		      PRE_KERNEL_2, CONFIG_GPIO_INIT_PRIORITY, (void *)&gpio_aesc_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(AESC_GPIO_INIT)


### PR DESCRIPTION
All gpio drivers need to have struct gpio_driver_config and struct gpio_driver_data at the first position of the data and config struct. The aesc driver was not doing this.

This commit adds the common structures to the first position. It also makes the config struct const, as it is not modified at runtime.

Fixes #110963