### PR TITLE
drivers: flash: fix flash_sim memory-region section name

### DIFF
--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -569,7 +569,8 @@ const struct flash_simulator_params *z_vrfy_flash_simulator_get_params(const str
 
 #define MOCK_FLASH_SECTION(n)                                                                      \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, memory_region),                                       \
-	(Z_GENERIC_SECTION(LINKER_DT_NODE_REGION_NAME(DT_INST_PHANDLE(n, memory_region)))), ())
+	(Z_GENERIC_SECTION(LINKER_DT_NODE_REGION_NAME_TOKEN(DT_INST_PHANDLE(n,			   \
+									    memory_region)))), ())
 
 #define FLASH_SIMULATOR_INIT(n)                                                                    \
 	IF_DISABLED(CONFIG_ARCH_POSIX, (                                                           \


### PR DESCRIPTION
Use LINKER_DT_NODE_REGION_NAME_TOKEN() when assigning the flash simulator
backing array section.

Using LINKER_DT_NODE_REGION_NAME() passes a quoted string into
Z_GENERIC_SECTION(), which produces a literal section named "FlashSim"
instead of FlashSim. The linker memory-region section matcher expects the
token form, so the array was not placed in the configured RAM region.

This is needed to be able to build with zephyr/llvm on some platforms.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
