### PR TITLE
Adds Allwinner Security ID (SID) eFuse and HWINFO driver support

### DIFF
--- a/drivers/hwinfo/CMakeLists.txt
+++ b/drivers/hwinfo/CMakeLists.txt
@@ -54,4 +54,5 @@ zephyr_library_sources_ifdef(CONFIG_HWINFO_SAM_RSTC hwinfo_sam_rstc.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_SILABS_S2 hwinfo_silabs_series2.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_SMARTBOND hwinfo_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_STM32 hwinfo_stm32.c)
+zephyr_library_sources_ifdef(CONFIG_HWINFO_SUNXI hwinfo_sunxi.c)
 # zephyr-keep-sorted-stop

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -62,6 +62,7 @@ rsource "Kconfig.sam_rstc"
 rsource "Kconfig.silabs_series2"
 rsource "Kconfig.smartbond"
 rsource "Kconfig.stm32"
+rsource "Kconfig.sunxi"
 # zephyr-keep-sorted-stop
 
 endif

--- a/drivers/hwinfo/Kconfig.sunxi
+++ b/drivers/hwinfo/Kconfig.sunxi
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Khai Do
+# SPDX-License-Identifier: Apache-2.0
+
+config HWINFO_SUNXI
+	bool "Allwinner sunXi hwinfo driver"
+	default y
+	depends on SOC_SUN50I_H618
+	select HWINFO_HAS_DRIVER
+	select OTP
+	select OTP_SUNXI
+	help
+	  Enable Allwinner sunXi hwinfo driver.

--- a/drivers/hwinfo/hwinfo_sunxi.c
+++ b/drivers/hwinfo/hwinfo_sunxi.c
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Khai Do
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/drivers/otp.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/util.h>
+#include <string.h>
+#include <errno.h>
+
+#define CHIP_ID_LENGTH 16
+
+ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+{
+	const struct device *efuse = DEVICE_DT_GET(DT_NODELABEL(sid));
+	uint8_t id[CHIP_ID_LENGTH];
+	int err;
+
+	if (!device_is_ready(efuse)) {
+		return -ENODEV;
+	}
+
+	/* Read 128-bit Chip ID from offset 0x00 of eFuse */
+	err = otp_read(efuse, 0x00, id, sizeof(id));
+	if (err != 0) {
+		return err;
+	}
+
+	length = MIN(length, sizeof(id));
+	memcpy(buffer, id, length);
+
+	return length;
+}

--- a/drivers/otp/CMakeLists.txt
+++ b/drivers/otp/CMakeLists.txt
@@ -11,4 +11,5 @@ zephyr_library_sources_ifdef(CONFIG_OTP_NXP_RT7XX_OCOTP otp_nxp_rt7xx_ocotp.c)
 zephyr_library_sources_ifdef(CONFIG_OTP_SIFLI_EFUSE otp_sifli_efuse.c)
 zephyr_library_sources_ifdef(CONFIG_OTP_STM32_BSEC otp_bsec_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_OTP_STM32_NVM otp_nvm_stm32.c)
+zephyr_library_sources_ifdef(CONFIG_OTP_SUNXI otp_sunxi.c)
 # zephyr-keep-sorted-stop

--- a/drivers/otp/Kconfig
+++ b/drivers/otp/Kconfig
@@ -25,6 +25,7 @@ source "drivers/otp/Kconfig.mcux_ocotp"
 source "drivers/otp/Kconfig.nxp_rt7xx_ocotp"
 source "drivers/otp/Kconfig.sifli"
 source "drivers/otp/Kconfig.stm32"
+source "drivers/otp/Kconfig.sunxi"
 # zephyr-keep-sorted-stop
 
 config OTP_INIT_PRIORITY

--- a/drivers/otp/Kconfig.sunxi
+++ b/drivers/otp/Kconfig.sunxi
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Khai Do
+# SPDX-License-Identifier: Apache-2.0
+
+config OTP_SUNXI
+	bool "Allwinner sunXi SID/eFuse driver"
+	default y
+	depends on DT_HAS_ALLWINNER_SUNXI_SID_ENABLED
+	help
+	  Enable Allwinner sunXi Security ID (SID) eFuse driver.

