### PR TITLE
soc: xlnx: versal: add RPU split TCM/OCM boot support

### DIFF
--- a/arch/arm/core/mpu/Kconfig
+++ b/arch/arm/core/mpu/Kconfig
@@ -85,6 +85,15 @@ config ARM_MPU_SRAM_WRITE_THROUGH
 	  When enabled, SRAM regions will use Write-Through cache policy
 	  instead of the default Write-Back policy.
 
+config ARM_MPU_SKIP_ARCH_INIT
+	bool "Skip MPU initialization"
+	help
+	  Select when early boot code (for example a TCM-resident stub) has
+	  already enabled and configured the MPU before the kernel runs.
+	  z_arm_mpu_init() skips reprogramming because disabling the MPU
+	  while executing from a region that is only reachable with the MPU
+	  enabled causes a fault.
+
 endif # ARM_MPU
 
 endif # CPU_HAS_MPU

--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -521,6 +521,18 @@ int z_arm_mpu_init(void)
 
 	LOG_DBG("total region count: %d", get_num_regions());
 
+#if defined(CONFIG_ARM_MPU_SKIP_ARCH_INIT)
+	/*
+	 * Early boot has already enabled the MPU. Re-programming requires
+	 * disabling it while executing from a region only reachable with
+	 * the MPU enabled.
+	 */
+	if ((__get_SCTLR() & SCTLR_M_Msk) != 0U) {
+		static_regions_num = mpu_config.num_regions;
+		return 0;
+	}
+#endif
+
 	arm_core_mpu_disable();
 
 #if defined(CONFIG_NOCACHE_MEMORY)

--- a/soc/xlnx/versal/CMakeLists.txt
+++ b/soc/xlnx/versal/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 zephyr_sources_ifdef(CONFIG_SOC_VERSAL_RPU soc.c)
+zephyr_sources_ifdef(CONFIG_SOC_VERSAL_RPU_OCM_BOOT rpu_ocm_boot.S)
+zephyr_sources_ifdef(CONFIG_SOC_VERSAL_RPU_OCM_BOOT rpu_ocm_mpu_init.c)
 zephyr_sources_ifdef(CONFIG_ARM_MMU arm_mmu_regions.c)
 
 zephyr_sources_ifdef(
@@ -16,8 +18,17 @@ zephyr_include_directories(.)
 
 if(CONFIG_SOC_VERSAL_RPU)
   # Use generic Cortex-A/R linker script
-  # Vectors are relocated to TCM 0x0 by z_arm_relocate_vector_table() at runtime
   set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld CACHE INTERNAL "")
+endif()
+
+if(CONFIG_SOC_VERSAL_RPU_OCM_BOOT)
+  # Boot stub runs from rom_start @ 0x0; z_arm_relocate_vector_table() copies the
+  # arch vector table over the stub once OCM is reachable.
+  zephyr_linker_sources(
+    ROM_START
+    SORT_KEY 0x0boot
+    rpu_ocm_boot.ld
+  )
 endif()
 
 if(CONFIG_SOC_VERSAL_APU)

--- a/soc/xlnx/versal/Kconfig
+++ b/soc/xlnx/versal/Kconfig
@@ -14,6 +14,25 @@ config SOC_VERSAL_RPU
 	select SOC_RESET_HOOK
 	select ARM_MPU
 
+# Split TCM/OCM memory map: vectors and boot stub in rom_start @ 0x0, image
+# linked in on-chip memory (OCM). Requires a TCM boot stub before any OCM
+# access; selected when rom_start relocation is enabled and SRAM is in OCM.
+config SOC_VERSAL_RPU_OCM_BOOT
+	bool
+	default y if ROMSTART_RELOCATION_ROM && \
+		($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SRAM)) >= 0xFF000000)
+	select ARM_MPU_SKIP_ARCH_INIT
+
+if SOC_VERSAL_RPU_OCM_BOOT
+
+config KERNEL_ENTRY
+	default "versal_rpu_ocm_boot"
+
+config ROM_START_OFFSET
+	default 0
+
+endif # SOC_VERSAL_RPU_OCM_BOOT
+
 config SOC_VERSAL_APU
 	select ARM64
 	select ARM_ARCH_TIMER

--- a/soc/xlnx/versal/arm_mpu_regions.c
+++ b/soc/xlnx/versal/arm_mpu_regions.c
@@ -152,9 +152,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 			 DEVICE_SHAREABLE |
 			 NOT_EXEC}),
 
