### PR TITLE
boards: amd: Add AMD Zynq UltraScale+ MPSoC (ZynqMP) board support

### DIFF
--- a/boards/amd/zynqmp_apu/Kconfig.defconfig
+++ b/boards/amd/zynqmp_apu/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_ZYNQMP_APU
+
+config BUILD_OUTPUT_BIN
+	default y
+
+endif # BOARD_ZYNQMP_APU

--- a/boards/amd/zynqmp_apu/Kconfig.zynqmp_apu
+++ b/boards/amd/zynqmp_apu/Kconfig.zynqmp_apu
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ZYNQMP_APU
+	select SOC_XILINX_ZYNQMP_APU

--- a/boards/amd/zynqmp_apu/board.cmake
+++ b/boards/amd/zynqmp_apu/board.cmake
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BUILD_WITH_TFA)
+  dt_chosen(chosen_sram_path PROPERTY "zephyr,sram")
+  dt_reg_addr(RAM_ADDR PATH "${chosen_sram_path}")
+
+  set(TFA_PLAT "zynqmp")
+  set(TFA_EXTRA_ARGS "PRELOADED_BL33_BASE=${RAM_ADDR}")
+  if(CONFIG_TFA_MAKE_BUILD_TYPE_DEBUG)
+    set(BUILD_FOLDER "debug")
+  else()
+    set(BUILD_FOLDER "release")
+  endif()
+  set(XSDB_BL31_PATH ${PROJECT_BINARY_DIR}/../tfa/zynqmp/${BUILD_FOLDER}/bl31/bl31.elf)
+  board_runner_args(xsdb "--bl31=${XSDB_BL31_PATH}")
+endif()
+
+include(${ZEPHYR_BASE}/boards/common/xsdb.board.cmake)

--- a/boards/amd/zynqmp_apu/board.yml
+++ b/boards/amd/zynqmp_apu/board.yml
@@ -7,3 +7,5 @@ board:
   vendor: amd
   socs:
   - name: zynqmp_apu
+    variants:
+    - name: smp

--- a/boards/amd/zynqmp_apu/board.yml
+++ b/boards/amd/zynqmp_apu/board.yml
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+board:
+  name: zynqmp_apu
+  full_name: AMD Zynq UltraScale+ MPSoC APU
+  vendor: amd
+  socs:
+  - name: zynqmp_apu

--- a/boards/amd/zynqmp_apu/doc/index.rst
+++ b/boards/amd/zynqmp_apu/doc/index.rst
@@ -1,0 +1,63 @@
+.. Copyright (c) 2026 Advanced Micro Devices, Inc.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. zephyr:board:: zynqmp_apu
+
+Overview
+********
+
+This board targets the Cortex-A53 application processing unit (APU) on AMD
+Zynq UltraScale+ MPSoC devices. GIC-400 for the APU cluster is at
+``0xf9010000``, high DDR at ``0x8_0000_0000``, and PS UART0 at ``0xff000000``.
+
+Hardware
+********
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+The default console is UART0 (typical Linux name ``ttyPS0``).
+
+Memories
+--------
+
+* ``sram0`` uses the low DDR window (2 GiB from ``0x0``).
+
+Known limitations
+=================
+
+* Only CPU0 is supported by this configuration.
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+Build (example):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: zynqmp_apu
+   :goals: build
+
+Arm Trusted Firmware (TF-A)
+===========================
+
+When ``CONFIG_BUILD_WITH_TFA`` is enabled (default for this board), the build
+also produces TF-A ``bl31.elf`` under
+``build/tfa/zynqmp/<release|debug>/bl31/``. On hardware, Zephyr runs as BL33
+after platform firmware (bitstream, FSBL, and PMUFW from the PDI) and TF-A have
+initialized the PS and provide PSCI via SMC.
+
+AMD ZynqMP boards do not boot from ``fip.bin``. TF-A is built with
+``PRELOADED_BL33_BASE`` set to the Zephyr load address from devicetree, and the
+XSDB runner loads the bitstream, FSBL, ``bl31.elf``, and Zephyr ELF separately.
+When ``CONFIG_BUILD_WITH_TFA`` is enabled, ``west flash`` passes the built
+``bl31.elf`` path automatically via ``--bl31``.
+
+References
+**********
+
+1. AMD Zynq UltraScale+ Device Technical Reference Manual (UG1085)

