### PR TITLE
doc: develop: test: ztest: use non-indented bullets for fakes list

### DIFF
--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -623,15 +623,15 @@ devicetree bindings for more information:
 
 .. zephyr-keep-sorted-start
 
- - :dtcompatible:`zephyr,fake-can`
- - :dtcompatible:`zephyr,fake-comp`
- - :dtcompatible:`zephyr,fake-eeprom`
- - :dtcompatible:`zephyr,fake-leds`
- - :dtcompatible:`zephyr,fake-pwm`
- - :dtcompatible:`zephyr,fake-regulator`
- - :dtcompatible:`zephyr,fake-rtc`
- - :dtcompatible:`zephyr,fake-stepper-ctrl`
- - :dtcompatible:`zephyr,fake-stepper-driver`
+* :dtcompatible:`zephyr,fake-can`
+* :dtcompatible:`zephyr,fake-comp`
+* :dtcompatible:`zephyr,fake-eeprom`
+* :dtcompatible:`zephyr,fake-leds`
+* :dtcompatible:`zephyr,fake-pwm`
+* :dtcompatible:`zephyr,fake-regulator`
+* :dtcompatible:`zephyr,fake-rtc`
+* :dtcompatible:`zephyr,fake-stepper-ctrl`
+* :dtcompatible:`zephyr,fake-stepper-driver`
 
 .. zephyr-keep-sorted-stop
 


### PR DESCRIPTION
Use non-indented bullets for the list of zephyr,fake-* devicetree bindings.

Documentation preview: https://builds.zephyrproject.io/zephyr/pr/111227/docs/develop/test/ztest.html#mocking-via-fff

For some reason, the current list is not rendered correctly.