### PR TITLE
cmake: armclang: fix C++ header search and AEABI flags

### DIFF
--- a/cmake/compiler/armclang/compiler_flags.cmake
+++ b/cmake/compiler/armclang/compiler_flags.cmake
@@ -7,6 +7,7 @@ set_property(TARGET asm APPEND PROPERTY required "--target=${triple}")
 
 # Only the ARM Compiler C library is currently supported.
 set_compiler_property(PROPERTY nostdinc)
+set_compiler_property(PROPERTY nostdinc_include)
 
 # Remove after testing that -Wshadow works
 set_compiler_property(PROPERTY warning_shadow_variables)

--- a/cmake/compiler/armclang/target.cmake
+++ b/cmake/compiler/armclang/target.cmake
@@ -65,7 +65,10 @@ string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 if(CONFIG_ARMCLANG_STD_LIBC)
   # Zephyr requires AEABI portability to ensure correct functioning of the C
   # library, for example error numbers, errno.h.
-  list(APPEND TOOLCHAIN_C_FLAGS -D_AEABI_PORTABILITY_LEVEL=1)
+  list(APPEND TOOLCHAIN_C_FLAGS
+    $<$<COMPILE_LANGUAGE:C>:-D_AEABI_PORTABILITY_LEVEL=1>
+    $<$<COMPILE_LANGUAGE:ASM>:-D_AEABI_PORTABILITY_LEVEL=1>
+  )
 endif()
 
 # The empty function is to make sure GCC runtime library flags like -lgcc are not passed.


### PR DESCRIPTION
Fixes #109007.

Avoid exporting the ARMClang builtin header path ahead of libc++ for C++ builds, and restrict `_AEABI_PORTABILITY_LEVEL=1` to C and ASM.

This restores the expected C++ standard library include behavior and avoids applying C-only AEABI portability handling to libc++.