### PR TITLE
DTS: Extend binding validation to support phandles

### DIFF
--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -248,6 +248,11 @@ Property entries in ``properties:`` are written in this syntax:
      min-len: <int>
      max-len: <int>
      specifier-space: <space-name>
+     target-compatibles:
+       - <compatible1>
+       - <compatible2>
+       ...
+     target-on-bus: <bus-name>
      dependency-mode: <normal | reverse | ignore | child-ignore>
 
 .. _dt-bindings-example-properties:
@@ -586,6 +591,87 @@ can write this property as follows:
      mboxes:
        type: phandle-array
        specifier-space: mbox
+
+.. _dt-bindings-target-compatibles:
+
+target-compatibles
+==================
+
+The ``target-compatibles`` setting constrains the node(s) that a ``phandle`` or
+``phandles`` property is allowed to reference. It takes a non-empty list of
+compatible strings. The build system emits an error if a referenced node does
+not have at least one of the listed strings in its ``compatible`` property.
+
+For example, a binding whose ``peer`` property must point to a companion node
+can be written as follows:
+
+.. code-block:: YAML
+
+   compatible: "vendor,controller"
+
+   properties:
+     peer:
+       type: phandle
+       target-compatibles:
+         - "vendor,companion-a"
+         - "vendor,companion-b"
+       description: |
+         Phandle linking the controller node to its companion node.
+
+.. code-block:: DTS
+
+   &controller {
+           peer = <&companion>;
+   };
+
+   companion: companion {
+           compatible = "vendor,companion-b";
+           /* ... */
+   };
+
+Pointing ``peer`` at a node with an unrelated compatible triggers a build error.
+
+.. _dt-bindings-target-on-bus:
+
+target-on-bus
+=============
+
+The ``target-on-bus`` setting is used with ``phandle`` and ``phandles`` properties
+to require that the referenced node appears on a specific :ref:`bus <dt-bindings-bus>`.
+It takes a single bus name, matching the values used with :ref:`on-bus <dt-bindings-on-bus>`.
+
+For example:
+
+.. code-block:: YAML
+
+   compatible: "vendor,controller"
+
+   properties:
+     sensor:
+       type: phandle
+       target-on-bus: i2c
+       description: |
+         Phandle to a node that must be a child of an I2C controller.
+
+``target-on-bus`` can also be used together with :ref:`target-compatibles
+<dt-bindings-target-compatibles>` to additionally disambiguate different
+bindings depending on the bus the node is on (see :ref:`on-bus
+<dt-bindings-on-bus>`).
+
+For example:
+
+.. code-block:: YAML
+
+   compatible: "vendor,controller"
+
+   properties:
+     sensor:
+       type: phandle
+       target-compatibles:
+         - "vendor,sensor"
+       target-on-bus: i2c
+       description: |
+         Phandle to a vendor,sensor node that must be attached to an I2C bus.
 
 .. _dt-bindings-dependency-mode:
 

--- a/dts/bindings/arm/arm,ethos-u.yaml
+++ b/dts/bindings/arm/arm,ethos-u.yaml
@@ -33,6 +33,8 @@ properties:
 
   fast-memory-region:
     type: phandle
+    target-compatibles:
+      - "zephyr,memory-region"
     description: |
       Phandle to a node compatible with "zephyr,memory-region" that represents
       a dedicated fast SRAM region used by the Ethos-U driver as scratch

--- a/dts/bindings/mfd/infineon,autanalog.yaml
+++ b/dts/bindings/mfd/infineon,autanalog.yaml
@@ -54,6 +54,8 @@ properties:
 
   ac-states:
     type: phandles
+    target-compatibles:
+      - "infineon,autanalog-ac-state"
     description: |
       Ordered list of AC state node phandles for advanced mode.  When present,
       the driver uses these nodes to build the full State Transition Table.

