### PR TITLE
net: wifi: remove 11r from roaming discovery

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -2286,14 +2286,6 @@ struct wifi_mgmt_ops {
 	int (*candidate_scan)(const struct device *dev,
 			      struct net_if *iface,
 			      struct wifi_scan_params *params);
-	/** Start 11r roaming
-	 *
-	 * @param dev Pointer to the device structure for the driver instance
-	 * @param iface Network interface to use for the roaming operation
-	 *
-	 * @return 0 if ok, < 0 if error
-	 */
-	int (*start_11r_roaming)(const struct device *dev, struct net_if *iface);
 	/** Set BSS max idle period
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1804,38 +1804,6 @@ int supplicant_candidate_scan(const struct device *dev __unused, struct net_if *
 
 	return 0;
 }
-
-int supplicant_11r_roaming(const struct device *dev __unused, struct net_if *iface)
-{
-	struct wpa_supplicant *wpa_s;
-	int ret = 0;
-
-	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
-
-	wpa_s = get_wpa_s_handle(iface);
-	if (!wpa_s) {
-		ret = -1;
-		goto out;
-	}
-
-	if (wpa_s->reassociate || (wpa_s->wpa_state >= WPA_AUTHENTICATING &&
-	    wpa_s->wpa_state < WPA_COMPLETED)) {
-		wpa_printf(MSG_INFO, "Reassociation is in progress, skip");
-		ret = 0;
-		goto out;
-	}
-
-	if (!wpa_cli_cmd_v("reassociate")) {
-		wpa_printf(MSG_ERROR, "%s: cli cmd <reassociate> fail",
-			   __func__);
-		ret = -1;
-		goto out;
-	}
-
-out:
-	k_mutex_unlock(&wpa_supplicant_mutex);
-	return ret;
-}
 #endif
 
 int supplicant_set_power_save(const struct device *dev, struct net_if *iface,

--- a/modules/hostap/src/supp_api.h
+++ b/modules/hostap/src/supp_api.h
@@ -154,15 +154,6 @@ int supplicant_11k_neighbor_request(const struct device *dev, struct net_if *ifa
  */
 int supplicant_candidate_scan(const struct device *dev, struct net_if *iface,
 			      struct wifi_scan_params *params);
-
-/** Send 11r roaming request
- *
- * @param dev Pointer to the device structure for the driver instance.
- * @param iface Network interface to use
- *
- * @return 0 if ok, < 0 if error
- */
-int supplicant_11r_roaming(const struct device *dev, struct net_if *iface);
 #endif
 
 /**

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -64,7 +64,6 @@ static const struct wifi_mgmt_ops mgmt_ops = {
 	.send_11k_neighbor_request = supplicant_11k_neighbor_request,
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
 	.candidate_scan = supplicant_candidate_scan,
-	.start_11r_roaming = supplicant_11r_roaming,
 #endif
 	.set_power_save = supplicant_set_power_save,
 	.set_twt = supplicant_set_twt,

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -42,7 +42,6 @@ struct wifi_rrm_neighbor_report_t {
 };
 
 struct wifi_roaming_params {
-	bool is_11r_used;
 	struct wifi_rrm_neighbor_report_t neighbor_rep;
 };
 
@@ -518,10 +517,6 @@ static int wifi_connect(uint64_t mgmt_request, struct net_if *iface,
 		break;
 	}
 
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
-	roaming_params.is_11r_used = params->ft_used;
-#endif
-
 	return wifi_mgmt_api->connect(dev, iface, params);
 }
 
@@ -636,13 +631,7 @@ static int wifi_start_roaming(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
-	if (roaming_params.is_11r_used) {
-		if (wifi_mgmt_api->start_11r_roaming == NULL) {
-			return -ENOTSUP;
-		}
-
-		return wifi_mgmt_api->start_11r_roaming(dev, iface);
-	} else if (wifi_mgmt_api->bss_support_neighbor_rep(dev, iface)) {
+	if (wifi_mgmt_api->bss_support_neighbor_rep(dev, iface)) {
 		memset(&roaming_params.neighbor_rep, 0x0, sizeof(roaming_params.neighbor_rep));
 		if (wifi_mgmt_api->send_11k_neighbor_request == NULL) {
 			return -ENOTSUP;


### PR DESCRIPTION
802.11r (FT) is a reassociation method, not a discovery method. FT is handled by wpa_supplicant during reassociation after any discovery method (11k/11v/legacy scan) finds a candidate.