### PR TITLE
drivers: mbox: nrf_vevif_task_tx: Add optional synchronization with the VPR core

### DIFF
--- a/drivers/mbox/mbox_nrf_vevif_task_rx.c
+++ b/drivers/mbox/mbox_nrf_vevif_task_rx.c
@@ -135,8 +135,6 @@ LISTIFY(DT_NUM_IRQS(DT_DRV_INST(0)), VEVIF_IRQ_FUN, ())
 
 static int vevif_task_rx_init(const struct device *dev)
 {
-	nrf_vpr_csr_vevif_tasks_clear(NRF_VPR_TASK_TRIGGER_ALL_MASK);
-
 	LISTIFY(DT_NUM_IRQS(DT_DRV_INST(0)), VEVIF_IRQ_CONNECT, (;));
 
 	return 0;

--- a/drivers/mbox/mbox_nrf_vevif_task_tx.c
+++ b/drivers/mbox/mbox_nrf_vevif_task_tx.c
@@ -14,11 +14,37 @@
 #define TASKS_IDX_MAX NRF_VPR_TASKS_TRIGGER_MAX
 #define VEVIF_RETRIGGER_DELAY_USEC 12
 
+#define VPR_READY_CHECK_NEEDED DT_ANY_INST_HAS_PROP_STATUS_OKAY(nordic_vpr_ready_event)
+
 struct mbox_vevif_task_tx_conf {
 	NRF_VPR_Type *vpr;
 	uint32_t tasks_mask;
 	uint8_t tasks;
+	uint8_t ready_event;
 };
+
+#if VPR_READY_CHECK_NEEDED
+struct mbox_vevif_task_tx_data {
+	bool ready;
+};
+
+static bool vpr_ready_check(const struct device *dev)
+{
+	const struct mbox_vevif_task_tx_conf *config = dev->config;
+	struct mbox_vevif_task_tx_data *data = dev->data;
+
+	if (data->ready) {
+		return true;
+	}
+
+	if (nrfy_vpr_event_check(config->vpr, nrf_vpr_triggered_event_get(config->ready_event))) {
+		data->ready = true;
+		return true;
+	}
+
+	return false;
+}
+#endif
 
 static inline bool vevif_task_tx_is_valid(const struct device *dev, uint32_t id)
 {
@@ -39,6 +65,13 @@ static int vevif_task_tx_send(const struct device *dev, uint32_t id, const struc
 		return -EMSGSIZE;
 	}
 
+#if VPR_READY_CHECK_NEEDED
+	/* Trigger task in the remote core only if core is ready to accept it as otherwise the task
+	 * will be lost. PPR core starts with unknown delay and it signals when it is ready.
+	 */
+	while (!vpr_ready_check(dev)) {
+	}
+#endif
 	nrfy_vpr_task_trigger(config->vpr, nrfy_vpr_trigger_task_get(id));
 
 #ifdef CONFIG_SOC_NRF54H20
@@ -74,13 +107,21 @@ static DEVICE_API(mbox, vevif_task_tx_driver_api) = {
 	BUILD_ASSERT(DT_INST_PROP(inst, nordic_tasks) <= VPR_TASKS_TRIGGER_MaxCount,               \
 		     "Number of tasks exceeds maximum");                                           \
                                                                                                    \
+	COND_CODE_0(VPR_READY_CHECK_NEEDED, (),                                                    \
+		(static struct mbox_vevif_task_tx_data data##inst = {                              \
+			.ready = !DT_INST_NODE_HAS_PROP(inst, nordic_vpr_ready_event),             \
+		};))                                                                               \
 	static const struct mbox_vevif_task_tx_conf conf##inst = {                                 \
 		.vpr = (NRF_VPR_Type *)DT_INST_REG_ADDR(inst),                                     \
 		.tasks = DT_INST_PROP(inst, nordic_tasks),                                         \
 		.tasks_mask = DT_INST_PROP(inst, nordic_tasks_mask),                               \
+		.ready_event = DT_INST_PROP_OR(inst, nordic_vpr_ready_event, 0),                   \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, &conf##inst, POST_KERNEL,                    \
-			      CONFIG_MBOX_INIT_PRIORITY, &vevif_task_tx_driver_api);
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL,                                                    \
+			      COND_CODE_0(VPR_READY_CHECK_NEEDED, (NULL), (&data##inst)),          \
+			      &conf##inst,                                                         \
+			      POST_KERNEL, CONFIG_MBOX_INIT_PRIORITY,                              \
+			      &vevif_task_tx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(VEVIF_TASK_TX_DEFINE)

--- a/dts/bindings/cpu/nordic,vpr.yaml
+++ b/dts/bindings/cpu/nordic,vpr.yaml
@@ -16,3 +16,8 @@ properties:
     required: true
     description:
       Bus width of the CPU.
+
+  nordic,vpr-ready-event:
+    type: int
+    description:
+      Event which is set by the VPR core (cpuppr) to indicate that it is running.

--- a/dts/bindings/mbox/nordic,nrf-vevif-task-tx.yaml
+++ b/dts/bindings/mbox/nordic,nrf-vevif-task-tx.yaml
@@ -29,6 +29,12 @@ properties:
   reg:
     required: true
 
+  nordic,vpr-ready-event:
+    type: int
+    description:
+      Event to wait for before sending messages. Used to synchronize with the VPR core
+      (cpuppr) which is not ready to receive signals immediately after VPR core is launched.
+
 mbox-cells:
   - channel
 

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -51,6 +51,7 @@
 			riscv,isa-base = "rv32e";
 			riscv,isa-extensions = "e", "m", "c", "zicsr";
 			nordic,bus-width = <32>;
+			nordic,vpr-ready-event = <15>;
 
 			cpuppr_vevif_rx: mailbox {
 				compatible = "nordic,nrf-vevif-task-rx";
@@ -900,6 +901,7 @@
 					status = "disabled";
 					#mbox-cells = <1>;
 					nordic,tasks = <16>;
+					nordic,vpr-ready-event = <15>;
 					nordic,tasks-mask = <0xfffffff0>;
 				};
 			};

--- a/soc/nordic/common/vpr/soc_init.c
+++ b/soc/nordic/common/vpr/soc_init.c
@@ -5,6 +5,7 @@
 
 #include <zephyr/init.h>
 #include <hal/nrf_vpr_csr.h>
+#include <hal/nrf_vpr_csr_vevif.h>
 
 static int vpr_init(void)
 {
@@ -25,6 +26,10 @@ static int vpr_init(void)
 	 */
 	nrf_vpr_csr_rtperiph_enable_set(true);
 
+#if DT_NODE_HAS_PROP(DT_NODELABEL(cpu), nordic_vpr_ready_event)
+	/* Notify parent core that core is ready and can accept IPC communication. */
+	nrf_vpr_csr_vevif_events_set(BIT(DT_PROP(DT_NODELABEL(cpu), nordic_vpr_ready_event)));
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
When cpuppr is started by the vpr_launcher it takes ~300 us until it is actually running. Any events triggered on APP side by the mailbox driver before PPR is running are lost. It means that establishing IPC communication will fail if it happens before PPR is running. So far, any IPC communication relied on being initialized when PPR is already running. 

PR adds an optional mechanism to allow checking vpr core readiness before sending the signal in the vevif_task_tx mailbox driver. Dedicated HW event (channel 15) is used for that.

PR contains:
- Adding new property (`nordic,vpr-ready-event`) to vpr and vevif-task-tx bindings and setting it to 15 for PPR related nodes
- Adding setting of that event by VPR init function
- Adding `vpr_ready_check` in the mailbox driver. Before setting a signal function is polling for VPR readiness. Polling is present only if PPR is enabled.