### PR TITLE
include: pm: add @file Doxygen tags to PM headers

### DIFF
--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Device Power Management API.
+ * @ingroup subsys_pm_device
+ */
+
 #ifndef ZEPHYR_INCLUDE_PM_DEVICE_H_
 #define ZEPHYR_INCLUDE_PM_DEVICE_H_
 

--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Device Runtime Power Management API.
+ * @ingroup subsys_pm_device_runtime
+ */
+
 #ifndef ZEPHYR_INCLUDE_PM_DEVICE_RUNTIME_H_
 #define ZEPHYR_INCLUDE_PM_DEVICE_RUNTIME_H_
 

--- a/include/zephyr/pm/pm.h
+++ b/include/zephyr/pm/pm.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Power Management API.
+ * @ingroup subsys_pm
+ */
+
 #ifndef ZEPHYR_INCLUDE_PM_PM_H_
 #define ZEPHYR_INCLUDE_PM_PM_H_
 
@@ -213,7 +219,7 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id);
  * @}
  */
 
-#else  /* CONFIG_PM */
+#else /* CONFIG_PM */
 
 static inline void pm_notifier_register(struct pm_notifier *notifier)
 {

--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the System Power Management Policy API.
+ * @ingroup subsys_pm_sys_policy
+ */
+
 #ifndef ZEPHYR_INCLUDE_PM_POLICY_H_
 #define ZEPHYR_INCLUDE_PM_POLICY_H_
 

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for System Power Management state definitions.
+ * @ingroup subsys_pm_states
+ */
+
 #ifndef ZEPHYR_INCLUDE_PM_STATE_H_
 #define ZEPHYR_INCLUDE_PM_STATE_H_
 


### PR DESCRIPTION
Add `@file` blocks to each PM header file, parented under the main doxygen group they belong to.