### PR TITLE
code_relocation: Fix case of source in application directory

### DIFF
--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -578,6 +578,10 @@ def get_obj_filename(all_obj_files, filename):
         if obj_file.name == obj_filename and filename.split("/")[-2] in obj_file.parent.name:
             return str(obj_file)
 
+    for obj_file in all_obj_files:
+        if obj_file.name == obj_filename and obj_file.parent.name == 'app.dir':
+            return str(obj_file)
+
 
 # Extracts all possible components for the input string:
 # <mem_region>[\ :program_header]:<flag_1>[;<flag_2>...]:<file_1>[;<file_2>...][,filter]


### PR DESCRIPTION
In the case the required file is locate in the root directory of the application, the parent directory is named "app.dir". So, it does not match with the existing rule.

Add a second pass to check if the object file can be found in "app.dir".

Note this bug has not been found earlier because the application source are usually placed in "src/" subdirectory.