### PR TITLE
tests/samples: optimize filters

### DIFF
--- a/samples/sensor/clock/sample.yaml
+++ b/samples/sensor/clock/sample.yaml
@@ -40,6 +40,8 @@ tests:
       - "boards/nrf528xx_rtc.overlay"
 
   sample.sensor.clock.system:
+    platform_type:
+      - mcu
     filter: CONFIG_SENSOR_CLOCK_SYSTEM
     tags:
       - drivers

--- a/tests/drivers/clock_control/pwm_clock/testcase.yaml
+++ b/tests/drivers/clock_control/pwm_clock/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   drivers.clock.pwm_clock:
+    platform_type:
+      - mcu
     filter: dt_compat_enabled("pwm-clock") and dt_compat_enabled("test-clock-control-pwm-clock")
     tags:
       - drivers

--- a/tests/drivers/display/display_read_write/testcase.yaml
+++ b/tests/drivers/display/display_read_write/testcase.yaml
@@ -147,6 +147,10 @@ tests:
   drivers.display.read_write.renesas_ra_glcdc:
     tags:
       - shield
+    vendor_allow:
+      - renesas
+    platform_type:
+      - mcu
     filter: dt_compat_enabled("renesas,ra-glcdc")
     extra_args:
       - platform:ek_ra8d1/r7fa8d1bhecbd:SHIELD=rtkmipilcdb00000be

--- a/tests/drivers/interrupt_controller/intc_exti_stm32/testcase.yaml
+++ b/tests/drivers/interrupt_controller/intc_exti_stm32/testcase.yaml
@@ -10,6 +10,10 @@ common:
 
 tests:
   drivers.interrupt_controller.intc_exti_stm32:
+    platform_type:
+      - mcu
+    vendor_allow:
+      - st
     extra_args:
       - DTC_OVERLAY_FILE="boards/exti_default_resources.overlay"
       - platform:nucleo_c071rb/stm32c071xx:EXTRA_DTC_OVERLAY_FILE="boards/nucleo_c071rb_stm32c071xx.overlay"

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -1,11 +1,11 @@
+common:
+  platform_type:
+    - mcu
+  tags:
+    - timer
 tests:
   kernel.timer.timer:
-    tags:
-      - kernel
-      - timer
     min_ram: 16
-    platform_type:
-      - mcu
     simulation_exclude:
       - renode
     harness_config:
@@ -18,12 +18,7 @@ tests:
     arch_exclude:
       - arc
   kernel.timer.timer_arc:
-    tags:
-      - kernel
-      - timer
     min_ram: 16
-    platform_type:
-      - mcu
     harness_config:
       record:
         regex:
@@ -34,9 +29,6 @@ tests:
     extra_configs:
       - CONFIG_SYS_CLOCK_TICKS_PER_SEC=10000
   kernel.timer.timer_behavior_external:
-    tags:
-      - kernel
-      - timer
     filter: dt_compat_enabled("test-kernel-timer-behavior-external")
     harness: pytest
     harness_config:

--- a/tests/lib/c_lib/strerror/testcase.yaml
+++ b/tests/lib/c_lib/strerror/testcase.yaml
@@ -29,6 +29,9 @@ tests:
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
   libraries.libc.strerror.newlib_nano:
+    toolchain_exclude:
+      - zephyr/gnu
+      - zephyr/llvm
     filter: CONFIG_NEWLIB_LIBC_SUPPORTED and CONFIG_HAS_NEWLIB_LIBC_NANO
     tags: newlib
     ignore_faults: true

--- a/tests/misc/print_format/testcase.yaml
+++ b/tests/misc/print_format/testcase.yaml
@@ -35,6 +35,9 @@ tests:
   printk.format:
     tags: clib
   printk.format_newlib:
+    toolchain_exclude:
+      - zephyr/gnu
+      - zephyr/llvm
     tags:
       - clib
       - newlib

--- a/tests/subsys/fs/fat_fs_api/testcase.yaml
+++ b/tests/subsys/fs/fat_fs_api/testcase.yaml
@@ -15,9 +15,13 @@ tests:
   filesystem.fat.api.mmc:
     extra_args: CONF_FILE="prj_mmc.conf"
     filter: dt_compat_enabled("zephyr,mmc-disk")
+    platform_type:
+      - mcu
   filesystem.fat.api.sdmmc:
     extra_args: CONF_FILE="prj_sdmmc.conf"
     filter: dt_compat_enabled("zephyr,sdmmc-disk")
+    platform_type:
+      - mcu
   filesystem.fat.ram.api:
     platform_allow:
       - native_sim


### PR DESCRIPTION
- **tests: timer: set platform_type to mcu**
- **tests: strerror: exclude zephyr/* toolchain**
- **tests: printk: exclude zephyr/* toolchain**
- **tests/samples: misc: limit filtering to hardware**
