### PR TITLE
include: mgmt: mcumgr: add missing Doxygen `@file` tags

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/enum_mgmt/enum_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/enum_mgmt/enum_mgmt.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the MCUmgr enumeration management group API.
+ * @ingroup mcumgr_enum_mgmt
+ */
+
 #ifndef H_ENUM_MGMT_
 #define H_ENUM_MGMT_
 

--- a/include/zephyr/mgmt/mcumgr/grp/enum_mgmt/enum_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/enum_mgmt/enum_mgmt_callbacks.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for MCUmgr enumeration management callback definitions.
+ * @ingroup mcumgr_callback_api_enum_mgmt
+ */
+
 #ifndef H_MCUMGR_ENUM_MGMT_CALLBACKS_
 #define H_MCUMGR_ENUM_MGMT_CALLBACKS_
 

--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
@@ -6,6 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the MCUmgr file system management group API.
+ * @ingroup mcumgr_fs_mgmt
+ */
+
 #ifndef H_FS_MGMT_
 #define H_FS_MGMT_
 

--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for MCUmgr file system management callback definitions.
+ * @ingroup mcumgr_callback_api_fs_mgmt
+ */
+
 #ifndef H_MCUMGR_FS_MGMT_CALLBACKS_
 #define H_MCUMGR_FS_MGMT_CALLBACKS_
 

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_client.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_client.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the MCUmgr image management client API.
+ * @ingroup mcumgr_img_mgmt_client
+ */
+
 #ifndef H_IMG_MGMT_CLIENT_
 #define H_IMG_MGMT_CLIENT_
 

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
@@ -6,6 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the MCUmgr OS management group API.
+ * @ingroup mcumgr_os_mgmt
+ */
+
 #ifndef H_OS_MGMT_
 #define H_OS_MGMT_
 

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for MCUmgr OS management callback definitions.
+ * @ingroup mcumgr_callback_api_os_mgmt
+ */
+
 #ifndef H_MCUMGR_OS_MGMT_CALLBACKS_
 #define H_MCUMGR_OS_MGMT_CALLBACKS_
 

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_client.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_client.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the MCUmgr OS management client API.
+ * @ingroup mcumgr_os_mgmt_client
+ */
+
 #ifndef H_OS_MGMT_CLIENT_
 #define H_OS_MGMT_CLIENT_
 

--- a/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the MCUmgr settings management group API.
+ * @ingroup mcumgr_settings_mgmt
+ */
+
 #ifndef H_SETTINGS_MGMT_
 #define H_SETTINGS_MGMT_
 

--- a/include/zephyr/mgmt/mcumgr/grp/shell_mgmt/shell_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/shell_mgmt/shell_mgmt.h
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the MCUmgr shell management group API.
+ * @ingroup mcumgr_shell_mgmt
+ */
+
 #ifndef H_SHELL_MGMT_
 #define H_SHELL_MGMT_
 

--- a/include/zephyr/mgmt/mcumgr/grp/stat_mgmt/stat_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/stat_mgmt/stat_mgmt.h
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the MCUmgr statistics management group API.
+ * @ingroup mcumgr_stat_mgmt
+ */
+
 #ifndef H_STAT_MGMT_
 #define H_STAT_MGMT_
 

--- a/include/zephyr/mgmt/mcumgr/grp/zephyr/zephyr_basic.h
+++ b/include/zephyr/mgmt/mcumgr/grp/zephyr/zephyr_basic.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the MCUmgr Zephyr basic management group API.
+ * @ingroup mcumgr_zephyr_basic_mgmt
+ */
+
 #ifndef ZEPHYR_INCLUDE_ZEPHYR_MCUMGR_GRP_ZBASIC_H_
 #define ZEPHYR_INCLUDE_ZEPHYR_MCUMGR_GRP_ZBASIC_H_
 

--- a/include/zephyr/mgmt/mcumgr/mgmt/handlers.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/handlers.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the MCUmgr command handler registration API.
+ * @ingroup mcumgr_handler_api
+ */
+
 #ifndef H_MCUMGR_MGMT_HANDLERS_
 #define H_MCUMGR_MGMT_HANDLERS_
 

--- a/include/zephyr/mgmt/mcumgr/smp/smp_client.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp_client.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the MCUmgr SMP client API.
+ * @ingroup mcumgr_smp_client
+ */
+
 #ifndef H_SMP_CLIENT_
 #define H_SMP_CLIENT_
 

--- a/include/zephyr/mgmt/mcumgr/transport/serial.h
+++ b/include/zephyr/mgmt/mcumgr/transport/serial.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the MCUmgr serial transport API.
+ * @ingroup mcumgr_transport_serial
+ */
+
 #ifndef ZEPHYR_INCLUDE_MGMT_SERIAL_H_
 #define ZEPHYR_INCLUDE_MGMT_SERIAL_H_
 


### PR DESCRIPTION
Add missing `@file` tags to MCUmgr public headers, and parent them under the Doxygen group they belong to.