### PR TITLE
wifi: Airoc issue fixes

### DIFF
--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -388,6 +388,10 @@ static int airoc_mgmt_send(const struct device *dev, struct net_pkt *pkt)
 	ret = whd_network_send_ethernet_data(airoc_if, (void *)buf);
 	if (ret != CY_RSLT_SUCCESS) {
 		LOG_ERR("whd_network_send_ethernet_data failed");
+		/* WHD does not consume the buffer on a synchronous failure, so
+		 * release it here to avoid leaking it from the TX pool.
+		 */
+		airoc_wifi_buffer_release((whd_buffer_t)buf, WHD_NETWORK_TX);
 #if defined(CONFIG_NET_STATISTICS_WIFI)
 		data->stats.errors.tx++;
 #endif
@@ -682,7 +686,6 @@ static int airoc_mgmt_disconnect(const struct device *dev, struct net_if *iface)
 	}
 
 	if (whd_wifi_leave(airoc_sta_if) != WHD_SUCCESS) {
-		k_sem_give(&data->sema_common);
 		ret = -EAGAIN;
 	} else {
 		data->is_sta_connected = false;


### PR DESCRIPTION
Some review showed there were some small issues in the airoc_wifi driver. A duplicated semaphore give on error and a memory leak when not releasing a buffer.

Fixes: #113303