### PR TITLE
drivers: debug: nrf_etr: Fix possible bus fault when shell is used

### DIFF
--- a/drivers/debug/debug_nrf_etr.c
+++ b/drivers/debug/debug_nrf_etr.c
@@ -249,7 +249,12 @@ static int log_output_func(uint8_t *buf, size_t size, void *ctx)
 			err = k_sem_take(&uart_sem, K_FOREVER);
 			__ASSERT_NO_MSG(err >= 0);
 
-			if (size == sizeof(frame_buf0)) {
+			/* When shell is used then function might be called with shell buffer which
+			 * is not 32-bit aligned.
+			 */
+			if (size == sizeof(frame_buf0) &&
+			    (!IS_ENABLED(CONFIG_DEBUG_NRF_ETR_SHELL) ||
+			      IS_ALIGNED(buf, sizeof(uint32_t)))) {
 				/* If full 16 byte frame is used we can optimize copying. */
 				uint64_t *tx_buf64 = (uint64_t *)tx_buf;
 				uint64_t *buf64 = (uint64_t *)buf;


### PR DESCRIPTION
When shell is used then log_output_func may be called with a buf argument which is not the log_output buffer. In that case buffer may not be word aligned and optimized copying cannot be used. Add additional check for alignment before using double word copying.