### PR TITLE
drivers: i2s_mcux_flexcomm: Fix the TX path

### DIFF
--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -63,6 +63,7 @@ struct i2s_mcux_data {
 	struct i2s_mcux_q_entry tx_in_msgs[CONFIG_I2S_MCUX_FLEXCOMM_TX_BLOCK_COUNT];
 	void *tx_out_msgs[CONFIG_I2S_MCUX_FLEXCOMM_TX_BLOCK_COUNT];
 	struct dma_block_config tx_dma_blocks[NUM_DMA_BLOCKS];
+	bool waiting_txdata;
 };
 
 static int i2s_mcux_flexcomm_cfg_convert(uint32_t base_frequency,
@@ -622,6 +623,19 @@ static int i2s_mcux_tx_stream_start(const struct device *dev)
 	I2S_Type *base = cfg->base;
 	struct i2s_mcux_q_entry queue_entry[NUM_DMA_BLOCKS] = { 0 };
 
+	/* Wait for 2 buffer writes before transmitting as the DMA channel will fail after
+	 * transferring one block if the next block is NULL.
+	 * However if the stream is in STOPPING state then send data immediately.
+	 */
+	if ((k_msgq_num_used_get(&stream->in_queue) == 1) &&
+		(stream->state != I2S_STATE_STOPPING)) {
+		dev_data->waiting_txdata = 1;
+		return ret;
+	}
+
+	/* Clear as we have at least 2 blocks of data to write or stream is in STOPPING state */
+	dev_data->waiting_txdata = 0;
+
 	for (int i = 0;
 	     i < NUM_DMA_BLOCKS && k_msgq_num_used_get(&stream->in_queue);
 	     i++) {
@@ -771,6 +785,10 @@ static int i2s_mcux_trigger(const struct device *dev, enum i2s_dir dir,
 		}
 		stream->state = I2S_STATE_STOPPING;
 		stream->last_block = true;
+		/* Start TX if waiting for a second block to be written. */
+		if (dev_data->waiting_txdata) {
+			ret = i2s_mcux_tx_stream_start(dev);
+		}
 		break;
 
 	case I2S_TRIGGER_DRAIN:
@@ -780,6 +798,10 @@ static int i2s_mcux_trigger(const struct device *dev, enum i2s_dir dir,
 			break;
 		}
 		stream->state = I2S_STATE_STOPPING;
+		/* Start TX if waiting for a second block to be written. */
+		if (dev_data->waiting_txdata) {
+			ret = i2s_mcux_tx_stream_start(dev);
+		}
 		break;
 
 	case I2S_TRIGGER_DROP:
@@ -874,6 +896,10 @@ static int i2s_mcux_write(const struct device *dev, void *mem_block,
 		return ret;
 	}
 
+	/* Start the stream if it was waiting for more data to be written */
+	if (dev_data->waiting_txdata) {
+		i2s_mcux_tx_stream_start(dev);
+	}
 	return ret;
 }
 

--- a/samples/drivers/i2s/output/boards/rd_rw612_bga.overlay
+++ b/samples/drivers/i2s/output/boards/rd_rw612_bga.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		i2s-tx = &flexcomm1;
+	};
+};
+
+&flexcomm1 {
+	compatible = "nxp,lpc-i2s";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&pinmux_flexcomm1_i2s>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
The TX path was broken if we did not prefill the TX queue with more than one block. This is because the TX DMA was queueing a NULL block causing DMA failures after transfer of the first block. Added logic to wait for at least 2 blocks before starting a transmit.
