### PR TITLE
tests: subsys: pm: Enable device pm for tests on MAX32 boards

### DIFF
--- a/tests/subsys/pm/power_mgmt_soc/boards/max32655evkit_max32655_m4.conf
+++ b/tests/subsys/pm/power_mgmt_soc/boards/max32655evkit_max32655_m4.conf
@@ -1,6 +1,7 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 CONFIG_COUNTER=y
+CONFIG_PM_DEVICE=y

--- a/tests/subsys/pm/power_mgmt_soc/boards/max32655fthr_max32655_m4.conf
+++ b/tests/subsys/pm/power_mgmt_soc/boards/max32655fthr_max32655_m4.conf
@@ -1,6 +1,7 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 CONFIG_COUNTER=y
+CONFIG_PM_DEVICE=y

--- a/tests/subsys/pm/power_mgmt_soc/boards/max32690evkit_max32690_m4.conf
+++ b/tests/subsys/pm/power_mgmt_soc/boards/max32690evkit_max32690_m4.conf
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,3 +6,5 @@
 CONFIG_COUNTER=y
 CONFIG_LOG_MODE_DEFERRED=y
 CONFIG_LOG_PROCESS_THREAD=y
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_RUNTIME=y

--- a/tests/subsys/pm/power_mgmt_soc/boards/max78002evkit_max78002_m4.conf
+++ b/tests/subsys/pm/power_mgmt_soc/boards/max78002evkit_max78002_m4.conf
@@ -1,6 +1,8 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 CONFIG_COUNTER=y
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_RUNTIME=y


### PR DESCRIPTION
Enable device power management so that system does not go to sleep before UART transmits the test output.