### PR TITLE
llext: fixes for ARM with LLVM (zephyr/llvm)

### DIFF
--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -198,13 +198,17 @@ const void *llext_find_sym(const struct llext_symtable *sym_table, const char *s
 		if (ordering_state == 0) {
 			const_syms = STRUCT_SECTION_START(llext_const_symbol);
 			STRUCT_SECTION_COUNT(llext_const_symbol, &sym_cnt);
+			/* Assume the table is sorted; downgrade to a linear scan as
+			 * soon as an out-of-order pair is found. The assignment must
+			 * not happen after the loop, or it would clobber the result.
+			 */
+			ordering_state = 1;
 			for (size_t i = 1; i < sym_cnt; i++) {
 				if (strcmp(const_syms[i - 1].name, const_syms[i].name) > 0) {
 					ordering_state = -1;
 					break;
 				}
 			}
-			ordering_state = 1;
 		}
 
 		if (ordering_state == 1) {

--- a/subsys/llext/llext_export.c
+++ b/subsys/llext/llext_export.c
@@ -21,6 +21,42 @@ EXPORT_GROUP_SYMBOL(LIBC, memmove);
 EXPORT_GROUP_SYMBOL(LIBC, strtoul);
 EXPORT_GROUP_SYMBOL(LIBC, sprintf);
 
+#if defined(CONFIG_ARM) && !defined(CONFIG_ARM64)
+/*
+ * On AArch32, compilers may lower memcpy()/memmove()/memset()/zero-init to the
+ * ARM EABI run-time helpers instead of the C library functions. These helpers
+ * are provided by the compiler run-time (libgcc/compiler-rt); export them so
+ * that extensions which reference them can be linked. The exact set emitted
+ * depends on the compiler (e.g. Clang uses the aligned __aeabi_memset4 /
+ * __aeabi_memclr4 variants where GCC may emit direct memset() calls).
+ */
+extern void __aeabi_memcpy(void);
+extern void __aeabi_memcpy4(void);
+extern void __aeabi_memcpy8(void);
+extern void __aeabi_memmove(void);
+extern void __aeabi_memmove4(void);
+extern void __aeabi_memmove8(void);
+extern void __aeabi_memset(void);
+extern void __aeabi_memset4(void);
+extern void __aeabi_memset8(void);
+extern void __aeabi_memclr(void);
+extern void __aeabi_memclr4(void);
+extern void __aeabi_memclr8(void);
+
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memcpy);
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memcpy4);
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memcpy8);
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memmove);
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memmove4);
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memmove8);
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memset);
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memset4);
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memset8);
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memclr);
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memclr4);
+EXPORT_GROUP_SYMBOL(LIBC, __aeabi_memclr8);
+#endif /* CONFIG_ARM && !CONFIG_ARM64 */
+
 /* These symbols are used if CCAC is given the flag -Os */
 #ifdef __CCAC__
 extern void __ac_mc_va(void);


### PR DESCRIPTION
- **llext: fix symbol lookup ordering detection in llext_find_sym**
- **llext: export ARM EABI mem helper functions**
