### PR TITLE
doc: build: signing: document signing key file resolution

### DIFF
--- a/doc/build/signing/index.rst
+++ b/doc/build/signing/index.rst
@@ -38,10 +38,11 @@ For more information on these and other related configuration options, see:
 
 - :kconfig:option:`SB_CONFIG_BOOTLOADER_MCUBOOT`: build the application for loading by MCUboot
 - :kconfig:option:`SB_CONFIG_BOOT_SIGNATURE_KEY_FILE`: the key file, or a comma-separated list of
-  key files, to use when signing images. If you have your own key, change this appropriately.
-  When a list is given, MCUboot embeds the public half of every key and accepts an image
-  signed with any of them; the first entry also signs the application, and every entry
-  past the first must be a public-only PEM of the same signature type
+  key files, to use when signing images. If you have your own key, change this appropriately; see
+  :ref:`build-signing-keys` for using an absolute path or a CMake variable such as ``${APP_DIR}``.
+  When a list is given, MCUboot embeds the public half of every key and accepts an image signed
+  with any of them; the first entry also signs the application, and every entry past the first
+  must be a public-only PEM of the same signature type for ``imgtool``.
 - :kconfig:option:`CONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS`: optional additional command line arguments
   for ``imgtool``
 - :kconfig:option:`CONFIG_MCUBOOT_GENERATE_CONFIRMED_IMAGE`: also generate a confirmed image,
@@ -71,6 +72,64 @@ should see something like this on your device's serial console when you run
 Whether ``west flash`` supports this feature depends on your runner. The ``nrfjprog`` and
 ``pyocd`` runners work with the above flow. If your runner does not support this flow and you
 would like it to, please send a patch or file an issue for adding support.
