### PR TITLE
arch: arm: cortex_m: guard CONFIG_USE_SWITCH for stack buffer

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -486,9 +486,11 @@ uint32_t z_check_thread_stack_fail(const uint32_t fault_addr, const uint32_t psp
 {
 	uint32_t sp = min_stack(fault_addr, psp);
 
-	if (sp != 0 && IS_ENABLED(CONFIG_USE_SWITCH)) {
+#if defined(CONFIG_USE_SWITCH)
+	if (sp != 0) {
 		sp += arm_m_switch_stack_buffer;
 	}
+#endif
 	return sp;
 }
 


### PR DESCRIPTION
arm_m_switch_stack_buffer is only defined when CONFIG_USE_SWITCH is
enabled. With link-time optimization or certain no-optimization builds
using Clang, the symbol is referenced unconditionally and the linker
fails with:

  ld.lld: error: undefined symbol: arm_m_switch_stack_buffer

Move the reference inside a preprocessor guard so that the symbol is
only accessed when the kernel is built with CONFIG_USE_SWITCH.

Assisted-by: GitHub Copilot:claude-sonnet-4.6
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