--- a/boards/amd/zynqmp_apu/support/xsdb_cfg.tcl
+++ b/boards/amd/zynqmp_apu/support/xsdb_cfg.tcl
@@ -1,0 +1,135 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+proc boot_jtag { } {
+	targets -set -filter {name =~ "PSU*"}
+	stop
+	mwr 0xffca0010 0x0
+	mwr 0xff5e0200 0x0100
+	rst -system
+}
+
+proc load_image args  {
+	set elf_file [lindex $args 0]
+	set bitfile [lindex $args 1]
+	set fsblelf_file [lindex $args 2]
+	set bl31_file [lindex $args 3]
+	set pmufw_file [lindex $args 4]
+
+	if { [info exists ::env(HW_SERVER_URL)] } {
+		connect -url $::env(HW_SERVER_URL)
+	} else {
+		connect
+	}
+
+	# Wait for targets to become available after connect
+	for {set i 0} {$i < 20} {incr i} {
+		if { [ta] != "" } break
+		after 50
+	}
+
+	after 2000
+	boot_jtag
+	after 2000
+
+	# load bitstream while PSU is the active target
+	if { [string length $bitfile] != 0 } {
+		fpga -f $bitfile -no-revision-check
+	}
+
+	# Load PMUFW on the PMU MicroBlaze before FSBL so TF-A IPI calls succeed.
+	# TF-A communicates with PMUFW via IPI during bl31_main (pm_mmio_read etc.);
+	# without PMUFW running the IPI notify loop hangs indefinitely.
+	# PMU MicroBlaze is hidden from JTAG by default after reset; writing
+	# 0x1C0 to PMU_GLOBAL_GEN_STORAGE4 (0xFFCA0038) makes it visible.
+	if { [string length $pmufw_file] != 0 } {
+		targets -set -nocase -filter {name =~ "*PSU*"}
+		mask_write 0xFFCA0038 0x1C0 0x1C0
+		if { [catch {targets -set -nocase -filter {name =~ "MicroBlaze PMU"}} err] == 0 } {
+			dow $pmufw_file
+			con
+			after 2000
+		} else {
+			puts "WARNING: PMU target not visible even after enabling JTAG visibility, skipping PMUFW load"
+		}
+	}
+
+	# Set APU exception vector base and release from reset before FSBL
+	targets -set -nocase -filter {name =~ "*APU*"}
+	mwr 0xffff0000 0x14000000
+
+	# FSBL must run on APU (A53 #0) to initialize DDR and clocks
+	targets -set -nocase -filter {name =~ "*A53*#0"}
+	rst -proc
+
+	if { [string length $fsblelf_file] != 0 } {
+		dow $fsblelf_file
+		after 2000
+		con
+		after 4000
+		catch {stop}
+	}
+
+	# load Zephyr and BL31 (TF-A) on APU (A53 #0)
+	targets -set -nocase -filter {name =~ "*A53*#0"}
+	rst -proc
+	after 2000
+	dow $elf_file
+	if { [string length $bl31_file] != 0 } {
+		dow $bl31_file
+	}
+	con
+	exit
+}
+
+switch $argc {
+	"1" {
+		set zephyr_elf [lindex $argv 0]
+		set bitstream ""
+		set fsbl_elf ""
+		set bl31_elf ""
+		set pmufw_elf ""
+	}
+	"2" {
+		set par [lindex $argv 1]
+		set substring "*.bit"
+		if { [string match -nocase $substring $par] == 0 } {
+			set bitstream ""
+			set fsbl_elf $par
+		} else {
+			set bitstream $par
+			set fsbl_elf ""
+		}
+		set zephyr_elf [lindex $argv 0]
+		set bl31_elf ""
+		set pmufw_elf ""
+	}
+	"3" {
+		set zephyr_elf [lindex $argv 0]
+		set bitstream [lindex $argv 1]
+		set fsbl_elf [lindex $argv 2]
+		set bl31_elf ""
+		set pmufw_elf ""
+	}
+	"4" {
+		set zephyr_elf [lindex $argv 0]
+		set bitstream [lindex $argv 1]
+		set fsbl_elf [lindex $argv 2]
+		set bl31_elf [lindex $argv 3]
+		set pmufw_elf ""
+	}
+	"5" {
+		set zephyr_elf [lindex $argv 0]
+		set bitstream [lindex $argv 1]
+		set fsbl_elf [lindex $argv 2]
+		set bl31_elf [lindex $argv 3]
+		set pmufw_elf [lindex $argv 4]
+	}
+	default {
+		puts "Insufficient number of args"
+		exit -1
+	}
+}
+
+load_image "$zephyr_elf" "$bitstream" "$fsbl_elf" "$bl31_elf" "$pmufw_elf"

--- a/boards/amd/zynqmp_apu/zynqmp_apu.dts
+++ b/boards/amd/zynqmp_apu/zynqmp_apu.dts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <arm64/xilinx/zynqmp_a53.dtsi>
+
+/ {
+	model = "AMD ZynqMP APU";
+	compatible = "xlnx,zynqmp";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+	};
+};
+
+&soc {
+	sram0: memory@0 {
+		compatible = "mmio-sram";
+		reg = <0x0 0x0 0x0 0x80000000>;
+	};
+};
+
+/* UART reference clock (Hz) */
+&cpu0 {
+	clock-frequency = <1200000000>;
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+	clock-frequency = <100000000>;
+};

--- a/boards/amd/zynqmp_apu/zynqmp_apu.yaml
+++ b/boards/amd/zynqmp_apu/zynqmp_apu.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: zynqmp_apu
+name: AMD ZynqMP APU
+arch: arm64
+toolchain:
+  - zephyr
+ram: 2097152
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: amd

--- a/boards/amd/zynqmp_apu/zynqmp_apu_defconfig
+++ b/boards/amd/zynqmp_apu/zynqmp_apu_defconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Zephyr is expected to run NS-EL1 with TF-A (or equivalent) providing PSCI.
+
+CONFIG_BUILD_WITH_TFA=y
+
+CONFIG_ARM64_VA_BITS_40=y
+CONFIG_ARM64_PA_BITS_40=y
+CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME=y
+
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_UART_XLNX_PS=y
+
+CONFIG_ARMV8_A_NS=y

--- a/boards/amd/zynqmp_apu/zynqmp_apu_zynqmp_apu_smp.dts
+++ b/boards/amd/zynqmp_apu/zynqmp_apu_zynqmp_apu_smp.dts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "zynqmp_apu.dts"
+
+/ {
+	cpus {
+		cpu1: cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <1>;
+			enable-method = "psci";
+		};
+
+		cpu2: cpu@2 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <2>;
+			enable-method = "psci";
+		};
+
+		cpu3: cpu@3 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <3>;
+			enable-method = "psci";
+		};
+	};
+};

