### PR TITLE
tests: drivers: crc: add CRC16-ITU-T test case

### DIFF
--- a/drivers/crc/crc_nxp.c
+++ b/drivers/crc/crc_nxp.c
@@ -85,6 +85,7 @@ static int crc_nxp_prepare_config(const struct device *dev, const struct crc_ctx
 		*use32 = false;
 		break;
 	case CRC16_CCITT:
+	case CRC16_ITU_T:
 		if (ctx->polynomial != CRC16_CCITT_POLY) {
 			return -EINVAL;
 		}
@@ -94,14 +95,6 @@ static int crc_nxp_prepare_config(const struct device *dev, const struct crc_ctx
 		break;
 	case CRC16_ANSI:
 		if (ctx->polynomial != CRC16_REFLECT_POLY) {
-			return -EINVAL;
-		}
-		cfg->seed &= 0xFFFFU;
-		cfg->crcBits = kCrcBits16;
-		*use32 = false;
-		break;
-	case CRC16_ITU_T:
-		if (ctx->polynomial != CRC16_CCITT_POLY) {
 			return -EINVAL;
 		}
 		cfg->seed &= 0xFFFFU;

--- a/drivers/crc/crc_nxp_lpc.c
+++ b/drivers/crc/crc_nxp_lpc.c
@@ -70,6 +70,7 @@ static int crc_nxp_lpc_prepare_config(const struct crc_ctx *ctx, crc_config_t *c
 		cfg->seed &= 0xFFFFU;
 		break;
 	case CRC16_CCITT:
+	case CRC16_ITU_T:
 		if (ctx->polynomial != CRC16_CCITT_POLY) {
 			return -EINVAL;
 		}

--- a/tests/drivers/crc/src/main.c
+++ b/tests/drivers/crc/src/main.c
@@ -141,6 +141,36 @@ ZTEST(crc, test_crc_16_ccitt)
 }
 
 /* Define result of CRC computation */
+#define RESULT_CRC_16_ITU_T 0x8866
+
+/**
+ * @brief Test that crc_16_itu_t works
+ */
+ZTEST(crc, test_crc_16_itu_t)
+{
+#ifndef CONFIG_CRC_DRIVER_HAS_CRC16_ITU_T
+	ztest_test_skip();
+#endif
+
+	static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_crc));
+
+	uint8_t data[8] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4};
+
+	struct crc_ctx ctx = {
+		.type = CRC16_ITU_T,
+		.polynomial = CRC16_CCITT_POLY,
+		.seed = CRC16_ITU_T_INIT_VAL,
+		.reversed = 0,
+	};
+
+	zassert_equal(crc_begin(dev, &ctx), 0);
+	zassert_equal(crc_update(dev, &ctx, data, sizeof(data)), 0);
+	zassert_equal(crc_finish(dev, &ctx), 0);
+
+	zassert_equal(crc_verify(&ctx, RESULT_CRC_16_ITU_T), 0);
+}
+
+/* Define result of CRC computation */
 #define RESULT_CRC_32_C 0xBB19ECB2
 
 /**


### PR DESCRIPTION
- Add a test for the CRC16-ITU-T algorithm through the CRC driver API.
- For NXP CRC drivers handle CRC16_ITU_T configuration together with CRC16_CCITT, as they share the same polynomial and differ only in input/output reflection. 

