### PR TITLE
Clean-up Doxygen top-level group + add CI check

### DIFF
--- a/.github/workflows/doxygen-checks.yml
+++ b/.github/workflows/doxygen-checks.yml
@@ -1,10 +1,14 @@
 # SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# Workflow that triggers on changes impacting API documentation and that checks that any newly
-# introduced API is properly documented.
+# Workflow that triggers on changes impacting API documentation. It checks that any newly
+# introduced API is properly documented, and that no new group shows up at the top level of the
+# API documentation index.
+#
+# The paths below track the Doxygen INPUT set declared in doc/zephyr.doxyfile.in, since a
+# top-level group can be introduced from any of those roots.
 
-name: Doxygen Coverage Delta Check
+name: Doxygen Checks
 
 on:
   pull_request:
@@ -12,8 +16,16 @@ on:
       - 'include/**'
       - 'subsys/testsuite/include/**'
       - 'subsys/testsuite/ztest/include/**'
+      - 'subsys/secure_storage/include/**'
+      - 'kernel/include/kernel_arch_interface.h'
+      - 'lib/libc/**'
+      - 'lib/midi2/**'
+      - 'modules/openthread/include/openthread.h'
+      - 'doc/_doxygen/**'
+      - 'doc/zephyr.doxyfile.in'
       - 'scripts/ci/doxygen_coverage_diff.py'
-      - '.github/workflows/doxygen-coverage-delta.yml'
+      - 'scripts/ci/doxygen_toplevel_groups.py'
+      - '.github/workflows/doxygen-checks.yml'
     branches:
       - main
       - v*-branch
@@ -23,8 +35,8 @@ permissions:
   contents: read
 
 jobs:
-  doc-coverage-diff:
-    name: "Doxygen Coverage Delta Check"
+  doxygen-checks:
+    name: "Doxygen Checks"
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
@@ -98,3 +110,10 @@ jobs:
             --warn-paths "include/zephyr/dt-bindings" \
             --warn-paths "include/zephyr/posix" \
             --summary-file "$GITHUB_STEP_SUMMARY"
+
+      # Runs even when the coverage check above failed, so that a contributor sees every problem
+      # in a single run. Reads the Doxygen XML produced for the PR branch further up.
+      - name: Check for new top-level Doxygen groups
+        if: ${{ !cancelled() }}
+        run: |
+          python3 scripts/ci/doxygen_toplevel_groups.py --xml-dir doc/_build/doxygen/xml

--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -291,6 +291,7 @@
 
 @brief Connectivity
 @defgroup connectivity Connectivity
+@ingroup os_services
 @{
 @}
 

--- a/doc/_doxygen/toplevel_groups.txt
+++ b/doc/_doxygen/toplevel_groups.txt
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Groups allowed at the top level of the API documentation index.
+#
+# A Doxygen group ends up here when no other group pulls it in with @ingroup or
+# @addtogroup. These are the coarse categories of the API index, so the list is
+# meant to stay short: nest a new group under an existing category instead of
+# adding a line below. Enforced by scripts/ci/doxygen_toplevel_groups.py.
+#
+# Blank lines are ignored and '#' starts a comment.
+
+# zephyr-keep-sorted-start
+device_model
+devicetree
+internal_api
+io_interfaces
+kernel_apis
+mem_mgmt
+os_services
+system_errno
+testing
+third_party
+toolchain
+utilities
+# zephyr-keep-sorted-stop
+
+# Doxygen's EXCLUDE_SYMBOLS drops leading-underscore names, so these three never
+# appear on the homepage but they are still top level in the Doxygen XML. list
+# them here to avoid having to maintain duplicated logic in
+# `doxygen_toplevel_groups` for groups that are going to be deleted soon anyway
+# as they are for the deprecated legacy USB device stack.
+_usb_device_core_api
+_usb_device_controller_api
+_usbc_device_api

--- a/doc/contribute/style/doxygen.rst
+++ b/doc/contribute/style/doxygen.rst
@@ -126,6 +126,15 @@ Example:
    For example, device driver emulators typically appear both in "Emulator Interfaces" and "Device
    drivers" groups. See :c:group:`i2c_emul_interface` for an example.
 
