### PR TITLE
 stm32: adc: Enable ADC differential on STM32N6 SoC series 

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -593,34 +593,43 @@ static void adc_stm32_calibration_delay(const struct device *dev)
 /* Number of ADC measurement during calibration procedure */
 #define ADC_CALIBRATION_STEPS (8U)
 
-static void adc_stm32_calibration_measure(ADC_TypeDef *adc, uint32_t *calibration_factor)
+static void adc_stm32_calibration_measure(ADC_TypeDef *adc,
+					  uint32_t calib_type)
 {
 	uint32_t calib_step;
-	uint32_t calib_factor_avg = 0;
+	int32_t calib_factor_avg;
 	uint8_t done = 0;
 
+	LL_ADC_StartCalibration(adc, calib_type);
 	do {
+		calib_factor_avg = 0;
+
 		for (calib_step = 0; calib_step < ADC_CALIBRATION_STEPS; calib_step++) {
 			LL_ADC_REG_StartConversion(adc);
 			while (LL_ADC_REG_IsConversionOngoing(adc) != 0UL) {
 			}
 
-			calib_factor_avg += LL_ADC_REG_ReadConversionData32(adc);
+			calib_factor_avg += (int32_t)LL_ADC_REG_ReadConversionData32(adc);
 		}
 
 		/* Compute the average data */
 		calib_factor_avg /= ADC_CALIBRATION_STEPS;
 
-		if ((calib_factor_avg == 0) && (LL_ADC_IsCalibrationOffsetEnabled(adc) == 0UL)) {
-			/* If average is 0 and offset is disabled
+		if (calib_type == LL_ADC_DIFFERENTIAL_ENDED) {
+			calib_factor_avg -= 0x7FF;
+		}
+
+		if ((calib_factor_avg <= 0) && (LL_ADC_IsCalibrationOffsetEnabled(adc) == 0UL)) {
+			/* If average is below 0 and offset is disabled
 			 * set offset and repeat measurements
 			 */
 			LL_ADC_EnableCalibrationOffset(adc);
 		} else {
-			*calibration_factor = (uint32_t)(calib_factor_avg);
+			LL_ADC_SetCalibrationFactor(adc, calib_type, (uint32_t)calib_factor_avg);
 			done = 1;
 		}
 	} while (done == 0);
+	LL_ADC_StopCalibration(adc);
 }
 #endif
 
@@ -684,17 +693,7 @@ static void adc_stm32_calibration_start(const struct device *dev, __maybe_unused
 #elif defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_ADC_StartCalibration(adc, LL_ADC_CALIB_OFFSET, calib_type);
 #elif defined(CONFIG_SOC_SERIES_STM32N6X)
-	uint32_t calibration_factor;
-
-	/* Start ADC calibration */
-	LL_ADC_StartCalibration(adc, STM32_IN_ADC_SINGLE_ENDED);
-	/* Disable additional offset before calibration start */
-	LL_ADC_DisableCalibrationOffset(adc);
-
-	adc_stm32_calibration_measure(adc, &calibration_factor);
-
-	LL_ADC_SetCalibrationFactor(adc, STM32_IN_ADC_SINGLE_ENDED, calibration_factor);
-	LL_ADC_StopCalibration(adc);
+	adc_stm32_calibration_measure(adc, calib_type);
 #elif !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
 #error "Missing calibration for this series"
 #endif
@@ -749,11 +748,30 @@ static int adc_stm32_calibrate(const struct device *dev, bool force)
 		return err;
 	}
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) || \
-	defined(CONFIG_SOC_SERIES_STM32N6X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc)
 	adc_stm32_calibration_delay(dev);
 	adc_stm32_calibration_start(dev, true);
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) */
+#elif defined(CONFIG_SOC_SERIES_STM32N6X)
+	uint32_t offset_required_single_end;
+
+	adc_stm32_calibration_delay(dev);
+	LL_ADC_DisableCalibrationOffset(adc);
+	adc_stm32_calibration_start(dev, true);
+
+	offset_required_single_end = LL_ADC_IsCalibrationOffsetEnabled(adc);
+
+	if (config->differential_channels_used) {
+		adc_stm32_calibration_start(dev, false);
+
+		/* If calibration offset was enabled by differential-ended
+		 * calibration, single-ended mode should be recalibrated with
+		 * calibration offset enabled.
+		 */
+		if (offset_required_single_end != LL_ADC_IsCalibrationOffsetEnabled(adc)) {
+			adc_stm32_calibration_start(dev, true);
+		}
+	}
+#endif
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X) && \
 	defined(CONFIG_CPU_CORTEX_M7)

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -502,6 +502,7 @@
 				st,adc-internal-regulator = "none";
 				st,adc-has-deep-powerdown;
 				st,adc-has-channel-preselection;
