### PR TITLE
drivers: select CACHE_MANAGEMENT if DCACHE

### DIFF
--- a/drivers/display/Kconfig.stm32_ltdc
+++ b/drivers/display/Kconfig.stm32_ltdc
@@ -8,7 +8,7 @@ menuconfig STM32_LTDC
 	default y
 	depends on DT_HAS_ST_STM32_LTDC_ENABLED
 	select USE_STM32_HAL_LTDC
-	select CACHE_MANAGEMENT if CPU_HAS_DCACHE
+	select CACHE_MANAGEMENT if DCACHE
 	select PINCTRL
 	select RESET
 	help

--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -62,7 +62,7 @@ config I2C_STM32_V2_DMA
 	bool "DMA support"
 	depends on I2C_STM32_V2
 	select DMA
-	select CACHE_MANAGEMENT if CPU_HAS_DCACHE
+	select CACHE_MANAGEMENT if DCACHE
 	select EXPERIMENTAL
 	help
 	  Enable DMA support for the STM32 I2C driver.

--- a/drivers/i2s/Kconfig.siwx91x
+++ b/drivers/i2s/Kconfig.siwx91x
@@ -6,7 +6,7 @@ menuconfig I2S_SILABS_SIWX91X
 	default y
 	depends on DT_HAS_SILABS_SIWX91X_I2S_ENABLED
 	depends on CLOCK_CONTROL
-	select CACHE_MANAGEMENT if CPU_HAS_DCACHE
+	select CACHE_MANAGEMENT if DCACHE
 	select DMA
 	select PINCTRL
 	select GPIO

--- a/drivers/i2s/Kconfig.stm32
+++ b/drivers/i2s/Kconfig.stm32
@@ -7,7 +7,7 @@ menuconfig I2S_STM32
 	bool "STM32 MCU I2S controller driver"
 	default y
 	depends on DT_HAS_ST_STM32_I2S_ENABLED
-	select CACHE_MANAGEMENT if CPU_HAS_DCACHE
+	select CACHE_MANAGEMENT if DCACHE
 	select DMA
 	select PINCTRL
 	help
@@ -30,7 +30,7 @@ menuconfig I2S_STM32_SAI
 	bool "STM32 MCU SAI controller driver"
 	default y
 	depends on DT_HAS_ST_STM32_SAI_ENABLED
-	select CACHE_MANAGEMENT if CPU_HAS_DCACHE
+	select CACHE_MANAGEMENT if DCACHE
 	select DMA
 	select USE_STM32_HAL_DMA
 	select USE_STM32_HAL_DMA_EX

--- a/drivers/spi/Kconfig.max32
+++ b/drivers/spi/Kconfig.max32
@@ -19,7 +19,7 @@ config SPI_MAX32_INTERRUPT
 config SPI_MAX32_DMA
 	bool "MAX32 MCU SPI DMA Support"
 	select DMA
-	select CACHE_MANAGEMENT if CPU_HAS_DCACHE
+	select CACHE_MANAGEMENT if DCACHE
 	select SPI_MAX32_INTERRUPT if SPI_MAX32_RTIO
 	help
 	  Enable DMA support for MAX32 MCU SPI driver.

--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -23,7 +23,7 @@ config SPI_STM32_INTERRUPT
 config SPI_STM32_DMA
 	bool "STM32 MCU SPI DMA Support"
 	select DMA
-	select CACHE_MANAGEMENT if CPU_HAS_DCACHE
+	select CACHE_MANAGEMENT if DCACHE
 	help
 	  Enable the SPI DMA mode for SPI instances
 	  that enable dma channels in their device tree node.


### PR DESCRIPTION
CACHE_MANAGEMENT depends on DCACHE,
therfore we should also only select it, if it is
enabled and not just if the cache exists, as the
user could disable DCACHE and then there
would be a problem.
DCACHE btw depends on CPU_HAS_DCACHE
and is enabled by default.