### PR TITLE
boards: shields: adafruit_2_8_tft_touch_v2: fix rotation, color & mirror

### DIFF
--- a/boards/shields/adafruit_2_8_tft_touch_v2/boards/rd_rw612_bga.overlay
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/boards/rd_rw612_bga.overlay
@@ -43,10 +43,12 @@
 		mipi-max-frequency = <15151515>;
 		duplex = <SPI_HALF_DUPLEX>;
 		reg = <0>;
-		width = <320>;
-		height = <240>;
-		pixel-format = <PANEL_PIXEL_FORMAT_RGB888>;
-		rotation = <90>;
+		width = <240>;
+		height = <320>;
+		pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
+		rotation = <270>;
+		v-mirror;
+		red-blue-swap;
 		frmctr1 = [00 18];
 		pwctrl1 = [23 00];
 		vmctrl1 = [3e 28];

--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -28,7 +28,9 @@
 			width = <240>;
 			height = <320>;
 			pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
-			rotation = <90>;
+			rotation = <270>;
+			v-mirror;
+			red-blue-swap;
 			frmctr1 = [00 18];
 			pwctrl1 = [23 00];
 			vmctrl1 = [3e 28];
@@ -63,10 +65,8 @@
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		swapped-x-y;
-		inverted-x;
-		inverted-y;
-		screen-width = <320>;
-		screen-height = <240>;
+		screen-width = <240>;
+		screen-height = <320>;
 		/* Uncomment if IRQ line is available (requires to solder jumper) */
 		/* int-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>; */
 	};


### PR DESCRIPTION
When testing this display shield with a nrf52840dk and with the sample `samples/drivers/display/` and `samples/subsys/display/lvgl` I noticed that display is mirrored and the colors are wrong. 
This PR does the following
- for ili9340, add `v-mirror` and `red-blue-swap`. 
- fix xy resolution for the touch ft5336
- change rotation to 270, see result in the photos below

I have tested it again with the samples:

<img width="640" height="480" alt="IMG_5126 Medium" src="https://github.com/user-attachments/assets/9f312502-249f-40ea-af0d-9a7e096c3194" />

(the hello world button is blue)
<img width="640" height="480" alt="IMG_5125 Medium" src="https://github.com/user-attachments/assets/28c3f83b-8cee-4c90-874a-2dbcbb16e839" />

fixes #111481 