### PR TITLE
drivers: flash: Add missing header to soc_flash_nrf_mramc.c

### DIFF
--- a/drivers/flash/soc_flash_nrf_mramc.c
+++ b/drivers/flash/soc_flash_nrf_mramc.c
@@ -7,6 +7,7 @@
 #include <string.h>
 
 #include <zephyr/drivers/flash.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)


### PR DESCRIPTION
kernel.h must be included now that file is making use of mutex.