### PR TITLE
Kconfig: fix cache line size default setting

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -367,8 +367,8 @@ source "arch/arc/core/mpu/Kconfig"
 
 endmenu
 
-config DCACHE_LINE_SIZE
-	default 32
+configdefault DCACHE_LINE_SIZE
+	default 32 if !$(dt_node_has_prop,/cpus/cpu@0,d-cache-line-size)
 
 config ARC_DCACHE_REGION_OPERATIONS
 	bool "DCACHE region operations"

--- a/boards/qemu/xtensa/Kconfig.defconfig
+++ b/boards/qemu/xtensa/Kconfig.defconfig
@@ -10,7 +10,7 @@ config IPM_CONSOLE_STACK_SIZE
 	default 2048 if IPM_CONSOLE_RECEIVER
 
 # Must match XCHAL_DCACHE_LINESIZE form core-isa.h
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 4 if BOARD_QEMU_XTENSA_SAMPLE_CONTROLLER32_MPU
 	default 32
 

--- a/soc/ambiq/apollo5x/Kconfig.defconfig
+++ b/soc/ambiq/apollo5x/Kconfig.defconfig
@@ -9,7 +9,7 @@ rsource "Kconfig.defconfig.apollo5*"
 config CACHE_MANAGEMENT
 	default y
 
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 32
 
 config DCACHE

--- a/soc/amd/acp_6_0/Kconfig.defconfig
+++ b/soc/amd/acp_6_0/Kconfig.defconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_ACP_6_0
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 128
 
 config CACHE_MANAGEMENT

--- a/soc/aspeed/ast10x0/Kconfig.defconfig
+++ b/soc/aspeed/ast10x0/Kconfig.defconfig
@@ -6,10 +6,10 @@ if SOC_SERIES_AST10X0
 
 rsource "Kconfig.defconfig.ast10*0"
 
-config ICACHE_LINE_SIZE
+configdefault ICACHE_LINE_SIZE
 	default 32
 
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 32
 
 choice CACHE_TYPE

--- a/soc/intel/intel_adsp/Kconfig.defconfig
+++ b/soc/intel/intel_adsp/Kconfig.defconfig
@@ -31,7 +31,7 @@ choice CACHE_TYPE
 	default SOC_CACHE
 endchoice
 
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 64
 
 endif # SOC_FAMILY_INTEL_ADSP

--- a/soc/mediatek/mt8xxx/Kconfig.defconfig
+++ b/soc/mediatek/mt8xxx/Kconfig.defconfig
@@ -37,7 +37,7 @@ config DCACHE
 	default y
 config CACHE_MANAGEMENT
 	default y
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 128
 
 config NOCACHE_MEMORY

--- a/soc/nxp/imx/imx8/Kconfig.defconfig
+++ b/soc/nxp/imx/imx8/Kconfig.defconfig
@@ -11,7 +11,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000
 
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 128
 
 config GEN_IRQ_VECTOR_TABLE

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_adsp
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_adsp
@@ -11,7 +11,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000
 
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 128
 
 config GEN_IRQ_VECTOR_TABLE

--- a/soc/nxp/imx/imx8ulp/Kconfig.defconfig
+++ b/soc/nxp/imx/imx8ulp/Kconfig.defconfig
@@ -11,7 +11,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000
 
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 128
 
 config GEN_IRQ_VECTOR_TABLE

--- a/soc/nxp/imx/imx8x/Kconfig.defconfig
+++ b/soc/nxp/imx/imx8x/Kconfig.defconfig
@@ -11,7 +11,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000
 
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 128
 
 config GEN_IRQ_VECTOR_TABLE

--- a/soc/nxp/imxrt/imxrt6xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt6xx/Kconfig.defconfig
@@ -75,7 +75,7 @@ config MCUX_CORE_SUFFIX
 	default "_dsp"
 
 # Must match XCHAL_DCACHE_LINESIZE from core-isa.h
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 256
 
 endif # SOC_MIMXRT685S_HIFI4

--- a/soc/nxp/imxrt/imxrt7xx/hifi4/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt7xx/hifi4/Kconfig.defconfig
@@ -25,7 +25,7 @@ config I2S_HAS_PLL_SETTING
 	default n
 
 # Must match XCHAL_DCACHE_LINESIZE from core-isa.h
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 256
 
 endif # SOC_MIMXRT798S_HIFI4

--- a/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
+++ b/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
@@ -56,7 +56,7 @@ choice CACHE_TYPE
 	default EXTERNAL_CACHE
 endchoice
 
-config ICACHE_LINE_SIZE
+configdefault ICACHE_LINE_SIZE
 	default 256
 
 endif # SOC_LPC55S36


### PR DESCRIPTION
Setting symbol default value without 'configdefault', or without explicit 'if' checks of dependencies, results in dependency weakening. In this case, I/DCACHE_LINE_SIZE are redefined and set to the given default value even if the dependency D/ICACHE is not enabled.