### PR TITLE
STM32: export SoC name expected by HAL to the module via a dedicated Kconfig option

### DIFF
--- a/boards/makerbase/mks_canable_v10/board.yml
+++ b/boards/makerbase/mks_canable_v10/board.yml
@@ -7,4 +7,4 @@ board:
   full_name: MKS CANable V1.0
   vendor: makerbase
   socs:
-    - name: stm32f072xb
+    - name: stm32f072x8

--- a/boards/st/nucleo_h7a3zi_q/board.yml
+++ b/boards/st/nucleo_h7a3zi_q/board.yml
@@ -3,4 +3,4 @@ board:
   full_name: Nucleo H7A3ZI-Q
   vendor: st
   socs:
-    - name: stm32h7a3xx
+    - name: stm32h7a3xxq

--- a/boards/st/stm32h7b3i_dk/board.yml
+++ b/boards/st/stm32h7b3i_dk/board.yml
@@ -3,4 +3,4 @@ board:
   full_name: STM32H7B3I Discovery kit
   vendor: st
   socs:
-    - name: stm32h7b3xx
+    - name: stm32h7b3xxq

--- a/dts/arm/st/f7/stm32f777Xi.dtsi
+++ b/dts/arm/st/f7/stm32f777Xi.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/f7/stm32f777.dtsi>
+
+/ {
+	soc {
+		flash-controller@40023c00 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_M(2)>;
+				ranges = <0 0x8000000 DT_SIZE_M(2)>;
+			};
+		};
+	};
+};

--- a/modules/Kconfig.stm32
+++ b/modules/Kconfig.stm32
@@ -17,6 +17,24 @@ config HAS_STM32CUBE
 	select HAS_CMSIS_CORE
 	depends on SOC_FAMILY_STM32
 
+config STM32CUBE_SOC_NAME_OVERRIDE
+	string
+	help
+	  Hidden option used to override the SoC name at STM32Cube HAL level.
+
+	  The STM32Cube HAL requires a global preprocessor definition which
+	  matches the target SoC's name to be defined, which can usually be
+	  derived from CONFIG_SOC. However, there are some exceptions where
+	  two different SoCs (with different CONFIG_SOC values) should use
+	  the same definition at STM32Cube HAL level.
+
+	  By default, this option has no value and is thus undefined. In this
+	  case, the STM32Cube HAL module shall derive the global preprocessor
+	  definition from CONFIG_SOC. If a value for this option is explicitly
+	  set at SoC level (using configdefault), the STM32Cube HAL module
+	  shall derive the global preprocessor definition from this option
+	  instead of CONFIG_SOC.
+
 if HAS_STM32CUBE
 
 config USE_STM32_HAL_ADC

--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -22,6 +22,7 @@ family:
     - name: stm32c5a3xx
   - name: stm32f0x
     socs:
+    - name: stm32f030x4
     - name: stm32f030x6
     - name: stm32f030x8
     - name: stm32f030xc
@@ -29,6 +30,7 @@ family:
     - name: stm32f042x6
     - name: stm32f051x8
     - name: stm32f070xb
+    - name: stm32f072x8
     - name: stm32f072xb
     - name: stm32f091xc
     - name: stm32f098xx
@@ -36,8 +38,10 @@ family:
     socs:
     - name: stm32f100xb
     - name: stm32f100xe
+    - name: stm32f103x8
     - name: stm32f103xb
     - name: stm32f103xe
+    - name: stm32f105xb
     - name: stm32f105xc
     - name: stm32f107xc
   - name: stm32f2x
@@ -89,6 +93,7 @@ family:
     - name: stm32f765xx
     - name: stm32f767xx
     - name: stm32f769xx
+    - name: stm32f777xx
   - name: stm32g0x
     socs:
     - name: stm32g030xx
@@ -134,11 +139,15 @@ family:
   - name: stm32h7x
     socs:
     - name: stm32h7a3xx
+    - name: stm32h7a3xxq
     - name: stm32h7b0xx
+    - name: stm32h7b0xxq
     - name: stm32h7b3xx
+    - name: stm32h7b3xxq
     - name: stm32h723xx
     - name: stm32h725xx
     - name: stm32h730xx
+    - name: stm32h730xxq
     - name: stm32h735xx
     - name: stm32h742xx
     - name: stm32h743xx

--- a/soc/st/stm32/stm32f0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32f0x/Kconfig.defconfig
@@ -7,6 +7,12 @@
 
 if SOC_SERIES_STM32F0X
 
+# STM32F030x4 must be exposed as STM32F030x6 at HAL level.
+# STM32F072x8 must be exposed as STM32F072xB at HAL level.
+configdefault STM32CUBE_SOC_NAME_OVERRIDE
+	default "stm32f030x6" if SOC_STM32F030X4
+	default "stm32f072xb" if SOC_STM32F072X8
+
 config SRAM_VECTOR_TABLE
 	default y
 

