### PR TITLE
net: gptp: fix path trace length validation

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -1204,9 +1204,9 @@ static void copy_path_trace(struct gptp_announce *announce)
 	int len = net_ntohs(announce->tlv.len);
 	struct gptp_path_trace *sys_path_trace;
 
-	if (len > GPTP_MAX_PATHTRACE_SIZE) {
+	if (len > GPTP_MAX_PATHTRACE_SIZE * GPTP_CLOCK_ID_LEN) {
 		NET_ERR("Too long path trace (%d vs %d)",
-			GPTP_MAX_PATHTRACE_SIZE, len);
+			GPTP_MAX_PATHTRACE_SIZE * GPTP_CLOCK_ID_LEN, len);
 		return;
 	}
 


### PR DESCRIPTION
Path trace length is increased by GPTP_CLOCK_ID_LEN (=8) for every clock id added to the list. But the check only accounted for 1 unit per clock id which resulted in false-positive errors.

Update the length check to correctly account for the full GPTP_CLOCK_ID_LEN per clock ID.