### PR TITLE
usb: device: uvc: fix frame interval sort element size

### DIFF
--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -1473,9 +1473,13 @@ static int uvc_add_vs_frame_desc(const struct device *dev,
 		}
 	}
 
-	/* UVC requires the frame intervals to be sorted, but not Zephyr */
+	/* UVC requires the frame intervals to be sorted, but not Zephyr.
+	 * dwFrameInterval is a uint8_t *, so each interval is a packed le32: sort
+	 * 4-byte elements. sizeof(*dwFrameInterval) is 1 and would reorder individual
+	 * bytes, corrupting the intervals into an unsorted, garbage list.
+	 */
 	qsort(dwFrameInterval, *bFrameIntervalType,
-	      sizeof(*dwFrameInterval), uvc_compare_frmival_desc);
+	      sizeof(uint32_t), uvc_compare_frmival_desc);
 
 	sys_put_le32(sys_get_le32(dwFrameInterval), dwDefaultFrameInterval);
 	format_desc->bNumFrameDescriptors += 1;

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -1485,7 +1485,7 @@ static int uvc_add_vs_frame_desc(const struct device *dev,
 
 	/* UVC requires the frame intervals to be sorted, but not Zephyr */
 	qsort(dwFrameInterval, *bFrameIntervalType,
-	      sizeof(*dwFrameInterval), uvc_compare_frmival_desc);
+	      sizeof(uint32_t), uvc_compare_frmival_desc);
 
 	sys_put_le32(sys_get_le32(dwFrameInterval), dwDefaultFrameInterval);
 	format_desc->bNumFrameDescriptors += 1;


### PR DESCRIPTION
### Summary

`uvc_add_vs_frame_desc()` sorts the discrete frame intervals with the wrong
`qsort()` element size:

```c
qsort(dwFrameInterval, *bFrameIntervalType,
      sizeof(*dwFrameInterval), uvc_compare_frmival_desc);
```

`dwFrameInterval` is a `uint8_t *`, so `sizeof(*dwFrameInterval)` is **1**, but
each frame interval is a packed 4-byte (le32) value. `qsort()` therefore reorders
individual *bytes* instead of whole intervals, corrupting every entry and
producing a garbage, unsorted `dwFrameInterval` list.

### Impact

Any UVC camera that enumerates **two or more** frame intervals emits a malformed
frame descriptor. Hosts that require the intervals to be sorted (e.g. Windows)
then fail to start the stream — the device enumerates but cannot be opened
(Device Manager Code 10 / `CM_PROB_FAILED_START`). A camera exposing a single
frame interval is unaffected, which is why this has gone unnoticed.

### Reproduced / verified on hardware

Himax HM0360 over DCMI on an STM32H7 (the sensor enumerates 60/30/15/10 fps).
The webcam refused to start on Windows; dumping the live descriptors over SWD
showed the `dwFrameInterval` array scrambled. With this fix the intervals are
correctly sorted and the camera opens.

### Fix

Pass `sizeof(uint32_t)` so `qsort()` sorts whole intervals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
