### PR TITLE
llext: fix llext_section_name NULL check logs

### DIFF
--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -477,7 +477,7 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 		if (name == NULL) {
 			LOG_ERR("Section %d has out of bounds string table index %d "
 				"for section name",
-				shdr->sh_name, i);
+				i, shdr->sh_name);
 			return -ENOEXEC;
 		}
 

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -252,7 +252,7 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 		if (name == NULL) {
 			LOG_ERR("section %d has out of bounds string table index %d "
 				"for section name",
-				shdr->sh_name, i);
+				i, shdr->sh_name);
 			return -ENOEXEC;
 		}
 


### PR DESCRIPTION
Corrects argument order in two logs that happen if NULL check succeeds on result of llext_section_name. Fixes issues introduced by PR #109875.