### PR TITLE
twister: Allow --shuffle-tests without --subset

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -447,8 +447,7 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
 
     parser.add_argument(
         "--shuffle-tests", action="store_true", default=None,
-        help="""Shuffle test execution order to get randomly distributed tests across subsets.
-                Used only when --subset is provided.""")
+        help="Shuffle test execution order to get randomly distributed tests.")
 
     parser.add_argument(
         "--shuffle-tests-seed", action="store", default=None,
@@ -973,10 +972,6 @@ def parse_arguments(
 
     if options.flash_before and options.device_flash_with_test:
         logger.error("--device-flash-with-test does not apply when --flash-before is used")
-        sys.exit(1)
-
-    if options.shuffle_tests and options.subset is None:
-        logger.error("--shuffle-tests requires --subset")
         sys.exit(1)
 
     if options.shuffle_tests_seed and options.shuffle_tests is None:

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -312,20 +312,20 @@ class TestPlan:
 
             self.generate_subset(subset, int(sets))
 
+        elif self.options.shuffle_tests:
+            self._shuffle_instances()
+
     def generate_subset(self, subset, sets):
         self.instances = OrderedDict(sorted(self.instances.items(),
                                 key=lambda x: (x[1].testsuite.name, x[0])))
 
         if self.options.shuffle_tests:
-            seed_value = int.from_bytes(os.urandom(8), byteorder="big")
-            if self.options.shuffle_tests_seed is not None:
-                seed_value = self.options.shuffle_tests_seed
-
-            logger.info(f"Shuffle tests with seed: {seed_value}")
-            random.seed(seed_value)
-            temp_list = list(self.instances.items())
-            random.shuffle(temp_list)
-            self.instances = OrderedDict(temp_list)
+            if sets > 1 and self.options.shuffle_tests_seed is None:
+                logger.warning(
+                    "Shuffling with a random seed across multiple subsets might not cover all "
+                    "tests. Consider providing a fixed seed with --shuffle-tests-seed."
+                )
+            self._shuffle_instances()
 
         # Do calculation based on what is actually going to be run and evaluated
         # at runtime, ignore the cases we already know going to be skipped.
@@ -357,6 +357,18 @@ class TestPlan:
             self.instances.update(skipped)
             self.instances.update(errors)
 
+    def _shuffle_instances(self):
+        """Shuffle test execution order to get randomly distributed tests."""
+        if self.options.shuffle_tests_seed is not None:
+            seed_value = self.options.shuffle_tests_seed
+        else:
+            seed_value = int.from_bytes(os.urandom(8), byteorder="big")
+
+        logger.info(f"Shuffle tests with seed: {seed_value}")
+        random.seed(seed_value)
+        temp_list = list(self.instances.items())
+        random.shuffle(temp_list)
+        self.instances = OrderedDict(temp_list)
 
     def report(self):
         if self.options.test_tree:

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -82,13 +82,6 @@ TESTDATA_1 = [
         None,
         None,
         None,
-        ['--shuffle-tests'],
-        '--shuffle-tests requires --subset'
-    ),
-    (
-        None,
-        None,
-        None,
         ['--shuffle-tests-seed', '0'],
         '--shuffle-tests-seed requires --shuffle-tests'
     ),
@@ -124,7 +117,6 @@ TESTDATA_1 = [
         'device serial without platform',
         'device serial with multiple platforms',
         'device flash with test without device testing',
-        'shuffle-tests without subset',
         'shuffle-tests-seed without shuffle-tests',
         'unrecognised argument',
         'pytest-twister-harness installed'


### PR DESCRIPTION
Previously --shuffle-tests required --subset to be set, which limited shuffling to subset-based runs. Remove that restriction so test execution order can be randomized in any run.

When shuffling with a random seed across multiple subsets, not all tests are guaranteed to be covered. Add a warning suggesting a fixed seed via --shuffle-tests-seed in that case.

---
You can try with a command:
`west twister -c -vv -ll debug --dry-run -T samples/subsys/mgmt/mcumgr/smp_svr -p nrf52840dk/nrf52840 --shuffle-tests --subset 1/2 --shuffle-tests-seed 1 && cat twister-out/testplan.json | grep name`
(use combination of parameters, no need to run, just --dry-run and check list of instances in testplan.json)