### PR TITLE
posix: cond: Allow statically initialized cond to pthread_cond_broadcast

### DIFF
--- a/subsys/portability/posix/options/cond.c
+++ b/subsys/portability/posix/options/cond.c
@@ -151,7 +151,7 @@ int pthread_cond_broadcast(pthread_cond_t *cvar)
 	int ret;
 	struct posix_cond *cv;
 
-	cv = get_posix_cond(*cvar);
+	cv = to_posix_cond(cvar);
 	if (cv == NULL) {
 		return EINVAL;
 	}

--- a/tests/subsys/portability/posix/threads_base/src/cond.c
+++ b/tests/subsys/portability/posix/threads_base/src/cond.c
@@ -72,4 +72,28 @@ ZTEST(cond, test_cond_init_existing_initialized_condattr)
 	zassert_ok(pthread_condattr_destroy(&att));
 }
 
+/**
+ * @brief Test pthread_cond_broadcast call with a statically initialized pthread_cond_t,
+ *        i.e. PTHREAD_COND_INITIALIZER assigned.
+ */
+ZTEST(cond, test_cond_broadcast_static_init_pthread_cond_t)
+{
+	pthread_cond_t cond = PTHREAD_COND_INITIALIZER; /* is considered statically initialized */
+
+	zassert_ok(pthread_cond_broadcast(&cond));
+	zassert_ok(pthread_cond_destroy(&cond));
+}
+
+/**
+ * @brief Test pthread_cond_signal call with a statically initialized pthread_cond_t,
+ *        i.e. PTHREAD_COND_INITIALIZER assigned.
+ */
+ZTEST(cond, test_cond_signal_static_init_pthread_cond_t)
+{
+	pthread_cond_t cond = PTHREAD_COND_INITIALIZER; /* is considered statically initialized */
+
+	zassert_ok(pthread_cond_signal(&cond));
+	zassert_ok(pthread_cond_destroy(&cond));
+}
+
 ZTEST_SUITE(cond, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
[POSIX](https://pubs.opengroup.org/onlinepubs/9799919799/functions/pthread_cond_broadcast.html) requires the condition variable `pthread_cond_t` to be initialized. Hence a static initialization with `PTHREAD_COND_INITIALIZER` shall be supported, as it is for `pthread_cond_signal` already.

This PR complements PR #109291.

Testing
- ZTests are included.
- Manually tested on two platforms

Note:
This feature is used in the
[GNU C++ Library](https://gcc.gnu.org/onlinedocs/libstdc++/manual/)'s pthread multithreading implementation, e.g. `ext/concurrence.h`.

For details, please see
[Zephyr SDK `pthread` Toolchain](https://github.com/sgothel/zephyr-sdk-pthread-toolchain).