### PR TITLE
boards: others: add vbatt definition for Pro Micro nRF52840

### DIFF
--- a/boards/others/promicro_nrf52840/promicro_nrf52840_nrf52840_common.dts
+++ b/boards/others/promicro_nrf52840/promicro_nrf52840_nrf52840_common.dts
@@ -30,6 +30,13 @@
 		};
 	};
 
+	vbatt {
+		compatible = "voltage-divider";
+		io-channels = <&adc NRF_SAADC_VDDHDIV5>;
+		output-ohms = <1>;
+		full-ohms = <5>;
+	};
+
 	pwmleds {
 		compatible = "pwm-leds";
 


### PR DESCRIPTION
The battery is connected to VDDH via a MOSFET on the Pro Micro nRF52840.

Schematic: https://chat.nologo.tech/d/80/14