### PR TITLE
doc rendering: fix and update formatting in header files inline comments

### DIFF
--- a/drivers/wifi/ameba/ameba_wifi_drv.c
+++ b/drivers/wifi/ameba/ameba_wifi_drv.c
@@ -673,7 +673,7 @@ static const struct net_wifi_mgmt_offload rtk_api = {
 	.wifi_mgmt_api = &ameba_wifi_mgmt,
 };
 
-/* inst replace by DT_DRV_COMPAT(inst) */
+/* inst replace by DT_DRV_INST(inst) */
 NET_DEVICE_DT_INST_DEFINE(0, ameba_wifi_dev_init, NULL, &ameba_data[STA_WLAN_INDEX], NULL,
 			  CONFIG_WIFI_INIT_PRIORITY, &rtk_api, ETHERNET_L2,
 			  NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU);

--- a/include/zephyr/cache.h
+++ b/include/zephyr/cache.h
@@ -558,7 +558,7 @@ static ALWAYS_INLINE void sys_cache_flush(void *addr, size_t size)
  *
  * @param ptr Pointer to be checked.
  *
- * @return True is pointer is in any coherence regions, false otherwise.
+ * @return True if pointer is in any coherence regions, false otherwise.
  */
 static ALWAYS_INLINE bool sys_cache_is_mem_coherent(void *ptr)
 {

--- a/include/zephyr/devicetree/can.h
+++ b/include/zephyr/devicetree/can.h
@@ -121,8 +121,8 @@ extern "C" {
 		    MIN(DT_PROP_OR(DT_CHILD(node_id, can_transceiver), max_bitrate, max), max))
 
 /**
- * @brief Get the minimum transceiver bitrate for a DT_DRV_COMPAT CAN controller
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get the minimum transceiver bitrate for a @c DT_DRV_COMPAT CAN controller
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param min minimum bitrate supported by the CAN controller
  * @return the minimum bitrate supported by the CAN controller/transceiver combination
  * @see DT_CAN_TRANSCEIVER_MIN_BITRATE()
@@ -131,8 +131,8 @@ extern "C" {
 	DT_CAN_TRANSCEIVER_MIN_BITRATE(DT_DRV_INST(inst), min)
 
 /**
- * @brief Get the maximum transceiver bitrate for a DT_DRV_COMPAT CAN controller
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get the maximum transceiver bitrate for a @c DT_DRV_COMPAT CAN controller
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param max maximum bitrate supported by the CAN controller
  * @return the maximum bitrate supported by the CAN controller/transceiver combination
  * @see DT_CAN_TRANSCEIVER_MAX_BITRATE()

--- a/include/zephyr/devicetree/clocks.h
+++ b/include/zephyr/devicetree/clocks.h
@@ -130,8 +130,7 @@ extern "C" {
  *
  * @param node_id node identifier
  * @param idx logical index into "clocks"
- * @return the node identifier for the clock controller referenced at
- *         index "idx"
+ * @return the node identifier for the clock controller referenced at index @p idx
  * @see DT_PHANDLE_BY_IDX()
  */
 #define DT_CLOCKS_CTLR_BY_IDX(node_id, idx) \
@@ -168,7 +167,7 @@ extern "C" {
  * @param node_id node identifier
  * @param name lowercase-and-underscores name of a clocks element
  *             as defined by the node's clock-names property
- * @return the node identifier for the clock controller referenced by name
+ * @return the node identifier for the clock controller referenced by @p name
  * @see DT_PHANDLE_BY_NAME()
  */
 #define DT_CLOCKS_CTLR_BY_NAME(node_id, name) \
@@ -202,7 +201,7 @@ extern "C" {
  * @param node_id node identifier for a node with a clocks property
  * @param idx logical index into clocks property
  * @param cell lowercase-and-underscores cell name
- * @return the cell value at index "idx"
+ * @return the cell value at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_CLOCKS_CELL_BY_IDX(node_id, idx, cell) \
@@ -285,8 +284,7 @@ extern "C" {
  *
  * @param inst instance number
  * @param idx logical index into "clocks"
- * @return the node identifier for the clock controller referenced at
- *         index "idx"
+ * @return the node identifier for the clock controller referenced at index @p idx
  * @see DT_CLOCKS_CTLR_BY_IDX()
  */
 #define DT_INST_CLOCKS_CTLR_BY_IDX(inst, idx) \
@@ -321,7 +319,7 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into clocks property
  * @param cell lowercase-and-underscores cell name
- * @return the cell value at index "idx"
+ * @return the cell value at index @p idx
  * @see DT_CLOCKS_CELL_BY_IDX()
  */
 #define DT_INST_CLOCKS_CELL_BY_IDX(inst, idx, cell) \

--- a/include/zephyr/devicetree/clocks.h
+++ b/include/zephyr/devicetree/clocks.h
@@ -253,7 +253,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_CLOCKS_HAS_IDX(DT_DRV_INST(inst), idx)
- * @param inst DT_DRV_COMPAT instance number; may or may not have any <tt>clocks</tt> property
+ * @param inst @c DT_DRV_COMPAT instance number; may or may not have any <tt>clocks</tt> property
  * @param idx index of a <tt>clocks</tt> property phandle-array whose existence to check
  * @return 1 if the index exists, 0 otherwise
  */
@@ -262,7 +262,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_CLOCK_HAS_NAME(DT_DRV_INST(inst), name)
- * @param inst DT_DRV_COMPAT instance number; may or may not have any <tt>clock-names</tt> property.
+ * @param inst @c DT_DRV_COMPAT instance number; may or may not have any <tt>clock-names</tt> property.
  * @param name lowercase-and-underscores <tt>clock-names</tt> cell value name to check
  * @return 1 if the clock name exists, 0 otherwise
  */
@@ -312,9 +312,9 @@ extern "C" {
 	DT_CLOCKS_CTLR_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's clock specifier's cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's clock specifier's cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into <tt>clocks</tt> property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index @p idx
@@ -324,8 +324,8 @@ extern "C" {
 	DT_CLOCKS_CELL_BY_IDX(DT_DRV_INST(inst), idx, cell)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's clock specifier's cell value by name
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get a @c DT_DRV_COMPAT instance's clock specifier's cell value by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a <tt>clocks</tt> element
  *             as defined by the node's <tt>clock-names</tt> property
  * @param cell lowercase-and-underscores cell name
@@ -337,7 +337,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_CLOCKS_CELL_BY_IDX(inst, 0, cell)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param cell lowercase-and-underscores cell name
  * @return the value of the cell inside the specifier at index 0
  */

--- a/include/zephyr/devicetree/clocks.h
+++ b/include/zephyr/devicetree/clocks.h
@@ -262,7 +262,8 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_CLOCK_HAS_NAME(DT_DRV_INST(inst), name)
- * @param inst @c DT_DRV_COMPAT instance number; may or may not have any <tt>clock-names</tt> property.
+ * @param inst @c DT_DRV_COMPAT instance number; may or may not have any <tt>clock-names</tt>
+ *             property.
  * @param name lowercase-and-underscores <tt>clock-names</tt> cell value name to check
  * @return 1 if the clock name exists, 0 otherwise
  */

--- a/include/zephyr/devicetree/clocks.h
+++ b/include/zephyr/devicetree/clocks.h
@@ -24,9 +24,9 @@ extern "C" {
  */
 
 /**
- * @brief Test if a node has a clocks phandle-array property at a given index
+ * @brief Test if a node has a <tt>clocks</tt> phandle-array property at a given index
  *
- * This expands to 1 if the given index is valid clocks property phandle-array index.
+ * This expands to 1 if the given index is valid <tt>clocks</tt> property phandle-array index.
  * Otherwise, it expands to 0.
  *
  * Example devicetree fragment:
@@ -46,17 +46,17 @@ extern "C" {
  *     DT_CLOCKS_HAS_IDX(DT_NODELABEL(n1), 2) // 0
  *     DT_CLOCKS_HAS_IDX(DT_NODELABEL(n2), 1) // 0
  *
- * @param node_id node identifier; may or may not have any clocks property
- * @param idx index of a clocks property phandle-array whose existence to check
+ * @param node_id node identifier; may or may not have any <tt>clocks</tt> property
+ * @param idx index of a <tt>clocks</tt> property phandle-array whose existence to check
  * @return 1 if the index exists, 0 otherwise
  */
 #define DT_CLOCKS_HAS_IDX(node_id, idx) \
 	DT_PROP_HAS_IDX(node_id, clocks, idx)
 
 /**
- * @brief Test if a node has a clock-names array property holds a given name
+ * @brief Test if a node has a <tt>clock-names</tt> array property holds a given name
  *
- * This expands to 1 if the name is available as clocks-name array property cell.
+ * This expands to 1 if the name is available as <tt>clock-names</tt> array property cell.
  * Otherwise, it expands to 0.
  *
  * Example devicetree fragment:
@@ -77,15 +77,15 @@ extern "C" {
  *     DT_CLOCKS_HAS_NAME(DT_NODELABEL(n1), beta)  // 1
  *     DT_CLOCKS_HAS_NAME(DT_NODELABEL(n2), beta)  // 0
  *
- * @param node_id node identifier; may or may not have any clock-names property.
- * @param name lowercase-and-underscores clock-names cell value name to check
+ * @param node_id node identifier; may or may not have any <tt>clock-names</tt> property.
+ * @param name lowercase-and-underscores <tt>clock-names</tt> cell value name to check
  * @return 1 if the clock name exists, 0 otherwise
  */
 #define DT_CLOCKS_HAS_NAME(node_id, name) \
 	DT_PROP_HAS_NAME(node_id, clocks, name)
 
 /**
- * @brief Get the number of elements in a clocks property
+ * @brief Get the number of elements in a <tt>clocks</tt> property
  *
  * Example devicetree fragment:
  *
@@ -102,7 +102,7 @@ extern "C" {
  *     DT_NUM_CLOCKS(DT_NODELABEL(n1)) // 2
  *     DT_NUM_CLOCKS(DT_NODELABEL(n2)) // 1
  *
- * @param node_id node identifier with a clocks property
+ * @param node_id node identifier with a <tt>clocks</tt> property
  * @return number of elements in the property
  */
 #define DT_NUM_CLOCKS(node_id) \
@@ -111,7 +111,7 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the controller phandle from a
- *        "clocks" phandle-array property at an index
+ *        <tt>clocks</tt> phandle-array property at an index
  *
  * Example devicetree fragment:
  *
@@ -129,7 +129,7 @@ extern "C" {
  *     DT_CLOCKS_CTLR_BY_IDX(DT_NODELABEL(n), 1)) // DT_NODELABEL(clk2)
  *
  * @param node_id node identifier
- * @param idx logical index into "clocks"
+ * @param idx logical index into <tt>clocks</tt> property
  * @return the node identifier for the clock controller referenced at index @p idx
  * @see DT_PHANDLE_BY_IDX()
  */
@@ -139,15 +139,14 @@ extern "C" {
 /**
  * @brief Equivalent to DT_CLOCKS_CTLR_BY_IDX(node_id, 0)
  * @param node_id node identifier
- * @return a node identifier for the clocks controller at index 0
- *         in "clocks"
+ * @return a node identifier for the clocks controller at index 0 in <tt>clocks</tt>
  * @see DT_CLOCKS_CTLR_BY_IDX()
  */
 #define DT_CLOCKS_CTLR(node_id) DT_CLOCKS_CTLR_BY_IDX(node_id, 0)
 
 /**
  * @brief Get the node identifier for the controller phandle from a
- *        clocks phandle-array property by name
+ *        <tt>clocks</tt> phandle-array property by name
  *
  * Example devicetree fragment:
  *
@@ -165,8 +164,8 @@ extern "C" {
  *     DT_CLOCKS_CTLR_BY_NAME(DT_NODELABEL(n), beta) // DT_NODELABEL(clk2)
  *
  * @param node_id node identifier
- * @param name lowercase-and-underscores name of a clocks element
- *             as defined by the node's clock-names property
+ * @param name lowercase-and-underscores name of a <tt>clocks</tt> element
+ *             as defined by the node's <tt>clock-names</tt> property
  * @return the node identifier for the clock controller referenced by @p name
  * @see DT_PHANDLE_BY_NAME()
  */
@@ -198,8 +197,8 @@ extern "C" {
  *     DT_CLOCKS_CELL_BY_IDX(DT_NODELABEL(n), 0, bus) // 10
  *     DT_CLOCKS_CELL_BY_IDX(DT_NODELABEL(n), 1, bits) // 40
  *
- * @param node_id node identifier for a node with a clocks property
- * @param idx logical index into clocks property
+ * @param node_id node identifier for a node with a <tt>clocks</tt> property
+ * @param idx logical index into <tt>clocks</tt> property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index @p idx
  * @see DT_PHA_BY_IDX()
@@ -233,9 +232,9 @@ extern "C" {
  *     DT_CLOCKS_CELL_BY_NAME(DT_NODELABEL(n), alpha, bus) // 10
  *     DT_CLOCKS_CELL_BY_NAME(DT_NODELABEL(n), beta, bits) // 40
  *
- * @param node_id node identifier for a node with a clocks property
- * @param name lowercase-and-underscores name of a clocks element
- *             as defined by the node's clock-names property
+ * @param node_id node identifier for a node with a <tt>clocks</tt> property
+ * @param name lowercase-and-underscores name of a <tt>clocks</tt> element
+ *             as defined by the node's <tt>clock-names</tt> property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value in the specifier at the named element
  * @see DT_PHA_BY_NAME()
@@ -245,7 +244,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_CLOCKS_CELL_BY_IDX(node_id, 0, cell)
- * @param node_id node identifier for a node with a clocks property
+ * @param node_id node identifier for a node with a <tt>clocks</tt> property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index 0
  * @see DT_CLOCKS_CELL_BY_IDX()
@@ -254,8 +253,8 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_CLOCKS_HAS_IDX(DT_DRV_INST(inst), idx)
- * @param inst DT_DRV_COMPAT instance number; may or may not have any clocks property
- * @param idx index of a clocks property phandle-array whose existence to check
+ * @param inst DT_DRV_COMPAT instance number; may or may not have any <tt>clocks</tt> property
+ * @param idx index of a <tt>clocks</tt> property phandle-array whose existence to check
  * @return 1 if the index exists, 0 otherwise
  */
 #define DT_INST_CLOCKS_HAS_IDX(inst, idx) \
@@ -263,8 +262,8 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_CLOCK_HAS_NAME(DT_DRV_INST(inst), name)
- * @param inst DT_DRV_COMPAT instance number; may or may not have any clock-names property.
- * @param name lowercase-and-underscores clock-names cell value name to check
+ * @param inst DT_DRV_COMPAT instance number; may or may not have any <tt>clock-names</tt> property.
+ * @param name lowercase-and-underscores <tt>clock-names</tt> cell value name to check
  * @return 1 if the clock name exists, 0 otherwise
  */
 #define DT_INST_CLOCKS_HAS_NAME(inst, name) \
@@ -273,17 +272,17 @@ extern "C" {
 /**
  * @brief Equivalent to DT_NUM_CLOCKS(DT_DRV_INST(inst))
  * @param inst instance number
- * @return number of elements in the clocks property
+ * @return number of elements in the <tt>clocks</tt> property
  */
 #define DT_INST_NUM_CLOCKS(inst) \
 	DT_NUM_CLOCKS(DT_DRV_INST(inst))
 
 /**
  * @brief Get the node identifier for the controller phandle from a
- *        "clocks" phandle-array property at an index
+ *        <tt>clocks</tt> phandle-array property at an index
  *
  * @param inst instance number
- * @param idx logical index into "clocks"
+ * @param idx logical index into <tt>clocks</tt> property
  * @return the node identifier for the clock controller referenced at index @p idx
  * @see DT_CLOCKS_CTLR_BY_IDX()
  */
@@ -293,19 +292,18 @@ extern "C" {
 /**
  * @brief Equivalent to DT_INST_CLOCKS_CTLR_BY_IDX(inst, 0)
  * @param inst instance number
- * @return a node identifier for the clocks controller at index 0
- *         in "clocks"
+ * @return a node identifier for the clocks controller at index 0 in <tt>clocks</tt> property
  * @see DT_CLOCKS_CTLR()
  */
 #define DT_INST_CLOCKS_CTLR(inst) DT_INST_CLOCKS_CTLR_BY_IDX(inst, 0)
 
 /**
  * @brief Get the node identifier for the controller phandle from a
- *        clocks phandle-array property by name
+ *        <tt>clocks</tt> phandle-array property by name
  *
  * @param inst instance number
- * @param name lowercase-and-underscores name of a clocks element
- *             as defined by the node's clock-names property
+ * @param name lowercase-and-underscores name of a <tt>clocks</tt> element
+ *             as defined by the node's <tt>clock-names</tt> property
  * @return the node identifier for the clock controller referenced by
  *         the named element
  * @see DT_CLOCKS_CTLR_BY_NAME()
@@ -317,7 +315,7 @@ extern "C" {
  * @brief Get a DT_DRV_COMPAT instance's clock specifier's cell value
  *        at an index
  * @param inst DT_DRV_COMPAT instance number
- * @param idx logical index into clocks property
+ * @param idx logical index into <tt>clocks</tt> property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index @p idx
  * @see DT_CLOCKS_CELL_BY_IDX()
@@ -328,8 +326,8 @@ extern "C" {
 /**
  * @brief Get a DT_DRV_COMPAT instance's clock specifier's cell value by name
  * @param inst DT_DRV_COMPAT instance number
- * @param name lowercase-and-underscores name of a clocks element
- *             as defined by the node's clock-names property
+ * @param name lowercase-and-underscores name of a <tt>clocks</tt> element
+ *             as defined by the node's <tt>clock-names</tt> property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value in the specifier at the named element
  * @see DT_CLOCKS_CELL_BY_NAME()

--- a/include/zephyr/devicetree/display.h
+++ b/include/zephyr/devicetree/display.h
@@ -24,8 +24,8 @@ extern "C" {
  */
 
 /**
- * @brief Get display node identifier by logical index from "displays" property of node with
- * compatible "zephyr,displays"
+ * @brief Get display node identifier by logical index from <tt>displays</tt> property of node with
+ * compatible <tt>"zephyr,displays"</tt>
  *
  * Example devicetree fragment:
  *
@@ -53,7 +53,7 @@ extern "C" {
  *     DT_ZEPHYR_DISPLAY(1) // node identifier for display node node-3
  * @endcode
  *
- * @param idx logical index of display node's phandle in "displays" property
+ * @param idx logical index of display node's phandle in <tt>displays</tt> property
  *
  * @return display node identifier, @ref DT_INVALID_NODE otherwise
  */
@@ -63,8 +63,9 @@ extern "C" {
 /**
  * @brief Get number of zephyr displays
  *
- * @return number of displays designated by "displays" property of "zephyr,displays" compatible
- * node, if it exists, otherwise 1 if "zephyr,display" chosen property exists, 0 otherwise
+ * @return number of displays designated by <tt>displays</tt> property of <tt>"zephyr,displays"</tt>
+ * compatible node, if it exists, otherwise 1 if <tt>"zephyr,display"</tt> chosen property exists,
+ * 0 otherwise
  */
 #define DT_ZEPHYR_DISPLAYS_COUNT                                                                   \
 	COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(zephyr_displays),                                    \

--- a/include/zephyr/devicetree/dma.h
+++ b/include/zephyr/devicetree/dma.h
@@ -25,7 +25,7 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the DMA controller from a
- *        dmas property at an index
+ *        <tt>dmas</tt> property at an index
  *
  * Example devicetree fragment:
  *
@@ -43,8 +43,8 @@ extern "C" {
  *     DT_DMAS_CTLR_BY_IDX(DT_NODELABEL(n), 0) // DT_NODELABEL(dma1)
  *     DT_DMAS_CTLR_BY_IDX(DT_NODELABEL(n), 1) // DT_NODELABEL(dma2)
  *
- * @param node_id node identifier for a node with a dmas property
- * @param idx logical index into dmas property
+ * @param node_id node identifier for a node with a <tt>dmas</tt> property
+ * @param idx logical index into <tt>dmas</tt> property
  * @return the node identifier for the DMA controller referenced at index @p idx
  * @see DT_PROP_BY_PHANDLE_IDX()
  */
@@ -52,7 +52,7 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the DMA controller from a
- *        dmas property by name
+ *        <tt>dmas</tt> property by name
  *
  * Example devicetree fragment:
  *
@@ -71,8 +71,8 @@ extern "C" {
  *     DT_DMAS_CTLR_BY_NAME(DT_NODELABEL(n), tx) // DT_NODELABEL(dma1)
  *     DT_DMAS_CTLR_BY_NAME(DT_NODELABEL(n), rx) // DT_NODELABEL(dma2)
  *
- * @param node_id node identifier for a node with a dmas property
- * @param name lowercase-and-underscores name of a dmas element
+ * @param node_id node identifier for a node with a <tt>dmas</tt> property
+ * @param name lowercase-and-underscores name of a <tt>dmas</tt> element
  *             as defined by the node's dma-names property
  * @return the node identifier for the DMA controller in the named element
  * @see DT_PHANDLE_BY_NAME()
@@ -82,19 +82,19 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_DMAS_CTLR_BY_IDX(node_id, 0)
- * @param node_id node identifier for a node with a dmas property
+ * @param node_id node identifier for a node with a <tt>dmas</tt> property
  * @return the node identifier for the DMA controller at index 0
- *         in the node's "dmas" property
+ *         in the node's <tt>dmas</tt> property
  * @see DT_DMAS_CTLR_BY_IDX()
  */
 #define DT_DMAS_CTLR(node_id) DT_DMAS_CTLR_BY_IDX(node_id, 0)
 
 /**
  * @brief Get the node identifier for the DMA controller from a
- *        DT_DRV_COMPAT instance's dmas property at an index
+ *        DT_DRV_COMPAT instance's <tt>dmas</tt> property at an index
  *
  * @param inst DT_DRV_COMPAT instance number
- * @param idx logical index into dmas property
+ * @param idx logical index into <tt>dmas</tt> property
  * @return the node identifier for the DMA controller referenced at index @p idx
  * @see DT_DMAS_CTLR_BY_IDX()
  */
@@ -103,9 +103,9 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the DMA controller from a
- *        DT_DRV_COMPAT instance's dmas property by name
+ *        DT_DRV_COMPAT instance's <tt>dmas</tt> property by name
  * @param inst DT_DRV_COMPAT instance number
- * @param name lowercase-and-underscores name of a dmas element
+ * @param name lowercase-and-underscores name of a <tt>dmas</tt> element
  *             as defined by the node's dma-names property
  * @return the node identifier for the DMA controller in the named element
  * @see DT_DMAS_CTLR_BY_NAME()
@@ -117,7 +117,7 @@ extern "C" {
  * @brief Equivalent to DT_INST_DMAS_CTLR_BY_IDX(inst, 0)
  * @param inst DT_DRV_COMPAT instance number
  * @return the node identifier for the DMA controller at index 0
- *         in the instance's "dmas" property
+ *         in the instance's <tt>dmas</tt> property
  * @see DT_DMAS_CTLR_BY_IDX()
  */
 #define DT_INST_DMAS_CTLR(inst) DT_INST_DMAS_CTLR_BY_IDX(inst, 0)
@@ -155,8 +155,8 @@ extern "C" {
  *     DT_DMAS_CELL_BY_IDX(DT_NODELABEL(n), 0, config) // 0x400
  *     DT_DMAS_CELL_BY_IDX(DT_NODELABEL(n), 1, config) // 0x404
  *
- * @param node_id node identifier for a node with a dmas property
- * @param idx logical index into dmas property
+ * @param node_id node identifier for a node with a <tt>dmas</tt> property
+ * @param idx logical index into <tt>dmas</tt> property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index @p idx
  * @see DT_PHA_BY_IDX()
@@ -167,7 +167,7 @@ extern "C" {
 /**
  * @brief Get a DT_DRV_COMPAT instance's DMA specifier's cell value at an index
  * @param inst DT_DRV_COMPAT instance number
- * @param idx logical index into dmas property
+ * @param idx logical index into <tt>dmas</tt> property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index @p idx
  * @see DT_DMAS_CELL_BY_IDX()
@@ -209,9 +209,9 @@ extern "C" {
  *     DT_DMAS_CELL_BY_NAME(DT_NODELABEL(n), tx, config) // 0x400
  *     DT_DMAS_CELL_BY_NAME(DT_NODELABEL(n), rx, config) // 0x404
  *
- * @param node_id node identifier for a node with a dmas property
- * @param name lowercase-and-underscores name of a dmas element
- *             as defined by the node's dma-names property
+ * @param node_id node identifier for a node with a <tt>dmas</tt> property
+ * @param name lowercase-and-underscores name of a <tt>dmas</tt> element
+ *             as defined by the node's <tt>dma-names</tt> property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value in the specifier at the named element
  * @see DT_PHA_BY_NAME()
@@ -227,8 +227,8 @@ extern "C" {
  *
  * Otherwise, this expands to @p default_value.
  *
- * @param node_id node identifier for a node with a dmas property
- * @param name lowercase-and-underscores name of a dmas element
+ * @param node_id node identifier for a node with a <tt>dmas</tt> property
+ * @param name lowercase-and-underscores name of a <tt>dmas</tt> element
  *             as defined by the node's dma-names property
  * @param cell lowercase-and-underscores cell name
  * @param default_value a fallback value to expand to
@@ -241,7 +241,7 @@ extern "C" {
 /**
  * @brief Get a DT_DRV_COMPAT instance's DMA specifier's cell value by name
  * @param inst DT_DRV_COMPAT instance number
- * @param name lowercase-and-underscores name of a dmas element
+ * @param name lowercase-and-underscores name of a <tt>dmas</tt> element
  *             as defined by the node's dma-names property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value in the specifier at the named element
@@ -251,39 +251,39 @@ extern "C" {
 	DT_DMAS_CELL_BY_NAME(DT_DRV_INST(inst), name, cell)
 
 /**
- * @brief Is index @p idx valid for a dmas property?
- * @param node_id node identifier for a node with a dmas property
- * @param idx logical index into dmas property
- * @return 1 if the "dmas" property has index @p idx, 0 otherwise
+ * @brief Is index @p idx valid for a <tt>dmas</tt> property?
+ * @param node_id node identifier for a node with a <tt>dmas</tt> property
+ * @param idx logical index into <tt>dmas</tt> property
+ * @return 1 if the <tt>dmas</tt> property has index @p idx, 0 otherwise
  */
 #define DT_DMAS_HAS_IDX(node_id, idx) \
 	IS_ENABLED(DT_CAT4(node_id, _P_dmas_IDX_, idx, _EXISTS))
 
 /**
- * @brief Is index @p idx valid for a DT_DRV_COMPAT instance's dmas property?
+ * @brief Is index @p idx valid for a DT_DRV_COMPAT instance's <tt>dmas</tt> property?
  * @param inst DT_DRV_COMPAT instance number
- * @param idx logical index into dmas property
- * @return 1 if the "dmas" property has a specifier at index @p idx, 0 otherwise
+ * @param idx logical index into <tt>dmas</tt> property
+ * @return 1 if the <tt>dmas</tt> property has a specifier at index @p idx, 0 otherwise
  */
 #define DT_INST_DMAS_HAS_IDX(inst, idx) \
 	DT_DMAS_HAS_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Does a dmas property have a named element?
- * @param node_id node identifier for a node with a dmas property
- * @param name lowercase-and-underscores name of a dmas element
+ * @brief Does a <tt>dmas</tt> property have a named element?
+ * @param node_id node identifier for a node with a <tt>dmas</tt> property
+ * @param name lowercase-and-underscores name of a <tt>dmas</tt> element
  *             as defined by the node's dma-names property
- * @return 1 if the dmas property has the named element, 0 otherwise
+ * @return 1 if the <tt>dmas</tt> property has the named element, 0 otherwise
  */
 #define DT_DMAS_HAS_NAME(node_id, name) \
 	DT_PROP_HAS_NAME(node_id, dmas, name)
 
 /**
- * @brief Does a DT_DRV_COMPAT instance's dmas property have a named element?
+ * @brief Does a DT_DRV_COMPAT instance's <tt>dmas</tt> property have a named element?
  * @param inst DT_DRV_COMPAT instance number
- * @param name lowercase-and-underscores name of a dmas element
+ * @param name lowercase-and-underscores name of a <tt>dmas</tt> element
  *             as defined by the node's dma-names property
- * @return 1 if the dmas property has the named element, 0 otherwise
+ * @return 1 if the <tt>dmas</tt> property has the named element, 0 otherwise
  */
 #define DT_INST_DMAS_HAS_NAME(inst, name) \
 	DT_DMAS_HAS_NAME(DT_DRV_INST(inst), name)

--- a/include/zephyr/devicetree/dma.h
+++ b/include/zephyr/devicetree/dma.h
@@ -91,9 +91,9 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the DMA controller from a
- *        DT_DRV_COMPAT instance's <tt>dmas</tt> property at an index
+ *        @c DT_DRV_COMPAT instance's <tt>dmas</tt> property at an index
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into <tt>dmas</tt> property
  * @return the node identifier for the DMA controller referenced at index @p idx
  * @see DT_DMAS_CTLR_BY_IDX()
@@ -103,8 +103,8 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the DMA controller from a
- *        DT_DRV_COMPAT instance's <tt>dmas</tt> property by name
- * @param inst DT_DRV_COMPAT instance number
+ *        @c DT_DRV_COMPAT instance's <tt>dmas</tt> property by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a <tt>dmas</tt> element
  *             as defined by the node's dma-names property
  * @return the node identifier for the DMA controller in the named element
@@ -115,7 +115,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_DMAS_CTLR_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the node identifier for the DMA controller at index 0
  *         in the instance's <tt>dmas</tt> property
  * @see DT_DMAS_CTLR_BY_IDX()
@@ -165,8 +165,8 @@ extern "C" {
 	DT_PHA_BY_IDX(node_id, dmas, idx, cell)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's DMA specifier's cell value at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get a @c DT_DRV_COMPAT instance's DMA specifier's cell value at an index
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into <tt>dmas</tt> property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index @p idx
@@ -239,8 +239,8 @@ extern "C" {
 	DT_PHA_BY_NAME_OR(node_id, dmas, name, cell, default_value)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's DMA specifier's cell value by name
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get a @c DT_DRV_COMPAT instance's DMA specifier's cell value by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a <tt>dmas</tt> element
  *             as defined by the node's dma-names property
  * @param cell lowercase-and-underscores cell name
@@ -260,8 +260,8 @@ extern "C" {
 	IS_ENABLED(DT_CAT4(node_id, _P_dmas_IDX_, idx, _EXISTS))
 
 /**
- * @brief Is index @p idx valid for a DT_DRV_COMPAT instance's <tt>dmas</tt> property?
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Is index @p idx valid for a @c DT_DRV_COMPAT instance's <tt>dmas</tt> property?
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into <tt>dmas</tt> property
  * @return 1 if the <tt>dmas</tt> property has a specifier at index @p idx, 0 otherwise
  */
@@ -279,8 +279,8 @@ extern "C" {
 	DT_PROP_HAS_NAME(node_id, dmas, name)
 
 /**
- * @brief Does a DT_DRV_COMPAT instance's <tt>dmas</tt> property have a named element?
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Does a @c DT_DRV_COMPAT instance's <tt>dmas</tt> property have a named element?
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a <tt>dmas</tt> element
  *             as defined by the node's dma-names property
  * @return 1 if the <tt>dmas</tt> property has the named element, 0 otherwise

--- a/include/zephyr/devicetree/dma.h
+++ b/include/zephyr/devicetree/dma.h
@@ -45,8 +45,7 @@ extern "C" {
  *
  * @param node_id node identifier for a node with a dmas property
  * @param idx logical index into dmas property
- * @return the node identifier for the DMA controller referenced at
- *         index "idx"
+ * @return the node identifier for the DMA controller referenced at index @p idx
  * @see DT_PROP_BY_PHANDLE_IDX()
  */
 #define DT_DMAS_CTLR_BY_IDX(node_id, idx) DT_PHANDLE_BY_IDX(node_id, dmas, idx)
@@ -96,8 +95,7 @@ extern "C" {
  *
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into dmas property
- * @return the node identifier for the DMA controller referenced at
- *         index "idx"
+ * @return the node identifier for the DMA controller referenced at index @p idx
  * @see DT_DMAS_CTLR_BY_IDX()
  */
 #define DT_INST_DMAS_CTLR_BY_IDX(inst, idx) \
@@ -160,7 +158,7 @@ extern "C" {
  * @param node_id node identifier for a node with a dmas property
  * @param idx logical index into dmas property
  * @param cell lowercase-and-underscores cell name
- * @return the cell value at index "idx"
+ * @return the cell value at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_DMAS_CELL_BY_IDX(node_id, idx, cell) \
@@ -171,7 +169,7 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into dmas property
  * @param cell lowercase-and-underscores cell name
- * @return the cell value at index "idx"
+ * @return the cell value at index @p idx
  * @see DT_DMAS_CELL_BY_IDX()
  */
 #define DT_INST_DMAS_CELL_BY_IDX(inst, idx, cell) \
@@ -253,19 +251,19 @@ extern "C" {
 	DT_DMAS_CELL_BY_NAME(DT_DRV_INST(inst), name, cell)
 
 /**
- * @brief Is index "idx" valid for a dmas property?
+ * @brief Is index @p idx valid for a dmas property?
  * @param node_id node identifier for a node with a dmas property
  * @param idx logical index into dmas property
- * @return 1 if the "dmas" property has index "idx", 0 otherwise
+ * @return 1 if the "dmas" property has index @p idx, 0 otherwise
  */
 #define DT_DMAS_HAS_IDX(node_id, idx) \
 	IS_ENABLED(DT_CAT4(node_id, _P_dmas_IDX_, idx, _EXISTS))
 
 /**
- * @brief Is index "idx" valid for a DT_DRV_COMPAT instance's dmas property?
+ * @brief Is index @p idx valid for a DT_DRV_COMPAT instance's dmas property?
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into dmas property
- * @return 1 if the "dmas" property has a specifier at index "idx", 0 otherwise
+ * @return 1 if the "dmas" property has a specifier at index @p idx, 0 otherwise
  */
 #define DT_INST_DMAS_HAS_IDX(inst, idx) \
 	DT_DMAS_HAS_IDX(DT_DRV_INST(inst), idx)

--- a/include/zephyr/devicetree/fixed-partitions.h
+++ b/include/zephyr/devicetree/fixed-partitions.h
@@ -55,33 +55,33 @@ extern "C" {
 /**
  * @brief Test if a fixed partition with a given label property exists
  * @param label lowercase-and-underscores label property value
- * @return 1 if any "fixed-partitions" child node has the given label,
+ * @return 1 if any <tt>fixed-partitions</tt> child node has the given label,
  *         0 otherwise.
  */
 #define DT_HAS_FIXED_PARTITION_LABEL(label) \
 	IS_ENABLED(DT_CAT3(DT_COMPAT_fixed_partitions_LABEL_, label, _EXISTS))
 
 /**
- * @brief Test if fixed-partition compatible node exists
+ * @brief Test if <tt>fixed-partitions</tt> compatible node exists
  *
  * @param node_id DTS node to test
- * @return 1 if node exists and is fixed-partition compatible, 0 otherwise.
+ * @return 1 if node exists and is <tt>fixed-partitions</tt> compatible, 0 otherwise.
  */
 #define DT_FIXED_PARTITION_EXISTS(node_id)		\
 	DT_NODE_HAS_COMPAT(DT_PARENT(node_id), fixed_partitions)
 
 /**
  * @brief Get a numeric identifier for a fixed partition
- * @param node_id node identifier for a fixed-partitions child node
+ * @param node_id node identifier for a <tt>fixed-partitions</tt> child node
  * @return the partition's ID, a unique zero-based index number
  */
 #define DT_FIXED_PARTITION_ID(node_id) DT_CAT(node_id, _PARTITION_ID)
 
 /**
  * @brief Get the node identifier of the flash memory for a partition
- * @param node_id node identifier for a fixed-partitions child node
+ * @param node_id node identifier for a <tt>fixed-partitions</tt> child node
  * @return the node identifier of the internal memory that contains the
- * fixed-partitions node, or @ref DT_INVALID_NODE if it doesn't exist.
+ * <tt>fixed-partitions</tt> node, or @ref DT_INVALID_NODE if it doesn't exist.
  */
 #define DT_MEM_FROM_FIXED_PARTITION(node_id)                                                       \
 	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_GPARENT(node_id), soc_nv_flash), (DT_GPARENT(node_id)),  \
@@ -89,9 +89,9 @@ extern "C" {
 
 /**
  * @brief Get the node identifier of the flash controller for a partition
- * @param node_id node identifier for a fixed-partitions child node
+ * @param node_id node identifier for a <tt>fixed-partitions</tt> child node
  * @return the node identifier of the memory technology device that
- * contains the fixed-partitions node.
+ * contains the <tt>fixed-partitions</tt> node.
  */
 #define DT_MTD_FROM_FIXED_PARTITION(node_id)                                                       \
 	COND_CODE_1(DT_NODE_EXISTS(DT_MEM_FROM_FIXED_PARTITION(node_id)),                          \
@@ -126,7 +126,7 @@ extern "C" {
  * addressable by the CPU. Otherwise, it may produce a compile-time
  * error, such as: `'__REG_IDX_0_VAL_ADDRESS' undeclared`.
  *
- * @param node_id node identifier for a fixed-partitions child node
+ * @param node_id node identifier for a <tt>fixed-partitions</tt> child node
  * @return the partition's offset plus the base address of the flash
  * node containing it.
  */
@@ -134,19 +134,19 @@ extern "C" {
 	(DT_REG_ADDR(node_id) + DT_REG_ADDR(DT_GPARENT(node_id)))
 
 /**
- * @brief Test if fixed-subpartitions compatible node exists
+ * @brief Test if <tt>fixed-subpartitions</tt> compatible node exists
  *
  * @param node_id DTS node to test
- * @return 1 if node exists and is fixed-subpartitions compatible, 0 otherwise.
+ * @return 1 if node exists and is <tt>fixed-subpartitions</tt> compatible, 0 otherwise.
  */
 #define DT_FIXED_SUBPARTITION_EXISTS(node_id)		\
 	DT_NODE_HAS_COMPAT(DT_PARENT(node_id), fixed_subpartitions)
 
 /**
  * @brief Get the node identifier of the flash memory for a subpartition
- * @param node_id node identifier for a fixed-subpartitions child node
+ * @param node_id node identifier for a <tt>fixed-subpartitions</tt> child node
  * @return the node identifier of the internal memory that contains the
- * fixed-subpartitions node, or @ref DT_INVALID_NODE if it doesn't exist.
+ * <tt>fixed-subpartitions</tt> node, or @ref DT_INVALID_NODE if it doesn't exist.
  */
 #define DT_MEM_FROM_FIXED_SUBPARTITION(node_id)                                                    \
 	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_GPARENT(DT_PARENT(node_id)), soc_nv_flash),              \
@@ -154,9 +154,9 @@ extern "C" {
 
 /**
  * @brief Get the node identifier of the flash controller for a subpartition
- * @param node_id node identifier for a fixed-subpartitions child node
+ * @param node_id node identifier for a <tt>fixed-subpartitions</tt> child node
  * @return the node identifier of the memory technology device that
- * contains the fixed-subpartitions node.
+ * contains the <tt>fixed-subpartitions</tt> node.
  */
 #define DT_MTD_FROM_FIXED_SUBPARTITION(node_id)                                                    \
 	COND_CODE_1(DT_NODE_EXISTS(DT_MEM_FROM_FIXED_SUBPARTITION(node_id)),                       \
@@ -202,7 +202,7 @@ extern "C" {
  * addressable by the CPU. Otherwise, it may produce a compile-time
  * error, such as: `'__REG_IDX_0_VAL_ADDRESS' undeclared`.
  *
- * @param node_id node identifier for a fixed-subpartitions child node
+ * @param node_id node identifier for a <tt>fixed-subpartitions</tt> child node
  * @return the subpartition's offset plus the base address of the flash
  * node containing it.
  */

--- a/include/zephyr/devicetree/gpio.h
+++ b/include/zephyr/devicetree/gpio.h
@@ -127,8 +127,8 @@ extern "C" {
 /**
  * @brief Get a GPIO specifier's flags cell at an index
  *
- * This macro expects GPIO specifiers with cells named "flags".
- * If there is no "flags" cell in the GPIO specifier, zero is returned.
+ * This macro expects GPIO specifiers with cells named <tt>flags</tt>.
+ * If there is no <tt>flags</tt> cell in the GPIO specifier, zero is returned.
  * Refer to the node's binding to check specifier cell names if necessary.
  *
  * Example devicetree fragment:
@@ -225,7 +225,7 @@ extern "C" {
 /**
  * @brief Get a GPIO hog specifier's pin cell at an index
  *
- * This macro only works for GPIO specifiers with cells named "pin".
+ * This macro only works for GPIO specifiers with cells named <tt>pin</tt>.
  * Refer to the node's binding to check if necessary.
  *
  * Example devicetree fragment:
@@ -260,7 +260,7 @@ extern "C" {
  *     DT_GPIO_HOG_PIN_BY_IDX(DT_NODELABEL(n2), 0) // 3
  *
  * @param node_id node identifier
- * @param idx logical index into "gpios"
+ * @param idx logical index into <tt>gpios</tt> property
  * @return the pin cell value at index @p idx
  */
 #define DT_GPIO_HOG_PIN_BY_IDX(node_id, idx) \
@@ -269,8 +269,8 @@ extern "C" {
 /**
  * @brief Get a GPIO hog specifier's flags cell at an index
  *
- * This macro expects GPIO specifiers with cells named "flags".
- * If there is no "flags" cell in the GPIO specifier, zero is returned.
+ * This macro expects GPIO specifiers with cells named <tt>flags</tt>.
+ * If there is no <tt>flags</tt> cell in the GPIO specifier, zero is returned.
  * Refer to the node's binding to check specifier cell names if necessary.
  *
  * Example devicetree fragment:
@@ -305,7 +305,7 @@ extern "C" {
  *     DT_GPIO_HOG_FLAGS_BY_IDX(DT_NODELABEL(n2), 0) // GPIO_ACTIVE_HIGH
  *
  * @param node_id node identifier
- * @param idx logical index into "gpios"
+ * @param idx logical index into <tt>gpios</tt> property
  * @return the flags cell value at index @p idx, or zero if there is none
  */
 #define DT_GPIO_HOG_FLAGS_BY_IDX(node_id, idx) \

--- a/include/zephyr/devicetree/gpio.h
+++ b/include/zephyr/devicetree/gpio.h
@@ -51,9 +51,8 @@ extern "C" {
  * @param node_id node identifier
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
- * @param idx logical index into "gpio_pha"
- * @return the node identifier for the gpio controller referenced at
- *         index "idx"
+ * @param idx logical index into @p gpio_pha
+ * @return the node identifier for the gpio controller referenced at index @p idx
  * @see DT_PHANDLE_BY_IDX()
  */
 #define DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, idx) \
@@ -64,8 +63,7 @@ extern "C" {
  * @param node_id node identifier
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
- * @return a node identifier for the gpio controller at index 0
- *         in "gpio_pha"
+ * @return a node identifier for the gpio controller at index 0 in @p gpio_pha
  * @see DT_GPIO_CTLR_BY_IDX()
  */
 #define DT_GPIO_CTLR(node_id, gpio_pha) \
@@ -108,8 +106,8 @@ extern "C" {
  * @param node_id node identifier
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
- * @param idx logical index into "gpio_pha"
- * @return the pin cell value at index "idx"
+ * @param idx logical index into @p gpio_pha
+ * @return the pin cell value at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_GPIO_PIN_BY_IDX(node_id, gpio_pha, idx) \
@@ -164,8 +162,8 @@ extern "C" {
  * @param node_id node identifier
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
- * @param idx logical index into "gpio_pha"
- * @return the flags cell value at index "idx", or zero if there is none
+ * @param idx logical index into @p gpio_pha
+ * @return the flags cell value at index @p idx, or zero if there is none
  * @see DT_PHA_BY_IDX()
  */
 #define DT_GPIO_FLAGS_BY_IDX(node_id, gpio_pha, idx) \
@@ -263,7 +261,7 @@ extern "C" {
  *
  * @param node_id node identifier
  * @param idx logical index into "gpios"
- * @return the pin cell value at index "idx"
+ * @return the pin cell value at index @p idx
  */
 #define DT_GPIO_HOG_PIN_BY_IDX(node_id, idx) \
 	DT_CAT4(node_id, _GPIO_HOGS_IDX_, idx, _VAL_pin)
@@ -308,7 +306,7 @@ extern "C" {
  *
  * @param node_id node identifier
  * @param idx logical index into "gpios"
- * @return the flags cell value at index "idx", or zero if there is none
+ * @return the flags cell value at index @p idx, or zero if there is none
  */
 #define DT_GPIO_HOG_FLAGS_BY_IDX(node_id, idx) \
 	COND_CODE_1(IS_ENABLED(DT_CAT4(node_id, _GPIO_HOGS_IDX_, idx, _VAL_flags_EXISTS)), \
@@ -320,8 +318,8 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
- * @param idx logical index into "gpio_pha"
- * @return the pin cell value at index "idx"
+ * @param idx logical index into @p gpio_pha property
+ * @return the pin cell value at index @p idx
  * @see DT_GPIO_PIN_BY_IDX()
  */
 #define DT_INST_GPIO_PIN_BY_IDX(inst, gpio_pha, idx) \
@@ -344,8 +342,8 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
- * @param idx logical index into "gpio_pha"
- * @return the flags cell value at index "idx", or zero if there is none
+ * @param idx logical index into @p gpio_pha
+ * @return the flags cell value at index @p idx, or zero if there is none
  * @see DT_GPIO_FLAGS_BY_IDX()
  */
 #define DT_INST_GPIO_FLAGS_BY_IDX(inst, gpio_pha, idx) \

--- a/include/zephyr/devicetree/gpio.h
+++ b/include/zephyr/devicetree/gpio.h
@@ -313,9 +313,9 @@ extern "C" {
 		    (DT_CAT4(node_id, _GPIO_HOGS_IDX_, idx, _VAL_flags)), (0))
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's GPIO specifier's pin cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's GPIO specifier's pin cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
  * @param idx logical index into @p gpio_pha property
@@ -327,7 +327,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_GPIO_PIN_BY_IDX(inst, gpio_pha, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
  * @return the pin cell value at index 0
@@ -337,9 +337,9 @@ extern "C" {
 	DT_INST_GPIO_PIN_BY_IDX(inst, gpio_pha, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's GPIO specifier's flags cell
+ * @brief Get a @c DT_DRV_COMPAT instance's GPIO specifier's flags cell
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
  * @param idx logical index into @p gpio_pha
@@ -351,7 +351,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_GPIO_FLAGS_BY_IDX(inst, gpio_pha, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
  * @return the flags cell value at index 0, or zero if there is none

--- a/include/zephyr/devicetree/hwspinlock.h
+++ b/include/zephyr/devicetree/hwspinlock.h
@@ -23,7 +23,8 @@ extern "C" {
  */
 
 /**
- * @brief Get the node identifier for the hardware spinlock controller from a hwlocks property by id
+ * @brief Get the node identifier for the hardware spinlock controller from a <tt>hwlocks</tt>
+ * property by index
  *
  * Example devicetree fragment:
  *
@@ -41,8 +42,8 @@ extern "C" {
  *     DT_HWSPINLOCK_CTRL_BY_IDX(DT_NODELABEL(n), 0) // DT_NODELABEL(hwlock1)
  *     DT_HWSPINLOCK_CTRL_BY_IDX(DT_NODELABEL(n), 1) // DT_NODELABEL(hwlock2)
  *
- * @param node_id node identifier for a node with a hwlocks property
- * @param idx index of a hwlocks element in the hwlocks
+ * @param node_id node identifier for a node with a <tt>hwlocks</tt> property
+ * @param idx index of an element in the <tt>hwlocks</tt> property
  *
  * @return the node identifier for the hardware spinlock controller in the named element
  *
@@ -52,8 +53,8 @@ extern "C" {
 	DT_PHANDLE_BY_IDX(node_id, hwlocks, idx)
 
 /**
- * @brief Get the node identifier for the hardware spinlock controller from a hwlocks property by
- *        name
+ * @brief Get the node identifier for the hardware spinlock controller from a <tt>hwlocks</tt>
+ *        property by name
  *
  * Example devicetree fragment:
  *
@@ -71,9 +72,9 @@ extern "C" {
  *     DT_HWSPINLOCK_CTRL_BY_NAME(DT_NODELABEL(n), rd) // DT_NODELABEL(hwlock1)
  *     DT_HWSPINLOCK_CTRL_BY_NAME(DT_NODELABEL(n), wr) // DT_NODELABEL(hwlock2)
  *
- * @param node_id node identifier for a node with a hwlocks property
- * @param name lowercase-and-underscores name of a hwlocks element
- *             as defined by the node's hwlocks-names property
+ * @param node_id node identifier for a node with a <tt>hwlocks</tt> property
+ * @param name lowercase-and-underscores name of a <tt>hwlocks</tt> element
+ *             as defined by the node's <tt>hwlocks-names</tt> property
  *
  * @return the node identifier for the hardware spinlock controller in the named element
  *
@@ -83,7 +84,7 @@ extern "C" {
 	DT_PHANDLE_BY_NAME(node_id, hwlocks, name)
 
 /**
- * @brief Get a hardware spinlock id by name
+ * @brief Get a hardware spinlock <tt>id</tt> field by name
  *
  * Example devicetree fragment:
  *
@@ -107,9 +108,9 @@ extern "C" {
  *     DT_HWSPINLOCK_ID_BY_NAME(DT_NODELABEL(n), rd) // 1
  *     DT_HWSPINLOCK_ID_BY_NAME(DT_NODELABEL(n), wr) // 6
  *
- * @param node_id node identifier for a node with a hwlocks property
- * @param name lowercase-and-underscores name of a hwlocks element
- *             as defined by the node's hwlock-names property
+ * @param node_id node identifier for a node with a <tt>hwlocks</tt> property
+ * @param name lowercase-and-underscores name of a <tt>hwlocks</tt> element
+ *             as defined by the node's <tt>hwlock-names</tt> property
  *
  * @return the channel value in the specifier at the named element or 0 if no
  *         named hardware spinlockis found
@@ -138,8 +139,8 @@ extern "C" {
  *     DT_HWSPINLOCK_ID_BY_IDX(DT_NODELABEL(n), 0) // 1
  *     DT_HWSPINLOCK_ID_BY_IDX(DT_NODELABEL(n), 1) // 6
  *
- * @param node_id node identifier for a node with a hwlocks property
- * @param idx index of a hwlocks element in the hwlocks
+ * @param node_id node identifier for a node with a <tt>hwlocks</tt> property
+ * @param idx index of a <tt>hwlocks</tt> element in the <tt>hwlocks</tt>
  *
  * @return the channel value in the specifier at the indexed element or 0 if no
  *         hardware spinlock is found is @p idx index

--- a/include/zephyr/devicetree/hwspinlock.h
+++ b/include/zephyr/devicetree/hwspinlock.h
@@ -112,7 +112,7 @@ extern "C" {
  *             as defined by the node's hwlock-names property
  *
  * @return the channel value in the specifier at the named element or 0 if no
- *         channels are supported
+ *         named hardware spinlockis found
  *
  * @see DT_PHA_BY_NAME()
  */
@@ -141,8 +141,8 @@ extern "C" {
  * @param node_id node identifier for a node with a hwlocks property
  * @param idx index of a hwlocks element in the hwlocks
  *
- * @return the channel value in the specifier at the named element or 0 if no
- *         channels are supported
+ * @return the channel value in the specifier at the indexed element or 0 if no
+ *         hardware spinlock is found is @p idx index
  *
  * @see DT_PHA_BY_IDX()
  */

--- a/include/zephyr/devicetree/interrupt_controller.h
+++ b/include/zephyr/devicetree/interrupt_controller.h
@@ -28,8 +28,8 @@ extern "C" {
 /**
  * @brief Get the aggregator level of an interrupt controller
  *
- * @note Aggregator level is equivalent to IRQ_LEVEL + 1 (a 2nd level aggregator has Zephyr level 1
- * IRQ encoding)
+ * @note Aggregator level is equivalent to <tt>IRQ_LEVEL + 1</tt> (a 2nd level aggregator has
+ * Zephyr level 1 IRQ encoding)
  *
  * @param node_id node identifier of an interrupt controller
  *
@@ -40,8 +40,8 @@ extern "C" {
 /**
  * @brief Get the aggregator level of a `DT_DRV_COMPAT` interrupt controller
  *
- * @note Aggregator level is equivalent to IRQ_LEVEL + 1 (a 2nd level aggregator has Zephyr level 1
- * IRQ encoding)
+ * @note Aggregator level is equivalent to <tt>IRQ_LEVEL + 1</tt> (a 2nd level aggregator has
+ * Zephyr level 1 IRQ encoding)
  *
  * @param inst instance of an interrupt controller
  *

--- a/include/zephyr/devicetree/interrupt_controller.h
+++ b/include/zephyr/devicetree/interrupt_controller.h
@@ -38,7 +38,7 @@ extern "C" {
 #define DT_INTC_GET_AGGREGATOR_LEVEL(node_id) UTIL_INC(DT_IRQ_LEVEL(node_id))
 
 /**
- * @brief Get the aggregator level of a `DT_DRV_COMPAT` interrupt controller
+ * @brief Get the aggregator level of a @c DT_DRV_COMPAT interrupt controller
  *
  * @note Aggregator level is equivalent to <tt>IRQ_LEVEL + 1</tt> (a 2nd level aggregator has
  * Zephyr level 1 IRQ encoding)

--- a/include/zephyr/devicetree/io-channels.h
+++ b/include/zephyr/devicetree/io-channels.h
@@ -89,10 +89,10 @@ extern "C" {
 #define DT_IO_CHANNELS_CTLR(node_id) DT_IO_CHANNELS_CTLR_BY_IDX(node_id, 0)
 
 /**
- * @brief Get the node identifier from a DT_DRV_COMPAT instance's <tt>io-channels</tt>
+ * @brief Get the node identifier from a @c DT_DRV_COMPAT instance's <tt>io-channels</tt>
  *        property at an index
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into <tt>io-channels</tt> property
  * @return the node identifier for the node referenced at index @p idx
  * @see DT_IO_CHANNELS_CTLR_BY_IDX()
@@ -101,9 +101,9 @@ extern "C" {
 	DT_IO_CHANNELS_CTLR_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Get the node identifier from a DT_DRV_COMPAT instance's <tt>io-channels</tt>
+ * @brief Get the node identifier from a @c DT_DRV_COMPAT instance's <tt>io-channels</tt>
  *        property by name
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of an <tt>io-channels</tt> element
  *             as defined by the node's io-channel-names property
  * @return the node identifier for the node referenced at the named element
@@ -114,7 +114,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_IO_CHANNELS_CTLR_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the node identifier for the node referenced at index 0
  *         in the node's <tt>io-channels</tt> property
  * @see DT_IO_CHANNELS_CTLR_BY_IDX()
@@ -213,7 +213,7 @@ extern "C" {
 /**
  * @brief Get an input cell from the DT_DRV_INST(inst) <tt>io-channels</tt>
  *        property at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into <tt>io-channels</tt> property
  * @return the input cell in the specifier at index @p idx
  * @see DT_IO_CHANNELS_INPUT_BY_IDX()
@@ -224,7 +224,7 @@ extern "C" {
 /**
  * @brief Get an input cell from the DT_DRV_INST(inst) <tt>io-channels</tt>
  *        property by name
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of an <tt>io-channels</tt> element
  *             as defined by the instance's io-channel-names property
  * @return the input cell in the specifier at the named element
@@ -235,7 +235,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_IO_CHANNELS_INPUT_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the input cell in the specifier at index 0
  */
 #define DT_INST_IO_CHANNELS_INPUT(inst) DT_INST_IO_CHANNELS_INPUT_BY_IDX(inst, 0)
@@ -333,7 +333,7 @@ extern "C" {
 /**
  * @brief Get an output cell from the DT_DRV_INST(inst) <tt>io-channels</tt>
  *        property at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into <tt>io-channels</tt> property
  * @return the output cell in the specifier at index @p idx
  * @see DT_IO_CHANNELS_OUTPUT_BY_IDX()
@@ -344,7 +344,7 @@ extern "C" {
 /**
  * @brief Get an output cell from the DT_DRV_INST(inst) <tt>io-channels</tt>
  *        property by name
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of an <tt>io-channels</tt> element
  *             as defined by the instance's io-channel-names property
  * @return the output cell in the specifier at the named element
@@ -355,7 +355,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_IO_CHANNELS_OUTPUT_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the output cell in the specifier at index 0
  */
 #define DT_INST_IO_CHANNELS_OUTPUT(inst) DT_INST_IO_CHANNELS_OUTPUT_BY_IDX(inst, 0)

--- a/include/zephyr/devicetree/io-channels.h
+++ b/include/zephyr/devicetree/io-channels.h
@@ -44,7 +44,7 @@ extern "C" {
  *
  * @param node_id node identifier for a node with an io-channels property
  * @param idx logical index into io-channels property
- * @return the node identifier for the node referenced at index "idx"
+ * @return the node identifier for the node referenced at index @p idx
  * @see DT_PROP_BY_PHANDLE_IDX()
  */
 #define DT_IO_CHANNELS_CTLR_BY_IDX(node_id, idx) \
@@ -94,7 +94,7 @@ extern "C" {
  *
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into io-channels property
- * @return the node identifier for the node referenced at index "idx"
+ * @return the node identifier for the node referenced at index @p idx
  * @see DT_IO_CHANNELS_CTLR_BY_IDX()
  */
 #define DT_INST_IO_CHANNELS_CTLR_BY_IDX(inst, idx) \
@@ -155,7 +155,7 @@ extern "C" {
  *
  * @param node_id node identifier for a node with an io-channels property
  * @param idx logical index into io-channels property
- * @return the input cell in the specifier at index "idx"
+ * @return the input cell in the specifier at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_IO_CHANNELS_INPUT_BY_IDX(node_id, idx) \
@@ -215,7 +215,7 @@ extern "C" {
  *        property at an index
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into io-channels property
- * @return the input cell in the specifier at index "idx"
+ * @return the input cell in the specifier at index @p idx
  * @see DT_IO_CHANNELS_INPUT_BY_IDX()
  */
 #define DT_INST_IO_CHANNELS_INPUT_BY_IDX(inst, idx) \
@@ -274,7 +274,7 @@ extern "C" {
  *
  * @param node_id node identifier for a node with an io-channels property
  * @param idx logical index into io-channels property
- * @return the output cell in the specifier at index "idx"
+ * @return the output cell in the specifier at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_IO_CHANNELS_OUTPUT_BY_IDX(node_id, idx) \
@@ -335,7 +335,7 @@ extern "C" {
  *        property at an index
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into io-channels property
- * @return the output cell in the specifier at index "idx"
+ * @return the output cell in the specifier at index @p idx
  * @see DT_IO_CHANNELS_OUTPUT_BY_IDX()
  */
 #define DT_INST_IO_CHANNELS_OUTPUT_BY_IDX(inst, idx) \

--- a/include/zephyr/devicetree/io-channels.h
+++ b/include/zephyr/devicetree/io-channels.h
@@ -25,7 +25,7 @@ extern "C" {
 /**
  *
  * @brief Get the node identifier for the node referenced by an
- *        io-channels property at an index
+ *        <tt>io-channels</tt> property at an index
  *
  * Example devicetree fragment:
  *
@@ -42,8 +42,8 @@ extern "C" {
  *     DT_IO_CHANNELS_CTLR_BY_IDX(DT_NODELABEL(n), 0) // DT_NODELABEL(adc1)
  *     DT_IO_CHANNELS_CTLR_BY_IDX(DT_NODELABEL(n), 1) // DT_NODELABEL(adc2)
  *
- * @param node_id node identifier for a node with an io-channels property
- * @param idx logical index into io-channels property
+ * @param node_id node identifier for a node with an <tt>io-channels</tt> property
+ * @param idx logical index into <tt>io-channels</tt> property
  * @return the node identifier for the node referenced at index @p idx
  * @see DT_PROP_BY_PHANDLE_IDX()
  */
@@ -52,7 +52,7 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the node referenced by an
- *        io-channels property by name
+ *        <tt>io-channels</tt> property by name
  *
  * Example devicetree fragment:
  *
@@ -70,8 +70,8 @@ extern "C" {
  *  DT_IO_CHANNELS_CTLR_BY_NAME(DT_NODELABEL(n), sensor) // DT_NODELABEL(adc1)
  *  DT_IO_CHANNELS_CTLR_BY_NAME(DT_NODELABEL(n), bandgap) // DT_NODELABEL(adc2)
  *
- * @param node_id node identifier for a node with an io-channels property
- * @param name lowercase-and-underscores name of an io-channels element
+ * @param node_id node identifier for a node with an <tt>io-channels</tt> property
+ * @param name lowercase-and-underscores name of an <tt>io-channels</tt> element
  *             as defined by the node's io-channel-names property
  * @return the node identifier for the node referenced at the named element
  * @see DT_PHANDLE_BY_NAME()
@@ -81,19 +81,19 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_IO_CHANNELS_CTLR_BY_IDX(node_id, 0)
- * @param node_id node identifier for a node with an io-channels property
+ * @param node_id node identifier for a node with an <tt>io-channels</tt> property
  * @return the node identifier for the node referenced at index 0
- *         in the node's "io-channels" property
+ *         in the node's <tt>io-channels</tt> property
  * @see DT_IO_CHANNELS_CTLR_BY_IDX()
  */
 #define DT_IO_CHANNELS_CTLR(node_id) DT_IO_CHANNELS_CTLR_BY_IDX(node_id, 0)
 
 /**
- * @brief Get the node identifier from a DT_DRV_COMPAT instance's io-channels
+ * @brief Get the node identifier from a DT_DRV_COMPAT instance's <tt>io-channels</tt>
  *        property at an index
  *
  * @param inst DT_DRV_COMPAT instance number
- * @param idx logical index into io-channels property
+ * @param idx logical index into <tt>io-channels</tt> property
  * @return the node identifier for the node referenced at index @p idx
  * @see DT_IO_CHANNELS_CTLR_BY_IDX()
  */
@@ -101,10 +101,10 @@ extern "C" {
 	DT_IO_CHANNELS_CTLR_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Get the node identifier from a DT_DRV_COMPAT instance's io-channels
+ * @brief Get the node identifier from a DT_DRV_COMPAT instance's <tt>io-channels</tt>
  *        property by name
  * @param inst DT_DRV_COMPAT instance number
- * @param name lowercase-and-underscores name of an io-channels element
+ * @param name lowercase-and-underscores name of an <tt>io-channels</tt> element
  *             as defined by the node's io-channel-names property
  * @return the node identifier for the node referenced at the named element
  * @see DT_IO_CHANNELS_CTLR_BY_NAME()
@@ -116,16 +116,16 @@ extern "C" {
  * @brief Equivalent to DT_INST_IO_CHANNELS_CTLR_BY_IDX(inst, 0)
  * @param inst DT_DRV_COMPAT instance number
  * @return the node identifier for the node referenced at index 0
- *         in the node's "io-channels" property
+ *         in the node's <tt>io-channels</tt> property
  * @see DT_IO_CHANNELS_CTLR_BY_IDX()
  */
 #define DT_INST_IO_CHANNELS_CTLR(inst) DT_INST_IO_CHANNELS_CTLR_BY_IDX(inst, 0)
 
 /**
- * @brief Get an io-channels specifier input cell at an index
+ * @brief Get an <tt>io-channels</tt> specifier input cell at an index
  *
- * This macro only works for io-channels specifiers with cells named
- * "input". Refer to the node's binding to check if necessary.
+ * This macro only works for <tt>io-channels</tt> specifiers with cells named
+ * <tt>input</tt>. Refer to the node's binding to check if necessary.
  *
  * Example devicetree fragment:
  *
@@ -153,8 +153,8 @@ extern "C" {
  *     DT_IO_CHANNELS_INPUT_BY_IDX(DT_NODELABEL(n), 0) // 10
  *     DT_IO_CHANNELS_INPUT_BY_IDX(DT_NODELABEL(n), 1) // 20
  *
- * @param node_id node identifier for a node with an io-channels property
- * @param idx logical index into io-channels property
+ * @param node_id node identifier for a node with an <tt>io-channels</tt> property
+ * @param idx logical index into <tt>io-channels</tt> property
  * @return the input cell in the specifier at index @p idx
  * @see DT_PHA_BY_IDX()
  */
@@ -162,10 +162,10 @@ extern "C" {
 	DT_PHA_BY_IDX(node_id, io_channels, idx, input)
 
 /**
- * @brief Get an io-channels specifier input cell by name
+ * @brief Get an <tt>io-channels</tt> specifier input cell by name
  *
- * This macro only works for io-channels specifiers with cells named
- * "input". Refer to the node's binding to check if necessary.
+ * This macro only works for <tt>io-channels</tt> specifiers with cells named
+ * <tt>input</tt>. Refer to the node's binding to check if necessary.
  *
  * Example devicetree fragment:
  *
@@ -194,8 +194,8 @@ extern "C" {
  *     DT_IO_CHANNELS_INPUT_BY_NAME(DT_NODELABEL(n), sensor) // 10
  *     DT_IO_CHANNELS_INPUT_BY_NAME(DT_NODELABEL(n), bandgap) // 20
  *
- * @param node_id node identifier for a node with an io-channels property
- * @param name lowercase-and-underscores name of an io-channels element
+ * @param node_id node identifier for a node with an <tt>io-channels</tt> property
+ * @param name lowercase-and-underscores name of an <tt>io-channels</tt> element
  *             as defined by the node's io-channel-names property
  * @return the input cell in the specifier at the named element
  * @see DT_PHA_BY_NAME()
@@ -204,17 +204,17 @@ extern "C" {
 	DT_PHA_BY_NAME(node_id, io_channels, name, input)
 /**
  * @brief Equivalent to DT_IO_CHANNELS_INPUT_BY_IDX(node_id, 0)
- * @param node_id node identifier for a node with an io-channels property
+ * @param node_id node identifier for a node with an <tt>io-channels</tt> property
  * @return the input cell in the specifier at index 0
  * @see DT_IO_CHANNELS_INPUT_BY_IDX()
  */
 #define DT_IO_CHANNELS_INPUT(node_id) DT_IO_CHANNELS_INPUT_BY_IDX(node_id, 0)
 
 /**
- * @brief Get an input cell from the "DT_DRV_INST(inst)" io-channels
+ * @brief Get an input cell from the DT_DRV_INST(inst) <tt>io-channels</tt>
  *        property at an index
  * @param inst DT_DRV_COMPAT instance number
- * @param idx logical index into io-channels property
+ * @param idx logical index into <tt>io-channels</tt> property
  * @return the input cell in the specifier at index @p idx
  * @see DT_IO_CHANNELS_INPUT_BY_IDX()
  */
@@ -222,10 +222,10 @@ extern "C" {
 	DT_IO_CHANNELS_INPUT_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Get an input cell from the "DT_DRV_INST(inst)" io-channels
+ * @brief Get an input cell from the DT_DRV_INST(inst) <tt>io-channels</tt>
  *        property by name
  * @param inst DT_DRV_COMPAT instance number
- * @param name lowercase-and-underscores name of an io-channels element
+ * @param name lowercase-and-underscores name of an <tt>io-channels</tt> element
  *             as defined by the instance's io-channel-names property
  * @return the input cell in the specifier at the named element
  * @see DT_IO_CHANNELS_INPUT_BY_NAME()
@@ -241,10 +241,10 @@ extern "C" {
 #define DT_INST_IO_CHANNELS_INPUT(inst) DT_INST_IO_CHANNELS_INPUT_BY_IDX(inst, 0)
 
 /**
- * @brief Get an io-channels specifier output cell at an index
+ * @brief Get an <tt>io-channels</tt> specifier output cell at an index
  *
- * This macro only works for io-channels specifiers with cells named
- * "output". Refer to the node's binding to check if necessary.
+ * This macro only works for <tt>io-channels</tt> specifiers with cells named
+ * <tt>output</tt>. Refer to the node's binding to check if necessary.
  *
  * Example devicetree fragment:
  *
@@ -272,8 +272,8 @@ extern "C" {
  *     DT_IO_CHANNELS_OUTPUT_BY_IDX(DT_NODELABEL(n), 0) // 10
  *     DT_IO_CHANNELS_OUTPUT_BY_IDX(DT_NODELABEL(n), 1) // 20
  *
- * @param node_id node identifier for a node with an io-channels property
- * @param idx logical index into io-channels property
+ * @param node_id node identifier for a node with an <tt>io-channels</tt> property
+ * @param idx logical index into <tt>io-channels</tt> property
  * @return the output cell in the specifier at index @p idx
  * @see DT_PHA_BY_IDX()
  */
@@ -281,10 +281,10 @@ extern "C" {
 	DT_PHA_BY_IDX(node_id, io_channels, idx, output)
 
 /**
- * @brief Get an io-channels specifier output cell by name
+ * @brief Get an <tt>io-channels</tt> specifier output cell by name
  *
- * This macro only works for io-channels specifiers with cells named
- * "output". Refer to the node's binding to check if necessary.
+ * This macro only works for <tt>io-channels</tt> specifiers with cells named
+ * <tt>output</tt>. Refer to the node's binding to check if necessary.
  *
  * Example devicetree fragment:
  *
@@ -313,8 +313,8 @@ extern "C" {
  *     DT_IO_CHANNELS_OUTPUT_BY_NAME(DT_NODELABEL(n), sensor) // 10
  *     DT_IO_CHANNELS_OUTPUT_BY_NAME(DT_NODELABEL(n), bandgap) // 20
  *
- * @param node_id node identifier for a node with an io-channels property
- * @param name lowercase-and-underscores name of an io-channels element
+ * @param node_id node identifier for a node with an <tt>io-channels</tt> property
+ * @param name lowercase-and-underscores name of an <tt>io-channels</tt> element
  *             as defined by the node's io-channel-names property
  * @return the output cell in the specifier at the named element
  * @see DT_PHA_BY_NAME()
@@ -324,17 +324,17 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_IO_CHANNELS_OUTPUT_BY_IDX(node_id, 0)
- * @param node_id node identifier for a node with an io-channels property
+ * @param node_id node identifier for a node with an <tt>io-channels</tt> property
  * @return the output cell in the specifier at index 0
  * @see DT_IO_CHANNELS_OUTPUT_BY_IDX()
  */
 #define DT_IO_CHANNELS_OUTPUT(node_id) DT_IO_CHANNELS_OUTPUT_BY_IDX(node_id, 0)
 
 /**
- * @brief Get an output cell from the "DT_DRV_INST(inst)" io-channels
+ * @brief Get an output cell from the DT_DRV_INST(inst) <tt>io-channels</tt>
  *        property at an index
  * @param inst DT_DRV_COMPAT instance number
- * @param idx logical index into io-channels property
+ * @param idx logical index into <tt>io-channels</tt> property
  * @return the output cell in the specifier at index @p idx
  * @see DT_IO_CHANNELS_OUTPUT_BY_IDX()
  */
@@ -342,10 +342,10 @@ extern "C" {
 	DT_IO_CHANNELS_OUTPUT_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Get an output cell from the "DT_DRV_INST(inst)" io-channels
+ * @brief Get an output cell from the DT_DRV_INST(inst) <tt>io-channels</tt>
  *        property by name
  * @param inst DT_DRV_COMPAT instance number
- * @param name lowercase-and-underscores name of an io-channels element
+ * @param name lowercase-and-underscores name of an <tt>io-channels</tt> element
  *             as defined by the instance's io-channel-names property
  * @return the output cell in the specifier at the named element
  * @see DT_IO_CHANNELS_OUTPUT_BY_NAME()

--- a/include/zephyr/devicetree/map.h
+++ b/include/zephyr/devicetree/map.h
@@ -15,7 +15,7 @@
  * specifier mapping based on DeviceTree specifications. It enables the extraction
  * and interpretation of mapping data represented as phandle-arrays.
  *
- * In a typical DeviceTree fragment, properties ending with "-map" specify:
+ * In a typical DeviceTree fragment, properties ending with <tt>-map</tt> specifier:
  *  - The child specifier to be mapped.
  *  - The parent node (phandle) to which the mapping applies.
  *  - The parent specifier associated with the mapping.
@@ -74,7 +74,7 @@
  * @brief Returns the existence of map property.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @retval True if the map exists, otherwise 0.
  *
  * @see DT_NODE_HAS_PROP
@@ -85,7 +85,7 @@
  * @brief Returns the number of maps for the given property.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @return The total count of mapping entries.
  *
  * @see DT_PROP_LEN
@@ -96,7 +96,7 @@
  * @brief Is index @p entry_idx valid for an array type property?
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx index to check
  * @return An expression which evaluates to 1 if @p entry_idx is a valid index
  *         into the given property, and 0 otherwise.
@@ -111,7 +111,7 @@
  * zero.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @return An expression which evaluates to 1 if 0 is a valid index
  *         into the given property, and 0 otherwise.
  */
@@ -121,7 +121,7 @@
  * @brief Get the number of child addresses.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @return The number of child addresses.
  */
@@ -132,7 +132,7 @@
  * @brief Checks if the child address has the specified index.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @param param_idx The index in the child addresses.
  * @retval True if the child address has the index, otherwise 0.
@@ -148,7 +148,7 @@
  * @p param_idx set to zero.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @retval True if the child address has the index, otherwise 0.
  */
@@ -159,7 +159,7 @@
  * @brief Get the child address element from a mapping entry, by index.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @param param_idx The index in the child addresses.
  * @return The element of the specified position of the child addresses.
@@ -174,7 +174,7 @@
  * @p param_idx set to zero.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @return The element of the specified position of the child addresses.
  */
@@ -185,7 +185,7 @@
  * @brief Get the number of child specifiers.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @return The number of child specifiers.
  */
@@ -196,7 +196,7 @@
  * @brief Checks if the child specifier has the specified index.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @param param_idx The index in the child specifiers.
  * @retval True if the child specifier has the index, otherwise 0.
@@ -212,7 +212,7 @@
  * @p param_idx set to zero.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @retval True if the child specifier has the index, otherwise 0.
  */
@@ -223,7 +223,7 @@
  * @brief Get the child specifier element from a mapping entry, by index.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @param param_idx The index in the child specifiers.
  * @return The element of the specified position of the child specifiers.
@@ -238,7 +238,7 @@
  * @p param_idx set to zero.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @return The element of the specified position of the child specifiers.
  */
@@ -249,7 +249,7 @@
  * @brief Extracts the parent node from a mapping entry.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @return The parent node id.
  */
@@ -263,7 +263,7 @@
  * to zero.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @return The parent node id.
  */
 #define DT_MAP_ENTRY_PARENT(node_id, prop)                                       \
@@ -273,7 +273,7 @@
  * @brief Get the number of parent addresses.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @return The number of parent addresses.
  */
@@ -284,7 +284,7 @@
  * @brief Checks if the parent address has the specified index.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @param param_idx The index in the parent addresses.
  * @retval True if the parent address has the index, otherwise 0.
@@ -300,7 +300,7 @@
  * @p param_idx set to zero.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @retval True if the parent address has the index, otherwise 0.
  */
@@ -311,7 +311,7 @@
  * @brief Get the parent address element from a mapping entry, by index.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @param param_idx The index in the parent addresses.
  * @retval The element of the specified position of the parent addresses.
@@ -326,7 +326,7 @@
  * @p param_idx set to zero.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @retval The element of the specified position of the parent addresses.
  */
@@ -337,7 +337,7 @@
  * @brief Get the number of parent specifiers.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @retval The number of parent specifiers.
  */
@@ -348,7 +348,7 @@
  * @brief Checks if the parent specifier has the specified index.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @param param_idx The index in the parent specifiers.
  * @retval True if the parent specifier has the index, otherwise 0.
@@ -364,7 +364,7 @@
  * @p param_idx set to zero.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @retval True if the parent specifier has the index, otherwise 0.
  */
@@ -375,7 +375,7 @@
  * @brief Get the parent specifier element from a mapping entry, by index.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @param param_idx The index in the parent specifiers.
  * @retval The element of the specified position of the parent specifiers.
@@ -390,7 +390,7 @@
  * @p param_idx set to zero.
  *
  * @param node_id The node identifier.
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param entry_idx The mapping entry index.
  * @retval The element of the specified position of the parent specifiers.
  */
@@ -401,7 +401,7 @@
  * @brief Invokes @p fn for each map entry in the @p map.
  *
  * @param node_id node identifier
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param fn macro to invoke
  *
  * @see DT_FOREACH_PROP_ELEM
@@ -412,7 +412,7 @@
  * @brief Invokes @p fn for each map entry in the @p map with separator.
  *
  * @param node_id node identifier
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g.. <tt>gpio_map</tt>
  * @param fn macro to invoke
  * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
  *            this is required to enable providing a comma as separator.
@@ -426,7 +426,7 @@
  * @brief Invokes @p fn for each map entry in the @p map with separator.
  *
  * @param node_id node identifier
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param fn macro to invoke
  * @param ... variable number of arguments to pass to fn
  *
@@ -439,7 +439,7 @@
  * @brief Invokes @p fn for each map entry in the @p map with separator.
  *
  * @param node_id node identifier
- * @param prop The map property name. i.e. "gpio_map"
+ * @param prop The map property name. E.g. <tt>gpio_map</tt>
  * @param fn macro to invoke
  * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
  *            this is required to enable providing a comma as separator.

--- a/include/zephyr/devicetree/map.h
+++ b/include/zephyr/devicetree/map.h
@@ -93,12 +93,12 @@
 #define DT_MAP_LEN(node_id, prop) DT_PROP_LEN(node_id, prop)
 
 /**
- * @brief Is index @p idx valid for an array type property?
+ * @brief Is index @p entry_idx valid for an array type property?
  *
  * @param node_id The node identifier.
  * @param prop The map property name. i.e. "gpio_map"
  * @param entry_idx index to check
- * @return An expression which evaluates to 1 if @p idx is a valid index
+ * @return An expression which evaluates to 1 if @p entry_idx is a valid index
  *         into the given property, and 0 otherwise.
  */
 #define DT_MAP_HAS_ENTRY_BY_IDX(node_id, prop, entry_idx)                                          \
@@ -112,7 +112,7 @@
  *
  * @param node_id The node identifier.
  * @param prop The map property name. i.e. "gpio_map"
- * @return An expression which evaluates to 1 if @p idx is a valid index
+ * @return An expression which evaluates to 1 if 0 is a valid index
  *         into the given property, and 0 otherwise.
  */
 #define DT_MAP_HAS_ENTRY(node_id, prop) DT_MAP_HAS_ENTRY_BY_IDX(node_id, prop, 0)
@@ -443,7 +443,7 @@
  * @param fn macro to invoke
  * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
  *            this is required to enable providing a comma as separator.
- * @param ... variable number of arguments to pass to fn
+ * @param ... variable number of arguments to pass to @p fn
  *
  * @see DT_FOREACH_PROP_ELEM_SEP_VARGS
  */

--- a/include/zephyr/devicetree/mapped-partition.h
+++ b/include/zephyr/devicetree/mapped-partition.h
@@ -65,31 +65,31 @@ extern "C" {
 /**
  * @brief Test if a mapped partition with a given label property exists.
  * @param label lowercase-and-underscores label property value.
- * @return 1 if the device has a "zephyr,mapped-partition" compatible, 0 otherwise.
+ * @return 1 if the device has a <tt>zephyr,mapped-partition</tt> compatible, 0 otherwise.
  */
 #define DT_HAS_MAPPED_PARTITION_LABEL(label)						\
 	IS_ENABLED(DT_CAT3(DT_COMPAT_zephyr_mapped_partition_LABEL_, label, _EXISTS))
 
 /**
- * @brief Test if zephyr,mapped-partition compatible node exists.
+ * @brief Test if <tt>zephyr,mapped-partition</tt> compatible node exists.
  *
  * @param node_id DTS node to test.
- * @return 1 if node exists and has a zephyr,mapped-partition compatible, 0 otherwise.
+ * @return 1 if node exists and has a <tt>zephyr,mapped-partition</tt> compatible, 0 otherwise.
  */
 #define DT_MAPPED_PARTITION_EXISTS(node_id) DT_NODE_HAS_COMPAT(node_id, zephyr_mapped_partition)
 
 /**
  * @brief Get a numeric identifier for a mapped partition.
- * @param node_id node identifier for a zephyr,mapped-partition node.
+ * @param node_id node identifier for a <tt>zephyr,mapped-partition</tt> node.
  * @return the partition's ID, a unique zero-based index number.
  */
 #define DT_MAPPED_PARTITION_ID(node_id) DT_CAT(node_id, _PARTITION_ID)
 
 /**
  * @brief Get the node identifier of the NVM memory for a partition.
- * @param node_id node identifier for a zephyr,mapped-partition node.
- * @return the node identifier of the internal memory that contains the zephyr,mapped-partition
- *         node, or @ref DT_INVALID_NODE if it doesn't exist.
+ * @param node_id node identifier for a <tt>zephyr,mapped-partition</tt> node.
+ * @return the node identifier of the internal memory that contains the
+ *         <tt>zephyr,mapped-partition</tt> node, or @ref DT_INVALID_NODE if it doesn't exist.
  */
 #define DT_MEM_FROM_MAPPED_PARTITION(node_id)						\
 	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_CAT(node_id, _NVM_DEVICE), soc_nv_flash),	\
@@ -98,9 +98,9 @@ extern "C" {
 
 /**
  * @brief Get the node identifier of the NVM controller for a partition.
- * @param node_id node identifier for a zephyr,mapped-partition node.
+ * @param node_id node identifier for a <tt>zephyr,mapped-partition</tt> node.
  * @return the node identifier of the memory technology device that contains the
- *         zephyr,mapped-partition node.
+ *         <tt>zephyr,mapped-partition</tt> node.
  */
 #define DT_MTD_FROM_MAPPED_PARTITION(node_id) DT_PARENT(DT_MEM_FROM_MAPPED_PARTITION(node_id))
 
@@ -135,7 +135,7 @@ extern "C" {
  * This macro can only be used with partitions of internal memory addressable by the CPU.
  * Otherwise, it may produce a compile-time error, such as: `'__REG_IDX_0_VAL_ADDRESS' undeclared`.
  *
- * @param node_id node identifier for a zephyr,mapped-partition node
+ * @param node_id node identifier for a <tt>zephyr,mapped-partition</tt> node
  * @return the partition's unit address.
  */
 #define DT_MAPPED_PARTITION_ADDR(node_id) DT_REG_ADDR(node_id)
@@ -171,7 +171,7 @@ extern "C" {
  * This macro can only be used with partitions of internal memory addressable by the CPU.
  * Otherwise, it may produce a compile-time error, such as: `'__REG_IDX_0_VAL_ADDRESS' undeclared`.
  *
- * @param node_id node identifier for a zephyr,mapped-partition node
+ * @param node_id node identifier for a <tt>zephyr,mapped-partition</tt> node
  * @return the partition's offset from the memory device.
  */
 #define DT_MAPPED_PARTITION_OFFSET(node_id)						\

--- a/include/zephyr/devicetree/mbox.h
+++ b/include/zephyr/devicetree/mbox.h
@@ -24,7 +24,7 @@ extern "C" {
  */
 
 /**
- * @brief Get the node identifier for the MBOX controller from a mboxes
+ * @brief Get the node identifier for the MBOX controller from a <tt>mboxes</tt>
  *	  property by name
  *
  * Example devicetree fragment:
@@ -42,9 +42,9 @@ extern "C" {
  *     DT_MBOX_CTLR_BY_NAME(DT_NODELABEL(n), tx) // DT_NODELABEL(mbox1)
  *     DT_MBOX_CTLR_BY_NAME(DT_NODELABEL(n), rx) // DT_NODELABEL(mbox1)
  *
- * @param node_id node identifier for a node with a mboxes property
- * @param name lowercase-and-underscores name of a mboxes element
- *             as defined by the node's mbox-names property
+ * @param node_id node identifier for a node with a <tt>mboxes</tt> property
+ * @param name lowercase-and-underscores name of a <tt>mboxes</tt> element
+ *             as defined by the node's <tt>mbox-names</tt> property
  *
  * @return the node identifier for the MBOX controller in the named element
  *
@@ -78,9 +78,9 @@ extern "C" {
  *     DT_MBOX_CHANNEL_BY_NAME(DT_NODELABEL(n), tx) // 1
  *     DT_MBOX_CHANNEL_BY_NAME(DT_NODELABEL(n), rx) // 6
  *
- * @param node_id node identifier for a node with a mboxes property
- * @param name lowercase-and-underscores name of a mboxes element
- *             as defined by the node's mbox-names property
+ * @param node_id node identifier for a node with a <tt>mboxes</tt> property
+ * @param name lowercase-and-underscores name of a <tt>mboxes</tt> element
+ *             as defined by the node's <tt>mbox-names</tt> property
  *
  * @return the channel value in the specifier at the named element or 0 if no
  *         channels are supported

--- a/include/zephyr/devicetree/nvmem.h
+++ b/include/zephyr/devicetree/nvmem.h
@@ -27,10 +27,10 @@ extern "C" {
  */
 
 /**
- * @brief Test if a node has an nvmem-cells phandle-array property at a given index
+ * @brief Test if a node has an <tt>nvmem-cells</tt> phandle-array property at a given index
  *
- * This expands to 1 if the given index is a valid nvmem-cells property phandle-array index.
- * Otherwise, it expands to 0.
+ * This expands to 1 if the given index is a valid <tt>nvmem-cells</tt> property phandle-array
+ * index. Otherwise, it expands to 0.
  *
  * Example devicetree fragment:
  *
@@ -48,17 +48,17 @@ extern "C" {
  *	DT_NVMEM_CELLS_HAS_IDX(DT_NODELABEL(eth), 1) // 0
  * @endcode
  *
- * @param node_id Node identifier that may or may not have an nvmem-cells property.
- * @param idx Index of an nvmem-cells property phandle-array whose existence to check.
+ * @param node_id Node identifier that may or may not have an <tt>nvmem-cells</tt> property.
+ * @param idx Index of an <tt>nvmem-cells</tt> property phandle-array whose existence to check.
  *
  * @return 1 if the index exists, 0 otherwise.
  */
 #define DT_NVMEM_CELLS_HAS_IDX(node_id, idx) DT_PROP_HAS_IDX(node_id, nvmem_cells, idx)
 
 /**
- * @brief Test if a node has an nvmem-cell-names array property holds a given name.
+ * @brief Test if a node has an <tt>nvmem-cell-names</tt> array property holds a given name.
  *
- * This expands to 1 if the name is available as nvmem-cells-name array property cell.
+ * This expands to 1 if the name is available as <tt>nvmem-cells-name</tt> array property cell.
  * Otherwise, it expands to 0.
  *
  * Example devicetree fragment:
@@ -77,15 +77,15 @@ extern "C" {
  *	DT_NVMEM_CELLS_HAS_NAME(DT_NODELABEL(eth), bogus)       // 0
  * @endcode
  *
- * @param node_id Node identifier that may or may not have an nvmem-cell-names property.
- * @param name Lowercase-and-underscores nvmem-cell-names cell value name to check.
+ * @param node_id Node identifier that may or may not have an <tt>nvmem-cell-names</tt> property.
+ * @param name Lowercase-and-underscores <tt>nvmem-cell-names</tt> cell value name to check.
  *
  * @return 1 if the index exists, 0 otherwise.
  */
 #define DT_NVMEM_CELLS_HAS_NAME(node_id, name) DT_PROP_HAS_NAME(node_id, nvmem_cells, name)
 
 /**
- * @brief Get the number of elements in an nvmem-cells property
+ * @brief Get the number of elements in an <tt>nvmem-cells</tt> property
  *
  * Example devicetree fragment:
  *
@@ -102,14 +102,15 @@ extern "C" {
  *	DT_NUM_NVMEM_CELLS(DT_NODELABEL(eth)) // 1
  * @endcode
  *
- * @param node_id Node identifier for a node with an nvmem-cells property.
+ * @param node_id Node identifier for a node with an <tt>nvmem-cells</tt> property.
  *
  * @return Number of elements in the property.
  */
 #define DT_NUM_NVMEM_CELLS(node_id) DT_PROP_LEN(node_id, nvmem_cells)
 
 /**
- * @brief Get the node identifier for the NVMEM cell from the nvmem-cells property by index.
+ * @brief Get the node identifier for the NVMEM cell from the <tt>nvmem-cells</tt> property by
+ * index.
  *
  * Example devicetree fragment:
  *
@@ -139,8 +140,8 @@ extern "C" {
  *	DT_NVMEM_CELL_BY_IDX(DT_NODELABEL(eth), 0) // DT_NODELABEL(mac_address)
  * @endcode
  *
- * @param node_id Node identifier for a node with an nvmem-cells property.
- * @param idx Index into the nvmem-cells property.
+ * @param node_id Node identifier for a node with an <tt>nvmem-cells</tt> property.
+ * @param idx Index into the <tt>nvmem-cells</tt> property.
  *
  * @return The node identifier for the NVMEM cell at index @p idx.
  */
@@ -151,17 +152,17 @@ extern "C" {
  *
  * Equivalent to DT_NVMEM_CELL_BY_IDX(node_id, 0).
  *
- * @param node_id Node identifier for a node with an nvmem-cells property.
+ * @param node_id Node identifier for a node with an <tt>nvmem-cells</tt> property.
  *
  * @return A node identifier for the NVMEM cell at index 0
- *         in "nvmem-cells".
+ *         in <tt>nvmem-cells</tt>.
  *
  * @see DT_NVMEM_CELL_BY_IDX()
  */
 #define DT_NVMEM_CELL(node_id) DT_NVMEM_CELL_BY_IDX(node_id, 0)
 
 /**
- * @brief Get the node identifier for the NVMEM cell from the nvmem-cells property by name.
+ * @brief Get the node identifier for the NVMEM cell from the <tt>nvmem-cells</tt> property by name.
  *
  * Example devicetree fragment:
  *
@@ -191,55 +192,58 @@ extern "C" {
  *	DT_NVMEM_CELL_BY_NAME(DT_NODELABEL(eth), mac_address) // DT_NODELABEL(mac_address)
  * @endcode
  *
- * @param node_id Node identifier for a node with an nvmem-cells property.
- * @param name Lowercase-and-underscores name of an nvmem-cells element
- *             as defined by the node's nvmem-cell-names property.
+ * @param node_id Node identifier for a node with an <tt>nvmem-cells</tt> property.
+ * @param name Lowercase-and-underscores name of an <tt>nvmem-cells</tt> element
+ *             as defined by the node's <tt>nvmem-cell-names</tt> property.
  *
  * @return The node identifier for the NVMEM cell by @p name.
  */
 #define DT_NVMEM_CELL_BY_NAME(node_id, name) DT_PHANDLE_BY_NAME(node_id, nvmem_cells, name)
 
 /**
- * @brief Test if a DT_DRV_COMPAT instance has an nvmem-cells property at a given index.
+ * @brief Test if a DT_DRV_COMPAT instance has an <tt>nvmem-cells</tt> property at a given index.
  *
  * Equivalent to DT_NVMEM_CELLS_HAS_IDX(DT_DRV_INST(inst), idx).
  *
- * @param inst DT_DRV_COMPAT instance number that may or may not have an nvmem-cells property.
- * @param idx Index of an nvmem-cells property phandle-array whose existence to check.
+ * @param inst DT_DRV_COMPAT instance number that may or may not have an <tt>nvmem-cells</tt>
+ *             property.
+ * @param idx Index of an <tt>nvmem-cells</tt> property phandle-array whose existence to check.
  *
  * @return 1 if the index exists, 0 otherwise.
  */
 #define DT_INST_NVMEM_CELLS_HAS_IDX(inst, idx) DT_NVMEM_CELLS_HAS_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Test if a DT_DRV_COMPAT instance has an nvmem-cell-names property with a given name.
+ * @brief Test if a @ref DT_DRV_COMPAT instance has an <tt>nvmem-cell-names</tt> property with a
+ * given name.
  *
  * Equivalent to DT_NVMEM_CELLS_HAS_NAME(DT_DRV_INST(inst), name).
  *
- * @param inst DT_DRV_COMPAT instance number that may or may not have an nvmem-cell-names property.
- * @param name Lowercase-and-underscores nvmem-cell-names cell value name to check.
+ * @param inst DT_DRV_COMPAT instance number that may or may not have an <tt>nvmem-cell-names</tt>
+ *             property.
+ * @param name Lowercase-and-underscores <tt>nvmem-cell-names</tt> cell value name to check.
  *
  * @return 1 if the nvmem cell name exists, 0 otherwise.
  */
 #define DT_INST_NVMEM_CELLS_HAS_NAME(inst, name) DT_NVMEM_CELLS_HAS_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get the number of elements in a DT_DRV_COMPAT instance's nvmem-cells property.
+ * @brief Get the number of elements in a DT_DRV_COMPAT instance's <tt>nvmem-cells</tt> property.
  *
  * Equivalent to DT_NUM_NVMEM_CELLS(DT_DRV_INST(inst)).
  *
  * @param inst DT_DRV_COMPAT instance number.
  *
- * @return Number of elements in the nvmem-cells property.
+ * @return Number of elements in the <tt>nvmem-cells</tt> property.
  */
 #define DT_INST_NUM_NVMEM_CELLS(inst) DT_NUM_NVMEM_CELLS(DT_DRV_INST(inst))
 
 /**
  * @brief Get the node identifier for the controller phandle from an
- *        nvmem-cells phandle-array property at an index
+ *        <tt>nvmem-cells</tt> phandle-array property at an index
  *
  * @param inst DT_DRV_COMPAT instance number.
- * @param idx Logical index into nvmem-cells property.
+ * @param idx Logical index into <tt>nvmem-cells</tt> property.
  *
  * @return The node identifier for the nvmem cell referenced at index @p idx.
  *
@@ -254,8 +258,7 @@ extern "C" {
  *
  * @param inst DT_DRV_COMPAT instance number.
  *
- * @return A node identifier for the nvmem cell at index 0
- *         in nvmem-cells.
+ * @return A node identifier for the nvmem cell at index 0 in <tt>nvmem-cells</tt>.
  *
  * @see DT_NVMEM_CELL()
  */
@@ -263,11 +266,11 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the controller phandle from an
- *        nvmem-cells phandle-array property by name
+ *        <tt>nvmem-cells</tt> phandle-array property by name
  *
  * @param inst DT_DRV_COMPAT instance number.
- * @param name Lowercase-and-underscores name of an nvmem-cells element
- *             as defined by the node's nvmem-cell-names property.
+ * @param name Lowercase-and-underscores name of an <tt>nvmem-cells</tt> element
+ *             as defined by the node's <tt>nvmem-cell-names</tt> property.
  *
  * @return The node identifier for the nvmem cell referenced by
  *         the named element.

--- a/include/zephyr/devicetree/nvmem.h
+++ b/include/zephyr/devicetree/nvmem.h
@@ -201,11 +201,11 @@ extern "C" {
 #define DT_NVMEM_CELL_BY_NAME(node_id, name) DT_PHANDLE_BY_NAME(node_id, nvmem_cells, name)
 
 /**
- * @brief Test if a DT_DRV_COMPAT instance has an <tt>nvmem-cells</tt> property at a given index.
+ * @brief Test if a @c DT_DRV_COMPAT instance has an <tt>nvmem-cells</tt> property at a given index.
  *
  * Equivalent to DT_NVMEM_CELLS_HAS_IDX(DT_DRV_INST(inst), idx).
  *
- * @param inst DT_DRV_COMPAT instance number that may or may not have an <tt>nvmem-cells</tt>
+ * @param inst @c DT_DRV_COMPAT instance number that may or may not have an <tt>nvmem-cells</tt>
  *             property.
  * @param idx Index of an <tt>nvmem-cells</tt> property phandle-array whose existence to check.
  *
@@ -214,12 +214,12 @@ extern "C" {
 #define DT_INST_NVMEM_CELLS_HAS_IDX(inst, idx) DT_NVMEM_CELLS_HAS_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Test if a @ref DT_DRV_COMPAT instance has an <tt>nvmem-cell-names</tt> property with a
+ * @brief Test if a @c DT_DRV_COMPAT instance has an <tt>nvmem-cell-names</tt> property with a
  * given name.
  *
  * Equivalent to DT_NVMEM_CELLS_HAS_NAME(DT_DRV_INST(inst), name).
  *
- * @param inst DT_DRV_COMPAT instance number that may or may not have an <tt>nvmem-cell-names</tt>
+ * @param inst @c DT_DRV_COMPAT instance number that may or may not have an <tt>nvmem-cell-names</tt>
  *             property.
  * @param name Lowercase-and-underscores <tt>nvmem-cell-names</tt> cell value name to check.
  *
@@ -228,11 +228,11 @@ extern "C" {
 #define DT_INST_NVMEM_CELLS_HAS_NAME(inst, name) DT_NVMEM_CELLS_HAS_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get the number of elements in a DT_DRV_COMPAT instance's <tt>nvmem-cells</tt> property.
+ * @brief Get the number of elements in a @c DT_DRV_COMPAT instance's <tt>nvmem-cells</tt> property.
  *
  * Equivalent to DT_NUM_NVMEM_CELLS(DT_DRV_INST(inst)).
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  *
  * @return Number of elements in the <tt>nvmem-cells</tt> property.
  */
@@ -242,7 +242,7 @@ extern "C" {
  * @brief Get the node identifier for the controller phandle from an
  *        <tt>nvmem-cells</tt> phandle-array property at an index
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into <tt>nvmem-cells</tt> property.
  *
  * @return The node identifier for the nvmem cell referenced at index @p idx.
@@ -252,11 +252,11 @@ extern "C" {
 #define DT_INST_NVMEM_CELL_BY_IDX(inst, idx) DT_NVMEM_CELL_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Get the node identifier for a DT_DRV_COMPAT instance's NVMEM cell at index 0.
+ * @brief Get the node identifier for a @c DT_DRV_COMPAT instance's NVMEM cell at index 0.
  *
  * Equivalent to DT_INST_NVMEM_CELL_BY_IDX(inst, 0).
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  *
  * @return A node identifier for the nvmem cell at index 0 in <tt>nvmem-cells</tt>.
  *
@@ -268,7 +268,7 @@ extern "C" {
  * @brief Get the node identifier for the controller phandle from an
  *        <tt>nvmem-cells</tt> phandle-array property by name
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name of an <tt>nvmem-cells</tt> element
  *             as defined by the node's <tt>nvmem-cell-names</tt> property.
  *

--- a/include/zephyr/devicetree/nvmem.h
+++ b/include/zephyr/devicetree/nvmem.h
@@ -142,7 +142,7 @@ extern "C" {
  * @param node_id Node identifier for a node with an nvmem-cells property.
  * @param idx Index into the nvmem-cells property.
  *
- * @return The node identifier for the NVMEM cell at index idx.
+ * @return The node identifier for the NVMEM cell at index @p idx.
  */
 #define DT_NVMEM_CELL_BY_IDX(node_id, idx) DT_PHANDLE_BY_IDX(node_id, nvmem_cells, idx)
 
@@ -195,7 +195,7 @@ extern "C" {
  * @param name Lowercase-and-underscores name of an nvmem-cells element
  *             as defined by the node's nvmem-cell-names property.
  *
- * @return The node identifier for the NVMEM cell by name.
+ * @return The node identifier for the NVMEM cell by @p name.
  */
 #define DT_NVMEM_CELL_BY_NAME(node_id, name) DT_PHANDLE_BY_NAME(node_id, nvmem_cells, name)
 
@@ -241,8 +241,7 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number.
  * @param idx Logical index into nvmem-cells property.
  *
- * @return The node identifier for the nvmem cell referenced at
- *         index "idx".
+ * @return The node identifier for the nvmem cell referenced at index @p idx.
  *
  * @see DT_NVMEM_CELL_CTLR_BY_IDX()
  */

--- a/include/zephyr/devicetree/nvmem.h
+++ b/include/zephyr/devicetree/nvmem.h
@@ -219,8 +219,8 @@ extern "C" {
  *
  * Equivalent to DT_NVMEM_CELLS_HAS_NAME(DT_DRV_INST(inst), name).
  *
- * @param inst @c DT_DRV_COMPAT instance number that may or may not have an <tt>nvmem-cell-names</tt>
- *             property.
+ * @param inst @c DT_DRV_COMPAT instance number that may or may not have an
+ *             <tt>nvmem-cell-names</tt> property.
  * @param name Lowercase-and-underscores <tt>nvmem-cell-names</tt> cell value name to check.
  *
  * @return 1 if the nvmem cell name exists, 0 otherwise.

--- a/include/zephyr/devicetree/ordinals.h
+++ b/include/zephyr/devicetree/ordinals.h
@@ -68,7 +68,7 @@
 #define DT_SUPPORTS_DEP_ORDS(node_id) DT_CAT(node_id, _SUPPORTS_ORDS)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's dependency ordinal
+ * @brief Get a @c DT_DRV_COMPAT instance's dependency ordinal
  *
  * Equivalent to DT_DEP_ORD(DT_DRV_INST(inst)).
  *
@@ -78,7 +78,7 @@
 #define DT_INST_DEP_ORD(inst) DT_DEP_ORD(DT_DRV_INST(inst))
 
 /**
- * @brief Get a list of dependency ordinals of a DT_DRV_COMPAT instance's
+ * @brief Get a list of dependency ordinals of a @c DT_DRV_COMPAT instance's
  *        direct dependencies
  *
  * Equivalent to DT_REQUIRES_DEP_ORDS(DT_DRV_INST(inst)).
@@ -91,7 +91,7 @@
 
 /**
  * @brief Get a list of dependency ordinals of what depends directly on a
- *        DT_DRV_COMPAT instance
+ *        @c DT_DRV_COMPAT instance
  *
  * Equivalent to DT_SUPPORTS_DEP_ORDS(DT_DRV_INST(inst)).
  *

--- a/include/zephyr/devicetree/partitions.h
+++ b/include/zephyr/devicetree/partitions.h
@@ -40,19 +40,20 @@ extern "C" {
 /**
  * @brief Test if a partition with a given label property exists
  * @param label lowercase-and-underscores label property value
- * @return 1 if the device has a "zephyr,mapped-partition" or "fixed-subpartitions" compatible,
- *         or parent has a "fixed-partitions" compatible, 0 otherwise.
+ * @return 1 if the device has a <tt><zephyr,mapped-partition</tt> or <tt>fixed-subpartitions</tt>
+ *         compatible, or parent has a <tt>fixed-partitions</tt> compatible, 0 otherwise.
  */
 #define DT_HAS_PARTITION_LABEL(label)								\
 	UTIL_OR(DT_HAS_MAPPED_PARTITION_LABEL(label), DT_HAS_FIXED_PARTITION_LABEL(label))
 
 /**
- * @brief Test if zephyr,mapped-partition, fixed-partitions or fixed-subpartitions compatible
- *        node exists
+ * @brief Test if <tt>zephyr,mapped-partition</tt>, <tt>fixed-subpartitions</tt> or
+ *        <tt>fixed-subpartitions</tt> compatible node exists
  *
  * @param node_id DTS node to test
- * @return 1 if node exists and has a "zephyr,mapped-partition" or "fixed-subpartitions"
- *         compatible, or if parent has a "fixed-partitions" compatible, 0 otherwise.
+ * @return 1 if node exists and has a <tt>zephyr,mapped-partition</tt> or
+ *         <tt>fixed-subpartitions</tt> compatible, or if parent has a <tt>fixed-partitions</tt>
+ *         compatible, 0 otherwise.
  */
 #define DT_PARTITION_EXISTS(node_id)				\
 	UTIL_OR(DT_MAPPED_PARTITION_EXISTS(node_id),		\

--- a/include/zephyr/devicetree/pinctrl.h
+++ b/include/zephyr/devicetree/pinctrl.h
@@ -33,10 +33,10 @@
  *     DT_PINCTRL_BY_IDX(DT_NODELABEL(n), 0, 1) // DT_NODELABEL(bar)
  *     DT_PINCTRL_BY_IDX(DT_NODELABEL(n), 1, 0) // DT_NODELABEL(baz)
  *
- * @param node_id node with a pinctrl-'pc_idx' property
+ * @param node_id node with a <tt>pinctrl-'pc_idx'</tt> property
  * @param pc_idx index of the pinctrl property itself
  * @param idx index into the value of the pinctrl property
- * @return node identifier for the phandle at index 'idx' in 'pinctrl-'pc_idx''
+ * @return node identifier for the phandle at index @p idx in <tt>pinctrl-'pc_idx'</tt>
  */
 #define DT_PINCTRL_BY_IDX(node_id, pc_idx, idx) \
 	DT_CAT6(node_id, _P_pinctrl_, pc_idx, _IDX_, idx, _PH)
@@ -307,7 +307,7 @@
  * @param inst instance number
  * @param pc_idx index of the pinctrl property itself
  * @param idx index into the value of the pinctrl property
- * @return node identifier for the phandle at index 'idx' in 'pinctrl-'pc_idx''
+ * @return node identifier for the phandle at index @p idx in <tt>pinctrl-'pc_idx'</tt>
  */
 #define DT_INST_PINCTRL_BY_IDX(inst, pc_idx, idx) \
 	DT_PINCTRL_BY_IDX(DT_DRV_INST(inst), pc_idx, idx)

--- a/include/zephyr/devicetree/pinctrl.h
+++ b/include/zephyr/devicetree/pinctrl.h
@@ -300,7 +300,7 @@
 
 /**
  * @brief Get a node identifier for a phandle in a pinctrl property by index
- *        for a DT_DRV_COMPAT instance
+ *        for a @c DT_DRV_COMPAT instance
  *
  * This is equivalent to DT_PINCTRL_BY_IDX(DT_DRV_INST(inst), pc_idx, idx).
  *
@@ -314,7 +314,7 @@
 
 /**
  * @brief Get a node identifier from a <tt>pinctrl-0</tt> property for a
- *        DT_DRV_COMPAT instance
+ *        @c DT_DRV_COMPAT instance
  *
  * This is equivalent to:
  *
@@ -332,7 +332,7 @@
 
 /**
  * @brief Get a node identifier for a phandle inside a pinctrl node
- *        for a DT_DRV_COMPAT instance
+ *        for a @c DT_DRV_COMPAT instance
  *
  * This is equivalent to DT_PINCTRL_BY_NAME(DT_DRV_INST(inst), name, idx).
  *
@@ -347,7 +347,7 @@
 
 /**
  * @brief Convert a pinctrl name to its corresponding index
- *        for a DT_DRV_COMPAT instance
+ *        for a @c DT_DRV_COMPAT instance
  *
  * This is equivalent to DT_PINCTRL_NAME_TO_IDX(DT_DRV_INST(inst),
  * name).
@@ -387,7 +387,7 @@
 
 /**
  * @brief Get the number of phandles in a pinctrl property
- *        for a DT_DRV_COMPAT instance
+ *        for a @c DT_DRV_COMPAT instance
  *
  * This is equivalent to DT_NUM_PINCTRLS_BY_IDX(DT_DRV_INST(inst),
  * pc_idx).
@@ -413,7 +413,7 @@
 	DT_NUM_PINCTRLS_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get the number of pinctrl properties in a DT_DRV_COMPAT instance
+ * @brief Get the number of pinctrl properties in a @c DT_DRV_COMPAT instance
  *
  * This is equivalent to DT_NUM_PINCTRL_STATES(DT_DRV_INST(inst)).
  *
@@ -424,7 +424,7 @@
 	DT_NUM_PINCTRL_STATES(DT_DRV_INST(inst))
 
 /**
- * @brief Test if a DT_DRV_COMPAT instance has a pinctrl property
+ * @brief Test if a @c DT_DRV_COMPAT instance has a pinctrl property
  *        with an index
  *
  * This is equivalent to DT_PINCTRL_HAS_IDX(DT_DRV_INST(inst), pc_idx).
@@ -437,7 +437,7 @@
 	DT_PINCTRL_HAS_IDX(DT_DRV_INST(inst), pc_idx)
 
 /**
- * @brief Test if a DT_DRV_COMPAT instance has a pinctrl property with a name
+ * @brief Test if a @c DT_DRV_COMPAT instance has a pinctrl property with a name
  *
  * This is equivalent to DT_PINCTRL_HAS_NAME(DT_DRV_INST(inst), name).
  *

--- a/include/zephyr/devicetree/pinctrl.h
+++ b/include/zephyr/devicetree/pinctrl.h
@@ -42,17 +42,17 @@
 	DT_CAT6(node_id, _P_pinctrl_, pc_idx, _IDX_, idx, _PH)
 
 /**
- * @brief Get a node identifier from a pinctrl-0 property
+ * @brief Get a node identifier from a <tt>pinctrl-0</tt> property
  *
  * This is equivalent to:
  *
  *     DT_PINCTRL_BY_IDX(node_id, 0, idx)
  *
- * It is provided for convenience since pinctrl-0 is commonly used.
+ * It is provided for convenience since <tt>pinctrl-0</tt> is commonly used.
  *
- * @param node_id node with a pinctrl-0 property
- * @param idx index into the pinctrl-0 property
- * @return node identifier for the phandle at index idx in the pinctrl-0
+ * @param node_id node with a <tt>pinctrl-0</tt> property
+ * @param idx index into the <tt>pinctrl-0</tt> property
+ * @return node identifier for the phandle at index idx in the <tt>pinctrl-0</tt>
  *         property of that node
  */
 #define DT_PINCTRL_0(node_id, idx) DT_PINCTRL_BY_IDX(node_id, 0, idx)
@@ -112,7 +112,7 @@
  * quotes" from it.
  *
  * DT_PINCTRL_IDX_TO_NAME_TOKEN() can only be used if the node has a
- * pinctrl-'pc_idx' property and a pinctrl-names property element for
+ * <tt>pinctrl-'pc_idx'</tt> property and a <tt>pinctrl-names</tt> property element for
  * that index. It is an error to use it in other circumstances.
  *
  * Example devicetree fragment:
@@ -216,7 +216,7 @@
 /**
  * @brief Get the number of pinctrl properties in a node
  *
- * This expands to 0 if there are no pinctrl-i properties.
+ * This expands to 0 if there are no <tt>pinctrl-'i'</tt> properties.
  * Otherwise, it expands to the number of such properties.
  *
  * Example devicetree fragment:
@@ -242,7 +242,7 @@
 /**
  * @brief Test if a node has a pinctrl property with an index
  *
- * This expands to 1 if the pinctrl-'idx' property exists.
+ * This expands to 1 if the <tt>pinctrl-'idx'</tt> property exists.
  * Otherwise, it expands to 0.
  *
  * Example devicetree fragment:
@@ -313,18 +313,18 @@
 	DT_PINCTRL_BY_IDX(DT_DRV_INST(inst), pc_idx, idx)
 
 /**
- * @brief Get a node identifier from a pinctrl-0 property for a
+ * @brief Get a node identifier from a <tt>pinctrl-0</tt> property for a
  *        DT_DRV_COMPAT instance
  *
  * This is equivalent to:
  *
  *     DT_PINCTRL_BY_IDX(DT_DRV_INST(inst), 0, idx)
  *
- * It is provided for convenience since pinctrl-0 is commonly used.
+ * It is provided for convenience since <tt>pinctrl-0</tt> is commonly used.
  *
  * @param inst instance number
- * @param idx index into the pinctrl-0 property
- * @return node identifier for the phandle at index idx in the pinctrl-0
+ * @param idx index into the <tt>pinctrl-0</tt> property
+ * @return node identifier for the phandle at index idx in the <tt>pinctrl-0</tt>
  *         property of that instance
  */
 #define DT_INST_PINCTRL_0(inst, idx) \

--- a/include/zephyr/devicetree/pwms.h
+++ b/include/zephyr/devicetree/pwms.h
@@ -321,9 +321,9 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the PWM controller from a
- *        DT_DRV_COMPAT instance's pwms property at an index
+ *        @c DT_DRV_COMPAT instance's pwms property at an index
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @return the node identifier for the PWM controller referenced at
  *         index @p idx
@@ -334,8 +334,8 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the PWM controller from a
- *        DT_DRV_COMPAT instance's pwms property by name
- * @param inst DT_DRV_COMPAT instance number
+ *        @c DT_DRV_COMPAT instance's pwms property by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
  * @return the node identifier for the PWM controller in the named element
@@ -346,7 +346,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CTLR_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the node identifier for the PWM controller at index 0
  *         in the instance's <tt>pwms</tt> property
  * @see DT_PWMS_CTLR_BY_IDX()
@@ -354,9 +354,9 @@ extern "C" {
 #define DT_INST_PWMS_CTLR(inst) DT_INST_PWMS_CTLR_BY_IDX(inst, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's PWM specifier's cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's PWM specifier's cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index @p idx
@@ -365,8 +365,8 @@ extern "C" {
 	DT_PWMS_CELL_BY_IDX(DT_DRV_INST(inst), idx, cell)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's PWM specifier's cell value by name
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get a @c DT_DRV_COMPAT instance's PWM specifier's cell value by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
  * @param cell lowercase-and-underscores cell name
@@ -378,7 +378,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, 0, cell)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index 0
  */
@@ -387,7 +387,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, channel)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @return the channel cell value at index @p idx
  * @see DT_INST_PWMS_CELL_BY_IDX()
@@ -397,7 +397,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_NAME(inst, name, channel)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
  * @return the channel cell value in the specifier at the named element
@@ -408,7 +408,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CHANNEL_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the channel cell value at index 0
  * @see DT_INST_PWMS_CHANNEL_BY_IDX()
  */
@@ -416,7 +416,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, period)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @return the period cell value at index @p idx
  * @see DT_INST_PWMS_CELL_BY_IDX()
@@ -426,7 +426,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_NAME(inst, name, period)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
  * @return the period cell value in the specifier at the named element
@@ -437,7 +437,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_PERIOD_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the period cell value at index 0
  * @see DT_INST_PWMS_PERIOD_BY_IDX()
  */
@@ -445,7 +445,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, flags)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @return the flags cell value at index @p idx, or zero if there is none
  * @see DT_INST_PWMS_CELL_BY_IDX()
@@ -455,7 +455,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_NAME(inst, name, flags)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
  * @return the flags cell value in the specifier at the named element,
@@ -467,7 +467,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_FLAGS_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the flags cell value at index 0, or zero if there is none
  * @see DT_INST_PWMS_FLAGS_BY_IDX()
  */

--- a/include/zephyr/devicetree/pwms.h
+++ b/include/zephyr/devicetree/pwms.h
@@ -46,7 +46,7 @@ extern "C" {
  * @param node_id node identifier for a node with a pwms property
  * @param idx logical index into pwms property
  * @return the node identifier for the PWM controller referenced at
- *         index "idx"
+ *         index @p idx
  * @see DT_PROP_BY_PHANDLE_IDX()
  */
 #define DT_PWMS_CTLR_BY_IDX(node_id, idx) \
@@ -130,7 +130,7 @@ extern "C" {
  * @param node_id node identifier for a node with a pwms property
  * @param idx logical index into pwms property
  * @param cell lowercase-and-underscores cell name
- * @return the cell value at index "idx"
+ * @return the cell value at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_PWMS_CELL_BY_IDX(node_id, idx, cell) \
@@ -202,7 +202,7 @@ extern "C" {
  *
  * @param node_id node identifier for a node with a pwms property
  * @param idx logical index into pwms property
- * @return the channel cell value at index "idx"
+ * @return the channel cell value at index @p idx
  * @see DT_PWMS_CELL_BY_IDX()
  */
 #define DT_PWMS_CHANNEL_BY_IDX(node_id, idx) \
@@ -243,7 +243,7 @@ extern "C" {
  *
  * @param node_id node identifier for a node with a pwms property
  * @param idx logical index into pwms property
- * @return the period cell value at index "idx"
+ * @return the period cell value at index @p idx
  * @see DT_PWMS_CELL_BY_IDX()
  */
 #define DT_PWMS_PERIOD_BY_IDX(node_id, idx) \
@@ -285,7 +285,7 @@ extern "C" {
  *
  * @param node_id node identifier for a node with a pwms property
  * @param idx logical index into pwms property
- * @return the flags cell value at index "idx", or zero if there is none
+ * @return the flags cell value at index @p idx, or zero if there is none
  * @see DT_PWMS_CELL_BY_IDX()
  */
 #define DT_PWMS_FLAGS_BY_IDX(node_id, idx) \
@@ -326,7 +326,7 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @return the node identifier for the PWM controller referenced at
- *         index "idx"
+ *         index @p idx
  * @see DT_PWMS_CTLR_BY_IDX()
  */
 #define DT_INST_PWMS_CTLR_BY_IDX(inst, idx) \
@@ -359,7 +359,7 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @param cell lowercase-and-underscores cell name
- * @return the cell value at index "idx"
+ * @return the cell value at index @p idx
  */
 #define DT_INST_PWMS_CELL_BY_IDX(inst, idx, cell) \
 	DT_PWMS_CELL_BY_IDX(DT_DRV_INST(inst), idx, cell)
@@ -389,7 +389,7 @@ extern "C" {
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, channel)
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
- * @return the channel cell value at index "idx"
+ * @return the channel cell value at index @p idx
  * @see DT_INST_PWMS_CELL_BY_IDX()
  */
 #define DT_INST_PWMS_CHANNEL_BY_IDX(inst, idx) \
@@ -418,7 +418,7 @@ extern "C" {
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, period)
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
- * @return the period cell value at index "idx"
+ * @return the period cell value at index @p idx
  * @see DT_INST_PWMS_CELL_BY_IDX()
  */
 #define DT_INST_PWMS_PERIOD_BY_IDX(inst, idx) \
@@ -447,7 +447,7 @@ extern "C" {
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, flags)
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
- * @return the flags cell value at index "idx", or zero if there is none
+ * @return the flags cell value at index @p idx, or zero if there is none
  * @see DT_INST_PWMS_CELL_BY_IDX()
  */
 #define DT_INST_PWMS_FLAGS_BY_IDX(inst, idx) \

--- a/include/zephyr/devicetree/pwms.h
+++ b/include/zephyr/devicetree/pwms.h
@@ -86,7 +86,7 @@ extern "C" {
  * @brief Equivalent to DT_PWMS_CTLR_BY_IDX(node_id, 0)
  * @param node_id node identifier for a node with a pwms property
  * @return the node identifier for the PWM controller at index 0
- *         in the node's "pwms" property
+ *         in the node's <tt>pwms</tt> property
  * @see DT_PWMS_CTLR_BY_IDX()
  */
 #define DT_PWMS_CTLR(node_id) DT_PWMS_CTLR_BY_IDX(node_id, 0)
@@ -195,7 +195,7 @@ extern "C" {
 /**
  * @brief Get a PWM specifier's channel cell value at an index
  *
- * This macro only works for PWM specifiers with cells named "channel".
+ * This macro only works for PWM specifiers with cells named <tt>channel</tt>.
  * Refer to the node's binding to check if necessary.
  *
  * This is equivalent to DT_PWMS_CELL_BY_IDX(node_id, idx, channel).
@@ -211,7 +211,7 @@ extern "C" {
 /**
  * @brief Get a PWM specifier's channel cell value by name
  *
- * This macro only works for PWM specifiers with cells named "channel".
+ * This macro only works for PWM specifiers with cells named <tt>channel</tt>.
  * Refer to the node's binding to check if necessary.
  *
  * This is equivalent to DT_PWMS_CELL_BY_NAME(node_id, name, channel).
@@ -236,7 +236,7 @@ extern "C" {
 /**
  * @brief Get PWM specifier's period cell value at an index
  *
- * This macro only works for PWM specifiers with cells named "period".
+ * This macro only works for PWM specifiers with cells named <tt>period</tt>.
  * Refer to the node's binding to check if necessary.
  *
  * This is equivalent to DT_PWMS_CELL_BY_IDX(node_id, idx, period).
@@ -252,7 +252,7 @@ extern "C" {
 /**
  * @brief Get a PWM specifier's period cell value by name
  *
- * This macro only works for PWM specifiers with cells named "period".
+ * This macro only works for PWM specifiers with cells named <tt>period</tt>.
  * Refer to the node's binding to check if necessary.
  *
  * This is equivalent to DT_PWMS_CELL_BY_NAME(node_id, name, period).
@@ -277,8 +277,8 @@ extern "C" {
 /**
  * @brief Get a PWM specifier's flags cell value at an index
  *
- * This macro expects PWM specifiers with cells named "flags".
- * If there is no "flags" cell in the PWM specifier, zero is returned.
+ * This macro expects PWM specifiers with cells named <tt>flags</tt>.
+ * If there is no <tt>flags</tt> cell in the PWM specifier, zero is returned.
  * Refer to the node's binding to check specifier cell names if necessary.
  *
  * This is equivalent to DT_PWMS_CELL_BY_IDX(node_id, idx, flags).
@@ -294,8 +294,8 @@ extern "C" {
 /**
  * @brief Get a PWM specifier's flags cell value by name
  *
- * This macro expects PWM specifiers with cells named "flags".
- * If there is no "flags" cell in the PWM specifier, zero is returned.
+ * This macro expects PWM specifiers with cells named <tt>flags</tt>.
+ * If there is no <tt>flags</tt> cell in the PWM specifier, zero is returned.
  * Refer to the node's binding to check specifier cell names if necessary.
  *
  * This is equivalent to DT_PWMS_CELL_BY_NAME(node_id, name, flags) if
@@ -348,7 +348,7 @@ extern "C" {
  * @brief Equivalent to DT_INST_PWMS_CTLR_BY_IDX(inst, 0)
  * @param inst DT_DRV_COMPAT instance number
  * @return the node identifier for the PWM controller at index 0
- *         in the instance's "pwms" property
+ *         in the instance's <tt>pwms</tt> property
  * @see DT_PWMS_CTLR_BY_IDX()
  */
 #define DT_INST_PWMS_CTLR(inst) DT_INST_PWMS_CTLR_BY_IDX(inst, 0)

--- a/include/zephyr/devicetree/reset.h
+++ b/include/zephyr/devicetree/reset.h
@@ -45,7 +45,7 @@ extern "C" {
  * @param node_id node identifier
  * @param idx logical index into "resets"
  * @return the node identifier for the reset controller referenced at
- *         index "idx"
+ *         index @p idx
  * @see DT_PHANDLE_BY_IDX()
  */
 #define DT_RESET_CTLR_BY_IDX(node_id, idx) \
@@ -116,7 +116,7 @@ extern "C" {
  * @param node_id node identifier for a node with a resets property
  * @param idx logical index into resets property
  * @param cell lowercase-and-underscores cell name
- * @return the cell value at index "idx"
+ * @return the cell value at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_RESET_CELL_BY_IDX(node_id, idx, cell) \
@@ -172,8 +172,7 @@ extern "C" {
  *
  * @param inst instance number
  * @param idx logical index into "resets"
- * @return the node identifier for the reset controller referenced at
- *         index "idx"
+ * @return the node identifier for the reset controller referenced at index @p idx
  * @see DT_RESET_CTLR_BY_IDX()
  */
 #define DT_INST_RESET_CTLR_BY_IDX(inst, idx) \
@@ -209,7 +208,7 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into resets property
  * @param cell lowercase-and-underscores cell name
- * @return the cell value at index "idx"
+ * @return the cell value at index @p idx
  * @see DT_RESET_CELL_BY_IDX()
  */
 #define DT_INST_RESET_CELL_BY_IDX(inst, idx, cell) \
@@ -264,7 +263,7 @@ extern "C" {
  *
  * @param node_id node identifier
  * @param idx logical index into "resets"
- * @return the id cell value at index "idx"
+ * @return the id cell value at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_RESET_ID_BY_IDX(node_id, idx) \
@@ -284,7 +283,7 @@ extern "C" {
  *        at an index
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into "resets"
- * @return the id cell value at index "idx"
+ * @return the id cell value at index @p idx
  * @see DT_RESET_ID_BY_IDX()
  */
 #define DT_INST_RESET_ID_BY_IDX(inst, idx) \

--- a/include/zephyr/devicetree/reset.h
+++ b/include/zephyr/devicetree/reset.h
@@ -203,9 +203,9 @@ extern "C" {
 	DT_RESET_CTLR_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's reset specifier's cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's reset specifier's cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into resets property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index @p idx
@@ -215,8 +215,8 @@ extern "C" {
 	DT_RESET_CELL_BY_IDX(DT_DRV_INST(inst), idx, cell)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's reset specifier's cell value by name
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get a @c DT_DRV_COMPAT instance's reset specifier's cell value by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a resets element
  *             as defined by the node's reset-names property
  * @param cell lowercase-and-underscores cell name
@@ -228,7 +228,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_RESET_CELL_BY_IDX(inst, 0, cell)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param cell lowercase-and-underscores cell name
  * @return the value of the cell inside the specifier at index 0
  */
@@ -279,9 +279,9 @@ extern "C" {
 	DT_RESET_ID_BY_IDX(node_id, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's Reset Controller specifier's <tt>id</tt> cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's Reset Controller specifier's <tt>id</tt> cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into <tt>resets</tt>
  * @return the <tt>id</tt> cell value at index @p idx
  * @see DT_RESET_ID_BY_IDX()
@@ -291,7 +291,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_RESET_ID_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the <tt>id</tt> cell value at index 0
  * @see DT_INST_RESET_ID_BY_IDX()
  */

--- a/include/zephyr/devicetree/reset.h
+++ b/include/zephyr/devicetree/reset.h
@@ -25,7 +25,7 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the controller phandle from a
- *        "resets" phandle-array property at an index
+ *        <tt>resets</tt> phandle-array property at an index
  *
  * Example devicetree fragment:
  *
@@ -43,7 +43,7 @@ extern "C" {
  *     DT_RESET_CTLR_BY_IDX(DT_NODELABEL(n), 1)) // DT_NODELABEL(reset2)
  *
  * @param node_id node identifier
- * @param idx logical index into "resets"
+ * @param idx logical index into <tt>resets</tt>
  * @return the node identifier for the reset controller referenced at
  *         index @p idx
  * @see DT_PHANDLE_BY_IDX()
@@ -55,7 +55,7 @@ extern "C" {
  * @brief Equivalent to DT_RESET_CTLR_BY_IDX(node_id, 0)
  * @param node_id node identifier
  * @return a node identifier for the reset controller at index 0
- *         in "resets"
+ *         in <tt>resets</tt>
  * @see DT_RESET_CTLR_BY_IDX()
  */
 #define DT_RESET_CTLR(node_id) \
@@ -168,10 +168,10 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the controller phandle from a
- *        "resets" phandle-array property at an index
+ *        <tt>resets</tt> phandle-array property at an index
  *
  * @param inst instance number
- * @param idx logical index into "resets"
+ * @param idx logical index into <tt>resets</tt>
  * @return the node identifier for the reset controller referenced at index @p idx
  * @see DT_RESET_CTLR_BY_IDX()
  */
@@ -182,7 +182,7 @@ extern "C" {
  * @brief Equivalent to DT_INST_RESET_CTLR_BY_IDX(inst, 0)
  * @param inst instance number
  * @return a node identifier for the reset controller at index 0
- *         in "resets"
+ *         in <tt>resets</tt>
  * @see DT_RESET_CTLR()
  */
 #define DT_INST_RESET_CTLR(inst) \
@@ -236,9 +236,9 @@ extern "C" {
 	DT_INST_RESET_CELL_BY_IDX(inst, 0, cell)
 
 /**
- * @brief Get a Reset Controller specifier's id cell at an index
+ * @brief Get a Reset Controller specifier's <tt>id</tt> cell at an index
  *
- * This macro only works for Reset Controller specifiers with cells named "id".
+ * This macro only works for Reset Controller specifiers with cells named <tt>id</tt>.
  * Refer to the node's binding to check if necessary.
  *
  * Example devicetree fragment:
@@ -262,8 +262,8 @@ extern "C" {
  *     DT_RESET_ID_BY_IDX(DT_NODELABEL(n), 0) // 10
  *
  * @param node_id node identifier
- * @param idx logical index into "resets"
- * @return the id cell value at index @p idx
+ * @param idx logical index into <tt>resets</tt>
+ * @return the <tt>id</tt> cell value at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_RESET_ID_BY_IDX(node_id, idx) \
@@ -272,18 +272,18 @@ extern "C" {
 /**
  * @brief Equivalent to DT_RESET_ID_BY_IDX(node_id, 0)
  * @param node_id node identifier
- * @return the id cell value at index 0
+ * @return the <tt>id</tt> cell value at index 0
  * @see DT_RESET_ID_BY_IDX()
  */
 #define DT_RESET_ID(node_id) \
 	DT_RESET_ID_BY_IDX(node_id, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's Reset Controller specifier's id cell value
+ * @brief Get a DT_DRV_COMPAT instance's Reset Controller specifier's <tt>id</tt> cell value
  *        at an index
  * @param inst DT_DRV_COMPAT instance number
- * @param idx logical index into "resets"
- * @return the id cell value at index @p idx
+ * @param idx logical index into <tt>resets</tt>
+ * @return the <tt>id</tt> cell value at index @p idx
  * @see DT_RESET_ID_BY_IDX()
  */
 #define DT_INST_RESET_ID_BY_IDX(inst, idx) \
@@ -292,7 +292,7 @@ extern "C" {
 /**
  * @brief Equivalent to DT_INST_RESET_ID_BY_IDX(inst, 0)
  * @param inst DT_DRV_COMPAT instance number
- * @return the id cell value at index 0
+ * @return the <tt>id</tt> cell value at index 0
  * @see DT_INST_RESET_ID_BY_IDX()
  */
 #define DT_INST_RESET_ID(inst) \

--- a/include/zephyr/devicetree/spi.h
+++ b/include/zephyr/devicetree/spi.h
@@ -215,7 +215,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_SPI_DEV_HAS_CS_GPIOS(DT_DRV_INST(inst)).
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return 1 if the instance's bus has a CS pin at index
  *         DT_INST_REG_ADDR(inst), 0 otherwise
  * @see DT_SPI_DEV_HAS_CS_GPIOS()
@@ -226,7 +226,7 @@ extern "C" {
 /**
  * @brief Get GPIO controller node identifier for a SPI device instance
  * This is equivalent to DT_SPI_DEV_CS_GPIOS_CTLR(DT_DRV_INST(inst)).
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return node identifier for instance's chip select GPIO controller
  * @see DT_SPI_DEV_CS_GPIOS_CTLR()
  */
@@ -235,7 +235,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_SPI_DEV_CS_GPIOS_PIN(DT_DRV_INST(inst)).
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return pin number of the instance's chip select GPIO
  * @see DT_SPI_DEV_CS_GPIOS_PIN()
  */
@@ -244,7 +244,7 @@ extern "C" {
 
 /**
  * @brief DT_SPI_DEV_CS_GPIOS_FLAGS(DT_DRV_INST(inst)).
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return flags value of the instance's chip select GPIO specifier,
  *         or zero if there is none
  * @see DT_SPI_DEV_CS_GPIOS_FLAGS()

--- a/include/zephyr/devicetree/spi.h
+++ b/include/zephyr/devicetree/spi.h
@@ -48,7 +48,7 @@ extern "C" {
  *     DT_SPI_HAS_CS_GPIOS(DT_NODELABEL(spi2)) // 0
  *
  * @param spi a SPI bus controller node identifier
- * @return 1 if "spi" has a cs-gpios property, 0 otherwise
+ * @return 1 if @p spi has a cs-gpios property, 0 otherwise
  */
 #define DT_SPI_HAS_CS_GPIOS(spi) DT_NODE_HAS_PROP(spi, cs_gpios)
 
@@ -73,7 +73,7 @@ extern "C" {
  *     DT_SPI_NUM_CS_GPIOS(DT_NODELABEL(spi2)) // 0
  *
  * @param spi a SPI bus controller node identifier
- * @return Logical length of spi's cs-gpios property, or 0 if "spi" doesn't
+ * @return Logical length of spi's cs-gpios property, or 0 if @p spi doesn't
  *         have a cs-gpios property
  */
 #define DT_SPI_NUM_CS_GPIOS(spi) \
@@ -112,7 +112,7 @@ extern "C" {
  *     DT_SPI_DEV_HAS_CS_GPIOS(DT_NODELABEL(c)) // 0
  *
  * @param spi_dev a SPI device node identifier
- * @return 1 if spi_dev's bus node DT_BUS(spi_dev) has a chip select
+ * @return 1 if @p spi_dev bus node DT_BUS(spi_dev) has a chip select
  *         pin at index DT_REG_ADDR(spi_dev), 0 otherwise
  */
 #define DT_SPI_DEV_HAS_CS_GPIOS(spi_dev)                                                           \
@@ -147,7 +147,7 @@ extern "C" {
  *     DT_SPI_DEV_CS_GPIOS_CTLR(DT_NODELABEL(b)) // DT_NODELABEL(gpio2)
  *
  * @param spi_dev a SPI device node identifier
- * @return node identifier for spi_dev's chip select GPIO controller
+ * @return node identifier for @p spi_dev chip select GPIO controller
  */
 #define DT_SPI_DEV_CS_GPIOS_CTLR(spi_dev) \
 	DT_GPIO_CTLR_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR_RAW(spi_dev))
@@ -155,7 +155,7 @@ extern "C" {
 /**
  * @brief Get a SPI device's chip select GPIO pin number
  *
- * It's an error if the GPIO specifier for spi_dev's entry in its
+ * It's an error if the GPIO specifier for @p spi_dev entry in its
  * bus node's cs-gpios property has no pin cell.
  *
  * Example devicetree fragment:
@@ -180,7 +180,7 @@ extern "C" {
  *     DT_SPI_DEV_CS_GPIOS_PIN(DT_NODELABEL(b)) // 20
  *
  * @param spi_dev a SPI device node identifier
- * @return pin number of spi_dev's chip select GPIO
+ * @return pin number of @p spi_dev chip select GPIO
  */
 #define DT_SPI_DEV_CS_GPIOS_PIN(spi_dev) \
 	DT_GPIO_PIN_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR_RAW(spi_dev))
@@ -203,11 +203,11 @@ extern "C" {
  *
  *     DT_SPI_DEV_CS_GPIOS_FLAGS(DT_NODELABEL(a)) // GPIO_ACTIVE_LOW
  *
- * If the GPIO specifier for spi_dev's entry in its bus node's
+ * If the GPIO specifier for @p spi_dev entry in its bus node's
  * cs-gpios property has no flags cell, this expands to zero.
  *
  * @param spi_dev a SPI device node identifier
- * @return flags value of spi_dev's chip select GPIO specifier, or
+ * @return flags value of @p spi_dev chip select GPIO specifier, or
  *         zero if there is none
  */
 #define DT_SPI_DEV_CS_GPIOS_FLAGS(spi_dev) \

--- a/include/zephyr/devicetree/wuc.h
+++ b/include/zephyr/devicetree/wuc.h
@@ -121,9 +121,9 @@ extern "C" {
 #define DT_INST_WUC(inst) DT_INST_WUC_BY_IDX(inst, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's wakeup controller specifier's cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's wakeup controller specifier's cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into wakeup-ctrls property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index @p idx
@@ -133,7 +133,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_WUC_CELL_BY_IDX(inst, 0, cell)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param cell lowercase-and-underscores cell name
  * @return the value of the cell inside the specifier at index 0
  */
@@ -181,9 +181,9 @@ extern "C" {
 #define DT_WUC_ID(node_id) DT_WUC_ID_BY_IDX(node_id, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's Wakeup Controller specifier's <tt>id</tt> cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's Wakeup Controller specifier's <tt>id</tt> cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into <tt>wakeup-ctrls</tt>
  * @return the <tt>id</tt> cell value at index @p idx
  * @see DT_WUC_ID_BY_IDX()
@@ -192,7 +192,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_WUC_ID_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the <tt>id</tt> cell value at index 0
  * @see DT_INST_WUC_ID_BY_IDX()
  */

--- a/include/zephyr/devicetree/wuc.h
+++ b/include/zephyr/devicetree/wuc.h
@@ -45,7 +45,7 @@ extern "C" {
  * @param node_id node identifier
  * @param idx logical index into "wakeup-ctrls"
  * @return the node identifier for the wakeup controller referenced at
- *         index "idx"
+ *         index @p idx
  * @see DT_PHANDLE_BY_IDX()
  */
 #define DT_WUC_BY_IDX(node_id, idx) DT_PHANDLE_BY_IDX(node_id, wakeup_ctrls, idx)
@@ -85,7 +85,7 @@ extern "C" {
  * @param node_id node identifier for a node with a wakeup-ctrls property
  * @param idx logical index into wakeup-ctrls property
  * @param cell lowercase-and-underscores cell name
- * @return the cell value at index "idx"
+ * @return the cell value at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_WUC_CELL_BY_IDX(node_id, idx, cell) DT_PHA_BY_IDX(node_id, wakeup_ctrls, idx, cell)
@@ -106,7 +106,7 @@ extern "C" {
  * @param inst instance number
  * @param idx logical index into "wakeup-ctrls"
  * @return the node identifier for the wakeup controller referenced at
- *         index "idx"
+ *         index @p idx
  * @see DT_WUC_BY_IDX()
  */
 #define DT_INST_WUC_BY_IDX(inst, idx) DT_WUC_BY_IDX(DT_DRV_INST(inst), idx)
@@ -126,7 +126,7 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into wakeup-ctrls property
  * @param cell lowercase-and-underscores cell name
- * @return the cell value at index "idx"
+ * @return the cell value at index @p idx
  * @see DT_WUC_CELL_BY_IDX()
  */
 #define DT_INST_WUC_CELL_BY_IDX(inst, idx, cell) DT_WUC_CELL_BY_IDX(DT_DRV_INST(inst), idx, cell)
@@ -167,7 +167,7 @@ extern "C" {
  *
  * @param node_id node identifier
  * @param idx logical index into "wakeup-ctrls"
- * @return the id cell value at index "idx"
+ * @return the id cell value at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_WUC_ID_BY_IDX(node_id, idx) DT_PHA_BY_IDX(node_id, wakeup_ctrls, idx, id)
@@ -185,7 +185,7 @@ extern "C" {
  *        at an index
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into "wakeup-ctrls"
- * @return the id cell value at index "idx"
+ * @return the id cell value at index @p idx
  * @see DT_WUC_ID_BY_IDX()
  */
 #define DT_INST_WUC_ID_BY_IDX(inst, idx) DT_WUC_ID_BY_IDX(DT_DRV_INST(inst), idx)

--- a/include/zephyr/devicetree/wuc.h
+++ b/include/zephyr/devicetree/wuc.h
@@ -25,7 +25,7 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the controller phandle from a
- *        "wakeup-ctrls" phandle-array property at an index
+ *        <tt>wakeup-ctrls</tt> phandle-array property at an index
  *
  * Example devicetree fragment:
  *
@@ -43,7 +43,7 @@ extern "C" {
  *     DT_WUC_BY_IDX(DT_NODELABEL(n), 1) // DT_NODELABEL(wuc2)
  *
  * @param node_id node identifier
- * @param idx logical index into "wakeup-ctrls"
+ * @param idx logical index into <tt>wakeup-ctrls</tt>
  * @return the node identifier for the wakeup controller referenced at
  *         index @p idx
  * @see DT_PHANDLE_BY_IDX()
@@ -54,7 +54,7 @@ extern "C" {
  * @brief Equivalent to DT_WUC_BY_IDX(node_id, 0)
  * @param node_id node identifier
  * @return a node identifier for the wakeup controller at index 0
- *         in "wakeup-ctrls"
+ *         in <tt>wakeup-ctrls</tt>
  * @see DT_WUC_BY_IDX()
  */
 #define DT_WUC(node_id) DT_WUC_BY_IDX(node_id, 0)
@@ -101,10 +101,10 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the controller phandle from a
- *        "wakeup-ctrls" phandle-array property at an index
+ *        <tt>wakeup-ctrls</tt> phandle-array property at an index
  *
  * @param inst instance number
- * @param idx logical index into "wakeup-ctrls"
+ * @param idx logical index into <tt>wakeup-ctrls</tt>
  * @return the node identifier for the wakeup controller referenced at
  *         index @p idx
  * @see DT_WUC_BY_IDX()
@@ -115,7 +115,7 @@ extern "C" {
  * @brief Equivalent to DT_INST_WUC_BY_IDX(inst, 0)
  * @param inst instance number
  * @return a node identifier for the wakeup controller at index 0
- *         in "wakeup-ctrls"
+ *         in <tt>wakeup-ctrls</tt>
  * @see DT_WUC_BY_IDX()
  */
 #define DT_INST_WUC(inst) DT_INST_WUC_BY_IDX(inst, 0)
@@ -140,9 +140,9 @@ extern "C" {
 #define DT_INST_WUC_CELL(inst, cell) DT_INST_WUC_CELL_BY_IDX(inst, 0, cell)
 
 /**
- * @brief Get a Wakeup Controller specifier's id cell at an index
+ * @brief Get a Wakeup Controller specifier's <tt>id</tt> cell at an index
  *
- * This macro only works for Wakeup Controller specifiers with cells named "id".
+ * This macro only works for Wakeup Controller specifiers with cells named <tt>id</tt>.
  * Refer to the node's binding to check if necessary.
  *
  * Example devicetree fragment:
@@ -166,8 +166,8 @@ extern "C" {
  *     DT_WUC_ID_BY_IDX(DT_NODELABEL(n), 0) // 10
  *
  * @param node_id node identifier
- * @param idx logical index into "wakeup-ctrls"
- * @return the id cell value at index @p idx
+ * @param idx logical index into <tt>wakeup-ctrls</tt>
+ * @return the <tt>id</tt> cell value at index @p idx
  * @see DT_PHA_BY_IDX()
  */
 #define DT_WUC_ID_BY_IDX(node_id, idx) DT_PHA_BY_IDX(node_id, wakeup_ctrls, idx, id)
@@ -175,17 +175,17 @@ extern "C" {
 /**
  * @brief Equivalent to DT_WUC_ID_BY_IDX(node_id, 0)
  * @param node_id node identifier
- * @return the id cell value at index 0
+ * @return the <tt>id</tt> cell value at index 0
  * @see DT_WUC_ID_BY_IDX()
  */
 #define DT_WUC_ID(node_id) DT_WUC_ID_BY_IDX(node_id, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's Wakeup Controller specifier's id cell value
+ * @brief Get a DT_DRV_COMPAT instance's Wakeup Controller specifier's <tt>id</tt> cell value
  *        at an index
  * @param inst DT_DRV_COMPAT instance number
- * @param idx logical index into "wakeup-ctrls"
- * @return the id cell value at index @p idx
+ * @param idx logical index into <tt>wakeup-ctrls</tt>
+ * @return the <tt>id</tt> cell value at index @p idx
  * @see DT_WUC_ID_BY_IDX()
  */
 #define DT_INST_WUC_ID_BY_IDX(inst, idx) DT_WUC_ID_BY_IDX(DT_DRV_INST(inst), idx)
@@ -193,7 +193,7 @@ extern "C" {
 /**
  * @brief Equivalent to DT_INST_WUC_ID_BY_IDX(inst, 0)
  * @param inst DT_DRV_COMPAT instance number
- * @return the id cell value at index 0
+ * @return the <tt>id</tt> cell value at index 0
  * @see DT_INST_WUC_ID_BY_IDX()
  */
 #define DT_INST_WUC_ID(inst) DT_INST_WUC_ID_BY_IDX(inst, 0)

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -449,12 +449,12 @@ struct adc_dt_spec {
 	COND_CODE_1(DT_PROP_HAS_NAME(node_id, io_channels, name), \
 		    (ADC_DT_SPEC_GET_BY_NAME(node_id, name)), (default_value))
 
-/** @brief Get ADC io-channel information from a DT_DRV_COMPAT devicetree
+/** @brief Get ADC io-channel information from a @c DT_DRV_COMPAT devicetree
  *         instance by name.
  *
  * @see ADC_DT_SPEC_GET_BY_NAME()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Channel name.
  *
  * @return Static initializer for an adc_dt_spec structure.
@@ -465,7 +465,7 @@ struct adc_dt_spec {
 /**
  * @brief Like ADC_DT_SPEC_INST_GET_BY_NAME(), with a fallback to a default value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Channel name.
  * @param default_value Fallback value to expand to.
  *
@@ -566,12 +566,12 @@ struct adc_dt_spec {
 	COND_CODE_1(DT_PROP_HAS_IDX(node_id, io_channels, idx), \
 		    (ADC_DT_SPEC_GET_BY_IDX(node_id, idx)), (default_value))
 
-/** @brief Get ADC io-channel information from a DT_DRV_COMPAT devicetree
+/** @brief Get ADC io-channel information from a @c DT_DRV_COMPAT devicetree
  *         instance.
  *
  * @see ADC_DT_SPEC_GET_BY_IDX()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Channel index.
  *
  * @return Static initializer for an adc_dt_spec structure.
@@ -582,7 +582,7 @@ struct adc_dt_spec {
 /**
  * @brief Like ADC_DT_SPEC_INST_GET_BY_IDX(), with a fallback to a default value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Channel index.
  * @param default_value Fallback value to expand to.
  *
@@ -623,7 +623,7 @@ struct adc_dt_spec {
  *
  * @see ADC_DT_SPEC_GET()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  *
  * @return Static initializer for an adc_dt_spec structure.
  */
@@ -634,7 +634,7 @@ struct adc_dt_spec {
  *
  * @see ADC_DT_SPEC_GET_OR()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param default_value Fallback value to expand to.
  *
  * @return Static initializer for a struct adc_dt_spec for the property,
@@ -1508,7 +1508,7 @@ static inline bool adc_is_ready_dt(const struct adc_dt_spec *spec)
 /**
  * @brief Get the decoder name for the current driver
  *
- * This function depends on `DT_DRV_COMPAT` being defined.
+ * This function depends on @c DT_DRV_COMPAT being defined.
  */
 #define ADC_DECODER_NAME() UTIL_CAT(DT_DRV_COMPAT, __adc_decoder_api)
 

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -108,9 +108,9 @@ struct bt_hci_driver_config {
 
 /**
  * @brief Static initializer for @p bt_hci_driver_config struct from
- * DT_DRV_COMPAT instance.
+ * @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @see BT_DT_HCI_DRIVER_CONFIG_GET()
  */
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -380,9 +380,9 @@ struct can_driver_config {
 	}
 
 /**
- * @brief Static initializer for @p can_driver_config struct from DT_DRV_COMPAT instance
+ * @brief Static initializer for @p can_driver_config struct from @c DT_DRV_COMPAT instance
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param _min_bitrate minimum bitrate supported by the CAN controller
  * @param _max_bitrate maximum bitrate supported by the CAN controller
  * @see CAN_DT_DRIVER_CONFIG_GET()
@@ -843,7 +843,7 @@ struct can_device_state {
 #endif /* CONFIG_CAN_STATS */
 
 /**
- * @brief Like CAN_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
+ * @brief Like CAN_DEVICE_DT_DEFINE() for an instance of a @c DT_DRV_COMPAT compatible
  *
  * @param inst Instance number. This is replaced by <tt>DT_DRV_INST(inst)</tt>
  *             in the call to CAN_DEVICE_DT_DEFINE().

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -845,7 +845,7 @@ struct can_device_state {
 /**
  * @brief Like CAN_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
  *
- * @param inst Instance number. This is replaced by <tt>DT_DRV_COMPAT(inst)</tt>
+ * @param inst Instance number. This is replaced by <tt>DT_DRV_INST(inst)</tt>
  *             in the call to CAN_DEVICE_DT_DEFINE().
  * @param ...  Other parameters as expected by CAN_DEVICE_DT_DEFINE().
  */

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -864,15 +864,15 @@ struct stm32_pclken {
 			STM32_CLOCK_INFO, (,), node_id)			\
 	}
 
-/* Get an array of STM32 clocks information for clocks listed in a DT_DRV_COMPAT instance node */
+/* Get an array of STM32 clocks information for clocks listed in a @c DT_DRV_COMPAT instance node */
 #define STM32_DT_INST_CLOCKS(inst)					\
 	STM32_DT_CLOCKS(DT_DRV_INST(inst))
 
-/* Get STM32 clock information for an indexed clock phandle in a DT_DRV_COMPAT instance node */
+/* Get STM32 clock information for an indexed clock phandle in a @c DT_DRV_COMPAT instance node */
 #define STM32_DT_INST_CLOCK_INFO_BY_IDX(clk_index, inst)		\
 	STM32_CLOCK_INFO(clk_index, DT_DRV_INST(inst))
 
-/* Get STM32 clock information for clock index 0 in a DT_DRV_COMPAT instance node */
+/* Get STM32 clock information for clock index 0 in a @c DT_DRV_COMPAT instance node */
 #define STM32_DT_INST_CLOCK_INFO(inst)					\
 	STM32_DT_INST_CLOCK_INFO_BY_IDX(0, inst)
 
@@ -886,11 +886,11 @@ struct stm32_pclken {
 		       STM32_CLOCK_DIV_SHIFT,				\
 	}
 
-/* Get STM32 clock information for named clock phandle in a DT_DRV_COMPAT instance node */
+/* Get STM32 clock information for named clock phandle in a @c DT_DRV_COMPAT instance node */
 #define STM32_DT_INST_CLOCK_INFO_BY_NAME(inst, name)			\
 	STM32_CLOCK_INFO_BY_NAME(DT_DRV_INST(inst), name)
 
-/* Return true only if at least an enabled instance of the DT_DRV_COMPAT has at least 2 clocks */
+/* Return true only if at least an enabled instance of the @c DT_DRV_COMPAT has at least 2 clocks */
 #define STM32_DOMAIN_CLOCK_INST_SUPPORT(inst) DT_INST_CLOCKS_HAS_IDX(inst, 1) ||
 #define STM32_DT_INST_DEV_DOMAIN_CLOCK_SUPPORT				\
 		(DT_INST_FOREACH_STATUS_OKAY(STM32_DOMAIN_CLOCK_INST_SUPPORT) 0)

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -254,12 +254,12 @@ struct dac_dt_spec {
 	COND_CODE_1(DT_PROP_HAS_NAME(node_id, io_channels, name), \
 		    (DAC_DT_SPEC_GET_BY_NAME(node_id, name)), (default_value))
 
-/** @brief Get DAC io-channel information from a DT_DRV_COMPAT devicetree
+/** @brief Get DAC io-channel information from a @c DT_DRV_COMPAT devicetree
  *         instance by name.
  *
  * @see DAC_DT_SPEC_GET_BY_NAME()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Channel name.
  *
  * @return Static initializer for an dac_dt_spec structure.
@@ -271,7 +271,7 @@ struct dac_dt_spec {
 /**
  * @brief Like DAC_DT_SPEC_INST_GET_BY_NAME(), with a fallback to a default value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Channel name.
  * @param default_value Fallback value to expand to.
  *
@@ -365,12 +365,12 @@ struct dac_dt_spec {
 	COND_CODE_1(DT_PROP_HAS_IDX(node_id, io_channels, idx), \
 		    (DAC_DT_SPEC_GET_BY_IDX(node_id, idx)), (default_value))
 
-/** @brief Get DAC io-channel information from a DT_DRV_COMPAT devicetree
+/** @brief Get DAC io-channel information from a @c DT_DRV_COMPAT devicetree
  *         instance.
  *
  * @see DAC_DT_SPEC_GET_BY_IDX()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Channel index.
  *
  * @return Static initializer for an dac_dt_spec structure.
@@ -381,7 +381,7 @@ struct dac_dt_spec {
 /**
  * @brief Like DAC_DT_SPEC_INST_GET_BY_IDX(), with a fallback to a default value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Channel index.
  * @param default_value Fallback value to expand to.
  *
@@ -422,7 +422,7 @@ struct dac_dt_spec {
  *
  * @see DAC_DT_SPEC_GET()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  *
  * @return Static initializer for an dac_dt_spec structure.
  */
@@ -433,7 +433,7 @@ struct dac_dt_spec {
  *
  * @see DAC_DT_SPEC_GET_OR()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param default_value Fallback value to expand to.
  *
  * @return Static initializer for a struct dac_dt_spec for the property,

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -160,7 +160,7 @@ struct emul {
 	};
 
 /**
- * @brief Like EMUL_DT_DEFINE(), but uses an instance of a DT_DRV_COMPAT compatible instead of a
+ * @brief Like EMUL_DT_DEFINE(), but uses an instance of a @c DT_DRV_COMPAT compatible instead of a
  *        node identifier.
  *
  * @param inst instance number. The @p node_id argument to EMUL_DT_DEFINE is set to

--- a/include/zephyr/drivers/emul_stub_device.h
+++ b/include/zephyr/drivers/emul_stub_device.h
@@ -24,7 +24,7 @@ struct emul_stub_dev_api {
 	/* Stub */
 };
 
-/* For every instance of a DT_DRV_COMPAT stub out a device for that instance */
+/* For every instance of a @c DT_DRV_COMPAT stub out a device for that instance */
 #define EMUL_STUB_DEVICE(n)                                                                        \
 	__maybe_unused static int emul_init_stub_##n(const struct device *dev)                     \
 	{                                                                                          \

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -156,7 +156,7 @@
  * @brief Declare SCMI TX/RX channels using node instance number
  *
  * Same as DT_SCMI_TRANSPORT_CHANNELS_DECLARE() but uses the
- * protocol's node instance number and the DT_DRV_COMPAT macro.
+ * protocol's node instance number and the @c DT_DRV_COMPAT macro.
  *
  * @param protocol node instance number
  */
@@ -301,7 +301,7 @@
 
 /**
  * @brief Just like DT_SCMI_PROTOCOL_DEFINE(), but uses an instance
- * of a `DT_DRV_COMPAT` compatible instead of a node identifier
+ * of a @c DT_DRV_COMPAT compatible instead of a node identifier
  *
  * @param inst Instance number
  * @param init_fn Pointer to protocol's initialization function

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -390,10 +390,10 @@ struct gpio_dt_spec {
 	GPIO_DT_SPEC_GET_BY_IDX_OR(node_id, prop, 0, default_value)
 
 /**
- * @brief Static initializer for a @p gpio_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @p gpio_dt_spec from a @c DT_DRV_COMPAT
  * instance's GPIO property at an index.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param prop lowercase-and-underscores property name
  * @param idx logical index into "prop"
  * @return static initializer for a struct gpio_dt_spec for the property
@@ -403,10 +403,10 @@ struct gpio_dt_spec {
 	GPIO_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), prop, idx)
 
 /**
- * @brief Static initializer for a @p gpio_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @p gpio_dt_spec from a @c DT_DRV_COMPAT
  *        instance's GPIO property at an index, with fallback
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param prop lowercase-and-underscores property name
  * @param idx logical index into "prop"
  * @param default_value fallback value to expand to
@@ -421,7 +421,7 @@ struct gpio_dt_spec {
 /**
  * @brief Equivalent to GPIO_DT_SPEC_INST_GET_BY_IDX(inst, prop, 0).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param prop lowercase-and-underscores property name
  * @return static initializer for a struct gpio_dt_spec for the property
  * @see GPIO_DT_SPEC_INST_GET_BY_IDX()
@@ -433,7 +433,7 @@ struct gpio_dt_spec {
  * @brief Equivalent to
  *        GPIO_DT_SPEC_INST_GET_BY_IDX_OR(inst, prop, 0, default_value).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param prop lowercase-and-underscores property name
  * @param default_value fallback value to expand to
  * @return static initializer for a struct gpio_dt_spec for the property
@@ -592,10 +592,10 @@ struct gpio_dt_spec {
 	GPIO_DT_RESERVED_RANGES_NGPIOS(node_id, DT_PROP(node_id, ngpios))
 
 /**
- * @brief Makes a bitmask of reserved GPIOs from a DT_DRV_COMPAT instance's
+ * @brief Makes a bitmask of reserved GPIOs from a @c DT_DRV_COMPAT instance's
  *        @p "gpio-reserved-ranges" property and @p "ngpios" argument
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the bitmask of reserved gpios
  * @param ngpios  number of GPIOs
  * @see GPIO_DT_RESERVED_RANGES()
@@ -604,10 +604,10 @@ struct gpio_dt_spec {
 		GPIO_DT_RESERVED_RANGES_NGPIOS(DT_DRV_INST(inst), ngpios)
 
 /**
- * @brief Make a bitmask of reserved GPIOs from a DT_DRV_COMPAT instance's GPIO
+ * @brief Make a bitmask of reserved GPIOs from a @c DT_DRV_COMPAT instance's GPIO
  *        @p "gpio-reserved-ranges" and @p "ngpios" properties
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the bitmask of reserved gpios
  * @see GPIO_DT_RESERVED_RANGES()
  */
@@ -674,10 +674,10 @@ struct gpio_dt_spec {
 	))
 
 /**
- * @brief Makes a bitmask of allowed GPIOs from a DT_DRV_COMPAT instance's
+ * @brief Makes a bitmask of allowed GPIOs from a @c DT_DRV_COMPAT instance's
  *        @p "gpio-reserved-ranges" property and @p "ngpios" argument
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param ngpios number of GPIOs
  * @return the bitmask of allowed gpios
  * @see GPIO_DT_NGPIOS_PORT_PIN_MASK_EXC()

--- a/include/zephyr/drivers/gpio/gpio_utils.h
+++ b/include/zephyr/drivers/gpio/gpio_utils.h
@@ -53,10 +53,10 @@ extern "C" {
 	GPIO_DT_PORT_PIN_MASK_NGPIOS_EXC(node_id, DT_PROP(node_id, ngpios))
 
 /**
- * @brief Make a bitmask of allowed GPIOs from a DT_DRV_COMPAT instance's GPIO
+ * @brief Make a bitmask of allowed GPIOs from a @c DT_DRV_COMPAT instance's GPIO
  *        @p "gpio-reserved-ranges" and @p "ngpios" DT properties values
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the bitmask of allowed gpios
  * @see GPIO_DT_PORT_PIN_MASK_NGPIOS_EXC()
  */
@@ -76,9 +76,9 @@ extern "C" {
 	}
 
 /**
- * @brief Make a struct gpio_driver_config initializer from a DT_DRV_COMPAT instance number
+ * @brief Make a struct gpio_driver_config initializer from a @c DT_DRV_COMPAT instance number
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return a struct gpio_driver_config initializer
  */
 #define GPIO_COMMON_CONFIG_FROM_DT_INST(inst)                   \

--- a/include/zephyr/drivers/hwspinlock.h
+++ b/include/zephyr/drivers/hwspinlock.h
@@ -159,7 +159,7 @@ struct hwspinlock_dt_spec {
 /**
  * @brief Instance version of HWSPINLOCK_DT_SPEC_GET_BY_IDX()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Index of the hwlocks element
  *
  * @see HWSPINLOCK_DT_SPEC_GET_BY_IDX()
@@ -170,7 +170,7 @@ struct hwspinlock_dt_spec {
 /**
  * @brief Instance version of HWSPINLOCK_DT_SPEC_GET_BY_NAME()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of the hwlocks element
  *
  * @see HWSPINLOCK_DT_SPEC_GET_BY_NAME()
@@ -180,7 +180,7 @@ struct hwspinlock_dt_spec {
 /**
  * @brief Instance version of HWSPINLOCK_DT_SPEC_GET()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  *
  * @see HWSPINLOCK_DT_SPEC_GET()
  */

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -771,7 +771,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 				    __VA_ARGS__)
 
 /**
- * @brief Like I2C_DEVICE_DT_DEINIT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
+ * @brief Like I2C_DEVICE_DT_DEINIT_DEFINE() for an instance of a @c DT_DRV_COMPAT compatible
  *
  * @param inst instance number. This is replaced by
  * <tt>DT_DRV_INST(inst)</tt> in the call to I2C_DEVICE_DT_DEINIT_DEFINE().
@@ -782,7 +782,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 	I2C_DEVICE_DT_DEINIT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
- * @brief Like I2C_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
+ * @brief Like I2C_DEVICE_DT_DEFINE() for an instance of a @c DT_DRV_COMPAT compatible
  *
  * @param inst instance number. This is replaced by
  * <tt>DT_DRV_INST(inst)</tt> in the call to I2C_DEVICE_DT_DEFINE().

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -774,7 +774,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  * @brief Like I2C_DEVICE_DT_DEINIT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
  *
  * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to I2C_DEVICE_DT_DEINIT_DEFINE().
+ * <tt>DT_DRV_INST(inst)</tt> in the call to I2C_DEVICE_DT_DEINIT_DEFINE().
  *
  * @param ... other parameters as expected by I2C_DEVICE_DT_DEINIT_DEFINE().
  */
@@ -785,7 +785,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  * @brief Like I2C_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
  *
  * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to I2C_DEVICE_DT_DEFINE().
+ * <tt>DT_DRV_INST(inst)</tt> in the call to I2C_DEVICE_DT_DEFINE().
  *
  * @param ... other parameters as expected by I2C_DEVICE_DT_DEFINE().
  */

--- a/include/zephyr/drivers/i3c/devicetree.h
+++ b/include/zephyr/drivers/i3c/devicetree.h
@@ -193,7 +193,7 @@ extern "C" {
 			 prio, api, __VA_ARGS__)
 
 /**
- * @brief Like I3C_TARGET_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
+ * @brief Like I3C_TARGET_DT_DEFINE() for an instance of a @c DT_DRV_COMPAT compatible
  *
  * @param inst instance number. This is replaced by <tt>DT_DRV_INST(inst)</tt> in the call
  * to I3C_TARGET_DT_DEFINE().

--- a/include/zephyr/drivers/i3c/devicetree.h
+++ b/include/zephyr/drivers/i3c/devicetree.h
@@ -195,8 +195,8 @@ extern "C" {
 /**
  * @brief Like I3C_TARGET_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
  *
- * @param inst instance number. This is replaced by
- * `DT_DRV_COMPAT(inst)` in the call to I3C_TARGET_DT_DEFINE().
+ * @param inst instance number. This is replaced by <tt>DT_DRV_INST(inst)</tt> in the call
+ * to I3C_TARGET_DT_DEFINE().
  *
  * @param ... other parameters as expected by I3C_TARGET_DT_DEFINE().
  */

--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -134,7 +134,7 @@ struct mbox_dt_spec {
 /**
  * @brief Instance version of MBOX_DT_CHANNEL_GET()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of the mboxes element
  *
  * @return static initializer for a struct mbox_dt_spec

--- a/include/zephyr/drivers/misc/interconn/renesas_elc/renesas_elc.h
+++ b/include/zephyr/drivers/misc/interconn/renesas_elc/renesas_elc.h
@@ -97,9 +97,9 @@ struct renesas_elc_dt_spec {
 
 /**
  * @brief Get the device pointer from the "renesas-elcs" property by element name for a
- * DT_DRV_COMPAT instance.
+ * @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  *
  * @return Device pointer.
@@ -108,10 +108,10 @@ struct renesas_elc_dt_spec {
 	DEVICE_DT_GET(DT_PHANDLE_BY_NAME(DT_DRV_INST(inst), renesas_elcs, name))
 
 /**
- * @brief Get the device pointer from the "renesas-elcs" property by index for a DT_DRV_COMPAT
+ * @brief Get the device pointer from the "renesas-elcs" property by index for a @c DT_DRV_COMPAT
  * instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  *
  * @return Device pointer.
@@ -121,9 +121,9 @@ struct renesas_elc_dt_spec {
 
 /**
  * @brief Get the device pointer from the "renesas-elcs" property by element name
- *        for a DT_DRV_COMPAT instance, or return NULL if the property does not exist.
+ *        for a @c DT_DRV_COMPAT instance, or return NULL if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  *
  * @return Device pointer or NULL.
@@ -133,9 +133,9 @@ struct renesas_elc_dt_spec {
 
 /**
  * @brief Get the device pointer from the "renesas-elcs" property by index
- *        for a DT_DRV_COMPAT instance, or return NULL if the property does not exist.
+ *        for a @c DT_DRV_COMPAT instance, or return NULL if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  *
  * @return Device pointer or NULL.
@@ -196,9 +196,9 @@ struct renesas_elc_dt_spec {
 		(default_value))
 
 /**
- * @brief Get the peripheral cell value by element name for a DT_DRV_COMPAT instance.
+ * @brief Get the peripheral cell value by element name for a @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  *
  * @return Peripheral cell value.
@@ -207,9 +207,9 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_PERIPHERAL_GET_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get the peripheral cell value by index for a DT_DRV_COMPAT instance.
+ * @brief Get the peripheral cell value by index for a @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  *
  * @return Peripheral cell value.
@@ -218,10 +218,10 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_PERIPHERAL_GET_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Get the peripheral cell value by element name for a DT_DRV_COMPAT instance,
+ * @brief Get the peripheral cell value by element name for a @c DT_DRV_COMPAT instance,
  *        or return a default value if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  * @param default_value Value to return if the property is not present.
  *
@@ -231,10 +231,10 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_PERIPHERAL_GET_BY_NAME_OR(DT_DRV_INST(inst), name, default_value)
 
 /**
- * @brief Get the peripheral cell value by index for a DT_DRV_COMPAT instance,
+ * @brief Get the peripheral cell value by index for a @c DT_DRV_COMPAT instance,
  *        or return a default value if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  * @param default_value Value to return if the property is not present.
  *
@@ -296,9 +296,9 @@ struct renesas_elc_dt_spec {
 		(default_value))
 
 /**
- * @brief Get the event cell value by element name for a DT_DRV_COMPAT instance.
+ * @brief Get the event cell value by element name for a @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  *
  * @return Event cell value.
@@ -307,9 +307,9 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_EVENT_GET_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get the event cell value by index for a DT_DRV_COMPAT instance.
+ * @brief Get the event cell value by index for a @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  *
  * @return Event cell value.
@@ -318,10 +318,10 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_EVENT_GET_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Get the event cell value by element name for a DT_DRV_COMPAT instance,
+ * @brief Get the event cell value by element name for a @c DT_DRV_COMPAT instance,
  *        or return a default value if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  * @param default_value Value to return if the property is not present.
  *
@@ -331,10 +331,10 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_EVENT_GET_BY_NAME_OR(DT_DRV_INST(inst), name, default_value)
 
 /**
- * @brief Get the event cell value by index for a DT_DRV_COMPAT instance,
+ * @brief Get the event cell value by index for a @c DT_DRV_COMPAT instance,
  *        or return a default value if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  * @param default_value Value to return if the property is not present.
  *

--- a/include/zephyr/drivers/mspi/devicetree.h
+++ b/include/zephyr/drivers/mspi/devicetree.h
@@ -312,7 +312,7 @@ extern "C" {
  * This is equivalent to
  * <tt>MSPI_CE_CONTROL_INIT(DT_DRV_INST(inst), delay)</tt>.
  *
- * Therefore, @p DT_DRV_COMPAT must already be defined before using
+ * Therefore, @c DT_DRV_COMPAT must already be defined before using
  * this macro.
  *
  * @param inst Devicetree node instance number

--- a/include/zephyr/drivers/mspi/devicetree.h
+++ b/include/zephyr/drivers/mspi/devicetree.h
@@ -33,7 +33,7 @@ extern "C" {
  * mspi_dev_cfg</tt> by reading the relevant data from the devicetree.
  *
  * @param mspi_dev Devicetree node identifier for the MSPI device whose
- *                 struct mspi_dev_cfg to create an initializer for
+ *                 <tt>struct mspi_dev_cfg</tt> to create an initializer for
  */
 #define MSPI_DEVICE_CONFIG_DT(mspi_dev)                                                           \
 	{                                                                                         \
@@ -80,7 +80,7 @@ extern "C" {
  * mspi_xip_cfg</tt> by reading the relevant data from the devicetree.
  *
  * @param mspi_dev Devicetree node identifier for the MSPI device whose
- *                 struct mspi_xip_cfg to create an initializer for
+ *                 <tt>struct mspi_xip_cfg</tt> to create an initializer for
  */
 #define MSPI_XIP_CONFIG_DT_NO_CHECK(mspi_dev)                                                     \
 	{                                                                                         \
@@ -97,7 +97,7 @@ extern "C" {
  * before calling <tt>MSPI_XIP_CONFIG_DT_NO_CHECK</tt>.
  *
  * @param mspi_dev Devicetree node identifier for the MSPI device whose
- *                 struct mspi_xip_cfg to create an initializer for
+ *                 <tt>struct mspi_xip_cfg</tt> to create an initializer for
  */
 #define MSPI_XIP_CONFIG_DT(mspi_dev)                                                              \
 		COND_CODE_1(DT_NODE_HAS_PROP(mspi_dev, xip_config),                               \
@@ -121,7 +121,7 @@ extern "C" {
  * mspi_scramble_cfg</tt> by reading the relevant data from the devicetree.
  *
  * @param mspi_dev Devicetree node identifier for the MSPI device whose
- *                 struct mspi_scramble_cfg to create an initializer for
+ *                 <tt>struct mspi_scramble_cfg</tt> to create an initializer for
  */
 #define MSPI_SCRAMBLE_CONFIG_DT_NO_CHECK(mspi_dev)                                                \
 	{                                                                                         \
@@ -137,7 +137,7 @@ extern "C" {
  * before calling <tt>MSPI_SCRAMBLE_CONFIG_DT_NO_CHECK</tt>.
  *
  * @param mspi_dev Devicetree node identifier for the MSPI device whose
- *                 struct mspi_scramble_cfg to create an initializer for
+ *                 <tt>struct mspi_scramble_cfg</tt> to create an initializer for
  */
 #define MSPI_SCRAMBLE_CONFIG_DT(mspi_dev)                                                         \
 		COND_CODE_1(DT_NODE_HAS_PROP(mspi_dev, scramble_config),                          \
@@ -161,7 +161,7 @@ extern "C" {
  * mspi_dev_id</tt> by reading the relevant data from the devicetree.
  *
  * @param mspi_dev Devicetree node identifier for the MSPI device whose
- *                 struct mspi_dev_id to create an initializer for
+ *                 <tt>struct mspi_dev_id</tt> to create an initializer for
  */
 #define MSPI_DEVICE_ID_DT(mspi_dev)                                                               \
 	{                                                                                         \
@@ -215,7 +215,7 @@ extern "C" {
  * @endcode
  *
  * @param mspi_dev a MSPI device node identifier
- * @return #gpio_dt_spec struct corresponding with mspi_dev's chip enable
+ * @return <tt>gpio_dt_spec</tt> struct corresponding with mspi_dev's chip enable
  */
 #define MSPI_DEV_CE_GPIOS_DT_SPEC_GET(mspi_dev)                                                   \
 		GPIO_DT_SPEC_GET_BY_IDX_OR(DT_BUS(mspi_dev), ce_gpios,                            \
@@ -228,7 +228,7 @@ extern "C" {
  * <tt>MSPI_DEV_CE_GPIOS_DT_SPEC_GET(DT_DRV_INST(inst))</tt>.
  *
  * @param inst Devicetree instance number
- * @return #gpio_dt_spec struct corresponding with mspi_dev's chip enable
+ * @return <tt>gpio_dt_spec</tt> struct corresponding with mspi_dev's chip enable
  */
 #define MSPI_DEV_CE_GPIOS_DT_SPEC_INST_GET(inst)                                                  \
 		MSPI_DEV_CE_GPIOS_DT_SPEC_GET(DT_DRV_INST(inst))
@@ -239,10 +239,10 @@ extern "C" {
  *
  * This helper macro check whether <tt>ce_gpios</tt> binding exist first
  * before calling <tt>GPIO_DT_SPEC_GET_BY_IDX</tt> and expand to an array of
- * gpio_dt_spec.
+ * <tt>gpio_dt_spec</tt>.
  *
  * @param node_id Devicetree node identifier for the MSPI controller
- * @return an array of gpio_dt_spec struct corresponding with mspi_dev's chip enables
+ * @return an array of <tt> struct gpio_dt_spec</tt> corresponding with mspi_dev's chip enables
  */
 #define MSPI_CE_GPIOS_DT_SPEC_GET(node_id)                                                        \
 {                                                                                                 \
@@ -258,17 +258,17 @@ extern "C" {
  * <tt>MSPI_CE_GPIOS_DT_SPEC_GET(DT_DRV_INST(inst))</tt>.
  *
  * @param inst Devicetree instance number
- * @return an array of gpio_dt_spec struct corresponding with mspi_dev's chip enables
+ * @return an array of <tt>struct gpio_dt_spec</tt> corresponding with mspi_dev's chip enables
  */
 #define MSPI_CE_GPIOS_DT_SPEC_INST_GET(inst)                                                      \
 		MSPI_CE_GPIOS_DT_SPEC_GET(DT_DRV_INST(inst))
 
 /**
- * @brief Initialize and get a pointer to a @p mspi_ce_control from a
+ * @brief Initialize and get a pointer to a <tt>mspi_ce_control</tt> structure from a
  *        devicetree node identifier
  *
  * This helper is useful for initializing a device on a MSPI bus. It
- * initializes a struct mspi_ce_control and returns a pointer to it.
+ * initializes a <tt>struct mspi_ce_control</tt> and returns a pointer to it.
  * Here, @p node_id is a node identifier for a MSPI device, not a MSPI
  * controller.
  *
@@ -298,8 +298,8 @@ extern "C" {
  * @endcode
  *
  * @param node_id Devicetree node identifier for a device on a MSPI bus
- * @param delay_ The @p delay field to set in the @p mspi_ce_control
- * @return a pointer to the @p mspi_ce_control structure
+ * @param delay_ The <tt>delay</tt> field to set in the <tt>mspi_ce_control</tt> structure
+ * @return a pointer to the <tt>mspi_ce_control</tt> structure
  */
 #define MSPI_CE_CONTROL_INIT(node_id, delay_)                                                     \
 	{                                                                                         \
@@ -307,7 +307,7 @@ extern "C" {
 	}
 
 /**
- * @brief Get a pointer to a @p mspi_ce_control from a devicetree node
+ * @brief Get a pointer to a <tt>mspi_ce_control</tt> structure from a devicetree node
  *
  * This is equivalent to
  * <tt>MSPI_CE_CONTROL_INIT(DT_DRV_INST(inst), delay)</tt>.
@@ -316,8 +316,8 @@ extern "C" {
  * this macro.
  *
  * @param inst Devicetree node instance number
- * @param delay_ The @p delay field to set in the @p mspi_ce_control
- * @return a pointer to the @p mspi_ce_control structure
+ * @param delay_ The <tt>delay</tt> field to set in the <tt>mspi_ce_control</tt> structure
+ * @return a pointer to the <tt>mspi_ce_control</tt> structure
  */
 #define MSPI_CE_CONTROL_INIT_INST(inst, delay_) MSPI_CE_CONTROL_INIT(DT_DRV_INST(inst), delay_)
 

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -202,10 +202,10 @@ struct pwm_dt_spec {
 	}
 
 /**
- * @brief Static initializer for a struct pwm_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a struct pwm_dt_spec from a @c DT_DRV_COMPAT
  *        instance.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Lowercase-and-underscores name of a pwms element as defined by
  *             the node's pwm-names property.
  *
@@ -243,7 +243,7 @@ struct pwm_dt_spec {
  * @brief Like PWM_DT_SPEC_INST_GET_BY_NAME(), with a fallback to a default
  *        value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Lowercase-and-underscores name of a pwms element as defined by
  *             the node's pwm-names property.
  * @param default_value Fallback value to expand to.
@@ -307,10 +307,10 @@ struct pwm_dt_spec {
 	}
 
 /**
- * @brief Static initializer for a struct pwm_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a struct pwm_dt_spec from a @c DT_DRV_COMPAT
  *        instance.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Logical index into 'pwms' property.
  *
  * @return Static initializer for a struct pwm_dt_spec for the property.
@@ -346,7 +346,7 @@ struct pwm_dt_spec {
  * @brief Like PWM_DT_SPEC_INST_GET_BY_IDX(), with a fallback to a default
  *        value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Logical index into 'pwms' property.
  * @param default_value Fallback value to expand to.
  *
@@ -373,7 +373,7 @@ struct pwm_dt_spec {
 /**
  * @brief Equivalent to <tt>PWM_DT_SPEC_INST_GET_BY_IDX(inst, 0)</tt>.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  *
  * @return Static initializer for a struct pwm_dt_spec for the property.
  *
@@ -401,7 +401,7 @@ struct pwm_dt_spec {
  * @brief Equivalent to
  *        <tt>PWM_DT_SPEC_INST_GET_BY_IDX_OR(inst, 0, default_value)</tt>.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param default_value Fallback value to expand to.
  *
  * @return Static initializer for a struct pwm_dt_spec for the property.

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -40,9 +40,9 @@ struct reset_dt_spec {
 };
 
 /**
- * @brief Static initializer for a @p reset_dt_spec
+ * @brief Static initializer for a @c reset_dt_spec
  *
- * This returns a static initializer for a @p reset_dt_spec structure given a
+ * This returns a static initializer for a @c reset_dt_spec structure given a
  * devicetree node identifier, a property specifying a Reset Controller and an index.
  *
  * Example devicetree fragment:
@@ -67,7 +67,7 @@ struct reset_dt_spec {
  *
  * @param node_id devicetree node identifier
  * @param idx logical index into "resets"
- * @return static initializer for a struct reset_dt_spec for the property
+ * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property
  */
 #define RESET_DT_SPEC_GET_BY_IDX(node_id, idx)					\
 	{									\
@@ -88,7 +88,7 @@ struct reset_dt_spec {
  * @param node_id devicetree node identifier
  * @param idx logical index into the 'resets' property
  * @param default_value fallback value to expand to
- * @return static initializer for a struct reset_dt_spec for the property,
+ * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property,
  *         or default_value if the node or property do not exist
  */
 #define RESET_DT_SPEC_GET_BY_IDX_OR(node_id, idx, default_value)	\
@@ -100,7 +100,7 @@ struct reset_dt_spec {
  * @brief Equivalent to RESET_DT_SPEC_GET_BY_IDX(node_id, 0).
  *
  * @param node_id devicetree node identifier
- * @return static initializer for a struct reset_dt_spec for the property
+ * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property
  * @see RESET_DT_SPEC_GET_BY_IDX()
  */
 #define RESET_DT_SPEC_GET(node_id) \
@@ -112,32 +112,32 @@ struct reset_dt_spec {
  *
  * @param node_id devicetree node identifier
  * @param default_value fallback value to expand to
- * @return static initializer for a struct reset_dt_spec for the property,
+ * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property,
  *         or default_value if the node or property do not exist
  */
 #define RESET_DT_SPEC_GET_OR(node_id, default_value)			\
 	RESET_DT_SPEC_GET_BY_IDX_OR(node_id, 0, default_value)
 
 /**
- * @brief Static initializer for a @p reset_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @c reset_dt_spec from a DT_DRV_COMPAT
  * instance's Reset Controller property at an index.
  *
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into "resets"
- * @return static initializer for a struct reset_dt_spec for the property
+ * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property
  * @see RESET_DT_SPEC_GET_BY_IDX()
  */
 #define RESET_DT_SPEC_INST_GET_BY_IDX(inst, idx) \
 	RESET_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Static initializer for a @p reset_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @c reset_dt_spec from a DT_DRV_COMPAT
  *	  instance's 'resets' property at an index, with fallback
  *
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into the 'resets' property
  * @param default_value fallback value to expand to
- * @return static initializer for a struct reset_dt_spec for the property,
+ * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property,
  *         or default_value if the node or property do not exist
  */
 #define RESET_DT_SPEC_INST_GET_BY_IDX_OR(inst, idx, default_value)	\
@@ -149,7 +149,7 @@ struct reset_dt_spec {
  * @brief Equivalent to RESET_DT_SPEC_INST_GET_BY_IDX(inst, 0).
  *
  * @param inst DT_DRV_COMPAT instance number
- * @return static initializer for a struct reset_dt_spec for the property
+ * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property
  * @see RESET_DT_SPEC_INST_GET_BY_IDX()
  */
 #define RESET_DT_SPEC_INST_GET(inst) \
@@ -161,7 +161,7 @@ struct reset_dt_spec {
  *
  * @param inst DT_DRV_COMPAT instance number
  * @param default_value fallback value to expand to
- * @return static initializer for a struct reset_dt_spec for the property,
+ * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property,
  *         or default_value if the node or property do not exist
  */
 #define RESET_DT_SPEC_INST_GET_OR(inst, default_value)			\
@@ -243,7 +243,7 @@ static inline int z_impl_reset_status(const struct device *dev, uint32_t id, uin
 }
 
 /**
- * @brief Get the reset status from a @p reset_dt_spec.
+ * @brief Get the reset status from a @c reset_dt_spec.
  *
  * This is equivalent to:
  *
@@ -285,7 +285,7 @@ static inline int z_impl_reset_line_assert(const struct device *dev, uint32_t id
 }
 
 /**
- * @brief Assert the reset state from a @p reset_dt_spec.
+ * @brief Assert the reset state from a @c reset_dt_spec.
  *
  * This is equivalent to:
  *
@@ -326,7 +326,7 @@ static inline int z_impl_reset_line_deassert(const struct device *dev, uint32_t 
 }
 
 /**
- * @brief Deassert the reset state from a @p reset_dt_spec.
+ * @brief Deassert the reset state from a @c reset_dt_spec.
  *
  * This is equivalent to:
  *
@@ -366,7 +366,7 @@ static inline int z_impl_reset_line_toggle(const struct device *dev, uint32_t id
 }
 
 /**
- * @brief Reset the device from a @p reset_dt_spec.
+ * @brief Reset the device from a @c reset_dt_spec.
  *
  * This is equivalent to:
  *

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -119,10 +119,10 @@ struct reset_dt_spec {
 	RESET_DT_SPEC_GET_BY_IDX_OR(node_id, 0, default_value)
 
 /**
- * @brief Static initializer for a @c reset_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @c reset_dt_spec from a @c DT_DRV_COMPAT
  * instance's Reset Controller property at an index.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into "resets"
  * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property
  * @see RESET_DT_SPEC_GET_BY_IDX()
@@ -131,10 +131,10 @@ struct reset_dt_spec {
 	RESET_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Static initializer for a @c reset_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @c reset_dt_spec from a @c DT_DRV_COMPAT
  *	  instance's 'resets' property at an index, with fallback
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into the 'resets' property
  * @param default_value fallback value to expand to
  * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property,
@@ -148,7 +148,7 @@ struct reset_dt_spec {
 /**
  * @brief Equivalent to RESET_DT_SPEC_INST_GET_BY_IDX(inst, 0).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property
  * @see RESET_DT_SPEC_INST_GET_BY_IDX()
  */
@@ -159,7 +159,7 @@ struct reset_dt_spec {
  * @brief Equivalent to
  *	  RESET_DT_SPEC_INST_GET_BY_IDX_OR(node_id, 0, default_value).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param default_value fallback value to expand to
  * @return static initializer for a <tt>struct reset_dt_spec</tt> for the property,
  *         or default_value if the node or property do not exist

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1518,7 +1518,7 @@ struct sensor_info {
  * compatible
  *
  * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to SENSOR_DEVICE_DT_DEFINE().
+ * <tt>DT_DRV_INST(inst)</tt> in the call to SENSOR_DEVICE_DT_DEFINE().
  *
  * @param ... other parameters as expected by SENSOR_DEVICE_DT_DEFINE().
  */

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1514,7 +1514,7 @@ struct sensor_info {
 	SENSOR_INFO_DT_DEFINE(node_id);
 
 /**
- * @brief Like SENSOR_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT
+ * @brief Like SENSOR_DEVICE_DT_DEFINE() for an instance of a @c DT_DRV_COMPAT
  * compatible
  *
  * @param inst instance number. This is replaced by
@@ -1616,7 +1616,7 @@ static inline int sensor_value_from_micro(struct sensor_value *val, int64_t micr
 /**
  * @brief Get the decoder name for the current driver
  *
- * This function depends on `DT_DRV_COMPAT` being defined.
+ * This function depends on @c DT_DRV_COMPAT being defined.
  */
 #define SENSOR_DECODER_NAME() UTIL_CAT(DT_DRV_COMPAT, __decoder_api)
 

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -538,7 +538,7 @@ static inline void smbus_xfer_stats(const struct device *dev, uint8_t sent,
 #endif /* CONFIG_SMBUS_STATS */
 
 /**
- * @brief Like SMBUS_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT
+ * @brief Like SMBUS_DEVICE_DT_DEFINE() for an instance of a @c DT_DRV_COMPAT
  * compatible
  *
  * @param inst instance number. This is replaced by

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -542,7 +542,7 @@ static inline void smbus_xfer_stats(const struct device *dev, uint8_t sent,
  * compatible
  *
  * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to SMBUS_DEVICE_DT_DEFINE().
+ * <tt>DT_DRV_INST(inst)</tt> in the call to SMBUS_DEVICE_DT_DEFINE().
  *
  * @param ... other parameters as expected by SMBUS_DEVICE_DT_DEFINE().
  */

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -405,7 +405,7 @@ struct spi_cs_control {
  * This is equivalent to
  * <tt>SPI_CS_CONTROL_INIT(DT_DRV_INST(inst), delay)</tt>.
  *
- * Therefore, @p DT_DRV_COMPAT must already be defined before using
+ * Therefore, @c DT_DRV_COMPAT must already be defined before using
  * this macro.
  *
  * @param inst Devicetree node instance number
@@ -836,7 +836,7 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
 				    level, prio, api, __VA_ARGS__)
 
 /**
- * @brief Like SPI_DEVICE_DT_DEINIT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`
+ * @brief Like SPI_DEVICE_DT_DEINIT_DEFINE(), but uses an instance of a @c DT_DRV_COMPAT
  * compatible instead of a node identifier.
  *
  * @param inst Instance number. The `node_id` argument to SPI_DEVICE_DT_DEINIT_DEFINE() is
@@ -847,7 +847,7 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
 	SPI_DEVICE_DT_DEINIT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
- * @brief Like SPI_DEVICE_DT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`
+ * @brief Like SPI_DEVICE_DT_DEFINE(), but uses an instance of a @c DT_DRV_COMPAT
  * compatible instead of a node identifier.
  *
  * @param inst Instance number. The `node_id` argument to SPI_DEVICE_DT_DEFINE() is

--- a/include/zephyr/drivers/wuc.h
+++ b/include/zephyr/drivers/wuc.h
@@ -115,10 +115,10 @@ struct wuc_dt_spec {
 	WUC_DT_SPEC_GET_BY_IDX_OR(node_id, 0, default_value)
 
 /**
- * @brief Static initializer for a @p wuc_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @p wuc_dt_spec from a @c DT_DRV_COMPAT
  * instance's Wakeup Controller property at an index.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into "wakeup-ctrls"
  * @return static initializer for a struct wuc_dt_spec for the property
  * @see WUC_DT_SPEC_GET_BY_IDX()
@@ -126,10 +126,10 @@ struct wuc_dt_spec {
 #define WUC_DT_SPEC_INST_GET_BY_IDX(inst, idx) WUC_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Static initializer for a @p wuc_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @p wuc_dt_spec from a @c DT_DRV_COMPAT
  *	  instance's 'wakeup-ctrls' property at an index, with fallback
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into the 'wakeup-ctrls' property
  * @param default_value fallback value to expand to
  * @return static initializer for a struct wuc_dt_spec for the property,
@@ -143,7 +143,7 @@ struct wuc_dt_spec {
 /**
  * @brief Equivalent to WUC_DT_SPEC_INST_GET_BY_IDX(inst, 0).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return static initializer for a struct wuc_dt_spec for the property
  * @see WUC_DT_SPEC_INST_GET_BY_IDX()
  */
@@ -153,7 +153,7 @@ struct wuc_dt_spec {
  * @brief Equivalent to
  *	  WUC_DT_SPEC_INST_GET_BY_IDX_OR(node_id, 0, default_value).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param default_value fallback value to expand to
  * @return static initializer for a struct wuc_dt_spec for the property,
  *         or default_value if the node or property do not exist

--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -295,7 +295,7 @@ void k_mem_unmap_phys_bare(uint8_t *virt, size_t size);
  *             anonymous memory. Must be page-aligned.
  * @param size Size of the memory mapping. This must be page-aligned.
  * @param flags K_MEM_PERM_*, K_MEM_MAP_* control flags.
- * @param is_anon True is requesting mapping with anonymous memory.
+ * @param is_anon True if requesting mapping with anonymous memory.
  *
  * @return The mapped memory location, or NULL if insufficient virtual address
  *         space, insufficient physical memory to establish the mapping,

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -1186,7 +1186,7 @@ static inline bool net_eth_is_vlan_interface(struct net_if *iface)
  * compatible
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to ETH_NET_DEVICE_DT_DEFINE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to ETH_NET_DEVICE_DT_DEFINE.
  *
  * @param ... other parameters as expected by ETH_NET_DEVICE_DT_DEFINE.
  */

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -3586,7 +3586,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * @brief Forward declaration of a network interface
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_ADD_IFACE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_DEVICE_DT_ADD_IFACE.
  * @param ... other parameters as expected by NET_DEVICE_DT_ADD_IFACE.
  */
 #define NET_IF_DT_INST_DECLARE(inst, ...) NET_IF_DT_DECLARE(DT_DRV_INST(inst), __VA_ARGS__)
@@ -3605,7 +3605,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * NET_DEVICE_DT_ADD_IFACE.
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_IF_DT_GET.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_IF_DT_GET.
  * @param ... other parameters as expected by NET_DEVICE_DT_ADD_IFACE.
  */
 #define NET_IF_DT_INST_GET(inst, ...) NET_IF_DT_GET(DT_DRV_INST(inst), __VA_ARGS__)
@@ -3652,7 +3652,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * @brief Like NET_DEVICE_DT_ADD_IFACE for an instance of a DT_DRV_COMPAT compatible
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_ADD_IFACE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_DEVICE_DT_ADD_IFACE.
  *
  * @param ... other parameters as expected by NET_DEVICE_DT_ADD_IFACE.
  */
@@ -3687,7 +3687,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * @brief Like NET_DEVICE_DT_DEFINE for an instance of a DT_DRV_COMPAT compatible
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_DEFINE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_DEVICE_DT_DEFINE.
  *
  * @param ... other parameters as expected by NET_DEVICE_DT_DEFINE.
  */
@@ -3760,7 +3760,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * compatible
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_DEFINE_INSTANCE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_DEVICE_DT_DEFINE_INSTANCE.
  *
  * @param ... other parameters as expected by NET_DEVICE_DT_DEFINE_INSTANCE.
  */
@@ -3830,7 +3830,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * compatible
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_OFFLOAD_DEFINE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_DEVICE_DT_OFFLOAD_DEFINE.
  *
  * @param ... other parameters as expected by NET_DEVICE_DT_OFFLOAD_DEFINE.
  */

--- a/include/zephyr/sensing/sensing_sensor.h
+++ b/include/zephyr/sensing/sensing_sensor.h
@@ -379,7 +379,7 @@ extern const struct rtio_iodev_api __sensing_iodev_api;
  * compatible
  *
  * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to SENSING_SENSORS_DT_DEFINE().
+ * <tt>DT_DRV_INST(inst)</tt> in the call to SENSING_SENSORS_DT_DEFINE().
  * @param ... other parameters as expected by SENSING_SENSORS_DT_DEFINE().
  */
 #define SENSING_SENSORS_DT_INST_DEFINE(inst, ...)	\

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -892,7 +892,7 @@ static bool is_fmt_spec(char c)
 	return (c >= 64) && (c <= 122);
 }
 
-/* Function checks if nth argument is a pointer (%p). Returns true is yes. Returns
+/* Function checks if nth argument is a pointer (%p). Returns true if yes. Returns
  * false if not or if string does not have nth argument.
  */
 bool is_ptr(const char *fmt, int n)


### PR DESCRIPTION
A series (far from being exhaustive) for updating inline description comments in header files to enhance rendering in the driver generated documentation. Plus also a few minor things I've seen by the way.

No functional changes.

The primary goal was the update device tree related generic macros description to better highlight in the generated documentations references to macro arguments and to DT property names, DT property cell names and some C source structures.
=> changes in **include/zephyr/devicetree/\*.h**

Along the way, also fix places where `DT_DRV_COMPAT(inst)` was mentioned while `DT_DRV_INST(inst)` should be.
=> tree wide updates

Add a `@c` specifier in front of `DT_DRV_COMPAT` occurrences.
=> changes in **include/zephyr/devicetree/\*.h** and **include/zephyr/drivers/\***



