### PR TITLE
net: l2: ethernet: validate MAC after driver start

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -824,6 +824,8 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 {
 	const struct device *dev = net_if_get_device(iface);
 	const struct ethernet_api *eth = dev->api;
+	struct net_linkaddr *mac_addr;
+	int ret;
 
 	NET_ASSERT(eth != NULL);
 
@@ -833,10 +835,31 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 		if (eth->stop) {
 			return eth->stop(dev, iface);
 		}
-	} else {
-		if (eth->start) {
-			return eth->start(dev, iface);
+
+		return 0;
+	}
+
+	if (eth->start) {
+		ret = eth->start(dev, iface);
+		if (ret < 0) {
+			return ret;
 		}
+	}
+
+	/* Validate the MAC address after the driver has started so that
+	 * companion chipsets which fetch their address from firmware/OTP
+	 * during bring-up have a valid link address by this point. A failure
+	 * here is terminal: net_if_up() fails and the interface is left
+	 * unusable, the same as if eth->start() itself had failed, so there
+	 * is no need to roll back with eth->stop() (which not every driver
+	 * implements).
+	 */
+	mac_addr = net_if_get_link_addr(iface);
+
+	if ((mac_addr->len != NET_ETH_ADDR_LEN) ||
+	    !net_eth_is_addr_valid((struct net_eth_addr *)mac_addr->addr)) {
+		NET_ERR("Invalid MAC address for iface %d (%p)", net_if_get_by_iface(iface), iface);
+		return -EINVAL;
 	}
 
 	return 0;


### PR DESCRIPTION
 net: l2: ethernet: validate MAC after driver start
    
  Commit 481035cf8e1 ("net: ethernet: check mac address when bringing a
  eth iface up") validated the link address before eth->start() was
  called. That broke Wi-Fi interfaces whose MAC is learnt from firmware
  during bring-up (e.g. nRF70 reads it from OTP once the companion
  firmware boots), leaving them unable to admin-up and preventing WPA
  supplicant from registering them. The offending commit was reverted in
  d8065e9f87c to unblock nRF Wi-Fi.
  
  Reintroduce the validation, but run eth->start() first so that drivers
  which populate their address during bring-up have a valid link address
  by the time it is checked. This keeps the useful diagnostic for
  misconfigured MACs while supporting drivers that only know their
  address after start.
  
  A failure of the post-start validation is terminal: net_if_up() fails
  and the interface is left unusable, the same as if eth->start() itself
  had failed. Return -EINVAL directly rather than rolling back with
  eth->stop(), so the behaviour is consistent for drivers that do not
  implement a stop op.
  
  Signed-off-by: Chaitanya Tata <Chaitanya.Tata@nordicsemi.no>
  Assisted-by: Claude:claude-opus-4.8