### PR TITLE
net: Cleanup Kconfig files

### DIFF
--- a/samples/net/cloud/aws_iot_mqtt/Kconfig
+++ b/samples/net/cloud/aws_iot_mqtt/Kconfig
@@ -68,8 +68,8 @@ config AWS_QOS
 	help
 	  Quality of Service to use for publishing and subscribing to topics.
 	  Notes:
-	  	- Use QoS 0 when passing DQP test suite
-	  	- QoS 2 is not supported by AWS MQTT broker
+	    - Use QoS 0 when passing DQP test suite
+	    - QoS 2 is not supported by AWS MQTT broker
 
 
 config AWS_EXPONENTIAL_BACKOFF

--- a/samples/net/sockets/echo_server/Kconfig
+++ b/samples/net/sockets/echo_server/Kconfig
@@ -60,10 +60,12 @@ config NET_SAMPLE_HTTPS_SERVER_SERVICE_PORT
 	depends on NET_SAMPLE_HTTPS_SERVICE
 
 if USB_DEVICE_STACK_NEXT
+
 # Source common USB sample options used to initialize new experimental USB
 # device stack. The scope of these options is limited to USB samples in project
 # tree, you cannot use them in your own application.
-	source "samples/subsys/usb/common/Kconfig.sample_usbd"
+source "samples/subsys/usb/common/Kconfig.sample_usbd"
+
 endif
 
 source "samples/net/common/Kconfig"

--- a/samples/net/ssh/Kconfig
+++ b/samples/net/ssh/Kconfig
@@ -26,10 +26,12 @@ config NET_SAMPLE_SSH_PASSWORD
 	  The value depends on your network setup.
 
 if USB_DEVICE_STACK_NEXT
+
 # Source common USB sample options used to initialize new experimental USB
 # device stack. The scope of these options is limited to USB samples in project
 # tree, you cannot use them in your own application.
-	source "samples/subsys/usb/common/Kconfig.sample_usbd"
+source "samples/subsys/usb/common/Kconfig.sample_usbd"
+
 endif
 
 source "samples/net/common/Kconfig"

--- a/samples/net/ssh/Kconfig
+++ b/samples/net/ssh/Kconfig
@@ -19,11 +19,8 @@ config NET_SAMPLE_SSH_USE_PASSWORD
 
 config NET_SAMPLE_SSH_PASSWORD
 	string "Default SSH server password"
-	# Kconfig lib does not like (even if quoted) " , ' or , in the string
-	# chr(115)+chr(121)+chr(115) = sys
-	# chr(98)+chr(97)+chr(115)+chr(101)+chr(54)+chr(52) = base64
-	# chr(111)+chr(115) = os
-	default "$(shell,python3 -c '__import__(chr(115)+chr(121)+chr(115)).stdout.write(__import__(chr(98)+chr(97)+chr(115)+chr(101)+chr(54)+chr(52)).b64encode(__import__(chr(111)+chr(115)).urandom(12)).decode()[:15])')"
+	# Generate a random default password at build time (see gen_random_password.py).
+	default "$(shell,python3 $(ZEPHYR_BASE)/samples/net/ssh/gen_random_password.py)"
 	depends on NET_SAMPLE_SSH_USE_PASSWORD
 	help
 	  The value depends on your network setup.

