### PR TITLE
i2c/rtio: handling synchronous and async operations: fixes and test

### DIFF
--- a/drivers/i2c/i2c_max32_rtio.c
+++ b/drivers/i2c/i2c_max32_rtio.c
@@ -269,33 +269,64 @@ static void i2c_max32_isr_controller(const struct device *dev, mxc_i2c_regs_t *i
 	}
 }
 
-static bool max32_start(const struct device *dev)
+/* Return true when message is started and will complete from an asynchronous
+ * handler, in which case @param status output value is meaningless.
+ * Return false when the operation is synchronous (i.e. it is completed)
+ * and set the operation status in output @param status.
+ */
+static bool max32_start(const struct device *dev, int *status)
 {
 	struct max32_i2c_data *data = dev->data;
 	struct i2c_rtio *ctx = data->ctx;
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
 	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
-	int res = 0;
+	int error;
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
-		return max32_msg_start(dev, I2C_MSG_READ | sqe->iodev_flags,
-					    sqe->rx.buf, sqe->rx.buf_len, dt_spec->addr);
+		error = max32_msg_start(dev, I2C_MSG_READ | sqe->iodev_flags, sqe->rx.buf,
+					sqe->rx.buf_len, dt_spec->addr);
+		break;
 	case RTIO_OP_TINY_TX:
 		data->second_msg_flag = 0;
-		return max32_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-					    (uint8_t *)sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
-					    dt_spec->addr);
+		error = max32_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
+					(uint8_t *)sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
+					dt_spec->addr);
+		break;
 	case RTIO_OP_TX:
-		return max32_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-					    (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
-					    dt_spec->addr);
+		error = max32_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
+					(uint8_t *)sqe->tx.buf, sqe->tx.buf_len, dt_spec->addr);
+		break;
 	case RTIO_OP_I2C_CONFIGURE:
-		res = max32_do_configure(dev, sqe->i2c_config);
-		return i2c_rtio_complete(data->ctx, res);
+		*status = max32_do_configure(dev, sqe->i2c_config);
+		return false;
 	default:
 		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);
-		return i2c_rtio_complete(data->ctx, -EINVAL);
+		*status = -EINVAL;
+		return false;
+	}
+
+	/* When max32_msg_start() fails, no asynchronous operation is started */
+	if (error != 0) {
+		*status = error;
+		return false;
+	}
+
+	return true;
+}
+
+static void max32_start_or_complete(const struct device *dev)
+{
+	struct max32_i2c_data *data = dev->data;
+	int status;
+
+	/* Process all synchronous sequences until an async one is started (which will complete
+	 * from an asynchronous handler) or the synchronous sequence is the last queued one.
+	 */
+	while (!max32_start(dev, &status)) {
+		if (!i2c_rtio_complete(data->ctx, status)) {
+			return;
+		}
 	}
 }
 
@@ -322,7 +353,7 @@ static void max32_complete(const struct device *dev, int status)
 
 	if (i2c_rtio_complete(ctx, status)) {
 		data->second_msg_flag = 1;
-		max32_start(dev);
+		max32_start_or_complete(dev);
 	} else {
 		data->second_msg_flag = 0;
 	}
@@ -334,10 +365,9 @@ static void max32_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_
 	struct i2c_rtio *const ctx = data->ctx;
 
 	if (i2c_rtio_submit(ctx, iodev_sqe)) {
-		max32_start(dev);
+		max32_start_or_complete(dev);
 	}
 }
-
 
 static void i2c_max32_isr(const struct device *dev)
 {

--- a/drivers/i2c/i2c_max32_rtio.c
+++ b/drivers/i2c/i2c_max32_rtio.c
@@ -269,11 +269,6 @@ static void i2c_max32_isr_controller(const struct device *dev, mxc_i2c_regs_t *i
 	}
 }
 
-/* Return true when message is started and will complete from an asynchronous
- * handler, in which case @param status output value is meaningless.
- * Return false when the operation is synchronous (i.e. it is completed)
- * and set the operation status in output @param status.
- */
 static bool max32_start(const struct device *dev, int *status)
 {
 	struct max32_i2c_data *data = dev->data;
@@ -315,21 +310,6 @@ static bool max32_start(const struct device *dev, int *status)
 	return true;
 }
 
-static void max32_start_or_complete(const struct device *dev)
-{
-	struct max32_i2c_data *data = dev->data;
-	int status;
-
-	/* Process all synchronous sequences until an async one is started (which will complete
-	 * from an asynchronous handler) or the synchronous sequence is the last queued one.
-	 */
-	while (!max32_start(dev, &status)) {
-		if (!i2c_rtio_complete(data->ctx, status)) {
-			return;
-		}
-	}
-}
-
 static void max32_complete(const struct device *dev, int status)
 {
 	struct max32_i2c_data *data = dev->data;
@@ -353,7 +333,7 @@ static void max32_complete(const struct device *dev, int status)
 
 	if (i2c_rtio_complete(ctx, status)) {
 		data->second_msg_flag = 1;
-		max32_start_or_complete(dev);
+		(void)i2c_rtio_run_sync_start_async(dev, ctx, max32_start);
 	} else {
 		data->second_msg_flag = 0;
 	}
@@ -365,7 +345,7 @@ static void max32_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_
 	struct i2c_rtio *const ctx = data->ctx;
 
 	if (i2c_rtio_submit(ctx, iodev_sqe)) {
-		max32_start_or_complete(dev);
+		(void)i2c_rtio_run_sync_start_async(dev, ctx, max32_start);
 	}
 }
 

