### PR TITLE
kconfig: cleanup ZEPHYR_BASE usage

### DIFF
--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_evt_monitor/Kconfig.hl78xx_evt_monitor
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_evt_monitor/Kconfig.hl78xx_evt_monitor
@@ -24,6 +24,6 @@ config HL78XX_EVT_MONITOR_APP_INIT_PRIORITY
 module=HL78XX_EVT_MONITOR
 module-dep=LOG
 module-str= Event notification monitor library
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 endif # HL78XX_EVT_MONITOR

--- a/drivers/usb/uvb/Kconfig
+++ b/drivers/usb/uvb/Kconfig
@@ -22,6 +22,6 @@ config UVB_MAX_MESSAGES
 
 module = UVB
 module-str = USB virtual bus service
-source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 endif # UVB

--- a/modules/nrf_wifi/bus/Kconfig
+++ b/modules/nrf_wifi/bus/Kconfig
@@ -26,7 +26,7 @@ config NRF70_ON_SPI
 module = WIFI_NRF70_BUSLIB
 module-dep = LOG
 module-str = Log level for Wi-Fi nRF70 bus library
-source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 config WIFI_NRF70_BUSLIB_LOG_LEVEL
 	# Enable error by default

--- a/subsys/bluetooth/Kconfig.logging
+++ b/subsys/bluetooth/Kconfig.logging
@@ -364,7 +364,7 @@ endif # BT_VOCS_CLIENT
 if BT_PBP
 module = BT_PBP
 module-str = "Public Broadcast Profile"
-source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 endif # BT_PBP
 
 endmenu # Audio
@@ -561,7 +561,7 @@ endif # BT_IAS_CLIENT
 if BT_IAS
 module = BT_IAS
 module-str = IAS
-source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 endif # BT_IAS
 
 # OTS (subsys/bluetooth/services/ots/Kconfig)
@@ -575,7 +575,7 @@ endif # BT_OTS_CLIENT
 if BT_OTS
 module = BT_OTS
 module-str = BT_OTS
-source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 endif # BT_OTS
 
 endmenu # Services

--- a/subsys/net/lib/ftp/Kconfig
+++ b/subsys/net/lib/ftp/Kconfig
@@ -39,6 +39,6 @@ config FTP_CLIENT_BUF_SIZE
 module=FTP_CLIENT
 module-dep=LOG
 module-str=FTP client
-source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 endif # FTP_CLIENT


### PR DESCRIPTION
Remove `$(ZEPHYR_BASE)` from `source "<file>"`.
Source is always relative to ZEPHYR_BASE, so no need to specify it.