+
+.. _build-signing-keys:
+
+Signing key files
+*****************
+
+When building with sysbuild, :kconfig:option:`SB_CONFIG_BOOT_SIGNATURE_KEY_FILE` selects the key
+used to sign images. Its value is propagated to two images:
+
+- the application image, as :kconfig:option:`CONFIG_MCUBOOT_SIGNATURE_KEY_FILE`, which ``imgtool``
+  uses to sign the application; and
+- the MCUboot image, as ``CONFIG_BOOT_SIGNATURE_KEY_FILE``, whose public part is built into the
+  bootloader so it can verify that signature.
+
+.. warning::
+
+   The default value points at one of the insecure development keys bundled with MCUboot (for
+   example :file:`root-ec-p256.pem`). These keys are public — they ship with every Zephyr and
+   MCUboot checkout — so they are only suitable for development and testing. For anything else,
+   generate your own key and keep the private key out of any repository or build directory that
+   you do not control.
+
+How sysbuild resolves the key file path
+=======================================
+
+The value of :kconfig:option:`SB_CONFIG_BOOT_SIGNATURE_KEY_FILE` is processed with CMake's
+``string(CONFIGURE)`` command, so any ``${VARIABLE}`` reference it contains is expanded as a CMake
+variable before the path is used. After expansion, an absolute path is used as-is; a relative path
+is resolved by each image independently:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Image
+     - Search order for a relative path
+   * - Application (:kconfig:option:`CONFIG_MCUBOOT_SIGNATURE_KEY_FILE`)
+     - ``APPLICATION_CONFIG_DIR``, then the west workspace topdir (``WEST_TOPDIR``)
+   * - MCUboot (``CONFIG_BOOT_SIGNATURE_KEY_FILE``)
+     - ``APPLICATION_CONFIG_DIR``, then the MCUboot module directory
+
+.. warning::
+
+   Each image resolves a relative path against a different base, so a bare relative path points at
+   a different file for each image and usually fails to build. Do not use one: give an absolute
+   path, or anchor the path with a CMake variable.
+
+``${APP_DIR}`` (the main application's source directory) is the recommended anchor: it keeps the
+key inside your own application, and both images resolve it to the same file. Any CMake variable
+available when the value is expanded may be used:
+
+.. code-block:: cfg
+
+   # sysbuild.conf
+   SB_CONFIG_BOOT_SIGNATURE_KEY_FILE="${APP_DIR}/keys/my-signing-key.pem"
+
+The same resolution rules apply to the optional encryption key file
+(:kconfig:option:`CONFIG_MCUBOOT_ENCRYPTION_KEY_FILE`).
 
 .. _west-extending-signing:
 

--- a/doc/build/sysbuild/images.rst
+++ b/doc/build/sysbuild/images.rst
@@ -283,7 +283,8 @@ configuration values, multiple can be used per image, the configuration should b
 different images to correctly configure them based upon options set in sysbuild. MCUboot
 configuration options are configured in both the application the MCUboot image using this method
 which allows sysbuild to be the central location for things like the signing key which are then
-kept in-sync in the main application bootloader images.
+kept in-sync in the main application bootloader images. See :ref:`build-signing-keys` for setting
+the key to an absolute path or a CMake variable such as ``${APP_DIR}``.
 
 Inside image configuration scripts, the ``ZCMAKE_APPLICATION`` variable is set to the name of the
 application being configured, the ``set_config_*`` sysbuild CMake functions can be used to set


### PR DESCRIPTION
The signing docs only described SB_CONFIG_BOOT_SIGNATURE_KEY_FILE as "the insecure default" key to "change this appropriately", with no guidance on where the key file may live or how a relative path to it is resolved.

A single SB_CONFIG_BOOT_SIGNATURE_KEY_FILE feeds two images that resolve relative key paths against different bases: the application image (CONFIG_MCUBOOT_SIGNATURE_KEY_FILE) against APPLICATION_CONFIG_DIR then WEST_TOPDIR, and the MCUboot image (CONFIG_BOOT_SIGNATURE_KEY_FILE) against APPLICATION_CONFIG_DIR then the MCUboot module directory. A key referenced by a bare relative path that one image can resolve is therefore not resolvable by the other.

Document this on the Signing Binaries page: the value is expanded with string(CONFIGURE), the per-image relative-path search order, and the need for either an absolute path or a ${APP_DIR}-anchored path (the only relative form that resolves identically for both images and keeps the key in the user-owned application). Cross-reference it from the sysbuild images page where the shared signing key is introduced.

## Reference and GH linking

### Discussions
- **zephyr discussion [#59063](https://github.com/zephyrproject-rtos/zephyr/discussions/59063)** — "Configuring custom bootloader signature key with sysbuild." Canonical dual-image custody Q&A; maintainer answer recommends `SB_CONFIG_BOOT_SIGNATURE_KEY_FILE="${APP_DIR}/my_key.pem"` in `sysbuild.conf` (or an absolute path). The `${APP_DIR}` anchor is *recommended here but documented nowhere*.
- **mcuboot PR [#2591](https://github.com/mcu-tools/mcuboot/pull/2591)** — "Support resolving relative key file path via WEST_TOPDIR" (closed **unmerged**, 2026-01-12). Maintainer (nordicjm): *"Not acceptable … use sysbuild and use an escaped path e.g. `${APP_DIR}/my.pem`."* Establishes that the app-image/bootloader-image resolution **asymmetry is by design**, so the gap is a documentation gap, not a bug to fix in code.
- **zephyr issue [#85270](https://github.com/zephyrproject-rtos/zephyr/issues/85270)** — closed "not planned" (2025-02-06). Confirms the supported knob is the sysbuild-scope `SB_CONFIG_BOOT_SIGNATURE_KEY_FILE` (plus `SB_CONFIG_BOOT_SIGNATURE_TYPE_*`), not the per-image `CONFIG_MCUBOOT_SIGNATURE_KEY_FILE`.

### Source code
Pinned at zephyr `main` `1cfe02062`, mcuboot `main` `0fae892`:
- **`zephyr/share/sysbuild/cmake/modules/sysbuild_extensions.cmake`** — the single `string(CONFIGURE …)` expansion of the key value in **sysbuild scope** (where `${APP_DIR}` = the main application and `${CMAKE_CURRENT_LIST_DIR}` = the sysbuild module dir inside zephyr). This is *why* `${APP_DIR}` works and `${CMAKE_CURRENT_LIST_DIR}` silently resolves into the zephyr tree.
- **`zephyr/cmake/mcuboot.cmake`** — application-image resolver: absolute → `${APPLICATION_CONFIG_DIR}` → `${WEST_TOPDIR}` (the `WEST_TOPDIR` fallback is flagged in-code as `west sign` backward-compat).
- **`mcuboot/boot/zephyr/CMakeLists.txt`** — bootloader-image resolver: absolute → `${APPLICATION_CONFIG_DIR}` → `${MCUBOOT_DIR}` (no `WEST_TOPDIR` fallback — the deliberate asymmetry).
- **`zephyr/share/sysbuild/images/bootloader/Kconfig`** — defines `SB_CONFIG_BOOT_SIGNATURE_KEY_FILE` (default points *inside* the mcuboot module).
- **`zephyr/share/sysbuild/image_configurations/MAIN_image_default.cmake`** and **`zephyr/share/sysbuild/images/bootloader/CMakeLists.txt`** — propagate that one symbol to the app image (`CONFIG_MCUBOOT_SIGNATURE_KEY_FILE`) and the bootloader image (`CONFIG_BOOT_SIGNATURE_KEY_FILE`) respectively.

### What the docs look like now
- **[Signing Binaries](https://docs.zephyrproject.org/latest/build/signing/index.html)** — only says the bundled key is "the insecure default"; silent on `APPLICATION_CONFIG_DIR` / `WEST_TOPDIR` / `MCUBOOT_DIR`, on `string(CONFIGURE)` expansion, and on the dual-image propagation.
- **[west sign](https://docs.zephyrproject.org/latest/develop/west/sign.html)** — documents only the app-side half ("relative to the west workspace topdir"); does not mention the bootloader image's different base.
- **[sysbuild / images](https://docs.zephyrproject.org/latest/build/sysbuild/images.html)** — confirms one `SB_CONFIG_BOOT_SIGNATURE_KEY_FILE` drives both images (and `FILE_SUFFIX` can split them) but says nothing about where the key may live or how relative paths resolve.

### Downstream guidance
- **NCS `bootloader_signature_keys`** — the clearest official statement anywhere: **"Use only absolute paths"** for `SB_CONFIG_BOOT_SIGNATURE_KEY_FILE`; set it in `sysbuild.conf`; store the private key **outside the build directory**. Downstream had to write this because upstream is silent.
- DevZone relative-path / wrong-consumer friction (years of it): [#113899](https://devzone.nordicsemi.com/f/nordic-q-a/113899/application-configuration-directory-empty) (`${APPLICATION_CONFIG_DIR}` → empty, confirmed SDK bug, sdk-nrf PR #16894), [#115651](https://devzone.nordicsemi.com/f/nordic-q-a/115651/signing-file-relative-key-path) (`${APP_DIR}` unexpanded → `/keys/…`), [#80629](https://devzone.nordicsemi.com/f/nordic-q-a/80629/decouple-mcuboot-public-key-storage-and-image-signing).

### MCUboot resolution-logic context
- **mcuboot PR [#2701](https://github.com/mcu-tools/mcuboot/pull/2701)** — multi-key support; *carries forward* the `IS_ABSOLUTE → APPLICATION_CONFIG_DIR → MCUBOOT_DIR` block verbatim. This is the resolution logic visible at mcuboot `main` HEAD.
- **mcuboot PR [#2702](https://github.com/mcu-tools/mcuboot/pull/2702)** — public-only PEM support for `getpub`/`verify` (underpins the custody model without changing path resolution).
- **MCUboot v2.3.0 release notes** (TrustedFirmware) — introduced `APPLICATION_CONFIG_DIR`-relative key resolution with `string(CONFIGURE)` escaping.

### Further references
- **zephyr discussion [#56453](https://github.com/zephyrproject-rtos/zephyr/discussions/56453)** — relative key paths concatenated onto the wrong base (corroborating report).
- **zephyr issue [#73066](https://github.com/zephyrproject-rtos/zephyr/issues/73066)** (closed via PR [#73390](https://github.com/zephyrproject-rtos/zephyr/pull/73390)) — maintainer awareness of the broader sysbuild-vs-image relative-anchoring class of bug.
- **zephyr discussion [#97181](https://github.com/zephyrproject-rtos/zephyr/discussions/97181)** — the encryption-key analog of this problem, still unanswered.
- **zephyr discussion [#64532](https://github.com/zephyrproject-rtos/zephyr/discussions/64532)** — overriding `SIGNING_SCRIPT` for external / HSM signing; **mcuboot issue [#599](https://github.com/mcu-tools/mcuboot/issues/599)** — HSM support.
- Third-party consensus (generate your own key, never ship the in-tree example keys): Foundries.io `zephyr-mcuboot-keys`, Hubble Zephyr DFU guide.

> Provenance: GitHub PR/issue/discussion numbers and the official-doc statements are high-confidence; DevZone dates are inferred from the referenced NCS versions (paraphrase-grade).

## Verification

- **Empirical:** resolution behavior verified against an example-application workspace (zephyr `main`, mcuboot `main`, nrf52840dk/nrf52840, ECDSA-P256): bare relative → resolves into mcuboot (fails); `${CMAKE_CURRENT_LIST_DIR}` → resolves into zephyr (fails); `${APP_DIR}` → builds, key stays in app: https://github.com/intercreate/example-application/pull/1
- **In-tree source of truth** confirmed against this checkout: `cmake/mcuboot.cmake`, `bootloader/mcuboot/boot/zephyr/CMakeLists.txt`, `share/sysbuild/cmake/modules/sysbuild_extensions.cmake`, and propagation via `share/sysbuild/image_configurations/MAIN_image_default.cmake` and `share/sysbuild/images/bootloader/CMakeLists.txt`.
- **RST:** heading underlines, `:ref:` / `:kconfig:option:` targets, and code-block conventions checked against existing docs. A full Sphinx build was not run locally (heavy); relying on the CI docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
