### PR TITLE
twister: reports: split Reporting class by responsibility

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -4,18 +4,27 @@
 # Copyright (c) 2018 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
 import logging
 import os
 import string
 import xml.etree.ElementTree as ET
+from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from platform import system as platform_system
+from typing import TYPE_CHECKING, Any
 
 from colorama import Fore
 from twisterlib.statuses import TwisterStatus
+
+if TYPE_CHECKING:
+    from twisterlib.environment import TwisterEnv
+    from twisterlib.testinstance import TestInstance
+    from twisterlib.testplan import TestPlan
 
 logger = logging.getLogger('twister')
 
@@ -30,45 +39,22 @@ class ReportStatus(str, Enum):
 
 
 class ReportingJSONEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, Path):
-            return str(obj)
-        return super().default(obj)
+    def default(self, o):
+        if isinstance(o, Path):
+            return str(o)
+        return super().default(o)
 
 
-class Reporting:
+class XUnitXMLReport:
+    """Create a report from tests results in XUnit format."""
 
-    json_filters = {
-        'twister.json': {
-            'deny_suite': ['footprint']
-        },
-        'footprint.json': {
-            'deny_status': ['FILTER'],
-            'deny_suite': ['testcases', 'execution_time', 'recording', 'retries', 'runnable']
-        }
-    }
-
-    def __init__(self, plan, env) -> None:
-        self.plan = plan #FIXME
-        self.instances = plan.instances
-        self.platforms = plan.platforms
-        self.selected_platforms = plan.selected_platforms
+    def __init__(
+        self, env: TwisterEnv, instances: dict[str, TestInstance], selected_platforms: Iterable[str]
+    ) -> None:
         self.env = env
+        self.instances = instances
+        self.selected_platforms = selected_platforms
         self.timestamp = datetime.now().isoformat()
