### PR TITLE
Bluetooth: BAP: SD: Add command to print receive state

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -221,6 +221,7 @@ struct scan_delegator_sync_state {
 	struct bt_le_per_adv_sync *pa_sync;
 	struct bt_conn *conn;
 	struct k_work_delayable pa_timer;
+	uint32_t bis_sync_req_bitfield;
 	uint32_t broadcast_id;
 	uint16_t pa_interval;
 	bool active;

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -36,6 +36,7 @@
 #include <audio/bap_internal.h>
 #include "audio.h"
 #include "common/bt_shell_private.h"
+#include "common/bt_str.h"
 #include "host/shell/bt.h"
 
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
@@ -405,13 +406,27 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 			   const struct bt_bap_scan_delegator_recv_state *recv_state,
 			   const uint32_t bis_sync_req[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS])
 {
+	struct scan_delegator_sync_state *state;
+	uint32_t bis_sync_req_bitfield = 0U;
+
 	ARG_UNUSED(conn);
 
 	bt_shell_print("BIS sync request received for %p", recv_state);
 
-	for (int i = 0; i < CONFIG_BT_BAP_BASS_MAX_SUBGROUPS; i++) {
+	for (uint8_t i = 0U; i < recv_state->num_subgroups; i++) {
 		bt_shell_print("  [%d]: 0x%08x", i, bis_sync_req[i]);
+
+		bis_sync_req_bitfield |= bis_sync_req[i];
 	}
+
+	state = sync_state_get(recv_state);
+	if (state == NULL) {
+		bt_shell_error("Could not get state from recv state %p", recv_state);
+
+		return -ENOENT;
+	}
+
+	state->bis_sync_req_bitfield = bis_sync_req_bitfield;
 
 	return 0;
 }
@@ -1069,6 +1084,42 @@ static int cmd_bap_scan_delegator_bis_synced(const struct shell *sh, size_t argc
 
 	return result;
 }
+static int cmd_bap_scan_delegator_print_recv_states(const struct shell *sh, size_t argc,
+						    char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	ARRAY_FOR_EACH(scan_delegator_sync_states, idx) {
+		struct scan_delegator_sync_state *sync_state = &scan_delegator_sync_states[idx];
+		const struct bt_bap_scan_delegator_recv_state *recv_state = sync_state->recv_state;
+
+		if (recv_state == NULL) {
+			continue;
+		}
+
+		shell_print(
+			sh,
+			"Receive State[%zu]: src ID %u, addr %s, adv_sid %u, broadcast_id 0x%06X, "
+			"pa_sync_state %u, encrypt state %u, num_subgroups %u",
+			idx, recv_state->src_id, bt_addr_le_str(&recv_state->addr),
+			recv_state->adv_sid, recv_state->broadcast_id, recv_state->pa_sync_state,
+			recv_state->encrypt_state, recv_state->num_subgroups);
+
+		for (uint8_t i = 0U; i < recv_state->num_subgroups; i++) {
+			const struct bt_bap_bass_subgroup *subgroup = &recv_state->subgroups[i];
+
+			shell_print(sh,
+				    "\tSubgroup[%u]: BIS sync 0x%08X (requested 0x%08X), "
+				    "metadata_len %u, metadata: %s",
+				    i, subgroup->bis_sync, sync_state->bis_sync_req_bitfield,
+				    subgroup->metadata_len,
+				    bt_hex(subgroup->metadata, subgroup->metadata_len));
+		}
+	}
+
+	return 0;
+}
 
 static int cmd_bap_scan_delegator(const struct shell *sh, size_t argc,
 				  char **argv)
@@ -1112,6 +1163,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bap_scan_delegator_cmds,
 	SHELL_CMD_ARG(synced, NULL,
 		      "Set server scan state <src_id> <bis_syncs>",
 		      cmd_bap_scan_delegator_bis_synced, 3, 0),
+	SHELL_CMD_ARG(print_recv_states, NULL, "Print all data from receive states",
+		      cmd_bap_scan_delegator_print_recv_states, 1, 0),
 	SHELL_SUBCMD_SET_END,
 );
 


### PR DESCRIPTION
Add command to loop through known receive states and print their content. This also adds the request BIS sync value for comparison to the currently synced value.