### PR TITLE
drivers: mspi: dw: Add software CE-break and timing support

### DIFF
--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -1816,6 +1816,14 @@ static int api_timing_config(const struct device *dev,
 	struct mspi_dw_data *dev_data = dev->data;
 	struct mspi_dw_timing_cfg *config = cfg;
 
+	/* MSPI_TIMING_PARAM_DUMMY indicates that the caller has no
+	 * platform-specific timing parameters to configure. Accept
+	 * it as a no-op.
+	 */
+	if (param_mask == MSPI_TIMING_PARAM_DUMMY) {
+		return 0;
+	}
+
 	if (param_mask & MSPI_DW_RX_TIMING_CFG) {
 		dev_data->rx_sample_dly = config->rx_sample_dly;
 		return 0;

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -51,6 +51,14 @@ struct mspi_dw_data {
 	uint32_t baudr;
 	uint32_t rx_sample_dly;
 
+	/* Software auto-CE-break. */
+	uint32_t mem_boundary;
+	uint32_t time_to_break;
+	uint32_t max_clocks_per_ce;
+
+	/* Active sub-packet fed to start_next_packet(). */
+	struct mspi_xfer_packet sub_pkt;
+
 #if defined(CONFIG_MSPI_XIP)
 	uint32_t xip_freq;
 	struct xip_params xip_params_stored;
@@ -244,6 +252,8 @@ static void async_packet_work_handler(struct k_work *work)
 			LOG_DBG("Starting next packet (%d/%d)",
 				dev_data->packets_done + 1,
 				dev_data->xfer.num_packet);
+
+			dev_data->sub_pkt = dev_data->xfer.packets[dev_data->packets_done];
 
 			rc = start_next_packet(dev);
 			if (rc >= 0) {
@@ -454,8 +464,7 @@ static void handle_end_of_packet(struct mspi_dw_data *dev_data)
 static void handle_fifos(const struct device *dev)
 {
 	struct mspi_dw_data *dev_data = dev->data;
-	const struct mspi_xfer_packet *packet =
-		&dev_data->xfer.packets[dev_data->packets_done];
+	const struct mspi_xfer_packet *packet = &dev_data->sub_pkt;
 	bool finished = false;
 
 	if (packet->dir == MSPI_TX) {
@@ -854,17 +863,15 @@ static int _api_dev_config(const struct device *dev,
 	}
 
 	if (param_mask & MSPI_DEVICE_CONFIG_MEM_BOUND) {
-		if (cfg->mem_boundary) {
-			LOG_ERR("Auto CE break is not supported.");
-			return -ENOTSUP;
+		if (cfg->mem_boundary && (cfg->mem_boundary & (cfg->mem_boundary - 1))) {
+			LOG_ERR("mem_boundary must be a power of two");
+			return -EINVAL;
 		}
+		dev_data->mem_boundary = cfg->mem_boundary;
 	}
 
 	if (param_mask & MSPI_DEVICE_CONFIG_BREAK_TIME) {
-		if (cfg->time_to_break) {
-			LOG_ERR("Auto CE break is not supported.");
-			return -ENOTSUP;
-		}
+		dev_data->time_to_break = cfg->time_to_break;
 	}
 
 	if (param_mask & MSPI_DEVICE_CONFIG_IO_MODE) {
@@ -993,6 +1000,22 @@ static int _api_dev_config(const struct device *dev,
 	/* Enable clock stretching. */
 	dev_data->spi_ctrlr0 |= SPI_CTRLR0_CLK_STRETCH_EN_BIT;
 
+	/* Precompute max clock cycles per CE assertion from tCEM budget. */
+	if (dev_data->time_to_break && dev_data->baudr) {
+		uint32_t freq_hz = dev_config->clock_frequency / dev_data->baudr;
+
+		/*
+		 * Convert time_to_break (us) to clock cycles.
+		 */
+		uint32_t max_clocks = (uint32_t)(
+			((uint64_t)dev_data->time_to_break * freq_hz) /
+			USEC_PER_SEC);
+
+		dev_data->max_clocks_per_ce = MAX(max_clocks, 1U);
+	} else {
+		dev_data->max_clocks_per_ce = 0;
+	}
+
 	return 0;
 }
 
@@ -1092,8 +1115,7 @@ static int start_next_packet(const struct device *dev)
 {
 	const struct mspi_dw_config *dev_config = dev->config;
 	struct mspi_dw_data *dev_data = dev->data;
-	const struct mspi_xfer_packet *packet =
-		&dev_data->xfer.packets[dev_data->packets_done];
+	const struct mspi_xfer_packet *packet = &dev_data->sub_pkt;
 	bool data_only_packet = dev_data->xfer.cmd_length == 0 &&
 				dev_data->xfer.addr_length == 0;
 	bool xip_enabled = COND_CODE_1(CONFIG_MSPI_XIP,
@@ -1443,6 +1465,141 @@ static int start_next_packet(const struct device *dev)
 	return finalize_packet(dev, rc);
 }
 
+/**
+ * Run one user-visible packet, splitting at address-aligned mem_boundary
+ * and/or tCEM clock budget limits if configured.
+ *
+ * For async transfers, mem_boundary splitting is not supported and is
+ * rejected before reaching this function.
+ */
+static int run_one_packet(const struct device *dev, const struct mspi_xfer_packet *src)
+{
+	struct mspi_dw_data *dev_data = dev->data;
+	const uint32_t boundary = dev_data->mem_boundary;
+	uint32_t max_data_bytes = 0;
+	size_t done = 0;
+	int rc;
+
+	/*
+	 * Derive max_data_bytes from the tCEM clock budget by subtracting
+	 * the clocks consumed by command, address, and dummy phases, then
+	 * converting the remaining clocks to data bytes.
+	 *
+	 * Command clocks: TT0/TT1 sends the command on 1 line in SDR;
+	 *                 TT2 sends it on io_lines in SDR or DDR (INST_DDR_EN).
+	 * Address clocks: TT0 sends the address on 1 line in SDR;
+	 *                 TT1/TT2 sends it on io_lines in SDR or DDR (SPI_DDR_EN).
+	 * Dummy clocks: direct clock count, direction-specific.
+	 */
+	if (dev_data->max_clocks_per_ce) {
+		bool ddr = dev_data->spi_ctrlr0 & SPI_CTRLR0_SPI_DDR_EN_BIT;
+		bool inst_ddr = dev_data->spi_ctrlr0 & SPI_CTRLR0_INST_DDR_EN_BIT;
+		uint32_t trans_type = FIELD_GET(SPI_CTRLR0_TRANS_TYPE_MASK,
+						dev_data->spi_ctrlr0);
+		uint32_t io_lines;
+
+		switch (FIELD_GET(CTRLR0_SPI_FRF_MASK, dev_data->ctrlr0)) {
+		case CTRLR0_SPI_FRF_DUAL:
+			io_lines = 2U;
+			break;
+		case CTRLR0_SPI_FRF_QUAD:
+			io_lines = 4U;
+			break;
+		case CTRLR0_SPI_FRF_OCTAL:
+			io_lines = 8U;
+			break;
+		default:
+			io_lines = 1U;
+			break;
+		}
+
+		uint32_t cmd_bits = (uint32_t)dev_data->xfer.cmd_length * 8U;
+		uint32_t cmd_clocks =
+			(trans_type == SPI_CTRLR0_TRANS_TYPE_TT2)
+			? DIV_ROUND_UP(cmd_bits, io_lines * (inst_ddr ? 2U : 1U))
+			: cmd_bits;
+
+		uint32_t addr_bits = (uint32_t)dev_data->xfer.addr_length * 8U;
+		uint32_t addr_clocks =
+			(trans_type != SPI_CTRLR0_TRANS_TYPE_TT0)
+			? DIV_ROUND_UP(addr_bits, io_lines * (ddr ? 2U : 1U))
+			: addr_bits;
+
+		uint32_t dummy_clocks = (src->dir == MSPI_TX)
+					? (uint32_t)dev_data->xfer.tx_dummy
+					: (uint32_t)dev_data->xfer.rx_dummy;
+
+		uint32_t overhead_clocks = cmd_clocks + addr_clocks +
+					   dummy_clocks;
+		uint32_t avail_clocks;
+
+		if (dev_data->max_clocks_per_ce > overhead_clocks) {
+			avail_clocks = dev_data->max_clocks_per_ce - overhead_clocks;
+		} else {
+			LOG_WRN("tCEM overhead (%u clocks) exceeds budget "
+				"(%u clocks); time_to_break is too small",
+				overhead_clocks, dev_data->max_clocks_per_ce);
+			avail_clocks = 1U;
+		}
+
+		/* Convert remaining clocks to data bytes.
+		 * Each clock transfers io_lines bits (SDR) or
+		 * io_lines * 2 bits (DDR).
+		 */
+		uint32_t bits_per_clock = io_lines * (ddr ? 2U : 1U);
+
+		max_data_bytes = (avail_clocks * bits_per_clock) / 8U;
+		if (!max_data_bytes) {
+			max_data_bytes = 1U;
+		}
+	}
+
+	/* Determine whether splitting is actually needed. */
+	bool crosses_boundary = boundary &&
+		((src->address & (boundary - 1)) + src->num_bytes) > boundary;
+	bool exceeds_ce_limit = max_data_bytes &&
+		(src->num_bytes > max_data_bytes);
+
+	if (!crosses_boundary && !exceeds_ce_limit) {
+		dev_data->sub_pkt = *src;
+		return start_next_packet(dev);
+	}
+
+	while (done < src->num_bytes) {
+		uint32_t addr = src->address + done;
+		size_t remaining = src->num_bytes - done;
+		size_t chunk = remaining;
+
+		if (boundary) {
+			uint32_t page_off = addr & (boundary - 1);
+
+			chunk = MIN(chunk, (size_t)(boundary - page_off));
+		}
+
+		if (max_data_bytes) {
+			chunk = MIN(chunk, (size_t)max_data_bytes);
+		}
+
+		dev_data->sub_pkt = (struct mspi_xfer_packet){
+			.dir = src->dir,
+			.cmd = src->cmd,
+			.address = addr,
+			.data_buf = &src->data_buf[done],
+			.num_bytes = chunk,
+			.cb_mask = (done + chunk >= src->num_bytes) ? src->cb_mask : 0,
+		};
+
+		rc = start_next_packet(dev);
+		if (rc < 0) {
+			return rc;
+		}
+
+		done += chunk;
+	}
+
+	return 0;
+}
+
 static int finalize_packet(const struct device *dev, int rc)
 {
 	struct mspi_dw_data *dev_data = dev->data;
@@ -1541,13 +1698,14 @@ static int _api_transceive(const struct device *dev,
 	 */
 	if (req->async) {
 		dev_data->packets_done = 0;
+		dev_data->sub_pkt = req->packets[0];
 		return start_next_packet(dev);
 	}
 
 	for (dev_data->packets_done = 0;
 	     dev_data->packets_done < dev_data->xfer.num_packet;
 	     dev_data->packets_done++) {
-		rc = start_next_packet(dev);
+		rc = run_one_packet(dev, &req->packets[dev_data->packets_done]);
 		if (rc < 0) {
 			return rc;
 		}
@@ -1568,9 +1726,17 @@ static int api_transceive(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (req->async && !IS_ENABLED(CONFIG_MULTITHREADING)) {
-		LOG_ERR("Asynchronous transfers require multithreading");
-		return -ENOTSUP;
+	if (req->async) {
+		if (!IS_ENABLED(CONFIG_MULTITHREADING)) {
+			LOG_ERR("Asynchronous transfers require multithreading");
+			return -ENOTSUP;
+		}
+
+		if (dev_data->mem_boundary || dev_data->max_clocks_per_ce) {
+			LOG_ERR("Asynchronous transfers with CE-break splitting "
+				"not yet supported");
+			return -ENOTSUP;
+		}
 	}
 
 	rc = pm_device_runtime_get(dev);

--- a/drivers/mspi/mspi_dw_vendor_specific.h
+++ b/drivers/mspi/mspi_dw_vendor_specific.h
@@ -215,8 +215,8 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 {
 	struct mspi_dw_data *dev_data = dev->data;
 	const struct mspi_dw_config *config = dev->config;
-	const struct mspi_xfer_packet *packet =
-		&dev_data->xfer.packets[dev_data->packets_done];
+	const struct mspi_xfer_packet *packet = &dev_data->sub_pkt;
+
 	NRF_MSPI_Type *preg = (NRF_MSPI_Type *)config->wrapper_regs;
 
 	/* Use vendor-specific data from config - stores job and transfer lists */


### PR DESCRIPTION
**Memory Boundary and Time-Based CE-Break Support:**
 
* Added support for splitting transfers at configurable memory boundaries (`mem_boundary`) and at a maximum segment size derived from the device's tCEM time budget (`time_to_break`). The `time_to_break` value (in µs) is converted to `max_clocks_per_ce` using the actual clock rate. At transfer time, command/address/dummy phase clocks are subtracted from this budget and the remaining clocks are converted to a data byte limit, ensuring no single CE assertion exceeds the device's maximum CE-low time.
 * The new `run_one_packet` function handles splitting user-visible packets at address-aligned boundaries and/or byte-count limits. For async transfers, CE-break splitting is not yet supported and is explicitly rejected.
 * Added validation to ensure `mem_boundary` is a power of two.
 
 **Packet Handling Refactor:**
 
 * Introduced a `sub_pkt` field in `struct mspi_dw_data` to consistently track the currently active sub-packet, simplifying code paths in both the main driver and vendor-specific DMA logic. All packet access is now routed through this field.
 
 **Timing Configuration:**
 
 * Accept `MSPI_TIMING_PARAM_DUMMY` in `api_timing_config()` as a no-op for platform compatibility.