### PR TITLE
include: audio: add codec equalizer conf properties

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -159,6 +159,7 @@ New APIs and options
 * Audio
 
   * :c:member:`pcm_stream_cfg.gain_db`
+  * :c:struct:`audio_codec_eq_cfg`
 
 * Bluetooth
 

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -26,7 +26,25 @@ struct wm8904_driver_config {
 	int fs_ratio;
 };
 
+struct wm8904_driver_data {
+	bool eq_enabled;
+};
+
+struct wm8904_eq_band_reg {
+	uint32_t band;
+	uint8_t reg;
+};
+
+static const struct wm8904_eq_band_reg wm8904_eq_band_regs[] = {
+	{WM8904_EQ_BAND_1, WM8904_REG_EQ_B1_GAIN},
+	{WM8904_EQ_BAND_2, WM8904_REG_EQ_B2_GAIN},
+	{WM8904_EQ_BAND_3, WM8904_REG_EQ_B3_GAIN},
+	{WM8904_EQ_BAND_4, WM8904_REG_EQ_B4_GAIN},
+	{WM8904_EQ_BAND_5, WM8904_REG_EQ_B5_GAIN},
+};
+
 #define DEV_CFG(dev) ((const struct wm8904_driver_config *const)dev->config)
+#define DEV_DATA(dev) ((struct wm8904_driver_data *const)dev->data)
 
 static void wm8904_write_reg(const struct device *dev, uint8_t reg, uint16_t val);
 static void wm8904_read_reg(const struct device *dev, uint8_t reg, uint16_t *val);
@@ -554,6 +572,48 @@ static void wm8904_stop_output(const struct device *dev)
 {
 }
 
+static inline uint16_t wm8904_eq_gain_encode(int32_t gain)
+{
+	return (uint16_t)(gain - WM8904_EQ_MIN_GAIN);
+}
+
+static int wm8904_eq_config(const struct device *dev, uint32_t band, int32_t gain)
+{
+	struct wm8904_driver_data *dev_data = DEV_DATA(dev);
+	int ret = -EINVAL;
+
+	if (!dev_data->eq_enabled) {
+
+		/* Enable EQ; all bands default to 0 dB. */
+		wm8904_write_reg(dev, WM8904_REG_EQ_ENA, 0x0001);
+		dev_data->eq_enabled = true;
+
+		LOG_DBG("EQ Enabled");
+	}
+
+	if (!IN_RANGE(gain, WM8904_EQ_MIN_GAIN, WM8904_EQ_MAX_GAIN)) {
+		LOG_ERR("Invalid EQ gain: %d dB (valid range: %d to %d)", (int)gain,
+			WM8904_EQ_MIN_GAIN, WM8904_EQ_MAX_GAIN);
+	} else {
+		for (size_t i = 0U; i < ARRAY_SIZE(wm8904_eq_band_regs); i++) {
+			if (wm8904_eq_band_regs[i].band == band) {
+				uint16_t encoded = wm8904_eq_gain_encode(gain);
+
+				LOG_DBG("EQ band %u (%u Hz) gain: %d dB, hex: 0x%04X",
+					(unsigned int)(i + 1U), band, (int)gain, encoded);
+				wm8904_write_reg(dev, wm8904_eq_band_regs[i].reg, encoded);
+				ret = 0;
+				break;
+			}
+		}
+		if (ret != 0) {
+			LOG_ERR("Invalid EQ band: %u Hz", band);
+		}
+	}
+
+	return ret;
+}
+
 static int wm8904_set_property(const struct device *dev, audio_property_t property,
 			       audio_channel_t channel, audio_property_value_t val)
 {
@@ -569,6 +629,12 @@ static int wm8904_set_property(const struct device *dev, audio_property_t proper
 
 	case AUDIO_PROPERTY_INPUT_MUTE:
 		return wm8904_in_mute_config(dev, channel, val.mute);
+
+	case AUDIO_PROPERTY_EQ_GAIN: {
+		struct audio_codec_eq_cfg *eq = &val.eq;
+
+		return wm8904_eq_config(dev, eq->band, eq->gain);
+	}
 	}
 
 	return -EINVAL;
@@ -682,6 +748,8 @@ static DEVICE_API(audio_codec, wm8904_driver_api) = {
 };
 
 #define WM8904_INIT(n)                                                                             \
+	struct wm8904_driver_data wm8904_device_data_##n = {                                       \
+		.eq_enabled = false};                                                              \
 	static const struct wm8904_driver_config wm8904_device_config_##n = {                      \
 		.i2c = I2C_DT_SPEC_INST_GET(n),                                                    \
 		.clock_source = DT_INST_ENUM_IDX(n, clock_source),                                 \
