### PR TITLE
drivers: serial: gd32: add UART asynchronous DMA support

### DIFF
--- a/drivers/dma/dma_gd32.c
+++ b/drivers/dma/dma_gd32.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
+ * Copyright (c) 2026 Liu Changjie <liucj1228@outlook.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -698,7 +699,7 @@ static DEVICE_API(dma, dma_gd32_driver_api) = {
                                                                                \
 	DEVICE_DT_INST_DEFINE(inst, dma_gd32_init, NULL,                       \
 			      &dma_gd32##inst##_data,                          \
-			      &dma_gd32##inst##_config, POST_KERNEL,           \
+			      &dma_gd32##inst##_config, PRE_KERNEL_1,          \
 			      CONFIG_DMA_INIT_PRIORITY, &dma_gd32_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GD32_DMA_INIT)

--- a/drivers/serial/Kconfig.gd32
+++ b/drivers/serial/Kconfig.gd32
@@ -8,6 +8,9 @@ config USART_GD32
 	select PINCTRL
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select SERIAL_SUPPORT_ASYNC if DT_HAS_GD_GD32_DMA_ENABLED || \
+				       DT_HAS_GD_GD32_DMA_V1_ENABLED
+	select DMA if UART_ASYNC_API
 	select USE_GD32_USART
 	help
 	  This option enables the USART driver for GD32 SoC family.

--- a/drivers/serial/usart_gd32.c
+++ b/drivers/serial/usart_gd32.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, ATL Electronics
  * Copyright (c) 2025 Aleksandr Senin <al@meshium.net>
+ * Copyright (c) 2026 Liu Changjie <liucj1228@outlook.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,6 +11,10 @@
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/gd32.h>
+#ifdef CONFIG_UART_ASYNC_API
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/dma/dma_gd32.h>
+#endif
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/drivers/uart.h>
@@ -21,6 +26,53 @@
 #ifndef USART_STAT
 #define USART_STAT USART_STAT0
 #endif
+#ifndef USART_RDATA
+#define USART_RDATA USART_DATA
+#endif
+#ifndef USART_TDATA
+#define USART_TDATA USART_DATA
+#endif
+#ifndef USART_RECEIVE_DMA_ENABLE
+#define USART_RECEIVE_DMA_ENABLE USART_DENR_ENABLE
+#endif
+#ifndef USART_RECEIVE_DMA_DISABLE
+#define USART_RECEIVE_DMA_DISABLE USART_DENR_DISABLE
+#endif
+#ifndef USART_TRANSMIT_DMA_ENABLE
+#define USART_TRANSMIT_DMA_ENABLE USART_DENT_ENABLE
+#endif
+#ifndef USART_TRANSMIT_DMA_DISABLE
+#define USART_TRANSMIT_DMA_DISABLE USART_DENT_DISABLE
+#endif
+
+#ifdef CONFIG_UART_ASYNC_API
+enum gd32_usart_dma_dir {
+	GD32_USART_DMA_TX,
+	GD32_USART_DMA_RX,
+};
+
+struct gd32_usart_dma_config {
+	const struct device *dev;
+	uint32_t channel;
+	uint32_t slot;
+	uint32_t config;
+};
+
+struct gd32_usart_dma_data {
+	const struct device *uart_dev;
+	struct dma_config config;
+	struct dma_block_config block;
+	struct k_work_delayable timeout_work;
+	uint8_t *buf;
+	size_t len;
+	size_t offset;
+	uint8_t *next_buf;
+	size_t next_len;
+	int32_t timeout_us;
+	bool busy;
+	bool requested;
+};
+#endif /* CONFIG_UART_ASYNC_API */
 
 struct gd32_usart_config {
 	uint32_t reg;
@@ -28,9 +80,13 @@ struct gd32_usart_config {
 	struct reset_dt_spec reset;
 	const struct pinctrl_dev_config *pcfg;
 	uint32_t parity;
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#ifdef CONFIG_UART_ASYNC_API
+	const struct gd32_usart_dma_config dma_tx;
+	const struct gd32_usart_dma_config dma_rx;
+#endif /* CONFIG_UART_ASYNC_API */
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 	uart_irq_config_func_t irq_config_func;
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API */
 };
 
 struct gd32_usart_data {
@@ -39,6 +95,12 @@ struct gd32_usart_data {
 	uart_irq_callback_user_data_t user_cb;
 	void *user_data;
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+#ifdef CONFIG_UART_ASYNC_API
+	uart_callback_t async_cb;
+	void *async_user_data;
+	struct gd32_usart_dma_data dma_tx;
+	struct gd32_usart_dma_data dma_rx;
+#endif /* CONFIG_UART_ASYNC_API */
 #ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	enum uart_config_parity parity;
 	enum uart_config_stop_bits stop_bits;
@@ -48,16 +110,652 @@ struct gd32_usart_data {
 #endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 };
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
+#ifdef CONFIG_UART_ASYNC_API
+static void usart_gd32_rx_idle_clear(uint32_t reg);
+static void usart_gd32_rx_idle(const struct device *dev);
+#endif /* CONFIG_UART_ASYNC_API */
+
 static void usart_gd32_isr(const struct device *dev)
 {
+#ifdef CONFIG_UART_ASYNC_API
+	const struct gd32_usart_config *const cfg = dev->config;
+
+	if (usart_interrupt_flag_get(cfg->reg, USART_INT_FLAG_IDLE) == SET) {
+		usart_gd32_rx_idle_clear(cfg->reg);
+		usart_gd32_rx_idle(dev);
+	}
+#endif /* CONFIG_UART_ASYNC_API */
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	struct gd32_usart_data *const data = dev->data;
 
 	if (data->user_cb) {
 		data->user_cb(dev, data->user_data);
 	}
-}
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+}
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API */
+
+#ifdef CONFIG_UART_ASYNC_API
+static void usart_gd32_async_callback(const struct device *dev, struct uart_event *evt)
+{
+	struct gd32_usart_data *const data = dev->data;
+
+	if (data->async_cb) {
+		data->async_cb(dev, evt, data->async_user_data);
+	}
+}
+
+static void usart_gd32_rx_idle_clear(uint32_t reg)
+{
+	volatile uint32_t stat;
+	volatile uint32_t data;
+
+	stat = USART_STAT(reg);
+	data = USART_RDATA(reg);
+	ARG_UNUSED(stat);
+	ARG_UNUSED(data);
+
+	usart_flag_clear(reg, USART_FLAG_IDLE);
+}
+
+static bool usart_gd32_dma_ready(const struct gd32_usart_dma_config *dma)
+{
+	return dma->dev && device_is_ready(dma->dev);
+}
+
+static bool usart_gd32_async_ready(const struct device *dev)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+
+	return usart_gd32_dma_ready(&cfg->dma_tx) && usart_gd32_dma_ready(&cfg->dma_rx);
+}
+
+static int usart_gd32_dma_request_channel(const struct gd32_usart_dma_config *dma,
+					  struct gd32_usart_dma_data *dma_data)
+{
+	uint32_t ch_filter;
+	int ret;
+
+	if (dma_data->requested) {
+		return 0;
+	}
+
+	ch_filter = BIT(dma->channel);
+	ret = dma_request_channel(dma->dev, &ch_filter);
+	if (ret < 0) {
+		return ret;
+	}
+
+	dma_data->requested = true;
+
+	return 0;
+}
+
+static void usart_gd32_dma_release_channel(const struct gd32_usart_dma_config *dma,
+					   struct gd32_usart_dma_data *dma_data)
+{
+	if (!dma_data->requested) {
+		return;
+	}
+
+	dma_release_channel(dma->dev, dma->channel);
+	dma_data->requested = false;
+}
+
+static uint32_t usart_gd32_rx_data_addr(const struct device *dev)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+
+	return (uint32_t)(uintptr_t)&USART_RDATA(cfg->reg);
+}
+
+static uint32_t usart_gd32_tx_data_addr(const struct device *dev)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+
+	return (uint32_t)(uintptr_t)&USART_TDATA(cfg->reg);
+}
+
+static void usart_gd32_dma_tx_cb(const struct device *dma_dev, void *user_data, uint32_t channel,
+				 int status)
+{
+	const struct device *dev = user_data;
+	const struct gd32_usart_config *const cfg = dev->config;
+	struct gd32_usart_data *const data = dev->data;
+	size_t sent = data->dma_tx.len;
+
+	if (status != 0) {
+		struct dma_status dma_status = {0};
+
+		if (dma_get_status(cfg->dma_tx.dev, cfg->dma_tx.channel, &dma_status) == 0) {
+			sent = data->dma_tx.len - MIN(data->dma_tx.len, dma_status.pending_length);
+		}
+	}
+
+	struct uart_event evt = {
+		.type = status ? UART_TX_ABORTED : UART_TX_DONE,
+		.data.tx = {
+			.buf = data->dma_tx.buf,
+			.len = sent,
+		},
+	};
+
+	ARG_UNUSED(dma_dev);
+	ARG_UNUSED(channel);
+
+	usart_dma_transmit_config(cfg->reg, USART_TRANSMIT_DMA_DISABLE);
+	data->dma_tx.busy = false;
+	usart_gd32_dma_release_channel(&cfg->dma_tx, &data->dma_tx);
+	usart_gd32_async_callback(dev, &evt);
+}
+
+static void usart_gd32_dma_rx_cb(const struct device *dma_dev, void *user_data, uint32_t channel,
+				 int status);
+
+static void usart_gd32_rx_rdy(const struct device *dev, size_t len)
+{
+	struct gd32_usart_data *const data = dev->data;
+
+	if (len > data->dma_rx.offset) {
+		struct uart_event evt = {
+			.type = UART_RX_RDY,
+			.data.rx = {
+				.buf = data->dma_rx.buf,
+				.len = len - data->dma_rx.offset,
+				.offset = data->dma_rx.offset,
+			},
+		};
+
+		usart_gd32_async_callback(dev, &evt);
+		data->dma_rx.offset = len;
+	}
+}
+
+static void usart_gd32_rx_release(const struct device *dev, uint8_t *buf)
+{
+	struct uart_event release_evt = {
+		.type = UART_RX_BUF_RELEASED,
+		.data.rx_buf = {
+			.buf = buf,
+		},
+	};
+
+	usart_gd32_async_callback(dev, &release_evt);
+}
+
+static void usart_gd32_rx_request(const struct device *dev)
+{
+	struct uart_event request_evt = {
+		.type = UART_RX_BUF_REQUEST,
+	};
+
+	usart_gd32_async_callback(dev, &request_evt);
+}
+
+static void usart_gd32_rx_disabled(const struct device *dev)
+{
+	struct uart_event disabled_evt = {
+		.type = UART_RX_DISABLED,
+	};
+
+	usart_gd32_async_callback(dev, &disabled_evt);
+}
+
+static bool usart_gd32_rx_timeout_enabled(const struct device *dev)
+{
+	struct gd32_usart_data *const data = dev->data;
+
+	return data->dma_rx.timeout_us != SYS_FOREVER_US;
+}
+
+static void usart_gd32_rx_idle_enable(const struct device *dev)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+
+	if (!usart_gd32_rx_timeout_enabled(dev)) {
+		return;
+	}
+
+	usart_gd32_rx_idle_clear(cfg->reg);
+	usart_interrupt_enable(cfg->reg, USART_INT_IDLE);
+}
+
+static void usart_gd32_rx_idle_disable(const struct device *dev)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+	struct gd32_usart_data *const data = dev->data;
+
+	usart_interrupt_disable(cfg->reg, USART_INT_IDLE);
+	(void)k_work_cancel_delayable(&data->dma_rx.timeout_work);
+}
+
+static size_t usart_gd32_rx_received_len(const struct device *dev)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+	struct gd32_usart_data *const data = dev->data;
+	struct dma_status status = {0};
+
+	if (dma_get_status(cfg->dma_rx.dev, cfg->dma_rx.channel, &status) != 0) {
+		return 0U;
+	}
+
+	return data->dma_rx.len - MIN(data->dma_rx.len, status.pending_length);
+}
+
+static void usart_gd32_rx_stop(const struct device *dev, size_t len)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+	struct gd32_usart_data *const data = dev->data;
+
+	usart_gd32_rx_idle_disable(dev);
+	usart_dma_receive_config(cfg->reg, USART_RECEIVE_DMA_DISABLE);
+
+	usart_gd32_rx_rdy(dev, len);
+	if (data->dma_rx.buf) {
+		usart_gd32_rx_release(dev, data->dma_rx.buf);
+	}
+
+	if (data->dma_rx.next_buf) {
+		usart_gd32_rx_release(dev, data->dma_rx.next_buf);
+		data->dma_rx.next_buf = NULL;
+		data->dma_rx.next_len = 0U;
+	}
+
+	data->dma_rx.busy = false;
+	usart_gd32_dma_release_channel(&cfg->dma_rx, &data->dma_rx);
+	usart_gd32_rx_disabled(dev);
+}
+
+static int usart_gd32_dma_configure(const struct device *dev, enum gd32_usart_dma_dir dir,
+				    uint8_t *buf, size_t len)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+	struct gd32_usart_data *const data = dev->data;
+	const struct gd32_usart_dma_config *dma;
+	struct gd32_usart_dma_data *dma_data;
+	int ret;
+
+	if (dir == GD32_USART_DMA_TX) {
+		dma = &cfg->dma_tx;
+		dma_data = &data->dma_tx;
+	} else {
+		dma = &cfg->dma_rx;
+		dma_data = &data->dma_rx;
+	}
+
+	if (!usart_gd32_dma_ready(dma)) {
+		return -ENODEV;
+	}
+
+	ret = usart_gd32_dma_request_channel(dma, dma_data);
+	if (ret < 0) {
+		return ret;
+	}
+
+	memset(&dma_data->config, 0, sizeof(dma_data->config));
+	memset(&dma_data->block, 0, sizeof(dma_data->block));
+
+	dma_data->config.dma_slot = dma->slot;
+	dma_data->config.channel_priority = GD32_DMA_CONFIG_PRIORITY(dma->config);
+	dma_data->config.block_count = 1U;
+	dma_data->config.head_block = &dma_data->block;
+	dma_data->config.user_data = (void *)dev;
+	dma_data->config.source_burst_length = 1U;
+	dma_data->config.dest_burst_length = 1U;
+	dma_data->config.source_data_size = 1U;
+	dma_data->config.dest_data_size = 1U;
+
+	dma_data->block.block_size = len;
+
+	if (dir == GD32_USART_DMA_TX) {
+		dma_data->config.channel_direction = MEMORY_TO_PERIPHERAL;
+		dma_data->config.dma_callback = usart_gd32_dma_tx_cb;
+		dma_data->block.source_address = (uint32_t)(uintptr_t)buf;
+		dma_data->block.dest_address = usart_gd32_tx_data_addr(dev);
+		dma_data->block.source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+		dma_data->block.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+	} else {
+		dma_data->config.channel_direction = PERIPHERAL_TO_MEMORY;
+		dma_data->config.dma_callback = usart_gd32_dma_rx_cb;
+		dma_data->block.source_address = usart_gd32_rx_data_addr(dev);
+		dma_data->block.dest_address = (uint32_t)(uintptr_t)buf;
+		dma_data->block.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+		dma_data->block.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+	}
+
+	dma_data->buf = buf;
+	dma_data->len = len;
+	dma_data->offset = 0U;
+
+	return dma_config(dma->dev, dma->channel, &dma_data->config);
+}
+
+static int usart_gd32_rx_start(const struct device *dev, uint8_t *buf, size_t len)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+	struct gd32_usart_data *const data = dev->data;
+	int ret;
+
+	ret = usart_gd32_dma_configure(dev, GD32_USART_DMA_RX, buf, len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	data->dma_rx.busy = true;
+	usart_dma_receive_config(cfg->reg, USART_RECEIVE_DMA_ENABLE);
+
+	ret = dma_start(cfg->dma_rx.dev, cfg->dma_rx.channel);
+	if (ret < 0) {
+		usart_dma_receive_config(cfg->reg, USART_RECEIVE_DMA_DISABLE);
+		data->dma_rx.busy = false;
+		return ret;
+	}
+
+	usart_gd32_rx_idle_enable(dev);
+
+	return 0;
+}
+
+static void usart_gd32_dma_rx_cb(const struct device *dma_dev, void *user_data, uint32_t channel,
+				 int status)
+{
+	const struct device *dev = user_data;
+	const struct gd32_usart_config *const cfg = dev->config;
+	struct gd32_usart_data *const data = dev->data;
+	uint8_t *next_buf;
+	size_t next_len;
+	size_t len;
+	int ret;
+
+	ARG_UNUSED(dma_dev);
+	ARG_UNUSED(channel);
+
+	if (!data->dma_rx.busy) {
+		return;
+	}
+
+	len = (status == 0) ? data->dma_rx.len : usart_gd32_rx_received_len(dev);
+
+	if (status != 0) {
+		struct uart_event stopped_evt = {
+			.type = UART_RX_STOPPED,
+			.data.rx_stop = {
+				.reason = UART_ERROR_OVERRUN,
+			},
+		};
+
+		usart_gd32_async_callback(dev, &stopped_evt);
+		usart_gd32_rx_stop(dev, len);
+		return;
+	}
+
+	usart_gd32_rx_idle_disable(dev);
+	usart_dma_receive_config(cfg->reg, USART_RECEIVE_DMA_DISABLE);
+
+	usart_gd32_rx_rdy(dev, len);
+	usart_gd32_rx_release(dev, data->dma_rx.buf);
+
+	next_buf = data->dma_rx.next_buf;
+	next_len = data->dma_rx.next_len;
+	data->dma_rx.next_buf = NULL;
+	data->dma_rx.next_len = 0U;
+
+	if (!next_buf) {
+		data->dma_rx.busy = false;
+		usart_gd32_dma_release_channel(&cfg->dma_rx, &data->dma_rx);
+		usart_gd32_rx_disabled(dev);
+		return;
+	}
+
+	ret = usart_gd32_rx_start(dev, next_buf, next_len);
+	if (ret < 0) {
+		usart_gd32_rx_release(dev, next_buf);
+		data->dma_rx.busy = false;
+		usart_gd32_dma_release_channel(&cfg->dma_rx, &data->dma_rx);
+		usart_gd32_rx_disabled(dev);
+		return;
+	}
+
+	usart_gd32_rx_request(dev);
+}
+
+static void usart_gd32_rx_idle(const struct device *dev)
+{
+	struct gd32_usart_data *const data = dev->data;
+	size_t len;
+
+	if (!data->dma_rx.busy || !usart_gd32_rx_timeout_enabled(dev)) {
+		return;
+	}
+
+	len = usart_gd32_rx_received_len(dev);
+	if (len <= data->dma_rx.offset) {
+		return;
+	}
+
+	(void)k_work_reschedule(&data->dma_rx.timeout_work, K_USEC(data->dma_rx.timeout_us));
+}
+
+static void usart_gd32_rx_timeout(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gd32_usart_dma_data *dma_rx =
+		CONTAINER_OF(dwork, struct gd32_usart_dma_data, timeout_work);
+	const struct device *dev = dma_rx->uart_dev;
+	size_t len;
+	unsigned int key;
+
+	key = irq_lock();
+
+	if (!dma_rx->busy) {
+		irq_unlock(key);
+		return;
+	}
+
+	len = usart_gd32_rx_received_len(dev);
+	if (len <= dma_rx->offset) {
+		irq_unlock(key);
+		return;
+	}
+
+	usart_gd32_rx_rdy(dev, len);
+
+	irq_unlock(key);
+}
+
+static int usart_gd32_callback_set(const struct device *dev, uart_callback_t callback,
+				   void *user_data)
+{
+	struct gd32_usart_data *const data = dev->data;
+
+	if (!usart_gd32_async_ready(dev)) {
+		return -ENOSYS;
+	}
+
+	data->async_cb = callback;
+	data->async_user_data = user_data;
+
+	return 0;
+}
+
+static int usart_gd32_tx(const struct device *dev, const uint8_t *buf, size_t len, int32_t timeout)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+	struct gd32_usart_data *const data = dev->data;
+	int ret;
+
+	ARG_UNUSED(timeout);
+
+	if (buf == NULL || len == 0U) {
+		return -EINVAL;
+	}
+
+	if (data->dma_tx.busy) {
+		return -EBUSY;
+	}
+
+	if (!usart_gd32_dma_ready(&cfg->dma_tx)) {
+		return -ENODEV;
+	}
+
+	ret = usart_gd32_dma_configure(dev, GD32_USART_DMA_TX, (uint8_t *)buf, len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	data->dma_tx.busy = true;
+	usart_dma_transmit_config(cfg->reg, USART_TRANSMIT_DMA_ENABLE);
+
+	ret = dma_start(cfg->dma_tx.dev, cfg->dma_tx.channel);
+	if (ret < 0) {
+		usart_dma_transmit_config(cfg->reg, USART_TRANSMIT_DMA_DISABLE);
+		data->dma_tx.busy = false;
+		return ret;
+	}
+
+	return 0;
+}
+
+static int usart_gd32_tx_abort(const struct device *dev)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+	struct gd32_usart_data *const data = dev->data;
+	struct dma_status status = {0};
+	size_t sent = 0U;
+
+	if (!data->dma_tx.busy) {
+		return -EFAULT;
+	}
+
+	if (dma_get_status(cfg->dma_tx.dev, cfg->dma_tx.channel, &status) == 0) {
+		sent = data->dma_tx.len - MIN(data->dma_tx.len, status.pending_length);
+	}
+	(void)dma_stop(cfg->dma_tx.dev, cfg->dma_tx.channel);
+	usart_dma_transmit_config(cfg->reg, USART_TRANSMIT_DMA_DISABLE);
+
+	data->dma_tx.busy = false;
+	usart_gd32_dma_release_channel(&cfg->dma_tx, &data->dma_tx);
+
+	struct uart_event evt = {
+		.type = UART_TX_ABORTED,
+		.data.tx = {
+			.buf = data->dma_tx.buf,
+			.len = sent,
+		},
+	};
+
+	usart_gd32_async_callback(dev, &evt);
+
+	return 0;
+}
+
+static int usart_gd32_rx_enable(const struct device *dev, uint8_t *buf, size_t len, int32_t timeout)
+{
+	struct gd32_usart_data *const data = dev->data;
+	int ret;
+
+	if (buf == NULL || len == 0U) {
+		return -EINVAL;
+	}
+
+	if (timeout < 0 && timeout != SYS_FOREVER_US) {
+		return -EINVAL;
+	}
+
+	if (data->dma_rx.busy) {
+		return -EBUSY;
+	}
+
+	data->dma_rx.next_buf = NULL;
+	data->dma_rx.next_len = 0U;
+	data->dma_rx.timeout_us = timeout;
+	ret = usart_gd32_rx_start(dev, buf, len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	usart_gd32_rx_request(dev);
+
+	return 0;
+}
+
+static int usart_gd32_rx_disable(const struct device *dev)
+{
+	const struct gd32_usart_config *const cfg = dev->config;
+	struct gd32_usart_data *const data = dev->data;
+	struct dma_status status = {0};
+	uint8_t *buf;
+	uint8_t *next_buf;
+	size_t received = 0U;
+	unsigned int key;
+
+	key = irq_lock();
+	if (!data->dma_rx.busy) {
+		irq_unlock(key);
+		return -EFAULT;
+	}
+
+	if (dma_get_status(cfg->dma_rx.dev, cfg->dma_rx.channel, &status) == 0) {
+		received = data->dma_rx.len - MIN(data->dma_rx.len, status.pending_length);
+	}
+	(void)dma_stop(cfg->dma_rx.dev, cfg->dma_rx.channel);
+
+	usart_interrupt_disable(cfg->reg, USART_INT_IDLE);
+	usart_dma_receive_config(cfg->reg, USART_RECEIVE_DMA_DISABLE);
+
+	buf = data->dma_rx.buf;
+	next_buf = data->dma_rx.next_buf;
+	data->dma_rx.next_buf = NULL;
+	data->dma_rx.next_len = 0U;
+	data->dma_rx.busy = false;
+	usart_gd32_dma_release_channel(&cfg->dma_rx, &data->dma_rx);
+	irq_unlock(key);
+
+	(void)k_work_cancel_delayable(&data->dma_rx.timeout_work);
+
+	usart_gd32_rx_rdy(dev, received);
+	if (buf) {
+		usart_gd32_rx_release(dev, buf);
+	}
+	if (next_buf) {
+		usart_gd32_rx_release(dev, next_buf);
+	}
+	usart_gd32_rx_disabled(dev);
+
+	return 0;
+}
+
+static int usart_gd32_rx_buf_rsp(const struct device *dev, uint8_t *buf, size_t len)
+{
+	struct gd32_usart_data *const data = dev->data;
+	unsigned int key;
+	int ret = 0;
+
+	if (buf == NULL || len == 0U) {
+		return -EINVAL;
+	}
+
+	key = irq_lock();
+	if (!data->dma_rx.busy) {
+		ret = -EACCES;
+		goto unlock;
+	}
+
+	if (data->dma_rx.next_buf) {
+		ret = -EBUSY;
+		goto unlock;
+	}
+
+	data->dma_rx.next_buf = buf;
+	data->dma_rx.next_len = len;
+
+unlock:
+	irq_unlock(key);
+	return ret;
+}
+#endif /* CONFIG_UART_ASYNC_API */
 
 static int usart_gd32_init(const struct device *dev)
 {
@@ -107,9 +805,15 @@ static int usart_gd32_init(const struct device *dev)
 	usart_transmit_config(cfg->reg, USART_TRANSMIT_ENABLE);
 	usart_enable(cfg->reg);
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 	cfg->irq_config_func(dev);
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API */
+#ifdef CONFIG_UART_ASYNC_API
+	data->dma_tx.uart_dev = dev;
+	data->dma_rx.uart_dev = dev;
+	data->dma_rx.timeout_us = SYS_FOREVER_US;
+	k_work_init_delayable(&data->dma_rx.timeout_work, usart_gd32_rx_timeout);
+#endif /* CONFIG_UART_ASYNC_API */
 #ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	/* Initialize runtime configuration from Devicetree defaults */
 	data->parity = cfg->parity;
@@ -421,6 +1125,14 @@ static DEVICE_API(uart, usart_gd32_driver_api) = {
 	.configure = usart_gd32_configure,
 	.config_get = usart_gd32_config_get,
 #endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
+#ifdef CONFIG_UART_ASYNC_API
+	.callback_set = usart_gd32_callback_set,
+	.tx = usart_gd32_tx,
+	.tx_abort = usart_gd32_tx_abort,
+	.rx_enable = usart_gd32_rx_enable,
+	.rx_disable = usart_gd32_rx_disable,
+	.rx_buf_rsp = usart_gd32_rx_buf_rsp,
+#endif /* CONFIG_UART_ASYNC_API */
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = usart_gd32_fifo_fill,
 	.fifo_read = usart_gd32_fifo_read,
@@ -438,7 +1150,7 @@ static DEVICE_API(uart, usart_gd32_driver_api) = {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 #define GD32_USART_IRQ_HANDLER(n)						\
 	static void usart_gd32_config_func_##n(const struct device *dev)	\
 	{									\
@@ -451,10 +1163,32 @@ static DEVICE_API(uart, usart_gd32_driver_api) = {
 	}
 #define GD32_USART_IRQ_HANDLER_FUNC_INIT(n)					\
 	.irq_config_func = usart_gd32_config_func_##n
-#else /* CONFIG_UART_INTERRUPT_DRIVEN */
+#else /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API */
 #define GD32_USART_IRQ_HANDLER(n)
 #define GD32_USART_IRQ_HANDLER_FUNC_INIT(n)
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API */
+
+#ifdef CONFIG_UART_ASYNC_API
+#define GD32_USART_DMA_INITIALIZER(idx, dir)					\
+	{									\
+		.dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(idx, dir)),	\
+		.channel = DT_INST_DMAS_CELL_BY_NAME(idx, dir, channel),		\
+		.slot = COND_CODE_1(						\
+			DT_HAS_COMPAT_STATUS_OKAY(gd_gd32_dma_v1),		\
+			(DT_INST_DMAS_CELL_BY_NAME(idx, dir, slot)), (0)),	\
+		.config = DT_INST_DMAS_CELL_BY_NAME(idx, dir, config),		\
+		}
+
+#define GD32_USART_DMA_INIT(idx, dir)						\
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(idx, dir),				\
+		    (GD32_USART_DMA_INITIALIZER(idx, dir)), ({0}))
+
+#define GD32_USART_DMA_CONFIG_INIT(n)						\
+	.dma_tx = GD32_USART_DMA_INIT(n, tx),					\
+	.dma_rx = GD32_USART_DMA_INIT(n, rx),
+#else
+#define GD32_USART_DMA_CONFIG_INIT(n)
+#endif /* CONFIG_UART_ASYNC_API */
 
 #define GD32_USART_INIT(n)							\
 	PINCTRL_DT_INST_DEFINE(n);						\
@@ -468,6 +1202,7 @@ static DEVICE_API(uart, usart_gd32_driver_api) = {
 		.reset = RESET_DT_SPEC_INST_GET(n),				\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
 		.parity = DT_INST_ENUM_IDX(n, parity),				\
+		GD32_USART_DMA_CONFIG_INIT(n)					\
 		 GD32_USART_IRQ_HANDLER_FUNC_INIT(n)				\
 	};									\
 	DEVICE_DT_INST_DEFINE(n, usart_gd32_init,				\

--- a/dts/bindings/serial/gd,gd32-usart.yaml
+++ b/dts/bindings/serial/gd,gd32-usart.yaml
@@ -19,3 +19,9 @@ properties:
 
   clocks:
     required: true
+
+  dmas:
+    description: DMA channels for TX and RX transfers.
+
+  dma-names:
+    description: DMA channel names. Expected values are "tx" and "rx".


### PR DESCRIPTION
Add DMA-backed UART asynchronous API support for GD32 USART.

  This adds:
  - Optional `dmas` and `dma-names` devicetree properties for GD32 USART
  - DMA-backed TX and RX paths in `usart_gd32`
  - Double-buffered RX handling with `UART_RX_BUF_REQUEST` and release events
  - IDLE-line based RX timeout support
  - TX abort reporting based on transferred byte count
  - GD32 DMA initialization at `PRE_KERNEL_1` so serial drivers can use DMA
    during their own init

  The async capability is enabled when a GD32 DMA node is present in
  devicetree.

  Validation:
  - Hardware echo validation was done on the upstream SkyStar GD32F407VET6
    integration branch using USART DMA RX/TX.