### PR TITLE
drivers: ramdisk: Add support for compressed initrd

### DIFF
--- a/drivers/disk/Kconfig.ram
+++ b/drivers/disk/Kconfig.ram
@@ -12,6 +12,15 @@ config DISK_DRIVER_RAM
 
 if DISK_DRIVER_RAM
 
+config RAM_LZ4_DECOMPRESSOR
+	bool
+
+config DISK_RAM_DECOMPRESS
+	bool "Decompress the initrd"
+	select RAM_LZ4_DECOMPRESSOR
+	help
+	  Decompress the initrd before using it as the RAM Disk.
+
 module = RAMDISK
 module-str = ramdisk
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/disk/ramdisk.c
+++ b/drivers/disk/ramdisk.c
@@ -15,11 +15,16 @@
 
 LOG_MODULE_REGISTER(ramdisk, CONFIG_RAMDISK_LOG_LEVEL);
 
+#if defined(CONFIG_DISK_RAM_DECOMPRESS)
+#include <lz4frame.h>
+#define LZ4_MAGIC 0x184D2204
+#endif
+
 struct ram_disk_data {
 	struct disk_info *info;
-#if defined(CONFIG_MMU)
+#if defined(CONFIG_MMU) || defined(CONFIG_DISK_RAM_DECOMPRESS)
 	uint8_t *ramdisk_buf;
-#endif
+#endif /* CONFIG_MMU || CONFIG_DISK_RAM_DECOMPRESS */
 };
 
 struct ram_disk_config {
@@ -27,6 +32,9 @@ struct ram_disk_config {
 	const size_t sector_count;
 	const size_t size;
 	uint8_t *const buf;
+#if defined(CONFIG_DISK_RAM_DECOMPRESS)
+	uint8_t *unpacked_buf; /* The buffer for decompressing */
+#endif /* CONFIG_DISK_RAM_DECOMPRESS */
 };
 
 #if defined(CONFIG_MMU)
@@ -39,17 +47,67 @@ static uint8_t *disk_ram_external_map(const struct ram_disk_config *conf)
 
 	return virt_start;
 }
-#endif
+
+#if defined(CONFIG_DISK_RAM_DECOMPRESS)
+static void disk_ram_external_unmap(char *virt_start, size_t size)
+{
+	k_mem_unmap_phys_bare(virt_start, size);
+}
+#endif /* CONFIG_DISK_RAM_DECOMPRESS */
+#endif /* CONFIG_MMU */
+
+#if defined(CONFIG_DISK_RAM_DECOMPRESS)
+static int disk_ram_is_compressed(char *virt_start)
+{
+	uint32_t magic = *(uint32_t *)virt_start;
+
+	return magic == LZ4_MAGIC;
+}
+
+static int disk_ram_decompress(char *compressed_buf, size_t compressed_size,
+				char *decompressed_buf, size_t decompressed_size)
+{
+	LZ4F_decompressionContext_t lz4_ctx = {0};
+	int final_status = 0;
+	size_t ret;
+
+	ret = LZ4F_createDecompressionContext(&lz4_ctx, LZ4F_VERSION);
+	if (LZ4F_isError(ret)) {
+		LOG_ERR("Can't create decompression context, error: %s\n",
+			LZ4F_getErrorName(ret));
+		return ret;
+	}
+
+	ret = LZ4F_decompress(lz4_ctx, decompressed_buf, &decompressed_size,
+			      compressed_buf, &compressed_size, NULL);
+	if (LZ4F_isError(ret)) {
+		LOG_ERR("Decompression failed: %s\n", LZ4F_getErrorName(ret));
+		final_status = ret;
+		goto cleanup;
+	}
+
+	/* The frame is not fully decompressed */
+	if (ret > 0) {
+		LOG_ERR("Decompression incomplete. Next expected size: %zu\n", ret);
+		final_status = -EMSGSIZE;
+	}
+
+cleanup:
+	LZ4F_freeDecompressionContext(lz4_ctx);
+
+	return final_status;
+}
+#endif /* CONFIG_DISK_RAM_DECOMPRESS */
 
 static void *lba_to_address(const struct device *dev, uint32_t lba)
 {
 	const struct ram_disk_config *config = dev->config;
-#if defined(CONFIG_MMU)
+#if defined(CONFIG_MMU) || defined(CONFIG_DISK_RAM_DECOMPRESS)
 	struct ram_disk_data *data = dev->data;
 	uint8_t *ramdisk_buf = data->ramdisk_buf;
-#else
+#else /* CONFIG_MMU || CONFIG_DISK_RAM_DECOMPRESS */
 	uint8_t *ramdisk_buf = config->buf;
-#endif
+#endif /* CONFIG_MMU || CONFIG_DISK_RAM_DECOMPRESS */
 
 	return &ramdisk_buf[lba * config->sector_size];
 }
