### PR TITLE
drivers: ethernet: sensry: fix return type of prototype

### DIFF
--- a/drivers/ethernet/eth_sensry_sy1xx_mac.c
+++ b/drivers/ethernet/eth_sensry_sy1xx_mac.c
@@ -101,7 +101,6 @@ struct sy1xx_mac_dev_data {
 };
 
 /* prototypes */
-static int sy1xx_mac_set_mac_addr(const struct device *dev);
 static int sy1xx_mac_set_promiscuous_mode(const struct device *dev, bool promiscuous_mode);
 static int sy1xx_mac_set_config(const struct device *dev,
 				struct net_if *iface,


### PR DESCRIPTION
We changed the return type of
sy1xx_mac_set_mac_addr, but forgot to change
the prorotype, but instead of fixing that we can
remove the prototype, as the function is only used after it is been implemented.