### PR TITLE
soc: ambiq: apollo5x: fix shared_ram.ld address expression

### DIFF
--- a/soc/ambiq/apollo5x/shared_ram.ld
+++ b/soc/ambiq/apollo5x/shared_ram.ld
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-SECTION_PROLOGUE (ambiq_dma_buff, DT_CHOSEN_SRAM_ADDR + CONFIG_SOC_AMBIQ_DMA_BUFF_LOCATION (NOLOAD),)
+SECTION_PROLOGUE (ambiq_dma_buff, (DT_CHOSEN_SRAM_ADDR + CONFIG_SOC_AMBIQ_DMA_BUFF_LOCATION) (NOLOAD),)
 {
     __ambiq_dma_buff_start = .;
     KEEP(*(SORT_BY_NAME(".ambiq_dma_buff*")))


### PR DESCRIPTION
Fixes #111444.

Wrap the `ambiq_dma_buff` section address expression in parentheses so the generated linker script is accepted by `ld.lld`.

Without the extra parentheses, the expanded `SECTION_PROLOGUE` output produces invalid section address syntax for LLVM's linker.