### PR TITLE
boards: st: nucleo_h755zi_q: add arduino_spi and enable spi1

### DIFF
--- a/boards/st/nucleo_h755zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h755zi_q/arduino_r3_connector.dtsi
@@ -39,4 +39,6 @@
 
 arduino_i2c: &i2c1 {};
 
+arduino_spi: &spi1 {};
+
 arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.dts
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.dts
@@ -35,3 +35,8 @@
 &rcc {
 	clock-frequency = <DT_FREQ_M(240)>;
 };
+
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
+	pinctrl-names = "default";
+};

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
@@ -166,3 +166,8 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
add arduino_spi and enable spi1 for use with arduino shields

tested with `west build -b nucleo_h755zi_q/stm32h755xx/m7 --shield adafruit_2_8_tft_touch_v2 samples/drivers/display`