+.. important::
+
+   A group with no parent becomes a top-level entry of the :ref:`api_overview`, whose categories
+   are deliberately few. Always give a new group a parent with ``@ingroup``.
+
+   The top-level entries are allowlisted in :zephyr_file:`doc/_doxygen/toplevel_groups.txt` and
+   enforced by :zephyr_file:`scripts/ci/doxygen_toplevel_groups.py`. Adding a new one requires
+   documentation maintainer approval.
+
 .. _doxygen_api_versioning:
 
 API Versioning

--- a/include/zephyr/audio/dmic.h
+++ b/include/zephyr/audio/dmic.h
@@ -20,6 +20,8 @@
 
 /**
  * @defgroup audio_interface Audio
+ * @ingroup io_interfaces
+ * @brief Interfaces for audio devices.
  * @{
  * @}
  */

--- a/include/zephyr/drivers/modem/hl7800.h
+++ b/include/zephyr/drivers/modem/hl7800.h
@@ -1,5 +1,6 @@
 /** @file
  * @brief HL7800 modem public API header file.
+ * @ingroup hl7800_interface
  *
  * Allows an application to control the HL7800 modem.
  *
@@ -18,6 +19,13 @@ extern "C" {
 #include <zephyr/types.h>
 
 #include <time.h>
+
+/**
+ * @defgroup hl7800_interface HL7800
+ * @brief Sierra Wireless HL7800 cellular modems.
+ * @ingroup cellular_interface_ext
+ * @{
+ */
 
 /* The size includes the NUL character, the strlen doesn't */
 #define MDM_HL7800_REVISION_MAX_SIZE 29
@@ -556,5 +564,7 @@ uint32_t mdm_hl7800_log_filter_set(uint32_t level);
 #ifdef __cplusplus
 }
 #endif
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_HL7800_H_ */

--- a/include/zephyr/drivers/modem/simcom-sim7080.h
+++ b/include/zephyr/drivers/modem/simcom-sim7080.h
@@ -1,5 +1,6 @@
 /** @file
  * @brief Simcom SIM7080 modem public API header file.
+ * @ingroup simcom_sim7080_interface
  *
  * Copyright (C) 2021 metraTec GmbH
  *
@@ -18,6 +19,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup simcom_sim7080_interface SIMCom SIM7080
+ * @brief SIMCom SIM7080 cellular modems.
+ * @ingroup cellular_interface_ext
+ * @{
+ */
 
 /** Maximum Length of GNSS UTC data */
 #define SIM7080_GNSS_DATA_UTC_LEN 20
@@ -636,5 +644,7 @@ int mdm_sim7080_set_lte_bands(uint32_t nb1, uint32_t m1);
 #ifdef __cplusplus
 }
 #endif
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_SIMCOM_SIM7080_H */

--- a/include/zephyr/dt-bindings/clock/imx952_clock.h
+++ b/include/zephyr/dt-bindings/clock/imx952_clock.h
@@ -109,6 +109,7 @@
 
 /**
  * @defgroup imx952_peripheral_clocks Peripheral Clocks (41-163)
+ * @ingroup imx952_clock_sources
  * Peripheral clock definitions based on MIMX9529 fsl_clock.h
  * @{
  */

--- a/include/zephyr/dt-bindings/clock/microchip-smartfusion2-clock.h
+++ b/include/zephyr/dt-bindings/clock/microchip-smartfusion2-clock.h
@@ -5,16 +5,18 @@
  */
 
 /**
- * @file microchip-smartfusion2-clock.h
- * @brief SmartFusion2 clock binding identifiers.
+ * @file
+ * @brief Clock identifiers for Microchip SmartFusion2
+ * @ingroup microchip_smartfusion2_clocks
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MICROCHIP_SMARTFUSION2_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MICROCHIP_SMARTFUSION2_CLOCK_H_
 
 /**
- * @defgroup smartfusion2_clock SmartFusion2 Clock Bindings
- * @brief SmartFusion2 SoC clock assignments.
+ * @defgroup microchip_smartfusion2_clocks Microchip SmartFusion2 clock identifiers
+ * @brief Clock identifiers for the Microchip SmartFusion2 SoC.
+ * @ingroup devicetree-clocks
  * @{
  */
 

