### PR TITLE
arch: xtensa: mmu: preserve existing PPN when re-tagging regions

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -1441,7 +1441,9 @@ static void region_map_update(uint32_t *l1_table, uintptr_t start,
 		}
 
 		pte = l2_table[l2_pos];
-		pte = PTE_PPN_SET(pte, start + offset);
+		if (is_pte_illegal(pte)) {
+			pte = PTE_PPN_SET(pte, start + offset);
+		}
 
 		if ((option & OPTION_RESTORE_ATTRS) == OPTION_RESTORE_ATTRS) {
 			new_attrs = PTE_BCKUP_ATTR_GET(pte);


### PR DESCRIPTION
region_map_update() unconditionally forced the physical page number of every touched PTE to (start + offset), which assumes an identity VA == PA mapping. On SoCs that bring up memory with a non-identity mapping (e.g. a DRAM region mapped via arch_mem_map() at a PA that differs from its VA), this clobbers the correct PA installed at boot.

region_map_update() is only used to re-tag the ring and attributes of an already-mapped region (memory-domain partitions, user thread stacks and reset), so the PPN of the live PTE is authoritative and must not be recomputed. Forcing PPN = start + offset repoints partition and user-stack pages at unbacked physical memory, and the first user-mode access faults with LoadStorePIFDataError (EXCCAUSE 13).

Preserve the existing PPN and only synthesize one from (start + offset) when the slot is currently unmapped (is_pte_illegal). For identity-mapped regions the live PPN already equals start + offset, so this is a no-op.