### PR TITLE
arch: arm: syscall: mark call_id register r6 as clobbered by SVC

### DIFF
--- a/include/zephyr/arch/arm/syscall.h
+++ b/include/zephyr/arch/arm/syscall.h
@@ -37,6 +37,13 @@ extern "C" {
 
 /* Syscall invocation macros. arm-specific machine constraints used to ensure
  * args land in the proper registers.
+ *
+ * Note: r6 carries the syscall call_id into the SVC. The SVC handler
+ * (z_arm_do_syscall) clobbers r6 while indexing the syscall dispatch table and
+ * the exception return does not restore it. r6 must therefore be declared as a
+ * read-write ("+r") operand, otherwise the compiler may assume it survives the
+ * SVC and hoist the (loop-invariant) call_id load out of a retry loop, causing
+ * subsequent iterations to issue the SVC with a corrupted call_id.
  */
 static inline uintptr_t arch_syscall_invoke6(uintptr_t arg1, uintptr_t arg2,
 					     uintptr_t arg3, uintptr_t arg4,
@@ -53,10 +60,10 @@ static inline uintptr_t arch_syscall_invoke6(uintptr_t arg1, uintptr_t arg2,
 
 	__asm__ volatile("svc %[svid]\n"
 			 IF_ENABLED(CONFIG_ARM_BTI, ("bti\n"))
-			 : "=r"(ret), "=r"(r1), "=r"(r2), "=r"(r3)
+			 : "=r"(ret), "=r"(r1), "=r"(r2), "=r"(r3), "+r" (r6)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r2), "r" (r3),
-			   "r" (r4), "r" (r5), "r" (r6)
+			   "r" (r4), "r" (r5)
 			 : "r8", "memory", "ip");
 
 	return ret;
@@ -76,10 +83,10 @@ static inline uintptr_t arch_syscall_invoke5(uintptr_t arg1, uintptr_t arg2,
 
 	__asm__ volatile("svc %[svid]\n"
 			 IF_ENABLED(CONFIG_ARM_BTI, ("bti\n"))
-			 : "=r"(ret), "=r"(r1), "=r"(r2), "=r"(r3)
+			 : "=r"(ret), "=r"(r1), "=r"(r2), "=r"(r3), "+r" (r6)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r2), "r" (r3),
-			   "r" (r4), "r" (r6)
+			   "r" (r4)
 			 : "r8", "memory", "ip");
 
 	return ret;
@@ -97,10 +104,9 @@ static inline uintptr_t arch_syscall_invoke4(uintptr_t arg1, uintptr_t arg2,
 
 	__asm__ volatile("svc %[svid]\n"
 			 IF_ENABLED(CONFIG_ARM_BTI, ("bti\n"))
-			 : "=r"(ret), "=r"(r1), "=r"(r2), "=r"(r3)
+			 : "=r"(ret), "=r"(r1), "=r"(r2), "=r"(r3), "+r" (r6)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
-			   "r" (ret), "r" (r1), "r" (r2), "r" (r3),
-			   "r" (r6)
+			   "r" (ret), "r" (r1), "r" (r2), "r" (r3)
 			 : "r8", "memory", "ip");
 
 	return ret;
@@ -117,9 +123,9 @@ static inline uintptr_t arch_syscall_invoke3(uintptr_t arg1, uintptr_t arg2,
 
 	__asm__ volatile("svc %[svid]\n"
 			 IF_ENABLED(CONFIG_ARM_BTI, ("bti\n"))
-			 : "=r"(ret), "=r"(r1), "=r"(r2)
+			 : "=r"(ret), "=r"(r1), "=r"(r2), "+r" (r6)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
-			   "r" (ret), "r" (r1), "r" (r2), "r" (r6)
+			   "r" (ret), "r" (r1), "r" (r2)
 			 : "r8", "memory", "r3", "ip");
 
 	return ret;
@@ -134,9 +140,9 @@ static inline uintptr_t arch_syscall_invoke2(uintptr_t arg1, uintptr_t arg2,
 
 	__asm__ volatile("svc %[svid]\n"
 			 IF_ENABLED(CONFIG_ARM_BTI, ("bti\n"))
-			 : "=r"(ret), "=r"(r1)
+			 : "=r"(ret), "=r"(r1), "+r" (r6)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
-			   "r" (ret), "r" (r1), "r" (r6)
+			   "r" (ret), "r" (r1)
 			 : "r8", "memory", "r2", "r3", "ip");
 
 	return ret;
@@ -150,9 +156,9 @@ static inline uintptr_t arch_syscall_invoke1(uintptr_t arg1,
 
 	__asm__ volatile("svc %[svid]\n"
 			 IF_ENABLED(CONFIG_ARM_BTI, ("bti\n"))
-			 : "=r"(ret)
+			 : "=r"(ret), "+r" (r6)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
-			   "r" (ret), "r" (r6)
+			   "r" (ret)
 			 : "r8", "memory", "r1", "r2", "r3", "ip");
 	return ret;
 }
@@ -164,9 +170,9 @@ static inline uintptr_t arch_syscall_invoke0(uintptr_t call_id)
 
 	__asm__ volatile("svc %[svid]\n"
 			 IF_ENABLED(CONFIG_ARM_BTI, ("bti\n"))
-			 : "=r"(ret)
+			 : "=r"(ret), "+r" (r6)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
-			   "r" (ret), "r" (r6)
+			   "r" (ret)
 			 : "r8", "memory", "r1", "r2", "r3", "ip");
 
 	return ret;


### PR DESCRIPTION
The syscall call_id is passed to the SVC in r6, but it was declared as an
input-only operand and omitted from the clobber list. The SVC handler
z_arm_do_syscall() destroys r6 (lsl r6, #2 to index _k_syscall_table[])
and the exception return does not restore it, since Cortex-M hardware
only stacks r0-r3/r12/lr/pc/xpsr.

Because the asm told the compiler r6 survives the SVC, it was free to
hoist the (loop-invariant) call_id load out of a retry loop. GCC happened
to rematerialize it before each svc, but Clang hoisted it: on a sys_sem
futex retry loop, the second iteration issued the SVC with the already
shifted r6 (e.g. 42<<2 = 168), dispatching a bogus, unimplemented syscall
and faulting with 'Unimplemented system call'.

Declare r6 as a read-write ("+r") operand in every arch_syscall_invokeN
so the compiler knows the SVC clobbers it and reloads call_id on each
invocation. It cannot be added to the clobber list directly as it is also
an operand.

Reproduced and verified on mps2/an385 with the LLVM toolchain:
tests/kernel/mem_protect/sys_sem (test_sem_take_multiple) now passes, and
the GCC build is unaffected.