--- a/drivers/i2c/i2c_mcux_lpi2c_rtio.c
+++ b/drivers/i2c/i2c_mcux_lpi2c_rtio.c
@@ -131,8 +131,8 @@ static uint32_t mcux_lpi2c_convert_flags(int msg_flags)
 	return flags;
 }
 
-static bool mcux_lpi2c_msg_start(const struct device *dev, uint8_t flags,
-				 uint8_t *buf, size_t buf_len, uint16_t i2c_addr)
+static int mcux_lpi2c_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf,
+				size_t buf_len, uint16_t i2c_addr)
 {
 	struct mcux_lpi2c_data *data = dev->data;
 	struct i2c_rtio *ctx = data->ctx;
@@ -141,7 +141,7 @@ static bool mcux_lpi2c_msg_start(const struct device *dev, uint8_t flags,
 	status_t status;
 
 	if (I2C_MSG_ADDR_10_BITS & flags) {
-		return i2c_rtio_complete(ctx, -ENOTSUP);
+		return -ENOTSUP;
 	}
 
 	/* Initialize the transfer descriptor */
@@ -171,41 +171,70 @@ static bool mcux_lpi2c_msg_start(const struct device *dev, uint8_t flags,
 	 */
 	if (status != kStatus_Success) {
 		LPI2C_MasterTransferAbort(base, &data->handle);
-		return i2c_rtio_complete(ctx, -EIO);
+		return -EIO;
 	}
 
-	return false;
+	return 0;
 }
 
-static void mcux_lpi2c_complete(const struct device *dev, int status);
-
-static bool mcux_lpi2c_start(const struct device *dev)
+/* Return true when message is started and will complete from an asynchronous
+ * handler, in which case @param status output value is meaningless.
+ * Return false when the operation is synchronous (i.e. it is completed)
+ * and set the operation status in output @param status.
+ */
+static bool mcux_lpi2c_start(const struct device *dev, int *status)
 {
 	struct mcux_lpi2c_data *data = dev->data;
 	struct i2c_rtio *ctx = data->ctx;
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
 	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
-
-	int res = 0;
+	int error;
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
-		return mcux_lpi2c_msg_start(dev, I2C_MSG_READ | sqe->iodev_flags,
-					    sqe->rx.buf, sqe->rx.buf_len, dt_spec->addr);
+		error = mcux_lpi2c_msg_start(dev, I2C_MSG_READ | sqe->iodev_flags, sqe->rx.buf,
+					     sqe->rx.buf_len, dt_spec->addr);
+		break;
 	case RTIO_OP_TINY_TX:
-		return mcux_lpi2c_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-					    (uint8_t *)sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
-					    dt_spec->addr);
+		error = mcux_lpi2c_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
+					     (uint8_t *)sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
+					     dt_spec->addr);
+		break;
 	case RTIO_OP_TX:
-		return mcux_lpi2c_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-					    (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
-					    dt_spec->addr);
+		error = mcux_lpi2c_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
+					     (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
+					     dt_spec->addr);
+		break;
 	case RTIO_OP_I2C_CONFIGURE:
-		res = mcux_lpi2c_do_configure(dev, sqe->i2c_config);
-		return i2c_rtio_complete(data->ctx, res);
+		*status = mcux_lpi2c_do_configure(dev, sqe->i2c_config);
+		return false;
 	default:
-		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);
-		return i2c_rtio_complete(data->ctx, -EINVAL);
+		LOG_ERR("Invalid op code %d for submission %p", sqe->op, (void *)sqe);
+		*status = -EINVAL;
+		return false;
+	}
+
+	/* When mcux_lpi2c_msg_start() fails, no asynchronous operation is started */
+	if (error != 0) {
+		*status = error;
+		return false;
+	}
+
+	return true;
+}
+
+static void mcux_lpi2c_start_or_complete(const struct device *dev)
+{
+	struct mcux_lpi2c_data *data = dev->data;
+	int status;
+
+	/* Process all synchronous sequences until an async one is started (which will complete
+	 * from an interrupt handler) or the synchronous sequence is the last queued one.
+	 */
+	while (!mcux_lpi2c_start(dev, &status)) {
+		if (!i2c_rtio_complete(data->ctx, status)) {
+			return;
+		}
 	}
 }
 
@@ -238,7 +267,7 @@ static void mcux_lpi2c_complete(const struct device *dev, status_t status)
 
 out:
 	if (i2c_rtio_complete(ctx, ret)) {
-		mcux_lpi2c_start(dev);
+		mcux_lpi2c_start_or_complete(dev);
 	}
 }
 
@@ -248,7 +277,7 @@ static void mcux_lpi2c_submit(const struct device *dev, struct rtio_iodev_sqe *i
 	struct i2c_rtio *const ctx = data->ctx;
 
 	if (i2c_rtio_submit(ctx, iodev_sqe)) {
-		mcux_lpi2c_start(dev);
+		mcux_lpi2c_start_or_complete(dev);
 	}
 }
 