-        self.outdir = os.path.abspath(env.options.outdir)
-        self.instance_fail_count = plan.instance_fail_count
-        self.footprint = None
-        self.coverage_status: bool = False
-
-    @staticmethod
-    def process_log(log_file):
-        filtered_string = ""
-        if os.path.exists(log_file):
-            with open(log_file, "rb") as f:
-                log = f.read().decode("utf-8")
-                filtered_string = ''.join(filter(lambda x: x in string.printable, log))
-
-        return filtered_string
 
     @staticmethod
     def xunit_testcase(
@@ -90,7 +76,8 @@ class Reporting:
             duration = 0
 
         eleTestcase = ET.SubElement(
-            eleTestsuite, "testcase",
+            eleTestsuite,
+            "testcase",
             classname=classname,
             name=f"{name}",
             time=f"{duration}")
@@ -135,13 +122,12 @@ class Reporting:
 
         return (fails, passes, errors, skips)
 
-    # Generate a report with all testsuites instead of doing this per platform
-    def xunit_report_suites(self, json_file, filename):
+    def create_with_all_testsuites(self, json_file: str | Path, filename: str | Path) -> None:
+        """Generate a report with all testsuites instead of doing this per platform."""
 
         json_data = {}
         with open(json_file) as json_results:
             json_data = json.load(json_results)
-
 
         env = json_data.get('environment', {})
         version = env.get('zephyr_version', None)
@@ -158,12 +144,17 @@ class Reporting:
 
         for suite in suites_to_report:
             duration = 0
-            eleTestsuite = ET.SubElement(eleTestsuites, 'testsuite',
-                                            name=suite.get("name"), time="0",
-                                            timestamp = self.timestamp,
-                                            tests="0",
-                                            failures="0",
-                                            errors="0", skipped="0")
+            eleTestsuite = ET.SubElement(
+                eleTestsuites,
+                'testsuite',
+                name=suite.get("name"),
+                time="0",
+                timestamp = self.timestamp,
+                tests="0",
+                failures="0",
+                errors="0",
+                skipped="0"
+            )
             eleTSPropetries = ET.SubElement(eleTestsuite, 'properties')
             # Multiple 'property' can be added to 'properties'
             # differing by name and value
@@ -202,7 +193,14 @@ class Reporting:
         with open(filename, 'wb') as report:
             report.write(result)
 
-    def xunit_report(self, json_file, filename, selected_platform=None, full_report=False):
+    def create(
+        self,
+        json_file: str | Path,
+        filename: str | Path,
+        selected_platform: str | None = None,
+        full_report: bool = False
+    ):
+        """Create XUnit report from a Twister JSON report."""
         if selected_platform:
             selected = [selected_platform]
             logger.info(f"Writing target report for {selected_platform}...")
@@ -213,7 +211,6 @@ class Reporting:
         json_data = {}
         with open(json_file) as json_results:
             json_data = json.load(json_results)
-
 
         env = json_data.get('environment', {})
         version = env.get('zephyr_version', None)
@@ -232,13 +229,17 @@ class Reporting:
                     continue
 
             duration = 0
-            eleTestsuite = ET.SubElement(eleTestsuites, 'testsuite',
-                                            name=platform,
-                                            timestamp = self.timestamp,
-                                            time="0",
-                                            tests="0",
-                                            failures="0",
-                                            errors="0", skipped="0")
+            eleTestsuite = ET.SubElement(
+                eleTestsuites,
+                'testsuite',
+                name=platform,
+                timestamp=self.timestamp,
+                time="0",
+                tests="0",
+                failures="0",
+                errors="0",
+                skipped="0"
+            )
             eleTSPropetries = ET.SubElement(eleTestsuite, 'properties')
             # Multiple 'property' can be added to 'properties'
             # differing by name and value
@@ -292,7 +293,22 @@ class Reporting:
         with open(filename, 'wb') as report:
             report.write(result)
 
-    def json_report(self, filename, version="NA", platform=None, filters=None):
+
+class JsonReport:
+    """Create a report from tests results in JSON format."""
+
+    def __init__(self, env: TwisterEnv, instances: dict[str, TestInstance]) -> None:
+        self.env = env
+        self.instances = instances
+
+    def create(
+        self,
+        filename: str | Path,
+        version: str = "NA",
+        platform: str | None = None,
+        filters: dict[str, Any] | None = None
+    ):
+        """Create Json report and save in a file."""
         logger.info(f"Writing JSON report {filename}")
 
         if self.env.options.report_all_options:
@@ -301,13 +317,14 @@ class Reporting:
             report_options = self.env.non_default_options()
 
         report = {}
-        report["environment"] = {"os": platform_system(),
-                                 "zephyr_version": version,
-                                 "toolchain": self.env.toolchain,
-                                 "commit_date": self.env.commit_date,
-                                 "run_date": self.env.run_date,
-                                 "options": report_options
-                                 }
+        report["environment"] = {
+            "os": platform_system(),
+            "zephyr_version": version,
+            "toolchain": self.env.toolchain,
+            "commit_date": self.env.commit_date,
+            "run_date": self.env.run_date,
+            "options": report_options
+        }
         suites = []
 
         for instance in self.instances.values():
@@ -380,7 +397,7 @@ class Reporting:
                 else:
                     suite["log"] = self.process_log(build_log)
 
-                suite["reason"] = self.get_detailed_reason(instance.reason, suite["log"])
+                suite["reason"] = self.get_detailed_reason(instance.reason, suite["log"])  # type: ignore
                 # update the reason to get more details also in other reports (e.g. junit)
                 # where build log is not available
                 instance.reason = suite["reason"]
@@ -471,10 +488,10 @@ class Reporting:
 
             # Compose external data only to these properties which pass filtering.
             if 'footprint' in suite:
-                do_all = 'all' in self.env.options.footprint_report
+                do_all = 'all' in self.env.options.footprint_report  # type: ignore
                 footprint_files = { 'ROM': 'rom.json', 'RAM': 'ram.json' }
                 for k,v in footprint_files.items():
-                    if do_all or k in self.env.options.footprint_report:
+                    if do_all or k in self.env.options.footprint_report:  # type: ignore
                         footprint_fname = os.path.join(instance.build_dir, v)
                         try:
                             with open(footprint_fname) as footprint_json:
@@ -482,8 +499,6 @@ class Reporting:
                                 suite['footprint'][k] = json.load(footprint_json)
                         except FileNotFoundError:
                             logger.error(f"Missing footprint.{k} for '{instance.name}'")
-                #
-            #
 
             suites.append(suite)
 
@@ -491,6 +506,98 @@ class Reporting:
         with open(filename, 'w') as json_file:
             json.dump(report, json_file, indent=4, separators=(',',':'), cls=ReportingJSONEncoder)
 
+    @staticmethod
+    def process_log(log_file: str | Path):
+        filtered_string = ""
+        if os.path.exists(log_file):
+            with open(log_file, "rb") as f:
+                log = f.read().decode("utf-8")
+                filtered_string = ''.join(filter(lambda x: x in string.printable, log))
+
+        return filtered_string
+
+    def get_detailed_reason(self, reason: str, log: str) -> str:
+        if reason == 'CMake build failure':
+            if error_key := self._parse_cmake_build_failure(log):
+                return f"{reason} - {error_key}"
+        elif reason == 'Build failure':  # noqa SIM102
+            if error_key := self._parse_build_failure(log):
+                return f"{reason} - {error_key}"
+        return reason
+
+    @staticmethod
+    def _parse_cmake_build_failure(log: str) -> str | None:
+        last_warning = 'no warning found'
+        lines = log.splitlines()
+        for i, line in enumerate(lines):
+            if "warning: " in line:
+                last_warning = line
+            elif "devicetree error: " in line:
+                return "devicetree error"
+            elif "fatal error: " in line:
+                return line[line.index('fatal error: ') :].strip()
+            elif "error: " in line:  # error: Aborting due to Kconfig warnings
+                if "undefined symbol" in last_warning:
+                    return last_warning[last_warning.index('undefined symbol') :].strip()
+                return last_warning
+            elif "CMake Error at" in line:
+                for next_line in lines[i + 1 :]:
+                    if next_line.strip():
+                        return line + ' ' + next_line
+                return line
+        return None
+
+    @staticmethod
+    def _parse_build_failure(log: str) -> str | None:
+        last_warning = ''
+        lines = log.splitlines()
+        for i, line in enumerate(lines):
+            if "undefined reference" in line:
+                return line[line.index('undefined reference') :].strip()
+            elif "error: ld returned" in line:
+                if last_warning:
+                    return last_warning
+                elif "overflowed by" in lines[i - 1]:
+                    return "ld.bfd: region overflowed"
+                elif "ld.bfd: warning: " in lines[i - 1]:
+                    return "ld.bfd:" + lines[i - 1].split("ld.bfd:", 1)[-1]
+                return line
+            elif "error: " in line:
+                return line[line.index('error: ') :].strip()
+            elif ": in function " in line:
+                last_warning = line[line.index('in function') :].strip()
+            elif "CMake Error at" in line:
+                for next_line in lines[i + 1 :]:
+                    if next_line.strip():
+                        return line + ' ' + next_line
+                return line
+        return None
+
+
+class Reporting:
+
+    json_filters = {
+        'twister.json': {
+            'deny_suite': ['footprint']
+        },
+        'footprint.json': {
+            'deny_status': ['FILTER'],
+            'deny_suite': ['testcases', 'execution_time', 'recording', 'retries', 'runnable']
+        }
+    }
+
+    def __init__(self, plan: TestPlan, env: TwisterEnv) -> None:
+        self.plan = plan  # FIXME
+        self.instances = plan.instances
+        self.platforms = plan.platforms
+        self.selected_platforms = plan.selected_platforms
+        self.env = env
+        self.outdir = os.path.abspath(env.options.outdir)
+        self.instance_fail_count = plan.instance_fail_count
+        self.footprint = None
+        self.coverage_status = None
+        self.json_report = JsonReport(self.env, self.instances)
+        self.xunit_report = XUnitXMLReport(self.env, self.instances, self.selected_platforms)
 
     def compare_metrics(self, filename):
         # name, datatype, lower results better
@@ -631,7 +738,7 @@ class Reporting:
             )
             logger.info("-+" * 40)
 
