### PR TITLE
tests: drivers: i2c: i2c_target_api: Add missing stm32 platforms and fix inline descriptions

### DIFF
--- a/tests/drivers/i2c/i2c_target_api/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/b_u585i_iot02a.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the STMod+.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the ST morpho header.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f207zg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f207zg.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the ST morpho header.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f401re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f401re.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the ST morpho header.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f429zi.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the ST morpho header.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.conf
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_I2C_STM32_INTERRUPT=y

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the ST morpho header.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.overlay
@@ -8,7 +8,7 @@
  *  Bus        SDA               SCL
  *          Pin   Hdr         Pin   Hdr
  *  i2c1    PB9   CN7:4      PB8   CN7:2
- *  i2c2    PB11  CN10:34    PB10  CN10:32
+ *  i2c2    PB11  CN10:34    PF1   CN9:19
  *
  * Short Pin PB9 to PB11, and PB8 to PB10, for the test to pass.
  */

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l073rz.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l073rz.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the ST morpho header.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l152re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l152re.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the ST morpho header.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the Arduino Shield Connectors and Morpho connectors.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the ST morpho header.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
@@ -1,5 +1,15 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+/* I2C bus pins are exposed on the ST P2 connector.
+ *
+ *  Bus        SDA               SCL
+ *          Pin   Hdr         Pin   Hdr
+ *  i2c1    PB9  P2:3         PB8  P2:4
+ *  i2c2    PB11 P1:31        PB10 P1:30
+ *
+ * Short Pin PB9 to PB11, and PB8 to PB10, for the test to pass.
+ */
+
 &i2c1 {
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the ST P2 connector.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
@@ -1,5 +1,15 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+/* I2C bus pins are exposed on the ST P2 connector.
+ *
+ *  Bus        SDA               SCL
+ *          Pin   Hdr         Pin   Hdr
+ *  i2c1    PB9  P2:3         PB8  P2:4
+ *  i2c2    PB11 P1:31        PB10 P1:30
+ *
+ * Short Pin PB9 to PB11, and PB8 to PB10, for the test to pass.
+ */
+
 #define IC2_TEST_0_DMA_TX <&dma1 2 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>
 #define IC2_TEST_0_DMA_RX <&dma1 3 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>
 

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.overlay
@@ -4,7 +4,7 @@
  *
  *  Bus        SDA               SCL
  *          Pin   Hdr         Pin   Hdr
- *  i2c1    PB7  P2:21        PB6  P2:22
+ *  i2c1    PB7  P2:22        PB6  P2:21
  *  i2c2    PA10 P2:43        PA9  P2:44
  *
  * Short Pin PB7 to PA10, and PB6 to PA9, for the test to pass.

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.overlay
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* I2C bus pins are exposed on the ST P2 connector.
  *

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -7,8 +7,8 @@
  *
  *  Bus        SDA                    SCL
  *          Pin   Hdr              Pin   Hdr
- *  i2c1    PC1   CN12:10 (D15)    PH9   CN12:9 (D14)
- *  i2c4    PE14  CN12:2  (D9)     PE13  CN11:7 (D6)
+ *  i2c1    PC1   CN12:9 (D14)     PH9   CN12:10 (D15)
+ *  i2c4    PE14  CN12:2 (D9)      PE13  CN11:7 (D6)
  *
  * Short Pin PC1 to PE14, and PH9 to PE13, for the test to pass.
  */

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -7,7 +7,7 @@
  *
  *  Bus        SDA                    SCL
  *          Pin   Hdr              Pin   Hdr
- *  i2c1    PC1   CN12:10 (D15)    PH9   CN12:9 (D14)
+ *  i2c1    PC1   CN12:9  (D14)    PH9   CN12:10 (D15)
  *  i2c4    PE14  CN12:2  (D9)     PE13  CN11:7 (D6)
  *
  * Short Pin PC1 to PE14, and PH9 to PE13, for the test to pass.

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -30,9 +30,12 @@ tests:
       - nucleo_f401re
       - nucleo_f429zi
       - nucleo_h503rb
+      - nucleo_h563zi
       - nucleo_h753zi
       - nucleo_l073rz
       - nucleo_l152re
+      - nucleo_l476rg
+      - nucleo_n657x0_q/stm32n657xx/sb
       - nucleo_u083rc
       - nucleo_u385rg_q
       - nucleo_wba55cg

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -14,21 +14,16 @@ tests:
       - disco_l475_iot1
       - esp32h2_devkitm
       - esp32s3_devkitc/esp32s3/procpu
-      - nucleo_f746zg
-      - nucleo_g474re
-      - nucleo_f091rc
-      - stm32f072b_disco
-      - stm32f3_disco
-      - stm32h573i_dk
-      - stm32l562e_dk
-      - stm32n6570_dk/stm32n657xx/sb
-      - stm32u083c_dk
+      - mr_canhubk3
       - nucleo_c071rb
       - nucleo_c5a3zg
-      - nucleo_g071rb
+      - nucleo_f091rc
       - nucleo_f207zg
       - nucleo_f401re
       - nucleo_f429zi
+      - nucleo_f746zg
+      - nucleo_g071rb
+      - nucleo_g474re
       - nucleo_h503rb
       - nucleo_h563zi
       - nucleo_h753zi
@@ -38,36 +33,34 @@ tests:
       - nucleo_n657x0_q/stm32n657xx/sb
       - nucleo_u083rc
       - nucleo_u385rg_q
-      - nucleo_wba55cg
       - nucleo_wb55rg
+      - nucleo_wba55cg
       - nucleo_wl55jc
       - rpi_pico
       - sltb010a@0
-      - mr_canhubk3
+      - stm32f072b_disco
+      - stm32f3_disco
+      - stm32h573i_dk
+      - stm32l562e_dk
+      - stm32n6570_dk/stm32n657xx/sb
+      - stm32u083c_dk
     integration_platforms:
       - nucleo_f091rc
     extra_configs:
       - CONFIG_APP_DUAL_ROLE_I2C=y
   drivers.i2c.target_api.single_role:
     platform_allow:
-      - frdm_mcxn947/mcxn947/cpu0
-      - mcx_n9xx_evk/mcxn947/cpu0
-      - mcxw72_evk
-      - mimxrt1170_evk@B/mimxrt1176/cm7
-      - mimxrt1170_evk/mimxrt1176/cm7
-      - mimxrt1180_evk/mimxrt1189/cm33
-      - mimxrt1180_evk/mimxrt1189/cm7
-      - mimxrt1040_evk
-      - mimxrt1060_evk/mimxrt1062/qspi
       - frdm_ke17z512
-      - frdm_mcxn236
       - frdm_mcxa156
-      - frdm_mcxa346
       - frdm_mcxa266
-      - frdm_mcxa366
       - frdm_mcxa344
-      - frdm_mcxc242
+      - frdm_mcxa346
+      - frdm_mcxa366
       - frdm_mcxa577
+      - frdm_mcxc242
+      - frdm_mcxn236
+      - frdm_mcxn947/mcxn947/cpu0
+      - it51xxx_evb/it51526aw
       - max32655evkit/max32655/m4
       - max32662evkit
       - max32666evkit/max32666/cpu0
@@ -76,6 +69,14 @@ tests:
       - max32675evkit
       - max32680evkit/max32680/m4
       - max32690evkit/max32690/m4
+      - mcx_n9xx_evk/mcxn947/cpu0
+      - mcxw72_evk
+      - mimxrt1040_evk
+      - mimxrt1060_evk/mimxrt1062/qspi
+      - mimxrt1170_evk@B/mimxrt1176/cm7
+      - mimxrt1170_evk/mimxrt1176/cm7
+      - mimxrt1180_evk/mimxrt1189/cm33
+      - mimxrt1180_evk/mimxrt1189/cm7
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpuppr
@@ -84,12 +85,11 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
+      - pic32cm_jh01_cpro
+      - pic32cx_sg41_cult
       - s32k5xxcvb/s32k566/m7
       - s32k5xxcvb/s32k566/r52
-      - it51xxx_evb/it51526aw
       - sam_e54_xpro
-      - pic32cx_sg41_cult
-      - pic32cm_jh01_cpro
     integration_platforms:
       - max32690evkit/max32690/m4
       - nrf54l15dk/nrf54l15/cpuapp

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -61,22 +61,22 @@ tests:
       - frdm_mcxn236
       - frdm_mcxn947/mcxn947/cpu0
       - it51xxx_evb/it51526aw
-      - mcx_n9xx_evk/mcxn947/cpu0
-      - mcxw72_evk
-      - mimxrt1170_evk@B/mimxrt1176/cm7
-      - mimxrt1170_evk/mimxrt1176/cm7
-      - mimxrt1180_evk/mimxrt1189/cm33
-      - mimxrt1180_evk/mimxrt1189/cm7
-      - mimxrt1040_evk
-      - mimxrt1060_evk/mimxrt1062/qspi
-      - max32662evkit
       - max32655evkit/max32655/m4
+      - max32662evkit
       - max32666evkit/max32666/cpu0
       - max32670evkit
       - max32672evkit
       - max32675evkit
       - max32680evkit/max32680/m4
       - max32690evkit/max32690/m4
+      - mcx_n9xx_evk/mcxn947/cpu0
+      - mcxw72_evk
+      - mimxrt1040_evk
+      - mimxrt1060_evk/mimxrt1062/qspi
+      - mimxrt1170_evk@B/mimxrt1176/cm7
+      - mimxrt1170_evk/mimxrt1176/cm7
+      - mimxrt1180_evk/mimxrt1189/cm33
+      - mimxrt1180_evk/mimxrt1189/cm7
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpuppr


### PR DESCRIPTION
Correct inline comments describing wiring of I2C buses pin to pass  **i2c_target_api** test for a few STM32 platforms.
Add some STM32 platforms in the `platform_allowed` list for **i2c_target_api** tests.
Alphabetize `platform_allowed` list for **i2c_target_api** tests.