### PR TITLE
net: ethernet: remove redundant capability check

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -997,10 +997,6 @@ int net_eth_promisc_mode(struct net_if *iface, bool enable)
 {
 	struct ethernet_req_params params;
 
-	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_PROMISC_MODE)) {
-		return -ENOTSUP;
-	}
-
 	params.promisc_mode = enable;
 
 	return net_mgmt(NET_REQUEST_ETHERNET_SET_PROMISC_MODE, iface,
@@ -1012,10 +1008,6 @@ int net_eth_txinjection_mode(struct net_if *iface, bool enable)
 {
 #ifdef CONFIG_NET_L2_ETHERNET_MGMT
 	struct ethernet_req_params params;
-
-	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_TXINJECTION_MODE)) {
-		return -ENOTSUP;
-	}
 
 	params.txinjection_mode = enable;
 
@@ -1034,10 +1026,6 @@ int net_eth_mac_filter(struct net_if *iface, struct net_eth_addr *mac,
 {
 #ifdef CONFIG_NET_L2_ETHERNET_MGMT
 	struct ethernet_req_params params;
-
-	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_HW_FILTERING)) {
-		return -ENOTSUP;
-	}
 
 	memcpy(&params.filter.mac_address, mac, sizeof(struct net_eth_addr));
 	params.filter.type = type;


### PR DESCRIPTION
remove redundant capability checks, as
these are also checked inside net_mgmt
with the same return code