### PR TITLE
twister: pytest: support per-test device launch args

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
@@ -33,9 +33,33 @@ class DeviceAdapter(abc.ABC):
         self.base_timeout: float = device_config.base_timeout
         self._reader_started: threading.Event = threading.Event()
         self.command: list[str] = []
+        self._extra_args_override: list[str] | None = None
 
         self.connections: list[DeviceConnection] = create_device_connections(device_config)
         self._log_files: list[Path] = [conn.log_path for conn in self.connections]
+
+    def set_extra_args(self, args: list[str] | None) -> None:
+        """Override extra args for the *next* launch.
+
+        A list (including an empty list) takes precedence over the
+        static ``DeviceConfig.extra_test_args`` populated from the
+        ``--extra-test-args`` CLI flag. The empty-list case is
+        meaningful: it launches the binary with no extra args at all,
+        explicitly suppressing the static value.
+
+        Pass ``None`` to clear the override and fall back to
+        ``extra_test_args`` — the default state, preserving existing
+        ``--extra-test-args`` behavior for callers that don't opt in.
+
+        Unlike ``extra_test_args`` (a single space-split string), this
+        list is consumed as-is — individual entries may contain spaces.
+
+        Calling this invalidates any cached command from a previous
+        launch, so a follow-up ``launch()`` will regenerate honoring
+        the new state.
+        """
+        self._extra_args_override = args
+        self.command = []
 
     @property
     def env(self) -> dict[str, str]:
