### PR TITLE
kernel: timeout: pluggable timeout queue backends

### DIFF
--- a/doc/kernel/data_structures/min_heap.rst
+++ b/doc/kernel/data_structures/min_heap.rst
@@ -65,6 +65,26 @@ In RTOS environments like Zephyr, this heap can be used in kernel-level or
 application-level modules where minimal latency to obtain the highest priority
 resource is needed.
 
+Value and reference variants
+****************************
+
+Two variants are provided, differing only in how elements are stored:
+
+- ``min_heap`` (described above) stores elements **by value** in a contiguous
+  buffer. An arbitrary element is removed by content (search) or by index.
+  This suits priority queues of small values looked up by content.
+
+- ``min_heap_ref`` stores **references** to caller-owned nodes, each embedding
+  a ``min_heap_handle``. Insertion is zero-copy, and a specific node is removed
+  in :math:`O(\log n)` using the handle the caller already holds, with no
+  search. This suits long-lived objects removed by identity rather than by
+  content, such as kernel timeouts.
+
+The two are complementary: the value heap cannot remove by identity in better
+than :math:`O(n)`, while the reference heap is a poor fit for
+value-with-search use. ``min_heap_ref`` is header-only and requires no
+Kconfig.
+
 Samples
 *******
 
@@ -74,4 +94,12 @@ Samples
 API Reference
 *************
 
+Value heap
+==========
+
 .. doxygengroup:: min_heap_apis
+
+Reference heap
+==============
+
+.. doxygengroup:: min_heap_ref_apis

--- a/doc/kernel/services/timing/clocks.rst
+++ b/doc/kernel/services/timing/clocks.rst
@@ -177,25 +177,60 @@ Timeout Queue
 -------------
 
 All Zephyr :c:type:`k_timeout_t` events specified using the API above are
-managed in a single, global queue of events.  Each event is stored in
-a double-linked list, with an attendant delta count in ticks from the
-previous event.  The action to take on an event is specified as a
-callback function pointer provided by the subsystem requesting the
-event, along with a :c:struct:`_timeout` tracking struct that is
-expected to be embedded within subsystem-defined data structures (for
-example: a :c:struct:`wait_q` struct, or a :c:type:`k_tid_t` thread struct).
+managed in a single, global queue of events.  The action to take on an
+event is specified as a callback function pointer provided by the
+subsystem requesting the event, along with a :c:struct:`_timeout`
+tracking struct that is expected to be embedded within subsystem-defined
+data structures (for example: a :c:struct:`wait_q` struct, or a
+:c:type:`k_tid_t` thread struct).
 
-Note that all variant units passed via a :c:type:`k_timeout_t` are converted
-to ticks once on insertion into the list.  There no
+Note that all variant units passed via a :c:type:`k_timeout_t` are
+converted to ticks once on insertion into the queue.  There are no
 multiple-conversion steps internal to the kernel, so precision is
-guaranteed at the tick level no matter how many events exist or how
-long a timeout might be.
+guaranteed at the tick level no matter how many events exist or how long
+a timeout might be.
 
