### PR TITLE
boards: nxp: mimxrt685_evk: use RMW for BOOT_CFG1 reboot workaround

### DIFF
--- a/boards/nxp/mimxrt685_evk/cm33/init.c
+++ b/boards/nxp/mimxrt685_evk/cm33/init.c
@@ -5,7 +5,23 @@
 
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
 #include <fsl_device_registers.h>
+
+/*
+ * OTP word BOOT_CFG1 (OCOTP shadow index 97) - boot-ROM FlexSPI flash
+ * reset-pin configuration. Field layout per the RT6xx boot ROM OTP map,
+ * cross-checked against mimxrt685_evk (PIO2_12 = 0x314000) and
+ * mimxrt595_evk (PIO4_5 = 0x164000):
+ *   bit  14    : FLEXSPI_RESET_PIN_ENABLE
+ *   bits 17:15 : GPIO port
+ *   bits 22:18 : GPIO pin
+ */
+#define BOOT_CFG1_FLEXSPI_RESET_ENABLE     BIT(14)
+#define BOOT_CFG1_FLEXSPI_RESET_PORT_MASK  GENMASK(17, 15)
+#define BOOT_CFG1_FLEXSPI_RESET_PIN_MASK   GENMASK(22, 18)
+#define BOOT_CFG1_FLEXSPI_RESET_PORT(p)    FIELD_PREP(BOOT_CFG1_FLEXSPI_RESET_PORT_MASK, (p))
+#define BOOT_CFG1_FLEXSPI_RESET_PIN(n)     FIELD_PREP(BOOT_CFG1_FLEXSPI_RESET_PIN_MASK, (n))
 
 void board_early_init_hook(void)
 {
@@ -49,13 +65,30 @@ void board_early_init_hook(void)
 
 #ifdef CONFIG_REBOOT
 	/*
-	 * The sys_reboot API calls NVIC_SystemReset. On the RT685, the warm
-	 * reset will not complete correctly unless the ROM toggles the
-	 * flash reset pin. We can control this behavior using the OTP shadow
-	 * register for OPT word BOOT_CFG1
+	 * sys_reboot() issues NVIC_SystemReset (warm reset). On the RT685 the
+	 * ROM must toggle the external FlexSPI flash reset pin during boot, or
+	 * the flash is left in a non-default mode and re-boot fails. Enable
+	 * this via the BOOT_CFG1 OTP shadow (physical fuses left unprogrammed).
 	 *
-	 * Set FLEXSPI_RESET_PIN_ENABLE=1, FLEXSPI_RESET_PIN= PIO2_12
+	 * On the EVK the MX25UM51345G Octal SPI flash RESET is connected to
+	 * PIO2_12.
+	 *
+	 * Read-modify-write so that any other BOOT_CFG1 bits already loaded
+	 * from programmed fuses are preserved.
+	 *
+	 * NOTE: this relies on the BOOT_CFG1 shadow word NOT being write-locked.
+	 * If the OCOTP shadow-write lock for this word is set (e.g. on a fused/
+	 * secured part), the write is ignored by hardware and this workaround
+	 * has no effect.
 	 */
-	 OCOTP->OTP_SHADOW[97] = 0x314000;
+	uint32_t cfg = OCOTP->OTP_SHADOW[97];
+
+	cfg &= ~(BOOT_CFG1_FLEXSPI_RESET_ENABLE |
+		 BOOT_CFG1_FLEXSPI_RESET_PORT_MASK |
+		 BOOT_CFG1_FLEXSPI_RESET_PIN_MASK);
+	cfg |= BOOT_CFG1_FLEXSPI_RESET_ENABLE |
+	       BOOT_CFG1_FLEXSPI_RESET_PORT(2) |   /* PIO2 */
+	       BOOT_CFG1_FLEXSPI_RESET_PIN(12);    /* _12  */
+	OCOTP->OTP_SHADOW[97] = cfg;
 #endif /* CONFIG_REBOOT */
 }


### PR DESCRIPTION
### Summary

The `sys_reboot()` OTP-shadow workaround in the RT685 EVK board init wrote the whole `BOOT_CFG1` shadow word with a magic constant (`0x314000`).

This switches it to a **read-modify-write using named bitfields** for `FLEXSPI_RESET_PIN_ENABLE`, port and pin, so:

- any other `BOOT_CFG1` bits already loaded from programmed fuses are preserved (a full-word write would clobber them on a fused/secured part);
- the configured flash reset pin (**PIO2_12**, the MX25UM51345G Octal SPI flash RESET on the EVK) is explicit instead of hidden inside a magic number.

The field layout (`ENABLE`@14, port[17:15], pin[18:22]) is derived from the two known values used in-tree and reconstructs both `mimxrt685_evk` (PIO2_12 = `0x314000`) and `mimxrt595_evk` (PIO4_5 = `0x164000`) exactly. Pointers to the authoritative RT6xx `BOOT_CFG1` fusemap definition are welcome.

### Behavior

No functional change on the EVK: with unprogrammed fuses the shadow word reads back 0, so the RMW result is identical to the previous write. The RMW only adds safety on parts where `BOOT_CFG1` fuses are programmed.

### Testing

`CONFIG_REBOOT` defaults to `n`, so this `#ifdef CONFIG_REBOOT` path is not built by default CI. Verified locally:

```
west build -b mimxrt685_evk/mimxrt685s/cm33 samples/hello_world -- -DCONFIG_REBOOT=y
```

links cleanly.

### Context

This is the original board the new MIMXRT685-AUD-EVK support (#107614) was copied from; the same fix is applied there. This PR addresses the review feedback for both by fixing the source board.
