### PR TITLE
include: zephyr: Introduce zerror header

### DIFF
--- a/include/zephyr/zerror/zerror.h
+++ b/include/zephyr/zerror/zerror.h
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright The Zephyr Project Contributors
+ */
+
+#ifndef ZEPHYR_INCLUDE_ZERROR_ZERROR_H_
+#define ZEPHYR_INCLUDE_ZERROR_ZERROR_H_
+
+#include <stdint.h>
+#include <sys/errno.h>
+#include <zephyr/sys/util_macro.h>
+
+/**
+ * @file
+ * @brief Error handling helper API interface
+ * @details This header provides a set of macros to create and manipulate
+ *          error codes in a compact and structured way. It allows combining a module identifier,
+ *          a custom error code, and a standard errno value into a single integer value, and
+ *          provides macros to extract each component from the combined error code.
+ * 			The integer is encoded as follow [MSB:LSB]: [sign:1bit][module:7bits][custom_code:8bits][errno:16bits]
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Type definition for zerror_t.
+ * @details This type is used to represent error codes in a compact format, combining module,
+ *          custom code, and errno values into a single integer. `zerror_t` should always
+ *          refer to a unique error source and hence can be simply propagated to upper functions.
+ */
+typedef int zerror_t;
+
+/** @cond INTERNAL_HIDDEN */
+
+#define Z_ZERRORNO_BITS           (16)
+#define Z_ZERROR_CUSTOM_CODE_BITS (8)
+#define Z_ZERROR_MODULE_BITS      (7)
+
+#define Z_ZERROR_CUSTOM_CODE_POS (Z_ZERRORNO_BITS)
+#define Z_ZERROR_MODULE_POS      (Z_ZERROR_CUSTOM_CODE_POS + Z_ZERROR_CUSTOM_CODE_BITS)
+
+#define Z_ZERRORNO_MASK             BIT_MASK(Z_ZERRORNO_BITS)
+#define Z_ZERROR_CUSTOM_CODE_MASK   (BIT_MASK(Z_ZERROR_CUSTOM_CODE_BITS) << Z_ZERROR_CUSTOM_CODE_POS)
+#define Z_ZERROR_CUSTOM_MODULE_MASK (BIT_MASK(Z_ZERROR_MODULE_BITS) << Z_ZERROR_MODULE_POS)
+#define Z_ZERROR_ABS(zerror)        (((int)(zerror)) < 0 ? -(zerror) : (zerror))
+
+#ifdef __ELASTERROR
+BUILD_ASSERT(__ELASTERROR <= INT16_MAX, "The maximum errno value must fit within 16 bits");
+#endif
+
+/** @endcond */
+
+/**
+ * @brief Combines a custom error code and an errno into a single integer value.
+ * @param module The error module. This value is limited to 7 bits unsigned value and it's
+ * application specific.
+ * @param custom_code The custom error code. This value is limited to a int8_t value and it's
+ * application specific.
+ * @param errno The standard errno value, limited to a int16_t value. The sign of the value is
+ * preserved, so negative errno values are supported.
+ */
+#define ZERROR(module, custom_code, errno)                                                         \
+	((zerror_t)(FIELD_PREP(Z_ZERROR_CUSTOM_MODULE_MASK, (module)) |                   \
+		    FIELD_PREP(Z_ZERROR_CUSTOM_CODE_MASK, (custom_code)) |                \
+		    FIELD_PREP(Z_ZERRORNO_MASK, (errno))))
+
+/**
+ * @brief Extracts the errno value from a zerror_t.
+ * @param zerror The zerror_t value.
+ * @return The extracted errno value.
+ */
+#define ZERROR_GET_ERRNO(zerror)                                                                   \
+	((int)((int16_t)FIELD_GET(Z_ZERRORNO_MASK, Z_ZERROR_ABS(zerror))))
+
+/**
+ * @brief Extracts the module value from a zerror_t.
+ * @param zerror The zerror_t value.
+ * @return The extracted module value.
+ */
+#define ZERROR_GET_MODULE(zerror)                                                                  \
+	((int)((uint8_t)FIELD_GET(Z_ZERROR_CUSTOM_MODULE_MASK, Z_ZERROR_ABS(zerror))))
+
+/**
+ * @brief Extracts the custom code value from a zerror_t.
+ * @param zerror The zerror_t value.
+ * @return The extracted custom code value.
+ */
+#define ZERROR_GET_CUSTOM_CODE(zerror)                                                             \
+	((int)((int8_t)FIELD_GET(Z_ZERROR_CUSTOM_CODE_MASK, Z_ZERROR_ABS(zerror))))
+
+/**
+ * @brief Returns from the current function if the expression evaluates to a non-zero zerror_t. The
+ * expression's returned value is used as return value,
+ * @note The expression must return a zerror_t value, if the expression returns an errno value, the
+ * errno sign will NOT be preserved in this case.
+ * @param expr The expression to evaluate.
+ */
+#define ZERROR_RETURN_ON_ERROR(expr)                                                               \
+	do {                                                                                       \
+		zerror_t _zerror_rc = (expr);                                                      \
+		if (_zerror_rc != 0) {                                                             \
+			return _zerror_rc;                                                         \
+		}                                                                                  \
+	} while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_ZERROR_ZERROR_H_ */

