### PR TITLE
arch: xtensa: extend syscall helper to invoke levels 0-3

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -316,6 +316,14 @@ config XTENSA_SYSCALL_USE_HELPER
 	  This is a workaround for toolchains where they have
 	  issue modeling register usage.
 
+config XTENSA_SYSCALL_USE_HELPER_ALL
+	bool "Use userspace syscall helper for all argument counts"
+	depends on XTENSA_SYSCALL_USE_HELPER
+	help
+	  Also route the 0-3 argument syscall invocations through the
+	  out-of-line helper functions, in addition to the 4-6 argument
+	  ones already handled by XTENSA_SYSCALL_USE_HELPER.
+
 config XTENSA_EMULATE_UNSUPPORTED_UNSIGNED_LOAD_STORE
 	bool "Emulate unsupported unsigned loads / stores"
 	depends on COMPILER_CODEGEN_VLIW_DISABLED

--- a/arch/xtensa/core/syscall_helper.c
+++ b/arch/xtensa/core/syscall_helper.c
@@ -76,6 +76,68 @@ uintptr_t xtensa_syscall_helper_args_4(uintptr_t arg1, uintptr_t arg2,
 }
 EXPORT_SYMBOL(xtensa_syscall_helper_args_4);
 
+#ifdef CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL
+uintptr_t xtensa_syscall_helper_args_3(uintptr_t arg1, uintptr_t arg2,
+				       uintptr_t arg3, uintptr_t call_id)
+{
+	register uintptr_t a2 __asm__("%a2") = call_id;
+	register uintptr_t a6 __asm__("%a6") = arg1;
+	register uintptr_t a3 __asm__("%a3") = arg2;
+	register uintptr_t a4 __asm__("%a4") = arg3;
+
+	__asm__ volatile(XTENSA_SYSCALL_ASM
+			 : "=r" (a2)
+			 : "r" (a2), "r" (a6), "r" (a3), "r" (a4)
+			 : "memory");
+
+	return a2;
+}
+EXPORT_SYMBOL(xtensa_syscall_helper_args_3);
+
+uintptr_t xtensa_syscall_helper_args_2(uintptr_t arg1, uintptr_t arg2,
+				       uintptr_t call_id)
+{
+	register uintptr_t a2 __asm__("%a2") = call_id;
+	register uintptr_t a6 __asm__("%a6") = arg1;
+	register uintptr_t a3 __asm__("%a3") = arg2;
+
+	__asm__ volatile(XTENSA_SYSCALL_ASM
+			 : "=r" (a2)
+			 : "r" (a2), "r" (a6), "r" (a3)
+			 : "memory");
+
+	return a2;
+}
+EXPORT_SYMBOL(xtensa_syscall_helper_args_2);
+
+uintptr_t xtensa_syscall_helper_args_1(uintptr_t arg1, uintptr_t call_id)
+{
+	register uintptr_t a2 __asm__("%a2") = call_id;
+	register uintptr_t a6 __asm__("%a6") = arg1;
+
+	__asm__ volatile(XTENSA_SYSCALL_ASM
+			 : "=r" (a2)
+			 : "r" (a2), "r" (a6)
+			 : "memory");
+
+	return a2;
+}
+EXPORT_SYMBOL(xtensa_syscall_helper_args_1);
+
+uintptr_t xtensa_syscall_helper_args_0(uintptr_t call_id)
+{
+	register uintptr_t a2 __asm__("%a2") = call_id;
+
+	__asm__ volatile(XTENSA_SYSCALL_ASM
+			 : "=r" (a2)
+			 : "r" (a2)
+			 : "memory");
+
+	return a2;
+}
+EXPORT_SYMBOL(xtensa_syscall_helper_args_0);
+#endif /* CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL */
+
 #endif /* CONFIG_XTENSA_SYSCALL_USE_HELPER */
 
 #if XCHAL_HAVE_THREADPTR == 0

