### PR TITLE
net: wifi: roaming optimization

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -72,6 +72,7 @@ Removed APIs and options
     * ``openthread_api_mutex_unlock()``
     * ``struct openthread_state_changed_cb``
     * ``TLS_CREDENTIAL_SERVER_CERTIFICATE``
+    * ``start_11r_roaming``
 
 * Random
 

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -2291,9 +2291,11 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance
 	 * @param iface Network interface to use for the roaming operation
 	 *
+	 * @deprecated Controlled by connection request params
+	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*start_11r_roaming)(const struct device *dev, struct net_if *iface);
+	__deprecated int (*start_11r_roaming)(const struct device *dev, struct net_if *iface);
 	/** Set BSS max idle period
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -562,6 +562,16 @@ config WIFI_NM_WPA_SUPPLICANT_ROAMING
 	  STA will try to find an AP with better RSSI. If found, STA will reassociate
 	  to the new AP automatically without losing connection.
 
+config WIFI_NM_WPA_SUPPLICANT_ROAMING_RETRY
+	int "Retry count on every roaming method"
+	depends on WIFI_NM_WPA_SUPPLICANT_ROAMING
+	default 1
+	help
+	  Number of times each of 11K and 11V roaming is attempted.
+	  When reaches this count, fall back to next roaming method.
+	  If both reaches this count, fall back to legacy roaming,
+	  which scans full channel.
+
 config WIFI_NM_WPA_SUPPLICANT_SKIP_DHCP_ON_ROAMING
 	bool "Skip DHCP after roaming to new AP"
 	help

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1804,38 +1804,6 @@ int supplicant_candidate_scan(const struct device *dev __unused, struct net_if *
 
 	return 0;
 }
-
-int supplicant_11r_roaming(const struct device *dev __unused, struct net_if *iface)
-{
-	struct wpa_supplicant *wpa_s;
-	int ret = 0;
-
-	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
-
-	wpa_s = get_wpa_s_handle(iface);
-	if (!wpa_s) {
-		ret = -1;
-		goto out;
-	}
-
-	if (wpa_s->reassociate || (wpa_s->wpa_state >= WPA_AUTHENTICATING &&
-	    wpa_s->wpa_state < WPA_COMPLETED)) {
-		wpa_printf(MSG_INFO, "Reassociation is in progress, skip");
-		ret = 0;
-		goto out;
-	}
-
-	if (!wpa_cli_cmd_v("reassociate")) {
-		wpa_printf(MSG_ERROR, "%s: cli cmd <reassociate> fail",
-			   __func__);
-		ret = -1;
-		goto out;
-	}
-
-out:
-	k_mutex_unlock(&wpa_supplicant_mutex);
-	return ret;
-}
 #endif
 
 int supplicant_set_power_save(const struct device *dev, struct net_if *iface,

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1732,7 +1732,7 @@ int supplicant_11k_neighbor_request(const struct device *dev, struct net_if *ifa
 	if (wpa_s->reassociate || (wpa_s->wpa_state >= WPA_AUTHENTICATING &&
 	    wpa_s->wpa_state < WPA_COMPLETED)) {
 		wpa_printf(MSG_INFO, "Reassociation is in progress, skip");
-		return 0;
+		return -EALREADY;
 	}
 
 	if (params) {
@@ -2030,7 +2030,7 @@ int supplicant_legacy_roam(const struct device *dev __unused, struct net_if *ifa
 	if (wpa_s->reassociate || (wpa_s->wpa_state >= WPA_AUTHENTICATING &&
 	    wpa_s->wpa_state < WPA_COMPLETED)) {
 		wpa_printf(MSG_INFO, "Reassociation is in progress, skip");
-		ret = 0;
+		ret = -EALREADY;
 		goto out;
 	}
 
@@ -2141,7 +2141,7 @@ int supplicant_btm_query(const struct device *dev __unused, struct net_if *iface
 	if (wpa_s->reassociate || (wpa_s->wpa_state >= WPA_AUTHENTICATING &&
 	    wpa_s->wpa_state < WPA_COMPLETED)) {
 		wpa_printf(MSG_INFO, "Reassociation is in progress, skip");
-		ret = 0;
+		ret = -EALREADY;
 		goto out;
 	}
 

--- a/modules/hostap/src/supp_api.h
+++ b/modules/hostap/src/supp_api.h
@@ -154,15 +154,6 @@ int supplicant_11k_neighbor_request(const struct device *dev, struct net_if *ifa
  */
 int supplicant_candidate_scan(const struct device *dev, struct net_if *iface,
 			      struct wifi_scan_params *params);
