### PR TITLE
linker: cbprintf: recognize relocated rodata for dictionary string lo…

### DIFF
--- a/include/zephyr/linker/utils.h
+++ b/include/zephyr/linker/utils.h
@@ -8,18 +8,24 @@
 #define ZEPHYR_INCLUDE_LINKER_UTILS_H_
 
 #include <stdbool.h>
+#include <stddef.h>
+#include <zephyr/toolchain.h>
 
 /**
- * @brief Check if address is in read only section.
+ * @brief Check if address is in a read only section.
  *
- * Note that this may return false if the address lies outside
- * the compiler's default read only sections (e.g. .rodata
- * section), depending on the linker script used. This also
- * applies to constants with explicit section attributes.
+ * Checks the default .rodata region as well as any relocated
+ * rodata sections (CCM_RODATA, SMEM_RODATA) whose linker symbols
+ * are exposed via weak references.  This ensures that string
+ * literals placed in custom rodata sections by
+ * zephyr_code_relocate(LOCATION ..._RODATA) are still recognised
+ * as read-only by cbprintf, preventing the deferred-logging
+ * packager from NULLing their pointers and appending copies that
+ * downstream IPC log transports may not reconstruct correctly.
  *
  * @param addr Address.
  *
- * @return True if address identified within read only section.
+ * @return True if address identified within any read only section.
  */
 static inline bool linker_is_in_rodata(const void *addr)
 {
@@ -39,18 +45,39 @@ static inline bool linker_is_in_rodata(const void *addr)
 	defined(CONFIG_OPENRISC)
 	extern char __rodata_region_start[];
 	extern char __rodata_region_end[];
-#define RO_START __rodata_region_start
-#define RO_END   __rodata_region_end
-#else
-#define RO_START 0
-#define RO_END   0
+
+	if (((const char *)addr >= (const char *)__rodata_region_start) &&
+	    ((const char *)addr < (const char *)__rodata_region_end)) {
+		return true;
+	}
 #endif
 
-	return (((const char *)addr >= (const char *)RO_START) &&
-		((const char *)addr < (const char *)RO_END));
+	/* Relocated rodata sections (CCM, SMEM) live outside the default
+	 * __rodata_region.  zephyr_code_relocate(... CCM_RODATA/SMEM_RODATA)
+	 * brackets the actual strings with __<mem>_rodata_reloc_start/end
+	 * (gen_relocate_app.py).  The bare __<mem>_rodata_start/end markers
+	 * are zero-sized and never span the strings, so they must NOT be used
+	 * here.  Weak symbols let builds without these sections skip the check.
+	 */
+	extern char __weak __ccm_rodata_reloc_start[];
+	extern char __weak __ccm_rodata_reloc_end[];
 
-#undef RO_START
-#undef RO_END
+	if (((const char *)__ccm_rodata_reloc_start != NULL) &&
+	    ((const char *)addr >= (const char *)__ccm_rodata_reloc_start) &&
+	    ((const char *)addr < (const char *)__ccm_rodata_reloc_end)) {
+		return true;
+	}
+
+	extern char __weak __smem_rodata_reloc_start[];
+	extern char __weak __smem_rodata_reloc_end[];
+
+	if (((const char *)__smem_rodata_reloc_start != NULL) &&
+	    ((const char *)addr >= (const char *)__smem_rodata_reloc_start) &&
+	    ((const char *)addr < (const char *)__smem_rodata_reloc_end)) {
+		return true;
+	}
+
+	return false;
 }
 
 #endif /* ZEPHYR_INCLUDE_LINKER_UTILS_H_ */

--- a/scripts/logging/dictionary/database_gen.py
+++ b/scripts/logging/dictionary/database_gen.py
@@ -468,8 +468,17 @@ def extract_static_strings(elf, database, section_extraction=False):
 
     if section_extraction:
         # Extract strings from ELF sections
-        string_sections = STATIC_STRING_SECTIONS
+        string_sections = list(STATIC_STRING_SECTIONS)
         rawstr_map = {}
+
+        # Relocated rodata sections (e.g. .ccm_rodata_reloc, .smem_rodata_reloc
+        # emitted by gen_relocate_app.py for zephyr_code_relocate(... *_RODATA))
+        # hold static string literals too. Without them, %s args pointing into
+        # relocated rodata are shipped as bare pointers the dictionary decoder
+        # cannot resolve, so they render blank.
+        string_sections += [
+            name for name in elf_sections if "rodata" in name and name not in string_sections
+        ]
 
         # Some architectures may put static strings into additional sections.
         # So need to extract them too.


### PR DESCRIPTION
## Summary

  cbprintf dictionary logging ships read-only string arguments to the host as
  bare pointers (resolved by address on the host) and deep-copies everything
  else. It decides which is which via `linker_is_in_rodata()`, which today only
  checks the default `__rodata_region`.

  Strings in libraries relocated with
  `zephyr_code_relocate(... CCM_RODATA / SMEM_RODATA)` land in
  `.ccm_rodata_reloc` / `.smem_rodata_reloc`, which sit outside
  `__rodata_region`. They are therefore misclassified as transient, and the
  dictionary backend cannot reconstruct them — string columns render blank or
  garbled.

  Both halves of the fix are required:
  - A firmware-only fix would ship pointers the host has no symbols to resolve.

  ## Changes

  - **`include/zephyr/linker/utils.h`** — `linker_is_in_rodata()` now also
    accepts the relocated spans `__ccm_rodata_reloc_*` / `__smem_rodata_reloc_*`.
    These are declared as **weak** symbols and **NULL-guarded**, so builds that
    don't relocate rodata are completely unaffected.
  - **`scripts/logging/dictionary/database_gen.py`** — include relocated rodata
    sections in dictionary string extraction so the host can resolve those
    pointers.

  ## Why weak symbols + NULL guard

  The relocated section markers (`__<mem>_rodata_reloc_start/end`, emitted by
  `gen_relocate_app.py`) only exist when something is actually relocated into
  CCM/SMEM rodata. Declaring them `__weak` and skipping the range check when the
  start symbol is NULL keeps the common case (no relocation) a no-op and avoids
  link errors on builds without those sections.

  ## Testing

  twister on `native_sim` and `unit_testing` (host/gnu toolchain):

  | Suite | Result |
  |---|---|
  | `tests/lib/cbprintf_package` | pass |
  | `tests/lib/cbprintf_fp` | pass |
  | `tests/unit/cbprintf` | pass |
  | `tests/subsys/logging/dictionary` | pass |

  **68/68 configurations, 1356/1356 test cases passed**, 0 failed, 0 errored.