### PR TITLE
cmake: Add monitoring for dts bindings being changed

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -113,6 +113,8 @@ set(EDT_PICKLE                  ${PROJECT_BINARY_DIR}/edt.pickle)
 set(ZEPHYR_DTS                  ${PROJECT_BINARY_DIR}/zephyr.dts)
 # The generated C header needed by <zephyr/devicetree.h>
 set(DEVICETREE_GENERATED_H      ${BINARY_DIR_INCLUDE_GENERATED}/devicetree_generated.h)
+# List of bindings used in a build
+set(DEVICETREE_BINDINGS_USED    ${PROJECT_BINARY_DIR}/dts_bindings_used.txt)
 # Generated build system internals.
 set(DTS_POST_CPP                ${PROJECT_BINARY_DIR}/zephyr.dts.pre)
 set(DTS_DEPS                    ${PROJECT_BINARY_DIR}/zephyr.dts.d)
@@ -340,6 +342,7 @@ function(dts_gen_defines)
 
   set(cmd_gen_defines ${PYTHON_EXECUTABLE} ${GEN_DEFINES_SCRIPT}
     --header-out ${DEVICETREE_GENERATED_H}.new
+    --deps-out ${DEVICETREE_BINDINGS_USED}
     --edt-pickle ${EDT_PICKLE}
     ${EXTRA_GEN_DEFINES_ARGS}
   )
@@ -352,6 +355,11 @@ function(dts_gen_defines)
   zephyr_file_copy(${DEVICETREE_GENERATED_H}.new ${DEVICETREE_GENERATED_H} ONLY_IF_DIFFERENT)
   file(REMOVE ${DEVICETREE_GENERATED_H}.new)
   message(STATUS "Generated devicetree_generated.h: ${DEVICETREE_GENERATED_H}")
+  file(STRINGS ${DEVICETREE_BINDINGS_USED} bindings)
+
+  if(bindings)
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${bindings})
+  endif()
 endfunction()
 
 function(dts_gen_driver_kconfig)

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -113,6 +113,27 @@ def main():
         write_chosen(edt)
         write_global_macros(edt)
 
+    # Output text file with all binding files, if argument is provided
+    if args.deps_out is not None:
+        with open(args.deps_out, "w", encoding="utf-8") as dependency_file:
+            output_binding_paths: set[str] = set()
+
+            for node in edt.nodes:
+                if (
+                    node.matching_compat
+                    and node.binding_path
+                    and node.binding_path not in output_binding_paths
+                ):
+                    print(f'{pathlib.Path(node.binding_path).as_posix()}', file=dependency_file)
+                    output_binding_paths.add(node.binding_path)
+
+                    for path in node.binding.included_binding_paths:
+                        if path in output_binding_paths:
+                            continue
+
+                        print(f'{pathlib.Path(path).as_posix()}', file=dependency_file)
+                        output_binding_paths.add(path)
+
 
 def node_z_path_id(node: edtlib.Node) -> str:
     # Return the node specific bit of the node's path identifier:
@@ -137,6 +158,7 @@ def parse_args() -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--header-out", required=True, help="path to write header to")
+    parser.add_argument("--deps-out", help="path to dependencies file to output")
     parser.add_argument("--edt-pickle", help="path to read pickled edtlib.EDT object from")
 
     return parser.parse_args()

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -115,6 +115,9 @@ class Binding:
     path:
       The absolute path to the file defining the binding.
 
+    included_binding_paths:
+      Paths to included binding YAML files.
+
     title:
       The free-form title of the binding (optional).
 
@@ -235,6 +238,7 @@ class Binding:
         """
         self.path: Optional[str] = path
         self._fname2path: dict[str, str] = fname2path
+        self._included_binding_paths: set[str] = set()
 
         if raw is None:
             if path is None:
@@ -320,6 +324,11 @@ class Binding:
         "See the class docstring"
         return self.raw.get('on-bus')
 
+    @property
+    def included_binding_paths(self) -> list[str]:
+        "See the class docstring"
+        return sorted(self._included_binding_paths)
+
     def _merge_includes(self, raw: dict, binding_path: Optional[str]) -> dict:
         # Constructor helper. Merges included files in
         # 'raw["include"]' into 'raw' using 'self._include_paths' as a
@@ -397,6 +406,8 @@ class Binding:
 
         if not path:
             _err(f"'{fname}' not found")
+
+        self._included_binding_paths.add(path)
 
         with open(path, encoding="utf-8") as f:
             contents = yaml.load(f, Loader=_BindingLoader)
@@ -1103,6 +1114,9 @@ class Node:
       The 'compatible' string for the binding that matched the node, or None if
       the node has no binding
 
+    binding:
+      The Binding object for the node, or None if the node has no binding
+
     binding_path:
       The path to the binding file for the node, or None if the node has no
       binding
@@ -1248,6 +1262,11 @@ class Node:
             _err(f"{self!r} has non-hex unit address")
 
         return _translate(addr, self._node)
+
+    @property
+    def binding(self) -> Optional[Binding]:
+        "See the class docstring."
+        return self._binding
 
     @property
     def title(self) -> Optional[str]:


### PR DESCRIPTION
Generates a new file for use by the build system which lists all the paths to dts bindings used in a build, then from CMake adds a dependency to these files so that if they are modified, CMake will re-run

Fixes #89855