### PR TITLE
drivers: modem: sim7080: runtime configurable rat and lte channels

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -634,6 +634,21 @@ gPTP
   New :c:func:`gptp_get_port_number` and :c:func:`gptp_set_port_number`
   can be used instead.
 
+Modem
+*****
+
+SIMCOM SIM7080
+==============
+
+* The Kconfig option :kconfig:option:`CONFIG_MODEM_SIMCOM_SIM7080_LTE_BANDS` has been split
+  into :kconfig:option:`CONFIG_MODEM_SIMCOM_SIM7080_LTE_BANDS_M1` and
+  :kconfig:option:`CONFIG_MODEM_SIMCOM_SIM7080_LTE_BANDS_NB1` since NB-IoT and CAT-M have
+  slightly different usable bands. The type of the newly introduced configuration values
+  is a hex bitmap of selected bands. By default bands 8, 20 and 28 are selected.
+
+  Applications configuring the :kconfig:option:`CONFIG_MODEM_SIMCOM_SIM7080_LTE_BANDS`
+  must update their configuration.
+
 LoRaWAN
 *******
 

--- a/drivers/modem/vendor_standalone/simcom/sim7080/Kconfig
+++ b/drivers/modem/vendor_standalone/simcom/sim7080/Kconfig
@@ -35,11 +35,19 @@ config MODEM_SIMCOM_SIM7080_INIT_PRIORITY
 	help
 	  simcom sim7080 driver initialization priority.
 
-config MODEM_SIMCOM_SIM7080_LTE_BANDS
-	string "LTE bands the driver can use"
-	default "8,20,28"
+config MODEM_SIMCOM_SIM7080_LTE_BANDS_M1
+	hex "Default LTE bands for CAT-M1"
+	default 0x8820
 	help
-		Comma separated list of usable lte bands.
+		Bitmap of channels the modem can use for CAT-M1.
+		Refer to enum sim7080_lte_chan.
+
+config MODEM_SIMCOM_SIM7080_LTE_BANDS_NB1
+	hex "Default LTE bands for NB-IoT"
+	default 0x8820
+	help
+		Bitmap of channels the modem can use for NB-IoT.
+		Refer to enum sim7080_lte_chan.
 
 config MODEM_SIMCOM_SIM7080_APN
 	string "APN for establishing a network connection"
@@ -83,7 +91,7 @@ config MODEM_SIMCOM_SIM7080_TLS_BUFFER_SIZE
 	default 256
 
 choice MODEM_SIMCOM_SIM7080_RAT
-	bool "Radio Access Technology Mode"
+	bool "Default Radio Access Technology Mode"
 	default MODEM_SIMCOM_SIM7080_RAT_NB1
 
 config MODEM_SIMCOM_SIM7080_RAT_NB1
@@ -95,6 +103,11 @@ config MODEM_SIMCOM_SIM7080_RAT_M1
 	bool "Cat-M1"
 	help
 		Enable Cat-M1 mode.
+
+config MODEM_SIMCOM_SIM7080_RAT_LTE_AUTO
+	bool "Automatic selection of NB-IoT or Cat-M1"
+	help
+		Enable automatic LTE technology selection.
 
 config MODEM_SIMCOM_SIM7080_RAT_GSM
 	bool "GSM"

--- a/drivers/modem/vendor_standalone/simcom/sim7080/sim7080.c
+++ b/drivers/modem/vendor_standalone/simcom/sim7080/sim7080.c
@@ -804,6 +804,21 @@ static int modem_init(const struct device *dev)
 	mdata.sms_buffer = NULL;
 	mdata.sms_buffer_pos = 0;
 
