### PR TITLE
drivers: sensor: bmm350: I3C, features, fixes, and emulator

### DIFF
--- a/drivers/sensor/bosch/bmm350/CMakeLists.txt
+++ b/drivers/sensor/bosch/bmm350/CMakeLists.txt
@@ -10,3 +10,5 @@ zephyr_library_sources(
 )
 zephyr_library_sources_ifdef(CONFIG_BMM350_TRIGGER bmm350_trigger.c)
 zephyr_library_sources_ifdef(CONFIG_BMM350_STREAM bmm350_stream.c)
+zephyr_library_sources_ifdef(CONFIG_EMUL_BMM350 bmm350_emul.c)
+zephyr_include_directories_ifdef(CONFIG_EMUL_BMM350 .)

--- a/drivers/sensor/bosch/bmm350/Kconfig
+++ b/drivers/sensor/bosch/bmm350/Kconfig
@@ -31,3 +31,12 @@ config BMM350_STREAM
 	depends on !BMM350_TRIGGER
 
 endif # BMM350
+
+config EMUL_BMM350
+	bool "Emulator for the BMM350 Geomagnetic sensor"
+	default y
+	depends on BMM350
+	depends on EMUL
+	help
+	  Enable the hardware emulator for the BMM350. Doing so allows exercising
+	  the driver against an emulated bus without real hardware.

--- a/drivers/sensor/bosch/bmm350/Kconfig
+++ b/drivers/sensor/bosch/bmm350/Kconfig
@@ -5,13 +5,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BMM350
-	bool "BMM350 I2C Geomagnetic Chip"
+	bool "BMM350 Geomagnetic Chip"
 	default y
 	depends on DT_HAS_BOSCH_BMM350_ENABLED
-	select I2C
-	select I2C_RTIO
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMM350),i2c)
+	select I2C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMM350),i2c)
+	select I3C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMM350),i3c)
+	select I3C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMM350),i3c)
 	help
-	  Enable driver for BMM350 I2C-based Geomagnetic sensor.
+	  Enable driver for BMM350 I2C/I3C-based Geomagnetic sensor.
 
 if BMM350
 

--- a/drivers/sensor/bosch/bmm350/bmm350.c
+++ b/drivers/sensor/bosch/bmm350/bmm350.c
@@ -1113,7 +1113,7 @@ static int bmm350_init_chip(const struct device *dev)
 	ret = bmm350_reg_write(dev, BMM350_REG_PAD_CTRL, config->drive_strength);
 	if (ret != 0) {
 		LOG_ERR("%s: failed to set pad drive strength", dev->name);
-		return ret;
+		goto err_poweroff;
 	}
 
 	ret = bmm350_otp_dump_after_boot(dev);

