### PR TITLE
modules: hostap: guard against NULL control interface

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -93,7 +93,11 @@ static K_WORK_DELAYABLE_DEFINE(wpa_supp_status_work,
 	({                                                                                         \
 		bool status;                                                                       \
                                                                                                    \
-		if (zephyr_wpa_cli_cmd_v(wpa_s->ctrl_conn, cmd, ##__VA_ARGS__) < 0) {              \
+		if (wpa_s->ctrl_conn == NULL) {                                                    \
+			wpa_printf(MSG_ERROR,                                                      \
+				   "Control interface not ready, dropping command: %s", cmd);      \
+			status = false;                                                            \
+		} else if (zephyr_wpa_cli_cmd_v(wpa_s->ctrl_conn, cmd, ##__VA_ARGS__) < 0) {       \
 			wpa_printf(MSG_ERROR, "Failed to execute wpa_cli command: %s", cmd);       \
 			status = false;                                                            \
 		} else {                                                                           \
@@ -662,7 +666,14 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 	wpas_remove_certs(wpa_s);
 #endif
 
+	if (wpa_s->ctrl_conn == NULL) {
+		wpa_printf(MSG_ERROR, "Control interface not ready");
+		ret = -EAGAIN;
+		goto out;
+	}
+
 	if (!wpa_cli_cmd_v("remove_network all")) {
+		ret = -EINVAL;
 		goto out;
 	}
 
@@ -1402,6 +1413,13 @@ int supplicant_connect(const struct device *dev __unused, struct net_if *iface,
 		goto out;
 	}
 
+	if (wpa_s->ctrl_conn == NULL) {
+		wpa_printf(MSG_ERROR,
+			   "Control interface not ready, supplicant still initializing");
+		ret = -EAGAIN;
+		goto out;
+	}
+
 	/* Allow connect in STA mode only even if we are connected already */
 	if  (wpa_s->current_ssid && wpa_s->current_ssid->mode != WPAS_MODE_INFRA) {
 		ret = -EBUSY;
@@ -1486,6 +1504,12 @@ int supplicant_status(const struct device *dev __unused, struct net_if *iface,
 
 	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
+		goto out;
+	}
+
+	if (wpa_s->ctrl_conn == NULL) {
+		wpa_printf(MSG_ERROR, "Control interface not ready");
+		ret = -EAGAIN;
 		goto out;
 	}
 

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -156,6 +156,11 @@ struct k_work_q *get_workq(void)
 /* found in hostap/wpa_supplicant/ctrl_iface_zephyr.c */
 extern int send_data(struct k_fifo *fifo, int sock, const char *buf, size_t len, int flags);
 
+/* Serializes wpa_s->ctrl_conn lifecycle (open/close) against its users in
+ * supp_api.c, so that the NULL checks there cannot race with teardown.
+ */
+extern struct k_mutex wpa_supplicant_mutex;
+
 int zephyr_wifi_send_event(const struct wpa_supplicant_event_msg *msg)
 {
 	struct supplicant_context *ctx;
@@ -379,7 +384,9 @@ static int add_interface(struct supplicant_context *ctx, struct net_if *iface)
 		net_if_get_name(iface, ctx->if_name, CONFIG_NET_INTERFACE_NAME_LEN);
 	}
 
+	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 	ret = zephyr_wpa_ctrl_init(wpa_s);
+	k_mutex_unlock(&wpa_supplicant_mutex);
 	if (ret) {
 		LOG_ERR("Failed to initialize supplicant control interface");
 		goto out;
@@ -473,7 +480,9 @@ static int del_interface(struct supplicant_context *ctx, struct net_if *iface)
 		goto out;
 	}
 
+	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 	zephyr_wpa_ctrl_deinit(wpa_s);
+	k_mutex_unlock(&wpa_supplicant_mutex);
 
 	ret = zephyr_wpa_cli_global_cmd_v("interface_remove %s", ifname);
 	if (ret) {


### PR DESCRIPTION
When an application issues a WiFi management request (e.g. NET_REQUEST_WIFI_CONNECT) shortly after boot, wpa_supplicant may not have finished initializing the per-interface control connection yet. In that window get_wpa_s_handle() already returns a valid wpa_s, but wpa_s->ctrl_conn is still NULL because zephyr_wpa_ctrl_init() has not run.

The wpa_cli_cmd_v() macro and a few direct callers passed this NULL ctrl_conn down to zephyr_wpa_cli_cmd_v() -> wpa_request() and on into send_data(), which dereferenced the connection (its send fifo), producing a hard fault / NULL pointer dereference. Calls that go through global_ctrl_conn were unaffected, which is why only some commands crashed.

Add NULL checks so the supplicant fails the request gracefully with -EAGAIN ("not ready yet") instead of faulting:

  - wpa_cli_cmd_v(): central guard covering all command call sites, including the unlocked ones.
  - wpas_add_and_config_network(), supplicant_connect() and supplicant_status(): explicit early checks before the direct z_wpa_ctrl_*() uses, returning a clear error to the caller.
  - Also propagate -EINVAL when "remove_network all" fails so the connect path no longer reports success on a dropped command.

The ctrl_conn pointer is only ever opened once during interface bring up (NULL -> valid, never freed), so the NULL check alone is sufficient for the reported boot-time race. To keep the check correct against interface teardown as well (valid -> NULL + freed in del_interface), serialize the open/close of ctrl_conn with the existing wpa_supplicant_mutex that the API entry points already hold, so a command holding the mutex cannot have ctrl_conn torn down underneath it.

Applications should still wait for the NET_EVENT_SUPPLICANT_CMD_READY event before issuing requests; this change just makes premature calls fail safely.

Fix #111756.


Assisted-by: Claude:claude-opus-4.8