--- a/drivers/i2c/i2c_mcux_lpi2c_rtio.c
+++ b/drivers/i2c/i2c_mcux_lpi2c_rtio.c
@@ -177,11 +177,6 @@ static int mcux_lpi2c_msg_start(const struct device *dev, uint8_t flags, uint8_t
 	return 0;
 }
 
-/* Return true when message is started and will complete from an asynchronous
- * handler, in which case @param status output value is meaningless.
- * Return false when the operation is synchronous (i.e. it is completed)
- * and set the operation status in output @param status.
- */
 static bool mcux_lpi2c_start(const struct device *dev, int *status)
 {
 	struct mcux_lpi2c_data *data = dev->data;
@@ -223,21 +218,6 @@ static bool mcux_lpi2c_start(const struct device *dev, int *status)
 	return true;
 }
 
-static void mcux_lpi2c_start_or_complete(const struct device *dev)
-{
-	struct mcux_lpi2c_data *data = dev->data;
-	int status;
-
-	/* Process all synchronous sequences until an async one is started (which will complete
-	 * from an interrupt handler) or the synchronous sequence is the last queued one.
-	 */
-	while (!mcux_lpi2c_start(dev, &status)) {
-		if (!i2c_rtio_complete(data->ctx, status)) {
-			return;
-		}
-	}
-}
-
 static void mcux_lpi2c_complete(const struct device *dev, status_t status)
 {
 	const struct mcux_lpi2c_config *config = dev->config;
@@ -267,7 +247,7 @@ static void mcux_lpi2c_complete(const struct device *dev, status_t status)
 
 out:
 	if (i2c_rtio_complete(ctx, ret)) {
-		mcux_lpi2c_start_or_complete(dev);
+		(void)i2c_rtio_run_sync_start_async(dev, ctx, mcux_lpi2c_start);
 	}
 }
 
@@ -277,10 +257,9 @@ static void mcux_lpi2c_submit(const struct device *dev, struct rtio_iodev_sqe *i
 	struct i2c_rtio *const ctx = data->ctx;
 
 	if (i2c_rtio_submit(ctx, iodev_sqe)) {
-		mcux_lpi2c_start_or_complete(dev);
+		(void)i2c_rtio_run_sync_start_async(dev, ctx, mcux_lpi2c_start);
 	}
 }
-
 
 static void mcux_lpi2c_master_transfer_callback(LPI2C_Type *base,
 						lpi2c_master_handle_t *handle,

--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -37,8 +37,8 @@ BUILD_ASSERT(
 
 static void i2c_nrfx_twi_rtio_complete(const struct device *dev, int status);
 
-static bool i2c_nrfx_twi_rtio_msg_start(const struct device *dev, uint8_t flags,
-					uint8_t *buf, size_t buf_len, uint16_t i2c_addr)
+static int i2c_nrfx_twi_rtio_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf,
+				       size_t buf_len, uint16_t i2c_addr)
 {
 	struct i2c_nrfx_twi_common_data *data = dev->data;
 	struct i2c_nrfx_twi_rtio_data *const dev_data = dev->data;
@@ -57,11 +57,9 @@ static bool i2c_nrfx_twi_rtio_msg_start(const struct device *dev, uint8_t flags,
 	if (ret != 0) {
 		nrfx_twi_disable(&data->twi);
 		dev_data->twi_enabled = false;
-
-		return i2c_rtio_complete(ctx, ret);
 	}
 
-	return false;
+	return ret;
 }
 
 static void i2c_nrfx_twi_rtio_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, void *userdata)
@@ -71,44 +69,73 @@ static void i2c_nrfx_twi_rtio_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, voi
 	i2c_nrfx_twi_rtio_complete(dev, 0);
 }
 
-static bool i2c_nrfx_twi_rtio_start(const struct device *dev)
+/* Return true when message is started and will complete from an asynchronous
+ * handler, in which case @param status output value is meaningless.
+ * Return false when the operation is synchronous (i.e. it is completed)
+ * and set the operation status in output @param status.
+ */
+static bool i2c_nrfx_twi_rtio_start(const struct device *dev, int *status)
 {
 	struct i2c_nrfx_twi_rtio_data *const dev_data = dev->data;
 	struct i2c_rtio *ctx = dev_data->ctx;
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
 	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
 	struct rtio_iodev_sqe *iodev_sqe;
+	int error;
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
-		return i2c_nrfx_twi_rtio_msg_start(dev, I2C_MSG_READ | sqe->iodev_flags,
-						   sqe->rx.buf, sqe->rx.buf_len, dt_spec->addr);
+		error = i2c_nrfx_twi_rtio_msg_start(dev, I2C_MSG_READ | sqe->iodev_flags,
+						    sqe->rx.buf, sqe->rx.buf_len, dt_spec->addr);
+		break;
 	case RTIO_OP_TINY_TX:
-		return i2c_nrfx_twi_rtio_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-						   (uint8_t *)sqe->tiny_tx.buf,
-						   sqe->tiny_tx.buf_len, dt_spec->addr);
+		error = i2c_nrfx_twi_rtio_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
+						    (uint8_t *)sqe->tiny_tx.buf,
+						    sqe->tiny_tx.buf_len, dt_spec->addr);
+		break;
 	case RTIO_OP_TX:
