### PR TITLE
drivers: max30101 replace a bunch of BUILD_ASSERTs

### DIFF
--- a/drivers/sensor/maxim/max30101/max30101.c
+++ b/drivers/sensor/maxim/max30101/max30101.c
@@ -264,18 +264,6 @@ static int max30101_init(const struct device *dev)
 	return 0;
 }
 
-#define MAX30101_CHECK(n)                                                                          \
-	BUILD_ASSERT(DT_INST_PROP_LEN(n, led_pa) == 3,                                             \
-		     "MAX30101 led-pa property must have exactly 3 elements");                     \
-	BUILD_ASSERT(DT_INST_PROP_LEN(n, led_slot) == 4,                                           \
-		     "MAX30101 led-slot property must have exactly 4 elements")
-
-#define MAX30102_CHECK(n)                                                                          \
-	BUILD_ASSERT(DT_INST_PROP_LEN(n, led_pa) == 2,                                            \
-		     "MAX30102 led-pa property must have exactly 2 elements");                     \
-	BUILD_ASSERT(DT_INST_PROP_LEN(n, led_slot) == 4,                                           \
-		     "MAX30102 led-slot property must have exactly 4 elements")
-
 #define MAX30101_SLOT_CFG(n)                                                                       \
 	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(n, acq_mode, heart_rate), \
 		(MAX30101_HR_SLOTS), \
@@ -323,7 +311,6 @@ static int max30101_init(const struct device *dev)
 				     CONFIG_SENSOR_INIT_PRIORITY, &max30101_driver_api);
 
 #define MAX30101_INIT(n)                                                                           \
-	MAX30101_CHECK(n);                                                                         \
 	MAX3010X_INIT(n, max30101, 0)
 
 DT_INST_FOREACH_STATUS_OKAY(MAX30101_INIT)
@@ -335,7 +322,6 @@ DT_INST_FOREACH_STATUS_OKAY(MAX30101_INIT)
 #define DT_DRV_COMPAT maxim_max30102
 
 #define MAX30102_INIT(n)                                                                           \
-	MAX30102_CHECK(n);                                                                         \
 	MAX3010X_INIT(n, max30102, 1)
 
 DT_INST_FOREACH_STATUS_OKAY(MAX30102_INIT)

--- a/dts/bindings/sensor/maxim,max30101.yaml
+++ b/dts/bindings/sensor/maxim,max30101.yaml
@@ -19,6 +19,8 @@ properties:
       [1]: IR LED
       [2]: Green LED
       Default set to [0xff, 0xff, 0xff], activate any chosen LED channel.
+    min-len: 3
+    max-len: 3
 
   led-slot:
     min: 0

--- a/dts/bindings/sensor/maxim,max30102.yaml
+++ b/dts/bindings/sensor/maxim,max30102.yaml
@@ -21,6 +21,8 @@ properties:
       [0]: Red LED
       [1]: IR LED
       The MAX30102 has no Green LED. Array must have exactly 2 elements.
+    min-len: 2
+    max-len: 2
 
   led-slot:
     min: 0

--- a/dts/bindings/sensor/maxim,max3010x-common.yaml
+++ b/dts/bindings/sensor/maxim,max3010x-common.yaml
@@ -140,3 +140,5 @@ properties:
       User needs to choose which LED is active for each slot.
       NOTE: If a LED is present on multiple slots, `sensor_channel_get`
       will result in the averaging of the values.
+    min-len: 4
+    max-len: 4


### PR DESCRIPTION
use min-len/max-len for asserting the correct length of the array, drop corresponding build asserts