### PR TITLE
net: ocpp: multiple fixes

### DIFF
--- a/subsys/net/lib/ocpp/ocpp.c
+++ b/subsys/net/lib/ocpp/ocpp.c
@@ -357,6 +357,10 @@ static int ocpp_process_server_msg(struct ocpp_info *ctx)
 
 	if (is_rsp) {
 		buf = strtok_r(uid, "-", &tmp);
+		/* strtok_r returns NULL when no '-' is present; atoi(NULL) is UB. */
+		if (buf == NULL) {
+			return -EINVAL;
+		}
 		sh = (struct ocpp_session *)(uintptr_t)atoi(buf);
 
 		buf = strtok_r(NULL, "-", &tmp);

--- a/subsys/net/lib/ocpp/ocpp_j.c
+++ b/subsys/net/lib/ocpp/ocpp_j.c
@@ -774,7 +774,8 @@ static int parse_remote_start_txn_msg(char *json,
 		return -EINVAL;
 	}
 
-	strncpy(idtag, payload.val2, CISTR50);
+	strncpy(idtag, payload.val2, CISTR50 - 1);
+	idtag[CISTR50 - 1] = '\0';
 	*idcon = payload.val1;
 
 	return 0;

--- a/subsys/net/lib/ocpp/ocpp_j.c
+++ b/subsys/net/lib/ocpp/ocpp_j.c
@@ -715,7 +715,8 @@ static int parse_getconfig_msg(char *json, char *key)
 
 	/* key is optional so return success*/
 	if (payload.key[0] != NULL) {
-		strcpy(key, payload.key[0]);
+		strncpy(key, payload.key[0], CISTR50 - 1);
+		key[CISTR50 - 1] = '\0';
 	}
 
 	return 0;


### PR DESCRIPTION
parse_getconfig_msg() copied the attacker-controlled "key" JSON field
into the caller's CISTR50 buffer with strcpy(), allowing an OCPP server
(or MITM) to smash the stack with an oversized field.

-> Use strncpy bounded to CISTR50 and NUL-terminate, matching the sibling
handlers.

ocpp_process_server_msg() called atoi(strtok_r(uid, "-", &tmp)) without
checking for NULL. When the CALLRESULT uid contains no '-' delimiter
strtok_r returns NULL and atoi(NULL) is undefined behaviour.

-> Return -EINVAL when the delimiter is absent.

parse_remote_start_txn_msg() used strncpy(idtag, payload.val2, CISTR50)
without forcing NUL termination, so a source string >= 50 bytes left
idtag unterminated. Use CISTR50 - 1 as the bound and set idtag[CISTR50 - 1] = '\0'.

Fixes: #113328