### PR TITLE
tests: drivers: adc: use 32-bit data on kit_pse84_ai/m55

### DIFF
--- a/tests/drivers/adc/adc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.conf
+++ b/tests/drivers/adc/adc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# The Infineon AutAnalog SAR ADC driver stores conversion results as 32-bit
+# samples, so the test must use 32-bit wide sample buffers.
+CONFIG_ADC_32_BITS_DATA=y

--- a/tests/drivers/adc/adc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
+++ b/tests/drivers/adc/adc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# The Infineon AutAnalog SAR ADC driver stores conversion results as 32-bit
+# samples, so the test must use 32-bit wide sample buffers.
+CONFIG_ADC_32_BITS_DATA=y


### PR DESCRIPTION
**Reproduced and fixed on real hardware** (kit_pse84_ai/pse846gps2dbzc4a/m55).

### Problem
All `adc_basic` subtests in `tests/drivers/adc/adc_api` fail on
`kit_pse84_ai/m55`:
```
Samples read: 0x04ba 0x0000 0x04c2 0x0000 0x04d1 0x0000
    Assertion failed at .../src/test_adc.c:155: check_samples:
    (INVALID_ADC_VALUE not equal to sample_value) [5] should be empty
 FAIL - test_adc_asynchronous_call
```
A valid value lands in every *even* slot and `0x0000` in every *odd* slot.

### Root cause
The Infineon AutAnalog SAR ADC driver stores each conversion result as a
**32-bit** word (`conversion_buffer` is `uint32_t *` and the buffer-size
check in `start_read()` uses `sizeof(int32_t)`). Without
`CONFIG_ADC_32_BITS_DATA` the test uses 16-bit (`int16_t`) sample buffers,
so each 32-bit result spans two slots — the value in one, `0x0000` in the
next — which `check_samples()` flags as a non-empty "should be empty" slot.

### Fix
Add a board config enabling `CONFIG_ADC_32_BITS_DATA=y` for
`kit_pse84_ai/pse846gps2dbzc4a/m55`, matching the existing approach already
used for the STM32N6 boards in this same test
(`stm32n6570_dk_sb.conf`, `nucleo_n657x0_q_sb.conf`).

### Verification on HW
```
TESTSUITE adc_basic succeeded
SUITE PASS - 100.00% [adc_basic]: pass = 6, fail = 0, skip = 1
PROJECT EXECUTION SUCCESSFUL
```
Unfilled slots now correctly read `0x80000000` (`INT_MIN`). No driver
change required.
