### PR TITLE
Bugfix/fix issue of lptmr wuc connect

### DIFF
--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -140,7 +140,7 @@ void sys_clock_idle_exit(void)
 
 void sys_clock_disable(void)
 {
-	const struct wuc_dt_spec wuc = WUC_DT_SPEC_INST_GET_OR(0, {0});
+	const struct wuc_dt_spec wuc = WUC_DT_SPEC_GET_OR(LPTMR_NODE, {0});
 
 	if (wuc.dev != NULL) {
 		(void)wuc_disable_wakeup_source_dt(&wuc);
@@ -199,7 +199,7 @@ static void mcux_lptmr_timer_isr(const void *arg)
 static int sys_clock_driver_init(void)
 {
 	lptmr_config_t config;
-	const struct wuc_dt_spec wuc = WUC_DT_SPEC_INST_GET_OR(0, {0});
+	const struct wuc_dt_spec wuc = WUC_DT_SPEC_GET_OR(LPTMR_NODE, {0});
 
 	if ((wuc.dev != NULL) && (wuc_enable_wakeup_source_dt(&wuc) != 0)) {
 		return -EIO;

--- a/tests/drivers/wuc/wuc_api/boards/frdm_mcxw72_mcxw727c.overlay
+++ b/tests/drivers/wuc/wuc_api/boards/frdm_mcxw72_mcxw727c.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/drivers/wuc/wuc_nxp_wuu.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 
 / {
 	zephyr,user {


### PR DESCRIPTION
The LPTMR system timer driver used WUC_DT_SPEC_INST_GET_OR() which
    relies on DT_DRV_COMPAT to resolve the device instance. Since the
    system timer obtains its node via DT_CHOSEN(zephyr_system_timer)
    rather than the standard device model, DT_DRV_COMPAT is undefined
    and the macro silently falls back to the default value {0}. This
    leaves wuc.dev as NULL and wuc_enable_wakeup_source_dt() is never
    called, so the WUU module wakeup source for LPTMR is not programmed.
    On MCXW7xx platforms this means timed wakeup from low-power states
    fails: the board enters sleep and never returns.
    Use WUC_DT_SPEC_GET_OR(LPTMR_NODE, ...) instead, which resolves
    directly from the chosen system-timer node where the wakeup-ctrls
    property is defined.