### PR TITLE
drivers: bluetooth: hci_bflb: match EVT RX count to ACL TX count

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.bflb
+++ b/drivers/bluetooth/hci/Kconfig.bflb
@@ -123,6 +123,12 @@ config BT_BUF_ACL_TX_COUNT
 	default 10 if BFLB_BL70X_BLE_M0S1T10
 	default 2
 
+# Set to 1 more than BT_BUF_ACL_TX_COUNT
+config BT_BUF_EVT_RX_COUNT
+	default 17 if BFLB_BL70X_BLE_M16S1
+	default 11 if BFLB_BL70X_BLE_M0S1T10
+	default 3
+
 endif # BT_BFLB_BL70X
 
 if BT_BFLB_BL60X
@@ -148,6 +154,11 @@ endchoice
 config BT_BUF_ACL_TX_COUNT
 	default 8 if BFLB_BL60X_BLE_M8S1
 	default 2
+
+# Set to 1 more than BT_BUF_ACL_TX_COUNT
+config BT_BUF_EVT_RX_COUNT
+	default 9 if BFLB_BL60X_BLE_M8S1
+	default 3
 
 endif # BT_BFLB_BL60X
 
@@ -269,6 +280,14 @@ config BT_BUF_ACL_TX_COUNT
 	default 4 if BFLB_BL70XL_BLE_M0S2P || BFLB_BL70XL_BLE_M2S1P
 	default 2
 
+# Set to 1 more than BT_BUF_ACL_TX_COUNT
+config BT_BUF_EVT_RX_COUNT
+	default 9 if BFLB_BL70XL_BLE_M8S1P
+	default 7 if BFLB_BL70XL_BLE_M0S4P || BFLB_BL70XL_BLE_M4S1P
+	default 6 if BFLB_BL70XL_BLE_M0S1RP
+	default 5 if BFLB_BL70XL_BLE_M0S2P || BFLB_BL70XL_BLE_M2S1P
+	default 3
+
 endif # BT_BFLB_BL70XL
 
 config BT_BFLB_BL61X
@@ -312,6 +331,11 @@ endchoice
 config BT_BUF_ACL_TX_COUNT
 	default 10 if BFLB_BL61X_BLE_1M10S1
 	default 4
+
+# Set to 1 more than BT_BUF_ACL_TX_COUNT
+config BT_BUF_EVT_RX_COUNT
+	default 11 if BFLB_BL61X_BLE_1M10S1
+	default 5
 
 config BFLB_BL61X_BLE_EM_64K
 	bool "Use 64 KB exchange memory (required for BR/EDR)"

--- a/drivers/bluetooth/hci/Kconfig.bflb
+++ b/drivers/bluetooth/hci/Kconfig.bflb
@@ -118,13 +118,13 @@ config BFLB_BL70X_BLE_EM_16K
 	  Only needed for the m16s1 variant.
 
 # ACL packet count the selected variant reports in LE Read Buffer Size
-config BT_BUF_ACL_TX_COUNT
+configdefault BT_BUF_ACL_TX_COUNT
 	default 16 if BFLB_BL70X_BLE_M16S1
 	default 10 if BFLB_BL70X_BLE_M0S1T10
 	default 2
 
 # Set to 1 more than BT_BUF_ACL_TX_COUNT
-config BT_BUF_EVT_RX_COUNT
+configdefault BT_BUF_EVT_RX_COUNT
 	default 17 if BFLB_BL70X_BLE_M16S1
 	default 11 if BFLB_BL70X_BLE_M0S1T10
 	default 3
@@ -151,12 +151,12 @@ config BFLB_BL60X_BLE_M8S1
 endchoice
 
 # ACL packet count the selected variant reports in LE Read Buffer Size
-config BT_BUF_ACL_TX_COUNT
+configdefault BT_BUF_ACL_TX_COUNT
 	default 8 if BFLB_BL60X_BLE_M8S1
 	default 2
 
 # Set to 1 more than BT_BUF_ACL_TX_COUNT
-config BT_BUF_EVT_RX_COUNT
+configdefault BT_BUF_EVT_RX_COUNT
 	default 9 if BFLB_BL60X_BLE_M8S1
 	default 3
 
@@ -273,7 +273,7 @@ config BFLB_BL70XL_BLE_EM_16K
 	  Only needed for the m8s1p variant (8 connections).
 
 # ACL packet count the selected variant reports in LE Read Buffer Size
-config BT_BUF_ACL_TX_COUNT
+configdefault BT_BUF_ACL_TX_COUNT
 	default 8 if BFLB_BL70XL_BLE_M8S1P
 	default 6 if BFLB_BL70XL_BLE_M0S4P || BFLB_BL70XL_BLE_M4S1P
 	default 5 if BFLB_BL70XL_BLE_M0S1RP
@@ -281,7 +281,7 @@ config BT_BUF_ACL_TX_COUNT
 	default 2
 
 # Set to 1 more than BT_BUF_ACL_TX_COUNT
-config BT_BUF_EVT_RX_COUNT
+configdefault BT_BUF_EVT_RX_COUNT
 	default 9 if BFLB_BL70XL_BLE_M8S1P
 	default 7 if BFLB_BL70XL_BLE_M0S4P || BFLB_BL70XL_BLE_M4S1P
 	default 6 if BFLB_BL70XL_BLE_M0S1RP
@@ -328,12 +328,12 @@ config BFLB_BL61X_BLE_1M2S1BREDR1
 endchoice
 
 # ACL packet count the selected variant reports in LE Read Buffer Size
-config BT_BUF_ACL_TX_COUNT
+configdefault BT_BUF_ACL_TX_COUNT
 	default 10 if BFLB_BL61X_BLE_1M10S1
 	default 4
 
 # Set to 1 more than BT_BUF_ACL_TX_COUNT
-config BT_BUF_EVT_RX_COUNT
+configdefault BT_BUF_EVT_RX_COUNT
 	default 11 if BFLB_BL61X_BLE_1M10S1
 	default 5
 


### PR DESCRIPTION
Add missing defaults for `BT_EVT_RX_COUNT` in `Kconfig.bflb_hci`.

fixes #111122.