### PR TITLE
drivers: flash: stm32_qspi: fix Read JEDEC ID phantom address phase

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -408,7 +408,7 @@ static int qspi_read_jedec_id(const struct device *dev, uint8_t *id)
 		.AddressSize = QSPI_ADDRESS_NONE,
 		.DummyCycles = dummy_cycles,
 		.InstructionMode = QSPI_INSTRUCTION_1_LINE,
-		.AddressMode = QSPI_ADDRESS_1_LINE,
+		.AddressMode = QSPI_ADDRESS_NONE,
 		.DataMode = QSPI_DATA_1_LINE,
 		.NbData = JESD216_READ_ID_LEN,
 	};


### PR DESCRIPTION
`qspi_read_jedec_id()` builds the JEDEC Read ID (`0x9F`) command with
`.AddressMode = QSPI_ADDRESS_1_LINE`, while intending to send no address
(`.AddressSize` is set to `QSPI_ADDRESS_NONE`, which is the AddressMode "none"
constant and, used as a size, equals `QSPI_ADDRESS_8_BITS`).

The STM32 HAL emits an address phase whenever
`AddressMode != QSPI_ADDRESS_NONE`, so the controller clocks a phantom 8-bit
address after the opcode. This shifts the returned data by one byte and drops
the manufacturer ID — e.g. a Winbond W25Q256JV returns `40 19 00` instead of
`ef 40 19`.

Fix: set `.AddressMode = QSPI_ADDRESS_NONE` so the Read ID command has no
address phase, as the `0x9F` command requires.

This path is only reachable with `CONFIG_FLASH_JESD216_API=y`; SFDP-based
init is unaffected, which is why probing/read/write work and only the reported
JEDEC ID was wrong.


## Fixes

Fixes #111184   <!-- replace with the issue number after filing BUG-REPORT.md -->

## Testing

Tested on STM32H743 + Winbond W25Q256JVFIQ on QUADSPI:

- Before: `flash_read_jedec_id()` -> `40 19 00`
- After:  `flash_read_jedec_id()` -> `ef 40 19`
