### PR TITLE
kernel: timer: Support 64-bit tick timeout and announce

### DIFF
--- a/boards/qemu/cortex_m0/nrf_timer_timer.c
+++ b/boards/qemu/cortex_m0/nrf_timer_timer.c
@@ -148,7 +148,7 @@ void timer0_nrf_isr(void *arg)
 
 
 	uint32_t t = get_comparator();
-	uint32_t dticks = counter_sub(t, last_count) / CYC_PER_TICK;
+	k_ticks_delta_t dticks = counter_sub(t, last_count) / CYC_PER_TICK;
 
 	last_count += dticks * CYC_PER_TICK;
 
@@ -162,7 +162,7 @@ void timer0_nrf_isr(void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : (dticks > 0));
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 	uint32_t cyc;
@@ -172,7 +172,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks - 1, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	uint32_t unannounced = counter_sub(counter(), last_count);
 
@@ -211,14 +211,14 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	NVIC_ClearPendingIRQ(TIMER0_IRQn);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret = counter_sub(counter(), last_count) / CYC_PER_TICK;
+	k_ticks_delta_t ret = counter_sub(counter(), last_count) / CYC_PER_TICK;
 
 	k_spin_unlock(&lock, key);
 	return ret;

--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -137,7 +137,7 @@ void stimer_isr(const void *arg)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -147,7 +147,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 	/* Adjust the ticks to the range of [1, MAX_TICKS]. */
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks, 1, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, (k_ticks_delta_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&g_lock);
 
@@ -183,7 +183,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&g_lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;

--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -55,7 +55,7 @@ static void isr(const void *arg)
 	sys_clock_announce(1);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	return 0U;
 }

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -56,7 +56,7 @@ BUILD_ASSERT((!IS_ENABLED(CONFIG_APIC_TIMER_TSC) &&
 /*
  * We have two constraints on the maximum number of cycles we can wait for.
  *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
+ * 1) sys_clock_announce() may only accept at most INT32_MAX ticks.
  *
  * 2) The number of cycles between two reports must fit in a cycle_diff_t
  *    variable before converting it to ticks.
@@ -72,7 +72,9 @@ BUILD_ASSERT((!IS_ENABLED(CONFIG_APIC_TIMER_TSC) &&
  * consecutive set bits coming from the original max values to produce a
  * nicer literal for assembly generation.
  */
-#define CYCLES_MAX_1	((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
+#define CYCLES_MAX_1                                                                               \
+	(IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? INT64_MAX                                              \
+					  : ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK))
 #define CYCLES_MAX_2	((uint64_t)CYCLE_DIFF_MAX)
 #define CYCLES_MAX_3	MIN(CYCLES_MAX_1, CYCLES_MAX_2)
 #define CYCLES_MAX_4	(CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
@@ -87,8 +89,8 @@ struct apic_timer_lvt {
 };
 
 static uint64_t last_cycle;
-static uint64_t last_tick;
-static uint32_t last_elapsed;
+static k_ticks_t last_tick;
+static k_ticks_delta_t last_elapsed;
 static union { uint32_t val; struct apic_timer_lvt lvt; } lvt_reg;
 
 static ALWAYS_INLINE uint64_t rdtsc(void)
@@ -130,7 +132,7 @@ static void isr(const void *arg)
 	k_spinlock_key_t key = sys_clock_lock();
 	uint64_t curr_cycle = rdtsc();
 	uint64_t delta_cycles = curr_cycle - last_cycle;
-	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
 
 	last_cycle += (cycle_diff_t)delta_ticks * CYC_PER_TICK;
 	last_tick += delta_ticks;
@@ -145,7 +147,7 @@ static void isr(const void *arg)
 	sys_clock_announce_locked(delta_ticks, key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -180,7 +182,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	set_trigger(next_cycle);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -190,7 +192,7 @@ uint32_t sys_clock_elapsed(void)
 
 	uint64_t curr_cycle = rdtsc();
 	uint64_t delta_cycles = curr_cycle - last_cycle;
-	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
 
 	last_elapsed = delta_ticks;
 	return delta_ticks;

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -256,7 +256,7 @@ static void timer_int_handler(const void *unused)
 
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	/* If the kernel allows us to miss tick announcements in idle,
 	 * then shut off the counter. (Note: we can assume if idle==true
@@ -357,7 +357,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!TICKLESS) {
 		return 0;

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -31,7 +31,7 @@ static uint32_t cyc_per_tick;
 /*
  * We have two constraints on the maximum number of cycles we can wait for.
  *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
+ * 1) sys_clock_announce() may only accept at most INT32_MAX ticks.
  *
  * 2) The number of cycles between two reports must fit in a cycle_diff_t
  *    variable before converting it to ticks.
@@ -47,7 +47,9 @@ static uint32_t cyc_per_tick;
  * consecutive set bits coming from the original max values to produce a
  * nicer literal for assembly generation.
  */
-#define CYCLES_MAX_1	((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
+#define CYCLES_MAX_1                                                                               \
+	(IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? INT64_MAX                                              \
+					  : ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK))
 #define CYCLES_MAX_2	((uint64_t)CYCLE_DIFF_MAX)
 #define CYCLES_MAX_3	MIN(CYCLES_MAX_1, CYCLES_MAX_2)
 #define CYCLES_MAX_4	(CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
@@ -62,8 +64,8 @@ static uint64_t cycles_max;
 #endif
 
 static uint64_t last_cycle;
-static uint64_t last_tick;
-static uint32_t last_elapsed;
+static k_ticks_t last_tick;
+static k_ticks_delta_t last_elapsed;
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = ARM_ARCH_TIMER_IRQ;
@@ -95,7 +97,7 @@ static void arm_arch_timer_compare_isr(const void *arg)
 
 	uint64_t curr_cycle = arm_arch_timer_count();
 	uint64_t delta_cycles = curr_cycle - last_cycle;
-	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
 
 	last_cycle += (cycle_diff_t)delta_ticks * CYC_PER_TICK;
 	last_tick += delta_ticks;
@@ -134,7 +136,7 @@ static void arm_arch_timer_compare_isr(const void *arg)
 	sys_clock_announce_locked(delta_ticks, key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -161,7 +163,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	arm_arch_timer_set_irq_mask(false);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -171,7 +173,7 @@ uint32_t sys_clock_elapsed(void)
 
 	uint64_t curr_cycle = arm_arch_timer_count();
 	uint64_t delta_cycles = curr_cycle - last_cycle;
-	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
 
 	last_elapsed = delta_ticks;
 	return delta_ticks;

--- a/drivers/timer/cc13xx_cc26xx_rtc_timer.c
+++ b/drivers/timer/cc13xx_cc26xx_rtc_timer.c
@@ -187,14 +187,14 @@ static void startDevice(void)
 	irq_unlock(key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
 #ifdef CONFIG_TICKLESS_KERNEL
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t) MAX_TICKS);
+	ticks = CLAMP(ticks - 1, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
@@ -216,10 +216,9 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif /* CONFIG_TICKLESS_KERNEL */
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
-	uint32_t ret = (AONRTCCurrent64BitValueGet() - rtc_last) /
-		RTC_COUNTS_PER_TICK;
+	k_ticks_delta_t ret = (AONRTCCurrent64BitValueGet() - rtc_last) / RTC_COUNTS_PER_TICK;
 
 	return ret;
 }

--- a/drivers/timer/cc23x0_rtc_timer.c
+++ b/drivers/timer/cc23x0_rtc_timer.c
@@ -31,22 +31,28 @@ static uint32_t last_rtc_count;
 
 #define TICK_PERIOD_MICRO_SEC (1000000 / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
-	/* If timeout is necessary */
-	if (ticks != K_TICKS_FOREVER) {
-		/* Get current value as early as possible */
-		uint32_t ticks_now = HWREG(RTC_BASE + RTC_O_TIME8U);
+	if (ticks == K_TICKS_FOREVER) {
+		return;
+	}
 
-		if ((ticks_now + ticks) >= RTC_TIMEOUT_MAX) {
-			/* Reset timer and start from 0 */
-			HWREG(RTC_BASE + RTC_O_CTL) = RTC_CTL_RST_CLR;
-			HWREG(RTC_BASE + RTC_O_CH0CC8U) = ticks;
-		}
+	/* Hardware compare register is 32-bit; clamp to RTC_TIMEOUT_MAX so the
+	 * arithmetic below cannot overflow uint32_t or int64_t when the kernel
+	 * passes a large value such as SYS_CLOCK_MAX_WAIT.
+	 */
+	ticks = CLAMP(ticks, 0, (k_ticks_delta_t)RTC_TIMEOUT_MAX);
 
-		HWREG(RTC_BASE + RTC_O_CH0CC8U) = ticks_now + ticks;
+	uint32_t ticks_now = HWREG(RTC_BASE + RTC_O_TIME8U);
+
+	if (((uint64_t)ticks_now + (uint64_t)ticks) >= RTC_TIMEOUT_MAX) {
+		/* Reset timer and start from 0 */
+		HWREG(RTC_BASE + RTC_O_CTL) = RTC_CTL_RST_CLR;
+		HWREG(RTC_BASE + RTC_O_CH0CC8U) = (uint32_t)ticks;
+	} else {
+		HWREG(RTC_BASE + RTC_O_CH0CC8U) = ticks_now + (uint32_t)ticks;
 	}
 }
 
@@ -59,10 +65,10 @@ uint32_t get_elapsed_ticks_rtc(uint32_t current_rtc_count)
 	}
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
-	int32_t elapsed_ticks = get_elapsed_ticks_rtc(HWREG(RTC_BASE + RTC_O_TIME8U)) /
-						      TICK_PERIOD_MICRO_SEC;
+	k_ticks_delta_t elapsed_ticks =
+		get_elapsed_ticks_rtc(HWREG(RTC_BASE + RTC_O_TIME8U)) / TICK_PERIOD_MICRO_SEC;
 
 	return elapsed_ticks;
 }

--- a/drivers/timer/cc23x0_systim_timer.c
+++ b/drivers/timer/cc23x0_systim_timer.c
@@ -52,25 +52,30 @@ static int sys_clock_driver_init(void);
 /*
  * Set system clock timeout.
  */
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
-	/* If timeout is necessary */
-	if (ticks != K_TICKS_FOREVER) {
-		/* Get current value as early as possible */
-		uint32_t now_tick = HWREG(SYSTIM_BASE + SYSTIM_O_TIME1U);
-		uint32_t timeout = ticks * TICK_PERIOD_MICRO_SEC;
-
-		if (timeout > SYSTIM_TIMEOUT_MAX) {
-			timeout = SYSTIM_TIMEOUT_MAX;
-		}
-		/* This should wrap around */
-		HWREG(SYSTIM_BASE + SYSTIM_O_CH0CC) = now_tick + timeout;
+	if (ticks == K_TICKS_FOREVER) {
+		return;
 	}
+
+	/* Clamp ticks so the multiplication by TICK_PERIOD_MICRO_SEC cannot
+	 * overflow uint32_t (or int64_t) when the kernel passes a large value
+	 * such as SYS_CLOCK_MAX_WAIT. SYSTIM_TIMEOUT_MAX cycles is the maximum
+	 * interval the 32-bit hardware compare register can schedule.
+	 */
+	ticks = CLAMP(ticks, 0, (k_ticks_delta_t)(SYSTIM_TIMEOUT_MAX / TICK_PERIOD_MICRO_SEC));
+
+	/* Get current value as early as possible */
+	uint32_t now_tick = HWREG(SYSTIM_BASE + SYSTIM_O_TIME1U);
+	uint32_t timeout = (uint32_t)ticks * TICK_PERIOD_MICRO_SEC;
+
+	/* This should wrap around */
+	HWREG(SYSTIM_BASE + SYSTIM_O_CH0CC) = now_tick + timeout;
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	/* Get current value as early as possible */
 	uint32_t current_systim_count = HWREG(SYSTIM_BASE + SYSTIM_O_TIME1U);

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -90,7 +90,7 @@ static cycle_t announced_cycles;
  * announce. Used by sys_clock_set_timeout() to compute a tick-aligned
  * absolute deadline relative to announced_cycles.
  */
-static uint32_t last_elapsed;
+static k_ticks_delta_t last_elapsed;
 
 /*
  * This local variable holds the amount of elapsed HW cycles due to
@@ -255,7 +255,7 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 #endif /* CONFIG_TRACING_ISR */
 
 	uint32_t dcycles;
-	uint32_t dticks;
+	k_ticks_delta_t dticks;
 
 	k_spinlock_key_t key = sys_clock_lock();
 
@@ -315,7 +315,7 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 }
 ARCH_ISR_DIAG_ON
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -479,7 +479,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -489,7 +489,7 @@ uint32_t sys_clock_elapsed(void)
 
 	uint32_t unannounced = cycle_count - announced_cycles;
 	uint32_t cyc = elapsed() + unannounced;
-	uint32_t dticks = cyc / CYC_PER_TICK;
+	k_ticks_delta_t dticks = cyc / CYC_PER_TICK;
 
 	last_elapsed = dticks;
 	return dticks;
