### PR TITLE
boards: shields: nxp_m2_wifi_bt: add nxp_wifi sd_gpios overlay

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -38,7 +38,6 @@
 &usdhc1 {
 	nxp_wifi {
 		pwr-gpios = <&gpio1 19 GPIO_ACTIVE_HIGH>;
-		sd-gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_1xk_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_1xk_wifi_bt.overlay
@@ -33,7 +33,6 @@
 	nxp_wifi {
 		compatible = "nxp,wifi";
 		wakeup-gpios = <&gpio1 26 GPIO_ACTIVE_LOW>;
-		oob-gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };

--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_1xk_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_1xk_wifi_bt.overlay
@@ -33,6 +33,7 @@
 	nxp_wifi {
 		compatible = "nxp,wifi";
 		wakeup-gpios = <&gpio1 26 GPIO_ACTIVE_LOW>;
+		sd-gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };

--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_2el_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_2el_wifi_bt.overlay
@@ -33,7 +33,6 @@
 	nxp_wifi {
 		compatible = "nxp,wifi";
 		wakeup-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
-		oob-gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };

--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_2el_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_2el_wifi_bt.overlay
@@ -33,6 +33,7 @@
 	nxp_wifi {
 		compatible = "nxp,wifi";
 		wakeup-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		sd-gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };

--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_2ll_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_2ll_wifi_bt.overlay
@@ -33,7 +33,6 @@
 	nxp_wifi {
 		compatible = "nxp,wifi";
 		wakeup-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
-		oob-gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };

--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_2ll_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_2ll_wifi_bt.overlay
@@ -33,6 +33,7 @@
 	nxp_wifi {
 		compatible = "nxp,wifi";
 		wakeup-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		sd-gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };

--- a/dts/bindings/wifi/nxp,wifi.yaml
+++ b/dts/bindings/wifi/nxp,wifi.yaml
@@ -32,9 +32,3 @@ properties:
       This pin defaults to active high when consumed by the SD card. The
       property value should ensure the flags properly describe the signal
       that is presented to the driver.
-
-  oob-gpios:
-    type: phandle-array
-    description: |
-      Out of band Wi-Fi reset gpio on host platform.
-      This GPIO will be used to reset Wi-Fi controller from host side.


### PR DESCRIPTION
boards: shields: nxp_m2_wifi_bt: add nxp_wifi sd_gpios overlay
    
    Configure different sd_gpios for different M2 cards.

Revert "dts: wifi: nxp: add out of band reset gpio pin"
    
    Revert out of band reset gpio DTS, as it is duplicate with
    sd_gpio.
    
    This reverts commit 16b90a1e0ba6d0a69d186b866cfcc5153129a62f.