### PR TITLE
serial: Add framing-error-reporting property

### DIFF
--- a/dts/bindings/serial/arm,pl011.yaml
+++ b/dts/bindings/serial/arm,pl011.yaml
@@ -8,6 +8,9 @@ properties:
   reg:
     required: true
 
+  framing-error-reporting:
+    default: "LAST_READ"
+
   fifo-disable:
     type: boolean
     description: Disable the UART FIFO

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -11,6 +11,9 @@ include:
   - name: atmel,assigned-clocks.yaml
 
 properties:
+  framing-error-reporting:
+    default: "STICKY_MULTIPLE"
+
   reg:
     required: true
 

--- a/dts/bindings/serial/espressif,esp32-uart.yaml
+++ b/dts/bindings/serial/espressif,esp32-uart.yaml
@@ -5,6 +5,9 @@ compatible: "espressif,esp32-uart"
 include: [uart-controller.yaml, uart-controller-pin-inversion.yaml, pinctrl-device.yaml]
 
 properties:
+  framing-error-reporting:
+    default: "ISR_SAVED"
+
   reg:
     required: true
 

--- a/dts/bindings/serial/nordic,nrf-uart-common.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart-common.yaml
@@ -1,6 +1,9 @@
 include: [uart-controller.yaml, pinctrl-device.yaml, nordic-clockpin.yaml]
 
 properties:
+  framing-error-reporting:
+    default: "STICKY_SINGLE"
+
   reg:
     required: true
 

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -5,6 +5,9 @@ compatible: "ns16550"
 include: [uart-controller.yaml, pcie-device.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
+  framing-error-reporting:
+    default: "FIFO_HEAD"
+
   reg-shift:
     type: int
     required: true

--- a/dts/bindings/serial/nxp,lpuart.yaml
+++ b/dts/bindings/serial/nxp,lpuart.yaml
@@ -5,6 +5,9 @@ compatible: "nxp,lpuart"
 include: [uart-controller.yaml, uart-controller-pin-inversion.yaml, pinctrl-device.yaml]
 
 properties:
+  framing-error-reporting:
+    default: "STICKY_MULTIPLE"
+
   reg:
     required: true
 

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -13,6 +13,9 @@ include:
   - name: uart-controller-pin-inversion.yaml
 
 properties:
+  framing-error-reporting:
+    default: "FIFO_HEAD"
+
   reg:
     required: true
 

--- a/dts/bindings/serial/uart-controller.yaml
+++ b/dts/bindings/serial/uart-controller.yaml
@@ -46,3 +46,57 @@ properties:
       - 7
       - 8
       - 9
+  framing-error-reporting:
+    type: string
+    description: |
+      Describes how the UART hardware reports framing errors relative
+      to byte reads via uart_fifo_read() and uart_err_check().
+
+      This property is used by protocols that rely on framing error
+      detection (e.g. DMX512 break detection) to adapt their error
+      handling strategy to the underlying hardware. This is especially
+      important for protocols that need to read the byte immediately
+      following a framing error.
+
+      "FIFO_HEAD" - Error flags reflect the byte at the FIFO head
+        BEFORE it is read. Reading pops the byte and updates the
+        flags for the new head. Callers can check errors before
+        reading to determine if the next byte is clean.
+        Multiple error bytes in the FIFO are reported individually.
+        Examples: NS16550, STM32 USART (with FIFO enabled).
+
+      "LAST_READ" - Error flags reflect the byte most recently read
+        from the data register (AFTER the read). Callers must read
+        first, then check. Requires explicit clearing of the error
+        status register between reads. Multiple error bytes in the
+        FIFO are reported individually as each byte is read.
+        Examples: ARM PL011 (RP2040, RP2350).
+
+      "STICKY_MULTIPLE" - A global error flag is set on the first
+        framing error and cleared by uart_err_check(). The flag
+        does NOT re-assert for error bytes already in the FIFO.
+        Multiple error bytes may be buffered, but only the first
+        is reported; subsequent error bytes are indistinguishable
+        from clean bytes.
+        Examples: NXP LPUART (i.MX RT, Kinetis), Atmel SAM0 (SAMD21).
+
+      "STICKY_SINGLE" - Same sticky-and-clear semantics as
+        "STICKY_MULTIPLE", but the hardware buffers only one byte
+        at a time (e.g. via single-byte DMA transfers). The
+        distinction from "STICKY_MULTIPLE" is that there are no
+        "hidden" error bytes behind the first one; each byte
+        triggers a separate ISR invocation.
+        Examples: Nordic nRF UARTE (nRF52, nRF53, nRF91).
+
+      "ISR_SAVED" - Framing errors are captured in the UART ISR and
+        stored in driver state. Cleared when the application calls
+        uart_err_check(). Behaves like "STICKY_MULTIPLE" from the
+        caller's perspective (one report per ISR invocation,
+        regardless of how many error bytes triggered the ISR).
+        Examples: Espressif ESP32 UART (all variants).
+    enum:
+      - "FIFO_HEAD"
+      - "LAST_READ"
+      - "STICKY_MULTIPLE"
+      - "STICKY_SINGLE"
+      - "ISR_SAVED"

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -32,6 +32,31 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Framing error reporting behavior.
+ *
+ * Describes how the UART hardware reports framing errors relative to
+ * byte reads via uart_fifo_read() and uart_err_check().
+ *
+ * Set via the framing-error-reporting devicetree property on the UART
+ * controller node. See uart-controller.yaml for detailed descriptions.
+ *
+ * Values are named to match the DT enum strings so they can be read
+ * with DT_STRING_TOKEN(node, framing_error_reporting).
+ */
+enum uart_framing_error_reporting {
+	/** @brief Errors track FIFO head, visible before read. */
+	FIFO_HEAD,
+	/** @brief Errors reflect most recently read byte. */
+	LAST_READ,
+	/** @brief Sticky flag, cleared on check, multiple bytes buffered. */
+	STICKY_MULTIPLE,
+	/** @brief Sticky flag, cleared on check, single byte buffered. */
+	STICKY_SINGLE,
+	/** @brief Errors captured in ISR, cleared on check. */
+	ISR_SAVED,
+};
+
 /** @brief Line control signals. */
 enum uart_line_ctrl {
 	UART_LINE_CTRL_BAUD_RATE = BIT(0), /**< Baud rate */


### PR DESCRIPTION
This PR adds property `framing-error-reporting` to UART drivers. This property allows a driver to expect how to actively handle a framing error if the next byte after a framing error needs to be read (for protocols like DMX512).

I am working on a DMX driver for Zephyr. DMX signals the start of a packet with a "Mark After Break" signal, which is interpreted as a framing error or break error on a UART. The next byte after the error is valid data that is a part of the packet. Normally, a line error would probably mean throwing away the data immediately before and after, but here I need to keep the data following the error. I have this working with Zephyr APIs on a bunch of platforms, but it is impossible for the driver to handle UART error handling type without knowing at compile time/runtime.

Assisted-by: Claude:claude-opus-4.7