@@ -522,7 +522,8 @@ void sys_clock_idle_exit(void)
 	if (timeout_idle) {
 		k_spinlock_key_t key = sys_clock_lock();
 		cycle_t systick_diff, missed_cycles;
-		uint32_t dcycles, dticks;
+		uint32_t dcycles;
+		k_ticks_delta_t dticks;
 		uint64_t systick_us, idle_timer_us;
 
 #if !defined(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -97,7 +97,7 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 	sys_clock_announce(dticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 #if defined(CONFIG_TICKLESS_KERNEL)
 	if (systimer_hal.dev == NULL) {
@@ -105,7 +105,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks - 1, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t now = get_systimer_alarm();
@@ -143,7 +143,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
@@ -154,7 +154,8 @@ uint32_t sys_clock_elapsed(void)
 	}
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret = ((uint32_t)get_systimer_alarm() - (uint32_t)last_count) / CYC_PER_TICK;
+	k_ticks_delta_t ret =
+		((uint32_t)get_systimer_alarm() - (uint32_t)last_count) / CYC_PER_TICK;
 
 	k_spin_unlock(&lock, key);
 	return ret;

--- a/drivers/timer/gecko_burtc_timer.c
+++ b/drivers/timer/gecko_burtc_timer.c
@@ -109,7 +109,7 @@ static void burtc_isr(const void *arg)
 	sys_clock_announce(unannounced);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -158,7 +158,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&g_lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || !g_init) {
 		return 0;

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -232,8 +232,8 @@ __WARN("HPET_INT_LEVEL_TRIGGER has no effect, DTS setting is used instead")
 #endif /* (DT_INST_IRQ_HAS_CELL(0, flags)) */
 
 static __pinned_bss uint64_t last_count;
-static __pinned_bss uint64_t last_tick;
-static __pinned_bss uint32_t last_elapsed;
+static __pinned_bss k_ticks_t last_tick;
+static __pinned_bss k_ticks_delta_t last_elapsed;
 
 #ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 static __pinned_bss unsigned int cyc_per_tick;
@@ -308,7 +308,7 @@ static void hpet_isr(const void *arg)
 			now = last_count;
 		}
 	}
-	uint32_t dticks = (uint32_t)((now - last_count) / cyc_per_tick);
+	k_ticks_delta_t dticks = (now - last_count) / cyc_per_tick;
 
 	last_count += (uint64_t)dticks * cyc_per_tick;
 	last_tick += dticks;
@@ -352,8 +352,7 @@ void smp_timer_init(void)
 	 */
 }
 
-__pinned_func
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+__pinned_func void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -378,8 +377,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif
 }
 
-__pinned_func
-uint32_t sys_clock_elapsed(void)
+__pinned_func k_ticks_delta_t sys_clock_elapsed(void)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -388,7 +386,7 @@ uint32_t sys_clock_elapsed(void)
 	}
 
 	uint64_t now = hpet_counter_get();
-	uint32_t ret = (uint32_t)((now - last_count) / cyc_per_tick);
+	k_ticks_delta_t ret = (now - last_count) / cyc_per_tick;
 
 	last_elapsed = ret;
 	return ret;

--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -66,7 +66,7 @@ static void lptimer_interrupt_handler(void *handler_arg, cyhal_lptimer_event_t e
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : (delta_ticks > 0));
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -106,7 +106,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
@@ -119,11 +119,11 @@ uint32_t sys_clock_elapsed(void)
 	k_spin_unlock(&lock, key);
 
 	/* gives the value of LPTIM counter (ms) since the previous 'announce' */
-	uint64_t ret = (((uint64_t)(lptimer_value - last_lptimer_value)) *
-			CONFIG_SYS_CLOCK_TICKS_PER_SEC) /
-		       LPTIMER_FREQ;
+	k_ticks_delta_t ret = (((uint64_t)(lptimer_value - last_lptimer_value)) *
+			       CONFIG_SYS_CLOCK_TICKS_PER_SEC) /
+			      LPTIMER_FREQ;
 
-	return (uint32_t)ret;
+	return ret;
 }
 
 uint32_t sys_clock_cycle_get_32(void)

--- a/drivers/timer/infineon_lp_timer_pdl.c
+++ b/drivers/timer/infineon_lp_timer_pdl.c
@@ -199,7 +199,7 @@ static void lptimer_set_delay(uint32_t delay)
 	Cy_MCWDT_SetInterruptMask(reg_addr, CY_MCWDT_CTR1);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	uint64_t current_cycles;
 	uint32_t cycles_per_tick;
@@ -275,12 +275,12 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	uint32_t current_cycles;
 	uint32_t cycles_per_tick;
 	uint32_t delta_cycles;
-	uint32_t delta_ticks;
+	k_ticks_delta_t delta_ticks;
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -124,10 +124,10 @@ static void compare_isr(const void *arg)
 	set_compare(next);
 #endif
 
-	sys_clock_announce_locked((int32_t)dticks, key);
+	sys_clock_announce_locked((k_ticks_delta_t)dticks, key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -135,7 +135,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 #ifdef CONFIG_TICKLESS_KERNEL
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	uint64_t curr = count();
 	uint64_t next;
@@ -151,16 +151,16 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}
-	uint64_t ret = (count() - last_count) / CYC_PER_TICK;
+	k_ticks_delta_t ret = (count() - last_count) / CYC_PER_TICK;
 
-	return (uint32_t)ret;
+	return ret;
 }
 
 uint32_t sys_clock_cycle_get_32(void)

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -114,8 +114,8 @@ static struct k_spinlock lock;
 /* Last HW count that we called sys_clock_announce() */
 static volatile uint32_t last_announced_hw_cnt;
 /* Last system (kernel) elapse and ticks */
-static volatile uint32_t last_elapsed;
-static volatile uint32_t last_ticks;
+static volatile k_ticks_delta_t last_elapsed;
+static volatile k_ticks_t last_ticks;
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = DT_IRQ_BY_IDX(DT_NODELABEL(timer), 3, irq);
@@ -170,8 +170,9 @@ static void evt_timer_isr(const void *unused)
 		 * Get free run observer count from last time announced and transform unit to
 		 * system tick
 		 */
-		uint32_t dticks = (~(read_timer_obser(FREE_RUN_TIMER))-last_announced_hw_cnt) /
-				  HW_CNT_PER_SYS_TICK;
+		k_ticks_delta_t dticks =
+			(~(read_timer_obser(FREE_RUN_TIMER)) - last_announced_hw_cnt) /
+			HW_CNT_PER_SYS_TICK;
 		last_announced_hw_cnt += (dticks * HW_CNT_PER_SYS_TICK);
 		last_ticks += dticks;
 		last_elapsed = 0;
@@ -193,7 +194,7 @@ static void free_run_timer_overflow_isr(const void *unused)
 	/* TODO: to increment 32-bit "top half" here for software 64-bit timer emulation. */
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -227,7 +228,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	 * ideally no more than one system tick in the future. So set event timer count
 	 * to 1 HW tick.
 	 */
-	ticks = CLAMP(ticks, 1, (int32_t)EVEN_TIMER_MAX_CNT_SYS_TICK);
+	ticks = CLAMP(ticks, 1, (k_ticks_delta_t)EVEN_TIMER_MAX_CNT_SYS_TICK);
 	next_cycs = (last_ticks + last_elapsed + ticks) * HW_CNT_PER_SYS_TICK;
 	now = ~read_timer_obser(FREE_RUN_TIMER);
 	if (unlikely(next_cycs <= now)) {
@@ -249,7 +250,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Always return 0 for non-tickless kernel system */
@@ -260,8 +261,8 @@ uint32_t sys_clock_elapsed(void)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	/* Get free run observer count from last time announced and transform unit to system tick */
-	uint32_t dticks =
-		(~(read_timer_obser(FREE_RUN_TIMER))-last_announced_hw_cnt) / HW_CNT_PER_SYS_TICK;
+	k_ticks_delta_t dticks =
+		(~(read_timer_obser(FREE_RUN_TIMER)) - last_announced_hw_cnt) / HW_CNT_PER_SYS_TICK;
 
 	last_elapsed = dticks;
 

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -84,8 +84,8 @@ static struct k_spinlock lock;
 /* Last HW count that we called sys_clock_announce() */
 static volatile uint32_t last_announced_hw_cnt;
 /* Last system (kernel) elapse and ticks */
-static volatile uint32_t last_elapsed;
-static volatile uint32_t last_ticks;
+static volatile k_ticks_delta_t last_elapsed;
+static volatile k_ticks_t last_ticks;
 
 enum ext_timer_raw_cnt {
 	EXT_NOT_RAW_CNT = 0,
@@ -195,8 +195,9 @@ static void evt_timer_isr(const void *unused)
 		 * Get free run observer count from last time announced and
 		 * transform unit to system tick
 		 */
-		uint32_t dticks = (~(IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER)) -
-				   last_announced_hw_cnt) / HW_CNT_PER_SYS_TICK;
+		k_ticks_delta_t dticks =
+			(~(IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER)) - last_announced_hw_cnt) /
+			HW_CNT_PER_SYS_TICK;
 		last_announced_hw_cnt += (dticks * HW_CNT_PER_SYS_TICK);
 		last_ticks += dticks;
 		last_elapsed = 0;
@@ -223,7 +224,7 @@ static void free_run_timer_overflow_isr(const void *unused)
 	 */
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	uint32_t hw_cnt;
 
@@ -262,7 +263,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		 * as soon as possible, ideally no more than one system tick
 		 * in the future. So set event timer count to 1 HW tick.
 		 */
-		ticks = CLAMP(ticks, 1, (int32_t)EVEN_TIMER_MAX_CNT_SYS_TICK);
+		ticks = CLAMP(ticks, 1, (k_ticks_delta_t)EVEN_TIMER_MAX_CNT_SYS_TICK);
 
 		next_cycs = (last_ticks + last_elapsed + ticks) * HW_CNT_PER_SYS_TICK;
 		now = ~(IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER));
@@ -285,10 +286,10 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 	k_spin_unlock(&lock, key);
 
-	LOG_DBG("timeout is 0x%x, set hw count 0x%x", ticks, hw_cnt);
+	LOG_DBG("timeout is 0x%llx, set hw count 0x%x", (long long)ticks, hw_cnt);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Always return 0 for non-tickless kernel system */
@@ -301,8 +302,8 @@ uint32_t sys_clock_elapsed(void)
 	 * Get free run observer count from last time announced and transform
 	 * unit to system tick
 	 */
-	uint32_t dticks = (~(IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER)) -
-				last_announced_hw_cnt) / HW_CNT_PER_SYS_TICK;
+	k_ticks_delta_t dticks = (~(IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER)) - last_announced_hw_cnt) /
+				 HW_CNT_PER_SYS_TICK;
 	last_elapsed = dticks;
 
 	k_spin_unlock(&lock, key);

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -104,7 +104,7 @@ static uint32_t gptimer_ctrl_clear_ip;
  * single wrap.
  */
 static uint32_t announced_cyc; /* counter value at the last announce (tick-aligned) */
