### PR TITLE
tests: drivers: timer: enable GRTC support for FLPR core

### DIFF
--- a/tests/drivers/timer/nrf_grtc_timer/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
+++ b/tests/drivers/timer/nrf_grtc_timer/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&grtc {
+	owned-channels = <5 6>;
+};

--- a/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -5,6 +5,7 @@ common:
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf54h20dk/nrf54h20/cpurad
     - nrf54h20dk/nrf54h20/cpuppr
+    - nrf54h20dk/nrf54h20/cpuflpr
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp/ns
     - nrf54l15dk/nrf54l15/cpuflpr


### PR DESCRIPTION
Add corresponding test overlays so that the GRTC
tests run correctly under Twister for the FLPR core.