### PR TITLE
modules: hostap: optionally offload supplicant connect/disconnect to a workqueue

### DIFF
--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -150,6 +150,10 @@ zephyr_library_sources(
   src/supp_events.c
 )
 
+zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_OFFLOAD_OPS
+  src/supp_cmd_wq.c
+)
+
 # Advanced features
 zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_RRM
   ${WIFI_NM_WPA_SUPPLICANT_BASE}/op_classes.c

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -76,6 +76,32 @@ config WIFI_NM_WPA_SUPPLICANT_WQ_PRIO
 	int "Thread priority of wpa_supplicant iface workqueue"
 	default 7
 
+config WIFI_NM_WPA_SUPPLICANT_OFFLOAD_OPS
+	bool "Offload heavy supplicant management ops to a dedicated workqueue"
+	help
+	  When enabled, the supplicant connect and disconnect operations run on a
+	  dedicated command workqueue instead of in the caller's context. The
+	  calling thread (application, shell, Connection Manager) blocks until the
+	  operation completes and still receives its return code, but the deep
+	  wpa_supplicant call chain executes on the command workqueue stack rather
+	  than the caller's. This lets the stacks of threads that issue Wi-Fi
+	  connect/disconnect be reduced. The connection result itself is still
+	  delivered asynchronously through the NET_EVENT_WIFI_* events.
+
+config WIFI_NM_WPA_SUPPLICANT_CMD_WQ_STACK_SIZE
+	int "Stack size for the wpa_supplicant command workqueue"
+	depends on WIFI_NM_WPA_SUPPLICANT_OFFLOAD_OPS
+	default 4400
+	help
+	  Stack size of the command workqueue that runs the connect and disconnect
+	  operations. It must be large enough for the supplicant connect/disconnect
+	  call chain that previously ran on the calling thread's stack.
+
+config WIFI_NM_WPA_SUPPLICANT_CMD_WQ_PRIO
+	int "Thread priority of the wpa_supplicant command workqueue"
+	depends on WIFI_NM_WPA_SUPPLICANT_OFFLOAD_OPS
+	default 7
+
 config WIFI_NM_WPA_SUPPLICANT_PRIO
 	int "Thread priority of wpa_supplicant"
 	default 0

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -22,6 +22,7 @@
 
 #include "supp_main.h"
 #include "supp_api.h"
+#include "supp_cmd_wq.h"
 #include "wpa_cli_zephyr.h"
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 #include "eap_peer/eap.h"
@@ -1381,18 +1382,11 @@ out:
 }
 
 /* Public API */
-int supplicant_connect(const struct device *dev __unused, struct net_if *iface,
-		       struct wifi_connect_req_params *params)
+static int supplicant_connect_impl(const struct device *dev __unused, struct net_if *iface,
+				   struct wifi_connect_req_params *params)
 {
 	struct wpa_supplicant *wpa_s;
 	int ret = 0;
-
-	if (!net_if_is_admin_up(iface)) {
-		wpa_printf(MSG_ERROR,
-			   "Interface %d is down, dropping connect",
-			   net_if_get_by_iface(iface));
-		return -1;
-	}
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
@@ -1428,6 +1422,51 @@ out:
 	}
 
 	return ret;