+	/* Load initial radio configuration */
+#if IS_ENABLED(CONFIG_MODEM_SIMCOM_SIM7080_RAT_NB1)
+	mdata.radio.rat = SIM7080_RAT_LTE_NB1;
+#elif IS_ENABLED(CONFIG_MODEM_SIMCOM_SIM7080_RAT_M1)
+	mdata.radio.rat = SIM7080_RAT_LTE_M1;
+#elif IS_ENABLED(CONFIG_MODEM_SIMCOM_SIM7080_RAT_LTE_AUTO)
+	mdata.radio.rat = SIM7080_RAT_LTE_AUTO;
+#elif IS_ENABLED(CONFIG_MODEM_SIMCOM_SIM7080_RAT_GSM)
+	mdata.radio.rat = SIM7080_RAT_GSM;
+#else
+#error "Invalid RAT choice"
+#endif
+	mdata.radio.lte_bands_nb1 = CONFIG_MODEM_SIMCOM_SIM7080_LTE_BANDS_NB1;
+	mdata.radio.lte_bands_m1 = CONFIG_MODEM_SIMCOM_SIM7080_LTE_BANDS_M1;
+
 	/* Socket config. */
 	ret = modem_socket_init(&mdata.socket_config, &mdata.sockets[0], ARRAY_SIZE(mdata.sockets),
 				MDM_BASE_SOCKET_NUM, true, &offload_socket_fd_op_vtable);

--- a/drivers/modem/vendor_standalone/simcom/sim7080/sim7080.h
+++ b/drivers/modem/vendor_standalone/simcom/sim7080/sim7080.h
@@ -50,7 +50,6 @@
 #define MDM_SSL_CERT_NAME_MAX_LEN 64
 #define MDM_SSL_SNI_MAX_LEN 253
 #define MDM_APN CONFIG_MODEM_SIMCOM_SIM7080_APN
-#define MDM_LTE_BANDS CONFIG_MODEM_SIMCOM_SIM7080_LTE_BANDS
 #define RSSI_TIMEOUT_SECS 30
 #define MDM_MAX_TLS_CTX 6
 
@@ -192,6 +191,15 @@ struct sim7080_data {
 		/* State of the ftp connection. */
 		enum sim7080_ftp_connection_state state;
 	} ftp;
+	/* Radio configuration */
+	struct {
+		/* Selected radio access technology */
+		enum sim7080_rat rat;
+		/* Configured LTE bands for NB-IoT */
+		uint32_t lte_bands_nb1;
+		/* Configured LTE bands for CAT-M1 */
+		uint32_t lte_bands_m1;
+	} radio;
 	/*
 	 * Semaphore(s).
 	 */

--- a/drivers/modem/vendor_standalone/simcom/sim7080/sim7080_pdp.c
+++ b/drivers/modem/vendor_standalone/simcom/sim7080/sim7080_pdp.c
@@ -9,21 +9,159 @@ LOG_MODULE_REGISTER(modem_simcom_sim7080_pdp, CONFIG_MODEM_LOG_LEVEL);
 
 #include "sim7080.h"
 
