### PR TITLE
drivers: flash_mspi_nor: Fix definition of NON_XIP_DEV_CFG_MASK

### DIFF
--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -1310,15 +1310,6 @@ static int flash_chip_init(const struct device *dev)
 				sfdp_signature, JESD216_SFDP_MAGIC);
 			return -ENODEV;
 		}
-
-		/* sfdp_read() may have changed io mode, so make sure
-		 * to switch back to target io mode.
-		 */
-		rc = switch_to_target_io_mode(dev);
-		if (rc < 0) {
-			LOG_ERR("Failed to switch to target io mode: %d", rc);
-			return rc;
-		}
 	}
 
 #if defined(CONFIG_MSPI_XIP)

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -30,7 +30,8 @@ LOG_MODULE_REGISTER(flash_mspi_nor, CONFIG_FLASH_LOG_LEVEL);
 			  MSPI_DEVICE_CONFIG_TX_DUMMY | \
 			  MSPI_DEVICE_CONFIG_IO_MODE)
 
-#define NON_XIP_DEV_CFG_MASK (MSPI_DEVICE_CONFIG_ALL & ~XIP_DEV_CFG_MASK)
+#define NON_XIP_DEV_CFG_MASK ((MSPI_DEVICE_CONFIG_ALL & ~XIP_DEV_CFG_MASK) | \
+			      MSPI_DEVICE_CONFIG_IO_MODE)
 
 static void set_up_xfer(const struct device *dev, enum mspi_xfer_direction dir,
 			enum mspi_xfer_mode xfer_mode);


### PR DESCRIPTION
This is a follow-up to commit d7d1a64e27cb5ef1c2325a8cb5eedb65b7557572.

The above commit added `MSPI_DEVICE_CONFIG_IO_MODE` to `XIP_DEV_CFG_MASK`, but in consequence it removed that bit from `NON_XIP_DEV_CFG_MASK` since the latter is defined with `& ~XIP_DEV_CFG_MASK`. And that bit must be present in `NON_XIP_DEV_CFG_MASK`, otherwise the driver will not configure IO mode as expected in `switch_to_target_io_mode()` and `_acquire()`.

Also revert a commit that was supposed to address a problem with IO mode but due to that incorrect definition of `NON_XIP_DEV_CFG_MASK` it did not solve the actual issue but only introduced unnecessary overhead.