+}
+
+/* Typed operation context for deferring connect onto the command workqueue. */
+struct supplicant_connect_cmd {
+	struct supplicant_cmd cmd;
+	const struct device *dev;
+	struct net_if *iface;
+	struct wifi_connect_req_params *params;
+	int result;
+};
+
+static void supplicant_connect_work(struct k_work *work)
+{
+	struct supplicant_connect_cmd *c =
+		CONTAINER_OF(work, struct supplicant_connect_cmd, cmd.work);
+
+	c->result = supplicant_connect_impl(c->dev, c->iface, c->params);
+}
+
+int supplicant_connect(const struct device *dev __unused, struct net_if *iface,
+		       struct wifi_connect_req_params *params)
+{
+	/* Cheap, supplicant-independent pre-check in the caller's context, so an
+	 * obviously-invalid request fails immediately without a workqueue round
+	 * trip.
+	 */
+	if (!net_if_is_admin_up(iface)) {
+		wpa_printf(MSG_ERROR,
+			   "Interface %d is down, dropping connect",
+			   net_if_get_by_iface(iface));
+		return -1;
+	}
+
+	if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_OFFLOAD_OPS)) {
+		struct supplicant_connect_cmd c = {
+			.dev = dev,
+			.iface = iface,
+			.params = params,
+		};
+
+		supplicant_run_on_cmd_wq(&c.cmd, supplicant_connect_work);
+		return c.result;
+	}
+
+	return supplicant_connect_impl(dev, iface, params);
 }
 
 int supplicant_disconnect(const struct device *dev __unused, struct net_if *iface)

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1469,9 +1469,49 @@ int supplicant_connect(const struct device *dev __unused, struct net_if *iface,
 	return supplicant_connect_impl(dev, iface, params);
 }
 
-int supplicant_disconnect(const struct device *dev __unused, struct net_if *iface)
+static int supplicant_disconnect_impl(const struct device *dev __unused, struct net_if *iface)
 {
 	return wpas_disconnect_network(iface, WPAS_MODE_INFRA);
+}
+
+/* Typed operation context for deferring disconnect onto the command workqueue. */
+struct supplicant_disconnect_cmd {
+	struct supplicant_cmd cmd;
+	const struct device *dev;
+	struct net_if *iface;
+	int result;
+};
+
+static void supplicant_disconnect_work(struct k_work *work)
+{
+	struct supplicant_disconnect_cmd *c =
+		CONTAINER_OF(work, struct supplicant_disconnect_cmd, cmd.work);
+
+	c->result = supplicant_disconnect_impl(c->dev, c->iface);
+}
+
+int supplicant_disconnect(const struct device *dev __unused, struct net_if *iface)
+{
+	/* Cheap pre-check in the caller's context (get_wpa_s_handle is a shallow
+	 * name lookup, already called without the supplicant mutex), so a request
+	 * for an unknown interface fails immediately without a workqueue round
+	 * trip.
+	 */
+	if (!get_wpa_s_handle(iface)) {
+		return -1;
+	}
+
+	if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_OFFLOAD_OPS)) {
+		struct supplicant_disconnect_cmd c = {
+			.dev = dev,
+			.iface = iface,
+		};
+
+		supplicant_run_on_cmd_wq(&c.cmd, supplicant_disconnect_work);
+		return c.result;
+	}
+
+	return supplicant_disconnect_impl(dev, iface);
 }
 
 enum wifi_mfp_options get_mfp(enum mfp_options supp_mfp_option)

--- a/modules/hostap/src/supp_cmd_wq.c
+++ b/modules/hostap/src/supp_cmd_wq.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#include "supp_cmd_wq.h"
+
+/* Provided by supp_main.c; the dedicated workqueue used to run heavy supplicant
+ * management operations off the caller's stack.
+ */
+extern struct k_work_q *get_cmd_wq(void);
+
+void supplicant_run_on_cmd_wq(struct supplicant_cmd *cmd, k_work_handler_t handler)
+{
+	struct k_work_q *wq = get_cmd_wq();
+
+	/* If invoked from the command workqueue itself (e.g. an operation issues a
+	 * nested request), run inline: submitting to the single-threaded workqueue
+	 * from its own thread would self-deadlock.
+	 */
+	if (k_current_get() == &wq->thread) {
+		handler(&cmd->work);
+		return;
+	}
+
+	k_work_init(&cmd->work, handler);
+	k_work_submit_to_queue(wq, &cmd->work);
+
+	/* Wait until the workqueue has finalized the work item, not merely run the
+	 * handler. work_queue_main() clears K_WORK_RUNNING and finalizes the item
+	 * after the handler returns, and cmd lives on the caller's stack, so
+	 * returning any earlier would let the workqueue touch a freed frame.
+	 */
+	k_work_flush(&cmd->work, &cmd->sync);
+}

