### PR TITLE
boards: nxp: mimxrt685_aud_evk: support external flash (NVS/LittleFS)

### DIFF
--- a/boards/nxp/mimxrt685_aud_evk/flash_config/flash_config.c
+++ b/boards/nxp/mimxrt685_aud_evk/flash_config/flash_config.c
@@ -13,6 +13,17 @@ const flexspi_nor_config_t flexspi_config = {
 		.version = FLASH_CONFIG_BLOCK_VERSION,
 		.cs_hold_time = 3,
 		.cs_setup_time = 3,
+		/*
+		 * Program the flash status/configuration register (WRSR 0x01,
+		 * LUT seq 2) with 0xC740: QE = 1 and the configuration-register
+		 * dummy-cycle bits set for a 10-cycle 1S-4S-4S (0xEC) read. This
+		 * matches the read latency the Zephyr flash driver installs for the
+		 * MX25U51245G, so AHB/XIP reads keep working after the driver
+		 * reinstalls the LUT during initialization.
+		 */
+		.device_mode_cfg_enable = 1,
+		.device_mode_seq = {.seq_num = 1, .seq_id = 2},
+		.device_mode_arg = 0xC740,
 		.controller_misc_option =
 			1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE,
 		.device_type = 0x1,
@@ -23,17 +34,19 @@ const flexspi_nor_config_t flexspi_config = {
 		.sflash_b1_size = 0x4000000U,
 		.sflash_b2_size = 0,
 		.lookup_table = {
-			/* Read (4READ4B: 0xEC) */
+			/* Read (4READ4B: 0xEC), 10 dummy cycles (CR DC bits) */
 			[0] = FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD,
 				0xEC, RADDR_SDR, FLEXSPI_4PAD, 0x20),
-			[1] = FLEXSPI_LUT_SEQ(MODE8_SDR, FLEXSPI_4PAD,
-				0x00, DUMMY_SDR, FLEXSPI_4PAD, 0x04),
-			[2] = FLEXSPI_LUT_SEQ(READ_SDR, FLEXSPI_4PAD,
-				0x04, STOP_EXE, FLEXSPI_1PAD, 0x00),
+			[1] = FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD,
+				0x0A, READ_SDR, FLEXSPI_4PAD, 0x04),
 
 			/* Read Status */
 			[4 * 1 + 0] = FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD,
 				0x05, READ_SDR, FLEXSPI_1PAD, 0x04),
+
+			/* Write Status/Config Register (device mode cfg) */
+			[4 * 2 + 0] = FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD,
+				0x01, WRITE_SDR, FLEXSPI_1PAD, 0x02),
 
 			/* Write Enable */
 			[4 * 3 + 0] = FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD,

--- a/boards/nxp/mimxrt685_aud_evk/mimxrt685_aud_evk_mimxrt685s_cm33.yaml
+++ b/boards/nxp/mimxrt685_aud_evk/mimxrt685_aud_evk_mimxrt685s_cm33.yaml
@@ -14,6 +14,7 @@ toolchain:
 ram: 4608
 flash: 3072
 supported:
+  - flash
   - gpio
   - uart
 vendor: nxp

--- a/samples/subsys/fs/littlefs/tests.yaml
+++ b/samples/subsys/fs/littlefs/tests.yaml
@@ -12,6 +12,7 @@ tests:
       - particle_xenon
       - disco_l475_iot1
       - mimxrt685_evk/mimxrt685s/cm33
+      - mimxrt685_aud_evk/mimxrt685s/cm33
       - mimxrt1060_evk/mimxrt1062/qspi
       - mimxrt1064_evk
       - qemu_x86

--- a/tests/subsys/fs/littlefs/boards/mimxrt685_aud_evk_mimxrt685s_cm33.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt685_aud_evk_mimxrt685s_cm33.overlay
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&mx25u51245g_flash {
+	partitions {
+		large_partition: partition@3c00000 {
+			compatible = "zephyr,mapped-partition";
+			label = "large";
+			reg = <0x03c00000 DT_SIZE_M(3)>;
+		};
+
+		medium_partition: partition@3f00000 {
+			compatible = "zephyr,mapped-partition";
+			label = "medium";
+			reg = <0x03f00000 DT_SIZE_K(960)>;
+		};
+
+		small_partition: partition@3ff0000 {
+			compatible = "zephyr,mapped-partition";
+			label = "small";
+			reg = <0x03ff0000 DT_SIZE_K(64)>;
+		};
+	};
+};

--- a/tests/subsys/fs/littlefs/tests.yaml
+++ b/tests/subsys/fs/littlefs/tests.yaml
@@ -20,6 +20,7 @@ common:
     - mimxrt1170_evk/mimxrt1176/cm7
     - mimxrt1180_evk/mimxrt1189/cm33
     - mimxrt595_evk/mimxrt595s/cm33
+    - mimxrt685_aud_evk/mimxrt685s/cm33
     - mimxrt685_evk/mimxrt685s/cm33
   integration_platforms:
     - native_sim


### PR DESCRIPTION
This adds working external flash support for the NXP MIMXRT685-AUD-EVK
(CM33), so NVS / LittleFS / FatFS run from the on-board Quad-SPI
MX25U51245G while executing in place (XIP).

### What
- **Fix the flash XIP read latency.** The board flash configuration
  block (FCB) now programs the MX25U51245G for the 10 dummy-cycle `0xEC`
  quad read that the FlexSPI NOR driver installs, so AHB/XIP instruction
  fetches keep working after the driver re-initializes the FlexSPI
  during boot. Previously the CPU locked up before `main()` as soon as
  any flash-backed subsystem (NVS, LittleFS, FatFS) brought up the flash
  driver, while non-flash samples (hello_world, blinky) were unaffected.
- **Add flash to twister coverage.** Declare `flash` in the board's
  supported features and add the board to the `sample.filesystem.littlefs`
  `platform_allow` list.

### Why
The generic FlexSPI NOR driver re-installs the read LUT for this part
with a 10 dummy-cycle latency (matching `rd_rw612_bga`, which uses the
same flash). The AUD-EVK FCB had configured the flash for a shorter
latency, so after driver init the controller sampled the read data at
the wrong point and XIP fetches returned corrupted data. The fix is
confined to the board FCB; the shared driver is left untouched, so other
boards using this flash (e.g. `rd_rw612_bga`) are unaffected.

### Testing
Verified on MIMXRT685-AUD-EVK (CM33), J-Link:
- `samples/subsys/kvss/nvs` — reaches `main()`, reads/writes all records,
  reboot counter persists across reboots.
- `samples/subsys/fs/littlefs` — mounts, reads/writes files.
- `samples/hello_world` and `samples/basic/blinky` still boot from XIP
  and run (the FCB change does not regress basic board functionality).
- `twister --build-only`: `tests/drivers/flash/common` and
  `sample.filesystem.littlefs` build for the board.
