### PR TITLE
drivers: i2c: stm32: factorize PM get/put, fix target config bit flag test

### DIFF
--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -11,7 +11,6 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
-#include <zephyr/pm/policy.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
 #include <soc.h>
@@ -198,14 +197,11 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 	k_sem_take(&data->bus_mutex, K_FOREVER);
 
 	/* Prevent driver from being suspended by PM until I2C transaction is complete */
-	ret = pm_device_runtime_get(dev);
+	ret = i2c_stm32_pm_get(dev);
 	if (ret < 0) {
 		LOG_ERR("i2c: PM runtime failure: %d", ret);
 		goto out_sem;
 	}
-
-	/* Prevent the clocks to be stopped during the i2c transaction */
-	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
 
 	current = msg;
 
@@ -224,9 +220,7 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 		num_msgs--;
 	}
 
-	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-
-	(void)pm_device_runtime_put(dev);
+	i2c_stm32_pm_put(dev);
 
 out_sem:
 	k_sem_give(&data->bus_mutex);

--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -401,7 +401,10 @@ static int i2c_stm32_init(const struct device *dev)
 		return ret;
 	}
 
-	(void)pm_device_runtime_enable(dev);
+	ret = pm_device_runtime_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
 	data->is_configured = true;
 

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -164,6 +164,9 @@ int i2c_stm32_pm_action(const struct device *dev, enum pm_device_action action);
 int i2c_stm32_suspend(const struct device *dev);
 #endif /* CONFIG_PM_DEVICE */
 
+int i2c_stm32_pm_get(const struct device *dev);
+void i2c_stm32_pm_put(const struct device *dev);
+
 int i2c_stm32_error(const struct device *dev);
 void i2c_stm32_event(const struct device *dev);
 

--- a/drivers/i2c/i2c_stm32_common.c
+++ b/drivers/i2c/i2c_stm32_common.c
@@ -10,6 +10,8 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/policy.h>
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -110,3 +112,22 @@ int i2c_stm32_pm_action(const struct device *dev, enum pm_device_action action)
 	return err;
 }
 #endif
+
+int i2c_stm32_pm_get(const struct device *dev)
+{
+	int ret;
+
+	ret = pm_device_runtime_get(dev);
+	if (ret == 0) {
+		/* Prevent the clocks to be stopped during the i2c transaction */
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	}
+
+	return ret;
+}
+
+void i2c_stm32_pm_put(const struct device *dev)
+{
+	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	(void)pm_device_runtime_put(dev);
+}

--- a/drivers/i2c/i2c_stm32_common.c
+++ b/drivers/i2c/i2c_stm32_common.c
@@ -121,6 +121,9 @@ int i2c_stm32_pm_get(const struct device *dev)
 	if (ret == 0) {
 		/* Prevent the clocks to be stopped during the i2c transaction */
 		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+		if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+			pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		}
 	}
 
 	return ret;
@@ -129,5 +132,8 @@ int i2c_stm32_pm_get(const struct device *dev)
 void i2c_stm32_pm_put(const struct device *dev)
 {
 	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+	}
 	(void)pm_device_runtime_put(dev);
 }

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -148,8 +148,7 @@ static void i2c_stm32_start_or_complete(const struct device *dev)
 	 */
 	while (!i2c_stm32_start(dev, &status)) {
 		if (!i2c_rtio_complete(data->ctx, status)) {
-			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-			(void)pm_device_runtime_put(dev);
+			i2c_stm32_pm_put(dev);
 			return;
 		}
 	}
@@ -162,8 +161,7 @@ void i2c_stm32_rtio_complete(const struct device *dev, int status)
 	if (i2c_rtio_complete(data->ctx, status)) {
 		i2c_stm32_start_or_complete(dev);
 	} else {
-		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-		(void)pm_device_runtime_put(dev);
+		i2c_stm32_pm_put(dev);
 	}
 }
 