-static const struct setup_cmd band_setup_cmds[] = {
-	#if defined(CONFIG_MODEM_SIMCOM_SIM7080_RAT_NB1)
-		SETUP_CMD_NOHANDLE("AT+CNMP=38"),
-		SETUP_CMD_NOHANDLE("AT+CMNB=2"),
-		SETUP_CMD_NOHANDLE("AT+CBANDCFG=\"NB-IOT\"," MDM_LTE_BANDS),
-	#endif /* defined(CONFIG_MODEM_SIMCOM_SIM7080_RAT_NB1) */
-	#if defined(CONFIG_MODEM_SIMCOM_SIM7080_RAT_M1)
-		SETUP_CMD_NOHANDLE("AT+CNMP=38"),
-		SETUP_CMD_NOHANDLE("AT+CMNB=1"),
-		SETUP_CMD_NOHANDLE("AT+CBANDCFG=\"CAT-M\"," MDM_LTE_BANDS),
-	#endif /* defined(CONFIG_MODEM_SIMCOM_SIM7080_RAT_M1) */
-	#if defined(CONFIG_MODEM_SIMCOM_SIM7080_RAT_GSM)
-		SETUP_CMD_NOHANDLE("AT+CNMP=13"),
-	#endif /* defined(CONFIG_MODEM_SIMCOM_SIM7080_RAT_GSM) */
+static const char *const lte_mode_lut[] = {
+	"AT+CMNB=2",
+	"AT+CMNB=1",
+	"AT+CMNB=3",
 };
+
+static const char *const lte_band_lut[] = {
+	"1",  "2",  "3",  "4",  "5",  "8",  "12", "13", "14", "18",
+	"19", "20", "25", "26", "27", "28", "66", "71", "85",
+};
+
+/**
+ * Configure bands for the selected radio access technology.
+ *
+ * @param rat Radio access technology. Only SIM7080_RAT_LTE_NB1 and SIM7080_RAT_LTE_M1 are valid.
+ * @param bands Band bitmap.
+ */
+static int configure_bands(enum sim7080_rat rat, uint32_t bands)
+{
+	const char *band_cmd;
+	uint32_t used_bands = 0;
+
+	if (rat == SIM7080_RAT_LTE_NB1) {
+		band_cmd = "AT+CBANDCFG=\"NB-IOT\"";
+		used_bands = bands & SIM7080_LTE_CHANNEL_MASK_NB1;
+	} else if (rat == SIM7080_RAT_LTE_M1) {
+		band_cmd = "AT+CBANDCFG=\"CAT-M\"";
+		used_bands = bands & SIM7080_LTE_CHANNEL_MASK_M1;
+	} else {
+		return -EINVAL;
+	}
+
+	LOG_DBG("Setting bands: rat=%d, bands=0x%" PRIX32 ", used_bands=0x%" PRIX32, (int)rat,
+		bands, used_bands);
+
+	/* Check if there are any bands activated */
+	if (used_bands == 0) {
+		LOG_ERR("No bands in sanitized channel mask");
+		return -EINVAL;
+	}
+
+	/* Do not get interrupted here */
+	(void)k_sem_take(&mdata.cmd_handler_data.sem_tx_lock, K_FOREVER);
+
+	/* Send the prefix of the band configuration */
+	int ret = modem_cmd_send_data_nolock(&mctx.iface, band_cmd, strlen(band_cmd));
+
+	if (ret != 0) {
+		LOG_ERR("Failed to send band configuration prefix");
+		goto out;
+	}
+
+	/* Send list of bands */
+	for (uint8_t i = 0; i < SIM7080_NUM_LTE_CHANNELS; i++) {
+		if ((used_bands & BIT(i)) == 0) {
+			continue;
+		}
+
+		ret = modem_cmd_send_data_nolock(&mctx.iface, ",", 1);
+		if (ret != 0) {
+			LOG_ERR("Failed to send delimiter");
+			goto out;
+		}
+
+		ret = modem_cmd_send_data_nolock(&mctx.iface, lte_band_lut[i],
+						 strlen(lte_band_lut[i]));
+		if (ret != 0) {
+			LOG_ERR("Failed to send channel");
+			goto out;
+		}
+	}
+
+	k_sem_reset(&mdata.sem_response);
+
+	/* Send the EOL */
+	ret = modem_cmd_send_data_nolock(&mctx.iface, "\r", 1);
+	if (ret != 0) {
+		LOG_ERR("Failed to send eol");
+		goto out;
+	}
+
+out:
+	k_sem_give(&mdata.cmd_handler_data.sem_tx_lock);
+
+	if (ret != 0) {
+		LOG_ERR("Setting LTE bands failed: %d", ret);
+		return ret;
+	}
+
+	return modem_cmd_handler_await(&mdata.cmd_handler_data, &mdata.sem_response,
+				       MDM_CMD_TIMEOUT);
+}
+
+/**
+ * Configure the preferred radio mode and used bands.
+ */
+static int configure_radio(void)
+{
+	const char *mode_cmd;
+
+	if (mdata.radio.rat < SIM7080_RAT_LTE_NB1 || mdata.radio.rat > SIM7080_RAT_GSM) {
+		return -EINVAL;
+	}
+
+	LOG_DBG("rat=%d, bands_nb1=0x%" PRIX32 ", bands_m1=0x%" PRIX32, (int)mdata.radio.rat,
+		mdata.radio.lte_bands_nb1, mdata.radio.lte_bands_m1);
+
+	if (mdata.radio.rat == SIM7080_RAT_GSM) {
+		mode_cmd = "AT+CNMP=13";
+	} else {
+		mode_cmd = "AT+CNMP=38";
+	}
+
+	/* Configure the preferred radio mode */
+	int ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0, mode_cmd,
+				 &mdata.sem_response, MDM_CMD_TIMEOUT);
+	if (ret < 0) {
+		LOG_ERR("Could not configure radio mode");
+		return ret;
+	}
+
+	/* Nothing more to do for GSM */
+	if (mdata.radio.rat == SIM7080_RAT_GSM) {
+		return 0;
+	}
+
+	/* Set the preferred LTE mode */
+	ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0, lte_mode_lut[mdata.radio.rat],
+			     &mdata.sem_response, MDM_CMD_TIMEOUT);
+	if (ret < 0) {
+		LOG_ERR("Could not configure LTE mode");
+		return ret;
+	}
+
+	/* Configure the LTE bands */
+	if (mdata.radio.rat == SIM7080_RAT_LTE_NB1 || mdata.radio.rat == SIM7080_RAT_LTE_AUTO) {
+		ret = configure_bands(SIM7080_RAT_LTE_NB1, mdata.radio.lte_bands_nb1);
+		if (ret != 0) {
+			LOG_ERR("Failed to configure NB-IoT bands");
+			return ret;
+		}
+	}
+
+	if (mdata.radio.rat == SIM7080_RAT_LTE_M1 || mdata.radio.rat == SIM7080_RAT_LTE_AUTO) {
+		ret = configure_bands(SIM7080_RAT_LTE_M1, mdata.radio.lte_bands_m1);
+		if (ret != 0) {
+			LOG_ERR("Failed to configure CAT-M1 bands");
+			return ret;
+		}
+	}
+
+	return 0;
+}
 
 /*
  * Handler for RSSI query.
@@ -105,20 +243,16 @@ int sim7080_pdp_activate(void)
 {
 	int counter;
 	int ret = 0;
-#if defined(CONFIG_MODEM_SIMCOM_SIM7080_RAT_GSM)
-	const char *buf = "AT+CREG?";
-	struct modem_cmd cmds[] = { MODEM_CMD("+CREG: ", on_cmd_cereg, 2U, ",") };
-#else
-	const char *buf = "AT+CEREG?";
-	struct modem_cmd cmds[] = { MODEM_CMD("+CEREG: ", on_cmd_cereg, 2U, ",") };
-#endif /* defined(CONFIG_MODEM_SIMCOM_SIM7080_RAT_GSM) */
+
+	const char *buf = mdata.radio.rat == SIM7080_RAT_GSM ? "AT+CREG?" : "AT+CEREG?";
+	struct modem_cmd cmds[] = {
+		MODEM_CMD(mdata.radio.rat == SIM7080_RAT_GSM ? "+CREG: " : "+CEREG: ", on_cmd_cereg,
+			  2U, ",")};
 
 	/* Set the preferred bands */