--- a/modules/hostap/src/supp_cmd_wq.h
+++ b/modules/hostap/src/supp_cmd_wq.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_MODULES_HOSTAP_SUPP_CMD_WQ_H_
+#define ZEPHYR_MODULES_HOSTAP_SUPP_CMD_WQ_H_
+
+#include <zephyr/kernel.h>
+
+/* Work bundle embedded by callers in their own (typed) operation context. The
+ * mechanism is intentionally agnostic of the operation - it only deals with the
+ * kernel work item - so it stays free of wpa_supplicant headers and can be unit
+ * tested in isolation.
+ */
+struct supplicant_cmd {
+	struct k_work work;
+	struct k_work_sync sync;
+};
+
+/**
+ * @brief Run a supplicant management operation on the command workqueue.
+ *
+ * Submits @a cmd to the dedicated supplicant command workqueue using @a handler
+ * and blocks until the work item has been finalized, keeping the deep supplicant
+ * call chain off the caller's stack.
+ *
+ * @a handler recovers its enclosing, fully typed operation context with
+ * CONTAINER_OF() and stores any result there; the caller reads it once this
+ * function returns. If invoked from the command workqueue thread itself,
+ * @a handler runs inline to avoid self-deadlocking the single-threaded queue.
+ */
+void supplicant_run_on_cmd_wq(struct supplicant_cmd *cmd, k_work_handler_t handler);
+
+#endif /* ZEPHYR_MODULES_HOSTAP_SUPP_CMD_WQ_H_ */

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -30,6 +30,10 @@ static struct k_thread tid;
 
 static K_THREAD_STACK_DEFINE(iface_wq_stack, CONFIG_WIFI_NM_WPA_SUPPLICANT_WQ_STACK_SIZE);
 
+#if defined(CONFIG_WIFI_NM_WPA_SUPPLICANT_OFFLOAD_OPS)
+static K_THREAD_STACK_DEFINE(cmd_wq_stack, CONFIG_WIFI_NM_WPA_SUPPLICANT_CMD_WQ_STACK_SIZE);
+#endif
+
 #define IFACE_NOTIFY_TIMEOUT_MS 1000
 #define IFACE_NOTIFY_RETRY_MS 10
 
@@ -126,6 +130,9 @@ struct supplicant_context {
 	int sock;
 	struct k_work iface_work;
 	struct k_work_q iface_wq;
+#if defined(CONFIG_WIFI_NM_WPA_SUPPLICANT_OFFLOAD_OPS)
+	struct k_work_q cmd_wq;
+#endif
 	int (*iface_handler)(struct supplicant_context *ctx, struct net_if *iface);
 };
 
@@ -152,6 +159,13 @@ struct k_work_q *get_workq(void)
 {
 	return &get_default_context()->iface_wq;
 }
+
+#if defined(CONFIG_WIFI_NM_WPA_SUPPLICANT_OFFLOAD_OPS)
+struct k_work_q *get_cmd_wq(void)
+{
+	return &get_default_context()->cmd_wq;
+}
+#endif
 
 /* found in hostap/wpa_supplicant/ctrl_iface_zephyr.c */
 extern int send_data(struct k_fifo *fifo, int sock, const char *buf, size_t len, int flags);
@@ -727,6 +741,20 @@ static void handler(void)
 			   K_THREAD_STACK_SIZEOF(iface_wq_stack),
 			   CONFIG_WIFI_NM_WPA_SUPPLICANT_WQ_PRIO,
 			   &iface_wq_cfg);