--- a/tests/include/zephyr/zerror/CMakeLists.txt
+++ b/tests/include/zephyr/zerror/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(include_zephyr_zerror)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/include/zephyr/zerror/prj.conf
+++ b/tests/include/zephyr/zerror/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/include/zephyr/zerror/src/main.c
+++ b/tests/include/zephyr/zerror/src/main.c
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright The Zephyr Project Contributors
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/zerror/zerror.h>
+
+#define TEST_MODULE      (0x42)
+#define TEST_CUSTOM_CODE (0x12)
+#define TEST_ERRNO       (EINVAL)
+
+ZTEST(test_zerror, test_zero_when_all_fields_are_zero)
+{
+	zerror_t err = ZERROR(0, 0, 0);
+
+	zassert_equal(err, 0, "ZERROR with all-zero fields should be 0");
+}
+
+ZTEST(test_zerror, test_get_module_returns_packed_module)
+{
+	zerror_t err = ZERROR(TEST_MODULE, TEST_CUSTOM_CODE, TEST_ERRNO);
+
+	zassert_equal(ZERROR_GET_MODULE(err), TEST_MODULE, "Module should be extracted unchanged");
+}
+
+ZTEST(test_zerror, test_get_module_returns_packed_module_on_negative_zerror)
+{
+	zerror_t err = -ZERROR(TEST_MODULE, TEST_CUSTOM_CODE, TEST_ERRNO);
+
+	zassert_equal(ZERROR_GET_MODULE(err), TEST_MODULE,
+		      "Module should be extracted unchanged on negative zerror");
+}
+
+ZTEST(test_zerror, test_get_custom_code_returns_packed_custom_code)
+{
+	zerror_t err = ZERROR(TEST_MODULE, TEST_CUSTOM_CODE, TEST_ERRNO);
+
+	zassert_equal(ZERROR_GET_CUSTOM_CODE(err), TEST_CUSTOM_CODE,
+		      "Custom code should be extracted unchanged");
+}
+
+ZTEST(test_zerror, test_get_custom_code_returns_packed_custom_code_on_negative_zerror)
+{
+	zerror_t err = -ZERROR(TEST_MODULE, TEST_CUSTOM_CODE, TEST_ERRNO);
+
+	zassert_equal(ZERROR_GET_CUSTOM_CODE(err), TEST_CUSTOM_CODE,
+		      "Custom code should be extracted unchanged on negative zerror");
+}
+
+ZTEST(test_zerror, test_get_errno_returns_packed_errno)
+{
+	zerror_t err = ZERROR(TEST_MODULE, TEST_CUSTOM_CODE, TEST_ERRNO);
+
+	zassert_equal(ZERROR_GET_ERRNO(err), TEST_ERRNO, "Errno should be extracted unchanged");
+}
+
+ZTEST(test_zerror, test_get_errno_returns_packed_errno_on_negative_zerror)
+{
+	zerror_t err = -ZERROR(TEST_MODULE, TEST_CUSTOM_CODE, TEST_ERRNO);
+
+	zassert_equal(ZERROR_GET_ERRNO(err), TEST_ERRNO,
+		      "Errno should be extracted unchanged on negative zerror %0x, %d", err,
+		      ZERROR_GET_ERRNO(err));
+}
+
+ZTEST(test_zerror, test_fields_are_independent)
+{
+	zerror_t err = ZERROR(TEST_MODULE, TEST_CUSTOM_CODE, TEST_ERRNO);
+
+	zassert_equal(ZERROR_GET_MODULE(err), TEST_MODULE,
+		      "Module should not be affected by other fields");
+	zassert_equal(ZERROR_GET_CUSTOM_CODE(err), TEST_CUSTOM_CODE,
+		      "Custom code should not be affected by other fields");
+	zassert_equal(ZERROR_GET_ERRNO(err), TEST_ERRNO,
+		      "Errno should not be affected by other fields");
+}
+
+ZTEST(test_zerror, test_module_max_value)
+{
+	/* The module field is limited to 7 bits. The maximum value is 0x7F. */
+	zerror_t err = ZERROR(0x7F, 0, 0);
+
+	zassert_equal(ZERROR_GET_MODULE(err), 0x7F, "Maximum 7-bit module should be preserved");
+}
+
+ZTEST(test_zerror, test_module_overflow_is_masked)
+{
+	/* Bits above the 7-bit module field must be masked off. */
+	zerror_t err = ZERROR(0xFF, 0, 0);
+
+	zassert_equal(ZERROR_GET_MODULE(err), 0x7F, "Module larger than 7 bits should be masked");
+}
+
+ZTEST(test_zerror, test_negative_custom_code_is_sign_extended)
+{
+	zerror_t err = ZERROR(TEST_MODULE, -TEST_CUSTOM_CODE, TEST_ERRNO);
+
+	zassert_equal(ZERROR_GET_CUSTOM_CODE(err), -TEST_CUSTOM_CODE,
+		      "Negative custom code should be sign extended");
+}
+
+ZTEST(test_zerror, test_negative_errno_is_sign_extended)
+{
+	zerror_t err = ZERROR(TEST_MODULE, TEST_CUSTOM_CODE, -EINVAL);
+
+	zassert_equal(ZERROR_GET_ERRNO(err), -EINVAL, "Negative errno should be sign extended");
+}
+
+ZTEST(test_zerror, test_max_errno_value)
+{
+	zerror_t err = ZERROR(0, 0, INT16_MAX);
+
+	zassert_equal(ZERROR_GET_ERRNO(err), INT16_MAX, "Maximum 16-bit errno should be preserved");
+}
+
+zerror_t return_on_error_from_errno_expression(void)
+{
+	/* The expression passed to the macro returns an errno instead of a zerror_t.
+	 * This should be avoided because the error code, when extracted from the zerror_r, will
+	 * lose the sign.
+	 */
+	ZERROR_RETURN_ON_ERROR(-TEST_ERRNO);
+	return 0;
+}
+
+ZTEST(test_zerror, test_int_to_zerror_conversion)
+{
+	zerror_t err = return_on_error_from_errno_expression();
+
+	zassert_true(err < 0, "Zerror from errno should be less than zero");
+	zassert_equal(ZERROR_GET_MODULE(err), 0,
+		      "Zerror from errno should have zero module, %0x, %d", err,
+		      ZERROR_GET_MODULE(err));
+	zassert_equal(ZERROR_GET_CUSTOM_CODE(err), 0,
+		      "Zerror from errno should have zero custom code, %0x, %d", err,
+		      ZERROR_GET_CUSTOM_CODE(err));
+
+	/* Since the errno sign is not retained in this case, we expect a positive number */
+	zassert_equal(ZERROR_GET_ERRNO(err), TEST_ERRNO,
+		      "Zerror from errno should have correct errno! %0x, %d", err,
+		      ZERROR_GET_ERRNO(err));
+}
+
+ZTEST_SUITE(test_zerror, NULL, NULL, NULL, NULL, NULL);