-	/* Region 3: OCM overlay - 256KB normal cacheable memory from 0xFFFC0000
-	 * This overlays the peripheral region and marks OCM as cacheable
-	 */
+	/* Region 3: OCM overlay - 256KB normal cacheable memory from 0xFFFC0000 */
 	MPU_REGION_ENTRY(
 		"ocm",
 		0xFFFC0000,
@@ -163,12 +161,13 @@ static const struct arm_mpu_region mpu_regions[] = {
 			 NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE}),
 
 	/* Region 4: Interrupt vectors at 0x0
-	 * ARMv7-R requires vectors at 0x0 (HIVECS=0)
+	 * ARMv7-R requires vectors at 0x0 (HIVECS=0).  Use 256 B to cover the
+	 * relocated table plus its literal pool (vector_table.S + pool > 64 B).
 	 */
 	MPU_REGION_ENTRY(
 		"vectors",
 		0x00000000,
-		REGION_64B,
+		REGION_256B,
 		{.rasr = P_RO_U_NA_Msk |
 			 NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE}),
 

--- a/soc/xlnx/versal/rpu_ocm_boot.S
+++ b/soc/xlnx/versal/rpu_ocm_boot.S
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Early boot for split TCM/OCM images on Versal RPU.
+ *
+ * This stub is linked at the start of rom_start (TCM @ 0x0) and is the first
+ * code executed on reset. The arch vector table follows in rom_start and is
+ * copied to 0x0 by z_arm_relocate_vector_table() after the MPU maps OCM.
+ * The rest of the image is linked at CONFIG_SRAM_BASE_ADDRESS (typically OCM).
+ */
+
+#include <zephyr/toolchain.h>
+#include <zephyr/arch/arm/cortex_a_r/cpu.h>
+
+#define RPU_0_CFG		0xFF9A0100
+#define SCTLR_HIVECS		0x00002000
+
+GDATA(z_interrupt_stacks)
+GDATA(z_arm_svc_stack)
+GDATA(z_arm_sys_stack)
+GDATA(z_arm_fiq_stack)
+GDATA(z_arm_abort_stack)
+GDATA(z_arm_undef_stack)
+GTEXT(z_arm_reset)
+
+_ASM_FILE_PROLOGUE
+
+	.section .text.boot, "ax"
+	.global versal_rpu_ocm_boot
+	.type versal_rpu_ocm_boot, %function
+	.align 2
+
+/*
+ * Program one MPU region: select by index, set base, attributes, size+enable.
+ * r0=base, r1=(size<<1)|1, r2=attr, r3=index
+ */
+.macro mpu_program base, size_en, attr, index
+	mov r3, #\index
+	mcr p15, 0, r3, c6, c2, 0
+	isb
+	ldr r0, =\base
+	mcr p15, 0, r0, c6, c1, 0
+	ldr r2, =\attr
+	mcr p15, 0, r2, c6, c1, 4
+	ldr r1, =\size_en
+	mcr p15, 0, r1, c6, c1, 2
+	dsb
+	isb
+.endm
+
+versal_rpu_ocm_boot:
+	/*
+	 * Point every mode SP at OCM stacks (constants only — no OCM access yet).
+	 * Same layout as z_arm_reset in reset.S.
+	 */
+	ldr r5, =(z_arm_fiq_stack + CONFIG_ARMV7_FIQ_STACK_SIZE)
+	ldr r6, =(z_interrupt_stacks + CONFIG_ISR_STACK_SIZE)
+	ldr r7, =(z_arm_abort_stack + CONFIG_ARMV7_EXCEPTION_STACK_SIZE)
+	ldr r8, =(z_arm_undef_stack + CONFIG_ARMV7_EXCEPTION_STACK_SIZE)
+	ldr r9, =(z_arm_svc_stack + CONFIG_ARMV7_SVC_STACK_SIZE)
+	ldr r10, =(z_arm_sys_stack + CONFIG_ARMV7_SYS_STACK_SIZE)
+
+	msr CPSR_c, #(MODE_FIQ | I_BIT | F_BIT)
+	mov sp, r5
+
+	msr CPSR_c, #(MODE_IRQ | I_BIT | F_BIT)
+	mov sp, r6
+
+	msr CPSR_c, #(MODE_ABT | I_BIT | F_BIT)
+	mov sp, r7
+
+	msr CPSR_c, #(MODE_UND | I_BIT | F_BIT)
+	mov sp, r8
+
+	msr CPSR_c, #(MODE_SVC | I_BIT | F_BIT)
+	mov sp, r9
+
+	msr CPSR_c, #(MODE_SYS | I_BIT | F_BIT)
+	mov sp, r10
+
+	msr CPSR_c, #(MODE_SVC | I_BIT | F_BIT)
+
+#if defined(CONFIG_CPU_HAS_FPU)
+	mrc p15, 0, r0, c1, c0, 2
+	orr r0, r0, #(CPACR_CP10(CPACR_FA) | CPACR_CP11(CPACR_FA))
+	mcr p15, 0, r0, c1, c0, 2
+	isb
+#endif
+
+	/* Disable MPU and caches. */
+	mrc p15, 0, r2, c1, c0, 0
+	bic r2, r2, #0x5
+	bic r2, r2, #SCTLR_HIVECS
+	bic r2, r2, #0x1000
+	mcr p15, 0, r2, c1, c0, 0
+	isb
+
+	mov r2, #0
+	mcr p15, 0, r2, c7, c5, 0
+	mcr p15, 0, r2, c15, c5, 0
+	dsb
+	isb
+
+	/* Disable all 16 MPU regions. */
+	mov r3, #0
+1:	mcr p15, 0, r3, c6, c2, 0
+	mrc p15, 0, r2, c6, c1, 2
+	bic r2, r2, #1
+	dsb
+	mcr p15, 0, r2, c6, c1, 2
+	dsb
+	isb
+	add r3, r3, #1
+	cmp r3, #16
+	bne 1b
+
+	/*
+	 * Minimal MPU map (must stay in TCM assembly — mpu_config lives in OCM
+	 * and cannot be accessed before these regions are enabled):
+	 *   0: TCM 512K cacheable (vectors at 0x0 after relocation)
+	 *   1: device 2G
+	 *   2: OCM SRAM (same window as the working arch+SoC boot stub)
+	 */
+	mpu_program 0x00000000, 0x25, 0x10b, 0
+	mpu_program 0x80000000, 0x3d, 0x105, 1
+	mpu_program CONFIG_SRAM_BASE_ADDRESS, 0x23, 0x30b, 2
+
+	/* Clear VINITHI after device region is mapped. */
+	ldr r0, =RPU_0_CFG
+	ldr r1, [r0]
+	bic r1, r1, #0x4
+	str r1, [r0]
+	dsb
+
+	/* Enable MPU + I/D-cache (SCTLR bits M=1, C=1, I=12). */
+	mrc p15, 0, r1, c1, c0, 0
+	bic r1, r1, #SCTLR_HIVECS
+	ldr r0, =0x1005
+	orr r1, r1, r0
+	dsb
+	mcr p15, 0, r1, c1, c0, 0
+	isb
+
+	b z_arm_reset

