### PR TITLE
twister: support `preferred_toolchain` for toolchain coverage

### DIFF
--- a/boards/qemu/riscv32e/qemu_riscv32e.yaml
+++ b/boards/qemu/riscv32e/qemu_riscv32e.yaml
@@ -6,6 +6,7 @@ simulation:
 arch: riscv
 toolchain:
   - zephyr
+preferred_toolchain: zephyr/llvm
 supported:
   - netif
 ram: 262144

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -154,6 +154,10 @@ class Platform:
         if self.supported_toolchains is None:
             self.supported_toolchains = []
 
+        self.preferred_toolchain = variant_data.get("preferred_toolchain",
+                                                    data.get("preferred_toolchain",
+                                                             None))
+
         support_toolchain_variants = {
           # we don't provide defaults for 'arc' intentionally: some targets can't be built with GNU
           # toolchain ("zephyr", "cross-compile" options) and for some targets we haven't provided

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -963,6 +963,8 @@ class TestPlan:
                         toolchain = 'host/llvm'
                     else:
                         toolchain = 'host/gnu'
+                elif plat.preferred_toolchain:
+                    toolchain = plat.preferred_toolchain
                 else:
                     toolchain = "zephyr" if not self.env.toolchain else self.env.toolchain
 

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -67,6 +67,8 @@ $defs:
         type: string
       tier:
         type: integer
+      preferred_toolchain:
+        type: string
       toolchain:
         type: array
         items:


### PR DESCRIPTION
- **twister: support preferred toolchain for a platform**
- **boards: qemu_riscv32e: prefer zephyr/llvm**
