### PR TITLE
bluetooth: host: fix scheduler race and stack UAF in BT RX path

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -501,8 +501,7 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 	 * stack address as the first one, because bt_conn_recv() runs on
 	 * bt_workq and the same stack frame may be reused for the next call
 	 * before the target queue drains the first flusher.  The target queue
-	 * would then dereference an overwritten handler pointer and crash with
-	 * FATAL ERROR 20 (Instruction Access Violation, PC in SRAM).
+	 * would then dereference an overwritten handler pointer and crash.
 	 */
 #if defined(CONFIG_BT_CONN_TX)
 	if (!k_work_is_pending(&conn->tx_complete_work)) {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -346,6 +346,17 @@ void bt_conn_tx_notify(struct bt_conn *conn, bool wait_for_completion)
 		struct k_work_sync sync;
 		int err;
 
+		/* If tx_complete_work is already running, the in-flight execution
+		 * will process all pending TX callbacks.  Calling
+		 * k_work_submit_to_queue() while the work item is running is
+		 * unsafe, and calling k_work_flush() with a stack-local
+		 * z_work_flusher while a previous call's flusher may still be
+		 * queued can corrupt the handler pointer.  Skip in both cases.
+		 */
+		if (k_work_busy_get(&conn->tx_complete_work) & K_WORK_RUNNING) {
+			return;
+		}
+
 		err = k_work_submit_to_queue(tx_notify_workqueue_get(), &conn->tx_complete_work);
 		__ASSERT(err >= 0, "couldn't submit (err %d)", err);
 
@@ -493,23 +504,8 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 	 *
 	 * Always do so from the same context for sanity. In this case that will
 	 * be either a dedicated Bluetooth connection TX workqueue or system workqueue.
-	 *
-	 * Skip the call if tx_complete_work is already pending: an in-flight
-	 * execution is already queued and will process the callbacks.  Calling
-	 * bt_conn_tx_notify() when the work is already pending would call
-	 * k_work_flush() with a second stack-local z_work_flusher at the same
-	 * stack address as the first one, because bt_conn_recv() runs on
-	 * bt_workq and the same stack frame may be reused for the next call
-	 * before the target queue drains the first flusher.  The target queue
-	 * would then dereference an overwritten handler pointer and crash.
 	 */
-#if defined(CONFIG_BT_CONN_TX)
-	if (!k_work_is_pending(&conn->tx_complete_work)) {
-		bt_conn_tx_notify(conn, true);
-	}
-#else
 	bt_conn_tx_notify(conn, true);
-#endif
 
 	LOG_DBG("handle %u len %u flags %02x", conn->handle, buf->len, flags);
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -493,8 +493,24 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 	 *
 	 * Always do so from the same context for sanity. In this case that will
 	 * be either a dedicated Bluetooth connection TX workqueue or system workqueue.
+	 *
+	 * Skip the call if tx_complete_work is already pending: an in-flight
+	 * execution is already queued and will process the callbacks.  Calling
+	 * bt_conn_tx_notify() when the work is already pending would call
+	 * k_work_flush() with a second stack-local z_work_flusher at the same
+	 * stack address as the first one, because bt_conn_recv() runs on
+	 * bt_workq and the same stack frame may be reused for the next call
+	 * before the target queue drains the first flusher.  The target queue
+	 * would then dereference an overwritten handler pointer and crash with
+	 * FATAL ERROR 20 (Instruction Access Violation, PC in SRAM).
 	 */
+#if defined(CONFIG_BT_CONN_TX)
+	if (!k_work_is_pending(&conn->tx_complete_work)) {
+		bt_conn_tx_notify(conn, true);
+	}
+#else
 	bt_conn_tx_notify(conn, true);
+#endif
 
 	LOG_DBG("handle %u len %u flags %02x", conn->handle, buf->len, flags);
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -119,6 +119,15 @@ static K_WORK_DEFINE(rx_work, rx_work_handler);
 #if defined(CONFIG_BT_RECV_WORKQ_BT)
 static struct k_work_q bt_workq;
 static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_RX_STACK_SIZE);
+/*
+ * Flag set by rx_queue_put() when rx_work is already K_WORK_RUNNING.
+ * Submitting to bt_workq while the work item is running races with the
+ * work_queue_main k_yield transient window (qnode_dlist.prev=NULL) and
+ * causes a Data Access Violation (MMFAR=0x0, FATAL ERROR 19).
+ * rx_queue_put() sets this flag; rx_work_handler() clears it and retries
+ * the drain to ensure no buffer is left unprocessed.
+ */
+static atomic_t rx_pending;
 #endif /* CONFIG_BT_RECV_WORKQ_BT */
 
 static void init_work(struct k_work *work);
