### PR TITLE
lora: native: sx126x: add Channel Activity Detection support

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -229,6 +229,9 @@ Libraries / Subsystems
     LoRaWAN 1.0.x Class A directly on top of the LoRa radio driver, without
     the Semtech LoRaMac-node dependency.  Currently supports the EU868 region.
   * :c:member:`lora_modem_config.sync_word`
+  * The native SX126x driver now implements Channel Activity Detection
+    (:c:func:`lora_cad`, :c:func:`lora_cad_async`), including Listen Before
+    Talk on send and a CAD gate on receive.
 
 Devicetree
 **********

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -20,6 +20,9 @@ LOG_MODULE_REGISTER(sx126x, CONFIG_LORA_LOG_LEVEL);
 
 #define SX126X_SF56_MIN_PREAMBLE_LEN	12
 
+/* Safety bound for the internal CAD (LBT / CAD-before-RX); CAD self-terminates. */
+#define SX126X_CAD_INTERNAL_TIMEOUT	K_SECONDS(2)
+
 static int bandwidth_to_reg(enum lora_signal_bandwidth bw, uint8_t *reg)
 {
 	switch (bw) {
@@ -114,6 +117,65 @@ static bool should_enable_ldro(enum lora_datarate sf, enum lora_signal_bandwidth
 	uint32_t symbol_time_us = ((1 << sf) * 1000000UL) / bw_hz;
 
 	return symbol_time_us > 16380;
+}
+
+static uint8_t cad_symbol_num_to_idx(enum lora_cad_symbol_num symbol_num)
+{
+	switch (symbol_num) {
+	case LORA_CAD_SYMB_1:
+		return SX126X_CAD_SYMB_1;
+	case LORA_CAD_SYMB_2:
+		return SX126X_CAD_SYMB_2;
+	case LORA_CAD_SYMB_4:
+		return SX126X_CAD_SYMB_4;
+	case LORA_CAD_SYMB_8:
+		return SX126X_CAD_SYMB_8;
+	case LORA_CAD_SYMB_16:
+		return SX126X_CAD_SYMB_16;
+	default:
+		/* 0 (unset) or unknown -> driver default */
+		return SX126X_CAD_DEFAULT_SYMB;
+	}
+}
+
+/* Recommended detection peak per SF, narrow/wide BW columns (Semtech RAL). */
+static uint8_t cad_default_det_peak(enum lora_datarate sf,
+				    enum lora_signal_bandwidth bw,
+				    uint8_t symb_idx)
+{
+	static const uint8_t det_peak[2][SF_12 - SF_5 + 1] = {
+		/* BW < 500 kHz:  SF5  SF6  SF7  SF8  SF9 SF10 SF11 SF12 */
+		{		 20,  21,  22,  24,  24,  25,  27,  27 },
+		/* BW >= 500 kHz: SF5  SF6  SF7  SF8  SF9 SF10 SF11 SF12 */
+		{		 22,  23,  25,  26,  30,  31,  33,  35 },
+	};
+	uint8_t peak = det_peak[(bw >= BW_500_KHZ) ? 1 : 0][sf - SF_5];
+
+	/* More integration symbols allow a lower (more sensitive) peak. */
+	if (symb_idx == SX126X_CAD_SYMB_4) {
+		peak -= 1;
+	} else if (symb_idx >= SX126X_CAD_SYMB_8) {
+		peak -= 2;
+	}
+
+	return peak;
+}
+
+static void sx126x_compute_cad_params(const struct device *dev,
+				      uint8_t *symb_idx, uint8_t *det_peak,
+				      uint8_t *det_min)
+{
+	struct sx126x_data *data = dev->data;
+	const struct lora_modem_config *config = &data->config;
+
+	*symb_idx = cad_symbol_num_to_idx(config->cad.symbol_num);
+
+	*det_peak = config->cad.detection_peak ? config->cad.detection_peak :
+		cad_default_det_peak(config->datarate, config->bandwidth,
+				     *symb_idx);
+
+	*det_min = config->cad.detection_minimum ? config->cad.detection_minimum :
+		SX126X_CAD_DET_MIN_DEFAULT;
 }
 
 static int sx126x_validate_config(const struct lora_modem_config *config)
@@ -394,6 +456,26 @@ static int sx126x_set_rx(const struct device *dev, uint32_t timeout_ms)
 	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_RX, buf, 3);
 }
 
