### PR TITLE
drivers: i2c: infineon_pdl: add Edge divider setup and harden HFCLK mapping

### DIFF
--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -263,60 +263,27 @@ void ifx_cat1_i2c_register_callback(const struct device *dev,
 }
 
 #if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-/* Packs a (peri-instance, peri-group) pair into a single uint8_t key,
- * matching the macro used in uart_infineon_pdl.c and spi_infineon_pdl.c.
- */
-#define IFX_CAT1_INSTANCE_GROUP(instance, group) (((instance) << 4) | (group))
-
-/* Map peri group to the HF clock index that drives it on PSE84.
- * Mirrors ifx_cat1_get_hfclk_for_peri_group() in uart_infineon_pdl.c.
- */
-static uint8_t _i2c_get_hfclk_for_peri_group(uint8_t peri_group)
-{
-#if defined(CONFIG_SOC_SERIES_PSE84)
-	switch (peri_group) {
-	case IFX_CAT1_INSTANCE_GROUP(0, 0):
-	case IFX_CAT1_INSTANCE_GROUP(1, 4):
-		return 0;
-	case IFX_CAT1_INSTANCE_GROUP(0, 7):
-	case IFX_CAT1_INSTANCE_GROUP(1, 0):
-		return 1;
-	case IFX_CAT1_INSTANCE_GROUP(0, 3):
-	case IFX_CAT1_INSTANCE_GROUP(1, 2):
-		return 5;
-	case IFX_CAT1_INSTANCE_GROUP(0, 4):
-	case IFX_CAT1_INSTANCE_GROUP(1, 3):
-		return 6;
-	case IFX_CAT1_INSTANCE_GROUP(1, 1):
-		return 7;
-	case IFX_CAT1_INSTANCE_GROUP(0, 2):
-		return 9;
-	case IFX_CAT1_INSTANCE_GROUP(0, 1):
-	case IFX_CAT1_INSTANCE_GROUP(0, 5):
-		return 10;
-	case IFX_CAT1_INSTANCE_GROUP(0, 8):
-		return 11;
-	case IFX_CAT1_INSTANCE_GROUP(0, 6):
-	case IFX_CAT1_INSTANCE_GROUP(0, 9):
-		return 13;
-	default:
-		break;
-	}
-#endif
-	return 0;
-}
-
 /*
- * Set the peri clock divider for I2C on PSOC Edge so that the SCB input clock
- * falls in the range required by Cy_SCB_I2C_SetDataRate().
+ * Configure the SCB oversampling clock divider for I2C on PSOC Edge.
  *
- * Target peri frequencies (from the PDL API Reference Guide for PSOC Edge):
- *   Controller 100 kHz:  [1.55, 3.2]  MHz -> 2 MHz
- *   Controller 400 kHz:  [7.82, 10]   MHz -> 8.5 MHz
- *   Controller 1 MHz:    [14.32, 25.8] MHz -> 20 MHz
- *   Target     100 kHz:  [1.55, 12.8] MHz -> 6 MHz
- *   Target     400 kHz:  [7.82, 15.38] MHz -> 12 MHz
- *   Target     1 MHz:    [15.84, 89.0] MHz -> 50 MHz
+ * Assumes freq is a valid, non-zero I2C data rate as validated by the
+ * caller (ifx_cat1_i2c_configure).
+ *
+ * The SCB requires specific oversampling clock (clk_scb) frequency ranges
+ * depending on the I2C speed and whether the device is in controller or
+ * target mode.
+ *
+ * Oversampling clock requirements (from device reference manuals):
+ *
+ * Controller mode:
+ *   100 kHz:  [1.55, 3.2] MHz    (selected: 2 MHz)
+ *   400 kHz:  [7.82, 10] MHz     (selected: 8.5 MHz)
+ *   1 MHz:    [14.32, 25.8] MHz  (selected: 20 MHz)
+ *
+ * Target mode:
+ *   100 kHz:  [1.55, 12.8] MHz   (selected: 6 MHz)
+ *   400 kHz:  [7.82, 15.38] MHz  (selected: 12 MHz)
+ *   1 MHz:    [15.84, 89.0] MHz  (selected: 50 MHz)
  */
 static int _i2c_set_peri_divider_edge(const struct device *dev, uint32_t freq, bool is_target_mode)
 {
@@ -333,6 +300,7 @@ static int _i2c_set_peri_divider_edge(const struct device *dev, uint32_t freq, b
 	uint32_t peri_freq = 0;
 	uint32_t source_freq;
 	uint32_t div_value;
+	uint8_t hfclk_idx;
 	cy_rslt_t status;
 
 	if (freq <= CY_SCB_I2C_STD_DATA_RATE) {
@@ -344,14 +312,16 @@ static int _i2c_set_peri_divider_edge(const struct device *dev, uint32_t freq, b
 	} else if (freq <= CY_SCB_I2C_FSTP_DATA_RATE) {
 		peri_freq = is_target_mode ? _EDGE_SCB_I2C_PERI_TGT_FSTP
 					   : _EDGE_SCB_I2C_PERI_CTRL_FSTP;
-	}
-
-	if (peri_freq == 0) {
+	} else {
 		return -EINVAL;
 	}
 
-	source_freq = Cy_SysClk_ClkHfGetFrequency(
-		_i2c_get_hfclk_for_peri_group(data->clock_peri_group));
+	hfclk_idx = ifx_cat1_utils_peri_pclk_get_hfclk(data->clock_peri_group);
+	if (hfclk_idx == (uint8_t)-EINVAL) {
+		return -ENOTSUP;
+	}
+
+	source_freq = Cy_SysClk_ClkHfGetFrequency(hfclk_idx);
 	if (source_freq == 0) {
 		return -EIO;
 	}
@@ -361,7 +331,14 @@ static int _i2c_set_peri_divider_edge(const struct device *dev, uint32_t freq, b
 		div_value = 1;
 	}
 
-	status = ifx_cat1_utils_peri_pclk_set_divider(config->clk_dst, &data->clock, div_value - 1);
+	if ((data->clock.block & 0x02) == 0) {
+		status = ifx_cat1_utils_peri_pclk_set_divider(config->clk_dst, &data->clock,
+									div_value - 1);
+	} else {
+		status = ifx_cat1_utils_peri_pclk_set_frac_divider(config->clk_dst, &data->clock,
+								    div_value - 1, 0);
+	}
+
 	if (status != CY_RSLT_SUCCESS) {
 		return -EIO;
 	}
@@ -1080,7 +1057,11 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 #endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
 };
 
-#if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#define PERI_INFO(n) .clock_peri_group = IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(               \
+	DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),                       \
+	DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1)),
+#elif defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C)
 #define PERI_INFO(n) .clock_peri_group = DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),
 #else
 #define PERI_INFO(n)

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -262,6 +262,120 @@ void ifx_cat1_i2c_register_callback(const struct device *dev,
 	data->irq_cause = 0;
 }
 