--- a/soc/xlnx/versal/rpu_ocm_boot.ld
+++ b/soc/xlnx/versal/rpu_ocm_boot.ld
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Boot stub is placed at the start of rom_start (before the vector table).
+ * On reset the CPU executes this code from TCM; z_arm_relocate_vector_table()
+ * later copies the vector table to address 0.
+ */
+KEEP(*(.text.boot))

--- a/soc/xlnx/versal/rpu_ocm_mpu_init.c
+++ b/soc/xlnx/versal/rpu_ocm_mpu_init.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/common/init.h>
+#include <zephyr/linker/linker-defs.h>
+
+#include <cmsis_core.h>
+
+void relocate_vector_table(void)
+{
+	size_t vector_size = (size_t)_vector_end - (size_t)_vector_start;
+	uintptr_t addr = 0U;
+
+	write_sctlr(read_sctlr() & ~HIVECS);
+	(void)arch_early_memcpy((void *)addr, (void *)_vector_start, vector_size);
+
+	/*
+	 * Boot enables D/I-cache before z_arm_reset.  Without maintenance the
+	 * relocated table at 0x0 may not be visible to instruction fetch, and
+	 * prefetch-abort dispatch at 0xc faults with IFAR == 0xc.
+	 */
+	for (uintptr_t off = 0U; off < vector_size; off += 32U) {
+		L1C_CleanInvalidateDCacheMVA((void *)(addr + off));
+	}
+	L1C_InvalidateICacheAll();
+	__ISB();
+}


### PR DESCRIPTION
## Summary

Enable **Versal RPU split TCM/OCM images**: a TCM-resident boot stub and `rom_start` live at address `0`, while the main Zephyr image runs from on-chip memory (OCM, e.g. `0xFFFC0000`).

Unlike the MPS4 ITCM/SRAM split (Cortex-M, MPU off at reset), Versal RPU is **Cortex-R5**: OCM is not executable until the ARM MPU maps it. Reset must run TCM-resident code that programs a minimal MPU map before branching to `z_arm_reset` in OCM.

The series is two commits:

1. **arch/arm** — generic `CONFIG_ARM_MPU_BOOT_CONFIGURED` hook (no Versal-specific arch code)
2. **soc/xlnx/versal** — TCM boot stub, linker placement, vector relocation with cache maintenance

Board DTS/defconfig changes are **not** in this PR. Platforms opt in via devicetree + Kconfig (see Testing).

## Background

On Versal RPU, TCM at `0x0` is small and must hold reset entry + eventually the vector table. The application is often linked in OCM.

