### PR TITLE
hostap: Legacy crypto rejig

### DIFF
--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -324,9 +324,9 @@ zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_NO
   CONFIG_CRYPTO_INTERNAL
 )
 
-zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_WEP
-  CONFIG_WEP
-)
+if(CONFIG_WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO AND CONFIG_WIFI_NM_WPA_SUPPLICANT_WEP)
+  zephyr_library_compile_definitions(CONFIG_WEP)
+endif()
 
 zephyr_library_sources_ifndef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
   ${HOSTAP_SRC_BASE}/crypto/tls_none.c

--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -47,7 +47,12 @@ zephyr_library_compile_definitions(
   CONFIG_CTRL_IFACE_ZEPHYR
   CONFIG_SUITEB192
   CONFIG_SUITEB
-  # Though MbedTLS is not FIPS compliant, we don't want to use broken crypto algorithms
+)
+
+# Though MbedTLS is not FIPS compliant, CONFIG_FIPS is used here to strip the
+# broken/legacy crypto call sites (HMAC-MD5, RC4, ...) and keep the default
+# build robust. Legacy WPA/TKIP interop explicitly opts out of this.
+zephyr_library_compile_definitions_ifndef(CONFIG_WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO
   CONFIG_FIPS
 )
 
@@ -701,7 +706,6 @@ zephyr_include_directories(
 
 zephyr_library_sources(
   ${HOSTAP_SRC_BASE}/crypto/crypto_mbedtls_alt.c
-  ${HOSTAP_SRC_BASE}/crypto/rc4.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_MBEDTLS_PSA
@@ -723,6 +727,17 @@ zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_TEST
   ${HOSTAP_SRC_BASE}/crypto/fips_prf_internal.c
   ${HOSTAP_SRC_BASE}/crypto/sha1-internal.c
 )
+endif()
+
+zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO
+  ${HOSTAP_SRC_BASE}/crypto/rc4.c
+)
+
+if(CONFIG_WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO AND NOT CONFIG_PSA_WANT_ALG_MD5)
+  zephyr_library_sources(
+    ${HOSTAP_SRC_BASE}/crypto/md5-internal.c
+    ${HOSTAP_SRC_BASE}/crypto/md5.c
+  )
 endif()
 
 zephyr_compile_definitions(WPA_SUPPLICANT_CLEANUP_INTERVAL=${CONFIG_WIFI_NM_WPA_SUPPLICANT_CLEANUP_INTERVAL})

--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -740,6 +740,14 @@ if(CONFIG_WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO AND NOT CONFIG_PSA_WANT_ALG_MD5)
   )
 endif()
 
