### PR TITLE
kernel: sched: drop stale wait-queue membership before re-pending

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -39,6 +39,18 @@ struct k_spinlock _sched_spinlock;
  */
 __incoherent struct k_thread _thread_dummy;
 
+/* One-shot guard + counter for the "already pended" recovery in
+ * add_to_waitq_locked(). The recovery is a defense-in-depth against a reachable
+ * state (a blocking pend from ISR -- e.g. a driver async callback doing
+ * k_sem_take(K_FOREVER) -- which the kernel does not yet refuse in production).
+ * It must not silently mask the producer: warn once + count, so a developer
+ * hitting this class finds the source instead of chasing a downstream crash.
+ * Once the kernel enforces "no blocking pend from ISR" in every build, the
+ * warning graduates to an __ASSERT and this becomes a true invariant check.
+ */
+static atomic_t already_pended_warned;
+static atomic_t already_pended_count;
+
 static ALWAYS_INLINE void update_cache(int preempt_ok);
 static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state,
 				      k_spinlock_key_t *key);
@@ -429,6 +441,15 @@ static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
 	 * so this is a no-op.
 	 */
 	if (thread->base.pended_on != NULL) {
+		(void)atomic_inc(&already_pended_count);
+		if (atomic_set(&already_pended_warned, 1) == 0) {
+			LOG_WRN("thread %p reached add_to_waitq_locked() still pended on "
+				"%p; recovered. Likely a blocking pend from ISR "
+				"(e.g. a driver async callback doing k_sem_take(K_FOREVER)) -- "
+				"fix the producer. (This recovery is a defense until the kernel "
+				"enforces no-blocking-pend-from-ISR in production; see PR #111518.)",
+				thread, thread->base.pended_on);
+		}
 		unpend_thread_no_timeout(thread);
 		(void)z_try_abort_thread_timeout(thread);
 	}

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -442,7 +442,13 @@ static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
 	 */
 	if (thread->base.pended_on != NULL) {
 		(void)atomic_inc(&already_pended_count);
-		if (atomic_set(&already_pended_warned, 1) == 0) {
+		/* Warn only for the ISR-context misuse (a real bug to alarm on);
+		 * the non-current-thread path (e.g. k_mbox_async_put's dummy carrier
+		 * via z_pend_thread, which legitimately reaches here already pended
+		 * without any swap race) is handled silently so it does not pollute
+		 * test console output. The counter still records both.
+		 */
+		if (k_is_in_isr() && atomic_set(&already_pended_warned, 1) == 0) {
 			LOG_WRN("thread %p reached add_to_waitq_locked() still pended on "
 				"%p; recovered. Likely a blocking pend from ISR "
 				"(e.g. a driver async callback doing k_sem_take(K_FOREVER)) -- "

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -411,6 +411,28 @@ void z_sched_yield(void)
 /* _sched_spinlock must be held */
 static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
 {
+	/* A thread can reach this point while still pended on (and linked in)
+	 * another wait queue. unready_thread() below only removes it from the run
+	 * queue (z_is_thread_queued()); with the shared qnode_dlist
+	 * (CONFIG_WAITQ_SIMPLE) the node would then be relinked into the new wait
+	 * queue while the old queue's head/tail are left dangling at it -- later
+	 * corrupting the list (e.g. a NULL deref in sys_dlist_remove()). Remove the
+	 * thread from any wait queue it is already on first.
+	 *
+	 * This is deliberately not gated on CONFIG_SWAP_NONATOMIC. That race is one
+	 * way the state arises (an ISR wakes a cooperatively-pending thread during
+	 * its own non-atomic arch_swap(), so it resumes still pended and then pends
+	 * on another queue), but a non-current thread can also be added to a wait
+	 * queue while still pended on a non-SWAP_NONATOMIC arch -- gating the
+	 * correction regressed kernel.mailbox.api on qemu_rx. In normal operation
+	 * pended_on is NULL here (a thread pends itself via z_pend_curr(_current)),
+	 * so this is a no-op.
+	 */
+	if (thread->base.pended_on != NULL) {
+		unpend_thread_no_timeout(thread);
+		(void)z_try_abort_thread_timeout(thread);
+	}
+
 	unready_thread(thread);
 	z_mark_thread_as_pending(thread);
 


### PR DESCRIPTION
## Summary

On a single-core Cortex-M target with the default `CONFIG_WAITQ_SIMPLE` (dlist
wait queues) and `CONFIG_SWAP_NONATOMIC=y`, a cooperative thread that pends on
wait queue **A**, is woken by an ISR during the non-atomic context switch, can
**resume execution while still linked in A**, and then pend on a *different*
wait queue **B**. `add_to_waitq_locked()` removes the thread only from the
**run queue** (`unready_thread()` → `z_is_thread_queued()`); it does **not**
remove a thread that is currently pending on another wait queue. Because the run
queue and every `WAITQ_SIMPLE` wait queue share the same
`thread->base.qnode_dlist`, the node is physically relinked into B while A's
`head`/`tail` are left dangling at it. The next pend on A appends the node to a
list whose `tail` already equals `&node` → the node becomes **self-referential**
→ a later `z_sched_wake()` finds a `_THREAD_QUEUED` thread inside a wait queue
→ `unpend_thread_no_timeout()` removes it via its run-queue links, and
`ready_thread()` then declines to re-link it (`!z_is_thread_queued()` is false)
→ the thread is left `QUEUED` but in no list → the next dequeue does
`sys_dlist_remove()` on an unlinked node → NULL dereference.

We hit this under Bluetooth (a cooperative workqueue thread pends on its
`notifyq`, an SPI peripheral ISR wakes it mid-swap, and it then pends on the SPI
driver's wait queue), but nothing here is Bluetooth-specific.

## Environment

- **Discovered on:** NCS v3.2.4 / Zephyr `v4.2.99` (`ncs-v3.2.4`), nRF5340 app
  core (Cortex-M33, **non-SMP**, `!CONFIG_USE_SWITCH`), `CONFIG_SCHED_SIMPLE=y`,
  `CONFIG_WAITQ_SIMPLE=y`, `CONFIG_SWAP_NONATOMIC=y`, `CONFIG_TIMESLICING=y`,
  32768 Hz tick.
- **Structurally present on upstream `main`** by source inspection (refs below
  are from `main`). The April-2026 scheduler refactor reorganized files but did
  not change the relevant logic: `add_to_waitq_locked()`/`unready_thread()`
  still clear only the run queue, `WAITQ_SIMPLE` still shares the node, and
  `do_swap()` still has the non-atomic window on `!CONFIG_USE_SWITCH` arches.

## Symptom

```
MPU FAULT / MemManage, MMFAR=0x0
PC ≈ sys_dlist_remove+4
(faulting access: writing through a NULL prev/next link)
```

> **Platform note:** `MMFAR=0x0` and the `MPU FAULT` / MemManage framing are
> **Cortex-M specific**. The platform-independent fact is a **NULL-pointer
> dereference inside `sys_dlist_remove()`** while writing through an unlinked
> node's `prev`/`next`. On other architectures this surfaces as that arch's
> equivalent (data abort / access to address `0`).

The faulting thread is whichever cooperative thread regularly pends, is woken by
an ISR, and then pends on a second wait queue (in our case a BT workqueue
thread; the victim is workload-dependent).

## Root cause

Three independent facts combine. All three are present on `main`.

### 1. A `WAITQ_SIMPLE` wait queue and the run queue share one node

`kernel/include/priority_q.h` maps both the simple run queue and the dlist wait
queue onto `z_priq_simple_*`, operating on the same `thread->base.qnode_dlist`.
`z_priq_simple_remove()` ignores the queue it is told to remove from — it
unlinks the node by its own `prev/next`:

```c
static ALWAYS_INLINE void z_priq_simple_remove(sys_dlist_t *pq, struct k_thread *thread)
{
    ARG_UNUSED(pq);
    sys_dlist_remove(&thread->base.qnode_dlist);
}
```

So a thread's `qnode_dlist` can only ever be in **one** list. If it is linked
in list X and is then added to list Y, X's `head/tail` are left dangling at it.

### 2. `add_to_waitq_locked()` only removes the thread from the run queue

`kernel/sched.c`:

```c
static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
{
    unready_thread(thread);                 // (a)
    z_mark_thread_as_pending(thread);
    if (wait_q != NULL) {
        thread->base.pended_on = wait_q;
        _priq_wait_add(&wait_q->waitq, thread);   // (b) sys_dlist_append(node)
    }
}

static void unready_thread(struct k_thread *thread)
{
    if (z_is_thread_queued(thread)) {       // only the RUN queue
        dequeue_thread(thread);
    }
    update_cache(thread == _current);
}
```

(a) removes the thread from the run queue **only**. It assumes the thread is not
currently on a wait queue — which is normally true, because a thread pends
itself (`z_pend_curr(_current, ...)`) and `_current` is, by definition, running.
There is no check on `thread->base.pended_on`.

### 3. `CONFIG_SWAP_NONATOMIC` can break that assumption

On `!CONFIG_USE_SWITCH` Cortex-M, `z_swap()` releases the scheduler spinlock and
calls `arch_swap()`, which switches via PendSV. There is a short window
("non-atomic swap") between *"thread added to wait queue A, scheduler lock
released"* and *"PendSV actually switches it out"* during which an ISR can run.
If that ISR wakes the just-pended thread, the thread can resume execution while
still recorded as pending on (and linked in) A. The kernel tracks this case with
`pending_current`, but the cleanup is incomplete: the thread ends up running
with `pended_on == A` and its node still in A.

### The captured planting (single-core, real hardware)

We instrumented the wait-queue tracer to follow the victim thread from boot and
freeze a circular ring on the first self-referential pend, **before** any
corruption recovery (so `z_sched_remove_unlinked == 0` at capture). The decisive
events (`+0x0` = the victim's `qnode_dlist`; `+0xd4` = its `notifyq` sentinel):

```
#7157 PEND(after add)  wait_q=A(notifyq)  pended_on=A   node.next/prev=&A_sentinel   (healthy: drained→idle)
#7158 PEND(entry)      wait_q=B(spi)      pended_on=A   caller=z_pend_curr   *** still pended_on A, still PENDING ***
#7159 PEND(after add)  wait_q=B(spi)      pended_on=B   node.next/prev=&B_sentinel   (node relinked to B; A left stale)
#7160 READY            caller=z_ready_thread                                          (B completes, wakes victim)
#7161 PEND(entry)      wait_q=A(notifyq)  state=QUEUED  node in run queue
#7162 PEND(after add)  wait_q=A(notifyq)  *** SELF-REF: node.next=node.prev=&node ***  (append to a list whose tail==&node)
```

- There is **no wake event between #7157 and #7158** — the victim went from
  "pended on A" to "pending on B" with no clean unpend (the `SWAP_NONATOMIC`
  ISR-wake path, item 3).
- At #7158, `add_to_waitq_locked(B)` runs with the victim still `pended_on=A`.
  `unready_thread()` sees it is `PENDING`, not `QUEUED`, so it does **not**
  remove it from A. `_priq_wait_add(B)` relinks the shared node into B (#7159),
  leaving A's `head/tail` dangling at `&node`.
- #7162 then appends the node to A whose `tail` is already `&node` → the node's
  `next`/`prev` both become `&node` (self-referential).

### The downstream cascade (and the crash)

Once A's head references a node that is also `_THREAD_QUEUED` on the run queue,
`z_sched_wake(A)` (`scheduler.c` → `z_unpend_first_thread_locked`,
`kernel/include/ksched.h`) takes it as a waiter and `unpend_thread_no_timeout()`
calls `sys_dlist_remove()` — which follows the node's **run-queue** links,
splicing it out of the run queue. `ready_thread()` (`kernel/sched.c`) then
declines to re-link it:

```c
if (!z_is_thread_queued(thread) && z_is_thread_ready(thread)) {  // QUEUED set -> FALSE
    queue_thread(thread);   // skipped -> node never re-linked
}
```

The thread is now flagged `QUEUED` but is in no list, with `next == prev ==
NULL`. The next dequeue does `sys_dlist_remove()` on it → `NULL->next = ...` →
the fault.

## What it is **not** (ruled out)

- **Not** a `k_work` self-submit / "submit a running work item" bug.
  Re-submitting a running work item is explicitly supported; the steady-state
  workqueue `notifyq` is emptied correctly on every wake (verified from boot).
- **Not** a `k_work_flush()` use-after-free.
- The trigger requires the victim to pend on a **second** wait queue while an
  ISR wakes it mid-swap; pure work churn (no second wait queue) does not
  reproduce it.

## Reproduction notes

This is a narrow `SWAP_NONATOMIC` timing window (~10–20 instructions in
`arch_swap`), so it is rare even under the production workload (≈ one planting
per several thousand pend/wake cycles). We reproduce it reliably **on hardware**
under sustained Bluetooth L2CAP CoC streaming with an SPI peripheral whose ISR
wakes the BT `tx_processor` workqueue thread. A self-contained
(`k_sem`-on-A / ISR-wake / `k_sem`-on-B) stress test exercises the same path but
has not yet hit the window in short runs; the hardware capture above is the
authoritative evidence. (We are happy to share the tracer patch and decoder.)

## Proposed fix (verified on hardware)

We landed **option A** (defensive): remove the thread from any wait queue it is
*already* on before adding it to the new one, in `add_to_waitq_locked()`
(`kernel/sched.c`). The correction is kept **unconditional** (not gated on
`CONFIG_SWAP_NONATOMIC`): an earlier attempt to gate it regressed
`kernel.mailbox.api` on `qemu_rx`, confirming the "added while still pended"
state is also reachable on a non-`SWAP_NONATOMIC` arch (a non-current thread
pended on a wait queue by another context), so the guard must stay unconditional.

```c
static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
{
    /* A thread can reach this point while still pended on (and linked in)
     * another wait queue. unready_thread() below only removes it from the RUN
     * queue, so without this the shared qnode_dlist (CONFIG_WAITQ_SIMPLE) is
     * relinked into the new wait queue while the old queue's head/tail dangle
     * at it -> later NULL deref in sys_dlist_remove(). Remove it from any wait
     * queue it is already on first. In normal operation pended_on is NULL here
     * (a thread pends itself via z_pend_curr(_current)), so this is a no-op.
     */
    if (thread->base.pended_on != NULL) {
        unpend_thread_no_timeout(thread);
        (void)z_try_abort_thread_timeout(thread);
    }

    unready_thread(thread);
    z_mark_thread_as_pending(thread);
    ...
}
```

We added a counter to the `if` branch to prove the race actually occurs and is
being corrected (not merely "didn't happen this run"):

| | Baseline (unpatched) | With option A |
|---|---|---|
| corruption (`z_priq_simple_remove` on unlinked node) | hundreds within 15–60 s | **0** over 3 min |
| first self-referential pend (frozen tracer) | yes (~60 s) | **no** |
| `z_sched_wake` finds a `QUEUED` waiter | 16+ | **0** |
| times the race condition was hit & corrected | n/a | **~19** (a few per 20 s) |

So the `pended_on != NULL` branch fires (the `SWAP_NONATOMIC` race genuinely
happens) yet **no corruption results** — the fix is exercised, not lucky. Both
`unpend_thread_no_timeout()` alone and the variant with `z_try_abort_thread_timeout()`
shown above were validated; they behave identically for this workload (wait
queue A is a workqueue `notifyq`, pended `K_FOREVER`, so there is no timeout to
abort — the abort is for generality).

We also captured the **root event** directly. A wait-queue tracer, extended to
log `pended_on`/state and the `z_swap()` return value at the point each pend
resumes, froze the victim returning from its own `k_sem_take()` on an SPI sync
sem still `_THREAD_PENDING`, with `pended_on` set, and with `swap_ret == -EAGAIN`
— the default the swap machinery installs and that a completed wake would
overwrite. Every healthy resume in the same ring shows `swap_ret == 0` /
`pended_on == NULL`. The `-EAGAIN` + non-NULL `pended_on` combination is the
`SWAP_NONATOMIC` resume-while-pended, and is distinct from a clean ISR
`k_sem_give` (which self-heals via `unpend_thread_no_timeout()` and would show
`swap_ret == 0`). Tracer + decoder available on request.

### Which fix? (for PR discussion)

- **A — Defensive (landed here, unconditional).** Local, minimal, low risk;
  also a safety net for any other caller that breaks the "not already on a wait
  queue" invariant. Gating it on `CONFIG_SWAP_NONATOMIC` was tried and reverted:
  it regressed `kernel.mailbox.api` on `qemu_rx`, which shows the invariant is
  violated outside the `SWAP_NONATOMIC` race too.
- **B — Root.** Make the `SWAP_NONATOMIC` / `pending_current` reconciliation
  fully unpend a thread woken during its own non-atomic swap, so it never
  resumes with `pended_on != NULL`. Fixes the origin, but is arch/
  scheduler-internal with a larger blast radius.
- **C — Hardening (complements A/B).** Make `ready_thread()`'s `QUEUED`
  early-out an assertion rather than a silent skip, so a lying `QUEUED`/list
  state is caught at its source instead of crashing later in
  `sys_dlist_remove()`.

A and B are compatible (A remains a cheap safety net even if B lands). We have
no strong preference and will adjust per maintainer guidance; this PR can track
the decision. We also have a local diagnostic build (wait-queue tracer + a
`z_priq_simple_*` trip guard that recovers the corruption) we can share.

## Related / credits

- The investigation started from two draft PRs against the *symptom*
  (`#111308` IPC `mbox_callback`, `#111309` BT RX path). Reviewer feedback there
  — that re-submitting a running `k_work` is supported, so the proposed guards
  addressed a non-bug — is what redirected us to the real scheduler root cause.
  Those PRs will be superseded by / linked from this report.

CC: @andyross @peter-mitsis @npitre @sylvioalves @jhedberg @alxelax

