### PR TITLE
soc: nxp: mcxn_a: enable deep power down mode support

### DIFF
--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
@@ -9,6 +9,7 @@
 #include <nxp/mcx/nxp_mcxa153.dtsi>
 #include "frdm_mcxa153-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <freq.h>
 
@@ -22,6 +23,7 @@
 		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		wakeup-button = &user_button_3;
 		pwm-0 = &flexpwm0_pwm0;
 		watchdog0 = &wwdt0;
 		ambient-temp0 = &p3t1755;
@@ -72,6 +74,8 @@
 			label = "User SW3";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_1>;
+			/* SW3 wakes via WUU external pin 9. */
+			wakeup-ctrls = <&wuu NXP_WUU_PIN_9_FALLING_INT>;
 		};
 	};
 

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
@@ -10,6 +10,7 @@
 #include "frdm_mcxa156-pinctrl.dtsi"
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 #include <freq.h>
 
 / {
@@ -22,6 +23,7 @@
 		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		wakeup-button = &user_button_2;
 		pwm-0 = &flexpwm0_pwm0;
 		mcuboot-button0 = &user_button_2;
 		watchdog0 = &wwdt0;
@@ -69,6 +71,8 @@
 			label = "User SW2";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_0>;
+			/* SW2 wakes via WUU external pin 9. */
+			wakeup-ctrls = <&wuu NXP_WUU_PIN_9_FALLING_INT>;
 		};
 
 		user_button_3: button_3 {

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
@@ -10,6 +10,7 @@
 #include "frdm_mcxa344-pinctrl.dtsi"
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 
 / {
 	model = "NXP FRDM_MCXA344 board";
@@ -21,6 +22,7 @@
 		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		wakeup-button = &user_button_2;
 		watchdog0 = &wwdt0;
 		die-temp0 = &temp0;
 	};
@@ -64,6 +66,8 @@
 			label = "User SW2";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_0>;
+			/* SW2 wakes via WUU external pin 9. */
+			wakeup-ctrls = <&wuu NXP_WUU_PIN_9_FALLING_INT>;
 		};
 
 		user_button_3: button_3 {

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
@@ -34,6 +34,7 @@
 		zephyr,shell-uart = &lpuart2;
 		zephyr,canbus = &flexcan0;
 		zephyr,edac = &erm0;
+		zephyr,system-timer-companion = &lptmr0;
 		zephyr,crc = &crc;
 	};
 

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dts
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dts
@@ -23,6 +23,7 @@
 		zephyr,edac = &erm0;
 		zephyr,crc = &crc;
 		zephyr,canbus = &flexcan0;
+		zephyr,system-timer-companion = &lptmr0;
 	};
 };
 

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -9,6 +9,7 @@
 #include "frdm_mcxa577-pinctrl.dtsi"
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 
 / {
 	aliases {
@@ -17,6 +18,7 @@
 		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		wakeup-button = &user_button_2;
 		watchdog0 = &wwdt0;
 		flash-controller = &fmu;
 		die-temp0 = &temp0;
@@ -49,6 +51,8 @@
 			label = "User SW2";
 			gpios = <&gpio3 17 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_0>;
+			/* P3_17 reaches the core as WUU external pin 26. */
+			wakeup-ctrls = <&wuu NXP_WUU_PIN_26_FALLING_INT>;
 		};
 
 		user_button_3: button_3 {

--- a/boards/nxp/frdm_mcxaxx6/board_common.dtsi
+++ b/boards/nxp/frdm_mcxaxx6/board_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
@@ -16,6 +17,7 @@
 		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		wakeup-button = &user_button_2;
 		watchdog0 = &wwdt0;
 		die-temp0 = &temp0;
 	};
@@ -59,6 +61,8 @@
 			label = "User SW2";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_0>;
+			/* SW2 wakes via WUU external pin 9. */
+			wakeup-ctrls = <&wuu NXP_WUU_PIN_9_FALLING_INT>;
 		};
 
 		user_button_3: button_3 {

--- a/boards/nxp/frdm_mcxn236/board.c
+++ b/boards/nxp/frdm_mcxn236/board.c
@@ -8,6 +8,9 @@
 #include <fsl_clock.h>
 #include <fsl_spc.h>
 #include <soc.h>
+#if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
+#include <fsl_vbat.h>
+#endif
 #if CONFIG_USB_DC_NXP_EHCI
 #include "usb_phy.h"
 #include "usb.h"
@@ -291,6 +294,9 @@ void board_early_init_hook(void)
 	CLOCK_SetupClockCtrl(kCLOCK_FRO12MHZ_ENA);
 #elif DT_PROP(DT_NODELABEL(lptmr0), clk_source) == 0x1
 	CLOCK_SetupClk16KClocking(kCLOCK_Clk16KToVsys);
+#if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
+	VBAT_EnableFRO16k(VBAT0, true);
+#endif
 #elif DT_PROP(DT_NODELABEL(lptmr0), clk_source) == 0x2
 	CLOCK_SetupOsc32KClocking(kCLOCK_Osc32kToVsys);
 #elif DT_PROP(DT_NODELABEL(lptmr0), clk_source) == 0x3

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 #include <zephyr/dt-bindings/gpio/dvp-20pin-connector.h>
 
 / {
@@ -41,6 +42,7 @@
 		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		wakeup-button = &user_button_2;
 		mcuboot-button0 = &user_button_2;
 	};
 
@@ -70,6 +72,8 @@
 			label = "User SW2";
 			gpios = <&gpio0 20 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_WAKEUP>;
+			/* SW2 wakes via WUU external pin 4. */
+			wakeup-ctrls = <&wuu NXP_WUU_PIN_4_FALLING_INT>;
 		};
 
 		user_button_3: button_1 {

--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -8,6 +8,9 @@
 #include <fsl_clock.h>
 #include <fsl_spc.h>
 #include <soc.h>
+#if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
+#include <fsl_vbat.h>
+#endif
 #if CONFIG_USB_DC_NXP_EHCI
 #include "usb_phy.h"
 #include "usb.h"
@@ -412,6 +415,9 @@ void board_early_init_hook(void)
 	CLOCK_SetupClockCtrl(kCLOCK_FRO12MHZ_ENA);
 #elif DT_PROP(DT_NODELABEL(lptmr0), clk_source) == 0x1
 	CLOCK_SetupClk16KClocking(kCLOCK_Clk16KToVsys);
+#if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
+	VBAT_EnableFRO16k(VBAT0, true);
+#endif
 #elif DT_PROP(DT_NODELABEL(lptmr0), clk_source) == 0x2
 	CLOCK_SetupOsc32KClocking(kCLOCK_Osc32kToVsys);
 #elif DT_PROP(DT_NODELABEL(lptmr0), clk_source) == 0x3

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/gpio/dvp-20pin-connector.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 
 / {
 	aliases {
@@ -17,6 +18,7 @@
 		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		wakeup-button = &user_button_2;
 		sdhc0 = &usdhc0;
 		mcuboot-button0 = &user_button_2;
 	};
@@ -56,7 +58,9 @@
 			label = "User SW2";
 			gpios = <&gpio0 23 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_0>;
-			status = "disabled";
+			/* SW2 wakes via WUU external pin 5. */
+			wakeup-ctrls = <&wuu NXP_WUU_PIN_5_FALLING_INT>;
+			status = "okay";
 		};
 
 		user_button_3: button_1 {

--- a/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
@@ -22,7 +22,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			cpu-power-states = <&sleep &deepsleep &powerdown>;
+			cpu-power-states = <&sleep &deepsleep &powerdown &deeppowerdown>;
 		};
 	};
 
@@ -53,6 +53,24 @@
 			power-state-name = "standby";
 			min-residency-us = <80000>;
 			exit-latency-us = <20>;
+		};
+
+		/*
+		 * Deep Power Down. The whole CORE domain (ARM core, NVIC, SysTick)
+		 * is power gated and LDO_CORE is turned off; the chip wakes through
+		 * the reset routine. All SRAM is retained by the SPC SRAM LDO, so the
+		 * full working set survives and S2RAM resume is transparent.
+		 */
+		deeppowerdown: deeppowerdown {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			/* Suspend-to-RAM needs the application to place its working set
+			 * in retained RAM and arm a wakeup source, so it is opt-in:
+			 * enable this node from the application to use it.
+			 */
+			status = "disabled";
+			min-residency-us = <500000>;
+			exit-latency-us = <500>;
 		};
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
@@ -350,6 +351,7 @@
 			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
+			wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 			status = "disabled";
 		};
 
@@ -478,9 +480,10 @@
 		};
 
 		wuu: system-modules@40092000 {
-			compatible = "nxp,wuu";
+			compatible = "nxp,wuc-wuu", "nxp,wuu";
 			reg = <0x40092000 0x1000>;
 			interrupts = <18 0>;
+			#wakeup-ctrl-cells = <1>;
 		};
 
 		cmc: system-modules@4008b000 {

--- a/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
@@ -22,7 +22,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			cpu-power-states = <&sleep &deepsleep &powerdown>;
+			cpu-power-states = <&sleep &deepsleep &powerdown &deeppowerdown>;
 		};
 	};
 
@@ -53,6 +53,24 @@
 			power-state-name = "standby";
 			min-residency-us = <80000>;
 			exit-latency-us = <20>;
+		};
+
+		/*
+		 * Deep Power Down. The whole CORE domain (ARM core, NVIC, SysTick)
+		 * is power gated and LDO_CORE is turned off; the chip wakes through
+		 * the reset routine. All SRAM is retained by the SPC SRAM LDO, so the
+		 * full working set survives and S2RAM resume is transparent.
+		 */
+		deeppowerdown: deeppowerdown {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			/* Suspend-to-RAM needs the application to place its working set
+			 * in retained RAM and arm a wakeup source, so it is opt-in:
+			 * enable this node from the application to use it.
+			 */
+			status = "disabled";
+			min-residency-us = <500000>;
+			exit-latency-us = <500>;
 		};
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
@@ -558,6 +559,7 @@
 			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
+			wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 			status = "disabled";
 		};
 
@@ -608,9 +610,10 @@
 		};
 
 		wuu: system-modules@40092000 {
-			compatible = "nxp,wuu";
+			compatible = "nxp,wuc-wuu", "nxp,wuu";
 			reg = <0x40092000 0x1000>;
 			interrupts = <18 0>;
+			#wakeup-ctrl-cells = <1>;
 		};
 
 		cmc: system-modules@4008b000 {

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -21,7 +21,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			cpu-power-states = <&sleep &deepsleep &powerdown>;
+			cpu-power-states = <&sleep &deepsleep &powerdown &deeppowerdown>;
 		};
 	};
 
@@ -52,6 +52,24 @@
 			power-state-name = "standby";
 			min-residency-us = <80000>;
 			exit-latency-us = <20>;
+		};
+
+		/*
+		 * Deep Power Down. The whole CORE domain (ARM core, NVIC, SysTick)
+		 * is power gated and LDO_CORE is turned off; the chip wakes through
+		 * the reset routine. All SRAM is retained by the SPC SRAM LDO, so the
+		 * full working set survives and S2RAM resume is transparent.
+		 */
+		deeppowerdown: deeppowerdown {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			/* Suspend-to-RAM needs the application to place its working set
+			 * in retained RAM and arm a wakeup source, so it is opt-in:
+			 * enable this node from the application to use it.
+			 */
+			status = "disabled";
+			min-residency-us = <500000>;
+			exit-latency-us = <500>;
 		};
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
@@ -499,6 +500,7 @@
 			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
+			wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 			status = "disabled";
 		};
 
