### PR TITLE
board: kit_pse84_ai: disable twister on this platform

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33_ns.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33_ns.yaml
@@ -9,6 +9,7 @@ type: mcu
 arch: arm
 sysbuild: true
 ram: 5120
+twister: false
 toolchain:
   - zephyr
 supported:


### PR DESCRIPTION
Disable this board for now as it pulls external git trees into the
build.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
