### PR TITLE
boards: esp32s3_box3: enable Bluetooth and WiFi

### DIFF
--- a/boards/espressif/esp32s3_box3/esp32s3_box3_procpu.dts
+++ b/boards/espressif/esp32s3_box3/esp32s3_box3_procpu.dts
@@ -25,6 +25,7 @@
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,bt-hci = &esp32_bt_hci;
 	};
 
 	buttons {
@@ -47,6 +48,14 @@
 };
 
 &gpio1 {
+	status = "okay";
+};
+
+&esp32_bt_hci {
+	status = "okay";
+};
+
+&wifi {
 	status = "okay";
 };
 


### PR DESCRIPTION
Add esp32_bt_hci alias to chosen node and enable both esp32_bt_hci
and wifi nodes on the ESP32-S3 Box 3 procpu board.