### PR TITLE
include: xen: add Doxygen groups and complete API documentation

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -60,6 +60,13 @@
 @{
 @}
 
+@brief Xen hypervisor support
+@defgroup xen_support Xen support
+@ingroup os_services
+@details Interfaces for running Zephyr as a Xen guest or as Xen Dom0.
+@{
+@}
+
 @brief MCUmgr
 @defgroup mcumgr MCUmgr
 @ingroup device_mgmt

--- a/include/zephyr/xen/console.h
+++ b/include/zephyr/xen/console.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Internal Xen console driver data.
+ * @ingroup xen_console_driver
+ */
+
 #ifndef __XEN_CONSOLE_H__
 #define __XEN_CONSOLE_H__
 
@@ -11,6 +18,17 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/device_mmio.h>
 
+/**
+ * @defgroup xen_console_driver Xen console driver
+ * @ingroup xen_internal
+ * @brief Keep the Xen UART console implementation synchronized with its device data layout.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+/**
+ * @brief Runtime data used by the Xen console UART driver.
+ */
 struct hvc_xen_data {
 	DEVICE_MMIO_RAM;	/* should be first */
 	const struct device *dev;
@@ -22,7 +40,17 @@ struct hvc_xen_data {
 	void *irq_cb_data;
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
+/** @endcond */
 
+/**
+ * @brief Initialize the Xen console UART instance.
+ *
+ * @param dev UART device instance to initialize.
+ *
+ * @return 0 on success, negative errno value on failure.
+ */
 int xen_console_init(const struct device *dev);
+
+/** @} */
 
 #endif /* __XEN_CONSOLE_H__ */

--- a/include/zephyr/xen/dmop.h
+++ b/include/zephyr/xen/dmop.h
@@ -4,10 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Xen device-model operations.
+ * @ingroup xen_device_model
+ */
+
 #ifndef ZEPHYR_XEN_DMOP_H_
 #define ZEPHYR_XEN_DMOP_H_
 
 #include <zephyr/xen/public/hvm/dm_op.h>
+
+/**
+ * @defgroup xen_device_model Xen device model
+ * @ingroup xen_support
+ * @brief Manage Xen I/O request servers and related device-model state.
+ * @{
+ */
 
 /**
  * @brief Create an I/O request server in the given Xen domain.
@@ -15,13 +28,14 @@
  * This function issues the XEN_DMOP_create_ioreq_server hypercall to create
  * a server that handles I/O requests on behalf of the guest domain.
  *
+ * @kconfig_dep{CONFIG_XEN_DMOP}
+ *
  * @param domid        Xen domain identifier where the server is created.
  * @param handle_bufioreq  Flag indicating whether buffered I/O requests should be handled.
  *                        Set to non-zero to enable buffered handling.
- * @param id           Output pointer to receive the newly created server ID.
+ * @param[out] id         Output pointer to receive the newly created server ID.
  *
- * @retval 0      On success
- * @retval -errno Negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int dmop_create_ioreq_server(domid_t domid, uint8_t handle_bufioreq, ioservid_t *id);
 
@@ -31,19 +45,22 @@ int dmop_create_ioreq_server(domid_t domid, uint8_t handle_bufioreq, ioservid_t 
  * Issues the XEN_DMOP_destroy_ioreq_server hypercall to tear down the
  * specified I/O request server.
  *
+ * @kconfig_dep{CONFIG_XEN_DMOP}
+ *
  * @param domid Xen domain identifier where the server exists.
  * @param id    I/O request server ID returned by dmop_create_ioreq_server().
  *
- * @retval 0      On success
- * @retval -errno Negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int dmop_destroy_ioreq_server(domid_t domid, ioservid_t id);
 
 /**
  * @brief Map a specified I/O address range to an existing I/O request server.
  *
- * This function issues the XEN_DMOP_map_io_range_to_ioreq_server hypercall to grant
- * access to the given I/O address range for the specified server.
+ * This function issues the XEN_DMOP_map_io_range_to_ioreq_server hypercall to grant access to the
+ * given I/O address range for the specified server.
+ *
+ * @kconfig_dep{CONFIG_XEN_DMOP}
  *
  * @param domid  Xen domain identifier where the mapping is applied.
  * @param id     I/O request server ID returned by dmop_create_ioreq_server().
@@ -51,17 +68,20 @@ int dmop_destroy_ioreq_server(domid_t domid, ioservid_t id);
  * @param start  Start physical address of the I/O range.
  * @param end    End physical address (inclusive) of the I/O range.
  *
- * @retval 0      On success
- * @retval -errno Negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
  */
-int dmop_map_io_range_to_ioreq_server(domid_t domid, ioservid_t id, uint32_t type, uint64_t start,
-				      uint64_t end);
+int dmop_map_io_range_to_ioreq_server(domid_t domid, ioservid_t id,
+	uint32_t type,
+	uint64_t start,
+	uint64_t end);
 
 /**
  * @brief Unmap an I/O address range from an I/O request server.
  *
- * Issues the XEN_DMOP_unmap_io_range_from_ioreq_server hypercall to revoke
- * access to a previously mapped I/O address range.
+ * Issues the XEN_DMOP_unmap_io_range_from_ioreq_server hypercall to revoke access to a previously
+ * mapped I/O address range.
+ *
+ * @kconfig_dep{CONFIG_XEN_DMOP}
  *
  * @param domid Xen domain identifier where the unmapping is applied.
  * @param id    I/O request server ID returned by dmop_create_ioreq_server().
@@ -69,14 +89,15 @@ int dmop_map_io_range_to_ioreq_server(domid_t domid, ioservid_t id, uint32_t typ
  * @param start Start physical address of the I/O range.
  * @param end   End physical address (inclusive) of the I/O range.
  *
- * @retval 0      On success
- * @retval -errno Negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int dmop_unmap_io_range_from_ioreq_server(domid_t domid, ioservid_t id, uint32_t type,
 					  uint64_t start, uint64_t end);
 
 /**
  * @brief Enable or disable an existing I/O request server.
+ *
+ * @kconfig_dep{CONFIG_XEN_DMOP}
  *
  * This function issues the XEN_DMOP_set_ioreq_server_state hypercall to change
  * the operational state of the specified I/O request server.
@@ -85,8 +106,7 @@ int dmop_unmap_io_range_from_ioreq_server(domid_t domid, ioservid_t id, uint32_t
  * @param id       I/O request server ID to modify.
  * @param enabled  Non-zero to enable the server, zero to disable it.
  *
- * @retval 0      On success
- * @retval -errno Negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int dmop_set_ioreq_server_state(domid_t domid, ioservid_t id, uint8_t enabled);
 
@@ -96,10 +116,11 @@ int dmop_set_ioreq_server_state(domid_t domid, ioservid_t id, uint8_t enabled);
  * This function issues the XEN_DMOP_nr_vcpus hypercall to retrieve
  * the current vCPU count for the specified domain.
  *
+ * @kconfig_dep{CONFIG_XEN_DMOP}
+ *
  * @param domid  Xen domain identifier to query.
  *
- * @retval num_vcpus The number of vCPUs on success.
- * @retval -errno    Negative errno code on failure.
+ * @return Number of vCPUs on success, negative errno value on failure.
  */
 int dmop_nr_vcpus(domid_t domid);
 
@@ -109,13 +130,16 @@ int dmop_nr_vcpus(domid_t domid);
  * This function issues the XEN_DMOP_set_irq_level hypercall to adjust
  * the signal level (assert or deassert) for the given IRQ line.
  *
+ * @kconfig_dep{CONFIG_XEN_DMOP}
+ *
  * @param domid  Xen domain identifier.
  * @param irq    IRQ number whose level is to be set.
  * @param level  Non-zero to assert (raise) the IRQ, zero to deassert (lower) it.
  *
- * @retval 0      On success
- * @retval -errno Negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int dmop_set_irq_level(domid_t domid, uint32_t irq, uint8_t level);
+
+/** @} */
 
 #endif /* ZEPHYR_XEN_DMOP_H_ */

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -6,8 +6,8 @@
 
 /**
  * @file
- *
- * @brief Xen Domain Control Interface
+ * @brief Xen Dom0 domain control operations.
+ * @ingroup xen_dom0_domain_control
  */
 
 #ifndef __XEN_DOM0_DOMCTL_H__
@@ -20,31 +20,44 @@
 #include <zephyr/kernel.h>
 
 /**
+ * @defgroup xen_dom0_domain_control Xen Dom0 domain control
+ * @ingroup xen_dom0
+ * @brief Control domain lifecycle, resources, and vCPUs from the privileged domain.
+ * @{
+ */
+
+/**
  * @brief Perform a scheduler operation on a specified domain.
+ *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
  *
  * @param domid The ID of the domain on which the scheduler operation is to be performed.
  * @param[in,out] sched_op A pointer to a `struct xen_domctl_scheduler_op` object that defines
  *                         the specific scheduler operation to be performed.
- * @retval 0 on success.
- * @retval -errno on failure.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_scheduler_op(int domid, struct xen_domctl_scheduler_op *sched_op);
 
 /**
- * @brief Pauses a domain in the Xen hypervisor.
+ * @brief Pause a domain in the Xen hypervisor.
+ *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
  *
  * @param domid The ID of the domain to be paused.
- * @retval 0 on success.
- * @retval -errno on failure.s
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_pausedomain(int domid);
 
 /**
- * @brief Unpauses a domain in the Xen hypervisor.
+ * @brief Unpause a domain in the Xen hypervisor.
  *
- * @param domid The domain ID of the domain to be unpaused.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid The ID of the domain to be unpaused.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_unpausedomain(int domid);
 
@@ -53,216 +66,255 @@ int xen_domctl_unpausedomain(int domid);
  *
  * This function resumes the execution of a domain in the shutdown state.
  *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
  * @param domid The ID of the domain to be resumed.
- * @retval 0 on success.
- * @retval -errno on failure.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_resumedomain(int domid);
 
 /**
- * @brief Retrieves the virtual CPU context for a specific domain and virtual CPU.
- * This function resumes the execution of a domain in the shutdown state.
+ * @brief Get the guest context of a domain vCPU. *
+ *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
  *
  * @param domid The ID of the domain.
  * @param vcpu The ID of the virtual CPU.
  * @param[out] ctxt Pointer to the `vcpu_guest_context_t` structure where the
  *                  virtual CPU context will be stored.
- * @retval 0 on success.
- * @retval -errno on failure.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_getvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt);
 
 /**
- * @brief Sets the virtual CPU context for a specified domain and virtual CPU.
+ * @brief Set the guest context of a domain vCPU.
+ *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
  *
  * @param domid The ID of the domain.
  * @param vcpu The ID of the virtual CPU.
  * @param ctxt Pointer to the virtual CPU guest context structure.
- * @retval 0 on success.
- * @retval -errno on failure.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_setvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt);
 
 /**
- * @brief Retrieves information about a Xen domain.
+ * @brief Get summary information for a domain.
+ *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
  *
  * @param domid The ID of the Xen domain to retrieve information for.
  * @param[out] dom_info Pointer to the structure where the retrieved
  *                      domain information will be stored.
- * @retval 0 on success.
- * @retval -errno on failure.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_getdomaininfo(int domid, xen_domctl_getdomaininfo_t *dom_info);
 
 /**
- * @brief Gets the paging mempool size for a specified domain.
+ * @brief Get the paging mempool size for a domain.
  *
- * @param domid The ID of the domain.
- * @param size pointer where to store size of the paging mempool.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param[out] size Buffer that receives the paging mempool size in bytes.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_get_paging_mempool_size(int domid, uint64_t *size);
 
 /**
- * @brief Sets the paging mempool size for a specified domain.
+ * @brief Set the paging mempool size for a domain.
  *
- * @param domid The ID of the domain.
- * @param size The size of the paging mempool in bytes.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param size New paging mempool size in bytes.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_set_paging_mempool_size(int domid, uint64_t size);
 
 /**
- * @brief Sets the maximum memory for a specified domain.
+ * @brief Set the maximum memory assigned to a domain.
  *
- * @param domid The domain ID of the domain to set the maximum memory for.
- * @param max_memkb The maximum memory (in kilobytes) to set for the domain.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param max_memkb Maximum memory in KiB.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_max_mem(int domid, uint64_t max_memkb);
 
 /**
- * @brief Sets the address size for a specified domain.
+ * @brief Set the address size used by a domain.
  *
- * @param domid The ID of the domain.
- * @param addr_size The address size to be set.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param addr_size Xen address-size selector.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_set_address_size(int domid, int addr_size);
 
 /**
- * @brief Set IOMEM permission for a domain.
+ * @brief Allow or deny I/O-memory access for a domain.
  *
- * @param domid The ID of the domain for which IOMEM permission is being set.
- * @param first_mfn The starting machine frame number of the memory range.
- * @param nr_mfns The number of MFNs in the memory range.
- * @param allow_access Flag indicating whether to allow or deny access to the
- *                     specified memory range. A non-zero value allows access,
- *                     while a zero value denies access.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
  *
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @param domid Target domain identifier.
+ * @param first_mfn First machine frame number in the range.
+ * @param nr_mfns Number of machine frames in the range.
+ * @param allow_access Set to non-zero to allow access, or zero to revoke it.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_iomem_permission(int domid, uint64_t first_mfn,
 				uint64_t nr_mfns, uint8_t allow_access);
 
 /**
- * @brief Maps a range of machine memory to a range of guest memory.
+ * @brief Map or unmap a machine-memory range into a guest frame range.
  *
- * @param domid The domain ID of the target domain.
- * @param first_gfn The first guest frame number to map.
- * @param first_mfn The first machine frame number to map.
- * @param nr_mfns The number of machine frames to map.
- * @param add_mapping Flag indicating whether to add or remove the mapping.
+ * The implementation automatically retries the operation with smaller chunks if
+ * Xen reports that the request is too large.
  *
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param first_gfn First guest frame number in the target range.
+ * @param first_mfn First machine frame number in the source range.
+ * @param nr_mfns Number of frames to process.
+ * @param add_mapping Set to non-zero to add the mapping, or zero to remove it.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_memory_mapping(int domid, uint64_t first_gfn, uint64_t first_mfn,
 			      uint64_t nr_mfns, uint32_t add_mapping);
 
 /**
- * @brief Assign a device to a guest. Sets up IOMMU structures.
+ * @brief Assign a devicetree-described device to a guest domain.
  *
- * @param domid The ID of the domain to which the device is to be assigned.
- * @param dtdev_path The path of the device tree device to be assigned.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * On arm64, this is primarily used for devices that can act as bus masters
+ * (DMA-capable devices). Xen configures the IOMMU as part of the assignment.
+ *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param dtdev_path NULL-terminated devicetree path to the device.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_assign_dt_device(int domid, char *dtdev_path);
 
 /**
- * @brief Deassign a device from a guest domain.
+ * @brief Remove a devicetree-described device assignment from a guest domain.
  *
- * @param domid The ID of the domain from which the device should be deassigned.
- * @param dtdev_path The path of the device tree device to be deassigned.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param dtdev_path NULL-terminated devicetree path to the device.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_deassign_dt_device(int domid, char *dtdev_path);
 
 /**
- * @brief Binds a physical IRQ to a specified domain.
+ * @brief Bind a physical interrupt to a guest domain.
  *
- * Only supports SPI IRQs for now.
+ * Only ``PT_IRQ_TYPE_SPI`` is currently supported.
  *
- * @param domid The ID of the domain to bind the IRQ to.
- * @param machine_irq The machine IRQ number to bind.
- * @param irq_type The type of IRQ to bind (PT_IRQ_TYPE_SPI).
- * @param bus The PCI bus number of the device generating the IRQ. (optional)
- * @param device The PCI device number generating the IRQ. (optional)
- * @param intx The PCI INTx line number of the device generating the IRQ. (optional)
- * @param isa_irq The ISA IRQ number to bind. (optional)
- * @param spi The shared peripheral interrupt (SPI) number to bind. (optional)
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param machine_irq Machine IRQ number to bind.
+ * @param irq_type Xen passthrough IRQ type.
+ * @param bus PCI bus number for PCI passthrough modes.
+ * @param device PCI device number for PCI passthrough modes.
+ * @param intx PCI INTx line for PCI passthrough modes.
+ * @param isa_irq ISA IRQ number for ISA passthrough modes.
+ * @param spi SPI number used with ``PT_IRQ_TYPE_SPI``.
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP @p irq_type is not supported by the current implementation.
  */
 int xen_domctl_bind_pt_irq(int domid, uint32_t machine_irq, uint8_t irq_type, uint8_t bus,
 			   uint8_t device, uint8_t intx, uint8_t isa_irq, uint16_t spi);
 
 /**
- * @brief Set the maximum number of vCPUs for a domain.
+ * @brief Set the maximum number of vCPUs available to a domain.
  *
- * The parameter passed to XEN_DOMCTL_max_vcpus must match the value passed to
- * XEN_DOMCTL_createdomain.  This hypercall is in the process of being removed
- * (once the failure paths in domain_create() have been improved), but is
- * still required in the short term to allocate the vcpus themselves.
+ * @p max_vcpus must match the value passed to ``XEN_DOMCTL_createdomain``. This
+ * hypercall is in the process of being removed (once the failure paths in
+ * ``domain_create()`` have been improved), but is still required in the short
+ * term to allocate the vCPUs themselves.
  *
- * @param domid The ID of the domain.
- * @param max_vcpus Maximum number of vCPUs to set.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param max_vcpus Maximum number of Xen vCPUs to allocate.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_max_vcpus(int domid, int max_vcpus);
 
 /**
- * @brief Creates a new domain with the specified domain ID and configuration.
+ * @brief Create a new domain.
  *
- * NB. domid is an IN/OUT parameter for this operation.
- * If it is specified as an invalid value (0 or >= DOMID_FIRST_RESERVED),
- * an id is auto-allocated and returned.
-
- * @param[in,out] domid Pointer to domain ID of the new domain.
- * @param config Pointer to a structure containing the configuration for the new domain.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @p domid is an IN/OUT parameter. If it is specified as an invalid value
+ * (0 or ``>= DOMID_FIRST_RESERVED``), Xen auto-allocates an identifier and
+ * returns it through @p domid.
+ *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param[in,out] domid Domain identifier request and response buffer.
+ * @param config Domain configuration passed to Xen.
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL @p domid or @p config is ``NULL``.
  */
 int xen_domctl_createdomain(int *domid, struct xen_domctl_createdomain *config);
 
 /**
- * @brief Clean and invalidate caches associated with given region of
- * guest memory.
+ * @brief Clean and invalidate caches for a guest memory range.
  *
- * @param domid The ID of the domain for which the cache needs to be flushed.
- * @param cacheflush A pointer to the `xen_domctl_cacheflush` structure that
- *                   contains the cache flush parameters.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param cacheflush Cache-flush request parameters.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
-int xen_domctl_cacheflush(int domid,  struct xen_domctl_cacheflush *cacheflush);
+int xen_domctl_cacheflush(int domid, struct xen_domctl_cacheflush *cacheflush);
 
 /**
- * @brief Destroys a Xen domain.
+ * @brief Destroy a domain.
  *
- * @param domid The ID of the domain to be destroyed.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_destroydomain(int domid);
 
 /**
- * @brief Retrieves information about a specific virtual CPU (vCPU) in a Xen domain.
+ * @brief Query runtime information for one domain vCPU.
  *
- * @param domid The ID of the domain.
- * @param vcpu The index of the vCPU.
- * @param[out] info Pointer to a structure to store the vCPU information.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param vcpu vCPU index to query.
+ * @param[out] info Buffer that receives the vCPU information.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xen_domctl_getvcpu(int domid, uint32_t vcpu, struct xen_domctl_getvcpuinfo *info);
+
+/** @} */
 
 #endif /* __XEN_DOM0_DOMCTL_H__ */

--- a/include/zephyr/xen/dom0/sysctl.h
+++ b/include/zephyr/xen/dom0/sysctl.h
@@ -6,23 +6,39 @@
 
 /**
  * @file
- *
- * @brief Xen System Control Interface
+ * @brief Xen Dom0 system control operations.
+ * @ingroup xen_dom0_sysctl
  */
 
 #ifndef __XEN_DOM0_SYSCTL_H__
 #define __XEN_DOM0_SYSCTL_H__
+
 #include <zephyr/xen/generic.h>
 #include <zephyr/xen/public/sysctl.h>
 #include <zephyr/xen/public/xen.h>
 
 /**
- * @brief Retrieves information about the host system.
+ * @defgroup xen_dom0 Xen Dom0 control
+ * @ingroup xen_support
+ * @brief Manage Xen domains and host resources from the privileged domain.
+ */
+
+/**
+ * @defgroup xen_dom0_sysctl Xen Dom0 sysctl
+ * @ingroup xen_dom0
+ * @brief Issue Xen sysctl operations that are available only to Dom0.
+ * @{
+ */
+
+/**
+ * @brief Query physical host information from Xen.
  *
- * @param[out] info A pointer to a `struct xen_sysctl_physinfo` structure where the
- *             retrieved information will be stored.
- * @retval 0 on success.
- * @retval -errno on failure.
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param[out] info Buffer that receives the Xen physical host information.
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL @p info is ``NULL``.
  */
 int xen_sysctl_physinfo(struct xen_sysctl_physinfo *info);
 
@@ -33,10 +49,15 @@ int xen_sysctl_physinfo(struct xen_sysctl_physinfo *info);
  *                        to store the retrieved domain information.
  * @param first The first domain ID to retrieve information for.
  * @param num The maximum number of domains to retrieve information for.
- * @retval 0 on success.
- * @retval -errno on failure.
+ *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @return Number of entries written to @p domaininfo on success, negative errno value on failure.
+ * @retval -EINVAL @p domaininfo is ``NULL`` or @p num is zero.
  */
 int xen_sysctl_getdomaininfo(struct xen_domctl_getdomaininfo *domaininfo,
 			     uint16_t first, uint16_t num);
+
+/** @} */
 
 #endif /* __XEN_DOM0_SYSCTL_H__ */

--- a/include/zephyr/xen/events.h
+++ b/include/zephyr/xen/events.h
@@ -7,10 +7,8 @@
 
 /**
  * @file
- * @brief Xen event channel interface
- *
- * This file provides the interface for managing Xen event channels,
- * including allocation, binding, and callback management.
+ * @brief Xen event channel services.
+ * @ingroup xen_event_channels
  */
 
 #ifndef __XEN_EVENTS_H__
@@ -20,111 +18,200 @@
 
 #include <zephyr/kernel.h>
 
+/**
+ * @defgroup xen_event_channels Xen event channels
+ * @ingroup xen_support
+ * @brief Allocate, bind, and service Xen event channels from Zephyr.
+ * @{
+ */
+
+/**
+ * @brief Event-channel callback signature.
+ *
+ * The callback runs from the Xen event interrupt handler.
+ *
+ * @param priv User data pointer that was registered with the event channel.
+ */
 typedef void (*evtchn_cb_t)(void *priv);
 
+/** @cond INTERNAL_HIDDEN */
+/* Internal event-channel callback slot. */
 struct event_channel_handle {
 	evtchn_cb_t cb;
 	void *priv;
 };
 typedef struct event_channel_handle evtchn_handle_t;
+/** @endcond */
 
-/*
- * Following functions just wrap Xen hypercalls, detailed description
- * of parameters and return values are located in include/xen/public/event_channel.h
+/**
+ * @brief Query the status of an event channel.
+ *
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * The caller provides the input domain and port in @p status, and Xen fills the
+ * remaining fields with the current channel state.
+ *
+ * @param[in,out] status Event-channel status request and response buffer.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int evtchn_status(evtchn_status_t *status);
+
+/**
+ * @brief Close a local event channel.
+ *
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * @param port Local event-channel port to close.
+ *
+ * @return 0 on success, negative errno value on failure.
+ */
 int evtchn_close(evtchn_port_t port);
+
+/**
+ * @brief Set the Xen priority assigned to an event channel.
+ *
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * @param port Local event-channel port to update.
+ * @param priority Xen event priority value.
+ *
+ * @return 0 on success, negative errno value on failure.
+ */
 int evtchn_set_priority(evtchn_port_t port, uint32_t priority);
+
+/**
+ * @brief Send a notification over an event channel.
+ *
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * @param port Local event-channel port to notify.
+ *
+ * @return 0 on success, negative errno value on failure.
+ */
 int notify_evtchn(evtchn_port_t port);
 
 /**
- * Allocate event-channel between caller and remote domain
+ * @brief Allocate an unbound event channel for the calling domain.
  *
- * @param remote_dom remote domain domid
- * @retval port local event channel port on success
- * @retval -errno negative code on error
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * @param remote_dom Domain that may bind to the allocated channel.
+ *
+ * @return Local event-channel port on success, negative errno value on failure.
  */
 int alloc_unbound_event_channel(domid_t remote_dom);
 
-#ifdef CONFIG_XEN_DOM0
 /**
- * Allocate event-channel between remote domains. Can be used only from Dom0.
+ * @brief Allocate an unbound event channel between two domains.
  *
- * @param dom first remote domain domid (may be DOMID_SELF)
- * @param remote_dom second remote domain domid
- * @retval port local event channel port on success
- * @retval -errno negative code on error
+ * @kconfig_dep{CONFIG_XEN_EVENTS,CONFIG_XEN_DOM0}
+ *
+ * @param dom Domain that receives the new local port. May be ``DOMID_SELF``.
+ * @param remote_dom Peer domain that may bind to the port.
+ *
+ * @return Local event-channel port on success, negative errno value on failure.
  */
 int alloc_unbound_event_channel_dom0(domid_t dom, domid_t remote_dom);
-#endif /* CONFIG_XEN_DOM0 */
 
 /**
- * Allocate local event channel, binded to remote port and attach specified callback
- * to it
+ * @brief Bind to a remote event channel and register a callback.
  *
- * @param remote_dom remote domain domid
- * @param remote_port remote domain event channel port number
- * @param cb callback, attached to locat port
- * @param data private data, that will be passed to cb
- * @retval port local event channel port on success
- * @retval -errno negative code on error
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * @param remote_dom Peer domain that already owns @p remote_port.
+ * @param remote_port Event-channel port in @p remote_dom.
+ * @param cb Callback invoked when the local channel fires.
+ * @param data User data pointer passed to @p cb.
+ *
+ * @return Local event-channel port on success, negative errno value on failure.
  */
 int bind_interdomain_event_channel(domid_t remote_dom, evtchn_port_t remote_port,
-		evtchn_cb_t cb, void *data);
+				   evtchn_cb_t cb, void *data);
 
 /**
- * Bind user-defined handler to specified event-channel
+ * @brief Attach a callback to an already allocated local event channel.
  *
- * @param port event channel number
- * @param cb pointer to event channel handler
- * @param data private data, that will be passed to handler as parameter
- * @retval 0 on success
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * @param port Local event-channel port number.
+ * @param cb Callback to invoke when the port is signaled.
+ * @param data User data pointer passed to @p cb.
+ *
+ * @retval 0 on success.
  */
 int bind_event_channel(evtchn_port_t port, evtchn_cb_t cb, void *data);
 
 /**
- * Unbind handler from event channel, substitute it with empty callback
+ * @brief Remove the callback bound to an event channel.
  *
- * @param port event channel number to unbind
- * @retval 0 on success
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * The channel remains allocated, but subsequent notifications are recorded as
+ * missed events until another callback is registered.
+ *
+ * @param port Local event-channel port number.
+ *
+ * @retval 0 on success.
  */
 int unbind_event_channel(evtchn_port_t port);
 
 /**
- * Check if missed events are present on specified port.
- * @param port event channel number
- * @retval 1 if missed events are present
- * @retval 0 otherwise
+ * @brief Get and clear the missed-event state for an unbound channel.
+ *
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * @param port Local event-channel port number.
+ *
+ * @retval 1 At least one event was recorded while no callback was bound.
+ * @retval 0 Otherwise.
  */
 int get_missed_events(evtchn_port_t port);
 
 /**
- * Disable event processing on specified port.
- * @param port event channel number
- * @retval 0 on success
- * @retval -errno negative code on error
+ * @brief Mask local delivery for an event channel.
+ *
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * @param port Local event-channel port number.
+ *
+ * @retval 0 Always returned after updating the shared-info mask bit.
  */
 int mask_event_channel(evtchn_port_t port);
 
 /**
- * Enable event processing on specified port.
- * @param port event channel number
- * @retval 0 on success
- * @retval -errno negative code on error
+ * @brief Unmask local delivery for an event channel.
+ *
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * @param port Local event-channel port number.
+ *
+ * @retval 0 Always returned after updating the shared-info mask bit.
  */
 int unmask_event_channel(evtchn_port_t port);
 
 /**
- * Clear event channel from pending events
- * @param port event channel number
+ * @brief Clear the pending bit for an event channel.
+ *
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * @param port Local event-channel port number.
  */
 void clear_event_channel(evtchn_port_t port);
 
 /**
- * Initialize Xen event channel driver, used on initialization
- * @retval 0 on success
- * @retval -errno negative code on error
+ * @brief Initialize Xen event handling for the current guest.
+ *
+ * @kconfig_dep{CONFIG_XEN_EVENTS}
+ *
+ * This function prepares the per-port callback table and connects the Zephyr
+ * ISR to the Xen event interrupt described by devicetree.
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Xen shared-info page is not mapped.
  */
 int xen_events_init(void);
+
+/** @} */
 
 #endif /* __XEN_EVENTS_H__ */

--- a/include/zephyr/xen/generic.h
+++ b/include/zephyr/xen/generic.h
@@ -3,10 +3,26 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Internal Xen support helpers.
+ * @ingroup xen_internal
+ */
+
 #ifndef __XEN_GENERIC_H__
 #define __XEN_GENERIC_H__
 
 #include <zephyr/xen/public/xen.h>
+
+/**
+ * @defgroup xen_internal Xen internal support
+ * @ingroup xen_support
+ * @brief Share low-level helpers used by the Zephyr Xen support code.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 #define XEN_PAGE_SIZE		4096
 #define XEN_PAGE_SHIFT		12
@@ -31,5 +47,9 @@
 	__atomic_compare_exchange_n(ptr, &stored, new, 0, __ATOMIC_SEQ_CST, \
 				__ATOMIC_SEQ_CST) ? new : old; \
 })
+
+/** @endcond */
+
+/** @} */
 
 #endif /* __XEN_GENERIC_H__ */

--- a/include/zephyr/xen/gnttab.h
+++ b/include/zephyr/xen/gnttab.h
@@ -3,101 +3,149 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Xen grant table helpers.
+ * @ingroup xen_grant_tables
+ */
+
 #ifndef __XEN_GNTTAB_H__
 #define __XEN_GNTTAB_H__
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <zephyr/xen/public/grant_table.h>
 
-/*
- * Assigns gref and permits access to 4K page for specific domain.
+/**
+ * @defgroup xen_grant_tables Xen grant tables
+ * @ingroup xen_support
+ * @brief Share memory with foreign domains and map foreign grants.
+ * @{
+ */
+
+/**
+ * @brief Grant another domain access to a guest frame.
  *
- * @param domid - id of the domain you sharing gref with
- * @param gfn - guest frame number of page, where grant will be located
- * @param readonly - permit readonly access to shared grant
- * @return - gref assigned to shared grant
+ * @kconfig_dep{CONFIG_XEN_GRANT_TABLE}
+ *
+ * @param domid Foreign domain that receives access to the frame.
+ * @param gfn Guest frame number to expose.
+ * @param readonly Set to ``true`` to grant read-only access.
+ *
+ * @return Grant reference that identifies the new entry.
  */
 grant_ref_t gnttab_grant_access(domid_t domid, unsigned long gfn,
-		bool readonly);
+				bool readonly);
 
