### PR TITLE
Bluetooth: host: Add API to get local controller info

### DIFF
--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -178,6 +178,40 @@ struct bt_le_per_adv_sync *bt_hci_per_adv_sync_lookup_handle(uint16_t handle);
  */
 const char *bt_hci_get_ver_str(uint8_t core_version);
 
+/** @brief Local Bluetooth controller version and manufacturer information.
+ *
+ * This information is read from the controller during Bluetooth initialization
+ * using the HCI Read Local Version Information command.
+ */
+struct bt_hci_local_info {
+	/** HCI version. See the BT_HCI_VERSION_* defines. */
+	uint8_t hci_version;
+
+	/** LMP or PAL version. See the BT_HCI_VERSION_* defines. */
+	uint8_t lmp_version;
+
+	/** HCI revision. */
+	uint16_t hci_revision;
+
+	/** LMP or PAL subversion. */
+	uint16_t lmp_subversion;
+
+	/** Manufacturer identifier. */
+	uint16_t manufacturer;
+};
+
+/** @brief Get local Bluetooth controller version and manufacturer information.
+ *
+ * This information is cached during Bluetooth initialization.
+ *
+ * @param info Local controller information to be populated.
+ *
+ * @retval 0 Success.
+ * @retval -EINVAL @p info is NULL.
+ * @retval -EAGAIN Bluetooth is not ready yet (e.g. bt_enable() has not completed).
+ */
+int bt_hci_get_local_info(struct bt_hci_local_info *info);
+
 /** @typedef bt_hci_vnd_evt_cb_t
   * @brief Callback type for vendor handling of HCI Vendor-Specific Events.
   *

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4066,6 +4066,25 @@ const char *bt_hci_get_ver_str(uint8_t core_version)
 	return "unknown";
 }
 
+int bt_hci_get_local_info(struct bt_hci_local_info *info)
+{
+	if (!info) {
+		return -EINVAL;
+	}
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
+	info->hci_version = bt_dev.hci_version;
+	info->lmp_version = bt_dev.lmp_version;
+	info->hci_revision = bt_dev.hci_revision;
+	info->lmp_subversion = bt_dev.lmp_subversion;
+	info->manufacturer = bt_dev.manufacturer;
+
+	return 0;
+}
+
 static void bt_dev_show_info(void)
 {
 	int i;


### PR DESCRIPTION
Expose local controller version and manufacturer information cached during Bluetooth initialization.

Fixes #41754