### PR TITLE
include: dt-bindings: reset: doxygen for numaker reset headers

### DIFF
--- a/include/zephyr/dt-bindings/reset/numaker_m031x_reset.h
+++ b/include/zephyr/dt-bindings/reset/numaker_m031x_reset.h
@@ -4,21 +4,49 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for Nuvoton NuMaker M031X
+ * @ingroup reset_controller_nuvoton_m031x
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M031X_RESET_H
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M031X_RESET_H
 
 /**
- * @file
- * @brief Reset module IDs for Nuvoton M031X
- * @ingroup reset_controller_nuvoton_m031x
+ * @addtogroup reset_controller_numaker Nuvoton NuMaker reset controller helpers
+ * @ingroup reset_controller_interface
+ *
+ * @brief Peripheral reset-cell identifiers for Nuvoton NuMaker devices.
+ *
+ * Devicetree macros for peripheral reset cells on Nuvoton NuMaker devices, for use with the
+ * <tt>nuvoton,numaker-rst</tt> compatible reset controller.
+ *
+ * Each SoC family header defines identifiers that encode the reset register location and bit
+ * position for a peripheral. The encoding is family-specific; use the provided identifiers
+ * directly rather than constructing reset cell values manually.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/reset/numaker_m031x_reset.h>
+ *
+ * &uart0 {
+ *         // ...
+ *         resets = <&rst NUMAKER_UART0_RST>;
+ *         // ...
+ * };
+ * @endcode
+ * @{
  */
 
 /**
- * @defgroup reset_controller_nuvoton_m031x Nuvoton NuMaker controller Devicetree helpers
- * @ingroup reset_controller_interface
+ * @defgroup reset_controller_nuvoton_m031x Nuvoton NuMaker M031X reset controller helpers
+ * @ingroup reset_controller_numaker
  *
- * @details Devicetree macos/defines for Nuvoton NuMaker devices,
- * for use with the <tt>nuvoton,numaker-rst</tt> binding.
+ * @brief Peripheral reset-cell identifiers for M031X devices.
+ *
+ * Reset identifiers follow the pattern @c NUMAKER_\<PERIPHERAL\>_RST, where @c \<PERIPHERAL\>
+ * is an M031X peripheral name (for example, @c NUMAKER_UART0_RST resets UART0). Pass these
+ * identifiers directly to a @c resets property.
  * @{
  */
 
@@ -109,7 +137,9 @@
 
 /** @} */
 
-/** @endcond INTERNAL_HIDDEN */
+/** @endcond */
+
+/** @} */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/reset/numaker_m2l31x_reset.h
+++ b/include/zephyr/dt-bindings/reset/numaker_m2l31x_reset.h
@@ -4,8 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for Nuvoton NuMaker M2L31X
+ * @ingroup reset_controller_nuvoton_m2l31x
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M2L31X_RESET_H
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M2L31X_RESET_H
+
+/**
+ * @addtogroup reset_controller_numaker Nuvoton NuMaker reset controller helpers
+ * @{
+ */
+
+/**
+ * @defgroup reset_controller_nuvoton_m2l31x Nuvoton NuMaker M2L31X reset controller helpers
+ * @ingroup reset_controller_numaker
+ *
+ * @brief Peripheral reset-cell identifiers for M2L31X devices.
+ *
+ * Reset identifiers follow the pattern @c NUMAKER_\<PERIPHERAL\>_RST, where @c \<PERIPHERAL\>
+ * is an M2L31X peripheral name (for example, @c NUMAKER_UART0_RST resets UART0). Pass these
+ * identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @name Reset module IDs
+ * @brief Register bit positions and reset IDs for Nuvoton M2L31X
+ * @{
+ */
 
 /* Beginning of M2L31 BSP sys_reg.h reset module copy */
 
@@ -151,5 +182,13 @@
 #define NUMAKER_OPA_RST         ((0x80UL<<24) | LPSCC_IPRST0_OPARST_Pos)
 
 /* End of M2L31 BSP sys.h reset module copy */
+
+/** @} */
+
+/** @endcond */
+
+/** @} */
+
+/** @} */
 
 #endif

--- a/include/zephyr/dt-bindings/reset/numaker_m333x_reset.h
+++ b/include/zephyr/dt-bindings/reset/numaker_m333x_reset.h
@@ -4,8 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for Nuvoton NuMaker M333X
+ * @ingroup reset_controller_nuvoton_m333x
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M333X_RESET_H
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M333X_RESET_H
+
+/**
+ * @addtogroup reset_controller_numaker Nuvoton NuMaker reset controller helpers
+ * @{
+ */
+
+/**
+ * @defgroup reset_controller_nuvoton_m333x Nuvoton NuMaker M333X reset controller helpers
+ * @ingroup reset_controller_numaker
+ *
+ * @brief Peripheral reset-cell identifiers for M333X devices.
+ *
+ * Reset identifiers follow the pattern @c NUMAKER_\<PERIPHERAL\>_RST, where @c \<PERIPHERAL\>
+ * is an M333X peripheral name (for example, @c NUMAKER_UART0_RST resets UART0). Pass these
+ * identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @name Reset module IDs
+ * @brief Register bit positions and reset IDs for Nuvoton M333X
+ * @{
+ */
 
 /* Beginning of M3331 BSP sys_reg.h reset module copy */
 
