### PR TITLE
gpio: add gpio-reserved-ranges support for stm32

### DIFF
--- a/soc/st/stm32/common/gpioport_mgr.c
+++ b/soc/st/stm32/common/gpioport_mgr.c
@@ -401,7 +401,7 @@ static DEVICE_API(gpio, dummy_gpio_api) = {
 #define GPIO_PORT_DEVICE_INIT(__node, __suffix, __base_addr, __port)		\
 	static const struct gpio_stm32_config gpio_stm32_cfg_## __suffix = {	\
 		.common = {							\
-			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(16U),	\
+			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_NODE(__node),	\
 		},								\
 		.base = (void *)__base_addr,					\
 		.port = __port,							\


### PR DESCRIPTION
Switched from `GPIO_PORT_PIN_MASK_FROM_NGPIOS` to the Devicetree-aware macros (`GPIO_PORT_PIN_MASK_FROM_DT_NODE` and `GPIO_PORT_PIN_MASK_FROM_DT_INST`) to ensure the gpio-reserved-ranges property is respected by the drivers.
This aligns with the architectural design established in PR #56295, where generic support for reserved ranges was centralized within the DT-aware pin mask macros rather than creating new top-level aliases.
I verified the local compilation successfully using `west build -p always -b nucleo_f401re samples/basic/blinky` and `west build -p always -b npcx9m6f_evb samples/basic/blinky` after the changes i made.

Fixes #57038