### PR TITLE
arch: arm: mpu: declare arm_core_mpu_enable/disable in header

### DIFF
--- a/arch/arm/core/mpu/arm_core_mpu.c
+++ b/arch/arm/core/mpu/arm_core_mpu.c
@@ -10,14 +10,12 @@
 #include <zephyr/kernel.h>
 
 #include "arm_core_mpu_dev.h"
+#include <zephyr/arch/arm/mpu/arm_mpu.h>
 #include <zephyr/linker/linker-defs.h>
 
 #define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mpu);
-
-extern void arm_core_mpu_enable(void);
-extern void arm_core_mpu_disable(void);
 
 /*
  * Maximum number of dynamic memory partitions that may be supplied to the MPU

--- a/include/zephyr/arch/arm/mpu/arm_mpu.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu.h
@@ -84,6 +84,35 @@ struct arm_mpu_config {
  */
 extern const struct arm_mpu_config mpu_config;
 
+/**
+ * @brief Enable the ARM Memory Protection Unit (MPU).
+ *
+ * Turns the MPU on so that the currently programmed memory regions become
+ * active and start enforcing their access permissions and memory attributes.
+ *
+ * It is typically called during MPU initialization, but it may also be used to
+ * re-enable protection after a transient region that temporarily called
+ * arm_core_mpu_disable(). The set of active regions is whatever was programmed
+ * prior to the call; this function does not modify any region.
+ */
+void arm_core_mpu_enable(void);
+
+/**
+ * @brief Disable the ARM Memory Protection Unit (MPU).
+ *
+ * Turns the MPU off so that no memory access permissions or attributes are
+ * enforced. After this call every access is permitted until
+ * the MPU is re-enabled with arm_core_mpu_enable().
+ *
+ * The programmed region descriptors are left untouched, so a subsequent
+ * arm_core_mpu_enable() restores the previous protection without
+ * reprogramming.
+ *
+ * @warning While the MPU is disabled, stack overflow guards, null-pointer
+ *          detection and userspace isolation are not enforced.
+ */
+void arm_core_mpu_disable(void);
+
 #if defined(CONFIG_CPU_CORTEX_M)
 /**
  * @brief MPU context structure to retain MPU register state across deep sleep.

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -34,7 +34,7 @@
 #endif
 
 #if defined(CONFIG_ARM)
-extern void arm_core_mpu_disable(void);
+#include <zephyr/arch/arm/mpu/arm_mpu.h>
 #endif
 
 #define INFO(fmt, ...) printk(fmt, ##__VA_ARGS__)


### PR DESCRIPTION
The arm_core_mpu_enable() and arm_core_mpu_disable() functions were defined in the ARM MPU driver but never declared in a header. As a result, callers had to provide their own local `extern` declarations to use them.

Add documented prototypes for both functions to include/zephyr/arch/arm/mpu/arm_mpu.h and drop the redundant `extern` declarations in arm_core_mpu.c and the userspace memory protection test.