### PR TITLE
Bluetooth: BAP: Shell: Fix bug when updating USB streams

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3121,13 +3121,14 @@ static void clear_stream_data(struct shell_stream *sh_stream)
 	}
 #endif
 
-	sh_stream->is_rx = sh_stream->is_tx = false;
-
 #if defined(CONFIG_LIBLC3)
 	if (IS_ENABLED(CONFIG_USBD_AUDIO2_CLASS)) {
 		update_usb_streams(sh_stream);
 	}
 #endif /* CONFIG_LIBLC3 */
+
+	/* Shall be done after update_usb_streams */
+	sh_stream->is_rx = sh_stream->is_tx = false;
 }
 
 static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)


### PR DESCRIPTION
Since update_usb_streams rely on the sh_stream->rx to determine whether to update the streams, we shall not clear that before calling update_usb_streams