@@ -137,5 +168,13 @@
 #define NUMAKER_ELLSI0_RST          ((0x18UL<<24) | SYS_IPRST3_ELLSI0RST_Pos)
 
 /* End of M3331 BSP sys.h reset module copy */
+
+/** @} */
+
+/** @endcond */
+
+/** @} */
+
+/** @} */
 
 #endif

--- a/include/zephyr/dt-bindings/reset/numaker_m335x_reset.h
+++ b/include/zephyr/dt-bindings/reset/numaker_m335x_reset.h
@@ -4,21 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for Nuvoton NuMaker M335X
+ * @ingroup reset_controller_nuvoton_m335x
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M335X_RESET_H
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M335X_RESET_H
 
 /**
- * @file
- * @brief Reset module IDs for Nuvoton M335X
- * @ingroup reset_controller_nuvoton_m335x
+ * @addtogroup reset_controller_numaker Nuvoton NuMaker reset controller helpers
+ * @{
  */
-
 /**
- * @defgroup reset_controller_nuvoton_m335x Nuvoton NuMaker controller Devicetree helpers
- * @ingroup reset_controller_interface
+ * @defgroup reset_controller_nuvoton_m335x Nuvoton NuMaker M335X reset controller helpers
+ * @ingroup reset_controller_numaker
  *
- * @details Devicetree macos/defines for Nuvoton NuMaker devices,
- * for use with the <tt>nuvoton,numaker-rst</tt> binding.
+ * @brief Peripheral reset-cell identifiers for M335X devices.
+ *
+ * Reset identifiers follow the pattern @c NUMAKER_\<PERIPHERAL\>_RST, where @c \<PERIPHERAL\>
+ * is an M335X peripheral name (for example, @c NUMAKER_UART0_RST resets UART0). Pass these
+ * identifiers directly to a @c resets property.
  * @{
  */
 
@@ -165,7 +172,9 @@
 
 /** @} */
 
-/** @endcond INTERNAL_HIDDEN */
+/** @endcond */
+
+/** @} */
 
 /** @} */
 

--- a/include/zephyr/dt-bindings/reset/numaker_m46x_reset.h
+++ b/include/zephyr/dt-bindings/reset/numaker_m46x_reset.h
@@ -4,8 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for Nuvoton NuMaker M46X
+ * @ingroup reset_controller_nuvoton_m46x
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M46X_RESET_H
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M46X_RESET_H
+
+/**
+ * @addtogroup reset_controller_numaker Nuvoton NuMaker reset controller helpers
+ * @{
+ */
+
+/**
+ * @defgroup reset_controller_nuvoton_m46x Nuvoton NuMaker M46X reset controller helpers
+ * @ingroup reset_controller_numaker
+ *
+ * @brief Peripheral reset-cell identifiers for M46X devices.
+ *
+ * Reset identifiers follow the pattern @c NUMAKER_\<PERIPHERAL\>_RST, where @c \<PERIPHERAL\>
+ * is an M46X peripheral name (for example, @c NUMAKER_UART0_RST resets UART0). Pass these
+ * identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @name Reset module IDs
+ * @brief Register bit positions and reset IDs for Nuvoton M46X
+ * @{
+ */
 
 /* Beginning of M460 BSP sys_reg.h reset module copy */
 
@@ -267,5 +298,13 @@
 #define NUMAKER_UART9_RST  ((0x18UL << 24) | NUMAKER_SYS_IPRST3_UART9RST_Pos)
 
 /* End of M460 BSP sys.h reset module copy */
+
+/** @} */
+
+/** @endcond */
+
+/** @} */
+
+/** @} */
 
 #endif

--- a/include/zephyr/dt-bindings/reset/numaker_m55m1x_reset.h
+++ b/include/zephyr/dt-bindings/reset/numaker_m55m1x_reset.h
@@ -4,8 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Peripheral reset identifiers for Nuvoton NuMaker M55M1X
+ * @ingroup reset_controller_nuvoton_m55m1x
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M55M1X_RESET_H
 #define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_NUMAKER_M55M1X_RESET_H
+
+/**
+ * @addtogroup reset_controller_numaker Nuvoton NuMaker reset controller helpers
+ * @{
+ */
+
+/**
+ * @defgroup reset_controller_nuvoton_m55m1x Nuvoton NuMaker M55M1X reset controller helpers
+ * @ingroup reset_controller_numaker
+ *
+ * @brief Peripheral reset-cell identifiers for M55M1X devices.
+ *
+ * Reset identifiers follow the pattern @c NUMAKER_SYS_\<PERIPHERAL\>RST, where
+ * @c \<PERIPHERAL\> is an M55M1X peripheral name (for example, @c NUMAKER_SYS_UART0RST resets
+ * UART0). Pass these identifiers directly to a @c resets property.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @name Reset module IDs
+ * @brief Register bit positions and reset IDs for Nuvoton M55M1X
+ * @{
+ */
 
 /* Beginning of M55M1 BSP sys_reg.h reset module copy */
 
@@ -206,5 +237,13 @@
 #define NUMAKER_SYS_WWDT1RST        ((0x2E0UL<<20) | SYS_WWDTRST_WWDT1RST_Pos)
 
 /* End of M55M1 BSP sys.h reset module copy */
+
+/** @} */
+
+/** @endcond */
+
+/** @} */
+
+/** @} */
 
 #endif


### PR DESCRIPTION
Add doxygen comments to the numaker reset headers.

https://builds.zephyrproject.io/zephyr/pr/111663/docs/doxygen/html/group__reset__controller__numaker.html