The normal `z_arm_mpu_init()` path disables the MPU and reprograms all regions from OCM-linked data. That is unsafe here: while the MPU is off or mid-reprogram, OCM-linked code and fetches at `0x0` are not executable, causing **prefetch aborts at `0xc`**.

A SoC-only `--wrap=z_arm_mpu_init()` skip was tried but proved unreliable on hardware (no `static_regions_num` update; MPU reprogram still faulted).

## Solution

### Early boot (SoC)

When `SOC_VERSAL_RPU_OCM_BOOT` is enabled (auto-selected when `ROMSTART_RELOCATION_ROM` is set and `zephyr,sram` is in OCM, address `>= 0xFF000000`):

- **`KERNEL_ENTRY`** defaults to `versal_rpu_ocm_boot` — reset enters the TCM stub, not the arch vector table directly.
- **`rpu_ocm_boot.ld`** places `.text.boot` at the start of `rom_start` via a `ROM_START` linker fragment (`SORT_KEY 0x0boot`).
- **`versal_rpu_ocm_boot`** (assembly, TCM-resident):
  - Sets mode stacks (constants only — no OCM access yet)
  - Programs a minimal MPU map inline (TCM, 2 GB device window, OCM SRAM) — cannot use `mpu_config[]` in OCM before mapping
  - Clears VINITHI, enables MPU + I/D-cache
  - Branches to `z_arm_reset` in OCM
- **`relocate_vector_table()`** override in `rpu_ocm_mpu_init.c` (called from arch `z_arm_relocate_vector_table()` in `reset.S`):
  - Copies the arch vector table from `rom_start` to `0x0` (overwriting the stub)
  - Performs D-cache clean/invalidate + I-cache invalidate so exception dispatch at `0x0`/`0xc` works with caches enabled

### Kernel init (arch)

When `CONFIG_ARM_MPU_BOOT_CONFIGURED` is selected and `SCTLR.M` is already set, `z_arm_mpu_init()` sets `static_regions_num = mpu_config.num_regions` and **returns without** disabling or reprogramming the MPU.

### MPU region table

Vectors MPU region expanded from 64 B to **256 B** in `arm_mpu_regions.c` to cover the relocated table plus its literal pool.

## Changes

| Commit | Files |
|--------|-------|
| `arch: arm: add ARM_MPU_BOOT_CONFIGURED for pre-enabled MPU` | `arch/arm/core/mpu/Kconfig`, `arch/arm/core/mpu/arm_mpu.c` |
| `soc: xlnx: versal: add RPU OCM boot stub` | `rpu_ocm_boot.S`, `rpu_ocm_boot.ld`, `rpu_ocm_mpu_init.c`, `soc/xlnx/versal/Kconfig`, `CMakeLists.txt`, `arm_mpu_regions.c` |

**Not included** (removed during review rework):

- Arch `__reset` / `vector_table.S` indirection
- Kconfig symbols in `Kconfig.defconfig` (moved to `soc/xlnx/versal/Kconfig`; OCM detection uses `$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SRAM))`, not deprecated `SRAM_BASE_ADDRESS`)

## Testing

Validated on **Versal RPU hardware** (`versal_rpu`) with OCM as SRAM:

- Boot stub executes from TCM `@ 0x0`
- Image linked and runs from OCM `@ 0xFFFC0000`
- Kernel reaches `main()` / shell without MPU prefetch abort at `0xc`

```sh
west build -p always -b versal_rpu tests/misc/test_build
```

**Required platform settings** (board overlay/defconfig — not in this PR):

| Setting | Purpose |
|---------|---------|
| `zephyr,sram = &ocm0` (or `&ocm`) | Link main image into OCM |
| `CONFIG_XIP=n` | RAM-linked (non-XIP) layout |
| `CONFIG_ROMSTART_RELOCATION_ROM=y` | Place `rom_start` (stub + vectors) in TCM `@ 0x0` |
| `CONFIG_ROMSTART_REGION_ADDRESS=0x00000000` | TCM alias (default) |
| `CONFIG_ROMSTART_REGION_SIZE=4` | 4 KB `rom_start` — room for boot stub + vector table |

Auto-selected when the above OCM layout is detected:

- `SOC_VERSAL_RPU_OCM_BOOT` → `KERNEL_ENTRY=versal_rpu_ocm_boot`, `ROM_START_OFFSET=0`, `ARM_MPU_BOOT_CONFIGURED`

## Notes for reviewers

- Arch change is limited to the generic early-MPU skip path; all Versal logic stays under `soc/xlnx/versal/`.
- MPS4-style `ROMSTART_RELOCATION_ROM` alone is insufficient on Cortex-R5 OCM — the TCM MPU bootstrap stub is required (validated on hardware).
- Board enablement can follow in a separate PR if preferred.