### PR TITLE
soc: espressif: esp32s3: decouple octal flash from octal psram

### DIFF
--- a/samples/boards/espressif/spiram_test/sample.yaml
+++ b/samples/boards/espressif/spiram_test/sample.yaml
@@ -9,24 +9,21 @@ common:
       - "SPIRAM mem test pass"
       - "Internal mem test pass"
 tests:
-  sample.boards.esp32.spiram:
-    platform_allow: esp32_devkitc/esp32/procpu
-    tags: esp32
-  sample.boards.esp32s2.spiram:
-    platform_allow: esp32s2_devkitc
-    tags: esp32s2
-  sample.boards.esp32s3.spiram:
+  sample.boards.espressif.spiram:
+    platform_allow:
+      - esp32_devkitc/esp32/procpu
+      - esp32s2_devkitc
+      - esp32s3_devkitc/esp32s3/procpu
+      - esp32c5_devkitc/esp32c5/hpcore
+      - esp32p4_function_ev_board/esp32p4/hpcore
+  sample.boards.espressif.spiram.octal_80m:
     platform_allow: esp32s3_devkitc/esp32s3/procpu
-    tags: esp32s3
-  sample.boards.esp32c5.spiram:
-    platform_allow: esp32c5_devkitc/esp32c5/hpcore
-    tags: esp32c5
-  sample.boards.esp32p4.spiram:
-    platform_allow: esp32p4_function_ev_board/esp32p4/hpcore
-    tags: esp32p4
-  sample.boards.esp32s3.spiram.octal_80m:
-    platform_allow: esp32s3_devkitc/esp32s3/procpu
-    tags: esp32s3
     extra_configs:
       - CONFIG_SPIRAM_SPEED_80M=y
       - CONFIG_SPIRAM_MODE_OCT=y
+  sample.boards.espressif.spiram.octal_flash:
+    platform_allow: esp32s3_devkitc/esp32s3/procpu
+    build_only: true
+    extra_configs:
+      - CONFIG_SPIRAM_MODE_OCT=y
+      - CONFIG_ESPTOOLPY_OCT_FLASH=y

--- a/soc/espressif/common/Kconfig.esptool
+++ b/soc/espressif/common/Kconfig.esptool
@@ -6,12 +6,12 @@ if SOC_FAMILY_ESPRESSIF_ESP32
 config ESPTOOLPY_OCT_FLASH
 	bool "Use Octal Flash"
 	depends on SOC_SERIES_ESP32S3
-	default y if SPIRAM_MODE_OCT
 	help
-	  Octal PSRAM modules are paired with octal flash. Enable octal flash
-	  by default in this case so its MSPI timing is tuned (DTR sample mode).
-	  Without it the flash falls back to untuned STR timing and can corrupt
-	  at high speeds. Disable manually if the board uses quad flash.
+	  Enable only when the board actually mounts an octal (OPI) flash chip.
+	  This selects OPI flash mode and tuned DTR sample timing. Flash and
+	  PSRAM line modes are independent: most octal-PSRAM modules (such as
+	  N8R8 and N16R8) pair octal PSRAM with quad flash, so leave this
+	  disabled unless the flash chip itself is octal.
 
 config ESPTOOLPY_FLASH_MODE_AUTO_DETECT
 	depends on SOC_SERIES_ESP32S3


### PR DESCRIPTION
Flash and PSRAM line modes are independent, so do not force octal flash when octal PSRAM is selected. Most octal-PSRAM modules pair octal PSRAM with quad flash, and the implicit default produced an OPI flash image that fails to boot on those boards. Make octal flash an explicit opt-in and add a build-only sample variant to keep the octal flash path under CI coverage.

Fix regression in #110861 where existing spiram octal + quad flash breaks.