### PR TITLE
stm32: tests: subsys: sd: sdmmc: boards: add support for stm32h573i_dk

### DIFF
--- a/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
@@ -381,6 +381,7 @@
 	pinctrl-names = "default";
 	cd-gpios = <&gpioh 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	disk-name = "SD";
+	bus-width = <4>;
 	status = "okay";
 };
 

--- a/boards/st/stm32h573i_dk/twister.yaml
+++ b/boards/st/stm32h573i_dk/twister.yaml
@@ -22,6 +22,7 @@ supported:
   - octospi
   - pwm
   - rtc
+  - sdhc
   - spi
   - uart
   - usb_device

--- a/drivers/sdhc/Kconfig.stm32
+++ b/drivers/sdhc/Kconfig.stm32
@@ -10,6 +10,7 @@ config SDHC_STM32_SDMMC
 	select USE_STM32_LL_SDMMC
 	select SDHC_SUPPORTS_NATIVE_MODE
 	select PINCTRL
+	select GPIO
 	default y
 	help
 	  Enables support for SD/SDIO devices using SDMMC peripheral on STM32.

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -565,6 +565,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB4, 11)>,
 				 <&rcc STM32_SRC_PLL1_Q SDMMC1_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB4, 11)>;
+			interrupt-names = "event";
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1212,6 +1212,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB3, 16)>,
 				 <&rcc STM32_SRC_PLL1_Q SDMMC_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB3, 16)>;
+			interrupt-names = "event";
 			interrupts = <49 0>;
 			status = "disabled";
 		};

--- a/tests/subsys/sd/sdmmc/boards/stm32h573i_dk.conf
+++ b/tests/subsys/sd/sdmmc/boards/stm32h573i_dk.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_HEAP_MEM_POOL_SIZE=2048

--- a/tests/subsys/sd/sdmmc/boards/stm32h573i_dk.overlay
+++ b/tests/subsys/sd/sdmmc/boards/stm32h573i_dk.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sdhc0 = &sdhc;
+	};
+};
+
+sdhc: &sdmmc1 {
+	interrupt-names = "event";
+	hw-flow-control;
+	min-bus-freq = <DT_FREQ_K(400)>;
+	max-bus-freq = <DT_FREQ_M(208)>;
+
+	sdmmc {
+		compatible = "zephyr,sdmmc-disk";
+		disk-name = "SD";
+		status = "okay";
+	};
+};

--- a/tests/subsys/sd/sdmmc/boards/stm32h573i_dk.overlay
+++ b/tests/subsys/sd/sdmmc/boards/stm32h573i_dk.overlay
@@ -11,7 +11,6 @@
 };
 
 sdhc: &sdmmc1 {
-	interrupt-names = "event";
 	hw-flow-control;
 	min-bus-freq = <DT_FREQ_K(400)>;
 	max-bus-freq = <DT_FREQ_M(208)>;

--- a/tests/subsys/sd/sdmmc/boards/stm32h747i_disco_stm32h747xx_m7.overlay
+++ b/tests/subsys/sd/sdmmc/boards/stm32h747i_disco_stm32h747xx_m7.overlay
@@ -11,12 +11,8 @@
 };
 
 sdhc: &sdmmc1 {
-	compatible = "st,stm32-sdmmc";
-	interrupts = <49 0>;
-	interrupt-names = "event";
 	hw-flow-control;
 	bus-width = <4>;
-	status = "okay";
 	min-bus-freq = <DT_FREQ_K(400)>;
 	max-bus-freq = <DT_FREQ_M(208)>;
 


### PR DESCRIPTION
This PR adds support for testing the SD card on STM32H573I-DK through SDHC.

