### PR TITLE
drivers: usb: usb_buf: check for DCACHE_LINE_SIZE before using it

### DIFF
--- a/include/zephyr/drivers/usb/usb_buf.h
+++ b/include/zephyr/drivers/usb/usb_buf.h
@@ -33,7 +33,7 @@
 #define USB_BUF_FORCE_NOCACHE		0
 #endif
 
-#if defined(CONFIG_DCACHE) && !USB_BUF_FORCE_NOCACHE
+#if defined(CONFIG_DCACHE_LINE_SIZE) && !USB_BUF_FORCE_NOCACHE
 /*
  * Here we try to get DMA-safe buffers, but we lack a consistent source of
  * information about data cache properties, such as line cache size, and a


### PR DESCRIPTION
CONFIG_DCACHE does not imply CONFIG_DCACHE_LINE_SIZE is defined (the latter depends on CONFIG_CACHE_MANAGEMENT **and** may be undefined if runtime cache line size detection is enabled)

Fixes build issues on STM32 platforms when `CONFIG_DCACHE=y` but `CONFIG_CACHE_MANAGEMENT=n` (because UDC doesn't `select CACHE_MANAGEMENT if DCACHE`, which is probably an issue of its own)