### PR TITLE
drivers: spi: spi_mcux_ecspi: use channel 0 for GPIO chip select

### DIFF
--- a/drivers/spi/spi_mcux_ecspi.c
+++ b/drivers/spi/spi_mcux_ecspi.c
@@ -67,7 +67,7 @@ static void spi_mcux_transfer_next_packet(const struct device *dev)
 		return;
 	}
 
-	transfer.channel = ctx->config->slave;
+	transfer.channel = spi_cs_is_gpio(ctx->config) ? kECSPI_Channel0 : ctx->config->slave;
 
 	if (spi_context_rx_buf_on(ctx)) {
 		transfer.rxData = &data->rx_data;


### PR DESCRIPTION
When a SPI device uses a GPIO chip select, spi_mcux_configure() initialises the controller on ECSPI channel 0. However spi_mcux_transfer_next_packet() started every transfer on transfer.channel = ctx->config->slave.

A device with reg != 0 transfers on an ECSPI channel that was never configured.

Select the transfer channel the same way spi_mcux_configure() already does: channel 0 when the chip select is a GPIO, and the slave number only for native chip selects.
