### PR TITLE
drivers: ethernet: remove redundant tx stats

### DIFF
--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -851,7 +851,6 @@ static int adin2111_port_send(const struct device *dev, struct net_pkt *pkt)
 	/* query remaining tx fifo space */
 	ret = adin2111_read_tx_space(adin, &tx_space);
 	if (ret < 0) {
-		eth_stats_update_errors_tx(data->iface);
 		LOG_ERR("Failed to read TX FIFO space, %d", ret);
 		goto end_unlock;
 	}
@@ -863,7 +862,6 @@ static int adin2111_port_send(const struct device *dev, struct net_pkt *pkt)
 	if (tx_space <
 	   (pkt_len + ADIN2111_FRAME_HEADER_SIZE + ADIN2111_INTERNAL_HEADER_SIZE)) {
 		/* tx buffer is full */
-		eth_stats_update_errors_tx(data->iface);
 		ret = -EBUSY;
 		goto end_unlock;
 	}
@@ -884,7 +882,6 @@ static int adin2111_port_send(const struct device *dev, struct net_pkt *pkt)
 	burst_size = ROUND_UP(padded_size, 4);
 	if ((burst_size + ADIN2111_WRITE_HEADER_SIZE) > CONFIG_ETH_ADIN2111_BUFFER_SIZE) {
 		ret = -ENOMEM;
-		eth_stats_update_errors_tx(data->iface);
 		goto end_unlock;
 	}
 
@@ -906,7 +903,6 @@ static int adin2111_port_send(const struct device *dev, struct net_pkt *pkt)
 			   (ctx->buf + header_size + ADIN2111_FRAME_HEADER_SIZE),
 			   pkt_len);
 	if (ret < 0) {
-		eth_stats_update_errors_tx(data->iface);
 		LOG_ERR("Port %u failed to read PKT into TX buffer, %d",
 			cfg->port_idx, ret);
 		goto end_unlock;
@@ -915,7 +911,6 @@ static int adin2111_port_send(const struct device *dev, struct net_pkt *pkt)
 	/* write transmit size */
 	ret = eth_adin2111_reg_write(adin, ADIN2111_TX_FSIZE, padded_size);
 	if (ret < 0) {
-		eth_stats_update_errors_tx(data->iface);
 		LOG_ERR("Port %u write FSIZE failed, %d", cfg->port_idx, ret);
 		goto end_unlock;
 	}
@@ -931,13 +926,8 @@ static int adin2111_port_send(const struct device *dev, struct net_pkt *pkt)
 			   &tx);
 end_check:
 	if (ret < 0) {
-		eth_stats_update_errors_tx(data->iface);
 		LOG_ERR("Port %u frame SPI write failed, %d", cfg->port_idx, ret);
-		goto end_unlock;
 	}
-
-	eth_stats_update_bytes_tx(data->iface, pkt_len);
-	eth_stats_update_pkts_tx(data->iface);
 
 end_unlock:
 	eth_adin2111_unlock(adin);

--- a/drivers/ethernet/eth_dm9051.c
+++ b/drivers/ethernet/eth_dm9051.c
@@ -446,8 +446,7 @@ static int eth_dm9051_tx(const struct device *dev, struct net_pkt *pkt)
 
 	/* Read TX data from net_pkt */
 	if (net_pkt_read(pkt, data->tx_buf, len)) {
-		ret = -EIO;
-		goto out_update_errors_tx;
+		return -EIO;
 	}
 
 	k_mutex_lock(&data->spi_lock, K_FOREVER);
@@ -479,27 +478,13 @@ static int eth_dm9051_tx(const struct device *dev, struct net_pkt *pkt)
 	k_mutex_unlock(&data->spi_lock);
 
 	if (k_sem_take(&data->tx_done, K_MSEC(10))) {
-		ret = -EIO;
-		goto out_update_errors_tx;
-	}
-
-	/* Update ethernet statistics */
-	eth_stats_update_bytes_tx(data->iface, len);
-	eth_stats_update_pkts_tx(data->iface);
-	if (net_eth_is_addr_broadcast(&NET_ETH_HDR(pkt)->dst)) {
-		eth_stats_update_broadcast_tx(data->iface);
-	} else if (net_eth_is_addr_multicast(&NET_ETH_HDR(pkt)->dst)) {
-		eth_stats_update_multicast_tx(data->iface);
-	}  else {
-		/* Unicast frame */
+		return -EIO;
 	}
 
 	return 0;
 
 out_spi_unlock:
 	k_mutex_unlock(&data->spi_lock);