@@ -539,9 +541,10 @@
 		};
 
 		wuu: system-modules@40092000 {
-			compatible = "nxp,wuu";
+			compatible = "nxp,wuc-wuu", "nxp,wuu";
 			reg = <0x40092000 0x1000>;
 			interrupts = <18 0>;
+			#wakeup-ctrl-cells = <1>;
 		};
 
 		cmc: system-modules@4008b000 {

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -12,6 +12,7 @@
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 
 / {
 	cpus: cpus {
@@ -23,11 +24,61 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			cpu-power-states = <&sleep &deepsleep &powerdown &deeppowerdown>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
 			};
+		};
+	};
+
+	power-states {
+		/*
+		 * Note:
+		 *  - 'exit-latency-us' depends on system clock frequency and voltage level.
+		 *  - 'min-residency-us' needs to be adjusted according to the actual project
+		 *    requirements. The values provided here are not applicable to all real
+		 *    projects.
+		 */
+		sleep: sleep {
+			compatible = "zephyr,power-state";
+			power-state-name = "runtime-idle";
+			min-residency-us = <10000>;
+			exit-latency-us = <1>;
+		};
+
+		deepsleep: deepsleep {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			min-residency-us = <50000>;
+			exit-latency-us = <10>;
+		};
+
+		powerdown: powerdown {
+			compatible = "zephyr,power-state";
+			power-state-name = "standby";
+			min-residency-us = <80000>;
+			exit-latency-us = <20>;
+		};
+
+		/*
+		 * Deep Power Down. The whole CORE domain (ARM core, NVIC, SysTick)
+		 * is power gated and LDO_CORE is turned off; the chip wakes through
+		 * the reset routine. Only the RAMA arrays kept alive by the VBAT
+		 * backup SRAM regulator survive, so the entire retained working set
+		 * must fit in that region for transparent S2RAM resume.
+		 */
+		deeppowerdown: deeppowerdown {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			/* Suspend-to-RAM needs the application to place its working set
+			 * in retained RAM and arm a wakeup source, so it is opt-in:
+			 * enable this node from the application to use it.
+			 */
+			status = "disabled";
+			min-residency-us = <500000>;
+			exit-latency-us = <500>;
 		};
 	};
 
@@ -511,6 +562,7 @@
 		prescale-glitch-filter-bypass;
 		clk-source = <1>;
 		resolution = <32>;
+		wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 	};
 
 	waketimer0: wake-timer@ae000 {
@@ -754,6 +806,24 @@
 	cmc: system-modules@c6000 {
 		compatible = "nxp,cmc";
 		reg = <0xc6000 0x1000>;
+	};
+
+	spc: system-modules@cb000 {
+		compatible = "nxp,spc";
+		reg = <0xcb000 0x1000>;
+		wakeup-delay = <0x7d>;
+	};
+
+	wuu: system-modules@92000 {
+		compatible = "nxp,wuc-wuu", "nxp,wuu";
+		reg = <0x92000 0x1000>;
+		interrupts = <18 0>;
+		#wakeup-ctrl-cells = <1>;
+	};
+
+	vbat: system-modules@93000 {
+		compatible = "nxp,vbat";
+		reg = <0x93000 0x1000>;
 	};
 
 	eim0: eim@400c7000 {

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
@@ -245,6 +246,7 @@
 			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
+			wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 			status = "disabled";
 		};
 
@@ -614,9 +616,10 @@
 		};
 
 		wuu: system-modules@40092000 {
-			compatible = "nxp,wuu";
+			compatible = "nxp,wuc-wuu", "nxp,wuu";
 			reg = <0x40092000 0x1000>;
 			interrupts = <18 0>;
+			#wakeup-ctrl-cells = <1>;
 		};
 
 		cmc: system-modules@4008b000 {

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -22,7 +22,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			cpu-power-states = <&sleep &deepsleep &powerdown>;
+			cpu-power-states = <&sleep &deepsleep &powerdown &deeppowerdown>;
 		};
 	};
 
@@ -53,6 +53,24 @@
 			power-state-name = "standby";
 			min-residency-us = <80000>;
 			exit-latency-us = <20>;
+		};
+
+		/*
+		 * Deep Power Down. The whole CORE domain (ARM core, NVIC, SysTick)
+		 * is power gated and LDO_CORE is turned off; the chip wakes through
+		 * the reset routine. All SRAM is retained by the SPC SRAM LDO, so the
+		 * full working set survives and S2RAM resume is transparent.
+		 */
+		deeppowerdown: deeppowerdown {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			/* Suspend-to-RAM needs the application to place its working set
+			 * in retained RAM and arm a wakeup source, so it is opt-in:
+			 * enable this node from the application to use it.
+			 */
+			status = "disabled";
+			min-residency-us = <500000>;
+			exit-latency-us = <500>;
 		};
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
@@ -26,7 +26,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			cpu-power-states = <&sleep &deepsleep &powerdown>;
+			cpu-power-states = <&sleep &deepsleep &powerdown &deeppowerdown>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
@@ -82,6 +82,24 @@
 			power-state-name = "standby";
 			min-residency-us = <80000>;
 			exit-latency-us = <20>;
+		};
+
+		/*
+		 * Deep Power Down. The whole CORE domain is power gated and the chip
+		 * wakes through the reset routine. Only SRAMA (the first 32 KB of the
+		 * RAM, retained by the VBAT RAM LDO) survives, so the entire retained
+		 * working set must fit in SRAMA for transparent resume.
+		 */
+		deeppowerdown: deeppowerdown {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			/* Suspend-to-RAM needs the application to place its working set
+			 * in retained RAM and arm a wakeup source, so it is opt-in:
+			 * enable this node from the application to use it.
+			 */
+			status = "disabled";
+			min-residency-us = <500000>;
+			exit-latency-us = <500>;
 		};
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
@@ -1014,6 +1015,7 @@
 		prescale-glitch-filter-bypass;
 		clk-source = <1>;
 		resolution = <32>;
+		wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 	};
 
 	lptmr1: lptmr@4b000 {
@@ -1174,9 +1176,10 @@
 	};
 
 	wuu: system-modules@46000 {
-		compatible = "nxp,wuu";
+		compatible = "nxp,wuc-wuu", "nxp,wuu";
 		reg = <0x46000 0x1000>;
 		interrupts = <147 0>;
+		#wakeup-ctrl-cells = <1>;
 	};
 
 	cmc: system-modules@48000 {

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
@@ -1165,6 +1166,7 @@
 		prescale-glitch-filter-bypass;
 		clk-source = <1>;
 		resolution = <32>;
+		wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 	};
 
 	lptmr1: lptmr@4b000 {
@@ -1305,9 +1307,10 @@
 	};
 
 	wuu: system-modules@46000 {
-		compatible = "nxp,wuu";
+		compatible = "nxp,wuc-wuu", "nxp,wuu";
 		reg = <0x46000 0x1000>;
 		interrupts = <147 0>;
+		#wakeup-ctrl-cells = <1>;
 	};
 
 	cmc: system-modules@48000 {

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -23,7 +23,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			cpu-power-states = <&sleep &deepsleep &powerdown>;
+			cpu-power-states = <&sleep &deepsleep &powerdown &deeppowerdown>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
@@ -64,6 +64,24 @@
 			power-state-name = "standby";
 			min-residency-us = <80000>;
 			exit-latency-us = <20>;
+		};
+
+		/*
+		 * Deep Power Down. The whole CORE domain is power gated and the chip
+		 * wakes through the reset routine. Only SRAMA (the first 32 KB of the
+		 * RAM, retained by the VBAT RAM LDO) survives, so the entire retained
+		 * working set must fit in SRAMA for transparent resume.
+		 */
+		deeppowerdown: deeppowerdown {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			/* Suspend-to-RAM needs the application to place its working set
+			 * in retained RAM and arm a wakeup source, so it is opt-in:
+			 * enable this node from the application to use it.
+			 */
+			status = "disabled";
+			min-residency-us = <500000>;
+			exit-latency-us = <500>;
 		};
 	};
 

--- a/dts/bindings/input/gpio-keys.yaml
+++ b/dts/bindings/input/gpio-keys.yaml
@@ -64,6 +64,7 @@ properties:
 
 child-binding:
   description: GPIO KEYS child node
+  include: wuc-device.yaml
   properties:
     gpios:
       type: phandle-array

--- a/samples/boards/nxp/mcxn_a/s2ram/CMakeLists.txt
+++ b/samples/boards/nxp/mcxn_a/s2ram/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(s2ram)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/boards/nxp/mcxn_a/s2ram/Kconfig
+++ b/samples/boards/nxp/mcxn_a/s2ram/Kconfig
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "NXP MCX suspend-to-RAM sample"
+
+choice
+	prompt "Suspend-to-RAM wakeup source"
+	default SAMPLE_S2RAM_WAKEUP_TIMER
+	help
+	  Select how the SoC is woken from suspend-to-RAM (Deep Power Down).
+
+config SAMPLE_S2RAM_WAKEUP_TIMER
+	bool "Timed wakeup"
+	help
+	  Wake after a fixed delay using a low-power timer.
+
+config SAMPLE_S2RAM_WAKEUP_BUTTON
+	bool "Button wakeup"
+	help
+	  Wake on a user button press.
+
+endchoice
+
+config SAMPLE_APP_TEST_CYCLES
+	int "Number of suspend-to-RAM cycles to execute"
+	range 1 1000
+	default 10
+	help
+	  Number of times the sample suspends to RAM and resumes before it
+	  stops. The retained cycle counter is checked against this value so
+	  a test harness can confirm every wakeup happened.
+
+source "Kconfig.zephyr"

