### PR TITLE
include: dt-bindings: reset: add doxygen for rp2040 and rp2350 reset headers

### DIFF
--- a/include/zephyr/dt-bindings/reset/rp2040_reset.h
+++ b/include/zephyr/dt-bindings/reset/rp2040_reset.h
@@ -4,8 +4,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for Raspberry Pi RP2040
+ * @ingroup reset_controller_raspberrypi_rp2040
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_RP2040_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_RP2040_RESET_H_
+
+/**
+ * @defgroup reset_controller_raspberrypi_rp2040 Raspberry Pi RP2040 reset controller helpers
+ * @brief Peripheral reset-cell identifiers for RP2040 SoC.
+ * @ingroup reset_controller_interface
+ *
+ * Devicetree macros for peripheral reset cells on Raspberry Pi RP2040 devices, for use with the
+ * <tt>raspberrypi,pico-reset</tt> compatible reset controller.
+ *
+ * Reset identifiers follow the pattern @c RPI_PICO_RESETS_RESET_\<PERIPHERAL\>, where
+ * @c \<PERIPHERAL\> is an RP2040 peripheral name (for example, @c RPI_PICO_RESETS_RESET_UART0
+ * resets UART0). Each identifier is the bit position of the peripheral in the RP2040 RESETS
+ * registers. Pass these identifiers directly to a @c resets property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/reset/rp2040_reset.h>
+ *
+ * &uart0 {
+ *         // ...
+ *         resets = <&reset RPI_PICO_RESETS_RESET_UART0>;
+ *         // ...
+ * };
+ * @endcode
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 #define RPI_PICO_RESETS_RESET_ADC        0
 #define RPI_PICO_RESETS_RESET_BUSCTRL    1
@@ -32,5 +65,9 @@
 #define RPI_PICO_RESETS_RESET_UART0      22
 #define RPI_PICO_RESETS_RESET_UART1      23
 #define RPI_PICO_RESETS_RESET_USBCTRL    24
+
+/** @endcond */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_RP2040_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/rp2350_reset.h
+++ b/include/zephyr/dt-bindings/reset/rp2350_reset.h
@@ -4,8 +4,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for Raspberry Pi RP2350
+ * @ingroup reset_controller_raspberrypi_rp2350
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_RP2350_RESET_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_RP2350_RESET_H_
+
+/**
+ * @defgroup reset_controller_raspberrypi_rp2350 Raspberry Pi RP2350 reset controller helpers
+ * @brief Peripheral reset-cell identifiers for RP2350 SoC.
+ * @ingroup reset_controller_interface
+ *
+ * Devicetree macros for peripheral reset cells on Raspberry Pi RP2350 devices, for use with the
+ * <tt>raspberrypi,pico-reset</tt> compatible reset controller.
+ *
+ * Reset identifiers follow the pattern @c RPI_PICO_RESETS_RESET_\<PERIPHERAL\>, where
+ * @c \<PERIPHERAL\> is an RP2350 peripheral name (for example, @c RPI_PICO_RESETS_RESET_UART0
+ * resets UART0). Each identifier is the bit position of the peripheral in the RP2350 RESETS
+ * registers. Pass these identifiers directly to a @c resets property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/reset/rp2350_reset.h>
+ *
+ * &uart0 {
+ *         // ...
+ *         resets = <&reset RPI_PICO_RESETS_RESET_UART0>;
+ *         // ...
+ * };
+ * @endcode
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 #define RPI_PICO_RESETS_RESET_ADC        0
 #define RPI_PICO_RESETS_RESET_BUSCTRL    1
@@ -36,5 +69,9 @@
 #define RPI_PICO_RESETS_RESET_UART0      26
 #define RPI_PICO_RESETS_RESET_UART1      27
 #define RPI_PICO_RESETS_RESET_USBCTRL    28
+
+/** @endcond */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_RP2350_RESET_H_ */


### PR DESCRIPTION
Add doxygen comments to the rp2040 and rp2350 reset headers.

- https://builds.zephyrproject.io/zephyr/pr/111660/docs/doxygen/html/group__reset__controller__raspberrypi__rp2350.html
- https://builds.zephyrproject.io/zephyr/pr/111660/docs/doxygen/html/group__reset__controller__raspberrypi__rp2040.html