### PR TITLE
west: runner: introduce rtkprog

### DIFF
--- a/boards/common/rtkprog.board.cmake
+++ b/boards/common/rtkprog.board.cmake
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_finalize_runner_args(rtkprog)

--- a/boards/realtek/rtl8752h_evb/board.cmake
+++ b/boards/realtek/rtl8752h_evb/board.cmake
@@ -5,3 +5,4 @@ board_runner_args(jlink "--device=RTL8752H" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/mpcli.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/rtkprog.board.cmake)

--- a/boards/realtek/rtl87x2g_evb_a/board.cmake
+++ b/boards/realtek/rtl87x2g_evb_a/board.cmake
@@ -5,3 +5,4 @@ board_runner_args(jlink "--device=RTL87X2G" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/mpcli.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/rtkprog.board.cmake)

--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -658,6 +658,21 @@ using the ``--device`` option:
 
 For more about the UF2 format and its tooling, see `USB Flashing Format (UF2)`_.
 
+.. _runner_rtkprog:
+
+Realtek Alternate Flash Programmer (rtkprog)
+********************************************
+
+``rtkprog`` is an open source implementation of the protocol needed to flash Realtek Bee family SoCs via UART.
+
+.. code-block:: console
+
+   west flash --runner rtkprog
+
+.. _rtkprog Source Code: https://github.com/a-labs-io/rtkprog
+.. _rtkprog Python package: https://pypi.org/p/rtkprog
+
+
 .. _runner_mpcli:
 
 Realtek Bee Flash Programmer (MPCli) Host Tools

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -61,6 +61,7 @@ _names = [
     'renode',
     'renode-robot',
     'rfp',
+    'rtkprog',
     'rtsflash',
     'sftool',
     'silabs_commander',

--- a/scripts/west_commands/runners/rtkprog.py
+++ b/scripts/west_commands/runners/rtkprog.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, A-Labs GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Runner for flashing Realtek devices with rtkprog.'''
+
+from pathlib import Path
+
+from runners.core import FileType, RunnerCaps, ZephyrBinaryRunner
+
+
+class RtkProgBinaryRunner(ZephyrBinaryRunner):
+    '''Runner front-end for rtkprog.'''
+
+    def __init__(self, cfg, port, build_dir, bin_address, chip_erase, reset):
+        super().__init__(cfg)
+        self.port = port
+        self.build_dir = build_dir
+        self.bin_address = bin_address
+        self.chip_erase = chip_erase
+        self.reset = reset
+        if not reset:
+            raise ValueError('rtkprog always resets')
+        self.app_bin_file = cfg.bin_file
+        self.ext_file = cfg.file
+        self.ext_file_type = cfg.file_type
+
+    @classmethod
+    def name(cls):
+        return 'rtkprog'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash'}, file=True, reset=True)
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        argument_parser = parser
+
+        argument_parser.add_argument(
+            '--port',
+            type=str,
+            help='Serial communication port (e.g., COM3, /dev/ttyUSB0)',
+        )
+        argument_parser.add_argument(
+            '--bin-address',
+            type=str,
+            help='Download address (hex format, e.g., 0x8000000)',
+        )
+        return parser
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        return RtkProgBinaryRunner(
+            cfg,
+            args.port,
+            build_dir=cfg.build_dir,
+            bin_address=args.bin_address,
+            chip_erase=args.erase,
+            reset=args.reset,
+        )
+
+    def execute_rtkprog(self, bin_file_path, download_address):
+        """
+        Execute rtkprog command with the given configuration file.
+        """
+        cmd_args = [
+            'rtkprog',
+        ]
+
+        # global args need to come before command
+        if self.port:
+            cmd_args.extend(['--port', self.port])
+
+        # command and command args
+        cmd_args.extend(
+            [
+                'write',
+                '-w',
+                download_address + ',0x0,' + str(bin_file_path),
+            ]
+        )
+
+        self.check_call(cmd_args)
+
+    def get_flash_parameters(self):
+        """Get file path and download address for flashing."""
+        if self.ext_file:
+            # Use external binary file
+            if self.ext_file_type != FileType.BIN:
+                raise ValueError('Cannot flash; runner only supports bin type')
+
+            bin_file_path = Path(self.ext_file)
+        else:
+            # Use build system generated file
+            bin_file_path = Path(self.app_bin_file)
+
+        download_address = self.bin_address or hex(
+            self.flash_address_from_build_conf(self.build_conf)
+        )
+
+        return bin_file_path, download_address
+
+    def do_run(self, command, **kwargs):
+        self.require('rtkprog')
+
+        bin_file_path, download_address = self.get_flash_parameters()
+
+        self.execute_rtkprog(bin_file_path, download_address)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -52,6 +52,7 @@ def test_runner_imports():
         'renode',
         'renode-robot',
         'rfp',
+        'rtkprog',
         'rtsflash',
         'sftool',
         'silabs_commander',

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -2,6 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# This file checks if all the expected runners are exported by
+# ZephyrBinaryRunner.get_runners(). This by design means the list of available
+# runners is duplicated between where they are defined and this check.
+# So duplicate code is expected and tolerated for this test file.
+#
+# pylint: disable=duplicate-code
+
 from runners.core import ZephyrBinaryRunner
 
 


### PR DESCRIPTION
Adds an alternative runner for Realtek ICs based on `rtkprog`, an open source alternative to the proprietary `mpcli` binary.

Unlike `mpcli`, which requires a separate download of the proprietary closed-source binary compiled only for specific host architectures, `rtkprog` is a cross-platform, open-source Python package that can be easily installed via `pip`. This not only makes it easier to get started with development, but also makes CI/CD integration easier.


`rtkprog` is available at https://github.com/a-labs-io/rtkprog and https://pypi.org/project/rtkprog/