### PR TITLE
scripts: west: fix zsh board and snippet completion

### DIFF
--- a/scripts/west_commands/completion/west-completion.zsh
+++ b/scripts/west_commands/completion/west-completion.zsh
@@ -116,7 +116,8 @@ _get_west_projs() {
 }
 
 _get_west_boards() {
-  _describe 'boards' $(__west_x boards --all-targets)
+  local -a boards=( $(__west_x boards --all-targets) )
+  _describe 'boards' boards
 }
 
 _get_west_shields() {
@@ -132,7 +133,8 @@ _get_west_shields() {
 }
 
 _get_west_snippets() {
-  _describe 'snippets' $(__west_x snippets --format='{name}')
+  local -a snippets=( $(__west_x snippets --format='{name}') )
+  _describe 'snippets' snippets
 }
 
 __west_tilde() {


### PR DESCRIPTION
Fix zsh completion for board targets and snippet names.

`_describe` expects an array name, but the completion candidates were passed directly. Store both candidate lists in local arrays first.

Fixes #111224

Tested with zsh 5.9 using the current board and snippet lists.