### PR TITLE
boards: imx91: enlarge CONFIG_MAX_XLAT_TABLES

### DIFF
--- a/boards/nxp/frdm_imx91/frdm_imx91_mimx9131_defconfig
+++ b/boards/nxp/frdm_imx91/frdm_imx91_mimx9131_defconfig
@@ -9,7 +9,7 @@ CONFIG_ARMV8_A_NS=y
 
 # MMU Options
 # Increase the value when encounter the assert on the MAX_XLAT_TABLES
-CONFIG_MAX_XLAT_TABLES=24
+CONFIG_MAX_XLAT_TABLES=32
 
 # Cache Options
 CONFIG_CACHE_MANAGEMENT=y

--- a/boards/nxp/imx91_evk/imx91_evk_mimx9131_defconfig
+++ b/boards/nxp/imx91_evk/imx91_evk_mimx9131_defconfig
@@ -9,7 +9,7 @@ CONFIG_ARMV8_A_NS=y
 
 # MMU Options
 # Increase the value when encounter the assert on the MAX_XLAT_TABLES
-CONFIG_MAX_XLAT_TABLES=24
+CONFIG_MAX_XLAT_TABLES=32
 
 # Cache Options
 CONFIG_CACHE_MANAGEMENT=y

--- a/boards/nxp/imx91_qsb/imx91_qsb_mimx9111_defconfig
+++ b/boards/nxp/imx91_qsb/imx91_qsb_mimx9111_defconfig
@@ -9,7 +9,7 @@ CONFIG_ARMV8_A_NS=y
 
 # MMU Options
 # Increase the value when encounter the assert on the MAX_XLAT_TABLES
-CONFIG_MAX_XLAT_TABLES=24
+CONFIG_MAX_XLAT_TABLES=32
 
 # Cache Options
 CONFIG_CACHE_MANAGEMENT=y


### PR DESCRIPTION
Enlarge CONFIG_MAX_XLAT_TABLES to avoid some test case failure, for example tests/kernel/device will report the following error: CONFIG_MAX_XLAT_TABLES is too small.