### PR TITLE
boards: esp32: p4: remove info about  RF binary blobs

### DIFF
--- a/boards/espressif/esp32p4_function_ev_board/doc/index.rst
+++ b/boards/espressif/esp32p4_function_ev_board/doc/index.rst
@@ -33,12 +33,6 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
-System Requirements
-*******************
-
-.. include:: ../../../espressif/common/system-requirements.rst
-   :start-after: espressif-system-requirements
-
 Programming and Debugging
 *************************
 


### PR DESCRIPTION
the esp32p4 has no RF, therefore the RF binary blobs should not be needed.