### PR TITLE
scripts: pylib: twister: shell: make command echo timeout configurable

### DIFF
--- a/samples/sensor/sensor_shell/pytest/test_sensor_shell.py
+++ b/samples/sensor/sensor_shell/pytest/test_sensor_shell.py
@@ -30,7 +30,13 @@ def test_sensor_shell_get(shell: Shell):
     for channel in range(channel_count):
         logger.info(f'channel {channel}')
         shell.wait_for_prompt()
-        lines = shell.exec_command(f'sensor get sensor@0 {channel}')
+        # This loop issues one command per channel, so under parallel/loaded
+        # targets the command echo can be delayed past the short default. Use
+        # the platform's base timeout to avoid spurious "did not find line"
+        # failures on the command echo.
+        lines = shell.exec_command(
+            f'sensor get sensor@0 {channel}', command_timeout=shell.base_timeout
+        )
         assert any([f'channel type={channel}' in line for line in lines]), 'expected response not found'
 
     logger.info('response is valid')

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py
@@ -58,6 +58,7 @@ class Shell:
         *,
         get_full_output: bool = False,
         full_output_timeout: float | None = None,
+        command_timeout: float = 1.0,
     ) -> list[str]:
         """
         Send shell command to a device and return response. Passed command
@@ -72,6 +73,11 @@ class Shell:
         :param full_output_timeout: Seconds to spend draining additional lines
             after the prompt. When ``get_full_output`` is True and this is
             omitted, ``timeout`` (or :attr:`base_timeout`) is used.
+        :param command_timeout: Seconds to wait for the device to echo back the
+            sent command. The echo is normally immediate, so the default is
+            short, but it can be increased for slow or heavily loaded targets
+            (e.g. several QEMU instances running in parallel) where the echo may
+            be delayed.
         """
         timeout = timeout or self.base_timeout
         command_ext = f'{command}\n\n'
@@ -83,7 +89,7 @@ class Shell:
         # wait for device command print - it should be done immediately after sending command to device
         lines.extend(
             self._device.readlines_until(
-                regex=regex_command, timeout=1.0, print_output=print_output
+                regex=regex_command, timeout=command_timeout, print_output=print_output
             )
         )
         # wait for device command execution


### PR DESCRIPTION
Shell.exec_command() waited a hardcoded 1.0s for the device to echo back the sent command, and callers had no way to extend it - the existing `timeout` argument only covers the prompt/execution wait, not the echo.

On slow or heavily loaded targets, e.g. several QEMU instances running in parallel, the echo can be delayed past 1.0s, leading to spurious "Did not find line" assertion failures.

Add a keyword-only `command_timeout` argument, defaulting to the previous 1.0s so existing callers are unaffected, allowing tests to extend the echo wait when needed.