### PR TITLE
ztest: various coding guideline fixes

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_test.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test.h
@@ -688,7 +688,7 @@ bool ztest_has_current_param(void);
 
 #define Z_TEST_P(suite, fn, t_options) \
 	struct ztest_unit_test_stats z_ztest_unit_test_stats_##suite##_##fn; \
-	static void _##suite##_##fn##_wrapper(void *data); \
+	static void _##suite##_##fn##_wrapper(void *wrapper_data); \
 	/* data carries the suite fixture from setup(); use             */ \
 	/* ztest_get_current_param() / ZTEST_GET_PARAM() for the value. */ \
 	static void suite##_##fn(void *data); \
@@ -724,7 +724,7 @@ bool ztest_has_current_param(void);
 
 #define Z_TEST(suite, fn, t_options, use_fixture)                                                  \
 	struct ztest_unit_test_stats z_ztest_unit_test_stats_##suite##_##fn;                       \
-	static void _##suite##_##fn##_wrapper(void *data);                                         \
+	static void _##suite##_##fn##_wrapper(void *wrapper_data);                                 \
 	static void suite##_##fn(                                                                  \
 		COND_CODE_1(use_fixture, (struct suite##_fixture *fixture), (void)));              \
 	static STRUCT_SECTION_ITERABLE(ztest_unit_test, z_ztest_unit_test__##suite##__##fn) = {    \

--- a/subsys/testsuite/ztest/include/zephyr/ztest_test.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test.h
@@ -896,6 +896,52 @@ struct ztest_arch_api {
 };
 
 /**
+ * @brief The active ztest backend instance.
+ *
+ * Exactly one ztest backend (the default, shell, or POSIX runner) provides
+ * a definition of this variable. All other backends declare it here so that
+ * each definition has a visible prior declaration.
+ */
+extern ZTEST_DMEM const struct ztest_arch_api ztest_api;
+
+/**
+ * @brief Default implementation of ztest_arch_api::run_all.
+ *
+ * Runs all registered test suites. Called by the active backend unless
+ * overridden via ztest_api.
+ *
+ * @param state     Global test state passed to each suite's predicate.
+ * @param shuffle   If true, randomize the order of suites and tests.
+ * @param suite_iter Number of times to repeat each suite.
+ * @param case_iter  Number of times to repeat each test case.
+ */
+void z_ztest_run_all(const void *state, bool shuffle, int suite_iter, int case_iter);
+
+/**
+ * @brief Default implementation of ztest_arch_api::should_suite_run.
+ *
+ * Evaluates whether the given suite should run by calling its predicate
+ * function (if any) against @p state.
+ *
+ * @param state Global test state.
+ * @param suite Pointer to the suite node to evaluate.
+ * @return true if the suite should run; false to skip it.
+ */
+bool z_ztest_should_suite_run(const void *state, struct ztest_suite_node *suite);
+
+/**
+ * @brief Default implementation of ztest_arch_api::should_test_run.
+ *
+ * Checks whether a specific test case within a suite should run, taking
+ * any active test filter into account.
+ *
+ * @param suite Name of the test suite.
+ * @param test  Name of the test case.
+ * @return true if the test should run; false to skip it.
+ */
+bool z_ztest_should_test_run(const char *suite, const char *test);
+
+/**
  * @}
  */
 

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -64,7 +64,7 @@ enum ztest_status {
 /**
  * @brief Tracks the current phase that ztest is operating in.
  */
-ZTEST_DMEM enum ztest_phase cur_phase = TEST_PHASE_FRAMEWORK;
+static ZTEST_DMEM enum ztest_phase cur_phase = TEST_PHASE_FRAMEWORK;
 
 static ZTEST_BMEM enum ztest_status test_status = ZTEST_STATUS_OK;
 
@@ -348,6 +348,7 @@ __maybe_unused static void run_test_rules(bool is_before, struct ztest_unit_test
 static void run_test_functions(struct ztest_suite_node *suite, struct ztest_unit_test *test,
 			       void *data)
 {
+	ARG_UNUSED(suite);
 	__ztest_set_test_phase(TEST_PHASE_TEST);
 	test->test(data);
 }
@@ -582,7 +583,8 @@ out:
 #define FAIL_FAST 0
 #endif
 
-K_THREAD_STACK_DEFINE(ztest_thread_stack, CONFIG_ZTEST_STACK_SIZE + CONFIG_TEST_EXTRA_STACK_SIZE);
+static K_THREAD_STACK_DEFINE(ztest_thread_stack,
+			     CONFIG_ZTEST_STACK_SIZE + CONFIG_TEST_EXTRA_STACK_SIZE);
 
 static void test_finalize(void)
 {
@@ -952,6 +954,11 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite, bool shuff
 	 * independent channels.  The argument is kept for ABI compatibility.
 	 */
 	ARG_UNUSED(param);
+
+#ifndef CONFIG_ZTEST_SHUFFLE
+	ARG_UNUSED(shuffle);
+	ARG_UNUSED(suite_iter);
+#endif
 
 	if (FAIL_FAST && test_status != ZTEST_STATUS_OK) {
 		return test_status;

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -128,7 +128,7 @@ static int cleanup_test(struct ztest_unit_test *test)
 		PRINT_DATA("Test %s failed: Unused mock return values\n", test->name);
 		ret = TC_FAIL;
 	} else {
-		;
+		/* No mock failures to report. */
 	}
 
 	return ret;
@@ -339,6 +339,8 @@ __maybe_unused static void run_test_rules(bool is_before, struct ztest_unit_test
 			rule->before_each(test, data);
 		} else if (!is_before && rule->after_each) {
 			rule->after_each(test, data);
+		} else {
+			/* No matching rule callback for this phase. */
 		}
 	}
 }
@@ -711,19 +713,19 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 	 */
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		get_start_time_cyc();
-		k_thread_create(&ztest_thread, ztest_thread_stack,
+		(void)k_thread_create(&ztest_thread, ztest_thread_stack,
 				K_THREAD_STACK_SIZEOF(ztest_thread_stack), test_cb, suite, test,
 				data, CONFIG_ZTEST_THREAD_PRIORITY, K_INHERIT_PERMS, K_FOREVER);
 
 		k_thread_access_grant(&ztest_thread, suite, test, suite->stats);
 		if (test->name != NULL) {
-			k_thread_name_set(&ztest_thread, test->name);
+			(void)k_thread_name_set(&ztest_thread, test->name);
 		}
 		/* Only start the thread if we're not skipping the suite */
 		if (test_result != ZTEST_RESULT_SUITE_SKIP &&
 		    test_result != ZTEST_RESULT_SUITE_FAIL) {
 			k_thread_start(&ztest_thread);
-			k_thread_join(&ztest_thread, K_FOREVER);
+			(void)k_thread_join(&ztest_thread, K_FOREVER);
 		}
 	} else if (test_result != ZTEST_RESULT_SUITE_SKIP &&
 		   test_result != ZTEST_RESULT_SUITE_FAIL) {
@@ -734,6 +736,8 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 			suite->before(data);
 		}
 		run_test_functions(suite, test, data);
+	} else {
+		/* Suite was skipped or failed; no tests to run. */
 	}
 
 	__ztest_set_test_phase(TEST_PHASE_AFTER);
@@ -752,7 +756,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 	/* Flush all logs in case deferred mode and default logging thread are used. */
 	while (IS_ENABLED(CONFIG_TEST_LOGGING_FLUSH_AFTER_TEST) &&
 	       IS_ENABLED(CONFIG_LOG_PROCESS_THREAD) && log_data_pending()) {
-		k_msleep(100);
+		(void)k_msleep(100);
 	}
 
 	if (test_result == ZTEST_RESULT_FAIL || test_result == ZTEST_RESULT_SUITE_FAIL ||
@@ -761,6 +765,8 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 		failed_expectation = false;
 	} else if (test_result == ZTEST_RESULT_SKIP || test_result == ZTEST_RESULT_SUITE_SKIP) {
 		ret = TC_SKIP;
+	} else {
+		/* Result already reflected in ret. */
 	}
 
 	if (test_result == ZTEST_RESULT_PASS || !FAIL_FAST) {
@@ -1003,7 +1009,8 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite, bool shuff
 			}
 		}
 #else
-		while (((test = z_ztest_get_next_test(suite->name, test)) != NULL)) {
+		for (test = z_ztest_get_next_test(suite->name, NULL); test != NULL;
+		     test = z_ztest_get_next_test(suite->name, test)) {
 			if (ztest_api.should_test_run(suite->name, test->name)) {
 				fail += z_ztest_run_test_dispatch(suite, test, data);
 			}
@@ -1052,7 +1059,8 @@ static void __ztest_show_suite_summary_oneline(struct ztest_suite_node *suite)
 	unsigned int suite_duration_worst_ms = 0;
 
 	/** summary of distinct run  */
-	while (((test = z_ztest_get_next_test(suite->name, test)) != NULL)) {
+	for (test = z_ztest_get_next_test(suite->name, NULL); test != NULL;
+	     test = z_ztest_get_next_test(suite->name, test)) {
 		distinct_total++;
 		suite_duration_worst_ms += test->stats->duration_worst_ms;
 		if (test->stats->skip_count == test->stats->run_count) {
@@ -1068,7 +1076,8 @@ static void __ztest_show_suite_summary_oneline(struct ztest_suite_node *suite)
 
 	if (distinct_skip == distinct_total) {
 		suite_result = TC_SKIP;
-		passrate_major = passrate_minor = 0;
+		passrate_minor = 0;
+		passrate_major = 0;
 	} else {
 		suite_result = (distinct_fail > 0) ? TC_FAIL : TC_PASS;
 		effective_total = distinct_total - distinct_skip;
@@ -1100,7 +1109,8 @@ static void __ztest_show_suite_summary_verbose(struct ztest_suite_node *suite)
 		return;
 	}
 
-	while (((test = z_ztest_get_next_test(suite->name, test)) != NULL)) {
+	for (test = z_ztest_get_next_test(suite->name, NULL); test != NULL;
+	     test = z_ztest_get_next_test(suite->name, test)) {
 		if (test->stats->skip_count == test->stats->run_count) {
 			tc_result = TC_SKIP;
 		} else if (test->stats->pass_count + test->stats->skip_count ==
@@ -1368,8 +1378,8 @@ static int cmd_list_cases(const struct shell *sh, size_t argc, char **argv)
 	int test_count = 0;
 
 	for (ptr = _ztest_suite_node_list_start; ptr < _ztest_suite_node_list_end; ++ptr) {
-		test = NULL;
-		while ((test = z_ztest_get_next_test(ptr->name, test)) != NULL) {
+		for (test = z_ztest_get_next_test(ptr->name, NULL); test != NULL;
+		     test = z_ztest_get_next_test(ptr->name, test)) {
 			shell_print(sh, "%s::%s", test->test_suite_name, test->name);
 			test_count++;
 		}
@@ -1605,7 +1615,7 @@ int main(void)
 		state.boots += 1;
 		if (test_status == 0) {
 			PRINT_DATA("Reset board #%u to test again\n", state.boots);
-			k_msleep(10);
+			(void)k_msleep(10);
 			sys_reboot(SYS_REBOOT_COLD);
 		} else {
 			PRINT_DATA("Failed after %u attempts\n", state.boots);

--- a/subsys/testsuite/ztest/src/ztest_defaults.c
+++ b/subsys/testsuite/ztest/src/ztest_defaults.c
@@ -31,7 +31,7 @@ EXPORT_SYMBOL(ztest_relative_filename);
  */
 void z_ztest_run_all(const void *state, bool shuffle, int suite_iter, int case_iter)
 {
-	ztest_run_test_suites(state, shuffle, suite_iter, case_iter);
+	(void)ztest_run_test_suites(state, shuffle, suite_iter, case_iter);
 }
 
 /**

--- a/subsys/testsuite/ztest/src/ztest_defaults.c
+++ b/subsys/testsuite/ztest/src/ztest_defaults.c
@@ -66,6 +66,8 @@ bool z_ztest_should_suite_run(const void *state, struct ztest_suite_node *suite)
  */
 bool z_ztest_should_test_run(const char *suite, const char *test)
 {
+	ARG_UNUSED(suite);
+	ARG_UNUSED(test);
 	return true;
 }
 


### PR DESCRIPTION
- **testsuite: ztest: align test wrapper parameter names**
- **testsuite: ztest: address MISRA Rule 13.4, 15.7 and 17.7**
- **testsuite: ztest: address MISRA Rule 2.7 and 8.4**
