### PR TITLE
drivers: wifi: infineon: clear result scan callback after scan start failure

### DIFF
--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -564,6 +564,7 @@ static int airoc_mgmt_scan(const struct device *dev,
 	if (whd_wifi_scan(airoc_sta_if, scan_type, WHD_BSS_TYPE_ANY, &(data->ssid), NULL, NULL,
 			  NULL, scan_callback, &(data->scan_result), data) != WHD_SUCCESS) {
 		LOG_ERR("Failed to start scan");
+		data->scan_rslt_cb = NULL;
 		k_sem_give(&data->sema_common);
 		return -EAGAIN;
 	}


### PR DESCRIPTION
This patch fixes a state handling issue in the Infineon AIROC Wi-Fi driver scan path.

### Problem:
In airoc_mgmt_scan(), data->scan_rslt_cb is assigned before calling whd_wifi_scan(). When whd_wifi_scan() fails, the function returns `-EAGAIN` without clearing data->scan_rslt_cb. As a consequence, a following scan attempt could incorrectly hit the "Scan callback in progress" path and return `-EINPROGRESS` even though no scan was actually running.

### What this PR changes:
This change clears data->scan_rslt_cb in the whd_wifi_scan() error path, keeping driver state consistent and allowing retries to proceed correctly after a transient scan start failure: prevent false "scan in progress" condition after failed scan start. 

