### PR TITLE
dts: arm: st: h7rs: fix SAI1 address

### DIFF
--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1062,8 +1062,8 @@
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			reg = <0x42005800 0x400>;
+			ranges = <0x0 0x42005800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL3_P SAI1_SEL(0)>;
 			status = "disabled";


### PR DESCRIPTION
The unit address of the node was correct, but not its `reg` properties (and thus not its `ranges` property either). Fix the latter two.

<img width="757" height="658" alt="image" src="https://github.com/user-attachments/assets/eef723f9-f591-46f5-94e6-e49b436c6477" />
