### PR TITLE
doc: remove zms header from INPUT in doxygen conf

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1046,7 +1046,6 @@ INPUT                  = @ZEPHYR_BASE@/doc/_doxygen/mainpage.md \
                          @ZEPHYR_BASE@/subsys/testsuite/include/ \
                          @ZEPHYR_BASE@/subsys/testsuite/ztest/include/ \
                          @ZEPHYR_BASE@/subsys/secure_storage/include/ \
-                         @ZEPHYR_BASE@/subsys/fs/zms/zms_priv.h \
                          @ZEPHYR_BASE@/modules/openthread/include/openthread.h \
 
 # This tag can be used to specify the character encoding of the source files


### PR DESCRIPTION
@ZEPHYR_BASE@/subsys/fs/zms/zms_priv.h  does not exist and is being
added as input.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
