### PR TITLE
divers: spi: xec: add low power mode support

### DIFF
--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -13,6 +13,9 @@
 #include <zephyr/drivers/spi.h>
 #include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
 #include <zephyr/dt-bindings/spi/spi.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 
@@ -54,6 +57,13 @@ struct mec5_qspi_config {
 #define MEC5_QSPI_XFR_FLAG_BUSY  BIT(1)
 #define MEC5_QSPI_XFR_FLAG_LDMA  BIT(2)
 
+#ifdef CONFIG_PM_DEVICE
+enum mec5_qspi_pm_policy_state_flag {
+	MEC5_QSPI_PM_POLICY_STATE_XFR_FLAG,
+	MEC5_QSPI_PM_POLICY_STATE_FLAG_COUNT,
+};
+#endif
+
 /* Device run time data */
 struct mec5_qspi_data {
 	struct spi_context ctx; /* has pointer to struct spi_config */
@@ -72,7 +82,28 @@ struct mec5_qspi_data {
 	uint32_t freq;
 	uint32_t operation;
 	uint8_t cs;
+#ifdef CONFIG_PM_DEVICE
+	ATOMIC_DEFINE(pm_policy_state_flags, MEC5_QSPI_PM_POLICY_STATE_FLAG_COUNT);
+#endif
 };
+
+#ifdef CONFIG_PM_DEVICE
+static void mec5_qspi_pm_policy_state_lock_get(struct mec5_qspi_data *data,
+					       enum mec5_qspi_pm_policy_state_flag flag)
+{
+	if (atomic_test_and_set_bit(data->pm_policy_state_flags, flag) == 0) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	}
+}
+
+static void mec5_qspi_pm_policy_state_lock_put(struct mec5_qspi_data *data,
+					       enum mec5_qspi_pm_policy_state_flag flag)
+{
+	if (atomic_test_and_clear_bit(data->pm_policy_state_flags, flag) == 1) {
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	}
+}
+#endif
 
 static int spi_feature_support(const struct spi_config *config)
 {
@@ -420,6 +451,10 @@ static int mec5_qspi_do_xfr(const struct device *dev, const struct spi_config *c
 
 	spi_context_lock(ctx, async, cb, userdata, config);
 
+#ifdef CONFIG_PM_DEVICE
+	mec5_qspi_pm_policy_state_lock_get(data, MEC5_QSPI_PM_POLICY_STATE_XFR_FLAG);
+#endif
+
 	ret = mec5_qspi_configure(dev, config);
 	if (ret != 0) {
 		goto do_xfr_exit;
@@ -446,6 +481,9 @@ static int mec5_qspi_do_xfr(const struct device *dev, const struct spi_config *c
 	}
 
 do_xfr_exit:
+#ifdef CONFIG_PM_DEVICE
+	mec5_qspi_pm_policy_state_lock_put(data, MEC5_QSPI_PM_POLICY_STATE_XFR_FLAG);
+#endif
 	spi_context_release(ctx, 0);
 
 	return ret;
@@ -659,6 +697,10 @@ static void mec5_qspi_ctx_next(const struct device *dev)
 		rc = qspi_uldma_fd2(dev, (const uint8_t *)txb, rxb, xlen, qflags);
 		if (rc != 0) {
 			spi_context_cs_control(ctx, false);
+#ifdef CONFIG_PM_DEVICE
+			mec5_qspi_pm_policy_state_lock_put(data,
+						MEC5_QSPI_PM_POLICY_STATE_XFR_FLAG);
+#endif
 			spi_context_complete(&data->ctx, dev, -EIO);
 		}
 	} else {
@@ -666,6 +708,9 @@ static void mec5_qspi_ctx_next(const struct device *dev)
 			spi_context_cs_control(ctx, false);
 		}
 
+#ifdef CONFIG_PM_DEVICE
+		mec5_qspi_pm_policy_state_lock_put(data, MEC5_QSPI_PM_POLICY_STATE_XFR_FLAG);
+#endif
 		spi_context_complete(&data->ctx, dev, 0);
 	}
 }
@@ -699,6 +744,9 @@ static void mec5_qspi_isr(const struct device *dev)
 	soc_ecia_girq_status_clear(devcfg->girq, devcfg->girq_pos);
 
 	if (status == -EIO) {
+#ifdef CONFIG_PM_DEVICE
+		mec5_qspi_pm_policy_state_lock_put(data, MEC5_QSPI_PM_POLICY_STATE_XFR_FLAG);
+#endif
 		spi_context_complete(&data->ctx, dev, -EIO);
 		return;
 	}
@@ -764,6 +812,36 @@ static int mec5_qspi_init(const struct device *dev)
 	return ret;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int mec5_qspi_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct mec5_qspi_config *devcfg = dev->config;
+	mm_reg_t qb = devcfg->regbase;
+	int ret = 0;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		sys_clear_bit(qb + XEC_QSPI_MODE_OFS, XEC_QSPI_MODE_ACTV_POS);
+		ret = pinctrl_apply_state(devcfg->pcfg, PINCTRL_STATE_SLEEP);
+		if (ret == -ENOENT) {
+			ret = 0;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		ret = pinctrl_apply_state(devcfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+		sys_set_bit(qb + XEC_QSPI_MODE_OFS, XEC_QSPI_MODE_ACTV_POS);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return ret;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 static DEVICE_API(spi, mec5_qspi_driver_api) = {
 	.transceive = mec5_qspi_xfr_sync,
 #ifdef CONFIG_SPI_ASYNC
@@ -808,7 +886,8 @@ static DEVICE_API(spi, mec5_qspi_driver_api) = {
 		.dcsda = DT_INST_PROP_OR(i, dcsda, 6u),                                            \
 		.ovrc = (uint32_t)DT_INST_PROP_OR(i, overrun_character, 0),                        \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(i, &mec5_qspi_init, NULL, &mec5_qspi_data_##i,                       \
+	PM_DEVICE_DT_INST_DEFINE(i, mec5_qspi_pm_action);                                          \
+	DEVICE_DT_INST_DEFINE(i, &mec5_qspi_init, PM_DEVICE_DT_INST_GET(i), &mec5_qspi_data_##i,   \
 			      &mec5_qspi_config_##i, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,        \
 			      &mec5_qspi_driver_api);
 

--- a/dts/arm/microchip/mec/mec172x/mec172xnsz-pinctrl.dtsi
+++ b/dts/arm/microchip/mec/mec172x/mec172xnsz-pinctrl.dtsi
@@ -1086,287 +1086,380 @@
 
 /* Add Sleep Pin Control */
 &pinctrl {
-	adc00_gpio200_sleep: adc00_gpio200_sleep {
+	/omit-if-no-ref/ adc00_gpio200_sleep: adc00_gpio200_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0200, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	adc03_gpio203_sleep: adc03_gpio203_sleep {
+	/omit-if-no-ref/ adc03_gpio203_sleep: adc03_gpio203_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0203, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	adc04_gpio204_sleep: adc04_gpio204_sleep {
+	/omit-if-no-ref/ adc04_gpio204_sleep: adc04_gpio204_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0204, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	adc05_gpio205_sleep: adc05_gpio205_sleep {
+	/omit-if-no-ref/ adc05_gpio205_sleep: adc05_gpio205_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0205, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	peci_dat_gpio042_sleep: peci_dat_gpio042_sleep {
+	/omit-if-no-ref/ peci_dat_gpio042_sleep: peci_dat_gpio042_sleep {
 		pinmux = <MCHP_XEC_PINMUX(042, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	vref_vtt_gpio044_sleep: vref_vtt_gpio044_sleep {
+	/omit-if-no-ref/ vref_vtt_gpio044_sleep: vref_vtt_gpio044_sleep {
 		pinmux = <MCHP_XEC_PINMUX(044, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	ps2_clk0a_gpio114_sleep: ps2_clk0a_gpio114_sleep {
+	/omit-if-no-ref/ ps2_clk0a_gpio114_sleep: ps2_clk0a_gpio114_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0114, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	ps2_dat0a_gpio115_sleep: ps2_dat0a_gpio115_sleep {
+	/omit-if-no-ref/ ps2_dat0a_gpio115_sleep: ps2_dat0a_gpio115_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0115, MCHP_AF1)>;
 		low-power-enable;
 	};
 
 	/* PWM */
-	pwm0_gpio053_sleep: pwm0_gpio053_sleep {
+	/omit-if-no-ref/ pwm0_gpio053_sleep: pwm0_gpio053_sleep {
 		pinmux = <MCHP_XEC_PINMUX(053, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	pwm0_alt_gpio241_sleep: pwm0_alt_gpio241_sleep {
+	/omit-if-no-ref/ pwm0_alt_gpio241_sleep: pwm0_alt_gpio241_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0241, MCHP_AF4)>;
 		low-power-enable;
 	};
 
-	pwm1_gpio054_sleep: pwm1_gpio054_sleep {
+	/omit-if-no-ref/ pwm1_gpio054_sleep: pwm1_gpio054_sleep {
 		pinmux = <MCHP_XEC_PINMUX(054, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	pwm2_gpio055_sleep: pwm2_gpio055_sleep {
+	/omit-if-no-ref/ pwm2_gpio055_sleep: pwm2_gpio055_sleep {
 		pinmux = <MCHP_XEC_PINMUX(055, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	pwm2_alt_gpio045_sleep: pwm2_alt_gpio045_sleep {
+	/omit-if-no-ref/ pwm2_alt_gpio045_sleep: pwm2_alt_gpio045_sleep {
 		pinmux = <MCHP_XEC_PINMUX(045, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	pwm3_gpio056_sleep: pwm3_gpio056_sleep {
+	/omit-if-no-ref/ pwm3_gpio056_sleep: pwm3_gpio056_sleep {
 		pinmux = <MCHP_XEC_PINMUX(056, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	pwm3_alt_gpio047_sleep: pwm3_alt_gpio047_sleep {
+	/omit-if-no-ref/ pwm3_alt_gpio047_sleep: pwm3_alt_gpio047_sleep {
 		pinmux = <MCHP_XEC_PINMUX(047, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	pwm4_gpio011_sleep: pwm4_gpio011_sleep {
+	/omit-if-no-ref/ pwm4_gpio011_sleep: pwm4_gpio011_sleep {
 		pinmux = <MCHP_XEC_PINMUX(011, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	pwm5_gpio002_sleep: pwm5_gpio002_sleep {
+	/omit-if-no-ref/ pwm5_gpio002_sleep: pwm5_gpio002_sleep {
 		pinmux = <MCHP_XEC_PINMUX(02, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	pwm6_gpio014_sleep: pwm6_gpio014_sleep {
+	/omit-if-no-ref/ pwm6_gpio014_sleep: pwm6_gpio014_sleep {
 		pinmux = <MCHP_XEC_PINMUX(014, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	pwm6_alt_gpio063_sleep: pwm6_alt_gpio063_sleep {
+	/omit-if-no-ref/ pwm6_alt_gpio063_sleep: pwm6_alt_gpio063_sleep {
 		pinmux = <MCHP_XEC_PINMUX(063, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	pwm7_gpio015_sleep: pwm7_gpio015_sleep {
+	/omit-if-no-ref/ pwm7_gpio015_sleep: pwm7_gpio015_sleep {
 		pinmux = <MCHP_XEC_PINMUX(015, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	pwm8_gpio035_sleep: pwm8_gpio035_sleep {
+	/omit-if-no-ref/ pwm8_gpio035_sleep: pwm8_gpio035_sleep {
 		pinmux = <MCHP_XEC_PINMUX(035, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	pwm8_alt_gpio175_sleep: pwm8_alt_gpio175_sleep {
+	/omit-if-no-ref/ pwm8_alt_gpio175_sleep: pwm8_alt_gpio175_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0175, MCHP_AF3)>;
 		low-power-enable;
 	};
 
 	/* EEPROM */
-	eeprom_cs_gpio116_sleep: eeprom_cs_gpio116_sleep {
+	/omit-if-no-ref/ eeprom_cs_gpio116_sleep: eeprom_cs_gpio116_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0116, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	eeprom_clk_gpio117_sleep: eeprom_clk_gpio117_sleep {
+	/omit-if-no-ref/ eeprom_clk_gpio117_sleep: eeprom_clk_gpio117_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0117, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	eeprom_mosi_gpio074_sleep: eeprom_mosi_gpio074_sleep {
+	/omit-if-no-ref/ eeprom_mosi_gpio074_sleep: eeprom_mosi_gpio074_sleep {
 		pinmux = <MCHP_XEC_PINMUX(074, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	eeprom_miso_gpio075_sleep: eeprom_miso_gpio075_sleep {
+	/omit-if-no-ref/ eeprom_miso_gpio075_sleep: eeprom_miso_gpio075_sleep {
 		pinmux = <MCHP_XEC_PINMUX(075, MCHP_AF2)>;
 		low-power-enable;
 	};
 
 	/* Keyscan */
-	ksi0_gpio017_sleep: ksi0_gpio017_sleep {
+	/omit-if-no-ref/ ksi0_gpio017_sleep: ksi0_gpio017_sleep {
 		pinmux = <MCHP_XEC_PINMUX(017, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	ksi1_gpio020_sleep: ksi1_gpio020_sleep {
+	/omit-if-no-ref/ ksi1_gpio020_sleep: ksi1_gpio020_sleep {
 		pinmux = <MCHP_XEC_PINMUX(020, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	ksi2_gpio021_sleep: ksi2_gpio021_sleep {
+	/omit-if-no-ref/ ksi2_gpio021_sleep: ksi2_gpio021_sleep {
 		pinmux = <MCHP_XEC_PINMUX(021, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	ksi3_gpio026_sleep: ksi3_gpio026_sleep {
+	/omit-if-no-ref/ ksi3_gpio026_sleep: ksi3_gpio026_sleep {
 		pinmux = <MCHP_XEC_PINMUX(026, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	ksi4_gpio027_sleep: ksi4_gpio027_sleep {
+	/omit-if-no-ref/ ksi4_gpio027_sleep: ksi4_gpio027_sleep {
 		pinmux = <MCHP_XEC_PINMUX(027, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	ksi5_gpio030_sleep: ksi5_gpio030_sleep {
+	/omit-if-no-ref/ ksi5_gpio030_sleep: ksi5_gpio030_sleep {
 		pinmux = <MCHP_XEC_PINMUX(030, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	ksi6_gpio031_sleep: ksi6_gpio031_sleep {
+	/omit-if-no-ref/ ksi6_gpio031_sleep: ksi6_gpio031_sleep {
 		pinmux = <MCHP_XEC_PINMUX(031, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	ksi7_gpio032_sleep: ksi7_gpio032_sleep {
+	/omit-if-no-ref/ ksi7_gpio032_sleep: ksi7_gpio032_sleep {
 		pinmux = <MCHP_XEC_PINMUX(032, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	kso00_gpio040_sleep: kso00_gpio040_sleep {
+	/omit-if-no-ref/ kso00_gpio040_sleep: kso00_gpio040_sleep {
 		pinmux = <MCHP_XEC_PINMUX(040, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	kso01_gpio045_sleep: kso01_gpio045_sleep {
+	/omit-if-no-ref/ kso01_gpio045_sleep: kso01_gpio045_sleep {
 		pinmux = <MCHP_XEC_PINMUX(045, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	kso02_gpio046_sleep: kso02_gpio046_sleep {
+	/omit-if-no-ref/ kso02_gpio046_sleep: kso02_gpio046_sleep {
 		pinmux = <MCHP_XEC_PINMUX(046, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	kso03_gpio047_sleep: kso03_gpio047_sleep {
+	/omit-if-no-ref/ kso03_gpio047_sleep: kso03_gpio047_sleep {
 		pinmux = <MCHP_XEC_PINMUX(047, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	kso04_gpio107_sleep: kso04_gpio107_sleep {
+	/omit-if-no-ref/ kso04_gpio107_sleep: kso04_gpio107_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0107, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	kso05_gpio112_sleep: kso05_gpio112_sleep {
+	/omit-if-no-ref/ kso05_gpio112_sleep: kso05_gpio112_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0112, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	kso06_gpio113_sleep: kso06_gpio113_sleep {
+	/omit-if-no-ref/ kso06_gpio113_sleep: kso06_gpio113_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0113, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	kso07_gpio120_sleep: kso07_gpio120_sleep {
+	/omit-if-no-ref/ kso07_gpio120_sleep: kso07_gpio120_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0120, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	kso08_gpio121_sleep: kso08_gpio121_sleep {
+	/omit-if-no-ref/ kso08_gpio121_sleep: kso08_gpio121_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0121, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	kso09_gpio122_sleep: kso09_gpio122_sleep {
+	/omit-if-no-ref/ kso09_gpio122_sleep: kso09_gpio122_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0122, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	kso10_gpio123_sleep: kso10_gpio123_sleep {
+	/omit-if-no-ref/ kso10_gpio123_sleep: kso10_gpio123_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0123, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	kso11_gpio124_sleep: kso11_gpio124_sleep {
+	/omit-if-no-ref/ kso11_gpio124_sleep: kso11_gpio124_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0124, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	kso12_gpio125_sleep: kso12_gpio125_sleep {
+	/omit-if-no-ref/ kso12_gpio125_sleep: kso12_gpio125_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0125, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	kso13_gpio126_sleep: kso13_gpio126_sleep {
+	/omit-if-no-ref/ kso13_gpio126_sleep: kso13_gpio126_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0126, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	kso14_gpio152_sleep: kso14_gpio152_sleep {
+	/omit-if-no-ref/ kso14_gpio152_sleep: kso14_gpio152_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0152, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	kso15_gpio151_sleep: kso15_gpio151_sleep {
+	/omit-if-no-ref/ kso15_gpio151_sleep: kso15_gpio151_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0151, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	kso16_gpio132_sleep: kso16_gpio132_sleep {
+	/omit-if-no-ref/ kso16_gpio132_sleep: kso16_gpio132_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0132, MCHP_AF2)>;
 		low-power-enable;
 	};
 
-	kso17_gpio140_sleep: kso17_gpio140_sleep {
+	/omit-if-no-ref/ kso17_gpio140_sleep: kso17_gpio140_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0140, MCHP_AF3)>;
 		low-power-enable;
 	};
 
 	/* BBLED */
-	led0_gpio156_sleep: led0_gpio156_sleep {
+	/omit-if-no-ref/ led0_gpio156_sleep: led0_gpio156_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0156, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	led1_gpio157_sleep: led1_gpio157_sleep {
+	/omit-if-no-ref/ led1_gpio157_sleep: led1_gpio157_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0157, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	led2_gpio153_sleep: led2_gpio153_sleep {
+	/omit-if-no-ref/ led2_gpio153_sleep: led2_gpio153_sleep {
 		pinmux = <MCHP_XEC_PINMUX(0153, MCHP_AF1)>;
 		low-power-enable;
 	};
 
-	led3_gpio035_sleep: led3_gpio035_sleep {
+	/omit-if-no-ref/ led3_gpio035_sleep: led3_gpio035_sleep {
 		pinmux = <MCHP_XEC_PINMUX(035, MCHP_AF4)>;
+		low-power-enable;
+	};
+
+	/* SHD spi */
+	/omit-if-no-ref/ shd_cs0_n_gpio055_sleep: shd_cs0_n_gpio055_sleep {
+		pinmux = <MCHP_XEC_PINMUX(055, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ shd_cs1_n_gpio002_sleep: shd_cs1_n_gpio002_sleep {
+		pinmux = <MCHP_XEC_PINMUX(02, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ shd_clk_gpio056_sleep: shd_clk_gpio056_sleep {
+		pinmux = <MCHP_XEC_PINMUX(056, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ shd_io0_gpio223_sleep: shd_io0_gpio223_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0223, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ shd_io1_gpio224_sleep: shd_io1_gpio224_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0224, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ shd_io2_gpio227_sleep: shd_io2_gpio227_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0227, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ shd_io3_gpio016_sleep: shd_io3_gpio016_sleep {
+		pinmux = <MCHP_XEC_PINMUX(016, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/* PVT spi */
+	/omit-if-no-ref/ pvt_cs_n_gpio124_sleep: pvt_cs_n_gpio124_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0124, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ pvt_clk_gpio125_sleep: pvt_clk_gpio125_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0125, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ pvt_io0_gpio121_sleep: pvt_io0_gpio121_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0121, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ pvt_io1_gpio122_sleep: pvt_io1_gpio122_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0122, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ pvt_io2_gpio123_sleep: pvt_io2_gpio123_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0123, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ pvt_io3_gpio126_sleep: pvt_io3_gpio126_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0126, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/* INT spi */
+	/omit-if-no-ref/ gpspi_cs_n_gpio116_sleep: gpspi_cs_n_gpio116_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0116, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ gpspi_clk_gpio117_sleep: gpspi_clk_gpio117_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0117, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ gpspi_io0_gpio074_sleep: gpspi_io0_gpio074_sleep {
+		pinmux = <MCHP_XEC_PINMUX(074, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ gpspi_io1_gpio075_sleep: gpspi_io1_gpio075_sleep {
+		pinmux = <MCHP_XEC_PINMUX(075, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ gpspi_wp_n_gpio076_sleep: gpspi_wp_n_gpio076_sleep {
+		pinmux = <MCHP_XEC_PINMUX(076, MCHP_GPIO)>;
 		low-power-enable;
 	};
 };

--- a/dts/arm/microchip/mec/mec5/mec1653b-b0-pinctrl.dtsi
+++ b/dts/arm/microchip/mec/mec5/mec1653b-b0-pinctrl.dtsi
@@ -1169,13 +1169,44 @@
 		low-power-enable;
 	};
 
-	/omit-if-no-ref/ qspi_shd_cs0_n_gpio055_fp: qspi_shd_cs0_n_gpio055_fp {
+	/omit-if-no-ref/ qspi_shd_cs0_n_gpio055_lp: qspi_shd_cs0_n_gpio055_lp {
 		pinmux = <MCHP_XEC_PINMUX(0055, MCHP_AF2)>;
 		low-power-enable;
 	};
 
 	/omit-if-no-ref/ qspi_shd_cs1_n_gpio002_lp: qspi_shd_cs1_n_gpio002_lp {
 		pinmux = <MCHP_XEC_PINMUX(0002, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/* PVT spi */
+	/omit-if-no-ref/ qspi_pvt_io3_gpio126_sleep: qspi_pvt_io3_gpio126_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0126, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ qspi_pvt_io2_gpio123_sleep: qspi_pvt_io2_gpio123_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0123, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ qspi_pvt_io1_gpio122_sleep: qspi_pvt_io1_gpio122_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0122, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ qspi_pvt_io0_gpio121_sleep: qspi_pvt_io0_gpio121_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0121, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ qspi_pvt_clk_gpio125_sleep: qspi_pvt_clk_gpio125_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0125, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ qspi_pvt_cs_n_gpio124_sleep: qspi_pvt_cs_n_gpio124_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0124, MCHP_AF1)>;
 		low-power-enable;
 	};
 

--- a/dts/arm/microchip/mec/mec5/mec5-common-pinctrl.dtsi
+++ b/dts/arm/microchip/mec/mec5/mec5-common-pinctrl.dtsi
@@ -1317,13 +1317,75 @@
 		low-power-enable;
 	};
 
-	/omit-if-no-ref/ qspi_shd_cs0_n_gpio055_fp: qspi_shd_cs0_n_gpio055_fp {
+	/omit-if-no-ref/ qspi_shd_cs0_n_gpio055_lp: qspi_shd_cs0_n_gpio055_lp {
 		pinmux = <MCHP_XEC_PINMUX(0055, MCHP_AF2)>;
 		low-power-enable;
 	};
 
 	/omit-if-no-ref/ qspi_shd_cs1_n_gpio002_lp: qspi_shd_cs1_n_gpio002_lp {
 		pinmux = <MCHP_XEC_PINMUX(0002, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/* INT spi */
+	/omit-if-no-ref/ int_spi_io0_gpio251_sleep: int_spi_io0_gpio251_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0251, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ int_spi_io1_gpio252_sleep: int_spi_io1_gpio252_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0252, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ int_spi_cs_n_gpio256_sleep: int_spi_cs_n_gpio256_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0256, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ int_spi_clk_gpio257_sleep: int_spi_clk_gpio257_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0257, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ int_spi_wp_gpio260_sleep: int_spi_wp_gpio260_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0260, MCHP_AF0)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ int_spi_wp_gpio261_sleep: int_spi_wp_gpio261_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0261, MCHP_AF0)>;
+		low-power-enable;
+	};
+
+	/* PVT spi */
+	/omit-if-no-ref/ qspi_pvt_io3_gpio126_sleep: qspi_pvt_io3_gpio126_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0126, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ qspi_pvt_io2_gpio123_sleep: qspi_pvt_io2_gpio123_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0123, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ qspi_pvt_io1_gpio122_sleep: qspi_pvt_io1_gpio122_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0122, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ qspi_pvt_io0_gpio121_sleep: qspi_pvt_io0_gpio121_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0121, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ qspi_pvt_clk_gpio125_sleep: qspi_pvt_clk_gpio125_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0125, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ qspi_pvt_cs_n_gpio124_sleep: qspi_pvt_cs_n_gpio124_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0124, MCHP_AF1)>;
 		low-power-enable;
 	};
 


### PR DESCRIPTION
Updated spi_xec_qmspi_ldma driver with low power support. Add a pm_action handler that clears MODE.ACTV and applies the pinctrl sleep state on suspend, and reverses both on resume. Hold a PM_STATE_SUSPEND_TO_IDLE policy lock for the duration of each transfer (sync and async) so suspend cannot enter mid- transaction.