### PR TITLE
include: cleanup: add scoped_guard() and scoped_cond_guard()

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3513,9 +3513,20 @@ Kernel:
     - include/zephyr/sys_clock.h
     - samples/kernel/
     - include/zephyr/kernel/
+    - include/zephyr/cleanup.h
+    - include/zephyr/cleanup/
     - tests/lib/p4workq/
   files-exclude:
     - tests/kernel/mem_protect/
+  file-groups:
+    - name: Cleanup helpers
+      collaborators:
+        - pdgendt
+      files:
+        - include/zephyr/cleanup.h
+        - include/zephyr/cleanup/
+        - doc/kernel/cleanup.rst
+        - tests/kernel/cleanup/
   labels:
     - "area: Kernel"
   tests:

--- a/doc/kernel/cleanup.rst
+++ b/doc/kernel/cleanup.rst
@@ -118,7 +118,7 @@ initialization and releases it on scope exit:
 
 .. code-block:: c
 
-    // Example guard definition (already provided by kernel.h)
+    // Example guard definition (already provided by <zephyr/cleanup/kernel.h>)
     SCOPE_GUARD_DEFINE(k_mutex, struct k_mutex *,
                        (void)k_mutex_lock(_T, K_FOREVER),
                        (void)k_mutex_unlock(_T));
@@ -134,6 +134,66 @@ initialization and releases it on scope exit:
 
         // Lock is automatically released when guard goes out of scope
     }
+
+Block-Scoped Guards
+===================
+
+While :c:macro:`scope_guard` holds a guard until the end of the *enclosing* scope,
+:c:macro:`scoped_guard` binds the guard to the brace block that immediately follows,
+releasing it as soon as that block is exited. This makes short critical sections
+explicit and keeps the lock object next to the code it protects:
+
+.. code-block:: c
+
+    static K_MUTEX_DEFINE(lock);
+
+    void worker(void)
+    {
+        // ... work that does not need the lock ...
+
+        scoped_guard(k_mutex, &lock) {
+            // lock held only inside these braces
+        }
+        // lock released here
+
+        // ... more work without the lock held ...
+    }
+
+The block runs exactly once. The lock is released on any exit from the block,
+including ``break``, ``return`` and ``goto``. Note that ``continue`` leaves the block
+(it behaves like ``break``) rather than re-running it.
+
+Conditional Guards
+==================
+
+Guards defined with :c:macro:`SCOPE_GUARD_DEFINE` always acquire the lock (they block
+with ``K_FOREVER``). To express a guard whose acquisition may fail (for example a
+non-blocking ``K_NO_WAIT`` try-lock), use :c:macro:`SCOPE_COND_GUARD_DEFINE` together
+with :c:macro:`scoped_cond_guard`. The acquire expression is evaluated for success: on
+failure the guard stores ``NULL``, the supplied fail statement runs, and the block is
+skipped.
+
+.. code-block:: c
+
+    // Example guard definition (already provided by <zephyr/cleanup/kernel.h>)
+    SCOPE_COND_GUARD_DEFINE(k_mutex_try, struct k_mutex *,
+                            k_mutex_lock(_T, K_NO_WAIT) == 0,
+                            (void)k_mutex_unlock(_T));
+
+    static K_MUTEX_DEFINE(lock);
+
+    int try_critical_section(void)
+    {
+        scoped_cond_guard(k_mutex_try, return -EBUSY, &lock) {
+            // runs only if the lock was acquired
+            // released automatically when the block is exited
+        }
+
+        return 0;
+    }
+
+The fail statement can be any statement, such as ``break``, ``return -EBUSY``, or
+``{}`` to silently skip the block.
 
 Scoped Defers
 =============
@@ -163,7 +223,7 @@ For functions with parameters:
 
 .. code-block:: c
 
-    // Example deferred k_free (already provided by kernel.h)
+    // Example deferred k_free (already provided by <zephyr/cleanup/kernel.h>)
     SCOPE_DEFER_DEFINE(k_free, void *);
 
     void allocate_and_use(void)

--- a/include/zephyr/cleanup.h
+++ b/include/zephyr/cleanup.h
@@ -123,6 +123,34 @@
 		}),                                                                                \
 		_type _T)
 
