### PR TITLE
dts: arm: st: c5: fix uart5 unit address

### DIFF
--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -671,9 +671,9 @@
 			status = "disabled";
 		};
 
-		uart5: serial@40004500 {
+		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
-			reg = <0x40004500 0x400>;
+			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1L, 20)>;
 			interrupts = <55 0>;


### PR DESCRIPTION
UART5 had incorrect unit address and reg value set. Replace both with correct address as stated in RM0522.

<img width="653" height="108" alt="image" src="https://github.com/user-attachments/assets/b9b8c94d-8e51-4e8a-9254-5416c8f3b595" />
