### PR TITLE
Update preprocessed file paths for BL2

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -447,9 +447,9 @@ if(CONFIG_BUILD_WITH_TFM)
   add_dependencies(zephyr_interface tfm)
 
   if(CONFIG_TFM_BL2)
-    set(PREPROCESSED_FILE_S "${TFM_BINARY_DIR}/bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s.o")
-    set(PREPROCESSED_FILE_S_NS "${TFM_BINARY_DIR}/bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s_ns.o")
-    set(PREPROCESSED_FILE_NS "${TFM_BINARY_DIR}/bl2/ext/mcuboot/CMakeFiles/signing_layout_ns.dir/signing_layout_ns.o")
+    set(PREPROCESSED_FILE_S "${TFM_BINARY_DIR}/bl2/ext/mcuboot/signing_layout_s_exported.o")
+    set(PREPROCESSED_FILE_S_NS "${TFM_BINARY_DIR}/bl2/ext/mcuboot/signing_layout_s_exported.o")
+    set(PREPROCESSED_FILE_NS "${TFM_BINARY_DIR}/bl2/ext/mcuboot/signing_layout_ns_exported.o")
     set(TFM_MCUBOOT_DIR "${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/bl2/ext/mcuboot")
   endif()
 


### PR DESCRIPTION
Requires https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/202

This patch fixes Zephyr's custom integration by adding a POST_BUILD step that uses generator expressions ($<TARGET_OBJECTS>) to safely grab the hashed output and copy it to a stable _exported.o name in the build directory. Zephyr is then updated to consume these stable artifacts.

Aiming to fix https://github.com/zephyrproject-rtos/zephyr/issues/111257