### PR TITLE
drivers: audio: wm8904 fix input volume

### DIFF
--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -630,13 +630,13 @@ static int wm8904_apply_properties(const struct device *dev)
 	wm8904_update_reg(
 		dev,
 		WM8904_REG_ANALOG_OUT1_LEFT,
-		WM8904_REGVAL_OUT_VOL(0, 1, 0, 0),
-		WM8904_REGMASK_OUT_MUTE
+		WM8904_REGMASK_OUT_VU,
+		WM8904_REGVAL_OUT_VOL(0, 1, 0, 0)
 	);
 	wm8904_update_reg(dev,
 		WM8904_REG_ANALOG_OUT2_LEFT,
-		WM8904_REGVAL_OUT_VOL(0, 1, 0, 0),
-		WM8904_REGMASK_OUT_MUTE
+		WM8904_REGMASK_OUT_VU,
+		WM8904_REGVAL_OUT_VOL(0, 1, 0, 0)
 	);
 
 	return 0;

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2024 NXP
+ * Copyright (c) 2026 Mario Paja
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,6 +25,7 @@ struct wm8904_driver_config {
 	const struct device *mclk_dev;
 	clock_control_subsys_t mclk_name;
 	int fs_ratio;
+	bool mic_bias;
 };
 
 #define DEV_CFG(dev) ((const struct wm8904_driver_config *const)dev->config)
@@ -442,6 +444,14 @@ static int wm8904_configure(const struct device *dev, struct audio_codec_cfg *cf
 	 */
 	wm8904_write_reg(dev, WM8904_REG_CLK_RATES_0, 0xA45F);
 
+	if (dev_cfg->mic_bias) {
+
+		/* MICBIAS_ENA=1
+		 * At the moment defaulting in 9/10 x AVDD
+		 */
+		wm8904_write_reg(dev, WM8904_REG_MIC_BIAS_CONTROL_0, 0x0001);
+	}
+
 	/* INL_ENA=1, INR ENA=1 */
 	wm8904_write_reg(dev, WM8904_REG_POWER_MGMT_0, 0x0003);
 
@@ -690,7 +700,8 @@ static DEVICE_API(audio_codec, wm8904_driver_api) = {
 		.mclk_name = COND_CODE_1(DT_INST_CLOCKS_HAS_NAME(n, mclk),                         \
 			((clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, name)),      \
 			(NULL)),                                                                   \
-		.fs_ratio = DT_INST_PROP_OR(n, fs_ratio, 0)};                                      \
+		.fs_ratio = DT_INST_PROP_OR(n, fs_ratio, 0),                                       \
+		.mic_bias = DT_INST_PROP_OR(n, mic_bias, 0)};                                      \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, &wm8904_device_config_##n, POST_KERNEL,         \
 			      CONFIG_AUDIO_CODEC_INIT_PRIORITY, &wm8904_driver_api);

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -26,6 +26,7 @@ struct wm8904_driver_config {
 	clock_control_subsys_t mclk_name;
 	int fs_ratio;
 	bool mic_bias;
+	int in_pga_vol;
 };
 
 #define DEV_CFG(dev) ((const struct wm8904_driver_config *const)dev->config)