@@ -155,7 +213,26 @@ static int disk_ram_init(const struct device *dev)
 	const struct ram_disk_config *config = dev->config;
 
 	data->ramdisk_buf = disk_ram_external_map(config);
+#elif defined(CONFIG_DISK_RAM_DECOMPRESS)
+	const struct ram_disk_config *config = dev->config;
+
+	data->ramdisk_buf = config->buf;
 #endif
+
+#if defined(CONFIG_DISK_RAM_DECOMPRESS)
+	if (disk_ram_is_compressed((char *)data->ramdisk_buf)) {
+		if (disk_ram_decompress((char *)data->ramdisk_buf, config->size,
+					(char *)config->unpacked_buf, config->size) < 0) {
+			return -EINVAL;
+		}
+#if defined(CONFIG_MMU)
+		LOG_INF("Freeing compressed initrd");
+		disk_ram_external_unmap(data->ramdisk_buf, config->size);
+#endif /* CONFIG_MMU */
+		data->ramdisk_buf = config->unpacked_buf;
+	}
+#endif /* CONFIG_DISK_RAM_DECOMPRESS */
+
 	return disk_access_register(info);
 }
 
@@ -178,22 +255,36 @@ static const struct disk_operations ram_disk_ops = {
 		     DT_REG_SIZE(DT_INST_PHANDLE(n, ram_region)),			\
 		     "Disk size is smaller than memory region");			\
 											\
+	IF_ENABLED(CONFIG_DISK_RAM_DECOMPRESS,						\
+		   (static uint8_t unpacked_buf_##n[RAMDISK_DEVICE_SIZE(n)];)		\
+	)										\
+											\
 	static struct ram_disk_config disk_config_##n = {				\
 		.sector_size = DT_INST_PROP(n, sector_size),				\
 		.sector_count = DT_INST_PROP(n, sector_count),				\
 		.size = RAMDISK_DEVICE_SIZE(n),						\
 		.buf = UINT_TO_POINTER(DT_REG_ADDR(DT_INST_PHANDLE(n, ram_region))),	\
+		IF_ENABLED(CONFIG_DISK_RAM_DECOMPRESS,					\
+			   (.unpacked_buf = unpacked_buf_##n,)				\
+		)									\
 	}
 
 #define RAMDISK_DEVICE_CONFIG_DEFINE_LOCAL(n)						\
 	static uint8_t disk_buf_##n[DT_INST_PROP(n, sector_size) *			\
 				    DT_INST_PROP(n, sector_count)];			\
 											\
+	IF_ENABLED(CONFIG_DISK_RAM_DECOMPRESS,						\
+		   (static uint8_t unpacked_buf_##n[RAMDISK_DEVICE_SIZE(n)];)		\
+	)										\
+											\
 	static struct ram_disk_config disk_config_##n = {				\
 		.sector_size = DT_INST_PROP(n, sector_size),				\
 		.sector_count = DT_INST_PROP(n, sector_count),				\
 		.size = RAMDISK_DEVICE_SIZE(n),						\
 		.buf = disk_buf_##n,							\
+		IF_ENABLED(CONFIG_DISK_RAM_DECOMPRESS,					\
+			   (.unpacked_buf = unpacked_buf_##n,)				\
+		)									\
 	}
 
 #define RAMDISK_DEVICE_CONFIG_DEFINE(n)							\


### PR DESCRIPTION
Add support for decompressing the initrd before using it as the RAM Disk. 
For now, only LZ4 compression is supported.

It is advised to use smaller block sizes for the compressed initrd to reduce the size of heap memory required for decompression.