### PR TITLE
net: route: Decrement packet lifetime for cross-interface on-link forwarding 

### DIFF
--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -44,6 +44,8 @@ LOG_MODULE_DECLARE(net_route, ROUTE_LOG_LEVEL);
 #include <zephyr/net/virtual.h>
 
 #include "route.h"
+#include "route_ipv4.h"
+#include "route_ipv6.h"
 
 static size_t route_addr_len(net_sa_family_t family)
 {
@@ -594,6 +596,22 @@ int net_route_packet_if(struct net_pkt *pkt, struct net_if *iface)
 	}
 
 	net_pkt_set_forwarding(pkt, forwarding);
+
+	if (forwarding) {
+		int ret = 0;
+
+		if (IS_ENABLED(CONFIG_NET_IPV4_FORWARDING) &&
+		    net_pkt_family(pkt) == NET_PF_INET) {
+			ret = net_route_ipv4_decrement_ttl(pkt);
+		} else if (IS_ENABLED(CONFIG_NET_IPV6_FORWARDING) &&
+			   net_pkt_family(pkt) == NET_PF_INET6) {
+			ret = net_route_ipv6_decrement_hop_limit(pkt);
+		}
+
+		if (ret < 0) {
+			return ret;
+		}
+	}
 
 	if (net_route_ll_addr_supported(iface)) {
 		memcpy(net_pkt_lladdr_src(pkt)->addr,

--- a/subsys/net/ip/route_ipv4.c
+++ b/subsys/net/ip/route_ipv4.c
@@ -185,6 +185,37 @@ bool net_route_ipv4_get_info(struct net_if *iface,
 	return true;
 }
 
+int net_route_ipv4_decrement_ttl(struct net_pkt *pkt)
+{
+	struct net_ipv4_hdr *hdr;
+	uint16_t chksum = 0U;
+	int ret;
+
+	NET_ASSERT(pkt);
+
+	hdr = NET_IPV4_HDR(pkt);
+	if (hdr == NULL) {
+		return -EINVAL;
+	}
+
+	if (hdr->ttl <= 1U) {
+		return -ETIMEDOUT;
+	}
+
+	hdr->ttl--;
+	net_pkt_set_ipv4_ttl(pkt, hdr->ttl);
+
+	hdr->chksum = 0U;
+	ret = net_calc_chksum_ipv4(pkt, &chksum);
+	if (ret < 0) {
+		return ret;
+	}
+
+	hdr->chksum = chksum;
+
+	return 0;
+}
+
 int net_route_ipv4_packet(struct net_pkt *pkt, const struct net_in_addr *nexthop)
 {
 	if (pkt == NULL || nexthop == NULL || net_pkt_iface(pkt) == NULL) {
@@ -192,28 +223,11 @@ int net_route_ipv4_packet(struct net_pkt *pkt, const struct net_in_addr *nexthop
 	}
 
 	if (net_pkt_forwarding(pkt)) {
-		struct net_ipv4_hdr *hdr = NET_IPV4_HDR(pkt);
-		uint16_t chksum = 0U;
-		int ret;
+		int ret = net_route_ipv4_decrement_ttl(pkt);
 
-		if (hdr == NULL) {
-			return -EINVAL;
-		}
-
-		if (hdr->ttl <= 1U) {
-			return -ETIMEDOUT;
-		}
-
-		hdr->ttl--;
-		net_pkt_set_ipv4_ttl(pkt, hdr->ttl);
-
-		hdr->chksum = 0U;
-		ret = net_calc_chksum_ipv4(pkt, &chksum);
 		if (ret < 0) {
 			return ret;
 		}
-
-		hdr->chksum = chksum;
 	}
 
 	net_pkt_set_ipv4_ll_resolve_addr(pkt, nexthop);

--- a/subsys/net/ip/route_ipv4.h
+++ b/subsys/net/ip/route_ipv4.h
@@ -138,6 +138,16 @@ bool net_route_ipv4_get_info(struct net_if *iface,
 			     struct net_in_addr **nexthop);
 
 /**
+ * @brief Decrement IPv4 TTL for a forwarded packet.
+ *
+ * @param pkt Network packet.
+ *
+ * @return 0 on success, -ETIMEDOUT if TTL has expired,
+ * or a negative errno value otherwise.
+ */
+int net_route_ipv4_decrement_ttl(struct net_pkt *pkt);
+
+/**
  * @brief Send the network packet to network via some intermediate host.
  *
  * @param pkt Network packet to send.

--- a/subsys/net/ip/route_ipv6.c
+++ b/subsys/net/ip/route_ipv6.c
@@ -450,6 +450,27 @@ bool net_route_ipv6_get_info(struct net_if *iface,
 	return true;
 }
 
+int net_route_ipv6_decrement_hop_limit(struct net_pkt *pkt)
+{
+	struct net_ipv6_hdr *hdr;
+
+	NET_ASSERT(pkt);
+
+	hdr = NET_IPV6_HDR(pkt);
+	if (hdr == NULL) {
+		return -EINVAL;
+	}
+
+	if (hdr->hop_limit <= 1U) {
+		return -ETIMEDOUT;
+	}
+
+	hdr->hop_limit--;
+	net_pkt_set_ipv6_hop_limit(pkt, hdr->hop_limit);
+
+	return 0;
+}
+
 int net_route_ipv6_packet(struct net_pkt *pkt, const struct net_in6_addr *nexthop)
 {
 	struct net_linkaddr *lladdr = NULL;
@@ -508,12 +529,11 @@ int net_route_ipv6_packet(struct net_pkt *pkt, const struct net_in6_addr *nextho
 	}
 
 	if (forwarding) {
-		if (NET_IPV6_HDR(pkt)->hop_limit <= 1U) {
-			return -ETIMEDOUT;
-		}
+		int ret = net_route_ipv6_decrement_hop_limit(pkt);
 
-		NET_IPV6_HDR(pkt)->hop_limit--;
-		net_pkt_set_ipv6_hop_limit(pkt, NET_IPV6_HDR(pkt)->hop_limit);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	net_pkt_set_iface(pkt, out_iface);

--- a/subsys/net/ip/route_ipv6.h
+++ b/subsys/net/ip/route_ipv6.h
@@ -269,6 +269,16 @@ bool net_route_ipv6_get_info(struct net_if *iface,
 			     struct net_in6_addr **nexthop);
 
 /**
+ * @brief Decrement IPv6 hop limit for a forwarded packet.
+ *
+ * @param pkt Network packet.
+ *
+ * @return 0 on success, -ETIMEDOUT if hop limit has expired,
+ * or a negative errno value otherwise.
+ */
+int net_route_ipv6_decrement_hop_limit(struct net_pkt *pkt);
+
+/**
  * @brief Send the network packet to network via some intermediate host.
  *
  * @param pkt Network packet to send.

--- a/tests/net/route/ipv4/src/main.c
+++ b/tests/net/route/ipv4/src/main.c
@@ -38,6 +38,7 @@ static struct net_in_addr subnet_addr = { .s4_addr = { 198, 51, 100, 99 } };
 static struct net_in_addr subnet_prefix = { .s4_addr = { 198, 51, 100, 0 } };
 static struct net_in_addr subnet_dest_addr = { .s4_addr = { 198, 51, 100, 42 } };
 static struct net_in_addr forward_src_addr = { .s4_addr = { 198, 51, 100, 200 } };
+static struct net_in_addr onlink_dest_addr_alt = { .s4_addr = { 192, 0, 3, 50 } };
 static struct net_eth_addr gateway_lladdr = { { 0x02, 0x00, 0x5e, 0x00, 0x53, 0x10 } };
 static struct net_eth_addr gateway_lladdr_alt = { { 0x02, 0x00, 0x5e, 0x00, 0x53, 0x11 } };
 
@@ -107,6 +108,9 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv4_access, struct net_ipv4_hdr);
 	const struct net_in_addr *resolve_addr;
+	struct net_pkt_cursor backup;
+	struct net_ipv4_hdr *hdr;
+	size_t ip_offset = sizeof(struct net_eth_hdr);
 
 	sent_pkt_seen = true;
 	sent_iface = net_if_lookup_by_dev(dev);
@@ -114,7 +118,7 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 	sent_forwarding = net_pkt_forwarding(pkt);
 	sent_ll_proto_type = net_pkt_ll_proto_type(pkt);
 	sent_arp_request_seen = false;
-	sent_ipv4_ttl = 0U;
+	sent_ipv4_ttl = sent_forwarding ? net_pkt_ipv4_ttl(pkt) : 0U;
 
 	resolve_addr = net_pkt_ipv4_ll_resolve_addr(pkt);
 	if (resolve_addr != NULL) {
@@ -127,15 +131,18 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 	if (net_pkt_ll_proto_type(pkt) == NET_ETH_PTYPE_ARP &&
 	    net_pkt_get_len(pkt) >= sizeof(struct net_eth_hdr)) {
 		sent_arp_request_seen = true;
-	} else if (net_pkt_ll_proto_type(pkt) == NET_ETH_PTYPE_IP &&
-		   net_pkt_get_len(pkt) >= sizeof(struct net_eth_hdr) +
-		   sizeof(struct net_ipv4_hdr)) {
-		struct net_pkt_cursor backup;
-		struct net_ipv4_hdr *hdr;
+	} else if (!sent_forwarding &&
+		   net_pkt_ll_proto_type(pkt) == NET_ETH_PTYPE_IP &&
+		   net_pkt_get_len(pkt) >= sizeof(struct net_ipv4_hdr)) {
+		if (net_pkt_get_len(pkt) >= ip_offset + sizeof(struct net_ipv4_hdr)) {
+			ip_offset = sizeof(struct net_eth_hdr);
+		} else {
+			ip_offset = 0U;
+		}
 
 		net_pkt_cursor_backup(pkt, &backup);
 		net_pkt_cursor_init(pkt);
-		if (net_pkt_skip(pkt, sizeof(struct net_eth_hdr)) == 0) {
+		if (net_pkt_skip(pkt, ip_offset) == 0) {
 			hdr = (struct net_ipv4_hdr *)net_pkt_get_data(pkt, &ipv4_access);
 			if (hdr != NULL) {
 				sent_ipv4_ttl = hdr->ttl;
@@ -756,6 +763,118 @@ static void test_route_ipv4_forward_ttl_expired_drops(void)
 	zassert_ok(net_route_ipv4_del(route), "Forwarding route del failed");
 }
 
+static void test_route_ipv4_forward_onlink_packet_between_ifaces(void)
+{
+	struct net_pkt *pkt;
+	struct net_ipv4_hdr *hdr;
+	int ret;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_IPV4_FORWARDING);
+
+	net_arp_clear_cache(my_iface_alt);
+	net_arp_update(my_iface_alt, &onlink_dest_addr_alt, &gateway_lladdr_alt,
+		       false, true);
+
+	reset_send_state();
+	drain_wait_data();
+
+	pkt = net_pkt_alloc_with_buffer(my_iface, sizeof(struct net_ipv4_hdr),
+					NET_AF_INET, 0, K_NO_WAIT);
+	zassert_not_null(pkt, "On-link forwarding packet alloc failed");
+
+	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IP);
+
+	hdr = (struct net_ipv4_hdr *)net_buf_add(pkt->buffer,
+						 sizeof(struct net_ipv4_hdr));
+	zassert_not_null(hdr, "Cannot reserve IPv4 header");
+
+	memset(hdr, 0, sizeof(*hdr));
+	hdr->vhl = 0x45;
+	hdr->ttl = 2U;
+	hdr->proto = NET_IPPROTO_UDP;
+	hdr->len = net_htons(sizeof(struct net_ipv4_hdr));
+	net_ipv4_addr_copy_raw(hdr->src, forward_src_addr.s4_addr);
+	net_ipv4_addr_copy_raw(hdr->dst, onlink_dest_addr_alt.s4_addr);
+	hdr->chksum = ipv4_header_checksum(hdr);
+
+	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv4_hdr));
+	net_pkt_set_ipv4_opts_len(pkt, 0U);
+	net_pkt_set_iface(pkt, my_iface);
+	net_pkt_set_family(pkt, NET_AF_INET);
+
+	ret = net_route_packet_if(pkt, my_iface_alt);
+	zassert_ok(ret, "On-link IPv4 route packet failed");
+
+	for (int i = 0; i < 5; i++) {
+		zassert_ok(k_sem_take(&wait_data, WAIT_TIME),
+			   "On-link forwarded packet was not sent");
+		if (sent_ll_proto_type != NET_ETH_PTYPE_ARP) {
+			break;
+		}
+	}
+
+	zassert_not_equal(sent_ll_proto_type, NET_ETH_PTYPE_ARP,
+			  "On-link forwarding should not stop at ARP");
+
+	zassert_true(sent_pkt_seen, "On-link forwarded packet not observed");
+	zassert_true(sent_forwarding, "On-link packet should be marked forwarded");
+	zassert_equal_ptr(sent_iface, my_iface_alt,
+			  "On-link forwarded packet used wrong egress interface");
+	zassert_equal_ptr(sent_orig_iface, my_iface,
+			  "On-link forwarded packet missing ingress interface");
+	zassert_equal(sent_ipv4_ttl, 1U,
+		      "On-link forwarded IPv4 packet should decrement TTL");
+}
+
+static void test_route_ipv4_forward_onlink_ttl_expired_drops(void)
+{
+	struct net_pkt *pkt;
+	struct net_ipv4_hdr *hdr;
+	int ret;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_IPV4_FORWARDING);
+
+	net_arp_update(my_iface_alt, &onlink_dest_addr_alt, &gateway_lladdr_alt,
+		       false, true);
+
+	reset_send_state();
+	drain_wait_data();
+
+	pkt = net_pkt_alloc_with_buffer(my_iface, sizeof(struct net_ipv4_hdr),
+					NET_AF_INET, 0, K_NO_WAIT);
+	zassert_not_null(pkt, "On-link forwarding packet alloc failed");
+
+	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IP);
+
+	hdr = (struct net_ipv4_hdr *)net_buf_add(pkt->buffer,
+						 sizeof(struct net_ipv4_hdr));
+	zassert_not_null(hdr, "Cannot reserve IPv4 header");
+
+	memset(hdr, 0, sizeof(*hdr));
+	hdr->vhl = 0x45;
+	hdr->ttl = 1U;
+	hdr->proto = NET_IPPROTO_UDP;
+	hdr->len = net_htons(sizeof(struct net_ipv4_hdr));
+	net_ipv4_addr_copy_raw(hdr->src, forward_src_addr.s4_addr);
+	net_ipv4_addr_copy_raw(hdr->dst, onlink_dest_addr_alt.s4_addr);
+	hdr->chksum = ipv4_header_checksum(hdr);
+
+	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv4_hdr));
+	net_pkt_set_ipv4_opts_len(pkt, 0U);
+	net_pkt_set_iface(pkt, my_iface);
+	net_pkt_set_family(pkt, NET_AF_INET);
+
+	ret = net_route_packet_if(pkt, my_iface_alt);
+	zassert_equal(ret, -ETIMEDOUT,
+		      "TTL-expired on-link packet must not be forwarded");
+	zassert_not_equal(k_sem_take(&wait_data, WAIT_TIME), 0,
+			  "TTL-expired on-link packet unexpectedly sent");
+	zassert_false(sent_pkt_seen,
+		      "TTL-expired on-link packet unexpectedly sent");
+
+	net_pkt_unref(pkt);
+}
+
 ZTEST(route_test_suite, test_route)
 {
 	test_init();
@@ -782,6 +901,8 @@ ZTEST(route_test_suite, test_route)
 	test_route_ipv4_select_src_iface_uses_explicit_route();
 	test_route_ipv4_forward_ttl_expired_drops();
 	test_route_ipv4_forward_packet_between_ifaces();
+	test_route_ipv4_forward_onlink_packet_between_ifaces();
+	test_route_ipv4_forward_onlink_ttl_expired_drops();
 }
 
 ZTEST_SUITE(route_test_suite, NULL, NULL, NULL, NULL, NULL);

--- a/tests/net/route/ipv6/src/main.c
+++ b/tests/net/route/ipv6/src/main.c
@@ -68,6 +68,8 @@ static struct net_in6_addr forward_nexthop = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0,
 						    0, 0, 0, 0, 0x0b, 0x0e, 0x0e, 0x5 } } };
 static struct net_in6_addr forward_dest_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 						     0, 0, 0, 0, 0xd, 0xe, 0x5, 0x9 } } };
+static struct net_in6_addr onlink_dest_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+						    0, 0, 0, 0, 0, 0, 0, 0x77 } } };
 
 /* Extra address is assigned to ll_addr */
 static struct net_in6_addr ll_addr = { { { 0xfe, 0x80, 0x43, 0xb8, 0, 0, 0, 0,
@@ -813,6 +815,103 @@ static void test_route_ipv6_forward_packet_between_ifaces(void)
 	zassert_ok(net_route_ipv6_del(route), "Forwarding route del failed");
 }
 
+static void test_route_ipv6_forward_onlink_packet_between_ifaces(void)
+{
+	struct net_nbr *nbr;
+	struct net_pkt *pkt;
+	struct net_ipv6_hdr *hdr;
+	int ret;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_IPV6_FORWARDING);
+
+	nbr = net_ipv6_nbr_add(peer_iface, &onlink_dest_addr,
+			       &net_route_data_peer.ll_addr, false,
+			       NET_IPV6_NBR_STATE_REACHABLE);
+	zassert_not_null(nbr, "On-link destination neighbor add failed");
+
+	reset_send_state();
+	drain_wait_data();
+	expected_ipv6_dst = &onlink_dest_addr;
+
+	pkt = net_pkt_alloc_with_buffer(my_iface, sizeof(struct net_ipv6_hdr),
+					NET_AF_INET6, NET_IPV6_NEXTHDR_NONE,
+					K_NO_WAIT);
+	zassert_not_null(pkt, "On-link forwarding packet alloc failed");
+
+	hdr = (struct net_ipv6_hdr *)net_buf_add(pkt->buffer,
+						 sizeof(struct net_ipv6_hdr));
+	zassert_not_null(hdr, "Cannot reserve IPv6 header");
+
+	memset(hdr, 0, sizeof(*hdr));
+	hdr->vtc = 0x60;
+	hdr->len = 0U;
+	hdr->nexthdr = NET_IPV6_NEXTHDR_NONE;
+	hdr->hop_limit = 2U;
+	net_ipv6_addr_copy_raw(hdr->src, forward_src_addr.s6_addr);
+	net_ipv6_addr_copy_raw(hdr->dst, onlink_dest_addr.s6_addr);
+
+	net_pkt_set_iface(pkt, my_iface);
+	net_pkt_set_family(pkt, NET_AF_INET6);
+
+	ret = net_route_packet_if(pkt, peer_iface);
+	zassert_ok(ret, "On-link IPv6 route packet failed");
+	zassert_ok(k_sem_take(&wait_data, WAIT_TIME), "On-link forwarded packet was not sent");
+
+	zassert_true(sent_pkt_seen, "On-link forwarded packet not observed");
+	zassert_equal_ptr(sent_iface, peer_iface,
+			  "On-link forwarded packet used wrong egress interface");
+	zassert_equal_ptr(sent_orig_iface, my_iface,
+			  "On-link forwarded packet missing ingress interface");
+	zassert_equal(sent_ipv6_hop_limit, 1U,
+		      "On-link forwarded IPv6 packet should decrement hop limit");
+	zassert_true(sent_forwarding, "On-link packet should be marked forwarded");
+
+	expected_ipv6_dst = NULL;
+	zassert_ok(net_nbr_unlink(nbr, &net_route_data_peer.ll_addr),
+		   "On-link destination neighbor remove failed");
+}
+
+static void test_route_ipv6_forward_onlink_hop_limit_expired_is_dropped(void)
+{
+	struct net_pkt *pkt;
+	struct net_ipv6_hdr *hdr;
+	int ret;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_IPV6_FORWARDING);
+
+	reset_send_state();
+	drain_wait_data();
+
+	pkt = net_pkt_alloc_with_buffer(my_iface, sizeof(struct net_ipv6_hdr),
+					NET_AF_INET6, NET_IPV6_NEXTHDR_NONE,
+					K_NO_WAIT);
+	zassert_not_null(pkt, "On-link forwarding packet alloc failed");
+
+	hdr = (struct net_ipv6_hdr *)net_buf_add(pkt->buffer,
+						 sizeof(struct net_ipv6_hdr));
+	zassert_not_null(hdr, "Cannot reserve IPv6 header");
+
+	memset(hdr, 0, sizeof(*hdr));
+	hdr->vtc = 0x60;
+	hdr->len = 0U;
+	hdr->nexthdr = NET_IPV6_NEXTHDR_NONE;
+	hdr->hop_limit = 1U;
+	net_ipv6_addr_copy_raw(hdr->src, forward_src_addr.s6_addr);
+	net_ipv6_addr_copy_raw(hdr->dst, onlink_dest_addr.s6_addr);
+
+	net_pkt_set_iface(pkt, my_iface);
+	net_pkt_set_family(pkt, NET_AF_INET6);
+
+	ret = net_route_packet_if(pkt, peer_iface);
+	zassert_equal(ret, -ETIMEDOUT,
+		      "Hop-limit-expired on-link packet must not be forwarded");
+	zassert_not_equal(k_sem_take(&wait_data, WAIT_TIME), 0,
+			  "Hop-limit-expired on-link packet unexpectedly sent");
+	zassert_false(sent_pkt_seen,
+		      "Hop-limit-expired on-link packet unexpectedly sent");
+
+	net_pkt_unref(pkt);
+}
 
 /*test case main entry*/
 ZTEST(route_test_suite, test_route)
@@ -840,6 +939,8 @@ ZTEST(route_test_suite, test_route)
 	test_route_ipv6_packet_without_iface();
 	test_route_ipv6_forward_hop_limit_expired_is_dropped();
 	test_route_ipv6_forward_packet_between_ifaces();
+	test_route_ipv6_forward_onlink_packet_between_ifaces();
+	test_route_ipv6_forward_onlink_hop_limit_expired_is_dropped();
 }
 
 ZTEST_SUITE(route_test_suite, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
On-link cross-interface forwarding did not decrement TTL or hop limit, unlike the explicit-route path.

Fixes: #113299