### PR TITLE
soc: nxp: mcxw7x: enable 10 dBm BLE TX power via configurable DCDC voltage

### DIFF
--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -191,6 +191,7 @@
 		compatible = "nxp,spc";
 		reg = <0x16000 0x1000>;
 		interrupts = <21 0>;
+		active-dcdc-output-microvolt = <2500000>;
 	};
 
 	wuu: system-modules@19000 {
@@ -447,9 +448,9 @@
 		compatible = "nxp,nbu";
 		interrupts = <48 2>;
 		interrupt-names = "nbu_rx_int";
-		max-tx-power-support = <0 7>; /* TODO: Add 10dbm support */
+		max-tx-power-support = <0 7 10>;
 		/* Max TX power can be overridden by the board */
-		max-tx-power-dbm = <7>;
+		max-tx-power-dbm = <10>;
 		wakeup-source;
 		wakeup-ctrls = <&wuu NXP_WUU_MODULE_2_DMA>;
 	};

--- a/dts/bindings/power/nxp,spc.yaml
+++ b/dts/bindings/power/nxp,spc.yaml
@@ -19,3 +19,12 @@ properties:
       to active modes (ACTIVE_CFG register), the
       LPWKUP_DELAY register must be configured to a
       minimum value.
+
+  active-dcdc-output-microvolt:
+    type: int
+    description: |
+      Active-mode DCDC regulator output voltage, in microvolts.
+      Legal values are SoC-specific; the SoC power init validates the
+      configured value against the levels the DCDC can actually produce.
+      When this property is absent, the SoC leaves the active-mode DCDC
+      output voltage untouched.

--- a/soc/nxp/mcx/mcxw/mcxw7xx/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/CMakeLists.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources(soc.c)
+zephyr_sources(soc_dcdc.c)
 zephyr_sources_ifdef(CONFIG_SOC_MCXW70AC mcxw70_platform_init.S)
 zephyr_sources_ifdef(CONFIG_SOC_MCXW716C mcxw71_platform_init.S)
 zephyr_sources_ifdef(CONFIG_SOC_MCXW727C mcxw72_platform_init.S)

--- a/soc/nxp/mcx/mcxw/mcxw7xx/power.c
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/power.c
@@ -109,8 +109,10 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /*
- * In active mode, all HVDs/LVDs are disabled.
- * DCDC regulated to 1.8V, Core LDO regulated to 1.1V;
+ * In active mode, all HVDs/LVDs are disabled, Core LDO regulated to 1.1V.
+ * The active-mode DCDC output voltage is configured separately and earlier by
+ * nxp_mcxw7x_dcdc_init() (see soc_dcdc.c), driven by the SPC device tree node,
+ * so it is intentionally not touched here.
  * In low power modes, all HVDs/LVDs are disabled.
  * Bandgap is disabled, DCDC regulated to 1.25V, Core LDO regulated to 1.05V.
  */
@@ -130,9 +132,6 @@ __weak void set_spc_configuration(void)
 
 	active_mode_regulator.bandgapMode = kSPC_BandgapEnabledBufferDisabled;
 	active_mode_regulator.lpBuff = false;
-	/* DCDC regulate to 1.8V. */
-	active_mode_regulator.DCDCOption.DCDCVoltage = kSPC_DCDC_SafeModeVoltage;
-	active_mode_regulator.DCDCOption.DCDCDriveStrength = kSPC_DCDC_NormalDriveStrength;
 	active_mode_regulator.SysLDOOption.SysLDOVoltage = kSPC_SysLDO_NormalVoltage;
 	active_mode_regulator.SysLDOOption.SysLDODriveStrength = kSPC_SysLDO_NormalDriveStrength;
 	/* Core LDO regulate to 1.1V. */
@@ -141,10 +140,10 @@ __weak void set_spc_configuration(void)
 	active_mode_regulator.CoreLDOOption.CoreLDODriveStrength = kSPC_CoreLDO_NormalDriveStrength;
 #endif /* FSL_FEATURE_SPC_HAS_CORELDO_VDD_DS */
 
