### PR TITLE
samples: mcumgr: smp_svr: fix compatibility with new USB stack

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/usb.overlay
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/usb.overlay
@@ -13,5 +13,6 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
+		hw-flow-control;
 	};
 };


### PR DESCRIPTION
Fixes #107633.

For MCUmgr over USB CDC ACM to work, it is absolutely critical that no packets get lost.

This, however, is only guaranteed with `hw-flow-control` enabled, which was missing in the example.