-out_update_errors_tx:
-	eth_stats_update_errors_tx(data->iface);
 	return ret;
 }
 

--- a/drivers/ethernet/eth_ivshmem.c
+++ b/drivers/ethernet/eth_ivshmem.c
@@ -103,13 +103,11 @@ static int eth_ivshmem_send(const struct device *dev, struct net_pkt *pkt)
 
 	if (res != 0) {
 		LOG_ERR("Failed to allocate tx buffer");
-		eth_stats_update_errors_tx(dev_data->iface);
 		return res;
 	}
 
 	if (net_pkt_read(pkt, data, len)) {
 		LOG_ERR("Failed to read tx packet");
-		eth_stats_update_errors_tx(dev_data->iface);
 		return -EIO;
 	}
 

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -454,7 +454,6 @@ static int lan865x_port_send(const struct device *dev, struct net_pkt *pkt)
 	k_sem_give(&ctx->tx_rx_sem);
 	if (ret < 0) {
 		LOG_ERR("TX transmission error, %d", ret);
-		eth_stats_update_errors_tx(net_pkt_iface(pkt));
 		return ret;
 	}
 

--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -313,30 +313,26 @@ static int eth_nxp_s32_tx(const struct device *dev, struct net_pkt *pkt)
 	status = Gmac_Ip_GetTxBuff(cfg->instance, cfg->tx_ring_idx, &buf, NULL);
 	if (status != GMAC_STATUS_SUCCESS) {
 		LOG_ERR("Failed to get tx buffer (%d)", status);
-		res = -ENOBUFS;
-		goto error;
+		return -ENOBUFS;
 	}
 
 	res = net_pkt_read(pkt, buf.Data, pkt_len);
 	if (res) {
 		LOG_ERR("Failed to copy packet to tx buffer (%d)", res);
-		res = -ENOBUFS;
-		goto error;
+		return -ENOBUFS;
 	}
 
 	buf.Length = (uint16_t)pkt_len;
 	status = Gmac_Ip_SendFrame(cfg->instance, cfg->tx_ring_idx, &buf, &tx_options);
 	if (status != GMAC_STATUS_SUCCESS) {
 		LOG_ERR("Failed to tx frame (%d)", status);
-		res = -EIO;
-		goto error;
+		return -EIO;
 	}
 
 	/* Wait for the transmission to complete */
 	if (k_sem_take(&ctx->tx_sem, ETH_NXP_S32_DMA_TX_TIMEOUT) != 0) {
 		LOG_ERR("Timeout transmitting frame");
-		res = -EIO;
-		goto error;
+		return -EIO;
 	}
 
 	/* Restore the buffer address pointer and clear the descriptor after the status is read */
@@ -344,16 +340,12 @@ static int eth_nxp_s32_tx(const struct device *dev, struct net_pkt *pkt)
 	if (status != GMAC_STATUS_SUCCESS) {
 		LOG_ERR("Failed to restore tx buffer: %s (%d) ",
 			(status == GMAC_STATUS_BUSY ? "busy" : "buf not found"), status);
-		res = -EIO;
+		return -EIO;
 	} else if (tx_info.ErrMask != 0U) {
 		LOG_ERR("Tx frame has errors (error mask 0x%X)", tx_info.ErrMask);
-		res = -EIO;
+		return -EIO;
 	}
 
-error:
-	if (res != 0) {
-		eth_stats_update_errors_tx(ctx->iface);
-	}
 	return res;
 }
 

