### PR TITLE
Remove unused Silabs Series 2 code

### DIFF
--- a/boards/silabs/dev_kits/xg24_ek2703a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg24_ek2703a/Kconfig.defconfig
@@ -6,12 +6,6 @@ if BOARD_XG24_EK2703A
 configdefault LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 
-config CMU_HFXO_FREQ
-	default 39000000
-
-config CMU_LFXO_FREQ
-	default 32768
-
 if SOC_GECKO_USE_RAIL
 
 config FPU

--- a/boards/sparkfun/thing_plus_matter_mgm240p/Kconfig.defconfig
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/Kconfig.defconfig
@@ -6,12 +6,6 @@
 
 if BOARD_SPARKFUN_THING_PLUS_MATTER_MGM240P
 
-config CMU_HFXO_FREQ
-	default 40000000
-
-config CMU_LFXO_FREQ
-	default 32768
-
 if SOC_GECKO_USE_RAIL
 
 config FPU

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -228,11 +228,7 @@ static int counter_gecko_init(const struct device *dev)
 		false,                /* Disable RTC during debug halt. */
 		false,                /* Don't wrap prescaler on CCV0 */
 		true,                 /* Counter wrap on CCV1 */
-#if defined(_SILICON_LABS_32B_SERIES_2)
-		(RTCC_CntPresc_TypeDef)(31UL - __CLZ(dev_cfg->prescaler)),
-#else
 		(RTCC_CntPresc_TypeDef)CMU_DivToLog2(dev_cfg->prescaler),
-#endif
 		rtccCntTickPresc,     /* Count according to prescaler value */
 #if defined(_RTCC_CTRL_BUMODETSEN_MASK)
 		false,                /* Don't store RTCC counter value in
@@ -272,8 +268,6 @@ static int counter_gecko_init(const struct device *dev)
 #if defined(CMU_LFECLKEN0_RTCC)
 	/* Enable LFECLK in CMU (will also enable oscillator if not enabled). */
 	CMU_ClockSelectSet(cmuClock_LFE, cmuSelect_LFXO);
-#elif defined(_SILICON_LABS_32B_SERIES_2)
-	CMU_ClockSelectSet(cmuClock_RTCC, cmuSelect_LFXO);
 #else
 	/* Enable LFACLK in CMU (will also enable oscillator if not enabled). */
 	CMU_ClockSelectSet(cmuClock_LFA, cmuSelect_LFXO);

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -23,11 +23,7 @@
 #if DT_NODE_HAS_PROP(id, peripheral_id)
 #define GET_GECKO_GPIO_INDEX(id) DT_INST_PROP(id, peripheral_id)
 #else
-#if defined(CONFIG_SOC_FAMILY_SILABS_S2)
-#define GECKO_GPIO_PORT_ADDR_SPACE_SIZE sizeof(GPIO_PORT_TypeDef)
-#else
 #define GECKO_GPIO_PORT_ADDR_SPACE_SIZE sizeof(GPIO_P_TypeDef)
-#endif
 /* Assumption for calculating gpio index:
  * 1. Address space of the first GPIO port is the address space for GPIO port A
  */
@@ -343,11 +339,7 @@ static void gpio_gecko_common_isr(const struct device *dev)
 		enabled_int = int_status & port_data->int_enabled_mask;
 		if (enabled_int != 0) {
 			int_status &= ~enabled_int;
-#if defined(_SILICON_LABS_32B_SERIES_2)
-			GPIO->IF_CLR = enabled_int;
-#else
 			GPIO->IFC = enabled_int;
-#endif
 			gpio_fire_callbacks(&port_data->callbacks, port_dev,
 					    enabled_int);
 		}

--- a/soc/silabs/common/soc.c
+++ b/soc/silabs/common/soc.c
@@ -40,26 +40,11 @@ static void init_lfxo(void)
 	 * Configuring LFXO disables it, so we can do that only if it's not
 	 * used as a SYSCLK/HFCLK source.
 	 */
-#if defined(_SILICON_LABS_32B_SERIES_2)
-	if (CMU_ClockSelectGet(cmuClock_SYSCLK) != cmuSelect_LFXO) {
-		/*
-		 * Check if device has LFXO configuration info in DEVINFO
-		 * See AN0016.2
-		 */
-		if ((DEVINFO->MODULEINFO & DEVINFO_MODULEINFO_LFXOCALVAL) ==
-		    DEVINFO_MODULEINFO_LFXOCALVAL_VALID) {
-			lfxoInit.capTune =
-				(DEVINFO->MODXOCAL & _DEVINFO_MODXOCAL_LFXOCAPTUNE_MASK) >>
-				_DEVINFO_MODXOCAL_LFXOCAPTUNE_SHIFT;
-		}
-		CMU_LFXOInit(&lfxoInit);
-	}
-#else
 	if (CMU_ClockSelectGet(cmuClock_HF) != cmuSelect_LFXO) {
 		CMU_LFXOInit(&lfxoInit);
 		CMU_OscillatorEnable(cmuOsc_LFXO, true, true);
 	}
-#endif /* _SILICON_LABS_32B_SERIES_2 */
+
 	SystemLFXOClockSet(CONFIG_CMU_LFXO_FREQ);
 }
 
