### PR TITLE
modules: hal_espressif: gate hal kconfig source by soc family

### DIFF
--- a/modules/hal_espressif/Kconfig
+++ b/modules/hal_espressif/Kconfig
@@ -17,7 +17,7 @@ config ESP_HAL_EARLY_LOG_LEVEL
 	  These use esp_rom_printf and are independent of CONFIG_LOG.
 	  0 = Off, 1 = Error, 2 = Warning, 3 = Info, 4 = Debug
 
-endif # SOC_FAMILY_ESPRESSIF_ESP32
-
 # Include the HAL's own Kconfig
 osource "$(ZEPHYR_HAL_ESPRESSIF_MODULE_DIR)/zephyr/Kconfig"
+
+endif # SOC_FAMILY_ESPRESSIF_ESP32


### PR DESCRIPTION
Move the osource of the HAL zephyr/Kconfig inside the SOC_FAMILY_ESPRESSIF_ESP32 guard. When the module directory variable is undefined on non-Espressif builds the path collapsed to /zephyr/Kconfig and caused recursive source errors.

Fixes #111545