### PR TITLE
scripts: dts: apply ruff format to `gen_defines.py`

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -136,16 +136,6 @@
 "./scripts/coredump/coredump_serial_log_parser.py" = [
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
 ]
-"./scripts/dts/gen_defines.py" = [
-    "B007",     # https://docs.astral.sh/ruff/rules/unused-loop-control-variable
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "E741",     # https://docs.astral.sh/ruff/rules/ambiguous-variable-name
-    "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
-    "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
-    "UP045",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation-optional
-]
 "./scripts/dts/python-devicetree/src/devicetree/_private.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
@@ -863,7 +853,6 @@ exclude = [
     "./samples/subsys/zbus/remote_mock/remote_mock.py",
     "./scripts/check_maintainers.py",
     "./scripts/ci/upload_test_results_es.py",
-    "./scripts/dts/gen_defines.py",
     "./scripts/dts/gen_edt.py",
     "./scripts/dts/python-devicetree/src/devicetree/_private.py",
     "./scripts/dts/python-devicetree/src/devicetree/dtlib.py",

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -14,16 +14,16 @@
 # edtlib. This will keep this script simple.
 
 import argparse
-from collections import defaultdict
 import os
 import pathlib
 import pickle
 import re
 import sys
-from typing import Iterable, NoReturn, Optional
+from collections import defaultdict
+from collections.abc import Iterable
+from typing import NoReturn
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'python-devicetree',
-                                'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'python-devicetree', 'src'))
 
 import edtlib_logger
 from devicetree import edtlib
@@ -61,8 +61,10 @@ def main():
             if 'zephyr,memory-region' in node.props:
                 region = node.props['zephyr,memory-region'].val
                 if region in regions:
-                    sys.exit(f"ERROR: Duplicate 'zephyr,memory-region' ({region}) properties "
-                             f"between {regions[region].path} and {node.path}")
+                    sys.exit(
+                        f"ERROR: Duplicate 'zephyr,memory-region' ({region}) properties "
+                        f"between {regions[region].path} and {node.path}"
+                    )
                 regions[region] = node
 
         for node in sorted_nodes:
@@ -72,30 +74,33 @@ def main():
             out_dt_define(f"{node.z_path_id}_PATH", f'"{escape(node.path)}"')
 
             out_comment("Node's name with unit-address:")
-            out_dt_define(f"{node.z_path_id}_FULL_NAME",
-                          f'"{escape(node.name)}"')
-            out_dt_define(f"{node.z_path_id}_FULL_NAME_UNQUOTED",
-                          f'{escape(node.name)}')
-            out_dt_define(f"{node.z_path_id}_FULL_NAME_TOKEN",
-                          f'{edtlib.str_as_token(escape(node.name))}')
-            out_dt_define(f"{node.z_path_id}_FULL_NAME_UPPER_TOKEN",
-                          f'{edtlib.str_as_token(escape(node.name)).upper()}')
+            out_dt_define(f"{node.z_path_id}_FULL_NAME", f'"{escape(node.name)}"')
+            out_dt_define(f"{node.z_path_id}_FULL_NAME_UNQUOTED", f'{escape(node.name)}')
+            out_dt_define(
+                f"{node.z_path_id}_FULL_NAME_TOKEN", f'{edtlib.str_as_token(escape(node.name))}'
+            )
+            out_dt_define(
+                f"{node.z_path_id}_FULL_NAME_UPPER_TOKEN",
+                f'{edtlib.str_as_token(escape(node.name)).upper()}',
+            )
 
             if node.parent is not None:
                 out_comment(f"Node parent ({node.parent.path}) identifier:")
-                out_dt_define(f"{node.z_path_id}_PARENT",
-                              f"DT_{node.parent.z_path_id}")
+                out_dt_define(f"{node.z_path_id}_PARENT", f"DT_{node.parent.z_path_id}")
 
-                out_comment(f"Node's index in its parent's list of children:")
-                out_dt_define(f"{node.z_path_id}_CHILD_IDX",
-                              node.parent.child_index(node))
+                out_comment("Node's index in its parent's list of children:")
+                out_dt_define(f"{node.z_path_id}_CHILD_IDX", node.parent.child_index(node))
 
             out_comment("Helpers for dealing with node labels:")
             out_dt_define(f"{node.z_path_id}_NODELABEL_NUM", len(node.labels))
-            out_dt_define(f"{node.z_path_id}_FOREACH_NODELABEL(fn)",
-                          " ".join(f"fn({nodelabel})" for nodelabel in node.labels))
-            out_dt_define(f"{node.z_path_id}_FOREACH_NODELABEL_VARGS(fn, ...)",
-                          " ".join(f"fn({nodelabel}, __VA_ARGS__)" for nodelabel in node.labels))
+            out_dt_define(
+                f"{node.z_path_id}_FOREACH_NODELABEL(fn)",
+                " ".join(f"fn({nodelabel})" for nodelabel in node.labels),
+            )
+            out_dt_define(
+                f"{node.z_path_id}_FOREACH_NODELABEL_VARGS(fn, ...)",
+                " ".join(f"fn({nodelabel}, __VA_ARGS__)" for nodelabel in node.labels),
+            )
 
             write_parent(node)
             write_children(node)
@@ -122,8 +127,7 @@ def node_z_path_id(node: edtlib.Node) -> str:
 
     components = ["N"]
     if node.parent is not None:
-        components.extend(f"S_{str2ident(component)}" for component in
-                          node.path.split("/")[1:])
+        components.extend(f"S_{str2ident(component)}" for component in node.path.split("/")[1:])
 
     return "_".join(components)
 
@@ -132,10 +136,8 @@ def parse_args() -> argparse.Namespace:
     # Returns parsed command-line arguments
 
     parser = argparse.ArgumentParser(allow_abbrev=False)
-    parser.add_argument("--header-out", required=True,
-                        help="path to write header to")
-    parser.add_argument("--edt-pickle",
-                        help="path to read pickled edtlib.EDT object from")
+    parser.add_argument("--header-out", required=True, help="path to write header to")
+    parser.add_argument("--edt-pickle", help="path to read pickled edtlib.EDT object from")
 
     return parser.parse_args()
 
@@ -158,8 +160,7 @@ Node dependency ordering (ordinal and path):
 
     for scc in edt.scc_order:
         if len(scc) > 1:
-            err("cycle in devicetree involving "
-                + ", ".join(node.path for node in scc))
+            err("cycle in devicetree involving " + ", ".join(node.path for node in scc))
         s += f"  {scc[0].dep_ordinal:<3} {scc[0].path}\n"
 
     s += """
@@ -210,13 +211,12 @@ Binding (compatible = {node.matching_compat}):
         # inconvenient when we want to do things like quote snippets
         # of .dtsi files within the descriptions, or otherwise
         # include the string "*/".
-        s += ("\n(Descriptions have moved to the Devicetree Bindings Index\n"
-              "in the documentation.)\n")
+        s += "\n(Descriptions have moved to the Devicetree Bindings Index\nin the documentation.)\n"
 
     out_comment(s)
 
 
-def relativize(path) -> Optional[str]:
+def relativize(path) -> str | None:
     # If 'path' is within $ZEPHYR_BASE, returns it relative to $ZEPHYR_BASE,
     # with a "$ZEPHYR_BASE/..." hint at the start of the string. Otherwise,
     # returns 'path' unchanged.
@@ -306,37 +306,37 @@ def write_ranges(node: edtlib.Node) -> None:
     if node.ranges is not None:
         idx_vals.append((f"{path_id}_RANGES_NUM", len(node.ranges)))
 
-    for i,range in enumerate(node.ranges):
+    for i, range in enumerate(node.ranges):
         idx_vals.append((f"{path_id}_RANGES_IDX_{i}_EXISTS", 1))
 
         if "pcie" in node.buses:
             idx_vals.append((f"{path_id}_RANGES_IDX_{i}_VAL_CHILD_BUS_FLAGS_EXISTS", 1))
             idx_macro = f"{path_id}_RANGES_IDX_{i}_VAL_CHILD_BUS_FLAGS"
             idx_value = range.child_bus_addr >> ((range.child_bus_cells - 1) * 32)
-            idx_vals.append((idx_macro,
-                             f"{idx_value} /* {hex(idx_value)} */"))
+            idx_vals.append((idx_macro, f"{idx_value} /* {hex(idx_value)} */"))
         if range.child_bus_addr is not None:
             idx_macro = f"{path_id}_RANGES_IDX_{i}_VAL_CHILD_BUS_ADDRESS"
             if "pcie" in node.buses:
                 idx_value = range.child_bus_addr & ((1 << (range.child_bus_cells - 1) * 32) - 1)
             else:
                 idx_value = range.child_bus_addr
-            idx_vals.append((idx_macro,
-                             f"{idx_value} /* {hex(idx_value)} */"))
+            idx_vals.append((idx_macro, f"{idx_value} /* {hex(idx_value)} */"))
         if range.parent_bus_addr is not None:
             idx_macro = f"{path_id}_RANGES_IDX_{i}_VAL_PARENT_BUS_ADDRESS"
-            idx_vals.append((idx_macro,
-                             f"{range.parent_bus_addr} /* {hex(range.parent_bus_addr)} */"))
+            idx_vals.append(
+                (idx_macro, f"{range.parent_bus_addr} /* {hex(range.parent_bus_addr)} */")
+            )
         if range.length is not None:
             idx_macro = f"{path_id}_RANGES_IDX_{i}_VAL_LENGTH"
-            idx_vals.append((idx_macro,
-                             f"{range.length} /* {hex(range.length)} */"))
+            idx_vals.append((idx_macro, f"{range.length} /* {hex(range.length)} */"))
 
     for macro, val in idx_vals:
         out_dt_define(macro, val)
 
-    out_dt_define(f"{path_id}_FOREACH_RANGE(fn)",
-            " ".join(f"fn(DT_{path_id}, {i})" for i,range in enumerate(node.ranges)))
+    out_dt_define(
+        f"{path_id}_FOREACH_RANGE(fn)",
+        " ".join(f"fn(DT_{path_id}, {i})" for i, range in enumerate(node.ranges)),
+    )
 
 
 def write_regs(node: edtlib.Node) -> None:
@@ -355,8 +355,7 @@ def write_regs(node: edtlib.Node) -> None:
         idx_vals.append((f"{path_id}_REG_IDX_{i}_EXISTS", 1))
         if reg.addr is not None:
             idx_macro = f"{path_id}_REG_IDX_{i}_VAL_ADDRESS"
-            idx_vals.append((idx_macro,
-                             f"{reg.addr} /* {hex(reg.addr)} */"))
+            idx_vals.append((idx_macro, f"{reg.addr} /* {hex(reg.addr)} */"))
             if reg.name:
                 name_vals.append((f"{path_id}_REG_NAME_{reg.name}_EXISTS", 1))
                 name_macro = f"{path_id}_REG_NAME_{reg.name}_VAL_ADDRESS"
@@ -364,8 +363,7 @@ def write_regs(node: edtlib.Node) -> None:
 
         if reg.size is not None:
             idx_macro = f"{path_id}_REG_IDX_{i}_VAL_SIZE"
-            idx_vals.append((idx_macro,
-                             f"{reg.size} /* {hex(reg.size)} */"))
+            idx_vals.append((idx_macro, f"{reg.size} /* {hex(reg.size)} */"))
             if reg.name:
                 name_macro = f"{path_id}_REG_NAME_{reg.name}_VAL_SIZE"
                 name_vals.append((name_macro, f"DT_{idx_macro}"))
@@ -375,20 +373,29 @@ def write_regs(node: edtlib.Node) -> None:
     for macro, val in name_vals:
         out_dt_define(macro, val)
 
-    out_dt_define(f"{path_id}_FOREACH_REG(fn)",
-                  " ".join(f"fn(DT_{path_id}, {i})" for i,reg in enumerate(node.regs)))
+    out_dt_define(
+        f"{path_id}_FOREACH_REG(fn)",
+        " ".join(f"fn(DT_{path_id}, {i})" for i, reg in enumerate(node.regs)),
+    )
 
-    out_dt_define(f"{path_id}_FOREACH_REG_SEP(fn, sep)",
-                  " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{path_id}, {i})"
-                  for i,reg in enumerate(node.regs)))
+    out_dt_define(
+        f"{path_id}_FOREACH_REG_SEP(fn, sep)",
+        " DT_DEBRACKET_INTERNAL sep ".join(
+            f"fn(DT_{path_id}, {i})" for i, reg in enumerate(node.regs)
+        ),
+    )
 
-    out_dt_define(f"{path_id}_FOREACH_REG_VARGS(fn, ...)",
-                  " ".join(f"fn(DT_{path_id}, {i}, __VA_ARGS__)"
-                  for i,reg in enumerate(node.regs)))
+    out_dt_define(
+        f"{path_id}_FOREACH_REG_VARGS(fn, ...)",
+        " ".join(f"fn(DT_{path_id}, {i}, __VA_ARGS__)" for i, reg in enumerate(node.regs)),
+    )
 
-    out_dt_define(f"{path_id}_FOREACH_REG_SEP_VARGS(fn, sep, ...)",
-                  " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{path_id}, {i}, __VA_ARGS__)"
-                  for i,reg in enumerate(node.regs)))
+    out_dt_define(
+        f"{path_id}_FOREACH_REG_SEP_VARGS(fn, sep, ...)",
+        " DT_DEBRACKET_INTERNAL sep ".join(
+            f"fn(DT_{path_id}, {i}, __VA_ARGS__)" for i, reg in enumerate(node.regs)
+        ),
+    )
 
 
 def write_interrupts(node: edtlib.Node) -> None:
@@ -401,8 +408,7 @@ def write_interrupts(node: edtlib.Node) -> None:
     def map_arm_gic_irq_type(irq, irq_num):
         # Maps ARM GIC IRQ (type)+(index) combo to linear IRQ number
         if "type" not in irq.data:
-            err(f"Expected binding for {irq.controller!r} to have 'type' in "
-                "interrupt-cells")
+            err(f"Expected binding for {irq.controller!r} to have 'type' in interrupt-cells")
         irq_type = irq.data["type"]
 
         if irq_type == 0:  # GIC_SPI
@@ -422,17 +428,15 @@ def write_interrupts(node: edtlib.Node) -> None:
         for cell_name, cell_value in irq.data.items():
             name = str2ident(cell_name)
 
-            if cell_name == "irq":
-                if "arm,gic" in irq.controller.compats:
-                    cell_value = map_arm_gic_irq_type(irq, cell_value)
+            if cell_name == "irq" and "arm,gic" in irq.controller.compats:
+                cell_value = map_arm_gic_irq_type(irq, cell_value)
 
             idx_vals.append((f"{path_id}_IRQ_IDX_{i}_EXISTS", 1))
             idx_macro = f"{path_id}_IRQ_IDX_{i}_VAL_{name}"
             idx_vals.append((idx_macro, cell_value))
             idx_vals.append((idx_macro + "_EXISTS", 1))
             if irq.name:
-                name_macro = (
-                    f"{path_id}_IRQ_NAME_{str2ident(irq.name)}_VAL_{name}")
+                name_macro = f"{path_id}_IRQ_NAME_{str2ident(irq.name)}_VAL_{name}"
                 name_vals.append((name_macro, f"DT_{idx_macro}"))
                 name_vals.append((name_macro + "_EXISTS", 1))
 
@@ -465,18 +469,20 @@ def write_compatibles(node: edtlib.Node) -> None:
     # them. The compatibles the node provides are what is important.
 
     for i, compat in enumerate(node.compats):
-        out_dt_define(
-            f"{node.z_path_id}_COMPAT_MATCHES_{str2ident(compat)}", 1)
+        out_dt_define(f"{node.z_path_id}_COMPAT_MATCHES_{str2ident(compat)}", 1)
 
         if node.edt.compat2vendor[compat]:
             out_dt_define(f"{node.z_path_id}_COMPAT_VENDOR_IDX_{i}_EXISTS", 1)
-            out_dt_define(f"{node.z_path_id}_COMPAT_VENDOR_IDX_{i}",
-                          quote_str(node.edt.compat2vendor[compat]))
+            out_dt_define(
+                f"{node.z_path_id}_COMPAT_VENDOR_IDX_{i}", quote_str(node.edt.compat2vendor[compat])
+            )
 
         if node.edt.compat2model[compat]:
             out_dt_define(f"{node.z_path_id}_COMPAT_MODEL_IDX_{i}_EXISTS", 1)
-            out_dt_define(f"{node.z_path_id}_COMPAT_MODEL_IDX_{i}",
-                          quote_str(node.edt.compat2model[compat]))
+            out_dt_define(
+                f"{node.z_path_id}_COMPAT_MODEL_IDX_{i}", quote_str(node.edt.compat2model[compat])
+            )
+
 
 def write_parent(node: edtlib.Node) -> None:
     # Visit all parent nodes.
@@ -486,9 +492,15 @@ def write_parent(node: edtlib.Node) -> None:
             node = node.parent
 
     # Writes helper macros for dealing with node's parent.
-    out_dt_define(f"{node.z_path_id}_FOREACH_ANCESTOR(fn)",
-            " ".join(f"fn(DT_{parent.z_path_id})" for parent in
-            _visit_parent_node(node) if parent is not None))
+    out_dt_define(
+        f"{node.z_path_id}_FOREACH_ANCESTOR(fn)",
+        " ".join(
+            f"fn(DT_{parent.z_path_id})"
+            for parent in _visit_parent_node(node)
+            if parent is not None
+        ),
+    )
+
 
 def write_children(node: edtlib.Node) -> None:
     # Writes helper macros for dealing with node's children.
@@ -517,37 +529,65 @@ def write_children(node: edtlib.Node) -> None:
 
         out_dt_define(f"{node.z_path_id}_CHILD_UNIT_ADDR_INT_{addr}", f"DT_{children[0].z_path_id}")
 
-    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD(fn)",
-            " ".join(f"fn(DT_{child.z_path_id})" for child in
-                node.children.values()))
+    out_dt_define(
+        f"{node.z_path_id}_FOREACH_CHILD(fn)",
+        " ".join(f"fn(DT_{child.z_path_id})" for child in node.children.values()),
+    )
 
-    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_SEP(fn, sep)",
-            " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{child.z_path_id})"
-            for child in node.children.values()))
+    out_dt_define(
+        f"{node.z_path_id}_FOREACH_CHILD_SEP(fn, sep)",
+        " DT_DEBRACKET_INTERNAL sep ".join(
+            f"fn(DT_{child.z_path_id})" for child in node.children.values()
+        ),
+    )
 
-    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_VARGS(fn, ...)",
-            " ".join(f"fn(DT_{child.z_path_id}, __VA_ARGS__)"
-            for child in node.children.values()))
+    out_dt_define(
+        f"{node.z_path_id}_FOREACH_CHILD_VARGS(fn, ...)",
+        " ".join(f"fn(DT_{child.z_path_id}, __VA_ARGS__)" for child in node.children.values()),
+    )
 
-    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_SEP_VARGS(fn, sep, ...)",
-            " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{child.z_path_id}, __VA_ARGS__)"
-            for child in node.children.values()))
+    out_dt_define(
+        f"{node.z_path_id}_FOREACH_CHILD_SEP_VARGS(fn, sep, ...)",
+        " DT_DEBRACKET_INTERNAL sep ".join(
+            f"fn(DT_{child.z_path_id}, __VA_ARGS__)" for child in node.children.values()
+        ),
+    )
 
-    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY(fn)",
-            " ".join(f"fn(DT_{child.z_path_id})"
-            for child in node.children.values() if child.status == "okay"))
+    out_dt_define(
+        f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY(fn)",
+        " ".join(
+            f"fn(DT_{child.z_path_id})"
+            for child in node.children.values()
+            if child.status == "okay"
+        ),
+    )
 
-    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY_SEP(fn, sep)",
-            " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{child.z_path_id})"
-            for child in node.children.values() if child.status == "okay"))
+    out_dt_define(
+        f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY_SEP(fn, sep)",
+        " DT_DEBRACKET_INTERNAL sep ".join(
+            f"fn(DT_{child.z_path_id})"
+            for child in node.children.values()
+            if child.status == "okay"
+        ),
+    )
 
-    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY_VARGS(fn, ...)",
-            " ".join(f"fn(DT_{child.z_path_id}, __VA_ARGS__)"
-            for child in node.children.values() if child.status == "okay"))
+    out_dt_define(
+        f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY_VARGS(fn, ...)",
+        " ".join(
+            f"fn(DT_{child.z_path_id}, __VA_ARGS__)"
+            for child in node.children.values()
+            if child.status == "okay"
+        ),
+    )
 
-    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(fn, sep, ...)",
-            " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{child.z_path_id}, __VA_ARGS__)"
-            for child in node.children.values() if child.status == "okay"))
+    out_dt_define(
+        f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(fn, sep, ...)",
+        " DT_DEBRACKET_INTERNAL sep ".join(
+            f"fn(DT_{child.z_path_id}, __VA_ARGS__)"
+            for child in node.children.values()
+            if child.status == "okay"
+        ),
+    )
 
 
 def write_status(node: edtlib.Node) -> None:
@@ -580,16 +620,22 @@ def write_pinctrls(node: edtlib.Node) -> None:
         out_dt_define(f"{node.z_path_id}_PINCTRL_NAME_{name}_EXISTS", 1)
         out_dt_define(f"{node.z_path_id}_PINCTRL_NAME_{name}_IDX", pc_idx)
         for idx, ph in enumerate(pinctrl.conf_nodes):
-            out_dt_define(f"{node.z_path_id}_PINCTRL_NAME_{name}_IDX_{idx}_PH",
-                          f"DT_{ph.z_path_id}")
+            out_dt_define(
+                f"{node.z_path_id}_PINCTRL_NAME_{name}_IDX_{idx}_PH", f"DT_{ph.z_path_id}"
+            )
 
 
 def write_partition_data(node: edtlib.Node) -> None:
     # Macros for partition nodes (fixed-partitions, fixed-subpartitions, zephyr,mapped-partition)
 
-    if not (node.parent and ("fixed-partitions" in node.parent.compats or
-        "zephyr,mapped-partition" in node.compats or
-        "fixed-subpartitions" in node.parent.compats)):
+    if not (
+        node.parent
+        and (
+            "fixed-partitions" in node.parent.compats
+            or "zephyr,mapped-partition" in node.compats
+            or "fixed-subpartitions" in node.parent.compats
+        )
+    ):
         return
 
     global flash_area_num
@@ -721,27 +767,28 @@ def write_vanilla_props(node: edtlib.Node) -> None:
         plen = prop_len(prop)
         if plen is not None:
             # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM
-            macro2val[f"{macro}_FOREACH_PROP_ELEM(fn)"] = (
-                ' \\\n\t'.join(f'fn(DT_{node.z_path_id}, {prop_id}, {i})'
-                               for i in range(plen)))
+            macro2val[f"{macro}_FOREACH_PROP_ELEM(fn)"] = ' \\\n\t'.join(
+                f'fn(DT_{node.z_path_id}, {prop_id}, {i})' for i in range(plen)
+            )
 
             # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM_SEP
             macro2val[f"{macro}_FOREACH_PROP_ELEM_SEP(fn, sep)"] = (
                 ' DT_DEBRACKET_INTERNAL sep \\\n\t'.join(
-                    f'fn(DT_{node.z_path_id}, {prop_id}, {i})'
-                    for i in range(plen)))
+                    f'fn(DT_{node.z_path_id}, {prop_id}, {i})' for i in range(plen)
+                )
+            )
 
             # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM_VARGS
-            macro2val[f"{macro}_FOREACH_PROP_ELEM_VARGS(fn, ...)"] = (
-                ' \\\n\t'.join(
-                    f'fn(DT_{node.z_path_id}, {prop_id}, {i}, __VA_ARGS__)'
-                    for i in range(plen)))
+            macro2val[f"{macro}_FOREACH_PROP_ELEM_VARGS(fn, ...)"] = ' \\\n\t'.join(
+                f'fn(DT_{node.z_path_id}, {prop_id}, {i}, __VA_ARGS__)' for i in range(plen)
+            )
 
             # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM_SEP_VARGS
             macro2val[f"{macro}_FOREACH_PROP_ELEM_SEP_VARGS(fn, sep, ...)"] = (
                 ' DT_DEBRACKET_INTERNAL sep \\\n\t'.join(
-                    f'fn(DT_{node.z_path_id}, {prop_id}, {i}, __VA_ARGS__)'
-                    for i in range(plen)))
+                    f'fn(DT_{node.z_path_id}, {prop_id}, {i}, __VA_ARGS__)' for i in range(plen)
+                )
+            )
 
             # DT_N_<node-id>_P_<prop-id>_LEN
             macro2val[f"{macro}_LEN"] = plen
@@ -768,7 +815,8 @@ def string_macros(macro: str, val: str):
         # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_TOKEN
         f"{macro}_STRING_TOKEN": as_token,
         # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UPPER_TOKEN
-        f"{macro}_STRING_UPPER_TOKEN": as_token.upper()}
+        f"{macro}_STRING_UPPER_TOKEN": as_token.upper(),
+    }
 
 
 def enum_macros(prop: edtlib.Property, macro: str):
@@ -778,7 +826,11 @@ def enum_macros(prop: edtlib.Property, macro: str):
     spec = prop.spec
     # DT_N_<node-id>_P_<prop-id>_IDX_<i>_ENUM_IDX
     ret = {f"{macro}_IDX_{i}_ENUM_IDX": index for i, index in enumerate(prop.enum_indices)}
-    val = prop.val_as_tokens if spec.enum_tokenizable else (prop.val if isinstance(prop.val, list) else [prop.val])
+    val = (
+        prop.val_as_tokens
+        if spec.enum_tokenizable
+        else (prop.val if isinstance(prop.val, list) else [prop.val])
+    )
 
     for i, subval in enumerate(val):
         # make sure the subval is a formated right.
@@ -821,9 +873,9 @@ def write_dep_info(node: edtlib.Node) -> None:
         if dep_list:
             # Sort the list by dependency ordinal for predictability.
             sorted_list = sorted(dep_list, key=lambda node: node.dep_ordinal)
-            return ("\\\n\t" + " \\\n\t"
-                    .join(f"{n.dep_ordinal}, /* {n.path} */"
-                          for n in sorted_list))
+            return "\\\n\t" + " \\\n\t".join(
+                f"{n.dep_ordinal}, /* {n.path} */" for n in sorted_list
+            )
         else:
             return "/* nothing */"
 
@@ -835,12 +887,10 @@ def write_dep_info(node: edtlib.Node) -> None:
     out_dt_define(f"{node.z_path_id}_ORD_STR_SORTABLE", f"{node.dep_ordinal:0>5}")
 
     out_comment("Ordinals for what this node depends on directly:")
-    out_dt_define(f"{node.z_path_id}_REQUIRES_ORDS",
-                  fmt_dep_list(node.depends_on))
+    out_dt_define(f"{node.z_path_id}_REQUIRES_ORDS", fmt_dep_list(node.depends_on))
 
     out_comment("Ordinals for what depends directly on this node:")
-    out_dt_define(f"{node.z_path_id}_SUPPORTS_ORDS",
-                  fmt_dep_list(node.required_by))
+    out_dt_define(f"{node.z_path_id}_SUPPORTS_ORDS", fmt_dep_list(node.required_by))
 
 
 def prop2value(prop: edtlib.Property) -> edtlib.PropertyValType:
@@ -867,7 +917,7 @@ def prop2value(prop: edtlib.Property) -> edtlib.PropertyValType:
     return None
 
 
-def prop_len(prop: edtlib.Property) -> Optional[int]:
+def prop_len(prop: edtlib.Property) -> int | None:
     # Returns the property's length if and only if we should generate
     # a _LEN macro for the property. Otherwise, returns None.
     #
@@ -894,9 +944,13 @@ def prop_len(prop: edtlib.Property) -> Optional[int]:
         # string is treated as a string-array of length 1.
         return 1
 
-    if (prop.type in ["array", "uint8-array", "string-array",
-                      "phandles", "phandle-array"] and
-                prop.name not in ["ranges", "dma-ranges", "reg", "interrupts"]):
+    if prop.type in [
+        "array",
+        "uint8-array",
+        "string-array",
+        "phandles",
+        "phandle-array",
+    ] and prop.name not in ["ranges", "dma-ranges", "reg", "interrupts"]:
         return len(prop.val)
 
     return None
@@ -965,14 +1019,13 @@ def controller_and_data_macros(entry: edtlib.ControllerAndData, i: int, macro: s
     # DT_N_<node-id>_P_<prop-id>_IDX_<i>_EXISTS
     ret[f"{macro}_IDX_{i}_EXISTS"] = 1
     # DT_N_<node-id>_P_<prop-id>_IDX_<i>_FOREACH_CELL
-    ret[f"{macro}_IDX_{i}_FOREACH_CELL(fn)"] = (
-            ' \\\n\t'.join(f'fn(DT_{node.z_path_id}, {pname}, {i}, {cell})'
-                           for cell in data))
+    ret[f"{macro}_IDX_{i}_FOREACH_CELL(fn)"] = ' \\\n\t'.join(
+        f'fn(DT_{node.z_path_id}, {pname}, {i}, {cell})' for cell in data
+    )
     # DT_N_<node-id>_P_<prop-id>_IDX_<i>_FOREACH_CELL_SEP
-    ret[f"{macro}_IDX_{i}_FOREACH_CELL_SEP(fn, sep)"] = (
-        ' DT_DEBRACKET_INTERNAL sep \\\n\t'.join(
-            f'fn(DT_{node.z_path_id}, {pname}, {i}, {cell})'
-               for cell in data))
+    ret[f"{macro}_IDX_{i}_FOREACH_CELL_SEP(fn, sep)"] = ' DT_DEBRACKET_INTERNAL sep \\\n\t'.join(
+        f'fn(DT_{node.z_path_id}, {pname}, {i}, {cell})' for cell in data
+    )
     # DT_N_<node-id>_P_<prop-id>_IDX_<i>_NUM_CELLS
     ret[f"{macro}_IDX_{i}_NUM_CELLS"] = len(data)
 
@@ -986,14 +1039,15 @@ def controller_and_data_macros(entry: edtlib.ControllerAndData, i: int, macro: s
     # DT_N_<node-id>_P_<prop-id>_NAME_<name>_IDX
     ret[f"{macro}_NAME_{name}_IDX"] = i
     # DT_N_<node-id>_P_<prop-id>_NAME_<name>_FOREACH_CELL
-    ret[f"{macro}_NAME_{name}_FOREACH_CELL(fn)"] = (
-            ' \\\n\t'.join(f'fn(DT_{node.z_path_id}, {pname}, {name}, {cell})'
-                           for cell in data))
+    ret[f"{macro}_NAME_{name}_FOREACH_CELL(fn)"] = ' \\\n\t'.join(
+        f'fn(DT_{node.z_path_id}, {pname}, {name}, {cell})' for cell in data
+    )
     # DT_N_<node-id>_P_<prop-id>_NAME_<name>_FOREACH_CELL_SEP
     ret[f"{macro}_NAME_{name}_FOREACH_CELL_SEP(fn, sep)"] = (
         ' DT_DEBRACKET_INTERNAL sep \\\n\t'.join(
-            f'fn(DT_{node.z_path_id}, {pname}, {name}, {cell})'
-               for cell in data))
+            f'fn(DT_{node.z_path_id}, {pname}, {name}, {cell})' for cell in data
+        )
+    )
     # DT_N_<node-id>_P_<prop-id>_NAME_<name>_NUM_CELLS
     ret[f"{macro}_NAME_{name}_NUM_CELLS"] = len(data)
     # DT_N_<node-id>_P_<prop-id>_IDX_<i>_NAME
@@ -1003,10 +1057,9 @@ def controller_and_data_macros(entry: edtlib.ControllerAndData, i: int, macro: s
     # DT_N_<node-id>_P_<prop-id>_NAME_<NAME>_EXISTS
     ret[f"{macro}_NAME_{name}_EXISTS"] = 1
     # DT_N_<node-id>_P_<prop-id>_NAME_<NAME>_VAL_<VAL>
-    for cell, val in data.items():
+    for cell, _val in data.items():
         cell_ident = str2ident(cell)
-        ret[f"{macro}_NAME_{name}_VAL_{cell_ident}"] = (
-            f"DT_{macro}_IDX_{i}_VAL_{cell_ident}")
+        ret[f"{macro}_NAME_{name}_VAL_{cell_ident}"] = f"DT_{macro}_IDX_{i}_VAL_{cell_ident}"
         ret[f"{macro}_NAME_{name}_VAL_{cell_ident}_EXISTS"] = 1
 
     return ret
@@ -1029,18 +1082,22 @@ def write_global_macros(edt: edtlib.EDT):
     # Global or tree-wide information, such as number of instances
     # with status "okay" for each compatible, is printed here.
 
-
     out_comment("Macros for iterating over all nodes and enabled nodes")
-    out_dt_define("FOREACH_HELPER(fn)",
-                  " ".join(f"fn(DT_{node.z_path_id})" for node in edt.nodes))
-    out_dt_define("FOREACH_OKAY_HELPER(fn)",
-                  " ".join(f"fn(DT_{node.z_path_id})" for node in edt.nodes
-                           if node.status == "okay"))
-    out_dt_define("FOREACH_VARGS_HELPER(fn, ...)",
-                  " ".join(f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in edt.nodes))
-    out_dt_define("FOREACH_OKAY_VARGS_HELPER(fn, ...)",
-                  " ".join(f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in edt.nodes
-                           if node.status == "okay"))
+    out_dt_define("FOREACH_HELPER(fn)", " ".join(f"fn(DT_{node.z_path_id})" for node in edt.nodes))
+    out_dt_define(
+        "FOREACH_OKAY_HELPER(fn)",
+        " ".join(f"fn(DT_{node.z_path_id})" for node in edt.nodes if node.status == "okay"),
+    )
+    out_dt_define(
+        "FOREACH_VARGS_HELPER(fn, ...)",
+        " ".join(f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in edt.nodes),
+    )
+    out_dt_define(
+        "FOREACH_OKAY_VARGS_HELPER(fn, ...)",
+        " ".join(
+            f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in edt.nodes if node.status == "okay"
+        ),
+    )
 
     n_okay_macros = {}
     for_each_macros = {}
@@ -1057,24 +1114,24 @@ def write_global_macros(edt: edtlib.EDT):
 
         # Helpers for non-INST for-each macros that take node
         # identifiers as arguments.
-        for_each_macros[f"DT_FOREACH_OKAY_{ident}(fn)"] = (
-            " ".join(f"fn(DT_{node.z_path_id})"
-                     for node in okay_nodes))
-        for_each_macros[f"DT_FOREACH_OKAY_VARGS_{ident}(fn, ...)"] = (
-            " ".join(f"fn(DT_{node.z_path_id}, __VA_ARGS__)"
-                     for node in okay_nodes))
+        for_each_macros[f"DT_FOREACH_OKAY_{ident}(fn)"] = " ".join(
+            f"fn(DT_{node.z_path_id})" for node in okay_nodes
+        )
+        for_each_macros[f"DT_FOREACH_OKAY_VARGS_{ident}(fn, ...)"] = " ".join(
+            f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in okay_nodes
+        )
 
         # Helpers for INST versions of for-each macros, which take
         # instance numbers. We emit separate helpers for these because
         # avoiding an intermediate node_id --> instance number
         # conversion in the preprocessor helps to keep the macro
         # expansions simpler. That hopefully eases debugging.
-        for_each_macros[f"DT_FOREACH_OKAY_INST_{ident}(fn)"] = (
-            " ".join(f"fn({edt.compat2nodes[compat].index(node)})"
-                     for node in okay_nodes))
-        for_each_macros[f"DT_FOREACH_OKAY_INST_VARGS_{ident}(fn, ...)"] = (
-            " ".join(f"fn({edt.compat2nodes[compat].index(node)}, __VA_ARGS__)"
-                     for node in okay_nodes))
+        for_each_macros[f"DT_FOREACH_OKAY_INST_{ident}(fn)"] = " ".join(
+            f"fn({edt.compat2nodes[compat].index(node)})" for node in okay_nodes
+        )
+        for_each_macros[f"DT_FOREACH_OKAY_INST_VARGS_{ident}(fn, ...)"] = " ".join(
+            f"fn({edt.compat2nodes[compat].index(node)}, __VA_ARGS__)" for node in okay_nodes
+        )
 
     for compat, nodes in edt.compat2nodes.items():
         for node in nodes:
@@ -1121,8 +1178,7 @@ def write_global_macros(edt: edtlib.EDT):
     out_comment('Bus information for status "okay" nodes of each compatible\n')
     for compat, buses in compat2buses.items():
         for bus in buses:
-            out_define(
-                f"DT_COMPAT_{str2ident(compat)}_BUS_{str2ident(bus)}", 1)
+            out_define(f"DT_COMPAT_{str2ident(compat)}_BUS_{str2ident(bus)}", 1)
 
     bus_by_id = {}
     for node in edt.nodes:
@@ -1141,7 +1197,6 @@ def write_global_macros(edt: edtlib.EDT):
     # For each bus controller and each bus type it exposes, count descendant
     # nodes whose resolved on-bus matches that bus.
     for bus_id, bus_node in bus_by_id.items():
-
         for bus in bus_node.buses:
             bus_ident = str2ident(bus)
 
@@ -1169,17 +1224,17 @@ def str2ident(s: str) -> str:
     return re.sub('[-,.@/+]', '_', s.lower())
 
 
-def list2init(l: Iterable[str]) -> str:
+def list2init(values: Iterable[str]) -> str:
     # Converts 'l', a Python list (or iterable), to a C array initializer
 
-    return "{" + ", ".join(l) + "}"
+    return "{" + ", ".join(values) + "}"
 
 
 def out_dt_define(
     macro: str,
     val: str,
-    width: Optional[int] = None,
-    deprecation_msg: Optional[str] = None,
+    width: int | None = None,
+    deprecation_msg: str | None = None,
 ) -> str:
     # Writes "#define DT_<macro> <val>" to the header file
     #
@@ -1200,14 +1255,14 @@ def out_dt_define(
 def out_define(
     macro: str,
     val: str,
-    width: Optional[int] = None,
-    deprecation_msg: Optional[str] = None,
+    width: int | None = None,
+    deprecation_msg: str | None = None,
 ) -> None:
     # Helper for out_dt_define(). Outputs "#define <macro> <val>",
     # adds a deprecation message if given, and allocates whitespace
     # unless told not to.
 
-    warn = fr' __WARN("{deprecation_msg}")' if deprecation_msg else ""
+    warn = rf' __WARN("{deprecation_msg}")' if deprecation_msg else ""
 
     if width:
         s = f"#define {macro.ljust(width)}{warn} {val}"
@@ -1246,6 +1301,7 @@ def out_comment(s: str, blank_before=True) -> None:
         #
         #   /* foo bar */
         print(f"/* {s} */", file=header_file)
+
 
 ESCAPE_TABLE = str.maketrans(
     {


### PR DESCRIPTION
Apply ruff format to `gen_defines.py` and remove it from `.ruff-excludes.toml` so that the file is checked during compliance checks.