-	SPC_SetActiveModeDCDCRegulatorConfig(MCXW7_SPC_ADDR, &active_mode_regulator.DCDCOption);
-
-	while (SPC_GetBusyStatusFlag(MCXW7_SPC_ADDR)) {
-	}
+	/*
+	 * Active-mode DCDC voltage is owned by nxp_mcxw7x_dcdc_init(); do not
+	 * reconfigure it here so the device tree configured value is preserved.
+	 */
 
 	SPC_SetActiveModeSystemLDORegulatorConfig(MCXW7_SPC_ADDR,
 						  &active_mode_regulator.SysLDOOption);

--- a/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
@@ -112,6 +112,12 @@ void soc_early_init_hook(void)
 	vbat_init();
 #endif
 
+	/* Apply the active-mode DCDC output voltage from device tree. This is
+	 * required (independently of CONFIG_PM) to reach the configured BLE TX
+	 * power, and is a no-op when no voltage is configured.
+	 */
+	nxp_mcxw7x_dcdc_init();
+
 	if (IS_ENABLED(CONFIG_PM)) {
 		nxp_mcxw7x_power_init();
 	}

--- a/soc/nxp/mcx/mcxw/mcxw7xx/soc.h
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/soc.h
@@ -23,4 +23,10 @@ void nxp_mcxw7x_power_init(void);
 #define nxp_mcxw7x_power_init(...) do { } while (0)
 #endif
 
+/* Apply the active-mode DCDC output voltage configured on the SPC device tree
+ * node. Compiled unconditionally (independent of CONFIG_PM); a no-op when no
+ * voltage is configured.
+ */
+void nxp_mcxw7x_dcdc_init(void);
+
 #endif /* _SOC__H_ */

