### PR TITLE
Nrf7120 - Add boot rom patch area to DTS

### DIFF
--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -100,15 +100,6 @@
 			compatible = "zephyr,memory-region", "mmio-sram";
 			zephyr,memory-region = "NRF_KMU_CRACEN_EXCHANGE";
 		};
-
-		nrf_mpc: memory@50041000 {
-			#address-cells = <1>;
-			#size-cells = <1>;
-			compatible = "nordic,nrf-mpc";
-			reg = <0x50041000 0x1000>;
-			override-num = <14>;
-			override-granularity = <4096>;
-		};
 	};
 
 	pwr_antswc: pwr_antswc {
@@ -996,6 +987,15 @@
 			reg = <0x40078000 0x1000>;
 			status = "disabled";
 			#mbox-cells = <1>;
+		};
+
+		nrf_mpc: memory@50041000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "nordic,nrf-mpc";
+			reg = <0x50041000 0x1000>;
+			override-num = <14>;
+			override-granularity = <4096>;
 		};
 
 		mram_controller: mram-controller@5004e000 {

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -189,6 +189,10 @@
 			reg = <0x28180000 DT_SIZE_K(512)>;
 		};
 
+		boot_rom_patch: memory@3fb000 {
+			reg = <0x3fb000 DT_SIZE_K(8)>;
+		};
+
 #ifdef USE_NON_SECURE_ADDRESS_MAP
 		global_peripherals: peripheral@40000000 {
 			reg = <0x40000000 0x10000000>;


### PR DESCRIPTION
Moving nrf_mpc out of the reserved-memory parent node as this is meant to be intended for a reserved RAM region. Also added Boot ROM patch region, purely to document it's existence.