-    def summary(self, results, duration):
+    def summary(self, results, duration: float):
         failed = 0
         run = 0
         for instance in self.instances.values():
@@ -740,7 +847,14 @@ class Reporting:
             " test configurations were only built."
         )
 
-    def save_reports(self, name, suffix, report_dir, no_update, platform_reports):
+    def save_reports(
+        self,
+        name: str,
+        suffix: str,
+        report_dir: str | Path,
+        no_update: bool,
+        platform_reports: bool
+    ) -> None:
         if not self.instances:
             return
 
@@ -761,22 +875,27 @@ class Reporting:
         if suffix:
             filename = f"{filename}_{suffix}"
 
-        if not no_update:
-            json_file = filename + ".json"
-            self.json_report(json_file, version=self.env.version,
-                             filters=self.json_filters['twister.json'])
-            if self.env.options.footprint_report is not None:
-                self.json_report(filename + "_footprint.json", version=self.env.version,
-                                 filters=self.json_filters['footprint.json'])
-            self.xunit_report(json_file, filename + ".xml", full_report=False)
-            self.xunit_report(json_file, filename + "_report.xml", full_report=True)
-            self.xunit_report_suites(json_file, filename + "_suite_report.xml")
+        if no_update:
+            return
 
-            if platform_reports:
-                self.target_report(json_file, outdir, suffix)
+        json_file = filename + ".json"
+        self.json_report.create(
+            json_file, version=self.env.version, filters=self.json_filters['twister.json']
+        )
+        if self.env.options.footprint_report is not None:
+            self.json_report.create(
+                filename + "_footprint.json",
+                version=self.env.version,
+                filters=self.json_filters['footprint.json']
+            )
+        self.xunit_report.create(json_file, filename + ".xml", full_report=False)
+        self.xunit_report.create(json_file, filename + "_report.xml", full_report=True)
+        self.xunit_report.create_with_all_testsuites(json_file, filename + "_suite_report.xml")
 
