### PR TITLE
Bluetooth: shell: fix l2cap metrics command argument count

### DIFF
--- a/subsys/bluetooth/host/shell/l2cap.c
+++ b/subsys/bluetooth/host/shell/l2cap.c
@@ -538,7 +538,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(allowlist_cmds,
 SHELL_STATIC_SUBCMD_SET_CREATE(l2cap_cmds,
 	SHELL_CMD_ARG(connect, NULL, "<psm> [sec_level]", cmd_connect, 2, 1),
 	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_disconnect, 1, 0),
-	SHELL_CMD_ARG(metrics, NULL, "<value on, off>", cmd_metrics, 2, 0),
+	SHELL_CMD_ARG(metrics, NULL, "<value on, off>", cmd_metrics, 1, 1),
 	SHELL_CMD_ARG(recv, NULL, "[delay (in milliseconds)", cmd_recv, 1, 1),
 	SHELL_CMD_ARG(register, NULL, "<psm> [sec_level] "
 		      "[policy: allowlist, 16byte_key]", cmd_register, 2, 2),


### PR DESCRIPTION
Fix the 'l2cap metrics' command argument definition. It accepts a single parameter ("metrics") to print throughput, but was incorrectly set to require two arguments, preventing output.

Update SHELL_CMD_ARG to min=1 and max=1 to allow enabling, disabling, and printing throughput metrics.