### PR TITLE
net: 6lo: range-check destination addressing mode index

### DIFF
--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -108,8 +108,18 @@ static int get_ihpc_inlined_size(uint16_t iphc)
 	size += sa_inline_size_table[(iphc & NET_6LO_IPHC_SA_MASK) >>
 				      NET_6LO_IPHC_SAM_POS];
 
-	size += da_inline_size_table[(iphc & NET_6LO_IPHC_DA_MASK) >>
-				      NET_6LO_IPHC_DAM_POS];
+	/* The destination index combines M | DAC | DAM and can be up to 4 bits
+	 * (0-15), but da_inline_size_table only covers the valid combinations.
+	 * Reject reserved/invalid modes rather than reading past the table.
+	 */
+	uint8_t da_idx = (iphc & NET_6LO_IPHC_DA_MASK) >> NET_6LO_IPHC_DAM_POS;
+
+	if (da_idx >= ARRAY_SIZE(da_inline_size_table)) {
+		NET_DBG("Invalid destination addressing mode");
+		return -1;
+	}
+
+	size += da_inline_size_table[da_idx];
 
 	NET_DBG("Size of inlined IP HDR data: %d", size);
 


### PR DESCRIPTION
get_ihpc_inlined_size() indexed da_inline_size_table (13 entries) with a
4-bit destination index (M|DAC|DAM, 0-15). Reserved combinations 13-15
read past the table, yielding a bogus inline size used downstream. Reject
an index beyond the table.

Assisted-by: Claude:claude-opus-4.6
Signed-off-by: Anas Nashif <anas.nashif@intel.com>

Fixes: #113043