### PR TITLE
modem: cellular: add board-specific init script hook

### DIFF
--- a/doc/services/modem/index.rst
+++ b/doc/services/modem/index.rst
@@ -349,6 +349,29 @@ binding, then write a driver source file using the macros from
 The example above is minimal but enough to start a PPP connection on a generic cellular modem.
 Refer to :zephyr_file:`drivers/modem/modem_cellular.c` for more complete examples.
 
+Board-specific init script
+==========================
+
+The init, network and dial scripts are vendor-scoped (keyed to the devicetree
+compatible), so configuration that differs between boards using the same modem,
+for example RF tuner band routing, would otherwise require forking the vendor
+driver. A board may instead register its own chat script with
+:c:macro:`MODEM_CELLULAR_BOARD_INIT_DEFINE`. The script runs over the AT control
+channel after CMUX is established and before APN and network configuration.
+Boards that register no script add no ROM or RAM footprint.
+
+The driver overrides the script's completion callback with the one that
+advances the connect sequence, so any callback set on the script is ignored.
+
+.. code-block:: c
+
+   MODEM_CHAT_MATCH_DEFINE(board_init_ok_match, "OK", "", NULL);
+   MODEM_CHAT_SCRIPT_CMDS_DEFINE(board_init_cmds,
+       MODEM_CHAT_SCRIPT_CMD_RESP("AT+QCFG=\"rf/tuner_cfg\",0,\"12,28\"", board_init_ok_match));
+   MODEM_CHAT_SCRIPT_NO_ABORT_DEFINE(board_init, board_init_cmds, NULL, 10);
+
+   MODEM_CELLULAR_BOARD_INIT_DEFINE(DT_NODELABEL(modem), &board_init);
+
 .. _cmux-power-saving:
 
 CMUX Power Saving

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -79,6 +79,8 @@ static const char *modem_cellular_state_str(enum modem_cellular_state state)
 		return "open dlci1";
 	case MODEM_CELLULAR_STATE_OPEN_DLCI2:
 		return "open dlci2";
+	case MODEM_CELLULAR_STATE_RUN_BOARD_INIT_SCRIPT:
+		return "run board init script";
 	case MODEM_CELLULAR_STATE_WAIT_FOR_APN:
 		return "wait for apn";
 	case MODEM_CELLULAR_STATE_AWAIT_REGISTERED:
@@ -163,6 +165,7 @@ static bool modem_cellular_apn_change_allowed(enum modem_cellular_state st)
 	case MODEM_CELLULAR_STATE_CONNECT_CMUX:
 	case MODEM_CELLULAR_STATE_OPEN_DLCI1:
 	case MODEM_CELLULAR_STATE_OPEN_DLCI2:
+	case MODEM_CELLULAR_STATE_RUN_BOARD_INIT_SCRIPT:
 	case MODEM_CELLULAR_STATE_WAIT_FOR_APN:
 		return true;
 	default:
@@ -1149,6 +1152,30 @@ static int modem_cellular_on_open_dlci1_state_leave(struct modem_cellular_data *
 	return 0;
 }
 
