### PR TITLE
samples: subsys: settings: extend timeout for tfm-ps

### DIFF
--- a/samples/subsys/settings/sample.yaml
+++ b/samples/subsys/settings/sample.yaml
@@ -62,6 +62,7 @@ tests:
       - CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
   sample.settings.tfm-ps:
+    timeout: 30
     tags:
       - trusted-firmware-m
     filter: CONFIG_TFM_PARTITION_PROTECTED_STORAGE


### PR DESCRIPTION
Longer execution when using tfm-ps.