--- a/include/zephyr/arch/xtensa/syscall.h
+++ b/include/zephyr/arch/xtensa/syscall.h
@@ -69,6 +69,18 @@ uintptr_t xtensa_syscall_helper_args_4(uintptr_t arg1, uintptr_t arg2,
 #define SYSINL inline
 #endif /* CONFIG_XTENSA_SYSCALL_USE_HELPER */
 
+#ifdef CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL
+uintptr_t xtensa_syscall_helper_args_3(uintptr_t arg1, uintptr_t arg2,
+				       uintptr_t arg3, uintptr_t call_id);
+
+uintptr_t xtensa_syscall_helper_args_2(uintptr_t arg1, uintptr_t arg2,
+				       uintptr_t call_id);
+
+uintptr_t xtensa_syscall_helper_args_1(uintptr_t arg1, uintptr_t call_id);
+
+uintptr_t xtensa_syscall_helper_args_0(uintptr_t call_id);
+#endif /* CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL */
+
 /**
  * We are following Linux Xtensa syscall ABI:
  *
@@ -155,6 +167,9 @@ static SYSINL uintptr_t arch_syscall_invoke4(uintptr_t arg1, uintptr_t arg2,
 static inline uintptr_t arch_syscall_invoke3(uintptr_t arg1, uintptr_t arg2,
 					     uintptr_t arg3, uintptr_t call_id)
 {
+#ifdef CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL
+	return xtensa_syscall_helper_args_3(arg1, arg2, arg3, call_id);
+#else
 	register uintptr_t a2 __asm__("%a2") = call_id;
 	register uintptr_t a6 __asm__("%a6") = arg1;
 	register uintptr_t a3 __asm__("%a3") = arg2;
@@ -166,11 +181,15 @@ static inline uintptr_t arch_syscall_invoke3(uintptr_t arg1, uintptr_t arg2,
 			 : "memory");
 
 	return a2;
+#endif /* CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL */
 }
 
 static inline uintptr_t arch_syscall_invoke2(uintptr_t arg1, uintptr_t arg2,
 					     uintptr_t call_id)
 {
+#ifdef CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL
+	return xtensa_syscall_helper_args_2(arg1, arg2, call_id);
+#else
 	register uintptr_t a2 __asm__("%a2") = call_id;
 	register uintptr_t a6 __asm__("%a6") = arg1;
 	register uintptr_t a3 __asm__("%a3") = arg2;
@@ -181,10 +200,14 @@ static inline uintptr_t arch_syscall_invoke2(uintptr_t arg1, uintptr_t arg2,
 			 : "memory");
 
 	return a2;
+#endif /* CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL */
 }
 
 static inline uintptr_t arch_syscall_invoke1(uintptr_t arg1, uintptr_t call_id)
 {
+#ifdef CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL
+	return xtensa_syscall_helper_args_1(arg1, call_id);
+#else
 	register uintptr_t a2 __asm__("%a2") = call_id;
 	register uintptr_t a6 __asm__("%a6") = arg1;
 
@@ -194,10 +217,14 @@ static inline uintptr_t arch_syscall_invoke1(uintptr_t arg1, uintptr_t call_id)
 			 : "memory");
 
 	return a2;
+#endif /* CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL */
 }
 
 static inline uintptr_t arch_syscall_invoke0(uintptr_t call_id)
 {
+#ifdef CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL
+	return xtensa_syscall_helper_args_0(call_id);
+#else
 	register uintptr_t a2 __asm__("%a2") = call_id;
 
 	__asm__ volatile(XTENSA_SYSCALL_ASM
@@ -206,6 +233,7 @@ static inline uintptr_t arch_syscall_invoke0(uintptr_t call_id)
 			 : "memory");
 
 	return a2;
+#endif /* CONFIG_XTENSA_SYSCALL_USE_HELPER_ALL */
 }
 
 /*


### PR DESCRIPTION
arch: xtensa: extend syscall helper to invoke levels 0-3

CONFIG_XTENSA_SYSCALL_USE_HELPER currently only routes the 4/5/6-argument
syscall invocations through out-of-line helper functions. Toolchains that
reject inline-asm fixed-register operands in inlinable functions still
fail to build the 0-3 argument variants.

Add xtensa_syscall_helper_args_0..3 and route arch_syscall_invoke0..3
through them when the helper is enabled, mirroring the existing 4/5/6
handling. The inline-asm fast path is preserved under the #else branch.

Signed-off-by: Hiren Virapara <Hiren.Virapara@amd.com>