### PR TITLE
net: ptp: reject out-of-range message type before size-table lookup

### DIFF
--- a/subsys/net/lib/ptp/msg.c
+++ b/subsys/net/lib/ptp/msg.c
@@ -459,6 +459,15 @@ int ptp_msg_post_recv(struct ptp_port *port, struct ptp_msg *msg, int cnt)
 	int64_t current;
 	int tlv_len;
 
+	/* type is a 4-bit field (0-15) taken straight off the wire, but
+	 * msg_size[] only has entries up to PTP_MSG_MANAGEMENT. Reject
+	 * undefined types before indexing to avoid an out-of-bounds read.
+	 */
+	if (type >= ARRAY_SIZE(msg_size)) {
+		LOG_ERR("Received message with unsupported type");
+		return -EBADMSG;
+	}
+
 	if (msg_size[type] > cnt) {
 		LOG_ERR("Received message with incorrect length");
 		return -EBADMSG;


### PR DESCRIPTION
ptp_msg_post_recv() indexed msg_size[] with the 4-bit message type taken
straight off the wire (0-15), but the table only has entries up to
PTP_MSG_MANAGEMENT (0xD). Types 0xE/0xF produced an out-of-bounds read
whose bogus length then drove a copy.

Reject type >= ARRAY_SIZE(msg_size) before indexing.

Assisted-by: GitHub Copilot:claude-sonnet-4.6
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
