### PR TITLE
Update bbled driver common to xec devices

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -348,6 +348,12 @@ Interrupt Controllers
   ``DT_INST_IRQ(n, sense)`` or ``DT_IRQ(node, sense)`` should be updated to use ``flags`` instead
   of ``sense``.
 
+LED 
+===
+* The ``girqs`` and ``pcrs`` properties (array type) of :dtcompatible:`microchip,xec-bbled` have been
+  replaced by encoded ``girqs`` (using ``MCHP_XEC_ECIA_GIRQ_ENC`` macros) and ``pcr-scr`` (int type)
+  for encoded PCR register index and bit position (:github:``).
+
 NXP
 ===
 

--- a/drivers/led/led_mchp_xec.c
+++ b/drivers/led/led_mchp_xec.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(led_xec, CONFIG_LED_LOG_LEVEL);
 /* Same BBLED hardware block in MEC15xx and MEC172x families
  * Config register
  */
+#define XEC_BBLED_CFG_OFS		0
 #define XEC_BBLED_CFG_MSK		0x1ffffu
 #define XEC_BBLED_CFG_MODE_POS		0
 #define XEC_BBLED_CFG_MODE_MSK		0x3u
@@ -41,6 +42,7 @@ LOG_MODULE_REGISTER(led_xec, CONFIG_LED_LOG_LEVEL);
 #define XEC_BBLED_CFG_WDT_RLD_DFLT	0x1400u
 
 /* Limits register */
+#define XEC_BBLED_LIM_OFS		0x04u
 #define XEC_BBLED_LIM_MSK		0xffffu
 #define XEC_BBLED_LIM_MIN_POS		0
 #define XEC_BBLED_LIM_MIN_MSK		0xffu
@@ -48,6 +50,7 @@ LOG_MODULE_REGISTER(led_xec, CONFIG_LED_LOG_LEVEL);
 #define XEC_BBLED_LIM_MAX_MSK		0xff00u
 
 /* Delay register */
+#define XEC_BBLED_DLY_OFS		0x08u
 #define XEC_BBLED_DLY_MSK		0xffffffu
 #define XEC_BBLED_DLY_LO_POS		0
 #define XEC_BBLED_DLY_LO_MSK		0xfffu
@@ -75,17 +78,8 @@ LOG_MODULE_REGISTER(led_xec, CONFIG_LED_LOG_LEVEL);
 #define XEC_BBLED_BLINK_PERIOD_MAX_MS	32000u
 #define XEC_BBLED_BLINK_PERIOD_MIN_MS	8u
 
-struct xec_bbled_regs {
-	volatile uint32_t config;
-	volatile uint32_t limits;
-	volatile uint32_t delay;
-	volatile uint32_t update_step_size;
-	volatile uint32_t update_interval;
-	volatile uint32_t output_delay;
-};
-
 struct xec_bbled_config {
-	struct xec_bbled_regs * const regs;
+	mm_reg_t base;
 	const struct pinctrl_dev_config *pcfg;
 	uint8_t enc_pcr;
 };