-	ret = modem_cmd_handler_setup_cmds(&mctx.iface, &mctx.cmd_handler, band_setup_cmds,
-					   ARRAY_SIZE(band_setup_cmds), &mdata.sem_response,
-					   MDM_REGISTRATION_TIMEOUT);
+	ret = configure_radio();
 	if (ret != 0) {
-		LOG_ERR("Failed to send band setup commands");
+		LOG_ERR("Failed to configure radio");
 		goto error;
 	}
 
@@ -266,4 +400,55 @@ int sim7080_pdp_deactivate(void)
 
 out:
 	return ret;
+}
+
+void mdm_sim7080_get_rat(enum sim7080_rat *rat)
+{
+	if (rat) {
+		*rat = mdata.radio.rat;
+	}
+}
+
+int mdm_sim7080_set_rat(enum sim7080_rat rat)
+{
+	if (rat < SIM7080_RAT_LTE_NB1 || rat > SIM7080_RAT_GSM) {
+		return -EINVAL;
+	}
+
+	mdata.radio.rat = rat;
+
+	return 0;
+}
+
+void mdm_sim7080_get_lte_bands(uint32_t *nb1, uint32_t *m1)
+{
+	if (nb1) {
+		*nb1 = mdata.radio.lte_bands_nb1;
+	}
+	if (m1) {
+		*m1 = mdata.radio.lte_bands_m1;
+	}
+}
+
+int mdm_sim7080_set_lte_bands(uint32_t nb1, uint32_t m1)
+{
+	if (nb1 != 0 && (nb1 & ~SIM7080_LTE_CHANNEL_MASK_NB1) != 0) {
+		LOG_ERR("Illegal NB-IoT band selection");
+		return -EINVAL;
+	}
+
+	if (m1 != 0 && (m1 & ~SIM7080_LTE_CHANNEL_MASK_M1) != 0) {
+		LOG_ERR("Illegal CAT-M1 band selection");
+		return -EINVAL;
+	}
+
+	if (nb1 != 0) {
+		mdata.radio.lte_bands_nb1 = nb1;
+	}
+
+	if (m1 != 0) {
+		mdata.radio.lte_bands_m1 = m1;
+	}
+
+	return 0;
 }

