### PR TITLE
tests: remove exclude on skipped board Corstone1000

### DIFF
--- a/tests/misc/test_build/testcase.yaml
+++ b/tests/misc/test_build/testcase.yaml
@@ -27,9 +27,6 @@ tests:
     tags: kconfig
     integration_platforms:
       - native_sim
-    platform_exclude:
-      - fvp_corstone1000/a320
-      - fvp_corstone1000/a320/smp
     extra_configs:
       - CONFIG_KERNEL_BIN_NAME="A_kconfig_value_with_a_utf8_char_in_it_Bøe_"
   buildsystem.lto.picolibc_module:


### PR DESCRIPTION
This platform is being skipped, so lets remove the exclude.
This needs to be fixed in twister to not bail like this on disabled
platforms, but for now we want to unstuck CI.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
