### PR TITLE
boards: teensy41: Enable LPI2C1

### DIFF
--- a/boards/pjrc/teensy4/teensy41.dts
+++ b/boards/pjrc/teensy4/teensy41.dts
@@ -80,6 +80,10 @@
 	status = "okay";
 };
 
+&lpi2c1 {
+	status = "okay";
+};
+
 &usdhc1 {
 	status = "okay";
 	no-1-8-v;

--- a/boards/pjrc/teensy4/teensy41.yaml
+++ b/boards/pjrc/teensy4/teensy41.yaml
@@ -19,6 +19,7 @@ supported:
   - sdhc
   - usb_device
   - netif:eth
+  - i2c
 testing:
   ignore_tags:
     - net


### PR DESCRIPTION
The Teensy 4.1's primary I2C bus (LPI2C1) is configured at the SoC level, with its pins already routed in teensy40.dts, but left disabled. To use it, users have to add their own overlay at the application level. The board's LPSPI3 comes enabled by default, so by enabling LPI2C1 we stay faithful to the existing pattern.

This change was tested on a Teensy 4.1 with a BME680 wired to pins 18 (SDA) and 19 (SCL). The merged devicetree shows the node enabled, and a logic analyzer capture shows the chip-ID read (0xD0 -> 0x61) and sensor reads, all acknowledged.

**Before:**
```
/* node '/soc/i2c@403f0000' defined in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:437 */
  lpi2c1: i2c@403f0000 {
	  compatible = "nxp,lpi2c";         /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:438 */
	  clock-frequency = < 0x186a0 >;    /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:439 */
	  #address-cells = < 0x1 >;         /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:440 */
	  #size-cells = < 0x0 >;            /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:441 */
	  reg = < 0x403f0000 0x4000 >;      /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:442 */
	  interrupts = < 0x1c 0x0 >;        /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:443 */
	  clocks = < &ccm 0x400 0x70 0x6 >; /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:444 */
	  status = "disabled";              /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:445 */
	  pinctrl-0 = < &pinmux_lpi2c1 >;   /* in zephyr/boards/pjrc/teensy4/teensy40.dts:100 */
	  pinctrl-names = "default";        /* in zephyr/boards/pjrc/teensy4/teensy40.dts:101 */
  };
```

**After:**
```
/* node '/soc/i2c@403f0000' defined in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:437 */
  lpi2c1: i2c@403f0000 {
	  compatible = "nxp,lpi2c";         /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:438 */
	  clock-frequency = < 0x186a0 >;    /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:439 */
	  #address-cells = < 0x1 >;         /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:440 */
	  #size-cells = < 0x0 >;            /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:441 */
	  reg = < 0x403f0000 0x4000 >;      /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:442 */
	  interrupts = < 0x1c 0x0 >;        /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:443 */
	  clocks = < &ccm 0x400 0x70 0x6 >; /* in zephyr/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi:444 */
	  pinctrl-0 = < &pinmux_lpi2c1 >;   /* in zephyr/boards/pjrc/teensy4/teensy40.dts:100 */
	  pinctrl-names = "default";        /* in zephyr/boards/pjrc/teensy4/teensy40.dts:101 */
	  status = "okay";                  /* in zephyr/boards/pjrc/teensy4/teensy41.dts:84 */
  };
```

**Logic analyzer capture:**

<img width="2491" height="1143" alt="teensy4 1-bme680" src="https://github.com/user-attachments/assets/324df78e-e30f-4112-a251-a66a272507c1" />

