### PR TITLE
soc: nxp: mcxaxx6: enable LPCAC instruction cache support

### DIFF
--- a/soc/nxp/mcx/mcxa/Kconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig
@@ -30,6 +30,8 @@ config SOC_SERIES_MCXAXX6
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_MCUX_CACHE
+	select CPU_HAS_ICACHE
+	select HAS_MCUX_SYSCON_LPCAC
 	select HAS_PM
 	select PM_STATE_SET_IRQ_LOCKED
 

--- a/soc/nxp/mcx/mcxa/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig.defconfig
@@ -33,4 +33,18 @@ configdefault SYSTEM_TIMER_RESET_BY_LPM
 
 endif # PM
 
+if SOC_SERIES_MCXAXX6
+
+config CACHE_MANAGEMENT
+	default y
+
+choice CACHE_TYPE
+	default EXTERNAL_CACHE
+endchoice
+
+config ICACHE_LINE_SIZE
+	default 256
+
+endif # SOC_SERIES_MCXAXX6
+
 endif # SOC_FAMILY_MCXA


### PR DESCRIPTION
Port LPCAC icache support from mcxa577 (mcxaxx7) to the mcxaxx6 series (mcxa266, mcxa346, mcxa366). Enables CPU_HAS_ICACHE and HAS_MCUX_SYSCON_LPCAC in the SoC Kconfig and sets CACHE_MANAGEMENT, CACHE_TYPE, and ICACHE_LINE_SIZE defaults in Kconfig.defconfig, allowing tests/kernel/cache to run on frdm_mcxaxx6 boards.