### PR TITLE
MAINTAINERS: add syscall headers to userspace area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6076,6 +6076,10 @@ Userspace:
     - ceolin
   files:
     - include/zephyr/internal/syscall_handler.h
+    - include/zephyr/arch/x86/*/syscall.h
+    - include/zephyr/arch/syscall.h
+    - include/zephyr/arch/*/syscall.h
+    - include/zephyr/syscall.h
     - doc/kernel/usermode/kernelobjects.rst
     - include/zephyr/app_memory/
     - include/zephyr/linker/app_smem*.ld


### PR DESCRIPTION
The syscall.h headers belong into the userspace domain, so make them
part of this area for coverage.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
