### PR TITLE
libc: armstdc: make __aeabi_errno_addr weak

### DIFF
--- a/lib/libc/armstdc/src/libc-hooks.c
+++ b/lib/libc/armstdc/src/libc-hooks.c
@@ -21,6 +21,7 @@ void __stdout_hook_install(int (*hook)(int))
 	_stdout_hook = hook;
 }
 
+__attribute__((weak))
 volatile int *__aeabi_errno_addr(void)
 {
 	return &_current->errno_var;


### PR DESCRIPTION
Fixes #111425.

Make Zephyr's `__aeabi_errno_addr` implementation a weak fallback.

This lets the Arm runtime provide the primary definition when present and avoids multiple-definition link failures.