### PR TITLE
spi: document SPI_LOCK_ON for chained-async and guard spi_context_lock

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -121,6 +121,9 @@ static inline bool spi_context_is_slave(struct spi_context *ctx)
  * The purpose of the context lock is to synchronize the usage of the driver/hardware.
  * The driver should call this function to claim or wait for ownership of the spi resource.
  * Usually the appropriate time to call this is at the start of the transceive API implementation.
+ *
+ * May block (and so must not be called from ISR) unless the lock is already
+ * held via SPI_LOCK_ON.
  */
 static inline void spi_context_lock(struct spi_context *ctx,
 				    bool asynchronous,
@@ -134,6 +137,10 @@ static inline void spi_context_lock(struct spi_context *ctx,
 			      (ctx->owner == spi_cfg);
 
 	if (!already_locked) {
+		__ASSERT(!k_is_in_isr(),
+			 "%s would block from ISR; "
+			 "use the RTIO submit path for chained async",
+			 __func__);
 		k_sem_take(&ctx->lock, K_FOREVER);
 		ctx->owner = spi_cfg;
 	}

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -190,6 +190,10 @@ extern "C" {
  * is the spi_config pointer given to the transaction API, so this same
  * config should be re-used to do another transaction or release the lock.
  *
+ * For chaining asynchronous transactions, use the RTIO submit path
+ * (@ref spi_iodev_submit) rather than re-entering
+ * transceive from the completion callback, which may run in ISR context.
+ *
  * See @ref spi_release for how to release the  lock.
  */
 #define SPI_LOCK_ON		BIT(13)


### PR DESCRIPTION
### Problem

`SPI_LOCK_ON` is documented only as an optional convenience for keeping the bus locked across consecutive transactions. It is in fact **required** for the common SPI-slave pattern of chaining asynchronous transactions by re-arming the next transfer from the completion callback.

On drivers whose completion callback runs in ISR context (where `spi_context_complete` invokes the callback *before* releasing the bus lock), omitting `SPI_LOCK_ON` makes each re-armed transceive call (see #111518):

```
spi_context_lock -> k_sem_take(ctx->lock, K_FOREVER)   [from ISR]
```

That is illegal (blocking from ISR), and with `CONFIG_ASSERT` disabled — the production default — it does not fail. It silently corrupts the kernel scheduler (the bus lock is held during the callback, so the take blocks, `z_pend_curr` pends `_current` from ISR, the `SWAP_NONATOMIC` window lets it return without switching, and the shared `qnode_dlist` ends up double-linked → self-referential → NULL deref in `sys_dlist_remove`).

### This change

- **`spi.h`**: document that `SPI_LOCK_ON` must be set when chaining async transactions from the completion callback, with the consequence of omitting it stated plainly (silent scheduler corruption in a non-debug build).
- **`spi_context.h`**: add `__ASSERT_NO_MSG(!k_is_in_isr())` at the top of `spi_context_lock`, so a missing `SPI_LOCK_ON` is caught **at the SPI layer** in debug/test builds (where `CONFIG_ASSERT` defaults to `y`) instead of decaying into scheduler corruption.

### Scope and what it does *not* do

- This is **debug-only enforcement** (an `__ASSERT`, compiled out when `CONFIG_ASSERT=n`). It improves debug/test-build coverage but does not by itself catch the misuse in production builds.
- The **production** fix — a real, non-debug runtime check in `k_sem_take`/`z_pend_curr` that refuses ISR context in every build — is the companion kernel PR `fix/enforce-no-blocking-pend-from-isr`. This PR complements it; it does not replace it.

### Risk

Very low: a documentation addition and a debug-only assert. The assert fires only in builds where `CONFIG_ASSERT=y` and only when a caller actually reaches `spi_context_lock` from ISR — which is always a bug, so failing there is strictly better than the status quo (silent scheduler corruption). No behavior change in production builds.

### Testing

- Built and verified with the chained-async SPIS slave from #111518: with `SPI_LOCK_ON` set, the assert does not fire (the `already_locked` fast path is taken, `k_sem_take` is skipped). Without `SPI_LOCK_ON` and `CONFIG_ASSERT=y`, the assert fires on the first re-arm with a clear message.
- No regression to existing SPI users expected (the assert only fires for the already-broken ISR-context case).

CC @tbursztyka @teburd @decsny @npitre @peter-mitsis @tmon-nordic
