### PR TITLE
boards: shield: correct PLLSAI config for stm32f769i_disco panel

### DIFF
--- a/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32f769i_disco.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32f769i_disco.overlay
@@ -15,8 +15,8 @@
 &pllsai {
 	div-m = <25>;
 	mul-n = <384>;
-	div-r = <5>;
-	post-div-r = <8>;
+	div-r = <7>;
+	post-div-r = <2>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };


### PR DESCRIPTION
Correct the ratio of PLLSAI pll used to control the LTDC. Previous settings were leading to a LTDC clock too small leading to artifacts on the display.  Adjust to settings allowing to reach LTDC pixel clock of 27MHz, allowing having clean display on the panel.