-		return i2c_nrfx_twi_rtio_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-						   (uint8_t *)sqe->tx.buf,
-						   sqe->tx.buf_len, dt_spec->addr);
+		error = i2c_nrfx_twi_rtio_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
+						    (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
+						    dt_spec->addr);
+		break;
 	case RTIO_OP_I2C_CONFIGURE:
-		(void)i2c_nrfx_twi_configure(dev, sqe->i2c_config);
-		/** This request will not generate an event therefore, this
-		 * code immediately submits a CQE in order to unblock
-		 * i2c_rtio_configure.
-		 */
-		return i2c_rtio_complete(ctx, 0);
+		*status = i2c_nrfx_twi_configure(dev, sqe->i2c_config);
+		return false;
 	case RTIO_OP_I2C_RECOVER:
-		(void)i2c_nrfx_twi_recover_bus(dev);
+		*status = i2c_nrfx_twi_recover_bus(dev);
 		return false;
 	case RTIO_OP_AWAIT:
 		iodev_sqe = CONTAINER_OF(sqe, struct rtio_iodev_sqe, sqe);
 		rtio_iodev_sqe_await_signal(iodev_sqe, i2c_nrfx_twi_rtio_sqe_signaled,
 					    (void *)dev);
+		*status = 0;
 		return false;
 	default:
 		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);
-		return i2c_rtio_complete(ctx, -EINVAL);
+		*status = -EINVAL;
+		return false;
+	}
+
+	if (error != 0) {
+		*status = error;
+		return false;
+	}
+
+	return true;
+}
+
+static void i2c_nrfx_twi_rtio_start_or_complete(const struct device *dev)
+{
+	struct i2c_nrfx_twi_rtio_data *data = dev->data;
+	int status;
+
+	/* Process all synchronous sequences until an async one is started (which will complete
+	 * from an asynchronous handler) or the synchronous sequence is the last queued one.
+	 */
+	while (!i2c_nrfx_twi_rtio_start(dev, &status)) {
+		if (!i2c_rtio_complete(data->ctx, status)) {
+			return;
+		}
 	}
 }
 
@@ -119,7 +146,7 @@ static void i2c_nrfx_twi_rtio_complete(const struct device *dev, int status)
 	struct i2c_rtio *const ctx = data->ctx;
 
 	if (i2c_rtio_complete(ctx, status)) {
-		(void)i2c_nrfx_twi_rtio_start(dev);
+		i2c_nrfx_twi_rtio_start_or_complete(dev);
 	} else {
 		nrfx_twi_disable(&data->twi);
 		data->twi_enabled = false;
@@ -169,7 +196,7 @@ static void i2c_nrfx_twi_rtio_submit(const struct device *dev, struct rtio_iodev
 	struct i2c_rtio *const ctx = data->ctx;
 
 	if (i2c_rtio_submit(ctx, iodev_seq)) {
-		(void)i2c_nrfx_twi_rtio_start(dev);
+		i2c_nrfx_twi_rtio_start_or_complete(dev);
 	}
 }
 

--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -69,11 +69,6 @@ static void i2c_nrfx_twi_rtio_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, voi
 	i2c_nrfx_twi_rtio_complete(dev, 0);
 }
 
-/* Return true when message is started and will complete from an asynchronous
- * handler, in which case @param status output value is meaningless.
- * Return false when the operation is synchronous (i.e. it is completed)
- * and set the operation status in output @param status.
- */
 static bool i2c_nrfx_twi_rtio_start(const struct device *dev, int *status)
 {
 	struct i2c_nrfx_twi_rtio_data *const dev_data = dev->data;
@@ -124,21 +119,6 @@ static bool i2c_nrfx_twi_rtio_start(const struct device *dev, int *status)
 	return true;
 }
 
-static void i2c_nrfx_twi_rtio_start_or_complete(const struct device *dev)
-{
-	struct i2c_nrfx_twi_rtio_data *data = dev->data;
-	int status;
-
-	/* Process all synchronous sequences until an async one is started (which will complete
-	 * from an asynchronous handler) or the synchronous sequence is the last queued one.
-	 */
-	while (!i2c_nrfx_twi_rtio_start(dev, &status)) {
-		if (!i2c_rtio_complete(data->ctx, status)) {
-			return;
-		}
-	}
-}
-
 static void i2c_nrfx_twi_rtio_complete(const struct device *dev, int status)
 {
 	/** Finalize if there are no more pending xfers */
@@ -146,7 +126,7 @@ static void i2c_nrfx_twi_rtio_complete(const struct device *dev, int status)
 	struct i2c_rtio *const ctx = data->ctx;
 
 	if (i2c_rtio_complete(ctx, status)) {
-		i2c_nrfx_twi_rtio_start_or_complete(dev);
+		(void)i2c_rtio_run_sync_start_async(dev, ctx, i2c_nrfx_twi_rtio_start);
 	} else {
 		nrfx_twi_disable(&data->twi);
 		data->twi_enabled = false;
@@ -196,7 +176,7 @@ static void i2c_nrfx_twi_rtio_submit(const struct device *dev, struct rtio_iodev
 	struct i2c_rtio *const ctx = data->ctx;
 
 	if (i2c_rtio_submit(ctx, iodev_seq)) {
-		i2c_nrfx_twi_rtio_start_or_complete(dev);
+		(void)i2c_rtio_run_sync_start_async(dev, data->ctx, i2c_nrfx_twi_rtio_start);
 	}
 }
 

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -43,11 +43,6 @@ static void i2c_nrfx_twim_rtio_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, vo
 	(void)i2c_nrfx_twim_rtio_complete(dev, 0);
 }
 
-/* Return true when message is started and will complete from an asynchronous
- * handler, in which case @param status output value is meaningless.
- * Return false when the operation is synchronous (i.e. it is completed)
- * and set the operation status in output @param status.
- */
 static bool i2c_nrfx_twim_rtio_start(const struct device *dev, int *status)
 {
 	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
@@ -136,33 +131,18 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev, int *status)
 	return true;
 }
 
