### PR TITLE
drivers: i3c: npcx: fix NULL deref of target_config in ISR

### DIFF
--- a/drivers/i3c/i3c_npcx.c
+++ b/drivers/i3c/i3c_npcx.c
@@ -2284,7 +2284,8 @@ static int npcx_i3c_target_xfer_end_handle(const struct device *dev)
 	const struct npcx_i3c_config *config = dev->config;
 	struct i3c_reg *inst = config->base;
 	struct mdma_reg *mdma_inst = config->mdma_base;
-	const struct i3c_target_callbacks *target_cb = data->target_config->callbacks;
+	const struct i3c_target_callbacks *target_cb =
+		(data->target_config != NULL) ? data->target_config->callbacks : NULL;
 	bool is_i3c_start = IS_BIT_SET(inst->INTMASKED, NPCX_I3C_INTMASKED_START);
 	bool is_i3c_stop = IS_BIT_SET(inst->INTMASKED, NPCX_I3C_INTMASKED_STOP);
 	enum npcx_i3c_oper_state op_state = get_oper_state(dev);
@@ -2765,7 +2766,8 @@ static void npcx_i3c_target_isr(const struct device *dev)
 	struct i3c_config_target *config_tgt = &data->config_target;
 	struct i3c_target_config *target_config = data->target_config;
 	struct i3c_reg *inst = config->base;
-	const struct i3c_target_callbacks *target_cb = data->target_config->callbacks;
+	const struct i3c_target_callbacks *target_cb =
+		(target_config != NULL) ? target_config->callbacks : NULL;
 
 #ifdef CONFIG_I3C_NPCX_DMA
 	struct mdma_reg *mdma_inst = config->mdma_base;
@@ -3159,6 +3161,7 @@ static DEVICE_API(i3c, npcx_i3c_driver_api) = {
 		.config_target.max_read_len = DT_INST_PROP_OR(id, maximum_read, 0),                \
 		.config_target.max_write_len = DT_INST_PROP_OR(id, maximum_write, 0),              \
 		.config_target.supported_hdr = false,                                              \
+		.target_config = NULL,                                                             \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(id, npcx_i3c_init, NULL, &npcx_i3c_data_##id, &npcx_i3c_config_##id, \
 			      POST_KERNEL, CONFIG_I3C_CONTROLLER_INIT_PRIORITY,                    \


### PR DESCRIPTION
data->target_config is NULL until i3c_target_register() is called by the application layer. The I3C bus master can assert a STOP condition during board init before registration occurs, firing the ISR while target_config is still NULL.

Both npcx_i3c_target_isr() and npcx_i3c_target_xfer_end_handle() unconditionally dereferenced data->target_config->callbacks, causing an MPU Instruction Access Violation when the resulting garbage pointer was used as a function pointer.

Guard the callbacks pointer derivation with a NULL check on target_config in both sites. Existing per-callback NULL guards downstream already handle the NULL case correctly.