### PR TITLE
modules: lvgl: set int type for LV_DRAW_BUF_ALIGN

### DIFF
--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -12,6 +12,9 @@ config LVGL
 
 if LVGL
 
+config LV_DRAW_BUF_ALIGN
+	int
+
 config LV_USE_MONKEY
 	bool
 


### PR DESCRIPTION
The addition of a default value for LV_DRAW_BUF_ALIGN in STM32 led to build warning due to a Kconfig defined without a type. Set its type to int in modules/lvgl/Kconfig, matching the type defined for this Kconfig option in the LVGL Kconfig.