### PR TITLE
net: mcp: select PSA_CRYPTO for HTTP transport

### DIFF
--- a/subsys/net/lib/mcp/Kconfig
+++ b/subsys/net/lib/mcp/Kconfig
@@ -300,6 +300,7 @@ config MCP_TRANSPORT_HTTP
 	select UUID_V4
 	select UUID_BASE64
 	select ENTROPY_GENERATOR
+	select PSA_CRYPTO
 	select MBEDTLS
 	select MBEDTLS_PSA_CRYPTO_C
 	select PSA_WANT_ALG_SHA_1


### PR DESCRIPTION
MCP_TRANSPORT_HTTP selects mbedTLS and PSA_WANT_ALG_SHA_1, which now depend on PSA_CRYPTO (since 5ef6b3ae468).

That was not required when MCP landed because mbedTLS could be enabled without PSA_CRYPTO; the resulting Kconfig warnings now fail CI.