### PR TITLE
tests: drivers: silabs: DMA

### DIFF
--- a/tests/drivers/dma/scatter_gather/boards/pg23_pk2504a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/pg23_pk2504a.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Silicon Laboratories, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};

--- a/tests/drivers/dma/scatter_gather/boards/pg28_2506a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/pg28_2506a.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Silicon Laboratories, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};

--- a/tests/drivers/dma/scatter_gather/boards/xg28_rb4401c.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xg28_rb4401c.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Silicon Laboratories, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};


### PR DESCRIPTION
 dma overlays are added for the following boards:
 pg23_pk2504a, pg28_pk2506a, xg28_rb4401c