### PR TITLE
drivers: sensor: add integer/fixed-point conversion helpers

### DIFF
--- a/doc/hardware/peripherals/sensor/read_and_decode.rst
+++ b/doc/hardware/peripherals/sensor/read_and_decode.rst
@@ -62,6 +62,89 @@ and trigger handling are solved.
    :ref:`rtio` compliant communication access to the sensor. Typically this means
    an :ref:`rtio` enabled bus driver for SPI or I2C.
 
+.. _sensor-fixed-point:
+
+Fixed-point values
+******************
+
+Decoded sensor data is returned as :c:type:`q31_t` fixed-point values. A
+``q31_t`` is a 32-bit signed integer container paired with a *shift* that places
+the binary point, letting drivers report fractional readings without using
+floating point.
+
+Q notation and the shift
+========================
+
+Fixed-point numbers are written using the notation :math:`Q_{m.n}`, where:
+
+:math:`m`
+   number of integer bits
+
+:math:`n`
+   number of fractional bits
+
+Zephyr's sensor subsystem uses a 32-bit signed container and specifies only
+:math:`m` as the shift:
+
+.. math::
+
+   Q_{m.(31-m)} \quad\quad 0 \leq m \leq 31
+
+with one sign bit and :math:`31 - m` fractional bits.
+
+The shift value is a tradeoff between  precision for range, increases in shift value
+increase range of real numbers the value can occupy at the cost of the step or value
+per lsb being larger and hence the loss of precision
+
+For example, a shift of 10 (10 integer bits and 21 fractional bits) encoded value spans:
+
+.. math::
+
+   -2^{10} \leq \text{value} < 2^{10} \quad\quad (-1024 \leq \text{value} < 1024)
+
+while the value per LSB (the smallest encodable step) is:
+
+.. math::
+
+   \text{value per LSB} = \frac{1}{2^{31 - m}}
+
+which is :math:`1 / 2^{21}` at a shift of 10.
+
+Scaling raw sensor samples
+==========================
+
+Sensors are usually read as ``int16`` or ``int24`` raw counts. The resolution is
+then set by the full-scale range (:math:`FS`) the sensor maps onto its
+integer-only representation of width :math:`N` bits:
+
+.. math::
+
+   \text{value per LSB} = \frac{FS}{2^{N - 1}}
+
+For example, an accelerometer with a +/-8 g full-scale range read as a signed
+16-bit sample resolves:
+
+.. math::
+
+   \frac{8}{2^{15}} = \frac{8}{32768} = \frac{1}{4096} \text{ g per LSB}
+
+A driver converts the raw count to an SI value using this scale (and offset, if any),
+then encodes that value as ``q31_t`` at the channel's shift.
+
+Conversion helpers
+==================
+
+The following helpers convert between an integer SI value (in micro, milli, or
+centi units) and the ``q31_t`` representation at a given shift:
+
+* :c:func:`sensor_q31_from_micro`, :c:func:`sensor_q31_from_milli`,
+  :c:func:`sensor_q31_from_centi`
+* :c:func:`sensor_q31_to_micro`, :c:func:`sensor_q31_to_milli`,
+  :c:func:`sensor_q31_to_centi`
+
+The :zephyr_file:`tests/drivers/sensor/utils` test suite exercises these helpers
+with ``int16`` samples for an IMU and a temperature sensor as worked examples.
+
 Polling Read
 ************
 

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1610,6 +1610,81 @@ static inline int sensor_value_from_micro(struct sensor_value *val, int64_t micr
 }
 
 /**
+ * @brief Convert a centi-unit integer value to a Q31 fixed-point value.
+ *
+ * @param centi The input value in centi (1/100) SI units.
+ * @param shift The shift (number of integer bits) the value is encoded with (0 to 31).
+ * @return The converted Q31 fixed-point value, saturated to the q31 range.
+ */
+static inline q31_t sensor_q31_from_centi(int64_t centi, int8_t shift)
+{
+	int64_t scaled = (centi * (int64_t)BIT(31 - shift)) / 100LL;
+
+	return (q31_t)CLAMP(scaled, INT32_MIN, INT32_MAX);
+}
+/**
+ * @brief Convert a milli-unit integer value to a Q31 fixed-point value.
+ *
+ * @param milli The input value in milli (1/1000) SI units.
+ * @param shift The shift (number of integer bits) the value is encoded with (0 to 31).
+ * @return The converted Q31 fixed-point value, saturated to the q31 range.
+ */
+static inline q31_t sensor_q31_from_milli(int64_t milli, int8_t shift)
+{
+	int64_t scaled = (milli * (int64_t)BIT(31 - shift)) / 1000LL;
+
+	return (q31_t)CLAMP(scaled, INT32_MIN, INT32_MAX);
+}
+/**
+ * @brief Convert a micro-unit integer value to a Q31 fixed-point value.
+ *
+ * @param micro The input value in micro (1/1000000) SI units.
+ * @param shift The shift (number of integer bits) the value is encoded with (0 to 31).
+ * @return The converted Q31 fixed-point value, saturated to the q31 range.
+ */
+static inline q31_t sensor_q31_from_micro(int64_t micro, int8_t shift)
+{
+	int64_t scaled = (micro * (int64_t)BIT(31 - shift)) / 1000000LL;
+
+	return (q31_t)CLAMP(scaled, INT32_MIN, INT32_MAX);
+}
+
+/**
+ * @brief Convert a Q31 fixed-point value to a centi-unit integer value.
+ *
+ * @param value The Q31 fixed-point value.
+ * @param shift The shift the value was encoded with.
+ * @return The converted value in centi (1/100) SI units.
+ */
+static inline int64_t sensor_q31_to_centi(q31_t value, int8_t shift)
+{
+	return ((int64_t)value * 100LL) / (int64_t)BIT(31 - shift);
+}
+
+/**
+ * @brief Convert a Q31 fixed-point value to a milli-unit integer value.
+ *
+ * @param value The Q31 fixed-point value.
+ * @param shift The shift the value was encoded with.
+ * @return The converted value in milli (1/1000) SI units.
+ */
+static inline int64_t sensor_q31_to_milli(q31_t value, int8_t shift)
+{
+	return ((int64_t)value * 1000LL) / (int64_t)BIT(31 - shift);
+}
+/**
+ * @brief Convert a Q31 fixed-point value to a micro-unit integer value.
+ *
+ * @param value The Q31 fixed-point value.
+ * @param shift The shift the value was encoded with.
+ * @return The converted value in micro (1/1000000) SI units.
+ */
+static inline int64_t sensor_q31_to_micro(q31_t value, int8_t shift)
+{
+	return ((int64_t)value * 1000000LL) / (int64_t)BIT(31 - shift);
+}
+
+/**
  * @}
  */
 