+				st,adc-has-differential-support;
 				st,adc-has-injected-support;
 				status = "disabled";
 			};
@@ -520,6 +521,7 @@
 				st,adc-internal-regulator = "none";
 				st,adc-has-deep-powerdown;
 				st,adc-has-channel-preselection;
+				st,adc-has-differential-support;
 				st,adc-has-injected-support;
 				status = "disabled";
 			};

--- a/samples/drivers/adc/adc_dt/boards/nucleo_n657x0_q_sb.overlay
+++ b/samples/drivers/adc/adc_dt/boards/nucleo_n657x0_q_sb.overlay
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Smile
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 10>, <&adc1 11>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/*
+	 * PA10 (Arduino A2) is shared:
+	 * positive input for channel 11 and negative input for channel 10
+	 */
+
+	channel@a {
+		reg = <10>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,differential;
+	};
+
+	channel@b {
+		reg = <11>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_dt/boards/stm32n6570_dk_sb.overlay
+++ b/samples/drivers/adc/adc_dt/boards/stm32n6570_dk_sb.overlay
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Smile
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 10>, <&adc1 11>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/*
+	 * PA10 (Arduino A2) is shared:
+	 * positive input for channel 11 and negative input for channel 10
+	 */
+
+	channel@a {
+		reg = <10>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,differential;
+	};
+
+	channel@b {
+		reg = <11>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_sequence/boards/nucleo_n657x0_q_sb.conf
+++ b/samples/drivers/adc/adc_sequence/boards/nucleo_n657x0_q_sb.conf
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Smile
+
+CONFIG_SEQUENCE_32BITS_REGISTERS=y

--- a/samples/drivers/adc/adc_sequence/boards/nucleo_n657x0_q_sb.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/nucleo_n657x0_q_sb.overlay
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Smile
+ */
+
+/ {
+	aliases {
+		adc0 = &adc1;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/*
+	 * PA10 (Arduino A2) is shared:
+	 * positive input for channel 11 and negative input for channel 10
+	 */
+
+	channel@a {
+		reg = <10>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,differential;
+	};
+
+	channel@b {
+		reg = <11>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_sequence/boards/stm32n6570_dk_sb.conf
+++ b/samples/drivers/adc/adc_sequence/boards/stm32n6570_dk_sb.conf
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Smile
+
+CONFIG_SEQUENCE_32BITS_REGISTERS=y

--- a/samples/drivers/adc/adc_sequence/boards/stm32n6570_dk_sb.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/stm32n6570_dk_sb.overlay
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Smile
+ */
+
+/ {
+	aliases {
+		adc0 = &adc1;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/*
+	 * PA10 (Arduino A2) is shared:
+	 * positive input for channel 11 and negative input for channel 10
+	 */
+
+	channel@a {
+		reg = <10>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,differential;
+	};
+
+	channel@b {
+		reg = <11>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/nucleo_n657x0_q_sb.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_n657x0_q_sb.overlay
@@ -18,12 +18,18 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
+	/*
+	 * PA10 (Arduino A2) is shared:
+	 * positive input for channel 11 and negative input for channel 10
+	 */
+
 	channel@a {
 		reg = <10>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
+		zephyr,differential;
 	};
 
 	channel@b {

--- a/tests/drivers/adc/adc_api/boards/stm32n6570_dk_sb.overlay
+++ b/tests/drivers/adc/adc_api/boards/stm32n6570_dk_sb.overlay
@@ -18,12 +18,18 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
+	/*
+	 * PA10 (Arduino A2) is shared:
+	 * positive input for channel 11 and negative input for channel 10
+	 */
+
 	channel@a {
 		reg = <10>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
+		zephyr,differential;
 	};
 
 	channel@b {


### PR DESCRIPTION
Change calibration process to handle differential calibration.

Calibration process specified in rm0486 section 32.4.8. 
Heavily inspired from `Src/stm32n6xx_hal_adc_ex.c` from
https://github.com/STMicroelectronics/stm32n6xx-hal-driver. 

Configure channel 10 to differential for Nucleo N657X0-Q and
STM32N6570-DK in adc_api test.
Add overlays for STM32N6 based boards for adc_dt
and adc_sequence samples.