### PR TITLE
drivers: counter: max32_wut: Disable counter before setting compare

### DIFF
--- a/drivers/counter/counter_max32_wut.c
+++ b/drivers/counter/counter_max32_wut.c
@@ -156,6 +156,7 @@ static int counter_max32_wut_set_alarm(const struct device *dev, uint8_t chan,
 
 	min_abs_ticks = (uint64_t)now_ticks + data->guard_period;
 	if ((!absolute && (abs_ticks < now_ticks)) || (abs_ticks > min_abs_ticks)) {
+		MXC_WUT_Disable(cfg->regs);
 		MXC_WUT_SetCompare(cfg->regs, abs_ticks & top_ticks);
 		MXC_WUT_Enable(cfg->regs);
 		return 0;

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -68,6 +68,8 @@ struct counter_alarm_cfg alarm_cfg;
 #endif
 #elif defined(CONFIG_COUNTER_TIMER_MAX32)
 #define SAMPLE_TIMER DT_NODELABEL(counter0)
+#elif defined(CONFIG_COUNTER_WUT_MAX32)
+#define SAMPLE_TIMER DT_NODELABEL(counter_wut1)
 #elif defined(CONFIG_COUNTER_RA_AGT)
 #define SAMPLE_TIMER DT_NODELABEL(counter0)
 #elif defined(CONFIG_COUNTER_RENESAS_RZ_GTM)

--- a/tests/drivers/counter/counter_basic_api/boards/max32657evkit_max32657.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/max32657evkit_max32657.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -50,6 +50,15 @@
 
 &timer5 {
 	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&wut0 {
+	status = "okay";
+	prescaler = <2>;
 
 	counter {
 		status = "okay";

--- a/tests/drivers/counter/counter_basic_api/boards/max32657evkit_max32657_ns.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/max32657evkit_max32657_ns.overlay
@@ -55,3 +55,12 @@
 		status = "okay";
 	};
 };
+
+&wut0 {
+	status = "okay";
+	prescaler = <2>;
+
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -211,6 +211,9 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_BEE_RTC
 	DEVS_FOR_DT_COMPAT(realtek_bee_counter_rtc)
 #endif
+#ifdef CONFIG_COUNTER_WUT_MAX32
+	DEVS_FOR_DT_COMPAT(adi_max32_wut)
+#endif
 };
 
 static const struct device *const period_devs[] = {


### PR DESCRIPTION
Disable Wake-Up Timer before setting a new compare value to comply with user guide recommendations. Also include Wake-Up Timer in counter test and sample.