### PR TITLE
boards: nxp: mimxrt1180_evk: fix cm7 dtcm/itcm region overlap

### DIFF
--- a/boards/nxp/mimxrt1180_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1180_evk/CMakeLists.txt
@@ -14,7 +14,13 @@ endif()
 if(CONFIG_NXP_BOARD_SPECIFIC_MPU_SETTINGS)
   if(CONFIG_SOC_MIMXRT1189_CM7)
     zephyr_sources(cm7/mpu_regions.c)
-    zephyr_linker_sources(DTCM_SECTION cm7/dtcm.ld)
+    # The DTCM_SECTION snippet only applies when a dedicated DTCM region is
+    # chosen. On the internal-memory CM7 variant DTCM is itself zephyr,sram, so
+    # no separate (overlapping) DTCM section group must be emitted.
+    dt_chosen(dtcm_chosen PROPERTY "zephyr,dtcm")
+    if(dtcm_chosen)
+      zephyr_linker_sources(DTCM_SECTION cm7/dtcm.ld)
+    endif()
   endif()
 endif()
 

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.dts
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.dts
@@ -16,8 +16,6 @@
 
 	chosen {
 		zephyr,sram = &dtcm;
-		zephyr,dtcm = &dtcm;
-		zephyr,itcm = &itcm;
 		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,flash = &itcm;
 		zephyr,console = &lpuart12;


### PR DESCRIPTION
## Summary

The MIMXRT1180-EVK cm7 variant aliased the same TCM node to two chosen roles: `zephyr,sram` **and** `zephyr,dtcm` both pointed at `&dtcm`, and `zephyr,flash` **and** `zephyr,itcm` both pointed at `&itcm`.

Because the DTCM/ITCM linker section groups are emitted at the TCM region origin (`GROUP_LINK_IN(DTCM/ITCM ...)`), they land on top of the regular `.data`/`.bss`/iterable sections that already start at the same origin. The boot-time `.dtcm_bss` zeroing then wipes the overlapping initialized data.

In `tests/subsys/rtio/workq` this zeroed the `rtio_iodev` iterable section, so `dummy_iodev.api` became `NULL`. `rtio_submit()` then calls `iodev->api->submit()` through the NULL `api`, jumping to a stray RAM address (`0x200027c0`) and taking an **MPU instruction-access-violation** in `rtio.workq.rtio_work.work_decouples_submission`.

This is the **same root cause** as #110248 (frdm_imxrt1186), on the superset MIMXRT1180-EVK.

## Fix

- Drop the redundant `zephyr,dtcm` / `zephyr,itcm` chosen entries on the cm7 variant - DTCM already is `zephyr,sram` and ITCM already is `zephyr,flash`, so the separate (overlapping) TCM section groups are both redundant and harmful.
- Guard the board's cm7 `DTCM_SECTION` linker snippet with a `dt_chosen()` check so it is only added when a dedicated DTCM region is actually chosen.

The cm33 variant is unaffected (`zephyr,sram = &hyperram0`, external flash, with DTCM/ITCM as genuinely separate regions).

## Testing

Reproduced and verified on `mimxrt1180_evk/mimxrt1189/cm7` via LinkServer. Before: `dummy_iodev.api == NULL`, call jumps to `0x200027c0`, MPU fault. After: `dummy_iodev.api == &r_iodev_test_api` and the rtio workq submit path runs without faulting (handler invoked correctly).

Related: #110248
