### PR TITLE
cmake: use `<file.ld>` for linker snippets inclusion

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1473,7 +1473,7 @@ function(zephyr_linker_sources location)
     file(RELATIVE_PATH relpath ${ZEPHYR_BASE}/include ${path})
 
     # Create strings to be written into the file
-    set (include_str "/* Sort key: \"${SORT_KEY}\" */#include \"${relpath}\"")
+    set (include_str "/* Sort key: \"${SORT_KEY}\" */#include <${relpath}>")
 
     # Remove line from other snippet file, if already used
     get_property(old_path GLOBAL PROPERTY "snippet_files_used_${relpath}")

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1456,7 +1456,7 @@ function(zephyr_linker_sources location)
     file(RELATIVE_PATH relpath ${ZEPHYR_BASE}/include ${path})
 
     # Create strings to be written into the file
-    set (include_str "/* Sort key: \"${SORT_KEY}\" */#include \"${relpath}\"")
+    set(include_str "/* Sort key: \"${SORT_KEY}\" */#include <${relpath}>")
 
     # Remove line from other snippet file, if already used
     get_property(old_path GLOBAL PROPERTY "snippet_files_used_${relpath}")


### PR DESCRIPTION
Use `<file.ld>` for linker snippet inclusion instead of `"file.ld"` to ensure files are picked up relative to the `<zephyr_base>/include` folder and not the linker template currently being pre-processed.

Fixes: #110877