### PR TITLE
testsuite: coverage: support `REBOOT` with `COVERAGE_SEMIHOST`

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -140,6 +140,20 @@ class CoverageTool:
             gcov_data = self.__class__.retrieve_gcov_data(filename)
             capture_complete = gcov_data['complete']
             extracted_coverage_info = gcov_data['data']
+
+            # GCDA files are expected to have an exact path derived from the source
+            # file name. If multiple GCDA files were created by the test application
+            # to handle reboots, we must merge the information back into a single file.
+            test_folder = pathlib.Path(filename).parent
+            # Hidden directories need to be included as the generated files can have paths
+            # like /..__module__
+            for subfile in glob.glob(f"{test_folder}/**/*.gcda.*",
+                                     recursive=True,
+                                     include_hidden=True):
+                output_file, _= subfile.rsplit('.', 1)
+                with open(subfile, 'rb') as f:
+                    extracted_coverage_info[output_file].append(f.read(-1))
+
             if capture_complete:
                 gcda_created = self.create_gcda_files(extracted_coverage_info)
                 if gcda_created:

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -18,6 +18,13 @@ K_HEAP_DEFINE(gcov_heap, CONFIG_COVERAGE_GCOV_HEAP_SIZE);
 
 static struct gcov_info *gcov_info_head;
 
+#if defined(CONFIG_COVERAGE_SEMIHOST) && defined(CONFIG_REBOOT)
+#define GCOV_FILENAME_KEY 0x23A5B6C4
+static char gcov_filename[512];
+static __noinit uint32_t gcov_filename_key;
+static __noinit uint32_t gcov_filename_idx;
+#endif
+
 /**
  * Is called by gcc-generated constructor code for each object file compiled
  * with -fprofile-arcs.
@@ -373,6 +380,17 @@ void gcov_coverage_semihost(void)
 	size_t written_size;
 	struct gcov_info *gcov_list_first = gcov_info_head;
 	struct gcov_info *gcov_list = gcov_info_head;
+	const char *filename;
+	int fd;
+
+#if defined(CONFIG_REBOOT)
+	if (gcov_filename_key != GCOV_FILENAME_KEY) {
+		gcov_filename_key = GCOV_FILENAME_KEY;
+		gcov_filename_idx = 0;
+	} else {
+		gcov_filename_idx += 1;
+	}
+#endif /* defined(CONFIG_REBOOT) */
 
 #ifdef CONFIG_MULTITHREADING
 	if (!k_is_in_isr()) {
@@ -385,10 +403,17 @@ void gcov_coverage_semihost(void)
 			goto file_dump_end;
 		}
 
-		int fd = semihost_open(gcov_list->filename, SEMIHOST_OPEN_WB);
+#if defined(CONFIG_REBOOT)
+		snprintf(gcov_filename, sizeof(gcov_filename), "%s.%d", gcov_list->filename,
+			 gcov_filename_idx);
+		filename = gcov_filename;
+#else
+		filename = gcov_list->filename;
+#endif /* defined(CONFIG_REBOOT) */
 
+		fd = semihost_open(filename, SEMIHOST_OPEN_WB);
 		if (fd < 0) {
-			printk("Failed to open file: %s\n", gcov_list->filename);
+			printk("Failed to open file: %s\n", filename);
 			goto coverage_dump_end;
 		}
 

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -416,9 +416,9 @@ void gcov_coverage_semihost(void)
 		}
 
 		k_heap_free(&gcov_heap, buffer);
+		semihost_close(fd);
 		gcov_list = gcov_list->next;
 		if (gcov_list_first == gcov_list) {
-			semihost_close(fd);
 			goto coverage_dump_end;
 		}
 	}

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -380,6 +380,10 @@ void gcov_coverage_semihost(void)
 	}
 #endif
 	while (gcov_list) {
+		if ((strlen(CONFIG_COVERAGE_DUMP_PATH_EXCLUDE) > 0) &&
+		    (fnmatch(CONFIG_COVERAGE_DUMP_PATH_EXCLUDE, gcov_list->filename, 0) == 0)) {
+			goto file_dump_end;
+		}
 
 		int fd = semihost_open(gcov_list->filename, SEMIHOST_OPEN_WB);
 
@@ -417,6 +421,7 @@ void gcov_coverage_semihost(void)
 
 		k_heap_free(&gcov_heap, buffer);
 		semihost_close(fd);
+file_dump_end:
 		gcov_list = gcov_list->next;
 		if (gcov_list_first == gcov_list) {
 			goto coverage_dump_end;


### PR DESCRIPTION
Always close the opened file descriptor after dumping the data to the file, not just on the very last loop iteration.

Respect the exclusion path set by `COVERAGE_DUMP_PATH_EXCLUDE` when dumping with `COVERAGE_SEMIHOST`.

Extend the `SEMIHOST` data dump function with support for multiple dumps per application run, such as when the test application is intentionally testing reboot paths.