### PR TITLE
twister: add post-build checks, detect cloned git repos

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -144,7 +144,7 @@ jobs:
       CCACHE_IGNOREOPTIONS: '-specs=* --specs=*'
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
-      TWISTER_COMMON: ' --test-config tests/test_config_ci.yaml --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '
+      TWISTER_COMMON: ' --test-config tests/test_config_ci.yaml --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 --post-build-checks '
       WEEKLY_OPTIONS: ' -M --build-only --all --show-footprint --report-filtered -j 32'
       PR_OPTIONS: ' --clobber-output --integration -j 16'
       PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered -j 16'

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -384,6 +384,13 @@ Artificially long but functional example:
         help="""Only run device tests with current artifacts, do not build
              the code""")
 
+    parser.add_argument(
+        "--post-build-checks", action="store_true",
+        help="""Run post-build checks on each build directory once a build
+             completes, for example detecting git repositories accidentally
+             cloned into a build directory. Disabled by default; intended to
+             be enabled in CI.""")
+
     parser.add_argument("--timeout-multiplier", type=float, default=1,
         help="""Globally adjust tests timeouts by specified multiplier. The resulting test
         timeout would be multiplication of test timeout value, board-level timeout multiplier

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1071,14 +1071,40 @@ class ProjectBuilder(FilterBuilder):
                             )
                             try:
                                 self.determine_testcases(results)
-                                next_op = 'gather_metrics'
+                                next_op = 'post_build' if self.options.post_build_checks \
+                                    else 'gather_metrics'
                             except BuildError as e:
                                 logger.error(str(e))
                                 self.instance.status = TwisterStatus.ERROR
                                 self.instance.reason = str(e)
                                 next_op = 'report'
                         else:
-                            next_op = 'gather_metrics'
+                            next_op = 'post_build' if self.options.post_build_checks \
+                                else 'gather_metrics'
+            except StatusAttributeError as sae:
+                logger.error(str(sae))
+                self.instance.status = TwisterStatus.ERROR
+                reason = 'Incorrect status assignment'
+                self.instance.reason = reason
+                self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
+                next_op = 'report'
+            finally:
+                self._add_to_processing_queue(processing_queue, next_op)
+
+        # Run post-build checks on the freshly built artifacts
+        elif op == "post_build":
+            try:
+                ret = self.post_build()
+                if ret.get('returncode', 1) > 0:
+                    self.instance.status = TwisterStatus.ERROR
+                    self.instance.reason = ret.get('reason', 'Post-build check failure')
+                    self.instance.add_missing_case_status(
+                        TwisterStatus.BLOCK,
+                        self.instance.reason
+                    )
+                    next_op = 'report'
+                else:
+                    next_op = 'gather_metrics'
             except StatusAttributeError as sae:
                 logger.error(str(sae))
                 self.instance.status = TwisterStatus.ERROR
@@ -1783,6 +1809,47 @@ class ProjectBuilder(FilterBuilder):
             logger.error(self.instance.reason)
             return
         return build_result
+
+    def post_build(self):
+        """Run post-build checks against the build directory.
+
+        Each check is a bound method returning ``None`` on success or a
+        human-readable reason string on failure. The first failing check
+        short-circuits and fails the build. New checks can be added to the
+        ``checks`` list below.
+        """
+        checks = [
+            self.check_no_nested_git_repos,
+        ]
+        for check in checks:
+            reason = check()
+            if reason:
+                logger.error(
+                    f"Post-build check '{check.__name__}' failed for "
+                    f"{self.instance.name}: {reason}"
+                )
+                return {"returncode": 1, "reason": reason}
+        return {"returncode": 0}
+
+    def check_no_nested_git_repos(self):
+        """Post-build check: a test or platform must never clone a git tree
+        into its build directory. Detect any nested git repository (a ``.git``
+        directory or file) under the build directory and fail if found.
+        """
+        found = []
+        for dirpath, dirnames, filenames in os.walk(self.instance.build_dir):
+            if '.git' in dirnames:
+                found.append(os.path.join(dirpath, '.git'))
+                # Do not descend into the discovered repository.
+                dirnames.remove('.git')
+            if '.git' in filenames:
+                found.append(os.path.join(dirpath, '.git'))
+        if found:
+            return (
+                "git repository cloned into build directory during build: "
+                + ", ".join(found)
+            )
+        return None
 
     def run(self):
 

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -1074,7 +1074,7 @@ TESTDATA_6 = [
         mock.ANY,
         ['build test: dummy instance name',
          'Determine test cases for test instance: dummy instance name'],
-        {'op': 'gather_metrics', 'test': mock.ANY},
+        {'op': 'post_build', 'test': mock.ANY},
         mock.ANY,
         mock.ANY,
         0,
@@ -1119,7 +1119,7 @@ TESTDATA_6 = [
         mock.ANY,
         ['build test: dummy instance name',
          'Determine test cases for test instance: dummy instance name'],
-        {'op': 'gather_metrics', 'test': mock.ANY},
+        {'op': 'post_build', 'test': mock.ANY},
         mock.ANY,
         mock.ANY,
         0,
@@ -1518,6 +1518,7 @@ def test_projectbuilder_process(
     pb.options.prep_artifacts_for_testing = options_prep_artifacts
     pb.options.runtime_artifact_cleanup = options_runtime_artifacts
     pb.options.cmake_only = options_cmake_only
+    pb.options.post_build_checks = True
     pb.options.outdir = tmp_path
     pb.options.log_file = None
     pb.options.log_level = "DEBUG"
@@ -1554,6 +1555,45 @@ def test_projectbuilder_process(
 
     if expected_missing:
         pb.instance.add_missing_case_status.assert_called_with(*expected_missing)
+
+
+@pytest.mark.parametrize(
+    'post_build_checks, expected_next_op',
+    [(True, 'post_build'), (False, 'gather_metrics')],
+    ids=['enabled', 'disabled']
+)
+def test_projectbuilder_process_post_build_checks_gating(
+    mocked_jobserver, tmp_path, post_build_checks, expected_next_op
+):
+    """A successful build transitions to 'post_build' only when post-build
+    checks are enabled; otherwise it goes straight to 'gather_metrics'.
+    """
+    instance_mock = mock.Mock()
+    instance_mock.name = 'dummy instance name'
+    instance_mock.status = 'success'
+    instance_mock.testsuite.harness = 'test'
+    env_mock = mock.Mock()
+
+    pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+    pb.options = mock.Mock()
+    pb.options.post_build_checks = post_build_checks
+    pb.options.outdir = tmp_path
+    pb.options.log_file = None
+    pb.options.log_level = "DEBUG"
+
+    pb.build = mock.Mock(return_value={'returncode': 0})
+    pb.determine_testcases = mock.Mock()
+
+    processing_queue_mock = mock.Mock()
+    lock_mock = mock.Mock(
+        __enter__=mock.Mock(return_value=(mock.Mock(), mock.Mock())),
+        __exit__=mock.Mock(return_value=None)
+    )
+    results_mock = mock.Mock()
+
+    pb.process(processing_queue_mock, mock.Mock(), {'op': 'build'}, lock_mock, results_mock)
+
+    processing_queue_mock.append.assert_called_with({'op': expected_next_op, 'test': mock.ANY})
 
 
 TESTDATA_7 = [
@@ -2358,6 +2398,63 @@ def test_projectbuilder_build(mocked_jobserver):
 
     pb.run_build.assert_called_once_with(['--build', 'build_dir'])
     assert res == {'dummy': 'dummy'}
+
+
+def test_projectbuilder_check_no_nested_git_repos(mocked_jobserver, tmp_path):
+    instance_mock = mock.Mock()
+    instance_mock.build_dir = str(tmp_path)
+    env_mock = mock.Mock()
+
+    pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+
+    # Clean build directory: no nested git repository.
+    assert pb.check_no_nested_git_repos() is None
+
+    # A '.git' directory cloned somewhere under the build directory must fail.
+    nested = tmp_path / 'subproject'
+    (nested / '.git').mkdir(parents=True)
+    reason = pb.check_no_nested_git_repos()
+    assert reason is not None
+    assert os.path.join('subproject', '.git') in reason
+
+
+def test_projectbuilder_check_no_nested_git_repos_gitfile(mocked_jobserver, tmp_path):
+    instance_mock = mock.Mock()
+    instance_mock.build_dir = str(tmp_path)
+    env_mock = mock.Mock()
+
+    pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+
+    # A '.git' file (e.g. a git submodule/worktree pointer) must also fail.
+    (tmp_path / '.git').write_text('gitdir: /elsewhere')
+    reason = pb.check_no_nested_git_repos()
+    assert reason is not None
+    assert '.git' in reason
+
+
+def test_projectbuilder_post_build_pass(mocked_jobserver):
+    instance_mock = mock.Mock()
+    env_mock = mock.Mock()
+
+    pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+    pb.check_no_nested_git_repos = mock.Mock(return_value=None)
+
+    assert pb.post_build() == {'returncode': 0}
+
+
+def test_projectbuilder_post_build_fail(mocked_jobserver):
+    instance_mock = mock.Mock()
+    instance_mock.name = 'dummy instance name'
+    env_mock = mock.Mock()
+
+    pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+    pb.check_no_nested_git_repos = mock.Mock(
+        return_value='cloned repo found', __name__='check_no_nested_git_repos'
+    )
+
+    res = pb.post_build()
+    assert res['returncode'] == 1
+    assert res['reason'] == 'cloned repo found'
 
 
 TESTDATA_14 = [


### PR DESCRIPTION
Add a new "post_build" operation to the twister build pipeline that runs
checks against the freshly built artifacts before metrics gathering. The
build stage now hands off to post_build, which fails the instance (ERROR,
missing cases BLOCKed) if any check reports a problem.

The first check, check_no_nested_git_repos, walks the build directory for
any nested git repository (a .git directory or file) and fails the build
if found. A test or platform should never clone a git tree into its build
directory; enforcing this per-build attributes the failure to the specific
test instance and works for local runs as well as CI.