### PR TITLE
kernel: sched: panic on blocking pend from ISR context

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -411,6 +411,9 @@ void z_sched_yield(void)
 /* _sched_spinlock must be held */
 static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
 {
+	/* A thread must not already be on a wait queue when added to a new one. */
+	__ASSERT_NO_MSG(thread->base.pended_on == NULL);
+
 	unready_thread(thread);
 	z_mark_thread_as_pending(thread);
 
@@ -503,6 +506,17 @@ void z_thread_timeout(struct _timeout *timeout)
 int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 	       _wait_q_t *wait_q, k_timeout_t timeout)
 {
+	/* A blocking pend from ISR context is a programming error with no
+	 * safe recovery: it would sleep whatever thread was interrupted and,
+	 * on CONFIG_SWAP_NONATOMIC, corrupt the scheduler. Refuse it fatally
+	 * in every build rather than degrading into the corruption traced in
+	 * #111518. Placed first so the refusal performs no side effect.
+	 */
+	if (arch_is_in_isr()) {
+		__ASSERT(false, "blocking pend from ISR context");
+		k_panic();
+	}
+
 #if defined(CONFIG_TIMESLICING) && defined(CONFIG_SWAP_NONATOMIC)
 	pending_current = _current;
 #endif /* CONFIG_TIMESLICING && CONFIG_SWAP_NONATOMIC */

--- a/tests/kernel/mbox/mbox_api/boards/qemu_rx_r5f562n8.conf
+++ b/tests/kernel/mbox/mbox_api/boards/qemu_rx_r5f562n8.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Tibor Kiss
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_TEST_EXTRA_STACK_SIZE=128


### PR DESCRIPTION
### Problem

A blocking pend from ISR context is a programming error with no safe recovery: it attempts to sleep whatever thread was interrupted and, on `CONFIG_SWAP_NONATOMIC`, corrupts the scheduler — the `qnode_dlist` double-link / NULL-deref traced in #111518. The debug-only `__ASSERT` guarding this was compiled out in production (`CONFIG_ASSERT` defaults to `n`), so the misuse shipped and ran for hours, surfacing only as intermittent scheduler corruption three subsystems away from its cause.

### This change

Catch it at the **funnel** instead of per-API. Every blocking primitive (sem, mutex, msgq, queue, stack, pipe, poll, events, mailbox, mem_slab, kheap, futex, …) routes through `z_pend_curr`, and reaching it always means a real block (callers handle `K_NO_WAIT` beforehand). So one check there covers them all, with no per-API return-contract churn:

```c
int z_pend_curr(...)
{
    ...
    if (arch_is_in_isr()) {
        __ASSERT(false, "blocking pend from ISR context");
        k_panic();
    }
    (void) k_spin_lock(&_sched_spinlock);
    ...
}
```

- `__ASSERT(false, ...)` gives the message and backtrace in debug builds.
- `k_panic()` makes it **fatal in every build**, closing the production gap that let #111518 ship.
- Placed before `_sched_spinlock` is acquired, so no lock is held on the panic path.

Also assert in `add_to_waitq_locked()` that a thread is not already on a wait queue when added to a new one (`pended_on == NULL`) — belt-and-suspenders for a double-pend that reaches the scheduler despite the above (e.g. a non-current thread re-pended without an intervening unpend).

### What this PR does _not_ do

A blocking take from ISR where the resource happens to be **available** takes the fast path and returns `0` without ever reaching `z_pend_curr` — so the misuse can still slip through until it contends. This residual gap is owned by a separate follow-up (see @Mattemagikern's draft using `CHECKIF(..)` at call sites), not this PR.

### Evolution

This supersedes the earlier per-API `-EINVAL` in `k_sem_take`: that approach reframed a programming error as a recoverable condition and made the semaphore the odd one out. Adopting @npitre's funnel-level suggestion and @Mattemagikern's consistency point collapses the PR to a single kernel-wide check. CC @npitre @peter-mitsis @Mattemagikern @andyross