### PR TITLE
drivers: gpio: renesas_rza2m: fix register base

### DIFF
--- a/drivers/gpio/gpio_renesas_rza2m.c
+++ b/drivers/gpio/gpio_renesas_rza2m.c
@@ -12,6 +12,9 @@
 #include <zephyr/logging/log.h>
 #include "gpio_renesas_rza2m.h"
 
+#define DEV_CFG(dev)  ((const struct gpio_rza2m_tint_config *const)(dev)->config)
+#define DEV_DATA(dev) ((struct gpio_rza2m_tint_data *)(dev)->data)
+
 LOG_MODULE_REGISTER(rza2m_gpio, CONFIG_GPIO_LOG_LEVEL);
 
 /* clang-format off */
@@ -477,7 +480,7 @@ static int gpio_rza2m_int_init(const struct device *dev)
 {
 	const struct gpio_rza2m_tint_config *config = dev->config;
 
-	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+	DEVICE_MMIO_NAMED_MAP(dev, mmio, K_MEM_CACHE_NONE);
 	config->gpio_int_init();
 
 	return 0;
@@ -516,7 +519,7 @@ static int gpio_rza2m_port_init(const struct device *port_dev)
 	GPIO_RZA2M_DECLARE_ALL_IRQS(node_id)                                                       \
 	GPIO_RZA2M_TINT_CONNECT_FUNC(node_id)                                                      \
 	static const struct gpio_rza2m_tint_config gpio_rza2m_tint_cfg_##node_id = {               \
-		DEVICE_MMIO_ROM_INIT(DT_PARENT(DT_INST(0, renesas_rza2m_gpio_int))),               \
+		DEVICE_MMIO_NAMED_ROM_INIT(mmio, DT_PARENT(DT_INST(0, renesas_rza2m_gpio_int))),   \
 		.gpio_int_init = gpio_rza2m_tint_connect_func##node_id,                            \
 	};                                                                                         \
 	static struct gpio_rza2m_tint_data gpio_rza2m_tint_data_##node_id;                         \

--- a/drivers/gpio/gpio_renesas_rza2m.h
+++ b/drivers/gpio/gpio_renesas_rza2m.h
@@ -17,13 +17,15 @@
 #define RZA2M_PFS_OFFSET  0x0200
 #define RZA2M_PWPR_OFFSET 0x02FF
 
-#define RZA2M_PDR(dev, port)      (DEVICE_MMIO_GET(dev) + RZA2M_PDR_OFFSET + ((port) * 2))
-#define RZA2M_PODR(dev, port)     (DEVICE_MMIO_GET(dev) + RZA2M_PODR_OFFSET + (port))
-#define RZA2M_PIDR(dev, port)     (DEVICE_MMIO_GET(dev) + RZA2M_PIDR_OFFSET + (port))
-#define RZA2M_PMR(dev, port)      (DEVICE_MMIO_GET(dev) + RZA2M_PMR_OFFSET + (port))
-#define RZA2M_DSCR(dev, port)     (DEVICE_MMIO_GET(dev) + RZA2M_DSCR_OFFSET + ((port) * 2))
-#define RZA2M_PFS(dev, port, pin) (DEVICE_MMIO_GET(dev) + RZA2M_PFS_OFFSET + ((port) * 8) + (pin))
-#define RZA2M_PWPR(dev)           (DEVICE_MMIO_GET(dev) + RZA2M_PWPR_OFFSET)
+#define RZA2M_REGS(dev, offset) (DEVICE_MMIO_NAMED_GET(dev, mmio) + (offset))
+
+#define RZA2M_PDR(dev, port)      (RZA2M_REGS(dev, RZA2M_PDR_OFFSET) + ((port) * 2))
+#define RZA2M_PODR(dev, port)     (RZA2M_REGS(dev, RZA2M_PODR_OFFSET) + (port))
+#define RZA2M_PIDR(dev, port)     (RZA2M_REGS(dev, RZA2M_PIDR_OFFSET) + (port))
+#define RZA2M_PMR(dev, port)      (RZA2M_REGS(dev, RZA2M_PMR_OFFSET) + (port))
+#define RZA2M_DSCR(dev, port)     (RZA2M_REGS(dev, RZA2M_DSCR_OFFSET) + ((port) * 2))
+#define RZA2M_PFS(dev, port, pin) (RZA2M_REGS(dev, RZA2M_PFS_OFFSET) + ((port) * 8) + (pin))
+#define RZA2M_PWPR(dev)           (RZA2M_REGS(dev, RZA2M_PWPR_OFFSET))
 
 #define RZA2M_GICD_ICFGR31               0xE8221C7C
 #define RZA2M_GICD_ICFGR30               0xE8221C78
@@ -101,12 +103,16 @@
 #define UNUSED_MASK 0x00
 
 struct gpio_rza2m_tint_config {
-	DEVICE_MMIO_ROM;
+	struct gpio_driver_config common;
+
+	DEVICE_MMIO_NAMED_ROM(mmio);
 	void (*gpio_int_init)(void);
 };
 
 struct gpio_rza2m_tint_data {
-	DEVICE_MMIO_RAM;
+	struct gpio_driver_data common;
+
+	DEVICE_MMIO_NAMED_RAM(mmio);
 };
 
 typedef struct gpio_rza2m_high_allowed_pin {


### PR DESCRIPTION
The current driver uses standard MMIO macros which assumes MMIO data is at the absolute top of the
struct.

This commit extends the changes made in PR #108244 to the renesas_rza2m gpio driver by switching to
named MMIO variants for both RAM and ROM initializations.