### PR TITLE
Add i2s support for Teensy4.1 board

### DIFF
--- a/boards/pjrc/teensy4/teensy4-pinctrl.dtsi
+++ b/boards/pjrc/teensy4/teensy4-pinctrl.dtsi
@@ -509,4 +509,30 @@
 			nxp,speed = "50-mhz";
 		};
 	};
+
+	pinmux_sai1: pinmux_sai1 {
+		group0 {
+			pinmux = <&iomuxc_gpio_b1_01_sai1_tx_data0>,   /* pin 7 */
+				 <&iomuxc_gpio_ad_b1_15_sai1_tx_sync>, /* pin 27 */
+				 <&iomuxc_gpio_ad_b1_14_sai1_tx_bclk>, /* pin 26 */
+				 <&iomuxc_gpio_b1_00_sai1_rx_data0>,   /* pin 8 */
+				 <&iomuxc_gpio_ad_b1_11_sai1_rx_bclk>, /* pin 21 */
+				 <&iomuxc_gpio_ad_b1_10_sai1_rx_sync>; /* pin 20 */
+			drive-strength = "r0-6";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+	};
+
+	pinmux_sai2: pinmux_sai2 {
+		group0 {
+			pinmux = <&iomuxc_gpio_emc_04_sai2_tx_data>, /* pin 2 */
+				 <&iomuxc_gpio_emc_05_sai2_tx_sync>, /* pin 3 */
+				 <&iomuxc_gpio_emc_06_sai2_tx_bclk>, /* pin 4 */
+				 <&iomuxc_gpio_emc_08_sai2_rx_data>; /* pin 5 */
+			drive-strength = "r0-6";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+	};
 };

--- a/boards/pjrc/teensy4/teensy40.dts
+++ b/boards/pjrc/teensy4/teensy40.dts
@@ -180,3 +180,13 @@ zephyr_udc0: &usb1 {
 &systick {
 	status = "okay";
 };
+
+&sai1 {
+	pinctrl-0 = <&pinmux_sai1>;
+	pinctrl-names = "default";
+};
+
+&sai2 {
+	pinctrl-0 = <&pinmux_sai2>;
+	pinctrl-names = "default";
+};

--- a/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
@@ -1048,13 +1048,17 @@
 			clock-mux = <2>;
 			/* Audio PLL Output Frequency is determined by:
 			 * (Fref * (DIV_SELECT + NUM/DENOM)) / POST_DIV
-			 * = (24MHz * (32 + 77 / 100)) / 1 = 786.48 MHz
+			 * = (24MHz * (32 + 96 / 125)) / 1 = 786.432 MHz
+			 * This can generate sample rates 8 kHz, 16 kHz, 32 kHz, 48 kHz, etc.
+			 * An alternative PLL frequency is:
+			 * = (24MHz * (30 + 66 / 625)) / 1 = 722.5344 MHz
+			 * to generate samples rates 11.025 kHz, 22.05 kHz, 44.1 kHz, etc.
 			 */
 			pll-clocks = <&anatop 0x70 0xc000 0>,
 				     <&anatop 0x70 0x7f 32>,
 				     <&anatop 0x70 0x180000 1>,
-				     <&anatop 0x80 0x3fffffff 77>,
-				     <&anatop 0x90 0x3fffffff 100>;
+				     <&anatop 0x80 0x3fffffff 96>,
+				     <&anatop 0x90 0x3fffffff 125>;
 			pll-clock-names = "src", "lp", "pd", "num", "den";
 			/* The maximum input frequency into the SAI mclk input is 300MHz
 			 * Based on this requirement, pre-div must be at least 3
@@ -1088,17 +1092,17 @@
 			clock-mux = <2>;
 			pre-div = <0>;
 			podf = <63>;
-			pll-clocks = <&anatop 0x70 0xc000 0x0>,
+			pll-clocks = <&anatop 0x70 0xc000 0>,
 				     <&anatop 0x70 0x7f 32>,
 				     <&anatop 0x70 0x180000 1>,
-				     <&anatop 0x80 0x3fffffff 77>,
-				     <&anatop 0x90 0x3fffffff 100>;
+				     <&anatop 0x80 0x3fffffff 96>,
+				     <&anatop 0x90 0x3fffffff 125>;
 			pll-clock-names = "src", "lp", "pd", "num", "den";
 			pinmuxes = <&iomuxcgpr 0x4 0x100000>;
 			interrupts = <57 0>;
 			dmas = <&edma0 0 21>, <&edma0 0 22>;
 			dma-names = "rx", "tx";
-			nxp,tx-channel = <0>;
+			nxp,tx-channel = <1>;
 			nxp,tx-dma-channel = <3>;
 			nxp,rx-dma-channel = <4>;
 			status = "disabled";
@@ -1118,14 +1122,14 @@
 			pll-clocks = <&anatop 0x70 0xc000 0>,
 				     <&anatop 0x70 0x7f 32>,
 				     <&anatop 0x70 0x180000 1>,
-				     <&anatop 0x80 0x3fffffff 77>,
-				     <&anatop 0x90 0x3fffffff 100>;
+				     <&anatop 0x80 0x3fffffff 96>,
+				     <&anatop 0x90 0x3fffffff 125>;
 			pll-clock-names = "src", "lp", "pd", "num", "den";
 			pinmuxes = <&iomuxcgpr 0x4 0x200000>;
 			interrupts = <58 0>, <59 0>;
 			dmas = <&edma0 0 83>, <&edma0 0 84>;
 			dma-names = "rx", "tx";
-			nxp,tx-channel = <0>;
+			nxp,tx-channel = <1>;
 			nxp,tx-dma-channel = <5>;
 			nxp,rx-dma-channel = <6>;
 			status = "disabled";

--- a/samples/drivers/i2s/output/boards/teensy41_mimxrt1062.overlay
+++ b/samples/drivers/i2s/output/boards/teensy41_mimxrt1062.overlay
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026 Koen Van Herck
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	aliases {
 		i2s-tx = &sai1;

--- a/samples/drivers/i2s/output/boards/teensy41_mimxrt1062.overlay
+++ b/samples/drivers/i2s/output/boards/teensy41_mimxrt1062.overlay
@@ -1,0 +1,9 @@
+/ {
+	aliases {
+		i2s-tx = &sai1;
+	};
+};
+
+&sai1 {
+	status = "okay";
+};

--- a/tests/drivers/i2s/i2s_speed/Readme.txt
+++ b/tests/drivers/i2s/i2s_speed/Readme.txt
@@ -53,3 +53,10 @@ signals externally on the EVK.  These are the HW changes required to run this te
         - Short BCLK J1-pin9  (SAI1_RX_BCLK/P3_18) to J8-pin25 (SAI0_TX_BCLK/P3_8)
         - Short SYNC J1-pin13 (SAI1_RX_FS/P1_7)    to J8-pin26 (SAI0_TX_FS/P3_9)
         - Short Data J1-pin15 (SAI1_RXD0/P2_9)     to J8-pin27  (SAI0_TXD0/P3_10)
+
+TEENSY41:
+This board uses a single SAI and connects the TX and RX signals by shorting externally on the board.
+These are the HW changes required to run this test on Teensy 4.1:
+	- Short BCLK pin 21 (SAI1_RX_BCLK  / GPIO_AD_B1_11) to pin 26 (SAI1_TX_BCLK  / GPIO_AD_B1_14)
+	- Short SYNC pin 20 (SAI1_RX_SYNC  / GPIO_AD_B1_10) to pin 27 (SAI1_TX_SYNC  / GPIO_AD_B1_15)
+	- Short Data pin 8  (SAI1_RX_DATA0 / GPIO_AD_B1_12) to pin 7  (SAI1_TX_DATA0 / GPIO_AD_B1_13)

--- a/tests/drivers/i2s/i2s_speed/boards/teensy41_mimxrt1062.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/teensy41_mimxrt1062.overlay
@@ -1,0 +1,9 @@
+/ {
+	aliases {
+		i2s-node0 = &sai1;
+	};
+};
+
+&sai1 {
+	status = "okay";
+};

--- a/tests/drivers/i2s/i2s_speed/boards/teensy41_mimxrt1062.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/teensy41_mimxrt1062.overlay
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026 Koen Van Herck
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	aliases {
 		i2s-node0 = &sai1;


### PR DESCRIPTION
Fixed rounding error on audio PLL frequency for NXP RT10xx SOC.
Added device tree elements for sai1 and sai2 nodes.
Added Teensy4 board support to i2s/output sample and i2s_speed test.