### PR TITLE
boards: armfly: stm32h743xih6: add onboard peripherals

### DIFF
--- a/boards/armfly/stm32h743xih6/armfly_stm32h743xih6.dts
+++ b/boards/armfly/stm32h743xih6/armfly_stm32h743xih6.dts
@@ -131,13 +131,14 @@
 		sw6 = &joy_up;
 		sw7 = &joy_left;
 		backlight-pwm = &lcd_bl_pwm;
+		eeprom-0 = &eeprom0;
 	};
 
 	backlight_pwm: backlight {
 		compatible = "pwm-leds";
 
 		lcd_bl_pwm: bl0 {
-			pwms = <&tim1_pwm 1 PWM_USEC(20000) PWM_POLARITY_NORMAL>;
+			pwms = <&tim1_pwm 1 PWM_USEC(50) PWM_POLARITY_NORMAL>;
 			label = "lcd_backlight_pwm";
 		};
 	};
@@ -225,6 +226,61 @@
 		reg = <0x5d>;
 		irq-gpios = <&gpioh 7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		alt-addr = <0x14>;
+	};
+
+	mpu6050: mpu6050@68 {
+		compatible = "invensense,mpu6050";
+		reg = <0x68>;
+		status = "okay";
+		accel-fs = <2>;
+		gyro-fs = <250>;
+		smplrt-div = <249>;
+	};
+
+	bh1750: bh1750@23 {
+		compatible = "rohm,bh1750";
+		reg = <0x23>;
+		status = "okay";
+		resolution = <1>;
+		mtreg = <69>;
+	};
+
+	bmp180: bmp180@77 {
+		compatible = "bosch,bmp180";
+		reg = <0x77>;
+		status = "okay";
+		osr-press = <3>;
+	};
+
+	eeprom0: eeprom@50 {
+		compatible = "atmel,at24";
+		reg = <0x50>;
+		size = <DT_SIZE_K(16)>;
+		pagesize = <64>;
+		address-width = <16>;
+		timeout = <5>;
+		status = "okay";
+	};
+};
+
+&quadspi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&quadspi_clk_pf10 &quadspi_bk1_ncs_pg6
+		     &quadspi_bk1_io0_pf8 &quadspi_bk1_io1_pf9
+		     &quadspi_bk1_io2_pf7 &quadspi_bk1_io3_pf6>;
+
+	flash-id = <1>;
+	status = "okay";
+
+	w25q256_qspi: qspi-nor-flash@0 {
+		compatible = "st,stm32-qspi-nor";
+		reg = <0>;
+		size = <DT_SIZE_M(256)>; /* 256 Mbits */
+		qspi-max-frequency = <100000000>;
+		cs-high-time = <1>;
+		status = "okay";
+		spi-bus-width = <4>;
+		writeoc = "PP_1_1_4";
 	};
 };
 

--- a/boards/armfly/stm32h743xih6/doc/index.rst
+++ b/boards/armfly/stm32h743xih6/doc/index.rst
@@ -97,8 +97,10 @@ The current board definition enables or describes the following hardware blocks:
 - USART1 console
 - GPIO keys
 - Optional board-private FMC latch GPIO controller for the onboard LEDs
-- I2C1 with the GT911 touch controller
+- I2C1 with the GT911 touch controller, MPU6050 motion sensor, BH1750
+  ambient light sensor, BMP180 pressure sensor, and AT24C128 EEPROM
 - SPI3 with SPI NOR flash
+- QUADSPI with QSPI NOR flash
 - SDMMC1 for the MicroSD socket
 - LTDC display controller using external SDRAM
 - PWM-based LCD backlight control
@@ -120,6 +122,7 @@ Default Zephyr peripheral mapping:
 - USART1 TX/RX: PA9 / PA10
 - I2C1 SCL/SDA: PB6 / PB9
 - GT911 INT: PH7
+- QUADSPI CLK/NCS/IO0/IO1/IO2/IO3: PF10 / PG6 / PF8 / PF9 / PF7 / PF6
 - SPI3 SCK/MISO/MOSI: PB3 / PB4 / PB5
 - SPI3 CS: PD13
 - SDMMC1 D0-D3/CK/CMD: PC8 / PC9 / PC10 / PC11 / PC12 / PD2
@@ -147,6 +150,17 @@ touch device through ``zephyr,touch``.
 
 The LVGL pointer pseudo-device is intentionally not part of the base board DTS.
 Applications that use LVGL can provide it in an overlay when needed.
+
+I2C Devices
+===========
+
+The board DTS describes the onboard I2C devices connected to ``I2C1``:
+
+- GT911 touch controller at address ``0x5d``
+- MPU6050 motion sensor at address ``0x68``
+- BH1750 ambient light sensor at address ``0x23``
+- BMP180 pressure sensor at address ``0x77``
+- AT24C128 EEPROM at address ``0x50``
 
 Serial Port
 ===========


### PR DESCRIPTION
Add board descriptions for additional onboard peripherals on the Armfly
STM32H743XIH6 board:

- W25Q256 QSPI NOR flash
- MPU6050 motion sensor
- BH1750 ambient light sensor
- BMP180 pressure sensor
- AT24C128 EEPROM
- Document the newly described peripherals and QSPI pin mapping