### PR TITLE
cpu_freq: timing noise policy

### DIFF
--- a/doc/services/cpu_freq/policies/index.rst
+++ b/doc/services/cpu_freq/policies/index.rst
@@ -8,3 +8,4 @@ CPU Frequency Scaling Policies
 
    on_demand.rst
    pressure.rst
+   timing_noise.rst

--- a/doc/services/cpu_freq/policies/timing_noise.rst
+++ b/doc/services/cpu_freq/policies/timing_noise.rst
@@ -1,0 +1,97 @@
+.. _timing_noise_policy:
+
+Timing Noise CPU Frequency Scaling Policy
+#########################################
+
+Overview
+########
+
+The timing noise policy is a CPU frequency scaling policy that periodically
+selects a random performance state (P-state). The intent is to inject timing
+variability by jittering the CPU clock, which can disrupt naive cycle-count
+or wall-clock measurements that assume a stable frequency.
+
+This is a randomized P-state policy. It is not a general side-channel
+countermeasure.
+
+Primary Mitigation
+##################
+
+Constant-time and constant-flow implementations that have been reviewed for
+side-channel leakage remain the primary mitigation against timing attacks.
+This policy does not replace those practices. At best, it may complicate a
+particular class of measurement.
+
+Attacker Model
+##############
+
+This policy considers an adversary that:
+
+* Observes relative execution time via cycle counters, wall-clock timers, or
+  similar software-visible timestamps
+* Relies on a stable CPU frequency so that small differences in instruction
+  count or data-dependent paths remain distinguishable across trials
+
+Randomized P-state selection does not defeat such an attack. Given enough
+samples, an attacker can often average through the noise. The policy only
+makes those measurements less convenient and less repeatable.
+
+Use Cases
+#########
+
+This policy may be useful when an application wants additional timing
+variability as a secondary layer on top of already sound software. It should
+be treated as a way to disrupt certain analyses, not as a security solution
+on its own.
+
+It is a poor fit for:
+
+* Hard real-time systems that need deterministic execution time
+* Safety-related systems where timing predictability is part of the safety case
+* Latency-sensitive workloads that cannot tolerate unexpected slow P-states
+* Strict power-budget designs, since frequent P-state changes may increase
+  average power consumption
+
+Configuration
+#############
+
+Enable the CPU frequency subsystem and select the timing noise policy:
+
+.. code-block:: kconfig
+
+   CONFIG_CPU_FREQ=y
+   CONFIG_CPU_FREQ_POLICY_TIMING_NOISE=y
+
+The policy uses the standard CPU frequency subsystem update interval,
+configured with:
+
+.. code-block:: kconfig
+
+   CONFIG_CPU_FREQ_INTERVAL_MS=<interval>
+
+Smaller update intervals increase timing variability, but also increase the
+number of frequency transitions.
+
+Random Number Generation
+########################
+
+The policy selects performance states using :c:func:`sys_rand32_get()`.
+Selecting ``CONFIG_CPU_FREQ_POLICY_TIMING_NOISE`` enables the entropy driver
+on platforms with a hardware entropy source. Prefer routing random draws
+through that driver when a TRNG is available:
+
+.. code-block:: kconfig
+
+   CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR=y
+
+Limitations
+###########
+
+* It does not eliminate timing side channels
+* It cannot compensate for fundamentally insecure software
+* It may reduce overall system performance
+* It may increase power consumption due to frequent performance state changes
+* It offers no guarantees against a determined or well-instrumented attacker
+
+For an example of the timing noise policy, refer to the
+:zephyr:code-sample:`cpu_freq_timing_noise` sample.

--- a/samples/subsys/cpu_freq/timing_noise/CMakeLists.txt
+++ b/samples/subsys/cpu_freq/timing_noise/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Sean Kyer
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(cpu_freq_timing_noise_sample)
+
+target_sources(app PRIVATE
+    src/main.c
+    src/password.c
+)

