### PR TITLE
modules: mbedtls: enable MBEDTLS_HAVE_ASM on Cortex-M mainline

### DIFF
--- a/modules/mbedtls/Kconfig.tf-psa-crypto
+++ b/modules/mbedtls/Kconfig.tf-psa-crypto
@@ -206,7 +206,9 @@ config MBEDTLS_PEM_WRITE_C
 
 config MBEDTLS_HAVE_ASM
 	bool "Use of assembly code"
-	default y if !ARM
+	# Enabled by default on ARMv7-M and ARMv8-M mainline cores because it brings performance improvement and footprint reduction.
+	# Disabled on other ARM architectures (e.g., ARMv6-M) because the footprint increases.
+	default y if !ARM || ARMV7_M_ARMV8_M_MAINLINE
 	help
 	  Enable use of assembly code in Mbed TLS. This improves the performance
 	  of asymmetric cryptography, however this might have an impact on the


### PR DESCRIPTION
MBEDTLS_HAVE_ASM defaults to "y if !ARM", so it is disabled on all ARM
targets. The ARM exclusion goes back to commit d599af40c8f1 ("ext/lib/
mbedtls: Add the TLS configuration file", 2017), where the #define was
guarded by "#if !defined(CONFIG_ARM)"; commit a6d82db50f96 (2019) kept
that default when it made the option configurable via Kconfig. At the
time there was no per-core ARM granularity to rely on, so a blanket
exclusion was a reasonable default.

The Mbed TLS MPI assembly (bn_mul.h MULADDC) uses the long multiply
(umull/umlal), which is available on the ARMv7-M and ARMv8-M mainline
cores (Cortex-M3/M4/M7/M33/M55) but not on the ARMv6-M / ARMv8-M
baseline cores (Cortex-M0/M0+/M23). The blanket exclusion therefore
also turns the assembly off on the mainline cores, where it is usable.

Enable it on ARMV7_M_ARMV8_M_MAINLINE, where it speeds up asymmetric
crypto noticeably (e.g. a WPA3-SAE group 19 handshake) at no code-size
cost; the asm path is in fact slightly smaller than the C multiply
loop. Baseline cores keep the previous default of n.

Assisted-by: Claude:claude-opus-4.8

P.S. I don't know the reason for not enabling on ARM originally, I have tested on nRF platform Cortex M33 and it seem to work fine and improve the performance (see comments below), so, opening this up for discussion.