### PR TITLE
boards: st: stm32h5f5j_dk: add Ethernet support

### DIFF
--- a/boards/st/stm32h5f5j_dk/doc/index.rst
+++ b/boards/st/stm32h5f5j_dk/doc/index.rst
@@ -170,6 +170,7 @@ Default Zephyr Peripheral Mapping:
 - LD3 (blue) : PB9
 - LD4 (orange) : PD15
 - ADC1 channel 0 input : PA0
+- ETH: PA1/PD1/PC4/PE5/PB11/PB12/PG12/PJ6/PJ7
 
 System Clock
 ------------

--- a/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
+++ b/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
@@ -223,9 +223,10 @@
 };
 
 &fdcan2 {
+	/* Disable by default due to conflict with MAC (PB12) */
 	pinctrl-0 = <&fdcan2_tx_pb13 &fdcan2_rx_pb12>;
 	pinctrl-names = "default";
-	status = "okay";
+	status = "disabled";
 };
 
 &fdcan3 {
@@ -267,6 +268,31 @@
 
 &vddcore {
 	status = "okay";
+};
+
+&mac {
+	pinctrl-0 = <&eth_rmii_ref_clk_pa1
+		     &eth_rmii_crs_dv_pd1
+		     &eth_rmii_rxd0_pc4
+		     &eth_rmii_rxd1_pe5
+		     &eth_rmii_tx_en_pb11
+		     &eth_rmii_txd0_pb12
+		     &eth_rmii_txd1_pg12>;
+	pinctrl-names = "default";
+	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+	status = "okay";
+};
+
+&mdio {
+	pinctrl-0 = <&eth_mdio_pj6 &eth_mdc_pj7>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
 };
 
 &xspim {

--- a/boards/st/stm32h5f5j_dk/stm32h5f5j_dk.yaml
+++ b/boards/st/stm32h5f5j_dk/stm32h5f5j_dk.yaml
@@ -19,6 +19,7 @@ supported:
   - entropy
   - gpio
   - i2c
+  - netif:eth
   - octospi
   - pwm
   - rtc


### PR DESCRIPTION
## Changes

- Added `mac` and `mdio` configuration to `stm32h5f5j_dk-common.dtsi` and enabled them. The RMII Ethernet pin configuration follows this schematic from ST: [MB2114](https://www.st.com/resource/en/schematic_pack/mb2114-h5f5lj-c01-schematic.pdf).
- Since the `fdcan2` has a pin conflict with `mac` (pin `pb12`), it has been disabled per default and the conflict was documented.
- Updated `stm32h5f5j_dk.yaml` to include the Ethernet tag.
- Updated `index.rst` to include the Ethernet pins.

## Tests

I tested these changes with the following example: [http_server](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/net/sockets/http_server).
I could ping the board after flashing the sample and also open the website in the browser. Everything worked as expected.