### PR TITLE
MAINTAINERS.yml: Bouffalolab Platforms: files: coarser matching

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -836,17 +836,22 @@ Bouffalolab Platforms:
     - josuah
     - will-tm
   files:
+    - boards/**/*bflb*
+    - boards/**/*bflb*/
     - boards/aithinker/ai_*/
-    - boards/bflb/
     - boards/doiting/
+    - boards/thirdreality/
     - boards/sipeed/m0sense/
     - boards/sipeed/m1s_dock/
     - boards/sipeed/maix_m0s_dock/
-    - drivers/*/*bflb*
-    - drivers/sensor/bflb/
+    - drivers/**/*bflb*
+    - drivers/**/*bflb*/
     - dts/riscv/bflb/
     - dts/bindings/*/bflb,*
     - soc/bflb/
+    - include/zephyr/**/*bflb*
+    - scripts/west_commands/runners/bflb*
+    - samples/**/*bflb*/
   labels:
     - "platform: Bouffalo Lab"
 


### PR DESCRIPTION
Add more broad matching rules to reduce the amount of manual work.

This uses the `**` operator to scan the whole depth, and always uses `*bflb*` to match in any part of the file name.

I think this now discovers these new things:

- scripts/west_commands/runners/bflb_mcu_tool.py
- samples/drivers/gpio/bflb_bl61x_wo_uart
- include/zephyr/dt-bindings/clock/bflb_*.h
- boards/common/bflb_mcu_tool.board.cmake