### PR TITLE
drivers: led: fake: fix fake_led_get_info_delegate() check

### DIFF
--- a/drivers/led/led_fake.c
+++ b/drivers/led/led_fake.c
@@ -43,7 +43,7 @@ static int fake_led_get_info_delegate(const struct device *dev, uint32_t led,
 {
 	const struct fake_led_config *config = dev->config;
 
-	if (info == NULL || *info == NULL) {
+	if (info == NULL) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Fix the check in fake_led_get_info_delegate() to not compare against unitialized memory.

Making as hot fix as this is breaking clang CI in `main`: https://github.com/zephyrproject-rtos/zephyr/actions/runs/27397505136/job/80968373164