### PR TITLE
drivers: ethernet: dwc_mac: esp32: add support

### DIFF
--- a/drivers/ethernet/dwc_mac/CMakeLists.txt
+++ b/drivers/ethernet/dwc_mac/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_library_sources_ifdef(CONFIG_ETH_DWC_ETHER_QOS_CORE eth_dwc_ether_qos_cor
 # Platform specific drivers
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_ETH_DWMAC_MMU eth_dwmac_mmu.c)
+zephyr_library_sources_ifdef(CONFIG_ETH_ESP32_DWC_ETHER_1000 eth_esp32_dwc_ether_1000.c)
 zephyr_library_sources_ifdef(CONFIG_ETH_STM32_DWC_ETHER_1000 eth_stm32_dwc_ether_1000.c)
 zephyr_library_sources_ifdef(CONFIG_ETH_STM32_DWC_ETHER_QOS eth_stm32_dwc_ether_qos.c)
 # zephyr-keep-sorted-stop

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -145,7 +145,9 @@ config ETH_DWC_ETHER_TX_HW_CHECKSUM
 	default y
 	help
 	  Enable transmit checksum offload to enhance throughput
-	  performances.
+	  performances. Only supported when store and forward mode
+	  is used for tx, which can't be used if the tx fifo is smaller
+	  than the maximum frame size.
 
 config ETH_DWC_ETHER_TX_HW_CHECKSUM_EN
 	bool

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -28,9 +28,10 @@ config ETH_DWC_ETHER_1000_CORE
 config ETH_ESP32_DWC_ETHER_1000
 	bool "Driver for DWC Ethernet MAC-based ESP32"
 	depends on !ETH_ESP32
-	depends on SOC_SERIES_ESP32
+	depends on SOC_SERIES_ESP32 || SOC_SERIES_ESP32P4
 	depends on DT_HAS_ESPRESSIF_ESP32_ETH_ENABLED
 	select ETH_DWC_ETHER_1000_CORE
+	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	default y
 	help
 	  This enables the Synopsys DesignWare MAC driver for ESP32 SoCs.
@@ -140,6 +141,7 @@ if ETH_DWC_ETHER_1000_CORE
 config ETH_DWC_ETHER_TX_HW_CHECKSUM
 	bool "Use TX hardware checksum"
 	select NET_CHECKSUM_OFFLOAD_SUPPORTED if NET_L2_ETHERNET
+	depends on !SOC_SERIES_ESP32P4
 	default y
 	help
 	  Enable transmit checksum offload to enhance throughput

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -25,6 +25,16 @@ config ETH_DWC_ETHER_1000_CORE
 	  also referred to as "dwc_ether_mac10_100_1000_universal".
 	  IP version v3.x is supported.
 
+config ETH_ESP32_DWC_ETHER_1000
+	bool "Driver for DWC Ethernet MAC-based ESP32"
+	depends on !ETH_ESP32
+	depends on SOC_SERIES_ESP32
+	depends on DT_HAS_ESPRESSIF_ESP32_ETH_ENABLED
+	select ETH_DWC_ETHER_1000_CORE
+	default y
+	help
+	  This enables the Synopsys DesignWare MAC driver for ESP32 SoCs.
+
 config ETH_STM32_DWC_ETHER_QOS
 	bool "Driver for DWC Ethernet QoS-based STM32"
 	depends on !ETH_STM32_HAL

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -203,7 +203,7 @@ static void dwmac_tx_release(const struct device *dev)
 			net_pkt_unref(pkt);
 
 			if ((des0 & TDES0_ES) != 0U) {
-				LOG_ERR("tx error (DES0 = 0x%08x)", des0);
+				LOG_DBG("tx error (DES0 = 0x%08x)", des0);
 				eth_stats_update_errors_tx(p->iface);
 			}
 		}
