### PR TITLE
include: dt-bindings: reset: stm32: improve doxygen documentation

### DIFF
--- a/dts/arm/st/u5/stm32u599.dtsi
+++ b/dts/arm/st/u5/stm32u599.dtsi
@@ -31,11 +31,11 @@
 			#size-cells = <0>;
 			reg = <0x40016c00 0x1000>;
 			clock-names = "dsiclk", "dsisrc", "refclk", "pixelclk";
-			clocks = <&rcc STM32_CLOCK(APB2, 27U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 27)>,
 				 <&rcc STM32_SRC_DSIPHY DSI_SEL(1)>,
 				 <&rcc STM32_SRC_HSE NO_SEL>,
 				 <&rcc STM32_SRC_PLL3_R NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 27U)>;
+			resets = <&rctl STM32_RESET(APB2, 27)>;
 			status = "disabled";
 		};
 

--- a/include/zephyr/dt-bindings/reset/stm32-common.h
+++ b/include/zephyr/dt-bindings/reset/stm32-common.h
@@ -4,19 +4,55 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree common helper macros
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32_RESET_COMMON_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32_RESET_COMMON_H_
 
 /**
- * Pack RCC register offset and bit in one 32-bit value.
+ * @defgroup reset_controller_stm32 STM32 reset controller helpers
+ * @ingroup reset_controller_interface
  *
- * 5 LSBs are used to keep bit number in 32-bit RCC register.
- * Next 12 bits are used to keep RCC register offset.
- * Remaining bits are unused.
+ * @brief Macros for encoding STM32 peripheral reset cells.
  *
- * @param bus STM32 bus name (expands to STM32_RESET_BUS_{bus})
- * @param bit Reset bit
+ * Devicetree macro for encoding peripheral reset cells on STM32 devices, for use with the
+ * <tt>st,stm32-rcc-rctl</tt> compatible reset controller.
+ *
+ * Each SoC family header (for example @c stm32h5_reset.h) defines the RCC bus reset register
+ * offsets for that family as @c STM32_RESET_BUS_<bus> constants. A peripheral reset cell is then
+ * encoded with @c STM32_RESET() by combining a bus constant with the bit position of the
+ * peripheral's reset line within that bus reset register.
+ *
+ * @note STM32MP1 and STM32MP13 redefine @c STM32_RESET() with separate SET/CLEAR offsets. STM32MP2
+ * uses per-peripheral registers.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/reset/stm32h5_reset.h>
+ *
+ * &usart1 {
+ *         resets = <&rctl STM32_RESET(APB2, 14)>;
+ * };
+ * @endcode
+ * @{
+ */
+
+/**
+ * @brief Encode a peripheral reset cell value for the <tt>st,stm32-rcc-rctl</tt> binding.
+ *
+ * Packs an RCC bus register offset and a bit position into one 32-bit reset cell value.
+ *
+ * Bits [4:0] hold the reset bit position within the 32-bit RCC bus register;
+ * bits [16:5] hold the RCC register byte offset relative to the RCC base address.
+ *
+ * @param bus RCC bus name.
+ * @param bit Bit position of the peripheral's reset line within the bus reset register
  */
 #define STM32_RESET(bus, bit) (((STM32_RESET_BUS_##bus) << 5U) | (bit))
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32_RESET_COMMON_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32c0_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32c0_reset.h
@@ -5,15 +5,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32C0
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32C0_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32C0_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_IOP   0x24
 #define STM32_RESET_BUS_AHB1  0x28
 #define STM32_RESET_BUS_APB1L 0x2C
 #define STM32_RESET_BUS_APB1H 0x30
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32C0_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32c5_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32c5_reset.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief DT bindings for STM32C5 reset system
+ * @brief STM32 reset controller devicetree helper macros for STM32C5
+ * @ingroup reset_controller_stm32
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32C5_RESET_H_

--- a/include/zephyr/dt-bindings/reset/stm32f0_1_3_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32f0_1_3_reset.h
@@ -4,14 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32F0/F1/F3
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32F0_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32F0_RESET_H_
 
 #include "stm32-common.h"
 
+/** @cond INTERNAL_HIDDEN */
+
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1 0x28
 #define STM32_RESET_BUS_APB1 0x10
 #define STM32_RESET_BUS_APB2 0x0C
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32F0_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32f2_4_7_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32f2_4_7_reset.h
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32F2/F4/F7
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32F2_4_7_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32F2_4_7_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1 0x10
@@ -15,5 +23,7 @@
 #define STM32_RESET_BUS_AHB3 0x18
 #define STM32_RESET_BUS_APB1 0x20
 #define STM32_RESET_BUS_APB2 0x24
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32F2_4_7_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32g0_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32g0_reset.h
@@ -4,15 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32G0
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32G0_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32G0_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_IOP   0x24
 #define STM32_RESET_BUS_AHB1  0x28
 #define STM32_RESET_BUS_APB1L 0x2C
 #define STM32_RESET_BUS_APB1H 0x30
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32G0_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32g4_l4_5_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32g4_l4_5_reset.h
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32G4/L4/L5
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32G4_L4_5_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32G4_L4_5_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1  0x28
@@ -16,5 +24,7 @@
 #define STM32_RESET_BUS_APB1L 0x38
 #define STM32_RESET_BUS_APB1H 0x3C
 #define STM32_RESET_BUS_APB2  0x40
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32G4_L4_5_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32h5_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32h5_reset.h
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32H5
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32H5_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32H5_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1  0x60
@@ -17,5 +25,7 @@
 #define STM32_RESET_BUS_APB1H 0x78
 #define STM32_RESET_BUS_APB2  0x7C
 #define STM32_RESET_BUS_APB3  0x80
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32H5_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32h7_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32h7_reset.h
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32H7
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32H7_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32H7_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1  0x80
@@ -19,5 +27,7 @@
 #define STM32_RESET_BUS_APB2  0x98
 #define STM32_RESET_BUS_APB3  0x8C
 #define STM32_RESET_BUS_APB4  0x9C
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32H7_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32h7rs_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32h7rs_reset.h
@@ -5,10 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32H7RS
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32H7RS_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32H7RS_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1  0x80
@@ -21,5 +29,7 @@
 #define STM32_RESET_BUS_APB1H 0x94
 #define STM32_RESET_BUS_APB2  0x98
 #define STM32_RESET_BUS_APB4  0x9C
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32H7RS_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32l0_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32l0_reset.h
@@ -4,15 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32L0
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32L0_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32L0_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_IOP  0x1C
 #define STM32_RESET_BUS_AHB1 0x20
 #define STM32_RESET_BUS_APB1 0x28
 #define STM32_RESET_BUS_APB2 0x24
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32L0_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32l1_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32l1_reset.h
@@ -4,14 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32L1
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32L1_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32L1_RESET_H_
 
 #include "stm32-common.h"
 
