### PR TITLE
soc: nxp: rw: pull wakeup pads to inactive level

### DIFF
--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -149,11 +149,13 @@ static void restore_mpu_state(void)
 static void config_wakeup_gpio_pins(void)
 {
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pin0))
-	pin_cfg = IOMUX_GPIO_IDX(24) | IOMUX_TYPE(IOMUX_GPIO);
+	pin_cfg = IOMUX_GPIO_IDX(24) | IOMUX_TYPE(IOMUX_GPIO) |
+		  IOMUX_PAD_PULL(DT_ENUM_IDX(DT_NODELABEL(pin0), wakeup_level) ? 0x2 : 0x1);
 	pinctrl_configure_pins(&pin_cfg, 1, 0);
 #endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pin1))
-	pin_cfg = IOMUX_GPIO_IDX(25) | IOMUX_TYPE(IOMUX_GPIO);
+	pin_cfg = IOMUX_GPIO_IDX(25) | IOMUX_TYPE(IOMUX_GPIO) |
+		  IOMUX_PAD_PULL(DT_ENUM_IDX(DT_NODELABEL(pin1), wakeup_level) ? 0x2 : 0x1);
 	pinctrl_configure_pins(&pin_cfg, 1, 0);
 #endif
 }


### PR DESCRIPTION
config_wakeup_gpio_pins() re-muxes the AON wakeup pads with no bias on every low power entry, clearing their pull. Sleep-force drive is also skipped for these pads (GPIO 22-27), so the SoC no longer holds them in sleep and, absent an external pull, they drift low. With a low-level wakeup that is the active level and wakes the SoC immediately.

Apply a pull opposing the wakeup-level so the SoC holds the pad at the inactive level.

Fixes #111890