### PR TITLE
Merge latest Kconfiglib updates

### DIFF
--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -15,7 +15,7 @@ Overview
 
 A Tkinter-based menuconfig implementation, based around a treeview control and
 a help display. The interface should feel familiar to people used to qconf
-('make xconfig'). Compatible with both Python 2 and Python 3.
+('make xconfig').
 
 The display can be toggled between showing the full tree and showing just a
 single menu (like menuconfig.py). Only single-menu mode distinguishes between
@@ -61,23 +61,11 @@ $srctree is supported through Kconfiglib.
 import errno
 import os
 import re
-import sys
 
-_PY2 = sys.version_info[0] < 3
-
-if _PY2:
-    # Python 2
-    from Tkinter import *
-    import ttk
-    import tkFont as font
-    import tkFileDialog as filedialog
-    import tkMessageBox as messagebox
-else:
-    # Python 3
-    from tkinter import *
-    import tkinter.ttk as ttk
-    import tkinter.font as font
-    from tkinter import filedialog, messagebox
+from tkinter import *
+import tkinter.ttk as ttk
+import tkinter.font as font
+from tkinter import filedialog, messagebox
 
 from kconfiglib import Symbol, Choice, MENU, COMMENT, MenuNode, \
                        BOOL, TRISTATE, STRING, INT, HEX, \
@@ -444,8 +432,7 @@ def _init_misc_ui():
     _dark_mode = _detect_system_dark_mode()
 
     _root.title(_kconf.mainmenu_text)
-    # iconphoto() isn't available in Python 2's Tkinter
-    _root.tk.call("wm", "iconphoto", _root._w, "-default", _icon_img)
+    _root.iconphoto(True, _icon_img)
     # Reducing the width of the window to 1 pixel makes it move around, at
     # least on GNOME. Prevent weird stuff like that.
     _root.minsize(128, 128)
@@ -620,9 +607,7 @@ def _create_kconfig_tree_and_desc(parent):
             desc["state"] = "disabled"
             return
 
-        # Text.replace() is not available in Python 2's Tkinter
-        desc.delete("1.0", "end")
-        desc.insert("end", _info_str(_id_to_node[sel[0]]))
+        desc.replace("1.0", "end", _info_str(_id_to_node[sel[0]]))
 
         desc["state"] = "disabled"
 
@@ -1234,11 +1219,6 @@ def _change_node(node, parent):
     if sc.type in (INT, HEX, STRING):
         s = _set_val_dialog(node, parent)
 
-        # Tkinter can return 'unicode' strings on Python 2, which Kconfiglib
-        # can't deal with. UTF-8-encode the string to work around it.
-        if _PY2 and isinstance(s, unicode):
-            s = s.encode("utf-8", "ignore")
-
         if s is not None:
             _set_val(sc, s)
 
@@ -1290,9 +1270,10 @@ def _set_val_dialog(node, parent):
     # Pops up a dialog for setting the value of the string/int/hex
     # symbol at node 'node'. 'parent' is the parent window.
 
+    _entry_res = None
+
     def ok(_=None):
-        # No 'nonlocal' in Python 2
-        global _entry_res
+        nonlocal _entry_res
 
         s = entry.get()
         if sym.type == HEX and not s.startswith(("0x", "0X")):
@@ -1303,7 +1284,7 @@ def _set_val_dialog(node, parent):
             dialog.destroy()
 
     def cancel(_=None):
-        global _entry_res
+        nonlocal _entry_res
         _entry_res = None
         dialog.destroy()
 

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -1130,7 +1130,7 @@ class Kconfig(object):
                 if expr_value(cond):
                     try:
                         with self._open_config(filename.str_value) as f:
-                            return f.name
+                            return f.name.replace('\\', '/')
                     except EnvironmentError:
                         continue
 
@@ -2131,6 +2131,10 @@ class Kconfig(object):
         else:
             # Absolute path
             rel_filename = filename
+
+        # Normalize path separators to '/' for cross-platform consistency
+        # (on Windows, paths may use '\' which would break comparisons)
+        rel_filename = rel_filename.replace('\\', '/')
 
         self.kconfig_filenames.append(rel_filename)
 

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -5,7 +5,7 @@
 Overview
 ========
 
-Kconfiglib is a Python 2/3 library for scripting and extracting information
+Kconfiglib is a Python 3 library for scripting and extracting information
 from Kconfig (https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt)
 configuration systems.
 
@@ -52,17 +52,14 @@ sections.
 make kmenuconfig
 ----------------
 
