### PR TITLE
cmake: sca: add include-what-you-use (IWYU) support

### DIFF
--- a/cmake/sca/iwyu/sca.cmake
+++ b/cmake/sca/iwyu/sca.cmake
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+include(extensions)
+
+# Find the include-what-you-use executable.
+find_program(IWYU_EXE NAMES include-what-you-use iwyu REQUIRED)
+message(STATUS "Found SCA: include-what-you-use (${IWYU_EXE})")
+
+# Get include-what-you-use user options. IWYU_OPTS is a semicolon separated
+# list of options passed to the include-what-you-use tool itself. Each option
+# is forwarded through the compiler driver using the '-Xiwyu' prefix as
+# required by the CMAKE_<LANG>_INCLUDE_WHAT_YOU_USE handling.
+zephyr_get(IWYU_OPTS)
+
+set(iwyu_command ${IWYU_EXE})
+if(DEFINED IWYU_OPTS)
+  foreach(iwyu_option IN LISTS IWYU_OPTS)
+    list(APPEND iwyu_command -Xiwyu ${iwyu_option})
+  endforeach()
+endif()
+
+# Enable include-what-you-use using the native CMake support. CMake invokes the
+# tool alongside the compiler for every translation unit and prints the
+# suggested include changes to stderr during the build.
+set(CMAKE_C_INCLUDE_WHAT_YOU_USE ${iwyu_command} CACHE INTERNAL "")
+set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${iwyu_command} CACHE INTERNAL "")

--- a/doc/develop/sca/iwyu.rst
+++ b/doc/develop/sca/iwyu.rst
@@ -1,0 +1,70 @@
+.. _iwyu:
+
+include-what-you-use (IWYU) support
+###################################
+
+`include-what-you-use <https://include-what-you-use.org/>`__ (IWYU) is a tool
+built on top of Clang and LLVM that analyzes ``#include`` directives in C and
+C++ source files. For every translation unit it reports headers that are
+included but not used, and symbols that are used but whose defining header is
+only included transitively. Acting on its suggestions keeps the set of includes
+minimal and explicit.
+
+Installing include-what-you-use
+*******************************
+
+``include-what-you-use`` is distributed by most Linux distributions, on ubuntu:
+
+.. code-block:: shell
+
+    sudo apt-get install iwyu
+
+Make sure the ``include-what-you-use`` binary is available in your :envvar:`PATH`.
+
+Run include-what-you-use
+************************
+
+.. note::
+
+   IWYU is built on Clang, so building with the LLVM toolchain produces the most
+   accurate results.
+
+To run include-what-you-use, :ref:`west build <west-building>` should be called
+with a ``-DZEPHYR_SCA_VARIANT=iwyu`` parameter, e.g.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: native_sim
+   :gen-args: -DZEPHYR_SCA_VARIANT=iwyu
+   :goals: build
+   :compact:
+
+The analysis runs alongside the compilation of each source file, and the
+suggested include changes are printed to the build output (stderr).
+
+Configuring include-what-you-use
+********************************
+
+include-what-you-use can be controlled using specific options. Refer to the
+`IWYU documentation <https://github.com/include-what-you-use/include-what-you-use/blob/master/README.md>`__
+for the full list of options.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``IWYU_OPTS``
+     - A semicolon separated list of include-what-you-use options. Each option
+       is forwarded to the tool with the required ``-Xiwyu`` prefix
+       automatically.
+
+These parameters can be passed on the command line, or be set as environment
+variables.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: native_sim
+   :gen-args: -DZEPHYR_SCA_VARIANT=iwyu -DIWYU_OPTS="--no_comments;--verbose=3"
+   :goals: build
+   :compact:


### PR DESCRIPTION
Add an SCA variant that enables include-what-you-use analysis via
CMake's built-in CMAKE_C_INCLUDE_WHAT_YOU_USE and
CMAKE_CXX_INCLUDE_WHAT_YOU_USE properties. The tool runs alongside the
compiler for each translation unit and reports unused includes and
includes that should be added.

The integration locates the include-what-you-use binary and forwards an
optional IWYU_OPTS list to the tool, prefixing each option with -Xiwyu as
required by the compiler-driven invocation.