### PR TITLE
include: sensing: add missing Doxygen `@file` tags

### DIFF
--- a/include/zephyr/sensing/sensing.h
+++ b/include/zephyr/sensing/sensing.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Main header file for the Sensing subsystem API.
+ * @ingroup sensing_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SENSING_H_
 #define ZEPHYR_INCLUDE_SENSING_H_
 

--- a/include/zephyr/sensing/sensing_datatypes.h
+++ b/include/zephyr/sensing/sensing_datatypes.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for Sensing subsystem data type definitions.
+ * @ingroup sensing_datatypes
+ */
+
 #ifndef ZEPHYR_INCLUDE_SENSING_DATATYPES_H_
 #define ZEPHYR_INCLUDE_SENSING_DATATYPES_H_
 

--- a/include/zephyr/sensing/sensing_sensor.h
+++ b/include/zephyr/sensing/sensing_sensor.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the Sensing subsystem sensor API.
+ * @ingroup sensing_sensor
+ */
+
 #ifndef ZEPHYR_INCLUDE_SENSING_SENSOR_H_
 #define ZEPHYR_INCLUDE_SENSING_SENSOR_H_
 

--- a/include/zephyr/sensing/sensing_sensor_types.h
+++ b/include/zephyr/sensing/sensing_sensor_types.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for Sensing subsystem sensor type definitions.
+ * @ingroup sensing_sensor_types
+ */
+
 #ifndef ZEPHYR_INCLUDE_SENSING_SENSOR_TYPES_H_
 #define ZEPHYR_INCLUDE_SENSING_SENSOR_TYPES_H_
 


### PR DESCRIPTION
Add missing `@file` tags to Sensing subsystem public headers, and parent them under the Doxygen group they belong to.