### PR TITLE
fs: ext2: bound superblock block size on mount

### DIFF
--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -262,6 +262,17 @@ int ext2_verify_disk_superblock(struct ext2_disk_superblock *sb)
 		return -EINVAL;
 	}
 
+	/* Block size is computed as 1024 << s_log_block_size and is used to size
+	 * the static block slab. A crafted value would overflow the shift and/or
+	 * exceed the statically configured maximum block size, corrupting the
+	 * allocator. The first term guards the shift against undefined behaviour.
+	 */
+	if (sys_le32_to_cpu(sb->s_log_block_size) > 11U ||
+	    (1024U << sys_le32_to_cpu(sb->s_log_block_size)) > CONFIG_EXT2_MAX_BLOCK_SIZE) {
+		LOG_ERR("Filesystem block size is too large");
+		return -ENOTSUP;
+	}
+
 	/* Check if file system may contain errors. */
 	if (sys_le16_to_cpu(sb->s_state) == EXT2_ERROR_FS) {
 		LOG_WRN("File system may contain errors.");


### PR DESCRIPTION
ext2_verify_disk_superblock() never validated s_log_block_size. A
crafted image could set it so that 1024 << s_log_block_size overflows
the shift or exceeds CONFIG_EXT2_MAX_BLOCK_SIZE, corrupting the static
block slab and leading to heap overflow on the first block read.

Reject block sizes that overflow the shift or exceed the configured
maximum.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>

Fixes: #113324