### PR TITLE
west.yml: update STM32 HAL with STM32MP2 build issue fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 8415f977f3738f425995c2327bf796696832d282
+      revision: ff19fb0b03bc9b3f1355e9f9b7b6b3a6c051f121
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
The CMakeLists on HAL file tries to add a non-existent file in build sources which fails miserably. Use an updated version of hal_stm32 which fixes this issue.