### PR TITLE
include: dt-bindings: reset: gd32: improve doxygen documentation

### DIFF
--- a/include/zephyr/dt-bindings/reset/gd32-common.h
+++ b/include/zephyr/dt-bindings/reset/gd32-common.h
@@ -4,20 +4,58 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief GD32 reset controller devicetree helper macros
+ * @ingroup reset_controller_gigadevice
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32_RESET_COMMON_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32_RESET_COMMON_H_
 
 /**
- * Encode RCU register offset and configuration bit.
+ * @defgroup reset_controller_gigadevice GigaDevice reset controller helpers
+ * @ingroup reset_controller_interface
  *
- * - 0..5: bit number
- * - 6..14: offset
- * - 15: reserved
+ * @brief Macros for encoding GD32 peripheral reset cells.
+ *
+ * Devicetree macros for encoding peripheral reset cells on GigaDevice GD32 devices, for use with
+ * the <tt>gd,gd32-rctl</tt> compatible reset controller.
+ *
+ * Each SoC family header (for example @c gd32f4xx.h) defines RCU reset register offsets for that
+ * family and peripheral reset identifiers as @c GD32_RESET_\<peripheral\> constants. A peripheral
+ * reset cell is encoded by combining an RCU register offset with the bit position of the
+ * peripheral's reset line within that register.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/reset/gd32f4xx.h>
+ *
+ * &usart0 {
+ *         resets = <&rctl GD32_RESET_USART0>;
+ * };
+ * @endcode
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @brief Encode a peripheral reset cell value for the <tt>gd,gd32-rctl</tt> binding.
+ *
+ * Packs an RCU register offset and a bit position into one 32-bit reset cell value.
+ *
+ * Bits [5:0]: bit position
+ * Bits [14:6]: RCU register offset
+ * Bit 15: reserved
  *
  * @param reg RCU register name (expands to GD32_{reg}_OFFSET)
- * @param bit Configuration bit
+ * @param bit Bit position of the peripheral's reset line within that register
  */
 #define GD32_RESET_CONFIG(reg, bit) \
 	(((GD32_ ## reg ## _OFFSET) << 6U) | (bit))
+
+/** @endcond */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32_RESET_COMMON_H_ */

--- a/include/zephyr/dt-bindings/reset/gd32a50x.h
+++ b/include/zephyr/dt-bindings/reset/gd32a50x.h
@@ -4,10 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for GigaDevice GD32A50x
+ * @ingroup reset_controller_gd32a50x
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32A50X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32A50X_H_
 
 #include "gd32-common.h"
+
+/**
+ * @defgroup reset_controller_gd32a50x GigaDevice GD32A50x reset controller helpers
+ * @brief GigaDevice GD32A50x reset controller helpers
+ * @ingroup reset_controller_gigadevice
+ *
+ * Reset identifiers follow the pattern @c GD32_RESET_\<PERIPHERAL\>, where
+ * @c \<PERIPHERAL\> is the GD32A50x peripheral name from the reference manual (for example, @c
+ * GD32_RESET_USART1 resets USART1 and @c GD32_RESET_GPIOA resets GPIO port A). Pass these
+ * identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @name Register offsets
@@ -21,7 +41,7 @@
 /** @} */
 
 /**
- * @name Clock enable/disable definitions for peripherals
+ * @name Peripheral reset identifiers
  * @{
  */
 
@@ -69,6 +89,10 @@
 #define GD32_RESET_TRIGSEL    GD32_RESET_CONFIG(APB2RST, 29U)
 #define GD32_RESET_CAN0       GD32_RESET_CONFIG(APB2RST, 30U)
 #define GD32_RESET_CAN1       GD32_RESET_CONFIG(APB2RST, 31U)
+
+/** @} */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/reset/gd32e10x.h
+++ b/include/zephyr/dt-bindings/reset/gd32e10x.h
@@ -4,10 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for GigaDevice GD32E10x
+ * @ingroup reset_controller_gd32e10x
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32E10X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32E10X_H_
 
 #include "gd32-common.h"
+
+/**
+ * @defgroup reset_controller_gd32e10x GigaDevice GD32E10x reset controller helpers
+ * @brief GigaDevice GD32E10x reset controller helpers
+ * @ingroup reset_controller_gigadevice
+ *
+ * Reset identifiers follow the pattern @c GD32_RESET_\<PERIPHERAL\>, where
+ * @c \<PERIPHERAL\> is the GD32E10x peripheral name from the reference manual (for example, @c
+ * GD32_RESET_USART0 resets USART0 and @c GD32_RESET_GPIOA resets GPIO port A). Pass these
+ * identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @name Register offsets
@@ -22,7 +42,7 @@
 /** @} */
 
 /**
- * @name Clock enable/disable definitions for peripherals
+ * @name Peripheral reset identifiers
  * @{
  */
 
@@ -73,6 +93,10 @@
 
 /* APB1 additional peripherals */
 #define GD32_RESET_CTC        GD32_RESET_CONFIG(ADDAPB1RST, 27U)
+
+/** @} */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/reset/gd32e50x.h
+++ b/include/zephyr/dt-bindings/reset/gd32e50x.h
@@ -4,10 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for GigaDevice GD32E50x
+ * @ingroup reset_controller_gd32e50x
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32E50X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32E50X_H_
 
 #include "gd32-common.h"
+
+/**
+ * @defgroup reset_controller_gd32e50x GigaDevice GD32E50x reset controller helpers
+ * @brief GigaDevice GD32E50x reset controller helpers
+ * @ingroup reset_controller_gigadevice
+ *
+ * Reset identifiers follow the pattern @c GD32_RESET_\<PERIPHERAL\>, where
+ * @c \<PERIPHERAL\> is the GD32E50x peripheral name from the reference manual (for example, @c
+ * GD32_RESET_USART0 resets USART0 and @c GD32_RESET_GPIOA resets GPIO port A). Pass these
+ * identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @name Register offsets
@@ -22,7 +42,7 @@
 /** @} */
 
 /**
- * @name Clock enable/disable definitions for peripherals
+ * @name Peripheral reset identifiers
  * @{
  */
 
@@ -84,6 +104,10 @@
 /* APB1 additional peripherals */
 #define GD32_RESET_CTC        GD32_RESET_CONFIG(ADDAPB1RST, 27U)
 #define GD32_RESET_CAN2       GD32_RESET_CONFIG(ADDAPB1RST, 31U)
+
+/** @} */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/reset/gd32f3x0.h
+++ b/include/zephyr/dt-bindings/reset/gd32f3x0.h
@@ -4,10 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for GigaDevice GD32F3x0
+ * @ingroup reset_controller_gd32f3x0
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32F3X0_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32F3X0_H_
 
 #include "gd32-common.h"
+
+/**
+ * @defgroup reset_controller_gd32f3x0 GigaDevice GD32F3x0 reset controller helpers
+ * @brief GigaDevice GD32F3x0 reset controller helpers
+ * @ingroup reset_controller_gigadevice
+ *
+ * Reset identifiers follow the pattern @c GD32_RESET_\<PERIPHERAL\>, where
+ * @c \<PERIPHERAL\> is the GD32F3x0 peripheral name from the reference manual (for example, @c
+ * GD32_RESET_USART0 resets USART0 and @c GD32_RESET_GPIOA resets GPIO port A). Pass these
+ * identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @name Register offsets
@@ -22,7 +42,7 @@
 /** @} */
 
 /**
- * @name Clock enable/disable definitions for peripherals
+ * @name Peripheral reset identifiers
  * @{
  */
 
@@ -59,6 +79,10 @@
 
 /* APB1 additional peripherals */
 #define GD32_RESET_CTC        GD32_RESET_CONFIG(ADDAPB1RST, 27U)
+
+/** @} */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/reset/gd32f403.h
+++ b/include/zephyr/dt-bindings/reset/gd32f403.h
@@ -4,10 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for GigaDevice GD32F403
+ * @ingroup reset_controller_gd32f403
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32F403_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32F403_H_
 
 #include "gd32-common.h"
+
+/**
+ * @defgroup reset_controller_gd32f403 GigaDevice GD32F403 reset controller helpers
+ * @brief GigaDevice GD32F403 reset controller helpers
+ * @ingroup reset_controller_gigadevice
+ *
+ * Reset identifiers follow the pattern @c GD32_RESET_\<PERIPHERAL\>, where
+ * @c \<PERIPHERAL\> is the GD32F403 peripheral name from the reference manual (for example, @c
+ * GD32_RESET_USART0 resets USART0 and @c GD32_RESET_GPIOA resets GPIO port A). Pass these
+ * identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @name Register offsets
@@ -22,7 +42,7 @@
 /** @} */
 
 /**
- * @name Clock enable/disable definitions for peripherals
+ * @name Peripheral reset identifiers
  * @{
  */
 
@@ -74,6 +94,10 @@
 
 /* APB1 additional peripherals */
 #define GD32_RESET_CTC        GD32_RESET_CONFIG(ADDAPB1RST, 27U)
+
+/** @} */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/reset/gd32f4xx.h
+++ b/include/zephyr/dt-bindings/reset/gd32f4xx.h
@@ -4,10 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for GigaDevice GD32F4xx
+ * @ingroup reset_controller_gd32f4xx
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32F4XX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32F4XX_H_
 
 #include "gd32-common.h"
+
+/**
+ * @defgroup reset_controller_gd32f4xx GigaDevice GD32F4xx reset controller helpers
+ * @brief GigaDevice GD32F4xx reset controller helpers
+ * @ingroup reset_controller_gigadevice
+ *
+ * Reset identifiers follow the pattern @c GD32_RESET_\<PERIPHERAL\>, where
+ * @c \<PERIPHERAL\> is the GD32F4xx peripheral name from the reference manual (for example, @c
+ * GD32_RESET_USART0 resets USART0 and @c GD32_RESET_GPIOA resets GPIO port A). Pass these
+ * identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @name Register offsets
@@ -24,7 +44,7 @@
 /** @} */
 
 /**
- * @name Clock enable/disable definitions for peripherals
+ * @name Peripheral reset identifiers
  * @{
  */
 
@@ -109,6 +129,10 @@
 /* APB1 additional peripherals */
 #define GD32_RESET_CTC        GD32_RESET_CONFIG(ADDAPB1RST, 27U)
 #define GD32_RESET_IREF       GD32_RESET_CONFIG(ADDAPB1RST, 31U)
+
+/** @} */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/reset/gd32l23x.h
+++ b/include/zephyr/dt-bindings/reset/gd32l23x.h
@@ -4,10 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for GigaDevice GD32L23x
+ * @ingroup reset_controller_gd32l23x
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32L23X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32L23X_H_
 
 #include "gd32-common.h"
+
+/**
+ * @defgroup reset_controller_gd32l23x GigaDevice GD32L23x reset controller helpers
+ * @brief GigaDevice GD32L23x reset controller helpers
+ * @ingroup reset_controller_gigadevice
+ *
+ * Reset identifiers follow the pattern @c GD32_RESET_\<PERIPHERAL\>, where
+ * @c \<PERIPHERAL\> is the GD32L23x peripheral name from the reference manual (for example, @c
+ * GD32_RESET_USART0 resets USART0 and @c GD32_RESET_GPIOA resets GPIO port A). Pass these
+ * identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @name Register offsets
@@ -21,7 +41,7 @@
 /** @} */
 
 /**
- * @name Clock enable/disable definitions for peripherals
+ * @name Peripheral reset identifiers
  * @{
  */
 
@@ -66,6 +86,10 @@
 #define GD32_RESET_TIMER8     GD32_RESET_CONFIG(APB2RST, 11U)
 #define GD32_RESET_SPI0       GD32_RESET_CONFIG(APB2RST, 12U)
 #define GD32_RESET_USART0     GD32_RESET_CONFIG(APB2RST, 14U)
+
+/** @} */
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/reset/gd32vf103.h
+++ b/include/zephyr/dt-bindings/reset/gd32vf103.h
@@ -4,10 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for GigaDevice GD32VF103
+ * @ingroup reset_controller_gd32vf103
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32VF103_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_GD32VF103_H_
 
 #include "gd32-common.h"
+
+/**
+ * @defgroup reset_controller_gd32vf103 GigaDevice GD32VF103 reset controller helpers
+ * @brief GigaDevice GD32VF103 reset controller helpers
+ * @ingroup reset_controller_gigadevice
+ *
+ * Reset identifiers follow the pattern @c GD32_RESET_\<PERIPHERAL\>, where
+ * @c \<PERIPHERAL\> is the GD32VF103 peripheral name from the reference manual (for example, @c
+ * GD32_RESET_USART0 resets USART0 and @c GD32_RESET_GPIOA resets GPIO port A). Pass these
+ * identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @name Register offsets
@@ -21,7 +41,7 @@
 /** @} */
 
 /**
- * @name Clock enable/disable definitions for peripherals
+ * @name Peripheral reset identifiers
  * @{
  */
 
@@ -63,6 +83,10 @@
 
 /* AHB peripherals */
 #define GD32_RESET_USBFS      GD32_RESET_CONFIG(AHBRST, 12U)
+
+/** @} */
+
+/** @endcond */
 
 /** @} */
 


### PR DESCRIPTION
Add a reset_controller_gigadevice Doxygen group under reset_controller_interface and document how GD32_RESET_<peripheral> identifiers are used with the gd,gd32-rctl reset controller, including a devicetree usage example.

* https://builds.zephyrproject.io/zephyr/pr/111288/docs/doxygen/html/group__reset__controller__gigadevice.html
* https://builds.zephyrproject.io/zephyr/pr/111288/api-coverage/zephyr/dt-bindings/reset/index.html