--- a/soc/st/stm32/stm32f0x/Kconfig.soc
+++ b/soc/st/stm32/stm32f0x/Kconfig.soc
@@ -58,16 +58,16 @@ config SOC_STM32F098XX
 	bool
 	select SOC_SERIES_STM32F0X
 
-# STM32F0 Cube package advises to use 'stm32f030x6' code
-# for both STM32F030x4 and STM32F030x6
 config SOC
-	default "stm32f030x6" if SOC_STM32F030X4 || SOC_STM32F030X6
+	default "stm32f030x4" if SOC_STM32F030X4
+	default "stm32f030x6" if SOC_STM32F030X6
 	default "stm32f030x8" if SOC_STM32F030X8
 	default "stm32f030xc" if SOC_STM32F030XC
 	default "stm32f031x6" if SOC_STM32F031X6
 	default "stm32f042x6" if SOC_STM32F042X6
 	default "stm32f051x8" if SOC_STM32F051X8
 	default "stm32f070xb" if SOC_STM32F070XB
-	default "stm32f072xb" if SOC_STM32F072X8 || SOC_STM32F072XB
+	default "stm32f072x8" if SOC_STM32F072X8
+	default "stm32f072xb" if SOC_STM32F072XB
 	default "stm32f091xc" if SOC_STM32F091XC
 	default "stm32f098xx" if SOC_STM32F098XX

--- a/soc/st/stm32/stm32f1x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32f1x/Kconfig.defconfig
@@ -7,6 +7,12 @@
 
 if SOC_SERIES_STM32F1X
 
+# STM32F103x8 must be exposed as STM32F103xB at HAL level.
+# STM32F105xB must be exposed as STM32F105xC at HAL level.
+configdefault STM32CUBE_SOC_NAME_OVERRIDE
+	default "stm32f103xb" if SOC_STM32F103X8
+	default "stm32f105xc" if SOC_STM32F105XB
+
 # adjust the fallback because of the LSI oscaillator characteristics
 config TASK_WDT_HW_FALLBACK_DELAY
 	depends on TASK_WDT_HW_FALLBACK

--- a/soc/st/stm32/stm32f1x/Kconfig.soc
+++ b/soc/st/stm32/stm32f1x/Kconfig.soc
@@ -70,7 +70,9 @@ config SOC_STM32F10X_CONNECTIVITY_LINE_DEVICE
 config SOC
 	default "stm32f100xb" if SOC_STM32F100XB
 	default "stm32f100xe" if SOC_STM32F100XE
-	default "stm32f103xb" if SOC_STM32F103XB || SOC_STM32F103X8
+	default "stm32f103x8" if SOC_STM32F103X8
+	default "stm32f103xb" if SOC_STM32F103XB
 	default "stm32f103xe" if SOC_STM32F103XE
-	default "stm32f105xc" if SOC_STM32F105XC || SOC_STM32F105XB
+	default "stm32f105xb" if SOC_STM32F105XB
+	default "stm32f105xc" if SOC_STM32F105XC
 	default "stm32f107xc" if SOC_STM32F107XC

--- a/soc/st/stm32/stm32f4x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32f4x/Kconfig.defconfig
@@ -7,6 +7,10 @@
 
 if SOC_SERIES_STM32F4X
 
+# STM32F401xD must be exposed as STM32F401xE at HAL level.
+configdefault STM32CUBE_SOC_NAME_OVERRIDE
+	default "stm32f401xe" if SOC_STM32F401XD
+
 configdefault SHARED_INTERRUPTS
 	default y if $(dt_nodelabel_enabled,timers1) && $(dt_nodelabel_enabled,timers9)
 	default y if $(dt_nodelabel_enabled,timers1) && $(dt_nodelabel_enabled,timers10)

--- a/tests/drivers/build_all/video/testcase.yaml
+++ b/tests/drivers/build_all/video/testcase.yaml
@@ -34,10 +34,10 @@ tests:
       - frdm_mcxn947/mcxn947/cpu0
   drivers.video.stm32_dcmi.build:
     platform_allow:
-      - stm32h7b3i_dk/stm32h7b3xx
+      - stm32h7b3i_dk
       - arduino_nicla_vision/stm32h747xx/m7
     extra_args:
-      - platform:stm32h7b3i_dk/stm32h7b3xx:SHIELD=st_b_cams_omv_mb1683
+      - platform:stm32h7b3i_dk:SHIELD=st_b_cams_omv_mb1683
   drivers.video.esp32_dvp.build:
     platform_allow:
       - esp32s3_eye/esp32s3/procpu

--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: ff19fb0b03bc9b3f1355e9f9b7b6b3a6c051f121
+      revision: 40b720b80ab8f399263998dfc9a0e8a2bfc7a729
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Alternative to https://github.com/zephyrproject-rtos/zephyr/pull/110081

