### PR TITLE
drivers: wifi: nxp: fix compile issue

### DIFF
--- a/drivers/wifi/nxp/CMakeLists.txt
+++ b/drivers/wifi/nxp/CMakeLists.txt
@@ -176,6 +176,35 @@ zephyr_code_relocate(FILES ${ZEPHYR_BASE}/subsys/net/ip/ipv6.c
                      FILTER "${NXP_IPV6_FILTER}"
                      LOCATION ${QUICK_ACCESS_CODE_AREA} NOKEEP)
 
+# IPV6 FRAGMENT
+string(JOIN "" NXP_IPV6_FRAG_FILTER
+       ".*\\.net_ipv6_handle_fragment_hdr|"
+       ".*\\.net_ipv6_send_fragmented_pkt|"
+       ".*\\.send_ipv6_fragment|"
+       ".*\\.reassemble_packet|"
+       ".*\\.reassembly_get|"
+       ".*\\.fragments_are_ready|"
+       ".*\\.shift_packets"
+)
+zephyr_code_relocate(FILES ${ZEPHYR_BASE}/subsys/net/ip/ipv6_fragment.c
+                     FILTER "${NXP_IPV6_FRAG_FILTER}"
+                     LOCATION RAM_TEXT NOKEEP)
+
+# IPV4 FRAGMENT
+string(JOIN "" NXP_IPV4_FRAG_FILTER
+       ".*\\.net_ipv4_handle_fragment_hdr|"
+       ".*\\.net_ipv4_prepare_for_send_fragment|"
+       ".*\\.net_ipv4_send_fragmented_pkt|"
+       ".*\\.send_ipv4_fragment|"
+       ".*\\.reassemble_packet|"
+       ".*\\.reassembly_get|"
+       ".*\\.fragments_are_ready|"
+       ".*\\.shift_packets"
+)
+zephyr_code_relocate(FILES ${ZEPHYR_BASE}/subsys/net/ip/ipv4_fragment.c
+                     FILTER "${NXP_IPV4_FRAG_FILTER}"
+                     LOCATION RAM_TEXT NOKEEP)
+
 string(JOIN "" NXP_NET_CONTEXT_FILTER
        ".*\\.context_sendto|"
        ".*\\.context_setup_udp_packet|"


### PR DESCRIPTION
On mimxrt1060_evk, CONFIG_CODE_DATA_RELOCATION_SRAM
is enabled by the board configuration, which causes arm_core_mpu.c
to reference __ram_text_reloc_start and __ram_text_reloc_size.
These symbols are only generated when at least one function
is relocated to RAM_TEXT. Since no code was previously placed
there, the build fails with undefined reference errors.
Fix this by relocating hot-path functions from ipv6_fragment.c
and ipv4_fragment.c to RAM_TEXT using function-level FILTER,
Only throughput-critical functions in the RX/TX fragment path
are selected, which also improves throughput performance.