### PR TITLE
net: lib: http_server: Ensure TCP is enabled

### DIFF
--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -55,12 +55,14 @@ if HTTP_SERVER
 
 config HTTP_SERVER_VERSION_1
 	bool "HTTP/1.x support"
+	select NET_TCP if NET_NATIVE
 	default y
 	help
 	  Support HTTP 1.x version.
 
 config HTTP_SERVER_VERSION_2
 	bool "HTTP/2 support"
+	select NET_TCP if NET_NATIVE
 	default y
 	help
 	  Support HTTP/2 version.


### PR DESCRIPTION
TCP is obligatory for HTTP1/HTTP2 to work, therefore ensure it's enabled if one of those is used, although make the select for native stack only, to ensure the library can still work with offloaded interfaces.

Fixes #111200