+
+#if defined(CONFIG_WIFI_NM_WPA_SUPPLICANT_OFFLOAD_OPS)
+	{
+		static const struct k_work_queue_config cmd_wq_cfg = {
+			.name = "hostap_cmd_wq",
+		};
+
+		k_work_queue_init(&ctx->cmd_wq);
+		k_work_queue_start(&ctx->cmd_wq, cmd_wq_stack,
+				   K_THREAD_STACK_SIZEOF(cmd_wq_stack),
+				   CONFIG_WIFI_NM_WPA_SUPPLICANT_CMD_WQ_PRIO,
+				   &cmd_wq_cfg);
+	}
+#endif
 
 	k_work_init(&ctx->iface_work, iface_work_handler);
 

--- a/tests/net/wifi/hostap/CMakeLists.txt
+++ b/tests/net/wifi/hostap/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(hostap_cmd_wq)
+
+# Build only the offload mechanism under test, plus the test harness. The
+# get_cmd_wq() hook (normally in supp_main.c) is stubbed in main.c, so the
+# whole wpa_supplicant is not pulled in.
+target_sources(app PRIVATE
+  src/main.c
+  ${ZEPHYR_BASE}/modules/hostap/src/supp_cmd_wq.c
+)
+
+target_include_directories(app PRIVATE
+  ${ZEPHYR_BASE}/modules/hostap/src
+)

--- a/tests/net/wifi/hostap/prj.conf
+++ b/tests/net/wifi/hostap/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/net/wifi/hostap/src/main.c
+++ b/tests/net/wifi/hostap/src/main.c
@@ -1,0 +1,142 @@
+/* main.c - wpa_supplicant command workqueue offload unit tests */
+
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
+
+#include "supp_cmd_wq.h"
+
+/* Dedicated command workqueue, provided to the code under test through the
+ * get_cmd_wq() hook that supp_main.c normally implements.
+ */
+#define CMD_WQ_STACK_SIZE 2048
+static K_THREAD_STACK_DEFINE(cmd_wq_stack, CMD_WQ_STACK_SIZE);
+static struct k_work_q cmd_wq;
+
+struct k_work_q *get_cmd_wq(void)
+{
+	return &cmd_wq;
+}
+
+/* Typed operation context, mirroring how the real supplicant ops embed
+ * struct supplicant_cmd and recover their context with CONTAINER_OF().
+ */
+struct test_op {
+	struct supplicant_cmd cmd;
+	int in;
+	int out;
+	k_tid_t ran_on;
+};
+
+static atomic_t calls;
+static atomic_t nested_calls;
+static k_tid_t nested_ran_on;
+
+static void echo_handler(struct k_work *work)
+{
+	struct test_op *op = CONTAINER_OF(work, struct test_op, cmd.work);
+
+	op->ran_on = k_current_get();
+	op->out = op->in;
+	atomic_inc(&calls);
+}
+
+static void nested_handler(struct k_work *work)
+{
+	struct test_op *op = CONTAINER_OF(work, struct test_op, cmd.work);
+
+	op->ran_on = k_current_get();
+	atomic_inc(&nested_calls);
+}
+
+static void reentrant_handler(struct k_work *work)
+{
+	struct test_op *op = CONTAINER_OF(work, struct test_op, cmd.work);
+	struct test_op nested = {0};
+
+	op->ran_on = k_current_get();
+	atomic_inc(&calls);
+
+	/* Issue a nested request from within the workqueue context. */
+	supplicant_run_on_cmd_wq(&nested.cmd, nested_handler);
+	nested_ran_on = nested.ran_on;
+}
+
+static void reset_state(void)
+{
+	atomic_clear(&calls);
+	atomic_clear(&nested_calls);
+	nested_ran_on = NULL;
+}
+
+/* The handler runs on the command workqueue thread, not the caller, exactly
+ * once.
+ */
+ZTEST(hostap_cmd_wq, test_runs_on_workqueue)
+{
+	struct test_op op = { .in = 42 };
+
+	reset_state();
+
+	supplicant_run_on_cmd_wq(&op.cmd, echo_handler);
+
+	zassert_equal(atomic_get(&calls), 1, "handler should run exactly once");
+	zassert_not_equal(op.ran_on, k_current_get(),
+			  "handler must run on the command workqueue, not the caller");
+	zassert_equal(op.ran_on, &cmd_wq.thread,
+		      "handler must run on the command workqueue thread");
+}
+
+/* A result stored by the handler in the caller-owned context is visible once
+ * supplicant_run_on_cmd_wq() returns.
+ */
+ZTEST(hostap_cmd_wq, test_result_propagation)
+{
+	struct test_op op = { .in = -EIO };
+
+	reset_state();
+
+	supplicant_run_on_cmd_wq(&op.cmd, echo_handler);
+
+	zassert_equal(op.out, -EIO, "result stored by the handler must reach the caller");
+	zassert_equal(atomic_get(&calls), 1, "handler should run exactly once");
+}
+
+/* A nested request issued from within a handler (i.e. from the workqueue
+ * thread) is handled inline by the re-entrancy guard - it runs on the same
+ * thread and does not dead-lock the single-threaded queue.
+ */
+ZTEST(hostap_cmd_wq, test_reentrant_runs_inline)
+{
+	struct test_op op = {0};
+
+	reset_state();
+
+	supplicant_run_on_cmd_wq(&op.cmd, reentrant_handler);
+
+	zassert_equal(atomic_get(&calls), 1, "outer handler should run once");
+	zassert_equal(atomic_get(&nested_calls), 1, "nested handler should run once");
+	zassert_equal(nested_ran_on, op.ran_on,
+		      "nested op must run inline on the workqueue thread");
+}
+
+static void *setup(void)
+{
+	static const struct k_work_queue_config cfg = {
+		.name = "test_cmd_wq",
+	};
+
+	k_work_queue_init(&cmd_wq);
+	k_work_queue_start(&cmd_wq, cmd_wq_stack, K_THREAD_STACK_SIZEOF(cmd_wq_stack),
+			   K_PRIO_PREEMPT(5), &cfg);
+
+	return NULL;
+}
+
+ZTEST_SUITE(hostap_cmd_wq, NULL, setup, NULL, NULL, NULL);