-This target runs the curses menuconfig interface with Python 3. As of
-Kconfiglib 12.2.0, both Python 2 and Python 3 are supported (previously, only
-Python 3 was supported, so this was a backport).
+This target runs the curses menuconfig interface with Python 3.
 
 
 make guiconfig
 --------------
 
-This target runs the Tkinter menuconfig interface. Both Python 2 and Python 3
-are supported. To change the Python interpreter used, pass
-PYTHONCMD=<executable> to 'make'. The default is 'python'.
+This target runs the Tkinter menuconfig interface. To change the Python
+interpreter used, pass PYTHONCMD=<executable> to 'make'. The default is 'python'.
 
 
 make [ARCH=<arch>] iscriptconfig
@@ -877,11 +874,8 @@ class Kconfig(object):
 
         Raises KconfigError on syntax/semantic errors, and OSError or (possibly
         a subclass of) IOError on IO errors ('errno', 'strerror', and
-        'filename' are available). Note that IOError is an alias for OSError on
-        Python 3, so it's enough to catch OSError there. If you need Python 2/3
-        compatibility, it's easiest to catch EnvironmentError, which is a
-        common base class of OSError/IOError on Python 2 and an alias for
-        OSError on Python 3.
+        'filename' are available). Note that IOError is an alias for OSError in
+        Python 3, so it's enough to catch OSError.
 
         filename (default: "Kconfig"):
           The Kconfig file to load. For the Linux kernel, you'll want "Kconfig"
@@ -923,11 +917,6 @@ class Kconfig(object):
 
           The "utf-8" default avoids exceptions on systems that are configured
           to use the C locale, which implies an ASCII encoding.
-
-          This parameter has no effect on Python 2, due to implementation
-          issues (regular strings turning into Unicode strings, which are
-          distinct in Python 2). Python 2 doesn't decode regular strings
-          anyway.
 
           Related PEP: https://www.python.org/dev/peps/pep-0538/
 
@@ -2118,18 +2107,12 @@ class Kconfig(object):
             try:
                 return self._open(join(self.srctree, filename), "r")
             except EnvironmentError as e2:
-                # This is needed for Python 3, because e2 is deleted after
-                # the try block:
-                #
-                # https://docs.python.org/3/reference/compound_stmts.html#the-try-statement
-                e = e2
-
-            raise _KconfigIOError(
-                e, "Could not open '{}' ({}: {}). Check that the $srctree "
-                   "environment variable ({}) is set correctly."
-                   .format(filename, errno.errorcode[e.errno], e.strerror,
-                           "set to '{}'".format(self.srctree) if self.srctree
-                               else "unset or blank"))
+                raise _KconfigIOError(
+                    e2, "Could not open '{}' ({}: {}). Check that the $srctree "
+                    "environment variable ({}) is set correctly."
+                    .format(filename, errno.errorcode[e.errno], e.strerror,
+                            "set to '{}'".format(self.srctree) if self.srctree
+                                else "unset or blank"))
 
     def _enter_file(self, filename):
         # Jumps to the beginning of a sourced Kconfig file, saving the previous
@@ -3917,41 +3900,8 @@ class Kconfig(object):
         self._parse_error("extra tokens at end of line")
 
     def _open(self, filename, mode):
-        # open() wrapper:
-        #
-        # - Enable universal newlines mode on Python 2 to ease
-        #   interoperability between Linux and Windows. It's already the
-        #   default on Python 3.
-        #
-        #   The "U" flag would currently work for both Python 2 and 3, but it's
-        #   deprecated on Python 3, so play it future-safe.
-        #
-        #   io.open() defaults to universal newlines on Python 2 (and is an
-        #   alias for open() on Python 3), but it returns 'unicode' strings and
-        #   slows things down:
-        #
-        #     Parsing x86 Kconfigs on Python 2
-        #
-        #     with open(..., "rU"):
-        #
-        #       real  0m0.930s
-        #       user  0m0.905s
-        #       sys   0m0.025s
-        #
-        #     with io.open():
-        #
-        #       real  0m1.069s
-        #       user  0m1.040s
-        #       sys   0m0.029s
-        #
-        #   There's no appreciable performance difference between "r" and
-        #   "rU" for parsing performance on Python 2.
-        #
-        # - For Python 3, force the encoding. Forcing the encoding on Python 2
-        #   turns strings into Unicode strings, which gets messy. Python 2
-        #   doesn't decode regular strings anyway.
-        return open(filename, "rU" if mode == "r" else mode) if _IS_PY2 else \
-               open(filename, mode, encoding=self._encoding)
+        # open() wrapper that forces the encoding
+        return open(filename, mode, encoding=self._encoding)
 
     def _check_undef_syms(self):
         # Prints warnings for all references to undefined symbols within the
