### PR TITLE
include: modem: document modem_cellular.h driver backend helpers

### DIFF
--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- /**
-  * @file
-  * @brief Internal macros and definitions for cellular modem drivers.
-  */
+/**
+ * @file modem_cellular.h
+ * @brief Backend helpers for implementing cellular modem drivers.
+ * @ingroup modem_cellular_backend
+ */
 
- #ifndef ZEPHYR_INCLUDE_DRIVERS_CELLULAR_INTERNAL_H_
- #define ZEPHYR_INCLUDE_DRIVERS_CELLULAR_INTERNAL_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CELLULAR_INTERNAL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CELLULAR_INTERNAL_H_
 
 #include <zephyr/drivers/cellular.h>
 #include <zephyr/modem/backend/uart.h>
@@ -24,25 +25,19 @@
 #include <zephyr/modem/ppp.h>
 #include <zephyr/sys/atomic.h>
 
-/**
- * @cond INTERNAL_HIDDEN
- *
- * For internal driver use only, skip these in public documentation.
- */
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @defgroup modem_cellular Definitions for cellular modem drivers
- *
- * This group contains internal definitions and macros for modem_cellular.c
- * These are exported into the header only to allow device macros to be exported,
- * these should not be used by external code.
- *
- *  @{
+ * @defgroup modem_cellular_backend Cellular modem helpers
+ * @brief Implement vendor-specific cellular modem drivers using common chat, CMUX, PPP, and
+ * power-management support.
+ * @in_driverbackendgroup{cellular_interface}
+ * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
 
 #define MODEM_CELLULAR_DATA_IMEI_LEN         (16)
 #define MODEM_CELLULAR_DATA_MODEL_ID_LEN     (65)
@@ -109,7 +104,18 @@ struct modem_cellular_event_cb {
 	void *user_data;
 };
 
+/** @endcond */
+
+/**
+ * @brief Runtime data for a cellular modem driver instance.
+ *
+ * Define one zero-initialized object per device instance. The object and all referenced
+ * configuration data must remain valid for the lifetime of the device. Set the documented
+ * configuration members before passing the object to @ref MODEM_CELLULAR_DEFINE_INSTANCE().
+ * The cellular modem implementation owns and updates all other members after device initialization.
+ */
 struct modem_cellular_data {
+	/** @cond INTERNAL_HIDDEN */
 	/* UART backend */
 	struct modem_pipe *uart_pipe;
 	struct modem_backend_uart uart_backend;
@@ -135,8 +141,23 @@ struct modem_cellular_data {
 	/* Modem chat */
 	struct modem_chat chat;
 	uint8_t chat_receive_buf[CONFIG_MODEM_CELLULAR_CHAT_BUFFER_SIZE];
+	/** @endcond */
+
+	/**
+	 * Command delimiter used by the modem, as a NULL-terminated string.
+	 *
+	 * Must not be NULL and must remain valid for the lifetime of the device.
+	 */
 	uint8_t *chat_delimiter;
+	/**
+	 * Characters filtered from modem responses, as a NULL-terminated string.
+	 *
+	 * May be NULL to disable filtering. A non-NULL string must remain valid for the lifetime of
+	 * the device.
+	 */
 	uint8_t *chat_filter;
+
+	/** @cond INTERNAL_HIDDEN */
 	uint8_t *chat_argv[32];
 	uint8_t script_failure_counter;
 
@@ -161,7 +182,12 @@ struct modem_cellular_data {
 	char apn_buf[MODEM_CELLULAR_MAX_APN_CMDS][MODEM_CELLULAR_APN_BUF_SIZE];
 
 	/* PPP */
+	/** @endcond */
+
+	/** PPP context used for the modem data connection. Must not be NULL. */
 	struct modem_ppp *ppp;
+
+	/** @cond INTERNAL_HIDDEN */
 	struct net_mgmt_event_callback net_mgmt_event_callback;
 
 	enum modem_cellular_state state;
@@ -186,7 +212,10 @@ struct modem_cellular_data {
 	atomic_t periodic_paused;
 	/** Set when a TIMEOUT is swallowed while paused; cleared on KICK. */
 	bool periodic_timeout_skipped;
+	/** @endcond */
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 struct modem_cellular_user_pipe {
 	struct modem_cmux_dlci dlci;
@@ -196,6 +225,8 @@ struct modem_cellular_user_pipe {
 	struct modem_pipe *pipe;
 	struct modem_pipelink *pipelink;
 };
+
+/** @endcond */
 
 /**
  * @brief Chat scripts for cellular modem.
@@ -211,30 +242,49 @@ struct modem_cellular_user_pipe {
  *
  */
 struct modem_cellular_config_scripts {
-	const struct modem_chat_script *set_baudrate; /**< script for setting the baudrate */
-	const struct modem_chat_script *init;         /**< script for initializing the CMUX */
-	const struct modem_chat_script *network;      /**< script for network registration */
-	const struct modem_chat_script *dial;         /**< script for starting the PPP data mode */
-	const struct modem_chat_script *periodic;     /**< script for periodic state polling */
-	const struct modem_chat_script *shutdown;     /**< script for shutting down the modem */
+	/** Optional script that configures the modem's UART baud rate. */
+	const struct modem_chat_script *set_baudrate;
+	/** Script that initializes the modem and enables CMUX. Must not be NULL. */
+	const struct modem_chat_script *init;
+	/** Optional script that waits for network registration before dialing. */
+	const struct modem_chat_script *network;
+	/** Script that starts the PPP data connection. Must not be NULL. */
+	const struct modem_chat_script *dial;
+	/** Optional script that periodically polls modem state while registered. */
+	const struct modem_chat_script *periodic;
+	/** Optional script that prepares the modem for power-off. */
+	const struct modem_chat_script *shutdown;
 };
 
 /**
- * @brief Vendor specific configuration that does not come from devicetree
+ * @brief Vendor-specific cellular modem configuration.
+ *
+ * Define one constant object for each modem variant. The referenced scripts and unsolicited-match
+ * array must remain valid for the lifetime of every device instance that uses this configuration.
  */
 struct modem_cellular_vendor_config {
+	/** Chat scripts implementing the modem lifecycle. */
 	struct modem_cellular_config_scripts scripts;
+	/** Unsolicited modem response matches. */
 	struct {
+		/** Array of unsolicited response matches, or NULL when @c size is zero. */
 		const struct modem_chat_match *matches;
+		/** Number of elements in @c matches. */
 		uint16_t size;
 	} unsol_matches;
+	/** Duration of the modem power-key pulse, in milliseconds. */
 	uint16_t power_pulse_duration_ms;
+	/** Duration of the modem reset pulse, in milliseconds. */
 	uint16_t reset_pulse_duration_ms;
+	/** Maximum modem startup delay, in milliseconds. */
 	uint16_t startup_time_ms;
+	/** Maximum modem shutdown delay, in milliseconds. */
 	uint16_t shutdown_time_ms;
-	/* Force the `autostart` property regardless of devicetree */
+	/** Force autostart regardless of the devicetree @c autostarts property. */
 	bool force_autostart;
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 struct modem_cellular_config {
 	const struct device *uart;
@@ -270,10 +320,6 @@ extern const struct cellular_driver_api modem_cellular_api;
 void modem_cellular_emit_event(struct modem_cellular_data *data, enum cellular_event evt,
 			       const void *payload);
 
-void modem_cellular_chat_callback_handler(struct modem_chat *chat,
-						 enum modem_chat_script_result result,
-						 void *user_data);
-
 void modem_cellular_chat_on_imei(struct modem_chat *chat, char **argv, uint16_t argc,
 				 void *user_data);
 void modem_cellular_chat_on_cgmm(struct modem_chat *chat, char **argv, uint16_t argc,
@@ -297,19 +343,43 @@ void modem_cellular_chat_on_cgev(struct modem_chat *chat, char **argv, uint16_t 
 void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, uint16_t argc,
 					void *user_data);
 
-/** @} */
+/** @endcond */
 
 /**
- * @defgroup modem_driver_macros Macros for defining cellular modem driver instances
+ * @brief Handle completion of a modem chat script.
  *
- * These macros are used for defining cellular modem driver instances.
- * See modem_cellular.c for usage examples.
+ * Use this as the callback for lifecycle scripts executed by the cellular modem state machine. The
+ * callback translates the chat result into the corresponding internal state-machine event.
+ *
+ * @param chat Chat instance that completed the script. Must not be NULL.
+ * @param result Script completion result.
+ * @param user_data Pointer to the associated @ref modem_cellular_data object. Must not be NULL.
+ */
+void modem_cellular_chat_callback_handler(struct modem_chat *chat,
+					  enum modem_chat_script_result result, void *user_data);
+
+/**
+ * @defgroup modem_driver_macros Cellular modem driver definition macros
+ * @brief Define device instances that use the cellular modem driver.
+ * @ingroup modem_cellular_backend
+ *
+ * See the cellular modem documentation for a complete out-of-tree driver example.
  *
  * @{
  */
 
+/**
+ * @brief Generate a unique C identifier for a modem instance object.
+ *
+ * @param name Base object name.
+ * @param inst Devicetree instance number.
+ *
+ * @return The generated C identifier.
+ */
 #define MODEM_CELLULAR_INST_NAME(name, inst) \
 	CONCAT(name, _, DT_DRV_COMPAT, inst)
+
+/** @cond INTERNAL_HIDDEN */
 
 #define MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(inst, name, size)                                     \
 	MODEM_PIPELINK_DT_INST_DEFINE(inst, name);                                                 \
@@ -349,9 +419,17 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 				      MODEM_CELLULAR_GET_PIPE_NAME_ARG _args,                      \
 				      MODEM_CELLULAR_GET_DLCI_ADDRESS_ARG _args)
 
-/*
- * Define and initialize user pipes dynamically
- * Takes an instance and pairs of (pipe name, DLCI address)
+/** @endcond */
+
+/**
+ * @brief Define additional CMUX user pipes for a modem instance.
+ *
+ * Each variadic argument is a parenthesized @c (name, dlci_address) pair. The macro defines the
+ * receive buffers, pipe links, and user-pipe array consumed by @ref MODEM_CELLULAR_DEFINE_INSTANCE.
+ * Invoke it once for each modem instance before invoking @ref MODEM_CELLULAR_DEFINE_INSTANCE.
+ *
+ * @param inst Devicetree instance number.
+ * @param ... One or more <tt>(name, dlci_address)</tt> pairs.
  */
 #define MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, ...)                                       \
 	FOR_EACH_FIXED_ARG(MODEM_CELLULAR_DEFINE_USER_PIPE_DATA_HELPER,                            \
@@ -362,7 +440,13 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 				   (,), inst, __VA_ARGS__)                                         \
 	);
 
-/* Define common chat matches for cellular modems to reduce copy-pasting */
+/**
+ * @brief Define common chat matches used by cellular modem scripts.
+ *
+ * Invoke this macro once at file scope. It defines matches for successful commands, common command
+ * failures, modem identity and signal queries, and PPP dial responses. The generated identifiers
+ * are intended for use in the modem's @ref modem_cellular_config_scripts.
+ */
 #define MODEM_CELLULAR_COMMON_CHAT_MATCHES()							   \
 	MODEM_CHAT_MATCH_DEFINE(ok_match, "OK", "", NULL);					   \
 	MODEM_CHAT_MATCHES_DEFINE(__maybe_unused allow_match,					   \
@@ -399,9 +483,11 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 				  MODEM_CHAT_MATCH("NO CARRIER", "", NULL),			   \
 				  MODEM_CHAT_MATCH("NO DIALTONE", "", NULL))
 
-/* Common URC match entries shared by every cellular modem driver.
- * Use as the body of a MODEM_CHAT_MATCHES_DEFINE() expansion so vendor
- * drivers can extend the table with their own vendor-specific URCs.
+/**
+ * @brief Expand to the common unsolicited response matches.
+ *
+ * Use this macro in the entry list passed to MODEM_CHAT_MATCHES_DEFINE().
+ * Vendor drivers may add additional entries after this expansion.
  */
 #define MODEM_CELLULAR_COMMON_UNSOL_MATCHES							   \
 	MODEM_CHAT_MATCH("+CREG: ", ",", modem_cellular_chat_on_cxreg),				   \
@@ -411,7 +497,17 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 	MODEM_CHAT_MATCH("APP RDY", "", modem_cellular_chat_on_modem_ready),			   \
 	MODEM_CHAT_MATCH("Ready", "", modem_cellular_chat_on_modem_ready)
 
-/* Helper to define modem instance */
+/**
+ * @brief Define a cellular modem device instance.
+ *
+ * This macro creates the immutable device configuration, power-management object, and Zephyr device
+ * for a devicetree instance. Before invoking it, define the instance's PPP object, initialize a
+ * @ref modem_cellular_data object, and invoke @ref MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES().
+ *
+ * @param inst Devicetree instance number.
+ * @param vendor_config Pointer to a constant @ref modem_cellular_vendor_config object. Must not be
+ *        NULL and must remain valid for the lifetime of the device.
+ */
 #define MODEM_CELLULAR_DEFINE_INSTANCE(inst, vendor_config)                                        \
 	BUILD_ASSERT(vendor_config != NULL, "vendor_config must be non-NULL");                     \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
@@ -451,10 +547,10 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 
 /** @} */
 
-/** @endcond */
+/** @} */
 
 /**
- * @addtogroup modem_cellular
+ * @addtogroup cellular_interface
  * @{
  */
 
@@ -466,11 +562,11 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
  * invocation at the time of this call is allowed to complete; suppression
  * takes effect from the next scheduled run.
  *
- * @param dev Cellular device instance backed by the cellular_modem driver
+ * @param dev Cellular device created with @ref MODEM_CELLULAR_DEFINE_INSTANCE(). Must not be NULL.
  *
- * @retval 0         Success
- * @retval -ENOTSUP  Device has no periodic chat script configured
- * @retval -EINVAL   Periodic script is already paused
+ * @retval 0 Success.
+ * @retval -ENOTSUP Device has no periodic chat script configured.
+ * @retval -EINVAL Periodic script is already paused.
  *
  * @see cellular_modem_resume_periodic_script
  */
@@ -483,11 +579,11 @@ int cellular_modem_pause_periodic_script(const struct device *dev);
  * skipped while paused, the script fires immediately; otherwise the
  * periodic timer restarts at the configured interval.
  *
- * @param dev Cellular device instance backed by the cellular_modem driver
+ * @param dev Cellular device created with @ref MODEM_CELLULAR_DEFINE_INSTANCE(). Must not be NULL.
  *
- * @retval 0         Success
- * @retval -ENOTSUP  Device has no periodic chat script configured
- * @retval -EINVAL   Periodic script is not currently paused
+ * @retval 0 Success.
+ * @retval -ENOTSUP Device has no periodic chat script configured.
+ * @retval -EINVAL Periodic script is not currently paused.
  *
  * @see cellular_modem_pause_periodic_script
  */


### PR DESCRIPTION
`modem_cellular.h` provides building blocks for implementing cellular modem drivers. Document its public API in the cellular driver backend section of the Doxygen docs instead of hiding it behind `@cond INTERNAL_HIDDEN`.

https://builds.zephyrproject.io/zephyr/pr/111639/docs/doxygen/html/group__modem__cellular__backend.html