### PR TITLE
drivers: audio: codec: restore static on aic26_api

### DIFF
--- a/drivers/audio/tlv320aic26.c
+++ b/drivers/audio/tlv320aic26.c
@@ -656,7 +656,7 @@ static int aic26_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_API(audio_codec, aic26_api) = {
+static DEVICE_API(audio_codec, aic26_api) = {
 	.configure        = aic26_configure,
 	.start_output     = aic26_start_output,
 	.stop_output      = aic26_stop_output,


### PR DESCRIPTION
The migration from static const struct audio_codec_api to DEVICE_API() (1cf451d) accidentally removed the static qualifier from aic26_api. Restore static to keep the symbol file-local and match the previous visibility semantics.