### PR TITLE
soc: nxp: imxrt: mimxrt685s/hifi4: fix nocache window end placement

### DIFF
--- a/soc/nxp/imxrt/imxrt6xx/hifi4/linker.ld
+++ b/soc/nxp/imxrt/imxrt6xx/hifi4/linker.ld
@@ -429,14 +429,17 @@ SECTIONS
   } >adsp_data_nocache
   _nocache_noload_ram_size = _nocache_noload_ram_end - _nocache_noload_ram_start;
 
-  _nocache_window_end (DSECT) :
-  {
-    /* Align to cache line */
-    . = ALIGN (64);
-
-    /* End of the nocache window (absolute from the nocache memory region) */
-    _nocache_window_end_noncached = ABSOLUTE(.);
-  } >adsp_data_nocache
+  /*
+   * End of the nocache window (absolute from the nocache memory region),
+   * aligned to a cache line.
+   *
+   * This is derived directly from the end of the nocache content instead of
+   * from a trailing (DSECT) marker section. When the nocache sections are
+   * empty (no symbols land in .nocache*) such a marker's location counter
+   * collapses back to the region origin, which would place .bss on top of
+   * .rodata and break section placement for the whole image.
+   */
+  _nocache_window_end_noncached = ALIGN(_nocache_ram_end, 64);
 
   .bss
     (ORIGIN(adsp_data) + (_nocache_window_end_noncached - ORIGIN(adsp_data_nocache)))


### PR DESCRIPTION
The nocache window scheme captured _nocache_window_end_noncached from a
trailing (DSECT) marker section placed after the .nocache* sections. When
those sections are empty (no symbols land in .nocache*, e.g. the amp_blinky
and amp_mbox samples), nothing pins the location counter forward and the
marker's '.' collapses back to the nocache region origin. The resulting
zero offset placed .bss on top of .rodata, producing non-monotonic LMAs
that ld 2.43.1 rejects under --fatal-warnings, breaking the HiFi4 remote
image link for both samples.

Derive _nocache_window_end_noncached directly from _nocache_ram_end, which
is captured inside the real _NOCACHE_SECTION_NAME output section and is
therefore correct even when the section is empty, then align it to a cache
line to preserve the original intent. This keeps the non-empty case
unchanged while fixing the empty case.

Fixes: b5060050b9bc ("soc: mimxrt685s/hifi4: Add nocache memory region")

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