-
-/** Send 11r roaming request
- *
- * @param dev Pointer to the device structure for the driver instance.
- * @param iface Network interface to use
- *
- * @return 0 if ok, < 0 if error
- */
-int supplicant_11r_roaming(const struct device *dev, struct net_if *iface);
 #endif
 
 /**

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -64,7 +64,6 @@ static const struct wifi_mgmt_ops mgmt_ops = {
 	.send_11k_neighbor_request = supplicant_11k_neighbor_request,
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
 	.candidate_scan = supplicant_candidate_scan,
-	.start_11r_roaming = supplicant_11r_roaming,
 #endif
 	.set_power_save = supplicant_set_power_save,
 	.set_twt = supplicant_set_twt,

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -42,7 +42,6 @@ struct wifi_rrm_neighbor_report_t {
 };
 
 struct wifi_roaming_params {
-	bool is_11r_used;
 	struct wifi_rrm_neighbor_report_t neighbor_rep;
 };
 
@@ -518,10 +517,6 @@ static int wifi_connect(uint64_t mgmt_request, struct net_if *iface,
 		break;
 	}
 
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
-	roaming_params.is_11r_used = params->ft_used;
-#endif
-
 	return wifi_mgmt_api->connect(dev, iface, params);
 }
 
@@ -636,13 +631,7 @@ static int wifi_start_roaming(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
-	if (roaming_params.is_11r_used) {
-		if (wifi_mgmt_api->start_11r_roaming == NULL) {
-			return -ENOTSUP;
-		}
-
-		return wifi_mgmt_api->start_11r_roaming(dev, iface);
-	} else if (wifi_mgmt_api->bss_support_neighbor_rep(dev, iface)) {
+	if (wifi_mgmt_api->bss_support_neighbor_rep(dev, iface)) {
 		memset(&roaming_params.neighbor_rep, 0x0, sizeof(roaming_params.neighbor_rep));
 		if (wifi_mgmt_api->send_11k_neighbor_request == NULL) {
 			return -ENOTSUP;

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -43,6 +43,8 @@ struct wifi_rrm_neighbor_report_t {
 
 struct wifi_roaming_params {
 	struct wifi_rrm_neighbor_report_t neighbor_rep;
+	int roaming_cnt_11k;
+	int roaming_cnt_11v;
 };
 
 static struct wifi_roaming_params roaming_params;
@@ -517,6 +519,11 @@ static int wifi_connect(uint64_t mgmt_request, struct net_if *iface,
 		break;
 	}
 
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
+	roaming_params.roaming_cnt_11k = 0;
+	roaming_params.roaming_cnt_11v = 0;
+#endif
+
 	return wifi_mgmt_api->connect(dev, iface, params);
 }
 
@@ -600,6 +607,12 @@ void wifi_mgmt_raise_connect_result_event(struct net_if *iface, int status)
 		.status = status,
 	};
 
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
+	if (status == 0) {
+		roaming_params.roaming_cnt_11k = 0;
+		roaming_params.roaming_cnt_11v = 0;
+	}
+#endif
 	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_CONNECT_RESULT,
 					iface, &cnx_status,
 					sizeof(struct wifi_status));
@@ -622,6 +635,7 @@ static int wifi_start_roaming(uint64_t mgmt_request, struct net_if *iface,
 {
 	const struct device *dev = net_if_get_device(iface);
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_api(iface);
+	int ret = -ENOTSUP;
 
 	if (wifi_mgmt_api == NULL) {
 		return -ENOTSUP;
@@ -631,25 +645,42 @@ static int wifi_start_roaming(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
-	if (wifi_mgmt_api->bss_support_neighbor_rep(dev, iface)) {
+	if (wifi_mgmt_api->bss_support_neighbor_rep(dev, iface) &&
+	    wifi_mgmt_api->send_11k_neighbor_request != NULL &&
+	    roaming_params.roaming_cnt_11k < CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING_RETRY) {
 		memset(&roaming_params.neighbor_rep, 0x0, sizeof(roaming_params.neighbor_rep));
-		if (wifi_mgmt_api->send_11k_neighbor_request == NULL) {
-			return -ENOTSUP;
+		ret = wifi_mgmt_api->send_11k_neighbor_request(dev, iface, NULL);
+		LOG_DBG("Start 11k roaming ret %d", ret);
+		if (ret == 0) {
+			roaming_params.roaming_cnt_11k++;
+			return 0;
+		} else if (ret == -EALREADY) {
+			return 0;
 		}
-
-		return wifi_mgmt_api->send_11k_neighbor_request(dev, iface, NULL);
-	} else if (wifi_mgmt_api->bss_ext_capab &&
-			wifi_mgmt_api->bss_ext_capab(dev, iface, WIFI_EXT_CAPAB_BSS_TRANSITION)) {
-		if (wifi_mgmt_api->btm_query) {
-			return wifi_mgmt_api->btm_query(dev, iface, 0x10);
-		} else {
-			return -ENOTSUP;
-		}
-	} else if (wifi_mgmt_api->legacy_roam) {
-		return wifi_mgmt_api->legacy_roam(dev, iface);
-	} else {
-		return -ENOTSUP;
+		roaming_params.roaming_cnt_11k++;
 	}
+
+	if (wifi_mgmt_api->bss_ext_capab &&
+	    wifi_mgmt_api->bss_ext_capab(dev, iface, WIFI_EXT_CAPAB_BSS_TRANSITION) &&
+	    wifi_mgmt_api->btm_query &&
+	    roaming_params.roaming_cnt_11v < CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING_RETRY) {
+		ret = wifi_mgmt_api->btm_query(dev, iface, 0x10);
+		LOG_DBG("Start 11v roaming ret %d", ret);
+		if (ret == 0) {
+			roaming_params.roaming_cnt_11v++;
+			return 0;
+		} else if (ret == -EALREADY) {
+			return 0;
+		}
+		roaming_params.roaming_cnt_11v++;
+	}
+
+	if (wifi_mgmt_api->legacy_roam) {
+		ret = wifi_mgmt_api->legacy_roam(dev, iface);
+		LOG_DBG("Start legacy roaming ret %d", ret);
+	}
+
+	return ret;
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_START_ROAMING, wifi_start_roaming);


### PR DESCRIPTION
net: wifi: add roaming retry count
    
    Add roaming retry count to fall back roaming method to next one.
    Roaming 11K/11V may fail because AP does not carry right candidate.
    In this case we can jump to next method when we receive signal change
    event again.

net: wifi: optimize 11R roaming case
    
    11R is not a way of getting candidate. It is a way of getting keys.
    So it can combine with 11K/11V/legacy roaming method.
    Remove explicit 11R roaming api as it is already set to supplicant
    in supplicant_connect.