### PR TITLE
net: icmpv4: reject too-small option pointer in Echo/Timestamp replies

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -159,6 +159,14 @@ static int icmpv4_update_record_route(uint8_t *opt_data,
 
 	len++;
 
+	/* The smallest legal pointer value is ptr_offset. A smaller value
+	 * would underflow `skip` (uint8_t) below and over-read the option data
+	 * into the reply.
+	 */
+	if (ptr < ptr_offset) {
+		goto drop;
+	}
+
 	skip = ptr - ptr_offset;
 	if (skip) {
 		/* Do not alter existed routes */
@@ -300,6 +308,14 @@ static int icmpv4_update_time_stamp(uint8_t *opt_data,
 	}
 
 	len++;
+
+	/* The smallest legal pointer value is ptr_offset. A smaller value
+	 * would underflow `skip` (uint8_t) below and over-read the option data
+	 * into the reply.
+	 */
+	if (ptr < ptr_offset) {
+		goto drop;
+	}
 
 	skip = ptr - ptr_offset;
 	if (skip) {


### PR DESCRIPTION
The Record Route and Timestamp handlers computed skip = ptr - ptr_offset
with ptr taken from the IP option. A pointer below ptr_offset underflowed
skip (uint8_t) to ~252 and over-read the option data into the reply,
leaking stack to a remote attacker.

Reject ptr < ptr_offset before the subtraction in both handlers.

Assisted-by: Claude:claude-opus-4.6
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
