### PR TITLE
stm32: tests: drivers: adc: adc_api: update b_u585i_iot02a_adc4  test scenario

### DIFF
--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -26,9 +26,8 @@ tests:
   drivers.adc.b_u585i_iot02a_adc4:
     extra_args:
       - platform:b_u585i_iot02a/stm32u585xx:DTC_OVERLAY_FILE="boards/b_u585i_iot02a_adc4.overlay"
-    integration_platforms:
-      - native_sim
-      - native_sim/native/64
+    platform_allow:
+      - b_u585i_iot02a
   drivers.adc.dma_st_stm32:
     depends_on:
       - dma


### PR DESCRIPTION
The changes only allow `b_u585i_iot02a` platform to execute `drivers.adc.b_u585i_iot02a_adc4` scenario. 
Due to the filter in the common test configuration section, other platforms are executing this scenario, but they should not.