### PR TITLE
scripts: build: gen_relocate: parse align suffix before section flags

### DIFF
--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -285,9 +285,14 @@ def assign_to_correct_mem_region(
     """
     use_section_kinds, memory_region = section_kinds_from_memory_region(memory_region)
 
+    # Split |COPY/|NOKEEP flags before the numeric align suffix, else a region
+    # like "SRAM_4|COPY" makes int("4|COPY") throw.
+    memory_region, sep, flags = memory_region.partition('|')
+    flags = sep + flags
     memory_region, _, align_size = memory_region.partition('_')
     if align_size:
         mpu_align[memory_region] = int(align_size)
+    memory_region = memory_region + flags
 
     keep_sections = '|NOKEEP' not in memory_region
     memory_region = memory_region.replace('|NOKEEP', '')


### PR DESCRIPTION
## Description

  `assign_to_correct_mem_region()` in `scripts/build/gen_relocate_app.py` reads an
  optional per-LOCATION MPU alignment from a numeric suffix on the memory region
  name (e.g. `SRAM_4` → 4-byte align) via `memory_region.partition('_')` followed
  by `int(align_size)`.

  A LOCATION can *also* carry a `|COPY` or `|NOKEEP` flag, but that flag is only
  stripped later (`memory_type.split("|", 1)[0]`). When both are present — e.g.
  `SRAM_4|COPY` — the align parse runs first and `int("4|COPY")` raises:

  ValueError: invalid literal for int() with base 10: '4|COPY'

  …aborting the build. So today a relocation LOCATION cannot combine a numeric
  alignment with a section flag.

  ## Fix

  Split the `|COPY` / `|NOKEEP` flag off the region name **before** parsing the
  numeric align suffix, then re-attach it so the existing `|NOKEEP` handling and
  `MemoryRegion` naming are unchanged.

  Behavior is identical for every LOCATION that already worked (plain regions,
  flag-only, align-only); only the previously-crashing align + flag combination is
  fixed.

  ## Impact

  - No change for any existing in-tree user of `zephyr_code_relocate()`.
  - Enables `<REGION>_<N>` (per-section N-byte align) to be combined with `|COPY` /
    `|NOKEEP`, e.g. to opt out of power-of-two MPU padding on targets where
    `CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT=y` and reclaim the padded space.

  ## Testing

  Verified `assign_to_correct_mem_region` parsing over all combinations —
  `SRAM_4|COPY`, `SRAM|COPY`, `SRAM_4`, `SRAM`, `SRAM_4|NOKEEP`, `SRAM|NOKEEP`:
  `SRAM_4|COPY` now resolves to region `SRAM|COPY` with `mpu_align[SRAM]=4` instead
  of raising; all other combinations are unchanged.