-/*
- * Finished access for previously shared grant. Does NOT
- * free memory, if it was previously allocated by
+/**
+ * @brief Release a grant reference created by gnttab_grant_access().
+ *
+ * This does NOT free memory that was previously allocated by
  * gnttab_alloc_and_grant().
  *
- * @param gref - grant reference that need to be closed
- * @return - zero on success, non-zero on failure
+ * @kconfig_dep{CONFIG_XEN_GRANT_TABLE}
+ *
+ * @param gref Grant reference to release.
+ *
+ * @retval 0 on success.
  */
 int gnttab_end_access(grant_ref_t gref);
 
-/*
- * Allocates 4K page for grant and share it via returned
- * gref. Need to k_free memory, which was allocated in
- * @map parameter after grant releasing.
+/**
+ * @brief Allocate a page and immediately grant access to it.
  *
- * @param map - double pointer to memory, where grant will be allocated
- * @param readonly - permit readonly access to allocated grant
- * @return -  grant ref on success or negative errno on failure
+ * The caller must release the grant and then ``k_free()`` the buffer returned
+ * in @p map once it is no longer needed.
+ *
+ * @kconfig_dep{CONFIG_XEN_GRANT_TABLE}
+ *
+ * @param[out] map Buffer that receives the page base address.
+ * @param readonly Set to ``true`` to grant read-only access.
+ *
+ * @return Grant reference on success, negative errno value on failure.
+ * @retval -ENOMEM Page allocation fails.
  */
 int32_t gnttab_alloc_and_grant(void **map, bool readonly);
 
