### PR TITLE
PSE84 autanalog SAR multi-sequencer

### DIFF
--- a/drivers/adc/Kconfig.infineon_autanalog_sar
+++ b/drivers/adc/Kconfig.infineon_autanalog_sar
@@ -13,3 +13,12 @@ config ADC_INFINEON_AUTANALOG_SAR
 	select ADC_CONFIGURABLE_INPUTS
 	help
 	  This option enables the ADC driver for Infineon MCUs using AutAnalog SAR ADC.
+
+config ADC_INFINEON_AUTANALOG_SAR_STREAM
+	bool "Infineon AutAnalog SAR ADC stream support"
+	default y
+	depends on ADC_INFINEON_AUTANALOG_SAR
+	depends on ADC_STREAM
+	help
+	  Enable streaming mode for the Infineon AutAnalog SAR ADC using the
+	  hardware FIFO to stream ADC samples via RTIO.

--- a/drivers/adc/adc_infineon_autanalog_sar.c
+++ b/drivers/adc/adc_infineon_autanalog_sar.c
@@ -36,12 +36,10 @@ LOG_MODULE_REGISTER(ifx_autanalog_sar_adc, CONFIG_ADC_LOG_LEVEL);
 #define ADC_AUTANALOG_SAR_DEFAULT_ACQUISITION_NS (1000u)
 #define ADC_AUTANALOG_SAR_RESOLUTION             12
 
-#define IFX_AUTANALOG_SAR_MAX_NUM_CHANNELS           32
-#define IFX_AUTANALOG_SAR_MAX_GPIO_CHANNELS          8
-#define IFX_AUTANALOG_SAR_MAX_MUX_CHANNELS           16
-#define IFX_AUTANALOG_SAR_MUX_CHANNEL_OFFSET         8
-#define IFX_AUTANALOG_SAR_NUM_SEQUENCERS             1
-#define IFX_AUTANALOG_SAR_NUM_ENABLED_CHANNELS(inst) DT_NUM_CHILDREN(DT_DRV_INST(inst))
+#define IFX_AUTANALOG_SAR_MAX_NUM_CHANNELS   32
+#define IFX_AUTANALOG_SAR_MAX_GPIO_CHANNELS  8
+#define IFX_AUTANALOG_SAR_MAX_MUX_CHANNELS   16
+#define IFX_AUTANALOG_SAR_MUX_CHANNEL_OFFSET 8
 
 #define IFX_AUTANALOG_SAR_SAMPLETIME_COUNT 4
 #define IFX_AUTANALOG_SAR_MAX_FIR_FILTERS  2
@@ -132,6 +130,29 @@ struct ifx_autanalog_sar_fir_config {
 	uint8_t fifo_sel;
 };
 