--- a/tests/include/zephyr/zerror/testcase.yaml
+++ b/tests/include/zephyr/zerror/testcase.yaml
@@ -1,0 +1,7 @@
+tests:
+  include.zephyr.zerror:
+    integration_platforms:
+      - qemu_cortex_m3
+      - native_sim
+    harness: ztest
+    tags: zerror


### PR DESCRIPTION
With this PR I aim to improve the error handling of applications running on Zephyr.

Currently, on Zephyr all errors are reported as `int` with the known `errno` values.
Although application can add additional custom errors, it's not simple to surface errors to higher application layers.
In applications, (some) people tend to add logs on errors and then either return the error code as is or swallow the error code completely.\
This approach tends to have issues:

- A function returning an error in a lower layer of the application (still application, but not top-most) doesn't always have to produce an error log, often it depends on the current state of the application
- Errors are not propagate consistently
- Log strings added where is not really needed cost flash area

Here you can see a code example of this pattern:
>NOTE: this is (hopefully) not a real-world example, but it serves only to explain the pattern where the above issues usually occurs

Application Server module

```c
static bool ping_server(void) {
  int rc = ping();
  if (rc != 0) {
    LOG_ERR("Ping error occurred %d", rc);
    return false;
  }
  return true;
}

bool app_server_is_alive(void) {
  // do something
  bool pong = ping_server();
  // do something
  return pong;
}
```