--- a/tests/net/wifi/hostap/testcase.yaml
+++ b/tests/net/wifi/hostap/testcase.yaml
@@ -1,0 +1,10 @@
+common:
+  harness: ztest
+  platform_allow:
+    - native_sim
+  tags:
+    - wifi
+    - hostap
+    - net
+tests:
+  net.wifi.hostap.cmd_wq: {}


### PR DESCRIPTION
**Problem**                                                                                        

`supplicant_connect()/disconnect()` run the full wpa_supplicant call chain in the caller's context. Since `net_mgmt()` handlers run on the calling thread, every thread that can trigger a Wi-Fi connect must be sized for that multi-kB chain — the app thread, the Wi-Fi shell, and any connectivity manager. This is wasteful when more than one such caller exists, e.g. the common pattern of provisioning credentials over the shell using `wifi cred add` and connecting programmatically using `wifi cred auto_connect`.

**Solution**

This PR adds `CONFIG_WIFI_NM_WPA_SUPPLICANT_OFFLOAD_OPS` Kconfig option (default n). When enabled, the connect/disconnect work runs on a dedicated supplicant workqueue. The caller blocks and still gets the real return code and the same `NET_EVENT_WIFI_*` events. The deep stack moves from every connect-capable thread to one queue - the more callers, the bigger the net saving. This allows to save ~3.5 kBytes per thread that runs wifi connect (wifi shell/conn_mgr/or app thread).
                                               
**Why this way**
                                                                                             
- At the supplicant (not `wifi_mgmt`/a backend): it's the chokepoint all callers funnel through, and offloaded backends have no deep chain to move.
- Dedicated queue: must differ from `iface_wq` and the eloop thread, which would self-deadlock.
- `k_work_flush`, not a semaphore: the workqueue touches the stack-resident work item after the handler returns.
- Typed thunks, not enum/union: dispatch stays compiler-checked and header-free, so it's unit-testable in isolation.
