### PR TITLE
[Backport v4.4-branch] soc: espressif: fix psram boot paths

### DIFF
--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -710,6 +710,17 @@ static const struct flash_parameters *flash_esp32_get_parameters(const struct de
 
 static int flash_esp32_init(const struct device *dev)
 {
+#ifndef CONFIG_MCUBOOT
+	/*
+	 * Switch the main flash chip to OS-aware functions now that the
+	 * scheduler is running. These were left as the no-OS (cache-suspend)
+	 * functions during early boot in esp_flash_config(), because the
+	 * OS-aware path can guard flash access with a mutex. MCUboot runs
+	 * single-threaded and keeps the no-OS functions.
+	 */
+	esp_flash_app_init();
+#endif
+
 #ifdef CONFIG_MULTITHREADING
 	struct flash_esp32_dev_data *const data = dev->data;
 

--- a/soc/espressif/common/Kconfig.esptool
+++ b/soc/espressif/common/Kconfig.esptool
@@ -6,6 +6,12 @@ if SOC_FAMILY_ESPRESSIF_ESP32
 config ESPTOOLPY_OCT_FLASH
 	bool "Use Octal Flash"
 	depends on SOC_SERIES_ESP32S3
+	default y if SPIRAM_MODE_OCT
+	help
+	  Octal PSRAM modules are paired with octal flash. Enable octal flash
+	  by default in this case so its MSPI timing is tuned (DTR sample mode).
+	  Without it the flash falls back to untuned STR timing and can corrupt
+	  at high speeds. Disable manually if the board uses quad flash.
 
 config ESPTOOLPY_FLASH_MODE_AUTO_DETECT
 	depends on SOC_SERIES_ESP32S3


### PR DESCRIPTION
Backport of the fix from https://github.com/zephyrproject-rtos/zephyr/pull/110861

Following commits were back-ported:
fea94bb75d7dddb13f832f17003440edb0b0f693
c604f128f716e2d689c666c8fb79ba84981770e8

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/111411