### PR TITLE
drivers: clock_control: fix RT1170 MICFIL clock init

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
+#include <zephyr/sys/util.h>
 #include <fsl_clock.h>
 #if defined(CONFIG_SOC_MIMX9352)
 #include <soc.h>
@@ -17,23 +18,54 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(clock_control);
 
+#if defined(CONFIG_SOC_SERIES_IMXRT11XX)
+/*
+ * The RT11xx MCUX clock table maps MIC root mux slot 6 to Audio PLL output.
+ * On boards that leave Audio PLL uninitialized, CLOCK_GetRootClockFreq()
+ * asserts instead of reporting that the rate is unavailable.
+ */
+#define RT11XX_MICFIL_NODE            DT_NODELABEL(micfil)
+#define RT11XX_MIC_ROOT_AUDIO_PLL_MUX kCLOCK_MIC_ClockRoot_MuxAudioPllOut
+
+static const uint32_t rt11xx_audio_pll_loop_div =
+	DT_PHA_BY_NAME_OR(RT11XX_MICFIL_NODE, pll_clocks, lp, value, 0U);
+static const uint32_t rt11xx_audio_pll_post_div =
+	DT_PHA_BY_NAME_OR(RT11XX_MICFIL_NODE, pll_clocks, pd, value, 0U);
+static const uint32_t rt11xx_audio_pll_numerator =
+	DT_PHA_BY_NAME_OR(RT11XX_MICFIL_NODE, pll_clocks, num, value, 0U);
+static const uint32_t rt11xx_audio_pll_denominator =
+	DT_PHA_BY_NAME_OR(RT11XX_MICFIL_NODE, pll_clocks, den, value, 0U);
+
+static bool mcux_ccm_rt11xx_audio_pll_ready(void)
+{
+	uint32_t reg = ANADIG_PLL->PLL_AUDIO_CTRL;
+	uint32_t ready_mask = ANADIG_PLL_PLL_AUDIO_CTRL_PLL_AUDIO_STABLE_MASK |
+			      ANADIG_PLL_PLL_AUDIO_CTRL_ENABLE_CLK_MASK;
+
+	return (reg & ready_mask) == ready_mask;
+}
+
+static void mcux_ccm_rt11xx_init_audio_pll(void)
+{
+	static const clock_audio_pll_config_t audio_pll_cfg = {
+		.loopDivider = rt11xx_audio_pll_loop_div,
+		.postDivider = rt11xx_audio_pll_post_div,
+		.numerator = rt11xx_audio_pll_numerator,
+		.denominator = rt11xx_audio_pll_denominator,
+		.ss = NULL,
+		.ssEnable = false,
+	};
+
+	CLOCK_InitAudioPll(&audio_pll_cfg);
+}
+
+#endif
+
 static int mcux_ccm_on(const struct device *dev,
 				  clock_control_subsys_t sub_system)
 {
 	uint32_t clock_name = (uintptr_t)sub_system;
 	uint32_t peripheral, instance;
-
-/*
- * RT11xx MICFIL clocking:
- * - Peripheral gate is kCLOCK_Pdm (LPCG)
- * - Root clock is kCLOCK_Root_Mic (PDM_CLK_ROOT)
- */
-#if defined(CONFIG_SOC_SERIES_IMXRT11XX)
-	if (clock_name == IMX_CCM_PDM_CLK) {
-		CLOCK_EnableClock(kCLOCK_Pdm);
-		return 0;
-	}
-#endif
 
 	peripheral = (clock_name & IMX_CCM_PERIPHERAL_MASK);
 	instance = (clock_name & IMX_CCM_INSTANCE_MASK);
@@ -62,6 +94,11 @@ static int mcux_ccm_on(const struct device *dev,
 		return 0;
 #endif
 #endif
+#if defined(CONFIG_SOC_SERIES_IMXRT11XX)
+	case IMX_CCM_PDM_CLK:
+		CLOCK_EnableClock(kCLOCK_Pdm);
+		return 0;
+#endif
 #ifdef CONFIG_MEMC_MCUX_FLEXSPI
 #ifdef CONFIG_SOC_MIMX9352
 	case IMX_CCM_FLEXSPI_CLK:
@@ -87,17 +124,6 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 {
 	uint32_t clock_name = (size_t) sub_system;
 	uint32_t clock_root, peripheral, instance;
-
-/*
- * RT11xx MICFIL clock query:
- * IMX_CCM_PDM_CLK should report the MIC root clock (PDM_CLK_ROOT).
- */
-#if defined(CONFIG_SOC_SERIES_IMXRT11XX)
-	if (clock_name == IMX_CCM_PDM_CLK) {
-		*rate = CLOCK_GetRootClockFreq(kCLOCK_Root_Mic);
-		return 0;
-	}
-#endif
 
 	peripheral = (clock_name & IMX_CCM_PERIPHERAL_MASK);
 	instance = (clock_name & IMX_CCM_INSTANCE_MASK);
@@ -217,6 +243,22 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 		clock_root = kCLOCK_Root_Sai4;
 		break;
 #endif
+#endif
+#if defined(CONFIG_SOC_SERIES_IMXRT11XX)
+	case IMX_CCM_PDM_CLK:
+		if (DT_NODE_HAS_PROP(RT11XX_MICFIL_NODE, pll_clocks) &&
+		    !mcux_ccm_rt11xx_audio_pll_ready()) {
+			mcux_ccm_rt11xx_init_audio_pll();
+		}
+
+		if ((CLOCK_GetRootClockMux(kCLOCK_Root_Mic) == RT11XX_MIC_ROOT_AUDIO_PLL_MUX) &&
+		    !mcux_ccm_rt11xx_audio_pll_ready()) {
+			*rate = 0U;
+			return -ENOTSUP;
+		}
+
+		*rate = CLOCK_GetRootClockFreq(kCLOCK_Root_Mic);
+		return 0;
 #endif
 
 #ifdef CONFIG_ETH_NXP_ENET

--- a/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
@@ -1212,6 +1212,15 @@
 			reg = <0x40c20000 0x1000>;
 			interrupts = <202 0>;
 			clocks = <&ccm IMX_CCM_PDM_CLK 0x1f00 4>;
+			/* Source from audio PLL */
+			clock-mux = <6>;
+			podf = <192>;
+			pll-clocks = <&anatop 0 0 0>,
+				     <&anatop 0 0 32>,
+				     <&anatop 0 0 1>,
+				     <&anatop 0 0 768>,
+				     <&anatop 0 0 1000>;
+			pll-clock-names = "src", "lp", "pd", "num", "den";
 			quality-mode = <1>;
 			cic-decimation-rate = <0>;
 			fifo-watermark = <4>;

--- a/dts/bindings/audio/nxp,micfil.yaml
+++ b/dts/bindings/audio/nxp,micfil.yaml
@@ -19,6 +19,23 @@ properties:
   clocks:
     required: true
 
+  clock-mux:
+    type: int
+    description: Clock mux source for MICFIL root clock
+
+  podf:
+    type: int
+    description: Root clock divider for MICFIL
+
+  pll-clocks:
+    type: phandle-array
+    description: Audio PLL settings used for MICFIL clocking
+    specifier-space: pll-clock
+
+  pll-clock-names:
+    type: string-array
+    description: Provided names of pll-clock specifiers
+
   quality-mode:
     type: int
     enum: [0, 1, 4, 5, 6, 7]

--- a/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
+++ b/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
@@ -104,9 +104,6 @@
 #define IMX_CCM_SAI3_CLK               0x1102UL
 #define IMX_CCM_SAI4_CLK               0x1103UL
 
-/* PDM */
-#define IMX_CCM_PDM_CLK                0x1110UL /*!< PDM/MICFIL clock identifier */
-
 /* ENET */
 #define IMX_CCM_ENET_CLK               0x1200UL
 #define IMX_CCM_ENET_PLL               0x1201UL
@@ -170,6 +167,9 @@
 #define IMX_CCM_SYSCTR_BASE_CLK        0x2700UL
 /** SYS_CTR 32 kHz LPO slow clock */
 #define IMX_CCM_SYSCTR_SLOW_CLK        0x2701UL
+
+/** PDM/MICFIL clock identifier */
+#define IMX_CCM_PDM_CLK                0x2800UL
 
 /* QTMR */
 #define IMX_CCM_QTMR_CLK               0x6000UL

--- a/tests/drivers/audio/dmic_api/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/tests/drivers/audio/dmic_api/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		dmic-dev = &micfil;
+	};
+};
+
+dmic_dev: &micfil {
+	status = "okay";
+
+	channel0: micfil-channel@0 {
+		status = "okay";
+	};
+
+	channel1: micfil-channel@1 {
+		status = "okay";
+	};
+
+	channel2: micfil-channel@2 {
+		status = "okay";
+	};
+
+	channel3: micfil-channel@3 {
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Keep the RT1170 MICFIL Audio PLL initialization in the CCM clock control path, but stop rewriting the MIC root clock while serving PDM rate queries.

Reprogramming the MIC root caused RT1170 regressions during runtime. It broke the i2s_codec sample and led to MICFIL capture starvation in dmic_api. This keeps the safe Audio PLL bring-up while preserving the working MIC root configuration used by the board.

The RT1170 dmic_api overlay and testcase enablement are included so the test covers the board directly.


Assisted-by: GitHub Copilot:GPT-5.4