### PR TITLE
drivers: otp: stm32: Init OTP NVM after flash init

### DIFF
--- a/drivers/otp/otp_nvm_stm32.c
+++ b/drivers/otp/otp_nvm_stm32.c
@@ -128,7 +128,7 @@ static DEVICE_API(otp, otp_stm32_nvm_api) = {
 	};											\
 												\
 	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, &_cfg,					\
-			      PRE_KERNEL_1, CONFIG_OTP_INIT_PRIORITY, &otp_stm32_nvm_api);
+			      POST_KERNEL, CONFIG_OTP_INIT_PRIORITY, &otp_stm32_nvm_api);
 
 #define OTP_STM32_NVM_INIT(inst)								\
 	OTP_STM32_NVM_INIT_INNER(inst, CONCAT(otp_stm32_nvm_cfg, inst))


### PR DESCRIPTION
On STM32, flash is init in POST_KERNEL stage. 
OTP is defined in flash DTS node. 
When using STM32 OTP driver for NVM, it should be init after flash controller.

Without this change, we can have this kind of error when `CONFIG_CHECK_INIT_PRIORITIES=y`
```
ERROR: Device initialization priority validation failed, the sequence of initialization calls does not match the devicetree dependencies.
ERROR: /soc/flash-controller@52002000/flash@8fff800 <NULL> is initialized before its dependency /soc/flash-controller@52002000 <stm32h7_flash_init> (PRE_KERNEL_1+27 < POST_KERNEL+10)
```

Feel free if I've missed something or if you have a better solution. If merging this fix, should we also align the bsec stm32 OTP driver initialization ?