@@ -141,8 +135,8 @@ static int xec_bbled_blink(const struct device *dev, uint32_t led,
 			    uint32_t delay_on, uint32_t delay_off)
 {
 	const struct xec_bbled_config * const config = dev->config;
-	struct xec_bbled_regs * const regs = config->regs;
-	uint32_t period, prescaler, dcs;
+	mm_reg_t base = config->base;
+	uint32_t period, prescaler, dcs, reg;
 
 	if (led) {
 		return -EINVAL;
@@ -163,15 +157,27 @@ static int xec_bbled_blink(const struct device *dev, uint32_t led,
 	prescaler = calc_blink_32k_prescaler(delay_on, delay_off);
 	dcs = calc_blink_duty_cycle(delay_on, delay_off);
 
-	regs->config = (regs->config & ~(XEC_BBLED_CFG_MODE_MSK))
+	reg = sys_read32(base + XEC_BBLED_CFG_OFS);
+	reg = (reg & ~(XEC_BBLED_CFG_MODE_MSK))
 		       | XEC_BBLED_CFG_MODE_OFF;
-	regs->delay = (regs->delay & ~(XEC_BBLED_DLY_LO_MSK))
+	sys_write32(reg, base + XEC_BBLED_CFG_OFS);
+
+	reg = sys_read32(base + XEC_BBLED_DLY_OFS);
+	reg = (reg & ~(XEC_BBLED_DLY_LO_MSK))
 		      | (prescaler & XEC_BBLED_DLY_LO_MSK);
-	regs->limits = (regs->limits & ~(XEC_BBLED_LIM_MIN_MSK))
+	sys_write32(reg, base + XEC_BBLED_DLY_OFS);
+
+	reg = sys_read32(base + XEC_BBLED_LIM_OFS);
+	reg = (reg & ~(XEC_BBLED_LIM_MIN_MSK))
 		       | (dcs & XEC_BBLED_LIM_MIN_MSK);
-	regs->config = (regs->config & ~(XEC_BBLED_CFG_MODE_MSK))
+	sys_write32(reg, base + XEC_BBLED_LIM_OFS);
+
+	reg = sys_read32(base + XEC_BBLED_CFG_OFS);
+	reg = (reg & ~(XEC_BBLED_CFG_MODE_MSK))
 		       | XEC_BBLED_CFG_MODE_PWM;
-	regs->config |= BIT(XEC_BBLED_CFG_EN_UPDATE_POS);
+	sys_write32(reg, base + XEC_BBLED_CFG_OFS);
+
+	sys_set_bits(base + XEC_BBLED_CFG_OFS, BIT(XEC_BBLED_CFG_EN_UPDATE_POS));
 
 	return 0;
 }
@@ -179,42 +185,49 @@ static int xec_bbled_blink(const struct device *dev, uint32_t led,
 static int xec_bbled_on(const struct device *dev, uint32_t led)
 {
 	const struct xec_bbled_config * const config = dev->config;
-	struct xec_bbled_regs * const regs = config->regs;
+	mm_reg_t base = config->base;
+	uint32_t reg;
 
 	if (led) {
 		return -EINVAL;
 	}
 
-	regs->config = (regs->config & ~(XEC_BBLED_CFG_MODE_MSK))
+	reg = sys_read32(base + XEC_BBLED_CFG_OFS);
+	reg = (reg & ~(XEC_BBLED_CFG_MODE_MSK))
 			| XEC_BBLED_CFG_MODE_ALWAYS_ON;
+	sys_write32(reg, base + XEC_BBLED_CFG_OFS);
 	return 0;
 }
 
 static int xec_bbled_off(const struct device *dev, uint32_t led)
 {
 	const struct xec_bbled_config * const config = dev->config;
-	struct xec_bbled_regs * const regs = config->regs;
+	mm_reg_t base = config->base;
+	uint32_t reg;
 
 	if (led) {
 		return -EINVAL;
 	}
 
-	regs->config = (regs->config & ~(XEC_BBLED_CFG_MODE_MSK))
+	reg = sys_read32(base + XEC_BBLED_CFG_OFS);
+	reg = (reg & ~(XEC_BBLED_CFG_MODE_MSK))
 			| XEC_BBLED_CFG_MODE_OFF;
+	sys_write32(reg, base + XEC_BBLED_CFG_OFS);
 	return 0;
 }
 
 static int xec_bbled_init(const struct device *dev)
 {
 	const struct xec_bbled_config * const config = dev->config;
-	struct xec_bbled_regs * const regs = config->regs;
+	mm_reg_t base = config->base;
+	uint32_t reg;
 	int ret;
 
 	soc_xec_pcr_sleep_en_clear(config->enc_pcr);
 
 	/* soft reset, disable BBLED WDT, set clock source to default (32KHz domain) */
-	regs->config |= BIT(XEC_BBLED_CFG_RST_PWM_POS);
-	regs->config = XEC_BBLED_CFG_MODE_OFF;
+	sys_set_bits(base + XEC_BBLED_CFG_OFS, BIT(XEC_BBLED_CFG_RST_PWM_POS));
+	sys_write32(XEC_BBLED_CFG_MODE_OFF, base + XEC_BBLED_CFG_OFS);
 
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret != 0) {
@@ -234,7 +247,7 @@ static DEVICE_API(led, xec_bbled_api) = {
 
 #define XEC_BBLED_CONFIG(i)						\
 static struct xec_bbled_config xec_bbled_config_##i = {			\
-	.regs = (struct xec_bbled_regs * const)DT_INST_REG_ADDR(i),	\
+	.base = DT_INST_REG_ADDR(i),	\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(i),			\
 	.enc_pcr = DT_INST_PROP(0, pcrs),		\
 }

--- a/drivers/led/led_mchp_xec.c
+++ b/drivers/led/led_mchp_xec.c
@@ -12,14 +12,12 @@
  */
 
 #include <soc.h>
-#ifndef CONFIG_SOC_SERIES_MEC15XX
-#include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
-#include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
-#endif
+#include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
 #include <zephyr/drivers/led.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/sys_io.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(led_xec, CONFIG_LED_LOG_LEVEL);
@@ -89,8 +87,7 @@ struct xec_bbled_regs {
 struct xec_bbled_config {
 	struct xec_bbled_regs * const regs;
 	const struct pinctrl_dev_config *pcfg;
-	uint8_t pcr_id;
-	uint8_t pcr_pos;
+	uint8_t enc_pcr;
 };
 
 /* delay_on and delay_off are in milliseconds
@@ -207,44 +204,13 @@ static int xec_bbled_off(const struct device *dev, uint32_t led)
 	return 0;
 }
 
-#ifdef CONFIG_SOC_SERIES_MEC15XX
-static inline void xec_bbled_slp_en_clr(const struct device *dev)
-{
-	const struct xec_bbled_config * const cfg = dev->config;
-	enum pcr_id pcr_val = PCR_MAX_ID;
-
-	switch (cfg->pcr_pos) {
-	case MCHP_PCR3_LED0_POS:
-		pcr_val = PCR_LED0;
-		break;
-	case MCHP_PCR3_LED1_POS:
-		pcr_val = PCR_LED1;
-		break;
-	case MCHP_PCR3_LED2_POS:
-		pcr_val = PCR_LED2;
-		break;
-	default:
-		return;
-	}
-
-	mchp_pcr_periph_slp_ctrl(pcr_val, 0);
-}
-#else
-static inline void xec_bbled_slp_en_clr(const struct device *dev)
-{
-	const struct xec_bbled_config * const cfg = dev->config;
-
-	z_mchp_xec_pcr_periph_sleep(cfg->pcr_id, cfg->pcr_pos, 0);
-}
-#endif
-
 static int xec_bbled_init(const struct device *dev)
 {
 	const struct xec_bbled_config * const config = dev->config;
 	struct xec_bbled_regs * const regs = config->regs;
 	int ret;
 
-	xec_bbled_slp_en_clr(dev);
+	soc_xec_pcr_sleep_en_clear(config->enc_pcr);
 
 	/* soft reset, disable BBLED WDT, set clock source to default (32KHz domain) */
 	regs->config |= BIT(XEC_BBLED_CFG_RST_PWM_POS);
@@ -270,8 +236,7 @@ static DEVICE_API(led, xec_bbled_api) = {
 static struct xec_bbled_config xec_bbled_config_##i = {			\
 	.regs = (struct xec_bbled_regs * const)DT_INST_REG_ADDR(i),	\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(i),			\
-	.pcr_id = (uint8_t)DT_INST_PROP_BY_IDX(i, pcrs, 0),		\
-	.pcr_pos = (uint8_t)DT_INST_PROP_BY_IDX(i, pcrs, 1),		\
+	.enc_pcr = DT_INST_PROP(0, pcrs),		\
 }
 
 #define XEC_BBLED_DEVICE(i)						\

--- a/dts/arm/microchip/mec/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec/mec1501hsz.dtsi
@@ -562,24 +562,24 @@
 		bbled0: bbled@4000b800 {
 			reg = <0x4000b800 0x100>;
 			interrupts = <83 0>;
-			girqs = <17 13>;
-			pcrs = <3 16>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 13)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 16)>;
 			status = "disabled";
 		};
 
 		bbled1: bbled@4000b900 {
 			reg = <0x4000b900 0x100>;
 			interrupts = <84 0>;
-			girqs = <17 14>;
-			pcrs = <3 17>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 14)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 17)>;
 			status = "disabled";
 		};
 
 		bbled2: bbled@4000ba00 {
 			reg = <0x4000ba00 0x100>;
 			interrupts = <85 0>;
-			girqs = <17 15>;
-			pcrs = <3 18>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 15)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 18)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -808,32 +808,32 @@ spip0: spip@40007000 {
 bbled0: bbled@4000b800 {
 	reg = <0x4000b800 0x100>;
 	interrupts = <83 0>;
-	girqs = <17 13>;
-	pcrs = <3 16>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 13)>;
+	pcrs = <MCHP_XEC_SCR_ENCODE(3, 16)>;
 	status = "disabled";
 };
 
 bbled1: bbled@4000b900 {
 	reg = <0x4000b900 0x100>;
 	interrupts = <84 0>;
-	girqs = <17 14>;
-	pcrs = <3 17>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 14)>;
+	pcrs = <MCHP_XEC_SCR_ENCODE(3, 17)>;
 	status = "disabled";
 };
 
 bbled2: bbled@4000ba00 {
 	reg = <0x4000ba00 0x100>;
 	interrupts = <85 0>;
-	girqs = <17 15>;
-	pcrs = <3 18>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 15)>;
+	pcrs = <MCHP_XEC_SCR_ENCODE(3, 18)>;
 	status = "disabled";
 };
 
 bbled3: bbled@4000bb00 {
 	reg = <0x4000bb00 0x100>;
 	interrupts = <86 0>;
-	girqs = <17 16>;
-	pcrs = <3 25>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 16)>;
+	pcrs = <MCHP_XEC_SCR_ENCODE(3, 25)>;
 	status = "disabled";
 };
 

