### PR TITLE
crc: add CRC-32/MPEG-2 support

### DIFF
--- a/drivers/crc/Kconfig
+++ b/drivers/crc/Kconfig
@@ -105,4 +105,9 @@ config CRC_DRIVER_HAS_CRC32_K_4_2
 	help
 	  CRC driver has CRC32K/4.2 computation
 
+config CRC_DRIVER_HAS_CRC32_MPEG2
+	bool
+	help
+	  CRC driver has CRC32 MPEG-2 computation
+
 endif # CRC_DEVICE

--- a/drivers/crc/Kconfig.nxp
+++ b/drivers/crc/Kconfig.nxp
@@ -12,6 +12,7 @@ config CRC_DRIVER_NXP
 	select CRC_DRIVER_HAS_CRC16_REFLECT
 	select CRC_DRIVER_HAS_CRC32_C
 	select CRC_DRIVER_HAS_CRC32_IEEE
+	select CRC_DRIVER_HAS_CRC32_MPEG2
 	help
 	  Enable the driver implementation for NXP microcontrollers
 
@@ -22,5 +23,6 @@ config CRC_DRIVER_NXP_LPC
 	select CRC_DRIVER_HAS_CRC16
 	select CRC_DRIVER_HAS_CRC16_CCITT
 	select CRC_DRIVER_HAS_CRC32_IEEE
+	select CRC_DRIVER_HAS_CRC32_MPEG2
 	help
 	  Enable the LPC CRC driver implementation for NXP microcontrollers

--- a/drivers/crc/crc_nxp.c
+++ b/drivers/crc/crc_nxp.c
@@ -123,6 +123,14 @@ static int crc_nxp_prepare_config(const struct device *dev, const struct crc_ctx
 		cfg->complementChecksum = true; /* IEEE requires final XOR */
 		*use32 = true;
 		break;
+	case CRC32_MPEG2:
+		if (ctx->polynomial != CRC32_IEEE_POLY) {
+			return -EINVAL;
+		}
+		cfg->crcBits = kCrcBits32;
+		/* MPEG-2 uses no input/output reflection and no final XOR */
+		*use32 = true;
+		break;
 	default:
 		return -ENOTSUP;
 	}
@@ -178,7 +186,8 @@ static int crc_nxp_update(const struct device *dev, struct crc_ctx *ctx, const v
 	}
 
 	/* Keep an updated result for streaming verification */
