### PR TITLE
soc: infineon: edge: pse84: scope MPU regions to owning core

### DIFF
--- a/soc/infineon/edge/pse84/mpu_regions.c
+++ b/soc/infineon/edge/pse84/mpu_regions.c
@@ -8,7 +8,22 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
-/* We are expected to give *CONFIG_SIZE* in KB, but REGION_ATTR
+/*
+ * Static MPU regions are scoped to the core that actually owns them.
+ *
+ * The PSE84 memory map exposes several core-specific code and shared windows
+ * (secure/non-secure CM33 code, the per-core allocatable shared windows, and
+ * the CM55 TCMs). Instantiating every window on both cores wastes scarce HW
+ * MPU regions: the CM33 only has 8 data regions, so unconditionally creating 6
+ * static regions left no room for memory-domain partitions and broke the
+ * userspace / memory-protection tests with -ENOSPC at init (the default domain
+ * could not allocate its libc/malloc partitions).
+ *
+ * Gating each window on its owning core keeps the CM33 static set down to
+ * {FLASH, SRAM, SHARED_MEMORY_33, M33S_CODE}, recovering partition slots, while
+ * the CM55 keeps only the windows it actually uses.
+ *
+ * We are expected to give *CONFIG_SIZE* in KB, but REGION_ATTR
  * expects bytes, so we multiply by 1024 to convert.
  */
 static const struct arm_mpu_region mpu_regions[] = {
@@ -35,7 +50,10 @@ static const struct arm_mpu_region mpu_regions[] = {
 			DT_REG_SIZE(DT_NODELABEL(m33_allocatable_shared)))),
 #endif
 
-#if DT_NODE_EXISTS(DT_NODELABEL(m55_allocatable_shared))
+	/* CM55-only nocache window: unused on the CM33, where it only wastes a
+	 * HW MPU region.
+	 */
+#if DT_NODE_EXISTS(DT_NODELABEL(m55_allocatable_shared)) && defined(CONFIG_CPU_CORTEX_M55)
 	MPU_REGION_ENTRY(
 		"SHARED_MEMORY 55",
 		DT_REG_ADDR(DT_NODELABEL(m55_allocatable_shared)),
@@ -44,7 +62,13 @@ static const struct arm_mpu_region mpu_regions[] = {
 			DT_REG_SIZE(DT_NODELABEL(m55_allocatable_shared)))),
 #endif
 
-#if DT_NODE_EXISTS(DT_NODELABEL(m33s_code))
+	/* Secure CM33 code-in-SRAM window: only meaningful for the secure CM33
+	 * image. The m33s_code node is also visible to a non-secure CM33 build, so
+	 * gate it on TRUSTED_EXECUTION_SECURE (not just !CM55) to keep it off the
+	 * non-secure CM33 and the CM55.
+	 */
+#if DT_NODE_EXISTS(DT_NODELABEL(m33s_code)) && \
+	defined(CONFIG_CPU_CORTEX_M33) && defined(CONFIG_TRUSTED_EXECUTION_SECURE)
 	MPU_REGION_ENTRY(
 		"M33S_CODE",
 		DT_REG_ADDR(DT_NODELABEL(m33s_code)),
@@ -53,7 +77,12 @@ static const struct arm_mpu_region mpu_regions[] = {
 			DT_REG_SIZE(DT_NODELABEL(m33s_code)))),
 #endif
 
-#if DT_NODE_EXISTS(DT_NODELABEL(m33_code))
+	/* Non-secure CM33 code-in-SRAM window: only meaningful for a non-secure
+	 * CM33 image. It is empty on the secure CM33 build and unused on the
+	 * CM55, so do not spend a HW MPU region on it there.
+	 */
+#if DT_NODE_EXISTS(DT_NODELABEL(m33_code)) && \
+	defined(CONFIG_CPU_CORTEX_M33) && !defined(CONFIG_TRUSTED_EXECUTION_SECURE)
 	MPU_REGION_ENTRY(
 		"M33_CODE",
 		DT_REG_ADDR(DT_NODELABEL(m33_code)),
@@ -62,6 +91,10 @@ static const struct arm_mpu_region mpu_regions[] = {
 			DT_REG_SIZE(DT_NODELABEL(m33_code)))),
 #endif
 
+	/* CM55-only tightly-coupled memories: the itcm/dtcm node labels exist only
+	 * in the CM55 devicetree (the CM33 uses separate itcm_m33s/dtcm_m33s nodes),
+	 * so DT_NODE_EXISTS already scopes these to the CM55 build.
+	 */
 #if DT_NODE_EXISTS(DT_NODELABEL(itcm))
 	MPU_REGION_ENTRY(
 		"ITCM",


### PR DESCRIPTION
The PSE84 static MPU region table is shared between the Cortex-M33 and
Cortex-M55 cores, but several of the regions only belong to one core.
Instantiating every region on both cores wastes scarce hardware MPU
slots. On a core with few data regions this leaves no room for
memory-domain partitions: the default domain can no longer allocate its
libc/malloc partitions and initialization fails with `-ENOSPC`
(`Failed to add default memory partition (-28)` /
`no free partition slots available`), which traps the kernel at boot and
breaks the userspace / memory-protection tests.

This scopes each single-core region to the core that actually owns it.

### Changes

- **`m55_allocatable_shared`** — a CM55-only nocache window; unused on
  the CM33. Now gated to `CONFIG_CPU_CORTEX_M55`.
- **`m33s_code` / `m33_code`** — hold the CM33 secure / non-secure code
  images; the CM55 never executes from them. `m33_code` is additionally
  only meaningful for a non-secure CM33 image (it is empty on the secure
  CM33 build), so it is gated off there too. Now gated to
  `!CONFIG_CPU_CORTEX_M55` (and, for `m33_code`,
  `CONFIG_CPU_CORTEX_M33 && !CONFIG_TRUSTED_EXECUTION_SECURE`).
- **`itcm` / `dtcm`** — the CM55 tightly-coupled memories; the CM33 cores
  never access them. Now gated to `CONFIG_CPU_CORTEX_M55`.
- **`m33_allocatable_shared`** is intentionally left on both cores, since
  it backs shared-memory consumers and is not specific to a single core.

On the secure CM33 build this reduces the static set to
`{FLASH, SRAM, SHARED_MEMORY_33, M33S_CODE}` (4 regions), restoring the
partition slots the default memory domain needs.

### Testing

- **CM55** (`kit_pse84_ai/pse846gps2dbzc4a/m55`, sysbuild,
  `tests/kernel/mem_protect/userspace`): before — boot trap,
  `no free partition slots available`, no tests run; after — full suite
  passes (`userspace` 32/0/2, `userspace_domain` 4/0/0,
  `userspace_domain_ctx` 3/0/0, `PROJECT EXECUTION SUCCESSFUL`).
- **CM33**: verified the static region table is reduced to 4 entries
  (`mpu_config.num_regions == 4`), so the default memory domain regains
  its partition budget.
