### PR TITLE
drivers: ethernet: dwc_mac: 1000: save rx_pkt and bytes

### DIFF
--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -173,8 +173,6 @@ static void dwmac_receive(const struct device *dev)
 	unsigned int d_idx;
 	uint32_t des0;
 	uint16_t bytes_so_far;
-	struct net_pkt *rx_pkt = NULL;
-	uint16_t rx_bytes = 0;
 
 	for (d_idx = p->rx_desc_tail; d_idx != p->rx_desc_head;
 	     INC_WRAP(d_idx, NB_RX_DESCS), k_sem_give(&p->free_rx_descs)) {
@@ -186,18 +184,18 @@ static void dwmac_receive(const struct device *dev)
 		}
 
 		if ((des0 & RDES0_FS) != 0U) {
-			rx_bytes = 0;
-			if (rx_pkt != NULL) {
+			p->rx_bytes = 0;
+			if (p->rx_pkt != NULL) {
 				eth_stats_update_errors_rx(p->iface);
-				net_pkt_unref(rx_pkt);
+				net_pkt_unref(p->rx_pkt);
 			}
-			rx_pkt = net_pkt_rx_alloc_on_iface(p->iface, K_NO_WAIT);
-			if (rx_pkt == NULL) {
+			p->rx_pkt = net_pkt_rx_alloc_on_iface(p->iface, K_NO_WAIT);
+			if (p->rx_pkt == NULL) {
 				eth_stats_update_errors_rx(p->iface);
 			}
 		}
 
-		if (rx_pkt == NULL) {
+		if (p->rx_pkt == NULL) {
 			continue;
 		}
 
@@ -207,27 +205,27 @@ static void dwmac_receive(const struct device *dev)
 
 		bytes_so_far = RX_LEN_FROM_RDES0(des0);
 
-		if (bytes_so_far < rx_bytes) {
+		if (bytes_so_far < p->rx_bytes) {
 			eth_stats_update_errors_rx(p->iface);
-			net_pkt_unref(rx_pkt);
-			rx_pkt = NULL;
+			net_pkt_unref(p->rx_pkt);
+			p->rx_pkt = NULL;
 			net_buf_unref(frag);
 			continue;
 		}
 
-		frag->len = bytes_so_far - rx_bytes;
-		rx_bytes = bytes_so_far;
-		net_pkt_frag_add(rx_pkt, frag);
+		frag->len = bytes_so_far - p->rx_bytes;
+		p->rx_bytes = bytes_so_far;
+		net_pkt_frag_add(p->rx_pkt, frag);
 
 		if ((des0 & RDES0_LS) != 0U) {
 			if ((des0 & RDES0_ES) == 0U) {
-				net_recv_data(p->iface, rx_pkt);
+				net_recv_data(p->iface, p->rx_pkt);
 			} else {
 				LOG_ERR("rx error (DES0 = 0x%08x)", des0);
 				eth_stats_update_errors_rx(p->iface);
-				net_pkt_unref(rx_pkt);
+				net_pkt_unref(p->rx_pkt);
 			}
-			rx_pkt = NULL;
+			p->rx_pkt = NULL;
 		}
 	}
 

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -251,8 +251,9 @@ static void dwmac_receive(struct dwmac_priv *p)
 {
 	struct dwmac_dma_desc *d;
 	struct net_buf *frag;
-	unsigned int d_idx, bytes_so_far;
+	unsigned int d_idx;
 	uint32_t des3_val;
+	uint16_t bytes_so_far;
 
 	for (d_idx = p->rx_desc_tail;
 	     d_idx != p->rx_desc_head;

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -124,10 +124,9 @@ struct dwmac_priv {
 #ifdef CONFIG_ETH_DWC_ETHER_QOS_CORE
 	struct net_buf *tx_frags[NB_TX_DESCS]; /* index shared with tx_descs */
 	struct net_buf *rx_frags[NB_RX_DESCS]; /* index shared with rx_descs */
-
-	struct net_pkt *rx_pkt;
-	unsigned int rx_bytes;
 #endif
+	struct net_pkt *rx_pkt;
+	uint16_t rx_bytes;
 
 	K_KERNEL_STACK_MEMBER(rx_refill_thread_stack, RX_REFILL_STACK_SIZE);
 	struct k_thread rx_refill_thread;


### PR DESCRIPTION
save rx_pkt and bytes, like in the qos mac, in case we got already got fragments of later packets.
