### PR TITLE
MAINTAINERS: Fix TI MSPM0 boards filter

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5848,7 +5848,7 @@ TI MSPM0 Platforms:
     - d-philpot
   files:
     - soc/ti/mspm0/
-    - boards/ti/lp_mspm0g3507/
+    - boards/ti/*mspm0*/
     - dts/arm/ti/mspm0/
     - dts/bindings/*/*mspm0*
     - drivers/*/*_mspm0*


### PR DESCRIPTION
Currently only the lp_mspm0g3507 board is listed as part of the "TI MSPM0 Platforms" but there are other boards. Use wildcard selection to capture all currently supported boards.