### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -352,7 +352,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 309d02c0df8625c52a6abc2fd95dc77fe80c163a
+      revision: 253d42e4c124aecd7b51afa4782140270e890a7d
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 21184a8f89f101538ad54c3b64a1d9c4da23bdb8


### PR DESCRIPTION
Update the HW models module to:
253d42e4c124aecd7b51afa4782140270e890a7d

Including the following:
253d42e hal: Add PPIB to nrf_hack for supported devices
281428d 54LS05: Add first version
4ff8094 RADIO: Support devices without BLECoded,15.4,DF,or CS
6b935b3 CRACEN: Support devices without CM or PK
6f0d410 GPIOTE: Support 54 devices without SECURE/NONSECURE port events
958e67f CRC: Add new bitwise API for 24bit BLE CRC 7e5f0ad CRC: Add new 32bit BLE CRC calculation
74550f6 Makefile: Trivial change to minimize rebase churn