### PR TITLE
board: kit_pse84_eval: disable twister on this platform

### DIFF
--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.yaml
@@ -9,6 +9,7 @@ type: mcu
 arch: arm
 sysbuild: true
 ram: 5120
+twister: false
 toolchain:
   - zephyr
 supported:

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -467,9 +467,14 @@ class TestPlan:
         arch_roots = self.env.arch_roots
 
         for platform in generate_platforms(board_roots, soc_roots, arch_roots):
+            self.platforms.append(platform)
+
+            # Platforms with `twister: false` are kept in the platform list so
+            # that references to them in test definitions still resolve (and
+            # twister does not abort on unidentified platforms), but they are
+            # never assigned tests nor used as default platforms.
             if not platform.twister:
                 continue
-            self.platforms.append(platform)
 
             if not self.test_config.override_default_platforms:
                 if platform.default:
@@ -958,6 +963,10 @@ class TestPlan:
                     if this_snippet not in found_snippets:
                         missing_required_snippet = this_snippet
                         break
+
+            # Platforms with `twister: false` are listed only so test
+            # references to them resolve; they are never assigned tests.
+            platform_scope = [plat for plat in platform_scope if plat.twister]
 
             # list of instances per testsuite, aka configurations.
             instance_list = []

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -1255,9 +1255,15 @@ def test_testplan_info(capfd):
     assert 'dummy text\n' in out
 
 
+# Platforms with twister=False (here 'p1e1') are still listed in platforms so
+# references to them resolve, but they are never added as default platforms.
 TESTDATA_8 = [
-    (False, ['p1e2/unit_testing', 'p2/unit_testing', 'p3/unit_testing'], ['p2/unit_testing', 'p3/unit_testing']),
-    (True, ['p1e2/unit_testing', 'p2/unit_testing', 'p3/unit_testing'], ['p3/unit_testing']),
+    (False,
+     ['p1e1/unit_testing', 'p1e2/unit_testing', 'p2/unit_testing', 'p3/unit_testing'],
+     ['p2/unit_testing', 'p3/unit_testing']),
+    (True,
+     ['p1e1/unit_testing', 'p1e2/unit_testing', 'p2/unit_testing', 'p3/unit_testing'],
+     ['p3/unit_testing']),
 ]
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- **twister: keep ignored platforms in the platform list**
- **board: kit_pse84_eval: disable twister on this platform**

Add a patch to twister to keep ignored platforms in the platform list. This
allows to disable twister on a specific platform by adding it to the ignored
platforms list.
