### PR TITLE
arch: x86: core: fix usage of cache line size API

### DIFF
--- a/arch/x86/core/cache.c
+++ b/arch/x86/core/cache.c
@@ -87,7 +87,7 @@ int arch_dcache_flush_and_invd_all(void)
  */
 int arch_dcache_flush_range(void *start_addr, size_t size)
 {
-	size_t line_size = sys_cache_data_line_size_get();
+	size_t line_size = CONFIG_DCACHE_LINE_SIZE;
 	uintptr_t start = (uintptr_t)start_addr;
 	uintptr_t end = start + size;
 


### PR DESCRIPTION
A component should not rely on the API it is implementing. In this case, the arch layer is implementing the arch cache API (include/zephyr/arch/cache.h), that is used by the public sys cache API (include/zephyr/cache.h), so it can't call the latter. Furthermore, it does not implement arch_cache_data_line_size_get(), so sys_cache_data_line_size_get() will always give the value of CONFIG_DCACHE_LINE_SIZE.