### PR TITLE
tests: subsys: pm: Add build assert for CPU power states 

### DIFF
--- a/tests/subsys/pm/power_mgmt_soc/src/power_mgmt.c
+++ b/tests/subsys/pm/power_mgmt_soc/src/power_mgmt.c
@@ -56,6 +56,8 @@ static const struct pm_state_info residency_info[] =
 	PM_STATE_INFO_LIST_FROM_DT_CPU(DT_NODELABEL(cpu0));
 static size_t residency_info_len = DT_NUM_CPU_POWER_STATES(DT_NODELABEL(cpu0));
 
+BUILD_ASSERT(DT_NUM_CPU_POWER_STATES(DT_NODELABEL(cpu0)) > 0, "No CPU power states defined");
+
 static void pm_latency_check(void)
 {
 	int64_t latency;


### PR DESCRIPTION
Add a BUILD_ASSERT to fail the build if no power states are defined for cpu0. This prevents the test from being flashed and run on boards where it is not relevant, which would result in a misleading PASS with
all counters remaining at zero.