### PR TITLE
Bluetooth: BAP: Shell: Make it easier to copy broadcast IDs

### DIFF
--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -130,7 +130,7 @@ static void bap_broadcast_assistant_scan_cb(const struct bt_le_scan_recv_info *i
 					    uint32_t broadcast_id)
 {
 	bt_shell_print(
-		"[DEVICE]: %s, broadcast_id 0x%06X, interval (ms) %u (0x%04x)), SID 0x%x, RSSI %i",
+		"[DEVICE]: %s, broadcast_id 0x%06X interval (ms) %u (0x%04x)), SID 0x%x, RSSI %i",
 		bt_addr_le_str(info->addr), broadcast_id,
 		BT_GAP_PER_ADV_INTERVAL_TO_MS(info->interval),
 		info->interval, info->sid, info->rssi);
@@ -166,7 +166,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 
 	is_bad_code = state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE;
 	bt_shell_print(
-		"BASS recv state: src_id %u, addr %s, sid %u, broadcast_id 0x%06X, sync_state "
+		"BASS recv state: src_id %u, addr %s, sid %u, broadcast_id 0x%06X sync_state "
 		"%u, encrypt_state %u%s%s",
 		state->src_id, bt_addr_le_str(&state->addr), state->adv_sid, state->broadcast_id,
 		state->pa_sync_state, state->encrypt_state, is_bad_code ? ", bad code" : "",

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -330,7 +330,7 @@ static int pa_sync_req_cb(struct bt_conn *conn,
 	struct scan_delegator_sync_state *state;
 
 	bt_shell_info(
-		"PA Sync request: past_avail %u, broadcast_id 0x%06X, pa_interval 0x%04x: %p",
+		"PA Sync request: past_avail %u, broadcast_id 0x%06X pa_interval 0x%04x: %p",
 		past_avail, recv_state->broadcast_id, pa_interval, recv_state);
 
 	state = sync_state_get_or_new(recv_state);


### PR DESCRIPTION
The broadcast ID is printed in the shell various places. Often the shell user wants to copy this value and use it for future commands.

Remove any following commas, so that the user can easier click-to-mark the value to copy it.