### PR TITLE
west.yml: Update Silabs HAL

### DIFF
--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -271,6 +271,7 @@ if(CONFIG_SILABS_SIWX91X_NWP)
   )
   zephyr_include_directories(.)
   zephyr_code_relocate(FILES
+    ${SISDK}/platform/common/src/sl_core_cortexm.c
     ${WISECONNECT}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_ram.c
     LOCATION RAM
   )

--- a/west.yml
+++ b/west.yml
@@ -248,7 +248,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: d91d60465ca99b0a8e44a429769ee759843267f7
+      revision: pull/180/head
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
This new version of the Silabs changes the functions called during the exclusive access to the flash.

Since CORE_ENTER_ATOMIC() is defined in sl_core_cortexm.c, this file also has to be relocated in RAM.