--- a/samples/boards/nxp/mcxn_a/s2ram/README.rst
+++ b/samples/boards/nxp/mcxn_a/s2ram/README.rst
@@ -1,0 +1,86 @@
+.. zephyr:code-sample:: nxp_mcx_s2ram
+   :name: NXP MCX suspend-to-RAM
+   :relevant-api: subsys_pm_states wuc_interface
+
+   Suspend an NXP MCXA/MCXN SoC to RAM and resume on an LPTMR timer (or button)
+   wakeup delivered through the WUU wakeup controller.
+
+Overview
+********
+
+This sample exercises :c:enumerator:`PM_STATE_SUSPEND_TO_RAM` on NXP MCXA and
+MCXN SoCs, where it is mapped to the SoC Deep Power Down mode. The CORE power
+domain is gated and the chip wakes through the reset routine; the
+:ref:`pm_s2ram <pm-guide>` resume path then returns directly to the suspend call
+site without re-running kernel or CPU initialization, so on both families the
+resume is transparent (resume-in-place) to the application.
+
+A stand-in application thread models a real workload: it does its work and then
+blocks waiting for its next event, with no knowledge of Deep Power Down. The
+thread suspends the SoC to RAM and the wakeup resumes it transparently, right
+where it blocked. A counter incremented before every suspend survives the cycle,
+so the printed value demonstrates the retained RAM.
+
+The thread repeats for ``CONFIG_SAMPLE_APP_TEST_CYCLES`` cycles (default 10) and then
+stops, printing a final ``Completed N suspend-to-RAM cycles`` line so a test
+harness can confirm every wakeup happened. No console input is needed. Once the
+run is over the SoC stays awake (every PM state is locked, so it only ever
+suspends when the sample explicitly asks it to).
+
+The wakeup source is configured through the :ref:`WUC (Wakeup Controller)
+<wuc_api>` subsystem and is selectable at build time:
+
+* ``CONFIG_SAMPLE_S2RAM_WAKEUP_TIMER`` (default) arms LPTMR0 through the counter alarm
+  API and routes it to the core as a WUU internal-module wakeup source. The
+  worker thread blocks in :c:func:`k_sleep`, so the cycle repeats automatically.
+
+* ``CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON`` resumes on a WUU external pin transition (the
+  board's ``wakeup-button``, SW2). Deep Power Down resets the GPIO, so there is
+  no live GPIO edge to catch on resume - the press is latched only by the WUU.
+  The sample therefore treats the suspend-to-RAM resume itself as the wake signal
+  (no other wakeup source is armed), observed from a PM notifier that releases the
+  worker thread. Press SW2 to advance each cycle.
+
+.. note::
+
+   On MCXN SoCs only SRAMA (the first 32 KB, retained by the VBAT RAM LDO)
+   survives Deep Power Down, so the whole retained working set must fit in SRAMA
+   and ``zephyr,sram`` must point to it. On MCXA SoCs all SRAM is retained by the
+   SPC SRAM retention LDO, so no placement constraint applies.
+
+Building and Running
+********************
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/nxp/mcxn_a/s2ram
+   :board: frdm_mcxa156
+   :goals: build flash
+   :compact:
+
+Sample Output
+*************
+
+.. code-block:: console
+
+   frdm_mcxa156 suspend-to-RAM demo
+   Retained S2RAM cycle counter: 0
+   Entering suspend-to-RAM (cycle 1/10); wake in 3 s
+   Resumed from suspend-to-RAM; retained counter is 1
+   Entering suspend-to-RAM (cycle 2/10); wake in 3 s
+   Resumed from suspend-to-RAM; retained counter is 2
+   ...
+   Entering suspend-to-RAM (cycle 10/10); wake in 3 s
+   Resumed from suspend-to-RAM; retained counter is 10
+   Completed 10 suspend-to-RAM cycles
+
+With ``CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON`` each cycle instead waits for an SW2 press:
+
+.. code-block:: console
+
+   frdm_mcxn236 suspend-to-RAM demo
+   Retained S2RAM cycle counter: 0
+   Entering suspend-to-RAM (cycle 1/10); press SW2 to wake
+   Resumed from suspend-to-RAM; retained counter is 1
+   Entering suspend-to-RAM (cycle 2/10); press SW2 to wake
+   Resumed from suspend-to-RAM; retained counter is 2
+   ...

--- a/samples/boards/nxp/mcxn_a/s2ram/app.overlay
+++ b/samples/boards/nxp/mcxn_a/s2ram/app.overlay
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Suspend-to-RAM (Deep Power Down) is opt-in: the SoC disables it by default.
+ * This sample places its working set in retained RAM and arms a wakeup source,
+ * so enable the state here.
+ */
+&deeppowerdown {
+	status = "okay";
+};
+
+&lptmr0 {
+	status = "okay";
+	clock-frequency = <16384>;
+	timer-mode-sel = <0>;
+};

--- a/samples/boards/nxp/mcxn_a/s2ram/boards/frdm_mcxa153.overlay
+++ b/samples/boards/nxp/mcxn_a/s2ram/boards/frdm_mcxa153.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ostimer0 {
+	status = "disabled";
+};
+
+&systick {
+	status = "okay";
+};
+
+/* Suspend-to-RAM is opt-in (the SoC disables it by default); enable it here. */
+&deeppowerdown {
+	status = "okay";
+};

--- a/samples/boards/nxp/mcxn_a/s2ram/boards/frdm_mcxa156.overlay
+++ b/samples/boards/nxp/mcxn_a/s2ram/boards/frdm_mcxa156.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ostimer0 {
+	status = "disabled";
+};
+
+&systick {
+	status = "okay";
+};
+
+/* Suspend-to-RAM is opt-in (the SoC disables it by default); enable it here. */
+&deeppowerdown {
+	status = "okay";
+};

--- a/samples/boards/nxp/mcxn_a/s2ram/boards/frdm_mcxa577.overlay
+++ b/samples/boards/nxp/mcxn_a/s2ram/boards/frdm_mcxa577.overlay
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Deep Power Down on MCXAxx7 can retain ONLY SRAM arrays A0 and A3 (per the
+ * reference manual, section "Deep Power Down mode"). A1 and A2 lose power in
+ * DPD regardless of the VBAT retention config. Constrain zephyr,sram to A3
+ * (16 KB at 0x20004000) so the entire retained working set - including the
+ * pm_s2ram marker and saved CPU context - lands in a DPD-retainable array.
+ */
+&sram0 {
+	reg = <0x20004000 0x4000>;
+};
+
+/* Suspend-to-RAM is opt-in (the SoC disables it by default); enable it here. */
+&deeppowerdown {
+	status = "okay";
+};

--- a/samples/boards/nxp/mcxn_a/s2ram/boards/frdm_mcxn236.overlay
+++ b/samples/boards/nxp/mcxn_a/s2ram/boards/frdm_mcxn236.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Constrain zephyr,sram to RAMA1-RAMA3 (24 KB at 0x20002000) so the whole
+ * retained working set is both kept across Deep Power Down and kept clear of
+ * the boot ROM scratch.
+ */
+&sram0 {
+	reg = <0x20002000 0x6000>;
+};
+
+/* Suspend-to-RAM is opt-in (the SoC disables it by default); enable it here. */
+&deeppowerdown {
+	status = "okay";
+};

--- a/samples/boards/nxp/mcxn_a/s2ram/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/samples/boards/nxp/mcxn_a/s2ram/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Constrain zephyr,sram to RAMA1-RAMA3 (24 KB at 0x20002000) so the whole
+ * retained working set is both kept across Deep Power Down and kept clear of
+ * the boot ROM scratch.
+ */
+&sram0 {
+	reg = <0x20002000 0x6000>;
+};
+
+/* Suspend-to-RAM is opt-in (the SoC disables it by default); enable it here. */
+&deeppowerdown {
+	status = "okay";
+};

--- a/samples/boards/nxp/mcxn_a/s2ram/prj.conf
+++ b/samples/boards/nxp/mcxn_a/s2ram/prj.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_PM=y
+CONFIG_WUC=y
+CONFIG_COUNTER=y
+CONFIG_COUNTER_MCUX_LPTMR_ALARM=y

--- a/samples/boards/nxp/mcxn_a/s2ram/sample.yaml
+++ b/samples/boards/nxp/mcxn_a/s2ram/sample.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  name: Suspend-to-RAM for NXP MCX
+
+common:
+  tags:
+    - power
+    - pm
+  platform_allow:
+    - frdm_mcxn947/mcxn947/cpu0
+    - mcx_n5xx_evk/mcxn547/cpu0
+    - mcx_n9xx_evk/mcxn947/cpu0
+    - frdm_mcxn236
+    - frdm_mcxa153
+    - frdm_mcxa156
+    - frdm_mcxa344
+    - frdm_mcxa266
+    - frdm_mcxa346
+    - frdm_mcxa366
+  integration_platforms:
+    - frdm_mcxn947/mcxn947/cpu0
+    - frdm_mcxa156
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "suspend-to-RAM demo"
+
+tests:
+  sample.boards.nxp.mcxn_a.s2ram.timer:
+    timeout: 120
+    harness_config:
+      type: one_line
+      regex:
+        - "Completed 10 suspend-to-RAM cycles"
+    extra_configs:
+      - CONFIG_SAMPLE_S2RAM_WAKEUP_TIMER=y
+  sample.boards.nxp.mcxn_a.s2ram.button:
+    extra_configs:
+      - CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON=y

--- a/samples/boards/nxp/mcxn_a/s2ram/sample.yaml
+++ b/samples/boards/nxp/mcxn_a/s2ram/sample.yaml
@@ -19,6 +19,7 @@ common:
     - frdm_mcxa266
     - frdm_mcxa346
     - frdm_mcxa366
+    - frdm_mcxa577
   integration_platforms:
     - frdm_mcxn947/mcxn947/cpu0
     - frdm_mcxa156

--- a/samples/boards/nxp/mcxn_a/s2ram/src/main.c
+++ b/samples/boards/nxp/mcxn_a/s2ram/src/main.c
@@ -1,0 +1,177 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/drivers/wuc.h>
+
+#define WAKEUP_DELAY_S 3U
+
+#define APP_STACK_SIZE 2048
+#define APP_PRIORITY   5
+
+/* Incremented before every suspend. Its value surviving the suspend/resume
+ * cycle proves the RAM was retained while the CORE domain was powered down.
+ */
+static uint32_t cycles;
+
+#define CONSOLE_NODE   DT_CHOSEN(zephyr_console)
+#define CONSOLE_PARENT DT_PARENT(CONSOLE_NODE)
+
+static const struct device *const console_dev = DEVICE_DT_GET(CONSOLE_NODE);
+#if DT_NODE_HAS_COMPAT(CONSOLE_PARENT, nxp_lp_flexcomm)
+#define HAS_FLEXCOMM_PARENT 1
+static const struct device *const flexcomm_dev = DEVICE_DT_GET(CONSOLE_PARENT);
+#endif
+
+/*
+ * Deep Power Down resets every CORE-domain peripheral. On a transparent resume
+ * the SoC restores the CPU context and clocks, but the console UART driver has
+ * no device pm hooks, so re-initialise it before printing. Three clock gates
+ * that Deep Power Down switched off have to be re-opened, bottom up, before the
+ * console can drive its pins again:
+ *
+ *   1. the PORT pin-mux controllers - their gate must be on for the LPUART
+ *      pinctrl re-apply (step 3) to actually reach the pad-mux registers,
+ *   2. the parent LP_FLEXCOMM - its init re-enables the peripheral clock gate
+ *      and re-selects LPUART mode, then
+ *   3. the LPUART itself - its init re-applies pinctrl and the baud/format.
+ *
+ * device_init() is a no-op on an already-initialised device, so clear the
+ * initialised flag to force each driver to re-run its init against the reset
+ * hardware. (A production driver would do this through a PM_DEVICE_ACTION_RESUME
+ * handler instead.) printk keeps working once the LPUART is back: its console
+ * output hook still points at the same device.
+ */
+#define REINIT_DEVICE(dev)				\
+	do {						\
+		(dev)->state->initialized = false;	\
+		(void)device_init(dev);			\
+	} while (0)
+
+#define REINIT_PORT(node_id) REINIT_DEVICE(DEVICE_DT_GET(node_id));
+
+static void resume_console(void)
+{
+	/* Re-open every PORT pin-mux clock gate that Deep Power Down closed. */
+	DT_FOREACH_STATUS_OKAY(nxp_port_pinmux, REINIT_PORT)
+
+#ifdef HAS_FLEXCOMM_PARENT
+	REINIT_DEVICE(flexcomm_dev);
+#endif
+	REINIT_DEVICE(console_dev);
+}
+
+#if defined(CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON)
+/* In real-world applications, the button's wake-up event should be handled
+ * via the driver hook, allowing the application to directly wait for input
+ * events without needing to consider the existence of WUU. However, due to
+ * the current lack of hook handling, we use the PM notifier to handle the
+ * wake-up event.
+ */
+static K_SEM_DEFINE(button_wakeup, 0, 1);
+static const struct wuc_dt_spec button = WUC_DT_SPEC_GET(DT_ALIAS(wakeup_button));
+
+static void on_pm_state_exit(enum pm_state state)
+{
+	if (state == PM_STATE_SUSPEND_TO_RAM) {
+		k_sem_give(&button_wakeup);
+	}
+}
+
+static struct pm_notifier button_pm_notifier = {
+	.state_exit = on_pm_state_exit,
+};
+#else
+/* LPTMR0 (the system-timer companion) reaches the core as a WUU internal-module
+ * wakeup source.
+ */
+static const struct wuc_dt_spec timer_wakeup = WUC_DT_SPEC_GET(DT_NODELABEL(lptmr0));
+#endif /* CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON */
+
+static void arm_wakeup_source(void)
+{
+#if defined(CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON)
+	(void)wuc_enable_wakeup_source_dt(&button);
+#else
+	(void)wuc_enable_wakeup_source_dt(&timer_wakeup);
+#endif
+}
+
+static void app_thread(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	while (cycles < CONFIG_SAMPLE_APP_TEST_CYCLES) {
+		cycles++;
+
+#if defined(CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON)
+		printk("Entering suspend-to-RAM (cycle %u/%u); press SW2 to wake\n", cycles,
+		       CONFIG_SAMPLE_APP_TEST_CYCLES);
+#else
+		printk("Entering suspend-to-RAM (cycle %u/%u); wake in %u s\n", cycles,
+		       CONFIG_SAMPLE_APP_TEST_CYCLES, WAKEUP_DELAY_S);
+#endif
+
+		/* Let the UART finish shifting out the line above before DPD cuts its clock. */
+		k_busy_wait(2000);
+
+#if defined(CONFIG_SOC_SERIES_MCXAXX6)
+		/* On MCXAxx6 the Deep Power Down wakeup reset clears the WUU
+		 * wakeup-source configuration, so the source has to be re-armed
+		 * before every entry.
+		 */
+		arm_wakeup_source();
+#endif
+
+		pm_state_force(0U, &(struct pm_state_info){PM_STATE_SUSPEND_TO_RAM, 0, 0});
+#if defined(CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON)
+		/* Block until SW2 wakes the SoC; the PM notifier gives this. */
+		k_sem_take(&button_wakeup, K_FOREVER);
+#else
+		k_sleep(K_SECONDS(WAKEUP_DELAY_S));
+#endif
+
+		resume_console();
+		printk("Resumed from suspend-to-RAM; retained counter is %u\n", cycles);
+	}
+
+	/* All threads are now idle for good, but every PM state is locked, so the
+	 * SoC stays awake and the board remains debuggable after the test.
+	 */
+	printk("Completed %u suspend-to-RAM cycles\n", cycles);
+}
+
+K_THREAD_STACK_DEFINE(app_stack, APP_STACK_SIZE);
+static struct k_thread app_thread_data;
+
+int main(void)
+{
+	printk("%s suspend-to-RAM demo\n", CONFIG_BOARD);
+	printk("Retained S2RAM cycle counter: %u\n", cycles);
+
+	pm_policy_state_lock_get(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+
+	/* The application selects and enables its own wakeup source through the
+	 * WUC subsystem; the SoC power code does not hard-code one.
+	 */
+#if defined(CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON)
+	pm_notifier_register(&button_pm_notifier);
+#endif
+	arm_wakeup_source();
+
+	k_thread_create(&app_thread_data, app_stack, APP_STACK_SIZE, app_thread,
+			NULL, NULL, NULL, APP_PRIORITY, 0, K_NO_WAIT);
+
+	return 0;
+}

--- a/samples/boards/nxp/mcxn_a/s2ram/src/main.c
+++ b/samples/boards/nxp/mcxn_a/s2ram/src/main.c
@@ -123,9 +123,9 @@ static void app_thread(void *p1, void *p2, void *p3)
 		/* Let the UART finish shifting out the line above before DPD cuts its clock. */
 		k_busy_wait(2000);
 
-#if defined(CONFIG_SOC_SERIES_MCXAXX6)
-		/* On MCXAxx6 the Deep Power Down wakeup reset clears the WUU
-		 * wakeup-source configuration, so the source has to be re-armed
+#if defined(CONFIG_SOC_SERIES_MCXAXX6) || defined(CONFIG_SOC_SERIES_MCXAXX7)
+		/* On MCXAxx6 / MCXAxx7 the Deep Power Down wakeup reset clears the
+		 * WUU wakeup-source configuration, so the source has to be re-armed
 		 * before every entry.
 		 */
 		arm_wakeup_source();

--- a/samples/boards/nxp/mcxn_a/system_off/CMakeLists.txt
+++ b/samples/boards/nxp/mcxn_a/system_off/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(system_off)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/boards/nxp/mcxn_a/system_off/Kconfig
+++ b/samples/boards/nxp/mcxn_a/system_off/Kconfig
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "NXP MCX system off sample"
+
+choice
+	prompt "Deep Power Down wakeup source"
+	default SAMPLE_SYSTEM_OFF_WAKEUP_TIMER
+	help
+	  Select how the SoC is woken from Deep Power Down (system off).
+
+config SAMPLE_SYSTEM_OFF_WAKEUP_TIMER
+	bool "Timed wakeup"
+	help
+	  Wake after a fixed delay using a low-power timer.
+
+config SAMPLE_SYSTEM_OFF_WAKEUP_BUTTON
+	bool "Button wakeup"
+	help
+	  Wake on a user button press.
+
+endchoice
+
+config SAMPLE_APP_TEST_CYCLES
+	int "Number of system-off cycles to execute"
+	range 1 1000
+	default 10
+	help
+	  Number of times the sample arms the wakeup source and enters system
+	  off before it stops. The completed cycle count is kept in retained
+	  SRAM across each Deep Power Down wake reset so a test harness can
+	  confirm every wakeup happened.
+
+source "Kconfig.zephyr"

--- a/samples/boards/nxp/mcxn_a/system_off/README.rst
+++ b/samples/boards/nxp/mcxn_a/system_off/README.rst
@@ -1,0 +1,81 @@
+.. zephyr:code-sample:: nxp_mcx_system_off
+   :name: NXP MCX system off
+   :relevant-api: sys_poweroff wuc_interface
+
+   Use system off (Deep Power Down) on NXP MCXA/MCXN SoCs and wake through
+   the WUU wakeup controller.
+
+Overview
+********
+
+This sample puts an NXP MCXA or MCXN SoC into system off, which is mapped
+to the SoC Deep Power Down mode. In Deep Power Down the CORE power domain
+is gated and the chip wakes through the reset routine, so a wakeup looks
+like a cold boot.
+
+The sample runs ``CONFIG_SAMPLE_APP_TEST_CYCLES`` system-off cycles (default 10) and
+then stops, printing a final ``Completed N system-off cycles`` line so a test
+harness can confirm every wakeup happened. No console input is needed.
+
+Because each wakeup is a reset, the completed-cycle counter must survive Deep
+Power Down. Deep Power Down gates every SRAM array, so the sample keeps the
+counter in retained SRAM and arms that SRAM's low-power retention (the VBAT SRAM
+LDO on MCXN, the SPC SRAM retention LDO on MCXA) before powering off. On each
+boot it tells a wake from a cold boot apart using the reset cause reported
+through :ref:`hwinfo <hwinfo_api>` (``RESET_LOW_POWER_WAKE``): a cold boot seeds
+the counter, a wake keeps counting. Once the target count is reached the sample
+returns without powering off, leaving the SoC awake and debuggable.
+
+The wakeup source is configured through the :ref:`WUC (Wakeup Controller)
+<wuc_api>` subsystem (the ``nxp,wuc-wuu`` driver). Two wakeup sources are
+selectable at build time:
+
+* ``CONFIG_SAMPLE_SYSTEM_OFF_WAKEUP_TIMER`` (default) arms LPTMR0 through the counter
+  alarm API and routes it to the core as a WUU internal-module wakeup source, so
+  the board wakes itself after a few seconds with no external action.
+
+* ``CONFIG_SAMPLE_SYSTEM_OFF_WAKEUP_BUTTON`` waits for a transition on a WUU external
+  pin. The board devicetree attaches the WUU source to its wakeup button node
+  (next to the button ``gpios``) and aliases it as ``wakeup-button``; the sample
+  simply enables ``DT_ALIAS(wakeup_button)``. No sample overlay is required. A
+  board describes it like::
+
+     &user_button_2 {
+         wakeup-ctrls = <&wuu NXP_WUU_PIN_0_FALLING_INT>;
+     };
+
+     / {
+         aliases {
+             wakeup-button = &user_button_2;
+         };
+     };
+
+Building and Running
+********************
+
+Build and flash the sample with the default (timer) wakeup source:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/nxp/mcxn_a/system_off
+   :board: frdm_mcxn947/mcxn947/cpu0
+   :goals: build flash
+   :compact:
+
+Sample Output
+*************
+
+.. code-block:: console
+
+   frdm_mcxn236 system off demo
+   Entering system off (cycle 1/10); the timer wakes it in 5 s
+   <the timer wakes the SoC after 5 s through the reset routine; main() restarts>
+   frdm_mcxn236 system off demo
+   Woke from system off; retained count 1/10
+   Entering system off (cycle 2/10); the timer wakes it in 5 s
+   ...
+   frdm_mcxn236 system off demo
+   Woke from system off; retained count 10/10
+   Completed 10 system-off cycles
+
+With ``CONFIG_SAMPLE_SYSTEM_OFF_WAKEUP_BUTTON`` each cycle instead waits for a press on
+the board's wakeup button (SW2) to leave system off.

--- a/samples/boards/nxp/mcxn_a/system_off/app.overlay
+++ b/samples/boards/nxp/mcxn_a/system_off/app.overlay
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lptmr0 {
+	status = "okay";
+	clock-frequency = <16384>;
+	timer-mode-sel = <0>;
+};

--- a/samples/boards/nxp/mcxn_a/system_off/boards/frdm_mcxa577.overlay
+++ b/samples/boards/nxp/mcxn_a/system_off/boards/frdm_mcxa577.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Deep Power Down on MCXAxx7 can retain ONLY SRAM arrays A0 and A3 (per the
+ * reference manual, "Deep Power Down mode"); A1/A2 lose power regardless of the
+ * VBAT retention config. Point zephyr,sram at A3 (16 KB at 0x20004000) so the
+ * retained .noinit cycle counter lands in a DPD-retainable array and survives
+ * the system-off wake reset.
+ */
+&sram0 {
+	reg = <0x20004000 0x4000>;
+};

--- a/samples/boards/nxp/mcxn_a/system_off/boards/frdm_mcxn236.overlay
+++ b/samples/boards/nxp/mcxn_a/system_off/boards/frdm_mcxn236.overlay
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Deep Power Down only retains RAMA on MCXN, so point zephyr,sram at RAMA1-RAMA3
+ * (24 KB at 0x20002000, clear of the boot ROM scratch in RAMA0). The retained
+ * cycle counter (.noinit) then lands in RAM the VBAT LDO keeps alive across the
+ * system-off wake reset.
+ */
+&sram0 {
+	reg = <0x20002000 0x6000>;
+};

--- a/samples/boards/nxp/mcxn_a/system_off/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/samples/boards/nxp/mcxn_a/system_off/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Deep Power Down only retains RAMA on MCXN, so point zephyr,sram at RAMA1-RAMA3
+ * (24 KB at 0x20002000, clear of the boot ROM scratch in RAMA0). The retained
+ * cycle counter (.noinit) then lands in RAM the VBAT LDO keeps alive across the
+ * system-off wake reset.
+ */
+&sram0 {
+	reg = <0x20002000 0x6000>;
+};

--- a/samples/boards/nxp/mcxn_a/system_off/prj.conf
+++ b/samples/boards/nxp/mcxn_a/system_off/prj.conf
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_POWEROFF=y
+CONFIG_WUC=y
+CONFIG_COUNTER=y
+CONFIG_COUNTER_MCUX_LPTMR_ALARM=y
+
+# The cycle counter is seeded on a cold boot and left untouched on a Deep Power
+# Down wake, told apart from the CMC reset cause reported through hwinfo.
+CONFIG_HWINFO=y

--- a/samples/boards/nxp/mcxn_a/system_off/sample.yaml
+++ b/samples/boards/nxp/mcxn_a/system_off/sample.yaml
@@ -19,6 +19,7 @@ common:
     - frdm_mcxa266
     - frdm_mcxa346
     - frdm_mcxa366
+    - frdm_mcxa577
   integration_platforms:
     - frdm_mcxn947/mcxn947/cpu0
     - frdm_mcxa156

--- a/samples/boards/nxp/mcxn_a/system_off/sample.yaml
+++ b/samples/boards/nxp/mcxn_a/system_off/sample.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  name: System Off for NXP MCX
+
+common:
+  tags:
+    - power
+    - poweroff
+  platform_allow:
+    - frdm_mcxn947/mcxn947/cpu0
+    - mcx_n5xx_evk/mcxn547/cpu0
+    - mcx_n9xx_evk/mcxn947/cpu0
+    - frdm_mcxn236
+    - frdm_mcxa153
+    - frdm_mcxa156
+    - frdm_mcxa344
+    - frdm_mcxa266
+    - frdm_mcxa346
+    - frdm_mcxa366
+  integration_platforms:
+    - frdm_mcxn947/mcxn947/cpu0
+    - frdm_mcxa156
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "system off demo"
+
+tests:
+  sample.boards.nxp.mcxn_a.system_off.timer:
+    timeout: 120
+    harness_config:
+      type: one_line
+      regex:
+        - "Completed 10 system-off cycles"
+    extra_configs:
+      - CONFIG_SAMPLE_SYSTEM_OFF_WAKEUP_TIMER=y
+  sample.boards.nxp.mcxn_a.system_off.button:
+    timeout: 300
+    extra_configs:
+      - CONFIG_SAMPLE_SYSTEM_OFF_WAKEUP_BUTTON=y

--- a/samples/boards/nxp/mcxn_a/system_off/src/main.c
+++ b/samples/boards/nxp/mcxn_a/system_off/src/main.c
@@ -31,12 +31,13 @@ static const struct wuc_dt_spec wakeup = WUC_DT_SPEC_GET(DT_ALIAS(wakeup_button)
  * retention is armed before entering Deep Power Down. This mirrors the SoC
  * suspend-to-RAM retention path; a production application would share that code.
  *
- *   - MCXN: the VBAT SRAM LDO retains RAMA. The linker places .noinit (and so
- *     the counter) in RAMA because the board overlay points zephyr,sram there.
- *   - MCXA: the SPC SRAM retention LDO retains every array, so the counter is
- *     retained wherever it lands.
+ *   - MCXN / MCXAxx7: the VBAT backup SRAM regulator retains RAMA. The linker
+ *     places .noinit (and so the counter) in RAMA because the board overlay
+ *     points zephyr,sram there.
+ *   - other MCXA: the SPC SRAM retention LDO retains every array, so the counter
+ *     is retained wherever it lands.
  */
-#if defined(CONFIG_SOC_FAMILY_MCXN)
+#if defined(CONFIG_SOC_FAMILY_MCXN) || defined(CONFIG_SOC_SERIES_MCXAXX7)
 #include <fsl_vbat.h>
 
 #define VBAT0_ADDR ((VBAT_Type *)DT_REG_ADDR(DT_INST(0, nxp_vbat)))

--- a/samples/boards/nxp/mcxn_a/system_off/src/main.c
+++ b/samples/boards/nxp/mcxn_a/system_off/src/main.c
@@ -1,0 +1,174 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/poweroff.h>
+#include <zephyr/drivers/wuc.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/toolchain.h>
+
+#if defined(CONFIG_SAMPLE_SYSTEM_OFF_WAKEUP_TIMER)
+#include <zephyr/drivers/counter.h>
+
+#define WAKEUP_DELAY_S 5U
+static const struct device *const lptmr = DEVICE_DT_GET(DT_NODELABEL(lptmr0));
+/* LPTMR0 reaches the core as a WUU internal-module wakeup source. */
+static const struct wuc_dt_spec wakeup = WUC_DT_SPEC_GET(DT_NODELABEL(lptmr0));
+#else
+/* The wakeup button (a WUU external pin) is described per board and aliased as
+ * "wakeup-button".
+ */
+static const struct wuc_dt_spec wakeup = WUC_DT_SPEC_GET(DT_ALIAS(wakeup_button));
+#endif
+
+/*
+ * Deep Power Down gates every SRAM array, so the cycle counter that has to
+ * survive the power-off/wake reset must live in an array whose low-power
+ * retention is armed before entering Deep Power Down. This mirrors the SoC
+ * suspend-to-RAM retention path; a production application would share that code.
+ *
+ *   - MCXN: the VBAT SRAM LDO retains RAMA. The linker places .noinit (and so
+ *     the counter) in RAMA because the board overlay points zephyr,sram there.
+ *   - MCXA: the SPC SRAM retention LDO retains every array, so the counter is
+ *     retained wherever it lands.
+ */
+#if defined(CONFIG_SOC_FAMILY_MCXN)
+#include <fsl_vbat.h>
+
+#define VBAT0_ADDR ((VBAT_Type *)DT_REG_ADDR(DT_INST(0, nxp_vbat)))
+#define MCXN_RAMA_ALL						\
+	(kVBAT_SramArray0 | kVBAT_SramArray1 | kVBAT_SramArray2 | kVBAT_SramArray3)
+
+static void retain_counter_ram(void)
+{
+	if (!VBAT_CheckFRO16kEnabled(VBAT0_ADDR)) {
+		VBAT_EnableFRO16k(VBAT0_ADDR, true);
+	}
+	VBAT_UngateFRO16k(VBAT0_ADDR, kVBAT_EnableClockToVddSys);
+	if (!VBAT_CheckBandgapEnabled(VBAT0_ADDR)) {
+		(void)VBAT_EnableBandgap(VBAT0_ADDR, true);
+	}
+	VBAT_EnableBandgapRefreshMode(VBAT0_ADDR, true);
+	(void)VBAT_EnableBackupSRAMRegulator(VBAT0_ADDR, true);
+	VBAT_RetainSRAMsInLowPowerModes(VBAT0_ADDR, MCXN_RAMA_ALL);
+}
+#elif defined(CONFIG_SOC_FAMILY_MCXA)
+#include <fsl_spc.h>
+
+#define SPC0_ADDR ((SPC_Type *)DT_REG_ADDR(DT_INST(0, nxp_spc)))
+
+static void retain_counter_ram(void)
+{
+	SPC_EnableSRAMLdo(SPC0_ADDR, true);
+	SPC_RetainSRAMArray(SPC0_ADDR, 0xFU);
+}
+#else
+static void retain_counter_ram(void)
+{
+}
+#endif
+
+/* Retained across the Deep Power Down reset (see retain_counter_ram()).
+ * Left uninitialised so the C runtime never clears it; a cold boot is
+ * detected from the reset cause and seeds it explicitly.
+ */
+static __noinit uint32_t cycles;
+
+#if defined(CONFIG_SAMPLE_SYSTEM_OFF_WAKEUP_TIMER)
+static void wakeup_alarm_cb(const struct device *dev, uint8_t chan_id, uint32_t ticks,
+			    void *user_data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(chan_id);
+	ARG_UNUSED(ticks);
+	ARG_UNUSED(user_data);
+}
+
+static int arm_timer_wakeup(void)
+{
+	struct counter_alarm_cfg cfg = {
+		.callback = wakeup_alarm_cb,
+		.ticks = counter_us_to_ticks(lptmr, (uint64_t)WAKEUP_DELAY_S * USEC_PER_SEC),
+		.flags = 0,
+	};
+
+	(void)counter_start(lptmr);
+
+	return counter_set_channel_alarm(lptmr, 0, &cfg);
+}
+#endif
+
+int main(void)
+{
+	uint32_t reset_cause = 0U;
+	bool woke;
+	int ret;
+
+	(void)hwinfo_get_reset_cause(&reset_cause);
+	(void)hwinfo_clear_reset_cause();
+	woke = (reset_cause & RESET_LOW_POWER_WAKE) != 0U;
+
+	if (!woke) {
+		/* Cold boot: seed the retained counter. */
+		cycles = 0U;
+	}
+
+	printk("%s system off demo\n", CONFIG_BOARD);
+	if (woke) {
+		printk("Woke from system off; retained count %u/%u\n", cycles,
+		       CONFIG_SAMPLE_APP_TEST_CYCLES);
+	}
+
+	if (cycles >= CONFIG_SAMPLE_APP_TEST_CYCLES) {
+		printk("Completed %u system-off cycles\n", CONFIG_SAMPLE_APP_TEST_CYCLES);
+		return 0;
+	}
+
+	if (!device_is_ready(wakeup.dev)) {
+		printk("WUC device %s not ready\n", wakeup.dev->name);
+		return 0;
+	}
+
+#if defined(CONFIG_SAMPLE_SYSTEM_OFF_WAKEUP_TIMER)
+	if (!device_is_ready(lptmr)) {
+		printk("LPTMR counter device not ready\n");
+		return 0;
+	}
+
+	ret = arm_timer_wakeup();
+	if (ret < 0) {
+		printk("Failed to arm LPTMR wakeup (%d)\n", ret);
+		return 0;
+	}
+#endif
+
+	ret = wuc_enable_wakeup_source_dt(&wakeup);
+	if (ret < 0) {
+		printk("Failed to enable wakeup source (%d)\n", ret);
+		return 0;
+	}
+
+	cycles++;
+	retain_counter_ram();
+
+#if defined(CONFIG_SAMPLE_SYSTEM_OFF_WAKEUP_TIMER)
+	printk("Entering system off (cycle %u/%u); the timer wakes it in %u s\r\n", cycles,
+	       CONFIG_SAMPLE_APP_TEST_CYCLES, WAKEUP_DELAY_S);
+#else
+	printk("Entering system off (cycle %u/%u); trigger the wakeup pin to restart\r\n", cycles,
+	       CONFIG_SAMPLE_APP_TEST_CYCLES);
+#endif
+
+	sys_poweroff();
+
+	/* Deep Power Down wakes through the reset routine, so this is never
+	 * reached on a working system off.
+	 */
+	printk("ERROR: System off failed\n");
+
+	return 0;
+}

--- a/soc/nxp/mcx/mcxa/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxa/CMakeLists.txt
@@ -10,3 +10,5 @@ zephyr_include_directories(.)
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
 
 zephyr_sources_ifdef(CONFIG_PM power.c)
+
+zephyr_sources_ifdef(CONFIG_POWEROFF poweroff.c)

--- a/soc/nxp/mcx/mcxa/Kconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig
@@ -51,3 +51,6 @@ config SOC_SERIES_MCXAXX7
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select ARM_TRUSTZONE_M
+	select HAS_PM
+	select WUC if PM
+	select HAS_POWEROFF

--- a/soc/nxp/mcx/mcxa/Kconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig
@@ -37,6 +37,8 @@ config SOC_SERIES_MCXAXX4
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
+	select HAS_PM
+	select HAS_POWEROFF
 
 config SOC_SERIES_MCXAXX7
 	select CPU_CORTEX_M33

--- a/soc/nxp/mcx/mcxa/Kconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig
@@ -15,6 +15,7 @@ config SOC_FAMILY_MCXA
 config SOC_SERIES_MCXA1X3
 	select CPU_CORTEX_M33
 	select HAS_PM
+	select WUC if PM
 	select HAS_POWEROFF
 
 config SOC_SERIES_MCXA1X6
@@ -22,6 +23,7 @@ config SOC_SERIES_MCXA1X6
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_PM
+	select WUC if PM
 	select HAS_POWEROFF
 
 config SOC_SERIES_MCXAXX6
@@ -30,6 +32,7 @@ config SOC_SERIES_MCXAXX6
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_PM
+	select WUC if PM
 	select HAS_POWEROFF
 
 config SOC_SERIES_MCXAXX4
@@ -38,6 +41,7 @@ config SOC_SERIES_MCXAXX4
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_PM
+	select WUC if PM
 	select HAS_POWEROFF
 
 config SOC_SERIES_MCXAXX7

--- a/soc/nxp/mcx/mcxa/Kconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig
@@ -15,12 +15,14 @@ config SOC_FAMILY_MCXA
 config SOC_SERIES_MCXA1X3
 	select CPU_CORTEX_M33
 	select HAS_PM
+	select HAS_POWEROFF
 
 config SOC_SERIES_MCXA1X6
 	select CPU_CORTEX_M33
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_PM
+	select HAS_POWEROFF
 
 config SOC_SERIES_MCXAXX6
 	select CPU_CORTEX_M33
@@ -28,6 +30,7 @@ config SOC_SERIES_MCXAXX6
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_PM
+	select HAS_POWEROFF
 
 config SOC_SERIES_MCXAXX4
 	select CPU_CORTEX_M33

--- a/soc/nxp/mcx/mcxa/power.c
+++ b/soc/nxp/mcx/mcxa/power.c
@@ -16,6 +16,9 @@
 #include <cmsis_core.h>
 #include <zephyr/arch/arm/cortex_m/scb.h>
 #include <zephyr/arch/common/pm_s2ram.h>
+#if defined(CONFIG_SOC_SERIES_MCXAXX7)
+#include <fsl_vbat.h>
+#endif
 #endif
 
 #define MCXA_WAKEUP_DELAY	DT_PROP_OR(DT_INST(0, nxp_spc), wakeup_delay, 0)
@@ -41,9 +44,6 @@ static void enter_low_power(void)
 }
 
 #if defined(CONFIG_PM_S2RAM)
-/* 0xF keeps every RAM array powered by the SPC SRAM retention LDO. */
-#define MCXA_SRAM_RETAIN_ALL	0xFU
-
 /*
  * Deep Power Down (mapped to PM_STATE_SUSPEND_TO_RAM) power gates the whole
  * CORE domain, including the ARM System Control Space (NVIC, SCB). The chip
@@ -83,11 +83,55 @@ static void mcxa_scs_restore(void)
 	}
 }
 
-static void mcxa_s2ram_retain_sram(void)
+#if !defined(CONFIG_SOC_SERIES_MCXAXX7)
+/* 0xF keeps every RAM array powered by the SPC SRAM retention LDO. */
+#define MCXA_SRAM_RETAIN_ALL	0xFU
+
+static int mcxa_s2ram_retain_sram(void)
 {
 	SPC_EnableSRAMLdo(MCXA_SPC_ADDR, true);
 	SPC_RetainSRAMArray(MCXA_SPC_ADDR, MCXA_SRAM_RETAIN_ALL);
+
+	return 0;
 }
+#else
+/* Parts without an SPC SRAM retention LDO (e.g. MCXAxx7) keep the RAMA arrays
+ * alive through the VBAT backup SRAM regulator instead, so the retained working
+ * set must fit in the VBAT-retained RAMA region.
+ */
+#define MCXA_VBAT_ADDR	(VBAT_Type *)DT_REG_ADDR(DT_INST(0, nxp_vbat))
+#define MCXA_RAMA_ALL	(kVBAT_SramArray0 | kVBAT_SramArray1 | \
+			 kVBAT_SramArray2 | kVBAT_SramArray3)
+
+static int mcxa_s2ram_retain_sram(void)
+{
+	if (!VBAT_CheckFRO16kEnabled(MCXA_VBAT_ADDR)) {
+		VBAT_EnableFRO16k(MCXA_VBAT_ADDR, true);
+	}
+
+	VBAT_UngateFRO16k(MCXA_VBAT_ADDR, kVBAT_EnableClockToVddSys);
+
+	if (!VBAT_CheckBandgapEnabled(MCXA_VBAT_ADDR)) {
+		if (VBAT_EnableBandgap(MCXA_VBAT_ADDR, true) != kStatus_Success) {
+			return -EIO;
+		}
+	}
+
+	/* Enable refresh mode to save power. */
+	VBAT_EnableBandgapRefreshMode(MCXA_VBAT_ADDR, true);
+
+	/* The backup SRAM regulator supplies the retained RAMA arrays across
+	 * Deep Power Down; if it cannot be enabled the context would be lost.
+	 */
+	if (VBAT_EnableBackupSRAMRegulator(MCXA_VBAT_ADDR, true) != kStatus_Success) {
+		return -EIO;
+	}
+
+	VBAT_RetainSRAMsInLowPowerModes(MCXA_VBAT_ADDR, MCXA_RAMA_ALL);
+
+	return 0;
+}
+#endif
 
 static int mcxa_enter_deep_power_down(void)
 {
@@ -131,7 +175,14 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 #if defined(CONFIG_PM_S2RAM)
 	case PM_STATE_SUSPEND_TO_RAM:
 		SPC_SetLowPowerWakeUpDelay(MCXA_SPC_ADDR, MCXA_WAKEUP_DELAY);
-		mcxa_s2ram_retain_sram();
+
+		if (mcxa_s2ram_retain_sram() != 0) {
+			/* SRAM retention could not be armed; entering Deep Power
+			 * Down now would lose the retained context, so stay running.
+			 */
+			break;
+		}
+
 		mcxa_scs_save();
 
 		/* A non-zero return means the SoC never entered Deep Power Down

--- a/soc/nxp/mcx/mcxa/power.c
+++ b/soc/nxp/mcx/mcxa/power.c
@@ -6,10 +6,8 @@
 
 #include <zephyr/pm/pm.h>
 #include <zephyr/arch/arch_interface.h>
-#include <zephyr/device.h>
 #include <fsl_cmc.h>
 #include <fsl_spc.h>
-#include <fsl_wuu.h>
 #include <zephyr/platform/hooks.h>
 #include <soc.h>
 
@@ -20,9 +18,7 @@
 #include <zephyr/arch/common/pm_s2ram.h>
 #endif
 
-#define WUU_WAKEUP_LPTMR0_IDX	6U
 #define MCXA_WAKEUP_DELAY	DT_PROP_OR(DT_INST(0, nxp_spc), wakeup_delay, 0)
-#define MCXA_WUU_ADDR		(WUU_Type *)DT_REG_ADDR(DT_INST(0, nxp_wuu))
 #define MCXA_CMC_ADDR		(CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc))
 #define MCXA_SPC_ADDR		(SPC_Type *)DT_REG_ADDR(DT_INST(0, nxp_spc))
 
@@ -31,8 +27,6 @@ static void pm_enter_hook(void)
 	CMC_SetPowerModeProtection(MCXA_CMC_ADDR, kCMC_AllowAllLowPowerModes);
 	CMC_EnableDebugOperation(MCXA_CMC_ADDR, false);
 	CMC_ConfigFlashMode(MCXA_CMC_ADDR, true, true, false);
-	WUU_SetInternalWakeUpModulesConfig(MCXA_WUU_ADDR, WUU_WAKEUP_LPTMR0_IDX,
-					   kWUU_InternalModuleInterrupt);
 }
 
 static void enter_low_power(void)

--- a/soc/nxp/mcx/mcxa/power.c
+++ b/soc/nxp/mcx/mcxa/power.c
@@ -10,9 +10,18 @@
 #include <fsl_cmc.h>
 #include <fsl_spc.h>
 #include <fsl_wuu.h>
+#include <zephyr/platform/hooks.h>
+#include <soc.h>
+
+#if defined(CONFIG_PM_S2RAM)
+#include <errno.h>
+#include <cmsis_core.h>
+#include <zephyr/arch/arm/cortex_m/scb.h>
+#include <zephyr/arch/common/pm_s2ram.h>
+#endif
 
 #define WUU_WAKEUP_LPTMR0_IDX	6U
-#define MCXA_WAKEUP_DELAY	DT_PROP_OR(DT_NODELABEL(spc), wakeup_delay, 0)
+#define MCXA_WAKEUP_DELAY	DT_PROP_OR(DT_INST(0, nxp_spc), wakeup_delay, 0)
 #define MCXA_WUU_ADDR		(WUU_Type *)DT_REG_ADDR(DT_INST(0, nxp_wuu))
 #define MCXA_CMC_ADDR		(CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc))
 #define MCXA_SPC_ADDR		(SPC_Type *)DT_REG_ADDR(DT_INST(0, nxp_spc))
@@ -37,6 +46,68 @@ static void enter_low_power(void)
 	arch_pm_state_set_finish(key);
 }
 
+#if defined(CONFIG_PM_S2RAM)
+/* 0xF keeps every RAM array powered by the SPC SRAM retention LDO. */
+#define MCXA_SRAM_RETAIN_ALL	0xFU
+
+/*
+ * Deep Power Down (mapped to PM_STATE_SUSPEND_TO_RAM) power gates the whole
+ * CORE domain, including the ARM System Control Space (NVIC, SCB). The chip
+ * wakes through the reset routine; arch_pm_s2ram_resume() then returns directly
+ * to the suspend call site without re-running kernel/CPU initialization, so the
+ * SCS state is saved here before entry and restored on resume.
+ */
+static struct {
+	uint32_t iser[ARRAY_SIZE(((NVIC_Type *)NVIC_BASE)->ISER)];
+	uint32_t ipr[(sizeof(((NVIC_Type *)NVIC_BASE)->IPR)) / sizeof(uint32_t)];
+	struct scb_context scb;
+} mcxa_scs_context;
+
+static void mcxa_scs_save(void)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(mcxa_scs_context.iser); i++) {
+		mcxa_scs_context.iser[i] = NVIC->ISER[i];
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(mcxa_scs_context.ipr); i++) {
+		mcxa_scs_context.ipr[i] = ((volatile uint32_t *)NVIC->IPR)[i];
+	}
+
+	z_arm_save_scb_context(&mcxa_scs_context.scb);
+}
+
+static void mcxa_scs_restore(void)
+{
+	z_arm_restore_scb_context(&mcxa_scs_context.scb);
+
+	for (size_t i = 0; i < ARRAY_SIZE(mcxa_scs_context.ipr); i++) {
+		((volatile uint32_t *)NVIC->IPR)[i] = mcxa_scs_context.ipr[i];
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(mcxa_scs_context.iser); i++) {
+		NVIC->ISER[i] = mcxa_scs_context.iser[i];
+	}
+}
+
+static void mcxa_s2ram_retain_sram(void)
+{
+	SPC_EnableSRAMLdo(MCXA_SPC_ADDR, true);
+	SPC_RetainSRAMArray(MCXA_SPC_ADDR, MCXA_SRAM_RETAIN_ALL);
+}
+
+static int mcxa_enter_deep_power_down(void)
+{
+	const cmc_power_domain_config_t cmc_config = {
+		.clock_mode = kCMC_GateAllSystemClocksEnterLowPowerMode,
+		.main_domain = kCMC_DeepPowerDown,
+	};
+
+	CMC_EnterLowPowerMode(MCXA_CMC_ADDR, &cmc_config);
+
+	return -EBUSY;
+}
+#endif /* CONFIG_PM_S2RAM */
+
 __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
 	pm_enter_hook();