-/*
- * Provides interface to acquire one or more pages that can be used for
- * mapping of foreign frames. Should be freed by gnttab_put_pages()
- * after use.
+/**
+ * @brief Allocate pages that can host grant mappings.
  *
- * @param npages - number of pages to allocate.
- * @return - pointer to page start address, that can be used as host_addr
- *           in struct gnttab_map_grant_ref, NULL on error.
+ * The returned range is suitable for use as ``host_addr`` in ``struct
+ * gnttab_map_grant_ref`` entries. Release it with gnttab_put_pages() after use.
+ *
+ * @kconfig_dep{CONFIG_XEN_GRANT_TABLE}
+ *
+ * @param npages Number of pages to allocate.
+ *
+ * @return Base address of the allocated range, or ``NULL`` on failure.
  */
 void *gnttab_get_pages(unsigned int npages);
 
-/*
- * Releases pages that were used for mapping foreign grant frames,
- * should be called after unmapping.
+/**
+ * @brief Release pages allocated by gnttab_get_pages().
  *
- * @param start_addr - pointer to start address of allocated buffer.
- * @param npages - number of pages allocated for the buffer.
- * @return - zero on success, non-zero on failure
+ * @kconfig_dep{CONFIG_XEN_GRANT_TABLE}
+ *
+ * @param start_addr Base address returned by gnttab_get_pages().
+ * @param npages Number of pages to release.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int gnttab_put_pages(void *start_addr, unsigned int npages);
 
-/*
- * Maps foreign grant ref to Zephyr address space.
+/**
+ * @brief Map one or more foreign grant references.
  *
- * @param map_ops - array of prepared gnttab_map_grant_ref's for mapping
- * @param count - number of grefs in map_ops array
- * @return - zero on success or negative errno on failure
- *           also per-page status will be set in map_ops[i].status (GNTST_*)
+ * The ``host_addr`` pages referenced by @p map_ops must be 4K-aligned and
+ * should be obtained from gnttab_get_pages().
  *
- * To map foreign frames you need 4K-aligned memory pages, which will be
- * used as host_addr for grant mapping - it should be acquired by gnttab_get_pages()
- * function.
+ * @kconfig_dep{CONFIG_XEN_GRANT_TABLE}
  *
- * If CONFIG_XEN_REGIONS is enabled, only addresses from extended regions are
- * supported.
+ * @param[in,out] map_ops Array of prepared map operations.
+ * @param count Number of entries in @p map_ops.
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EFAULT Xen extended regions are enabled and a host address is
+ *         outside them.
+ *
+ * Xen also stores a per-entry status code in each ``map_ops[i].status`` field.
  */
 int gnttab_map_refs(struct gnttab_map_grant_ref *map_ops, unsigned int count);
 
