### PR TITLE
manifest: atmel: dac macro for SAM3X

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -162,7 +162,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: 8cd575049f04131e333558072484bfc6334c19c4
+      revision: 8f95c79f2a80427ef446563cc9addefa959e92a9
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
Add a missing DAC macro for Atmel SAM3X SoC series.