### PR TITLE
net: if: Fix potential deadlock in case multiple interfaces go up in parallel

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3633,14 +3633,21 @@ static void iface_ipv6_start(struct net_if *iface)
 
 static void iface_ipv6_stop(struct net_if *iface)
 {
-	struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;
+	struct net_if_ipv6 *ipv6;
 
 	if (!net_if_flag_is_set(iface, NET_IF_IPV6) ||
 	    net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
 		return;
 	}
 
+	/* notify_iface_down() runs without net_if_lock() held, so take it here
+	 * to access the IPv6 address structures safely.
+	 */
+	net_if_lock(iface);
+
+	ipv6 = iface->config.ip.ipv6;
 	if (ipv6 == NULL) {
+		net_if_unlock(iface);
 		return;
 	}
 
@@ -3658,6 +3665,8 @@ static void iface_ipv6_stop(struct net_if *iface)
 						  &ipv6->unicast[i].address.in6_addr);
 		}
 	}
+
+	net_if_unlock(iface);
 }
 
 static void iface_ipv6_init(int if_count)
@@ -5963,6 +5972,14 @@ static void notify_iface_up(struct net_if *iface)
 
 	net_if_flag_set(iface, NET_IF_RUNNING);
 	net_mgmt_event_notify(NET_EVENT_IF_UP, iface);
+
+	/* net_virtual_enable() and the IPv6/IPv4 startup below transmit packets
+	 * (RS, MLD join) and lock other interfaces, so drop net_if_lock() around
+	 * them - otherwise two interfaces coming up concurrently could deadlock
+	 * (ABBA). The caller holds the lock exactly once.
+	 */
+	net_if_unlock(iface);
+
 	net_virtual_enable(iface);
 
 	/* If the interface is only having point-to-point traffic then we do
@@ -5978,12 +5995,20 @@ static void notify_iface_up(struct net_if *iface)
 		iface_ipv4_start(iface);
 		net_ipv4_autoconf_start(iface);
 	}
+
+	net_if_lock(iface);
 }
 
 static void notify_iface_down(struct net_if *iface)
 {
 	net_if_flag_clear(iface, NET_IF_RUNNING);
 	net_mgmt_event_notify(NET_EVENT_IF_DOWN, iface);
+
+	/* As in notify_iface_up(), drop net_if_lock() around the parts that
+	 * transmit packets and lock other interfaces.
+	 */
+	net_if_unlock(iface);
+
 	net_virtual_disable(iface);
 
 	if (!net_if_is_offloaded(iface) &&
@@ -5995,10 +6020,10 @@ static void notify_iface_down(struct net_if *iface)
 	}
 
 	if (IS_ENABLED(CONFIG_NET_NATIVE_TCP)) {
-		net_if_unlock(iface);
 		net_tcp_close_all_for_iface(iface);
-		net_if_lock(iface);
 	}
+
+	net_if_lock(iface);
 }
 
 const char *net_if_oper_state2str(enum net_if_oper_state state)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1705,9 +1705,13 @@ out:
  */
 static void rejoin_ipv6_mcast_groups(struct net_if *iface)
 {
+	struct net_in6_addr solicit_addrs[NET_IF_MAX_IPV6_ADDR];
 	struct net_if_mcast_addr *ifaddr, *next;
 	struct net_if_ipv6 *ipv6;
 	sys_slist_t rejoin_needed;
+	int solicit_count = 0;
+
+	sys_slist_init(&rejoin_needed);
 
 	net_if_lock(iface);
 
@@ -1719,14 +1723,21 @@ static void rejoin_ipv6_mcast_groups(struct net_if *iface)
 		goto out;
 	}
 
-	/* Rejoin solicited node multicasts if the interface has ND enabled. */
+	/* Collect the addresses whose solicited node multicast groups need to
+	 * be (re)joined if the interface has ND enabled. The join itself is
+	 * done below without the iface lock held: join_mcast_nodes() transmits
+	 * MLD reports, whose TX path locks other interfaces, so doing it under
+	 * net_if_lock() could deadlock (ABBA) when two interfaces are brought
+	 * up concurrently.
+	 */
 	if (!net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
 		ARRAY_FOR_EACH(ipv6->unicast, i) {
 			if (!ipv6->unicast[i].is_used) {
 				continue;
 			}
 
-			join_mcast_nodes(iface, &ipv6->unicast[i].address.in6_addr);
+			solicit_addrs[solicit_count++] =
+				ipv6->unicast[i].address.in6_addr;
 		}
 	}
 
