### PR TITLE
boards: infineon: kit_pse84_eval: add CM55 debug restart command

### DIFF
--- a/boards/infineon/kit_pse84_eval/board.cmake
+++ b/boards/infineon/kit_pse84_eval/board.cmake
@@ -11,6 +11,10 @@ if(CONFIG_CPU_CORTEX_M55)
   board_runner_args(openocd "--gdb-init=disconnect")
   board_runner_args(openocd "--gdb-init=target extended-remote :3334")
   board_runner_args(openocd "--target-handle=CHIPNAME.cm55")
+  # GDB `run` cannot restart the CM55 (it is released by the CM33 enable_cm55
+  # application, not by a chip reset). Provide a `restart` command that replays
+  # the gdb-attach sequence instead.
+  board_runner_args(openocd "--gdb-init=source ${BOARD_DIR}/support/pse84_cm55_restart.gdb")
 else()
   board_runner_args(openocd "--target-handle=CHIPNAME.cm33")
 endif()

--- a/boards/infineon/kit_pse84_eval/support/pse84_cm55_restart.gdb
+++ b/boards/infineon/kit_pse84_eval/support/pse84_cm55_restart.gdb
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# GDB helper that restarts a CM55 debug session on kit_pse84_eval.
+#
+# The CM55 application is not started by a chip reset: it is released by the
+# CM33 `enable_cm55` application calling Cy_SysEnableCM55(). A plain GDB `run`
+# performs a blind chip reset, which leaves the CM55 parked in the ROM
+# "safe" endless-loop (pc=0x3ff00) instead of at the application reset
+# handler, so `run` cannot restart the CM55.
+#
+# The `restart` command below replays the exact OpenOCD gdb-attach sequence
+# that the initial `west debug` connection uses: it reconnects to the CM33
+# gdb server (which resets and halts the CM33 at its reset vector), then to
+# the CM55 gdb server (whose gdb-attach event runs `reset_halt cm55`, resuming
+# the now-halted CM33 so the enable_cm55 application releases the CM55 and the
+# CM55 halts at its reset handler).
+#
+# Use `restart` instead of `run` to restart a CM55 debug session.
+
+define restart
+  disconnect
+  target extended-remote :3333
+  disconnect
+  target extended-remote :3334
+  maintenance flush register-cache
+end
+
+document restart
+Restart the CM55 debug session.
+
+Use this instead of `run`, which cannot restart the CM55 on this board.
+After `restart` the CM55 is halted at its reset handler; use `continue` to
+run to your breakpoints.
+end


### PR DESCRIPTION
## Summary

On `kit_pse84_eval` the CM55 application is not started by a chip reset: it is released by the CM33 `enable_cm55` application calling `Cy_SysEnableCM55()`. The correct CM55 debug bring-up (OpenOCD `reset_halt_cm55`: reset+halt CM33, arm the CM55 core reset, then resume the CM33 so its `enable_cm55` application releases the CM55) is wired only to the OpenOCD `gdb-attach` event.

A GDB `run` does not re-fire `gdb-attach`; it performs a blind chip reset whose cat1d reset events park the CM55 in the ROM "safe" endless-loop (`pc=0x3ff00`). The CM55 is then unexaminable and the debug session is lost, so `run` cannot restart the CM55.

This PR adds a sourced GDB helper defining a `restart` command that replays the initial `west debug` attach sequence (reconnect to the CM33 gdb server, then the CM55 gdb server, re-running the `gdb-attach` handshake), wired into the CM55 runner gdb-init. Use `restart` instead of `run` to restart a CM55 debug session; afterwards the CM55 is halted at its reset handler and `continue` proceeds to user breakpoints.

## Testing

Reproduced and validated on a `kit_pse84_eval` (PSE846GPS2DBZC4A, B0) over KitProg3: `run` consistently locks the CM55 at `0x3ff00`, while `restart` repeatedly halts the CM55 at its reset handler and continues to the breakpoint in `main`.