@@ -3980,7 +3930,7 @@ class Kconfig(object):
 
             return True
 
-        for sym in (self.syms.viewvalues if _IS_PY2 else self.syms.values)():
+        for sym in self.syms.values():
             # - sym.nodes empty means the symbol is undefined (has no
             #   definition locations)
             #
@@ -6548,16 +6498,9 @@ def _save_old(path):
     if islink(path):
         # Preserve symlinks
         copy_fn = copy
-    elif hasattr(os, "replace"):
-        # Python 3 (3.3+) only. Best choice when available, because it
-        # removes <filename>.old on both *nix and Windows.
-        copy_fn = os.replace
-    elif os.name == "posix":
-        # Removes <filename>.old on POSIX systems
-        copy_fn = os.rename
     else:
-        # Fall back on copying
-        copy_fn = copy
+        # atomic replace of <filename>.old
+        copy_fn = os.replace
 
     try:
         copy_fn(path, path + ".old")
@@ -6928,30 +6871,21 @@ def _error_if_fn(kconf, _, cond, msg):
 def _shell_fn(kconf, _, command):
     import subprocess  # Only import as needed, to save some startup time
 
-    stdout, stderr = subprocess.Popen(
-        command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    ).communicate()
+    result = subprocess.run(
+        command,
+        shell=True,
+        capture_output=True,
+        text=True,
+        encoding=kconf._encoding
+    )
 
-    if not _IS_PY2:
-        try:
-            stdout = stdout.decode(kconf._encoding)
-            stderr = stderr.decode(kconf._encoding)
-        except UnicodeDecodeError as e:
-            _decoding_error(e, kconf.filename, kconf.linenr)
-
-    if stderr:
+    if result.stderr:
         kconf._warn("'{}' wrote to stderr: {}".format(
-                        command, "\n".join(stderr.splitlines())),
+                        command, "\n".join(result.stderr.splitlines())),
                     kconf.loc)
 
-    # Universal newlines with splitlines() (to prevent e.g. stray \r's in
-    # command output on Windows), trailing newline removal, and
-    # newline-to-space conversion.
-    #
-    # On Python 3 versions before 3.6, it's not possible to specify the
-    # encoding when passing universal_newlines=True to Popen() (the 'encoding'
-    # parameter was added in 3.6), so we do this manual version instead.
-    return "\n".join(stdout.splitlines()).rstrip("\n").replace("\n", " ")
+    # Trailing newline removal, and newline-to-space conversion.
+    return result.stdout.rstrip("\n").replace("\n", " ")
 
 #
 # Global constants