--- a/include/zephyr/dt-bindings/interrupt-controller/microchip-smartfusion2-irq.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/microchip-smartfusion2-irq.h
@@ -4,18 +4,50 @@
  */
 
 /**
- * @file microchip-smartfusion2-irq.h
- * @brief SmartFusion2 interrupt binding identifiers.
+ * @file
+ * @brief Microchip SmartFusion2 interrupt controller devicetree macros
+ * @ingroup dt_microchip_smartfusion2_irq
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_MICROCHIP_SMARTFUSION2_IRQ_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_MICROCHIP_SMARTFUSION2_IRQ_H_
 
 /**
- * @defgroup smartfusion2_irq SmartFusion2 Interrupt Bindings
- * @brief SmartFusion2 SoC interrupt assignments.
+ * @defgroup dt_microchip_smartfusion2_irq Microchip SmartFusion2 interrupt controller
+ * @brief Devicetree macros for the Microchip SmartFusion2 interrupt controller.
+ * @ingroup devicetree-interrupt_controller
+ *
+ * This header provides the MSS interrupt numbers for the SmartFusion2 SoC. Interrupts are
+ * routed to the Cortex-M3 NVIC, so an @c interrupts entry takes two cells: the interrupt
+ * number, followed by the NVIC priority.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/interrupt-controller/microchip-smartfusion2-irq.h>
+ *
+ * uart0: serial@40000000 {
+ *         compatible = "ns16550";
+ *         reg = <0x40000000 0x1000>;
+ *         interrupts = <SMARTFUSION2_IRQ_UART0 4>;
+ * };
+ * @endcode
+ *
+ * Interrupt numbers follow two naming conventions:
+ *
+ * - <tt>SMARTFUSION2_IRQ_\<peripheral\></tt> is the interrupt number for an MSS peripheral,
+ *   for example @c SMARTFUSION2_IRQ_UART0, @c SMARTFUSION2_IRQ_ETHERNET_MAC, or
+ *   @c SMARTFUSION2_IRQ_TIMER1. Use these in new devicetree sources.
+ * - <tt>M2S_IRQ_\<peripheral\></tt> are legacy aliases retained for the existing in-tree
+ *   sources. Each expands to its @c SMARTFUSION2_IRQ_* counterpart, and several alias the
+ *   same underlying interrupt: @c M2S_IRQ_I2C0_MAIN, @c M2S_IRQ_I2C0_ALERT and
+ *   @c M2S_IRQ_I2C0_SUS all resolve to @c SMARTFUSION2_IRQ_I2C0.
+ *
+ * @c SMARTFUSION2_IRQ_WDOG_WAKEUP and @c SMARTFUSION2_IRQ_RTC_WAKEUP name wakeup sources that
+ * are not connected to the NVIC.
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
 
 /** @brief Default, unspecified interrupt type. */
 #define IRQ_TYPE_NONE                      0
@@ -133,6 +165,8 @@
 #define M2S_IRQ_USB_DMA                   SMARTFUSION2_IRQ_USB_DMA
 /** @brief Legacy alias for GPIO0 interrupt. */
 #define M2S_IRQ_GPIO0                     SMARTFUSION2_IRQ_GPIO0
+
+/** @endcond */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/pinctrl/focaltech_ft9001_pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/focaltech_ft9001_pinctrl.h
@@ -7,19 +7,19 @@
 /**
  * @file
  * @brief Devicetree pin control helpers for FocalTech FT9001
- * @ingroup focaltech_ft9001_pinctrl
+ * @ingroup pinctrl_focaltech_ft9001
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_FOCALTECH_FT9001_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_FOCALTECH_FT9001_PINCTRL_H_
 
 /**
- * @defgroup focaltech_pinctrl FocalTech pin control helpers
+ * @addtogroup focaltech_pinctrl FocalTech pin control helpers
  * @ingroup devicetree-pinctrl
  */
 
 /**
- * @defgroup focaltech_ft9001_pinctrl FocalTech FT9001 pin control helpers
+ * @defgroup pinctrl_focaltech_ft9001 FocalTech FT9001 pin control helpers
  * @brief Macros for pin multiplexing configuration on FocalTech FT9001
  * @ingroup focaltech_pinctrl
  *
@@ -64,10 +64,6 @@
 #define FOCALTECH_PINCTRL_BIT_MASK   0x1FU
 #define FOCALTECH_PINCTRL_REG_MASK   0xFFFFFU
 
-#define FOCALTECH_PINMUX(reg, bit, value)                                                          \
-	(((reg) << FOCALTECH_PINCTRL_REG_POS) | ((bit) << FOCALTECH_PINCTRL_BIT_POS) |             \
-	 ((value) << FOCALTECH_PINCTRL_VALUE_POS))
-
 #define FOCALTECH_PINCTRL_REG_GET(pinmux)                                                          \
 	((((pinmux) >> FOCALTECH_PINCTRL_REG_POS) & FOCALTECH_PINCTRL_REG_MASK) |                  \
 	 FOCALTECH_IOCTRL_BASE)
@@ -94,6 +90,7 @@
 /**
  * @defgroup focaltech_pinctrl_regs FT9001 IOCTRL register offsets
  * @brief Register offsets used as @a reg arguments to @ref FOCALTECH_PINMUX
+ * @ingroup pinctrl_focaltech_ft9001
  * @{
  */
 

