### PR TITLE
kernel: events: update comment explaining the wake algorithm

### DIFF
--- a/kernel/events.c
+++ b/kernel/events.c
@@ -193,14 +193,13 @@ static uint32_t k_event_post_internal(struct k_event *event, uint32_t events,
 
 	/*
 	 * Posting an event has the potential to wake multiple pended threads.
-	 * It is desirable to unpend all affected threads simultaneously. When
+	 * It is desirable to wake all affected threads simultaneously. When
 	 * z_sched_waitq_walk() allows removal of nodes from the wait queue,
-	 * we unpend and ready each thread as part of the callback. Otherwise,
-	 * proceed in three steps:
+	 * we wake (unpend and ready) each thread as part of the callback.
+	 * Otherwise, proceed in two steps:
 	 *
-	 * 1. Walk the waitq and create a linked list of threads to unpend.
-	 * 2. Unpend each of the threads in the linked list
-	 * 3. Ready each of the threads in the linked list
+	 * 1. Walk the waitq and create a linked list of threads to wake.
+	 * 2. Walk the resulting linked list and wake each of the threads.
 	 */
 
 #ifdef CONFIG_WAITQ_SCALABLE


### PR DESCRIPTION
The comment made it seem like we do two passes on the "threads that need wakeup" list: a first one to unpend and another to ready. In reality, we do only one path and perform both operations at one using `z_sched_wake_thread_locked()`.

Update the comment explaining the algorithm so it reflects more accurately what the code actually does.