### PR TITLE
tests: integration: kernel: increase STACK_SIZE to 1024

### DIFF
--- a/tests/integration/kernel/src/main.c
+++ b/tests/integration/kernel/src/main.c
@@ -10,7 +10,7 @@
 
 
 /* COMMON DEFFINITIONS */
-#define STACK_SIZE	500
+#define STACK_SIZE	1024
 #define LIST_LEN 8
 
 static struct k_sem sema;


### PR DESCRIPTION
Increase stack size due to following test not passing anymore:

```
west twister -p qemu_cortex_a53/qemu_cortex_a53/smp -s integration.kernel
```

CI failure in main: https://github.com/zephyrproject-rtos/zephyr/actions/runs/27604696894/job/81642043557