### PR TITLE
tests: drivers: gpio: add gpio_basic_api loopback overlay for kit_xmc72_evk

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/kit_xmc72_evk_xmc7200d_e272k8384_m7_0.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/kit_xmc72_evk_xmc7200d_e272k8384_m7_0.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio_prt18 0 0>;
+		in-gpios = <&gpio_prt18 1 0>;
+	};
+};
+
+&gpio_prt18 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/kit_xmc72_evk_xmc7200d_e272k8384_m7_1.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/kit_xmc72_evk_xmc7200d_e272k8384_m7_1.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio_prt18 0 0>;
+		in-gpios = <&gpio_prt18 1 0>;
+	};
+};
+
+&gpio_prt18 {
+	status = "okay";
+};


### PR DESCRIPTION
## Summary

The `drivers.gpio.2pin` scenario in `tests/drivers/gpio/gpio_basic_api`
filters on `dt_compat_enabled("test-gpio-basic-api")`. The Infineon
`kit_xmc72_evk` board had no such overlay for either M7 core, so the
scenario was silently filtered out and never built or run on that
platform.

This adds a `test-gpio-basic-api` loopback overlay for `kit_xmc72_evk`
on the `m7_0` and `m7_1` cores, matching the pattern already used by the
other Infineon boards (`kit_pse84_*`, `kit_psc3m5_evk`).

## Details

- Uses the otherwise-unused GPIO port 18 (pins 0 and 1). Ports 13/16/17/21
  are already reserved on this board for UART, LEDs and buttons.
- Running (as opposed to just building) the test requires a jumper wire
  between P18.0 and P18.1, consumed via the existing `gpio_loopback`
  fixture, consistent with the other 2-pin GPIO loopback platforms.

## Testing

- `west twister -p kit_xmc72_evk/xmc7200d_e272k8384/m7_0 -p kit_xmc72_evk/xmc7200d_e272k8384/m7_1 -s drivers.gpio.2pin`
  now selects the scenario (previously filtered, 0 selected).
- `west build -b kit_xmc72_evk/xmc7200d_e272k8384/m7_0 tests/drivers/gpio/gpio_basic_api -T drivers.gpio.2pin`
  builds and links cleanly.