+struct ifx_autanalog_sar_seq_hs_config {
+	uint8_t gpio_channels;
+	uint8_t mux_mode;
+	uint8_t mux0_sel;
+	uint8_t mux1_sel;
+	bool sample_time_en;
+	uint8_t sample_time;
+	bool acc_en;
+	uint8_t acc_count;
+	uint8_t cal_req;
+	uint8_t next_action;
+};
+
+struct ifx_autanalog_sar_seq_lp_config {
+	uint8_t mux0_sel;
+	bool sample_time_en;
+	uint8_t sample_time;
+	bool acc_en;
+	uint8_t acc_count;
+	uint8_t cal_req;
+	uint8_t next_action;
+};
+
 struct ifx_autanalog_sar_adc_config {
 	void (*irq_func)(void);
 	const struct device *mfd;
@@ -150,6 +171,10 @@ struct ifx_autanalog_sar_adc_config {
 	struct ifx_autanalog_sar_fir_config fir[IFX_AUTANALOG_SAR_MAX_FIR_FILTERS];
 	bool fifo_enabled;
 	struct ifx_autanalog_sar_fifo_config fifo_cfg;
+	uint8_t num_hs_seq;
+	const struct ifx_autanalog_sar_seq_hs_config *hs_seq;
+	uint8_t num_lp_seq;
+	const struct ifx_autanalog_sar_seq_lp_config *lp_seq;
 	bool lp_mode;
 	bool lp_diff_en;
 };
@@ -190,7 +215,7 @@ struct ifx_autanalog_sar_adc_data {
 	cy_stc_autanalog_sar_hs_chan_t
 		pdl_adc_hs_channel_cfg_obj_arr[IFX_AUTANALOG_SAR_MAX_GPIO_CHANNELS];
 	cy_stc_autanalog_sar_sta_hs_t pdl_adc_hs_static_obj;
-	cy_stc_autanalog_sar_seq_tab_hs_t pdl_adc_seq_hs_cfg_obj[IFX_AUTANALOG_SAR_NUM_SEQUENCERS];
+	cy_stc_autanalog_sar_seq_tab_hs_t *pdl_adc_seq_hs_cfg;
 
 	/* PDL structures for MUX channels */
 	cy_stc_autanalog_sar_mux_chan_t
@@ -198,7 +223,7 @@ struct ifx_autanalog_sar_adc_data {
 
 	/* PDL structures for LP mode */
 	cy_stc_autanalog_sar_sta_lp_t pdl_adc_lp_static_obj;
-	cy_stc_autanalog_sar_seq_tab_lp_t pdl_adc_seq_lp_cfg_obj[IFX_AUTANALOG_SAR_NUM_SEQUENCERS];
+	cy_stc_autanalog_sar_seq_tab_lp_t *pdl_adc_seq_lp_cfg;
 
 	/* PDL structures for FIR filters */
 	cy_stc_autanalog_sar_fir_cfg_t pdl_fir_cfg[IFX_AUTANALOG_SAR_MAX_FIR_FILTERS];
@@ -257,21 +282,36 @@ static void ifx_init_pdl_structs(struct ifx_autanalog_sar_adc_data *data,
 {
 	data->pdl_adc_top_obj = (cy_stc_autanalog_sar_t){
 		.sarStaCfg = &data->pdl_adc_top_static_obj,
-		/* This driver implementation uses only a single sequencer.  The sequencer is
-		 * reconfigured every time an adc read is started.  Hardware supports up to 32
-		 * sequencers, which can be used for more advanced ADC configurations.
-		 */
-		.hsSeqTabNum = cfg->lp_mode ? 0U : IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
-		.hsSeqTabArr = cfg->lp_mode ? NULL : &data->pdl_adc_seq_hs_cfg_obj[0],
-		.lpSeqTabNum = cfg->lp_mode ? IFX_AUTANALOG_SAR_NUM_SEQUENCERS : 0U,
-		.lpSeqTabArr = cfg->lp_mode ? &data->pdl_adc_seq_lp_cfg_obj[0] : NULL,
+		.hsSeqTabNum = cfg->lp_mode ? 0U : cfg->num_hs_seq,
+		.hsSeqTabArr = cfg->lp_mode ? NULL : &data->pdl_adc_seq_hs_cfg[0],
+		.lpSeqTabNum = cfg->lp_mode ? cfg->num_lp_seq : 0U,
+		.lpSeqTabArr = cfg->lp_mode ? &data->pdl_adc_seq_lp_cfg[0] : NULL,
 		.firNum = cfg->fir_count,
 		.firCfg = (cfg->fir_count > 0) ? &data->pdl_fir_cfg[0] : NULL,
 		.fifoCfg = cfg->fifo_enabled ? &data->pdl_fifo_cfg : NULL,
 	};
 
-	if (!cfg->lp_mode) {
-		data->pdl_adc_seq_hs_cfg_obj[0] = (cy_stc_autanalog_sar_seq_tab_hs_t){
+	/* Populate HS sequencer entries from DT config or use defaults */
+	if (cfg->hs_seq != NULL) {
+		for (uint8_t i = 0; i < cfg->num_hs_seq; i++) {
+			data->pdl_adc_seq_hs_cfg[i] = (cy_stc_autanalog_sar_seq_tab_hs_t){
+				.chanEn = cfg->hs_seq[i].gpio_channels,
+				.muxMode = cfg->hs_seq[i].mux_mode,
+				.mux0Sel = cfg->hs_seq[i].mux0_sel,
+				.mux1Sel = cfg->hs_seq[i].mux1_sel,
+				.sampleTimeEn = cfg->hs_seq[i].sample_time_en,
+				.sampleTime = (cy_en_autanalog_sar_sample_time_t)cfg->hs_seq[i]
+						      .sample_time,
+				.accEn = cfg->hs_seq[i].acc_en,
+				.accCount = (cy_en_autanalog_sar_acc_cnt_t)cfg->hs_seq[i].acc_count,
+				.calReq = (cy_en_autanalog_sar_calibrate_t)cfg->hs_seq[i].cal_req,
+				.nextAction =
+					(cy_en_autanalog_sar_next_act_t)cfg->hs_seq[i].next_action,
+			};
+		}
+	} else {
+		/* No DT sequencer entries: single entry with backward-compatible defaults */
+		data->pdl_adc_seq_hs_cfg[0] = (cy_stc_autanalog_sar_seq_tab_hs_t){
 			.chanEn = CY_AUTANALOG_SAR_CHAN_MASK_GPIO_DISABLED,
 			.muxMode = CY_AUTANALOG_SAR_CHAN_CFG_MUX_DISABLED,
 			.mux0Sel = CY_AUTANALOG_SAR_CHAN_CFG_MUX0,
@@ -283,8 +323,27 @@ static void ifx_init_pdl_structs(struct ifx_autanalog_sar_adc_data *data,
 			.calReq = CY_AUTANALOG_SAR_CAL_DISABLED,
 			.nextAction = CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP,
 		};
+	}
+
+	/* Populate LP sequencer entries from DT config or use defaults */
+	if (cfg->lp_seq != NULL) {
+		for (uint8_t i = 0; i < cfg->num_lp_seq; i++) {
+			data->pdl_adc_seq_lp_cfg[i] = (cy_stc_autanalog_sar_seq_tab_lp_t){
+				.chanEn = true,
+				.mux0Sel = cfg->lp_seq[i].mux0_sel,
+				.sampleTimeEn = cfg->lp_seq[i].sample_time_en,
+				.sampleTime = (cy_en_autanalog_sar_sample_time_t)cfg->lp_seq[i]
+						      .sample_time,
+				.accEn = cfg->lp_seq[i].acc_en,
+				.accCount = (cy_en_autanalog_sar_acc_cnt_t)cfg->lp_seq[i].acc_count,
+				.calReq = (cy_en_autanalog_sar_calibrate_t)cfg->lp_seq[i].cal_req,
+				.nextAction =
+					(cy_en_autanalog_sar_next_act_t)cfg->lp_seq[i].next_action,
+			};
+		}
 	} else {
-		data->pdl_adc_seq_lp_cfg_obj[0] = (cy_stc_autanalog_sar_seq_tab_lp_t){
+		/* No DT LP sequencer entries: single entry with backward-compatible defaults */
+		data->pdl_adc_seq_lp_cfg[0] = (cy_stc_autanalog_sar_seq_tab_lp_t){
 			.chanEn = true,
 			.mux0Sel = 0,
 			.sampleTimeEn = true,
@@ -438,7 +497,7 @@ static void ifx_autanalog_sar_complete_error(struct ifx_autanalog_sar_adc_data *
 static int ifx_build_hs_sequencer_entry(uint32_t channels, struct ifx_autanalog_sar_adc_data *data)
 {
 	uint8_t timer_index = IFX_AUTANALOG_SAR_SAMPLETIME_COUNT;
-	cy_stc_autanalog_sar_seq_tab_hs_t *seq_entry = &data->pdl_adc_seq_hs_cfg_obj[0];
+	cy_stc_autanalog_sar_seq_tab_hs_t *seq_entry = &data->pdl_adc_seq_hs_cfg[0];
 	uint32_t hw_channels = IFX_ADC_HW_CHANNELS_MASK(channels);
 	uint8_t gpio_channels = IFX_GPIO_CHANNELS_MASK(hw_channels);
 	uint16_t mux_channels = IFX_MUX_CHANNELS_MASK(hw_channels);
@@ -514,16 +573,14 @@ static int ifx_build_hs_sequencer_entry(uint32_t channels, struct ifx_autanalog_
 		}
 	}
 
+	/* Only update channel-related fields; sampleTimeEn, accEn, accCount,
+	 * calReq and nextAction are preserved from DT initialisation.
+	 */
 	seq_entry->sampleTime = (cy_en_autanalog_sar_sample_time_t)timer_index;
 	seq_entry->chanEn = gpio_channels;
 	seq_entry->muxMode = mux_mode;
 	seq_entry->mux0Sel = mux0_sel;
 	seq_entry->mux1Sel = mux1_sel;
-	seq_entry->sampleTimeEn = true;
-	seq_entry->accEn = false;
-	seq_entry->accCount = CY_AUTANALOG_SAR_ACC_CNT2;
-	seq_entry->calReq = CY_AUTANALOG_SAR_CAL_DISABLED;
-	seq_entry->nextAction = CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
 
 	return 0;
 } /* ifx_build_hs_sequencer_entry() */
@@ -543,7 +600,7 @@ static int ifx_build_hs_sequencer_entry(uint32_t channels, struct ifx_autanalog_
 static int ifx_build_lp_sequencer_entry(uint32_t channels, struct ifx_autanalog_sar_adc_data *data)
 {
 	uint16_t mux_channels = IFX_MUX_CHANNELS_MASK(channels);
-	cy_stc_autanalog_sar_seq_tab_lp_t *seq_entry = &data->pdl_adc_seq_lp_cfg_obj[0];
+	cy_stc_autanalog_sar_seq_tab_lp_t *seq_entry = &data->pdl_adc_seq_lp_cfg[0];
 	uint8_t mux_idx = 0xFF;
 	uint8_t ch_id;
 
@@ -581,14 +638,9 @@ static int ifx_build_lp_sequencer_entry(uint32_t channels, struct ifx_autanalog_
 
 	seq_entry->chanEn = true;
 	seq_entry->mux0Sel = mux_idx;
-	seq_entry->sampleTimeEn = true;
 	seq_entry->sampleTime =
 		(cy_en_autanalog_sar_sample_time_t)data->autanalog_channel_cfg[ch_id]
 			.sample_time_idx;
-	seq_entry->accEn = false;
-	seq_entry->accCount = CY_AUTANALOG_SAR_ACC_CNT2;
-	seq_entry->calReq = CY_AUTANALOG_SAR_CAL_DISABLED;
-	seq_entry->nextAction = CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
 
 	return 0;
 } /* ifx_build_lp_sequencer_entry() */
@@ -656,33 +708,42 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 		Cy_AutAnalog_SAR_ClearMuxChanResultStatus(0, mux_ch);
 	}
 
-	/* This implementation uses a single sequencer which is reconfigured for every ADC
-	 * read operation.  If needed, this can be extended to use multiple sequencers.
-	 */
 	if (cfg->lp_mode) {
-		if (ifx_build_lp_sequencer_entry(sequence->channels, data) != 0) {
-			LOG_ERR("Error building LP ADC Sequencer Configuration");
-			ifx_autanalog_sar_complete_error(data, -EINVAL);
-			return;
+		if (cfg->lp_seq != NULL) {
+			/* DT-defined LP sequencer: force last entry to single-shot */
+			data->pdl_adc_seq_lp_cfg[cfg->num_lp_seq - 1].nextAction =
+				CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+			result_status = Cy_AutAnalog_SAR_LoadLPseqTable(
+				0, cfg->num_lp_seq, &data->pdl_adc_seq_lp_cfg[0]);
+		} else {
+			if (ifx_build_lp_sequencer_entry(sequence->channels, data) != 0) {
+				LOG_ERR("Error building LP ADC Sequencer Configuration");
+				ifx_autanalog_sar_complete_error(data, -EINVAL);
+				return;
+			}
+			data->pdl_adc_seq_lp_cfg[0].nextAction =
+				CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+			result_status =
+				Cy_AutAnalog_SAR_LoadLPseqTable(0, 1, &data->pdl_adc_seq_lp_cfg[0]);
 		}
-
-		result_status = Cy_AutAnalog_SAR_LoadLPseqTable(0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
-								&data->pdl_adc_seq_lp_cfg_obj[0]);
 	} else {
-		if (ifx_build_hs_sequencer_entry(sequence->channels, data) != 0) {
-			LOG_ERR("Error building HS ADC Sequencer Configuration");
-			ifx_autanalog_sar_complete_error(data, -EINVAL);
-			return;
+		if (cfg->hs_seq != NULL) {
+			/* DT-defined HS sequencer: force last entry to single-shot */
+			data->pdl_adc_seq_hs_cfg[cfg->num_hs_seq - 1].nextAction =
+				CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+			result_status = Cy_AutAnalog_SAR_LoadHSseqTable(
+				0, cfg->num_hs_seq, &data->pdl_adc_seq_hs_cfg[0]);
+		} else {
+			if (ifx_build_hs_sequencer_entry(sequence->channels, data) != 0) {
+				LOG_ERR("Error building HS ADC Sequencer Configuration");
+				ifx_autanalog_sar_complete_error(data, -EINVAL);
+				return;
+			}
+			data->pdl_adc_seq_hs_cfg[0].nextAction =
+				CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+			result_status = Cy_AutAnalog_SAR_LoadHSseqTable(
+				0, cfg->num_hs_seq, &data->pdl_adc_seq_hs_cfg[0]);
 		}
-
-		result_status = Cy_AutAnalog_SAR_LoadHSseqTable(0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
-								&data->pdl_adc_seq_hs_cfg_obj[0]);
-	}
-	if (result_status != CY_AUTANALOG_SUCCESS) {
-		LOG_ERR("Error Loading ADC Sequencer Configuration: %u",
-			(unsigned int)result_status);
-		ifx_autanalog_sar_complete_error(data, -EIO);
-		return;
 	}
 
 	/* State 0 is used for LP/HS mode selection and peripheral power up.
@@ -1751,18 +1812,26 @@ static void ifx_autanalog_sar_submit_stream(const struct device *dev,
 
 	/* Configure the sequencer for continuous mode */
 	if (cfg->lp_mode) {
-		if (ifx_build_lp_sequencer_entry(sequence->channels, data) != 0) {
-			LOG_ERR("Error building LP ADC sequencer for stream");
-			rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
-			return;
+		if (cfg->lp_seq != NULL) {
+			/* DT-defined LP sequencer: set last entry to continuous */
+			data->pdl_adc_seq_lp_cfg[cfg->num_lp_seq - 1].nextAction =
+				CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
+		} else {
+			if (ifx_build_lp_sequencer_entry(sequence->channels, data) != 0) {
+				LOG_ERR("Error building LP ADC sequencer for stream");
+				rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+				return;
+			}
+			data->pdl_adc_seq_lp_cfg[0].nextAction =
+				CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
 		}
 
 		/* Set to continuous mode: loop back to start after each conversion */
-		data->pdl_adc_seq_lp_cfg_obj[0].nextAction =
+		data->pdl_adc_seq_lp_cfg[0].nextAction =
 			CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
 
 		uint32_t result_status = Cy_AutAnalog_SAR_LoadLPseqTable(
-			0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS, &data->pdl_adc_seq_lp_cfg_obj[0]);
+			0, cfg->num_lp_seq, &data->pdl_adc_seq_lp_cfg[0]);
 
 		if (result_status != CY_AUTANALOG_SUCCESS) {
 			LOG_ERR("Failed to load LP sequencer for stream: %u",
@@ -1771,18 +1840,26 @@ static void ifx_autanalog_sar_submit_stream(const struct device *dev,
 			return;
 		}
 	} else {
-		if (ifx_build_hs_sequencer_entry(sequence->channels, data) != 0) {
-			LOG_ERR("Error building ADC sequencer for stream");
-			rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
-			return;
+		if (cfg->hs_seq != NULL) {
+			/* DT-defined HS sequencer: set last entry to continuous */
+			data->pdl_adc_seq_hs_cfg[cfg->num_hs_seq - 1].nextAction =
+				CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
+		} else {
+			if (ifx_build_hs_sequencer_entry(sequence->channels, data) != 0) {
+				LOG_ERR("Error building ADC sequencer for stream");
+				rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+				return;
+			}
+			data->pdl_adc_seq_hs_cfg[0].nextAction =
+				CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
 		}
 
 		/* Set to continuous mode: loop back to start after each conversion */
-		data->pdl_adc_seq_hs_cfg_obj[0].nextAction =
+		data->pdl_adc_seq_hs_cfg[0].nextAction =
 			CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
 
 		uint32_t result_status = Cy_AutAnalog_SAR_LoadHSseqTable(
-			0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS, &data->pdl_adc_seq_hs_cfg_obj[0]);
+			0, cfg->num_hs_seq, &data->pdl_adc_seq_hs_cfg[0]);
 
 		if (result_status != CY_AUTANALOG_SUCCESS) {
 			LOG_ERR("Failed to load sequencer for stream: %u",
@@ -1824,15 +1901,13 @@ int adc_ifx_autanalog_sar_stream_stop(const struct device *dev)
 	 * STOP state.
 	 */
 	if (cfg->lp_mode) {
-		data->pdl_adc_seq_lp_cfg_obj[0].nextAction =
-			CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
-		(void)Cy_AutAnalog_SAR_LoadLPseqTable(0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
-						      &data->pdl_adc_seq_lp_cfg_obj[0]);
+		data->pdl_adc_seq_lp_cfg[0].nextAction = CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+		(void)Cy_AutAnalog_SAR_LoadLPseqTable(0, cfg->num_lp_seq,
+						      &data->pdl_adc_seq_lp_cfg[0]);
 	} else {
-		data->pdl_adc_seq_hs_cfg_obj[0].nextAction =
-			CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
-		(void)Cy_AutAnalog_SAR_LoadHSseqTable(0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
-						      &data->pdl_adc_seq_hs_cfg_obj[0]);
+		data->pdl_adc_seq_hs_cfg[0].nextAction = CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+		(void)Cy_AutAnalog_SAR_LoadHSseqTable(0, cfg->num_hs_seq,
+						      &data->pdl_adc_seq_hs_cfg[0]);
 	}
 
 	/* Clear the streaming state under an interrupt lock so the final STOP scan's
@@ -2096,6 +2171,75 @@ static int ifx_autanalog_sar_get_decoder(const struct device *dev,
 		.watermark_mask = IFX_FIFO_WATERMARK_MASK(n),                                 \
 		}
 
+/* HS sequencer entry configuration from DT child nodes.
+ * Child nodes with compatible "infineon,autanalog-sar-seq-hs" are collected
+ * into a const config array.  The count drives the PDL sequencer table size.
+ */
+#define IFX_COUNT_SEQ_HS(child) + DT_NODE_HAS_COMPAT(child, infineon_autanalog_sar_seq_hs)
+
+/* Number of seq-hs-* child nodes defined in DT for instance n */
+#define IFX_HS_SEQ_DT_COUNT(n) (0 DT_INST_FOREACH_CHILD(n, IFX_COUNT_SEQ_HS))
+
+/* Effective PDL array size: at least 1 so there is always a runtime entry */
+#define IFX_HS_SEQ_PDL_COUNT(n) (IFX_HS_SEQ_DT_COUNT(n) + !IFX_HS_SEQ_DT_COUNT(n))
+
+/* Generate one config initialiser for an HS sequencer child node */
+#define IFX_SEQ_HS_CFG_ENTRY(child)                                                        \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(child, infineon_autanalog_sar_seq_hs), (                \
+		{                                                                                  \
+			.gpio_channels = DT_PROP(child, gpio_channels),                            \
+			.mux_mode = DT_PROP(child, mux_mode),                                      \
+			.mux0_sel = DT_PROP(child, mux0_sel),                                      \
+			.mux1_sel = DT_PROP(child, mux1_sel),                                      \
+			.sample_time_en = DT_PROP(child, sample_time_en),                          \
+			.sample_time = DT_PROP(child, sample_time),                                \
+			.acc_en = DT_PROP(child, acc_en),                                          \
+			.acc_count = DT_PROP(child, acc_count),                                    \
+			.cal_req = DT_PROP(child, cal_req),                                        \
+			.next_action = DT_PROP(child, next_action),                                \
+		},                                                                                 \
+	), ())
+
+/* Declare the const config array of HS sequencer entries for instance n */
+#define IFX_SEQ_HS_CFG_ARRAY(n)                                                            \
+	static const struct ifx_autanalog_sar_seq_hs_config                                    \
+		ifx_sar_seq_hs_cfg_##n[] = {                                                       \
+		DT_INST_FOREACH_CHILD(n, IFX_SEQ_HS_CFG_ENTRY)                                     \
+	}
+
+/* LP sequencer entry configuration from DT child nodes.
+ * Child nodes with compatible "infineon,autanalog-sar-seq-lp" are collected
+ * into a const config array.
+ */
+#define IFX_COUNT_SEQ_LP(child) + DT_NODE_HAS_COMPAT(child, infineon_autanalog_sar_seq_lp)
+
+/* Number of seq-lp-* child nodes defined in DT for instance n */
+#define IFX_LP_SEQ_DT_COUNT(n) (0 DT_INST_FOREACH_CHILD(n, IFX_COUNT_SEQ_LP))
+
+/* Effective PDL array size: at least 1 so there is always a runtime entry */
+#define IFX_LP_SEQ_PDL_COUNT(n) (IFX_LP_SEQ_DT_COUNT(n) + !IFX_LP_SEQ_DT_COUNT(n))
+
+/* Generate one config initialiser for an LP sequencer child node */
+#define IFX_SEQ_LP_CFG_ENTRY(child)                                                        \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(child, infineon_autanalog_sar_seq_lp), (                \
+		{                                                                                  \
+			.mux0_sel = DT_PROP(child, mux0_sel),                                      \
+			.sample_time_en = DT_PROP(child, sample_time_en),                          \
+			.sample_time = DT_PROP(child, sample_time),                                \
+			.acc_en = DT_PROP(child, acc_en),                                          \
+			.acc_count = DT_PROP(child, acc_count),                                    \
+			.cal_req = DT_PROP(child, cal_req),                                        \
+			.next_action = DT_PROP(child, next_action),                                \
+		},                                                                                 \
+	), ())
+
+/* Declare the const config array of LP sequencer entries for instance n */
+#define IFX_SEQ_LP_CFG_ARRAY(n)                                                            \
+	static const struct ifx_autanalog_sar_seq_lp_config                                    \
+		ifx_sar_seq_lp_cfg_##n[] = {                                                       \
+		DT_INST_FOREACH_CHILD(n, IFX_SEQ_LP_CFG_ENTRY)                                     \
+	}
+
 /* Device Instantiation */
 #define IFX_AUTANALOG_SAR_ADC_INIT(n)                                                              \
 	ADC_IFX_AUTANALOG_SAR_DRIVER_API(n);                                     \
@@ -2108,6 +2252,15 @@ static int ifx_autanalog_sar_get_decoder(const struct device *dev,
 			(IFX_FIR_COEFF_DECLARE(n, fir_1);), ())), ())                \
 	/* Per-channel DT config array */                                                          \
 	IFX_CHAN_DT_CFG_ARRAY(n);                                                                  \
+	/* HS sequencer config array (may be empty) */                                         \
+	IFX_SEQ_HS_CFG_ARRAY(n);                                                               \
+	/* LP sequencer config array (may be empty) */                                         \
+	IFX_SEQ_LP_CFG_ARRAY(n);                                                               \
+	/* Per-instance PDL sequencer arrays */                                                \
+	static cy_stc_autanalog_sar_seq_tab_hs_t                                               \
+		ifx_sar_hs_seq_pdl_##n[IFX_HS_SEQ_PDL_COUNT(n)];                                   \
+	static cy_stc_autanalog_sar_seq_tab_lp_t                                               \
+		ifx_sar_lp_seq_pdl_##n[IFX_LP_SEQ_PDL_COUNT(n)];                                   \
 	static void ifx_autanalog_sar_adc_config_func_##n(void);                                   \
 	static const struct ifx_autanalog_sar_adc_config ifx_autanalog_sar_adc_config_##n = {      \
 		.irq_func = ifx_autanalog_sar_adc_config_func_##n,                                 \
@@ -2133,6 +2286,10 @@ static int ifx_autanalog_sar_get_decoder(const struct device *dev,
 					(IFX_FIFO_CFG_INIT(n)), ({0})),            \
 		.num_dt_channels = ARRAY_SIZE(ifx_sar_chan_dt_cfg_##n),                            \
 		.dt_channels = ifx_sar_chan_dt_cfg_##n,                                            \
+		.num_hs_seq = IFX_HS_SEQ_PDL_COUNT(n),                                             \
+		.hs_seq = (IFX_HS_SEQ_DT_COUNT(n) > 0) ? ifx_sar_seq_hs_cfg_##n : NULL, \
+		.num_lp_seq = IFX_LP_SEQ_PDL_COUNT(n),                                             \
+		.lp_seq = (IFX_LP_SEQ_DT_COUNT(n) > 0) ? ifx_sar_seq_lp_cfg_##n : NULL, \
 		.lp_mode = DT_INST_PROP(n, lp_mode),                                               \
 		.lp_diff_en = DT_INST_PROP(n, lp_diff_en),                                         \
 	};                                                                                     \
@@ -2140,6 +2297,8 @@ static int ifx_autanalog_sar_get_decoder(const struct device *dev,
 		ADC_CONTEXT_INIT_LOCK(ifx_autanalog_sar_adc_data_##n, ctx),                        \
 		ADC_CONTEXT_INIT_TIMER(ifx_autanalog_sar_adc_data_##n, ctx),                       \
 		ADC_CONTEXT_INIT_SYNC(ifx_autanalog_sar_adc_data_##n, ctx),                        \
+		.pdl_adc_seq_hs_cfg = ifx_sar_hs_seq_pdl_##n,                                      \
+		.pdl_adc_seq_lp_cfg = ifx_sar_lp_seq_pdl_##n,                                      \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(n, &ifx_autanalog_sar_adc_init, NULL,                                \
 			      &ifx_autanalog_sar_adc_data_##n, &ifx_autanalog_sar_adc_config_##n,  \

--- a/drivers/adc/adc_infineon_autanalog_sar.c
+++ b/drivers/adc/adc_infineon_autanalog_sar.c
@@ -11,14 +11,20 @@
 
 #define DT_DRV_COMPAT infineon_autanalog_sar_adc
 
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/dt-bindings/adc/infineon-autanalog-sar.h>
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/adc/infineon_autanalog_sar.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 #include <infineon_autanalog.h>
+
+#ifdef CONFIG_ADC_INFINEON_AUTANALOG_SAR_STREAM
+#include <zephyr/rtio/rtio.h>
+#endif
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
@@ -44,6 +50,46 @@ LOG_MODULE_REGISTER(ifx_autanalog_sar_adc, CONFIG_ADC_LOG_LEVEL);
 
 /* LPOSC frequency used in LP mode (4.096 MHz) */
 #define IFX_AUTANALOG_SAR_LPOSC_FREQ_HZ 4096000
+
+/* AC State Transition Table indices used by this driver (see the basic STT defined
+ * in the MFD): state 2 triggers the SAR conversion, after which the AC walks to its
+ * STOP state.
+ */
+#define IFX_AUTANALOG_SAR_AC_STATE_SAR_SAMPLE 2
+
+#ifdef CONFIG_ADC_INFINEON_AUTANALOG_SAR_STREAM
+/* Maximum number of channels that can be streamed simultaneously (max number of FIFOs) */
+#define IFX_AUTANALOG_SAR_STREAM_MAX_CHANNELS 8
+
+/* Bounded wait for the SAR to finish the single STOP scan commanded when a stream
+ * is stopped and then power down.  A single LP/HS conversion completes in a few
+ * tens of microseconds, so this only ever spins for one scan; it is not an open
+ * ended poll on an unconditionally-running (continuous mode) SAR.
+ */
+#define IFX_AUTANALOG_SAR_STREAM_STOP_POLL_US 10
+#define IFX_AUTANALOG_SAR_STREAM_STOP_RETRIES 100
+
+/**
+ * @brief Private header placed at the start of each RTIO buffer for stream data.
+ *
+ * Layout: [header][chan_info × num_channels][int32_t raw_samples[]]
+ */
+struct ifx_autanalog_sar_stream_header {
+	uint64_t timestamp_ns;
+	uint16_t vref_mv;
+	uint8_t trigger;
+	uint8_t num_channels;
+	uint8_t resolution;
+	uint8_t empty;
+	uint16_t reserved;
+};
+
+struct ifx_autanalog_sar_stream_chan_info {
+	uint8_t channel_id;
+	uint8_t fifo_buf_idx;
+	uint16_t sample_count;
+};
+#endif /* CONFIG_ADC_INFINEON_AUTANALOG_SAR_STREAM */
 
 /* clang-format off */
 
@@ -163,6 +209,38 @@ struct ifx_autanalog_sar_adc_data {
 	/* FIFO watermark callback */
 	adc_ifx_autanalog_sar_fifo_callback_t fifo_callback;
 	void *fifo_callback_user_data;
+
+#ifdef CONFIG_ADC_INFINEON_AUTANALOG_SAR_STREAM
+	/* Stream state */
+	struct rtio_iodev_sqe *stream_sqe;
+	bool streaming;
+	uint8_t stream_num_channels;
+	struct {
+		uint8_t channel_id;
+		uint8_t fifo_buf_idx; /* 0-based FIFO buffer index (fifo_sel - 1) */
+	} stream_channels[IFX_AUTANALOG_SAR_STREAM_MAX_CHANNELS];
+#endif /* CONFIG_ADC_INFINEON_AUTANALOG_SAR_STREAM */
+};
+
+/* FIFO interrupt status arrays used to map buffer index to status bits */
+static const uint32_t fifo_level_masks[8] = {
+	CY_AUTANALOG_INT_FIFO_LEVEL0, CY_AUTANALOG_INT_FIFO_LEVEL1, CY_AUTANALOG_INT_FIFO_LEVEL2,
+	CY_AUTANALOG_INT_FIFO_LEVEL3, CY_AUTANALOG_INT_FIFO_LEVEL4, CY_AUTANALOG_INT_FIFO_LEVEL5,
+	CY_AUTANALOG_INT_FIFO_LEVEL6, CY_AUTANALOG_INT_FIFO_LEVEL7,
+};
+
+static const uint32_t fifo_overflow_masks[8] = {
+	CY_AUTANALOG_INT_FIFO_OVERFLOW0, CY_AUTANALOG_INT_FIFO_OVERFLOW1,
+	CY_AUTANALOG_INT_FIFO_OVERFLOW2, CY_AUTANALOG_INT_FIFO_OVERFLOW3,
+	CY_AUTANALOG_INT_FIFO_OVERFLOW4, CY_AUTANALOG_INT_FIFO_OVERFLOW5,
+	CY_AUTANALOG_INT_FIFO_OVERFLOW6, CY_AUTANALOG_INT_FIFO_OVERFLOW7,
+};
+
+static const uint32_t fifo_underflow_masks[8] = {
+	CY_AUTANALOG_INT_FIFO_UNDERFLOW0, CY_AUTANALOG_INT_FIFO_UNDERFLOW1,
+	CY_AUTANALOG_INT_FIFO_UNDERFLOW2, CY_AUTANALOG_INT_FIFO_UNDERFLOW3,
+	CY_AUTANALOG_INT_FIFO_UNDERFLOW4, CY_AUTANALOG_INT_FIFO_UNDERFLOW5,
+	CY_AUTANALOG_INT_FIFO_UNDERFLOW6, CY_AUTANALOG_INT_FIFO_UNDERFLOW7,
 };
 
 /**
@@ -612,7 +690,7 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 	 * State 2 is the SAR sampling state.
 	 * State 3 jumps back to state 1
 	 */
-	Cy_AutAnalog_OverrideControllerState(2);
+	Cy_AutAnalog_OverrideControllerState(IFX_AUTANALOG_SAR_AC_STATE_SAR_SAMPLE);
 	ifx_autanalog_start_autonomous_control(cfg->mfd);
 
 #if defined(CONFIG_ADC_ASYNC)
@@ -668,6 +746,18 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx, bool repe
 static int start_read(const struct device *dev, const struct adc_sequence *sequence)
 {
 	struct ifx_autanalog_sar_adc_data *data = dev->data;
+
+#ifdef CONFIG_ADC_INFINEON_AUTANALOG_SAR_STREAM
+	/* Reads and streaming share the single SAR sequencer and the Autonomous
+	 * Controller, so they are mutually exclusive.  Reject a read while a stream
+	 * is active instead of failing later with an opaque -EBUSY from the AC; the
+	 * caller must stop the stream (adc_ifx_autanalog_sar_stream_stop()) first.
+	 */
+	if (data->streaming) {
+		LOG_ERR("ADC is streaming; stop the stream before reading");
+		return -EBUSY;
+	}
+#endif
 
 	if (sequence->buffer_size < (sizeof(int32_t) * POPCOUNT(sequence->channels))) {
 		LOG_ERR("Buffer too small");
@@ -751,12 +841,23 @@ static void ifx_autanalog_sar_adc_isr(const struct device *dev)
  * The FIFO has its own dedicated interrupt line that is separate from
  * the main autanalog interrupt.
  */
+#ifdef CONFIG_ADC_INFINEON_AUTANALOG_SAR_STREAM
+static void ifx_autanalog_sar_stream_fifo_handler(const struct device *dev, uint32_t fifo_status);
+#endif
+
 static void ifx_autanalog_sar_fifo_isr(const struct device *dev)
 {
 	struct ifx_autanalog_sar_adc_data *data = dev->data;
 	uint32_t fifo_status = Cy_AutAnalog_FIFO_GetInterruptStatusMasked(0);
 
 	Cy_AutAnalog_FIFO_ClearInterrupt(0, fifo_status);
+
+#ifdef CONFIG_ADC_INFINEON_AUTANALOG_SAR_STREAM
+	if (data->streaming) {
+		ifx_autanalog_sar_stream_fifo_handler(dev, fifo_status);
+		return;
+	}
+#endif
 
 	/* The callback is expected to have drained the FIFO below the
 	 * watermark so the level interrupt will not immediately re-fire.
@@ -1178,24 +1279,6 @@ static int ifx_autanalog_sar_adc_init(const struct device *dev)
 
 	/* Configure FIFO interrupts if FIFO is enabled */
 	if (cfg->fifo_enabled) {
-		static const uint32_t fifo_level_masks[] = {
-			CY_AUTANALOG_INT_FIFO_LEVEL0, CY_AUTANALOG_INT_FIFO_LEVEL1,
-			CY_AUTANALOG_INT_FIFO_LEVEL2, CY_AUTANALOG_INT_FIFO_LEVEL3,
-			CY_AUTANALOG_INT_FIFO_LEVEL4, CY_AUTANALOG_INT_FIFO_LEVEL5,
-			CY_AUTANALOG_INT_FIFO_LEVEL6, CY_AUTANALOG_INT_FIFO_LEVEL7,
-		};
-		static const uint32_t fifo_overflow_masks[] = {
-			CY_AUTANALOG_INT_FIFO_OVERFLOW0, CY_AUTANALOG_INT_FIFO_OVERFLOW1,
-			CY_AUTANALOG_INT_FIFO_OVERFLOW2, CY_AUTANALOG_INT_FIFO_OVERFLOW3,
-			CY_AUTANALOG_INT_FIFO_OVERFLOW4, CY_AUTANALOG_INT_FIFO_OVERFLOW5,
-			CY_AUTANALOG_INT_FIFO_OVERFLOW6, CY_AUTANALOG_INT_FIFO_OVERFLOW7,
-		};
-		static const uint32_t fifo_underflow_masks[] = {
-			CY_AUTANALOG_INT_FIFO_UNDERFLOW0, CY_AUTANALOG_INT_FIFO_UNDERFLOW1,
-			CY_AUTANALOG_INT_FIFO_UNDERFLOW2, CY_AUTANALOG_INT_FIFO_UNDERFLOW3,
-			CY_AUTANALOG_INT_FIFO_UNDERFLOW4, CY_AUTANALOG_INT_FIFO_UNDERFLOW5,
-			CY_AUTANALOG_INT_FIFO_UNDERFLOW6, CY_AUTANALOG_INT_FIFO_UNDERFLOW7,
-		};
 		uint32_t fifo_int_mask = 0;
 
 		for (uint8_t i = 0; i < CY_AUTANALOG_FIFO_BUFS_NUM; i++) {
@@ -1345,7 +1428,568 @@ int adc_ifx_autanalog_sar_fifo_set_callback(const struct device *dev,
 	return 0;
 }
 
+#ifdef CONFIG_ADC_INFINEON_AUTANALOG_SAR_STREAM
+
+/**
+ * @brief Compute the RTIO buffer header size (aligned to 4 bytes)
+ */
+static inline uint32_t ifx_stream_header_size(uint8_t num_channels)
+{
+	uint32_t size = sizeof(struct ifx_autanalog_sar_stream_header) +
+			num_channels * sizeof(struct ifx_autanalog_sar_stream_chan_info);
+
+	return (size + 3) & ~3u;
+}
+
+/**
+ * @brief Convert a raw 12-bit ADC sample to q31_t format
+ *
+ * @param raw    Raw signed 32-bit ADC result from FIFO
+ * @param vref_mv Reference voltage in millivolts
+ * @param shift  Q-format shift (integer bits)
+ * @return q31_t value
+ *
+ * The full-scale code (scale - 1) maps to vref_mv, so the voltage per LSB in
+ * microvolts is sensitivity_uv = vref_mv * 1000 * (scale - 1) / scale / scale.
+ * A q31 value represents a voltage in units of 2^-(31 - shift) volts, so the
+ * encoded value is raw * sensitivity_uv * 2^(31 - shift) / 1e6.  All of the
+ * arithmetic below is carried out in int64_t to avoid overflow; the final
+ * result is guaranteed to fit in q31 because raw is a 12-bit code and the
+ * shift is chosen by ifx_vref_to_shift() so full scale maps to <= 1.0.
+ */
+static inline q31_t ifx_raw_to_q31(int32_t raw, uint16_t vref_mv, int8_t shift)
+{
+	uint32_t scale = BIT(ADC_AUTANALOG_SAR_RESOLUTION);
+	uint32_t sensitivity_uv = (vref_mv * (scale - 1)) / scale * 1000 / scale;
+	int64_t q31_per_uv = INT64_C(1) << (31 - shift);
+
+	return (q31_t)(q31_per_uv * sensitivity_uv / 1000000 * raw);
+}
+
+/**
+ * @brief Compute shift for q31 encoding from vref_mv
+ */
+static inline int8_t ifx_vref_to_shift(uint16_t vref_mv)
+{
+	int8_t count = 1;
+
+	while (vref_mv > 1) {
+		vref_mv /= 2;
+		count++;
+	}
+
+	return count;
+}
+
+/**
+ * @brief Drain a single FIFO buffer.
+ */
+static void ifx_stream_drain_fifo(uint8_t buf_idx)
+{
+	int32_t dummy;
+
+	while (Cy_AutAnalog_FIFO_GetSize(0, buf_idx) > 0) {
+		Cy_AutAnalog_FIFO_ReadData(0, buf_idx, 1, &dummy);
+	}
+}
+
+/**
+ * @brief Read a FIFO buffer into the stream frame or drain it.
+ */
+static void ifx_stream_consume_fifo(uint8_t buf_idx, uint16_t sample_count, int32_t **samples,
+				    bool drop_data)
+{
+	if (sample_count == 0) {
+		return;
+	}
+
+	if (!drop_data) {
+		Cy_AutAnalog_FIFO_ReadData(0, buf_idx, sample_count, *samples);
+		*samples += sample_count;
+	} else {
+		ifx_stream_drain_fifo(buf_idx);
+	}
+}
+
+/**
+ * @brief Determine the actual trigger type from the FIFO interrupt status.
+ *
+ * Checks the status bits for any FIFO buffer used by the stream.
+ * If any overflow bit is set, the trigger is FIFO_FULL; if any
+ * level bit is set, it is FIFO_WATERMARK.
+ */
+static enum adc_trigger_type ifx_stream_classify_trigger(struct ifx_autanalog_sar_adc_data *data,
+							 uint32_t fifo_status)
+{
+	for (uint8_t i = 0; i < data->stream_num_channels; i++) {
+		uint8_t buf = data->stream_channels[i].fifo_buf_idx;
+
+		if (fifo_status & fifo_overflow_masks[buf]) {
+			return ADC_TRIG_FIFO_FULL;
+		}
+	}
+	for (uint8_t i = 0; i < data->stream_num_channels; i++) {
+		uint8_t buf = data->stream_channels[i].fifo_buf_idx;
+
+		if (fifo_status & fifo_level_masks[buf]) {
+			return ADC_TRIG_FIFO_WATERMARK;
+		}
+	}
+	/* Fallback — should not happen if we are called from the ISR */
+	return ADC_TRIG_FIFO_WATERMARK;
+}
+
+/**
+ * @brief Look up the data_opt for a given trigger type in the read config.
+ *
+ * If the trigger is not listed, default to INCLUDE so data is not silently dropped.
+ */
+static enum adc_stream_data_opt
+ifx_stream_data_opt_for_trigger(const struct adc_read_config *read_cfg,
+				enum adc_trigger_type trigger)
+{
+	for (size_t i = 0; i < read_cfg->trigger_cnt; i++) {
+		if (read_cfg->triggers[i].trigger == trigger) {
+			return read_cfg->triggers[i].opt;
+		}
+	}
+	return ADC_STREAM_DATA_INCLUDE;
+}
+
+/**
+ * @brief Handle FIFO data for an active stream
+ *
+ * Called from FIFO ISR context when streaming is active.  Drains all FIFO
+ * buffers that are mapped to streamed channels, encodes the data into an
+ * RTIO buffer, and completes the pending iodev sqe.
+ */
+static void ifx_autanalog_sar_stream_fifo_handler(const struct device *dev, uint32_t fifo_status)
+{
+	struct ifx_autanalog_sar_adc_data *data = dev->data;
+	struct rtio_iodev_sqe *sqe = data->stream_sqe;
+	uint64_t timestamp = k_ticks_to_ns_floor64(k_uptime_ticks());
+
+	if (sqe == NULL) {
+		/* No pending sqe yet — leave data in the hardware FIFO.
+		 * The multishot re-submission will provide a fresh sqe
+		 * and the next FIFO interrupt will deliver the
+		 * accumulated samples.
+		 */
+		return;
+	}
+
+	data->stream_sqe = NULL;
+
+	uint8_t num_ch = data->stream_num_channels;
+	uint16_t counts[IFX_AUTANALOG_SAR_STREAM_MAX_CHANNELS];
+	uint16_t total_samples = 0;
+
+	/* Gather FIFO fill levels for each streamed channel */
+	for (uint8_t i = 0; i < num_ch; i++) {
+		counts[i] = Cy_AutAnalog_FIFO_GetSize(0, data->stream_channels[i].fifo_buf_idx);
+		total_samples += counts[i];
+	}
+
+	/* Determine actual trigger from the FIFO interrupt status bits */
+	enum adc_trigger_type trigger = ifx_stream_classify_trigger(data, fifo_status);
+
+	/* Look up data_opt for the trigger that actually fired */
+	const struct adc_read_config *read_cfg = sqe->sqe.iodev->data;
+	enum adc_stream_data_opt data_opt = ifx_stream_data_opt_for_trigger(read_cfg, trigger);
+	bool drop_data = (data_opt == ADC_STREAM_DATA_DROP || data_opt == ADC_STREAM_DATA_NOP);
+
+	/* Calculate buffer size */
+	uint32_t hdr_size = ifx_stream_header_size(num_ch);
+	uint32_t data_size = drop_data ? 0 : (total_samples * sizeof(int32_t));
+	uint32_t buf_size = hdr_size + data_size;
+
+	uint8_t *buf;
+	uint32_t buf_len;
+
+	if (rtio_sqe_rx_buf(sqe, buf_size, buf_size, &buf, &buf_len) != 0) {
+		/* Mempool temporarily exhausted — put the sqe back and
+		 * leave data in the hardware FIFO.  The next FIFO
+		 * interrupt (watermark or overflow) will retry once the
+		 * application releases buffers.
+		 */
+		data->stream_sqe = sqe;
+		return;
+	}
+
+	/* Fill header */
+	struct ifx_autanalog_sar_stream_header *hdr = (struct ifx_autanalog_sar_stream_header *)buf;
+
+	hdr->timestamp_ns = timestamp;
+	hdr->vref_mv = adc_ref_internal(dev);
+	hdr->trigger = (uint8_t)trigger;
+	hdr->num_channels = num_ch;
+	hdr->resolution = ADC_AUTANALOG_SAR_RESOLUTION;
+	hdr->empty = drop_data ? 1 : 0;
+	hdr->reserved = 0;
+
+	/* Fill per-channel info */
+	struct ifx_autanalog_sar_stream_chan_info *chan_info =
+		(struct ifx_autanalog_sar_stream_chan_info
+			 *)(buf + sizeof(struct ifx_autanalog_sar_stream_header));
+
+	int32_t *samples = (int32_t *)(buf + hdr_size);
+
+	for (uint8_t i = 0; i < num_ch; i++) {
+		chan_info[i].channel_id = data->stream_channels[i].channel_id;
+		chan_info[i].fifo_buf_idx = data->stream_channels[i].fifo_buf_idx;
+		chan_info[i].sample_count = counts[i];
+
+		ifx_stream_consume_fifo(data->stream_channels[i].fifo_buf_idx, counts[i], &samples,
+					drop_data);
+	}
+
+	rtio_iodev_sqe_ok(sqe, 0);
+}
+
+/**
+ * @brief Submit handler for ADC streaming via RTIO
+ *
+ * Sets up continuous ADC conversion with FIFO-based data collection.
+ * On first call, configures the sequencer for continuous mode and starts
+ * the ADC.  On subsequent calls (multishot re-submissions), just stores
+ * the new sqe for the FIFO ISR.
+ */
+static void ifx_autanalog_sar_submit_stream(const struct device *dev,
+					    struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct ifx_autanalog_sar_adc_data *data = dev->data;
+	const struct ifx_autanalog_sar_adc_config *cfg = dev->config;
+	const struct adc_read_config *read_cfg = iodev_sqe->sqe.iodev->data;
+	cy_stc_autanalog_state_t ac_state;
+
+	if (!cfg->fifo_enabled) {
+		LOG_ERR("Stream requires FIFO to be enabled in device tree");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+		return;
+	}
+
+	/* With fifo-chan-id the FIFO packs the channel ID into each word, so a bulk
+	 * Cy_AutAnalog_FIFO_ReadData() no longer yields a plain sample value.  The stream
+	 * already reports the channel via the per-channel info (one channel per FIFO buffer
+	 * is enforced below), so the embedded ID is redundant and would corrupt the decoded
+	 * value.  Reject the combination instead of silently producing bad data.
+	 */
+	if (cfg->fifo_chan_id) {
+		LOG_ERR("Streaming is not supported with fifo-chan-id enabled");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+		return;
+	}
+
+	Cy_AutAnalog_GetControllerState(&ac_state);
+	if (ac_state.ac.status == CY_AUTANALOG_AC_STATUS_RUNNING) {
+		LOG_ERR("Autonomous Controller is busy");
+		rtio_iodev_sqe_err(iodev_sqe, -EBUSY);
+		return;
+	}
+
+	/* Store the sqe for the FIFO ISR.  Guard the store with an interrupt lock so
+	 * the FIFO ISR (which reads and clears data->stream_sqe) cannot observe a torn
+	 * hand-off, mirroring the locking done in adc_ifx_autanalog_sar_stream_stop().
+	 */
+	unsigned int key = irq_lock();
+
+	data->stream_sqe = iodev_sqe;
+	irq_unlock(key);
+
+	/* If already streaming, the ADC is running continuously;
+	 * just await the next FIFO interrupt.
+	 */
+	if (data->streaming) {
+		return;
+	}
+
+	/* Build channel-to-FIFO mapping from the sequence channel mask */
+	const struct adc_sequence *sequence = read_cfg->sequence;
+
+	if (sequence == NULL || sequence->channels == 0) {
+		LOG_ERR("Stream sequence not configured");
+		rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+		return;
+	}
+
+	data->stream_num_channels = 0;
+	uint8_t fifo_seen_mask = 0; /* Track FIFO buffers already in use */
+
+	for (uint8_t i = 0; i < IFX_AUTANALOG_SAR_MAX_NUM_CHANNELS; i++) {
+		if ((sequence->channels & BIT(i)) == 0) {
+			continue;
+		}
+
+		uint8_t fifo_sel = data->autanalog_channel_cfg[i].fifo_sel;
+
+		if (fifo_sel == 0) {
+			LOG_ERR("Channel %d not routed to FIFO (missing fifo-sel)", i);
+			rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+			return;
+		}
+
+		uint8_t buf_idx = fifo_sel - 1;
+
+		if (fifo_seen_mask & BIT(buf_idx)) {
+			LOG_ERR("Channels sharing FIFO buffer %d not supported for streaming",
+				buf_idx);
+			rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+			return;
+		}
+		fifo_seen_mask |= BIT(buf_idx);
+
+		if (data->stream_num_channels >= IFX_AUTANALOG_SAR_STREAM_MAX_CHANNELS) {
+			LOG_ERR("Too many stream channels");
+			rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+			return;
+		}
+
+		data->stream_channels[data->stream_num_channels].channel_id = i;
+		data->stream_channels[data->stream_num_channels].fifo_buf_idx = buf_idx;
+		data->stream_num_channels++;
+	}
+
+	/* Configure the sequencer for continuous mode */
+	if (cfg->lp_mode) {
+		if (ifx_build_lp_sequencer_entry(sequence->channels, data) != 0) {
+			LOG_ERR("Error building LP ADC sequencer for stream");
+			rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+			return;
+		}
+
+		/* Set to continuous mode: loop back to start after each conversion */
+		data->pdl_adc_seq_lp_cfg_obj[0].nextAction =
+			CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
+
+		uint32_t result_status = Cy_AutAnalog_SAR_LoadLPseqTable(
+			0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS, &data->pdl_adc_seq_lp_cfg_obj[0]);
+
+		if (result_status != CY_AUTANALOG_SUCCESS) {
+			LOG_ERR("Failed to load LP sequencer for stream: %u",
+				(unsigned int)result_status);
+			rtio_iodev_sqe_err(iodev_sqe, -EIO);
+			return;
+		}
+	} else {
+		if (ifx_build_hs_sequencer_entry(sequence->channels, data) != 0) {
+			LOG_ERR("Error building ADC sequencer for stream");
+			rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+			return;
+		}
+
+		/* Set to continuous mode: loop back to start after each conversion */
+		data->pdl_adc_seq_hs_cfg_obj[0].nextAction =
+			CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
+
+		uint32_t result_status = Cy_AutAnalog_SAR_LoadHSseqTable(
+			0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS, &data->pdl_adc_seq_hs_cfg_obj[0]);
+
+		if (result_status != CY_AUTANALOG_SUCCESS) {
+			LOG_ERR("Failed to load sequencer for stream: %u",
+				(unsigned int)result_status);
+			rtio_iodev_sqe_err(iodev_sqe, -EIO);
+			return;
+		}
+	}
+
+	/* State 0 is used for LP/HS mode selection and peripheral power up.
+	 * State 1 is the stop/reconfiguration state.
+	 * State 2 is the SAR sampling state.
+	 * State 3 jumps back to state 1
+	 */
+	Cy_AutAnalog_OverrideControllerState(IFX_AUTANALOG_SAR_AC_STATE_SAR_SAMPLE);
+	ifx_autanalog_start_autonomous_control(cfg->mfd);
+
+	data->streaming = true;
+
+	LOG_DBG("ADC stream started with %d channels", data->stream_num_channels);
+}
+
+int adc_ifx_autanalog_sar_stream_stop(const struct device *dev)
+{
+	struct ifx_autanalog_sar_adc_data *data = dev->data;
+	const struct ifx_autanalog_sar_adc_config *cfg = dev->config;
+	struct rtio_iodev_sqe *sqe;
+	unsigned int key;
+	int ret = 0;
+
+	if (!data->streaming) {
+		return -EALREADY;
+	}
+
+	/* Stop it the only way the hardware allows: switch the sequencer back to
+	 * single-shot (nextAction = STOP), then re-trigger the AC from the SAR
+	 * sampling state.  The AC runs one more SAR scan, now using the STOP
+	 * sequencer, after which the SAR powers down and the AC walks back to its
+	 * STOP state.
+	 */
+	if (cfg->lp_mode) {
+		data->pdl_adc_seq_lp_cfg_obj[0].nextAction =
+			CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+		(void)Cy_AutAnalog_SAR_LoadLPseqTable(0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
+						      &data->pdl_adc_seq_lp_cfg_obj[0]);
+	} else {
+		data->pdl_adc_seq_hs_cfg_obj[0].nextAction =
+			CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+		(void)Cy_AutAnalog_SAR_LoadHSseqTable(0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
+						      &data->pdl_adc_seq_hs_cfg_obj[0]);
+	}
+
+	/* Clear the streaming state under an interrupt lock so the final STOP scan's
+	 * FIFO interrupt (below) is handled on the non-streaming path and cannot touch
+	 * the SQE we are about to release. The hardware FIFO is intentionally left intact.
+	 */
+	key = irq_lock();
+	sqe = data->stream_sqe;
+	data->stream_sqe = NULL;
+	data->streaming = false;
+	data->stream_num_channels = 0;
+	irq_unlock(key);
+
+	/* Re-trigger the AC from the SAR sampling state so it issues one final scan
+	 * with the STOP sequencer and then halts.  Safe because the AC is not RUNNING
+	 * during streaming (it self-stopped after kicking off the continuous scan).
+	 */
+	Cy_AutAnalog_RunControllerState(IFX_AUTANALOG_SAR_AC_STATE_SAR_SAMPLE);
+	ifx_autanalog_start_autonomous_control(cfg->mfd);
+
+	/* Wait for the single STOP scan to complete and the SAR to power down,
+	 * so a subsequent adc_read() does not race the in-flight conversion.
+	 * This is a deterministic single-conversion wait.
+	 */
+	for (int i = 0; i < IFX_AUTANALOG_SAR_STREAM_STOP_RETRIES; i++) {
+		if (!Cy_AutAnalog_SAR_IsBusy(0)) {
+			break;
+		}
+		k_busy_wait(IFX_AUTANALOG_SAR_STREAM_STOP_POLL_US);
+	}
+	if (Cy_AutAnalog_SAR_IsBusy(0)) {
+		LOG_WRN("SAR did not go idle after stream stop");
+		ret = -EBUSY;
+	}
+
+	/* Terminate the in-flight multishot SQE (if any) so RTIO does not stall.
+	 * The caller is expected to have cancelled the stream's multishot handle
+	 * (rtio_sqe_cancel) before calling this, so it will not be resubmitted.
+	 */
+	if (sqe != NULL) {
+		rtio_iodev_sqe_err(sqe, -ECANCELED);
+	}
+
+	LOG_DBG("ADC stream stopped");
+	return ret;
+}
+
+/* ---- Decoder implementation ---- */
+static int ifx_autanalog_sar_decoder_get_frame_count(const uint8_t *buffer, uint32_t channel,
+						     uint16_t *frame_count)
+{
+	const struct ifx_autanalog_sar_stream_header *hdr =
+		(const struct ifx_autanalog_sar_stream_header *)buffer;
+
+	if (hdr->empty) {
+		*frame_count = 0;
+		return 0;
+	}
+
+	if (channel >= hdr->num_channels) {
+		return -ENOTSUP;
+	}
+
+	const struct ifx_autanalog_sar_stream_chan_info *chan_info =
+		(const struct ifx_autanalog_sar_stream_chan_info
+			 *)(buffer + sizeof(struct ifx_autanalog_sar_stream_header));
+
+	*frame_count = chan_info[channel].sample_count;
+	return 0;
+}
+
+static int ifx_autanalog_sar_decoder_decode(const uint8_t *buffer, uint32_t channel, uint32_t *fit,
+					    uint16_t max_count, void *data_out)
+{
+	ARG_UNUSED(max_count);
+	const struct ifx_autanalog_sar_stream_header *hdr =
+		(const struct ifx_autanalog_sar_stream_header *)buffer;
+	struct adc_data *out = (struct adc_data *)data_out;
+
+	if (hdr->empty || channel >= hdr->num_channels) {
+		return -ENODATA;
+	}
+
+	const struct ifx_autanalog_sar_stream_chan_info *chan_info =
+		(const struct ifx_autanalog_sar_stream_chan_info
+			 *)(buffer + sizeof(struct ifx_autanalog_sar_stream_header));
+
+	if (*fit >= chan_info[channel].sample_count) {
+		return 0; /* No more frames */
+	}
+
+	/* Find sample data offset: sum counts of prior channels */
+	uint32_t hdr_size = ifx_stream_header_size(hdr->num_channels);
+	uint32_t sample_offset = 0;
+
+	for (uint32_t i = 0; i < channel; i++) {
+		sample_offset += chan_info[i].sample_count;
+	}
+	sample_offset += *fit;
+
+	const int32_t *samples = (const int32_t *)(buffer + hdr_size);
+	int32_t raw = samples[sample_offset];
+
+	memset(out, 0, sizeof(*out));
+	out->header.base_timestamp_ns = hdr->timestamp_ns;
+	out->header.reading_count = 1;
+	out->shift = ifx_vref_to_shift(hdr->vref_mv);
+	out->readings[0].timestamp_delta = 0;
+	out->readings[0].value = ifx_raw_to_q31(raw, hdr->vref_mv, out->shift);
+
+	(*fit)++;
+
+	/* This decoder emits one frame per call regardless of max_count, matching the
+	 * adc_data readings[1] single-reading layout.  Return the number of frames
+	 * decoded (1) as required by the adc_decoder_api decode() contract.
+	 */
+	return 1;
+}
+
+static bool ifx_autanalog_sar_decoder_has_trigger(const uint8_t *buffer,
+						  enum adc_trigger_type trigger)
+{
+	const struct ifx_autanalog_sar_stream_header *hdr =
+		(const struct ifx_autanalog_sar_stream_header *)buffer;
+
+	switch (trigger) {
+	case ADC_TRIG_FIFO_WATERMARK:
+	case ADC_TRIG_FIFO_FULL:
+		return hdr->trigger == (uint8_t)trigger;
+	default:
+		return false;
+	}
+}
+
+ADC_DECODER_API_DT_DEFINE() = {
+	.get_frame_count = ifx_autanalog_sar_decoder_get_frame_count,
+	.decode = ifx_autanalog_sar_decoder_decode,
+	.has_trigger = ifx_autanalog_sar_decoder_has_trigger,
+};
+
+static int ifx_autanalog_sar_get_decoder(const struct device *dev,
+					 const struct adc_decoder_api **api)
+{
+	ARG_UNUSED(dev);
+	*api = &ADC_DECODER_NAME();
+	return 0;
+}
+
+#endif /* CONFIG_ADC_INFINEON_AUTANALOG_SAR_STREAM */
+
 /* clang-format off */
+
+#define ADC_IFX_AUTANALOG_SAR_STREAM_API(n)                                                        \
+	IF_ENABLED(CONFIG_ADC_INFINEON_AUTANALOG_SAR_STREAM, (                                     \
+		.submit = ifx_autanalog_sar_submit_stream,                                         \
+		.get_decoder = ifx_autanalog_sar_get_decoder,                                      \
+	))
 
 #ifdef CONFIG_ADC_ASYNC
 #define ADC_IFX_AUTANALOG_SAR_DRIVER_API(n)                                                        \
@@ -1354,6 +1998,7 @@ int adc_ifx_autanalog_sar_fifo_set_callback(const struct device *dev,
 		.read = ifx_autanalog_sar_adc_read,                                                \
 		.read_async = ifx_autanalog_sar_adc_read_async,                                    \
 		.ref_internal = DT_INST_PROP(n, vref_mv),                                          \
+		ADC_IFX_AUTANALOG_SAR_STREAM_API(n)                                                \
 	};
 #else
 #define ADC_IFX_AUTANALOG_SAR_DRIVER_API(n)                                                        \
@@ -1361,6 +2006,7 @@ int adc_ifx_autanalog_sar_fifo_set_callback(const struct device *dev,
 		.channel_setup = ifx_autanalog_sar_adc_channel_setup,                              \
 		.read = ifx_autanalog_sar_adc_read,                                                \
 		.ref_internal = DT_INST_PROP(n, vref_mv),                                          \
+		ADC_IFX_AUTANALOG_SAR_STREAM_API(n)                                                \
 	};
 #endif /* CONFIG_ADC_ASYNC */
 

--- a/drivers/adc/adc_infineon_autanalog_sar.c
+++ b/drivers/adc/adc_infineon_autanalog_sar.c
@@ -43,6 +43,8 @@ LOG_MODULE_REGISTER(ifx_autanalog_sar_adc, CONFIG_ADC_LOG_LEVEL);
 
 #define IFX_AUTANALOG_SAR_SAMPLETIME_COUNT 4
 #define IFX_AUTANALOG_SAR_MAX_FIR_FILTERS  2
+#define IFX_AUTANALOG_SAR_LIMIT_CFG_NUM    4
+#define IFX_AUTANALOG_SAR_CORR_COEFF_NUM   8
 
 #define IFX_AUTANALOG_HF_CLK_SRC 9
 
@@ -137,6 +139,12 @@ struct ifx_autanalog_sar_fir_config {
 	uint8_t fifo_sel;
 };
 
+struct ifx_autanalog_sar_limit_config {
+	uint8_t condition;
+	int32_t low;
+	int32_t high;
+};
+
 struct ifx_autanalog_sar_seq_hs_config {
 	uint8_t gpio_channels;
 	uint8_t mux_mode;
@@ -184,6 +192,11 @@ struct ifx_autanalog_sar_adc_config {
 	const struct ifx_autanalog_sar_seq_lp_config *lp_seq;
 	bool lp_mode;
 	bool lp_diff_en;
+	struct ifx_autanalog_sar_limit_config limit_cond[IFX_AUTANALOG_SAR_LIMIT_CFG_NUM];
+	uint8_t limit_cond_mask; /* bitmask of which limit conditions are configured */
+	bool has_gain_offset_corr;
+	uint16_t gain_corr[IFX_AUTANALOG_SAR_CORR_COEFF_NUM];
+	int16_t offset_corr[IFX_AUTANALOG_SAR_CORR_COEFF_NUM];
 };
 
 struct ifx_autanalog_sar_adc_channel_config {
@@ -251,6 +264,9 @@ struct ifx_autanalog_sar_adc_data {
 
 	/* PDL structure for FIFO configuration */
 	cy_stc_autanalog_fifo_cfg_t pdl_fifo_cfg;
+
+	/* PDL structures for range detection / limit conditions */
+	cy_stc_autanalog_sar_limit_t pdl_limit_cond[IFX_AUTANALOG_SAR_LIMIT_CFG_NUM];
 
 	/* FIFO watermark callback */
 	adc_ifx_autanalog_sar_fifo_callback_t fifo_callback;
@@ -394,10 +410,22 @@ static void ifx_init_pdl_structs(struct ifx_autanalog_sar_adc_data *data,
 		.chanID = cfg->fifo_chan_id,
 		.shiftMode = cfg->shift_mode,
 		.intMuxChan = {NULL}, /* MUX channels configured during channel setup */
-		.limitCond = {NULL},  /* We don't expose the range detection */
+		.limitCond = {NULL},
 		.muxResultMask = 0u,  /* MUX result mask updated during channel setup */
 		.firResultMask = cfg->fir_result_mask,
 	};
+
+	/* Populate range detection limit conditions from DT */
+	for (uint8_t i = 0; i < IFX_AUTANALOG_SAR_LIMIT_CFG_NUM; i++) {
+		if ((cfg->limit_cond_mask & BIT(i)) != 0) {
+			data->pdl_limit_cond[i] = (cy_stc_autanalog_sar_limit_t){
+				.cond = (cy_en_autanalog_sar_cond_t)cfg->limit_cond[i].condition,
+				.low = cfg->limit_cond[i].low,
+				.high = cfg->limit_cond[i].high,
+			};
+			data->pdl_adc_top_static_obj.limitCond[i] = &data->pdl_limit_cond[i];
+		}
+	}
 
 	if (!cfg->lp_mode) {
 		data->pdl_adc_hs_static_obj = (cy_stc_autanalog_sar_sta_hs_t){
@@ -1262,7 +1290,6 @@ static int ifx_autanalog_sar_adc_channel_setup(const struct device *dev,
 		return 0;
 	}
 
-	/* Determine if this is a MUX channel based on channel_id range */
 	is_mux_channel = (channel_cfg->channel_id >= IFX_AUTANALOG_SAR_MUX_CHANNEL_OFFSET);
 
 	/* LP mode only supports MUX channels */
@@ -1377,6 +1404,16 @@ static int ifx_autanalog_sar_adc_init(const struct device *dev)
 	if (result_val != CY_AUTANALOG_SUCCESS) {
 		LOG_ERR("Failed to initialize AutAnalog SAR ADC");
 		return -EIO;
+	}
+
+	/* Load offset and gain correction coefficients if provided via DT */
+	if (cfg->has_gain_offset_corr) {
+		result_val = Cy_AutAnalog_SAR_LoadOffsetGainCorr(
+			0, (uint16_t *)cfg->gain_corr, (int16_t *)cfg->offset_corr);
+		if (result_val != CY_AUTANALOG_SUCCESS) {
+			LOG_ERR("Failed to load offset/gain correction coefficients");
+			return -EIO;
+		}
 	}
 
 	/* Note: We can only partially initialize the AutAnalog system here.  If we try to
@@ -2297,6 +2334,35 @@ static int ifx_autanalog_sar_get_decoder(const struct device *dev,
 		DT_INST_FOREACH_CHILD(n, IFX_SEQ_LP_CFG_ENTRY)                                     \
 	}
 
+/* Limit condition configuration from DT properties limit-cond-0 through limit-cond-3.
+ * Each property is an array of <condition low high>.
+ */
+#define IFX_LIMIT_COND_INIT(n, idx)                                                                \
+	{                                                                                          \
+		.condition = (uint8_t)DT_INST_PROP_BY_IDX(n, limit_cond_##idx, 0),                 \
+		.low = (int32_t)DT_INST_PROP_BY_IDX(n, limit_cond_##idx, 1),                      \
+		.high = (int32_t)DT_INST_PROP_BY_IDX(n, limit_cond_##idx, 2),                     \
+	}
+
+#define IFX_LIMIT_COND_MASK(n)                                                                     \
+	((DT_INST_NODE_HAS_PROP(n, limit_cond_0) << 0) |                                          \
+	 (DT_INST_NODE_HAS_PROP(n, limit_cond_1) << 1) |                                          \
+	 (DT_INST_NODE_HAS_PROP(n, limit_cond_2) << 2) |                                          \
+	 (DT_INST_NODE_HAS_PROP(n, limit_cond_3) << 3))
+
+/* Gain/offset correction: true if either gain-corr or offset-corr is defined */
+#define IFX_HAS_GAIN_OFFSET_CORR(n)                                                                \
+	(DT_INST_NODE_HAS_PROP(n, gain_corr) || DT_INST_NODE_HAS_PROP(n, offset_corr))
+
+/* Default gain is 0x8000 (unity).  Default offset is 0. */
+#define IFX_GAIN_CORR_ELEM(n, idx)                                                                 \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, gain_corr),                                          \
+		    ((uint16_t)DT_INST_PROP_BY_IDX(n, gain_corr, idx)), (0x8000u))
+
+#define IFX_OFFSET_CORR_ELEM(n, idx)                                                               \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, offset_corr),                                        \
+		    ((int16_t)DT_INST_PROP_BY_IDX(n, offset_corr, idx)), (0))
+
 /* Device Instantiation */
 #define IFX_AUTANALOG_SAR_ADC_INIT(n)                                                              \
 	ADC_IFX_AUTANALOG_SAR_DRIVER_API(n);                                     \
@@ -2349,6 +2415,30 @@ static int ifx_autanalog_sar_get_decoder(const struct device *dev,
 		.lp_seq = (IFX_LP_SEQ_DT_COUNT(n) > 0) ? ifx_sar_seq_lp_cfg_##n : NULL, \
 		.lp_mode = DT_INST_PROP(n, lp_mode),                                               \
 		.lp_diff_en = DT_INST_PROP(n, lp_diff_en),                                         \
+		.limit_cond = {                                                                    \
+			COND_CODE_1(DT_INST_NODE_HAS_PROP(n, limit_cond_0),                        \
+				    (IFX_LIMIT_COND_INIT(n, 0)), ({0})),                           \
+			COND_CODE_1(DT_INST_NODE_HAS_PROP(n, limit_cond_1),                        \
+				    (IFX_LIMIT_COND_INIT(n, 1)), ({0})),                           \
+			COND_CODE_1(DT_INST_NODE_HAS_PROP(n, limit_cond_2),                        \
+				    (IFX_LIMIT_COND_INIT(n, 2)), ({0})),                           \
+			COND_CODE_1(DT_INST_NODE_HAS_PROP(n, limit_cond_3),                        \
+				    (IFX_LIMIT_COND_INIT(n, 3)), ({0})),                           \
+		},                                                                                 \
+		.limit_cond_mask = IFX_LIMIT_COND_MASK(n),                                         \
+		.has_gain_offset_corr = IFX_HAS_GAIN_OFFSET_CORR(n),                               \
+		.gain_corr = {                                                                     \
+			IFX_GAIN_CORR_ELEM(n, 0), IFX_GAIN_CORR_ELEM(n, 1),                       \
+			IFX_GAIN_CORR_ELEM(n, 2), IFX_GAIN_CORR_ELEM(n, 3),                       \
+			IFX_GAIN_CORR_ELEM(n, 4), IFX_GAIN_CORR_ELEM(n, 5),                       \
+			IFX_GAIN_CORR_ELEM(n, 6), IFX_GAIN_CORR_ELEM(n, 7),                       \
+		},                                                                                 \
+		.offset_corr = {                                                                   \
+			IFX_OFFSET_CORR_ELEM(n, 0), IFX_OFFSET_CORR_ELEM(n, 1),                   \
+			IFX_OFFSET_CORR_ELEM(n, 2), IFX_OFFSET_CORR_ELEM(n, 3),                   \
+			IFX_OFFSET_CORR_ELEM(n, 4), IFX_OFFSET_CORR_ELEM(n, 5),                   \
+			IFX_OFFSET_CORR_ELEM(n, 6), IFX_OFFSET_CORR_ELEM(n, 7),                   \
+		},                                                                                 \
 	};                                                                                     \
 	static struct ifx_autanalog_sar_adc_data ifx_autanalog_sar_adc_data_##n = {                \
 		ADC_CONTEXT_INIT_LOCK(ifx_autanalog_sar_adc_data_##n, ctx),                        \

--- a/drivers/adc/adc_infineon_autanalog_sar.c
+++ b/drivers/adc/adc_infineon_autanalog_sar.c
@@ -194,6 +194,7 @@ struct ifx_autanalog_sar_adc_config {
 	bool lp_diff_en;
 	struct ifx_autanalog_sar_limit_config limit_cond[IFX_AUTANALOG_SAR_LIMIT_CFG_NUM];
 	uint8_t limit_cond_mask; /* bitmask of which limit conditions are configured */
+	bool ac_advanced;        /* true when parent MFD uses advanced AC (ac-states in DT) */
 	bool has_gain_offset_corr;
 	uint16_t gain_corr[IFX_AUTANALOG_SAR_CORR_COEFF_NUM];
 	int16_t offset_corr[IFX_AUTANALOG_SAR_CORR_COEFF_NUM];
@@ -411,7 +412,7 @@ static void ifx_init_pdl_structs(struct ifx_autanalog_sar_adc_data *data,
 		.shiftMode = cfg->shift_mode,
 		.intMuxChan = {NULL}, /* MUX channels configured during channel setup */
 		.limitCond = {NULL},
-		.muxResultMask = 0u,  /* MUX result mask updated during channel setup */
+		.muxResultMask = 0u, /* MUX result mask updated during channel setup */
 		.firResultMask = cfg->fir_result_mask,
 	};
 
@@ -708,7 +709,6 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 	const struct ifx_autanalog_sar_adc_config *cfg = data->dev->config;
 	const struct adc_sequence *sequence = &ctx->sequence;
 	uint32_t result_status;
-	cy_stc_autanalog_state_t ac_state;
 
 	data->repeat_buffer = data->conversion_buffer;
 	if (data->conversion_buffer == NULL || sequence->buffer_size == 0) {
@@ -734,11 +734,15 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 		return;
 	}
 
-	Cy_AutAnalog_GetControllerState(&ac_state);
-	if (ac_state.ac.status == CY_AUTANALOG_AC_STATUS_RUNNING) {
-		LOG_ERR("Autonomous Controller is busy");
-		ifx_autanalog_sar_complete_error(data, -EBUSY);
-		return;
+	if (!cfg->ac_advanced) {
+		cy_stc_autanalog_state_t ac_state;
+
+		Cy_AutAnalog_GetControllerState(&ac_state);
+		if (ac_state.ac.status == CY_AUTANALOG_AC_STATUS_RUNNING) {
+			LOG_ERR("Autonomous Controller is busy");
+			ifx_autanalog_sar_complete_error(data, -EBUSY);
+			return;
+		}
 	}
 
 	if (Cy_AutAnalog_SAR_IsBusy(0)) {
@@ -757,51 +761,63 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 		Cy_AutAnalog_SAR_ClearMuxChanResultStatus(0, mux_ch);
 	}
 
-	if (cfg->lp_mode) {
-		if (cfg->lp_seq != NULL) {
-			/* DT-defined LP sequencer: force last entry to single-shot */
-			data->pdl_adc_seq_lp_cfg[cfg->num_lp_seq - 1].nextAction =
-				CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
-			result_status = Cy_AutAnalog_SAR_LoadLPseqTable(
-				0, cfg->num_lp_seq, &data->pdl_adc_seq_lp_cfg[0]);
-		} else {
-			if (ifx_build_lp_sequencer_entry(sequence->channels, data) != 0) {
-				LOG_ERR("Error building LP ADC Sequencer Configuration");
-				ifx_autanalog_sar_complete_error(data, -EINVAL);
-				return;
-			}
-			data->pdl_adc_seq_lp_cfg[0].nextAction =
-				CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
-			result_status =
-				Cy_AutAnalog_SAR_LoadLPseqTable(0, 1, &data->pdl_adc_seq_lp_cfg[0]);
-		}
-	} else {
-		if (cfg->hs_seq != NULL) {
-			/* DT-defined HS sequencer: force last entry to single-shot */
-			data->pdl_adc_seq_hs_cfg[cfg->num_hs_seq - 1].nextAction =
-				CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
-			result_status = Cy_AutAnalog_SAR_LoadHSseqTable(
-				0, cfg->num_hs_seq, &data->pdl_adc_seq_hs_cfg[0]);
-		} else {
-			if (ifx_build_hs_sequencer_entry(sequence->channels, data) != 0) {
-				LOG_ERR("Error building HS ADC Sequencer Configuration");
-				ifx_autanalog_sar_complete_error(data, -EINVAL);
-				return;
-			}
-			data->pdl_adc_seq_hs_cfg[0].nextAction =
-				CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
-			result_status = Cy_AutAnalog_SAR_LoadHSseqTable(
-				0, cfg->num_hs_seq, &data->pdl_adc_seq_hs_cfg[0]);
-		}
-	}
-
-	/* State 0 is used for LP/HS mode selection and peripheral power up.
-	 * State 1 is the stop/reconfiguration state.
-	 * State 2 is the SAR sampling state.
-	 * State 3 jumps back to state 1
+	/* In advanced AC mode the state machine is already running and
+	 * triggers SAR conversions according to its STT.  Skip sequencer
+	 * loading and AC start — just wait for results below.
 	 */
-	Cy_AutAnalog_OverrideControllerState(IFX_AUTANALOG_SAR_AC_STATE_SAR_SAMPLE);
-	ifx_autanalog_start_autonomous_control(cfg->mfd);
+	if (!cfg->ac_advanced) {
+		if (cfg->lp_mode) {
+			if (cfg->lp_seq != NULL) {
+				/* DT-defined LP sequencer: force last entry to single-shot */
+				data->pdl_adc_seq_lp_cfg[cfg->num_lp_seq - 1].nextAction =
+					CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+				result_status = Cy_AutAnalog_SAR_LoadLPseqTable(
+					0, cfg->num_lp_seq, &data->pdl_adc_seq_lp_cfg[0]);
+			} else {
+				if (ifx_build_lp_sequencer_entry(sequence->channels, data) != 0) {
+					LOG_ERR("Error building LP ADC Sequencer Configuration");
+					ifx_autanalog_sar_complete_error(data, -EINVAL);
+					return;
+				}
+				data->pdl_adc_seq_lp_cfg[0].nextAction =
+					CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+				result_status = Cy_AutAnalog_SAR_LoadLPseqTable(
+					0, 1, &data->pdl_adc_seq_lp_cfg[0]);
+			}
+		} else {
+			if (cfg->hs_seq != NULL) {
+				/* DT-defined HS sequencer: force last entry to single-shot */
+				data->pdl_adc_seq_hs_cfg[cfg->num_hs_seq - 1].nextAction =
+					CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+				result_status = Cy_AutAnalog_SAR_LoadHSseqTable(
+					0, cfg->num_hs_seq, &data->pdl_adc_seq_hs_cfg[0]);
+			} else {
+				if (ifx_build_hs_sequencer_entry(sequence->channels, data) != 0) {
+					LOG_ERR("Error building HS ADC Sequencer Configuration");
+					ifx_autanalog_sar_complete_error(data, -EINVAL);
+					return;
+				}
+				data->pdl_adc_seq_hs_cfg[0].nextAction =
+					CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+				result_status = Cy_AutAnalog_SAR_LoadHSseqTable(
+					0, cfg->num_hs_seq, &data->pdl_adc_seq_hs_cfg[0]);
+			}
+		}
+		if (result_status != CY_AUTANALOG_SUCCESS) {
+			LOG_ERR("Error Loading ADC Sequencer Configuration: %u",
+				(unsigned int)result_status);
+			ifx_autanalog_sar_complete_error(data, -EIO);
+			return;
+		}
+
+		/* State 0 is used for LP/HS mode selection and peripheral power up.
+		 * State 1 is the stop/reconfiguration state.
+		 * State 2 is the SAR sampling state.
+		 * State 3 jumps back to state 1
+		 */
+		Cy_AutAnalog_OverrideControllerState(IFX_AUTANALOG_SAR_AC_STATE_SAR_SAMPLE);
+		ifx_autanalog_start_autonomous_control(cfg->mfd);
+	}
 
 #if defined(CONFIG_ADC_ASYNC)
 	if (!data->ctx.asynchronous) {
@@ -1408,8 +1424,8 @@ static int ifx_autanalog_sar_adc_init(const struct device *dev)
 
 	/* Load offset and gain correction coefficients if provided via DT */
 	if (cfg->has_gain_offset_corr) {
-		result_val = Cy_AutAnalog_SAR_LoadOffsetGainCorr(
-			0, (uint16_t *)cfg->gain_corr, (int16_t *)cfg->offset_corr);
+		result_val = Cy_AutAnalog_SAR_LoadOffsetGainCorr(0, (uint16_t *)cfg->gain_corr,
+								 (int16_t *)cfg->offset_corr);
 		if (result_val != CY_AUTANALOG_SUCCESS) {
 			LOG_ERR("Failed to load offset/gain correction coefficients");
 			return -EIO;
@@ -1808,7 +1824,6 @@ static void ifx_autanalog_sar_submit_stream(const struct device *dev,
 	struct ifx_autanalog_sar_adc_data *data = dev->data;
 	const struct ifx_autanalog_sar_adc_config *cfg = dev->config;
 	const struct adc_read_config *read_cfg = iodev_sqe->sqe.iodev->data;
-	cy_stc_autanalog_state_t ac_state;
 
 	if (!cfg->fifo_enabled) {
 		LOG_ERR("Stream requires FIFO to be enabled in device tree");
@@ -1828,11 +1843,15 @@ static void ifx_autanalog_sar_submit_stream(const struct device *dev,
 		return;
 	}
 
-	Cy_AutAnalog_GetControllerState(&ac_state);
-	if (ac_state.ac.status == CY_AUTANALOG_AC_STATUS_RUNNING) {
-		LOG_ERR("Autonomous Controller is busy");
-		rtio_iodev_sqe_err(iodev_sqe, -EBUSY);
-		return;
+	if (!cfg->ac_advanced) {
+		cy_stc_autanalog_state_t ac_state;
+
+		Cy_AutAnalog_GetControllerState(&ac_state);
+		if (ac_state.ac.status == CY_AUTANALOG_AC_STATUS_RUNNING) {
+			LOG_ERR("Autonomous Controller is busy");
+			rtio_iodev_sqe_err(iodev_sqe, -EBUSY);
+			return;
+		}
 	}
 
 	/* Store the sqe for the FIFO ISR.  Guard the store with an interrupt lock so
@@ -1897,72 +1916,69 @@ static void ifx_autanalog_sar_submit_stream(const struct device *dev,
 		data->stream_num_channels++;
 	}
 
-	/* Configure the sequencer for continuous mode */
-	if (cfg->lp_mode) {
-		if (cfg->lp_seq != NULL) {
-			/* DT-defined LP sequencer: set last entry to continuous */
-			data->pdl_adc_seq_lp_cfg[cfg->num_lp_seq - 1].nextAction =
-				CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
-		} else {
-			if (ifx_build_lp_sequencer_entry(sequence->channels, data) != 0) {
-				LOG_ERR("Error building LP ADC sequencer for stream");
-				rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
-				return;
-			}
-			data->pdl_adc_seq_lp_cfg[0].nextAction =
-				CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
-		}
-
-		/* Set to continuous mode: loop back to start after each conversion */
-		data->pdl_adc_seq_lp_cfg[0].nextAction =
-			CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
-
-		uint32_t result_status = Cy_AutAnalog_SAR_LoadLPseqTable(
-			0, cfg->num_lp_seq, &data->pdl_adc_seq_lp_cfg[0]);
-
-		if (result_status != CY_AUTANALOG_SUCCESS) {
-			LOG_ERR("Failed to load LP sequencer for stream: %u",
-				(unsigned int)result_status);
-			rtio_iodev_sqe_err(iodev_sqe, -EIO);
-			return;
-		}
-	} else {
-		if (cfg->hs_seq != NULL) {
-			/* DT-defined HS sequencer: set last entry to continuous */
-			data->pdl_adc_seq_hs_cfg[cfg->num_hs_seq - 1].nextAction =
-				CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
-		} else {
-			if (ifx_build_hs_sequencer_entry(sequence->channels, data) != 0) {
-				LOG_ERR("Error building ADC sequencer for stream");
-				rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
-				return;
-			}
-			data->pdl_adc_seq_hs_cfg[0].nextAction =
-				CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
-		}
-
-		/* Set to continuous mode: loop back to start after each conversion */
-		data->pdl_adc_seq_hs_cfg[0].nextAction =
-			CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
-
-		uint32_t result_status = Cy_AutAnalog_SAR_LoadHSseqTable(
-			0, cfg->num_hs_seq, &data->pdl_adc_seq_hs_cfg[0]);
-
-		if (result_status != CY_AUTANALOG_SUCCESS) {
-			LOG_ERR("Failed to load sequencer for stream: %u",
-				(unsigned int)result_status);
-			rtio_iodev_sqe_err(iodev_sqe, -EIO);
-			return;
-		}
-	}
-
-	/* State 0 is used for LP/HS mode selection and peripheral power up.
-	 * State 1 is the stop/reconfiguration state.
-	 * State 2 is the SAR sampling state.
-	 * State 3 jumps back to state 1
+	/* In advanced AC mode the state machine is already running and
+	 * triggers SAR conversions via the STT.
 	 */
-	Cy_AutAnalog_OverrideControllerState(IFX_AUTANALOG_SAR_AC_STATE_SAR_SAMPLE);
-	ifx_autanalog_start_autonomous_control(cfg->mfd);
+	if (!cfg->ac_advanced) {
+		/* Configure the sequencer for continuous mode */
+		if (cfg->lp_mode) {
+			if (cfg->lp_seq != NULL) {
+				/* DT-defined LP sequencer: set last entry to continuous */
+				data->pdl_adc_seq_lp_cfg[cfg->num_lp_seq - 1].nextAction =
+					CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
+			} else {
+				if (ifx_build_lp_sequencer_entry(sequence->channels, data) != 0) {
+					LOG_ERR("Error building LP ADC sequencer for stream");
+					rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+					return;
+				}
+				data->pdl_adc_seq_lp_cfg[0].nextAction =
+					CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
+			}
+
+			uint32_t result_status = Cy_AutAnalog_SAR_LoadLPseqTable(
+				0, cfg->num_lp_seq, &data->pdl_adc_seq_lp_cfg[0]);
+
+			if (result_status != CY_AUTANALOG_SUCCESS) {
+				LOG_ERR("Failed to load LP sequencer for stream: %u",
+					(unsigned int)result_status);
+				rtio_iodev_sqe_err(iodev_sqe, -EIO);
+				return;
+			}
+		} else {
+			if (cfg->hs_seq != NULL) {
+				/* DT-defined HS sequencer: set last entry to continuous */
+				data->pdl_adc_seq_hs_cfg[cfg->num_hs_seq - 1].nextAction =
+					CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
+			} else {
+				if (ifx_build_hs_sequencer_entry(sequence->channels, data) != 0) {
+					LOG_ERR("Error building ADC sequencer for stream");
+					rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+					return;
+				}
+				data->pdl_adc_seq_hs_cfg[0].nextAction =
+					CY_AUTANALOG_SAR_NEXT_ACTION_GO_TO_ENTRY_ADDR;
+			}
+
+			uint32_t result_status = Cy_AutAnalog_SAR_LoadHSseqTable(
+				0, cfg->num_hs_seq, &data->pdl_adc_seq_hs_cfg[0]);
+
+			if (result_status != CY_AUTANALOG_SUCCESS) {
+				LOG_ERR("Failed to load sequencer for stream: %u",
+					(unsigned int)result_status);
+				rtio_iodev_sqe_err(iodev_sqe, -EIO);
+				return;
+			}
+		}
+
+		/* State 0 is used for LP/HS mode selection and peripheral power up.
+		 * State 1 is the stop/reconfiguration state.
+		 * State 2 is the SAR sampling state.
+		 * State 3 jumps back to state 1
+		 */
+		Cy_AutAnalog_OverrideControllerState(IFX_AUTANALOG_SAR_AC_STATE_SAR_SAMPLE);
+		ifx_autanalog_start_autonomous_control(cfg->mfd);
+	}
 
 	data->streaming = true;
 
@@ -2426,6 +2442,7 @@ static int ifx_autanalog_sar_get_decoder(const struct device *dev,
 				    (IFX_LIMIT_COND_INIT(n, 3)), ({0})),                           \
 		},                                                                                 \
 		.limit_cond_mask = IFX_LIMIT_COND_MASK(n),                                         \
+		.ac_advanced = DT_NODE_HAS_PROP(DT_INST_PARENT(n), ac_states),                     \
 		.has_gain_offset_corr = IFX_HAS_GAIN_OFFSET_CORR(n),                               \
 		.gain_corr = {                                                                     \
 			IFX_GAIN_CORR_ELEM(n, 0), IFX_GAIN_CORR_ELEM(n, 1),                       \

--- a/drivers/adc/adc_infineon_autanalog_sar.c
+++ b/drivers/adc/adc_infineon_autanalog_sar.c
@@ -118,6 +118,13 @@ struct ifx_autanalog_sar_channel_dt_config {
 	uint8_t channel_id;
 	uint8_t fifo_sel;
 	bool mux_buf_bypass;
+	bool sign;
+	bool differential;
+	uint8_t neg_pin;
+	uint8_t pos_coeff;
+	uint8_t neg_coeff;
+	bool acc_shift;
+	uint8_t limit;
 };
 
 struct ifx_autanalog_sar_fir_config {
@@ -188,6 +195,20 @@ struct ifx_autanalog_sar_adc_channel_config {
 	bool mux_buf_bypass;
 	/* FIFO selection for this channel */
 	uint8_t fifo_sel;
+	/* Sign extension enable */
+	bool sign;
+	/* Differential mode enable (GPIO channels only) */
+	bool differential;
+	/* Negative GPIO pin for differential mode */
+	uint8_t neg_pin;
+	/* Positive correction coefficient */
+	uint8_t pos_coeff;
+	/* Negative correction coefficient */
+	uint8_t neg_coeff;
+	/* Accumulator shift enable */
+	bool acc_shift;
+	/* Limit status / range detection selection */
+	uint8_t limit;
 };
 
 struct ifx_autanalog_sar_adc_data {
@@ -1077,13 +1098,21 @@ static int ifx_autanalog_sar_setup_gpio_channel(struct ifx_autanalog_sar_adc_dat
 	data->pdl_adc_hs_static_obj.hsGpioChan[hw_channel] = pdl_channel;
 
 	pdl_channel->posPin = channel_cfg->input_positive;
-	pdl_channel->hsDiffEn = false;
-	pdl_channel->sign = false;
-	pdl_channel->posCoeff = CY_AUTANALOG_SAR_CH_COEFF_DISABLED;
-	pdl_channel->negPin = CY_AUTANALOG_SAR_PIN_GPIO0;
-	pdl_channel->accShift = false;
-	pdl_channel->negCoeff = CY_AUTANALOG_SAR_CH_COEFF_DISABLED;
-	pdl_channel->hsLimit = CY_AUTANALOG_SAR_LIMIT_STATUS_DISABLED;
+	pdl_channel->hsDiffEn = data->autanalog_channel_cfg[channel_cfg->channel_id].differential;
+	pdl_channel->sign = data->autanalog_channel_cfg[channel_cfg->channel_id].sign;
+	pdl_channel->posCoeff =
+		(cy_en_autanalog_sar_ch_coeff_t)data->autanalog_channel_cfg[channel_cfg->channel_id]
+			.pos_coeff;
+	pdl_channel->negPin = data->autanalog_channel_cfg[channel_cfg->channel_id].differential
+				      ? data->autanalog_channel_cfg[channel_cfg->channel_id].neg_pin
+				      : CY_AUTANALOG_SAR_PIN_GPIO0;
+	pdl_channel->accShift = data->autanalog_channel_cfg[channel_cfg->channel_id].acc_shift;
+	pdl_channel->negCoeff =
+		(cy_en_autanalog_sar_ch_coeff_t)data->autanalog_channel_cfg[channel_cfg->channel_id]
+			.neg_coeff;
+	pdl_channel->hsLimit =
+		(cy_en_autanalog_sar_limit_t)data->autanalog_channel_cfg[channel_cfg->channel_id]
+			.limit;
 	pdl_channel->fifoSel =
 		(cy_en_autanalog_fifo_sel_t)data->autanalog_channel_cfg[channel_cfg->channel_id]
 			.fifo_sel;
@@ -1125,14 +1154,20 @@ static int ifx_autanalog_sar_setup_mux_channel(struct ifx_autanalog_sar_adc_data
 	data->pdl_adc_top_static_obj.intMuxChan[mux_idx] = pdl_mux_channel;
 
 	pdl_mux_channel->posPin = (cy_en_autanalog_sar_pin_mux_t)channel_cfg->input_positive;
-	pdl_mux_channel->sign = false;
-	pdl_mux_channel->posCoeff = CY_AUTANALOG_SAR_CH_COEFF_DISABLED;
+	pdl_mux_channel->sign = data->autanalog_channel_cfg[channel_cfg->channel_id].sign;
+	pdl_mux_channel->posCoeff =
+		(cy_en_autanalog_sar_ch_coeff_t)data->autanalog_channel_cfg[channel_cfg->channel_id]
+			.pos_coeff;
 	pdl_mux_channel->negPin = (cy_en_autanalog_sar_pin_mux_t)channel_cfg->input_negative;
 	pdl_mux_channel->buffBypass =
 		data->autanalog_channel_cfg[channel_cfg->channel_id].mux_buf_bypass;
-	pdl_mux_channel->accShift = false;
-	pdl_mux_channel->negCoeff = CY_AUTANALOG_SAR_CH_COEFF_DISABLED;
-	pdl_mux_channel->muxLimit = CY_AUTANALOG_SAR_LIMIT_STATUS_DISABLED;
+	pdl_mux_channel->accShift = data->autanalog_channel_cfg[channel_cfg->channel_id].acc_shift;
+	pdl_mux_channel->negCoeff =
+		(cy_en_autanalog_sar_ch_coeff_t)data->autanalog_channel_cfg[channel_cfg->channel_id]
+			.neg_coeff;
+	pdl_mux_channel->muxLimit =
+		(cy_en_autanalog_sar_limit_t)data->autanalog_channel_cfg[channel_cfg->channel_id]
+			.limit;
 	pdl_mux_channel->fifoSel =
 		(cy_en_autanalog_fifo_sel_t)data->autanalog_channel_cfg[channel_cfg->channel_id]
 			.fifo_sel;
@@ -1237,8 +1272,8 @@ static int ifx_autanalog_sar_adc_channel_setup(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (channel_cfg->differential) {
-		LOG_ERR("Differential channels not supported");
+	if (channel_cfg->differential && is_mux_channel) {
+		LOG_ERR("Differential mode for MUX channels is configured via sequencer mux-mode");
 		return -EINVAL;
 	}
 
@@ -1303,6 +1338,13 @@ static int ifx_autanalog_sar_adc_init(const struct device *dev)
 		data->autanalog_channel_cfg[i].sample_time_idx = 0xFF;
 		data->autanalog_channel_cfg[i].fifo_sel = IFX_AUTANALOG_SAR_FIFO_DISABLED;
 		data->autanalog_channel_cfg[i].mux_buf_bypass = false;
+		data->autanalog_channel_cfg[i].sign = false;
+		data->autanalog_channel_cfg[i].differential = false;
+		data->autanalog_channel_cfg[i].neg_pin = 0;
+		data->autanalog_channel_cfg[i].pos_coeff = 0;
+		data->autanalog_channel_cfg[i].neg_coeff = 0;
+		data->autanalog_channel_cfg[i].acc_shift = false;
+		data->autanalog_channel_cfg[i].limit = 0;
 	}
 
 	data->dev = dev;
@@ -1316,6 +1358,14 @@ static int ifx_autanalog_sar_adc_init(const struct device *dev)
 			data->autanalog_channel_cfg[ch].mux_buf_bypass =
 				cfg->dt_channels[i].mux_buf_bypass;
 			data->autanalog_channel_cfg[ch].fifo_sel = cfg->dt_channels[i].fifo_sel;
+			data->autanalog_channel_cfg[ch].sign = cfg->dt_channels[i].sign;
+			data->autanalog_channel_cfg[ch].differential =
+				cfg->dt_channels[i].differential;
+			data->autanalog_channel_cfg[ch].neg_pin = cfg->dt_channels[i].neg_pin;
+			data->autanalog_channel_cfg[ch].pos_coeff = cfg->dt_channels[i].pos_coeff;
+			data->autanalog_channel_cfg[ch].neg_coeff = cfg->dt_channels[i].neg_coeff;
+			data->autanalog_channel_cfg[ch].acc_shift = cfg->dt_channels[i].acc_shift;
+			data->autanalog_channel_cfg[ch].limit = cfg->dt_channels[i].limit;
 		}
 	}
 
@@ -2134,6 +2184,13 @@ static int ifx_autanalog_sar_get_decoder(const struct device *dev,
 			.channel_id = (uint8_t)DT_REG_ADDR(child_node_id),                         \
 			.mux_buf_bypass = DT_PROP_OR(child_node_id, mux_buf_bypass, 0),            \
 			.fifo_sel = (uint8_t)DT_PROP_OR(child_node_id, fifo_sel, 0),               \
+			.sign = DT_PROP_OR(child_node_id, sign, 0),                                \
+			.differential = DT_PROP_OR(child_node_id, differential, 0),                \
+			.neg_pin = (uint8_t)DT_PROP_OR(child_node_id, neg_pin, 0),                 \
+			.pos_coeff = (uint8_t)DT_PROP_OR(child_node_id, pos_coeff, 0),             \
+			.neg_coeff = (uint8_t)DT_PROP_OR(child_node_id, neg_coeff, 0),             \
+			.acc_shift = DT_PROP_OR(child_node_id, acc_shift, 0),                      \
+			.limit = (uint8_t)DT_PROP_OR(child_node_id, limit, 0),                     \
 		},), ())
 
 #define IFX_CHAN_DT_CFG_ARRAY(n)                                                                   \

--- a/drivers/adc/adc_infineon_autanalog_sar.c
+++ b/drivers/adc/adc_infineon_autanalog_sar.c
@@ -42,6 +42,9 @@ LOG_MODULE_REGISTER(ifx_autanalog_sar_adc, CONFIG_ADC_LOG_LEVEL);
 
 #define IFX_AUTANALOG_HF_CLK_SRC 9
 
+/* LPOSC frequency used in LP mode (4.096 MHz) */
+#define IFX_AUTANALOG_SAR_LPOSC_FREQ_HZ 4096000
+
 /* clang-format off */
 
 /* FIR pseudo-channel support: FIR filter outputs appear as virtual ADC channels */
@@ -101,6 +104,8 @@ struct ifx_autanalog_sar_adc_config {
 	struct ifx_autanalog_sar_fir_config fir[IFX_AUTANALOG_SAR_MAX_FIR_FILTERS];
 	bool fifo_enabled;
 	struct ifx_autanalog_sar_fifo_config fifo_cfg;
+	bool lp_mode;
+	bool lp_diff_en;
 };
 
 struct ifx_autanalog_sar_adc_channel_config {
@@ -145,6 +150,10 @@ struct ifx_autanalog_sar_adc_data {
 	cy_stc_autanalog_sar_mux_chan_t
 		pdl_adc_mux_channel_cfg_obj_arr[IFX_AUTANALOG_SAR_MAX_MUX_CHANNELS];
 
+	/* PDL structures for LP mode */
+	cy_stc_autanalog_sar_sta_lp_t pdl_adc_lp_static_obj;
+	cy_stc_autanalog_sar_seq_tab_lp_t pdl_adc_seq_lp_cfg_obj[IFX_AUTANALOG_SAR_NUM_SEQUENCERS];
+
 	/* PDL structures for FIR filters */
 	cy_stc_autanalog_sar_fir_cfg_t pdl_fir_cfg[IFX_AUTANALOG_SAR_MAX_FIR_FILTERS];
 
@@ -174,32 +183,44 @@ static void ifx_init_pdl_structs(struct ifx_autanalog_sar_adc_data *data,
 		 * reconfigured every time an adc read is started.  Hardware supports up to 32
 		 * sequencers, which can be used for more advanced ADC configurations.
 		 */
-		.hsSeqTabNum = IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
-		.hsSeqTabArr = &data->pdl_adc_seq_hs_cfg_obj[0],
-		.lpSeqTabNum = 0U,
-		.lpSeqTabArr = NULL,
+		.hsSeqTabNum = cfg->lp_mode ? 0U : IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
+		.hsSeqTabArr = cfg->lp_mode ? NULL : &data->pdl_adc_seq_hs_cfg_obj[0],
+		.lpSeqTabNum = cfg->lp_mode ? IFX_AUTANALOG_SAR_NUM_SEQUENCERS : 0U,
+		.lpSeqTabArr = cfg->lp_mode ? &data->pdl_adc_seq_lp_cfg_obj[0] : NULL,
 		.firNum = cfg->fir_count,
 		.firCfg = (cfg->fir_count > 0) ? &data->pdl_fir_cfg[0] : NULL,
 		.fifoCfg = cfg->fifo_enabled ? &data->pdl_fifo_cfg : NULL,
 	};
 
-	data->pdl_adc_seq_hs_cfg_obj[0] = (cy_stc_autanalog_sar_seq_tab_hs_t){
-		.chanEn = CY_AUTANALOG_SAR_CHAN_MASK_GPIO_DISABLED,
-		.muxMode = CY_AUTANALOG_SAR_CHAN_CFG_MUX_DISABLED,
-		.mux0Sel = CY_AUTANALOG_SAR_CHAN_CFG_MUX0,
-		.mux1Sel = CY_AUTANALOG_SAR_CHAN_CFG_MUX0,
-		.sampleTimeEn = true,
-		.sampleTime = CY_AUTANALOG_SAR_SAMPLE_TIME0,
-		.accEn = false,
-		.accCount = CY_AUTANALOG_SAR_ACC_CNT2,
-		.calReq = CY_AUTANALOG_SAR_CAL_DISABLED,
-		.nextAction = CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP, /* Single Shot mode  */
-
-	};
+	if (!cfg->lp_mode) {
+		data->pdl_adc_seq_hs_cfg_obj[0] = (cy_stc_autanalog_sar_seq_tab_hs_t){
+			.chanEn = CY_AUTANALOG_SAR_CHAN_MASK_GPIO_DISABLED,
+			.muxMode = CY_AUTANALOG_SAR_CHAN_CFG_MUX_DISABLED,
+			.mux0Sel = CY_AUTANALOG_SAR_CHAN_CFG_MUX0,
+			.mux1Sel = CY_AUTANALOG_SAR_CHAN_CFG_MUX0,
+			.sampleTimeEn = true,
+			.sampleTime = CY_AUTANALOG_SAR_SAMPLE_TIME0,
+			.accEn = false,
+			.accCount = CY_AUTANALOG_SAR_ACC_CNT2,
+			.calReq = CY_AUTANALOG_SAR_CAL_DISABLED,
+			.nextAction = CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP,
+		};
+	} else {
+		data->pdl_adc_seq_lp_cfg_obj[0] = (cy_stc_autanalog_sar_seq_tab_lp_t){
+			.chanEn = true,
+			.mux0Sel = 0,
+			.sampleTimeEn = true,
+			.sampleTime = CY_AUTANALOG_SAR_SAMPLE_TIME0,
+			.accEn = false,
+			.accCount = CY_AUTANALOG_SAR_ACC_CNT2,
+			.calReq = CY_AUTANALOG_SAR_CAL_DISABLED,
+			.nextAction = CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP,
+		};
+	}
 
 	data->pdl_adc_top_static_obj = (cy_stc_autanalog_sar_sta_t){
-		.lpStaCfg = NULL, /* This driver implementation only implements HS mode.*/
-		.hsStaCfg = &data->pdl_adc_hs_static_obj,
+		.lpStaCfg = cfg->lp_mode ? &data->pdl_adc_lp_static_obj : NULL,
+		.hsStaCfg = cfg->lp_mode ? NULL : &data->pdl_adc_hs_static_obj,
 		.posBufPwr = (cy_en_autanalog_sar_buf_pwr_t)cfg->pos_buf_pwr,
 		.negBufPwr = (cy_en_autanalog_sar_buf_pwr_t)cfg->neg_buf_pwr,
 		/* Note:  This setting chooses "accumulate and dump" vs. "interleaved" for channels
@@ -220,27 +241,22 @@ static void ifx_init_pdl_structs(struct ifx_autanalog_sar_adc_data *data,
 		.firResultMask = cfg->fir_result_mask,
 	};
 
-	data->pdl_adc_hs_static_obj = (cy_stc_autanalog_sar_sta_hs_t){
-		.hsVref = (cy_en_autanalog_sar_vref_t)cfg->vref_source,
-		.hsSampleTime = {
-				0,
-				0,
-				0,
-				0,
-			},
-		/* These will be configured during channel setup */
-		.hsGpioChan = {
-				NULL,
-				NULL,
-				NULL,
-				NULL,
-				NULL,
-				NULL,
-				NULL,
-				NULL,
-			},
-		.hsGpioResultMask = 0,
-	};
+	if (!cfg->lp_mode) {
+		data->pdl_adc_hs_static_obj = (cy_stc_autanalog_sar_sta_hs_t){
+			.hsVref = (cy_en_autanalog_sar_vref_t)cfg->vref_source,
+			.hsSampleTime = {0, 0, 0, 0},
+			/* These will be configured during channel setup */
+			.hsGpioChan = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL},
+			.hsGpioResultMask = 0,
+		};
+	} else {
+		/* Initialize LP static configuration */
+		data->pdl_adc_lp_static_obj = (cy_stc_autanalog_sar_sta_lp_t){
+			.lpDiffEn = cfg->lp_diff_en,
+			.lpVref = (cy_en_autanalog_sar_vref_t)cfg->vref_source,
+			.lpSampleTime = {0, 0, 0, 0},
+		};
+	}
 
 	/* Initialize FIR filter configurations from device tree */
 	for (uint8_t i = 0; i < cfg->fir_count; i++) {
@@ -323,6 +339,12 @@ static void ifx_autanalog_sar_get_results(uint32_t channels,
 		}
 	}
 } /* ifx_autanalog_sar_get_results() */
+
+static void ifx_autanalog_sar_complete_error(struct ifx_autanalog_sar_adc_data *data, int status)
+{
+	data->conversion_result = status;
+	adc_context_complete(&data->ctx, status);
+}
 
 /**
  * @brief Build a sequencer entry for the specified channels
@@ -428,6 +450,71 @@ static int ifx_build_hs_sequencer_entry(uint32_t channels, struct ifx_autanalog_
 	return 0;
 } /* ifx_build_hs_sequencer_entry() */
 
+/**
+ * @brief Build an LP sequencer entry for the specified channel
+ *
+ * @param channels Bitmask of channels to include in the sequencer entry
+ * @param data Pointer to driver data structure
+ *
+ * Builds a single LP sequencer entry.  LP mode supports only one MUX channel
+ * per entry (only mux0Sel is available), so exactly one MUX channel must be
+ * set in @p channels.
+ *
+ * @return 0 on success, -EINVAL if an error occurs.
+ */
+static int ifx_build_lp_sequencer_entry(uint32_t channels, struct ifx_autanalog_sar_adc_data *data)
+{
+	uint16_t mux_channels = IFX_MUX_CHANNELS_MASK(channels);
+	cy_stc_autanalog_sar_seq_tab_lp_t *seq_entry = &data->pdl_adc_seq_lp_cfg_obj[0];
+	uint8_t mux_idx = 0xFF;
+	uint8_t ch_id;
+
+	if (IFX_GPIO_CHANNELS_MASK(channels) != 0) {
+		LOG_ERR("LP mode does not support GPIO channels");
+		return -EINVAL;
+	}
+
+	if (mux_channels == 0) {
+		LOG_ERR("No MUX channels specified for LP mode");
+		return -EINVAL;
+	}
+
+	/* LP sequencer entry has only mux0Sel, so exactly one MUX channel is allowed */
+	if (POPCOUNT(mux_channels) != 1) {
+		LOG_ERR("LP mode supports only one MUX channel per sequencer entry");
+		return -EINVAL;
+	}
+
+	/* Find the single set bit */
+	for (uint8_t i = 0; i < IFX_AUTANALOG_SAR_MAX_MUX_CHANNELS; i++) {
+		if ((mux_channels & BIT(i)) != 0) {
+			mux_idx = i;
+			break;
+		}
+	}
+
+	ch_id = mux_idx + IFX_AUTANALOG_SAR_MUX_CHANNEL_OFFSET;
+
+	if (data->autanalog_channel_cfg[ch_id].sample_time_idx >=
+	    IFX_AUTANALOG_SAR_SAMPLETIME_COUNT) {
+		LOG_ERR("Invalid sample time index for channel %d", ch_id);
+		return -EINVAL;
+	}
+
+	seq_entry->chanEn = true;
+	seq_entry->mux0Sel = mux_idx;
+	seq_entry->sampleTimeEn = true;
+	seq_entry->sampleTime =
+		(cy_en_autanalog_sar_sample_time_t)data->autanalog_channel_cfg[ch_id]
+			.sample_time_idx;
+	seq_entry->accEn = false;
+	seq_entry->accCount = CY_AUTANALOG_SAR_ACC_CNT2;
+	seq_entry->calReq = CY_AUTANALOG_SAR_CAL_DISABLED;
+	seq_entry->nextAction = CY_AUTANALOG_SAR_NEXT_ACTION_STATE_STOP;
+
+	return 0;
+} /* ifx_build_lp_sequencer_entry() */
+
 /** @brief Start ADC sampling
  *
  * @param ctx Pointer to ADC context
@@ -442,17 +529,17 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 	const struct ifx_autanalog_sar_adc_config *cfg = data->dev->config;
 	const struct adc_sequence *sequence = &ctx->sequence;
 	uint32_t result_status;
+	cy_stc_autanalog_state_t ac_state;
 
 	data->repeat_buffer = data->conversion_buffer;
 	if (data->conversion_buffer == NULL || sequence->buffer_size == 0) {
-		data->conversion_result = -ENOMEM;
+		ifx_autanalog_sar_complete_error(data, -ENOMEM);
 		return;
 	}
 
 	if (sequence->channels == 0) {
 		LOG_ERR("No channels specified");
-		data->conversion_result = -EINVAL;
-
+		ifx_autanalog_sar_complete_error(data, -EINVAL);
 		return;
 	}
 
@@ -468,58 +555,80 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 		return;
 	}
 
+	Cy_AutAnalog_GetControllerState(&ac_state);
+	if (ac_state.ac.status == CY_AUTANALOG_AC_STATUS_RUNNING) {
+		LOG_ERR("Autonomous Controller is busy");
+		ifx_autanalog_sar_complete_error(data, -EBUSY);
+		return;
+	}
+
+	if (Cy_AutAnalog_SAR_IsBusy(0)) {
+		LOG_ERR("SAR is busy");
+		ifx_autanalog_sar_complete_error(data, -EBUSY);
+		return;
+	}
+
+	uint8_t gpio_ch = IFX_GPIO_CHANNELS_MASK(sequence->channels);
+	uint16_t mux_ch = IFX_MUX_CHANNELS_MASK(sequence->channels);
+
+	if (gpio_ch != 0) {
+		Cy_AutAnalog_SAR_ClearHSchanResultStatus(0, gpio_ch);
+	}
+	if (mux_ch != 0) {
+		Cy_AutAnalog_SAR_ClearMuxChanResultStatus(0, mux_ch);
+	}
+
 	/* This implementation uses a single sequencer which is reconfigured for every ADC
 	 * read operation.  If needed, this can be extended to use multiple sequencers.
 	 */
-	if (ifx_build_hs_sequencer_entry(sequence->channels, data) != 0) {
-		LOG_ERR("Error building ADC Sequencer Configuration");
-		data->conversion_result = -EINVAL;
-		return;
-	}
+	if (cfg->lp_mode) {
+		if (ifx_build_lp_sequencer_entry(sequence->channels, data) != 0) {
+			LOG_ERR("Error building LP ADC Sequencer Configuration");
+			ifx_autanalog_sar_complete_error(data, -EINVAL);
+			return;
+		}
 
-	/* Stop the Autonomous Controller while we reconfigure the sequencer */
-	ifx_autanalog_pause_autonomous_control(cfg->mfd);
-	result_status = Cy_AutAnalog_SAR_LoadHSseqTable(0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
-							&data->pdl_adc_seq_hs_cfg_obj[0]);
+		result_status = Cy_AutAnalog_SAR_LoadLPseqTable(0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
+								&data->pdl_adc_seq_lp_cfg_obj[0]);
+	} else {
+		if (ifx_build_hs_sequencer_entry(sequence->channels, data) != 0) {
+			LOG_ERR("Error building HS ADC Sequencer Configuration");
+			ifx_autanalog_sar_complete_error(data, -EINVAL);
+			return;
+		}
+
+		result_status = Cy_AutAnalog_SAR_LoadHSseqTable(0, IFX_AUTANALOG_SAR_NUM_SEQUENCERS,
+								&data->pdl_adc_seq_hs_cfg_obj[0]);
+	}
 	if (result_status != CY_AUTANALOG_SUCCESS) {
 		LOG_ERR("Error Loading ADC Sequencer Configuration: %u",
 			(unsigned int)result_status);
-		data->conversion_result = -EIO;
+		ifx_autanalog_sar_complete_error(data, -EIO);
 		return;
 	}
 
+	/* State 0 is used for LP/HS mode selection and peripheral power up.
+	 * State 1 is the stop/reconfiguration state.
+	 * State 2 is the SAR sampling state.
+	 * State 3 jumps back to state 1
+	 */
+	Cy_AutAnalog_OverrideControllerState(2);
 	ifx_autanalog_start_autonomous_control(cfg->mfd);
-
-	{
-		uint8_t gpio_ch = IFX_GPIO_CHANNELS_MASK(sequence->channels);
-		uint16_t mux_ch = IFX_MUX_CHANNELS_MASK(sequence->channels);
-
-		if (gpio_ch != 0) {
-			Cy_AutAnalog_SAR_ClearHSchanResultStatus(0, gpio_ch);
-		}
-		if (mux_ch != 0) {
-			Cy_AutAnalog_SAR_ClearMuxChanResultStatus(0, mux_ch);
-		}
-	}
 
 #if defined(CONFIG_ADC_ASYNC)
 	if (!data->ctx.asynchronous) {
 #endif
 		/* Wait for conversion to complete */
-		{
-			uint8_t gpio_ch = IFX_GPIO_CHANNELS_MASK(sequence->channels);
-			uint16_t mux_ch = IFX_MUX_CHANNELS_MASK(sequence->channels);
-			bool gpio_done, mux_done;
+		bool gpio_done, mux_done;
 
-			do {
-				gpio_done = (gpio_ch == 0) ||
-					    ((Cy_AutAnalog_SAR_GetHSchanResultStatus(0) &
-					      gpio_ch) == gpio_ch);
-				mux_done = (mux_ch == 0) ||
-					   ((Cy_AutAnalog_SAR_GetMuxChanResultStatus(0) & mux_ch) ==
-					    mux_ch);
-			} while (!gpio_done || !mux_done);
-		}
+		do {
+			gpio_done =
+				(gpio_ch == 0) ||
+				((Cy_AutAnalog_SAR_GetHSchanResultStatus(0) & gpio_ch) == gpio_ch);
+			mux_done =
+				(mux_ch == 0) ||
+				((Cy_AutAnalog_SAR_GetMuxChanResultStatus(0) & mux_ch) == mux_ch);
+		} while (!gpio_done || !mux_done);
 
 		ifx_autanalog_sar_get_results(sequence->channels, data);
 		adc_context_on_sampling_done(&data->ctx, data->dev);
@@ -661,27 +770,58 @@ static void ifx_autanalog_sar_fifo_isr(const struct device *dev)
  * @brief Calculate the sample time register value based on requested acquisition
  * time
  *
- * @param acquisition_time_ns Requested acquisition time in nanoseconds
+ * @param acquisition_time Requested acquisition time encoded with ADC_ACQ_TIME()
  *
  * @return Acquisition clock cycles, 0 if error
  */
-static uint16_t ifx_calc_acquisition_timer_val(uint32_t acquisition_time_ns)
+static uint16_t ifx_calc_acquisition_timer_val(uint16_t acquisition_time, bool lp_mode)
 {
 	const uint32_t ACQUISITION_CLOCKS_MIN = 1;
 	const uint32_t ACQUISITION_CLOCKS_MAX = 1024;
 
-	uint32_t timer_clock_cycles;
-	uint32_t clock_frequency_hz;
-	uint32_t clock_period_ns;
+	uint32_t timer_clock_cycles = 0UL;
+	uint32_t acquisition_time_ns = 0UL;
 
-	clock_frequency_hz = Cy_SysClk_ClkHfGetFrequency(IFX_AUTANALOG_HF_CLK_SRC);
-	if (clock_frequency_hz == 0) {
-		LOG_ERR("Failed to get AutAnalog clock frequency");
-		return 0;
+	if (acquisition_time == ADC_ACQ_TIME_DEFAULT) {
+		acquisition_time_ns = ADC_AUTANALOG_SAR_DEFAULT_ACQUISITION_NS;
+	} else {
+		switch (ADC_ACQ_TIME_UNIT(acquisition_time)) {
+		case ADC_ACQ_TIME_MICROSECONDS:
+			acquisition_time_ns = ADC_ACQ_TIME_VALUE(acquisition_time) * NSEC_PER_USEC;
+			break;
+		case ADC_ACQ_TIME_NANOSECONDS:
+			acquisition_time_ns = ADC_ACQ_TIME_VALUE(acquisition_time);
+			break;
+		case ADC_ACQ_TIME_TICKS:
+			timer_clock_cycles = ADC_ACQ_TIME_VALUE(acquisition_time);
+			break;
+		default:
+			LOG_ERR("Unsupported acquisition time unit: %u",
+				(unsigned int)ADC_ACQ_TIME_UNIT(acquisition_time));
+			return 0;
+		}
 	}
 
-	clock_period_ns = NSEC_PER_SEC / clock_frequency_hz;
-	timer_clock_cycles = (acquisition_time_ns + (clock_period_ns - 1)) / clock_period_ns;
+	if (timer_clock_cycles == 0UL) {
+		uint32_t clock_frequency_hz;
+		uint32_t clock_period_ns;
+
+		if (lp_mode) {
+			clock_frequency_hz = IFX_AUTANALOG_SAR_LPOSC_FREQ_HZ;
+		} else {
+			clock_frequency_hz = Cy_SysClk_ClkHfGetFrequency(IFX_AUTANALOG_HF_CLK_SRC);
+		}
+
+		if (clock_frequency_hz == 0) {
+			LOG_ERR("Failed to get AutAnalog clock frequency");
+			return 0;
+		}
+
+		clock_period_ns = NSEC_PER_SEC / clock_frequency_hz;
+		timer_clock_cycles =
+			(acquisition_time_ns + (clock_period_ns - 1)) / clock_period_ns;
+	}
+
 	if (timer_clock_cycles < ACQUISITION_CLOCKS_MIN) {
 		timer_clock_cycles = ACQUISITION_CLOCKS_MIN;
 		LOG_WRN("ADC acquisition time too short, using minimum");
@@ -850,6 +990,38 @@ static int ifx_autanalog_sar_setup_mux_channel(struct ifx_autanalog_sar_adc_data
 	return 0;
 }
 
+/**
+ * @brief Find or allocate a sample time slot matching the requested acquisition time.
+ *
+ * Searches the available sample time slots (shared by all channels) for one already
+ * configured with @p timer_clock_cycles.  If none matches, the first free slot is
+ * allocated with the requested value.  The LP and HS modes maintain separate slot
+ * arrays; @p lp_mode selects which one is used.
+ *
+ * @param data Pointer to driver data structure.
+ * @param lp_mode True to search the LP slot array, false for the HS slot array.
+ * @param timer_clock_cycles Requested sample time in acquisition clock cycles.
+ *
+ * @return Slot index on success, 0xFF if no matching or free slot is available.
+ */
+static uint8_t ifx_find_sample_time_slot(struct ifx_autanalog_sar_adc_data *data, bool lp_mode,
+					 uint16_t timer_clock_cycles)
+{
+	uint16_t *sample_times = lp_mode ? data->pdl_adc_lp_static_obj.lpSampleTime
+					 : data->pdl_adc_hs_static_obj.hsSampleTime;
+
+	for (size_t i = 0; i < IFX_AUTANALOG_SAR_SAMPLETIME_COUNT; i++) {
+		if (sample_times[i] == timer_clock_cycles) {
+			return (uint8_t)i;
+		} else if (sample_times[i] == 0) {
+			sample_times[i] = timer_clock_cycles;
+			return (uint8_t)i;
+		}
+	}
+
+	return 0xFF;
+} /* ifx_find_sample_time_slot() */
+
 static int ifx_autanalog_sar_adc_channel_setup(const struct device *dev,
 					       const struct adc_channel_cfg *channel_cfg)
 {
@@ -896,6 +1068,13 @@ static int ifx_autanalog_sar_adc_channel_setup(const struct device *dev,
 	/* Determine if this is a MUX channel based on channel_id range */
 	is_mux_channel = (channel_cfg->channel_id >= IFX_AUTANALOG_SAR_MUX_CHANNEL_OFFSET);
 
+	/* LP mode only supports MUX channels */
+	if (cfg->lp_mode && !is_mux_channel) {
+		LOG_ERR("LP mode supports only MUX channels (channel ID >= %d)",
+			IFX_AUTANALOG_SAR_MUX_CHANNEL_OFFSET);
+		return -EINVAL;
+	}
+
 	if (channel_cfg->differential) {
 		LOG_ERR("Differential channels not supported");
 		return -EINVAL;
@@ -921,18 +1100,9 @@ static int ifx_autanalog_sar_adc_channel_setup(const struct device *dev,
 	 * configurations. If all sample time slots have been used and don't match the
 	 * requested time, return an error and stop configuring the ADC channel.
 	 */
-	timer_clock_cycles = ifx_calc_acquisition_timer_val(channel_cfg->acquisition_time);
-	sample_time_idx = 0xFF;
-	for (size_t i = 0; i < IFX_AUTANALOG_SAR_SAMPLETIME_COUNT; i++) {
-		if (data->pdl_adc_hs_static_obj.hsSampleTime[i] == timer_clock_cycles) {
-			sample_time_idx = i;
-			break;
-		} else if (data->pdl_adc_hs_static_obj.hsSampleTime[i] == 0) {
-			data->pdl_adc_hs_static_obj.hsSampleTime[i] = timer_clock_cycles;
-			sample_time_idx = i;
-			break;
-		}
-	}
+	timer_clock_cycles =
+		ifx_calc_acquisition_timer_val(channel_cfg->acquisition_time, cfg->lp_mode);
+	sample_time_idx = ifx_find_sample_time_slot(data, cfg->lp_mode, timer_clock_cycles);
 
 	if (sample_time_idx == 0xFF) {
 		LOG_ERR("No available sample time slots for requested acquisition time");
@@ -1317,6 +1487,8 @@ int adc_ifx_autanalog_sar_fifo_set_callback(const struct device *dev,
 					(IFX_FIFO_CFG_INIT(n)), ({0})),            \
 		.num_dt_channels = ARRAY_SIZE(ifx_sar_chan_dt_cfg_##n),                            \
 		.dt_channels = ifx_sar_chan_dt_cfg_##n,                                            \
+		.lp_mode = DT_INST_PROP(n, lp_mode),                                               \
+		.lp_diff_en = DT_INST_PROP(n, lp_diff_en),                                         \
 	};                                                                                     \
 	static struct ifx_autanalog_sar_adc_data ifx_autanalog_sar_adc_data_##n = {                \
 		ADC_CONTEXT_INIT_LOCK(ifx_autanalog_sar_adc_data_##n, ctx),                        \

--- a/drivers/mfd/mfd_infineon_autanalog.c
+++ b/drivers/mfd/mfd_infineon_autanalog.c
@@ -549,6 +549,19 @@ int ifx_autanalog_pause_autonomous_control(const struct device *dev)
 	return 0;
 }
 
+int ifx_autanalog_fw_trigger(const struct device *dev, uint8_t trigger)
+{
+	ARG_UNUSED(dev);
+
+	if (trigger > CY_AUTANALOG_FW_TRIGGER3) {
+		return -EINVAL;
+	}
+
+	Cy_AutAnalog_FwTrigger((cy_en_autanalog_fw_trigger_t)trigger);
+
+	return 0;
+}
+
 /**
  * @brief Shared ISR for the AutAnalog subsystem
  *
@@ -662,9 +675,10 @@ int ifx_autanalog_init(void)
 			},                                                                     \
 		.timer =                                                                       \
 			{                                                                      \
-				.enable = false,                                               \
-				.clkSrc = CY_AUTANALOG_TIMER_CLK_LP,                           \
-				.period = 0U,                                                  \
+				.enable = DT_INST_PROP(n, ac_timer_enable),                    \
+				.clkSrc = (cy_en_autanalog_timer_clk_src_t)                    \
+					DT_INST_PROP(n, ac_timer_clk_src),                         \
+				.period = (uint16_t)DT_INST_PROP(n, ac_timer_period),          \
 			},                                                                     \
 	};                                                                                     \
                                                                                                \

--- a/drivers/mfd/mfd_infineon_autanalog.c
+++ b/drivers/mfd/mfd_infineon_autanalog.c
@@ -72,7 +72,7 @@ static const uint32_t ifx_autanalog_intr_masks[IFX_AUTANALOG_PERIPH_COUNT] = {
  * Two modes are supported:
  *
  * Basic mode (no ac-states property):
- *   A hardcoded 3-state SAR single-shot sequence is generated.  SAR fields
+ *   A hardcoded 4-state SAR single-shot sequence is generated.  SAR fields
  *   are populated at compile time when the SAR ADC child node is enabled.
  *
  * Advanced mode (ac-states property present):
@@ -90,35 +90,82 @@ static const uint32_t ifx_autanalog_intr_masks[IFX_AUTANALOG_PERIPH_COUNT] = {
 #define IFX_AUTANALOG_BASIC_MODE_HAS_SAR                                                      \
 	((0 DT_INST_FOREACH_STATUS_OKAY(IFX_AUTANALOG_BASIC_MODE_SAR_COUNT_ENTRY)) > 0)
 
+/*
+ * Child node accessors — centralise the SoC-specific DT node name tokens
+ * so that the rest of the driver is address-independent.
+ */
+#define SAR_NODE(n)    DT_CHILD(DT_DRV_INST(n), adc0_80000)
+#define PRB_NODE(n)    DT_CHILD(DT_DRV_INST(n), prb_e0300)
+#define PTCOMP_NODE(n) DT_CHILD(DT_DRV_INST(n), ptcomp_40000)
+#define CTB0_NODE(n)   DT_CHILD(DT_DRV_INST(n), ctb0_0)
+#define CTB1_NODE(n)   DT_CHILD(DT_DRV_INST(n), ctb1_10000)
+#define DAC0_NODE(n)   DT_CHILD(DT_DRV_INST(n), dac0_60000)
+#define DAC1_NODE(n)   DT_CHILD(DT_DRV_INST(n), dac1_70000)
+
 /** 1 when the SAR ADC child node is enabled */
-#define SAR_IS_USED(n) DT_NODE_HAS_STATUS(DT_CHILD(DT_DRV_INST(n), adc0_80000), okay)
+#define SAR_IS_USED(n) DT_NODE_HAS_STATUS(SAR_NODE(n), okay)
+
+/** 1 when the SAR ADC child is enabled and configured for LP mode */
+#define SAR_LP_MODE(n)                                                                         \
+	COND_CODE_1(SAR_IS_USED(n), (DT_PROP(SAR_NODE(n), lp_mode)), (0))
+
+/** 1 when the PRB child node is enabled */
+#define PRB_IS_USED(n) DT_NODE_HAS_STATUS(PRB_NODE(n), okay)
+
+/** 1 when the PRB child is enabled and configured for LP mode */
+#define PRB_LP_MODE(n)                                                                         \
+	COND_CODE_1(PRB_IS_USED(n), (DT_PROP(PRB_NODE(n), lp_mode)), (0))
 
 /** 1 when the PTCOMP child node is enabled */
-#define PTCOMP_IS_USED(n) DT_NODE_HAS_STATUS(DT_CHILD(DT_DRV_INST(n), ptcomp_40000), okay)
+#define PTCOMP_IS_USED(n) DT_NODE_HAS_STATUS(PTCOMP_NODE(n), okay)
+
+/** 1 when the PTCOMP child is enabled and configured for LP mode */
+#define PTCOMP_LP_MODE(n)                                                                      \
+	COND_CODE_1(PTCOMP_IS_USED(n), (DT_PROP(PTCOMP_NODE(n), lp_mode)), (0))
 
 /** 1 when the CTB0 child node is enabled */
-#define CTB0_IS_USED(n) DT_NODE_HAS_STATUS(DT_CHILD(DT_DRV_INST(n), ctb0_0), okay)
+#define CTB0_IS_USED(n) DT_NODE_HAS_STATUS(CTB0_NODE(n), okay)
+
+/** 1 when the CTB0 child is enabled and configured for LP mode */
+#define CTB0_LP_MODE(n)                                                                        \
+	COND_CODE_1(CTB0_IS_USED(n), (DT_PROP(CTB0_NODE(n), lp_mode)), (0))
 
 /** 1 when the CTB1 child node is enabled */
-#define CTB1_IS_USED(n) DT_NODE_HAS_STATUS(DT_CHILD(DT_DRV_INST(n), ctb1_10000), okay)
+#define CTB1_IS_USED(n) DT_NODE_HAS_STATUS(CTB1_NODE(n), okay)
+
+/** 1 when the CTB1 child is enabled and configured for LP mode */
+#define CTB1_LP_MODE(n)                                                                        \
+	COND_CODE_1(CTB1_IS_USED(n), (DT_PROP(CTB1_NODE(n), lp_mode)), (0))
+
+/** 1 when the DAC0 child node is enabled */
+#define DAC0_IS_USED(n) DT_NODE_HAS_STATUS(DAC0_NODE(n), okay)
+
+/** 1 when the DAC0 child is enabled and configured for LP mode */
+#define DAC0_LP_MODE(n)                                                                        \
+	COND_CODE_1(DAC0_IS_USED(n), (DT_PROP(DAC0_NODE(n), lp_mode)), (0))
+
+/** 1 when the DAC1 child node is enabled */
+#define DAC1_IS_USED(n) DT_NODE_HAS_STATUS(DAC1_NODE(n), okay)
+
+/** 1 when the DAC1 child is enabled and configured for LP mode */
+#define DAC1_LP_MODE(n)                                                                        \
+	COND_CODE_1(DAC1_IS_USED(n), (DT_PROP(DAC1_NODE(n), lp_mode)), (0))
+
+/** 1 when any enabled child peripheral requests LP mode */
+#define AUTANALOG_LP_MODE(n)                                                                   \
+	(SAR_LP_MODE(n) || PRB_LP_MODE(n) || PTCOMP_LP_MODE(n) ||                                 \
+	 CTB0_LP_MODE(n) || CTB1_LP_MODE(n) || DAC0_LP_MODE(n) || DAC1_LP_MODE(n))
 
 /*
  * Helper macros to read the gain property from an opamp child node
  * nested inside a CTB child of this AutAnalog instance.
- * Path: AutAnalog(n) → ctb_child → opamp_oa_idx
+ * Path: CTB node → opamp_oa_idx
  */
-#define CTB_OA_NODE(n, ctb_child, oa_idx)                                                      \
-	DT_CHILD(DT_CHILD(DT_DRV_INST(n), ctb_child), opamp_##oa_idx)
-#define CTB_OA_EXISTS(n, ctb_child, oa_idx) DT_NODE_EXISTS(CTB_OA_NODE(n, ctb_child, oa_idx))
-#define CTB_OA_GAIN(n, ctb_child, oa_idx)                                                      \
-	COND_CODE_1(CTB_OA_EXISTS(n, ctb_child, oa_idx), \
-		    (DT_PROP(CTB_OA_NODE(n, ctb_child, oa_idx), gain)), (0))
-
-/** 1 when the DAC0 child node is enabled */
-#define DAC0_IS_USED(n) DT_NODE_HAS_STATUS(DT_CHILD(DT_DRV_INST(n), dac0_60000), okay)
-
-/** 1 when the DAC1 child node is enabled */
-#define DAC1_IS_USED(n) DT_NODE_HAS_STATUS(DT_CHILD(DT_DRV_INST(n), dac1_70000), okay)
+#define CTB_OA_NODE(ctb_node, oa_idx)  DT_CHILD(ctb_node, opamp_##oa_idx)
+#define CTB_OA_EXISTS(ctb_node, oa_idx) DT_NODE_EXISTS(CTB_OA_NODE(ctb_node, oa_idx))
+#define CTB_OA_GAIN(ctb_node, oa_idx)                                                          \
+	COND_CODE_1(CTB_OA_EXISTS(ctb_node, oa_idx), \
+		    (DT_PROP(CTB_OA_NODE(ctb_node, oa_idx), gain)), (0))
 
 /*
  * Default DAC channel for basic-mode STT entries.
@@ -127,32 +174,34 @@ static const uint32_t ifx_autanalog_intr_masks[IFX_AUTANALOG_PERIPH_COUNT] = {
  */
 #define IFX_AUTANALOG_DEFAULT_DAC_CHAN 15
 
-/** 1 when the PRB child node is enabled */
-#define PRB_IS_USED(n) DT_NODE_HAS_STATUS(DT_CHILD(DT_DRV_INST(n), prb_e0300), okay)
-
-/* ===== Basic mode: hardcoded 3-state SAR single-shot STT ===== */
-
-#define IFX_AUTANALOG_BASIC_NUM_STT 3
+/* ===== Basic mode: hardcoded 4-state SAR single-shot STT ===== */
+#define IFX_AUTANALOG_BASIC_NUM_STT 4
 
 #define IFX_AUTANALOG_BASIC_STT(n)                                                               \
 	static cy_stc_autanalog_stt_ac_t ifx_autanalog_ac_stt_##n[] = {                          \
 		{                                                                                \
 			.unlock = true,                                                          \
+			.lpMode = AUTANALOG_LP_MODE(n),                                          \
 			.condition = CY_AUTANALOG_STT_AC_CONDITION_BLOCK_READY,                  \
 			.action = CY_AUTANALOG_STT_AC_ACTION_WAIT_FOR,                           \
-			.branchState = 1,                                                        \
-		},                                                                               \
-		{                                                                                \
-			.condition = CY_AUTANALOG_STT_AC_CONDITION_SAR_DONE,                     \
-			.action = CY_AUTANALOG_STT_AC_ACTION_WAIT_FOR,                           \
-			.branchState = 0,                                                        \
 		},                                                                               \
 		{                                                                                \
 			.condition = CY_AUTANALOG_STT_AC_CONDITION_FALSE,                        \
 			.action = CY_AUTANALOG_STT_AC_ACTION_STOP,                               \
 		},                                                                               \
+		{                                                                                \
+			.condition = CY_AUTANALOG_STT_AC_CONDITION_SAR_EOS,                      \
+			.action = CY_AUTANALOG_STT_AC_ACTION_WAIT_FOR,                           \
+		},                                                                               \
+		{                                                                                \
+			.unlock = false,                                                         \
+			.condition = CY_AUTANALOG_STT_AC_CONDITION_TRUE,                    \
+			.action = CY_AUTANALOG_STT_AC_ACTION_BRANCH_IF_TRUE,                     \
+			.branchState = 1U,                                                       \
+		},                                                                               \
 	};                                                                                       \
 	static cy_stc_autanalog_stt_sar_t ifx_autanalog_sar_stt_##n[] = {                        \
+		{.unlock = SAR_IS_USED(n), .enable = SAR_IS_USED(n)},                            \
 		{.unlock = SAR_IS_USED(n), .enable = SAR_IS_USED(n)},                            \
 		{.unlock = SAR_IS_USED(n), .enable = SAR_IS_USED(n), .trigger = SAR_IS_USED(n)}, \
 		{.unlock = SAR_IS_USED(n), .enable = SAR_IS_USED(n)},                            \
@@ -173,58 +222,79 @@ static const uint32_t ifx_autanalog_intr_masks[IFX_AUTANALOG_PERIPH_COUNT] = {
 		 .dynCfgIdxComp0 = 0,                                                              \
 		 .enableComp1 = PTCOMP_IS_USED(n),                                                 \
 		 .dynCfgIdxComp1 = 1},                                                             \
+		{.unlock = PTCOMP_IS_USED(n),                                                      \
+		 .enableComp0 = PTCOMP_IS_USED(n),                                                 \
+		 .dynCfgIdxComp0 = 0,                                                              \
+		 .enableComp1 = PTCOMP_IS_USED(n),                                                 \
+		 .dynCfgIdxComp1 = 1},                                                             \
 	};                                                                                         \
 	static cy_stc_autanalog_stt_ctb_t ifx_autanalog_ctb0_stt_##n[] = {                         \
 		{.unlock = CTB0_IS_USED(n),                                                        \
 		 .enableOpamp0 = CTB0_IS_USED(n),                                                  \
 		 .cfgOpamp0 = 0,                                                                   \
-		 .gainOpamp0 = CTB_OA_GAIN(n, ctb0_0, 0),                                          \
+		 .gainOpamp0 = CTB_OA_GAIN(CTB0_NODE(n), 0),                                       \
 		 .enableOpamp1 = CTB0_IS_USED(n),                                                  \
 		 .cfgOpamp1 = 1,                                                                   \
-		 .gainOpamp1 = CTB_OA_GAIN(n, ctb0_0, 1)},                                         \
+		 .gainOpamp1 = CTB_OA_GAIN(CTB0_NODE(n), 1)},                                      \
 		{.unlock = CTB0_IS_USED(n),                                                        \
 		 .enableOpamp0 = CTB0_IS_USED(n),                                                  \
 		 .cfgOpamp0 = 0,                                                                   \
-		 .gainOpamp0 = CTB_OA_GAIN(n, ctb0_0, 0),                                          \
+		 .gainOpamp0 = CTB_OA_GAIN(CTB0_NODE(n), 0),                                       \
 		 .enableOpamp1 = CTB0_IS_USED(n),                                                  \
 		 .cfgOpamp1 = 1,                                                                   \
-		 .gainOpamp1 = CTB_OA_GAIN(n, ctb0_0, 1)},                                         \
+		 .gainOpamp1 = CTB_OA_GAIN(CTB0_NODE(n), 1)},                                      \
 		{.unlock = CTB0_IS_USED(n),                                                        \
 		 .enableOpamp0 = CTB0_IS_USED(n),                                                  \
 		 .cfgOpamp0 = 0,                                                                   \
-		 .gainOpamp0 = CTB_OA_GAIN(n, ctb0_0, 0),                                          \
+		 .gainOpamp0 = CTB_OA_GAIN(CTB0_NODE(n), 0),                                       \
 		 .enableOpamp1 = CTB0_IS_USED(n),                                                  \
 		 .cfgOpamp1 = 1,                                                                   \
-		 .gainOpamp1 = CTB_OA_GAIN(n, ctb0_0, 1)},                                         \
+		 .gainOpamp1 = CTB_OA_GAIN(CTB0_NODE(n), 1)},                                      \
+		{.unlock = CTB0_IS_USED(n),                                                        \
+		 .enableOpamp0 = CTB0_IS_USED(n),                                                  \
+		 .cfgOpamp0 = 0,                                                                   \
+		 .gainOpamp0 = CTB_OA_GAIN(CTB0_NODE(n), 0),                                       \
+		 .enableOpamp1 = CTB0_IS_USED(n),                                                  \
+		 .cfgOpamp1 = 1,                                                                   \
+		 .gainOpamp1 = CTB_OA_GAIN(CTB0_NODE(n), 1)},                                      \
 	};                                                                                         \
 	static cy_stc_autanalog_stt_ctb_t ifx_autanalog_ctb1_stt_##n[] = {                         \
 		{.unlock = CTB1_IS_USED(n),                                                        \
 		 .enableOpamp0 = CTB1_IS_USED(n),                                                  \
 		 .cfgOpamp0 = 0,                                                                   \
-		 .gainOpamp0 = CTB_OA_GAIN(n, ctb1_10000, 0),                                      \
+		 .gainOpamp0 = CTB_OA_GAIN(CTB1_NODE(n), 0),                                       \
 		 .enableOpamp1 = CTB1_IS_USED(n),                                                  \
 		 .cfgOpamp1 = 1,                                                                   \
-		 .gainOpamp1 = CTB_OA_GAIN(n, ctb1_10000, 1)},                                     \
+		 .gainOpamp1 = CTB_OA_GAIN(CTB1_NODE(n), 1)},                                      \
 		{.unlock = CTB1_IS_USED(n),                                                        \
 		 .enableOpamp0 = CTB1_IS_USED(n),                                                  \
 		 .cfgOpamp0 = 0,                                                                   \
-		 .gainOpamp0 = CTB_OA_GAIN(n, ctb1_10000, 0),                                      \
+		 .gainOpamp0 = CTB_OA_GAIN(CTB1_NODE(n), 0),                                       \
 		 .enableOpamp1 = CTB1_IS_USED(n),                                                  \
 		 .cfgOpamp1 = 1,                                                                   \
-		 .gainOpamp1 = CTB_OA_GAIN(n, ctb1_10000, 1)},                                     \
+		 .gainOpamp1 = CTB_OA_GAIN(CTB1_NODE(n), 1)},                                      \
 		{.unlock = CTB1_IS_USED(n),                                                        \
 		 .enableOpamp0 = CTB1_IS_USED(n),                                                  \
 		 .cfgOpamp0 = 0,                                                                   \
-		 .gainOpamp0 = CTB_OA_GAIN(n, ctb1_10000, 0),                                      \
+		 .gainOpamp0 = CTB_OA_GAIN(CTB1_NODE(n), 0),                                       \
 		 .enableOpamp1 = CTB1_IS_USED(n),                                                  \
 		 .cfgOpamp1 = 1,                                                                   \
-		 .gainOpamp1 = CTB_OA_GAIN(n, ctb1_10000, 1)},                                     \
+		 .gainOpamp1 = CTB_OA_GAIN(CTB1_NODE(n), 1)},                                      \
+		{.unlock = CTB1_IS_USED(n),                                                        \
+		 .enableOpamp0 = CTB1_IS_USED(n),                                                  \
+		 .cfgOpamp0 = 0,                                                                   \
+		 .gainOpamp0 = CTB_OA_GAIN(CTB1_NODE(n), 0),                                       \
+		 .enableOpamp1 = CTB1_IS_USED(n),                                                  \
+		 .cfgOpamp1 = 1,                                                                   \
+		 .gainOpamp1 = CTB_OA_GAIN(CTB1_NODE(n), 1)},                                      \
 	};                                                                                         \
 	static cy_stc_autanalog_stt_dac_t ifx_autanalog_dac0_stt_##n[] = {                     \
 		{.unlock = DAC0_IS_USED(n), .enable = DAC0_IS_USED(n),                             \
 		 .channel = IFX_AUTANALOG_DEFAULT_DAC_CHAN},                                       \
 		{.unlock = DAC0_IS_USED(n), .enable = DAC0_IS_USED(n),                             \
 		 .trigger = DAC0_IS_USED(n), .channel = IFX_AUTANALOG_DEFAULT_DAC_CHAN},           \
+		{.unlock = DAC0_IS_USED(n), .enable = DAC0_IS_USED(n),                             \
+		 .channel = IFX_AUTANALOG_DEFAULT_DAC_CHAN},                                       \
 		{.unlock = DAC0_IS_USED(n), .enable = DAC0_IS_USED(n),                             \
 		 .channel = IFX_AUTANALOG_DEFAULT_DAC_CHAN},                                       \
 	};                                                                                     \
@@ -235,8 +305,11 @@ static const uint32_t ifx_autanalog_intr_masks[IFX_AUTANALOG_PERIPH_COUNT] = {
 		 .trigger = DAC1_IS_USED(n), .channel = IFX_AUTANALOG_DEFAULT_DAC_CHAN},           \
 		{.unlock = DAC1_IS_USED(n), .enable = DAC1_IS_USED(n),                             \
 		 .channel = IFX_AUTANALOG_DEFAULT_DAC_CHAN},                                       \
+		{.unlock = DAC1_IS_USED(n), .enable = DAC1_IS_USED(n),                             \
+		 .channel = IFX_AUTANALOG_DEFAULT_DAC_CHAN},                                       \
 	};                                                                                     \
 	static cy_stc_autanalog_stt_prb_t ifx_autanalog_prb_stt_##n[] = {                          \
+		{.unlock = PRB_IS_USED(n), .prbVref0Fw = true, .prbVref1Fw = true},                \
 		{.unlock = PRB_IS_USED(n), .prbVref0Fw = true, .prbVref1Fw = true},                \
 		{.unlock = PRB_IS_USED(n), .prbVref0Fw = true, .prbVref1Fw = true},                \
 		{.unlock = PRB_IS_USED(n), .prbVref0Fw = true, .prbVref1Fw = true},                \
@@ -258,6 +331,11 @@ static const uint32_t ifx_autanalog_intr_masks[IFX_AUTANALOG_PERIPH_COUNT] = {
 		 .prb = &ifx_autanalog_prb_stt_##n[2],                                             \
 		 .ptcomp = {&ifx_autanalog_ptcomp0_stt_##n[2]},                                    \
 		 .sar = {&ifx_autanalog_sar_stt_##n[2]}},                                          \
+		{.ac = &ifx_autanalog_ac_stt_##n[3],                                               \
+		 .prb = &ifx_autanalog_prb_stt_##n[3],                                             \
+		 .ctb = {&ifx_autanalog_ctb0_stt_##n[3], &ifx_autanalog_ctb1_stt_##n[3]},          \
+		 .ptcomp = {&ifx_autanalog_ptcomp0_stt_##n[3]},                                    \
+		 .sar = {&ifx_autanalog_sar_stt_##n[3]}},                                          \
 	};
 
 /* ===== Advanced mode: STT from DT ac-states phandle list ===== */
@@ -646,16 +724,6 @@ DT_INST_FOREACH_STATUS_OKAY(IFX_AUTANALOG_MFD_INIT)
 static int ifx_autanalog_start_ac(void)
 {
 	Cy_AutAnalog_StartAutonomousControl();
-
-#if IFX_AUTANALOG_BASIC_MODE_HAS_SAR
-	/* This is to allow the AC to complete its initial
-	 * power-up cycle through the STT for basic mode before
-	 * the SAR attempts to pause and reconfigure it.
-	 */
-	do {
-		k_busy_wait(100);
-	} while (Cy_AutAnalog_IsBusy());
-#endif
 	LOG_DBG("AutAnalog AC started");
 	return 0;
 }

--- a/dts/bindings/adc/infineon,autanalog-sar-adc.yaml
+++ b/dts/bindings/adc/infineon,autanalog-sar-adc.yaml
@@ -152,6 +152,62 @@ properties:
 
       Only effective when lp-mode is also set.
 
+  limit-cond-0:
+    type: array
+    description: |
+      Range detection condition 0. Channels that set limit =
+      IFX_AUTANALOG_SAR_LIMIT_STC0 use this condition. The array contains
+      three integers: <condition low high>.
+
+      condition uses IFX_AUTANALOG_SAR_COND_* constants from
+      <dt-bindings/adc/infineon-autanalog-sar.h>:
+        IFX_AUTANALOG_SAR_COND_BELOW   (0) - result < low
+        IFX_AUTANALOG_SAR_COND_INSIDE  (1) - low <= result < high
+        IFX_AUTANALOG_SAR_COND_ABOVE   (2) - result > high
+        IFX_AUTANALOG_SAR_COND_OUTSIDE (3) - result < low OR result >= high
+
+      low and high are signed 32-bit threshold values in ADC counts.
+
+  limit-cond-1:
+    type: array
+    description: |
+      Range detection condition 1. See limit-cond-0 for format.
+
+  limit-cond-2:
+    type: array
+    description: |
+      Range detection condition 2. See limit-cond-0 for format.
+
+  limit-cond-3:
+    type: array
+    description: |
+      Range detection condition 3. See limit-cond-0 for format.
+
+  gain-corr:
+    type: array
+    description: |
+      Array of 8 gain correction coefficients, one per coefficient slot
+      (COEFF0 through COEFF7). Each value is an unsigned 16-bit fixed-point
+      number in the format X.XXXXXXXXXXXXXXX where:
+        - 0x0001 = 1/32768 = 0.000030517578125
+        - 0x8000 = 1.0 (default / unity gain)
+        - 0xFFFF = 2 - 1/32768 = 1.999969482421875
+
+      Channels select which coefficient slot to use via the per-channel
+      pos-coeff and neg-coeff properties.
+
+  offset-corr:
+    type: array
+    description: |
+      Array of 8 signed offset correction coefficients, one per coefficient
+      slot (COEFF0 through COEFF7). Each value is a signed 16-bit integer
+      added to the 12-bit ADC result:
+        - Range: -2048 (0xF800) to +2047 (0x07FF)
+        - Default: 0 (no offset correction)
+
+      Channels select which coefficient slot to use via the per-channel
+      pos-coeff and neg-coeff properties.
+
 child-binding:
   properties:
     mux-buf-bypass:

--- a/dts/bindings/adc/infineon,autanalog-sar-adc.yaml
+++ b/dts/bindings/adc/infineon,autanalog-sar-adc.yaml
@@ -159,6 +159,74 @@ child-binding:
       description: |
         Bypass the Hi-Z buffers for MUX channels.
 
+    sign:
+      type: boolean
+      description: |
+        Enable sign extension for this channel's conversion result.
+
+    differential:
+      type: boolean
+      description: |
+        Enable differential mode for this GPIO channel. When set, the negative
+        input pin is taken from the neg-pin property. Only applies to GPIO
+        channels (channel IDs 0-7).
+
+    neg-pin:
+      type: int
+      default: 0
+      description: |
+        Negative GPIO pin for differential mode on GPIO channels. Only used
+        when differential is enabled. Values correspond to GPIO pin indices
+        (0-7).
+
+    pos-coeff:
+      type: int
+      default: 0
+      enum: [0, 1, 2, 3, 4, 5, 6, 7, 8]
+      description: |
+        Positive channel correction coefficient selection.
+        Use IFX_AUTANALOG_SAR_CH_COEFF_* constants from
+        <dt-bindings/adc/infineon-autanalog-sar.h>.
+          IFX_AUTANALOG_SAR_CH_COEFF_DISABLED (0) - Disabled (default)
+          IFX_AUTANALOG_SAR_CH_COEFF0         (1) - Coefficient config 0
+          IFX_AUTANALOG_SAR_CH_COEFF1         (2) - Coefficient config 1
+          IFX_AUTANALOG_SAR_CH_COEFF2         (3) - Coefficient config 2
+          IFX_AUTANALOG_SAR_CH_COEFF3         (4) - Coefficient config 3
+          IFX_AUTANALOG_SAR_CH_COEFF4         (5) - Coefficient config 4
+          IFX_AUTANALOG_SAR_CH_COEFF5         (6) - Coefficient config 5
+          IFX_AUTANALOG_SAR_CH_COEFF6         (7) - Coefficient config 6
+          IFX_AUTANALOG_SAR_CH_COEFF7         (8) - Coefficient config 7
+
+    neg-coeff:
+      type: int
+      default: 0
+      enum: [0, 1, 2, 3, 4, 5, 6, 7, 8]
+      description: |
+        Negative channel correction coefficient selection.
+        Use IFX_AUTANALOG_SAR_CH_COEFF_* constants from
+        <dt-bindings/adc/infineon-autanalog-sar.h>.
+        See pos-coeff for valid values.
+
+    acc-shift:
+      type: boolean
+      description: |
+        Enable accumulator shift for this channel. When enabled, the
+        accumulator result is right-shifted after accumulation.
+
+    limit:
+      type: int
+      default: 0
+      enum: [0, 1, 2, 3, 4]
+      description: |
+        Limit status / range detection configuration for this channel.
+        Use IFX_AUTANALOG_SAR_LIMIT_* constants from
+        <dt-bindings/adc/infineon-autanalog-sar.h>.
+          IFX_AUTANALOG_SAR_LIMIT_DISABLED (0) - Disabled (default)
+          IFX_AUTANALOG_SAR_LIMIT_STC0     (1) - Limit status config 0
+          IFX_AUTANALOG_SAR_LIMIT_STC1     (2) - Limit status config 1
+          IFX_AUTANALOG_SAR_LIMIT_STC2     (3) - Limit status config 2
+          IFX_AUTANALOG_SAR_LIMIT_STC3     (4) - Limit status config 3
+
     fifo-sel:
       type: int
       default: 0

--- a/dts/bindings/adc/infineon,autanalog-sar-adc.yaml
+++ b/dts/bindings/adc/infineon,autanalog-sar-adc.yaml
@@ -128,6 +128,30 @@ properties:
     description: |
       Enable channel number identifier for data stored in FIFO.
 
+  lp-mode:
+    type: boolean
+    description: |
+      Enable Low Power (LP) mode for the SAR ADC. In LP mode the ADC is clocked
+      from the LPOSC at 4.096 MHz instead of CLK_HF and only MUX channels
+      (channel IDs >= 8) can be used. The maximum throughput in LP mode is
+      200 ksps. LP mode is available in both Active and Deep Sleep power modes.
+
+      When lp-mode is set the parent AutAnalog MFD basic-mode STT automatically
+      enters LP operation for the AC states. LP mode is also activated if any
+      other AutAnalog child peripheral (DAC, CTB, PTCOMP, PRB) sets lp-mode.
+      In advanced mode (ac-states), use the per-state ac-lp-mode property
+      instead.
+
+  lp-diff-en:
+    type: boolean
+    description: |
+      Enable differential mode for the LP channel. When set, the LP sampler
+      operates in differential mode measuring the difference between the
+      positive and negative MUX inputs. Required for accurate die temperature
+      measurement in LP mode.
+
+      Only effective when lp-mode is also set.
+
 child-binding:
   properties:
     mux-buf-bypass:

--- a/dts/bindings/adc/infineon,autanalog-sar-seq-hs.yaml
+++ b/dts/bindings/adc/infineon,autanalog-sar-seq-hs.yaml
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+title: Infineon AutAnalog SAR ADC HS Sequencer Table Entry
+
+description: |
+  High-Speed (HS) mode sequencer table entry for the Infineon AutAnalog SAR
+  ADC.  Up to 32 entries may be defined as child nodes of the ADC node.  Nodes
+  must be named "seq-hs-<index>" (e.g. seq-hs-0, seq-hs-1, ...).
+
+  Each entry configures one step in the ADC scan sequence.  The hardware
+  executes entries in order, with the next-action field controlling
+  transitions between entries.
+
+  When only default (single-entry) operation is desired, these nodes may be
+  omitted entirely and the driver will create a single entry with backward-
+  compatible defaults.
+
+  Use IFX_AUTANALOG_SAR_SEQ_* constants from
+  <dt-bindings/adc/infineon-autanalog-sar.h> for property values.
+
+compatible: "infineon,autanalog-sar-seq-hs"
+
+properties:
+  sample-time-en:
+    type: boolean
+    description: |
+      Enable the programmable sample-time delay for this sequencer entry.
+      When disabled, the ADC uses its default minimum sampling window.
+
+  acc-en:
+    type: boolean
+    description: |
+      Enable accumulation / averaging for conversions triggered by this
+      sequencer entry.
+
+  acc-count:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+    description: |
+      Number of samples to accumulate when acc-en is set.
+      Use IFX_AUTANALOG_SAR_SEQ_ACC_CNT* constants.
+        0 = 2 samples   (IFX_AUTANALOG_SAR_SEQ_ACC_CNT2)
+        1 = 4 samples   (IFX_AUTANALOG_SAR_SEQ_ACC_CNT4)
+        2 = 8 samples   (IFX_AUTANALOG_SAR_SEQ_ACC_CNT8)
+        3 = 16 samples  (IFX_AUTANALOG_SAR_SEQ_ACC_CNT16)
+        4 = 32 samples  (IFX_AUTANALOG_SAR_SEQ_ACC_CNT32)
+        5 = 64 samples  (IFX_AUTANALOG_SAR_SEQ_ACC_CNT64)
+        6 = 128 samples (IFX_AUTANALOG_SAR_SEQ_ACC_CNT128)
+        7 = 256 samples (IFX_AUTANALOG_SAR_SEQ_ACC_CNT256)
+
+  cal-req:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3]
+    description: |
+      Real-time calibration request for this sequencer entry.
+      Use IFX_AUTANALOG_SAR_SEQ_CAL_* constants.
+        0 = Disabled  (IFX_AUTANALOG_SAR_SEQ_CAL_DISABLED)
+        1 = Both offset and linearity (IFX_AUTANALOG_SAR_SEQ_CAL_BOTH)
+        2 = Offset only    (IFX_AUTANALOG_SAR_SEQ_CAL_OFFSET)
+        3 = Linearity only (IFX_AUTANALOG_SAR_SEQ_CAL_LINEARITY)
+
+  next-action:
+    type: int
+    default: 0
+    enum: [0, 1, 2]
+    description: |
+      Action after this sequencer entry completes.
+      Use IFX_AUTANALOG_SAR_SEQ_NEXT_* constants.
+        0 = Stop, send SAR_EOS and SAR_DONE, go idle
+            (IFX_AUTANALOG_SAR_SEQ_NEXT_STOP)
+        1 = Send SAR_EOS and return to start (continuous)
+            (IFX_AUTANALOG_SAR_SEQ_NEXT_REPEAT)
+        2 = Continue to next entry in scan table
+            (IFX_AUTANALOG_SAR_SEQ_NEXT_CONTINUE)
+
+  gpio-channels:
+    type: int
+    default: 0
+    description: |
+      Bitmask of GPIO channels (0-7) to sample in this sequencer entry.
+      Each bit enables the corresponding GPIO channel.  When zero, GPIO
+      channel selection is configured at runtime.
+
+  mux-mode:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3, 4]
+    description: |
+      MUX channel operating mode for this sequencer entry.
+      Use IFX_AUTANALOG_SAR_MUX_* constants.
+
+  mux0-sel:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    description: |
+      MUX0 channel selection (0-15) for this entry.
+      Selects which of the 16 internal MUX channels to sample.
+
+  mux1-sel:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    description: |
+      MUX1 channel selection (0-15) for this entry.
+      Selects which of the 16 internal MUX channels to sample.
+
+  sample-time:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3]
+    description: |
+      Which of the 4 sample-time slots to use for this entry.
+      Use IFX_AUTANALOG_SAR_SEQ_SAMPLE_TIME* constants.

--- a/dts/bindings/adc/infineon,autanalog-sar-seq-lp.yaml
+++ b/dts/bindings/adc/infineon,autanalog-sar-seq-lp.yaml
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+title: Infineon AutAnalog SAR ADC LP Sequencer Table Entry
+
+description: |
+  Low-Power (LP) mode sequencer table entry for the Infineon AutAnalog SAR
+  ADC.  Up to 32 entries may be defined as child nodes of the ADC node.  Nodes
+  must be named "seq-lp-<index>" (e.g. seq-lp-0, seq-lp-1, ...).
+
+  LP mode only supports MUX channels; each entry selects a single MUX
+  channel via mux0-sel.
+
+  When only default (single-entry) operation is desired, these nodes may be
+  omitted entirely and the driver will create a single entry with backward-
+  compatible defaults.
+
+  Use IFX_AUTANALOG_SAR_SEQ_* constants from
+  <dt-bindings/adc/infineon-autanalog-sar.h> for property values.
+
+compatible: "infineon,autanalog-sar-seq-lp"
+
+properties:
+  mux0-sel:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    description: |
+      MUX channel selection (0-15) for this LP sequencer entry.
+      Selects which of the 16 internal MUX channels to sample.
+      Each MUX channel's analog input pin and FIFO routing are
+      configured via the corresponding channel@N node.
+
+  sample-time-en:
+    type: boolean
+    description: |
+      Enable the programmable sample-time delay for this sequencer entry.
+      When using multiple sequencer entries that switch between MUX
+      channels, this should be enabled to allow the analog input to
+      settle before conversion.
+
+  sample-time:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3]
+    description: |
+      Which of the 4 sample-time slots to use for this entry.
+
+  acc-en:
+    type: boolean
+    description: |
+      Enable accumulation / averaging for conversions triggered by this
+      sequencer entry.
+
+  acc-count:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+    description: |
+      Number of samples to accumulate when acc-en is set.
+      Use IFX_AUTANALOG_SAR_SEQ_ACC_CNT* constants.
+
+  cal-req:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3]
+    description: |
+      Real-time calibration request for this sequencer entry.
+      Use IFX_AUTANALOG_SAR_SEQ_CAL_* constants.
+
+  next-action:
+    type: int
+    default: 0
+    enum: [0, 1, 2]
+    description: |
+      Action after this sequencer entry completes.
+      Use IFX_AUTANALOG_SAR_SEQ_NEXT_* constants.

--- a/dts/bindings/mfd/infineon,autanalog.yaml
+++ b/dts/bindings/mfd/infineon,autanalog.yaml
@@ -66,6 +66,31 @@ properties:
       sequence (basic mode) and automatically populates SAR fields based on
       the SAR ADC child node status.
 
+  ac-timer-enable:
+    type: boolean
+    description: |
+      Enable the Autonomous Controller timer.  The timer fires a
+      TIMER_DONE_WAKE condition each time the counter reaches the
+      period set by ac-timer-period.
+
+  ac-timer-clk-src:
+    type: int
+    default: 0
+    description: |
+      AC timer clock source.
+        0 = CLK_LPOSC (nominally 4.096 MHz, LP oscillator)
+        1 = CLK_LF    (nominally 32 kHz, low-frequency clock)
+      Use CLK_LF for maximum sleep duration between samples.
+
+  ac-timer-period:
+    type: int
+    default: 0
+    description: |
+      AC timer period (0-65535).  The timer counts clock ticks
+      (selected by ac-timer-clk-src) and fires TIMER_DONE_WAKE when
+      the count reaches this value.  Only meaningful when
+      ac-timer-enable is set.
+
 examples:
   - |
     /* Example of custom 4-state sequence using SAR.

--- a/include/zephyr/drivers/adc/infineon_autanalog_sar.h
+++ b/include/zephyr/drivers/adc/infineon_autanalog_sar.h
@@ -201,6 +201,31 @@ int adc_ifx_autanalog_sar_fifo_set_callback(const struct device *dev,
 					    adc_ifx_autanalog_sar_fifo_callback_t callback,
 					    void *user_data);
 
+/**
+ * @brief Stop an active RTIO ADC stream and tear down its software state.
+ *
+ * Switches the SAR sequencer back to single-shot mode and halts the
+ * free-running (continuous) SAR.  It clears the streaming state and
+ * terminates the in-flight RTIO submission (if any) with -ECANCELED.  After this
+ * returns, the SAR is idle and the shared sequencer is free for a subsequent
+ * adc_read(), and streaming can be restarted with a fresh adc_stream() call.
+ *
+ * The hardware FIFO is left intact: any samples already captured are preserved,
+ * so an application can stop and later resume streaming without losing data.  A
+ * one-shot adc_read() reads the result registers rather than the FIFO, so the
+ * retained samples do not affect it.
+ *
+ * The caller must cancel the stream's multishot SQE handle (rtio_sqe_cancel())
+ * before calling this function so RTIO does not resubmit and restart the stream.
+ *
+ * @param dev  ADC device (infineon,autanalog-sar-adc instance).
+ *
+ * @retval 0 on success.
+ * @retval -EALREADY if no stream is currently active.
+ * @retval -EBUSY if the SAR did not return to idle after the final conversion.
+ */
+int adc_ifx_autanalog_sar_stream_stop(const struct device *dev);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/include/zephyr/dt-bindings/adc/infineon-autanalog-sar.h
+++ b/include/zephyr/dt-bindings/adc/infineon-autanalog-sar.h
@@ -215,4 +215,14 @@
 #define IFX_AUTANALOG_SAR_CH_COEFF7         8 /**< Correction coefficient config 7 */
 /** @} */
 
+/**
+ * @name Range detection condition (cy_en_autanalog_sar_cond_t)
+ * @{
+ */
+#define IFX_AUTANALOG_SAR_COND_BELOW   0 /**< result < low threshold */
+#define IFX_AUTANALOG_SAR_COND_INSIDE  1 /**< low <= result < high */
+#define IFX_AUTANALOG_SAR_COND_ABOVE   2 /**< result > high threshold */
+#define IFX_AUTANALOG_SAR_COND_OUTSIDE 3 /**< result < low OR result >= high */
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_INFINEON_AUTANALOG_SAR_H_ */

--- a/include/zephyr/dt-bindings/adc/infineon-autanalog-sar.h
+++ b/include/zephyr/dt-bindings/adc/infineon-autanalog-sar.h
@@ -200,4 +200,19 @@
 #define IFX_AUTANALOG_SAR_SEQ_SAMPLE_TIME3 3 /**< Sample time slot 3 */
 /** @} */
 
+/**
+ * @name Channel correction coefficient (cy_en_autanalog_sar_ch_coeff_t)
+ * @{
+ */
+#define IFX_AUTANALOG_SAR_CH_COEFF_DISABLED 0 /**< Coefficient not used */
+#define IFX_AUTANALOG_SAR_CH_COEFF0         1 /**< Correction coefficient config 0 */
+#define IFX_AUTANALOG_SAR_CH_COEFF1         2 /**< Correction coefficient config 1 */
+#define IFX_AUTANALOG_SAR_CH_COEFF2         3 /**< Correction coefficient config 2 */
+#define IFX_AUTANALOG_SAR_CH_COEFF3         4 /**< Correction coefficient config 3 */
+#define IFX_AUTANALOG_SAR_CH_COEFF4         5 /**< Correction coefficient config 4 */
+#define IFX_AUTANALOG_SAR_CH_COEFF5         6 /**< Correction coefficient config 5 */
+#define IFX_AUTANALOG_SAR_CH_COEFF6         7 /**< Correction coefficient config 6 */
+#define IFX_AUTANALOG_SAR_CH_COEFF7         8 /**< Correction coefficient config 7 */
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_INFINEON_AUTANALOG_SAR_H_ */

--- a/include/zephyr/dt-bindings/adc/infineon-autanalog-sar.h
+++ b/include/zephyr/dt-bindings/adc/infineon-autanalog-sar.h
@@ -157,4 +157,47 @@
 #define IFX_AUTANALOG_SAR_FIFO_SPLIT8 3 /**< Eight 64-word buffers */
 /** @} */
 
+/**
+ * @name Sequencer next action (cy_en_autanalog_sar_next_act_t)
+ * @{
+ */
+#define IFX_AUTANALOG_SAR_SEQ_NEXT_STOP     0 /**< Stop, send SAR_EOS and SAR_DONE, idle */
+#define IFX_AUTANALOG_SAR_SEQ_NEXT_REPEAT   1 /**< Send SAR_EOS, return to start (continuous) */
+#define IFX_AUTANALOG_SAR_SEQ_NEXT_CONTINUE 2 /**< Continue to next entry in scan table */
+/** @} */
+
+/**
+ * @name Sequencer calibration request (cy_en_autanalog_sar_calibrate_t)
+ * @{
+ */
+#define IFX_AUTANALOG_SAR_SEQ_CAL_DISABLED  0 /**< Calibration disabled */
+#define IFX_AUTANALOG_SAR_SEQ_CAL_BOTH      1 /**< Both offset and linearity */
+#define IFX_AUTANALOG_SAR_SEQ_CAL_OFFSET    2 /**< Offset calibration only */
+#define IFX_AUTANALOG_SAR_SEQ_CAL_LINEARITY 3 /**< Linearity calibration only */
+/** @} */
+
+/**
+ * @name Sequencer accumulator count (cy_en_autanalog_sar_acc_cnt_t)
+ * @{
+ */
+#define IFX_AUTANALOG_SAR_SEQ_ACC_CNT2   0 /**< 2 samples averaged */
+#define IFX_AUTANALOG_SAR_SEQ_ACC_CNT4   1 /**< 4 samples averaged */
+#define IFX_AUTANALOG_SAR_SEQ_ACC_CNT8   2 /**< 8 samples averaged */
+#define IFX_AUTANALOG_SAR_SEQ_ACC_CNT16  3 /**< 16 samples averaged */
+#define IFX_AUTANALOG_SAR_SEQ_ACC_CNT32  4 /**< 32 samples averaged */
+#define IFX_AUTANALOG_SAR_SEQ_ACC_CNT64  5 /**< 64 samples averaged */
+#define IFX_AUTANALOG_SAR_SEQ_ACC_CNT128 6 /**< 128 samples averaged */
+#define IFX_AUTANALOG_SAR_SEQ_ACC_CNT256 7 /**< 256 samples averaged */
+/** @} */
+
+/**
+ * @name Sequencer sample time slot selection (cy_en_autanalog_sar_sample_time_t)
+ * @{
+ */
+#define IFX_AUTANALOG_SAR_SEQ_SAMPLE_TIME0 0 /**< Sample time slot 0 */
+#define IFX_AUTANALOG_SAR_SEQ_SAMPLE_TIME1 1 /**< Sample time slot 1 */
+#define IFX_AUTANALOG_SAR_SEQ_SAMPLE_TIME2 2 /**< Sample time slot 2 */
+#define IFX_AUTANALOG_SAR_SEQ_SAMPLE_TIME3 3 /**< Sample time slot 3 */
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_INFINEON_AUTANALOG_SAR_H_ */

--- a/include/zephyr/dt-bindings/mfd/infineon-autanalog.h
+++ b/include/zephyr/dt-bindings/mfd/infineon-autanalog.h
@@ -130,4 +130,12 @@
 #define IFX_AUTANALOG_DAC_DIR_REVERSE  2 /**< Backward / decrement */
 /** @} */
 
+/**
+ * @name AC Timer clock source values (cy_en_autanalog_timer_clk_src_t)
+ * @{
+ */
+#define IFX_AUTANALOG_TIMER_CLK_LP 0 /**< CLK_LPOSC (nominally 4.096 MHz) */
+#define IFX_AUTANALOG_TIMER_CLK_LF 1 /**< CLK_LF (nominally 32 kHz) */
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MFD_INFINEON_AUTANALOG_H_ */

--- a/samples/drivers/adc/adc_stream/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/drivers/adc/adc_stream/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/infineon-autanalog-sar.h>
+#include <dt-bindings/mfd/infineon-autanalog.h>
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+
+	zephyr,user {
+		io-channels = <&adc0 8>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/* Enable LP mode: clocked from LPOSC at 4.096 MHz, MUX channels only */
+	lp-mode;
+
+	/* MUX channel: P15.0 via internal MUX routing.
+	 * Channel ID 8 = MUX channel index 0.
+	 */
+	channel@8 {
+		reg = <8>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 250)>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IFX_AUTANALOG_SAR_PIN_MUX_GPIO0>; /* P15.0 */
+		fifo-sel = <IFX_AUTANALOG_SAR_FIFO_0>;
+		mux-buf-bypass;
+	};
+
+	fifo {
+		compatible = "infineon,autanalog-sar-fifo";
+		fifo-levels = <256>;
+	};
+};

--- a/samples/drivers/adc/adc_stream/sample.yaml
+++ b/samples/drivers/adc/adc_stream/sample.yaml
@@ -24,3 +24,6 @@ tests:
       - DTC_OVERLAY_FILE=boards/apard32690_max32690_m4_max32.overlay
     platform_allow:
       - apard32690/max32690/m4
+  sample.driver.adc_stream.pse84:
+    platform_allow:
+      - kit_pse84_eval/pse846gps2dbzc4a/m55

--- a/samples/drivers/adc/adc_stream/src/main.c
+++ b/samples/drivers/adc/adc_stream/src/main.c
@@ -121,12 +121,14 @@ static int print_adc_stream(const struct device *adc, struct rtio_iodev *local_i
 			/* Decode all available ADC sample frames */
 			for (int i = 0; i < frame_count; i++) {
 				decoder->decode(buf, channel, &adc_fit, 1, &adc_data);
-				printk("ADC data for %s channel %d (%" PRIq(6) ") %lluns\n",
-				adc->name, channel,
-				PRIq_arg(adc_data.readings[0].value, 6, adc_data.shift),
-				(adc_data.header.base_timestamp_ns
-				+ adc_data.readings[0].timestamp_delta));
 			}
+
+			/* Print only the last value to reduce output */
+			printk("ADC data for %s channel %d: %u samples (%" PRIq(6) ") %lluns\n",
+			       adc->name, channel, frame_count,
+			       PRIq_arg(adc_data.readings[0].value, 6, adc_data.shift),
+			       (adc_data.header.base_timestamp_ns +
+				adc_data.readings[0].timestamp_delta));
 		}
 
 		rtio_release_buffer(&adc_ctx, buf, buf_len);

--- a/soc/infineon/edge/common/infineon_autanalog.h
+++ b/soc/infineon/edge/common/infineon_autanalog.h
@@ -41,6 +41,21 @@ enum ifx_autanalog_periph {
 	IFX_AUTANALOG_PERIPH_COUNT,   /**< Number of AutAnalog peripheral types */
 };
 
+/**
+ * @brief AC firmware trigger indices
+ *
+ * Corresponds to cy_en_autanalog_fw_trigger_t in the PDL.
+ * Used with ifx_autanalog_fw_trigger() to assert sticky FW triggers
+ * that the AC state machine can test via TR_AUTANALOG_IN0..IN3 conditions.
+ */
+enum ifx_autanalog_ac_fw_trigger {
+	IFX_AUTANALOG_AC_FW_TRIGGER_0 = 0, /**< FW trigger 0 (TR_AUTANALOG_IN0) */
+	IFX_AUTANALOG_AC_FW_TRIGGER_1 = 1, /**< FW trigger 1 (TR_AUTANALOG_IN1) */
+	IFX_AUTANALOG_AC_FW_TRIGGER_2 = 2, /**< FW trigger 2 (TR_AUTANALOG_IN2) */
+	IFX_AUTANALOG_AC_FW_TRIGGER_3 = 3, /**< FW trigger 3 (TR_AUTANALOG_IN3) */
+	IFX_AUTANALOG_AC_FW_TRIGGER_COUNT, /**< Number of FW triggers */
+};
+
 /** ISR handler type for AutAnalog child devices */
 typedef void (*ifx_autanalog_child_isr_t)(const struct device *dev);
 
@@ -97,6 +112,19 @@ int ifx_autanalog_start_autonomous_control(const struct device *dev);
  * @return 0 on success, negative error code on failure
  */
 int ifx_autanalog_pause_autonomous_control(const struct device *dev);
+
+/**
+ * @brief Send a firmware trigger to the Autonomous Controller
+ *
+ * Asserts a sticky FW trigger that the AC state machine can test via
+ * TR_AUTANALOG_IN0..IN3 conditions.  The trigger is cleared when the AC
+ * executes a state whose condition matches the corresponding TR_INx.
+ *
+ * @param dev AutAnalog MFD device
+ * @param trigger Trigger index, use enum ifx_autanalog_ac_fw_trigger values
+ * @return 0 on success, -EINVAL if trigger index is out of range
+ */
+int ifx_autanalog_fw_trigger(const struct device *dev, uint8_t trigger);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Depends on https://github.com/zephyrproject-rtos/zephyr/pull/111196

- Added support for multiple sequencers in the PSE84 autanalog SAR ADC
- Added differential and signed output support to the PSE84 autanalog SAR
- Added limit detection functionality to PSE84 autanalog SAR
- Added correction and offset coefficients loading from DT