### PR TITLE
boards: muselab: nano_ch32v317: add general-purpose timer / PWM support

### DIFF
--- a/boards/muselab/nano_ch32v317/nano_ch32v317-pinctrl.dtsi
+++ b/boards/muselab/nano_ch32v317/nano_ch32v317-pinctrl.dtsi
@@ -27,4 +27,13 @@
 	mdio_default: mdio_default {
 		/* No MDIO pinmux required for internal PHY */
 	};
+
+	pwm2_default: pwm2_default {
+		group1 {
+			pinmux = <TIM2_CH1_PA0_0>;
+			output-high;
+			drive-push-pull;
+			slew-rate = "max-speed-10mhz";
+		};
+	};
 };

--- a/boards/muselab/nano_ch32v317/nano_ch32v317.yaml
+++ b/boards/muselab/nano_ch32v317/nano_ch32v317.yaml
@@ -13,4 +13,5 @@ supported:
   - netif:eth
   - uart
   - spi
+  - pwm
 vendor: muselab

--- a/boards/muselab/nano_ch32v317/nano_ch32v317_common.dtsi
+++ b/boards/muselab/nano_ch32v317/nano_ch32v317_common.dtsi
@@ -6,6 +6,7 @@
 #include <wch/ch32v317/ch32v317wc.dtsi>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "nano_ch32v317-pinctrl.dtsi"
 
 / {
@@ -28,8 +29,22 @@
 		};
 	};
 
+	pwmleds: pwmleds {
+		compatible = "pwm-leds";
+		status = "disabled";
+
+		/* PA0 is the board user LED (active-low) and also TIM2_CH1
+		 * (no remap). Driving it with PWM2 channel 0 gives a breathing
+		 * LED effect via fade_led without extra wiring.
+		 */
+		pwm_led_2: pwm_led_2 {
+			pwms = <&pwm2 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+		};
+	};
+
 	aliases {
 		led0 = &led_1;
+		pwm-led0 = &pwm_led_2;
 	};
 };
 

--- a/samples/basic/fade_led/boards/nano_ch32v317.overlay
+++ b/samples/basic/fade_led/boards/nano_ch32v317.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Liu Changjie
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Drive the on-board PA0 LED (active-low, tied to TIM2_CH1 with no remap)
+ * as a breathing LED using the fade_led sample.
+ */
+
+/ {
+	leds {
+		/* Disable the gpio-led so PA0 is owned by PWM, not GPIO. */
+		status = "disabled";
+	};
+};
+
+&pwmleds {
+	status = "okay";
+};
+
+&tim2 {
+	status = "okay";
+	/* Timer clock is 144 MHz (RCC HPRE_DIV1; WCH clock driver returns
+	 * AHB == APB1 == APB2). fade_led uses a 20 ms period = 50 Hz.
+	 * 144 MHz / 65536 / 50 Hz ~ 44, so pick prescaler 43 for a counter
+	 * clock of 3.27 MHz and a 20 ms period of ~65536 cycles.
+	 */
+	prescaler = <43>;
+};
+
+&pwm2 {
+	status = "okay";
+	pinctrl-0 = <&pwm2_default>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
This series adds general-purpose timer (PWM) support to the CH32V317 SoC
  and enables it on the `nano_ch32v317` board, driving the on-board user LED
  as a PWM output.

  ### Commits

  1. **dt-bindings: pinctrl** — Add `TIM1`-`TIM4` channel / complementary /
     break / ETR pinmux macros for the CH32V20x/V30x family, covering all
     AFIO remap combinations from the reference manual. `TIM5/8/9/10` use
     PCFR2 remap bits and are left as a follow-up (TODO noted).
  2. **dts: ch32v317** — Add `TIM1`-`TIM5` and `TIM8`-`TIM10` nodes (with
     `gptm-pwm` children) to the SoC devicetree. Basic timers `TIM6/TIM7`
     are omitted (no PWM outputs). All nodes are disabled by default.
  3. **boards: nano_ch32v317** — Wire the user LED (PA0, active-low) to
     `TIM2_CH1`, add a `pwm-leds` node (disabled by default so the default
     build keeps PA0 as a GPIO LED), a `fade_led` sample overlay, and mark
     the board as supporting `pwm`.

  ## Testing

  Built and flashed the `fade_led` sample to a real `nano_ch32v317` board:

  west build -p always -b nano_ch32v317 samples/basic/fade_led
  west flash

  Confirmed the PWM waveform on **PA0** with an oscilloscope (~50 Hz period,
  duty cycle sweeping 0–100% — breathing LED). Scope capture attached below.
<img width="688" height="386" alt="Adobe Express - video_2026-06-21_20-22-40" src="https://github.com/user-attachments/assets/85f4b566-c183-4f50-b576-b32479ce31a8" />

  The default `nano_ch32v317` build (no overlay) is unchanged — PA0 remains a
  GPIO LED — verified `hello_world` still builds and the `pwm-leds` node stays
  disabled.