--- a/drivers/otp/otp_sunxi.c
+++ b/drivers/otp/otp_sunxi.c
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Khai Do
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT allwinner_sunxi_sid
+
+#include <zephyr/drivers/otp.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/sys_io.h>
+#include <string.h>
+#include <errno.h>
+
+#define SIDC_PRCTL      0x40
+#define SIDC_RDKEY      0x60
+#define SIDC_OP_LOCK    0xAC
+
+#define SIDC_PRCTL_OFFSET_MASK   GENMASK(24, 16)
+#define SIDC_PRCTL_LOCK_MASK     GENMASK(15, 8)
+#define SIDC_PRCTL_OP_MASK       GENMASK(1, 0)
+#define SIDC_PRCTL_READ          BIT(1)
+
+/* 1 ms timeout limit for polling loop */
+#define EFUSE_TIMEOUT_US 1000
+
+struct otp_sunxi_config {
+	uintptr_t base;
+	size_t size;
+};
+
+static int sun8i_efuse_read(uintptr_t base, uint32_t offset, uint32_t *val)
+{
+	uint32_t reg_val;
+	uint32_t timeout = EFUSE_TIMEOUT_US;
+
+	reg_val = sys_read32(base + SIDC_PRCTL);
+	reg_val &= ~(SIDC_PRCTL_OFFSET_MASK | SIDC_PRCTL_OP_MASK);
+	reg_val |= FIELD_PREP(SIDC_PRCTL_OFFSET_MASK, offset);
+	sys_write32(reg_val, base + SIDC_PRCTL);
+
+	/* Lock access using SIDC_OP_LOCK (0xAC) and trigger register-based read (0x2) */
+	reg_val &= ~(SIDC_PRCTL_LOCK_MASK | SIDC_PRCTL_OP_MASK);
+	reg_val |= FIELD_PREP(SIDC_PRCTL_LOCK_MASK, SIDC_OP_LOCK) | SIDC_PRCTL_READ;
+	sys_write32(reg_val, base + SIDC_PRCTL);
+
+	/* Poll until the read bit (0x2) is cleared by hardware */
+	while (sys_read32(base + SIDC_PRCTL) & SIDC_PRCTL_READ) {
+		if (timeout-- == 0) {
+			return -ETIMEDOUT;
+		}
+		k_busy_wait(1);
+	}
+
+	reg_val &= ~(SIDC_PRCTL_OFFSET_MASK | SIDC_PRCTL_LOCK_MASK | SIDC_PRCTL_OP_MASK);
+	sys_write32(reg_val, base + SIDC_PRCTL);
+
+	*val = sys_read32(base + SIDC_RDKEY);
+
+	return 0;
+}
+
+static int otp_sunxi_read(const struct device *dev, off_t offset, void *out, size_t len)
+{
+	const struct otp_sunxi_config *config = dev->config;
+	uint8_t *buf = (uint8_t *)out;
+	int err;
+
+	if (len == 0) {
+		return 0;
+	}
+
+	if (out == NULL || offset < 0) {
+		return -EINVAL;
+	}
+
+	if (offset + len > config->size) {
+		return -EINVAL;
+	}
+
+	/* eFuse hardware can only be read in 4-byte word alignments */
+	uint32_t start_offset = offset;
+	uint32_t end_offset = offset + len;
+
+	for (uint32_t off = ROUND_DOWN(start_offset, 4); off < end_offset; off += 4) {
+		uint32_t word = 0;
+
+		err = sun8i_efuse_read(config->base, off, &word);
+		if (err < 0) {
+			return err;
+		}
+		for (uint32_t i = 0; i < 4; i++) {
+			uint32_t byte_pos = off + i;
+
+			if (byte_pos >= start_offset && byte_pos < end_offset) {
+				buf[byte_pos - start_offset] = (uint8_t)(word >> (i * 8));
+			}
+		}
+	}
+
+	return 0;
+}
+
+static DEVICE_API(otp, otp_sunxi_api) = {
+	.read = otp_sunxi_read,
+};
+
+#define OTP_SUNXI_INIT(inst) \
+	static const struct otp_sunxi_config otp_config_##inst = { \
+		.base = DT_INST_REG_ADDR(inst), \
+		.size = DT_INST_PROP(inst, size), \
+	}; \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, \
+			      &otp_config_##inst, POST_KERNEL, \
+			      CONFIG_OTP_INIT_PRIORITY, &otp_sunxi_api);
+
+DT_INST_FOREACH_STATUS_OKAY(OTP_SUNXI_INIT)

--- a/dts/arm64/allwinner/sun50i-h618.dtsi
+++ b/dts/arm64/allwinner/sun50i-h618.dtsi
@@ -70,5 +70,12 @@
 			clock-frequency = <24000000>;
 			status = "disabled";
 		};
+
+		sid: efuse@3006000 {
+			compatible = "allwinner,sunxi-sid";
+			reg = <0x03006000 0x1000>;
+			size = <256>;
+			status = "okay";
+		};
 	};
 };

--- a/dts/bindings/otp/allwinner,sunxi-sid.yaml
+++ b/dts/bindings/otp/allwinner,sunxi-sid.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Khai Do
+# SPDX-License-Identifier: Apache-2.0
+
+description: Allwinner Security ID (SID) eFuse Controller
+
+compatible: "allwinner,sunxi-sid"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  size:
+    type: int
+    required: true
+    description: Size of efuse storage (bytes)

--- a/soc/allwinner/sun50i_h618/CMakeLists.txt
+++ b/soc/allwinner/sun50i_h618/CMakeLists.txt
@@ -3,4 +3,6 @@
 
 zephyr_include_directories(.)
 
+zephyr_sources(soc.c)
+
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/allwinner/sun50i_h618/soc.c
+++ b/soc/allwinner/sun50i_h618/soc.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Khai Do
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/arm64/arm_mmu.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+
+static const struct arm_mmu_region mmu_regions[] = {
+	MMU_REGION_FLAT_ENTRY("SID", DT_REG_ADDR(DT_NODELABEL(sid)), DT_REG_SIZE(DT_NODELABEL(sid)),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+};
+
+const struct arm_mmu_config mmu_config = {
+	.num_regions = ARRAY_SIZE(mmu_regions),
+	.mmu_regions = mmu_regions,
+};


### PR DESCRIPTION
**OTP Driver:** Adds register-based indirect readout for Allwinner eFuses
**HWINFO Driver:** Exposes the 128-bit unique Chip ID via standard API
Validated successfully on Orange Pi Zero 2W (H618)

### On linux:
<img width="737" height="47" alt="Screenshot from 2026-06-15 22-29-35" src="https://github.com/user-attachments/assets/bc77d895-e6bb-41f2-9fbb-3ff7d5f015e4" />

### Run on zephyr
<img width="997" height="308" alt="Screenshot from 2026-06-15 22-37-52" src="https://github.com/user-attachments/assets/e368e8c0-78c3-4c84-89b1-4f7a6723d5fa" />

