### PR TITLE
dts: nxp: mcx: move shared Nx4x nodes to family common dtsi

### DIFF
--- a/dts/arm/nxp/mcx/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn94x_common.dtsi
@@ -7,10 +7,6 @@
 #include "nxp_mcxnx4x_common.dtsi"
 
 / {
-	chosen {
-		zephyr,entropy = &trng;
-	};
-
 	soc {
 		compatible = "nxp,mcxn94x", "nxp,mcx", "simple-bus";
 	};
@@ -128,15 +124,5 @@
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		number-of-mb = <32>;
 		status = "disabled";
-	};
-
-	crypto@54000 {
-		compatible = "nxp,els";
-		reg = <0x54000 0x200>;
-		clocks = <&syscon MCUX_ELS_CLK>;
-
-		trng: rng {
-			compatible = "nxp,els-trng";
-		};
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -14,6 +14,10 @@
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
 / {
+	chosen {
+		zephyr,entropy = &trng;
+	};
+
 	cpus: cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -1356,6 +1360,16 @@
 		interrupts = <101 0>;
 		clocks = <&syscon MCUX_TSI_CLK>;
 		status = "disabled";
+	};
+
+	crypto@54000 {
+		compatible = "nxp,els";
+		reg = <0x54000 0x200>;
+		clocks = <&syscon MCUX_ELS_CLK>;
+
+		trng: rng {
+			compatible = "nxp,els-trng";
+		};
 	};
 };
 

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -14,6 +14,10 @@
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
 / {
+	chosen {
+		zephyr,entropy = &trng;
+	};
+
 	cpus: cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -1166,6 +1170,14 @@
 		status = "disabled";
 	};
 
+	tsi0: tsi@50000 {
+		compatible = "nxp,tsi-input";
+		reg = <0x50000 0x1000>;
+		interrupts = <101 0>;
+		clocks = <&syscon MCUX_TSI_CLK>;
+		status = "disabled";
+	};
+
 	lptmr0: lptmr@4a000 {
 		compatible = "nxp,lptmr";
 		reg = <0x4a000 0x1000>;
@@ -1356,6 +1368,16 @@
 		interrupts = <101 0>;
 		clocks = <&syscon MCUX_TSI_CLK>;
 		status = "disabled";
+	};
+
+	crypto@54000 {
+		compatible = "nxp,els";
+		reg = <0x54000 0x200>;
+		clocks = <&syscon MCUX_ELS_CLK>;
+
+		trng: rng {
+			compatible = "nxp,els-trng";
+		};
 	};
 };
 


### PR DESCRIPTION
Move nodes that are not specific to MCXN94x from the SoC-specific DTSI into the MCXNx4x family common DTSI.

Relocate the entropy chosen node, TSI node and ELS/TRNG crypto block to the family-level include so all MCXNx4x derivatives can reuse the same baseline description.