### PR TITLE
include: dma: realtek: reparent doxygen group

### DIFF
--- a/include/zephyr/drivers/dma/dma_bee.h
+++ b/include/zephyr/drivers/dma/dma_bee.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Realtek Bee DMA Configuration Macros
+ * @ingroup dma_bee_macros
  *
  * This header contains helper macros to extract DMA configuration parameters
  * (such as direction, data size, burst size, etc.) from the Devicetree
@@ -19,6 +20,7 @@
 /**
  * @defgroup dma_bee_macros Realtek Bee DMA Macros
  * @brief Macros for extracting DMA configuration from Devicetree
+ * @ingroup dma_interface
  * @{
  */
 


### PR DESCRIPTION
dma_bee.h documentation was "polluting" top-level doxygen groups. Fix by reparenting under DMA (will need to properly organize/document all other DMA headers at some point, btw).