### PR TITLE
Bluetooth: BAP: Shell: Handle delete of CAP group

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3157,7 +3157,9 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 	bt_shell_print("Stream %p released", stream);
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
-	if (default_unicast_group.bap_group != NULL && !default_unicast_group.is_cap) {
+	if ((IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && default_unicast_group.is_cap &&
+	     default_unicast_group.cap_group != NULL) ||
+	    default_unicast_group.bap_group != NULL) {
 		bool group_can_be_deleted = true;
 
 		for (size_t i = 0U; i < ARRAY_SIZE(unicast_streams); i++) {
@@ -3182,12 +3184,21 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 
 			bt_shell_print("All streams released, deleting group");
 
-			err = bt_bap_unicast_group_delete(default_unicast_group.bap_group);
+			if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && default_unicast_group.is_cap) {
+				err = bt_cap_unicast_group_delete(default_unicast_group.cap_group);
+				if (err == 0) {
+					default_unicast_group.cap_group = NULL;
+					default_unicast_group.is_cap = false;
+				}
+			} else {
+				err = bt_bap_unicast_group_delete(default_unicast_group.bap_group);
+				if (err == 0) {
+					default_unicast_group.bap_group = NULL;
+				}
+			}
 
 			if (err != 0) {
 				bt_shell_error("Failed to delete unicast group: %d", err);
-			} else {
-				default_unicast_group.bap_group = NULL;
 			}
 		}
 	}

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -100,17 +100,6 @@ static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
 		bt_shell_error("Unicast stop failed for conn %p (%d)", conn, err);
 	} else {
 		bt_shell_print("Unicast stop completed");
-
-		if (default_unicast_group.is_cap && default_unicast_group.cap_group != NULL) {
-			err = bt_cap_unicast_group_delete(default_unicast_group.cap_group);
-			if (err != 0) {
-				bt_shell_error("Failed to delete unicast group %p: %d",
-					       default_unicast_group.cap_group, err);
-			} else {
-				default_unicast_group.cap_group = NULL;
-				default_unicast_group.is_cap = false;
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
If the is_cap boolean is set, the group was not automatically deleted when all the streams were relased. CAP instead had a different way of deleting the group, but in the case of an error in CAP unicast start, that group was not deletable.

This change make it so that the user can always delete the unicast group, as BAP or CAP, by releasing all the streams, regardless of what procedures have failed or succeeded, or even been cancelled.