### PR TITLE
include: Bluetooth: Mesh: add or complete Doxygen `@file` tags

### DIFF
--- a/include/zephyr/bluetooth/mesh/blob.h
+++ b/include/zephyr/bluetooth/mesh/blob.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh BLOB Transfer model API.
+ * @ingroup bt_mesh_blob
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_H__
 

--- a/include/zephyr/bluetooth/mesh/blob_cli.h
+++ b/include/zephyr/bluetooth/mesh/blob_cli.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh BLOB Transfer Client model API.
+ * @ingroup bt_mesh_blob_cli
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_CLI_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_CLI_H_
 

--- a/include/zephyr/bluetooth/mesh/blob_io_flash.h
+++ b/include/zephyr/bluetooth/mesh/blob_io_flash.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh BLOB flash stream API.
+ * @ingroup bt_mesh_blob_io_flash
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_IO_FLASH_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_IO_FLASH_H__
 

--- a/include/zephyr/bluetooth/mesh/blob_srv.h
+++ b/include/zephyr/bluetooth/mesh/blob_srv.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh BLOB Transfer Server model API.
+ * @ingroup bt_mesh_blob_srv
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_SRV_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_SRV_H_
 

--- a/include/zephyr/bluetooth/mesh/brg_cfg.h
+++ b/include/zephyr/bluetooth/mesh/brg_cfg.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for Bluetooth Mesh Bridge Configuration common definitions.
+ * @ingroup bt_mesh_brg_cfg
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BRG_CFG_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BRG_CFG_H__
 

--- a/include/zephyr/bluetooth/mesh/brg_cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/brg_cfg_cli.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Bridge Configuration Client model API.
+ * @ingroup bt_mesh_brg_cfg_cli
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BRG_CFG_CLI_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BRG_CFG_CLI_H__
 

--- a/include/zephyr/bluetooth/mesh/cdb.h
+++ b/include/zephyr/bluetooth/mesh/cdb.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Configuration Database (CDB) API.
+ * @ingroup bt_mesh
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_CDB_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_CDB_H_
 

--- a/include/zephyr/bluetooth/mesh/dfd.h
+++ b/include/zephyr/bluetooth/mesh/dfd.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Firmware Distribution models API.
+ * @ingroup bt_mesh_dfd
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFD_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFD_H__
 

--- a/include/zephyr/bluetooth/mesh/dfu.h
+++ b/include/zephyr/bluetooth/mesh/dfu.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Device Firmware Update (DFU) API.
+ * @ingroup bt_mesh_dfu
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFU_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFU_H__
 

--- a/include/zephyr/bluetooth/mesh/dfu_metadata.h
+++ b/include/zephyr/bluetooth/mesh/dfu_metadata.h
@@ -6,6 +6,11 @@
 
 /**
  * @file
+ * @brief Header file for the Bluetooth Mesh Device Firmware Update (DFU) metadata API.
+ * @ingroup bt_mesh_dfu_metadata
+ */
+
+/**
  * @defgroup bt_mesh_dfu_metadata Bluetooth Mesh Device Firmware Update (DFU) metadata
  * @ingroup bt_mesh_dfu
  * @{

--- a/include/zephyr/bluetooth/mesh/large_comp_data_cli.h
+++ b/include/zephyr/bluetooth/mesh/large_comp_data_cli.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Large Composition Data Client model API.
+ * @ingroup bt_mesh_large_comp_data_cli
+ */
+
 #ifndef BT_MESH_LARGE_COMP_DATA_CLI_H__
 #define BT_MESH_LARGE_COMP_DATA_CLI_H__
 

--- a/include/zephyr/bluetooth/mesh/large_comp_data_srv.h
+++ b/include/zephyr/bluetooth/mesh/large_comp_data_srv.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Large Composition Data Server model API.
+ * @ingroup bt_mesh_large_comp_data_srv
+ */
+
 #ifndef BT_MESH_LARGE_COMP_DATA_SRV_H__
 #define BT_MESH_LARGE_COMP_DATA_SRV_H__
 

--- a/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
+++ b/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh On-Demand Private GATT Proxy Client model API.
+ * @ingroup bt_mesh_od_priv_proxy_cli
+ */
+
 #ifndef BT_MESH_OD_PRIV_PROXY_CLI_H__
 #define BT_MESH_OD_PRIV_PROXY_CLI_H__
 

--- a/include/zephyr/bluetooth/mesh/od_priv_proxy_srv.h
+++ b/include/zephyr/bluetooth/mesh/od_priv_proxy_srv.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh On-Demand Private GATT Proxy Server model API.
+ * @ingroup bt_mesh_od_priv_proxy_srv
+ */
+
 #ifndef BT_MESH_OD_PRIV_PROXY_SRV_H__
 #define BT_MESH_OD_PRIV_PROXY_SRV_H__
 

