### PR TITLE
kernel: sched: ready unpended threads unconditionally in *unpend_all

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -773,14 +773,13 @@ int z_unpend_all(_wait_q_t *wait_q)
 
 	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
 		unpend_thread_no_timeout(thread);
-		/* On -EAGAIN the handler is in flight on another CPU; it is
-		 * blocked on _sched_spinlock and will ready the thread itself
-		 * once we drop the lock. The thread is already unpended, so
-		 * the handler's wake path is harmless.
+		/* Abort the timeout and ready the thread unconditionally. If
+		 * the timeout handler is in flight on another CPU, the abort
+		 * flags it superseded and z_thread_timeout() bails when it
+		 * runs -- so it will NOT ready the thread, we must.
 		 */
-		if (z_try_abort_thread_timeout(thread) != -EAGAIN) {
-			ready_thread(thread);
-		}
+		(void)z_try_abort_thread_timeout(thread);
+		ready_thread(thread);
 		need_sched = 1;
 	}
 
@@ -795,13 +794,11 @@ static inline void unpend_all(_wait_q_t *wait_q)
 	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
 		unpend_thread_no_timeout(thread);
 		arch_thread_return_value_set(thread, 0);
-		/* See z_unpend_all() for the -EAGAIN rationale. The return
-		 * value is set above, so an in-flight handler that later
-		 * readies this thread does not overwrite it.
+		/* See z_unpend_all(): the in-flight handler bails on the
+		 * superseded mark, so we ready the thread unconditionally.
 		 */
-		if (z_try_abort_thread_timeout(thread) != -EAGAIN) {
-			ready_thread(thread);
-		}
+		(void)z_try_abort_thread_timeout(thread);
+		ready_thread(thread);
 	}
 }
 


### PR DESCRIPTION
`z_unpend_all()` and `unpend_all()` skip readying a woken thread when
`z_try_abort_thread_timeout()` returns `-EAGAIN`, on the assumption that
an in-flight timeout handler on another CPU will ready the thread itself
once the scheduler lock is dropped.

That assumption no longer holds after the timeout-abort rework
(#109977). `z_thread_timeout()` now bails out when it observes the
timeout has been marked superseded, and `z_try_abort_thread_timeout()`
sets exactly that superseded mark on the `-EAGAIN` path. So on SMP, when
a waiter's timeout fires on one CPU at the same moment `*unpend_all()`
processes it on another:

- `*unpend_all()` unpends the thread and, seeing `-EAGAIN`, does NOT
  ready it.
- the in-flight `z_thread_timeout()` finds the timeout superseded and
  bails, so it does NOT ready it either.

The thread ends up off every wait queue and on no run queue: orphaned,
with no remaining wake source. `k_heap` / `sys_mempool` waiters with a
finite timeout are the reachable callers.

Fix: ready the thread unconditionally after aborting its timeout, the
same idiom `z_unpend_first_thread_locked()` and `kernel/events.c`
already use. The abort still marks the in-flight handler superseded so
it bails and cannot double-wake; `ready_thread()` is idempotent
regardless, and a thread the handler already woke has been unpended and
so is not revisited by `*unpend_all()`.

Manifests only on SMP with `CONFIG_SYS_CLOCK_EXISTS` and a timeout
expiring concurrently with the wake, which the test suite does not force.