--- a/boards/amd/zynqmp_apu/zynqmp_apu_zynqmp_apu_smp.yaml
+++ b/boards/amd/zynqmp_apu/zynqmp_apu_zynqmp_apu_smp.yaml
@@ -1,0 +1,10 @@
+identifier: zynqmp_apu/zynqmp_apu/smp
+name: AMD ZynqMP APU SMP
+arch: arm64
+toolchain:
+  - zephyr
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: amd

--- a/boards/amd/zynqmp_apu/zynqmp_apu_zynqmp_apu_smp_defconfig
+++ b/boards/amd/zynqmp_apu/zynqmp_apu_zynqmp_apu_smp_defconfig
@@ -1,0 +1,29 @@
+# The Zephyr build from this defconfig is expected to boot from
+# Xilinx Arm Trusted Firmware (ATF).
+# Boot Flow is: bitstream + FSBL + PMUFW -> TF-A -> Zephyr
+CONFIG_BUILD_WITH_TFA=y
+
+CONFIG_ARM64_VA_BITS_40=y
+CONFIG_ARM64_PA_BITS_40=y
+CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME=y
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable serial port
+CONFIG_UART_XLNX_PS=y
+
+# This should be commented in order to test at EL1 S (EL1 Secure)
+CONFIG_ARMV8_A_NS=y
+
+# PSCI support Enable
+CONFIG_PM_CPU_OPS=y
+CONFIG_PM_CPU_OPS_PSCI=y
+
+# Enable SMP support
+CONFIG_SMP=y
+CONFIG_MP_MAX_NUM_CPUS=4

--- a/boards/amd/zynqmp_rpu/Kconfig.defconfig
+++ b/boards/amd/zynqmp_rpu/Kconfig.defconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_ZYNQMP_RPU
+
+config BUILD_OUTPUT_BIN
+	default y
+
+if USERSPACE
+
+config COMPILER_ISA_THUMB2
+	default n
+
+endif
+
+endif # BOARD_ZYNQMP_RPU

--- a/boards/amd/zynqmp_rpu/Kconfig.zynqmp_rpu
+++ b/boards/amd/zynqmp_rpu/Kconfig.zynqmp_rpu
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ZYNQMP_RPU
+	select SOC_XILINX_ZYNQMP_RPU

--- a/boards/amd/zynqmp_rpu/board.cmake
+++ b/boards/amd/zynqmp_rpu/board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+include(${ZEPHYR_BASE}/boards/common/xsdb.board.cmake)

--- a/boards/amd/zynqmp_rpu/board.yml
+++ b/boards/amd/zynqmp_rpu/board.yml
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+board:
+  name: zynqmp_rpu
+  full_name: AMD Zynq UltraScale+ MPSoC RPU
+  vendor: amd
+  socs:
+  - name: zynqmp_rpu

--- a/boards/amd/zynqmp_rpu/doc/index.rst
+++ b/boards/amd/zynqmp_rpu/doc/index.rst
@@ -1,0 +1,65 @@
+.. Copyright (c) 2026 Advanced Micro Devices, Inc.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. zephyr:board:: zynqmp_rpu
+
+Overview
+********
+
+This board configuration targets the Cortex-R5 real-time processing unit (RPU) on
+AMD Zynq UltraScale+ MPSoC. R5 DDR starts at ``0x00400000``, GIC for the RPU is
+at ``0xf9000000``, and PS UART0 is at ``0xff000000``.
+
+Hardware
+********
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+The default console is UART0 (typical Linux name ``ttyPS0``).
+
+Memories
+--------
+
+* ``sram0`` is at ``0x0400_0000`` (64 MiB).
+* QSPI linear flash is mapped at ``0xc0000000`` (512 MiB).
+
+Known limitations
+=================
+
+* Dual-redundant lock-step R5 operation is not targeted by this board file.
+* Only the first R5 core is supported.
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+QEMU
+====
+
+The board uses the ``arm-generic-fdt`` QEMU machine with a ZCU102 hardware DTB
+compiled from ``zynqmp_rpu-qemu.dts`` at build time. The Zephyr ELF is loaded on
+``cpu-num=4`` (the R5 cluster); MMIO pokes at ``0xff5e023c`` and ``0xff9a0000``
+release the R5 from reset.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: zynqmp_rpu
+   :goals: run
+   :compact:
+
+Hardware (XSDB)
+===============
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: zynqmp_rpu
+   :goals: build
+
+References
+**********
+
+1. AMD Zynq UltraScale+ Device Technical Reference Manual (UG1085)

