### PR TITLE
samples: rtio: sensor_batch_processing: check rtio_sqe_acquire() return

### DIFF
--- a/samples/subsys/rtio/sensor_batch_processing/src/main.c
+++ b/samples/subsys/rtio/sensor_batch_processing/src/main.c
@@ -31,6 +31,11 @@ int main(void)
 	for (int n = 0; n < N; n++) {
 		struct rtio_sqe *sqe = rtio_sqe_acquire(&ez_io);
 
+		if (sqe == NULL) {
+			LOG_ERR("Failed to acquire a submission queue event");
+			return -ENOMEM;
+		}
+
 		rtio_sqe_prep_read_with_pool(sqe, iodev, RTIO_PRIO_HIGH, NULL);
 	}
 
@@ -85,6 +90,11 @@ int main(void)
 		 */
 		for (m = 0; m < M; m++) {
 			struct rtio_sqe *sqe = rtio_sqe_acquire(&ez_io);
+
+			if (sqe == NULL) {
+				LOG_ERR("Failed to acquire a submission queue event");
+				return -ENOMEM;
+			}
 
 			rtio_release_buffer(&ez_io, userdata[m], data_len[m]);
 			rtio_sqe_prep_read_with_pool(sqe, iodev, RTIO_PRIO_HIGH, NULL);


### PR DESCRIPTION
rtio_sqe_acquire() returns NULL when no submission queue event is available, but the sample passed the result straight into rtio_sqe_prep_read_with_pool() without checking it. That helper calls rtio_sqe_prep_read(), which does memset(sqe, 0, sizeof(*sqe)), so a NULL sqe turns into a write to a near-NULL address.

On frdm_imxrt1186/mimxrt1186/cm7 the first acquire in the queue-fill loop returns NULL, and the unchecked dereference faults:

  E: ***** MPU FAULT *****
  E:   Data Access Violation
  E:   MMFAR Address: 0x2
  E: Faulting instruction address (r15/pc): 0x000004b6

The faulting pc is inside memset() and the call returns into main() at the rtio_sqe_prep_read_with_pool() site (lr 0x10dd, r0 0x2, r2 46), confirming sqe was NULL.

Check the return value in both the initial fill loop and the recycle loop and bail out with -ENOMEM and a clear log message instead of dereferencing NULL. This turns an unrecoverable hard fault into a diagnosable error on platforms that cannot satisfy the request.

Fixes #110245