-/*
- * Unmap foreign grant refs. The gnttab_put_pages() should be used after this for
- * pages that were successfully unmapped.
+/**
+ * @brief Unmap one or more foreign grant references.
  *
- * @param unmap_ops - array of prepared gnttab_unmap_grant_ref's for unmapping
- * @param count - number of grefs in unmap_ops array
- * @return - @count on success or negative errno on failure
- *           also per-page status will be set in unmap_ops[i].status (GNTST_*)
+ * Use gnttab_put_pages() afterwards for the pages that were successfully
+ * unmapped.
  *
- * If CONFIG_XEN_REGIONS is enabled, only addresses from extended regions are
- * supported.
+ * @kconfig_dep{CONFIG_XEN_GRANT_TABLE}
+ *
+ * @param[in,out] unmap_ops Array of prepared unmap operations.
+ * @param count Number of entries in @p unmap_ops.
+ *
+ * @return Value returned by the ``GNTTABOP_unmap_grant_ref`` hypercall (0 on
+ *         success), negative errno value on failure.
+ * @retval -EFAULT Xen extended regions are enabled and a host address is
+ *         outside them.
+ *
+ * Xen also stores a per-entry status code in each ``unmap_ops[i].status``
+ * field.
  */
 int gnttab_unmap_refs(struct gnttab_unmap_grant_ref *unmap_ops, unsigned int count);
 
