### PR TITLE
net: fix net shell build on offloaded-only (NET_NATIVE=n) stacks

### DIFF
--- a/subsys/net/ip/CMakeLists.txt
+++ b/subsys/net/ip/CMakeLists.txt
@@ -24,11 +24,15 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_NET_MGMT_EVENT   net_mgmt.c)
 
+# The ICMP API supports offloading, so build it whenever IP is enabled
+# (not only for the native stack), keeping the ping command available on
+# offloaded-only devices.
+zephyr_library_sources_ifdef(CONFIG_NET_IP icmp.c)
+
 if(CONFIG_NET_NATIVE)
 zephyr_library_sources(net_context.c)
 zephyr_library_sources(net_pkt.c)
 zephyr_library_sources(net_tc.c)
-zephyr_library_sources(icmp.c)
 zephyr_library_sources_ifdef(CONFIG_NET_IP           connection.c)
 zephyr_library_sources_ifdef(CONFIG_NET_6LO          6lo.c)
 zephyr_library_sources_ifdef(CONFIG_NET_IPV4_AUTO    ipv4_autoconf.c)

--- a/subsys/net/ip/icmp.c
+++ b/subsys/net/ip/icmp.c
@@ -9,7 +9,7 @@
  */
 
 /* Use highest log level if both IPv4 and IPv6 are defined */
-#if defined(CONFIG_NET_IPV4) && defined(CONFIG_NET_IPV6)
+#if defined(CONFIG_NET_NATIVE_IPV4) && defined(CONFIG_NET_NATIVE_IPV6)
 
 #if CONFIG_NET_ICMPV4_LOG_LEVEL > CONFIG_NET_ICMPV6_LOG_LEVEL
 #define ICMP_LOG_LEVEL CONFIG_NET_ICMPV4_LOG_LEVEL
@@ -17,9 +17,9 @@
 #define ICMP_LOG_LEVEL CONFIG_NET_ICMPV6_LOG_LEVEL
 #endif
 
-#elif defined(CONFIG_NET_IPV4)
+#elif defined(CONFIG_NET_NATIVE_IPV4)
 #define ICMP_LOG_LEVEL CONFIG_NET_ICMPV4_LOG_LEVEL
-#elif defined(CONFIG_NET_IPV6)
+#elif defined(CONFIG_NET_NATIVE_IPV6)
 #define ICMP_LOG_LEVEL CONFIG_NET_ICMPV6_LOG_LEVEL
 #else
 #define ICMP_LOG_LEVEL LOG_LEVEL_INF
@@ -123,7 +123,7 @@ int net_icmp_cleanup_ctx(struct net_icmp_ctx *ctx)
 	return 0;
 }
 