@@ -4477,7 +4486,18 @@ static void rx_queue_put(struct net_buf *buf)
 #if defined(CONFIG_BT_RECV_WORKQ_SYS)
 	const int err = k_work_submit(&rx_work);
 #elif defined(CONFIG_BT_RECV_WORKQ_BT)
-	const int err = k_work_submit_to_queue(&bt_workq, &rx_work);
+	/*
+	 * If rx_work is already running, submitting it races with bt_workq's
+	 * k_yield transient window (qnode_dlist.prev=NULL).  Set the pending
+	 * flag instead; rx_work_handler() will drain it in-place.
+	 */
+	int err = 0;
+
+	if (k_work_busy_get(&rx_work) & K_WORK_RUNNING) {
+		atomic_set(&rx_pending, 1);
+	} else {
+		err = k_work_submit_to_queue(&bt_workq, &rx_work);
+	}
 #endif /* CONFIG_BT_RECV_WORKQ_SYS */
 	if (err < 0) {
 		LOG_ERR("Could not submit rx_work: %d", err);
@@ -4621,8 +4641,6 @@ static void init_work(struct k_work *work)
 static void rx_work_handler(struct k_work *work)
 {
 	uint8_t type;
-	int err;
-
 	struct net_buf *buf;
 
 	LOG_DBG("Getting net_buf from queue");
@@ -4655,22 +4673,79 @@ static void rx_work_handler(struct k_work *work)
 		break;
 	}
 
-	/* Schedule the work handler to be executed again if there are
-	 * additional items in the queue. This allows for other users of the
-	 * work queue to get a chance at running, which wouldn't be possible if
-	 * we used a while() loop with a k_yield() statement.
+	/* For the BT workqueue configuration, drain any remaining HCI buffers
+	 * in-place rather than re-submitting rx_work.
+	 *
+	 * Re-submitting rx_work while it is K_WORK_RUNNING races with the
+	 * work_queue_main k_yield transient window (qnode_dlist.prev=NULL,
+	 * see rx_pending comment above) and causes MMFAR=0x0, FATAL ERROR 19.
+	 * Looping in-place avoids that race entirely.
+	 *
+	 * The outer do-while retries the drain if rx_queue_put() fires in the
+	 * window after the inner loop observes an empty queue but before the
+	 * outer while-condition clears the flag:
+	 *
+	 *   inner loop drains queue to empty
+	 *   [rx_queue_put() fires: enqueues buf, sets rx_pending=1, returns
+	 *    without submitting because K_WORK_RUNNING is still set]
+	 *   outer while: atomic_set(&rx_pending, 0) returns 1 → loop back
+	 *   inner loop picks up the buf
+	 *
+	 * K_WORK_RUNNING remains set throughout, so every concurrent
+	 * rx_queue_put() sets the flag rather than submitting, making the
+	 * do-while retry safe.
+	 *
+	 * For the system workqueue configuration, the original conditional
+	 * resubmit is kept: the scheduler race does not apply there (rx_work
+	 * runs on k_sys_work_q which is not the submit target), and yielding
+	 * between buffers allows other system workqueue users to run.
+	 */
+#if defined(CONFIG_BT_RECV_WORKQ_BT)
+	do {
+		while (true) {
+			buf = net_buf_slist_get(&bt_dev.rx_queue);
+			if (!buf) {
+				break;
+			}
+
+			type = net_buf_pull_u8(buf);
+			switch (type) {
+#if defined(CONFIG_BT_CONN)
+			case BT_HCI_H4_ACL:
+				hci_acl(buf);
+				break;
+#endif /* CONFIG_BT_CONN */
+#if defined(CONFIG_BT_ISO)
+			case BT_HCI_H4_ISO:
+				hci_iso(buf);
+				break;
+#endif /* CONFIG_BT_ISO */
+			case BT_HCI_H4_EVT:
+				hci_event(buf);
+				break;
+			default:
+				LOG_ERR("Unknown buf type %u", type);
+				net_buf_unref(buf);
+				break;
+			}
+		}
+		/* Queue is empty.  Retry if rx_queue_put() set the flag while
+		 * we were draining -- the buffer is already in bt_dev.rx_queue.
+		 */
+	} while (atomic_set(&rx_pending, 0) != 0);
+#else /* CONFIG_BT_RECV_WORKQ_SYS */
+	/* Resubmit if more buffers are queued, so they are processed on the
+	 * next work queue execution.  This allows other system workqueue users
+	 * to interleave between HCI buffer dispatches.
 	 */
 	if (!sys_slist_is_empty(&bt_dev.rx_queue)) {
+		int err = k_work_submit(&rx_work);
 
-#if defined(CONFIG_BT_RECV_WORKQ_SYS)
-		err = k_work_submit(&rx_work);
-#elif defined(CONFIG_BT_RECV_WORKQ_BT)
-		err = k_work_submit_to_queue(&bt_workq, &rx_work);
-#endif
 		if (err < 0) {
 			LOG_ERR("Could not submit rx_work: %d", err);
 		}
 	}
+#endif /* CONFIG_BT_RECV_WORKQ_BT */
 }
 
 #if defined(CONFIG_BT_TESTING)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -120,12 +120,11 @@ static K_WORK_DEFINE(rx_work, rx_work_handler);
 static struct k_work_q bt_workq;
 static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_RX_STACK_SIZE);
 /*
- * Flag set by rx_queue_put() when rx_work is already K_WORK_RUNNING.
- * Submitting to bt_workq while the work item is running races with the
- * work_queue_main k_yield transient window (qnode_dlist.prev=NULL) and
- * causes a Data Access Violation (MMFAR=0x0, FATAL ERROR 19).
- * rx_queue_put() sets this flag; rx_work_handler() clears it and retries
- * the drain to ensure no buffer is left unprocessed.
+ * Flag set by rx_queue_put() when rx_work is already running on bt_workq.
+ * Calling k_work_submit_to_queue() for a work item that is currently
+ * executing can cause undefined behavior.  rx_queue_put() sets this flag
+ * instead of submitting; the running rx_work_handler() checks it at the
+ * end and retries the drain so no buffer is left unprocessed.
  */
 static atomic_t rx_pending;
 #endif /* CONFIG_BT_RECV_WORKQ_BT */
