### PR TITLE
drivers: gpio: pca_series: fix interrupt mask register polarity

### DIFF
--- a/drivers/gpio/gpio_pca_series.c
+++ b/drivers/gpio/gpio_pca_series.c
@@ -1444,8 +1444,8 @@ static int gpio_pca_series_pin_interrupt_configure_standard(
 		}
 	}
 
-	int_mask = int_fall | int_rise;
-	input_latch = ~int_mask;
+	input_latch = int_fall | int_rise;
+	int_mask = ~input_latch;
 
 #ifdef CONFIG_GPIO_PCA_SERIES_CACHE_ALL
 	/** read from cache even if this register is not present on device */


### PR DESCRIPTION
The interrupt mask register on PCA family devices seems to use active-low polarity: a bit value of `0` enables the interrupt on that pin, while `1` masks it. Refer to [PCAL9539A datasheet](https://www.nxp.com/docs/en/data-sheet/PCAL9539A.pdf) as an example.  

<img width="1347" height="473" alt="image" src="https://github.com/user-attachments/assets/42de833a-834f-4db1-ada1-716dd6fb23a6" />

However, in the code, the mask is calculated with wrong polarity: 

```c
int_mask = int_fall | int_rise;
```

Consequently, every pin configured for interrupts was immediately masked, so the interrupt pin was never asserted.

The `input_latch` is also using the wrong polarity. Refer to section 6.2.7 in the datasheet: 

<img width="1347" height="593" alt="image" src="https://github.com/user-attachments/assets/3d5a67b9-999d-4378-ac1a-5d9a958ec029" />

The fix in this MR corrects both polarity issues mentioned above: 

```c
input_latch = int_fall | int_rise;
int_mask = ~input_latch;
```

This change has been validated on the compatible TCAL9539 device. After the fix, the interrupt pin is asserted on the expected input transition. Prior to the fix no interrupt was ever generated. However, due to lack of hardware, it was not tested for all the other devices in the same family. 