### PR TITLE
virtio: improve error checking

### DIFF
--- a/drivers/virtio/virtio_common.c
+++ b/drivers/virtio/virtio_common.c
@@ -29,6 +29,19 @@ void virtio_isr(const struct device *dev, uint8_t isr_status, uint16_t virtqueue
 				);
 
 				/*
+				 * The used ring is written by the (untrusted) device.
+				 * A descriptor id beyond the queue size would index
+				 * recv_cbs[]/desc[] out of bounds and lead to an
+				 * arbitrary callback pointer being invoked below.
+				 */
+				if (chain_head >= vq->num) {
+					LOG_ERR("invalid used ring id %u (num %u)",
+						chain_head, vq->num);
+					vq->last_used_idx++;
+					continue;
+				}
+
+				/*
 				 * We are making a copy here, because chain will be
 				 * returned before invoking the callback and may be
 				 * overwritten by the time callback is called. This

--- a/drivers/virtio/virtio_pci.c
+++ b/drivers/virtio/virtio_pci.c
@@ -143,7 +143,12 @@ static bool virtio_pci_read_cap(
 			((uint32_t *)&tmp)[i] = pcie_conf_read(bdf, cap_off + i);
 		}
 		if (tmp.cfg_type == cfg_type) {
-			assert(tmp.cap_len == cap_struct_size);
+			if (tmp.cap_len < sizeof(struct virtio_pci_cap) ||
+			    tmp.cap_len > cap_struct_size) {
+				LOG_ERR("invalid virtio pci cap_len %u for bdf 0x%x",
+					tmp.cap_len, bdf);
+				return false;
+			}
 			size_t extra_data_words =
 				(tmp.cap_len - sizeof(struct virtio_pci_cap)) / sizeof(uint32_t);
 			size_t extra_data_offset =


### PR DESCRIPTION
- **drivers: virtio: reject out-of-range used-ring descriptor id**
- **drivers: virtio: validate PCI capability length at runtime**

Fixes: #113343