### PR TITLE
tests: net: http_server: fix sec_tag_list size on TLS test

### DIFF
--- a/tests/net/lib/http_server/tls/src/main.c
+++ b/tests/net/lib/http_server/tls/src/main.c
@@ -161,7 +161,7 @@ static void test_tls(void)
 		const sec_tag_t *sec_tag_list;
 		size_t sec_tag_list_size;
 
-		sec_tag_list_size = sizeof(sec_tag_list);
+		sec_tag_list_size = sizeof(sec_tag_list_verify_none);
 		sec_tag_list = sec_tag_list_verify_none;
 
 		ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_SEC_TAG_LIST,


### PR DESCRIPTION
`sec_tag_list_size` was initialized with `sizeof(sec_tag_list)`, which is the size of a pointer. On 64-bit targets (e.g. native_sim/native/64), this feeds an extra garbage `sec_tag` into `setsockopt` and breaks credential lookup. Use the size of the actual array instead.

This should probably be back-ported to version 4.4 and maybe also 4.3.