### PR TITLE
samples: fido2: filter on hid-device DT compat

### DIFF
--- a/samples/subsys/authentication/fido2/sample.yaml
+++ b/samples/subsys/authentication/fido2/sample.yaml
@@ -3,6 +3,7 @@ sample:
 common:
   depends_on:
     - usbd
+  filter: dt_compat_enabled("zephyr,hid-device")
   harness: console
   harness_config:
     type: one_line


### PR DESCRIPTION
The fido2 sample (added in `5eca9e8c`) enables `CONFIG_FIDO2_TRANSPORT_USB_HID`, which `select`s `CONFIG_USBD_HID_SUPPORT`. `USBD_HID_SUPPORT` `depends on DT_HAS_ZEPHYR_HID_DEVICE_ENABLED`, so on boards that do not provide a `zephyr,hid-device` devicetree node the select cannot be satisfied and Kconfig emits an unmet-dependency warning. Twister runs with `-W`, which promotes that warning to a build error, so the sample fails CI on any platform without a hid-device DT node (e.g. the Infineon PSE84 evaluation kits).

Add `filter: dt_compat_enabled("zephyr,hid-device")` so twister statically filters those platforms instead of attempting to build and failing.

### Verification

Local twister run (`-b`, four PSE84 board/core combos) before the change:
```
1/1 100%  built (not run):    0, filtered:    0, failed:    0, error:    1
sample.authentication.fido2 on kit_pse84_eval/pse846gps2dbzc4a/m55 error
```

After the change:
```
4/4 100%  built (not run):    0, filtered:    4, failed:    0, error:    0
1 test scenarios (4 configurations) selected, 4 configurations filtered (0 by static filter, 4 at runtime).
```

The three boards that ship overlays for this sample (blackpill_h523ce, weact_esp32s3_b_procpu, weact_stm32wb55_core) define a `zephyr,hid-device` node, so they are unaffected by the filter.

### Signed-off-by
Bill Waters <bill.waters@infineon.com>
