### PR TITLE
debug: Add Kconfig option to enable GCC to export callgraph files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,7 @@ else()
 endif()
 
 zephyr_cc_option_ifdef(CONFIG_STACK_USAGE            -fstack-usage)
+zephyr_cc_option_ifdef(CONFIG_CALLGRAPH_INFO         -fcallgraph-info)
 
 # If the compiler supports it, strip the ${ZEPHYR_BASE} prefix from the
 # __FILE__ macro used in __ASSERT*, in the

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -115,6 +115,13 @@ config STACK_USAGE
 	  Generate an extra file that specifies the maximum amount of stack used,
 	  on a per-function basis.
 
+config CALLGRAPH_INFO
+	bool "Generate call graph information"
+	help
+	  Generate an extra .ci file for each compilation unit, that specifies all
+	  calls known to GCC at complile time on a per-function basis. Calls are
+	  specified in the VCG format.
+
 config STACK_SENTINEL
 	bool "Stack sentinel"
 	select THREAD_STACK_INFO


### PR DESCRIPTION
This enables further static analysis on top of already implemented STACK_USAGE. Both options were introduced by adacore together into GCC and discussed together in an accompanying paper. stackcheck.pl and puncover scan objdump output, which is architecture dependent. Adding CALLGRAPH_INFO then allow to follow the idea of the adacore paper and independently of the architecture get a description of the callgraph in the .ci file and stack usage in the .su file - to later then get stack usage estimations for all architectures from the compilers output, instead of manually curating assembly regex's for call and stack instructions.

The paper mentioned for reference:

Link: https://www.adacore.com/uploads/papers/Stack_Analysis.pdf

Signed-off-by: Paul Würtz <paulwuertz@posteo.de>