### PR TITLE
twister: pre/post script parameters and reordering

### DIFF
--- a/doc/develop/twister/index.rst
+++ b/doc/develop/twister/index.rst
@@ -1682,6 +1682,41 @@ test can interact with all devices.
 An example multi-DUT test can be found at
 :zephyr_file:`tests/subsys/testsuite/multidut`.
 
+Scripts
+-------
+
+Twister allows to execute custom scripts before and after the execution of the tests.
+
+Four options of the hardware map file allow specifying the path to the scripts:
+- ``pre_script``: executed before flashing and connecting to serial.
+- ``pre_flash_script``: executed before flashing.
+- ``post_flash_script``: executed after flashing.
+- ``post_script``: executed after closing serial connection.
+
+The options support passing parameters (for example ``python3 pre_script.py foo bar``).
+
+.. code-block:: yaml
+
+    - connected: true
+      id: 01
+      platform: nrf52840dk/nrf52840
+      serial: /dev/ttyACM0
+      pre_script: pre_script.sh
+      pre_flash_script: pre_flash_script.sh
+      post_flash_script: post_flash_script.sh
+      post_script: post_script.sh
+
+.. code-block:: yaml
+
+    - connected: true
+      id: 01
+      platform: nrf52840dk/nrf52840
+      serial: /dev/ttyACM0
+      pre_script: python3 pre_script.py foo bar
+      pre_flash_script: python3 pre_flash_script.py foo bar
+      post_flash_script: python3 post_flash_script.py foo bar
+      post_script: python3 post_script.py foo bar
+
 Quarantine
 ----------
 

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -148,6 +148,9 @@ class HardwareAdapter(DeviceAdapter):
             logger.error(msg)
             raise TwisterHarnessException(msg)
 
+        if self.device_config.pre_flash_script:
+            self._run_custom_script(self.device_config.pre_flash_script, self.base_timeout)
+
         if self.device_config.id:
             logger.debug('Flashing device %s', self.device_config.id)
         log_command(logger, 'Flashing command', self.command, level=logging.DEBUG)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -118,6 +118,8 @@ class HardwareAdapter(DeviceAdapter):
 
     def _device_launch(self) -> None:
         """Flash and run application on a device and connect with serial port."""
+        if self.device_config.pre_script:
+            self._run_custom_script(self.device_config.pre_script, self.base_timeout)
         if self.device_config.flash_before:
             # For hardware devices with shared USB or software USB, connect after flashing.
             # Retry for up to 10 seconds for USB-CDC based devices to enumerate.
@@ -145,9 +147,6 @@ class HardwareAdapter(DeviceAdapter):
             msg = 'Flash command is empty, please verify if it was generated properly.'
             logger.error(msg)
             raise TwisterHarnessException(msg)
-
-        if self.device_config.pre_script:
-            self._run_custom_script(self.device_config.pre_script, self.base_timeout)
 
         if self.device_config.id:
             logger.debug('Flashing device %s', self.device_config.id)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import shlex
 import subprocess
 import time
 from pathlib import Path
