### PR TITLE
kernel: timeout: unsigned tick interface and central announce-range capping

### DIFF
--- a/boards/qemu/cortex_m0/nrf_timer_timer.c
+++ b/boards/qemu/cortex_m0/nrf_timer_timer.c
@@ -171,7 +171,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	uint32_t unannounced = counter_sub(counter(), last_count);

--- a/boards/qemu/cortex_m0/nrf_timer_timer.c
+++ b/boards/qemu/cortex_m0/nrf_timer_timer.c
@@ -162,7 +162,7 @@ void timer0_nrf_isr(void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : (dticks > 0));
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 	uint32_t cyc;

--- a/boards/qemu/cortex_m0/nrf_timer_timer.c
+++ b/boards/qemu/cortex_m0/nrf_timer_timer.c
@@ -171,7 +171,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	uint32_t unannounced = counter_sub(counter(), last_count);
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -522,6 +522,19 @@ Syscon
   larger register offsets. Code that explicitly declares ``uint16_t`` variables for the
   register parameter or implements the syscon driver API functions may need to be updated.
 
+Timer
+=====
+
+* :c:func:`sys_clock_set_timeout`, :c:func:`sys_clock_announce` and
+  :c:func:`sys_clock_announce_locked` now take their tick count as an unsigned
+  ``uint32_t`` rather than a signed ``int32_t``. Out-of-tree system timer drivers must
+  update their :c:func:`sys_clock_set_timeout` definition accordingly, otherwise the build
+  fails with a conflicting-types error. The kernel now also caps the requested timeout at
+  ``SYS_CLOCK_MAX_WAIT`` and no longer passes ``K_TICKS_FOREVER`` to the driver, so such
+  drivers no longer need to clamp the request against the :c:func:`sys_clock_announce`
+  range or special-case ``K_TICKS_FOREVER``; only their own hardware cycle-count limits
+  still need enforcing (:github:`111022`).
+
 USB
 ===
 

--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -146,7 +146,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	}
 
 	/* Adjust the ticks to the range of [1, MAX_TICKS]. */
-	ticks = CLAMP(ticks, 1, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&g_lock);
 

--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -146,7 +146,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	}
 
 	/* Adjust the ticks to the range of [1, MAX_TICKS]. */
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks, 1, (int32_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&g_lock);

