### PR TITLE
boards: beagle: beagleconnect_zepto: Enable watchdog timer

### DIFF
--- a/boards/beagle/beagleconnect_zepto/beagleconnect_zepto.dts
+++ b/boards/beagle/beagleconnect_zepto/beagleconnect_zepto.dts
@@ -19,6 +19,7 @@
 	aliases {
 		led0 = &led0;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 
 	chosen {
@@ -72,5 +73,9 @@
 };
 
 &gpioa {
+	status = "okay";
+};
+
+&wdt0 {
 	status = "okay";
 };

--- a/boards/beagle/beagleconnect_zepto/beagleconnect_zepto.yaml
+++ b/boards/beagle/beagleconnect_zepto/beagleconnect_zepto.yaml
@@ -16,3 +16,4 @@ vendor: beagle
 supported:
   - pinctrl
   - uart
+  - watchdog


### PR DESCRIPTION
- Tested with samples/drivers/watchdog/