-/*
- * Convert grant ref status codes (GNTST_*) to text messages.
+/**
+ * @brief Convert a Xen grant-table status into readable text.
  *
- * @param status - negative GNTST_* code, that needs to be converted
- * @return - constant pointer to text message, associated with @status
+ * @kconfig_dep{CONFIG_XEN_GRANT_TABLE}
+ *
+ * @param status Negative ``GNTST_*`` status code.
+ *
+ * @return Pointer to a constant error string.
  */
 const char *gnttabop_error(int16_t status);
+
+/** @} */
 
 #endif /* __XEN_GNTTAB_H__ */

--- a/include/zephyr/xen/hvm.h
+++ b/include/zephyr/xen/hvm.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Xen HVM operations.
+ * @ingroup xen_hvm
+ */
+
 #ifndef __XEN_HVM_H__
 #define __XEN_HVM_H__
 
@@ -11,7 +18,35 @@
 
 #include <zephyr/kernel.h>
 
+/**
+ * @defgroup xen_hvm Xen HVM operations
+ * @ingroup xen_support
+ * @brief Configure Xen HVM guest parameters through HVM hypercalls.
+ * @{
+ */
+
+/**
+ * @brief Set an HVM parameter for a Xen domain.
+ *
+ * @param idx HVM parameter selector, typically one of the ``HVM_PARAM_*`` constants.
+ * @param domid Target Xen domain identifier.
+ * @param value Parameter value to store.
+ *
+ * @return 0 on success, negative errno value on failure.
+ */
 int hvm_set_parameter(int idx, int domid, uint64_t value);
