### PR TITLE
drivers: ieee802154: esp32: handle rx queue-full case

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2170,6 +2170,8 @@ Documentation Infrastructure:
     - "area: IEEE 802.15.4"
   tests:
     - drivers.ieee802154
+    - net.ieee802154
+    - sample.net.openthread
 
 "Drivers: IPM":
   status: odd fixes
@@ -4650,6 +4652,7 @@ Networking:
     - "area: IEEE 802.15.4"
   tests:
     - net.ieee802154
+    - sample.net.openthread
 
 "Networking: OCPP":
   status: maintained

--- a/drivers/ieee802154/ieee802154_esp32.c
+++ b/drivers/ieee802154/ieee802154_esp32.c
@@ -149,7 +149,7 @@ void IRAM_ATTR esp_ieee802154_receive_done(uint8_t *frame, esp_ieee802154_frame_
 	msg.info = *frame_info;
 
 	if (k_msgq_put(&ieee802154_esp32_rx_msgq, &msg, K_NO_WAIT) != 0) {
-		mmm
+		LOG_ERR("RX queue full, frame dropped");
 	}
 
 done:


### PR DESCRIPTION
Replace a leftover placeholder in the rx queue-full branch with an error log.

Related to https://github.com/zephyrproject-rtos/zephyr/pull/110583