-static uint32_t last_elapsed;  /* ticks reported by the last sys_clock_elapsed() */
+static k_ticks_delta_t last_elapsed; /* ticks reported by the last sys_clock_elapsed() */
 
 static inline uint32_t up_counter(volatile struct gptimer_regs *regs)
 {
@@ -132,7 +132,7 @@ static void timer_isr(const void *unused)
 	ARG_UNUSED(unused);
 	volatile struct gptimer_regs *regs = get_regs();
 	volatile struct gptimer_timer_regs *tmr = &regs->timer[0];
-	uint32_t dticks;
+	k_ticks_delta_t dticks;
 
 	if ((tmr->ctrl & GPTIMER_CTRL_IP) == 0) {
 		return; /* interrupt not for us */
@@ -159,7 +159,7 @@ static void timer_isr(const void *unused)
 	sys_clock_announce(dticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 	volatile struct gptimer_regs *regs = get_regs();
@@ -174,13 +174,14 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		ticks = MAX_TICKS;
 	}
 
-	/* The ISR eventually announces last_elapsed + ticks (plus IRQ-servicing
-	 * latency) and sys_clock_announce() takes an int32_t. Keep the sum
-	 * within INT32_MAX, reserving half the range for the latency.
+	/* The deadline is programmed as a 32-bit cycle reload, then read back
+	 * as a signed int32_t delay against the free-running counter. Keep
+	 * (last_elapsed + ticks) * CYC_PER_TICK below INT32_MAX / 2 - i.e.
+	 * last_elapsed + ticks <= MAX_TICKS / 2 in ticks - so the delay stays
+	 * positive when interpreted as int32_t, with half the range reserved
+	 * for IRQ-servicing latency.
 	 */
-	if (ticks > (INT32_MAX / 2 - last_elapsed)) {
-		ticks = INT32_MAX / 2 - last_elapsed;
-	}
+	ticks = CLAMP(ticks, 0, MAX(0, (k_ticks_delta_t)(MAX_TICKS / 2) - last_elapsed));
 
 	/* Absolute, tick-aligned deadline from the last announce, programmed as
 	 * a relative delay. last_elapsed is the tick count already reported via
@@ -196,7 +197,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	program_subtimer0(regs, delay);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	volatile struct gptimer_regs *regs = get_regs();
 

--- a/drivers/timer/litex_timer.c
+++ b/drivers/timer/litex_timer.c
@@ -74,7 +74,7 @@ uint64_t sys_clock_cycle_get_64(void)
 }
 
 /* tickless kernel is not supported */
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	return 0;
 }

--- a/drivers/timer/max32_rv32_sys_timer.c
+++ b/drivers/timer/max32_rv32_sys_timer.c
@@ -39,12 +39,14 @@ static const struct max32_perclk perclk = {
 
 static struct k_spinlock lock;
 static uint32_t last_cycle;
-static uint32_t last_tick;
-static uint32_t last_elapsed;
+static k_ticks_t last_tick;
+static k_ticks_delta_t last_elapsed;
 
 #define CYCLE_DIFF_MAX (~(uint32_t)0)
 
-#define CYCLES_MAX_1 ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
+#define CYCLES_MAX_1                                                                               \
+	(IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? INT64_MAX                                              \
+					  : ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK))
 #define CYCLES_MAX_2 ((uint64_t)CYCLE_DIFF_MAX)
 #define CYCLES_MAX_3 MIN(CYCLES_MAX_1, CYCLES_MAX_2)
 #define CYCLES_MAX_4 (CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
@@ -67,7 +69,7 @@ static void rv32_sys_timer_irq_handler(const struct device *unused)
 
 	uint32_t curr_cycle = MXC_TMR_GetCount(regs);
 	uint32_t delta_cycles = curr_cycle - last_cycle;
-	uint32_t delta_ticks = (uint32_t)delta_cycles / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = delta_cycles / CYC_PER_TICK;
 
 	last_cycle += (uint32_t)delta_ticks * CYC_PER_TICK;
 	last_tick += delta_ticks;
@@ -91,7 +93,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	return MXC_TMR_GetCount(regs) * DT_INST_PROP(0, prescaler);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
@@ -100,8 +102,8 @@ uint32_t sys_clock_elapsed(void)
 	uint32_t curr_cycle = MXC_TMR_GetCount(regs);
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	int32_t delta_cycles = curr_cycle - last_cycle;
-	int32_t delta_ticks = (uint32_t)delta_cycles / CYC_PER_TICK;
+	uint32_t delta_cycles = curr_cycle - last_cycle;
+	k_ticks_delta_t delta_ticks = delta_cycles / CYC_PER_TICK;
 
 	last_elapsed = delta_ticks;
 	k_spin_unlock(&lock, key);
@@ -109,7 +111,7 @@ uint32_t sys_clock_elapsed(void)
 	return delta_ticks;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
@@ -123,12 +125,16 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	uint32_t next_cycle;
 	uint32_t count;
 
-	if (ticks == INT32_MAX) {
+	if (ticks == SYS_CLOCK_MAX_WAIT) {
 		next_cycle = (last_tick * CYC_PER_TICK) + CYCLES_MAX;
 	} else if (ticks == 0) {
 		next_cycle = MXC_TMR_GetCount(regs) + (CYC_PER_TICK * 3 / 2);
 		next_cycle -= (next_cycle % CYC_PER_TICK);
 	} else {
+		/* Clamp ticks so the multiplication by CYC_PER_TICK below cannot
+		 * overflow when the kernel passes a large value.
+		 */
+		ticks = CLAMP(ticks, 0, (k_ticks_delta_t)(CYCLES_MAX / CYC_PER_TICK));
 		next_cycle = (last_tick + last_elapsed + ticks) * CYC_PER_TICK;
 		if ((next_cycle - last_cycle) > CYCLES_MAX) {
 			next_cycle = (last_tick * CYC_PER_TICK) + CYCLES_MAX;

--- a/drivers/timer/max32_wut_timer.c
+++ b/drivers/timer/max32_wut_timer.c
@@ -53,7 +53,7 @@ static void max32_wut_timer_isr(const void *arg)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	uint32_t curr = MXC_WUT_GetCount(WUT_REGS);
-	uint32_t delta_ticks = (curr - last_count) / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = (curr - last_count) / CYC_PER_TICK;
 
 	last_count += delta_ticks * CYC_PER_TICK;
 
@@ -72,7 +72,7 @@ static void max32_wut_timer_isr(const void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : 1);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -84,7 +84,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		ticks = MAX_TICKS;
 	}
 
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks - 1, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
@@ -110,7 +110,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
@@ -119,7 +119,7 @@ uint32_t sys_clock_elapsed(void)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	uint32_t curr = MXC_WUT_GetCount(WUT_REGS);
-	uint32_t delta_ticks = (curr - last_count) / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = (curr - last_count) / CYC_PER_TICK;
 
 	k_spin_unlock(&lock, key);
 

--- a/drivers/timer/mchp_sam_pit64b_timer.c
+++ b/drivers/timer/mchp_sam_pit64b_timer.c
@@ -61,7 +61,7 @@ static void pit64b_isr(const void *arg)
 	ARG_UNUSED(arg);
 
 	uint32_t dcycles;
-	uint32_t delta_ticks;
+	k_ticks_delta_t delta_ticks;
 
 	(void)cycles_elapsed();
 
@@ -71,7 +71,7 @@ static void pit64b_isr(const void *arg)
 
 		dcycles = cycle_count - announced_cycles;
 		delta_ticks = dcycles / CYCLES_PER_TICK;
-		announced_cycles += delta_ticks * CYCLES_PER_TICK;
+		announced_cycles += (cycle_t)delta_ticks * CYCLES_PER_TICK;
 
 		sys_clock_announce(delta_ticks);
 	} else {
@@ -79,7 +79,7 @@ static void pit64b_isr(const void *arg)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -94,6 +94,11 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	uint32_t delay;
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
+	/* Hardware compare value is 21-bit (MAX_CYCLES); clamp ticks so the
+	 * multiplication by CYCLES_PER_TICK below cannot overflow uint32_t when
+	 * the kernel passes a large value such as SYS_CLOCK_MAX_WAIT.
+	 */
+	ticks = CLAMP(ticks, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	key = k_spin_lock(&lock);
 	cycle_count += cycles_elapsed();
@@ -130,7 +135,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	uint32_t cycles;
 

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -182,14 +182,14 @@ static uint32_t last_announcement; /* last time we called sys_clock_announce() *
  * Writing a new value to preload only takes effect once the count
  * register reaches 0.
  */
-void sys_clock_set_timeout(int32_t n, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t n, bool idle)
 {
 	ARG_UNUSED(idle);
 
 	uint32_t ccr, temp;
-	int full_ticks;          /* number of complete ticks we'll wait */
-	uint32_t full_cycles;    /* full_ticks represented as cycles */
-	uint32_t partial_cycles; /* number of cycles to first tick boundary */
+	k_ticks_delta_t full_ticks; /* number of complete ticks we'll wait */
+	uint32_t full_cycles;       /* full_ticks represented as cycles */
+	uint32_t partial_cycles;    /* number of cycles to first tick boundary */
 
 	if (idle && (n == K_TICKS_FOREVER)) {
 		/*
@@ -243,10 +243,10 @@ void sys_clock_set_timeout(int32_t n, bool idle)
  * sys_clock_announce in the ISR. The caller casts uint32_t to int32_t.
  * We must make sure bit[31] is 0 in the return value.
  */
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	uint32_t ccr;
-	uint32_t ticks;
+	k_ticks_delta_t ticks;
 	int32_t elapsed;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
@@ -258,7 +258,7 @@ uint32_t sys_clock_elapsed(void)
 	if (elapsed < 0) {
 		elapsed = -1 * elapsed;
 	}
-	ticks = (uint32_t)elapsed;
+	ticks = (k_ticks_delta_t)elapsed;
 	ticks += cached_icr - ccr;
 	ticks /= CYCLES_PER_TICK;
 	ticks &= TIMER_COUNT_MASK;
@@ -273,7 +273,7 @@ static void xec_rtos_timer_isr(const void *arg)
 	ARG_UNUSED(arg);
 
 	uint32_t cycles;
-	int32_t ticks;
+	k_ticks_delta_t ticks;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
@@ -322,7 +322,7 @@ static void xec_rtos_timer_isr(const void *arg)
 	sys_clock_announce(1);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	return 0U;
 }

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -130,7 +130,7 @@ void mcux_imx_gpt_isr(const void *arg)
  * Next needed call to sys_clock_announce will not be until the specified number
  * of ticks from the current time have elapsed.
  */
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Not supported on tickful kernels */
@@ -141,7 +141,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	/* Clamp ticks. We subtract one since we round up to next tick */
-	ticks = CLAMP((ticks - 1), 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP((ticks - 1), 0, (k_ticks_delta_t)MAX_TICKS);
 
 	key = k_spin_lock(&lock);
 
@@ -165,7 +165,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 }
 
 /* Get the number of ticks since the last call to sys_clock_announce() */
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Always return 0 for tickful kernel system */

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -66,7 +66,7 @@ static inline uint32_t counter_delta(uint32_t now, uint32_t then)
 	return (now - then) & COUNTER_MAX;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -83,7 +83,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	/* Clamp ticks. We subtract one since we round up to next tick */
-	ticks = CLAMP((ticks - 1), 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP((ticks - 1), 0, (k_ticks_delta_t)MAX_TICKS);
 
 	key = k_spin_lock(&lock);
 
@@ -150,7 +150,7 @@ void sys_clock_disable(void)
 	LPTMR_StopTimer(LPTMR_BASE);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -27,7 +27,11 @@
 	((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() /                                      \
 		    (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
 #define CYC_PER_US ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() / (uint64_t)USEC_PER_SEC))
+#ifdef CONFIG_TIMEOUT_64BIT
+#define MAX_CYC INT64_MAX
+#else
 #define MAX_CYC    INT_MAX
+#endif
 #define MAX_TICKS  ((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
 #define MIN_DELAY  CONFIG_MCUX_OS_TIMER_MIN_DELAY
 
@@ -65,10 +69,10 @@ void mcux_os_timer_set_next_tick_match(void)
 	OSTIMER_SetMatchValue(base, next_tick_cycles_match, NULL);
 }
 
-static uint32_t mcux_os_timer_calc_elapsed_ticks(uint64_t current_cycles)
+static k_ticks_delta_t mcux_os_timer_calc_elapsed_ticks(uint64_t current_cycles)
 {
 	uint64_t elapsed_cycles = current_cycles - last_count;
-	uint32_t elapsed_ticks = (uint32_t)elapsed_cycles / CYC_PER_TICK;
+	k_ticks_delta_t elapsed_ticks = (k_ticks_delta_t)(elapsed_cycles / CYC_PER_TICK);
 	return elapsed_ticks;
 }
 
@@ -82,7 +86,7 @@ void mcux_lpc_ostick_isr(const void *arg)
 	base->OSEVENT_CTRL &= ~OSTIMER_OSEVENT_CTRL_OSTIMER_INTENA_MASK;
 
 	uint64_t now = mcux_lpc_ostick_get_compensated_timer_value();
-	uint32_t elapsed_ticks = mcux_os_timer_calc_elapsed_ticks(now);
+	k_ticks_delta_t elapsed_ticks = mcux_os_timer_calc_elapsed_ticks(now);
 
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/*
@@ -244,7 +248,7 @@ bool z_nxp_os_timer_ignore_timer_wakeup(void)
 	return (wait_forever || counter_remaining_ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Only for tickless kernel system */
@@ -268,14 +272,14 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	ARG_UNUSED(idle);
 #endif
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks - 1, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t now = mcux_lpc_ostick_get_compensated_timer_value();
-	uint32_t adj, cyc = ticks * CYC_PER_TICK;
+	uint64_t adj, cyc = (uint64_t)ticks * CYC_PER_TICK;
 
 	/* Round up to next tick boundary. */
-	adj = (uint32_t)(now - last_count) + (CYC_PER_TICK - 1);
+	adj = (uint64_t)(now - last_count) + (CYC_PER_TICK - 1);
 	if (cyc <= MAX_CYC - adj) {
 		cyc += adj;
 	} else {
@@ -283,7 +287,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	}
 	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
 
-	if ((int32_t)(cyc + last_count - now) < MIN_DELAY) {
+	if ((int64_t)(cyc + last_count - now) < MIN_DELAY) {
 		cyc += CYC_PER_TICK;
 	}
 
@@ -294,7 +298,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Always return 0 for tickful kernel system */
@@ -304,7 +308,7 @@ uint32_t sys_clock_elapsed(void)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	uint64_t now = mcux_lpc_ostick_get_compensated_timer_value();
-	uint32_t elapsed_ticks = mcux_os_timer_calc_elapsed_ticks(now);
+	k_ticks_delta_t elapsed_ticks = mcux_os_timer_calc_elapsed_ticks(now);
 
 	k_spin_unlock(&lock, key);
 

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -61,7 +61,7 @@ static void timer_isr(const void *arg)
 	sys_clock_announce(TICKLESS ? dticks : 1);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -70,7 +70,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks - 1, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t current_count = get_cp0_count();
@@ -94,14 +94,14 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!TICKLESS) {
 		return 0;
 	}
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ticks_elapsed = (get_cp0_count() - last_count) / CYC_PER_TICK;
+	k_ticks_delta_t ticks_elapsed = (get_cp0_count() - last_count) / CYC_PER_TICK;
 
 	k_spin_unlock(&lock, key);
 	return ticks_elapsed;

--- a/drivers/timer/mtk_adsp_timer.c
+++ b/drivers/timer/mtk_adsp_timer.c
@@ -135,7 +135,7 @@ uint64_t sys_clock_cycle_get_64(void)
 	return (((uint64_t)h0) << 32) | l;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	/* Compute desired expiration time */
 	uint64_t now = sys_clock_cycle_get_64();
@@ -165,13 +165,12 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret;
+	k_ticks_delta_t ret;
 
-	ret = (uint32_t)((sys_clock_cycle_get_64() - last_announce)
-			 / OST64_PER_TICK);
+	ret = (sys_clock_cycle_get_64() - last_announce) / OST64_PER_TICK;
 	k_spin_unlock(&lock, key);
 	return ret;
 }

--- a/drivers/timer/native_sim_timer.c
+++ b/drivers/timer/native_sim_timer.c
@@ -44,7 +44,7 @@ static void np_timer_isr(const void *arg)
 	ARG_UNUSED(arg);
 
 	uint64_t now = nsi_hws_get_time();
-	int32_t elapsed_ticks = (now - last_tick_time)/tick_period;
+	k_ticks_delta_t elapsed_ticks = (now - last_tick_time) / tick_period;
 
 	last_tick_time += elapsed_ticks*tick_period;
 	sys_clock_announce(elapsed_ticks);
@@ -71,16 +71,14 @@ void np_timer_isr_test_hook(const void *arg)
  * @param idle Hint to the driver that the system is about to enter
  *        the idle state immediately after setting the timeout
  */
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint64_t silent_ticks;
 
-	/* Note that we treat INT_MAX literally as anyhow the maximum amount of
-	 * ticks we can report with sys_clock_announce() is INT_MAX
-	 */
+	/* K_TICKS_FOREVER means park the simulated timer indefinitely. */
 	if (ticks == K_TICKS_FOREVER) {
 		silent_ticks = INT64_MAX;
 	} else if (ticks > 0) {
@@ -100,7 +98,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
  * this with appropriate locking, the driver needs only provide an
  * instantaneous answer.
  */
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	return (nsi_hws_get_time() - last_tick_time)/tick_period;
 }

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -71,8 +71,8 @@ static const struct npcx_clk_cfg itim_clk_cfg[] = NPCX_DT_CLK_CFG_ITEMS_LIST(0);
 static struct k_spinlock lock;
 /* Announced cycles in system timer before executing sys_clock_announce() */
 static uint64_t cyc_sys_announced;
-static uint64_t last_ticks;
-static uint32_t last_elapsed;
+static k_ticks_t last_ticks;
+static k_ticks_delta_t last_elapsed;
 
 /* Current target cycles of time-out signal in event timer */
 static uint32_t cyc_evt_timeout;
@@ -138,7 +138,7 @@ static inline void npcx_itim_evt_disable(void)
 }
 
 /* ITIM local functions */
-static int npcx_itim_start_evt_tmr_by_tick(int32_t ticks)
+static int npcx_itim_start_evt_tmr_by_tick(k_ticks_delta_t ticks)
 {
 	/*
 	 * Get desired cycles of event timer from the requested ticks which
@@ -168,7 +168,7 @@ static int npcx_itim_start_evt_tmr_by_tick(int32_t ticks)
 			cyc_evt_timeout = CLAMP(dticks, 1, NPCX_ITIM32_MAX_CNT);
 		}
 	}
-	LOG_DBG("ticks %x, cyc_evt_timeout %x", ticks, cyc_evt_timeout);
+	LOG_DBG("ticks %llx, cyc_evt_timeout %x", (long long)ticks, cyc_evt_timeout);
 
 	/* Disable event timer if needed before configuring counter */
 	if (IS_BIT_SET(evt_tmr->ITCTS32, NPCX_ITCTSXX_ITEN)) {
@@ -194,7 +194,7 @@ static void npcx_itim_evt_isr(const struct device *dev)
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		k_spinlock_key_t key = k_spin_lock(&lock);
 		uint64_t curr = npcx_itim_get_sys_cyc64();
-		uint32_t delta_ticks = (uint32_t)((curr - cyc_sys_announced) / SYS_CYCLES_PER_TICK);
+		k_ticks_delta_t delta_ticks = (curr - cyc_sys_announced) / SYS_CYCLES_PER_TICK;
 
 		cyc_sys_announced += delta_ticks * SYS_CYCLES_PER_TICK;
 		last_ticks += delta_ticks;
@@ -252,7 +252,7 @@ static uint32_t npcx_itim_evt_elapsed_cyc32(void)
 #endif /* CONFIG_PM */
 
 /* System timer api functions */
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -261,7 +261,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		return;
 	}
 
-	LOG_DBG("timeout is %d", ticks);
+	LOG_DBG("timeout is %lld", (long long)ticks);
 	/* Start a event timer in ticks */
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
@@ -269,7 +269,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Always return 0 for tickful kernel system */
@@ -278,7 +278,7 @@ uint32_t sys_clock_elapsed(void)
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t delta_cycle = npcx_itim_get_sys_cyc64() - cyc_sys_announced;
-	uint32_t delta_ticks = (uint32_t)(delta_cycle / SYS_CYCLES_PER_TICK);
+	k_ticks_delta_t delta_ticks = (k_ticks_delta_t)(delta_cycle / SYS_CYCLES_PER_TICK);
 
 	last_elapsed = delta_ticks;
 	k_spin_unlock(&lock, key);

--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -159,7 +159,7 @@ static void sys_clock_timeout_handler(int32_t id, uint64_t cc_val, void *p_conte
 {
 	ARG_UNUSED(id);
 	ARG_UNUSED(p_context);
-	uint32_t dticks;
+	k_ticks_delta_t dticks;
 
 	sys_event_unregister(false);
 	dticks = counter_sub(cc_val, last_count) / CYC_PER_TICK;
@@ -174,7 +174,7 @@ static void sys_clock_timeout_handler(int32_t id, uint64_t cc_val, void *p_conte
 	}
 
 	last_elapsed = 0;
-	sys_clock_announce((int32_t)dticks);
+	sys_clock_announce(dticks);
 }
 
 int32_t z_nrf_grtc_timer_chan_alloc(void)
@@ -487,7 +487,7 @@ uint64_t sys_clock_cycle_get_64(void)
 	return counter();
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
@@ -495,7 +495,7 @@ uint32_t sys_clock_elapsed(void)
 
 	last_elapsed = counter_sub(counter(), last_count);
 
-	return (uint32_t)(last_elapsed / CYC_PER_TICK);
+	return last_elapsed / CYC_PER_TICK;
 }
 
 #if !defined(CONFIG_GEN_SW_ISR_TABLE)
@@ -626,7 +626,7 @@ static int grtc_post_init(void)
 #endif
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -667,7 +667,7 @@ bail:
 	return err;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 	uint64_t target_time;
@@ -696,7 +696,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	compare_set(SYS_CLOCK_CH, target_time, sys_clock_timeout_handler, NULL, false);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;

--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -16,8 +16,8 @@
 
 static struct k_spinlock lock;
 static uint32_t last_count;
-static uint64_t last_ticks;
-static uint32_t last_elapsed;
+static k_ticks_t last_ticks;
+static k_ticks_delta_t last_elapsed;
 static uint32_t cyc_per_tick;
 
 static ALWAYS_INLINE void set_compare(uint32_t time)
@@ -45,7 +45,7 @@ void z_openrisc_timer_isr(void)
 
 	const uint32_t current_count = get_count();
 	const uint32_t delta_count = current_count - last_count;
-	const uint32_t delta_ticks = delta_count / cyc_per_tick;
+	const k_ticks_delta_t delta_ticks = delta_count / cyc_per_tick;
 
 	last_count += delta_ticks * cyc_per_tick;
 	last_ticks += delta_ticks;
@@ -65,7 +65,7 @@ void z_openrisc_timer_isr(void)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 #if defined(CONFIG_TICKLESS_KERNEL)
 	if (ticks == K_TICKS_FOREVER) {
@@ -73,7 +73,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 			return;
 		}
 
-		ticks = INT32_MAX;
+		/* Program the hardware for its maximum timeout. */
+		ticks = MAX_CYC / 2 / cyc_per_tick;
 	}
 
 	/*
@@ -97,7 +98,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
@@ -107,7 +108,7 @@ uint32_t sys_clock_elapsed(void)
 
 	const uint32_t current_count = get_count();
 	const uint32_t delta_count = current_count - last_count;
-	const uint32_t delta_ticks = delta_count / cyc_per_tick;
+	const k_ticks_delta_t delta_ticks = delta_count / cyc_per_tick;
 
 	last_elapsed = delta_ticks;
 	k_spin_unlock(&lock, key);

--- a/drivers/timer/rcar_cmt_timer.c
+++ b/drivers/timer/rcar_cmt_timer.c
@@ -72,7 +72,7 @@ static void cmt_isr(void *arg)
 	sys_clock_announce(1);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	/* Always return 0 for tickful operation */
 	return 0;

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -70,7 +70,7 @@ static void rtmr_isr(const void *arg)
 	ARG_UNUSED(arg);
 
 	uint32_t cycles;
-	int32_t ticks;
+	k_ticks_delta_t ticks;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
@@ -98,12 +98,12 @@ static void rtmr_isr(const void *arg)
 	sys_clock_announce(ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
 	uint32_t cur_cnt, temp;
-	int full_ticks;
+	k_ticks_delta_t full_ticks;
 	uint32_t full_cycles;
 	uint32_t partial_cycles;
 
@@ -146,10 +146,10 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	uint32_t cur_cnt;
-	uint32_t ticks;
+	k_ticks_delta_t ticks;
 	int32_t elapsed;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
@@ -160,7 +160,7 @@ uint32_t sys_clock_elapsed(void)
 	if (elapsed < 0) {
 		elapsed = -1 * elapsed;
 	}
-	ticks = (uint32_t)elapsed;
+	ticks = (k_ticks_delta_t)elapsed;
 	ticks += previous_cnt - cur_cnt;
 	ticks /= CYCLES_PER_TICK;
 	ticks &= RTMR_COUNTER_MSK;

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -54,7 +54,7 @@ static void ra_ulpt_timer_isr(void)
 {
 	uint32_t cycles;
 	uint32_t dcycles;
-	uint32_t dticks;
+	k_ticks_delta_t dticks;
 	IRQn_Type irq = R_FSP_CurrentIrqGet();
 
 	/* Clear pending IRQ to prevent re-triggering. */
@@ -82,7 +82,7 @@ static void ra_ulpt_timer_isr(void)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -91,18 +91,18 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		return;
 	}
 
-	/* No timeout change for K_TICKS_FOREVER or INT32_MAX. */
-	if (ticks == K_TICKS_FOREVER || ticks == INT32_MAX) {
+	/* No timeout change for K_TICKS_FOREVER or SYS_CLOCK_MAX_WAIT. */
+	if (ticks == K_TICKS_FOREVER || ticks == SYS_CLOCK_MAX_WAIT) {
 		return;
 	}
 
 	/* Clamp the ticks value to a valid range. */
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks - 1, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	/* Calculate the timer delay in cycles. */
 	uint32_t cycles = ~RA_ULPT_INST1_REG->ULPTCNT;
 	uint32_t unannounced = cycles - cycle_announced;
-	uint32_t delay = ticks * CYCLE_PER_TICK;
+	uint32_t delay = (uint32_t)ticks * CYCLE_PER_TICK;
 
 	/* Adjust delay to align with tick boundaries. */
 	delay += unannounced;
@@ -115,7 +115,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	RA_ULPT_INST0_REG->ULPTCNT = delay - 1U;
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	/* Elapsed time calculation is unsupported in tickful mode. */
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -120,7 +120,7 @@ uint64_t sys_clock_cycle_get_64(void)
 }
 #endif /* CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER */
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Always return 0 for tickful operation */
@@ -129,18 +129,19 @@ uint32_t sys_clock_elapsed(void)
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	uint32_t ret;
+	k_ticks_delta_t ret;
 	cycle_t current_cycle_count;
 
 	current_cycle_count = cmt1_elapsed();
 
 	if (current_cycle_count < announced_cycle_count) {
 		/* cycle_count overflowed */
-		ret = (uint32_t)((current_cycle_count +
-				  (CYCLE_COUNT_MAX - announced_cycle_count + 1)) /
-				 CYCLES_PER_TICK);
+		ret = (k_ticks_delta_t)((current_cycle_count +
+					 (CYCLE_COUNT_MAX - announced_cycle_count + 1)) /
+					CYCLES_PER_TICK);
 	} else {
-		ret = (uint32_t)((current_cycle_count - announced_cycle_count) / CYCLES_PER_TICK);
+		ret = (k_ticks_delta_t)((current_cycle_count - announced_cycle_count) /
+					CYCLES_PER_TICK);
 	}
 
 	k_spin_unlock(&lock, key);
@@ -150,7 +151,7 @@ uint32_t sys_clock_elapsed(void)
 
 static void cmt0_isr(void)
 {
-	k_ticks_t dticks;
+	k_ticks_delta_t dticks;
 	cycle_t current_cycle_count;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
@@ -159,12 +160,12 @@ static void cmt0_isr(void)
 
 	if (current_cycle_count < announced_cycle_count) {
 		/* cycle_count overflowed */
-		dticks = (k_ticks_t)((current_cycle_count +
-				      (CYCLE_COUNT_MAX - announced_cycle_count + 1)) /
-				     CYCLES_PER_TICK);
+		dticks = (k_ticks_delta_t)((current_cycle_count +
+					    (CYCLE_COUNT_MAX - announced_cycle_count + 1)) /
+					   CYCLES_PER_TICK);
 	} else {
-		dticks = (k_ticks_t)((current_cycle_count - announced_cycle_count) /
-				     CYCLES_PER_TICK);
+		dticks = (k_ticks_delta_t)((current_cycle_count - announced_cycle_count) /
+					   CYCLES_PER_TICK);
 	}
 
 	announced_cycle_count = (current_cycle_count / CYCLES_PER_TICK) * CYCLES_PER_TICK;
@@ -207,17 +208,17 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
 
-	if (ticks == K_TICKS_FOREVER || ticks == INT32_MAX) {
+	if (ticks == K_TICKS_FOREVER || ticks == SYS_CLOCK_MAX_WAIT) {
 		return;
 	}
 
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks - 1, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 

--- a/drivers/timer/renesas_rz_gtm_timer.c
+++ b/drivers/timer/renesas_rz_gtm_timer.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(renesas_rz_gtm_timer);
 /*
  * We have two constraints on the maximum number of cycles we can wait for.
  *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
+ * 1) sys_clock_announce() may only accept at most INT32_MAX ticks.
  *
  * 2) The number of cycles between two reports must fit in a cycle_diff_t
  *    variable before converting it to ticks.
@@ -38,7 +38,9 @@ LOG_MODULE_REGISTER(renesas_rz_gtm_timer);
  * consecutive set bits coming from the original max values to produce a
  * nicer literal for assembly generation.
  */
-#define CYCLES_MAX_1 ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
+#define CYCLES_MAX_1                                                                               \
+	(IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? INT64_MAX                                              \
+					  : ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK))
 #define CYCLES_MAX_2 ((uint64_t)CYCLE_DIFF_MAX)
 #define CYCLES_MAX_3 MIN(CYCLES_MAX_1, CYCLES_MAX_2)
 #define CYCLES_MAX_4 (CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
@@ -65,8 +67,8 @@ struct rz_os_timer_data {
 	timer_ctrl_t *fsp_ctrl;
 	struct k_spinlock lock;
 	uint32_t last_cycle;
-	uint32_t last_tick;
-	uint32_t last_elapsed;
+	k_ticks_t last_tick;
+	k_ticks_delta_t last_elapsed;
 };
 
 void rz_os_timer_gtm_isr(const struct device *dev)
@@ -84,7 +86,7 @@ static void ostm_irq_handler(timer_callback_args_t *arg)
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 	uint32_t delta_cycles = sys_clock_cycle_get_32() - data->last_cycle;
-	uint32_t delta_ticks = delta_cycles / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = delta_cycles / CYC_PER_TICK;
 
 	data->last_cycle += delta_ticks * CYC_PER_TICK;
 	data->last_tick += delta_ticks;
@@ -105,7 +107,7 @@ static void ostm_irq_handler(timer_callback_args_t *arg)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
@@ -124,6 +126,11 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	if (ticks == K_TICKS_FOREVER) {
 		next_cycle = data->last_cycle + CYCLES_MAX;
 	} else {
+		/* Clamp ticks so the multiplication by CYC_PER_TICK below cannot
+		 * overflow when the kernel passes a large value such as
+		 * SYS_CLOCK_MAX_WAIT.
+		 */
+		ticks = CLAMP(ticks, 0, (k_ticks_delta_t)(CYCLES_MAX / CYC_PER_TICK));
 		next_cycle = (data->last_tick + data->last_elapsed + ticks) * CYC_PER_TICK;
 		if ((next_cycle - data->last_cycle) > CYCLES_MAX) {
 			next_cycle = data->last_cycle + CYCLES_MAX;
@@ -136,7 +143,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&data->lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
@@ -145,7 +152,7 @@ uint32_t sys_clock_elapsed(void)
 	struct rz_os_timer_data *data = (struct rz_os_timer_data *)g_os_timer_dev->data;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 	uint32_t delta_cycles = sys_clock_cycle_get_32() - data->last_cycle;
-	uint32_t delta_ticks = delta_cycles / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = delta_cycles / CYC_PER_TICK;
 
 	data->last_elapsed = delta_ticks;
 	k_spin_unlock(&data->lock, key);

--- a/drivers/timer/renesas_rza2m_os_timer.c
+++ b/drivers/timer/renesas_rza2m_os_timer.c
@@ -62,7 +62,7 @@ const int32_t z_sys_timer_irq_for_test = OSTM_IRQ_NUM;
 /*
  * We have two constraints on the maximum number of cycles we can wait for.
  *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
+ * 1) sys_clock_announce() may only accept at most INT32_MAX ticks.
  *
  * 2) The number of cycles between two reports must fit in a cycle_diff_t
  *    variable before converting it to ticks.
@@ -78,7 +78,9 @@ const int32_t z_sys_timer_irq_for_test = OSTM_IRQ_NUM;
  * consecutive set bits coming from the original max values to produce a
  * nicer literal for assembly generation.
  */
-#define CYCLES_MAX_1 ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
+#define CYCLES_MAX_1                                                                               \
+	(IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? INT64_MAX                                              \
+					  : ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK))
 #define CYCLES_MAX_2 ((uint64_t)CYCLE_DIFF_MAX)
 #define CYCLES_MAX_3 MIN(CYCLES_MAX_1, CYCLES_MAX_2)
 #define CYCLES_MAX_4 (CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
@@ -92,8 +94,8 @@ static uint32_t cyc_per_tick;
 
 static struct k_spinlock lock;
 static uint32_t last_cycle;
-static uint32_t last_tick;
-static uint32_t last_elapsed;
+static k_ticks_t last_tick;
+static k_ticks_delta_t last_elapsed;
 extern unsigned int z_clock_hw_cycles_per_sec;
 
 static void ostm_irq_handler(const struct device *dev)
@@ -101,7 +103,7 @@ static void ostm_irq_handler(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	uint32_t delta_cycles = sys_clock_cycle_get_32() - last_cycle;
-	uint32_t delta_ticks = delta_cycles / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = delta_cycles / CYC_PER_TICK;
 
 	last_cycle += (cycle_diff_t)delta_ticks * CYC_PER_TICK;
 	last_tick += delta_ticks;
@@ -119,7 +121,7 @@ static void ostm_irq_handler(const struct device *dev)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
@@ -136,6 +138,11 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	if (ticks == K_TICKS_FOREVER) {
 		next_cycle = last_cycle + CYCLES_MAX;
 	} else {
+		/* Clamp ticks so the multiplication by CYC_PER_TICK below cannot
+		 * overflow when the kernel passes a large value such as
+		 * SYS_CLOCK_MAX_WAIT.
+		 */
+		ticks = CLAMP(ticks, 0, (k_ticks_delta_t)(CYCLES_MAX / CYC_PER_TICK));
 		next_cycle = (last_tick + last_elapsed + ticks) * CYC_PER_TICK;
 		if ((next_cycle - last_cycle) > CYCLES_MAX) {
 			next_cycle = last_cycle + CYCLES_MAX;
@@ -148,14 +155,14 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}
 
 	uint32_t delta_cycles = sys_clock_cycle_get_32() - last_cycle;
-	uint32_t delta_ticks = delta_cycles / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = delta_cycles / CYC_PER_TICK;
 
 	last_elapsed = delta_ticks;
 

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -28,7 +28,7 @@
 /*
  * We have two constraints on the maximum number of cycles we can wait for.
  *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
+ * 1) sys_clock_announce() may only accept at most INT32_MAX ticks.
  *
  * 2) The number of cycles between two reports must fit in a cycle_diff_t
  *    variable before converting it to ticks.
@@ -44,15 +44,17 @@
  * consecutive set bits coming from the original max values to produce a
  * nicer literal for assembly generation.
  */
-#define CYCLES_MAX_1 ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
+#define CYCLES_MAX_1                                                                               \
+	(IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? INT64_MAX                                              \
+					  : ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK))
 #define CYCLES_MAX_2 ((uint64_t)CYCLE_DIFF_MAX)
 #define CYCLES_MAX_3 MIN(CYCLES_MAX_1, CYCLES_MAX_2)
 #define CYCLES_MAX_4 (CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
 #define CYCLES_MAX   (CYCLES_MAX_4 + LSB_GET(CYCLES_MAX_4))
 
 static uint64_t last_count;
-static uint64_t last_ticks;
-static uint32_t last_elapsed;
+static k_ticks_t last_ticks;
+static k_ticks_delta_t last_elapsed;
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = TIMER_IRQN;
@@ -108,7 +110,7 @@ static void timer_isr(const void *arg)
 
 	uint64_t now = mtime();
 	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
+	k_ticks_delta_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
 
 	last_count += (cycle_diff_t)dticks * CYC_PER_TICK;
 	last_ticks += dticks;
@@ -123,7 +125,7 @@ static void timer_isr(const void *arg)
 	sys_clock_announce_locked(dticks, key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -138,6 +140,11 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	if (ticks == K_TICKS_FOREVER) {
 		cyc = last_count + CYCLES_MAX;
 	} else {
+		/* Clamp ticks so the multiplication by CYC_PER_TICK below cannot
+		 * overflow when the kernel passes a large value such as
+		 * SYS_CLOCK_MAX_WAIT.
+		 */
+		ticks = CLAMP(ticks, 0, (k_ticks_delta_t)(CYCLES_MAX / CYC_PER_TICK));
 		cyc = (last_ticks + last_elapsed + ticks) * CYC_PER_TICK;
 		if ((cyc - last_count) > CYCLES_MAX) {
 			cyc = last_count + CYCLES_MAX;
@@ -146,7 +153,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	set_mtimecmp(cyc);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -156,7 +163,7 @@ uint32_t sys_clock_elapsed(void)
 
 	uint64_t now = mtime();
 	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
+	k_ticks_delta_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
 
 	last_elapsed = dticks;
 	return dticks;

--- a/drivers/timer/riscv_supervisor_timer.c
+++ b/drivers/timer/riscv_supervisor_timer.c
@@ -25,7 +25,7 @@
 /*
  * We have two constraints on the maximum number of cycles we can wait for.
  *
- * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
+ * 1) sys_clock_announce() may only accept at most INT32_MAX ticks.
  *
  * 2) The number of cycles between two reports must fit in a cycle_diff_t
  *    variable before converting it to ticks.
@@ -41,7 +41,9 @@
  * consecutive set bits coming from the original max values to produce a
  * nicer literal for assembly generation.
  */
-#define CYCLES_MAX_1 ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
+#define CYCLES_MAX_1                                                                               \
+	(IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? INT64_MAX                                              \
+					  : ((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK))
 #define CYCLES_MAX_2 ((uint64_t)CYCLE_DIFF_MAX)
 #define CYCLES_MAX_3 MIN(CYCLES_MAX_1, CYCLES_MAX_2)
 #define CYCLES_MAX_4 (CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
@@ -53,8 +55,8 @@ const int32_t z_sys_timer_irq_for_test = IRQ_S_TIMER;
 
 static struct k_spinlock lock;
 static uint64_t last_count;
-static uint64_t last_ticks;
-static uint32_t last_elapsed;
+static k_ticks_t last_ticks;
+static k_ticks_delta_t last_elapsed;
 
 static void sbi_set_timer(uint64_t deadline)
 {
@@ -81,7 +83,7 @@ static void timer_isr(const void *arg)
 
 	uint64_t now = stime();
 	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
+	k_ticks_delta_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
 
 	last_count += (cycle_diff_t)dticks * CYC_PER_TICK;
 	last_ticks += dticks;
@@ -97,7 +99,7 @@ static void timer_isr(const void *arg)
 	sys_clock_announce(dticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -111,6 +113,11 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	if (ticks == K_TICKS_FOREVER) {
 		cyc = last_count + CYCLES_MAX;
 	} else {
+		/* Clamp ticks so the multiplication by CYC_PER_TICK below cannot
+		 * overflow when the kernel passes a large value such as
+		 * SYS_CLOCK_MAX_WAIT.
+		 */
+		ticks = CLAMP(ticks, 0, (k_ticks_delta_t)(CYCLES_MAX / CYC_PER_TICK));
 		cyc = (last_ticks + last_elapsed + ticks) * CYC_PER_TICK;
 		if ((cyc - last_count) > CYCLES_MAX) {
 			cyc = last_count + CYCLES_MAX;
@@ -121,7 +128,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
@@ -130,7 +137,7 @@ uint32_t sys_clock_elapsed(void)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t now = stime();
 	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
+	k_ticks_delta_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
 
 	last_elapsed = dticks;
 	k_spin_unlock(&lock, key);

--- a/drivers/timer/rv32m1_lptmr_timer.c
+++ b/drivers/timer/rv32m1_lptmr_timer.c
@@ -66,7 +66,7 @@ uint32_t sys_clock_cycle_get_32(void)
 /*
  * Since we're not tickless, this is identically zero.
  */
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	return 0;
 }

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -181,14 +181,14 @@ static void rtc_isr(const void *arg)
 #endif /* CONFIG_TICKLESS_KERNEL */
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
 #ifdef CONFIG_TICKLESS_KERNEL
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t) MAX_TICKS);
+	ticks = CLAMP(ticks - 1, 0, (k_ticks_delta_t) MAX_TICKS);
 
 	/* Compute number of RTC cycles until the next timeout. */
 	uint32_t count = rtc_count();
@@ -229,7 +229,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif /* CONFIG_TICKLESS_KERNEL */
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 #ifdef CONFIG_TICKLESS_KERNEL
 	return (rtc_count() - rtc_last) / CYCLES_PER_TICK;

--- a/drivers/timer/silabs_sleeptimer_timer.c
+++ b/drivers/timer/silabs_sleeptimer_timer.c
@@ -35,7 +35,7 @@ extern unsigned int z_clock_hw_cycles_per_sec;
 /* Global timer state */
 struct sleeptimer_timer_data {
 	uint32_t cyc_per_tick;      /* Number of hw_cycles per 1 kernel tick */
-	uint32_t max_timeout_ticks; /* MAX_TIMEOUT_CYC expressed as ticks */
+	k_ticks_delta_t max_timeout_ticks; /* MAX_TIMEOUT_CYC expressed as ticks */
 	atomic_t last_count;        /* Value of counter when the previous tick was announced */
 	struct k_spinlock lock;     /* Spinlock to sync between ISR and updating the timeout */
 	bool initialized;           /* Set to true when timer is initialized */
@@ -60,7 +60,7 @@ static void sleeptimer_cb(sl_sleeptimer_timer_handle_t *handle, void *data)
 	sys_clock_announce(unannounced);
 }
 
-static void sleeptimer_clock_set_timeout(int32_t ticks, struct sleeptimer_timer_data *timer)
+static void sleeptimer_clock_set_timeout(k_ticks_delta_t ticks, struct sleeptimer_timer_data *timer)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
@@ -88,7 +88,7 @@ static void sleeptimer_clock_set_timeout(int32_t ticks, struct sleeptimer_timer_
 	k_spin_unlock(&timer->lock, key);
 }
 
-static uint32_t sleeptimer_clock_elapsed(struct sleeptimer_timer_data *timer)
+static k_ticks_delta_t sleeptimer_clock_elapsed(struct sleeptimer_timer_data *timer)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || !timer->initialized) {
 		/* No unannounced ticks can have elapsed if not in tickless mode */
@@ -99,14 +99,14 @@ static uint32_t sleeptimer_clock_elapsed(struct sleeptimer_timer_data *timer)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
 	sleeptimer_clock_set_timeout(ticks, &g_sleeptimer_timer_data);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	return sleeptimer_clock_elapsed(&g_sleeptimer_timer_data);
 }

--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -29,7 +29,7 @@ static uint32_t timer_val_31_24;
 
 static uint32_t last_isr_val;
 static uint32_t last_isr_val_rounded;
-static uint32_t announced_ticks;
+static k_ticks_t announced_ticks;
 
 static uint32_t get_rc32k_max_frequency(void)
 {
@@ -107,7 +107,7 @@ static void schedule_next_interrupt(uint32_t ticks)
 	}
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
@@ -151,12 +151,12 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		}
 	}
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks - 1, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	schedule_next_interrupt(ticks);
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
@@ -184,7 +184,7 @@ void timer2_isr(const void *arg)
 {
 	uint32_t val;
 	int32_t delta;
-	int32_t dticks;
+	k_ticks_delta_t dticks;
 
 	ARG_UNUSED(arg);
 

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -258,9 +258,8 @@ static void lptim_irq_handler(const struct device *unused)
 		k_spin_unlock(&lock, key);
 
 		/* announce the elapsed time in ms (count register is 16bit) */
-		uint32_t dticks = (autoreload
-				* CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-				/ lptim_clock_freq;
+		k_ticks_delta_t dticks =
+			(autoreload * CONFIG_SYS_CLOCK_TICKS_PER_SEC) / lptim_clock_freq;
 
 		sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL)
 				? dticks : (dticks > 0));
@@ -302,7 +301,7 @@ static inline uint32_t z_clock_lptim_getcounter(void)
 	return lp_time;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
 	uint32_t next_arr = 0;
@@ -464,8 +463,7 @@ static uint32_t sys_clock_lp_time_get(void)
 	return lp_time;
 }
 
-
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
@@ -480,9 +478,10 @@ uint32_t sys_clock_elapsed(void)
 	/* gives the value of LPTIM counter (ms)
 	 * since the previous 'announce'
 	 */
-	uint64_t ret = ((uint64_t)lp_time * CONFIG_SYS_CLOCK_TICKS_PER_SEC) / lptim_clock_freq;
+	k_ticks_delta_t ret =
+		((uint64_t)lp_time * CONFIG_SYS_CLOCK_TICKS_PER_SEC) / lptim_clock_freq;
 
-	return (uint32_t)(ret);
+	return ret;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -704,7 +703,8 @@ void sys_clock_idle_exit(void)
 #ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
 	if (timeout_stdby) {
 		cycle_t missed_lptim_cnt;
-		uint32_t stdby_timer_diff, stdby_timer_post, dticks;
+		uint32_t stdby_timer_diff, stdby_timer_post;
+		k_ticks_delta_t dticks;
 		uint64_t stdby_timer_us;
 
 		/* Get current value for standby timer and reset LPTIM counter value

--- a/drivers/timer/stm32wb0_radio_timer.c
+++ b/drivers/timer/stm32wb0_radio_timer.c
@@ -61,7 +61,7 @@ static void radio_timer_error_isr(void *args)
 
 static void radio_timer_cpu_wkup_isr(void *args)
 {
-	int32_t dticks;
+	k_ticks_delta_t dticks;
 	uint64_t diff_cycles;
 
 	ARG_UNUSED(args);
@@ -78,7 +78,7 @@ static void radio_timer_cpu_wkup_isr(void *args)
 
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		diff_cycles = HAL_RADIO_TIMER_GetCurrentSysTime() - announced_cycles;
-		dticks = (int32_t)k_cyc_to_ticks_near64(diff_cycles);
+		dticks = (k_ticks_delta_t)k_cyc_to_ticks_near64(diff_cycles);
 		announced_cycles += k_ticks_to_cyc_near32(dticks);
 		sys_clock_announce(dticks);
 	} else {
@@ -105,7 +105,7 @@ static void radio_timer_txrx_wkup_isr(void *args)
 }
 #endif /* CONFIG_SOC_STM32WB06XX || CONFIG_SOC_STM32WB07XX */
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -142,7 +142,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	}
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;

--- a/drivers/timer/sy1xx_sys_timer.c
+++ b/drivers/timer/sy1xx_sys_timer.c
@@ -140,7 +140,7 @@ static int32_t sy1xx_sys_timer_config(uint32_t base, struct sy1xx_timer_cfg *cfg
 	return 0;
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	return 0;
 }

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -18,7 +18,7 @@
 
 /* Weak-linked noop defaults for optional driver interfaces*/
 
-void __weak sys_clock_set_timeout(int32_t ticks, bool idle)
+void __weak sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 }
 

--- a/drivers/timer/ti_dmtimer.c
+++ b/drivers/timer/ti_dmtimer.c
@@ -84,7 +84,7 @@ static void ti_dmtimer_isr(void *param)
 
 	uint32_t curr_cycle = TI_DM_TIMER_READ(systick_timer_dev, TCRR);
 	uint32_t delta_cycles = curr_cycle - data->last_cycle;
-	uint32_t delta_ticks = delta_cycles / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = delta_cycles / CYC_PER_TICK;
 
 	data->last_cycle = curr_cycle;
 
@@ -103,7 +103,7 @@ static void ti_dmtimer_isr(void *param)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
@@ -115,7 +115,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks, 1, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks, 1, (k_ticks_delta_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
@@ -141,7 +141,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	return curr_cycle;
 }
 
-unsigned int sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	struct ti_dm_timer_data *data = systick_timer_dev->data;
 
@@ -154,7 +154,7 @@ unsigned int sys_clock_elapsed(void)
 
 	uint32_t curr_cycle = TI_DM_TIMER_READ(systick_timer_dev, TCRR);
 	uint32_t delta_cycles = curr_cycle - data->last_cycle;
-	uint32_t delta_ticks = delta_cycles / CYC_PER_TICK;
+	k_ticks_delta_t delta_ticks = delta_cycles / CYC_PER_TICK;
 
 	k_spin_unlock(&data->lock, key);
 

--- a/drivers/timer/ti_rti_timer.c
+++ b/drivers/timer/ti_rti_timer.c
@@ -77,7 +77,7 @@ static void ti_rti_timer_isr(void *param)
 	sys_clock_announce(1);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 	ARG_UNUSED(ticks);
@@ -89,7 +89,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	return (uint32_t)sys_read32(RTI_REG(RTIFRC0));
 }
 
-unsigned int sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	/* This driver doesn't support tickless kernel, return 0 for tickful kernel */
 	return 0;

--- a/drivers/timer/wch_systick_ch32v00x.c
+++ b/drivers/timer/wch_systick_ch32v00x.c
@@ -43,7 +43,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	return ch32v00x_systick_count + SYSTICK->CNT;
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	return 0;
 }

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -73,7 +73,7 @@ static void update_match(uint32_t cycles, uint32_t match)
 static void ttc_isr(const void *arg)
 {
 	uint32_t cycles;
-	uint32_t ticks;
+	k_ticks_delta_t ticks;
 
 	ARG_UNUSED(arg);
 
@@ -101,7 +101,7 @@ static void ttc_isr(const void *arg)
 	sys_clock_announce(ticks);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 #ifdef CONFIG_TICKLESS_KERNEL
 	uint32_t cycles;
@@ -114,6 +114,11 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	if (ticks == K_TICKS_FOREVER) {
 		next_cycles = cycles + CYCLES_NEXT_MAX;
 	} else {
+		/* Hardware counter is 32-bit. Clamp ticks so the multiplication
+		 * by CYCLES_PER_TICK does not overflow uint32_t when the kernel
+		 * passes a large value such as SYS_CLOCK_MAX_WAIT.
+		 */
+		ticks = CLAMP(ticks, 0, (k_ticks_delta_t)(CYCLES_NEXT_MAX / CYCLES_PER_TICK));
 		next_cycles = cycles + ((uint32_t)ticks * CYCLES_PER_TICK);
 	}
 
@@ -122,7 +127,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 #ifdef CONFIG_TICKLESS_KERNEL
 	uint32_t cycles;

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -55,11 +55,11 @@ static uint32_t ccount(void)
 	return val + ccount_comp();
 }
 
-static uint32_t sys_clock_elapsed_ticks(uint32_t curr)
+static k_ticks_delta_t sys_clock_elapsed_ticks(uint32_t curr)
 {
-	uint32_t dticks = (curr - last_count) / CYC_PER_TICK;
+	k_ticks_delta_t dticks = (curr - last_count) / CYC_PER_TICK;
 
-	last_count += dticks * CYC_PER_TICK;
+	last_count += (uint32_t)dticks * CYC_PER_TICK;
 
 	return dticks;
 }
@@ -71,7 +71,7 @@ static void ccompare_isr(const void *arg)
 	k_spinlock_key_t key = sys_clock_lock();
 
 	uint32_t curr = ccount();
-	uint32_t dticks = sys_clock_elapsed_ticks(curr);
+	k_ticks_delta_t dticks = sys_clock_elapsed_ticks(curr);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		uint32_t next = last_count + CYC_PER_TICK;
@@ -85,13 +85,13 @@ static void ccompare_isr(const void *arg)
 	sys_clock_announce_locked(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1, key);
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	ticks = CLAMP(ticks - 1, 0, (k_ticks_delta_t)MAX_TICKS);
 
 	uint32_t curr = ccount(), cyc, adj;
 
@@ -128,7 +128,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif
 }
 
-uint32_t sys_clock_elapsed(void)
+k_ticks_delta_t sys_clock_elapsed(void)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -177,7 +177,7 @@ void sys_clock_idle_exit(void)
 		ccount_compensation += missed_cycles;
 
 		ccount_now = ccount();
-		uint32_t dticks = sys_clock_elapsed_ticks(ccount_now);
+		k_ticks_delta_t dticks = sys_clock_elapsed_ticks(ccount_now);
 
 		timeout_idle = false;
 

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -16,6 +16,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_SYSTEM_TIMER_H_
 
 #include <stdbool.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/types.h>
 #include <zephyr/spinlock.h>
 
@@ -23,8 +24,11 @@
 extern "C" {
 #endif
 
-#define SYS_CLOCK_MAX_WAIT (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) \
-			    ? K_TICKS_FOREVER : INT_MAX)
+#define SYS_CLOCK_MAX_WAIT                                                                         \
+	(IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE)                                               \
+		 ? K_TICKS_FOREVER                                                                 \
+		 : (IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? (k_ticks_delta_t)INT64_MAX                  \
+						     : (k_ticks_delta_t)INT32_MAX))
 
 /**
  * @brief System Clock APIs
@@ -144,14 +148,17 @@ bool sys_clock_is_locked(void);
  * if this could cause rollover of the internal counter (i.e. the
  * system uptime counter is allowed to be wrong
  *
- * Note also that it is conventional for the kernel to pass INT_MAX
- * for ticks if it wants to preserve the uptime tick count but doesn't
- * have a specific event to await.  The intent here is that the driver
- * will schedule any needed timeout as far into the future as
- * possible.  For the specific case of INT_MAX, the next call to
- * sys_clock_announce() may occur at any point in the future, not just
- * at INT_MAX ticks.  But the correspondence between the announced
- * ticks and real-world time must be correct.
+ * Note also that it is conventional for the kernel to pass
+ * SYS_CLOCK_MAX_WAIT for ticks if it wants to preserve the uptime tick
+ * count but doesn't have a specific event to await.  The value of
+ * SYS_CLOCK_MAX_WAIT depends on CONFIG_TIMEOUT_64BIT: it is INT64_MAX
+ * when 64-bit timeouts are enabled (the default) and INT32_MAX otherwise.
+ * The intent here is that the driver will schedule any needed timeout as
+ * far into the future as possible.  For the specific case of
+ * SYS_CLOCK_MAX_WAIT, the next call to sys_clock_announce() may occur at
+ * any point in the future, not just at SYS_CLOCK_MAX_WAIT ticks.  But the
+ * correspondence between the announced ticks and real-world time must be
+ * correct.
  *
  * A final note about SMP: note that the call to sys_clock_set_timeout()
  * is made on any CPU, and reflects the next timeout desired globally.
@@ -168,7 +175,7 @@ bool sys_clock_is_locked(void);
  * @param idle Hint to the driver that the system is about to enter
  *        the idle state immediately after setting the timeout
  */
-void sys_clock_set_timeout(int32_t ticks, bool idle);
+void sys_clock_set_timeout(k_ticks_delta_t ticks, bool idle);
 
 /**
  * @brief Timer idle exit notification
@@ -204,7 +211,7 @@ void sys_clock_idle_exit(void);
  * @param ticks Elapsed time, in ticks
  * @param key Lock key obtained from sys_clock_lock().
  */
-void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key);
+void sys_clock_announce_locked(k_ticks_delta_t ticks, k_spinlock_key_t key);
 
 /**
  * @brief Announce time progress to the kernel (legacy wrapper)
@@ -216,7 +223,7 @@ void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key);
  *
  * @param ticks Elapsed time, in ticks
  */
-static inline void sys_clock_announce(int32_t ticks)
+static inline void sys_clock_announce(k_ticks_delta_t ticks)
 {
 	sys_clock_announce_locked(ticks, sys_clock_lock());
 }
@@ -232,7 +239,7 @@ static inline void sys_clock_announce(int32_t ticks)
  * @note This function is called by the kernel with the system clock
  * lock held.
  */
-uint32_t sys_clock_elapsed(void);
+k_ticks_delta_t sys_clock_elapsed(void);
 
 /**
  * @brief Disable system timer.

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -206,7 +206,12 @@ struct z_kernel {
 	struct _cpu cpus[CONFIG_MP_MAX_NUM_CPUS];
 
 #ifdef CONFIG_PM
+	/* Can't use k_ticks_delta_t for header dependency reasons */
+#ifdef CONFIG_TIMEOUT_64BIT
+	int64_t idle; /* Number of ticks for kernel idling */
+#else
 	int32_t idle; /* Number of ticks for kernel idling */
+#endif
 #endif
 
 	/*

--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -12,6 +12,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/pm/state.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/toolchain.h>
 
@@ -86,7 +87,7 @@ struct pm_policy_event {
  * @return The power state the system should use for the given cpu. The function
  * will return NULL if system should remain into PM_STATE_ACTIVE.
  */
-const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks);
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, k_ticks_delta_t ticks);
 
 /** @endcond */
 

--- a/include/zephyr/sys/clock.h
+++ b/include/zephyr/sys/clock.h
@@ -51,6 +51,20 @@ typedef uint32_t k_ticks_t;
 #define K_TICKS_FOREVER ((k_ticks_t)(-1))
 
 /**
+ * @brief Signed tick delta type
+ *
+ * Used for tracking elapsed-tick deltas (k_ticks_t uses negative values to
+ * indicate an absolute tick count rather than a negative delta).
+ * Sized to match CONFIG_TIMEOUT_64BIT so that the sys_clock_announce path
+ * carries the same range as the timeouts.
+ */
+#ifdef CONFIG_TIMEOUT_64BIT
+typedef int64_t k_ticks_delta_t;
+#else
+typedef int32_t k_ticks_delta_t;
+#endif
+
+/**
  * @brief Kernel timeout type
  *
  * Timeout arguments presented to kernel APIs are stored in this

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -207,7 +207,7 @@ bool z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state);
  *
  * @return True if the system suspended, otherwise return false
  */
-bool pm_system_suspend(int32_t ticks);
+bool pm_system_suspend(k_ticks_delta_t ticks);
 
 #endif /* CONFIG_PM */
 

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -84,7 +84,7 @@ static inline int z_try_abort_thread_timeout(struct k_thread *thread)
 	return z_try_abort_timeout(&thread->base.timeout);
 }
 
-int32_t z_get_next_timeout_expiry(void);
+k_ticks_delta_t z_get_next_timeout_expiry(void);
 
 k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 
@@ -94,7 +94,7 @@ k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 #define z_init_thread_timeout(thread_base) do {} while (false)
 #define z_try_abort_thread_timeout(to) 0
 #define z_is_inactive_timeout(to) 1
-#define z_get_next_timeout_expiry() ((int32_t) K_TICKS_FOREVER)
+#define z_get_next_timeout_expiry() ((k_ticks_delta_t) K_TICKS_FOREVER)
 #define z_set_timeout_expiry(ticks, is_idle) do {} while (false)
 
 static inline k_ticks_t z_add_thread_timeout(struct k_thread *thread, k_timeout_t ticks)

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -27,7 +27,7 @@ static sys_dlist_t timeout_list = SYS_DLIST_STATIC_INIT(&timeout_list);
 static struct k_spinlock timeout_lock;
 
 /* Ticks left to process in the currently-executing sys_clock_announce() */
-static int announce_remaining;
+static k_ticks_delta_t announce_remaining;
 
 /* CPU id currently inside sys_clock_announce_locked()'s firing loop, or -1
  * when no CPU is. The SMP early-return below ensures at most one CPU is in
@@ -92,7 +92,7 @@ static void remove_timeout(struct _timeout *t)
 	sys_dlist_remove(&t->node);
 }
 
-static int32_t elapsed(void)
+static k_ticks_delta_t elapsed(void)
 {
 	/*
 	 * While *this* CPU is executing sys_clock_announce_locked()'s firing
@@ -114,25 +114,21 @@ static int32_t elapsed(void)
 	 * keeps sys_clock_tick_get() monotonic across the announce window.
 	 */
 	if (this_cpu_announcing()) {
-		return 0U;
+		return 0;
 	}
 	return sys_clock_elapsed() +
 	       (IS_ENABLED(CONFIG_SMP) ? announce_remaining : 0);
 }
 
-static int32_t next_timeout(int32_t ticks_elapsed)
+static k_ticks_delta_t next_timeout(k_ticks_delta_t ticks_elapsed)
 {
 	struct _timeout *to = first();
-	int32_t ret;
 
-	if ((to == NULL) ||
-	    ((int64_t)(to->dticks - ticks_elapsed) > (int64_t)INT_MAX)) {
-		ret = SYS_CLOCK_MAX_WAIT;
-	} else {
-		ret = max(0, to->dticks - ticks_elapsed);
+	if (to == NULL) {
+		return SYS_CLOCK_MAX_WAIT;
 	}
 
-	return ret;
+	return MAX((k_ticks_delta_t)0, (k_ticks_delta_t)(to->dticks - ticks_elapsed));
 }
 
 k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout)
@@ -152,7 +148,7 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 
 	K_SPINLOCK(&timeout_lock) {
 		struct _timeout *t;
-		int32_t ticks_elapsed;
+		k_ticks_delta_t ticks_elapsed;
 		bool has_elapsed = false;
 
 		if (Z_IS_TIMEOUT_RELATIVE(timeout)) {
@@ -306,9 +302,9 @@ k_ticks_t z_timeout_expires(const struct _timeout *timeout)
 }
 EXPORT_SYMBOL(z_timeout_expires);
 
-int32_t z_get_next_timeout_expiry(void)
+k_ticks_delta_t z_get_next_timeout_expiry(void)
 {
-	int32_t ret = (int32_t) K_TICKS_FOREVER;
+	k_ticks_delta_t ret = (k_ticks_delta_t)K_TICKS_FOREVER;
 
 	K_SPINLOCK(&timeout_lock) {
 		ret = next_timeout(elapsed());
@@ -316,7 +312,7 @@ int32_t z_get_next_timeout_expiry(void)
 	return ret;
 }
 
-void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
+void sys_clock_announce_locked(k_ticks_delta_t ticks, k_spinlock_key_t key)
 {
 	/* We release the lock around the callbacks below, so on SMP
 	 * systems someone might be already running the loop.  Don't

--- a/soc/infineon/cat1b/cyw20829/power.c
+++ b/soc/infineon/cat1b/cyw20829/power.c
@@ -17,7 +17,7 @@
 LOG_MODULE_REGISTER(soc_power, CONFIG_SOC_LOG_LEVEL);
 
 /*
- * Called from pm_system_suspend(int32_t ticks) in subsys/power.c
+ * Called from pm_system_suspend(k_ticks_delta_t ticks) in subsys/pm/pm.c
  * For deep sleep pm_system_suspend has executed all the driver
  * power management call backs.
  */

--- a/soc/infineon/cat1b/psc3/power.c
+++ b/soc/infineon/cat1b/psc3/power.c
@@ -20,7 +20,7 @@
 LOG_MODULE_REGISTER(soc_power, CONFIG_SOC_LOG_LEVEL);
 
 /*
- * Called from pm_system_suspend(int32_t ticks) in subsys/power.c
+ * Called from pm_system_suspend(k_ticks_delta_t ticks) in subsys/pm/pm.c
  * For deep sleep pm_system_suspend has executed all the driver
  * power management call backs.
  */

--- a/soc/infineon/edge/pse84/power.c
+++ b/soc/infineon/edge/pse84/power.c
@@ -20,7 +20,7 @@
 LOG_MODULE_REGISTER(soc_power, CONFIG_SOC_LOG_LEVEL);
 
 /*
- * Called from pm_system_suspend(int32_t ticks) in subsys/power.c
+ * Called from pm_system_suspend(k_ticks_delta_t ticks) in subsys/pm/pm.c
  * For deep sleep pm_system_suspend has executed all the driver
  * power management call backs.
  */

--- a/soc/ite/ec/common/policy.c
+++ b/soc/ite/ec/common/policy.c
@@ -8,7 +8,7 @@
 #include <zephyr/pm/policy.h>
 #include <soc.h>
 
-__weak const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+__weak const struct pm_state_info *pm_policy_next_state(uint8_t cpu, k_ticks_delta_t ticks)
 {
 	const struct pm_state_info *cpu_states;
 	uint8_t num_cpu_states;
@@ -30,7 +30,7 @@ __weak const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t tic
 		 * The tick interval for the system to enter sleep mode needs
 		 * to be longer than or equal to the minimum residency.
 		 */
-		if (ticks >= min_residency) {
+		if ((ticks == K_TICKS_FOREVER) || (ticks >= min_residency)) {
 			return state;
 		}
 	}

--- a/soc/microchip/mec/common/soc_pm_mgmt.c
+++ b/soc/microchip/mec/common/soc_pm_mgmt.c
@@ -179,7 +179,7 @@ static void z_power_soc_sleep(void)
  *   tick = get next timeout expiration
  *   pm_system_suspend(ticks) in pm subsystem
  *
- * pm_system_suspend(int32_t ticks) in subsys/power.c
+ * pm_system_suspend(k_ticks_delta_t ticks) in subsys/pm/pm.c
  * if exit latency is acceptible.
  *   lock scheduler
  *   set pm post ops flag

--- a/soc/microchip/mec/mec15xx/power.c
+++ b/soc/microchip/mec/mec15xx/power.c
@@ -98,7 +98,7 @@ static void z_power_soc_sleep(void)
 }
 
 /*
- * Called from pm_system_suspend(int32_t ticks) in subsys/power.c
+ * Called from pm_system_suspend(k_ticks_delta_t ticks) in subsys/pm/pm.c
  * For deep sleep pm_system_suspend has executed all the driver
  * power management call backs.
  */

--- a/soc/microchip/mec/mec172x/power.c
+++ b/soc/microchip/mec/mec172x/power.c
@@ -138,7 +138,7 @@ static void z_power_soc_sleep(void)
 }
 
 /*
- * Called from pm_system_suspend(int32_t ticks) in subsys/power.c
+ * Called from pm_system_suspend(k_ticks_delta_t ticks) in subsys/pm/pm.c
  * For deep sleep pm_system_suspend has executed all the driver
  * power management call backs.
  */

--- a/soc/nxp/mcx/mcxw/mcxw2xx/power.c
+++ b/soc/nxp/mcx/mcxw/mcxw2xx/power.c
@@ -142,7 +142,7 @@ uint64_t z_sys_clock_lpm_exit(void)
 #endif /* CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS */
 
 #if CONFIG_PM_POLICY_CUSTOM
-__weak const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+__weak const struct pm_state_info *pm_policy_next_state(uint8_t cpu, k_ticks_delta_t ticks)
 {
 	uint8_t num_cpu_states;
 	const struct pm_state_info *cpu_states;

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -73,7 +73,7 @@ static inline void pm_state_notify(bool entering_state)
 	k_spin_unlock(&pm_notifier_lock, pm_notifier_key);
 }
 
-static inline int32_t ticks_expiring_sooner(int32_t ticks1, int32_t ticks2)
+static inline k_ticks_delta_t ticks_expiring_sooner(k_ticks_delta_t ticks1, k_ticks_delta_t ticks2)
 {
 	/*
 	 * Ticks are relative numbers that defines the number of ticks
@@ -145,12 +145,12 @@ bool pm_state_force(uint8_t cpu, const struct pm_state_info *info)
 	return true;
 }
 
-bool pm_system_suspend(int32_t kernel_ticks)
+bool pm_system_suspend(k_ticks_delta_t kernel_ticks)
 {
 	uint8_t id = CPU_ID;
 	k_spinlock_key_t key;
-	int32_t ticks, events_ticks;
-	uint32_t exit_latency_ticks;
+	k_ticks_delta_t ticks, events_ticks;
+	k_ticks_delta_t exit_latency_ticks;
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, system_suspend, kernel_ticks);
 
@@ -167,7 +167,7 @@ bool pm_system_suspend(int32_t kernel_ticks)
 	ticks = ticks_expiring_sooner(kernel_ticks, events_ticks);
 
 #ifdef CONFIG_PM_CUSTOM_TICKS_HOOK
-	int32_t custom_ticks = pm_policy_next_custom_ticks();
+	k_ticks_delta_t custom_ticks = pm_policy_next_custom_ticks();
 
 	ticks = ticks_expiring_sooner(custom_ticks, ticks);
 #endif /* CONFIG_PM_CUSTOM_TICKS_HOOK */
@@ -215,7 +215,7 @@ bool pm_system_suspend(int32_t kernel_ticks)
 		 */
 		k_spinlock_key_t key = sys_clock_lock();
 
-		sys_clock_set_timeout(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks), true);
+		sys_clock_set_timeout(MAX(0, ticks - exit_latency_ticks), true);
 		sys_clock_unlock(key);
 	}
 

--- a/subsys/pm/policy/policy_default.c
+++ b/subsys/pm/policy/policy_default.c
@@ -9,7 +9,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/pm/device.h>
 
-const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, k_ticks_delta_t ticks)
 {
 	uint8_t num_cpu_states;
 	const struct pm_state_info *cpu_states;
@@ -33,7 +33,7 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 			min_residency_ticks = k_us_to_ticks_ceil32(min_residency_us);
 		}
 
-		if (ticks < min_residency_ticks) {
+		if ((ticks != K_TICKS_FOREVER) && (ticks < min_residency_ticks)) {
 			/* If current state has higher residency then use the previous state; */
 			break;
 		}

--- a/tests/kernel/timer/timeout/src/main.c
+++ b/tests/kernel/timer/timeout/src/main.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
+#include <zephyr/drivers/timer/system_timer.h>
 
 #ifdef CONFIG_TIMEOUT_64BIT
 /**
@@ -112,6 +113,32 @@ ZTEST(timeout, test_timeout_sum_absolute)
 	result = K_TIMEOUT_SUM(K_TICKS(6), K_TIMEOUT_ABS_TICKS(INT64_MAX - 8));
 	zassert_true(K_TIMEOUT_EQ(result, K_TICKS(INT64_MIN + 1)),
 		     "Expected INT64_MIN + 1 ticks");
+}
+
+/*
+ * Verify that sys_clock_announce() correctly advances the kernel tick counter
+ * when called with a delta larger than INT32_MAX.
+ */
+ZTEST(timeout, test_large_tick_announce)
+{
+	const k_ticks_delta_t large = (k_ticks_delta_t)INT32_MAX + 1000;
+	struct k_timer tmr;
+	int64_t t0, t1;
+
+	/* A timer set for INT32_MAX + 500 ticks must fire when large ticks elapse. */
+	k_timer_init(&tmr, NULL, NULL);
+	k_timer_start(&tmr, K_TICKS((k_ticks_t)INT32_MAX + 500), K_NO_WAIT);
+
+	t0 = sys_clock_tick_get();
+	sys_clock_announce(large);
+	t1 = sys_clock_tick_get();
+
+	zassert_equal(t1 - t0, (int64_t)large, "Tick counter advanced by %lld, expected %lld",
+		      (long long)(t1 - t0), (long long)large);
+
+	zassert_equal(k_timer_status_get(&tmr), 1, "Timer set for >INT32_MAX ticks did not fire");
+
+	k_timer_stop(&tmr);
 }
 #endif
 

--- a/tests/subsys/pm/device_wakeup_api/src/main.c
+++ b/tests/subsys/pm/device_wakeup_api/src/main.c
@@ -56,7 +56,7 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	ARG_UNUSED(substate_id);
 }
 
-const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, k_ticks_delta_t ticks)
 {
 	const struct pm_state_info *cpu_states;
 

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -452,7 +452,7 @@ ZTEST(policy_api, test_pm_policy_state_constraints)
 #endif /* CONFIG_PM_POLICY_DEFAULT */
 
 #ifdef CONFIG_PM_POLICY_CUSTOM
-const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, k_ticks_delta_t ticks)
 {
 	static const struct pm_state_info state = {.state = PM_STATE_SOFT_OFF};
 

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -249,7 +249,7 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Our PM policy handler */
-const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, k_ticks_delta_t ticks)
 {
 	const struct pm_state_info *cpu_states;
 

--- a/tests/subsys/pm/power_mgmt_multicore/src/main.c
+++ b/tests/subsys/pm/power_mgmt_multicore/src/main.c
@@ -62,7 +62,7 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	atomic_set_bit(&exit_post_ops_cpus, _current_cpu->id);
 }
 
