### PR TITLE
cmake: armlink: propagate libc++ runtime selection

### DIFF
--- a/cmake/linker/armlink/linker_flags.cmake
+++ b/cmake/linker/armlink/linker_flags.cmake
@@ -5,6 +5,10 @@
 
 set_property(TARGET linker PROPERTY undefined --undefined=)
 
+if(CONFIG_CPP AND NOT CONFIG_EXTERNAL_MODULE_LIBCPP)
+	set_property(TARGET linker PROPERTY cpp_base --stdlib=libc++)
+endif()
+
 # `armlink` does not accept -O* flags so drop flags to avoid build error.
 set_property(TARGET linker PROPERTY no_optimization "")
 set_property(TARGET linker PROPERTY optimization_debug "")

--- a/cmake/linker/armlink/target.cmake
+++ b/cmake/linker/armlink/target.cmake
@@ -78,7 +78,7 @@ function(toolchain_ld_link_elf)
     ${ZEPHYR_LIBS_OBJECTS}
     kernel
     $<TARGET_OBJECTS:${OFFSETS_LIB}>
-    --library_type=microlib
+    $<$<NOT:$<BOOL:${CONFIG_ARMCLANG_STD_LIBC}>>:--library_type=microlib>
     --entry=$<TARGET_PROPERTY:linker,ENTRY>
     "--keep=\"*.o(.init_*)\""
     "--keep=\"*.o(.device_*)\""
@@ -123,7 +123,12 @@ macro(toolchain_linker_finalize)
     set(zephyr_std_libs "${zephyr_std_libs} ${link_flag}")
   endforeach()
 
-  set(common_link "<LINK_FLAGS> <LINK_LIBRARIES> <OBJECTS> ${zephyr_std_libs} -o <TARGET>")
+  set(linker_cpp_base)
+  if(CONFIG_CPP)
+    get_property(linker_cpp_base TARGET linker PROPERTY cpp_base)
+  endif()
+
+  set(common_link "<LINK_FLAGS> <LINK_LIBRARIES> <OBJECTS> ${linker_cpp_base} ${zephyr_std_libs} -o <TARGET>")
   set(CMAKE_C_LINK_EXECUTABLE "<CMAKE_LINKER> <CMAKE_C_LINK_FLAGS> ${common_link}")
   set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_LINKER> <CMAKE_CXX_LINK_FLAGS> ${common_link}")
   set(CMAKE_ASM_LINK_EXECUTABLE "<CMAKE_LINKER> <CMAKE_ASM_LINK_FLAGS> ${common_link}")


### PR DESCRIPTION
Fixes #111440.

Propagate the libc++ runtime choice into `armlink`-driven C++ links and avoid forcing microlib when the full Arm standard C library is selected.

This keeps the linker runtime selection aligned with the configured toolchain and avoids late C++ runtime link failures.