@@ -190,7 +191,7 @@ class HardwareAdapter(DeviceAdapter):
     @staticmethod
     def _run_custom_script(script_path: str | Path, timeout: float) -> None:
         with subprocess.Popen(
-            str(script_path), stderr=subprocess.PIPE, stdout=subprocess.PIPE
+            shlex.split(str(script_path)), stderr=subprocess.PIPE, stdout=subprocess.PIPE
         ) as proc:
             try:
                 stdout, stderr = proc.communicate(timeout=timeout)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -115,6 +115,11 @@ def pytest_addoption(parser: pytest.Parser):
         help='Script executed before flashing and connecting to serial.'
     )
     twister_harness_group.addoption(
+        '--pre-flash-script',
+        metavar='PATH',
+        help='Script executed before flashing.'
+    )
+    twister_harness_group.addoption(
         '--post-flash-script',
         metavar='PATH',
         help='Script executed after flashing.'
@@ -174,6 +179,7 @@ def _normalize_paths(config: pytest.Config) -> None:
     config.option.twister_config = _normalize_path(config.option.twister_config)
     config.option.pre_script = _normalize_path(config.option.pre_script)
     config.option.post_script = _normalize_path(config.option.post_script)
+    config.option.pre_flash_script = _normalize_path(config.option.pre_flash_script)
     config.option.post_flash_script = _normalize_path(config.option.post_flash_script)
 
 

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -44,6 +44,7 @@ class DeviceConfig:
     name: str = ''
     pre_script: Path | None = None
     post_script: Path | None = None
+    pre_flash_script: Path | None = None
     post_flash_script: Path | None = None
     fixtures: list[str] = None
     extra_test_args: str = ''
@@ -151,6 +152,7 @@ class TwisterHarnessConfig:
                 flash_command=flash_command,
                 pre_script=get_path(config.option.pre_script) or get_path(dut.pre_script),
                 post_script=get_path(config.option.post_script) or get_path(dut.post_script),
+                pre_flash_script=get_path(config.option.pre_flash_script) or get_path(dut.pre_flash_script),
                 post_flash_script=get_path(config.option.post_flash_script) or get_path(dut.post_flash_script),
                 fixtures=config.option.fixtures or test_params.twister_fixtures or dut.fixtures,
                 extra_test_args=config.option.extra_test_args or test_params.extra_test_args,

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -682,7 +682,7 @@ class DeviceHandler(Handler):
 
         return ser_pty_process
 
-    def _handle_robot_test(self, harness, hardware, command, serial_device, serial_pty,
+    def _handle_robot_test(self, harness, hardware, command, serial_device, pre_flash_script,
                             post_flash_script, post_script, script_param, flash_timeout):
         """Flash device and run Robot Framework test directly without serial monitoring."""
         start_time = time.time()
@@ -690,6 +690,12 @@ class DeviceHandler(Handler):
         logger.debug(f'Flash command: {command}')
         failure_type = Handler.FailureType.NONE
         stderr = b""
+
+        if pre_flash_script:
+            timeout = 30
+            if script_param:
+                timeout = script_param.get("pre_flash_timeout", timeout)
+            self.run_custom_script(pre_flash_script, timeout)
 
         try:
             with subprocess.Popen(
@@ -744,11 +750,13 @@ class DeviceHandler(Handler):
     def handle(self, harness):
         robot_test = getattr(harness, "is_robot_test", False) is True
         hardware: CompoundHardwareData = self.instance.reserved_duts[0]
-
-        # Run pre-script BEFORE starting serial PTY to avoid conflicts
         pre_script = hardware.pre_script
+        pre_flash_script = hardware.pre_flash_script
+        post_flash_script = hardware.post_flash_script
+        post_script = hardware.post_script
         script_param = hardware.script_param
 
+        # Run pre-script BEFORE starting serial PTY to avoid conflicts
         if pre_script:
             timeout = 30
             if script_param:
@@ -768,9 +776,6 @@ class DeviceHandler(Handler):
 
         command = self._create_command(runner, hardware)
 
-        post_flash_script = hardware.post_flash_script
-        post_script = hardware.post_script
-
         flash_timeout = hardware.flash_timeout
         if hardware.flash_with_test:
             flash_timeout += self.get_test_timeout()
@@ -779,7 +784,7 @@ class DeviceHandler(Handler):
             # For robot tests: flash the device, then hand off to Robot Framework
             # directly. Robot Framework will open the serial port itself.
             self._handle_robot_test(
-                harness, hardware, command, serial_device, serial_pty,
+                harness, hardware, command, serial_device, pre_flash_script,
                 post_flash_script, post_script, script_param, flash_timeout
             )
             return
@@ -812,6 +817,13 @@ class DeviceHandler(Handler):
         d_log = f"{self.instance.build_dir}/device.log"
         logger.debug(f'Flash command: {command}', )
         failure_type = Handler.FailureType.NONE
+
+        if pre_flash_script:
+            timeout = 30
+            if script_param:
+                timeout = script_param.get("pre_flash_timeout", timeout)
+            self.run_custom_script(pre_flash_script, timeout)
+
         try:
             stdout = stderr = None
             with subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -521,8 +521,10 @@ class DeviceHandler(Handler):
                     break
 
     @staticmethod
-    def run_custom_script(script, timeout):
-        with subprocess.Popen(script, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
+    def run_custom_script(script_path: str | Path, timeout: float):
+        with subprocess.Popen(
+            shlex.split(str(script_path)), stderr=subprocess.PIPE, stdout=subprocess.PIPE
+        ) as proc:
             try:
                 stdout, stderr = proc.communicate(timeout=timeout)
                 logger.debug(stdout.decode())
@@ -532,7 +534,7 @@ class DeviceHandler(Handler):
             except subprocess.TimeoutExpired:
                 proc.kill()
                 proc.communicate()
-                logger.error(f"{script} timed out")
+                logger.error(f"{script_path} timed out")
 
     def _create_flash_command(self, hardware):
         flash_command = next(csv.reader([self.options.flash_command]))

--- a/scripts/pylib/twister/twisterlib/hardwaredata.py
+++ b/scripts/pylib/twister/twisterlib/hardwaredata.py
@@ -22,6 +22,7 @@ class HardwareData:
     runner_params: str | None = None
     pre_script: str | None = None
     post_script: str | None = None
+    pre_flash_script: str | None = None
     post_flash_script: str | None = None
     script_param: str | None = None
     runner: str | None = None

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -248,9 +248,10 @@ class HardwareMap:
         duts = scl.yaml_load_verify(map_file, hwm_schema)
         for dut in duts:
             pre_script = dut.get('pre_script')
-            script_param = dut.get('script_param')
             post_script = dut.get('post_script')
+            pre_flash_script = dut.get('pre_flash_script')
             post_flash_script = dut.get('post_flash_script')
+            script_param = dut.get('script_param')
             flash_timeout = dut.get('flash_timeout') or self.options.device_flash_timeout
             flash_with_test = dut.get('flash_with_test')
             if flash_with_test is None:
@@ -288,10 +289,11 @@ class HardwareMap:
                               serial_baud=serial_baud,
                               connected=connected,
                               pre_script=pre_script,
-                              flash_before=flash_before,
                               post_script=post_script,
+                              pre_flash_script=pre_flash_script,
                               post_flash_script=post_flash_script,
                               script_param=script_param,
+                              flash_before=flash_before,
                               flash_timeout=flash_timeout,
                               flash_with_test=flash_with_test,
                               west_flash_cmd=west_flash_cmd)

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -30,11 +30,13 @@ items:
       type: integer
     serial_baud:
       type: integer
+    pre_script:
+      type: string
     post_script:
       type: string
-    post_flash_script:
+    pre_flash_script:
       type: string
-    pre_script:
+    post_flash_script:
       type: string
     fixtures:
       type: array
@@ -52,6 +54,8 @@ items:
         pre_script_timeout:
           type: integer
         post_script_timeout:
+          type: integer
+        pre_flash_timeout:
           type: integer
         post_flash_timeout:
           type: integer

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1167,6 +1167,7 @@ def test_devicehandler_handle(
         serial='dummy serial',
         pre_script='dummy pre script',
         post_script='dummy post script',
+        pre_flash_script='dummy pre flash script',
         post_flash_script='dummy post flash script',
         flash_timeout=60,
         flash_with_test=True
@@ -1226,6 +1227,7 @@ def test_devicehandler_handle(
 
     handler.run_custom_script.assert_has_calls([
         mock.call('dummy pre script', mock.ANY),
+        mock.call('dummy pre flash script', mock.ANY),
         mock.call('dummy post flash script', mock.ANY),
         mock.call('dummy post script', mock.ANY)
     ])

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -51,14 +51,16 @@ TESTDATA_1 = [
             'runner_params': ['dummy', 'runner', 'params'],
             'pre_script': 'dummy pre script',
             'post_script': 'dummy post script',
+            'pre_flash_script': 'dummy pre flash script',
             'post_flash_script': 'dummy post flash script',
             'runner': 'dummy runner',
             'flash_timeout': 30,
             'flash_with_test': True,
             'script_param': {
                 'pre_script_timeout' : 30,
-                'post_flash_timeout' : 30,
                 'post_script_timeout' : 30,
+                'pre_flash_timeout' : 30,
+                'post_flash_timeout' : 30,
                 }
         },
         {
@@ -72,14 +74,16 @@ TESTDATA_1 = [
             'runner_params': ['dummy', 'runner', 'params'],
             'pre_script': 'dummy pre script',
             'post_script': 'dummy post script',
+            'pre_flash_script': 'dummy pre flash script',
             'post_flash_script': 'dummy post flash script',
             'runner': 'dummy runner',
             'flash_timeout': 30,
             'flash_with_test': True,
             'script_param': {
                 'pre_script_timeout' : 30,
-                'post_flash_timeout' : 30,
                 'post_script_timeout' : 30,
+                'pre_flash_timeout' : 30,
+                'post_flash_timeout' : 30,
                 }
         },
         '<dummy platform (dummy product) on dummy serial>'


### PR DESCRIPTION
These improvements allow:
- To pass parameters from the hardware map file to the pre/post scripts, which is much convenient to use the same script multiple times with different arguments (for example)
- To execute the pre-script first, before flashing and before connecting, whatever the configuration of `flash_before` is, which make more sense, and this is also what is describe in the code. It can be used to power on the target for example so we need it before flashing and connecting.
- Introduce the pre-flash-script to replace old pre-script location so that we can keep the possibility to call some scripts before flashing. This means we now have four scripts called in order pre-script, pre-flash-script, post-flash-script and post-script. Each call once.

It is tested with the following command line: `west twister --no-clean -vv -ll debug -T samples/hello_world -T samples/subsys/testsuite/pytest/shell --device-testing --hardware-map hwmap.yaml --force-platform`

And the following hardware map file:
```
- connected: true
  id: 066EFF535550755187245544
  platform: nucleo_l476rg
  product: STM32 STLink
  runner: openocd
  serial: /dev/ttyACM0
  pre_script: python3 /home/jguittet/script.py pre_script foo bar
  pre_flash_script: python3 /home/jguittet/script.py pre_flash_script foo bar
  post_flash_script: python3 /home/jguittet/script.py post_flash_script foo bar
  post_script: python3 /home/jguittet/script.py post_script foo bar
```

And with the following python script `/home/jguittet/script.py`:
```
import sys

print("Arguments received:")

for i, arg in enumerate(sys.argv):
    print(f"argv[{i}] = {arg}")
```

The output log show the scripts being called properly:
```
(.venv) jguittet@WIPC26010524:~/zephyrproject/zephyr$ west twister --no-clean -vv -ll debug -T samples/hello_world -T samples/subsys/testsuite/pytest/shell --device-testing --hardware-map hwmap.yaml --force-platform
Keeping artifacts untouched
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-6523-g9851238061b0
DEBUG   - Running cmake script /home/jguittet/zephyrproject/zephyr/cmake/verify-toolchain.cmake
DEBUG   - Calling cmake: /usr/bin/cmake -DFORMAT=json -P /home/jguittet/zephyrproject/zephyr/cmake/verify-toolchain.cmake
DEBUG   - Finished running /home/jguittet/zephyrproject/zephyr/cmake/verify-toolchain.cmake
INFO    - Using 'zephyr/gnu' toolchain variant.
DEBUG   - Reading testsuite configuration files under /home/jguittet/zephyrproject/zephyr/samples/hello_world...
DEBUG   - Found possible testsuite in /home/jguittet/zephyrproject/zephyr/samples/hello_world
DEBUG   - Reading testsuite configuration files under /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell...
DEBUG   - Found possible testsuite in /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell
DEBUG   - No duplicates found.
DEBUG   -  platform filter: ['nucleo_l476rg']
DEBUG   - platform_pattern: []
DEBUG   -    vendor filter: []
DEBUG   -      arch_filter: None
DEBUG   -       tag_filter: None
DEBUG   -      exclude_tag: None
DEBUG   - Checking platform filter: ['nucleo_l476rg']
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.04 seconds

Device testing on:

| Platform                  | ID                       | Serial device   |
|---------------------------|--------------------------|-----------------|
| nucleo_l476rg/stm32l476xx | 066EFF535550755187245544 | /dev/ttyACM0    |

INFO    - JOBS: 16
INFO    - Adding tasks to the queue...
DEBUG   - adding nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.basic.helloworld
DEBUG   - adding nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.pytest.shell
DEBUG   - adding nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.pytest.shell.vt100_colors_off
DEBUG   - adding nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.harness.shell
INFO    - Added initial list of jobs to queue
DEBUG   - Running cmake on /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx
DEBUG   - Calling cmake: /usr/bin/cmake -B/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.harness.shell -DTC_RUNID=cd29c874eba1902ab6cbca3f474968bd -DTC_NAME=sample.harness.shell -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DEXTRA_GEN_EDT_ARGS=--edtlib-Werror -GNinja -DPython3_EXECUTABLE=/home/jguittet/zephyrproject/.venv/bin/python3 -DZEPHYR_TOOLCHAIN_VARIANT=zephyr/gnu -S/home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell -DBOARD=nucleo_l476rg/stm32l476xx -DMODULES=dts,kconfig -P/home/jguittet/zephyrproject/zephyr/cmake/package_helper.cmake
DEBUG   - Running cmake on /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx
DEBUG   - Calling cmake: /usr/bin/cmake -B/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell.vt100_colors_off -DTC_RUNID=0d2ea70907ec50f2e5f79fa0526846e4 -DTC_NAME=sample.pytest.shell.vt100_colors_off -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DEXTRA_GEN_EDT_ARGS=--edtlib-Werror -GNinja -DPython3_EXECUTABLE=/home/jguittet/zephyrproject/.venv/bin/python3 -DZEPHYR_TOOLCHAIN_VARIANT=zephyr/gnu -S/home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell -DOVERLAY_CONFIG=/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell.vt100_colors_off/twister/testsuite_extra.conf -DBOARD=nucleo_l476rg/stm32l476xx -DMODULES=dts,kconfig -P/home/jguittet/zephyrproject/zephyr/cmake/package_helper.cmake
DEBUG   - Running cmake on /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx
DEBUG   - Calling cmake: /usr/bin/cmake -B/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell -DTC_RUNID=379f170ca6fb4549ef84ba70ac6eb79d -DTC_NAME=sample.pytest.shell -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DEXTRA_GEN_EDT_ARGS=--edtlib-Werror -GNinja -DPython3_EXECUTABLE=/home/jguittet/zephyrproject/.venv/bin/python3 -DZEPHYR_TOOLCHAIN_VARIANT=zephyr/gnu -S/home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell -DBOARD=nucleo_l476rg/stm32l476xx -DMODULES=dts,kconfig -P/home/jguittet/zephyrproject/zephyr/cmake/package_helper.cmake
DEBUG   - Running cmake on /home/jguittet/zephyrproject/zephyr/samples/hello_world for nucleo_l476rg/stm32l476xx
DEBUG   - Calling cmake: /usr/bin/cmake -B/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/hello_world/sample.basic.helloworld -DTC_RUNID=5c25972e960757d1fee8eae7e3e783f2 -DTC_NAME=sample.basic.helloworld -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DEXTRA_GEN_EDT_ARGS=--edtlib-Werror -GNinja -DPython3_EXECUTABLE=/home/jguittet/zephyrproject/.venv/bin/python3 -DZEPHYR_TOOLCHAIN_VARIANT=zephyr/gnu -S/home/jguittet/zephyrproject/zephyr/samples/hello_world -DBOARD=nucleo_l476rg/stm32l476xx
DEBUG   - Launched 16 jobs
DEBUG   - Finished running cmake /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx in 51.80 seconds
DEBUG   - Finished running cmake /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx in 51.80 seconds
DEBUG   - Running cmake on /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx
DEBUG   - Running cmake on /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx
DEBUG   - Calling cmake: /usr/bin/cmake -B/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell.vt100_colors_off -DTC_RUNID=0d2ea70907ec50f2e5f79fa0526846e4 -DTC_NAME=sample.pytest.shell.vt100_colors_off -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DEXTRA_GEN_EDT_ARGS=--edtlib-Werror -GNinja -DPython3_EXECUTABLE=/home/jguittet/zephyrproject/.venv/bin/python3 -DZEPHYR_TOOLCHAIN_VARIANT=zephyr/gnu -S/home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell -DOVERLAY_CONFIG=/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell.vt100_colors_off/twister/testsuite_extra.conf -DBOARD=nucleo_l476rg/stm32l476xx
DEBUG   - Calling cmake: /usr/bin/cmake -B/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell -DTC_RUNID=379f170ca6fb4549ef84ba70ac6eb79d -DTC_NAME=sample.pytest.shell -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DEXTRA_GEN_EDT_ARGS=--edtlib-Werror -GNinja -DPython3_EXECUTABLE=/home/jguittet/zephyrproject/.venv/bin/python3 -DZEPHYR_TOOLCHAIN_VARIANT=zephyr/gnu -S/home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell -DBOARD=nucleo_l476rg/stm32l476xx
DEBUG   - Finished running cmake /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx in 51.90 seconds
DEBUG   - Running cmake on /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx
DEBUG   - Calling cmake: /usr/bin/cmake -B/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.harness.shell -DTC_RUNID=cd29c874eba1902ab6cbca3f474968bd -DTC_NAME=sample.harness.shell -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DEXTRA_GEN_EDT_ARGS=--edtlib-Werror -GNinja -DPython3_EXECUTABLE=/home/jguittet/zephyrproject/.venv/bin/python3 -DZEPHYR_TOOLCHAIN_VARIANT=zephyr/gnu -S/home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell -DBOARD=nucleo_l476rg/stm32l476xx
DEBUG   - Finished running cmake /home/jguittet/zephyrproject/zephyr/samples/hello_world for nucleo_l476rg/stm32l476xx in 58.48 seconds
DEBUG   - build test: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.basic.helloworld
DEBUG   - Building /home/jguittet/zephyrproject/zephyr/samples/hello_world for nucleo_l476rg/stm32l476xx
DEBUG   - Running /usr/bin/cmake --build /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/hello_world/sample.basic.helloworld
DEBUG   - Finished running cmake /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx in 48.68 seconds
DEBUG   - Finished running cmake /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx in 48.57 seconds
DEBUG   - Finished running cmake /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx in 48.67 seconds
DEBUG   - build test: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.pytest.shell
DEBUG   - Building /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx
DEBUG   - Running /usr/bin/cmake --build /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell
DEBUG   - build test: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.harness.shell
DEBUG   - Building /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx
DEBUG   - build test: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.pytest.shell.vt100_colors_off
DEBUG   - Building /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx
DEBUG   - Running /usr/bin/cmake --build /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.harness.shell
DEBUG   - Running /usr/bin/cmake --build /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell.vt100_colors_off
DEBUG   - Finished building /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx in 23.89 seconds
DEBUG   - Finished building /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx in 23.89 seconds
DEBUG   - Retain DUT:nucleo_l476rg/stm32l476xx, Id:066EFF535550755187245544, counter:1, failures:0
DEBUG   - run test: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.harness.shell
DEBUG   - Reset instance status from 'passed' to None before run.
DEBUG   - Configuration saved to /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.harness.shell/twister_pytest_config.yaml
DEBUG   - Finished building /home/jguittet/zephyrproject/zephyr/samples/hello_world for nucleo_l476rg/stm32l476xx in 65.99 seconds
DEBUG   - Running pytest command: export PYTHONPATH=/home/jguittet/zephyrproject/zephyr/scripts/pylib/pytest-twister-harness/src:${PYTHONPATH} && /home/jguittet/zephyrproject/.venv/bin/python3 -m pytest -s -v --log-cli-level=DEBUG '--log-cli-format=%(levelname)s: %(message)s' --junit-xml=/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.harness.shell/report.xml --twister-config=/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.harness.shell/twister_pytest_config.yaml /home/jguittet/zephyrproject/zephyr/scripts/pylib/shell-twister-harness --testdata=/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.harness.shell/test_shell.yml -p twister_harness.plugin
DEBUG   - Finished building /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell for nucleo_l476rg/stm32l476xx in 23.93 seconds
DEBUG   - PYTEST: ============================= test session starts ==============================
DEBUG   - PYTEST: platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /home/jguittet/zephyrproject/.venv/bin/python3
DEBUG   - PYTEST: cachedir: .pytest_cache
DEBUG   - PYTEST: rootdir: /home/jguittet/zephyrproject/zephyr
DEBUG   - PYTEST: collecting ... collected 1 item
DEBUG   - PYTEST: scripts/pylib/shell-twister-harness/test_shell.py::test_shell_harness
DEBUG   - PYTEST: -------------------------------- live log setup --------------------------------
DEBUG   - PYTEST: DEBUG: Get device type "hardware"
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = pre_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Opening serial connection for /dev/ttyACM0
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = pre_flash_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Flashing device 066EFF535550755187245544
DEBUG   - PYTEST: DEBUG: Flashing command: /home/jguittet/zephyrproject/.venv/bin/west flash --no-rebuild --build-dir /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.harness.shell --runner openocd -- --cmd-pre-init 'hla_serial 066EFF535550755187245544'
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = post_flash_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Flashing finished
DEBUG   - PYTEST: DEBUG: Found matching key: CONFIG_SHELL_PROMPT_UART="uart:~$ "
DEBUG   - PYTEST: INFO: Wait for prompt
DEBUG   - PYTEST: DEBUG: Got prompt
DEBUG   - PYTEST: -------------------------------- live log call ---------------------------------
DEBUG   - PYTEST: INFO: send command: kernel cycles
DEBUG   - PYTEST: DEBUG: #: uart:~$ kernel cycles
DEBUG   - PYTEST: DEBUG: #: cycles: 59869785 hw cycles
DEBUG   - PYTEST: DEBUG: #: uart:~$ 
DEBUG   - PYTEST: INFO: response is valid
DEBUG   - PYTEST: INFO: send command: kernel version
DEBUG   - PYTEST: DEBUG: #: uart:~$ kernel version
DEBUG   - PYTEST: DEBUG: #: Zephyr version 4.4.99
DEBUG   - PYTEST: DEBUG: #: uart:~$ 
DEBUG   - PYTEST: INFO: response is valid
DEBUG   - PYTEST: PASSED
DEBUG   - PYTEST: ------------------------------ live log teardown -------------------------------
DEBUG   - PYTEST: DEBUG: Closed serial connection for /dev/ttyACM0
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = post_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: - generated xml file: /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.harness.shell/report.xml -
DEBUG   - PYTEST: ============================== 1 passed in 7.24s ===============================
DEBUG   - run status: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.harness.shell passed
DEBUG   - Release DUT:nucleo_l476rg/stm32l476xx, Id:066EFF535550755187245544, counter:1, failures:0
INFO    - 1/4 nucleo_l476rg/stm32l476xx sample.harness.shell                               PASSED (device: 066EFF535550755187245544, 7.243s <zephyr/gnu>)
INFO    -                                    sample.harness.shell.test_shell_harness                                     PASSED      
DEBUG   - Retain DUT:nucleo_l476rg/stm32l476xx, Id:066EFF535550755187245544, counter:2, failures:0
DEBUG   - run test: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.pytest.shell
DEBUG   - Reset instance status from 'passed' to None before run.
DEBUG   - Configuration saved to /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell/twister_pytest_config.yaml
DEBUG   - Running pytest command: export PYTHONPATH=/home/jguittet/zephyrproject/zephyr/scripts/pylib/pytest-twister-harness/src:${PYTHONPATH} && /home/jguittet/zephyrproject/.venv/bin/python3 -m pytest -s -v --log-cli-level=DEBUG '--log-cli-format=%(levelname)s: %(message)s' --junit-xml=/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell/report.xml --twister-config=/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell/twister_pytest_config.yaml /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell/pytest -p twister_harness.plugin
DEBUG   - PYTEST: ============================= test session starts ==============================
DEBUG   - PYTEST: platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /home/jguittet/zephyrproject/.venv/bin/python3
DEBUG   - PYTEST: cachedir: .pytest_cache
DEBUG   - PYTEST: rootdir: /home/jguittet/zephyrproject/zephyr
DEBUG   - PYTEST: collecting ... collected 2 items
DEBUG   - PYTEST: samples/subsys/testsuite/pytest/shell/pytest/test_shell.py::test_shell_print_help
DEBUG   - PYTEST: -------------------------------- live log setup --------------------------------
DEBUG   - PYTEST: DEBUG: Get device type "hardware"
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = pre_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Opening serial connection for /dev/ttyACM0
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = pre_flash_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Flashing device 066EFF535550755187245544
DEBUG   - PYTEST: DEBUG: Flashing command: /home/jguittet/zephyrproject/.venv/bin/west flash --no-rebuild --build-dir /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell --runner openocd -- --cmd-pre-init 'hla_serial 066EFF535550755187245544'
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = post_flash_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Flashing finished
DEBUG   - PYTEST: DEBUG: Found matching key: CONFIG_SHELL_PROMPT_UART="uart:~$ "
DEBUG   - PYTEST: INFO: Wait for prompt
DEBUG   - PYTEST: DEBUG: Got prompt
DEBUG   - PYTEST: -------------------------------- live log call ---------------------------------
DEBUG   - PYTEST: INFO: send "help" command
DEBUG   - PYTEST: DEBUG: #: uart:~$ help
DEBUG   - PYTEST: DEBUG: #: Please press the <Tab> button to see all available commands.
DEBUG   - PYTEST: DEBUG: #: You can also use the <Tab> button to prompt or auto-complete all commands or its subcommands.
DEBUG   - PYTEST: DEBUG: #: You can try to call commands with <-h> or <--help> parameter for more information.
DEBUG   - PYTEST: DEBUG: #: Shell supports following meta-keys:
DEBUG   - PYTEST: DEBUG: #:   Ctrl + (a key from: abcdefklnptuw)
DEBUG   - PYTEST: DEBUG: #:   Alt  + (a key from: bf)
DEBUG   - PYTEST: DEBUG: #: Please refer to shell documentation for more details.
DEBUG   - PYTEST: DEBUG: #: Available commands:
DEBUG   - PYTEST: DEBUG: #:   clear    : Clear screen.
DEBUG   - PYTEST: DEBUG: #:   date     : Date commands
DEBUG   - PYTEST: DEBUG: #:   device   : Device commands
DEBUG   - PYTEST: DEBUG: #:   devmem   : Read/write physical memory
DEBUG   - PYTEST: DEBUG: #:              Usage:
DEBUG   - PYTEST: DEBUG: #:              Read memory at address with optional width:
DEBUG   - PYTEST: DEBUG: #:              devmem <address> [<width>]
DEBUG   - PYTEST: DEBUG: #:              Write memory at address with mandatory width and value:
DEBUG   - PYTEST: DEBUG: #:              devmem <address> <width> <value>
DEBUG   - PYTEST: DEBUG: #:   help     : Prints the help message.
DEBUG   - PYTEST: DEBUG: #:   history  : Command history.
DEBUG   - PYTEST: DEBUG: #:   kernel   : Kernel commands
DEBUG   - PYTEST: DEBUG: #:   rem      : Ignore lines beginning with 'rem '
DEBUG   - PYTEST: DEBUG: #:   resize   : Console gets terminal screen size or assumes default in case the
DEBUG   - PYTEST: DEBUG: #:              readout fails. It must be executed after each terminal width change
DEBUG   - PYTEST: DEBUG: #:              to ensure correct text display.
DEBUG   - PYTEST: DEBUG: #:   retval   : Print return value of most recent command
DEBUG   - PYTEST: DEBUG: #:   shell    : Useful, not Unix-like shell commands.
DEBUG   - PYTEST: DEBUG: #: uart:~$ 
DEBUG   - PYTEST: INFO: response is valid
DEBUG   - PYTEST: PASSED
DEBUG   - PYTEST: ------------------------------ live log teardown -------------------------------
DEBUG   - PYTEST: DEBUG: Closed serial connection for /dev/ttyACM0
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = post_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: samples/subsys/testsuite/pytest/shell/pytest/test_shell.py::test_shell_print_version
DEBUG   - PYTEST: -------------------------------- live log setup --------------------------------
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = pre_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Opening serial connection for /dev/ttyACM0
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = pre_flash_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Flashing device 066EFF535550755187245544
DEBUG   - PYTEST: DEBUG: Flashing command: /home/jguittet/zephyrproject/.venv/bin/west flash --no-rebuild --build-dir /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell --runner openocd -- --cmd-pre-init 'hla_serial 066EFF535550755187245544'
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = post_flash_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Flashing finished
DEBUG   - PYTEST: DEBUG: Found matching key: CONFIG_SHELL_PROMPT_UART="uart:~$ "
DEBUG   - PYTEST: INFO: Wait for prompt
DEBUG   - PYTEST: DEBUG: Got prompt
DEBUG   - PYTEST: -------------------------------- live log call ---------------------------------
DEBUG   - PYTEST: INFO: send "kernel version" command
DEBUG   - PYTEST: DEBUG: #: uart:~$ kernel version
DEBUG   - PYTEST: DEBUG: #: Zephyr version 4.4.99
DEBUG   - PYTEST: DEBUG: #: uart:~$ 
DEBUG   - PYTEST: INFO: response is valid
DEBUG   - PYTEST: PASSED
DEBUG   - PYTEST: ------------------------------ live log teardown -------------------------------
DEBUG   - PYTEST: DEBUG: Closed serial connection for /dev/ttyACM0
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = post_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: - generated xml file: /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell/report.xml -
DEBUG   - PYTEST: ============================== 2 passed in 6.42s ===============================
DEBUG   - run status: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.pytest.shell passed
DEBUG   - Release DUT:nucleo_l476rg/stm32l476xx, Id:066EFF535550755187245544, counter:2, failures:0
INFO    - 2/4 nucleo_l476rg/stm32l476xx sample.pytest.shell                                PASSED (device: 066EFF535550755187245544, 6.419s <zephyr/gnu>)
INFO    -                                    sample.pytest.shell.test_shell_print_help                                   PASSED      
INFO    -                                    sample.pytest.shell.test_shell_print_version                                PASSED      
DEBUG   - Retain DUT:nucleo_l476rg/stm32l476xx, Id:066EFF535550755187245544, counter:3, failures:0
DEBUG   - run test: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.pytest.shell.vt100_colors_off
DEBUG   - Reset instance status from 'passed' to None before run.
DEBUG   - Configuration saved to /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell.vt100_colors_off/twister_pytest_config.yaml
DEBUG   - Running pytest command: export PYTHONPATH=/home/jguittet/zephyrproject/zephyr/scripts/pylib/pytest-twister-harness/src:${PYTHONPATH} && /home/jguittet/zephyrproject/.venv/bin/python3 -m pytest -s -v --log-cli-level=DEBUG '--log-cli-format=%(levelname)s: %(message)s' --junit-xml=/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell.vt100_colors_off/report.xml --twister-config=/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell.vt100_colors_off/twister_pytest_config.yaml /home/jguittet/zephyrproject/zephyr/samples/subsys/testsuite/pytest/shell/pytest -p twister_harness.plugin
DEBUG   - PYTEST: ============================= test session starts ==============================
DEBUG   - PYTEST: platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /home/jguittet/zephyrproject/.venv/bin/python3
DEBUG   - PYTEST: cachedir: .pytest_cache
DEBUG   - PYTEST: rootdir: /home/jguittet/zephyrproject/zephyr
DEBUG   - PYTEST: collecting ... collected 2 items
DEBUG   - PYTEST: samples/subsys/testsuite/pytest/shell/pytest/test_shell.py::test_shell_print_help
DEBUG   - PYTEST: -------------------------------- live log setup --------------------------------
DEBUG   - PYTEST: DEBUG: Get device type "hardware"
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = pre_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Opening serial connection for /dev/ttyACM0
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = pre_flash_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Flashing device 066EFF535550755187245544
DEBUG   - PYTEST: DEBUG: Flashing command: /home/jguittet/zephyrproject/.venv/bin/west flash --no-rebuild --build-dir /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell.vt100_colors_off --runner openocd -- --cmd-pre-init 'hla_serial 066EFF535550755187245544'
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = post_flash_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Flashing finished
DEBUG   - PYTEST: DEBUG: Found matching key: CONFIG_SHELL_PROMPT_UART="uart:~$ "
DEBUG   - PYTEST: INFO: Wait for prompt
DEBUG   - PYTEST: DEBUG: Got prompt
DEBUG   - PYTEST: -------------------------------- live log call ---------------------------------
DEBUG   - PYTEST: INFO: send "help" command
DEBUG   - PYTEST: DEBUG: #: uart:~$ help
DEBUG   - PYTEST: DEBUG: #: Please press the <Tab> button to see all available commands.
DEBUG   - PYTEST: DEBUG: #: You can also use the <Tab> button to prompt or auto-complete all commands or its subcommands.
DEBUG   - PYTEST: DEBUG: #: You can try to call commands with <-h> or <--help> parameter for more information.
DEBUG   - PYTEST: DEBUG: #: Shell supports following meta-keys:
DEBUG   - PYTEST: DEBUG: #:   Ctrl + (a key from: abcdefklnptuw)
DEBUG   - PYTEST: DEBUG: #:   Alt  + (a key from: bf)
DEBUG   - PYTEST: DEBUG: #: Please refer to shell documentation for more details.
DEBUG   - PYTEST: DEBUG: #: Available commands:
DEBUG   - PYTEST: DEBUG: #:   clear    : Clear screen.
DEBUG   - PYTEST: DEBUG: #:   date     : Date commands
DEBUG   - PYTEST: DEBUG: #:   device   : Device commands
DEBUG   - PYTEST: DEBUG: #:   devmem   : Read/write physical memory
DEBUG   - PYTEST: DEBUG: #:              Usage:
DEBUG   - PYTEST: DEBUG: #:              Read memory at address with optional width:
DEBUG   - PYTEST: DEBUG: #:              devmem <address> [<width>]
DEBUG   - PYTEST: DEBUG: #:              Write memory at address with mandatory width and value:
DEBUG   - PYTEST: DEBUG: #:              devmem <address> <width> <value>
DEBUG   - PYTEST: DEBUG: #:   help     : Prints the help message.
DEBUG   - PYTEST: DEBUG: #:   history  : Command history.
DEBUG   - PYTEST: DEBUG: #:   kernel   : Kernel commands
DEBUG   - PYTEST: DEBUG: #:   rem      : Ignore lines beginning with 'rem '
DEBUG   - PYTEST: DEBUG: #:   resize   : Console gets terminal screen size or assumes default in case the
DEBUG   - PYTEST: DEBUG: #:              readout fails. It must be executed after each terminal width change
DEBUG   - PYTEST: DEBUG: #:              to ensure correct text display.
DEBUG   - PYTEST: DEBUG: #:   retval   : Print return value of most recent command
DEBUG   - PYTEST: DEBUG: #:   shell    : Useful, not Unix-like shell commands.
DEBUG   - PYTEST: DEBUG: #: uart:~$
DEBUG   - PYTEST: INFO: response is valid
DEBUG   - PYTEST: PASSED
DEBUG   - PYTEST: ------------------------------ live log teardown -------------------------------
DEBUG   - PYTEST: DEBUG: Closed serial connection for /dev/ttyACM0
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = post_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: samples/subsys/testsuite/pytest/shell/pytest/test_shell.py::test_shell_print_version
DEBUG   - PYTEST: -------------------------------- live log setup --------------------------------
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = pre_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Opening serial connection for /dev/ttyACM0
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = pre_flash_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Flashing device 066EFF535550755187245544
DEBUG   - PYTEST: DEBUG: Flashing command: /home/jguittet/zephyrproject/.venv/bin/west flash --no-rebuild --build-dir /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell.vt100_colors_off --runner openocd -- --cmd-pre-init 'hla_serial 066EFF535550755187245544'
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = post_flash_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: DEBUG: Flashing finished
DEBUG   - PYTEST: DEBUG: Found matching key: CONFIG_SHELL_PROMPT_UART="uart:~$ "
DEBUG   - PYTEST: INFO: Wait for prompt
DEBUG   - PYTEST: DEBUG: Got prompt
DEBUG   - PYTEST: -------------------------------- live log call ---------------------------------
DEBUG   - PYTEST: INFO: send "kernel version" command
DEBUG   - PYTEST: DEBUG: #: uart:~$ kernel version
DEBUG   - PYTEST: DEBUG: #: Zephyr version 4.4.99
DEBUG   - PYTEST: DEBUG: #: uart:~$
DEBUG   - PYTEST: INFO: response is valid
DEBUG   - PYTEST: PASSED
DEBUG   - PYTEST: ------------------------------ live log teardown -------------------------------
DEBUG   - PYTEST: DEBUG: Closed serial connection for /dev/ttyACM0
DEBUG   - PYTEST: DEBUG: Arguments received:
DEBUG   - PYTEST: argv[0] = /home/jguittet/script.py
DEBUG   - PYTEST: argv[1] = post_script
DEBUG   - PYTEST: argv[2] = foo
DEBUG   - PYTEST: argv[3] = bar
DEBUG   - PYTEST: - generated xml file: /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/subsys/testsuite/pytest/shell/sample.pytest.shell.vt100_colors_off/report.xml -
DEBUG   - PYTEST: ============================== 2 passed in 6.49s ===============================
DEBUG   - run status: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.pytest.shell.vt100_colors_off passed
DEBUG   - Release DUT:nucleo_l476rg/stm32l476xx, Id:066EFF535550755187245544, counter:3, failures:0
INFO    - 3/4 nucleo_l476rg/stm32l476xx sample.pytest.shell.vt100_colors_off               PASSED (device: 066EFF535550755187245544, 6.495s <zephyr/gnu>)
INFO    -                                    sample.pytest.shell.vt100_colors_off.test_shell_print_help                  PASSED      
INFO    -                                    sample.pytest.shell.vt100_colors_off.test_shell_print_version               PASSED      
DEBUG   - Retain DUT:nucleo_l476rg/stm32l476xx, Id:066EFF535550755187245544, counter:4, failures:0
DEBUG   - run test: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.basic.helloworld
DEBUG   - Reset instance status from 'passed' to None before run.
DEBUG   - Arguments received:
argv[0] = /home/jguittet/script.py
argv[1] = pre_script
argv[2] = foo
argv[3] = bar

DEBUG   - Using serial device /dev/ttyACM0 @ 115200 baud
DEBUG   - Flash command: ['west', 'flash', '--no-rebuild', '-d', '/home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/hello_world/sample.basic.helloworld', '--runner', 'openocd', '--', '--cmd-pre-init', 'hla_serial 066EFF535550755187245544']
DEBUG   - Arguments received:
argv[0] = /home/jguittet/script.py
argv[1] = pre_flash_script
argv[2] = foo
argv[3] = bar

DEBUG   - DEVICE: *** Booting Zephyr OS build v4.4.0-6523-g9851238061b0 ***
DEBUG   - DEVICE: Hello World! nucleo_l476rg/stm32l476xx
DEBUG   - HARNESS:Console:EXPECTED:'Hello World! (.*)'
DEBUG   - -- west flash: using runner openocd
Flashing file: /home/jguittet/zephyrproject/zephyr/twister-out/nucleo_l476rg_stm32l476xx/zephyr_gnu/samples/hello_world/sample.basic.helloworld/zephyr/zephyr.hex

DEBUG   - Arguments received:
argv[0] = /home/jguittet/script.py
argv[1] = post_flash_script
argv[2] = foo
argv[3] = bar

DEBUG   - Arguments received:
argv[0] = /home/jguittet/script.py
argv[1] = post_script
argv[2] = foo
argv[3] = bar

DEBUG   - run status: nucleo_l476rg/stm32l476xx/zephyr/gnu/sample.basic.helloworld passed
DEBUG   - Release DUT:nucleo_l476rg/stm32l476xx, Id:066EFF535550755187245544, counter:4, failures:0
INFO    - 4/4 nucleo_l476rg/stm32l476xx sample.basic.helloworld                            PASSED (device: 066EFF535550755187245544, 1.535s <zephyr/gnu>)
INFO    -                                    sample.basic.helloworld                                                     PASSED      

INFO    - 4 test scenarios (4 configurations) selected, 0 configurations filtered (0 by static filter, 0 at runtime).
Summary
├── Total test suites: 4
├── Processed test suites: 4
│   ├── Filtered test suites: 0
│   │   ├── Filtered test suites (static): 0
│   │   └── Filtered test suites (at runtime): 0
│   └── Selected test suites: 4
│       ├── Skipped test suites: 0
│       ├── Passed test suites: 4
│       ├── Built only test suites: 0
│       ├── Failed test suites: 0
│       └── Errors in test suites: 0
└── Total test cases: 6
    ├── Filtered test cases: 0
    └── Selected test cases: 6
        ├── Passed test cases: 6
        ├── Skipped test cases: 0
        ├── Built only test cases: 0
        ├── Blocked test cases: 0
        ├── Failed test cases: 0
        └── Errors in test cases: 0
INFO    - 4 of 4 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 168.83 seconds.
INFO    - 6 of 6 executed test cases passed (100.00%) on 1 out of total 1599 platforms (0.06%).
INFO    - 4 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board                     | ID                       |   Counter |   Failures |
|---------------------------|--------------------------|-----------|------------|
| nucleo_l476rg/stm32l476xx | 066EFF535550755187245544 |         4 |          0 |
INFO    - Saving reports...
INFO    - Writing JSON report /home/jguittet/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/jguittet/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/jguittet/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```