### PR TITLE
modules: hostap: default choose SNR for network selection

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -746,6 +746,15 @@ Networking
   :kconfig:option:`CONFIG_NET_L2_PTP` should be updated to use
   :kconfig:option:`CONFIG_NET_L2_PTP_TIMESTAMPING` instead.
 
+* The default WPA supplicant network selection criterion has changed from
+  throughput-based to reliability-based (SNR), switching the
+  :kconfig:option:`WIFI_NM_WPA_SUPPLICANT_NW_SEL` Kconfig default from
+  :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_NW_SEL_THROUGHPUT` to
+  :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_NW_SEL_RELIABILITY`.
+  Previously, SNR above 25 dBm was considered sufficient and largely excluded
+  from AP selection; SNR is now always factored in, improving connection stability
+  for embedded Wi-Fi use cases. Users who need the previous behaviour can restore it by enabling
+  :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_NW_SEL_THROUGHPUT`.
 
 Ethernet
 ========

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -801,7 +801,7 @@ config FIPS
 
 choice WIFI_NM_WPA_SUPPLICANT_NW_SEL
 	prompt "WPA supplicant Network selection criterion"
-	default WIFI_NM_WPA_SUPPLICANT_NW_SEL_THROUGHPUT
+	default WIFI_NM_WPA_SUPPLICANT_NW_SEL_RELIABILITY
 	help
 	  Select the network selection method for the supplicant.
 


### PR DESCRIPTION
For RTOS Wi-Fi device, SNR is more often required than throughput.
    Throughput-based selection favors APs advertising higher data rates or
    wider channel bandwidth, which may not reflect actual link quality in
    embedded/IoT deployments. In contrast, SNR-based selection prioritizes
    signal quality, leading to more stable connections, fewer
    retransmissions, and better roaming decisions — all critical for
    resource-constrained RTOS devices that prioritize connection stability
    over raw throughput.
    
    So choose WIFI_NM_WPA_SUPPLICANT_NW_SEL_RELIABILITY by default.