### PR TITLE
drivers: sensor: bmp581: add emulator and test suite

### DIFF
--- a/drivers/sensor/bosch/bmp581/CMakeLists.txt
+++ b/drivers/sensor/bosch/bmp581/CMakeLists.txt
@@ -17,3 +17,6 @@ zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API
 zephyr_library_sources_ifdef(CONFIG_BMP581_STREAM
   bmp581_stream.c
 )
+
+zephyr_library_sources_ifdef(CONFIG_EMUL_BMP581 bmp581_emul.c)
+zephyr_include_directories_ifdef(CONFIG_EMUL_BMP581 .)

--- a/drivers/sensor/bosch/bmp581/Kconfig
+++ b/drivers/sensor/bosch/bmp581/Kconfig
@@ -23,3 +23,12 @@ config BMP581_STREAM
 	depends on SENSOR_ASYNC_API
 	depends on GPIO
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMP581),int-gpios)
+
+config EMUL_BMP581
+	bool "Emulator for the BMP581 barometric pressure sensor"
+	default y
+	depends on BMP581
+	depends on EMUL
+	help
+	  Enable the hardware emulator for the BMP581. Doing so allows exercising
+	  the driver against an emulated bus without real hardware.

--- a/drivers/sensor/bosch/bmp581/bmp581_emul.c
+++ b/drivers/sensor/bosch/bmp581/bmp581_emul.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT bosch_bmp581
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i2c_emul.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/spi_emul.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+#include "bmp581.h"
+#include "bmp581_emul.h"
+
+LOG_MODULE_DECLARE(bmp581, CONFIG_SENSOR_LOG_LEVEL);
+
+/* Size of the emulated register file (highest register is CMD at 0x7E). */
+#define BMP581_EMUL_NUM_REGS 0x80
+
+struct bmp581_emul_data {
+	uint8_t reg[BMP581_EMUL_NUM_REGS];
+};
+
+static void bmp581_emul_reset(const struct emul *target)
+{
+	struct bmp581_emul_data *data = target->data;
+
+	memset(data->reg, 0, sizeof(data->reg));
+	data->reg[BMP5_REG_CHIP_ID] = BMP5_CHIP_ID_PRIM;
+	/* NVM ready, no NVM error. */
+	data->reg[BMP5_REG_STATUS] = BMP5_INT_NVM_RDY;
+}
+
+static void bmp581_emul_set_reg24(struct bmp581_emul_data *data, uint8_t reg, uint32_t val)
+{
+	data->reg[reg] = (uint8_t)(val & 0xFF);
+	data->reg[reg + 1] = (uint8_t)((val >> 8) & 0xFF);
+	data->reg[reg + 2] = (uint8_t)((val >> 16) & 0xFF);
+}
+
+void bmp581_emul_set_temp_raw(const struct emul *target, int32_t raw_temp)
+{
+	bmp581_emul_set_reg24(target->data, BMP5_REG_TEMP_DATA_XLSB, (uint32_t)raw_temp);
+}
+
+void bmp581_emul_set_press_raw(const struct emul *target, uint32_t raw_press)
+{
+	bmp581_emul_set_reg24(target->data, BMP5_REG_PRESS_DATA_XLSB, raw_press);
+}
+
+static int bmp581_emul_handle_write(const struct emul *target, uint8_t reg, uint8_t val)
+{
+	struct bmp581_emul_data *data = target->data;
+
+	if (reg >= BMP581_EMUL_NUM_REGS) {
+		return -EINVAL;
+	}
+
+	switch (reg) {
+	case BMP5_REG_CMD:
+		if (val == BMP5_SOFT_RESET_CMD) {
+			bmp581_emul_reset(target);
+			/* Signal soft-reset / power-on completion. */
+			data->reg[BMP5_REG_INT_STATUS] = BMP5_INT_ASSERTED_POR_SOFTRESET_COMPLETE;
+		}
+		break;
+	default:
+		data->reg[reg] = val;
+		break;
+	}
+
+	return 0;
+}
+
+static int bmp581_emul_transfer_i2c(const struct emul *target, struct i2c_msg *msgs, int num_msgs,
+				    int addr)
+{
+	struct bmp581_emul_data *data = target->data;
+
+	i2c_dump_msgs_rw(target->dev, msgs, num_msgs, addr, false);
+
+	if (num_msgs < 1) {
+		LOG_ERR("Invalid number of messages: %d", num_msgs);
+		return -EIO;
+	}
+	if ((msgs[0].flags & I2C_MSG_READ) || msgs[0].len < 1) {
+		LOG_ERR("Unexpected first message");
+		return -EIO;
+	}
+
+	/*
+	 * msgs[0] is always a write carrying the register address (the BMP581 bus
+	 * may also split the written data into a separate follow-up write message).
+	 * Subsequent messages are either the write payload or a read.
+	 */
+	uint8_t reg = msgs[0].buf[0];
+	uint8_t write_off = 0;
+	int ret;
+
+	for (uint32_t i = 1; i < msgs[0].len; i++) {
+		ret = bmp581_emul_handle_write(target, reg + write_off++, msgs[0].buf[i]);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	for (int m = 1; m < num_msgs; m++) {
+		struct i2c_msg *msg = &msgs[m];
+
+		if (msg->flags & I2C_MSG_READ) {
+			for (uint32_t i = 0; i < msg->len; i++) {
+				uint8_t a = reg + i;
+
+				msg->buf[i] = (a < BMP581_EMUL_NUM_REGS) ? data->reg[a] : 0;
+			}
+		} else {
+			for (uint32_t i = 0; i < msg->len; i++) {
+				ret = bmp581_emul_handle_write(target, reg + write_off++,
+							       msg->buf[i]);
+				if (ret < 0) {
+					return ret;
+				}
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int bmp581_emul_init(const struct emul *target, const struct device *parent)
+{
+	ARG_UNUSED(parent);
+
+	bmp581_emul_reset(target);
+
+	return 0;
+}
+
+static int bmp581_emul_io_spi(const struct emul *target, const struct spi_config *config,
+			      const struct spi_buf_set *tx_bufs, const struct spi_buf_set *rx_bufs)
+{
+	struct bmp581_emul_data *data = target->data;
+	const struct spi_buf *tx, *txd, *rxd;
+	uint8_t regn;
+	int count;
+
+	ARG_UNUSED(config);
+	__ASSERT_NO_MSG(tx_bufs || rx_bufs);
+	__ASSERT_NO_MSG(!tx_bufs || !rx_bufs || tx_bufs->count == rx_bufs->count);
+
+	count = tx_bufs ? tx_bufs->count : rx_bufs->count;
+	if (count != 2) {
+		LOG_ERR("Unexpected SPI buffer count %d", count);
+		return -EIO;
+	}
+
+	/* buffers[0] carries the 1-byte register address, buffers[1] the data. */
+	tx = tx_bufs ? tx_bufs->buffers : NULL;
+	txd = tx_bufs ? &tx_bufs->buffers[1] : NULL;
+	rxd = rx_bufs ? &rx_bufs->buffers[1] : NULL;
+
+	if (tx == NULL || tx->len != 1) {
+		LOG_ERR("Expected a 1-byte register address");
+		return -EIO;
+	}
+
+	regn = *(uint8_t *)tx->buf;
+
+	if (regn & BMP5_SPI_RD_MASK) {
+		/* Read transaction. */
+		if (rxd == NULL) {
+			return -EPERM;
+		}
+		regn &= ~BMP5_SPI_RD_MASK;
+		for (uint32_t i = 0; i < rxd->len; i++) {
+			uint8_t a = regn + i;
+
+			((uint8_t *)rxd->buf)[i] = (a < BMP581_EMUL_NUM_REGS) ? data->reg[a] : 0;
+		}
+	} else {
+		/* Write transaction. */
+		if (txd == NULL) {
+			return -EIO;
+		}
+		for (uint32_t i = 0; i < txd->len; i++) {
+			int ret = bmp581_emul_handle_write(target, regn + i,
+							   ((uint8_t *)txd->buf)[i]);
+
+			if (ret < 0) {
+				return ret;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static const struct i2c_emul_api bmp581_emul_api_i2c = {
+	.transfer = bmp581_emul_transfer_i2c,
+};
+
+static struct spi_emul_api bmp581_emul_api_spi = {
+	.io = bmp581_emul_io_spi,
+};
+
+#define BMP581_EMUL_DEFINE(n, bus_api)                                                             \
+	static struct bmp581_emul_data bmp581_emul_data_##n;                                       \
+	EMUL_DT_INST_DEFINE(n, bmp581_emul_init, &bmp581_emul_data_##n, NULL, &bus_api, NULL)
+
+#define BMP581_EMUL_BUS_API(n)                                                                     \
+	COND_CODE_1(DT_INST_ON_BUS(n, spi), (bmp581_emul_api_spi), (bmp581_emul_api_i2c))
+
+/*
+ * The I2C and SPI transports are emulated. I3C instances also report as being on
+ * the I2C bus (I3C is backward compatible), so they are excluded explicitly.
+ */
+#define BMP581_EMUL(n)                                                                             \
+	COND_CODE_1(DT_INST_ON_BUS(n, i3c), (), (BMP581_EMUL_DEFINE(n, BMP581_EMUL_BUS_API(n))))
+
+DT_INST_FOREACH_STATUS_OKAY(BMP581_EMUL)

--- a/drivers/sensor/bosch/bmp581/bmp581_emul.h
+++ b/drivers/sensor/bosch/bmp581/bmp581_emul.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_BMP581_BMP581_EMUL_H_
+#define ZEPHYR_DRIVERS_SENSOR_BMP581_BMP581_EMUL_H_
+
+#include <zephyr/drivers/emul.h>
+#include <stdint.h>
+
+/**
+ * @brief Set the raw temperature sample registers.
+ *
+ * @param target Pointer to the emulator instance.
+ * @param raw_temp Raw 24-bit temperature value (LSB = 1/65536 degC).
+ */
+void bmp581_emul_set_temp_raw(const struct emul *target, int32_t raw_temp);
+
+/**
+ * @brief Set the raw pressure sample registers.
+ *
+ * @param target Pointer to the emulator instance.
+ * @param raw_press Raw 24-bit pressure value (LSB = 1/64 Pa).
+ */
+void bmp581_emul_set_press_raw(const struct emul *target, uint32_t raw_press);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_BMP581_BMP581_EMUL_H_ */

--- a/tests/drivers/sensor/bmp581/CMakeLists.txt
+++ b/tests/drivers/sensor/bmp581/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Meta Platforms
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(bmp581)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/sensor/bmp581/app.overlay
+++ b/tests/drivers/sensor/bmp581/app.overlay
@@ -1,0 +1,18 @@
+/* Copyright (c) 2026 Meta Platforms
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c0 {
+	bmp581: bmp581@46 {
+		compatible = "bosch,bmp581";
+		reg = <0x46>;
+	};
+};
+
+&spi0 {
+	bmp581_spi: bmp581@0 {
+		compatible = "bosch,bmp581";
+		reg = <0>;
+		spi-max-frequency = <0>;
+	};
+};

--- a/tests/drivers/sensor/bmp581/prj.conf
+++ b/tests/drivers/sensor/bmp581/prj.conf
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Meta Platforms
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+
+CONFIG_SENSOR=y
+CONFIG_EMUL=y
+CONFIG_SPI=y
+CONFIG_SPI_EMUL=y
+
+CONFIG_I2C_LOG_LEVEL_WRN=y
+CONFIG_SENSOR_LOG_LEVEL_WRN=y

--- a/tests/drivers/sensor/bmp581/src/main.c
+++ b/tests/drivers/sensor/bmp581/src/main.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Meta Platforms
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/ztest.h>
+
+#include "bmp581_emul.h"
+
+struct bmp581_fixture {
+	const struct device *i2c_dev;
+	const struct emul *i2c_target;
+	const struct device *spi_dev;
+	const struct emul *spi_target;
+};
+
+static void *bmp581_setup(void)
+{
+	static struct bmp581_fixture fixture = {
+		.i2c_dev = DEVICE_DT_GET(DT_NODELABEL(bmp581)),
+		.i2c_target = EMUL_DT_GET(DT_NODELABEL(bmp581)),
+		.spi_dev = DEVICE_DT_GET(DT_NODELABEL(bmp581_spi)),
+		.spi_target = EMUL_DT_GET(DT_NODELABEL(bmp581_spi)),
+	};
+
+	zassert_not_null(fixture.i2c_dev);
+	zassert_not_null(fixture.i2c_target);
+	zassert_not_null(fixture.spi_dev);
+	zassert_not_null(fixture.spi_target);
+	return &fixture;
+}
+
+static void bmp581_before(void *f)
+{
+	struct bmp581_fixture *fixture = f;
+
+	bmp581_emul_set_temp_raw(fixture->i2c_target, 0);
+	bmp581_emul_set_press_raw(fixture->i2c_target, 0);
+	bmp581_emul_set_temp_raw(fixture->spi_target, 0);
+	bmp581_emul_set_press_raw(fixture->spi_target, 0);
+}
+
+ZTEST_SUITE(bmp581, NULL, bmp581_setup, bmp581_before, NULL, NULL);
+
+static void check_fetch_temp(const struct device *dev, const struct emul *target)
+{
+	/* raw 1638400 -> 1638400 / 65536 = 25.0 degC */
+	const int32_t raw_temp = 1638400;
+	struct sensor_value val;
+
+	bmp581_emul_set_temp_raw(target, raw_temp);
+
+	zassert_ok(sensor_sample_fetch(dev));
+	zassert_ok(sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &val));
+
+	zassert_within(sensor_value_to_double(&val), (double)raw_temp / 65536.0, 0.01,
+		       "temperature mismatch: %d.%06d", val.val1, val.val2);
+}
+
+static void check_fetch_press(const struct device *dev, const struct emul *target)
+{
+	/* raw 6400000 -> (6400000 >> 6) / 1000 = 100.0 kPa */
+	const uint32_t raw_press = 6400000;
+	struct sensor_value val;
+
+	bmp581_emul_set_press_raw(target, raw_press);
+
+	zassert_ok(sensor_sample_fetch(dev));
+	zassert_ok(sensor_channel_get(dev, SENSOR_CHAN_PRESS, &val));
+
+	zassert_within(sensor_value_to_double(&val), (double)(raw_press >> 6) / 1000.0, 0.01,
+		       "pressure mismatch: %d.%06d", val.val1, val.val2);
+}
+
+/* The drivers must have initialised against the emulated chips (soft-reset, chip-id, NVM). */
+ZTEST_F(bmp581, test_i2c_device_ready)
+{
+	zassert_true(device_is_ready(fixture->i2c_dev), "BMP581 (I2C) device not ready");
+}
+
+ZTEST_F(bmp581, test_i2c_fetch_temp)
+{
+	check_fetch_temp(fixture->i2c_dev, fixture->i2c_target);
+}
+
+ZTEST_F(bmp581, test_i2c_fetch_press)
+{
+	check_fetch_press(fixture->i2c_dev, fixture->i2c_target);
+}
+
+ZTEST_F(bmp581, test_i2c_attr_set_sampling_frequency)
+{
+	struct sensor_value odr = {.val1 = 50, .val2 = 0};
+
+	zassert_ok(sensor_attr_set(fixture->i2c_dev, SENSOR_CHAN_ALL,
+				   SENSOR_ATTR_SAMPLING_FREQUENCY, &odr));
+}
+
+ZTEST_F(bmp581, test_spi_device_ready)
+{
+	zassert_true(device_is_ready(fixture->spi_dev), "BMP581 (SPI) device not ready");
+}
+
+ZTEST_F(bmp581, test_spi_fetch_temp)
+{
+	check_fetch_temp(fixture->spi_dev, fixture->spi_target);
+}
+
+ZTEST_F(bmp581, test_spi_fetch_press)
+{
+	check_fetch_press(fixture->spi_dev, fixture->spi_target);
+}

--- a/tests/drivers/sensor/bmp581/testcase.yaml
+++ b/tests/drivers/sensor/bmp581/testcase.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Meta Platforms
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.sensor.bmp581:
+    tags:
+      - drivers
+      - sensor
+    platform_allow:
+      - native_sim
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
## Summary

Adds an emulator and test suite for the Bosch BMP581 barometric pressure sensor, so the driver can be exercised on `native_sim` without hardware.

**Emulator**
- Add a BMP581 bus emulator (`CONFIG_EMUL_BMP581`) modelling the register file, the soft-reset / power-on-complete handshake, the chip-id and NVM-ready status, and the temperature/pressure data registers.
- Emulates both the **I2C** and **SPI** transports, selected per devicetree instance. The I2C path handles the BMP581 bus splitting a register write into separate address and data messages; the SPI path handles the read/write address framing (`BMP5_SPI_RD_MASK`). I3C instances are excluded (as there is no i3c emulator until https://github.com/zephyrproject-rtos/zephyr/pull/108614 is merged) (they also report as being on the I2C bus). Raw temperature/pressure setters are exposed for tests.

**Tests**
- Add `tests/drivers/sensor/bmp581`: a ztest suite covering device init, temperature and pressure fetch/convert, and a sampling-frequency attribute set, run against the emulator on **both an I2C and a SPI** device instance.