+static int sx126x_set_cad_params(const struct device *dev, uint8_t symb_num,
+				 uint8_t det_peak, uint8_t det_min,
+				 uint8_t exit_mode, uint32_t timeout)
+{
+	uint8_t buf[7];
+
+	buf[0] = symb_num;
+	buf[1] = det_peak;
+	buf[2] = det_min;
+	buf[3] = exit_mode;
+	sys_put_be24(timeout, &buf[4]);
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_CAD_PARAMS, buf, 7);
+}
+
+static int sx126x_set_cad(const struct device *dev)
+{
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_CAD, NULL, 0);
+}
+
 static int sx126x_get_rx_buffer_status(const struct device *dev,
 				       uint8_t *payload_len, uint8_t *offset)
 {
@@ -527,9 +609,10 @@ static int sx126x_chip_init(const struct device *dev)
 		return ret;
 	}
 
-	/* Configure IRQs on DIO1: TX done, RX done, timeout */
+	/* Configure IRQs on DIO1: TX done, RX done, timeout, CAD done */
 	uint16_t irq_mask = SX126X_IRQ_TX_DONE | SX126X_IRQ_RX_DONE |
-			    SX126X_IRQ_RX_TX_TIMEOUT | SX126X_IRQ_CRC_ERR;
+			    SX126X_IRQ_RX_TX_TIMEOUT | SX126X_IRQ_CRC_ERR |
+			    SX126X_IRQ_CAD_DONE | SX126X_IRQ_CAD_ACTIVITY_DETECTED;
 	ret = sx126x_set_dio_irq_params(dev, irq_mask, irq_mask, 0, 0);
 	if (ret < 0) {
 		LOG_ERR("Set IRQ params failed: %d", ret);
@@ -804,6 +887,35 @@ static void sx126x_handle_irq_timeout(const struct device *dev)
 	}
 }
 
+static void sx126x_handle_irq_cad_done(const struct device *dev,
+				       uint16_t irq_status)
+{
+	struct sx126x_data *data = dev->data;
+	bool detected = (irq_status & SX126X_IRQ_CAD_ACTIVITY_DETECTED) != 0;
+	struct sx126x_cad_result result = {
+		.detected = detected,
+		.status = 0,
+	};
+
+	LOG_DBG("CAD done: %s", detected ? "activity" : "clear");
+
+	/* CAD self-terminates to STDBY_RC; return to rest (also resets state). */
+	sx126x_set_sleep(dev);
+
+	if (data->cad_cb != NULL) {
+		/* Async: clear cb before invoking so it may start a new op. */
+		lora_cad_cb cb = data->cad_cb;
+		void *user_data = data->cad_cb_user_data;
+
+		data->cad_cb = NULL;
+		data->cad_cb_user_data = NULL;
+		cb(dev, detected, user_data);
+		return;
+	}
+
+	k_msgq_put(&data->cad_msgq, &result, K_NO_WAIT);
+}
+
 static void sx126x_irq_work_handler(struct k_work *work)
 {
 	struct sx126x_data *data = CONTAINER_OF(work, struct sx126x_data, irq_work);
@@ -832,6 +944,10 @@ static void sx126x_irq_work_handler(struct k_work *work)
 
 	if (irq_status & SX126X_IRQ_RX_TX_TIMEOUT) {
 		sx126x_handle_irq_timeout(dev);
+	}
+
+	if (irq_status & SX126X_IRQ_CAD_DONE) {
+		sx126x_handle_irq_cad_done(dev, irq_status);
 	}
 
 	/* Re-enable the DIO1 interrupt for the next event (unless sleeping) */
@@ -938,6 +1054,107 @@ out:
 	return ret;
 }
 
