### PR TITLE
ci: test_plan: fix _macro_to_compat

### DIFF
--- a/scripts/ci/test_plan_v2.py
+++ b/scripts/ci/test_plan_v2.py
@@ -1821,7 +1821,10 @@ class DriverCompatStrategy(SelectionStrategy):
               first  _ → ,   →  adi,max14906_gpio
               rest   _ → -   →  adi,max14906-gpio
         """
-        first_sep = macro_value.index("_")
+        first_sep = macro_value.find("_")
+        if first_sep == -1:
+            # for compat values like "ns16550" with no vendor/device separation
+            return macro_value
         vendor = macro_value[:first_sep]
         device = macro_value[first_sep + 1 :].replace("_", "-")
         return f"{vendor},{device}"


### PR DESCRIPTION
fix _macro_to_compat for compatibles, that
dont have a vendor or a separator like
"ns16550".

CI broken in: https://github.com/zephyrproject-rtos/zephyr/actions/runs/27696928058/job/81922537552?pr=111499

https://github.com/zephyrproject-rtos/zephyr/pull/111499