### PR TITLE
drivers: wifi: esp32: start wifi at init for ble coexistence

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -1525,6 +1525,13 @@ static int esp32_wifi_dev_init(const struct device *dev)
 		return -EIO;
 	}
 
+	/* Start Wi-Fi early to enable coexistence for WiFi/BT operation. */
+	ret = esp_wifi_start();
+	if (ret != ESP_OK) {
+		LOG_ERR("Unable to start the Wi-Fi: %d", ret);
+		return -EIO;
+	}
+
 	if (IS_ENABLED(CONFIG_WIFI_STA_AUTO_DHCPV4)) {
 		net_mgmt_init_event_callback(&esp32_dhcp_cb, wifi_event_handler, DHCPV4_MASK);
 		net_mgmt_add_event_callback(&esp32_dhcp_cb);


### PR DESCRIPTION
Start the Wi-Fi driver during initialization so coexistence is enabled early. Without it the Wi-Fi pp task blocks at boot when BLE is also used, hanging the device.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/111138