@@ -6973,9 +6907,6 @@ STR_TO_TRI = {
 # distinct from a cached None (no selection). Any object that's not None or a
 # Symbol will do. We test this with 'is'.
 _NO_CACHED_SELECTION = 0
-
-# Are we running on Python 2?
-_IS_PY2 = sys.version_info[0] < 3
 
 try:
     _UNAME_RELEASE = os.uname()[2]
@@ -7267,15 +7198,14 @@ KIND_TO_STR = {
 # Helper functions for getting compiled regular expressions, with the needed
 # matching function returned directly as a small optimization.
 #
-# Use ASCII regex matching on Python 3. It's already the default on Python 2.
-
+# Use ASCII regex matching on Python 3.
 
 def _re_match(regex):
-    return re.compile(regex, 0 if _IS_PY2 else re.ASCII).match
+    return re.compile(regex, re.ASCII).match
 
 
 def _re_search(regex):
-    return re.compile(regex, 0 if _IS_PY2 else re.ASCII).search
+    return re.compile(regex, re.ASCII).search
 
 
 # Various regular expressions used during parsing

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -3108,6 +3108,36 @@ class Kconfig(object):
 
         return expr
 
+    def _parse_depends(self):
+        # Parses conditional dependencies with syntax "depends on <expr> if <condition>"
+        # Returns the appropriate expression that represents the conditional dependency
+
+        # Parse the main dependency expression
+        main_expr = self._parse_expr(True)
+
+        # Check if there's an optional "if <condition>" clause
+        if self._check_token(_T_IF):
+            # Parse the condition expression
+            condition = self._parse_expr(True)
+
+            # Check for end of line
+            if self._tokens[self._tokens_i] is not None:
+                self._trailing_tokens_error()
+
+            # Create conditional dependency: "depends on A if B" becomes "!B || A"
+            # This means: if B is false, the dependency is satisfied (y)
+            #             if B is true, the dependency becomes A
+            return self._make_or(
+                (NOT, condition),
+                main_expr
+            )
+        else:
+            # No conditional clause, just return the main expression
+            if self._tokens[self._tokens_i] is not None:
+                self._trailing_tokens_error()
+
+            return main_expr
+
     def _parse_props(self, node):
         # Parses and adds properties to the MenuNode 'node' (type, 'prompt',
         # 'default's, etc.) Properties are later copied up to symbols and
@@ -3143,7 +3173,7 @@ class Kconfig(object):
                     self._parse_error("expected 'on' after 'depends'")
 
                 node.dep = self._make_and(node.dep,
-                                          self._expect_expr_and_eol())
+                                          self._parse_depends())
 
             elif t0 is _T_HELP:
                 self._parse_help(node)

--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -7,7 +7,7 @@
 Overview
 ========
 
-A curses-based Python 2/3 menuconfig implementation. The interface should feel
+A curses-based Python 3 menuconfig implementation. The interface should feel
 familiar to people used to mconf ('make menuconfig').
 
 Supports the same keys as mconf, and also supports a set of keybindings
@@ -985,12 +985,7 @@ def _init():
     # Looking for this in addition to KEY_BACKSPACE (which is unreliable) makes
     # backspace work with TERM=vt100. That makes it likely to work in sane
     # environments.
-    _ERASE_CHAR = curses.erasechar()
-    if sys.version_info[0] >= 3:
-        # erasechar() returns a one-byte bytes object on Python 3. This sets
-        # _ERASE_CHAR to a blank string if it can't be decoded, which should be
-        # harmless.
-        _ERASE_CHAR = _ERASE_CHAR.decode("utf-8", "ignore")
+    _ERASE_CHAR = curses.erasechar().decode("utf-8", "ignore")
 
     _init_styles()
 
@@ -2129,11 +2124,7 @@ def _jump_to_dialog():
 
             except re.error as e:
                 # Bad regex. Remember the error message so we can show it.
-                bad_re = "Bad regular expression"
-                # re.error.msg was added in Python 3.5
-                if hasattr(e, "msg"):
-                    bad_re += ": " + e.msg
-
+                bad_re = f"Bad regular expression: {e.msg}"
                 matches = []
 
             # Reset scroll and jump to the top of the list of matches
@@ -2636,7 +2627,7 @@ def _help_info(sc):
 
     for node in sc.nodes:
         if node.help is not None:
-            s += "Help:\n\n{}\n\n".format(_indent(node.help, 2))
+            s += "Help:\n\n{}\n\n".format(textwrap.indent(node.help, "  "))
 
     return s
 
@@ -2778,7 +2769,7 @@ def _kconfig_def_info(item):
              .format(node.filename, node.linenr,
                      _include_path_info(node),
                      _menu_path_info(node),
-                     _indent(node.custom_str(_name_and_val_str), 2))
+                     textwrap.indent(node.custom_str(_name_and_val_str), "  "))
 
     return s
 
@@ -2808,13 +2799,6 @@ def _menu_path_info(node):
                          standard_sc_expr_str(node.item)) + path
 
     return "(Top)" + path
-
-
-def _indent(s, n):
-    # Returns 's' with each line indented 'n' spaces. textwrap.indent() is not
-    # available in Python 2 (it's 3.3+).
-
-    return "\n".join(n*" " + line for line in s.split("\n"))
 
 
 def _name_and_val_str(sc):
@@ -3143,9 +3127,7 @@ def _is_num(name):
 
 
 def _getch_compat(win):
-    # Uses get_wch() if available (Python 3.3+) and getch() otherwise.
-    #
-    # Also falls back on getch() if get_wch() raises curses.error, to work
+    # Fall back on getch() if get_wch() raises curses.error, to work
     # around an issue when resizing the terminal on at least macOS Catalina.
     # See https://github.com/ulfalizer/Kconfiglib/issues/84.
     #


### PR DESCRIPTION
This PR brings in the latest three commits from https://github.com/zephyrproject-rtos/Kconfiglib:
- [drop support for Python 2.x as it is very much EOL](https://github.com/zephyrproject-rtos/Kconfiglib/commit/24aef157aead07f813f874f43ee471b057e622cb)
- [Support conditional deps using "depends on A if B"](https://github.com/zephyrproject-rtos/Kconfiglib/commit/d13e125024ec1c8e573aacd463765d028515503e)
- [kconfiglib: testsuite: Support running on Windows](https://github.com/zephyrproject-rtos/Kconfiglib/commit/b8535af53f0650a69e52db4bf8585c09d55852e7)

