### PR TITLE
Add ipct configs nrf7120

### DIFF
--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -442,6 +442,8 @@
 				compatible = "nordic,nrf-ipct-global";
 				reg = <0x8d000 0x1000>;
 				interrupts = <141 NRF_DEFAULT_IRQ_PRIORITY>;
+				channels = <4>;
+				global-domain-id = <1>;
 				status = "disabled";
 			};
 

--- a/soc/nordic/nrf71/soc.c
+++ b/soc/nordic/nrf71/soc.c
@@ -155,6 +155,12 @@ static void grtc_configuration(void)
 	nrf_spu_feature_secattr_set(NRF_SPU20, NRF_SPU_FEATURE_GRTC_INTERRUPT, 5, 0, 0);
 	nrf_spu_feature_secattr_set(NRF_SPU20, NRF_SPU_FEATURE_GRTC_SYSCOUNTER, 0, 0, 0);
 }
+
+static void ipct_configuration(void)
+{
+	/* Grant secure access to IPCT, since NS by default */
+	nrf_spu_periph_perm_secattr_set(NRF_SPU10, 13, true);
+}
 #endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
 
 #if defined(CONFIG_SOC_NRF71_WIFI_BOOT)
@@ -183,6 +189,7 @@ void soc_early_init_hook(void)
 	/* Skip for tf-m, configuration exist in target_cfg_71.c */
 	mpc_configuration();
 	grtc_configuration();
+	ipct_configuration();
 #endif
 
 #if defined(CONFIG_SOC_NRF71_WIFI_BOOT)


### PR DESCRIPTION
Add missing ipct properties in dts
Configure ipct for secure access when `CONFIG_TRUSTED_EXECUTION_NONSECURE` is false