@@ -71,28 +56,6 @@ static void init_lfxo(void)
 static ALWAYS_INLINE void clock_init(void)
 {
 #ifdef CONFIG_CMU_HFCLK_HFXO
-#if defined(_SILICON_LABS_32B_SERIES_2)
-	if (CMU_ClockSelectGet(cmuClock_SYSCLK) != cmuSelect_HFXO) {
-		/*
-		 * Check if device has HFXO configuration info in DEVINFO
-		 * See AN0016.2
-		 */
-		if ((DEVINFO->MODULEINFO & DEVINFO_MODULEINFO_HFXOCALVAL) ==
-		    DEVINFO_MODULEINFO_HFXOCALVAL_VALID) {
-			hfxoInit.ctuneXoAna =
-				(DEVINFO->MODXOCAL & _DEVINFO_MODXOCAL_HFXOCTUNEXOANA_MASK) >>
-				_DEVINFO_MODXOCAL_HFXOCTUNEXOANA_SHIFT;
-			hfxoInit.ctuneXiAna =
-				(DEVINFO->MODXOCAL & _DEVINFO_MODXOCAL_HFXOCTUNEXIANA_MASK) >>
-				_DEVINFO_MODXOCAL_HFXOCTUNEXIANA_SHIFT;
-		}
-
-		CMU_HFXOInit(&hfxoInit);
-		CMU_ClockSelectSet(cmuClock_SYSCLK, cmuSelect_HFXO);
-	}
-
-	SystemHFXOClockSet(CONFIG_CMU_HFXO_FREQ);
-#else
 	if (CMU_ClockSelectGet(cmuClock_HF) != cmuSelect_HFXO) {
 		CMU_HFXOInit(&hfxoInit);
 		CMU_OscillatorEnable(cmuOsc_HFXO, true, true);
@@ -100,15 +63,10 @@ static ALWAYS_INLINE void clock_init(void)
 	}
 	SystemHFXOClockSet(CONFIG_CMU_HFXO_FREQ);
 	CMU_OscillatorEnable(cmuOsc_HFRCO, false, false);
-#endif /* _SILICON_LABS_32B_SERIES_2 */
 #elif (defined CONFIG_CMU_HFCLK_LFXO)
 	/* LFXO should've been already brought up by init_lfxo() */
-#if defined(_SILICON_LABS_32B_SERIES_2)
-	CMU_ClockSelectSet(cmuClock_SYSCLK, cmuSelect_LFXO);
-#else
 	CMU_ClockSelectSet(cmuClock_HF, cmuSelect_LFXO);
 	CMU_OscillatorEnable(cmuOsc_HFRCO, false, false);
-#endif /* _SILICON_LABS_32B_SERIES_2 */
 #elif (defined CONFIG_CMU_HFCLK_HFRCO)
 	/*
 	 * This is the default clock, the controller starts with
@@ -127,13 +85,8 @@ static ALWAYS_INLINE void clock_init(void)
 #error "Unsupported clock source for HFCLK selected"
 #endif
 
-#if defined(_SILICON_LABS_32B_SERIES_2)
-	/* Enable the High Frequency Peripheral Clock */
-	CMU_ClockEnable(cmuClock_PCLK, true);
-#else
 	/* Enable the High Frequency Peripheral Clock */
 	CMU_ClockEnable(cmuClock_HFPER, true);
-#endif /* _SILICON_LABS_32B_SERIES_2 */
 
 #if defined(CONFIG_GPIO_GECKO) || defined(CONFIG_LOG_BACKEND_SWO)
 	CMU_ClockEnable(cmuClock_GPIO, true);
@@ -165,9 +118,6 @@ static void swo_init(void)
 {
 	struct soc_gpio_pin pin_swo = PIN_SWO;
 
-#if defined(_SILICON_LABS_32B_SERIES_2)
-	GPIO->TRACEROUTEPEN = GPIO_TRACEROUTEPEN_SWVPEN;
-#else
 	/* Select HFCLK as the debug trace clock */
 	CMU->DBGCLKSEL = CMU_DBGCLKSEL_DBG_HFCLK;
 
@@ -179,7 +129,6 @@ static void swo_init(void)
 #else
 	GPIO->ROUTE = GPIO_ROUTE_SWOPEN | (SWO_LOCATION << 8);
 #endif
-#endif /* _SILICON_LABS_32B_SERIES_2 */
 
 	GPIO_PinModeSet(pin_swo.port, pin_swo.pin, pin_swo.mode, pin_swo.out);
 }


### PR DESCRIPTION
Silabs SoCs like Series 2, which are based on simplicity_sdk rather than gecko_sdk use different drivers:
- `soc/silabs/silabs_s2/soc.c` instead of `soc/silabs/common/soc.c`
- `drivers/gpio/gpio_silabs.c` instead of `drivers/gpio/gpio_gecko.c`
- `drivers/counter/counter_silabs_*.c` instead of `drivers/counter/counter_gecko_rtcc.c`

Their Kconfig dependencies don't even allow them to use the old drivers anymore. Thus, this PR removes all Series 2 support from these drivers to simplify them and ease future changes.