### PR TITLE
ci: test plan: improve west project/hal coverage

### DIFF
--- a/scripts/ci/test_plan_v2.py
+++ b/scripts/ci/test_plan_v2.py
@@ -3109,6 +3109,13 @@ class ManifestStrategy(SelectionStrategy):
        covers tests that are explicitly catalogued for the module but may not
        carry a ``tags:`` field matching the project name.
 
+    7. When the changed project is a *HAL* listed in :attr:`_HAL_VENDORS`,
+       emit one more :class:`TwisterCall` that runs ``tests/integration/kernel``
+       restricted to the HAL's vendor(s) via twister ``--vendor``.  A HAL
+       revision bump affects the whole silicon family, so the generic
+       integration-kernel suite is built on every board of that vendor to
+       confirm it still builds and boots.
+
     This strategy **consumes** all matched manifest files so they do not
     reach :class:`MaintainerAreaStrategy`.
 
@@ -3123,6 +3130,52 @@ class ManifestStrategy(SelectionStrategy):
     # Manifest files that trigger this strategy
     _MANIFEST_FILES: frozenset = frozenset({"west.yml"})
     _SUBMANIFEST_PREFIX: str = "submanifests/"
+
+    # Generic test root used to verify that a vendor's boards still build/boot.
+    _INTEGRATION_TEST_ROOT: str = "tests/integration/kernel"
+
+    # Mapping of west *HAL* project names to the twister ``--vendor`` value(s)
+    # whose boards depend on that HAL.  When a HAL module revision is bumped in
+    # the manifest, the affected silicon is best exercised by building the
+    # generic integration-kernel suite on *every* board of the corresponding
+    # vendor(s) - the ``--tag``/``--test-pattern`` calls below only cover tests
+    # that explicitly opt in, which misses most boards.
+    #
+    # Vendor strings are the ``vendor:`` values used in ``boards/**/board.yml``
+    # (i.e. the ``dts/bindings/vendor-prefixes.txt`` prefixes).  A HAL may serve
+    # more than one vendor (e.g. ``hal_xtensa`` powers both Intel and Cadence
+    # parts); list all of them.  HALs with no clearly-associated board vendor
+    # are intentionally omitted and fall back to the tag/pattern calls.
+    _HAL_VENDORS: dict = {
+        "hal_adi": ["adi"],
+        "hal_ambiq": ["ambiq"],
+        "hal_atmel": ["atmel"],
+        "hal_bouffalolab": ["bflb"],
+        "hal_espressif": ["espressif"],
+        "hal_ethos_u": ["arm"],
+        "hal_gigadevice": ["gd"],
+        "hal_infineon": ["infineon", "cypress"],
+        "hal_intel": ["intel"],
+        "hal_microchip": ["microchip"],
+        "hal_nordic": ["nordic"],
+        "hal_nuvoton": ["nuvoton"],
+        "hal_nxp": ["nxp"],
+        "hal_openisa": ["openisa"],
+        "hal_quicklogic": ["quicklogic"],
+        "hal_realtek": ["realtek"],
+        "hal_renesas": ["renesas"],
+        "hal_rpi_pico": ["raspberrypi"],
+        "hal_sifli": ["sifli"],
+        "hal_silabs": ["silabs"],
+        "hal_st": ["st"],
+        "hal_stm32": ["st"],
+        "hal_tdk": ["tdk"],
+        "hal_telink": ["telink"],
+        "hal_ti": ["ti"],
+        "hal_wch": ["wch"],
+        "hal_wurthelektronik": ["we"],
+        "hal_xtensa": ["intel", "cdns"],
+    }
 
     @property
     def name(self):
@@ -3209,6 +3262,30 @@ class ManifestStrategy(SelectionStrategy):
                     integration=True,
                 )
             )