@@ -1734,8 +1745,6 @@ static void rejoin_ipv6_mcast_groups(struct net_if *iface)
 	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {
 		goto out;
 	}
-
-	sys_slist_init(&rejoin_needed);
 
 	/* Rejoin any mcast address present on the interface, but marked as not joined. */
 	ARRAY_FOR_EACH(ipv6->mcast, i) {
@@ -1747,10 +1756,18 @@ static void rejoin_ipv6_mcast_groups(struct net_if *iface)
 		sys_slist_prepend(&rejoin_needed, &ipv6->mcast[i].rejoin_node);
 	}
 
+out:
 	net_if_unlock(iface);
 
-	/* Start DAD for all the addresses without holding the iface lock
-	 * to avoid any possible mutex deadlock issues.
+	/* Join the solicited node multicast groups without holding the iface
+	 * lock, see the comment above.
+	 */
+	for (int i = 0; i < solicit_count; i++) {
+		join_mcast_nodes(iface, &solicit_addrs[i]);
+	}
+
+	/* Rejoin multicast groups without holding the iface lock to avoid any
+	 * possible mutex deadlock issues.
 	 */
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&rejoin_needed,
 					  ifaddr, next, rejoin_node) {
@@ -1767,11 +1784,6 @@ static void rejoin_ipv6_mcast_groups(struct net_if *iface)
 				net_if_get_by_iface(iface));
 		}
 	}
