### PR TITLE
Eth lan865x pullup internal

### DIFF
--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -365,6 +365,18 @@ static int lan865x_init(const struct device *dev)
 	struct lan865x_data *ctx = dev->data;
 	int ret;
 
+	/* Configures rst gpio - 'rst-gpios' required property set in DT */
+	if (!gpio_is_ready_dt(&cfg->reset)) {
+		LOG_ERR("Reset GPIO device %s is not ready", cfg->reset.port->name);
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&cfg->reset, GPIO_OUTPUT_INACTIVE);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure reset GPIO, %d", ret);
+		return ret;
+	}
+
 	__ASSERT(cfg->spi.config.frequency <= LAN865X_SPI_MAX_FREQUENCY,
 		 "SPI frequency exceeds supported maximum\n");
 
@@ -412,17 +424,7 @@ static int lan865x_init(const struct device *dev)
 		K_PRIO_COOP(CONFIG_ETH_LAN865X_IRQ_THREAD_PRIO), 0, K_NO_WAIT);
 	k_thread_name_set(ctx->tid_int, "lan865x_interrupt");
 
-	/* Perform HW reset - 'rst-gpios' required property set in DT */
-	if (!gpio_is_ready_dt(&cfg->reset)) {
-		LOG_ERR("Reset GPIO device %s is not ready", cfg->reset.port->name);
-		return -ENODEV;
-	}
-
-	ret = gpio_pin_configure_dt(&cfg->reset, GPIO_OUTPUT_INACTIVE);
-	if (ret < 0) {
-		LOG_ERR("Failed to configure reset GPIO, %d", ret);
-		return ret;
-	}
+	/* Perform HW reset */
 
 	ret = net_eth_mac_load(&cfg->mac_cfg, ctx->mac_address);
 	if (ret == -ENODATA) {


### PR DESCRIPTION
Allows for you to use an internal pull up in the device tree.

Previously the reset gpio is configured after SPI tries to read from a register in LAN865x before the gpio reset is enabled, creating this SPI error.
<img width="1036" height="145" alt="zephyr_log_old" src="https://github.com/user-attachments/assets/bb79c0bb-3a9d-4766-a07b-a997afa74243" />

The reset line will also never come up
<img width="1834" height="1223" alt="zephyr_pr_old" src="https://github.com/user-attachments/assets/5aec1051-e7c2-481a-92ad-347d441fb93e" />

Moving when reset is configured allows it to come up before SPI transactions are sent
<img width="2149" height="1265" alt="zephyr_pr_new" src="https://github.com/user-attachments/assets/c612c9bc-f57b-4a75-a643-99654cb974ed" />