--- a/samples/net/ssh/gen_random_password.py
+++ b/samples/net/ssh/gen_random_password.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Print a random default password for the SSH sample, invoked from Kconfig."""
+
+import base64
+import os
+import sys
+
+# No trailing newline: the output is used verbatim as the Kconfig string value.
+sys.stdout.write(base64.b64encode(os.urandom(12)).decode()[:15])

--- a/samples/net/zperf/Kconfig
+++ b/samples/net/zperf/Kconfig
@@ -20,10 +20,12 @@ config NET_SAMPLE_CODE_RAM_NAME
 endif # NET_SAMPLE_CODE_RELOCATE
 
 if USB_DEVICE_STACK_NEXT
+
 # Source common USB sample options used to initialize new experimental USB
 # device stack. The scope of these options is limited to USB samples in project
 # tree, you cannot use them in your own application.
-	source "samples/subsys/usb/common/Kconfig.sample_usbd"
+source "samples/subsys/usb/common/Kconfig.sample_usbd"
+
 endif
 
 configdefault NRF_WIFI_DATA_HEAP_SIZE

--- a/subsys/net/conn_mgr/Kconfig
+++ b/subsys/net/conn_mgr/Kconfig
@@ -25,7 +25,8 @@ config NET_CONNECTION_MANAGER_MONITOR_STACK_SIZE
 	int "Size of the stack allocated for the conn_mgr_monitor thread"
 	default 512
 	help
-	  Sets the stack size which will be used by the connection manager for connectivity monitoring.
+	  Sets the stack size which will be used by the connection manager for
+	  connectivity monitoring.
 
 config NET_CONNECTION_MANAGER_MONITOR_PRIORITY
 	int "Monitoring thread starting priority"

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -71,11 +71,13 @@ config NET_PMTU
 	depends on NET_IPV6_PMTU || NET_IPV4_PMTU
 
 if NET_PMTU
+
 module = NET_PMTU
 module-dep = NET_LOG
 module-str = Log level for PMTU
 module-help = Enables PMTU to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
+
 endif # NET_PMTU
 
 config NET_NATIVE_TCP
@@ -102,11 +104,13 @@ config NET_OFFLOADING_SUPPORT
 	  only one option instead of two.
 
 if NET_OFFLOAD
+
 module = NET_OFFLOAD
 module-dep = NET_LOG
 module-str = Log level for offload layer
 module-help = Enables offload layer to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
+
 endif # NET_OFFLOAD
 
 config NET_RAW_MODE
@@ -468,11 +472,13 @@ config NET_UDP_MISSING_CHECKSUM
 	  UDP checksum in transmission path.
 
 if NET_UDP
+
 module = NET_UDP
 module-dep = NET_LOG
 module-str = Log level for UDP
 module-help = Enables UDP handler output debug messages
 source "subsys/net/Kconfig.template.log_config.net"
+
 endif # NET_UDP
 
 config NET_MAX_CONN
@@ -953,11 +959,13 @@ config NET_PROMISCUOUS_MODE
 	  also needs to read the promiscuous mode data.
 
 if NET_PROMISCUOUS_MODE
+
 module = NET_PROMISC
 module-dep = NET_LOG
 module-str = Log level for promiscuous mode
 module-help = Enables promiscuous mode to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
+
 endif # NET_PROMISCUOUS_MODE
 
 config NET_DISABLE_ICMP_DESTINATION_UNREACHABLE

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -79,8 +79,8 @@ config NET_INITIAL_IPV4_MCAST_LOOP
 	bool "Control whether the socket sees multicast packets sent by itself"
 	default y
 	help
-	Assign initial value to IPV4_MULTICAST_LOOP in socket options,
-	if not set by the user using setsockopt().
+	  Assign initial value to IPV4_MULTICAST_LOOP in socket options,
+	  if not set by the user using setsockopt().
 
 config NET_IF_MCAST_IPV4_SOURCE_COUNT
 	int "Max number of IPv4 sources per mcast address to be included or excluded"
@@ -256,6 +256,7 @@ config NET_IPV4_NAT
 	  Add iptable rule to allow specific packets to be forwarded.
 
 if NET_IPV4_NAT
+
 config NET_IPV4_CONN_TRACK_MAX_NUM
 	int "Maximum connection track maintained for IP forward"
 	default 10
@@ -269,6 +270,7 @@ config NET_IPV4_IPTABLE_RULE_MAX_NUM
 	default 3
 	help
 	  Maximum number of active IP table rules.
+
 endif
 
 module = NET_IPV4
@@ -298,12 +300,15 @@ source "subsys/net/Kconfig.template.log_config.net"
 #endif
 
 if NET_IPV4_AUTO
+
 module = NET_IPV4_AUTO
 module-dep = NET_LOG
 module-str = Log level for IPv4 autoconf client
 module-help = Enable debug diagnostic from IPv4 autoconf client.
 source "subsys/net/Kconfig.template.log_config.net"
+
 endif # NET_IPV4_AUTO
 
 endif # NET_NATIVE_IPV4
+
 endif # NET_IPV4

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -494,11 +494,13 @@ config NET_MAX_6LO_CONTEXTS
 	  network and memory consumption. More 6CO options uses more memory.
 
 if NET_6LO
+
 module = NET_6LO
 module-dep = NET_LOG
 module-str = Log level for 6LoWPAN library
 module-help = Enables 6LoWPAN code to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
+
 endif # NET_6LO
 
 module = NET_IPV6
@@ -538,4 +540,5 @@ module-help = Enables IPv6 routing engine debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
 endif # NET_NATIVE_IPV6
+
 endif # NET_IPV6

--- a/subsys/net/ip/Kconfig.mgmt
+++ b/subsys/net/ip/Kconfig.mgmt
@@ -96,6 +96,7 @@ config NET_MGMT_EVENT_INFO
 	  on the type of event.
 
 if NET_MGMT_EVENT_INFO
+
 config NET_MGMT_EVENT_INFO_DEFAULT_DATA_SIZE
 	int "Default size of event information data"
 	default 32
@@ -111,6 +112,7 @@ config NET_MGMT_EVENT_MONITOR
 	  default. Note that you should probably increase the value of
 	  NET_MGMT_EVENT_QUEUE_SIZE from the default in order not to miss
 	  any events.
+
 endif # NET_MGMT_EVENT_INFO
 
 config NET_MGMT_EVENT_MONITOR_STACK_SIZE
@@ -145,6 +147,7 @@ config NET_MGMT_THREAD_PRIO_CUSTOM
 	bool "Customize net mgmt thread priority"
 
 if NET_MGMT_THREAD_PRIO_CUSTOM
+
 config NET_MGMT_THREAD_PRIORITY
 	int "Priority of net_mgmt thread"
 	default NUM_PREEMPT_PRIORITIES

--- a/subsys/net/l2/Kconfig
+++ b/subsys/net/l2/Kconfig
@@ -11,7 +11,9 @@ config NET_L2_DUMMY
 	  simulating a network interface when running network stack inside QEMU.
 
 if NET_L2_DUMMY
+
 source "subsys/net/l2/dummy/Kconfig"
+
 endif
 
 source "subsys/net/l2/virtual/Kconfig"
@@ -59,12 +61,14 @@ config NET_L2_WIFI_MGMT
 	  Enable support for Wi-Fi Management interface.
 
 if NET_L2_WIFI_MGMT
+
 module = NET_L2_WIFI_MGMT
 module-dep = NET_LOG
 module-str = Log level for Wi-Fi management layer
 module-help = Enables Wi-Fi management interface to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 source "subsys/net/l2/wifi/Kconfig"
+
 endif # NET_L2_WIFI_MGMT
 
 config NET_L2_WIFI_SHELL

--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -280,4 +280,5 @@ config NET_CONFIG_SNTP_INIT_USE_CONNECTION_MANAGER
 	  also sent every time when the network connection is established.
 
 endif # NET_CONFIG_SNTP_INIT_RESYNC
+
 endif # NET_CONFIG_CLOCK_SNTP_INIT

--- a/subsys/net/lib/dhcpv6/Kconfig
+++ b/subsys/net/lib/dhcpv6/Kconfig
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
 # Copyright (c) 2024 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -49,9 +48,11 @@ config NET_DHCPV6_DNS_SERVER_VIA_INTERFACE
 	  interface.
 
 if NET_DHCPV6
+
 module = NET_DHCPV6
 module-dep = NET_LOG
 module-str = Log level for DHCPv6 client
 module-help = Enables DHCPv6 client code to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
+
 endif # NET_DHCPV6

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -253,7 +253,8 @@ config MDNS_RESOLVER_BUF_SIZE
 	int "Size of the net_buf pool buffers"
 	default 512
 	help
-	  For larger DNS SD TXT records and long service instance names, bigger buffers are necessary
+	  For larger DNS SD TXT records and long service instance names, bigger buffers
+	  are necessary
 
 config MDNS_RESPONDER_TTL
 	int "Time-to-Live of returned DNS name"
@@ -309,6 +310,7 @@ config MDNS_RESPONDER_DNS_SD
 	  using e.g. 'avahi-browse -t -r _greybus._tcp'.
 
 if MDNS_RESPONDER_DNS_SD
+
 config MDNS_RESPONDER_DNS_SD_SERVICE_TYPE_ENUMERATION
 	bool "DNS SD Service Type Enumeration"
 	default y
@@ -317,6 +319,7 @@ config MDNS_RESPONDER_DNS_SD_SERVICE_TYPE_ENUMERATION
 	  performs DNS-SD Service Type Enumeration according to RFC 6763,
 	  Chapter 9. By doing so, Zephyr network services are discoverable
 	  using e.g. 'avahi-browse -t -r _services._dns-sd._udp.local'.
+
 endif # MDNS_RESPONDER_DNS_SD
 
 module = MDNS_RESPONDER

--- a/subsys/net/lib/latmon/Kconfig
+++ b/subsys/net/lib/latmon/Kconfig
@@ -10,6 +10,7 @@ config NET_LATMON
 	  This option enables the latency monitoring support for Zephyr
 
 if NET_LATMON
+
 config NET_LATMON_PORT
 	int "Latmon - Latmus communication port"
 	default 2306

--- a/subsys/net/lib/mcp/Kconfig
+++ b/subsys/net/lib/mcp/Kconfig
@@ -11,6 +11,7 @@ menuconfig MCP_SERVER
 	  Support for MCP Server functionality.
 
 if MCP_SERVER
+
 config MCP_SERVER_COUNT
 	int "Number of MCP server instances"
 	default 1

--- a/subsys/net/lib/midi2/Kconfig
+++ b/subsys/net/lib/midi2/Kconfig
@@ -18,6 +18,7 @@ config NETMIDI2_HOST
 	  Following "Network MIDI 2.0 (UDP) Transport Specification" v1.0
 
 if NETMIDI2_HOST
+
 config NETMIDI2_HOST_MAX_CLIENTS
 	int "Maximum number of clients supported by the Network MIDI2 host"
 	default 5
@@ -32,4 +33,5 @@ module-dep=NET_LOG
 module-str=Log level for network MIDI2
 module-help=Enables midi2 debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
+
 endif

--- a/subsys/net/lib/trickle/Kconfig
+++ b/subsys/net/lib/trickle/Kconfig
@@ -10,9 +10,11 @@ config NET_TRICKLE
 	  so say 'n' if unsure.
 
 if NET_TRICKLE
+
 module = NET_TRICKLE
 module-dep = NET_LOG
 module-str = Log level for Trickle algorithm
 module-help = Enables Trickle library output debug messages
 source "subsys/net/Kconfig.template.log_config.net"
+
 endif # NET_TRICKLE

--- a/subsys/net/pkt_filter/Kconfig
+++ b/subsys/net/pkt_filter/Kconfig
@@ -39,6 +39,7 @@ module-dep = NET_LOG
 module-str = Log level for packet filtering
 module-help = Enables packet filter output debug messages
 source "subsys/net/Kconfig.template.log_config.net"
+
 endif # NET_PKT_FILTER
 
 endmenu


### PR DESCRIPTION
Fix Kconfig style issues in the networking subsystem/samples: add blank lines around top-level if/endif, fix help text indentation and wrap overly long help lines.

Applying rules from https://docs.zephyrproject.org/latest/contribute/style/kconfig.html as spotted by https://github.com/zephyrproject-rtos/zephyr/pull/111839