### PR TITLE
tests: drivers: spi: Build fixes for sam_e54_xpro board

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/boards/sam_e54_xpro.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/sam_e54_xpro.overlay
@@ -22,6 +22,7 @@
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
+		spi-max-frequency = <1000>;
 	};
 };
 


### PR DESCRIPTION
Properly set the spi-max-frequency in the overlay for this board, to avoid test build failures.

Fixes test build failures in main: https://github.com/zephyrproject-rtos/zephyr/actions/runs/27765469259/job/82150935681#step:12:1223

/cc @nashif 