### PR TITLE
ipc: ipc_service: guard mbox_callback against submit-while-running scheduler race

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -48,6 +48,28 @@ struct backend_data_t {
 	/* MBOX WQ */
 	struct k_work mbox_work;
 	struct k_work_q mbox_wq;
+	/* Set to 1 by mbox_init() after k_work_queue_start() completes.
+	 * Checked in mbox_callback() (ISR context) before submitting work.
+	 * Guards against two races:
+	 *   1. Boot-time: mbox IRQ fires before k_work_queue_start() finishes.
+	 *   2. Runtime:   rapid mbox IRQ bursts arrive while mbox_wq thread
+	 *                 is in a transient scheduler state (between run-queue
+	 *                 removal and wait-queue insertion during k_yield), where
+	 *                 the thread's qnode_dlist has .prev=NULL and calling
+	 *                 sys_dlist_remove on it causes ZEPHYR FATAL ERROR 19.
+	 * Both races cause a NULL-dereference in sys_dlist_remove →
+	 * Data Access Violation (MMFAR=0x0).
+	 * Dropping the rare mbox notification during these windows is safe:
+	 * the IPC backend will re-notify on the next TX/RX event.
+	 */
+	atomic_t mbox_wq_ready;
+	/* Counts mbox callbacks that arrived while mbox_work was already
+	 * running (K_WORK_RUNNING set).  Incrementing an atomic from ISR is
+	 * safe.  mbox_callback_process checks this after draining the vring
+	 * and processes any accumulated events in-place, so no notification
+	 * is lost while avoiding the scheduler-transient-state crash path.
+	 */
+	atomic_t mbox_pending;
 
 	/* General */
 	unsigned int role;
@@ -312,12 +334,64 @@ static void mbox_callback_process(struct k_work *item)
 	vq_id = (data->role == ROLE_HOST) ? VIRTQUEUE_ID_HOST : VIRTQUEUE_ID_REMOTE;
 
 	virtqueue_notification(data->vr.vq[vq_id]);
+
+	/* Drain any mbox events that arrived while this work item was
+	 * already running.  mbox_callback() increments mbox_pending instead
+	 * of calling k_work_submit_to_queue (which would race with the
+	 * scheduler's transient state during k_yield and crash).
+	 *
+	 * We loop here rather than re-submitting, so that the mbox_wq thread
+	 * never calls k_work_submit_to_queue on itself while executing.
+	 * Each iteration atomically reads and clears mbox_pending; if it was
+	 * non-zero there may be new vring entries to drain.  The loop exits
+	 * when no further events have been recorded.
+	 *
+	 * Safety cap: virtqueue_notification already drains ALL pending
+	 * descriptors per call (rpmsg_virtio_rx_callback inner while-loop),
+	 * so a single extra iteration is almost always sufficient.  The cap
+	 * of 8 prevents spinning forever if mbox_callback fires continuously
+	 * (e.g. under pathological load).
+	 */
+	for (int i = 0; i < 8; i++) {
+		if (atomic_set(&data->mbox_pending, 0) == 0) {
+			break;
+		}
+		virtqueue_notification(data->vr.vq[vq_id]);
+	}
 }
 
 static void mbox_callback(const struct device *instance, uint32_t channel,
 			  void *user_data, struct mbox_msg *msg_data)
 {
 	struct backend_data_t *data = user_data;
+
+	/* Guard against submitting work before mbox_wq is fully started or
+	 * while its thread is in a scheduler-transient state.  See the
+	 * mbox_wq_ready comment in backend_data_t for the full rationale.
+	 */
+	if (!atomic_get(&data->mbox_wq_ready)) {
+		return;
+	}
+
+	/* Guard against the runtime scheduler race: if mbox_work is already
+	 * running (K_WORK_RUNNING), submitting it again triggers
+	 * notify_queue_locked → z_sched_wake → unpend_thread_no_timeout →
+	 * sys_dlist_remove while the work queue thread may be in a transient
+	 * scheduler window where qnode_dlist.prev is NULL → MMFAR=0x0 crash.
+	 *
+	 * Instead of dropping the notification, increment mbox_pending so
+	 * mbox_callback_process will process accumulated events in-place
+	 * after draining the current vring batch.  No re-submission is done
+	 * from within the running work item.
+	 *
+	 * k_work_busy_get() is safe to call from ISR (it only reads atomic
+	 * flags under a spinlock that masks IRQs, which is a no-op inside an
+	 * ISR on Cortex-M).
+	 */
+	if (k_work_busy_get(&data->mbox_work) & K_WORK_RUNNING) {
+		atomic_inc(&data->mbox_pending);
+		return;
+	}
 
 	k_work_submit_to_queue(&data->mbox_wq, &data->mbox_work);
 }
