### PR TITLE
drivers/adc/adc_shell: support >16bit adcs.

### DIFF
--- a/drivers/adc/adc_shell.c
+++ b/drivers/adc/adc_shell.c
@@ -391,7 +391,7 @@ static int cmd_adc_read(const struct shell *sh, size_t argc, char **argv)
 	uint8_t adc_channel_id = strtol(argv[1], NULL, 10);
 	/* -1 index of adc label name */
 	struct adc_hdl *adc = get_adc(argv[-1]);
-	int16_t m_sample_buffer[BUFFER_SIZE];
+	int32_t m_sample_buffer[BUFFER_SIZE];
 	int retval;
 
 	if (!device_is_ready(adc->dev)) {


### PR DESCRIPTION
The adc read shell utility only passed a single 16bit value as the buffer.  This precludes any driver for 24/32 bit ADCs from using the ADC shell utilities.

The extra two bytes of stack ram used seems a fair tradeoff if you're already using the adc shell.