### PR TITLE
tests: drivers: i2c: fix iic0 interrupt conflict on fpb_ra8e1

### DIFF
--- a/tests/drivers/i2c/i2c_api/boards/fpb_ra8e1.overlay
+++ b/tests/drivers/i2c/i2c_api/boards/fpb_ra8e1.overlay
@@ -12,7 +12,7 @@
 };
 
 &iic0 {
-	interrupts = <95 1>, <94 1>, <93 1>, <92 1>;
+	interrupts = <88 1>, <87 1>, <86 1>, <85 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 	#address-cells = <1>;


### PR DESCRIPTION
The IIC0 overlay for the I2C API test on the Renesas RA fpb_ra8e1 board used interrupt numbers that overlapped with IIC1 (IRQs 92-94).

Fix IIC0 to use a separate consecutive range (85-88).