### PR TITLE
Bluetooth: Host: Fix RPA expire issues for adv

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -247,11 +247,7 @@ static void adv_rpa_expired(struct bt_le_ext_adv *adv, void *data)
 
 static void adv_rpa_invalidate(struct bt_le_ext_adv *adv, void *data)
 {
-	/* RPA of Advertisers limited by timeout or number of packets only expire
-	 * when they are stopped.
-	 */
-	if (!atomic_test_bit(adv->flags, BT_ADV_LIMITED) &&
-	    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
+	if (atomic_test_bit(adv->flags, BT_ADV_RPA_UPDATE)) {
 		adv_rpa_expired(adv, data);
 	}
 }
@@ -703,15 +699,12 @@ static void rpa_timeout(struct k_work *work)
 	adv_enabled = le_adv_rpa_timeout();
 	le_rpa_invalidate();
 
-	/* IF no roles using the RPA is running we can stop the RPA timer */
-	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
-		if (!(adv_enabled || atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING) ||
-		      bt_le_scan_active_scanner_running())) {
-			return;
-		}
+	/* Update the RPA if we have any active procedures that use it */
+	if ((IS_ENABLED(CONFIG_BT_BROADCASTER) && adv_enabled) ||
+	    (IS_ENABLED(CONFIG_BT_CENTRAL) && atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) ||
+	    (IS_ENABLED(CONFIG_BT_OBSERVER) && bt_le_scan_active_scanner_running())) {
+		le_update_private_addr();
 	}
-
-	le_update_private_addr();
 }
 #endif /* CONFIG_BT_PRIVACY */
 


### PR DESCRIPTION
This commit fixes 2 things:
1) If an advertising set is not enabled, the rpa_expired callback
   is no longer called. Since we pause the adv set to update the RPA
   we need to use BT_ADV_RPA_UPDATE instead of BT_ADV_ENABLED to check
   whether it is "active".
2) If we do not have an active advertising set, not scanning or
   not initiating a connection, the RPA timer is stopped. The
   timer is started again whenever any action that uses RPA is
   started again.