### PR TITLE
scripts: dts: gen_defines: Fix ZEPHYR_BASE output

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -344,6 +344,7 @@ function(dts_gen_defines)
     --header-out ${DEVICETREE_GENERATED_H}.new
     --deps-out ${DEVICETREE_BINDINGS_USED}
     --edt-pickle ${EDT_PICKLE}
+    --zephyr-base ${ZEPHYR_BASE}
     ${EXTRA_GEN_DEFINES_ARGS}
   )
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -32,10 +32,18 @@ from devicetree import edtlib
 def main():
     global header_file
     global flash_area_num
+    global ZEPHYR_BASE
 
     args = parse_args()
 
     edtlib_logger.setup_edtlib_logging()
+
+    base_path = args.zephyr_base or os.getenv("ZEPHYR_BASE")
+
+    if base_path:
+        ZEPHYR_BASE = pathlib.Path(base_path)
+    else:
+        ZEPHYR_BASE = pathlib.Path(__file__).resolve().parents[2]
 
     with open(args.edt_pickle, 'rb') as f:
         edt = pickle.load(f)
@@ -160,6 +168,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--header-out", required=True, help="path to write header to")
     parser.add_argument("--deps-out", help="path to dependencies file to output")
     parser.add_argument("--edt-pickle", help="path to read pickled edtlib.EDT object from")
+    parser.add_argument("--zephyr-base", help="path to zephyr base")
 
     return parser.parse_args()
 
@@ -243,12 +252,11 @@ def relativize(path) -> str | None:
     # with a "$ZEPHYR_BASE/..." hint at the start of the string. Otherwise,
     # returns 'path' unchanged.
 
-    zbase = os.getenv("ZEPHYR_BASE")
-    if zbase is None:
+    if ZEPHYR_BASE is None:
         return path
 
     try:
-        return str("$ZEPHYR_BASE" / pathlib.Path(path).relative_to(zbase))
+        return str("$ZEPHYR_BASE" / pathlib.Path(path).relative_to(ZEPHYR_BASE))
     except ValueError:
         # Not within ZEPHYR_BASE
         return path


### PR DESCRIPTION
Fixes this missing output, which helps with repducible build debugging, to use the zephyr prefix when the bindings are located there irrespective of if the (long deprecated) environmental value is set