### PR TITLE
arch: arm: define TLS area also when multithreading is disabled

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -693,6 +693,21 @@ FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(k_thread_entry_t main_
 	/* Set PSP to the highest address of the main stack. */
 	char *psp = K_THREAD_STACK_BUFFER(z_main_stack) + K_THREAD_STACK_SIZEOF(z_main_stack);
 
+#if defined(CONFIG_THREAD_LOCAL_STORAGE)
+	/* On Cortex-M, TLS uses a global variable as pointer to
+	 * the thread local storage area. With multithreading disabled
+	 * there is no context switch to set it, so it must be
+	 * initialized here, carving the TLS area out of the top of
+	 * the main stack.
+	 */
+	extern uintptr_t z_arm_tls_ptr;
+	size_t tls_size;
+
+	tls_size = arch_tls_stack_setup(&z_main_thread, psp);
+	z_arm_tls_ptr = z_main_thread.tls;
+	psp -= tls_size;
+#endif
+
 #if defined(CONFIG_BUILTIN_STACK_GUARD)
 	char *psplim = (K_THREAD_STACK_BUFFER(z_main_stack));
 	/* Clear PSPLIM before setting it to guard the main stack area. */


### PR DESCRIPTION
## Content of the PR

TLS area must be defined also when multithreading is disabled. Not doing so whould cause access to libc variables like `errno` to fail with a crash.

## What it solves

A runtime crash for MCUboot which is currently visible on `main` branch for the following sample:
`west build -p -b nrf5340dk/nrf5340/cpuapp samples/sysbuild/with_mcuboot/ --test sample.sysbuild.with_mcuboot`

The stack trace looks like this:
```
arch_system_halt (reason=25) at /home/valerio/nordic/zephyr-mainline/zephyr/kernel/fatal.c:29
29		for (;;) {
(gdb) backtrace
#0  arch_system_halt (reason=25) at /home/valerio/nordic/zephyr-mainline/zephyr/kernel/fatal.c:29
#1  0x000071f6 in k_sys_fatal_error_handler (reason=<optimized out>, esf=<optimized out>) at /home/valerio/nordic/zephyr-mainline/zephyr/kernel/fatal.c:43
#2  0x0000720a in z_fatal_error (reason=<optimized out>, esf=<optimized out>) at /home/valerio/nordic/zephyr-mainline/zephyr/kernel/fatal.c:118
#3  0x00005e62 in z_arm_fatal_error (reason=<optimized out>, esf=esf@entry=0x200053f8 <z_interrupt_stacks+1984>) at /home/valerio/nordic/zephyr-mainline/zephyr/arch/arm/core/fatal.c:93
#4  0x00001386 in z_arm_fault (msp=<optimized out>, psp=<optimized out>, exc_return=<optimized out>, callee_regs=<optimized out>)
    at /home/valerio/nordic/zephyr-mainline/zephyr/arch/arm/core/cortex_m/fault.c:1090
#5  0x0000145c in z_arm_usage_fault () at /home/valerio/nordic/zephyr-mainline/zephyr/arch/arm/core/cortex_m/fault_s.S:103
#6  <signal handler called>
#7  0x000019fe in calloc (nmemb=<optimized out>, size=<optimized out>) at /home/valerio/nordic/zephyr-mainline/zephyr/lib/libc/common/source/stdlib/malloc.c:310
#8  0x0000819c in mbedtls_md_setup (ctx=ctx@entry=0x20000fa8 <global_data+112>, md_info=md_info@entry=0x9567 <mbedtls_sha256_info>, hmac=hmac@entry=0)
    at /home/valerio/nordic/zephyr-mainline/modules/crypto/tf-psa-crypto/extras/md.c:497
#9  0x000088d2 in mbedtls_hmac_drbg_seed (ctx=ctx@entry=0x20000fa8 <global_data+112>, md_info=0x9567 <mbedtls_sha256_info>, f_entropy=0x8611 <mbedtls_entropy_func>, 
    p_entropy=p_entropy@entry=0x20000f44 <global_data+12>, custom=custom@entry=0x20007bfc <z_main_stack+10180> "PSA", len=len@entry=3)
    at /home/valerio/nordic/zephyr-mainline/modules/crypto/tf-psa-crypto/drivers/builtin/src/hmac_drbg.c:235
#10 0x0000537a in mbedtls_psa_drbg_seed (len=3, drbg_ctx=0x20000fa8 <global_data+112>, entropy=0x20000f44 <global_data+12>, custom=0x20007bfc <z_main_stack+10180> "PSA")
    at /home/valerio/nordic/zephyr-mainline/modules/crypto/tf-psa-crypto/core/psa_crypto_random_impl.h:154
#11 psa_random_internal_seed (rng=rng@entry=0x20000f3c <global_data+4>) at /home/valerio/nordic/zephyr-mainline/modules/crypto/tf-psa-crypto/core/psa_crypto_random.c:53
#12 0x000052fa in mbedtls_psa_random_seed (rng=0x20000f3c <global_data+4>) at /home/valerio/nordic/zephyr-mainline/modules/crypto/tf-psa-crypto/core/psa_crypto.c:8460
#13 mbedtls_psa_crypto_init_subsystem (subsystem=PSA_CRYPTO_SUBSYSTEM_RNG) at /home/valerio/nordic/zephyr-mainline/modules/crypto/tf-psa-crypto/core/psa_crypto.c:9075
#14 psa_crypto_init () at /home/valerio/nordic/zephyr-mainline/modules/crypto/tf-psa-crypto/core/psa_crypto.c:9138
#15 0x000070d8 in _mbedtls_init () at /home/valerio/nordic/zephyr-mainline/zephyr/modules/mbedtls/zephyr_init.c:54
#16 0x00003e3e in z_sys_init_run_level (level=level@entry=INIT_LEVEL_POST_KERNEL) at /home/valerio/nordic/zephyr-mainline/zephyr/kernel/init.c:247
#17 0x00003e52 in bg_thread_main (unused1=<optimized out>, unused2=<optimized out>, unused3=<optimized out>) at /home/valerio/nordic/zephyr-mainline/zephyr/kernel/init.c:299
#18 0x000015ea in z_arm_switch_to_main_no_multithreading (main_entry=0x0 <flash_area_erased_val>, p1=0x68 <z_log_minimal_hexdump_print+104>, p2=warning: (Internal error: pc 0x0 in read in CU, but not in symtab.)
```

The root cause of the crash is as follows:
- tf-psa-crypto tries to `malloc()` some memory in [the MD module](https://github.com/zephyrproject-rtos/TF-PSA-Crypto/blob/2d881593696aec687ca2246c53de207c2b9bf782/extras/md.c#L497)
- heap memory is disabled in the build so malloc fails as expected
- when failing [it tries to](https://github.com/zephyrproject-rtos/zephyr/blob/a3e41914e33e9bf0169307c8b3696bb98bc7f926/lib/libc/common/source/stdlib/malloc.c#L289) set `errno = ENOMEM;`
- `errno` is a thread-local variable. The compiler emits a call to `__aeabi_read_tp` to get the TLS base, which on Cortex-M just returns the global `z_arm_tls_ptr` ([arch/arm/core/cortex_m/__aeabi_read_tp.S](https://github.com/zephyrproject-rtos/zephyr/blob/main/arch/arm/core/cortex_m/__aeabi_read_tp.S#L23))
- `z_arm_tls_ptr == 0x0` because it was never initialized
- device crashes

