### PR TITLE
include: logging: organize doxygen documentation across logging subsystem

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the logging subsystem.
+ * @ingroup log_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_H_
 
@@ -25,6 +31,16 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Default interval for rate-limited log messages, in milliseconds.
+ *
+ * Period used by the rate-limited logging macros that do not take an explicit
+ * rate (for example @ref LOG_ERR_RATELIMIT). It evaluates to
+ * @kconfig{CONFIG_LOG_RATELIMIT_INTERVAL_MS} when @kconfig{CONFIG_LOG_RATELIMIT}
+ * is enabled, and to 0 (no rate limiting) otherwise.
+ *
+ * @ingroup log_api
+ */
 #ifdef CONFIG_LOG_RATELIMIT
 #define LOG_RATELIMIT_INTERVAL_MS CONFIG_LOG_RATELIMIT_INTERVAL_MS
 

--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -32,24 +32,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Default interval for rate-limited log messages, in milliseconds.
- *
- * Period used by the rate-limited logging macros that do not take an explicit
- * rate (for example @ref LOG_ERR_RATELIMIT). It evaluates to
- * @kconfig{CONFIG_LOG_RATELIMIT_INTERVAL_MS} when @kconfig{CONFIG_LOG_RATELIMIT}
- * is enabled, and to 0 (no rate limiting) otherwise.
- *
- * @ingroup log_api
- */
-#ifdef CONFIG_LOG_RATELIMIT
-#define LOG_RATELIMIT_INTERVAL_MS CONFIG_LOG_RATELIMIT_INTERVAL_MS
-
-#else
-#define LOG_RATELIMIT_INTERVAL_MS 0
-
-#endif
-
-/**
  * @brief Logging
  * @defgroup logging Logging
  * @since 1.13
@@ -63,6 +45,11 @@ extern "C" {
  * @brief Logger API
  * @defgroup log_api Logging API
  * @ingroup logger
+ * @{
+ */
+
+/**
+ * @name Standard logging
  * @{
  */
 
@@ -125,6 +112,34 @@ extern "C" {
 		}                                                                                  \
 	} while (0)
 
+/** @} */
+
+/**
+ * @name Rate-limited logging
+ *
+ * Rate-limited variants drop repeated messages so that a frequently-hit call
+ * site cannot flood the log. Each call site is limited independently using
+ * atomic operations for thread safety, and a summary of skipped messages is
+ * emitted when logging resumes. The plain variants use the default interval
+ * @ref LOG_RATELIMIT_INTERVAL_MS; the `_RATE` variants take an explicit
+ * interval.
+ * @{
+ */
+
+/**
+ * @brief Default interval for rate-limited log messages, in milliseconds.
+ *
+ * Period used by the rate-limited logging macros that do not take an explicit
+ * rate (for example @ref LOG_ERR_RATELIMIT). It evaluates to
+ * @kconfig{CONFIG_LOG_RATELIMIT_INTERVAL_MS} when @kconfig{CONFIG_LOG_RATELIMIT}
+ * is enabled, and to 0 (no rate limiting) otherwise.
+ */
+#ifdef CONFIG_LOG_RATELIMIT
+#define LOG_RATELIMIT_INTERVAL_MS CONFIG_LOG_RATELIMIT_INTERVAL_MS
+#else
+#define LOG_RATELIMIT_INTERVAL_MS 0
+#endif
+
 /**
  * @brief Core rate-limited logging macro for regular messages
  *
@@ -158,22 +173,6 @@ extern "C" {
 			atomic_inc(&__skipped_count);                                              \
 		}                                                                                  \
 	} while (0)
-
-/**
- * @brief Rate-limited logging macros
- *
- * @details These macros provide rate-limited logging functionality to prevent
- * log flooding when messages are generated frequently. Each macro ensures that
- * log messages are not output more frequently than a specified interval.
- * Rate limiting is per-macro-call-site, meaning each unique call has its own
- * independent rate limit.
- *
- * The macros use atomic operations to ensure thread safety in multi-threaded
- * environments. Only one thread can successfully log a message within the
- * specified rate limit period.
- *
- * @see CONFIG_LOG_RATELIMIT_INTERVAL_MS
- */
 
 /**
  * @brief Core rate-limited logging macro with level parameter
@@ -369,14 +368,6 @@ extern "C" {
 	_LOG_HEXDUMP_RATELIMIT_LVL(LOG_LEVEL_DBG, LOG_RATELIMIT_INTERVAL_MS, _data, _length, _str)
 
 /**
- * @brief Rate-limited logging macros with custom rate
- *
- * @details These macros provide rate-limited logging functionality with custom
- * rate intervals. They take an explicit rate parameter (in milliseconds) that
- * specifies the minimum interval between log messages.
- */
-
-/**
  * @brief Writes an ERROR level message to the log with custom rate limiting.
  *
  * @details It's meant to report severe errors, such as those from which it's
@@ -492,6 +483,13 @@ extern "C" {
 #define LOG_HEXDUMP_DBG_RATELIMIT_RATE(_rate_ms, _data, _length, _str)                             \
 	_LOG_HEXDUMP_RATELIMIT_LVL(LOG_LEVEL_DBG, _rate_ms, _data, _length, _str)
 
+/** @} */
+
+/**
+ * @name Raw output
+ * @{
+ */
+
 /**
  * @brief Unconditionally print raw log message.
  *
@@ -512,6 +510,13 @@ extern "C" {
  * followed by as many values as specifiers.
  */
 #define LOG_RAW(...) Z_LOG_PRINTK(1, __VA_ARGS__)
+
+/** @} */
+
+/**
+ * @name Instance logging
+ * @{
+ */
 
 /**
  * @brief Writes an ERROR level message associated with the instance to the log.
@@ -570,6 +575,13 @@ extern "C" {
  */
 #define LOG_INST_DBG(_log_inst, ...) Z_LOG_INSTANCE(LOG_LEVEL_DBG, _log_inst, __VA_ARGS__)
 
