### PR TITLE
modules: lvgl: register vsync event and flush-wait callback

### DIFF
--- a/modules/lvgl/include/lvgl_display.h
+++ b/modules/lvgl/include/lvgl_display.h
@@ -8,6 +8,7 @@
 #ifndef ZEPHYR_MODULES_LVGL_DISPLAY_H_
 #define ZEPHYR_MODULES_LVGL_DISPLAY_H_
 
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/display.h>
 #include <lvgl.h>
 
@@ -18,10 +19,10 @@ extern "C" {
 struct lvgl_disp_data {
 	const struct device *display_dev;
 	struct display_capabilities cap;
-	bool blanking_on;
-#ifdef CONFIG_LV_Z_FLUSH_THREAD
 	struct k_sem flush_complete;
-#endif
+	uint32_t vsync_event_handle;
+	bool vsync_event_registered;
+	bool blanking_on;
 };
 
 struct lvgl_display_flush {
@@ -38,6 +39,7 @@ void lvgl_flush_cb_16bit(lv_display_t *display, const lv_area_t *area, uint8_t *
 void lvgl_flush_cb_24bit(lv_display_t *display, const lv_area_t *area, uint8_t *px_map);
 void lvgl_flush_cb_32bit(lv_display_t *display, const lv_area_t *area, uint8_t *px_map);
 
+void lvgl_wait_cb(lv_display_t *display);
 void lvgl_rounder_cb_mono(lv_event_t *e);
 void lvgl_set_mono_conversion_buffer(uint8_t *buffer, uint32_t buffer_size);
 

--- a/modules/lvgl/include/lvgl_display.h
+++ b/modules/lvgl/include/lvgl_display.h
@@ -19,6 +19,9 @@ struct lvgl_disp_data {
 	const struct device *display_dev;
 	struct display_capabilities cap;
 	bool blanking_on;
+#ifdef CONFIG_LV_Z_FLUSH_THREAD
+	struct k_sem flush_complete;
+#endif
 };
 
 struct lvgl_display_flush {

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -79,9 +79,9 @@ static uint8_t *mono_vtile_buf_p[DT_ZEPHYR_DISPLAYS_COUNT] = {NULL};
 /* prevent unaligned memory accesses. */
 
 #if defined(CONFIG_LV_Z_VDB_CUSTOM_SECTION)
-#define LV_BUF_SECTION	Z_GENERIC_SECTION(.lvgl_buf)
+#define LV_BUF_SECTION Z_GENERIC_SECTION(.lvgl_buf)
 #elif defined(CONFIG_LV_Z_VDB_ZEPHYR_REGION)
-#define LV_BUF_SECTION	Z_GENERIC_SECTION(CONFIG_LV_Z_VDB_ZEPHYR_REGION_NAME)
+#define LV_BUF_SECTION Z_GENERIC_SECTION(CONFIG_LV_Z_VDB_ZEPHYR_REGION_NAME)
 #else
 #define LV_BUF_SECTION
 #endif
@@ -308,6 +308,16 @@ lv_result_t lv_mem_test_core(void)
 	return LV_RESULT_OK;
 }
 
+static enum display_event_result display_vsync_event(const struct device *dev, uint32_t evt,
+						     const struct display_event_data *data,
+						     void *user_data)
+{
+	struct lvgl_disp_data *p_disp_data = user_data;
+
+	k_sem_give(&p_disp_data->flush_complete);
+	return DISPLAY_EVENT_RESULT_CONTINUE;
+}
+
 #define ENUMERATE_DISPLAY_DEVS(n) display_dev[n] = DEVICE_DT_GET(DISPLAY_NODE(n));
 
 int lvgl_init(void)
@@ -360,6 +370,29 @@ int lvgl_init(void)
 			LOG_ERR("Display %d not supported.", i);
 			return -ENOTSUP;
 		}
+
+		p_disp_data->vsync_event_registered =
+			display_register_event_cb(display_dev[i], display_vsync_event, p_disp_data,
+						  DISPLAY_EVENT_VSYNC, true,
+						  &p_disp_data->vsync_event_handle) == 0;
+
+#ifdef CONFIG_LV_Z_FLUSH_THREAD
+		/* with a flush thread, we always set a flush wait callback
+		 * to avoid having LVGL spin and take CPU time waiting for the
+		 * flush to be over
+		 */
+		k_sem_init(&p_disp_data->flush_complete, 0, 1);
+		lv_display_set_flush_wait_cb(lv_displays[i], lvgl_wait_cb);
+#else
+		/* without a flush thread, we only need to set a flush wait callback
+		 * if we successfully registered a vsync event
+		 * else we just assume that `display_write` handles it for us
+		 */
+		if (p_disp_data->vsync_event_registered) {
+			k_sem_init(&p_disp_data->flush_complete, 0, 1);
+			lv_display_set_flush_wait_cb(lv_displays[i], lvgl_wait_cb);
+		}
+#endif
 
 #ifdef CONFIG_LV_Z_BUFFER_ALLOC_STATIC
 		lvgl_allocate_rendering_buffers_static(lv_displays[i], i);

--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -19,14 +19,18 @@ void lvgl_flush_thread_entry(void *arg1, void *arg2, void *arg3)
 {
 	struct lvgl_display_flush flush;
 	struct lvgl_disp_data *data;
+	bool is_last;
 
 	while (1) {
 		k_msgq_get(&flush_queue, &flush, K_FOREVER);
 		data = (struct lvgl_disp_data *)lv_display_get_user_data(flush.display);
 
-		flush.desc.frame_incomplete = !lv_display_flush_is_last(flush.display);
+		is_last = lv_display_flush_is_last(flush.display);
+		flush.desc.frame_incomplete = !is_last;
 		display_write(data->display_dev, flush.x, flush.y, &flush.desc, flush.buf);
-
+		if (is_last && data->vsync_event_registered) {
+			continue;
+		}
 		k_sem_give(&data->flush_complete);
 	}
 }
@@ -34,13 +38,14 @@ void lvgl_flush_thread_entry(void *arg1, void *arg2, void *arg3)
 K_THREAD_DEFINE(lvgl_flush_thread, CONFIG_LV_Z_FLUSH_THREAD_STACK_SIZE, lvgl_flush_thread_entry,
 		NULL, NULL, NULL, CONFIG_LV_Z_FLUSH_THREAD_PRIORITY, 0, 0);
 
-static void lvgl_wait_cb(lv_display_t *display)
+#endif /* CONFIG_LV_Z_FLUSH_THREAD */
+
+void lvgl_wait_cb(lv_display_t *display)
 {
 	struct lvgl_disp_data *data = (struct lvgl_disp_data *)lv_display_get_user_data(display);
+
 	k_sem_take(&data->flush_complete, K_FOREVER);
 }
-
-#endif /* CONFIG_LV_Z_FLUSH_THREAD */
 
 #ifdef CONFIG_LV_Z_USE_ROUNDER_CB
 void lvgl_rounder_cb(lv_event_t *e)
@@ -67,11 +72,6 @@ int set_lvgl_rendering_cb(lv_display_t *display)
 {
 	int err = 0;
 	struct lvgl_disp_data *data = (struct lvgl_disp_data *)lv_display_get_user_data(display);
-
-#ifdef CONFIG_LV_Z_FLUSH_THREAD
-	k_sem_init(&data->flush_complete, 0, 1);
-	lv_display_set_flush_wait_cb(display, lvgl_wait_cb);
-#endif
 
 	switch (data->cap.current_pixel_format) {
 	case PIXEL_FORMAT_ARGB_8888:
@@ -138,8 +138,15 @@ void lvgl_flush_display(struct lvgl_display_flush *request)
 	k_yield();
 #else
 	/* Write directly to the display */
-	request->desc.frame_incomplete = !lv_display_flush_is_last(request->display);
+	bool is_last = lv_display_flush_is_last(request->display);
+
+	request->desc.frame_incomplete = !is_last;
 	display_write(data->display_dev, request->x, request->y, &request->desc, request->buf);
+	if (is_last && data->vsync_event_registered) {
+		/* wait for vsync event to unlock lvgl*/
+		k_sem_reset(&data->flush_complete);
+		return;
+	}
 	lv_display_flush_ready(request->display);
 #endif
 }

--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -12,11 +12,8 @@
 
 #ifdef CONFIG_LV_Z_FLUSH_THREAD
 
-K_SEM_DEFINE(flush_complete, 0, 1);
-/* Needed because the wait callback might be called even if not flush is pending */
-K_SEM_DEFINE(flush_required, 0, 1);
-/* Message queue will only ever need to queue one message */
-K_MSGQ_DEFINE(flush_queue, sizeof(struct lvgl_display_flush), 1, 1);
+/* There can be up to DISPLAY_COUNT flush events at the same time*/
+K_MSGQ_DEFINE(flush_queue, sizeof(struct lvgl_display_flush), DT_ZEPHYR_DISPLAYS_COUNT, 1);
 
 void lvgl_flush_thread_entry(void *arg1, void *arg2, void *arg3)
 {
@@ -30,18 +27,17 @@ void lvgl_flush_thread_entry(void *arg1, void *arg2, void *arg3)
 		flush.desc.frame_incomplete = !lv_display_flush_is_last(flush.display);
 		display_write(data->display_dev, flush.x, flush.y, &flush.desc, flush.buf);
 
-		k_sem_give(&flush_complete);
+		k_sem_give(&data->flush_complete);
 	}
 }
 
 K_THREAD_DEFINE(lvgl_flush_thread, CONFIG_LV_Z_FLUSH_THREAD_STACK_SIZE, lvgl_flush_thread_entry,
 		NULL, NULL, NULL, CONFIG_LV_Z_FLUSH_THREAD_PRIORITY, 0, 0);
 
-void lvgl_wait_cb(lv_display_t *display)
+static void lvgl_wait_cb(lv_display_t *display)
 {
-	if (k_sem_take(&flush_required, K_NO_WAIT) == 0) {
-		k_sem_take(&flush_complete, K_FOREVER);
-	}
+	struct lvgl_disp_data *data = (struct lvgl_disp_data *)lv_display_get_user_data(display);
+	k_sem_take(&data->flush_complete, K_FOREVER);
 }
 
 #endif /* CONFIG_LV_Z_FLUSH_THREAD */
@@ -73,6 +69,7 @@ int set_lvgl_rendering_cb(lv_display_t *display)
 	struct lvgl_disp_data *data = (struct lvgl_disp_data *)lv_display_get_user_data(display);
 
 #ifdef CONFIG_LV_Z_FLUSH_THREAD
+	k_sem_init(&data->flush_complete, 0, 1);
 	lv_display_set_flush_wait_cb(display, lvgl_wait_cb);
 #endif
 
@@ -128,21 +125,19 @@ int set_lvgl_rendering_cb(lv_display_t *display)
 
 void lvgl_flush_display(struct lvgl_display_flush *request)
 {
+	struct lvgl_disp_data *data =
+		(struct lvgl_disp_data *)lv_display_get_user_data(request->display);
 #ifdef CONFIG_LV_Z_FLUSH_THREAD
 	/*
 	 * LVGL will only start a flush once the previous one is complete,
 	 * so we can reset the flush state semaphore here.
 	 */
-	k_sem_reset(&flush_complete);
+	k_sem_reset(&data->flush_complete);
 	k_msgq_put(&flush_queue, request, K_FOREVER);
-	k_sem_give(&flush_required);
 	/* Explicitly yield, in case the calling thread is a cooperative one */
 	k_yield();
 #else
 	/* Write directly to the display */
-	struct lvgl_disp_data *data =
-		(struct lvgl_disp_data *)lv_display_get_user_data(request->display);
-
 	request->desc.frame_incomplete = !lv_display_flush_is_last(request->display);
 	display_write(data->display_dev, request->x, request->y, &request->desc, request->buf);
 	lv_display_flush_ready(request->display);


### PR DESCRIPTION
This PR fixes an issue when LV_Z_FLUSH_THREAD is enabled with multiple displays and takes advantage of the display API vsync events to drive lvgl's flush wait callback

So the core problem right now is that `display_write` can block. In the case of the `renesas_ra` display driver, it can block for up to 30ms as it waits for a vsync event. This means that while we wait, LVGL can't process other events like input or other custom timers that don't require rendering

So the approach here is to check if the display driver supports vsync events, if it does, we register and use it to signal LVGL that the flush is completed, while the flushing happens, LVGL's thread can continue running and process other events

I tested this on top of #111178 which implements vsync events on the `renesas_ra` display driver