### PR TITLE
tests: drivers: timer: nrf_grtc_timer: Add support for nRF7120

### DIFF
--- a/tests/drivers/timer/nrf_grtc_timer/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/timer/nrf_grtc_timer/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&grtc {
+	interrupts = <228 2>;
+};
+
+test_timer: &timer21 {
+	status = "okay";
+	/*interrupts = <203 1>; from .dtsi file*/
+};
+
+&timer20 {
+	status = "okay";
+	interrupts = <202 0>;
+};
+
+&timer00 {
+	status = "okay";
+	prescaler = <0>;
+};
+
+/ {
+	chosen {
+		zephyr,cpu-load-counter = &timer00;
+	};
+
+	busy-sim {
+		compatible = "vnd,busy-sim";
+		status = "okay";
+		counter = <&timer20>;
+	};
+};

--- a/tests/drivers/timer/nrf_grtc_timer/boards/nrf7120dk_nrf7120_cpuflpr.overlay
+++ b/tests/drivers/timer/nrf_grtc_timer/boards/nrf7120dk_nrf7120_cpuflpr.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&grtc {
+	/*interrupts = <226 1>; from .dtsi file*/
+};
+
+test_timer: &timer21 {
+	status = "okay";
+	/*interrupts = <203 1>; from .dtsi file*/
+};
+
+&timer20 {
+	status = "okay";
+	interrupts = <202 0>;
+};
+
+&timer00 {
+	status = "okay";
+	prescaler = <0>;
+};
+
+/ {
+	chosen {
+		zephyr,cpu-load-counter = &timer00;
+	};
+
+	busy-sim {
+		compatible = "vnd,busy-sim";
+		status = "okay";
+		counter = <&timer20>;
+	};
+};

--- a/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -15,6 +15,7 @@ common:
     - nrf54lm20dk/nrf54lm20b/cpuflpr
     - nrf7120dk/nrf7120/cpuapp
     - nrf7120dk/nrf7120/cpuapp/ns
+    - nrf7120dk/nrf7120/cpuflpr
     - ophelia4ev/nrf54l15/cpuapp
     - ophelia4ev/nrf54l15/cpuflpr
   integration_platforms:


### PR DESCRIPTION
Add nRF7120 cpuapp and flpr support to grtc timer tests