### PR TITLE
drivers: flash: include kernel header in soc_flash_nrf_mramc.c

### DIFF
--- a/drivers/flash/soc_flash_nrf_mramc.c
+++ b/drivers/flash/soc_flash_nrf_mramc.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/flash.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
 
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 #include "tfm_ioctl_core_api.h"


### PR DESCRIPTION
Added the kernel header to the soc_flash_nrf_mramc.c as it is needed for mutex's which are part of the driver.