### PR TITLE
dts: arm: alif: ensemble: add E4/E6/E8 shared peripheral layer

### DIFF
--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk-pinctrl.dtsi
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk-pinctrl.dtsi
@@ -72,4 +72,26 @@
 			pinmux = <PIN_P3_5__UART5_TX_A>;
 		};
 	};
+
+	pinctrl_uart6: pinctrl_uart6 {
+		group0 {
+			pinmux = <PIN_P10_5__UART6_RX_A>;
+			input-enable;
+		};
+
+		group1 {
+			pinmux = <PIN_P10_6__UART6_TX_A>;
+		};
+	};
+
+	pinctrl_uart7: pinctrl_uart7 {
+		group0 {
+			pinmux = <PIN_P9_3__UART7_RX_B>;
+			input-enable;
+		};
+
+		group1 {
+			pinmux = <PIN_P9_4__UART7_TX_B>;
+		};
+	};
 };

--- a/dts/arm/alif/ensemble/ae402fa0e5597le0.dtsi
+++ b/dts/arm/alif/ensemble/ae402fa0e5597le0.dtsi
@@ -4,7 +4,7 @@
  */
 
 #include <mem.h>
-#include <alif/ensemble/common/ensemble_common.dtsi>
+#include <alif/ensemble/common/ensemble_e4_e6_e8.dtsi>
 
 &soc {
 	sram0: sram@2000000 {

--- a/dts/arm/alif/ensemble/ae402fa0e5597le0_nvic_irq.dtsi
+++ b/dts/arm/alif/ensemble/ae402fa0e5597le0_nvic_irq.dtsi
@@ -9,4 +9,4 @@
  * A board that uses this SoC includes this for RTSS (NVIC) cores.
  */
 
-#include <alif/ensemble/common/ensemble_common_nvic_irq.dtsi>
+#include <alif/ensemble/common/ensemble_e4_e6_e8_nvic_irq.dtsi>

--- a/dts/arm/alif/ensemble/ae612fa0e5597ls0.dtsi
+++ b/dts/arm/alif/ensemble/ae612fa0e5597ls0.dtsi
@@ -4,7 +4,7 @@
  */
 
 #include <mem.h>
-#include <alif/ensemble/common/ensemble_common.dtsi>
+#include <alif/ensemble/common/ensemble_e4_e6_e8.dtsi>
 
 &soc {
 	sram0: sram@2000000 {

--- a/dts/arm/alif/ensemble/ae612fa0e5597ls0_nvic_irq.dtsi
+++ b/dts/arm/alif/ensemble/ae612fa0e5597ls0_nvic_irq.dtsi
@@ -9,4 +9,4 @@
  * A board that uses this SoC includes this for RTSS (NVIC) cores.
  */
 
-#include <alif/ensemble/common/ensemble_common_nvic_irq.dtsi>
+#include <alif/ensemble/common/ensemble_e4_e6_e8_nvic_irq.dtsi>

--- a/dts/arm/alif/ensemble/ae822fa0e5597ls0.dtsi
+++ b/dts/arm/alif/ensemble/ae822fa0e5597ls0.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <mem.h>
-#include <alif/ensemble/common/ensemble_common.dtsi>
+#include <alif/ensemble/common/ensemble_e4_e6_e8.dtsi>
 
 &soc {
 	sram0: sram@2000000 {

--- a/dts/arm/alif/ensemble/ae822fa0e5597ls0_gic_irq.dtsi
+++ b/dts/arm/alif/ensemble/ae822fa0e5597ls0_gic_irq.dtsi
@@ -9,4 +9,4 @@
  * A board that uses this SoC includes this for APSS (GIC) cores.
  */
 
-#include <alif/ensemble/common/ensemble_common_gic_irq.dtsi>
+#include <alif/ensemble/common/ensemble_e4_e6_e8_gic_irq.dtsi>

--- a/dts/arm/alif/ensemble/ae822fa0e5597ls0_nvic_irq.dtsi
+++ b/dts/arm/alif/ensemble/ae822fa0e5597ls0_nvic_irq.dtsi
@@ -9,4 +9,4 @@
  * A board that uses this SoC includes this for RTSS (NVIC) cores.
  */
 
-#include <alif/ensemble/common/ensemble_common_nvic_irq.dtsi>
+#include <alif/ensemble/common/ensemble_e4_e6_e8_nvic_irq.dtsi>

--- a/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8.dtsi
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Alif Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Peripherals shared by the E4, E6 and E8 Ensemble SoCs that are additional
+ * to the minimum common subset (see ensemble_common.dtsi). As with the common
+ * layer, interrupt routing is intentionally kept out of this file and lives in
+ * the controller-specific ensemble_e4_e6_e8_{nvic,gic}_irq.dtsi files.
+ */
+
+#include <alif/ensemble/common/ensemble_common.dtsi>
+
+&soc {
+	uart6: uart@4901e000 {
+		compatible = "ns16550";
+		reg = <0x4901e000 0x1000>;
+		clocks = <&clockctrl ALIF_UART6_SYST_PCLK>;
+		reg-shift = <2>;
+		current-speed = <115200>;
+		status = "disabled";
+	};
+
+	uart7: uart@4901f000 {
+		compatible = "ns16550";
+		reg = <0x4901f000 0x1000>;
+		clocks = <&clockctrl ALIF_UART7_SYST_PCLK>;
+		reg-shift = <2>;
+		current-speed = <115200>;
+		status = "disabled";
+	};
+};

--- a/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8_gic_irq.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8_gic_irq.dtsi
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Alif Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * GIC interrupt routing for peripherals shared by the E4, E6 and E8 Ensemble
+ * SoCs (see ensemble_e4_e6_e8.dtsi). Included by the per-SoC _gic_irq.dtsi.
+ */
+
+#include <alif/ensemble/common/ensemble_common_gic_irq.dtsi>
+
+&uart6 {
+	interrupt-parent = <&gic>;
+	interrupts = <GIC_SPI 119 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+};
+
+&uart7 {
+	interrupt-parent = <&gic>;
+	interrupts = <GIC_SPI 120 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+};

--- a/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8_nvic_irq.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8_nvic_irq.dtsi
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Alif Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * NVIC interrupt routing for peripherals shared by the E4, E6 and E8 Ensemble
+ * SoCs (see ensemble_e4_e6_e8.dtsi). Included by the per-SoC _nvic_irq.dtsi.
+ */
+
+#include <alif/ensemble/common/ensemble_common_nvic_irq.dtsi>
+
+&uart6 {
+	interrupt-parent = <&nvic>;
+	interrupts = <130 0>;
+};
+
+&uart7 {
+	interrupt-parent = <&nvic>;
+	interrupts = <131 0>;
+};


### PR DESCRIPTION
The E4, E6 and E8 SoCs share a set of peripherals that are additional to the minimum subset defined in `ensemble_common.dtsi`. Introduce an `ensemble_e4_e6_e8.dtsi` resource layer (and matching  `_nvic_irq/_gic_irq` routing layers) to hold these, sitting between the common layer and the per-SoC files. Rewire the E4/E6/E8 SoC and interrupt dtsi to include the new layer instead of the common one. E1C keeps including the common layer directly. The new layer is populated with UART6 and UART7.

Also add UART6/UART7 pinctrl groups to Ensemble E8 DK pinctrl dtsi.