### PR TITLE
Bluetooth: BAP: SD: Add missing bt_conn_drop

### DIFF
--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -482,6 +482,19 @@ static struct bt_le_per_adv_sync_cb pa_sync_cb = {
 	.term = pa_term_cb,
 };
 
+static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
+{
+	ARRAY_FOR_EACH_PTR(scan_delegator_sync_states, sync_state) {
+		if (sync_state->conn == conn) {
+			bt_conn_drop(&sync_state->conn);
+		}
+	}
+}
+
+static struct bt_conn_cb conn_cb = {
+	.disconnected = disconnected_cb,
+};
+
 static int cmd_bap_scan_delegator_init(const struct shell *sh, size_t argc,
 				       char **argv)
 {
@@ -505,11 +518,18 @@ static int cmd_bap_scan_delegator_init(const struct shell *sh, size_t argc,
 			return -ENOEXEC;
 		}
 
+		err = bt_conn_cb_register(&conn_cb);
+		if (err != 0) {
+			shell_error(sh, "Failed to register conn callbacks (err: %d)", err);
+			return -ENOEXEC;
+		}
+
 		registered = true;
 	}
 
 	return 0;
 }
+
 static int cmd_bap_scan_delegator_set_past_pref(const struct shell *sh,
 						size_t argc, char **argv)
 {


### PR DESCRIPTION
If using past, we may take a reference to the ACL, but that reference was never returned.