### PR TITLE
drivers: lora: lbm: fix DIO1 interrupt race when stopping async RX

### DIFF
--- a/drivers/lora/lora-basics-modem/lbm_common.c
+++ b/drivers/lora/lora-basics-modem/lbm_common.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Embeint Inc
+ * Copyright (c) 2026 Jakub Rzeszutko <jakub.rzeszutko@verkada.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -59,6 +60,12 @@ static bool modem_release(const struct device *dev)
 	if (!atomic_cas(&data->modem_state, STATE_BUSY, STATE_CLEANUP)) {
 		return false;
 	}
+
+	/* Disable DIO1 interrupt immediately so no new work items are scheduled
+	 * while the chip is transitioning to sleep. Any work item already queued
+	 * will find MODE_SLEEP and return early without touching the hardware.
+	 */
+	lbm_optional_dio1_irq_configure_dt(&config->dio1, GPIO_INT_DISABLE);
 
 	/* Configure modem for sleep */
 	lbm_driver_antenna_configure(dev, MODE_SLEEP);
@@ -241,6 +248,12 @@ int lbm_lora_send_async(const struct device *dev, uint8_t *msg, uint32_t msg_len
 		goto release;
 	}
 
+	/* Clear any stale IRQ flags and re-arm DIO1 before starting TX so that
+	 * the TX-done interrupt is delivered.
+	 */
+	(void)ral_clear_irq_status(&config->ralf.ral, RAL_IRQ_ALL);
+	lbm_optional_dio1_irq_configure_dt(&config->dio1, GPIO_INT_EDGE_TO_ACTIVE);
+
 	/* Start the transmission */
 	status = ral_set_tx(&config->ralf.ral);
 	if (status != RAL_STATUS_OK) {
@@ -316,6 +329,12 @@ int lbm_lora_recv(const struct device *dev, uint8_t *msg, uint8_t msg_len, k_tim
 	lbm_driver_antenna_configure(dev, MODE_RX);
 	data->modem_mode = MODE_RX;
 
+	/* Clear any stale IRQ flags from the previous operation, then re-arm
+	 * DIO1 so the RX-done interrupt is delivered.
+	 */
+	(void)ral_clear_irq_status(&config->ralf.ral, RAL_IRQ_ALL);
+	lbm_optional_dio1_irq_configure_dt(&config->dio1, GPIO_INT_EDGE_TO_ACTIVE);
+
 	/* Start the reception in continuous mode.
 	 * Receive timeouts are handled by the k_poll timeout.
 	 * In theory we should be able to use the one-shot mode here and transition
@@ -387,6 +406,12 @@ int lbm_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user_da
 	/* Store user state */
 	data->rx_state.async.rx_cb = cb;
 	data->rx_state.async.user_data = user_data;
+
+	/* Clear any stale IRQ flags from the previous operation, then re-arm
+	 * DIO1 so packet-received interrupts are delivered.
+	 */
+	(void)ral_clear_irq_status(&config->ralf.ral, RAL_IRQ_ALL);
+	lbm_optional_dio1_irq_configure_dt(&config->dio1, GPIO_INT_EDGE_TO_ACTIVE);
 
 	/* Start the reception in continuous mode */
 	status = ral_set_rx(&config->ralf.ral, RAL_RX_TIMEOUT_CONTINUOUS_MODE);
@@ -529,7 +554,10 @@ static void op_done_work_handler(struct k_work *work)
 
 	switch (data->modem_mode) {
 	case MODE_SLEEP:
-		LOG_WRN("Unexpected modem mode (%d)", data->modem_mode);
+		/* DIO1 was disabled by modem_release() before the chip went to
+		 * sleep. This work item was already queued when DIO1 fired. The
+		 * modem is now idle, just return without touching the hardware.
+		 */
 		return;
 	case MODE_TX:
 	case MODE_CW:
@@ -558,6 +586,15 @@ static void op_done_work_handler(struct k_work *work)
 	case MODE_CAD:
 		LOG_DBG("CAD complete (TBC)");
 		break;
+	}
+
+	/* The async RX callback above may have stopped reception by calling
+	 * lora_recv_async(dev, NULL, NULL). In that case modem_release() has
+	 * already disabled DIO1 and put the chip to sleep, so accessing the
+	 * hardware here would needlessly wake it again. Nothing left to do.
+	 */
+	if (data->modem_mode == MODE_SLEEP) {
+		return;
 	}
 
 	/* Get and reset the current IRQ state */

--- a/drivers/lora/lora-basics-modem/lbm_common.h
+++ b/drivers/lora/lora-basics-modem/lbm_common.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Embeint Inc
+ * Copyright (c) 2026 Jakub Rzeszutko <jakub.rzeszutko@verkada.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,6 +36,8 @@ struct lbm_lora_config_common {
 	/* LBM radio abstraction layer structure */
 	ralf_t ralf;
 	bool force_ldro;
+	/* DIO1 interrupt pin - managed by lbm_common.c to control interrupt enable/disable */
+	struct gpio_dt_spec dio1;
 };
 
 /* Common LBM modem data, must be first element of device data */
@@ -115,6 +118,27 @@ static inline int lbm_optional_gpio_set_dt(const struct gpio_dt_spec *spec, int 
 {
 	if (spec->port != NULL) {
 		return gpio_pin_set_dt(spec, value);
+	}
+	return 0;
+}
+
+/**
+ * @brief Configure the DIO1 interrupt if the pin has been provided
+ *
+ * Drivers that route their interrupt through a single DIO1 line (e.g. SX126x,
+ * LR11xx) populate the common dio1 pin. Other parts (e.g. SX127x) manage
+ * several DIO lines themselves and leave it unset; for those this is a no-op.
+ *
+ * @param spec DIO1 GPIO specification from devicetree
+ * @param flags Interrupt configuration flags
+ *
+ * @return a value from gpio_pin_interrupt_configure_dt()
+ */
+static inline int lbm_optional_dio1_irq_configure_dt(const struct gpio_dt_spec *spec,
+						     gpio_flags_t flags)
+{
+	if (spec->port != NULL) {
+		return gpio_pin_interrupt_configure_dt(spec, flags);
 	}
 	return 0;
 }

--- a/drivers/lora/lora-basics-modem/lbm_sx126x.c
+++ b/drivers/lora/lora-basics-modem/lbm_sx126x.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Embeint Inc
+ * Copyright (c) 2026 Jakub Rzeszutko <jakub.rzeszutko@verkada.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -89,7 +90,6 @@ struct lbm_sx126x_config {
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec reset;
 	struct gpio_dt_spec busy;
-	struct gpio_dt_spec dio1;
 	struct gpio_dt_spec ant_enable;
 	struct gpio_dt_spec tx_enable;
 	struct gpio_dt_spec rx_enable;
@@ -147,7 +147,7 @@ static int sx126x_ensure_device_ready(const struct device *dev, k_timeout_t time
 	if (data->asleep) {
 		LOG_DBG("SLEEP -> ACTIVE");
 		/* Re-enable the DIO1 interrupt */
-		gpio_pin_interrupt_configure_dt(&config->dio1, GPIO_INT_EDGE_TO_ACTIVE);
+		gpio_pin_interrupt_configure_dt(&config->lbm_common.dio1, GPIO_INT_EDGE_TO_ACTIVE);
 		/* DO NOT USE sx126x_get_status as this will result in recursion */
 		ret = spi_write_dt(&config->spi, &tx_buf_set);
 		if (ret) {
@@ -194,7 +194,7 @@ sx126x_hal_status_t sx126x_hal_write(const void *context, const uint8_t *command
 	if (command[0] == SX126X_SET_SLEEP) {
 		LOG_DBG("ACTIVE -> SLEEP");
 		/* Disable the DIO1 interrupt to save power */
-		(void)gpio_pin_interrupt_configure_dt(&config->dio1, GPIO_INT_DISABLE);
+		(void)gpio_pin_interrupt_configure_dt(&config->lbm_common.dio1, GPIO_INT_DISABLE);
 		dev_data->asleep = true;
 		/* Wait for sleep to take effect */
 		k_sleep(K_MSEC(1));
@@ -455,15 +455,15 @@ int lbm_driver_add_dio1_gpio_callback(const struct device *dev,
 		return -EINVAL;
 	}
 
-	gpio_init_callback(callback, handler, BIT(config->dio1.pin));
+	gpio_init_callback(callback, handler, BIT(config->lbm_common.dio1.pin));
 
-	ret = gpio_add_callback(config->dio1.port, callback);
+	ret = gpio_add_callback(config->lbm_common.dio1.port, callback);
 	if (ret < 0) {
 		LOG_ERR("Failed to add GPIO callback: %d", ret);
 		return ret;
 	}
 
-	gpio_pin_interrupt_configure_dt(&config->dio1, GPIO_INT_EDGE_TO_ACTIVE);
+	gpio_pin_interrupt_configure_dt(&config->lbm_common.dio1, GPIO_INT_EDGE_TO_ACTIVE);
 
 	LOG_DBG("Added user GPIO callback");
 	return 0;
@@ -483,7 +483,7 @@ int lbm_driver_remove_dio1_gpio_callback(const struct device *dev,
 		return -EINVAL;
 	}
 
-	ret = gpio_remove_callback(config->dio1.port, callback);
+	ret = gpio_remove_callback(config->lbm_common.dio1.port, callback);
 	if (ret < 0) {
 		LOG_ERR("Failed to remove GPIO callback: %d", ret);
 		return ret;
@@ -521,12 +521,13 @@ int lbm_driver_radio_init(const struct device *dev)
 	}
 
 	/* Configure and enable interrupts */
-	gpio_init_callback(&data->dio1_callback, sx126x_dio1_callback, BIT(config->dio1.pin));
-	if (gpio_add_callback(config->dio1.port, &data->dio1_callback) < 0) {
+	gpio_init_callback(&data->dio1_callback, sx126x_dio1_callback,
+			   BIT(config->lbm_common.dio1.pin));
+	if (gpio_add_callback(config->lbm_common.dio1.port, &data->dio1_callback) < 0) {
 		LOG_ERR("Could not set GPIO callback for DIO1 interrupt.");
 		return -EIO;
 	}
-	gpio_pin_interrupt_configure_dt(&config->dio1, GPIO_INT_EDGE_TO_ACTIVE);
+	gpio_pin_interrupt_configure_dt(&config->lbm_common.dio1, GPIO_INT_EDGE_TO_ACTIVE);
 
 	LOG_INF("Radio initialized");
 	return 0;
@@ -546,7 +547,7 @@ static int sx126x_init(const struct device *dev)
 	/* Setup GPIOs */
 	if (gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT_INACTIVE) ||
 	    gpio_pin_configure_dt(&config->busy, GPIO_INPUT) ||
-	    gpio_pin_configure_dt(&config->dio1, GPIO_INPUT)) {
+	    gpio_pin_configure_dt(&config->lbm_common.dio1, GPIO_INPUT)) {
 		LOG_ERR("GPIO configuration failed.");
 		return -EIO;
 	}
@@ -575,11 +576,11 @@ static int sx126x_init(const struct device *dev)
 	static const struct lbm_sx126x_config config_##node_id = {                                 \
 		.lbm_common.ralf = RALF_SX126X_INSTANTIATE(DEVICE_DT_GET(node_id)),                \
 		.lbm_common.force_ldro = DT_PROP(node_id, force_ldro),                             \
+		.lbm_common.dio1 = GPIO_DT_SPEC_GET(node_id, dio1_gpios),                          \
 		.spi = SPI_DT_SPEC_GET(                                                            \
 			node_id, SPI_WORD_SET(8) | SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB),         \
 		.reset = GPIO_DT_SPEC_GET(node_id, reset_gpios),                                   \
 		.busy = GPIO_DT_SPEC_GET(node_id, busy_gpios),                                     \
-		.dio1 = GPIO_DT_SPEC_GET(node_id, dio1_gpios),                                     \
 		.ant_enable = GPIO_DT_SPEC_GET_OR(node_id, antenna_enable_gpios, {0}),             \
 		.tx_enable = GPIO_DT_SPEC_GET_OR(node_id, tx_enable_gpios, {0}),                   \
 		.rx_enable = GPIO_DT_SPEC_GET_OR(node_id, rx_enable_gpios, {0}),                   \


### PR DESCRIPTION
Calling `lora_recv_async(dev, NULL, NULL)` from inside the async callback races with the DIO1 interrupt. `modem_release()` sets the mode to `MODE_SLEEP` and sleeps the chip, but DIO1 is still enabled, so a packet arriving in that window schedules a work item that then runs with `MODE_SLEEP` set and logs `Unexpected modem mode (0)`. On the in-tree SX126x path this also leaves the chip awake instead of asleep; on parts that re-assert DIO1 on wake (an LR11xx board, where I hit this) it turns into an infinite loop.

Fix, in three parts:

- Disable DIO1 in `modem_release()` before sleeping and re-enable it (with a stale-IRQ clear) when starting the next RX/TX. `dio1` is moved into `lbm_lora_config_common` so the common layer owns the gating. Drivers that don't use a single DIO1 line (SX127x) leave it unset and it's accessed through a NULL-guarded helper.
- The work handler returns early on `MODE_SLEEP` instead of touching the hardware.
- When the async callback stops reception, the handler sees the modem was already released and returns before re-reading the IRQ, so the chip stays asleep.

All changes are in `lbm_common.c` and the in-tree `lbm_sx126x.c` / `lbm_sx127x.c`. LR11xx isn't upstream yet — it's just where this escalated into a hard hang; the driver comes in a separate PR.

Fixes #111484