### PR TITLE
doc: use native doxygen requirement traceability commands

### DIFF
--- a/doc/project/documentation.rst
+++ b/doc/project/documentation.rst
@@ -20,8 +20,9 @@ Reference to Requirements
 APIs for the most part document the implementation of requirements or advertised
 features and can be traced back to features. We use the API documentation as the
 main interface to trace implementation back to documented features. This is done
-using custom _doxygen_ tags that reference requirements maintained somewhere
-else in a requirement catalogue.
+using doxygen's native requirements traceability commands (``@satisfies`` and
+``@verifies``) that reference requirements maintained somewhere else in a
+requirement catalogue.
 
 Test Documentation
 *******************
@@ -58,7 +59,27 @@ for traceability reports. Here are a few guidelines to be followed:
 - All test documentation should be under doxygen groups that are prefixed
   with tests\_
 
-The custom doxygen ``@verify`` directive signifies that a test verifies a
+Documenting a Requirement
+=========================
+
+A requirement is documented with the doxygen ``@requirement`` command, which
+takes a unique identifier and an optional title. Doxygen collects all
+requirements on a single page and allows them to be referenced from anywhere by
+their identifier. Use a comment block dedicated to the requirement, typically
+maintained in the requirement catalogue::
+
+    /**
+    * @requirement ZEPH-015 (Give a semaphore)
+    *
+    * The kernel shall provide a mechanism to give a semaphore, increasing its
+    * count up to its configured maximum.
+    */
+
+The identifier used here (for example ``ZEPH-015``) is the same one referenced by
+the ``@satisfies`` and ``@verifies`` commands below, which is what links the
+implementation and tests back to the requirement.
+
+The doxygen ``@verifies`` command signifies that a test verifies a
 requirement::
 
     /**
@@ -74,7 +95,7 @@ requirement::
     * Some details about the test
     * more details
     *
-    * @verify{@req{1111}}
+    * @verifies ZEPH-015
     */
     void test_sema_thread2thread(void)
     {
@@ -87,7 +108,7 @@ requirement::
     */
 
 To get coverage of how an implementation or a piece of code satisfies a
-requirements, we use the ``satisfy`` alias in doxygen::
+requirement, we use the doxygen ``@satisfies`` command::
 
     /**
     * @brief Give a semaphore.
@@ -99,7 +120,7 @@ requirements, we use the ``satisfy`` alias in doxygen::
     *
     * @param sem Address of the semaphore.
     *
-    * @satisfy{@req{015}}
+    * @satisfies ZEPH-015
     */
     __syscall void k_sem_give(struct k_sem *sem);
 

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -286,9 +286,6 @@ TAB_SIZE               = 8
 # @} or use a double escape (\\{ and \\})
 
 ALIASES                = "kconfig{1}=\c \1" \
-                         "req{1}=\ref ZEPH_\1 \"ZEPH-\1\"" \
-                         "satisfy{1}=\xrefitem satisfy \"Satisfies requirement\" \"Requirement Implementation\" \1" \
-                         "verify{1}=\xrefitem verify \"Verifies requirement\" \"Requirement Verification\" \1" \
                          "kconfig_dep{1}=\attention Available only when the following Kconfig option is enabled: \kconfig{\1}." \
                          "kconfig_dep{2}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}." \
                          "kconfig_dep{3}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}, \kconfig{\3}." \


### PR DESCRIPTION
Doxygen natively supports requirement traceability through the
@requirement, @satisfies and @verifies commands. Switch the
documentation guidelines to use these official commands and drop the
custom @req, @satisfy and @verify ALIASES that previously emulated this
behaviour via \xrefitem and \ref.

Also add a short section describing how to document a requirement with
the @requirement command so the traceability example is self-contained:
define a requirement, then reference its identifier from @satisfies and
@verifies.
