### PR TITLE
drivers: serial: wch: reorder USART init / apply pinctrl first

### DIFF
--- a/drivers/serial/uart_wch_usart.c
+++ b/drivers/serial/uart_wch_usart.c
@@ -43,6 +43,11 @@ static int usart_wch_init(const struct device *dev)
 
 	clock_control_on(config->clock_dev, clock_sys);
 
+	err = pinctrl_apply_state(config->pin_cfg, PINCTRL_STATE_DEFAULT);
+	if (err != 0) {
+		return err;
+	}
+
 	err = clock_control_get_rate(config->clock_dev, clock_sys, &clock_rate);
 	if (err != 0) {
 		return err;
@@ -62,15 +67,11 @@ static int usart_wch_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	regs->BRR = divn;
-	regs->CTLR1 = ctlr1;
+	regs->CTLR1 = 0;
 	regs->CTLR2 = 0;
 	regs->CTLR3 = 0;
-
-	err = pinctrl_apply_state(config->pin_cfg, PINCTRL_STATE_DEFAULT);
-	if (err != 0) {
-		return err;
-	}
+	regs->BRR = divn;
+	regs->CTLR1 = ctlr1;
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	config->irq_config_func(dev);


### PR DESCRIPTION
The USART init sequence configured BRR and CTLR1 (enabling the UART) and only afterwards applied the pinctrl state. Reorder so that:

1. The clock is enabled.
2. The pinctrl state is applied before the peripheral is enabled.
3. CTLR1 is cleared first to ensure the UART is disabled while CTLR2/CTLR3 and the baud-rate divisor (BRR) are programmed, then CTLR1 is written last to enable the UART with the final configuration.

Programming the control and baud-rate registers while the UART is disabled and bringing up the pins before enabling avoids configuring the peripheral in an undefined intermediate state. This is the ordering required by the CH32H417 (QingKe V5F) and was regression-tested on `boards/muselab/nano_ch32v317` to confirm it does not affect existing single-core parts.