--- a/dts/arm/microchip/mec/mec5.dtsi
+++ b/dts/arm/microchip/mec/mec5.dtsi
@@ -643,21 +643,24 @@
 		bbled0: bbled@4000b800 {
 			reg = <0x4000b800 0x100>;
 			interrupts = <83 3>;
-			girqs = <17 13>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 13)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 16)>;
 			status = "disabled";
 		};
 
 		bbled1: bbled@4000b900 {
 			reg = <0x4000b900 0x100>;
 			interrupts = <84 3>;
-			girqs = <17 14>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 14)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 17)>;
 			status = "disabled";
 		};
 
 		bbled2: bbled@4000ba00 {
 			reg = <0x4000ba00 0x100>;
 			interrupts = <85 3>;
-			girqs = <17 15>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 15)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 18)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/microchip/mec/mec5_mec1743qlj.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1743qlj.dtsi
@@ -49,6 +49,7 @@
 		bbled3: bbled@4000bb00 {
 			reg = <0x4000bb00 0x100>;
 			interrupts = <86 3>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 25)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/microchip/mec/mec5_mec1743qsz.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1743qsz.dtsi
@@ -48,6 +48,7 @@
 		bbled3: bbled@4000bb00 {
 			reg = <0x4000bb00 0x100>;
 			interrupts = <86 3>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 25)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/microchip/mec/mec5_mec1753qlj.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1753qlj.dtsi
