### PR TITLE
rtio: Assert the read/write/transceive lengths

### DIFF
--- a/include/zephyr/rtio/sqe.h
+++ b/include/zephyr/rtio/sqe.h
@@ -425,10 +425,12 @@ static inline void rtio_sqe_prep_nop(struct rtio_sqe *sqe,
 	sqe->userdata = userdata;
 }
 
+
 /**
- * @brief Prepare a read op submission
+ * @cond ignore
+ * @brief Common helper for prep read family of functions
  */
-static inline void rtio_sqe_prep_read(struct rtio_sqe *sqe,
+static inline void _rtio_sqe_prep_read(struct rtio_sqe *sqe,
 				      const struct rtio_iodev *iodev,
 				      int8_t prio,
 				      uint8_t *buf,
@@ -443,6 +445,22 @@ static inline void rtio_sqe_prep_read(struct rtio_sqe *sqe,
 	sqe->rx.buf = buf;
 	sqe->userdata = userdata;
 }
+/** @endcond */
+
+/**
+ * @brief Prepare a read op submission
+ */
+static inline void rtio_sqe_prep_read(struct rtio_sqe *sqe,
+				      const struct rtio_iodev *iodev,
+				      int8_t prio,
+				      uint8_t *buf,
+				      uint32_t len,
+				      void *userdata)
+{
+	__ASSERT_NO_MSG(len > 0 && buf != NULL);
+
+	_rtio_sqe_prep_read(sqe, iodev, prio, buf, len, userdata);
+}
 
 /**
  * @brief Prepare a read op submission with context's mempool
@@ -453,7 +471,7 @@ static inline void rtio_sqe_prep_read_with_pool(struct rtio_sqe *sqe,
 						const struct rtio_iodev *iodev, int8_t prio,
 						void *userdata)
 {
-	rtio_sqe_prep_read(sqe, iodev, prio, NULL, 0, userdata);
+	_rtio_sqe_prep_read(sqe, iodev, prio, NULL, 0, userdata);
 	sqe->flags = RTIO_SQE_MEMPOOL_BUFFER;
 }
 
@@ -475,6 +493,8 @@ static inline void rtio_sqe_prep_write(struct rtio_sqe *sqe,
 				       uint32_t len,
 				       void *userdata)
 {
+	__ASSERT_NO_MSG(len > 0 && buf != NULL);
+
 	memset(sqe, 0, sizeof(struct rtio_sqe));
 	sqe->op = RTIO_OP_TX;
 	sqe->prio = prio;
@@ -502,6 +522,7 @@ static inline void rtio_sqe_prep_tiny_write(struct rtio_sqe *sqe,
 					    void *userdata)
 {
 	__ASSERT_NO_MSG(tiny_write_len <= sizeof(sqe->tiny_tx.buf));
+	__ASSERT_NO_MSG(tiny_write_len > 0 && tiny_write_data != NULL);
 
 	memset(sqe, 0, sizeof(struct rtio_sqe));
 	sqe->op = RTIO_OP_TINY_TX;
@@ -564,6 +585,8 @@ static inline void rtio_sqe_prep_transceive(struct rtio_sqe *sqe,
 					    uint32_t buf_len,
 					    void *userdata)
 {
+	__ASSERT_NO_MSG(buf_len > 0 && tx_buf != NULL && rx_buf != NULL);
+
 	memset(sqe, 0, sizeof(struct rtio_sqe));
 	sqe->op = RTIO_OP_TXRX;
 	sqe->prio = prio;


### PR DESCRIPTION
The length of buffer being read or written or transceived should never be 0, and the pointer should never be null.

Adds a private read prep helper to allow for the mempool reads (which do not set a pointer or length) to bypass the assert.