### PR TITLE
Bluetooth: BAP: Shell: Don't clear do_plc in the middle of SDU

### DIFF
--- a/samples/bluetooth/bap_broadcast_sink/src/lc3.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/lc3.c
@@ -120,8 +120,6 @@ static bool decode_frame(struct lc3_data *data, size_t frame_cnt)
 			LOG_DBG("[%zu]: Performing PLC", stream->reporting_info.lc3_decoded_cnt);
 		}
 #endif /* CONFIG_INFO_REPORTING_INTERVAL > 0 */
-
-		data->do_plc = false; /* clear flag */
 	} else {
 		iso_data = net_buf_pull_mem(data->buf, octets_per_frame);
 
@@ -466,6 +464,7 @@ void lc3_enqueue_for_decoding(struct stream_rx *stream, const struct bt_iso_recv
 		LOG_WRN("Could not allocate LC3 data item");
 		return;
 	}
+	(void)memset(data, 0, sizeof(*data));
 
 	if ((info->flags & BT_ISO_FLAGS_VALID) == 0) {
 		data->do_plc = true;

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2629,8 +2629,6 @@ static bool decode_frame(struct lc3_data *data, size_t frame_cnt)
 		if ((sh_stream->rx.decoded_cnt % bap_stats_interval) == 0) {
 			bt_shell_print("[%zu]: Performing PLC", sh_stream->rx.decoded_cnt);
 		}
-
-		data->do_plc = false; /* clear flag */
 	} else {
 		iso_data = net_buf_pull_mem(data->buf, octets_per_frame);
 
@@ -2818,6 +2816,7 @@ static void audio_recv(struct bt_bap_stream *stream,
 
 			return;
 		}
+		(void)memset(data, 0, sizeof(*data));
 
 		if ((info->flags & BT_ISO_FLAGS_VALID) == 0) {
 			data->do_plc = true;


### PR DESCRIPTION
The do_plc applies to the entire PLC, and not the individual frames, so we should not clear it after doing PLC on the first frame.

Additionally this will now also do a memset after k_mem_slab_alloc to avoid having to clearing data manually before free'ing it.