### PR TITLE
drivers: mspi: update TMOD register handling for nrf-mspi

### DIFF
--- a/drivers/mspi/mspi_dw_vendor_specific.h
+++ b/drivers/mspi/mspi_dw_vendor_specific.h
@@ -255,15 +255,12 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 		joblist[job_idx] = EVDMA_NULL_JOB();
 		/* rx_job is always EVDMA_NULL_JOB() for transmit */
 		transfer_list->rx_job = &joblist[job_idx];
-		preg->TMOD = MSPI_TMOD_TMOD_TXONLY;
 	} else {
 		preg->CONFIG.RXTRANSFERLENGTH = ((packet->num_bytes) >>
 						dev_data->bytes_per_frame_exp);
 
 		/* If sending address or command while being configured as controller */
 		if (job_idx > 0 && config->op_mode == MSPI_OP_MODE_CONTROLLER) {
-			preg->TMOD = MSPI_TMOD_TMOD_TXANDRX;
-
 			/* After command and address, setup RX job for data */
 			joblist[job_idx++] = EVDMA_NULL_JOB();
 			transfer_list->rx_job = &joblist[job_idx];
@@ -272,14 +269,18 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 			joblist[job_idx]   = EVDMA_NULL_JOB();
 		} else {
 			/* Sending command or address while configured as target isn't supported */
-			preg->TMOD = MSPI_TMOD_TMOD_RXONLY;
-
 			transfer_list->rx_job = &joblist[0];
 			joblist[0] = EVDMA_JOB(packet->data_buf, packet->num_bytes,
 					       EVDMA_PLAIN_DATA);
 			joblist[1] = EVDMA_NULL_JOB();
 			transfer_list->tx_job = &joblist[1];
 		}
+	}
+
+	/* The wrapper's TMOD register is only used in peripheral mode */
+	if (config->op_mode == MSPI_OP_MODE_PERIPHERAL) {
+		preg->TMOD = (packet->dir == MSPI_TX) ? MSPI_TMOD_TMOD_TXONLY
+						      : MSPI_TMOD_TMOD_RXONLY;
 	}
 
 	/* The wrapper uses formatting registers regardless of whether it is driving a display


### PR DESCRIPTION
There is an upcoming MDK change to remove MSPI_TMOD_TMOD_TXANDRX due to it being redundant. The wrapper TMOD register only needs to be set in peripheral mode.