+/** @cond INTERNAL_HIDDEN */
+
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1 0x10
 #define STM32_RESET_BUS_APB1 0x18
 #define STM32_RESET_BUS_APB2 0x14
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32L1_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32mp13_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32mp13_reset.h
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32MP13
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32MP13_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32MP13_RESET_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * Pack RCC register offset and bit in one 32-bit value.
@@ -41,5 +49,7 @@
 #define STM32_RESET_BUS_APB5_CLR   0x6C4
 #define STM32_RESET_BUS_APB6_SET   0x6C8
 #define STM32_RESET_BUS_APB6_CLR   0x6CC
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32MP13_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32mp1_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32mp1_reset.h
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32MP1
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32MP1_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32MP1_RESET_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * Pack RCC register offset and bit in one 32-bit value.
@@ -43,5 +51,7 @@
 #define STM32_RESET_BUS_APB4_CLR   0x184
 #define STM32_RESET_BUS_APB5_SET   0x188
 #define STM32_RESET_BUS_APB5_CLR   0x18C
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32MP1_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32mp2_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32mp2_reset.h
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32MP2
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32MP2_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32MP2_RESET_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * Pack RCC register offset and bit in one 32-bit value.
@@ -38,5 +46,7 @@
 #define STM32_RESET_PERIPH_I3C2		0x8CC
 #define STM32_RESET_PERIPH_I3C3		0x8D0
 #define STM32_RESET_PERIPH_I3C4		0x8D4
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32MP2_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32n6_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32n6_reset.h
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32N6
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32N6_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32N6_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1	0x210
@@ -21,5 +29,7 @@
 #define STM32_RESET_BUS_APB4L	0x234
 #define STM32_RESET_BUS_APB4H	0x238
 #define STM32_RESET_BUS_APB5	0x23C
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32N6_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32u0_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32u0_reset.h
@@ -4,15 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32U0
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32U0_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32U0_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_IOP   0x2C
 #define STM32_RESET_BUS_AHB1  0x28
 #define STM32_RESET_BUS_APB1L 0x38
 #define STM32_RESET_BUS_APB1H 0x40
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32U0_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32u3_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32u3_reset.h
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32U3
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32U3_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32U3_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1  0x060
@@ -17,5 +25,7 @@
 #define STM32_RESET_BUS_APB1H 0x078
 #define STM32_RESET_BUS_APB2  0x07C
 #define STM32_RESET_BUS_APB3  0x080
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32U3_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32u5_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32u5_reset.h
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32U5
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32U5_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32U5_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1  0x60
@@ -18,5 +26,7 @@
 #define STM32_RESET_BUS_APB1H 0x78
 #define STM32_RESET_BUS_APB2  0x7C
 #define STM32_RESET_BUS_APB3  0x80
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32U5_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32wb0_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32wb0_reset.h
@@ -4,15 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32WB0
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32WB0_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32WB0_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB0	0x30
 #define STM32_RESET_BUS_APB0	0x34
 #define STM32_RESET_BUS_APB1	0x38
 #define STM32_RESET_BUS_APB2	0x3C
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32WB0_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32wb_l_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32wb_l_reset.h
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32WB/WL
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32WB_L_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32WB_L_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1  0x28
@@ -17,5 +25,7 @@
 #define STM32_RESET_BUS_APB1H 0x3C
 #define STM32_RESET_BUS_APB2  0x40
 #define STM32_RESET_BUS_APB3  0x44
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32WB_L_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32wba_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32wba_reset.h
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief STM32 reset controller devicetree helper macros for STM32WBA
+ * @ingroup reset_controller_stm32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32WBA_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32WBA_RESET_H_
 
 #include "stm32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* RCC bus reset register offset */
 #define STM32_RESET_BUS_AHB1  0x60
@@ -18,5 +26,7 @@
 #define STM32_RESET_BUS_APB1H 0x78
 #define STM32_RESET_BUS_APB2  0x7C
 #define STM32_RESET_BUS_APB7  0x80
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32WBA_RESET_H_ */


### PR DESCRIPTION
Add a reset_controller_st Doxygen group under reset_controller_interface and document how ``STM32_RESET()`` encodes RCC reset lines for the ``st,stm32-rcc-rctl`` controller, including a devicetree usage example.

Hide the internal ``STM32_RESET_BUS_*`` register offset tokens from the public API docs. Users should rely on ``STM32_RESET(bus, bit)`` rather than the low-level bus offset defines.

* https://builds.zephyrproject.io/zephyr/pr/111245/docs/doxygen/html/group__reset__controller__stm32.html
* https://builds.zephyrproject.io/zephyr/pr/111245/api-coverage/zephyr/dt-bindings/reset/index.html