### PR TITLE
manifest: Update hal_silabs for SiWx91x

### DIFF
--- a/modules/hal_silabs/wiseconnect/nwp_fw_version.c
+++ b/modules/hal_silabs/wiseconnect/nwp_fw_version.c
@@ -5,7 +5,7 @@
  */
 
 /* This value needs to be updated when the Wiseconnect SDK (hal_silabs/wiseconnect) is updated
- * Currently mapped to Wiseconnect SDK 4.0.2
+ * Currently mapped to Wiseconnect SDK 4.0.3
  */
 
 #include <nwp_fw_version.h>
@@ -15,7 +15,7 @@ const sl_wifi_firmware_version_t siwx91x_nwp_fw_expected_version = {
 	.major = 2,
 	.minor = 15,
 	.security_version = 5,
-	.patch_num = 2,
+	.patch_num = 3,
 	.customer_id = 0,
-	.build_num = 2,
+	.build_num = 1,
 };

--- a/west.yml
+++ b/west.yml
@@ -248,7 +248,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 030242dfa7e0649ff7fe764899c498f1e2c68f15
+      revision: d91d60465ca99b0a8e44a429769ee759843267f7
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Update hal_silabs with latest NWP firmware, which fixes issues related to privacy for BLE Central mode and TWT for Wi-Fi. Update the version check to match the new firmware version.