### PR TITLE
twister: mark tests not run when configure-time simulator is missing

### DIFF
--- a/scripts/pylib/twister/twisterlib/constants.py
+++ b/scripts/pylib/twister/twisterlib/constants.py
@@ -32,6 +32,17 @@ SUPPORTED_SIMS = [
 SUPPORTED_SIMS_IN_PYTEST = ['native', 'qemu']
 SUPPORTED_SIMS_WITH_EXEC = ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native', 'simics', 'custom']
 
+# Simulators whose executable is resolved at CMake configure time (via
+# find_program) instead of being known during test planning. The binary that
+# gets used can depend on the build configuration (e.g. Arm FVP selects a
+# different model depending on the Ethos-U NPU), so these cannot be listed in
+# SUPPORTED_SIMS_WITH_EXEC and checked up front. After the build, availability
+# is read from the named CMakeCache variable: a missing entry or a *-NOTFOUND
+# value means the simulator was not found and the test cannot be executed.
+SIM_PROGRAM_CMAKE_VARS = {
+    'armfvp': 'ARMFVP',
+}
+
 PYTEST_HARNESSES = ['pytest', 'shell', 'power', 'display_capture']
 
 SUPPORTED_HARNESSES = [

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -29,7 +29,7 @@ from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 from packaging import version
 from twisterlib.cmakecache import CMakeCache
-from twisterlib.constants import canonical_zephyr_base
+from twisterlib.constants import SIM_PROGRAM_CMAKE_VARS, canonical_zephyr_base
 from twisterlib.error import (
     BuildError,
     ConfigurationError,
@@ -881,6 +881,14 @@ class FilterBuilder(CMake):
 
 class ProjectBuilder(FilterBuilder):
 
+    # Optional post-build checks, run when --post-build-checks is enabled.
+    # Each entry is the name of a bound method returning None on success or a
+    # human-readable reason string on failure. Extend the pipeline by adding a
+    # new method name here rather than modifying run_post_build_checks().
+    POST_BUILD_CHECKS = (
+        "check_no_nested_git_repos",
+    )
+
     def __init__(self, instance: TestInstance, env: TwisterEnv, jobserver, **kwargs):
         super().__init__(
             instance.testsuite,
@@ -1071,16 +1079,14 @@ class ProjectBuilder(FilterBuilder):
                             )
                             try:
                                 self.determine_testcases(results)
-                                next_op = 'post_build' if self.options.post_build_checks \
-                                    else 'gather_metrics'
+                                next_op = 'post_build'
                             except BuildError as e:
                                 logger.error(str(e))
                                 self.instance.status = TwisterStatus.ERROR
                                 self.instance.reason = str(e)
                                 next_op = 'report'
                         else:
-                            next_op = 'post_build' if self.options.post_build_checks \
-                                else 'gather_metrics'
+                            next_op = 'post_build'
             except StatusAttributeError as sae:
                 logger.error(str(sae))
                 self.instance.status = TwisterStatus.ERROR
@@ -1811,21 +1817,45 @@ class ProjectBuilder(FilterBuilder):
         return build_result
 
     def post_build(self):
-        """Run post-build checks against the build directory.
+        """Post-build processing against the freshly built artifacts.
 
-        Each check is a bound method returning ``None`` on success or a
-        human-readable reason string on failure. The first failing check
-        short-circuits and fails the build. New checks can be added to the
-        ``checks`` list below.
+        This stage always runs after a successful build. It first resolves
+        simulator availability (which may mark the instance as not run), then
+        runs the optional post-build checks. The two concerns are handled by
+        dedicated methods.
         """
-        checks = [
-            self.check_no_nested_git_repos,
-        ]
-        for check in checks:
-            reason = check()
+        self.check_simulator_availability()
+        return self.run_post_build_checks()
+
+    def check_simulator_availability(self):
+        """Mark the instance as not run if its simulator binary, resolved at
+        CMake configure time (recorded in CMakeCache), was not found.
+
+        Availability of such simulators (e.g. Arm FVP) cannot be determined
+        during test planning, so it is checked here once the build has run.
+        """
+        if self.instance.run and (sim_reason := self._simulator_unavailable_reason()):
+            logger.debug(f"Instance {self.instance.name} can't run: {sim_reason}")
+            self.instance.run = False
+            self.instance.status = TwisterStatus.NOTRUN
+            self.instance.reason = sim_reason
+            self.instance.add_missing_case_status(TwisterStatus.NOTRUN, sim_reason)
+
+    def run_post_build_checks(self):
+        """Run the optional post-build checks, gated by ``--post-build-checks``.
+
+        Each check named in ``POST_BUILD_CHECKS`` returns ``None`` on success
+        or a human-readable reason string on failure; the first failing check
+        short-circuits and fails the build.
+        """
+        if not self.options.post_build_checks:
+            return {"returncode": 0}
+
+        for check_name in self.POST_BUILD_CHECKS:
+            reason = getattr(self, check_name)()
             if reason:
                 logger.error(
-                    f"Post-build check '{check.__name__}' failed for "
+                    f"Post-build check '{check_name}' failed for "
                     f"{self.instance.name}: {reason}"
                 )
                 return {"returncode": 1, "reason": reason}
@@ -1895,6 +1925,55 @@ class ProjectBuilder(FilterBuilder):
             instance.metrics["available_rom"] = 0
             instance.metrics["available_ram"] = 0
         return build_result
+
+    def _cmake_cache_path(self) -> str:
+        """Path to the CMakeCache.txt holding this instance's build variables.
+
+        For sysbuild builds the application image (and therefore variables
+        such as the simulator executable) lives in the default domain's build
+        directory rather than the top-level build directory.
+        """
+        build_dir = self.build_dir
+        if self.instance.sysbuild:
+            domain_path = os.path.join(build_dir, "domains.yaml")
+            try:
+                domains = Domains.from_file(domain_path)
+            except FileNotFoundError:
+                return os.path.join(build_dir, "CMakeCache.txt")
+            domain_build = domains.get_default_domain().build_dir
+            if not os.path.isabs(domain_build):
+                domain_build = os.path.normpath(os.path.join(build_dir, domain_build))
+            build_dir = domain_build
+        return os.path.join(build_dir, "CMakeCache.txt")
+
+    def _simulator_unavailable_reason(self) -> str | None:
+        """Return a reason string if the instance's simulator binary was not
+        found at CMake configure time, otherwise None.
+
+        Some simulators (e.g. Arm FVP) resolve their executable at configure
+        time via find_program(), and the binary that gets used can vary with
+        the build configuration, so their availability cannot be determined
+        during test planning. The result is recorded in CMakeCache, which is
+        inspected here after the build.
+        """
+        simulator = self.instance.platform.simulator_by_name(self.options.sim_name)
+        if simulator is None:
+            return None
+
+        cmake_var = SIM_PROGRAM_CMAKE_VARS.get(simulator.name)
+        if cmake_var is None:
+            return None
+
+        try:
+            cache = CMakeCache.from_file(self._cmake_cache_path())
+        except FileNotFoundError:
+            return None
+
+        value = cache.get(cmake_var)
+        if value is None or str(value).endswith("-NOTFOUND"):
+            return f"{simulator.name} simulator binary not found"
+
+        return None
 
     @staticmethod
     def calc_size(instance: TestInstance, from_buildlog: bool):

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -1558,15 +1558,16 @@ def test_projectbuilder_process(
 
 
 @pytest.mark.parametrize(
-    'post_build_checks, expected_next_op',
-    [(True, 'post_build'), (False, 'gather_metrics')],
+    'post_build_checks',
+    [True, False],
     ids=['enabled', 'disabled']
 )
-def test_projectbuilder_process_post_build_checks_gating(
-    mocked_jobserver, tmp_path, post_build_checks, expected_next_op
+def test_projectbuilder_process_post_build_transition(
+    mocked_jobserver, tmp_path, post_build_checks
 ):
-    """A successful build transitions to 'post_build' only when post-build
-    checks are enabled; otherwise it goes straight to 'gather_metrics'.
+    """A successful build always transitions to 'post_build', regardless of
+    whether the optional post-build checks are enabled. The post_build stage
+    itself decides whether to run those checks.
     """
     instance_mock = mock.Mock()
     instance_mock.name = 'dummy instance name'
@@ -1593,7 +1594,7 @@ def test_projectbuilder_process_post_build_checks_gating(
 
     pb.process(processing_queue_mock, mock.Mock(), {'op': 'build'}, lock_mock, results_mock)
 
-    processing_queue_mock.append.assert_called_with({'op': expected_next_op, 'test': mock.ANY})
+    processing_queue_mock.append.assert_called_with({'op': 'post_build', 'test': mock.ANY})
 
 
 TESTDATA_7 = [
@@ -2437,6 +2438,8 @@ def test_projectbuilder_post_build_pass(mocked_jobserver):
     env_mock = mock.Mock()
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+    pb.options.post_build_checks = True
+    pb._simulator_unavailable_reason = mock.Mock(return_value=None)
     pb.check_no_nested_git_repos = mock.Mock(return_value=None)
 
     assert pb.post_build() == {'returncode': 0}
@@ -2448,6 +2451,8 @@ def test_projectbuilder_post_build_fail(mocked_jobserver):
     env_mock = mock.Mock()
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+    pb.options.post_build_checks = True
+    pb._simulator_unavailable_reason = mock.Mock(return_value=None)
     pb.check_no_nested_git_repos = mock.Mock(
         return_value='cloned repo found', __name__='check_no_nested_git_repos'
     )
@@ -2455,6 +2460,48 @@ def test_projectbuilder_post_build_fail(mocked_jobserver):
     res = pb.post_build()
     assert res['returncode'] == 1
     assert res['reason'] == 'cloned repo found'
+
+
+def test_projectbuilder_post_build_checks_skipped(mocked_jobserver):
+    """When --post-build-checks is not set, the optional checks are skipped
+    but post_build still succeeds (and other processing still runs).
+    """
+    instance_mock = mock.Mock()
+    env_mock = mock.Mock()
+
+    pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+    pb.options.post_build_checks = False
+    pb._simulator_unavailable_reason = mock.Mock(return_value=None)
+    pb.check_no_nested_git_repos = mock.Mock(
+        return_value='cloned repo found', __name__='check_no_nested_git_repos'
+    )
+
+    assert pb.post_build() == {'returncode': 0}
+    pb.check_no_nested_git_repos.assert_not_called()
+
+
+def test_projectbuilder_post_build_simulator_unavailable(mocked_jobserver):
+    """A runnable instance whose configure-time simulator binary is missing is
+    marked as not run during post_build, without failing the build.
+    """
+    instance_mock = mock.Mock()
+    instance_mock.name = 'dummy instance name'
+    instance_mock.run = True
+    env_mock = mock.Mock()
+
+    pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+    pb.options.post_build_checks = False
+    pb._simulator_unavailable_reason = mock.Mock(
+        return_value='armfvp simulator binary not found'
+    )
+
+    assert pb.post_build() == {'returncode': 0}
+    assert instance_mock.run is False
+    assert instance_mock.status == TwisterStatus.NOTRUN
+    assert instance_mock.reason == 'armfvp simulator binary not found'
+    instance_mock.add_missing_case_status.assert_called_once_with(
+        TwisterStatus.NOTRUN, 'armfvp simulator binary not found'
+    )
 
 
 TESTDATA_14 = [
@@ -2569,6 +2616,90 @@ def test_projectbuilder_run(
 
     if expect_handle:
         pb.instance.handler.handle.assert_called_once_with(harness_mock)
+
+
+TESTDATA_SIM_UNAVAILABLE = [
+    # No simulator selected for the platform.
+    (None, None, None),
+    # Simulator that does not resolve its binary at configure time.
+    ('qemu', None, None),
+    # Arm FVP binary found at configure time.
+    ('armfvp', '/opt/fvp/FVP_Base', None),
+    # Arm FVP binary not found at configure time.
+    ('armfvp', 'ARMFVP-NOTFOUND', 'armfvp simulator binary not found'),
+    # Arm FVP cache variable missing entirely.
+    ('armfvp', 'missing', 'armfvp simulator binary not found'),
+]
+
+
+@pytest.mark.parametrize(
+    'sim_name, armfvp_value, expected_reason',
+    TESTDATA_SIM_UNAVAILABLE,
+    ids=['no sim', 'non-configure sim', 'fvp found', 'fvp not found', 'fvp missing']
+)
+def test_projectbuilder_simulator_unavailable_reason(
+    mocked_jobserver,
+    tmp_path,
+    sim_name,
+    armfvp_value,
+    expected_reason
+):
+    instance_mock = mock.Mock()
+    instance_mock.build_dir = str(tmp_path)
+    instance_mock.sysbuild = False
+    if sim_name is None:
+        instance_mock.platform.simulator_by_name = mock.Mock(return_value=None)
+    else:
+        simulator_mock = mock.Mock()
+        simulator_mock.name = sim_name
+        instance_mock.platform.simulator_by_name = mock.Mock(return_value=simulator_mock)
+
+    if armfvp_value == 'missing':
+        # CMakeCache exists but has no ARMFVP entry.
+        with open(os.path.join(str(tmp_path), 'CMakeCache.txt'), 'w') as f:
+            f.write('SOME_OTHER_VAR:STRING=value\n')
+    elif armfvp_value is not None:
+        with open(os.path.join(str(tmp_path), 'CMakeCache.txt'), 'w') as f:
+            f.write(f'ARMFVP:FILEPATH={armfvp_value}\n')
+
+    env_mock = mock.Mock()
+    pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+    pb.options = mock.Mock()
+    pb.options.sim_name = sim_name
+
+    assert pb._simulator_unavailable_reason() == expected_reason
+
+
+def test_projectbuilder_simulator_unavailable_reason_sysbuild(
+    mocked_jobserver, tmp_path
+):
+    """For sysbuild builds, the simulator variable is read from the default
+    domain's CMakeCache, not the top-level build directory.
+    """
+    domain_build = tmp_path / 'my_app'
+    domain_build.mkdir()
+    with open(os.path.join(str(domain_build), 'CMakeCache.txt'), 'w') as f:
+        f.write('ARMFVP:FILEPATH=ARMFVP-NOTFOUND\n')
+    # A stray top-level cache with the binary present must be ignored.
+    with open(os.path.join(str(tmp_path), 'CMakeCache.txt'), 'w') as f:
+        f.write('ARMFVP:FILEPATH=/opt/fvp/FVP_Base\n')
+
+    instance_mock = mock.Mock()
+    instance_mock.build_dir = str(tmp_path)
+    instance_mock.sysbuild = True
+    simulator_mock = mock.Mock()
+    simulator_mock.name = 'armfvp'
+    instance_mock.platform.simulator_by_name = mock.Mock(return_value=simulator_mock)
+
+    env_mock = mock.Mock()
+    pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+    pb.options = mock.Mock()
+    pb.options.sim_name = 'armfvp'
+
+    domains_mock = mock.Mock()
+    domains_mock.get_default_domain.return_value.build_dir = 'my_app'
+    with mock.patch('twisterlib.runner.Domains.from_file', return_value=domains_mock):
+        assert pb._simulator_unavailable_reason() == 'armfvp simulator binary not found'
 
 
 TESTDATA_15 = [


### PR DESCRIPTION
Some simulators resolve their executable at CMake configure time via
find_program() instead of being known during test planning, and the
binary that gets used can depend on the build configuration. Arm FVP is
the motivating case: Corstone-300 selects a different model depending on
the Ethos-U NPU, so armfvp cannot be listed in SUPPORTED_SIMS_WITH_EXEC
and checked up front. As a result, when the FVP binary was not installed
Twister still considered the test runnable, attempted to run nothing, and
reported a misleading status.

Inspect CMakeCache after the build instead: add a SIM_PROGRAM_CMAKE_VARS
mapping of simulator name to the cache variable recording its resolved
executable. When the variable is absent or holds a *-NOTFOUND value
(e.g. ARMFVP:FILEPATH=ARMFVP-NOTFOUND), mark the instance as NOTRUN with
a clear reason and propagate that status to its test cases, so the test
is no longer reported as runnable.

This check is done in the post_build stage, which now always runs after a
successful build; the --post-build-checks option only gates the optional
build-failing checks, which are skipped inside post_build when it is not
set. This keeps the not-run determination separate from gather_metrics,
where it did not belong.
