### PR TITLE
ci: do_not_merge: show the merge-block reason as a commit status

### DIFF
--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -11,6 +11,8 @@ on:
 
 permissions:
   contents: read
+  statuses: write # to publish the merge-gate commit status
+  pull-requests: read # to read PR labels and description
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}

--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -15,10 +15,13 @@ DNM_LABELS = ["DNM", "DNM (manifest)", "TSC", "Architecture Review", "dev-review
 
 
 def print_rate_limit(gh, org):
-    response = gh.get_organization(org)
-    for header, value in response.raw_headers.items():
-        if header.startswith("x-ratelimit"):
-            print(f"{header}: {value}")
+    try:
+        response = gh.get_organization(org)
+        for header, value in response.raw_headers.items():
+            if header.startswith("x-ratelimit"):
+                print(f"{header}: {value}")
+    except github.GithubException as e:
+        print(f"WARNING: could not read rate limit for '{org}': {e}")
 
 
 def parse_args(argv):

--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -41,6 +41,28 @@ def parse_args(argv):
 WAIT_FOR_WORKFLOWS = set({"Manifest"})
 WAIT_FOR_DELAY_S = 60
 
+STATUS_CONTEXT = "Merge gate"
+
+
+def publish_status(repo, pr, reasons):
+    if reasons:
+        state = "failure"
+        description = ("Gated (not a CI failure): " + "; ".join(reasons))[:140]
+    else:
+        state = "success"
+        description = "No merge blockers"
+
+    print(f"publishing status '{STATUS_CONTEXT}': {state} - {description}")
+    try:
+        repo.get_commit(pr.head.sha).create_status(
+            state=state,
+            context=STATUS_CONTEXT,
+            description=description,
+            target_url=pr.html_url,
+        )
+    except github.GithubException as e:
+        print(f"WARNING: could not publish '{STATUS_CONTEXT}' status: {e}")
+
 
 def workflow_delay(repo, pr):
     print(f"PR is at {pr.head.sha}")
@@ -77,20 +99,22 @@ def main(argv):
 
     print(f"pr: {pr.html_url}")
 
-    fail = False
+    reasons = []
 
     for label in pr.get_labels():
         print(f"label: {label.name}")
 
         if label.name in DNM_LABELS or label.name.startswith("block:"):
             print(f"Pull request is labeled as \"{label.name}\".")
-            fail = True
+            reasons.append(f'label "{label.name}"')
 
     if not pr.body:
-        print("Pull request is description is empty.")
-        fail = True
+        print("Pull request description is empty.")
+        reasons.append("empty PR description")
 
-    if fail:
+    publish_status(repo, pr, reasons)
+
+    if reasons:
         print("This workflow fails so that the pull request cannot be merged.")
         sys.exit(1)
 


### PR DESCRIPTION
A blocked PR (`DNM`, `DNM (manifest)`, etc.) shows the same red `Prevent Merging` as a genuine CI failure, so you can't tell them apart without opening the PR.

Publish a `Merge gate` commit status naming the reason, e.g. `Gated (not a CI failure): label "DNM (manifest)"`. It shows on hover and in the merge box. The job still exits 1, so the merge stays blocked a no branch-protection change.

Also harden `print_rate_limit()` so a diagnostics error can't abort the gate.