### PR TITLE
tests: drivers: fuel_gauge: fix deprecated prop_val initializers

### DIFF
--- a/tests/drivers/fuel_gauge/lc709203f/src/test_lc709203f.c
+++ b/tests/drivers/fuel_gauge/lc709203f/src/test_lc709203f.c
@@ -53,7 +53,7 @@ ZTEST_USER_F(lc709203f, test_set_all_props_failed__returns_err)
 		/* Invalid property */
 		FUEL_GAUGE_PROP_MAX,
 	};
-	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {0};
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {{.avg_current_ua = 0}};
 
 	int ret = fuel_gauge_set_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
 
@@ -75,9 +75,9 @@ ZTEST_USER_F(lc709203f, test_set_some_props_failed__returns_err)
 
 	union fuel_gauge_prop_val props[] = {
 		/* First invalid property */
-		{0},
+		{.avg_current_ua = 0},
 		/* Second invalid property */
-		{0},
+		{.avg_current_ua = 0},
 		/* Valid property */
 		/* Sets state of charge threshold to generate Alarm signal*/
 		{.state_of_charge_alarm_pct = 10},

--- a/tests/drivers/fuel_gauge/ltc2959/src/test_ltc2959.c
+++ b/tests/drivers/fuel_gauge/ltc2959/src/test_ltc2959.c
@@ -275,9 +275,9 @@ ZTEST_F(ltc2959, test_set_some_props_failed__returns_err)
 
 	union fuel_gauge_prop_val props[] = {
 		/* First invalid property */
-		{0},
+		{.avg_current_ua = 0},
 		/* Second invalid property */
-		{0},
+		{.avg_current_ua = 0},
 		/* Valid property */
 		{.voltage_uv = 0},
 	};

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -42,7 +42,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_some_props_failed_returns_bad_status)
 		/* Valid property */
 		FUEL_GAUGE_VOLTAGE_UV,
 	};
-	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {0};
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
 
 	int ret = fuel_gauge_get_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
 
@@ -55,7 +55,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_all_props_failed_returns_err)
 		/* Invalid property */
 		FUEL_GAUGE_PROP_MAX,
 	};
-	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {0};
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {{.avg_current_ua = 0}};
 
 	int ret = fuel_gauge_set_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
 
@@ -77,9 +77,9 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_some_props_failed_returns_err)
 
 	union fuel_gauge_prop_val props[] = {
 		/* First invalid property */
-		{0},
+		{.avg_current_ua = 0},
 		/* Second invalid property */
-		{0},
+		{.avg_current_ua = 0},
 		/* Valid property */
 		/* Set Manufacturer's Access to arbitrary word */
 		{.sbs_mfr_access_word = 1},
@@ -166,7 +166,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
 		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS,
 	};
 
-	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {0};
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
 
 	zassert_ok(fuel_gauge_get_props(fixture->dev, prop_types, props, ARRAY_SIZE(props)));
 }
@@ -181,7 +181,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_props__returns_ok)
 		FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
 
 	};
-	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {0};
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {{.avg_current_ua = 0}};
 
 	zassert_ok(fuel_gauge_set_props(fixture->dev, prop_types, props, ARRAY_SIZE(props)));
 }


### PR DESCRIPTION
Initializing union `fuel_gauge_prop_val` with `{0}` touches the now deprecated `avg_current` member and fails `-Werror,-Wdeprecated-declarations` builds. Use designated initializers or omit zero-init where values are unused.