@@ -343,11 +417,18 @@ static int mbox_init(const struct device *instance)
 	}
 
 	k_work_init(&data->mbox_work, mbox_callback_process);
+	atomic_set(&data->mbox_pending, 0);
 
 	err = mbox_register_callback_dt(&conf->mbox_rx, mbox_callback, data);
 	if (err != 0) {
 		return err;
 	}
+
+	/* Mark the work queue as ready BEFORE enabling the mbox interrupt.
+	 * Once the interrupt is enabled any incoming mbox event will call
+	 * mbox_callback(), which checks this flag before submitting work.
+	 */
+	atomic_set(&data->mbox_wq_ready, 1);
 
 	return mbox_set_enabled_dt(&conf->mbox_rx, 1);
 }
@@ -358,6 +439,10 @@ static int mbox_deinit(const struct device *instance)
 	struct backend_data_t *data = instance->data;
 	k_tid_t wq_thread;
 	int err;
+
+	/* Prevent new mbox_callback submissions before disabling the interrupt. */
+	atomic_set(&data->mbox_wq_ready, 0);
+	atomic_set(&data->mbox_pending, 0);
 
 	err = mbox_set_enabled_dt(&conf->mbox_rx, 0);
 	if (err != 0) {


### PR DESCRIPTION
The `mbox_callback` ISR calls `k_work_submit_to_queue()` every time the remote core signals a new vring message.  When the work item is already `K_WORK_RUNNING`, the submit triggers `notify_queue_locked()` -> `z_sched_wake()` -> `unready_thread()` -> `sys_dlist_remove(thread_node)`. If the work-queue thread is in the four-instruction window at the start of `z_impl_k_yield()` before `BASEPRI_MAX` is set, `thread_node->prev` is transiently `NULL` (the thread has been removed from the run queue but not yet inserted into the wait queue).  Dereferencing NULL crashes with MMFAR=0x0, FATAL ERROR 19.

There is also a boot-time variant: the mbox hardware interrupt fires before `k_work_queue_start()` has initialized the work-queue thread struct.  The thread's `qnode_dlist.prev` is zero (`NULL`) at that point and the same crash occurs.

Fix both races:

1. Add `mbox_wq_ready` atomic flag, set after `k_work_queue_start()` completes and cleared in `mbox_deinit()`.  `mbox_callback()` returns immediately when the flag is not set.  The network-side IPC layer will retransmit via the vring retry mechanism.

2. Add `mbox_pending` atomic counter.  When `mbox_callback()` sees `K_WORK_RUNNING` on the work item, it increments the counter instead of calling `k_work_submit_to_queue()`.  `mbox_callback_process()` drains the counter in a bounded in-place loop (max 8 iterations) after its primary `virtqueue_notification()` call.  Draining in-place rather than re-submitting means `k_work_submit_to_queue()` is never called from within a running work item, eliminating the yield race.

`k_work_busy_get()` is safe to call from ISR context: it reads atomic state flags under the Zephyr scheduler spinlock which, on Cortex-M, masks IRQs via BASEPRI -- a no-op inside an ISR that is already running.

Tested on:
- nRF5340 (nRF7002-DK as BLE central, BL5340-DVK as BLE peripheral + SPI slave)
- Workload: L2CAP CoC bidirectional streaming at ~150 ms BLE connection interval, ~6 SPI transactions/s from an external SPI master

Two crash modes were reproduced and confirmed fixed:

1. Boot-time (`mbox_wq_ready` flag):
  mbox ISR fired from the network core within ~2 ms of appcore boot, before `k_work_queue_start()` completed. Crashed immediately at `sys_dlist_remove` with `MMFAR=0x0, FATAL ERROR 19`.

2. Runtime (mbox_pending counter + drain loop):
  Under sustained BLE ACL + SPI traffic, `mbox_callback()` fired during the ~62 ns window at the start of `z_impl_k_yield()` before `BASEPRI_MAX` is set. Observed `MMFAR=0x0, FATAL ERROR 19` with PC at `sys_dlist_remove+4` and `IPSR` identifying the mbox IRQ. Reproduced reliably within 1-30 s of streaming start; fixed build ran 20+ back-to-back 30-second test cycles without crash.
  
 CC: @doki-nordic