@@ -62,9 +86,17 @@ class DeviceAdapter(abc.ABC):
         """
         self.close()
 
+        # Externally-set ``self.command`` (set directly by the caller,
+        # e.g. test fixtures) is honored as-is. Otherwise generate the
+        # command and append the per-test override (None means "no
+        # override"; an explicit list — even empty — replaces the
+        # static fallback). ``set_extra_args`` clears ``self.command``
+        # so any change in override forces regeneration.
         if not self.command:
             self.generate_command()
-            if self.device_config.extra_test_args:
+            if self._extra_args_override is not None:
+                self.command.extend(self._extra_args_override)
+            elif self.device_config.extra_test_args:
                 self.command.extend(self.device_config.extra_test_args.split())
 
         self.start_reader()

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
@@ -90,9 +90,39 @@ def unlaunched_duts(
 
 
 @pytest.fixture(scope=determine_scope)
-def dut(unlaunched_dut: DeviceAdapter) -> Generator[DeviceAdapter, None, None]:
+def device_extra_args() -> list[str] | None:
+    """Extra args appended to the device launch command.
+
+    Override in a downstream ``conftest.py`` (or via a same-scope
+    ``@pytest.fixture`` in a test module) to inject runtime spawn args
+    without round-tripping through the static ``--extra-test-args`` CLI
+    flag. The returned list is consumed as-is, so individual entries
+    may contain spaces (unlike ``--extra-test-args`` which is split on
+    whitespace).
+
+    Shares scope with ``dut`` (function-scoped by default, configurable
+    via ``--dut-scope``), so each launched device sees the override
+    appropriate to its scope.
+
+    Return values:
+
+    - ``None`` (the default) — no override; the static
+      ``--extra-test-args`` CLI value is used unchanged.
+    - ``[]`` — explicit empty override; launches the binary with no
+      extra args, suppressing the static value.
+    - ``["--foo", ...]`` — replaces the static value with this list.
+    """
+    return None
+
+
+@pytest.fixture(scope=determine_scope)
+def dut(
+    unlaunched_dut: DeviceAdapter,
+    device_extra_args: list[str] | None,
+) -> Generator[DeviceAdapter, None, None]:
     """Return launched device - with run application."""
     dut = unlaunched_dut
+    dut.set_extra_args(device_extra_args)
     dut.launch()
     yield dut
 

--- a/scripts/pylib/pytest-twister-harness/tests/device/binary_adapter_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/device/binary_adapter_test.py
@@ -194,3 +194,108 @@ def test_if_unit_binary_adapter_get_command_returns_proper_string(tmp_path: Path
     device.generate_command()
     assert isinstance(device.command, list)
     assert device.command == [str(tmp_path / 'testbinary')]
+
+
+@mock.patch('subprocess.Popen')
+def test_set_extra_args_appends_to_command_on_launch(patched_popen, device: NativeSimulatorAdapter) -> None:
+    """``set_extra_args`` should append its args to the auto-generated
+    command at launch time, taking precedence over ``extra_test_args``."""
+    device.device_config.extra_test_args = '--static-arg'
+    device.set_extra_args(['--per-test', '--eeprom=/tmp/eep.bin'])
+    device.launch()
+    binary = str(device.device_config.build_dir / 'zephyr' / 'zephyr.exe')
+    assert device.command == [binary, '--per-test', '--eeprom=/tmp/eep.bin']
+    device.close()
+
+
+@mock.patch('subprocess.Popen')
+def test_set_extra_args_overrides_take_effect_across_launches(
+    patched_popen, device: NativeSimulatorAdapter
+) -> None:
+    """A second ``set_extra_args`` call must replace the first — without
+    this, the cached ``command`` from a previous launch would leak."""
+    device.set_extra_args(['--first'])
+    device.launch()
+    device.close()
+    device.set_extra_args(['--second'])
+    device.launch()
+    binary = str(device.device_config.build_dir / 'zephyr' / 'zephyr.exe')
+    assert device.command == [binary, '--second']
+    device.close()
+
+
+@mock.patch('subprocess.Popen')
+def test_extra_test_args_static_fallback_preserved(
+    patched_popen, device: NativeSimulatorAdapter
+) -> None:
+    """When no per-test override is set, the static ``extra_test_args``
+    CLI value flows through unchanged — backward compat for callers that
+    have never used ``set_extra_args``."""
+    device.device_config.extra_test_args = '--a --b=c'
+    device.launch()
+    binary = str(device.device_config.build_dir / 'zephyr' / 'zephyr.exe')
+    assert device.command == [binary, '--a', '--b=c']
+    device.close()
+
+
+@mock.patch('subprocess.Popen')
+def test_set_extra_args_none_preserves_static(
+    patched_popen, device: NativeSimulatorAdapter
+) -> None:
+    """``set_extra_args(None)`` means 'no override' — the static
+    ``extra_test_args`` flows through unchanged. The ``dut`` fixture
+    relies on this when the user-overridable ``device_extra_args``
+    fixture returns its default of ``None``."""
+    device.device_config.extra_test_args = '--static-arg'
+    device.set_extra_args(None)
+    device.launch()
+    binary = str(device.device_config.build_dir / 'zephyr' / 'zephyr.exe')
+    assert device.command == [binary, '--static-arg']
+    device.close()
+
+
+@mock.patch('subprocess.Popen')
+def test_set_extra_args_empty_list_suppresses_static(
+    patched_popen, device: NativeSimulatorAdapter
+) -> None:
+    """``set_extra_args([])`` is an *explicit* empty override — distinct
+    from ``None``. It launches the binary with no extra args at all,
+    suppressing the static value. Lets a test opt out of CLI-supplied
+    ``--extra-test-args`` for that one launch."""
+    device.device_config.extra_test_args = '--static-arg'
+    device.set_extra_args([])
+    device.launch()
+    binary = str(device.device_config.build_dir / 'zephyr' / 'zephyr.exe')
+    assert device.command == [binary]
+    device.close()
+
+
+@mock.patch('subprocess.Popen')
+def test_set_extra_args_can_be_cleared_back_to_static(
+    patched_popen, device: NativeSimulatorAdapter
+) -> None:
+    """A test that opts into the override must be able to opt back out
+    by passing ``None`` — what makes the dut fixture's 'always call
+    set_extra_args' pattern safe across mixed test suites."""
+    device.device_config.extra_test_args = '--static-arg'
+    device.set_extra_args(['--per-test'])
+    device.launch()
+    device.close()
+    device.set_extra_args(None)  # clear the override
+    device.launch()
+    binary = str(device.device_config.build_dir / 'zephyr' / 'zephyr.exe')
+    assert device.command == [binary, '--static-arg']
+    device.close()
+
+
+@mock.patch('subprocess.Popen')
+def test_externally_set_command_still_honored(
+    patched_popen, device: NativeSimulatorAdapter
+) -> None:
+    """Tests that manipulate ``device.command`` directly (pre-existing
+    pattern used by this very file's fixtures) must still work — only
+    explicit ``set_extra_args`` calls trigger regeneration."""
+    device.command = ['python3', '/path/to/script.py']
+    device.launch()
+    assert device.command == ['python3', '/path/to/script.py']
+    device.close()


### PR DESCRIPTION
Add `set_extra_args()` on `DeviceAdapter` and a same-scope `device_extra_args` fixture so tests can inject per-launch args (e.g. `--eeprom=<path>`) without round-tripping through the static `--extra-test-args` CLI flag. `None` (the fixture default) keeps existing behavior; `[]` explicitly suppresses static args; a list replaces them.

Assisted-by: Claude:claude-opus-4.7