### PR TITLE
scripts: Adopt PEP 604 union syntax for annotations

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1838,7 +1838,7 @@ class Node:
         prop_min_len = prop_spec.min_len
         prop_max_len = prop_spec.max_len
         if prop_min_len is not None or prop_max_len is not None:
-            if isinstance(val, (list, bytes)):
+            if isinstance(val, list | bytes):
                 val_len = len(val)
                 if prop_min_len is not None and val_len < prop_min_len:
                     _err(f"value of property '{name}' on {self.path} in "

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1875,7 +1875,7 @@ class Node:
         prop_min_len = prop_spec.min_len
         prop_max_len = prop_spec.max_len
         if prop_min_len is not None or prop_max_len is not None:
-            if isinstance(val, (list, bytes)):
+            if isinstance(val, list | bytes):
                 val_len = len(val)
                 if prop_min_len is not None and val_len < prop_min_len:
                     _err(f"value of property '{name}' on {self.path} in "

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -6,7 +6,6 @@ import os
 import re
 import tempfile
 from copy import deepcopy
-from typing import Optional
 
 import pytest
 
@@ -107,9 +106,9 @@ def temporary_chdir(dirname):
         os.chdir(here)
 
 @contextlib.contextmanager
-def dtlib_raises(err: Optional[str] = None,
-                 err_endswith: Optional[str] = None,
-                 err_matches: Optional[str] = None):
+def dtlib_raises(err: str | None = None,
+                 err_endswith: str | None = None,
+                 err_matches: str | None = None):
     '''A context manager for running a block of code that should raise
     DTError. Exactly one of the arguments 'err', 'err_endswith',
     and 'err_matches' must be given. The semantics are:

--- a/scripts/generate_usb_vif/generate_vif.py
+++ b/scripts/generate_usb_vif/generate_vif.py
@@ -78,7 +78,7 @@ def add_vif_spec_from_source_to_xml(xml_ele, source_xml_ele):
 
 
 def is_simple_datatype(value):
-    if isinstance(value, (str, int, bool)):
+    if isinstance(value, str | int | bool):
         return True
     return False
 

--- a/scripts/utils/pinctrl_nrf_migrate.py
+++ b/scripts/utils/pinctrl_nrf_migrate.py
@@ -83,7 +83,7 @@ import enum
 from pathlib import Path
 import re
 import shutil
-from typing import Callable, Optional, Dict, List
+from typing import Callable, Dict, List
 
 
 #
@@ -455,7 +455,7 @@ def adjust_content(content: List[str], board: str) -> List[DeviceConfiguration]:
 
 def match_and_store_pin(
     config: DeviceConfiguration, signals: Dict[str, str], line: str
-) -> Optional[str]:
+) -> str | None:
     """Match and store a pin mapping.
 
     Args:
@@ -488,7 +488,7 @@ def match_and_store_pin(
 #
 
 
-def process_uart(config: DeviceConfiguration, signals, line: str) -> Optional[str]:
+def process_uart(config: DeviceConfiguration, signals, line: str) -> str | None:
     """Process UART/UARTE devices."""
 
     # check if line specifies a pin
@@ -504,7 +504,7 @@ def process_uart(config: DeviceConfiguration, signals, line: str) -> Optional[st
     return line
 
 
-def process_spi(config: DeviceConfiguration, signals, line: str) -> Optional[str]:
+def process_spi(config: DeviceConfiguration, signals, line: str) -> str | None:
     """Process SPI devices."""
 
     # check if line specifies a pin
@@ -526,7 +526,7 @@ def process_spi(config: DeviceConfiguration, signals, line: str) -> Optional[str
     return line
 
 
-def process_pwm(config: DeviceConfiguration, signals, line: str) -> Optional[str]:
+def process_pwm(config: DeviceConfiguration, signals, line: str) -> str | None:
     """Process PWM devices."""
 
     # check if line specifies a pin

--- a/scripts/west_commands/tests/test_nrf.py
+++ b/scripts/west_commands/tests/test_nrf.py
@@ -48,7 +48,7 @@ class TC(typing.NamedTuple):    # 'TestCase'
     family: str
 
     # 'APP', 'NET', 'APP+NET', or None.
-    coprocessor: typing.Optional[str]
+    coprocessor: str | None
 
     # Run a recover command first if True
     recover: bool


### PR DESCRIPTION
Use PEP 604 union syntax (X | Y) for type hints and isinstance checks to satisfy the Ruff UP007 and UP038 rules.

To get rid of annoying Ruff errors when running the check_compliance script:
`./scripts/ci/check_compliance.py -m Ruff -m Pylint  -c upstream/main..`

Edit:
~~For files licensed under BSD-3-Clause or ISC, add the rules to .ruff-excludes.toml instead of editing the sources, to avoid touching files that would trigger license compliance warnings.~~