### PR TITLE
MAINTAINERS: add Holt-Sun as PM collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4933,6 +4933,7 @@ Power management:
     - JordanYates
     - ZhaoxiangJin
     - yongxu-wang15
+    - Holt-Sun
   files:
     - include/zephyr/pm/
     - samples/subsys/pm/


### PR DESCRIPTION
Add myself as a collaborator for the Power management area.
I have been contributing to Zephyr system PM and SoC PM support, including:
- NXP SoC low-power state support and fixes
- PM resume IRQ restore ordering work
- documentation and contract clarification for IRQ-locked PM resume
- RFC discussions around PM resume, direct ISRs, and zero-latency interrupts

PR #108933, #110144, #109654, and related NXP SoC PM enablement PRs #103806, #102228, #101458.
RFC:  https://github.com/zephyrproject-rtos/zephyr/issues/110140, https://github.com/zephyrproject-rtos/zephyr/issues/108857 

I would like to help review and maintain this area, especially around system PM hooks, SoC PM behavior, and PM/interrupt ordering.
