### PR TITLE
serial: Fix PL011 error staying latched

### DIFF
--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -231,8 +231,18 @@ static void pl011_poll_out(const struct device *dev,
 
 static int pl011_err_check(const struct device *dev)
 {
-	uint32_t rsr = get_uart(dev)->rsr;
 	int errors = 0;
+	uint32_t rsr;
+
+	/* Clear the latched error status first, then re-read.
+	 * RSR latches errors from the most recent DR read.
+	 * Writing any value to ECR (same address, write side) clears
+	 * all error flags.  We clear first so that after this call
+	 * returns, RSR is clean and ready to latch errors from the
+	 * next DR read.
+	 */
+	rsr = get_uart(dev)->rsr;
+	get_uart(dev)->rsr = 0;
 
 	if (rsr & PL011_RSR_ECR_OE) {
 		errors |= UART_ERROR_OVERRUN;
@@ -512,7 +522,10 @@ static void pl011_irq_err_disable(const struct device *dev)
 
 static int pl011_irq_is_pending(const struct device *dev)
 {
-	return pl011_irq_rx_ready(dev) || pl011_irq_tx_ready(dev);
+	volatile struct pl011_regs *uart = get_uart(dev);
+
+	return pl011_irq_rx_ready(dev) || pl011_irq_tx_ready(dev) ||
+	       (uart->mis & PL011_IMSC_ERROR_MASK);
 }
 
 static void pl011_irq_callback_set(const struct device *dev,
@@ -710,6 +723,14 @@ void pl011_isr(const struct device *dev)
 	if (uart->mis & PL011_IMSC_CTSMIM) {
 		uart->icr = PL011_IMSC_CTSMIM;
 		uart->imsc &= ~PL011_IMSC_CTSMIM;
+	}
+
+	/* Clear error interrupts (OE, BE, PE, FE) so they don't
+	 * re-fire endlessly.  The error status is still available
+	 * via uart_err_check() which reads RSR.
+	 */
+	if (uart->mis & PL011_IMSC_ERROR_MASK) {
+		uart->icr = uart->mis & PL011_IMSC_ERROR_MASK;
 	}
 
 	/* Verify if the callback has been registered */


### PR DESCRIPTION
This PR fixes an issue where a framing error is never cleared on the PL011 serial peripheral. I discovered this while working on a DMX512 input driver that explicitly relies on detecting a framing error (the start of a packet) but was then unable to consistently read data coming in after handling the error.

I found this on an RP2040. The [datasheet](https://pip-assets.raspberrypi.com/categories/814-rp2040/documents/RP-008371-DS-1-rp2040-datasheet.pdf) page 430 for register `UARTRSR` says for all four error bits:
> This bit is cleared to 0 by a write to UARTECR. 

Additionally, section 4.2.6.5 on page 426 says about the error interrupt:
> You can determine the cause of the interrupt by reading the Raw Interrupt Status Register, UARTRIS, or the Masked Interrupt Status Register, UARTMIS. It can be cleared by writing to the relevant bits of the Interrupt Clear Register, UARTICR (bits 7 to 10 are the error clear bits).

The interrupt issue only matters if `uart_irq_err_enable();` has been called. I have verified that the interrupt issue causes a hang and that this fixes it.

_I used the help of Claude Opus 4.7 on this PR. I do not use this tool for issue/PR comments and take full responsibility for this code._

Assisted-by: Claude:claude-opus-4.7

Fixes: #112931