### PR TITLE
boards: qemu: x86: add virtio input

### DIFF
--- a/boards/qemu/x86/board.cmake
+++ b/boards/qemu/x86/board.cmake
@@ -72,12 +72,17 @@ if(CONFIG_ENTROPY_VIRTIO)
   set(QEMU_VIRTIO_ENTROPY_FLAGS -device virtio-rng-pci)
 endif()
 
+if(CONFIG_INPUT_VIRTIO)
+  set(QEMU_VIRTIO_INPUT_FLAGS -device virtio-tablet-pci,addr=05.0,id=input0)
+endif()
+
 set(QEMU_FLAGS_${ARCH}
   -m ${QEMU_MEMORY_SIZE_MB}
   -cpu ${QEMU_CPU_TYPE_${ARCH}}${QEMU_CPU_FLAGS}
   -machine q35
   -device isa-debug-exit,iobase=0xf4,iosize=0x04
   ${QEMU_VIRTIO_ENTROPY_FLAGS}
+  ${QEMU_VIRTIO_INPUT_FLAGS}
   ${REBOOT_FLAG}
   )
 

--- a/boards/qemu/x86/qemu_x86.dts
+++ b/boards/qemu/x86/qemu_x86.dts
@@ -46,6 +46,7 @@
 		zephyr,ieee802154 = &ieee802154;
 		zephyr,canbus = &can0;
 		zephyr,display = &ramfb0;
+		zephyr,touch = &input0;
 	};
 
 	pcie0: pcie0 {
@@ -78,6 +79,24 @@
 			interrupt-parent = <&intc>;
 
 			status = "okay";
+		};
+
+		virtio_input_pci: virtio-input-pci {
+			compatible = "virtio,pci";
+
+			vendor-id = <0x1af4>;
+			device-id = <0x1052>;
+
+			interrupts = <10 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
+			interrupt-parent = <&intc>;
+
+			status = "okay";
+
+			input0: virtio-input {
+				compatible = "virtio,input";
+				display = <&ramfb0>;
+				status = "okay";
+			};
 		};
 	};
 

--- a/samples/modules/lvgl/demos/boards/qemu_x86.overlay
+++ b/samples/modules/lvgl/demos/boards/qemu_x86.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Use a smaller framebuffer to keep software rendering responsive under TCG. */
+&ramfb0 {
+	width = <480>;
+	height = <272>;
+};

--- a/samples/subsys/display/lvgl/boards/qemu_x86.conf
+++ b/samples/subsys/display/lvgl/boards/qemu_x86.conf
@@ -1,0 +1,2 @@
+# Wall-clock timing for interactive use
+CONFIG_QEMU_ICOUNT=n

--- a/samples/subsys/display/lvgl/boards/qemu_x86.overlay
+++ b/samples/subsys/display/lvgl/boards/qemu_x86.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Use a smaller framebuffer to keep software rendering responsive under TCG. */
+&ramfb0 {
+	width = <480>;
+	height = <272>;
+};

--- a/tests/drivers/build_all/virtio/boards/qemu_x86_64.overlay
+++ b/tests/drivers/build_all/virtio/boards/qemu_x86_64.overlay
@@ -71,21 +71,4 @@
 			status = "okay";
 		};
 	};
-
-	virtio_input_pci: virtio-input-pci {
-		compatible = "virtio,pci";
-
-		vendor-id = <0x1af4>;
-		device-id = <0x1052>;
-
-		interrupts = <0xb 0x0 0x0>;
-		interrupt-parent = <&intc>;
-
-		status = "okay";
-
-		device {
-			compatible = "virtio,input";
-			status = "okay";
-		};
-	};
 };

--- a/tests/drivers/entropy/api/boards/qemu_x86_64.overlay
+++ b/tests/drivers/entropy/api/boards/qemu_x86_64.overlay
@@ -24,4 +24,8 @@
 			compatible = "virtio,device4";
 		};
 	};
+
+	virtio_input_pci: virtio-input-pci {
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
Allow VirtIO input added in https://github.com/zephyrproject-rtos/zephyr/pull/111029 also for qemu_x86.

Tested with `west build -b qemu_x86 && west build -t run` in `samples/subsys/display/lvgl`.