### PR TITLE
drivers: crc: nxp: add clocks/resets to MCXA CRC nodes

### DIFF
--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -114,6 +114,12 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 	}
 #endif
 
+#if defined(CONFIG_CRC_DRIVER_NXP)
+	if ((uint32_t)sub_system == MCUX_CRC_CLK) {
+		CLOCK_EnableClock(kCLOCK_Crc0);
+	}
+#endif
+
 #if defined(CONFIG_PINCTRL_NXP_PORT)
 	switch ((uint32_t)sub_system) {
 #if defined(CONFIG_SOC_FAMILY_MCXA) || defined(CONFIG_SOC_FAMILY_MCXL)

--- a/drivers/crc/crc_nxp.c
+++ b/drivers/crc/crc_nxp.c
@@ -7,6 +7,7 @@
 
 #include <zephyr/drivers/crc.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(nxp_crc, CONFIG_CRC_LOG_LEVEL);
@@ -20,6 +21,7 @@ struct crc_nxp_config {
 	CRC_Type *base;
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
+	struct reset_dt_spec reset;
 };
 
 struct crc_nxp_data {
@@ -240,6 +242,18 @@ static int crc_nxp_init(const struct device *dev)
 		}
 	}
 
+	if (config->reset.dev != NULL) {
+		if (!device_is_ready(config->reset.dev)) {
+			return -ENODEV;
+		}
+
+		int ret = reset_line_deassert_dt(&config->reset);
+
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
 	k_sem_init(&data->lock, 1, 1);
 	return 0;
 }
@@ -253,6 +267,7 @@ static int crc_nxp_init(const struct device *dev)
 		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clocks),                   \
 			((clock_control_subsys_t)DT_INST_CLOCKS_CELL(inst, name)),                 \
 			((clock_control_subsys_t)0U)),                                             \
+		.reset = RESET_DT_SPEC_INST_GET_OR(inst, {0}),                                     \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, crc_nxp_init, NULL, &crc_nxp_data_##inst,                      \
 			      &crc_nxp_config_##inst, POST_KERNEL,                                 \

--- a/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
@@ -479,6 +479,8 @@
 		crc: crc@4008a000 {
 			compatible = "nxp,crc";
 			reg = <0x4008a000 0x1000>;
+			clocks = <&syscon MCUX_CRC_CLK>;
+			resets = <&reset NXP_SYSCON_RESET(0, 10)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
@@ -634,6 +634,8 @@
 		crc: crc@4008a000 {
 			compatible = "nxp,crc";
 			reg = <0x4008a000 0x1000>;
+			clocks = <&syscon MCUX_CRC_CLK>;
+			resets = <&reset NXP_SYSCON_RESET(0, 12)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -68,7 +68,7 @@
 			#clock-cells = <1>;
 
 			reset: reset {
-				compatible = "nxp,lpc-syscon-reset";
+				compatible = "nxp,mrcc-reset";
 				#reset-cells = <1>;
 			};
 		};
@@ -565,6 +565,8 @@
 		crc: crc@4008a000 {
 			compatible = "nxp,crc";
 			reg = <0x4008a000 0x1000>;
+			clocks = <&syscon MCUX_CRC_CLK>;
+			resets = <&reset NXP_SYSCON_RESET(0, 13)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -784,6 +784,8 @@
 	crc: crc@c5000 {
 		compatible = "nxp,crc";
 		reg = <0xc5000 0x1000>;
+		clocks = <&syscon MCUX_CRC_CLK>;
+		resets = <&reset NXP_SYSCON_RESET(0, 14)>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -661,6 +661,8 @@
 		crc: crc@4008a000 {
 			compatible = "nxp,crc";
 			reg = <0x4008a000 0x1000>;
+			clocks = <&syscon MCUX_CRC_CLK>;
+			resets = <&reset NXP_SYSCON_RESET(0, 13)>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/crc/nxp,crc.yaml
+++ b/dts/bindings/crc/nxp,crc.yaml
@@ -7,7 +7,7 @@ description: NXP CRC (Cyclic Redundancy Check) driver
 
 compatible: "nxp,crc"
 
-include: [base.yaml]
+include: [reset-device.yaml, base.yaml]
 
 properties:
   reg:

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -225,4 +225,7 @@
 /** SLCD peripheral clock identifier. */
 #define MCUX_SLCD_CLK MCUX_LPC_CLK_ID(0x34, 0x00)
 
+/** CRC peripheral clock identifier. */
+#define MCUX_CRC_CLK MCUX_LPC_CLK_ID(0x35, 0x00)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */

--- a/soc/nxp/mcx/mcxa/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig.defconfig
@@ -26,6 +26,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config FLASH_FILL_BUFFER_SIZE
 	default 128
 
+config RESET
+	default y if DT_HAS_NXP_MRCC_RESET_ENABLED
+
 if PM
 
 configdefault SYSTEM_TIMER_RESET_BY_LPM


### PR DESCRIPTION
- add clocks and resets to MCXA CRC nodes.
- crc_nxp: deassert in init if a dt reset is given. On MCXA SoCs the CRC peripheral boots held in reset, so enabling its clock is not enough. Deassert the reset during driver init.
- nxp,crc.yaml: include reset-device.yaml for the resets property.
- mcxa Kconfig.defconfig: enable CONFIG_RESET when MRCC reset is present.
- clock_control_mcux_syscon: enable the CRC clock gate.
- mcxa344: fix reset controller compatible to nxp,mrcc-reset.

Tested on frdm_mcxa344, frdm_mcxa156, frdm_mcxa266.