@@ -36,8 +37,6 @@ static void wm8904_update_reg(const struct device *dev, uint8_t reg, uint16_t ma
 static void wm8904_soft_reset(const struct device *dev);
 
 static void wm8904_configure_output(const struct device *dev);
-
-static void wm8904_configure_input(const struct device *dev);
 
 static int wm8904_protocol_config(const struct device *dev, audio_dai_type_t dai_type)
 {
@@ -232,48 +231,6 @@ static int wm8904_out_mute_config(const struct device *dev, audio_channel_t chan
 	return wm8904_out_update(dev, channel, val, mask);
 }
 
-static int wm8904_in_update(
-	const struct device *dev,
-	audio_channel_t channel,
-	uint16_t mask,
-	uint16_t val
-)
-{
-	switch (channel) {
-	case AUDIO_CHANNEL_FRONT_LEFT:
-		wm8904_update_reg(dev, WM8904_REG_ANALOG_LEFT_IN_0, mask, val);
-		return 0;
-
-	case AUDIO_CHANNEL_FRONT_RIGHT:
-		wm8904_update_reg(dev, WM8904_REG_ANALOG_RIGHT_IN_0, mask, val);
-		return 0;
-
-	case AUDIO_CHANNEL_ALL:
-		wm8904_update_reg(dev, WM8904_REG_ANALOG_LEFT_IN_0, mask, val);
-		wm8904_update_reg(dev, WM8904_REG_ANALOG_RIGHT_IN_0, mask, val);
-		return 0;
-
-	default:
-		return -EINVAL;
-	}
-}
-
-static int wm8904_in_volume_config(const struct device *dev, audio_channel_t channel, int volume)
-{
-	const uint16_t val = WM8904_REGVAL_IN_VOL(0, volume);
-	const uint16_t mask = WM8904_REGMASK_IN_VOLUME;
-
-	return wm8904_in_update(dev, channel, mask, val);
-}
-
-static int wm8904_in_mute_config(const struct device *dev, audio_channel_t channel, bool mute)
-{
-	const uint16_t val = WM8904_REGVAL_IN_VOL(mute, 0);
-	const uint16_t mask = WM8904_REGMASK_IN_MUTE;
-
-	return wm8904_in_update(dev, channel, mask, val);
-}
-
 static int wm8904_route_input(const struct device *dev, audio_channel_t channel, uint32_t input)
 {
 	if (input < 1 || input > 3) {
@@ -302,6 +259,84 @@ static int wm8904_route_input(const struct device *dev, audio_channel_t channel,
 
 	wm8904_update_reg(dev, reg, mask, val);
 	return 0;
+}
+
+static int wm8904_in_pga_update_channel(const struct device *dev, audio_channel_t channel,
+					uint16_t mask, uint16_t val)
+{
+	switch (channel) {
+	case AUDIO_CHANNEL_FRONT_LEFT:
+		wm8904_update_reg(dev, WM8904_REG_ANALOG_LEFT_IN_0, mask, val);
+		return 0;
+
+	case AUDIO_CHANNEL_FRONT_RIGHT:
+		wm8904_update_reg(dev, WM8904_REG_ANALOG_RIGHT_IN_0, mask, val);
+		return 0;
+
+	case AUDIO_CHANNEL_ALL:
+		wm8904_update_reg(dev, WM8904_REG_ANALOG_LEFT_IN_0, mask, val);
+		wm8904_update_reg(dev, WM8904_REG_ANALOG_RIGHT_IN_0, mask, val);
+		return 0;
+
+	default:
+		return -EINVAL;
+	}
+}
+
+static int wm8904_in_pga_vol_config(const struct device *dev, int volume)
+{
+	const uint16_t val = WM8904_REGVAL_IN_PGA_VOL(0, volume);
+	const uint16_t mask = WM8904_REGMASK_IN_PGA_VOLUME;
+
+	return wm8904_in_pga_update_channel(dev, AUDIO_CHANNEL_ALL, mask, val);
+}
+
+static int wm8904_in_pga_mute_channel_config(const struct device *dev, audio_channel_t channel,
+					     bool mute)
+{
+	const uint16_t val = WM8904_REGVAL_IN_PGA_VOL(mute, 0);
+	const uint16_t mask = WM8904_REGMASK_IN_PGA_MUTE;
+
+	return wm8904_in_pga_update_channel(dev, channel, mask, val);
+}
+
+static void wm8904_in_pga_config(const struct device *dev)
+{
+	const struct wm8904_driver_config *const dev_cfg = DEV_CFG(dev);
+
+	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_LEFT, 2);
+	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_RIGHT, 2);
+
+	wm8904_in_pga_vol_config(dev, dev_cfg->in_pga_vol);
+	wm8904_in_pga_mute_channel_config(dev, AUDIO_CHANNEL_ALL, false);
+}
+
+static int wm8904_in_volume_config(const struct device *dev, audio_channel_t channel, int volume)
+{
+	const uint16_t mask = WM8904_REGMASK_IN_VOL | WM8904_REGMASK_IN_VU;
+
+	switch (channel) {
+	case AUDIO_CHANNEL_FRONT_LEFT:
+		wm8904_update_reg(dev, WM8904_REG_ADC_DIGITAL_VOLUME_LEFT, mask,
+				  WM8904_REGVAL_IN_VOL(1, volume));
+		return 0;
+
+	case AUDIO_CHANNEL_FRONT_RIGHT:
+		wm8904_update_reg(dev, WM8904_REG_ADC_DIGITAL_VOLUME_RIGHT, mask,
+				  WM8904_REGVAL_IN_VOL(1, volume));
+		return 0;
+
+	case AUDIO_CHANNEL_ALL:
+		wm8904_update_reg(dev, WM8904_REG_ADC_DIGITAL_VOLUME_LEFT, mask,
+				  WM8904_REGVAL_IN_VOL(0, volume));
+		wm8904_update_reg(dev, WM8904_REG_ADC_DIGITAL_VOLUME_RIGHT, mask,
+				  WM8904_REGVAL_IN_VOL(1, volume));
+
+		return 0;
+
+	default:
+		return -EINVAL;
+	}
 }
 
 static void wm8904_set_master_clock(const struct device *dev, audio_dai_cfg_t *cfg, uint32_t sysclk)
@@ -541,12 +576,12 @@ static int wm8904_configure(const struct device *dev, struct audio_codec_cfg *cf
 		break;
 
 	case AUDIO_ROUTE_CAPTURE:
-		wm8904_configure_input(dev);
+		wm8904_in_pga_config(dev);
 		break;
 
 	case AUDIO_ROUTE_PLAYBACK_CAPTURE:
 		wm8904_configure_output(dev);
-		wm8904_configure_input(dev);
+		wm8904_in_pga_config(dev);
 		break;
 
 	default:
@@ -578,7 +613,7 @@ static int wm8904_set_property(const struct device *dev, audio_property_t proper
 		return wm8904_in_volume_config(dev, channel, val.vol);
 
 	case AUDIO_PROPERTY_INPUT_MUTE:
-		return wm8904_in_mute_config(dev, channel, val.mute);
+		return wm8904_in_pga_mute_channel_config(dev, channel, val.mute);
 	}
 
 	return -EINVAL;
@@ -673,15 +708,6 @@ static void wm8904_configure_output(const struct device *dev)
 	wm8904_apply_properties(dev);
 }
 
-static void wm8904_configure_input(const struct device *dev)
-{
-	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_LEFT, 2);
-	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_RIGHT, 2);
-
-	wm8904_in_volume_config(dev, AUDIO_CHANNEL_ALL, WM8904_INPUT_VOLUME_DEFAULT);
-	wm8904_in_mute_config(dev, AUDIO_CHANNEL_ALL, false);
-}
-
 static DEVICE_API(audio_codec, wm8904_driver_api) = {
 	.configure = wm8904_configure,
 	.start_output = wm8904_start_output,
@@ -701,7 +727,8 @@ static DEVICE_API(audio_codec, wm8904_driver_api) = {
 			((clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, name)),      \
 			(NULL)),                                                                   \
 		.fs_ratio = DT_INST_PROP_OR(n, fs_ratio, 0),                                       \
-		.mic_bias = DT_INST_PROP_OR(n, mic_bias, 0)};                                      \
+		.mic_bias = DT_INST_PROP_OR(n, mic_bias, 0),                                       \
+		.in_pga_vol = DT_INST_PROP_OR(n, input_pga_volume, 5)};                            \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, &wm8904_device_config_##n, POST_KERNEL,         \
 			      CONFIG_AUDIO_CODEC_INIT_PRIORITY, &wm8904_driver_api);

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -27,6 +27,7 @@ struct wm8904_driver_config {
 	int fs_ratio;
 	bool mic_bias;
 	int in_pga_vol;
+	int in_pga_sel;
 };
 
 #define DEV_CFG(dev) ((const struct wm8904_driver_config *const)dev->config)
