### PR TITLE
wch: ch32: Remove redundant HSE clock frequency

### DIFF
--- a/boards/muselab/nano_ch32v317/nano_ch32v317_common.dtsi
+++ b/boards/muselab/nano_ch32v317/nano_ch32v317_common.dtsi
@@ -35,6 +35,7 @@
 
 &clk_hse {
 	status = "okay";
+	clock-frequency = <DT_FREQ_M(8)>;
 };
 
 &pll {

--- a/boards/wch/ch32v305f_evt_r0/ch32v305f_evt_r0.dts
+++ b/boards/wch/ch32v305f_evt_r0/ch32v305f_evt_r0.dts
@@ -47,6 +47,7 @@
 
 &clk_hse {
 	status = "okay";
+	clock-frequency = <DT_FREQ_M(8)>;
 };
 
 &pll {

--- a/boards/wch/ch32v307v_evt_r1/ch32v307v_evt_r1_common.dtsi
+++ b/boards/wch/ch32v307v_evt_r1/ch32v307v_evt_r1_common.dtsi
@@ -57,6 +57,7 @@
 
 &clk_hse {
 	status = "okay";
+	clock-frequency = <DT_FREQ_M(8)>;
 };
 
 &pll {

--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -7,10 +7,6 @@
 #include <wch/qingke-v4b.dtsi>
 #include <wch/common/ch32v20x_30x_common.dtsi>
 
-&clk_hse {
-	clock-frequency = <DT_FREQ_M(8)>;
-};
-
 &pll {
 	mul = <15>;
 };

--- a/dts/riscv/wch/ch32v305/ch32v305.dtsi
+++ b/dts/riscv/wch/ch32v305/ch32v305.dtsi
@@ -91,10 +91,6 @@
 	};
 };
 
-&clk_hse {
-	clock-frequency = <DT_FREQ_M(8)>;
-};
-
 &pll {
 	mul = <18>;
 };

--- a/dts/riscv/wch/ch32v307/ch32v307.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307.dtsi
@@ -143,10 +143,6 @@
 	};
 };
 
-&clk_hse {
-	clock-frequency = <DT_FREQ_M(8)>;
-};
-
 &pll {
 	mul = <18>;
 };

--- a/dts/riscv/wch/ch32v317/ch32v317.dtsi
+++ b/dts/riscv/wch/ch32v317/ch32v317.dtsi
@@ -143,10 +143,6 @@
 	};
 };
 
-&clk_hse {
-	clock-frequency = <DT_FREQ_M(8)>;
-};
-
 &pll {
 	mul = <18>;
 };


### PR DESCRIPTION
This PR removes a redundant HSE clock frequency definition for wch. This value is really dependent on the component placed on a board (not the soc), so two layers of default are not necessary. If this is a common Zephyr convention, then please close this PR.

It is already present in (which is included by the file modified in this PR):
https://github.com/zephyrproject-rtos/zephyr/blob/8d2af84f9619b39bba090ee3a3e6d41984969a3c/dts/riscv/wch/common/ch32v20x_30x_common.dtsi#L20-L25