### PR TITLE
MAINTAINERS: add mr_navq95b to NXP MCU Robotics

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4193,6 +4193,7 @@ NXP Platforms (MCU):
       collaborators:
         - bperseghetti
         - PetervdPerk-NXP
+        - AndreHeinemans-NXP
       files:
         - boards/nxp/vmu*/
         - boards/nxp/rddrone_fmuk66/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4130,6 +4130,7 @@ NXP Platforms (MCU):
     - boards/nxp/vmu*/
     - boards/nxp/rddrone_fmuk66/
     - tests/boards/vmu_rt1170/
+    - boards/nxp/mr_navq95b/
   files-exclude:
     - dts/arm/nxp/imx/nxp_imx*
     - boards/nxp/frdm_imx[0-9]*/
@@ -4195,6 +4196,7 @@ NXP Platforms (MCU):
       files:
         - boards/nxp/vmu*/
         - boards/nxp/rddrone_fmuk66/
+        - boards/nxp/mr_navq95b/
         - tests/boards/vmu_rt1170/
     - name: NXP Camera Shields
       collaborators:


### PR DESCRIPTION
The mr_navq95b board is maintained by 'NXP Platforms (MCU)' and file-group: 'NXP MCU robotics'

Also add myself as collaborator for NXP MCU Robotics