### PR TITLE
soc: espressif: esp32c5/c6/h2/p4 fix lp clock power and apm access-path init

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -285,6 +285,32 @@ static int esp32_select_rtc_slow_clk(uint8_t slow_clk)
 #endif
 		rtc_clk_slow_src_set(rtc_slow_clk_src);
 
+#if defined(CONFIG_SOC_SERIES_ESP32C5) || defined(CONFIG_SOC_SERIES_ESP32C6) ||                    \
+	defined(CONFIG_SOC_SERIES_ESP32H2) || defined(CONFIG_SOC_SERIES_ESP32P4)
+		/*
+		 * The source enums differ per SoC (ESP32-C5 has no RC32K,
+		 * ESP32-P4 has no OSC_SLOW), so each term is computed under the
+		 * SoC guard where its enum exists.
+		 */
+		bool xpd_xtal32k = (rtc_slow_clk_src == ESP32_RTC_SLOW_CLK_SRC_XTAL32K);
+		bool xpd_rc32k = false;
+
+#if !defined(CONFIG_SOC_SERIES_ESP32P4)
+		xpd_xtal32k |= (rtc_slow_clk_src == SOC_RTC_SLOW_CLK_SRC_OSC_SLOW);
+#endif
+#if !defined(CONFIG_SOC_SERIES_ESP32C5)
+		xpd_rc32k = (rtc_slow_clk_src == SOC_RTC_SLOW_CLK_SRC_RC32K);
+#endif
+
+		pmu_lp_power_t lp_clk_power = {
+			.xpd_xtal32k = xpd_xtal32k,
+			.xpd_rc32k = xpd_rc32k,
+			.xpd_fosc = 1,
+			.pd_osc = 0,
+		};
+		pmu_ll_lp_set_clk_power(&PMU, PMU_MODE_LP_ACTIVE, lp_clk_power.val);
+#endif
+
 		if (CONFIG_CLOCK_CONTROL_ESP32_RTC_CLK_CAL_CYCLES > 0) {
 			cal_val = rtc_clk_cal(CLK_CAL_RTC_SLOW,
 					      CONFIG_CLOCK_CONTROL_ESP32_RTC_CLK_CAL_CYCLES);

--- a/soc/espressif/esp32c5/hpcore_init_ulp.c
+++ b/soc/espressif/esp32c5/hpcore_init_ulp.c
@@ -12,8 +12,6 @@
 #include "ulp_lp_core.h"
 #include "ulp_lp_core_memory_shared.h"
 #include <esp_sleep.h>
-#include <hal/lp_core_ll.h>
-#include <esp_private/esp_pmu.h>
 
 LOG_MODULE_REGISTER(lp_core_loader, CONFIG_KERNEL_LOG_LEVEL);
 
@@ -59,18 +57,7 @@ void IRAM_ATTR lp_core_image_init(void)
 #endif
 	};
 
-	/*
-	 * pmu_init() is never called in Zephyr (skipped due to
-	 * CONFIG_BOOTLOADER_MCUBOOT). Call it here to configure
-	 * PMU power parameters needed for LP->HP wakeup.
-	 */
-	pmu_init();
-
 	ulp_lp_core_run(&cfg);
-
-	/* Disable stall/reset so LP core survives HP deep sleep */
-	lp_core_ll_stall_at_sleep_request(false);
-	lp_core_ll_rst_at_sleep_enable(false);
 }
 
 void soc_late_init_hook(void)

--- a/soc/espressif/esp32c5/hw_init.c
+++ b/soc/espressif/esp32c5/hw_init.c
@@ -14,10 +14,8 @@
 #include <hal/mmu_hal.h>
 #include <hal/mmu_ll.h>
 
-#include <soc/hp_apm_reg.h>
-#include <soc/lp_apm_reg.h>
-#include <soc/lp_apm0_reg.h>
 #include <soc/pcr_reg.h>
+#include <hal/apm_ll.h>
 
 #include <bootloader_clock.h>
 #include <bootloader_flash.h>
@@ -41,9 +39,24 @@ int hardware_init(void)
 	ana_reset_config();
 	super_wdt_auto_feed();
 