Application FSM-StateConnecting

```c
static state_t run_state(void) {
  if (app_server_is_alive()) {
    return STATE_CONNECTED;
  }
  return STATE_CONNECTING;
}
```

Application FSM-StateConnected

```c
static state_t run_state(void) {
  if (!app_server_is_alive()) {
    return STATE_CONNECTING;
  }
  return STATE_CONNECTED;
}
```

From this example every time the ping to the server fails there will be an error entry in the log, although only in case of the connected state the missed pong is unexpected and should trigger an error log.\
Additionally, the source of the error is not lost in application and can be retrieved only from the logs.

With the proposed `zerror` module, I intend to make the surfacing of application level errors much easier and to basically solve/reduce all of the above issues.

Using the example above, the code would look like this:

Application error modules:
```c
// Application modules (application specific)
#define EMODULE_SERVER 1
```

Application Server module header
```c
// Module specific errors
#define ESMISSING_PONG 1
``

Application Server module impl
```c
static zerror_t ping_server(void) {
  int rc = ping();
  if (rc != 0) {
    return -ZERROR(EMODULE_SERVER, ESMISSING_PONG, rc);
  }
  return 0;
}

zerror_t app_server_is_alive(void) {
  // do something
  ZERROR_RETURN_ON_ERROR(ping_server());
  // do something
  return 0;
}
```

Application FSM-StateConnecting

```c
state_t run_state(void) {
  zerror_t rc = app_server_is_alive();
  if (rc == 0) {
    return STATE_CONNECTED;
  }
  return STATE_CONNECTING;
}
```

Application FSM-StateConnected

```c
state_t run_state(void) {
  zerror_t rc = app_server_is_alive();
  if (rc != 0) {
    LOG_ERR("Error occurred: on %d, with error %d caused by error %d", ZERROR_GET_MODULE(rc), ZERROR_GET_CUSTOM_CODE(rc), ZERROR_GET_ERRNO(rc));
    return STATE_CONNECTING;
  }
  return STATE_CONNECTED;
}
```

The `ZERROR` is used to create a unique error, the `module`-`custom-code` should be a unique combination that allows to uniquely identify the error source.

The `ZERROR_RETURN_ON_ERROR` macro is used to surface the errors, since an `error_t` already embeds the unique source of the error, it can simply be returned to the upper layers, and can be addressed once in the right place.

Since the `error_t` type is still an `int`, the ergonomic of the `errno` error checking (e.g. `if (rc < 0)` style) is retained with this approach.

Every feedback and improvements points are very welcome :)