--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -137,7 +137,7 @@ void stimer_isr(const void *arg)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -54,29 +54,15 @@ BUILD_ASSERT((!IS_ENABLED(CONFIG_APIC_TIMER_TSC) &&
 #define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
 
 /*
- * We have two constraints on the maximum number of cycles we can wait for.
- *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
- *
- * 2) The number of cycles between two reports must fit in a cycle_diff_t
- *    variable before converting it to ticks.
- *
- * Then:
- *
- * 3) Pick the smallest between (1) and (2).
- *
- * 4) Take into account some room for the unavoidable IRQ servicing latency.
- *    Let's use 3/4 of the max range.
- *
- * Finally let's add the LSB value to the result so to clear out a bunch of
- * consecutive set bits coming from the original max values to produce a
- * nicer literal for assembly generation.
+ * Maximum number of cycles to wait between two sys_clock_announce() reports:
+ * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
+ * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
+ * servicing latency so a late report still fits, then add the LSB so the value
+ * clears a run of low set bits for a nicer literal in the generated assembly.
  */
-#define CYCLES_MAX_1	((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
-#define CYCLES_MAX_2	((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_3	MIN(CYCLES_MAX_1, CYCLES_MAX_2)
-#define CYCLES_MAX_4	(CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
-#define CYCLES_MAX	(CYCLES_MAX_4 + LSB_GET(CYCLES_MAX_4))
+#define CYCLES_MAX_1	((uint64_t)CYCLE_DIFF_MAX)
+#define CYCLES_MAX_2	(CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
+#define CYCLES_MAX	(CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
 
 struct apic_timer_lvt {
 	uint8_t vector   : 8;
@@ -157,13 +143,9 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	uint64_t next_cycle;
 
-	if (ticks == K_TICKS_FOREVER) {
+	next_cycle = (last_tick + last_elapsed + ticks) * CYC_PER_TICK;
+	if ((next_cycle - last_cycle) > CYCLES_MAX) {
 		next_cycle = last_cycle + CYCLES_MAX;
-	} else {
-		next_cycle = (last_tick + last_elapsed + ticks) * CYC_PER_TICK;
-		if ((next_cycle - last_cycle) > CYCLES_MAX) {
-			next_cycle = last_cycle + CYCLES_MAX;
-		}
 	}
 
 	/*

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -145,7 +145,7 @@ static void isr(const void *arg)
 	sys_clock_announce_locked(delta_ticks, key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -256,7 +256,7 @@ static void timer_int_handler(const void *unused)
 
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	/* If the kernel allows us to miss tick announcements in idle,
 	 * then shut off the counter. (Note: we can assume if idle==true

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -268,7 +268,8 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	 * However for single core using 32-bits arc timer, idle cannot
 	 * be ignored, as 32-bits timer will overflow in a not-long time.
 	 */
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && ticks == K_TICKS_FOREVER) {
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
+	    ticks == SYS_CLOCK_MAX_WAIT) {
 		timer0_control_register_set(0);
 		timer0_count_register_set(0);
 		timer0_limit_register_set(0);
@@ -298,7 +299,8 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	arch_irq_unlock(key);
 #endif
 #else
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && idle && ticks == K_TICKS_FOREVER) {
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
+	    ticks == SYS_CLOCK_MAX_WAIT) {
 		timer0_control_register_set(0);
 		timer0_count_register_set(0);
 		timer0_limit_register_set(0);

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -312,7 +312,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t delay;
 	uint32_t unannounced;
 
-	ticks = MIN(MAX_TICKS, (uint32_t)(MAX((int32_t)(ticks - 1), 0)));
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -29,37 +29,15 @@ static uint32_t cyc_per_tick;
 #define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
 
 /*
- * We have two constraints on the maximum number of cycles we can wait for.
- *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
- *
- * 2) The number of cycles between two reports must fit in a cycle_diff_t
- *    variable before converting it to ticks.
- *
- * Then:
- *
- * 3) Pick the smallest between (1) and (2).
- *
- * 4) Take into account some room for the unavoidable IRQ servicing latency.
- *    Let's use 3/4 of the max range.
- *
- * Finally let's add the LSB value to the result so to clear out a bunch of
- * consecutive set bits coming from the original max values to produce a
- * nicer literal for assembly generation.
+ * Maximum number of cycles to wait between two sys_clock_announce() reports:
+ * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
+ * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
+ * servicing latency so a late report still fits, then add the LSB so the value
+ * clears a run of low set bits for a nicer literal in the generated assembly.
  */
-#define CYCLES_MAX_1	((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
-#define CYCLES_MAX_2	((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_3	MIN(CYCLES_MAX_1, CYCLES_MAX_2)
-#define CYCLES_MAX_4	(CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
-#define CYCLES_MAX_5	(CYCLES_MAX_4 + LSB_GET(CYCLES_MAX_4))
-
-#ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
-/* precompute CYCLES_MAX at driver init to avoid runtime double divisions */
-static uint64_t cycles_max;
-#define CYCLES_MAX cycles_max
-#else
-#define CYCLES_MAX CYCLES_MAX_5
-#endif
+#define CYCLES_MAX_1	((uint64_t)CYCLE_DIFF_MAX)
+#define CYCLES_MAX_2	(CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
+#define CYCLES_MAX	(CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
 
 static uint64_t last_cycle;
 static uint64_t last_tick;
@@ -142,19 +120,10 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (idle && ticks == K_TICKS_FOREVER) {
-		return;
-	}
+	uint64_t next_cycle = (last_tick + last_elapsed + ticks) * CYC_PER_TICK;
 
-	uint64_t next_cycle;
-
-	if (ticks == K_TICKS_FOREVER) {
+	if ((next_cycle - last_cycle) > CYCLES_MAX) {
 		next_cycle = last_cycle + CYCLES_MAX;
-	} else {
-		next_cycle = (last_tick + last_elapsed + ticks) * CYC_PER_TICK;
-		if ((next_cycle - last_cycle) > CYCLES_MAX) {
-			next_cycle = last_cycle + CYCLES_MAX;
-		}
 	}
 
 	arm_arch_timer_set_compare(next_cycle);
@@ -240,7 +209,6 @@ static int sys_clock_driver_init(void)
 	arm_arch_timer_init();
 #ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	cyc_per_tick = sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-	cycles_max = CYCLES_MAX_5;
 #endif
 	last_tick = arm_arch_timer_count() / CYC_PER_TICK;
 	last_cycle = last_tick * CYC_PER_TICK;

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -134,7 +134,7 @@ static void arm_arch_timer_compare_isr(const void *arg)
 	sys_clock_announce_locked(delta_ticks, key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/cc13xx_cc26xx_rtc_timer.c
+++ b/drivers/timer/cc13xx_cc26xx_rtc_timer.c
@@ -193,7 +193,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #ifdef CONFIG_TICKLESS_KERNEL
 
-	ticks = CLAMP(ticks - 1, 0, (int32_t) MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 

--- a/drivers/timer/cc13xx_cc26xx_rtc_timer.c
+++ b/drivers/timer/cc13xx_cc26xx_rtc_timer.c
@@ -187,7 +187,7 @@ static void startDevice(void)
 	irq_unlock(key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/cc13xx_cc26xx_rtc_timer.c
+++ b/drivers/timer/cc13xx_cc26xx_rtc_timer.c
@@ -193,7 +193,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #ifdef CONFIG_TICKLESS_KERNEL
 
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t) MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);

--- a/drivers/timer/cc23x0_rtc_timer.c
+++ b/drivers/timer/cc23x0_rtc_timer.c
@@ -31,7 +31,7 @@ static uint32_t last_rtc_count;
 
 #define TICK_PERIOD_MICRO_SEC (1000000 / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/cc23x0_rtc_timer.c
+++ b/drivers/timer/cc23x0_rtc_timer.c
@@ -35,19 +35,16 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
-	/* If timeout is necessary */
-	if (ticks != K_TICKS_FOREVER) {
-		/* Get current value as early as possible */
-		uint32_t ticks_now = HWREG(RTC_BASE + RTC_O_TIME8U);
+	/* Get current value as early as possible */
+	uint32_t ticks_now = HWREG(RTC_BASE + RTC_O_TIME8U);
 
-		if ((ticks_now + ticks) >= RTC_TIMEOUT_MAX) {
-			/* Reset timer and start from 0 */
-			HWREG(RTC_BASE + RTC_O_CTL) = RTC_CTL_RST_CLR;
-			HWREG(RTC_BASE + RTC_O_CH0CC8U) = ticks;
-		}
-
-		HWREG(RTC_BASE + RTC_O_CH0CC8U) = ticks_now + ticks;
+	if ((ticks_now + ticks) >= RTC_TIMEOUT_MAX) {
+		/* Reset timer and start from 0 */
+		HWREG(RTC_BASE + RTC_O_CTL) = RTC_CTL_RST_CLR;
+		HWREG(RTC_BASE + RTC_O_CH0CC8U) = ticks;
 	}
+
+	HWREG(RTC_BASE + RTC_O_CH0CC8U) = ticks_now + ticks;
 }
 
 uint32_t get_elapsed_ticks_rtc(uint32_t current_rtc_count)

--- a/drivers/timer/cc23x0_systim_timer.c
+++ b/drivers/timer/cc23x0_systim_timer.c
@@ -56,18 +56,15 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
-	/* If timeout is necessary */
-	if (ticks != K_TICKS_FOREVER) {
-		/* Get current value as early as possible */
-		uint32_t now_tick = HWREG(SYSTIM_BASE + SYSTIM_O_TIME1U);
-		uint32_t timeout = ticks * TICK_PERIOD_MICRO_SEC;
+	/* Get current value as early as possible */
+	uint32_t now_tick = HWREG(SYSTIM_BASE + SYSTIM_O_TIME1U);
+	uint32_t timeout = ticks * TICK_PERIOD_MICRO_SEC;
 
-		if (timeout > SYSTIM_TIMEOUT_MAX) {
-			timeout = SYSTIM_TIMEOUT_MAX;
-		}
-		/* This should wrap around */
-		HWREG(SYSTIM_BASE + SYSTIM_O_CH0CC) = now_tick + timeout;
+	if (timeout > SYSTIM_TIMEOUT_MAX) {
+		timeout = SYSTIM_TIMEOUT_MAX;
 	}
+	/* This should wrap around */
+	HWREG(SYSTIM_BASE + SYSTIM_O_CH0CC) = now_tick + timeout;
 }
 
 uint32_t sys_clock_elapsed(void)

--- a/drivers/timer/cc23x0_systim_timer.c
+++ b/drivers/timer/cc23x0_systim_timer.c
@@ -52,7 +52,7 @@ static int sys_clock_driver_init(void);
 /*
  * Set system clock timeout.
  */
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -315,7 +315,7 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 }
 ARCH_ISR_DIAG_ON
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -404,10 +404,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	cycle_diff_t unannounced = cycle_count - announced_cycles;
 
-	if (ticks == K_TICKS_FOREVER) {
-		/* Schedule as far out as SysTick can go in one LOAD. */
-		cycles = MAX_CYCLES;
-	} else if (unannounced < 0) {
+	if (unannounced < 0) {
 		/*
 		 * cycle_count has overtaken announced_cycles by more than half
 		 * the cycle_diff_t range. This is reachable when the ISR is

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -321,11 +321,11 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	/* Fast CPUs and a 24 bit counter mean that even idle systems
 	 * need to wake up multiple times per second.  If the kernel
-	 * allows us to miss tick announcements in idle, then shut off
-	 * the counter. (Note: we can assume if idle==true that
-	 * interrupts are already disabled)
+	 * allows us to miss tick announcements while nothing is pending
+	 * (sloppy idle), then shut off the counter.
 	 */
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && idle && ticks == K_TICKS_FOREVER) {
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
+	    ticks == SYS_CLOCK_MAX_WAIT) {
 		SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
 		last_load = TIMER_STOPPED;
 		return;

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -104,7 +104,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -97,7 +97,7 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 	sys_clock_announce(dticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 #if defined(CONFIG_TICKLESS_KERNEL)
 	if (systimer_hal.dev == NULL) {

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -126,7 +126,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	set_systimer_alarm(cyc + last_count);
 
 #if defined(CONFIG_PM)
-	if (idle && ticks != K_TICKS_FOREVER) {
+	if (idle) {
 		uint64_t timeout_us =
 			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -104,7 +104,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t now = get_systimer_alarm();

--- a/drivers/timer/gecko_burtc_timer.c
+++ b/drivers/timer/gecko_burtc_timer.c
@@ -123,7 +123,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	 * 0 - announce upcoming tick itself
 	 * 1 - skip upcoming one, but announce the one after it, etc.
 	 */
-	ticks = (ticks == K_TICKS_FOREVER) ? g_max_timeout_ticks : ticks;
 	ticks = CLAMP(ticks - 1, 0, g_max_timeout_ticks);
 
 	k_spinlock_key_t key = k_spin_lock(&g_lock);

--- a/drivers/timer/gecko_burtc_timer.c
+++ b/drivers/timer/gecko_burtc_timer.c
@@ -123,7 +123,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	 * 0 - announce upcoming tick itself
 	 * 1 - skip upcoming one, but announce the one after it, etc.
 	 */
-	ticks = CLAMP(ticks - 1, 0, g_max_timeout_ticks);
+	ticks = CLAMP(ticks, 1, g_max_timeout_ticks) - 1;
 
 	k_spinlock_key_t key = k_spin_lock(&g_lock);
 

--- a/drivers/timer/gecko_burtc_timer.c
+++ b/drivers/timer/gecko_burtc_timer.c
@@ -109,7 +109,7 @@ static void burtc_isr(const void *arg)
 	sys_clock_announce(unannounced);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -242,8 +242,6 @@ static unsigned int cyc_per_tick;
 	(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 #endif /* CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME */
 
-#define HPET_MAX_TICKS ((int32_t)0x7fffffff)
-
 #ifdef HPET_INT_LEVEL_TRIGGER
 /**
  * @brief Write to General Interrupt Status Register
@@ -360,16 +358,14 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint32_t reg;
 
-	if (ticks == K_TICKS_FOREVER && idle) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
 		reg = hpet_gconf_get();
 		reg &= ~GCONF_ENABLE;
 		hpet_gconf_set(reg);
 		return;
 	}
 
-	ticks = ticks == K_TICKS_FOREVER ? HPET_MAX_TICKS : ticks;
-	ticks = CLAMP(ticks, 0, HPET_MAX_TICKS/2);
-
+	/* The comparator is 64-bit, so the requested timeout needs no clamp. */
 	uint64_t cyc = (last_tick + last_elapsed + ticks) * cyc_per_tick;
 
 	hpet_timer_comparator_set_safe(cyc);

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -351,7 +351,7 @@ void smp_timer_init(void)
 	 */
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -76,7 +76,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (ticks == K_TICKS_FOREVER) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
 		key = k_spin_lock(&lock);
 		/* Disable the LPTIMER events */
 		cyhal_lptimer_enable_event(&lptimer_obj, CYHAL_LPTIMER_COMPARE_MATCH,

--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -66,7 +66,7 @@ static void lptimer_interrupt_handler(void *handler_arg, cyhal_lptimer_event_t e
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : (delta_ticks > 0));
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -85,7 +85,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		return;
 	}
 
-	/* passing ticks==1 means "announce the next tick", ticks value of zero (or even negative)
+	/* passing ticks==1 means "announce the next tick", ticks value of zero
 	 * is legal and treated identically: it simply indicates the kernel would like the next
 	 * tick announcement as soon as possible.
 	 */

--- a/drivers/timer/infineon_lp_timer_pdl.c
+++ b/drivers/timer/infineon_lp_timer_pdl.c
@@ -199,7 +199,7 @@ static void lptimer_set_delay(uint32_t delay)
 	Cy_MCWDT_SetInterruptMask(reg_addr, CY_MCWDT_CTR1);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	uint64_t current_cycles;
 	uint32_t cycles_per_tick;
@@ -222,7 +222,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	/* Configure and Enable the LPTIMER events */
 	lptimer_enable_event(true);
 
-	/* passing ticks==1 means "announce the next tick", ticks value of zero (or even negative)
+	/* passing ticks==1 means "announce the next tick", ticks value of zero
 	 * is legal and treated identically: it simply indicates the kernel would like the next
 	 * tick announcement as soon as possible.
 	 */

--- a/drivers/timer/infineon_lp_timer_pdl.c
+++ b/drivers/timer/infineon_lp_timer_pdl.c
@@ -213,7 +213,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (ticks == K_TICKS_FOREVER) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
 		/* Disable the LPTIMER events */
 		lptimer_enable_event(false);
 		return;

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -134,8 +134,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #ifdef CONFIG_TICKLESS_KERNEL
-	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 0, (uint32_t)MAX_TICKS);
 
 	uint64_t curr = count();
 	uint64_t next;

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -127,7 +127,7 @@ static void compare_isr(const void *arg)
 	sys_clock_announce_locked((int32_t)dticks, key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -124,7 +124,7 @@ static void compare_isr(const void *arg)
 	set_compare(next);
 #endif
 
-	sys_clock_announce_locked((int32_t)dticks, key);
+	sys_clock_announce_locked(dticks, key);
 }
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
@@ -134,7 +134,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #ifdef CONFIG_TICKLESS_KERNEL
-	ticks = CLAMP(ticks, 0, (uint32_t)MAX_TICKS);
+	ticks = MIN(ticks, MAX_TICKS);
 
 	uint64_t curr = count();
 	uint64_t next;

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -193,7 +193,7 @@ static void free_run_timer_overflow_isr(const void *unused)
 	/* TODO: to increment 32-bit "top half" here for software 64-bit timer emulation. */
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -227,7 +227,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	 * ideally no more than one system tick in the future. So set event timer count
 	 * to 1 HW tick.
 	 */
-	ticks = CLAMP(ticks, 1, (int32_t)EVEN_TIMER_MAX_CNT_SYS_TICK);
+	ticks = CLAMP(ticks, 1, EVEN_TIMER_MAX_CNT_SYS_TICK);
 	next_cycs = (last_ticks + last_elapsed + ticks) * HW_CNT_PER_SYS_TICK;
 	now = ~read_timer_obser(FREE_RUN_TIMER);
 	if (unlikely(next_cycs <= now)) {

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -210,14 +210,14 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* Disable event timer */
 	ext_timer_disable(EVENT_TIMER);
 
-	if (ticks == K_TICKS_FOREVER) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
 		/*
-		 * If kernel doesn't have a timeout:
-		 * 1.CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = y (no future timer interrupts are expected),
-		 *   kernel pass K_TICKS_FOREVER (0xFFFF FFFF FFFF FFFF), we handle this case in
-		 *   here.
-		 * 2.CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = n (schedule timeout as far into the future
-		 *   as possible), kernel pass INT_MAX (0x7FFF FFFF), we handle it in later else {}.
+		 * The kernel has no pending timeout, which it signals with
+		 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle no future
+		 * timer interrupt is required, so leave the event timer
+		 * disabled and stop waking up. Without sloppy idle we fall
+		 * through and still schedule the (capped) timeout so the
+		 * uptime tick count stays correct.
 		 */
 		k_spin_unlock(&lock, key);
 		return;

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -261,7 +261,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		 * as soon as possible, ideally no more than one system tick
 		 * in the future. So set event timer count to 1 HW tick.
 		 */
-		ticks = CLAMP(ticks, 1, (int32_t)EVEN_TIMER_MAX_CNT_SYS_TICK);
+		ticks = CLAMP(ticks, 1, EVEN_TIMER_MAX_CNT_SYS_TICK);
 
 		next_cycs = (last_ticks + last_elapsed + ticks) * HW_CNT_PER_SYS_TICK;
 		now = ~(IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER));

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -240,15 +240,14 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* Disable event timer */
 	IT8XXX2_EXT_CTRLX(EVENT_TIMER) &= ~IT8XXX2_EXT_ETXEN;
 
-	if (ticks == K_TICKS_FOREVER) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
 		/*
-		 * If kernel doesn't have a timeout:
-		 * 1.CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = y (no future timer interrupts
-		 *   are expected), kernel pass K_TICKS_FOREVER (0xFFFF FFFF FFFF FFFF),
-		 *   we handle this case in here.
-		 * 2.CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = n (schedule timeout as far
-		 *   into the future as possible), kernel pass INT_MAX (0x7FFF FFFF),
-		 *   we handle it in later else {}.
+		 * The kernel has no pending timeout, which it signals with
+		 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle no future
+		 * timer interrupt is required, so leave the event timer
+		 * disabled and stop waking up. Without sloppy idle we fall
+		 * through to the else and still schedule the (capped) timeout
+		 * so the uptime tick count stays correct.
 		 */
 		k_spin_unlock(&lock, key);
 		return;

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -223,7 +223,7 @@ static void free_run_timer_overflow_isr(const void *unused)
 	 */
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	uint32_t hw_cnt;
 

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -159,7 +159,7 @@ static void timer_isr(const void *unused)
 	sys_clock_announce(dticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 	volatile struct gptimer_regs *regs = get_regs();

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -19,8 +19,6 @@
  * announces every elapsed tick rather than dropping it.
  */
 
-#include <limits.h>
-
 #define DT_DRV_COMPAT gaisler_gptimer
 
 #include <zephyr/init.h>
@@ -170,16 +168,13 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (ticks == K_TICKS_FOREVER || ticks > MAX_TICKS) {
-		ticks = MAX_TICKS;
-	}
-
-	/* The ISR eventually announces last_elapsed + ticks (plus IRQ-servicing
-	 * latency) and sys_clock_announce() takes an int32_t. Keep the sum
-	 * within INT32_MAX, reserving half the range for the latency.
+	/* Cap to the cycle-count window: ticks * CYC_PER_TICK must stay below
+	 * 2^31 so the signed delay delta below cannot wrap. The kernel already
+	 * caps the requested tick count (SYS_CLOCK_MAX_WAIT), so this is the
+	 * only limit the driver still has to enforce.
 	 */
-	if (ticks > (INT32_MAX / 2 - last_elapsed)) {
-		ticks = INT32_MAX / 2 - last_elapsed;
+	if (ticks > MAX_TICKS) {
+		ticks = MAX_TICKS;
 	}
 
 	/* Absolute, tick-aligned deadline from the last announce, programmed as
@@ -187,7 +182,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	 * sys_clock_elapsed(), so the fire lands on the requested tick boundary
 	 * regardless of the sub-tick offset of the counter.
 	 */
-	target = announced_cyc + (last_elapsed + (uint32_t)ticks) * CYC_PER_TICK;
+	target = announced_cyc + (last_elapsed + ticks) * CYC_PER_TICK;
 	now = up_counter(regs);
 	delay = target - now;
 	if (delay < (int32_t)MIN_DELAY_CYC) {

--- a/drivers/timer/max32_rv32_sys_timer.c
+++ b/drivers/timer/max32_rv32_sys_timer.c
@@ -109,7 +109,7 @@ uint32_t sys_clock_elapsed(void)
 	return delta_ticks;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/max32_rv32_sys_timer.c
+++ b/drivers/timer/max32_rv32_sys_timer.c
@@ -44,13 +44,16 @@ static uint32_t last_elapsed;
 
 #define CYCLE_DIFF_MAX (~(uint32_t)0)
 
-#define CYCLES_MAX_1 ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
-#define CYCLES_MAX_2 ((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_3 MIN(CYCLES_MAX_1, CYCLES_MAX_2)
-#define CYCLES_MAX_4 (CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
-#define CYCLES_MAX_5 (CYCLES_MAX_4 + LSB_GET(CYCLES_MAX_4))
-
-#define CYCLES_MAX CYCLES_MAX_5
+/*
+ * Maximum number of cycles to wait between two sys_clock_announce() reports:
+ * the elapsed cycle count must fit in CYCLE_DIFF_MAX before it is divided down
+ * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
+ * servicing latency so a late report still fits, then add the LSB so the value
+ * clears a run of low set bits for a nicer literal in the generated assembly.
+ */
+#define CYCLES_MAX_1 ((uint64_t)CYCLE_DIFF_MAX)
+#define CYCLES_MAX_2 (CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
+#define CYCLES_MAX   (CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
 
 #if PRESCALER == 0
 #define PRES_VAL TMR_PRES_1
@@ -119,7 +122,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t next_cycle;
 	uint32_t count;
 
-	if (ticks == INT32_MAX) {
+	if (ticks == SYS_CLOCK_MAX_WAIT) {
 		next_cycle = (last_tick * CYC_PER_TICK) + CYCLES_MAX;
 	} else if (ticks == 0) {
 		next_cycle = MXC_TMR_GetCount(regs) + (CYC_PER_TICK * 3 / 2);

--- a/drivers/timer/max32_rv32_sys_timer.c
+++ b/drivers/timer/max32_rv32_sys_timer.c
@@ -115,10 +115,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (idle && ticks == K_TICKS_FOREVER) {
-		return;
-	}
-
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t next_cycle;
 	uint32_t count;

--- a/drivers/timer/max32_wut_timer.c
+++ b/drivers/timer/max32_wut_timer.c
@@ -80,7 +80,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 

--- a/drivers/timer/max32_wut_timer.c
+++ b/drivers/timer/max32_wut_timer.c
@@ -80,10 +80,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (ticks == K_TICKS_FOREVER) {
-		ticks = MAX_TICKS;
-	}
-
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);

--- a/drivers/timer/max32_wut_timer.c
+++ b/drivers/timer/max32_wut_timer.c
@@ -72,7 +72,7 @@ static void max32_wut_timer_isr(const void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : 1);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/mchp_sam_pit64b_timer.c
+++ b/drivers/timer/mchp_sam_pit64b_timer.c
@@ -79,7 +79,7 @@ static void pit64b_isr(const void *arg)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/mchp_sam_pit64b_timer.c
+++ b/drivers/timer/mchp_sam_pit64b_timer.c
@@ -93,7 +93,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t val1, val2;
 	uint32_t delay;
 
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
+	ticks = MIN(ticks, (uint32_t)MAX_TICKS);
 
 	key = k_spin_lock(&lock);
 	cycle_count += cycles_elapsed();

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -182,7 +182,7 @@ static uint32_t last_announcement; /* last time we called sys_clock_announce() *
  * Writing a new value to preload only takes effect once the count
  * register reaches 0.
  */
-void sys_clock_set_timeout(int32_t n, bool idle)
+void sys_clock_set_timeout(uint32_t n, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -191,7 +191,7 @@ void sys_clock_set_timeout(uint32_t n, bool idle)
 	uint32_t full_cycles;    /* full_ticks represented as cycles */
 	uint32_t partial_cycles; /* number of cycles to first tick boundary */
 
-	if (idle && (n == K_TICKS_FOREVER)) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (n == SYS_CLOCK_MAX_WAIT)) {
 		/*
 		 * We are not in a locked section. Are writes to two
 		 * global objects safe from pre-emption?
@@ -203,7 +203,7 @@ void sys_clock_set_timeout(uint32_t n, bool idle)
 
 	if (n < 1) {
 		full_ticks = 0;
-	} else if ((n == K_TICKS_FOREVER) || (n > MAX_TICKS)) {
+	} else if (n > MAX_TICKS) {
 		full_ticks = MAX_TICKS - 1;
 	} else {
 		full_ticks = n - 1;

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -140,7 +140,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t next, adj, now;
 
 	/* Clamp ticks. We subtract one since we round up to next tick */
-	ticks = CLAMP((ticks - 1), 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	key = k_spin_lock(&lock);
 

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -130,7 +130,7 @@ void mcux_imx_gpt_isr(const void *arg)
  * Next needed call to sys_clock_announce will not be until the specified number
  * of ticks from the current time have elapsed.
  */
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Not supported on tickful kernels */

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -139,7 +139,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	k_spinlock_key_t key;
 	uint32_t next, adj, now;
 
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	/* Clamp ticks. We subtract one since we round up to next tick */
 	ticks = CLAMP((ticks - 1), 0, (int32_t)MAX_TICKS);
 

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -83,7 +83,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t next, adj, now;
 
 	/* Clamp ticks. We subtract one since we round up to next tick */
-	ticks = CLAMP((ticks - 1), 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	key = k_spin_lock(&lock);
 

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -70,8 +70,9 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
-	if (idle && (ticks == K_TICKS_FOREVER)) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
 		LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
+		return;
 	}
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
@@ -81,7 +82,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	k_spinlock_key_t key;
 	uint32_t next, adj, now;
 
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	/* Clamp ticks. We subtract one since we round up to next tick */
 	ticks = CLAMP((ticks - 1), 0, (int32_t)MAX_TICKS);
 

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -66,7 +66,7 @@ static inline uint32_t counter_delta(uint32_t now, uint32_t then)
 	return (now - then) & COUNTER_MAX;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -244,7 +244,7 @@ bool z_nxp_os_timer_ignore_timer_wakeup(void)
 	return (wait_forever || counter_remaining_ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Only for tickless kernel system */

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -267,7 +267,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 #else
 	ARG_UNUSED(idle);
 #endif
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t now = mcux_lpc_ostick_get_compensated_timer_value();

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -267,7 +267,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 #else
 	ARG_UNUSED(idle);
 #endif
-	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);

--- a/drivers/timer/mcux_stm_timer.c
+++ b/drivers/timer/mcux_stm_timer.c
@@ -84,7 +84,7 @@ static void mcux_stm_timer_isr(const void *arg)
 	sys_clock_announce_locked((int32_t)delta_ticks, key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -99,10 +99,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	if (ticks == K_TICKS_FOREVER) {
 		cycles = cycles_max;
 	} else {
-		if (ticks < 0) {
-			ticks = 0;
-		}
-
 		uint64_t wait_ticks = (uint64_t)last_elapsed + (uint64_t)ticks;
 		uint64_t wait_cycles = wait_ticks * (uint64_t)cycles_per_tick;
 

--- a/drivers/timer/mcux_stm_timer.c
+++ b/drivers/timer/mcux_stm_timer.c
@@ -81,7 +81,7 @@ static void mcux_stm_timer_isr(const void *arg)
 		stm_disable_compare();
 	}
 
-	sys_clock_announce_locked((int32_t)delta_ticks, key);
+	sys_clock_announce_locked(delta_ticks, key);
 }
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)

--- a/drivers/timer/mcux_stm_timer.c
+++ b/drivers/timer/mcux_stm_timer.c
@@ -94,16 +94,9 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	uint32_t cycles;
-
-	if (ticks == K_TICKS_FOREVER) {
-		cycles = cycles_max;
-	} else {
-		uint64_t wait_ticks = (uint64_t)last_elapsed + (uint64_t)ticks;
-		uint64_t wait_cycles = wait_ticks * (uint64_t)cycles_per_tick;
-
-		cycles = (wait_cycles > cycles_max) ? cycles_max : (uint32_t)wait_cycles;
-	}
+	uint64_t wait_ticks = (uint64_t)last_elapsed + (uint64_t)ticks;
+	uint64_t wait_cycles = wait_ticks * (uint64_t)cycles_per_tick;
+	uint32_t cycles = (wait_cycles > cycles_max) ? cycles_max : (uint32_t)wait_cycles;
 
 	stm_set_compare(last_count + cycles);
 }

--- a/drivers/timer/mcux_sysctr_timer.c
+++ b/drivers/timer/mcux_sysctr_timer.c
@@ -163,7 +163,7 @@ static void sysctr_timer_isr(const void *arg)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	uint64_t next_cycle;
 	uint64_t now;
@@ -191,10 +191,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	if (ticks == K_TICKS_FOREVER) {
 		next_cycle = last_cycle + MAX_CYCLES;
 	} else {
-		/* Per sys_clock API: treat any other negative value as "fire ASAP". */
-		if (ticks < 0) {
-			ticks = 0;
-		}
 		/*
 		 * Compute elapsed ticks from the most recent announce locally
 		 * instead of relying on a cached value from sys_clock_elapsed(),

--- a/drivers/timer/mcux_sysctr_timer.c
+++ b/drivers/timer/mcux_sysctr_timer.c
@@ -188,22 +188,17 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	now = counter_read();
 
-	if (ticks == K_TICKS_FOREVER) {
-		next_cycle = last_cycle + MAX_CYCLES;
-	} else {
-		/*
-		 * Compute elapsed ticks from the most recent announce locally
-		 * instead of relying on a cached value from sys_clock_elapsed(),
-		 * which may be stale (or never have been called) by the time we
-		 * arrive here.
-		 */
-		uint64_t elapsed_ticks = (now - last_cycle) / CYC_PER_TICK;
+	/*
+	 * Compute elapsed ticks from the most recent announce locally
+	 * instead of relying on a cached value from sys_clock_elapsed(),
+	 * which may be stale (or never have been called) by the time we
+	 * arrive here.
+	 */
+	uint64_t elapsed_ticks = (now - last_cycle) / CYC_PER_TICK;
 
-		next_cycle = last_cycle +
-			     (elapsed_ticks + (uint64_t)ticks) * CYC_PER_TICK;
-		if ((next_cycle - last_cycle) > MAX_CYCLES) {
-			next_cycle = last_cycle + MAX_CYCLES;
-		}
+	next_cycle = last_cycle + (elapsed_ticks + (uint64_t)ticks) * CYC_PER_TICK;
+	if ((next_cycle - last_cycle) > MAX_CYCLES) {
+		next_cycle = last_cycle + MAX_CYCLES;
 	}
 
 	min = now + MIN_DELAY_CYCLES;

--- a/drivers/timer/mcux_sysctr_timer.c
+++ b/drivers/timer/mcux_sysctr_timer.c
@@ -66,21 +66,11 @@ BUILD_ASSERT((CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC % CONFIG_SYS_CLOCK_TICKS_PER_SE
 		      / (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 
 /*
- * Limit the maximum programmed compare distance. Two constraints apply:
- *
- *   1) Half of the 56-bit counter span. This prevents ambiguity with the
- *      ">=" comparison when the counter eventually wraps.
- *
- *   2) INT32_MAX * CYC_PER_TICK. The tick delta computed in the ISR
- *      (delta_cycles / CYC_PER_TICK) must fit in uint32_t and, more
- *      importantly, in the int32_t parameter accepted by
- *      sys_clock_announce(). With a 56-bit counter this bound is tighter
- *      than (1) at typical tick rates (e.g. 24 MHz / 10 kHz ticks leaves
- *      ~5e12 cycles, far below 2^55).
- *
- * Use the smaller of the two so both invariants hold.
+ * Limit the maximum programmed compare distance to half the 56-bit counter
+ * span. This keeps the ">=" comparison unambiguous when the counter
+ * eventually wraps.
  */
-#define MAX_CYCLES MIN((uint64_t)INT32_MAX * CYC_PER_TICK, COUNTER_SPAN / 2)
+#define MAX_CYCLES (COUNTER_SPAN / 2)
 
 #define MIN_DELAY_CYCLES  CONFIG_MCUX_SYSCTR_TIMER_MIN_DELAY
 

--- a/drivers/timer/mcux_sysctr_timer.c
+++ b/drivers/timer/mcux_sysctr_timer.c
@@ -23,8 +23,9 @@
  * Tickless operation:
  *   - ISR disables compare (clears ISTAT) and masks the interrupt.
  *   - sys_clock_set_timeout() programs a new compare value and re-enables.
- *   - For K_TICKS_FOREVER + idle, the compare interrupt stays disabled
- *     until sys_clock_idle_exit() or the next set_timeout call.
+ *   - Under sloppy idle with no near deadline, the compare interrupt
+ *     stays disabled until sys_clock_idle_exit() or the next set_timeout
+ *     call.
  */
 
 #include <zephyr/init.h>
@@ -169,15 +170,17 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint64_t now;
 	uint64_t min;
 
+	ARG_UNUSED(idle);
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
 
-	if (idle && (ticks == K_TICKS_FOREVER)) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
 		/*
-		 * No kernel timeout pending and going to idle — disable the
-		 * compare interrupt entirely.  sys_clock_idle_exit() will
-		 * re-enable if the CPU wakes from an external source.
+		 * No near deadline to schedule: under sloppy idle, disable the
+		 * compare interrupt entirely. sys_clock_idle_exit() will
+		 * re-enable it when the CPU wakes from an external source.
 		 */
 		SYSCTR_EnableCompare(CMP_BASE, TIMER_CMP_FRAME, false);
 		SYSCTR_DisableInterrupts(CMP_BASE, TIMER_CMP_INT_MASK);

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -69,7 +69,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -61,7 +61,7 @@ static void timer_isr(const void *arg)
 	sys_clock_announce(TICKLESS ? dticks : 1);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -69,7 +69,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t current_count = get_cp0_count();

--- a/drivers/timer/mtk_adsp_timer.c
+++ b/drivers/timer/mtk_adsp_timer.c
@@ -139,7 +139,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	/* Compute desired expiration time */
 	uint64_t now = sys_clock_cycle_get_64();
-	uint64_t end = now + CLAMP(ticks - 1, 0, MAX_TICKS) * OST64_PER_TICK;
+	uint64_t end = now + (CLAMP(ticks, 1, MAX_TICKS) - 1) * OST64_PER_TICK;
 	uint32_t dt = (uint32_t)MIN(end - last_announce, CYC64_MAX);
 
 	/* Round up to tick boundary */

--- a/drivers/timer/mtk_adsp_timer.c
+++ b/drivers/timer/mtk_adsp_timer.c
@@ -135,7 +135,7 @@ uint64_t sys_clock_cycle_get_64(void)
 	return (((uint64_t)h0) << 32) | l;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	/* Compute desired expiration time */
 	uint64_t now = sys_clock_cycle_get_64();

--- a/drivers/timer/native_sim_timer.c
+++ b/drivers/timer/native_sim_timer.c
@@ -71,7 +71,7 @@ void np_timer_isr_test_hook(const void *arg)
  * @param idle Hint to the driver that the system is about to enter
  *        the idle state immediately after setting the timeout
  */
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/native_sim_timer.c
+++ b/drivers/timer/native_sim_timer.c
@@ -78,16 +78,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint64_t silent_ticks;
 
-	/* Note that we treat INT_MAX literally as anyhow the maximum amount of
-	 * ticks we can report with sys_clock_announce() is INT_MAX
-	 */
-	if (ticks == K_TICKS_FOREVER) {
-		silent_ticks = INT64_MAX;
-	} else if (ticks > 0) {
-		silent_ticks = ticks - 1;
-	} else {
-		silent_ticks = 0;
-	}
+	silent_ticks = (ticks > 0) ? ticks - 1 : 0;
 	hwtimer_set_silent_ticks(silent_ticks);
 #endif
 }

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -252,7 +252,7 @@ static uint32_t npcx_itim_evt_elapsed_cyc32(void)
 #endif /* CONFIG_PM */
 
 /* System timer api functions */
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -145,28 +145,24 @@ static int npcx_itim_start_evt_tmr_by_tick(int32_t ticks)
 	 * round up to next tick boundary.
 	 */
 
-	if (ticks == K_TICKS_FOREVER) {
-		cyc_evt_timeout = NPCX_ITIM32_MAX_CNT;
+	uint64_t next_cycs;
+	uint64_t curr = npcx_itim_get_sys_cyc64();
+	uint64_t dcycles;
+
+	if (ticks == 0) {
+		ticks = 1;
+	}
+
+	next_cycs = (last_ticks + last_elapsed + ticks) * SYS_CYCLES_PER_TICK;
+	if (unlikely(next_cycs <= curr)) {
+		cyc_evt_timeout = 1;
 	} else {
-		uint64_t next_cycs;
-		uint64_t curr = npcx_itim_get_sys_cyc64();
-		uint64_t dcycles;
+		uint32_t dticks;
 
-		if (ticks <= 0) {
-			ticks = 1;
-		}
-
-		next_cycs = (last_ticks + last_elapsed + ticks) * SYS_CYCLES_PER_TICK;
-		if (unlikely(next_cycs <= curr)) {
-			cyc_evt_timeout = 1;
-		} else {
-			uint32_t dticks;
-
-			dcycles = next_cycs - curr;
-			dticks = DIV_ROUND_UP(dcycles * EVT_CYCLES_PER_SEC,
-					      sys_clock_hw_cycles_per_sec());
-			cyc_evt_timeout = CLAMP(dticks, 1, NPCX_ITIM32_MAX_CNT);
-		}
+		dcycles = next_cycs - curr;
+		dticks = DIV_ROUND_UP(dcycles * EVT_CYCLES_PER_SEC,
+				      sys_clock_hw_cycles_per_sec());
+		cyc_evt_timeout = CLAMP(dticks, 1, NPCX_ITIM32_MAX_CNT);
 	}
 	LOG_DBG("ticks %x, cyc_evt_timeout %x", ticks, cyc_evt_timeout);
 

--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -626,7 +626,7 @@ static int grtc_post_init(void)
 #endif
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -174,7 +174,7 @@ static void sys_clock_timeout_handler(int32_t id, uint64_t cc_val, void *p_conte
 	}
 
 	last_elapsed = 0;
-	sys_clock_announce((int32_t)dticks);
+	sys_clock_announce(dticks);
 }
 
 int32_t z_nrf_grtc_timer_chan_alloc(void)

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -667,7 +667,7 @@ bail:
 	return err;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 	uint64_t target_time;

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -676,7 +676,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (ticks == K_TICKS_FOREVER) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
 		target_time = last_count + MAX_CYCLES;
 		sys_busy = false;
 	} else {

--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -74,7 +74,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	 * to be usable elsewhere. The half range gives us extra room to cope
 	 * with the unavoidable IRQ servicing latency.
 	 */
-	ticks = CLAMP(ticks, 0, MAX_CYC / 2 / cyc_per_tick);
+	ticks = MIN(ticks, MAX_CYC / 2 / cyc_per_tick);
 
 	const uint32_t compare =
 		((last_ticks + last_elapsed + (uint32_t)ticks) * cyc_per_tick) & MAX_CYC;

--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -68,14 +68,6 @@ void z_openrisc_timer_isr(void)
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 #if defined(CONFIG_TICKLESS_KERNEL)
-	if (ticks == K_TICKS_FOREVER) {
-		if (idle) {
-			return;
-		}
-
-		ticks = INT32_MAX;
-	}
-
 	/*
 	 * Clamp the max period length to a number of cycles that can fit
 	 * in half the range of a cycle_diff_t for native width divisions

--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -65,7 +65,7 @@ void z_openrisc_timer_isr(void)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 #if defined(CONFIG_TICKLESS_KERNEL)
 	if (ticks == K_TICKS_FOREVER) {

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -107,7 +107,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t full_cycles;
 	uint32_t partial_cycles;
 
-	if (idle && (ticks == K_TICKS_FOREVER)) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (ticks == SYS_CLOCK_MAX_WAIT)) {
 		RTMR_REG->CTRL = 0U;
 		previous_cnt = RTMR_TIMER_STOPPED;
 		return;
@@ -115,7 +115,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	if (ticks < 1) {
 		full_ticks = 0;
-	} else if ((ticks == K_TICKS_FOREVER) || (ticks > MAX_TICKS)) {
+	} else if (ticks > MAX_TICKS) {
 		full_ticks = MAX_TICKS - 1;
 	} else {
 		full_ticks = ticks - 1;

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -98,7 +98,7 @@ static void rtmr_isr(const void *arg)
 	sys_clock_announce(ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -82,7 +82,7 @@ static void ra_ulpt_timer_isr(void)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -96,8 +96,15 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	/* Clamp the ticks value to a valid range. */
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	/* Preserve the original behavior even though it looks wrong; to be
+	 * revisited.
+	 */
+	if (ticks >= 1) {
+		ticks -= 1;
+	}
+	if (ticks > MAX_TICKS) {
+		ticks = MAX_TICKS;
+	}
 
 	/* Calculate the timer delay in cycles. */
 	uint32_t cycles = ~RA_ULPT_INST1_REG->ULPTCNT;

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -91,8 +91,8 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	/* No timeout change for K_TICKS_FOREVER or INT32_MAX. */
-	if (ticks == K_TICKS_FOREVER || ticks == INT32_MAX) {
+	/* No timeout change when the kernel has no near deadline to schedule. */
+	if (ticks == SYS_CLOCK_MAX_WAIT) {
 		return;
 	}
 

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -218,7 +218,15 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	/* Preserve the original behavior even though it looks wrong; to be
+	 * revisited.
+	 */
+	if (ticks >= 1) {
+		ticks -= 1;
+	}
+	if (ticks > MAX_TICKS) {
+		ticks = MAX_TICKS;
+	}
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -213,7 +213,8 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (ticks == K_TICKS_FOREVER || ticks == INT32_MAX) {
+	/* Nothing to do when the kernel has no near deadline to schedule. */
+	if (ticks == SYS_CLOCK_MAX_WAIT) {
 		return;
 	}
 

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -207,7 +207,7 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/renesas_rz_gtm_timer.c
+++ b/drivers/timer/renesas_rz_gtm_timer.c
@@ -20,34 +20,18 @@ LOG_MODULE_REGISTER(renesas_rz_gtm_timer);
 #define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
 
 /*
- * We have two constraints on the maximum number of cycles we can wait for.
- *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
- *
- * 2) The number of cycles between two reports must fit in a cycle_diff_t
- *    variable before converting it to ticks.
- *
- * Then:
- *
- * 3) Pick the smallest between (1) and (2).
- *
- * 4) Take into account some room for the unavoidable IRQ servicing latency.
- *    Let's use 3/4 of the max range.
- *
- * Finally let's add the LSB value to the result so to clear out a bunch of
- * consecutive set bits coming from the original max values to produce a
- * nicer literal for assembly generation.
+ * Maximum number of cycles to wait between two sys_clock_announce() reports:
+ * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
+ * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
+ * servicing latency so a late report still fits, then add the LSB so the value
+ * clears a run of low set bits for a nicer literal in the generated assembly.
  */
-#define CYCLES_MAX_1 ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
-#define CYCLES_MAX_2 ((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_3 MIN(CYCLES_MAX_1, CYCLES_MAX_2)
-#define CYCLES_MAX_4 (CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
-#define CYCLES_MAX_5 (CYCLES_MAX_4 + LSB_GET(CYCLES_MAX_4))
+#define CYCLES_MAX_1 ((uint64_t)CYCLE_DIFF_MAX)
+#define CYCLES_MAX_2 (CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
+#define CYCLES_MAX   (CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
 
-/* precompute CYCLES_MAX and CYC_PER_TICK at driver init to avoid runtime double divisions */
-static uint64_t cycles_max;
+/* precompute CYC_PER_TICK at driver init to avoid runtime double divisions */
 static uint32_t cyc_per_tick;
-#define CYCLES_MAX   cycles_max
 #define CYC_PER_TICK cyc_per_tick
 
 static void ostm_irq_handler(timer_callback_args_t *arg);
@@ -107,11 +91,9 @@ static void ostm_irq_handler(timer_callback_args_t *arg)
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
+	ARG_UNUSED(idle);
 
-	if (idle && ticks == K_TICKS_FOREVER) {
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
 
@@ -121,13 +103,9 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	if (ticks == K_TICKS_FOREVER) {
+	next_cycle = (data->last_tick + data->last_elapsed + ticks) * CYC_PER_TICK;
+	if ((next_cycle - data->last_cycle) > CYCLES_MAX) {
 		next_cycle = data->last_cycle + CYCLES_MAX;
-	} else {
-		next_cycle = (data->last_tick + data->last_elapsed + ticks) * CYC_PER_TICK;
-		if ((next_cycle - data->last_cycle) > CYCLES_MAX) {
-			next_cycle = data->last_cycle + CYCLES_MAX;
-		}
 	}
 
 	config->fsp_api->periodSet(data->fsp_ctrl, next_cycle);
@@ -191,7 +169,6 @@ static int sys_clock_driver_init(void)
 	data->last_cycle = 0;
 	z_clock_hw_cycles_per_sec = R_FSP_SystemClockHzGet(FSP_PRIV_CLOCK_P0CLK);
 	cyc_per_tick = sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-	cycles_max = CYCLES_MAX_5;
 	data->fsp_cfg->period_counts = CYC_PER_TICK;
 	ret = config->fsp_api->open(data->fsp_ctrl, data->fsp_cfg);
 	if (ret != FSP_SUCCESS) {

--- a/drivers/timer/renesas_rz_gtm_timer.c
+++ b/drivers/timer/renesas_rz_gtm_timer.c
@@ -105,7 +105,7 @@ static void ostm_irq_handler(timer_callback_args_t *arg)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/renesas_rza2m_os_timer.c
+++ b/drivers/timer/renesas_rza2m_os_timer.c
@@ -119,7 +119,7 @@ static void ostm_irq_handler(const struct device *dev)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/renesas_rza2m_os_timer.c
+++ b/drivers/timer/renesas_rza2m_os_timer.c
@@ -60,34 +60,18 @@ const int32_t z_sys_timer_irq_for_test = OSTM_IRQ_NUM;
 #define OSTM_CTL_FREERUN           2
 
 /*
- * We have two constraints on the maximum number of cycles we can wait for.
- *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
- *
- * 2) The number of cycles between two reports must fit in a cycle_diff_t
- *    variable before converting it to ticks.
- *
- * Then:
- *
- * 3) Pick the smallest between (1) and (2).
- *
- * 4) Take into account some room for the unavoidable IRQ servicing latency.
- *    Let's use 3/4 of the max range.
- *
- * Finally let's add the LSB value to the result so to clear out a bunch of
- * consecutive set bits coming from the original max values to produce a
- * nicer literal for assembly generation.
+ * Maximum number of cycles to wait between two sys_clock_announce() reports:
+ * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
+ * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
+ * servicing latency so a late report still fits, then add the LSB so the value
+ * clears a run of low set bits for a nicer literal in the generated assembly.
  */
-#define CYCLES_MAX_1 ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
-#define CYCLES_MAX_2 ((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_3 MIN(CYCLES_MAX_1, CYCLES_MAX_2)
-#define CYCLES_MAX_4 (CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
-#define CYCLES_MAX_5 (CYCLES_MAX_4 + LSB_GET(CYCLES_MAX_4))
+#define CYCLES_MAX_1 ((uint64_t)CYCLE_DIFF_MAX)
+#define CYCLES_MAX_2 (CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
+#define CYCLES_MAX   (CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
 
-/* Precompute CYCLES_MAX and CYC_PER_TICK at driver init to avoid runtime double divisions */
-static uint64_t cycles_max;
+/* Precompute CYC_PER_TICK at driver init to avoid runtime double divisions */
 static uint32_t cyc_per_tick;
-#define CYCLES_MAX   cycles_max
 #define CYC_PER_TICK cyc_per_tick
 
 static struct k_spinlock lock;
@@ -121,11 +105,9 @@ static void ostm_irq_handler(const struct device *dev)
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
+	ARG_UNUSED(idle);
 
-	if (idle && ticks == K_TICKS_FOREVER) {
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
 
@@ -133,13 +115,9 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	if (ticks == K_TICKS_FOREVER) {
+	next_cycle = (last_tick + last_elapsed + ticks) * CYC_PER_TICK;
+	if ((next_cycle - last_cycle) > CYCLES_MAX) {
 		next_cycle = last_cycle + CYCLES_MAX;
-	} else {
-		next_cycle = (last_tick + last_elapsed + ticks) * CYC_PER_TICK;
-		if ((next_cycle - last_cycle) > CYCLES_MAX) {
-			next_cycle = last_cycle + CYCLES_MAX;
-		}
 	}
 
 	sys_write32(next_cycle, OSTM_REG_ADDR(OSTM_CMP_OFFSET));
@@ -209,7 +187,6 @@ static int sys_clock_driver_init(void)
 	last_tick = 0;
 	last_cycle = 0;
 	cyc_per_tick = sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-	cycles_max = CYCLES_MAX_5;
 
 	DEVICE_MMIO_TOPLEVEL_MAP(ostm_base, K_MEM_CACHE_NONE);
 

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -123,7 +123,7 @@ static void timer_isr(const void *arg)
 	sys_clock_announce_locked(dticks, key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -26,29 +26,15 @@
 #define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
 
 /*
- * We have two constraints on the maximum number of cycles we can wait for.
- *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
- *
- * 2) The number of cycles between two reports must fit in a cycle_diff_t
- *    variable before converting it to ticks.
- *
- * Then:
- *
- * 3) Pick the smallest between (1) and (2).
- *
- * 4) Take into account some room for the unavoidable IRQ servicing latency.
- *    Let's use 3/4 of the max range.
- *
- * Finally let's add the LSB value to the result so to clear out a bunch of
- * consecutive set bits coming from the original max values to produce a
- * nicer literal for assembly generation.
+ * Maximum number of cycles to wait between two sys_clock_announce() reports:
+ * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
+ * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
+ * servicing latency so a late report still fits, then add the LSB so the value
+ * clears a run of low set bits for a nicer literal in the generated assembly.
  */
-#define CYCLES_MAX_1 ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
-#define CYCLES_MAX_2 ((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_3 MIN(CYCLES_MAX_1, CYCLES_MAX_2)
-#define CYCLES_MAX_4 (CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
-#define CYCLES_MAX   (CYCLES_MAX_4 + LSB_GET(CYCLES_MAX_4))
+#define CYCLES_MAX_1 ((uint64_t)CYCLE_DIFF_MAX)
+#define CYCLES_MAX_2 (CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
+#define CYCLES_MAX   (CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
 
 static uint64_t last_count;
 static uint64_t last_ticks;
@@ -135,13 +121,9 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	uint64_t cyc;
 
-	if (ticks == K_TICKS_FOREVER) {
+	cyc = (last_ticks + last_elapsed + ticks) * CYC_PER_TICK;
+	if ((cyc - last_count) > CYCLES_MAX) {
 		cyc = last_count + CYCLES_MAX;
-	} else {
-		cyc = (last_ticks + last_elapsed + ticks) * CYC_PER_TICK;
-		if ((cyc - last_count) > CYCLES_MAX) {
-			cyc = last_count + CYCLES_MAX;
-		}
 	}
 	set_mtimecmp(cyc);
 }

--- a/drivers/timer/riscv_supervisor_timer.c
+++ b/drivers/timer/riscv_supervisor_timer.c
@@ -97,7 +97,7 @@ static void timer_isr(const void *arg)
 	sys_clock_announce(dticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/riscv_supervisor_timer.c
+++ b/drivers/timer/riscv_supervisor_timer.c
@@ -23,29 +23,15 @@
 #define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
 
 /*
- * We have two constraints on the maximum number of cycles we can wait for.
- *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
- *
- * 2) The number of cycles between two reports must fit in a cycle_diff_t
- *    variable before converting it to ticks.
- *
- * Then:
- *
- * 3) Pick the smallest between (1) and (2).
- *
- * 4) Take into account some room for the unavoidable IRQ servicing latency.
- *    Let's use 3/4 of the max range.
- *
- * Finally let's add the LSB value to the result so to clear out a bunch of
- * consecutive set bits coming from the original max values to produce a
- * nicer literal for assembly generation.
+ * Maximum number of cycles to wait between two sys_clock_announce() reports:
+ * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
+ * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
+ * servicing latency so a late report still fits, then add the LSB so the value
+ * clears a run of low set bits for a nicer literal in the generated assembly.
  */
-#define CYCLES_MAX_1 ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
-#define CYCLES_MAX_2 ((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_3 MIN(CYCLES_MAX_1, CYCLES_MAX_2)
-#define CYCLES_MAX_4 (CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
-#define CYCLES_MAX   (CYCLES_MAX_4 + LSB_GET(CYCLES_MAX_4))
+#define CYCLES_MAX_1 ((uint64_t)CYCLE_DIFF_MAX)
+#define CYCLES_MAX_2 (CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
+#define CYCLES_MAX   (CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = IRQ_S_TIMER;
@@ -108,13 +94,9 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t cyc;
 
-	if (ticks == K_TICKS_FOREVER) {
+	cyc = (last_ticks + last_elapsed + ticks) * CYC_PER_TICK;
+	if ((cyc - last_count) > CYCLES_MAX) {
 		cyc = last_count + CYCLES_MAX;
-	} else {
-		cyc = (last_ticks + last_elapsed + ticks) * CYC_PER_TICK;
-		if ((cyc - last_count) > CYCLES_MAX) {
-			cyc = last_count + CYCLES_MAX;
-		}
 	}
 	sbi_set_timer(cyc);
 

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -205,8 +205,8 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #else /* !CONFIG_TICKLESS_KERNEL */
 
-	if (ticks == K_TICKS_FOREVER) {
-		/* Disable comparator for K_TICKS_FOREVER. */
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+		/* Disable comparator when the kernel has no pending timeout. */
 		rtc_timeout = rtc_counter;
 		return;
 	}

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -187,7 +187,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #ifdef CONFIG_TICKLESS_KERNEL
 
-	ticks = CLAMP(ticks - 1, 0, (int32_t) MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	/* Compute number of RTC cycles until the next timeout. */
 	uint32_t count = rtc_count();

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -187,7 +187,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #ifdef CONFIG_TICKLESS_KERNEL
 
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t) MAX_TICKS);
 
 	/* Compute number of RTC cycles until the next timeout. */

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -181,7 +181,7 @@ static void rtc_isr(const void *arg)
 #endif /* CONFIG_TICKLESS_KERNEL */
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -207,9 +207,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #else /* !CONFIG_TICKLESS_KERNEL */
 
 	if (ticks == K_TICKS_FOREVER) {
-		/* Disable comparator for K_TICKS_FOREVER and other negative
-		 * values.
-		 */
+		/* Disable comparator for K_TICKS_FOREVER. */
 		rtc_timeout = rtc_counter;
 		return;
 	}

--- a/drivers/timer/silabs_sleeptimer_timer.c
+++ b/drivers/timer/silabs_sleeptimer_timer.c
@@ -99,7 +99,7 @@ static uint32_t sleeptimer_clock_elapsed(struct sleeptimer_timer_data *timer)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/silabs_sleeptimer_timer.c
+++ b/drivers/timer/silabs_sleeptimer_timer.c
@@ -66,7 +66,6 @@ static void sleeptimer_clock_set_timeout(int32_t ticks, struct sleeptimer_timer_
 		return;
 	}
 
-	ticks = (ticks == K_TICKS_FOREVER) ? timer->max_timeout_ticks : ticks;
 	ticks = CLAMP(ticks, 0, timer->max_timeout_ticks);
 
 	k_spinlock_key_t key = k_spin_lock(&timer->lock);

--- a/drivers/timer/silabs_sleeptimer_timer.c
+++ b/drivers/timer/silabs_sleeptimer_timer.c
@@ -66,7 +66,7 @@ static void sleeptimer_clock_set_timeout(int32_t ticks, struct sleeptimer_timer_
 		return;
 	}
 
-	ticks = CLAMP(ticks, 0, timer->max_timeout_ticks);
+	ticks = MIN(ticks, timer->max_timeout_ticks);
 
 	k_spinlock_key_t key = k_spin_lock(&timer->lock);
 

--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -146,7 +146,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 			ticks = watchdog_expire_ticks - 2;
 		}
 	}
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	schedule_next_interrupt(ticks);
 }

--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -113,10 +113,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (ticks == K_TICKS_FOREVER) {
-		/* FIXME we could disable timer here */
-	}
-
 	/*
 	 * When Watchdog is NOT enabled but power management is, system
 	 * starts watchdog before PD_SYS is powered off.
@@ -150,7 +146,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 			ticks = watchdog_expire_ticks - 2;
 		}
 	}
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	schedule_next_interrupt(ticks);

--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -107,7 +107,7 @@ static void schedule_next_interrupt(uint32_t ticks)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -395,7 +395,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	 * treated identically: it simply indicates the kernel would like the
 	 * next tick announcement as soon as possible.
 	 */
-	ticks = CLAMP(ticks - 1, 1, lptim_time_base);
+	ticks = CLAMP(ticks, 2, lptim_time_base) - 1;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -302,7 +302,7 @@ static inline uint32_t z_clock_lptim_getcounter(void)
 	return lp_time;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
 	uint32_t next_arr = 0;
@@ -388,7 +388,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		return;
 	}
 	/* passing ticks==1 means "announce the next tick",
-	 * ticks value of zero (or even negative) is legal and
+	 * ticks value of zero is legal and
 	 * treated identically: it simply indicates the kernel would like the
 	 * next tick announcement as soon as possible.
 	 */

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -369,10 +369,13 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	}
 
 	/*
-	 * When CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = y, ticks equals to -1
-	 * is treated as a lptim off ; never waking up ; lptim not clocked anymore
+	 * The kernel has no pending timeout, which it signals with
+	 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle the LPTIM can be
+	 * turned off entirely (never waking up, not clocked anymore).
+	 * Without sloppy idle we fall through and schedule the (capped)
+	 * timeout so the uptime tick count stays correct.
 	 */
-	if (ticks == K_TICKS_FOREVER) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
 		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
 		return;
 	}

--- a/drivers/timer/stm32wb0_radio_timer.c
+++ b/drivers/timer/stm32wb0_radio_timer.c
@@ -61,7 +61,7 @@ static void radio_timer_error_isr(void *args)
 
 static void radio_timer_cpu_wkup_isr(void *args)
 {
-	int32_t dticks;
+	uint32_t dticks;
 	uint64_t diff_cycles;
 
 	ARG_UNUSED(args);
@@ -78,7 +78,7 @@ static void radio_timer_cpu_wkup_isr(void *args)
 
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		diff_cycles = HAL_RADIO_TIMER_GetCurrentSysTime() - announced_cycles;
-		dticks = (int32_t)k_cyc_to_ticks_near64(diff_cycles);
+		dticks = k_cyc_to_ticks_near64(diff_cycles);
 		announced_cycles += k_ticks_to_cyc_near32(dticks);
 		sys_clock_announce(dticks);
 	} else {

--- a/drivers/timer/stm32wb0_radio_timer.c
+++ b/drivers/timer/stm32wb0_radio_timer.c
@@ -105,7 +105,7 @@ static void radio_timer_txrx_wkup_isr(void *args)
 }
 #endif /* CONFIG_SOC_STM32WB06XX || CONFIG_SOC_STM32WB07XX */
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/stm32wb0_radio_timer.c
+++ b/drivers/timer/stm32wb0_radio_timer.c
@@ -109,10 +109,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
-	if (ticks == K_TICKS_FOREVER) {
-		return;
-	}
-
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		uint32_t current_time, delay;
 		uint32_t key;

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -18,7 +18,7 @@
 
 /* Weak-linked noop defaults for optional driver interfaces*/
 
-void __weak sys_clock_set_timeout(int32_t ticks, bool idle)
+void __weak sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 }
 

--- a/drivers/timer/ti_dmtimer.c
+++ b/drivers/timer/ti_dmtimer.c
@@ -114,7 +114,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks, 1, (int32_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);

--- a/drivers/timer/ti_dmtimer.c
+++ b/drivers/timer/ti_dmtimer.c
@@ -103,7 +103,7 @@ static void ti_dmtimer_isr(void *param)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/ti_dmtimer.c
+++ b/drivers/timer/ti_dmtimer.c
@@ -114,7 +114,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ticks = CLAMP(ticks, 1, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 

--- a/drivers/timer/ti_rti_timer.c
+++ b/drivers/timer/ti_rti_timer.c
@@ -77,7 +77,7 @@ static void ti_rti_timer_isr(void *param)
 	sys_clock_announce(1);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 	ARG_UNUSED(ticks);

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -101,7 +101,7 @@ static void ttc_isr(const void *arg)
 	sys_clock_announce(ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 #ifdef CONFIG_TICKLESS_KERNEL
 	uint32_t cycles;

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -110,12 +110,8 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* Read counter value */
 	cycles = read_count();
 
-	/* Calculate timeout counter value */
-	if (ticks == K_TICKS_FOREVER) {
-		next_cycles = cycles + CYCLES_NEXT_MAX;
-	} else {
-		next_cycles = cycles + ((uint32_t)ticks * CYCLES_PER_TICK);
-	}
+	/* Calculate timeout counter value, clamped to the hardware max */
+	next_cycles = cycles + MIN((uint32_t)ticks * CYCLES_PER_TICK, CYCLES_NEXT_MAX);
 
 	/* Set match value for the next interrupt */
 	update_match(cycles, next_cycles);

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -90,7 +90,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	uint32_t curr = ccount(), cyc, adj;
 

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -90,7 +90,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
-	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	uint32_t curr = ccount(), cyc, adj;

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -112,7 +112,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	set_ccompare(cyc - ccount_comp());
 
 	if (IS_ENABLED(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)) {
-		if (idle && ticks != K_TICKS_FOREVER) {
+		if (idle) {
 			uint64_t timeout_us =
 				((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -85,7 +85,7 @@ static void ccompare_isr(const void *arg)
 	sys_clock_announce_locked(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1, key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -134,9 +134,8 @@ bool sys_clock_is_locked(void);
  * is that one tick announcement should occur within one tick BEFORE
  * the specified expiration (that is, passing ticks==1 means "announce
  * the next tick", this convention was chosen to match legacy usage).
- * Similarly a ticks value of zero (or even negative) is legal and
- * treated identically: it simply indicates the kernel would like the
- * next tick announcement as soon as possible.
+ * Similarly a ticks value of zero is legal: it simply indicates the
+ * kernel would like the next tick announcement as soon as possible.
  *
  * Note that ticks can also be passed the special value K_TICKS_FOREVER,
  * indicating that no future timer interrupts are expected or required
@@ -168,7 +167,7 @@ bool sys_clock_is_locked(void);
  * @param idle Hint to the driver that the system is about to enter
  *        the idle state immediately after setting the timeout
  */
-void sys_clock_set_timeout(int32_t ticks, bool idle);
+void sys_clock_set_timeout(uint32_t ticks, bool idle);
 
 /**
  * @brief Timer idle exit notification
@@ -204,7 +203,7 @@ void sys_clock_idle_exit(void);
  * @param ticks Elapsed time, in ticks
  * @param key Lock key obtained from sys_clock_lock().
  */
-void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key);
+void sys_clock_announce_locked(uint32_t ticks, k_spinlock_key_t key);
 
 /**
  * @brief Announce time progress to the kernel (legacy wrapper)
@@ -216,7 +215,7 @@ void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key);
  *
  * @param ticks Elapsed time, in ticks
  */
-static inline void sys_clock_announce(int32_t ticks)
+static inline void sys_clock_announce(uint32_t ticks)
 {
 	sys_clock_announce_locked(ticks, sys_clock_lock());
 }

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -23,8 +23,18 @@
 extern "C" {
 #endif
 
-#define SYS_CLOCK_MAX_WAIT (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) \
-			    ? K_TICKS_FOREVER : INT_MAX)
+/*
+ * Maximum number of ticks the kernel will ever ask a timer driver to wait
+ * before the next sys_clock_announce(). It is half of the unsigned tick
+ * range so that the elapsed-tick count the driver eventually announces is
+ * guaranteed to fit in the (unsigned) sys_clock_announce() argument. The
+ * other half is left as slack to absorb a late announce (e.g. interrupt
+ * latency, or a timeout that fires slightly past its deadline) without
+ * overflowing that argument. The kernel caps the value passed to
+ * sys_clock_set_timeout() to this, so a driver need not clamp against the
+ * announce range and only has to honour its own cycle-count limits.
+ */
+#define SYS_CLOCK_MAX_WAIT (UINT32_MAX / 2)
 
 /**
  * @brief System Clock APIs

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -27,7 +27,7 @@ static sys_dlist_t timeout_list = SYS_DLIST_STATIC_INIT(&timeout_list);
 static struct k_spinlock timeout_lock;
 
 /* Ticks left to process in the currently-executing sys_clock_announce() */
-static int announce_remaining;
+static uint32_t announce_remaining;
 
 /* CPU id currently inside sys_clock_announce_locked()'s firing loop, or -1
  * when no CPU is. The SMP early-return below ensures at most one CPU is in
@@ -92,7 +92,7 @@ static void remove_timeout(struct _timeout *t)
 	sys_dlist_remove(&t->node);
 }
 
-static int32_t elapsed(void)
+static uint32_t elapsed(void)
 {
 	/*
 	 * While *this* CPU is executing sys_clock_announce_locked()'s firing
@@ -152,7 +152,7 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 
 	K_SPINLOCK(&timeout_lock) {
 		struct _timeout *t;
-		int32_t ticks_elapsed;
+		uint32_t ticks_elapsed;
 		bool has_elapsed = false;
 
 		if (Z_IS_TIMEOUT_RELATIVE(timeout)) {
@@ -316,7 +316,7 @@ int32_t z_get_next_timeout_expiry(void)
 	return ret;
 }
 
-void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
+void sys_clock_announce_locked(uint32_t ticks, k_spinlock_key_t key)
 {
 	/* We release the lock around the callbacks below, so on SMP
 	 * systems someone might be already running the loop.  Don't

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -120,19 +120,52 @@ static uint32_t elapsed(void)
 	       (IS_ENABLED(CONFIG_SMP) ? announce_remaining : 0);
 }
 
-static int32_t next_timeout(int32_t ticks_elapsed)
+static uint32_t next_timeout(uint32_t ticks_elapsed)
 {
 	struct _timeout *to = first();
-	int32_t ret;
+	uint32_t dticks;
 
-	if ((to == NULL) ||
-	    ((int64_t)(to->dticks - ticks_elapsed) > (int64_t)INT_MAX)) {
-		ret = SYS_CLOCK_MAX_WAIT;
-	} else {
-		ret = max(0, to->dticks - ticks_elapsed);
+	/*
+	 * sys_clock_announce() reports the ticks elapsed since the previous
+	 * announce, so the gap between two announces must not exceed
+	 * SYS_CLOCK_MAX_WAIT for the announced count to fit. The budget left
+	 * from now on is SYS_CLOCK_MAX_WAIT - ticks_elapsed; if it is already
+	 * spent ask for an announce right away.
+	 */
+	if (ticks_elapsed >= SYS_CLOCK_MAX_WAIT) {
+		return 0;
 	}
 
-	return ret;
+	/*
+	 * With nothing pending under sloppy idle, report SYS_CLOCK_MAX_WAIT
+	 * verbatim (not the budget): it is the "no deadline" value a driver
+	 * looks for to stop the clock entirely, and a skewed uptime is
+	 * acceptable. Without sloppy idle the uptime must stay correct, so
+	 * respect the budget and keep waking up.
+	 */
+	if (to == NULL) {
+		if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE)) {
+			return SYS_CLOCK_MAX_WAIT;
+		}
+		return SYS_CLOCK_MAX_WAIT - ticks_elapsed;
+	}
+
+	/*
+	 * A timeout further out than can be scheduled in one step: wait nearly
+	 * the whole budget, but stop one short of SYS_CLOCK_MAX_WAIT so it is
+	 * never mistaken for the "no deadline" value above (which would drop
+	 * the timeout under sloppy idle); an intermediate announce re-evaluates.
+	 * Testing to->dticks (which may be 64-bit) against the cap also keeps
+	 * the remaining arithmetic in 32 bits.
+	 */
+	if (to->dticks >= SYS_CLOCK_MAX_WAIT) {
+		return SYS_CLOCK_MAX_WAIT - 1 - ticks_elapsed;
+	}
+
+	/* Otherwise wait until the timeout, relative to now (0 if due). */
+	dticks = (uint32_t)to->dticks;
+
+	return (dticks > ticks_elapsed) ? (dticks - ticks_elapsed) : 0;
 }
 
 k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout)
@@ -311,7 +344,16 @@ int32_t z_get_next_timeout_expiry(void)
 	int32_t ret = (int32_t) K_TICKS_FOREVER;
 
 	K_SPINLOCK(&timeout_lock) {
-		ret = next_timeout(elapsed());
+		uint32_t t = next_timeout(elapsed());
+
+		/*
+		 * next_timeout() is unsigned; only fold it into the signed
+		 * result when it fits, otherwise leave the K_TICKS_FOREVER
+		 * default.
+		 */
+		if (t <= INT32_MAX) {
+			ret = (int32_t)t;
+		}
 	}
 	return ret;
 }


### PR DESCRIPTION
sys_clock_announce() can only carry a bounded number of elapsed ticks, yet
nothing in the core guaranteed the value handed to sys_clock_set_timeout()
respected that bound. next_timeout() capped the delay relative to "now",
while the eventual announce reports the distance from the previous announce.
When an early timeout is repeatedly cancelled and replaced by a later one,
announces are deferred and that distance can exceed the range even though
every individual set_timeout() delay was in range.

To stay correct, each tickless driver has had to clamp the programmed
deadline itself and emit intermediate announces. That makes it a latent bug
in any driver that omits the clamp (an over-long interval overflows the
elapsed-tick count reported back to the kernel), and needless complexity in
the ones that do implement it. Several in-tree drivers did not have the
clamp.

Moving the cap into the core fixes both sides: drivers that lacked the clamp
are no longer exposed, and drivers that carried it can drop it, since they
now only have to honour their own (cycle based) hardware limits.

* The kernel tick interface (sys_clock_set_timeout(), sys_clock_announce(),
  sys_clock_announce_locked() and the internal tick accounting) becomes
  unsigned. There is no notion of a negative number of ticks to schedule or
  announce, and the freed sign bit doubles the representable announce range.
  This is a mechanical, source compatible change for driver bodies.

* next_timeout() now bounds the distance from the previous announce (rather
  than from "now") to SYS_CLOCK_MAX_WAIT, which becomes UINT32_MAX/2. The
  upper half of the range is reserved as slack so a late announce (interrupt
  latency, or a timeout firing slightly past its deadline) still fits.
  Drivers no longer need to clamp for the announce range.

* The driver cleanup follows: K_TICKS_FOREVER is removed from every timer
  driver (it is a k_ticks_t concept, not a tick count one); the few drivers
  that stop the clock while idle now do so on the SYS_CLOCK_MAX_WAIT sentinel
  gated by CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE; and the obsolete announce-range
  cycle clamps (the arm_arch_timer CYCLES_MAX chain and its cohort, and hpet)
  collapse to the hardware counter width only.

Done as a sequence of single-purpose commits, each buildable on its own.


Fixes #111099
