### PR TITLE
[Backport v4.3-branch] drivers: can: bosch: m_can: switch to macro for declaring data struct

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1421,8 +1421,6 @@ int can_mcan_init(const struct device *dev)
 	__ASSERT_NO_MSG(cbs->num_std <= config->mram_elements[CAN_MCAN_MRAM_CFG_STD_FILTER]);
 	__ASSERT_NO_MSG(cbs->num_ext <= config->mram_elements[CAN_MCAN_MRAM_CFG_EXT_FILTER]);
 
-	k_mutex_init(&data->lock);
-	k_mutex_init(&data->tx_mtx);
 	k_sem_init(&data->tx_sem, cbs->num_tx, cbs->num_tx);
 
 	if (config->common.phy != NULL && !device_is_ready(config->common.phy)) {

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -217,8 +217,7 @@ static const struct can_mcan_ops mcux_mcan_ops = {
 					    &mcux_mcan_ops,		\
 					    &mcux_mcan_cbs_##n);	\
 									\
-	static struct can_mcan_data can_mcan_data_##n =			\
-		CAN_MCAN_DATA_INITIALIZER(NULL);			\
+	CAN_MCAN_DATA_DEFINE(can_mcan_data_##n, NULL);                  \
 									\
 	CAN_DEVICE_DT_INST_DEFINE(n, mcux_mcan_init, NULL,		\
 				  &can_mcan_data_##n,			\

--- a/drivers/can/can_nrf.c
+++ b/drivers/can/can_nrf.c
@@ -199,7 +199,7 @@ static int can_nrf_init(const struct device *dev)
 	static const struct can_mcan_config can_mcan_nrf_config##n = CAN_MCAN_DT_CONFIG_INST_GET(  \
 		n, &can_nrf_config##n, &can_mcan_nrf_ops, &can_mcan_nrf_cbs##n);                   \
                                                                                                    \
-	static struct can_mcan_data can_mcan_nrf_data##n = CAN_MCAN_DATA_INITIALIZER(NULL);        \
+	CAN_MCAN_DATA_DEFINE(can_mcan_nrf_data##n, NULL);                                          \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, can_nrf_init, NULL, &can_mcan_nrf_data##n,                        \
 			      &can_mcan_nrf_config##n, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,      \

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -308,8 +308,7 @@ static const struct can_mcan_ops can_numaker_ops = {
                                                                                   \
 	static uint32_t can_numaker_data_##inst;                                  \
                                                                                   \
-	static struct can_mcan_data can_mcan_data_##inst =                        \
-		CAN_MCAN_DATA_INITIALIZER(&can_numaker_data_ ## inst);            \
+	CAN_MCAN_DATA_DEFINE(can_mcan_data_##inst, &can_numaker_data_##inst);     \
                                                                                   \
 	CAN_DEVICE_DT_INST_DEFINE(inst,                                           \
 		can_numaker_init,                                                 \

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -189,9 +189,7 @@ static void config_can_##inst##_irq(void)                                       
 					    &can_sam_ops,		\
 					    &can_sam_cbs_##inst);
 
-#define CAN_SAM_DATA_INST(inst)						\
-	static struct can_mcan_data can_mcan_data_##inst =		\
-		CAN_MCAN_DATA_INITIALIZER(NULL);
+#define CAN_SAM_DATA_INST(inst) CAN_MCAN_DATA_DEFINE(can_mcan_data_##inst, NULL);
 
 #define CAN_SAM_DEVICE_INST(inst)						\
 	CAN_DEVICE_DT_INST_DEFINE(inst, can_sam_init, NULL,			\

--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -231,9 +231,7 @@ static void config_can_##inst##_irq(void)						\
 		CAN_MCAN_DT_CONFIG_INST_GET(inst, &can_sam0_cfg_##inst, &can_sam0_ops,  \
 					    &can_sam0_cbs_##inst);
 
-#define CAN_SAM0_DATA_INST(inst)							\
-	static struct can_mcan_data can_mcan_data_##inst =				\
-		CAN_MCAN_DATA_INITIALIZER(NULL);
+#define CAN_SAM0_DATA_INST(inst) CAN_MCAN_DATA_DEFINE(can_mcan_data_##inst, NULL);
 
 #define CAN_SAM0_DEVICE_INST(inst)							\
 	CAN_DEVICE_DT_INST_DEFINE(inst, can_sam0_init, NULL,				\

--- a/drivers/can/can_stm32_fdcan.c
+++ b/drivers/can/can_stm32_fdcan.c
@@ -615,9 +615,7 @@ static void config_can_##inst##_irq(void)                                      \
 					    &can_stm32fd_ops,		\
 					    &can_stm32fd_cbs_##inst);
 
-#define CAN_STM32FD_DATA_INST(inst)					\
-	static struct can_mcan_data can_mcan_data_##inst =		\
-		CAN_MCAN_DATA_INITIALIZER(NULL);
+#define CAN_STM32FD_DATA_INST(inst) CAN_MCAN_DATA_DEFINE(can_mcan_data_##inst, NULL);
 
 #define CAN_STM32FD_DEVICE_INST(inst)						\
 	CAN_DEVICE_DT_INST_DEFINE(inst, can_stm32fd_init, NULL,			\

--- a/drivers/can/can_stm32h7_fdcan.c
+++ b/drivers/can/can_stm32h7_fdcan.c
@@ -284,8 +284,7 @@ static const struct can_mcan_ops can_stm32h7_ops = {
 					    &can_stm32h7_ops,		    \
 					    &can_stm32h7_cbs_##n);	    \
 									    \
-	static struct can_mcan_data can_mcan_data_##n =			    \
-		CAN_MCAN_DATA_INITIALIZER(NULL);			    \
+	CAN_MCAN_DATA_DEFINE(can_mcan_data_##n, NULL);                      \
 									    \
 	CAN_DEVICE_DT_INST_DEFINE(n, can_stm32h7_init, NULL,		    \
 				  &can_mcan_data_##n,			    \

--- a/drivers/can/can_tcan4x5x.c
+++ b/drivers/can/can_tcan4x5x.c
@@ -904,8 +904,7 @@ static const struct can_mcan_ops tcan4x5x_ops = {
                                                                                                    \
 	static struct tcan4x5x_data tcan4x5x_data_##inst;                                          \
                                                                                                    \
-	static struct can_mcan_data can_mcan_data_##inst =                                         \
-		CAN_MCAN_DATA_INITIALIZER(&tcan4x5x_data_##inst);                                  \
+	CAN_MCAN_DATA_DEFINE(can_mcan_data_##inst, &tcan4x5x_data_##inst);                         \
                                                                                                    \
 	PM_DEVICE_DT_INST_DEFINE(inst, tcan4x5x_pm_control);                                       \
 	CAN_DEVICE_DT_INST_DEFINE(inst, tcan4x5x_init, PM_DEVICE_DT_INST_GET(inst),                \

--- a/include/zephyr/drivers/can/can_mcan.h
+++ b/include/zephyr/drivers/can/can_mcan.h
@@ -1325,11 +1325,14 @@ struct can_mcan_config {
 	CAN_MCAN_DT_CONFIG_GET(DT_DRV_INST(inst), _custom, _ops, _cbs)
 
 /**
- * @brief Initializer for a @a can_mcan_data struct
+ * @brief Statically define and initialize a @a can_mcan_data struct
+ * @param _name Name of the can_mcan_data struct
  * @param _custom Pointer to custom driver frontend data structure
  */
-#define CAN_MCAN_DATA_INITIALIZER(_custom)                                                         \
-	{                                                                                          \
+#define CAN_MCAN_DATA_DEFINE(_name, _custom)                                                       \
+	static struct can_mcan_data _name = {                                                      \
+		.lock = Z_MUTEX_INITIALIZER(_name.lock),                                           \
+		.tx_mtx = Z_MUTEX_INITIALIZER(_name.tx_mtx),                                       \
 		.custom = _custom,                                                                 \
 	}
 


### PR DESCRIPTION
Manually backport d39362336497aa812a2d88704b46fa0bb93f8d06 from #111096 as the automatic backport failed (#111340).

_Original PR description:_

---

Switch to using a macro for declaring the Bosch M_CAN driver data struct and have the macro statically initialize the k_mutex structures at build time.

The "lock" mutex can be used by the vendor-specific driver front-ends before the can_mcan_init() function is called (e.g. for configuring the Message RAM), which will result in attempts to lock an unitialized k_mutex.

Fixes: #111031