### PR TITLE
drivers: ieee802154: silabs: fix encryping data poll packets

### DIFF
--- a/drivers/ieee802154/ieee802154_silabs_efr32.c
+++ b/drivers/ieee802154/ieee802154_silabs_efr32.c
@@ -206,6 +206,12 @@ static size_t sl_802154_get_mhr_length(struct ieee802154_mhr *mhr)
 		length += sl_802154_get_aux_sec_hdr_bytes(mhr->aux_sec);
 	}
 
+	/* Derived from FindPayloadIndex in the openthread code base. */
+	if (mhr->fs->fc.frame_type == IEEE802154_FRAME_TYPE_MAC_COMMAND &&
+	    mhr->fs->fc.frame_version != IEEE802154_VERSION_802154) {
+		length += 1;
+	}
+
 	return length;
 }
 


### PR DESCRIPTION
Sleep End Devices (SED) use data poll packets to check if the coordinator has data to send. These packets use the type
IEEE802154_FRAME_TYPE_MAC_COMMAND, which as an additional field inside the part of the header thats supposed to be part of the authenticated data rather than the encrypted payload.

sl_802154_get_mhr_length has to detect this situation and adjust the returned header size accordingly. The check is modeled after what the function FindPayloadIndex does inside of the openthread source code. That code is used, if the device doesn't support IEEE802154_HW_TX_SEC.

Before this fix, neither Wireshark nor the receiver of the message were able to decrypt the message. This caused sleepy devices to be unable to communicate.