### PR TITLE
scripts: west_commands: drop never used 'help' argument in flash.py

### DIFF
--- a/scripts/west_commands/flash.py
+++ b/scripts/west_commands/flash.py
@@ -18,9 +18,8 @@ class Flash(WestCommand):
     def __init__(self):
         super().__init__(
             'flash',
-            # Keep this in sync with the string in west-commands.yml.
-            'flash and run a binary on a board',
-            "Permanently reprogram a board's flash with a new binary.",
+            '',
+            description="Permanently reprogram a board's flash with a new binary.",
             accepts_unknown_args=True)
         self.runner_key = 'flash-runner'  # in runners.yaml
 

--- a/scripts/west_commands/flash.py
+++ b/scripts/west_commands/flash.py
@@ -19,7 +19,7 @@ class Flash(WestCommand):
         super().__init__(
             'flash',
             '',
-            description="Permanently reprogram a board's flash with a new binary.",
+            description="Reprogram a board's flash with a new binary.",
             accepts_unknown_args=True)
         self.runner_key = 'flash-runner'  # in runners.yaml
 


### PR DESCRIPTION
This removes the warning seen in west flash -h, see zephyrproject-rtos/west#927 for details.

Fixes commit b001dee32973 ("scripts: empty unused .help duplicates in west extensions")