+#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+/* Packs a (peri-instance, peri-group) pair into a single uint8_t key,
+ * matching the macro used in uart_infineon_pdl.c and spi_infineon_pdl.c.
+ */
+#define IFX_CAT1_INSTANCE_GROUP(instance, group) (((instance) << 4) | (group))
+
+/* Map peri group to the HF clock index that drives it on PSE84.
+ * Mirrors ifx_cat1_get_hfclk_for_peri_group() in uart_infineon_pdl.c.
+ */
+static uint8_t _i2c_get_hfclk_for_peri_group(uint8_t peri_group)
+{
+#if defined(CONFIG_SOC_SERIES_PSE84)
+	switch (peri_group) {
+	case IFX_CAT1_INSTANCE_GROUP(0, 0):
+	case IFX_CAT1_INSTANCE_GROUP(1, 4):
+		return 0;
+	case IFX_CAT1_INSTANCE_GROUP(0, 7):
+	case IFX_CAT1_INSTANCE_GROUP(1, 0):
+		return 1;
+	case IFX_CAT1_INSTANCE_GROUP(0, 3):
+	case IFX_CAT1_INSTANCE_GROUP(1, 2):
+		return 5;
+	case IFX_CAT1_INSTANCE_GROUP(0, 4):
+	case IFX_CAT1_INSTANCE_GROUP(1, 3):
+		return 6;
+	case IFX_CAT1_INSTANCE_GROUP(1, 1):
+		return 7;
+	case IFX_CAT1_INSTANCE_GROUP(0, 2):
+		return 9;
+	case IFX_CAT1_INSTANCE_GROUP(0, 1):
+	case IFX_CAT1_INSTANCE_GROUP(0, 5):
+		return 10;
+	case IFX_CAT1_INSTANCE_GROUP(0, 8):
+		return 11;
+	case IFX_CAT1_INSTANCE_GROUP(0, 6):
+	case IFX_CAT1_INSTANCE_GROUP(0, 9):
+		return 13;
+	default:
+		break;
+	}
+#endif
+	return 0;
+}
+
+/*
+ * Set the peri clock divider for I2C on PSOC Edge so that the SCB input clock
+ * falls in the range required by Cy_SCB_I2C_SetDataRate().
+ *
+ * Target peri frequencies (from the PDL API Reference Guide for PSOC Edge):
+ *   Controller 100 kHz:  [1.55, 3.2]  MHz -> 2 MHz
+ *   Controller 400 kHz:  [7.82, 10]   MHz -> 8.5 MHz
+ *   Controller 1 MHz:    [14.32, 25.8] MHz -> 20 MHz
+ *   Target     100 kHz:  [1.55, 12.8] MHz -> 6 MHz
+ *   Target     400 kHz:  [7.82, 15.38] MHz -> 12 MHz
+ *   Target     1 MHz:    [15.84, 89.0] MHz -> 50 MHz
+ */
+static int _i2c_set_peri_divider_edge(const struct device *dev, uint32_t freq, bool is_target_mode)
+{
+#define _EDGE_SCB_I2C_PERI_CTRL_STD   2000000UL  /* controller, 100 kHz */
+#define _EDGE_SCB_I2C_PERI_CTRL_FST   8500000UL  /* controller, 400 kHz */
+#define _EDGE_SCB_I2C_PERI_CTRL_FSTP  20000000UL /* controller, 1 MHz   */
+#define _EDGE_SCB_I2C_PERI_TGT_STD    6000000UL  /* target, 100 kHz     */
+#define _EDGE_SCB_I2C_PERI_TGT_FST    12000000UL /* target, 400 kHz     */
+#define _EDGE_SCB_I2C_PERI_TGT_FSTP   50000000UL /* target, 1 MHz       */
+
+	struct ifx_cat1_i2c_data *data = dev->data;
+	const struct ifx_cat1_i2c_config *const config = dev->config;
+	CySCB_Type *base = config->base;
+	uint32_t peri_freq = 0;
+	uint32_t source_freq;
+	uint32_t div_value;
+	cy_rslt_t status;
+
+	if (freq <= CY_SCB_I2C_STD_DATA_RATE) {
+		peri_freq = is_target_mode ? _EDGE_SCB_I2C_PERI_TGT_STD
+					   : _EDGE_SCB_I2C_PERI_CTRL_STD;
+	} else if (freq <= CY_SCB_I2C_FST_DATA_RATE) {
+		peri_freq = is_target_mode ? _EDGE_SCB_I2C_PERI_TGT_FST
+					   : _EDGE_SCB_I2C_PERI_CTRL_FST;
+	} else if (freq <= CY_SCB_I2C_FSTP_DATA_RATE) {
+		peri_freq = is_target_mode ? _EDGE_SCB_I2C_PERI_TGT_FSTP
+					   : _EDGE_SCB_I2C_PERI_CTRL_FSTP;
+	}
+
+	if (peri_freq == 0) {
+		return -EINVAL;
+	}
+
+	source_freq = Cy_SysClk_ClkHfGetFrequency(
+		_i2c_get_hfclk_for_peri_group(data->clock_peri_group));
+	if (source_freq == 0) {
+		return -EIO;
+	}
+
+	div_value = source_freq / peri_freq;
+	if (div_value == 0) {
+		div_value = 1;
+	}
+
+	status = ifx_cat1_utils_peri_pclk_set_divider(config->clk_dst, &data->clock, div_value - 1);
+	if (status != CY_RSLT_SUCCESS) {
+		return -EIO;
+	}
+
+	ifx_cat1_utils_peri_pclk_enable_divider(config->clk_dst, &data->clock);
+
+	uint32_t actual_peri_freq = ifx_cat1_utils_peri_pclk_get_frequency(
+		config->clk_dst, &data->clock);
+
+	Cy_SCB_I2C_SetDataRate(base, freq, actual_peri_freq);
+	return 0;
+}
+#endif /* CONFIG_SOC_FAMILY_INFINEON_EDGE */
+
 #ifdef USE_I2C_SET_PERI_DIVIDER
 uint32_t _i2c_set_peri_divider(const struct device *dev, uint32_t freq, bool is_slave)
 {
@@ -509,8 +623,16 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 #ifdef USE_I2C_SET_PERI_DIVIDER
 	_i2c_set_peri_divider(dev, CAT1_I2C_SPEED_STANDARD_HZ,
 			      (data->scb_config.i2cMode == CY_SCB_I2C_SLAVE));
+#elif defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+	if (_i2c_set_peri_divider_edge(dev, data->frequencyhal_hz,
+				      (data->scb_config.i2cMode == CY_SCB_I2C_SLAVE)) != 0) {
+		LOG_ERR("Failed to configure I2C peripheral clock divider");
+		k_sem_give(&data->operation_sem);
+		return -EIO;
+	}
 #elif defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
