### PR TITLE
Add missing properties from various nodes in nrf7120.dtsi

### DIFF
--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -756,6 +756,7 @@
 				clocks = <&lfxo>, <&pclk>;
 				clock-names = "lfclock", "hfclock";
 				status = "disabled";
+				extended-channels = <0>;
 			};
 
 			tdm: tdm@e8000 {

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -495,6 +495,7 @@
 				#size-cells = <0>;
 				clock-frequency = <I2C_BITRATE_STANDARD>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 			};
 
@@ -528,6 +529,7 @@
 				#size-cells = <0>;
 				clock-frequency = <I2C_BITRATE_STANDARD>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 			};
 
@@ -561,6 +563,7 @@
 				#size-cells = <0>;
 				clock-frequency = <I2C_BITRATE_STANDARD>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 			};
 
@@ -787,6 +790,7 @@
 				#size-cells = <0>;
 				clock-frequency = <I2C_BITRATE_STANDARD>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 			};
 
@@ -820,6 +824,7 @@
 				#size-cells = <0>;
 				clock-frequency = <I2C_BITRATE_STANDARD>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 			};
 
@@ -868,6 +873,7 @@
 				#size-cells = <0>;
 				clock-frequency = <I2C_BITRATE_STANDARD>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 			};
 


### PR DESCRIPTION
Add clock-tolerance-percent property for i2c nodes.
Add extended-channels for grtc node.