### PR TITLE
drivers: timer: simplify intel_adsp_timer

### DIFF
--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -135,20 +135,12 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 #ifdef CONFIG_TICKLESS_KERNEL
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 0, (int32_t)MAX_TICKS);
 
 	uint64_t curr = count();
 	uint64_t next;
-	uint32_t adj, cyc = ticks * CYC_PER_TICK;
+	uint32_t cyc = ticks * CYC_PER_TICK;
 
-	/* Round up to next tick boundary */
-	adj = (uint32_t)(curr - last_count) + (CYC_PER_TICK - 1);
-	if (cyc <= MAX_CYC - adj) {
-		cyc += adj;
-	} else {
-		cyc = MAX_CYC;
-	}
-	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
 	next = last_count + cyc;
 
 	if (((uint32_t)next - (uint32_t)curr) < MIN_DELAY) {


### PR DESCRIPTION
Simplifies the sys_clock_set_timeout() calculation used to determine the next correct cycle at which to trigger the timer interrupt. There is no risk that number of cycles we are adding will exceed MAX_CYCLES.

--

Furthermore, should the current cycle count match the 'last_count', it prevents the timer from firing one tick too early. That firing would not lead to miscount of ticks, nor mis-execution of handlers. However it could lead to one extra timer interrupt being processed unnecessarily.