### PR TITLE
Bluetooth: HAS: Add check for has.registered in security cb

### DIFF
--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -376,6 +376,10 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 		return;
 	}
 
+	if (!has.registered) {
+		return;
+	}
+
 	ret = bt_conn_get_info(client->conn, &info);
 	if (ret < 0) {
 		LOG_ERR("bt_conn_get_info err %d", ret);


### PR DESCRIPTION
If we had a bond with a device and the flags were non-zero, and we power cycled but where bt_has_register was not called before the bonded device reconnected then in the
security_changed we would call notify_work_reschedule which would then notify_work_handler would access uninitialized values like hearing_aid_features_attr or the other attributes (they would be NULL), causing an assert when calling bt_gatt_is_subscribed.

Fixes: #113346