### PR TITLE
include: Bluetooth: add or complete Doxygen `@file` tags

### DIFF
--- a/include/zephyr/bluetooth/ead.h
+++ b/include/zephyr/bluetooth/ead.h
@@ -2,6 +2,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Encrypted Advertising Data (EAD) API.
+ * @ingroup bt_ead
+ */
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/include/zephyr/bluetooth/services/ans.h
+++ b/include/zephyr/bluetooth/services/ans.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Alert Notification Service (ANS) API.
+ * @ingroup bt_ans
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_ANS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_ANS_H_
 

--- a/include/zephyr/bluetooth/services/bas.h
+++ b/include/zephyr/bluetooth/services/bas.h
@@ -6,6 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Battery Service (BAS) API.
+ * @ingroup bt_bas
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_BAS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_BAS_H_
 

--- a/include/zephyr/bluetooth/services/cts.h
+++ b/include/zephyr/bluetooth/services/cts.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Current Time Service (CTS) API.
+ * @ingroup bt_cts
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_CTS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_CTS_H_
 

--- a/include/zephyr/bluetooth/services/dis.h
+++ b/include/zephyr/bluetooth/services/dis.h
@@ -1,12 +1,14 @@
-/** @file
- *  @brief GATT Device Information Service
- */
-
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  * Copyright (c) 2016 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for the Bluetooth Device Information Service (DIS) API.
+ * @ingroup bluetooth
  */
 
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_DIS_H_

--- a/include/zephyr/bluetooth/services/hrs.h
+++ b/include/zephyr/bluetooth/services/hrs.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Heart Rate Service (HRS) API.
+ * @ingroup bt_hrs
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_HRS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_HRS_H_
 

--- a/include/zephyr/bluetooth/services/ias.h
+++ b/include/zephyr/bluetooth/services/ias.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Immediate Alert Service (IAS) API.
+ * @ingroup bt_ias
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_IAS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_IAS_H_
 

--- a/include/zephyr/bluetooth/services/nus.h
+++ b/include/zephyr/bluetooth/services/nus.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Nordic UART Service (NUS) API.
+ * @ingroup bluetooth
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_NUS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_NUS_H_
 

--- a/include/zephyr/bluetooth/services/nus/inst.h
+++ b/include/zephyr/bluetooth/services/nus/inst.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for Bluetooth Nordic UART Service (NUS) instance definitions.
+ * @ingroup bluetooth
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_NUS_INST_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_NUS_INST_H_
 

--- a/include/zephyr/bluetooth/services/ots.h
+++ b/include/zephyr/bluetooth/services/ots.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Bluetooth Object Transfer Service (OTS) API.
+ * @ingroup bt_ots
+ */
+
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_OTS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_SERVICES_OTS_H_
 


### PR DESCRIPTION
Add `@file` tags to all Bluetooth services headers (when missing), and parent under the doxygen group they belong to.