### PR TITLE
manifest: hal_nxp: update revision for __aeabi_memcpy fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: f2a28824f26c55ee68e36f04fb748db9f6a00ed3
+      revision: dd01dc65d73e910fecd9f4a7c550fec16211b5fb
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
## Summary

- Update hal_nxp manifest revision to include `__aeabi_memcpy` aliases in `fsl_memcpy.S`
- Fixes "multiple definition of `memcpy'" link error when `CONFIG_LLEXT=y` on NXP Cortex-M platforms

## Root Cause

Zephyr commit aa31c8a69a1a added `EXPORT_GROUP_SYMBOL` for `__aeabi_memcpy*` in `llext_export.c`. NXP's optimized `fsl_memcpy.S` only defines `memcpy` without `__aeabi_memcpy` aliases, so the linker pulls in picolibc's `memcpy.c.o` (which provides `__aeabi_memcpy` as weak but also carries a strong `memcpy`), causing a multiple definition conflict.

## Fix

hal_nxp PR: https://github.com/zephyrproject-rtos/hal_nxp/pull/753

Adds `.thumb_set` aliases so `__aeabi_memcpy`, `__aeabi_memcpy4`, `__aeabi_memcpy8` resolve to the NXP optimized `memcpy`. Same calling convention — simple alias is correct.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/111367

## Test plan

- [x] `west build -p always tests/subsys/llext/ -b rd_rw612_bga` — passes
- [x] `west build -p always samples/hello_world/ -b mimxrt1180_evk/mimxrt1189/cm33` — passes
- [x] Verified `__aeabi_memcpy*` symbols point to NXP optimized implementation via `nm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)