@@ -237,6 +238,7 @@ static int wm8904_route_input(const struct device *dev, audio_channel_t channel,
 		return -EINVAL;
 	}
 
+	/* Only Single-Ended is supported */
 	uint8_t val = WM8904_REGVAL_INSEL(0, input - 1, input - 1, 0);
 	uint8_t mask = WM8904_REGMASK_INSEL_CMENA
 		| WM8904_REGMASK_INSEL_IP_SEL_P
@@ -304,8 +306,8 @@ static void wm8904_in_pga_config(const struct device *dev)
 {
 	const struct wm8904_driver_config *const dev_cfg = DEV_CFG(dev);
 
-	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_LEFT, 2);
-	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_RIGHT, 2);
+	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_LEFT, dev_cfg->in_pga_sel);
+	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_RIGHT, dev_cfg->in_pga_sel);
 
 	wm8904_in_pga_vol_config(dev, dev_cfg->in_pga_vol);
 	wm8904_in_pga_mute_channel_config(dev, AUDIO_CHANNEL_ALL, false);
@@ -728,7 +730,8 @@ static DEVICE_API(audio_codec, wm8904_driver_api) = {
 			(NULL)),                                                                   \
 		.fs_ratio = DT_INST_PROP_OR(n, fs_ratio, 0),                                       \
 		.mic_bias = DT_INST_PROP_OR(n, mic_bias, 0),                                       \
