### PR TITLE
dts: bindings: i2c: gpio-i2c: make `clock-frequency` required

### DIFF
--- a/dts/bindings/i2c/gpio-i2c.yaml
+++ b/dts/bindings/i2c/gpio-i2c.yaml
@@ -24,3 +24,5 @@ properties:
     type: phandle-array
     required: true
     description: GPIO to which the SDA pin of the I2C bus is connected.
+  clock-frequency:
+    required: true


### PR DESCRIPTION
The driver expects `clock-frequency` binding to be set.