+/** @} */
+
+/**
+ * @name Hexdump logging
+ * @{
+ */
+
 /**
  * @brief Writes an ERROR level hexdump message to the log.
  *
@@ -615,6 +627,13 @@ extern "C" {
  * @param _str    Persistent, raw string.
  */
 #define LOG_HEXDUMP_DBG(_data, _length, _str) Z_LOG_HEXDUMP(LOG_LEVEL_DBG, _data, _length, (_str))
+
+/** @} */
+
+/**
+ * @name Instance hexdump logging
+ * @{
+ */
 
 /**
  * @brief Writes an ERROR hexdump message associated with the instance to the
@@ -675,6 +694,8 @@ extern "C" {
  */
 #define LOG_INST_HEXDUMP_DBG(_log_inst, _data, _length, _str)                                      \
 	Z_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_DBG, _log_inst, _data, _length, _str)
+
+/** @} */
 
 /**
  * @brief Writes an formatted string to the log.
@@ -752,6 +773,11 @@ extern struct k_mem_partition k_log_partition;
 #else
 #define Z_LOG_MODULE_PARTITION(_k_app_mem)
 #endif
+
+/**
+ * @name Module registration
+ * @{
+ */
 
 /**
  * @brief Create module-specific state and register the module with Logger.
@@ -849,6 +875,8 @@ extern struct k_mem_partition k_log_partition;
  */
 #define LOG_LEVEL_SET(level)                                                                       \
 	static const uint32_t __log_level __unused = Z_LOG_RESOLVED_LEVEL(level, 0)
+
+/** @} */
 
 #ifdef CONFIG_LOG_CUSTOM_HEADER
 /* This include must always be at the end of log.h */

--- a/include/zephyr/logging/log_backend.h
+++ b/include/zephyr/logging/log_backend.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the logging backend interface.
+ * @ingroup log_backend
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_H_
 
