### PR TITLE
net: ipv6: bound 6CO context length in Router Advertisement

### DIFF
--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2519,8 +2519,13 @@ static inline bool handle_ra_6co(struct net_pkt *pkt, uint8_t len)
 	 * bits in the Context Prefix field that are valid.  The value ranges
 	 * from 0 to 128.  If it is more than 64, then the Length MUST be 3.
 	 */
-	if ((context->context_len > 64 && len != 3U) ||
+	if (context->context_len > 128U ||
+	    (context->context_len > 64 && len != 3U) ||
 	    (context->context_len <= 64U && len != 2U)) {
+		/* Per RFC 6775 the context length is at most 128. A larger
+		 * value makes context_len/8 exceed the prefix size and
+		 * underflows the memset length below.
+		 */
 		return false;
 	}
 


### PR DESCRIPTION
handle_ra_6co() did not enforce the RFC 6775 maximum context length of
128. A larger value made context_len/8 exceed the prefix size and
underflowed the memset length, smashing the 6lo context table from an
unauthenticated link-local Router Advertisement.

Reject context_len > 128 before computing the memset length.

Assisted-by: Claude:claude-opus-4.6
Signed-off-by: Anas Nashif <anas.nashif@intel.com>

Fixes: #113048