+# EAP-TTLS phase-2 CHAP (RFC 1994) is compiled only when CONFIG_FIPS is off,
+# i.e. when LEGACY_CRYPTO opts out of CONFIG_FIPS. Link chap.c for the symbol.
+if(CONFIG_WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO AND (CONFIG_EAP_TTLS OR CONFIG_EAP_SERVER_TTLS))
+  zephyr_library_sources(
+    ${HOSTAP_SRC_BASE}/eap_common/chap.c
+  )
+endif()
+
 zephyr_compile_definitions(WPA_SUPPLICANT_CLEANUP_INTERVAL=${CONFIG_WIFI_NM_WPA_SUPPLICANT_CLEANUP_INTERVAL})
 
 zephyr_compile_definitions_ifdef(CONFIG_WIFI_NM_HOSTAPD_AP

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -157,13 +157,11 @@ config WIFI_NM_WPA_SUPPLICANT_RRM
 	default y
 endif
 
-config WIFI_NM_WPA_SUPPLICANT_WEP
-	bool "WEP (Legacy crypto) support"
-
 config WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO
 	bool "Legacy (non-FIPS) crypto for backward compatibility"
 	default y
 	depends on !WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE
+	imply WIFI_NM_WPA_SUPPLICANT_WEP
 	select DEPRECATED
 	select NOT_SECURE
 	help
@@ -175,6 +173,10 @@ config WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO
 	  Also links hostap rc4.c for group-key unwrap. When PSA_WANT_ALG_MD5
 	  is off, CMake links md5-internal.c and md5.c so EAPOL-Key v1
 	  HMAC-MD5 does not depend on PSA.
+
+	  Implies WIFI_NM_WPA_SUPPLICANT_WEP by default (merged legacy option,
+	  kept for prj.conf compatibility). Set CONFIG_WIFI_NM_WPA_SUPPLICANT_WEP=n
+	  to strip WEP while keeping WPA/TKIP interop.
 
 	  Enabled by default so WPA/TKIP and other legacy AP interop works
 	  out of the box. This is NOT a TKIP-only switch: it disables CONFIG_FIPS
@@ -191,8 +193,21 @@ config WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO
 	  need a build with legacy algorithms stripped entirely.
 
 	  Enabled by default for now. The default will change to disabled in a
-	  future Zephyr release. Set this explicitly if you need WPA/TKIP or
-	  other legacy AP interop.
+	  future Zephyr release, which will also disable WEP and TKIP interop
+	  unless LEGACY_CRYPTO is set explicitly.
+
+config WIFI_NM_WPA_SUPPLICANT_WEP
+	bool "WEP support (deprecated)"
+	depends on !WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE
+	select DEPRECATED
+	select NOT_SECURE
+	help
+	  Deprecated: merged under WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO.
+	  Symbol retained for backward compatibility with existing prj.conf
+	  files that set CONFIG_WIFI_NM_WPA_SUPPLICANT_WEP. WEP is enabled by
+	  default via LEGACY_CRYPTO imply; set CONFIG_WIFI_NM_WPA_SUPPLICANT_WEP=n
+	  to strip WEP while keeping WPA/TKIP interop. Has no effect unless
+	  LEGACY_CRYPTO is enabled.
 
 choice WIFI_NM_WPA_SUPPLICANT_CRYPTO_BACKEND
 	prompt "WPA supplicant crypto implementation"

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -160,6 +160,40 @@ endif
 config WIFI_NM_WPA_SUPPLICANT_WEP
 	bool "WEP (Legacy crypto) support"
 
+config WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO
+	bool "Legacy (non-FIPS) crypto for backward compatibility"
+	default y
+	depends on !WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE
+	select DEPRECATED
+	select NOT_SECURE
+	help
+	  Drop CONFIG_FIPS from the supplicant build to re-enable the legacy
+	  and broken crypto call sites. CONFIG_FIPS is not real FIPS validation
+	  (MbedTLS is not FIPS validated); it is just a switch to strip these
+	  algorithms from the default build.
+
+	  Also links hostap rc4.c for group-key unwrap. When PSA_WANT_ALG_MD5
+	  is off, CMake links md5-internal.c and md5.c so EAPOL-Key v1
+	  HMAC-MD5 does not depend on PSA.
+
+	  Enabled by default so WPA/TKIP and other legacy AP interop works
+	  out of the box. This is NOT a TKIP-only switch: it disables CONFIG_FIPS
+	  wholesale and brings back the whole legacy crypto surface, including:
+	    - WPA1/TKIP EAPOL-Key descriptor version 1 (HMAC-MD5 4-way MIC and
+	      RC4 group-key unwrap)
+	    - MD5/RC4/DES based paths (e.g. EAP-FAST key export, IKEv2 MD5 PRF,
+	      EAP-PWD MD5)
+
+	  The main reason to enable it is interoperability with legacy
+	  WPA-PSK/TKIP access points still seen in the field and legacy
+	  interop/QuickTrack test cases. TKIP is deprecated and not allowed in
+	  current Wi-Fi Alliance certification programs. Turn this off if you
+	  need a build with legacy algorithms stripped entirely.
+
+	  Enabled by default for now. The default will change to disabled in a
+	  future Zephyr release. Set this explicitly if you need WPA/TKIP or
+	  other legacy AP interop.
+
 choice WIFI_NM_WPA_SUPPLICANT_CRYPTO_BACKEND
 	prompt "WPA supplicant crypto implementation"
 	default WIFI_NM_WPA_SUPPLICANT_CRYPTO_ALT


### PR DESCRIPTION
Fix WPA-PSK association needed for quicktrack. While at it, rejig the legacy crypto, move WEP/TKIP (RC4) or HMAC-MD5 (WPA) to Legacy crypto, keep defaults to ensure the PR is backwards compatible, but also mark these as both deprecated and not secure symbol,  in the future WEP symbol will be removed and we will disable legacy crypto by default (with enough notice) to make OOB experience secure.