-Note that the list structure means that the CPU work involved in
-managing large numbers of timeouts is quadratic in the number of
-active timeouts.  The API design of the timeout queue was intended to
-permit a more scalable backend data structure, but no such
-implementation exists currently.
+The data structure that holds the queue is selected at build time
+through the :kconfig:option:`CONFIG_TIMEOUT_BACKEND` choice.  Only the
+front end is shared between backends (the announce path, the SMP
+re-entry handling, and the relative versus absolute timeout rules); each
+backend supplies the queue itself, so an integrator can match the data
+structure to the workload without touching the common code.
+
+The default, :kconfig:option:`CONFIG_TIMEOUT_BACKEND_DLIST`, stores
+events in a doubly linked list sorted by expiry, each holding a delta
+count in ticks from its predecessor.  Insertion is O(N) in the number of
+pending timeouts: inexpensive for the handful a typical system has
+pending, but it scales poorly when many are outstanding.  The three
+alternative backends, all currently experimental, trade extra memory or
+behaviour for faster insertion at scale:
+
+* :kconfig:option:`CONFIG_TIMEOUT_BACKEND_MINHEAP` keeps the events in a
+  binary min-heap keyed on absolute expiry, making insertion and removal
+  O(log N).  It requires 64-bit ticks
+  (:kconfig:option:`CONFIG_TIMEOUT_64BIT`) and a fixed-capacity heap
+  (:kconfig:option:`CONFIG_TIMEOUT_HEAP_MAX_ENTRIES`, whose overflow is
+  fatal), and it does not preserve the firing order of timeouts that
+  expire on the same tick.
+
+* :kconfig:option:`CONFIG_TIMEOUT_BACKEND_WHEEL` is a hierarchical timer
+  wheel with O(1) insertion and removal for the near future and a sorted
+  overflow list beyond.  It has the largest per-event and static
+  footprint, does not preserve same-tick firing order, and wakes a
+  tickless-idle CPU periodically because its next-timeout estimate is
+  bounded by the wheel period (a power cost the other backends avoid).
+
+* :kconfig:option:`CONFIG_TIMEOUT_BACKEND_BUCKET` is a single-level
+  bucketed delta list, a simpler relative of the wheel.  It gives O(1)
+  insertion within a tunable near-future window
+  (:kconfig:option:`CONFIG_TIMEOUT_BUCKET_LISTS`) and falls back to a
+  sorted overflow list beyond it.  It also requires 64-bit ticks, but
+  unlike the wheel it preserves same-tick firing order and adds no
+  idle-wakeup cost.
+
+The non-default backends target systems that hold many concurrent
+timeouts, especially ones clustered in the near future.  For most
+applications the delta list remains the appropriate default.
 
 Timer Drivers
 -------------

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1854,9 +1854,7 @@ struct k_timer_observer {
 #define Z_TIMER_INITIALIZER(obj, expiry, stop) \
 	{ \
 	.timeout = { \
-		.node = {},\
 		.fn = z_timer_expiration_handler, \
-		.dticks = 0, \
 	}, \
 	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q), \
 	.expiry_fn = expiry, \

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -315,8 +315,16 @@ struct _timeout {
 	int64_t abs_ticks;
 	struct min_heap_handle heap_handle;
 #else
-	/* Sorted delta-list backend: delta-ticks to the predecessor node. */
+	/*
+	 * Delta-list and timer-wheel backends: a list node plus dticks (a
+	 * delta to the predecessor for the delta list; an encoded slot
+	 * position for the wheel). The wheel adds a flags field recording
+	 * which wheel tier the timeout currently occupies.
+	 */
 	sys_dnode_t node;
+#if defined(CONFIG_TIMEOUT_BACKEND_WHEEL)
+	uint32_t flags;
+#endif
 #ifdef CONFIG_TIMEOUT_64BIT
 	/* Can't use k_ticks_t for header dependency reasons */
 	int64_t dticks;

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -30,6 +30,9 @@
 #include <zephyr/kernel/stats.h>
 #include <zephyr/kernel/obj_core.h>
 #include <zephyr/sys/rb.h>
+#if defined(CONFIG_TIMEOUT_BACKEND_MINHEAP)
+#include <zephyr/sys/min_heap_ref.h>
+#endif
 #endif
 
 #define K_NUM_THREAD_PRIO (CONFIG_NUM_PREEMPT_PRIORITIES + CONFIG_NUM_COOP_PRIORITIES + 1)
@@ -297,14 +300,31 @@ struct _timeout;
 typedef void (*_timeout_func_t)(struct _timeout *t);
 
 struct _timeout {
+	/*
+	 * Backend-specific queue representation. The handler pointer (fn) is
+	 * common to all backends and kept as the trailing member; everything
+	 * above it is owned by the selected timeout backend (see
+	 * kernel/include/timeout_q.h).
+	 */
+#if defined(CONFIG_TIMEOUT_BACKEND_MINHEAP)
+	/*
+	 * Min-heap backend: absolute expiry tick plus the heap position
+	 * handle. heap_handle.idx == 0 means the timeout is not queued
+	 * (idle, popped for announcing, or aborted).
+	 */
+	int64_t abs_ticks;
+	struct min_heap_handle heap_handle;
+#else
+	/* Sorted delta-list backend: delta-ticks to the predecessor node. */
 	sys_dnode_t node;
-	_timeout_func_t fn;
 #ifdef CONFIG_TIMEOUT_64BIT
 	/* Can't use k_ticks_t for header dependency reasons */
 	int64_t dticks;
 #else
 	int32_t dticks;
 #endif
+#endif /* CONFIG_TIMEOUT_BACKEND_MINHEAP */
+	_timeout_func_t fn;
 };
 
 typedef void (*k_thread_timeslice_fn_t)(struct k_thread *thread, void *data);

--- a/include/zephyr/sys/min_heap_ref.h
+++ b/include/zephyr/sys/min_heap_ref.h
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2026 Aerlync Labs Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header-file for the reference (handle-based) min-heap data structure
+ * @ingroup min_heap_ref_apis
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_MIN_HEAP_REF_H_
+#define ZEPHYR_INCLUDE_SYS_MIN_HEAP_REF_H_
+
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup min_heap_ref_apis Reference min-heap
+ * @ingroup datastructure_apis
+ * @brief Reference (handle-based) min-heap implementation
+ *
+ * A min-heap is a binary tree-based data structure in which the smallest element is always at the
+ * root. Unlike the value-based min-heap, this variant stores pointers to caller-owned nodes that
+ * embed a min_heap_handle, so insertion is zero-copy and a specific node can be removed in
+ * O(log n) using its handle, with no search.
+ *
+ * @{
+ */
+
+/**
+ * @brief Embeddable heap position handle
+ *
+ * Embed in the user struct, recover the containing struct with CONTAINER_OF().
+ *
+ */
+struct min_heap_handle {
+	/** 1-based storage index; 0 means not in heap */
+	uint16_t idx;
+};
+
+/**
+ * @brief Comparator function type for min-heap ordering.
+ *
+ * This function compares two heap nodes to establish their relative order.
+ * It must be implemented by the user and provided at min-heap
+ * initialization.
+ *
+ * @param a First handle pointer for comparison.
+ * @param b Second handle pointer for comparison.
+ *
+ * @return Negative value if @p a is less than @p b,
+ *         positive value if @p a is greater than @p b,
+ *         zero if they are equal.
+ */
+typedef int (*min_heap_ref_cmp_t)(const struct min_heap_handle *a, const struct min_heap_handle *b);
+
+/**
+ * @brief min-heap data structure with user-provided comparator.
+ */
+struct min_heap_ref {
+	/** Array of handle pointers: one slot per element */
+	struct min_heap_handle **storage;
+	/** Maximum number of elements */
+	size_t capacity;
+	/** Current elements count */
+	size_t size;
+	/** Comparator function: returns <0, 0, >0 */
+	min_heap_ref_cmp_t cmp;
+};
+
+/**
+ * @brief Define a min-heap instance.
+ *
+ * @param name Base name for the heap instance.
+ * @param cap Capacity (number of elements).
+ * @param cmp_func Comparator function used by the heap
+ */
+#define MIN_HEAP_REF_DEFINE(name, cap, cmp_func)                                       \
+	static struct min_heap_handle *(name##_storage)[(cap)];                        \
+	struct min_heap_ref name = {                                                   \
+		.storage = (name##_storage),                                           \
+		.capacity = (cap),                                                     \
+		.size = 0,                                                             \
+		.cmp = (cmp_func),                                                     \
+	}
+
+/**
+ * @brief Define a statically allocated min-heap instance.
+ *
+ * @param name Base name for the heap instance.
+ * @param cap Capacity (number of elements).
+ * @param cmp_func Comparator function used by the heap
+ */
+#define MIN_HEAP_REF_DEFINE_STATIC(name, cap, cmp_func)                                \
+	static struct min_heap_handle *(name##_storage)[(cap)];                        \
+	static struct min_heap_ref name = {                                            \
+		.storage = (name##_storage),                                           \
+		.capacity = (cap),                                                     \
+		.size = 0,                                                             \
+		.cmp = (cmp_func),                                                     \
+	}
+
+/**
+ * @brief Initialize a min-heap instance at runtime.
+ *
+ * Sets up the internal structure of a min heap using a user-provided
+ * handle pointer array, capacity, and comparator function. This function must
+ * be called before using the heap if not statically defined.
+ *
+ * @param heap Pointer to the min-heap structure.
+ * @param storage Pointer to array of handle pointers.
+ * @param capacity Maximum number of elements the heap can store.
+ * @param cmp Comparator function used to order the heap elements.
+ *
+ * @note All arguments must be valid. This function does not allocate memory.
+ *
+ */
+static inline void min_heap_ref_init(struct min_heap_ref *heap, struct min_heap_handle **storage,
+				 size_t capacity, min_heap_ref_cmp_t cmp)
+{
+	__ASSERT_NO_MSG(heap != NULL);
+	__ASSERT_NO_MSG(storage != NULL);
+	__ASSERT_NO_MSG(cmp != NULL);
+
+	heap->storage = storage;
+	heap->capacity = capacity;
+	heap->size = 0;
+	heap->cmp = cmp;
+}
+
+/**
+ * @brief Swap two elements in the heap storage, updating their idx fields.
+ *
+ * @param heap Pointer to the min-heap.
+ * @param a Index of the first element.
+ * @param b Index of the second element.
+ */
+static inline void min_heap_ref_swap(struct min_heap_ref *heap, size_t a, size_t b)
+{
+	struct min_heap_handle *tmp = heap->storage[a];
+
+	heap->storage[a] = heap->storage[b];
+	heap->storage[b] = tmp;
+	heap->storage[a]->idx = (uint16_t)(a + 1U);
+	heap->storage[b]->idx = (uint16_t)(b + 1U);
+}
+
+/**
+ * @brief Restore heap order by moving a node up the tree.
+ *
+ * Moves the node at the given index upward in the heap until the min-heap property is restored.
+ *
+ * @param heap Pointer to the min-heap.
+ * @param index Index of the node to heapify upwards.
+ */
+static inline void min_heap_ref_heapify_up(struct min_heap_ref *heap, size_t index)
+{
+	while (index > 0) {
+		size_t parent = (index - 1U) / 2U;
+
+		if (heap->cmp(heap->storage[index], heap->storage[parent]) >= 0) {
+			break;
+		}
+		min_heap_ref_swap(heap, index, parent);
+		index = parent;
+	}
+}
+
+/**
+ * @brief Restore heap order by moving a node down the tree.
+ *
+ * Moves the node at the sepcified index downward in the heap until the min-heap property is
+ * restored.
+ *
+ * @param heap Pointer to the min-heap.
+ * @param index Index of the node to heapify downward.
+ */
+static inline void min_heap_ref_heapify_down(struct min_heap_ref *heap, size_t index)
+{
+	for (size_t left = 2U * index + 1U; left < heap->size; left = 2U * index + 1U) {
+		size_t right = left + 1U;
+		size_t smallest = index;
+
+		if (heap->cmp(heap->storage[left], heap->storage[smallest]) < 0) {
+			smallest = left;
+		}
+		if (right < heap->size &&
+		    heap->cmp(heap->storage[right], heap->storage[smallest]) < 0) {
+			smallest = right;
+		}
+		if (smallest == index) {
+			break;
+		}
+		min_heap_ref_swap(heap, index, smallest);
+		index = smallest;
+	}
+}
+
+/**
+ * @brief Push a handle into the min-heap.
+ *
+ * Adds a new handle to the min-heap and restores the heap order by moving it
+ * upward as necessary. Insert operation will fail if the min-heap
+ * has reached full capacity.
+ *
+ * @param heap Pointer to the min-heap.
+ * @param handle Pointer to the handle to insert.
+ *
+ * @return 0 on Success, -1 if the heap is full.
+ */
+static inline int min_heap_ref_push(struct min_heap_ref *heap, struct min_heap_handle *handle)
+{
+	__ASSERT_NO_MSG(heap != NULL);
+	__ASSERT_NO_MSG(handle != NULL);
+	__ASSERT_NO_MSG(handle->idx == 0U);
+	__ASSERT(heap->size < UINT16_MAX, "heap idx overflow");
+
+	if (heap->size >= heap->capacity) {
+		return -1;
+	}
+
+	heap->storage[heap->size] = handle;
+	handle->idx = (uint16_t)(heap->size + 1U);
+	heap->size++;
+	min_heap_ref_heapify_up(heap, heap->size - 1U);
+
+	return 0;
+}
+
+/**
+ * @brief Peek at the top element of the min-heap.
+ *
+ * The function will not remove the element from the min-heap.
+ *
+ * @param heap Pointer to the min-heap.
+ *
+ * @return Pointer to the top handle, or NULL if the heap is empty.
+ */
+static inline const struct min_heap_handle *min_heap_ref_peek(const struct min_heap_ref *heap)
+{
+	__ASSERT_NO_MSG(heap != NULL);
+	return heap->size == 0U ? NULL : heap->storage[0];
+}
+
+/**
+ * @brief Remove a specific element from the min-heap by handle.
+ *
+ * The handle's idx field gives the O(1) location, no linear scan needed.
+ *
+ * @param heap Pointer to the min-heap.
+ * @param handle Handle of the element to remove (must currently be in heap).
+ *
+ * @return true in success, false otherwise.
+ */
+static inline bool min_heap_ref_remove(struct min_heap_ref *heap, struct min_heap_handle *handle)
+{
+	__ASSERT_NO_MSG(heap != NULL);
+	__ASSERT_NO_MSG(handle != NULL);
+
+	if (handle->idx == 0U || (size_t)handle->idx > heap->size) {
+		return false;
+	}
+
+	size_t id = (size_t)(handle->idx - 1U);
+
+	handle->idx = 0U;
+	heap->size--;
+
+	if (id != heap->size) {
+		struct min_heap_handle *last = heap->storage[heap->size];
+
+		heap->storage[heap->size] = NULL;
+		heap->storage[id] = last;
+		last->idx = (uint16_t)(id + 1U);
+		min_heap_ref_heapify_down(heap, id);
+		min_heap_ref_heapify_up(heap, id);
+	} else {
+		heap->storage[heap->size] = NULL;
+	}
+
+	return true;
+}
+
+/**
+ * @brief Check if the min heap is empty.
+ *
+ * This function checks whether the heap contains any elements.
+ *
+ * @param heap Pointer to the min heap.
+ *
+ * @return true if heap is empty, false otherwise.
+ */
+static inline bool min_heap_ref_is_empty(struct min_heap_ref *heap)
+{
+	__ASSERT_NO_MSG(heap != NULL);
+	return (heap->size == 0);
+}
+
+/**
+ * @brief Remove and return the highest priority element's handle.
+ *
+ * @param heap Pointer to heap.
+ *
+ * @return Handle of the removed minimum element, or NULL if empty.
+ *	   Use CONTAINER_OF() to recover the containing struct.
+ */
+static inline struct min_heap_handle *min_heap_ref_pop(struct min_heap_ref *heap)
+{
+	__ASSERT_NO_MSG(heap != NULL);
+
+	if (heap->size == 0U) {
+		return NULL;
+	}
+
+	struct min_heap_handle *min = heap->storage[0];
+	bool ok = min_heap_ref_remove(heap, min);
+
+	__ASSERT_NO_MSG(ok);
+	(void)ok;
+	return min;
+}
+
+/**
+ * @brief Iterate over every element currently in the min-heap.
+ *
+ * Visits all elements in internal storage-array order (BFS level order).
+ * This is NOT the sorted order
+ *
+ * Usage:
+ * @code
+ *   struct min_heap_handle *h;
+ *   MIN_HEAP_REF_FOREACH(&heap, h) {
+ *	struct data *t = CONTAINER_OF(h, struct data, handle);
+ *   }
+ * @endcode
+ *
+ * @param __heap Pointer to the min-heap.
+ * @param __handle min_heap_handle pointer.
+ */
+#define MIN_HEAP_REF_FOREACH(__heap, __handle)                                         \
+	for (size_t __mh_i = 0;                                                        \
+	     (__mh_i < (__heap)->size) && ((__handle) = (__heap)->storage[__mh_i], true); \
+	     __mh_i++)
+/**
+ * @brief Iterate over every element in the min-heap yielding the embedding container struct
+ *
+ * Usage:
+ * @code
+ *   struct data *t;
+ *   MIN_HEAP_REF_FOREACH_CONTAINER(&heap, t, handle) {
+ *	printk("key=%d\n", t->key);
+ *   }
+ * @endcode
+ *
+ * @param __heap Pointer to the min-heap
+ * @param __cn Caller-declared pointer to the container struct type
+ * @param __field Name of the min_heap_handle member in the container
+ */
+#define MIN_HEAP_REF_FOREACH_CONTAINER(__heap, __cn, __field)                          \
+	for (size_t __mh_i = 0;                                                        \
+	     (__mh_i < (__heap)->size) &&                                              \
+	     ((__cn) = CONTAINER_OF((__heap)->storage[__mh_i], __typeof__(*(__cn)), __field), \
+	     true);                                                                    \
+	     __mh_i++)
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SYS_MIN_HEAP_REF_H_ */

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -781,6 +781,17 @@ config TIMEOUT_BACKEND_MINHEAP
 	  a fatal error. Consider this when many timeouts are pending and
 	  insertion cost on the delta list dominates.
 
+config TIMEOUT_BACKEND_WHEEL
+	bool "Hierarchical timer wheel [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  A hierarchical timer wheel: O(1) insertion and removal for timeouts
+	  expiring within the next ~1024 ticks, with a sorted overflow list
+	  for anything beyond. Sift work is amortised at 32-tick boundaries.
+	  Best when many short-lived timeouts are pending. Costs ~1 KB of
+	  static state, so it is a poor fit for very small-RAM targets, and
+	  it does not guarantee same-tick firing order.
+
 endchoice # TIMEOUT_BACKEND
 
 config TIMEOUT_HEAP_MAX_ENTRIES

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -792,7 +792,31 @@ config TIMEOUT_BACKEND_WHEEL
 	  static state, so it is a poor fit for very small-RAM targets, and
 	  it does not guarantee same-tick firing order.
 
+config TIMEOUT_BACKEND_BUCKET
+	bool "Single-level bucketed delta list [EXPERIMENTAL]"
+	depends on TIMEOUT_64BIT
+	select EXPERIMENTAL
+	help
+	  A simpler relative of the timer wheel: one per-tick bucket list for
+	  the next CONFIG_TIMEOUT_BUCKET_LISTS ticks (O(1) insert/remove) plus
+	  a sorted overflow list for anything beyond (O(n) insert). Migration
+	  is on demand against the actual next event, so it imposes no
+	  tickless-idle floor. Requires 64-bit timeouts.
+
 endchoice # TIMEOUT_BACKEND
+
+config TIMEOUT_BUCKET_LISTS
+	int "Number of per-tick buckets for the bucketed backend"
+	depends on TIMEOUT_BACKEND_BUCKET
+	default 32
+	range 8 64
+	help
+	  Number of single-tick bucket lists (must be a power of two between 8
+	  and 64). Timeouts expiring within this many ticks get O(1) insertion;
+	  longer ones land in the sorted overflow list. Larger values widen
+	  the O(1) window at the cost of more static RAM (one list head each).
+	  Below 8 the plain delta-list backend is likely the better choice. The
+	  occupancy bitmap is a uint32_t for up to 32 buckets, a uint64_t beyond.
 
 config TIMEOUT_HEAP_MAX_ENTRIES
 	int "Maximum simultaneous pending timeouts in the heap"

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -752,6 +752,54 @@ config TIMEOUT_64BIT
 	  availability of absolute timeout values (which require the
 	  extra precision).
 
+choice TIMEOUT_BACKEND
+	prompt "Timeout queue backend"
+	default TIMEOUT_BACKEND_DLIST
+	depends on SYS_CLOCK_EXISTS
+	help
+	  Selects the data structure used by the kernel timeout subsystem
+	  to track pending timeouts. All backends share the same front-end
+	  (kernel/timeout.c); they differ only in the queue representation
+	  and its performance trade-offs.
+
+config TIMEOUT_BACKEND_DLIST
+	bool "Sorted delta list"
+	help
+	  The original Zephyr backend: a doubly linked list sorted by
+	  expiry, each node storing a delta to its predecessor. Insertion
+	  is O(n), head removal O(1). No capacity limit and no extra static
+	  RAM. The right default for most systems.
+
+config TIMEOUT_BACKEND_MINHEAP
+	bool "Binary min-heap [EXPERIMENTAL]"
+	depends on TIMEOUT_64BIT
+	select EXPERIMENTAL
+	help
+	  A binary min-heap keyed on absolute expiry tick. Insertion and
+	  arbitrary removal are O(log n). Requires 64-bit timeouts and a
+	  fixed-capacity heap (CONFIG_TIMEOUT_HEAP_MAX_ENTRIES); overflow is
+	  a fatal error. Consider this when many timeouts are pending and
+	  insertion cost on the delta list dominates.
+
+endchoice # TIMEOUT_BACKEND
+
+config TIMEOUT_HEAP_MAX_ENTRIES
+	int "Maximum simultaneous pending timeouts in the heap"
+	depends on TIMEOUT_BACKEND_MINHEAP
+	default 128
+	help
+	  Static capacity of the timeout min-heap array.
+
+	  Set this to the peak number of simultaneously pending timeouts your
+	  application requires. As a starting point, count:
+	    - Active threads (each may have one pending timeout)
+	    - Active k_timer instances
+	    - Delayable work items
+	    - Network / socket timeouts
+
+	  Overflow causes k_panic() at runtime. If you see unexpected panics,
+	  increase this value and rebuild.
+
 config SYS_CLOCK_MAX_TIMEOUT_DAYS
 	int "Max timeout (in days) used in conversions"
 	default 365

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -23,17 +23,30 @@ extern "C" {
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 
 /*
- * Per-node timeout helpers.
+ * Per-node timeout helpers (Kconfig choice TIMEOUT_BACKEND).
  *
  * z_init_timeout() and z_is_inactive_timeout() operate on a single
  * struct _timeout and are needed tree-wide (timer.c, work.c, poll.c, ...),
- * so they live here and depend only on struct _timeout's fields (see
- * kernel_structs.h). The queue itself (the z_timeout_q_*() operations and the
- * backend instance) is private to kernel/timeout.c, which includes the
- * matching backend implementation header directly. The sorted delta list is
- * the only backend today; when alternatives land this becomes a
- * Kconfig-driven choice.
+ * so they live here and depend only on the chosen backend's struct _timeout
+ * fields (see kernel_structs.h). The queue itself (the z_timeout_q_*()
+ * operations and the backend instance) is private to kernel/timeout.c, which
+ * includes the matching backend implementation header directly.
  */
+#if defined(CONFIG_TIMEOUT_BACKEND_MINHEAP)
+
+static inline void z_init_timeout(struct _timeout *to)
+{
+	to->heap_handle.idx = 0U;
+	to->abs_ticks = 0;
+}
+
+static inline bool z_is_inactive_timeout(const struct _timeout *to)
+{
+	return to->heap_handle.idx == 0U;
+}
+
+#else /* CONFIG_TIMEOUT_BACKEND_DLIST */
+
 static inline void z_init_timeout(struct _timeout *to)
 {
 	sys_dnode_init(&to->node);
@@ -44,6 +57,8 @@ static inline bool z_is_inactive_timeout(const struct _timeout *to)
 {
 	return !sys_dnode_is_linked(&to->node);
 }
+
+#endif
 
 /* Adds the timeout to the queue.
  *

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -22,10 +22,27 @@ extern "C" {
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 
+/*
+ * Per-node timeout helpers.
+ *
+ * z_init_timeout() and z_is_inactive_timeout() operate on a single
+ * struct _timeout and are needed tree-wide (timer.c, work.c, poll.c, ...),
+ * so they live here and depend only on struct _timeout's fields (see
+ * kernel_structs.h). The queue itself (the z_timeout_q_*() operations and the
+ * backend instance) is private to kernel/timeout.c, which includes the
+ * matching backend implementation header directly. The sorted delta list is
+ * the only backend today; when alternatives land this becomes a
+ * Kconfig-driven choice.
+ */
 static inline void z_init_timeout(struct _timeout *to)
 {
 	sys_dnode_init(&to->node);
 	to->dticks = 0;
+}
+
+static inline bool z_is_inactive_timeout(const struct _timeout *to)
+{
+	return !sys_dnode_is_linked(&to->node);
 }
 
 /* Adds the timeout to the queue.
@@ -61,11 +78,6 @@ int z_try_abort_timeout(struct _timeout *to);
  * taking their own lock, and bail if it returns true.
  */
 bool z_timeout_inflight_superseded(const struct _timeout *to);
-
-static inline bool z_is_inactive_timeout(const struct _timeout *to)
-{
-	return !sys_dnode_is_linked(&to->node);
-}
 
 static inline void z_init_thread_timeout(struct _thread_base *thread_base)
 {

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -59,7 +59,7 @@ static inline bool z_is_inactive_timeout(const struct _timeout *to)
 	return !sys_dnode_is_linked(&to->node);
 }
 
-#else /* CONFIG_TIMEOUT_BACKEND_DLIST */
+#else /* CONFIG_TIMEOUT_BACKEND_DLIST or _BUCKET */
 
 static inline void z_init_timeout(struct _timeout *to)
 {

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -45,6 +45,20 @@ static inline bool z_is_inactive_timeout(const struct _timeout *to)
 	return to->heap_handle.idx == 0U;
 }
 
+#elif defined(CONFIG_TIMEOUT_BACKEND_WHEEL)
+
+static inline void z_init_timeout(struct _timeout *to)
+{
+	sys_dnode_init(&to->node);
+	to->flags = 0U;
+	to->dticks = 0;
+}
+
+static inline bool z_is_inactive_timeout(const struct _timeout *to)
+{
+	return !sys_dnode_is_linked(&to->node);
+}
+
 #else /* CONFIG_TIMEOUT_BACKEND_DLIST */
 
 static inline void z_init_timeout(struct _timeout *to)

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -16,9 +16,8 @@
 
 #include <timeslicing.h>
 
+/* Absolute tick counter: ticks since boot. */
 static uint64_t curr_tick;
-
-static sys_dlist_t timeout_list = SYS_DLIST_STATIC_INIT(&timeout_list);
 
 /*
  * The timeout code shall take no locks other than its own (timeout_lock), nor
@@ -69,29 +68,6 @@ static inline void inflight_mark_superseded(void)
 					       INFLIGHT_SUPERSEDED_BIT);
 }
 
-static struct _timeout *first(void)
-{
-	sys_dnode_t *t = sys_dlist_peek_head(&timeout_list);
-
-	return (t == NULL) ? NULL : CONTAINER_OF(t, struct _timeout, node);
-}
-
-static struct _timeout *next(struct _timeout *t)
-{
-	sys_dnode_t *n = sys_dlist_peek_next(&timeout_list, &t->node);
-
-	return (n == NULL) ? NULL : CONTAINER_OF(n, struct _timeout, node);
-}
-
-static void remove_timeout(struct _timeout *t)
-{
-	if (next(t) != NULL) {
-		next(t)->dticks += t->dticks;
-	}
-
-	sys_dlist_remove(&t->node);
-}
-
 static uint32_t elapsed(void)
 {
 	/*
@@ -120,9 +96,25 @@ static uint32_t elapsed(void)
 	       (IS_ENABLED(CONFIG_SMP) ? announce_remaining : 0);
 }
 
+/*
+ * Backend queue implementation. The selected backend's queue instance and its
+ * z_timeout_q_*() operations are private to this file: the backend is a header
+ * included only here, after the shared state above, so those operations can
+ * reach curr_tick / announce_remaining / inflight_timeout / timeout_lock
+ * directly. The per-node helpers (z_init_timeout / z_is_inactive_timeout) are
+ * tree-wide and live in timeout_q.h.
+ */
+#include "timeout_list.h"
+
+/*
+ * Ticks the driver may wait before the next sys_clock_announce(). The
+ * announce-range cap lives here, in the backend-independent front end, so no
+ * backend has to reproduce it: the backend only reports the delta to its
+ * earliest pending timeout via z_timeout_q_next_expiry().
+ */
 static uint32_t next_timeout(uint32_t ticks_elapsed)
 {
-	struct _timeout *to = first();
+	k_ticks_t next = z_timeout_q_next_expiry();
 	uint32_t dticks;
 
 	/*
@@ -143,7 +135,7 @@ static uint32_t next_timeout(uint32_t ticks_elapsed)
 	 * acceptable. Without sloppy idle the uptime must stay correct, so
 	 * respect the budget and keep waking up.
 	 */
-	if (to == NULL) {
+	if (next == K_TICKS_FOREVER) {
 		if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE)) {
 			return SYS_CLOCK_MAX_WAIT;
 		}
@@ -155,15 +147,15 @@ static uint32_t next_timeout(uint32_t ticks_elapsed)
 	 * the whole budget, but stop one short of SYS_CLOCK_MAX_WAIT so it is
 	 * never mistaken for the "no deadline" value above (which would drop
 	 * the timeout under sloppy idle); an intermediate announce re-evaluates.
-	 * Testing to->dticks (which may be 64-bit) against the cap also keeps
-	 * the remaining arithmetic in 32 bits.
+	 * Testing next (which may be 64-bit) against the cap also keeps the
+	 * remaining arithmetic in 32 bits.
 	 */
-	if (to->dticks >= SYS_CLOCK_MAX_WAIT) {
+	if (next >= SYS_CLOCK_MAX_WAIT) {
 		return SYS_CLOCK_MAX_WAIT - 1 - ticks_elapsed;
 	}
 
 	/* Otherwise wait until the timeout, relative to now (0 if due). */
-	dticks = (uint32_t)to->dticks;
+	dticks = (uint32_t)next;
 
 	return (dticks > ticks_elapsed) ? (dticks - ticks_elapsed) : 0;
 }
@@ -180,13 +172,13 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 	__ASSERT_NO_MSG(sys_cache_is_mem_coherent(to));
 #endif /* CONFIG_KERNEL_COHERENCE */
 
-	__ASSERT(!sys_dnode_is_linked(&to->node), "");
+	__ASSERT(z_is_inactive_timeout(to), "");
 	to->fn = fn;
 
 	K_SPINLOCK(&timeout_lock) {
-		struct _timeout *t;
-		uint32_t ticks_elapsed = 0U;
+		uint32_t ticks_elapsed;
 		bool has_elapsed = false;
+		k_ticks_t dticks;
 
 		if (Z_IS_TIMEOUT_RELATIVE(timeout)) {
 			ticks_elapsed = elapsed();
@@ -208,30 +200,16 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 			 * announce is *not* at a tick edge and still needs
 			 * the round-up.
 			 */
-			to->dticks = timeout.ticks + ticks_elapsed +
-				     (this_cpu_announcing() ? 0 : 1);
-			ticks = curr_tick + to->dticks;
+			dticks = timeout.ticks + ticks_elapsed +
+				 (this_cpu_announcing() ? 0 : 1);
+			ticks = curr_tick + dticks;
 		} else {
-			k_ticks_t dticks = Z_TICK_ABS(timeout.ticks) - curr_tick;
-
-			to->dticks = max(1, dticks);
+			dticks = Z_TICK_ABS(timeout.ticks) - curr_tick;
+			dticks = max(1, dticks);
 			ticks = timeout.ticks;
 		}
 
-		for (t = first(); t != NULL; t = next(t)) {
-			if (t->dticks > to->dticks) {
-				t->dticks -= to->dticks;
-				sys_dlist_insert(&t->node, &to->node);
-				break;
-			}
-			to->dticks -= t->dticks;
-		}
-
-		if (t == NULL) {
-			sys_dlist_append(&timeout_list, &to->node);
-		}
-
-		if (to == first() && !any_cpu_announcing()) {
+		if (z_timeout_q_insert(to, dticks) && !any_cpu_announcing()) {
 			if (!has_elapsed) {
 				/* In case of absolute timeout that is first to expire
 				 * elapsed need to be read from the system clock.
@@ -250,12 +228,11 @@ int z_try_abort_timeout(struct _timeout *to)
 	int ret = -EINVAL;
 
 	K_SPINLOCK(&timeout_lock) {
-		if (sys_dnode_is_linked(&to->node)) {
-			bool is_first = (to == first());
+		if (!z_is_inactive_timeout(to)) {
+			bool was_first = z_timeout_q_remove(to);
 
-			remove_timeout(to);
 			ret = 0;
-			if (is_first) {
+			if (was_first) {
 				sys_clock_set_timeout(next_timeout(elapsed()), false);
 			}
 		} else if (IS_ENABLED(CONFIG_SMP) && inflight_ptr() == to &&
@@ -295,28 +272,13 @@ bool z_timeout_inflight_superseded(const struct _timeout *to)
 	return superseded;
 }
 
-/* must be locked */
-static k_ticks_t timeout_rem(const struct _timeout *timeout)
-{
-	k_ticks_t ticks = 0;
-
-	for (struct _timeout *t = first(); t != NULL; t = next(t)) {
-		ticks += t->dticks;
-		if (timeout == t) {
-			break;
-		}
-	}
-
-	return ticks;
-}
-
 k_ticks_t z_timeout_remaining(const struct _timeout *timeout)
 {
 	k_ticks_t ticks = 0;
 
 	K_SPINLOCK(&timeout_lock) {
 		if (!z_is_inactive_timeout(timeout)) {
-			ticks = timeout_rem(timeout) - elapsed();
+			ticks = z_timeout_q_remainder(timeout) - elapsed();
 		}
 	}
 
@@ -331,7 +293,7 @@ k_ticks_t z_timeout_expires(const struct _timeout *timeout)
 	K_SPINLOCK(&timeout_lock) {
 		ticks = curr_tick;
 		if (!z_is_inactive_timeout(timeout)) {
-			ticks += timeout_rem(timeout);
+			ticks += z_timeout_q_remainder(timeout);
 		}
 	}
 
@@ -375,42 +337,44 @@ void sys_clock_announce_locked(uint32_t ticks, k_spinlock_key_t key)
 	announce_remaining = ticks;
 	announcing_cpu = CPU_ID;
 
-	struct _timeout *t;
+	while (announce_remaining > 0) {
+		struct _timeout *t;
+		int32_t dt = z_timeout_q_next_gap();
 
-	for (t = first();
-	     (t != NULL) && (t->dticks <= announce_remaining);
-	     t = first()) {
-		_timeout_func_t handler = t->fn;
+		if ((uint32_t)dt > announce_remaining) {
+			/* Next event is past this announce window: advance the
+			 * backend by the residual ticks without firing anything.
+			 */
+			dt = (int32_t)announce_remaining;
+		}
 
-		/* Advance curr_tick and decrement announce_remaining
-		 * together under the lock so non-announcing CPUs observe
-		 * a consistent (curr_tick + announce_remaining +
-		 * sys_clock_elapsed()) == T_real even while we drop the
-		 * lock around the handler. The "we are announcing" state
-		 * is carried by announcing_cpu, so announce_remaining
-		 * reaching 0 mid-loop is harmless: same-tick handlers'
-		 * z_add_timeout() still anchors via this_cpu_announcing(),
-		 * and another CPU's announce still folds into ours via
-		 * any_cpu_announcing() in the SMP early-return.
+		/* Advance curr_tick and decrement announce_remaining together
+		 * under the lock so non-announcing CPUs observe a consistent
+		 * (curr_tick + announce_remaining + sys_clock_elapsed()) ==
+		 * T_real even while we drop the lock around handlers. The "we
+		 * are announcing" state is carried by announcing_cpu, so
+		 * announce_remaining reaching 0 mid-loop is harmless: same-tick
+		 * handlers' z_add_timeout() still anchors via
+		 * this_cpu_announcing(), and another CPU's announce still folds
+		 * into ours via any_cpu_announcing() in the SMP early-return.
 		 */
-		curr_tick += t->dticks;
-		announce_remaining -= t->dticks;
+		z_timeout_q_advance(dt);
+		curr_tick += dt;
+		announce_remaining -= dt;
 
-		sys_dlist_remove(&t->node);
-		inflight_timeout = t;
+		/* Drain everything due at the new curr_tick. */
+		while ((t = z_timeout_q_pop_due()) != NULL) {
+			_timeout_func_t handler = t->fn;
 
-		k_spin_unlock(&timeout_lock, key);
-		handler(t);
-		key = k_spin_lock(&timeout_lock);
-		inflight_timeout = NULL;
+			inflight_timeout = t;
+
+			k_spin_unlock(&timeout_lock, key);
+			handler(t);
+			key = k_spin_lock(&timeout_lock);
+			inflight_timeout = NULL;
+		}
 	}
 
-	if (t != NULL) {
-		t->dticks -= announce_remaining;
-	}
-
-	curr_tick += announce_remaining;
-	announce_remaining = 0;
 	announcing_cpu = -1;
 
 	sys_clock_set_timeout(next_timeout(0), false);

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -109,6 +109,8 @@ static uint32_t elapsed(void)
 #include "timeout_minheap.h"
 #elif defined(CONFIG_TIMEOUT_BACKEND_WHEEL)
 #include "timeout_wheel.h"
+#elif defined(CONFIG_TIMEOUT_BACKEND_BUCKET)
+#include "timeout_bucket.h"
 #else /* CONFIG_TIMEOUT_BACKEND_DLIST */
 #include "timeout_list.h"
 #endif

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -104,7 +104,11 @@ static uint32_t elapsed(void)
  * directly. The per-node helpers (z_init_timeout / z_is_inactive_timeout) are
  * tree-wide and live in timeout_q.h.
  */
+#if defined(CONFIG_TIMEOUT_BACKEND_MINHEAP)
+#include "timeout_minheap.h"
+#else /* CONFIG_TIMEOUT_BACKEND_DLIST */
 #include "timeout_list.h"
+#endif
 
 /*
  * Ticks the driver may wait before the next sys_clock_announce(). The

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -21,7 +21,8 @@ static uint64_t curr_tick;
 
 /*
  * The timeout code shall take no locks other than its own (timeout_lock), nor
- * shall it call any other subsystem while holding this lock.
+ * shall it call any other subsystem while holding this lock. Code outside this
+ * file takes it through sys_clock_lock()/sys_clock_unlock().
  */
 static struct k_spinlock timeout_lock;
 
@@ -106,6 +107,8 @@ static uint32_t elapsed(void)
  */
 #if defined(CONFIG_TIMEOUT_BACKEND_MINHEAP)
 #include "timeout_minheap.h"
+#elif defined(CONFIG_TIMEOUT_BACKEND_WHEEL)
+#include "timeout_wheel.h"
 #else /* CONFIG_TIMEOUT_BACKEND_DLIST */
 #include "timeout_list.h"
 #endif
@@ -341,6 +344,15 @@ void sys_clock_announce_locked(uint32_t ticks, k_spinlock_key_t key)
 	announce_remaining = ticks;
 	announcing_cpu = CPU_ID;
 
+#ifdef _TIMEOUT_BACKEND_OWNS_ANNOUNCE
+	/* The backend (timer wheel) runs the firing loop itself: its per-tick
+	 * advance is a bitmap jump over empty ticks and its sift is a
+	 * time-driven event with no single timeout to drive a generic loop.
+	 * It advances curr_tick / announce_remaining and fires handlers via
+	 * the same inflight_timeout dance as below.
+	 */
+	key = z_timeout_q_announce(key);
+#else
 	while (announce_remaining > 0) {
 		struct _timeout *t;
 		int32_t dt = z_timeout_q_next_gap();
@@ -378,6 +390,7 @@ void sys_clock_announce_locked(uint32_t ticks, k_spinlock_key_t key)
 			inflight_timeout = NULL;
 		}
 	}
+#endif /* _TIMEOUT_BACKEND_OWNS_ANNOUNCE */
 
 	announcing_cpu = -1;
 

--- a/kernel/timeout_bucket.h
+++ b/kernel/timeout_bucket.h
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2026 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_KERNEL_TIMEOUT_BUCKET_H_
+#define ZEPHYR_KERNEL_TIMEOUT_BUCKET_H_
+
+/**
+ * @file
+ * @brief Single-level bucketed delta-list timeout backend (implementation).
+ *
+ * Timeouts expiring within the next CONFIG_TIMEOUT_BUCKET_LISTS ticks go into a
+ * per-tick "bucket" list (O(1) insert and remove); everything beyond goes into
+ * a single "overflow" list sorted by absolute expiry (O(n) insert, O(1)
+ * remove). A bitmap of non-empty buckets makes "ticks until the next expiry"
+ * O(1). As curr_tick crosses the end of the current bucket window, the overflow
+ * entries that have come within range are migrated into buckets.
+ *
+ * Migration is on demand against the actual next event, so an idle system with
+ * a distant timeout sleeps straight to it rather than waking periodically.
+ * Overflow stores absolute expiry, so 64-bit timeouts are required.
+ *
+ * The per-node representation is node + dticks: a bucket entry stores its
+ * bucket index (< BUCKET_LISTS) in dticks; an overflow entry stores its
+ * absolute expiry (>= BUCKET_LISTS) in dticks. The two ranges never overlap,
+ * so no flag is needed to tell them apart.
+ *
+ * Window invariant: buckets cover the half-open tick range
+ * [cursor_base, cursor_base + BUCKET_LISTS). cursor_base is kept aligned to
+ * BUCKET_LISTS, so a bucket's index equals both its tick offset within the
+ * window and (absolute expiry & (BUCKET_LISTS - 1)). curr_tick is always
+ * within the window. Everything expiring at or beyond cursor_base +
+ * BUCKET_LISTS lives in the overflow list, sorted by absolute expiry.
+ *
+ * Included only by kernel/timeout.c, after its shared state (curr_tick), so
+ * the bucket state and the z_timeout_q_*() operations below are private to
+ * that translation unit. The per-node helpers live in
+ * kernel/include/timeout_q.h.
+ */
+
+#include <zephyr/init.h>
+#include <zephyr/sys/dlist.h>
+
+#define BUCKET_LISTS CONFIG_TIMEOUT_BUCKET_LISTS
+#define BUCKET_MASK  (BUCKET_LISTS - 1)
+
+BUILD_ASSERT((BUCKET_LISTS & BUCKET_MASK) == 0,
+	     "CONFIG_TIMEOUT_BUCKET_LISTS must be a power of two");
+BUILD_ASSERT(BUCKET_LISTS <= 64, "bucket occupancy bitmap is at most 64 bits");
+
+/* Occupancy bitmap, one bit per bucket. Stay 32-bit for the common (and
+ * smallest, cheapest-to-scan on 32-bit targets) window and only widen to
+ * 64-bit when more than 32 buckets are configured.
+ */
+#if BUCKET_LISTS <= 32
+typedef uint32_t bucket_bitmap_t;
+#define bucket_bits_ctz(x) u32_count_trailing_zeros(x)
+#else
+typedef uint64_t bucket_bitmap_t;
+#define bucket_bits_ctz(x) u64_count_trailing_zeros(x)
+#endif
+#define BUCKET_BIT(n) ((bucket_bitmap_t)1 << (n))
+
+static sys_dlist_t bucket[BUCKET_LISTS];
+static sys_dlist_t overflow;        /* sorted ascending by absolute expiry */
+static bucket_bitmap_t bucket_bits; /* bit p set => bucket[p] is non-empty */
+static uint64_t cursor_base;        /* window start, aligned to BUCKET_LISTS */
+
+static int timeout_bucket_init(void)
+{
+	for (unsigned int i = 0; i < BUCKET_LISTS; i++) {
+		sys_dlist_init(&bucket[i]);
+	}
+	sys_dlist_init(&overflow);
+	bucket_bits = 0U;
+	cursor_base = 0U;
+
+	return 0;
+}
+
+/* Runs before the timer driver (PRE_KERNEL_2) and before any timeout is added.
+ * Priority 0 keeps it ahead of other PRE_KERNEL_1 initialisation.
+ */
+SYS_INIT(timeout_bucket_init, PRE_KERNEL_1, 0);
+
+static struct _timeout *overflow_head(void)
+{
+	sys_dnode_t *n = sys_dlist_peek_head(&overflow);
+
+	return (n == NULL) ? NULL : CONTAINER_OF(n, struct _timeout, node);
+}
+
+/* Ticks from curr_tick to the earliest pending expiry, or INT64_MAX if none. */
+static int64_t earliest_gap(void)
+{
+	int64_t gap = INT64_MAX;
+	unsigned int cur_off = (unsigned int)(curr_tick & BUCKET_MASK);
+
+	/* Nearest non-empty bucket strictly ahead of curr_tick in the window.
+	 * cursor_base is aligned, so bucket index == window offset.
+	 */
+	if (cur_off < (BUCKET_LISTS - 1)) {
+		bucket_bitmap_t ahead = bucket_bits & (~(bucket_bitmap_t)0 << (cur_off + 1));
+
+		if (ahead != 0U) {
+			gap = (int64_t)bucket_bits_ctz(ahead) - cur_off;
+		}
+	}
+
+	if (gap == INT64_MAX) {
+		struct _timeout *t = overflow_head();
+
+		if (t != NULL) {
+			gap = (int64_t)t->dticks - (int64_t)curr_tick;
+		}
+	}
+
+	return gap;
+}
+
+static bool z_timeout_q_insert(struct _timeout *to, k_ticks_t dticks)
+{
+	uint64_t expiry = curr_tick + (uint64_t)dticks;
+	int64_t old_gap = earliest_gap();
+
+	if (expiry < cursor_base + BUCKET_LISTS) {
+		unsigned int idx = (unsigned int)(expiry & BUCKET_MASK);
+
+		to->dticks = idx;
+		bucket_bits |= BUCKET_BIT(idx);
+		sys_dlist_append(&bucket[idx], &to->node);
+	} else {
+		/* Overflow: keep sorted ascending by absolute expiry. Insert
+		 * after any equal-keyed entries so same-tick order stays FIFO.
+		 */
+		struct _timeout *t;
+
+		to->dticks = (k_ticks_t)expiry;
+		SYS_DLIST_FOR_EACH_CONTAINER(&overflow, t, node) {
+			if ((uint64_t)t->dticks > expiry) {
+				sys_dlist_insert(&t->node, &to->node);
+				return (int64_t)dticks < old_gap;
+			}
+		}
+		sys_dlist_append(&overflow, &to->node);
+	}
+
+	return (int64_t)dticks < old_gap;
+}
+
+static k_ticks_t z_timeout_q_remainder(const struct _timeout *to)
+{
+	if ((uint64_t)to->dticks < BUCKET_LISTS) {
+		/* Bucket entry: reconstruct its absolute expiry, the unique
+		 * tick in the window whose low bits are the bucket index.
+		 */
+		uint64_t off = ((uint64_t)to->dticks - cursor_base) & BUCKET_MASK;
+
+		return (k_ticks_t)((cursor_base + off) - curr_tick);
+	}
+
+	return (k_ticks_t)((uint64_t)to->dticks - curr_tick);
+}
+
+static bool z_timeout_q_remove(struct _timeout *to)
+{
+	bool was_first = (z_timeout_q_remainder(to) <= earliest_gap());
+
+	if ((uint64_t)to->dticks < BUCKET_LISTS) {
+		unsigned int idx = (unsigned int)to->dticks;
+
+		sys_dlist_remove(&to->node);
+		if (sys_dlist_is_empty(&bucket[idx])) {
+			bucket_bits &= ~BUCKET_BIT(idx);
+		}
+	} else {
+		/* Overflow stores absolute expiry (not a delta), so removal
+		 * needs no successor fix-up.
+		 */
+		sys_dlist_remove(&to->node);
+	}
+
+	return was_first;
+}
+
+/* Ticks from curr_tick to the earliest pending timeout, or K_TICKS_FOREVER if
+ * none. The announce-range cap is applied centrally by next_timeout() in
+ * timeout.c.
+ */
+static k_ticks_t z_timeout_q_next_expiry(void)
+{
+	int64_t gap = earliest_gap();
+
+	return (gap == INT64_MAX) ? K_TICKS_FOREVER : (k_ticks_t)gap;
+}
+
+static int32_t z_timeout_q_next_gap(void)
+{
+	int64_t gap = earliest_gap();
+
+	return (gap == INT64_MAX) ? INT32_MAX : (int32_t)MIN(gap, (int64_t)INT32_MAX);
+}
+
+static void z_timeout_q_advance(int32_t dt)
+{
+	uint64_t new_curr = curr_tick + (uint64_t)dt;
+
+	if (new_curr < cursor_base + BUCKET_LISTS) {
+		/* Still inside the current window: nothing to migrate. */
+		return;
+	}
+
+	/* Crossed the window. The loop only advances past the boundary when no
+	 * bucket lies ahead (next_gap then came from overflow), so every bucket
+	 * is empty here. Re-base the window onto curr_tick's new position and
+	 * migrate the overflow entries that have come within range.
+	 */
+	cursor_base = new_curr & ~(uint64_t)BUCKET_MASK;
+	bucket_bits = 0U;
+
+	struct _timeout *t;
+
+	while ((t = overflow_head()) != NULL &&
+	       (uint64_t)t->dticks < cursor_base + BUCKET_LISTS) {
+		unsigned int idx = (unsigned int)((uint64_t)t->dticks & BUCKET_MASK);
+
+		sys_dlist_remove(&t->node);
+		t->dticks = idx;
+		bucket_bits |= BUCKET_BIT(idx);
+		sys_dlist_append(&bucket[idx], &t->node);
+	}
+}
+
+static struct _timeout *z_timeout_q_pop_due(void)
+{
+	unsigned int idx = (unsigned int)(curr_tick & BUCKET_MASK);
+	sys_dnode_t *n = sys_dlist_peek_head(&bucket[idx]);
+	struct _timeout *t;
+
+	if (n == NULL) {
+		return NULL;
+	}
+
+	/* All entries in bucket[curr_tick & MASK] expire exactly at curr_tick. */
+	t = CONTAINER_OF(n, struct _timeout, node);
+	sys_dlist_remove(&t->node);
+	if (sys_dlist_is_empty(&bucket[idx])) {
+		bucket_bits &= ~BUCKET_BIT(idx);
+	}
+
+	return t;
+}
+
+#endif /* ZEPHYR_KERNEL_TIMEOUT_BUCKET_H_ */

--- a/kernel/timeout_list.h
+++ b/kernel/timeout_list.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_KERNEL_TIMEOUT_LIST_H_
+#define ZEPHYR_KERNEL_TIMEOUT_LIST_H_
+
+/**
+ * @file
+ * @brief Sorted delta-list timeout backend (implementation).
+ *
+ * This is the original (and default) timeout queue: a doubly linked list
+ * sorted by expiry, where each node stores its expiry as a delta (dticks)
+ * relative to its predecessor. Insertion is O(n), head removal is O(1).
+ *
+ * Included only by kernel/timeout.c, after its shared state, so the queue
+ * instance and the z_timeout_q_*() operations below are private to that
+ * translation unit. The per-node helpers live in kernel/include/timeout_q.h.
+ */
+
+#include <zephyr/sys/dlist.h>
+
+static sys_dlist_t timeout_list = SYS_DLIST_STATIC_INIT(&timeout_list);
+
+static inline struct _timeout *z_timeout_q_first(void)
+{
+	sys_dnode_t *t = sys_dlist_peek_head(&timeout_list);
+
+	return (t == NULL) ? NULL : CONTAINER_OF(t, struct _timeout, node);
+}
+
+static inline struct _timeout *z_timeout_q_next(struct _timeout *t)
+{
+	sys_dnode_t *n = sys_dlist_peek_next(&timeout_list, &t->node);
+
+	return (n == NULL) ? NULL : CONTAINER_OF(n, struct _timeout, node);
+}
+
+/* Insert @to so that it expires @dticks ticks after curr_tick. Returns true
+ * if @to is now the earliest pending timeout.
+ */
+static inline bool z_timeout_q_insert(struct _timeout *to, k_ticks_t dticks)
+{
+	struct _timeout *t;
+
+	to->dticks = dticks;
+	for (t = z_timeout_q_first(); t != NULL; t = z_timeout_q_next(t)) {
+		if (t->dticks > to->dticks) {
+			t->dticks -= to->dticks;
+			sys_dlist_insert(&t->node, &to->node);
+			return z_timeout_q_first() == to;
+		}
+		to->dticks -= t->dticks;
+	}
+
+	sys_dlist_append(&timeout_list, &to->node);
+	return z_timeout_q_first() == to;
+}
+
+/* Remove an arbitrary timeout from the queue, absorbing its delta into the
+ * successor so the remaining deltas stay valid. Returns true if @to was the
+ * earliest pending timeout. Used only by the abort path, never from announce.
+ */
+static inline bool z_timeout_q_remove(struct _timeout *to)
+{
+	bool was_first = (z_timeout_q_first() == to);
+	struct _timeout *n = z_timeout_q_next(to);
+
+	if (n != NULL) {
+		n->dticks += to->dticks;
+	}
+	sys_dlist_remove(&to->node);
+
+	return was_first;
+}
+
+/* Ticks from curr_tick until @to expires. Caller holds timeout_lock and has
+ * verified that @to is active.
+ */
+static inline k_ticks_t z_timeout_q_remainder(const struct _timeout *to)
+{
+	k_ticks_t ticks = 0;
+
+	for (struct _timeout *t = z_timeout_q_first(); t != NULL;
+	     t = z_timeout_q_next(t)) {
+		ticks += t->dticks;
+		if (to == t) {
+			break;
+		}
+	}
+
+	return ticks;
+}
+
+/* Ticks from (curr_tick + ticks_elapsed) until the next expiry, clamped to
+ * int32 / SYS_CLOCK_MAX_WAIT. Empty queue yields SYS_CLOCK_MAX_WAIT.
+ */
+/* Ticks from curr_tick to the earliest pending timeout, or K_TICKS_FOREVER if
+ * the queue is empty. The announce-range cap is applied centrally by
+ * next_timeout() in timeout.c.
+ */
+static inline k_ticks_t z_timeout_q_next_expiry(void)
+{
+	struct _timeout *to = z_timeout_q_first();
+
+	return (to == NULL) ? K_TICKS_FOREVER : to->dticks;
+}
+
+/* --- announce-loop helpers (see sys_clock_announce_locked() in timeout.c) --- */
+
+/* Ticks from curr_tick until the next event the announce loop must act on
+ * (here: the earliest expiry). A value larger than any announce window when
+ * the queue is empty.
+ */
+static inline int32_t z_timeout_q_next_gap(void)
+{
+	struct _timeout *t = z_timeout_q_first();
+
+	return (t == NULL) ? INT32_MAX : (int32_t)MIN((int64_t)t->dticks, INT32_MAX);
+}
+
+/* Advance backend state by @dt ticks. For the delta list this shifts the head
+ * closer to expiry; a head whose gap is fully consumed reads dticks == 0 and
+ * is then drained by z_timeout_q_pop_due(). The caller advances curr_tick.
+ */
+static inline void z_timeout_q_advance(int32_t dt)
+{
+	struct _timeout *t = z_timeout_q_first();
+
+	if (t != NULL) {
+		t->dticks -= dt;
+	}
+}
+
+/* Pop and return one timeout that is due at the current curr_tick, or NULL if
+ * none is due right now. Strict head-only removal with no delta absorption:
+ * z_timeout_q_advance() has already brought the head's dticks to 0, and
+ * curr_tick was advanced to match, so the successor's stored delta stays
+ * valid without propagation.
+ */
+static inline struct _timeout *z_timeout_q_pop_due(void)
+{
+	struct _timeout *t = z_timeout_q_first();
+
+	if ((t == NULL) || (t->dticks != 0)) {
+		return NULL;
+	}
+
+	sys_dlist_remove(&t->node);
+
+	return t;
+}
+
+#endif /* ZEPHYR_KERNEL_TIMEOUT_LIST_H_ */

--- a/kernel/timeout_minheap.h
+++ b/kernel/timeout_minheap.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Aerlync Labs Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_KERNEL_TIMEOUT_MINHEAP_H_
+#define ZEPHYR_KERNEL_TIMEOUT_MINHEAP_H_
+
+/**
+ * @file
+ * @brief Binary min-heap timeout backend (implementation).
+ *
+ * Pending timeouts are kept in a binary min-heap keyed on absolute expiry
+ * tick (struct _timeout's abs_ticks). Insertion and arbitrary removal are
+ * O(log n); the earliest timeout is always at the root. A timeout that is
+ * not queued has heap_handle.idx == 0.
+ *
+ * Included only by kernel/timeout.c, after its shared state (curr_tick), so
+ * the heap instance and the z_timeout_q_*() operations below are private to
+ * that translation unit. The per-node helpers live in
+ * kernel/include/timeout_q.h.
+ */
+
+#include <zephyr/sys/min_heap_ref.h>
+
+static int timeout_cmp(const struct min_heap_handle *a, const struct min_heap_handle *b)
+{
+	const struct _timeout *ta = CONTAINER_OF(a, struct _timeout, heap_handle);
+	const struct _timeout *tb = CONTAINER_OF(b, struct _timeout, heap_handle);
+
+	if (ta->abs_ticks < tb->abs_ticks) {
+		return -1;
+	}
+
+	return (ta->abs_ticks > tb->abs_ticks) ? 1 : 0;
+}
+
+MIN_HEAP_REF_DEFINE_STATIC(timeout_heap_inst, CONFIG_TIMEOUT_HEAP_MAX_ENTRIES, timeout_cmp);
+
+static inline struct _timeout *z_timeout_q_root(void)
+{
+	const struct min_heap_handle *h = min_heap_ref_peek(&timeout_heap_inst);
+
+	return (h == NULL) ? NULL : CONTAINER_OF(h, struct _timeout, heap_handle);
+}
+
+/* Insert @to so that it expires @dticks ticks after curr_tick. Returns true
+ * if @to is now the earliest pending timeout (heap root).
+ */
+static inline bool z_timeout_q_insert(struct _timeout *to, k_ticks_t dticks)
+{
+	to->abs_ticks = (int64_t)curr_tick + dticks;
+
+	if (unlikely(min_heap_ref_push(&timeout_heap_inst, &to->heap_handle) != 0)) {
+		/*
+		 * Heap overflow is always a configuration error: there is no
+		 * graceful way to drop a kernel timeout. Increase
+		 * CONFIG_TIMEOUT_HEAP_MAX_ENTRIES.
+		 */
+		k_panic();
+	}
+
+	return to->heap_handle.idx == 1U;
+}
+
+/* Remove an arbitrary timeout from the heap. Returns true if it was the
+ * earliest pending timeout. Used only by the abort path, never from announce.
+ */
+static inline bool z_timeout_q_remove(struct _timeout *to)
+{
+	bool was_first = (to->heap_handle.idx == 1U);
+
+	(void)min_heap_ref_remove(&timeout_heap_inst, &to->heap_handle);
+
+	return was_first;
+}
+
+/* Ticks from curr_tick until @to expires. Caller holds timeout_lock and has
+ * verified that @to is active.
+ */
+static inline k_ticks_t z_timeout_q_remainder(const struct _timeout *to)
+{
+	return (k_ticks_t)(to->abs_ticks - (int64_t)curr_tick);
+}
+
+/* Ticks from curr_tick to the earliest pending timeout, or K_TICKS_FOREVER if
+ * the heap is empty. The announce-range cap is applied centrally by
+ * next_timeout() in timeout.c.
+ */
+static inline k_ticks_t z_timeout_q_next_expiry(void)
+{
+	struct _timeout *t = z_timeout_q_root();
+
+	return (t == NULL) ? K_TICKS_FOREVER
+			   : (k_ticks_t)(t->abs_ticks - (int64_t)curr_tick);
+}
+
+/* --- announce-loop helpers (see sys_clock_announce_locked() in timeout.c) --- */
+
+/* Ticks from curr_tick until the earliest expiry. A value larger than any
+ * announce window when the heap is empty.
+ */
+static inline int32_t z_timeout_q_next_gap(void)
+{
+	struct _timeout *t = z_timeout_q_root();
+
+	if (t == NULL) {
+		return INT32_MAX;
+	}
+
+	return (int32_t)MIN(t->abs_ticks - (int64_t)curr_tick, (int64_t)INT32_MAX);
+}
+
+/* Advance backend state by @dt ticks. The heap stores absolute expiry ticks,
+ * so the caller's curr_tick += dt is all the advancing required here.
+ */
+static inline void z_timeout_q_advance(int32_t dt)
+{
+	ARG_UNUSED(dt);
+}
+
+/* Pop and return one timeout that is due at the current curr_tick, or NULL if
+ * none is due right now. Tied timeouts share the same abs_ticks and are
+ * drained by successive calls.
+ */
+static inline struct _timeout *z_timeout_q_pop_due(void)
+{
+	struct _timeout *t = z_timeout_q_root();
+
+	if ((t == NULL) || (t->abs_ticks > (int64_t)curr_tick)) {
+		return NULL;
+	}
+
+	return CONTAINER_OF(min_heap_ref_pop(&timeout_heap_inst), struct _timeout, heap_handle);
+}
+
+#endif /* ZEPHYR_KERNEL_TIMEOUT_MINHEAP_H_ */

--- a/kernel/timeout_wheel.h
+++ b/kernel/timeout_wheel.h
@@ -1,0 +1,543 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2026 Peter Mitsis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_KERNEL_TIMEOUT_WHEEL_H_
+#define ZEPHYR_KERNEL_TIMEOUT_WHEEL_H_
+
+/**
+ * @file
+ * @brief Hierarchical timer-wheel timeout backend (implementation).
+ *
+ * Timeouts are bucketed by how far in the future they expire:
+ *   - "soon"    : one list per tick for the next NUM_SOON_LISTS ticks (O(1))
+ *   - "later"   : one list per NUM_SOON_LISTS-tick band (O(1))
+ *   - "distant" : a sorted delta list for everything beyond (O(n), but the
+ *                 list is kept short)
+ * Every NUM_SOON_LISTS ticks the announce path sifts the current "later" band
+ * down into "soon" and refills it from "distant". Insertion into soon/later is
+ * O(1); the win is large when many short-lived timeouts are pending.
+ *
+ * The wheel provides its own announce loop (z_timeout_q_announce, selected by
+ * _TIMEOUT_BACKEND_OWNS_ANNOUNCE) rather than the generic
+ * next_gap/advance/pop_due primitives: its per-tick advance is a bitmap scan
+ * that jumps over empty ticks, and its sift is a time-driven event not tied to
+ * any single timeout.
+ *
+ * Included only by kernel/timeout.c, after its shared state, so the wheel
+ * state, the z_timeout_q_*() operations and the backend-owned announce loop
+ * below are private to that translation unit and reach the front end's shared
+ * state (curr_tick, announce_remaining, inflight_timeout) directly. The
+ * per-node helpers live in kernel/include/timeout_q.h.
+ */
+
+#include <zephyr/init.h>
+#include <zephyr/sys/dlist.h>
+
+/* Per-node flag bits (struct _timeout's flags field): which tier the timeout
+ * currently lives in, so removal can maintain the soon-list occupancy bitmap.
+ */
+#define _TIMEOUT_FLAG_TIMER_WHEEL_SOON  BIT(0)
+#define _TIMEOUT_FLAG_TIMER_WHEEL_LATER BIT(1)
+
+/* This backend supplies its own announce loop. */
+#define _TIMEOUT_BACKEND_OWNS_ANNOUNCE 1
+
+#define NUM_SOON_LISTS  32
+#define NUM_LATER_LISTS 32
+
+struct timeout_wheel {
+	sys_dlist_t soon[NUM_SOON_LISTS];   /* timeouts expiring soon lists */
+	sys_dlist_t later[NUM_LATER_LISTS]; /* timeouts expiring later lists */
+	sys_dlist_t distant;                /* timeouts expiring far in future */
+	sys_dlist_t soon_defer;             /* special soon list */
+	uint32_t    soon_bits;              /* Set bit indicates list in use */
+	uint32_t    soon_index;             /* Current soon list index */
+	uint32_t    later_index;
+	uint32_t    announcing;             /* 1: Announcing soon_index, else 0 */
+	uint32_t    sifted;                 /* 1: Sifted, else 0 */
+};
+
+static struct timeout_wheel wheel;
+
+static int timeout_wheel_init(void)
+{
+	unsigned int i;
+
+	for (i = 0; i < NUM_SOON_LISTS; i++) {
+		sys_dlist_init(&wheel.soon[i]);
+	}
+
+	for (i = 0; i < NUM_LATER_LISTS; i++) {
+		sys_dlist_init(&wheel.later[i]);
+	}
+
+	sys_dlist_init(&wheel.distant);
+	sys_dlist_init(&wheel.soon_defer);
+
+	wheel.soon_bits = 0;
+	wheel.soon_index = NUM_SOON_LISTS - 1;
+	wheel.later_index = 0;
+	wheel.announcing = 0;
+	wheel.sifted = 1;
+
+	return 0;
+}
+
+/* Initialize the wheel before the timer driver (PRE_KERNEL_2) and before any
+ * timeout can be added. Priority 0 keeps it ahead of other PRE_KERNEL_1 init.
+ */
+SYS_INIT(timeout_wheel_init, PRE_KERNEL_1, 0);
+
+static inline void timeout_wheel_clear_flags(struct _timeout *to)
+{
+	to->flags &= ~(_TIMEOUT_FLAG_TIMER_WHEEL_SOON |
+		       _TIMEOUT_FLAG_TIMER_WHEEL_LATER);
+}
+
+/* Return the last item in the specified list, or NULL if the list is empty. */
+static struct _timeout *timeout_wheel_last_in_list(sys_dlist_t *list)
+{
+	sys_dnode_t *t = sys_dlist_peek_tail(list);
+
+	return (t == NULL) ? NULL : CONTAINER_OF(t, struct _timeout, node);
+}
+
+/* Return the first timeout expiring in the specified list, or NULL. */
+static struct _timeout *timeout_wheel_first_in_list(sys_dlist_t *list)
+{
+	sys_dnode_t *t = sys_dlist_peek_head(list);
+
+	return (t == NULL) ? NULL : CONTAINER_OF(t, struct _timeout, node);
+}
+
+/*
+ * Get the first timeout in the wheel from its 'soon' lists. NULL means that
+ * the first timeout is the sift operation which always implicitly exists
+ * within the final 'soon' list.
+ */
+static struct _timeout *timeout_wheel_first(void)
+{
+	uint32_t bitmap;
+	unsigned int index;
+	sys_dnode_t *t;
+
+	bitmap = wheel.soon_bits | BIT(NUM_SOON_LISTS - 1);
+	if (wheel.sifted == 0) {
+		bitmap &= ~(BIT(wheel.soon_index) - 1);
+	}
+	index = u32_count_trailing_zeros(bitmap);
+
+	t = sys_dlist_peek_head(&wheel.soon[index]);
+
+	return (t == NULL) ? NULL : CONTAINER_OF(t, struct _timeout, node);
+}
+
+/* Return the timeout following @a t expiring "distantly". */
+static struct _timeout *timeout_wheel_next_distant(struct _timeout *t)
+{
+	sys_dnode_t *n = sys_dlist_peek_next(&wheel.distant, &t->node);
+
+	return (n == NULL) ? NULL : CONTAINER_OF(n, struct _timeout, node);
+}
+
+/*
+ * Prepend a timeout to the appropriate "soon" list. Only called during sifting
+ * after the timeout had been removed from a 'later' list, where its 'dticks'
+ * field was a composite value. Prepending preserves time ordering.
+ */
+static void timeout_wheel_prepend_soon(struct _timeout *to)
+{
+	unsigned int index = to->dticks & (NUM_SOON_LISTS - 1);
+
+	wheel.soon_bits |= BIT(index);
+	sys_dlist_prepend(&wheel.soon[index], &to->node);
+	to->flags |= _TIMEOUT_FLAG_TIMER_WHEEL_SOON;
+	to->dticks = index;
+}
+
+/*
+ * Append a timeout to the appropriate "soon" list, recording the list index
+ * in the timeout's 'dticks' field.
+ */
+static void timeout_wheel_append_soon(struct _timeout *to)
+{
+	unsigned int index;
+
+	index = (to->dticks + wheel.soon_index) & (NUM_SOON_LISTS - 1);
+	to->dticks = index;
+
+	wheel.soon_bits |= BIT(index);
+	sys_dlist_append(&wheel.soon[index], &to->node);
+	to->flags |= _TIMEOUT_FLAG_TIMER_WHEEL_SOON;
+}
+
+/*
+ * Append a timeout to the soon deferred list. Special case for timeouts that
+ * are exactly NUM_SOON_LISTS into the future while the system is announcing:
+ * they must not get mixed with the currently-expiring rotation. They move into
+ * the appropriate 'soon' list at the end of the announce.
+ */
+static void timeout_wheel_append_soon_defer(struct _timeout *to)
+{
+	unsigned int index;
+
+	index = (to->dticks + wheel.soon_index) & (NUM_SOON_LISTS - 1);
+	to->dticks = index + NUM_SOON_LISTS;
+
+	sys_dlist_append(&wheel.soon_defer, &to->node);
+	to->flags |= _TIMEOUT_FLAG_TIMER_WHEEL_SOON;
+}
+
+/*
+ * Append a timeout to the appropriate "later" list. The 'dticks' field is set
+ * to identify both the eventual 'soon' list and the 'later' list it goes to.
+ */
+static void timeout_wheel_append_later(struct _timeout *to)
+{
+	uint32_t position;
+	uint32_t soon;
+	uint32_t later;
+
+	position = to->dticks + wheel.soon_index - NUM_SOON_LISTS;
+
+	soon = position & (NUM_SOON_LISTS - 1);
+	later = ((position / NUM_SOON_LISTS) + wheel.later_index -
+		 wheel.sifted) & (NUM_LATER_LISTS - 1);
+
+	to->dticks = (later * NUM_SOON_LISTS) + soon;
+	to->flags |= _TIMEOUT_FLAG_TIMER_WHEEL_LATER;
+
+	sys_dlist_append(&wheel.later[later], &to->node);
+}
+
+/*
+ * Insert a timeout into the "distant" list, an expiry-ordered delta list. For
+ * good performance the distant list should stay short.
+ */
+static void timeout_wheel_insert_distant(struct _timeout *to, uint32_t cutoff)
+{
+	struct _timeout *t;
+
+	to->dticks -= cutoff;
+
+	for (t = timeout_wheel_first_in_list(&wheel.distant);
+	     t != NULL; t = timeout_wheel_next_distant(t)) {
+		if (t->dticks > to->dticks) {
+			t->dticks -= to->dticks;
+			sys_dlist_insert(&t->node, &to->node);
+			break;
+		}
+		to->dticks -= t->dticks;
+	}
+
+	if (t == NULL) {
+		sys_dlist_append(&wheel.distant, &to->node);
+	}
+}
+
+/*
+ * Add a timeout to the wheel (with to->dticks already set to its tick delta
+ * from curr_tick). It is never placed into the 'soon_index' list.
+ */
+static void timeout_wheel_add_timeout(struct _timeout *to)
+{
+	__ASSERT_NO_MSG(to->dticks != 0);
+
+	if (to->dticks <= (NUM_SOON_LISTS - wheel.announcing)) {
+		timeout_wheel_append_soon(to);
+		return;
+	}
+
+	if (to->dticks == NUM_SOON_LISTS) {
+		timeout_wheel_append_soon_defer(to);
+		return;
+	}
+
+	uint32_t cutoff;
+
+	cutoff = ((NUM_LATER_LISTS + wheel.sifted + 1) *
+		  NUM_SOON_LISTS) - wheel.soon_index - 1;
+	if (to->dticks <= cutoff) {
+		timeout_wheel_append_later(to);
+		return;
+	}
+
+	timeout_wheel_insert_distant(to, cutoff);
+}
+
+/* Remove the specified timeout. */
+static void timeout_wheel_remove_timeout(struct _timeout *to)
+{
+	sys_dlist_remove(&to->node);
+
+	if (to->flags & _TIMEOUT_FLAG_TIMER_WHEEL_SOON) {
+		unsigned int index = to->dticks;
+
+		/* soon_defer entries carry index + NUM_SOON_LISTS and own no
+		 * soon_bits bit; only true soon-list entries do.
+		 */
+		if (index < NUM_SOON_LISTS &&
+		    sys_dlist_is_empty(&wheel.soon[index])) {
+			wheel.soon_bits &= ~BIT(index);
+		}
+	}
+
+	timeout_wheel_clear_flags(to);
+}
+
+/* Calculate the number of ticks until the specified timeout expires. */
+static k_ticks_t timeout_wheel_remainder(const struct _timeout *to)
+{
+	if (to->flags & _TIMEOUT_FLAG_TIMER_WHEEL_SOON) {
+		uint32_t now = wheel.soon_index;
+		uint32_t idx = to->dticks;
+
+		if (idx == now) {
+			return (1U - wheel.announcing) * NUM_SOON_LISTS;
+		} else if (idx >= NUM_SOON_LISTS) {
+			/* Special case if querying item in 'soon_defer' list */
+			return NUM_SOON_LISTS;
+		}
+
+		return (idx - now) & (NUM_SOON_LISTS - 1U);
+	}
+
+	if (to->flags & _TIMEOUT_FLAG_TIMER_WHEEL_LATER) {
+		uint32_t later_slot = to->dticks / NUM_SOON_LISTS;
+		uint32_t soon_index = to->dticks & (NUM_SOON_LISTS - 1U);
+
+		/* later slots ahead until the bucket is sifted */
+		uint32_t slots_ahead = ((later_slot - wheel.later_index) &
+					(NUM_LATER_LISTS - 1U)) + wheel.sifted;
+
+		return (k_ticks_t)((NUM_SOON_LISTS - wheel.soon_index) +
+				   (slots_ahead * NUM_SOON_LISTS) + soon_index);
+	}
+
+	struct _timeout *t;
+	k_ticks_t remaining;
+
+	remaining  = ((NUM_LATER_LISTS + wheel.sifted + 1) *
+		      NUM_SOON_LISTS) - wheel.soon_index - 1;
+
+	for (t = timeout_wheel_first_in_list(&wheel.distant);
+	     t != NULL; t = timeout_wheel_next_distant(t)) {
+		remaining += t->dticks;
+		if (t == to) {
+			break;
+		}
+	}
+
+	return remaining;
+}
+
+/*
+ * Sift from a 'later' list down into the appropriate 'soon' lists. Timeouts
+ * are prepended to the 'soon' list to preserve time ordering.
+ */
+static void timeout_wheel_sift_down_to_soon(void)
+{
+	sys_dlist_t *list;
+	struct _timeout *t;
+
+	list = &wheel.later[wheel.later_index];
+	while ((t = timeout_wheel_last_in_list(list)) != NULL) {
+		sys_dlist_remove(&t->node);
+		timeout_wheel_clear_flags(t);
+		timeout_wheel_prepend_soon(t);
+	}
+}
+
+/*
+ * Sift from the 'distant' list down into the appropriate 'later' list. Two
+ * steps: prepare (massage dticks/flags of the leading distant timeouts) then
+ * move them en masse into the 'later' list.
+ */
+static void timeout_wheel_sift_down_to_later(void)
+{
+	struct _timeout *t;
+	int64_t sift_ticks = NUM_SOON_LISTS;
+	struct _timeout *head = timeout_wheel_first_in_list(&wheel.distant);
+	struct _timeout *tail = NULL;
+	int new_dticks = wheel.later_index * NUM_SOON_LISTS;
+
+	for (t = head; t != NULL; t = timeout_wheel_next_distant(t)) {
+		if (t->dticks >= sift_ticks) {
+			t->dticks -= sift_ticks;
+			break;
+		}
+
+		sift_ticks -= t->dticks;
+		new_dticks += t->dticks;
+
+		t->flags |= _TIMEOUT_FLAG_TIMER_WHEEL_LATER;
+		t->dticks = new_dticks;
+		tail = t;
+	}
+
+	if (tail != NULL) {
+		sys_dlist_range_prepend(&wheel.later[wheel.later_index],
+					&head->node, &tail->node);
+	}
+}
+
+/*
+ * Sifting runs every NUM_SOON_LISTS ticks: first move the current 'later' list
+ * into the 'soon' lists, freeing it to receive the next batch sifted from
+ * 'distant'.
+ */
+static void timeout_wheel_sift_down(void)
+{
+	timeout_wheel_sift_down_to_soon();
+
+	timeout_wheel_sift_down_to_later();
+
+	/* Advance to the next 'later' list */
+	wheel.later_index++;
+	wheel.later_index &= (NUM_LATER_LISTS - 1);
+	wheel.sifted = 1;
+}
+
+/*
+ * Announce all the timeouts expiring "now" (at soon_index). curr_tick has been
+ * advanced. Handlers fire with the lock dropped; inflight_timeout tracks
+ * the in-flight timeout so aborts race correctly.
+ */
+static k_spinlock_key_t timeout_wheel_announce_now(k_spinlock_key_t key)
+{
+	struct _timeout *t;
+	uint32_t index = wheel.soon_index;
+
+	wheel.sifted = 0;
+	wheel.announcing = 1;
+	for (t = timeout_wheel_first_in_list(&wheel.soon[index]);
+	     t != NULL;
+	     t = timeout_wheel_first_in_list(&wheel.soon[index])) {
+		sys_dlist_remove(&t->node);
+		timeout_wheel_clear_flags(t);
+
+		inflight_timeout = t;
+		k_spin_unlock(&timeout_lock, key);
+		t->fn(t);
+		key = k_spin_lock(&timeout_lock);
+		inflight_timeout = NULL;
+	}
+	wheel.announcing = 0;
+
+	/*
+	 * The 'soon_index' slot is now drained, so 'soon deferred' timeouts
+	 * (exactly NUM_SOON_LISTS into the future) can move into their slots.
+	 */
+	for (t = timeout_wheel_first_in_list(&wheel.soon_defer);
+	     t != NULL;
+	     t = timeout_wheel_first_in_list(&wheel.soon_defer)) {
+		sys_dlist_remove(&t->node);
+		/* Correct the dticks to be the appropriate 'soon' list index */
+		t->dticks &= (NUM_SOON_LISTS - 1);
+		wheel.soon_bits |= BIT(t->dticks);
+		sys_dlist_append(&wheel.soon[t->dticks], &t->node);
+	}
+
+	if (index == (NUM_SOON_LISTS - 1)) {
+		timeout_wheel_sift_down();
+	}
+
+	return key;
+}
+
+/*
+ * Backend interface (see kernel/timeout.c).
+ */
+
+static bool z_timeout_q_insert(struct _timeout *to, k_ticks_t dticks)
+{
+	to->dticks = dticks;
+	timeout_wheel_add_timeout(to);
+
+	return to == timeout_wheel_first();
+}
+
+static bool z_timeout_q_remove(struct _timeout *to)
+{
+	bool was_first = (to == timeout_wheel_first());
+
+	timeout_wheel_remove_timeout(to);
+
+	return was_first;
+}
+
+static k_ticks_t z_timeout_q_remainder(const struct _timeout *to)
+{
+	return timeout_wheel_remainder(to);
+}
+
+/*
+ * Ticks from curr_tick to the next 'soon' timeout, between 1 and
+ * NUM_SOON_LISTS (the 'soon_index' list is excluded as it is timing out).
+ * Never K_TICKS_FOREVER: a sift is always pending, which is why the wheel
+ * wakes a tickless-idle CPU at least every NUM_SOON_LISTS ticks. The
+ * announce-range cap is applied centrally by next_timeout() in timeout.c.
+ */
+static k_ticks_t z_timeout_q_next_expiry(void)
+{
+	struct _timeout *to = timeout_wheel_first();
+	int64_t dticks = (to != NULL) ? to->dticks : (NUM_SOON_LISTS - 1);
+
+	dticks = ((NUM_SOON_LISTS - 1 - wheel.soon_index + dticks) &
+		  (NUM_SOON_LISTS - 1)) + 1;
+
+	return (k_ticks_t)dticks;
+}
+
+/* Backend-owned announce loop (see _TIMEOUT_BACKEND_OWNS_ANNOUNCE). Drains all
+ * timeouts due within announce_remaining ticks, firing each handler with the
+ * subsystem lock dropped; advances curr_tick and announce_remaining. Returns
+ * the (possibly re-acquired) spinlock key.
+ */
+static k_spinlock_key_t z_timeout_q_announce(k_spinlock_key_t key)
+{
+	uint32_t mask;
+	int      next;    /* Index of next 'soon' list to expire */
+	int      num_ticks_to_advance;
+	int      correction;  /* NUM_SOON_LISTS or 0 */
+	uint32_t bits;
+
+	while (announce_remaining > 0) {
+
+		mask = 0xFFFFFFFF << ((wheel.soon_index + 1) & (NUM_SOON_LISTS - 1));
+		bits = wheel.soon_bits | BIT(NUM_SOON_LISTS - 1);
+		next = u32_count_trailing_zeros(mask & bits);
+		correction = ((wheel.soon_index + 1) / NUM_SOON_LISTS) * NUM_SOON_LISTS;
+		num_ticks_to_advance = next + correction - wheel.soon_index;
+
+		if (num_ticks_to_advance > announce_remaining) {
+			curr_tick += announce_remaining;
+			wheel.sifted = 0;
+			wheel.soon_index += announce_remaining;
+			wheel.soon_index &= (NUM_SOON_LISTS - 1);
+
+			announce_remaining = 0;
+			break;
+		}
+
+		/*
+		 * 1. Advance to the next tick to process.
+		 * 2. Clear its bit in the 'soon_bits'.
+		 */
+		wheel.soon_index += num_ticks_to_advance;
+		wheel.soon_index &= (NUM_SOON_LISTS - 1);
+		wheel.soon_bits &= ~BIT(wheel.soon_index);
+
+		curr_tick += num_ticks_to_advance;
+		key = timeout_wheel_announce_now(key);
+		announce_remaining -= num_ticks_to_advance;
+	}
+
+	return key;
+}
+
+#endif /* ZEPHYR_KERNEL_TIMEOUT_WHEEL_H_ */

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -76,14 +76,14 @@ void z_timer_expiration_handler(struct _timeout *t)
 	k_spinlock_key_t key = k_spin_lock(&timer_lock);
 
 	/* A same-CPU IRQ may have raced with our dispatch between
-	 * sys_clock_announce() popping us off the list and us taking
+	 * sys_clock_announce() popping us off the queue and us taking
 	 * timer.c::lock. Two cases:
-	 *  - The timer was restarted (z_add_timeout re-linked the node):
-	 *    sys_dnode_is_linked() is true, the new schedule fires later.
+	 *  - The timer was restarted (z_add_timeout re-queued the timeout):
+	 *    it is active again, and the new schedule fires later.
 	 *  - The timer was stopped (z_try_abort_timeout marked the
 	 *    in-flight slot superseded): bail without firing expiry_fn.
 	 */
-	if (sys_dnode_is_linked(&t->node) ||
+	if (!z_is_inactive_timeout(t) ||
 	    z_timeout_inflight_superseded(t)) {
 		k_spin_unlock(&timer_lock, key);
 		return;

--- a/subsys/shell/modules/kernel_service/thread/list.c
+++ b/subsys/shell/modules/kernel_service/thread/list.c
@@ -76,11 +76,20 @@ static void shell_tdata_dump(const struct k_thread *cthread, void *user_data)
 		    (thread == k_current_get()) ? "*" : " ",
 		    thread,
 		    tname ? tname : "NA");
+	/* Raw backend scheduling field: delta-ticks for the dlist backend,
+	 * absolute expiry tick for the min-heap backend.
+	 */
+#if defined(CONFIG_TIMEOUT_BACKEND_MINHEAP)
+	int64_t timeout_raw = (int64_t)thread->base.timeout.abs_ticks;
+#else
+	int64_t timeout_raw = (int64_t)thread->base.timeout.dticks;
+#endif
+
 	/* Cannot use lld as it's less portable. */
 	shell_print(sh, "\toptions: 0x%x, priority: %d timeout: %" PRId64,
 		    thread->base.user_options,
 		    thread->base.prio,
-		    (int64_t)thread->base.timeout.dticks);
+		    timeout_raw);
 	shell_print(sh, "\tstate: %s, entry: %p",
 		    k_thread_state_str(thread, state_str, sizeof(state_str)),
 		    thread->entry.pEntry);

--- a/tests/kernel/common/src/timeout_order.c
+++ b/tests/kernel/common/src/timeout_order.c
@@ -71,8 +71,11 @@ ZTEST(common_1cpu, test_timeout_order)
 {
 	int ii, prio = k_thread_priority_get(k_current_get()) + 1;
 
-	if (IS_ENABLED(CONFIG_TIMEOUT_BACKEND_MINHEAP)) {
-		/* The min-heap backend makes no same-tick ordering guarantee. */
+	if (IS_ENABLED(CONFIG_TIMEOUT_BACKEND_MINHEAP) ||
+	    IS_ENABLED(CONFIG_TIMEOUT_BACKEND_WHEEL)) {
+		/* The min-heap and timer-wheel backends make no same-tick
+		 * ordering guarantee.
+		 */
 		ztest_test_skip();
 	}
 

--- a/tests/kernel/common/src/timeout_order.c
+++ b/tests/kernel/common/src/timeout_order.c
@@ -71,6 +71,11 @@ ZTEST(common_1cpu, test_timeout_order)
 {
 	int ii, prio = k_thread_priority_get(k_current_get()) + 1;
 
+	if (IS_ENABLED(CONFIG_TIMEOUT_BACKEND_MINHEAP)) {
+		/* The min-heap backend makes no same-tick ordering guarantee. */
+		ztest_test_skip();
+	}
+
 	for (ii = 0; ii < NUM_TIMEOUTS; ii++) {
 		(void)k_thread_create(&threads[ii], stacks[ii], STACKSIZE,
 				      thread, INT_TO_POINTER(ii), 0, 0,

--- a/tests/kernel/timeout/tests.yaml
+++ b/tests/kernel/timeout/tests.yaml
@@ -3,3 +3,9 @@ tests:
     tags:
       - kernel
       - timer
+  kernel.timer.timeout.min_heap:
+    extra_configs:
+      - CONFIG_TIMEOUT_BACKEND_MINHEAP=y
+    tags:
+      - kernel
+      - timer

--- a/tests/kernel/timeout/tests.yaml
+++ b/tests/kernel/timeout/tests.yaml
@@ -9,3 +9,9 @@ tests:
     tags:
       - kernel
       - timer
+  kernel.timer.timeout.wheel:
+    extra_configs:
+      - CONFIG_TIMEOUT_BACKEND_WHEEL=y
+    tags:
+      - kernel
+      - timer

--- a/tests/kernel/timeout/tests.yaml
+++ b/tests/kernel/timeout/tests.yaml
@@ -15,3 +15,9 @@ tests:
     tags:
       - kernel
       - timer
+  kernel.timer.timeout.bucket:
+    extra_configs:
+      - CONFIG_TIMEOUT_BACKEND_BUCKET=y
+    tags:
+      - kernel
+      - timer

--- a/tests/lib/min_heap_ref/CMakeLists.txt
+++ b/tests/lib/min_heap_ref/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Aerlync Labs Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(min_heap_ref)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/min_heap_ref/prj.conf
+++ b/tests/lib/min_heap_ref/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/lib/min_heap_ref/src/test_min_heap_ref.c
+++ b/tests/lib/min_heap_ref/src/test_min_heap_ref.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026 Aerlync Labs Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/min_heap_ref.h>
+#include <zephyr/ztest_assert.h>
+
+struct data {
+	struct min_heap_handle handle;
+	int key;
+	int value;
+};
+
+static int compare_gt(const struct min_heap_handle *a, const struct min_heap_handle *b)
+{
+	const struct data *da = CONTAINER_OF(a, struct data, handle);
+	const struct data *db = CONTAINER_OF(b, struct data, handle);
+
+	if (da->key < db->key) {
+		return 1;
+	} else if (da->key > db->key) {
+		return -1;
+	}
+
+	return 0;
+}
+
+static int compare_ls(const struct min_heap_handle *a, const struct min_heap_handle *b)
+{
+	const struct data *da = CONTAINER_OF(a, struct data, handle);
+	const struct data *db = CONTAINER_OF(b, struct data, handle);
+
+	return da->key - db->key;
+}
+
+#define HEAP_CAPACITY 8
+#define LOWEST_KEY_LS 2
+#define LOWEST_KEY_GT 30
+
+MIN_HEAP_REF_DEFINE_STATIC(my_heap, HEAP_CAPACITY, compare_ls);
+MIN_HEAP_REF_DEFINE_STATIC(my_heap_gt, HEAP_CAPACITY, compare_gt);
+
+struct data elements[] = {
+	{ .key = 10, .value = 100 },
+	{ .key = 5,  .value = 200 },
+	{ .key = 30, .value = 300 },
+	{ .key = 2,  .value = 400 },
+	{ .key = 3,  .value = 400 },
+	{ .key = 4,  .value = 400 },
+	{ .key = 6,  .value = 400 },
+	{ .key = 22,  .value = 400 },
+};
+
+/* Pop all elements and verify they come out in descending key order */
+static void validate_heap_order_gt(struct min_heap_ref *h)
+{
+	int prev_key = INT_MAX;
+	struct min_heap_handle *handle;
+
+	while ((handle = min_heap_ref_pop(h)) != NULL) {
+		struct data *d = CONTAINER_OF(handle, struct data, handle);
+
+		zassert_true(d->key <= prev_key, "Heap order violated: %d < %d", d->key, prev_key);
+		prev_key = d->key;
+		/* Reset handle so elements can be re-inserted in later tests */
+		d->handle.idx = 0U;
+	}
+}
+
+/* Pop all elements and verify they come out in ascending key order */
+static void validate_heap_order_ls(struct min_heap_ref *h)
+{
+	int prev_key = INT_MIN;
+	struct min_heap_handle *handle;
+
+	while ((handle = min_heap_ref_pop(h)) != NULL) {
+		struct data *d = CONTAINER_OF(handle, struct data, handle);
+
+		zassert_true(d->key >= prev_key, "Heap order violated: %d < %d", d->key, prev_key);
+		prev_key = d->key;
+		/* Reset handle so elements can be re-inserted in later tests */
+		d->handle.idx = 0U;
+	}
+}
+
+ZTEST(min_heap_ref_api, test_insert)
+{
+	int ret;
+
+	for (int i = 0; i < ARRAY_SIZE(elements); i++) {
+
+		elements[i].handle.idx = 0U;
+		ret = min_heap_ref_push(&my_heap, &elements[i].handle);
+		zassert_ok(ret, "min_heap_ref_push failed");
+	}
+	validate_heap_order_ls(&my_heap);
+
+	for (int i = 0; i < ARRAY_SIZE(elements); i++) {
+
+		elements[i].handle.idx = 0U;
+		ret = min_heap_ref_push(&my_heap_gt, &elements[i].handle);
+		zassert_ok(ret, "min_heap_ref_push failed");
+	}
+
+	/* Try to push one more element to the now full heap */
+	struct data extra = {.key = 99, .value = 0};
+
+	ret = min_heap_ref_push(&my_heap_gt, &extra.handle);
+	zassert_equal(ret, -1, "push on full heap should return -1");
+
+	validate_heap_order_gt(&my_heap_gt);
+}
+
+ZTEST(min_heap_ref_api, test_peek_and_pop)
+{
+	int ret;
+
+	MIN_HEAP_REF_DEFINE_STATIC(runtime_heap, HEAP_CAPACITY, compare_ls);
+
+	for (int i = 0; i < ARRAY_SIZE(elements); i++) {
+
+		elements[i].handle.idx = 0U;
+		ret = min_heap_ref_push(&runtime_heap, &elements[i].handle);
+		zassert_ok(ret, "min_heap_ref_push failed");
+	}
+
+	const struct min_heap_handle *peek_h = min_heap_ref_peek(&runtime_heap);
+
+	zassert_not_null(peek_h, "peek on non-empty heap returned NULL");
+
+	const struct data *peeked = CONTAINER_OF(peek_h, struct data, handle);
+	int peek_key = peeked->key;
+
+	struct min_heap_handle *pop_h = min_heap_ref_pop(&runtime_heap);
+	struct data *popped = CONTAINER_OF(pop_h, struct data, handle);
+
+	zassert_equal(peek_key, popped->key, "peek/pop mismatch");
+	zassert_equal(popped->key, LOWEST_KEY_LS, "Expected minimum key %d, got %d", LOWEST_KEY_LS,
+		      popped->key);
+	popped->handle.idx = 0U;
+
+	validate_heap_order_ls(&runtime_heap);
+	zassert_is_null(min_heap_ref_peek(&runtime_heap), "peek on empty heap should return NULL");
+}
+
+ZTEST(min_heap_ref_api, test_remove)
+{
+	int ret;
+
+	for (int i = 0; i < ARRAY_SIZE(elements); i++) {
+
+		elements[i].handle.idx = 0U;
+		ret = min_heap_ref_push(&my_heap, &elements[i].handle);
+		zassert_ok(ret, "min_heap_ref_push failed");
+	}
+
+	/* Remove element with key = 5 directly by handle */
+	struct data *target = &elements[1];
+
+	zassert_true(target->handle.idx > 0U, "Element not in heap");
+	zassert_true(min_heap_ref_remove(&my_heap, &target->handle),
+		     "Failed to remove valid handle");
+	zassert_equal(target->handle.idx, 0U, "idx not cleared after remove");
+	zassert_false(min_heap_ref_is_empty(&my_heap), "heap should not be empty");
+
+	struct data not_inserted = {.key = 77};
+
+	zassert_false(min_heap_ref_remove(&my_heap, &not_inserted.handle),
+		      "Remove operation of uninserted handle should return false");
+
+	validate_heap_order_ls(&my_heap);
+	zassert_true(min_heap_ref_is_empty(&my_heap), "heap should be empty");
+}
+
+ZTEST(min_heap_ref_api, test_foreach)
+{
+	struct min_heap_handle *h;
+	struct data *d;
+	int ret;
+
+	for (int i = 0; i < ARRAY_SIZE(elements); i++) {
+
+		elements[i].handle.idx = 0U;
+		ret = min_heap_ref_push(&my_heap, &elements[i].handle);
+		zassert_ok(ret, "min_heap_ref_push failed");
+	}
+
+	bool visited[ARRAY_SIZE(elements)] = {};
+	int count = 0;
+
+	MIN_HEAP_REF_FOREACH(&my_heap, h) {
+		d = CONTAINER_OF(h, struct data, handle);
+		int idx = (int)(d - elements);
+
+		zassert_true(idx >= 0 && idx < (int)ARRAY_SIZE(elements),
+			     "Handle outside elements array");
+		zassert_false(visited[idx], "handle %d visited twice", idx);
+		visited[idx] = true;
+		count++;
+	}
+	zassert_equal(count, (int)ARRAY_SIZE(elements), "FOREACH visit count mismatch");
+	for (int i = 0; i < (int)ARRAY_SIZE(elements); i++) {
+
+		zassert_true(visited[i], "element[%d] not visited by FOREACH", i);
+	}
+
+	bool visited2[ARRAY_SIZE(elements)] = {};
+	int count2 = 0;
+
+	MIN_HEAP_REF_FOREACH_CONTAINER(&my_heap, d, handle)
+	{
+		int idx = (int)(d - elements);
+
+		zassert_true(idx >= 0 && idx < (int)ARRAY_SIZE(elements),
+			     "container outside elements array");
+		zassert_false(visited2[idx], "Container %d visited twice", idx);
+		visited2[idx] = true;
+		count2++;
+	}
+	zassert_equal(count2, (int)ARRAY_SIZE(elements), "FOREACH_CONTAINER visit count mismatch");
+	for (int i = 0; i < (int)ARRAY_SIZE(elements); i++) {
+		zassert_true(visited2[i], "element[%d] not visited by FOREACH_CONTAINER", i);
+	}
+
+	/* Drain heap, reset all idx*/
+	validate_heap_order_ls(&my_heap);
+
+	int empty_count = 0;
+
+	MIN_HEAP_REF_FOREACH(&my_heap, h) {
+		empty_count++;
+	}
+	zassert_equal(empty_count, 0, "FOREACH body executed on empty heap");
+
+	MIN_HEAP_REF_FOREACH_CONTAINER(&my_heap, d, handle)
+	{
+		empty_count++;
+	}
+	zassert_equal(empty_count, 0, "FOREACH_CONTAINER body executes on empty heap");
+}
+
+ZTEST_SUITE(min_heap_ref_api, NULL, NULL, NULL, NULL, NULL);

--- a/tests/lib/min_heap_ref/tests.yaml
+++ b/tests/lib/min_heap_ref/tests.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Aerlync Labs Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  libraries.min_heap_ref:
+    tags:
+      - data_structures
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
## Overview

The kernel tracks pending timeouts in a single sorted delta list. Insertion
is O(N), which is fine for a handful of timeouts but scales poorly when many
are pending, and everything adds to the same queue: kernel timers, blocked
threads, time slicing, networking, work queues. Two recent proposals replace
that data structure with faster alternatives, a min-heap (#106013) and a
hierarchical timer wheel (#108339), each by forking or heavily #ifdef-ing
kernel/timeout.c.

This series takes a different route. It factors kernel/timeout.c into a thin
backend-independent front end over a pluggable timeout-queue backend, then
offers the alternatives as selectable backends behind a single Kconfig choice
(TIMEOUT_BACKEND). The front end keeps the parts that have historically been
the source of subtle timeout bugs in one place: the announce path, the SMP
re-entry guard, the in-flight handler synchronization, and the relative versus
absolute and round-up rules. A fix there applies to every backend, and a new
backend is self-contained rather than another fork.

The split follows how the queue is actually used. Only two per-node helpers
(initialize a timeout, test whether it is queued) are needed tree-wide, so
they stay in timeout_q.h. The queue itself, its instance and all of its
operations, is used only by timeout.c, so each backend is an implementation
header that timeout.c includes directly, after its shared state. The backend's
queue and instance are therefore private to that one translation unit: it
needs no exported symbols and no shared-state plumbing, and a backend that
runs its own announce loop (the wheel) reaches the front end's state directly.

## Motivation

Issue #102932 asked for an O(1)-insert alternative for systems holding many
concurrent timeouts, especially clustered in the near future. The min-heap
(#106013) and timer wheel (#108339) both answered it, and a reviewer also
floated a skip list. None is universally best: each has a workload it serves
and costs it imposes. Rather than pick one and bolt it on, this makes the
data structure a build-time choice so integrators can match it to their
workload, while the default and the common code stay untouched in behavior.

## Backends

- Sorted delta list (TIMEOUT_BACKEND_DLIST, default). The original queue,
  behavior unchanged. O(N) insert, O(1) abort, no extra static state.

- Binary min-heap (TIMEOUT_BACKEND_MINHEAP). O(log N) insert and arbitrary
  remove, smallest per-timeout node. Requires 64-bit timeouts and a
  fixed-capacity heap. The heap algorithm is derived from Sayooj K Karun's
  work in #106013; rather than redesign the existing value-based min_heap
  library (which other subsystems depend on), this adds a small reference
  (handle-based) variant, sys/min_heap_ref, that the backend builds on.

- Hierarchical timer wheel (TIMEOUT_BACKEND_WHEEL). O(1) insertion and removal
  for timeouts up to ~1024 ticks out, with a sorted overflow list beyond.
  Largest static state. The wheel data structure and algorithm are the work
  of Peter Mitsis in #108339, re-homed here behind the backend interface.

- Single-level bucketed delta list (TIMEOUT_BACKEND_BUCKET). A simpler
  structure introduced by this series: per-tick buckets for a tunable
  near-future window plus a sorted overflow list. O(1) insert and abort within
  the window, and uniquely among the non-default backends it keeps same-tick
  FIFO order and imposes no tickless-idle wakeup penalty.

The delta list stays the default. The other three are EXPERIMENTAL.

## Measured comparison

Gathered with the timeout management benchmark from #104637 (not included
here) on qemu_cortex_a53, average cycles per operation. QEMU cycle counts are
estimates: read the trends, not the absolutes. The benchmark inserts N
timeouts with waits 1..N ticks then aborts them.

Insert, increasing waits (worst case for the delta list):

| N   | dlist | heap | wheel | bucket |
|-----|-------|------|-------|--------|
| 16  | 165   | 125  | 132   | 139    |
| 128 | 666   | 123  | 135   | 428    |
| 512 | 2394  | 123  | 136   | 2004   |

Abort, in expiry order:

| N   | dlist | heap | wheel | bucket |
|-----|-------|------|-------|--------|
| 512 | 129   | 515  | 84    | 175    |

Static cost (64-bit):

|                       | dlist | heap   | wheel  | bucket |
|-----------------------|-------|--------|--------|--------|
| struct _timeout       | 32 B  | 24 B   | 40 B   | 32 B   |
| backend static state  | 16 B  | ~1 KB  | ~1 KB  | ~540 B |

Reading of the data:

- dlist: O(N) insert for non-head insertion, but the cheapest abort and the
  smallest state. Fine until insert cost actually bites.
- heap: best insert at scale, but the most expensive abort, and abort is the
  more common operation in practice (timeouts are cancelled far more often
  than they fire). Smallest node, but bounded capacity.
- wheel: O(1) on every operation across the whole range, the best raw scaling.
  Costs the largest node, ~1 KB of state, no same-tick ordering, and a
  tickless-idle wakeup floor (see limitations).
- bucket: O(1) within its near-future window (matching the wheel when timeouts
  cluster there), degrading to delta-list behavior beyond it; no idle floor,
  same-tick FIFO, modest state.

The benchmark's uniform 1..N spread is adversarial to single-tier backends and
favorable to the wheel's wider window. For the near-future-clustered workload
that motivated #102932, the bucketed backend stays in its O(1) regime. The
honest conclusion is that no backend dominates, which is the argument for the
abstraction itself.

## Status and known limitations

- The series builds on #109977 (in-flight handler synchronization), now in
  mainline, which moved the popped-but-not-yet-fired handling out of the
  per-node state and into the subsystem and so simplified the abstraction
  layer: backends carry no announcing or aborted sentinels of their own.
- The min-heap and bucket backends require CONFIG_TIMEOUT_64BIT.
- The min-heap has a fixed capacity (CONFIG_TIMEOUT_HEAP_MAX_ENTRIES); overflow
  is a fatal error, and it does not guarantee same-tick firing order.
- The timer wheel does not guarantee same-tick firing order, and its
  next-timeout never exceeds the soon-window, so it wakes a tickless-idle CPU
  periodically even when idle. This is a power regression versus the other
  backends and currently fails the cpu_idle and timer_interrupt assertions in
  tests/kernel/context. It is inherent to the wheel algorithm and is the main
  reason it is gated EXPERIMENTAL.

Each backend was exercised by forcing it on across the kernel timer, timepoint,
sleep, context and common test suites on qemu_x86, qemu_x86_64,
qemu_cortex_a53 (SMP) and qemu_riscv64. The dlist and bucket backends pass the
full set; the heap and wheel pass except for the same-tick-ordering and
idle-wakeup cases noted above, which are skipped or expected for them.

## Relationship to existing PRs

- Incorporates the data structures from #106013 (min-heap) and #108339 (timer
  wheel) behind the shared abstraction rather than landing them as standalone
  forks of kernel/timeout.c, crediting the original authors. For the min-heap
  this adds a reference (handle-based) min_heap variant (sys/min_heap_ref) for
  the backend to build on and leaves the existing value-based min_heap
  unchanged, rather than redesigning a library that other subsystems use.
- Does not include the benchmark from #104637, which can land independently;
  the numbers above were gathered with it.

## Commit layout

The series is arranged so each step builds and stands on its own:

1. Factor the delta list into a pluggable backend (no behavior change). The
   per-node helpers stay tree-wide in timeout_q.h; the queue moves into
   kernel/timeout_list.h, an implementation header included only by timeout.c.
2. Add a reference (handle-based) min-heap, sys/min_heap_ref, with docs and
   tests. The existing value-based min_heap is left untouched.
3. The min-heap backend (kernel/timeout_minheap.h) plus a timeout test variant.
4. The timer-wheel backend (kernel/timeout_wheel.h) plus a test variant.
5. The bucketed delta-list backend (kernel/timeout_bucket.h) plus a test
   variant.

The abstraction plus the default delta list (step 1) is independently useful
and could merge ahead of the alternative backends if preferred.