-/* Start RTIO operations until there are no more queued or an async operation is pending */
-static void i2c_nrfx_twim_rtio_start_or_complete(const struct device *dev)
-{
-	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
-	int status;
-
-	/* Process all synchronous sequences until an async one is started (which will complete
-	 * later) or the synchronous sequence is the last queued one.
-	 */
-	while (!i2c_nrfx_twim_rtio_start(dev, &status)) {
-		if (!i2c_rtio_complete(config->ctx, status)) {
-			/* Release bus on completion */
-			pm_device_runtime_put(dev);
-			return;
-		}
-	}
-}
-
 static void i2c_nrfx_twim_rtio_complete(const struct device *dev, int status)
 {
 	/** Finalize if there are no more pending xfers */
 	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
-	struct i2c_rtio *ctx = config->ctx;
+	bool async_started = false;
 
-	if (i2c_rtio_complete(ctx, status)) {
-		i2c_nrfx_twim_rtio_start_or_complete(dev);
-	} else {
+	if (i2c_rtio_complete(config->ctx, status)) {
+		async_started = i2c_rtio_run_sync_start_async(dev, config->ctx,
+							      i2c_nrfx_twim_rtio_start);
+	}
+
+	if (!async_started) {
 		/* Release bus on completion */
 		pm_device_runtime_put(dev);
 	}
@@ -202,7 +182,10 @@ static void i2c_nrfx_twim_rtio_submit(const struct device *dev, struct rtio_iode
 		if (pm_device_runtime_get(dev) < 0) {
 			(void)i2c_rtio_complete(ctx, -EINVAL);
 		} else {
-			i2c_nrfx_twim_rtio_start_or_complete(dev);
+			if (!i2c_rtio_run_sync_start_async(dev, config->ctx,
+							   i2c_nrfx_twim_rtio_start)) {
+				pm_device_runtime_put(dev);
+			}
 		}
 	}
 }

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -177,16 +177,22 @@ static void i2c_nrfx_twim_rtio_submit(const struct device *dev, struct rtio_iode
 {
 	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
 	struct i2c_rtio *ctx = config->ctx;
+	int ret;
 
-	if (i2c_rtio_submit(ctx, iodev_seq)) {
-		if (pm_device_runtime_get(dev) < 0) {
-			(void)i2c_rtio_complete(ctx, -EINVAL);
-		} else {
-			if (!i2c_rtio_run_sync_start_async(dev, config->ctx,
-							   i2c_nrfx_twim_rtio_start)) {
-				pm_device_runtime_put(dev);
-			}
+	if (!i2c_rtio_submit(ctx, iodev_seq)) {
+		return;
+	}
+
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		/* Flush pending transactions since we failed to get the device */
+		while (i2c_rtio_complete(ctx, ret)) {
 		}
+		return;
+	}
+
+	if (!i2c_rtio_run_sync_start_async(dev, ctx, i2c_nrfx_twim_rtio_start)) {
+		pm_device_runtime_put(dev);
 	}
 }
 

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -34,21 +34,6 @@ struct i2c_nrfx_twim_rtio_data {
 	uint16_t user_rx_buf_size;
 };
 
-static bool i2c_nrfx_twim_rtio_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf,
-					 size_t buf_len, uint16_t i2c_addr)
-{
-	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
-	struct i2c_rtio *ctx = config->ctx;
-	int ret = 0;
-
-	ret = i2c_nrfx_twim_msg_transfer(dev, flags, buf, buf_len, i2c_addr);
-	if (ret != 0) {
-		return i2c_rtio_complete(ctx, ret);
-	}
-
-	return false;
-}
-
 static void i2c_nrfx_twim_rtio_complete(const struct device *dev, int status);
 
 static void i2c_nrfx_twim_rtio_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, void *userdata)
@@ -58,7 +43,12 @@ static void i2c_nrfx_twim_rtio_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, vo
 	(void)i2c_nrfx_twim_rtio_complete(dev, 0);
 }
 
