### PR TITLE
include: dt-bindings: sensor: add doxygen for sensor DT macros

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -25,6 +25,216 @@
 @{
 @}
 
+@defgroup sensor_interface_ext_adi Analog Devices
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Analog Devices.
+@{
+@}
+
+@defgroup sensor_interface_ext_ams AMS
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from AMS.
+@{
+@}
+
+@defgroup sensor_interface_ext_ap Angst+Pfister
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Angst+Pfister.
+@{
+@}
+
+@defgroup sensor_interface_ext_avago Avago Technologies
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Avago Technologies.
+@{
+@}
+
+@defgroup sensor_interface_ext_avia Avia Semiconductor
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Avia Semiconductor.
+@{
+@}
+
+@defgroup sensor_interface_ext_bosch Bosch Sensortec
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Bosch Sensortec.
+@{
+@}
+
+@defgroup sensor_interface_ext_brcm Broadcom
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Broadcom.
+@{
+@}
+
+@defgroup sensor_interface_ext_fintek Fintek
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Fintek.
+@{
+@}
+
+@defgroup sensor_interface_ext_festo Festo
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Festo.
+@{
+@}
+
+@defgroup sensor_interface_ext_gss Gas Sensing Solutions
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Gas Sensing Solutions.
+@{
+@}
+
+@defgroup sensor_interface_ext_hzgrow Hangzhou Grow
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Hangzhou Grow.
+@{
+@}
+
+@defgroup sensor_interface_ext_iclegend Iclegend
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Iclegend.
+@{
+@}
+
+@defgroup sensor_interface_ext_infineon Infineon
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Infineon.
+@{
+@}
+
+@defgroup sensor_interface_ext_ite ITE
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from ITE.
+@{
+@}
+
+@defgroup sensor_interface_ext_meas Measurement Specialties
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Measurement Specialties.
+@{
+@}
+
+@defgroup sensor_interface_ext_melexis Melexis
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Melexis.
+@{
+@}
+
+@defgroup sensor_interface_ext_memsic MEMSIC
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from MEMSIC.
+@{
+@}
+
+@defgroup sensor_interface_ext_microchip Microchip
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Microchip.
+@{
+@}
+
+@defgroup sensor_interface_ext_national National Semiconductor
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from National Semiconductor.
+@{
+@}
+
+@defgroup sensor_interface_ext_nordic Nordic Semiconductor
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Nordic Semiconductor.
+@{
+@}
+
+@defgroup sensor_interface_ext_nuvoton Nuvoton
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Nuvoton.
+@{
+@}
+
+@defgroup sensor_interface_ext_nxp NXP
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from NXP.
+@{
+@}
+
+@defgroup sensor_interface_ext_pixart PixArt
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from PixArt.
+@{
+@}
+
+@defgroup sensor_interface_ext_phosense Phosense
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Phosense.
+@{
+@}
+
+@defgroup sensor_interface_ext_pni PNI
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from PNI.
+@{
+@}
+
+@defgroup sensor_interface_ext_realtek Realtek
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Realtek.
+@{
+@}
+
+@defgroup sensor_interface_ext_rohm ROHM
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from ROHM.
+@{
+@}
+
+@defgroup sensor_interface_ext_sciosense ScioSense
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from ScioSense.
+@{
+@}
+
+@defgroup sensor_interface_ext_sensirion Sensirion
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Sensirion.
+@{
+@}
+
+@defgroup sensor_interface_ext_st STMicroelectronics
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from STMicroelectronics.
+@{
+@}
+
+@defgroup sensor_interface_ext_tdk TDK InvenSense
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from TDK InvenSense.
+@{
+@}
+
+@defgroup sensor_interface_ext_ti Texas Instruments
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Texas Instruments.
+@{
+@}
+
+@defgroup sensor_interface_ext_vishay Vishay
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Vishay.
+@{
+@}
+
+@defgroup sensor_interface_ext_we Wurth Elektronik
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Wurth Elektronik.
+@{
+@}
+
+@defgroup sensor_interface_ext_winsen Winsen
+@ingroup sensor_interface_ext
+@brief Device-specific extensions for sensors from Winsen.
+@{
+@}
+
 @defgroup misc_interfaces Miscellaneous Devices
 @ingroup io_interfaces
 @brief Interfaces for hardware peripherals that do not have a dedicated driver class.

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -20,7 +20,7 @@
  * @ingroup io_interfaces
  * @{
  *
- * @defgroup sensor_interface_ext Device-specific Sensor API extensions
+ * @defgroup sensor_interface_ext Device-specific Sensor API extensions and Devicetree constants.
  * @{
  * @}
  */

--- a/include/zephyr/drivers/sensor/adltc2990.h
+++ b/include/zephyr/drivers/sensor/adltc2990.h
@@ -15,7 +15,7 @@
 /**
  * @brief Analog Devices ADLTC2990 Quad I2C Voltage, Current and Temperature Monitor
  * @defgroup adltc2990_interface ADLTC2990
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_adi
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/adt7420.h
+++ b/include/zephyr/drivers/sensor/adt7420.h
@@ -16,7 +16,7 @@
 /**
  * @brief Analog Devices ADT7420 Temperature Sensor
  * @defgroup adt7420_interface ADT7420
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_adi
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/afbr_s50.h
+++ b/include/zephyr/drivers/sensor/afbr_s50.h
@@ -17,7 +17,7 @@
 /**
  * @brief Broadcom AFBR-S50 3D ToF sensor
  * @defgroup afbr_s50_interface AFBR-S50
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_brcm
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/apds9960.h
+++ b/include/zephyr/drivers/sensor/apds9960.h
@@ -23,7 +23,7 @@ extern "C" {
 /**
  * @brief Avago APDS9960 ambient light, RGB, proximity and gesture sensor
  * @defgroup apds9960_interface APDS9960
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_avago
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/bd8lb600fs.h
+++ b/include/zephyr/drivers/sensor/bd8lb600fs.h
@@ -15,7 +15,7 @@
 /**
  * @brief ROHM Semiconductor BD8LB600FS open load and over-current detection
  * @defgroup bd8lb600fs_interface BD8LB600FS
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_rohm
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/bmm350.h
+++ b/include/zephyr/drivers/sensor/bmm350.h
@@ -16,7 +16,7 @@
 /**
  * @brief Bosch BMM350 3-Axis Magnetometer
  * @defgroup bmm350_interface BMM350
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_bosch
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/bmp581_user.h
+++ b/include/zephyr/drivers/sensor/bmp581_user.h
@@ -21,7 +21,7 @@
 /**
  * @brief Bosch BMP581 Barometric pressure sensor
  * @defgroup bmp581_interface BMP581
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_bosch
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/ens160.h
+++ b/include/zephyr/drivers/sensor/ens160.h
@@ -14,7 +14,7 @@
 
 /**
  * @defgroup ens160_interface ENS160
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_sciosense
  * @brief ScioSense ENS160 digital metal-oxide multi-gas sensor
  * @{
  */

--- a/include/zephyr/drivers/sensor/explorir_m.h
+++ b/include/zephyr/drivers/sensor/explorir_m.h
@@ -15,7 +15,7 @@
 
 /**
  * @defgroup explorir_m_interface ExplorIR-M
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_gss
  * @brief Gas Sensing Solutions ExplorIR-M CO<sub>2</sub> sensor
  * @{
  */

--- a/include/zephyr/drivers/sensor/f75303.h
+++ b/include/zephyr/drivers/sensor/f75303.h
@@ -15,7 +15,7 @@
 /**
  * @brief Fintek F75303 temperature sensor
  * @defgroup f75303_interface F75303
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_fintek
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/fcx_mldx5.h
+++ b/include/zephyr/drivers/sensor/fcx_mldx5.h
@@ -16,7 +16,7 @@
 /**
  * @brief Angst+Pfister FCX-MLDX5 O<sub>2</sub> sensor
  * @defgroup fcx_mldx5_interface FCX-MLDX5
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_ap
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/fdc2x1x.h
+++ b/include/zephyr/drivers/sensor/fdc2x1x.h
@@ -16,7 +16,7 @@
 /**
  * @brief Texas Instruments FDC2X1X capacitive sensor
  * @defgroup fdc2x1x_interface FDC2X1X
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_ti
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/grow_r502a.h
+++ b/include/zephyr/drivers/sensor/grow_r502a.h
@@ -15,7 +15,7 @@
 
 /**
  * @defgroup grow_r502a_interface Grow R502A
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_hzgrow
  * @brief HZ-Grow GROW_R502A fingerprint sensor
  * @{
  */

--- a/include/zephyr/drivers/sensor/htu31d.h
+++ b/include/zephyr/drivers/sensor/htu31d.h
@@ -19,7 +19,7 @@
 
 /**
  * @defgroup htu31d_interface HTU31D
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_meas
  * @brief TE Connectivity HTU31D temperature and humidity sensor
  * @{
  */

--- a/include/zephyr/drivers/sensor/hx711.h
+++ b/include/zephyr/drivers/sensor/hx711.h
@@ -14,7 +14,7 @@
 
 /**
  * @defgroup hx711_interface HX711
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_avia
  * @brief Avia Semiconductor HX711 24-bit ADC Specialized for Load Cells / Strain Gauges
  * @{
  */

--- a/include/zephyr/drivers/sensor/ina2xx.h
+++ b/include/zephyr/drivers/sensor/ina2xx.h
@@ -16,7 +16,7 @@
 /**
  * @brief TI INA2xx current/power monitor family
  * @defgroup ina2xx_interface INA2XX
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_ti
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/lis2dh.h
+++ b/include/zephyr/drivers/sensor/lis2dh.h
@@ -15,7 +15,7 @@
 
 /**
  * @defgroup lis2dh_interface LIS2DH
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_st
  * @brief ST Microelectronics LIS2DH 3-axis accelerometer
  * @{
  */

--- a/include/zephyr/drivers/sensor/lm95234.h
+++ b/include/zephyr/drivers/sensor/lm95234.h
@@ -15,7 +15,7 @@
 
 /**
  * @defgroup lm95234_interface LM95234
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_national
  * @brief LM95234 Quad Remote Diode and Local Temperature Sensor
  * @{
  */

--- a/include/zephyr/drivers/sensor/lsm6dsvxxx.h
+++ b/include/zephyr/drivers/sensor/lsm6dsvxxx.h
@@ -15,7 +15,7 @@
 
 /**
  * @defgroup lsm6dsvxxx_interface LSM6DSVXXX
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_st
  * @brief ST Microelectronics LSM6DSVXXX 3-axis IMU family
  * @{
  */

--- a/include/zephyr/drivers/sensor/max17055.h
+++ b/include/zephyr/drivers/sensor/max17055.h
@@ -15,7 +15,7 @@
 
 /**
  * @defgroup max17055_interface MAX17055
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_adi
  * @brief Maxim Integrated MAX17055 fuel gauge
  * @{
  */

--- a/include/zephyr/drivers/sensor/max30210.h
+++ b/include/zephyr/drivers/sensor/max30210.h
@@ -15,7 +15,7 @@
 /**
  * @brief Analog Devices MAX30210 High-Accuracy Temperature Sensor
  * @defgroup max30210_interface MAX30210
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_adi
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/max31790.h
+++ b/include/zephyr/drivers/sensor/max31790.h
@@ -15,7 +15,7 @@
 /**
  * @brief Maxim MAX31790 6-Channel PWM-Output Fan RPM Controller
  * @defgroup max31790_interface MAX31790
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_adi
  *
  * The MAX31790 provides fan fault monitoring and fan speed (RPM) sensing.
  * Fan speed uses the standard @ref SENSOR_CHAN_RPM channel.

--- a/include/zephyr/drivers/sensor/max32664c.h
+++ b/include/zephyr/drivers/sensor/max32664c.h
@@ -15,7 +15,7 @@
 
 /**
  * @defgroup max32664c_interface MAX32664C
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_adi
  * @brief Maxim Integrated MAX32664C biometric sensor hub
  * @{
  */

--- a/include/zephyr/drivers/sensor/mcp9600.h
+++ b/include/zephyr/drivers/sensor/mcp9600.h
@@ -16,7 +16,7 @@
 /**
  * @brief Microchip MCP9600 Thermocouple Electromotive Force (EMF) to °C Converter
  * @defgroup mcp9600_interface MCP9600
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_microchip
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/mhz19b.h
+++ b/include/zephyr/drivers/sensor/mhz19b.h
@@ -15,7 +15,7 @@
 
 /**
  * @defgroup mhz19b_interface MH-Z19B
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_winsen
  * @brief Winsen MH-Z19B CO<sub>2</sub> sensor
  * @{
  */

--- a/include/zephyr/drivers/sensor/mlx90394.h
+++ b/include/zephyr/drivers/sensor/mlx90394.h
@@ -15,7 +15,7 @@
 /**
  * @brief Melexis MLX90394 magnetometer
  * @defgroup mlx90394_interface MLX90394
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_melexis
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/mmc56x3.h
+++ b/include/zephyr/drivers/sensor/mmc56x3.h
@@ -18,7 +18,7 @@
 
 /**
  * @defgroup mmc56x3_interface MMC56X3
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_memsic
  * @brief Memsic MMC56X3 3-axis magnetic and temperature sensor
  * @{
  */

--- a/include/zephyr/drivers/sensor/npm10xx.h
+++ b/include/zephyr/drivers/sensor/npm10xx.h
@@ -16,7 +16,7 @@ extern "C" {
  * @file npm10xx.h
  * @brief Nordic's nPM10 Series PMIC Sensor driver custom channels and attributes
  * @defgroup sensor_interface_npm10xx nPM10xx Sensor interface
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_nordic
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/paj7620.h
+++ b/include/zephyr/drivers/sensor/paj7620.h
@@ -16,7 +16,7 @@
 /**
  * @brief Pixart PAJ7620 gesture sensor
  * @defgroup paj7620_interface PAJ7620
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_pixart
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/pat9136.h
+++ b/include/zephyr/drivers/sensor/pat9136.h
@@ -17,7 +17,7 @@
 /**
  * @brief Pixart PAT9136 optical flow sensor
  * @defgroup pat9136_interface PAT9136
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_pixart
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/qdec_bee.h
+++ b/include/zephyr/drivers/sensor/qdec_bee.h
@@ -18,7 +18,7 @@
 /**
  * @brief Realtek Bee QDEC
  * @defgroup qdec_bee_interface Realtek Bee QDEC
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_realtek
  *
  * Realtek Bee QDEC provides custom sensor channels for raw X/Y/Z axis counts.
  * @{

--- a/include/zephyr/drivers/sensor/qdec_mcux.h
+++ b/include/zephyr/drivers/sensor/qdec_mcux.h
@@ -16,7 +16,7 @@
 /**
  * @brief NXP MCUX QDEC sensor
  * @defgroup sensor_qdec_mcux QDEC MCUX
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_nxp
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/s3km1110.h
+++ b/include/zephyr/drivers/sensor/s3km1110.h
@@ -15,7 +15,7 @@
 /**
  * @brief Iclegend S3KM1110 24 GHz mmWave radar
  * @defgroup s3km1110_interface Iclegend S3KM1110
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_iclegend
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/scd4x.h
+++ b/include/zephyr/drivers/sensor/scd4x.h
@@ -16,7 +16,7 @@
 /**
  * @brief Sensirion SCD4X CO<sub>2</sub> sensor
  * @defgroup scd4x_interface SCD4X
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_sensirion
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/sgp40.h
+++ b/include/zephyr/drivers/sensor/sgp40.h
@@ -18,7 +18,7 @@
 
 /**
  * @defgroup sgp40_interface SGP40
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_sensirion
  * @brief Sensirion SGP40 gas sensor
  * @{
  */

--- a/include/zephyr/drivers/sensor/sht4x.h
+++ b/include/zephyr/drivers/sensor/sht4x.h
@@ -19,7 +19,7 @@
 
 /**
  * @defgroup sht4x_interface SHT4X
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_sensirion
  * @brief Sensirion SHT4X temperature and humidity sensor
  * @{
  */

--- a/include/zephyr/drivers/sensor/tcs3400.h
+++ b/include/zephyr/drivers/sensor/tcs3400.h
@@ -16,7 +16,7 @@
 /**
  * @brief AMS TCS3400 RGBC sensor
  * @defgroup tcs3400_interface TCS3400
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_ams
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/tle9104.h
+++ b/include/zephyr/drivers/sensor/tle9104.h
@@ -14,7 +14,7 @@
 
 /**
  * @defgroup tle9104_interface TLE9104
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_infineon
  * @brief TLE9104 4-channel powertrain switch
  * @{
  */

--- a/include/zephyr/drivers/sensor/tmag5273.h
+++ b/include/zephyr/drivers/sensor/tmag5273.h
@@ -15,7 +15,7 @@
 /**
  * @brief Texas Instruments TMAG5273 Low-Power Linear 3D Hall-Effect Sensor
  * @defgroup tmag5273_interface TMAG5273
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_ti
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/tmp11x.h
+++ b/include/zephyr/drivers/sensor/tmp11x.h
@@ -16,7 +16,7 @@
 /**
  * @brief TMP11X temperature sensors
  * @defgroup tmp11x_interface TMP11X
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_ti
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/tmp451.h
+++ b/include/zephyr/drivers/sensor/tmp451.h
@@ -23,7 +23,7 @@ extern "C" {
 /**
  * @brief TI TMP451 temperature sensor
  * @defgroup tmp451_interface TMP451
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_ti
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/veaa_x_3.h
+++ b/include/zephyr/drivers/sensor/veaa_x_3.h
@@ -16,7 +16,7 @@
 /**
  * @brief Festo VEAA X-3 pressure regulator
  * @defgroup veaa_x_3_interface VEAA X-3
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_festo
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/veml6031.h
+++ b/include/zephyr/drivers/sensor/veml6031.h
@@ -17,7 +17,7 @@
 
 /**
  * @defgroup veml6031_interface VEML6031
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_vishay
  * @brief Vishay VEML6031 High Accuracy Ambient Light Sensor
  * @{
  */

--- a/include/zephyr/drivers/sensor/veml6046.h
+++ b/include/zephyr/drivers/sensor/veml6046.h
@@ -17,7 +17,7 @@
 
 /**
  * @defgroup veml6046_interface VEML6046
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_vishay
  * @brief Vishay VEML6046 RGBIR Sensor
  * @{
  */

--- a/include/zephyr/drivers/sensor/veml60xx-common.h
+++ b/include/zephyr/drivers/sensor/veml60xx-common.h
@@ -15,7 +15,7 @@
 
 /**
  * @defgroup veml60xx_interface VEML60XX
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_vishay
  * @brief Vishay VEML60xx sensor family common attributes
  * @{
  */

--- a/include/zephyr/drivers/sensor/vl53l0x.h
+++ b/include/zephyr/drivers/sensor/vl53l0x.h
@@ -15,7 +15,7 @@
 /**
  * @brief ST VL53L0X time-of-flight ranging sensor
  * @defgroup vl53l0x_interface VL53L0X
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_st
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/wsen_pads_2511020213301.h
+++ b/include/zephyr/drivers/sensor/wsen_pads_2511020213301.h
@@ -16,7 +16,7 @@
 /**
  * @brief Würth Elektronik WSEN-PADS-2511020213301 absolute pressure sensor
  * @defgroup wsen_pads_2511020213301_interface WSEN-PADS-2511020213301
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_we
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/wsen_tids_2521020222501.h
+++ b/include/zephyr/drivers/sensor/wsen_tids_2521020222501.h
@@ -16,7 +16,7 @@
 /**
  * @brief Würth Elektronik WSEN-TIDS-2521020222501 temperature sensor
  * @defgroup wsen_tids_2521020222501_interface WSEN-TIDS-2521020222501
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_we
  * @{
  */
 

--- a/include/zephyr/drivers/sensor/xbr818.h
+++ b/include/zephyr/drivers/sensor/xbr818.h
@@ -17,7 +17,7 @@
 /**
  * @brief Phosense XBR818 10 GHz Radar
  * @defgroup xbr818_interface XBR818
- * @ingroup sensor_interface_ext
+ * @ingroup sensor_interface_ext_phosense
  * @{
  */
 

--- a/include/zephyr/dt-bindings/sensor/adxl345.h
+++ b/include/zephyr/dt-bindings/sensor/adxl345.h
@@ -3,35 +3,47 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the Analog Devices ADXL345 accelerometer.
+ * @ingroup adxl345_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX345_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX345_H_
 
 /**
- * @defgroup adxl345 ADXL345 DT Options
- * @ingroup sensor_interface
+ * @defgroup adxl345_interface ADXL345
+ * @ingroup sensor_interface_ext_adi
+ * @brief Analog Devices ADXL345 3-axis accelerometer
  * @{
  */
 
 /**
- * @defgroup adxl345_odr Output Rate options
+ * @name Output data rate options
+ *
+ * Values for the `odr` devicetree property.
  * @{
  */
-#define ADXL345_DT_ODR_12_5		7
-#define ADXL345_DT_ODR_25		8
-#define ADXL345_DT_ODR_50		9
-#define ADXL345_DT_ODR_100		10
-#define ADXL345_DT_ODR_200		11
-#define ADXL345_DT_ODR_400		12
+#define ADXL345_DT_ODR_12_5 7  /**< 12.5 Hz */
+#define ADXL345_DT_ODR_25   8  /**< 25 Hz */
+#define ADXL345_DT_ODR_50   9  /**< 50 Hz */
+#define ADXL345_DT_ODR_100  10 /**< 100 Hz */
+#define ADXL345_DT_ODR_200  11 /**< 200 Hz */
+#define ADXL345_DT_ODR_400  12 /**< 400 Hz */
 /** @} */
 
 /**
- * @defgroup adxl345_range Select range options
+ * @name Measurement range options
+ *
+ * Values for the `range` devicetree property.
  * @{
  */
-#define ADXL345_DT_RANGE_2G	    0
-#define ADXL345_DT_RANGE_4G	    1
-#define ADXL345_DT_RANGE_8G	    2
-#define ADXL345_DT_RANGE_16G    3
+#define ADXL345_DT_RANGE_2G  0 /**< ±2 g */
+#define ADXL345_DT_RANGE_4G  1 /**< ±4 g */
+#define ADXL345_DT_RANGE_8G  2 /**< ±8 g */
+#define ADXL345_DT_RANGE_16G 3 /**< ±16 g */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/adxl355.h
+++ b/include/zephyr/dt-bindings/sensor/adxl355.h
@@ -6,21 +6,24 @@
 
 /**
  * @file
- * @brief Devicetree bindings for the Analog Devices ADXL355 accelerometer
- *
+ * @brief Devicetree binding constants for the Analog Devices ADXL355 accelerometer.
+ * @ingroup adxl355_interface
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_ADXL355_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_ADXL355_H_
 
 /**
- * @defgroup adxl355 ADXL355 DT Options
- * @ingroup sensor_interface
+ * @defgroup adxl355_interface ADXL355
+ * @ingroup sensor_interface_ext_adi
+ * @brief Analog Devices ADXL355 3-axis accelerometer
  * @{
  */
 
 /**
- * @defgroup adxl355_odr Output Rate options
+ * @name Output Rate options
+ *
+ * Values for the `odr` devicetree property.
  * @{
  */
 /** Output data rate: 4000 Hz */
@@ -48,7 +51,9 @@
 /** @} */
 
 /**
- * @defgroup adxl355_range Select range options
+ * @name Select range options
+ *
+ * Values for the `range` devicetree property.
  * @{
  */
 /** Select ±2 g measurement range */
@@ -60,7 +65,9 @@
 /** @} */
 
 /**
- * @defgroup adxl355_hpf_corner High Pass Filter corner options
+ * @name High Pass Filter corner options
+ *
+ * Values for the `hpf-corner` devicetree property.
  * @{
  */
 /** High-pass filter disabled */
@@ -80,7 +87,9 @@
 /** @} */
 
 /**
- * @defgroup adxl355_ext_clk External Clock options
+ * @name External Clock options
+ *
+ * Values for the `ext-clk` devicetree property.
  * @{
  */
 /** External clock disabled */
@@ -90,7 +99,9 @@
 /** @} */
 
 /**
- * @defgroup adxl355_ext_sync External Sync options
+ * @name External Sync options
+ *
+ * Values for the `ext-sync` devicetree property.
  * @{
  */
 /** Internal synchronization */

--- a/include/zephyr/dt-bindings/sensor/adxl362.h
+++ b/include/zephyr/dt-bindings/sensor/adxl362.h
@@ -3,24 +3,33 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the Analog Devices ADXL362 accelerometer.
+ * @ingroup adxl362_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX362_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX362_H_
 
 /**
- * @defgroup adxl362 ADXL362 DT Options
- * @ingroup sensor_interface
+ * @defgroup adxl362_interface ADXL362
+ * @ingroup sensor_interface_ext_adi
+ * @brief Analog Devices ADXL362 3-axis accelerometer
  * @{
  */
 
 /**
- * @defgroup adxl362_fifo_mode FIFO mode options
+ * @name FIFO mode options
+ *
+ * Values for the `fifo-mode` devicetree property.
  * @{
  */
-#define ADXL362_FIFO_MODE_DISABLED        0x0
-#define ADXL362_FIFO_MODE_OLDEST_SAVED    0x1
-#define ADXL362_FIFO_MODE_STREAM          0x2
-#define ADXL362_FIFO_MODE_TRIGGERED       0x3
-
+#define ADXL362_FIFO_MODE_DISABLED     0x0 /**< FIFO disabled */
+#define ADXL362_FIFO_MODE_OLDEST_SAVED 0x1 /**< Stop when full, keep oldest samples */
+#define ADXL362_FIFO_MODE_STREAM       0x2 /**< Continuous stream, overwrite oldest */
+#define ADXL362_FIFO_MODE_TRIGGERED    0x3 /**< Capture samples around a trigger event */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/adxl367.h
+++ b/include/zephyr/dt-bindings/sensor/adxl367.h
@@ -3,23 +3,33 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the Analog Devices ADXL367 accelerometer.
+ * @ingroup adxl367_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX367_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX367_H_
 
 /**
- * @defgroup adxl367 ADXL367 DT Options
- * @ingroup sensor_interface
+ * @defgroup adxl367_interface ADXL367
+ * @ingroup sensor_interface_ext_adi
+ * @brief Analog Devices ADXL367 3-axis accelerometer
  * @{
  */
 
 /**
- * @defgroup adxl367_fifo_mode FIFO mode options
+ * @name FIFO mode options
+ *
+ * Values for the `fifo-mode` devicetree property.
  * @{
  */
-#define ADXL367_FIFO_MODE_DISABLED        0x0
-#define ADXL367_FIFO_MODE_OLDEST_SAVED    0x1
-#define ADXL367_FIFO_MODE_STREAM          0x2
-#define ADXL367_FIFO_MODE_TRIGGERED       0x3
+#define ADXL367_FIFO_MODE_DISABLED     0x0 /**< FIFO disabled */
+#define ADXL367_FIFO_MODE_OLDEST_SAVED 0x1 /**< Stop when full, keep oldest samples */
+#define ADXL367_FIFO_MODE_STREAM       0x2 /**< Continuous stream, overwrite oldest */
+#define ADXL367_FIFO_MODE_TRIGGERED    0x3 /**< Capture samples around a trigger event */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/adxl372.h
+++ b/include/zephyr/dt-bindings/sensor/adxl372.h
@@ -3,25 +3,33 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the Analog Devices ADXL372 accelerometer.
+ * @ingroup adxl372_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX372_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX372_H_
 
 /**
- * @defgroup adxl372 ADXL372 DT Options
- * @ingroup sensor_interface
+ * @defgroup adxl372_interface ADXL372
+ * @ingroup sensor_interface_ext_adi
+ * @brief Analog Devices ADXL372 3-axis accelerometer
  * @{
  */
 
 /**
- * @defgroup ADXL372_FIFO_MODE FIFO mode options
+ * @name FIFO mode options
+ *
+ * Values for the `fifo-mode` devicetree property.
  * @{
  */
-
-#define ADXL372_FIFO_MODE_BYPASSED        0x0
-#define ADXL372_FIFO_MODE_STREAMED        0x1
-#define ADXL372_FIFO_MODE_TRIGGERED       0x2
-#define ADXL372_FIFO_MODE_OLD_SAVED       0x3
-
+#define ADXL372_FIFO_MODE_BYPASSED  0x0 /**< FIFO bypassed (disabled) */
+#define ADXL372_FIFO_MODE_STREAMED  0x1 /**< Continuous stream, overwrite oldest */
+#define ADXL372_FIFO_MODE_TRIGGERED 0x2 /**< Capture samples around a trigger event */
+#define ADXL372_FIFO_MODE_OLD_SAVED 0x3 /**< Stop when full, keep oldest samples */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/afbr_s50.h
+++ b/include/zephyr/dt-bindings/sensor/afbr_s50.h
@@ -4,32 +4,67 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the Broadcom AFBR-S50 ToF sensor.
+ * @ingroup afbr_s50_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_BRCM_AFBR_S50_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_BRCM_AFBR_S50_H_
 
 /**
- * @name afbr_s50 Dual Frequency Mode Settings
+ * @defgroup afbr_s50_interface AFBR-S50
+ * @ingroup sensor_interface_ext_brcm
+ * @brief Broadcom AFBR-S50 time-of-flight distance sensor
  * @{
  */
-#define AFBR_S50_DT_DFM_MODE_OFF		0
-#define AFBR_S50_DT_DFM_MODE_4X			1
-#define AFBR_S50_DT_DFM_MODE_8X			2
+
+/**
+ * @name Dual-frequency mode options
+ *
+ * Values for the `dual-freq-mode` devicetree property.
+ *
+ * Dual-frequency mode extends the unambiguous range by combining measurements
+ * at two modulation frequencies.
+ * @{
+ */
+#define AFBR_S50_DT_DFM_MODE_OFF		0 /**< Disabled */
+#define AFBR_S50_DT_DFM_MODE_4X			1 /**< 4x range extension */
+#define AFBR_S50_DT_DFM_MODE_8X			2 /**< 8x range extension */
 /** @} */
 
 /**
- * @name afbr_s50 Measurement Modes
+ * @name Measurement modes
+ *
+ * Values for the `measurement-mode` devicetree property.
+ *
+ * Modes with the laser-class-2 suffix raise the optical output power.
  * @{
  */
+/** Short range */
 #define AFBR_S50_DT_MODE_SHORT_RANGE					1
+/** Long range */
 #define AFBR_S50_DT_MODE_LONG_RANGE					2
+/** High-speed short range */
 #define AFBR_S50_DT_MODE_HIGH_SPEED_SHORT_RANGE				5
+/** High-speed long range */
 #define AFBR_S50_DT_MODE_HIGH_SPEED_LONG_RANGE				6
+/** High-precision short range */
 #define AFBR_S50_DT_MODE_HIGH_PRECISION_SHORT_RANGE			9
+/** Short range, laser class 2 */
 #define AFBR_S50_DT_MODE_SHORT_RANGE_LASER_CLASS_2			129
+/** Long range, laser class 2 */
 #define AFBR_S50_DT_MODE_LONG_RANGE_LASER_CLASS_2			130
+/** High-speed short range, laser class 2 */
 #define AFBR_S50_DT_MODE_HIGH_SPEED_SHORT_RANGE_LASER_CLASS_2		133
+/** High-speed long range, laser class 2 */
 #define AFBR_S50_DT_MODE_HIGH_SPEED_LONG_RANGE_LASER_CLASS_2		134
+/** High-precision short range, laser class 2 */
 #define AFBR_S50_DT_MODE_HIGH_PRECISION_SHORT_RANGE_LASER_CLASS_2	137
+/** @} */
+
 /** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_BRCM_AFBR_S50_H_ */

--- a/include/zephyr/dt-bindings/sensor/apds9253.h
+++ b/include/zephyr/dt-bindings/sensor/apds9253.h
@@ -5,50 +5,65 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree binding constants for the Broadcom APDS9253 light sensor.
+ * @ingroup apds9253_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_APDS9253_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_APDS9253_H_
 
 #include <zephyr/dt-bindings/dt-util.h>
 
 /**
- * @name apds9253 resolution channel references
+ * @defgroup apds9253_interface APDS9253
+ * @ingroup sensor_interface_ext_avago
+ * @brief Broadcom APDS9253 RGB and ambient light sensor
  * @{
  */
 
-#define APDS9253_RESOLUTION_20BIT_400MS 0
-#define APDS9253_RESOLUTION_19BIT_200MS BIT(4)
-#define APDS9253_RESOLUTION_18BIT_100MS BIT(5) /* default */
-#define APDS9253_RESOLUTION_17BIT_50MS  (BIT(5) | BIT(4))
-#define APDS9253_RESOLUTION_16BIT_25MS  BIT(6)
-#define APDS9253_RESOLUTION_13BIT_3MS   (BIT(6) | BIT(4))
-
+/**
+ * @name ADC resolution and integration time
+ *
+ * Values for the `resolution` devicetree property.
+ * @{
+ */
+#define APDS9253_RESOLUTION_20BIT_400MS 0                 /**< 20-bit, 400 ms */
+#define APDS9253_RESOLUTION_19BIT_200MS BIT(4)            /**< 19-bit, 200 ms */
+#define APDS9253_RESOLUTION_18BIT_100MS BIT(5)            /**< 18-bit, 100 ms (default) */
+#define APDS9253_RESOLUTION_17BIT_50MS  (BIT(5) | BIT(4)) /**< 17-bit, 50 ms */
+#define APDS9253_RESOLUTION_16BIT_25MS  BIT(6)            /**< 16-bit, 25 ms */
+#define APDS9253_RESOLUTION_13BIT_3MS   (BIT(6) | BIT(4)) /**< 13-bit, 3 ms */
 /** @} */
 
 /**
- * @name apds9253 measurement rate
+ * @name Measurement rate
+ *
+ * Values for the `rate` devicetree property.
  * @{
  */
-
-#define APDS9253_MEASUREMENT_RATE_2000MS (BIT(2) | BIT(1) | BIT(0))
-#define APDS9253_MEASUREMENT_RATE_1000MS (BIT(2) | BIT(0))
-#define APDS9253_MEASUREMENT_RATE_500MS  BIT(2)
-#define APDS9253_MEASUREMENT_RATE_200MS  (BIT(1) | BIT(0))
-#define APDS9253_MEASUREMENT_RATE_100MS  BIT(1) /* default */
-#define APDS9253_MEASUREMENT_RATE_50MS   BIT(0)
-#define APDS9253_MEASUREMENT_RATE_25MS   0
-
+#define APDS9253_MEASUREMENT_RATE_2000MS (BIT(2) | BIT(1) | BIT(0)) /**< 2000 ms */
+#define APDS9253_MEASUREMENT_RATE_1000MS (BIT(2) | BIT(0))          /**< 1000 ms */
+#define APDS9253_MEASUREMENT_RATE_500MS  BIT(2)                     /**< 500 ms */
+#define APDS9253_MEASUREMENT_RATE_200MS  (BIT(1) | BIT(0))          /**< 200 ms */
+#define APDS9253_MEASUREMENT_RATE_100MS  BIT(1)                     /**< 100 ms (default) */
+#define APDS9253_MEASUREMENT_RATE_50MS   BIT(0)                     /**< 50 ms */
+#define APDS9253_MEASUREMENT_RATE_25MS   0                          /**< 25 ms */
 /** @} */
 
 /**
- * @name apds9253 gain range
+ * @name Gain range
+ *
+ * Values for the `gain` devicetree property.
  * @{
  */
-
-#define APDS9253_GAIN_RANGE_18 BIT(2)
-#define APDS9253_GAIN_RANGE_9  (BIT(1) | BIT(0))
-#define APDS9253_GAIN_RANGE_6  BIT(1)
-#define APDS9253_GAIN_RANGE_3  BIT(0) /* default */
-#define APDS9253_GAIN_RANGE_1  0
+#define APDS9253_GAIN_RANGE_18 BIT(2)            /**< 18x gain */
+#define APDS9253_GAIN_RANGE_9  (BIT(1) | BIT(0)) /**< 9x gain */
+#define APDS9253_GAIN_RANGE_6  BIT(1)            /**< 6x gain */
+#define APDS9253_GAIN_RANGE_3  BIT(0)            /**< 3x gain (default) */
+#define APDS9253_GAIN_RANGE_1  0                 /**< 1x gain */
+/** @} */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/sensor/bmp581.h
+++ b/include/zephyr/dt-bindings/sensor/bmp581.h
@@ -20,7 +20,9 @@
  */
 
 /**
- * @defgroup bmp581_power_modes Sensor power modes
+ * @name Sensor power modes
+ *
+ * Values for the `power-mode` devicetree property.
  * @{
  */
 #define BMP581_DT_MODE_NORMAL		1 /**< NORMAL mode */
@@ -29,7 +31,9 @@
 /** @} */
 
 /**
- * @defgroup bmp581_output_data_rate Output data rate options
+ * @name Output data rate options
+ *
+ * Values for the `odr` devicetree property.
  * @{
  */
 #define BMP581_DT_ODR_240_HZ		0x00 /**< 240 Hz */
@@ -67,7 +71,9 @@
 /** @} */
 
 /**
- * @defgroup bmp581_oversampling Oversampling options.
+ * @name Oversampling options
+ *
+ * Values for the `press-osr` and `temp-osr` devicetree properties.
  *
  * Valid values for temperature and pressure sensor oversampling ratio.
  * @{
@@ -83,7 +89,10 @@
 /** @} */
 
 /**
- * @defgroup bmp581_iir_filter IIR Filter options.
+ * @name IIR Filter options
+ * @anchor bmp581_iir_filter
+ *
+ * Values for the `press-iir` and `temp-iir` devicetree properties.
  *
  * Valid values for temperature and pressure IIR filter coefficient.
  *
@@ -98,7 +107,6 @@
  * - @f$ filtercoefficient @f$ is one of the coefficient values below
  *
  * Higher coefficient values provide more filtering (smoother output) but increase response time.
- *
  * @{
  */
 #define BMP581_DT_IIR_FILTER_BYPASS	0x00 /**< Bypass */

--- a/include/zephyr/dt-bindings/sensor/bq274xx.h
+++ b/include/zephyr/dt-bindings/sensor/bq274xx.h
@@ -11,17 +11,45 @@
  *   Datasheet: https://www.ti.com/lit/gpn/bq27427
  *   Technical reference manual: https://www.ti.com/lit/pdf/sluucd5
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the TI BQ274xx fuel gauges.
+ * @ingroup bq274xx_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_BQ274XX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_BQ274XX_H_
 
-/* Chemistry IDs for BQ27427 */
-#define BQ27427_CHEM_ID_A 0x3230
-#define BQ27427_CHEM_ID_B 0x1202
-#define BQ27427_CHEM_ID_C 0x3142
+/**
+ * @defgroup bq274xx_interface BQ274XX
+ * @ingroup sensor_interface_ext_ti
+ * @brief Texas Instruments BQ274xx battery fuel gauges
+ * @{
+ */
 
-/* Chemistry IDs for BQ27421 variants */
-#define BQ27421_G1A_CHEM_ID 0x0128
-#define BQ27421_G1B_CHEM_ID 0x0312
-#define BQ27421_G1D_CHEM_ID 0x3142
+/**
+ * @name BQ27427 chemistry IDs
+ *
+ * Values for the `chemistry-id` devicetree property.
+ * @{
+ */
+#define BQ27427_CHEM_ID_A 0x3230 /**< Chemistry profile A (4.35 V) */
+#define BQ27427_CHEM_ID_B 0x1202 /**< Chemistry profile B (4.2 V, default) */
+#define BQ27427_CHEM_ID_C 0x3142 /**< Chemistry profile C (4.4 V) */
+/** @} */
+
+/**
+ * @name BQ27421 chemistry IDs
+ *
+ * Values for the `chemistry-id` devicetree property.
+ * @{
+ */
+#define BQ27421_G1A_CHEM_ID 0x0128 /**< BQ27421-G1A chemistry ID */
+#define BQ27421_G1B_CHEM_ID 0x0312 /**< BQ27421-G1B chemistry ID */
+#define BQ27421_G1D_CHEM_ID 0x3142 /**< BQ27421-G1D chemistry ID */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_BQ274XX_H_ */

--- a/include/zephyr/dt-bindings/sensor/icm42686.h
+++ b/include/zephyr/dt-bindings/sensor/icm42686.h
@@ -4,97 +4,117 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the TDK InvenSense ICM42686 IMU.
+ * @ingroup icm42686_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_TDK_ICM42686P_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_TDK_ICM42686P_H_
 
 #include "icm4268x.h"
 
 /**
- * @defgroup ICM42686 Invensense (TDK) ICM42686 DT Options
- * @ingroup sensor_interface
+ * @defgroup icm42686_interface ICM42686
+ * @ingroup sensor_interface_ext_tdk
+ * @brief TDK InvenSense ICM42686 6-axis IMU
  * @{
  */
 
 /**
- * @defgroup ICM42686_ACCEL_POWER_MODES Accelerometer power modes
+ * @name Accelerometer power modes
+ *
+ * Values for the `accel-pwr-mode` devicetree property.
  * @{
  */
-#define ICM42686_DT_ACCEL_OFF		ICM4268X_DT_ACCEL_OFF
-#define ICM42686_DT_ACCEL_LP		ICM4268X_DT_ACCEL_LP
-#define ICM42686_DT_ACCEL_LN		ICM4268X_DT_ACCEL_LN
+#define ICM42686_DT_ACCEL_OFF		ICM4268X_DT_ACCEL_OFF /**< Powered down */
+#define ICM42686_DT_ACCEL_LP		ICM4268X_DT_ACCEL_LP  /**< Low-power mode */
+#define ICM42686_DT_ACCEL_LN		ICM4268X_DT_ACCEL_LN  /**< Low-noise mode */
 /** @} */
 
 /**
- * @defgroup ICM42686_GYRO_POWER_MODES Gyroscope power modes
+ * @name Gyroscope power modes
+ *
+ * Values for the `gyro-pwr-mode` devicetree property.
  * @{
  */
-#define ICM42686_DT_GYRO_OFF		ICM4268X_DT_GYRO_OFF
-#define ICM42686_DT_GYRO_STANDBY	ICM4268X_DT_GYRO_STANDBY
-#define ICM42686_DT_GYRO_LN		ICM4268X_DT_GYRO_LN
+#define ICM42686_DT_GYRO_OFF		ICM4268X_DT_GYRO_OFF     /**< Powered down */
+#define ICM42686_DT_GYRO_STANDBY	ICM4268X_DT_GYRO_STANDBY /**< Standby */
+#define ICM42686_DT_GYRO_LN		ICM4268X_DT_GYRO_LN      /**< Low-noise mode */
 /** @} */
 
 /**
- * @defgroup ICM42686_ACCEL_SCALE Accelerometer scale options
+ * @name Accelerometer full-scale range options
+ *
+ * Values for the `accel-fs` devicetree property.
  * @{
  */
-#define ICM42686_DT_ACCEL_FS_32		0
-#define ICM42686_DT_ACCEL_FS_16		1
-#define ICM42686_DT_ACCEL_FS_8		2
-#define ICM42686_DT_ACCEL_FS_4		3
-#define ICM42686_DT_ACCEL_FS_2		4
+#define ICM42686_DT_ACCEL_FS_32		0 /**< ±32 g */
+#define ICM42686_DT_ACCEL_FS_16		1 /**< ±16 g */
+#define ICM42686_DT_ACCEL_FS_8		2 /**< ±8 g */
+#define ICM42686_DT_ACCEL_FS_4		3 /**< ±4 g */
+#define ICM42686_DT_ACCEL_FS_2		4 /**< ±2 g */
 /** @} */
 
 /**
- * @defgroup ICM42686_GYRO_SCALE Gyroscope scale options
+ * @name Gyroscope full-scale range options
+ *
+ * Values for the `gyro-fs` devicetree property.
  * @{
  */
-#define ICM42686_DT_GYRO_FS_4000		0
-#define ICM42686_DT_GYRO_FS_2000		1
-#define ICM42686_DT_GYRO_FS_1000		2
-#define ICM42686_DT_GYRO_FS_500			3
-#define ICM42686_DT_GYRO_FS_250			4
-#define ICM42686_DT_GYRO_FS_125			5
-#define ICM42686_DT_GYRO_FS_62_5		6
-#define ICM42686_DT_GYRO_FS_31_25		7
+#define ICM42686_DT_GYRO_FS_4000		0 /**< ±4000 dps */
+#define ICM42686_DT_GYRO_FS_2000		1 /**< ±2000 dps */
+#define ICM42686_DT_GYRO_FS_1000		2 /**< ±1000 dps */
+#define ICM42686_DT_GYRO_FS_500			3 /**< ±500 dps */
+#define ICM42686_DT_GYRO_FS_250			4 /**< ±250 dps */
+#define ICM42686_DT_GYRO_FS_125			5 /**< ±125 dps */
+#define ICM42686_DT_GYRO_FS_62_5		6 /**< ±62.5 dps */
+#define ICM42686_DT_GYRO_FS_31_25		7 /**< ±31.25 dps */
 /** @} */
 
 /**
- * @defgroup ICM42686_ACCEL_DATA_RATE Accelerometer data rate options
+ * @name Accelerometer data rate options
+ *
+ * Values for the `accel-odr` devicetree property.
  * @{
  */
-#define ICM42686_DT_ACCEL_ODR_32000		ICM4268X_DT_ACCEL_ODR_32000
-#define ICM42686_DT_ACCEL_ODR_16000		ICM4268X_DT_ACCEL_ODR_16000
-#define ICM42686_DT_ACCEL_ODR_8000		ICM4268X_DT_ACCEL_ODR_8000
-#define ICM42686_DT_ACCEL_ODR_4000		ICM4268X_DT_ACCEL_ODR_4000
-#define ICM42686_DT_ACCEL_ODR_2000		ICM4268X_DT_ACCEL_ODR_2000
-#define ICM42686_DT_ACCEL_ODR_1000		ICM4268X_DT_ACCEL_ODR_1000
-#define ICM42686_DT_ACCEL_ODR_200		ICM4268X_DT_ACCEL_ODR_200
-#define ICM42686_DT_ACCEL_ODR_100		ICM4268X_DT_ACCEL_ODR_100
-#define ICM42686_DT_ACCEL_ODR_50		ICM4268X_DT_ACCEL_ODR_50
-#define ICM42686_DT_ACCEL_ODR_25		ICM4268X_DT_ACCEL_ODR_25
-#define ICM42686_DT_ACCEL_ODR_12_5		ICM4268X_DT_ACCEL_ODR_12_5
-#define ICM42686_DT_ACCEL_ODR_6_25		ICM4268X_DT_ACCEL_ODR_6_25
-#define ICM42686_DT_ACCEL_ODR_3_125		ICM4268X_DT_ACCEL_ODR_3_125
-#define ICM42686_DT_ACCEL_ODR_1_5625		ICM4268X_DT_ACCEL_ODR_1_5625
-#define ICM42686_DT_ACCEL_ODR_500		ICM4268X_DT_ACCEL_ODR_500
+#define ICM42686_DT_ACCEL_ODR_32000		ICM4268X_DT_ACCEL_ODR_32000 /**< 32 kHz */
+#define ICM42686_DT_ACCEL_ODR_16000		ICM4268X_DT_ACCEL_ODR_16000 /**< 16 kHz */
+#define ICM42686_DT_ACCEL_ODR_8000		ICM4268X_DT_ACCEL_ODR_8000  /**< 8 kHz */
+#define ICM42686_DT_ACCEL_ODR_4000		ICM4268X_DT_ACCEL_ODR_4000  /**< 4 kHz */
+#define ICM42686_DT_ACCEL_ODR_2000		ICM4268X_DT_ACCEL_ODR_2000  /**< 2 kHz */
+#define ICM42686_DT_ACCEL_ODR_1000		ICM4268X_DT_ACCEL_ODR_1000  /**< 1 kHz */
+#define ICM42686_DT_ACCEL_ODR_200		ICM4268X_DT_ACCEL_ODR_200   /**< 200 Hz */
+#define ICM42686_DT_ACCEL_ODR_100		ICM4268X_DT_ACCEL_ODR_100   /**< 100 Hz */
+#define ICM42686_DT_ACCEL_ODR_50		ICM4268X_DT_ACCEL_ODR_50    /**< 50 Hz */
+#define ICM42686_DT_ACCEL_ODR_25		ICM4268X_DT_ACCEL_ODR_25    /**< 25 Hz */
+#define ICM42686_DT_ACCEL_ODR_12_5		ICM4268X_DT_ACCEL_ODR_12_5  /**< 12.5 Hz */
+#define ICM42686_DT_ACCEL_ODR_6_25		ICM4268X_DT_ACCEL_ODR_6_25  /**< 6.25 Hz */
+#define ICM42686_DT_ACCEL_ODR_3_125		ICM4268X_DT_ACCEL_ODR_3_125 /**< 3.125 Hz */
+#define ICM42686_DT_ACCEL_ODR_1_5625		ICM4268X_DT_ACCEL_ODR_1_5625 /**< 1.5625 Hz */
+#define ICM42686_DT_ACCEL_ODR_500		ICM4268X_DT_ACCEL_ODR_500   /**< 500 Hz */
 /** @} */
 
 /**
- * @defgroup ICM42686_GYRO_DATA_RATE Gyroscope data rate options
+ * @name Gyroscope data rate options
+ *
+ * Values for the `gyro-odr` devicetree property.
  * @{
  */
-#define ICM42686_DT_GYRO_ODR_32000		ICM4268X_DT_GYRO_ODR_32000
-#define ICM42686_DT_GYRO_ODR_16000		ICM4268X_DT_GYRO_ODR_16000
-#define ICM42686_DT_GYRO_ODR_8000		ICM4268X_DT_GYRO_ODR_8000
-#define ICM42686_DT_GYRO_ODR_4000		ICM4268X_DT_GYRO_ODR_4000
-#define ICM42686_DT_GYRO_ODR_2000		ICM4268X_DT_GYRO_ODR_2000
-#define ICM42686_DT_GYRO_ODR_1000		ICM4268X_DT_GYRO_ODR_1000
-#define ICM42686_DT_GYRO_ODR_200		ICM4268X_DT_GYRO_ODR_200
-#define ICM42686_DT_GYRO_ODR_100		ICM4268X_DT_GYRO_ODR_100
-#define ICM42686_DT_GYRO_ODR_50			ICM4268X_DT_GYRO_ODR_50
-#define ICM42686_DT_GYRO_ODR_25			ICM4268X_DT_GYRO_ODR_25
-#define ICM42686_DT_GYRO_ODR_12_5		ICM4268X_DT_GYRO_ODR_12_5
-#define ICM42686_DT_GYRO_ODR_500		ICM4268X_DT_GYRO_ODR_500
+#define ICM42686_DT_GYRO_ODR_32000		ICM4268X_DT_GYRO_ODR_32000 /**< 32 kHz */
+#define ICM42686_DT_GYRO_ODR_16000		ICM4268X_DT_GYRO_ODR_16000 /**< 16 kHz */
+#define ICM42686_DT_GYRO_ODR_8000		ICM4268X_DT_GYRO_ODR_8000  /**< 8 kHz */
+#define ICM42686_DT_GYRO_ODR_4000		ICM4268X_DT_GYRO_ODR_4000  /**< 4 kHz */
+#define ICM42686_DT_GYRO_ODR_2000		ICM4268X_DT_GYRO_ODR_2000  /**< 2 kHz */
+#define ICM42686_DT_GYRO_ODR_1000		ICM4268X_DT_GYRO_ODR_1000  /**< 1 kHz */
+#define ICM42686_DT_GYRO_ODR_200		ICM4268X_DT_GYRO_ODR_200   /**< 200 Hz */
+#define ICM42686_DT_GYRO_ODR_100		ICM4268X_DT_GYRO_ODR_100   /**< 100 Hz */
+#define ICM42686_DT_GYRO_ODR_50			ICM4268X_DT_GYRO_ODR_50    /**< 50 Hz */
+#define ICM42686_DT_GYRO_ODR_25			ICM4268X_DT_GYRO_ODR_25    /**< 25 Hz */
+#define ICM42686_DT_GYRO_ODR_12_5		ICM4268X_DT_GYRO_ODR_12_5  /**< 12.5 Hz */
+#define ICM42686_DT_GYRO_ODR_500		ICM4268X_DT_GYRO_ODR_500   /**< 500 Hz */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/icm42688.h
+++ b/include/zephyr/dt-bindings/sensor/icm42688.h
@@ -4,96 +4,116 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the TDK InvenSense ICM42688 IMU.
+ * @ingroup icm42688_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_TDK_ICM42688P_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_TDK_ICM42688P_H_
 
 #include "icm4268x.h"
 
 /**
- * @defgroup icm42688 Invensense (TDK) ICM42688 DT Options
- * @ingroup sensor_interface
+ * @defgroup icm42688_interface ICM42688
+ * @ingroup sensor_interface_ext_tdk
+ * @brief TDK InvenSense ICM42688 6-axis IMU
  * @{
  */
 
 /**
- * @defgroup icm42688_accel_power_modes Accelerometer power modes
+ * @name Accelerometer power modes
+ *
+ * Values for the `accel-pwr-mode` devicetree property.
  * @{
  */
-#define ICM42688_DT_ACCEL_OFF		ICM4268X_DT_ACCEL_OFF
-#define ICM42688_DT_ACCEL_LP		ICM4268X_DT_ACCEL_LP
-#define ICM42688_DT_ACCEL_LN		ICM4268X_DT_ACCEL_LN
+#define ICM42688_DT_ACCEL_OFF		ICM4268X_DT_ACCEL_OFF /**< Powered down */
+#define ICM42688_DT_ACCEL_LP		ICM4268X_DT_ACCEL_LP  /**< Low-power mode */
+#define ICM42688_DT_ACCEL_LN		ICM4268X_DT_ACCEL_LN  /**< Low-noise mode */
 /** @} */
 
 /**
- * @defgroup icm42688_gyro_power_modes Gyroscope power modes
+ * @name Gyroscope power modes
+ *
+ * Values for the `gyro-pwr-mode` devicetree property.
  * @{
  */
-#define ICM42688_DT_GYRO_OFF		ICM4268X_DT_GYRO_OFF
-#define ICM42688_DT_GYRO_STANDBY	ICM4268X_DT_GYRO_STANDBY
-#define ICM42688_DT_GYRO_LN		ICM4268X_DT_GYRO_LN
+#define ICM42688_DT_GYRO_OFF		ICM4268X_DT_GYRO_OFF     /**< Powered down */
+#define ICM42688_DT_GYRO_STANDBY	ICM4268X_DT_GYRO_STANDBY /**< Standby */
+#define ICM42688_DT_GYRO_LN		ICM4268X_DT_GYRO_LN      /**< Low-noise mode */
 /** @} */
 
 /**
- * @defgroup icm42688_accel_scale Accelerometer scale options
+ * @name Accelerometer full-scale range options
+ *
+ * Values for the `accel-fs` devicetree property.
  * @{
  */
-#define ICM42688_DT_ACCEL_FS_16	0
-#define ICM42688_DT_ACCEL_FS_8		1
-#define ICM42688_DT_ACCEL_FS_4		2
-#define ICM42688_DT_ACCEL_FS_2		3
+#define ICM42688_DT_ACCEL_FS_16	0 /**< ±16 g */
+#define ICM42688_DT_ACCEL_FS_8		1 /**< ±8 g */
+#define ICM42688_DT_ACCEL_FS_4		2 /**< ±4 g */
+#define ICM42688_DT_ACCEL_FS_2		3 /**< ±2 g */
 /** @} */
 
 /**
- * @defgroup icm42688_gyro_scale Gyroscope scale options
+ * @name Gyroscope full-scale range options
+ *
+ * Values for the `gyro-fs` devicetree property.
  * @{
  */
-#define ICM42688_DT_GYRO_FS_2000		0
-#define ICM42688_DT_GYRO_FS_1000		1
-#define ICM42688_DT_GYRO_FS_500		2
-#define ICM42688_DT_GYRO_FS_250		3
-#define ICM42688_DT_GYRO_FS_125		4
-#define ICM42688_DT_GYRO_FS_62_5		5
-#define ICM42688_DT_GYRO_FS_31_25		6
-#define ICM42688_DT_GYRO_FS_15_625		7
+#define ICM42688_DT_GYRO_FS_2000		0 /**< ±2000 dps */
+#define ICM42688_DT_GYRO_FS_1000		1 /**< ±1000 dps */
+#define ICM42688_DT_GYRO_FS_500		2 /**< ±500 dps */
+#define ICM42688_DT_GYRO_FS_250		3 /**< ±250 dps */
+#define ICM42688_DT_GYRO_FS_125		4 /**< ±125 dps */
+#define ICM42688_DT_GYRO_FS_62_5		5 /**< ±62.5 dps */
+#define ICM42688_DT_GYRO_FS_31_25		6 /**< ±31.25 dps */
+#define ICM42688_DT_GYRO_FS_15_625		7 /**< ±15.625 dps */
 /** @} */
 
 /**
- * @defgroup icm42688_accel_data_rate Accelerometer data rate options
+ * @name Accelerometer data rate options
+ *
+ * Values for the `accel-odr` devicetree property.
  * @{
  */
-#define ICM42688_DT_ACCEL_ODR_32000		ICM4268X_DT_ACCEL_ODR_32000
-#define ICM42688_DT_ACCEL_ODR_16000		ICM4268X_DT_ACCEL_ODR_16000
-#define ICM42688_DT_ACCEL_ODR_8000		ICM4268X_DT_ACCEL_ODR_8000
-#define ICM42688_DT_ACCEL_ODR_4000		ICM4268X_DT_ACCEL_ODR_4000
-#define ICM42688_DT_ACCEL_ODR_2000		ICM4268X_DT_ACCEL_ODR_2000
-#define ICM42688_DT_ACCEL_ODR_1000		ICM4268X_DT_ACCEL_ODR_1000
-#define ICM42688_DT_ACCEL_ODR_200		ICM4268X_DT_ACCEL_ODR_200
-#define ICM42688_DT_ACCEL_ODR_100		ICM4268X_DT_ACCEL_ODR_100
-#define ICM42688_DT_ACCEL_ODR_50		ICM4268X_DT_ACCEL_ODR_50
-#define ICM42688_DT_ACCEL_ODR_25		ICM4268X_DT_ACCEL_ODR_25
-#define ICM42688_DT_ACCEL_ODR_12_5		ICM4268X_DT_ACCEL_ODR_12_5
-#define ICM42688_DT_ACCEL_ODR_6_25		ICM4268X_DT_ACCEL_ODR_6_25
-#define ICM42688_DT_ACCEL_ODR_3_125		ICM4268X_DT_ACCEL_ODR_3_125
-#define ICM42688_DT_ACCEL_ODR_1_5625		ICM4268X_DT_ACCEL_ODR_1_5625
-#define ICM42688_DT_ACCEL_ODR_500		ICM4268X_DT_ACCEL_ODR_500
+#define ICM42688_DT_ACCEL_ODR_32000	ICM4268X_DT_ACCEL_ODR_32000  /**< 32 kHz */
+#define ICM42688_DT_ACCEL_ODR_16000	ICM4268X_DT_ACCEL_ODR_16000  /**< 16 kHz */
+#define ICM42688_DT_ACCEL_ODR_8000	ICM4268X_DT_ACCEL_ODR_8000   /**< 8 kHz */
+#define ICM42688_DT_ACCEL_ODR_4000	ICM4268X_DT_ACCEL_ODR_4000   /**< 4 kHz */
+#define ICM42688_DT_ACCEL_ODR_2000	ICM4268X_DT_ACCEL_ODR_2000   /**< 2 kHz */
+#define ICM42688_DT_ACCEL_ODR_1000	ICM4268X_DT_ACCEL_ODR_1000   /**< 1 kHz */
+#define ICM42688_DT_ACCEL_ODR_200	ICM4268X_DT_ACCEL_ODR_200    /**< 200 Hz */
+#define ICM42688_DT_ACCEL_ODR_100	ICM4268X_DT_ACCEL_ODR_100    /**< 100 Hz */
+#define ICM42688_DT_ACCEL_ODR_50	ICM4268X_DT_ACCEL_ODR_50     /**< 50 Hz */
+#define ICM42688_DT_ACCEL_ODR_25	ICM4268X_DT_ACCEL_ODR_25     /**< 25 Hz */
+#define ICM42688_DT_ACCEL_ODR_12_5	ICM4268X_DT_ACCEL_ODR_12_5   /**< 12.5 Hz */
+#define ICM42688_DT_ACCEL_ODR_6_25	ICM4268X_DT_ACCEL_ODR_6_25   /**< 6.25 Hz */
+#define ICM42688_DT_ACCEL_ODR_3_125	ICM4268X_DT_ACCEL_ODR_3_125  /**< 3.125 Hz */
+#define ICM42688_DT_ACCEL_ODR_1_5625	ICM4268X_DT_ACCEL_ODR_1_5625 /**< 1.5625 Hz */
+#define ICM42688_DT_ACCEL_ODR_500	ICM4268X_DT_ACCEL_ODR_500    /**< 500 Hz */
 /** @} */
 
 /**
- * @defgroup icm42688_gyro_data_rate Gyroscope data rate options
+ * @name Gyroscope data rate options
+ *
+ * Values for the `gyro-odr` devicetree property.
  * @{
  */
-#define ICM42688_DT_GYRO_ODR_32000		ICM4268X_DT_GYRO_ODR_32000
-#define ICM42688_DT_GYRO_ODR_16000		ICM4268X_DT_GYRO_ODR_16000
-#define ICM42688_DT_GYRO_ODR_8000		ICM4268X_DT_GYRO_ODR_8000
-#define ICM42688_DT_GYRO_ODR_4000		ICM4268X_DT_GYRO_ODR_4000
-#define ICM42688_DT_GYRO_ODR_2000		ICM4268X_DT_GYRO_ODR_2000
-#define ICM42688_DT_GYRO_ODR_1000		ICM4268X_DT_GYRO_ODR_1000
-#define ICM42688_DT_GYRO_ODR_200		ICM4268X_DT_GYRO_ODR_200
-#define ICM42688_DT_GYRO_ODR_100		ICM4268X_DT_GYRO_ODR_100
-#define ICM42688_DT_GYRO_ODR_50			ICM4268X_DT_GYRO_ODR_50
-#define ICM42688_DT_GYRO_ODR_25			ICM4268X_DT_GYRO_ODR_25
-#define ICM42688_DT_GYRO_ODR_12_5		ICM4268X_DT_GYRO_ODR_12_5
-#define ICM42688_DT_GYRO_ODR_500		ICM4268X_DT_GYRO_ODR_500
+#define ICM42688_DT_GYRO_ODR_32000	ICM4268X_DT_GYRO_ODR_32000 /**< 32 kHz */
+#define ICM42688_DT_GYRO_ODR_16000	ICM4268X_DT_GYRO_ODR_16000 /**< 16 kHz */
+#define ICM42688_DT_GYRO_ODR_8000	ICM4268X_DT_GYRO_ODR_8000  /**< 8 kHz */
+#define ICM42688_DT_GYRO_ODR_4000	ICM4268X_DT_GYRO_ODR_4000  /**< 4 kHz */
+#define ICM42688_DT_GYRO_ODR_2000	ICM4268X_DT_GYRO_ODR_2000  /**< 2 kHz */
+#define ICM42688_DT_GYRO_ODR_1000	ICM4268X_DT_GYRO_ODR_1000  /**< 1 kHz */
+#define ICM42688_DT_GYRO_ODR_200	ICM4268X_DT_GYRO_ODR_200   /**< 200 Hz */
+#define ICM42688_DT_GYRO_ODR_100	ICM4268X_DT_GYRO_ODR_100   /**< 100 Hz */
+#define ICM42688_DT_GYRO_ODR_50		ICM4268X_DT_GYRO_ODR_50    /**< 50 Hz */
+#define ICM42688_DT_GYRO_ODR_25		ICM4268X_DT_GYRO_ODR_25    /**< 25 Hz */
+#define ICM42688_DT_GYRO_ODR_12_5	ICM4268X_DT_GYRO_ODR_12_5  /**< 12.5 Hz */
+#define ICM42688_DT_GYRO_ODR_500	ICM4268X_DT_GYRO_ODR_500   /**< 500 Hz */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/icm4268x.h
+++ b/include/zephyr/dt-bindings/sensor/icm4268x.h
@@ -4,72 +4,88 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants shared by the TDK InvenSense ICM4268x IMUs.
+ * @ingroup icm4268x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_TDK_ICM4268X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_TDK_ICM4268X_H_
 
 #include "sensor_axis_align.h"
 
 /**
- * @defgroup ICM4268X Invensense (TDK) ICM4268X DT Options
- * @ingroup sensor_interface
+ * @defgroup icm4268x_interface ICM4268X
+ * @ingroup sensor_interface_ext_tdk
+ * @brief TDK InvenSense ICM4268x 6-axis IMU family
  * @{
  */
 
 /**
- * @defgroup ICM4268X_ACCEL_POWER_MODES Accelerometer power modes
+ * @name Accelerometer power modes
+ *
+ * Values for the `accel-pwr-mode` devicetree property.
  * @{
  */
-#define ICM4268X_DT_ACCEL_OFF		0
-#define ICM4268X_DT_ACCEL_LP		2
-#define ICM4268X_DT_ACCEL_LN		3
+#define ICM4268X_DT_ACCEL_OFF		0 /**< Powered down */
+#define ICM4268X_DT_ACCEL_LP		2 /**< Low-power mode */
+#define ICM4268X_DT_ACCEL_LN		3 /**< Low-noise mode */
 /** @} */
 
 /**
- * @defgroup ICM4268X_GYRO_POWER_MODES Gyroscope power modes
+ * @name Gyroscope power modes
+ *
+ * Values for the `gyro-pwr-mode` devicetree property.
  * @{
  */
-#define ICM4268X_DT_GYRO_OFF		0
-#define ICM4268X_DT_GYRO_STANDBY	1
-#define ICM4268X_DT_GYRO_LN		3
+#define ICM4268X_DT_GYRO_OFF		0 /**< Powered down */
+#define ICM4268X_DT_GYRO_STANDBY	1 /**< Standby */
+#define ICM4268X_DT_GYRO_LN		3 /**< Low-noise mode */
 /** @} */
 
 /**
- * @defgroup ICM4268X_ACCEL_DATA_RATE Accelerometer data rate options
+ * @name Accelerometer data rate options
+ *
+ * Values for the `accel-odr` devicetree property.
  * @{
  */
-#define ICM4268X_DT_ACCEL_ODR_32000		1
-#define ICM4268X_DT_ACCEL_ODR_16000		2
-#define ICM4268X_DT_ACCEL_ODR_8000		3
-#define ICM4268X_DT_ACCEL_ODR_4000		4
-#define ICM4268X_DT_ACCEL_ODR_2000		5
-#define ICM4268X_DT_ACCEL_ODR_1000		6
-#define ICM4268X_DT_ACCEL_ODR_200		7
-#define ICM4268X_DT_ACCEL_ODR_100		8
-#define ICM4268X_DT_ACCEL_ODR_50		9
-#define ICM4268X_DT_ACCEL_ODR_25		10
-#define ICM4268X_DT_ACCEL_ODR_12_5		11
-#define ICM4268X_DT_ACCEL_ODR_6_25		12
-#define ICM4268X_DT_ACCEL_ODR_3_125		13
-#define ICM4268X_DT_ACCEL_ODR_1_5625		14
-#define ICM4268X_DT_ACCEL_ODR_500		15
+#define ICM4268X_DT_ACCEL_ODR_32000		1  /**< 32 kHz */
+#define ICM4268X_DT_ACCEL_ODR_16000		2  /**< 16 kHz */
+#define ICM4268X_DT_ACCEL_ODR_8000		3  /**< 8 kHz */
+#define ICM4268X_DT_ACCEL_ODR_4000		4  /**< 4 kHz */
+#define ICM4268X_DT_ACCEL_ODR_2000		5  /**< 2 kHz */
+#define ICM4268X_DT_ACCEL_ODR_1000		6  /**< 1 kHz */
+#define ICM4268X_DT_ACCEL_ODR_200		7  /**< 200 Hz */
+#define ICM4268X_DT_ACCEL_ODR_100		8  /**< 100 Hz */
+#define ICM4268X_DT_ACCEL_ODR_50		9  /**< 50 Hz */
+#define ICM4268X_DT_ACCEL_ODR_25		10 /**< 25 Hz */
+#define ICM4268X_DT_ACCEL_ODR_12_5		11 /**< 12.5 Hz */
+#define ICM4268X_DT_ACCEL_ODR_6_25		12 /**< 6.25 Hz */
+#define ICM4268X_DT_ACCEL_ODR_3_125		13 /**< 3.125 Hz */
+#define ICM4268X_DT_ACCEL_ODR_1_5625		14 /**< 1.5625 Hz */
+#define ICM4268X_DT_ACCEL_ODR_500		15 /**< 500 Hz */
 /** @} */
 
 /**
- * @defgroup ICM4268X_GYRO_DATA_RATE Gyroscope data rate options
+ * @name Gyroscope data rate options
+ *
+ * Values for the `gyro-odr` devicetree property.
  * @{
  */
-#define ICM4268X_DT_GYRO_ODR_32000		1
-#define ICM4268X_DT_GYRO_ODR_16000		2
-#define ICM4268X_DT_GYRO_ODR_8000		3
-#define ICM4268X_DT_GYRO_ODR_4000		4
-#define ICM4268X_DT_GYRO_ODR_2000		5
-#define ICM4268X_DT_GYRO_ODR_1000		6
-#define ICM4268X_DT_GYRO_ODR_200		7
-#define ICM4268X_DT_GYRO_ODR_100		8
-#define ICM4268X_DT_GYRO_ODR_50			9
-#define ICM4268X_DT_GYRO_ODR_25			10
-#define ICM4268X_DT_GYRO_ODR_12_5		11
-#define ICM4268X_DT_GYRO_ODR_500		15
+#define ICM4268X_DT_GYRO_ODR_32000		1  /**< 32 kHz */
+#define ICM4268X_DT_GYRO_ODR_16000		2  /**< 16 kHz */
+#define ICM4268X_DT_GYRO_ODR_8000		3  /**< 8 kHz */
+#define ICM4268X_DT_GYRO_ODR_4000		4  /**< 4 kHz */
+#define ICM4268X_DT_GYRO_ODR_2000		5  /**< 2 kHz */
+#define ICM4268X_DT_GYRO_ODR_1000		6  /**< 1 kHz */
+#define ICM4268X_DT_GYRO_ODR_200		7  /**< 200 Hz */
+#define ICM4268X_DT_GYRO_ODR_100		8  /**< 100 Hz */
+#define ICM4268X_DT_GYRO_ODR_50			9  /**< 50 Hz */
+#define ICM4268X_DT_GYRO_ODR_25			10 /**< 25 Hz */
+#define ICM4268X_DT_GYRO_ODR_12_5		11 /**< 12.5 Hz */
+#define ICM4268X_DT_GYRO_ODR_500		15 /**< 500 Hz */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/icm45686.h
+++ b/include/zephyr/dt-bindings/sensor/icm45686.h
@@ -5,124 +5,151 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the TDK InvenSense ICM45686 IMU.
+ * @ingroup icm45686_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_TDK_ICM45686_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_TDK_ICM45686_H_
 
 /**
- * @defgroup ICM45686 Invensense (TDK) ICM45686 DT Options
- * @ingroup sensor_interface
+ * @defgroup icm45686_interface ICM45686
+ * @ingroup sensor_interface_ext_tdk
+ * @brief TDK InvenSense ICM45686 6-axis IMU
  * @{
  */
 
 /**
- * @defgroup ICM45686_ACCEL_POWER_MODES Accelerometer power modes
+ * @name Accelerometer power modes
+ *
+ * Values for the `accel-pwr-mode` devicetree property.
  * @{
  */
-#define ICM45686_DT_ACCEL_OFF		0
-#define ICM45686_DT_ACCEL_LP		2
-#define ICM45686_DT_ACCEL_LN		3
+#define ICM45686_DT_ACCEL_OFF		0 /**< Powered down */
+#define ICM45686_DT_ACCEL_LP		2 /**< Low-power mode */
+#define ICM45686_DT_ACCEL_LN		3 /**< Low-noise mode */
 /** @} */
 
 /**
- * @defgroup ICM45686_GYRO_POWER_MODES Gyroscope power modes
+ * @name Gyroscope power modes
+ *
+ * Values for the `gyro-pwr-mode` devicetree property.
  * @{
  */
-#define ICM45686_DT_GYRO_OFF		0
-#define ICM45686_DT_GYRO_STANDBY	1
-#define ICM45686_DT_GYRO_LP		2
-#define ICM45686_DT_GYRO_LN		3
+#define ICM45686_DT_GYRO_OFF		0 /**< Powered down */
+#define ICM45686_DT_GYRO_STANDBY	1 /**< Standby */
+#define ICM45686_DT_GYRO_LP		2 /**< Low-power mode */
+#define ICM45686_DT_GYRO_LN		3 /**< Low-noise mode */
 /** @} */
 
 /**
- * @defgroup ICM45686_ACCEL_SCALE Accelerometer scale options
+ * @name Accelerometer full-scale range options
+ *
+ * Values for the `accel-fs` devicetree property.
  * @{
  */
-#define ICM45686_DT_ACCEL_FS_32		0
-#define ICM45686_DT_ACCEL_FS_16		1
-#define ICM45686_DT_ACCEL_FS_8		2
-#define ICM45686_DT_ACCEL_FS_4		3
-#define ICM45686_DT_ACCEL_FS_2		4
+#define ICM45686_DT_ACCEL_FS_32		0 /**< ±32 g */
+#define ICM45686_DT_ACCEL_FS_16		1 /**< ±16 g */
+#define ICM45686_DT_ACCEL_FS_8		2 /**< ±8 g */
+#define ICM45686_DT_ACCEL_FS_4		3 /**< ±4 g */
+#define ICM45686_DT_ACCEL_FS_2		4 /**< ±2 g */
 /** @} */
 
 /**
- * @defgroup ICM45686_GYRO_SCALE Gyroscope scale options
+ * @name Gyroscope full-scale range options
+ *
+ * Values for the `gyro-fs` devicetree property.
  * @{
  */
-#define ICM45686_DT_GYRO_FS_4000	0
-#define ICM45686_DT_GYRO_FS_2000	1
-#define ICM45686_DT_GYRO_FS_1000	2
-#define ICM45686_DT_GYRO_FS_500		3
-#define ICM45686_DT_GYRO_FS_250		4
-#define ICM45686_DT_GYRO_FS_125		5
-#define ICM45686_DT_GYRO_FS_62_5	6
-#define ICM45686_DT_GYRO_FS_31_25	7
-#define ICM45686_DT_GYRO_FS_15_625	8
+#define ICM45686_DT_GYRO_FS_4000	0 /**< ±4000 dps */
+#define ICM45686_DT_GYRO_FS_2000	1 /**< ±2000 dps */
+#define ICM45686_DT_GYRO_FS_1000	2 /**< ±1000 dps */
+#define ICM45686_DT_GYRO_FS_500		3 /**< ±500 dps */
+#define ICM45686_DT_GYRO_FS_250		4 /**< ±250 dps */
+#define ICM45686_DT_GYRO_FS_125		5 /**< ±125 dps */
+#define ICM45686_DT_GYRO_FS_62_5	6 /**< ±62.5 dps */
+#define ICM45686_DT_GYRO_FS_31_25	7 /**< ±31.25 dps */
+#define ICM45686_DT_GYRO_FS_15_625	8 /**< ±15.625 dps */
 /** @} */
 
 /**
- * @defgroup ICM45686_ACCEL_DATA_RATE Accelerometer data rate options
+ * @name Accelerometer data rate options
+ *
+ * Values for the `accel-odr` devicetree property.
  * @{
  */
-#define ICM45686_DT_ACCEL_ODR_6400	3 /* LN-mode only */
-#define ICM45686_DT_ACCEL_ODR_3200	4 /* LN-mode only */
-#define ICM45686_DT_ACCEL_ODR_1600	5 /* LN-mode only */
-#define ICM45686_DT_ACCEL_ODR_800	6 /* LN-mode only */
-#define ICM45686_DT_ACCEL_ODR_400	7 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_ACCEL_ODR_200	8 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_ACCEL_ODR_100	9 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_ACCEL_ODR_50	10 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_ACCEL_ODR_25	11 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_ACCEL_ODR_12_5	12 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_ACCEL_ODR_6_25	13 /* LP-mode only */
-#define ICM45686_DT_ACCEL_ODR_3_125	14 /* LP-mode only */
-#define ICM45686_DT_ACCEL_ODR_1_5625	15 /* LP-mode only */
+#define ICM45686_DT_ACCEL_ODR_6400	3  /**< 6400 Hz (LN mode only) */
+#define ICM45686_DT_ACCEL_ODR_3200	4  /**< 3200 Hz (LN mode only) */
+#define ICM45686_DT_ACCEL_ODR_1600	5  /**< 1600 Hz (LN mode only) */
+#define ICM45686_DT_ACCEL_ODR_800	6  /**< 800 Hz (LN mode only) */
+#define ICM45686_DT_ACCEL_ODR_400	7  /**< 400 Hz (LN or LP mode) */
+#define ICM45686_DT_ACCEL_ODR_200	8  /**< 200 Hz (LN or LP mode) */
+#define ICM45686_DT_ACCEL_ODR_100	9  /**< 100 Hz (LN or LP mode) */
+#define ICM45686_DT_ACCEL_ODR_50	10 /**< 50 Hz (LN or LP mode) */
+#define ICM45686_DT_ACCEL_ODR_25	11 /**< 25 Hz (LN or LP mode) */
+#define ICM45686_DT_ACCEL_ODR_12_5	12 /**< 12.5 Hz (LN or LP mode) */
+#define ICM45686_DT_ACCEL_ODR_6_25	13 /**< 6.25 Hz (LP mode only) */
+#define ICM45686_DT_ACCEL_ODR_3_125	14 /**< 3.125 Hz (LP mode only) */
+#define ICM45686_DT_ACCEL_ODR_1_5625	15 /**< 1.5625 Hz (LP mode only) */
 /** @} */
 
 /**
- * @defgroup ICM45686_GYRO_DATA_RATE Gyroscope data rate options
+ * @name Gyroscope data rate options
+ *
+ * Values for the `gyro-odr` devicetree property.
  * @{
  */
-#define ICM45686_DT_GYRO_ODR_6400	3 /* LN-mode only */
-#define ICM45686_DT_GYRO_ODR_3200	4 /* LN-mode only */
-#define ICM45686_DT_GYRO_ODR_1600	5 /* LN-mode only */
-#define ICM45686_DT_GYRO_ODR_800	6 /* LN-mode only */
-#define ICM45686_DT_GYRO_ODR_400	7 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_GYRO_ODR_200	8 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_GYRO_ODR_100	9 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_GYRO_ODR_50		10 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_GYRO_ODR_25		11 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_GYRO_ODR_12_5	12 /* Both LN-mode and LP-mode */
-#define ICM45686_DT_GYRO_ODR_6_25	13 /* LP-mode only */
-#define ICM45686_DT_GYRO_ODR_3_125	14 /* LP-mode only */
-#define ICM45686_DT_GYRO_ODR_1_5625	15 /* LP-mode only */
+#define ICM45686_DT_GYRO_ODR_6400	3  /**< 6400 Hz (LN mode only) */
+#define ICM45686_DT_GYRO_ODR_3200	4  /**< 3200 Hz (LN mode only) */
+#define ICM45686_DT_GYRO_ODR_1600	5  /**< 1600 Hz (LN mode only) */
+#define ICM45686_DT_GYRO_ODR_800	6  /**< 800 Hz (LN mode only) */
+#define ICM45686_DT_GYRO_ODR_400	7  /**< 400 Hz (LN or LP mode) */
+#define ICM45686_DT_GYRO_ODR_200	8  /**< 200 Hz (LN or LP mode) */
+#define ICM45686_DT_GYRO_ODR_100	9  /**< 100 Hz (LN or LP mode) */
+#define ICM45686_DT_GYRO_ODR_50		10 /**< 50 Hz (LN or LP mode) */
+#define ICM45686_DT_GYRO_ODR_25		11 /**< 25 Hz (LN or LP mode) */
+#define ICM45686_DT_GYRO_ODR_12_5	12 /**< 12.5 Hz (LN or LP mode) */
+#define ICM45686_DT_GYRO_ODR_6_25	13 /**< 6.25 Hz (LP mode only) */
+#define ICM45686_DT_GYRO_ODR_3_125	14 /**< 3.125 Hz (LP mode only) */
+#define ICM45686_DT_GYRO_ODR_1_5625	15 /**< 1.5625 Hz (LP mode only) */
 /** @} */
 
 /**
- * @defgroup ICM45686_GYRO_LPF Gyroscope Low-pass Filtering options
+ * @name Gyroscope low-pass filter options
+ *
+ * Values for the `gyro-lpf` devicetree property.
+ *
+ * Bandwidth is expressed as a fraction of the selected output data rate.
  * @{
  */
-#define ICM45686_DT_GYRO_LPF_BW_OFF	0
-#define ICM45686_DT_GYRO_LPF_BW_1_4	1
-#define ICM45686_DT_GYRO_LPF_BW_1_8	2
-#define ICM45686_DT_GYRO_LPF_BW_1_16	3
-#define ICM45686_DT_GYRO_LPF_BW_1_32	4
-#define ICM45686_DT_GYRO_LPF_BW_1_64	5
-#define ICM45686_DT_GYRO_LPF_BW_1_128	6
+#define ICM45686_DT_GYRO_LPF_BW_OFF	0 /**< Filter disabled */
+#define ICM45686_DT_GYRO_LPF_BW_1_4	1 /**< ODR / 4 */
+#define ICM45686_DT_GYRO_LPF_BW_1_8	2 /**< ODR / 8 */
+#define ICM45686_DT_GYRO_LPF_BW_1_16	3 /**< ODR / 16 */
+#define ICM45686_DT_GYRO_LPF_BW_1_32	4 /**< ODR / 32 */
+#define ICM45686_DT_GYRO_LPF_BW_1_64	5 /**< ODR / 64 */
+#define ICM45686_DT_GYRO_LPF_BW_1_128	6 /**< ODR / 128 */
 /** @} */
 
 /**
- * @defgroup ICM45686_ACCEL_LPF Accelerometer Low-pass Filtering options
+ * @name Accelerometer low-pass filter options
+ *
+ * Values for the `accel-lpf` devicetree property.
+ *
+ * Bandwidth is expressed as a fraction of the selected output data rate.
  * @{
  */
-#define ICM45686_DT_ACCEL_LPF_BW_OFF	0
-#define ICM45686_DT_ACCEL_LPF_BW_1_4	1
-#define ICM45686_DT_ACCEL_LPF_BW_1_8	2
-#define ICM45686_DT_ACCEL_LPF_BW_1_16	3
-#define ICM45686_DT_ACCEL_LPF_BW_1_32	4
-#define ICM45686_DT_ACCEL_LPF_BW_1_64	5
-#define ICM45686_DT_ACCEL_LPF_BW_1_128	6
+#define ICM45686_DT_ACCEL_LPF_BW_OFF	0 /**< Filter disabled */
+#define ICM45686_DT_ACCEL_LPF_BW_1_4	1 /**< ODR / 4 */
+#define ICM45686_DT_ACCEL_LPF_BW_1_8	2 /**< ODR / 8 */
+#define ICM45686_DT_ACCEL_LPF_BW_1_16	3 /**< ODR / 16 */
+#define ICM45686_DT_ACCEL_LPF_BW_1_32	4 /**< ODR / 32 */
+#define ICM45686_DT_ACCEL_LPF_BW_1_64	5 /**< ODR / 64 */
+#define ICM45686_DT_ACCEL_LPF_BW_1_128	6 /**< ODR / 128 */
 /** @} */
-
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/sensor/iis2dlpc.h
+++ b/include/zephyr/dt-bindings/sensor/iis2dlpc.h
@@ -3,40 +3,86 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST IIS2DLPC accelerometer.
+ * @ingroup iis2dlpc_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_IIS2DLPC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_IIS2DLPC_H_
 
-/* power-modes */
-#define IIS2DLPC_DT_LP_M1			0
-#define IIS2DLPC_DT_LP_M2			1
-#define IIS2DLPC_DT_LP_M3			2
-#define IIS2DLPC_DT_LP_M4			3
-#define IIS2DLPC_DT_HP_MODE			4
+/**
+ * @defgroup iis2dlpc_interface IIS2DLPC
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics IIS2DLPC 3-axis accelerometer
+ * @{
+ */
 
-/* Filter bandwidth */
-#define IIS2DLPC_DT_FILTER_BW_ODR_DIV_2		0
-#define IIS2DLPC_DT_FILTER_BW_ODR_DIV_4		1
-#define IIS2DLPC_DT_FILTER_BW_ODR_DIV_10	2
-#define IIS2DLPC_DT_FILTER_BW_ODR_DIV_20	3
+/**
+ * @name Power modes
+ *
+ * Values for the `power-mode` devicetree property.
+ * @{
+ */
+#define IIS2DLPC_DT_LP_M1			0 /**< Low-power mode 1 (12-bit) */
+#define IIS2DLPC_DT_LP_M2			1 /**< Low-power mode 2 (14-bit) */
+#define IIS2DLPC_DT_LP_M3			2 /**< Low-power mode 3 (14-bit) */
+#define IIS2DLPC_DT_LP_M4			3 /**< Low-power mode 4 (14-bit) */
+#define IIS2DLPC_DT_HP_MODE			4 /**< High-performance mode (14-bit) */
+/** @} */
 
-/* Tap mode */
-#define IIS2DLPC_DT_SINGLE_TAP			0
-#define IIS2DLPC_DT_SINGLE_DOUBLE_TAP		1
+/**
+ * @name Filter bandwidth options
+ *
+ * Bandwidth of the anti-aliasing filter, as a fraction of the ODR.
+ * @{
+ */
+#define IIS2DLPC_DT_FILTER_BW_ODR_DIV_2		0 /**< ODR / 2 */
+#define IIS2DLPC_DT_FILTER_BW_ODR_DIV_4		1 /**< ODR / 4 */
+#define IIS2DLPC_DT_FILTER_BW_ODR_DIV_10	2 /**< ODR / 10 */
+#define IIS2DLPC_DT_FILTER_BW_ODR_DIV_20	3 /**< ODR / 20 */
+/** @} */
 
-/* Free-Fall threshold */
-#define IIS2DLPC_DT_FF_THRESHOLD_156_mg		0
-#define IIS2DLPC_DT_FF_THRESHOLD_219_mg		1
-#define IIS2DLPC_DT_FF_THRESHOLD_250_mg		2
-#define IIS2DLPC_DT_FF_THRESHOLD_312_mg		3
-#define IIS2DLPC_DT_FF_THRESHOLD_344_mg		4
-#define IIS2DLPC_DT_FF_THRESHOLD_406_mg		5
-#define IIS2DLPC_DT_FF_THRESHOLD_469_mg		6
-#define IIS2DLPC_DT_FF_THRESHOLD_500_mg		7
+/**
+ * @name Tap detection mode
+ *
+ * Values for the `tap-mode` devicetree property.
+ * @{
+ */
+#define IIS2DLPC_DT_SINGLE_TAP			0 /**< Single-tap only */
+#define IIS2DLPC_DT_SINGLE_DOUBLE_TAP		1 /**< Single and double tap */
+/** @} */
 
-/* wakeup duration */
-#define IIS2DLPC_DT_WAKEUP_1_ODR		0
-#define IIS2DLPC_DT_WAKEUP_2_ODR		1
-#define IIS2DLPC_DT_WAKEUP_3_ODR		2
-#define IIS2DLPC_DT_WAKEUP_4_ODR		3
+/**
+ * @name Free-fall threshold options
+ *
+ * Free-fall detection threshold.
+ * @{
+ */
+#define IIS2DLPC_DT_FF_THRESHOLD_156_mg		0 /**< 156 mg */
+#define IIS2DLPC_DT_FF_THRESHOLD_219_mg		1 /**< 219 mg */
+#define IIS2DLPC_DT_FF_THRESHOLD_250_mg		2 /**< 250 mg */
+#define IIS2DLPC_DT_FF_THRESHOLD_312_mg		3 /**< 312 mg */
+#define IIS2DLPC_DT_FF_THRESHOLD_344_mg		4 /**< 344 mg */
+#define IIS2DLPC_DT_FF_THRESHOLD_406_mg		5 /**< 406 mg */
+#define IIS2DLPC_DT_FF_THRESHOLD_469_mg		6 /**< 469 mg */
+#define IIS2DLPC_DT_FF_THRESHOLD_500_mg		7 /**< 500 mg */
+/** @} */
+
+/**
+ * @name Wake-up duration options
+ *
+ * Wake-up event duration, in ODR periods.
+ * @{
+ */
+#define IIS2DLPC_DT_WAKEUP_1_ODR		0 /**< 1 ODR period */
+#define IIS2DLPC_DT_WAKEUP_2_ODR		1 /**< 2 ODR periods */
+#define IIS2DLPC_DT_WAKEUP_3_ODR		2 /**< 3 ODR periods */
+#define IIS2DLPC_DT_WAKEUP_4_ODR		3 /**< 4 ODR periods */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_IIS2DLPC_H_ */

--- a/include/zephyr/dt-bindings/sensor/iis2iclx.h
+++ b/include/zephyr/dt-bindings/sensor/iis2iclx.h
@@ -3,23 +3,51 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST IIS2ICLX inclinometer.
+ * @ingroup iis2iclx_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_IIS2ICLX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_IIS2ICLX_H_
 
-/* Accel range */
-#define IIS2ICLX_DT_FS_500mG			0
-#define IIS2ICLX_DT_FS_3G			1
-#define IIS2ICLX_DT_FS_1G			2
-#define IIS2ICLX_DT_FS_2G			3
+/**
+ * @defgroup iis2iclx_interface IIS2ICLX
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics IIS2ICLX 2-axis inclinometer
+ * @{
+ */
 
-/* Accel Data rates */
-#define IIS2ICLX_DT_ODR_OFF			0x0
-#define IIS2ICLX_DT_ODR_12Hz5			0x1
-#define IIS2ICLX_DT_ODR_26H			0x2
-#define IIS2ICLX_DT_ODR_52Hz			0x3
-#define IIS2ICLX_DT_ODR_104Hz			0x4
-#define IIS2ICLX_DT_ODR_208Hz			0x5
-#define IIS2ICLX_DT_ODR_416Hz			0x6
-#define IIS2ICLX_DT_ODR_833Hz			0x7
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `range` devicetree property.
+ * @{
+ */
+#define IIS2ICLX_DT_FS_500mG			0 /**< ±0.5 g */
+#define IIS2ICLX_DT_FS_3G			1 /**< ±3 g */
+#define IIS2ICLX_DT_FS_1G			2 /**< ±1 g */
+#define IIS2ICLX_DT_FS_2G			3 /**< ±2 g */
+/** @} */
+
+/**
+ * @name Accelerometer output data rate
+ *
+ * Values for the `odr` devicetree property.
+ * @{
+ */
+#define IIS2ICLX_DT_ODR_OFF			0x0 /**< Power-down */
+#define IIS2ICLX_DT_ODR_12Hz5			0x1 /**< 12.5 Hz */
+#define IIS2ICLX_DT_ODR_26H			0x2 /**< 26 Hz */
+#define IIS2ICLX_DT_ODR_52Hz			0x3 /**< 52 Hz */
+#define IIS2ICLX_DT_ODR_104Hz			0x4 /**< 104 Hz */
+#define IIS2ICLX_DT_ODR_208Hz			0x5 /**< 208 Hz */
+#define IIS2ICLX_DT_ODR_416Hz			0x6 /**< 416 Hz */
+#define IIS2ICLX_DT_ODR_833Hz			0x7 /**< 833 Hz */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_IIS2ICLX_H_ */

--- a/include/zephyr/dt-bindings/sensor/iis3dwb.h
+++ b/include/zephyr/dt-bindings/sensor/iis3dwb.h
@@ -3,53 +3,109 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST IIS3DWB accelerometer.
+ * @ingroup iis3dwb_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_IIS3DWB_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_IIS3DWB_H_
 
 #include <zephyr/dt-bindings/dt-util.h>
 
-/* Data rate */
-#define IIS3DWB_DT_ODR_OFF      0
-#define IIS3DWB_DT_ODR_26k7Hz   5  /* available in LP and HP mode */
+/**
+ * @defgroup iis3dwb_interface IIS3DWB
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics IIS3DWB 3-axis vibration accelerometer
+ * @{
+ */
 
-/* Accelerometer Full-scale */
-#define IIS3DWB_DT_FS_2G  0 /* 2g (0.061 mg/LSB)  */
-#define IIS3DWB_DT_FS_16G 1 /* 16g (0.488 mg/LSB) */
-#define IIS3DWB_DT_FS_4G  2 /* 4g (0.122 mg/LSB)  */
-#define IIS3DWB_DT_FS_8G  3 /* 8g (0.244 mg/LSB)  */
+/**
+ * @name Output data rate options
+ *
+ * Values for the `odr` devicetree property.
+ * @{
+ */
+#define IIS3DWB_DT_ODR_OFF      0 /**< Power-down */
+#define IIS3DWB_DT_ODR_26k7Hz   5 /**< 26.7 kHz */
+/** @} */
 
-/* filter settings */
-#define IIS3DWB_DT_SLOPE_ODR_DIV_4  0x10
-#define IIS3DWB_DT_HP_REF_MODE      0x37
-#define IIS3DWB_DT_HP_ODR_DIV_10    0x11
-#define IIS3DWB_DT_HP_ODR_DIV_20    0x12
-#define IIS3DWB_DT_HP_ODR_DIV_45    0x13
-#define IIS3DWB_DT_HP_ODR_DIV_100   0x14
-#define IIS3DWB_DT_HP_ODR_DIV_200   0x15
-#define IIS3DWB_DT_HP_ODR_DIV_400   0x16
-#define IIS3DWB_DT_HP_ODR_DIV_800   0x17
-#define IIS3DWB_DT_LP_6k3Hz         0x00
-#define IIS3DWB_DT_LP_ODR_DIV_4     0x80
-#define IIS3DWB_DT_LP_ODR_DIV_10    0x81
-#define IIS3DWB_DT_LP_ODR_DIV_20    0x82
-#define IIS3DWB_DT_LP_ODR_DIV_45    0x83
-#define IIS3DWB_DT_LP_ODR_DIV_100   0x84
-#define IIS3DWB_DT_LP_ODR_DIV_200   0x85
-#define IIS3DWB_DT_LP_ODR_DIV_400   0x86
-#define IIS3DWB_DT_LP_ODR_DIV_800   0x87
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `range` devicetree property.
+ * @{
+ */
+#define IIS3DWB_DT_FS_2G  0 /**< ±2 g (0.061 mg/LSB) */
+#define IIS3DWB_DT_FS_16G 1 /**< ±16 g (0.488 mg/LSB) */
+#define IIS3DWB_DT_FS_4G  2 /**< ±4 g (0.122 mg/LSB) */
+#define IIS3DWB_DT_FS_8G  3 /**< ±8 g (0.244 mg/LSB) */
+/** @} */
 
-/* Accelerometer FIFO batching data rate */
-#define IIS3DWB_DT_XL_NOT_BATCHED        0x0
-#define IIS3DWB_DT_XL_BATCHED_AT_26k7Hz  0xA
+/**
+ * @name Filter path options
+ *
+ * Values for the `filter` devicetree property.
+ *
+ * Select the digital filter applied to the accelerometer output: slope,
+ * high-pass (HP) or low-pass (LP), with the corner expressed as a fraction of
+ * the output data rate (ODR).
+ * @{
+ */
+#define IIS3DWB_DT_SLOPE_ODR_DIV_4  0x10 /**< Slope filter, ODR / 4 */
+#define IIS3DWB_DT_HP_REF_MODE      0x37 /**< High-pass reference mode */
+#define IIS3DWB_DT_HP_ODR_DIV_10    0x11 /**< High-pass, ODR / 10 */
+#define IIS3DWB_DT_HP_ODR_DIV_20    0x12 /**< High-pass, ODR / 20 */
+#define IIS3DWB_DT_HP_ODR_DIV_45    0x13 /**< High-pass, ODR / 45 */
+#define IIS3DWB_DT_HP_ODR_DIV_100   0x14 /**< High-pass, ODR / 100 */
+#define IIS3DWB_DT_HP_ODR_DIV_200   0x15 /**< High-pass, ODR / 200 */
+#define IIS3DWB_DT_HP_ODR_DIV_400   0x16 /**< High-pass, ODR / 400 */
+#define IIS3DWB_DT_HP_ODR_DIV_800   0x17 /**< High-pass, ODR / 800 */
+#define IIS3DWB_DT_LP_6k3Hz         0x00 /**< Low-pass, 6.3 kHz */
+#define IIS3DWB_DT_LP_ODR_DIV_4     0x80 /**< Low-pass, ODR / 4 */
+#define IIS3DWB_DT_LP_ODR_DIV_10    0x81 /**< Low-pass, ODR / 10 */
+#define IIS3DWB_DT_LP_ODR_DIV_20    0x82 /**< Low-pass, ODR / 20 */
+#define IIS3DWB_DT_LP_ODR_DIV_45    0x83 /**< Low-pass, ODR / 45 */
+#define IIS3DWB_DT_LP_ODR_DIV_100   0x84 /**< Low-pass, ODR / 100 */
+#define IIS3DWB_DT_LP_ODR_DIV_200   0x85 /**< Low-pass, ODR / 200 */
+#define IIS3DWB_DT_LP_ODR_DIV_400   0x86 /**< Low-pass, ODR / 400 */
+#define IIS3DWB_DT_LP_ODR_DIV_800   0x87 /**< Low-pass, ODR / 800 */
+/** @} */
 
-/* Temperature FIFO batching data rate */
-#define IIS3DWB_DT_TEMP_NOT_BATCHED      0
-#define IIS3DWB_DT_TEMP_BATCHED_AT_104Hz 3
+/**
+ * @name Accelerometer FIFO batching rate
+ *
+ * Values for the `accel-fifo-batch-rate` devicetree property.
+ * @{
+ */
+#define IIS3DWB_DT_XL_NOT_BATCHED        0x0 /**< Not batched */
+#define IIS3DWB_DT_XL_BATCHED_AT_26k7Hz  0xA /**< 26.7 kHz */
+/** @} */
 
-/* Accelerometer FIFO timestamp ratio */
-#define IIS3DWB_DT_TS_NOT_BATCHED 0x0
-#define IIS3DWB_DT_DEC_TS_1       0x1
-#define IIS3DWB_DT_DEC_TS_8       0x2
-#define IIS3DWB_DT_DEC_TS_32      0x3
+/**
+ * @name Temperature FIFO batching rate
+ *
+ * Values for the `temp-fifo-batch-rate` devicetree property.
+ * @{
+ */
+#define IIS3DWB_DT_TEMP_NOT_BATCHED      0 /**< Not batched */
+#define IIS3DWB_DT_TEMP_BATCHED_AT_104Hz 3 /**< 104 Hz */
+/** @} */
+
+/**
+ * @name FIFO timestamp decimation
+ *
+ * Values for the `timestamp-fifo-batch-rate` devicetree property.
+ * @{
+ */
+#define IIS3DWB_DT_TS_NOT_BATCHED 0x0 /**< Timestamp not batched */
+#define IIS3DWB_DT_DEC_TS_1       0x1 /**< Decimation by 1 */
+#define IIS3DWB_DT_DEC_TS_8       0x2 /**< Decimation by 8 */
+#define IIS3DWB_DT_DEC_TS_32      0x3 /**< Decimation by 32 */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_IIS3DWB_H_ */

--- a/include/zephyr/dt-bindings/sensor/ina226.h
+++ b/include/zephyr/dt-bindings/sensor/ina226.h
@@ -4,42 +4,81 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree binding constants for the TI INA226 power monitor.
+ * @ingroup ina226_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INA226_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_INA226_H_
 
 #include <zephyr/dt-bindings/dt-util.h>
 
-/* Reset Mode. */
-#define INA226_RST_NORMAL_OPERATION	0x00
-#define INA226_RST_SYSTEM_RESET		0x01
+/**
+ * @defgroup ina226_interface INA226
+ * @ingroup sensor_interface_ext_ti
+ * @brief Texas Instruments INA226 current and power monitor
+ * @{
+ */
 
-/* Averaging Mode. */
-#define INA226_AVG_MODE_1		0x00
-#define INA226_AVG_MODE_4		0x01
-#define INA226_AVG_MODE_16		0x02
-#define INA226_AVG_MODE_64		0x03
-#define INA226_AVG_MODE_128		0x04
-#define INA226_AVG_MODE_256		0x05
-#define INA226_AVG_MODE_512		0x06
-#define INA226_AVG_MODE_1024		0x07
+/**
+ * @name Reset mode
+ *
+ * Reset-mode selection.
+ * @{
+ */
+#define INA226_RST_NORMAL_OPERATION	0x00 /**< Normal operation */
+#define INA226_RST_SYSTEM_RESET		0x01 /**< Trigger a system reset */
+/** @} */
 
-/* Conversion time for bus and shunt voltage in micro-seconds. */
-#define INA226_CONV_TIME_140		0x00
-#define INA226_CONV_TIME_204		0x01
-#define INA226_CONV_TIME_332		0x02
-#define INA226_CONV_TIME_588		0x03
-#define INA226_CONV_TIME_1100		0x04
-#define INA226_CONV_TIME_2116		0x05
-#define INA226_CONV_TIME_4156		0x06
-#define INA226_CONV_TIME_8244		0x07
+/**
+ * @name Averaging mode (number of samples)
+ *
+ * Averaging-mode selection.
+ * @{
+ */
+#define INA226_AVG_MODE_1		0x00 /**< 1 sample */
+#define INA226_AVG_MODE_4		0x01 /**< 4 samples */
+#define INA226_AVG_MODE_16		0x02 /**< 16 samples */
+#define INA226_AVG_MODE_64		0x03 /**< 64 samples */
+#define INA226_AVG_MODE_128		0x04 /**< 128 samples */
+#define INA226_AVG_MODE_256		0x05 /**< 256 samples */
+#define INA226_AVG_MODE_512		0x06 /**< 512 samples */
+#define INA226_AVG_MODE_1024		0x07 /**< 1024 samples */
+/** @} */
 
-/* Operating Mode. */
-#define INA226_OPER_MODE_POWER_DOWN			0x00
-#define INA226_OPER_MODE_SHUNT_VOLTAGE_TRIG		0x01
-#define INA226_OPER_MODE_BUS_VOLTAGE_TRIG		0x02
-#define INA226_OPER_MODE_SHUNT_BUS_VOLTAGE_TRIG		0x03
-#define INA226_OPER_MODE_SHUNT_VOLTAGE_CONT		0x05
-#define INA226_OPER_MODE_BUS_VOLTAGE_CONT		0x06
-#define INA226_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT		0x07
+/**
+ * @name Bus and shunt voltage conversion time
+ *
+ * Bus and shunt voltage conversion-time selection.
+ * @{
+ */
+#define INA226_CONV_TIME_140		0x00 /**< 140 µs */
+#define INA226_CONV_TIME_204		0x01 /**< 204 µs */
+#define INA226_CONV_TIME_332		0x02 /**< 332 µs */
+#define INA226_CONV_TIME_588		0x03 /**< 588 µs */
+#define INA226_CONV_TIME_1100		0x04 /**< 1100 µs */
+#define INA226_CONV_TIME_2116		0x05 /**< 2116 µs */
+#define INA226_CONV_TIME_4156		0x06 /**< 4156 µs */
+#define INA226_CONV_TIME_8244		0x07 /**< 8244 µs */
+/** @} */
+
+/**
+ * @name Operating mode
+ *
+ * Operating-mode selection.
+ * @{
+ */
+#define INA226_OPER_MODE_POWER_DOWN			0x00 /**< Power-down */
+#define INA226_OPER_MODE_SHUNT_VOLTAGE_TRIG		0x01 /**< Shunt voltage, triggered */
+#define INA226_OPER_MODE_BUS_VOLTAGE_TRIG		0x02 /**< Bus voltage, triggered */
+#define INA226_OPER_MODE_SHUNT_BUS_VOLTAGE_TRIG		0x03 /**< Shunt and bus, triggered */
+#define INA226_OPER_MODE_SHUNT_VOLTAGE_CONT		0x05 /**< Shunt voltage, continuous */
+#define INA226_OPER_MODE_BUS_VOLTAGE_CONT		0x06 /**< Bus voltage, continuous */
+#define INA226_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT		0x07 /**< Shunt and bus, continuous */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_INA226_H_ */

--- a/include/zephyr/dt-bindings/sensor/ina230.h
+++ b/include/zephyr/dt-bindings/sensor/ina230.h
@@ -4,65 +4,108 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the TI INA230 power monitor.
+ * @ingroup ina230_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INA230_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_INA230_H_
 
 #include <zephyr/dt-bindings/dt-util.h>
 
-/* Mask/Enable bits that asserts the ALERT pin */
-#define INA230_SHUNT_VOLTAGE_OVER    BIT(15)
-#define INA230_SHUNT_VOLTAGE_UNDER   BIT(14)
-#define INA230_BUS_VOLTAGE_OVER      BIT(13)
-#define INA230_BUS_VOLTAGE_UNDER     BIT(12)
-#define INA230_OVER_LIMIT_POWER      BIT(11)
-#define INA230_CONVERSION_READY      BIT(10)
-#define INA230_ALERT_FUNCTION_FLAG   BIT(4)
-#define INA230_CONVERSION_READY_FLAG BIT(3)
-#define INA230_MATH_OVERFLOW_FLAG    BIT(2)
-#define INA230_ALERT_POLARITY        BIT(1)
-#define INA230_ALERT_LATCH_ENABLE    BIT(0)
-
-/* Operating Mode */
-#define INA230_OPER_MODE_POWER_DOWN             0x00
-#define INA230_OPER_MODE_SHUNT_VOLTAGE_TRIG     0x01
-#define INA230_OPER_MODE_BUS_VOLTAGE_TRIG       0x02
-#define INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_TRIG 0x03
-#define INA230_OPER_MODE_SHUNT_VOLTAGE_CONT     0x05
-#define INA230_OPER_MODE_BUS_VOLTAGE_CONT       0x06
-#define INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT 0x07
-
-/* Conversion time for bus and shunt in micro-seconds */
-#define INA230_CONV_TIME_140  0x00
-#define INA230_CONV_TIME_204  0x01
-#define INA230_CONV_TIME_332  0x02
-#define INA230_CONV_TIME_588  0x03
-#define INA230_CONV_TIME_1100 0x04
-#define INA230_CONV_TIME_2116 0x05
-#define INA230_CONV_TIME_4156 0x06
-#define INA230_CONV_TIME_8244 0x07
-
-/* Averaging Mode */
-#define INA230_AVG_MODE_1    0x00
-#define INA230_AVG_MODE_4    0x01
-#define INA230_AVG_MODE_16   0x02
-#define INA230_AVG_MODE_64   0x03
-#define INA230_AVG_MODE_128  0x04
-#define INA230_AVG_MODE_256  0x05
-#define INA230_AVG_MODE_512  0x06
-#define INA230_AVG_MODE_1024 0x07
+/**
+ * @defgroup ina230_interface INA230
+ * @ingroup sensor_interface_ext_ti
+ * @brief Texas Instruments INA230 current and power monitor
+ * @{
+ */
 
 /**
- * @brief Macro for creating the INA230 configuration value
+ * @name Mask/enable bits that assert the ALERT pin
  *
- * @param mode  Operating mode.
- * @param svct  Conversion time for shunt voltage.
- * @param bvct  Conversion time for bus voltage.
- * @param avg   Averaging mode.
+ * Mask/enable flags that assert the ALERT pin.
+ * @{
+ */
+#define INA230_SHUNT_VOLTAGE_OVER    BIT(15) /**< Shunt voltage over-limit */
+#define INA230_SHUNT_VOLTAGE_UNDER   BIT(14) /**< Shunt voltage under-limit */
+#define INA230_BUS_VOLTAGE_OVER      BIT(13) /**< Bus voltage over-limit */
+#define INA230_BUS_VOLTAGE_UNDER     BIT(12) /**< Bus voltage under-limit */
+#define INA230_OVER_LIMIT_POWER      BIT(11) /**< Power over-limit */
+#define INA230_CONVERSION_READY      BIT(10) /**< Conversion-ready enable */
+#define INA230_ALERT_FUNCTION_FLAG   BIT(4)  /**< Alert function flag */
+#define INA230_CONVERSION_READY_FLAG BIT(3)  /**< Conversion-ready flag */
+#define INA230_MATH_OVERFLOW_FLAG    BIT(2)  /**< Math overflow flag */
+#define INA230_ALERT_POLARITY        BIT(1)  /**< Alert pin polarity */
+#define INA230_ALERT_LATCH_ENABLE    BIT(0)  /**< Alert latch enable */
+/** @} */
+
+/**
+ * @name Operating mode
+ * @anchor ina230_oper_mode
+ *
+ * Operating-mode argument for the INA230_CONFIG() macro.
+ * @{
+ */
+#define INA230_OPER_MODE_POWER_DOWN             0x00 /**< Power-down */
+#define INA230_OPER_MODE_SHUNT_VOLTAGE_TRIG     0x01 /**< Shunt voltage, triggered */
+#define INA230_OPER_MODE_BUS_VOLTAGE_TRIG       0x02 /**< Bus voltage, triggered */
+#define INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_TRIG 0x03 /**< Shunt and bus, triggered */
+#define INA230_OPER_MODE_SHUNT_VOLTAGE_CONT     0x05 /**< Shunt voltage, continuous */
+#define INA230_OPER_MODE_BUS_VOLTAGE_CONT       0x06 /**< Bus voltage, continuous */
+#define INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT 0x07 /**< Shunt and bus, continuous */
+/** @} */
+
+/**
+ * @name Bus and shunt voltage conversion time
+ * @anchor ina230_conv_time
+ *
+ * Conversion-time argument for the INA230_CONFIG() macro.
+ * @{
+ */
+#define INA230_CONV_TIME_140  0x00 /**< 140 µs */
+#define INA230_CONV_TIME_204  0x01 /**< 204 µs */
+#define INA230_CONV_TIME_332  0x02 /**< 332 µs */
+#define INA230_CONV_TIME_588  0x03 /**< 588 µs */
+#define INA230_CONV_TIME_1100 0x04 /**< 1100 µs */
+#define INA230_CONV_TIME_2116 0x05 /**< 2116 µs */
+#define INA230_CONV_TIME_4156 0x06 /**< 4156 µs */
+#define INA230_CONV_TIME_8244 0x07 /**< 8244 µs */
+/** @} */
+
+/**
+ * @name Averaging mode (number of samples)
+ * @anchor ina230_avg
+ *
+ * Averaging-mode argument for the INA230_CONFIG() macro.
+ * @{
+ */
+#define INA230_AVG_MODE_1    0x00 /**< 1 sample */
+#define INA230_AVG_MODE_4    0x01 /**< 4 samples */
+#define INA230_AVG_MODE_16   0x02 /**< 16 samples */
+#define INA230_AVG_MODE_64   0x03 /**< 64 samples */
+#define INA230_AVG_MODE_128  0x04 /**< 128 samples */
+#define INA230_AVG_MODE_256  0x05 /**< 256 samples */
+#define INA230_AVG_MODE_512  0x06 /**< 512 samples */
+#define INA230_AVG_MODE_1024 0x07 /**< 1024 samples */
+/** @} */
+
+/**
+ * @brief Build the INA230 configuration register value.
+ *
+ * @param mode  Operating mode (see @ref ina230_oper_mode).
+ * @param svct  Shunt voltage conversion time (see @ref ina230_conv_time).
+ * @param bvct  Bus voltage conversion time (see @ref ina230_conv_time).
+ * @param avg   Averaging mode (see @ref ina230_avg).
  */
 #define INA230_CONFIG(mode, \
 		      svct, \
 		      bvct, \
 		      avg)  \
 	(((avg) << 9) | ((bvct) << 6) | ((svct) << 3) | (mode))
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_INA230_H_ */

--- a/include/zephyr/dt-bindings/sensor/ina237.h
+++ b/include/zephyr/dt-bindings/sensor/ina237.h
@@ -3,69 +3,124 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the TI INA237 power monitor.
+ * @ingroup ina237_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INA237_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_INA237_H_
 
 #include <zephyr/dt-bindings/dt-util.h>
 
-/* Operating Mode */
-#define INA237_CFG_HIGH_PRECISION			BIT(4)
-#define INA237_OPER_MODE_SHUTDOWN			0x00
-#define INA237_OPER_MODE_BUS_VOLTAGE_TRIG		0x01
-#define INA237_OPER_MODE_SHUNT_VOLTAGE_TRIG		0x02
-#define INA237_OPER_MODE_SHUNT_BUS_VOLTAGE_TRIG		0x03
-#define INA237_OPER_MODE_TEMP_TRIG			0x04
-#define INA237_OPER_MODE_TEMP_BUS_VOLTAGE_TRIG		0x05
-#define INA237_OPER_MODE_TEMP_SHUNT_VOLTAGE_TRIG	0x06
-#define INA237_OPER_MODE_BUS_SHUNT_VOLTAGE_TEMP_TRIG	0x07
-#define INA237_OPER_MODE_BUS_VOLTAGE_CONT		0x09
-#define INA237_OPER_MODE_SHUNT_VOLTAGE_CONT		0x0A
-#define INA237_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT		0x0B
-#define INA237_OPER_MODE_TEMP_CONT			0x0C
-#define INA237_OPER_MODE_BUS_VOLTAGE_TEMP_CONT		0x0D
-#define INA237_OPER_MODE_TEMP_SHUNT_VOLTAGE_CONT	0x0E
-#define INA237_OPER_MODE_BUS_SHUNT_VOLTAGE_TEMP_CONT	0x0F
-
-/* Conversion time for bus, shunt and temp in micro-seconds */
-#define INA237_CONV_TIME_50   0x00
-#define INA237_CONV_TIME_84   0x01
-#define INA237_CONV_TIME_150  0x02
-#define INA237_CONV_TIME_280  0x03
-#define INA237_CONV_TIME_540  0x04
-#define INA237_CONV_TIME_1052 0x05
-#define INA237_CONV_TIME_2074 0x06
-#define INA237_CONV_TIME_4120 0x07
-
-/* Averaging Mode */
-#define INA237_AVG_MODE_1    0x00
-#define INA237_AVG_MODE_4    0x01
-#define INA237_AVG_MODE_16   0x02
-#define INA237_AVG_MODE_64   0x03
-#define INA237_AVG_MODE_128  0x04
-#define INA237_AVG_MODE_256  0x05
-#define INA237_AVG_MODE_512  0x06
-#define INA237_AVG_MODE_1024 0x07
-
-/* Reset Mode */
-#define INA237_RST_NORMAL_OPERATION	0x00
-#define INA237_RST_SYSTEM_RESET		0x01
-
-/* Delay for initial ADC conversion in steps of 2 ms */
-#define INA237_INIT_ADC_DELAY_0_S	0x00
-#define INA237_INIT_ADC_DELAY_2_MS	0x01
-#define INA237_INIT_ADC_DELAY_510_MS	0xFF
-
-/* Shunt full scale range selection across IN+ and IN–. */
-#define INA237_ADC_RANGE_163_84	0x00
-#define INA237_ADC_RANGE_40_96	0x01
+/**
+ * @defgroup ina237_interface INA237
+ * @ingroup sensor_interface_ext_ti
+ * @brief Texas Instruments INA237 current and power monitor
+ * @{
+ */
 
 /**
- * @brief Macro for creating the INA237 configuration value
+ * @name Operating mode
+ * @anchor ina237_oper_mode
  *
- * @param rst_mode	Reset mode.
- * @param convdly	Delay for initial ADC conversion in steps of 2 ms.
- * @param adc_range	Shunt full scale range selection across IN+ and IN–.
+ * Operating-mode argument for the INA237_ADC_CONFIG() macro.
+ * @{
+ */
+#define INA237_CFG_HIGH_PRECISION			BIT(4) /**< High-precision mode flag */
+#define INA237_OPER_MODE_SHUTDOWN			0x00 /**< Shutdown */
+#define INA237_OPER_MODE_BUS_VOLTAGE_TRIG		0x01 /**< Bus voltage, triggered */
+#define INA237_OPER_MODE_SHUNT_VOLTAGE_TRIG		0x02 /**< Shunt voltage, triggered */
+#define INA237_OPER_MODE_SHUNT_BUS_VOLTAGE_TRIG		0x03 /**< Shunt and bus, triggered */
+#define INA237_OPER_MODE_TEMP_TRIG			0x04 /**< Temperature, triggered */
+#define INA237_OPER_MODE_TEMP_BUS_VOLTAGE_TRIG		0x05 /**< Temp and bus, triggered */
+#define INA237_OPER_MODE_TEMP_SHUNT_VOLTAGE_TRIG	0x06 /**< Temp and shunt, triggered */
+#define INA237_OPER_MODE_BUS_SHUNT_VOLTAGE_TEMP_TRIG	0x07 /**< Bus, shunt and temp, triggered */
+#define INA237_OPER_MODE_BUS_VOLTAGE_CONT		0x09 /**< Bus voltage, continuous */
+#define INA237_OPER_MODE_SHUNT_VOLTAGE_CONT		0x0A /**< Shunt voltage, continuous */
+#define INA237_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT		0x0B /**< Shunt and bus, continuous */
+#define INA237_OPER_MODE_TEMP_CONT			0x0C /**< Temperature, continuous */
+#define INA237_OPER_MODE_BUS_VOLTAGE_TEMP_CONT		0x0D /**< Bus and temp, continuous */
+#define INA237_OPER_MODE_TEMP_SHUNT_VOLTAGE_CONT	0x0E /**< Temp and shunt, continuous */
+#define INA237_OPER_MODE_BUS_SHUNT_VOLTAGE_TEMP_CONT	0x0F /**< Bus, shunt and temp, continuous */
+/** @} */
+
+/**
+ * @name Bus, shunt and temperature conversion time
+ * @anchor ina237_conv_time
  *
+ * Conversion-time argument for the INA237_ADC_CONFIG() macro.
+ * @{
+ */
+#define INA237_CONV_TIME_50   0x00 /**< 50 µs */
+#define INA237_CONV_TIME_84   0x01 /**< 84 µs */
+#define INA237_CONV_TIME_150  0x02 /**< 150 µs */
+#define INA237_CONV_TIME_280  0x03 /**< 280 µs */
+#define INA237_CONV_TIME_540  0x04 /**< 540 µs */
+#define INA237_CONV_TIME_1052 0x05 /**< 1052 µs */
+#define INA237_CONV_TIME_2074 0x06 /**< 2074 µs */
+#define INA237_CONV_TIME_4120 0x07 /**< 4120 µs */
+/** @} */
+
+/**
+ * @name Averaging mode (number of samples)
+ * @anchor ina237_avg
+ *
+ * Averaging-mode argument for the INA237_ADC_CONFIG() macro.
+ * @{
+ */
+#define INA237_AVG_MODE_1    0x00 /**< 1 sample */
+#define INA237_AVG_MODE_4    0x01 /**< 4 samples */
+#define INA237_AVG_MODE_16   0x02 /**< 16 samples */
+#define INA237_AVG_MODE_64   0x03 /**< 64 samples */
+#define INA237_AVG_MODE_128  0x04 /**< 128 samples */
+#define INA237_AVG_MODE_256  0x05 /**< 256 samples */
+#define INA237_AVG_MODE_512  0x06 /**< 512 samples */
+#define INA237_AVG_MODE_1024 0x07 /**< 1024 samples */
+/** @} */
+
+/**
+ * @name Reset mode
+ * @anchor ina237_reset
+ *
+ * Reset-mode argument for the INA237_CONFIG() macro.
+ * @{
+ */
+#define INA237_RST_NORMAL_OPERATION	0x00 /**< Normal operation */
+#define INA237_RST_SYSTEM_RESET		0x01 /**< Trigger a system reset */
+/** @} */
+
+/**
+ * @name Initial ADC conversion delay (steps of 2 ms)
+ * @anchor ina237_init_adc_delay
+ *
+ * Initial ADC-delay argument for the INA237_CONFIG() macro.
+ * @{
+ */
+#define INA237_INIT_ADC_DELAY_0_S	0x00 /**< 0 s (no delay) */
+#define INA237_INIT_ADC_DELAY_2_MS	0x01 /**< 2 ms */
+#define INA237_INIT_ADC_DELAY_510_MS	0xFF /**< 510 ms */
+/** @} */
+
+/**
+ * @name Shunt full-scale range across IN+ and IN−
+ * @anchor ina237_adc_range
+ *
+ * Shunt full-scale range argument for the INA237_CONFIG() macro.
+ * @{
+ */
+#define INA237_ADC_RANGE_163_84	0x00 /**< ±163.84 mV */
+#define INA237_ADC_RANGE_40_96	0x01 /**< ±40.96 mV */
+/** @} */
+
+/**
+ * @brief Build the INA237 configuration register value.
+ *
+ * @param rst_mode  Reset mode (see @ref ina237_reset).
+ * @param convdly   Initial ADC conversion delay (see @ref ina237_init_adc_delay).
+ * @param adc_range Shunt full-scale range (see @ref ina237_adc_range).
  */
 #define INA237_CONFIG(rst_mode, \
 		      convdly, \
@@ -73,13 +128,13 @@
 	(((rst_mode) << 15) | ((convdly) << 6) | ((adc_range) << 4))
 
 /**
- * @brief Macro for creating the INA237 ADC configuration value
+ * @brief Build the INA237 ADC configuration register value.
  *
- * @param mode   Operating mode.
- * @param vshct  Conversion time for shunt voltage.
- * @param vbusct Conversion time for bus voltage.
- * @param vtct   Conversion time for temperature.
- * @param avg    Averaging mode.
+ * @param mode   Operating mode (see @ref ina237_oper_mode).
+ * @param vshct  Shunt voltage conversion time (see @ref ina237_conv_time).
+ * @param vbusct Bus voltage conversion time (see @ref ina237_conv_time).
+ * @param vtct   Temperature conversion time (see @ref ina237_conv_time).
+ * @param avg    Averaging mode (see @ref ina237_avg).
  */
 #define INA237_ADC_CONFIG(mode, \
 		      vshct, \
@@ -87,5 +142,7 @@
 		      vtct, \
 		      avg)  \
 	(((mode) << 12) | ((vbusct) << 9) | ((vshct) << 6) | ((vtct) << 3) | (avg))
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_INA237_H_ */

--- a/include/zephyr/dt-bindings/sensor/ism330dhcx.h
+++ b/include/zephyr/dt-bindings/sensor/ism330dhcx.h
@@ -3,21 +3,43 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST ISM330DHCX IMU.
+ * @ingroup ism330dhcx_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_ISM330DHCX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_ISM330DHCX_H_
 
-/* Accel and Gyro Data rates */
-#define ISM330DHCX_DT_ODR_OFF			0x0
-#define ISM330DHCX_DT_ODR_12Hz5			0x1
-#define ISM330DHCX_DT_ODR_26H			0x2
-#define ISM330DHCX_DT_ODR_52Hz			0x3
-#define ISM330DHCX_DT_ODR_104Hz			0x4
-#define ISM330DHCX_DT_ODR_208Hz			0x5
-#define ISM330DHCX_DT_ODR_416Hz			0x6
-#define ISM330DHCX_DT_ODR_833Hz			0x7
-#define ISM330DHCX_DT_ODR_1666Hz		0x8
-#define ISM330DHCX_DT_ODR_3332Hz		0x9
-#define ISM330DHCX_DT_ODR_6667Hz		0xa
-#define ISM330DHCX_DT_ODR_1Hz6			0xb
+/**
+ * @defgroup ism330dhcx_interface ISM330DHCX
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics ISM330DHCX 6-axis IMU
+ * @{
+ */
+
+/**
+ * @name Accelerometer and gyroscope output data rate
+ *
+ * Values for the `accel-odr` and `gyro-odr` devicetree properties.
+ * @{
+ */
+#define ISM330DHCX_DT_ODR_OFF			0x0 /**< Power-down */
+#define ISM330DHCX_DT_ODR_12Hz5			0x1 /**< 12.5 Hz */
+#define ISM330DHCX_DT_ODR_26H			0x2 /**< 26 Hz */
+#define ISM330DHCX_DT_ODR_52Hz			0x3 /**< 52 Hz */
+#define ISM330DHCX_DT_ODR_104Hz			0x4 /**< 104 Hz */
+#define ISM330DHCX_DT_ODR_208Hz			0x5 /**< 208 Hz */
+#define ISM330DHCX_DT_ODR_416Hz			0x6 /**< 416 Hz */
+#define ISM330DHCX_DT_ODR_833Hz			0x7 /**< 833 Hz */
+#define ISM330DHCX_DT_ODR_1666Hz		0x8 /**< 1666 Hz */
+#define ISM330DHCX_DT_ODR_3332Hz		0x9 /**< 3332 Hz */
+#define ISM330DHCX_DT_ODR_6667Hz		0xa /**< 6667 Hz */
+#define ISM330DHCX_DT_ODR_1Hz6			0xb /**< 1.6 Hz (low-power) */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_ISM330DHCX_H_ */

--- a/include/zephyr/dt-bindings/sensor/ism6hg256x.h
+++ b/include/zephyr/dt-bindings/sensor/ism6hg256x.h
@@ -3,34 +3,71 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST ISM6HG256X IMU.
+ * @ingroup ism6hg256x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_ISM6HG256X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_ISM6HG256X_H_
 
 #include "lsm6dsvxxx.h"
 
-/* Accel High-g odr */
-#define ISM6HG256X_HG_XL_ODR_OFF		0x0
-#define ISM6HG256X_HG_XL_ODR_AT_480Hz		0x3
-#define ISM6HG256X_HG_XL_ODR_AT_960Hz		0x4
-#define ISM6HG256X_HG_XL_ODR_AT_1920Hz		0x5
-#define ISM6HG256X_HG_XL_ODR_AT_3840Hz		0x6
-#define ISM6HG256X_HG_XL_ODR_AT_7680Hz		0x7
+/**
+ * @defgroup ism6hg256x_interface ISM6HG256X
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics ISM6HG256X high-g 6-axis IMU
+ *
+ * Output data rates and FIFO settings are shared across the family; see
+ * @ref lsm6dsvxxx_interface.
+ * @{
+ */
 
-/* Accel range */
-#define ISM6HG256X_DT_FS_2G			2
-#define ISM6HG256X_DT_FS_4G			4
-#define ISM6HG256X_DT_FS_8G			8
-#define ISM6HG256X_DT_FS_16G			16
-#define ISM6HG256X_DT_FS_32G			32
-#define ISM6HG256X_DT_FS_64G			64
-#define ISM6HG256X_DT_FS_128G			128
-#define ISM6HG256X_DT_FS_256G			256
+/**
+ * @name High-g accelerometer output data rate
+ *
+ * Values for the `accel-hg-odr` devicetree property.
+ * @{
+ */
+#define ISM6HG256X_HG_XL_ODR_OFF		0x0 /**< Power-down */
+#define ISM6HG256X_HG_XL_ODR_AT_480Hz		0x3 /**< 480 Hz */
+#define ISM6HG256X_HG_XL_ODR_AT_960Hz		0x4 /**< 960 Hz */
+#define ISM6HG256X_HG_XL_ODR_AT_1920Hz		0x5 /**< 1920 Hz */
+#define ISM6HG256X_HG_XL_ODR_AT_3840Hz		0x6 /**< 3840 Hz */
+#define ISM6HG256X_HG_XL_ODR_AT_7680Hz		0x7 /**< 7680 Hz */
+/** @} */
 
-/* Gyro range */
-#define ISM6HG256X_DT_FS_250DPS			0x1
-#define ISM6HG256X_DT_FS_500DPS			0x2
-#define ISM6HG256X_DT_FS_1000DPS		0x3
-#define ISM6HG256X_DT_FS_2000DPS		0x4
-#define ISM6HG256X_DT_FS_4000DPS		0x5
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `accel-range` devicetree property.
+ * @{
+ */
+#define ISM6HG256X_DT_FS_2G			2   /**< ±2 g */
+#define ISM6HG256X_DT_FS_4G			4   /**< ±4 g */
+#define ISM6HG256X_DT_FS_8G			8   /**< ±8 g */
+#define ISM6HG256X_DT_FS_16G			16  /**< ±16 g */
+#define ISM6HG256X_DT_FS_32G			32  /**< ±32 g */
+#define ISM6HG256X_DT_FS_64G			64  /**< ±64 g */
+#define ISM6HG256X_DT_FS_128G			128 /**< ±128 g */
+#define ISM6HG256X_DT_FS_256G			256 /**< ±256 g */
+/** @} */
+
+/**
+ * @name Gyroscope full-scale range
+ *
+ * Values for the `gyro-range` devicetree property.
+ * @{
+ */
+#define ISM6HG256X_DT_FS_250DPS			0x1 /**< ±250 dps */
+#define ISM6HG256X_DT_FS_500DPS			0x2 /**< ±500 dps */
+#define ISM6HG256X_DT_FS_1000DPS		0x3 /**< ±1000 dps */
+#define ISM6HG256X_DT_FS_2000DPS		0x4 /**< ±2000 dps */
+#define ISM6HG256X_DT_FS_4000DPS		0x5 /**< ±4000 dps */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_ISM6HG256X_H_ */

--- a/include/zephyr/dt-bindings/sensor/it51xxx_tach.h
+++ b/include/zephyr/dt-bindings/sensor/it51xxx_tach.h
@@ -3,18 +3,33 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ITE IT51xxx tachometer.
+ * @ingroup it51xxx_tach_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_ITE_TACH_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_ITE_TACH_H_
 
 /**
- * @name Tachometer input pin
+ * @defgroup it51xxx_tach_interface IT51XXX tachometer
+ * @ingroup sensor_interface_ext_ite
+ * @brief ITE IT51xxx tachometer
  * @{
  */
 
-/** Tachometer input from pin A */
-#define IT51XXX_TACH_INPUT_PIN_A	0
-/** Tachometer input from pin B */
-#define IT51XXX_TACH_INPUT_PIN_B	1
+/**
+ * @name Tachometer input pin
+ *
+ * Values for the `input-pin` devicetree property.
+ * @{
+ */
+#define IT51XXX_TACH_INPUT_PIN_A	0 /**< Tachometer input from pin A */
+#define IT51XXX_TACH_INPUT_PIN_B	1 /**< Tachometer input from pin B */
+/** @} */
 
 /** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_ITE_TACH_H_ */

--- a/include/zephyr/dt-bindings/sensor/it8xxx2_tach.h
+++ b/include/zephyr/dt-bindings/sensor/it8xxx2_tach.h
@@ -3,18 +3,33 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ITE IT8xxx2 tachometer.
+ * @ingroup it8xxx2_tach_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_ITE_TACH_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_ITE_TACH_H_
 
 /**
- * @name Tachometer channels
+ * @defgroup it8xxx2_tach_interface IT8XXX2 tachometer
+ * @ingroup sensor_interface_ext_ite
+ * @brief ITE IT8xxx2 tachometer
  * @{
  */
 
-/** Tachometer channel A */
-#define IT8XXX2_TACH_CHANNEL_A		0
-/** Tachometer channel B */
-#define IT8XXX2_TACH_CHANNEL_B		1
+/**
+ * @name Tachometer channels
+ *
+ * Values for the `channel` devicetree property.
+ * @{
+ */
+#define IT8XXX2_TACH_CHANNEL_A		0 /**< Tachometer channel A */
+#define IT8XXX2_TACH_CHANNEL_B		1 /**< Tachometer channel B */
+/** @} */
 
 /** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_ITE_TACH_H_ */

--- a/include/zephyr/dt-bindings/sensor/it8xxx2_vcmp.h
+++ b/include/zephyr/dt-bindings/sensor/it8xxx2_vcmp.h
@@ -3,52 +3,69 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ITE IT8xxx2 voltage comparator.
+ * @ingroup it8xxx2_vcmp_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_IT8XXX2_VCMP_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_IT8XXX2_VCMP_H_
 
 /**
- * @name it8xxx2 voltage comparator channel references
+ * @defgroup it8xxx2_vcmp_interface IT8XXX2 voltage comparator
+ * @ingroup sensor_interface_ext_ite
+ * @brief ITE IT8xxx2 voltage comparator
  * @{
  */
 
-#define VCMP_CHANNEL_0				0
-#define VCMP_CHANNEL_1				1
-#define VCMP_CHANNEL_2				2
-#define VCMP_CHANNEL_3				3
-#define VCMP_CHANNEL_4				4
-#define VCMP_CHANNEL_5				5
-#define VCMP_CHANNEL_CNT			6
-
+/**
+ * @name Voltage comparator channels
+ *
+ * Values for the `vcmp-ch` devicetree property.
+ * @{
+ */
+#define VCMP_CHANNEL_0				0 /**< Channel 0 */
+#define VCMP_CHANNEL_1				1 /**< Channel 1 */
+#define VCMP_CHANNEL_2				2 /**< Channel 2 */
+#define VCMP_CHANNEL_3				3 /**< Channel 3 */
+#define VCMP_CHANNEL_4				4 /**< Channel 4 */
+#define VCMP_CHANNEL_5				5 /**< Channel 5 */
+#define VCMP_CHANNEL_CNT			6 /**< Number of channels */
 /** @} */
 
 /**
- * @name it8xxx2 voltage comparator scan period for "all comparator channel"
+ * @name Scan period across all channels
+ *
+ * Values for the `scan-period` devicetree property.
  * @{
  */
-
-#define IT8XXX2_VCMP_SCAN_PERIOD_100US		0x10
-#define IT8XXX2_VCMP_SCAN_PERIOD_200US		0x20
-#define IT8XXX2_VCMP_SCAN_PERIOD_400US		0x30
-#define IT8XXX2_VCMP_SCAN_PERIOD_600US		0x40
-#define IT8XXX2_VCMP_SCAN_PERIOD_800US		0x50
-#define IT8XXX2_VCMP_SCAN_PERIOD_1MS		0x60
-#define IT8XXX2_VCMP_SCAN_PERIOD_1_5MS		0x70
-#define IT8XXX2_VCMP_SCAN_PERIOD_2MS		0x80
-#define IT8XXX2_VCMP_SCAN_PERIOD_2_5MS		0x90
-#define IT8XXX2_VCMP_SCAN_PERIOD_3MS		0xa0
-#define IT8XXX2_VCMP_SCAN_PERIOD_4MS		0xb0
-#define IT8XXX2_VCMP_SCAN_PERIOD_5MS		0xc0
-
+#define IT8XXX2_VCMP_SCAN_PERIOD_100US		0x10 /**< 100 µs */
+#define IT8XXX2_VCMP_SCAN_PERIOD_200US		0x20 /**< 200 µs */
+#define IT8XXX2_VCMP_SCAN_PERIOD_400US		0x30 /**< 400 µs */
+#define IT8XXX2_VCMP_SCAN_PERIOD_600US		0x40 /**< 600 µs */
+#define IT8XXX2_VCMP_SCAN_PERIOD_800US		0x50 /**< 800 µs */
+#define IT8XXX2_VCMP_SCAN_PERIOD_1MS		0x60 /**< 1 ms */
+#define IT8XXX2_VCMP_SCAN_PERIOD_1_5MS		0x70 /**< 1.5 ms */
+#define IT8XXX2_VCMP_SCAN_PERIOD_2MS		0x80 /**< 2 ms */
+#define IT8XXX2_VCMP_SCAN_PERIOD_2_5MS		0x90 /**< 2.5 ms */
+#define IT8XXX2_VCMP_SCAN_PERIOD_3MS		0xa0 /**< 3 ms */
+#define IT8XXX2_VCMP_SCAN_PERIOD_4MS		0xb0 /**< 4 ms */
+#define IT8XXX2_VCMP_SCAN_PERIOD_5MS		0xc0 /**< 5 ms */
 /** @} */
 
 /**
- * @name it8xxx2 voltage comparator interrupt trigger mode
+ * @name Interrupt trigger mode
+ *
+ * Values for the `comparison` devicetree property.
  * @{
  */
-
-#define IT8XXX2_VCMP_LESS_OR_EQUAL		0
-#define IT8XXX2_VCMP_GREATER			1
-#define IT8XXX2_VCMP_UNDEFINED			0xffff
+#define IT8XXX2_VCMP_LESS_OR_EQUAL		0      /**< Trigger when ≤ threshold */
+#define IT8XXX2_VCMP_GREATER			1      /**< Trigger when > threshold */
+#define IT8XXX2_VCMP_UNDEFINED			0xffff /**< Undefined / unused */
+/** @} */
 
 /** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_IT8XXX2_VCMP_H_ */

--- a/include/zephyr/dt-bindings/sensor/lis2de12.h
+++ b/include/zephyr/dt-bindings/sensor/lis2de12.h
@@ -3,25 +3,53 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LIS2DE12 accelerometer.
+ * @ingroup lis2de12_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DE12_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DE12_H_
 
-/* Accel range */
-#define	LIS2DE12_DT_FS_2G			0
-#define	LIS2DE12_DT_FS_4G			1
-#define	LIS2DE12_DT_FS_8G			2
-#define	LIS2DE12_DT_FS_16G			3
+/**
+ * @defgroup lis2de12_interface LIS2DE12
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LIS2DE12 3-axis accelerometer
+ * @{
+ */
 
-/* Accel rates */
-#define LIS2DE12_DT_ODR_OFF			0x00 /* Power-Down */
-#define LIS2DE12_DT_ODR_AT_1Hz			0x01 /* 1Hz (normal) */
-#define LIS2DE12_DT_ODR_AT_10Hz			0x02 /* 10Hz (normal) */
-#define LIS2DE12_DT_ODR_AT_25Hz			0x03 /* 25Hz (normal) */
-#define LIS2DE12_DT_ODR_AT_50Hz			0x04 /* 50Hz (normal) */
-#define LIS2DE12_DT_ODR_AT_100Hz		0x05 /* 100Hz (normal) */
-#define LIS2DE12_DT_ODR_AT_200Hz		0x06 /* 200Hz (normal) */
-#define LIS2DE12_DT_ODR_AT_400Hz		0x07 /* 400Hz (normal) */
-#define LIS2DE12_DT_ODR_AT_1kHz620		0x08 /* 1KHz620 (normal) */
-#define LIS2DE12_DT_ODR_AT_5kHz376		0x09 /* 5KHz376 (normal) */
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `accel-range` devicetree property.
+ * @{
+ */
+#define	LIS2DE12_DT_FS_2G			0 /**< ±2 g */
+#define	LIS2DE12_DT_FS_4G			1 /**< ±4 g */
+#define	LIS2DE12_DT_FS_8G			2 /**< ±8 g */
+#define	LIS2DE12_DT_FS_16G			3 /**< ±16 g */
+/** @} */
+
+/**
+ * @name Accelerometer output data rate
+ *
+ * Values for the `accel-odr` devicetree property.
+ * @{
+ */
+#define LIS2DE12_DT_ODR_OFF			0x00 /**< Power-down */
+#define LIS2DE12_DT_ODR_AT_1Hz			0x01 /**< 1 Hz (normal) */
+#define LIS2DE12_DT_ODR_AT_10Hz			0x02 /**< 10 Hz (normal) */
+#define LIS2DE12_DT_ODR_AT_25Hz			0x03 /**< 25 Hz (normal) */
+#define LIS2DE12_DT_ODR_AT_50Hz			0x04 /**< 50 Hz (normal) */
+#define LIS2DE12_DT_ODR_AT_100Hz		0x05 /**< 100 Hz (normal) */
+#define LIS2DE12_DT_ODR_AT_200Hz		0x06 /**< 200 Hz (normal) */
+#define LIS2DE12_DT_ODR_AT_400Hz		0x07 /**< 400 Hz (normal) */
+#define LIS2DE12_DT_ODR_AT_1kHz620		0x08 /**< 1620 Hz (normal) */
+#define LIS2DE12_DT_ODR_AT_5kHz376		0x09 /**< 5376 Hz (normal) */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DE12_H_ */

--- a/include/zephyr/dt-bindings/sensor/lis2dh.h
+++ b/include/zephyr/dt-bindings/sensor/lis2dh.h
@@ -3,20 +3,46 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LIS2DH 3-axis accelerometer.
+ * @ingroup lis2dh_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DH_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DH_H_
 
-/* GPIO interrupt configuration */
-#define LIS2DH_DT_GPIO_INT_EDGE_BOTH			0
-#define LIS2DH_DT_GPIO_INT_EDGE_RISING			1
-#define LIS2DH_DT_GPIO_INT_EDGE_FALLING			2
-#define LIS2DH_DT_GPIO_INT_LEVEL_HIGH			3
-#define LIS2DH_DT_GPIO_INT_LEVEL_LOW			4
+/**
+ * @addtogroup lis2dh_interface
+ * @{
+ */
 
-/* Any Motion mode */
-#define LIS2DH_DT_ANYM_OR_COMBINATION			0
-#define LIS2DH_DT_ANYM_6D_MOVEMENT			1
-#define LIS2DH_DT_ANYM_AND_COMBINATION			2
-#define LIS2DH_DT_ANYM_6D_POSITION			3
+/**
+ * @name GPIO interrupt configuration
+ *
+ * Values for the `int1-gpio-config` and `int2-gpio-config` devicetree properties.
+ * @{
+ */
+#define LIS2DH_DT_GPIO_INT_EDGE_BOTH		0 /**< Trigger on both signal edges */
+#define LIS2DH_DT_GPIO_INT_EDGE_RISING		1 /**< Trigger on the rising edge */
+#define LIS2DH_DT_GPIO_INT_EDGE_FALLING		2 /**< Trigger on the falling edge */
+#define LIS2DH_DT_GPIO_INT_LEVEL_HIGH		3 /**< Trigger while the signal is high */
+#define LIS2DH_DT_GPIO_INT_LEVEL_LOW		4 /**< Trigger while the signal is low */
+/** @} */
+
+/**
+ * @name Any-motion detection mode
+ *
+ * Values for the `anym-mode` devicetree property.
+ * @{
+ */
+#define LIS2DH_DT_ANYM_OR_COMBINATION		0 /**< OR combination of enabled axes */
+#define LIS2DH_DT_ANYM_6D_MOVEMENT		1 /**< 6-direction movement recognition */
+#define LIS2DH_DT_ANYM_AND_COMBINATION		2 /**< AND combination of enabled axes */
+#define LIS2DH_DT_ANYM_6D_POSITION		3 /**< 6-direction position recognition */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DH_H_ */

--- a/include/zephyr/dt-bindings/sensor/lis2ds12.h
+++ b/include/zephyr/dt-bindings/sensor/lis2ds12.h
@@ -3,27 +3,57 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LIS2DS12 accelerometer.
+ * @ingroup lis2ds12_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DS12_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DS12_H_
 
-/* power-modes */
-#define LIS2DS12_DT_POWER_DOWN			0
-#define LIS2DS12_DT_LOW_POWER			1
-#define LIS2DS12_DT_HIGH_RESOLUTION		2
-#define LIS2DS12_DT_HIGH_FREQUENCY		3
+/**
+ * @defgroup lis2ds12_interface LIS2DS12
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LIS2DS12 3-axis accelerometer
+ * @{
+ */
 
-/* Data rate */
-#define LIS2DS12_DT_ODR_OFF			0
-#define LIS2DS12_DT_ODR_1Hz_LP			1  /* available in LP mode only */
-#define LIS2DS12_DT_ODR_12Hz5			2  /* available in LP and HR mode */
-#define LIS2DS12_DT_ODR_25Hz			3  /* available in LP and HR mode */
-#define LIS2DS12_DT_ODR_50Hz			4  /* available in LP and HR mode */
-#define LIS2DS12_DT_ODR_100Hz			5  /* available in LP and HR mode */
-#define LIS2DS12_DT_ODR_200Hz			6  /* available in LP and HR mode */
-#define LIS2DS12_DT_ODR_400Hz			7  /* available in LP and HR mode */
-#define LIS2DS12_DT_ODR_800Hz			8  /* available in LP and HR mode */
-#define LIS2DS12_DT_ODR_1600Hz			9  /* available in HF mode only */
-#define LIS2DS12_DT_ODR_3200Hz_HF		10 /* available in HF mode only */
-#define LIS2DS12_DT_ODR_6400Hz_HF		11 /* available in HF mode only */
+/**
+ * @name Power modes
+ *
+ * Values for the `power-mode` devicetree property.
+ * @{
+ */
+#define LIS2DS12_DT_POWER_DOWN			0 /**< Power-down */
+#define LIS2DS12_DT_LOW_POWER			1 /**< Low-power mode */
+#define LIS2DS12_DT_HIGH_RESOLUTION		2 /**< High-resolution mode */
+#define LIS2DS12_DT_HIGH_FREQUENCY		3 /**< High-frequency mode */
+/** @} */
+
+/**
+ * @name Output data rate options
+ *
+ * Values for the `odr` devicetree property.
+ *
+ * LP: low-power, HR: high-resolution, HF: high-frequency mode.
+ * @{
+ */
+#define LIS2DS12_DT_ODR_OFF			0  /**< Power-down */
+#define LIS2DS12_DT_ODR_1Hz_LP			1  /**< 1 Hz (LP mode only) */
+#define LIS2DS12_DT_ODR_12Hz5			2  /**< 12.5 Hz (LP or HR mode) */
+#define LIS2DS12_DT_ODR_25Hz			3  /**< 25 Hz (LP or HR mode) */
+#define LIS2DS12_DT_ODR_50Hz			4  /**< 50 Hz (LP or HR mode) */
+#define LIS2DS12_DT_ODR_100Hz			5  /**< 100 Hz (LP or HR mode) */
+#define LIS2DS12_DT_ODR_200Hz			6  /**< 200 Hz (LP or HR mode) */
+#define LIS2DS12_DT_ODR_400Hz			7  /**< 400 Hz (LP or HR mode) */
+#define LIS2DS12_DT_ODR_800Hz			8  /**< 800 Hz (LP or HR mode) */
+#define LIS2DS12_DT_ODR_1600Hz			9  /**< 1600 Hz (HF mode only) */
+#define LIS2DS12_DT_ODR_3200Hz_HF		10 /**< 3200 Hz (HF mode only) */
+#define LIS2DS12_DT_ODR_6400Hz_HF		11 /**< 6400 Hz (HF mode only) */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DS12_H_ */

--- a/include/zephyr/dt-bindings/sensor/lis2du12.h
+++ b/include/zephyr/dt-bindings/sensor/lis2du12.h
@@ -3,29 +3,59 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LIS2DU12 accelerometer.
+ * @ingroup lis2du12_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DU12_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DU12_H_
 
-/* Accel range */
-#define	LIS2DU12_DT_FS_2G			0
-#define	LIS2DU12_DT_FS_4G			1
-#define	LIS2DU12_DT_FS_8G			2
-#define	LIS2DU12_DT_FS_16G			3
+/**
+ * @defgroup lis2du12_interface LIS2DU12
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LIS2DU12 3-axis accelerometer
+ * @{
+ */
 
-/* Accel rates */
-#define LIS2DU12_DT_ODR_OFF			0x00 /* Power-Down */
-#define LIS2DU12_DT_ODR_AT_1Hz6_ULP		0x01 /* 1Hz6 (ultra low power) */
-#define LIS2DU12_DT_ODR_AT_3Hz_ULP		0x02 /* 3Hz (ultra low power) */
-#define LIS2DU12_DT_ODR_AT_6Hz_ULP		0x03 /* 6Hz (ultra low power) */
-#define LIS2DU12_DT_ODR_AT_6Hz			0x04 /* 6Hz (normal) */
-#define LIS2DU12_DT_ODR_AT_12Hz			0x05 /* 12Hz5 (normal) */
-#define LIS2DU12_DT_ODR_AT_25Hz			0x06 /* 25Hz (normal) */
-#define LIS2DU12_DT_ODR_AT_50Hz			0x07 /* 50Hz (normal) */
-#define LIS2DU12_DT_ODR_AT_100Hz		0x08 /* 100Hz (normal) */
-#define LIS2DU12_DT_ODR_AT_200Hz		0x09 /* 200Hz (normal) */
-#define LIS2DU12_DT_ODR_AT_400Hz		0x0a /* 400Hz (normal) */
-#define LIS2DU12_DT_ODR_AT_800Hz		0x0b /* 800Hz (normal) */
-#define LIS2DU12_DT_ODR_TRIG_PIN		0x0e /* Single-shot high latency by INT2 */
-#define LIS2DU12_DT_ODR_TRIG_SW			0x0f /* Single-shot high latency by IF */
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `accel-range` devicetree property.
+ * @{
+ */
+#define	LIS2DU12_DT_FS_2G			0 /**< ±2 g */
+#define	LIS2DU12_DT_FS_4G			1 /**< ±4 g */
+#define	LIS2DU12_DT_FS_8G			2 /**< ±8 g */
+#define	LIS2DU12_DT_FS_16G			3 /**< ±16 g */
+/** @} */
+
+/**
+ * @name Accelerometer output data rate
+ *
+ * Values for the `accel-odr` devicetree property.
+ *
+ * ULP: ultra-low-power mode.
+ * @{
+ */
+#define LIS2DU12_DT_ODR_OFF			0x00 /**< Power-down */
+#define LIS2DU12_DT_ODR_AT_1Hz6_ULP		0x01 /**< 1.6 Hz (ULP) */
+#define LIS2DU12_DT_ODR_AT_3Hz_ULP		0x02 /**< 3 Hz (ULP) */
+#define LIS2DU12_DT_ODR_AT_6Hz_ULP		0x03 /**< 6 Hz (ULP) */
+#define LIS2DU12_DT_ODR_AT_6Hz			0x04 /**< 6 Hz (normal) */
+#define LIS2DU12_DT_ODR_AT_12Hz			0x05 /**< 12.5 Hz (normal) */
+#define LIS2DU12_DT_ODR_AT_25Hz			0x06 /**< 25 Hz (normal) */
+#define LIS2DU12_DT_ODR_AT_50Hz			0x07 /**< 50 Hz (normal) */
+#define LIS2DU12_DT_ODR_AT_100Hz		0x08 /**< 100 Hz (normal) */
+#define LIS2DU12_DT_ODR_AT_200Hz		0x09 /**< 200 Hz (normal) */
+#define LIS2DU12_DT_ODR_AT_400Hz		0x0a /**< 400 Hz (normal) */
+#define LIS2DU12_DT_ODR_AT_800Hz		0x0b /**< 800 Hz (normal) */
+#define LIS2DU12_DT_ODR_TRIG_PIN		0x0e /**< Single-shot, high latency, via INT2 */
+#define LIS2DU12_DT_ODR_TRIG_SW			0x0f /**< Single-shot, high latency, via bus */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DU12_H_ */

--- a/include/zephyr/dt-bindings/sensor/lis2dux12.h
+++ b/include/zephyr/dt-bindings/sensor/lis2dux12.h
@@ -3,79 +3,145 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LIS2DUX12 accelerometer.
+ * @ingroup lis2dux12_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_LIS2DUX12_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_LIS2DUX12_H_
 
 #include <zephyr/dt-bindings/dt-util.h>
 
-/* Operating Mode */
-#define LIS2DUX12_OPER_MODE_POWER_DOWN        0
-#define LIS2DUX12_OPER_MODE_LOW_POWER         1
-#define LIS2DUX12_OPER_MODE_HIGH_PERFORMANCE  2
-#define LIS2DUX12_OPER_MODE_SINGLE_SHOT       3
+/**
+ * @defgroup lis2dux12_interface LIS2DUX12
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LIS2DUX12 3-axis accelerometer
+ * @{
+ */
 
-/* Data rate */
-#define LIS2DUX12_DT_ODR_OFF      0
-#define LIS2DUX12_DT_ODR_1Hz_ULP  1  /* available in ultra-low power mode */
-#define LIS2DUX12_DT_ODR_3Hz_ULP  2  /* available in ultra-low power mode */
-#define LIS2DUX12_DT_ODR_25Hz_ULP 3  /* available in ultra-low power mode */
-#define LIS2DUX12_DT_ODR_6Hz      4  /* available in LP and HP mode */
-#define LIS2DUX12_DT_ODR_12Hz5    5  /* available in LP and HP mode */
-#define LIS2DUX12_DT_ODR_25Hz     6  /* available in LP and HP mode */
-#define LIS2DUX12_DT_ODR_50Hz     7  /* available in LP and HP mode */
-#define LIS2DUX12_DT_ODR_100Hz    8  /* available in LP and HP mode */
-#define LIS2DUX12_DT_ODR_200Hz    9  /* available in LP and HP mode */
-#define LIS2DUX12_DT_ODR_400Hz    10 /* available in LP and HP mode */
-#define LIS2DUX12_DT_ODR_800Hz    11 /* available in LP and HP mode */
-#define LIS2DUX12_DT_ODR_END      12
+/**
+ * @name Operating mode
+ *
+ * Values for the `power-mode` devicetree property.
+ * @{
+ */
+#define LIS2DUX12_OPER_MODE_POWER_DOWN        0 /**< Power-down */
+#define LIS2DUX12_OPER_MODE_LOW_POWER         1 /**< Low-power mode */
+#define LIS2DUX12_OPER_MODE_HIGH_PERFORMANCE  2 /**< High-performance mode */
+#define LIS2DUX12_OPER_MODE_SINGLE_SHOT       3 /**< Single-shot mode */
+/** @} */
 
-/* Accelerometer Full-scale */
-#define LIS2DUX12_DT_FS_2G  0 /* 2g (0.061 mg/LSB)  */
-#define LIS2DUX12_DT_FS_4G  1 /* 4g (0.122 mg/LSB)  */
-#define LIS2DUX12_DT_FS_8G  2 /* 8g (0.244 mg/LSB)  */
-#define LIS2DUX12_DT_FS_16G 3 /* 16g (0.488 mg/LSB) */
+/**
+ * @name Output data rate options
+ *
+ * Values for the `odr` devicetree property.
+ *
+ * ULP: ultra-low-power, LP: low-power, HP: high-performance mode.
+ * @{
+ */
+#define LIS2DUX12_DT_ODR_OFF      0  /**< Power-down */
+#define LIS2DUX12_DT_ODR_1Hz_ULP  1  /**< 1 Hz (ULP mode only) */
+#define LIS2DUX12_DT_ODR_3Hz_ULP  2  /**< 3 Hz (ULP mode only) */
+#define LIS2DUX12_DT_ODR_25Hz_ULP 3  /**< 25 Hz (ULP mode only) */
+#define LIS2DUX12_DT_ODR_6Hz      4  /**< 6 Hz (LP or HP mode) */
+#define LIS2DUX12_DT_ODR_12Hz5    5  /**< 12.5 Hz (LP or HP mode) */
+#define LIS2DUX12_DT_ODR_25Hz     6  /**< 25 Hz (LP or HP mode) */
+#define LIS2DUX12_DT_ODR_50Hz     7  /**< 50 Hz (LP or HP mode) */
+#define LIS2DUX12_DT_ODR_100Hz    8  /**< 100 Hz (LP or HP mode) */
+#define LIS2DUX12_DT_ODR_200Hz    9  /**< 200 Hz (LP or HP mode) */
+#define LIS2DUX12_DT_ODR_400Hz    10 /**< 400 Hz (LP or HP mode) */
+#define LIS2DUX12_DT_ODR_800Hz    11 /**< 800 Hz (LP or HP mode) */
+#define LIS2DUX12_DT_ODR_END      12 /**< Sentinel, one past the last ODR */
+/** @} */
 
-/* Accelerometer FIFO batching data rate */
-#define LIS2DUX12_DT_BDR_XL_ODR        0x0
-#define LIS2DUX12_DT_BDR_XL_ODR_DIV_2  0x1
-#define LIS2DUX12_DT_BDR_XL_ODR_DIV_4  0x2
-#define LIS2DUX12_DT_BDR_XL_ODR_DIV_8  0x3
-#define LIS2DUX12_DT_BDR_XL_ODR_DIV_16 0x4
-#define LIS2DUX12_DT_BDR_XL_ODR_DIV_32 0x5
-#define LIS2DUX12_DT_BDR_XL_ODR_DIV_64 0x6
-#define LIS2DUX12_DT_BDR_XL_ODR_OFF    0x7
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `range` devicetree property.
+ * @{
+ */
+#define LIS2DUX12_DT_FS_2G  0 /**< ±2 g (0.061 mg/LSB) */
+#define LIS2DUX12_DT_FS_4G  1 /**< ±4 g (0.122 mg/LSB) */
+#define LIS2DUX12_DT_FS_8G  2 /**< ±8 g (0.244 mg/LSB) */
+#define LIS2DUX12_DT_FS_16G 3 /**< ±16 g (0.488 mg/LSB) */
+/** @} */
 
-/* Accelerometer FIFO timestamp ratio */
-#define LIS2DUX12_DT_DEC_TS_OFF  0x0
-#define LIS2DUX12_DT_DEC_TS_1    0x1
-#define LIS2DUX12_DT_DEC_TS_8    0x2
-#define LIS2DUX12_DT_DEC_TS_32   0x3
+/**
+ * @name Accelerometer FIFO batching data rate
+ *
+ * Values for the `accel-fifo-batch-rate` devicetree property.
+ * @{
+ */
+#define LIS2DUX12_DT_BDR_XL_ODR        0x0 /**< Batched at ODR */
+#define LIS2DUX12_DT_BDR_XL_ODR_DIV_2  0x1 /**< Batched at ODR / 2 */
+#define LIS2DUX12_DT_BDR_XL_ODR_DIV_4  0x2 /**< Batched at ODR / 4 */
+#define LIS2DUX12_DT_BDR_XL_ODR_DIV_8  0x3 /**< Batched at ODR / 8 */
+#define LIS2DUX12_DT_BDR_XL_ODR_DIV_16 0x4 /**< Batched at ODR / 16 */
+#define LIS2DUX12_DT_BDR_XL_ODR_DIV_32 0x5 /**< Batched at ODR / 32 */
+#define LIS2DUX12_DT_BDR_XL_ODR_DIV_64 0x6 /**< Batched at ODR / 64 */
+#define LIS2DUX12_DT_BDR_XL_ODR_OFF    0x7 /**< Not batched */
+/** @} */
 
-/* Accelerometer FIFO tags (aligned with lis2dux12_fifo_sensor_tag_t) */
-#define LIS2DUXXX_FIFO_EMPTY         0x0
-#define LIS2DUXXX_XL_TEMP_TAG        0x2
-#define LIS2DUXXX_XL_ONLY_2X_TAG     0x3
-#define LIS2DUXXX_TIMESTAMP_TAG      0x4
-#define LIS2DUXXX_STEP_COUNTER_TAG   0x12
-#define LIS2DUXXX_MLC_RESULT_TAG     0x1A
-#define LIS2DUXXX_MLC_FILTER_TAG     0x1B
-#define LIS2DUXXX_MLC_FEATURE        0x1C
-#define LIS2DUXXX_FSM_RESULT_TAG     0x1D
+/**
+ * @name Accelerometer FIFO timestamp decimation
+ *
+ * Values for the `timestamp-fifo-batch-rate` devicetree property.
+ * @{
+ */
+#define LIS2DUX12_DT_DEC_TS_OFF  0x0 /**< Timestamp not batched */
+#define LIS2DUX12_DT_DEC_TS_1    0x1 /**< Decimation by 1 */
+#define LIS2DUX12_DT_DEC_TS_8    0x2 /**< Decimation by 8 */
+#define LIS2DUX12_DT_DEC_TS_32   0x3 /**< Decimation by 32 */
+/** @} */
 
-/* Accelerometer FIFO modes (aligned with lis2dux12_operation_t) */
-#define LIS2DUXXX_DT_BYPASS_MODE            0x0
-#define LIS2DUXXX_DT_FIFO_MODE              0x1
-#define LIS2DUXXX_DT_STREAM_TO_FIFO_MODE    0x3
-#define LIS2DUXXX_DT_BYPASS_TO_STREAM_MODE  0x4
-#define LIS2DUXXX_DT_STREAM_MODE            0x6
-#define LIS2DUXXX_DT_BYPASS_TO_FIFO_MODE    0x7
-#define LIS2DUXXX_DT_FIFO_OFF               0x8
+/**
+ * @name FIFO record tags
+ *
+ * FIFO record tag values reported in the FIFO data stream.
+ * @{
+ */
+#define LIS2DUXXX_FIFO_EMPTY         0x0  /**< FIFO empty */
+#define LIS2DUXXX_XL_TEMP_TAG        0x2  /**< Accelerometer and temperature */
+#define LIS2DUXXX_XL_ONLY_2X_TAG     0x3  /**< Accelerometer only, 2x compressed */
+#define LIS2DUXXX_TIMESTAMP_TAG      0x4  /**< Timestamp */
+#define LIS2DUXXX_STEP_COUNTER_TAG   0x12 /**< Step counter */
+#define LIS2DUXXX_MLC_RESULT_TAG     0x1A /**< Machine-learning core result */
+#define LIS2DUXXX_MLC_FILTER_TAG     0x1B /**< Machine-learning core filter */
+#define LIS2DUXXX_MLC_FEATURE        0x1C /**< Machine-learning core feature */
+#define LIS2DUXXX_FSM_RESULT_TAG     0x1D /**< Finite-state-machine result */
+/** @} */
 
-/* Accelerometer registers */
-#define LIS2DUXXX_DT_FIFO_CTRL           0x15U
-#define LIS2DUXXX_DT_STATUS              0x25U
-#define LIS2DUXXX_DT_FIFO_STATUS1        0x26U
-#define LIS2DUXXX_DT_OUTX_L              0x28U
-#define LIS2DUXXX_DT_FIFO_DATA_OUT_TAG   0x40U
+/**
+ * @name FIFO modes
+ *
+ * FIFO operating modes used by the driver.
+ * @{
+ */
+#define LIS2DUXXX_DT_BYPASS_MODE            0x0 /**< Bypass (FIFO disabled) */
+#define LIS2DUXXX_DT_FIFO_MODE              0x1 /**< FIFO mode */
+#define LIS2DUXXX_DT_STREAM_TO_FIFO_MODE    0x3 /**< Stream-to-FIFO mode */
+#define LIS2DUXXX_DT_BYPASS_TO_STREAM_MODE  0x4 /**< Bypass-to-stream mode */
+#define LIS2DUXXX_DT_STREAM_MODE            0x6 /**< Continuous stream mode */
+#define LIS2DUXXX_DT_BYPASS_TO_FIFO_MODE    0x7 /**< Bypass-to-FIFO mode */
+#define LIS2DUXXX_DT_FIFO_OFF               0x8 /**< FIFO off */
+/** @} */
+
+/**
+ * @name Register addresses
+ *
+ * Register addresses used by the driver.
+ * @{
+ */
+#define LIS2DUXXX_DT_FIFO_CTRL           0x15U /**< FIFO_CTRL register */
+#define LIS2DUXXX_DT_STATUS              0x25U /**< STATUS register */
+#define LIS2DUXXX_DT_FIFO_STATUS1        0x26U /**< FIFO_STATUS1 register */
+#define LIS2DUXXX_DT_OUTX_L              0x28U /**< OUTX_L output register */
+#define LIS2DUXXX_DT_FIFO_DATA_OUT_TAG   0x40U /**< FIFO_DATA_OUT_TAG register */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_LIS2DUX12_H_ */

--- a/include/zephyr/dt-bindings/sensor/lis2dw12.h
+++ b/include/zephyr/dt-bindings/sensor/lis2dw12.h
@@ -3,58 +3,110 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LIS2DW12 accelerometer.
+ * @ingroup lis2dw12_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DW12_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DW12_H_
 
-/* power-modes */
-#define LIS2DW12_DT_LP_M1			0
-#define LIS2DW12_DT_LP_M2			1
-#define LIS2DW12_DT_LP_M3			2
-#define LIS2DW12_DT_LP_M4			3
-#define LIS2DW12_DT_HP_MODE			4
+/**
+ * @defgroup lis2dw12_interface LIS2DW12
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LIS2DW12 3-axis accelerometer
+ * @{
+ */
 
-/* Filter bandwidth */
-#define LIS2DW12_DT_FILTER_BW_ODR_DIV_2		0
-#define LIS2DW12_DT_FILTER_BW_ODR_DIV_4		1
-#define LIS2DW12_DT_FILTER_BW_ODR_DIV_10	2
-#define LIS2DW12_DT_FILTER_BW_ODR_DIV_20	3
+/**
+ * @name Power modes
+ *
+ * Values for the `power-mode` devicetree property.
+ * @{
+ */
+#define LIS2DW12_DT_LP_M1			0 /**< Low-power mode 1 (12-bit) */
+#define LIS2DW12_DT_LP_M2			1 /**< Low-power mode 2 (14-bit) */
+#define LIS2DW12_DT_LP_M3			2 /**< Low-power mode 3 (14-bit) */
+#define LIS2DW12_DT_LP_M4			3 /**< Low-power mode 4 (14-bit) */
+#define LIS2DW12_DT_HP_MODE			4 /**< High-performance mode (14-bit) */
+/** @} */
 
-/* Tap mode */
-#define LIS2DW12_DT_SINGLE_TAP			0
-#define LIS2DW12_DT_SINGLE_DOUBLE_TAP		1
+/**
+ * @name Filter bandwidth options
+ *
+ * Values for the `bw-filt` devicetree property.
+ * @{
+ */
+#define LIS2DW12_DT_FILTER_BW_ODR_DIV_2		0 /**< ODR / 2 */
+#define LIS2DW12_DT_FILTER_BW_ODR_DIV_4		1 /**< ODR / 4 */
+#define LIS2DW12_DT_FILTER_BW_ODR_DIV_10	2 /**< ODR / 10 */
+#define LIS2DW12_DT_FILTER_BW_ODR_DIV_20	3 /**< ODR / 20 */
+/** @} */
 
-/* Free-Fall threshold */
-#define LIS2DW12_DT_FF_THRESHOLD_156_mg		0
-#define LIS2DW12_DT_FF_THRESHOLD_219_mg		1
-#define LIS2DW12_DT_FF_THRESHOLD_250_mg		2
-#define LIS2DW12_DT_FF_THRESHOLD_312_mg		3
-#define LIS2DW12_DT_FF_THRESHOLD_344_mg		4
-#define LIS2DW12_DT_FF_THRESHOLD_406_mg		5
-#define LIS2DW12_DT_FF_THRESHOLD_469_mg		6
-#define LIS2DW12_DT_FF_THRESHOLD_500_mg		7
+/**
+ * @name Tap detection mode
+ *
+ * Values for the `tap-mode` devicetree property.
+ * @{
+ */
+#define LIS2DW12_DT_SINGLE_TAP			0 /**< Single-tap only */
+#define LIS2DW12_DT_SINGLE_DOUBLE_TAP		1 /**< Single and double tap */
+/** @} */
 
-/* wakeup duration */
-#define LIS2DW12_DT_WAKEUP_1_ODR		0
-#define LIS2DW12_DT_WAKEUP_2_ODR		1
-#define LIS2DW12_DT_WAKEUP_3_ODR		2
-#define LIS2DW12_DT_WAKEUP_4_ODR		3
+/**
+ * @name Free-fall threshold options
+ *
+ * Values for the `ff-threshold` devicetree property.
+ * @{
+ */
+#define LIS2DW12_DT_FF_THRESHOLD_156_mg		0 /**< 156 mg */
+#define LIS2DW12_DT_FF_THRESHOLD_219_mg		1 /**< 219 mg */
+#define LIS2DW12_DT_FF_THRESHOLD_250_mg		2 /**< 250 mg */
+#define LIS2DW12_DT_FF_THRESHOLD_312_mg		3 /**< 312 mg */
+#define LIS2DW12_DT_FF_THRESHOLD_344_mg		4 /**< 344 mg */
+#define LIS2DW12_DT_FF_THRESHOLD_406_mg		5 /**< 406 mg */
+#define LIS2DW12_DT_FF_THRESHOLD_469_mg		6 /**< 469 mg */
+#define LIS2DW12_DT_FF_THRESHOLD_500_mg		7 /**< 500 mg */
+/** @} */
 
-/* sleep duration */
-#define LIS2DW12_DT_SLEEP_0_ODR		    0
-#define LIS2DW12_DT_SLEEP_1_ODR		    1
-#define LIS2DW12_DT_SLEEP_2_ODR		    2
-#define LIS2DW12_DT_SLEEP_3_ODR		    3
-#define LIS2DW12_DT_SLEEP_4_ODR		    4
-#define LIS2DW12_DT_SLEEP_5_ODR		    5
-#define LIS2DW12_DT_SLEEP_6_ODR		    6
-#define LIS2DW12_DT_SLEEP_7_ODR		    7
-#define LIS2DW12_DT_SLEEP_8_ODR		    8
-#define LIS2DW12_DT_SLEEP_9_ODR		    9
-#define LIS2DW12_DT_SLEEP_10_ODR		10
-#define LIS2DW12_DT_SLEEP_11_ODR		11
-#define LIS2DW12_DT_SLEEP_12_ODR		12
-#define LIS2DW12_DT_SLEEP_13_ODR		13
-#define LIS2DW12_DT_SLEEP_14_ODR		14
-#define LIS2DW12_DT_SLEEP_15_ODR		15
+/**
+ * @name Wake-up duration options
+ *
+ * Values for the `wakeup-duration` devicetree property.
+ * @{
+ */
+#define LIS2DW12_DT_WAKEUP_1_ODR		0 /**< 1 ODR period */
+#define LIS2DW12_DT_WAKEUP_2_ODR		1 /**< 2 ODR periods */
+#define LIS2DW12_DT_WAKEUP_3_ODR		2 /**< 3 ODR periods */
+#define LIS2DW12_DT_WAKEUP_4_ODR		3 /**< 4 ODR periods */
+/** @} */
+
+/**
+ * @name Sleep duration options
+ *
+ * Values for the `sleep-duration` devicetree property.
+ * @{
+ */
+#define LIS2DW12_DT_SLEEP_0_ODR		    0  /**< 0 ODR periods */
+#define LIS2DW12_DT_SLEEP_1_ODR		    1  /**< 1 ODR period */
+#define LIS2DW12_DT_SLEEP_2_ODR		    2  /**< 2 ODR periods */
+#define LIS2DW12_DT_SLEEP_3_ODR		    3  /**< 3 ODR periods */
+#define LIS2DW12_DT_SLEEP_4_ODR		    4  /**< 4 ODR periods */
+#define LIS2DW12_DT_SLEEP_5_ODR		    5  /**< 5 ODR periods */
+#define LIS2DW12_DT_SLEEP_6_ODR		    6  /**< 6 ODR periods */
+#define LIS2DW12_DT_SLEEP_7_ODR		    7  /**< 7 ODR periods */
+#define LIS2DW12_DT_SLEEP_8_ODR		    8  /**< 8 ODR periods */
+#define LIS2DW12_DT_SLEEP_9_ODR		    9  /**< 9 ODR periods */
+#define LIS2DW12_DT_SLEEP_10_ODR		10 /**< 10 ODR periods */
+#define LIS2DW12_DT_SLEEP_11_ODR		11 /**< 11 ODR periods */
+#define LIS2DW12_DT_SLEEP_12_ODR		12 /**< 12 ODR periods */
+#define LIS2DW12_DT_SLEEP_13_ODR		13 /**< 13 ODR periods */
+#define LIS2DW12_DT_SLEEP_14_ODR		14 /**< 14 ODR periods */
+#define LIS2DW12_DT_SLEEP_15_ODR		15 /**< 15 ODR periods */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LIS2DW12_H_ */

--- a/include/zephyr/dt-bindings/sensor/lps22hh.h
+++ b/include/zephyr/dt-bindings/sensor/lps22hh.h
@@ -3,17 +3,39 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LPS22HH pressure sensor.
+ * @ingroup lps22hh_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LPS22HH_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LPS22HH_H_
 
-/* Data rate */
-#define LPS22HH_DT_ODR_POWER_DOWN		0
-#define LPS22HH_DT_ODR_1HZ			1
-#define LPS22HH_DT_ODR_10HZ			2
-#define LPS22HH_DT_ODR_25HZ			3
-#define LPS22HH_DT_ODR_50HZ			4
-#define LPS22HH_DT_ODR_75HZ			5
-#define LPS22HH_DT_ODR_100HZ			6
-#define LPS22HH_DT_ODR_200HZ			7
+/**
+ * @defgroup lps22hh_interface LPS22HH
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LPS22HH pressure and temperature sensor
+ * @{
+ */
+
+/**
+ * @name Output data rate options
+ *
+ * Values for the `odr` devicetree property.
+ * @{
+ */
+#define LPS22HH_DT_ODR_POWER_DOWN		0 /**< Power-down */
+#define LPS22HH_DT_ODR_1HZ			1 /**< 1 Hz */
+#define LPS22HH_DT_ODR_10HZ			2 /**< 10 Hz */
+#define LPS22HH_DT_ODR_25HZ			3 /**< 25 Hz */
+#define LPS22HH_DT_ODR_50HZ			4 /**< 50 Hz */
+#define LPS22HH_DT_ODR_75HZ			5 /**< 75 Hz */
+#define LPS22HH_DT_ODR_100HZ			6 /**< 100 Hz */
+#define LPS22HH_DT_ODR_200HZ			7 /**< 200 Hz */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LPS22HH_H_ */

--- a/include/zephyr/dt-bindings/sensor/lps2xdf.h
+++ b/include/zephyr/dt-bindings/sensor/lps2xdf.h
@@ -4,41 +4,79 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LPS2xDF pressure sensors.
+ * @ingroup lps2xdf_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LPS2xDF_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LPS2xDF_H_
 
-/* Data rate */
-#define LPS2xDF_DT_ODR_POWER_DOWN		0
-#define LPS2xDF_DT_ODR_1HZ			1
-#define LPS2xDF_DT_ODR_4HZ			2
-#define LPS2xDF_DT_ODR_10HZ			3
-#define LPS2xDF_DT_ODR_25HZ			4
-#define LPS2xDF_DT_ODR_50HZ			5
-#define LPS2xDF_DT_ODR_75HZ			6
-#define LPS2xDF_DT_ODR_100HZ			7
-#define LPS2xDF_DT_ODR_200HZ			8
+/**
+ * @defgroup lps2xdf_interface LPS2xDF
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LPS2xDF pressure and temperature sensors
+ * @{
+ */
 
-/* Low Pass filter */
-#define LPS2xDF_DT_LP_FILTER_OFF		0
-#define LPS2xDF_DT_LP_FILTER_ODR_4		1
-#define LPS2xDF_DT_LP_FILTER_ODR_9		3
+/**
+ * @name Output data rate options
+ *
+ * Values for the `odr` devicetree property.
+ * @{
+ */
+#define LPS2xDF_DT_ODR_POWER_DOWN		0 /**< Power-down */
+#define LPS2xDF_DT_ODR_1HZ			1 /**< 1 Hz */
+#define LPS2xDF_DT_ODR_4HZ			2 /**< 4 Hz */
+#define LPS2xDF_DT_ODR_10HZ			3 /**< 10 Hz */
+#define LPS2xDF_DT_ODR_25HZ			4 /**< 25 Hz */
+#define LPS2xDF_DT_ODR_50HZ			5 /**< 50 Hz */
+#define LPS2xDF_DT_ODR_75HZ			6 /**< 75 Hz */
+#define LPS2xDF_DT_ODR_100HZ			7 /**< 100 Hz */
+#define LPS2xDF_DT_ODR_200HZ			8 /**< 200 Hz */
+/** @} */
 
-/* Average (number of samples) filter */
-#define LPS2xDF_DT_AVG_4_SAMPLES		0
-#define LPS2xDF_DT_AVG_8_SAMPLES		1
-#define LPS2xDF_DT_AVG_16_SAMPLES		2
-#define LPS2xDF_DT_AVG_32_SAMPLES		3
-#define LPS2xDF_DT_AVG_64_SAMPLES		4
-#define LPS2xDF_DT_AVG_128_SAMPLES		5
-#define LPS2xDF_DT_AVG_256_SAMPLES		6
-#define LPS2xDF_DT_AVG_512_SAMPLES		7
+/**
+ * @name Low-pass filter options
+ *
+ * Values for the `lpf` devicetree property.
+ * @{
+ */
+#define LPS2xDF_DT_LP_FILTER_OFF		0 /**< Filter disabled */
+#define LPS2xDF_DT_LP_FILTER_ODR_4		1 /**< ODR / 4 */
+#define LPS2xDF_DT_LP_FILTER_ODR_9		3 /**< ODR / 9 */
+/** @} */
 
-/* Full Scale Pressure Mode */
-#define LPS28DFW_DT_FS_MODE_1_1260		0
-#define LPS28DFW_DT_FS_MODE_2_4060		1
+/**
+ * @name Averaging (number of samples) options
+ *
+ * Values for the `avg` devicetree property.
+ * @{
+ */
+#define LPS2xDF_DT_AVG_4_SAMPLES		0 /**< 4 samples */
+#define LPS2xDF_DT_AVG_8_SAMPLES		1 /**< 8 samples */
+#define LPS2xDF_DT_AVG_16_SAMPLES		2 /**< 16 samples */
+#define LPS2xDF_DT_AVG_32_SAMPLES		3 /**< 32 samples */
+#define LPS2xDF_DT_AVG_64_SAMPLES		4 /**< 64 samples */
+#define LPS2xDF_DT_AVG_128_SAMPLES		5 /**< 128 samples */
+#define LPS2xDF_DT_AVG_256_SAMPLES		6 /**< 256 samples */
+#define LPS2xDF_DT_AVG_512_SAMPLES		7 /**< 512 samples */
+/** @} */
 
-/* Full Scale Pressure Mode */
-#define ILPS22QS_DT_FS_MODE_1_1260		0
-#define ILPS22QS_DT_FS_MODE_2_4060		1
+/**
+ * @name Full-scale pressure mode options
+ *
+ * Values for the `fs` devicetree property.
+ * @{
+ */
+#define LPS28DFW_DT_FS_MODE_1_1260		0 /**< LPS28DFW mode 1 (1260 hPa) */
+#define LPS28DFW_DT_FS_MODE_2_4060		1 /**< LPS28DFW mode 2 (4060 hPa) */
+#define ILPS22QS_DT_FS_MODE_1_1260		0 /**< ILPS22QS mode 1 (1260 hPa) */
+#define ILPS22QS_DT_FS_MODE_2_4060		1 /**< ILPS22QS mode 2 (4060 hPa) */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LPS22DF_H_ */

--- a/include/zephyr/dt-bindings/sensor/lsm6dso.h
+++ b/include/zephyr/dt-bindings/sensor/lsm6dso.h
@@ -3,57 +3,115 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LSM6DSO IMU.
+ * @ingroup lsm6dso_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSO_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSO_H_
 
-/* Accel power-modes */
-#define LSM6DSO_DT_XL_HP_MODE			0
-#define LSM6DSO_DT_XL_LP_NORMAL_MODE		1
-#define LSM6DSO_DT_XL_ULP_MODE			2
+/**
+ * @defgroup lsm6dso_interface LSM6DSO
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LSM6DSO 6-axis IMU
+ * @{
+ */
 
-/* Gyro power-modes */
-#define LSM6DSO_DT_GY_HP_MODE			0
-#define LSM6DSO_DT_GY_NORMAL_MODE		1
+/**
+ * @name Accelerometer power modes
+ *
+ * Values for the `accel-pm` devicetree property.
+ * @{
+ */
+#define LSM6DSO_DT_XL_HP_MODE			0 /**< High-performance mode */
+#define LSM6DSO_DT_XL_LP_NORMAL_MODE		1 /**< Low-power / normal mode */
+#define LSM6DSO_DT_XL_ULP_MODE			2 /**< Ultra-low-power mode */
+/** @} */
 
-/* Accel range */
-#define LSM6DSO_DT_FS_2G			0
-#define LSM6DSO_DT_FS_16G			1
-#define LSM6DSO_DT_FS_4G			2
-#define LSM6DSO_DT_FS_8G			3
+/**
+ * @name Gyroscope power modes
+ *
+ * Values for the `gyro-pm` devicetree property.
+ * @{
+ */
+#define LSM6DSO_DT_GY_HP_MODE			0 /**< High-performance mode */
+#define LSM6DSO_DT_GY_NORMAL_MODE		1 /**< Normal mode */
+/** @} */
 
-/* Gyro range */
-#define LSM6DSO_DT_FS_250DPS			0
-#define LSM6DSO_DT_FS_125DPS			1
-#define LSM6DSO_DT_FS_500DPS			2
-#define LSM6DSO_DT_FS_1000DPS			4
-#define LSM6DSO_DT_FS_2000DPS			6
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `accel-range` devicetree property.
+ * @{
+ */
+#define LSM6DSO_DT_FS_2G			0 /**< ±2 g */
+#define LSM6DSO_DT_FS_16G			1 /**< ±16 g */
+#define LSM6DSO_DT_FS_4G			2 /**< ±4 g */
+#define LSM6DSO_DT_FS_8G			3 /**< ±8 g */
+/** @} */
 
-/* Accel and Gyro Data rates */
-#define LSM6DSO_DT_ODR_OFF			0x0
-#define LSM6DSO_DT_ODR_12Hz5			0x1
-#define LSM6DSO_DT_ODR_26H			0x2
-#define LSM6DSO_DT_ODR_52Hz			0x3
-#define LSM6DSO_DT_ODR_104Hz			0x4
-#define LSM6DSO_DT_ODR_208Hz			0x5
-#define LSM6DSO_DT_ODR_417Hz			0x6
-#define LSM6DSO_DT_ODR_833Hz			0x7
-#define LSM6DSO_DT_ODR_1667Hz			0x8
-#define LSM6DSO_DT_ODR_3333Hz			0x9
-#define LSM6DSO_DT_ODR_6667Hz			0xa
-#define LSM6DSO_DT_ODR_1Hz6			0xb
+/**
+ * @name Gyroscope full-scale range
+ *
+ * Values for the `gyro-range` devicetree property.
+ * @{
+ */
+#define LSM6DSO_DT_FS_250DPS			0 /**< ±250 dps */
+#define LSM6DSO_DT_FS_125DPS			1 /**< ±125 dps */
+#define LSM6DSO_DT_FS_500DPS			2 /**< ±500 dps */
+#define LSM6DSO_DT_FS_1000DPS			4 /**< ±1000 dps */
+#define LSM6DSO_DT_FS_2000DPS			6 /**< ±2000 dps */
+/** @} */
 
-/* Low pass filter dividers */
-#define LSM6DSO_DT_LP_ODR_DIV_2			0
-#define LSM6DSO_DT_LP_ODR_DIV_10		1
-#define LSM6DSO_DT_LP_ODR_DIV_20		2
-#define LSM6DSO_DT_LP_ODR_DIV_45		3
-#define LSM6DSO_DT_LP_ODR_DIV_100		4
-#define LSM6DSO_DT_LP_ODR_DIV_200		5
-#define LSM6DSO_DT_LP_ODR_DIV_400		6
-#define LSM6DSO_DT_LP_ODR_DIV_800		7
+/**
+ * @name Accelerometer and gyroscope output data rate
+ *
+ * Values for the `accel-odr` and `gyro-odr` devicetree properties.
+ * @{
+ */
+#define LSM6DSO_DT_ODR_OFF			0x0 /**< Power-down */
+#define LSM6DSO_DT_ODR_12Hz5			0x1 /**< 12.5 Hz */
+#define LSM6DSO_DT_ODR_26H			0x2 /**< 26 Hz */
+#define LSM6DSO_DT_ODR_52Hz			0x3 /**< 52 Hz */
+#define LSM6DSO_DT_ODR_104Hz			0x4 /**< 104 Hz */
+#define LSM6DSO_DT_ODR_208Hz			0x5 /**< 208 Hz */
+#define LSM6DSO_DT_ODR_417Hz			0x6 /**< 417 Hz */
+#define LSM6DSO_DT_ODR_833Hz			0x7 /**< 833 Hz */
+#define LSM6DSO_DT_ODR_1667Hz			0x8 /**< 1667 Hz */
+#define LSM6DSO_DT_ODR_3333Hz			0x9 /**< 3333 Hz */
+#define LSM6DSO_DT_ODR_6667Hz			0xa /**< 6667 Hz */
+#define LSM6DSO_DT_ODR_1Hz6			0xb /**< 1.6 Hz (low-power) */
+/** @} */
 
-/* Tap mode */
-#define LSM6DSO_DT_SINGLE_TAP			0
-#define LSM6DSO_DT_SINGLE_DOUBLE_TAP		1
+/**
+ * @name Low-pass filter divider options
+ *
+ * Values for the `accel-lp-filter` devicetree property.
+ * @{
+ */
+#define LSM6DSO_DT_LP_ODR_DIV_2			0 /**< ODR / 2 */
+#define LSM6DSO_DT_LP_ODR_DIV_10		1 /**< ODR / 10 */
+#define LSM6DSO_DT_LP_ODR_DIV_20		2 /**< ODR / 20 */
+#define LSM6DSO_DT_LP_ODR_DIV_45		3 /**< ODR / 45 */
+#define LSM6DSO_DT_LP_ODR_DIV_100		4 /**< ODR / 100 */
+#define LSM6DSO_DT_LP_ODR_DIV_200		5 /**< ODR / 200 */
+#define LSM6DSO_DT_LP_ODR_DIV_400		6 /**< ODR / 400 */
+#define LSM6DSO_DT_LP_ODR_DIV_800		7 /**< ODR / 800 */
+/** @} */
+
+/**
+ * @name Tap detection mode
+ *
+ * Values for the `tap-mode` devicetree property.
+ * @{
+ */
+#define LSM6DSO_DT_SINGLE_TAP			0 /**< Single-tap only */
+#define LSM6DSO_DT_SINGLE_DOUBLE_TAP		1 /**< Single and double tap */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSO_H_ */

--- a/include/zephyr/dt-bindings/sensor/lsm6dso16is.h
+++ b/include/zephyr/dt-bindings/sensor/lsm6dso16is.h
@@ -3,44 +3,80 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LSM6DSO16IS IMU.
+ * @ingroup lsm6dso16is_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSO16IS_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSO16IS_H_
 
-/* Accel range */
-#define	LSM6DSO16IS_DT_FS_2G			0
-#define	LSM6DSO16IS_DT_FS_16G			1
-#define	LSM6DSO16IS_DT_FS_4G			2
-#define	LSM6DSO16IS_DT_FS_8G			3
+/**
+ * @defgroup lsm6dso16is_interface LSM6DSO16IS
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LSM6DSO16IS 6-axis IMU
+ * @{
+ */
 
-/* Gyro range */
-#define	LSM6DSO16IS_DT_FS_250DPS		0x0
-#define	LSM6DSO16IS_DT_FS_500DPS		0x1
-#define	LSM6DSO16IS_DT_FS_1000DPS		0x2
-#define	LSM6DSO16IS_DT_FS_2000DPS		0x3
-#define	LSM6DSO16IS_DT_FS_125DPS		0x10
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `accel-range` devicetree property.
+ * @{
+ */
+#define	LSM6DSO16IS_DT_FS_2G			0 /**< ±2 g */
+#define	LSM6DSO16IS_DT_FS_16G			1 /**< ±16 g */
+#define	LSM6DSO16IS_DT_FS_4G			2 /**< ±4 g */
+#define	LSM6DSO16IS_DT_FS_8G			3 /**< ±8 g */
+/** @} */
 
-/* Accel and Gyro Data rates */
-#define LSM6DSO16IS_DT_ODR_OFF			0x0
-#define LSM6DSO16IS_DT_ODR_12Hz5_HP		0x1
-#define LSM6DSO16IS_DT_ODR_26H_HP		0x2
-#define LSM6DSO16IS_DT_ODR_52Hz_HP		0x3
-#define LSM6DSO16IS_DT_ODR_104Hz_HP		0x4
-#define LSM6DSO16IS_DT_ODR_208Hz_HP		0x5
-#define LSM6DSO16IS_DT_ODR_416Hz_HP		0x6
-#define LSM6DSO16IS_DT_ODR_833Hz_HP		0x7
-#define LSM6DSO16IS_DT_ODR_1667Hz_HP		0x8
-#define LSM6DSO16IS_DT_ODR_3333Hz_HP		0x9
-#define LSM6DSO16IS_DT_ODR_6667Hz_HP		0xa
-#define LSM6DSO16IS_DT_ODR_12Hz5_LP		0x11
-#define LSM6DSO16IS_DT_ODR_26H_LP		0x12
-#define LSM6DSO16IS_DT_ODR_52Hz_LP		0x13
-#define LSM6DSO16IS_DT_ODR_104Hz_LP		0x14
-#define LSM6DSO16IS_DT_ODR_208Hz_LP		0x15
-#define LSM6DSO16IS_DT_ODR_416Hz_LP		0x16
-#define LSM6DSO16IS_DT_ODR_833Hz_LP		0x17
-#define LSM6DSO16IS_DT_ODR_1667Hz_LP		0x18
-#define LSM6DSO16IS_DT_ODR_3333Hz_LP		0x19
-#define LSM6DSO16IS_DT_ODR_6667Hz_LP		0x1a
-#define LSM6DSO16IS_DT_ODR_1Hz6_LP		0x1b
+/**
+ * @name Gyroscope full-scale range
+ *
+ * Values for the `gyro-range` devicetree property.
+ * @{
+ */
+#define	LSM6DSO16IS_DT_FS_250DPS		0x0  /**< ±250 dps */
+#define	LSM6DSO16IS_DT_FS_500DPS		0x1  /**< ±500 dps */
+#define	LSM6DSO16IS_DT_FS_1000DPS		0x2  /**< ±1000 dps */
+#define	LSM6DSO16IS_DT_FS_2000DPS		0x3  /**< ±2000 dps */
+#define	LSM6DSO16IS_DT_FS_125DPS		0x10 /**< ±125 dps */
+/** @} */
+
+/**
+ * @name Accelerometer and gyroscope output data rate
+ *
+ * Values for the `accel-odr` and `gyro-odr` devicetree properties.
+ *
+ * HP: high-performance, LP: low-power mode.
+ * @{
+ */
+#define LSM6DSO16IS_DT_ODR_OFF			0x0  /**< Power-down */
+#define LSM6DSO16IS_DT_ODR_12Hz5_HP		0x1  /**< 12.5 Hz (HP) */
+#define LSM6DSO16IS_DT_ODR_26H_HP		0x2  /**< 26 Hz (HP) */
+#define LSM6DSO16IS_DT_ODR_52Hz_HP		0x3  /**< 52 Hz (HP) */
+#define LSM6DSO16IS_DT_ODR_104Hz_HP		0x4  /**< 104 Hz (HP) */
+#define LSM6DSO16IS_DT_ODR_208Hz_HP		0x5  /**< 208 Hz (HP) */
+#define LSM6DSO16IS_DT_ODR_416Hz_HP		0x6  /**< 416 Hz (HP) */
+#define LSM6DSO16IS_DT_ODR_833Hz_HP		0x7  /**< 833 Hz (HP) */
+#define LSM6DSO16IS_DT_ODR_1667Hz_HP		0x8  /**< 1667 Hz (HP) */
+#define LSM6DSO16IS_DT_ODR_3333Hz_HP		0x9  /**< 3333 Hz (HP) */
+#define LSM6DSO16IS_DT_ODR_6667Hz_HP		0xa  /**< 6667 Hz (HP) */
+#define LSM6DSO16IS_DT_ODR_12Hz5_LP		0x11 /**< 12.5 Hz (LP) */
+#define LSM6DSO16IS_DT_ODR_26H_LP		0x12 /**< 26 Hz (LP) */
+#define LSM6DSO16IS_DT_ODR_52Hz_LP		0x13 /**< 52 Hz (LP) */
+#define LSM6DSO16IS_DT_ODR_104Hz_LP		0x14 /**< 104 Hz (LP) */
+#define LSM6DSO16IS_DT_ODR_208Hz_LP		0x15 /**< 208 Hz (LP) */
+#define LSM6DSO16IS_DT_ODR_416Hz_LP		0x16 /**< 416 Hz (LP) */
+#define LSM6DSO16IS_DT_ODR_833Hz_LP		0x17 /**< 833 Hz (LP) */
+#define LSM6DSO16IS_DT_ODR_1667Hz_LP		0x18 /**< 1667 Hz (LP) */
+#define LSM6DSO16IS_DT_ODR_3333Hz_LP		0x19 /**< 3333 Hz (LP) */
+#define LSM6DSO16IS_DT_ODR_6667Hz_LP		0x1a /**< 6667 Hz (LP) */
+#define LSM6DSO16IS_DT_ODR_1Hz6_LP		0x1b /**< 1.6 Hz (LP) */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSO16IS_H_ */

--- a/include/zephyr/dt-bindings/sensor/lsm6dsv16x.h
+++ b/include/zephyr/dt-bindings/sensor/lsm6dsv16x.h
@@ -3,23 +3,54 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LSM6DSV16X IMU.
+ * @ingroup lsm6dsv16x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV16X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV16X_H_
 
 #include "lsm6dsvxxx.h"
 
-/* Accel range */
-#define LSM6DSV16X_DT_FS_2G			2
-#define LSM6DSV16X_DT_FS_4G			4
-#define LSM6DSV16X_DT_FS_8G			8
-#define LSM6DSV16X_DT_FS_16G			16
+/**
+ * @defgroup lsm6dsv16x_interface LSM6DSV16X
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LSM6DSV16X 6-axis IMU
+ *
+ * Output data rates and FIFO settings are shared across the family; see
+ * @ref lsm6dsvxxx_interface.
+ * @{
+ */
 
-/* Gyro range */
-#define LSM6DSV16X_DT_FS_125DPS			0x0
-#define LSM6DSV16X_DT_FS_250DPS			0x1
-#define LSM6DSV16X_DT_FS_500DPS			0x2
-#define LSM6DSV16X_DT_FS_1000DPS		0x3
-#define LSM6DSV16X_DT_FS_2000DPS		0x4
-#define LSM6DSV16X_DT_FS_4000DPS		0xc
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `accel-range` devicetree property.
+ * @{
+ */
+#define LSM6DSV16X_DT_FS_2G			2  /**< ±2 g */
+#define LSM6DSV16X_DT_FS_4G			4  /**< ±4 g */
+#define LSM6DSV16X_DT_FS_8G			8  /**< ±8 g */
+#define LSM6DSV16X_DT_FS_16G			16 /**< ±16 g */
+/** @} */
+
+/**
+ * @name Gyroscope full-scale range
+ *
+ * Values for the `gyro-range` devicetree property.
+ * @{
+ */
+#define LSM6DSV16X_DT_FS_125DPS			0x0 /**< ±125 dps */
+#define LSM6DSV16X_DT_FS_250DPS			0x1 /**< ±250 dps */
+#define LSM6DSV16X_DT_FS_500DPS			0x2 /**< ±500 dps */
+#define LSM6DSV16X_DT_FS_1000DPS		0x3 /**< ±1000 dps */
+#define LSM6DSV16X_DT_FS_2000DPS		0x4 /**< ±2000 dps */
+#define LSM6DSV16X_DT_FS_4000DPS		0xc /**< ±4000 dps */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV16X_H_ */

--- a/include/zephyr/dt-bindings/sensor/lsm6dsv320x.h
+++ b/include/zephyr/dt-bindings/sensor/lsm6dsv320x.h
@@ -3,35 +3,72 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LSM6DSV320X IMU.
+ * @ingroup lsm6dsv320x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV320X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV320X_H_
 
 #include "lsm6dsvxxx.h"
 
-/* Accel High-g odr */
-#define LSM6DSV320X_HG_XL_ODR_OFF		0x0
-#define LSM6DSV320X_HG_XL_ODR_AT_480Hz		0x3
-#define LSM6DSV320X_HG_XL_ODR_AT_960Hz		0x4
-#define LSM6DSV320X_HG_XL_ODR_AT_1920Hz		0x5
-#define LSM6DSV320X_HG_XL_ODR_AT_3840Hz		0x6
-#define LSM6DSV320X_HG_XL_ODR_AT_7680Hz		0x7
+/**
+ * @defgroup lsm6dsv320x_interface LSM6DSV320X
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LSM6DSV320X dual accelerometer and gyroscope IMU
+ *
+ * Output data rates and FIFO settings are shared across the family; see
+ * @ref lsm6dsvxxx_interface.
+ * @{
+ */
 
-/* Accel range */
-#define LSM6DSV320X_DT_FS_2G			2
-#define LSM6DSV320X_DT_FS_4G			4
-#define LSM6DSV320X_DT_FS_8G			8
-#define LSM6DSV320X_DT_FS_16G			16
-#define LSM6DSV320X_DT_FS_32G			32
-#define LSM6DSV320X_DT_FS_64G			64
-#define LSM6DSV320X_DT_FS_128G			128
-#define LSM6DSV320X_DT_FS_256G			256
-#define LSM6DSV320X_DT_FS_320G			320
+/**
+ * @name High-g accelerometer output data rate
+ *
+ * Values for the `accel-hg-odr` devicetree property.
+ * @{
+ */
+#define LSM6DSV320X_HG_XL_ODR_OFF		0x0 /**< Power-down */
+#define LSM6DSV320X_HG_XL_ODR_AT_480Hz		0x3 /**< 480 Hz */
+#define LSM6DSV320X_HG_XL_ODR_AT_960Hz		0x4 /**< 960 Hz */
+#define LSM6DSV320X_HG_XL_ODR_AT_1920Hz		0x5 /**< 1920 Hz */
+#define LSM6DSV320X_HG_XL_ODR_AT_3840Hz		0x6 /**< 3840 Hz */
+#define LSM6DSV320X_HG_XL_ODR_AT_7680Hz		0x7 /**< 7680 Hz */
+/** @} */
 
-/* Gyro range */
-#define LSM6DSV320X_DT_FS_250DPS		0x1
-#define LSM6DSV320X_DT_FS_500DPS		0x2
-#define LSM6DSV320X_DT_FS_1000DPS		0x3
-#define LSM6DSV320X_DT_FS_2000DPS		0x4
-#define LSM6DSV320X_DT_FS_4000DPS		0x5
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `accel-range` devicetree property.
+ * @{
+ */
+#define LSM6DSV320X_DT_FS_2G			2   /**< ±2 g */
+#define LSM6DSV320X_DT_FS_4G			4   /**< ±4 g */
+#define LSM6DSV320X_DT_FS_8G			8   /**< ±8 g */
+#define LSM6DSV320X_DT_FS_16G			16  /**< ±16 g */
+#define LSM6DSV320X_DT_FS_32G			32  /**< ±32 g */
+#define LSM6DSV320X_DT_FS_64G			64  /**< ±64 g */
+#define LSM6DSV320X_DT_FS_128G			128 /**< ±128 g */
+#define LSM6DSV320X_DT_FS_256G			256 /**< ±256 g */
+#define LSM6DSV320X_DT_FS_320G			320 /**< ±320 g */
+/** @} */
+
+/**
+ * @name Gyroscope full-scale range
+ *
+ * Values for the `gyro-range` devicetree property.
+ * @{
+ */
+#define LSM6DSV320X_DT_FS_250DPS		0x1 /**< ±250 dps */
+#define LSM6DSV320X_DT_FS_500DPS		0x2 /**< ±500 dps */
+#define LSM6DSV320X_DT_FS_1000DPS		0x3 /**< ±1000 dps */
+#define LSM6DSV320X_DT_FS_2000DPS		0x4 /**< ±2000 dps */
+#define LSM6DSV320X_DT_FS_4000DPS		0x5 /**< ±4000 dps */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV320X_H_ */

--- a/include/zephyr/dt-bindings/sensor/lsm6dsv32x.h
+++ b/include/zephyr/dt-bindings/sensor/lsm6dsv32x.h
@@ -3,23 +3,54 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LSM6DSV32X IMU.
+ * @ingroup lsm6dsv32x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV32X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV32X_H_
 
 #include "lsm6dsvxxx.h"
 
-/* Accel range */
-#define LSM6DSV32X_DT_FS_4G                     4
-#define LSM6DSV32X_DT_FS_8G                     8
-#define LSM6DSV32X_DT_FS_16G                    16
-#define LSM6DSV32X_DT_FS_32G                    32
+/**
+ * @defgroup lsm6dsv32x_interface LSM6DSV32X
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LSM6DSV32X 6-axis IMU
+ *
+ * Output data rates and FIFO settings are shared across the family; see
+ * @ref lsm6dsvxxx_interface.
+ * @{
+ */
 
-/* Gyro range */
-#define LSM6DSV32X_DT_FS_125DPS			0x0
-#define LSM6DSV32X_DT_FS_250DPS			0x1
-#define LSM6DSV32X_DT_FS_500DPS			0x2
-#define LSM6DSV32X_DT_FS_1000DPS		0x3
-#define LSM6DSV32X_DT_FS_2000DPS		0x4
-#define LSM6DSV32X_DT_FS_4000DPS		0xc
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `accel-range` devicetree property.
+ * @{
+ */
+#define LSM6DSV32X_DT_FS_4G                     4  /**< ±4 g */
+#define LSM6DSV32X_DT_FS_8G                     8  /**< ±8 g */
+#define LSM6DSV32X_DT_FS_16G                    16 /**< ±16 g */
+#define LSM6DSV32X_DT_FS_32G                    32 /**< ±32 g */
+/** @} */
+
+/**
+ * @name Gyroscope full-scale range
+ *
+ * Values for the `gyro-range` devicetree property.
+ * @{
+ */
+#define LSM6DSV32X_DT_FS_125DPS			0x0 /**< ±125 dps */
+#define LSM6DSV32X_DT_FS_250DPS			0x1 /**< ±250 dps */
+#define LSM6DSV32X_DT_FS_500DPS			0x2 /**< ±500 dps */
+#define LSM6DSV32X_DT_FS_1000DPS		0x3 /**< ±1000 dps */
+#define LSM6DSV32X_DT_FS_2000DPS		0x4 /**< ±2000 dps */
+#define LSM6DSV32X_DT_FS_4000DPS		0xc /**< ±4000 dps */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV32X_H_ */

--- a/include/zephyr/dt-bindings/sensor/lsm6dsv80x.h
+++ b/include/zephyr/dt-bindings/sensor/lsm6dsv80x.h
@@ -3,33 +3,70 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LSM6DSV80X IMU.
+ * @ingroup lsm6dsv80x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV80X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV80X_H_
 
 #include "lsm6dsvxxx.h"
 
-/* Accel High-g odr */
-#define LSM6DSV80X_HG_XL_ODR_OFF		0x0
-#define LSM6DSV80X_HG_XL_ODR_AT_480Hz		0x3
-#define LSM6DSV80X_HG_XL_ODR_AT_960Hz		0x4
-#define LSM6DSV80X_HG_XL_ODR_AT_1920Hz		0x5
-#define LSM6DSV80X_HG_XL_ODR_AT_3840Hz		0x6
-#define LSM6DSV80X_HG_XL_ODR_AT_7680Hz		0x7
+/**
+ * @defgroup lsm6dsv80x_interface LSM6DSV80X
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LSM6DSV80X dual accelerometer and gyroscope IMU
+ *
+ * Output data rates and FIFO settings are shared across the family; see
+ * @ref lsm6dsvxxx_interface.
+ * @{
+ */
 
-/* Accel range */
-#define LSM6DSV80X_DT_FS_2G			2
-#define LSM6DSV80X_DT_FS_4G			4
-#define LSM6DSV80X_DT_FS_8G			8
-#define LSM6DSV80X_DT_FS_16G			16
-#define LSM6DSV80X_DT_FS_32G			32
-#define LSM6DSV80X_DT_FS_64G			64
-#define LSM6DSV80X_DT_FS_80G			80
+/**
+ * @name High-g accelerometer output data rate
+ *
+ * Values for the `accel-hg-odr` devicetree property.
+ * @{
+ */
+#define LSM6DSV80X_HG_XL_ODR_OFF		0x0 /**< Power-down */
+#define LSM6DSV80X_HG_XL_ODR_AT_480Hz		0x3 /**< 480 Hz */
+#define LSM6DSV80X_HG_XL_ODR_AT_960Hz		0x4 /**< 960 Hz */
+#define LSM6DSV80X_HG_XL_ODR_AT_1920Hz		0x5 /**< 1920 Hz */
+#define LSM6DSV80X_HG_XL_ODR_AT_3840Hz		0x6 /**< 3840 Hz */
+#define LSM6DSV80X_HG_XL_ODR_AT_7680Hz		0x7 /**< 7680 Hz */
+/** @} */
 
-/* Gyro range */
-#define LSM6DSV80X_DT_FS_250DPS			0x1
-#define LSM6DSV80X_DT_FS_500DPS			0x2
-#define LSM6DSV80X_DT_FS_1000DPS		0x3
-#define LSM6DSV80X_DT_FS_2000DPS		0x4
-#define LSM6DSV80X_DT_FS_4000DPS		0x5
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `accel-range` devicetree property.
+ * @{
+ */
+#define LSM6DSV80X_DT_FS_2G			2  /**< ±2 g */
+#define LSM6DSV80X_DT_FS_4G			4  /**< ±4 g */
+#define LSM6DSV80X_DT_FS_8G			8  /**< ±8 g */
+#define LSM6DSV80X_DT_FS_16G			16 /**< ±16 g */
+#define LSM6DSV80X_DT_FS_32G			32 /**< ±32 g */
+#define LSM6DSV80X_DT_FS_64G			64 /**< ±64 g */
+#define LSM6DSV80X_DT_FS_80G			80 /**< ±80 g */
+/** @} */
+
+/**
+ * @name Gyroscope full-scale range
+ *
+ * Values for the `gyro-range` devicetree property.
+ * @{
+ */
+#define LSM6DSV80X_DT_FS_250DPS			0x1 /**< ±250 dps */
+#define LSM6DSV80X_DT_FS_500DPS			0x2 /**< ±500 dps */
+#define LSM6DSV80X_DT_FS_1000DPS		0x3 /**< ±1000 dps */
+#define LSM6DSV80X_DT_FS_2000DPS		0x4 /**< ±2000 dps */
+#define LSM6DSV80X_DT_FS_4000DPS		0x5 /**< ±4000 dps */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSV80X_H_ */

--- a/include/zephyr/dt-bindings/sensor/lsm6dsvxxx.h
+++ b/include/zephyr/dt-bindings/sensor/lsm6dsvxxx.h
@@ -3,187 +3,215 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants shared by the ST LSM6DSVxxx 6-axis IMUs.
+ * @ingroup lsm6dsvxxx_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSVXXX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM6DSVXXX_H_
 
 /**
- * @name STMicroelectronics LSM6DSVXXX sensor DT Options
- * @ingroup sensor_interface
+ * @addtogroup lsm6dsvxxx_interface
  * @{
  */
 
 /**
- * @name Accel and Gyro Data rates
+ * @name Accelerometer and gyroscope data rates
+ *
+ * Values for the `accel-odr` and `gyro-odr` devicetree properties.
+ *
+ * HA01 and HA02 select the first and second high-accuracy ODR sets, respectively.
  * @{
  */
-#define LSM6DSVXXX_DT_ODR_OFF			0x0
-#define LSM6DSVXXX_DT_ODR_AT_1Hz875		0x1
-#define LSM6DSVXXX_DT_ODR_AT_7Hz5		0x2
-#define LSM6DSVXXX_DT_ODR_AT_15Hz		0x3
-#define LSM6DSVXXX_DT_ODR_AT_30Hz		0x4
-#define LSM6DSVXXX_DT_ODR_AT_60Hz		0x5
-#define LSM6DSVXXX_DT_ODR_AT_120Hz		0x6
-#define LSM6DSVXXX_DT_ODR_AT_240Hz		0x7
-#define LSM6DSVXXX_DT_ODR_AT_480Hz		0x8
-#define LSM6DSVXXX_DT_ODR_AT_960Hz		0x9
-#define LSM6DSVXXX_DT_ODR_AT_1920Hz		0xA
-#define LSM6DSVXXX_DT_ODR_AT_3840Hz		0xB
-#define LSM6DSVXXX_DT_ODR_AT_7680Hz		0xC
-#define LSM6DSVXXX_DT_ODR_HA01_AT_15Hz625	0x13
-#define LSM6DSVXXX_DT_ODR_HA01_AT_31Hz25	0x14
-#define LSM6DSVXXX_DT_ODR_HA01_AT_62Hz5		0x15
-#define LSM6DSVXXX_DT_ODR_HA01_AT_125Hz		0x16
-#define LSM6DSVXXX_DT_ODR_HA01_AT_250Hz		0x17
-#define LSM6DSVXXX_DT_ODR_HA01_AT_500Hz		0x18
-#define LSM6DSVXXX_DT_ODR_HA01_AT_1000Hz	0x19
-#define LSM6DSVXXX_DT_ODR_HA01_AT_2000Hz	0x1A
-#define LSM6DSVXXX_DT_ODR_HA01_AT_4000Hz	0x1B
-#define LSM6DSVXXX_DT_ODR_HA01_AT_8000Hz	0x1C
-#define LSM6DSVXXX_DT_ODR_HA02_AT_12Hz5		0x23
-#define LSM6DSVXXX_DT_ODR_HA02_AT_25Hz		0x24
-#define LSM6DSVXXX_DT_ODR_HA02_AT_50Hz		0x25
-#define LSM6DSVXXX_DT_ODR_HA02_AT_100Hz		0x26
-#define LSM6DSVXXX_DT_ODR_HA02_AT_200Hz		0x27
-#define LSM6DSVXXX_DT_ODR_HA02_AT_400Hz		0x28
-#define LSM6DSVXXX_DT_ODR_HA02_AT_800Hz		0x29
-#define LSM6DSVXXX_DT_ODR_HA02_AT_1600Hz	0x2A
-#define LSM6DSVXXX_DT_ODR_HA02_AT_3200Hz	0x2B
-#define LSM6DSVXXX_DT_ODR_HA02_AT_6400Hz	0x2C
+#define LSM6DSVXXX_DT_ODR_OFF			0x0  /**< Powered down */
+#define LSM6DSVXXX_DT_ODR_AT_1Hz875		0x1  /**< 1.875 Hz */
+#define LSM6DSVXXX_DT_ODR_AT_7Hz5		0x2  /**< 7.5 Hz */
+#define LSM6DSVXXX_DT_ODR_AT_15Hz		0x3  /**< 15 Hz */
+#define LSM6DSVXXX_DT_ODR_AT_30Hz		0x4  /**< 30 Hz */
+#define LSM6DSVXXX_DT_ODR_AT_60Hz		0x5  /**< 60 Hz */
+#define LSM6DSVXXX_DT_ODR_AT_120Hz		0x6  /**< 120 Hz */
+#define LSM6DSVXXX_DT_ODR_AT_240Hz		0x7  /**< 240 Hz */
+#define LSM6DSVXXX_DT_ODR_AT_480Hz		0x8  /**< 480 Hz */
+#define LSM6DSVXXX_DT_ODR_AT_960Hz		0x9  /**< 960 Hz */
+#define LSM6DSVXXX_DT_ODR_AT_1920Hz		0xA  /**< 1920 Hz */
+#define LSM6DSVXXX_DT_ODR_AT_3840Hz		0xB  /**< 3840 Hz */
+#define LSM6DSVXXX_DT_ODR_AT_7680Hz		0xC  /**< 7680 Hz */
+#define LSM6DSVXXX_DT_ODR_HA01_AT_15Hz625	0x13 /**< High-accuracy 1, 15.625 Hz */
+#define LSM6DSVXXX_DT_ODR_HA01_AT_31Hz25	0x14 /**< High-accuracy 1, 31.25 Hz */
+#define LSM6DSVXXX_DT_ODR_HA01_AT_62Hz5		0x15 /**< High-accuracy 1, 62.5 Hz */
+#define LSM6DSVXXX_DT_ODR_HA01_AT_125Hz		0x16 /**< High-accuracy 1, 125 Hz */
+#define LSM6DSVXXX_DT_ODR_HA01_AT_250Hz		0x17 /**< High-accuracy 1, 250 Hz */
+#define LSM6DSVXXX_DT_ODR_HA01_AT_500Hz		0x18 /**< High-accuracy 1, 500 Hz */
+#define LSM6DSVXXX_DT_ODR_HA01_AT_1000Hz	0x19 /**< High-accuracy 1, 1000 Hz */
+#define LSM6DSVXXX_DT_ODR_HA01_AT_2000Hz	0x1A /**< High-accuracy 1, 2000 Hz */
+#define LSM6DSVXXX_DT_ODR_HA01_AT_4000Hz	0x1B /**< High-accuracy 1, 4000 Hz */
+#define LSM6DSVXXX_DT_ODR_HA01_AT_8000Hz	0x1C /**< High-accuracy 1, 8000 Hz */
+#define LSM6DSVXXX_DT_ODR_HA02_AT_12Hz5		0x23 /**< High-accuracy 2, 12.5 Hz */
+#define LSM6DSVXXX_DT_ODR_HA02_AT_25Hz		0x24 /**< High-accuracy 2, 25 Hz */
+#define LSM6DSVXXX_DT_ODR_HA02_AT_50Hz		0x25 /**< High-accuracy 2, 50 Hz */
+#define LSM6DSVXXX_DT_ODR_HA02_AT_100Hz		0x26 /**< High-accuracy 2, 100 Hz */
+#define LSM6DSVXXX_DT_ODR_HA02_AT_200Hz		0x27 /**< High-accuracy 2, 200 Hz */
+#define LSM6DSVXXX_DT_ODR_HA02_AT_400Hz		0x28 /**< High-accuracy 2, 400 Hz */
+#define LSM6DSVXXX_DT_ODR_HA02_AT_800Hz		0x29 /**< High-accuracy 2, 800 Hz */
+#define LSM6DSVXXX_DT_ODR_HA02_AT_1600Hz	0x2A /**< High-accuracy 2, 1600 Hz */
+#define LSM6DSVXXX_DT_ODR_HA02_AT_3200Hz	0x2B /**< High-accuracy 2, 3200 Hz */
+#define LSM6DSVXXX_DT_ODR_HA02_AT_6400Hz	0x2C /**< High-accuracy 2, 6400 Hz */
 /** @} */
 
 /**
- * @name Accelerometer batching rates
+ * @name Accelerometer FIFO batching rates
+ *
+ * Values for the `accel-fifo-batch-rate` devicetree property.
  * @{
  */
-#define LSM6DSVXXX_DT_XL_NOT_BATCHED		0x0
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_1Hz875	0x1
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_7Hz5	0x2
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_15Hz	0x3
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_30Hz	0x4
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_60Hz	0x5
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_120Hz	0x6
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_240Hz	0x7
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_480Hz	0x8
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_960Hz	0x9
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_1920Hz	0xa
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_3840Hz	0xb
-#define LSM6DSVXXX_DT_XL_BATCHED_AT_7680Hz	0xc
+#define LSM6DSVXXX_DT_XL_NOT_BATCHED		0x0 /**< Not batched */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_1Hz875	0x1 /**< 1.875 Hz */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_7Hz5	0x2 /**< 7.5 Hz */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_15Hz	0x3 /**< 15 Hz */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_30Hz	0x4 /**< 30 Hz */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_60Hz	0x5 /**< 60 Hz */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_120Hz	0x6 /**< 120 Hz */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_240Hz	0x7 /**< 240 Hz */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_480Hz	0x8 /**< 480 Hz */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_960Hz	0x9 /**< 960 Hz */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_1920Hz	0xa /**< 1920 Hz */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_3840Hz	0xb /**< 3840 Hz */
+#define LSM6DSVXXX_DT_XL_BATCHED_AT_7680Hz	0xc /**< 7680 Hz */
 /** @} */
 
 /**
- * @name Gyroscope batching rates
+ * @name Gyroscope FIFO batching rates
+ *
+ * Values for the `gyro-fifo-batch-rate` devicetree property.
  * @{
  */
-#define LSM6DSVXXX_DT_GY_NOT_BATCHED		0x0
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_1Hz875	0x1
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_7Hz5	0x2
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_15Hz	0x3
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_30Hz	0x4
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_60Hz	0x5
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_120Hz	0x6
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_240Hz	0x7
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_480Hz	0x8
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_960Hz	0x9
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_1920Hz	0xa
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_3840Hz	0xb
-#define LSM6DSVXXX_DT_GY_BATCHED_AT_7680Hz	0xc
+#define LSM6DSVXXX_DT_GY_NOT_BATCHED		0x0 /**< Not batched */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_1Hz875	0x1 /**< 1.875 Hz */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_7Hz5	0x2 /**< 7.5 Hz */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_15Hz	0x3 /**< 15 Hz */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_30Hz	0x4 /**< 30 Hz */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_60Hz	0x5 /**< 60 Hz */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_120Hz	0x6 /**< 120 Hz */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_240Hz	0x7 /**< 240 Hz */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_480Hz	0x8 /**< 480 Hz */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_960Hz	0x9 /**< 960 Hz */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_1920Hz	0xa /**< 1920 Hz */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_3840Hz	0xb /**< 3840 Hz */
+#define LSM6DSVXXX_DT_GY_BATCHED_AT_7680Hz	0xc /**< 7680 Hz */
 /** @} */
 
 /**
- * @name Temperature sensor batching rates
+ * @name Temperature FIFO batching rates
+ *
+ * Values for the `temp-fifo-batch-rate` devicetree property.
  * @{
  */
-#define LSM6DSVXXX_DT_TEMP_NOT_BATCHED		0x0
-#define LSM6DSVXXX_DT_TEMP_BATCHED_AT_1Hz875	0x1
-#define LSM6DSVXXX_DT_TEMP_BATCHED_AT_15Hz	0x2
-#define LSM6DSVXXX_DT_TEMP_BATCHED_AT_60Hz	0x3
+#define LSM6DSVXXX_DT_TEMP_NOT_BATCHED		0x0 /**< Not batched */
+#define LSM6DSVXXX_DT_TEMP_BATCHED_AT_1Hz875	0x1 /**< 1.875 Hz */
+#define LSM6DSVXXX_DT_TEMP_BATCHED_AT_15Hz	0x2 /**< 15 Hz */
+#define LSM6DSVXXX_DT_TEMP_BATCHED_AT_60Hz	0x3 /**< 60 Hz */
 /** @} */
 
 /**
- * @name Sensor Fusion Low Power Data rates
+ * @name Sensor-fusion low-power data rates
+ *
+ * Values for the `sflp-odr` devicetree property.
  * @{
  */
-#define LSM6DSVXXX_DT_SFLP_ODR_AT_15Hz		0x0
-#define LSM6DSVXXX_DT_SFLP_ODR_AT_30Hz		0x1
-#define LSM6DSVXXX_DT_SFLP_ODR_AT_60Hz		0x2
-#define LSM6DSVXXX_DT_SFLP_ODR_AT_120Hz		0x3
-#define LSM6DSVXXX_DT_SFLP_ODR_AT_240Hz		0x4
-#define LSM6DSVXXX_DT_SFLP_ODR_AT_480Hz		0x5
+#define LSM6DSVXXX_DT_SFLP_ODR_AT_15Hz		0x0 /**< 15 Hz */
+#define LSM6DSVXXX_DT_SFLP_ODR_AT_30Hz		0x1 /**< 30 Hz */
+#define LSM6DSVXXX_DT_SFLP_ODR_AT_60Hz		0x2 /**< 60 Hz */
+#define LSM6DSVXXX_DT_SFLP_ODR_AT_120Hz		0x3 /**< 120 Hz */
+#define LSM6DSVXXX_DT_SFLP_ODR_AT_240Hz		0x4 /**< 240 Hz */
+#define LSM6DSVXXX_DT_SFLP_ODR_AT_480Hz		0x5 /**< 480 Hz */
 /** @} */
 
 /**
- * @name Sensor Fusion Low Power FIFO enable defs
+ * @name Sensor-fusion low-power FIFO outputs
+ *
+ * Values for the `sflp-fifo-enable` devicetree property.
  * @{
  */
-#define LSM6DSVXXX_DT_SFLP_FIFO_OFF				0x0
-#define LSM6DSVXXX_DT_SFLP_FIFO_GAME_ROTATION			0x1
-#define LSM6DSVXXX_DT_SFLP_FIFO_GRAVITY				0x2
-#define LSM6DSVXXX_DT_SFLP_FIFO_GAME_ROTATION_GRAVITY		0x3
-#define LSM6DSVXXX_DT_SFLP_FIFO_GBIAS				0x4
-#define LSM6DSVXXX_DT_SFLP_FIFO_GAME_ROTATION_GBIAS		0x5
-#define LSM6DSVXXX_DT_SFLP_FIFO_GRAVITY_GBIAS			0x6
-#define LSM6DSVXXX_DT_SFLP_FIFO_GAME_ROTATION_GRAVITY_GBIAS	0x7
+#define LSM6DSVXXX_DT_SFLP_FIFO_OFF				0x0 /**< No SFLP output */
+#define LSM6DSVXXX_DT_SFLP_FIFO_GAME_ROTATION			0x1 /**< Game-rotation vector */
+#define LSM6DSVXXX_DT_SFLP_FIFO_GRAVITY				0x2 /**< Gravity vector */
+#define LSM6DSVXXX_DT_SFLP_FIFO_GAME_ROTATION_GRAVITY		0x3 /**< Rotation and gravity */
+#define LSM6DSVXXX_DT_SFLP_FIFO_GBIAS				0x4 /**< Gyroscope bias */
+#define LSM6DSVXXX_DT_SFLP_FIFO_GAME_ROTATION_GBIAS		0x5 /**< Rotation and gyro bias */
+#define LSM6DSVXXX_DT_SFLP_FIFO_GRAVITY_GBIAS			0x6 /**< Gravity and gyro bias */
+#define LSM6DSVXXX_DT_SFLP_FIFO_GAME_ROTATION_GRAVITY_GBIAS	0x7 /**< Rotation, gravity, bias */
 /** @} */
 
 /**
- * @name FIFO tags
+ * @name FIFO record tags
+ *
+ * FIFO record tag values reported in the FIFO data stream.
  * @{
  */
-#define LSM6DSVXXX_FIFO_EMPTY                    0x0
-#define LSM6DSVXXX_GY_NC_TAG                     0x1
-#define LSM6DSVXXX_XL_NC_TAG                     0x2
-#define LSM6DSVXXX_TEMPERATURE_TAG               0x3
-#define LSM6DSVXXX_TIMESTAMP_TAG                 0x4
-#define LSM6DSVXXX_CFG_CHANGE_TAG                0x5
-#define LSM6DSVXXX_XL_NC_T_2_TAG                 0x6
-#define LSM6DSVXXX_XL_NC_T_1_TAG                 0x7
-#define LSM6DSVXXX_XL_2XC_TAG                    0x8
-#define LSM6DSVXXX_XL_3XC_TAG                    0x9
-#define LSM6DSVXXX_GY_NC_T_2_TAG                 0xA
-#define LSM6DSVXXX_GY_NC_T_1_TAG                 0xB
-#define LSM6DSVXXX_GY_2XC_TAG                    0xC
-#define LSM6DSVXXX_GY_3XC_TAG                    0xD
-#define LSM6DSVXXX_SENSORHUB_TARGET0_TAG         0xE
-#define LSM6DSVXXX_SENSORHUB_TARGET1_TAG         0xF
-#define LSM6DSVXXX_SENSORHUB_TARGET2_TAG         0x10
-#define LSM6DSVXXX_SENSORHUB_TARGET3_TAG         0x11
-#define LSM6DSVXXX_STEP_COUNTER_TAG              0x12
-#define LSM6DSVXXX_SFLP_GAME_ROTATION_VECTOR_TAG 0x13
-#define LSM6DSVXXX_SFLP_GYROSCOPE_BIAS_TAG       0x16
-#define LSM6DSVXXX_SFLP_GRAVITY_VECTOR_TAG       0x17
-#define LSM6DSVXXX_HG_XL_PEAK_TAG                0x18
-#define LSM6DSVXXX_SENSORHUB_NACK_TAG            0x19
-#define LSM6DSVXXX_MLC_RESULT_TAG                0x1A
-#define LSM6DSVXXX_MLC_FILTER                    0x1B
-#define LSM6DSVXXX_MLC_FEATURE                   0x1C
-#define LSM6DSVXXX_XL_HG_TAG                     0x1D
-#define LSM6DSVXXX_GY_ENHANCED_EIS               0x1E
+#define LSM6DSVXXX_FIFO_EMPTY                    0x0  /**< FIFO empty */
+#define LSM6DSVXXX_GY_NC_TAG                     0x1  /**< Gyroscope, not compressed */
+#define LSM6DSVXXX_XL_NC_TAG                     0x2  /**< Accelerometer, not compressed */
+#define LSM6DSVXXX_TEMPERATURE_TAG               0x3  /**< Temperature */
+#define LSM6DSVXXX_TIMESTAMP_TAG                 0x4  /**< Timestamp */
+#define LSM6DSVXXX_CFG_CHANGE_TAG                0x5  /**< Configuration change */
+#define LSM6DSVXXX_XL_NC_T_2_TAG                 0x6  /**< Accelerometer, T-2 sample */
+#define LSM6DSVXXX_XL_NC_T_1_TAG                 0x7  /**< Accelerometer, T-1 sample */
+#define LSM6DSVXXX_XL_2XC_TAG                    0x8  /**< Accelerometer, 2x compressed */
+#define LSM6DSVXXX_XL_3XC_TAG                    0x9  /**< Accelerometer, 3x compressed */
+#define LSM6DSVXXX_GY_NC_T_2_TAG                 0xA  /**< Gyroscope, T-2 sample */
+#define LSM6DSVXXX_GY_NC_T_1_TAG                 0xB  /**< Gyroscope, T-1 sample */
+#define LSM6DSVXXX_GY_2XC_TAG                    0xC  /**< Gyroscope, 2x compressed */
+#define LSM6DSVXXX_GY_3XC_TAG                    0xD  /**< Gyroscope, 3x compressed */
+#define LSM6DSVXXX_SENSORHUB_TARGET0_TAG         0xE  /**< Sensor-hub target 0 */
+#define LSM6DSVXXX_SENSORHUB_TARGET1_TAG         0xF  /**< Sensor-hub target 1 */
+#define LSM6DSVXXX_SENSORHUB_TARGET2_TAG         0x10 /**< Sensor-hub target 2 */
+#define LSM6DSVXXX_SENSORHUB_TARGET3_TAG         0x11 /**< Sensor-hub target 3 */
+#define LSM6DSVXXX_STEP_COUNTER_TAG              0x12 /**< Step counter */
+#define LSM6DSVXXX_SFLP_GAME_ROTATION_VECTOR_TAG 0x13 /**< SFLP game-rotation vector */
+#define LSM6DSVXXX_SFLP_GYROSCOPE_BIAS_TAG       0x16 /**< SFLP gyroscope bias */
+#define LSM6DSVXXX_SFLP_GRAVITY_VECTOR_TAG       0x17 /**< SFLP gravity vector */
+#define LSM6DSVXXX_HG_XL_PEAK_TAG                0x18 /**< High-g accelerometer peak */
+#define LSM6DSVXXX_SENSORHUB_NACK_TAG            0x19 /**< Sensor-hub NACK */
+#define LSM6DSVXXX_MLC_RESULT_TAG                0x1A /**< Machine-learning core result */
+#define LSM6DSVXXX_MLC_FILTER                    0x1B /**< Machine-learning core filter */
+#define LSM6DSVXXX_MLC_FEATURE                   0x1C /**< Machine-learning core feature */
+#define LSM6DSVXXX_XL_HG_TAG                     0x1D /**< High-g accelerometer */
+#define LSM6DSVXXX_GY_ENHANCED_EIS               0x1E /**< Gyroscope enhanced EIS */
 /** @} */
 
 /**
- * @name status registers
+ * @name Status and output register addresses
+ *
+ * Status and output register addresses used by the driver.
  * @{
  */
-#define LSM6DSVXXX_STATUS_REG			0x1EU
-#define LSM6DSVXXX_OUTX_L_A			0x28U
-#define LSM6DSVXXX_FIFO_STATUS1			0x1BU
-#define LSM6DSVXXX_FIFO_DATA_OUT_TAG		0x78U
+#define LSM6DSVXXX_STATUS_REG			0x1EU /**< STATUS_REG register */
+#define LSM6DSVXXX_OUTX_L_A			0x28U /**< OUTX_L_A accelerometer output */
+#define LSM6DSVXXX_FIFO_STATUS1			0x1BU /**< FIFO_STATUS1 register */
+#define LSM6DSVXXX_FIFO_DATA_OUT_TAG		0x78U /**< FIFO_DATA_OUT_TAG register */
 /** @} */
 
 /**
- * @name FIFO settings
+ * @name FIFO control register addresses and modes
+ *
+ * FIFO control register addresses and mode values used by the driver.
  * @{
  */
-#define LSM6DSVXXX_BYPASS_MODE			0x00U
-#define LSM6DSVXXX_FIFO_CTRL4			0x0AU
+#define LSM6DSVXXX_BYPASS_MODE			0x00U /**< FIFO bypass (disabled) mode */
+#define LSM6DSVXXX_FIFO_CTRL4			0x0AU /**< FIFO_CTRL4 register */
 /** @} */
 
 /**
  * @name GPIO interrupt configuration
+ *
+ * Values for the `int-gpio-config` devicetree property.
  * @{
  */
-#define LSM6DSVXXX_DT_GPIO_INT_EDGE_TO_ACTIVE	0 /*!< Edge-triggered interrupt */
-#define LSM6DSVXXX_DT_GPIO_INT_LEVEL_ACTIVE	1 /*!< Level-triggered interrupt */
+#define LSM6DSVXXX_DT_GPIO_INT_EDGE_TO_ACTIVE	0 /**< Edge-triggered interrupt */
+#define LSM6DSVXXX_DT_GPIO_INT_LEVEL_ACTIVE	1 /**< Level-triggered interrupt */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/lsm9ds1.h
+++ b/include/zephyr/dt-bindings/sensor/lsm9ds1.h
@@ -4,89 +4,142 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST LSM9DS1 IMU and magnetometer.
+ * @ingroup lsm9ds1_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM9DS1_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM9DS1_H_
 
-/* Accel range */
-#define LSM9DS1_DT_FS_2G  0
-#define LSM9DS1_DT_FS_16G 1
-#define LSM9DS1_DT_FS_4G  2
-#define LSM9DS1_DT_FS_8G  3
+/**
+ * @defgroup lsm9ds1_interface LSM9DS1
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics LSM9DS1 9-axis IMU (accel, gyro, magnetometer)
+ * @{
+ */
 
-#define LSM9DS1_DT_FS_245DPS  0
-#define LSM9DS1_DT_FS_500DPS  1
-#define LSM9DS1_DT_FS_2000DPS 3
+/**
+ * @name Accelerometer full-scale range
+ *
+ * Values for the `accel-range` devicetree property.
+ * @{
+ */
+#define LSM9DS1_DT_FS_2G  0 /**< ±2 g */
+#define LSM9DS1_DT_FS_16G 1 /**< ±16 g */
+#define LSM9DS1_DT_FS_4G  2 /**< ±4 g */
+#define LSM9DS1_DT_FS_8G  3 /**< ±8 g */
+/** @} */
 
-#define LSM9DS1_IMU_OFF            0x00
-#define LSM9DS1_GY_OFF_XL_10Hz     0x10
-#define LSM9DS1_GY_OFF_XL_50Hz     0x20
-#define LSM9DS1_GY_OFF_XL_119Hz    0x30
-#define LSM9DS1_GY_OFF_XL_238Hz    0x40
-#define LSM9DS1_GY_OFF_XL_476Hz    0x50
-#define LSM9DS1_GY_OFF_XL_952Hz    0x60
-#define LSM9DS1_XL_OFF_GY_14Hz9    0x01
-#define LSM9DS1_XL_OFF_GY_59Hz5    0x02
-#define LSM9DS1_XL_OFF_GY_119Hz    0x03
-#define LSM9DS1_XL_OFF_GY_238Hz    0x04
-#define LSM9DS1_XL_OFF_GY_476Hz    0x05
-#define LSM9DS1_XL_OFF_GY_952Hz    0x06
-#define LSM9DS1_IMU_14Hz9          0x11
-#define LSM9DS1_IMU_59Hz5          0x22
-#define LSM9DS1_IMU_119Hz          0x33
-#define LSM9DS1_IMU_238Hz          0x44
-#define LSM9DS1_IMU_476Hz          0x55
-#define LSM9DS1_IMU_952Hz          0x66
-#define LSM9DS1_XL_OFF_GY_14Hz9_LP 0x81
-#define LSM9DS1_XL_OFF_GY_59Hz5_LP 0x82
-#define LSM9DS1_XL_OFF_GY_119Hz_LP 0x83
-#define LSM9DS1_IMU_14Hz9_LP       0x91
-#define LSM9DS1_IMU_59Hz5_LP       0xA2
-#define LSM9DS1_IMU_119Hz_LP       0xB3
+/**
+ * @name Gyroscope full-scale range
+ *
+ * Values for the `gyro-range` devicetree property.
+ * @{
+ */
+#define LSM9DS1_DT_FS_245DPS  0 /**< ±245 dps */
+#define LSM9DS1_DT_FS_500DPS  1 /**< ±500 dps */
+#define LSM9DS1_DT_FS_2000DPS 3 /**< ±2000 dps */
+/** @} */
 
-/* magnetometer */
+/**
+ * @name Accelerometer and gyroscope output data rate
+ *
+ * Values for the `imu-odr` devicetree property.
+ *
+ * Each value selects an accelerometer (XL) and gyroscope (GY) rate
+ * combination. The _LP suffix selects the gyroscope low-power mode.
+ * @{
+ */
+#define LSM9DS1_IMU_OFF            0x00 /**< Accelerometer and gyroscope off */
+#define LSM9DS1_GY_OFF_XL_10Hz     0x10 /**< GY off, XL 10 Hz */
+#define LSM9DS1_GY_OFF_XL_50Hz     0x20 /**< GY off, XL 50 Hz */
+#define LSM9DS1_GY_OFF_XL_119Hz    0x30 /**< GY off, XL 119 Hz */
+#define LSM9DS1_GY_OFF_XL_238Hz    0x40 /**< GY off, XL 238 Hz */
+#define LSM9DS1_GY_OFF_XL_476Hz    0x50 /**< GY off, XL 476 Hz */
+#define LSM9DS1_GY_OFF_XL_952Hz    0x60 /**< GY off, XL 952 Hz */
+#define LSM9DS1_XL_OFF_GY_14Hz9    0x01 /**< XL off, GY 14.9 Hz */
+#define LSM9DS1_XL_OFF_GY_59Hz5    0x02 /**< XL off, GY 59.5 Hz */
+#define LSM9DS1_XL_OFF_GY_119Hz    0x03 /**< XL off, GY 119 Hz */
+#define LSM9DS1_XL_OFF_GY_238Hz    0x04 /**< XL off, GY 238 Hz */
+#define LSM9DS1_XL_OFF_GY_476Hz    0x05 /**< XL off, GY 476 Hz */
+#define LSM9DS1_XL_OFF_GY_952Hz    0x06 /**< XL off, GY 952 Hz */
+#define LSM9DS1_IMU_14Hz9          0x11 /**< XL and GY 14.9 Hz */
+#define LSM9DS1_IMU_59Hz5          0x22 /**< XL and GY 59.5 Hz */
+#define LSM9DS1_IMU_119Hz          0x33 /**< XL and GY 119 Hz */
+#define LSM9DS1_IMU_238Hz          0x44 /**< XL and GY 238 Hz */
+#define LSM9DS1_IMU_476Hz          0x55 /**< XL and GY 476 Hz */
+#define LSM9DS1_IMU_952Hz          0x66 /**< XL and GY 952 Hz */
+#define LSM9DS1_XL_OFF_GY_14Hz9_LP 0x81 /**< XL off, GY 14.9 Hz (low-power) */
+#define LSM9DS1_XL_OFF_GY_59Hz5_LP 0x82 /**< XL off, GY 59.5 Hz (low-power) */
+#define LSM9DS1_XL_OFF_GY_119Hz_LP 0x83 /**< XL off, GY 119 Hz (low-power) */
+#define LSM9DS1_IMU_14Hz9_LP       0x91 /**< XL and GY 14.9 Hz (low-power) */
+#define LSM9DS1_IMU_59Hz5_LP       0xA2 /**< XL and GY 59.5 Hz (low-power) */
+#define LSM9DS1_IMU_119Hz_LP       0xB3 /**< XL and GY 119 Hz (low-power) */
+/** @} */
 
-#define LSM9DS1_DT_FS_4Ga  0
-#define LSM9DS1_DT_FS_8Ga  1
-#define LSM9DS1_DT_FS_12Ga 2
-#define LSM9DS1_DT_FS_16Ga 3
+/**
+ * @name Magnetometer full-scale range
+ *
+ * Values for the `mag-range` devicetree property.
+ * @{
+ */
+#define LSM9DS1_DT_FS_4Ga  0 /**< ±4 gauss */
+#define LSM9DS1_DT_FS_8Ga  1 /**< ±8 gauss */
+#define LSM9DS1_DT_FS_12Ga 2 /**< ±12 gauss */
+#define LSM9DS1_DT_FS_16Ga 3 /**< ±16 gauss */
+/** @} */
 
-#define LSM9DS1_MAG_POWER_DOWN 0xC0
-#define LSM9DS1_MAG_LP_0Hz625  0x00
-#define LSM9DS1_MAG_LP_1Hz25   0x01
-#define LSM9DS1_MAG_LP_2Hz5    0x02
-#define LSM9DS1_MAG_LP_5Hz     0x03
-#define LSM9DS1_MAG_LP_10Hz    0x04
-#define LSM9DS1_MAG_LP_20Hz    0x05
-#define LSM9DS1_MAG_LP_40Hz    0x06
-#define LSM9DS1_MAG_LP_80Hz    0x07
-#define LSM9DS1_MAG_MP_0Hz625  0x10
-#define LSM9DS1_MAG_MP_1Hz25   0x11
-#define LSM9DS1_MAG_MP_2Hz5    0x12
-#define LSM9DS1_MAG_MP_5Hz     0x13
-#define LSM9DS1_MAG_MP_10Hz    0x14
-#define LSM9DS1_MAG_MP_20Hz    0x15
-#define LSM9DS1_MAG_MP_40Hz    0x16
-#define LSM9DS1_MAG_MP_80Hz    0x17
-#define LSM9DS1_MAG_HP_0Hz625  0x20
-#define LSM9DS1_MAG_HP_1Hz25   0x21
-#define LSM9DS1_MAG_HP_2Hz5    0x22
-#define LSM9DS1_MAG_HP_5Hz     0x23
-#define LSM9DS1_MAG_HP_10Hz    0x24
-#define LSM9DS1_MAG_HP_20Hz    0x25
-#define LSM9DS1_MAG_HP_40Hz    0x26
-#define LSM9DS1_MAG_HP_80Hz    0x27
-#define LSM9DS1_MAG_UHP_0Hz625 0x30
-#define LSM9DS1_MAG_UHP_1Hz25  0x31
-#define LSM9DS1_MAG_UHP_2Hz5   0x32
-#define LSM9DS1_MAG_UHP_5Hz    0x33
-#define LSM9DS1_MAG_UHP_10Hz   0x34
-#define LSM9DS1_MAG_UHP_20Hz   0x35
-#define LSM9DS1_MAG_UHP_40Hz   0x36
-#define LSM9DS1_MAG_UHP_80Hz   0x37
-#define LSM9DS1_MAG_UHP_155Hz  0x38
-#define LSM9DS1_MAG_HP_300Hz   0x28
-#define LSM9DS1_MAG_MP_560Hz   0x18
-#define LSM9DS1_MAG_LP_1000Hz  0x08
-#define LSM9DS1_MAG_ONE_SHOT   0x70
+/**
+ * @name Magnetometer output data rate
+ *
+ * Values for the `mag-odr` devicetree property.
+ *
+ * LP: low-power, MP: medium-performance, HP: high-performance,
+ * UHP: ultra-high-performance mode.
+ * @{
+ */
+#define LSM9DS1_MAG_POWER_DOWN 0xC0 /**< Power-down */
+#define LSM9DS1_MAG_LP_0Hz625  0x00 /**< LP, 0.625 Hz */
+#define LSM9DS1_MAG_LP_1Hz25   0x01 /**< LP, 1.25 Hz */
+#define LSM9DS1_MAG_LP_2Hz5    0x02 /**< LP, 2.5 Hz */
+#define LSM9DS1_MAG_LP_5Hz     0x03 /**< LP, 5 Hz */
+#define LSM9DS1_MAG_LP_10Hz    0x04 /**< LP, 10 Hz */
+#define LSM9DS1_MAG_LP_20Hz    0x05 /**< LP, 20 Hz */
+#define LSM9DS1_MAG_LP_40Hz    0x06 /**< LP, 40 Hz */
+#define LSM9DS1_MAG_LP_80Hz    0x07 /**< LP, 80 Hz */
+#define LSM9DS1_MAG_MP_0Hz625  0x10 /**< MP, 0.625 Hz */
+#define LSM9DS1_MAG_MP_1Hz25   0x11 /**< MP, 1.25 Hz */
+#define LSM9DS1_MAG_MP_2Hz5    0x12 /**< MP, 2.5 Hz */
+#define LSM9DS1_MAG_MP_5Hz     0x13 /**< MP, 5 Hz */
+#define LSM9DS1_MAG_MP_10Hz    0x14 /**< MP, 10 Hz */
+#define LSM9DS1_MAG_MP_20Hz    0x15 /**< MP, 20 Hz */
+#define LSM9DS1_MAG_MP_40Hz    0x16 /**< MP, 40 Hz */
+#define LSM9DS1_MAG_MP_80Hz    0x17 /**< MP, 80 Hz */
+#define LSM9DS1_MAG_HP_0Hz625  0x20 /**< HP, 0.625 Hz */
+#define LSM9DS1_MAG_HP_1Hz25   0x21 /**< HP, 1.25 Hz */
+#define LSM9DS1_MAG_HP_2Hz5    0x22 /**< HP, 2.5 Hz */
+#define LSM9DS1_MAG_HP_5Hz     0x23 /**< HP, 5 Hz */
+#define LSM9DS1_MAG_HP_10Hz    0x24 /**< HP, 10 Hz */
+#define LSM9DS1_MAG_HP_20Hz    0x25 /**< HP, 20 Hz */
+#define LSM9DS1_MAG_HP_40Hz    0x26 /**< HP, 40 Hz */
+#define LSM9DS1_MAG_HP_80Hz    0x27 /**< HP, 80 Hz */
+#define LSM9DS1_MAG_UHP_0Hz625 0x30 /**< UHP, 0.625 Hz */
+#define LSM9DS1_MAG_UHP_1Hz25  0x31 /**< UHP, 1.25 Hz */
+#define LSM9DS1_MAG_UHP_2Hz5   0x32 /**< UHP, 2.5 Hz */
+#define LSM9DS1_MAG_UHP_5Hz    0x33 /**< UHP, 5 Hz */
+#define LSM9DS1_MAG_UHP_10Hz   0x34 /**< UHP, 10 Hz */
+#define LSM9DS1_MAG_UHP_20Hz   0x35 /**< UHP, 20 Hz */
+#define LSM9DS1_MAG_UHP_40Hz   0x36 /**< UHP, 40 Hz */
+#define LSM9DS1_MAG_UHP_80Hz   0x37 /**< UHP, 80 Hz */
+#define LSM9DS1_MAG_UHP_155Hz  0x38 /**< UHP, 155 Hz */
+#define LSM9DS1_MAG_HP_300Hz   0x28 /**< HP, 300 Hz */
+#define LSM9DS1_MAG_MP_560Hz   0x18 /**< MP, 560 Hz */
+#define LSM9DS1_MAG_LP_1000Hz  0x08 /**< LP, 1000 Hz */
+#define LSM9DS1_MAG_ONE_SHOT   0x70 /**< Single (one-shot) conversion */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LSM9DS1_H_ */

--- a/include/zephyr/dt-bindings/sensor/mc3419.h
+++ b/include/zephyr/dt-bindings/sensor/mc3419.h
@@ -3,46 +3,63 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the MEMSIC MC3419 accelerometer.
+ * @ingroup mc3419_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MEMSIC_MC3419_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MEMSIC_MC3419_H_
 
 /**
- * @defgroup mc3419 Memsic DT Options
- * @ingroup sensor_interface
+ * @defgroup mc3419_interface MC3419
+ * @ingroup sensor_interface_ext_memsic
+ * @brief MEMSIC MC3419 3-axis accelerometer
  * @{
  */
 
 /**
- * @defgroup mc3419_lpf_configs Lowe pass filter configurations
+ * @name Low-pass filter options
+ *
+ * Values for the `lpf-fc-sel` devicetree property.
+ *
+ * Enabled options set the filter corner frequency (Fc) to a fraction of the
+ * internal data rate (IDR).
  * @{
  */
-#define MC3419_LPF_DISABLE                 0
-#define MC3419_LPF_EN_WITH_IDR_BY_4p255_FC 9
-#define MC3419_LPF_EN_WITH_IDR_BY_6_FC     10
-#define MC3419_LPF_EN_WITH_IDR_BY_12_FC    11
-#define MC3419_LPF_EN_WITH_IDR_BY_16_FC    13
+#define MC3419_LPF_DISABLE                 0  /**< Filter disabled */
+#define MC3419_LPF_EN_WITH_IDR_BY_4p255_FC 9  /**< Fc = IDR / 4.255 */
+#define MC3419_LPF_EN_WITH_IDR_BY_6_FC     10 /**< Fc = IDR / 6 */
+#define MC3419_LPF_EN_WITH_IDR_BY_12_FC    11 /**< Fc = IDR / 12 */
+#define MC3419_LPF_EN_WITH_IDR_BY_16_FC    13 /**< Fc = IDR / 16 */
 /** @} */
 
 /**
- * @defgroup mc3419_decimation_rates decimate sampling rate by provided rate
+ * @name Decimation rate options
+ *
+ * Values for the `decimation-rate` devicetree property.
+ *
+ * Divide the internal data rate (IDR) by the selected factor.
  * @{
  */
-#define MC3419_DECIMATE_IDR_BY_1    0
-#define MC3419_DECIMATE_IDR_BY_2    1
-#define MC3419_DECIMATE_IDR_BY_4    2
-#define MC3419_DECIMATE_IDR_BY_5    3
-#define MC3419_DECIMATE_IDR_BY_8    4
-#define MC3419_DECIMATE_IDR_BY_10   5
-#define MC3419_DECIMATE_IDR_BY_16   6
-#define MC3419_DECIMATE_IDR_BY_20   7
-#define MC3419_DECIMATE_IDR_BY_40   8
-#define MC3419_DECIMATE_IDR_BY_67   9
-#define MC3419_DECIMATE_IDR_BY_80   10
-#define MC3419_DECIMATE_IDR_BY_100  11
-#define MC3419_DECIMATE_IDR_BY_200  12
-#define MC3419_DECIMATE_IDR_BY_250  13
-#define MC3419_DECIMATE_IDR_BY_500  14
-#define MC3419_DECIMATE_IDR_BY_1000 15
+#define MC3419_DECIMATE_IDR_BY_1    0  /**< IDR / 1 */
+#define MC3419_DECIMATE_IDR_BY_2    1  /**< IDR / 2 */
+#define MC3419_DECIMATE_IDR_BY_4    2  /**< IDR / 4 */
+#define MC3419_DECIMATE_IDR_BY_5    3  /**< IDR / 5 */
+#define MC3419_DECIMATE_IDR_BY_8    4  /**< IDR / 8 */
+#define MC3419_DECIMATE_IDR_BY_10   5  /**< IDR / 10 */
+#define MC3419_DECIMATE_IDR_BY_16   6  /**< IDR / 16 */
+#define MC3419_DECIMATE_IDR_BY_20   7  /**< IDR / 20 */
+#define MC3419_DECIMATE_IDR_BY_40   8  /**< IDR / 40 */
+#define MC3419_DECIMATE_IDR_BY_67   9  /**< IDR / 67 */
+#define MC3419_DECIMATE_IDR_BY_80   10 /**< IDR / 80 */
+#define MC3419_DECIMATE_IDR_BY_100  11 /**< IDR / 100 */
+#define MC3419_DECIMATE_IDR_BY_200  12 /**< IDR / 200 */
+#define MC3419_DECIMATE_IDR_BY_250  13 /**< IDR / 250 */
+#define MC3419_DECIMATE_IDR_BY_500  14 /**< IDR / 500 */
+#define MC3419_DECIMATE_IDR_BY_1000 15 /**< IDR / 1000 */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/mcp9600.h
+++ b/include/zephyr/dt-bindings/sensor/mcp9600.h
@@ -3,45 +3,57 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the Microchip MCP9600 thermocouple converter.
+ * @ingroup mcp9600_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MICRO_MCP9600_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MICRO_MCP9600_H_
 
 /**
- * @defgroup mcp9600 MCP9600 DT Options
- * @ingroup sensor_interface
+ * @addtogroup mcp9600_interface
  * @{
  */
 
 /**
- * @defgroup mcp9600_thermocouple_type Thermocouple type selection
+ * @name Thermocouple type selection
+ *
+ * Values for the `thermocouple-type` devicetree property.
  * @{
  */
-#define MCP9600_DT_TYPE_K 0x0
-#define MCP9600_DT_TYPE_J 0x1
-#define MCP9600_DT_TYPE_T 0x2
-#define MCP9600_DT_TYPE_N 0x3
-#define MCP9600_DT_TYPE_S 0x4
-#define MCP9600_DT_TYPE_E 0x5
-#define MCP9600_DT_TYPE_B 0x6
-#define MCP9600_DT_TYPE_R 0x7
+#define MCP9600_DT_TYPE_K 0x0 /**< Type K thermocouple */
+#define MCP9600_DT_TYPE_J 0x1 /**< Type J thermocouple */
+#define MCP9600_DT_TYPE_T 0x2 /**< Type T thermocouple */
+#define MCP9600_DT_TYPE_N 0x3 /**< Type N thermocouple */
+#define MCP9600_DT_TYPE_S 0x4 /**< Type S thermocouple */
+#define MCP9600_DT_TYPE_E 0x5 /**< Type E thermocouple */
+#define MCP9600_DT_TYPE_B 0x6 /**< Type B thermocouple */
+#define MCP9600_DT_TYPE_R 0x7 /**< Type R thermocouple */
 /** @} */
 
 /**
- * @defgroup mcp9600_adc_resolution ADC resolution
+ * @name ADC resolution options
+ *
+ * Values for the `adc-resolution` devicetree property.
  * @{
  */
-#define MCP9600_DT_ADC_RES_18BIT 0x0
-#define MCP9600_DT_ADC_RES_16BIT 0x1
-#define MCP9600_DT_ADC_RES_14BIT 0x2
-#define MCP9600_DT_ADC_RES_12BIT 0x3
+#define MCP9600_DT_ADC_RES_18BIT 0x0 /**< 18-bit resolution */
+#define MCP9600_DT_ADC_RES_16BIT 0x1 /**< 16-bit resolution */
+#define MCP9600_DT_ADC_RES_14BIT 0x2 /**< 14-bit resolution */
+#define MCP9600_DT_ADC_RES_12BIT 0x3 /**< 12-bit resolution */
 /** @} */
 
 /**
- * @defgroup mcp9600_cold_junction_temp_resolution Cold junction temperature resolution
+ * @name Cold-junction temperature resolution
+ *
+ * Values for the `cold-junction-temp-resolution` devicetree property.
  * @{
  */
-#define MCP9600_DT_COLD_JUNC_TMP_RES_0_0625C 0x0
-#define MCP9600_DT_COLD_JUNC_TMP_RES_0_25C   0x1
+#define MCP9600_DT_COLD_JUNC_TMP_RES_0_0625C 0x0 /**< 0.0625 °C resolution */
+#define MCP9600_DT_COLD_JUNC_TMP_RES_0_25C   0x1 /**< 0.25 °C resolution */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/mtch9010.h
+++ b/include/zephyr/dt-bindings/sensor/mtch9010.h
@@ -3,17 +3,45 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the Microchip MTCH9010 sensor.
+ * @ingroup mtch9010_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_MTCH9010_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_MTCH9010_H_
 
-/* Operating Mode */
-#define MTCH9010_CAPACITIVE 0x0
-#define MTCH9010_CONDUCTIVE 0x1
+/**
+ * @defgroup mtch9010_interface MTCH9010
+ * @ingroup sensor_interface_ext_microchip
+ * @brief Microchip MTCH9010 capacitive/conductive liquid-level sensor
+ * @{
+ */
 
-/* Output UART Data Formats */
-#define MTCH9010_OUTPUT_FORMAT_DELTA 0x0
-#define MTCH9010_OUTPUT_FORMAT_CURRENT 0x1
-#define MTCH9010_OUTPUT_FORMAT_BOTH 0x2
-#define MTCH9010_OUTPUT_FORMAT_MPLAB_DATA_VISUALIZER 0x3
+/**
+ * @name Operating mode
+ *
+ * Values for the `operating-mode` devicetree property.
+ * @{
+ */
+#define MTCH9010_CAPACITIVE 0x0 /**< Capacitive sensing */
+#define MTCH9010_CONDUCTIVE 0x1 /**< Conductive sensing */
+/** @} */
+
+/**
+ * @name UART output data format
+ *
+ * Values for the `extended-output-format` devicetree property.
+ * @{
+ */
+#define MTCH9010_OUTPUT_FORMAT_DELTA 0x0                 /**< Delta from reference */
+#define MTCH9010_OUTPUT_FORMAT_CURRENT 0x1               /**< Current measurement */
+#define MTCH9010_OUTPUT_FORMAT_BOTH 0x2                  /**< Delta and current */
+#define MTCH9010_OUTPUT_FORMAT_MPLAB_DATA_VISUALIZER 0x3 /**< MPLAB Data Visualizer stream */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_MTCH9010_H_ */

--- a/include/zephyr/dt-bindings/sensor/npcx_tach.h
+++ b/include/zephyr/dt-bindings/sensor/npcx_tach.h
@@ -3,14 +3,42 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the Nuvoton NPCX tachometer.
+ * @ingroup npcx_tach_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_NPCX_TACH_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_NPCX_TACH_H_
 
-/* NPCX tachometer port type */
-#define NPCX_TACH_PORT_A     0
-#define NPCX_TACH_PORT_B     1
+/**
+ * @defgroup npcx_tach_interface NPCX tachometer
+ * @ingroup sensor_interface_ext_nuvoton
+ * @brief Nuvoton NPCX tachometer
+ * @{
+ */
 
-/* NPCX tachometer specific operate frequency */
-#define NPCX_TACH_FREQ_LFCLK 32768
+/**
+ * @name Tachometer port
+ *
+ * Values for the `port` devicetree property.
+ * @{
+ */
+#define NPCX_TACH_PORT_A     0 /**< Tachometer port A */
+#define NPCX_TACH_PORT_B     1 /**< Tachometer port B */
+/** @} */
+
+/**
+ * @name Operating frequency
+ *
+ * Values for the `sample-clk` devicetree property.
+ * @{
+ */
+#define NPCX_TACH_FREQ_LFCLK 32768 /**< Low-frequency clock (32768 Hz) */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_NPCX_TACH_H_ */

--- a/include/zephyr/dt-bindings/sensor/pac194x.h
+++ b/include/zephyr/dt-bindings/sensor/pac194x.h
@@ -4,36 +4,55 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree binding constants for the Microchip PAC194x power monitor.
+ * @ingroup pac194x_interface
+ */
+
 #ifndef PAC194X_H_DTS_BINDINGS
 #define PAC194X_H_DTS_BINDINGS
 
 /**
- * @file pac194x.h
- * @brief Driver definitions for the PAC194X power monitor.
+ * @defgroup pac194x_interface PAC194X
+ * @ingroup sensor_interface_ext_microchip
+ * @brief Microchip PAC194x power monitor
+ * @{
  */
 
-/** Unipolar FSR range */
-#define PAC_UNIPOLAR_FSR	0
-/** Bipolar FSR range */
-#define PAC_BIPOLAR_FSR		1
-/** Bipolar FSR/2 range */
-#define PAC_BIPOLAR_HALF_FSR	2
+/**
+ * @name Full-scale range mode
+ *
+ * Values for the `microchip,vbus-mode` and `microchip,vsense-mode` devicetree properties.
+ * @{
+ */
+#define PAC_UNIPOLAR_FSR	0 /**< Unipolar full-scale range */
+#define PAC_BIPOLAR_FSR		1 /**< Bipolar full-scale range */
+#define PAC_BIPOLAR_HALF_FSR	2 /**< Bipolar half (FSR / 2) range */
+/** @} */
 
-/** Accumulate Power data */
-#define PAC_ACCUM_VPOWER	0
-/** Accumulate Current data */
-#define PAC_ACCUM_VSENSE	1
-/** Accumulate Voltage data */
-#define PAC_ACCUM_VBUS		2
+/**
+ * @name Accumulation source
+ *
+ * Values for the `microchip,accumulation-mode` devicetree property.
+ * @{
+ */
+#define PAC_ACCUM_VPOWER	0 /**< Accumulate power data */
+#define PAC_ACCUM_VSENSE	1 /**< Accumulate current (sense voltage) data */
+#define PAC_ACCUM_VBUS		2 /**< Accumulate bus voltage data */
+/** @} */
 
+/**
+ * @name Refresh mode
+ *
+ * Values for the `microchip,refresh-mode` devicetree property.
+ * @{
+ */
+#define PAC_REFRESH_MANUAL	0 /**< Manual refresh */
+#define PAC_REFRESH_AUTO_WAIT	1 /**< Automatic refresh, wait for valid data */
+#define PAC_REFRESH_AUTO_NOWAIT	2 /**< Automatic refresh, do not wait */
+/** @} */
 
-/** Refresh mode manual */
-#define PAC_REFRESH_MANUAL	0
-
-/** Refresh mode */
-#define PAC_REFRESH_AUTO_WAIT	1
-
-/** Refresh mode */
-#define PAC_REFRESH_AUTO_NOWAIT	2
+/** @} */
 
 #endif /* PAC194X_H_DTS_BINDINGS */

--- a/include/zephyr/dt-bindings/sensor/qdec_nrf.h
+++ b/include/zephyr/dt-bindings/sensor/qdec_nrf.h
@@ -3,16 +3,39 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the Nordic nRF quadrature decoder.
+ * @ingroup qdec_nrf_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_QDEC_NRF_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_QDEC_NRF_H_
 
-#define SAMPLEPER_128US         0
-#define SAMPLEPER_256US         1
-#define SAMPLEPER_512US         2
-#define SAMPLEPER_1024US        3
-#define SAMPLEPER_2048US        4
-#define SAMPLEPER_4096US        5
-#define SAMPLEPER_8192US        6
-#define SAMPLEPER_16384US       7
+/**
+ * @defgroup qdec_nrf_interface QDEC nRF
+ * @ingroup sensor_interface_ext_nordic
+ * @brief Nordic nRF quadrature decoder (QDEC)
+ * @{
+ */
+
+/**
+ * @name Sample period options
+ *
+ * Values for the `nordic,period` devicetree property.
+ * @{
+ */
+#define SAMPLEPER_128US         0 /**< 128 µs */
+#define SAMPLEPER_256US         1 /**< 256 µs */
+#define SAMPLEPER_512US         2 /**< 512 µs */
+#define SAMPLEPER_1024US        3 /**< 1024 µs */
+#define SAMPLEPER_2048US        4 /**< 2048 µs */
+#define SAMPLEPER_4096US        5 /**< 4096 µs */
+#define SAMPLEPER_8192US        6 /**< 8192 µs */
+#define SAMPLEPER_16384US       7 /**< 16384 µs */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_QDEC_NRF_H_ */

--- a/include/zephyr/dt-bindings/sensor/qdec_nxp_s32.h
+++ b/include/zephyr/dt-bindings/sensor/qdec_nxp_s32.h
@@ -4,104 +4,151 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Logic Trigger Numbers. See Trgmux_Ip_Init_PBcfg.h */
-#define TRGMUX_LOGIC_GROUP_0_TRIGGER_0 (0) /* Logic Trigger 0 */
-#define TRGMUX_LOGIC_GROUP_0_TRIGGER_1 (1) /* Logic Trigger 1 */
-#define TRGMUX_LOGIC_GROUP_1_TRIGGER_0 (2) /* Logic Trigger 2 */
-#define TRGMUX_LOGIC_GROUP_1_TRIGGER_1 (3) /* Logic Trigger 3 */
-
-/*-----------------------------------------------
- * TRGMUX HARDWARE TRIGGER INPUT
- * See Trgmux_Ip_Cfg_Defines.h
- *-----------------------------------------------
+/**
+ * @file
+ * @brief Devicetree binding constants for the NXP S32 quadrature decoder.
+ * @ingroup qdec_nxp_s32_interface
  */
-#define TRGMUX_IP_INPUT_SIUL2_IN0  (60)
-#define TRGMUX_IP_INPUT_SIUL2_IN1  (61)
-#define TRGMUX_IP_INPUT_SIUL2_IN2  (62)
-#define TRGMUX_IP_INPUT_SIUL2_IN3  (63)
-#define TRGMUX_IP_INPUT_SIUL2_IN4  (64)
-#define TRGMUX_IP_INPUT_SIUL2_IN5  (65)
-#define TRGMUX_IP_INPUT_SIUL2_IN6  (66)
-#define TRGMUX_IP_INPUT_SIUL2_IN7  (67)
-#define TRGMUX_IP_INPUT_SIUL2_IN8  (68)
-#define TRGMUX_IP_INPUT_SIUL2_IN9  (69)
-#define TRGMUX_IP_INPUT_SIUL2_IN10 (70)
-#define TRGMUX_IP_INPUT_SIUL2_IN11 (71)
-#define TRGMUX_IP_INPUT_SIUL2_IN12 (72)
-#define TRGMUX_IP_INPUT_SIUL2_IN13 (73)
-#define TRGMUX_IP_INPUT_SIUL2_IN14 (74)
-#define TRGMUX_IP_INPUT_SIUL2_IN15 (75)
 
-#define TRGMUX_IP_INPUT_LCU1_LC0_OUT_I0 (105)
-#define TRGMUX_IP_INPUT_LCU1_LC0_OUT_I1 (106)
-#define TRGMUX_IP_INPUT_LCU1_LC0_OUT_I2 (107)
-#define TRGMUX_IP_INPUT_LCU1_LC0_OUT_I3 (108)
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_QDEC_NXP_S32_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_QDEC_NXP_S32_H_
 
-/*-----------------------------------------------
- *  TRGMUX HARDWARE TRIGGER OUTPUT
- *  See Trgmux_Ip_Cfg_Defines.h
- *-----------------------------------------------
+/**
+ * @defgroup qdec_nxp_s32_interface QDEC NXP S32
+ * @ingroup sensor_interface_ext_nxp
+ * @brief NXP S32 quadrature decoder TRGMUX and LCU routing
+ * @{
  */
-#define TRGMUX_IP_OUTPUT_LCU1_0_INP_I0 (144)
-#define TRGMUX_IP_OUTPUT_LCU1_0_INP_I1 (145)
-#define TRGMUX_IP_OUTPUT_LCU1_0_INP_I2 (146)
-#define TRGMUX_IP_OUTPUT_LCU1_0_INP_I3 (147)
 
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH1_4_IPP_IND_CH1    (32)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH1_4_IPP_IND_CH2    (33)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH1_4_IPP_IND_CH3    (34)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH1_4_IPP_IND_CH4    (35)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH5_9_IPP_IND_CH5    (36)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH5_9_IPP_IND_CH6    (37)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH5_9_IPP_IND_CH7    (38)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH5_9_IPP_IND_CH9    (39)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH10_13_IPP_IND_CH10 (40)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH10_13_IPP_IND_CH11 (41)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH10_13_IPP_IND_CH12 (42)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH10_13_IPP_IND_CH13 (43)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH14_15_IPP_IND_CH14 (44)
-#define TRGMUX_IP_OUTPUT_EMIOS0_CH14_15_IPP_IND_CH15 (45)
-
-/*-----------------------------------------------
- *  LCU SOURCE MUX SELECT
- *  See Lcu_Ip_Cfg_Defines.h
- *-----------------------------------------------
+/**
+ * @name Logic trigger numbers
+ *
+ * Logic trigger identifiers used in the `trgmux` property.
+ *
+ * See Trgmux_Ip_Init_PBcfg.h.
+ * @{
  */
-#define LCU_IP_MUX_SEL_LOGIC_0                   (0)
-#define LCU_IP_MUX_SEL_LU_IN_0                   (1)
-#define LCU_IP_MUX_SEL_LU_IN_1                   (2)
-#define LCU_IP_MUX_SEL_LU_IN_2                   (3)
-#define LCU_IP_MUX_SEL_LU_IN_3                   (4)
-#define LCU_IP_MUX_SEL_LU_IN_4                   (5)
-#define LCU_IP_MUX_SEL_LU_IN_5                   (6)
-#define LCU_IP_MUX_SEL_LU_IN_6                   (7)
-#define LCU_IP_MUX_SEL_LU_IN_7                   (8)
-#define LCU_IP_MUX_SEL_LU_IN_8                   (9)
-#define LCU_IP_MUX_SEL_LU_IN_9                   (10)
-#define LCU_IP_MUX_SEL_LU_IN_10                  (11)
-#define LCU_IP_MUX_SEL_LU_IN_11                  (12)
-#define LCU_IP_MUX_SEL_LU_OUT_0                  (13)
-#define LCU_IP_MUX_SEL_LU_OUT_1                  (14)
-#define LCU_IP_MUX_SEL_LU_OUT_2                  (15)
-#define LCU_IP_MUX_SEL_LU_OUT_3                  (16)
-#define LCU_IP_MUX_SEL_LU_OUT_4                  (17)
-#define LCU_IP_MUX_SEL_LU_OUT_5                  (18)
-#define LCU_IP_MUX_SEL_LU_OUT_6                  (19)
-#define LCU_IP_MUX_SEL_LU_OUT_7                  (20)
-#define LCU_IP_MUX_SEL_LU_OUT_8                  (21)
-#define LCU_IP_MUX_SEL_LU_OUT_9                  (22)
-#define LCU_IP_MUX_SEL_LU_OUT_10                 (23)
-#define LCU_IP_MUX_SEL_LU_OUT_11                 (24)
+#define TRGMUX_LOGIC_GROUP_0_TRIGGER_0 (0) /**< Logic trigger 0 */
+#define TRGMUX_LOGIC_GROUP_0_TRIGGER_1 (1) /**< Logic trigger 1 */
+#define TRGMUX_LOGIC_GROUP_1_TRIGGER_0 (2) /**< Logic trigger 2 */
+#define TRGMUX_LOGIC_GROUP_1_TRIGGER_1 (3) /**< Logic trigger 3 */
+/** @} */
 
-#define LCU_IP_IN_0				 (0)
-#define LCU_IP_IN_1				 (1)
-#define LCU_IP_IN_2				 (2)
-#define LCU_IP_IN_3				 (3)
-#define LCU_IP_IN_4				 (4)
-#define LCU_IP_IN_5				 (5)
-#define LCU_IP_IN_6				 (6)
-#define LCU_IP_IN_7				 (7)
-#define LCU_IP_IN_8				 (8)
-#define LCU_IP_IN_9				 (9)
-#define LCU_IP_IN_10				 (10)
-#define LCU_IP_IN_11				 (11)
+/**
+ * @name TRGMUX hardware trigger inputs
+ *
+ * TRGMUX trigger input identifiers used in the `trgmux-io-config` property.
+ *
+ * See Trgmux_Ip_Cfg_Defines.h.
+ * @{
+ */
+#define TRGMUX_IP_INPUT_SIUL2_IN0  (60) /**< SIUL2 input 0 */
+#define TRGMUX_IP_INPUT_SIUL2_IN1  (61) /**< SIUL2 input 1 */
+#define TRGMUX_IP_INPUT_SIUL2_IN2  (62) /**< SIUL2 input 2 */
+#define TRGMUX_IP_INPUT_SIUL2_IN3  (63) /**< SIUL2 input 3 */
+#define TRGMUX_IP_INPUT_SIUL2_IN4  (64) /**< SIUL2 input 4 */
+#define TRGMUX_IP_INPUT_SIUL2_IN5  (65) /**< SIUL2 input 5 */
+#define TRGMUX_IP_INPUT_SIUL2_IN6  (66) /**< SIUL2 input 6 */
+#define TRGMUX_IP_INPUT_SIUL2_IN7  (67) /**< SIUL2 input 7 */
+#define TRGMUX_IP_INPUT_SIUL2_IN8  (68) /**< SIUL2 input 8 */
+#define TRGMUX_IP_INPUT_SIUL2_IN9  (69) /**< SIUL2 input 9 */
+#define TRGMUX_IP_INPUT_SIUL2_IN10 (70) /**< SIUL2 input 10 */
+#define TRGMUX_IP_INPUT_SIUL2_IN11 (71) /**< SIUL2 input 11 */
+#define TRGMUX_IP_INPUT_SIUL2_IN12 (72) /**< SIUL2 input 12 */
+#define TRGMUX_IP_INPUT_SIUL2_IN13 (73) /**< SIUL2 input 13 */
+#define TRGMUX_IP_INPUT_SIUL2_IN14 (74) /**< SIUL2 input 14 */
+#define TRGMUX_IP_INPUT_SIUL2_IN15 (75) /**< SIUL2 input 15 */
+
+#define TRGMUX_IP_INPUT_LCU1_LC0_OUT_I0 (105) /**< LCU1 LC0 output 0 */
+#define TRGMUX_IP_INPUT_LCU1_LC0_OUT_I1 (106) /**< LCU1 LC0 output 1 */
+#define TRGMUX_IP_INPUT_LCU1_LC0_OUT_I2 (107) /**< LCU1 LC0 output 2 */
+#define TRGMUX_IP_INPUT_LCU1_LC0_OUT_I3 (108) /**< LCU1 LC0 output 3 */
+/** @} */
+
+/**
+ * @name TRGMUX hardware trigger outputs
+ *
+ * TRGMUX trigger output identifiers used in the `trgmux-io-config` property.
+ *
+ * See Trgmux_Ip_Cfg_Defines.h.
+ * @{
+ */
+#define TRGMUX_IP_OUTPUT_LCU1_0_INP_I0 (144) /**< LCU1 instance 0 input 0 */
+#define TRGMUX_IP_OUTPUT_LCU1_0_INP_I1 (145) /**< LCU1 instance 0 input 1 */
+#define TRGMUX_IP_OUTPUT_LCU1_0_INP_I2 (146) /**< LCU1 instance 0 input 2 */
+#define TRGMUX_IP_OUTPUT_LCU1_0_INP_I3 (147) /**< LCU1 instance 0 input 3 */
+
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH1_4_IPP_IND_CH1    (32) /**< eMIOS0 channel 1 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH1_4_IPP_IND_CH2    (33) /**< eMIOS0 channel 2 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH1_4_IPP_IND_CH3    (34) /**< eMIOS0 channel 3 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH1_4_IPP_IND_CH4    (35) /**< eMIOS0 channel 4 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH5_9_IPP_IND_CH5    (36) /**< eMIOS0 channel 5 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH5_9_IPP_IND_CH6    (37) /**< eMIOS0 channel 6 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH5_9_IPP_IND_CH7    (38) /**< eMIOS0 channel 7 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH5_9_IPP_IND_CH9    (39) /**< eMIOS0 channel 9 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH10_13_IPP_IND_CH10 (40) /**< eMIOS0 channel 10 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH10_13_IPP_IND_CH11 (41) /**< eMIOS0 channel 11 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH10_13_IPP_IND_CH12 (42) /**< eMIOS0 channel 12 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH10_13_IPP_IND_CH13 (43) /**< eMIOS0 channel 13 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH14_15_IPP_IND_CH14 (44) /**< eMIOS0 channel 14 */
+#define TRGMUX_IP_OUTPUT_EMIOS0_CH14_15_IPP_IND_CH15 (45) /**< eMIOS0 channel 15 */
+/** @} */
+
+/**
+ * @name LCU source mux selection
+ *
+ * Values for the `lcu-mux-sel` devicetree property.
+ *
+ * See Lcu_Ip_Cfg_Defines.h.
+ * @{
+ */
+#define LCU_IP_MUX_SEL_LOGIC_0                   (0)  /**< Constant logic 0 */
+#define LCU_IP_MUX_SEL_LU_IN_0                   (1)  /**< LCU input 0 */
+#define LCU_IP_MUX_SEL_LU_IN_1                   (2)  /**< LCU input 1 */
+#define LCU_IP_MUX_SEL_LU_IN_2                   (3)  /**< LCU input 2 */
+#define LCU_IP_MUX_SEL_LU_IN_3                   (4)  /**< LCU input 3 */
+#define LCU_IP_MUX_SEL_LU_IN_4                   (5)  /**< LCU input 4 */
+#define LCU_IP_MUX_SEL_LU_IN_5                   (6)  /**< LCU input 5 */
+#define LCU_IP_MUX_SEL_LU_IN_6                   (7)  /**< LCU input 6 */
+#define LCU_IP_MUX_SEL_LU_IN_7                   (8)  /**< LCU input 7 */
+#define LCU_IP_MUX_SEL_LU_IN_8                   (9)  /**< LCU input 8 */
+#define LCU_IP_MUX_SEL_LU_IN_9                   (10) /**< LCU input 9 */
+#define LCU_IP_MUX_SEL_LU_IN_10                  (11) /**< LCU input 10 */
+#define LCU_IP_MUX_SEL_LU_IN_11                  (12) /**< LCU input 11 */
+#define LCU_IP_MUX_SEL_LU_OUT_0                  (13) /**< LCU output 0 */
+#define LCU_IP_MUX_SEL_LU_OUT_1                  (14) /**< LCU output 1 */
+#define LCU_IP_MUX_SEL_LU_OUT_2                  (15) /**< LCU output 2 */
+#define LCU_IP_MUX_SEL_LU_OUT_3                  (16) /**< LCU output 3 */
+#define LCU_IP_MUX_SEL_LU_OUT_4                  (17) /**< LCU output 4 */
+#define LCU_IP_MUX_SEL_LU_OUT_5                  (18) /**< LCU output 5 */
+#define LCU_IP_MUX_SEL_LU_OUT_6                  (19) /**< LCU output 6 */
+#define LCU_IP_MUX_SEL_LU_OUT_7                  (20) /**< LCU output 7 */
+#define LCU_IP_MUX_SEL_LU_OUT_8                  (21) /**< LCU output 8 */
+#define LCU_IP_MUX_SEL_LU_OUT_9                  (22) /**< LCU output 9 */
+#define LCU_IP_MUX_SEL_LU_OUT_10                 (23) /**< LCU output 10 */
+#define LCU_IP_MUX_SEL_LU_OUT_11                 (24) /**< LCU output 11 */
+/** @} */
+
+/**
+ * @name LCU inputs
+ *
+ * Values for the `lcu-input-idx` devicetree property.
+ * @{
+ */
+#define LCU_IP_IN_0				 (0)  /**< LCU input 0 */
+#define LCU_IP_IN_1				 (1)  /**< LCU input 1 */
+#define LCU_IP_IN_2				 (2)  /**< LCU input 2 */
+#define LCU_IP_IN_3				 (3)  /**< LCU input 3 */
+#define LCU_IP_IN_4				 (4)  /**< LCU input 4 */
+#define LCU_IP_IN_5				 (5)  /**< LCU input 5 */
+#define LCU_IP_IN_6				 (6)  /**< LCU input 6 */
+#define LCU_IP_IN_7				 (7)  /**< LCU input 7 */
+#define LCU_IP_IN_8				 (8)  /**< LCU input 8 */
+#define LCU_IP_IN_9				 (9)  /**< LCU input 9 */
+#define LCU_IP_IN_10				 (10) /**< LCU input 10 */
+#define LCU_IP_IN_11				 (11) /**< LCU input 11 */
+/** @} */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_QDEC_NXP_S32_H_ */

--- a/include/zephyr/dt-bindings/sensor/qdec_stm32.h
+++ b/include/zephyr/dt-bindings/sensor/qdec_stm32.h
@@ -3,24 +3,51 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the STM32 quadrature decoder.
+ * @ingroup qdec_stm32_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_QDEC_STM32_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_QDEC_STM32_H_
 
-#define NO_FILTER	0
-#define FDIV1_N2	1
-#define FDIV1_N4	2
-#define FDIV1_N8	3
-#define FDIV2_N6	4
-#define FDIV2_N8	5
-#define FDIV4_N6	6
-#define FDIV4_N8	7
-#define FDIV8_N6	8
-#define FDIV8_N8	9
-#define FDIV16_N5	10
-#define FDIV16_N6	11
-#define FDIV16_N8	12
-#define FDIV32_N5	13
-#define FDIV32_N6	14
-#define FDIV32_N8	15
+/**
+ * @defgroup qdec_stm32_interface QDEC STM32
+ * @ingroup sensor_interface_ext_st
+ * @brief STM32 timer-based quadrature decoder (QDEC)
+ * @{
+ */
+
+/**
+ * @name Input filter options
+ *
+ * Digital input filter applied to the timer encoder inputs.
+ *
+ * FDIVx selects the sampling clock as a fraction of the timer clock (fDTS) and
+ * Ny the number of consecutive matching samples required to validate a
+ * transition.
+ * @{
+ */
+#define NO_FILTER	0  /**< No filter (sampling at fDTS) */
+#define FDIV1_N2	1  /**< fDTS, 2 samples */
+#define FDIV1_N4	2  /**< fDTS, 4 samples */
+#define FDIV1_N8	3  /**< fDTS, 8 samples */
+#define FDIV2_N6	4  /**< fDTS / 2, 6 samples */
+#define FDIV2_N8	5  /**< fDTS / 2, 8 samples */
+#define FDIV4_N6	6  /**< fDTS / 4, 6 samples */
+#define FDIV4_N8	7  /**< fDTS / 4, 8 samples */
+#define FDIV8_N6	8  /**< fDTS / 8, 6 samples */
+#define FDIV8_N8	9  /**< fDTS / 8, 8 samples */
+#define FDIV16_N5	10 /**< fDTS / 16, 5 samples */
+#define FDIV16_N6	11 /**< fDTS / 16, 6 samples */
+#define FDIV16_N8	12 /**< fDTS / 16, 8 samples */
+#define FDIV32_N5	13 /**< fDTS / 32, 5 samples */
+#define FDIV32_N6	14 /**< fDTS / 32, 6 samples */
+#define FDIV32_N8	15 /**< fDTS / 32, 8 samples */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_QDEC_STM32_H_ */

--- a/include/zephyr/dt-bindings/sensor/rm3100.h
+++ b/include/zephyr/dt-bindings/sensor/rm3100.h
@@ -5,33 +5,43 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the PNI RM3100 magnetometer.
+ * @ingroup rm3100_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PNI_RM3100_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PNI_RM3100_H_
 
 /**
- * @defgroup RM3100 PNI DT Options
- * @ingroup sensor_interface
+ * @defgroup rm3100_interface RM3100
+ * @ingroup sensor_interface_ext_pni
+ * @brief PNI RM3100 3-axis magnetometer
  * @{
  */
 
 /**
- * @defgroup RM3100_ODR Output data rate options
+ * @name Output data rate options
+ *
+ * Values for the `odr` devicetree property.
  * @{
  */
-#define RM3100_DT_ODR_600	0x92
-#define RM3100_DT_ODR_300	0x93
-#define RM3100_DT_ODR_150	0x94
-#define RM3100_DT_ODR_75	0x95
-#define RM3100_DT_ODR_37_5	0x96
-#define RM3100_DT_ODR_18	0x97
-#define RM3100_DT_ODR_9		0x98
-#define RM3100_DT_ODR_4_5	0x99
-#define RM3100_DT_ODR_2_3	0x9A
-#define RM3100_DT_ODR_1_2	0x9B
-#define RM3100_DT_ODR_0_6	0x9C
-#define RM3100_DT_ODR_0_3	0x9D
-#define RM3100_DT_ODR_0_015	0x9E
-#define RM3100_DT_ODR_0_0075	0x9F
+#define RM3100_DT_ODR_600	0x92 /**< 600 Hz */
+#define RM3100_DT_ODR_300	0x93 /**< 300 Hz */
+#define RM3100_DT_ODR_150	0x94 /**< 150 Hz */
+#define RM3100_DT_ODR_75	0x95 /**< 75 Hz */
+#define RM3100_DT_ODR_37_5	0x96 /**< 37.5 Hz */
+#define RM3100_DT_ODR_18	0x97 /**< 18 Hz */
+#define RM3100_DT_ODR_9		0x98 /**< 9 Hz */
+#define RM3100_DT_ODR_4_5	0x99 /**< 4.5 Hz */
+#define RM3100_DT_ODR_2_3	0x9A /**< 2.3 Hz */
+#define RM3100_DT_ODR_1_2	0x9B /**< 1.2 Hz */
+#define RM3100_DT_ODR_0_6	0x9C /**< 0.6 Hz */
+#define RM3100_DT_ODR_0_3	0x9D /**< 0.3 Hz */
+#define RM3100_DT_ODR_0_015	0x9E /**< 0.015 Hz */
+#define RM3100_DT_ODR_0_0075	0x9F /**< 0.0075 Hz */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/sensor_axis_align.h
+++ b/include/zephyr/dt-bindings/sensor/sensor_axis_align.h
@@ -2,32 +2,44 @@
  * Copyright 2025 CogniPilot Foundation
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for sensor axis alignment.
+ * @ingroup sensor_axis_align_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_AXIS_ALIGN_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_AXIS_ALIGN_H_
 
 /**
- * @defgroup sensor_axis_align Sensor axis alignment DT Options
- * @ingroup sensor_interface
+ * @defgroup sensor_axis_align_interface Sensor axis alignment
+ * @ingroup sensor_interface_ext
+ * @brief Shared constants for remapping sensor axes in the devicetree
  * @{
  */
 
 /**
- * @defgroup sensor_axis_align_index_dt Axis description for sensor alignment
+ * @name Axis index
+ *
+ * Values for the `axis-align-x`, `axis-align-y`, and `axis-align-z` devicetree properties.
  * @{
  */
-#define SENSOR_AXIS_ALIGN_DT_X		0
-#define SENSOR_AXIS_ALIGN_DT_Y		1
-#define SENSOR_AXIS_ALIGN_DT_Z		2
+#define SENSOR_AXIS_ALIGN_DT_X		0 /**< X axis */
+#define SENSOR_AXIS_ALIGN_DT_Y		1 /**< Y axis */
+#define SENSOR_AXIS_ALIGN_DT_Z		2 /**< Z axis */
 /** @} */
 
 /**
- * @defgroup sensor_axis_align_dt Axis description for sensor alignment
+ * @name Axis direction
+ *
+ * Values for the `axis-align-x-sign`, `axis-align-y-sign`, and
+ * `axis-align-z-sign` devicetree properties.
  * @{
  */
-#define SENSOR_AXIS_ALIGN_DT_NEG		0
-#define SENSOR_AXIS_ALIGN_DT_POS		2
+#define SENSOR_AXIS_ALIGN_DT_NEG		0 /**< Negative direction */
+#define SENSOR_AXIS_ALIGN_DT_POS		2 /**< Positive direction */
 /** @} */
-
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/sensor/stcc4.h
+++ b/include/zephyr/dt-bindings/sensor/stcc4.h
@@ -6,15 +6,30 @@
 
 /**
  * @file
- * @brief Devicetree constants for the Sensirion STCC4 CO2 sensor
+ * @brief Devicetree binding constants for the Sensirion STCC4 CO2 sensor.
+ * @ingroup stcc4_interface
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_STCC4_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_STCC4_H_
 
-/** Continuous measurement mode (~1 Hz) */
-#define STCC4_DT_MODE_CONTINUOUS  0
-/** Single-shot measurement mode (on demand, 500ms per measurement) */
-#define STCC4_DT_MODE_SINGLE_SHOT 1
+/**
+ * @defgroup stcc4_interface STCC4
+ * @ingroup sensor_interface_ext_sensirion
+ * @brief Sensirion STCC4 CO2 sensor
+ * @{
+ */
+
+/**
+ * @name Measurement mode
+ *
+ * Values for the `measurement-mode` devicetree property.
+ * @{
+ */
+#define STCC4_DT_MODE_CONTINUOUS  0 /**< Continuous measurement (~1 Hz) */
+#define STCC4_DT_MODE_SINGLE_SHOT 1 /**< Single-shot measurement (500 ms each) */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STCC4_H_ */

--- a/include/zephyr/dt-bindings/sensor/stts22h.h
+++ b/include/zephyr/dt-bindings/sensor/stts22h.h
@@ -3,16 +3,38 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the ST STTS22H temperature sensor.
+ * @ingroup stts22h_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ST_STTS22H_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ST_STTS22H_H_
 
-/* Output Data Rates */
-#define	STTS22H_POWER_DOWN	0x00
-#define	STTS22H_ONE_SHOT	0x01
-#define	STTS22H_1Hz		0x04
-#define	STTS22H_25Hz		0x02
-#define	STTS22H_50Hz		0x12
-#define	STTS22H_100Hz		0x22
-#define	STTS22H_200Hz		0x32
+/**
+ * @defgroup stts22h_interface STTS22H
+ * @ingroup sensor_interface_ext_st
+ * @brief STMicroelectronics STTS22H temperature sensor
+ * @{
+ */
+
+/**
+ * @name Output data rate options
+ *
+ * Values for the `sampling-rate` devicetree property.
+ * @{
+ */
+#define	STTS22H_POWER_DOWN	0x00 /**< Power-down */
+#define	STTS22H_ONE_SHOT	0x01 /**< One-shot conversion */
+#define	STTS22H_1Hz		0x04 /**< 1 Hz */
+#define	STTS22H_25Hz		0x02 /**< 25 Hz */
+#define	STTS22H_50Hz		0x12 /**< 50 Hz */
+#define	STTS22H_100Hz		0x22 /**< 100 Hz */
+#define	STTS22H_200Hz		0x32 /**< 200 Hz */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_STTS22H_H_ */

--- a/include/zephyr/dt-bindings/sensor/tmag5273.h
+++ b/include/zephyr/dt-bindings/sensor/tmag5273.h
@@ -3,87 +3,171 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the TI TMAG5273 3-axis Hall-effect sensor.
+ * @ingroup tmag5273_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_TMAG5273_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_TMAG5273_H_
 
 #include <zephyr/dt-bindings/dt-util.h>
 
-/* Operating Mode */
-#define TMAG5273_DT_OPER_MODE_CONTINUOUS 0
-#define TMAG5273_DT_OPER_MODE_STANDBY    1
+/**
+ * @addtogroup tmag5273_interface
+ * @{
+ */
 
-/* Axis */
-#define TMAG5273_DT_AXIS_NONE 0x0
-#define TMAG5273_DT_AXIS_X    0x1
-#define TMAG5273_DT_AXIS_Y    0x2
-#define TMAG5273_DT_AXIS_Z    0x4
+/**
+ * @name Operating mode
+ *
+ * Values for the `operation-mode` devicetree property.
+ * @{
+ */
+#define TMAG5273_DT_OPER_MODE_CONTINUOUS 0 /**< Continuous conversion */
+#define TMAG5273_DT_OPER_MODE_STANDBY    1 /**< Standby (conversion on request) */
+/** @} */
+
+/**
+ * @name Magnetic axis selection
+ *
+ * Values for the `axis` devicetree property.
+ * @{
+ */
+#define TMAG5273_DT_AXIS_NONE 0x0 /**< No axis */
+#define TMAG5273_DT_AXIS_X    0x1 /**< X axis */
+#define TMAG5273_DT_AXIS_Y    0x2 /**< Y axis */
+#define TMAG5273_DT_AXIS_Z    0x4 /**< Z axis */
+/** X and Y axes */
 #define TMAG5273_DT_AXIS_XY   (TMAG5273_DT_AXIS_X | TMAG5273_DT_AXIS_Y)
+/** X and Z axes */
 #define TMAG5273_DT_AXIS_XZ   (TMAG5273_DT_AXIS_X | TMAG5273_DT_AXIS_Z)
+/** Y and Z axes */
 #define TMAG5273_DT_AXIS_YZ   (TMAG5273_DT_AXIS_Y | TMAG5273_DT_AXIS_Z)
+/** All axes */
 #define TMAG5273_DT_AXIS_XYZ  (TMAG5273_DT_AXIS_X | TMAG5273_DT_AXIS_Y | TMAG5273_DT_AXIS_Z)
-#define TMAG5273_DT_AXIS_XYX  0x8
-#define TMAG5273_DT_AXIS_YXY  0x9
-#define TMAG5273_DT_AXIS_YZY  0xA
-#define TMAG5273_DT_AXIS_XZX  0xB
+#define TMAG5273_DT_AXIS_XYX  0x8 /**< X, Y then X axes */
+#define TMAG5273_DT_AXIS_YXY  0x9 /**< Y, X then Y axes */
+#define TMAG5273_DT_AXIS_YZY  0xA /**< Y, Z then Y axes */
+#define TMAG5273_DT_AXIS_XZX  0xB /**< X, Z then X axes */
+/** @} */
 
-/* Range */
-#define TMAG5273_DT_AXIS_RANGE_LOW     0
-#define TMAG5273_DT_AXIS_RANGE_HIGH    1
-#define TMAG5273_DT_AXIS_RANGE_RUNTIME 2
+/**
+ * @name Magnetic measurement range
+ *
+ * Values for the `range` devicetree property.
+ * @{
+ */
+#define TMAG5273_DT_AXIS_RANGE_LOW     0 /**< Low range */
+#define TMAG5273_DT_AXIS_RANGE_HIGH    1 /**< High range */
+#define TMAG5273_DT_AXIS_RANGE_RUNTIME 2 /**< Range selected at runtime */
+/** @} */
 
-/* Interrupt-Mode */
-#define TMAG5273_DT_INT_THROUGH_INT         0
-#define TMAG5273_DT_INT_THROUGH_INT_EXC_I2C 1
-#define TMAG5273_DT_INT_THROUGH_SCL         2
-#define TMAG5273_DT_INT_THROUGH_SCL_EXC_I2C 3
+/**
+ * @name Interrupt routing mode
+ *
+ * Interrupt routing mode.
+ * @{
+ */
+#define TMAG5273_DT_INT_THROUGH_INT         0 /**< Interrupt through the INT pin */
+#define TMAG5273_DT_INT_THROUGH_INT_EXC_I2C 1 /**< INT pin, except during I2C bus access */
+#define TMAG5273_DT_INT_THROUGH_SCL         2 /**< Interrupt through the SCL pin */
+#define TMAG5273_DT_INT_THROUGH_SCL_EXC_I2C 3 /**< SCL pin, except during I2C bus access */
+/** @} */
 
-/* Threshold crossings */
-#define TMAG5273_DT_THRX_COUNT_1 0
-#define TMAG5273_DT_THRX_COUNT_4 1
+/**
+ * @name Threshold crossing count
+ *
+ * Number of threshold crossings before an interrupt.
+ * @{
+ */
+#define TMAG5273_DT_THRX_COUNT_1 0 /**< Trigger after 1 crossing */
+#define TMAG5273_DT_THRX_COUNT_4 1 /**< Trigger after 4 crossings */
+/** @} */
 
-/* Threshold direction */
-#define TMAG5273_DT_THRX_ABOVE   0
-#define TMAG5273_DT_THRX_BELOW   1
-#define TMAG5273_DT_THRX_OUTSIDE 2
-#define TMAG5273_DT_THRX_INSIDE  3
+/**
+ * @name Threshold crossing direction
+ *
+ * Threshold-crossing direction that triggers an interrupt.
+ * @{
+ */
+#define TMAG5273_DT_THRX_ABOVE   0 /**< Field rises above the threshold */
+#define TMAG5273_DT_THRX_BELOW   1 /**< Field falls below the threshold */
+#define TMAG5273_DT_THRX_OUTSIDE 2 /**< Field leaves the threshold window */
+#define TMAG5273_DT_THRX_INSIDE  3 /**< Field enters the threshold window */
+/** @} */
 
-/* Temperature coefficient */
-#define TMAG5273_DT_TEMP_COEFF_NONE    0
-#define TMAG5273_DT_TEMP_COEFF_NDBFE   1
-#define TMAG5273_DT_TEMP_COEFF_CERAMIC 2
+/**
+ * @name Magnet temperature coefficient
+ *
+ * Values for the `temperature-coefficient` devicetree property.
+ * @{
+ */
+#define TMAG5273_DT_TEMP_COEFF_NONE    0 /**< No compensation */
+#define TMAG5273_DT_TEMP_COEFF_NDBFE   1 /**< NdBFe magnet (0.12 %/°C) */
+#define TMAG5273_DT_TEMP_COEFF_CERAMIC 2 /**< Ceramic magnet (0.2 %/°C) */
+/** @} */
 
-/* Angle/Magnitude calculation */
-#define TMAG5273_DT_ANGLE_MAG_NONE    0
-#define TMAG5273_DT_ANGLE_MAG_XY      1
-#define TMAG5273_DT_ANGLE_MAG_YZ      2
-#define TMAG5273_DT_ANGLE_MAG_XZ      3
-#define TMAG5273_DT_ANGLE_MAG_RUNTIME 4
+/**
+ * @name Angle and magnitude calculation
+ *
+ * Values for the `angle-magnitude-axis` devicetree property.
+ * @{
+ */
+#define TMAG5273_DT_ANGLE_MAG_NONE    0 /**< Disabled */
+#define TMAG5273_DT_ANGLE_MAG_XY      1 /**< From the X and Y axes */
+#define TMAG5273_DT_ANGLE_MAG_YZ      2 /**< From the Y and Z axes */
+#define TMAG5273_DT_ANGLE_MAG_XZ      3 /**< From the X and Z axes */
+#define TMAG5273_DT_ANGLE_MAG_RUNTIME 4 /**< Axis pair selected at runtime */
+/** @} */
 
-/* Channel Magnitude Gain Correction */
-#define TMAG5273_DT_CORRECTION_CH_1 0
-#define TMAG5273_DT_CORRECTION_CH_2 1
+/**
+ * @name Magnitude gain correction channel
+ *
+ * Values for the `ch-mag-gain-correction` devicetree property.
+ * @{
+ */
+#define TMAG5273_DT_CORRECTION_CH_1 0 /**< Apply gain correction to channel 1 */
+#define TMAG5273_DT_CORRECTION_CH_2 1 /**< Apply gain correction to channel 2 */
+/** @} */
 
-/* Averaging */
-#define TMAG5273_DT_AVERAGING_NONE 0
-#define TMAG5273_DT_AVERAGING_2X   1
-#define TMAG5273_DT_AVERAGING_4X   2
-#define TMAG5273_DT_AVERAGING_8X   3
-#define TMAG5273_DT_AVERAGING_16X  4
-#define TMAG5273_DT_AVERAGING_32X  5
+/**
+ * @name Sample averaging
+ *
+ * Values for the `average-mode` devicetree property.
+ * @{
+ */
+#define TMAG5273_DT_AVERAGING_NONE 0 /**< No averaging (1 sample) */
+#define TMAG5273_DT_AVERAGING_2X   1 /**< 2 samples averaged */
+#define TMAG5273_DT_AVERAGING_4X   2 /**< 4 samples averaged */
+#define TMAG5273_DT_AVERAGING_8X   3 /**< 8 samples averaged */
+#define TMAG5273_DT_AVERAGING_16X  4 /**< 16 samples averaged */
+#define TMAG5273_DT_AVERAGING_32X  5 /**< 32 samples averaged */
+/** @} */
 
-/* Sleeptime */
-#define TMAG5273_DT_SLEEPTIME_1MS     0
-#define TMAG5273_DT_SLEEPTIME_5MS     1
-#define TMAG5273_DT_SLEEPTIME_10MS    2
-#define TMAG5273_DT_SLEEPTIME_15MS    3
-#define TMAG5273_DT_SLEEPTIME_20MS    4
-#define TMAG5273_DT_SLEEPTIME_30MS    5
-#define TMAG5273_DT_SLEEPTIME_50MS    6
-#define TMAG5273_DT_SLEEPTIME_100MS   7
-#define TMAG5273_DT_SLEEPTIME_500MS   8
-#define TMAG5273_DT_SLEEPTIME_1000MS  9
-#define TMAG5273_DT_SLEEPTIME_2000MS  10
-#define TMAG5273_DT_SLEEPTIME_5000MS  11
-#define TMAG5273_DT_SLEEPTIME_20000MS 12
+/**
+ * @name Sleep time between conversions
+ *
+ * Sleep time between conversions in standby mode.
+ * @{
+ */
+#define TMAG5273_DT_SLEEPTIME_1MS     0  /**< 1 ms */
+#define TMAG5273_DT_SLEEPTIME_5MS     1  /**< 5 ms */
+#define TMAG5273_DT_SLEEPTIME_10MS    2  /**< 10 ms */
+#define TMAG5273_DT_SLEEPTIME_15MS    3  /**< 15 ms */
+#define TMAG5273_DT_SLEEPTIME_20MS    4  /**< 20 ms */
+#define TMAG5273_DT_SLEEPTIME_30MS    5  /**< 30 ms */
+#define TMAG5273_DT_SLEEPTIME_50MS    6  /**< 50 ms */
+#define TMAG5273_DT_SLEEPTIME_100MS   7  /**< 100 ms */
+#define TMAG5273_DT_SLEEPTIME_500MS   8  /**< 500 ms */
+#define TMAG5273_DT_SLEEPTIME_1000MS  9  /**< 1000 ms */
+#define TMAG5273_DT_SLEEPTIME_2000MS  10 /**< 2000 ms */
+#define TMAG5273_DT_SLEEPTIME_5000MS  11 /**< 5000 ms */
+#define TMAG5273_DT_SLEEPTIME_20000MS 12 /**< 20000 ms */
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_TMAG5273_H_ */

--- a/include/zephyr/dt-bindings/sensor/tmp114.h
+++ b/include/zephyr/dt-bindings/sensor/tmp114.h
@@ -3,27 +3,37 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the TI TMP114 temperature sensor.
+ * @ingroup tmp114_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_TI_TMP114_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_TI_TMP114_H_
 
 /**
- * @defgroup tmp114 Texas Instruments (TI) TMP114 DT Options
- * @ingroup sensor_interface
+ * @defgroup tmp114_interface TMP114
+ * @ingroup sensor_interface_ext_ti
+ * @brief Texas Instruments TMP114 temperature sensor
  * @{
  */
 
 /**
- * @defgroup tmp114_odr Temperature output data rate
+ * @name Output data rate options
+ *
+ * Values for the `odr` devicetree property.
  * @{
  */
-#define TMP114_DT_ODR_6_4_MS   0
-#define TMP114_DT_ODR_31_25_MS 1
-#define TMP114_DT_ODR_62_5_MS  2
-#define TMP114_DT_ODR_125_MS   3
-#define TMP114_DT_ODR_250_MS   4
-#define TMP114_DT_ODR_500_MS   5
-#define TMP114_DT_ODR_1000_MS  6
-#define TMP114_DT_ODR_2000_MS  7
+#define TMP114_DT_ODR_6_4_MS   0 /**< 6.4 ms */
+#define TMP114_DT_ODR_31_25_MS 1 /**< 31.25 ms */
+#define TMP114_DT_ODR_62_5_MS  2 /**< 62.5 ms */
+#define TMP114_DT_ODR_125_MS   3 /**< 125 ms */
+#define TMP114_DT_ODR_250_MS   4 /**< 250 ms */
+#define TMP114_DT_ODR_500_MS   5 /**< 500 ms */
+#define TMP114_DT_ODR_1000_MS  6 /**< 1000 ms */
+#define TMP114_DT_ODR_2000_MS  7 /**< 2000 ms */
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/sensor/tmp11x.h
+++ b/include/zephyr/dt-bindings/sensor/tmp11x.h
@@ -3,37 +3,47 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the TI TMP11x temperature sensors.
+ * @ingroup tmp11x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_TI_TMP11X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_TI_TMP11X_H_
 
 /**
- * @defgroup tmp11x Texas Instruments (TI) TMP11X DT Options
- * @ingroup sensor_interface
+ * @addtogroup tmp11x_interface
  * @{
  */
 
 /**
- * @defgroup tmp11x_odr Temperature output data rate
+ * @name Output data rate options
+ *
+ * Values for the `odr` devicetree property.
  * @{
  */
-#define TMP11X_DT_ODR_15_5_MS  0
-#define TMP11X_DT_ODR_125_MS   0x80
-#define TMP11X_DT_ODR_250_MS   0x100
-#define TMP11X_DT_ODR_500_MS   0x180
-#define TMP11X_DT_ODR_1000_MS  0x200
-#define TMP11X_DT_ODR_4000_MS  0x280
-#define TMP11X_DT_ODR_8000_MS  0x300
-#define TMP11X_DT_ODR_16000_MS 0x380
+#define TMP11X_DT_ODR_15_5_MS  0     /**< 15.5 ms */
+#define TMP11X_DT_ODR_125_MS   0x80  /**< 125 ms */
+#define TMP11X_DT_ODR_250_MS   0x100 /**< 250 ms */
+#define TMP11X_DT_ODR_500_MS   0x180 /**< 500 ms */
+#define TMP11X_DT_ODR_1000_MS  0x200 /**< 1000 ms */
+#define TMP11X_DT_ODR_4000_MS  0x280 /**< 4000 ms */
+#define TMP11X_DT_ODR_8000_MS  0x300 /**< 8000 ms */
+#define TMP11X_DT_ODR_16000_MS 0x380 /**< 16000 ms */
 /** @} */
 
 /**
- * @defgroup tmp11x_os Temperature average sample count
+ * @name Averaging (oversampling) options
+ *
+ * Values for the `oversampling` devicetree property.
  * @{
  */
-#define TMP11X_DT_OVERSAMPLING_1  0
-#define TMP11X_DT_OVERSAMPLING_8  0x20
-#define TMP11X_DT_OVERSAMPLING_32 0x40
-#define TMP11X_DT_OVERSAMPLING_64 0x60
+#define TMP11X_DT_OVERSAMPLING_1  0    /**< 1 conversion averaged */
+#define TMP11X_DT_OVERSAMPLING_8  0x20 /**< 8 conversions averaged */
+#define TMP11X_DT_OVERSAMPLING_32 0x40 /**< 32 conversions averaged */
+#define TMP11X_DT_OVERSAMPLING_64 0x60 /**< 64 conversions averaged */
 /** @} */
 
 /** @} */


### PR DESCRIPTION
Enhanced documentation for sensor devicetree bindings by grouping everyting under the existing sensor_interface_ext group and adding groups/descriptions for the different constants used to configure the bindings.

* https://builds.zephyrproject.io/zephyr/pr/111300/docs/doxygen/html/group__sensor__interface__ext.html
* https://builds.zephyrproject.io/zephyr/pr/111300/api-coverage/zephyr/dt-bindings/sensor/index.html