### PR TITLE
include: shell: organize doxygen documentation across shell subsystem

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the shell subsystem.
+ * @ingroup shell_api
+ */
+
 #ifndef SHELL_H__
 #define SHELL_H__
 
@@ -27,6 +33,7 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 #ifndef CONFIG_SHELL_PROMPT_BUFF_SIZE
 #define CONFIG_SHELL_PROMPT_BUFF_SIZE 0
 #endif
@@ -46,6 +53,15 @@ extern "C" {
 #define Z_SHELL_CMD_ROOT_LVL		(0u)
 
 #define SHELL_HEXDUMP_BYTES_IN_LINE	16
+/** @endcond */
+
+/**
+ * @defgroup shell_api Shell
+ * @since 1.14
+ * @version 1.0.0
+ * @ingroup os_services
+ * @{
+ */
 
 /**
  * @brief Flag indicates that optional arguments will be treated as one,
@@ -70,15 +86,6 @@ extern "C" {
  *	  validated.
  */
 #define SHELL_OPT_ARG_MAX		(0xFD)
-
-/**
- * @brief Shell API
- * @defgroup shell_api Shell API
- * @since 1.14
- * @version 1.0.0
- * @ingroup os_services
- * @{
- */
 
 struct shell_static_entry;
 
@@ -109,6 +116,7 @@ union shell_cmd_entry {
 
 struct shell;
 
+/** @brief Argument count constraints and remote routing for a shell command. */
 struct shell_static_args {
 	uint8_t mandatory; /*!< Number of mandatory arguments. */
 	uint8_t optional;  /*!< Number of optional arguments. */
@@ -285,7 +293,7 @@ typedef int (*shell_dict_cmd_handler)(const struct shell *sh, size_t argc,
 #define Z_SHELL_STATIC_ENTRY_PADDING 0
 #endif
 
-/*
+/**
  * @brief Shell static command descriptor.
  */
 struct shell_static_entry {
@@ -294,7 +302,9 @@ struct shell_static_entry {
 	const union shell_cmd_entry *subcmd;	/*!< Pointer to subcommand. */
 	shell_cmd_handler handler;		/*!< Command handler. */
 	struct shell_static_args args;		/*!< Command arguments. */
+	/** @cond INTERNAL_HIDDEN */
 	uint8_t padding[Z_SHELL_STATIC_ENTRY_PADDING];
+	/** @endcond */
 };
 
 /**
@@ -305,9 +315,9 @@ struct shell_static_entry {
  * consistent and easier to read.
  */
 struct shell_cmd_help {
-	/* @cond INTERNAL_HIDDEN */
+	/** @cond INTERNAL_HIDDEN */
 	uint32_t magic;
-	/* @endcond */
+	/** @endcond */
 	const char *description; /*!< Command description */
 	const char *usage;       /*!< Command usage string */
 };
@@ -707,6 +717,8 @@ static inline bool shell_help_is_structured(const char *help)
 #define SHELL_EXPR_CMD(_expr, _syntax, _subcmd, _help, _handler) \
 	SHELL_EXPR_CMD_ARG(_expr, _syntax, _subcmd, _help, _handler, 0, 0, 0, 0)
 
+/** @cond INTERNAL_HIDDEN */
+
 /* Internal macro used for creating handlers for dictionary commands. */
 #define Z_SHELL_CMD_DICT_HANDLER_CREATE(_data, _handler)		\
 static int UTIL_CAT(UTIL_CAT(cmd_dict_, UTIL_CAT(_handler, _)),		\
@@ -722,6 +734,8 @@ static int UTIL_CAT(UTIL_CAT(cmd_dict_, UTIL_CAT(_handler, _)),		\
 	SHELL_CMD_ARG(GET_ARG_N(1, __DEBRACKET _data), NULL, GET_ARG_N(3, __DEBRACKET _data),	\
 		UTIL_CAT(UTIL_CAT(cmd_dict_, UTIL_CAT(_handler, _)),	\
 			GET_ARG_N(1, __DEBRACKET _data)), 1, 0)
+
+/** @endcond */
 
 /**
  * @brief Initializes shell dictionary commands.
@@ -764,7 +778,7 @@ static int UTIL_CAT(UTIL_CAT(cmd_dict_, UTIL_CAT(_handler, _)),		\
 		SHELL_SUBCMD_SET_END					\
 	)
 
-/* @cond INTERNAL_HIDDEN */
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @internal @brief Internal shell state in response to data received from the
@@ -801,12 +815,32 @@ enum shell_readline_state {
 	SHELL_READLINE_CANCELED,
 };
 
-/* @endcond */
+/** @endcond */
 
+/**
+ * @brief Shell transport event handler callback.
+ *
+ * Invoked by a transport backend to notify the shell core that a transport
+ * event occurred (for example, received data is ready, or a transmission
+ * completed).
+ *
+ * @param evt     Transport event that occurred.
+ * @param context Opaque context pointer provided to the transport at
+ *                initialization time (see shell_transport_api.init).
+ */
 typedef void (*shell_transport_handler_t)(enum shell_transport_evt evt,
 					  void *context);
 
-
+/**
+ * @brief Shell uninitialization completion callback.
+ *
+ * Invoked from the shell thread context once shell_uninit() has finished, just
+ * before the shell thread is aborted.
+ *
+ * @param sh  Shell instance that was uninitialized.
+ * @param res Result of the operation: 0 on success, negative errno code on
+ *            failure.
+ */
 typedef void (*shell_uninit_cb_t)(const struct shell *sh, int res);
 
 /** @brief Bypass callback.
@@ -861,8 +895,8 @@ struct shell_transport_api {
 	 * @param blocking_tx If true, the transport TX is enabled in blocking
 	 *		      mode.
 	 *
-	 * @return NRF_SUCCESS on successful enabling, error otherwise (also if
-	 * not supported).
+	 * @return 0 on success, negative errno code on failure (including when
+	 * the operation is not supported).
 	 */
 	int (*enable)(const struct shell_transport *transport,
 		      bool blocking_tx);
@@ -904,10 +938,19 @@ struct shell_transport_api {
 
 };
 
+/**
+ * @brief Shell transport instance.
+ *
+ * Binds a transport backend implementation (@ref shell_transport_api) to its
+ * per-instance context. It is instantiated by a backend's `SHELL_*_DEFINE`
+ * macro and referenced by a shell instance through its transport interface.
+ */
 struct shell_transport {
-	const struct shell_transport_api *api;
-	void *ctx;
+	const struct shell_transport_api *api; /**< Transport backend operations. */
+	void *ctx;                             /**< Transport instance context. */
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @brief Shell statistics structure.
@@ -991,10 +1034,13 @@ enum shell_signal {
 	SHELL_SIGNAL_TXDONE = BIT(3),
 };
 
+/** @endcond */
+
 /**
  * @brief Shell instance context.
  */
 struct shell_ctx {
+	/** @cond INTERNAL_HIDDEN */
 #if defined(CONFIG_SHELL_PROMPT_CHANGE) && CONFIG_SHELL_PROMPT_CHANGE
 	char prompt[CONFIG_SHELL_PROMPT_BUFF_SIZE]; /*!< shell current prompt. */
 #else
@@ -1061,9 +1107,12 @@ struct shell_ctx {
 	struct k_sem lock_sem;
 	k_tid_t tid;
 	int ret_val;
+	/** @endcond */
 };
 
+/** @cond INTERNAL_HIDDEN */
 extern const struct log_backend_api log_backend_shell_api;
+/** @endcond */
 
 /**
  * @brief Flags for setting shell output newline sequence.
@@ -1077,6 +1126,7 @@ enum shell_flag {
  * @brief Shell instance internals.
  */
 struct shell {
+	/** @cond INTERNAL_HIDDEN */
 	const char *default_prompt; /*!< shell default prompt. */
 
 	const struct shell_transport *iface; /*!< Transport interface.*/
@@ -1097,6 +1147,7 @@ struct shell {
 	const char *name;
 	struct k_thread *thread;
 	k_thread_stack_t *stack;
+	/** @endcond */
 };
 
 extern void z_shell_print_stream(const void *user_ctx, const char *data,
@@ -1228,20 +1279,23 @@ int shell_stop(const struct shell *sh);
 #include <zephyr/shell/shell_remote_cli.h>
 #endif
 
+/** @cond INTERNAL_HIDDEN */
+void __printf_like(3, 4) shell_fprintf_impl(const struct shell *sh, enum shell_vt100_color color,
+					    const char *fmt, ...);
+/** @endcond */
+
 /**
  * @brief printf-like function which sends formatted data stream to the shell.
  *
  * This function can be used from the command handler or from threads, but not
- * from an interrupt context.
+ * from an interrupt context. When @kconfig{CONFIG_SHELL_REMOTE_CLI} is enabled
+ * the output is transparently routed to the remote shell instead.
  *
  * @param[in] sh	Pointer to the shell instance.
  * @param[in] color	Printed text color.
  * @param[in] fmt	Format string.
  * @param[in] ...	List of parameters to print.
  */
-void __printf_like(3, 4) shell_fprintf_impl(const struct shell *sh, enum shell_vt100_color color,
-					    const char *fmt, ...);
-
 #define shell_fprintf(sh, color, fmt, ...)                                                         \
 	COND_CODE_1(IS_ENABLED(CONFIG_SHELL_REMOTE_CLI), \
 		(SHELL_REMOTE_CLI_FPRINTF(sh, color, fmt, ##__VA_ARGS__)), \

--- a/include/zephyr/shell/shell_adsp_memory_window.h
+++ b/include/zephyr/shell/shell_adsp_memory_window.h
@@ -6,8 +6,8 @@
 
 /**
  * @file
- * @brief ADSP memory window shell backend
- * @ingroup shell_api
+ * @brief Header file for the ADSP memory window shell backend.
+ * @ingroup shell_adsp_memory_window
  */
 
 #ifndef SHELL_ADSP_MEMORY_WINDOW_H__
@@ -20,6 +20,7 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 extern const struct shell_transport_api shell_adsp_memory_window_transport_api;
 
 struct sys_winstream;
@@ -43,7 +44,20 @@ struct shell_adsp_memory_window {
 	/** Last read sequence number */
 	uint32_t read_seqno;
 };
+/** @endcond */
 
+/**
+ * @defgroup shell_adsp_memory_window ADSP memory window shell backend
+ * @ingroup shell_backends
+ * @brief Shell access over an ADSP memory window.
+ * @{
+ */
+
+/**
+ * @brief Define an ADSP memory window shell transport instance.
+ *
+ * @param _name Name of the transport instance.
+ */
 #define SHELL_ADSP_MEMORY_WINDOW_DEFINE(_name)				\
 	static struct shell_adsp_memory_window _name##_shell_adsp_memory_window;\
 	struct shell_transport _name = {					\
@@ -60,6 +74,8 @@ struct shell_adsp_memory_window {
  * @returns Pointer to the shell instance.
  */
 const struct shell *shell_backend_adsp_memory_window_get_ptr(void);
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/shell/shell_backend.h
+++ b/include/zephyr/shell/shell_backend.h
@@ -6,8 +6,8 @@
 
 /**
  * @file
- * @brief Shell backend API
- * @ingroup shell_api
+ * @brief Header file for the shell backend accessors.
+ * @ingroup shell_backends
  */
 
 #ifndef ZEPHYR_INCLUDE_SHELL_BACKEND_H_
@@ -22,11 +22,34 @@ extern "C" {
 #endif
 
 /**
- * @brief Get backend.
+ * @defgroup shell_backends Shell backends
+ * @brief Transport backends that connect a shell instance to a communication channel.
+ * @ingroup shell_api
  *
- * @param[in] idx  Pointer to the backend instance.
+ * A shell instance is driven by a transport backend (UART, RTT, Telnet, MQTT,
+ * WebSocket, SSH, RPMsg, ...). Backends are normally selected and enabled through
+ * their Kconfig options (for example @kconfig{CONFIG_SHELL_BACKEND_SERIAL}), and the
+ * shell subsystem instantiates the configured backend automatically. Applications
+ * usually do not reference the symbols in this group directly.
  *
- * @return Pointer to the backend instance.
+ * What each backend header exposes is therefore a small, mostly implementation
+ * oriented surface:
+ * - a `SHELL_<name>_DEFINE()` macro that instantiates a transport, used by the
+ *   backend implementation itself (and available for custom instances);
+ * - a `shell_backend_<name>_get_ptr()` accessor returning that backend's shell
+ *   instance, for the few callers that need to address a specific backend (e.g.
+ *   the dummy backend in tests, or UART in management code);
+ * - occasional backend-specific helpers.
+ *
+ * @{
+ */
+
+/**
+ * @brief Get a shell backend by index.
+ *
+ * @param[in] idx Index of the backend, from 0 to shell_backend_count_get() - 1.
+ *
+ * @return Pointer to the backend instance at the given index.
  */
 static inline const struct shell *shell_backend_get(uint32_t idx)
 {
@@ -59,6 +82,8 @@ static inline int shell_backend_count_get(void)
  * @return Pointer to the backend instance if found, NULL if backend is not found.
  */
 const struct shell *shell_backend_get_by_name(const char *backend_name);
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/shell/shell_dummy.h
+++ b/include/zephyr/shell/shell_dummy.h
@@ -8,8 +8,8 @@
 
 /**
  * @file
- * @brief Dummy shell backend for testing
- * @ingroup shell_api
+ * @brief Header file for the dummy shell backend.
+ * @ingroup shell_dummy
  */
 
 #ifndef ZEPHYR_INCLUDE_SHELL_DUMMY_H_
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 extern const struct shell_transport_api shell_dummy_transport_api;
 
 struct shell_dummy {
@@ -47,7 +48,20 @@ struct shell_dummy {
 	/** Event handler context. */
 	void *context;
 };
+/** @endcond */
 
+/**
+ * @defgroup shell_dummy Dummy shell backend
+ * @ingroup shell_backends
+ * @brief In-memory shell backend used for testing.
+ * @{
+ */
+
+/**
+ * @brief Define a dummy shell transport instance.
+ *
+ * @param _name Name of the transport instance.
+ */
 #define SHELL_DUMMY_DEFINE(_name)					\
 	static struct shell_dummy _name##_shell_dummy;			\
 	struct shell_transport _name = {				\
@@ -104,6 +118,8 @@ int shell_backend_dummy_push_input(const struct shell *sh, const char *data, siz
  * @param sh	Shell pointer
  */
 void shell_backend_dummy_clear_input(const struct shell *sh);
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/shell/shell_fprintf.h
+++ b/include/zephyr/shell/shell_fprintf.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the shell formatted output helpers.
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_FPRINTF_H_
 #define ZEPHYR_INCLUDE_SHELL_FPRINTF_H_
 
@@ -14,6 +19,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** @cond INTERNAL_HIDDEN */
 
 typedef void (*shell_fprintf_fwrite)(const void *user_ctx,
 				     const char *data,
@@ -33,6 +40,8 @@ struct shell_fprintf {
 	const void *user_ctx;
 	struct shell_fprintf_control_block *ctrl_blk;
 };
+
+/** @endcond */
 
 /**
  * @brief Macro for defining shell_fprintf instance.

--- a/include/zephyr/shell/shell_history.h
+++ b/include/zephyr/shell/shell_history.h
@@ -6,8 +6,7 @@
 
 /**
  * @file
- * @brief Shell history
- * @ingroup shell_api
+ * @brief Header file for the shell command history.
  */
 
 #ifndef ZEPHYR_INCLUDE_SHELL_HISTORY_H_
@@ -23,12 +22,13 @@
 extern "C" {
 #endif
 
-
+/** @cond INTERNAL_HIDDEN */
 struct shell_history {
 	struct k_heap *heap;
 	sys_dlist_t list;
 	sys_dnode_t *current;
 };
+/** @endcond */
 
 /**
  * @brief Create shell history instance.

--- a/include/zephyr/shell/shell_log_backend.h
+++ b/include/zephyr/shell/shell_log_backend.h
@@ -6,8 +6,7 @@
 
 /**
  * @file
- * @brief Shell backend
- * @ingroup shell_api
+ * @brief Header file for the shell log backend.
  */
 
 #ifndef ZEPHYR_INCLUDE_SHELL_LOG_BACKEND_H_
@@ -22,6 +21,7 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 extern const struct log_backend_api log_backend_shell_api;
 
 /** @brief Shell log backend states. */
@@ -53,6 +53,8 @@ struct shell_log_backend_msg {
 	struct log_msg *msg;
 	uint32_t timestamp;
 };
+
+/** @endcond */
 
 /** @brief Prototype of function outputting processed data. */
 int z_shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx);

--- a/include/zephyr/shell/shell_mqtt.h
+++ b/include/zephyr/shell/shell_mqtt.h
@@ -6,8 +6,8 @@
 
 /**
  * @file
- * @brief MQTT shell backend
- * @ingroup shell_api
+ * @brief Header file for the MQTT shell backend.
+ * @ingroup shell_mqtt
  */
 
 #ifndef ZEPHYR_INCLUDE_SHELL_MQTT_H_
@@ -25,6 +25,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** @cond INTERNAL_HIDDEN */
 
 #define RX_RB_SIZE CONFIG_SHELL_MQTT_RX_BUF_SIZE
 #define TX_BUF_SIZE CONFIG_SHELL_MQTT_TX_BUF_SIZE
@@ -110,7 +112,20 @@ struct shell_mqtt {
 		SHELL_MQTT_NETWORK_CONNECTED,
 	} network_state;
 };
+/** @endcond */
 
+/**
+ * @defgroup shell_mqtt MQTT shell backend
+ * @ingroup shell_backends
+ * @brief Shell access over an MQTT connection.
+ * @{
+ */
+
+/**
+ * @brief Define an MQTT shell transport instance.
+ *
+ * @param _name Name of the transport instance.
+ */
 #define SHELL_MQTT_DEFINE(_name)                                                                   \
 	static struct shell_mqtt _name##_shell_mqtt;                                               \
 	struct shell_transport _name = { .api = &shell_mqtt_transport_api,                         \
@@ -139,6 +154,8 @@ const struct shell *shell_backend_mqtt_get_ptr(void);
  * @return true if length of devid > 0
  */
 bool shell_mqtt_get_devid(char *id, int id_max_len);
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/shell/shell_rpmsg.h
+++ b/include/zephyr/shell/shell_rpmsg.h
@@ -6,8 +6,8 @@
 
 /**
  * @file
- * @brief RPMsg shell backend
- * @ingroup shell_api
+ * @brief Header file for the RPMsg shell backend.
+ * @ingroup shell_rpmsg
  */
 
 #ifndef ZEPHYR_INCLUDE_SHELL_RPMSG_H_
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 extern const struct shell_transport_api shell_rpmsg_transport_api;
 
 /** RPMsg received message placeholder */
@@ -60,7 +61,20 @@ struct shell_rpmsg {
 	/** The number of bytes consumed from rx_cur */
 	size_t rx_consumed;
 };
+/** @endcond */
 
+/**
+ * @defgroup shell_rpmsg RPMsg shell backend
+ * @ingroup shell_backends
+ * @brief Shell access over an RPMsg endpoint.
+ * @{
+ */
+
+/**
+ * @brief Define an RPMsg shell transport instance.
+ *
+ * @param _name Name of the transport instance.
+ */
 #define SHELL_RPMSG_DEFINE(_name)					\
 	static struct shell_rpmsg _name##_shell_rpmsg;			\
 	struct shell_transport _name = {				\
@@ -85,6 +99,8 @@ int shell_backend_rpmsg_init_transport(struct rpmsg_device *rpmsg_dev);
  * @returns Pointer to the shell instance.
  */
 const struct shell *shell_backend_rpmsg_get_ptr(void);
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/shell/shell_rtt.h
+++ b/include/zephyr/shell/shell_rtt.h
@@ -6,8 +6,8 @@
 
 /**
  * @file
- * @brief RTT shell backend
- * @ingroup shell_api
+ * @brief Header file for the RTT shell backend.
+ * @ingroup shell_rtt
  */
 
 #ifndef ZEPHYR_INCLUDE_SHELL_RTT_H_
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 extern const struct shell_transport_api shell_rtt_transport_api;
 
 struct shell_rtt {
@@ -26,7 +27,20 @@ struct shell_rtt {
 	struct k_timer timer;
 	void *context;
 };
+/** @endcond */
 
+/**
+ * @defgroup shell_rtt RTT shell backend
+ * @ingroup shell_backends
+ * @brief Shell access over a SEGGER RTT channel.
+ * @{
+ */
+
+/**
+ * @brief Define an RTT shell transport instance.
+ *
+ * @param _name Name of the transport instance.
+ */
 #define SHELL_RTT_DEFINE(_name)					\
 	static struct shell_rtt _name##_shell_rtt;			\
 	struct shell_transport _name = {				\
@@ -43,6 +57,9 @@ struct shell_rtt {
  * @returns Pointer to the shell instance.
  */
 const struct shell *shell_backend_rtt_get_ptr(void);
+
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/shell/shell_ssh.h
+++ b/include/zephyr/shell/shell_ssh.h
@@ -7,8 +7,8 @@
 
 /**
  * @file
- * @brief SSH shell backend
- * @ingroup shell_api
+ * @brief Header file for the SSH shell backend.
+ * @ingroup shell_ssh
  */
 
 #ifndef ZEPHYR_INCLUDE_SHELL_SSH_H_
@@ -21,6 +21,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup shell_ssh SSH shell backend
+ * @ingroup shell_backends
+ * @brief Shell access over an SSH connection.
+ * @{
+ */
 
 /** Maximum password length supported by the shell SSH transport. */
 #define SHELL_SSH_MAX_PASSWORD_LEN 32
@@ -113,6 +120,8 @@ int shell_sshd_transport_event_callback(struct ssh_transport *transport,
 #endif /* CONFIG_SSH_SERVER */
 
 /** @endcond */
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/shell/shell_string_conv.h
+++ b/include/zephyr/shell/shell_string_conv.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the shell string conversion helpers.
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_STRING_CONV_H_
 #define ZEPHYR_INCLUDE_SHELL_STRING_CONV_H_
 
@@ -13,6 +19,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @addtogroup shell_api
+ * @{
+ */
 
 /** @brief String to long conversion with error check.
  *
@@ -81,6 +92,8 @@ unsigned long long shell_strtoull(const char *str, int base, int *err);
  * @return Converted boolean value.
  */
 bool shell_strtobool(const char *str, int base, int *err);
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/shell/shell_telnet.h
+++ b/include/zephyr/shell/shell_telnet.h
@@ -6,8 +6,8 @@
 
 /**
  * @file
- * @brief Telnet shell backend
- * @ingroup shell_api
+ * @brief Header file for the Telnet shell backend.
+ * @ingroup shell_telnet
  */
 
 #ifndef ZEPHYR_INCLUDE_SHELL_TELNET_H_
@@ -20,6 +20,7 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 extern const struct shell_transport_api shell_telnet_transport_api;
 
 #define SHELL_TELNET_POLLFD_COUNT 3
@@ -69,7 +70,20 @@ struct shell_telnet {
 	/** If set, no output is sent to the TELNET client. */
 	bool output_lock;
 };
+/** @endcond */
 
+/**
+ * @defgroup shell_telnet Telnet shell backend
+ * @ingroup shell_backends
+ * @brief Shell access over a TELNET connection.
+ * @{
+ */
+
+/**
+ * @brief Define a Telnet shell transport instance.
+ *
+ * @param _name Name of the transport instance.
+ */
 #define SHELL_TELNET_DEFINE(_name)					\
 	static struct shell_telnet _name##_shell_telnet;		\
 	struct shell_transport _name = {				\
@@ -86,6 +100,8 @@ struct shell_telnet {
  * @returns Pointer to the shell instance.
  */
 const struct shell *shell_backend_telnet_get_ptr(void);
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/shell/shell_types.h
+++ b/include/zephyr/shell/shell_types.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the shell terminal types and colors.
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_TYPES_H_
 #define ZEPHYR_INCLUDE_SHELL_TYPES_H_
 
@@ -11,20 +18,32 @@
 extern "C" {
 #endif
 
+/**
+ * @addtogroup shell_api
+ * @{
+ */
+
+/** @brief Text colors available for shell output. */
 enum shell_vt100_color {
-	SHELL_VT100_COLOR_BLACK,
-	SHELL_VT100_COLOR_RED,
-	SHELL_VT100_COLOR_GREEN,
-	SHELL_VT100_COLOR_YELLOW,
-	SHELL_VT100_COLOR_BLUE,
-	SHELL_VT100_COLOR_MAGENTA,
-	SHELL_VT100_COLOR_CYAN,
-	SHELL_VT100_COLOR_WHITE,
+	SHELL_VT100_COLOR_BLACK,   /**< Black. */
+	SHELL_VT100_COLOR_RED,     /**< Red. */
+	SHELL_VT100_COLOR_GREEN,   /**< Green. */
+	SHELL_VT100_COLOR_YELLOW,  /**< Yellow. */
+	SHELL_VT100_COLOR_BLUE,    /**< Blue. */
+	SHELL_VT100_COLOR_MAGENTA, /**< Magenta. */
+	SHELL_VT100_COLOR_CYAN,    /**< Cyan. */
+	SHELL_VT100_COLOR_WHITE,   /**< White. */
 
-	SHELL_VT100_COLOR_DEFAULT,
+	SHELL_VT100_COLOR_DEFAULT, /**< Terminal default foreground color. */
 
+	/** @cond INTERNAL_HIDDEN */
 	VT100_COLOR_END
+	/** @endcond */
 };
+
+/** @} */
+
+/** @cond INTERNAL_HIDDEN */
 
 struct shell_vt100_colors {
 	enum shell_vt100_color col; /*!< Text color. */
@@ -46,6 +65,8 @@ struct shell_vt100_ctx {
 	struct shell_vt100_colors col;
 	uint16_t printed_cmd;  /*!< printed commands counter */
 };
+
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/shell/shell_uart.h
+++ b/include/zephyr/shell/shell_uart.h
@@ -6,8 +6,8 @@
 
 /**
  * @file
- * @brief Serial shell backend
- * @ingroup shell_api
+ * @brief Header file for the UART shell backend.
+ * @ingroup shell_uart
  */
 
 #ifndef ZEPHYR_INCLUDE_SHELL_UART_H_
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 extern const struct shell_transport_api shell_uart_transport_api;
 
 #ifndef CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE
@@ -86,6 +87,14 @@ struct shell_uart_polling {
 #else
 #define SHELL_UART_STRUCT struct shell_uart_int_driven
 #endif
+/** @endcond */
+
+/**
+ * @defgroup shell_uart UART shell backend
+ * @ingroup shell_backends
+ * @brief Shell access over a UART serial connection.
+ * @{
+ */
 
 /**
  * @brief Macro for creating shell UART transport instance named @p _name
@@ -116,6 +125,8 @@ const struct shell *shell_backend_uart_get_ptr(void);
  * @returns Pointer to the smp shell data.
  */
 struct smp_shell_data *shell_uart_smp_shell_data_get_ptr(void);
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/shell/shell_websocket.h
+++ b/include/zephyr/shell/shell_websocket.h
@@ -6,8 +6,8 @@
 
 /**
  * @file
- * @brief Websocket shell backend
- * @ingroup shell_api
+ * @brief Header file for the WebSocket shell backend.
+ * @ingroup shell_websocket
  */
 
 #ifndef ZEPHYR_INCLUDE_SHELL_WEBSOCKET_H_
@@ -21,6 +21,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** @cond INTERNAL_HIDDEN */
 
 #define SHELL_WEBSOCKET_SERVICE_COUNT CONFIG_SHELL_WEBSOCKET_BACKEND_COUNT
 
@@ -118,9 +120,28 @@ int shell_websocket_enable(const struct shell *sh);
 		     CONFIG_SHELL_WEBSOCKET_LOG_MESSAGE_QUEUE_TIMEOUT,		\
 		     SHELL_FLAG_OLF_CRLF);					\
 	DEFINE_WEBSOCKET_HTTP_SERVICE(_service)
+/** @endcond */
+
+/**
+ * @defgroup shell_websocket Websocket shell backend
+ * @ingroup shell_backends
+ * @brief Shell access over a WebSocket connection.
+ * @{
+ */
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 /* Use a secure connection only for Websocket. */
+/**
+ * @brief Define a websocket shell service.
+ *
+ * Defines the websocket shell transport, its shell instance, and the HTTP(S)
+ * service that exposes it at @kconfig{CONFIG_SHELL_WEBSOCKET_ENDPOINT_URL}.
+ *
+ * @param _service           Name of the websocket service instance.
+ * @param _sec_tag_list      TLS security tag list for the secure (HTTPS)
+ *                           connection. Ignored when TLS is not enabled.
+ * @param _sec_tag_list_size Number of entries in @p _sec_tag_list.
+ */
 #define WEBSOCKET_CONSOLE_DEFINE(_service, _sec_tag_list, _sec_tag_list_size) \
 	static uint16_t SHELL_WS_PORT_NAME(_service) =			  \
 		CONFIG_SHELL_WEBSOCKET_PORT;				  \
@@ -139,6 +160,17 @@ int shell_websocket_enable(const struct shell *sh);
 
 #else /* CONFIG_NET_SOCKETS_SOCKOPT_TLS */
 /* TLS not possible so define only normal HTTP service */
+/**
+ * @brief Define a websocket shell service.
+ *
+ * Defines the websocket shell transport, its shell instance, and the HTTP(S)
+ * service that exposes it at @kconfig{CONFIG_SHELL_WEBSOCKET_ENDPOINT_URL}.
+ *
+ * @param _service           Name of the websocket service instance.
+ * @param _sec_tag_list      TLS security tag list for the secure (HTTPS)
+ *                           connection. Ignored when TLS is not enabled.
+ * @param _sec_tag_list_size Number of entries in @p _sec_tag_list.
+ */
 #define WEBSOCKET_CONSOLE_DEFINE(_service, _sec_tag_list, _sec_tag_list_size) \
 	static uint16_t SHELL_WS_PORT_NAME(_service) =			\
 		CONFIG_SHELL_WEBSOCKET_PORT;				\
@@ -152,8 +184,15 @@ int shell_websocket_enable(const struct shell *sh);
 
 #endif /* CONFIG_NET_SOCKETS_SOCKOPT_TLS */
 
+/**
+ * @brief Enable a websocket shell service defined with @ref WEBSOCKET_CONSOLE_DEFINE.
+ *
+ * @param _service Name of the websocket service instance.
+ */
 #define WEBSOCKET_CONSOLE_ENABLE(_service)				\
 	(void)shell_websocket_enable(&GET_WS_SHELL_NAME(_service))
+
+/** @} */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Brings every shell header to 100% Doxygen coverage while making the public API surface explicit.

- Hid internal stuff with `@cond INTERNAL_HIDDEN`
- Documented the genuine public API (command/print/lifecycle/transport helpers, string-conversion helpers, per-backend `*_DEFINE` macros, etc.) and added missing `@file` blocks.
- Reorganized groups: a `shell_backends` group holds the generic accessors, and each transport (uart, rtt, telnet, mqtt, websocket, ssh, ...) now has its own subgroup under it.

---

* https://builds.zephyrproject.io/zephyr/pr/111813/docs/doxygen/html/group__shell__api.html
* [Coverage report](https://builds.zephyrproject.io/zephyr/pr/111813/api-coverage/zephyr/shell/index.html)