### PR TITLE
Bluetooth: BAP: Shell: USB use LOG_RATELIMT instead of bap_stats

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -65,8 +65,6 @@ size_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_a
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
 
-unsigned long bap_get_stats_interval(void);
-
 #if defined(CONFIG_LIBLC3)
 #include "lc3.h"
 

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -198,11 +198,6 @@ struct bt_cap_stream *cap_stream_from_shell_stream(struct shell_stream *sh_strea
 	return &sh_stream->stream;
 }
 
-unsigned long bap_get_stats_interval(void)
-{
-	return bap_stats_interval;
-}
-
 void bap_foreach_stream(void (*func)(struct shell_stream *sh_stream, void *data), void *data)
 {
 #if defined(CONFIG_BT_BAP_UNICAST)

--- a/subsys/bluetooth/audio/shell/bap_usb.c
+++ b/subsys/bluetooth/audio/shell/bap_usb.c
@@ -45,6 +45,7 @@
 
 LOG_MODULE_REGISTER(bap_usb, CONFIG_BT_BAP_STREAM_LOG_LEVEL);
 
+#define USB_LOG_RATE           (30U * MSEC_PER_SEC) /* 30 seconds */
 #define USB_ENQUEUE_COUNT      30U /* 30ms */
 #define USB_FRAME_DURATION_US  1000U
 #define USB_SAMPLE_CNT         ((USB_FRAME_DURATION_US * USB_SAMPLE_RATE) / USEC_PER_SEC)
@@ -133,15 +134,13 @@ static void usb_data_request(const struct device *dev)
 	if (size != 0) {
 		static size_t cnt;
 
-		if ((++cnt % bap_get_stats_interval()) == 0U) {
-			LOG_INF("[%zu]: Sending USB audio", cnt);
-		}
+		cnt++;
+		LOG_INF_RATELIMIT_RATE(USB_LOG_RATE, "[%zu]: Sending USB audio", cnt);
 	} else {
 		static size_t cnt;
 
-		if ((++cnt % bap_get_stats_interval()) == 0U) {
-			LOG_INF("[%zu]: Sending empty USB audio", cnt);
-		}
+		cnt++;
+		LOG_INF_RATELIMIT_RATE(USB_LOG_RATE, "[%zu]: Sending empty USB audio", cnt);
 	}
 
 	err = usbd_uac2_send(dev, IN_TERMINAL_ID, pcm_buf, USB_STEREO_FRAME_SIZE);
@@ -192,12 +191,10 @@ static void bap_usb_send_frames_to_usb(void)
 
 		/* Not enough space to store data */
 		if (ring_buf_space_get(&usb_in_ring_buf) < sizeof(stereo_frame)) {
-			if ((fail_cnt % bap_get_stats_interval()) == 0U) {
-				LOG_WRN("[%zu] Could not send more than %zu frames to USB",
-					fail_cnt, i);
-			}
-
 			fail_cnt++;
+			LOG_WRN_RATELIMIT_RATE(USB_LOG_RATE,
+					       "[%zu] Could not send more than %zu frames to USB",
+					       fail_cnt, i);
 
 			break;
 		}
@@ -238,9 +235,8 @@ static void bap_usb_send_frames_to_usb(void)
 		}
 	}
 
-	if ((++cnt % bap_get_stats_interval()) == 0U) {
-		LOG_INF("[%zu]: Sending %u USB audio frame", cnt, frame_cnt);
-	}
+	cnt++;
+	LOG_INF_RATELIMIT_RATE(USB_LOG_RATE, "[%zu]: Sending %zu USB audio frame", cnt, frame_cnt);
 
 	bap_usb_clear_frames_to_usb();
 }
@@ -263,9 +259,8 @@ int bap_usb_add_frame_to_usb(enum bt_audio_location chan_allocation, const int16
 
 	static size_t cnt;
 
-	if ((++cnt % bap_get_stats_interval()) == 0U) {
-		LOG_INF("[%zu]: Adding USB audio frame", cnt);
-	}
+	cnt++;
+	LOG_INF_RATELIMIT_RATE(USB_LOG_RATE, "[%zu]: Adding USB audio frame", cnt);
 
 	if (frame_size > LC3_MAX_NUM_SAMPLES_MONO * sizeof(int16_t) || frame_size == 0U) {
 		LOG_DBG("Invalid frame of size %zu", frame_size);
@@ -496,9 +491,8 @@ static void usb_data_recv_cb(const struct device *dev, uint8_t terminal, void *b
 	 */
 	bap_foreach_stream(stream_cb, UINT_TO_POINTER(old_write_index));
 
-	if ((++cnt % bap_get_stats_interval()) == 0U) {
-		LOG_DBG("USB Data received (count = %d)", cnt);
-	}
+	cnt++;
+	LOG_DBG_RATELIMIT_RATE(USB_LOG_RATE, "USB Data received (count = %zu)", cnt);
 
 	k_mem_slab_free(&usb_out_buf_pool, buf);
 }


### PR DESCRIPTION
Instead of logging based on the bap stats interval, the USB part will not just use a flat rate limit of 30 seconds. Since the bap_stats_interval and USB rates are used for 2 very different things, and since USB will likely be trigger way more often, it did not make a lot of sense to use the same value for both.

30 seconds was chosen as it still provides information to the user on a reasonable interval, without filling up the shell console too fast.