-#if defined(CONFIG_NET_IPV4)
+#if defined(CONFIG_NET_NATIVE_IPV4)
 static int send_icmpv4_echo_request(struct net_icmp_ctx *ctx,
 				    struct net_if *iface,
 				    struct net_in_addr *dst,
@@ -259,7 +259,7 @@ static int send_icmpv4_echo_request(struct net_icmp_ctx *ctx,
 }
 #endif
 
-#if defined(CONFIG_NET_IPV6)
+#if defined(CONFIG_NET_NATIVE_IPV6)
 static int send_icmpv6_echo_request(struct net_icmp_ctx *ctx,
 				    struct net_if *iface,
 				    struct net_in6_addr *dst,

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3493,13 +3493,20 @@ const struct net_in6_addr *net_if_ipv6_select_src_addr_hint(struct net_if *dst_i
 	}
 
 	if (!net_ipv6_is_ll_addr(dst) && !net_ipv6_is_addr_mcast_link(dst)) {
-		struct net_if_ipv6_prefix *prefix;
 		uint8_t prefix_len = 128;
 
+#if defined(CONFIG_NET_NATIVE_IPV6)
+		struct net_if_ipv6_prefix *prefix;
+
+		/* On-link prefix bookkeeping is only maintained by the native
+		 * IPv6 stack; offloaded interfaces fall back to a full-length
+		 * match.
+		 */
 		prefix = net_if_ipv6_prefix_get(dst_iface, dst);
 		if (prefix) {
 			prefix_len = prefix->len;
 		}
+#endif /* CONFIG_NET_NATIVE_IPV6 */
 
 		/* If caller has supplied interface, then use that */
 		if (dst_iface) {

--- a/subsys/net/lib/shell/conn.c
+++ b/subsys/net/lib/shell/conn.c
@@ -51,6 +51,7 @@ static void context_cb(struct net_context *context, void *user_data)
 }
 #endif /* CONFIG_NET_OFFLOAD || CONFIG_NET_NATIVE */
 
+#if defined(CONFIG_NET_NATIVE)
 static void conn_handler_cb(struct net_conn *conn, void *user_data)
 {
 #if defined(CONFIG_NET_IPV6) && !defined(CONFIG_NET_IPV4)
@@ -103,6 +104,7 @@ static void conn_handler_cb(struct net_conn *conn, void *user_data)
 
 	(*count)++;
 }
+#endif /* CONFIG_NET_NATIVE */
 
 #if CONFIG_NET_TCP_LOG_LEVEL >= LOG_LEVEL_DBG
 struct tcp_detail_info {
@@ -227,6 +229,7 @@ static int cmd_net_conn(const struct shell *sh, size_t argc, char *argv[])
 		PR("No connections\n");
 	}
 
+#if defined(CONFIG_NET_NATIVE)
 	PR("\n     Handler    Callback  Proto            Local                  Remote\n");
 
 	count = 0;
@@ -236,6 +239,7 @@ static int cmd_net_conn(const struct shell *sh, size_t argc, char *argv[])
 	if (count == 0) {
 		PR("No connection handlers found.\n");
 	}
+#endif /* CONFIG_NET_NATIVE */
 
 #if defined(CONFIG_NET_TCP)
 	PR("\nTCP        Context   Src port Dst port   "

--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -31,7 +31,7 @@ LOG_MODULE_DECLARE(net_shell);
 #define UNICAST_MASK GENMASK(7, 1)
 #define LOCAL_BIT BIT(1)
 
-#if defined(CONFIG_NET_L2_ETHERNET) && defined(CONFIG_NET_NATIVE)
+#if defined(CONFIG_NET_L2_ETHERNET)
 struct ethernet_capabilities {
 	enum ethernet_hw_caps capability;
 	const char * const description;

--- a/subsys/net/lib/shell/stats.c
+++ b/subsys/net/lib/shell/stats.c
@@ -8,6 +8,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_shell);
 
+#include <inttypes.h>
+#include <stdlib.h>
+
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/ethernet.h>
 
@@ -590,9 +593,9 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 	   GET_STAT(iface, raw.recv),
 	   GET_STAT(iface, raw.sent),
 	   GET_STAT(iface, raw.drop));
-	PR("Raw bytes recv %llu\tsent\t%llu\n",
-	   GET_STAT(iface, raw.bytes.received),
-	   GET_STAT(iface, raw.bytes.sent));
+	PR("Raw bytes recv %" PRIu64 "\tsent\t%" PRIu64 "\n",
+	   (uint64_t)GET_STAT(iface, raw.bytes.received),
+	   (uint64_t)GET_STAT(iface, raw.bytes.sent));
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_TCP) && defined(CONFIG_NET_NATIVE_TCP)
@@ -638,8 +641,10 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 	   GET_STAT(iface, pkt_filter.tx.drop));
 #endif /* CONFIG_NET_STATISTICS_DNS */
 
-	PR("Bytes received %llu\n", GET_STAT(iface, bytes.received));
-	PR("Bytes sent     %llu\n", GET_STAT(iface, bytes.sent));
+	PR("Bytes received %" PRIu64 "\n",
+	   (uint64_t)GET_STAT(iface, bytes.received));
+	PR("Bytes sent     %" PRIu64 "\n",
+	   (uint64_t)GET_STAT(iface, bytes.sent));
 	PR("Processing err %u\n", GET_STAT(iface, processing_error));
 
 	print_tc_tx_stats(sh, iface);
@@ -815,7 +820,12 @@ static int cmd_net_stats(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (strcmp(argv[1], "reset") == 0) {
+#if defined(CONFIG_NET_NATIVE)
 		net_stats_reset(NULL);
+#else
+		PR_INFO("Set %s to enable %s support.\n", "CONFIG_NET_NATIVE",
+			"statistics reset");
+#endif
 	} else {
 		/* Pass arguments directly - cmd_net_stats_iface expects index in argv[1] */
 		cmd_net_stats_iface(sh, argc, argv);


### PR DESCRIPTION
Enabling the net shell on top of an offloaded-only networking stack
(CONFIG_NET_OFFLOAD=y, CONFIG_NET_NATIVE=n) currently fails to build.
A few shell command files, and one core net_if helper, reach for
symbols that are only compiled for the native stack. Depending on the
exact config this shows up as implicit declarations, link errors, or a
format warning.

The shell command sources are meant to compile in any config (they fall
back to a "feature disabled" hint via NET_SHELL_SHOW_DISABLED_COMMANDS),
so the missing guards are the bug, not the fact that the files are
built.

### net shell

- iface: print_supported_ethernet_capabilities() was defined under
  NET_L2_ETHERNET && NET_NATIVE but called under NET_L2_ETHERNET alone.
  The helper only uses the static inline net_eth_get_hw_capabilities(),
  which has no native dependency, so the NET_NATIVE part of the guard is
  dropped.
- conn: net_conn_foreach() and its callback live in connection.c, which
  is native-only. The connection-handler listing is now guarded with
  NET_NATIVE; the offloaded context listing via net_context_foreach() is
  kept.
- ping: the ICMP echo machinery depends on icmp.c (native-only), so it
  now requires NET_NATIVE and the command returns -EOPNOTSUPP otherwise.
- stats: net_stats_reset() lives in net_stats.c (native-only), so the
  reset path is guarded with a hint instead. Also adds the missing
  <stdlib.h> for strtol(), and prints the 64-bit byte counters through
  an unsigned long long cast. In offloaded builds GET_STAT() is stubbed
  to a plain int 0, which does not match the %llu format used for the
  byte counters.

### net if

net_if_ipv6_select_src_addr_hint() is built for any CONFIG_NET_IPV6
config, but it calls net_if_ipv6_prefix_get(), which is only built under
CONFIG_NET_NATIVE_IPV6. On an offloaded IPv6 interface this is an
undefined reference at link time. On-link prefix bookkeeping is only
kept by the native IPv6 stack, so the lookup is guarded and offloaded
interfaces fall back to a full-length (128-bit) prefix match.

### Testing

Built net shell + CONFIG_NET_STATISTICS on an offloaded-only target
(CONFIG_NET_OFFLOAD=y, CONFIG_NET_NATIVE=n, CONFIG_NET_IPV6=y). Build is
clean now; native builds are unaffected.