### PR TITLE
boards: nxp: frdm_mcxc242: enable GPIOD controller

### DIFF
--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
@@ -121,6 +121,10 @@
 	status = "okay";
 };
 
+&gpiod {
+	status = "okay";
+};
+
 &gpioe {
 	status = "okay";
 };


### PR DESCRIPTION
Enable the GPIOD controller in the FRDM-MCXC242 board definition so that GPIO pins on port D can be used by applications without requiring a board overlay.