### PR TITLE
drivers: intc: nxp: enable WKPU on NXP MCXE31x

### DIFF
--- a/drivers/interrupt_controller/Kconfig.nxp_s32
+++ b/drivers/interrupt_controller/Kconfig.nxp_s32
@@ -13,7 +13,7 @@ if NXP_S32_WKPU
 config NXP_S32_WKPU_SOURCES_MAX
 	int
 	range 32 64
-	default 64 if SOC_SERIES_S32K3
+	default 64
 	help
 	  Number of WKPU external and internal sources per controller. This is
 	  a SoC integration option.

--- a/dts/arm/nxp/mcx/nxp_mcxe31x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxe31x_common.dtsi
@@ -1229,7 +1229,7 @@
 	};
 
 	wkpu: wkpu@2b4000 {
-		compatible = "nxp,wkpu";
+		compatible = "nxp,s32-wkpu";
 		reg = <0x2b4000 0x90>;
 		interrupts = <83 0>;
 		status = "disabled";

--- a/tests/drivers/interrupt_controller/wkpu_nxp/CMakeLists.txt
+++ b/tests/drivers/interrupt_controller/wkpu_nxp/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(wkpu_nxp)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/interrupt_controller/wkpu_nxp/boards/frdm_mcxe31b.overlay
+++ b/tests/drivers/interrupt_controller/wkpu_nxp/boards/frdm_mcxe31b.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Enable the Wake-up Unit. The RTC counter (used as the internal stimulus) is
+ * already enabled in the board devicetree.
+ */
+&wkpu {
+	status = "okay";
+};

--- a/tests/drivers/interrupt_controller/wkpu_nxp/prj.conf
+++ b/tests/drivers/interrupt_controller/wkpu_nxp/prj.conf
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_COUNTER=y

--- a/tests/drivers/interrupt_controller/wkpu_nxp/src/main.c
+++ b/tests/drivers/interrupt_controller/wkpu_nxp/src/main.c
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Functional test for the NXP WKPU (Wake-up Unit) interrupt controller driver
+ * on MCXE31x, exercised through an *internal* wake-up source so that no
+ * external pin stimulus / loopback jumper is required.
+ *
+ * Per the MCXE31x Reference Manual (section "WKPU wake-up source connectivity"),
+ * the RTC timeout event is hard-wired to WKPU wake-up source 1. The RTC counter
+ * alarm channel 0 (RTCVAL) generates that timeout. So the test:
+ *   1. arms WKPU source 1 for a rising-edge interrupt,
+ *   2. programs an RTC counter alarm a few seconds out, and
+ *   3. asserts that the WKPU interrupt (IRQ 83) fires and runs the WKPU
+ *      driver callback.
+ *
+ * The WKPU callback firing is the proof: the RTC's own NVIC interrupt path is
+ * separate and does not pass through WKPU.
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/interrupt_controller/intc_wkpu_nxp_s32.h>
+
+/* RM: WKPU wake-up source 1 == RTC timeout. */
+#define WKPU_RTC_TIMEOUT_SOURCE 1U
+/* counter_mcux_rtc_jdp: channel 0 == RTCVAL (the RTC timeout compare). */
+#define RTC_ALARM_CHANNEL       0U
+
+static const struct device *const wkpu = DEVICE_DT_GET(DT_NODELABEL(wkpu));
+static const struct device *const rtc = DEVICE_DT_GET(DT_NODELABEL(rtc));
+
+static K_SEM_DEFINE(wkpu_sem, 0, 1);
+static volatile uint8_t fired_source = 0xFFU;
+
+static void wkpu_callback(uint8_t source, void *arg)
+{
+	ARG_UNUSED(arg);
+	fired_source = source;
+	k_sem_give(&wkpu_sem);
+}
+
+/* Required by the counter API; the RTC NVIC path is not the proof here. */
+static void rtc_alarm_callback(const struct device *dev, uint8_t chan_id,
+			       uint32_t ticks, void *user_data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(chan_id);
+	ARG_UNUSED(ticks);
+	ARG_UNUSED(user_data);
+}
+
+ZTEST(wkpu_nxp, test_rtc_timeout_triggers_wkpu)
+{
+	uint32_t freq;
+	int err;
+
+	zassert_true(device_is_ready(wkpu), "WKPU device not ready");
+	zassert_true(device_is_ready(rtc), "RTC counter device not ready");
+
+	/* Arm WKPU source 1 (RTC timeout). The source index is passed as the
+	 * driver's "pin" argument so the callback can report which line fired.
+	 */
+	err = wkpu_nxp_s32_set_callback(wkpu, WKPU_RTC_TIMEOUT_SOURCE,
+					WKPU_RTC_TIMEOUT_SOURCE, wkpu_callback, NULL);
+	zassert_ok(err, "wkpu_nxp_s32_set_callback() failed: %d", err);
+
+	wkpu_nxp_s32_enable_interrupt(wkpu, WKPU_RTC_TIMEOUT_SOURCE,
+				      WKPU_NXP_S32_RISING_EDGE);
+
+	/* Program an RTC compare a few seconds out on the RTCVAL channel. The
+	 * counter is free-running from driver init.
+	 */
+	freq = counter_get_frequency(rtc);
+	zassert_true(freq > 0U, "invalid RTC counter frequency");
+
+	struct counter_alarm_cfg alarm_cfg = {
+		.callback = rtc_alarm_callback,
+		.ticks = counter_us_to_ticks(rtc, 3000000U), /* ~3 s */
+		.flags = 0U,
+	};
+
+	err = counter_set_channel_alarm(rtc, RTC_ALARM_CHANNEL, &alarm_cfg);
+	zassert_ok(err, "counter_set_channel_alarm() failed: %d", err);
+
+	/* The RTC timeout must drive WKPU source 1 -> WKPU ISR -> wkpu_callback. */
+	err = k_sem_take(&wkpu_sem, K_SECONDS(10));
+
+	wkpu_nxp_s32_disable_interrupt(wkpu, WKPU_RTC_TIMEOUT_SOURCE);
+	(void)counter_cancel_channel_alarm(rtc, RTC_ALARM_CHANNEL);
+
+	zassert_ok(err, "WKPU interrupt from RTC timeout did not fire within 10 s");
+	zassert_equal(fired_source, WKPU_RTC_TIMEOUT_SOURCE,
+		      "WKPU fired on unexpected source %u (expected %u)",
+		      fired_source, WKPU_RTC_TIMEOUT_SOURCE);
+}
+
+ZTEST_SUITE(wkpu_nxp, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/interrupt_controller/wkpu_nxp/tests.yaml
+++ b/tests/drivers/interrupt_controller/wkpu_nxp/tests.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags:
+    - drivers
+    - interrupt_controller
+    - wkpu
+  harness: ztest
+tests:
+  drivers.interrupt_controller.wkpu_nxp:
+    # Exercises the WKPU driver through the RTC-timeout internal wake-up source
+    # (no external pin stimulus required).
+    platform_allow:
+      - frdm_mcxe31b
+    integration_platforms:
+      - frdm_mcxe31b


### PR DESCRIPTION
Enables the Wake-up Unit (WKPU) interrupt controller on NXP MCXE31x (MCXE315 / 316 / 317 / 31B).

The MCXE31x WKPU is register-compatible with the existing `nxp,s32-wkpu` driver (same register map, base `0x402B4000`, IRQ 83, 64 sources), so it reuses that driver unchanged.

**Changes**
- Bind the `wkpu@2b4000` node in the shared `nxp_mcxe31x_common.dtsi` to `nxp,s32-wkpu` (was a placeholder `nxp,wkpu` with no driver), and add `NXP_S32_WKPU_SOURCES_MAX default 64 if SOC_SERIES_MCXE31X` so all 64 sources are used. S32K3 default and the driver source are untouched.
- Add a ztest that validates the WKPU via the RTC-timeout internal source (WKPU source 1) — no external pin/jumper needed.

**Testing**
- `frdm_mcxe31b` hardware: `SUITE PASS` — WKPU interrupt from RTC timeout fires in ~3.5 s.