--- a/boards/amd/zynqmp_rpu/support/xsdb_cfg.tcl
+++ b/boards/amd/zynqmp_rpu/support/xsdb_cfg.tcl
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+proc boot_jtag { } {
+	targets -set -filter {name =~ "PSU*"}
+	stop
+	mwr 0xffca0010 0x0
+	mwr 0xff5e0200 0x0100
+	rst -system
+}
+
+proc load_image args  {
+	set elf_file [lindex $args 0]
+	set bitfile [lindex $args 1]
+	set fsblelf_file [lindex $args 2]
+
+	if { [info exists ::env(HW_SERVER_URL)] } {
+		connect -url $::env(HW_SERVER_URL)
+	} else {
+		connect
+	}
+
+	after 2000
+	boot_jtag
+	after 2000
+
+	# load bitstream while PSU is the active target
+	if { [string length $bitfile] != 0 } {
+		fpga -f $bitfile -no-revision-check
+	}
+
+	# FSBL must run on APU (A53 #0) to initialize DDR and clocks
+	if { [string length $fsblelf_file] != 0 } {
+		targets -set -nocase -filter {name =~ "*A53*#0"}
+		rst -proc
+		dow $fsblelf_file
+		after 1000
+		con
+		after 3000
+		stop
+	}
+
+	# load Zephyr on RPU (R5 #0)
+	targets -set -nocase -filter {name =~ "*R5*#0"}
+	rst -proc
+	after 100
+
+	# Initialize TCM vector region (first 256 bytes) for JTAG boot.
+	# This prevents prefetch abort from uninitialized exception vectors
+	# at 0x0 when booting via JTAG/XSDB without PLM initialization.
+	mwr -size w 0x0 0x0 64
+	after 100
+
+	dow $elf_file
+	con
+	exit
+}
+
+switch $argc {
+	"1" {
+		set zephyr_elf [lindex $argv 0]
+		set bitstream ""
+		set fsbl_elf ""
+	}
+	"2" {
+		set par [lindex $argv 1]
+		set substring "*.bit"
+		if { [string match -nocase $substring $par] == 0 } {
+			set bitstream ""
+			set fsbl_elf $par
+		} else {
+			set bitstream $par
+			set fsbl_elf ""
+		}
+		set zephyr_elf [lindex $argv 0]
+	}
+	"3" {
+		set zephyr_elf [lindex $argv 0]
+		set bitstream [lindex $argv 1]
+		set fsbl_elf [lindex $argv 2]
+	}
+	default {
+		puts "Insufficient number of args"
+		exit -1
+	}
+}
+
+load_image "$zephyr_elf" "$bitstream" "$fsbl_elf"

--- a/boards/amd/zynqmp_rpu/zynqmp_rpu.dts
+++ b/boards/amd/zynqmp_rpu/zynqmp_rpu.dts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <arm/xilinx/zynqmp_rpu.dtsi>
+
+/ {
+	model = "AMD ZynqMP RPU";
+	compatible = "xlnx,zynqmp-r5";
+
+	sram0: memory@4000000 {
+		compatible = "mmio-sram";
+		reg = <0x04000000 0x04000000>;
+	};
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,ocm = &ocm;
+	};
+};
+
+&flash0 {
+	reg = <0xc0000000 0x20000000>;
+};
+
+/* UART reference clock (Hz) */
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+	clock-frequency = <100000000>;
+};
+
+&ttc0 {
+	status = "okay";
+	clock-frequency = <100000000>;
+};
+
+&psgpio {
+	status = "okay";
+};

--- a/boards/amd/zynqmp_rpu/zynqmp_rpu.yaml
+++ b/boards/amd/zynqmp_rpu/zynqmp_rpu.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: zynqmp_rpu
+name: AMD ZynqMP RPU
+arch: arm
+toolchain:
+  - zephyr
+ram: 262144
+flash: 524288
+supported:
+  - gpio
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: amd

--- a/boards/amd/zynqmp_rpu/zynqmp_rpu_defconfig
+++ b/boards/amd/zynqmp_rpu/zynqmp_rpu_defconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_XIP=n
+
+CONFIG_ISR_STACK_SIZE=512
+CONFIG_THREAD_STACK_INFO=y
+
+# Enable serial port
+CONFIG_SERIAL=y
+
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable UART driver
+CONFIG_UART_XLNX_PS=y

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -30,7 +30,7 @@
 
 		uart0: uart@ff000000 {
 			compatible = "xlnx,xuartps";
-			reg = <0xff000000 0x4c>;
+			reg = <0xff000000 0x1000>;
 			status = "disabled";
 			interrupts = <GIC_SPI 21 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>;
@@ -39,7 +39,7 @@
 
 		uart1: uart@ff010000 {
 			compatible = "xlnx,xuartps";
-			reg = <0xff010000 0x4c>;
+			reg = <0xff010000 0x1000>;
 			status = "disabled";
 			interrupts = <GIC_SPI 22 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>;

--- a/dts/arm/xilinx/zynqmp_rpu.dtsi
+++ b/dts/arm/xilinx/zynqmp_rpu.dtsi
@@ -100,8 +100,9 @@
 		gic: interrupt-controller@f9000000 {
 			compatible = "arm,gic-v1", "arm,gic";
 			reg = <0xf9000000 0x1000>,
-			      <0xf9001000 0x100>;
+			      <0xf9001000 0x1000>;
 			interrupt-controller;
+			#address-cells = <0>;
 			#interrupt-cells = <4>;
 			status = "okay";
 		};

--- a/dts/arm64/xilinx/zynqmp_a53.dtsi
+++ b/dts/arm64/xilinx/zynqmp_a53.dtsi
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <arm64/armv8-a.dtsi>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	model = "Xilinx ZynqMP Cortex-A53";
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <0x0>;
+			enable-method = "psci";
+		};
+	};
+
+	psci {
+		compatible = "arm,psci-0.2", "arm,psci";
+		method = "smc";
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 14 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	};
+
+	soc: soc {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		interrupt-parent = <&gic>;
+
+		gic: interrupt-controller@f9010000 {
+			compatible = "arm,gic-400", "arm,gic-v2", "arm,gic";
+			reg = <0x0 0xf9010000 0x0 0x10000>,
+			      <0x0 0xf9020000 0x0 0x20000>;
+			interrupt-controller;
+			#address-cells = <0>;
+			#interrupt-cells = <4>;
+		};
+
+		uart0: uart@ff000000 {
+			compatible = "xlnx,xuartps";
+			reg = <0x0 0xff000000 0x0 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 21 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "irq_0";
+		};
+
+		uart1: uart@ff010000 {
+			compatible = "xlnx,xuartps";
+			reg = <0x0 0xff010000 0x0 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 22 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "irq_0";
+		};
+
+		ttc0: timer@ff110000 {
+			compatible = "xlnx,ttcps";
+			status = "disabled";
+			interrupts = <GIC_SPI 36 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 37 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 38 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "irq_0", "irq_1", "irq_2";
+			reg = <0x0 0xff110000 0x0 0x1000>;
+		};
+
+		ttc1: timer@ff120000 {
+			compatible = "xlnx,ttcps";
+			status = "disabled";
+			interrupts = <GIC_SPI 39 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 40 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 41 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "irq_0", "irq_1", "irq_2";
+			reg = <0x0 0xff120000 0x0 0x1000>;
+		};
+
+		ttc2: timer@ff130000 {
+			compatible = "xlnx,ttcps";
+			status = "disabled";
+			interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 43 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 44 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "irq_0", "irq_1", "irq_2";
+			reg = <0x0 0xff130000 0x0 0x1000>;
+		};
+
+		ttc3: timer@ff140000 {
+			compatible = "xlnx,ttcps";
+			status = "disabled";
+			interrupts = <GIC_SPI 45 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 46 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 47 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "irq_0", "irq_1", "irq_2";
+			reg = <0x0 0xff140000 0x0 0x1000>;
+		};
+	};
+};