+/**
+ * @brief Define a conditional (failable) scoped guard type
+ *
+ * This macro defines a guard whose lock acquisition may fail, for use with
+ * @ref scoped_cond_guard. Unlike @ref SCOPE_GUARD_DEFINE, the acquire expression is
+ * evaluated for success: when it evaluates truthy the guard stores @p _type @c _T and
+ * the release expression runs on scope exit; when it evaluates falsy the guard stores
+ * @c NULL and nothing is released.
+ *
+ * @param _name Name of the guard (will be prefixed with guard_)
+ * @param _type Type of the lock object (must be a pointer type)
+ * @param _try_lock Expression evaluating truthy when the lock is acquired
+ *                  (can reference <tt>_T</tt>)
+ * @param _unlock Expression to release the lock (can reference <tt>_T</tt>)
+ *
+ * @kconfig_dep{CONFIG_SCOPE_CLEANUP_HELPERS}
+ *
+ * Usage:
+ * @code{.c}
+ * SCOPE_COND_GUARD_DEFINE(k_mutex_try, struct k_mutex *,
+ *                         k_mutex_lock(_T, K_NO_WAIT) == 0,
+ *                         (void)k_mutex_unlock(_T));
+ * @endcode
+ */
+#define SCOPE_COND_GUARD_DEFINE(_name, _type, _try_lock, _unlock)                                  \
+	SCOPE_VAR_DEFINE(guard_##_name, _type, if (_T != NULL) { _unlock; },                       \
+			 ((_try_lock) ? _T : NULL), _type _T)
+
 /** @cond INTERNAL_HIDDEN */
 
 #define Z_SCOPE_DEFER_DEFINE_VOID(_func)                                                           \
@@ -174,6 +202,30 @@
  * @internal
  */
 #define Z_UNIQUE_ID(_prefix) _CONCAT(_CONCAT(Z_UNIQUE_ID_, _prefix), __COUNTER__)
