### PR TITLE
net: http: Fix compile issue

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -236,6 +236,7 @@ static int setup_h3_socket(const struct http_service_desc *svc, int af,
 	}
 
 #if defined(CONFIG_HTTP_SERVER_TLS_USE_ALPN)
+#if defined(CONFIG_HTTP_SERVER_VERSION_3)
 		if (zsock_setsockopt(quic_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_ALPN_LIST,
 				     h3_alpn_list, sizeof(h3_alpn_list)) < 0) {
 			ret = -errno;
@@ -243,6 +244,7 @@ static int setup_h3_socket(const struct http_service_desc *svc, int af,
 			zsock_close(quic_sock);
 			goto out;
 	}
+#endif /* defined(CONFIG_HTTP_SERVER_VERSION_3) */
 #endif /* defined(CONFIG_HTTP_SERVER_TLS_USE_ALPN) */
 #endif /* defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS) */
 


### PR DESCRIPTION
When CONFIG_HTTP_SERVER_VERSION_3 is not defined, h3_alpn_list could be used without being defined. Add the missing #define block to fix the error.