-	if ((ctx->type == CRC32_C) || (ctx->type == CRC32_IEEE)) {
+	if ((ctx->type == CRC32_C) || (ctx->type == CRC32_IEEE) ||
+	    (ctx->type == CRC32_MPEG2)) {
 		ctx->result = CRC_Get32bitResult(config->base);
 	} else {
 		ctx->result = (uint32_t)CRC_Get16bitResult(config->base);
@@ -196,7 +205,8 @@ static int crc_nxp_finish(const struct device *dev, struct crc_ctx *ctx)
 	}
 
 	/* Read final result */
-	if (((ctx->type == CRC32_C) || (ctx->type == CRC32_IEEE))) {
+	if ((ctx->type == CRC32_C) || (ctx->type == CRC32_IEEE) ||
+	    (ctx->type == CRC32_MPEG2)) {
 		ctx->result = CRC_Get32bitResult(config->base);
 	} else {
 		ctx->result = (uint32_t)CRC_Get16bitResult(config->base);

--- a/drivers/crc/crc_nxp_lpc.c
+++ b/drivers/crc/crc_nxp_lpc.c
@@ -84,6 +84,15 @@ static int crc_nxp_lpc_prepare_config(const struct crc_ctx *ctx, crc_config_t *c
 		/* IEEE uses final XOR */
 		cfg->complementOut = true;
 		break;
+	case CRC32_MPEG2:
+		if (ctx->polynomial != CRC32_IEEE_POLY) {
+			return -EINVAL;
+		}
+		cfg->polynomial = kCRC_Polynomial_CRC_32;
+		/* MPEG-2 uses no reflection and no final XOR; both already
+		 * default to false above.
+		 */
+		break;
 	default:
 		return -ENOTSUP;
 	}
@@ -147,7 +156,7 @@ static int crc_nxp_lpc_update(const struct device *dev, struct crc_ctx *ctx, con
 	}
 
 	/* Keep an updated result for streaming verification */
-	if (ctx->type == CRC32_IEEE) {
+	if ((ctx->type == CRC32_IEEE) || (ctx->type == CRC32_MPEG2)) {
 		ctx->result = CRC_Get32bitResult(config->base);
 	} else {
 		ctx->result = (uint32_t)CRC_Get16bitResult(config->base);
@@ -168,7 +177,7 @@ static int crc_nxp_lpc_finish(const struct device *dev, struct crc_ctx *ctx)
 		return -EINVAL;
 	}
 
-	if (ctx->type == CRC32_IEEE) {
+	if ((ctx->type == CRC32_IEEE) || (ctx->type == CRC32_MPEG2)) {
 		ctx->result = CRC_Get32bitResult(config->base);
 	} else {
 		ctx->result = (uint32_t)CRC_Get16bitResult(config->base);

--- a/include/zephyr/drivers/crc.h
+++ b/include/zephyr/drivers/crc.h
@@ -96,6 +96,9 @@ extern "C" {
 /** CRC32_K_4_2 initial value */
 #define CRC32_K_4_2_INIT_VAL 0xFFFFFFFFU
 
+/** CRC32_MPEG2 initial value */
+#define CRC32_MPEG2_INIT_VAL 0xFFFFFFFFU
+
 /** @endcond */
 
 /**

--- a/include/zephyr/sys/crc.h
+++ b/include/zephyr/sys/crc.h
@@ -116,6 +116,7 @@ enum crc_type {
 	CRC32_C,     /**< Use @ref crc32_c */
 	CRC32_IEEE,  /**< Use @ref crc32_ieee */
 	CRC32_K_4_2, /**< Use @ref crc32_k_4_2_update */
+	CRC32_MPEG2, /**< Use @ref crc32_mpeg2 */
 };
 
 /**
@@ -337,6 +338,36 @@ uint32_t crc32_c(uint32_t crc, const uint8_t *data,
 uint32_t crc32_k_4_2_update(uint32_t crc, const uint8_t *data, size_t len);
 
 /**
+ * @brief Generate CRC-32/MPEG-2 checksum.
+ *
+ * Uses polynomial 0x04C11DB7 with initial value 0xFFFFFFFF, no input or output
+ * reflection and no final XOR (CRC-32/MPEG-2). Equivalent to calling
+ * @ref crc32_mpeg2_update with @p crc set to 0xFFFFFFFF.
+ *
+ * @param  data         Pointer to data on which the CRC should be calculated.
+ * @param  len          Data length.
+ *
+ * @return CRC-32 value.
+ */
+uint32_t crc32_mpeg2(const uint8_t *data, size_t len);
+
+/**
+ * @brief Update a CRC-32/MPEG-2 checksum.
+ *
+ * Computes a CRC-32 using polynomial 0x04C11DB7 in MSB-first form, with no
+ * input or output reflection and no final XOR. With @p crc set to 0xFFFFFFFF
+ * on the first call this produces the standard CRC-32/MPEG-2 value.
+ *
+ * @param crc   CRC-32 checksum that needs to be updated (use 0xFFFFFFFF for
+ *              the first call to match CRC-32/MPEG-2).
+ * @param data  Pointer to data on which the CRC should be calculated.
+ * @param len   Data length.
+ *
+ * @return CRC-32 value.
+ */
+uint32_t crc32_mpeg2_update(uint32_t crc, const uint8_t *data, size_t len);
+
+/**
  * @brief Compute CCITT variant of CRC 8
  *
  * Normal CCITT variant of CRC 8 is using 0x07.
@@ -512,6 +543,8 @@ static inline uint32_t crc_by_type(enum crc_type type, const uint8_t *src, size_
 		return crc32_ieee_update(seed, src, len);
 	case CRC32_K_4_2:
 		return crc32_k_4_2_update(seed, src, len);
+	case CRC32_MPEG2:
+		return crc32_mpeg2_update(seed, src, len);
 	default:
 		break;
 	}

--- a/subsys/crc/Kconfig
+++ b/subsys/crc/Kconfig
@@ -148,6 +148,16 @@ config CRC32_K_4_2
 	  CRC32-IEEE used in Ethernet, ZIP files, and other data integrity
 	  applications.
 
+config CRC32_MPEG2
+	bool "CRC-32 (MPEG-2)"
+	depends on CRC_DRIVER_HAS_CRC32_MPEG2
+	default y
+	help
+	  Implements the CRC-32/MPEG-2 algorithm (polynomial 0x04C11DB7,
+	  initial value 0xFFFFFFFF, no input/output reflection, no final
+	  XOR). Used by MPEG-2 transport streams (ISO/IEC 13818-1) and
+	  commonly available in MCU CRC peripherals.
+
 config CRC32_K_4_2_TABLE_256
 	bool "CRC-32K/4.2 Table 256"
 	help

--- a/subsys/crc/crc32_sw.c
+++ b/subsys/crc/crc32_sw.c
@@ -31,3 +31,27 @@ uint32_t __weak crc32_ieee_update(uint32_t crc, const uint8_t *data, size_t len)
 
 	return (~crc);
 }
+
+uint32_t __weak crc32_mpeg2(const uint8_t *data, size_t len)
+{
+	return crc32_mpeg2_update(0xFFFFFFFFU, data, len);
+}
+
+uint32_t __weak crc32_mpeg2_update(uint32_t crc, const uint8_t *data, size_t len)
+{
+	/* crc table generated from polynomial 0x04C11DB7 (MSB-first, no reflection) */
+	static const uint32_t table[16] = {
+		0x00000000U, 0x04C11DB7U, 0x09823B6EU, 0x0D4326D9U, 0x130476DCU, 0x17C56B6BU,
+		0x1A864DB2U, 0x1E475005U, 0x2608EDB8U, 0x22C9F00FU, 0x2F8AD6D6U, 0x2B4BCB61U,
+		0x350C9B64U, 0x31CD86D3U, 0x3C8EA00AU, 0x384FBDBDU,
+	};
+
+	for (size_t i = 0; i < len; i++) {
+		uint8_t byte = data[i];
+
+		crc = (crc << 4) ^ table[((crc >> 28) ^ ((uint32_t)byte >> 4)) & 0x0f];
+		crc = (crc << 4) ^ table[((crc >> 28) ^ byte) & 0x0f];
+	}
+
+	return crc;
+}

--- a/subsys/crc/crc_hardware.c
+++ b/subsys/crc/crc_hardware.c
@@ -376,3 +376,30 @@ uint32_t crc32_k_4_2_update(uint32_t crc, const uint8_t *const data, const size_
 	return ctx.result;
 }
 #endif
+
+#ifdef CONFIG_CRC32_MPEG2
+uint32_t crc32_mpeg2_update(uint32_t crc, const uint8_t *data, size_t len)
+{
+	int ret;
+
+	struct crc_ctx ctx = {
+		.type = CRC32_MPEG2,
+		.polynomial = CRC32_IEEE_POLY,
+		.seed = crc,
+		.reversed = 0,
+	};
+
+	ret = crc_operation(crc_dev, &ctx, data, len);
+	if (ret != 0) {
+		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		return 0;
+	}
+
+	return ctx.result;
+}
+
+uint32_t crc32_mpeg2(const uint8_t *data, size_t len)
+{
+	return crc32_mpeg2_update(CRC32_MPEG2_INIT_VAL, data, len);
+}
+#endif

--- a/tests/drivers/crc/src/main.c
+++ b/tests/drivers/crc/src/main.c
@@ -199,6 +199,34 @@ ZTEST(crc, test_crc_32_ieee)
 }
 
 /* Define result of CRC computation */
+#define RESULT_CRC_32_MPEG2 0x80AE8C93
+
+/**
+ * @brief Test that crc_32_mpeg2 works
+ */
+ZTEST(crc, test_crc_32_mpeg2)
+{
+#ifndef CONFIG_CRC_DRIVER_HAS_CRC32_MPEG2
+	ztest_test_skip();
+#endif
+
+	static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_crc));
+
+	uint8_t data[8] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4};
+	struct crc_ctx ctx = {
+		.type = CRC32_MPEG2,
+		.polynomial = CRC32_IEEE_POLY,
+		.seed = CRC32_MPEG2_INIT_VAL,
+		.reversed = 0,
+	};
+
+	zassert_equal(crc_begin(dev, &ctx), 0);
+	zassert_equal(crc_update(dev, &ctx, data, sizeof(data)), 0);
+	zassert_equal(crc_finish(dev, &ctx), 0);
+	zassert_equal(crc_verify(&ctx, RESULT_CRC_32_MPEG2), 0);
+}
+
+/* Define result of CRC computation */
 #define RESULT_CRC_8_REMAIN_3 0xBB
 
 /**

--- a/tests/subsys/crc/src/main.c
+++ b/tests/subsys/crc/src/main.c
@@ -138,6 +138,19 @@ ZTEST(crc_subsys, test_crc_32_ieee)
 }
 
 /* Define result of CRC computation */
+#define RESULT_CRC32_MPEG2 0x80AE8C93
+
+/**
+ * @brief Test that crc_32_mpeg2 works
+ */
+ZTEST(crc_subsys, test_crc_32_mpeg2)
+{
+	uint8_t data[8] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4};
+
+	zassert_equal(crc32_mpeg2(data, sizeof(data)), RESULT_CRC32_MPEG2);
+}
+
+/* Define result of CRC computation */
 #define RESULT_CRC8_CCITT_REMAIN_1 0x57
 
 /**


### PR DESCRIPTION
- Adds the CRC-32/MPEG-2 variant  (ISO/IEC 13818-1 Annex A, ITU-T H.222.0)  to both the software CRC subsystem and the CRC device API.
- Adds crc32_mpeg2() and crc32_mpeg2_update().
- Adds CRC-32/MPEG-2 support to the NXP CRC drivers.
- Adds CRC-32/MPEG-2 ztest case in tests/drivers/crc and in tests/subsys/crc.

Tested on lpcxpresso55s69 and frdm-mcxn947

