### PR TITLE
drivers/flash: ite: Fix upper bound calculation and simplify erase flow

### DIFF
--- a/drivers/flash/flash_ite_it51xxx_m1k.c
+++ b/drivers/flash/flash_ite_it51xxx_m1k.c
@@ -283,7 +283,8 @@ static int m1k_flash_erase(const struct device *dev, off_t offset, size_t len)
 	flash_set_m1k_pe_lba(dev, offset);
 
 	/* It's the upper bound address of M1K-ERASE */
-	flash_set_m1k_erase_uba(dev, offset + FLASH_ERASE_BLK_SZ);
+	/* UBA points to the last 4KB block of the erase region. */
+	flash_set_m1k_erase_uba(dev, offset + len - FLASH_ERASE_BLK_SZ);
 
 	m1kflhctrl7_cmd = sys_read8(SMFI_M1KFLHCTRL7) & ~GENMASK(7, 6);
 	/* Erase the flash within an address range */
@@ -499,15 +500,9 @@ static int flash_it51xxx_erase(const struct device *dev, off_t offset, size_t le
 
 	k_sem_take(&data->sem, K_FOREVER);
 
-	while (len > 0) {
-		ret = m1k_flash_erase(dev, offset, len);
-		if (ret != 0) {
-			LOG_ERR("%s: failed at offset=%#lx", __func__, offset);
-			break;
-		}
-
-		offset += FLASH_ERASE_BLK_SZ;
-		len -= FLASH_ERASE_BLK_SZ;
+	ret = m1k_flash_erase(dev, offset, len);
+	if (ret != 0) {
+		LOG_ERR("%s: failed at offset=%#lx", __func__, offset);
 	}
 
 	k_sem_give(&data->sem);


### PR DESCRIPTION
Upper bound is defined as the last block within the erase region. Subtract one block unit from the erase size when programming upper bound to prevent the erase range from extending into the next block.

With the correct upper/lower bounds in place, erase requests can be handled in a single operation. Remove the block-by-block erase loop.