@@ -57,11 +128,40 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		break;
 
 	case PM_STATE_STANDBY:
-		SPC_SetLowPowerWakeUpDelay(SPC0, MCXA_WAKEUP_DELAY);
+		SPC_SetLowPowerWakeUpDelay(MCXA_SPC_ADDR, MCXA_WAKEUP_DELAY);
 		CMC_SetClockMode(MCXA_CMC_ADDR, kCMC_GateAllSystemClocksEnterLowPowerMode);
 		CMC_SetMAINPowerMode(MCXA_CMC_ADDR, kCMC_PowerDownMode);
 		enter_low_power();
 		break;
+
+#if defined(CONFIG_PM_S2RAM)
+	case PM_STATE_SUSPEND_TO_RAM:
+		SPC_SetLowPowerWakeUpDelay(MCXA_SPC_ADDR, MCXA_WAKEUP_DELAY);
+		mcxa_s2ram_retain_sram();
+		mcxa_scs_save();
+
+		/* A non-zero return means the SoC never entered Deep Power Down
+		 * and is still fully operational, so skip the resume-path
+		 * re-initialization below.
+		 */
+		if (arch_pm_s2ram_suspend(mcxa_enter_deep_power_down) != 0) {
+			break;
+		}
+
+		SystemInit();
+
+		/* re-build clock tree */
+		board_early_init_hook();
+
+		/* idle-thread stack is nearly full, it is easy to reach the
+		 * PSPLIM limit on resume. Drop the limit here, the next context
+		 * switch re-establishes the per-thread PSPLIM.
+		 */
+		__set_PSPLIM(0U);
+
+		mcxa_scs_restore();
+		break;
+#endif
 
 	default:
 		break;