-	if (_i2c_set_peri_divider_psoc4(dev, data->frequencyhal_hz, is_target_mode) != 0) {
+	if (_i2c_set_peri_divider_psoc4(dev, data->frequencyhal_hz,
+				       (data->scb_config.i2cMode == CY_SCB_I2C_SLAVE)) != 0) {
 		LOG_ERR("Failed to configure I2C peripheral clock divider");
 		k_sem_give(&data->operation_sem);
 		return -EIO;


### PR DESCRIPTION
**Description**
This PR adds proper peripheral clock divider setup for the Infineon I2C driver on PSOC Edge devices and hardens the clock source mapping to prevent silent misconfiguration.
The original PSOC Edge I2C implementation lacked an explicit path to program the SCB peripheral divider, leaving the divider in power-on-reset state (divide-by-1). This caused the SCB input clock to run at the raw HF clock frequency (≥100 MHz), making I2C waveforms many orders of magnitude too fast for any slave device to respond.
Additionally, the follow-up correction adds an explicit invalid HFCLK mapping sentinel to prevent silent fallback to clock index 0 when the peri-group to HFCLK mapping is unknown. This ensures failures are explicit rather than resulting in subtle I2C timing issues.

I2C is a critical interface on the platform (used for sensors, peripherals, etc.), so correct initialization is essential. Without these fixes:

- I2C initialization appears to succeed, but slave devices do not respond.
- Bus timing is incorrect (SCB clock runs uncontrolled), preventing valid communication.
- Debugging is difficult because there is no explicit error signal.
- With this PR, I2C on PSOC Edge:
- Properly divides the peripheral clock to the required range (e.g., 2 MHz for 100 kHz mode).
- Calls Cy_SCB_I2C_SetDataRate() with the actual clock frequency.
- Fails fast and explicitly if clock mapping is unsupported.
- This enables full I2C functionality for ArduinoCore-Zephyr PSOC Edge boards and makes future portability to other Edge variants safer and more maintainable.