@@ -275,7 +275,7 @@ static void dwmac_receive(const struct device *dev)
 					net_pkt_unref(p->rx_pkt);
 				}
 			} else {
-				LOG_ERR("rx error (DES0 = 0x%08x)", des0);
+				LOG_DBG("rx error (DES0 = 0x%08x)", des0);
 				eth_stats_update_errors_rx(p->iface);
 				net_pkt_unref(p->rx_pkt);
 			}

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -271,7 +271,9 @@ static void dwmac_receive(const struct device *dev)
 
 		if ((des0 & RDES0_LS) != 0U) {
 			if ((des0 & RDES0_ES) == 0U) {
-				net_recv_data(p->iface, p->rx_pkt);
+				if (net_recv_data(p->iface, p->rx_pkt) < 0) {
+					net_pkt_unref(p->rx_pkt);
+				}
 			} else {
 				LOG_ERR("rx error (DES0 = 0x%08x)", des0);
 				eth_stats_update_errors_rx(p->iface);

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -556,6 +556,8 @@ int dwmac_probe(const struct device *dev)
 			(p->feature0 & DWMAC_HWFR_ALTDESC) ? "yes" : "no");
 	}
 
+	DWMAC_REG_WRITE(DWMAC_DMAOMR, DWMAC_DMAOMR_TSF | DWMAC_DMAOMR_RSF);
+
 	ret = dwmac_platform_init(dev);
 	if (ret < 0) {
 		return ret;
@@ -570,7 +572,6 @@ int dwmac_probe(const struct device *dev)
 
 	DWMAC_REG_WRITE(DWMAC_DMATDLAR, TXDESC_PHYS_L(0));
 	DWMAC_REG_WRITE(DWMAC_DMARDLAR, RXDESC_PHYS_L(0));
-	DWMAC_REG_WRITE(DWMAC_DMAOMR, DWMAC_DMAOMR_TSF | DWMAC_DMAOMR_RSF);
 
 	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_RX_HW_CHECKSUM_EN)) {
 		DWMAC_REG_WRITE(DWMAC_MACCR, DWMAC_REG_READ(DWMAC_MACCR) | DWMAC_MACCR_IPCO);

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -523,6 +523,38 @@ int dwmac_probe(const struct device *dev)
 	/* get configured hardware features */
 	p->feature0 = DWMAC_REG_READ(DWMAC_HWFR);
 	LOG_DBG("hw_feature: 0x%08x", p->feature0);
+	/* early IP versions don't support this register */
+	if (p->feature0 != 0) {
+		LOG_DBG("10/100 Mbps support: %s",
+			(p->feature0 & DWMAC_HWFR_10_100) ? "yes" : "no");
+		LOG_DBG("1000 Mbps support: %s", (p->feature0 & DWMAC_HWFR_1000) ? "yes" : "no");
+		LOG_DBG("Half-duplex support: %s", (p->feature0 & DWMAC_HWFR_HD) ? "yes" : "no");
+		LOG_DBG("Expanded DA Hash Filter: %s",
+			(p->feature0 & DWMAC_HWFR_HASHF) ? "yes" : "no");
+		LOG_DBG("Multiple MAC Addr Reg: %s",
+			(p->feature0 & DWMAC_HWFR_ADDMAC) ? "yes" : "no");
+		LOG_DBG("PCS register support: %s", (p->feature0 & DWMAC_HWFR_PCS) ? "yes" : "no");
+		LOG_DBG("SMA(MDIO) support: %s",
+			(p->feature0 & DWMAC_HWFR_SMA) ? "yes" : "no");
+		LOG_DBG("PMT Remote Wakeup support: %s",
+			(p->feature0 & DWMAC_HWFR_PMTW) ? "yes" : "no");
+		LOG_DBG("PMT Magic Packet support: %s",
+			(p->feature0 & DWMAC_HWFR_PMTM) ? "yes" : "no");
+		LOG_DBG("RMON support: %s", (p->feature0 & DWMAC_HWFR_RMON) ? "yes" : "no");
+		LOG_DBG("IEEE 1588-2002 support: %s",
+			(p->feature0 & DWMAC_HWFR_TS2002) ? "yes" : "no");
+		LOG_DBG("IEEE 1588-2008 support: %s",
+			(p->feature0 & DWMAC_HWFR_TS2008) ? "yes" : "no");
+		LOG_DBG("TX Checksum Offload support: %s",
+			(p->feature0 & DWMAC_HWFR_TX_CHK) ? "yes" : "no");
+		LOG_DBG("RX Checksum Offload support: %s",
+			(p->feature0 & DWMAC_HWFR_RXCHKV1) ? "yes" : "no");
+		LOG_DBG("RX Checksum Offload v2 support: %s",
+			(p->feature0 & DWMAC_HWFR_RXCHKV2) ? "yes" : "no");
+		LOG_DBG(">2K FIFO support: %s", (p->feature0 & DWMAC_HWFR_FIFO2K) ? "yes" : "no");
+		LOG_DBG("Alternate Descriptor support: %s",
+			(p->feature0 & DWMAC_HWFR_ALTDESC) ? "yes" : "no");
+	}
 
 	ret = dwmac_platform_init(dev);
 	if (ret < 0) {

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -490,6 +490,7 @@ static void dwmac_iface_init(struct net_if *iface)
 
 	DWMAC_REG_WRITE(DWMAC_MACCR,
 			DWMAC_REG_READ(DWMAC_MACCR) |
+			DWMAC_MACCR_APCS |
 			DWMAC_MACCR_CSTF |
 			DWMAC_MACCR_TE |
 			DWMAC_MACCR_RE);

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -321,7 +321,9 @@ static void dwmac_receive(struct dwmac_priv *p)
 				LOG_DBG("pkt len/frags=%zd/%d",
 					net_pkt_get_len(p->rx_pkt),
 					net_pkt_get_nbfrags(p->rx_pkt));
-				net_recv_data(p->iface, p->rx_pkt);
+				if (net_recv_data(p->iface, p->rx_pkt) < 0) {
+					net_pkt_unref(p->rx_pkt);
+				}
 			} else {
 				LOG_ERR("rx error (DES3 = 0x%08x)", des3_val);
 				eth_stats_update_errors_rx(p->iface);

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -1327,9 +1327,12 @@ extern const struct ethernet_api dwmac_api;
 
 /* DMA operation mode bits */
 #define DWMAC_DMAOMR_SR    BIT(1)
+#define DWMAC_DMAOMR_OSF   BIT(2)
 #define DWMAC_DMAOMR_ST    BIT(13)
 #define DWMAC_DMAOMR_TSF   BIT(21)
 #define DWMAC_DMAOMR_RSF   BIT(25)
+#define DWMAC_DMAOMR_TTC   GENMASK(16, 14)
+#define DWMAC_DMAOMR_RTC   GENMASK(4, 3)
 
 /* DMA bus mode bits */
 #define DWMAC_DMABMR_SR    BIT(0)

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -1280,8 +1280,13 @@ extern const struct ethernet_api dwmac_api;
 
 #elif defined(CONFIG_ETH_DWC_ETHER_1000_CORE)
 
+#ifdef CONFIG_SOC_SERIES_ESP32
+#define DWMAC_MAC_OFFSET		0x1000
+#define DWMAC_DMA_OFFSET		0x0000
+#else
 #define DWMAC_MAC_OFFSET		0x0000
 #define DWMAC_DMA_OFFSET		0x1000
+#endif
 
 /* GMAC register map */
 #define DWMAC_MACCR      (DWMAC_MAC_OFFSET + 0x0000)

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -1280,22 +1280,25 @@ extern const struct ethernet_api dwmac_api;
 
 #elif defined(CONFIG_ETH_DWC_ETHER_1000_CORE)
 
-/* GMAC register map */
-#define DWMAC_MACCR      0x0000
-#define DWMAC_MACFFR     0x0004
-#define DWMAC_MACVERR    0x0020
-#define DWMAC_MACA0HR    0x0040
-#define DWMAC_MACA0LR    0x0044
+#define DWMAC_MAC_OFFSET		0x0000
+#define DWMAC_DMA_OFFSET		0x1000
 
-#define DWMAC_DMABMR       0x1000
-#define DWMAC_DMATPDR      0x1004
-#define DWMAC_DMARPDR      0x1008
-#define DWMAC_DMARDLAR     0x100C
-#define DWMAC_DMATDLAR     0x1010
-#define DWMAC_DMASR        0x1014
-#define DWMAC_DMAOMR       0x1018
-#define DWMAC_DMAIER       0x101C
-#define DWMAC_HWFR         0x1058
+/* GMAC register map */
+#define DWMAC_MACCR      (DWMAC_MAC_OFFSET + 0x0000)
+#define DWMAC_MACFFR     (DWMAC_MAC_OFFSET + 0x0004)
+#define DWMAC_MACVERR    (DWMAC_MAC_OFFSET + 0x0020)
+#define DWMAC_MACA0HR    (DWMAC_MAC_OFFSET + 0x0040)
+#define DWMAC_MACA0LR    (DWMAC_MAC_OFFSET + 0x0044)
+
+#define DWMAC_DMABMR       (DWMAC_DMA_OFFSET + 0x0000)
+#define DWMAC_DMATPDR      (DWMAC_DMA_OFFSET + 0x0004)
+#define DWMAC_DMARPDR      (DWMAC_DMA_OFFSET + 0x0008)
+#define DWMAC_DMARDLAR     (DWMAC_DMA_OFFSET + 0x000C)
+#define DWMAC_DMATDLAR     (DWMAC_DMA_OFFSET + 0x0010)
+#define DWMAC_DMASR        (DWMAC_DMA_OFFSET + 0x0014)
+#define DWMAC_DMAOMR       (DWMAC_DMA_OFFSET + 0x0018)
+#define DWMAC_DMAIER       (DWMAC_DMA_OFFSET + 0x001C)
+#define DWMAC_HWFR         (DWMAC_DMA_OFFSET + 0x0058)
 
 /* MAC control bits */
 #define DWMAC_MACCR_RE     BIT(2)
@@ -1355,8 +1358,8 @@ extern const struct ethernet_api dwmac_api;
 #define DWMAC_HWFR_ALTDESC BIT(24)
 
 /* DWMAC v3.x MDIO registers (GMAC core) */
-#define MAC_MDIO_ADDRESS 0x0010
-#define MAC_MDIO_DATA    0x0014
+#define MAC_MDIO_ADDRESS (DWMAC_MAC_OFFSET + 0x0010)
+#define MAC_MDIO_DATA    (DWMAC_MAC_OFFSET + 0x0014)
 
 #define MAC_MDIO_ADDRESS_PA     GENMASK(15, 11)
 #define MAC_MDIO_ADDRESS_RDA    GENMASK(10, 6)

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -1308,6 +1308,7 @@ extern const struct ethernet_api dwmac_api;
 /* MAC control bits */
 #define DWMAC_MACCR_RE     BIT(2)
 #define DWMAC_MACCR_TE     BIT(3)
+#define DWMAC_MACCR_APCS   BIT(7)
 #define DWMAC_MACCR_IPCO   BIT(10)
 #define DWMAC_MACCR_DM     BIT(11)
 #define DWMAC_MACCR_FES    BIT(14)

--- a/drivers/ethernet/dwc_mac/eth_esp32_dwc_ether_1000.c
+++ b/drivers/ethernet/dwc_mac/eth_esp32_dwc_ether_1000.c
@@ -1,0 +1,151 @@
+/*
+ * Driver for Synopsys DesignWare MAC
+ *
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(dwmac_plat, CONFIG_ETHERNET_LOG_LEVEL);
+
+#define DT_DRV_COMPAT espressif_esp32_eth
+
+#include <sys/types.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
+
+#include "eth_dwmac_priv.h"
+
+#include <esp_mac.h>
+#include <hal/emac_ll.h>
+
+#include "../eth_esp32_priv.h"
+
+BUILD_ASSERT(DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rmii) ||
+		     DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii),
+	     "Unsupported PHY interface type. Only RMII and MII are supported.");
+
+/* The DMA bus master interface is 32-bit on this IP */
+#define DATA_BUS_WIDTH 32
+
+DWMAC_ASSERT_BUFFER_ALIGNMENT(DATA_BUS_WIDTH);
+
+PINCTRL_DT_INST_DEFINE(0);
+
+int dwmac_bus_init(const struct device *dev)
+{
+	const struct dwmac_config *cfg = dev->config;
+	const struct pinctrl_dev_config *pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0);
+	int ret;
+
+	ret = clock_control_on(cfg->clock, cfg->mac_clk);
+	if (ret < 0 && ret != -EALREADY) {
+		LOG_ERR("Failed to setup ethernet clock");
+		return ret;
+	}
+
+	if (DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rmii)) {
+		int rmii_clk_gpio = -1;
+
+		ret = esp32_emac_iomux_init_rmii_pinctrl(pcfg, &rmii_clk_gpio);
+		if (ret != 0) {
+			return -EIO;
+		}
+#if DT_INST_NODE_HAS_PROP(0, ref_clk_output_gpios)
+		BUILD_ASSERT(DT_INST_GPIO_PIN(0, ref_clk_output_gpios) == 0 ||
+				     DT_INST_GPIO_PIN(0, ref_clk_output_gpios) == 16 ||
+				     DT_INST_GPIO_PIN(0, ref_clk_output_gpios) == 17,
+			     "Only GPIO0/16/17 are allowed as a GPIO REF_CLK source!");
+		int ref_clk_gpio = DT_INST_GPIO_PIN(0, ref_clk_output_gpios);
+
+		esp32_emac_iomux_rmii_clk_output(ref_clk_gpio);
+
+		/* Configure REF_CLK output when GPIO0 is used */
+		if (ref_clk_gpio == 0) {
+			REG_SET_FIELD(PIN_CTRL, CLK_OUT1, 6);
+		}
+
+		emac_ll_clock_enable_rmii_output(&EMAC_EXT);
+		esp_clk_tree_enable_src(SOC_MOD_CLK_APLL, true);
+		ret = esp32_emac_config_apll_clock();
+		if (ret != 0) {
+			return -EIO;
+		}
+#else
+		esp32_emac_iomux_rmii_clk_input(rmii_clk_gpio);
+		emac_ll_clock_enable_rmii_input(&EMAC_EXT);
+#endif
+	} else { /* phy_connection_type: mii */
+		esp32_emac_iomux_init_mii();
+		emac_ll_clock_enable_mii(&EMAC_EXT);
+	}
+
+	return 0;
+}
+
+#define DESCRIPTOR_ALIGNMENT ((DATA_BUS_WIDTH) / (BITS_PER_BYTE))
+
+#if defined(CONFIG_NOCACHE_MEMORY)
+#define __desc_mem __nocache_noinit __aligned(DESCRIPTOR_ALIGNMENT)
+#else
+#define __desc_mem __noinit __aligned(DESCRIPTOR_ALIGNMENT)
+#endif
+
+static struct dwmac_dma_desc dwmac_tx_descs[NB_TX_DESCS] __desc_mem;
+static struct dwmac_dma_desc dwmac_rx_descs[NB_RX_DESCS] __desc_mem;
+
+int dwmac_platform_init(const struct device *dev)
+{
+	const struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
+	struct dwmac_priv *p = dev->data;
+	int ret;
+
+	p->tx_descs = dwmac_tx_descs;
+	p->rx_descs = dwmac_rx_descs;
+
+	/* Configure ISR */
+	ret = esp_intr_alloc(DT_INST_IRQ_BY_IDX(0, 0, irq),
+			     ESP_PRIO_TO_FLAGS(DT_INST_IRQ_BY_IDX(0, 0, priority)) |
+				     ESP_INT_FLAGS_CHECK(DT_INST_IRQ_BY_IDX(0, 0, flags)),
+			     (intr_handler_t)dwmac_isr, (void *)(uintptr_t)dev, NULL);
+	if (ret != 0) {
+		return -EIO;
+	}
+
+	ret = net_eth_mac_load(&mac_cfg, p->mac_addr);
+	if (ret == -ENODATA) {
+		if (esp_read_mac(p->mac_addr, ESP_MAC_ETH) != ESP_OK) {
+			ret = -EIO;
+		} else {
+			ret = 0;
+		}
+	}
+
+	if (ret < 0) {
+		LOG_ERR("Failed to load MAC address (%d)", ret);
+		return ret;
+	}
+
+	LOG_DBG("MAC address %02x:%02x:%02x:%02x:%02x:%02x", p->mac_addr[0], p->mac_addr[1],
+		p->mac_addr[2], p->mac_addr[3], p->mac_addr[4], p->mac_addr[5]);
+
+	return 0;
+}
+
+static const struct dwmac_config dwmac_config = {
+	DEVICE_MMIO_ROM_INIT(DT_DRV_INST(0)),
+	.phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, phy_handle)),
+	.clock = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
+	.mac_clk = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, offset),
+};
+
+static struct dwmac_priv dwmac_instance;
+
+ETH_NET_DEVICE_DT_INST_DEFINE(0, dwmac_probe, NULL, &dwmac_instance, &dwmac_config,
+			      CONFIG_ETH_INIT_PRIORITY, &dwmac_api, NET_ETH_MTU);

