### PR TITLE
esp32: serial: Save UART framing errors before clearing, catch all errors

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -93,6 +93,12 @@
 
 LOG_MODULE_REGISTER(uart_esp32, CONFIG_UART_LOG_LEVEL);
 
+/** Mask of all error-class UART interrupts. */
+#define UART_ESP32_ERR_INTR_MASK                                               \
+	(UART_INTR_PARITY_ERR | UART_INTR_FRAM_ERR | UART_INTR_BRK_DET |     \
+	 UART_INTR_RXFIFO_OVF | UART_INTR_RS485_PARITY_ERR |                  \
+	 UART_INTR_RS485_FRM_ERR | UART_INTR_RS485_CLASH)
+
 struct uart_esp32_config {
 	const struct device *clock_dev;
 	const struct pinctrl_dev_config *pcfg;
@@ -136,6 +142,12 @@ struct uart_esp32_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t irq_cb;
 	void *irq_cb_data;
+#endif
+#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API || CONFIG_PM
+	/** Error flags saved by the ISR before it clears the hardware.
+	 *  Consumed and cleared by uart_err_check().
+	 */
+	uint32_t isr_error_flags;
 #endif
 #if CONFIG_UART_ASYNC_API
 	struct uart_esp32_async_data async;
@@ -235,10 +247,48 @@ static void uart_esp32_poll_out(const struct device *dev, unsigned char c)
 static int uart_esp32_err_check(const struct device *dev)
 {
 	struct uart_esp32_data *data = dev->data;
-	uint32_t mask = uart_hal_get_intsts_mask(&data->hal);
-	uint32_t err = mask & (UART_INTR_PARITY_ERR | UART_INTR_FRAM_ERR);
+	uint32_t mask;
+	int errors = 0;
 
-	return err;
+	/*
+	 * When the ISR is active, it saves error flags before clearing
+	 * hardware. Read the saved copy and also poll hardware for any
+	 * errors that arrived since the last ISR invocation. We always
+	 * need to poll the register since not all ISRs may be enabled.
+	 *
+	 * In pure polling mode (no ISR) read hardware directly.
+	 */
+#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API || CONFIG_PM
+	unsigned int key = irq_lock();
+
+	mask = data->isr_error_flags;
+	data->isr_error_flags = 0;
+	mask |= uart_hal_get_intsts_mask(&data->hal) & UART_ESP32_ERR_INTR_MASK;
+	uart_hal_clr_intsts_mask(&data->hal, mask & UART_ESP32_ERR_INTR_MASK);
+
+	irq_unlock(key);
+#else
+	mask = uart_hal_get_intsts_mask(&data->hal);
+	uart_hal_clr_intsts_mask(&data->hal, mask & UART_ESP32_ERR_INTR_MASK);
+#endif
+
+	if (mask & (UART_INTR_PARITY_ERR | UART_INTR_RS485_PARITY_ERR)) {
+		errors |= UART_ERROR_PARITY;
+	}
+	if (mask & (UART_INTR_FRAM_ERR | UART_INTR_RS485_FRM_ERR)) {
+		errors |= UART_ERROR_FRAMING;
+	}
+	if (mask & UART_INTR_BRK_DET) {
+		errors |= UART_BREAK;
+	}
+	if (mask & UART_INTR_RXFIFO_OVF) {
+		errors |= UART_ERROR_OVERRUN;
+	}
+	if (mask & UART_INTR_RS485_CLASH) {
+		errors |= UART_ERROR_COLLISION;
+	}
+
+	return errors;
 }
 
 #ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
@@ -539,22 +589,24 @@ static void uart_esp32_irq_err_enable(const struct device *dev)
 {
 	struct uart_esp32_data *data = dev->data;
 
-	/* enable framing, parity */
-	uart_hal_ena_intr_mask(&data->hal, UART_INTR_FRAM_ERR);
-	uart_hal_ena_intr_mask(&data->hal, UART_INTR_PARITY_ERR);
+	uart_hal_ena_intr_mask(&data->hal, UART_ESP32_ERR_INTR_MASK);
 }
 
 static void uart_esp32_irq_err_disable(const struct device *dev)
 {
 	struct uart_esp32_data *data = dev->data;
 
-	uart_hal_disable_intr_mask(&data->hal, UART_INTR_FRAM_ERR);
-	uart_hal_disable_intr_mask(&data->hal, UART_INTR_PARITY_ERR);
+	uart_hal_disable_intr_mask(&data->hal, UART_ESP32_ERR_INTR_MASK);
 }
 
 static int uart_esp32_irq_is_pending(const struct device *dev)
 {
-	return uart_esp32_irq_rx_ready(dev) || uart_esp32_irq_tx_ready(dev);
+	struct uart_esp32_data *data = dev->data;
+
+	/* Data ready or error-only interrupt (e.g. framing error with no data ready). */
+	return uart_esp32_irq_rx_ready(dev) ||
+	       uart_esp32_irq_tx_ready(dev) ||
+	       data->isr_error_flags;
 }
 
 static void uart_esp32_irq_update(const struct device *dev)
@@ -617,6 +669,12 @@ static void IRAM_ATTR uart_esp32_isr(void *arg)
 	if (uart_intr_status == 0) {
 		return;
 	}
+
+	/* Save error flags before clearing so that uart_err_check()
+	 * can report them from the user callback.
+	 */
+	data->isr_error_flags |= uart_intr_status & UART_ESP32_ERR_INTR_MASK;
+
 	uart_hal_clr_intsts_mask(&data->hal, uart_intr_status);
 
 #if CONFIG_PM


### PR DESCRIPTION
This PR fixes a bug where esp32 UART errors are cleared before they can be read. Additionally, all line errors (such as break and FIFO overflow) are now watched and reported.

I also put all of the errors into one common mask to reduce the chance of one being left out if any are added/removed in the future.

This bug meant that an application couldn't properly detect if a line error had occurred and could ingest corrupted data or miss some data.

Assisted-by: Claude:claude-opus-4.7