+
+/**
+ * @brief Get an HVM parameter from a Xen domain.
+ *
+ * @param idx HVM parameter selector, typically one of the ``HVM_PARAM_*`` constants.
+ * @param domid Target Xen domain identifier.
+ * @param[out] value Pointer to the buffer that receives the parameter value.
+ *
+ * @return 0 on success, negative errno value on failure.
+ */
 int hvm_get_parameter(int idx, int domid, uint64_t *value);
+
+/** @} */
 
 #endif /* __XEN_HVM_H__ */

--- a/include/zephyr/xen/memory.h
+++ b/include/zephyr/xen/memory.h
@@ -3,6 +3,12 @@
  * Copyright (c) 2023 EPAM Systems
  */
 
+/**
+ * @file
+ * @brief Xen memory management operations.
+ * @ingroup xen_memory_management
+ */
+
 #ifndef ZEPHYR_XEN_MEMORY_H_
 #define ZEPHYR_XEN_MEMORY_H_
 
@@ -11,81 +17,95 @@
 #include <zephyr/xen/public/xen.h>
 
 /**
- * Add mapping for specified page frame in Xen domain physmap.
+ * @defgroup xen_memory_management Xen memory management
+ * @ingroup xen_support
+ * @brief Manage domain physmaps and Xen-owned resources.
+ * @{
+ */
+
+/**
+ * @brief Add a single mapping to a domain physmap.
  *
- * @param domid	domain id, where mapping will be added. For unprivileged should
- *		be DOMID_SELF.
- * @param idx	index into space being mapped.
- * @param space	XENMAPSPACE_* mapping space identifier.
- * @param gpfn	page frame where the source mapping page should appear.
- * @return	zero on success, negative errno on error.
+ * @param domid Domain whose physmap is updated. Unprivileged callers must use
+ *              ``DOMID_SELF``.
+ * @param idx Index within the Xen mapping space identified by @p space.
+ * @param space Mapping space selector, typically one of the ``XENMAPSPACE_*``
+ *              constants.
+ * @param gpfn Guest frame number where the mapping becomes visible.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xendom_add_to_physmap(int domid, unsigned long idx, unsigned int space,
 			  xen_pfn_t gpfn);
 
 /**
- * Add mapping for specified set of page frames to Xen domain physmap.
+ * @brief Add multiple mappings to a domain physmap.
  *
- * @param domid		domain id, where mapping will be added. For unprivileged
- *			should be DOMID_SELF.
- * @param foreign_domid	for gmfn_foreign - domain id, whose pages being mapped,
- *			0 for other.
- * @param space		XENMAPSPACE_* mapping space identifier.
- * @param size		number of page frames being mapped.
- * @param idxs		array of indexes into space being mapped.
- * @param gpfns		array of page frames where the mapping should appear.
- * @param errs		array of per-index error codes.
- * @return		zero on success, negative errno on error.
+ * @param domid Domain whose physmap is updated. Unprivileged callers must use
+ *              ``DOMID_SELF``.
+ * @param foreign_domid Foreign domain identifier used with
+ * ``XENMAPSPACE_gmfn_foreign``. Pass ``0`` for the other mapping spaces.
+ * @param space Mapping space selector, typically one of the ``XENMAPSPACE_*``
+ *              constants.
+ * @param size Number of mappings described by the arrays.
+ * @param idxs Array of mapping-space indexes.
+ * @param gpfns Array of guest frame numbers that receive the mappings.
+ * @param[out] errs Array that receives a per-entry Xen status code.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xendom_add_to_physmap_batch(int domid, int foreign_domid,
 				unsigned int space, unsigned int size,
 				xen_ulong_t *idxs, xen_pfn_t *gpfns, int *errs);
 
 /**
- * Removes page frame from Xen domain physmap.
+ * @brief Remove a mapping from a domain physmap.
  *
- * @param domid	domain id, whose page is going to be removed. For unprivileged
- *		should be DOMID_SELF.
- * @param gpfn	page frame number, that needs to be removed
- * @return	zero on success, negative errno on error.
+ * @param domid Domain whose physmap is updated. Unprivileged callers must use
+ * ``DOMID_SELF``.
+ * @param gpfn Guest frame number to remove.
+ *
+ * @return 0 on success, negative errno value on failure.
  */
 int xendom_remove_from_physmap(int domid, xen_pfn_t gpfn);
 
 /**
- * Populate specified Xen domain page frames with memory.
+ * @brief Populate guest frames with memory.
  *
- * @param domid		domain id, where mapping will be added. For unprivileged
- *			should be DOMID_SELF.
- * @param extent_order	size/alignment of each extent (size is 2^extent_order),
- *			e.g. 0 for 4K extents, 9 for 2M etc.
- * @param nr_extents	number of page frames being populated.
- * @param mem_flags	N/A, should be 0 for Arm.
- * @param extent_start	page frame bases of extents to populate with memory.
- * @return		number of populated frames success, negative errno on
- *			error.
+ * @param domid Domain whose physmap is populated. Unprivileged callers must use
+ * ``DOMID_SELF``.
+ * @param extent_order Extent order used by Xen, where each extent covers
+ *                     ``2^extent_order`` pages.
+ * @param nr_extents Number of entries in @p extent_start.
+ * @param mem_flags Xen memory flags. Arm guests currently pass ``0``.
+ * @param extent_start Array of guest frame numbers that receive the populated
+ *                     extents.
+ *
+ * @return Number of populated extents on success, negative errno value on
+ *         failure.
  */
 int xendom_populate_physmap(int domid, unsigned int extent_order,
 			    unsigned int nr_extents, unsigned int mem_flags,
 			    xen_pfn_t *extent_start);
 
 /**
- * @brief Acquire a resource mapping for the Xen domain.
+ * @brief Acquire a Xen-managed resource mapping for a domain.
  *
- * Issues the XENMEM_acquire_resource hypercall to map a resource buffer
- * (e.g., I/O request server, grant table, VM trace buffer) into the
- * specified domain's physmap, or query its total size.
+ * @param domid Target domain identifier.
+ * @param type Xen resource type, for example ``XENMEM_resource_ioreq_server``.
+ * @param id Resource instance identifier interpreted according to @p type.
+ * @param frame Starting frame within the Xen resource. Ignored when
+ *              ``*nr_frames`` is 0 (size query).
+ * @param[in,out] nr_frames On entry, number of frames to acquire. On return,
+ * the number of frames that Xen reports for the request.
+ * @param[out] frame_list Guest frame list buffer: input GFNs for HVM guests,
+ *             output MFNs for PV guests.
  *
- * @param domid        Target domain identifier. Use DOMID_SELF for the calling domain.
- * @param type         Resource type identifier (e.g., XENMEM_resource_ioreq_server).
- * @param id           Resource-specific identifier (e.g., server ID or table ID).
- * @param frame        Starting frame number for mapping, or ignored if *nr_frames == 0.
- * @param nr_frames    [in,out] On input, number of frames to map; on return,
- *                     number of frames actually mapped (or total frames if queried).
- * @param frame_list   Guest frame list buffer: input GFNs for HVM guests,
- *                     output MFNs for PV guests.
- * @return             Zero on success, or a negative errno code on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int xendom_acquire_resource(domid_t domid, uint16_t type, uint32_t id, uint64_t frame,
 			    uint32_t *nr_frames, xen_pfn_t *frame_list);
+
+/** @} */
 
 #endif /* ZEPHYR_XEN_MEMORY_H_ */

