### PR TITLE
eth: wch: fix link bug on CH32V307 and correctly initialise internal CH32V317 PHY

### DIFF
--- a/boards/muselab/nano_ch32v317/nano_ch32v317-pinctrl.dtsi
+++ b/boards/muselab/nano_ch32v317/nano_ch32v317-pinctrl.dtsi
@@ -21,11 +21,58 @@
 	};
 
 	mac_default: mac_default {
-		/* No pinmux needed for internal 100M PHY */
+		mac_internal_crsdv {
+			pinmux = <CH32V20X_V30X_PINMUX_DEFINE(PE, 9, ETH, 0)>;
+			bias-pull-up;
+		};
+
+		mac_internal_rxd0 {
+			pinmux = <CH32V20X_V30X_PINMUX_DEFINE(PE, 14, ETH, 0)>;
+			bias-pull-up;
+		};
+
+		mac_internal_rxd1 {
+			pinmux = <CH32V20X_V30X_PINMUX_DEFINE(PE, 13, ETH, 0)>;
+			bias-pull-up;
+		};
+
+		mac_internal_txen {
+			pinmux = <CH32V20X_V30X_PINMUX_DEFINE(PE, 8, ETH, 0)>;
+			output-high;
+			slew-rate = "max-speed-50mhz";
+		};
+
+		mac_internal_txc {
+			pinmux = <CH32V20X_V30X_PINMUX_DEFINE(PE, 12, ETH, 0)>;
+			output-high;
+			slew-rate = "max-speed-50mhz";
+		};
+
+		mac_internal_txd0 {
+			pinmux = <CH32V20X_V30X_PINMUX_DEFINE(PE, 11, ETH, 0)>;
+			output-high;
+			slew-rate = "max-speed-50mhz";
+		};
+
+		mac_internal_txd1 {
+			pinmux = <CH32V20X_V30X_PINMUX_DEFINE(PE, 10, ETH, 0)>;
+			output-high;
+			slew-rate = "max-speed-50mhz";
+		};
 	};
 
 	mdio_default: mdio_default {
-		/* No MDIO pinmux required for internal PHY */
+		mac_internal_mdc {
+			pinmux = <CH32V20X_V30X_PINMUX_DEFINE(PE, 15, ETH, 0)>;
+			output-high;
+			slew-rate = "max-speed-50mhz";
+		};
+
+		mac_internal_mdio {
+			pinmux = <CH32V20X_V30X_PINMUX_DEFINE(PD, 8, ETH, 0)>;
+			output-high;
+			slew-rate = "max-speed-50mhz";
+		};
 	};
 
 	pwm2_default: pwm2_default {

--- a/drivers/ethernet/eth_wch.c
+++ b/drivers/ethernet/eth_wch.c
@@ -393,12 +393,59 @@ static void eth_isr(const struct device *dev)
 	}
 }
 
