### PR TITLE
modules: mbedtls: enable MBEDTLS_ECP_NIST_OPTIM by default

### DIFF
--- a/modules/mbedtls/Kconfig.tf-psa-crypto
+++ b/modules/mbedtls/Kconfig.tf-psa-crypto
@@ -20,6 +20,7 @@ config TF_PSA_CRYPTO_USER_CONFIG
 
 config MBEDTLS_ECP_NIST_OPTIM
 	bool "NIST curves optimization"
+	default y
 	depends on PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC
 
 comment "Supported ciphers and cipher modes"

--- a/modules/mbedtls/Kconfig.tf-psa-crypto
+++ b/modules/mbedtls/Kconfig.tf-psa-crypto
@@ -22,6 +22,12 @@ config MBEDTLS_ECP_NIST_OPTIM
 	bool "NIST curves optimization"
 	default y
 	depends on PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC
+	help
+	  Enable specific 'modulo p' routines for each NIST prime. Depending on the
+	  prime and architecture, makes operations 4 to 8 times faster on the
+	  corresponding curve.
+
+	  The cost is a small amount of flash for the reduction tables.
 
 comment "Supported ciphers and cipher modes"
 


### PR DESCRIPTION
MBEDTLS_ECP_NIST_OPTIM enables optimized modular reduction for the NIST curves (P-256/P-384/P-521). Upstream Mbed TLS and TF-PSA-Crypto define this option by default in their configuration headers, but when it was converted to a Kconfig symbol it was given no default and therefore silently defaults to n.

Without it, every field multiplication on a NIST curve falls back to generic modular reduction, which is roughly an order of magnitude slower. This significantly penalizes ECC-heavy paths; for example a WPA3-SAE (group 19) handshake slows from ~450 ms to ~5 s.

Restore the upstream default by defaulting the option to y. It is already gated on PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC, so it only takes effect when ECC is in use; the only cost is a small amount of flash for the reduction tables.


Assisted-by: Claude:claude-opus-4.8