+static int sx126x_cad_start(const struct device *dev, lora_cad_cb cb,
+			    void *user_data)
+{
+	struct sx126x_data *data = dev->data;
+	uint8_t symb_idx, det_peak, det_min;
+	int ret;
+
+	if (!data->config_valid) {
+		LOG_ERR("Not configured");
+		return -EINVAL;
+	}
+
+	if (!atomic_cas(&data->state, SX126X_REST_STATE, SX126X_STATE_CAD)) {
+		LOG_ERR("Busy");
+		return -EBUSY;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	ret = sx126x_ensure_ready(dev);
+	if (ret < 0) {
+		k_mutex_unlock(&data->lock);
+		atomic_set(&data->state, SX126X_REST_STATE);
+		return ret;
+	}
+
+	data->cad_cb = cb;
+	data->cad_cb_user_data = user_data;
+	k_msgq_purge(&data->cad_msgq);
+
+	sx126x_compute_cad_params(dev, &symb_idx, &det_peak, &det_min);
+
+	ret = sx126x_set_cad_params(dev, symb_idx, det_peak, det_min,
+				    SX126X_CAD_EXIT_ONLY, 0);
+	if (ret < 0) {
+		goto out_error;
+	}
+
+	sx126x_set_rf_path(dev, true, false);
+
+	ret = sx126x_set_cad(dev);
+	if (ret < 0) {
+		goto out_error;
+	}
+
+	k_mutex_unlock(&data->lock);
+	return 0;
+
+out_error:
+	data->cad_cb = NULL;
+	data->cad_cb_user_data = NULL;
+	sx126x_set_sleep(dev);
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+static int sx126x_lora_cad(const struct device *dev, k_timeout_t timeout)
+{
+	struct sx126x_data *data = dev->data;
+	struct sx126x_cad_result result;
+	int ret;
+
+	ret = sx126x_cad_start(dev, NULL, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* IRQ handler returns the radio to rest on completion. */
+	ret = k_msgq_get(&data->cad_msgq, &result, timeout);
+	if (ret < 0) {
+		LOG_DBG("CAD timeout");
+		sx126x_set_standby(dev, SX126X_STANDBY_RC);
+		sx126x_set_sleep(dev);
+		return -ETIMEDOUT;
+	}
+
+	return result.detected ? 1 : 0;
+}
+
+static int sx126x_lora_cad_async(const struct device *dev, lora_cad_cb cb,
+				 void *user_data)
+{
+	struct sx126x_data *data = dev->data;
+
+	if (cb == NULL) {
+		/* Cancel a pending CAD. */
+		k_mutex_lock(&data->lock, K_FOREVER);
+		data->cad_cb = NULL;
+		data->cad_cb_user_data = NULL;
+		if (atomic_cas(&data->state, SX126X_STATE_CAD,
+			       SX126X_STATE_IDLE)) {
+			sx126x_set_standby(dev, SX126X_STANDBY_RC);
+			sx126x_set_sleep(dev);
+		}
+		k_mutex_unlock(&data->lock);
+		return 0;
+	}
+
+	return sx126x_cad_start(dev, cb, user_data);
+}
+
 static int sx126x_lora_send_async(const struct device *dev,
 				  uint8_t *data_buf, uint32_t data_len,
 				  struct k_poll_signal *async)
@@ -953,6 +1170,18 @@ static int sx126x_lora_send_async(const struct device *dev,
 	if (data_len > SX126X_MAX_PAYLOAD_LEN) {
 		LOG_ERR("Payload too long: %u", data_len);
 		return -EINVAL;
+	}
+
+	/* Listen Before Talk: refuse to transmit if the channel is busy. */
+	if (data->config.cad.mode == LORA_CAD_MODE_LBT) {
+		ret = sx126x_lora_cad(dev, SX126X_CAD_INTERNAL_TIMEOUT);
+		if (ret < 0) {
+			return ret;
+		}
+		if (ret == 1) {
+			LOG_DBG("LBT: channel busy");
+			return -EBUSY;
+		}
 	}
 
 	if (!atomic_cas(&data->state, SX126X_REST_STATE, SX126X_STATE_TX)) {
@@ -1052,6 +1281,18 @@ static int sx126x_lora_recv(const struct device *dev, uint8_t *data_buf,
 	if (!data->config_valid) {
 		LOG_ERR("Not configured");
 		return -EINVAL;
+	}
+
+	/* CAD before receive: return immediately if the channel is idle. */
+	if (data->config.cad.mode == LORA_CAD_MODE_RX) {
+		ret = sx126x_lora_cad(dev, SX126X_CAD_INTERNAL_TIMEOUT);
+		if (ret < 0) {
+			return ret;
+		}
+		if (ret == 0) {
+			LOG_DBG("CAD: channel idle, skipping RX");
+			return 0;
+		}
 	}
 
 	if (!atomic_cas(&data->state, SX126X_REST_STATE, SX126X_STATE_RX)) {
@@ -1515,6 +1756,8 @@ static DEVICE_API(lora, sx126x_lora_api) = {
 	.send_async = sx126x_lora_send_async,
 	.recv = sx126x_lora_recv,
 	.recv_async = sx126x_lora_recv_async,
+	.cad = sx126x_lora_cad,
+	.cad_async = sx126x_lora_cad_async,
 	.recv_duty_cycle = sx126x_lora_recv_duty_cycle,
 	.recv_duty_cycle_async = sx126x_lora_recv_duty_cycle_async,
 	.airtime = sx126x_lora_airtime,
@@ -1548,6 +1791,8 @@ static int sx126x_init(const struct device *dev)
 		    sizeof(struct sx126x_tx_result), 1);
 	k_msgq_init(&data->rx_msgq, (char *)&data->rx_result,
 		    sizeof(struct sx126x_rx_result), 1);
+	k_msgq_init(&data->cad_msgq, (char *)&data->cad_result,
+		    sizeof(struct sx126x_cad_result), 1);
 	k_work_init(&data->irq_work, sx126x_irq_work_handler);
 	data->dev = dev;
 	atomic_set(&data->state, SX126X_STATE_IDLE);

--- a/drivers/lora/native/sx126x/sx126x.h
+++ b/drivers/lora/native/sx126x/sx126x.h
@@ -19,6 +19,7 @@ enum sx126x_state {
 	SX126X_STATE_TX,
 	SX126X_STATE_RX,
 	SX126X_STATE_RX_DUTY_CYCLE,
+	SX126X_STATE_CAD,
 };
 
 struct sx126x_tx_result {
@@ -29,6 +30,11 @@ struct sx126x_rx_result {
 	int16_t rssi;
 	int8_t snr;
 	uint8_t len;
+	int status;
+};
+
+struct sx126x_cad_result {
+	bool detected;
 	int status;
 };
 
@@ -50,6 +56,14 @@ struct sx126x_data {
 	/* RX completion via message queue */
 	struct k_msgq rx_msgq;
 	struct sx126x_rx_result rx_result;
+
+	/* CAD completion via message queue (blocking CAD/LBT/RX-gate) */
+	struct k_msgq cad_msgq;
+	struct sx126x_cad_result cad_result;
+
+	/* Async CAD callback */
+	lora_cad_cb cad_cb;
+	void *cad_cb_user_data;
 
 	/* RX data buffer (shared between IRQ handler and recv) */
 	uint8_t rx_buf[SX126X_MAX_PAYLOAD_LEN];

--- a/drivers/lora/native/sx126x/sx126x_regs.h
+++ b/drivers/lora/native/sx126x/sx126x_regs.h
@@ -132,6 +132,22 @@
 #define SX126X_LORA_IQ_STANDARD             0x00
 #define SX126X_LORA_IQ_INVERTED             0x01
 
+/* CAD Symbol Number for SET_CAD_PARAMS: index 0..4, not the count 1/2/4/8/16. */
+#define SX126X_CAD_SYMB_1                   0x00
+#define SX126X_CAD_SYMB_2                   0x01
+#define SX126X_CAD_SYMB_4                   0x02
+#define SX126X_CAD_SYMB_8                   0x03
+#define SX126X_CAD_SYMB_16                  0x04
+
+/* CAD Exit Mode (for SET_CAD_PARAMS) */
+#define SX126X_CAD_EXIT_ONLY                0x00  /* CAD then back to STDBY_RC */
+#define SX126X_CAD_EXIT_RX                  0x01  /* CAD then RX on detection */
+#define SX126X_CAD_EXIT_LBT                 0x10  /* Listen Before Talk */
+
+/* CAD defaults (vendor/datasheet recommended) */
+#define SX126X_CAD_DET_MIN_DEFAULT          10
+#define SX126X_CAD_DEFAULT_SYMB             SX126X_CAD_SYMB_2
+
 /* TX Power Ramp Time (for SET_TX_PARAMS) */
 #define SX126X_RAMP_10_US                   0x00
 #define SX126X_RAMP_20_US                   0x01

--- a/samples/drivers/lora/cad/CMakeLists.txt
+++ b/samples/drivers/lora/cad/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(lora_cad)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/lora/cad/README.rst
+++ b/samples/drivers/lora/cad/README.rst
@@ -1,0 +1,66 @@
+.. zephyr:code-sample:: lora-cad
+   :name: LoRa Channel Activity Detection
+   :relevant-api: lora_interface
+
+   Detect LoRa channel activity and use Listen Before Talk.
+
+Overview
+********
+
+This sample demonstrates Channel Activity Detection (CAD) on the LoRa API:
+
+* ``lora_cad()`` (blocking) and ``lora_cad_async()`` (callback-based) to probe
+  the channel for LoRa activity.
+* ``LORA_CAD_MODE_LBT`` to perform "listen before talk" automatically inside
+  ``lora_send()``.
+
+By default the sample starts in **scanner** mode. Hold **button 0** during
+boot to select **sender** mode.
+
+The scanner demonstrates ``lora_cad_async()`` once, then runs ``lora_cad()``
+continuously and reports, for each window of 20 probes, how many found the
+channel busy. The sender enables ``LORA_CAD_MODE_LBT`` and transmits
+repeatedly with a long preamble. CAD flags a preamble's presence roughly
+once per packet, so the busy count stays a small fraction of the window
+even with the sender active.
+
+Note that CAD detects LoRa modulation (chirps), not arbitrary RF energy, so
+the channel must be loaded with real LoRa transmissions; a continuous wave
+would not reliably trip CAD.
+
+Building and Running
+********************
+
+Build and flash on a board with a ``lora0`` alias, for example
+``nucleo_wl55jc`` or ``nrf52840dk/nrf52840`` with the SX1261 shield:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/lora/cad
+   :host-os: unix
+   :board: nucleo_wl55jc
+   :goals: build flash
+   :compact:
+
+Sample Output (scanner)
+=======================
+
+.. code-block:: console
+
+   [00:00:00.070,000] <inf> lora_cad: Scanner mode: probing channel with CAD
+   [00:00:00.070,000] <inf> lora_cad: Asynchronous CAD probe
+   [00:00:00.116,000] <inf> lora_cad: Async CAD result: channel clear
+   [00:00:00.116,000] <inf> lora_cad: Continuous CAD scan
+   [00:00:01.018,000] <inf> lora_cad: channel busy on 1 of last 20 probes
+   [00:00:01.920,000] <inf> lora_cad: channel busy on 1 of last 20 probes
+   [00:00:02.821,000] <inf> lora_cad: channel busy on 0 of last 20 probes
+   [00:00:03.723,000] <inf> lora_cad: channel busy on 1 of last 20 probes
+
+Sample Output (sender)
+======================
+
+.. code-block:: console
+
+   [00:00:00.250,000] <inf> lora_cad: Sender mode: Listen Before Talk enabled
+   [00:00:00.290,000] <inf> lora_cad: Sent packet 0
+   [00:00:01.120,000] <inf> lora_cad: Sent packet 1
+   [00:00:01.950,000] <inf> lora_cad: Sent packet 2

--- a/samples/drivers/lora/cad/prj.conf
+++ b/samples/drivers/lora/cad/prj.conf
@@ -1,0 +1,7 @@
+CONFIG_LOG=y
+CONFIG_LORA=y
+CONFIG_LORA_MODULE_BACKEND_NATIVE=y
+CONFIG_PRINTK=y
+
+# Stay in standby between CAD probes (no per-probe deep-sleep wake).
+CONFIG_LORA_SX126X_NATIVE_SLEEP=n

--- a/samples/drivers/lora/cad/sample.yaml
+++ b/samples/drivers/lora/cad/sample.yaml
@@ -1,0 +1,23 @@
+common:
+  tags: lora
+  depends_on: lora
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "<inf> lora_cad: Scanner mode: probing channel with CAD"
+sample:
+  description: Demonstration of LoRa Channel Activity Detection (CAD)
+  name: LoRa CAD Sample
+tests:
+  sample.drivers.lora.cad.native:
+    build_only: true
+    extra_args:
+      - SHIELD=semtech_sx1261mb2bas
+    platform_allow:
+      - nrf52840dk/nrf52840
+  sample.drivers.lora.cad.native.stm32wl:
+    filter: dt_compat_enabled("st,stm32wl-subghz-radio")
+    build_only: true
+    integration_platforms:
+      - nucleo_wl55jc

--- a/samples/drivers/lora/cad/src/main.c
+++ b/samples/drivers/lora/cad/src/main.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * LoRa Channel Activity Detection (CAD) sample.
+ *
+ * Hold button 0 at boot for the sender role; default is scanner. The
+ * scanner reports how many of each window of CAD probes found the channel
+ * busy; the sender loads the channel with LBT transmissions.
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/lora.h>
+#include <zephyr/kernel.h>
+
+#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(lora_cad);
+
+#define DEFAULT_RADIO_NODE DT_ALIAS(lora0)
+BUILD_ASSERT(DT_NODE_HAS_STATUS_OKAY(DEFAULT_RADIO_NODE),
+	     "No default LoRa radio specified in DT");
+
+#define FREQUENCY 865100000
+#define BANDWIDTH BW_125_KHZ
+#define SPREADING_FACTOR SF_10
+#define CODING_RATE CR_4_5
+
+/* CAD detects preamble chirps, so a long preamble is easier to catch. */
+#define PREAMBLE_LEN 64
+
+#define TX_DATA_LEN 12
+#define SCAN_WINDOW 20
+#define TX_GAP_MS 50
+
+static struct k_poll_signal cad_done_signal;
+
+static void cad_cb(const struct device *dev, bool activity_detected,
+		   void *user_data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(user_data);
+
+	LOG_INF("Async CAD result: channel %s",
+		activity_detected ? "busy" : "clear");
+	k_poll_signal_raise(&cad_done_signal, activity_detected);
+}
+
+static int run_scanner(const struct device *lora_dev)
+{
+	struct lora_modem_config config = {
+		.frequency = FREQUENCY,
+		.bandwidth = BANDWIDTH,
+		.datarate = SPREADING_FACTOR,
+		.coding_rate = CODING_RATE,
+		.preamble_len = PREAMBLE_LEN,
+		.public_network = false,
+		.tx_power = 4,
+		.tx = false,
+		.cad = {
+			.symbol_num = LORA_CAD_SYMB_4,
+		},
+	};
+	struct k_poll_event event;
+	int busy = 0;
+	int probes = 0;
+	int ret;
+
+	ret = lora_config(lora_dev, &config);
+	if (ret < 0) {
+		LOG_ERR("LoRa config failed: %d", ret);
+		return ret;
+	}
+
+	LOG_INF("Scanner mode: probing channel with CAD");
+
+	LOG_INF("Asynchronous CAD probe");
+	k_poll_signal_init(&cad_done_signal);
+
+	ret = lora_cad_async(lora_dev, cad_cb, NULL);
+	if (ret < 0) {
+		LOG_ERR("lora_cad_async failed: %d", ret);
+		return ret;
+	}
+
+	k_poll_event_init(&event, K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY,
+			  &cad_done_signal);
+	k_poll(&event, 1, K_FOREVER);
+
+	LOG_INF("Continuous CAD scan");
+	for (;;) {
+		ret = lora_cad(lora_dev, K_SECONDS(1));
+		if (ret < 0) {
+			LOG_ERR("lora_cad failed: %d", ret);
+			return ret;
+		}
+
+		if (ret == 1) {
+			busy++;
+		}
+
+		if (++probes == SCAN_WINDOW) {
+			LOG_INF("channel busy on %d of last %d probes",
+				busy, SCAN_WINDOW);
+			busy = 0;
+			probes = 0;
+		}
+	}
+}
+
+static int run_sender(const struct device *lora_dev)
+{
+	struct lora_modem_config config = {
+		.frequency = FREQUENCY,
+		.bandwidth = BANDWIDTH,
+		.datarate = SPREADING_FACTOR,
+		.coding_rate = CODING_RATE,
+		.preamble_len = PREAMBLE_LEN,
+		.public_network = false,
+		.tx_power = 4,
+		.tx = true,
+		.cad = {
+			.mode = LORA_CAD_MODE_LBT,
+			.symbol_num = LORA_CAD_SYMB_4,
+		},
+	};
+	char data[TX_DATA_LEN] = {'l', 'o', 'r', 'a', ' ', 'c',
+				   'a', 'd', ' ', ' ', ' ', '0'};
+	int ret;
+
+	ret = lora_config(lora_dev, &config);
+	if (ret < 0) {
+		LOG_ERR("LoRa config failed: %d", ret);
+		return ret;
+	}
+
+	LOG_INF("Sender mode: Listen Before Talk enabled");
+
+	while (1) {
+		ret = lora_send(lora_dev, data, TX_DATA_LEN);
+		if (ret < 0 && ret != -EBUSY) {
+			LOG_ERR("LoRa send failed: %d", ret);
+			return ret;
+		}
+
+		if (ret == -EBUSY) {
+			LOG_WRN("Channel busy (LBT), skipping transmission");
+		} else {
+			LOG_INF("Sent packet %c", data[TX_DATA_LEN - 1]);
+
+			if (data[TX_DATA_LEN - 1] == '9') {
+				data[TX_DATA_LEN - 1] = '0';
+			} else {
+				data[TX_DATA_LEN - 1] += 1;
+			}
+		}
+
+		k_sleep(K_MSEC(TX_GAP_MS));
+	}
+
+	return 0;
+}
+
+static bool is_sender_mode(void)
+{
+#if DT_NODE_EXISTS(DT_ALIAS(sw0))
+	const struct gpio_dt_spec btn = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
+
+	if (!gpio_is_ready_dt(&btn)) {
+		return false;
+	}
+
+	gpio_pin_configure_dt(&btn, GPIO_INPUT);
+	k_sleep(K_MSEC(10));
+
+	return gpio_pin_get_dt(&btn) != 0;
+#else
+	return false;
+#endif
+}
+
+int main(void)
+{
+	const struct device *const lora_dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
+
+	if (!device_is_ready(lora_dev)) {
+		LOG_ERR("%s not ready", lora_dev->name);
+		return 0;
+	}
+
+	if (is_sender_mode()) {
+		return run_sender(lora_dev);
+	}
+
+	return run_scanner(lora_dev);
+}


### PR DESCRIPTION
Implement Channel Activity Detection on the native SX126x driver, tested on `nucleo_wl55jc` (`STM32WL`).