--- a/drivers/ethernet/eth_nxp_s32_netc.c
+++ b/drivers/ethernet/eth_nxp_s32_netc.c
@@ -140,29 +140,22 @@ int nxp_s32_eth_tx(const struct device *dev, struct net_pkt *pkt)
 	}
 	if (status != NETC_ETH_IP_STATUS_SUCCESS) {
 		LOG_ERR("Failed to get tx buffer: %d", status);
-		res = -ENOBUFS;
-		goto error;
+		return -ENOBUFS;
 	}
 	buf.length = (uint16_t)pkt_len;
 
 	res = net_pkt_read(pkt, buf.data, pkt_len);
 	if (res) {
 		LOG_ERR("Failed to copy packet to tx buffer: %d", res);
-		res = -ENOBUFS;
-		goto error;
+		return -ENOBUFS;
 	}
 
 	status = Netc_Eth_Ip_SendFrame(cfg->si_idx, cfg->tx_ring_idx, &buf, NULL);
 	if (status != NETC_ETH_IP_STATUS_SUCCESS) {
 		LOG_ERR("Failed to tx frame: %d", status);
-		res = -EIO;
-		goto error;
+		return -EIO;
 	}
 
-error:
-	if (res != 0) {
-		eth_stats_update_errors_tx(ctx->iface);
-	}
 	return res;
 }
 

--- a/drivers/ethernet/eth_renesas_ra_rmac.c
+++ b/drivers/ethernet/eth_renesas_ra_rmac.c
@@ -420,11 +420,6 @@ tx_end:
 #endif
 	}
 #endif
-
-	if (ret) {
-		eth_stats_update_errors_tx(data->iface);
-	}
-
 	return ret;
 }
 

--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -263,7 +263,6 @@ static void eth_stellaris_isr(const struct device *dev)
 
 	if (isr_val & BIT_MACRIS_TXER) {
 		LOG_ERR("Transmit Frame Error");
-		eth_stats_update_errors_tx(dev_data->iface);
 		dev_data->tx_err = true;
 		k_sem_give(&dev_data->tx_sem);
 	}

--- a/drivers/ethernet/eth_wch.c
+++ b/drivers/ethernet/eth_wch.c
@@ -214,7 +214,6 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 
 	LOG_DBG("Sending Packet: %p of Length: %u", pkt, total_len);
 	if (total_len > (ETH_TXBUF_SIZE * ETH_TXBUF_NB)) {
-		eth_stats_update_errors_tx(data->iface);
 		LOG_ERR("Packet spans all available descriptors");
 		return -ENOBUFS;
 	}
@@ -224,7 +223,6 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 
 	do {
 		if ((dma_tx_desc_current->Status & ETH_DMATxDesc_OWN) != 0U) {
-			eth_stats_update_errors_tx(data->iface);
 			LOG_ERR("No Descriptors Available");
 			res = -EBUSY;
 			goto error;
@@ -235,7 +233,6 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 			bytes_remaining > ETH_TXBUF_SIZE ? ETH_TXBUF_SIZE : bytes_remaining;
 		if (net_pkt_read(pkt, (void *)(dma_tx_desc_current->Buffer1Addr), chunk_size) !=
 		    0U) {
-			eth_stats_update_errors_tx(data->iface);
 			LOG_ERR("Could not read descriptor buffer!");
 			res = -ENOBUFS;
 			goto error;
@@ -267,7 +264,6 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 
 	/* Wait for end of TX buffer transmission */
 	if (k_sem_take(&data->tx_int_sem, K_MSEC(ETH_DMA_TX_TIMEOUT_MS)) != 0) {
-		eth_stats_update_errors_tx(data->iface);
 		LOG_DBG("TX ISR Timeout");
 		res = -EIO;
 		goto error;

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -558,9 +558,6 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt)
 
 	ret = 0;
 error:
-	if (ret != 0) {
-		eth_stats_update_errors_tx(iface_dst);
-	}
 	return ret;
 }
 


### PR DESCRIPTION
remove setting tx stats, that are already handled
by ethernet_send. It will already call
eth_stats_update_errors_tx on failiure
and on success via ethernet_update_tx_stats
it calls eth_stats_update_bytes_tx,
eth_stats_update_pkts_tx,
eth_stats_update_broadcast_tx and
eth_stats_update_multicast_tx.