### PR TITLE
drivers: pwm: mcux_sctimer: guard counter start

### DIFF
--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -774,7 +774,9 @@ static int mcux_sctimer_pwm_pm_action(const struct device *dev, enum pm_device_a
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 #ifdef CONFIG_PM_DEVICE
-		SCTIMER_StartTimer(config->base, kSCTIMER_Counter_U);
+		if (data->pwm_channel_active) {
+			SCTIMER_StartTimer(config->base, kSCTIMER_Counter_U);
+		}
 #endif /* CONFIG_PM_DEVICE */
 		err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 		if (err < 0 && err != -ENOENT) {


### PR DESCRIPTION
The PM_DEVICE_ACTION_RESUME handler started the SCT counter unconditionally. When RESUME runs before the first pwm_set_cycles() no period match or counter limit event exists yet, so the counter free-runs across its full 32-bit range. By the time a channel is configured, COUNT has climbed past the period match installed as the counter limit; since the limit only fires on COUNT == match, the counter never resets and the output is stranded until a full 32-bit wrap. Guard the start with pwm_channel_active so the counter is only started once at least one channel has been configured.

Fixes #111888