--- a/include/zephyr/bluetooth/mesh/op_agg_cli.h
+++ b/include/zephyr/bluetooth/mesh/op_agg_cli.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Opcodes Aggregator Client model API.
+ * @ingroup bt_mesh_op_agg_cli
+ */
+
 #ifndef BT_MESH_OP_AGG_CLI_H__
 #define BT_MESH_OP_AGG_CLI_H__
 

--- a/include/zephyr/bluetooth/mesh/op_agg_srv.h
+++ b/include/zephyr/bluetooth/mesh/op_agg_srv.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Opcodes Aggregator Server model API.
+ * @ingroup bt_mesh_op_agg_srv
+ */
+
 #ifndef BT_MESH_OP_AGG_SRV_H__
 #define BT_MESH_OP_AGG_SRV_H__
 

--- a/include/zephyr/bluetooth/mesh/priv_beacon_cli.h
+++ b/include/zephyr/bluetooth/mesh/priv_beacon_cli.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Private Beacon Client model API.
+ * @ingroup bt_mesh_priv_beacon_cli
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_PRIV_BEACON_CLI_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_PRIV_BEACON_CLI_H__
 

--- a/include/zephyr/bluetooth/mesh/priv_beacon_srv.h
+++ b/include/zephyr/bluetooth/mesh/priv_beacon_srv.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Private Beacon Server model API.
+ * @ingroup bt_mesh_priv_beacon_srv
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_PRIV_BEACON_SRV_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_PRIV_BEACON_SRV_H__
 

--- a/include/zephyr/bluetooth/mesh/rpr.h
+++ b/include/zephyr/bluetooth/mesh/rpr.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for Bluetooth Mesh Remote Provisioning common definitions.
+ * @ingroup bt_mesh_rpr
+ */
+
 #ifndef ZEPHYR_INCLUDE_BT_MESH_RPR_H__
 #define ZEPHYR_INCLUDE_BT_MESH_RPR_H__
 

--- a/include/zephyr/bluetooth/mesh/rpr_cli.h
+++ b/include/zephyr/bluetooth/mesh/rpr_cli.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Remote Provisioning Client model API.
+ * @ingroup bt_mesh_rpr_cli
+ */
+
 #ifndef ZEPHYR_INCLUDE_BT_MESH_RPR_CLI_H__
 #define ZEPHYR_INCLUDE_BT_MESH_RPR_CLI_H__
 

--- a/include/zephyr/bluetooth/mesh/rpr_srv.h
+++ b/include/zephyr/bluetooth/mesh/rpr_srv.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Remote Provisioning Server model API.
+ * @ingroup bt_mesh_rpr_srv
+ */
+
 #ifndef ZEPHYR_INCLUDE_BT_MESH_RPR_SRV_H__
 #define ZEPHYR_INCLUDE_BT_MESH_RPR_SRV_H__
 

--- a/include/zephyr/bluetooth/mesh/sar_cfg.h
+++ b/include/zephyr/bluetooth/mesh/sar_cfg.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for Bluetooth Mesh SAR Configuration common definitions.
+ * @ingroup bt_mesh_sar_cfg
+ */
+
 #ifndef BT_MESH_SAR_CFG_H__
 #define BT_MESH_SAR_CFG_H__
 

--- a/include/zephyr/bluetooth/mesh/shell.h
+++ b/include/zephyr/bluetooth/mesh/shell.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh shell commands.
+ * @ingroup bt_mesh
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_SHELL_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_SHELL_H_
 

--- a/include/zephyr/bluetooth/mesh/sol_pdu_rpl_cli.h
+++ b/include/zephyr/bluetooth/mesh/sol_pdu_rpl_cli.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Solicitation PDU RPL Client model API.
+ * @ingroup bt_mesh_sol_pdu_rpl_cli
+ */
+
 #ifndef BT_MESH_SOL_PDU_RPL_CLI_H__
 #define BT_MESH_SOL_PDU_RPL_CLI_H__
 

--- a/include/zephyr/bluetooth/mesh/sol_pdu_rpl_srv.h
+++ b/include/zephyr/bluetooth/mesh/sol_pdu_rpl_srv.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Mesh Solicitation PDU RPL Configuration Server model API.
+ * @ingroup bt_mesh_sol_pdu_rpl_srv
+ */
+
 #ifndef BT_MESH_SOL_PDU_RPL_SRV_H__
 #define BT_MESH_SOL_PDU_RPL_SRV_H__
 


### PR DESCRIPTION
Add `@file` tags to all Bluetooth Mesh headers (when missing), and parent under the doxygen group they belong to for better navigability in doxygen website.