### PR TITLE
include: modem: reparent vendor cellular APIs in doxygen

### DIFF
--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -19,6 +19,10 @@
  * @defgroup cellular_interface Cellular
  * @ingroup io_interfaces
  * @{
+ *
+ * @defgroup cellular_interface_ext Device-specific Cellular API extensions
+ * @{
+ * @}
  */
 
 #include <zephyr/types.h>

--- a/include/zephyr/drivers/modem/hl78xx_apis.h
+++ b/include/zephyr/drivers/modem/hl78xx_apis.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file hl78xx_apis.h
+ * @brief Header file for extended cellular API of HL78xx modems
+ * @ingroup hl78xx_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_HL78XX_APIS_H_
 #define ZEPHYR_INCLUDE_DRIVERS_HL78XX_APIS_H_
 
@@ -18,7 +25,9 @@ extern "C" {
 #endif
 
 /**
- * @defgroup hl78xx_constants HL78xx Constants and Macros
+ * @defgroup hl78xx_interface HL78xx
+ * @brief Sierra Wireless HL78xx cellular modems
+ * @ingroup cellular_interface_ext
  * @{
  */
 
@@ -73,8 +82,6 @@ extern "C" {
 #define MDM_MAX_HOSTNAME_LEN     128
 /** Maximum length of serial number string */
 #define MDM_SERIAL_NUMBER_LENGTH 32
-
-/** @} */
 
 /**
  * @brief Define an Event monitor to receive notifications in the system workqueue thread.
@@ -1292,5 +1299,7 @@ int hl78xx_gnss_assist_data_delete(const struct device *dev);
 #ifdef __cplusplus
 }
 #endif
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_HL78XX_APIS_H_ */

--- a/include/zephyr/drivers/modem/st87mxx_app_services.h
+++ b/include/zephyr/drivers/modem/st87mxx_app_services.h
@@ -5,15 +5,24 @@
  */
 
 /**
- * @file
- * @brief ST87Mxx application services public API.
+ * @file st87mxx_app_services.h
+ * @brief Header file for extended cellular API of ST87Mxx modems
+ * @ingroup st87mxx_interface
  */
 
 #ifndef STM87MXX_APP_SRV_H
 #define STM87MXX_APP_SRV_H
 
 /**
+ * @defgroup st87mxx_interface ST87Mxx
+ * @brief STMicroelectronics ST87Mxx cellular modems
+ * @ingroup cellular_interface_ext
+ * @{
+ */
+
+/**
  * @defgroup st87mxx_constants ST87Mxx Constants
+ * @ingroup st87mxx_interface
  * @{
  */
 
@@ -24,6 +33,7 @@
 
 /**
  * @defgroup st87mxx_gnss_configuration GNSS configuration
+ * @ingroup st87mxx_interface
  * @{
  */
 
@@ -73,6 +83,7 @@
 
 /**
  * @defgroup st87mxx_wscan_configuration WIFI scanning configuration
+ * @ingroup st87mxx_interface
  * @{
  */
 
@@ -238,5 +249,7 @@ int st87mxx_getrssi(st87mxx_get_rssi_callback_t *get_rssi_callback_func);
  * @retval State of the current sequence
  */
 sequence_state st87mxx_app_services_getstate(void);
+
+/** @} */
 
 #endif /* STM87MXX_APP_SRV_H */


### PR DESCRIPTION
Add cellular_interface_ext under the cellular driver API and group HL78xx and ST87Mxx extended APIs under it.