@@ -50,6 +50,7 @@
 		bbled3: bbled@4000bb00 {
 			reg = <0x4000bb00 0x100>;
 			interrupts = <86 3>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 25)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/microchip/mec/mec5_mec1753qsz.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1753qsz.dtsi
@@ -49,6 +49,7 @@
 		bbled3: bbled@4000bb00 {
 			reg = <0x4000bb00 0x100>;
 			interrupts = <86 3>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 25)>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/led/microchip,xec-bbled.yaml
+++ b/dts/bindings/led/microchip,xec-bbled.yaml
@@ -3,9 +3,12 @@
 
 description: Microchip XEC BBLED
 
-include: [base.yaml, pinctrl-device.yaml]
-
 compatible: "microchip,xec-bbled"
+
+include:
+  - name: base.yaml
+  - name: pinctrl-device.yaml
+  - name: microchip,dmec-ecia-girq.yaml
 
 properties:
   reg:
@@ -14,12 +17,7 @@ properties:
   interrupts:
     required: true
 
-  girqs:
-    type: array
-    required: true
-    description: Array of pairs of GIRQ number and bit position
-
   pcrs:
-    type: array
+    type: int
     required: true
     description: BBLED PCR register index and bit position


### PR DESCRIPTION
SOC helper macro used to enable the bbled block.
Updated the girq, pcr device tree node with new macro.
Offset based register access used instead of CMSIS