### PR TITLE
[Backport v4.4-branch] net: ip: Mark only cross-interface traffic forwarded

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -381,6 +381,13 @@ static enum net_verdict ipv6_route_packet(struct net_pkt *pkt,
 			add_route(net_pkt_orig_iface(pkt), &src_ip, 128);
 		}
 
+		if (IS_ENABLED(CONFIG_NET_ROUTING) &&
+		    net_pkt_orig_iface(pkt) != net_pkt_iface(pkt)) {
+			net_pkt_set_forwarding(pkt, true);
+		} else {
+			net_pkt_set_forwarding(pkt, false);
+		}
+
 		ret = net_route_packet(pkt, nexthop);
 		if (ret < 0) {
 			NET_DBG("Cannot re-route pkt %p via %s "

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -825,6 +825,7 @@ int net_route_mcast_forward_packet(struct net_pkt *pkt, struct net_ipv6_hdr *hdr
 	 * a direct access to the buffer there is no need to perform read/write operations.
 	 */
 	hdr->hop_limit--;
+	net_pkt_set_ipv6_hop_limit(pkt, hdr->hop_limit);
 
 	ARRAY_FOR_EACH_PTR(route_mcast_entries, route) {
 		struct net_pkt *pkt_cpy = NULL;
@@ -1063,7 +1064,9 @@ static bool is_ll_addr_supported(struct net_if *iface)
 int net_route_packet(struct net_pkt *pkt, struct net_in6_addr *nexthop)
 {
 	struct net_linkaddr *lladdr = NULL;
+	struct net_if *orig_iface;
 	struct net_nbr *nbr;
+	bool forwarding;
 	int err;
 
 	net_ipv6_nbr_lock();
@@ -1104,7 +1107,24 @@ int net_route_packet(struct net_pkt *pkt, struct net_in6_addr *nexthop)
 		}
 	}
 
-	net_pkt_set_forwarding(pkt, true);
+	orig_iface = net_pkt_orig_iface(pkt);
+	forwarding = net_pkt_forwarding(pkt);
+
+	if (orig_iface != NULL) {
+		forwarding = IS_ENABLED(CONFIG_NET_ROUTING) &&
+			     orig_iface != nbr->iface;
+		net_pkt_set_forwarding(pkt, forwarding);
+	}
+
+	if (forwarding) {
+		if (NET_IPV6_HDR(pkt)->hop_limit <= 1U) {
+			err = -ETIMEDOUT;
+			goto error;
+		}
+
+		NET_IPV6_HDR(pkt)->hop_limit--;
+		net_pkt_set_ipv6_hop_limit(pkt, NET_IPV6_HDR(pkt)->hop_limit);
+	}
 
 	/* Set the source ll address of the iface (if relevant) and the
 	 * destination address to be the nexthop recipient.
@@ -1131,13 +1151,19 @@ error:
 
 int net_route_packet_if(struct net_pkt *pkt, struct net_if *iface)
 {
+	bool forwarding = false;
+
 	/* The destination is reachable via iface. But since no valid nexthop
 	 * is known, net_pkt_lladdr_dst(pkt) cannot be set here.
 	 */
 	net_pkt_set_orig_iface(pkt, net_pkt_iface(pkt));
 	net_pkt_set_iface(pkt, iface);
 
-	net_pkt_set_forwarding(pkt, true);
+	if (IS_ENABLED(CONFIG_NET_ROUTING)) {
+		forwarding = net_pkt_orig_iface(pkt) != iface;
+	}
+
+	net_pkt_set_forwarding(pkt, forwarding);
 
 	/* Set source LL address if only if relevant */
 	if (is_ll_addr_supported(iface)) {


### PR DESCRIPTION
Backport of the fix from #109585 to `v4.4-branch`.

Fixes: #111431