### PR TITLE
net: http: server: re-poll on spurious zsock_poll() return of 0

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -1426,7 +1426,15 @@ static int http_server_run(struct http_server_ctx *ctx)
 		}
 
 		if (ret == 0) {
-			break; /* timeout -1 should never produce 0, but be safe */
+			/* With an infinite timeout zsock_poll() can still return
+			 * 0 when a wake source fired but no fd reported an event.
+			 * Re-poll instead of breaking: the break path skips
+			 * close_all_sockets(), leaking the sockets and leaving
+			 * the client inactivity timers armed, which the caller's
+			 * re-init then memsets - corrupting the kernel timeout
+			 * list.
+			 */
+			continue;
 		}
 
 		/* Stop event on fds[0] */


### PR DESCRIPTION
Fixes #111238

`http_server_run()` polls with an infinite timeout and treats a
`zsock_poll()` return of `0` as "should never happen", breaking out of
the loop. It can happen (spurious wakeup: `k_poll()` wakes but no fd
reports an event), and the `break` returns `0` without taking the
`closing:` path, so `close_all_sockets()` is skipped. This leaks the
sockets and leaves the per-client inactivity timers armed in the kernel
timeout list; the server thread then re-inits and `memset()`s the
client array over those still-armed timeouts, corrupting the kernel
timeout list and causing a delayed fault.

Re-poll instead of breaking. With an infinite timeout, polling again is
always correct and leaves the sockets and their timers intact.

See #111238 for the full analysis.