--- a/soc/nxp/mcx/mcxw/mcxw7xx/soc_dcdc.c
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/soc_dcdc.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Active-mode DCDC regulator output voltage configuration for MCXW7x.
+ *
+ * The target voltage is taken from the SPC device tree node
+ * (active-dcdc-output-microvolt). This is compiled unconditionally so the
+ * configuration is applied regardless of whether CONFIG_PM is enabled. When
+ * the property is absent the routine is a no-op and the DCDC output voltage is
+ * left untouched.
+ *
+ * This logic is intentionally kept self-contained (save/disable LVDs and HVDs,
+ * change the voltage, restore the detectors) so it can later be lifted into a
+ * dedicated SPC driver without device tree or binding churn.
+ */
+
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+#include <fsl_spc.h>
+
+#define SPC_NODE DT_INST(0, nxp_spc)
+
+#if DT_NODE_HAS_PROP(SPC_NODE, active_dcdc_output_microvolt)
+
+#define SPC_BASE ((SPC_Type *)DT_REG_ADDR(SPC_NODE))
+#define DCDC_OUTPUT_UV DT_PROP(SPC_NODE, active_dcdc_output_microvolt)
+
+/*
+ * MCXW7x active-mode DCDC output voltage levels, in microvolts.
+ *
+ * The DCDC voltage level register selects one of four nominal levels. The
+ * 2.5V output is not a register level on its own: it is a custom mode that
+ * selects the NormalVoltage (1.5V) level and additionally sets the
+ * DCDC_CFG VOUT2P5_SEL bit. It is only useful to reach the 10 dBm BLE TX
+ * power and is therefore enabled only for that case.
+ */
+#define DCDC_UV_LOW_UNDER 1250000 /* kSPC_DCDC_LowUnderVoltage */
+#define DCDC_UV_MID       1350000 /* kSPC_DCDC_MidVoltage */
+#define DCDC_UV_NORMAL    1500000 /* kSPC_DCDC_NormalVoltage */
+#define DCDC_UV_SAFE_MODE 1800000 /* kSPC_DCDC_SafeModeVoltage */
+#define DCDC_UV_2P5       2500000 /* kSPC_DCDC_NormalVoltage + VOUT2P5_SEL */
+
+BUILD_ASSERT(DCDC_OUTPUT_UV == DCDC_UV_LOW_UNDER || DCDC_OUTPUT_UV == DCDC_UV_MID ||
+		     DCDC_OUTPUT_UV == DCDC_UV_NORMAL || DCDC_OUTPUT_UV == DCDC_UV_SAFE_MODE ||
+		     DCDC_OUTPUT_UV == DCDC_UV_2P5,
+	     "active-dcdc-output-microvolt is not a level the MCXW7x DCDC can produce "
+	     "(legal values: 1250000, 1350000, 1500000, 1800000, 2500000)");
+
+/*
+ * Cross-check the configured DCDC output voltage against the BLE radio max TX
+ * power. Achieving 10 dBm requires the DCDC in its custom 2.5V mode; up to
+ * 7 dBm requires at least 1.8V. The check only fires when both properties are
+ * present.
+ */
+#define NBU_NODE DT_CHOSEN(zephyr_nbu)
+
+#if DT_NODE_EXISTS(NBU_NODE) && DT_NODE_HAS_PROP(NBU_NODE, max_tx_power_dbm)
+#define NBU_MAX_TX_POWER_DBM DT_PROP(NBU_NODE, max_tx_power_dbm)
+
+BUILD_ASSERT(NBU_MAX_TX_POWER_DBM <= 7 || DCDC_OUTPUT_UV == DCDC_UV_2P5,
+	     "max-tx-power-dbm above 7 dBm requires active-dcdc-output-microvolt = 2500000");
+BUILD_ASSERT(NBU_MAX_TX_POWER_DBM <= 0 || DCDC_OUTPUT_UV >= DCDC_UV_SAFE_MODE,
+	     "max-tx-power-dbm above 0 dBm requires active-dcdc-output-microvolt >= 1800000");
+#endif /* nbu max-tx-power-dbm present */
+
+static spc_dcdc_voltage_level_t mcxw7x_dcdc_level(void)
+{
+	switch (DCDC_OUTPUT_UV) {
+	case DCDC_UV_LOW_UNDER:
+		return kSPC_DCDC_LowUnderVoltage;
+	case DCDC_UV_MID:
+		return kSPC_DCDC_MidVoltage;
+	case DCDC_UV_SAFE_MODE:
+		return kSPC_DCDC_SafeModeVoltage;
+	case DCDC_UV_NORMAL:
+	case DCDC_UV_2P5:
+	default:
+		/* The 2.5V custom mode also uses the NormalVoltage level. */
+		return kSPC_DCDC_NormalVoltage;
+	}
+}
+
+void nxp_mcxw7x_dcdc_init(void)
+{
+	SPC_Type *base = SPC_BASE;
+	spc_active_mode_dcdc_option_t dcdc_option;
+
+	/*
+	 * Save the active-mode voltage detector state, then disable all LVDs
+	 * and HVDs so the DCDC output voltage can be changed safely. The HAL
+	 * exposes the enable bits as a single masked word rather than per
+	 * detector getters, so decode each bit from that status word.
+	 */
+	uint32_t vd_status = SPC_GetActiveModeVoltageDetectStatus(base);
+	bool core_hvd = (vd_status & SPC_ACTIVE_CFG_CORE_HVDE_MASK) != 0U;
+	bool core_lvd = (vd_status & SPC_ACTIVE_CFG_CORE_LVDE_MASK) != 0U;
+	bool sys_hvd = (vd_status & SPC_ACTIVE_CFG_SYS_HVDE_MASK) != 0U;
+	bool sys_lvd = (vd_status & SPC_ACTIVE_CFG_SYS_LVDE_MASK) != 0U;
+	bool io_hvd = (vd_status & SPC_ACTIVE_CFG_IO_HVDE_MASK) != 0U;
+	bool io_lvd = (vd_status & SPC_ACTIVE_CFG_IO_LVDE_MASK) != 0U;
+
+	SPC_EnableActiveModeCoreHighVoltageDetect(base, false);
+	SPC_EnableActiveModeCoreLowVoltageDetect(base, false);
+	SPC_EnableActiveModeSystemHighVoltageDetect(base, false);
+	SPC_EnableActiveModeSystemLowVoltageDetect(base, false);
+	SPC_EnableActiveModeIOHighVoltageDetect(base, false);
+	SPC_EnableActiveModeIOLowVoltageDetect(base, false);
+	while (SPC_GetBusyStatusFlag(base)) {
+	}
+
+	/*
+	 * VOUT2P5_SEL turns the NormalVoltage level into the custom 2.5V
+	 * output. It is set only for the 2.5V mode and cleared otherwise.
+	 */
+	if (DCDC_OUTPUT_UV == DCDC_UV_2P5) {
+		base->DCDC_CFG |= SPC_DCDC_CFG_VOUT2P5_SEL_MASK;
+	} else {
+		base->DCDC_CFG &= ~SPC_DCDC_CFG_VOUT2P5_SEL_MASK;
+	}
+
+	dcdc_option.DCDCVoltage = mcxw7x_dcdc_level();
+	dcdc_option.DCDCDriveStrength = kSPC_DCDC_NormalDriveStrength;
+	(void)SPC_SetActiveModeDCDCRegulatorConfig(base, &dcdc_option);
+	while (SPC_GetBusyStatusFlag(base)) {
+	}
+
+	/* Restore the voltage detectors to their previous state. */
+	SPC_EnableActiveModeCoreHighVoltageDetect(base, core_hvd);
+	SPC_EnableActiveModeCoreLowVoltageDetect(base, core_lvd);
+	SPC_EnableActiveModeSystemHighVoltageDetect(base, sys_hvd);
+	SPC_EnableActiveModeSystemLowVoltageDetect(base, sys_lvd);
+	SPC_EnableActiveModeIOHighVoltageDetect(base, io_hvd);
+	SPC_EnableActiveModeIOLowVoltageDetect(base, io_lvd);
+	while (SPC_GetBusyStatusFlag(base)) {
+	}
+}
+
+#else /* active-dcdc-output-microvolt not present */
+
+void nxp_mcxw7x_dcdc_init(void)
+{
+	/* No DCDC output voltage configured in device tree; leave it untouched. */
+}
+
+#endif /* DT_NODE_HAS_PROP(SPC_NODE, active_dcdc_output_microvolt) */