--- a/drivers/ethernet/dwc_mac/eth_esp32_dwc_ether_1000.c
+++ b/drivers/ethernet/dwc_mac/eth_esp32_dwc_ether_1000.c
@@ -38,6 +38,12 @@ DWMAC_ASSERT_BUFFER_ALIGNMENT(DATA_BUS_WIDTH);
 
 PINCTRL_DT_INST_DEFINE(0);
 
+#ifdef CONFIG_SOC_SERIES_ESP32
+#define EMAC_EXT_ADDR (&EMAC_EXT)
+#else
+#define EMAC_EXT_ADDR (NULL)
+#endif
+
 int dwmac_bus_init(const struct device *dev)
 {
 	const struct dwmac_config *cfg = dev->config;
@@ -71,7 +77,7 @@ int dwmac_bus_init(const struct device *dev)
 			REG_SET_FIELD(PIN_CTRL, CLK_OUT1, 6);
 		}
 
-		emac_ll_clock_enable_rmii_output(&EMAC_EXT);
+		emac_ll_clock_enable_rmii_output(EMAC_EXT_ADDR);
 		esp_clk_tree_enable_src(SOC_MOD_CLK_APLL, true);
 		ret = esp32_emac_config_apll_clock();
 		if (ret != 0) {
@@ -79,11 +85,11 @@ int dwmac_bus_init(const struct device *dev)
 		}
 #else
 		esp32_emac_iomux_rmii_clk_input(rmii_clk_gpio);