--- a/samples/subsys/cpu_freq/timing_noise/README.rst
+++ b/samples/subsys/cpu_freq/timing_noise/README.rst
@@ -1,0 +1,91 @@
+.. zephyr:code-sample:: cpu_freq_timing_noise
+   :name: CPU frequency scaling timing noise sample
+   :relevant-api: subsys_cpu_freq
+
+   Show how randomized P-state selection can disrupt a simple cycle-count
+   password guessing experiment.
+
+Overview
+********
+
+This sample implements a deliberately non-constant-time password check and a
+naive timing experiment that ranks character guesses by cycle count. Building
+the sample in the default configuration demonstrates how that experiment can
+recover the password when the CPU frequency is stable.
+
+Rebuilding with ``timing_noise_prj.conf`` enables the timing noise policy,
+which periodically selects a random P-state. That frequency jitter tends to
+scramble the ranking used by this particular experiment, so the guessed
+string stops matching the secret. That outcome is specific to this
+measurement setup. It does not mean the underlying leak is gone, nor that
+an attacker is defeated in general.
+
+Constant-time password checking would still be the correct fix. This sample
+exists to illustrate how randomized P-state selection can disrupt a simple
+cycle-count ranking.
+
+.. code-block:: console
+
+   west build -b frdm_mcxn236 samples/subsys/cpu_freq/timing_noise \
+     -- -DEXTRA_CONF_FILE=timing_noise_prj.conf
+
+Building and Running
+********************
+
+Build without the timing noise policy (stable frequency; experiment succeeds):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/cpu_freq/timing_noise
+   :board: frdm_mcxn236
+   :goals: build
+   :compact:
+
+Build with the timing noise policy enabled:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/cpu_freq/timing_noise
+   :board: frdm_mcxn236
+   :goals: build
+   :compact:
+   :gen-args: -DEXTRA_CONF_FILE=timing_noise_prj.conf
+
+Flash and run:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/cpu_freq/timing_noise
+   :board: frdm_mcxn236
+   :goals: flash
+   :compact:
+
+Sample Output
+=============
+
+Default mode (stable frequency; ranking recovers the secret)
+------------------------------------------------------------
+
+.. code-block:: none
+
+   pos 0 try A -> 79 cycles
+   pos 0 try B -> 83 cycles
+   pos 0 try C -> 91 cycles
+   ...
+   Recovered so far: P
+
+   pos 1 try A -> 87 cycles
+   pos 1 try B -> 92 cycles
+   ...
+   Recovered so far: Pa
+
+
+With timing noise (this experiment's ranking collapses)
+-------------------------------------------------------
+
+.. code-block:: none
+
+   pos 0 try A -> 101 cycles
+   pos 0 try B -> 100 cycles
+   pos 0 try C -> 102 cycles
+   ...
+   Recovered so far: PxSaaZ
+
+   (no stable ordering between candidates)

--- a/samples/subsys/cpu_freq/timing_noise/prj.conf
+++ b/samples/subsys/cpu_freq/timing_noise/prj.conf
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Sean Kyer
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Default config: no CPUFreq policy. The cycle-count ranking can recover
+# the password when the CPU frequency is stable.
+#
+
+CONFIG_LOG=y
+CONFIG_LOG_MODE_DEFERRED=y

--- a/samples/subsys/cpu_freq/timing_noise/src/main.c
+++ b/samples/subsys/cpu_freq/timing_noise/src/main.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Sean Kyer
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "password.h"
+
+LOG_MODULE_REGISTER(cpu_freq_timing_noise_sample, LOG_LEVEL_INF);
+
+#define MAX_PASSWORD_LEN 64
+#define NUM_SAMPLES      20
+
+static uint64_t measure_guess(const char *guess)
+{
+	uint64_t start = k_cycle_get_64();
+
+	check_password(guess);
+	uint64_t end = k_cycle_get_64();
+
+	return end - start;
+}
+
+static const char charset[] =
+	"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+";
+
+int main(void)
+{
+	LOG_INF("Starting timing side-channel attack...");
+
+	char recovered[MAX_PASSWORD_LEN] = {0};
+	char test[MAX_PASSWORD_LEN] = {0};
+
+	size_t recovered_len = 0;
+	size_t charset_len = strlen(charset);
+
+	for (size_t pos = 0; pos < MAX_PASSWORD_LEN - 1; pos++) {
+		uint64_t best_time = 0;
+		char best_char = 0;
+		bool found_any = false;
+
+		for (size_t c = 0; c < charset_len; c++) {
+			memcpy(test, recovered, recovered_len);
+			test[recovered_len] = charset[c];
+			test[recovered_len + 1] = '\0';
+
+			uint64_t total = 0;
+
+			for (int i = 0; i < NUM_SAMPLES; i++) {
+				total += measure_guess(test);
+			}
+
+			uint64_t avg = total / NUM_SAMPLES;
+
+			/*
+			 * If this character took longer to process than the others, then it
+			 * must be the next correct character.
+			 */
+			if (!found_any || avg > best_time) {
+				best_time = avg;
+				best_char = charset[c];
+				found_any = true;
+			}
+		}
+
+		LOG_INF("found pos %d try %c -> %llu cycles", recovered_len, best_char, best_time);
+
+		recovered[recovered_len++] = best_char;
+		recovered[recovered_len] = '\0';
+
+		LOG_INF("Recovered so far: %s", recovered);
+
+		/* stop when correct full string found */
+		if (check_password(recovered)) {
+			LOG_INF("Final password recovered: %s", recovered);
+			break;
+		}
+
+		k_sleep(K_MSEC(250));
+	}
+
+	LOG_INF("Attack sample finished.");
+
+	return 0;
+}

--- a/samples/subsys/cpu_freq/timing_noise/src/password.c
+++ b/samples/subsys/cpu_freq/timing_noise/src/password.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Sean Kyer
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+
+#include "password.h"
+
+static const char secret[] = "Password123!";
+
+#define SECRET_LEN (sizeof(secret) - 1)
+
+/*
+ * Deliberately non-constant-time check used as the attack surface for the
+ * sample's cycle-count ranking experiment. Of course, a real password check
+ * should not be written this way. Constant-time comparison remains the
+ * correct fix; frequency jitter only affects this particular measurement.
+ */
+bool check_password(const char *guess)
+{
+	for (int i = 0; i < SECRET_LEN; i++) {
+		if (guess[i] != secret[i]) {
+			return false;
+		}
+	}
+
+	/* Doing some login processing */
+	k_busy_wait(1000);
+
+	return true;
+}

--- a/samples/subsys/cpu_freq/timing_noise/src/password.h
+++ b/samples/subsys/cpu_freq/timing_noise/src/password.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Sean Kyer
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef PASSWORD_H
+#define PASSWORD_H
+
+#include <stdbool.h>
+
+bool check_password(const char *password);
+
+#endif /* PASSWORD_H */

--- a/samples/subsys/cpu_freq/timing_noise/tests.yaml
+++ b/samples/subsys/cpu_freq/timing_noise/tests.yaml
@@ -1,0 +1,21 @@
+sample:
+  description: CPU frequency timing noise policy sample
+  name: CPU Freq Timing Noise Policy
+common:
+  tags: cpu_freq
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+    - "^.*<inf> cpu_freq_timing_noise_sample: Starting timing side-channel attack\\.\\.\\."
+    - "^.*<inf> cpu_freq_timing_noise_sample: found pos [0-9]+ try \
+       [A-Za-z0-9!@#\\$%\\^&\\*()\\-_=\\+]+ -> [0-9]+ cycles"
+    - "^.*<inf> cpu_freq_timing_noise_sample: Recovered so far: .+"
+
+tests:
+  sample.cpu_freq_timing_noise:
+    extra_args: EXTRA_CONF_FILE=timing_noise_prj.conf
+    integration_platforms:
+    - frdm_mcxn236
+    platform_allow:
+    - frdm_mcxn236

--- a/samples/subsys/cpu_freq/timing_noise/timing_noise_prj.conf
+++ b/samples/subsys/cpu_freq/timing_noise/timing_noise_prj.conf
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Sean Kyer
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Enable the timing noise (randomized P-state) policy.
+# Entropy is selected by the policy; use the on-chip TRNG for sys_rand32_get().
+#
+
+CONFIG_CPU_FREQ=y
+CONFIG_CPU_FREQ_LOG_LEVEL_DBG=y
+CONFIG_CPU_FREQ_INTERVAL_MS=500
+CONFIG_CPU_FREQ_POLICY_TIMING_NOISE=y
+CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR=y

--- a/subsys/cpu_freq/CMakeLists.txt
+++ b/subsys/cpu_freq/CMakeLists.txt
@@ -15,4 +15,5 @@ endif()
 
 zephyr_sources_ifdef(CONFIG_CPU_FREQ_POLICY_ON_DEMAND policies/on_demand/on_demand.c)
 zephyr_sources_ifdef(CONFIG_CPU_FREQ_POLICY_PRESSURE policies/pressure/pressure.c)
+zephyr_sources_ifdef(CONFIG_CPU_FREQ_POLICY_TIMING_NOISE policies/timing_noise/timing_noise.c)
 zephyr_sources_ifdef(CONFIG_CPU_FREQ_PSTATE_SET_STUB cpu_freq_stub.c)

--- a/subsys/cpu_freq/Kconfig
+++ b/subsys/cpu_freq/Kconfig
@@ -98,6 +98,15 @@ config CPU_FREQ_POLICY_PRESSURE_LOWEST_PRIO
 
 endif
 
+config CPU_FREQ_POLICY_TIMING_NOISE
+	bool "Timing noise policy"
+	select ENTROPY_GENERATOR if ENTROPY_NODE_ENABLED
+	help
+	  Timing noise policy. Periodically selects a random performance state
+	  via sys_rand32_get() to inject timing variability. This may disrupt
+	  naive timing analysis that assumes a stable CPU frequency. It is not
+	  a general side-channel countermeasure.
+
 endchoice # CPU_FREQ_POLICY
 
 choice CPU_FREQ_PSTATE_SET

--- a/subsys/cpu_freq/policies/timing_noise/timing_noise.c
+++ b/subsys/cpu_freq/policies/timing_noise/timing_noise.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Sean Kyer
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/cpu_freq/policy.h>
+#include <zephyr/cpu_freq/cpu_freq.h>
+#include <zephyr/random/random.h>
+
+LOG_MODULE_REGISTER(cpu_freq_policy_timing_noise, CONFIG_CPU_FREQ_LOG_LEVEL);
+
+const struct pstate *soc_pstates[] = {
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(performance_states), PSTATE_DT_GET, (,))
+};
+
+const size_t soc_pstates_count = ARRAY_SIZE(soc_pstates);
+
+int cpu_freq_policy_select_pstate(const struct pstate **pstate_out)
+{
+	size_t idx;
+	uint32_t rnd;
+
+	if (pstate_out == NULL) {
+		return -EINVAL;
+	}
+
+	rnd = sys_rand32_get();
+
+	/* Uniform mapping to valid P-state range */
+	idx = (uint32_t)(((uint64_t)rnd * soc_pstates_count) >> 32);
+
+	*pstate_out = soc_pstates[idx];
+
+	LOG_DBG("Timing noise policy: rnd=%u idx=%zu freq_level=%d", rnd, idx,
+		soc_pstates[idx]->load_threshold);
+
+	return 0;
+}
+
+void cpu_freq_policy_reset(void)
+{
+    /* No reset required */
+}
+
+const struct pstate *cpu_freq_policy_pstate_set(const struct pstate *state)
+{
+	int rv = cpu_freq_pstate_set(state);
+
+	if (rv != 0) {
+		LOG_ERR("Failed to set P-state: %d", rv);
+		return NULL;
+	}
+
+	return state;
+}


### PR DESCRIPTION
Introduce a side-channel defense policy. 

Allows the CPUFreq subsystem to supply a layer of security against timing and power based side-channel attacks.

Please read the side_channel_defense.rst and the accompanying sample for the rationale behind this policy. I believe there is prior art in NXP smart card HSMs that purposefully drift their CPU clocking as a side-channel countermeasure. 

This sample is purposefully vulnerable in order to demonstrate the subsystem. I am curious to hear from the community, and specifically from security experts, their thoughts on having Zephyr provide some level of low-effort security transparently for a user' system. As well as to provide direction on it's effectiveness for more intricate attacks.

The sample provided uses the sysclock for 'wall time'. This only works because the frdm board has independent clocking, so changing the clock speed effects execution time without modifying the clock used for timing. A real side-channel attack would likely use some equipment with its own stable clock, I've only implemented it this way so a sample running on HW can demonstrate this policy.