### PR TITLE
tests: ipc: pbuf: set min_ram

### DIFF
--- a/tests/subsys/ipc/pbuf/testcase.yaml
+++ b/tests/subsys/ipc/pbuf/testcase.yaml
@@ -7,6 +7,7 @@ tests:
     # For native(POSIX arch) targets, let's skip those which do not produce an executable
     # (amp targets which need more images)
     filter: not CONFIG_ARCH_POSIX or CONFIG_BUILD_OUTPUT_EXE
+    min_ram: 20
     integration_platforms:
       - native_sim
     timeout: 120


### PR DESCRIPTION
Increase minimal ram requirements for this test, it was on the edge and
started failing on platforms with low memory.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
