### PR TITLE
tests: llext: disable RISC-V DEP for readonly_mmu scenarios

### DIFF
--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -104,6 +104,12 @@ tests:
       - CONFIG_LLEXT_HEAP_SIZE=128 # qemu_cortex_a9 requires larger heap
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
       - CONFIG_LLEXT_RODATA_NO_RELOC=y
+      # On RISC-V (no MMU, no userspace) llext copies code into RAM and runs it
+      # in machine mode, so the loaded text region must stay executable. DEP
+      # installs a locked catch-all PMP entry that makes all RAM non-executable
+      # with no way to mark the region executable. Setting an unknown symbol to
+      # 'n' is a no-op, so this is safe on the MMU arches.
+      - CONFIG_PMP_DATA_EXECUTION_PREVENTION=n
   llext.readonly_mmu.memblk:
     arch_allow:
       - arm64
@@ -119,6 +125,9 @@ tests:
       - CONFIG_LLEXT_HEAP_MEMBLK=y
       - CONFIG_LLEXT_EXT_HEAP_SIZE=64
       - CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE=4096
+      # See note above: RISC-V executes loaded code from RAM in machine mode,
+      # which is incompatible with DEP's locked catch-all PMP entry.
+      - CONFIG_PMP_DATA_EXECUTION_PREVENTION=n
   llext.writable:
     arch_allow:
       - arm


### PR DESCRIPTION
The readonly_mmu and readonly_mmu.memblk scenarios run on RISC-V PMP
targets without an MMU and without user space. There llext copies the
extension text into the heap and jumps to it from machine mode. With
CONFIG_PMP_DATA_EXECUTION_PREVENTION now defaulting to y, a locked
catch-all PMP entry marks all RAM non-executable and there is no path to
mark the loaded region executable (llext_adjust_mmu_permissions() is
CONFIG_MMU-only and the executable mem-domain partitions are
CONFIG_USERSPACE-only), so execution faults with an instruction access
fault. Disable DEP for these two scenarios; setting an unknown symbol to
n is a no-op, so this stays safe on the MMU arches.

This only patches the test. With DEP defaulting to y, any RISC-V
application that loads llext code into RAM and runs it in kernel mode
hits the same fault. A real fix needs llext to mark its text region
executable on RISC-V PMP (or DEP to account for runtime-loaded code);
neither exists today.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