--- a/tests/drivers/sensor/utils/CMakeLists.txt
+++ b/tests/drivers/sensor/utils/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sensor_utils)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/sensor/utils/prj.conf
+++ b/tests/drivers/sensor/utils/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/drivers/sensor/utils/src/main.c
+++ b/tests/drivers/sensor/utils/src/main.c
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2026 Ale Alfaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <zephyr/ztest.h>
+#include <zephyr/drivers/sensor.h>
+
+/*
+ * Tests and usage reference for the sensor fixed-point helpers that convert sensor
+ * readings to and from SI units.
+ *
+ * See the "Fixed-point values" section in
+ * doc/hardware/peripherals/sensor/read_and_decode.rst for the Q31 background.
+ */
+
+#define ACCEL_SHIFT    10
+#define GYRO_SHIFT     10
+#define TEMP_SHIFT     10
+/*
+ * The q31 scaling at a given shift that can be multiplied to convert a value to fixed point, i.e.
+ * 2^(31 - shift). Expected values are written as a multiple of this to make it clear what this
+ * values are really in terms of SI units
+ */
+#define Q31_ONE(shift) ((q31_t)BIT(31 - (shift)))
+
+/* Q31 conversion constants */
+/* Accel sensor: fs=8g 8/32768 = 1/4096 g per LSB. */
+#define ACCEL_SCALING   Q31_ONE(ACCEL_SHIFT)
+#define ACCEL_FS_RANGE  8
+#define ACCEL_LSB_PER_G (4096)
+#define GYRO_SCALING    Q31_ONE(GYRO_SHIFT)
+#define GYRO_RANGE_DPS  1000
+#define TEMP_SCALING    Q31_ONE(TEMP_SHIFT)
+
+/* A signed 16-bit sample spans its full-scale range over +/- 2^15 counts. */
+#define SAMPLE_WIDTH_BITS 16
+#define SAMPLE_FULL_SCALE (1 << (SAMPLE_WIDTH_BITS - 1)) /* signed: negative raw divides right */
+
+/* Temperature sensor: 1/512 deg C per LSB, offset of 23.000 C. */
+#define TEMP_LSB_PER_C                512
+#define TEMP_OFFSET_MICRO_DEG_CELSIUS (23000000LL)
+
+#define MICRO_PER_UNIT 1000000LL
+#define MILLI_PER_UNIT 1000LL
+#define CENTI_PER_UNIT 100LL
+
+ZTEST_SUITE(sensor_fp, NULL, NULL, NULL, NULL, NULL);
+
+/*
+ * SI units -> q31  tests
+ */
+struct si_units_to_q31_case {
+	int64_t si_val;
+	q31_t expected;
+};
+
+/* Conversion to q31 from micro units */
+ZTEST_P(sensor_fp, test_accel_from_micro)
+{
+	const struct si_units_to_q31_case *c = ZTEST_GET_PARAM_PTR(struct si_units_to_q31_case);
+	q31_t q = sensor_q31_from_micro(c->si_val, ACCEL_SHIFT);
+
+	zexpect_equal(q, c->expected, "%lld si_val-g @ shift %d: got %d, expected %d",
+		      (long long)c->si_val, ACCEL_SHIFT, q, c->expected);
+}
+
+static const struct si_units_to_q31_case accel_micro_normal[] = {
+	{.si_val = 1 * MICRO_PER_UNIT, .expected = ACCEL_SCALING},     /* +1.00 g */
+	{.si_val = MICRO_PER_UNIT / 2, .expected = ACCEL_SCALING / 2}, /* +0.50 g */
+	{.si_val = -1 * MICRO_PER_UNIT, .expected = -ACCEL_SCALING},   /* -1.00 g */
+};
+ZTEST_DEFINE_PARAM_VALUES_ARRAY(accel_micro_normal_vals, accel_micro_normal);
+ZTEST_INSTANTIATE_TEST_SUITE_P(accel_micro_normal, sensor_fp, test_accel_from_micro,
+			       accel_micro_normal_vals);
+
+/* Conversion to q31 from milli units */
+ZTEST_P(sensor_fp, test_gyro_from_milli)
+{
+	const struct si_units_to_q31_case *c = ZTEST_GET_PARAM_PTR(struct si_units_to_q31_case);
+	q31_t q = sensor_q31_from_milli(c->si_val, GYRO_SHIFT);
+
+	zexpect_equal(q, c->expected, "%lld milli-dps @ shift %d: got %d, expected %d",
+		      (long long)c->si_val, GYRO_SHIFT, q, c->expected);
+}
+
+static const struct si_units_to_q31_case gyro_milli_normal[] = {
+	{.si_val = 250 * MILLI_PER_UNIT, .expected = 250 * GYRO_SCALING},   /* +250 dps */
+	{.si_val = MILLI_PER_UNIT / 2, .expected = GYRO_SCALING / 2},       /* +0.5 dps */
+	{.si_val = -250 * MILLI_PER_UNIT, .expected = -250 * GYRO_SCALING}, /* -250 dps */
+};
+ZTEST_DEFINE_PARAM_VALUES_ARRAY(gyro_milli_normal_vals, gyro_milli_normal);
+ZTEST_INSTANTIATE_TEST_SUITE_P(gyro_milli, sensor_fp, test_gyro_from_milli, gyro_milli_normal_vals);
+
+/* Conversion to q31 from centi units */
+ZTEST_P(sensor_fp, test_temp_from_centi)
+{
+	const struct si_units_to_q31_case *c = ZTEST_GET_PARAM_PTR(struct si_units_to_q31_case);
+	q31_t q = sensor_q31_from_centi(c->si_val, TEMP_SHIFT);
+
+	zexpect_equal(q, c->expected, "%lld centi-C @ shift %d: got %d, expected %d",
+		      (long long)c->si_val, TEMP_SHIFT, q, c->expected);
+}
+
+static const struct si_units_to_q31_case temp_centi_normal[] = {
+	{.si_val = 23 * CENTI_PER_UNIT, .expected = 23 * TEMP_SCALING},   /*  23.00 C */
+	{.si_val = -10 * CENTI_PER_UNIT, .expected = -10 * TEMP_SCALING}, /* -10.00 C */
+	{.si_val = 0, .expected = 0},                                     /*   0.00 C */
+};
+ZTEST_DEFINE_PARAM_VALUES_ARRAY(temp_centi_normal_vals, temp_centi_normal);
+ZTEST_INSTANTIATE_TEST_SUITE_P(temp_centi, sensor_fp, test_temp_from_centi, temp_centi_normal_vals);
+
+/*
+ * q31 -> SI units tests
+ */
+struct q31_to_si_units_case {
+	q31_t q;
+	int64_t expected;
+};
+
+/* Conversion to micro units from q31 */
+ZTEST_P(sensor_fp, test_accel_to_micro)
+{
+	const struct q31_to_si_units_case *c = ZTEST_GET_PARAM_PTR(struct q31_to_si_units_case);
+	int64_t micro = sensor_q31_to_micro(c->q, ACCEL_SHIFT);
+
+	zexpect_equal(micro, c->expected, "q31 %d @ shift %d: got %lld, expected %lld", c->q,
+		      ACCEL_SHIFT, (long long)micro, (long long)c->expected);
+}
+
+static const struct q31_to_si_units_case accel_to_micro[] = {
+	{.q = ACCEL_SCALING, .expected = MICRO_PER_UNIT},         /* 1,000,000 micro g */
+	{.q = ACCEL_SCALING / 2, .expected = MICRO_PER_UNIT / 2}, /* 500,000 micro g */
+	{.q = -ACCEL_SCALING, .expected = -1 * MICRO_PER_UNIT},   /* -1,000,000 micro g */
+};
+ZTEST_DEFINE_PARAM_VALUES_ARRAY(accel_to_micro_vals, accel_to_micro);
+ZTEST_INSTANTIATE_TEST_SUITE_P(accel_to_micro, sensor_fp, test_accel_to_micro, accel_to_micro_vals);
+
+/* Conversion to milli units from q31 */
+ZTEST_P(sensor_fp, test_gyro_to_milli)
+{
+	const struct q31_to_si_units_case *c = ZTEST_GET_PARAM_PTR(struct q31_to_si_units_case);
+	int64_t milli = sensor_q31_to_milli(c->q, GYRO_SHIFT);
+
+	zexpect_equal(milli, c->expected, "q31 %d @ shift %d: got %lld, expected %lld", c->q,
+		      GYRO_SHIFT, (long long)milli, (long long)c->expected);
+}
+
+static const struct q31_to_si_units_case gyro_to_milli[] = {
+	{.q = GYRO_SCALING, .expected = MILLI_PER_UNIT},         /*  1000 milli-dps */
+	{.q = GYRO_SCALING / 2, .expected = MILLI_PER_UNIT / 2}, /* 500 milli-dps */
+	{.q = -GYRO_SCALING, .expected = -1 * MILLI_PER_UNIT},   /* -1000 milli-dps */
+};
+ZTEST_DEFINE_PARAM_VALUES_ARRAY(gyro_to_milli_vals, gyro_to_milli);
+ZTEST_INSTANTIATE_TEST_SUITE_P(gyro_to_milli, sensor_fp, test_gyro_to_milli, gyro_to_milli_vals);
+
+/* Conversion to centi units from q31 */
+ZTEST_P(sensor_fp, test_temp_to_centi)
+{
+	const struct q31_to_si_units_case *c = ZTEST_GET_PARAM_PTR(struct q31_to_si_units_case);
+	int64_t centi = sensor_q31_to_centi(c->q, TEMP_SHIFT);
+
+	zexpect_equal(centi, c->expected, "q31 %d @ shift %d: got %lld, expected %lld", c->q,
+		      TEMP_SHIFT, (long long)centi, (long long)c->expected);
+}
+
+static const struct q31_to_si_units_case temp_to_centi[] = {
+	{.q = 23 * TEMP_SCALING, .expected = 23 * CENTI_PER_UNIT},   /*  2300 centi C */
+	{.q = TEMP_SCALING / 2, .expected = CENTI_PER_UNIT / 2},     /*  50 centi C */
+	{.q = -23 * TEMP_SCALING, .expected = -23 * CENTI_PER_UNIT}, /* -2300 centi C */
+};
+ZTEST_DEFINE_PARAM_VALUES_ARRAY(temp_to_centi_vals, temp_to_centi);
+ZTEST_INSTANTIATE_TEST_SUITE_P(temp_to_centi, sensor_fp, test_temp_to_centi, temp_to_centi_vals);
+
+/*
+ * value -> q31 -> value : exactly representable readings come back unchanged.
+ */
+ZTEST(sensor_fp, test_roundtrip)
+{
+	q31_t q;
+	int64_t expected;
+
+	/* accelerometer: +1.5 g in micro-g */
+	expected = (3 * MICRO_PER_UNIT) / 2;
+	q = sensor_q31_from_micro(expected, ACCEL_SHIFT);
+	zexpect_equal(sensor_q31_to_micro(q, ACCEL_SHIFT), expected, "accel 1.5 g round-trip");
+
+	/* temperature: 23.00 C in centi */
+	expected = 23 * CENTI_PER_UNIT;
+	q = sensor_q31_from_centi(expected, TEMP_SHIFT);
+	zexpect_equal(sensor_q31_to_centi(q, TEMP_SHIFT), expected, "temp 23.00 C round-trip");
+
+	/* gyroscope: 250.0 dps in milli */
+	expected = 250 * MILLI_PER_UNIT;
+	q = sensor_q31_from_milli(expected, GYRO_SHIFT);
+	zexpect_equal(sensor_q31_to_milli(q, GYRO_SHIFT), expected, "gyro 250 dps round-trip");
+}
+
+/*
+ * value -> q31 from a raw register read -- the real driver scenario.
+ *
+ * A driver turns the raw sample into an SI value using the sensor's full-scale
+ * range / sensitivity (and offset), then encodes that as q31.
+ */
+struct raw_to_q31_case {
+	int16_t raw;
+	q31_t expected;
+};
+
+/* Accelerometer: 16-bit signed sample, +/- 8 g full-scale (so 1 g = 4096 LSB). */
+ZTEST_P(sensor_fp, test_accel_from_raw)
+{
+	const struct raw_to_q31_case *c = ZTEST_GET_PARAM_PTR(struct raw_to_q31_case);
+	/* raw counts -> micro-g: full-scale ACCEL_FS_RANGE spans SAMPLE_FULL_SCALE counts. */
+	int64_t micro_g = ((int64_t)c->raw * ACCEL_FS_RANGE * MICRO_PER_UNIT) / SAMPLE_FULL_SCALE;
+	q31_t q = sensor_q31_from_micro(micro_g, ACCEL_SHIFT);
+
+	zexpect_equal(q, c->expected, "raw %d: got %d, expected %d", c->raw, q, c->expected);
+}
+
+static const struct raw_to_q31_case accel_from_raw[] = {
+	{.raw = ACCEL_LSB_PER_G, .expected = ACCEL_SCALING},         /* +1.0 g */
+	{.raw = ACCEL_LSB_PER_G / 2, .expected = ACCEL_SCALING / 2}, /* +0.5 g */
+	{.raw = 2 * ACCEL_LSB_PER_G, .expected = 2 * ACCEL_SCALING}, /* +2.0 g */
+	{.raw = -ACCEL_LSB_PER_G, .expected = -ACCEL_SCALING},       /* -1.0 g */
+};
+ZTEST_DEFINE_PARAM_VALUES_ARRAY(accel_raw_vals, accel_from_raw);
+ZTEST_INSTANTIATE_TEST_SUITE_P(accel_raw, sensor_fp, test_accel_from_raw, accel_raw_vals);
+
+/* Temperature: 16-bit sample, 512 LSB/deg C, reading 23 C at raw 0. */
+ZTEST_P(sensor_fp, test_temp_from_raw)
+{
+	const struct raw_to_q31_case *c = ZTEST_GET_PARAM_PTR(struct raw_to_q31_case);
+	/* raw counts -> micro-C: apply sensitivity (LSB/C) and the 23 C offset. */
+	int64_t micro_c =
+		TEMP_OFFSET_MICRO_DEG_CELSIUS + ((int64_t)c->raw * MICRO_PER_UNIT) / TEMP_LSB_PER_C;
+	q31_t q = sensor_q31_from_micro(micro_c, TEMP_SHIFT);
+
+	zexpect_equal(q, c->expected, "raw %d: got q31=%d (%d C), expected q31=%d (%d C)", c->raw,
+		      q, (q / TEMP_SCALING), c->expected, (c->expected / TEMP_SCALING));
+}
+
+/* Gyroscope: 16-bit signed sample, +/- 1000 dps full-scale. */
+ZTEST_P(sensor_fp, test_gyro_from_raw)
+{
+	const struct raw_to_q31_case *c = ZTEST_GET_PARAM_PTR(struct raw_to_q31_case);
+	/* raw counts -> milli-dps: full-scale GYRO_RANGE_DPS spans SAMPLE_FULL_SCALE counts. */
+	int64_t milli_dps = ((int64_t)c->raw * GYRO_RANGE_DPS * MILLI_PER_UNIT) / SAMPLE_FULL_SCALE;
+	q31_t q = sensor_q31_from_milli(milli_dps, GYRO_SHIFT);
+
+	zexpect_equal(q, c->expected, "raw %d: got %d, expected %d", c->raw, q, c->expected);
+}
+
+static const struct raw_to_q31_case gyro_from_raw[] = {
+	{.raw = SAMPLE_FULL_SCALE / 2, .expected = 500 * GYRO_SCALING},     /* +500 dps */
+	{.raw = SAMPLE_FULL_SCALE / 4, .expected = 250 * GYRO_SCALING},     /* +250 dps */
+	{.raw = SAMPLE_FULL_SCALE / 8, .expected = 125 * GYRO_SCALING},     /* +125 dps */
+	{.raw = -(SAMPLE_FULL_SCALE / 2), .expected = -500 * GYRO_SCALING}, /* -500 dps */
+};
+ZTEST_DEFINE_PARAM_VALUES_ARRAY(gyro_raw_vals, gyro_from_raw);
+ZTEST_INSTANTIATE_TEST_SUITE_P(gyro_raw, sensor_fp, test_gyro_from_raw, gyro_raw_vals);
+
+static const struct raw_to_q31_case temp_from_raw[] = {
+	{.raw = 0, .expected = 23 * TEMP_SCALING},                   /* 23.0 C */
+	{.raw = TEMP_LSB_PER_C, .expected = 24 * TEMP_SCALING},      /* 24.0 C */
+	{.raw = -TEMP_LSB_PER_C, .expected = 22 * TEMP_SCALING},     /* 22.0 C */
+	{.raw = 10 * TEMP_LSB_PER_C, .expected = 33 * TEMP_SCALING}, /* 33.0 C */
+};
+ZTEST_DEFINE_PARAM_VALUES_ARRAY(temp_raw_vals, temp_from_raw);
+ZTEST_INSTANTIATE_TEST_SUITE_P(temp_raw, sensor_fp, test_temp_from_raw, temp_raw_vals);

