### PR TITLE
drivers: ethernet: dwmac: validate buffer constraints

### DIFF
--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -73,6 +73,9 @@ config ETH_DWMAC_MMU
 
 if ETH_DWC_ETHER_QOS_CORE || ETH_DWC_ETHER_1000_CORE
 
+configdefault NET_BUF_ALIGNMENT
+	default DCACHE_LINE_SIZE if DCACHE
+
 config DWMAC_NB_TX_DESCS
 	int "Number of entries in the transmit descriptor ring"
 	default 16

--- a/drivers/ethernet/dwc_mac/eth_dwmac_mmu.c
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_mmu.c
@@ -23,14 +23,17 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "eth_dwmac_priv.h"
 
+/*
+ * Don't impose any restriction based on data bus width as it is unknown.
+ * Usually, cache line size will be a multiple of the data bus width, so
+ * aligning to cache line size should be sufficient.
+ */
+DWMAC_ASSERT_BUFFER_ALIGNMENT(0);
+
 int dwmac_bus_init(const struct device *dev __unused)
 {
 	return 0;
 }
-
-#if (CONFIG_DCACHE_LINE_SIZE+0 == 0)
-#error "CONFIG_DCACHE_LINE_SIZE must be configured to a non-zero value"
-#endif
 
 static struct dwmac_dma_desc __aligned(CONFIG_DCACHE_LINE_SIZE)
 			dwmac_tx_rx_descriptors[NB_TX_DESCS + NB_RX_DESCS];

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -18,6 +18,54 @@
 #include <zephyr/sys/device_mmio.h>
 
 /*
+ * Common checks
+ */
+
+/*
+ * If a data cache is enabled, cache line size must be configured to a non-zero
+ * value for this driver to work correctly.
+ */
+#if CONFIG_DCACHE
+#if (CONFIG_DCACHE_LINE_SIZE+0 == 0)
+#error "CONFIG_DCACHE_LINE_SIZE must be configured to a non-zero value"
+#endif
+#endif
+
+/*
+ * The DMA imposes certain constraints on the buffers:
+ * 1. The DMA can only perform accesses with the data bus width. Even though buffers can start on
+ *    any address, other data in the first and last words of the buffer may be corrupted. To
+ *    avoid this, we require buffers to be aligned to the data bus width and their size to be a
+ *    multiple of the data bus width.
+ * 2. If a data cache is enabled, buffers must also be aligned to the cache line size and their
+ *    size must be a multiple of the cache line size. This is because for cache management, cache
+ *    lines are invalidated, so if a buffer is not aligned to cache line size, the first and last
+ *    cache line of the buffer may contain other data, which can be corrupted when invalidated.
+ */
+#define DWMAC_ASSERT_BUFFER_ALIGNMENT(bus_width)                                                   \
+	BUILD_ASSERT(                                                                              \
+		((CONFIG_NET_BUF_DATA_SIZE) % MAX(                                                 \
+			((bus_width) / 8),                                                         \
+			COND_CODE_1(CONFIG_DCACHE, (CONFIG_DCACHE_LINE_SIZE), (0))                 \
+		)) == 0, "CONFIG_NET_BUF_DATA_SIZE must be a multiple of the data bus width or "   \
+			 "cache line size"                                                         \
+	);                                                                                         \
+	BUILD_ASSERT(                                                                              \
+		COND_CODE_0(CONFIG_NET_BUF_ALIGNMENT, (sizeof(void *)), (CONFIG_NET_BUF_ALIGNMENT))\
+		>= MAX(                                                                            \
+			((bus_width) / 8),                                                         \
+			COND_CODE_1(CONFIG_DCACHE, (CONFIG_DCACHE_LINE_SIZE), (0))                 \
+		), "CONFIG_NET_BUF_ALIGNMENT must be at least the data bus width or cache line"    \
+		   "size"                                                                          \
+	);                                                                                         \
+	IF_ENABLED(CONFIG_DCACHE, (                                                                \
+		BUILD_ASSERT(                                                                      \
+			(CONFIG_NET_BUF_ALIGNMENT) % (CONFIG_DCACHE_LINE_SIZE) == 0,               \
+			"CONFIG_NET_BUF_ALIGNMENT must be a multiple of the data cache line size"  \
+		)                                                                                  \
+	));
+
+/*
  * Global driver parameters
  */
 

--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_1000.c
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_1000.c
@@ -30,6 +30,11 @@ LOG_MODULE_REGISTER(dwmac_plat, CONFIG_ETHERNET_LOG_LEVEL);
 #define ST_OUI_B1 0x80
 #define ST_OUI_B2 0xE1
 
+/* The DMA bus master interface is 32-bit on this IP */
+#define DATA_BUS_WIDTH 32
+
+DWMAC_ASSERT_BUFFER_ALIGNMENT(DATA_BUS_WIDTH);
+
 BUILD_ASSERT(DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii) ||
 		     DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rmii),
 	     "Unsupported PHY connection type");
@@ -88,12 +93,13 @@ int dwmac_bus_init(const struct device *dev)
 	return 0;
 }
 
+#define DESCRIPTOR_ALIGNMENT ((DATA_BUS_WIDTH) / (BITS_PER_BYTE))
 #if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm)) && defined(CONFIG_SOC_SERIES_STM32F7X)
-#define __desc_mem __dtcm_noinit_section __aligned(4)
+#define __desc_mem __dtcm_noinit_section __aligned(DESCRIPTOR_ALIGNMENT)
 #elif defined(CONFIG_NOCACHE_MEMORY)
-#define __desc_mem __nocache_noinit __aligned(4)
+#define __desc_mem __nocache_noinit __aligned(DESCRIPTOR_ALIGNMENT)
 #else
-#define __desc_mem __noinit __aligned(4)
+#define __desc_mem __noinit __aligned(DESCRIPTOR_ALIGNMENT)
 #endif
 
 static struct dwmac_dma_desc dwmac_tx_descs[NB_TX_DESCS] __desc_mem;

--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_qos.c
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_qos.c
@@ -35,6 +35,11 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define ST_OUI_B1 0x80
 #define ST_OUI_B2 0xE1
 
+/* The DMA bus master interface is 32-bit on this IP */
+#define DATA_BUS_WIDTH 32
+
+DWMAC_ASSERT_BUFFER_ALIGNMENT(DATA_BUS_WIDTH);
+
 #if defined(CONFIG_SOC_SERIES_STM32H5X)
 
 #if DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii)
@@ -117,10 +122,11 @@ int dwmac_bus_init(const struct device *dev)
 	return 0;
 }
 
+#define DESCRIPTOR_ALIGNMENT ((DATA_BUS_WIDTH) / (BITS_PER_BYTE))
 #if defined(CONFIG_NOCACHE_MEMORY)
-#define __desc_mem __nocache __aligned(4)
+#define __desc_mem __nocache __aligned(DESCRIPTOR_ALIGNMENT)
 #else
-#define __desc_mem __aligned(4)
+#define __desc_mem __aligned(DESCRIPTOR_ALIGNMENT)
 #endif
 
 /* Descriptor rings in uncached memory */


### PR DESCRIPTION
Add build-time validation of buffer constraints for the DWMAC driver. This ensures that the configured buffer sizes and alignment meet the hardware requirements, preventing potential runtime issues due to misconfiguration.