### PR TITLE
drivers: mipi_dbi: spi: allow splitting the data phase into chunks

### DIFF
--- a/drivers/mipi_dbi/Kconfig.spi
+++ b/drivers/mipi_dbi/Kconfig.spi
@@ -20,4 +20,16 @@ config MIPI_DBI_SPI_3WIRE
 	  driver. This requires manually packing each byte with a data/command
 	  bit, and may slow down display data transmission.
 
+config MIPI_DBI_SPI_DATA_CHUNK_SIZE
+	int "Max bytes per SPI data transfer (0 = unlimited)"
+	default 0
+	help
+	  When non-zero, the 4-wire data phase is split into separate SPI
+	  transfers of at most this many bytes each (chip-select cycles between
+	  chunks) instead of one continuous transfer. This is a workaround for
+	  SPI controllers that drop bytes during a single long continuous
+	  transfer (observed on i.MX93 LPSPI driving an SSD1680 e-paper panel:
+	  a single multi-byte transfer truncates the panel RAM write). Leave at
+	  0 (one transfer) for normal controllers; small values are much slower.
+
 endif # MIPI_DBI_SPI

--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -186,14 +186,31 @@ mipi_dbi_spi_write_helper_4wire_8bit(const struct device *dev,
 	}
 
 	if (len > 0) {
-		buffer.buf = (void *)data_buf;
-		buffer.len = len;
-
 		/* Set CD pin high for data */
 		gpio_pin_set_dt(&config->cmd_data, 1);
-		ret = spi_write(config->spi_dev, &dbi_config->config, &buf_set);
-		if (ret < 0) {
-			goto out;
+
+		/* Optionally split the data phase into chunks, with CS cycling
+		 * between them, to work around controllers that drop bytes during
+		 * a single long continuous transfer (see
+		 * CONFIG_MIPI_DBI_SPI_DATA_CHUNK_SIZE). 0 means one transfer.
+		 */
+		size_t max_chunk = len;
+		size_t off = 0;
+
+		if (CONFIG_MIPI_DBI_SPI_DATA_CHUNK_SIZE > 0) {
+			max_chunk = CONFIG_MIPI_DBI_SPI_DATA_CHUNK_SIZE;
+		}
+
+		while (off < len) {
+			size_t chunk = MIN(len - off, max_chunk);
+
+			buffer.buf = (void *)(data_buf + off);
+			buffer.len = chunk;
+			ret = spi_write(config->spi_dev, &dbi_config->config, &buf_set);
+			if (ret < 0) {
+				goto out;
+			}
+			off += chunk;
 		}
 	}
 out:


### PR DESCRIPTION
### Summary

Add `CONFIG_MIPI_DBI_SPI_DATA_CHUNK_SIZE` to the MIPI-DBI SPI driver. When
non-zero, the 4-wire data phase is sent as several SPI transfers of at most
that many bytes each (chip select cycles between chunks) instead of one
continuous transfer. Default is `0` (single transfer) — **no behavior change**
for controllers that work correctly today.

### Motivation

Some SPI controllers don't transfer a single multi-byte buffer reliably.
Concretely, on i.MX93 LPSPI (`spi_nxp_lpspi`) driving an SSD1680 e-paper panel
through `ssd16xx` + `mipi-dbi-spi`, a single multi-byte RAM write reaches the
panel only partially, while splitting the same data into smaller `spi_write`
calls is received intact (on this controller transfers up to ~10 bytes are
reliable). This option lets such panels/controllers work without changing the
default path for everyone else.

This is a **workaround**; the underlying LPSPI behavior is tracked in #111124.
The option is still generally useful: some controllers/panels genuinely require
the chip select to cycle between data chunks.

### Details

- New Kconfig `MIPI_DBI_SPI_DATA_CHUNK_SIZE` (int, default 0 = one transfer).
- `mipi_dbi_spi_write_helper_4wire_8bit()` splits the data phase accordingly.
- Command phase and the 0-default path are unchanged.

### Testing

- `frdm_imx93/mimx9352/m33` + SSD1680 2.13" e-paper over LPSPI3: image renders
  correctly with `CONFIG_MIPI_DBI_SPI_DATA_CHUNK_SIZE=8`; corrupted/partial
  with the default `0` (single transfer). On this controller chunk sizes up to
  10 render correctly, so 8 is used with margin.
- `default 0` build is byte-for-byte the same transfer path as before.
- `./scripts/ci/check_compliance.py` passes.

### Open question for reviewers

The chunking is currently applied only to the 4-wire 8-bit write helper — the
path exercised by the e-paper panel here. Setting the option on a 16-bit or
3-wire display would currently have no effect. Should I extend the same
chunking to `mipi_dbi_spi_write_helper_4wire_16bit()` and the 3-wire helper
for consistency? (Those paths are untested on my hardware.)

Related issue: #111124