### PR TITLE
wch: ch32v20x: Set clock default to full 144 MHz

### DIFF
--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -12,7 +12,7 @@
 };
 
 &pll {
-	mul = <15>;
+	mul = <18>;
 };
 
 &sram0 {
@@ -25,5 +25,5 @@
 };
 
 &cpu0 {
-	clock-frequency = <DT_FREQ_M(120)>;
+	clock-frequency = <DT_FREQ_M(144)>;
 };


### PR DESCRIPTION
This commit sets the `wch` default clock to its full speed of 144 MHz. This is not an overclock.

This goes back to the original PR (#87490) where the defaults are set to run the CPU at 120 MHz. There is no obvious reason to me to not use the maximum (non-overclock) 144 MHz. I could not find any previous discussion about it. Please let me know if there are known caveats with running at that speed on this MCU.