--- a/dts/bindings/net/wireless/nordic,nrf-radio.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf-radio.yaml
@@ -119,6 +119,9 @@ properties:
 
   fem:
     type: phandle
+    target-compatibles:
+      - "radio-fem-two-ctrl-pins"
+      - "nordic,nrf21540-fem"
     description: |
       Phandle linking the RADIO node to its external front-end module.
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -494,8 +494,9 @@ class Binding:
             return
 
         ok_prop_keys = {"description", "type", "required",
-                        "enum", "const", "default", "deprecated",
-                        "specifier-space", "min", "max", "min-len", "max-len"}
+                "enum", "const", "default", "deprecated",
+                "specifier-space", "target-compatibles",
+                "min", "max", "min-len", "max-len"}
 
         for prop_name, options in raw["properties"].items():
             for key in options:
@@ -585,6 +586,10 @@ class PropertySpec:
 
     specifier_space:
       The specifier space for the property as given in the binding, or None.
+
+    target_compatibles:
+      A list of compatible strings that referenced node(s) must match, or
+        None. This is only valid for 'phandle' and 'phandles' type properties.
 
     min:
       The minimum value the property may take as given in the binding, or None.
@@ -688,6 +693,11 @@ class PropertySpec:
     def specifier_space(self) -> Optional[str]:
         "See the class docstring"
         return self._raw.get("specifier-space")
+
+    @property
+    def target_compatibles(self) -> Optional[list[str]]:
+        "See the class docstring"
+        return self._raw.get("target-compatibles")
 
     @property
     def min(self) -> Optional[int]:
@@ -1873,6 +1883,22 @@ class Node:
         required = prop_spec.required
         default = prop_spec.default
         specifier_space = prop_spec.specifier_space
