### PR TITLE
Bluetooth: PACS: Fix typo when failing to register PACS

### DIFF
--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -884,7 +884,7 @@ int bt_pacs_register(const struct bt_pacs_register_param *param)
 
 	err = bt_gatt_service_register(&pacs_svc);
 	if (err != 0) {
-		LOG_DBG("Failed to register ASCS in gatt DB: %d", err);
+		LOG_DBG("Failed to register PACS in gatt DB: %d", err);
 		atomic_clear_bit(pacs.flags, PACS_FLAG_REGISTERED);
 
 		return -ENOEXEC;


### PR DESCRIPTION
It should log "PACS" instead of "ASCS".