### PR TITLE
tests: modules: tf-m: regression: make the CMake code reusable

### DIFF
--- a/tests/modules/tf-m/regression/CMakeLists.txt
+++ b/tests/modules/tf-m/regression/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(tfm_regression_test)
+
+include(test.cmake)

--- a/tests/modules/tf-m/regression/test.cmake
+++ b/tests/modules/tf-m/regression/test.cmake
@@ -4,12 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.20.0)
-
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-
-project(tfm_regression_test)
-
 set(TFM_TEST_REG_TEST_PATH  ${ZEPHYR_TF_M_TESTS_MODULE_DIR}/tests_reg/test)
 set(TFM_TEST_LIB_PATH  ${ZEPHYR_TF_M_TESTS_MODULE_DIR}/lib)
 set(TFM_API_NS_PATH ${CMAKE_BINARY_DIR}/tfm/api_ns)


### PR DESCRIPTION
Have a minimal CMakeLists.txt that only contains the prologue CMake code and then includes the actual logic.

This will allow downstream users to reuse all the CMake code without calling find_package() twice, which should be avoided.