--- a/include/zephyr/dt-bindings/power/imx952_power.h
+++ b/include/zephyr/dt-bindings/power/imx952_power.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Power domain definitions for NXP i.MX952 SoC
+ * @ingroup imx952_power_domains
  *
  * This file defines power domain IDs for the i.MX952 system-on-chip.
  * These definitions are based on MIMX9529 fsl_power.h from MCUXpresso SDK.
@@ -16,8 +17,9 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_POWER_IMX952_POWER_H_
 
 /**
- * @defgroup imx952_power_domains Power Domain IDs
- * @brief Power domain slice indices for i.MX952 SoC (21 total)
+ * @defgroup imx952_power_domains NXP i.MX952 Power Domains
+ * @brief Power domain slice indices for i.MX952 SoC
+ * @ingroup devicetree
  * @{
  */
 

--- a/include/zephyr/dt-bindings/reset/focaltech_ft9001_reset.h
+++ b/include/zephyr/dt-bindings/reset/focaltech_ft9001_reset.h
@@ -4,12 +4,44 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for FocalTech FT9001
+ * @ingroup reset_controller_focaltech_ft9001
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_FOCALTECH_FT9001_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_FOCALTECH_FT9001_RESET_H_
 
 /**
+ * @defgroup reset_controller_focaltech_ft9001 FocalTech FT9001 reset controller helpers
+ * @brief FocalTech FT9001 reset controller helpers
+ * @ingroup reset_controller_interface
+ *
+ * Devicetree macros for encoding peripheral reset cells on FocalTech FT9001 devices, for use with
+ * the <tt>focaltech,ft9001-cpm-rctl</tt> compatible reset controller.
+ *
+ * Reset identifiers follow the pattern @c FOCALTECH_RESET_\<PERIPHERAL\>, where @c \<PERIPHERAL\>
+ * is the FT9001 peripheral name from the reference manual (for example, @c FOCALTECH_RESET_SCI2
+ * resets SCI2 and @c FOCALTECH_RESET_EPORT0 resets EPORT0). Pass these identifiers directly to a
+ * @c resets property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/reset/focaltech_ft9001_reset.h>
+ *
+ * &sci2 {
+ *         resets = <&rctl FOCALTECH_RESET_SCI2>;
+ * };
+ * @endcode
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
  * @defgroup focaltech_reset_macros FocalTech Reset Configuration Macros
  * @brief Macros for encoding reset register and bit information
+ * @ingroup reset_controller_focaltech_ft9001
  * @{
  */
 
@@ -21,9 +53,12 @@
 
 /** @} */
 
+/** @endcond */
+
 /**
  * @defgroup focaltech_reset_regs FocalTech Reset Control Module Registers
  * @brief Reset Control Module Register offsets
+ * @ingroup reset_controller_focaltech_ft9001
  * @{
  */
 
@@ -45,12 +80,14 @@
 /**
  * @defgroup focaltech_reset_enables FocalTech Reset Enable/Disable Definitions
  * @brief Reset enable/disable definitions for peripherals
+ * @ingroup reset_controller_focaltech_ft9001
  * @{
  */
 
 /**
  * @defgroup focaltech_eportrstr_resets EPORTRSTR Reset Control
  * @brief EPORT Reset Control Register peripherals
+ * @ingroup focaltech_reset_enables
  * @{
  */
 
@@ -80,6 +117,7 @@
 /**
  * @defgroup focaltech_multirstcr_resets MULTIRSTCR Reset Control
  * @brief Multi Reset Control Register peripherals
+ * @ingroup focaltech_reset_enables
  * @{
  */
 