@@ -70,12 +170,20 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 
 __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	ARG_UNUSED(state);
 	ARG_UNUSED(substate_id);
+#if !defined(CONFIG_PM_S2RAM)
+	ARG_UNUSED(state);
+#endif
 
 	if ((SCB->SCR & SCB_SCR_SLEEPDEEP_Msk) == SCB_SCR_SLEEPDEEP_Msk) {
 		SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
 	}
+
+#if defined(CONFIG_PM_S2RAM)
+	if (state == PM_STATE_SUSPEND_TO_RAM) {
+		SPC_ClearPeriphIOIsolationFlag(MCXA_SPC_ADDR);
+	}
+#endif
 
 	SPC_ClearPowerDomainLowPowerRequestFlag(MCXA_SPC_ADDR, kSPC_PowerDomain0);
 	SPC_ClearLowPowerRequest(MCXA_SPC_ADDR);

--- a/soc/nxp/mcx/mcxa/poweroff.c
+++ b/soc/nxp/mcx/mcxa/poweroff.c
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/poweroff.h>
+#include <zephyr/toolchain.h>
+#include <fsl_cmc.h>
+#include <fsl_spc.h>
+
+#define MCXA_CMC_ADDR		(CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc))
+#define MCXA_SPC_ADDR		(SPC_Type *)DT_REG_ADDR(DT_INST(0, nxp_spc))
+#define MCXA_WAKEUP_DELAY	DT_PROP_OR(DT_INST(0, nxp_spc), wakeup_delay, 0)
+
+void z_sys_poweroff(void)
+{
+	const cmc_power_domain_config_t cmc_config = {
+		.clock_mode = kCMC_GateAllSystemClocksEnterLowPowerMode,
+		.main_domain = kCMC_DeepPowerDown,
+	};
+
+	SPC_SetLowPowerWakeUpDelay(MCXA_SPC_ADDR, MCXA_WAKEUP_DELAY);
+	CMC_SetPowerModeProtection(MCXA_CMC_ADDR, kCMC_AllowAllLowPowerModes);
+	CMC_EnterLowPowerMode(MCXA_CMC_ADDR, &cmc_config);
+
+	CODE_UNREACHABLE;
+}

