### PR TITLE
drivers: wifi: infineon: fix supplicant compiler error

### DIFF
--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -2404,6 +2404,7 @@ int airoc_wifi_wpa_supp_reg_mgmt_frame(void *if_priv, u16 frame_type, size_t mat
 }
 #endif
 
+#if defined(CONFIG_WIFI_NM_WPA_SUPPLICANT)
 static inline unsigned short mhz_from_5g_channel(uint8_t ch)
 {
 	/* 5GHz channels: 36, 40, 44, 48, 149, 153, 157, 161, 165 */
@@ -2496,7 +2497,6 @@ out:
 	return status;
 }
 
-#if defined(CONFIG_WIFI_NM_WPA_SUPPLICANT)
 static const struct zep_wpa_supp_dev_ops airoc_wifi_wpa_drv_ops = {
 	.init = airoc_wifi_wpa_supp_dev_init,
 	.scan2 = airoc_wifi_wpa_supp_scan2,


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/107029 is merged, it provide supporting wpa_supplicant. That means wifi shell sample should be able to support two different mechanism. One use wpa_supplicant, another one use wifi_mgmt_ops directly without wpa_supplicant.
 
Some structures like wpa_supp_event_supported_band or functions in airoc_wifi.c belongs to wpa_supplicant only.
Therefore if we compile wifi shell without wpa_supplicant, it causes build error.