### PR TITLE
bluetooth: mesh: shell: fix BLOB transfer progress calculation

### DIFF
--- a/subsys/bluetooth/mesh/shell/blob.c
+++ b/subsys/bluetooth/mesh/shell/blob.c
@@ -128,18 +128,20 @@ static uint8_t get_progress(const struct bt_mesh_blob_xfer_info *info)
 {
 	uint8_t total_blocks;
 	uint8_t blocks_not_rxed = 0;
-	uint8_t blocks_not_rxed_size;
-	int i;
 
 	total_blocks = DIV_ROUND_UP(info->size, 1U << info->block_size_log);
 
-	blocks_not_rxed_size = DIV_ROUND_UP(total_blocks, 8);
-
-	for (i = 0; i < blocks_not_rxed_size; i++) {
-		blocks_not_rxed += info->missing_blocks[i % 8] & (1 << (i % 8));
+	if (total_blocks == 0) {
+		return 0;
 	}
 
-	return (total_blocks - blocks_not_rxed) / total_blocks;
+	for (int i = 0; i < total_blocks; i++) {
+		if (info->missing_blocks[i / 8] & (1 << (i % 8))) {
+			blocks_not_rxed++;
+		}
+	}
+
+	return (100U * (total_blocks - blocks_not_rxed)) / total_blocks;
 }
 
 static void xfer_progress(struct bt_mesh_blob_cli *cli,


### PR DESCRIPTION
The get_progress() function in the BLOB shell had two bugs:

1. The loop iterated over byte count (DIV_ROUND_UP(total_blocks, 8)) instead of total block count, and the bit indexing used i % 8 for both the byte index and bit position, meaning it only ever inspected the first byte of the missing_blocks array.

2. The final calculation (total_blocks - blocks_not_rxed) / total_blocks performed integer division without scaling, always yielding 0 or 1 instead of a percentage.

Fix the loop to iterate over all block bits using proper byte/bit indexing, and multiply the numerator by 100 to produce a correct 0-100 percentage result.