### PR TITLE
tests: kernel/mem_protect: shorten syscall stress wait on QEMU

### DIFF
--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -20,6 +20,11 @@
 #define SLEEP_MS_LONG	300
 #elif defined(CONFIG_WHISPER_TARGET)
 #define SLEEP_MS_LONG	300
+#elif defined(CONFIG_QEMU_TARGET)
+/* Emulators are much slower than real hardware, especially in the kyield
+ * scenario where every syscall forces a userspace context switch.
+ */
+#define SLEEP_MS_LONG	300
 #else
 #define SLEEP_MS_LONG	15000
 #endif


### PR DESCRIPTION
The syscall switch stress test sleeps SLEEP_MS_LONG (15s by default)
while user threads hammer syscalls. In the kyield scenario
(TIMESLICE_SIZE=0) every syscall forces a userspace context switch,
each of which reprograms the MMU/MPU and is expensive to emulate.
Under QEMU this makes kernel.memory_protection.syscalls.kyield take a
very long time to run.

QEMU is a simulator, much slower than the real hardware the 15s value
targets, just like the Whisper and Intel ADSP simulators that already
use a shortened delay. Use the same 300ms wait for QEMU targets. A
second of continuous syscall hammering is still ample to smoke out
concurrency issues.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
