### PR TITLE
Backport misc LLEXT input validation fixes to v3.7 branch

### DIFF
--- a/include/zephyr/llext/loader.h
+++ b/include/zephyr/llext/loader.h
@@ -75,7 +75,7 @@ struct llext_loader {
 	 * @param[in] ldr Loader
 	 * @param[in] pos Position to obtain a pointer to
 	 *
-	 * @returns a pointer into the buffer or `NULL` if not supported
+	 * @returns a pointer into the buffer or `NULL` if not supported or pointer out of bounds.
 	 */
 	void *(*peek)(struct llext_loader *ldr, size_t pos);
 

--- a/subsys/llext/buf_loader.c
+++ b/subsys/llext/buf_loader.c
@@ -34,5 +34,9 @@ void *llext_buf_peek(struct llext_loader *l, size_t pos)
 {
 	struct llext_buf_loader *buf_l = CONTAINER_OF(l, struct llext_buf_loader, loader);
 
+	if (pos >= buf_l->len) {
+		return NULL;
+	}
+
 	return (void *)(buf_l->buf + pos);
 }

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -37,14 +37,20 @@ ssize_t llext_find_section(struct llext_loader *ldr, const char *search_name)
 	     i < ldr->hdr.e_shnum;
 	     i++, pos += ldr->hdr.e_shentsize) {
 		shdr = llext_peek(ldr, pos);
-		if (!shdr) {
-			/* The peek() method isn't supported */
+		if (shdr == NULL) {
+			/* The peek() method isn't supported, or - less likely - shdr is
+			 * out of bounds
+			 */
 			return -ENOTSUP;
 		}
 
 		const char *name = llext_peek(ldr,
 					      ldr->sects[LLEXT_MEM_SHSTRTAB].sh_offset +
 					      shdr->sh_name);
+
+		if (name == NULL) {
+			return -ENOEXEC;
+		}
 
 		if (!strcmp(name, search_name)) {
 			return shdr->sh_offset;

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -62,9 +62,16 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 	 */
 	uint8_t *text = ext->mem[LLEXT_MEM_TEXT];
 
-	LOG_DBG("Found %p in PLT %u size %zu cnt %u text %p",
-		(void *)llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB, shdr->sh_name),
-		shdr->sh_type, (size_t)shdr->sh_entsize, sh_cnt, (void *)text);
+	const char *sect_name = llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB, shdr->sh_name);
+
+	if (sect_name == NULL) {
+		LOG_WRN("PLT: out of bounds string table index %u for section name, "
+			"trying to continue",
+			shdr->sh_name);
+	}
+
+	LOG_DBG("Found %p in PLT %u size %zu cnt %u text %p", (void *)sect_name, shdr->sh_type,
+		(size_t)shdr->sh_entsize, sh_cnt, (void *)text);
 
 	const elf_shdr_t *sym_shdr = ldr->sects + LLEXT_MEM_SYMTAB;
 	unsigned int sym_cnt = sym_shdr->sh_size / sym_shdr->sh_entsize;
@@ -114,6 +121,12 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 		}
 
 		const char *name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym_tbl.st_name);