-const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, k_ticks_delta_t ticks)
 {
 	static const struct pm_state_info states[] = {
 		{


### PR DESCRIPTION
## Background

The default size for the kernel timer/timeout subsystem was changed to a 64-bit `k_ticks_t` type a few years ago via the `CONFIG_TIMEOUT_64BIT` kconfig. However, the `sys_clock_set_timeout()`, `sys_clock_annouce()`, and `sys_clock_elapsed()` APIs still take a 32-bit tick count, limiting the maximum timeout and maximum elapsed ticks that can be announced in a single call to `INT32_MAX`. Timer drivers work around this by clamping the maximum programmed hardware interval to ensure that the eventual call to `sys_clock_announce()` does not overflow (taking worst-case ISR latency into account).

Long timeouts - those spanning more than `INT32_MAX` ticks - are handled by the kernel through multiple intermediate wake-ups: the driver fires at the clamped limit, the kernel announces the partial count (which does not reach any queued timeout), reprograms the next interval, and repeats until the full duration has elapsed. System uptime and timeout correctness are preserved by this mechanism; the workaround is generally functional. The implementation of this is a not-so-obvious check in the `next_timeout()` function in `timeout.c`:

```c
	if ((to == NULL) ||
	    ((int64_t)(to->dticks - ticks_elapsed) > (int64_t)INT_MAX)) {
		ret = SYS_CLOCK_MAX_WAIT;
	} else {
		ret = max(0, to->dticks - ticks_elapsed);
	}
```

as well as calculations in timer drivers that explicitly limit the maximum ticks to sleep to `INT32_MAX`, for example:

```c
  /*
   * We have two constraints on the maximum number of cycles we can wait for.
   *
   * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
   *
   ...
   */
  #define CYCLES_MAX_1	((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
  ...
```

There are three concerns with this approach however:

1. The type mismatch between the `int32_t` announce path and the already-64-bit `k_timeout_t.ticks` and `struct _timeout.dticks` fields (when `CONFIG_TIMEOUT_64BIT=y`) is an **inconsistency** and a **maintenance problem**: ticks are treated sometimes as 64-bit and sometimes as 32-bit in the timeout, timer, and pm code.  The requirement that the maximum ticks between announcements is INT32_MAX is enforced by the combination of the code in `next_timeout` and the various guards scattered across the timer drivers - it is not built into the timeout system naturally since timeouts themselves allow 64-bit by default.

    Several timer drivers already track elapsed ticks (or cycles) in `uint64_t`/`int64_t` locals and pass them to `sys_clock_announce()` — for example `drivers/timer/esp32_sys_timer.c` computes `uint64_t dticks` in both the ISR and `sys_clock_idle_exit()` and passes it directly to `sys_clock_announce()`. Under the current API this is a silent narrowing conversion: any value above `INT32_MAX` would become a low-32-bit truncation that would leave the timer and kernel ticks out-of-sync (and potentially run the kernel `curr_tick` backwards). In practice these drivers are not currently triggering the issue because their own internal clamps (e.g. `MAX_CYC = 0xFFFFFFFFu` in the esp32 driver) keep `dticks` within the safe range, but the conversion is unsafe by type and would break if a driver author widened its internal clamp. The `k_ticks_delta_t` migration makes the conversion lossless (`uint64_t → int64_t` for any non-negative value), eliminating this risk.

2. The second concern is a minor loss of **efficiency** for drivers backed by a 64-bit hardware counter (such as the ARM generic timer or RISCV machine timer).  This hardware is capable of sleeping for the full requested duration without intermediate wake-ups, but is prevented from doing so for large timeouts.  Using the default 10000 Hz tick rate, this forces a spurious wake-up roughly every 2.5 days regardless of the requested timeout (admittedly this is only a *very* minor loss of efficiency - but see point 3).

3. The last concern is actual **functional failures** with unexpected wakeups.  If a timer is set for a long duration, or no timer is set at all, then the system is forced to wake-up every 2.5 days at least, just to announce the new system tick (nothing actually cares at this point). Some systems are not tolerant of such unplanned wake-up events, for example when they depend on an external controller to wake up first and enable dependent resources.

    We (Qualcomm) have run into this problem twice already. The first case involves a Zephyr-based MCU used in an automotive application. The MCU enters an extreme deep sleep state when the car is left "off" for a long time (but the MCU remains alive due to very fast wake-up requirements), with the ability to exit that state dependent on a second controller (delivered by a different vendor) waking up first. The forced periodic announce wake-ups break this design as despite no pending activity, the MCU still tries to wake up. The second case is in an internal SoC subsystem using Zephyr. This subsystem cannot control its own system resources and relies on the main processor to enable them prior to waking-up from deep sleep - the required periodic wake-ups force the main processor to regularly wake-up the subsystem even if it has no reason to.

## Existing 64-bit infrastructure

The kernel already has substantial 64-bit tick support behind `CONFIG_TIMEOUT_64BIT` (which defaults to `y`):

| Component | Type | Notes |
|---|---|---|
| `k_ticks_t` | `int64_t` / `uint32_t` | Conditionally 64-bit since Zephyr 2.2 |
| `k_timeout_t.ticks` | `k_ticks_t` | The public timeout type |
| `struct _timeout.dticks` | `int64_t` / `int32_t` | Per-entry delta in the timeout queue - commented as being `k_ticks_t` but (inconsistently) uses signed `int32_t` |
| `curr_tick` (timeout.c) | `uint64_t` | Always 64-bit |

The gap is in the *next timeout path* and *announce path*: the functions that send the next wakeup tick to the hardware driver and then move elapsed time from the hardware timer driver into `curr_tick`. Despite the kernel tracking time internally with full 64-bit precision, these APIs and their internal helpers are all typed as `int32_t` and were never updated when `CONFIG_TIMEOUT_64BIT` was introduced.

## Solution: `k_ticks_delta_t`

We introduce a new public type `k_ticks_delta_t` for signed tick *deltas*:

```c
/* include/zephyr/sys/clock.h */
#ifdef CONFIG_TIMEOUT_64BIT
typedef int64_t k_ticks_delta_t;
#else
typedef int32_t k_ticks_delta_t;
#endif
```

The type mirrors the pattern already used by `k_ticks_t` and carries the same `CONFIG_TIMEOUT_64BIT` semantics. When `CONFIG_TIMEOUT_64BIT` is disabled (uncommon; the default is enabled), `k_ticks_delta_t` is `int32_t` and the generated code is identical to the previous behaviour.

A separate type is used rather than reusing `k_ticks_t` because:

1. `k_ticks_t` is unsigned (`uint32_t`) when `CONFIG_TIMEOUT_64BIT=n`. Elapsed and delta values are *signed* by convention in the existing code; mixing in an unsigned type could introduce silent truncation and comparison bugs.
2. `k_ticks_t` uses negative values to indicate an *absolute* tick-count, whereas for `k_ticks_delta_t` a negative value is a negative *relative* value.
3. If changing the default ticks argument type for the existing sys_clock APIs (from `int32_t` to `int64_t`) is not acceptable, then we could use a new Kconfig to set the type of `k_ticks_delta_t` independently of `k_ticks` and keep it defaulted to 32 bits. Allowing divergence between the two types requires adding back the complicated code in `next_timeout` and undoes the benefits of a common size though.

**That being said**, using a single type for all uses of *ticks* would be **simpler** and more **consistent**. So here are counter-arguments to the separate-type arguments above:

1. There is no valid case for passing a negative tick value to `sys_clock_announce()` or `sys_clock_set_timeout()` (and `sys_clock_elapsed()` returns a `uint32_t` already). Current code would likely "handle" a *small* negative value reasonably (time would run backwards but probably not break immediately) whereas a huge positive value (if an erroneous negative was cast to unsigned) would probably break things right away. So perhaps a signed value is more robust to bugs, but such bugs are as likely to result in *large* negative values (BOOM!) as much as *small* ones (probably handled ok).

    Note that `struct _timeout.dticks` is defined as `int32_t` (not `uint32_t` as the `k_ticks_t` type it claims to represent does) when`CONFIG_TIMEOUT_64BIT`=`n`. That suggests no signedness compatibility issues exist or we would already have seen them.

2. If we assume negative values are not valid for these `sys_clock_*` APIs then the fact that `k_ticks_t` treats those as an *absolute* value is irrelevant.
3. If we are ok changing the default type to `int64_t` anyway, then there remains no reason to have a separate type if the first two points are ok!


## Summary of Key Changes

### `include/zephyr/sys/clock.h`

- Add `k_ticks_delta_t` typedef immediately after `k_ticks_t`.

### `include/zephyr/drivers/timer/system_timer.h`

- `sys_clock_announce_locked(int32_t ticks, ...)` → `k_ticks_delta_t ticks`
- `sys_clock_announce(int32_t ticks)` inline wrapper → `k_ticks_delta_t ticks`
- `sys_clock_set_timeout(int32_t ticks, bool idle)` → `k_ticks_delta_t ticks`
- `sys_clock_elapsed(void)` return type `uint32_t` → `k_ticks_delta_t`

  The narrowing from unsigned 32-bit to signed 32-bit when `CONFIG_TIMEOUT_64BIT=n` is safe because the `uint32_t` return type was already broader than the rest of the protocol could handle in that configuration - `z_add_timeout()` eventually assigns the return value of `sys_clock_elapsed()` to `int32_t ticks_elapsed`, so values above `INT32_MAX` would have been silently truncated to a negative number. The upper half of the `uint32_t` range was already unusable.

  When `CONFIG_TIMEOUT_64BIT=y` the new return type is `int64_t`, which is strictly larger than the old `uint32_t`, so there is no regression in the default build.  - `SYS_CLOCK_MAX_WAIT` updated: non-sloppy-idle now expands to `INT64_MAX` when `CONFIG_TIMEOUT_64BIT=y` rather than `INT_MAX`, allowing drivers to be programmed for the full 64-bit range when their hardware supports it.  - Added explicit `#include <zephyr/sys/clock.h>` to make the header self-contained (previously `k_ticks_t`/`K_TICKS_FOREVER` relied on `<zephyr/kernel.h>` being included by callers before this header).  - `sys_clock_set_timeout()` docstring: updated the "conventional to pass `INT_MAX`" note to reference `SYS_CLOCK_MAX_WAIT` and explain its value under each `CONFIG_TIMEOUT_64BIT` setting.

### `kernel/timeout.c`

All internal variables that carry tick deltas in the announce path are updated.

The `(int64_t)(to->dticks - ticks_elapsed) > (int64_t)INT_MAX` overflow guard in `next_timeout()` is removed: it existed solely to prevent a value too large for the `int32_t` return type from being passed back. With `k_ticks_delta_t` the return type can hold the full range of `dticks`, so the guard is redundant.  Drivers that can only program 32-bit hardware timers continue to clamp in their own `sys_clock_set_timeout()` implementations, as before.

Note that the removal is also correct when `CONFIG_TIMEOUT_64BIT=n`. In that configuration `k_ticks_delta_t = int32_t` (matching the old return type), but `struct _timeout.dticks` is also `int32_t` - bounded by `INT32_MAX`. Therefore `to->dticks - ticks_elapsed` can never exceed `INT_MAX` in that build, and the guard condition could never have evaluated to true. The guard was only ever reachable when `to->dticks` was `int64_t` (i.e. `CONFIG_TIMEOUT_64BIT=y`), which is exactly the case now handled correctly by the widened return type.

### `include/zephyr/kernel_structs.h`

`_kernel.idle` (the field that carries the next-timeout value across the `pm_system_suspend()` boundary) is conditioned on `CONFIG_TIMEOUT_64BIT`:

```c
#ifdef CONFIG_TIMEOUT_64BIT
    int64_t idle;   /* Number of ticks for kernel idling */
#else
    int32_t idle;
#endif
```

The same pattern as `struct _timeout.dticks` is used; the `k_ticks_delta_t` alias is not referenced here because `kernel_structs.h` must not depend on `kernel.h` (and therefore cannot include `sys/clock.h`).

### `kernel/include/kernel_internal.h` and `subsys/pm/pm.c`

`pm_system_suspend()` parameter: `int32_t` → `k_ticks_delta_t`.

### Timer drivers (~57 files)

All driver implementations of `sys_clock_set_timeout()` and `sys_clock_elapsed()` receive a signature update to match the new API types. Function bodies are mostly unchanged (except where minor additional type updates were required): drivers that have a 32-bit hardware timer continue to clamp internally, and their behaviour is identical to before.

## Backward compatibility

When `CONFIG_TIMEOUT_64BIT=n`:

- `k_ticks_delta_t` is `int32_t` - typedef only, no ABI change.
- Every changed function signature reduces to its previous form or functionaly equivalent (`sys_clock_elapsed()` safely changes from unsigned to signed as discussed earlier).

When `CONFIG_TIMEOUT_64BIT=y` (the default since Zephyr 2.2):

- The announce path now carries `int64_t` through the kernel correctly.
- Drivers that only have 32-bit hardware timers are unaffected: they compute a `uint32_t` or `int32_t` delta locally and pass it to `sys_clock_announce()`; the implicit sign-extension to `int64_t` at the call site is lossless.