-static int eth_wch_start(const struct device *dev, struct net_if *iface __unused)
+static int eth_mac_init(const struct device *dev)
 {
 	const struct eth_wch_config *config = dev->config;
 	ETH_TypeDef *eth = config->regs;
 
+	eth->DMABMR |= ETH_DMABMR_SR;
+	while ((eth->DMABMR & ETH_DMABMR_SR) != 0) {
+	}
+
+	/* Configure ethernet MAC */
+	eth->MACCR = 0x0;
+#if defined(CONFIG_ETH_WCH_HW_CHECKSUM)
+	eth->MACCR |= ETH_MACCR_IPCO;
+#endif /* defined(CONFIG_ETH_WCH_HW_CHECKSUM) */
+
+	eth->MACHTHR = 0x0;
+	eth->MACHTLR = 0x0;
+	eth->MACFCR = 0x0;
+	eth->MACVLANTR = 0x0;
+
+	eth->DMAOMR = ETH_DMAOMR_TSF | ETH_DMAOMR_FEF | ETH_DMAOMR_FUGF;
+
+	/* Disable unwanted MMC interrupts */
+	eth->MMCTIMR = ETH_MMCTIMR_TGFM;
+	eth->MMCRIMR = ETH_MMCRIMR_RGUFM | ETH_MMCRIMR_RFCEM;
+
+	eth->DMAIER =
+		(ETH_DMA_IT_NIS | ETH_DMA_IT_R | ETH_DMA_IT_T | ETH_DMA_IT_AIS | ETH_DMA_IT_RBU);
+
+	if (strcmp(config->connection_type, "internal") == 0) {
+		eth->MACCR |= ETH_MACCR_PR;
+		eth->DMAIER |= ETH_DMA_IT_PHYLINK;
+	}
+
+	init_tx_dma_desc(eth);
+	init_rx_dma_desc(eth);
+
+	return 0;
+}
+
+static int eth_wch_start(const struct device *dev, struct net_if *iface __unused)
+{
+	const struct eth_wch_config *config = dev->config;
+	struct eth_wch_data *data = dev->data;
+	ETH_TypeDef *eth = config->regs;
+
 	LOG_DBG("Starting ETH HAL driver");
+
+	/* DMA engine on WCH seems to handle disconnects differently to the
+	   equivalent ST peripheral. ETH_DMA reset on start seems to fix the issue */
+	eth_mac_init(dev);
+	set_mac_addr(config->regs, data->mac_addr, iface);
+	setup_mac_filter(config->regs);
 
 	eth->MACCR |= ETH_MACCR_TE | ETH_MACCR_RE;
 	eth->DMAOMR |= ETH_DMAOMR_FTF | ETH_DMAOMR_ST | ETH_DMAOMR_SR;
@@ -473,47 +520,6 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 	net_eth_carrier_set(data->iface, state->is_up);
 }
 
-static int eth_mac_init(const struct device *dev)
-{
-	const struct eth_wch_config *config = dev->config;
-	ETH_TypeDef *eth = config->regs;
-
-	eth->DMABMR |= ETH_DMABMR_SR;
-	while (eth->DMABMR & ETH_DMABMR_SR) {
-		;
-	}
-
-	/* Configure ethernet MAC */
-	eth->MACCR = 0x0;
-#if defined(CONFIG_ETH_WCH_HW_CHECKSUM)
-	eth->MACCR |= ETH_MACCR_IPCO;
-#endif /* defined(CONFIG_ETH_WCH_HW_CHECKSUM) */
-
-	eth->MACHTHR = 0x0;
-	eth->MACHTLR = 0x0;
-	eth->MACFCR = 0x0;
-	eth->MACVLANTR = 0x0;
-
-	eth->DMAOMR = ETH_DMAOMR_TSF | ETH_DMAOMR_FEF | ETH_DMAOMR_FUGF;
-
-	/* Disable unwanted MMC interrupts */
-	eth->MMCTIMR = ETH_MMCTIMR_TGFM;
-	eth->MMCRIMR = ETH_MMCRIMR_RGUFM | ETH_MMCRIMR_RFCEM;
-
-	eth->DMAIER =
-		(ETH_DMA_IT_NIS | ETH_DMA_IT_R | ETH_DMA_IT_T | ETH_DMA_IT_AIS | ETH_DMA_IT_RBU);
-
-	if (strcmp(config->connection_type, "internal") == 0) {
-		eth->MACCR |= ETH_MACCR_PR;
-		eth->DMAIER |= ETH_DMA_IT_PHYLINK;
-	}
-
-	init_tx_dma_desc(eth);
-	init_rx_dma_desc(eth);
-
-	return 0;
-}
-
 static void eth_wch_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
@@ -570,10 +576,8 @@ static enum ethernet_hw_caps eth_wch_get_capabilities(const struct device *dev _
 		;
 }
 
