### PR TITLE
usbc: replace tcpci_tcpm_get_status_register

### DIFF
--- a/drivers/usb_c/tcpc/fusb307.c
+++ b/drivers/usb_c/tcpc/fusb307.c
@@ -544,7 +544,7 @@ void fusb307_alert_work_cb(struct k_work *work)
 		return;
 	}
 
-	tcpci_tcpm_get_status_register(&cfg->bus, TCPC_ALERT_STATUS, &alert_reg);
+	tcpci_tcpm_get_alert_status(&cfg->bus, &alert_reg);
 
 	while (alert_reg != 0) {
 		enum tcpc_alert alert_type = tcpci_alert_reg_to_enum(alert_reg);
@@ -556,8 +556,7 @@ void fusb307_alert_work_cb(struct k_work *work)
 		} else if (alert_type == TCPC_ALERT_FAULT_STATUS) {
 			uint8_t fault;
 
-			tcpci_tcpm_get_status_register(&cfg->bus, TCPC_FAULT_STATUS,
-						       (uint16_t *)&fault);
+			tcpci_tcpm_get_fault_status(&cfg->bus, &fault);
 			tcpci_tcpm_clear_status_register(&cfg->bus, TCPC_FAULT_STATUS,
 							 (uint16_t)fault);
 
@@ -565,8 +564,7 @@ void fusb307_alert_work_cb(struct k_work *work)
 		} else if (alert_type == TCPC_ALERT_POWER_STATUS) {
 			uint8_t pwr_status;
 
-			tcpci_tcpm_get_status_register(&cfg->bus, TCPC_POWER_STATUS,
-						       (uint16_t *)&pwr_status);
+			tcpci_tcpm_get_power_status(&cfg->bus, &pwr_status);
 
 			LOG_DBG("power status: %02x", pwr_status);
 		} else if (alert_type == TCPC_ALERT_MSG_STATUS) {
@@ -588,7 +586,7 @@ void fusb307_alert_work_cb(struct k_work *work)
 	}
 
 	tcpci_tcpm_clear_status_register(&cfg->bus, TCPC_ALERT_STATUS, clear_flags);