--- a/tests/drivers/sensor/utils/testcase.yaml
+++ b/tests/drivers/sensor/utils/testcase.yaml
@@ -1,0 +1,7 @@
+tests:
+  drivers.sensor.utils:
+    integration_platforms:
+      - native_sim
+    tags:
+      - drivers
+      - sensor


### PR DESCRIPTION
### Summary

Adds reusable helpers for converting between SI units and q31 fixed-point values for sensors. 

The Sensor (V2) decoder/encoder API works in q31 fixed-point which lacks any common helpers, example usage or any documentation. As this is a new concept for many new developers having some helpers, tests and documentation for fixed point conversion can be really helpful.

Additionally sensor drivers currently implement their own helpers that do the same types of conversions but are only scoped to that drivers  (e.g. the `Q31_SHIFT_VAL` /`Q31_SHIFT_MICROVAL` macros in ST sensor decoders). Having common helpers would help consolidate this code into a single,tested implementation for consistency and correctness. 

This PR provides the implementation, testing and documentation for fixed point conversion with special emphasis on being beginner friendly as this might be their first introduction to fixed point numbers.

### Added

- **`include: drivers: sensor`** — `sensor_q31_{from,to}_{centi,milli,micro}()`
- **`tests: drivers: sensor`** — Tests added to covert all the new conversion helpers using practical values and examples to help new contributors understand how this helpers and fixed point in general are used.
- **`doc: drivers: sensor`** — Documentation below sensor V2 driver API on fixed point numbers given a short introduction and an example of the shift value on how they affect the sensor encoded values.

> [!NOTE] Implementation notes
> - Supporting centi, milli and micro scale similar to the sensor_value conversion helpers
> - Using `CLAMP` for avoiding saturation when converting to fixed point
> - Using scaling value for a given shift in the form of `BIT(31-m)` and making the order of operation so multiplication is first and then division to avoid losing precision due to values getting truncated. 


Signed-off-by: Ale Alfaro <ale16alfaro@gmail.com>