--- a/scripts/west_commands/runners/xsdb.py
+++ b/scripts/west_commands/runners/xsdb.py
@@ -18,9 +18,11 @@ class XSDBBinaryRunner(ZephyrBinaryRunner):
         self.elf_file = cfg.elf_file
         if not config:
             cfgfile_path = os.path.join(cfg.board_dir, 'support')
-            default = os.path.join(cfgfile_path, 'xsdb.cfg')
-            if os.path.exists(default):
-                config = default
+            for name in ('xsdb_cfg.tcl', 'xsdb.cfg'):
+                candidate = os.path.join(cfgfile_path, name)
+                if os.path.exists(candidate):
+                    config = candidate
+                    break
         self.xsdb_cfg_file = config
         self.bitstream = bitstream
         self.fsbl = fsbl

--- a/scripts/west_commands/runners/xsdb.py
+++ b/scripts/west_commands/runners/xsdb.py
@@ -13,7 +13,7 @@ from runners.core import RunnerCaps, RunnerConfig, ZephyrBinaryRunner
 
 class XSDBBinaryRunner(ZephyrBinaryRunner):
     def __init__(self, cfg: RunnerConfig, config=None, bitstream=None,
-            fsbl=None, pdi=None, bl31=None, dtb=None):
+            fsbl=None, pdi=None, bl31=None, dtb=None, pmufw=None):
         super().__init__(cfg)
         self.elf_file = cfg.elf_file
         if not config:
@@ -27,6 +27,7 @@ class XSDBBinaryRunner(ZephyrBinaryRunner):
         self.pdi = pdi
         self.bl31 = bl31
         self.dtb = dtb
+        self.pmufw = pmufw
 
     @classmethod
     def name(cls):
@@ -44,6 +45,7 @@ class XSDBBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--pdi', help='path to the base/boot pdi file')
         parser.add_argument('--bl31', help='path to the bl31(ATF) elf file')
         parser.add_argument('--system-dtb', help='path to the system.dtb file')
+        parser.add_argument('--pmufw', help='path to the PMU firmware elf file (ZynqMP)')
 
     @classmethod
     def do_create(
@@ -51,21 +53,13 @@ class XSDBBinaryRunner(ZephyrBinaryRunner):
     ) -> "XSDBBinaryRunner":
         return XSDBBinaryRunner(cfg, config=args.config,
                 bitstream=args.bitstream, fsbl=args.fsbl,
-                pdi=args.pdi, bl31=args.bl31, dtb=args.system_dtb)
+                pdi=args.pdi, bl31=args.bl31, dtb=args.system_dtb,
+                pmufw=args.pmufw)
 
     def do_run(self, command, **kwargs):
-        if self.bitstream and self.fsbl:
-            cmd = ['xsdb', self.xsdb_cfg_file, self.elf_file, self.bitstream, self.fsbl]
-        elif self.bitstream:
-            cmd = ['xsdb', self.xsdb_cfg_file, self.elf_file, self.bitstream]
-        elif self.fsbl:
-            cmd = ['xsdb', self.xsdb_cfg_file, self.elf_file, self.fsbl]
-        elif self.pdi and self.bl31 and self.dtb:
-            cmd = ['xsdb', self.xsdb_cfg_file, self.elf_file, self.pdi, self.bl31, self.dtb]
-        elif self.pdi and self.bl31:
-            cmd = ['xsdb', self.xsdb_cfg_file, self.elf_file, self.pdi, self.bl31]
-        elif self.pdi:
-            cmd = ['xsdb', self.xsdb_cfg_file, self.elf_file, self.pdi]
-        else:
-            cmd = ['xsdb', self.xsdb_cfg_file, self.elf_file]
+        cmd = ['xsdb', self.xsdb_cfg_file, self.elf_file]
+        for param in (self.bitstream, self.fsbl, self.pdi, self.bl31,
+                      self.dtb, self.pmufw):
+            if param is not None:
+                cmd.append(param)
         self.check_call(cmd)

