### PR TITLE
cmake: clang: Fix no_global_merge flag compatibility

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -149,6 +149,10 @@ set_compiler_property(PROPERTY diagnostic -fcolor-diagnostics)
 # clang flag to disable macro backtrace in diagnostics (can't fully disable it, so limit to 1)
 set_compiler_property(PROPERTY no_track_macro_expansion "-fmacro-backtrace-limit=1")
 
-set_compiler_property(PROPERTY no_global_merge "-mno-global-merge")
+if(CONFIG_RISCV)
+  set_compiler_property(PROPERTY no_global_merge "")
+else()
+  set_compiler_property(PROPERTY no_global_merge "-mno-global-merge")
+endif()
 
 set_compiler_property(PROPERTY specs)


### PR DESCRIPTION
The -mno-global-merge flag is not recognized by Clang. Since GCC also
sets this property to an empty string, update Clang to match for
cross-platform compatibility. This fixes RISC-V builds with Clang.

Fixes build error on qemu_riscv32e with LLVM:
clang: error: argument unused during compilation: '-mno-global-merge'

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
