### PR TITLE
Bluetooth: BAP: BA: Shell: Change order of pa_interval and bis_sync

### DIFF
--- a/doc/services/connectivity/bluetooth/shell/audio/bap_broadcast_assistant.rst
+++ b/doc/services/connectivity/bluetooth/shell/audio/bap_broadcast_assistant.rst
@@ -35,7 +35,7 @@ subscribe to all notifications.
    scan_stop         : Stop scanning for BISs
    add_src           : Add a source <address: XX:XX:XX:XX:XX:XX> <type:
                         public/random> <adv_sid> <sync_pa> <broadcast_id>
-                        [<pa_interval>] [<sync_bis>] [<metadata>]
+                        [<sync_bis>] [<pa_interval>] [<metadata>]
    add_broadcast_id  : Add a source by broadcast ID <broadcast_id> <sync_pa>
                         [<sync_bis>] [<metadata>]
    add_broadcast_name: Add a source by broadcast name <broadcast_name> <sync_pa>

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -500,10 +500,30 @@ static int cmd_bap_broadcast_assistant_add_src(const struct shell *sh,
 
 	param.broadcast_id = broadcast_id;
 
+	/* TODO: Support multiple subgroups */
 	if (argc > 6) {
+		unsigned long bis_sync;
+
+		bis_sync = shell_strtoul(argv[6], 0, &result);
+		if (result) {
+			shell_error(sh, "Could not parse bis_sync: %d", result);
+
+			return -ENOEXEC;
+		}
+
+		if (!BT_BAP_BASS_VALID_BIT_BITFIELD(bis_sync)) {
+			shell_error(sh, "Invalid bis_sync: %lu", bis_sync);
+
+			return -ENOEXEC;
+		}
+
+		subgroup.bis_sync = bis_sync;
+	}
+
+	if (argc > 7) {
 		unsigned long pa_interval;
 
-		pa_interval = shell_strtoul(argv[6], 0, &result);
+		pa_interval = shell_strtoul(argv[7], 0, &result);
 		if (result) {
 			shell_error(sh, "Could not parse pa_interval: %d",
 				    result);
@@ -523,26 +543,6 @@ static int cmd_bap_broadcast_assistant_add_src(const struct shell *sh,
 		param.pa_interval = pa_interval;
 	} else {
 		param.pa_interval = BT_BAP_PA_INTERVAL_UNKNOWN;
-	}
-
-	/* TODO: Support multiple subgroups */
-	if (argc > 7) {
-		unsigned long bis_sync;
-
-		bis_sync = shell_strtoul(argv[7], 0, &result);
-		if (result) {
-			shell_error(sh, "Could not parse bis_sync: %d", result);
-
-			return -ENOEXEC;
-		}
-
-		if (!BT_BAP_BASS_VALID_BIT_BITFIELD(bis_sync)) {
-			shell_error(sh, "Invalid bis_sync: %lu", bis_sync);
-
-			return -ENOEXEC;
-		}
-
-		subgroup.bis_sync = bis_sync;
 	}
 
 	if (argc > 8) {
@@ -1265,7 +1265,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(add_src, NULL,
 		      "Add a source <address: XX:XX:XX:XX:XX:XX> "
 		      "<type: public/random> <adv_sid> <sync_pa> "
-		      "<broadcast_id> [<pa_interval>] [<sync_bis>] "
+		      "<broadcast_id> [<sync_bis>] [<pa_interval>] "
 		      "[<metadata>]",
 		      cmd_bap_broadcast_assistant_add_src, 6, 3),
 	SHELL_CMD_ARG(add_broadcast_id, NULL,


### PR DESCRIPTION
Change the order of the pa_interval and bis_sync arguments for the add_src command. The reason is that the user will generally care more about setting the right bis_sync value (e.g. to 0x01) rather than the PA interval which may be set to "unknown" in any case. With this change the user can set the bis_sync without the pa_interval and just defer to the "unknown" PA interval value.