### PR TITLE
drivers: dma: drop LOG_INF from nxp_gdma init

### DIFF
--- a/drivers/dma/dma_nxp_gdma.c
+++ b/drivers/dma/dma_nxp_gdma.c
@@ -326,8 +326,6 @@ static int dma_nxp_gdma_init(const struct device *dev)
 	/* Configure and enable interrupts */
 	config->irq_config_func(dev);
 
-	LOG_INF("NXP GDMA initialized with %d channels", config->num_channels);
-
 	return 0;
 }
 


### PR DESCRIPTION
dma_nxp_gdma_init() runs at PRE_KERNEL_1 and emitted an unconditional LOG_INF on the init success path. Under the default deferred logging mode that log captures a timestamp via the system clock, which on RW612 is not initialized until PRE_KERNEL_2, hanging boot on frdm_rw612 (seen with the lvgl sample). ztest masks it by defaulting to minimal logging, which takes no timestamp.

Other DMA drivers that log on init success run at POST_KERNEL, after the clock is up; nxp_gdma is the only one doing so at PRE_KERNEL_1. Remove the line to avoid the early-boot hang.