### PR TITLE
Bluetooth: Host: Add appropriate dependency for BT_RX_STACK_SIZE

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -110,6 +110,7 @@ endchoice
 
 config BT_RX_STACK_SIZE
 	int "Size of the receiving thread stack"
+	depends on BT_RECV_WORKQ_BT
 	default 768 if BT_HCI_RAW
 	default 3092 if BT_MESH_GATT_CLIENT
 	default 2800 if BT_MESH_PB_GATT


### PR DESCRIPTION
This option will only be used when the host has its own recv workqueue. Add the appropriate dependency so that the option doesn't needlessly (and potentially misleadlingly) show up in .config files.