### PR TITLE
tests: drivers: led: api: add missing argument to satisfy format string

### DIFF
--- a/tests/drivers/led/led_api/src/test_led_api.c
+++ b/tests/drivers/led/led_api/src/test_led_api.c
@@ -179,7 +179,7 @@ ZTEST_USER(led_user, test_led_set_color)
 				colors[col] = level;
 
 				ret = led_set_color(led_ctrl, led, num_colors, colors);
-				zassert_ok(ret, "LED %d - failed to set color[%d] to %d", led,
+				zassert_ok(ret, "LED %d - failed to set color[%d] to %d", led, col,
 					   level);
 			}
 		}


### PR DESCRIPTION
Add missing variable argument to satisfy format string.