-	tcpci_tcpm_get_status_register(&cfg->bus, TCPC_ALERT_STATUS, &alert_reg);
+	tcpci_tcpm_get_alert_status(&cfg->bus, &alert_reg);
 
 	/* If alert_reg is not 0 or the interrupt signal is still active */
 	if ((alert_reg != 0) || gpio_pin_get_dt(&cfg->alert_gpio)) {
@@ -609,7 +607,7 @@ void fusb307_init_work_cb(struct k_work *work)
 
 	LOG_INF("Initializing FUSB307 chip: %s", data->dev->name);
 
-	ret = tcpci_tcpm_get_status_register(&cfg->bus, TCPC_POWER_STATUS, (uint16_t *)&power_reg);
+	ret = tcpci_tcpm_get_power_status(&cfg->bus, &power_reg);
 	if (ret != 0 || (power_reg & TCPC_REG_POWER_STATUS_UNINIT)) {
 		data->init_retries++;
 

--- a/drivers/usb_c/tcpc/fusb307.c
+++ b/drivers/usb_c/tcpc/fusb307.c
@@ -373,30 +373,6 @@ static int fusb307_tcpc_dump_std_reg(const struct device *dev)
 	return tcpci_tcpm_dump_std_reg(&cfg->bus);
 }
 
-static int fusb307_tcpc_get_status_register(const struct device *dev, enum tcpc_status_reg reg,
-					   uint32_t *status)
-{
-	const struct fusb307_cfg *cfg = dev->config;
-
-	if (reg == TCPC_VENDOR_DEFINED_STATUS) {
-		return tcpci_read_reg8(&cfg->bus, FUSB307_REG_ALERT_VD, (uint8_t *)status);
-	}
-
-	return tcpci_tcpm_get_status_register(&cfg->bus, reg, (uint16_t *)status);
-}
-
-static int fusb307_tcpc_clear_status_register(const struct device *dev, enum tcpc_status_reg reg,
-					     uint32_t mask)
-{
-	const struct fusb307_cfg *cfg = dev->config;
-
-	if (reg == TCPC_VENDOR_DEFINED_STATUS) {
-		return tcpci_write_reg8(&cfg->bus, FUSB307_REG_ALERT_VD, (uint8_t)mask);
-	}
-
-	return tcpci_tcpm_clear_status_register(&cfg->bus, reg, (uint16_t)mask);
-}
-
 static int fusb307_tcpc_mask_status_register(const struct device *dev, enum tcpc_status_reg reg,
 					    uint32_t mask)
 {
@@ -534,8 +510,6 @@ static DEVICE_API(tcpc, fusb307_driver_api) = {
 	.set_cc_polarity = fusb307_tcpc_set_cc_polarity,
 	.transmit_data = fusb307_tcpc_transmit_data,
 	.dump_std_reg = fusb307_tcpc_dump_std_reg,
-	.get_status_register = fusb307_tcpc_get_status_register,
-	.clear_status_register = fusb307_tcpc_clear_status_register,
 	.mask_status_register = fusb307_tcpc_mask_status_register,
 	.set_debug_accessory = fusb307_tcpc_set_debug_accessory,
 	.set_debug_detach = NULL,

--- a/drivers/usb_c/tcpc/ps8xxx.c
+++ b/drivers/usb_c/tcpc/ps8xxx.c
@@ -332,18 +332,6 @@ int ps8xxx_tcpc_dump_std_reg(const struct device *dev)
 	return tcpci_tcpm_dump_std_reg(&cfg->bus);
 }
 
-int ps8xxx_tcpc_get_status_register(const struct device *dev, enum tcpc_status_reg reg,
-				    uint32_t *status)
-{
-	return -ENOSYS;
-}
-
-int ps8xxx_tcpc_clear_status_register(const struct device *dev, enum tcpc_status_reg reg,
-				      uint32_t mask)
-{
-	return -ENOSYS;
-}
-
 int ps8xxx_tcpc_mask_status_register(const struct device *dev, enum tcpc_status_reg reg,
 				     uint32_t mask)
 {
@@ -465,8 +453,6 @@ static DEVICE_API(tcpc, ps8xxx_driver_api) = {
 	.set_cc_polarity = ps8xxx_tcpc_set_cc_polarity,
 	.transmit_data = ps8xxx_tcpc_transmit_data,
 	.dump_std_reg = ps8xxx_tcpc_dump_std_reg,
-	.get_status_register = ps8xxx_tcpc_get_status_register,
-	.clear_status_register = ps8xxx_tcpc_clear_status_register,
 	.mask_status_register = ps8xxx_tcpc_mask_status_register,
 	.set_debug_accessory = ps8xxx_tcpc_set_debug_accessory,
 	.set_debug_detach = ps8xxx_tcpc_set_debug_detach,

--- a/drivers/usb_c/tcpc/ps8xxx.c
+++ b/drivers/usb_c/tcpc/ps8xxx.c
@@ -487,7 +487,7 @@ void ps8xxx_alert_work_cb(struct k_work *work)
 		return;
 	}
 
-	tcpci_tcpm_get_status_register(&cfg->bus, TCPC_ALERT_STATUS, &alert_reg);
+	tcpci_tcpm_get_alert_status(&cfg->bus, &alert_reg);
 
 	while (alert_reg != 0) {
 		enum tcpc_alert alert_type = tcpci_alert_reg_to_enum(alert_reg);
@@ -499,8 +499,7 @@ void ps8xxx_alert_work_cb(struct k_work *work)
 		} else if (alert_type == TCPC_ALERT_FAULT_STATUS) {
 			uint8_t fault;
 
-			tcpci_tcpm_get_status_register(&cfg->bus, TCPC_FAULT_STATUS,
-						       (uint16_t *)&fault);
+			tcpci_tcpm_get_fault_status(&cfg->bus, &fault);
 			tcpci_tcpm_clear_status_register(&cfg->bus, TCPC_FAULT_STATUS,
 							 (uint16_t)fault);
 
@@ -508,8 +507,7 @@ void ps8xxx_alert_work_cb(struct k_work *work)
 		} else if (alert_type == TCPC_ALERT_EXTENDED_STATUS) {
 			uint8_t ext_status;
 
-			tcpci_tcpm_get_status_register(&cfg->bus, TCPC_EXTENDED_STATUS,
-						       (uint16_t *)&ext_status);
+			tcpci_tcpm_get_extended_status(&cfg->bus, &ext_status);
 			tcpci_tcpm_clear_status_register(&cfg->bus, TCPC_EXTENDED_STATUS,
 							 (uint16_t)ext_status);
 
@@ -518,15 +516,13 @@ void ps8xxx_alert_work_cb(struct k_work *work)
 		} else if (alert_type == TCPC_ALERT_POWER_STATUS) {
 			uint8_t pwr_status;
 
-			tcpci_tcpm_get_status_register(&cfg->bus, TCPC_POWER_STATUS,
-						       (uint16_t *)&pwr_status);
+			tcpci_tcpm_get_power_status(&cfg->bus, &pwr_status);
 
 			LOG_DBG("PS8xxx power status: %02x", pwr_status);
 		} else if (alert_type == TCPC_ALERT_EXTENDED) {
 			uint8_t alert_status;
 
-			tcpci_tcpm_get_status_register(&cfg->bus, TCPC_EXTENDED_ALERT_STATUS,
-						       (uint16_t *)&alert_status);
+			tcpci_tcpm_get_extended_alert_status(&cfg->bus, &alert_status);
 			tcpci_tcpm_clear_status_register(&cfg->bus, TCPC_EXTENDED_ALERT_STATUS,
 							 (uint16_t)alert_status);
 
@@ -546,7 +542,7 @@ void ps8xxx_alert_work_cb(struct k_work *work)
 	}
 
 	tcpci_tcpm_clear_status_register(&cfg->bus, TCPC_ALERT_STATUS, clear_flags);
-	tcpci_tcpm_get_status_register(&cfg->bus, TCPC_ALERT_STATUS, &alert_reg);
+	tcpci_tcpm_get_alert_status(&cfg->bus, &alert_reg);
 
 	if (alert_reg != 0) {
 		k_work_submit(work);
@@ -564,7 +560,7 @@ void ps8xxx_init_work_cb(struct k_work *work)
 	int ret;
 
 	LOG_INF("Initializing PS8xxx chip: %s", data->dev->name);
-	ret = tcpci_tcpm_get_status_register(&cfg->bus, TCPC_POWER_STATUS, (uint16_t *)&power_reg);
+	ret = tcpci_tcpm_get_power_status(&cfg->bus, &power_reg);
 	if (ret != 0 || (power_reg & TCPC_REG_POWER_STATUS_UNINIT)) {
 		data->init_retries++;
 

--- a/drivers/usb_c/tcpc/rt1715.c
+++ b/drivers/usb_c/tcpc/rt1715.c
@@ -379,30 +379,6 @@ static int rt1715_tcpc_dump_std_reg(const struct device *dev)
 	return tcpci_tcpm_dump_std_reg(&cfg->bus);
 }
 
-static int rt1715_tcpc_get_status_register(const struct device *dev, enum tcpc_status_reg reg,
-					   uint32_t *status)
-{
-	const struct rt1715_cfg *cfg = dev->config;
-
-	if (reg == TCPC_VENDOR_DEFINED_STATUS) {
-		return tcpci_read_reg8(&cfg->bus, RT1715_REG_RT_INT, (uint8_t *)status);
-	}
-
-	return tcpci_tcpm_get_status_register(&cfg->bus, reg, (uint16_t *)status);
-}
-
-static int rt1715_tcpc_clear_status_register(const struct device *dev, enum tcpc_status_reg reg,
-					     uint32_t mask)
-{
-	const struct rt1715_cfg *cfg = dev->config;
-
-	if (reg == TCPC_VENDOR_DEFINED_STATUS) {
-		return tcpci_write_reg8(&cfg->bus, RT1715_REG_RT_INT, (uint8_t)mask);
-	}
-
-	return tcpci_tcpm_clear_status_register(&cfg->bus, reg, (uint16_t)mask);
-}
-
 static int rt1715_tcpc_mask_status_register(const struct device *dev, enum tcpc_status_reg reg,
 					    uint32_t mask)
 {
@@ -499,8 +475,6 @@ static DEVICE_API(tcpc, rt1715_driver_api) = {
 	.set_cc_polarity = rt1715_tcpc_set_cc_polarity,
 	.transmit_data = rt1715_tcpc_transmit_data,
 	.dump_std_reg = rt1715_tcpc_dump_std_reg,
-	.get_status_register = rt1715_tcpc_get_status_register,
-	.clear_status_register = rt1715_tcpc_clear_status_register,
 	.mask_status_register = rt1715_tcpc_mask_status_register,
 	.set_drp_toggle = rt1715_tcpc_set_drp_toggle,
 	.get_chip_info = rt1715_tcpc_get_chip_info,

--- a/drivers/usb_c/tcpc/rt1715.c
+++ b/drivers/usb_c/tcpc/rt1715.c
@@ -503,7 +503,7 @@ void rt1715_alert_work_cb(struct k_work *work)
 		return;
 	}
 
-	tcpci_tcpm_get_status_register(&cfg->bus, TCPC_ALERT_STATUS, &alert_reg);
+	tcpci_tcpm_get_alert_status(&cfg->bus, &alert_reg);
 
 	while (alert_reg != 0) {
 		enum tcpc_alert alert_type = tcpci_alert_reg_to_enum(alert_reg);
@@ -515,8 +515,7 @@ void rt1715_alert_work_cb(struct k_work *work)
 		} else if (alert_type == TCPC_ALERT_FAULT_STATUS) {
 			uint8_t fault;
 
-			tcpci_tcpm_get_status_register(&cfg->bus, TCPC_FAULT_STATUS,
-						       (uint16_t *)&fault);
+			tcpci_tcpm_get_fault_status(&cfg->bus, &fault);
 			tcpci_tcpm_clear_status_register(&cfg->bus, TCPC_FAULT_STATUS,
 							 (uint16_t)fault);
 
@@ -524,8 +523,7 @@ void rt1715_alert_work_cb(struct k_work *work)
 		} else if (alert_type == TCPC_ALERT_POWER_STATUS) {
 			uint8_t pwr_status;
 
-			tcpci_tcpm_get_status_register(&cfg->bus, TCPC_POWER_STATUS,
-						       (uint16_t *)&pwr_status);
+			tcpci_tcpm_get_power_status(&cfg->bus, &pwr_status);
 
 			LOG_DBG("power status: %02x", pwr_status);
 		} else if (alert_type == TCPC_ALERT_MSG_STATUS) {
@@ -547,7 +545,7 @@ void rt1715_alert_work_cb(struct k_work *work)
 	}
 
 	tcpci_tcpm_clear_status_register(&cfg->bus, TCPC_ALERT_STATUS, clear_flags);
-	tcpci_tcpm_get_status_register(&cfg->bus, TCPC_ALERT_STATUS, &alert_reg);
+	tcpci_tcpm_get_alert_status(&cfg->bus, &alert_reg);
 
 	/* If alert_reg is not 0 or the interrupt signal is still active */
 	if ((alert_reg != 0) || gpio_pin_get_dt(&cfg->alert_gpio)) {
@@ -568,7 +566,7 @@ void rt1715_init_work_cb(struct k_work *work)
 
 	LOG_INF("Initializing RT1715 chip: %s", data->dev->name);
 
-	ret = tcpci_tcpm_get_status_register(&cfg->bus, TCPC_POWER_STATUS, (uint16_t *)&power_reg);
+	ret = tcpci_tcpm_get_power_status(&cfg->bus, &power_reg);
 	if (ret != 0 || (power_reg & TCPC_REG_POWER_STATUS_UNINIT)) {
 		data->init_retries++;
 

--- a/drivers/usb_c/tcpc/tcpci.c
+++ b/drivers/usb_c/tcpc/tcpci.c
@@ -644,26 +644,34 @@ int tcpci_tcpm_set_cc_polarity(const struct i2c_dt_spec *bus, enum tc_cc_polarit
 		(polarity == TC_POLARITY_CC1) ? 0 : TCPC_REG_TCPC_CTRL_PLUG_ORIENTATION);
 }
 
-int tcpci_tcpm_get_status_register(const struct i2c_dt_spec *bus, enum tcpc_status_reg reg,
-				   uint16_t *status)
+int tcpci_tcpm_get_alert_status(const struct i2c_dt_spec *bus, uint16_t *status)
 {
-	switch (reg) {
-	case TCPC_ALERT_STATUS:
-		return tcpci_read_reg16(bus, TCPC_REG_ALERT, status);
-	case TCPC_CC_STATUS:
-		return tcpci_read_reg8(bus, TCPC_REG_CC_STATUS, (uint8_t *)status);
-	case TCPC_POWER_STATUS:
-		return tcpci_read_reg8(bus, TCPC_REG_POWER_STATUS, (uint8_t *)status);
-	case TCPC_FAULT_STATUS:
-		return tcpci_read_reg8(bus, TCPC_REG_FAULT_STATUS, (uint8_t *)status);
-	case TCPC_EXTENDED_STATUS:
-		return tcpci_read_reg8(bus, TCPC_REG_EXT_STATUS, (uint8_t *)status);
-	case TCPC_EXTENDED_ALERT_STATUS:
-		return tcpci_read_reg8(bus, TCPC_REG_ALERT_EXT, (uint8_t *)status);
-	default:
-		LOG_ERR("Not a TCPCI-specified reg address");
-		return -EINVAL;
-	}
+	return tcpci_read_reg16(bus, TCPC_REG_ALERT, status);
+}
+
+int tcpci_tcpm_get_cc_status(const struct i2c_dt_spec *bus, uint8_t *status)
+{
+	return tcpci_read_reg8(bus, TCPC_REG_CC_STATUS, status);
+}
+
+int tcpci_tcpm_get_power_status(const struct i2c_dt_spec *bus, uint8_t *status)
+{
+	return tcpci_read_reg8(bus, TCPC_REG_POWER_STATUS, status);
+}
+
+int tcpci_tcpm_get_fault_status(const struct i2c_dt_spec *bus, uint8_t *status)
+{
+	return tcpci_read_reg8(bus, TCPC_REG_FAULT_STATUS, status);
+}
+
+int tcpci_tcpm_get_extended_status(const struct i2c_dt_spec *bus, uint8_t *status)
+{
+	return tcpci_read_reg8(bus, TCPC_REG_EXT_STATUS, status);
+}
+
+int tcpci_tcpm_get_extended_alert_status(const struct i2c_dt_spec *bus, uint8_t *status)
+{
+	return tcpci_read_reg8(bus, TCPC_REG_ALERT_EXT, status);
 }
 
 int tcpci_tcpm_clear_status_register(const struct i2c_dt_spec *bus, enum tcpc_status_reg reg,
@@ -727,10 +735,10 @@ int tcpci_tcpm_set_src_ctrl(const struct i2c_dt_spec *bus, bool enable)
 
 int tcpci_tcpm_get_snk_ctrl(const struct i2c_dt_spec *bus, bool *sinking)
 {
-	uint16_t reg;
+	uint8_t reg;
 	int ret;
 
-	ret = tcpci_tcpm_get_status_register(bus, TCPC_REG_POWER_STATUS, &reg);
+	ret = tcpci_tcpm_get_power_status(bus, &reg);
 	if (ret == 0) {
 		*sinking = reg & TCPC_REG_POWER_STATUS_SINKING_VBUS;
 	}
@@ -740,10 +748,10 @@ int tcpci_tcpm_get_snk_ctrl(const struct i2c_dt_spec *bus, bool *sinking)
 
 int tcpci_tcpm_get_src_ctrl(const struct i2c_dt_spec *bus, bool *sourcing)
 {
-	uint16_t reg;
+	uint8_t reg;
 	int ret;
 
-	ret = tcpci_tcpm_get_status_register(bus, TCPC_REG_POWER_STATUS, &reg);
+	ret = tcpci_tcpm_get_power_status(bus, &reg);
 	if (ret == 0) {
 		*sourcing = reg & TCPC_REG_POWER_STATUS_SOURCING_VBUS;
 	}

--- a/include/zephyr/drivers/usb_c/tcpci_priv.h
+++ b/include/zephyr/drivers/usb_c/tcpci_priv.h
@@ -236,15 +236,58 @@ int tcpci_tcpm_set_cc_polarity(const struct i2c_dt_spec *bus, enum tc_cc_polarit
 int tcpci_tcpm_set_vconn(const struct i2c_dt_spec *bus, bool enable);
 
 /**
- * @brief Function to get the status of a specific TCPCI status register.
+ * @brief Function to get the status of the TCPCI alert register.
  *
  * @param bus I2C bus
- * @param reg Enum representing the status register to be read
  * @param status Pointer to the variable where the status will be stored
  * @return int Status of I2C operation, 0 in case of success
  */
-int tcpci_tcpm_get_status_register(const struct i2c_dt_spec *bus, enum tcpc_status_reg reg,
-				   uint16_t *status);
+int tcpci_tcpm_get_alert_status(const struct i2c_dt_spec *bus, uint16_t *status);
+
+/**
+ * @brief Function to get the status of the TCPCI CC status register.
+ *
+ * @param bus I2C bus
+ * @param status Pointer to the variable where the status will be stored
+ * @return int Status of I2C operation, 0 in case of success
+ */
+int tcpci_tcpm_get_cc_status(const struct i2c_dt_spec *bus, uint8_t *status);
+
+/**
+ * @brief Function to get the status of the TCPCI power status register.
+ *
+ * @param bus I2C bus
+ * @param status Pointer to the variable where the status will be stored
+ * @return int Status of I2C operation, 0 in case of success
+ */
+int tcpci_tcpm_get_power_status(const struct i2c_dt_spec *bus, uint8_t *status);
+
+/**
+ * @brief Function to get the status of the TCPCI fault status register.
+ *
+ * @param bus I2C bus
+ * @param status Pointer to the variable where the status will be stored
+ * @return int Status of I2C operation, 0 in case of success
+ */
+int tcpci_tcpm_get_fault_status(const struct i2c_dt_spec *bus, uint8_t *status);
+
+/**
+ * @brief Function to get the status of the TCPCI extended status register.
+ *
+ * @param bus I2C bus
+ * @param status Pointer to the variable where the status will be stored
+ * @return int Status of I2C operation, 0 in case of success
+ */
+int tcpci_tcpm_get_extended_status(const struct i2c_dt_spec *bus, uint8_t *status);
+
+/**
+ * @brief Function to get the status of the TCPCI extended alert status register.
+ *
+ * @param bus I2C bus
+ * @param status Pointer to the variable where the status will be stored
+ * @return int Status of I2C operation, 0 in case of success
+ */
+int tcpci_tcpm_get_extended_alert_status(const struct i2c_dt_spec *bus, uint8_t *status);
 
 /**
  * @brief Function to clear specific bits in a TCPCI status register.

--- a/include/zephyr/drivers/usb_c/tcpci_priv.h
+++ b/include/zephyr/drivers/usb_c/tcpci_priv.h
@@ -237,15 +237,58 @@ int tcpci_tcpm_set_cc_polarity(const struct i2c_dt_spec *bus, enum tc_cc_polarit
 int tcpci_tcpm_set_vconn(const struct i2c_dt_spec *bus, bool enable);
 
 /**
- * @brief Function to get the status of a specific TCPCI status register.
+ * @brief Function to get the status of the TCPCI alert register.
  *
  * @param bus I2C bus
- * @param reg Enum representing the status register to be read
  * @param status Pointer to the variable where the status will be stored
  * @return int Status of I2C operation, 0 in case of success
  */
-int tcpci_tcpm_get_status_register(const struct i2c_dt_spec *bus, enum tcpc_status_reg reg,
-				   uint16_t *status);
+int tcpci_tcpm_get_alert_status(const struct i2c_dt_spec *bus, uint16_t *status);
+
+/**
+ * @brief Function to get the status of the TCPCI CC status register.
+ *
+ * @param bus I2C bus
+ * @param status Pointer to the variable where the status will be stored
+ * @return int Status of I2C operation, 0 in case of success
+ */
+int tcpci_tcpm_get_cc_status(const struct i2c_dt_spec *bus, uint8_t *status);
+
+/**
+ * @brief Function to get the status of the TCPCI power status register.
+ *
+ * @param bus I2C bus
+ * @param status Pointer to the variable where the status will be stored
+ * @return int Status of I2C operation, 0 in case of success
+ */
+int tcpci_tcpm_get_power_status(const struct i2c_dt_spec *bus, uint8_t *status);
+
+/**
+ * @brief Function to get the status of the TCPCI fault status register.
+ *
+ * @param bus I2C bus
+ * @param status Pointer to the variable where the status will be stored
+ * @return int Status of I2C operation, 0 in case of success
+ */
+int tcpci_tcpm_get_fault_status(const struct i2c_dt_spec *bus, uint8_t *status);
+
+/**
+ * @brief Function to get the status of the TCPCI extended status register.
+ *
+ * @param bus I2C bus
+ * @param status Pointer to the variable where the status will be stored
+ * @return int Status of I2C operation, 0 in case of success
+ */
+int tcpci_tcpm_get_extended_status(const struct i2c_dt_spec *bus, uint8_t *status);
+
+/**
+ * @brief Function to get the status of the TCPCI extended alert status register.
+ *
+ * @param bus I2C bus
+ * @param status Pointer to the variable where the status will be stored
+ * @return int Status of I2C operation, 0 in case of success
+ */
+int tcpci_tcpm_get_extended_alert_status(const struct i2c_dt_spec *bus, uint8_t *status);
 
 /**
  * @brief Function to clear specific bits in a TCPCI status register.

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -277,22 +277,6 @@ typedef int (*tcpc_api_transmit_data_t)(const struct device *dev, struct pd_msg 
 typedef int (*tcpc_api_dump_std_reg_t)(const struct device *dev);
 
 /**
- * @brief Callback API to get a status register.
- *
- * See tcpc_get_status_register() for argument description.
- */
-typedef int (*tcpc_api_get_status_register_t)(const struct device *dev, enum tcpc_status_reg reg,
-					      uint32_t *status);
-
-/**
- * @brief Callback API to clear bits in a status register.
- *
- * See tcpc_clear_status_register() for argument description.
- */
-typedef int (*tcpc_api_clear_status_register_t)(const struct device *dev, enum tcpc_status_reg reg,
-						uint32_t mask);
-
-/**
  * @brief Callback API to mask or unmask status register bits.
  *
  * See tcpc_mask_status_register() for argument description.
@@ -419,10 +403,6 @@ __subsystem struct tcpc_driver_api {
 	tcpc_api_transmit_data_t transmit_data;
 	/** @driver_ops_optional @copybrief tcpc_dump_std_reg */
 	tcpc_api_dump_std_reg_t dump_std_reg;
-	/** @driver_ops_optional @copybrief tcpc_get_status_register */
-	tcpc_api_get_status_register_t get_status_register;
-	/** @driver_ops_optional @copybrief tcpc_clear_status_register */
-	tcpc_api_clear_status_register_t clear_status_register;
 	/** @driver_ops_optional @copybrief tcpc_mask_status_register */
 	tcpc_api_mask_status_register_t mask_status_register;
 	/** @driver_ops_optional @copybrief tcpc_set_debug_accessory */
@@ -851,53 +831,6 @@ static inline int tcpc_set_alert_handler_cb(const struct device *dev,
 	__ASSERT(api->set_alert_handler_cb != NULL, "Callback pointer should not be NULL");
 
 	return api->set_alert_handler_cb(dev, handler, data);
-}
-
-/**
- * @brief Gets a status register
- *
- * @param dev     Runtime device structure
- * @param reg     The status register to read
- * @param status  Pointer where the status is stored
- *
- * @retval 0 on success
- * @retval -EIO on failure
- * @retval -ENOSYS if not implemented
- */
-static inline int tcpc_get_status_register(const struct device *dev, enum tcpc_status_reg reg,
-					   uint32_t *status)
-{
-	const struct tcpc_driver_api *api = DEVICE_API_GET(tcpc, dev);
-
-	if (api->get_status_register == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_status_register(dev, reg, status);
-}
-
-/**
- * @brief Clears a TCPC status register
- *
- * @param dev   Runtime device structure
- * @param reg   The status register to read
- * @param mask  A bit mask of the status register to clear.
- *		A status bit is cleared when it's set to 1.
- *
- * @retval 0 on success
- * @retval -EIO on failure
- * @retval -ENOSYS if not implemented
- */
-static inline int tcpc_clear_status_register(const struct device *dev, enum tcpc_status_reg reg,
-					     uint32_t mask)
-{
-	const struct tcpc_driver_api *api = DEVICE_API_GET(tcpc, dev);
-
-	if (api->clear_status_register == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->clear_status_register(dev, reg, mask);
 }
 
 /**

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -278,22 +278,6 @@ typedef int (*tcpc_api_transmit_data_t)(const struct device *dev, struct pd_msg 
 typedef int (*tcpc_api_dump_std_reg_t)(const struct device *dev);
 
 /**
- * @brief Callback API to get a status register.
- *
- * See tcpc_get_status_register() for argument description.
- */
-typedef int (*tcpc_api_get_status_register_t)(const struct device *dev, enum tcpc_status_reg reg,
-					      uint32_t *status);
-
-/**
- * @brief Callback API to clear bits in a status register.
- *
- * See tcpc_clear_status_register() for argument description.
- */
-typedef int (*tcpc_api_clear_status_register_t)(const struct device *dev, enum tcpc_status_reg reg,
-						uint32_t mask);
-
-/**
  * @brief Callback API to mask or unmask status register bits.
  *
  * See tcpc_mask_status_register() for argument description.
@@ -420,10 +404,6 @@ __subsystem struct tcpc_driver_api {
 	tcpc_api_transmit_data_t transmit_data;
 	/** @driver_ops_optional @copybrief tcpc_dump_std_reg */
 	tcpc_api_dump_std_reg_t dump_std_reg;
-	/** @driver_ops_optional @copybrief tcpc_get_status_register */
-	tcpc_api_get_status_register_t get_status_register;
-	/** @driver_ops_optional @copybrief tcpc_clear_status_register */
-	tcpc_api_clear_status_register_t clear_status_register;
 	/** @driver_ops_optional @copybrief tcpc_mask_status_register */
 	tcpc_api_mask_status_register_t mask_status_register;
 	/** @driver_ops_optional @copybrief tcpc_set_debug_accessory */
@@ -852,53 +832,6 @@ static inline int tcpc_set_alert_handler_cb(const struct device *dev,
 	__ASSERT(api->set_alert_handler_cb != NULL, "Callback pointer should not be NULL");
 
 	return api->set_alert_handler_cb(dev, handler, data);
-}
-
-/**
- * @brief Gets a status register
- *
- * @param dev     Runtime device structure
- * @param reg     The status register to read
- * @param status  Pointer where the status is stored
- *
- * @retval 0 on success
- * @retval -EIO on failure
- * @retval -ENOSYS if not implemented
- */
-static inline int tcpc_get_status_register(const struct device *dev, enum tcpc_status_reg reg,
-					   uint32_t *status)
-{
-	const struct tcpc_driver_api *api = DEVICE_API_GET(tcpc, dev);
-
-	if (api->get_status_register == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_status_register(dev, reg, status);
-}
-
-/**
- * @brief Clears a TCPC status register
- *
- * @param dev   Runtime device structure
- * @param reg   The status register to read
- * @param mask  A bit mask of the status register to clear.
- *		A status bit is cleared when it's set to 1.
- *
- * @retval 0 on success
- * @retval -EIO on failure
- * @retval -ENOSYS if not implemented
- */
-static inline int tcpc_clear_status_register(const struct device *dev, enum tcpc_status_reg reg,
-					     uint32_t mask)
-{
-	const struct tcpc_driver_api *api = DEVICE_API_GET(tcpc, dev);
-
-	if (api->clear_status_register == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->clear_status_register(dev, reg, mask);
 }
 
 /**


### PR DESCRIPTION
Replace generic tcpci_tcpm_get_status_register() with type-safe, register specific, helper functions.

This fixes several out of bounds read errors across the various TCPC drivers.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/84719 https://github.com/zephyrproject-rtos/zephyr/issues/84725 https://github.com/zephyrproject-rtos/zephyr/issues/84732 https://github.com/zephyrproject-rtos/zephyr/issues/84736 https://github.com/zephyrproject-rtos/zephyr/issues/84746
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/84747 https://github.com/zephyrproject-rtos/zephyr/issues/84753 https://github.com/zephyrproject-rtos/zephyr/issues/90722 https://github.com/zephyrproject-rtos/zephyr/pull/90744 https://github.com/zephyrproject-rtos/zephyr/issues/90725

Assisted-by: Gemini CLI