### PR TITLE
nxp: enable OS event timer (OSTIMER) as kernel timer on MCXN54x/N94x and MCXW23

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -235,13 +235,13 @@ arduino_serial: &flexcomm2_lpuart2 {};
 	};
 };
 
-/*
- * MCXN947 board uses OS timer as the kernel timer
- * In case we need to switch to SYSTICK timer, then
- * replace &os_timer with &systick
+/* The MCXN947 can use ostimer as the kernel timer.
+ * We enable it in the dts, and which specific timer
+ * to use as the system timer can be controlled through
+ * Kconfig option based on application requirements.
  */
 &os_timer {
-	status = "disabled";
+	status = "okay";
 };
 
 &systick {

--- a/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk.dtsi
+++ b/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk.dtsi
@@ -119,13 +119,13 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
-/*
- * MCXN947 board uses OS timer as the kernel timer
- * In case we need to switch to SYSTICK timer, then
- * replace &os_timer with &systick
+/* The MCXNx4x (MCXN547/MCXN947) can use ostimer as the kernel timer.
+ * We enable it in the dts, and which specific timer
+ * to use as the system timer can be controlled through
+ * Kconfig option based on application requirements.
  */
 &os_timer {
-	status = "disabled";
+	status = "okay";
 };
 
 &systick {

--- a/dts/arm/nxp/mcx/nxp_mcxw23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw23x_common.dtsi
@@ -82,6 +82,16 @@
 		clock-frequency = <32000000>;
 		#clock-cells = <0>;
 	};
+
+	/*
+	 * 32.768 kHz RTC oscillator (RTCOSC32K) that clocks the OS event timer
+	 * when OSTIMER is selected as the system timer (MCXW23 RM 45.4.11.2.24).
+	 */
+	clk_32k: clock-32k {
+		compatible = "fixed-clock";
+		clock-frequency = <32768>;
+		#clock-cells = <0>;
+	};
 };
 
 &sram {

--- a/soc/nxp/mcx/mcxw/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/Kconfig.defconfig
@@ -5,8 +5,11 @@ rsource "*/Kconfig.defconfig"
 
 if SOC_FAMILY_MCXW
 
+# Ensure SysTick is not enabled by default if another system timer is selected.
+# OS timer stays off by default on MCXW (reserved as a low-power companion),
+# but this lets it be selected as the system timer without a SysTick conflict.
 config CORTEX_M_SYSTICK
-	default n if MCUX_LPTMR_TIMER
+	default n if (MCUX_LPTMR_TIMER || MCUX_OS_TIMER)
 
 config OPENTHREAD_PLATFORM_CSL_UNCERT
 	default 20 if OPENTHREAD

--- a/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig.defconfig
@@ -19,11 +19,22 @@ config NUM_IRQS
 	default 61
 
 DT_SYSCLK_PATH := $(dt_nodelabel_path,sysclk)
+DT_OSTIMER_CLK_PATH := $(dt_nodelabel_path,clk_32k)
 
 configdefault SYS_CLOCK_HW_CYCLES_PER_SEC
+	# MCXW23 clocks the OS event timer from the 32.768 kHz RTC oscillator (PMC
+	# OSTIMERCLKSEL resets to 32.768 kHz and the HAL never reselects it; MCXW23
+	# RM 45.4.11.2.24), unlike other NXP parts where OSTIMER is 1 MHz. The rate
+	# is taken from the clk_32k fixed-clock node rather than hardcoded. Note:
+	# selecting OSTIMER trades timing precision (~1 ms tick, ~30 us resolution)
+	# for low-power always-on operation, so SysTick stays the default where
+	# fine-grained timing is needed.
+	default $(dt_node_int_prop_int,$(DT_OSTIMER_CLK_PATH),clock-frequency) if MCUX_OS_TIMER
 	default $(dt_node_int_prop_int,$(DT_SYSCLK_PATH),clock-frequency) if CORTEX_M_SYSTICK
 
 configdefault SYS_CLOCK_TICKS_PER_SEC
+	# 32.768 kHz / 1024 = 32 cycles per tick exactly when OSTIMER is the timer.
+	default 1024 if MCUX_OS_TIMER
 	default 1000 if PM
 
 # Set to the minimal size of data which can be written.


### PR DESCRIPTION
## Description

Enable the NXP OS event timer (OSTIMER, `nxp,os-timer` / `mcux_os_timer`) as a
selectable Zephyr kernel system timer on the MCXN54x/MCXN94x and MCXW23 SoCs.
OSTIMER stays **opt-in**; the existing default kernel timer (SysTick) is
unchanged on every affected board.

Two independent commits:

1. **`boards: nxp: enable OS timer on MCXN54x/N94x boards`**
   `frdm_mcxn947` and `mcx_nx4x_evk` (MCX-N5XX-EVK / MCX-N9XX-EVK) left the
   `&os_timer` node `disabled`, so OSTIMER could not be selected as the kernel
   timer even though the SoC supports it. Enable the node (matching
   `frdm_mcxn236`). SysTick remains the default; OSTIMER becomes available via
   `CONFIG_MCUX_OS_TIMER`.

2. **`soc: nxp: mcxw: support OS timer as kernel timer on MCXW23`**
   On MCXW23 the OS event timer is reserved as the low-power companion to
   SysTick and could not be used as the system timer: selecting
   `CONFIG_MCUX_OS_TIMER` left `CORTEX_M_SYSTICK` enabled (duplicate
   `sys_clock_*` symbols → link failure) and no OS-timer clock rate was
   defined. This commit disables `CORTEX_M_SYSTICK` by default when
   `MCUX_OS_TIMER` is selected (as already done for `MCUX_LPTMR_TIMER`) and
   defines the rate.

## MCXW23 OSTIMER clock rate (32.768 kHz, not 1 MHz)

Unlike other NXP parts where OSTIMER runs at 1 MHz, the MCXW23 OS event timer
is clocked from the **32.768 kHz** RTC oscillator: the PMC `OSTIMERCLKSEL`
field resets to 32.768 kHz and is left at reset (the HAL only enables, never
reselects, the OS timer clock; `mcxw2xx/power.c` also documents "OS_TIMER uses
32K clock"). Ref: MCXW23 RM §45.4.11.2.24. Hence:
- `SYS_CLOCK_HW_CYCLES_PER_SEC = 32768`
- `SYS_CLOCK_TICKS_PER_SEC = 1024` (exactly 32 cycles/tick; 10000 would not
  divide 32768)

## Default behavior is unchanged

Both MCXW defaults are gated on `MCUX_OS_TIMER` (off by default), and the MCXN
change only makes the node available. A before/after **default `.config` diff**
is byte-identical for the system-timer selection on `frdm_mcxw23` and
`frdm_mcxw72` (the latter confirms the family-level Kconfig edit doesn't disturb
the LPTMR-based MCXW7xx parts), and on the MCXN boards the only delta is
`MCUX_OS_TIMER` appearing as an available-but-disabled option — `SysTick`,
frequency, and tick rate are identical.

## Testing

Build-only validation (`samples/hello_world`, Zephyr SDK):

| Check | Result |
|---|---|
| OSTIMER as system timer (`CONFIG_MCUX_OS_TIMER=y`) | builds on MCXN547, MCXN947 (cpu0/cpu1), MCXN236, RW612 (×3), RT595/685/700; SysTick auto-disabled, single timer |
| MCXW23 OSTIMER | builds; `HZ=32768`, `TICKS=1024` (exact) |
| Default (SysTick) regression | all changed boards build unchanged |
| Before/after default `.config` | system-timer selection unchanged (byte-identical / availability-only delta) |