@@ -121,6 +159,7 @@
 /**
  * @defgroup focaltech_sysrstcr_resets SYSRSTCR Reset Control
  * @brief System Reset Control Register peripherals
+ * @ingroup focaltech_reset_enables
  * @{
  */
 
@@ -158,6 +197,7 @@
 /**
  * @defgroup focaltech_ahb3rstcr_resets AHB3RSTCR Reset Control
  * @brief AHB3 Reset Control Register peripherals
+ * @ingroup focaltech_reset_enables
  * @{
  */
 
@@ -183,6 +223,7 @@
 /**
  * @defgroup focaltech_arithrstcr_resets ARITHRSTCR Reset Control
  * @brief Algorithm Reset Control Register peripherals
+ * @ingroup focaltech_reset_enables
  * @{
  */
 
@@ -214,6 +255,7 @@
 /**
  * @defgroup focaltech_ipsrstcr_resets IPSRSTCR Reset Control
  * @brief IPS Reset Control Register peripherals
+ * @ingroup focaltech_reset_enables
  * @{
  */
 
@@ -279,6 +321,8 @@
 #define FOCALTECH_RESET_AHB2IPS FOCALTECH_RESET_CONFIG(IPSRSTCR, 30U)
 /** PWMT3 reset */
 #define FOCALTECH_RESET_PWMT3   FOCALTECH_RESET_CONFIG(IPSRSTCR, 31U)
+
+/** @} */
 
 /** @} */
 

--- a/include/zephyr/tracing/tracing_hooks.h
+++ b/include/zephyr/tracing/tracing_hooks.h
@@ -27,6 +27,7 @@
 /**
  * @brief Tracing hooks for thread events
  * @defgroup subsys_tracing_apis_thread Thread
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -377,11 +378,12 @@
 #define sys_port_trace_k_thread_sched_suspend(thread)
 #endif
 
-/** @}c*/ /* end of subsys_tracing_apis_thread */
+/** @} */ /* end of subsys_tracing_apis_thread */
 
 /**
  * @brief Tracing hooks for work item events
  * @defgroup subsys_tracing_apis_work Work item
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -505,6 +507,7 @@
 /**
  * @brief Tracing hooks for work queue events
  * @defgroup subsys_tracing_apis_work_q Work queue
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -599,6 +602,7 @@
 /**
  * @brief Tracing hooks for delayable work item events
  * @defgroup subsys_tracing_apis_work_delayable Delayable work item
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -750,6 +754,7 @@
 /**
  * @brief Tracing hooks for triggered work item events
  * @defgroup subsys_tracing_apis_work_poll Triggered work item
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -841,6 +846,7 @@
 /**
  * @brief Tracing hooks for polling events
  * @defgroup subsys_tracing_apis_poll Polling
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -907,6 +913,7 @@
 /**
  * @brief Tracing hooks for semaphore events
  * @defgroup subsys_tracing_apis_sem Semaphore
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -976,6 +983,7 @@
 /**
  * @brief Tracing hooks for mutex events
  * @defgroup subsys_tracing_apis_mutex Mutex
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -1036,6 +1044,7 @@
 /**
  * @brief Tracing hooks for conditional variable events
  * @defgroup subsys_tracing_apis_condvar Conditional variable
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -1115,6 +1124,7 @@
 /**
  * @brief Tracing hooks for queue events
  * @defgroup subsys_tracing_apis_queue Queue
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -1374,6 +1384,7 @@
 /**
  * @brief Tracing hooks for FIFO events
  * @defgroup subsys_tracing_apis_fifo FIFO
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -1542,6 +1553,7 @@
 /**
  * @brief Tracing hooks for LIFO events
  * @defgroup subsys_tracing_apis_lifo LIFO
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -1622,6 +1634,7 @@
 /**
  * @brief Tracing hooks for stack events
  * @defgroup subsys_tracing_apis_stack Stack
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -1717,6 +1730,7 @@
 /**
  * @brief Tracing hooks for message queue events
  * @defgroup subsys_tracing_apis_msgq Message queue
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -1868,6 +1882,7 @@
 /**
  * @brief Tracing hooks for mailbox events
  * @defgroup subsys_tracing_apis_mbox Mailbox
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -1985,6 +2000,7 @@
 /**
  * @brief Tracing hooks for pipe events
  * @defgroup subsys_tracing_apis_pipe Pipe
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -2093,6 +2109,7 @@
 /**
  * @brief Tracing hooks for heap events
  * @defgroup subsys_tracing_apis_heap Heap
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -2294,6 +2311,7 @@
 /**
  * @brief Tracing hooks for memory slab events
  * @defgroup subsys_tracing_apis_mslab Memory slab
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -2355,6 +2373,7 @@
 /**
  * @brief Tracing hooks for timer events
  * @defgroup subsys_tracing_apis_timer Timer
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -2464,6 +2483,7 @@
 /**
  * @brief Tracing hooks for event events
  * @defgroup subsys_tracing_apis_event Event
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -2532,6 +2552,7 @@
 /**
  * @brief Tracing hooks for system power management events
  * @defgroup subsys_tracing_apis_pm_system System PM
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -2557,6 +2578,7 @@
 /**
  * @brief Tracing hooks for device runtime power management events
  * @defgroup subsys_tracing_apis_pm_device_runtime PM Device Runtime
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -2652,6 +2674,7 @@
 /**
  * @brief Tracing hooks for network events
  * @defgroup subsys_tracing_apis_net Network
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -2714,6 +2737,7 @@
 /**
  * @brief Tracing hooks for network socket events
  * @defgroup subsys_tracing_apis_socket Network socket
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -3093,6 +3117,7 @@
 /**
  * @brief Tracing hooks for GPIO events
  * @defgroup subsys_tracing_apis_gpio GPIO
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -3362,6 +3387,7 @@
 /**
  * @brief RTIO Tracing APIs
  * @defgroup subsys_tracing_apis_rtio RTIO Tracing APIs
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -3507,12 +3533,15 @@
 /** @} */ /* end of subsys_tracing_apis_rtio */
 
 /**
+ * @brief Tracing hooks provided only by specific backends
  * @defgroup subsys_tracing_apis_backend_ext Backend-specific extensions
- * @{
+ * @ingroup subsys_tracing_apis
  *
  * Hooks defined only by specific backends (e.g. SystemView pipe internals).
  * Provided here as no-op fallbacks so every backend resolves the full set.
+ * @{
  */
