### PR TITLE
lorawan: frag_transport: reject fragment index 0

### DIFF
--- a/subsys/lorawan/services/frag_transport.c
+++ b/subsys/lorawan/services/frag_transport.c
@@ -321,6 +321,11 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 				break;
 			}
 
+			if (frag_counter == 0U) {
+				LOG_DBG("Invalid fragment index 0");
+				break;
+			}
+
 			if (frag_counter > ctx.nb_frag) {
 				/* Additional fragments have to be cached in RAM for recovery
 				 * algorithm.


### PR DESCRIPTION
DataFragment fragments are 1-indexed. A frag_counter of 0 underflows
(frag_counter - 1) in the decoder, producing a wild frame index and
flash offset. Reject it at the transport layer.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>

Fixes: #112927