--- a/include/zephyr/xen/regions.h
+++ b/include/zephyr/xen/regions.h
@@ -6,58 +6,85 @@
 
 /**
  * @file
- * @brief Xen extended regions interface
- *
- * This file provides the interface for managing Xen extended regions,
- * including allocation, freeing pages, and mapping/unmapping extended
- * regions memory.
+ * @brief Xen extended region management.
+ * @ingroup xen_regions
  */
 
 #ifndef ZEPHYR_INCLUDE_XEN_REGIONS_H_
 #define ZEPHYR_INCLUDE_XEN_REGIONS_H_
 
+#include <stdbool.h>
+#include <stddef.h>
+
 /**
- * Checks if the provided address belongs to the Xen extended regions
+ * @defgroup xen_regions Xen extended regions
+ * @ingroup xen_support
+ * @brief Allocate, free, and map buffers from Xen extended memory regions.
+ * @{
+ */
+
+/**
+ * @brief Check whether an address belongs to a configured extended region.
  *
- * @param ptr the address/pointer to be checked
- * @return true if the address is located within an extended region
- * @return false if the address is outside all extended regions or if ptr is NULL
+ * @kconfig_dep{CONFIG_XEN_REGIONS}
+ *
+ * @param ptr Address to test.
+ *
+ * @retval true @p ptr is inside one of the configured extended regions.
+ * @retval false @p ptr is ``NULL`` or outside all configured extended regions.
  */
 bool xen_region_is_addr_extreg(void *ptr);
 
 /**
- * Allocate pages from the extended regions
+ * @brief Allocate one or more contiguous pages from an extended region.
  *
- * @param nr_pages number of pages to be allocated
- * @return pointer to the allocated pages
+ * @kconfig_dep{CONFIG_XEN_REGIONS}
+ *
+ * @param nr_pages Number of Xen pages to allocate.
+ *
+ * @return Base address of the allocated range, or ``NULL`` if no region can satisfy the request.
  */
 void *xen_region_get_pages(size_t nr_pages);
 
 /**
- * Free pages on extended regions
+ * @brief Release pages previously allocated from an extended region.
  *
- * @param ptr pointer to the pages, allocated by xen_region_get_pages call
- * @param nr_pages number of pages that were allocated
- * @return zero on success, non-zero on failure
+ * @kconfig_dep{CONFIG_XEN_REGIONS}
+ *
+ * @param ptr Base address returned by xen_region_get_pages().
+ * @param nr_pages Number of pages to release.
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EIO @p ptr does not belong to a known extended region.
  */
 int xen_region_put_pages(void *ptr, size_t nr_pages);
 
 /**
- * Map extended region memory
+ * @brief Map an extended-region buffer into the kernel address space.
  *
- * @param ptr pointer to the pages, allocated by xen_region_get_pages call
- * @param nr_pages number of pages that should be mapped
- * @return zero on success, non-zero on failure
+ * @kconfig_dep{CONFIG_XEN_REGIONS}
+ *
+ * @param ptr Base address of the extended-region buffer.
+ * @param nr_pages Number of pages to map.
+ *
+ * @retval 0 on success.
+ * @retval -EFAULT @p ptr does not belong to an extended region.
  */
 int xen_region_map(void *ptr, size_t nr_pages);
 
 /**
- * Unmap extended region memory
+ * @brief Unmap an extended-region buffer from the kernel address space.
  *
- * @param ptr pointer to the pages, allocated by xen_region_get_pages call
- * @param nr_pages number of pages that should be unmapped
- * @return zero on success, non-zero on failure
+ * @kconfig_dep{CONFIG_XEN_REGIONS}
+ *
+ * @param ptr Base address of the extended-region buffer.
+ * @param nr_pages Number of pages to unmap.
+ *
+ * @retval 0 on success.
+ * @retval -EFAULT @p ptr does not belong to an extended region.
  */
 int xen_region_unmap(void *ptr, size_t nr_pages);
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_XEN_REGIONS_H_ */

