### PR TITLE
kernel: stack canaries: disable TLS canaries for Clang on RISC-V

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -843,6 +843,13 @@ config STACK_CANARIES_TLS
 	bool "Stack canaries using thread local storage"
 	depends on THREAD_LOCAL_STORAGE
 	depends on ARCH_HAS_STACK_CANARIES_TLS
+	# Clang's RISC-V backend rejects the -mstack-protector-guard=tls family of
+	# flags, so the canary cannot be anchored to the TLS base register. Without
+	# them Clang emits an absolute reference to the thread-local __stack_chk_guard
+	# symbol (which resolves to address 0), producing an image that faults in the
+	# prologue of the first canary-instrumented function. Disallow the
+	# combination so it cannot be selected into a silently broken build.
+	depends on !(RISCV && "$(TOOLCHAIN_VARIANT_COMPILER)" = "llvm")
 	help
 	  This option enables compiler stack canaries on TLS.
 

--- a/tests/kernel/mem_protect/stackprot/testcase.yaml
+++ b/tests/kernel/mem_protect/stackprot/testcase.yaml
@@ -11,6 +11,10 @@ tests:
     ignore_faults: true
   kernel.memory_protection.stackprot_tls:
     filter: CONFIG_ARCH_HAS_STACK_CANARIES_TLS and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE
+    # Clang's RISC-V backend does not support the -mstack-protector-guard=tls
+    # flags, so the canary cannot be placed in TLS. See STACK_CANARIES_TLS.
+    toolchain_exclude:
+      - zephyr/llvm
     tags:
       - kernel
       - userspace


### PR DESCRIPTION
Clang's RISC-V backend rejects the -mstack-protector-guard=tls family of
flags used to anchor the stack canary to the TLS base register. With those
flags stripped, Clang falls back to an absolute reference to the
thread-local __stack_chk_guard symbol, which resolves to address 0. The
build compiles cleanly but the resulting image faults in the prologue of
the first canary-instrumented function (vprintk during early boot, before
the console is up), then re-faults forever in the trap handler, producing
no output at all.

Guard STACK_CANARIES_TLS so it cannot be selected for Clang on RISC-V,
falling back to the global canary which Clang handles correctly, and
exclude the kernel.memory_protection.stackprot_tls test from zephyr/llvm.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