+
+            # When a HAL module changes, build the generic integration-kernel
+            # suite on every board of the vendor(s) that depend on that HAL.
+            vendors = self._HAL_VENDORS.get(proj_name)
+            if vendors:
+                vendor_args = []
+                for v in vendors:
+                    vendor_args += ["--vendor", v]
+                log.info(
+                    "[%s] HAL '%s' → %s on vendor(s): %s",
+                    self.name,
+                    proj_name,
+                    self._INTEGRATION_TEST_ROOT,
+                    ", ".join(vendors),
+                )
+                calls.append(
+                    TwisterCall(
+                        description=f"ManifestStrategy: HAL '{proj_name}' "
+                        f"(vendor: {', '.join(vendors)})",
+                        testsuite_roots=[self._INTEGRATION_TEST_ROOT],
+                        platforms=list(self._platform_filter),
+                        extra_args=vendor_args,
+                    )
+                )
 
             test_names = west_project_tests.get(proj_name, [])
             if test_names:

--- a/scripts/ci/test_plan_v2.py
+++ b/scripts/ci/test_plan_v2.py
@@ -3116,6 +3116,15 @@ class ManifestStrategy(SelectionStrategy):
        integration-kernel suite is built on every board of that vendor to
        confirm it still builds and boots.
 
+    8. Cross-reference the ``labels:`` of the project's
+       ``"West project: <name>"`` area against every *other* area in
+       ``MAINTAINERS.yml``.  For each area that shares one of those labels and
+       carries a ``tests:`` list, emit a :class:`TwisterCall` with
+       ``--test-pattern`` arguments built from those tests.  This links a
+       module to the topic areas it belongs to (e.g. ``hal_adi`` labelled
+       ``"platform: ADI"`` also runs the tests catalogued by the ``Drivers``
+       areas carrying that same label).
+
     This strategy **consumes** all matched manifest files so they do not
     reach :class:`MaintainerAreaStrategy`.
 
@@ -3248,7 +3257,9 @@ class ManifestStrategy(SelectionStrategy):
             ", ".join(sorted(changed_projects)),
         )
 
-        west_project_tests = self._load_west_project_tests()
+        areas = self._load_areas()
+        west_project_tests = self._west_project_tests(areas)
+        project_labels, label_to_tests = self._build_label_index(areas)
 
         calls = []
         for proj_name in sorted(changed_projects):
@@ -3305,19 +3316,45 @@ class ManifestStrategy(SelectionStrategy):
                     )
                 )
 
+            # Label cross-reference: pull in tests from any *other* MAINTAINERS
+            # area that shares a label with this project's "West project: <name>"
+            # area.  A HAL labelled "platform: X" thus also runs the tests
+            # catalogued by the "Drivers: X" area, etc.
+            own_area = f"West project: {proj_name}"
+            label_test_names: list = []
+            shared = []  # (label, area_name) for logging
+            for label in sorted(project_labels.get(proj_name, set())):
+                for area_name, tests in sorted(label_to_tests.get(label, {}).items()):
+                    if area_name == own_area:
+                        continue
+                    shared.append((label, area_name))
+                    label_test_names.extend(tests)
+
+            if label_test_names:
+                patterns = list(dict.fromkeys(_test_pattern(t) for t in label_test_names))
+                log.info(
+                    "[%s] '%s' shares labels with %s → %d test pattern(s)",
+                    self.name,
+                    proj_name,
+                    ", ".join(f"{a!r} (via {lbl!r})" for lbl, a in shared),
+                    len(patterns),
+                )
+                calls.append(
+                    TwisterCall(
+                        description=f"ManifestStrategy: '{proj_name}' (shared-label tests)",
+                        test_patterns=patterns,
+                        platforms=list(self._platform_filter),
+                    )
+                )
+
         return calls, set(manifest_files)
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
 
-    def _load_west_project_tests(self):
-        """Return a dict mapping west project name → ``tests:`` list.
-
-        Reads all ``"West project: <name>"`` areas from ``MAINTAINERS.yml``
-        and returns only those that carry a non-empty ``tests:`` list.  When
-        no maintainers file is configured, an empty dict is returned.
-        """
+    def _load_areas(self):
+        """Return the raw ``MAINTAINERS.yml`` mapping (``{}`` when unavailable)."""
         if not self._maintainers_file:
             return {}
         try:
@@ -3326,17 +3363,52 @@ class ManifestStrategy(SelectionStrategy):
         except OSError as exc:
             log.warning("[%s] Cannot read maintainers file: %s", self.name, exc)
             return {}
-        if not isinstance(data, dict):
-            return {}
+        return data if isinstance(data, dict) else {}
+
+    @staticmethod
+    def _west_project_tests(areas):
+        """Return ``{west_project_name: tests}`` for areas with a ``tests:`` list.
+
+        Only ``"West project: <name>"`` areas that carry a non-empty ``tests:``
+        list are included.
+        """
         prefix = "West project: "
         result = {}
-        for key, area in data.items():
-            if not key.startswith(prefix):
+        for key, area in areas.items():
+            if not key.startswith(prefix) or not isinstance(area, dict):
                 continue
-            tests = area.get("tests", []) if isinstance(area, dict) else []
+            tests = area.get("tests", [])
             if tests:
                 result[key[len(prefix) :]] = tests
         return result
+
+    @staticmethod
+    def _build_label_index(areas):
+        """Return ``(project_labels, label_to_tests)`` derived from *areas*.
+
+        ``project_labels`` maps a west project name to the set of ``labels:``
+        declared on its ``"West project: <name>"`` area.
+
+        ``label_to_tests`` maps each label to ``{area_name: tests}`` for every
+        area (of any kind) that carries both that label and a non-empty
+        ``tests:`` list.  This lets a changed manifest project pull in the
+        tests of sibling areas that share one of its labels (e.g. a HAL whose
+        ``"platform: X"`` label is also used by the ``Drivers: X`` area).
+        """
+        prefix = "West project: "
+        project_labels: dict = {}
+        label_to_tests: dict = {}
+        for key, area in areas.items():
+            if not isinstance(area, dict):
+                continue
+            labels = area.get("labels") or []
+            if key.startswith(prefix):
+                project_labels[key[len(prefix) :]] = set(labels)
+            tests = area.get("tests") or []
+            if tests:
+                for label in labels:
+                    label_to_tests.setdefault(label, {})[key] = tests
+        return project_labels, label_to_tests
 
     def _diff_manifests(self, base_commit, head_commit="HEAD"):
         """Return the set of project names whose revision changed between

--- a/scripts/tests/ci/test_test_plan_v2.py
+++ b/scripts/tests/ci/test_test_plan_v2.py
@@ -1110,3 +1110,103 @@ class TestManifestStrategyHalVendors:
         assert all("--vendor" not in c.extra_args for c in calls)
         # The tag-based module call is still produced.
         assert any(c.extra_args[:2] == ["-t", "mbedtls"] for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# ManifestStrategy - shared-label cross reference
+# ---------------------------------------------------------------------------
+
+
+class TestManifestStrategySharedLabels:
+    """A changed project pulls in tests from areas sharing one of its labels."""
+
+    MAINTAINERS = textwrap.dedent(
+        """
+        "West project: hal_adi":
+          files: []
+          labels:
+            - "platform: ADI"
+        "Drivers: ADI things":
+          files:
+            - drivers/foo/
+          labels:
+            - "platform: ADI"
+          tests:
+            - drivers.adi
+            - sensor.adi
+        "Unrelated area":
+          files:
+            - misc/
+          labels:
+            - "area: Other"
+          tests:
+            - misc.other
+        """
+    )
+
+    def _strategy(self, tmp_path, changed_projects):
+        mf = tmp_path / "MAINTAINERS.yml"
+        mf.write_text(self.MAINTAINERS)
+        strategy = tp.ManifestStrategy(
+            zephyr_base="/fake/zephyr",
+            repo=mock.Mock(),
+            commits="base..HEAD",
+            maintainers_file=str(mf),
+        )
+        strategy._diff_manifests = mock.Mock(return_value=set(changed_projects))
+        return strategy
+
+    def test_shared_label_pulls_in_area_tests(self, tmp_path):
+        strategy = self._strategy(tmp_path, {"hal_adi"})
+        calls, _ = strategy.analyze(["west.yml"])
+
+        label_calls = [c for c in calls if "shared-label" in c.description]
+        assert len(label_calls) == 1
+        patterns = label_calls[0].test_patterns
+        assert patterns == [tp._test_pattern("drivers.adi"), tp._test_pattern("sensor.adi")]
+
+    def test_unshared_label_area_excluded(self, tmp_path):
+        strategy = self._strategy(tmp_path, {"hal_adi"})
+        calls, _ = strategy.analyze(["west.yml"])
+
+        all_patterns = [p for c in calls for p in c.test_patterns]
+        assert tp._test_pattern("misc.other") not in all_patterns
+
+    def test_own_area_tests_not_double_counted(self, tmp_path):
+        # The changed project's *own* West-project area must not feed the
+        # shared-label call (that is handled by the step-6 tests path).
+        maintainers = textwrap.dedent(
+            """
+            "West project: hal_adi":
+              files: []
+              labels:
+                - "platform: ADI"
+              tests:
+                - own.adi
+            """
+        )
+        mf = tmp_path / "MAINTAINERS.yml"
+        mf.write_text(maintainers)
+        strategy = tp.ManifestStrategy(
+            zephyr_base="/fake/zephyr",
+            repo=mock.Mock(),
+            commits="base..HEAD",
+            maintainers_file=str(mf),
+        )
+        strategy._diff_manifests = mock.Mock(return_value={"hal_adi"})
+        calls, _ = strategy.analyze(["west.yml"])
+
+        assert not any("shared-label" in c.description for c in calls)
+        # but the own-area tests path still fires
+        assert any("MAINTAINERS tests" in c.description for c in calls)
+
+    def test_no_maintainers_file_no_label_calls(self, tmp_path):
+        strategy = tp.ManifestStrategy(
+            zephyr_base="/fake/zephyr",
+            repo=mock.Mock(),
+            commits="base..HEAD",
+        )
+        strategy._diff_manifests = mock.Mock(return_value={"hal_adi"})
+        calls, _ = strategy.analyze(["west.yml"])
+
+        assert not any("shared-label" in c.description for c in calls)

--- a/scripts/tests/ci/test_test_plan_v2.py
+++ b/scripts/tests/ci/test_test_plan_v2.py
@@ -1064,3 +1064,49 @@ class TestOrchestratorRun:
         orch.run(["some/file.c"], output_file=out)
         data = json.loads(Path(out).read_text())
         assert len(data["testsuites"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# ManifestStrategy - HAL → vendor mapping
+# ---------------------------------------------------------------------------
+
+
+class TestManifestStrategyHalVendors:
+    """The HAL→vendor mapping should drive a vendor-restricted integration run."""
+
+    def _strategy(self, changed_projects):
+        strategy = tp.ManifestStrategy(
+            zephyr_base="/fake/zephyr",
+            repo=mock.Mock(),
+            commits="base..HEAD",
+        )
+        # Bypass the git/west diff machinery: pretend these projects changed.
+        strategy._diff_manifests = mock.Mock(return_value=set(changed_projects))
+        return strategy
+
+    def test_hal_emits_vendor_integration_call(self):
+        strategy = self._strategy({"hal_nordic"})
+        calls, handled = strategy.analyze(["west.yml"])
+
+        assert handled == {"west.yml"}
+        vendor_calls = [c for c in calls if "--vendor" in c.extra_args]
+        assert len(vendor_calls) == 1
+        call = vendor_calls[0]
+        assert call.testsuite_roots == [tp.ManifestStrategy._INTEGRATION_TEST_ROOT]
+        assert call.extra_args == ["--vendor", "nordic"]
+
+    def test_hal_with_multiple_vendors(self):
+        strategy = self._strategy({"hal_xtensa"})
+        calls, _ = strategy.analyze(["west.yml"])
+
+        vendor_calls = [c for c in calls if "--vendor" in c.extra_args]
+        assert len(vendor_calls) == 1
+        assert vendor_calls[0].extra_args == ["--vendor", "intel", "--vendor", "cdns"]
+
+    def test_non_hal_project_emits_no_vendor_call(self):
+        strategy = self._strategy({"mbedtls"})
+        calls, _ = strategy.analyze(["west.yml"])
+
+        assert all("--vendor" not in c.extra_args for c in calls)
+        # The tag-based module call is still produced.
+        assert any(c.extra_args[:2] == ["-t", "mbedtls"] for c in calls)


### PR DESCRIPTION
- **ci: test_plan_v2: map HAL modules to board vendors**
- **ci: test_plan_v2: cross-reference manifest project labels**

take commit a7043e3dba74d7c2b434ab52fb1391b6f5e84652 for example...

before:
```
(.venv) nuc14:zephyr(main): ./scripts/ci/test_plan_v2.py -c a7043e3dba74d7c2b434ab52fb1391b6f5e84652~1..a7043e3dba74d7c2b434ab52fb1391b6f5e84652
INFO: Changed files (1):
  west.yml
INFO: === Strategy: ComplexityScorer ===
INFO: Analyzing git repository in /home/nashif/zephyrproject/zephyr
INFO: Commit #db1a6aaa36fddbdd7f588020ca2309bd56ac57f5 in 2026-06-18 05:33:51-04:00 from Stefan Schwendeler
INFO: Commit #a7043e3dba74d7c2b434ab52fb1391b6f5e84652 in 2026-06-18 05:34:22-04:00 from Mathieu Choplain
INFO: [ComplexityScorer] Patchset complexity score: 0.00  (0 source file(s) analysed, threshold=10.0, escalate=False)
INFO: === Strategy: IgnoreList ===
INFO: === Strategy: BoilerplateFilter ===
INFO: === Strategy: DirectTest ===
INFO: === Strategy: SnippetStrategy ===
INFO: === Strategy: BoardStrategy ===
INFO: === Strategy: SoCStrategy ===
INFO: === Strategy: ManifestStrategy ===
INFO: validation.valid
INFO: validation.valid
INFO: [ManifestStrategy] Changed west.yml modules: hal_stm32
INFO:   [ManifestStrategy] consumed 1 file(s), 0 remaining.
INFO:   Executing call: ManifestStrategy: module 'hal_stm32'
INFO: Running: /home/nashif/zephyrproject/zephyr/scripts/twister -c --integration -t hal_stm32 --save-tests /tmp/twister_partial_i9m3yfyj.json
Deleting output directory /home/nashif/zephyrproject/zephyr/twister-out
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-5460-g65a95c5f127b
INFO    - Using 'zephyr/gnu' toolchain variant.
INFO    - Selecting default platforms per testsuite scenario
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 1.65 seconds
INFO    - Writing JSON report /home/nashif/zephyrproject/zephyr/twister-out/testplan.json
INFO    - Writing JSON report /tmp/twister_partial_i9m3yfyj.json
INFO:   → 0 suites from twister, 0 new (total so far: 0)
INFO: === Strategy: DriverCompat === (skipped - no remaining files)
INFO: === Strategy: DtsBinding === (skipped - no remaining files)
INFO: === Strategy: KconfigImpact === (skipped - no remaining files)
INFO: === Strategy: HeaderImpact === (skipped - no remaining files)
INFO: === Strategy: MaintainerArea === (skipped - no remaining files)
INFO: === Summary: 0 unique test suites selected ===
INFO: No test suites selected - testplan.json not written.
INFO: .testplan written (tests=0, nodes=0, full=False)
```


after:

```
./scripts/ci/test_plan_v2.py -c a7043e3dba74d7c2b434ab52fb1391b6f5e84652~1..a7043e3dba74d7c2b434ab52fb1391b6f5e84652
INFO: Changed files (1):
  west.yml
INFO: === Strategy: ComplexityScorer ===
INFO: Analyzing git repository in /home/nashif/zephyrproject/zephyr
INFO: Commit #db1a6aaa36fddbdd7f588020ca2309bd56ac57f5 in 2026-06-18 05:33:51-04:00 from Stefan Schwendeler
INFO: Commit #a7043e3dba74d7c2b434ab52fb1391b6f5e84652 in 2026-06-18 05:34:22-04:00 from Mathieu Choplain
INFO: [ComplexityScorer] Patchset complexity score: 0.00  (0 source file(s) analysed, threshold=10.0, escalate=False)
INFO: === Strategy: IgnoreList ===
INFO: === Strategy: BoilerplateFilter ===
INFO: === Strategy: DirectTest ===
INFO: === Strategy: SnippetStrategy ===
INFO: === Strategy: BoardStrategy ===
INFO: === Strategy: SoCStrategy ===
INFO: === Strategy: ManifestStrategy ===
INFO: validation.valid
INFO: validation.valid
INFO: [ManifestStrategy] Changed west.yml modules: hal_stm32
INFO: [ManifestStrategy] HAL 'hal_stm32' → tests/integration/kernel on vendor(s): st
INFO: [ManifestStrategy] 'hal_stm32' shares labels with 'STM32 Platforms' (via 'platform: STM32') → 1 test pattern(s)
INFO:   [ManifestStrategy] consumed 1 file(s), 0 remaining.
INFO:   Executing call: ManifestStrategy: module 'hal_stm32'
INFO: Running: /home/nashif/zephyrproject/zephyr/scripts/twister -c --integration -t hal_stm32 --save-tests /tmp/twister_partial_bhk6jmgm.json
Deleting output directory /home/nashif/zephyrproject/zephyr/twister-out
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-5624-g5ae415b6a252
INFO    - Using 'zephyr/gnu' toolchain variant.
INFO    - Selecting default platforms per testsuite scenario
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 1.52 seconds
INFO    - Writing JSON report /home/nashif/zephyrproject/zephyr/twister-out/testplan.json
INFO    - Writing JSON report /tmp/twister_partial_bhk6jmgm.json
INFO:   → 0 suites from twister, 0 new (total so far: 0)
INFO:   Executing call: ManifestStrategy: HAL 'hal_stm32' (vendor: st)
INFO: Running: /home/nashif/zephyrproject/zephyr/scripts/twister -c -T tests/integration/kernel --vendor st --save-tests /tmp/twister_partial_6wjpmy4v.json
Deleting output directory /home/nashif/zephyrproject/zephyr/twister-out
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-5624-g5ae415b6a252
INFO    - Using 'zephyr/gnu' toolchain variant.
INFO    - Selecting platforms by vendors: st
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.01 seconds
INFO    - Writing JSON report /home/nashif/zephyrproject/zephyr/twister-out/testplan.json
INFO    - Writing JSON report /tmp/twister_partial_6wjpmy4v.json
INFO:   → 141 suites from twister, 141 new (total so far: 141)
INFO:   Executing call: ManifestStrategy: 'hal_stm32' (shared-label tests)
INFO: Running: /home/nashif/zephyrproject/zephyr/scripts/twister -c --test-pattern ^sample\.boards\.stm32(\.|$) --save-tests /tmp/twister_partial__bfn_wrm.json
Deleting output directory /home/nashif/zephyrproject/zephyr/twister-out
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-5624-g5ae415b6a252
INFO    - Using 'zephyr/gnu' toolchain variant.
INFO    - Selecting default platforms per testsuite scenario
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.01 seconds
INFO    - Writing JSON report /home/nashif/zephyrproject/zephyr/twister-out/testplan.json
INFO    - Writing JSON report /tmp/twister_partial__bfn_wrm.json
INFO:   → 86 suites from twister, 86 new (total so far: 227)
INFO: === Strategy: DriverCompat === (skipped - no remaining files)
INFO: === Strategy: DtsBinding === (skipped - no remaining files)
INFO: === Strategy: KconfigImpact === (skipped - no remaining files)
INFO: === Strategy: HeaderImpact === (skipped - no remaining files)
INFO: === Strategy: MaintainerArea === (skipped - no remaining files)
INFO: === Summary: 227 unique test suites selected ===
INFO: Test plan written to testplan.json (227 suites)
INFO: .testplan written (tests=227, nodes=1, full=False)
```