-static bool i2c_nrfx_twim_rtio_start(const struct device *dev)
+/* Return true when message is started and will complete from an asynchronous
+ * handler, in which case @param status output value is meaningless.
+ * Return false when the operation is synchronous (i.e. it is completed)
+ * and set the operation status in output @param status.
+ */
+static bool i2c_nrfx_twim_rtio_start(const struct device *dev, int *status)
 {
 	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
 	struct i2c_nrfx_twim_rtio_data *data = dev->data;
@@ -66,30 +56,34 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev)
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
 	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
 	struct rtio_iodev_sqe *iodev_sqe;
+	int error;
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
 		if (!nrf_dma_accessible_check(&config->common.twim, sqe->rx.buf)) {
 			if (sqe->rx.buf_len > config->common.msg_buf_size) {
-				return i2c_rtio_complete(ctx, -ENOSPC);
+				error = -ENOSPC;
+				break;
 			}
 
 			data->user_rx_buf = sqe->rx.buf;
 			data->user_rx_buf_size = sqe->rx.buf_len;
-			return i2c_nrfx_twim_rtio_msg_start(dev,
-							    I2C_MSG_READ | sqe->iodev_flags,
-							    config->common.msg_buf,
-							    data->user_rx_buf_size,
-							    dt_spec->addr);
+			error = i2c_nrfx_twim_msg_transfer(dev, I2C_MSG_READ | sqe->iodev_flags,
+							   config->common.msg_buf,
+							   data->user_rx_buf_size,
+							   dt_spec->addr);
+		} else {
+			data->user_rx_buf = NULL;
+			error = i2c_nrfx_twim_msg_transfer(dev, I2C_MSG_READ | sqe->iodev_flags,
+							   sqe->rx.buf, sqe->rx.buf_len,
+							   dt_spec->addr);
 		}
-
-		data->user_rx_buf = NULL;
-		return i2c_nrfx_twim_rtio_msg_start(dev, I2C_MSG_READ | sqe->iodev_flags,
-						    sqe->rx.buf, sqe->rx.buf_len, dt_spec->addr);
+		break;
 	case RTIO_OP_TINY_TX:
-		return i2c_nrfx_twim_rtio_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-						    sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
-						    dt_spec->addr);
+		error = i2c_nrfx_twim_msg_transfer(dev, I2C_MSG_WRITE | sqe->iodev_flags,
+						   sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
+						   dt_spec->addr);
+		break;
 	case RTIO_OP_TX:
 		/* If buffer is not accessible by DMA, copy it into the internal driver buffer */
 		if (!nrf_dma_accessible_check(&config->common.twim, sqe->tx.buf)) {
@@ -103,40 +97,60 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev)
 					"(the one with greater value) in the "
 					"\"%s\"' node.",
 					sqe->tx.buf_len, config->common.msg_buf_size, dev->name);
-				return i2c_rtio_complete(ctx, -ENOSPC);
+				error = -ENOSPC;
+				break;
 			}
+
 			memcpy(config->common.msg_buf, sqe->tx.buf, sqe->tx.buf_len);
 			sqe->tx.buf = config->common.msg_buf;
 		}
-		return i2c_nrfx_twim_rtio_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-						    (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
-						    dt_spec->addr);
+		error = i2c_nrfx_twim_msg_transfer(dev, I2C_MSG_WRITE | sqe->iodev_flags,
+						   (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
+						   dt_spec->addr);
+		break;
 	case RTIO_OP_I2C_CONFIGURE:
-		(void)i2c_nrfx_twim_configure(dev, sqe->i2c_config);
-		/** This request will not generate an event therefore, this
-		 * code immediately submits a CQE in order to unblock
-		 * i2c_rtio_configure.
-		 */
-		return i2c_rtio_complete(ctx, 0);
+		*status = i2c_nrfx_twim_configure(dev, sqe->i2c_config);
+		return false;
 	case RTIO_OP_I2C_RECOVER:
-		(void)i2c_nrfx_twim_recover_bus(dev);
+		*status = i2c_nrfx_twim_recover_bus(dev);
 		return false;
 	case RTIO_OP_AWAIT:
 		iodev_sqe = CONTAINER_OF(sqe, struct rtio_iodev_sqe, sqe);
 		rtio_iodev_sqe_await_signal(iodev_sqe, i2c_nrfx_twim_rtio_sqe_signaled,
 					    (void *)dev);
+		*status = 0;
 		return false;
 	default:
 		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);
-		return i2c_rtio_complete(ctx, -EINVAL);
+		error = -EINVAL;
 	}
+
+	/* When reaching this point from the above switch case, an asynchronous operation
+	 * is started only upon a successful status.
+	 */
+	if (error != 0) {
+		*status = error;
+		return false;
+	}
+
+	return true;
 }
 
 /* Start RTIO operations until there are no more queued or an async operation is pending */
