### PR TITLE
net: ipv6: decrement hop limit only for actually forwarded packets

### DIFF
--- a/subsys/net/ip/route_ipv6.c
+++ b/subsys/net/ip/route_ipv6.c
@@ -253,6 +253,7 @@ int net_route_ipv6_mcast_forward_packet(struct net_pkt *pkt,
 	int ret = 0;
 	int err = 0;
 
+	/* Decrement hop limit; required for forwarding. */
 	hdr->hop_limit--;
 	net_pkt_set_ipv6_hop_limit(pkt, hdr->hop_limit);
 
@@ -273,7 +274,7 @@ int net_route_ipv6_mcast_forward_packet(struct net_pkt *pkt,
 				continue;
 			}
 
-			pkt_cpy = net_pkt_shallow_clone(pkt, K_NO_WAIT);
+			pkt_cpy = net_pkt_clone(pkt, K_NO_WAIT);
 			if (pkt_cpy == NULL) {
 				err--;
 				continue;
@@ -291,6 +292,10 @@ int net_route_ipv6_mcast_forward_packet(struct net_pkt *pkt,
 			}
 		}
 	}
+
+	/* Restore initial hop limit for further processing. */
+	hdr->hop_limit++;
+	net_pkt_set_ipv6_hop_limit(pkt, hdr->hop_limit);
 
 	return (err == 0) ? ret : err;
 }


### PR DESCRIPTION
Hop limit should only be decremented if a route is found and if the packet is actually forwarded.

Fixes #111277