### PR TITLE
drivers: led: do not inline API calls containing many branches

### DIFF
--- a/drivers/led/CMakeLists.txt
+++ b/drivers/led/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/led.h)
 
 zephyr_library()
 
+zephyr_library_sources_ifdef(CONFIG_LED led_common.c)
 zephyr_library_sources_ifdef(CONFIG_LED_SHELL led_shell.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE led_handlers.c)
 

--- a/drivers/led/led_common.c
+++ b/drivers/led/led_common.c
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2018 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/types.h>
+
+inline int z_impl_led_set_brightness(const struct device *dev, uint32_t led, uint8_t value)
+{
+	const struct led_driver_api *api = DEVICE_API_GET(led, dev);
+
+	if (api->set_brightness == NULL) {
+		if (api->on == NULL || api->off == NULL) {
+			return -ENOSYS;
+		}
+	}
+
+	if (value > LED_BRIGHTNESS_MAX) {
+		return -EINVAL;
+	}
+
+	if (api->set_brightness == NULL) {
+		if (value) {
+			return api->on(dev, led);
+		} else {
+			return api->off(dev, led);
+		}
+	}
+
+	return api->set_brightness(dev, led, value);
+}
+
+inline int z_impl_led_on(const struct device *dev, uint32_t led)
+{
+	const struct led_driver_api *api = DEVICE_API_GET(led, dev);
+
+	if (api->set_brightness == NULL && api->on == NULL) {
+		return -ENOSYS;
+	}
+
+	if (api->on == NULL) {
+		return api->set_brightness(dev, led, LED_BRIGHTNESS_MAX);
+	}
+
+	return api->on(dev, led);
+}
+
+inline int z_impl_led_off(const struct device *dev, uint32_t led)
+{
+	const struct led_driver_api *api = DEVICE_API_GET(led, dev);
+
+	if (api->set_brightness == NULL && api->off == NULL) {
+		return -ENOSYS;
+	}
+
+	if (api->off == NULL) {
+		return api->set_brightness(dev, led, 0);
+	}
+
+	return api->off(dev, led);
+}

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -192,33 +192,6 @@ static inline int z_impl_led_get_info(const struct device *dev, uint32_t led,
 __syscall int led_set_brightness(const struct device *dev, uint32_t led,
 				     uint8_t value);
 
-static inline int z_impl_led_set_brightness(const struct device *dev,
-					    uint32_t led,
-					    uint8_t value)
-{
-	const struct led_driver_api *api = DEVICE_API_GET(led, dev);
-
-	if (api->set_brightness == NULL) {
-		if (api->on == NULL || api->off == NULL) {
-			return -ENOSYS;
-		}
-	}
-
-	if (value > LED_BRIGHTNESS_MAX) {
-		return -EINVAL;
-	}
-
-	if (api->set_brightness == NULL) {
-		if (value) {
-			return api->on(dev, led);
-		} else {
-			return api->off(dev, led);
-		}
-	}
-
-	return api->set_brightness(dev, led, value);
-}
-
 /**
  * @brief Write/update a strip of LED channels
  *
@@ -316,21 +289,6 @@ static inline int z_impl_led_set_color(const struct device *dev, uint32_t led,
  */
 __syscall int led_on(const struct device *dev, uint32_t led);
 
-static inline int z_impl_led_on(const struct device *dev, uint32_t led)
-{
-	const struct led_driver_api *api = DEVICE_API_GET(led, dev);
-
-	if (api->set_brightness == NULL && api->on == NULL) {
-		return -ENOSYS;
-	}
-
-	if (api->on == NULL) {
-		return api->set_brightness(dev, led, LED_BRIGHTNESS_MAX);
-	}
-
-	return api->on(dev, led);
-}
-
 /**
  * @brief Turn off an LED
  *
@@ -344,21 +302,6 @@ static inline int z_impl_led_on(const struct device *dev, uint32_t led)
  * @return 0 on success, negative on error
  */
 __syscall int led_off(const struct device *dev, uint32_t led);
-
-static inline int z_impl_led_off(const struct device *dev, uint32_t led)
-{
-	const struct led_driver_api *api = DEVICE_API_GET(led, dev);
-
-	if (api->set_brightness == NULL && api->off == NULL) {
-		return -ENOSYS;
-	}
-
-	if (api->off == NULL) {
-		return api->set_brightness(dev, led, 0);
-	}
-
-	return api->off(dev, led);
-}
 
 /*
  * LED DT helpers.


### PR DESCRIPTION
Do not inline LED driver class API calls containing many branches, as this quickly adds up in ROM footprint. Instead, move the implementation of these to a new led_common.c file similar to other driver classes.