### PR TITLE
doc: allow passing extra twister flags during hw features generation

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -1513,6 +1513,7 @@ def load_board_catalog_into_domain(app: Sphinx) -> None:
             app.builder.format == "html" and app.config.zephyr_generate_hw_features
         ),
         hw_features_vendor_filter=app.config.zephyr_hw_features_vendor_filter,
+        extra_twister_flags=app.config.zephyr_hw_features_twister_extra_flags,
     )
 
     # Preserve existing docnames when reloading the catalog
@@ -1534,6 +1535,7 @@ def setup(app):
     app.add_config_value("zephyr_breathe_insert_related_samples", False, "env")
     app.add_config_value("zephyr_generate_hw_features", False, "env")
     app.add_config_value("zephyr_hw_features_vendor_filter", [], "env", types=[list[str]])
+    app.add_config_value("zephyr_hw_features_twister_extra_flags", [], "env", types=[list[str]])
 
     app.add_domain(ZephyrDomain)
 

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -140,7 +140,7 @@ def gather_board_build_info(twister_out_dir):
     return board_devicetrees, board_runners
 
 
-def run_twister_cmake_only(outdir, vendor_filter):
+def run_twister_cmake_only(outdir, vendor_filter, extra_flags):
     """Run twister in cmake-only mode to generate build info files.
 
     Delegates to ``gen_catalogs.run_twister_cmake_only()`` so the
@@ -150,7 +150,7 @@ def run_twister_cmake_only(outdir, vendor_filter):
         outdir: Directory where twister should output its files
         vendor_filter: Limit build info to boards from listed vendors
     """
-    gen_catalogs.run_twister_cmake_only(Path(outdir), vendor_filter)
+    gen_catalogs.run_twister_cmake_only(Path(outdir), vendor_filter, extra_flags)
 
 
 def guess_file_from_patterns(directory, patterns, name, extensions):
@@ -198,7 +198,9 @@ def guess_doc_page(board_or_shield):
     return doc_file
 
 
-def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
+def get_catalog(
+    generate_hw_features=False, hw_features_vendor_filter=None, extra_twister_flags=None
+):
     """Get the board catalog.
 
     Args:
@@ -246,7 +248,7 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
     if generate_hw_features:
         logger.info("Running twister in cmake-only mode to get Devicetree files for all boards")
         with tempfile.TemporaryDirectory() as tmp_dir:
-            run_twister_cmake_only(tmp_dir, hw_features_vendor_filter)
+            run_twister_cmake_only(tmp_dir, hw_features_vendor_filter, extra_twister_flags)
             board_devicetrees, board_runners = gather_board_build_info(Path(tmp_dir))
     else:
         logger.info("Skipping generation of supported hardware features.")

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -365,6 +365,7 @@ external_content_keep = [
 zephyr_breathe_insert_related_samples = True
 zephyr_generate_hw_features = not tags.has("hw_features_turbo")  # pylint: disable=undefined-variable  # noqa: F821
 zephyr_hw_features_vendor_filter = []
+zephyr_hw_features_twister_extra_flags = []
 
 # -- Options for sphinx.ext.graphviz --------------------------------------
 

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -1424,6 +1424,9 @@ Boards
       config option ``zephyr_hw_features_vendor_filter`` to the list of vendors to generate features for.
       If the option is empty, hardware features are generated for all boards from all vendors.
 
+      The config option ``zephyr_hw_features_twister_extra_flags`` can be used to provide additional flags to the
+      twister command.
+
 .. rst:directive:: .. zephyr:board-supported-runners::
 
    This directive is used to show the supported runners for the board documented in the current

--- a/scripts/ci/gen_catalogs.py
+++ b/scripts/ci/gen_catalogs.py
@@ -237,14 +237,20 @@ def _get_binding_type(binding_path: Path) -> str:
 # ---------------------------------------------------------------------------
 
 
-def run_twister_cmake_only(outdir: Path, vendor_filter: list) -> None:
+def run_twister_cmake_only(
+    outdir: Path, vendor_filter: list[str], extra_flags: list[str] | None = None
+) -> None:
     """Run twister in cmake-only mode to generate build-info and EDT files.
 
     Args:
         outdir: Directory where twister should write its output.
         vendor_filter: If non-empty, restrict to boards from these vendors.
+        extra_flags: List of additional flags that should be passed to twister.
     """
     python = str(_VENV_PYTHON) if _VENV_PYTHON.exists() else sys.executable
+
+    if extra_flags is None:
+        extra_flags = []
 
     twister_cmd = [
         python,
@@ -260,6 +266,7 @@ def run_twister_cmake_only(outdir: Path, vendor_filter: list) -> None:
         "-v",
         "--outdir",
         str(outdir),
+        *extra_flags,
     ]
 
     if vendor_filter:


### PR DESCRIPTION
There currently is no way to modify behaviour of twister during hw features generation.

For example we run into an issue were we hit Out Of Memory errors on our doc build instance, and wanted to modify the number of jobs. This adds an option zephyr_twister_extra_flags to allow for supplying additional flags.