-	REG_WRITE(LP_APM_FUNC_CTRL_REG, 0);
-	REG_WRITE(LP_APM0_FUNC_CTRL_REG, 0);
-	REG_WRITE(HP_APM_FUNC_CTRL_REG, 0);
+	/*
+	 * The APM access-path filters default to enabled and only allow
+	 * masters in TEE mode. Disable them so the application (which runs in
+	 * REE mode) is not denied access to peripherals.
+	 */
+	apm_ll_hp_apm_enable_ctrl_filter_all(false);
+	apm_ll_lp_apm_enable_ctrl_filter_all(false);
+	apm_ll_lp_apm0_enable_ctrl_filter_all(false);
+
+	/*
+	 * On power-up only the HP CPU starts in TEE mode; the LP CPU defaults
+	 * to REE2. The TEE controller grants access to the PMU and LP_AON
+	 * peripherals to TEE mode only, so LP-core accesses to that window are
+	 * silently dropped, breaking the LP->HP wakeup path. Put both cores in
+	 * TEE mode to match the access-control configuration.
+	 */
+	apm_ll_hp_tee_set_master_sec_mode(APM_MASTER_HPCORE, APM_SEC_MODE_TEE);
+	apm_ll_lp_tee_set_master_sec_mode(APM_MASTER_LPCORE, APM_SEC_MODE_TEE);
 
 	/*
 	 * Configure PMA (Physical Memory Attributes) entries to replace

--- a/soc/espressif/esp32c6/hw_init.c
+++ b/soc/espressif/esp32c6/hw_init.c
@@ -14,10 +14,8 @@
 #include <hal/mmu_hal.h>
 #include <hal/mmu_ll.h>
 
-#include <soc/hp_apm_reg.h>
-#include <soc/lp_apm_reg.h>
-#include <soc/lp_apm0_reg.h>
 #include <soc/pcr_reg.h>
+#include <hal/apm_ll.h>
 
 #include <bootloader_clock.h>
 #include <bootloader_flash.h>
@@ -47,9 +45,9 @@ int hardware_init(void)
 	 * So, at boot disabling these filters. They will enable as per the
 	 * use case by TEE initialization code.
 	 */
-	REG_WRITE(LP_APM_FUNC_CTRL_REG, 0);
-	REG_WRITE(LP_APM0_FUNC_CTRL_REG, 0);
-	REG_WRITE(HP_APM_FUNC_CTRL_REG, 0);
+	apm_ll_hp_apm_enable_ctrl_filter_all(false);
+	apm_ll_lp_apm_enable_ctrl_filter_all(false);
+	apm_ll_lp_apm0_enable_ctrl_filter_all(false);
 
 #ifdef CONFIG_BOOTLOADER_REGION_PROTECTION_ENABLE
 	esp_cpu_configure_region_protection();

--- a/soc/espressif/esp32h2/hw_init.c
+++ b/soc/espressif/esp32h2/hw_init.c
@@ -14,10 +14,8 @@
 #include <hal/mmu_hal.h>
 #include <hal/mmu_ll.h>
 
-#include <soc/hp_apm_reg.h>
-#include <soc/lp_apm_reg.h>
-#include <soc/lp_apm0_reg.h>
 #include <soc/pcr_reg.h>
+#include <hal/apm_ll.h>
 
 #include <bootloader_clock.h>
 #include <bootloader_flash.h>
@@ -40,9 +38,14 @@ int hardware_init(void)
 	ana_reset_config();
 	super_wdt_auto_feed();
 
-	REG_WRITE(LP_APM_FUNC_CTRL_REG, 0);
-	REG_WRITE(LP_APM0_FUNC_CTRL_REG, 0);
-	REG_WRITE(HP_APM_FUNC_CTRL_REG, 0);
+	/*
+	 * The APM access-path filters default to enabled and only allow
+	 * masters in TEE mode. Disable them so the application (which runs in
+	 * REE mode) is not denied access to peripherals. The ESP32-H2 has no
+	 * LP_APM0 controller.
+	 */
+	apm_ll_hp_apm_enable_ctrl_filter_all(false);
+	apm_ll_lp_apm_enable_ctrl_filter_all(false);
 
 #ifdef CONFIG_BOOTLOADER_REGION_PROTECTION_ENABLE
 	esp_cpu_configure_region_protection();


### PR DESCRIPTION
Re-narrow the LP clock power to the selected slow-clock source after init on
c5/c6/h2/p4, and clear the APM access-path filters via the apm_ll helpers, with
c5 also placing both cores in TEE mode for the LP->HP wakeup path.