### PR TITLE
west.yml: update STM32 HAL to newer Cube versions

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 8b66f0b68f40686f117179e6976f16c8103fe17f
+      revision: 8415f977f3738f425995c2327bf796696832d282
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
The following STM32Cube packages are updated:
- STM32F0: v1.11.5 -> v1.11.6
- STM32F1: v1.8.6 -> v1.8.7
- STM32F2: v1.9.5 -> v1.9.6
- STM32F3: v1.11.5 -> v1.11.6
- STM32G0: v1.6.2 -> v1.6.3
- STM32G4: v1.6.1 -> v1.6.3
- STM32H7: v1.12.1 -> v1.13.0
- STM32L0: v1.12.3 -> v1.12.4
- STM32L1: v1.10.5 -> v1.10.6
- STM32MP2: v1.2.0 -> v1.3.0
- STM32WL: v1.4.0 -> v1.5.0

PR on HAL side: https://github.com/zephyrproject-rtos/hal_stm32/pull/375