### PR TITLE
stm32: lvgl: correct dma2d bindings path, fix dma2d Kconfig and temporarily disable DMA2D on STM32N6

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -589,10 +589,6 @@ zephyr_jpegenc: &jpeg {
 	status = "okay";
 };
 
-&dma2d {
-	status = "okay";
-};
-
 &rng {
 	status = "okay";
 };

--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -173,16 +173,15 @@ choice LV_COLOR_DEPTH
 	default LV_COLOR_DEPTH_32 if STM32_LTDC_ARGB8888
 endchoice
 
-# In case of using DMA2D, buffer alignment must be ensured
-# for both cache handling as well as DMA2D address registers
-# constraints
-# Keep it simple and always align on cache lines
+# Use 32-byte alignment for all buffers as required by DMA2D.
+# This conveniently also matches the data cache line size,
+# ensuring safe D$ flush/invalidate operations.
 if DT_HAS_ST_STM32_DMA2D_ENABLED
-# Align buffer provided to DMA2D on 32 bytes boundaries
+
 config LV_ATTRIBUTE_MEM_ALIGN_SIZE
 	default 32
 
-# Align area width on cache line (32 bytes), depends on format
+# Value for 32-byte area width alignment depends on format
 config LV_Z_AREA_X_ALIGNMENT_WIDTH
 	default 16 if STM32_LTDC_RGB565
 	default 96 if STM32_LTDC_RGB888

--- a/soc/st/stm32/stm32n6x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32n6x/Kconfig.defconfig
@@ -39,11 +39,7 @@ configdefault NVMEM
 endif # STM32_IOCELL
 
 # Add LVGL HAL include file for SOC supporting DMA2D
-if LVGL && DT_HAS_ST_STM32_DMA2D_ENABLED
-
-config LV_DRAW_DMA2D_HAL_INCLUDE
-	default "stm32n6xx.h"
-
-endif # LVGL
+configdefault LV_DRAW_DMA2D_HAL_INCLUDE
+	default "stm32n6xx.h" if LVGL && DT_HAS_ST_STM32_DMA2D_ENABLED
 
 endif # SOC_SERIES_STM32N6X


### PR DESCRIPTION
This PR correct 3 comments from @JarmouniA and @mathieuchopstm that couldn't made it into the PR #103687 before merging.

Moreover, while rebasing the PR #105238 I discovered a regression in the LVGL application (crash) which seems to be due to the usage of DMA2D (inherited following rebase). While simple application (capture_to_lvgl, benchmark, demos, lvgl) do work properly even with DMA2D, I propose to temporarily disable the DMA2D / LVGL while checking this in order to avoid leading to other potential issues with LVGL application.