--- a/include/zephyr/xen/version.h
+++ b/include/zephyr/xen/version.h
@@ -3,28 +3,51 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef __XEN_DOM0_VERSION_H__
-#define __XEN_DOM0_VERSION_H__
+
+/**
+ * @file
+ * @brief Xen version queries.
+ * @ingroup xen_version_queries
+ */
+
+#ifndef __XEN_VERSION_H__
+#define __XEN_VERSION_H__
+
 #include <zephyr/xen/generic.h>
 #include <zephyr/xen/public/version.h>
 #include <zephyr/xen/public/xen.h>
 
 /**
- * Get Xen hypervisor version integer encoded information
+ * @defgroup xen_version_queries Xen version queries
+ * @ingroup xen_support
+ * @brief Query the Xen hypervisor version exposed to the current domain.
+ * @{
+ */
+
+/**
+ * @brief Get the Xen version encoded as major and minor numbers.
  *
- * @retval Xen version on success
- * @retval -errno on error
+ * The returned integer uses the Xen ``major:minor`` encoding defined by
+ * ``XENVER_version``.
+ *
+ * @return Encoded Xen version on success, negative errno value on failure.
  */
 int xen_version(void);
 
 /**
- * Get Xen hypervisor extra version string
+ * @brief Get the Xen extra version string.
  *
- * @param extra - buffer to store the extra version string
- * @param len - maximum length of the buffer
- * @retval 0 on success
- * @retval -errno on error
+ * The destination buffer is cleared before the hypercall runs.
+ *
+ * @param[out] extra Destination buffer for the extra version string.
+ * @param len Size of @p extra in bytes. It must be at least
+ * ``XEN_EXTRAVERSION_LEN``.
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL @p extra is ``NULL`` or @p len is too small.
  */
 int xen_version_extraversion(char *extra, int len);
 
-#endif /* __XEN_DOM0_VERSION_H__ */
+/** @} */
+
+#endif /* __XEN_VERSION_H__ */


### PR DESCRIPTION
Introduce a hierarchical Doxygen group structure for the Xen support headers and document the Zephyr-facing hypercall wrappers.

If needed, I can try to keep the changes to the existing Doxygen docs to the minimum but there's several inconsistencies (copy/paste errors) that this is also fixing.

https://builds.zephyrproject.io/zephyr/pr/111094/docs/doxygen/html/group__xen__support.html
https://builds.zephyrproject.io/zephyr/pr/111094/api-coverage/