--- a/include/zephyr/drivers/modem/simcom-sim7080.h
+++ b/include/zephyr/drivers/modem/simcom-sim7080.h
@@ -30,6 +30,13 @@ extern "C" {
 /** Maximum timeout for DNS queries in milliseconds */
 #define SIM7080_DNS_MAX_TIMEOUT_MS 60000
 
+/** Channel Mask for NB-IoT */
+#define SIM7080_LTE_CHANNEL_MASK_NB1 0x7BEFFU
+/** Channel Mask for CAT-M1 */
+#define SIM7080_LTE_CHANNEL_MASK_M1  0x5FFFFU
+/** Number of LTE channels supported by the modem */
+#define SIM7080_NUM_LTE_CHANNELS     19U
+
 /** Sim7080 modem state */
 enum sim7080_state {
 	SIM7080_STATE_INIT = 0, /**< Initial modem state */
@@ -37,6 +44,37 @@ enum sim7080_state {
 	SIM7080_STATE_NETWORKING, /**< Network active */
 	SIM7080_STATE_GNSS, /**< GNSS active */
 	SIM7080_STATE_OFF, /**< Modem off */
+};
+
+/** Modem radio access technology */
+enum sim7080_rat {
+	SIM7080_RAT_LTE_NB1,  /**< NB-IoT only */
+	SIM7080_RAT_LTE_M1,   /**< LTE CAT M1 only */
+	SIM7080_RAT_LTE_AUTO, /**< Modem automatically selects M1 or NB1 */
+	SIM7080_RAT_GSM,      /**< GSM */
+};
+
+/** Supported LTE channels */
+enum sim7080_lte_chan {
+	SIM7080_LTE_CHAN_B1 = BIT(0),   /**< LTE Band 1 */
+	SIM7080_LTE_CHAN_B2 = BIT(1),   /**< LTE Band 2 */
+	SIM7080_LTE_CHAN_B3 = BIT(2),   /**< LTE Band 3 */
+	SIM7080_LTE_CHAN_B4 = BIT(3),   /**< LTE Band 4 */
+	SIM7080_LTE_CHAN_B5 = BIT(4),   /**< LTE Band 5 */
+	SIM7080_LTE_CHAN_B8 = BIT(5),   /**< LTE Band 8 */
+	SIM7080_LTE_CHAN_B12 = BIT(6),  /**< LTE Band 12 */
+	SIM7080_LTE_CHAN_B13 = BIT(7),  /**< LTE Band 13 */
+	SIM7080_LTE_CHAN_B14 = BIT(8),  /**< LTE Band 14 */
+	SIM7080_LTE_CHAN_B18 = BIT(9),  /**< LTE Band 18 */
+	SIM7080_LTE_CHAN_B19 = BIT(10), /**< LTE Band 19 */
+	SIM7080_LTE_CHAN_B20 = BIT(11), /**< LTE Band 20 */
+	SIM7080_LTE_CHAN_B25 = BIT(12), /**< LTE Band 25 */
+	SIM7080_LTE_CHAN_B26 = BIT(13), /**< LTE Band 26 */
+	SIM7080_LTE_CHAN_B27 = BIT(14), /**< LTE Band 27 */
+	SIM7080_LTE_CHAN_B28 = BIT(15), /**< LTE Band 28 */
+	SIM7080_LTE_CHAN_B66 = BIT(16), /**< LTE Band 66 */
+	SIM7080_LTE_CHAN_B71 = BIT(17), /**< LTE Band 71 */
+	SIM7080_LTE_CHAN_B85 = BIT(18), /**< LTE Band 85 */
 };
 
 /** Sim7080 gnss data structure */
@@ -548,6 +586,52 @@ int mdm_sim7080_configure_tls_certs(int fd, const char *root_ca, const char *cli
  */
 int mdm_sim7080_configure_dtls_psktable(int fd, const char *psktable);
 #endif
+
+/**
+ * @brief Get the currently selected radio technology.
+ *
+ * @param rat [out] Gets set to the current technology.
+ */
+void mdm_sim7080_get_rat(enum sim7080_rat *rat);
+
+/**
+ * @brief Set the radio technology.
+ *
+ * @param rat The radio technology.
+ * @retval 0 Success.
+ * @retval -EINVAL The selected technology is not available.
+ *
+ * @note This function needs to be called before mdm_sim7080_start_network().
+ *       If networking is already active, the change will not affect the current session.
+ *		 To apply changes, networking has to be restarted.
+ *		 A power cycle may be needed for the modem to forget the last working configuration.
+ */
+int mdm_sim7080_set_rat(enum sim7080_rat rat);
+
+/**
+ * @brief Get the currently used LTE bands.
+ *
+ * @param nb1 [out] Used NB-IoT bands. May be NULL.
+ * @param m1 [out] Used CAT-M1 bands. May be NULL.
+ */
+void mdm_sim7080_get_lte_bands(uint32_t *nb1, uint32_t *m1);
+
+/**
+ * @brief Set the LTE bands to use.
+ *
+ * @param nb1 NB-IoT bands to use. 0 to not change the bands.
+ * @param m1 CAT-M1 bands to use. 0 to not change the bands.
+ * @retval 0 Success.
+ * @retval -EINVAL The band selection is illegal.
+ *
+ * @note This function needs to be called before mdm_sim7080_start_network().
+ *       If networking is already active, the change will not affect the current session.
+ *		 To apply changes, networking has to be restarted.
+ *		 A power cycle may be needed for the modem to forget the last working configuration.
+ * @note Available NB-IoT and CAT-M1 differ. Refer to SIM7080_LTE_CHANNEL_MASK_NB1
+ *       and SIM7080_LTE_CHANNEL_MASK_M1.
+ */
+int mdm_sim7080_set_lte_bands(uint32_t nb1, uint32_t m1);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added functions to make radio access technology and lte channels runtime configurable. Defaults are still derived from kconfig values.