@@ -18,9 +25,9 @@ extern "C" {
 #endif
 
 /**
- * @brief Logger backend interface
- * @defgroup log_backend Logger backend interface
+ * @defgroup log_backend Logger backends
  * @ingroup logger
+ * @brief Interface implemented by logging backends and used by the log core.
  * @{
  */
 
@@ -59,18 +66,29 @@ union log_backend_evt_arg {
 
 /**
  * @brief Logger backend API.
+ *
+ * Set of operations a backend implements. Mandatory operations must always be
+ * provided; optional operations may be left @c NULL, in which case the log core
+ * skips them.
  */
 struct log_backend_api {
+	/** @brief Mandatory: process a single log message (see log_backend_msg_process()). */
 	void (*process)(const struct log_backend *const backend,
 			union log_msg_generic *msg);
 
+	/** @brief Optional: report number of dropped messages (see log_backend_dropped()). */
 	void (*dropped)(const struct log_backend *const backend, uint32_t cnt);
+	/** @brief Mandatory: switch the backend to panic (blocking) mode. */
 	void (*panic)(const struct log_backend *const backend);
+	/** @brief Optional: initialize the backend (see log_backend_init()). */
 	void (*init)(const struct log_backend *const backend);
+	/** @brief Optional: poll for backend readiness (see log_backend_is_ready()). */
 	int (*is_ready)(const struct log_backend *const backend);
+	/** @brief Optional: set the output format type (see log_backend_format_set()). */
 	int (*format_set)(const struct log_backend *const backend,
 				uint32_t log_type);
 
+	/** @brief Optional: handle a backend event (see log_backend_notify()). */
 	void (*notify)(const struct log_backend *const backend,
 		       enum log_backend_evt event,
 		       union log_backend_evt_arg *arg);
@@ -78,8 +96,12 @@ struct log_backend_api {
 
 /**
  * @brief Logger backend control block.
+ *
+ * Holds the run-time state of a backend instance. Managed by the log core;
+ * backends should not modify it directly.
  */
 struct log_backend_control_block {
+	/** @cond INTERNAL_HIDDEN */
 	void *ctx;
 	uint8_t id;
 	bool active;
@@ -87,16 +109,17 @@ struct log_backend_control_block {
 
 	/* Initialization level. */
 	uint8_t level;
+	/** @endcond */
 };
 
 /**
  * @brief Logger backend structure.
  */
 struct log_backend {
-	const struct log_backend_api *api;
-	struct log_backend_control_block *cb;
-	const char *name;
-	bool autostart;
+	const struct log_backend_api *api; /**< Backend operations. */
+	struct log_backend_control_block *cb; /**< Run-time control block. */
+	const char *name; /**< Unique backend name. */
+	bool autostart; /**< Enable the backend automatically at logger startup. */
 };
 
 /**

--- a/include/zephyr/logging/log_backend_adsp_hda.h
+++ b/include/zephyr/logging/log_backend_adsp_hda.h
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief Header file for the Intel ADSP HDA log backend API
+ * @brief Header file for the Intel ADSP HDA log backend.
  * @ingroup log_backend_adsp_hda
  */
 
@@ -14,16 +14,16 @@
 #define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_ADSP_HDA_H_
 
 /**
- * @brief Intel ADSP HDA log backend API
- * @defgroup log_backend_adsp_hda Intel ADSP HDA log backend API
+ * @defgroup log_backend_adsp_hda Intel ADSP HDA log backend
  * @ingroup log_backend
+ * @brief Logging backend that streams over an Intel ADSP HDA DMA channel.
  * @{
  */
 
 #include <stdint.h>
 
 /**
- *@brief HDA logger requires a hook for IPC messages
+ * @brief HDA logger requires a hook for IPC messages
  *
  * When the log is flushed and written with DMA an IPC message should
  * be sent to inform the host. This hook function pointer allows for that

--- a/include/zephyr/logging/log_backend_adsp_mtrace.h
+++ b/include/zephyr/logging/log_backend_adsp_mtrace.h
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief Header file for the Intel ADSP mtrace log backend API
+ * @brief Header file for the Intel ADSP mtrace log backend.
  * @ingroup log_backend_adsp_mtrace
  */
 
@@ -14,9 +14,9 @@
 #define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_ADSP_MTRACE_H_
 
 /**
- * @brief Intel ADSP mtrace log backend API
- * @defgroup log_backend_adsp_mtrace Intel ADSP mtrace log backend API
+ * @defgroup log_backend_adsp_mtrace Intel ADSP mtrace log backend
  * @ingroup log_backend
+ * @brief Logging backend that writes to an Intel ADSP mtrace SRAM buffer.
  * @{
  */
 
@@ -24,7 +24,7 @@
 #include <stddef.h>
 
 /**
- *@brief mtracelogger requires a hook for IPC messages
+ * @brief mtrace logger requires a hook for IPC messages
  *
  * When new log data is added to the SRAM buffer, a IPC message
  * should be sent to the host. This hook function pointer allows
@@ -40,6 +40,11 @@ typedef void(*adsp_mtrace_log_hook_t)(size_t written, size_t space_left);
  */
 void adsp_mtrace_log_init(adsp_mtrace_log_hook_t hook);
 
+/**
+ * @brief Get the Intel ADSP mtrace log backend.
+ *
+ * @return Pointer to the mtrace log backend instance.
+ */
 const struct log_backend *log_backend_adsp_mtrace_get(void);
 
 /** @} */

--- a/include/zephyr/logging/log_backend_ble.h
+++ b/include/zephyr/logging/log_backend_ble.h
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief Header file for the Bluetooth log backend API
+ * @brief Header file for the Bluetooth log backend.
  * @ingroup log_backend_ble
  */
 
@@ -14,9 +14,9 @@
 #define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_BLE_H_
 
 /**
- * @brief Bluetooth log backend API
- * @defgroup log_backend_ble Bluetooth log backend API
+ * @defgroup log_backend_ble Bluetooth log backend
  * @ingroup log_backend
+ * @brief Logging backend that transmits messages over a Bluetooth LE service.
  * @{
  */
 

--- a/include/zephyr/logging/log_backend_mqtt.h
+++ b/include/zephyr/logging/log_backend_mqtt.h
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief Header file for the MQTT log backend API
+ * @brief Header file for the MQTT log backend.
  * @ingroup log_backend_mqtt
  */
 
@@ -20,9 +20,9 @@ extern "C" {
 #endif
 
 /**
- * @brief MQTT log backend API
- * @defgroup log_backend_mqtt MQTT log backend API
+ * @defgroup log_backend_mqtt MQTT log backend
  * @ingroup log_backend
+ * @brief Logging backend that publishes messages to an MQTT broker.
  * @{
  */
 

--- a/include/zephyr/logging/log_backend_net.h
+++ b/include/zephyr/logging/log_backend_net.h
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief Header file for the network log backend API
+ * @brief Header file for the network log backend.
  * @ingroup log_backend_net
  */
 
@@ -14,9 +14,9 @@
 #define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_NET_H_
 
 /**
- * @brief Network log backend API
- * @defgroup log_backend_net Network log backend API
+ * @defgroup log_backend_net Network log backend
  * @ingroup log_backend
+ * @brief Logging backend that sends messages to a syslog server over the network.
  * @{
  */
 

--- a/include/zephyr/logging/log_backend_std.h
+++ b/include/zephyr/logging/log_backend_std.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the standard logging backend helpers.
+ * @ingroup log_backend_std
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_STD_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_STD_H_
 
@@ -15,9 +22,9 @@ extern "C" {
 #endif
 
 /**
- * @brief Logger backend interface for forwarding to standard backend
- * @defgroup log_backend_std Logger backend standard interface
- * @ingroup logger
+ * @defgroup log_backend_std Standard backend helpers
+ * @ingroup log_backend
+ * @brief Helpers for backends that format messages through @ref log_output.
  * @{
  */
 

--- a/include/zephyr/logging/log_backend_ws.h
+++ b/include/zephyr/logging/log_backend_ws.h
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief Header file for the websocket log backend API
+ * @brief Header file for the websocket log backend.
  * @ingroup log_backend_ws
  */
 
@@ -14,9 +14,9 @@
 #define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_WS_H_
 
 /**
- * @brief Websocket log backend API
- * @defgroup log_backend_ws Websocket log backend API
+ * @defgroup log_backend_ws Websocket log backend
  * @ingroup log_backend
+ * @brief Logging backend that sends messages over a WebSocket connection.
  * @{
  */
 

--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the logging core.
+ * @ingroup log_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_CORE_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_CORE_H_
 
@@ -16,15 +23,30 @@
 /* This header file keeps all macros and functions needed for creating logging
  * messages (macros like @ref LOG_ERR).
  */
+
+/**
+ * @addtogroup log_api
+ * @{
+ */
+
+/** @brief Severity level used to disable logging for a source. */
 #define LOG_LEVEL_NONE 0
+/** @brief Error severity level. */
 #define LOG_LEVEL_ERR  1
+/** @brief Warning severity level. */
 #define LOG_LEVEL_WRN  2
+/** @brief Informational severity level. */
 #define LOG_LEVEL_INF  3
+/** @brief Debug severity level. */
 #define LOG_LEVEL_DBG  4
+
+/** @} */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** @cond INTERNAL_HIDDEN */
 
 #ifndef CONFIG_LOG
 #define CONFIG_LOG_DEFAULT_LEVEL 0
@@ -480,8 +502,12 @@ TYPE_SECTION_END_EXTERN(struct log_source_const_data, log_const);
 			  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, __VA_ARGS__);\
 } while (0)
 
+/** @endcond */
+
 /** @brief Get index of the log source based on the address of the constant data
  *         associated with the source.
+ *
+ * @ingroup log_api
  *
  * @param data Address of the constant data.
  *
@@ -493,6 +519,8 @@ static inline uint32_t log_const_source_id(
 	return ((const uint8_t *)data - (uint8_t *)TYPE_SECTION_START(log_const))/
 			sizeof(struct log_source_const_data);
 }
+
+/** @cond INTERNAL_HIDDEN */
 
 TYPE_SECTION_START_EXTERN(struct log_source_dynamic_data, log_dynamic);
 TYPE_SECTION_END_EXTERN(struct log_source_dynamic_data, log_dynamic);
@@ -506,8 +534,12 @@ TYPE_SECTION_END_EXTERN(struct log_source_dynamic_data, log_dynamic);
 #define LOG_INSTANCE_DYNAMIC_DATA(_module_name, _inst) \
 	LOG_ITEM_DYNAMIC_DATA(Z_LOG_INSTANCE_FULL_NAME(_module_name, _inst))
 
+/** @endcond */
+
 /** @brief Get index of the log source based on the address of the dynamic data
  *         associated with the source.
+ *
+ * @ingroup log_api
  *
  * @param data Address of the dynamic data.
  *
@@ -520,6 +552,8 @@ static inline uint32_t log_dynamic_source_id(struct log_source_dynamic_data *dat
 }
 
 /** @brief Get index of the log source based on the address of the associated data.
+ *
+ * @ingroup log_api
  *
  * @param source Address of the data structure (dynamic if runtime filtering is
  * enabled and static otherwise).
@@ -543,9 +577,11 @@ void z_log_printf_arg_checker(const char *fmt, ...)
 /**
  * @brief Write a generic log message.
  *
+ * @ingroup log_api
+ *
  * @note This function is intended to be used when porting other log systems.
  *
- * @param level          Log level..
+ * @param level          Log level.
  * @param fmt            String to format.
  * @param ap             Pointer to arguments list.
  */

--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -29,6 +29,11 @@
  * @{
  */
 
+/**
+ * @name Severity levels
+ * @{
+ */
+
 /** @brief Severity level used to disable logging for a source. */
 #define LOG_LEVEL_NONE 0
 /** @brief Error severity level. */
@@ -39,6 +44,8 @@
 #define LOG_LEVEL_INF  3
 /** @brief Debug severity level. */
 #define LOG_LEVEL_DBG  4
+
+/** @} */
 
 /** @} */
 

--- a/include/zephyr/logging/log_ctrl.h
+++ b/include/zephyr/logging/log_ctrl.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the logger control functions.
+ * @ingroup log_ctrl
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_CTRL_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_CTRL_H_
 
@@ -32,6 +39,14 @@ extern "C" {
  * @{
  */
 
+/**
+ * @brief Timestamp source callback.
+ *
+ * Returns the current timestamp value used to stamp log messages. Registered
+ * with log_set_timestamp_func().
+ *
+ * @return Current timestamp.
+ */
 typedef log_timestamp_t (*log_timestamp_get_t)(void);
 
 /** @brief Function system initialization of the logger.
@@ -295,6 +310,7 @@ int log_mem_get_usage(uint32_t *buf_size, uint32_t *usage);
  */
 int log_mem_get_max_usage(uint32_t *max);
 
+/** @cond INTERNAL_HIDDEN */
 #if defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_MINIMAL)
 #define LOG_CORE_INIT() log_core_init()
 #define LOG_PANIC() log_panic()
@@ -311,6 +327,7 @@ int log_mem_get_max_usage(uint32_t *max);
 #define LOG_PANIC() /* Empty */
 #define LOG_PROCESS() false
 #endif
+/** @endcond */
 
 #include <zephyr/syscalls/log_ctrl.h>
 

--- a/include/zephyr/logging/log_frontend.h
+++ b/include/zephyr/logging/log_frontend.h
@@ -3,10 +3,29 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the logging frontend interface.
+ * @ingroup log_frontend
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_FRONTEND_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_FRONTEND_H_
 
 #include <zephyr/logging/log_core.h>
+
+/**
+ * @defgroup log_frontend Logger frontend
+ * @ingroup logger
+ * @brief Interface implemented by a logging frontend that bypasses the core.
+ *
+ * A frontend receives log messages directly from the logging macros, before the
+ * core message buffer, and is responsible for their handling. Most applications
+ * do not implement these functions; they are provided by a frontend
+ * implementation selected through Kconfig.
+ * @{
+ */
 
 /** @brief Initialize frontend.
  */
@@ -80,5 +99,7 @@ void log_frontend_simple_2(const void *source, uint32_t level,
 
 /** @brief Panic state notification. */
 void log_frontend_panic(void);
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_LOGGING_LOG_FRONTEND_H_ */

--- a/include/zephyr/logging/log_frontend_stmesp.h
+++ b/include/zephyr/logging/log_frontend_stmesp.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the STMESP logging frontend.
+ * @ingroup log_frontend_stmesp
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_FRONTEND_STMESP_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_FRONTEND_STMESP_H_
 
@@ -15,6 +22,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup log_frontend_stmesp STMESP frontend
+ * @ingroup log_frontend
+ * @brief Logging frontend that emits messages and trace points over STM (STMESP).
+ * @{
+ */
 
 /** @brief Notify frontend that ETR/STM is ready.
  *
@@ -99,7 +113,9 @@ void log_frontend_stmesp_log0(const void *source, uint32_t x);
  */
 void log_frontend_stmesp_log1(const void *source, uint32_t x, uint32_t arg);
 
+/** @cond INTERNAL_HIDDEN */
 TYPE_SECTION_START_EXTERN(const char *, log_stmesp_ptr);
+/** @endcond */
 
 /** @brief Macro for handling a turbo log message with no arguments.
  *
@@ -135,6 +151,8 @@ TYPE_SECTION_START_EXTERN(const char *, log_stmesp_ptr);
 			sizeof(void *);                                                            \
 		log_frontend_stmesp_log1(_source, _idx, (uintptr_t)(GET_ARG_N(2, __VA_ARGS__)));   \
 	} while (0)
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/logging/log_frontend_stmesp_demux.h
+++ b/include/zephyr/logging/log_frontend_stmesp_demux.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the STMESP stream demultiplexer.
+ * @ingroup log_frontend_stmesp_demux_apis
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_FRONTEND_STMESP_DEMUX_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_FRONTEND_STMESP_DEMUX_H_
 
@@ -15,12 +21,13 @@ extern "C" {
 #endif
 
 /**
- * @defgroup log_frontend_stmesp_apis Trace and Debug Domain APIs
+ * @defgroup log_frontend_stmesp_apis Trace and debug domain
  * @ingroup logging
  * @{
  * @}
- * @defgroup log_frontend_stpesp_demux_apis Logging frontend STMESP Demultiplexer API
+ * @defgroup log_frontend_stmesp_demux_apis STMESP demultiplexer
  * @ingroup log_frontend_stmesp_apis
+ * @brief Host-side demultiplexer for STPv2 streams carrying logs and trace points.
  * @{
  */
 
@@ -297,6 +304,19 @@ void log_frontend_stmesp_demux_free(union log_frontend_stmesp_demux_packet packe
  *         cannot be retrieved.
  */
 const char *log_frontend_stmesp_demux_sname_get(uint32_t m_id, uint16_t s_id);
+
+/** @brief Get the format string of a turbo log message.
+ *
+ * Turbo log messages reference their format string by index rather than
+ * carrying it inline. This helper resolves that index, using the source data
+ * shared by the originating core, back to the format string.
+ *
+ * @param m_id Major ID.
+ * @param s_id Source ID (index of the string).
+ *
+ * @return Pointer to the format string, or an empty/"unknown" string if it
+ *         cannot be retrieved.
+ */
 const char *log_frontend_stmesp_demux_str_get(uint32_t m_id, uint16_t s_id);
 
 /** @brief Check if there are any started but not completed log messages.

--- a/include/zephyr/logging/log_instance.h
+++ b/include/zephyr/logging/log_instance.h
@@ -44,6 +44,11 @@ struct log_source_dynamic_data {
  * @{
  */
 
+/**
+ * @name Instance registration
+ * @{
+ */
+
 /** @internal
  *
  * Creates name of variable and section for constant log data.
@@ -175,6 +180,8 @@ struct log_source_dynamic_data {
  */
 #define LOG_INSTANCE_REGISTER(_module_name, _inst_name, _level) \
 	IF_ENABLED(CONFIG_LOG, (Z_LOG_INSTANCE_REGISTER(_module_name, _inst_name, _level)))
+
+/** @} */
 
 /** @} */
 

--- a/include/zephyr/logging/log_instance.h
+++ b/include/zephyr/logging/log_instance.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for log instance registration.
+ * @ingroup log_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_INSTANCE_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_INSTANCE_H_
 
@@ -12,6 +19,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** @cond INTERNAL_HIDDEN */
 
 /** @brief Constant data associated with the source of log messages. */
 struct log_source_const_data {
@@ -27,6 +36,13 @@ struct log_source_dynamic_data {
 	uint32_t dummy_64;
 #endif
 };
+
+/** @endcond */
+
+/**
+ * @addtogroup log_api
+ * @{
+ */
 
 /** @internal
  *
@@ -159,6 +175,8 @@ struct log_source_dynamic_data {
  */
 #define LOG_INSTANCE_REGISTER(_module_name, _inst_name, _level) \
 	IF_ENABLED(CONFIG_LOG, (Z_LOG_INSTANCE_REGISTER(_module_name, _inst_name, _level)))
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/logging/log_internal.h
+++ b/include/zephyr/logging/log_internal.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for logging internal functions.
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_INTERNAL_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_INTERNAL_H_
 
@@ -19,6 +25,8 @@ extern "C" {
  * shared between various portions of logging subsystem. Functions are internal
  * not intended to be used outside, including logging backends.
  */
+
+/** @cond INTERNAL_HIDDEN */
 
 /** @brief Structure wrapper to be used for memory section. */
 struct log_mpsc_pbuf {
@@ -162,6 +170,8 @@ static inline bool z_log_is_local_domain(uint8_t domain_id)
  * @return Timestamp.
  */
 log_timestamp_t z_log_timestamp(void);
+
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/logging/log_link.h
+++ b/include/zephyr/logging/log_link.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the log link interface.
+ * @ingroup log_link
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_LINK_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_LINK_H_
 
@@ -17,55 +24,85 @@ extern "C" {
 #endif
 
 /**
- * @brief Log link API
- * @defgroup log_link Log link API
+ * @defgroup log_link Log links
  * @ingroup logger
+ * @brief Interface for log links bringing in messages from remote domains.
  * @{
  */
 
 struct log_link;
 
+/**
+ * @brief Callback invoked by a link for each received log message.
+ *
+ * @param link Link instance.
+ * @param msg  Message received from the remote domain.
+ */
 typedef void (*log_link_callback_t)(const struct log_link *link,
 				    union log_msg_generic *msg);
 
+/**
+ * @brief Callback invoked by a link to report dropped messages.
+ *
+ * @param link    Link instance.
+ * @param dropped Number of messages dropped since the previous notification.
+ */
 typedef void (*log_link_dropped_cb_t)(const struct log_link *link,
 				      uint32_t dropped);
 
+/** @brief Log link configuration passed to the link at initiation time. */
 struct log_link_config {
-	log_link_callback_t msg_cb;
-	log_link_dropped_cb_t dropped_cb;
+	log_link_callback_t msg_cb;        /**< Callback for received messages. */
+	log_link_dropped_cb_t dropped_cb;  /**< Callback for dropped messages. */
 };
 
+/**
+ * @brief Log link API.
+ *
+ * Set of operations implemented by a log link backend.
+ */
 struct log_link_api {
+	/** @brief Initiate the link (see log_link_initiate()). */
 	int (*initiate)(const struct log_link *link, struct log_link_config *config);
+	/** @brief Complete link activation (see log_link_activate()). */
 	int (*activate)(const struct log_link *link);
+	/** @brief Get a domain name (see log_link_get_domain_name()). */
 	int (*get_domain_name)(const struct log_link *link, uint32_t domain_id,
 				char *buf, size_t *length);
+	/** @brief Get a source name (see log_link_get_source_name()). */
 	int (*get_source_name)(const struct log_link *link, uint32_t domain_id,
 				uint16_t source_id, char *buf, size_t *length);
+	/** @brief Get level settings of a source (see log_link_get_levels()). */
 	int (*get_levels)(const struct log_link *link, uint32_t domain_id,
 				uint16_t source_id, uint8_t *level,
 				uint8_t *runtime_level);
+	/** @brief Set runtime level of a source (see log_link_set_runtime_level()). */
 	int (*set_runtime_level)(const struct log_link *link, uint32_t domain_id,
 				uint16_t source_id, uint8_t level);
 };
 
+/** @brief Run-time control block for a @ref log_link instance. */
 struct log_link_ctrl_blk {
+	/** @cond INTERNAL_HIDDEN */
 	uint32_t domain_cnt;
 	uint16_t source_cnt[1 + COND_CODE_1(CONFIG_LOG_MULTIDOMAIN,
 					    (CONFIG_LOG_REMOTE_DOMAIN_MAX_COUNT),
 					    (0))];
 	uint32_t domain_offset;
 	uint32_t *filters;
+	/** @endcond */
 };
 
+/** @brief Log link instance. */
 struct log_link {
-	const struct log_link_api *api;
-	const char *name;
-	struct log_link_ctrl_blk *ctrl_blk;
-	void *ctx;
+	const struct log_link_api *api; /**< Link operations. */
+	const char *name;               /**< Unique link name. */
+	struct log_link_ctrl_blk *ctrl_blk; /**< Run-time control block. */
+	void *ctx;                      /**< Context associated with the link. */
+	/** @cond INTERNAL_HIDDEN */
 	struct mpsc_pbuf_buffer *mpsc_pbuf;
 	const struct mpsc_pbuf_buffer_config *mpsc_pbuf_config;
+	/** @endcond */
 };
 
 /** @brief Create instance of a log link.

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for log messages.
+ * @ingroup log_msg
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_MSG_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_MSG_H_
 
@@ -27,9 +34,20 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 #define LOG_MSG_DEBUG 0
 #define LOG_MSG_DBG(...) IF_ENABLED(LOG_MSG_DEBUG, (printk(__VA_ARGS__)))
+/** @endcond */
 
+/**
+ * @brief Timestamp value associated with a log message.
+ *
+ * 32-bit wide by default, or 64-bit when @kconfig{CONFIG_LOG_TIMESTAMP_64BIT}
+ * is enabled. The meaning of the value (ticks, cycles, microseconds, ...)
+ * depends on the registered timestamp source; see log_set_timestamp_func().
+ *
+ * @ingroup log_msg
+ */
 #ifdef CONFIG_LOG_TIMESTAMP_64BIT
 typedef uint64_t log_timestamp_t;
 #else
@@ -37,12 +55,13 @@ typedef uint32_t log_timestamp_t;
 #endif
 
 /**
- * @brief Log message API
- * @defgroup log_msg Log message API
+ * @brief Log message
+ * @defgroup log_msg Log messages
  * @ingroup logger
  * @{
  */
 
+/** @cond INTERNAL_HIDDEN */
 #define Z_LOG_MSG_LOG 0
 
 #define Z_LOG_MSG_PACKAGE_BITS 11
@@ -103,14 +122,8 @@ struct log_msg {
 	uint8_t data[];
 };
 
-/**
- * @cond INTERNAL_HIDDEN
- */
 BUILD_ASSERT(sizeof(struct log_msg) % Z_LOG_MSG_ALIGNMENT == 0,
 	     "Log msg size must aligned");
-/**
- * @endcond
- */
 
 
 struct log_msg_generic_hdr {
@@ -728,6 +741,8 @@ static inline bool z_log_item_is_msg(const union log_msg_generic *msg)
 {
 	return msg->generic.type == Z_LOG_MSG_LOG;
 }
+
+/** @endcond */
 
 /** @brief Get total length (in 32 bit words) of a log message.
  *

--- a/include/zephyr/logging/log_multidomain_helper.h
+++ b/include/zephyr/logging/log_multidomain_helper.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the multidomain logging helpers.
+ * @ingroup log_backend_multidomain
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_MULTIDOMAIN_HELPER_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_MULTIDOMAIN_HELPER_H_
 
@@ -70,70 +76,70 @@
 
 /** @brief Content of the logging message. */
 struct log_multidomain_log_msg {
-	FLEXIBLE_ARRAY_DECLARE(uint8_t, data);
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, data); /**< Serialized log message bytes. */
 } __packed;
 
 /** @brief Content of the domain count message. */
 struct log_multidomain_domain_cnt {
-	uint16_t count;
+	uint16_t count; /**< Number of domains. */
 } __packed;
 
 /** @brief Content of the source count message. */
 struct log_multidomain_source_cnt {
-	uint8_t domain_id;
-	uint16_t count;
+	uint8_t domain_id; /**< Domain ID the request applies to. */
+	uint16_t count;    /**< Number of sources in the domain. */
 } __packed;
 
 /** @brief Content of the domain name message. */
 struct log_multidomain_domain_name {
-	uint8_t domain_id;
-	char name[];
+	uint8_t domain_id; /**< Domain ID. */
+	char name[];       /**< Null-terminated domain name. */
 } __packed;
 
 /** @brief Content of the source name message. */
 struct log_multidomain_source_name {
-	uint8_t domain_id;
-	uint16_t source_id;
-	char name[];
+	uint8_t domain_id;  /**< Domain ID. */
+	uint16_t source_id; /**< Source ID within the domain. */
+	char name[];        /**< Null-terminated source name. */
 } __packed;
 
 /** @brief Content of the message for getting logging levels. */
 struct log_multidomain_levels {
-	uint8_t domain_id;
-	uint16_t source_id;
-	uint8_t level;
-	uint8_t runtime_level;
+	uint8_t domain_id;     /**< Domain ID. */
+	uint16_t source_id;    /**< Source ID within the domain. */
+	uint8_t level;         /**< Compile-time level. */
+	uint8_t runtime_level; /**< Run-time level. */
 } __packed;
 
 /** @brief Content of the message for setting logging level. */
 struct log_multidomain_set_runtime_level {
-	uint8_t domain_id;
-	uint16_t source_id;
-	uint8_t runtime_level;
+	uint8_t domain_id;     /**< Domain ID. */
+	uint16_t source_id;    /**< Source ID within the domain. */
+	uint8_t runtime_level; /**< Run-time level to set. */
 } __packed;
 
 /** @brief Content of the message for getting amount of dropped messages. */
 struct log_multidomain_dropped {
-	uint32_t dropped;
+	uint32_t dropped; /**< Number of dropped messages. */
 } __packed;
 
 /** @brief Union with all message types. */
 union log_multidomain_msg_data {
-	struct log_multidomain_log_msg log_msg;
-	struct log_multidomain_domain_cnt domain_cnt;
-	struct log_multidomain_source_cnt source_cnt;
-	struct log_multidomain_domain_name domain_name;
-	struct log_multidomain_source_name source_name;
-	struct log_multidomain_levels levels;
-	struct log_multidomain_set_runtime_level set_rt_level;
-	struct log_multidomain_dropped dropped;
+	struct log_multidomain_log_msg log_msg;           /**< Log message payload. */
+	struct log_multidomain_domain_cnt domain_cnt;     /**< Domain count payload. */
+	struct log_multidomain_source_cnt source_cnt;     /**< Source count payload. */
+	struct log_multidomain_domain_name domain_name;   /**< Domain name payload. */
+	struct log_multidomain_source_name source_name;   /**< Source name payload. */
+	struct log_multidomain_levels levels;             /**< Levels payload. */
+	struct log_multidomain_set_runtime_level set_rt_level; /**< Set-level payload. */
+	struct log_multidomain_dropped dropped;           /**< Dropped count payload. */
 };
 
 /** @brief Message. */
 struct log_multidomain_msg {
-	uint8_t id;
-	uint8_t status;
-	union log_multidomain_msg_data data;
+	uint8_t id;     /**< Message ID, see @ref LOG_MULTIDOMAIN_HELPER_MESSAGE_IDS. */
+	uint8_t status; /**< Status code, see @ref LOG_MULTIDOMAIN_STATUS. */
+	union log_multidomain_msg_data data; /**< Message payload. */
 } __packed;
 
 /** @brief Forward declaration. */
@@ -141,26 +147,31 @@ struct log_multidomain_link;
 
 /** @brief Structure with link transport API. */
 struct log_multidomain_link_transport_api {
+	/** @brief Initialize the transport. */
 	int (*init)(struct log_multidomain_link *link);
+	/** @brief Send a buffer to the remote backend. */
 	int (*send)(struct log_multidomain_link *link, void *data, size_t len);
 };
 
 /** @brief Union for holding data returned by associated remote backend. */
 union log_multidomain_link_dst {
-	uint16_t count;
+	uint16_t count; /**< Domain or source count. */
 
+	/** @brief Destination buffer for a requested name. */
 	struct {
-		char *dst;
-		size_t *len;
+		char *dst;   /**< Output buffer for the name. */
+		size_t *len; /**< In/out buffer length, updated with the name length. */
 	} name;
 
+	/** @brief Returned level settings of a source. */
 	struct {
-		uint8_t level;
-		uint8_t runtime_level;
+		uint8_t level;         /**< Compile-time level. */
+		uint8_t runtime_level; /**< Run-time level. */
 	} levels;
 
+	/** @brief Result of a set-runtime-level request. */
 	struct {
-		uint8_t level;
+		uint8_t level; /**< Run-time level actually set. */
 	} set_runtime_level;
 };
 
@@ -169,11 +180,17 @@ extern struct log_link_api log_multidomain_link_api;
 
 /** @brief Remote link structure. */
 struct log_multidomain_link {
+	/** Transport operations. */
 	const struct log_multidomain_link_transport_api *transport_api;
+	/** Semaphore signaled when a response is ready. */
 	struct k_sem rdy_sem;
+	/** Associated log link instance. */
 	const struct log_link *link;
+	/** Storage for the latest response. */
 	union log_multidomain_link_dst dst;
+	/** Status of the last operation. */
 	int status;
+	/** Set once the link is ready. */
 	bool ready;
 };
 
@@ -182,7 +199,9 @@ struct log_multidomain_backend;
 
 /** @brief Backend transport API. */
 struct log_multidomain_backend_transport_api {
+	/** Initialize the transport. */
 	int (*init)(struct log_multidomain_backend *backend);
+	/** Send a buffer to the remote link. */
 	int (*send)(struct log_multidomain_backend *backend, void *data, size_t len);
 };
 
@@ -191,11 +210,17 @@ extern const struct log_backend_api log_multidomain_backend_api;
 
 /** @brief Remote backend structure. */
 struct log_multidomain_backend {
+	/** Transport operations. */
 	const struct log_multidomain_backend_transport_api *transport_api;
+	/** Associated log backend instance. */
 	const struct log_backend *log_backend;
+	/** Semaphore signaled when the remote is ready. */
 	struct k_sem rdy_sem;
+	/** Set when the backend is in panic mode. */
 	bool panic;
+	/** Status of the last operation. */
 	int status;
+	/** Set once the backend is ready. */
 	bool ready;
 };
 

--- a/include/zephyr/logging/log_output.h
+++ b/include/zephyr/logging/log_output.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the log output formatter.
+ * @ingroup log_output
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_OUTPUT_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_OUTPUT_H_
 
@@ -17,9 +24,9 @@ extern "C" {
 #endif
 
 /**
- * @brief Log output API
- * @defgroup log_output Log output API
+ * @defgroup log_output Log output
  * @ingroup logger
+ * @brief Formatting of log messages into human-readable or structured output.
  * @{
  */
 
@@ -62,16 +69,27 @@ extern "C" {
 
 /**@} */
 
-/** @brief Supported backend logging format types for use
- * with log_format_set() API to switch log format at runtime.
+/**
+ * @name Output format types
+ *
+ * Values used with log_format_set() and log_backend_format_set() to select the
+ * output format of a backend at run time.
+ * @{
  */
+
+/** @brief Plain text output format. */
 #define LOG_OUTPUT_TEXT 0
 
+/** @brief MIPI Sys-T output format. */
 #define LOG_OUTPUT_SYST 1
 
+/** @brief Dictionary-based (binary) output format. */
 #define LOG_OUTPUT_DICT 2
 
+/** @brief Custom, user-provided output format. */
 #define LOG_OUTPUT_CUSTOM 3
+
+/** @} */
 
 /**
  * @brief Prototype of the function processing output data.
@@ -88,19 +106,21 @@ extern "C" {
  */
 typedef int (*log_output_func_t)(uint8_t *buf, size_t size, void *ctx);
 
-/* @brief Control block structure for log_output instance.  */
+/** @brief Run-time control block for a @ref log_output instance. */
 struct log_output_control_block {
+	/** @cond INTERNAL_HIDDEN */
 	atomic_t offset;
 	void *ctx;
 	const char *hostname;
+	/** @endcond */
 };
 
-/** @brief Log_output instance structure. */
+/** @brief Log output instance. */
 struct log_output {
-	log_output_func_t func;
-	struct log_output_control_block *control_block;
-	uint8_t *buf;
-	size_t size;
+	log_output_func_t func; /**< Function called to write formatted output. */
+	struct log_output_control_block *control_block; /**< Run-time control block. */
+	uint8_t *buf; /**< Buffer holding formatted output before it is written. */
+	size_t size; /**< Size of @ref log_output.buf, in bytes. */
 };
 
 /**

--- a/include/zephyr/logging/log_output_custom.h
+++ b/include/zephyr/logging/log_output_custom.h
@@ -4,6 +4,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for custom log output formatting.
+ * @ingroup log_output
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_OUTPUT_CUSTOM_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_OUTPUT_CUSTOM_H_
 
@@ -68,7 +75,7 @@ typedef int (*log_timestamp_printer_t)(const struct log_output *output, const ch
  * @endcode
  *
  * @param output The logger instance to write to
- * @param timestamp
+ * @param timestamp Message timestamp to format.
  * @param printer The printing function to use when formatting the timestamp.
  */
 typedef int (*log_timestamp_format_func_t)(const struct log_output *output,
@@ -81,7 +88,7 @@ typedef int (*log_timestamp_format_func_t)(const struct log_output *output,
  * process formatted string and output the data.
  *
  * @param output Pointer to the log output instance.
- * @param timestamp
+ * @param timestamp Message timestamp to format.
  * @param printer The printing function to use when formatting the timestamp.
  */
 int log_custom_timestamp_print(const struct log_output *output, const log_timestamp_t timestamp,

--- a/include/zephyr/logging/log_output_dict.h
+++ b/include/zephyr/logging/log_output_dict.h
@@ -4,6 +4,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for dictionary-based log output.
+ * @ingroup log_output
+ */
+
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_OUTPUT_DICT_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_OUTPUT_DICT_H_
 
@@ -18,33 +25,31 @@ extern "C" {
 #endif
 
 /**
- * Log message type
+ * @addtogroup log_output
+ * @{
  */
+
+/** @brief Dictionary output message type. */
 enum log_dict_output_msg_type {
-	MSG_NORMAL = 0,
-	MSG_DROPPED_MSG = 1,
+	MSG_NORMAL = 0,      /**< Normal log message. */
+	MSG_DROPPED_MSG = 1, /**< Notification about dropped messages. */
 };
 
-/**
- * Output header for one dictionary based log message.
- */
+/** @brief On-wire header for one dictionary-based log message. */
 struct log_dict_output_normal_msg_hdr_t {
-	uint8_t type;
-	uint32_t domain:4;
-	uint32_t level:4;
-	uint32_t package_len:16;
-	uint32_t data_len:16;
-	uintptr_t source;
-	log_timestamp_t timestamp;
+	uint8_t type;             /**< Message type, see @ref log_dict_output_msg_type. */
+	uint32_t domain:4;        /**< Domain ID. */
+	uint32_t level:4;         /**< Severity level. */
+	uint32_t package_len:16;  /**< Length of the cbprintf package, in bytes. */
+	uint32_t data_len:16;     /**< Length of the appended hexdump data, in bytes. */
+	uintptr_t source;         /**< Address identifying the log source. */
+	log_timestamp_t timestamp; /**< Message timestamp. */
 } __packed;
 
-/**
- * Output for one dictionary based log message about
- * dropped messages.
- */
+/** @brief On-wire dictionary-based message reporting dropped messages. */
 struct log_dict_output_dropped_msg_t {
-	uint8_t type;
-	uint16_t num_dropped_messages;
+	uint8_t type;                  /**< Message type, see @ref log_dict_output_msg_type. */
+	uint16_t num_dropped_messages; /**< Number of dropped messages. */
 } __packed;
 
 /** @brief Process log messages v2 for dictionary-based logging.
@@ -67,6 +72,8 @@ void log_dict_output_msg_process(const struct log_output *log_output,
  * @param cnt        Number of dropped messages.
  */
 void log_dict_output_dropped_process(const struct log_output *output, uint32_t cnt);
+
+/** @} */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Brings every logging header to 100% Doxygen coverage while making the public API surface explicit.

- Hid internals with `@cond INTERNAL_HIDDEN` (message-creation machinery, message-format structs, filter helpers, runtime control blocks).
- Documented the genuine public API and added missing `@file` blocks (severity levels, message accessors, control API, backend/link/frontend interfaces, output formatter, multidomain helpers).
- Tidied groups: standard backend helpers under `log_backend`, a new `log_frontend` umbrella, and dropped the redundant "API"/"Interface" suffix from group titles.

---

* https://builds.zephyrproject.io/zephyr/pr/111867/docs/doxygen/html/group__logging.html
* [Coverage report](https://builds.zephyrproject.io/zephyr/pr/111867/api-coverage/zephyr/logging/index.html)