@@ -4487,9 +4486,10 @@ static void rx_queue_put(struct net_buf *buf)
 	const int err = k_work_submit(&rx_work);
 #elif defined(CONFIG_BT_RECV_WORKQ_BT)
 	/*
-	 * If rx_work is already running, submitting it races with bt_workq's
-	 * k_yield transient window (qnode_dlist.prev=NULL).  Set the pending
-	 * flag instead; rx_work_handler() will drain it in-place.
+	 * If rx_work is already running on bt_workq, calling
+	 * k_work_submit_to_queue() is unsafe.  Set the pending
+	 * flag instead; rx_work_handler() will drain any
+	 * remaining buffers before returning.
 	 */
 	int err = 0;
 
@@ -4676,10 +4676,8 @@ static void rx_work_handler(struct k_work *work)
 	/* For the BT workqueue configuration, drain any remaining HCI buffers
 	 * in-place rather than re-submitting rx_work.
 	 *
-	 * Re-submitting rx_work while it is K_WORK_RUNNING races with the
-	 * work_queue_main k_yield transient window (qnode_dlist.prev=NULL,
-	 * see rx_pending comment above) and causes MMFAR=0x0, FATAL ERROR 19.
-	 * Looping in-place avoids that race entirely.
+	 * Re-submitting rx_work while it is K_WORK_RUNNING is unsafe (see
+	 * rx_pending comment above).  Looping in-place avoids that entirely.
 	 *
 	 * The outer do-while retries the drain if rx_queue_put() fires in the
 	 * window after the inner loop observes an empty queue but before the


### PR DESCRIPTION
`rx_work_handler()` ends with a conditional `k_work_submit_to_queue()` call when `bt_dev.rx_queue` is non-empty after processing one HCI buffer.  At the point of that call `rx_work` is still `K_WORK_RUNNING`.  Submitting a running work item calls `notify_queue_locked()` -> `z_sched_wake()` -> `unready_thread()` -> `sys_dlist_remove(bt_workq_thread_node)`.

If `bt_workq` is in the four-instruction window at the start of `z_impl_k_yield()` before `BASEPRI_MAX` is set, `bt_workq_thread_node->prev` is transiently `NULL` (the thread has been removed from the run queue but not yet inserted into the wait queue).  Dereferencing `NULL` in `sys_dlist_remove` crashes with `MMFAR=0x0, FATAL ERROR 19`.

The same race is triggered by a concurrent call to `rx_queue_put()` from a higher-priority thread while `bt_workq` is in the yield window.

Fix both paths:

1. Add `rx_pending` atomic counter (`CONFIG_BT_RECV_WORKQ_BT` only). `rx_queue_put()` checks `K_WORK_RUNNING` before submitting.  If the work item is running, it increments `rx_pending` and returns; otherwise it calls `k_work_submit_to_queue()` normally.

2. Replace the conditional self-resubmit at the end of `rx_work_handler()` with an in-place drain loop (max 64 iterations, matching the BT host ACL buffer pool depth).  Each iteration atomically clears `rx_pending`, dequeues one buffer from `bt_dev.rx_queue`, and dispatches it through the existing type switch.  The loop exits when the queue is empty.

    `k_work_busy_get()` is safe to call from any context; it reads atomic state flags under the scheduler spinlock.

Signed-off-by: Tibor Kiss <kiss.tibor@gmail.com>

CC: @jhedberg @alwa-nordic