### PR TITLE
west: twister: enhancements to mplab_ipe runner

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -106,7 +106,7 @@ class HardwareAdapter(DeviceAdapter):
             elif runner == "openocd" and self.device_config.product == "LPC-LINK2 CMSIS-DAP":
                 extra_args.append("--cmd-pre-init")
                 extra_args.append(f'adapter serial {board_id}')
-            elif runner == 'jlink' or (
+            elif runner in ('jlink', 'mplab_ipe') or (
                 runner == 'stm32cubeprogrammer' and self.device_config.product != "BOOT-SERIAL"
             ):
                 base_args.append('--dev-id')

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -599,7 +599,7 @@ class DeviceHandler(Handler):
                 elif runner == "openocd" and product == "LPC-LINK2 CMSIS-DAP":
                     command_extra_args.append("--cmd-pre-init")
                     command_extra_args.append(f"adapter serial {board_id}")
-                elif runner == "jlink":
+                elif runner in ("jlink", "mplab_ipe"):
                     command.append("--dev-id")
                     command.append(board_id)
                 elif runner == "linkserver":

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -109,6 +109,7 @@ class HardwareMap:
         'NXP',
         'NXP Semiconductors',
         'Microchip Technology Inc.',
+        'Microchip Technology Incorporated',
         'FTDI',
         'Digilent',
         'Microsoft',
@@ -133,6 +134,14 @@ class HardwareMap:
         'dediprog': [
             'TTL232R-3V3',
             'MCP2200 USB Serial Port Emulator'
+        ],
+        'mplab_ipe': [
+            'MPLAB* PKoB 4',
+            'MPLAB* PICKit 5',
+            'MPLAB* PICKit Basic',
+            'MPLAB* SNAP ICD',
+            'MPLAB* ICD 5',
+            'MPLAB* ICE',
         ]
     }
 
@@ -340,6 +349,9 @@ class HardwareMap:
 
                 if d.product is None:
                     d.product = 'unknown'
+
+                if 'MPLAB' in d.product:
+                    d.product = 'MPLAB-TOOL'
 
                 s_dev = DUT(platform="unknown",
                                         id=d.serial_number,

--- a/scripts/west_commands/runners/mplab_ipe.py
+++ b/scripts/west_commands/runners/mplab_ipe.py
@@ -76,7 +76,6 @@ class MPLABIPEBinaryRunner(ZephyrBinaryRunner):
 
         cmd = [
             exe,
-            f"-TP{self.tool}",  # probe type
             f"-P{self.part}",  # part number of the SoC
             f"-F{hex_file}",
             "-M",  # Program all memories
@@ -86,6 +85,8 @@ class MPLABIPEBinaryRunner(ZephyrBinaryRunner):
 
         if self.dev_id:
             cmd.append(f"-TS{self.dev_id}")  # Select programmer by serial number
+        elif self.tool is not None:
+            cmd.append(f"-TP{self.tool}")  # Select programmer by name of the tool
 
         if self.erase:
             cmd.append("-E")


### PR DESCRIPTION
- fix mplab_ipe runner to use the board by serial number
- fix twister handler to pass dev_id to mplab_ipe runner
- fix map file generation to include MPLAB boards

Signed-off-by: Shankar Ramasamy <shankar.ramasamy@microchip.com>