-		emac_ll_clock_enable_rmii_input(&EMAC_EXT);
+		emac_ll_clock_enable_rmii_input(EMAC_EXT_ADDR);
 #endif
 	} else { /* phy_connection_type: mii */
 		esp32_emac_iomux_init_mii();
-		emac_ll_clock_enable_mii(&EMAC_EXT);
+		emac_ll_clock_enable_mii(EMAC_EXT_ADDR);
 	}
 
 	return 0;
@@ -108,6 +114,12 @@ int dwmac_platform_init(const struct device *dev)
 
 	p->tx_descs = dwmac_tx_descs;
 	p->rx_descs = dwmac_rx_descs;
+
+#ifdef CONFIG_SOC_SERIES_ESP32P4
+	/* Deactivates store and forward mode for rx and tx */
+	/* Enable OSF (Operate on Second Frame) to improve performance */
+	DWMAC_REG_WRITE(DWMAC_DMAOMR, DWMAC_DMAOMR_OSF | FIELD_PREP(DWMAC_DMAOMR_RTC, 0x3));
+#endif
 
 	/* Configure ISR */
 	ret = esp_intr_alloc(DT_INST_IRQ_BY_IDX(0, 0, irq),

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -19,15 +19,11 @@
 #include <esp_mac.h>
 #include <hal/emac_hal.h>
 #include <hal/emac_ll.h>
-#include <hal/emac_periph.h>
 #include <soc/rtc.h>
 #include <soc/gpio_periph.h>
 #include <soc/gpio_sig_map.h>
-#include <soc/io_mux_reg.h>
 #include <soc/soc.h>
 #include <clk_ctrl_os.h>
-#include <esp_clk_tree.h>
-#include <esp_private/esp_clk_tree_common.h>
 
 LOG_MODULE_REGISTER(eth_esp32, CONFIG_ETHERNET_LOG_LEVEL);
 
@@ -387,102 +383,6 @@ static uint32_t eth_esp32_receive_frame(struct eth_esp32_dev_data *dev_data, uin
 	return copy_len;
 }
 
-#if !DT_INST_NODE_HAS_PROP(0, ref_clk_output_gpios)
-static void eth_esp32_iomux_rmii_clk_input(int gpio_num)
-{
-	const emac_iomux_info_t *pin;
-
-	pin = esp32_emac_iomux_find(emac_rmii_iomux_pins.clki, gpio_num);
-	if (pin != NULL) {
-		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-}
-#endif
-
-static void eth_esp32_iomux_init_mii(void)
-{
-	const emac_iomux_info_t *pin;
-
-	/*
-	 * ESP32 EMAC uses dedicated IOMUX pins, not GPIO matrix.
-	 * Only PIN_FUNC_SELECT is needed to route signals.
-	 */
-
-	/* TX_CLK - input */
-	pin = emac_mii_iomux_pins.clk_tx;
-	if (pin != NULL) {
-		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-
-	/* TX_EN - output */
-	pin = emac_mii_iomux_pins.tx_en;
-	if (pin != NULL) {
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-
-	/* TXD0-3 - outputs */
-	pin = emac_mii_iomux_pins.txd0;
-	if (pin != NULL) {
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-
-	pin = emac_mii_iomux_pins.txd1;
-	if (pin != NULL) {
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-
-	pin = emac_mii_iomux_pins.txd2;
-	if (pin != NULL) {
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-
-	pin = emac_mii_iomux_pins.txd3;
-	if (pin != NULL) {
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-
-	/* RX_CLK - input */
-	pin = emac_mii_iomux_pins.clk_rx;
-	if (pin != NULL) {
-		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-
-	/* RX_DV - input */
-	pin = emac_mii_iomux_pins.rx_dv;
-	if (pin != NULL) {
-		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-
-	/* RXD0-3 - inputs */
-	pin = emac_mii_iomux_pins.rxd0;
-	if (pin != NULL) {
-		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-
-	pin = emac_mii_iomux_pins.rxd1;
-	if (pin != NULL) {
-		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-
-	pin = emac_mii_iomux_pins.rxd2;
-	if (pin != NULL) {
-		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-
-	pin = emac_mii_iomux_pins.rxd3;
-	if (pin != NULL) {
-		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
-	}
-}
-
 static enum ethernet_hw_caps eth_esp32_caps(const struct device *dev __unused,
 					    struct net_if *iface __unused)
 {
@@ -729,11 +629,11 @@ int eth_esp32_initialize(const struct device *dev)
 			goto err;
 		}
 #else
-		eth_esp32_iomux_rmii_clk_input(rmii_clk_gpio);
+		esp32_emac_iomux_rmii_clk_input(rmii_clk_gpio);
 		emac_hal_clock_enable_rmii_input(&dev_data->hal);
 #endif
 	} else { /* phy_connection_type: mii */
-		eth_esp32_iomux_init_mii();
+		esp32_emac_iomux_init_mii();
 		emac_hal_clock_enable_mii(&dev_data->hal);
 	}
 

--- a/drivers/ethernet/eth_esp32_priv.h
+++ b/drivers/ethernet/eth_esp32_priv.h
@@ -11,6 +11,8 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 
+#include <esp_clk_tree.h>
+#include <esp_private/esp_clk_tree_common.h>
 #include <hal/emac_periph.h>
 #include <soc/gpio_periph.h>
 #include <soc/io_mux_reg.h>
@@ -185,6 +187,100 @@ static inline int esp32_emac_config_apll_clock(void)
 
 	return 0;
 }
+#else
+static inline void esp32_emac_iomux_rmii_clk_input(int gpio_num)
+{
+	const emac_iomux_info_t *pin;
+
+	pin = esp32_emac_iomux_find(emac_rmii_iomux_pins.clki, gpio_num);
+	if (pin != NULL) {
+		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+}
 #endif
+
+static inline void esp32_emac_iomux_init_mii(void)
+{
+	const emac_iomux_info_t *pin;
+
+	/*
+	 * ESP32 EMAC uses dedicated IOMUX pins, not GPIO matrix.
+	 * Only PIN_FUNC_SELECT is needed to route signals.
+	 */
+
+	/* TX_CLK - input */
+	pin = emac_mii_iomux_pins.clk_tx;
+	if (pin != NULL) {
+		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+
+	/* TX_EN - output */
+	pin = emac_mii_iomux_pins.tx_en;
+	if (pin != NULL) {
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+
+	/* TXD0-3 - outputs */
+	pin = emac_mii_iomux_pins.txd0;
+	if (pin != NULL) {
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+
+	pin = emac_mii_iomux_pins.txd1;
+	if (pin != NULL) {
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+
+	pin = emac_mii_iomux_pins.txd2;
+	if (pin != NULL) {
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+
+	pin = emac_mii_iomux_pins.txd3;
+	if (pin != NULL) {
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+
+	/* RX_CLK - input */
+	pin = emac_mii_iomux_pins.clk_rx;
+	if (pin != NULL) {
+		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+
+	/* RX_DV - input */
+	pin = emac_mii_iomux_pins.rx_dv;
+	if (pin != NULL) {
+		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+
+	/* RXD0-3 - inputs */
+	pin = emac_mii_iomux_pins.rxd0;
+	if (pin != NULL) {
+		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+
+	pin = emac_mii_iomux_pins.rxd1;
+	if (pin != NULL) {
+		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+
+	pin = emac_mii_iomux_pins.rxd2;
+	if (pin != NULL) {
+		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+
+	pin = emac_mii_iomux_pins.rxd3;
+	if (pin != NULL) {
+		PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin->gpio_num]);
+		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
+	}
+}
 
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_ESP32_PRIV_H_ */

--- a/drivers/ethernet/mdio/Kconfig.esp32
+++ b/drivers/ethernet/mdio/Kconfig.esp32
@@ -6,5 +6,6 @@ config MDIO_ESP32
 	default y
 	depends on SOC_SERIES_ESP32 || SOC_SERIES_ESP32P4
 	depends on DT_HAS_ESPRESSIF_ESP32_MDIO_ENABLED
+	depends on !MDIO_DWMAC
 	help
 	  Enable ESP32 MCU Family MDIO driver.

--- a/drivers/ethernet/mdio/mdio_esp32.c
+++ b/drivers/ethernet/mdio/mdio_esp32.c
@@ -16,12 +16,8 @@
 #include <esp_mac.h>
 #include <hal/emac_hal.h>
 #include <hal/emac_ll.h>
-#include <hal/emac_periph.h>
 #include <soc/rtc.h>
 #include <soc/gpio_periph.h>
-#include <soc/io_mux_reg.h>
-#include <esp_clk_tree.h>
-#include <esp_private/esp_clk_tree_common.h>
 
 LOG_MODULE_REGISTER(mdio_esp32, CONFIG_MDIO_LOG_LEVEL);
 

--- a/dts/riscv/espressif/esp32p4/esp32p4_common.dtsi
+++ b/dts/riscv/espressif/esp32p4/esp32p4_common.dtsi
@@ -683,7 +683,7 @@
 			status = "disabled";
 
 			mdio: mdio {
-				compatible = "espressif,esp32-mdio";
+				compatible = "espressif,esp32-mdio", "snps,dwmac-mdio";
 				status = "disabled";
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -586,7 +586,7 @@
 			status = "disabled";
 
 			mdio: mdio {
-				compatible = "espressif,esp32-mdio";
+				compatible = "espressif,esp32-mdio", "snps,dwmac-mdio";
 				status = "disabled";
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/soc/espressif/esp32/Kconfig
+++ b/soc/espressif/esp32/Kconfig
@@ -52,6 +52,7 @@ config ESP32_DEEP_SLEEP_WAKEUP_DELAY
 config ESP32_EMAC
 	bool
 	default y if ETH_ESP32
+	default y if ETH_ESP32_DWC_ETHER_1000
 	default y if MDIO_ESP32
 	help
 	  Hidden option to enable the ESP32 Ethernet MAC driver.

--- a/soc/espressif/esp32p4/Kconfig
+++ b/soc/espressif/esp32p4/Kconfig
@@ -72,6 +72,7 @@ rsource "Kconfig.caps"
 config ESP32P4_EMAC
 	bool
 	default y if ETH_ESP32
+	default y if ETH_ESP32_DWC_ETHER_1000
 	default y if MDIO_ESP32
 	help
 	  Hidden option to enable the ESP32-P4 Ethernet

--- a/tests/drivers/build_all/ethernet/tests.yaml
+++ b/tests/drivers/build_all/ethernet/tests.yaml
@@ -36,3 +36,4 @@ tests:
       - stm32h7s78_dk/stm32h7s7xx/ext_flash_app
       - stm32h573i_dk
       - esp32_ethernet_kit/esp32/procpu
+      - esp32p4x_function_ev_board/esp32p4/hpcore

--- a/tests/drivers/build_all/ethernet/tests.yaml
+++ b/tests/drivers/build_all/ethernet/tests.yaml
@@ -24,9 +24,10 @@ tests:
     platform_allow:
       - stm32h573i_dk
 
-  net.ethernet.build.stm32_dwmac:
+  net.ethernet.build.dwmac:
     extra_configs:
       - CONFIG_ETH_STM32_HAL=n
+      - CONFIG_ETH_ESP32=n
     platform_allow:
       - stm32h735g_disco
       - nucleo_h753zi
@@ -34,3 +35,4 @@ tests:
       - nucleo_f767zi
       - stm32h7s78_dk/stm32h7s7xx/ext_flash_app
       - stm32h573i_dk
+      - esp32_ethernet_kit/esp32/procpu


### PR DESCRIPTION
add support for the esp32 in the generic
dwc_mac driver.
esp32 specific code is based
the init of the original esp32 eth driver in zephyr.

The esp32 uses HW version 3.70.

test via
```
west build -p -b esp32_ethernet_kit/esp32/procpu samples/net/dhcpv4_client/ -- -DCONFIG_ETH_ESP32=n
```

works on the esp32 and the esp32p4