+static const struct modem_chat_script *modem_cellular_board_init_script(const struct device *dev)
+{
+	STRUCT_SECTION_FOREACH(modem_cellular_board_init, board_init) {
+		if (board_init->dev == dev) {
+			return board_init->script;
+		}
+	}
+
+	return NULL;
+}
+
+static void modem_cellular_enter_apn_state(struct modem_cellular_data *data)
+{
+	const struct modem_cellular_config *config = data->dev->config;
+
+	if (config->use_default_pdp_context) {
+		modem_cellular_enter_state_network_or_dial(data);
+	} else if (!modem_cellular_needs_apn(data)) {
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_APN_SCRIPT);
+	} else {
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_WAIT_FOR_APN);
+	}
+}
+
 static int modem_cellular_on_open_dlci2_state_enter(struct modem_cellular_data *data)
 {
 	modem_pipe_attach(data->dlci2_pipe, modem_cellular_dlci2_pipe_handler, data);
@@ -1158,18 +1185,15 @@ static int modem_cellular_on_open_dlci2_state_enter(struct modem_cellular_data *
 static void modem_cellular_open_dlci2_event_handler(struct modem_cellular_data *data,
 						    enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config = data->dev->config;
-
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_DLCI2_OPENED:
 		data->cmd_pipe = data->dlci2_pipe;
 
-		if (config->use_default_pdp_context) {
-			modem_cellular_enter_state_network_or_dial(data);
-		} else if (!modem_cellular_needs_apn(data)) {
-			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_APN_SCRIPT);
+		if (modem_cellular_board_init_script(data->dev) != NULL) {
+			modem_cellular_enter_state(data,
+						   MODEM_CELLULAR_STATE_RUN_BOARD_INIT_SCRIPT);
 		} else {
-			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_WAIT_FOR_APN);
+			modem_cellular_enter_apn_state(data);
 		}
 		break;
 
@@ -1224,6 +1248,48 @@ static bool modem_cellular_is_script_retry_exceeded(struct modem_cellular_data *
 	return false;
 }
 
+static int modem_cellular_on_run_board_init_script_state_enter(struct modem_cellular_data *data)
+{
+	modem_chat_attach(&data->chat, data->dlci1_pipe);
+
+	/* The registered script is const; copy it to attach the driver's
+	 * completion callback.
+	 */
+	data->board_init_script = *modem_cellular_board_init_script(data->dev);
+	modem_chat_script_set_callback(&data->board_init_script,
+				       modem_cellular_chat_callback_handler);
+
+	/* Allow modem time to enter command mode before running the board script */
+	modem_cellular_start_timer(data, K_MSEC(200));
+	return 0;
+}
+
+static void modem_cellular_run_board_init_script_event_handler(struct modem_cellular_data *data,
+							       enum modem_cellular_event evt)
+{
+	switch (evt) {
+	case MODEM_CELLULAR_EVENT_TIMEOUT:
+		modem_chat_run_script_async(&data->chat, &data->board_init_script);
+		break;
+	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
+		modem_cellular_script_success(data);
+		modem_cellular_enter_apn_state(data);
+		break;
+	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
+		modem_cellular_script_failed(data);
+		if (modem_cellular_is_script_retry_exceeded(data)) {
+			modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_SUSPEND);
+		} else {
+			modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
+		}
+		break;
+	case MODEM_CELLULAR_EVENT_SUSPEND:
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
+		break;
+	default:
+		break;
+	}
+}
 
 static int modem_cellular_on_run_apn_script_state_enter(struct modem_cellular_data *data)
 {
@@ -1766,6 +1832,10 @@ static int modem_cellular_on_state_enter(struct modem_cellular_data *data)
 		ret = modem_cellular_on_open_dlci2_state_enter(data);
 		break;
 
+	case MODEM_CELLULAR_STATE_RUN_BOARD_INIT_SCRIPT:
+		ret = modem_cellular_on_run_board_init_script_state_enter(data);
+		break;
+
 	case MODEM_CELLULAR_STATE_RUN_APN_SCRIPT:
 		ret = modem_cellular_on_run_apn_script_state_enter(data);
 		break;
@@ -1948,6 +2018,10 @@ static void modem_cellular_event_handler(struct modem_cellular_data *data,
 
 	case MODEM_CELLULAR_STATE_OPEN_DLCI2:
 		modem_cellular_open_dlci2_event_handler(data, evt);
+		break;
+
+	case MODEM_CELLULAR_STATE_RUN_BOARD_INIT_SCRIPT:
+		modem_cellular_run_board_init_script_event_handler(data, evt);
 		break;
 
 	case MODEM_CELLULAR_STATE_WAIT_FOR_APN:

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -22,6 +22,7 @@
 #include <zephyr/modem/pipe.h>
 #include <zephyr/modem/pipelink.h>
 #include <zephyr/modem/ppp.h>
+#include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/atomic.h>
 
 /**
@@ -69,6 +70,7 @@ enum modem_cellular_state {
 	MODEM_CELLULAR_STATE_CONNECT_CMUX,
 	MODEM_CELLULAR_STATE_OPEN_DLCI1,
 	MODEM_CELLULAR_STATE_OPEN_DLCI2,
+	MODEM_CELLULAR_STATE_RUN_BOARD_INIT_SCRIPT,
 	MODEM_CELLULAR_STATE_WAIT_FOR_APN,
 	MODEM_CELLULAR_STATE_RUN_APN_SCRIPT,
 	MODEM_CELLULAR_STATE_RUN_NETWORK_SCRIPT,
@@ -159,6 +161,8 @@ struct modem_cellular_data {
 	struct modem_chat_script_chat apn_chats[MODEM_CELLULAR_MAX_APN_CMDS];
 	struct modem_chat_script apn_script;
 	char apn_buf[MODEM_CELLULAR_MAX_APN_CMDS][MODEM_CELLULAR_APN_BUF_SIZE];
+
+	struct modem_chat_script board_init_script;
 
 	/* PPP */
 	struct modem_ppp *ppp;
@@ -448,6 +452,40 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
 			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL,                \
 			      CONFIG_MODEM_CELLULAR_INIT_PRIORITY, &modem_cellular_api);
+
+/**
+ * @brief Descriptor binding a board-supplied init script to a modem instance.
+ *
+ * Registered with MODEM_CELLULAR_BOARD_INIT_DEFINE.
+ */
+struct modem_cellular_board_init {
+	const struct device *dev;
+	const struct modem_chat_script *script;
+};
+
+/**
+ * @brief Register a board-specific init script for a modem instance.
+ *
+ * The script runs over the AT control channel after CMUX is established and
+ * before APN and network configuration. The driver supplies the completion
+ * callback that advances the connect sequence, so the script's own callback
+ * is unused.
+ *
+ * @param node_id Devicetree node identifier of the modem instance.
+ * @param _script Pointer to a modem_chat_script defined with
+ *                MODEM_CHAT_SCRIPT_DEFINE.
+ */
+#if defined(CONFIG_MODEM_CELLULAR)
+#define MODEM_CELLULAR_BOARD_INIT_DEFINE(node_id, _script)                                         \
+	static const STRUCT_SECTION_ITERABLE(                                                      \
+		modem_cellular_board_init,                                                         \
+		CONCAT(modem_cellular_board_init_, DT_DEP_ORD(node_id))) = {                       \
+		.dev = DEVICE_DT_GET(node_id),                                                     \
+		.script = (_script),                                                               \
+	}
+#else
+#define MODEM_CELLULAR_BOARD_INIT_DEFINE(node_id, _script)
+#endif
 
 /** @} */
 

--- a/include/zephyr/linker/common-rom/common-rom-misc.ld
+++ b/include/zephyr/linker/common-rom/common-rom-misc.ld
@@ -14,6 +14,10 @@
 	ITERABLE_SECTION_ROM(settings_handler_static, Z_LINK_ITERABLE_SUBALIGN)
 #endif
 
+#if defined(CONFIG_MODEM_CELLULAR)
+	ITERABLE_SECTION_ROM(modem_cellular_board_init, Z_LINK_ITERABLE_SUBALIGN)
+#endif
+
 #if defined(CONFIG_SENSING)
 	ITERABLE_SECTION_ROM(sensing_sensor_info, Z_LINK_ITERABLE_SUBALIGN)
 #endif

--- a/tests/drivers/build_all/modem/src/main.c
+++ b/tests/drivers/build_all/modem/src/main.c
@@ -7,6 +7,20 @@
 #include <zephyr/device.h>
 #include <zephyr/toolchain.h>
 
+#ifdef CONFIG_MODEM_CELLULAR
+#include <zephyr/modem/chat.h>
+#include <zephyr/drivers/modem/modem_cellular.h>
+
+/* Validate the board-init registration macro expands, links, and binds a
+ * board-supplied chat script to a modem instance.
+ */
+MODEM_CHAT_MATCH_DEFINE(board_init_ok_match, "OK", "", NULL);
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(board_init_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT", board_init_ok_match));
+MODEM_CHAT_SCRIPT_NO_ABORT_DEFINE(board_init_script, board_init_script_cmds, NULL, 4);
+MODEM_CELLULAR_BOARD_INIT_DEFINE(DT_NODELABEL(test_quectel_eg25_g), &board_init_script);
+#endif /* CONFIG_MODEM_CELLULAR */
+
 int main(void)
 {
 #ifdef CONFIG_MODEM_CELLULAR


### PR DESCRIPTION
The init, network and dial scripts are vendor-scoped (keyed to the devicetree compatible), so configuration that differs between boards sharing a modem, RF tuner band routing for example, can only be added by forking the vendor driver.

Add `MODEM_CELLULAR_BOARD_INIT_DEFINE`, which registers a board-supplied chat script against a modem instance through an iterable section. The driver runs it over the AT control channel in a new `RUN_BOARD_INIT_SCRIPT` state, after CMUX is established and before APN and network configuration, and only when a script is registered.