-
-	return;
-
-out:
-	net_if_unlock(iface);
 }
 
 /* To be called when interface comes operational down so that multicast

--- a/tests/net/iface_with_mld/CMakeLists.txt
+++ b/tests/net/iface_with_mld/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(iface_with_mld)
+
+target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/net/iface_with_mld/prj.conf
+++ b/tests/net/iface_with_mld/prj.conf
@@ -1,0 +1,27 @@
+CONFIG_NETWORKING=y
+CONFIG_NET_TEST=y
+CONFIG_NET_IPV6=y
+CONFIG_NET_IF_MAX_IPV6_COUNT=4
+
+CONFIG_NET_L2_DUMMY=y
+CONFIG_NET_L2_ETHERNET=n
+
+# Make bring-up actually transmit (all-nodes MLD report), so the operational
+# state notification runs the packet TX path while the interface is being
+# brought up.
+CONFIG_NET_IPV6_MLD=y
+
+# The TX path checks whether the destination is one of our own addresses via
+# net_if_ipv6_addr_lookup_raw(), which walks and locks every interface in turn.
+# That is the cross-interface lock the deadlock test relies on, so keep the
+# address check enabled and make sure the dummy L2 loopback short-circuit (in
+# check_ip()) is not compiled in.
+CONFIG_NET_IP_ADDR_CHECK=y
+CONFIG_NET_LOOPBACK=n
+
+CONFIG_ENTROPY_GENERATOR=y
+CONFIG_TEST_RANDOM_GENERATOR=y
+
+CONFIG_ZTEST=y
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_ZTEST_STACK_SIZE=2048

--- a/tests/net/iface_with_mld/src/main.c
+++ b/tests/net/iface_with_mld/src/main.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Regression test for the ABBA deadlock that could occur when two network
+ * interfaces are brought up concurrently.
+ *
+ * Bringing an interface up runs notify_iface_up(), which transmits packets
+ * (e.g. the all-nodes MLD report). The TX path runs check_ip() ->
+ * net_ipv6_is_my_addr_raw() -> net_if_ipv6_addr_lookup_raw(), which walks and
+ * locks *every* interface in turn. In the buggy code this ran while
+ * net_if_lock(iface) of the interface being brought up was still held, so two
+ * interfaces coming up concurrently could deadlock.
+ *
+ * To reproduce this deterministically we give the "slow" dummy interface a
+ * driver start() callback that sleeps. net_if_up() invokes start() while
+ * holding net_if_lock(slow_iface), so the lock is held for the whole sleep.
+ * While the slow interface is parked in start(), the test brings the "fast"
+ * interface up from another thread. Its bring-up TX iterates the interfaces
+ * and blocks on lock(slow); once the slow interface wakes, its own bring-up TX
+ * tries to take lock(fast) -> ABBA.
+ *
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/atomic.h>
+
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/dummy.h>
+
+/* How long the slow interface holds net_if_lock() inside its start(). */
+#define SLOW_START_SLEEP_MS 300
+
+/*
+ * Time allowed for each bring-up thread to finish. The fixed code only blocks
+ * for the duration of the slow interface's start() sleep, so this must be
+ * larger than SLOW_START_SLEEP_MS, but still finite to catch a real deadlock.
+ */
+#define BRINGUP_TIMEOUT K_MSEC(SLOW_START_SLEEP_MS + 3000)
+
+static struct net_if *slow_iface;
+static struct net_if *fast_iface;
+
+static struct net_in6_addr slow_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0xaa, 0, 0, 0,
+					     0, 0, 0, 0, 0, 0, 0, 0x1 } } };
+static struct net_in6_addr fast_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0xbb, 0, 0, 0,
+					     0, 0, 0, 0, 0, 0, 0, 0x1 } } };
+
+static atomic_t slow_start_armed;
+static K_SEM_DEFINE(slow_in_start, 0, 1);
+static K_SEM_DEFINE(done_slow, 0, 1);
+static K_SEM_DEFINE(done_fast, 0, 1);
+
+struct dummy_dev_data {
+	uint8_t mac[6];
+};
+
+static struct dummy_dev_data slow_data = {
+	.mac = { 0x00, 0x00, 0x5e, 0x00, 0x53, 0x01 },
+};
+static struct dummy_dev_data fast_data = {
+	.mac = { 0x00, 0x00, 0x5e, 0x00, 0x53, 0x02 },
+};
+
+static void dummy_iface_init(struct net_if *iface)
+{
+	struct dummy_dev_data *data = net_if_get_device(iface)->data;
+
+	net_if_set_link_addr(iface, data->mac, sizeof(data->mac),
+			     NET_LINK_DUMMY);
+
+	/* Keep the interface down until the test brings it up explicitly. */
+	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+}
+
+static int dummy_dev_send(const struct device *dev, struct net_pkt *pkt)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(pkt);
+
+	return 0;
+}
+
+static int slow_dev_start(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	if (atomic_get(&slow_start_armed)) {
+		/*
+		 * net_if_up() holds net_if_lock(slow_iface) across this call.
+		 * Let the test know we are here (and thus holding the lock),
+		 * then keep holding it for a while so the concurrent bring-up
+		 * of the other interface runs inside this window.
+		 */
+		k_sem_give(&slow_in_start);
+		k_msleep(SLOW_START_SLEEP_MS);
+	}
+
+	return 0;
+}
+
+static int dummy_dev_stop(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return 0;
+}
+
+static struct dummy_api slow_api = {
+	.iface_api.init = dummy_iface_init,
+	.send = dummy_dev_send,
+	.start = slow_dev_start,
+	.stop = dummy_dev_stop,
+};
+
+static struct dummy_api fast_api = {
+	.iface_api.init = dummy_iface_init,
+	.send = dummy_dev_send,
+	.stop = dummy_dev_stop,
+};
+
+NET_DEVICE_INIT(slow_iface_dev, "slow_iface", NULL, NULL, &slow_data, NULL,
+		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &slow_api, DUMMY_L2,
+		NET_L2_GET_CTX_TYPE(DUMMY_L2), 127);
+
+NET_DEVICE_INIT(fast_iface_dev, "fast_iface", NULL, NULL, &fast_data, NULL,
+		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &fast_api, DUMMY_L2,
+		NET_L2_GET_CTX_TYPE(DUMMY_L2), 127);
+
+static K_THREAD_STACK_DEFINE(slow_stack, 2048);
+static K_THREAD_STACK_DEFINE(fast_stack, 2048);
+static struct k_thread slow_thread;
+static struct k_thread fast_thread;
+
+static void slow_thread_fn(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	(void)net_if_up(slow_iface);
+	k_sem_give(&done_slow);
+}
+
+static void fast_thread_fn(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	(void)net_if_up(fast_iface);
+	k_sem_give(&done_fast);
+}
+
+static void *iface_with_mld_setup(void)
+{
+	struct net_if_addr *ifaddr;
+
+	slow_iface = net_if_lookup_by_dev(DEVICE_GET(slow_iface_dev));
+	fast_iface = net_if_lookup_by_dev(DEVICE_GET(fast_iface_dev));
+
+	zassert_not_null(slow_iface, "slow_iface not found");
+	zassert_not_null(fast_iface, "fast_iface not found");
+
+	ifaddr = net_if_ipv6_addr_add(slow_iface, &slow_addr, NET_ADDR_MANUAL, 0);
+	zassert_not_null(ifaddr, "Cannot add IPv6 address to slow_iface");
+
+	ifaddr = net_if_ipv6_addr_add(fast_iface, &fast_addr, NET_ADDR_MANUAL, 0);
+	zassert_not_null(ifaddr, "Cannot add IPv6 address to fast_iface");
+
+	return NULL;
+}
+
+ZTEST(net_iface_with_mld, test_concurrent_bringup_no_deadlock)
+{
+	int ret;
+
+	/* Arm the slow interface so its start() holds net_if_lock() and sleeps. */
+	atomic_set(&slow_start_armed, 1);
+
+	k_thread_create(&slow_thread, slow_stack,
+			K_THREAD_STACK_SIZEOF(slow_stack), slow_thread_fn,
+			NULL, NULL, NULL, K_PRIO_PREEMPT(5), 0, K_NO_WAIT);
+
+	/* Wait until the slow interface is inside start() holding its lock. */
+	ret = k_sem_take(&slow_in_start, K_SECONDS(1));
+	zassert_ok(ret, "slow_iface did not reach start()");
+
+	/* Now bring the fast interface up concurrently. */
+	k_thread_create(&fast_thread, fast_stack,
+			K_THREAD_STACK_SIZEOF(fast_stack), fast_thread_fn,
+			NULL, NULL, NULL, K_PRIO_PREEMPT(6), 0, K_NO_WAIT);
+
+	ret = k_sem_take(&done_fast, BRINGUP_TIMEOUT);
+	zassert_ok(ret, "fast_iface bring-up did not finish - deadlock with slow_iface");
+
+	ret = k_sem_take(&done_slow, BRINGUP_TIMEOUT);
+	zassert_ok(ret, "slow_iface bring-up did not finish - deadlock with fast_iface");
+
+	zassert_true(net_if_is_up(slow_iface), "slow_iface is not up");
+	zassert_true(net_if_is_up(fast_iface), "fast_iface is not up");
+}
+
+ZTEST_SUITE(net_iface_with_mld, NULL, iface_with_mld_setup, NULL, NULL, NULL);

--- a/tests/net/iface_with_mld/testcase.yaml
+++ b/tests/net/iface_with_mld/testcase.yaml
@@ -1,0 +1,8 @@
+common:
+  min_ram: 16
+  depends_on: netif
+  tags:
+    - net
+    - iface
+tests:
+  net.iface.with_mld: {}


### PR DESCRIPTION
* Unlock the interface mutex before operations that can cause deadlock (virtual/ipv4/ipv6 bringup). This should be safe, as functions like `rejoin_multicast_groups()` etc. lock the mutex on their own when accessing interface data.
* `iface_ipv6_stop()` did not lock the mutex when iterating the address table, so improve that.
* Update `rejoin_ipv6_mcast_groups() ` to avoid sending MLD reports with interface mutex locked, to avoid deadlocks.
* Finally add regression tests that detected the deadlock, to confirm the issue is solved. Note I had to do this as a separate test suite, as it required MLD/ND to be enabled and the existing `tests/net/iface` test suite had just too many tests relying on MLD/ND being disabled to make it feasible to extend.

Fixes #111757