-static int eth_wch_set_config(const struct device *dev,
-			      struct net_if *iface __unused,
-			      enum ethernet_config_type type,
-			      const struct ethernet_config *config)
+static int eth_wch_set_config(const struct device *dev, struct net_if *iface __unused,
+			      enum ethernet_config_type type, const struct ethernet_config *config)
 {
 	struct eth_wch_data *data = dev->data;
 	const struct eth_wch_config *dev_config = dev->config;

--- a/drivers/ethernet/eth_wch.c
+++ b/drivers/ethernet/eth_wch.c
@@ -422,10 +422,12 @@ static int eth_mac_init(const struct device *dev)
 	eth->DMAIER =
 		(ETH_DMA_IT_NIS | ETH_DMA_IT_R | ETH_DMA_IT_T | ETH_DMA_IT_AIS | ETH_DMA_IT_RBU);
 
+#if defined(CONFIG_SOC_CH32V307)
 	if (strcmp(config->connection_type, "internal") == 0) {
 		eth->MACCR |= ETH_MACCR_PR;
 		eth->DMAIER |= ETH_DMA_IT_PHYLINK;
 	}
+#endif
 
 	init_tx_dma_desc(eth);
 	init_rx_dma_desc(eth);
@@ -441,8 +443,10 @@ static int eth_wch_start(const struct device *dev, struct net_if *iface __unused
 
 	LOG_DBG("Starting ETH HAL driver");
 
-	/* DMA engine on WCH seems to handle disconnects differently to the
-	   equivalent ST peripheral. ETH_DMA reset on start seems to fix the issue */
+	/*
+	 * DMA engine on WCH seems to handle disconnects differently to the
+	 * equivalent ST peripheral. ETH_DMA reset on start seems to fix the issue
+	 */
 	eth_mac_init(dev);
 	set_mac_addr(config->regs, data->mac_addr, iface);
 	setup_mac_filter(config->regs);
@@ -660,7 +664,12 @@ static int eth_wch_init(const struct device *dev)
 			;
 		}
 
+#if defined(CONFIG_SOC_CH32V317)
+		/* CH32V317 Internal PHY is internally on an RMII interface */
+		AFIO->PCFR1 |= AFIO_PCFR1_MII_RMII_SEL;
+#else
 		EXTEN->EXTEN_CTR |= EXTEN_ETH_10M_EN;
+#endif
 	} else if (strcmp(config->connection_type, "rmii") == 0) {
 		AFIO->PCFR1 |= AFIO_PCFR1_MII_RMII_SEL;
 	} else if (strcmp(config->connection_type, "rgmii") == 0) {

--- a/dts/riscv/wch/ch32v317/ch32v317.dtsi
+++ b/dts/riscv/wch/ch32v317/ch32v317.dtsi
@@ -21,8 +21,8 @@
 				compatible = "wch,ethernet";
 				interrupt-parent = <&pfic>;
 				interrupts = <77>, <78>;
-				internal-phy-pllmul = "15";
-				internal-phy-prediv = "2";
+				internal-phy-pllmul = "12.5";
+				internal-phy-prediv = "1";
 				status = "disabled";
 			};
 


### PR DESCRIPTION
Draft PR with minor fixups for Ethernet WCH: as follows.

- **All CH32 Ethernet:** There seems to be a hardware quirk where the DMA engine occasionally drops packets following the PHY link status change. The most reliable fix seems to be to just reset the DMA engine when the PHY status changes.
- **CH32V317**: The CH32V317 Internal PHY is secretly an RMII PHY on reserved pins. Driver update now correctly initialises.

The CH32V317 internal PHY still seems quite unstable (the WCH example code does a cryptic set of configuration writes to undocumented PHY registers, which I suspect may be to tune out a hardware timing bug).
Until I have this resolved, I'll keep this as draft, but if anyone is developing on the CH32V307 Internal PHY I'd recommend applying this branch as a patch.