-static void i2c_nrfx_twim_rtio_start_next_async(const struct device *dev)
+static void i2c_nrfx_twim_rtio_start_or_complete(const struct device *dev)
 {
-	while (i2c_nrfx_twim_rtio_start(dev)) {
-		;
+	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
+	int status;
+
+	/* Process all synchronous sequences until an async one is started (which will complete
+	 * later) or the synchronous sequence is the last queued one.
+	 */
+	while (!i2c_nrfx_twim_rtio_start(dev, &status)) {
+		if (!i2c_rtio_complete(config->ctx, status)) {
+			/* Release bus on completion */
+			pm_device_runtime_put(dev);
+			return;
+		}
 	}
 }
 
@@ -147,7 +161,7 @@ static void i2c_nrfx_twim_rtio_complete(const struct device *dev, int status)
 	struct i2c_rtio *ctx = config->ctx;
 
 	if (i2c_rtio_complete(ctx, status)) {
-		i2c_nrfx_twim_rtio_start_next_async(dev);
+		i2c_nrfx_twim_rtio_start_or_complete(dev);
 	} else {
 		/* Release bus on completion */
 		pm_device_runtime_put(dev);
@@ -188,7 +202,7 @@ static void i2c_nrfx_twim_rtio_submit(const struct device *dev, struct rtio_iode
 		if (pm_device_runtime_get(dev) < 0) {
 			(void)i2c_rtio_complete(ctx, -EINVAL);
 		} else {
-			i2c_nrfx_twim_rtio_start_next_async(dev);
+			i2c_nrfx_twim_rtio_start_or_complete(dev);
 		}
 	}
 }

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -79,9 +79,6 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 	return ret;
 }
 
-/* Return true when message is started and will complete from an interrupt
- * handler, otherwise return false and set return status in @param status.
- */
 static bool i2c_stm32_start(const struct device *dev, int *status)
 {
 	struct i2c_stm32_data *data = dev->data;
@@ -137,29 +134,16 @@ static bool i2c_stm32_start(const struct device *dev, int *status)
 	return true;
 }
 
-static void i2c_stm32_start_or_complete(const struct device *dev)
-{
-	struct i2c_stm32_data *data = dev->data;
-	int status;
-
-	/* Process all synchronous sequences until an async one is started (which will complete
-	 * from an asynchronous handler) or the synchronous sequence is the last queued one.
-	 */
-	while (!i2c_stm32_start(dev, &status)) {
-		if (!i2c_rtio_complete(data->ctx, status)) {
-			i2c_stm32_pm_put(dev);
-			return;
-		}
-	}
-}
-
 void i2c_stm32_rtio_complete(const struct device *dev, int status)
 {
 	struct i2c_stm32_data *data = dev->data;
+	bool async_started = false;
 
 	if (i2c_rtio_complete(data->ctx, status)) {
-		i2c_stm32_start_or_complete(dev);
-	} else {
+		async_started = i2c_rtio_run_sync_start_async(dev, data->ctx, i2c_stm32_start);
+	}
+
+	if (!async_started) {
 		i2c_stm32_pm_put(dev);
 	}
 }
@@ -246,7 +230,9 @@ static void i2c_stm32_submit(const struct device *dev, struct rtio_iodev_sqe *io
 			do {
 			} while (i2c_rtio_complete(data->ctx, ret));
 		} else {
-			i2c_stm32_start_or_complete(dev);
+			if (!i2c_rtio_run_sync_start_async(dev, data->ctx, i2c_stm32_start)) {
+				i2c_stm32_pm_put(dev);
+			}
 		}
 	}
 }

--- a/include/zephyr/drivers/i2c/rtio.h
+++ b/include/zephyr/drivers/i2c/rtio.h
@@ -43,6 +43,16 @@ struct i2c_rtio {
 	};
 
 /**
+ * @brief Callback to start the pending I2C operation
+ *
+ * @param dev I2C bus
+ * @param status Output return code of the operation if the function returns
+ * false (i.e. message completed synchronously), otherwise output value is meaningless
+ * @retval true if an asynchronous operation is started, false otherwise
+ */
+typedef bool (*i2c_rtio_cb_run_sync_start_async)(const struct device *dev, int *status);
+
+/**
  * @brief Copy an array of i2c_msgs to rtio submissions and a transaction
  *
  * @retval sqe Last sqe setup in the copy
@@ -107,6 +117,32 @@ int i2c_rtio_transfer(struct i2c_rtio *ctx, struct i2c_msg *msgs, uint8_t num_ms
  * See i2c_recover().
  */
 int i2c_rtio_recover(struct i2c_rtio *ctx);
+
+/**
+ * @brief Process synchronous operations until an asynchronous operation
+ * is started or there are no more queued operations.
+ *
+ * @param dev I2C bus
+ * @param ctx I2C RTIO driver context
+ * @param cb Callback to process a synchronous operation or start an async operation
+ *
+ * @retval true if an asynchronous message is started, false otherwise.
+ */
+static inline bool i2c_rtio_run_sync_start_async(const struct device *dev, struct i2c_rtio *ctx,
+						 i2c_rtio_cb_run_sync_start_async cb)
+{
+	int status;
+
+	__ASSERT_NO_MSG(cb != NULL);
+
+	while (!cb(dev, &status)) {
+		if (!i2c_rtio_complete(ctx, status)) {
+			return false;
+		}
+	}
+
+	return true;
+}
 
 #ifdef __cplusplus
 }

--- a/samples/drivers/i2c/rtio_loopback/src/main.c
+++ b/samples/drivers/i2c/rtio_loopback/src/main.c
@@ -264,12 +264,34 @@ static int sample_rtio_configure_and_recover(void)
 	return ret;
 }
 