+        if platform_reports:
+            self.target_report(json_file, outdir, suffix)
 
-    def target_report(self, json_file, outdir, suffix):
+    def target_report(self, json_file: str | Path, outdir: str | Path, suffix: str) -> None:
         platforms = {repr(inst.platform):inst.platform for _, inst in self.instances.items()}
         for platform in platforms.values():
             if suffix:
@@ -785,68 +904,15 @@ class Reporting:
             else:
                 filename = os.path.join(outdir,f"{platform.normalized_name}.xml")
                 json_platform_file = os.path.join(outdir, platform.normalized_name)
-            self.xunit_report(json_file, filename, platform.name, full_report=True)
-            self.json_report(json_platform_file + ".json",
-                             version=self.env.version, platform=platform.name,
-                             filters=self.json_filters['twister.json'])
+            self.xunit_report.create(json_file, filename, platform.name, full_report=True)
+            self.json_report.create(
+                json_platform_file + ".json",
+                version=self.env.version, platform=platform.name,
+                filters=self.json_filters['twister.json']
+            )
             if self.env.options.footprint_report is not None:
-                self.json_report(json_platform_file + "_footprint.json",
-                                 version=self.env.version, platform=platform.name,
-                                 filters=self.json_filters['footprint.json'])
-
-    def get_detailed_reason(self, reason: str, log: str) -> str:
-        if reason == 'CMake build failure':
-            if error_key := self._parse_cmake_build_failure(log):
-                return f"{reason} - {error_key}"
-        elif reason == 'Build failure':  # noqa SIM102
-            if error_key := self._parse_build_failure(log):
-                return f"{reason} - {error_key}"
-        return reason
-
-    @staticmethod
-    def _parse_cmake_build_failure(log: str) -> str | None:
-        last_warning = 'no warning found'
-        lines = log.splitlines()
-        for i, line in enumerate(lines):
-            if "warning: " in line:
-                last_warning = line
-            elif "devicetree error: " in line:
-                return "devicetree error"
-            elif "fatal error: " in line:
-                return line[line.index('fatal error: ') :].strip()
-            elif "error: " in line:  # error: Aborting due to Kconfig warnings
-                if "undefined symbol" in last_warning:
-                    return last_warning[last_warning.index('undefined symbol') :].strip()
-                return last_warning
-            elif "CMake Error at" in line:
-                for next_line in lines[i + 1 :]:
-                    if next_line.strip():
-                        return line + ' ' + next_line
-                return line
-        return None
-
-    @staticmethod
-    def _parse_build_failure(log: str) -> str | None:
-        last_warning = ''
-        lines = log.splitlines()
-        for i, line in enumerate(lines):
-            if "undefined reference" in line:
-                return line[line.index('undefined reference') :].strip()
-            elif "error: ld returned" in line:
-                if last_warning:
-                    return last_warning
-                elif "overflowed by" in lines[i - 1]:
-                    return "ld.bfd: region overflowed"
-                elif "ld.bfd: warning: " in lines[i - 1]:
-                    return "ld.bfd:" + lines[i - 1].split("ld.bfd:", 1)[-1]
-                return line
-            elif "error: " in line:
-                return line[line.index('error: ') :].strip()
-            elif ": in function " in line:
-                last_warning = line[line.index('in function') :].strip()
-            elif "CMake Error at" in line:
-                for next_line in lines[i + 1 :]:
-                    if next_line.strip():
-                        return line + ' ' + next_line
-                return line
-        return None
+                self.json_report.create(
+                    json_platform_file + "_footprint.json",
+                    version=self.env.version, platform=platform.name,
+                    filters=self.json_filters['footprint.json']
+                )

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -187,10 +187,10 @@ class Twister:
         report = Reporting(tplan, env)
         plan_file = os.path.join(self.options.outdir, "testplan.json")
         if not os.path.exists(plan_file):
-            report.json_report(plan_file, env.version)
+            report.json_report.create(plan_file, env.version)
 
         if self.options.save_tests:
-            report.json_report(self.options.save_tests, env.version)
+            report.json_report.create(self.options.save_tests, env.version)
             raise SystemExit(0)
 
         if self.options.report_summary is not None:


### PR DESCRIPTION
Extract XUnitXMLReport and JsonReport classes from the monolithic Reporting class so that each class has a single, well-defined responsibility. Move build error parsing methods (_parse_cmake_build_failure, _parse_build_failure, get_detailed_reason) to a dedicated class.

Rename xunit_report() to XUnitXMLReport.create() and xunit_report_suites() to XUnitXMLReport.create_with_all_testsuites() to better reflect their purpose. Add type annotations to new class constructors and key methods.

Update Reporting.reports() to instantiate and delegate to the new classes instead of calling methods on self directly.

**Functionality has not been changed.**