### PR TITLE
dts: bindings: dma: stm32u5: clean up binding

### DIFF
--- a/dts/bindings/dma/st,stm32u5-dma.yaml
+++ b/dts/bindings/dma/st,stm32u5-dma.yaml
@@ -1,54 +1,22 @@
 # Copyright (c) 2022 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-  STM32U5 DMA controller.
+title: STM32U5 DMA controller
 
-  It is present on stm32U5 devices as a GP DMA
-  This controller includes several channels with different requests.
-  DMA clients connected to the STM32 DMA controller must use a three-cell
-  specifier for each channel.
-  For the client part, example for stm32u585 on GPDMA1 instance
-    Tx using channel 0 with request 7
-    Rx using channel 1 with request 6
-    spi1 {
-     dmas = <&gpdma1 0 7 0x10440>,
-            <&gpdma1 1 6 0x10480>;
-     dma-names = "tx", "rx";
-    };
-  It is a phandle to the DMA controller plus the following three integer cells
-    1. channel: the stream or channel from 0 to (<dma-channels> - 1).
-    2. slot: DMA periph request ID, which is written in the REQSEL bits of the CxTR2
-    the slot is a value between <0> .. (<dma-requests> - 1).
-    3. channel-config: A 32bit mask specifying the DMA channel configuration
-    which is device dependent:
-        -bit 6-7 : Direction  (see dma.h)
-               0x0: MEM to MEM
-               0x1: MEM to PERIPH
-               0x2: PERIPH to MEM
-               0x3: reserved for PERIPH to PERIPH
-        -bit 9 : Peripheral Increment Address
-               0x0: no address increment between transfers
-               0x1: increment address between transfers
-        -bit 10 : Memory Increment Address
-               0x0: no address increment between transfers
-               0x1: increment address between transfers
-        -bit 11-12 : Peripheral data size
-               0x0: Byte (8 bits)
-               0x1: Half-word (16 bits)
-               0x2: Word (32 bits)
-               0x3: reserved
-        -bit 13-14 : Memory data size
-               0x0: Byte (8 bits)
-               0x1: Half-word (16 bits)
-               0x2: Word (32 bits)
-               0x3: reserved
-        -bit 15: Reserved
-        -bit 16-17 : Priority level
-               0x0: low
-               0x1: medium
-               0x2: high
-               0x3: very high
+description: |
+  LPDMA/GPDMA/HPDMA direct memory access controllers; first found in STM32U5.
+
+  These DMA controllers contain various channels as well as a request multiplexer
+  that allows any of the DMA request lines to trigger an arbitrary channel, in a
+  similar fashion to the combined (DMA1/DMA2)+DMAMUX found in some STM32 series.
+
+  The DMA cells are used as follows:
+    - channel: DMA channel to use
+        (between 0 and (<dma-channels> - 1))
+    - slot: ID of request that should trigger the channel
+        (between 0 and (<dma-requests> - 1))
+    - channel-config: 32-bit configuration bitmask
+        (refer to include/zephyr/dt-bindings/dma/stm32_dma.h for details)
 
 compatible: "st,stm32u5-dma"
 
@@ -62,7 +30,44 @@ properties:
   "#dma-cells":
     const: 3
 
+  interrupts:
+    description: |
+      One interrupt cell per channel, in order of channel numbers.
+
+      For example, if channel 0 has IRQn 74 and channel 1 has IRQn 47:
+        interrupts = <74 0>, <47 0>;
+
 dma-cells:
   - channel
   - slot
   - channel-config
+
+examples:
+  - |
+    /* Definition example: STM32U5 SoC DTSI */
+    gpdma1: dma@40020000 {
+      compatible = "st,stm32u5-dma";
+      #dma-cells = <3>;
+      reg = <0x40020000 DT_SIZE_K(1)>;
+      clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
+      interrupts = <29 0>, <30 0>, <31 0>, <32 0>,
+                   <33 0>, <34 0>, <35 0>, <36 0>,
+                   <80 0>, <81 0>, <82 0>, <83 0>,
+                   <84 0>, <85 0>, <86 0>, <87 0>;
+      dma-channels = <16>;
+      dma-requests = <114>;
+    };
+
+  - |
+    /*
+     * Usage example: SPI1 Rx/Tx via GPDMA on STM32U585
+     *
+     * Allocates channel 0/1 to Rx/Tx (request ID 6/7).
+     * Refer to your product's Reference Manual for
+     * the list and mapping of available DMA requests.
+     */
+    &spi1 {
+      dmas = <&gpdma 0 6 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_MEDIUM)>,
+             <&gpdma 1 7 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_MEDIUM)>;
+      dma-names = "rx", "tx";
+    };


### PR DESCRIPTION
- add a `title` to the binding
- add description for the `interrupts` property indicating expected use
- rework description to be simpler and mention the LPDMA/GPDMA/HPDMA controller names explicitly
- simplify cells description, refering to the dedicated header instead of repeating the information for `channel-config`
- make examples proper snippets instead of being in the description (and make them use named constants from stm32_dma.h)