-/* This is functionally identical to sample_standard_write_read() but uses RTIO */
-static int sample_rtio_write_read(void)
+static int sample_rtio_maybe_configure_write_read(bool do_configure)
 {
 	struct rtio_sqe *wr_sqe, *rd_sqe;
 	struct rtio_cqe *wr_rd_cqe;
 	int ret;
+
+	if (do_configure) {
+		struct rtio_sqe *sqe;
+
+		/*
+		 * We allocate one submission queue event (SQE) as defined by RTIO_DEFINE()
+		 * and configure it to apply an I2C controller configuration using
+		 * sample_rtio_iodev.
+		 */
+		sqe = rtio_sqe_acquire(&sample_rtio);
+		rtio_sqe_prep_i2c_configure(sqe,
+					    &sample_rtio_iodev,
+					    0,
+					    I2C_CONTROLLER_DEV_CONFIG,
+					    NULL);
+
+		/*
+		 * In this case, we don't actually care which submission is handled first, we
+		 * chain them to ensure they remain ordered, so when we read the CQEs after
+		 * they have completed, we know that the first CQE is the result of the first SQE.
+		 */
+		sqe->flags |= RTIO_SQE_CHAINED;
+	}
 
 	/*
 	 * We allocate one of the 3 submission queue events (SQEs) as defined by
@@ -317,9 +339,20 @@ static int sample_rtio_write_read(void)
 	 * In this case, we wait for the two SQEs to be completed before
 	 * continuing, similar to calling i2c_transfer().
 	 */
-	ret = rtio_submit(&sample_rtio, 2);
+	ret = rtio_submit(&sample_rtio, do_configure ? 3 : 2);
 	if (ret) {
 		return ret;
+	}
+
+	if (do_configure) {
+		struct rtio_cqe *cqe;
+
+		/* This is the result of the i2c configure SQE */
+		cqe = rtio_cqe_consume(&sample_rtio);
+		if (cqe->result) {
+			ret = cqe->result;
+		}
+		rtio_cqe_release(&sample_rtio, cqe);
 	}
 
 	/*
@@ -337,6 +370,17 @@ static int sample_rtio_write_read(void)
 	/* Release the CQE after having checked its result. */
 	rtio_cqe_release(&sample_rtio, wr_rd_cqe);
 	return ret;
+}
+
+/* This is functionally identical to sample_standard_write_read() but uses RTIO */
+static int sample_rtio_write_read(void)
+{
+	return sample_rtio_maybe_configure_write_read(false);
+}
+
+static int sample_rtio_configure_write_read(void)
+{
+	return sample_rtio_maybe_configure_write_read(true);
 }
 
 static void rtio_write_read_done_callback(struct rtio *r, const struct rtio_sqe *sqe,
@@ -502,6 +546,21 @@ int main(void)
 	ret = sample_rtio_write_read();
 	if (ret) {
 		printk("%s %s (%d)\n", "rtio_write_read", "failed", ret);
+		return 0;
+	}
+
+	ret = sample_validate_write_read();
+	if (ret) {
+		printk("%s %s (%d)\n", "rtio_write_read", "corrupted", ret);
+		return 0;
+	}
+
+	sample_reset_buffers();
+
+	printk("%s %s\n", "rtio_configure_write_read", "running");
+	ret = sample_rtio_configure_write_read();
+	if (ret) {
+		printk("%s %s (%d)\n", "rtio_configure_write_read", "failed", ret);
 		return 0;
 	}
 

--- a/samples/drivers/i2c/rtio_loopback/src/main.c
+++ b/samples/drivers/i2c/rtio_loopback/src/main.c
@@ -331,12 +331,12 @@ static int sample_rtio_write_read(void)
 	 */
 	wr_rd_cqe = rtio_cqe_consume(&sample_rtio);
 	if (wr_rd_cqe->result) {
-		return wr_rd_cqe->result;
+		ret = wr_rd_cqe->result;
 	}
 
 	/* Release the CQE after having checked its result. */
 	rtio_cqe_release(&sample_rtio, wr_rd_cqe);
-	return 0;
+	return ret;
 }
 
 static void rtio_write_read_done_callback(struct rtio *r, const struct rtio_sqe *sqe,


### PR DESCRIPTION
This P-R proposes a test sequence for the I2C RTIO drivers that submits 3 operations: configure then read then write.
Many in-tree driver do not support this RTIO sequence series because badly handling the execution of the 2 async operations (read, write) after the synchronous one (configure).

While this test is proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111068, the current P-R proposes a correction for the several I2C RTIO intree drivers that would fails on this test.

This is an RFC P-R since, aside the STM32 drivers, I quite blindly modified the other drivers. I tried to be consistent, but could not test.

This P-R also includes a fix for a missing call to pm_device_runtime_put() in NRFx/Twim RTIO driver.

~~The STM32 patches (the 3 first commits of this sereis) are already part of another P-R: https://github.com/zephyrproject-rtos/zephyr/pull/110623~~ **(now merged)**

The series ends with the proposed tests in the hope that one having the required HW can easily test theses changes.
