### PR TITLE
drivers: watchdog: siwx91x: Fix typo

### DIFF
--- a/drivers/watchdog/wdt_silabs_siwx91x.c
+++ b/drivers/watchdog/wdt_silabs_siwx91x.c
@@ -245,7 +245,7 @@ static DEVICE_API(wdt, siwx91x_wdt_driver_api) = {
 	.feed = siwx91x_wdt_feed,
 };
 
-#define siwx91x_WDT_INIT(inst)                                                                     \
+#define SIWX91X_WDT_INIT(inst)                                                                     \
 	static struct siwx91x_wdt_data siwx91x_wdt_data_##inst;                                    \
 	static void siwx91x_wdt_irq_configure_##inst(void)                                         \
 	{                                                                                          \
@@ -263,4 +263,4 @@ static DEVICE_API(wdt, siwx91x_wdt_driver_api) = {
 			      &siwx91x_wdt_config_##inst, PRE_KERNEL_1,                            \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &siwx91x_wdt_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(siwx91x_WDT_INIT)
+DT_INST_FOREACH_STATUS_OKAY(SIWX91X_WDT_INIT)


### PR DESCRIPTION
Obviously, siwx91x_WDT_INIT() should be spelled SIWX91X_WDT_INIT()