### PR TITLE
[Backport v4.4-branch] net: ipv6: decrement hop limit only for actually forwarded packets

### DIFF
--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -824,7 +824,9 @@ int net_route_mcast_forward_packet(struct net_pkt *pkt, struct net_ipv6_hdr *hdr
 	 * Change its value in a common buffer so the forwardee has a proper count. As we have
 	 * a direct access to the buffer there is no need to perform read/write operations.
 	 */
+	/* Decrement hop limit; required for forwarding. */
 	hdr->hop_limit--;
+	net_pkt_set_ipv6_hop_limit(pkt, hdr->hop_limit);
 
 	ARRAY_FOR_EACH_PTR(route_mcast_entries, route) {
 		struct net_pkt *pkt_cpy = NULL;
@@ -840,7 +842,7 @@ int net_route_mcast_forward_packet(struct net_pkt *pkt, struct net_ipv6_hdr *hdr
 				continue;
 			}
 
-			pkt_cpy = net_pkt_shallow_clone(pkt, K_NO_WAIT);
+			pkt_cpy = net_pkt_clone(pkt, K_NO_WAIT);
 
 			if (pkt_cpy == NULL) {
 				err--;
@@ -859,6 +861,10 @@ int net_route_mcast_forward_packet(struct net_pkt *pkt, struct net_ipv6_hdr *hdr
 			}
 		}
 	}
+
+	/* Restore initial hop limit for further processing. */
+	hdr->hop_limit++;
+	net_pkt_set_ipv6_hop_limit(pkt, hdr->hop_limit);
 
 	return (err == 0) ? ret : err;
 }


### PR DESCRIPTION
Hop limit should only be decremented if a route is found and if the packet is actually forwarded.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/111277