### PR TITLE
net: lib: http_server: Improve header capture behavior documentation

### DIFF
--- a/doc/services/connectivity/networking/api/http_server.rst
+++ b/doc/services/connectivity/networking/api/http_server.rst
@@ -410,7 +410,9 @@ The ``request_ctx`` parameter is used to pass request data to the application:
 
 * The ``headers``, ``header_count`` and ``headers_status`` fields pass request
   headers to the application, if
-  :kconfig:option:`CONFIG_HTTP_SERVER_CAPTURE_HEADERS` is enabled.
+  :kconfig:option:`CONFIG_HTTP_SERVER_CAPTURE_HEADERS` is enabled. These fields
+  are only populated in the first callback of a request; see
+  :ref:`http_server_interface_accessing_request_headers` for details.
 
 The ``response_ctx`` field is used by the application to pass response data to
 the HTTP server:
@@ -476,36 +478,69 @@ processing of the Websocket connection is application-specific, hence outside
 of scope of this guide. See :zephyr:code-sample:`sockets-http-server` for an
 example Websocket-based echo service implementation.
 
+.. _http_server_interface_accessing_request_headers:
+
 Accessing request headers
 =========================
 
 The application can register an interest in any specific HTTP request headers.
 These headers are then stored for each incoming request, and can be accessed
-from within a dynamic resource callback. Request headers are only included in
-the first callback for a given request, and are not passed to any subsequent
-callbacks.
+from within a dynamic resource callback.
+
+.. important::
+
+   Captured request headers are delivered to the application **only in the first
+   callback** for a given request. In any subsequent callback for the same
+   request the ``headers``, ``header_count`` and ``headers_status`` fields of
+   ``request_ctx`` are cleared (``headers_status`` becomes
+   :c:enumerator:`HTTP_HEADER_STATUS_NONE`). Applications must copy out any
+   header value they need during the first callback rather than reading it later.
+
+   Note that the first callback may or may not also carry request body data
+   (this depends on the HTTP method and on transport framing). Do not condition
+   header handling on the presence of body data: always inspect
+   ``headers_status`` and stash the headers when it is not
+   :c:enumerator:`HTTP_HEADER_STATUS_NONE`.
 
 This feature must first be enabled with
 :kconfig:option:`CONFIG_HTTP_SERVER_CAPTURE_HEADERS` Kconfig option.
 
 Then the application can register headers to be captured, and read the values
-from within the dynamic resource callback:
+from within the dynamic resource callback. The recommended pattern is to copy
+out the headers of interest in the first callback, then act on them once the
+full request body has been received:
 
 .. code-block:: c
 
     HTTP_SERVER_REGISTER_HEADER_CAPTURE(capture_user_agent, "User-Agent");
 
+    static char user_agent[64];
+
     static int dyn_handler(struct http_client_ctx *client, enum http_transaction_status status,
                            const struct http_request_ctx *request_ctx,
                            struct http_response_ctx *response_ctx, void *user_data)
     {
-        size_t header_count = client->header_capture_ctx.count;
-        const struct http_header *headers = client->header_capture_ctx.headers;
+        /* Request headers are only present in the first callback, so copy out
+         * any values needed later before they are gone.
+         */
+        if (request_ctx->headers_status != HTTP_HEADER_STATUS_NONE) {
+            for (size_t i = 0; i < request_ctx->header_count; i++) {
+                const struct http_header *hdr = &request_ctx->headers[i];
 
-        LOG_INF("Captured %d headers with request", header_count);
+                LOG_INF("Captured header: '%s: %s'", hdr->name, hdr->value);
 
-        for (uint32_t i = 0; i < header_count; i++) {
-            LOG_INF("Header: '%s: %s'", headers[i].name, headers[i].value);
+                if (strcasecmp(hdr->name, "User-Agent") == 0) {
+                    strncpy(user_agent, hdr->value, sizeof(user_agent) - 1);
+                }
+            }
+        }
+
+        /* Process request body data (may be empty in the first callback). */
+
+        if (status == HTTP_SERVER_REQUEST_DATA_FINAL) {
+            /* Full request received: act on the body together with the header
+             * values stashed above (e.g. user_agent).
+             */
         }
 
         return 0;

--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -195,7 +195,18 @@ struct http_header {
 	const char *value; /**< Pointer to header value NULL-terminated string. */
 };
 
-/** @brief HTTP request context */
+/**
+ * @brief HTTP request context
+ *
+ * @note The captured request headers (@ref headers, @ref header_count and
+ *       @ref headers_status) are only populated in the first dynamic resource
+ *       callback of a request. In any subsequent callback for the same request,
+ *       @ref headers is NULL, @ref header_count is 0 and @ref headers_status is
+ *       @ref HTTP_HEADER_STATUS_NONE. The first callback may or may not also
+ *       carry request body data, so do not condition header handling on the
+ *       presence of @ref data. Copy out any header values you need during that
+ *       first callback.
+ */
 struct http_request_ctx {
 	uint8_t *data;                          /**< HTTP request data */
 	size_t data_len;                        /**< Length of HTTP request data */
@@ -225,6 +236,9 @@ struct http_response_ctx {
  *               HTTP_SERVER_TRANSACTION_ABORTED and HTTP_SERVER_TRANSACTION_COMPLETE are
  *               terminal notifications.
  * @param request_ctx Request context structure containing HTTP request data that was received.
+ *                    Captured request headers (if
+ *                    @kconfig{CONFIG_HTTP_SERVER_CAPTURE_HEADERS} is enabled) are only available
+ *                    in the first callback of a request; see @ref http_request_ctx.
  * @param response_ctx Response context structure for application to populate with response data.
  * @param user_data User specified data.
  *

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -196,6 +196,9 @@ config HTTP_SERVER_CAPTURE_HEADERS
 	help
 	  This setting enables the HTTP server to capture selected headers that have
 	  been registered by the application.
+	  Captured headers are delivered to the dynamic resource callback only in
+	  the first callback for a given request, and are not available in any
+	  subsequent callback.
 
 config HTTP_SERVER_CAPTURE_HEADER_BUFFER_SIZE
 	int "Size of buffer for capturing HTTP headers for application use"


### PR DESCRIPTION
Captured request headers are only delivered in the first dynamic resource callback, which was not documented explicitly enough, causing confusion for users. Document this contract on the Kconfig option, the API, and the HTTP server guide.

Fixes #111202