### PR TITLE
dts: arm: st: stm32mp13: add low-speed clocks and RTC support

### DIFF
--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -93,6 +93,10 @@
 	status = "okay";
 };
 
+&clk_lse {
+	status = "okay";
+};
+
 &cpusw {
 	clocks = <&clk_hsi>;
 	clock-frequency = <DT_FREQ_M(64)>;
@@ -321,4 +325,9 @@ csi_interface: &dcmipp {
 		reg = <0>;
 		reset-gpios = <&mcp23017 9 GPIO_ACTIVE_LOW>;
 	};
+};
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK(APB5, 8)>, <&rcc STM32_SRC_LSE RTC_SEL(1)>;
+	status = "okay";
 };

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -353,6 +353,16 @@
 			resets = <&rctl STM32_RESET(AHB6, 20)>;
 			status = "disabled";
 		};
+
+		rtc: rtc@5c004000 {
+			compatible = "st,stm32-rtc";
+			reg = <0x5c004000 0x400>;
+			interrupts = <GIC_SPI 3 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&rcc STM32_CLOCK(APB5, 8)>;
+			alarms-count = <2>;
+			alrm-exti-line = <19>;
+			status = "disabled";
+		};
 	};
 
 	gic: gic@a0021000 {

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -389,6 +389,20 @@
 			status = "disabled";
 		};
 
+		clk_lse: clk-lse {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <32768>;
+			status = "disabled";
+		};
+
+		clk_lsi: clk-lsi {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_K(32)>;
+			status = "disabled";
+		};
+
 		cpusw: cpusw {
 			#clock-cells = <0>;
 			compatible = "st,stm32mp13-cpu-clock-mux";

--- a/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
@@ -6,6 +6,8 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP13_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP13_CLOCK_H_
 
+/** @cond INTERNAL_HIDDEN */
+
 #include "stm32_common_clocks.h"
 
 /** System clock */
@@ -153,5 +155,7 @@
 #define DCMIPP_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, DCMIPPCKSELR_REG)
 #define SAES_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, SAESCKSELR_REG)
 #define RTC_SEL(val)            STM32_DT_CLOCK_SELECT((val), 17, 16, BDCR_REG)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP13_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
@@ -44,6 +44,7 @@
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_AHB6
 
 /** @brief Device domain clocks selection helpers */
+#define BDCR_REG                0x400
 #define MCO1CFGR_REG		0x460
 #define MCO2CFGR_REG		0x464
 #define I2C12CKSELR_REG		0x600
@@ -151,5 +152,6 @@
 #define STGEN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, STGENCKSELR_REG)
 #define DCMIPP_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, DCMIPPCKSELR_REG)
 #define SAES_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, SAESCKSELR_REG)
+#define RTC_SEL(val)            STM32_DT_CLOCK_SELECT((val), 17, 16, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP13_CLOCK_H_ */


### PR DESCRIPTION
## Summary

Add low-speed clock and RTC devicetree support for STM32MP13 and
enable RTC on the STM32MP135F-DK board.

## Changes

- add LSI and LSE low-speed clock nodes in `stm32mp13.dtsi`
- add RTC node in `stm32mp13.dtsi`
- enable LSE clock on `stm32mp135f_dk`
- enable RTC on `stm32mp135f_dk`

## Rationale

LSE is used as the RTC clock source because it remains available in
the backup domain when VBAT is present, allowing the RTC to keep
running in that configuration.

## Testing

- tested on STM32MP135F-DK hardware
- verified LSI and LSE clock configuration
- used the configured clocks in a delay-based LED test on hardware
- verified RTC initialization and operation