+
 /**
  * @brief Trace initialization of a dynamically allocated pipe Enter API
  * @param pipe Pipe object

--- a/lib/libc/minimal/include/errno.h
+++ b/lib/libc/minimal/include/errno.h
@@ -21,7 +21,8 @@
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_ERRNO_H_
 
 /**
- * @brief System error numbers
+ * @brief System error numbers.
+ *
  *        Error codes returned by functions.
  *        Includes a list of those defined by IEEE Std 1003.1-2017.
  * @defgroup system_errno Error numbers

--- a/scripts/ci/doxygen_toplevel_groups.py
+++ b/scripts/ci/doxygen_toplevel_groups.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Doxygen Top-level Group Check
+
+A Doxygen group that no other group pulls in with @ingroup or @addtogroup ends up at the root of
+the API documentation index. Those top-level categories are meant to stay few and stable, so this
+script compares them against an allowlist and fails on any addition, or on an allowlisted group
+that is no longer top level.
+
+The set is read from Doxygen's XML, not from the sources: a group's parent may be declared in
+another file, or via @addtogroup nested inside a third group, and Doxygen merges all such
+declarations. The rule below is the one doc/_extensions/zephyr/api_overview.py uses to render the
+index -- a group is top-level if no other group lists it as an <innergroup>.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import NamedTuple
+
+ZEPHYR_BASE = Path(__file__).resolve().parents[2]
+ALLOWLIST = ZEPHYR_BASE / "doc" / "_doxygen" / "toplevel_groups.txt"
+
+
+class Problem(NamedTuple):
+    """A finding to report, optionally anchored to a line of source.
+
+    `summary` names the kind of problem, `message` the group it applies to, and `remedy` how to
+    resolve it. Both surfaces announce the kind already -- an annotation through its title, the job
+    summary through a heading -- so `message` need not restate it, and the summary can group
+    findings under that heading and state `remedy` once instead of on every line.
+
+    An annotation always covers a single group, so `summary` is singular; the summary heading spans
+    every finding of a kind and so needs `summary_plural`, which cannot be derived by suffixing an
+    "s" ("entry" -> "entries").
+
+    `message` and `remedy` are markdown: names and Doxygen commands are wrapped in backticks so
+    that the summary renders them as code rather than, say, turning @ingroup into a user mention.
+    """
+
+    summary: str
+    summary_plural: str
+    message: str
+    remedy: str
+    file: str | None = None
+    line: int | None = None
+
+
+def quantify(count: int, singular: str, plural: str) -> str:
+    """Render `count` with its noun agreeing in number."""
+    return f"{count} {singular if count == 1 else plural}"
+
+
+def repo_relative(path: str) -> str | None:
+    """Map a path recorded by Doxygen onto one relative to ZEPHYR_BASE.
+
+    Doxygen writes absolute paths from the machine it ran on, which need not share a prefix with
+    this checkout, so fall back to the longest trailing portion naming an existing file. Drop the
+    anchor first: joining an absolute path onto ZEPHYR_BASE discards ZEPHYR_BASE, which would let
+    a file outside the repository match.
+    """
+    candidate = Path(path)
+    try:
+        return str(candidate.relative_to(ZEPHYR_BASE))
+    except ValueError:
+        pass
+
+    parts = candidate.parts[1:] if candidate.is_absolute() else candidate.parts
+    for i in range(len(parts)):
+        suffix = Path(*parts[i:])
+        if (ZEPHYR_BASE / suffix).exists():
+            return str(suffix)
+    return None
+
+
+def declaration_of(name: str, source: str | None) -> tuple[str | None, int | None]:
+    """Locate the @defgroup declaring `name`, as a (path relative to ZEPHYR_BASE, line) pair."""
+    cmd = ["git", "grep", "-n", "-E", rf"@defgroup[[:space:]]+{re.escape(name)}([[:space:]]|$)"]
+    if source:
+        cmd += ["--", source]
+
+    try:
+        out = subprocess.run(
+            cmd, cwd=ZEPHYR_BASE, capture_output=True, text=True, check=False
+        ).stdout
+    except OSError:
+        return None, None
+
+    for line in out.splitlines():
+        path, _, rest = line.partition(":")
+        lineno, _, _ = rest.partition(":")
+        if lineno.isdigit():
+            return path, int(lineno)
+    return None, None
+
+
+def group_source(compounddef: ET.Element) -> str | None:
+    """Path of the file Doxygen read a group from, relative to ZEPHYR_BASE, if it can be known.
+
+    A group carries no location of its own, but its members do.
+    """
+    location = compounddef.find("./sectiondef/memberdef/location")
+    if location is None or not location.get("file"):
+        return None
+    return repo_relative(location.get("file"))
+
+
+def toplevel_groups(xml_dir: Path) -> dict[str, tuple[str, ET.Element]]:
+    """Return {group name: (title, compounddef)} for every top-level group in a Doxygen XML dir."""
+    index = ET.parse(xml_dir / "index.xml").getroot()
+    refids = {
+        compound.get("refid"): compound.find("name").text
+        for compound in index
+        if compound.get("kind") == "group"
+    }
+
+    nested: set[str] = set()
+    groups: dict[str, tuple[str, ET.Element]] = {}
+    for refid in refids:
+        compounddef = ET.parse(xml_dir / f"{refid}.xml").getroot().find("compounddef")
+        nested.update(inner.get("refid") for inner in compounddef.findall("innergroup"))
+        title = compounddef.find("title")
+        groups[refid] = (title.text if title is not None else "", compounddef)
+
+    return {refids[refid]: groups[refid] for refid in refids if refid not in nested}
+
+
+def read_allowlist(path: Path) -> set[str]:
+    """Read the allowlist, one group name per line. '#' starts a comment."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return {name for line in lines if (name := line.split("#", 1)[0].strip())}
+
+
+def find_problems(xml_dir: Path) -> list[Problem]:
+    """Compare the top-level groups against the allowlist."""
+    toplevel = toplevel_groups(xml_dir)
+    allowed = read_allowlist(ALLOWLIST)
+
+    problems = []
+    for name, (title, compounddef) in sorted(toplevel.items()):
+        if name in allowed:
+            continue
+        file, line = declaration_of(name, group_source(compounddef))
+        problems.append(
+            Problem(
+                summary="New top-level Doxygen group",
+                summary_plural="New top-level Doxygen groups",
+                message=f'`{name}` ("{title}")',
+                remedy=(
+                    "Give the group a parent with `@ingroup` so that it nests under an existing "
+                    "category. Where a new top-level category really is intended, allowlist the "
+                    "group in `doc/_doxygen/toplevel_groups.txt`; that requires approval from the "
+                    "documentation maintainers."
+                ),
+                file=file,
+                line=line,
+            )
+        )
+
+    for name in sorted(allowed - set(toplevel)):
+        problems.append(
+            Problem(
+                summary="Stale top-level group allowlist entry",
+                summary_plural="Stale top-level group allowlist entries",
+                message=f"`{name}`",
+                remedy=(
+                    "The group now has a parent, or no longer exists, so its line in "
+                    "`doc/_doxygen/toplevel_groups.txt` is obsolete. Delete the line to keep the "
+                    "allowlist in step with the API index."
+                ),
+            )
+        )
+
+    return problems
+
+
+def annotate(problems: list[Problem]) -> None:
+    """Print each problem as a GitHub Actions error annotation.
+
+    Each annotation is read on its own, away from the job summary, so it carries its remedy too.
+    Annotations render as plain text, hence stripping the markdown backticks.
+    """
+    for problem in problems:
+        location = f"file={problem.file},line={problem.line}," if problem.file else ""
+        text = f"{problem.message}: {problem.remedy}".replace("`", "")
+        print(f"::error {location}title={problem.summary}::{text}")
+
+
+def write_summary(problems: list[Problem], summary_file: str) -> None:
+    """Append a markdown summary of the problems to `summary_file`."""
+    try:
+        with open(summary_file, "a", encoding="utf-8") as f:
+            f.write("\n## 🗂️ Doxygen Top-level Group Check Results\n\n")
+
+            if not problems:
+                f.write("✅ **No new top-level Doxygen groups!**\n")
+                return
+
+            count = quantify(len(problems), "problem", "problems")
+            f.write(f"> [!CAUTION]\n> **{count} with the top-level API documentation index.**\n\n")
+
+            kinds: dict[str, list[Problem]] = {}
+            for problem in problems:
+                kinds.setdefault(problem.summary, []).append(problem)
+
+            for found in kinds.values():
+                heading = found[0].summary if len(found) == 1 else found[0].summary_plural
+                f.write(f"### {heading}\n\n{found[0].remedy}\n\n")
+                for problem in found:
+                    location = f" — `{problem.file}:{problem.line}`" if problem.file else ""
+                    f.write(f"- {problem.message}{location}\n")
+                f.write("\n")
+
+            f.write(
+                "See the project's [Doxygen style guidelines]"
+                "(https://docs.zephyrproject.org/latest/contribute/style/doxygen.html).\n"
+            )
+    except OSError as e:
+        print(f"::warning::Failed to write summary file '{summary_file}': {e}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+    parser.add_argument("--xml-dir", required=True, help="Path to the Doxygen XML output directory")
+    args = parser.parse_args()
+
+    xml_dir = Path(args.xml_dir)
+    if not (xml_dir / "index.xml").exists():
+        print(f"::error::Doxygen XML index not found under '{xml_dir}'. Was Doxygen run?")
+        return 1
+    if not ALLOWLIST.exists():
+        print(f"::error::Allowlist not found: {ALLOWLIST}")
+        return 1
+
+    try:
+        problems = find_problems(xml_dir)
+    except (ET.ParseError, OSError) as e:
+        print(f"::error::Failed to read Doxygen XML under '{xml_dir}': {e}")
+        return 1
+
+    annotate(problems)
+    if summary_file := os.environ.get("GITHUB_STEP_SUMMARY"):
+        write_summary(problems, summary_file)
+
+    if problems:
+        count = quantify(len(problems), "problem", "problems")
+        print(f"Found {count} with the top-level Doxygen groups.")
+        return 1
+
+    print("No new top-level Doxygen groups.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Shuffling things around to not clutter top-level Doxygen home page

Last commit adds a check complementing the coverage "delta" check that already existed, so that we detect in CI when unparented groups are being added so as to avoid the top-level doxygen groups becoming a mess :)
The result of the job in case someone would be introducing a top-level group inadvertently would look like this: https://github.com/zephyrproject-rtos/zephyr/actions/runs/29088095508?pr=111574.

Cleaned-up Doxygen homepage at https://builds.zephyrproject.io/zephyr/pr/111574/docs/doxygen/html/topics.html