@@ -243,14 +241,12 @@ static void i2c_stm32_submit(const struct device *dev, struct rtio_iodev_sqe *io
 	iodev_sqe->sqe.iodev_flags |= RTIO_IODEV_I2C_RESTART;
 
 	if (i2c_rtio_submit(data->ctx, iodev_sqe)) {
-		ret = pm_device_runtime_get(dev);
+		ret = i2c_stm32_pm_get(dev);
 		if (ret < 0) {
 			/* Flush pending requests since we failed to get the device */
 			do {
 			} while (i2c_rtio_complete(data->ctx, ret));
 		} else {
-			/* Prevent the clocks to be stopped during the i2c transaction */
-			pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
 			i2c_stm32_start_or_complete(dev);
 		}
 	}

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -311,7 +311,10 @@ static int i2c_stm32_init(const struct device *dev)
 		return ret;
 	}
 
-	(void)pm_device_runtime_enable(dev);
+	ret = pm_device_runtime_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
 	return 0;
 }

--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -508,7 +508,7 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 		return -EBUSY;
 	}
 
-	if (config->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+	if ((config->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -362,7 +362,7 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 		return -EBUSY;
 	}
 
-	if (config->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+	if ((config->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -300,7 +300,7 @@ static struct i2c_target_config *i2c_stm32_target_cfg_get(const struct device *d
 		 * If 7-bit mode is enabled, find the correct cfg based on
 		 * the I2C address sent by bus controller.
 		 */
-		if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		if ((data->target_cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0) {
 			target_cfg = data->target_cfg;
 		} else {
 			uint8_t target_address;
@@ -525,7 +525,7 @@ int i2c_stm32_target_register(const struct device *dev,
 
 	if (!data->target_cfg) {
 		data->target_cfg = config;
-		if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		if ((data->target_cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0) {
 			LL_I2C_SetOwnAddress1(i2c, config->address, LL_I2C_OWNADDRESS1_10BIT);
 			LOG_DBG("i2c: target #1 registered with 10-bit address");
 		} else {
@@ -537,7 +537,7 @@ int i2c_stm32_target_register(const struct device *dev,
 
 		LOG_DBG("i2c: target #1 registered");
 	} else {
-		if (config->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		if ((config->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0) {
 			(void)pm_device_runtime_put(dev);
 			return -EINVAL;
 		}

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -100,7 +100,7 @@ static void i2c_stm32_target_event(const struct device *dev)
 		 * If 7-bit mode is enabled, find the correct cfg based on
 		 * the I2C address sent by bus controller.
 		 */
-		if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		if ((data->target_cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0) {
 			target_cfg = data->target_cfg;
 		} else {
 			uint8_t target_address;
@@ -249,7 +249,7 @@ int i2c_stm32_target_register(const struct device *dev,
 
 	if (!data->target_cfg) {
 		data->target_cfg = config;
-		if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		if ((data->target_cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0) {
 			LL_I2C_SetOwnAddress1(i2c, config->address, LL_I2C_OWNADDRESS1_10BIT);
 			LOG_DBG("i2c: target #1 registered with 10-bit address");
 		} else {
@@ -261,7 +261,7 @@ int i2c_stm32_target_register(const struct device *dev,
 
 		LOG_DBG("i2c: target #1 registered");
 	} else {
-		if (config->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		if ((config->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0) {
 			(void)pm_device_runtime_put(dev);
 			return -EINVAL;
 		}


### PR DESCRIPTION
* Test I2C_TARGET_FLAGS_ADDR_10_BITS as a bit flag value instead of a 32bit overall value.
* Report error returned by pm_device_runtime_enable() in STM32 I2C drivers.
* Factorize PM get/put seequence into common i2c_stm32_pm_get() and i2c_stm32_pm_put() helper functions
* Get/put PM state lock for suspend-to-ram mode when CONFIG_PM_S2RAM is enabled.