--- a/soc/nxp/mcx/mcxa/soc.c
+++ b/soc/nxp/mcx/mcxa/soc.c
@@ -16,10 +16,23 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <soc.h>
+#if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
+#include <fsl_spc.h>
+#include <fsl_cmc.h>
+#define MCXA_CMC	((CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc)))
+#define MCXA_SPC	((SPC_Type *)DT_REG_ADDR(DT_INST(0, nxp_spc)))
+#endif
 
 #ifdef CONFIG_SOC_RESET_HOOK
 void soc_reset_hook(void)
 {
+#if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
+	if ((CMC_GetSystemResetStatus(MCXA_CMC) & kCMC_WakeUpReset) != 0UL) {
+		SPC_ClearPeriphIOIsolationFlag(MCXA_SPC);
+		SPC_ClearPowerDomainLowPowerRequestFlag(MCXA_SPC, kSPC_PowerDomain0);
+		SPC_ClearLowPowerRequest(MCXA_SPC);
+	}
+#endif
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	SystemInit();
 #endif /* ! CONFIG_TRUSTED_EXECUTION_NONSECURE */

--- a/soc/nxp/mcx/mcxn/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxn/CMakeLists.txt
@@ -40,4 +40,6 @@ zephyr_library_sources_ifdef(CONFIG_CPU_FREQ_PSTATE_SET_SOC cpu_freq_scale.c)
 
 zephyr_sources_ifdef(CONFIG_PM power.c)
 
+zephyr_sources_ifdef(CONFIG_PM_S2RAM s2ram.c)
+
 zephyr_sources_ifdef(CONFIG_POWEROFF poweroff.c)

--- a/soc/nxp/mcx/mcxn/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxn/CMakeLists.txt
@@ -39,3 +39,5 @@ set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/li
 zephyr_library_sources_ifdef(CONFIG_CPU_FREQ_PSTATE_SET_SOC cpu_freq_scale.c)
 
 zephyr_sources_ifdef(CONFIG_PM power.c)
+
+zephyr_sources_ifdef(CONFIG_POWEROFF poweroff.c)

--- a/soc/nxp/mcx/mcxn/Kconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig
@@ -22,6 +22,7 @@ config SOC_MCXN947_CPU0
 	select CPU_HAS_ICACHE
 	select HAS_MCUX_SYSCON_LPCAC
 	select HAS_PM
+	select WUC if PM
 	select HAS_POWEROFF
 
 config SOC_MCXN947_CPU1
@@ -45,6 +46,7 @@ config SOC_MCXN547_CPU0
 	select CPU_HAS_ICACHE
 	select HAS_MCUX_SYSCON_LPCAC
 	select HAS_PM
+	select WUC if PM
 	select HAS_POWEROFF
 
 config SOC_MCXN547_CPU1
@@ -65,6 +67,7 @@ config SOC_MCXN236
 	select CPU_HAS_ICACHE
 	select HAS_MCUX_SYSCON_LPCAC
 	select HAS_PM
+	select WUC if PM
 	select HAS_POWEROFF
 
 if SOC_FAMILY_MCXN

--- a/soc/nxp/mcx/mcxn/Kconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig
@@ -16,6 +16,7 @@ config SOC_MCXN947_CPU0
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select SOC_RESET_HOOK
+	select SOC_EARLY_RESET_HOOK if PM_S2RAM
 	select ARM_TRUSTZONE_M
 	select HAS_MCUX_CACHE
 	select CPU_HAS_ICACHE
@@ -38,6 +39,7 @@ config SOC_MCXN547_CPU0
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select SOC_RESET_HOOK
+	select SOC_EARLY_RESET_HOOK if PM_S2RAM
 	select ARM_TRUSTZONE_M
 	select HAS_MCUX_CACHE
 	select CPU_HAS_ICACHE
@@ -57,6 +59,7 @@ config SOC_MCXN236
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select SOC_RESET_HOOK
+	select SOC_EARLY_RESET_HOOK if PM_S2RAM
 	select ARM_TRUSTZONE_M
 	select HAS_CPU_FREQ
 	select CPU_HAS_ICACHE

--- a/soc/nxp/mcx/mcxn/Kconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig
@@ -21,6 +21,7 @@ config SOC_MCXN947_CPU0
 	select CPU_HAS_ICACHE
 	select HAS_MCUX_SYSCON_LPCAC
 	select HAS_PM
+	select HAS_POWEROFF
 
 config SOC_MCXN947_CPU1
 	select CPU_CORTEX_M33
@@ -42,6 +43,7 @@ config SOC_MCXN547_CPU0
 	select CPU_HAS_ICACHE
 	select HAS_MCUX_SYSCON_LPCAC
 	select HAS_PM
+	select HAS_POWEROFF
 
 config SOC_MCXN547_CPU1
 	select CPU_CORTEX_M33
@@ -60,6 +62,7 @@ config SOC_MCXN236
 	select CPU_HAS_ICACHE
 	select HAS_MCUX_SYSCON_LPCAC
 	select HAS_PM
+	select HAS_POWEROFF
 
 if SOC_FAMILY_MCXN
 

--- a/soc/nxp/mcx/mcxn/power.c
+++ b/soc/nxp/mcx/mcxn/power.c
@@ -9,15 +9,12 @@
 #include <zephyr/device.h>
 #include <fsl_cmc.h>
 #include <fsl_spc.h>
-#include <fsl_wuu.h>
 
 #if defined(CONFIG_PM_S2RAM)
 void mcxn_pm_suspend_to_ram(void);
 #endif
 
-#define WUU_WAKEUP_LPTMR0_IDX	6U
-#define MCXN_WAKEUP_DELAY	DT_PROP_OR(DT_NODELABEL(spc), wakeup_delay, 0)
-#define MCXN_WUU_ADDR		(WUU_Type *)DT_REG_ADDR(DT_INST(0, nxp_wuu))
+#define MCXN_WAKEUP_DELAY	DT_PROP_OR(DT_INST(0, nxp_spc), wakeup_delay, 0)
 #define MCXN_CMC_ADDR		(CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc))
 #define MCXN_SPC_ADDR		(SPC_Type *)DT_REG_ADDR(DT_INST(0, nxp_spc))
 
@@ -26,8 +23,6 @@ static void pm_enter_hook(void)
 	CMC_SetPowerModeProtection(MCXN_CMC_ADDR, kCMC_AllowAllLowPowerModes);
 	CMC_EnableDebugOperation(MCXN_CMC_ADDR, false);
 	CMC_ConfigFlashMode(MCXN_CMC_ADDR, true, false);
-	WUU_SetInternalWakeUpModulesConfig(MCXN_WUU_ADDR, WUU_WAKEUP_LPTMR0_IDX,
-					   kWUU_InternalModuleInterrupt);
 }
 
 static void enter_low_power(void)

