### PR TITLE
stm32: tests: drivers: adc: adc_api: fix regression on  nucleo_wl55jc platform

### DIFF
--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -101,6 +101,7 @@ stm32_lp_tick_source: &lptim1 {
 	mul-n = <6>;
 	div-r = <2>;
 	div-q = <2>;
+	div-p = <2>;
 	clocks = <&clk_hsi>;
 	status = "okay";
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_wl55jc.overlay
@@ -16,6 +16,11 @@
 			      STM32_DMA_PERIPH_16BITS)>;
 	dma-names = "dmamux";
 
+	clocks = <&rcc STM32_CLOCK(APB2, 9)>,
+		 <&rcc STM32_SRC_PLL_P ADC_SEL(2)>;
+	clock-names = "adcx", "adc_ker";
+	st,adc-clock-source = "ASYNC";
+	st,adc-prescaler = <8>;
 	pinctrl-0 = <&adc_in4_pb2 &adc_in5_pb1>;
 	#address-cells = <1>;
 	#size-cells = <0>;


### PR DESCRIPTION
These changes will fix the regression introduced after this [commit](https://github.com/zephyrproject-rtos/zephyr/commit/d844a4a861c7708a96e9d1d74383aa5362b374cb) on the `nucleo_wl55jc` platform. 



The ADC resolution will now be configured correctly, and we will no longer get the following console output:

`E: ADC overrun error occurred. Use DMA, reduce clock source frequency, increase prescaler value or increase sampling times. 
`