### PR TITLE
[Backport v3.7-branch] net: ip: Mark only cross-interface traffic forwarded

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -359,6 +359,13 @@ static enum net_verdict ipv6_route_packet(struct net_pkt *pkt,
 				  (struct in6_addr *)hdr->src, 128);
 		}
 
+		if (IS_ENABLED(CONFIG_NET_ROUTING) &&
+		    net_pkt_orig_iface(pkt) != net_pkt_iface(pkt)) {
+			net_pkt_set_forwarding(pkt, true);
+		} else {
+			net_pkt_set_forwarding(pkt, false);
+		}
+
 		ret = net_route_packet(pkt, nexthop);
 		if (ret < 0) {
 			NET_DBG("Cannot re-route pkt %p via %s "

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -824,6 +824,7 @@ int net_route_mcast_forward_packet(struct net_pkt *pkt, struct net_ipv6_hdr *hdr
 	 * a direct access to the buffer there is no need to perform read/write operations.
 	 */
 	hdr->hop_limit--;
+	net_pkt_set_ipv6_hop_limit(pkt, hdr->hop_limit);
 
 	ARRAY_FOR_EACH_PTR(route_mcast_entries, route) {
 		struct net_pkt *pkt_cpy = NULL;
@@ -1011,7 +1012,9 @@ exit:
 int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 {
 	struct net_linkaddr_storage *lladdr;
+	struct net_if *orig_iface;
 	struct net_nbr *nbr;
+	bool forwarding;
 	int err;
 
 	net_ipv6_nbr_lock();
@@ -1066,7 +1069,24 @@ int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 	}
 #endif
 
-	net_pkt_set_forwarding(pkt, true);
+	orig_iface = net_pkt_orig_iface(pkt);
+	forwarding = net_pkt_forwarding(pkt);
+
+	if (orig_iface != NULL) {
+		forwarding = IS_ENABLED(CONFIG_NET_ROUTING) &&
+			     orig_iface != nbr->iface;
+		net_pkt_set_forwarding(pkt, forwarding);
+	}
+
+	if (forwarding) {
+		if (NET_IPV6_HDR(pkt)->hop_limit <= 1U) {
+			err = -ETIMEDOUT;
+			goto error;
+		}
+
+		NET_IPV6_HDR(pkt)->hop_limit--;
+		net_pkt_set_ipv6_hop_limit(pkt, NET_IPV6_HDR(pkt)->hop_limit);
+	}
 
 	/* Set the destination and source ll address in the packet.
 	 * We set the destination address to be the nexthop recipient.
@@ -1091,6 +1111,8 @@ error:
 
 int net_route_packet_if(struct net_pkt *pkt, struct net_if *iface)
 {
+	bool forwarding = false;
+
 	/* The destination is reachable via iface. But since no valid nexthop
 	 * is known, net_pkt_lladdr_dst(pkt) cannot be set here.
 	 */
@@ -1098,7 +1120,11 @@ int net_route_packet_if(struct net_pkt *pkt, struct net_if *iface)
 	net_pkt_set_orig_iface(pkt, net_pkt_iface(pkt));
 	net_pkt_set_iface(pkt, iface);
 
-	net_pkt_set_forwarding(pkt, true);
+	if (IS_ENABLED(CONFIG_NET_ROUTING)) {
+		forwarding = net_pkt_orig_iface(pkt) != iface;
+	}
+
+	net_pkt_set_forwarding(pkt, forwarding);
 
 	net_pkt_lladdr_src(pkt)->addr = net_pkt_lladdr_if(pkt)->addr;
 	net_pkt_lladdr_src(pkt)->type = net_pkt_lladdr_if(pkt)->type;


### PR DESCRIPTION
Backport of the fix from #109585 to `v3.7-branch`.

Fixes: #111431