### PR TITLE
drivers: wifi: infineon: fix state lockup by leaving network on failure

### DIFF
--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -501,6 +501,8 @@ static void airoc_event_task(void)
 		case WLC_E_DEAUTH_IND:
 		case WLC_E_DISASSOC_IND:
 			net_if_dormant_on(airoc_wifi_iface);
+			whd_wifi_leave(airoc_sta_if);
+			airoc_wifi_data.is_sta_connected = false;
 			break;
 
 		default:
@@ -605,6 +607,8 @@ static int airoc_mgmt_connect(const struct device *dev, struct wifi_connect_req_
 		goto error;
 	}
 
+	whd_wifi_leave(airoc_sta_if);
+
 	usr_result.SSID.length = params->ssid_length;
 	memcpy(usr_result.SSID.value, params->ssid, params->ssid_length);
 	usr_result.security = convert_zephyr_security_to_whd(params->security);
@@ -642,6 +646,8 @@ static int airoc_mgmt_connect(const struct device *dev, struct wifi_connect_req_
 	if (whd_wifi_join(airoc_sta_if, &usr_result.SSID, usr_result.security, params->psk,
 			  params->psk_length) != WHD_SUCCESS) {
 		LOG_ERR("Failed to connect with network");
+
+		whd_wifi_leave(airoc_sta_if);
 
 		ret = -EAGAIN;
 		goto error;


### PR DESCRIPTION
## Problem

The AIROC Wi-Fi driver may become unable to reconnect after an unexpected link loss, such as when the access point is powered off or the device loses signal coverage. The issue is reproducible when the access point is powered off while network traffic is active.

A reproducible scenario is:

1. Connect to an access point.
2. Start network traffic (e.g. ICMP ping).
3. Power off the access point.
4. Wait for connectivity to be lost.
5. Attempt to disconnect and reconnect.

In this state, the driver may fail subsequent connection attempts with:

```text
[117578] Function whd_wifi_set_ioctl_buffer failed at line 4396 checkres = 101580800 
[103786] Function whd_wifi_prepare_join failed at line 1614 checkres = 101580800
[103790] Function whd_wifi_active_join_init failed at line 1518 checkres = 101580800 
```

After the failure occurs, additional connection attempts continue to fail and even scan operations may no longer succeed.

## Root Cause

The driver does not fully clear its connection state after certain disconnection scenarios.

While processing `WLC_E_DEAUTH_IND` and `WLC_E_DISASSOC_IND`, the internal station connection state remains active and the WHD association is not explicitly terminated. This can leave the driver and WHD stack in an inconsistent state for future operations.

## Solution

Clear the association state when processing disconnection indications by:

* Calling `whd_wifi_leave()` when handling `WLC_E_DEAUTH_IND` and `WLC_E_DISASSOC_IND`.
* Updating the driver's internal connection state (`is_sta_connected`) when a disconnect indication is received.
* Calling `whd_wifi_leave()` before initiating a new connection attempt.
* Calling `whd_wifi_leave()` after a failed join operation to ensure stale association state is not retained.

## Validation

The issue was reproduced using the Zephyr Wi-Fi shell sample:

```text id="g2qdkd"
samples/net/wifi/shell
```

running on `rpi_pico/rp2040/w` with the CYW43439 AIROC driver.

The following sequence consistently reproduced the problem:

1. Connect to an access point using `wifi connect`.
2. Verify connectivity using `net ping`.
3. Start a continuous ping to an external host.
4. While the ping is in progress, power off the access point.
5. Wait for connectivity to be lost.
6. Power the access point back on.
7. Execute `wifi disconnect`.
8. Attempt to reconnect using `wifi connect`.

Before this change:

* The disconnect operation could trigger WHD errors.
* Subsequent connection attempts failed with `whd_wifi_prepare_join()` and `whd_wifi_active_join_init()` errors.
* The driver could enter a state where neither reconnection nor scan operations succeeded.

After this change:

* The device successfully disconnects and reconnects after unexpected link loss.
* DHCP acquisition succeeds after reconnection.
* Repeated testing did not reveal any adverse effects during normal connection, disconnection, and reconnection flows.

## Testing

 Built and tested on rpi_pico/rp2040/w
```text id="g2qdkd"
west build samples/net/wifi/shell -p always -b rpi_pico/rp2040/w
```

Without fix:
```text id="g2qdkd"

[3415] WLAN MAC Address : 28:CD:C1:0C:C6:2A

[3420] WLAN Firmware    : wl0: Jun  5 2024 06:33:59 version 7.95.88 (cf1d613 CY) FWID 01-7b7cf51a

[3429] WLAN CLM         : API: 12.2 Data: 9.10.39 Compiler: 1.29.4 ClmImport: 1.36.3 Creation: 2024-04-16 21:20:55 

[3436] WHD VERSION      : 3.3.3.26653
[3440]  : WIFI5-v3.3.3
[3442]  : GCC 14.3
[3443]  : 2025-04-14 03:18:50 +0000

*** Booting Zephyr OS build v4.4.0-rc3 ***
uart:~$ wifi connect -s "Ola" -p "senai123" -k 1
Connected
Connection requested
[00:00:26.784,000] <inf> net_dhcpv4: Received: 10.46.248.178
uart:~$ net ping 8.8.8.8
PING 8.8.8.8
28 bytes from 8.8.8.8 to 10.46.248.178: icmp_seq=1 ttl=115 time=43 ms
28 bytes from 8.8.8.8 to 10.46.248.178: icmp_seq=2 ttl=115 time=45 ms
28 bytes from 8.8.8.8 to 10.46.248.178: icmp_seq=3 ttl=115 time=70 ms
uart:~$ I will start a ping and power off the router while the ping is running
I: command not found
uart:~$ net ping 8.8.8.8
PING 8.8.8.8
28 bytes from 8.8.8.8 to 10.46.248.178: icmp_seq=1 ttl=115 time=34 ms
Failed to send ping,uart:~$ Now I will power the router back on and repeat the ping
Now: command not found
uart:~$ net ping 8.8.8.8
PING 8.8.8.8
Failed to send ping,uart:~$ # Agora vou mandar desconectar do roteador e apos tentar conectar novame
#: command not found
uart:~$ wifi disconnect 

[117578] Function whd_wifi_set_ioctl_buffer failed at line 4396 checkres = 101580800 
Disconnection request done (0)
Disconnect requested
uart:~$ wifi connect -s "Ola" -p "senai123" -k 1

[155196] Function whd_wifi_prepare_join failed at line 1614 checkres = 101580800 

[155201] Function whd_wifi_active_join_init failed at line 1518 checkres = 101580800 
Connection request failed (UNKNOWN/-11)
[00:02:35.209,000] <err> infineon_airoc_wifi: Failed to connect with network
Connection request failed with error: -11
uart:~$ From this point on, the driver no longer works
From: command not found
uart:~$ wifi connect -s "Ola" -p "senai123" -k 1

[103786] Function whd_wifi_prepare_join failed at line 1614 checkres = 101580800 

[103790] Function whd_wifi_active_join_init failed at line 1518 checkres = 101580800 
Connection request failed (UNKNOWN/-11)
[00:01:43.798,000] <err> infineon_airoc_wifi: Failed to connect with network
Connection request failed with error: -11
uart:~$ wifi scan 

[114399] whd_management_set_event_handler: send event_msgs(iovar) failed

[114403] Function whd_wifi_scan failed at line 2929 checkres = 101580800 
Scan request failed
[00:01:54.409,000] <err> infineon_airoc_wifi: Failed to start scan
uart:~$ 
```

With fix:
```text id="g2qdkd"
[3463] WLAN MAC Address : 28:CD:C1:0C:C6:2A

[3468] WLAN Firmware    : wl0: Jun  5 2024 06:33:59 version 7.95.88 (cf1d613 CY) FWID 01-7b7cf51a

[3477] WLAN CLM         : API: 12.2 Data: 9.10.39 Compiler: 1.29.4 ClmImport: 1.36.3 Creation: 2024-04-16 21:20:55 

[3484] WHD VERSION      : 3.3.3.26653
[3488]  : WIFI5-v3.3.3
[3490]  : GCC 14.3
[3491]  : 2025-04-14 03:18:50 +0000

*** Booting Zephyr OS build v4.4.0-rc3 ***
uart:~$ wifi connect -s "Ola" -p "senai123" -k 1
Connected
Connection requested
[00:00:24.061,000] <inf> net_dhcpv4: Received: 10.46.248.178
uart:~$ net ping 8.8.8.8
PING 8.8.8.8
28 bytes from 8.8.8.8 to 10.46.248.178: icmp_seq=1 ttl=114 time=32 ms
28 bytes from 8.8.8.8 to 10.46.248.178: icmp_seq=2 ttl=114 time=71 ms
28 bytes from 8.8.8.8 to 10.46.248.178: icmp_seq=3 ttl=115 time=31 ms
uart:~$ I will start a ping and power off the router while the ping is running
I: command not found
uart:~$  net ping 8.8.8.8
PING 8.8.8.8
28 bytes from 8.8.8.8 to 10.46.248.178: icmp_seq=1 ttl=115 time=40 ms
Failed to send ping,uart:~$ Now I will disconnect from the router and then attempt to reconnect
Now: command not found
uart:~$ wifi disconnect
Disconnection request done (0)
Disconnect requested
uart:~$ wifi connect -s "Ola" -p "senai123" -k 1
Connected
Connection requested
[00:02:04.700,000] <inf> net_dhcpv4: Received: 10.46.248.178
uart:~$ net ping 8.8.8.8
PING 8.8.8.8
28 bytes from 8.8.8.8 to 10.46.248.178: icmp_seq=1 ttl=114 time=33 ms
28 bytes from 8.8.8.8 to 10.46.248.178: icmp_seq=2 ttl=114 time=43 ms
28 bytes from 8.8.8.8 to 10.46.248.178: icmp_seq=3 ttl=115 time=43 ms
uart:~$ 
```



