### PR TITLE
drivers: hwinfo: enable NXP KE platforms

### DIFF
--- a/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
@@ -11,5 +11,6 @@ supported:
   - adc
   - flash
   - gpio
+  - hwinfo
   - uart
   - watchdog

--- a/boards/nxp/frdm_ke16z/frdm_ke16z.yaml
+++ b/boards/nxp/frdm_ke16z/frdm_ke16z.yaml
@@ -10,4 +10,5 @@ ram: 8
 supported:
   - flash
   - gpio
+  - hwinfo
   - uart

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
@@ -13,6 +13,7 @@ supported:
   - dma
   - flash
   - gpio
+  - hwinfo
   - i2c
   - pwm
   - spi

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
@@ -16,6 +16,7 @@ toolchain:
 supported:
   - counter
   - gpio
+  - hwinfo
   - adc
   - flash
   - uart

--- a/boards/nxp/twr_ke18f/twr_ke18f.yaml
+++ b/boards/nxp/twr_ke18f/twr_ke18f.yaml
@@ -13,6 +13,7 @@ supported:
   - counter
   - dac
   - dma
+  - hwinfo
   - i2c
   - flash
   - pwm

--- a/dts/arm/nxp/kinetis/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke1xf.dtsi
@@ -121,7 +121,7 @@
 		};
 
 		sim: sim@40048000 {
-			compatible = "nxp,kinetis-ke1xf-sim";
+			compatible = "nxp,kinetis-ke1xf-sim", "nxp,sim-uuid";
 			reg = <0x40048000 0x1000>;
 		};
 
@@ -257,6 +257,11 @@
 				clock-frequency = <DT_FREQ_K(128)>;
 				#clock-cells = <0>;
 			};
+		};
+
+		rcm: rcm@4007f000 {
+			compatible = "nxp,rcm-hwinfo";
+			reg = <0x4007f000 0x1000>;
 		};
 
 		pcc: pcc@40065000 {

--- a/dts/arm/nxp/kinetis/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke1xz.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -582,6 +582,11 @@
 		smc: smc@4007e000 {
 			compatible = "nxp,smc";
 			reg = <0x4007e000 0x1000>;
+		};
+
+		rcm: rcm@4007f000 {
+			compatible = "nxp,rcm-hwinfo";
+			reg = <0x4007f000 0x1000>;
 		};
 
 		crc: crc@40032000 {


### PR DESCRIPTION
Add nxp,rcm-hwinfo reset-cause nodes to the KE1xZ and KE1xF SoC devicetrees, and add the nxp,sim-uuid device-id compatible to the KE1xF SIM node, so the existing NXP hwinfo RCM and SIM drivers are available on FRDM-KE15Z, FRDM-KE16Z, FRDM-KE17Z, FRDM-KE17Z512 and TWR-KE18F. KE1xZ has no unique-ID register, so only reset cause is enabled there. Advertise hwinfo in each board's twister supported list.

This extends existing NXP hwinfo driver coverage without changing the driver implementation. Verified with tests/drivers/hwinfo: builds on all five boards, and the suite passes on FRDM-KE17Z hardware (reset cause tests pass, device id skipped).