--- a/soc/nxp/mcx/mcxn/power.c
+++ b/soc/nxp/mcx/mcxn/power.c
@@ -11,6 +11,10 @@
 #include <fsl_spc.h>
 #include <fsl_wuu.h>
 
+#if defined(CONFIG_PM_S2RAM)
+void mcxn_pm_suspend_to_ram(void);
+#endif
+
 #define WUU_WAKEUP_LPTMR0_IDX	6U
 #define MCXN_WAKEUP_DELAY	DT_PROP_OR(DT_NODELABEL(spc), wakeup_delay, 0)
 #define MCXN_WUU_ADDR		(WUU_Type *)DT_REG_ADDR(DT_INST(0, nxp_wuu))
@@ -59,12 +63,18 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		break;
 
 	case PM_STATE_STANDBY:
-		SPC_SetLowPowerWakeUpDelay(SPC0, MCXN_WAKEUP_DELAY);
+		SPC_SetLowPowerWakeUpDelay(MCXN_SPC_ADDR, MCXN_WAKEUP_DELAY);
 		CMC_SetClockMode(MCXN_CMC_ADDR, kCMC_GateAllSystemClocksEnterLowPowerMode);
 		CMC_SetMAINPowerMode(MCXN_CMC_ADDR, kCMC_PowerDownMode);
 		CMC_SetWAKEPowerMode(MCXN_CMC_ADDR, kCMC_PowerDownMode);
 		enter_low_power();
 		break;
+
+#if defined(CONFIG_PM_S2RAM)
+	case PM_STATE_SUSPEND_TO_RAM:
+		mcxn_pm_suspend_to_ram();
+		break;
+#endif
 
 	default:
 		break;
@@ -73,14 +83,22 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 
 __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	ARG_UNUSED(state);
 	ARG_UNUSED(substate_id);
+#if !defined(CONFIG_PM_S2RAM)
+	ARG_UNUSED(state);
+#endif
 
 	if ((SCB->SCR & SCB_SCR_SLEEPDEEP_Msk) == SCB_SCR_SLEEPDEEP_Msk) {
 		SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
 	}
 
 	CMC_SetClockMode(MCXN_CMC_ADDR, kCMC_GateNoneClock);
+
+#if defined(CONFIG_PM_S2RAM)
+	if (state == PM_STATE_SUSPEND_TO_RAM) {
+		SPC_ClearPeriphIOIsolationFlag(MCXN_SPC_ADDR);
+	}
+#endif
 
 	SPC_ClearPowerDomainLowPowerRequestFlag(MCXN_SPC_ADDR, kSPC_PowerDomain0);
 	SPC_ClearPowerDomainLowPowerRequestFlag(MCXN_SPC_ADDR, kSPC_PowerDomain1);

--- a/soc/nxp/mcx/mcxn/poweroff.c
+++ b/soc/nxp/mcx/mcxn/poweroff.c
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/poweroff.h>
+#include <zephyr/toolchain.h>
+#include <fsl_cmc.h>
+#include <fsl_spc.h>
+
+#define MCXN_CMC_ADDR		(CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc))
+#define MCXN_SPC_ADDR		(SPC_Type *)DT_REG_ADDR(DT_INST(0, nxp_spc))
+#define MCXN_WAKEUP_DELAY	DT_PROP_OR(DT_INST(0, nxp_spc), wakeup_delay, 0)
+
+void z_sys_poweroff(void)
+{
+	const cmc_power_domain_config_t cmc_config = {
+		.clock_mode = kCMC_GateAllSystemClocksEnterLowPowerMode,
+		.main_domain = kCMC_DeepPowerDown,
+		.wake_domain = kCMC_DeepPowerDown,
+	};
+
+	SPC_SetLowPowerWakeUpDelay(MCXN_SPC_ADDR, MCXN_WAKEUP_DELAY);
+	CMC_SetPowerModeProtection(MCXN_CMC_ADDR, kCMC_AllowAllLowPowerModes);
+	CMC_EnterLowPowerMode(MCXN_CMC_ADDR, &cmc_config);
+
+	CODE_UNREACHABLE;
+}

