### PR TITLE
authenticaion: fido2: introduce clientPin

### DIFF
--- a/doc/services/authentication/fido2/index.rst
+++ b/doc/services/authentication/fido2/index.rst
@@ -22,6 +22,7 @@ The subsystem currently supports the following CTAP2 commands:
 - ``authenticatorMakeCredential``
 - ``authenticatorGetAssertion``
 - ``authenticatorGetInfo``
+- ``authenticatorClientPIN``
 - ``authenticatorGetNextAssertion``
 - ``authenticatorSelection``
 

--- a/include/zephyr/authentication/fido2/fido2_storage.h
+++ b/include/zephyr/authentication/fido2/fido2_storage.h
@@ -155,6 +155,13 @@ int fido2_storage_sign_count_increment(const uint8_t *cred_id, size_t cred_id_le
 				       uint32_t *new_count);
 
 /**
+ * @brief Get remaining PIN retries
+ * @param retries Number of remaining PIN attempts.
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_storage_pin_retries_get(uint8_t *retries);
+
+/**
  * @endcond
  */
 

--- a/include/zephyr/authentication/fido2/fido2_storage.h
+++ b/include/zephyr/authentication/fido2/fido2_storage.h
@@ -162,6 +162,12 @@ int fido2_storage_sign_count_increment(const uint8_t *cred_id, size_t cred_id_le
 int fido2_storage_pin_retries_get(uint8_t *retries);
 
 /**
+ * @brief Decrement remaining PIN retries
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_storage_pin_retries_decrement(void);
+
+/**
  * @brief Reset remaining PIN retries
  * @return 0 on success, negative errno on failure
  */

--- a/include/zephyr/authentication/fido2/fido2_storage.h
+++ b/include/zephyr/authentication/fido2/fido2_storage.h
@@ -162,6 +162,26 @@ int fido2_storage_sign_count_increment(const uint8_t *cred_id, size_t cred_id_le
 int fido2_storage_pin_retries_get(uint8_t *retries);
 
 /**
+ * @brief Reset remaining PIN retries
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_storage_pin_retries_reset(void);
+
+/**
+ * @brief Set PIN hash
+ * @param pin_hash Stored PIN hash.
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_storage_pin_set(uint8_t pin_hash[FIDO2_PIN_HASH_SIZE]);
+
+/**
+ * @brief Get stored PIN hash
+ * @param pin_hash Stored PIN hash.
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_storage_pin_get(uint8_t pin_hash[FIDO2_PIN_HASH_SIZE]);
+
+/**
  * @endcond
  */
 

--- a/include/zephyr/authentication/fido2/fido2_types.h
+++ b/include/zephyr/authentication/fido2/fido2_types.h
@@ -76,6 +76,18 @@ extern "C" {
 /** @brief Maximum number of supported versions */
 #define FIDO2_MAX_VERSIONS 4
 
+/** @brief P-256 public key export size */
+#define FIDO2_P256_UNCOMPRESSED_KEY_SIZE 65
+
+/** @brief P-256 coordinate size */
+#define FIDO2_P256_COORD_SIZE 32
+
+/** @brief EC point prefix */
+#define FIDO2_EC_POINT_UNCOMPRESSED 0x04
+
+/** @brief ASN.1-encoded ECDSA signature length */
+#define FIDO2_ECDSA_SIG_MAX_SIZE 72
+
 /** @brief Credential extension HMAC secret */
 #define FIDO2_EXT_HMAC_SECRET     BIT(0)
 /** @brief Credential extension largeBlobKey */
@@ -177,9 +189,10 @@ enum fido2_cred_protect {
 
 /** @brief COSE algorithm identifiers */
 enum fido2_cose_alg {
-	FIDO2_COSE_ES256 = -7,   /**< ECDSA w/ SHA-256 */
-	FIDO2_COSE_EDDSA = -8,   /**< EdDSA */
-	FIDO2_COSE_RS256 = -257, /**< RSASSA-PKCS1-v1_5 w/ SHA-256 */
+	FIDO2_COSE_ES256 = -7,           /**< ECDSA w/ SHA-256 */
+	FIDO2_COSE_EDDSA = -8,           /**< EdDSA */
+	FIDO2_COSE_ECDHES_HKDF256 = -25, /**< ECDH ES w/ HKDF */
+	FIDO2_COSE_RS256 = -257,         /**< RSASSA-PKCS1-v1_5 w/ SHA-256 */
 };
 
 /** @brief A stored FIDO2 credential */

--- a/include/zephyr/authentication/fido2/fido2_types.h
+++ b/include/zephyr/authentication/fido2/fido2_types.h
@@ -272,6 +272,8 @@ struct fido2_device_info {
 	uint8_t num_pin_uv_auth_protocols;
 	/** Remaining PIN retry attempts. */
 	uint8_t pin_retries;
+	/** Current minimum PIN length */
+	uint8_t min_pin_length;
 };
 
 #ifdef __cplusplus

--- a/samples/subsys/authentication/fido2/README.rst
+++ b/samples/subsys/authentication/fido2/README.rst
@@ -15,8 +15,10 @@ websites that support WebAuthn, such as `webauthn.io <https://webauthn.io>`_.
 Supported operations:
 
 - ``authenticatorMakeCredential``
-- ``authenticatorGetAssertion`` and ``authenticatorGetNextAssertion``
+- ``authenticatorGetAssertion``
 - ``authenticatorGetInfo``
+- ``authenticatorClientPIN``
+- ``authenticatorGetNextAssertion``
 - ``authenticatorSelection``
 
 Requirements
@@ -48,17 +50,11 @@ For the Black Pill STM32H523 board:
    :goals: build flash
 
 After flashing, connect the board to your computer via its USB port.
-Open `webauthn.io <https://webauthn.io>`_ in Chrome or Firefox:
+Open `webauthn.io <https://webauthn.io>`_ in any WebAuthn-compatible
+browser (e.g., Chrome, Edge, Firefox, Safari) and follow these steps:
 
 1. Enter a username and click **Register**.
-2. The browser prompts for a security key. Press the user-presence button
-   on the board.
-3. Registration should succeed.
-4. Click **Authenticate** and press the button again to log in.
-
-.. note::
-
-   This sample does not implement clientPin. Chromium-based browsers may
-   require clientPin for discoverable credentials, even though it is not
-   enforced by the FIDO2 specification. Use non-discoverable credentials
-   on Chrome, or use Firefox or Safari.
+2. The browser prompts for a security key. Press the user-presence button on the board.
+3. Setup or enter a PIN if prompted.
+4. Registration should succeed.
+5. Click **Authenticate**, press the button again, and enter pin to log in.

--- a/subsys/authentication/fido2/CMakeLists.txt
+++ b/subsys/authentication/fido2/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library_sources(
   fido2_core.c
   fido2_cbor.c
   fido2_crypto.c
+  fido2_clientpin.c
 )
 
 add_subdirectory(attestation)

--- a/subsys/authentication/fido2/Kconfig
+++ b/subsys/authentication/fido2/Kconfig
@@ -13,6 +13,8 @@ menuconfig FIDO2
 	select PSA_WANT_ALG_ECDH
 	select PSA_WANT_ALG_SHA_256
 	select PSA_WANT_ALG_GCM
+	select PSA_WANT_ALG_HMAC
+	select PSA_WANT_ALG_CBC_NO_PADDING
 	select PSA_WANT_ECC_SECP_R1_256
 	help
 	  Enable the FIDO2/CTAP2 authenticator subsystem.
@@ -104,6 +106,13 @@ config FIDO2_PIN_MAX_RETRIES
 	help
 	  Maximum number of attempts left before PIN is disabled.
 	  Must not be more than 8 per the CTAP2 specification.
+
+config FIDO2_MIN_PIN_LENGTH
+	int "Minimum PIN length"
+	default 4
+	range 4 63
+	help
+	  Minimum PIN length enforced by the authenticator.
 
 rsource "attestation/Kconfig"
 rsource "transport/Kconfig"

--- a/subsys/authentication/fido2/Kconfig
+++ b/subsys/authentication/fido2/Kconfig
@@ -114,6 +114,12 @@ config FIDO2_MIN_PIN_LENGTH
 	help
 	  Minimum PIN length enforced by the authenticator.
 
+config FIDO2_PIN_TOKEN_TIMEOUT_MS
+	int "pinUvAuthToken usage timeout (ms)"
+	default 30000
+	help
+	  Maximum time in milliseconds a pinUvAuthToken remains valid.
+
 rsource "attestation/Kconfig"
 rsource "transport/Kconfig"
 rsource "up/Kconfig"

--- a/subsys/authentication/fido2/Kconfig
+++ b/subsys/authentication/fido2/Kconfig
@@ -10,6 +10,7 @@ menuconfig FIDO2
 	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE
 	select PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY
 	select PSA_WANT_ALG_ECDSA
+	select PSA_WANT_ALG_ECDH
 	select PSA_WANT_ALG_SHA_256
 	select PSA_WANT_ALG_GCM
 	select PSA_WANT_ECC_SECP_R1_256
@@ -95,6 +96,14 @@ config FIDO2_ALWAYS_UV
 	  including when userVerification is set to "discouraged".
 
 	  This overrides makeCredUvNotRqd
+
+config FIDO2_PIN_MAX_RETRIES
+	int "Maximum PIN retries before lockout"
+	default 8
+	range 1 8
+	help
+	  Maximum number of attempts left before PIN is disabled.
+	  Must not be more than 8 per the CTAP2 specification.
 
 rsource "attestation/Kconfig"
 rsource "transport/Kconfig"

--- a/subsys/authentication/fido2/fido2_cbor.c
+++ b/subsys/authentication/fido2/fido2_cbor.c
@@ -8,12 +8,12 @@
 #include <zephyr/authentication/fido2/fido2_types.h>
 #include <zcbor_encode.h>
 #include <zcbor_decode.h>
-
-#include "fido2_cbor.h"
-#include "fido2_crypto.h"
-#include "zcbor_common.h"
+#include <zcbor_common.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+
+#include "fido2_cbor.h"
 
 LOG_MODULE_DECLARE(fido2, CONFIG_FIDO2_LOG_LEVEL);
 
@@ -71,212 +71,21 @@ LOG_MODULE_DECLARE(fido2, CONFIG_FIDO2_LOG_LEVEL);
 #define GETINFO_KEY_TRANSPORTS                   0x09
 #define GETINFO_KEY_FIRMWARE_VERSION             0x0E
 
-int fido2_cbor_encode_get_info(const struct fido2_device_info *info, uint8_t *cbor_out,
-			       size_t cbor_out_cap, size_t *cbor_out_len)
-{
-	ZCBOR_STATE_E(zs, 5, cbor_out, cbor_out_cap, 1);
-
-	if (!zcbor_map_start_encode(zs, 10)) {
-		return -ENOMEM;
-	}
-
-	/* 0x01: versions */
-	if (!zcbor_uint32_put(zs, GETINFO_KEY_VERSIONS) ||
-	    !zcbor_list_start_encode(zs, info->num_versions)) {
-		return -ENOMEM;
-	}
-	for (int i = 0; i < info->num_versions; ++i) {
-		if (!zcbor_tstr_put_term(zs, info->versions[i], 32)) {
-			return -ENOMEM;
-		}
-	}
-	if (!zcbor_list_end_encode(zs, info->num_versions)) {
-		return -ENOMEM;
-	}
-
-	/* 0x02: extensions */
-	if (info->num_extensions > 0) {
-		if (!zcbor_uint32_put(zs, GETINFO_KEY_EXTENSIONS) ||
-		    !zcbor_list_start_encode(zs, info->num_extensions)) {
-			return -ENOMEM;
-		}
-		for (int i = 0; i < info->num_extensions; ++i) {
-			if (!zcbor_tstr_put_term(zs, info->extensions[i], 64)) {
-				return -ENOMEM;
-			}
-		}
-		if (!zcbor_list_end_encode(zs, info->num_extensions)) {
-			return -ENOMEM;
-		}
-	}
-
-	/* 0x03: aaguid */
-	if (!zcbor_uint32_put(zs, GETINFO_KEY_AAGUID) ||
-	    !zcbor_bstr_encode_ptr(zs, info->aaguid, FIDO2_AAGUID_SIZE)) {
-		return -ENOMEM;
-	}
-
-	/* 0x04: options */
-	uint8_t opt_count = 3; /* rk, up, plat always present */
-
-	if (info->options.uv) {
-		++opt_count;
-	}
-	if (info->options.always_uv) {
-		++opt_count;
-	}
-	if (info->options.cred_mgmt) {
-		++opt_count;
-	}
-	if (info->num_pin_uv_auth_protocols > 0) {
-		++opt_count;
-	}
-	if (info->options.pin_uv_auth_token) {
-		++opt_count;
-	}
-	if (info->options.make_cred_uv_not_rqd) {
-		++opt_count;
-	}
-	if (info->options.no_mc_ga_permissions_with_client_pin) {
-		++opt_count;
-	}
-
-	if (!zcbor_uint32_put(zs, GETINFO_KEY_OPTIONS) || !zcbor_map_start_encode(zs, opt_count)) {
-		return -ENOMEM;
-	}
-	if (!zcbor_tstr_put_lit(zs, "rk") || !zcbor_bool_put(zs, info->options.rk)) {
-		return -ENOMEM;
-	}
-	if (!zcbor_tstr_put_lit(zs, "up") || !zcbor_bool_put(zs, info->options.up)) {
-		return -ENOMEM;
-	}
-	if (info->options.uv) {
-		if (!zcbor_tstr_put_lit(zs, "uv") || !zcbor_bool_put(zs, info->options.uv)) {
-			return -ENOMEM;
-		}
-	}
-	if (!zcbor_tstr_put_lit(zs, "plat") || !zcbor_bool_put(zs, info->options.plat)) {
-		return -ENOMEM;
-	}
-	if (info->options.always_uv) {
-		if (!zcbor_tstr_put_lit(zs, "alwaysUv") || !zcbor_bool_put(zs, true)) {
-			return -ENOMEM;
-		}
-	}
-	if (info->options.cred_mgmt) {
-		if (!zcbor_tstr_put_lit(zs, "credMgmt") ||
-		    !zcbor_bool_put(zs, info->options.cred_mgmt)) {
-			return -ENOMEM;
-		}
-	}
-	/*
-	 * clientPin: false = supported but not set, true = supported and set,
-	 * absent = unsupported. So we check with num_pin_uv_auth_protocols
-	 */
-	if (info->num_pin_uv_auth_protocols > 0) {
-		if (!zcbor_tstr_put_lit(zs, "clientPin") ||
-		    !zcbor_bool_put(zs, info->options.client_pin)) {
-			return -ENOMEM;
-		}
-	}
-	if (info->options.pin_uv_auth_token) {
-		if (!zcbor_tstr_put_lit(zs, "pinUvAuthToken") || !zcbor_bool_put(zs, true)) {
-			return -ENOMEM;
-		}
-	}
-	if (info->options.make_cred_uv_not_rqd) {
-		if (!zcbor_tstr_put_lit(zs, "makeCredUvNotRqd") || !zcbor_bool_put(zs, true)) {
-			return -ENOMEM;
-		}
-	}
-	if (info->options.no_mc_ga_permissions_with_client_pin) {
-		if (!zcbor_tstr_put_lit(zs, "noMcGaPermissionsWithClientPin") ||
-		    !zcbor_bool_put(zs, true)) {
-			return -ENOMEM;
-		}
-	}
-	if (!zcbor_map_end_encode(zs, opt_count)) {
-		return -ENOMEM;
-	}
-
-	/* 0x05: maxMsgSize */
-	if (!zcbor_uint32_put(zs, GETINFO_KEY_MAX_MSG_SIZE) ||
-	    !zcbor_uint32_put(zs, info->max_msg_size)) {
-		return -ENOMEM;
-	}
-
-	/* 0x06: pinUvAuthProtocols */
-	if (info->num_pin_uv_auth_protocols > 0) {
-		if (!zcbor_uint32_put(zs, GETINFO_KEY_PIN_UV_AUTH_PROTOCOLS) ||
-		    !zcbor_list_start_encode(zs, info->num_pin_uv_auth_protocols)) {
-			return -ENOMEM;
-		}
-		for (int i = 0; i < info->num_pin_uv_auth_protocols; ++i) {
-			if (!zcbor_uint32_put(zs, info->pin_uv_auth_protocols[i])) {
-				return -ENOMEM;
-			}
-		}
-		if (!zcbor_list_end_encode(zs, info->num_pin_uv_auth_protocols)) {
-			return -ENOMEM;
-		}
-	}
-
-	/* 0x07: maxCredentialCountInList */
-	if (!zcbor_uint32_put(zs, GETINFO_KEY_MAX_CREDENTIAL_COUNT_IN_LIST) ||
-	    !zcbor_uint32_put(zs, info->max_credential_count)) {
-		return -ENOMEM;
-	}
-
-	/* 0x08: maxCredentialIdLength */
-	if (!zcbor_uint32_put(zs, GETINFO_KEY_MAX_CREDENTIAL_ID_LENGTH) ||
-	    !zcbor_uint32_put(zs, info->max_credential_id_length)) {
-		return -ENOMEM;
-	}
-
-	/* 0x09: transports */
-	if (info->transports != 0) {
-		uint8_t transport_count = 0;
-
-		if (info->transports & FIDO2_TRANSPORT_USB) {
-			++transport_count;
-		}
-		if (info->transports & FIDO2_TRANSPORT_BLE) {
-			++transport_count;
-		}
-		if (info->transports & FIDO2_TRANSPORT_NFC) {
-			++transport_count;
-		}
-		if (!zcbor_uint32_put(zs, GETINFO_KEY_TRANSPORTS) ||
-		    !zcbor_list_start_encode(zs, transport_count)) {
-			return -ENOMEM;
-		}
-		if ((info->transports & FIDO2_TRANSPORT_BLE) && !zcbor_tstr_put_lit(zs, "ble")) {
-			return -ENOMEM;
-		}
-		if ((info->transports & FIDO2_TRANSPORT_NFC) && !zcbor_tstr_put_lit(zs, "nfc")) {
-			return -ENOMEM;
-		}
-		if ((info->transports & FIDO2_TRANSPORT_USB) && !zcbor_tstr_put_lit(zs, "usb")) {
-			return -ENOMEM;
-		}
-		if (!zcbor_list_end_encode(zs, transport_count)) {
-			return -ENOMEM;
-		}
-	}
-
-	/* 0x0E: firmwareVersion */
-	if (!zcbor_uint32_put(zs, GETINFO_KEY_FIRMWARE_VERSION) ||
-	    !zcbor_uint32_put(zs, info->firmware_version)) {
-		return -ENOMEM;
-	}
-
-	if (!zcbor_map_end_encode(zs, 10)) {
-		return -ENOMEM;
-	}
-
-	*cbor_out_len = zs->payload - cbor_out;
-	return 0;
-}
+/* authenticatorClientPIN 0x06 */
+#define CLIENTPIN_KEY_PIN_UV_AUTH_PROTOCOL 0x01
+#define CLIENTPIN_KEY_SUB_COMMAND          0x02
+#define CLIENTPIN_KEY_KEY_AGREEMENT        0x03
+#define CLIENTPIN_KEY_PIN_UV_AUTH_PARAM    0x04
+#define CLIENTPIN_KEY_NEW_PIN_ENC          0x05
+#define CLIENTPIN_KEY_PIN_HASH_ENC         0x06
+#define CLIENTPIN_KEY_PERMISSIONS          0x09
+#define CLIENTPIN_KEY_RP_ID                0x0A
+/* authenticatorClientPIN response */
+#define CLIENTPIN_RESP_KEY_AGREEMENT       0x01
+#define CLIENTPIN_RESP_PIN_UV_AUTH_TOKEN   0x02
+#define CLIENTPIN_RESP_PIN_RETRIES         0x03
+#define CLIENTPIN_RESP_POWER_CYCLE_STATE   0x04
+#define CLIENTPIN_RESP_UV_RETRIES          0x05
 
 static int decode_tstr_field(zcbor_state_t *zs, char *out, size_t out_cap)
 {
@@ -295,6 +104,80 @@ static int decode_tstr_field(zcbor_state_t *zs, char *out, size_t out_cap)
 	return 0;
 }
 
+/* Unlike fido2_cbor_encode_cose_key, this one is internal */
+static int decode_cose_key(zcbor_state_t *zs, uint8_t *pub_key, size_t pub_key_size,
+			   size_t *pub_key_len)
+{
+	uint8_t x[FIDO2_P256_COORD_SIZE];
+	uint8_t y[FIDO2_P256_COORD_SIZE];
+	struct zcbor_string str;
+	int32_t key;
+
+	bool has_x = false;
+	bool has_y = false;
+	bool has_alg = false;
+
+	if (!zcbor_map_start_decode(zs)) {
+		return -EBADMSG;
+	}
+
+	while (!zcbor_array_at_end(zs)) {
+		if (!zcbor_int32_decode(zs, &key)) {
+			return -EBADMSG;
+		}
+
+		switch (key) {
+		case 3: {
+			int32_t alg;
+
+			/* We don't need the alg value, we just make sure it exists */
+			if (!zcbor_int32_decode(zs, &alg)) {
+				return -EBADMSG;
+			}
+			has_alg = true;
+			break;
+		}
+		/* -2 (x) = x coordinate */
+		case -2:
+			if (!zcbor_bstr_decode(zs, &str) || str.len != FIDO2_P256_COORD_SIZE) {
+				return -EBADMSG;
+			}
+			memcpy(x, str.value, str.len);
+			has_x = true;
+			break;
+		/* -3 (y) = y coordinate */
+		case -3:
+			if (!zcbor_bstr_decode(zs, &str) || str.len != FIDO2_P256_COORD_SIZE) {
+				return -EBADMSG;
+			}
+			memcpy(y, str.value, str.len);
+			has_y = true;
+			break;
+		default:
+			if (!zcbor_any_skip(zs, NULL)) {
+				return -EBADMSG;
+			}
+			break;
+		}
+	}
+
+	if (!zcbor_map_end_decode(zs)) {
+		return -EBADMSG;
+	}
+
+	if (!has_x || !has_y || !has_alg) {
+		return -EBADMSG;
+	}
+
+	pub_key[0] = FIDO2_EC_POINT_UNCOMPRESSED;
+	memcpy(pub_key + 1, x, FIDO2_P256_COORD_SIZE);
+	memcpy(pub_key + 1 + FIDO2_P256_COORD_SIZE, y, FIDO2_P256_COORD_SIZE);
+	*pub_key_len = FIDO2_P256_UNCOMPRESSED_KEY_SIZE;
+
+	return 0;
+}
+
+/* authenticatorMakeCredential 0x01 operations */
 static int mc_decode_rp(zcbor_state_t *zs, struct fido2_make_credential_params *params)
 {
 	struct zcbor_string str;
@@ -754,6 +637,124 @@ int fido2_cbor_decode_make_credential(const uint8_t *cbor_in, size_t cbor_in_len
 	return 0;
 }
 
+int fido2_cbor_encode_cose_key(const uint8_t *pub_key, size_t pub_key_len, uint8_t *cbor_out,
+			       size_t cbor_out_cap, size_t *cbor_out_len)
+{
+	ZCBOR_STATE_E(zs, 5, cbor_out, cbor_out_cap, 1);
+	const uint8_t *x;
+	const uint8_t *y;
+
+	if (pub_key_len < FIDO2_P256_UNCOMPRESSED_KEY_SIZE ||
+	    pub_key[0] != FIDO2_EC_POINT_UNCOMPRESSED) {
+		return -EINVAL;
+	}
+
+	x = pub_key + 1;
+	y = pub_key + 1 + FIDO2_P256_COORD_SIZE;
+
+	if (!zcbor_map_start_encode(zs, 5)) {
+		return -ENOMEM;
+	}
+
+	/* 1 (kty) = 2 (EC2) */
+	if (!zcbor_int32_put(zs, 1) || !zcbor_int32_put(zs, 2)) {
+		return -ENOMEM;
+	}
+	/* 3 (alg) = -7 (ES256) */
+	if (!zcbor_int32_put(zs, 3) || !zcbor_int32_put(zs, FIDO2_COSE_ES256)) {
+		return -ENOMEM;
+	}
+	/* -1 (crv) = 1 (P-256) */
+	if (!zcbor_int32_put(zs, -1) || !zcbor_int32_put(zs, 1)) {
+		return -ENOMEM;
+	}
+	/* -2 (x) = x coordinate */
+	if (!zcbor_int32_put(zs, -2) || !zcbor_bstr_encode_ptr(zs, x, FIDO2_P256_COORD_SIZE)) {
+		return -ENOMEM;
+	}
+	/* -3 (y) = y coordinate */
+	if (!zcbor_int32_put(zs, -3) || !zcbor_bstr_encode_ptr(zs, y, FIDO2_P256_COORD_SIZE)) {
+		return -ENOMEM;
+	}
+
+	if (!zcbor_map_end_encode(zs, 5)) {
+		return -ENOMEM;
+	}
+
+	*cbor_out_len = zs->payload - cbor_out;
+
+	return 0;
+}
+
+int fido2_cbor_encode_make_credential_resp(const uint8_t *auth_data, size_t auth_data_len,
+					   const struct fido2_attestation_result *att_result,
+					   uint8_t *cbor_out, size_t cbor_out_cap,
+					   size_t *cbor_out_len)
+{
+	ZCBOR_STATE_E(zs, 5, cbor_out, cbor_out_cap, 1);
+
+	uint8_t att_stmt_entries = 0;
+
+	if (att_result->sig != NULL && att_result->sig_len > 0) {
+		att_stmt_entries = 2; /* alg + sig */
+		if (att_result->x5c != NULL && att_result->x5c_len > 0) {
+			att_stmt_entries = 3; /* alg + sig + x5c */
+		}
+	}
+
+	if (!zcbor_map_start_encode(zs, 3)) {
+		return -ENOMEM;
+	}
+
+	/* 0x01: fmt */
+	if (!zcbor_uint32_put(zs, MAKE_CREDENTIAL_RESP_FMT) ||
+	    !zcbor_tstr_put_term(zs, att_result->fmt, FIDO2_ATTESTATION_FMT_MAX_LEN)) {
+		return -ENOMEM;
+	}
+	/* 0x02: authData */
+	if (!zcbor_uint32_put(zs, MAKE_CREDENTIAL_RESP_AUTH_DATA) ||
+	    !zcbor_bstr_encode_ptr(zs, auth_data, auth_data_len)) {
+		return -ENOMEM;
+	}
+	/* 0x03: attStmt */
+	if (!zcbor_uint32_put(zs, MAKE_CREDENTIAL_RESP_ATT_STMT) ||
+	    !zcbor_map_start_encode(zs, att_stmt_entries)) {
+		return -ENOMEM;
+	}
+	if (att_stmt_entries >= 2) {
+		if (!zcbor_tstr_put_lit(zs, "alg") || !zcbor_int32_put(zs, att_result->alg)) {
+			return -ENOMEM;
+		}
+		if (!zcbor_tstr_put_lit(zs, "sig") ||
+		    !zcbor_bstr_encode_ptr(zs, att_result->sig, att_result->sig_len)) {
+			return -ENOMEM;
+		}
+	}
+	if (att_stmt_entries >= 3) {
+		if (!zcbor_tstr_put_lit(zs, "x5c") || !zcbor_list_start_encode(zs, 1)) {
+			return -ENOMEM;
+		}
+		if (!zcbor_bstr_encode_ptr(zs, att_result->x5c, att_result->x5c_len)) {
+			return -ENOMEM;
+		}
+		if (!zcbor_list_end_encode(zs, 1)) {
+			return -ENOMEM;
+		}
+	}
+	if (!zcbor_map_end_encode(zs, att_stmt_entries)) {
+		return -ENOMEM;
+	}
+
+	if (!zcbor_map_end_encode(zs, 3)) {
+		return -ENOMEM;
+	}
+
+	*cbor_out_len = zs->payload - cbor_out;
+
+	return 0;
+}
+
+/* authenticatorGetAssertion 0x02 operations */
 static int ga_decode_allow_list(zcbor_state_t *zs, struct fido2_get_assertion_params *params)
 {
 	struct zcbor_string str;
@@ -1000,123 +1001,6 @@ int fido2_cbor_decode_get_assertion(const uint8_t *cbor_in, size_t cbor_in_len,
 	return 0;
 }
 
-int fido2_cbor_encode_cose_key(const uint8_t *pub_key, size_t pub_key_len, uint8_t *cbor_out,
-			       size_t cbor_out_cap, size_t *cbor_out_len)
-{
-	ZCBOR_STATE_E(zs, 5, cbor_out, cbor_out_cap, 1);
-	const uint8_t *x;
-	const uint8_t *y;
-
-	if (pub_key_len < FIDO2_P256_UNCOMPRESSED_KEY_SIZE ||
-	    pub_key[0] != FIDO2_EC_POINT_UNCOMPRESSED) {
-		return -EINVAL;
-	}
-
-	x = pub_key + 1;
-	y = pub_key + 1 + FIDO2_P256_COORD_SIZE;
-
-	if (!zcbor_map_start_encode(zs, 5)) {
-		return -ENOMEM;
-	}
-
-	/* 1 (kty) = 2 (EC2) */
-	if (!zcbor_int32_put(zs, 1) || !zcbor_int32_put(zs, 2)) {
-		return -ENOMEM;
-	}
-	/* 3 (alg) = -7 (ES256) */
-	if (!zcbor_int32_put(zs, 3) || !zcbor_int32_put(zs, FIDO2_COSE_ES256)) {
-		return -ENOMEM;
-	}
-	/* -1 (crv) = 1 (P-256) */
-	if (!zcbor_int32_put(zs, -1) || !zcbor_int32_put(zs, 1)) {
-		return -ENOMEM;
-	}
-	/* -2 (x) = x coordinate */
-	if (!zcbor_int32_put(zs, -2) || !zcbor_bstr_encode_ptr(zs, x, FIDO2_P256_COORD_SIZE)) {
-		return -ENOMEM;
-	}
-	/* -3 (x) = x coordinate */
-	if (!zcbor_int32_put(zs, -3) || !zcbor_bstr_encode_ptr(zs, y, FIDO2_P256_COORD_SIZE)) {
-		return -ENOMEM;
-	}
-
-	if (!zcbor_map_end_encode(zs, 5)) {
-		return -ENOMEM;
-	}
-
-	*cbor_out_len = zs->payload - cbor_out;
-
-	return 0;
-}
-
-int fido2_cbor_encode_make_credential_resp(const uint8_t *auth_data, size_t auth_data_len,
-					   const struct fido2_attestation_result *att_result,
-					   uint8_t *cbor_out, size_t cbor_out_cap,
-					   size_t *cbor_out_len)
-{
-	ZCBOR_STATE_E(zs, 5, cbor_out, cbor_out_cap, 1);
-
-	uint8_t att_stmt_entries = 0;
-
-	if (att_result->sig != NULL && att_result->sig_len > 0) {
-		att_stmt_entries = 2; /* alg + sig */
-		if (att_result->x5c != NULL && att_result->x5c_len > 0) {
-			att_stmt_entries = 3; /* alg + sig + x5c */
-		}
-	}
-
-	if (!zcbor_map_start_encode(zs, 3)) {
-		return -ENOMEM;
-	}
-
-	/* 0x01: fmt */
-	if (!zcbor_uint32_put(zs, MAKE_CREDENTIAL_RESP_FMT) ||
-	    !zcbor_tstr_put_term(zs, att_result->fmt, FIDO2_ATTESTATION_FMT_MAX_LEN)) {
-		return -ENOMEM;
-	}
-	/* 0x02: authData */
-	if (!zcbor_uint32_put(zs, MAKE_CREDENTIAL_RESP_AUTH_DATA) ||
-	    !zcbor_bstr_encode_ptr(zs, auth_data, auth_data_len)) {
-		return -ENOMEM;
-	}
-	/* 0x03: attStmt */
-	if (!zcbor_uint32_put(zs, MAKE_CREDENTIAL_RESP_ATT_STMT) ||
-	    !zcbor_map_start_encode(zs, att_stmt_entries)) {
-		return -ENOMEM;
-	}
-	if (att_stmt_entries >= 2) {
-		if (!zcbor_tstr_put_lit(zs, "alg") || !zcbor_int32_put(zs, att_result->alg)) {
-			return -ENOMEM;
-		}
-		if (!zcbor_tstr_put_lit(zs, "sig") ||
-		    !zcbor_bstr_encode_ptr(zs, att_result->sig, att_result->sig_len)) {
-			return -ENOMEM;
-		}
-	}
-	if (att_stmt_entries >= 3) {
-		if (!zcbor_tstr_put_lit(zs, "x5c") || !zcbor_list_start_encode(zs, 1)) {
-			return -ENOMEM;
-		}
-		if (!zcbor_bstr_encode_ptr(zs, att_result->x5c, att_result->x5c_len)) {
-			return -ENOMEM;
-		}
-		if (!zcbor_list_end_encode(zs, 1)) {
-			return -ENOMEM;
-		}
-	}
-	if (!zcbor_map_end_encode(zs, att_stmt_entries)) {
-		return -ENOMEM;
-	}
-
-	if (!zcbor_map_end_encode(zs, 3)) {
-		return -ENOMEM;
-	}
-
-	*cbor_out_len = zs->payload - cbor_out;
-
-	return 0;
-}
-
 int fido2_cbor_encode_get_assertion_resp(const uint8_t *cred_id, size_t cred_id_len,
 					 const uint8_t *auth_data, size_t auth_data_len,
 					 const uint8_t *sig, size_t sig_len, const uint8_t *user_id,
@@ -1189,6 +1073,422 @@ int fido2_cbor_encode_get_assertion_resp(const uint8_t *cred_id, size_t cred_id_
 	}
 
 	if (!zcbor_map_end_encode(zs, num_entries)) {
+		return -ENOMEM;
+	}
+
+	*cbor_out_len = zs->payload - cbor_out;
+
+	return 0;
+}
+
+/* authenticatorGetInfo 0x04 operations */
+int fido2_cbor_encode_get_info(const struct fido2_device_info *info, uint8_t *cbor_out,
+			       size_t cbor_out_cap, size_t *cbor_out_len)
+{
+	ZCBOR_STATE_E(zs, 5, cbor_out, cbor_out_cap, 1);
+
+	if (!zcbor_map_start_encode(zs, 10)) {
+		return -ENOMEM;
+	}
+
+	/* 0x01: versions */
+	if (!zcbor_uint32_put(zs, GETINFO_KEY_VERSIONS) ||
+	    !zcbor_list_start_encode(zs, info->num_versions)) {
+		return -ENOMEM;
+	}
+	for (int i = 0; i < info->num_versions; ++i) {
+		if (!zcbor_tstr_put_term(zs, info->versions[i], 32)) {
+			return -ENOMEM;
+		}
+	}
+	if (!zcbor_list_end_encode(zs, info->num_versions)) {
+		return -ENOMEM;
+	}
+
+	/* 0x02: extensions */
+	if (info->num_extensions > 0) {
+		if (!zcbor_uint32_put(zs, GETINFO_KEY_EXTENSIONS) ||
+		    !zcbor_list_start_encode(zs, info->num_extensions)) {
+			return -ENOMEM;
+		}
+		for (int i = 0; i < info->num_extensions; ++i) {
+			if (!zcbor_tstr_put_term(zs, info->extensions[i], 64)) {
+				return -ENOMEM;
+			}
+		}
+		if (!zcbor_list_end_encode(zs, info->num_extensions)) {
+			return -ENOMEM;
+		}
+	}
+
+	/* 0x03: aaguid */
+	if (!zcbor_uint32_put(zs, GETINFO_KEY_AAGUID) ||
+	    !zcbor_bstr_encode_ptr(zs, info->aaguid, FIDO2_AAGUID_SIZE)) {
+		return -ENOMEM;
+	}
+
+	/* 0x04: options */
+	uint8_t opt_count = 3; /* rk, up, plat always present */
+
+	if (info->options.uv) {
+		++opt_count;
+	}
+	if (info->options.always_uv) {
+		++opt_count;
+	}
+	if (info->options.cred_mgmt) {
+		++opt_count;
+	}
+	if (info->num_pin_uv_auth_protocols > 0) {
+		++opt_count;
+	}
+	if (info->options.pin_uv_auth_token) {
+		++opt_count;
+	}
+	if (info->options.make_cred_uv_not_rqd) {
+		++opt_count;
+	}
+	if (info->options.no_mc_ga_permissions_with_client_pin) {
+		++opt_count;
+	}
+
+	if (!zcbor_uint32_put(zs, GETINFO_KEY_OPTIONS) || !zcbor_map_start_encode(zs, opt_count)) {
+		return -ENOMEM;
+	}
+	if (!zcbor_tstr_put_lit(zs, "rk") || !zcbor_bool_put(zs, info->options.rk)) {
+		return -ENOMEM;
+	}
+	if (!zcbor_tstr_put_lit(zs, "up") || !zcbor_bool_put(zs, info->options.up)) {
+		return -ENOMEM;
+	}
+	if (info->options.uv) {
+		if (!zcbor_tstr_put_lit(zs, "uv") || !zcbor_bool_put(zs, info->options.uv)) {
+			return -ENOMEM;
+		}
+	}
+	if (!zcbor_tstr_put_lit(zs, "plat") || !zcbor_bool_put(zs, info->options.plat)) {
+		return -ENOMEM;
+	}
+	if (info->options.always_uv) {
+		if (!zcbor_tstr_put_lit(zs, "alwaysUv") || !zcbor_bool_put(zs, true)) {
+			return -ENOMEM;
+		}
+	}
+	if (info->options.cred_mgmt) {
+		if (!zcbor_tstr_put_lit(zs, "credMgmt") ||
+		    !zcbor_bool_put(zs, info->options.cred_mgmt)) {
+			return -ENOMEM;
+		}
+	}
+	/*
+	 * clientPin: false = supported but not set, true = supported and set,
+	 * absent = unsupported. So we check with num_pin_uv_auth_protocols
+	 */
+	if (info->num_pin_uv_auth_protocols > 0) {
+		if (!zcbor_tstr_put_lit(zs, "clientPin") ||
+		    !zcbor_bool_put(zs, info->options.client_pin)) {
+			return -ENOMEM;
+		}
+	}
+	if (info->options.pin_uv_auth_token) {
+		if (!zcbor_tstr_put_lit(zs, "pinUvAuthToken") || !zcbor_bool_put(zs, true)) {
+			return -ENOMEM;
+		}
+	}
+	if (info->options.make_cred_uv_not_rqd) {
+		if (!zcbor_tstr_put_lit(zs, "makeCredUvNotRqd") || !zcbor_bool_put(zs, true)) {
+			return -ENOMEM;
+		}
+	}
+	if (info->options.no_mc_ga_permissions_with_client_pin) {
+		if (!zcbor_tstr_put_lit(zs, "noMcGaPermissionsWithClientPin") ||
+		    !zcbor_bool_put(zs, true)) {
+			return -ENOMEM;
+		}
+	}
+	if (!zcbor_map_end_encode(zs, opt_count)) {
+		return -ENOMEM;
+	}
+
+	/* 0x05: maxMsgSize */
+	if (!zcbor_uint32_put(zs, GETINFO_KEY_MAX_MSG_SIZE) ||
+	    !zcbor_uint32_put(zs, info->max_msg_size)) {
+		return -ENOMEM;
+	}
+
+	/* 0x06: pinUvAuthProtocols */
+	if (info->num_pin_uv_auth_protocols > 0) {
+		if (!zcbor_uint32_put(zs, GETINFO_KEY_PIN_UV_AUTH_PROTOCOLS) ||
+		    !zcbor_list_start_encode(zs, info->num_pin_uv_auth_protocols)) {
+			return -ENOMEM;
+		}
+		for (int i = 0; i < info->num_pin_uv_auth_protocols; ++i) {
+			if (!zcbor_uint32_put(zs, info->pin_uv_auth_protocols[i])) {
+				return -ENOMEM;
+			}
+		}
+		if (!zcbor_list_end_encode(zs, info->num_pin_uv_auth_protocols)) {
+			return -ENOMEM;
+		}
+	}
+
+	/* 0x07: maxCredentialCountInList */
+	if (!zcbor_uint32_put(zs, GETINFO_KEY_MAX_CREDENTIAL_COUNT_IN_LIST) ||
+	    !zcbor_uint32_put(zs, info->max_credential_count)) {
+		return -ENOMEM;
+	}
+
+	/* 0x08: maxCredentialIdLength */
+	if (!zcbor_uint32_put(zs, GETINFO_KEY_MAX_CREDENTIAL_ID_LENGTH) ||
+	    !zcbor_uint32_put(zs, info->max_credential_id_length)) {
+		return -ENOMEM;
+	}
+
+	/* 0x09: transports */
+	if (info->transports != 0) {
+		uint8_t transport_count = 0;
+
+		if (info->transports & FIDO2_TRANSPORT_USB) {
+			++transport_count;
+		}
+		if (info->transports & FIDO2_TRANSPORT_BLE) {
+			++transport_count;
+		}
+		if (info->transports & FIDO2_TRANSPORT_NFC) {
+			++transport_count;
+		}
+		if (!zcbor_uint32_put(zs, GETINFO_KEY_TRANSPORTS) ||
+		    !zcbor_list_start_encode(zs, transport_count)) {
+			return -ENOMEM;
+		}
+		if ((info->transports & FIDO2_TRANSPORT_BLE) && !zcbor_tstr_put_lit(zs, "ble")) {
+			return -ENOMEM;
+		}
+		if ((info->transports & FIDO2_TRANSPORT_NFC) && !zcbor_tstr_put_lit(zs, "nfc")) {
+			return -ENOMEM;
+		}
+		if ((info->transports & FIDO2_TRANSPORT_USB) && !zcbor_tstr_put_lit(zs, "usb")) {
+			return -ENOMEM;
+		}
+		if (!zcbor_list_end_encode(zs, transport_count)) {
+			return -ENOMEM;
+		}
+	}
+
+	/* 0x0E: firmwareVersion */
+	if (!zcbor_uint32_put(zs, GETINFO_KEY_FIRMWARE_VERSION) ||
+	    !zcbor_uint32_put(zs, info->firmware_version)) {
+		return -ENOMEM;
+	}
+
+	if (!zcbor_map_end_encode(zs, 10)) {
+		return -ENOMEM;
+	}
+
+	*cbor_out_len = zs->payload - cbor_out;
+	return 0;
+}
+
+/* authenticatorClientPIN 0x06 operations */
+int fido2_cbor_decode_client_pin(const uint8_t *cbor_in, size_t cbor_in_len,
+				 struct fido2_client_pin_params *params)
+{
+	ZCBOR_STATE_D(zs, 5, cbor_in, cbor_in_len, 1, 0);
+	struct zcbor_string str;
+	uint32_t key;
+
+	bool has_cmd = false;
+
+	if (!zcbor_map_start_decode(zs)) {
+		return -EBADMSG;
+	}
+
+	while (!zcbor_array_at_end(zs)) {
+		if (!zcbor_uint32_decode(zs, &key)) {
+			return -EBADMSG;
+		}
+
+		switch (key) {
+		case CLIENTPIN_KEY_PIN_UV_AUTH_PROTOCOL: {
+			uint32_t proto;
+
+			if (!zcbor_uint32_decode(zs, &proto)) {
+				return -EBADMSG;
+			}
+			params->pin_uv_auth_protocol = (uint8_t)proto;
+			params->has_pin_uv_auth_protocol = true;
+			break;
+		}
+		case CLIENTPIN_KEY_SUB_COMMAND: {
+			uint32_t cmd;
+
+			if (!zcbor_uint32_decode(zs, &cmd)) {
+				return -EBADMSG;
+			}
+			params->sub_command = (uint8_t)cmd;
+			has_cmd = true;
+			break;
+		}
+		case CLIENTPIN_KEY_KEY_AGREEMENT: {
+			if (decode_cose_key(zs, params->key_agreement,
+					    sizeof(params->key_agreement),
+					    &params->key_agreement_len)) {
+				return -EBADMSG;
+			}
+			params->has_key_agreement = true;
+			break;
+		}
+		case CLIENTPIN_KEY_PIN_UV_AUTH_PARAM:
+			if (!zcbor_bstr_decode(zs, &str)) {
+				return -EBADMSG;
+			}
+			if (str.len > sizeof(params->pin_uv_auth_param)) {
+				return -EBADMSG;
+			}
+			memcpy(params->pin_uv_auth_param, str.value, str.len);
+			params->pin_uv_auth_param_len = str.len;
+			params->has_pin_uv_auth_param = true;
+			break;
+		case CLIENTPIN_KEY_NEW_PIN_ENC:
+			if (!zcbor_bstr_decode(zs, &str)) {
+				return -EBADMSG;
+			}
+			if (str.len > sizeof(params->new_pin_enc)) {
+				return -EBADMSG;
+			}
+			memcpy(params->new_pin_enc, str.value, str.len);
+			params->new_pin_enc_len = str.len;
+			params->has_new_pin_enc = true;
+			break;
+		case CLIENTPIN_KEY_PIN_HASH_ENC:
+			if (!zcbor_bstr_decode(zs, &str)) {
+				return -EBADMSG;
+			}
+			if (str.len > sizeof(params->pin_hash_enc)) {
+				return -EBADMSG;
+			}
+			memcpy(params->pin_hash_enc, str.value, str.len);
+			params->pin_hash_enc_len = str.len;
+			params->has_pin_hash_enc = true;
+			break;
+		case CLIENTPIN_KEY_PERMISSIONS: {
+			uint32_t val;
+
+			if (!zcbor_uint32_decode(zs, &val)) {
+				return -EBADMSG;
+			}
+			params->permissions = (uint8_t)val;
+			params->has_permissions = true;
+			break;
+		}
+		case CLIENTPIN_KEY_RP_ID:
+			if (decode_tstr_field(zs, params->rp_id, sizeof(params->rp_id))) {
+				return -EBADMSG;
+			}
+			params->has_rp_id = true;
+			break;
+		default:
+			if (!zcbor_any_skip(zs, NULL)) {
+				return -EBADMSG;
+			}
+			break;
+		}
+	}
+
+	if (!zcbor_map_end_decode(zs)) {
+		return -EBADMSG;
+	}
+
+	if (!has_cmd) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int fido2_cbor_encode_client_pin_retries(uint8_t retries, bool power_cycle_s, uint8_t *cbor_out,
+					 size_t cbor_out_cap, size_t *cbor_out_len)
+{
+	ZCBOR_STATE_E(zs, 5, cbor_out, cbor_out_cap, 1);
+	int num_entries = 1;
+
+	if (power_cycle_s) {
+		++num_entries;
+	}
+
+	if (!zcbor_map_start_encode(zs, num_entries)) {
+		return -ENOMEM;
+	}
+	if (!zcbor_uint32_put(zs, CLIENTPIN_RESP_PIN_RETRIES) || !zcbor_uint32_put(zs, retries)) {
+		return -ENOMEM;
+	}
+	if (power_cycle_s) {
+		if (!zcbor_uint32_put(zs, CLIENTPIN_RESP_POWER_CYCLE_STATE) ||
+		    !zcbor_uint32_put(zs, power_cycle_s)) {
+			return -ENOMEM;
+		}
+	}
+	if (!zcbor_map_end_encode(zs, num_entries)) {
+		return -ENOMEM;
+	}
+
+	*cbor_out_len = zs->payload - cbor_out;
+
+	return 0;
+}
+
+int fido2_cbor_encode_client_pin_key_agreement(const uint8_t *pub_key, size_t pub_key_len,
+					       uint8_t *cbor_out, size_t cbor_out_cap,
+					       size_t *cbor_out_len)
+{
+	ZCBOR_STATE_E(zs, 5, cbor_out, cbor_out_cap, 1);
+	const uint8_t *x;
+	const uint8_t *y;
+
+	if (pub_key_len < FIDO2_P256_UNCOMPRESSED_KEY_SIZE ||
+	    pub_key[0] != FIDO2_EC_POINT_UNCOMPRESSED) {
+		return -EINVAL;
+	}
+
+	x = pub_key + 1;
+	y = pub_key + 1 + FIDO2_P256_COORD_SIZE;
+
+	if (!zcbor_map_start_encode(zs, 1)) {
+		return -ENOMEM;
+	}
+	if (!zcbor_uint32_put(zs, CLIENTPIN_RESP_KEY_AGREEMENT)) {
+		return -ENOMEM;
+	}
+
+	if (!zcbor_map_start_encode(zs, 5)) {
+		return -ENOMEM;
+	}
+	/* 1 (kty) = 2 (EC2) */
+	if (!zcbor_int32_put(zs, 1) || !zcbor_int32_put(zs, 2)) {
+		return -ENOMEM;
+	}
+	/* 3 (alg) = -25 (although this is not the algorithm actually used) */
+	if (!zcbor_int32_put(zs, 3) || !zcbor_int32_put(zs, FIDO2_COSE_ECDHES_HKDF256)) {
+		return -ENOMEM;
+	}
+	/* -1 (crv) = 1 (P-256) */
+	if (!zcbor_int32_put(zs, -1) || !zcbor_int32_put(zs, 1)) {
+		return -ENOMEM;
+	}
+	/* -2 (x) = x coordinate */
+	if (!zcbor_int32_put(zs, -2) || !zcbor_bstr_encode_ptr(zs, x, FIDO2_P256_COORD_SIZE)) {
+		return -ENOMEM;
+	}
+	/* -3 (y) = y coordinate */
+	if (!zcbor_int32_put(zs, -3) || !zcbor_bstr_encode_ptr(zs, y, FIDO2_P256_COORD_SIZE)) {
+		return -ENOMEM;
+	}
+
+	if (!zcbor_map_end_encode(zs, 5)) {
+		return -ENOMEM;
+	}
+
+	if (!zcbor_map_end_encode(zs, 1)) {
 		return -ENOMEM;
 	}
 

--- a/subsys/authentication/fido2/fido2_cbor.c
+++ b/subsys/authentication/fido2/fido2_cbor.c
@@ -1505,3 +1505,26 @@ int fido2_cbor_encode_client_pin_key_agreement(const uint8_t *pub_key, size_t pu
 
 	return 0;
 }
+
+int fido2_cbor_encode_client_pin_token(const uint8_t *token_enc, size_t token_enc_len,
+				       uint8_t *cbor_out, size_t cbor_out_cap, size_t *cbor_out_len)
+{
+	ZCBOR_STATE_E(zs, 5, cbor_out, cbor_out_cap, 1);
+
+	if (!zcbor_map_start_encode(zs, 1)) {
+		return -ENOMEM;
+	}
+
+	if (!zcbor_uint32_put(zs, CLIENTPIN_RESP_PIN_UV_AUTH_TOKEN) ||
+	    !zcbor_bstr_encode_ptr(zs, token_enc, token_enc_len)) {
+		return -ENOMEM;
+	}
+
+	if (!zcbor_map_end_encode(zs, 1)) {
+		return -ENOMEM;
+	}
+
+	*cbor_out_len = zs->payload - cbor_out;
+
+	return 0;
+}

--- a/subsys/authentication/fido2/fido2_cbor.c
+++ b/subsys/authentication/fido2/fido2_cbor.c
@@ -69,6 +69,7 @@ LOG_MODULE_DECLARE(fido2, CONFIG_FIDO2_LOG_LEVEL);
 #define GETINFO_KEY_MAX_CREDENTIAL_COUNT_IN_LIST 0x07
 #define GETINFO_KEY_MAX_CREDENTIAL_ID_LENGTH     0x08
 #define GETINFO_KEY_TRANSPORTS                   0x09
+#define GETINFO_KEY_MIN_PIN_LENGTH               0x0D
 #define GETINFO_KEY_FIRMWARE_VERSION             0x0E
 
 /* authenticatorClientPIN 0x06 */
@@ -1087,7 +1088,7 @@ int fido2_cbor_encode_get_info(const struct fido2_device_info *info, uint8_t *cb
 {
 	ZCBOR_STATE_E(zs, 5, cbor_out, cbor_out_cap, 1);
 
-	if (!zcbor_map_start_encode(zs, 10)) {
+	if (!zcbor_map_start_encode(zs, 15)) {
 		return -ENOMEM;
 	}
 
@@ -1275,13 +1276,21 @@ int fido2_cbor_encode_get_info(const struct fido2_device_info *info, uint8_t *cb
 		}
 	}
 
+	/* 0x0D: minPINLength */
+	if (info->num_pin_uv_auth_protocols > 0) {
+		if (!zcbor_uint32_put(zs, GETINFO_KEY_MIN_PIN_LENGTH) ||
+		    !zcbor_uint32_put(zs, info->min_pin_length)) {
+			return -ENOMEM;
+		}
+	}
+
 	/* 0x0E: firmwareVersion */
 	if (!zcbor_uint32_put(zs, GETINFO_KEY_FIRMWARE_VERSION) ||
 	    !zcbor_uint32_put(zs, info->firmware_version)) {
 		return -ENOMEM;
 	}
 
-	if (!zcbor_map_end_encode(zs, 10)) {
+	if (!zcbor_map_end_encode(zs, 15)) {
 		return -ENOMEM;
 	}
 

--- a/subsys/authentication/fido2/fido2_cbor.h
+++ b/subsys/authentication/fido2/fido2_cbor.h
@@ -309,4 +309,18 @@ int fido2_cbor_encode_client_pin_key_agreement(const uint8_t *pub_key, size_t pu
 					       uint8_t *cbor_out, size_t cbor_out_cap,
 					       size_t *cbor_out_len);
 
+/**
+ * Encode clientPIN getPINToken response.
+ *
+ * @param token_enc Encrypted pinUvAuthToken
+ * @param token_enc_len Length of encrypted token
+ * @param cbor_out Output buffer
+ * @param cbor_out_cap Buffer size
+ * @param cbor_out_len Encoded length written
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_cbor_encode_client_pin_token(const uint8_t *token_enc, size_t token_enc_len,
+				       uint8_t *cbor_out, size_t cbor_out_cap,
+				       size_t *cbor_out_len);
+
 #endif /* FIDO2_CBOR_H_ */

--- a/subsys/authentication/fido2/fido2_cbor.h
+++ b/subsys/authentication/fido2/fido2_cbor.h
@@ -13,20 +13,14 @@
 /** Maximum number of algorithms in pubKeyCredParams */
 #define FIDO2_MAX_ALGORITHMS 8
 
-/** PIN Protocol 1 auth param size (HMAC-SHA-256 truncated to 16 bytes) */
-#define FIDO2_CBOR_PIN_AUTH_SIZE_P1 16
-
-/** PIN Protocol 2 auth param size (full HMAC-SHA-256, 32 bytes) */
-#define FIDO2_CBOR_PIN_AUTH_SIZE_P2 32
-
 /** Maximum PIN auth param size across all supported protocols */
 #define FIDO2_CBOR_PIN_AUTH_MAX_SIZE 32
 
 /** Maximum encrypted PIN size */
-#define FIDO2_CBOR_PIN_ENC_MAX_SIZE 64
+#define FIDO2_CBOR_PIN_ENC_MAX_SIZE 80
 
 /** Encrypted PIN hash size */
-#define FIDO2_CBOR_PIN_HASH_ENC_SIZE 16
+#define FIDO2_CBOR_PIN_HASH_ENC_SIZE 32
 
 /** Number of attestation statement format identifiers */
 #define FIDO2_CBOR_MAX_ATTESTATION_FORMATS 4
@@ -147,15 +141,60 @@ struct fido2_get_assertion_params {
 };
 
 /**
- * Encode authenticatorGetInfo response.
+ * Decoded authenticatorClientPin request parameters.
+ */
+struct fido2_client_pin_params {
+	/** 0x01: pinUvAuthProtocol */
+	uint8_t pin_uv_auth_protocol;
+	/** Whether pinUvAuthProtocol was present */
+	bool has_pin_uv_auth_protocol;
+	/** 0x02: subCommand */
+	uint8_t sub_command;
+	/** 0x03: keyAgreement */
+	uint8_t key_agreement[FIDO2_P256_UNCOMPRESSED_KEY_SIZE];
+	/** Length of keyAgreement */
+	size_t key_agreement_len;
+	/** Whether keyAgreement was present */
+	bool has_key_agreement;
+	/** 0x04: pinUvAuthParam */
+	uint8_t pin_uv_auth_param[FIDO2_CBOR_PIN_AUTH_MAX_SIZE];
+	/** Length of pinUvAuthParam */
+	size_t pin_uv_auth_param_len;
+	/** Whether pinUvAuthParam was present */
+	bool has_pin_uv_auth_param;
+	/** 0x05: newPinEnc */
+	uint8_t new_pin_enc[FIDO2_CBOR_PIN_ENC_MAX_SIZE];
+	/** newPinEnc len */
+	size_t new_pin_enc_len;
+	/** Whether newPinEnc was present */
+	bool has_new_pin_enc;
+	/** 0x06: pinHashEnc */
+	uint8_t pin_hash_enc[FIDO2_CBOR_PIN_HASH_ENC_SIZE];
+	/** pinHashEnc len */
+	size_t pin_hash_enc_len;
+	/** Whether pinHashEnc was present */
+	bool has_pin_hash_enc;
+	/** 0x09: permissions */
+	uint32_t permissions;
+	/** Whether permissions was present */
+	bool has_permissions;
+	/** 0x0A: rpId */
+	char rp_id[FIDO2_RP_ID_MAX_LEN];
+	/** Whether rpId was present */
+	bool has_rp_id;
+};
+
+/**
+ * Encode a COSE_Key for ES256 (P-256) public key.
  *
- * @param info         Device info to encode
+ * @param pub_key Uncompressed public key
+ * @param pub_key_len Public key length
  * @param cbor_out     Output buffer
  * @param cbor_out_cap Capacity of @p cbor_out in bytes
  * @param cbor_out_len Number of bytes written to @p cbor_out
  * @return 0 on success, negative errno on failure
  */
-int fido2_cbor_encode_get_info(const struct fido2_device_info *info, uint8_t *cbor_out,
+int fido2_cbor_encode_cose_key(const uint8_t *pub_key, size_t pub_key_len, uint8_t *cbor_out,
 			       size_t cbor_out_cap, size_t *cbor_out_len);
 
 /**
@@ -168,17 +207,6 @@ int fido2_cbor_encode_get_info(const struct fido2_device_info *info, uint8_t *cb
  */
 int fido2_cbor_decode_make_credential(const uint8_t *cbor_in, size_t cbor_in_len,
 				      struct fido2_make_credential_params *params);
-
-/**
- * Decode authenticatorGetAssertion request.
- *
- * @param cbor_in CBOR-encoded request
- * @param cbor_in_len Length of request data
- * @param params Output: decoded parameters
- * @return 0 on success, negative errno on failure
- */
-int fido2_cbor_decode_get_assertion(const uint8_t *cbor_in, size_t cbor_in_len,
-				    struct fido2_get_assertion_params *params);
 
 /**
  * Encode authenticatorMakeCredential response.
@@ -195,6 +223,17 @@ int fido2_cbor_encode_make_credential_resp(const uint8_t *auth_data, size_t auth
 					   const struct fido2_attestation_result *att,
 					   uint8_t *cbor_out, size_t cbor_out_cap,
 					   size_t *cbor_out_len);
+
+/**
+ * Decode authenticatorGetAssertion request.
+ *
+ * @param cbor_in CBOR-encoded request
+ * @param cbor_in_len Length of request data
+ * @param params Output: decoded parameters
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_cbor_decode_get_assertion(const uint8_t *cbor_in, size_t cbor_in_len,
+				    struct fido2_get_assertion_params *params);
 
 /**
  * Encode authenticatorGetAssertion response.
@@ -221,16 +260,53 @@ int fido2_cbor_encode_get_assertion_resp(const uint8_t *cred_id, size_t cred_id_
 					 size_t *cbor_out_len);
 
 /**
- * Encode a COSE_Key for ES256 (P-256) public key.
+ * Encode authenticatorGetInfo response.
  *
- * @param pub_key Uncompressed public key
- * @param pub_key_len Public key length
- * @param cbor_out     Output buffer
+ * @param info Device info to encode
+ * @param cbor_out Output buffer
  * @param cbor_out_cap Capacity of @p cbor_out in bytes
  * @param cbor_out_len Number of bytes written to @p cbor_out
  * @return 0 on success, negative errno on failure
  */
-int fido2_cbor_encode_cose_key(const uint8_t *pub_key, size_t pub_key_len, uint8_t *cbor_out,
+int fido2_cbor_encode_get_info(const struct fido2_device_info *info, uint8_t *cbor_out,
 			       size_t cbor_out_cap, size_t *cbor_out_len);
+
+/**
+ * Decode authenticatorClientPIN request.
+ *
+ * @param cbor_in CBOR-encoded request
+ * @param cbor_in_len Length of request data
+ * @param params Output: decoded parameters
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_cbor_decode_client_pin(const uint8_t *cbor_in, size_t cbor_in_len,
+				 struct fido2_client_pin_params *params);
+
+/**
+ * Encode clientPIN getPINRetries response.
+ *
+ * @param retries Remaining PIN retry count
+ * @param power_cycle_s Requires a power cycle
+ * @param cbor_out Output buffer
+ * @param cbor_out_cap Buffer size
+ * @param cbor_out_len Encoded length written
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_cbor_encode_client_pin_retries(uint8_t retries, bool power_cycle_s, uint8_t *cbor_out,
+					 size_t cbor_out_cap, size_t *cbor_out_len);
+
+/**
+ * Encode clientPIN getKeyAgreement response.
+ *
+ * @param pub_key Uncompressed P-256 public key (65 bytes)
+ * @param pub_key_len Public key length
+ * @param cbor_out Output buffer
+ * @param cbor_out_cap Buffer size
+ * @param cbor_out_len Encoded length written
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_cbor_encode_client_pin_key_agreement(const uint8_t *pub_key, size_t pub_key_len,
+					       uint8_t *cbor_out, size_t cbor_out_cap,
+					       size_t *cbor_out_len);
 
 #endif /* FIDO2_CBOR_H_ */

--- a/subsys/authentication/fido2/fido2_clientpin.c
+++ b/subsys/authentication/fido2/fido2_clientpin.c
@@ -187,6 +187,9 @@ int fido2_clientpin_pin_verify_pin_uv_auth_token(const uint8_t *msg, size_t msg_
 						 uint32_t permissions, const char *rp_id)
 {
 
+	if (!pin_uv_auth_token_in_use) {
+		return -EACCES;
+	}
 	if (sys_timepoint_expired(pin_uv_auth_token_timeout)) {
 		stop_using_pin_uv_auth_token();
 		return -EACCES;

--- a/subsys/authentication/fido2/fido2_clientpin.c
+++ b/subsys/authentication/fido2/fido2_clientpin.c
@@ -5,6 +5,8 @@
  */
 #include <zephyr/logging/log.h>
 #include <zephyr/authentication/fido2/fido2_storage.h>
+#include <zephyr/random/random.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "fido2_cbor.h"
@@ -15,6 +17,18 @@ LOG_MODULE_DECLARE(fido2, CONFIG_FIDO2_LOG_LEVEL);
 
 static uint32_t key_agreement_key_id;
 static uint8_t shared_secret[FIDO2_SHA256_SIZE];
+static size_t consecutive_pin_mismatches;
+
+/* pin_uv_auth_token states */
+static uint8_t pin_uv_auth_token[FIDO2_SHA256_SIZE];
+static char pin_uv_auth_token_rp_id[FIDO2_RP_ID_MAX_LEN];
+static uint8_t pin_uv_auth_token_perms;
+static uint8_t pin_uv_auth_protocol;
+static bool pin_uv_auth_token_in_use;
+static bool pin_uv_auth_token_user_present;
+static bool pin_uv_auth_token_user_verified;
+static bool pin_uv_auth_token_timer_running;
+static k_timepoint_t pin_uv_auth_token_timeout;
 
 static int generate_key_agreement(void)
 {
@@ -64,10 +78,9 @@ static int decapsulate(const uint8_t *platform_key, size_t platform_key_len, uin
 	return 0;
 }
 
-static int verify(uint8_t protocol, const uint8_t *msg, size_t msg_len,
+static int verify(const uint8_t *key, const uint8_t *msg, size_t msg_len,
 		  const uint8_t *pin_uv_auth_param, size_t pin_uv_auth_param_len)
 {
-	const uint8_t *key = shared_secret; /* Indirection as key differs for protocol 2 */
 	uint8_t mac[FIDO2_SHA256_SIZE];
 	int ret;
 
@@ -87,14 +100,14 @@ static int decrypt(uint8_t protocol, const uint8_t *ciphertext, size_t ciphertex
 		   uint8_t *plaintext, size_t plaintext_size, size_t *plaintext_len)
 {
 	const uint8_t *key = shared_secret;
-	uint8_t iv[16];
+	uint8_t iv[16] = {0};
 
 	if (protocol == FIDO2_PIN_PROTOCOL_V1) {
 		if (ciphertext_len == 0 || ciphertext_len % 16 != 0 ||
 		    ciphertext_len > plaintext_size) {
 			return -EINVAL;
 		}
-	} else if (FIDO2_PIN_PROTOCOL_V2) {
+	} else if (protocol == FIDO2_PIN_PROTOCOL_V2) {
 		/* TODO: proto 2 */
 		return -EINVAL;
 	}
@@ -103,16 +116,88 @@ static int decrypt(uint8_t protocol, const uint8_t *ciphertext, size_t ciphertex
 					       plaintext_size, plaintext_len);
 }
 
+static int encrypt(uint8_t protocol, const uint8_t *plaintext, size_t plaintext_len,
+		   uint8_t *ciphertext, size_t ciphertext_size, size_t *ciphertext_len)
+{
+	const uint8_t *key = shared_secret;
+	uint8_t iv[16] = {0};
+
+	if (protocol == FIDO2_PIN_PROTOCOL_V1) {
+		if (plaintext_len == 0 || ciphertext_size < plaintext_len) {
+			return -EINVAL;
+		}
+	} else if (protocol == FIDO2_PIN_PROTOCOL_V2) {
+		/* TODO: proto 2 */
+		return -EINVAL;
+	}
+
+	return fido2_crypto_aes256_cbc_encrypt(key, iv, plaintext, plaintext_len, ciphertext,
+					       ciphertext_size, ciphertext_len);
+}
+
+static void reset_pin_uv_auth_token(void)
+{
+	sys_csrand_get(pin_uv_auth_token, sizeof(pin_uv_auth_token));
+
+	pin_uv_auth_token_perms = 0;
+	pin_uv_auth_token_in_use = false;
+	pin_uv_auth_token_user_present = false;
+	pin_uv_auth_token_user_verified = false;
+	pin_uv_auth_token_timer_running = false;
+	memset(pin_uv_auth_token_rp_id, 0, sizeof(pin_uv_auth_token_rp_id));
+}
+
+static void begin_using_pin_uv_auth_token(bool user_present, uint8_t permissions, uint8_t protocol)
+{
+	pin_uv_auth_token_timeout = sys_timepoint_calc(K_MSEC(CONFIG_FIDO2_PIN_TOKEN_TIMEOUT_MS));
+	pin_uv_auth_token_timer_running = true;
+	pin_uv_auth_token_user_present = user_present;
+	pin_uv_auth_token_user_verified = true;
+	pin_uv_auth_token_in_use = true;
+	pin_uv_auth_token_perms = permissions;
+	pin_uv_auth_protocol = protocol;
+}
+
+static void stop_using_pin_uv_auth_token(void)
+{
+	pin_uv_auth_token_perms = 0;
+	pin_uv_auth_token_in_use = false;
+	pin_uv_auth_token_timer_running = false;
+	pin_uv_auth_token_user_verified = false;
+	pin_uv_auth_token_user_present = false;
+	memset(pin_uv_auth_token_rp_id, 0, sizeof(pin_uv_auth_token_rp_id));
+}
+
 int fido2_clientpin_init(void)
 {
+	reset_pin_uv_auth_token();
+
 	return generate_key_agreement();
 }
 
-int fido2_clientpin_pin_is_set(void)
+bool fido2_clientpin_pin_is_set(void)
 {
 	uint8_t hash[FIDO2_PIN_HASH_SIZE];
 
 	return (fido2_storage_pin_get(hash) == 0);
+}
+
+int fido2_clientpin_pin_verify_pin_uv_auth_token(const uint8_t *msg, size_t msg_len,
+						 const uint8_t *auth_param, size_t auth_param_len,
+						 uint32_t permissions, const char *rp_id)
+{
+
+	if (sys_timepoint_expired(pin_uv_auth_token_timeout)) {
+		stop_using_pin_uv_auth_token();
+		return -EACCES;
+	}
+
+	if ((permissions & pin_uv_auth_token_perms) != permissions) {
+		stop_using_pin_uv_auth_token();
+		return -EPERM;
+	}
+
+	return verify(pin_uv_auth_token, msg, msg_len, auth_param, auth_param_len);
 }
 
 /* authenticatorClientPIN subCommands */
@@ -178,7 +263,7 @@ enum fido2_status fido2_clientpin_cmd_set_pin(uint8_t protocol, const uint8_t *p
 		return FIDO2_ERR_INVALID_PARAMETER;
 	}
 
-	ret = verify(protocol, new_pin_enc, new_pin_enc_len, pin_uv_auth_param,
+	ret = verify(shared_secret, new_pin_enc, new_pin_enc_len, pin_uv_auth_param,
 		     protocol == FIDO2_PIN_PROTOCOL_V1 ? FIDO2_PIN_AUTH_SIZE_P1
 						       : FIDO2_PIN_AUTH_SIZE_P2);
 	if (ret) {
@@ -212,6 +297,104 @@ enum fido2_status fido2_clientpin_cmd_set_pin(uint8_t protocol, const uint8_t *p
 	}
 
 	ret = fido2_storage_pin_retries_reset();
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	return FIDO2_OK;
+}
+
+enum fido2_status fido2_clientpin_cmd_get_pin_token(uint8_t protocol, const uint8_t *platform_key,
+						    size_t platform_key_len,
+						    const uint8_t *pin_hash_enc,
+						    size_t pin_hash_enc_len, uint8_t *cbor_out,
+						    size_t cbor_out_cap, size_t *cbor_out_len)
+{
+	uint8_t retries;
+	uint8_t pin_hash_dec[FIDO2_PIN_HASH_SIZE];
+	size_t pin_hash_dec_len;
+	uint8_t stored_pin_hash[FIDO2_PIN_HASH_SIZE];
+	uint8_t token_enc[FIDO2_PIN_TOKEN_ENC_MAX_SIZE];
+	size_t token_enc_len;
+	int ret;
+
+	if (!fido2_clientpin_pin_is_set()) {
+		return FIDO2_ERR_PIN_AUTH_INVALID;
+	}
+
+	ret = fido2_storage_pin_retries_get(&retries);
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	if (retries == 0) {
+		return FIDO2_ERR_PIN_BLOCKED;
+	}
+
+	ret = decapsulate(platform_key, platform_key_len, protocol);
+	if (ret) {
+		return FIDO2_ERR_INVALID_PARAMETER;
+	}
+
+	ret = fido2_storage_pin_retries_decrement();
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	ret = decrypt(protocol, pin_hash_enc, pin_hash_enc_len, pin_hash_dec, FIDO2_PIN_HASH_SIZE,
+		      &pin_hash_dec_len);
+	if (ret) {
+		return FIDO2_ERR_PIN_AUTH_INVALID;
+	}
+
+	ret = fido2_storage_pin_get(stored_pin_hash);
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	if (memcmp(pin_hash_dec, stored_pin_hash, FIDO2_PIN_HASH_SIZE) != 0) {
+		ret = generate_key_agreement();
+		if (ret) {
+			return FIDO2_ERR_OTHER;
+		}
+
+		ret = fido2_storage_pin_retries_get(&retries);
+		if (ret) {
+			return FIDO2_ERR_OTHER;
+		}
+
+		if (retries == 0) {
+			return FIDO2_ERR_PIN_BLOCKED;
+		}
+
+		++consecutive_pin_mismatches;
+		if (consecutive_pin_mismatches >= 3) {
+			return FIDO2_ERR_PIN_AUTH_BLOCKED;
+		}
+
+		return FIDO2_ERR_PIN_INVALID;
+	}
+
+	consecutive_pin_mismatches = 0;
+
+	ret = fido2_storage_pin_retries_reset();
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	reset_pin_uv_auth_token();
+
+	begin_using_pin_uv_auth_token(false, FIDO2_PIN_PERM_MC | FIDO2_PIN_PERM_GA, protocol);
+
+	ret = encrypt(protocol, pin_uv_auth_token, sizeof(pin_uv_auth_token), token_enc,
+		      sizeof(token_enc), &token_enc_len);
+	if (ret) {
+		stop_using_pin_uv_auth_token();
+		return FIDO2_ERR_OTHER;
+	}
+
+	ret = fido2_cbor_encode_client_pin_token(token_enc, token_enc_len, cbor_out, cbor_out_cap,
+						 cbor_out_len);
 	if (ret) {
 		return FIDO2_ERR_OTHER;
 	}

--- a/subsys/authentication/fido2/fido2_clientpin.c
+++ b/subsys/authentication/fido2/fido2_clientpin.c
@@ -200,6 +200,11 @@ int fido2_clientpin_pin_verify_pin_uv_auth_token(const uint8_t *msg, size_t msg_
 		return -EPERM;
 	}
 
+	if ((pin_uv_auth_token_rp_id[0] != '\0') && (rp_id != NULL) &&
+	    (strcmp(pin_uv_auth_token_rp_id, rp_id) != 0)) {
+		return -EACCES;
+	}
+
 	return verify(pin_uv_auth_token, msg, msg_len, auth_param, auth_param_len);
 }
 
@@ -307,11 +312,10 @@ enum fido2_status fido2_clientpin_cmd_set_pin(uint8_t protocol, const uint8_t *p
 	return FIDO2_OK;
 }
 
-enum fido2_status fido2_clientpin_cmd_get_pin_token(uint8_t protocol, const uint8_t *platform_key,
-						    size_t platform_key_len,
-						    const uint8_t *pin_hash_enc,
-						    size_t pin_hash_enc_len, uint8_t *cbor_out,
-						    size_t cbor_out_cap, size_t *cbor_out_len)
+enum fido2_status fido2_clientpin_cmd_get_pin_token_pin_w_perms(
+	uint8_t protocol, const uint8_t *platform_key, size_t platform_key_len,
+	const uint8_t *pin_hash_enc, size_t pin_hash_enc_len, uint8_t permissions,
+	const char *rp_id, uint8_t *cbor_out, size_t cbor_out_cap, size_t *cbor_out_len)
 {
 	uint8_t retries;
 	uint8_t pin_hash_dec[FIDO2_PIN_HASH_SIZE];
@@ -387,7 +391,13 @@ enum fido2_status fido2_clientpin_cmd_get_pin_token(uint8_t protocol, const uint
 
 	reset_pin_uv_auth_token();
 
-	begin_using_pin_uv_auth_token(false, FIDO2_PIN_PERM_MC | FIDO2_PIN_PERM_GA, protocol);
+	begin_using_pin_uv_auth_token(false, permissions, protocol);
+
+	/* Ignored for getPinToken */
+	if (rp_id != NULL) {
+		strncpy(pin_uv_auth_token_rp_id, rp_id, sizeof(pin_uv_auth_token_rp_id) - 1);
+		pin_uv_auth_token_rp_id[sizeof(pin_uv_auth_token_rp_id) - 1] = '\0';
+	}
 
 	ret = encrypt(protocol, pin_uv_auth_token, sizeof(pin_uv_auth_token), token_enc,
 		      sizeof(token_enc), &token_enc_len);

--- a/subsys/authentication/fido2/fido2_clientpin.c
+++ b/subsys/authentication/fido2/fido2_clientpin.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Siratul Islam <siratul.islam@linux.dev>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/logging/log.h>
+#include <zephyr/authentication/fido2/fido2_storage.h>
+
+#include "fido2_cbor.h"
+#include "fido2_crypto.h"
+#include "fido2_clientpin.h"
+
+LOG_MODULE_DECLARE(fido2, CONFIG_FIDO2_LOG_LEVEL);
+
+static uint32_t key_agreement_key_id;
+
+static int generate_key_agreement(void)
+{
+	int ret;
+
+	ret = fido2_crypto_ecdh_generate_keypair(&key_agreement_key_id);
+	if (ret) {
+		LOG_ERR("KeyAgreement key gen failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int fido2_clientpin_init(void)
+{
+	return generate_key_agreement();
+}
+
+enum fido2_status fido2_clientpin_cmd_get_retries(uint8_t *cbor_out, size_t cbor_out_cap,
+						  size_t *cbor_out_len)
+{
+	uint8_t retries;
+	int ret;
+
+	ret = fido2_storage_pin_retries_get(&retries);
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	ret = fido2_cbor_encode_client_pin_retries(retries, false, cbor_out, cbor_out_cap,
+						   cbor_out_len);
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	return FIDO2_OK;
+}
+
+enum fido2_status fido2_clientpin_cmd_get_key_agreement(uint8_t *cbor_out, size_t cbor_out_cap,
+							size_t *cbor_out_len)
+{
+	uint8_t pub_key[FIDO2_P256_UNCOMPRESSED_KEY_SIZE];
+	size_t pub_key_len;
+	int ret;
+
+	ret = fido2_crypto_export_pubkey(key_agreement_key_id, pub_key, sizeof(pub_key),
+					 &pub_key_len);
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	ret = fido2_cbor_encode_client_pin_key_agreement(pub_key, pub_key_len, cbor_out,
+							 cbor_out_cap, cbor_out_len);
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	return FIDO2_OK;
+}

--- a/subsys/authentication/fido2/fido2_clientpin.c
+++ b/subsys/authentication/fido2/fido2_clientpin.c
@@ -5,6 +5,7 @@
  */
 #include <zephyr/logging/log.h>
 #include <zephyr/authentication/fido2/fido2_storage.h>
+#include <string.h>
 
 #include "fido2_cbor.h"
 #include "fido2_crypto.h"
@@ -13,10 +14,18 @@
 LOG_MODULE_DECLARE(fido2, CONFIG_FIDO2_LOG_LEVEL);
 
 static uint32_t key_agreement_key_id;
+static uint8_t shared_secret[FIDO2_SHA256_SIZE];
 
 static int generate_key_agreement(void)
 {
 	int ret;
+
+	if (key_agreement_key_id != 0) {
+		ret = fido2_crypto_destroy_key(key_agreement_key_id);
+		if (ret) {
+			return ret;
+		}
+	}
 
 	ret = fido2_crypto_ecdh_generate_keypair(&key_agreement_key_id);
 	if (ret) {
@@ -27,11 +36,86 @@ static int generate_key_agreement(void)
 	return 0;
 }
 
+static int decapsulate(const uint8_t *platform_key, size_t platform_key_len, uint8_t protocol)
+{
+	uint8_t z[FIDO2_SHA256_SIZE];
+	size_t z_len;
+	int ret;
+
+	ret = fido2_crypto_ecdh_agree(key_agreement_key_id, platform_key, platform_key_len, z,
+				      &z_len);
+	if (ret) {
+		LOG_ERR("ECDH agreement failed: %d", ret);
+		return ret;
+	}
+
+	if (protocol == FIDO2_PIN_PROTOCOL_V1) {
+		ret = fido2_crypto_sha256(z, z_len, shared_secret);
+		if (ret) {
+			return ret;
+		}
+	} else if (protocol == FIDO2_PIN_PROTOCOL_V2) {
+		/* TODO: proto 2 */
+		return -EINVAL;
+	} else {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int verify(uint8_t protocol, const uint8_t *msg, size_t msg_len,
+		  const uint8_t *pin_uv_auth_param, size_t pin_uv_auth_param_len)
+{
+	const uint8_t *key = shared_secret; /* Indirection as key differs for protocol 2 */
+	uint8_t mac[FIDO2_SHA256_SIZE];
+	int ret;
+
+	ret = fido2_crypto_hmac_sha256(key, FIDO2_SHA256_SIZE, msg, msg_len, mac);
+	if (ret) {
+		return ret;
+	}
+
+	if (memcmp(mac, pin_uv_auth_param, pin_uv_auth_param_len) != 0) {
+		return -EACCES;
+	}
+
+	return 0;
+}
+
+static int decrypt(uint8_t protocol, const uint8_t *ciphertext, size_t ciphertext_len,
+		   uint8_t *plaintext, size_t plaintext_size, size_t *plaintext_len)
+{
+	const uint8_t *key = shared_secret;
+	uint8_t iv[16];
+
+	if (protocol == FIDO2_PIN_PROTOCOL_V1) {
+		if (ciphertext_len == 0 || ciphertext_len % 16 != 0 ||
+		    ciphertext_len > plaintext_size) {
+			return -EINVAL;
+		}
+	} else if (FIDO2_PIN_PROTOCOL_V2) {
+		/* TODO: proto 2 */
+		return -EINVAL;
+	}
+
+	return fido2_crypto_aes256_cbc_decrypt(key, iv, ciphertext, ciphertext_len, plaintext,
+					       plaintext_size, plaintext_len);
+}
+
 int fido2_clientpin_init(void)
 {
 	return generate_key_agreement();
 }
 
+int fido2_clientpin_pin_is_set(void)
+{
+	uint8_t hash[FIDO2_PIN_HASH_SIZE];
+
+	return (fido2_storage_pin_get(hash) == 0);
+}
+
+/* authenticatorClientPIN subCommands */
 enum fido2_status fido2_clientpin_cmd_get_retries(uint8_t *cbor_out, size_t cbor_out_cap,
 						  size_t *cbor_out_len)
 {
@@ -67,6 +151,67 @@ enum fido2_status fido2_clientpin_cmd_get_key_agreement(uint8_t *cbor_out, size_
 
 	ret = fido2_cbor_encode_client_pin_key_agreement(pub_key, pub_key_len, cbor_out,
 							 cbor_out_cap, cbor_out_len);
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	return FIDO2_OK;
+}
+
+enum fido2_status fido2_clientpin_cmd_set_pin(uint8_t protocol, const uint8_t *platform_key,
+					      size_t platform_key_len, const uint8_t *new_pin_enc,
+					      size_t new_pin_enc_len,
+					      const uint8_t *pin_uv_auth_param)
+{
+	uint8_t padded_pin[FIDO2_PIN_PADDED_SIZE];
+	size_t padded_pin_len;
+	size_t new_pin_len;
+	uint8_t new_pin_hash[FIDO2_SHA256_SIZE];
+	int ret;
+
+	if (fido2_clientpin_pin_is_set()) {
+		return FIDO2_ERR_PIN_AUTH_INVALID;
+	}
+
+	ret = decapsulate(platform_key, platform_key_len, protocol);
+	if (ret) {
+		return FIDO2_ERR_INVALID_PARAMETER;
+	}
+
+	ret = verify(protocol, new_pin_enc, new_pin_enc_len, pin_uv_auth_param,
+		     protocol == FIDO2_PIN_PROTOCOL_V1 ? FIDO2_PIN_AUTH_SIZE_P1
+						       : FIDO2_PIN_AUTH_SIZE_P2);
+	if (ret) {
+		return FIDO2_ERR_PIN_AUTH_INVALID;
+	}
+
+	ret = decrypt(protocol, new_pin_enc, new_pin_enc_len, padded_pin, sizeof(padded_pin),
+		      &padded_pin_len);
+	if (ret) {
+		return FIDO2_ERR_PIN_AUTH_INVALID;
+	}
+
+	if (padded_pin_len != FIDO2_PIN_PADDED_SIZE) {
+		return FIDO2_ERR_INVALID_PARAMETER;
+	}
+
+	/* Remove trailng 0s */
+	new_pin_len = strnlen((const char *)padded_pin, FIDO2_PIN_PADDED_SIZE);
+	if (new_pin_len < CONFIG_FIDO2_MIN_PIN_LENGTH) {
+		return FIDO2_ERR_PIN_POLICY_VIOLATION;
+	}
+
+	ret = fido2_crypto_sha256(padded_pin, new_pin_len, new_pin_hash);
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	ret = fido2_storage_pin_set(new_pin_hash);
+	if (ret) {
+		return FIDO2_ERR_OTHER;
+	}
+
+	ret = fido2_storage_pin_retries_reset();
 	if (ret) {
 		return FIDO2_ERR_OTHER;
 	}

--- a/subsys/authentication/fido2/fido2_clientpin.h
+++ b/subsys/authentication/fido2/fido2_clientpin.h
@@ -10,13 +10,15 @@
 #include <zephyr/authentication/fido2/fido2_types.h>
 
 /** PIN Protocol 1 auth param size */
-#define FIDO2_PIN_AUTH_SIZE_P1  16
+#define FIDO2_PIN_AUTH_SIZE_P1       16
 /** PIN Protocol 2 auth param size */
-#define FIDO2_PIN_AUTH_SIZE_P2  32
+#define FIDO2_PIN_AUTH_SIZE_P2       32
 /** Maximum PIN auth param size */
-#define FIDO2_PIN_AUTH_MAX_SIZE 32
+#define FIDO2_PIN_AUTH_MAX_SIZE      32
 /** Padded PIN size */
-#define FIDO2_PIN_PADDED_SIZE   64
+#define FIDO2_PIN_PADDED_SIZE        64
+/** Encrypted PIN token size */
+#define FIDO2_PIN_TOKEN_ENC_MAX_SIZE 48
 
 #define FIDO2_CLIENTPIN_GET_PIN_RETRIES           0x01 /**< getPINRetries */
 #define FIDO2_CLIENTPIN_GET_KEY_AGREEMENT         0x02 /**< getKeyAgreement */
@@ -50,9 +52,24 @@ int fido2_clientpin_init(void);
 /**
  * Check if PIN is set.
  *
- * @return 0 on success, negative errno on failure
+ * @return true if PIN is set, false if not.
  */
-int fido2_clientpin_pin_is_set(void);
+bool fido2_clientpin_pin_is_set(void);
+
+/**
+ * Verify a pinUvAuthParam.
+ *
+ * @param msg Message that was authenticated.
+ * @param msg_len Length of @p msg in bytes.
+ * @param auth_param pinUvAuthParam received from the platform.
+ * @param auth_param_len Length of @p auth_param in bytes.
+ * @param permissions Permissions that the token must have.
+ * @param rp_id Relying party ID.
+ * @return 0 on success, negative errno on failure.
+ */
+int fido2_clientpin_pin_verify_pin_uv_auth_token(const uint8_t *msg, size_t msg_len,
+						 const uint8_t *auth_param, size_t auth_param_len,
+						 uint32_t permissions, const char *rp_id);
 
 /**
  * Handle getPINRetries.
@@ -91,5 +108,24 @@ enum fido2_status fido2_clientpin_cmd_set_pin(uint8_t protocol, const uint8_t *p
 					      size_t platform_key_len, const uint8_t *new_pin_enc,
 					      size_t new_pin_enc_len,
 					      const uint8_t *pin_uv_auth_param);
+
+/**
+ * Handle getPinToken.
+ *
+ * @param protocol PIN/UV auth protocol version.
+ * @param platform_key Platform's ECDH public key.
+ * @param platform_key_len Length of @p platform_key in bytes.
+ * @param pin_hash_enc Encrypted PIN hash.
+ * @param pin_hash_enc_len Length of @p pin_hash_enc in bytes.
+ * @param cbor_out Output buffer for the CBOR-encoded response.
+ * @param cbor_out_cap Size of @p cbor_out in bytes.
+ * @param cbor_out_len Set to the number of bytes written to @p cbor_out.
+ * @return FIDO2_OK on success, FIDO2_ERR_* on failure.
+ */
+enum fido2_status fido2_clientpin_cmd_get_pin_token(uint8_t protocol, const uint8_t *platform_key,
+						    size_t platform_key_len,
+						    const uint8_t *pin_hash_enc,
+						    size_t pin_hash_enc_len, uint8_t *cbor_out,
+						    size_t cbor_out_cap, size_t *cbor_out_len);
 
 #endif /* FIDO2_CLIENTPIN_H_ */

--- a/subsys/authentication/fido2/fido2_clientpin.h
+++ b/subsys/authentication/fido2/fido2_clientpin.h
@@ -15,6 +15,8 @@
 #define FIDO2_PIN_AUTH_SIZE_P2  32
 /** Maximum PIN auth param size */
 #define FIDO2_PIN_AUTH_MAX_SIZE 32
+/** Padded PIN size */
+#define FIDO2_PIN_PADDED_SIZE   64
 
 #define FIDO2_CLIENTPIN_GET_PIN_RETRIES           0x01 /**< getPINRetries */
 #define FIDO2_CLIENTPIN_GET_KEY_AGREEMENT         0x02 /**< getKeyAgreement */
@@ -32,12 +34,25 @@
 #define FIDO2_PIN_PERM_LBW  BIT(4) /**< Large Blob Write */
 #define FIDO2_PIN_PERM_ACFG BIT(5) /**< Authenticator Configuration */
 
+/** ClientPIN protocols */
+enum fido2_clientpin_protocols {
+	FIDO2_PIN_PROTOCOL_V1 = 1,
+	FIDO2_PIN_PROTOCOL_V2,
+};
+
 /**
  * Generates the initial ECDH key agreement key pair.
  *
  * @return 0 on success, negative errno on failure
  */
 int fido2_clientpin_init(void);
+
+/**
+ * Check if PIN is set.
+ *
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_clientpin_pin_is_set(void);
 
 /**
  * Handle getPINRetries.
@@ -60,5 +75,21 @@ enum fido2_status fido2_clientpin_cmd_get_retries(uint8_t *cbor_out, size_t cbor
  */
 enum fido2_status fido2_clientpin_cmd_get_key_agreement(uint8_t *cbor_out, size_t cbor_out_cap,
 							size_t *cbor_out_len);
+
+/**
+ * Handle setPIN.
+ *
+ * @param protocol PIN/UV auth protocol version.
+ * @param platform_key Platform's ECDH public key.
+ * @param platform_key_len Length of @p platform_key in bytes.
+ * @param new_pin_enc Encrypted new pin.
+ * @param new_pin_enc_len Length of @p new_pin_enc in bytes.
+ * @param pin_uv_auth_param Result of calling authenticate(shared secret, newPinEnc).
+ * @return FIDO2_OK on success, FIDO2_ERR_* on failure.
+ */
+enum fido2_status fido2_clientpin_cmd_set_pin(uint8_t protocol, const uint8_t *platform_key,
+					      size_t platform_key_len, const uint8_t *new_pin_enc,
+					      size_t new_pin_enc_len,
+					      const uint8_t *pin_uv_auth_param);
 
 #endif /* FIDO2_CLIENTPIN_H_ */

--- a/subsys/authentication/fido2/fido2_clientpin.h
+++ b/subsys/authentication/fido2/fido2_clientpin.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Siratul Islam <siratul.islam@linux.dev>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FIDO2_CLIENTPIN_H_
+#define FIDO2_CLIENTPIN_H_
+
+#include <zephyr/authentication/fido2/fido2_types.h>
+
+/** PIN Protocol 1 auth param size */
+#define FIDO2_PIN_AUTH_SIZE_P1  16
+/** PIN Protocol 2 auth param size */
+#define FIDO2_PIN_AUTH_SIZE_P2  32
+/** Maximum PIN auth param size */
+#define FIDO2_PIN_AUTH_MAX_SIZE 32
+
+#define FIDO2_CLIENTPIN_GET_PIN_RETRIES           0x01 /**< getPINRetries */
+#define FIDO2_CLIENTPIN_GET_KEY_AGREEMENT         0x02 /**< getKeyAgreement */
+#define FIDO2_CLIENTPIN_SET_PIN                   0x03 /**< setPIN */
+#define FIDO2_CLIENTPIN_CHANGE_PIN                0x04 /**< changePIN */
+#define FIDO2_CLIENTPIN_GET_PIN_TOKEN             0x05 /**< getPinToken */
+#define FIDO2_CLIENTPIN_GET_PIN_TOKEN_UV_W_PERMS  0x06 /**< UvWithPermissions */
+#define FIDO2_CLIENTPIN_GET_UV_RETRIES            0x07 /**< getUVRetries */
+#define FIDO2_CLIENTPIN_GET_PIN_TOKEN_PIN_W_PERMS 0x09 /**< PinWithPermissions */
+
+#define FIDO2_PIN_PERM_MC   BIT(0) /**< MakeCredential */
+#define FIDO2_PIN_PERM_GA   BIT(1) /**< GetAssertion */
+#define FIDO2_PIN_PERM_CM   BIT(2) /**< Credential Management */
+#define FIDO2_PIN_PERM_BE   BIT(3) /**< Bio Enrollment */
+#define FIDO2_PIN_PERM_LBW  BIT(4) /**< Large Blob Write */
+#define FIDO2_PIN_PERM_ACFG BIT(5) /**< Authenticator Configuration */
+
+/**
+ * Generates the initial ECDH key agreement key pair.
+ *
+ * @return 0 on success, negative errno on failure
+ */
+int fido2_clientpin_init(void);
+
+/**
+ * Handle getPINRetries.
+ *
+ * @param cbor_out Output buffer for the CBOR-encoded response.
+ * @param cbor_out_cap Size of @p cbor_out in bytes.
+ * @param cbor_out_len Set to the number of bytes written to @p cbor_out.
+ * @return FIDO2_OK on success, FIDO2_ERR_OTHER on failure.
+ */
+enum fido2_status fido2_clientpin_cmd_get_retries(uint8_t *cbor_out, size_t cbor_out_cap,
+						  size_t *cbor_out_len);
+
+/**
+ * Handle KeyAgreement.
+ *
+ * @param cbor_out Output buffer for the CBOR-encoded response.
+ * @param cbor_out_cap Size of @p cbor_out in bytes.
+ * @param cbor_out_len Set to the number of bytes written to @p cbor_out.
+ * @return FIDO2_OK on success, FIDO2_ERR_OTHER on failure.
+ */
+enum fido2_status fido2_clientpin_cmd_get_key_agreement(uint8_t *cbor_out, size_t cbor_out_cap,
+							size_t *cbor_out_len);
+
+#endif /* FIDO2_CLIENTPIN_H_ */

--- a/subsys/authentication/fido2/fido2_clientpin.h
+++ b/subsys/authentication/fido2/fido2_clientpin.h
@@ -110,22 +110,23 @@ enum fido2_status fido2_clientpin_cmd_set_pin(uint8_t protocol, const uint8_t *p
 					      const uint8_t *pin_uv_auth_param);
 
 /**
- * Handle getPinToken.
+ * Handle getPinToken / getPinUvAuthTokenUsingPinWithPermissions.
  *
  * @param protocol PIN/UV auth protocol version.
  * @param platform_key Platform's ECDH public key.
  * @param platform_key_len Length of @p platform_key in bytes.
  * @param pin_hash_enc Encrypted PIN hash.
  * @param pin_hash_enc_len Length of @p pin_hash_enc in bytes.
+ * @param permissions Permissions that the token must have.
+ * @param rp_id Relying party ID.
  * @param cbor_out Output buffer for the CBOR-encoded response.
  * @param cbor_out_cap Size of @p cbor_out in bytes.
  * @param cbor_out_len Set to the number of bytes written to @p cbor_out.
  * @return FIDO2_OK on success, FIDO2_ERR_* on failure.
  */
-enum fido2_status fido2_clientpin_cmd_get_pin_token(uint8_t protocol, const uint8_t *platform_key,
-						    size_t platform_key_len,
-						    const uint8_t *pin_hash_enc,
-						    size_t pin_hash_enc_len, uint8_t *cbor_out,
-						    size_t cbor_out_cap, size_t *cbor_out_len);
+enum fido2_status fido2_clientpin_cmd_get_pin_token_pin_w_perms(
+	uint8_t protocol, const uint8_t *platform_key, size_t platform_key_len,
+	const uint8_t *pin_hash_enc, size_t pin_hash_enc_len, uint8_t permissions,
+	const char *rp_id, uint8_t *cbor_out, size_t cbor_out_cap, size_t *cbor_out_len);
 
 #endif /* FIDO2_CLIENTPIN_H_ */

--- a/subsys/authentication/fido2/fido2_core.c
+++ b/subsys/authentication/fido2/fido2_core.c
@@ -714,7 +714,19 @@ static enum fido2_status handle_client_pin(uint8_t *cbor_in, size_t cbor_in_len,
 			cp_params.key_agreement_len, cp_params.new_pin_enc,
 			cp_params.new_pin_enc_len, cp_params.pin_uv_auth_param);
 	case FIDO2_CLIENTPIN_CHANGE_PIN:
+		/* TODO */
+		return FIDO2_ERR_INVALID_SUBCOMMAND;
 	case FIDO2_CLIENTPIN_GET_PIN_TOKEN:
+		if (!cp_params.has_key_agreement || !cp_params.has_pin_hash_enc) {
+			return FIDO2_ERR_MISSING_PARAMETER;
+		}
+		if (cp_params.has_permissions || cp_params.has_rp_id) {
+			return FIDO2_ERR_INVALID_PARAMETER;
+		}
+		return fido2_clientpin_cmd_get_pin_token(
+			cp_params.pin_uv_auth_protocol, cp_params.key_agreement,
+			cp_params.key_agreement_len, cp_params.pin_hash_enc,
+			cp_params.pin_hash_enc_len, cbor_out, cbor_out_cap, cbor_out_len);
 	case FIDO2_CLIENTPIN_GET_PIN_TOKEN_UV_W_PERMS:
 	case FIDO2_CLIENTPIN_GET_UV_RETRIES:
 	case FIDO2_CLIENTPIN_GET_PIN_TOKEN_PIN_W_PERMS:

--- a/subsys/authentication/fido2/fido2_core.c
+++ b/subsys/authentication/fido2/fido2_core.c
@@ -565,8 +565,9 @@ static enum fido2_status handle_get_assertion(uint8_t *cbor_in, size_t cbor_in_l
 {
 	uint8_t rp_id_hash[FIDO2_SHA256_SIZE];
 	size_t found_creds_count = 0;
-	uint8_t flags = 0;
+	bool user_verified = false;
 	uint16_t num_credentials;
+	uint8_t flags = 0;
 	int ret;
 
 	ret = fido2_cbor_decode_get_assertion(cbor_in, cbor_in_len, &ga_params);
@@ -614,6 +615,44 @@ static enum fido2_status handle_get_assertion(uint8_t *cbor_in, size_t cbor_in_l
 		return FIDO2_ERR_NO_CREDENTIALS;
 	}
 
+	if (ga_params.has_pin_uv_auth_param) {
+		if (ga_params.pin_uv_auth_param_len == 0) {
+			set_runtime_state(FIDO2_RUNTIME_STATE_WAITING_USER_PRESENCE);
+			notify_wire(transport, cid, FIDO2_WIRE_STATUS_UP_NEEDED);
+
+			ret = fido2_up_wait();
+			if (ret) {
+				return FIDO2_ERR_OPERATION_DENIED;
+			}
+
+			set_runtime_state(FIDO2_RUNTIME_STATE_PROCESSING);
+			notify_wire(transport, cid, FIDO2_WIRE_STATUS_PROCESSING);
+
+			return fido2_clientpin_pin_is_set() ? FIDO2_ERR_PIN_INVALID
+							    : FIDO2_ERR_PIN_NOT_SET;
+		}
+		if (!ga_params.has_pin_uv_auth_protocol) {
+			return FIDO2_ERR_MISSING_PARAMETER;
+		}
+
+		ret = fido2_clientpin_pin_verify_pin_uv_auth_token(
+			ga_params.client_data_hash, FIDO2_SHA256_SIZE, ga_params.pin_uv_auth_param,
+			ga_params.pin_uv_auth_param_len, FIDO2_PIN_PERM_GA, ga_params.rp_id);
+		if (ret == -EPERM) {
+			return FIDO2_ERR_UNAUTHORIZED_PERMISSION;
+		}
+		if (ret) {
+			return FIDO2_ERR_PIN_AUTH_INVALID;
+		}
+
+		user_verified = true;
+	} else if (IS_ENABLED(CONFIG_FIDO2_ALWAYS_UV)) {
+		if (fido2_clientpin_pin_is_set()) { /* PIN set but no pinuvauthparam */
+			return FIDO2_ERR_PUAT_REQUIRED;
+		}
+		return FIDO2_ERR_OPERATION_DENIED; /* alwaysUV true, no PIN set */
+	}
+
 	if (ga_params.up) {
 		set_runtime_state(FIDO2_RUNTIME_STATE_WAITING_USER_PRESENCE);
 		notify_wire(transport, cid, FIDO2_WIRE_STATUS_UP_NEEDED);
@@ -630,6 +669,10 @@ static enum fido2_status handle_get_assertion(uint8_t *cbor_in, size_t cbor_in_l
 		notify_wire(transport, cid, FIDO2_WIRE_STATUS_PROCESSING);
 
 		flags = AUTH_DATA_FLAG_UP;
+	}
+
+	if (user_verified) {
+		flags |= AUTH_DATA_FLAG_UV;
 	}
 
 	/* Exclude numberOfCredentials when allowList is pesent or found_creds_count is exactly 1*/
@@ -746,10 +789,13 @@ static enum fido2_status handle_client_pin(uint8_t *cbor_in, size_t cbor_in_len,
 	case FIDO2_CLIENTPIN_GET_PIN_RETRIES:
 		return fido2_clientpin_cmd_get_retries(cbor_out, cbor_out_cap, cbor_out_len);
 	case FIDO2_CLIENTPIN_GET_KEY_AGREEMENT:
+		if (!cp_params.has_pin_uv_auth_protocol) {
+			return FIDO2_ERR_MISSING_PARAMETER;
+		}
 		return fido2_clientpin_cmd_get_key_agreement(cbor_out, cbor_out_cap, cbor_out_len);
 	case FIDO2_CLIENTPIN_SET_PIN:
-		if (!cp_params.has_pin_uv_auth_param || !cp_params.has_new_pin_enc ||
-		    !cp_params.has_key_agreement) {
+		if (!cp_params.has_pin_uv_auth_protocol || !cp_params.has_pin_uv_auth_param ||
+		    !cp_params.has_new_pin_enc || !cp_params.has_key_agreement) {
 			return FIDO2_ERR_MISSING_PARAMETER;
 		}
 		return fido2_clientpin_cmd_set_pin(
@@ -760,7 +806,8 @@ static enum fido2_status handle_client_pin(uint8_t *cbor_in, size_t cbor_in_len,
 		/* TODO */
 		return FIDO2_ERR_INVALID_SUBCOMMAND;
 	case FIDO2_CLIENTPIN_GET_PIN_TOKEN: /* Backwards compatibility */
-		if (!cp_params.has_key_agreement || !cp_params.has_pin_hash_enc) {
+		if (!cp_params.has_pin_uv_auth_protocol || !cp_params.has_key_agreement ||
+		    !cp_params.has_pin_hash_enc) {
 			return FIDO2_ERR_MISSING_PARAMETER;
 		}
 		if (cp_params.has_permissions || cp_params.has_rp_id) {
@@ -775,9 +822,12 @@ static enum fido2_status handle_client_pin(uint8_t *cbor_in, size_t cbor_in_len,
 	case FIDO2_CLIENTPIN_GET_UV_RETRIES:
 		return FIDO2_ERR_INVALID_SUBCOMMAND;
 	case FIDO2_CLIENTPIN_GET_PIN_TOKEN_PIN_W_PERMS:
-		if (!cp_params.has_key_agreement || !cp_params.has_pin_hash_enc ||
-		    !cp_params.has_permissions) {
+		if (!cp_params.has_pin_uv_auth_protocol || !cp_params.has_key_agreement ||
+		    !cp_params.has_pin_hash_enc || !cp_params.has_permissions) {
 			return FIDO2_ERR_MISSING_PARAMETER;
+		}
+		if (cp_params.permissions == 0) {
+			return FIDO2_ERR_INVALID_PARAMETER;
 		}
 		return fido2_clientpin_cmd_get_pin_token_pin_w_perms(
 			cp_params.pin_uv_auth_protocol, cp_params.key_agreement,

--- a/subsys/authentication/fido2/fido2_core.c
+++ b/subsys/authentication/fido2/fido2_core.c
@@ -543,10 +543,6 @@ static enum fido2_status handle_get_assertion(uint8_t *cbor_in, size_t cbor_in_l
 	if (ga_params.has_pin_uv_auth_param) {
 		ga_params.uv = false;
 	}
-	if (ga_params.uv) {
-		LOG_WRN("Rejected GetAssertion: UV not supported");
-		return FIDO2_ERR_OPERATION_DENIED;
-	}
 	if (ga_params.has_enterprise_attestation) {
 		LOG_WRN("Rejected GetAssertion: enterprise attestation not supported");
 		return FIDO2_ERR_INVALID_PARAMETER;
@@ -632,14 +628,15 @@ static enum fido2_status handle_get_info(uint8_t *cbor_out, size_t cbor_out_cap,
 	info.versions[0] = "FIDO_2_0";
 	info.versions[1] = "FIDO_2_1";
 	info.num_versions = 2;
-	info.num_pin_uv_auth_protocols = 0;
+	info.num_pin_uv_auth_protocols = 1;
+	info.pin_uv_auth_protocols[0] = FIDO2_PIN_PROTOCOL_V1;
 	info.max_credential_count = CONFIG_FIDO2_MAX_CREDENTIALS;
 	info.max_msg_size = CONFIG_FIDO2_CBOR_MAX_SIZE;
 	info.max_credential_id_length = FIDO2_CREDENTIAL_ID_MAX_SIZE;
-	info.transports = 0;
-
+	info.min_pin_length = CONFIG_FIDO2_MIN_PIN_LENGTH;
 	info.firmware_version = 0x00010000;
 
+	info.transports = 0;
 	if (IS_ENABLED(CONFIG_FIDO2_TRANSPORT_USB_HID)) {
 		info.transports |= FIDO2_TRANSPORT_USB;
 	}
@@ -647,8 +644,8 @@ static enum fido2_status handle_get_info(uint8_t *cbor_out, size_t cbor_out_cap,
 	info.options.rk = !IS_ENABLED(CONFIG_FIDO2_STORAGE_NONE);
 	info.options.up = true;
 	info.options.plat = false;
-	/* These will depend on config */
-	info.options.uv = false;
+	info.options.pin_uv_auth_token = true;
+	info.options.client_pin = fido2_clientpin_pin_is_set();
 	/* Allow non-UV non-discoverable credential creation */
 	info.options.make_cred_uv_not_rqd = !IS_ENABLED(CONFIG_FIDO2_ALWAYS_UV);
 	/* Force UV even when RP sets userVerification=discouraged */
@@ -708,6 +705,14 @@ static enum fido2_status handle_client_pin(uint8_t *cbor_in, size_t cbor_in_len,
 	case FIDO2_CLIENTPIN_GET_KEY_AGREEMENT:
 		return fido2_clientpin_cmd_get_key_agreement(cbor_out, cbor_out_cap, cbor_out_len);
 	case FIDO2_CLIENTPIN_SET_PIN:
+		if (!cp_params.has_pin_uv_auth_param || !cp_params.has_new_pin_enc ||
+		    !cp_params.has_key_agreement) {
+			return FIDO2_ERR_MISSING_PARAMETER;
+		}
+		return fido2_clientpin_cmd_set_pin(
+			cp_params.pin_uv_auth_protocol, cp_params.key_agreement,
+			cp_params.key_agreement_len, cp_params.new_pin_enc,
+			cp_params.new_pin_enc_len, cp_params.pin_uv_auth_param);
 	case FIDO2_CLIENTPIN_CHANGE_PIN:
 	case FIDO2_CLIENTPIN_GET_PIN_TOKEN:
 	case FIDO2_CLIENTPIN_GET_PIN_TOKEN_UV_W_PERMS:

--- a/subsys/authentication/fido2/fido2_core.c
+++ b/subsys/authentication/fido2/fido2_core.c
@@ -19,6 +19,7 @@
 
 #include "fido2_cbor.h"
 #include "fido2_crypto.h"
+#include "fido2_clientpin.h"
 
 LOG_MODULE_REGISTER(fido2, CONFIG_FIDO2_LOG_LEVEL);
 
@@ -59,6 +60,8 @@ static uint8_t ga_next_rp_id_hash[FIDO2_SHA256_SIZE];
 static uint8_t ga_next_flags;
 static k_timepoint_t ga_next_deadline;
 static bool ga_next_pending;
+/* clientPIN */
+static struct fido2_client_pin_params cp_params;
 
 static uint8_t ctap_tx_frame[CONFIG_FIDO2_CBOR_MAX_SIZE];
 
@@ -687,6 +690,36 @@ static enum fido2_status handle_get_info(uint8_t *cbor_out, size_t cbor_out_cap,
 	return FIDO2_OK;
 }
 
+static enum fido2_status handle_client_pin(uint8_t *cbor_in, size_t cbor_in_len, uint8_t *cbor_out,
+					   size_t cbor_out_cap, size_t *cbor_out_len,
+					   const struct fido2_transport *transport, uint32_t cid)
+{
+	int ret;
+
+	ret = fido2_cbor_decode_client_pin(cbor_in, cbor_in_len, &cp_params);
+	if (ret) {
+		LOG_WRN("ClientPIN CBOR decode failed: %d", ret);
+		return FIDO2_ERR_INVALID_CBOR;
+	}
+
+	switch (cp_params.sub_command) {
+	case FIDO2_CLIENTPIN_GET_PIN_RETRIES:
+		return fido2_clientpin_cmd_get_retries(cbor_out, cbor_out_cap, cbor_out_len);
+	case FIDO2_CLIENTPIN_GET_KEY_AGREEMENT:
+		return fido2_clientpin_cmd_get_key_agreement(cbor_out, cbor_out_cap, cbor_out_len);
+	case FIDO2_CLIENTPIN_SET_PIN:
+	case FIDO2_CLIENTPIN_CHANGE_PIN:
+	case FIDO2_CLIENTPIN_GET_PIN_TOKEN:
+	case FIDO2_CLIENTPIN_GET_PIN_TOKEN_UV_W_PERMS:
+	case FIDO2_CLIENTPIN_GET_UV_RETRIES:
+	case FIDO2_CLIENTPIN_GET_PIN_TOKEN_PIN_W_PERMS:
+	default:
+		return FIDO2_ERR_INVALID_SUBCOMMAND;
+	}
+
+	return FIDO2_OK;
+}
+
 static enum fido2_status handle_get_next_assertion(uint8_t *cbor_out, size_t cbor_out_cap,
 						   size_t *cbor_out_len)
 {
@@ -750,9 +783,8 @@ static enum fido2_status process_command(uint8_t cmd, uint8_t *cbor_in, size_t c
 	case FIDO2_CMD_GET_INFO:
 		return handle_get_info(cbor_out, cbor_out_cap, cbor_out_len);
 	case FIDO2_CMD_CLIENT_PIN:
-		/* TODO: clientPin */
-		*cbor_out_len = 0;
-		return FIDO2_ERR_INVALID_COMMAND;
+		return handle_client_pin(cbor_in, cbor_in_len, cbor_out, cbor_out_cap, cbor_out_len,
+					 transport, cid);
 	case FIDO2_CMD_RESET:
 		/* TODO: Reset */
 		*cbor_out_len = 0;
@@ -864,6 +896,12 @@ int fido2_init(void)
 	ret = fido2_storage_init();
 	if (ret) {
 		LOG_ERR("Storage init failed: %d", ret);
+		return ret;
+	}
+
+	ret = fido2_clientpin_init();
+	if (ret) {
+		LOG_ERR("clientPIN init failed: %d", ret);
 		return ret;
 	}
 

--- a/subsys/authentication/fido2/fido2_core.c
+++ b/subsys/authentication/fido2/fido2_core.c
@@ -324,6 +324,49 @@ handle_make_credential(uint8_t *cbor_in, size_t cbor_in_len, uint8_t *cbor_out, 
 		return FIDO2_ERR_OTHER;
 	}
 
+	if (mc_params.has_pin_uv_auth_param) {
+		if (mc_params.pin_uv_auth_param_len == 0) {
+			set_runtime_state(FIDO2_RUNTIME_STATE_WAITING_USER_PRESENCE);
+			notify_wire(transport, cid, FIDO2_WIRE_STATUS_UP_NEEDED);
+
+			ret = fido2_up_wait();
+			if (ret) {
+				return FIDO2_ERR_OPERATION_DENIED;
+			}
+
+			set_runtime_state(FIDO2_RUNTIME_STATE_PROCESSING);
+			notify_wire(transport, cid, FIDO2_WIRE_STATUS_PROCESSING);
+
+			return fido2_clientpin_pin_is_set() ? FIDO2_ERR_PIN_INVALID
+							    : FIDO2_ERR_PIN_NOT_SET;
+		}
+		if (!mc_params.has_pin_uv_auth_protocol) {
+			return FIDO2_ERR_MISSING_PARAMETER;
+		}
+
+		ret = fido2_clientpin_pin_verify_pin_uv_auth_token(
+			mc_params.client_data_hash, FIDO2_SHA256_SIZE, mc_params.pin_uv_auth_param,
+			mc_params.pin_uv_auth_param_len, FIDO2_PIN_PERM_MC, mc_params.rp_id);
+		if (ret == -EPERM) {
+			return FIDO2_ERR_UNAUTHORIZED_PERMISSION;
+		}
+		if (ret) {
+			return FIDO2_ERR_PIN_AUTH_INVALID;
+		}
+
+		user_verified = true;
+	} else if (fido2_clientpin_pin_is_set()) { /* PIN set but no pinuvauthparam */
+		if (IS_ENABLED(CONFIG_FIDO2_ALWAYS_UV)) {
+			return FIDO2_ERR_PUAT_REQUIRED; /* override makeCredUvNotRqd */
+		}
+
+		if (mc_params.resident_key) { /* makeCredUvNotRqd only applies to non-disco */
+			return FIDO2_ERR_PUAT_REQUIRED;
+		}
+	} else if (IS_ENABLED(CONFIG_FIDO2_ALWAYS_UV)) { /* alwaysUV true, no PIN set */
+		return FIDO2_ERR_OPERATION_DENIED;
+	}
+
 	if (mc_check_exclude_list()) {
 		set_runtime_state(FIDO2_RUNTIME_STATE_WAITING_USER_PRESENCE);
 		notify_wire(transport, cid, FIDO2_WIRE_STATUS_UP_NEEDED);

--- a/subsys/authentication/fido2/fido2_core.c
+++ b/subsys/authentication/fido2/fido2_core.c
@@ -759,20 +759,31 @@ static enum fido2_status handle_client_pin(uint8_t *cbor_in, size_t cbor_in_len,
 	case FIDO2_CLIENTPIN_CHANGE_PIN:
 		/* TODO */
 		return FIDO2_ERR_INVALID_SUBCOMMAND;
-	case FIDO2_CLIENTPIN_GET_PIN_TOKEN:
+	case FIDO2_CLIENTPIN_GET_PIN_TOKEN: /* Backwards compatibility */
 		if (!cp_params.has_key_agreement || !cp_params.has_pin_hash_enc) {
 			return FIDO2_ERR_MISSING_PARAMETER;
 		}
 		if (cp_params.has_permissions || cp_params.has_rp_id) {
 			return FIDO2_ERR_INVALID_PARAMETER;
 		}
-		return fido2_clientpin_cmd_get_pin_token(
+		return fido2_clientpin_cmd_get_pin_token_pin_w_perms(
 			cp_params.pin_uv_auth_protocol, cp_params.key_agreement,
 			cp_params.key_agreement_len, cp_params.pin_hash_enc,
-			cp_params.pin_hash_enc_len, cbor_out, cbor_out_cap, cbor_out_len);
+			cp_params.pin_hash_enc_len, FIDO2_PIN_PERM_MC | FIDO2_PIN_PERM_GA, NULL,
+			cbor_out, cbor_out_cap, cbor_out_len);
 	case FIDO2_CLIENTPIN_GET_PIN_TOKEN_UV_W_PERMS:
 	case FIDO2_CLIENTPIN_GET_UV_RETRIES:
+		return FIDO2_ERR_INVALID_SUBCOMMAND;
 	case FIDO2_CLIENTPIN_GET_PIN_TOKEN_PIN_W_PERMS:
+		if (!cp_params.has_key_agreement || !cp_params.has_pin_hash_enc ||
+		    !cp_params.has_permissions) {
+			return FIDO2_ERR_MISSING_PARAMETER;
+		}
+		return fido2_clientpin_cmd_get_pin_token_pin_w_perms(
+			cp_params.pin_uv_auth_protocol, cp_params.key_agreement,
+			cp_params.key_agreement_len, cp_params.pin_hash_enc,
+			cp_params.pin_hash_enc_len, cp_params.permissions, cp_params.rp_id,
+			cbor_out, cbor_out_cap, cbor_out_len);
 	default:
 		return FIDO2_ERR_INVALID_SUBCOMMAND;
 	}

--- a/subsys/authentication/fido2/fido2_crypto.c
+++ b/subsys/authentication/fido2/fido2_crypto.c
@@ -347,3 +347,24 @@ int fido2_crypto_unwrap_credential(const uint8_t *cred_id,
 
 	return status;
 }
+
+int fido2_crypto_ecdh_generate_keypair(uint32_t *key_id)
+{
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	psa_status_t status;
+	psa_key_id_t id;
+
+	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_DERIVE);
+	psa_set_key_algorithm(&attr, PSA_ALG_ECDH);
+	psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
+	psa_set_key_bits(&attr, FIDO2_ES256_KEY_BITS);
+
+	status = psa_generate_key(&attr, &id);
+	psa_reset_key_attributes(&attr);
+
+	if (status == PSA_SUCCESS) {
+		*key_id = id;
+	}
+
+	return status;
+}

--- a/subsys/authentication/fido2/fido2_crypto.c
+++ b/subsys/authentication/fido2/fido2_crypto.c
@@ -62,6 +62,7 @@ static psa_status_t ensure_wrap_key(void)
 
 	status = psa_generate_key(&attr, &key_id);
 	psa_reset_key_attributes(&attr);
+
 	if (status != PSA_SUCCESS) {
 		LOG_ERR("Wrap key generation failed: %d", status);
 		return status;
@@ -357,7 +358,7 @@ int fido2_crypto_ecdh_generate_keypair(uint32_t *key_id)
 	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_DERIVE);
 	psa_set_key_algorithm(&attr, PSA_ALG_ECDH);
 	psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
-	psa_set_key_bits(&attr, FIDO2_ES256_KEY_BITS);
+	psa_set_key_bits(&attr, PSA_BYTES_TO_BITS(FIDO2_SHA256_SIZE));
 
 	status = psa_generate_key(&attr, &id);
 	psa_reset_key_attributes(&attr);
@@ -365,6 +366,98 @@ int fido2_crypto_ecdh_generate_keypair(uint32_t *key_id)
 	if (status == PSA_SUCCESS) {
 		*key_id = id;
 	}
+
+	return status;
+}
+
+int fido2_crypto_ecdh_agree(uint32_t key_id, const uint8_t *peer_key, size_t peer_key_len,
+			    uint8_t z[FIDO2_SHA256_SIZE], size_t *z_len)
+{
+	psa_status_t status;
+
+	status = psa_raw_key_agreement(PSA_ALG_ECDH, key_id, peer_key, peer_key_len, z,
+				       FIDO2_SHA256_SIZE, z_len);
+	return status;
+}
+
+int fido2_crypto_hmac_sha256(const uint8_t *key, size_t key_len, const uint8_t *msg, size_t msg_len,
+			     uint8_t mac[FIDO2_SHA256_SIZE])
+{
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	psa_status_t status;
+	psa_key_id_t id;
+	size_t mac_len;
+
+	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_SIGN_MESSAGE);
+	psa_set_key_algorithm(&attr, PSA_ALG_HMAC(PSA_ALG_SHA_256));
+	psa_set_key_type(&attr, PSA_KEY_TYPE_HMAC);
+	psa_set_key_bits(&attr, key_len * 8);
+
+	status = psa_import_key(&attr, key, key_len, &id);
+	psa_reset_key_attributes(&attr);
+
+	if (status) {
+		return status;
+	}
+
+	status = psa_mac_compute(id, PSA_ALG_HMAC(PSA_ALG_SHA_256), msg, msg_len, mac,
+				 FIDO2_SHA256_SIZE, &mac_len);
+
+	psa_destroy_key(id);
+
+	return status;
+}
+
+int fido2_crypto_aes256_cbc_decrypt(const uint8_t key[FIDO2_SHA256_SIZE], const uint8_t *iv,
+				    const uint8_t *ciphertext, size_t ciphertext_len,
+				    uint8_t *plaintext, size_t plaintext_size,
+				    size_t *plaintext_len)
+{
+	psa_key_id_t aes_key;
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	psa_cipher_operation_t op = PSA_CIPHER_OPERATION_INIT;
+	psa_status_t status;
+	size_t update_len, finish_len;
+
+	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_DECRYPT);
+	psa_set_key_algorithm(&attr, PSA_ALG_CBC_NO_PADDING);
+	psa_set_key_type(&attr, PSA_KEY_TYPE_AES);
+	psa_set_key_bits(&attr, PSA_BYTES_TO_BITS(FIDO2_SHA256_SIZE));
+
+	status = psa_import_key(&attr, key, FIDO2_SHA256_SIZE, &aes_key);
+	psa_reset_key_attributes(&attr);
+
+	if (status != PSA_SUCCESS) {
+		return status;
+	}
+
+	status = psa_cipher_decrypt_setup(&op, aes_key, PSA_ALG_CBC_NO_PADDING);
+	if (status != PSA_SUCCESS) {
+		goto cleanup;
+	}
+
+	status = psa_cipher_set_iv(&op, iv, PSA_BLOCK_CIPHER_BLOCK_LENGTH(PSA_KEY_TYPE_AES));
+	if (status != PSA_SUCCESS) {
+		goto cleanup;
+	}
+
+	status = psa_cipher_update(&op, ciphertext, ciphertext_len, plaintext, plaintext_size,
+				   &update_len);
+	if (status != PSA_SUCCESS) {
+		goto cleanup;
+	}
+
+	status = psa_cipher_finish(&op, plaintext + update_len, plaintext_size - update_len,
+				   &finish_len);
+	if (status != PSA_SUCCESS) {
+		goto cleanup;
+	}
+
+	*plaintext_len = update_len + finish_len;
+
+cleanup:
+	psa_cipher_abort(&op);
+	psa_destroy_key(aes_key);
 
 	return status;
 }

--- a/subsys/authentication/fido2/fido2_crypto.c
+++ b/subsys/authentication/fido2/fido2_crypto.c
@@ -413,25 +413,25 @@ int fido2_crypto_aes256_cbc_decrypt(const uint8_t key[FIDO2_SHA256_SIZE], const 
 				    uint8_t *plaintext, size_t plaintext_size,
 				    size_t *plaintext_len)
 {
-	psa_key_id_t aes_key;
 	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
 	psa_cipher_operation_t op = PSA_CIPHER_OPERATION_INIT;
-	psa_status_t status;
 	size_t update_len, finish_len;
+	psa_status_t status;
+	psa_key_id_t id;
 
 	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_DECRYPT);
 	psa_set_key_algorithm(&attr, PSA_ALG_CBC_NO_PADDING);
 	psa_set_key_type(&attr, PSA_KEY_TYPE_AES);
 	psa_set_key_bits(&attr, PSA_BYTES_TO_BITS(FIDO2_SHA256_SIZE));
 
-	status = psa_import_key(&attr, key, FIDO2_SHA256_SIZE, &aes_key);
+	status = psa_import_key(&attr, key, FIDO2_SHA256_SIZE, &id);
 	psa_reset_key_attributes(&attr);
 
 	if (status != PSA_SUCCESS) {
 		return status;
 	}
 
-	status = psa_cipher_decrypt_setup(&op, aes_key, PSA_ALG_CBC_NO_PADDING);
+	status = psa_cipher_decrypt_setup(&op, id, PSA_ALG_CBC_NO_PADDING);
 	if (status != PSA_SUCCESS) {
 		goto cleanup;
 	}
@@ -457,7 +457,61 @@ int fido2_crypto_aes256_cbc_decrypt(const uint8_t key[FIDO2_SHA256_SIZE], const 
 
 cleanup:
 	psa_cipher_abort(&op);
-	psa_destroy_key(aes_key);
+	psa_destroy_key(id);
+
+	return status;
+}
+
+int fido2_crypto_aes256_cbc_encrypt(const uint8_t key[FIDO2_SHA256_SIZE], const uint8_t *iv,
+				    const uint8_t *plaintext, size_t plaintext_len,
+				    uint8_t *ciphertext, size_t ciphertext_size,
+				    size_t *ciphertext_len)
+{
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	psa_cipher_operation_t op = PSA_CIPHER_OPERATION_INIT;
+	size_t update_len, finish_len;
+	psa_status_t status;
+	psa_key_id_t id;
+
+	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_ENCRYPT);
+	psa_set_key_algorithm(&attr, PSA_ALG_CBC_NO_PADDING);
+	psa_set_key_type(&attr, PSA_KEY_TYPE_AES);
+	psa_set_key_bits(&attr, PSA_BYTES_TO_BITS(FIDO2_SHA256_SIZE));
+
+	status = psa_import_key(&attr, key, FIDO2_SHA256_SIZE, &id);
+	psa_reset_key_attributes(&attr);
+
+	if (status != PSA_SUCCESS) {
+		return status;
+	}
+
+	status = psa_cipher_encrypt_setup(&op, id, PSA_ALG_CBC_NO_PADDING);
+	if (status != PSA_SUCCESS) {
+		goto cleanup;
+	}
+
+	status = psa_cipher_set_iv(&op, iv, PSA_BLOCK_CIPHER_BLOCK_LENGTH(PSA_KEY_TYPE_AES));
+	if (status != PSA_SUCCESS) {
+		goto cleanup;
+	}
+
+	status = psa_cipher_update(&op, plaintext, plaintext_len, ciphertext, ciphertext_size,
+				   &update_len);
+	if (status != PSA_SUCCESS) {
+		goto cleanup;
+	}
+
+	status = psa_cipher_finish(&op, ciphertext + update_len, ciphertext_size - update_len,
+				   &finish_len);
+	if (status != PSA_SUCCESS) {
+		goto cleanup;
+	}
+
+	*ciphertext_len = update_len + finish_len;
+
+cleanup:
+	psa_cipher_abort(&op);
+	psa_destroy_key(id);
 
 	return status;
 }

--- a/subsys/authentication/fido2/fido2_crypto.h
+++ b/subsys/authentication/fido2/fido2_crypto.h
@@ -9,15 +9,6 @@
 
 #include <zephyr/authentication/fido2/fido2_types.h>
 
-/* P-256 public key export size */
-#define FIDO2_P256_UNCOMPRESSED_KEY_SIZE 65
-/* P-256 coordinate size */
-#define FIDO2_P256_COORD_SIZE            32
-/* EC point prefix */
-#define FIDO2_EC_POINT_UNCOMPRESSED      0x04
-/* ASN.1-encoded ECDSA signature length */
-#define FIDO2_ECDSA_SIG_MAX_SIZE         72
-
 /**
  * Initialize the crypto module.
  * @return 0 on success, non-zero on failure
@@ -110,5 +101,13 @@ int fido2_crypto_wrap_credential(uint32_t key_id, const uint8_t rp_id_hash[FIDO2
 int fido2_crypto_unwrap_credential(const uint8_t *cred_id,
 				   const uint8_t rp_id_hash[FIDO2_SHA256_SIZE],
 				   uint32_t *key_id_out);
+
+/**
+ * Generate a ECDH P-256 keypair and return the PSA key ID.
+ *
+ * @param key_id  PSA persistent key identifier
+ * @return 0 on success, non-zero on failure
+ */
+int fido2_crypto_ecdh_generate_keypair(uint32_t *key_id);
 
 #endif /* FIDO2_CRYPTO_H_ */

--- a/subsys/authentication/fido2/fido2_crypto.h
+++ b/subsys/authentication/fido2/fido2_crypto.h
@@ -82,7 +82,7 @@ int fido2_crypto_destroy_key(uint32_t key_id);
 /**
  * Wrap a PSA key_id and rp_id_hash into a credential ID.
  *
- * @param key_id        PSA persistent key identifier
+ * @param key_id        PSA key ID
  * @param rp_id_hash    SHA-256 of the relying party ID
  * @param cred_id_out   Output buffer, FIDO2_NON_DISCOVERABLE_CRED_ID_SIZE bytes
  * @return 0 on success, non-zero on failure
@@ -93,9 +93,9 @@ int fido2_crypto_wrap_credential(uint32_t key_id, const uint8_t rp_id_hash[FIDO2
 /**
  * Unwrap a credential ID back to key_id.
  *
- * @param cred_id       Credential ID, FIDO2_NON_DISCOVERABLE_CRED_ID_SIZE bytes
- * @param rp_id_hash    SHA-256 of the relying party ID
- * @param key_id_out    Recovered PSA key identifier
+ * @param cred_id Credential ID, FIDO2_NON_DISCOVERABLE_CRED_ID_SIZE bytes
+ * @param rp_id_hash SHA-256 of the relying party ID
+ * @param key_id_out Recovered PSA key identifier
  * @return 0 on success, non-zero on failure
  */
 int fido2_crypto_unwrap_credential(const uint8_t *cred_id,
@@ -105,9 +105,52 @@ int fido2_crypto_unwrap_credential(const uint8_t *cred_id,
 /**
  * Generate a ECDH P-256 keypair and return the PSA key ID.
  *
- * @param key_id  PSA persistent key identifier
+ * @param key_id PSA key ID
  * @return 0 on success, non-zero on failure
  */
 int fido2_crypto_ecdh_generate_keypair(uint32_t *key_id);
+
+/**
+ * Perform ECDH key agreement.
+ *
+ * @param key_id PSA key ID
+ * @param peer_key Peer's public key
+ * @param peer_key_len Length of @p peer_key in bytes
+ * @param z Output buffer
+ * @param z_len Number of bytes written to @p z
+ * @return 0 on success, non-zero on failure
+ */
+int fido2_crypto_ecdh_agree(uint32_t key_id, const uint8_t *peer_key, size_t peer_key_len,
+			    uint8_t z[FIDO2_SHA256_SIZE], size_t *z_len);
+
+/**
+ * Compute HMAC-SHA-256 over a message
+ *
+ * @param key HMAC key
+ * @param key_len Length of @p key in bytes
+ * @param msg Message to authenticate
+ * @param msg_len Length of @p msg in bytes
+ * @param mac Output buffer for the 32-byte MAC
+ * @return 0 on success, non-zero on failure
+ */
+int fido2_crypto_hmac_sha256(const uint8_t *key, size_t key_len, const uint8_t *msg, size_t msg_len,
+			     uint8_t mac[FIDO2_SHA256_SIZE]);
+
+/**
+ * Decrypt data using AES-256-CBC without padding
+ *
+ * @param key 256-bit AES key
+ * @param iv Initialization vector
+ * @param ciphertext Ciphertext to decrypt
+ * @param ciphertext_len Length of @p ciphertext in bytes
+ * @param plaintext Output buffer for plaintext
+ * @param plaintext_size Size of @p plaintext in bytes
+ * @param plaintext_len Set to the number of bytes written to @p out
+ * @return 0 on success, non-zero on failure
+ */
+int fido2_crypto_aes256_cbc_decrypt(const uint8_t key[FIDO2_SHA256_SIZE], const uint8_t *iv,
+				    const uint8_t *ciphertext, size_t ciphertext_len,
+				    uint8_t *plaintext, size_t plaintext_size,
+				    size_t *plaintext_len);
 
 #endif /* FIDO2_CRYPTO_H_ */

--- a/subsys/authentication/fido2/fido2_crypto.h
+++ b/subsys/authentication/fido2/fido2_crypto.h
@@ -145,12 +145,29 @@ int fido2_crypto_hmac_sha256(const uint8_t *key, size_t key_len, const uint8_t *
  * @param ciphertext_len Length of @p ciphertext in bytes
  * @param plaintext Output buffer for plaintext
  * @param plaintext_size Size of @p plaintext in bytes
- * @param plaintext_len Set to the number of bytes written to @p out
+ * @param plaintext_len Set to the number of bytes written to @p plaintext
  * @return 0 on success, non-zero on failure
  */
 int fido2_crypto_aes256_cbc_decrypt(const uint8_t key[FIDO2_SHA256_SIZE], const uint8_t *iv,
 				    const uint8_t *ciphertext, size_t ciphertext_len,
 				    uint8_t *plaintext, size_t plaintext_size,
 				    size_t *plaintext_len);
+
+/**
+ * Encrypt data using AES-256-CBC without padding
+ *
+ * @param key 256-bit AES key
+ * @param iv Initialization vector
+ * @param plaintext Plaintext to encrypt
+ * @param plaintext_len Length of @p plaintext in bytes
+ * @param ciphertext Output buffer for ciphertext
+ * @param ciphertext_size Size of @p ciphertext in bytes
+ * @param ciphertext_len Set to the number of bytes written to @p ciphertext
+ * @return 0 on success, non-zero on failure
+ */
+int fido2_crypto_aes256_cbc_encrypt(const uint8_t key[FIDO2_SHA256_SIZE], const uint8_t *iv,
+				    const uint8_t *plaintext, size_t plaintext_len,
+				    uint8_t *ciphertext, size_t ciphertext_size,
+				    size_t *ciphertext_len);
 
 #endif /* FIDO2_CRYPTO_H_ */

--- a/subsys/authentication/fido2/storage/fido2_storage.c
+++ b/subsys/authentication/fido2/storage/fido2_storage.c
@@ -72,6 +72,11 @@ int fido2_storage_pin_retries_get(uint8_t *retries)
 	return fido2_storage_backend.pin_retries_get(retries);
 }
 
+int fido2_storage_pin_retries_decrement(void)
+{
+	return fido2_storage_backend.pin_retries_decrement();
+}
+
 int fido2_storage_pin_retries_reset(void)
 {
 	return fido2_storage_backend.pin_retries_reset();

--- a/subsys/authentication/fido2/storage/fido2_storage.c
+++ b/subsys/authentication/fido2/storage/fido2_storage.c
@@ -66,3 +66,8 @@ int fido2_storage_sign_count_increment(const uint8_t *cred_id, size_t cred_id_le
 {
 	return fido2_storage_backend.sign_count_increment(cred_id, cred_id_len, new_count);
 }
+
+int fido2_storage_pin_retries_get(uint8_t *retries)
+{
+	return fido2_storage_backend.pin_retries_get(retries);
+}

--- a/subsys/authentication/fido2/storage/fido2_storage.c
+++ b/subsys/authentication/fido2/storage/fido2_storage.c
@@ -71,3 +71,18 @@ int fido2_storage_pin_retries_get(uint8_t *retries)
 {
 	return fido2_storage_backend.pin_retries_get(retries);
 }
+
+int fido2_storage_pin_retries_reset(void)
+{
+	return fido2_storage_backend.pin_retries_reset();
+}
+
+int fido2_storage_pin_set(uint8_t pin_hash[FIDO2_PIN_HASH_SIZE])
+{
+	return fido2_storage_backend.pin_set(pin_hash);
+}
+
+int fido2_storage_pin_get(uint8_t pin_hash[FIDO2_PIN_HASH_SIZE])
+{
+	return fido2_storage_backend.pin_get(pin_hash);
+}

--- a/subsys/authentication/fido2/storage/fido2_storage_none.c
+++ b/subsys/authentication/fido2/storage/fido2_storage_none.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2026 Siratul Islam <email@sirat.me>
+ * Copyright (c) 2026 Siratul Islam <siratul.islam@linux.dev>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <errno.h>
+#include <sys/errno.h>
 #include <zephyr/authentication/fido2/fido2_types.h>
 #include <zephyr/authentication/fido2/fido2_storage.h>
 
@@ -62,6 +62,37 @@ static int none_backend_sign_count_increment(const uint8_t *cred_id, size_t cred
 	return -ENOTSUP;
 }
 
+static int none_backend_pin_retries_get(uint8_t *retries)
+{
+	*retries = 0;
+
+	return -ENOTSUP;
+}
+
+static int none_backend_pin_retries_decrement(void)
+{
+	return -ENOTSUP;
+}
+
+static int none_backend_pin_retries_reset(void)
+{
+	return -ENOTSUP;
+}
+
+static int none_backend_pin_set(const uint8_t *pin_hash)
+{
+	ARG_UNUSED(pin_hash);
+
+	return -ENOTSUP;
+}
+
+static int none_backend_pin_get(uint8_t *pin_hash)
+{
+	ARG_UNUSED(pin_hash);
+
+	return -ENOTSUP;
+}
+
 const struct fido2_storage_api fido2_storage_backend = {
 	.init = none_backend_init,
 	.store = none_backend_store,
@@ -69,4 +100,9 @@ const struct fido2_storage_api fido2_storage_backend = {
 	.remove = none_backend_remove,
 	.find_by_rp = none_backend_find_by_rp,
 	.sign_count_increment = none_backend_sign_count_increment,
+	.pin_retries_get = none_backend_pin_retries_get,
+	.pin_retries_decrement = none_backend_pin_retries_decrement,
+	.pin_retries_reset = none_backend_pin_retries_reset,
+	.pin_set = none_backend_pin_set,
+	.pin_get = none_backend_pin_get,
 };

--- a/subsys/authentication/fido2/storage/fido2_storage_settings.c
+++ b/subsys/authentication/fido2/storage/fido2_storage_settings.c
@@ -15,6 +15,7 @@ LOG_MODULE_DECLARE(fido2, CONFIG_FIDO2_LOG_LEVEL);
 
 #define FIDO2_SETTINGS_BASE        "fido2"
 #define FIDO2_SETTINGS_CRED_PREFIX FIDO2_SETTINGS_BASE "/cred"
+#define FIDO2_SETTINGS_PIN_RETRIES FIDO2_SETTINGS_BASE "/pin_retries"
 #define FIDO2_SETTINGS_KEY_MAX     20
 
 static void build_key(char *buf, size_t size, int idx)
@@ -149,6 +150,17 @@ static int settings_backend_sign_count_increment(const uint8_t *cred_id, size_t 
 	return settings_save_one(key, &cred, sizeof(cred));
 }
 
+static int settings_backend_pin_retries_get(uint8_t *retries)
+{
+	ssize_t len = settings_load_one(FIDO2_SETTINGS_PIN_RETRIES, retries, sizeof(*retries));
+
+	if (len != sizeof(*retries)) {
+		*retries = CONFIG_FIDO2_PIN_MAX_RETRIES;
+	}
+
+	return 0;
+}
+
 const struct fido2_storage_api fido2_storage_backend = {
 	.init = settings_backend_init,
 	.store = settings_backend_store,
@@ -156,4 +168,5 @@ const struct fido2_storage_api fido2_storage_backend = {
 	.remove = settings_backend_remove,
 	.find_by_rp = settings_backend_find_by_rp,
 	.sign_count_increment = settings_backend_sign_count_increment,
+	.pin_retries_get = settings_backend_pin_retries_get,
 };

--- a/subsys/authentication/fido2/storage/fido2_storage_settings.c
+++ b/subsys/authentication/fido2/storage/fido2_storage_settings.c
@@ -162,6 +162,19 @@ static int settings_backend_pin_retries_get(uint8_t *retries)
 	return 0;
 }
 
+static int settings_backend_pin_retries_decrement(void)
+{
+	uint8_t retries;
+
+	settings_backend_pin_retries_get(&retries);
+
+	if (retries > 0) {
+		--retries;
+	}
+
+	return settings_save_one(FIDO2_SETTINGS_PIN_RETRIES, &retries, sizeof(retries));
+}
+
 static int settings_backend_pin_retries_reset(void)
 {
 	uint8_t retries = CONFIG_FIDO2_PIN_MAX_RETRIES;
@@ -193,6 +206,7 @@ const struct fido2_storage_api fido2_storage_backend = {
 	.find_by_rp = settings_backend_find_by_rp,
 	.sign_count_increment = settings_backend_sign_count_increment,
 	.pin_retries_get = settings_backend_pin_retries_get,
+	.pin_retries_decrement = settings_backend_pin_retries_decrement,
 	.pin_retries_reset = settings_backend_pin_retries_reset,
 	.pin_set = settings_backend_pin_set,
 	.pin_get = settings_backend_pin_get,

--- a/subsys/authentication/fido2/storage/fido2_storage_settings.c
+++ b/subsys/authentication/fido2/storage/fido2_storage_settings.c
@@ -16,6 +16,7 @@ LOG_MODULE_DECLARE(fido2, CONFIG_FIDO2_LOG_LEVEL);
 #define FIDO2_SETTINGS_BASE        "fido2"
 #define FIDO2_SETTINGS_CRED_PREFIX FIDO2_SETTINGS_BASE "/cred"
 #define FIDO2_SETTINGS_PIN_RETRIES FIDO2_SETTINGS_BASE "/pin_retries"
+#define FIDO2_SETTINGS_PIN_HASH    FIDO2_SETTINGS_BASE "/pin_hash"
 #define FIDO2_SETTINGS_KEY_MAX     20
 
 static void build_key(char *buf, size_t size, int idx)
@@ -161,6 +162,29 @@ static int settings_backend_pin_retries_get(uint8_t *retries)
 	return 0;
 }
 
+static int settings_backend_pin_retries_reset(void)
+{
+	uint8_t retries = CONFIG_FIDO2_PIN_MAX_RETRIES;
+
+	return settings_save_one(FIDO2_SETTINGS_PIN_RETRIES, &retries, sizeof(retries));
+}
+
+static int settings_backend_pin_set(const uint8_t *pin_hash)
+{
+	return settings_save_one(FIDO2_SETTINGS_PIN_HASH, pin_hash, FIDO2_PIN_HASH_SIZE);
+}
+
+static int settings_backend_pin_get(uint8_t *pin_hash)
+{
+	ssize_t len = settings_load_one(FIDO2_SETTINGS_PIN_HASH, pin_hash, FIDO2_PIN_HASH_SIZE);
+
+	if (len != FIDO2_PIN_HASH_SIZE) {
+		return -ENOENT;
+	}
+
+	return 0;
+}
+
 const struct fido2_storage_api fido2_storage_backend = {
 	.init = settings_backend_init,
 	.store = settings_backend_store,
@@ -169,4 +193,7 @@ const struct fido2_storage_api fido2_storage_backend = {
 	.find_by_rp = settings_backend_find_by_rp,
 	.sign_count_increment = settings_backend_sign_count_increment,
 	.pin_retries_get = settings_backend_pin_retries_get,
+	.pin_retries_reset = settings_backend_pin_retries_reset,
+	.pin_set = settings_backend_pin_set,
+	.pin_get = settings_backend_pin_get,
 };


### PR DESCRIPTION
This PR implements the following subcommands of authenticatorClientPIN (0x06) protocol.
- getPINRetries 
- getKeyAgreement
- setPIN
- getPinToken
- getPinUvAuthTokenUsingUvWithPermissions

It is now possible to use Zephyr FIDO2 stack with most RPs (Google, Github etc.) as the primary authentication method.