@@ -692,7 +760,7 @@ static DEVICE_API(audio_codec, wm8904_driver_api) = {
 			(NULL)),                                                                   \
 		.fs_ratio = DT_INST_PROP_OR(n, fs_ratio, 0)};                                      \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, &wm8904_device_config_##n, POST_KERNEL,         \
-			      CONFIG_AUDIO_CODEC_INIT_PRIORITY, &wm8904_driver_api);
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, &wm8904_device_data_##n, &wm8904_device_config_##n,   \
+			      POST_KERNEL, CONFIG_AUDIO_CODEC_INIT_PRIORITY, &wm8904_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(WM8904_INIT)

--- a/drivers/audio/wm8904.h
+++ b/drivers/audio/wm8904.h
@@ -48,11 +48,19 @@
 #define WM8904_REG_ANALOG_OUT2_RIGHT        (0x3C)
 #define WM8904_REG_GPIO_CONTROL_4           (0x7C)
 /* FLL control register */
-#define WM8904_REG_FLL_CONTROL_1 (0x74)
-#define WM8904_REG_FLL_CONTROL_2 (0x75)
-#define WM8904_REG_FLL_CONTROL_3 (0x76)
-#define WM8904_REG_FLL_CONTROL_4 (0x77)
-#define WM8904_REG_FLL_CONTROL_5 (0x78)
+#define WM8904_REG_FLL_CONTROL_1            (0x74)
+#define WM8904_REG_FLL_CONTROL_2            (0x75)
+#define WM8904_REG_FLL_CONTROL_3            (0x76)
+#define WM8904_REG_FLL_CONTROL_4            (0x77)
+#define WM8904_REG_FLL_CONTROL_5            (0x78)
+/* EQ register */
+#define WM8904_REG_EQ_ENA                   (0x86)
+#define WM8904_REG_EQ_B1_GAIN               (0x87)
+#define WM8904_REG_EQ_B2_GAIN               (0x88)
+#define WM8904_REG_EQ_B3_GAIN               (0x89)
+#define WM8904_REG_EQ_B4_GAIN               (0x8A)
+#define WM8904_REG_EQ_B5_GAIN               (0x8B)
+
 /* GPIO control register */
 #define WM8904_REG_GPIO_CONTROL_1 (0x79)
 #define WM8904_REG_GPIO_CONTROL_2 (0x7A)
@@ -113,6 +121,15 @@
 #define WM8904_MAP_HEADPHONE_LINEOUT_MAX_VOLUME 0x3FU
 #define WM8904_DAC_MAX_VOLUME                   0xC0U
 
+/* EQ Bands in Hz */
+#define WM8904_EQ_BAND_1   100U
+#define WM8904_EQ_BAND_2   300U
+#define WM8904_EQ_BAND_3   875U
+#define WM8904_EQ_BAND_4   2400U
+#define WM8904_EQ_BAND_5   6900U
+/* EQ MAX/MIN Gain in dB */
+#define WM8904_EQ_MAX_GAIN 12
+#define WM8904_EQ_MIN_GAIN -12
 
 /*! @brief The audio data transfer protocol. */
 typedef enum _wm8904_protocol {

--- a/include/zephyr/audio/codec.h
+++ b/include/zephyr/audio/codec.h
@@ -77,7 +77,8 @@ typedef enum {
 	AUDIO_PROPERTY_OUTPUT_VOLUME, /**< Output volume */
 	AUDIO_PROPERTY_OUTPUT_MUTE,   /**< Output mute/unmute */
 	AUDIO_PROPERTY_INPUT_VOLUME,  /**< Input volume */
-	AUDIO_PROPERTY_INPUT_MUTE     /**< Input mute/unmute */
+	AUDIO_PROPERTY_INPUT_MUTE,    /**< Input mute/unmute */
+	AUDIO_PROPERTY_EQ_GAIN        /**< Output equalizer gain */
 } audio_property_t;
 
 /**
@@ -175,11 +176,20 @@ struct audio_codec_cfg {
 };
 
 /**
+ * Codec EQ property values
+ */
+struct audio_codec_eq_cfg {
+	uint32_t band; /**< EQ band center frequency in Hz, must match a supported codec EQ band. */
+	int32_t gain;  /**< EQ band gain in dB, codec-specific range. */
+};
+
+/**
  * Codec property values
  */
 typedef union {
-	int vol;   /**< Volume level (codec-specific) */
-	bool mute; /**< Mute if @a true, unmute if @a false */
+	int vol;                      /**< Volume level (codec-specific) */
+	bool mute;                    /**< Mute if @a true, unmute if @a false */
+	struct audio_codec_eq_cfg eq; /**< Codec Equalizer settings */
 } audio_property_value_t;
 
 /**


### PR DESCRIPTION
This PR adds EQ conf properties to codec.h and enables EQ support to WM8904

Tested on STM32N6570-DK


https://github.com/user-attachments/assets/6523b7f6-6d37-4495-a9fb-f1c8c8498307

