### PR TITLE
ci: stale: fix misleading reopen note in stale PR message

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -21,7 +21,8 @@ jobs:
         stale-pr-message: 'This pull request has been marked as stale because it has been open (more
           than) 30 days with no activity. Remove the stale label or add a comment saying that you
           would like to have the label removed otherwise this pull request will automatically be
-          closed in 7 days. Note, that you can always re-open a closed pull request at any time.'
+          closed in 7 days. Note that if it gets closed, you can ask someone to reopen it for you if
+          you do not have the permissions to do so.'
         stale-issue-message: 'This issue has been marked as stale because it has been open (more
           than) 30 days with no activity. Remove the stale label or add a comment saying that you
           would like to have the label removed otherwise this issue will automatically be closed in


### PR DESCRIPTION
The stale PR message claimed that contributors can always re-open a closed pull request at any time. In practice, re-opening a pull request requires triage (or higher) permissions, which regular contributors do not have, so a closed pull request cannot be re-opened by its author.

Reword the message to tell contributors to ask someone with the appropriate permissions to re-open the pull request for them instead.

Fixes #111579