### PR TITLE
MAINTAINERS: Add devbhavej as fuel-gauge Collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1984,6 +1984,8 @@ Documentation Infrastructure:
     - aaronemassey
     - DBS06
     - teburd
+  collaborators:
+    - devbhavej
   files:
     - drivers/fuel_gauge/
     - dts/bindings/fuel-gauge/


### PR DESCRIPTION
This commit adds devbhavej (myself) as collaborator for fuel-gauge drivers as nominated by maintainers of fuel-gauge.