### PR DESCRIPTION
## Description

On MCXW7x the active-mode DCDC regulator output voltage was previously
fixed by the SoC power init path, which only ran when `CONFIG_PM` was
enabled. The default BLE TX power was therefore capped at 7 dBm, since
reaching the radio's maximum of 10 dBm requires the DCDC regulator in
its 2.5V custom mode.

This series makes the active-mode DCDC output voltage configurable from
the SPC device tree node and applies it unconditionally at boot, then
enables 10 dBm as the default on the MCXW71/MCXW72 families.

## Changes

**1. `soc: nxp: mcxw7xx: add configurable active-mode DCDC output voltage`**
- Add an optional `active-dcdc-output-microvolt` property to the
  `nxp,spc` binding. The property is intentionally SoC-agnostic: legal
  values are validated per-SoC in C rather than via a binding enum,
  since the shared compatible spans several SoC families with different
  DCDC capabilities.
- New `soc_dcdc.c`, compiled unconditionally (independent of
  `CONFIG_PM`). `nxp_mcxw7x_dcdc_init()` maps the configured microvolt
  value to the HAL DCDC level, sets `VOUT2P5_SEL` only for the 2.5V
  custom mode, and applies the change with the active-mode voltage
  detectors saved/disabled/restored around it.
- `BUILD_ASSERT`s reject values the DCDC cannot produce and cross-check
  the configured voltage against the NBU `max-tx-power-dbm` (10 dBm
  requires 2.5V, above 0 dBm requires at least 1.8V).
- The active-mode DCDC handling is moved out of
  `set_spc_configuration()` in `power.c` so the device-tree value is
  preserved and not overwritten by the low-power init path.
- When the property is absent the routine compiles to a no-op (this is
  the path taken on MCXW70, whose SPC variant is not yet supported).

**2. `dts: arm: nxp: mcxw7x: enable 10 dBm BLE TX power by default`**
- Add `10` to the NBU `max-tx-power-support` list and bump the default
  `max-tx-power-dbm` from 7 to 10.
- Set `active-dcdc-output-microvolt = <2500000>` on the SPC node, as
  required to reach 10 dBm. Boards may still override
  `max-tx-power-dbm` if a lower limit is needed.

## Testing

Tested with `samples/bluetooth/peripheral` on:
- `frdm_mcxw71` (mcxw716c)
- `frdm_mcxw72` (mcxw727c)
- `frdm_mcxw70` (mcxw70ac) — exercises the no-op DCDC path

All three build cleanly.

## Notes

- MCXW70 (KW43/periph5) uses a different SPC variant (HP_CFG register,
  `VOUT2P5_SEL` in `ACTIVE_CFG`, no VDD_SYS detectors). Its support is
  intentionally deferred; the shared `soc_dcdc.c` compiles to a no-op
  there because the device tree property is not set.