+
+/*
+ * Block-scope wrapper for @ref scoped_guard. A single-iteration nested for-loop ties the
+ * lifetime of the guard variable (_g) - and thus its cleanup/release - to the brace body
+ * that follows. The body is guarded on _g != NULL so that a conditional guard whose
+ * acquisition fails skips the body instead of running it without the lock held.
+ * For an unconditional guard _g is always non-NULL.
+ */
+#define Z_SCOPED_GUARD(_name, _g, _done, ...)                                                      \
+	for (int _done = 0; _done == 0; _done = 1)                                                 \
+		for (scope_var(guard_##_name, _g)(__VA_ARGS__); _done == 0 && _g != NULL;          \
+		     _done = 1)
+
+/*
+ * Block-scope wrapper for @ref scoped_cond_guard. Like Z_SCOPED_GUARD but the guard
+ * variable is named (_g) so the body can be guarded on whether the lock was acquired:
+ * when acquisition fails _g is NULL, _fail runs and the body is skipped.
+ */
+#define Z_SCOPED_COND_GUARD(_name, _g, _done, _fail, ...)                                          \
+	for (int _done = 0; _done == 0; _done = 1)                                                 \
+		for (scope_var(guard_##_name, _g)(__VA_ARGS__); _done == 0; _done = 1)             \
+			if (_g == NULL) {                                                          \
+				_fail;                                                             \
+			} else
 
 /** @endcond */
 
@@ -238,6 +290,70 @@
  * Usage: @code{.c} scope_guard(k_mutex)(&my_mutex); @endcode
  */
 #define scope_guard(_name) scope_var(guard_##_name, Z_UNIQUE_ID(guard))
+
+/**
+ * @brief Acquire a guard for the lifetime of the following block
+ *
+ * This macro acquires a scoped guard lock and holds it for the duration of the brace
+ * block that immediately follows, releasing it as soon as the block is exited. Unlike
+ * @ref scope_guard, whose guard lives until the end of the enclosing scope, the guard
+ * created here is bound to its own block.
+ *
+ * The block runs exactly once. The lock is released on any exit from the block,
+ * including <tt>break</tt>, <tt>return</tt> and <tt>goto</tt>. Note that, because the
+ * block is implemented with a hidden loop, <tt>break</tt> and <tt>continue</tt> leave
+ * the guarded block rather than affecting an enclosing loop.
+ *
+ * This macro also accepts a guard defined with @ref SCOPE_COND_GUARD_DEFINE. In that
+ * case the block is skipped (and nothing is held) if the lock cannot be acquired; use
+ * @ref scoped_cond_guard when you need to run a statement on acquisition failure.
+ *
+ * @param _name Name of the guard type (defined by @ref SCOPE_GUARD_DEFINE or
+ *              @ref SCOPE_COND_GUARD_DEFINE)
+ * @param ...   Arguments to acquire the guard (e.g. the lock object)
+ *
+ * @kconfig_dep{CONFIG_SCOPE_CLEANUP_HELPERS}
+ *
+ * Usage:
+ * @code{.c}
+ * scoped_guard(k_mutex, &my_mutex) {
+ *         // lock held only inside these braces
+ * }
+ * // lock released here
+ * @endcode
+ */
+#define scoped_guard(_name, ...)                                                                   \
+	Z_SCOPED_GUARD(_name, Z_UNIQUE_ID(scoped_g), Z_UNIQUE_ID(scoped_done), __VA_ARGS__)
+
+/**
+ * @brief Conditionally acquire a guard for the lifetime of the following block
+ *
+ * This macro attempts to acquire a conditional (failable) scoped guard and, on success,
+ * holds it for the duration of the brace block that immediately follows, releasing it as
+ * soon as the block is exited. If the lock cannot be acquired, @p _fail is executed and
+ * the block is skipped.
+ *
+ * On success the block runs exactly once and the lock is released on any exit from the
+ * block, including <tt>break</tt>, <tt>return</tt> and <tt>goto</tt> (<tt>continue</tt>
+ * behaves like <tt>break</tt>).
+ *
+ * @param _name Name of the guard type (defined by @ref SCOPE_COND_GUARD_DEFINE)
+ * @param _fail Statement executed when the lock cannot be acquired (e.g. <tt>break</tt>,
+ *              <tt>return -EBUSY</tt>, or <tt>{}</tt> to silently skip the block)
+ * @param ...   Arguments to acquire the guard (e.g. the lock object)
+ *
+ * @kconfig_dep{CONFIG_SCOPE_CLEANUP_HELPERS}
+ *
+ * Usage:
+ * @code{.c}
+ * scoped_cond_guard(k_mutex_try, return -EBUSY, &my_mutex) {
+ *         // lock held only inside these braces, runs only if acquired
+ * }
+ * @endcode
+ */
+#define scoped_cond_guard(_name, _fail, ...)                                                       \
+	Z_SCOPED_COND_GUARD(_name, Z_UNIQUE_ID(scoped_g), Z_UNIQUE_ID(scoped_done), _fail,         \
+			    __VA_ARGS__)
 
 /**
  * @brief Register a scoped deferred call

--- a/include/zephyr/cleanup/kernel.h
+++ b/include/zephyr/cleanup/kernel.h
@@ -34,6 +34,18 @@ SCOPE_GUARD_DEFINE(k_mutex, struct k_mutex *, (void)k_mutex_lock(_T, K_FOREVER),
 SCOPE_GUARD_DEFINE(k_sem, struct k_sem *, (void)k_sem_take(_T, K_FOREVER), k_sem_give(_T));
 
 /**
+ * @brief Conditional guard for k_mutex, acquiring with K_NO_WAIT.
+ * Usage: @code{.c} scoped_cond_guard(k_mutex_try, return -EBUSY, &lock) { ... } @endcode
+ */
+SCOPE_COND_GUARD_DEFINE(k_mutex_try, struct k_mutex *, k_mutex_lock(_T, K_NO_WAIT) == 0,
+			(void)k_mutex_unlock(_T));
+/**
+ * @brief Conditional guard for k_sem, taking with K_NO_WAIT.
+ * Usage: @code{.c} scoped_cond_guard(k_sem_try, return -EBUSY, &sem) { ... } @endcode
+ */
+SCOPE_COND_GUARD_DEFINE(k_sem_try, struct k_sem *, k_sem_take(_T, K_NO_WAIT) == 0, k_sem_give(_T));
+
+/**
  * @brief Defer k_free.
  * Usage: @code{.c} scope_defer(k_free)(ptr); @endcode
  */

--- a/tests/kernel/cleanup/src/main.c
+++ b/tests/kernel/cleanup/src/main.c
@@ -101,6 +101,109 @@ ZTEST(cleanup_api, test_defer_k_sem_give)
 	zexpect_equal(lock.count, 1);
 }
 
+ZTEST(cleanup_api, test_scoped_guard_k_mutex)
+{
+	struct k_mutex lock;
+	int runs = 0;
+
+	zassert_ok(k_mutex_init(&lock));
+
+	scoped_guard(k_mutex, &lock) {
+		runs++;
+		zexpect_equal(lock.lock_count, 1);
+	}
+
+	zexpect_equal(runs, 1);
+	zexpect_equal(lock.lock_count, 0);
+}
+
+ZTEST(cleanup_api, test_scoped_guard_k_sem)
+{
+	struct k_sem lock;
+	int runs = 0;
+
+	zassert_ok(k_sem_init(&lock, 1, 1));
+
+	scoped_guard(k_sem, &lock) {
+		runs++;
+		zexpect_equal(lock.count, 0);
+	}
+
+	zexpect_equal(runs, 1);
+	zexpect_equal(lock.count, 1);
+}
+
+ZTEST(cleanup_api, test_scoped_guard_break)
+{
+	struct k_mutex lock;
+	int runs = 0;
+
+	zassert_ok(k_mutex_init(&lock));
+
+	scoped_guard(k_mutex, &lock) {
+		runs++;
+		zexpect_equal(lock.lock_count, 1);
+		break;
+	}
+
+	zexpect_equal(runs, 1);             /* ran once, break did not re-enter */
+	zexpect_equal(lock.lock_count, 0);  /* break released the guard */
+}
+
+ZTEST(cleanup_api, test_scoped_cond_guard_acquired)
+{
+	struct k_sem lock;
+	int runs = 0;
+
+	zassert_ok(k_sem_init(&lock, 1, 1));
+
+	scoped_cond_guard(k_sem_try, zassert_unreachable(), &lock) {
+		runs++;
+		zexpect_equal(lock.count, 0);
+	}
+
+	zexpect_equal(runs, 1);
+	zexpect_equal(lock.count, 1);
+}
+
+ZTEST(cleanup_api, test_scoped_cond_guard_busy)
+{
+	struct k_sem lock;
+	int runs = 0;
+	bool failed = false;
+
+	/* No tokens available, so the take with K_NO_WAIT must fail */
+	zassert_ok(k_sem_init(&lock, 0, 1));
+
+	scoped_cond_guard(k_sem_try, failed = true, &lock) {
+		runs++;
+	}
+
+	/* The body must be skipped and the fail statement must run */
+	zexpect_equal(runs, 0);
+	zexpect_true(failed);
+	zexpect_equal(lock.count, 0);
+}
+
+ZTEST(cleanup_api, test_scoped_guard_cond_busy_skips)
+{
+	struct k_sem lock;
+	int runs = 0;
+
+	/* No tokens available, so the take with K_NO_WAIT must fail */
+	zassert_ok(k_sem_init(&lock, 0, 1));
+
+	/* Using a conditional guard with the plain scoped_guard must skip the body
+	 * when the lock cannot be acquired, never run it without the lock held.
+	 */
+	scoped_guard(k_sem_try, &lock) {
+		runs++;
+	}
+
+	zexpect_equal(runs, 0);
+	zexpect_equal(lock.count, 0);
+}
+
 ZTEST(cleanup_api, test_defer_k_free)
 {
 	void *my_ptr = k_malloc(10);

--- a/tests/kernel/cleanup/testcase.yaml
+++ b/tests/kernel/cleanup/testcase.yaml
@@ -2,6 +2,13 @@ tests:
   kernel.cleanup.api:
     tags:
       - kernel
-    toolchain_allow: gcc
+    toolchain_exclude:
+      - iar
     platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - qemu_x86
+      - qemu_cortex_m3
+      - qemu_riscv32
+    integration_platforms:
       - native_sim


### PR DESCRIPTION
Add block-scoped guard variants on top of the existing cleanup
helpers. `scoped_guard()` binds a guard to the following block and
releases it at the closing brace; `scoped_cond_guard()`, together with
`SCOPE_COND_GUARD_DEFINE`, supports failable acquisition and skips the
block when the lock is not taken.