--- a/scripts/west_commands/tests/test_xsdb.py
+++ b/scripts/west_commands/tests/test_xsdb.py
@@ -172,3 +172,18 @@ def test_xsdbbinaryrunner_create(check_call, path_exists, tc, runner_config):
     runner.do_run("flash")
 
     assert check_call.call_args_list == [call(tc["expected_cmd"])]
+
+
+@patch("runners.xsdb.os.path.exists")
+def test_xsdbbinaryrunner_default_config_prefers_tcl(path_exists, runner_config):
+    '''Default config lookup prefers xsdb_cfg.tcl over xsdb.cfg.'''
+
+    def exists_side_effect(path):
+        return path.endswith("xsdb_cfg.tcl") or path.endswith("xsdb.cfg")
+
+    path_exists.side_effect = exists_side_effect
+
+    with patch("runners.xsdb.os.path.join", side_effect=lambda *parts: "/".join(parts)):
+        runner = XSDBBinaryRunner(cfg=runner_config)
+
+    assert runner.xsdb_cfg_file == f"{runner_config.board_dir}/support/xsdb_cfg.tcl"

--- a/scripts/west_commands/tests/test_xsdb.py
+++ b/scripts/west_commands/tests/test_xsdb.py
@@ -16,6 +16,7 @@ TEST_CASES = [
         "pdi": None,
         "bl31": None,
         "dtb": None,
+        "pmufw": None,
         "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF],
     },
     {
@@ -25,6 +26,7 @@ TEST_CASES = [
         "pdi": None,
         "bl31": None,
         "dtb": None,
+        "pmufw": None,
         "expected_cmd": ["xsdb", "custom_cfg_path", RC_KERNEL_ELF],
     },
     {
@@ -34,6 +36,7 @@ TEST_CASES = [
         "pdi": None,
         "bl31": None,
         "dtb": None,
+        "pmufw": None,
         "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF, "bitstream_path"],
     },
     {
@@ -43,6 +46,7 @@ TEST_CASES = [
         "pdi": None,
         "bl31": None,
         "dtb": None,
+        "pmufw": None,
         "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF, "fsbl_path"],
     },
     {
@@ -52,6 +56,7 @@ TEST_CASES = [
         "pdi": None,
         "bl31": None,
         "dtb": None,
+        "pmufw": None,
         "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF, "bitstream_path", "fsbl_path"],
     },
     {
@@ -61,6 +66,7 @@ TEST_CASES = [
         "pdi": "pdi_path",
         "bl31": None,
         "dtb": None,
+        "pmufw": None,
         "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF, "pdi_path"],
     },
     {
@@ -70,6 +76,7 @@ TEST_CASES = [
         "pdi": "pdi_path",
         "bl31": "bl31_path",
         "dtb": None,
+        "pmufw": None,
         "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF, "pdi_path", "bl31_path"],
     },
     {
@@ -79,6 +86,7 @@ TEST_CASES = [
         "pdi": "pdi_path",
         "bl31": "bl31_path",
         "dtb": "dtb_path",
+        "pmufw": None,
         "expected_cmd": [
             "xsdb",
             "default_cfg_path",
@@ -86,6 +94,24 @@ TEST_CASES = [
             "pdi_path",
             "bl31_path",
             "dtb_path",
+        ],
+    },
+    {
+        "config": None,
+        "bitstream": "bitstream_path",
+        "fsbl": "fsbl_path",
+        "pdi": None,
+        "bl31": "bl31_path",
+        "dtb": None,
+        "pmufw": "pmufw_path",
+        "expected_cmd": [
+            "xsdb",
+            "default_cfg_path",
+            RC_KERNEL_ELF,
+            "bitstream_path",
+            "fsbl_path",
+            "bl31_path",
+            "pmufw_path",
         ],
     },
 ]
@@ -106,6 +132,7 @@ def test_xsdbbinaryrunner_init(check_call, path_exists, tc, runner_config):
             pdi=tc["pdi"],
             bl31=tc["bl31"],
             dtb=tc["dtb"],
+            pmufw=tc["pmufw"],
         )
 
     runner.do_run("flash")
@@ -131,6 +158,8 @@ def test_xsdbbinaryrunner_create(check_call, path_exists, tc, runner_config):
         args.extend(["--bl31", tc["bl31"]])
     if tc["dtb"]:
         args.extend(["--system-dtb", tc["dtb"]])
+    if tc["pmufw"]:
+        args.extend(["--pmufw", tc["pmufw"]])
 
     parser = argparse.ArgumentParser(allow_abbrev=False)
     XSDBBinaryRunner.add_parser(parser)

--- a/soc/xlnx/zynqmp/CMakeLists.txt
+++ b/soc/xlnx/zynqmp/CMakeLists.txt
@@ -2,9 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources(
-  soc.c
-)
+zephyr_sources_ifdef(CONFIG_SOC_XILINX_ZYNQMP_RPU soc.c)
 zephyr_sources_ifdef(
   CONFIG_ARM_MPU
   arm_mpu_regions.c
@@ -14,4 +12,8 @@ zephyr_include_directories(.)
 
 if(CONFIG_SOC_XILINX_ZYNQMP_RPU)
   set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld CACHE INTERNAL "")
+endif()
+
+if(CONFIG_SOC_XILINX_ZYNQMP_APU)
+  set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")
 endif()

--- a/soc/xlnx/zynqmp/Kconfig
+++ b/soc/xlnx/zynqmp/Kconfig
@@ -10,3 +10,9 @@ config SOC_XILINX_ZYNQMP_RPU
 	select CPU_HAS_ARM_MPU
 	imply ARM_MPU
 	select VFP_DP_D16
+
+config SOC_XILINX_ZYNQMP_APU
+	select ARM64
+	select ARM_ARCH_TIMER
+	select CPU_CORTEX_A53
+	select CPU_HAS_MMU

--- a/soc/xlnx/zynqmp/Kconfig.defconfig
+++ b/soc/xlnx/zynqmp/Kconfig.defconfig
@@ -16,6 +16,28 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 
 endif # SOC_XILINX_ZYNQMP_RPU
 
+if SOC_XILINX_ZYNQMP_APU
+
+configdefault DCACHE_LINE_SIZE
+	default 64
+
+configdefault ICACHE_LINE_SIZE
+	default 64
+
+config CACHE_MANAGEMENT
+	default y
+
+config ARM_ARCH_TIMER
+	default y
+
+config NUM_IRQS
+	default 195
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+endif # SOC_XILINX_ZYNQMP_APU
+
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_FLASH := zephyr,flash
 

--- a/soc/xlnx/zynqmp/Kconfig.soc
+++ b/soc/xlnx/zynqmp/Kconfig.soc
@@ -11,8 +11,15 @@ config SOC_XILINX_ZYNQMP_RPU
 	help
 	  Xilinx ZynqMP RPU
 
+config SOC_XILINX_ZYNQMP_APU
+	bool
+	select SOC_XILINX_ZYNQMP
+	help
+	  Xilinx ZynqMP APU (Cortex-A53)
+
 config SOC_FAMILY
 	default "xilinx_zynqmp" if SOC_XILINX_ZYNQMP
 
 config SOC
 	default "zynqmp_rpu" if SOC_XILINX_ZYNQMP_RPU
+	default "zynqmp_apu" if SOC_XILINX_ZYNQMP_APU

--- a/soc/xlnx/zynqmp/arm_mpu_regions.c
+++ b/soc/xlnx/zynqmp/arm_mpu_regions.c
@@ -21,12 +21,76 @@ BUILD_ASSERT(REGION_CUSTOMED_MEMORY_SIZE(DT_REG_SIZE(DT_CHOSEN(zephyr_ipc_shm)) 
 	REGION_CUSTOMED_MEMORY_SIZE(DT_REG_SIZE(DT_CHOSEN(zephyr_ipc_shm)) / 1024U)
 #endif
 
+/*
+ * ARMv7-R MPU natural alignment rule: base_address % region_size == 0.
+ * The hardware silently masks the low bits of the base address when a region
+ * is misaligned, mapping the wrong physical range with no build error.
+ *
+ * Two constraints must both be satisfied:
+ *   1. The chosen base must be naturally aligned to the region size.
+ *   2. The region must cover the full range [base, DDR_END) where
+ *      DDR_END = DT_CHOSEN_SRAM_ADDR + DT_CHOSEN_SRAM_SIZE.
+ *      Using only DT_CHOSEN_SRAM_SIZE as the region size fails when
+ *      DT_CHOSEN_SRAM_ADDR is non-zero (e.g. 1 MiB offset pushes DDR_END
+ *      past the next 256 MiB boundary, leaving the top of stack uncovered).
+ *
+ * Strategy: for each candidate size, round DT_CHOSEN_SRAM_ADDR DOWN to the
+ * nearest naturally-aligned boundary to get the candidate base, then check
+ * whether base + size >= DDR_END.  Select the smallest size that fits.
+ * This finds the tightest single region rather than always anchoring at 0x0,
+ * which is critical for AMP designs where the R5 app occupies only a high
+ * portion of DDR (e.g. 0x50000000-0x7FEFFFFF) and mapping 0x0 onwards would
+ * expose Linux DDR as R5-cacheable normal memory.
+ *
+ * Alignment is guaranteed by construction: (SRAM_ADDR & ~(size-1)) is always
+ * a multiple of size for any power-of-2 size.
+ *
+ * Examples:
+ *   SRAM=0x100000, SIZE=256M → DDR_END=0x10100000:
+ *     256M: base=0x0, end=0x10000000 < DDR_END → skip
+ *     512M: base=0x0, end=0x20000000 >= DDR_END → base=0x00000000, REGION_512M
+ *
+ *   SRAM=0x50000000, SIZE=767M → DDR_END=0x7FF00000:
+ *     256M: base=0x50000000, end=0x60000000 < DDR_END → skip
+ *     512M: base=0x40000000, end=0x60000000 < DDR_END → skip
+ *     1G:   base=0x40000000, end=0x80000000 >= DDR_END → base=0x40000000, REGION_1G
+ *     (vs old anchor-at-0: base=0x0, REGION_2G — 1 GB of Linux DDR over-mapped)
+ */
+#define ZYNQMP_DDR_END     (DT_CHOSEN_SRAM_ADDR + DT_CHOSEN_SRAM_SIZE)
+
+/* Naturally-aligned base for each candidate size */
+#define ZYNQMP_256M_BASE   ((DT_CHOSEN_SRAM_ADDR) & 0xF0000000U)
+#define ZYNQMP_512M_BASE   ((DT_CHOSEN_SRAM_ADDR) & 0xE0000000U)
+#define ZYNQMP_1G_BASE     ((DT_CHOSEN_SRAM_ADDR) & 0xC0000000U)
+
+/* Exclusive end of each candidate region */
+#define ZYNQMP_256M_REND   (ZYNQMP_256M_BASE + 0x10000000U)
+#define ZYNQMP_512M_REND   (ZYNQMP_512M_BASE + 0x20000000U)
+#define ZYNQMP_1G_REND     (ZYNQMP_1G_BASE   + 0x40000000U)
+
+#if (ZYNQMP_DDR_END <= ZYNQMP_256M_REND)
+#  define ZYNQMP_SRAM_REGION_BASE  ZYNQMP_256M_BASE
+#  define ZYNQMP_SRAM_REGION_SIZE  REGION_256M
+#elif (ZYNQMP_DDR_END <= ZYNQMP_512M_REND)
+#  define ZYNQMP_SRAM_REGION_BASE  ZYNQMP_512M_BASE
+#  define ZYNQMP_SRAM_REGION_SIZE  REGION_512M
+#elif (ZYNQMP_DDR_END <= ZYNQMP_1G_REND)
+#  define ZYNQMP_SRAM_REGION_BASE  ZYNQMP_1G_BASE
+#  define ZYNQMP_SRAM_REGION_SIZE  REGION_1G
+#else
+#  define ZYNQMP_SRAM_REGION_BASE  0x00000000U
+#  define ZYNQMP_SRAM_REGION_SIZE  REGION_2G
+#endif
+
 static const struct arm_mpu_region mpu_regions[] = {
-	/* Basic SRAM mapping is all data, R/W + XN */
+	/* SRAM/DDR: R/W + XN, tightest naturally-aligned region covering
+	 * [ZYNQMP_SRAM_REGION_BASE, DDR_END).  Base and size are computed at
+	 * build time from DT_CHOSEN_SRAM_ADDR + DT_CHOSEN_SRAM_SIZE above.
+	 */
 	MPU_REGION_ENTRY(
 		"sram",
-		DT_CHOSEN_SRAM_ADDR,
-		REGION_SRAM_SIZE,
+		ZYNQMP_SRAM_REGION_BASE,
+		ZYNQMP_SRAM_REGION_SIZE,
 		{.rasr = P_RW_U_NA_Msk |
 			 NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE |
 			 NOT_EXEC}),
@@ -38,7 +102,6 @@ static const struct arm_mpu_region mpu_regions[] = {
 		REGION_FLASH_SIZE,
 		{.rasr = P_RO_U_RO_Msk |
 			 NORMAL_OUTER_INNER_WRITE_BACK_NON_SHAREABLE}),
-	/* RAM contains R/W data, non-executable */
 #else /* !CONFIG_XIP */
 #if CONFIG_FLASH_SIZE > 0
 	/* Keep any real flash window RO + XN when executing from RAM. */
@@ -50,7 +113,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 			 NORMAL_OUTER_INNER_WRITE_BACK_NON_SHAREABLE |
 			 NOT_EXEC}),
 #endif
-	/* add rom_region mapping for SRAM which is RO + executable */
+	/* rom_region: code + rodata in SRAM — RO + executable */
 	MPU_REGION_ENTRY(
 		"rom_region",
 		(uint32_t)(&__rom_region_start),

--- a/soc/xlnx/zynqmp/soc.yml
+++ b/soc/xlnx/zynqmp/soc.yml
@@ -2,3 +2,4 @@ family:
 - name: xilinx_zynqmp
   socs:
   - name: zynqmp_rpu
+  - name: zynqmp_apu


### PR DESCRIPTION
  This series adds complete Zephyr support for the AMD Zynq UltraScale+ MPSoC (ZynqMP), covering both the Cortex-A53 APU
  (ARM64) and the Cortex-R5F RPU (ARMv7-R), along with the SoC infrastructure, DTS fixes, and runner enhancements needed to
  boot them.

  What's added

  SoC layer (soc: xlnx)
  - New SOC_XILINX_ZYNQMP_APU target for the quad-core Cortex-A53 cluster running as NS-EL1 behind TF-A. Introduces
  dts/arm64/xilinx/zynqmp_a53.dtsi with GIC-400, UART0/1, TTC0–3 timers, and ARMv8 arch timer.
  - Bug fix for the RPU MPU SRAM region: replaces the fixed-base approach with a compile-time algorithm that finds the
  smallest naturally-aligned ARMv7-R region covering the configured DDR window, preventing alignment faults and AMP isolation
  breakage when SRAM is placed above 0x0.

  DTS fixes (dts: arm: xlnx: zynqmp)
  - Corrects UART0/UART1 reg sizes from 0x4c to the full 4 KB page (0x1000).
  - Expands the GICC reg size to 0x1000 and adds the missing #address-cells = <0> required by the arm,gic binding.

  Runner (runners: xsdb)
  - Adds --pmufw CLI argument and a new dispatch path for the complete ZynqMP APU boot sequence: bitstream + FSBL + bl31
  (TF-A) + PMU firmware.

  Boards
  - zynqmp_apu: single-core Cortex-A53 board targeting TF-A boot (Boot PDI → TF-A → Zephyr at NS-EL1). Includes XSDB TCL
  script for JTAG bring-up.
  - zynqmp_apu/smp: SMP variant exposing all four Cortex-A53 cores via PSCI, enabling CONFIG_SMP=y with up to 4 CPUs.
  - zynqmp_rpu: Cortex-R5F board with TCM vector-region initialization, FSBL-driven DDR/clock setup via XSDB, and QSPI flash
  node.

  Tested on

  Hardware bring-up via XSDB/JTAG on ZynqMP ZCU102.
