### PR TITLE
net: Fix commented out ifs in Kconfig

### DIFF
--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -289,13 +289,15 @@ module-str = Log level for ICMPv4
 module-help = Enables ICMPv4 code to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
-#if NET_IPV4_ACD
+if NET_IPV4_ACD
+
 module = NET_IPV4_ACD
 module-dep = NET_LOG
 module-str = Log level for IPv4 address conflict detection
 module-help = Enables IPv4 address conflict detection debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
-#endif
+
+endif
 
 if NET_IPV4_AUTO
 module = NET_IPV4_AUTO

--- a/subsys/net/lib/mqtt/Kconfig
+++ b/subsys/net/lib/mqtt/Kconfig
@@ -81,7 +81,7 @@ config MQTT_CLEAN_SESSION
 	  the client. Setting this flag to 0 allows the client to create a
 	  persistent session.
 
-#if MQTT_VERSION_5_0
+if MQTT_VERSION_5_0
 
 config MQTT_USER_PROPERTIES_MAX
 	int "Maximum number of user properties in a packet"
@@ -114,6 +114,6 @@ config MQTT_TOPIC_ALIAS_STRING_MAX
 	help
 	  Specifies a size of a buffer for storing aliased topics.
 
-#endif # MQTT_VERSION_5_0
+endif # MQTT_VERSION_5_0
 
 endif # MQTT_LIB


### PR DESCRIPTION
Some if blocks were commented out by mistake, fix this.