### PR TITLE
dts: arm: st: *: use generic name for cryptographic accelerator nodes

### DIFF
--- a/dts/arm/st/f4/stm32f415.dtsi
+++ b/dts/arm/st/f4/stm32f415.dtsi
@@ -10,7 +10,7 @@
 	soc {
 		compatible = "st,stm32f415", "st,stm32f4", "simple-bus";
 
-		cryp: cryp@50060000 {
+		cryp: crypto@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;

--- a/dts/arm/st/f4/stm32f417.dtsi
+++ b/dts/arm/st/f4/stm32f417.dtsi
@@ -10,7 +10,7 @@
 	soc {
 		compatible = "st,stm32f417", "st,stm32f4", "simple-bus";
 
-		cryp: cryp@50060000 {
+		cryp: crypto@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;

--- a/dts/arm/st/f4/stm32f423.dtsi
+++ b/dts/arm/st/f4/stm32f423.dtsi
@@ -10,7 +10,7 @@
 	soc {
 		compatible = "st,stm32f423", "st,stm32f4", "simple-bus";
 
-		aes: aes@50060000 {
+		aes: crypto@50060000 {
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -11,7 +11,7 @@
 	soc {
 		compatible = "st,stm32f437", "st,stm32f4", "simple-bus";
 
-		cryp: cryp@50060000 {
+		cryp: crypto@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;

--- a/dts/arm/st/f4/stm32f439.dtsi
+++ b/dts/arm/st/f4/stm32f439.dtsi
@@ -10,7 +10,7 @@
 	soc {
 		compatible = "st,stm32f439", "st,stm32f4", "simple-bus";
 
-		cryp: cryp@50060000 {
+		cryp: crypto@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;

--- a/dts/arm/st/f4/stm32f479.dtsi
+++ b/dts/arm/st/f4/stm32f479.dtsi
@@ -10,7 +10,7 @@
 	soc {
 		compatible = "st,stm32f479", "st,stm32f4", "simple-bus";
 
-		cryp: cryp@50060000 {
+		cryp: crypto@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;

--- a/dts/arm/st/g0/stm32g0_crypt.dtsi
+++ b/dts/arm/st/g0/stm32g0_crypt.dtsi
@@ -10,7 +10,7 @@
 	};
 
 	soc {
-		aes: aes@40026000 {
+		aes: crypto@40026000 {
 			compatible = "st,stm32-aes";
 			reg = <0x40026000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 16)>;

--- a/dts/arm/st/h5/stm32h5_crypt.dtsi
+++ b/dts/arm/st/h5/stm32h5_crypt.dtsi
@@ -6,7 +6,7 @@
 
 / {
 	soc {
-		aes: aes@420c0000 {
+		aes: crypto@420c0000 {
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;

--- a/dts/arm/st/h7/stm32h730.dtsi
+++ b/dts/arm/st/h7/stm32h730.dtsi
@@ -10,7 +10,7 @@
 	soc {
 		compatible = "st,stm32h730", "st,stm32h7", "simple-bus";
 
-		cryp: cryp@48021000 {
+		cryp: crypto@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
@@ -19,7 +19,7 @@
 			status = "disabled";
 		};
 
-		hash: hash@48021400 {
+		hash: crypto@48021400 {
 			compatible = "st,stm32-hash";
 			reg = <0x48021400 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;

--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -11,7 +11,7 @@
 	soc {
 		compatible = "st,stm32h750", "st,stm32h7", "simple-bus";
 
-		cryp: cryp@48021000 {
+		cryp: crypto@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
@@ -20,7 +20,7 @@
 			status = "disabled";
 		};
 
-		hash: hash@48021400 {
+		hash: crypto@48021400 {
 			compatible = "st,stm32-hash";
 			reg = <0x48021400 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;

--- a/dts/arm/st/h7/stm32h753.dtsi
+++ b/dts/arm/st/h7/stm32h753.dtsi
@@ -10,7 +10,7 @@
 	soc {
 		compatible = "st,stm32h753", "st,stm32h7", "simple-bus";
 
-		cryp: cryp@48021000 {
+		cryp: crypto@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
@@ -19,7 +19,7 @@
 			status = "disabled";
 		};
 
-		hash: hash@48021400 {
+		hash: crypto@48021400 {
 			compatible = "st,stm32-hash";
 			reg = <0x48021400 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;

--- a/dts/arm/st/h7/stm32h755.dtsi
+++ b/dts/arm/st/h7/stm32h755.dtsi
@@ -11,7 +11,7 @@
 	soc {
 		compatible = "st,stm32h755", "st,stm32h7", "simple-bus";
 
-		cryp: cryp@48021000 {
+		cryp: crypto@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
@@ -20,7 +20,7 @@
 			status = "disabled";
 		};
 
-		hash: hash@48021400 {
+		hash: crypto@48021400 {
 			compatible = "st,stm32-hash";
 			reg = <0x48021400 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;

--- a/dts/arm/st/h7/stm32h757.dtsi
+++ b/dts/arm/st/h7/stm32h757.dtsi
@@ -10,7 +10,7 @@
 	soc {
 		compatible = "st,stm32h757", "st,stm32h7", "simple-bus";
 
-		cryp: cryp@48021000 {
+		cryp: crypto@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
@@ -19,7 +19,7 @@
 			status = "disabled";
 		};
 
-		hash: hash@48021400 {
+		hash: crypto@48021400 {
 			compatible = "st,stm32-hash";
 			reg = <0x48021400 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;

--- a/dts/arm/st/h7/stm32h7b0.dtsi
+++ b/dts/arm/st/h7/stm32h7b0.dtsi
@@ -14,7 +14,7 @@
 	soc {
 		compatible = "st,stm32h7b0", "st,stm32h7", "simple-bus";
 
-		cryp: cryp@48021000 {
+		cryp: crypto@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
@@ -24,7 +24,7 @@
 			status = "disabled";
 		};
 
-		hash: hash@48021400 {
+		hash: crypto@48021400 {
 			compatible = "st,stm32-hash";
 			reg = <0x48021400 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;

--- a/dts/arm/st/l0/stm32l083.dtsi
+++ b/dts/arm/st/l0/stm32l083.dtsi
@@ -10,7 +10,7 @@
 	soc {
 		compatible = "st,stm32l083", "st,stm32l0", "simple-bus";
 
-		aes: aes@40026000 {
+		aes: crypto@40026000 {
 			compatible = "st,stm32-aes";
 			reg = <0x40026000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 16)>;

--- a/dts/arm/st/l4/stm32l4_crypt.dtsi
+++ b/dts/arm/st/l4/stm32l4_crypt.dtsi
@@ -6,7 +6,7 @@
 
 / {
 	soc {
-		aes: aes@50060000 {
+		aes: crypto@50060000 {
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;

--- a/dts/arm/st/l5/stm32l562.dtsi
+++ b/dts/arm/st/l5/stm32l562.dtsi
@@ -10,7 +10,7 @@
 	soc {
 		compatible = "st,stm32l562", "st,stm32l5", "simple-bus";
 
-		aes: aes@420c0000 {
+		aes: crypto@420c0000 {
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -447,7 +447,7 @@
 			status = "disabled";
 		};
 
-		aes: aes@40026000 {
+		aes: crypto@40026000 {
 			compatible = "st,stm32-aes";
 			reg = <0x40026000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 16)>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -959,7 +959,7 @@
 			status = "disabled";
 		};
 
-		hash: hash@420c0400 {
+		hash: crypto@420c0400 {
 			compatible = "st,stm32-hash";
 			reg = <0x420c0400 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;

--- a/dts/arm/st/u5/stm32u5_crypt.dtsi
+++ b/dts/arm/st/u5/stm32u5_crypt.dtsi
@@ -6,7 +6,7 @@
 
 / {
 	soc {
-		aes: aes@420c0000 {
+		aes: crypto@420c0000 {
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -568,7 +568,7 @@
 			status = "disabled";
 		};
 
-		aes1: aes@50060000 {
+		aes1: crypto@50060000 {
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -540,7 +540,7 @@
 			status = "disabled";
 		};
 
-		aes: aes@420c0000 {
+		aes: crypto@420c0000 {
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;

--- a/dts/arm/st/wba/stm32wba23.dtsi
+++ b/dts/arm/st/wba/stm32wba23.dtsi
@@ -54,7 +54,7 @@
 			interrupts = <44 0>;
 		};
 
-		aes: aes@420c0000 {
+		aes: crypto@420c0000 {
 			interrupts = <52 0>;
 		};
 

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -512,7 +512,7 @@
 			};
 		};
 
-		aes: aes@58001800 {
+		aes: crypto@58001800 {
 			compatible = "st,stm32-aes";
 			reg = <0x58001800 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 17)>;


### PR DESCRIPTION
The Devicetree recommends `crypto` as a generic name. Use it for nodes representing cryptographic accelerators on STM32: AES, CRYP and HASH.

Since nodelabels are not modified, I don't think this is worth mentioning in the migration guide; let me know if you think otherwise.