-		.in_pga_vol = DT_INST_PROP_OR(n, input_pga_volume, 5)};                            \
+		.in_pga_vol = DT_INST_PROP_OR(n, input_pga_volume, 5),                             \
+		.in_pga_sel = DT_INST_PROP_OR(n, input_pga_select, 2)};                            \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, &wm8904_device_config_##n, POST_KERNEL,         \
 			      CONFIG_AUDIO_CODEC_INIT_PRIORITY, &wm8904_driver_api);

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -34,6 +34,7 @@ struct wm8904_driver_config {
 	clock_control_subsys_t mclk_name;
 	int fs_ratio;
 	int in_pga_sel;
+	int in_pga_vol;
 	enum mic_bias_select mic_bias_sel;
 };
 
@@ -64,7 +65,7 @@ static void wm8904_soft_reset(const struct device *dev);
 
 static void wm8904_configure_output(const struct device *dev);
 
-static void wm8904_configure_input(const struct device *dev);
+static void wm8904_in_pga_config(const struct device *dev);
 
 static int wm8904_protocol_config(const struct device *dev, audio_dai_type_t dai_type)
 {
@@ -259,12 +260,8 @@ static int wm8904_out_mute_config(const struct device *dev, audio_channel_t chan
 	return wm8904_out_update(dev, channel, val, mask);
 }
 
-static int wm8904_in_update(
-	const struct device *dev,
-	audio_channel_t channel,
-	uint16_t mask,
-	uint16_t val
-)
+static int wm8904_in_pga_update_channel(const struct device *dev, audio_channel_t channel,
+					uint16_t mask, uint16_t val)
 {
 	switch (channel) {
 	case AUDIO_CHANNEL_FRONT_LEFT:
@@ -285,20 +282,49 @@ static int wm8904_in_update(
 	}
 }
 
-static int wm8904_in_volume_config(const struct device *dev, audio_channel_t channel, int volume)
+static int wm8904_in_pga_vol_config(const struct device *dev, int volume)
 {
-	const uint16_t val = WM8904_REGVAL_IN_VOL(0, volume);
-	const uint16_t mask = WM8904_REGMASK_IN_VOLUME;
+	const uint16_t val = WM8904_REGVAL_IN_PGA_VOL(0, volume);
+	const uint16_t mask = WM8904_REGMASK_IN_PGA_VOLUME;
 
-	return wm8904_in_update(dev, channel, mask, val);
+	return wm8904_in_pga_update_channel(dev, AUDIO_CHANNEL_ALL, mask, val);
 }
 
-static int wm8904_in_mute_config(const struct device *dev, audio_channel_t channel, bool mute)
+static int wm8904_in_pga_mute_channel_config(const struct device *dev, audio_channel_t channel,
+					     bool mute)
 {
-	const uint16_t val = WM8904_REGVAL_IN_VOL(mute, 0);
-	const uint16_t mask = WM8904_REGMASK_IN_MUTE;
+	const uint16_t val = WM8904_REGVAL_IN_PGA_VOL(mute, 0);
+	const uint16_t mask = WM8904_REGMASK_IN_PGA_MUTE;
 
-	return wm8904_in_update(dev, channel, mask, val);
+	return wm8904_in_pga_update_channel(dev, channel, mask, val);
+}
+
+static int wm8904_in_volume_config(const struct device *dev, audio_channel_t channel, int volume)
+{
+	const uint16_t mask = WM8904_REGMASK_IN_VOL | WM8904_REGMASK_IN_VU;
+
+	switch (channel) {
+	case AUDIO_CHANNEL_FRONT_LEFT:
+		wm8904_update_reg(dev, WM8904_REG_ADC_DIGITAL_VOLUME_LEFT, mask,
+				  WM8904_REGVAL_IN_VOL(1, volume));
+		return 0;
+
+	case AUDIO_CHANNEL_FRONT_RIGHT:
+		wm8904_update_reg(dev, WM8904_REG_ADC_DIGITAL_VOLUME_RIGHT, mask,
+				  WM8904_REGVAL_IN_VOL(1, volume));
+		return 0;
+
+	case AUDIO_CHANNEL_ALL:
+		wm8904_update_reg(dev, WM8904_REG_ADC_DIGITAL_VOLUME_LEFT, mask,
+				  WM8904_REGVAL_IN_VOL(0, volume));
+		wm8904_update_reg(dev, WM8904_REG_ADC_DIGITAL_VOLUME_RIGHT, mask,
+				  WM8904_REGVAL_IN_VOL(1, volume));
+
+		return 0;
+
+	default:
+		return -EINVAL;
+	}
 }
 
 static int wm8904_route_input(const struct device *dev, audio_channel_t channel, uint32_t input)
@@ -569,12 +595,12 @@ static int wm8904_configure(const struct device *dev, struct audio_codec_cfg *cf
 		break;
 
 	case AUDIO_ROUTE_CAPTURE:
-		wm8904_configure_input(dev);
+		wm8904_in_pga_config(dev);
 		break;
 
 	case AUDIO_ROUTE_PLAYBACK_CAPTURE:
 		wm8904_configure_output(dev);
-		wm8904_configure_input(dev);
+		wm8904_in_pga_config(dev);
 		break;
 
 	default:
@@ -648,7 +674,7 @@ static int wm8904_set_property(const struct device *dev, audio_property_t proper
 		return wm8904_in_volume_config(dev, channel, val.vol);
 
 	case AUDIO_PROPERTY_INPUT_MUTE:
-		return wm8904_in_mute_config(dev, channel, val.mute);
+		return wm8904_in_pga_mute_channel_config(dev, channel, val.mute);
 
 	case AUDIO_PROPERTY_EQ_GAIN: {
 		struct audio_codec_eq_cfg *eq = &val.eq;
@@ -749,15 +775,15 @@ static void wm8904_configure_output(const struct device *dev)
 	wm8904_apply_properties(dev);
 }
 
-static void wm8904_configure_input(const struct device *dev)
+static void wm8904_in_pga_config(const struct device *dev)
 {
 	const struct wm8904_driver_config *const dev_cfg = DEV_CFG(dev);
 
 	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_LEFT, dev_cfg->in_pga_sel);
 	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_RIGHT, dev_cfg->in_pga_sel);
 
-	wm8904_in_volume_config(dev, AUDIO_CHANNEL_ALL, WM8904_INPUT_VOLUME_DEFAULT);
-	wm8904_in_mute_config(dev, AUDIO_CHANNEL_ALL, false);
+	wm8904_in_pga_vol_config(dev, dev_cfg->in_pga_vol);
+	wm8904_in_pga_mute_channel_config(dev, AUDIO_CHANNEL_ALL, false);
 }
 
 static DEVICE_API(audio_codec, wm8904_driver_api) = {
@@ -782,6 +808,7 @@ static DEVICE_API(audio_codec, wm8904_driver_api) = {
 			(NULL)),                                                                   \
 		.fs_ratio = DT_INST_PROP_OR(n, fs_ratio, 0),                                       \
 		.in_pga_sel = DT_INST_PROP_OR(n, input_pga_select, 2),                             \
+		.in_pga_vol = DT_INST_PROP_OR(n, input_pga_volume, 5),                             \
 		.mic_bias_sel = CONCAT(MIC_BIAS_,                                                  \
 			DT_INST_STRING_UPPER_TOKEN_OR(n, wolfson_mic_bias_voltage, DISABLED))};    \
                                                                                                    \

--- a/drivers/audio/wm8904.h
+++ b/drivers/audio/wm8904.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2024 NXP
+ * Copyright (c) 2026 Mario Paja
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +13,8 @@
  ******************************************************************************/
 
 #define WM8904_REG_RESET                    (0x00)
+#define WM8904_REG_MIC_BIAS_CONTROL_0       (0X06)
+#define WM8904_REG_MIC_BIAS_CONTROL_1       (0X07)
 #define WM8904_REG_ANALOG_ADC_0             (0x0A)
 #define WM8904_REG_POWER_MGMT_0             (0x0C)
 #define WM8904_REG_POWER_MGMT_2             (0x0E)

--- a/drivers/audio/wm8904.h
+++ b/drivers/audio/wm8904.h
@@ -68,9 +68,6 @@
 #define WM8904_OUTPUT_VOLUME_MIN (0b000000)
 #define WM8904_OUTPUT_VOLUME_MAX (0b111111)
 #define WM8904_OUTPUT_VOLUME_DEFAULT (0b101101)
-#define WM8904_INPUT_VOLUME_MIN (0b00000)
-#define WM8904_INPUT_VOLUME_MAX (0b11111)
-#define WM8904_INPUT_VOLUME_DEFAULT (0b00101)
 
 /**
  * WM8904_ANALOG_OUT1_LEFT, WM8904_ANALOG_OUT1_RIGHT (headphone outs),
@@ -92,10 +89,18 @@
  * [7]   - MUTE: Input mute
  * [4:0] - VOL: 5 bit volume value
  */
-#define WM8904_REGVAL_IN_VOL(mute, vol) \
-	((mute & 0b1) << 7 | (vol & 0b00011111))
-#define WM8904_REGMASK_IN_MUTE		0b10000000
-#define WM8904_REGMASK_IN_VOLUME	0b00011111
+#define WM8904_REGVAL_IN_PGA_VOL(mute, vol) ((mute & 0b1) << 7 | (vol & 0b00011111))
+#define WM8904_REGMASK_IN_PGA_MUTE          0b10000000
+#define WM8904_REGMASK_IN_PGA_VOLUME        0b00011111
+
+/**
+ * WM8904_ADC_DIGITAL_VOLUME_LEFT, WM8904_ADC_DIGITAL_VOLUME_RIGHT
+ * [8]   - VU: Volume update, works for entire channel pair
+ * [7:0] - VOL: 8-bit volume value
+ */
+#define WM8904_REGVAL_IN_VOL(vu, vol) (((vu & 0b1) << 8) | (vol & 0b011111111))
+#define WM8904_REGMASK_IN_VU          0b100000000
+#define WM8904_REGMASK_IN_VOL         0b011111111
 
 /**
  * WM8904_ANALOG_LEFT_IN_1, WM8904_ANALOG_RIGHT_IN_1:

--- a/drivers/audio/wm8904.h
+++ b/drivers/audio/wm8904.h
@@ -75,9 +75,6 @@
 #define WM8904_OUTPUT_VOLUME_MIN (0b000000)
 #define WM8904_OUTPUT_VOLUME_MAX (0b111111)
 #define WM8904_OUTPUT_VOLUME_DEFAULT (0b101101)
-#define WM8904_INPUT_VOLUME_MIN (0b00000)
-#define WM8904_INPUT_VOLUME_MAX (0b11111)
-#define WM8904_INPUT_VOLUME_DEFAULT (0b00101)
 
 /**
  * WM8904_ANALOG_OUT1_LEFT, WM8904_ANALOG_OUT1_RIGHT (headphone outs),
@@ -99,10 +96,18 @@
  * [7]   - MUTE: Input mute
  * [4:0] - VOL: 5 bit volume value
  */
-#define WM8904_REGVAL_IN_VOL(mute, vol) \
-	((mute & 0b1) << 7 | (vol & 0b00011111))
-#define WM8904_REGMASK_IN_MUTE		0b10000000
-#define WM8904_REGMASK_IN_VOLUME	0b00011111
+#define WM8904_REGVAL_IN_PGA_VOL(mute, vol) ((mute & 0b1) << 7 | (vol & 0b00011111))
+#define WM8904_REGMASK_IN_PGA_MUTE          0b10000000
+#define WM8904_REGMASK_IN_PGA_VOLUME        0b00011111
+
+/**
+ * WM8904_ADC_DIGITAL_VOLUME_LEFT, WM8904_ADC_DIGITAL_VOLUME_RIGHT
+ * [8]   - VU: Volume update, works for entire channel pair
+ * [7:0] - VOL: 8-bit volume value
+ */
+#define WM8904_REGVAL_IN_VOL(vu, vol) (((vu & 0b1) << 8) | (vol & 0b011111111))
+#define WM8904_REGMASK_IN_VU          0b100000000
+#define WM8904_REGMASK_IN_VOL         0b011111111
 
 /**
  * WM8904_REG_MIC_BIAS_CONTROL_0:

--- a/dts/bindings/audio/wolfson,wm8904.yaml
+++ b/dts/bindings/audio/wolfson,wm8904.yaml
@@ -56,3 +56,12 @@ properties:
       corresponding to an analog gain range of -1.5 dB to +28.3 dB in
       ~0.96 dB steps. Out-of-range values are clamped by the driver.
       The default gain is 5 (00101b), i.e. ~+3.3 dB.
+
+  input-pga-select:
+    type: int
+    default: 2
+    enum: [1, 2, 3]
+    description: |
+      Selects the WM8904 input PGA source channel.
+      Only single-ended input mode is supported.
+      On the 32-pin QFN package, only channels 1 and 2 are supported.

--- a/dts/bindings/audio/wolfson,wm8904.yaml
+++ b/dts/bindings/audio/wolfson,wm8904.yaml
@@ -1,4 +1,5 @@
 # Copyright 2024 NXP
+# Copyright (c) 2026 Mario Paja
 # SPDX-License-Identifier: Apache-2.0
 
 description: WM8904 audio codec
@@ -10,6 +11,7 @@ compatible: "wolfson,wm8904"
 properties:
   reg:
     required: true
+
   clock-source:
     type: string
     default: "MCLK"
@@ -23,6 +25,7 @@ properties:
     enum:
       - "MCLK"
       - "FLL"
+
   fs-ratio:
     type: int
     default: 256
@@ -33,3 +36,8 @@ properties:
       On such platforms, the driver assumes the MCLK frequency to be equal
       to (fs-ratio * <sample rate>), where the sample rate comes from the
       audio codec configuration provided at runtime.
+
+  mic-bias:
+    type: boolean
+    description: |
+     Enables microphone bias voltage for the connected microphone input.

--- a/dts/bindings/audio/wolfson,wm8904.yaml
+++ b/dts/bindings/audio/wolfson,wm8904.yaml
@@ -41,3 +41,18 @@ properties:
     type: boolean
     description: |
      Enables microphone bias voltage for the connected microphone input.
+
+  input-pga-volume:
+    type: int
+    default: 5
+    min: 0
+    max: 31
+    description: |
+      Static analog input PGA gain value, applied to the input PGA.
+      Used to set fixed input gain staging to match the sensitivity
+      of the connected microphone or line-in source.
+
+      Valid range is 0 to 31 (5-bit register, 0x00-0x1F / 00000b-11111b),
+      corresponding to an analog gain range of -1.5 dB to +28.3 dB in
+      ~0.96 dB steps. Out-of-range values are clamped by the driver.
+      The default gain is 5 (00101b), i.e. ~+3.3 dB.

--- a/dts/bindings/audio/wolfson,wm8904.yaml
+++ b/dts/bindings/audio/wolfson,wm8904.yaml
@@ -40,6 +40,20 @@ properties:
       Selects the WM8904 input PGA source channel.
       Only single-ended input mode is supported.
       On the 32-pin QFN package, only channels 1 and 2 are supported.
+  input-pga-volume:
+    type: int
+    default: 5
+    min: 0
+    max: 31
+    description: |
+      Static analog input PGA gain value, applied to the input PGA.
+      Used to set fixed input gain staging to match the sensitivity
+      of the connected microphone or line-in source.
+
+      Valid range is 0 to 31 (5-bit register, 0x00-0x1F / 00000b-11111b),
+      corresponding to an analog gain range of -1.5 dB to +28.3 dB in
+      ~0.96 dB steps. Out-of-range values are clamped by the driver.
+      The default gain is 5 (00101b), i.e. ~+3.3 dB.
   wolfson,mic-bias-voltage:
     type: string
     description: |


### PR DESCRIPTION
Analog input should not be used to adjust the input gain on runtime.

These changes fix input volume configuration by introducing one DTS parameter for input-pga-volume
and using ADC Digital volume control to adjust the input volume on runtime.