+        target_compatibles = prop_spec.target_compatibles
+
+        def validate_target_compatibles(target: Node, index: Optional[int] = None) -> None:
+            if not target_compatibles:
+                return
+
+            if any(compat in target.compats for compat in target_compatibles):
+                return
+
+            idx = f"[{index}]" if index is not None else ""
+            _err(
+                f"property '{name}{idx}' on {node.path} in {self.edt.dts_path} "
+                f"points to {target.path}, but this node has compatibles {target.compats!r}; "
+                f"expected one of {target_compatibles!r} from "
+                f"'target-compatibles' in {binding_path}"
+            )
 
         if prop and deprecated:
             msg = (
@@ -1925,10 +1951,15 @@ class Node:
             return prop.to_strings()
 
         if prop_type == "phandle":
-            return self.edt._node2enode[prop.to_node()]
+            target = self.edt._node2enode[prop.to_node()]
+            validate_target_compatibles(target)
+            return target
 
         if prop_type == "phandles":
-            return [self.edt._node2enode[node] for node in prop.to_nodes()]
+            targets = [self.edt._node2enode[node] for node in prop.to_nodes()]
+            for i, target in enumerate(targets):
+                validate_target_compatibles(target, i)
+            return targets
 
         if prop_type == "phandle-array":
             # This type is a bit high-level for dtlib as it involves
@@ -3067,7 +3098,8 @@ def _check_prop_by_type(prop_name: str,
                         options: dict,
                         binding_path: Optional[str]) -> None:
     # Binding._check_properties() helper. Checks 'type:', 'default:',
-    # 'const:', 'specifier-space:', 'min:' and 'max:' for the property
+    # 'const:', 'specifier-space:', 'target-compatibles:', 'min:' and 'max:'
+    # for the property
     # named 'prop_name'
 
     prop_type = options.get("type")
@@ -3077,6 +3109,7 @@ def _check_prop_by_type(prop_name: str,
     max_val = options.get("max")
     min_len = options.get("min-len")
     max_len = options.get("max-len")
+    target_compatibles = options.get("target-compatibles")
 
     if prop_type is None:
         _err(f"missing 'type:' for '{prop_name}' in 'properties' in "
@@ -3101,6 +3134,23 @@ def _check_prop_by_type(prop_name: str,
         _err(f"'{prop_name}' in 'properties:' in '{binding_path}' "
              f"has type 'phandle-array' and its name does not end in 's', "
              f"but no 'specifier-space' was provided.")
+
+    if target_compatibles is not None:
+        if prop_type not in {"phandle", "phandles"}:
+            _err(f"'target-compatibles' in 'properties: {prop_name}' "
+                 f"has type '{prop_type}', expected 'phandle' or 'phandles'")
+
+        if not isinstance(target_compatibles, list):
+            _err(f"'target-compatibles' for '{prop_name}' in '{binding_path}' "
+                 "is not a list")
+
+        if not target_compatibles:
+            _err(f"'target-compatibles' for '{prop_name}' in '{binding_path}' "
+                 "must not be empty")
+
+        if not all(isinstance(compat, str) for compat in target_compatibles):
+            _err(f"'target-compatibles' for '{prop_name}' in '{binding_path}' "
+                 "must be a list of strings")
 
     # If you change const_types, be sure to update the type annotation
     # for PropertySpec.const.

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -531,7 +531,8 @@ class Binding:
         ok_prop_keys = {"description", "type", "required",
                         "enum", "const", "default", "deprecated",
                         "specifier-space", "min", "max", "min-len", "max-len",
-                        "dependency-mode"}
+                        "dependency-mode", "target-compatibles",
+                        "target-on-bus"}
 
         for prop_name, options in raw["properties"].items():
             for key in options:
@@ -622,6 +623,14 @@ class PropertySpec:
 
     specifier_space:
       The specifier space for the property as given in the binding, or None.
+
+    target_compatibles:
+      A list of compatible strings that referenced node(s) must match, or
+      None. This is only valid for 'phandle' and 'phandles' type properties.
+
+    target_on_bus:
+      A bus name (e.g. "i2c") that the referenced node(s) must appear on, or
+      None. This is only valid for 'phandle' and 'phandles' type properties.
 
     min:
       The minimum value the property may take as given in the binding, or None.
@@ -734,6 +743,16 @@ class PropertySpec:
     def specifier_space(self) -> Optional[str]:
         "See the class docstring"
         return self._raw.get("specifier-space")
+
+    @property
+    def target_compatibles(self) -> Optional[list[str]]:
+        "See the class docstring"
+        return self._raw.get("target-compatibles")
+
+    @property
+    def target_on_bus(self) -> Optional[str]:
+        "See the class docstring"
+        return self._raw.get("target-on-bus")
 
     @property
     def min(self) -> Optional[int]:
@@ -1942,6 +1961,28 @@ class Node:
         required = prop_spec.required
         default = prop_spec.default
         specifier_space = prop_spec.specifier_space
+        target_compatibles = prop_spec.target_compatibles
+        target_on_bus = prop_spec.target_on_bus
+
+        def validate_target(target: Node, index: Optional[int] = None) -> None:
+            idx = f"[{index}]" if index is not None else ""
+
+            if target_compatibles and not any(
+                    compat in target.compats for compat in target_compatibles):
+                _err(
+                    f"property '{name}{idx}' on {node.path} in {self.edt.dts_path} "
+                    f"points to {target.path}, but this node has compatibles "
+                    f"{target.compats!r}; expected one of {target_compatibles!r} "
+                    f"from 'target-compatibles' in {binding_path}"
+                )
+
+            if target_on_bus is not None and target_on_bus not in target.on_buses:
+                _err(
+                    f"property '{name}{idx}' on {node.path} in {self.edt.dts_path} "
+                    f"points to {target.path}, which is on bus(es) "
+                    f"{target.on_buses!r}; expected bus '{target_on_bus}' from "
+                    f"'target-on-bus' in {binding_path}"
+                )
 
         if prop and deprecated:
             msg = (
@@ -1995,10 +2036,15 @@ class Node:
             return prop.to_strings()
 
         if prop_type == "phandle":
-            return self.edt._node2enode[prop.to_node()]
+            target = self.edt._node2enode[prop.to_node()]
+            validate_target(target)
+            return target
 
         if prop_type == "phandles":
-            return [self.edt._node2enode[node] for node in prop.to_nodes()]
+            targets = [self.edt._node2enode[node] for node in prop.to_nodes()]
+            for i, target in enumerate(targets):
+                validate_target(target, i)
+            return targets
 
         if prop_type == "phandle-array":
             # This type is a bit high-level for dtlib as it involves
@@ -3225,7 +3271,8 @@ def _check_prop_by_type(prop_name: str,
                         binding_path: Optional[str],
                         local_options: dict) -> None:
     # Binding._check_properties() helper. Checks 'type:', 'default:',
-    # 'const:', 'specifier-space:', 'min:' and 'max:' for the property
+    # 'const:', 'specifier-space:', 'target-compatibles:', 'target-on-bus:',
+    # 'min:' and 'max:' for the property
     # named 'prop_name'
 
     prop_type = options.get("type")
@@ -3235,6 +3282,8 @@ def _check_prop_by_type(prop_name: str,
     max_val = options.get("max")
     min_len = options.get("min-len")
     max_len = options.get("max-len")
+    target_compatibles = options.get("target-compatibles")
+    target_on_bus = options.get("target-on-bus")
 
     if prop_type is None:
         _err(f"missing 'type:' for '{prop_name}' in 'properties' in "
@@ -3259,6 +3308,32 @@ def _check_prop_by_type(prop_name: str,
         _err(f"'{prop_name}' in 'properties:' in '{binding_path}' "
              f"has type 'phandle-array' and its name does not end in 's', "
              f"but no 'specifier-space' was provided.")
+
+    if target_compatibles is not None:
+        if prop_type not in {"phandle", "phandles"}:
+            _err(f"'target-compatibles' in 'properties: {prop_name}' "
+                 f"has type '{prop_type}', expected 'phandle' or 'phandles'")
+
+        if not isinstance(target_compatibles, list):
+            _err(f"'target-compatibles' for '{prop_name}' in '{binding_path}' "
+                 "is not a list")
+
+        if not target_compatibles:
+            _err(f"'target-compatibles' for '{prop_name}' in '{binding_path}' "
+                 "must not be empty")
+
+        if not all(isinstance(compat, str) for compat in target_compatibles):
+            _err(f"'target-compatibles' for '{prop_name}' in '{binding_path}' "
+                 "must be a list of strings")
+
+    if target_on_bus is not None:
+        if prop_type not in {"phandle", "phandles"}:
+            _err(f"'target-on-bus' in 'properties: {prop_name}' "
+                 f"has type '{prop_type}', expected 'phandle' or 'phandles'")
+
+        if not isinstance(target_on_bus, str):
+            _err(f"'target-on-bus' for '{prop_name}' in '{binding_path}' "
+                 "is not a string")
 
     # If you change const_types, be sure to update the type annotation
     # for PropertySpec.const.

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -1070,6 +1070,164 @@ def test_prop_range_len_errs(tmp_path):
         f"{str(dts_file)} has length 1, which is less than the "
         f"'min-len' value in {binding_path} (2)")
 
+def test_target_compatibles(tmp_path):
+    '''Test target-compatibles validation for phandle and phandles.'''
+
+    binding_file = tmp_path / "target-compat.yaml"
+    with open(binding_file, "w", encoding="utf-8") as f:
+        f.write(
+            """\
+description: target compatible test
+compatible: "target-user"
+
+properties:
+  single:
+    type: phandle
+    target-compatibles:
+      - "target-ok"
+
+  multiple:
+    type: phandles
+    target-compatibles:
+      - "target-ok"
+"""
+        )
+
+    dts_ok = tmp_path / "target-compat-ok.dts"
+    with open(dts_ok, "w", encoding="utf-8") as f:
+        f.write(
+            """\
+/dts-v1/;
+
+/ {
+    target_ok: target-ok {
+        compatible = "target-ok";
+    };
+
+    user {
+        compatible = "target-user";
+        single = <&target_ok>;
+        multiple = <&target_ok &target_ok>;
+    };
+};
+"""
+        )
+
+    edt = edtlib.EDT(str(dts_ok), [str(tmp_path)])
+    user = edt.get_node("/user")
+    assert user.props["single"].val.path == "/target-ok"
+    assert [node.path for node in user.props["multiple"].val] == ["/target-ok", "/target-ok"]
+
+    dts_bad = tmp_path / "target-compat-bad.dts"
+    with open(dts_bad, "w", encoding="utf-8") as f:
+        f.write(
+            """\
+/dts-v1/;
+
+/ {
+    target_bad: target-bad {
+        compatible = "target-bad";
+    };
+
+    user {
+        compatible = "target-user";
+        single = <&target_bad>;
+    };
+};
+"""
+        )
+
+    with pytest.raises(edtlib.EDTError) as e:
+        edtlib.EDT(str(dts_bad), [str(tmp_path)])
+
+    assert str(e.value) == (
+        f"property 'single' on /user in {str(dts_bad)} points to /target-bad, "
+        "but this node has compatibles ['target-bad']; expected one of ['target-ok'] "
+        f"from 'target-compatibles' in {str(binding_file)}"
+    )
+
+
+def test_target_compatibles_binding_errs(tmp_path):
+    '''Test target-compatibles binding schema errors.'''
+
+    binding_file = tmp_path / "wrong-target-compat.yaml"
+
+    with open(binding_file, "w", encoding="utf-8") as f:
+        f.write(
+            """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    target-compatibles:
+      - "target-ok"
+"""
+        )
+
+    with pytest.raises(edtlib.EDTError) as e:
+        edtlib.Binding(str(binding_file), {})
+    assert str(e.value) == (
+        "'target-compatibles' in 'properties: foo' has type 'int', "
+        "expected 'phandle' or 'phandles'"
+    )
+
+    with open(binding_file, "w", encoding="utf-8") as f:
+        f.write(
+            """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: phandle
+    target-compatibles: "target-ok"
+"""
+        )
+
+    with pytest.raises(edtlib.EDTError) as e:
+        edtlib.Binding(str(binding_file), {})
+    assert str(e.value) == (
+        f"'target-compatibles' for 'foo' in '{str(binding_file)}' is not a list"
+    )
+
+    with open(binding_file, "w", encoding="utf-8") as f:
+        f.write(
+            """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: phandle
+    target-compatibles: []
+"""
+        )
+
+    with pytest.raises(edtlib.EDTError) as e:
+        edtlib.Binding(str(binding_file), {})
+    assert str(e.value) == (
+        f"'target-compatibles' for 'foo' in '{str(binding_file)}' must not be empty"
+    )
+
+    with open(binding_file, "w", encoding="utf-8") as f:
+        f.write(
+            """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: phandle
+    target-compatibles:
+      - "target-ok"
+      - 123
+"""
+        )
+
+    with pytest.raises(edtlib.EDTError) as e:
+        edtlib.Binding(str(binding_file), {})
+    assert str(e.value) == (
+        f"'target-compatibles' for 'foo' in '{str(binding_file)}' must be a list of strings"
+    )
+
 def test_prop_range_binding_errs(tmp_path):
     '''Test errors in binding definitions with invalid min:/max:'''
 

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -1083,6 +1083,281 @@ def test_prop_range_len_errs(tmp_path):
         f"{str(dts_file)} has length 1, which is less than the "
         f"'min-len' value in {binding_path} (2)")
 
+def test_target_compatibles(tmp_path):
+    '''Test target-compatibles validation for phandle and phandles.'''
+
+    binding_file = tmp_path / "target-compat.yaml"
+    with open(binding_file, "w", encoding="utf-8") as f:
+        f.write(
+            """\
+description: target compatible test
+compatible: "target-user"
+
+properties:
+  single:
+    type: phandle
+    target-compatibles:
+      - "target-ok"
+
+  multiple:
+    type: phandles
+    target-compatibles:
+      - "target-ok"
+""")
+
+    def edt_from_dts(dts_content, fname):
+        dts_file = tmp_path / fname
+        with open(dts_file, "w", encoding="utf-8") as f:
+            f.write(dts_content)
+        return edtlib.EDT(str(dts_file), [str(tmp_path)])
+
+    edt = edt_from_dts(
+        """\
+/dts-v1/;
+
+/ {
+    target_ok: target-ok {
+        compatible = "target-ok";
+    };
+
+    user {
+        compatible = "target-user";
+        single = <&target_ok>;
+        multiple = <&target_ok &target_ok>;
+    };
+};
+""",
+        "target-compat-ok.dts")
+
+    user = edt.get_node("/user")
+    assert user.props["single"].val.path == "/target-ok"
+    assert [node.path for node in user.props["multiple"].val] == ["/target-ok", "/target-ok"]
+
+    with pytest.raises(edtlib.EDTError) as e:
+        edt_from_dts(
+            """\
+/dts-v1/;
+
+/ {
+    target_bad: target-bad {
+        compatible = "target-bad";
+    };
+
+    user {
+        compatible = "target-user";
+        single = <&target_bad>;
+    };
+};
+""",
+            "target-compat-bad.dts")
+
+    dts_bad = tmp_path / "target-compat-bad.dts"
+    assert str(e.value) == (
+        f"property 'single' on /user in {str(dts_bad)} points to /target-bad, "
+        "but this node has compatibles ['target-bad']; expected one of ['target-ok'] "
+        f"from 'target-compatibles' in {str(binding_file)}")
+
+
+def test_target_on_bus(tmp_path):
+    '''Test target-on-bus validation, paired with target-compatibles.'''
+
+    bindings = {
+        "i2c.yaml": """\
+description: i2c bus
+compatible: "vnd,i2c"
+bus: i2c
+""",
+        "spi.yaml": """\
+description: spi bus
+compatible: "vnd,spi"
+bus: spi
+""",
+        "sensor.yaml": """\
+description: sensor
+compatible: "target-sensor"
+""",
+        "user.yaml": """\
+description: user
+compatible: "target-user"
+properties:
+  sensor:
+    type: phandle
+    target-on-bus: i2c
+""",
+    }
+    for fname, contents in bindings.items():
+        with open(tmp_path / fname, "w", encoding="utf-8") as f:
+            f.write(contents)
+
+    def edt_from_dts(dts_content, fname):
+        dts_file = tmp_path / fname
+        with open(dts_file, "w", encoding="utf-8") as f:
+            f.write(dts_content)
+        return edtlib.EDT(str(dts_file), [str(tmp_path)])
+
+    edt = edt_from_dts(
+        """\
+/dts-v1/;
+
+/ {
+    i2c {
+        compatible = "vnd,i2c";
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        sensor: sensor@0 {
+            compatible = "target-sensor";
+            reg = <0>;
+        };
+    };
+
+    user {
+        compatible = "target-user";
+        sensor = <&sensor>;
+    };
+};
+""",
+        "target-on-bus-ok.dts")
+    assert edt.get_node("/user").props["sensor"].val.path == "/i2c/sensor@0"
+
+    with pytest.raises(edtlib.EDTError) as e:
+        edt_from_dts(
+            """\
+/dts-v1/;
+
+/ {
+    spi {
+        compatible = "vnd,spi";
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        sensor: sensor@0 {
+            compatible = "target-sensor";
+            reg = <0>;
+        };
+    };
+
+    user {
+        compatible = "target-user";
+        sensor = <&sensor>;
+    };
+};
+""",
+            "target-on-bus-bad.dts")
+
+    binding_file = tmp_path / "user.yaml"
+    dts_bad = tmp_path / "target-on-bus-bad.dts"
+    assert str(e.value) == (
+        f"property 'sensor' on /user in {str(dts_bad)} points to /spi/sensor@0, "
+        "which is on bus(es) ['spi']; expected bus 'i2c' "
+        f"from 'target-on-bus' in {str(binding_file)}")
+
+
+def test_target_compatibles_binding_errs(tmp_path):
+    '''Test target-compatibles binding schema errors.'''
+
+    def check_binding_err(yaml_content, expected_err):
+        binding_file = tmp_path / "target-compat.yaml"
+        with open(binding_file, "w", encoding="utf-8") as f:
+            f.write(yaml_content)
+        with pytest.raises(edtlib.EDTError) as e:
+            edtlib.Binding(str(binding_file), {})
+        assert str(e.value) == expected_err
+
+    path = str(tmp_path / "target-compat.yaml")
+
+    # target-compatibles on unsupported type
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    target-compatibles:
+      - "target-ok"
+""",
+        "'target-compatibles' in 'properties: foo' has type 'int', "
+        "expected 'phandle' or 'phandles'")
+
+    # target-compatibles not a list
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: phandle
+    target-compatibles: "target-ok"
+""",
+        f"'target-compatibles' for 'foo' in '{path}' is not a list")
+
+    # empty target-compatibles
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: phandle
+    target-compatibles: []
+""",
+        f"'target-compatibles' for 'foo' in '{path}' must not be empty")
+
+    # target-compatibles not a list of strings
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: phandle
+    target-compatibles:
+      - "target-ok"
+      - 123
+""",
+        f"'target-compatibles' for 'foo' in '{path}' must be a list of strings")
+
+
+def test_target_on_bus_binding_errs(tmp_path):
+    '''Test target-on-bus binding schema errors.'''
+
+    def check_binding_err(yaml_content, expected_err):
+        binding_file = tmp_path / "target-on-bus.yaml"
+        with open(binding_file, "w", encoding="utf-8") as f:
+            f.write(yaml_content)
+        with pytest.raises(edtlib.EDTError) as e:
+            edtlib.Binding(str(binding_file), {})
+        assert str(e.value) == expected_err
+
+    path = str(tmp_path / "target-on-bus.yaml")
+
+    # target-on-bus on unsupported type
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    target-on-bus: i2c
+""",
+        "'target-on-bus' in 'properties: foo' has type 'int', "
+        "expected 'phandle' or 'phandles'")
+
+    # target-on-bus not a string
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: phandle
+    target-on-bus:
+      - i2c
+""",
+        f"'target-on-bus' for 'foo' in '{path}' is not a string")
+
 def test_prop_range_binding_errs(tmp_path):
     '''Test errors in binding definitions with invalid min:/max:'''
 


### PR DESCRIPTION
Implements RFC
https://github.com/zephyrproject-rtos/zephyr/issues/110163


Error when using wrong type
```
-- Found devicetree overlay: /Users/kylebonnici/workspace/personal/zephyrproject/zephyr/samples/bluetooth/central_otc/app.overlay
devicetree error: property 'fem' on /soc/radio@40001000 in /Users/kylebonnici/workspace/personal/zephyrproject/zephyr/samples/bluetooth/central_otc/build/zephyr/zephyr.dts.pre points to /soc/adc@40007000, but this node has compatibles ['nordic,nrf-saadc']; expected one of ['radio-fem-two-ctrl-pins', 'nordic,nrf21540-fem'] from 'target-compatibles' in /Users/kylebonnici/workspace/personal/zephyrproject/zephyr/dts/bindings/net/wireless/nordic,nrf-radio.yaml
```