### PR TITLE
drivers: sdhc: imx_usdhc: revert Zephyr-side cache maintenance

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -7,7 +7,6 @@
 #define DT_DRV_COMPAT nxp_imx_usdhc
 
 #include <zephyr/kernel.h>
-#include <zephyr/cache.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/sdhc.h>
 #include <zephyr/sd/sd_spec.h>
@@ -476,72 +475,6 @@ static int imx_usdhc_set_io(const struct device *dev, struct sdhc_io *ios)
 	return 0;
 }
 
-#ifdef CONFIG_IMX_USDHC_DMA_SUPPORT
-/*
- * Cache maintenance for the data buffer on the ADMA2 DMA path. The buffer
- * (rxData/txData) is supplied by upper layers (FAT FS, SD subsys) and lives
- * in regular cacheable RAM. Without these calls, on a write the controller
- * may DMA-read stale RAM (CPU's writes still in D-cache), and on a read the
- * CPU may consume stale cache lines after the controller has DMA-written
- * fresh data to RAM.
- *
- * Pattern: flush before transfer (covers TX correctness and prevents dirty
- * cache eviction over DMA-written data on RX), invalidate after transfer
- * on RX (so the CPU sees the freshly DMA-written data).
- */
-#ifdef CONFIG_SDHC_SCATTER_GATHER_TRANSFER
-static void imx_usdhc_dcache_pre_xfer(usdhc_scatter_gather_data_t *data)
-{
-	usdhc_scatter_gather_data_list_t *sg;
-
-	if (data == NULL) {
-		return;
-	}
-	for (sg = &data->sgData; sg != NULL && sg->dataAddr != NULL; sg = sg->dataList) {
-		sys_cache_data_flush_range(sg->dataAddr, sg->dataSize);
-	}
-}
-
-static void imx_usdhc_dcache_post_xfer(usdhc_scatter_gather_data_t *data)
-{
-	usdhc_scatter_gather_data_list_t *sg;
-
-	if (data == NULL || data->dataDirection != kUSDHC_TransferDirectionReceive) {
-		return;
-	}
-	for (sg = &data->sgData; sg != NULL && sg->dataAddr != NULL; sg = sg->dataList) {
-		sys_cache_data_invd_range(sg->dataAddr, sg->dataSize);
-	}
-}
-#else
-static void imx_usdhc_dcache_pre_xfer(usdhc_data_t *data)
-{
-	void *buf;
-	size_t len;
-
-	if (data == NULL) {
-		return;
-	}
-	buf = data->rxData ? (void *)data->rxData : (void *)data->txData;
-	if (buf != NULL) {
-		len = (size_t)data->blockSize * data->blockCount;
-		sys_cache_data_flush_range(buf, len);
-	}
-}
-
-static void imx_usdhc_dcache_post_xfer(usdhc_data_t *data)
-{
-	size_t len;
-
-	if (data == NULL || data->rxData == NULL) {
-		return;
-	}
-	len = (size_t)data->blockSize * data->blockCount;
-	sys_cache_data_invd_range((void *)data->rxData, len);
-}
-#endif /* CONFIG_SDHC_SCATTER_GATHER_TRANSFER */
-#endif /* CONFIG_IMX_USDHC_DMA_SUPPORT */
-
 /*
  * Internal transfer function, used by tuning and request apis
  */
@@ -560,8 +493,6 @@ static int imx_usdhc_transfer(const struct device *dev, struct usdhc_host_transf
 	dma_config.burstLen = kUSDHC_EnBurstLenForINCR;
 #endif
 	dma_config.dmaMode = kUSDHC_DmaModeAdma2;
-
-	imx_usdhc_dcache_pre_xfer(request->transfer->data);
 #endif /* CONFIG_IMX_USDHC_DMA_SUPPORT */
 
 	/* Reset transfer status */
@@ -604,9 +535,6 @@ static int imx_usdhc_transfer(const struct device *dev, struct usdhc_host_transf
 		if (dev_data->transfer_status & TRANSFER_DATA_FAILED) {
 			return -EIO;
 		}
-#ifdef CONFIG_IMX_USDHC_DMA_SUPPORT
-		imx_usdhc_dcache_post_xfer(request->transfer->data);
-#endif
 	}
 	return 0;
 }

--- a/modules/hal_nxp/mcux/CMakeLists.txt
+++ b/modules/hal_nxp/mcux/CMakeLists.txt
@@ -137,9 +137,9 @@ zephyr_library_compile_definitions_ifdef(CONFIG_NOCACHE_MEMORY
   __STARTUP_INITIALIZE_NONCACHEDATA
   )
 
-zephyr_library_compile_definitions_ifdef(CONFIG_HAS_MCUX_CACHE
-  FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL
-  )
+if(CONFIG_HAS_MCUX_CACHE OR CONFIG_HAS_MCUX_XCACHE)
+  zephyr_library_compile_definitions(FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL)
+endif()
 
 # CMSIS SystemInit() disables the hardware watchdog by default
 # (DISABLE_WDOG defaults to 1). Leave it running so the Zephyr watchdog


### PR DESCRIPTION
NXP's USDHC driver already does its own cache maintenance, as Zephyr defines `FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL` on cores with a cache:
https://github.com/zephyrproject-rtos/zephyr/blob/2d8b1b11332a87a878c89ece8895163c0b510582/modules/hal_nxp/mcux/CMakeLists.txt#L140-L142

Not only is the Zephyr-side logic redundant, it clobbers the response data in cases when the SDK can't use DMA (specifically, [when the RX buffer isn't 4-byte aligned][not-aligned]): in those cases, the SDK code writes to the buffer, those writes go to cache, then Zephyr invalidates the cache discarding the written data.

This partially reverts #108716, leaving only the new default value for `CONFIG_SDHC_BUFFER_ALIGNMENT`.

[not-aligned]: https://github.com/zephyrproject-rtos/hal_nxp/blob/cddb38858338247c3b9216a643b0a3a0e0722ad9/mcux/mcux-sdk-ng/drivers/usdhc/fsl_usdhc.c#L1343-L1346

As for issue #107862, which #108716 was written to fix, I suspect but cannot be sure that it was another symptom of nxp-mcuxpresso/mcuxsdk-core#20, which I fixed with nxp-mcuxpresso/mcuxsdk-core#25. Unfortunately, that fix didn't make it into Zephyr until June 11th (zephyrproject-rtos/hal_nxp#740), two days after #108716 landed.

@hakehuang, can you re-test the #107862 setup on this PR to make sure the SD card sample still works? If it doesn't, there must be some other bug in the SDK's cache maintenance that needs fixing.