--- a/soc/nxp/mcx/mcxn/s2ram.c
+++ b/soc/nxp/mcx/mcxn/s2ram.c
@@ -1,0 +1,142 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <zephyr/init.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/platform/hooks.h>
+#include <zephyr/arch/common/pm_s2ram.h>
+#include <soc.h>
+#include <cmsis_core.h>
+#include <zephyr/arch/arm/cortex_m/scb.h>
+#include <fsl_cmc.h>
+#include <fsl_spc.h>
+#include <fsl_vbat.h>
+
+#define MCXN_CMC_ADDR		(CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc))
+#define MCXN_SPC_ADDR		(SPC_Type *)DT_REG_ADDR(DT_INST(0, nxp_spc))
+#define MCXN_VBAT_ADDR		(VBAT_Type *)DT_REG_ADDR(DT_INST(0, nxp_vbat))
+#define MCXN_WAKEUP_DELAY	DT_PROP_OR(DT_INST(0, nxp_spc), wakeup_delay, 0)
+
+/* All four 8 KB RAMA arrays. */
+#define MCXN_RAMA_ALL	(kVBAT_SramArray0 | kVBAT_SramArray1 | \
+			 kVBAT_SramArray2 | kVBAT_SramArray3)
+
+/*
+ * Deep Power Down (mapped to PM_STATE_SUSPEND_TO_RAM) power gates the whole
+ * CORE domain, including the ARM System Control Space (NVIC, SCB). The chip
+ * wakes through the reset routine; arch_pm_s2ram_resume() then returns directly
+ * to the suspend call site without re-running kernel/CPU initialization, so the
+ * SCS state is saved here before entry and restored on resume.
+ */
+static struct {
+	uint32_t iser[ARRAY_SIZE(((NVIC_Type *)NVIC_BASE)->ISER)];
+	uint32_t ipr[(sizeof(((NVIC_Type *)NVIC_BASE)->IPR)) / sizeof(uint32_t)];
+	struct scb_context scb;
+} mcxn_scs_context;
+
+static void mcxn_scs_save(void)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(mcxn_scs_context.iser); i++) {
+		mcxn_scs_context.iser[i] = NVIC->ISER[i];
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(mcxn_scs_context.ipr); i++) {
+		mcxn_scs_context.ipr[i] = ((volatile uint32_t *)NVIC->IPR)[i];
+	}
+
+	z_arm_save_scb_context(&mcxn_scs_context.scb);
+}
+
+static void mcxn_scs_restore(void)
+{
+	z_arm_restore_scb_context(&mcxn_scs_context.scb);
+
+	for (size_t i = 0; i < ARRAY_SIZE(mcxn_scs_context.ipr); i++) {
+		((volatile uint32_t *)NVIC->IPR)[i] = mcxn_scs_context.ipr[i];
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(mcxn_scs_context.iser); i++) {
+		NVIC->ISER[i] = mcxn_scs_context.iser[i];
+	}
+}
+
+static int mcxn_s2ram_retain_sram(void)
+{
+	if (!VBAT_CheckFRO16kEnabled(MCXN_VBAT_ADDR)) {
+		VBAT_EnableFRO16k(MCXN_VBAT_ADDR, true);
+	}
+
+	VBAT_UngateFRO16k(MCXN_VBAT_ADDR, kVBAT_EnableClockToVddSys);
+
+	if (!VBAT_CheckBandgapEnabled(MCXN_VBAT_ADDR)) {
+		if (VBAT_EnableBandgap(MCXN_VBAT_ADDR, true) != kStatus_Success) {
+			return -EIO;
+		}
+	}
+
+	/* Enable refresh mode to save power */
+	VBAT_EnableBandgapRefreshMode(MCXN_VBAT_ADDR, true);
+
+	/* The backup SRAM regulator supplies the retained RAMA arrays across
+	 * Deep Power Down; if it cannot be enabled the context would be lost.
+	 */
+	if (VBAT_EnableBackupSRAMRegulator(MCXN_VBAT_ADDR, true) != kStatus_Success) {
+		return -EIO;
+	}
+
+	VBAT_RetainSRAMsInLowPowerModes(MCXN_VBAT_ADDR, MCXN_RAMA_ALL);
+
+	return 0;
+}
+
+static int mcxn_enter_deep_power_down(void)
+{
+	const cmc_power_domain_config_t cmc_config = {
+		.clock_mode = kCMC_GateAllSystemClocksEnterLowPowerMode,
+		.main_domain = kCMC_DeepPowerDown,
+		.wake_domain = kCMC_DeepPowerDown,
+	};
+
+	CMC_EnterLowPowerMode(MCXN_CMC_ADDR, &cmc_config);
+
+	return -EBUSY;
+}
+
+void mcxn_pm_suspend_to_ram(void)
+{
+	SPC_SetLowPowerWakeUpDelay(MCXN_SPC_ADDR, MCXN_WAKEUP_DELAY);
+
+	if (mcxn_s2ram_retain_sram() != 0) {
+		/* SRAM retention could not be armed; entering Deep Power Down now
+		 * would lose the retained context, so stay running.
+		 */
+		return;
+	}
+
+	mcxn_scs_save();
+
+	/* A non-zero return means the SoC never entered Deep Power Down and is
+	 * still fully operational, so skip the resume-path rebuild below.
+	 */
+	if (arch_pm_s2ram_suspend(mcxn_enter_deep_power_down) != 0) {
+		return;
+	}
+
+	/* re-enable aGDET/dGDET; re-disable RAM ECC */
+	SystemInit();
+
+	/* re-build clock tree */
+	board_early_init_hook();
+
+	/* idle-thread stack is nearly full, it is easy to reach the
+	 * PSPLIM limit on resume. Drop the limit here, the next context
+	 * switch re-establishes the per-thread PSPLIM.
+	 */
+	__set_PSPLIM(0U);
+
+	mcxn_scs_restore();
+}

--- a/soc/nxp/mcx/mcxn/soc.c
+++ b/soc/nxp/mcx/mcxn/soc.c
@@ -16,11 +16,23 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <soc.h>
+#if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
+#include <fsl_spc.h>
+#include <fsl_cmc.h>
+#endif
 
 #ifdef CONFIG_SOC_RESET_HOOK
 
 void soc_reset_hook(void)
 {
+#if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
+	if ((CMC_GetSystemResetStatus(CMC0) & kCMC_WakeUpReset) != 0UL) {
+		SPC_ClearPeriphIOIsolationFlag(SPC0);
+		SPC_ClearPowerDomainLowPowerRequestFlag(SPC0, kSPC_PowerDomain0);
+		SPC_ClearPowerDomainLowPowerRequestFlag(SPC0, kSPC_PowerDomain1);
+		SPC_ClearLowPowerRequest(SPC0);
+	}
+#endif
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	SystemInit();
 #endif /* ! CONFIG_TRUSTED_EXECUTION_NONSECURE */

--- a/soc/nxp/mcx/mcxn/soc.c
+++ b/soc/nxp/mcx/mcxn/soc.c
@@ -21,6 +21,24 @@
 #include <fsl_cmc.h>
 #endif
 
+#ifdef CONFIG_SOC_EARLY_RESET_HOOK
+
+void soc_early_reset_hook(void)
+{
+	/* SystemInit() disables RAM ECC, so the retained working set in RAMA
+	 * is written without valid ECC check bits. The transparent S2RAM resume
+	 * longjmps out of reset.S before soc_reset_hook / SystemInit() runs,
+	 * while Deep Power Down has reset ECC_ENABLE_CTRL back to its hardware
+	 * default (ECC on). So arch_pm_s2ram_resume() reads the retained marker
+	 * with ECC erroneously on, mis-"corrects" it against the absent check
+	 * bits and the marker check fails. Re-disable ECC here, before that read,
+	 * restoring the SystemInit() state.
+	 */
+	SYSCON0->ECC_ENABLE_CTRL = 0U;
+}
+
+#endif /* CONFIG_SOC_EARLY_RESET_HOOK */
+
 #ifdef CONFIG_SOC_RESET_HOOK
 
 void soc_reset_hook(void)


### PR DESCRIPTION
enable deep power down (suspend to ram) support.

1. Map DPD to System Off
Suitable for pursuing ultra-low static current consumption, with wake-up intervals measured in minutes/hours for "shutdown-style" sleep mode — waking up is equivalent to rebooting. `.data/.bss/stack` must survive entirely in retained RAMA, while other non-retained parts can be placed in other RAM blocks.

2. Map DPD to Suspend-to-RAM
Applicable for scenarios with more frequent wake-ups where work must resume immediately after waking. Working data needs to fit within the retention RAM, and `zephyr,sram` must point to the retention RAM.

tested on
frdm_mcxn947
frdm_mcxn236
frdm_mcxa153
frdm_mcxa156
frdm_mcxa266
frdm_mcxa344
frdm_mcxa577

<details>
<summary>MCXN236 test log</summary>


1. system off timer wakeup
```
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Entering system off (cycle 1/10); the timer wakes it in 5 s
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 1/10
Entering system off (cycle 2/10); the timer wakes it in 5 s
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 2/10
Entering system off (cycle 3/10); the timer wakes it in 5 s
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 3/10
Entering system off (cycle 4/10); the timer wakes it in 5 s
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 4/10
Entering system off (cycle 5/10); the timer wakes it in 5 s
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 5/10
Entering system off (cycle 6/10); the timer wakes it in 5 s
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 6/10
Entering system off (cycle 7/10); the timer wakes it in 5 s
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 7/10
Entering system off (cycle 8/10); the timer wakes it in 5 s
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 8/10
Entering system off (cycle 9/10); the timer wakes it in 5 s
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 9/10
Entering system off (cycle 10/10); the timer wakes it in 5 s
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 10/10
Completed 10 system-off cycles
```

2. system off button wakeup
```
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Entering system off (cycle 1/10); trigger the wakeup pin to restart
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 1/10
Entering system off (cycle 2/10); trigger the wakeup pin to restart
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 2/10
Entering system off (cycle 3/10); trigger the wakeup pin to restart
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 3/10
Entering system off (cycle 4/10); trigger the wakeup pin to restart
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 4/10
Entering system off (cycle 5/10); trigger the wakeup pin to restart
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 5/10
Entering system off (cycle 6/10); trigger the wakeup pin to restart
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 6/10
Entering system off (cycle 7/10); trigger the wakeup pin to restart
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 7/10
Entering system off (cycle 8/10); trigger the wakeup pin to restart
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 8/10
Entering system off (cycle 9/10); trigger the wakeup pin to restart
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 9/10
Entering system off (cycle 10/10); trigger the wakeup pin to restart
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 system off demo
Woke from system off; retained count 10/10
Completed 10 system-off cycles
```

3. s2ram timer wakeup
```
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 suspend-to-RAM demo
Retained S2RAM cycle counter: 0
Entering suspend-to-RAM (cycle 1/10); wake in 3 s
Resumed from suspend-to-RAM; retained counter is 1
Entering suspend-to-RAM (cycle 2/10); wake in 3 s
Resumed from suspend-to-RAM; retained counter is 2
Entering suspend-to-RAM (cycle 3/10); wake in 3 s
Resumed from suspend-to-RAM; retained counter is 3
Entering suspend-to-RAM (cycle 4/10); wake in 3 s
Resumed from suspend-to-RAM; retained counter is 4
Entering suspend-to-RAM (cycle 5/10); wake in 3 s
Resumed from suspend-to-RAM; retained counter is 5
Entering suspend-to-RAM (cycle 6/10); wake in 3 s
Resumed from suspend-to-RAM; retained counter is 6
Entering suspend-to-RAM (cycle 7/10); wake in 3 s
Resumed from suspend-to-RAM; retained counter is 7
Entering suspend-to-RAM (cycle 8/10); wake in 3 s
Resumed from suspend-to-RAM; retained counter is 8
Entering suspend-to-RAM (cycle 9/10); wake in 3 s
Resumed from suspend-to-RAM; retained counter is 9
Entering suspend-to-RAM (cycle 10/10); wake in 3 s
Resumed from suspend-to-RAM; retained counter is 10
Completed 10 suspend-to-RAM cycles
```

4. s2ram button wakeup
```
*** Booting Zephyr OS build v4.4.0-6939-g052b05371c82 ***
frdm_mcxn236 suspend-to-RAM demo
Retained S2RAM cycle counter: 0
Entering suspend-to-RAM (cycle 1/10); press SW2 to wake
Resumed from suspend-to-RAM; retained counter is 1
Entering suspend-to-RAM (cycle 2/10); press SW2 to wake
Resumed from suspend-to-RAM; retained counter is 2
Entering suspend-to-RAM (cycle 3/10); press SW2 to wake
Resumed from suspend-to-RAM; retained counter is 3
Entering suspend-to-RAM (cycle 4/10); press SW2 to wake
Resumed from suspend-to-RAM; retained counter is 4
Entering suspend-to-RAM (cycle 5/10); press SW2 to wake
Resumed from suspend-to-RAM; retained counter is 5
Entering suspend-to-RAM (cycle 6/10); press SW2 to wake
Resumed from suspend-to-RAM; retained counter is 6
Entering suspend-to-RAM (cycle 7/10); press SW2 to wake
Resumed from suspend-to-RAM; retained counter is 7
Entering suspend-to-RAM (cycle 8/10); press SW2 to wake
Resumed from suspend-to-RAM; retained counter is 8
Entering suspend-to-RAM (cycle 9/10); press SW2 to wake
Resumed from suspend-to-RAM; retained counter is 9
Entering suspend-to-RAM (cycle 10/10); press SW2 to wake
Resumed from suspend-to-RAM; retained counter is 10
Completed 10 suspend-to-RAM cycles
```