### PR TITLE
tests: drivers: can: api: specify integration platforms

### DIFF
--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -5,9 +5,15 @@ common:
   depends_on: can
 tests:
   drivers.can.api:
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
     filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
       and not dt_compat_enabled("infineon,xmc4xxx-can-node")
   drivers.can.api.rtr:
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
     filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
       and not dt_compat_enabled("infineon,xmc4xxx-can-node")
     extra_configs:
@@ -21,6 +27,8 @@ tests:
   drivers.can.api.nxp_s32_canxl.non_rx_fifo:
     extra_configs:
       - CONFIG_CAN_NXP_S32_RX_FIFO=n
+    integration_platforms:
+      - s32z2xxdc2/s32z270/rtu0
     platform_allow:
       - s32z2xxdc2/s32z270/rtu0
       - s32z2xxdc2/s32z270/rtu1


### PR DESCRIPTION
Specify the integration platforms instead of relying on run-time filtering and reduce integration test of the NXP CANXL driver in non-RX FIFO mode to one platform.