+
+		if (name == NULL) {
+			LOG_ERR("PLT: out of bounds string table index %u for symbol name",
+				sym_tbl.st_name);
+			continue;
+		}
 
 		/*
 		 * Both r_offset and sh_addr are addresses for which the extension
@@ -232,6 +245,13 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local)
 
 		name = llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB, shdr->sh_name);
 
+		if (name == NULL) {
+			LOG_ERR("Section %d has out of bounds string table index %d "
+				"for section name",
+				i, shdr->sh_name);
+			return -ENOEXEC;
+		}
+
 		/*
 		 * FIXME: The Xtensa port is currently using a different way of
 		 * handling relocations that ultimately results in separate
@@ -289,6 +309,13 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local)
 			}
 
 			name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym.st_name);
+
+			if (name == NULL) {
+				LOG_ERR("out of bounds string table index %u "
+					"for symbol name",
+					sym.st_name);
+				return -ENOEXEC;
+			}
 
 			LOG_DBG("relocation %d:%d info 0x%zx (type %zd, sym %zd) offset %zd "
 				"sym_name %s sym_type %d sym_bind %d sym_ndx %d",

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -79,7 +79,7 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 		}
 
 		if (ret < 0) {
-			LOG_ERR("PLT: failed to read RELA #%u, trying to continue", i);
+			LOG_WRN("PLT: failed to read RELA #%u, trying to continue", i);
 			continue;
 		}
 
@@ -99,7 +99,7 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 		}
 
 		if (ret < 0) {
-			LOG_ERR("PLT: failed to read symbol table #%u RELA #%u, trying to continue",
+			LOG_WRN("PLT: failed to read symbol table #%u RELA #%u, trying to continue",
 				j, i);
 			continue;
 		}
@@ -129,11 +129,24 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 		size_t got_offset;
 
 		if (tgt) {
+			if (rela.r_offset >= tgt->sh_size) {
+				LOG_WRN("PLT: r_offset %#zx out of target section "
+					"(size %#zx), skipping",
+					(size_t)rela.r_offset, (size_t)tgt->sh_size);
+				continue;
+			}
 			got_offset = rela.r_offset + tgt->sh_offset -
 				ldr->sects[LLEXT_MEM_TEXT].sh_offset;
 		} else {
-			got_offset = llext_file_offset(ldr, rela.r_offset) -
-				ldr->sects[LLEXT_MEM_TEXT].sh_offset;
+			ssize_t offset = llext_file_offset(ldr, rela.r_offset);
+
+			if (offset < 0) {
+				LOG_WRN("Offset %#zx not found in ELF, trying to continue",
+					(size_t)rela.r_offset);
+				continue;
+			}
+
+			got_offset = offset - ldr->sects[LLEXT_MEM_TEXT].sh_offset;
 		}
 
 		uint32_t stb = ELF_ST_BIND(sym_tbl.st_info);

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -497,6 +497,11 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 
 		if ((stt == STT_FUNC || stt == STT_OBJECT) &&
 		    stb == STB_GLOBAL && shndx != SHN_UNDEF) {
+			if (shndx >= ldr->sect_cnt) {
+				LOG_ERR("Symbol %d has invalid section index %u", i, shndx);
+				return -ENOEXEC;
+			}
+
 			const char *name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym.st_name);
 
 			__ASSERT(j <= sym_tab->sym_cnt, "Miscalculated symbol number %u\n", j);

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -208,6 +208,13 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext)
 
 		name = llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB, shdr->sh_name);
 
+		if (name == NULL) {
+			LOG_ERR("section %d has out of bounds string table index %d "
+				"for section name",
+				i, shdr->sh_name);
+			return -ENOEXEC;
+		}
+
 		/* Identify the section type by its flags */
 		enum llext_mem mem_idx;
 
@@ -404,6 +411,12 @@ static int llext_count_export_syms(struct llext_loader *ldr, struct llext *ext)
 
 		name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym.st_name);
 
+		if (name == NULL) {
+			LOG_ERR("Out of bounds string table index for symbol name %d in symbol %d",
+				sym.st_name, i);
+			return -ENOEXEC;
+		}
+
 		if ((stt == STT_FUNC || stt == STT_OBJECT) && stb == STB_GLOBAL) {
 			LOG_DBG("function symbol %d, name %s, type tag %d, bind %d, sect %d",
 				i, name, stt, stb, sect);
@@ -503,6 +516,13 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 			}
 
 			const char *name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym.st_name);
+
+			if (name == NULL) {
+				LOG_ERR("Symbol %d has out of bounds string table index %d for "
+					"symbol name",
+					i, sym.st_name);
+				return -ENOEXEC;
+			}
 
 			__ASSERT(j <= sym_tab->sym_cnt, "Miscalculated symbol number %u\n", j);
 

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -54,6 +54,10 @@ int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 static inline const char *llext_string(struct llext_loader *ldr, struct llext *ext,
 				       enum llext_mem mem_idx, unsigned int idx)
 {
+	if (idx >= ext->mem_size[mem_idx]) {
+		return NULL;
+	}
+
 	return (char *)ext->mem[mem_idx] + idx;
 }
 


### PR DESCRIPTION
Dropped these commits from #109875 as inapplicable:

* llext: add bounds to init / fini fn_table size
* llext: validate st_shndx in llext_symbol_name for STT_SECTION symbols
* llext: validate sh_info before indexing sect_map in load pass

Reworked these commits:

* llext: add bounds checking to llext_string (llext_section_name and llext_symbol_name not added yet, only using llext_string, fixed argument order in logs after two llext_string calls to get section name)
* llext: bound-check r_offset in Xtensa PLT (v3.7 doesn't have check for shared branch yet, so add that too)

Fixes #111216
