### PR TITLE
soc: wch: fix the startup code after changing the flash address

### DIFF
--- a/soc/wch/ch32v/qingke_v2a/vector.S
+++ b/soc/wch/ch32v/qingke_v2a/vector.S
@@ -18,12 +18,14 @@ GTEXT(__initialize)
 
 SECTION_FUNC(vectors, ivt)
 	.option norvc
-	j       __start
+	lui     a0, %hi(__start)
+	jr      %lo(__start)(a0)
 	.rept   CONFIG_VECTOR_TABLE_SIZE
 	.word	_isr_wrapper
 	.endr
 
 SECTION_FUNC(vectors, __start)
-	li 	a0, 3
+	la      a0, ivt
+	ori     a0, a0, 3
 	csrw	mtvec, a0
-	j	__initialize
+	tail	__initialize

--- a/soc/wch/ch32v/qingke_v2c/vector.S
+++ b/soc/wch/ch32v/qingke_v2c/vector.S
@@ -18,12 +18,14 @@ GTEXT(__initialize)
 
 SECTION_FUNC(vectors, ivt)
 	.option norvc
-	j       __start
+	lui     a0, %hi(__start)
+	jr      %lo(__start)(a0)
 	.rept   CONFIG_VECTOR_TABLE_SIZE
 	.word	_isr_wrapper
 	.endr
 
 SECTION_FUNC(vectors, __start)
-	li 	a0, 3
+	la      a0, ivt
+	ori     a0, a0, 3
 	csrw	mtvec, a0
-	j	__initialize
+	tail	__initialize


### PR DESCRIPTION
The flash on the ch32v series starts at 0x8000000 and, depending on the system configuration, is aliased to 0x0. PR #110383 fixed flashing with minichlink by changing the flash Devicetree entry to point at the flash base, not the alias, but this broke the boot.

Fix by updating the ch32v003 and ch32v00x vector.S to jump into flash. This matches the behaviour of the other ch32v series startup code.