### PR TITLE
drivers: ethernet: xlnx_gem: fix start/stop device signatures

### DIFF
--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -539,7 +539,8 @@ static int eth_xlnx_gem_send(const struct device *dev, struct net_pkt *pkt)
  * @param dev Pointer to the device data
  * @retval    0 upon successful completion
  */
-static int eth_xlnx_gem_start_device(const struct device *dev)
+static int eth_xlnx_gem_start_device(const struct device *dev,
+				     struct net_if *iface __unused)
 {
 	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
 	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
@@ -588,7 +589,8 @@ static int eth_xlnx_gem_start_device(const struct device *dev)
  * @param dev Pointer to the device data
  * @retval    0 upon successful completion
  */
-static int eth_xlnx_gem_stop_device(const struct device *dev)
+static int eth_xlnx_gem_stop_device(const struct device *dev,
+				    struct net_if *iface __unused)
 {
 	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
 	struct eth_xlnx_gem_dev_data *dev_data = dev->data;


### PR DESCRIPTION
The March-2026 Ethernet API migration (commit db984ee196b) added struct net_if *iface to the net_if_api start/stop declarations but the eth_xlnx_gem_start_device and eth_xlnx_gem_stop_device definitions were not updated, causing a build failure for any target that enables the GEM driver (e.g. Zynq-7000 with zperf).

Added the missing parameter to both definitions.