### PR TITLE
bluetooth: mesh: shell: dfd: report transfer progress in percent

### DIFF
--- a/subsys/bluetooth/mesh/shell/dfd.c
+++ b/subsys/bluetooth/mesh/shell/dfd.c
@@ -158,7 +158,7 @@ static int cmd_dfd_receivers_get(const struct shell *sh, size_t argc, char *argv
 	}
 
 	cnt = MIN(cnt, dfd_srv->target_cnt - first);
-	uint8_t progress = bt_mesh_dfu_cli_progress(&dfd_srv->dfu) / 2;
+	uint8_t progress = bt_mesh_dfu_cli_progress(&dfd_srv->dfu);
 
 	shell_print(sh, "{\n\t\"target_cnt\": %d,\n\t\"targets\": {",
 		    dfd_srv->target_cnt);


### PR DESCRIPTION
The "dfd receivers-get" shell command prints the firmware distribution progress under the JSON "progress" key, but first divides bt_mesh_dfu_cli_progress() by two.

bt_mesh_dfu_cli_progress() is documented to return "the progress of the current transfer in percent", i.e. a 0-100 value. The division mirrors the on-wire encoding of the Transfer Progress field in the Firmware Distribution Receivers List message, which is expressed in 2% increments (0-50, see handle_receivers_get() in dfd_srv.c). That encoding is correct for the over-the-air field, but applying it to a human-facing diagnostic command is misleading: the command reports half of the actual percentage (e.g. 25 while the transfer is at 50%).

It is also inconsistent with the Firmware Update Client shell command: cmd_dfu_tx_progress() in shell/dfu.c prints bt_mesh_dfu_cli_progress() directly as "DFU progress: %u %%", i.e. a 0-100 percentage.

Drop the division so the dfd shell reports the 0-100 percentage that the API returns, aligning it with the dfu cli command. The on-wire encoding in dfd_srv.c is intentionally left unchanged.