### PR TITLE
sysbuild: pass ZEPHYR_BASE to images

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -325,6 +325,7 @@ function(ExternalZephyrProject_Add)
     CMAKE_VERBOSE_MAKEFILE
     WEST_PYTHON        # Temporary export. Waiting for #87083 and extensions.cmake to be cleaned up.
     Python3_EXECUTABLE # Temporary export. Waiting for #87083 and extensions.cmake to be cleaned up.
+    ZEPHYR_BASE
   )
 
   set(sysbuild_cache_file ${CMAKE_BINARY_DIR}/${ZBUILD_APPLICATION}_sysbuild_cache.txt)


### PR DESCRIPTION
Ensure same ZEPHYR_BASE is used by sysbuild and Zephyr images.