--- a/drivers/sensor/bosch/bmm350/bmm350.c
+++ b/drivers/sensor/bosch/bmm350/bmm350.c
@@ -1026,6 +1026,11 @@ static void bmm350_submit_one_shot(const struct device *dev, struct rtio_iodev_s
 	read_sqe->flags |= RTIO_SQE_CHAINED;
 
 	cb_sqe = rtio_sqe_acquire(bus->rtio.ctx);
+	if (cb_sqe == NULL) {
+		rtio_sqe_drop_all(bus->rtio.ctx);
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
 
 	rtio_sqe_prep_callback_no_cqe(cb_sqe, bmm350_one_shot_complete,
 				      iodev_sqe, (void *)dev);

--- a/drivers/sensor/bosch/bmm350/bmm350.c
+++ b/drivers/sensor/bosch/bmm350/bmm350.c
@@ -1004,17 +1004,33 @@ static int bmm350_init(const struct device *dev)
 		FIELD_PREP(BMM350_INT_CTRL_INT_OD_MSK, DT_INST_PROP(inst, push_pull_int)) |        \
 		BMM350_INT_CTRL_DRDY_DATA_REG_EN_MSK | BMM350_INT_CTRL_INT_OUTPUT_EN_MSK,
 
+#define BMM350_BUS_IODEV_DEFINE(inst)                                                              \
+	COND_CODE_1(DT_INST_ON_BUS(inst, i3c),                                                     \
+		    (I3C_DT_IODEV_DEFINE(bmm350_bus_##inst, DT_DRV_INST(inst))),                   \
+		    (I2C_DT_IODEV_DEFINE(bmm350_bus_##inst, DT_DRV_INST(inst))))
+
+#define BMM350_BUS_TYPE(inst)                                                                      \
+	COND_CODE_1(DT_INST_ON_BUS(inst, i3c), (BMM350_BUS_TYPE_I3C), (BMM350_BUS_TYPE_I2C))
+
+#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(bosch_bmm350, i3c)
+#define BMM350_BUS_I3C_ID(inst)                                                                    \
+	COND_CODE_1(DT_INST_ON_BUS(inst, i3c), (.i3c.id = I3C_DEVICE_ID_DT_INST(inst),), ())
+#else
+#define BMM350_BUS_I3C_ID(inst)
+#endif
+
 #define BMM350_DEFINE(inst)                                                                        \
                                                                                                    \
 	RTIO_DEFINE(bmm350_rtio_ctx_##inst, 8, 8);                                                 \
-	I2C_DT_IODEV_DEFINE(bmm350_bus_##inst, DT_DRV_INST(inst));                                 \
+	BMM350_BUS_IODEV_DEFINE(inst);                                                             \
                                                                                                    \
 	static struct bmm350_data bmm350_data_##inst;                                              \
 	static const struct bmm350_config bmm350_config_##inst = {                                 \
 		.bus.rtio = {                                                                      \
 			.ctx = &bmm350_rtio_ctx_##inst,                                            \
 			.iodev = &bmm350_bus_##inst,                                               \
-			.type = BMM350_BUS_TYPE_I2C,                                               \
+			.type = BMM350_BUS_TYPE(inst),                                             \
+			BMM350_BUS_I3C_ID(inst)                                                    \
 		},										   \
 		.bus_io = &bmm350_bus_rtio,                                                        \
 		.default_odr = DT_INST_ENUM_IDX(inst, odr) + BMM350_DATA_RATE_400HZ,               \

--- a/drivers/sensor/bosch/bmm350/bmm350.c
+++ b/drivers/sensor/bosch/bmm350/bmm350.c
@@ -444,6 +444,11 @@ static int bmm350_channel_get(const struct device *dev, enum sensor_channel chan
 		bmm350_convert(val + 1, drv_data->mag_temp_data.mag[1]);
 		bmm350_convert(val + 2, drv_data->mag_temp_data.mag[2]);
 		break;
+	case SENSOR_CHAN_DIE_TEMP:
+		/* Stored in centi-degC (0.01 degC). */
+		val->val1 = drv_data->mag_temp_data.temperature / 100;
+		val->val2 = (drv_data->mag_temp_data.temperature % 100) * 10000;
+		break;
 	default:
 		return -ENOTSUP;
 	}

--- a/drivers/sensor/bosch/bmm350/bmm350.c
+++ b/drivers/sensor/bosch/bmm350/bmm350.c
@@ -276,6 +276,9 @@ static int set_powermode(const struct device *dev, enum bmm350_power_modes power
 
 		/* Set PMU command configuration to desired power mode */
 		ret = bmm350_reg_write(dev, BMM350_REG_PMU_CMD, reg_data);
+		if (ret != 0) {
+			return ret;
+		}
 		k_usleep(delay_us);
 	}
 
@@ -1091,6 +1094,10 @@ static int bmm350_init_chip(const struct device *dev)
 
 	/* Set the command in the command register */
 	ret = bmm350_reg_write(dev, BMM350_REG_CMD, soft_reset);
+	if (ret != 0) {
+		LOG_ERR("failed to issue soft reset");
+		goto err_poweroff;
+	}
 	k_usleep(BMM350_SOFT_RESET_DELAY);
 	/* Read chip ID (can only be read in sleep mode)*/
 	if (bmm350_reg_read(dev, BMM350_REG_CHIP_ID, &chip_id[0], sizeof(chip_id)) < 0) {

--- a/drivers/sensor/bosch/bmm350/bmm350.c
+++ b/drivers/sensor/bosch/bmm350/bmm350.c
@@ -14,6 +14,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/check.h>
+#include <zephyr/drivers/sensor/bmm350.h>
 
 #include "bmm350.h"
 #include "bmm350_decoder.h"
@@ -586,6 +587,217 @@ static int set_mag_odr_osr(const struct device *dev, const struct sensor_value *
 		LOG_ERR("failed to set suspend mode");
 		return -EIO;
 	}
+
+	return 0;
+}
+
+/*
+ * Delays (microseconds) used by the self-test sequence, matching the Bosch
+ * BMM350 SensorAPI (self_test_entry_config / self_test_config).
+ */
+#define BMM350_ST_SUSPEND_DELAY UINT32_C(30000)
+#define BMM350_ST_FGR_DELAY     UINT32_C(30000)
+#define BMM350_ST_BR_FAST_DELAY UINT32_C(4000)
+#define BMM350_ST_FM_FAST_DELAY UINT32_C(16000)
+#define BMM350_ST_USER_DELAY    UINT32_C(1000)
+#define BMM350_ST_SAMPLE_DELAY  UINT32_C(6000)
+
+/*
+ * Read the uncompensated X/Y magnetometer data and convert the LSB values to
+ * micro-Tesla using the default sensitivity coefficients. The self-test checks
+ * the differential response, so the (sample-independent) OTP compensation is
+ * intentionally not applied, matching the Bosch SensorAPI read_out_raw_data().
+ */
+static int bmm350_self_test_read_xy(const struct device *dev, int32_t out_ut[2])
+{
+	struct bmm350_raw_mag_data raw;
+	int32_t raw_xy[2];
+	int ret;
+
+	ret = bmm350_reg_read(dev, BMM350_REG_MAG_X_XLSB, raw.buf, sizeof(raw.buf));
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Sign-extend the 24-bit X and Y samples (buf[0..1] are dummy bytes). */
+	for (int i = 0; i < 2; i++) {
+		int off = (i * 3) + 2;
+
+		raw_xy[i] = ((int32_t)raw.buf[off + 2] << 24) | ((int32_t)raw.buf[off + 1] << 16) |
+			    ((int32_t)raw.buf[off] << 8);
+		raw_xy[i] >>= 8;
+
+		out_ut[i] = (int32_t)(((int64_t)raw_xy[i] * BMM350_LSB_TO_UT_XY_COEFF) /
+				      BMM350_LSB_TO_UT_COEFF_DIV);
+	}
+
+	return 0;
+}
+
+/* Self-test entry configuration: re-initialise the TMR sensor (Bosch sequence). */
+static int bmm350_self_test_entry(const struct device *dev)
+{
+	struct bmm350_pmu_cmd_status_0 status;
+	int ret;
+
+	/* Reset can only be triggered from suspend mode. */
+	ret = bmm350_reg_write(dev, BMM350_REG_PMU_CMD, BMM350_PMU_CMD_SUS);
+	if (ret != 0) {
+		return ret;
+	}
+	k_usleep(BMM350_ST_SUSPEND_DELAY);
+
+	/* 100 Hz ODR, 2x averaging, all axes enabled. */
+	ret = bmm350_reg_write(dev, BMM350_REG_PMU_CMD_AGGR_SET,
+			       BMM350_ODR_100HZ | (BMM350_AVG_2 << BMM350_AVG_POS));
+	if (ret != 0) {
+		return ret;
+	}
+	ret = bmm350_reg_write(dev, BMM350_REG_PMU_CMD_AXIS_EN, BMM350_EN_XYZ_MSK);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Flux-guide reset with full CRST recharge. */
+	ret = bmm350_reg_write(dev, BMM350_REG_PMU_CMD, BMM350_PMU_CMD_FGR);
+	if (ret != 0) {
+		return ret;
+	}
+	k_usleep(BMM350_ST_FGR_DELAY);
+	ret = bmm350_get_pmu_cmd_status_0(dev, &status);
+	if (ret != 0) {
+		return ret;
+	}
+	if (status.pmu_cmd_value != BMM350_PMU_CMD_STATUS_0_FGR) {
+		return -EIO;
+	}
+
+	/* Bit reset with full CRST recharge. */
+	ret = bmm350_reg_write(dev, BMM350_REG_PMU_CMD, BMM350_PMU_CMD_BR_FAST);
+	if (ret != 0) {
+		return ret;
+	}
+	k_usleep(BMM350_ST_BR_FAST_DELAY);
+	ret = bmm350_get_pmu_cmd_status_0(dev, &status);
+	if (ret != 0) {
+		return ret;
+	}
+	if (status.pmu_cmd_value != BMM350_PMU_CMD_STATUS_0_BR_FAST) {
+		return -EIO;
+	}
+
+	/* Prime fast-forced mode. */
+	ret = bmm350_reg_write(dev, BMM350_REG_PMU_CMD, BMM350_PMU_CMD_FM_FAST);
+	if (ret != 0) {
+		return ret;
+	}
+	k_usleep(BMM350_ST_FM_FAST_DELAY);
+	ret = bmm350_get_pmu_cmd_status_0(dev, &status);
+	if (ret != 0) {
+		return ret;
+	}
+	if (status.pmu_cmd_value != BMM350_PMU_CMD_STATUS_0_FM_FAST) {
+		return -EIO;
+	}
+	k_usleep(10);
+
+	return 0;
+}
+
+/*
+ * Apply the given user self-test excitation (BMM350_SELF_TEST_*), trigger one
+ * fast-forced measurement and return the excited axis response in micro-Tesla.
+ */
+static int bmm350_self_test_axis(const struct device *dev, uint8_t st_cmd, uint8_t axis,
+				 int32_t *out_ut)
+{
+	struct bmm350_pmu_cmd_status_0 status;
+	int32_t xy_ut[2];
+	int ret;
+
+	ret = bmm350_reg_write(dev, BMM350_REG_TMR_SELFTEST_USER, st_cmd);
+	if (ret != 0) {
+		return ret;
+	}
+	k_usleep(BMM350_ST_USER_DELAY);
+
+	ret = bmm350_reg_write(dev, BMM350_REG_PMU_CMD, BMM350_PMU_CMD_FM_FAST);
+	if (ret != 0) {
+		return ret;
+	}
+	k_usleep(BMM350_ST_SAMPLE_DELAY);
+
+	ret = bmm350_get_pmu_cmd_status_0(dev, &status);
+	if (ret != 0) {
+		return ret;
+	}
+	if (status.pmu_cmd_value != BMM350_PMU_CMD_STATUS_0_FM_FAST) {
+		return -EIO;
+	}
+
+	ret = bmm350_self_test_read_xy(dev, xy_ut);
+	if (ret != 0) {
+		return ret;
+	}
+
+	*out_ut = xy_ut[axis];
+
+	return 0;
+}
+
+int bmm350_self_test(const struct device *dev, struct bmm350_self_test_result *result)
+{
+	uint8_t last_pwr_mode;
+	int ret;
+
+	if (result == NULL) {
+		return -EINVAL;
+	}
+
+	/* Remember the power mode so it can be restored after the test. */
+	ret = bmm350_reg_read(dev, BMM350_REG_PMU_CMD, &last_pwr_mode, 1);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = bmm350_self_test_entry(dev);
+	if (ret == 0) {
+		ret = bmm350_self_test_axis(dev, BMM350_SELF_TEST_POS_X, 0, &result->x_pos);
+	}
+	if (ret == 0) {
+		ret = bmm350_self_test_axis(dev, BMM350_SELF_TEST_NEG_X, 0, &result->x_neg);
+	}
+	if (ret == 0) {
+		ret = bmm350_self_test_axis(dev, BMM350_SELF_TEST_POS_Y, 1, &result->y_pos);
+	}
+	if (ret == 0) {
+		ret = bmm350_self_test_axis(dev, BMM350_SELF_TEST_NEG_Y, 1, &result->y_neg);
+	}
+
+	/* Disable the user self-test regardless of the outcome. */
+	(void)bmm350_reg_write(dev, BMM350_REG_TMR_SELFTEST_USER, BMM350_SELF_TEST_DISABLE);
+	k_usleep(BMM350_ST_USER_DELAY);
+
+	/* Restore normal mode if the device was in normal mode before the test. */
+	if (last_pwr_mode == BMM350_PMU_CMD_NM) {
+		int restore_ret = bmm350_set_powermode(dev, BMM350_NORMAL_MODE);
+
+		if (ret == 0) {
+			ret = restore_ret;
+		}
+	}
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	result->x_delta = result->x_pos - result->x_neg;
+	result->y_delta = result->y_pos - result->y_neg;
+
+	LOG_INF("%s: self-test XP=%d XN=%d YP=%d YN=%d (uT)", dev->name, result->x_pos,
+		result->x_neg, result->y_pos, result->y_neg);
+	LOG_INF("%s: self-test X_delta=%d Y_delta=%d (uT)", dev->name, result->x_delta,
+		result->y_delta);
 
 	return 0;
 }

--- a/drivers/sensor/bosch/bmm350/bmm350.h
+++ b/drivers/sensor/bosch/bmm350/bmm350.h
@@ -477,7 +477,7 @@ struct bmm350_encoded_data {
 	struct {
 		uint64_t timestamp;
 		uint8_t events : 1;
-		uint8_t channels : 3;
+		uint8_t channels : 4;
 	} header;
 	struct mag_compensate comp;
 	struct bmm350_raw_mag_data payload;

--- a/drivers/sensor/bosch/bmm350/bmm350.h
+++ b/drivers/sensor/bosch/bmm350/bmm350.h
@@ -15,14 +15,17 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i3c.h>
 #include <zephyr/rtio/rtio.h>
 
 #define DT_DRV_COMPAT bosch_bmm350
 
 #define BMM350_BUS_I2C DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#define BMM350_BUS_I3C DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
 
 enum bmm350_bus_type {
 	BMM350_BUS_TYPE_I2C,
+	BMM350_BUS_TYPE_I3C,
 };
 
 struct bmm350_bus {
@@ -30,6 +33,12 @@ struct bmm350_bus {
 		struct rtio *ctx;
 		struct rtio_iodev *iodev;
 		enum bmm350_bus_type type;
+#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(bosch_bmm350, i3c)
+		struct {
+			struct i3c_device_desc *desc;
+			const struct i3c_device_id id;
+		} i3c;
+#endif
 	} rtio;
 	struct i2c_dt_spec i2c;
 };

--- a/drivers/sensor/bosch/bmm350/bmm350_bus.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_bus.c
@@ -13,6 +13,13 @@ static int bmm350_bus_check_rtio(const struct bmm350_bus *bus)
 	if (bus->rtio.type == BMM350_BUS_TYPE_I2C) {
 		return i2c_is_ready_iodev(bus->rtio.iodev) ? 0 : -ENODEV;
 	}
+#if defined(CONFIG_I3C)
+	if (bus->rtio.type == BMM350_BUS_TYPE_I3C) {
+		const struct i3c_iodev_data *data = bus->rtio.iodev->data;
+
+		return device_is_ready(data->bus) ? 0 : -ENODEV;
+	}
+#endif
 
 	return -EIO;
 }
@@ -36,6 +43,8 @@ static int bmm350_prep_reg_read_rtio_async(const struct bmm350_bus *bus,
 	rtio_sqe_prep_read(read_buf_sqe, iodev, RTIO_PRIO_NORM, buf, size, NULL);
 	if (bus->rtio.type == BMM350_BUS_TYPE_I2C) {
 		read_buf_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	} else if (bus->rtio.type == BMM350_BUS_TYPE_I3C) {
+		read_buf_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
 	}
 
 	/** Send back last SQE so it can be concatenated later. */
@@ -67,6 +76,8 @@ static int bmm350_prep_reg_write_rtio_async(const struct bmm350_bus *bus,
 	rtio_sqe_prep_tiny_write(write_sqe, iodev, RTIO_PRIO_NORM, write_buf, 2, NULL);
 	if (bus->rtio.type == BMM350_BUS_TYPE_I2C) {
 		write_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP;
+	} else if (bus->rtio.type == BMM350_BUS_TYPE_I3C) {
+		write_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP;
 	}
 
 	/** Send back SQE so it can be concatenated later. */

--- a/drivers/sensor/bosch/bmm350/bmm350_decoder.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_decoder.c
@@ -23,9 +23,11 @@ void bmm350_decoder_compensate_raw_data(const struct bmm350_raw_mag_data *raw_da
 	 * fields (e.g. during self-test or saturation).
 	 */
 	int64_t out_data[4];
+	int64_t t_delta;
+	const int64_t scale100 = (int64_t)BMM350_MAG_COMP_COEFF_SCALING * 100;
 	int32_t dut_offset_coef[3], dut_sensit_coef[3], dut_tco[3], dut_tcs[3];
 
-	/* Convert mag lsb to uT and temp lsb to degC */
+	/* Convert mag lsb to uT and temp lsb to centi-degC (0.01 degC) */
 	out_data[0] = ((sign_extend(raw_data->magn_x, BMM350_SIGNED_24_BIT) *
 			BMM350_LSB_TO_UT_XY_COEFF) /
 		       BMM350_LSB_TO_UT_COEFF_DIV);
@@ -35,20 +37,21 @@ void bmm350_decoder_compensate_raw_data(const struct bmm350_raw_mag_data *raw_da
 	out_data[2] = ((sign_extend(raw_data->magn_z, BMM350_SIGNED_24_BIT) *
 			BMM350_LSB_TO_UT_Z_COEFF) /
 		       BMM350_LSB_TO_UT_COEFF_DIV);
-	out_data[3] = ((sign_extend(raw_data->temp, BMM350_SIGNED_24_BIT) *
-			BMM350_LSB_TO_UT_TEMP_COEFF) /
-		       BMM350_LSB_TO_UT_COEFF_DIV);
+	out_data[3] = ((int64_t)sign_extend(raw_data->temp, BMM350_SIGNED_24_BIT) *
+		       BMM350_LSB_TO_UT_TEMP_COEFF * 100) /
+		      BMM350_LSB_TO_UT_COEFF_DIV;
 
+	/* Subtract the 25.49 degC offset (expressed in centi-degC). */
 	if (out_data[3] > 0) {
-		out_data[3] = (out_data[3] - (2549 / 100));
+		out_data[3] = (out_data[3] - 2549);
 	} else if (out_data[3] < 0) {
-		out_data[3] = (out_data[3] + (2549 / 100));
+		out_data[3] = (out_data[3] + 2549);
 	}
 
 	/* Apply compensation to temperature reading */
 	out_data[3] = (((BMM350_MAG_COMP_COEFF_SCALING + comp->dut_sensit_coef.t_sens) *
 			out_data[3]) +
-		       comp->dut_offset_coef.t_offs) /
+		       ((int64_t)comp->dut_offset_coef.t_offs * 100)) /
 		      BMM350_MAG_COMP_COEFF_SCALING;
 
 	/* Store magnetic compensation structure to an array */
@@ -68,18 +71,23 @@ void bmm350_decoder_compensate_raw_data(const struct bmm350_raw_mag_data *raw_da
 	dut_tcs[1] = comp->dut_tcs.tcs_y;
 	dut_tcs[2] = comp->dut_tcs.tcs_z;
 
+	/*
+	 * Temperature delta from the calibration reference, in centi-degC. The
+	 * TCO/TCS stages below fold in the extra factor of 100 via scale100 so the
+	 * temperature correction uses the full 0.01 degC resolution.
+	 */
+	t_delta = out_data[3] - ((int64_t)comp->dut_t0 * 100);
+
 	/* Compensate raw magnetic data */
 	for (size_t indx = 0; indx < 3; indx++) {
 		out_data[indx] = (out_data[indx] *
 				  (BMM350_MAG_COMP_COEFF_SCALING + dut_sensit_coef[indx])) /
 				 BMM350_MAG_COMP_COEFF_SCALING;
 		out_data[indx] = (out_data[indx] + dut_offset_coef[indx]);
-		out_data[indx] = ((out_data[indx] * BMM350_MAG_COMP_COEFF_SCALING) +
-				  (dut_tco[indx] * (out_data[3] - comp->dut_t0))) /
-				 BMM350_MAG_COMP_COEFF_SCALING;
-		out_data[indx] = (out_data[indx] * BMM350_MAG_COMP_COEFF_SCALING) /
-				 (BMM350_MAG_COMP_COEFF_SCALING +
-				  (dut_tcs[indx] * (out_data[3] - comp->dut_t0)));
+		out_data[indx] = ((out_data[indx] * scale100) + (dut_tco[indx] * t_delta)) /
+				 scale100;
+		out_data[indx] = (out_data[indx] * scale100) /
+				 (scale100 + (dut_tcs[indx] * t_delta));
 	}
 
 	out->mag[0] = (int32_t)((((out_data[0] * BMM350_MAG_COMP_COEFF_SCALING) -

--- a/drivers/sensor/bosch/bmm350/bmm350_decoder.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_decoder.c
@@ -17,7 +17,12 @@ void bmm350_decoder_compensate_raw_data(const struct bmm350_raw_mag_data *raw_da
 					const struct mag_compensate *comp,
 					struct bmm350_mag_temp_data *out)
 {
-	int32_t out_data[4];
+	/*
+	 * Use 64-bit intermediates: the cross-axis stage scales by
+	 * BMM350_MAG_COMP_COEFF_SCALING twice, which overflows int32 for strong
+	 * fields (e.g. during self-test or saturation).
+	 */
+	int64_t out_data[4];
 	int32_t dut_offset_coef[3], dut_sensit_coef[3], dut_tco[3], dut_tcs[3];
 
 	/* Convert mag lsb to uT and temp lsb to degC */
@@ -77,19 +82,19 @@ void bmm350_decoder_compensate_raw_data(const struct bmm350_raw_mag_data *raw_da
 				  (dut_tcs[indx] * (out_data[3] - comp->dut_t0)));
 	}
 
-	out->mag[0] = ((((out_data[0] * BMM350_MAG_COMP_COEFF_SCALING) -
+	out->mag[0] = (int32_t)((((out_data[0] * BMM350_MAG_COMP_COEFF_SCALING) -
 		    (comp->cross_axis.cross_x_y * out_data[1])) *
 		   BMM350_MAG_COMP_COEFF_SCALING) /
 		  ((BMM350_MAG_COMP_COEFF_SCALING * BMM350_MAG_COMP_COEFF_SCALING) -
 		   (comp->cross_axis.cross_y_x * comp->cross_axis.cross_x_y)));
 
-	out->mag[1] = ((((out_data[1] * BMM350_MAG_COMP_COEFF_SCALING) -
+	out->mag[1] = (int32_t)((((out_data[1] * BMM350_MAG_COMP_COEFF_SCALING) -
 		    (comp->cross_axis.cross_y_x * out_data[0])) *
 		   BMM350_MAG_COMP_COEFF_SCALING) /
 		  ((BMM350_MAG_COMP_COEFF_SCALING * BMM350_MAG_COMP_COEFF_SCALING) -
 		   (comp->cross_axis.cross_y_x * comp->cross_axis.cross_x_y)));
 
-	out->mag[2] = (out_data[2] +
+	out->mag[2] = (int32_t)(out_data[2] +
 		  (((out_data[0] *
 		     ((comp->cross_axis.cross_y_x * comp->cross_axis.cross_z_y) -
 		      (comp->cross_axis.cross_z_x * BMM350_MAG_COMP_COEFF_SCALING))) -
@@ -99,9 +104,10 @@ void bmm350_decoder_compensate_raw_data(const struct bmm350_raw_mag_data *raw_da
 		  (((BMM350_MAG_COMP_COEFF_SCALING * BMM350_MAG_COMP_COEFF_SCALING) -
 		    comp->cross_axis.cross_y_x * comp->cross_axis.cross_x_y)));
 
-	LOG_DBG("mag data %d %d %d", out_data[0], out_data[1], out_data[2]);
+	LOG_DBG("mag data %d %d %d", (int32_t)out_data[0], (int32_t)out_data[1],
+		(int32_t)out_data[2]);
 
-	out->temperature = out_data[3];
+	out->temperature = (int32_t)out_data[3];
 }
 
 #ifdef CONFIG_SENSOR_ASYNC_API

--- a/drivers/sensor/bosch/bmm350/bmm350_decoder.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_decoder.c
@@ -139,6 +139,9 @@ static uint8_t bmm350_encode_channel(enum sensor_channel chan)
 		encode_bmask |= BIT(1);
 		encode_bmask |= BIT(2);
 		break;
+	case SENSOR_CHAN_DIE_TEMP:
+		encode_bmask |= BIT(3);
+		break;
 	default:
 		break;
 	}
@@ -160,6 +163,7 @@ int bmm350_encode(const struct device *dev,
 
 	if (is_trigger) {
 		edata->header.channels |= bmm350_encode_channel(SENSOR_CHAN_MAGN_XYZ);
+		edata->header.channels |= bmm350_encode_channel(SENSOR_CHAN_DIE_TEMP);
 	} else {
 		const struct sensor_chan_spec *const channels = read_config->channels;
 		size_t num_channels = read_config->count;
@@ -216,6 +220,7 @@ static int bmm350_decoder_get_size_info(struct sensor_chan_spec chan_spec,
 	case SENSOR_CHAN_MAGN_X:
 	case SENSOR_CHAN_MAGN_Y:
 	case SENSOR_CHAN_MAGN_Z:
+	case SENSOR_CHAN_DIE_TEMP:
 		*base_size = sizeof(struct sensor_q31_data);
 		*frame_size = sizeof(struct sensor_q31_sample_data);
 		return 0;
@@ -297,6 +302,33 @@ static int bmm350_decoder_decode(const uint8_t *buffer,
 		out->readings[0].values[0] = (result.mag[0] << 8) / 100;
 		out->readings[0].values[1] = (result.mag[1] << 8) / 100;
 		out->readings[0].values[2] = (result.mag[2] << 8) / 100;
+
+		*fit = 1;
+		return 1;
+	}
+	case SENSOR_CHAN_DIE_TEMP: {
+
+		channel_request = bmm350_encode_channel(chan_spec.chan_type);
+		if ((channel_request & edata->header.channels) != channel_request) {
+			return -ENODATA;
+		}
+
+		struct sensor_q31_data *out = data_out;
+
+		out->header.base_timestamp_ns = edata->header.timestamp;
+		out->header.reading_count = 1;
+
+		struct bmm350_mag_temp_data result;
+
+		bmm350_decoder_compensate_raw_data(&edata->payload,
+						   &edata->comp,
+						   &result);
+
+		/** Temperature is in centi-degC (0.01 degC),
+		 * so we're reserving 8 fractional bits.
+		 */
+		out->shift = (31 - 8);
+		out->readings[0].value = (result.temperature << 8) / 100;
 
 		*fit = 1;
 		return 1;

--- a/drivers/sensor/bosch/bmm350/bmm350_emul.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_emul.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT bosch_bmm350
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i2c_emul.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+#include "bmm350.h"
+#include "bmm350_emul.h"
+
+LOG_MODULE_DECLARE(BMM350, CONFIG_SENSOR_LOG_LEVEL);
+
+/* Size of the emulated register file (highest register is CMD at 0x7E). */
+#define BMM350_EMUL_NUM_REGS 0x80
+
+/*
+ * BMM350 I2C reads return two dummy bytes ahead of the addressed register data.
+ */
+#define BMM350_EMUL_READ_DUMMY_BYTES 2
+
+struct bmm350_emul_data {
+	uint8_t reg[BMM350_EMUL_NUM_REGS];
+};
+
+struct bmm350_emul_cfg {
+};
+
+static void bmm350_emul_reset(const struct emul *target)
+{
+	struct bmm350_emul_data *data = target->data;
+
+	memset(data->reg, 0, sizeof(data->reg));
+	data->reg[BMM350_REG_CHIP_ID] = BMM350_CHIP_ID;
+}
+
+static void bmm350_emul_set_reg24(struct bmm350_emul_data *data, uint8_t reg, int32_t val)
+{
+	data->reg[reg] = (uint8_t)(val & 0xFF);
+	data->reg[reg + 1] = (uint8_t)((val >> 8) & 0xFF);
+	data->reg[reg + 2] = (uint8_t)((val >> 16) & 0xFF);
+}
+
+void bmm350_emul_set_mag_raw(const struct emul *target, int32_t x, int32_t y, int32_t z)
+{
+	struct bmm350_emul_data *data = target->data;
+
+	bmm350_emul_set_reg24(data, BMM350_REG_MAG_X_XLSB, x);
+	bmm350_emul_set_reg24(data, BMM350_REG_MAG_Y_XLSB, y);
+	bmm350_emul_set_reg24(data, BMM350_REG_MAG_Z_XLSB, z);
+}
+
+void bmm350_emul_set_temp_raw(const struct emul *target, int32_t temp)
+{
+	struct bmm350_emul_data *data = target->data;
+
+	bmm350_emul_set_reg24(data, BMM350_REG_TEMP_XLSB, temp);
+}
+
+static void bmm350_emul_handle_write(const struct emul *target, uint8_t reg, uint8_t val)
+{
+	struct bmm350_emul_data *data = target->data;
+
+	switch (reg) {
+	case BMM350_REG_CMD:
+		if (val == BMM350_CMD_SOFTRESET) {
+			bmm350_emul_reset(target);
+		}
+		break;
+	case BMM350_REG_OTP_CMD_REG:
+		data->reg[reg] = val;
+		/* Mark the OTP command complete; OTP words read back as zero. */
+		data->reg[BMM350_REG_OTP_STATUS_REG] = BMM350_OTP_STATUS_CMD_DONE;
+		data->reg[BMM350_REG_OTP_DATA_MSB_REG] = 0;
+		data->reg[BMM350_REG_OTP_DATA_LSB_REG] = 0;
+		break;
+	case BMM350_REG_TMR_SELFTEST_USER: {
+		/* Model a self-test excitation response on the selected axis. */
+		const int32_t st_raw = 30000;
+
+		data->reg[reg] = val;
+		switch (val) {
+		case BMM350_SELF_TEST_POS_X:
+			bmm350_emul_set_reg24(data, BMM350_REG_MAG_X_XLSB, st_raw);
+			break;
+		case BMM350_SELF_TEST_NEG_X:
+			bmm350_emul_set_reg24(data, BMM350_REG_MAG_X_XLSB, -st_raw);
+			break;
+		case BMM350_SELF_TEST_POS_Y:
+			bmm350_emul_set_reg24(data, BMM350_REG_MAG_Y_XLSB, st_raw);
+			break;
+		case BMM350_SELF_TEST_NEG_Y:
+			bmm350_emul_set_reg24(data, BMM350_REG_MAG_Y_XLSB, -st_raw);
+			break;
+		default:
+			break;
+		}
+		break;
+	}
+	case BMM350_REG_PMU_CMD: {
+		/* Reflect the issued command back through PMU_CMD_STATUS_0. */
+		uint8_t pmu_value = val & 0x07;
+		uint8_t status;
+
+		if (val == BMM350_PMU_CMD_BR_FAST) {
+			pmu_value = BMM350_PMU_CMD_STATUS_0_BR_FAST;
+		}
+		status = pmu_value << BMM350_PMU_CMD_VALUE_POS;
+
+		if (val == BMM350_PMU_CMD_NM) {
+			status |= BMM350_PWR_MODE_IS_NORMAL_MSK;
+		}
+
+		data->reg[reg] = val;
+		data->reg[BMM350_REG_PMU_CMD_STATUS_0] = status;
+		break;
+	}
+	default:
+		data->reg[reg] = val;
+		break;
+	}
+}
+
+static int bmm350_emul_transfer_i2c(const struct emul *target, struct i2c_msg *msgs, int num_msgs,
+				    int addr)
+{
+	struct bmm350_emul_data *data = target->data;
+
+	i2c_dump_msgs_rw(target->dev, msgs, num_msgs, addr, false);
+
+	if (num_msgs < 1) {
+		LOG_ERR("Invalid number of messages: %d", num_msgs);
+		return -EIO;
+	}
+	if ((msgs[0].flags & I2C_MSG_READ) || msgs[0].len < 1) {
+		LOG_ERR("Unexpected first message");
+		return -EIO;
+	}
+
+	uint8_t reg = msgs[0].buf[0];
+
+	if (num_msgs == 1) {
+		/* Write transaction: [reg, data...]. */
+		for (uint32_t i = 1; i < msgs[0].len; i++) {
+			bmm350_emul_handle_write(target, reg + (i - 1), msgs[0].buf[i]);
+		}
+		return 0;
+	}
+
+	/* Read transaction: register write followed by a read. */
+	struct i2c_msg *rd = &msgs[1];
+
+	if (!(rd->flags & I2C_MSG_READ)) {
+		LOG_ERR("Expected a read message");
+		return -EIO;
+	}
+
+	for (uint32_t i = 0; i < rd->len; i++) {
+		if (i < BMM350_EMUL_READ_DUMMY_BYTES) {
+			rd->buf[i] = 0;
+			continue;
+		}
+
+		uint8_t a = reg + (i - BMM350_EMUL_READ_DUMMY_BYTES);
+
+		rd->buf[i] = (a < BMM350_EMUL_NUM_REGS) ? data->reg[a] : 0;
+	}
+
+	return 0;
+}
+
+static int bmm350_emul_init(const struct emul *target, const struct device *parent)
+{
+	ARG_UNUSED(parent);
+
+	bmm350_emul_reset(target);
+
+	return 0;
+}
+
+static const struct i2c_emul_api bmm350_emul_api_i2c = {
+	.transfer = bmm350_emul_transfer_i2c,
+};
+
+#define BMM350_EMUL_DEFINE(n)                                                                      \
+	static const struct bmm350_emul_cfg bmm350_emul_cfg_##n;                                   \
+	static struct bmm350_emul_data bmm350_emul_data_##n;                                       \
+	EMUL_DT_INST_DEFINE(n, bmm350_emul_init, &bmm350_emul_data_##n, &bmm350_emul_cfg_##n,      \
+			    &bmm350_emul_api_i2c, NULL)
+
+/*
+ * Only the I2C transport is emulated. I3C bus instances also report as being on
+ * the I2C bus (I3C is backward compatible), so they are excluded explicitly.
+ */
+#define BMM350_EMUL(n) COND_CODE_1(DT_INST_ON_BUS(n, i3c), (), (BMM350_EMUL_DEFINE(n)))
+
+DT_INST_FOREACH_STATUS_OKAY(BMM350_EMUL)

--- a/drivers/sensor/bosch/bmm350/bmm350_emul.h
+++ b/drivers/sensor/bosch/bmm350/bmm350_emul.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_BMM350_BMM350_EMUL_H_
+#define ZEPHYR_DRIVERS_SENSOR_BMM350_BMM350_EMUL_H_
+
+#include <zephyr/drivers/emul.h>
+#include <stdint.h>
+
+/**
+ * @brief Set the raw (uncompensated) magnetometer sample registers.
+ *
+ * @param target Pointer to the emulator instance.
+ * @param x Raw X-axis value (signed 24-bit range).
+ * @param y Raw Y-axis value (signed 24-bit range).
+ * @param z Raw Z-axis value (signed 24-bit range).
+ */
+void bmm350_emul_set_mag_raw(const struct emul *target, int32_t x, int32_t y, int32_t z);
+
+/**
+ * @brief Set the raw (uncompensated) temperature sample register.
+ *
+ * @param target Pointer to the emulator instance.
+ * @param temp Raw temperature value (signed 24-bit range).
+ */
+void bmm350_emul_set_temp_raw(const struct emul *target, int32_t temp);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_BMM350_BMM350_EMUL_H_ */

--- a/drivers/sensor/bosch/bmm350/bmm350_stream.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_stream.c
@@ -143,6 +143,11 @@ static void bmm350_event_handler(const struct device *dev)
 	read_sqe->flags |= RTIO_SQE_CHAINED;
 
 	cb_sqe = rtio_sqe_acquire(cfg->bus.rtio.ctx);
+	if (cb_sqe == NULL) {
+		rtio_sqe_drop_all(cfg->bus.rtio.ctx);
+		bmm350_stream_result(dev, -ENOMEM);
+		return;
+	}
 
 	rtio_sqe_prep_callback_no_cqe(cb_sqe, bmm350_stream_event_complete,
 				      iodev_sqe, (void *)dev);

--- a/drivers/sensor/bosch/bmm350/bmm350_trigger.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_trigger.c
@@ -91,8 +91,15 @@ int bmm350_trigger_set(const struct device *dev, const struct sensor_trigger *tr
 	data->drdy_trigger = trig;
 	data->drdy_handler = handler;
 
-	/* Set PMU command configuration */
-	ret = bmm350_reg_write(dev, BMM350_REG_INT_CTRL, cfg->int_flags);
+	if (handler != NULL) {
+		/* Enable the data-ready interrupt output. */
+		ret = bmm350_reg_write(dev, BMM350_REG_INT_CTRL, cfg->int_flags);
+	} else {
+		/* Disable the data-ready interrupt output. */
+		ret = bmm350_reg_write(dev, BMM350_REG_INT_CTRL,
+				       cfg->int_flags & ~(BMM350_INT_CTRL_DRDY_DATA_REG_EN_MSK |
+							  BMM350_INT_CTRL_INT_OUTPUT_EN_MSK));
+	}
 	if (ret < 0) {
 		return ret;
 	}

--- a/dts/bindings/sensor/bosch,bmm350-i3c.yaml
+++ b/dts/bindings/sensor/bosch,bmm350-i3c.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Meta Platforms
+
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Bosch BMM350 Geomagnetic sensor on I3C.  See more info at:
+    https://www.bosch-sensortec.com/products/motion-sensors/magnetometers/bmm350/
+
+compatible: "bosch,bmm350"
+
+include: [i3c-device.yaml, "bosch,bmm350.yaml"]

--- a/include/zephyr/drivers/sensor/bmm350.h
+++ b/include/zephyr/drivers/sensor/bmm350.h
@@ -20,6 +20,47 @@
  * @{
  */
 
+#include <zephyr/device.h>
+
+/**
+ * @brief BMM350 user self-test result.
+ *
+ * Holds the magnetic response, in micro-Tesla, to the positive and negative
+ * user self-test excitation on the X and Y axes, together with the resulting
+ * per-axis delta (positive - negative). A healthy sensor produces a delta well
+ * above the device's self-test limit on both axes; see the BMM350 datasheet for
+ * the expected magnitude.
+ */
+struct bmm350_self_test_result {
+	int32_t x_pos;   /**< X-axis response to positive excitation [uT] */
+	int32_t x_neg;   /**< X-axis response to negative excitation [uT] */
+	int32_t y_pos;   /**< Y-axis response to positive excitation [uT] */
+	int32_t y_neg;   /**< Y-axis response to negative excitation [uT] */
+	int32_t x_delta; /**< x_pos - x_neg [uT] */
+	int32_t y_delta; /**< y_pos - y_neg [uT] */
+};
+
+/**
+ * @brief Run the BMM350 built-in user self-test.
+ *
+ * Re-initialises the TMR sensor and measures the response to a positive and
+ * negative excitation on the X and Y axes, following the Bosch SensorAPI
+ * sequence. The device configuration in place before the call is restored on
+ * return.
+ *
+ * The caller is responsible for judging the result against the device's
+ * self-test limit (see the BMM350 datasheet); this function only reports the
+ * measured responses.
+ *
+ * This must not be called while the sensor is streaming.
+ *
+ * @param dev    Pointer to the sensor device.
+ * @param result Output: per-axis self-test responses and deltas.
+ *
+ * @return 0 if successful, negative errno code on failure.
+ */
+int bmm350_self_test(const struct device *dev, struct bmm350_self_test_result *result);
+
 /**
  * @brief Performs a magnetic reset.
  *

--- a/tests/drivers/build_all/sensor/i3c.dtsi
+++ b/tests/drivers/build_all/sensor/i3c.dtsi
@@ -75,3 +75,10 @@ test_i3c_bmp581: bmp581@800000803e0000004 {
 	assigned-address = <0x8>;
 	int-gpios = <&test_gpio 0 0>;
 };
+
+test_i3c_bmm350: bmm350@900000803e0000009 {
+	compatible = "bosch,bmm350";
+	reg = <0x9 0x00000803 0xe0000009>;
+	assigned-address = <0x9>;
+	drdy-gpios = <&test_gpio 0 0>;
+};

--- a/tests/drivers/build_all/sensor/i3c.dtsi
+++ b/tests/drivers/build_all/sensor/i3c.dtsi
@@ -76,6 +76,13 @@ test_i3c_bmp581: bmp581@800000803e0000004 {
 	int-gpios = <&test_gpio 0 0>;
 };
 
+test_i3c_bmm350: bmm350@900000803e0000009 {
+	compatible = "bosch,bmm350";
+	reg = <0x9 0x00000803 0xe0000009>;
+	assigned-address = <0x9>;
+	drdy-gpios = <&test_gpio 0 0>;
+};
+
 test_i3c_icm56686: icm56686@680000046a00000011 {
 	compatible = "invensense,icm56686";
 	reg = <0x68 0x0 0x0>;

--- a/tests/drivers/sensor/bmm350/CMakeLists.txt
+++ b/tests/drivers/sensor/bmm350/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Meta Platforms
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(bmm350)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/sensor/bmm350/app.overlay
+++ b/tests/drivers/sensor/bmm350/app.overlay
@@ -1,0 +1,10 @@
+/* Copyright (c) 2026 Meta Platforms
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c0 {
+	bmm350: bmm350@14 {
+		compatible = "bosch,bmm350";
+		reg = <0x14>;
+	};
+};

--- a/tests/drivers/sensor/bmm350/prj.conf
+++ b/tests/drivers/sensor/bmm350/prj.conf
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Meta Platforms
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+
+CONFIG_SENSOR=y
+CONFIG_EMUL=y
+
+CONFIG_I2C_LOG_LEVEL_WRN=y
+CONFIG_SENSOR_LOG_LEVEL_WRN=y

--- a/tests/drivers/sensor/bmm350/src/main.c
+++ b/tests/drivers/sensor/bmm350/src/main.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Meta Platforms
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/bmm350.h>
+#include <zephyr/ztest.h>
+
+#include "bmm350.h"
+#include "bmm350_emul.h"
+
+struct bmm350_fixture {
+	const struct device *dev;
+	const struct emul *target;
+};
+
+static void *bmm350_setup(void)
+{
+	static struct bmm350_fixture fixture = {
+		.dev = DEVICE_DT_GET(DT_NODELABEL(bmm350)),
+		.target = EMUL_DT_GET(DT_NODELABEL(bmm350)),
+	};
+
+	zassert_not_null(fixture.dev);
+	zassert_not_null(fixture.target);
+	return &fixture;
+}
+
+static void bmm350_before(void *f)
+{
+	struct bmm350_fixture *fixture = f;
+
+	/* Start each test from a clean register file. */
+	bmm350_emul_set_mag_raw(fixture->target, 0, 0, 0);
+	bmm350_emul_set_temp_raw(fixture->target, 0);
+}
+
+ZTEST_SUITE(bmm350, NULL, bmm350_setup, bmm350_before, NULL, NULL);
+
+/* The driver must have initialised against the emulated chip (chip-id, OTP, reset). */
+ZTEST_F(bmm350, test_device_ready)
+{
+	zassert_true(device_is_ready(fixture->dev), "BMM350 device not ready");
+}
+
+/* Expected channel value (Gauss) for a given raw axis sample, with zero OTP trim. */
+static double expected_mag_gauss(int32_t raw, int32_t coeff)
+{
+	int32_t micro_tesla = (int32_t)(((int64_t)raw * coeff) / BMM350_LSB_TO_UT_COEFF_DIV);
+
+	return (double)micro_tesla / 100.0;
+}
+
+ZTEST_F(bmm350, test_fetch_mag)
+{
+	const int32_t raw_x = 10000;
+	const int32_t raw_y = 20000;
+	const int32_t raw_z = -15000;
+	struct sensor_value val[3];
+
+	bmm350_emul_set_mag_raw(fixture->target, raw_x, raw_y, raw_z);
+
+	zassert_ok(sensor_sample_fetch(fixture->dev));
+	zassert_ok(sensor_channel_get(fixture->dev, SENSOR_CHAN_MAGN_XYZ, val));
+
+	zassert_within(sensor_value_to_double(&val[0]),
+		       expected_mag_gauss(raw_x, BMM350_LSB_TO_UT_XY_COEFF), 0.01, "X mismatch");
+	zassert_within(sensor_value_to_double(&val[1]),
+		       expected_mag_gauss(raw_y, BMM350_LSB_TO_UT_XY_COEFF), 0.01, "Y mismatch");
+	zassert_within(sensor_value_to_double(&val[2]),
+		       expected_mag_gauss(raw_z, BMM350_LSB_TO_UT_Z_COEFF), 0.01, "Z mismatch");
+}
+
+ZTEST_F(bmm350, test_fetch_mag_single_channels)
+{
+	struct sensor_value val;
+
+	bmm350_emul_set_mag_raw(fixture->target, 30000, 0, 0);
+	zassert_ok(sensor_sample_fetch(fixture->dev));
+
+	zassert_ok(sensor_channel_get(fixture->dev, SENSOR_CHAN_MAGN_X, &val));
+	zassert_within(sensor_value_to_double(&val),
+		       expected_mag_gauss(30000, BMM350_LSB_TO_UT_XY_COEFF), 0.01, "X mismatch");
+}
+
+ZTEST_F(bmm350, test_die_temp)
+{
+	/* raw 50490 -> 50490/10 - 25.49 = 25.00 degC */
+	struct sensor_value val;
+
+	bmm350_emul_set_temp_raw(fixture->target, 50490);
+
+	zassert_ok(sensor_sample_fetch(fixture->dev));
+	zassert_ok(sensor_channel_get(fixture->dev, SENSOR_CHAN_DIE_TEMP, &val));
+
+	zassert_within(sensor_value_to_double(&val), 25.0, 0.05, "temperature mismatch: %d.%06d",
+		       val.val1, val.val2);
+}
+
+ZTEST_F(bmm350, test_attr_sampling_frequency)
+{
+	struct sensor_value odr = {.val1 = 100, .val2 = 0};
+	struct sensor_value read_back;
+
+	zassert_ok(sensor_attr_set(fixture->dev, SENSOR_CHAN_MAGN_XYZ,
+				   SENSOR_ATTR_SAMPLING_FREQUENCY, &odr));
+	zassert_ok(sensor_attr_get(fixture->dev, SENSOR_CHAN_MAGN_XYZ,
+				   SENSOR_ATTR_SAMPLING_FREQUENCY, &read_back));
+
+	zassert_equal(read_back.val1, 100, "expected 100 Hz, got %d.%06d", read_back.val1,
+		      read_back.val2);
+}
+
+/*
+ * Drive the full self-test PMU/forced-mode handshake against the emulator, which
+ * models an excitation response on each axis. bmm350_self_test() reports the raw
+ * deltas; here we check they exceed the datasheet minimum (260 uT).
+ */
+ZTEST_F(bmm350, test_self_test)
+{
+	struct bmm350_self_test_result result = {0};
+
+	zassert_ok(bmm350_self_test(fixture->dev, &result));
+	zassert_true(result.x_delta >= 260, "x_delta=%d too small", result.x_delta);
+	zassert_true(result.y_delta >= 260, "y_delta=%d too small", result.y_delta);
+}

--- a/tests/drivers/sensor/bmm350/tests.yaml
+++ b/tests/drivers/sensor/bmm350/tests.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Meta Platforms
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.sensor.bmm350:
+    tags:
+      - drivers
+      - sensor
+    platform_allow:
+      - native_sim
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
## Summary

Adds I3C support plus several features, fixes, and test infrastructure to the Bosch BMM350 magnetometer driver.

**Features**
- I3C bus support alongside I2C, selected per devicetree instance (mirrors the `bmp581` multi-bus pattern); adds a `bosch,bmm350-i3c` binding and an I3C node to the sensor `build_all` test.
- User self-test via `bmm350_self_test()` in the public header, ported from the Bosch SensorAPI sequence (TMR re-init + per-step PMU status checks); reports per-axis responses/deltas for the caller to judge.
- `SENSOR_CHAN_DIE_TEMP` exposed on both the classic (`channel_get`) and RTIO decoder paths, at 0.01 degC.

**Fixes**
- NULL-check the completion-callback RTIO SQE in the one-shot and streaming paths.
- Use 64-bit intermediates in the compensation math to avoid int32 overflow at strong fields.
- Allow disabling the data-ready trigger (NULL handler).
- Check the soft-reset / PMU register writes during init, and return the part to suspend on a pad-drive write failure.
- Carry temperature at 0.01 degC in compensation: full-resolution temperature into the TCO/TCS terms and the correct 25.49 degC offset.

**Emulator and tests**
- Add a BMM350 bus emulator (`CONFIG_EMUL_BMM350`) modelling the register file, the two dummy bytes returned ahead of each I2C read, the soft-reset/OTP handshake, the PMU magnetic-reset/forced-mode status sequence, and an emul_sensor backend for the magnetometer and die-temperature channels.
- Add `tests/drivers/sensor/bmm350`: a ztest suite (init, magnetometer fetch/decode, die temperature, sampling-frequency attribute, self-test) running against the emulator on native_sim.

