### PR TITLE
ipc: ipc_service: icbmsg: Rework backend to improve performance, API coverage and reduce code size

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -149,8 +149,8 @@ ipc0: &cpuapp_cpurad_ipc {
 	mbox-names = "rx", "tx";
 	tx-region = <&cpuapp_cpurad_ipc_shm>;
 	rx-region = <&cpurad_cpuapp_ipc_shm>;
-	tx-blocks = <32>;
-	rx-blocks = <32>;
+	tx-blocks = <15>;
+	rx-blocks = <15>;
 
 	bt_hci_ipc0: bt_hci_ipc0 {
 		compatible = "zephyr,bt-hci-ipc";

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -66,8 +66,8 @@ ipc0: &cpuapp_cpurad_ipc {
 	mbox-names = "tx", "rx";
 	tx-region = <&cpurad_cpuapp_ipc_shm>;
 	rx-region = <&cpuapp_cpurad_ipc_shm>;
-	tx-blocks = <32>;
-	rx-blocks = <32>;
+	tx-blocks = <15>;
+	rx-blocks = <15>;
 };
 
 &cpurad_cpusys_ipc {

--- a/doc/services/ipc/ipc_service/backends/ipc_service_icbmsg.rst
+++ b/doc/services/ipc/ipc_service/backends/ipc_service_icbmsg.rst
@@ -3,41 +3,65 @@
 ICMsg with dynamically allocated buffers backend
 ################################################
 
-This backend is built on top of the :ref:`ipc_service_backend_icmsg`.
 Data transferred over this backend travels in dynamically allocated buffers on shared memory.
-The ICMsg just sends references to the buffers.
-It also supports multiple endpoints.
+Allocation is thread safe and can happen from any context.
+The backend supports:
 
-This architecture allows for overcoming some common problems with other backends (mostly related to multithread access and zero-copy).
-This backend provides an alternative with no significant limitations.
+* Multiple endpoints.
+* No-copy sending.
+* Holding RX buffers.
+* Sending from an interrupt context.
+* Two levels of endpoint priorities.
+* Statistics and optional shell command with utilization report
+* Up to 32 blocks are supported.
+* Data cache support.
+* Low memory footprint (around 2 kB of code).
 
 Overview
 ========
 
-The shared memory is divided into two parts.
-One is reserved for the ICMsg and the other contains equal-sized blocks.
-The number of blocks is configured in the devicetree.
+For each direction a shared memory region is reserved and each region is divided into two parts.
+One part forms a pool of fixed size buffers and the allocator builds a variable size buffer from adjacent buffers in the pool.
+The other part is used for control path consisting of two message queues (for each direction).
+There is a producer queue which is written by the sender and read by the receiver and a consumer queue which is written by the receiver and read by the sender.
+The producer queue has information about location (within the pool) of the next message.
+The consumer queue has information about location (within the pool) of the consumed message.
 
 The data sending process is following:
 
-* The sender allocates one or more blocks.
-  If there are not enough sequential blocks, it waits using the timeout provided in the parameter that also includes K_FOREVER and K_NO_WAIT.
+* The sender allocates one or more blocks from the pool.
+  If there are not enough sequential blocks, a thread context waits using the timeout provided in the parameter that also includes K_FOREVER and K_NO_WAIT.
 * The allocated blocks are filled with data.
+  At the beginning of the first block there is a 32 bit message header with length, endpoint ID and own block index.
   For the zero-copy case, this is done by the caller, otherwise, it is copied automatically.
   During this time other threads are not blocked in any way as long as there are enough free blocks for them.
   They can allocate, send data and receive data.
-* A message containing the block index is sent over ICMsg to the receiver.
-  The size of the ICMsg queue is large enough to hold messages for all blocks, so it will never overflow.
-* The receiver can hold the data as long as desired.
+* A block index with the beginning of the message is written to the producer queue.
+  Information about the priority of the endpoint is appended to the block index.
+  :kconfig:option:`CONFIG_IPC_SERVICE_BACKEND_ICBMSG_MAX_ACTIVE_COUNT` defines number of slots in the queue.
+  Mailbox notification is send to the receiver.
+* The receiver reads the producer queue. Higher prioriy messages are processed first.
+  It can hold the data as long as desired.
   Again, other threads are not blocked as long as there are enough free blocks for them.
-* When data is no longer needed, the backend sends a release message over ICMsg.
-* When the backend receives this message, it deallocates all blocks.
-  It is done internally by the backend and it is invisible to the caller.
+* When data is no longer needed, the receiver writes to the consumer queue the block index.
+* The sender is performing a garbage collection by reading the consumer queue and freeing the buffers.
+  Garbage collection is performed after sending any message or if there is no available buffers.
 
 Configuration
 =============
 
 The backend is configured using Kconfig and devicetree.
+
+There are following Kconfig options:
+
+:kconfig:option:`CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP` - maximum number of registered endpoints.
+
+:kconfig:option:`CONFIG_IPC_SERVICE_BACKEND_ICBMSG_MAX_ACTIVE_COUNT` - number of slots in the queues.
+
+:kconfig:option:`CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT` - support for deregistration and closing.
+
+:kconfig:option:`CONFIG_IPC_SERVICE_BACKEND_ICBMSG_SHELL` - support for the shell command.
+
 When configuring the backend, do the following:
 
 * If at least one of the cores uses data cache on shared memory, set the ``dcache-alignment`` value.
@@ -54,6 +78,15 @@ When configuring the backend, do the following:
     Make sure that you set correct value of the ``dcache-alignment``.
     At first, wrong value may not show any signs, which may give a false impression that everything works.
     Unstable behavior will appear sooner or later.
+
+If ``dcache-alignment`` is used then configuration for the number of blocks should be selected carefully to avoid inefficient usage of the memory.
+That is because the blocks are aligned to the cache alignment and if the number of blocks is not a multiple of the cache alignment then the last block will not be used efficiently.
+That is because the blocks and control data are aligned to the cache alignment.
+For example, if ``dcache-alignment`` is 32 and 1024 bytes of shared memory is used for one direction.
+Control data will take 64 bytes and 960 bytes are left for the buffers.
+Using 16 blocks will result in 32 bytes per block (due to the cache alignment).
+Using 15 blocks will result in 64 bytes per block (due to the cache alignment) with much better memory utilization.
+
 
 See the following configuration example for one of the instances:
 
@@ -76,7 +109,7 @@ See the following configuration example for one of the instances:
          tx-region = <&tx>;
          rx-region = <&rx>;
          tx-blocks = <16>;
-         rx-blocks = <32>;
+         rx-blocks = <16>;
          mboxes = <&mbox 0>, <&mbox 1>;
          mbox-names = "tx", "rx";
          status = "okay";
@@ -87,6 +120,12 @@ See the following configuration example for one of the instances:
 You must provide a similar configuration for the other side of the communication (domain or CPU).
 Swap the MBOX channels, memory regions (``tx-region`` and ``rx-region``), and block count (``tx-blocks`` and ``rx-blocks``).
 
+Limitations
+===========
+
+* Expected same endianness on both sides of the communication.
+* No support for detection of unexpected remote reset.
+
 Samples
 =======
 
@@ -96,7 +135,6 @@ Detailed Protocol Specification
 ===============================
 
 The ICBMsg protocol transfers messages using dynamically allocated blocks of shared memory.
-Internally, it uses ICMsg for control messages.
 
 Shared Memory Organization
 --------------------------
@@ -107,7 +145,7 @@ Those regions are interchanged on each core.
 
 Each shared memory region is divided into following two parts:
 
-* **ICMsg area** - An area reserved by ICMsg instance and used to transfer the control messages.
+* **Control area** - An area reserved by producer and consumer queues.
 * **Blocks area** - An area containing allocatable blocks carrying the content of the messages.
   This area is divided into even-sized blocks aligned to cache boundaries.
 
@@ -129,14 +167,14 @@ The algorithm:
    * ``region_end_aligned = ROUND_DOWN(region_end, alignment)``
    * ``region_size_aligned = region_end_aligned - region_begin_aligned``
 
-#. Calculate the minimum size required for ICMsg area ``icmsg_min_size``, which is a sum of:
+#. Calculate the minimum size required for the control area:
 
-   * ICMsg header size (refer to the ICMsg specification)
-   * ICMsg message size for 4 bytes of content (refer to the ICMsg specification) multiplied by ``local_blocks + remote_blocks + 2``
+   * for each queue there is :kconfig:option:`IPC_SERVICE_BACKEND_ICBMSG_MAX_ACTIVE_COUNT` bytes and 8 byte queue header.
+   * Typically control data takes less than 64 bytes per direction.
 
 #. Calculate available size for block area. Note that the actual size may be smaller because of block alignment:
 
-   ``blocks_area_available_size = region_size_aligned - icmsg_min_size``
+   ``blocks_area_available_size = region_size_aligned - control_area``
 
 #. Calculate single block size:
 
@@ -167,224 +205,68 @@ Message Transfer
 
 The ICBMsg uses following two types of messages:
 
-* **Binding message** - Message exchanged during endpoint binding process (described below).
-* **Data message** - Message carrying actual data from a user.
+* **Control message** - Messages like binding or unbinding.
+* **Data message** - Message carrying actual user data.
 
 They serve different purposes, but their lifetime and flow are the same.
 The following steps describe it:
 
 #. The sender wants to send a message that contains ``K`` bytes.
 #. The sender reserves blocks from his ``tx-region`` blocks area that can hold at least ``K + 4`` bytes.
-   The additional ``+ 4`` bytes are reserved for the header, which contains the exact size of the message.
+   The additional ``+ 4`` bytes are reserved for the header.
    The blocks must be continuous (one after another).
    The sender is responsible for block allocation management.
-   It is up to the implementation to decide what to do if no blocks are available.
-#. The sender fills the header with a 32-bit integer value, ``K`` (little-endian).
+   If blocks are not available then a thread context may block and an interrupt context will return error.
+#. The sender fills the header.
 #. The sender fills the remaining part of the blocks with his data.
    Unused space is ignored.
-#. The sender sends an ``MSG_DATA`` or ``MSG_BOUND`` control message over ICMsg that contains starting block number (where the header is located).
-   Details about the control message are in the next section.
-#. The control message travels to the receiver.
-#. The receiver reads message size and data from his ``rx-region`` starting from the block number received in the control message.
-#. The receiver processes the message.
-#. The receiver sends ``MSG_RELEASE_DATA`` or ``MSG_RELEASE_BOUND`` control message over ICMsg containing the starting block number
-   (the same as inside received control message).
-#. The control message travels back to the sender.
-#. The sender releases the blocks starting from the block number provided in the control message.
-   The number of blocks to release can be calculated using a size from the header.
+#. The sender writes the message to the producer queue and sends the mailbox signal.
+#. The receiver excutes mailbox callback in the mailbox interrupt context and reads the producer queue.
+#. The receiver reads the block index and locates the message within his ``rx-region``.
+#. The receiver reads the endpoint and message length and processes the message.
+#. The receiver consumes the message by writing its block index to the consumer queue.
+   The mailbox signal is not send.
+#. The sender checks consume queue after each sending or if sending fails.
+   Messages are read from the consumer queue and released to the pool.
 
 .. image:: icbmsg_message.svg
    :align: center
 
 |
 
-Control Messages
-----------------
-
-The control messages are transmitted over ICMsg.
-Each control message contains three bytes.
-The first byte tells what kind of message it is.
-
-The allocated size for ICMsg ensures that the maximum possible number of control messages will fit into its ring buffer,
-so sending over the ICMsg will never fail because of buffer overflow.
-
-MSG_DATA
-^^^^^^^^
-
-.. list-table::
-   :header-rows: 1
-
-   * - byte 0
-     - byte 1
-     - byte 2
-   * - MSG_DATA
-     - endpoint address
-     - block number
-   * - 0x00
-     - 0x00 ÷ 0xFD
-     - 0x00 ÷ N-1
-
-The ``MSG_DATA`` control message indicates that a new data message was sent.
-The data message starts with a header inside ``block number``.
-The data message was sent over the endpoint specified in ``endpoint address``.
-The endpoint binding procedure must be finished before sending this control message.
-
-MSG_RELEASE_DATA
-^^^^^^^^^^^^^^^^
-
-.. list-table::
-   :header-rows: 1
-
-   * - byte 0
-     - byte 1
-     - byte 2
-   * - MSG_RELEASE_DATA
-     - unused
-     - block number
-   * - 0x01
-     -
-     - 0x00 ÷ N-1
-
-The ``MSG_RELEASE_DATA`` control message is sent in response to ``MSG_DATA``.
-It informs us that the data message starting with ``block number`` was received and is no longer needed.
-When this control message is received, the blocks containing the message must be released.
-
-MSG_BOUND
-^^^^^^^^^
-
-.. list-table::
-   :header-rows: 1
-
-   * - byte 0
-     - byte 1
-     - byte 2
-   * - MSG_BOUND
-     - endpoint address
-     - block number
-   * - 0x02
-     - 0x00 ÷ 0xFD
-     - 0x00 ÷ N-1
-
-The ``MSG_BOUND`` control message is similar to the ``MSG_DATA`` except the blocks carry binding information.
-See the next section for details on the binding procedure.
-
-MSG_RELEASE_BOUND
-^^^^^^^^^^^^^^^^^
-
-.. list-table::
-   :header-rows: 1
-
-   * - byte 0
-     - byte 1
-     - byte 2
-   * - MSG_RELEASE_BOUND
-     - endpoint address
-     - block number
-   * - 0x03
-     - 0x00 ÷ 0xFD
-     - 0x00 ÷ N-1
-
-The ``MSG_RELEASE_BOUND`` control message is sent in response to ``MSG_BOUND``.
-It is similar to the ``MSG_RELEASE_DATA`` except the ``endpoint address`` is required.
-See the next section for details on the binding procedure.
-
-Initialization
---------------
-
-The ICBMsg initialization calls ICMsg to initialize.
-When it is done, no further initialization is required.
-Blocks can be left uninitialized.
-
-After ICBMsg initialization, you are ready for the endpoint binding procedure.
-
-Endpoint Binding
+Binding Instances
 -----------------
 
-So far, the protocol is symmetrical.
-Each side of the connection was the same.
-The binding process is not symmetrical.
-There are following two roles:
+When backend instance is opened it send bound message which contains a 64 bit magic number.
+Mailbox callback is enabled and instance is waiting for bound message.
+After receiving bound message, instance is bound to the remote instance and endpoints can be registered.
 
-* **Initiator** - It assigns endpoint addresses and sends binding messages.
-* **Follower** - It waits for a binding message.
+Binding Endpoint
+----------------
 
-The roles are determined based on the addresses of the ``rx-region`` and ``tx-region``.
+Endpoint binding message contains SHA of the endpoint name and endpoint ID which is the index in the local array with endpoint's data.
 
-* If ``address of rx-region < address of tx-region``, then it is initiator.
-* If ``address of rx-region > address of tx-region``, then it is follower.
+There are two possible scenarios:
 
-The binding process needs an endpoint name and is responsible for following two things:
+* The remote instance sent binding message for the endpoint before it was registered.
+* The endpoint is registered before receiving the binding message from the remote instance.
 
-* To establish a common endpoint address,
-* To make sure that two sides are ready to exchange messages over that endpoint.
+When the binding message is received then SHA is compared to the stored SHA in the array of endpoint's data.
+If match is found then it means that the endpoint is already registered by the local instance.
+Endpoint ID is stored in the endpoint's data and bound callback is called.
+If match is not found then empty slot is found and endpoint ID and SHA is stored in the available slot.
 
-After ICMsg is initialized, both sides can start the endpoint binding.
-There are no restrictions on the order in which the sides start the endpoint binding.
+When endpoint is registered then SHA for the name is calculated and compared to the stored SHA in the array of endpoint's data.
+If match is found then it means that remote binding message for that endpoint is already received.
+In this case binding message is sent to the remote instance and bound callback is called.
+If match is not found then empty slot is found and endpoint ID and SHA is stored in the available slot.
+Binding message is sent to the remote instance but endpoints are not bound yet.
 
-Initiator Binding Procedure
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Later on, remote endpoint ID is used for data message to identify the endpoint.
 
-The initiator sends a binding message.
-It contains a single null-terminated string with an endpoint name.
-As usual, it is preceded by a message header containing the message size (including null-terminator).
+Unbinding Endpoint
+------------------
 
-Example of the binding message for ``example`` endpoint name:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Header
-     - Endpoint name
-     - Null-terminator
-   * - bytes 0-3
-     - bytes 4-10
-     - byte 11
-   * - 0x00000008
-     - ``example``
-     - 0x00
-
-The binding message is sent using the ``MSG_BOUND`` control message and released with the ``MSG_RELEASE_BOUND`` control message.
-
-The endpoint binding procedure from the initiator's point of view is the following:
-
-#. The initiator assigns an endpoint address to this endpoint.
-#. The initiator sends a binding message containing the endpoint name and address.
-#. The initiator waits for any message from the follower using this endpoint address.
-   Usually, it will be ``MSG_RELEASE_BOUND``, but ``MSG_DATA`` is also allowed.
-#. The initiator is bound to an endpoint, and it can send data messages using this endpoint.
-
-Follower Binding Procedure
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If the follower receives a binding message before it starts the binding procedure on that endpoint, it should store the message for later.
-It should not send the ``MSG_RELEASE_BOUND`` yet.
-
-The endpoint binding procedure from the follower's point of view is the following:
-
-#. The follower waits for a binding message containing its endpoint name.
-   The message may be a newly received message or a message stored before the binding procedure started.
-#. The follower stores the endpoint address assigned to this endpoint by the initiator.
-#. The follower sends the ``MSG_RELEASE_BOUND`` control message.
-#. The follower is bound to an endpoint, and it can send data messages using this endpoint.
-
-Example sequence diagrams
--------------------------
-
-The following diagram shows a few examples of how the messages flow between two ends.
-There is a binding of two endpoints and one fully processed data message exchange.
-
-.. image:: icbmsg_flows.svg
-   :align: center
-
-|
-
-Protocol Versioning
--------------------
-
-The protocol allows improvements in future versions.
-The newer implementations should be able to work with older ones in backward compatible mode.
-To allow it, the current protocol version has the following restrictions:
-
-* If the receiver receives a longer control message, it should use only the first three bytes and ignore the remaining.
-* If the receiver receives a control message starting with a byte that does not match any of the messages described here, it should ignore it.
-* If the receiver receives a binding message with additional bytes at the end, it should ignore the additional bytes.
+When endpoint is unregistered then unbinding control message is sent.
+Endpoint is removed from the array of endpoint's data.
+When unbinding message is received then endpoint slot is marked as empty and unbinding callback is called.

--- a/dts/bindings/ipc/zephyr,ipc-icbmsg.yaml
+++ b/dts/bindings/ipc/zephyr,ipc-icbmsg.yaml
@@ -15,8 +15,12 @@ properties:
     description: number of allocable TX blocks
     required: true
     type: int
+    min: 1
+    max: 32
 
   rx-blocks:
     description: number of allocable RX blocks
     required: true
     type: int
+    min: 1
+    max: 32

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay
@@ -56,7 +56,7 @@
 			tx-region = <&sram_ipc1_tx>;
 			rx-region = <&sram_ipc1_rx>;
 			tx-blocks = <32>;
-			rx-blocks = <48>;
+			rx-blocks = <32>;
 			mboxes = <&mbox 2>, <&mbox 3>;
 			mbox-names = "tx", "rx";
 			status = "okay";

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -45,6 +45,6 @@ ipc1: &cpuapp_cpurad_ipc_b {
 	mbox-names = "rx", "tx";
 	tx-region = <&cpuapp_cpurad_ipc_shm_b>;
 	rx-region = <&cpurad_cpuapp_ipc_shm_b>;
-	tx-blocks = <32>;
-	rx-blocks = <32>;
+	tx-blocks = <15>;
+	rx-blocks = <15>;
 };

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/remote/boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/remote/boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay
@@ -50,7 +50,7 @@
 			compatible = "zephyr,ipc-icbmsg";
 			tx-region = <&sram_ipc1_tx>;
 			rx-region = <&sram_ipc1_rx>;
-			tx-blocks = <48>;
+			tx-blocks = <32>;
 			rx-blocks = <32>;
 			mboxes = <&mbox 2>, <&mbox 3>;
 			mbox-names = "rx", "tx";

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/remote/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/remote/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -45,6 +45,6 @@ ipc1: &cpuapp_cpurad_ipc_b {
 	mbox-names = "tx", "rx";
 	tx-region = <&cpurad_cpuapp_ipc_shm_b>;
 	rx-region = <&cpuapp_cpurad_ipc_shm_b>;
-	tx-blocks = <32>;
-	rx-blocks = <32>;
+	tx-blocks = <15>;
+	rx-blocks = <15>;
 };

--- a/subsys/ipc/ipc_service/backends/Kconfig.icbmsg
+++ b/subsys/ipc/ipc_service/backends/Kconfig.icbmsg
@@ -6,7 +6,8 @@ menuconfig IPC_SERVICE_BACKEND_ICBMSG
 	default y
 	depends on MBOX
 	depends on DT_HAS_ZEPHYR_IPC_ICBMSG_ENABLED
-	select IPC_SERVICE_ICMSG
+	select SYS_HASH_FUNC32
+	select SYS_HASH_FUNC32_DJB2
 	help
 	  Choosing this backend results in multi endpoint implementation based
 	  on dynamically allocated buffers. References to them are send over
@@ -23,13 +24,27 @@ config IPC_SERVICE_BACKEND_ICBMSG_NUM_EP
 	  backend. The number of endpoints are applied to all the instances,
 	  so this value should be maximum number among all the instances.
 
-config IPC_SERVICE_BACKEND_ICBMSG_EP_BOUND_WORK_Q_STACK_SIZE
-	int "Workqueue stack size"
-	default 1024 if NO_OPTIMIZATIONS
-	default 512
+config IPC_SERVICE_BACKEND_ICBMSG_MAX_ACTIVE_COUNT
+	int "Maximum number of active buffers"
+	range 16 32
+	default 16
 	help
-	  Workqueue stack size for bounding processing
-	  (this configuration is not optimized).
+	  Maximum number of concurrently active buffers in the message queues.
+
+config IPC_SERVICE_BACKEND_ICBMSG_DEINIT
+	bool "Support closing and deregistering endpoints"
+	help
+	  Enable support for closing and deregistering endpoints. Disabled by
+	  by default to reduce the code size.
+
+config IPC_SERVICE_BACKEND_ICBMSG_SHELL
+	bool "ICBMsg shell commands"
+	depends on SHELL
+	select STATS
+	select STATS_NAMES
+	help
+	  Enable shell commands for the ICBMsg IPC backend. When enabled,
+	  the "icbmsg stats" command prints human-readable IPC statistics.
 
 module = IPC_SERVICE_BACKEND_ICBMSG
 module-str = ICMSG backend with separate buffers

--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -8,83 +8,56 @@
  * ICBMsg backend.
  *
  * This is an IPC service backend that dynamically allocates buffers for data storage
- * and uses ICMsg to send references to them.
+ * and uses control queues to send references to them to the remote side.
  *
  * Shared memory organization
  * --------------------------
  *
- * Single channel (RX or TX) of the shared memory is divided into two areas: ICMsg area
- * followed by Blocks area. ICMsg is used to send and receive short 3-byte messages.
+ * Single channel (RX or TX) of the shared memory is divided into two areas: Control data area
+ * followed by Blocks area. Control data for each direction consists of two queues: producer and
+ * consumer. Producer queue is used to produce control messages to the remote side and it is
+ * written only by the TX side and read by the RX side. It contains information about location
+ * where pending messages starts (block index). Consumer queue is written by the RX side
+ * and read by the TX side. It contains information about messages that are already consumed.
  * Blocks area is evenly divided into aligned blocks. Blocks are used to allocate
  * buffers containing actual data. Data buffers can span multiple blocks. The first block
- * starts with the size of the following data.
+ * starts with the 4 byte header that contains size of the following data, 8 bit endpoint address
+ * and block index. Endpoint address 0xFF is reserved for control messages.
  *
- *  +------------+-------------+
- *  | ICMsg area | Blocks area |
- *  +------------+-------------+
- *       _______/               \_________________________________________
+ *  +--------------+-------------+
+ *  | Control area | Blocks area |
+ *  +--------------+-------------+
+ *       _____  __/               \_________________________________________
  *      /                                                                 \
  *      +-----------+-----------+-----------+-----------+-   -+-----------+
  *      |  Block 0  |  Block 1  |  Block 2  |  Block 3  | ... | Block N-1 |
  *      +-----------+-----------+-----------+-----------+-   -+-----------+
  *            _____/                                     \_____
  *           /                                                 \
- *           +------+--------------------------------+---------+
- *           | size | data_buffer[size] ...          | padding |
- *           +------+--------------------------------+---------+
+ *           +--------+--------------------------------+---------+
+ *           | header | data_buffer[size] ...          | padding |
+ *           +--------+--------------------------------+---------+
  *
- * The sender holds information about reserved blocks using bitarray and it is responsible
- * for allocating and releasing the blocks. The receiver just tells the sender that it
- * does not need a specific buffer anymore.
+ * The sender holds information about reserved blocks using a 32-bit bitmask and it is
+ * responsible for allocating and releasing the blocks. The receiver just tells the sender
+ * that it does not need a specific buffer anymore.
  *
- * Control messages
- * ----------------
+ * Backend supports up to 32 blocks and 255 endpoints. Produce and consume queues have configurable
+ * capacity which should be equal or smaller than the number of blocks.
  *
- * ICMsg is used to send and receive small 3-byte control messages.
- *
- *  - Send data
- *    | MSG_DATA | endpoint address | block index |
- *    This message is used to send data buffer to specific endpoint.
- *
- *  - Release data
- *    | MSG_RELEASE_DATA | 0 | block index |
- *    This message is a response to the "Send data" message and it is used to inform that
- *    specific buffer is not used anymore and can be released. Endpoint addresses does
- *    not matter here, so it is zero.
- *
- *  - Bound endpoint
- *    | MSG_BOUND | endpoint address | block index |
- *    This message starts the bounding of the endpoint. The buffer contains a
- *    null-terminated endpoint name.
- *
- *  - Release bound endpoint
- *    | MSG_RELEASE_BOUND | endpoint address | block index |
- *    This message is a response to the "Bound endpoint" message and it is used to inform
- *    that a specific buffer (starting at "block index") is not used anymore and
- *    a the endpoint is bounded and can now receive a data.
- *
- * Bounding endpoints
- * ------------------
- *
- * When ICMsg is bounded and user registers an endpoint on initiator side, the backend
- * sends "Bound endpoint". Endpoint address is assigned by the initiator. When follower
- * gets the message and user on follower side also registered the same endpoint,
- * the backend calls "bound" callback and sends back "Release bound endpoint".
- * The follower saves the endpoint address. The follower's endpoint is ready to send
- * and receive data. When the initiator gets "Release bound endpoint" message or any
- * data messages, it calls bound endpoint and it is ready to send data.
+ * Backend supports 2 priority levels. Normal priority (0) and high (1).
  */
 
-#undef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200809L /* For strnlen() */
-
+#include <stdint.h>
 #include <string.h>
 
 #include <zephyr/logging/log.h>
 #include <zephyr/device.h>
+#include <zephyr/drivers/mbox.h>
+#include <zephyr/stats/stats.h>
 #include <zephyr/sys/barrier.h>
-#include <zephyr/sys/bitarray.h>
-#include <zephyr/ipc/icmsg.h>
+#include <zephyr/sys/hash_function.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/ipc/ipc_service_backend.h>
 #include <zephyr/cache.h>
 
@@ -95,1199 +68,1247 @@
 #define MAYBE_CONST const
 #endif
 
-LOG_MODULE_REGISTER(ipc_icbmsg,
-		    CONFIG_IPC_SERVICE_BACKEND_ICBMSG_LOG_LEVEL);
+LOG_MODULE_REGISTER(ipc_icbmsg, CONFIG_IPC_SERVICE_BACKEND_ICBMSG_LOG_LEVEL);
+
+/** Size of the header (size field) of the block. */
+#define ICBMSG_BLOCK_HEADER_SIZE (sizeof(struct icbmsg_block_header))
 
 #define DT_DRV_COMPAT zephyr_ipc_icbmsg
+
+/** Required block alignment. */
+#define BLOCK_ALIGNMENT sizeof(uint32_t)
+
+/** Returns required data cache alignment for instance "i". */
+#define GET_CACHE_ALIGNMENT(i) DT_INST_PROP_OR(i, dcache_alignment, 4)
+
+#define MATCHING_CACHE_ALIGNMENT(i) (GET_CACHE_ALIGNMENT(i) == GET_CACHE_ALIGNMENT(0)) &&
+#if !(DT_INST_FOREACH_STATUS_OKAY(MATCHING_CACHE_ALIGNMENT) 1)
+#error "Cache alignment needs to be the same for all instances"
+#endif
 
 /** Allowed number of endpoints. */
 #define NUM_EPT CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP
 
-/** Special endpoint address indicating invalid (or empty) entry. */
-#define EPT_ADDR_INVALID 0xFF
+/** Special endpoint address for control messages. */
+#define EPT_CONTROL 0xFF
 
-/** Special value for empty entry in bound message waiting table. */
-#define WAITING_BOUND_MSG_EMPTY 0xFFFF
-
-/** Size of the header (size field) of the block. */
-#define BLOCK_HEADER_SIZE (sizeof(struct block_header))
-
-/** Flag indicating that ICMsg was bounded for this instance. */
-#define CONTROL_BOUNDED BIT(31)
-
-/** Registered endpoints count mask in flags. */
-#define FLAG_EPT_COUNT_MASK 0xFFFF
-
-/** Workqueue stack size for bounding processing (this configuration is not optimized). */
-#define EP_BOUND_WORK_Q_STACK_SIZE \
-	(CONFIG_IPC_SERVICE_BACKEND_ICBMSG_EP_BOUND_WORK_Q_STACK_SIZE)
-
-/** Workqueue priority for bounding processing. */
-#define EP_BOUND_WORK_Q_PRIORITY (CONFIG_SYSTEM_WORKQUEUE_PRIORITY)
-
+/** Control message types. */
 enum msg_type {
-	MSG_DATA = 0,		/* Data message. */
-	MSG_RELEASE_DATA,	/* Release data buffer message. */
-	MSG_BOUND,		/* Endpoint bounding message. */
-	MSG_RELEASE_BOUND,	/* Release endpoint bound message.
-				 * This message is also indicator for the receiving side
-				 * that the endpoint bounding was fully processed on
-				 * the sender side.
-				 */
+	MSG_EP_BOUND,   /* Endpoint bounding message. */
+	MSG_EP_UNBOUND, /* Endpoint unbounding message. */
 };
 
-enum ept_bounding_state {
-	EPT_UNCONFIGURED = 0,	/* Endpoint in not configured (initial state). */
-	EPT_CONFIGURED,		/* Endpoint is configured, waiting for work queue to
-				 * start bounding process.
-				 */
-	EPT_BOUNDING,		/* Only on initiator. Bound message was send,
-				 * but bound callback was not called yet, because
-				 * we are waiting for any incoming messages.
-				 */
-	EPT_READY,		/* Bounding is done. Bound callback was called. */
+/** Instance states. */
+enum state {
+	STATE_IDLE = 0,
+	STATE_CONNECTING,
+	STATE_CONNECTED,
 };
 
-enum ept_rebound_state {
-	EPT_NORMAL = 0,		/* No endpoint rebounding is needed. */
-	EPT_DEREGISTERED,	/* Endpoint was deregistered. */
-	EPT_REBOUNDING,		/* Rebounding was requested, waiting for work queue to
-				 * start rebounding process.
-				 */
+/** Endpoint states. */
+enum ept_state {
+	EPT_UNBOUND = 0,
+	EPT_READY,
 };
 
-struct channel_config {
-	uint8_t *blocks_ptr;	/* Address where the blocks start. */
-	size_t block_size;	/* Size of one block. */
-	size_t block_count;	/* Number of blocks. */
+/** Maximum number of active messages in the message queue (number of slots). */
+#define MAX_ACTIVE_COUNT CONFIG_IPC_SERVICE_BACKEND_ICBMSG_MAX_ACTIVE_COUNT
+
+/** Bit field used to mark high priority messages. */
+#define HI_PRIO_MASK BIT(7)
+
+/** Padding size to align the message queue to the cache alignment. */
+#define SHM_PADDING_SIZE                                                                           \
+	GET_CACHE_ALIGNMENT(0) > sizeof(uint32_t)                                                  \
+		? ((GET_CACHE_ALIGNMENT(0) -                                                       \
+		    (MAX_ACTIVE_COUNT + sizeof(struct icbmsg_shm_q_hdr))) %                        \
+		   GET_CACHE_ALIGNMENT(0))                                                         \
+		: 0
+
+/** Message queue header. */
+struct icbmsg_shm_q_hdr {
+	uint32_t block_idx;
+	uint32_t hi_prio_cnt;
+};
+
+/** Message queue. */
+struct icbmsg_shm_q {
+	struct icbmsg_shm_q_hdr hdr;
+	uint8_t slots[MAX_ACTIVE_COUNT];
+	uint8_t padding[SHM_PADDING_SIZE];
+};
+
+BUILD_ASSERT(sizeof(struct icbmsg_shm_q) % GET_CACHE_ALIGNMENT(0) == 0);
+
+STATS_SECT_START(icbmsg_stats)
+STATS_SECT_ENTRY32(tx_packet_block1_count)
+STATS_SECT_ENTRY32(tx_packet_block2_count)
+STATS_SECT_ENTRY32(tx_packet_block_more_count)
+STATS_SECT_ENTRY32(tx_packet_count)
+STATS_SECT_ENTRY32(tx_alloc_failed_count)
+STATS_SECT_ENTRY32(tx_data_count)
+STATS_SECT_ENTRY32(tx_max_active_count)
+STATS_SECT_ENTRY32(tx_curr_block_usage_count)
+STATS_SECT_ENTRY32(tx_max_block_usage_count)
+STATS_SECT_ENTRY32(rx_packet_count)
+STATS_SECT_ENTRY32(rx_data_count)
+STATS_SECT_END;
+
+STATS_NAME_START(icbmsg_stats)
+STATS_NAME(icbmsg_stats, tx_packet_block1_count)
+STATS_NAME(icbmsg_stats, tx_packet_block2_count)
+STATS_NAME(icbmsg_stats, tx_packet_block_more_count)
+STATS_NAME(icbmsg_stats, tx_packet_count)
+STATS_NAME(icbmsg_stats, tx_alloc_failed_count)
+STATS_NAME(icbmsg_stats, tx_data_count)
+STATS_NAME(icbmsg_stats, tx_max_active_count)
+STATS_NAME(icbmsg_stats, tx_curr_block_usage_count)
+STATS_NAME(icbmsg_stats, tx_max_block_usage_count)
+STATS_NAME(icbmsg_stats, rx_packet_count)
+STATS_NAME(icbmsg_stats, rx_data_count)
+STATS_NAME_END(icbmsg_stats);
+
+/** Message queue configuration for a single direction. */
+struct icbmsg_msg_q_config {
+	volatile struct icbmsg_shm_q *prod_shmq;
+	volatile struct icbmsg_shm_q *cons_shmq;
+};
+
+/** Local message queue data. */
+struct icbmsg_msg_q_data {
+	uint32_t tx_active_count;
+	volatile uint32_t tx_local_cons_idx;
+	volatile uint32_t rx_local_prod_idx;
+	volatile uint32_t rx_local_hi_prio_cnt;
+};
+
+/** Bound packet. */
+struct icbmsg_bound_packet {
+	uint32_t magic[2];
+	uint32_t buf_count[2];
+};
+
+/** Endpoint bound packet. */
+struct icbmsg_ep_bound_packet {
+	uint8_t ept_addr;
+	uint32_t name_hash;
+} __packed;
+
+/** Endpoint unbound packet. */
+struct icbmsg_ep_unbound_packet {
+	uint8_t ept_addr;
+} __packed;
+
+/** Control packet. */
+struct icbmsg_control_packet {
+	uint8_t msg_type;
+	union {
+		struct icbmsg_ep_bound_packet bound;
+		struct icbmsg_ep_unbound_packet unbound;
+	} data;
+};
+
+/** Bound packet magic values. */
+#define BOUND_PACKET_MAGIC_VALUE1 0x456789AB
+#define BOUND_PACKET_MAGIC_VALUE2 0xAB896745
+
+/** Initialize bound packet. */
+#define BOUND_PACKET_INIT(buf_count1, buf_count2)                                                  \
+	{                                                                                          \
+		.magic = {BOUND_PACKET_MAGIC_VALUE1, BOUND_PACKET_MAGIC_VALUE2},                   \
+		.buf_count = {buf_count1, buf_count2},                                             \
+	}
+
+/** Block header. */
+struct icbmsg_block_header {
+	/** Size of the following data. */
+	uint16_t size;
+	/** Block index. */
+	uint8_t index;
+	/** Endpoint address. */
+	uint8_t ept;
+};
+
+/** Packet. */
+struct icbmsg_packet {
+	/** Block header. */
+	struct icbmsg_block_header header;
+	/** Data. */
+	uint8_t data[];
+};
+
+/** Buffer heap. */
+struct icbmsg_buf_heap {
+	/** Blocks pointer. */
+	uint8_t *blocks_ptr;
+	/** Block size. */
+	size_t block_size;
+	/** Block count. */
+	size_t block_count;
 };
 
 struct icbmsg_config {
-	struct icmsg_config_t control_config;	/* Configuration of the ICMsg. */
-	struct channel_config rx;		/* RX channel config. */
-	struct channel_config tx;		/* TX channel config. */
-	sys_bitarray_t *tx_usage_bitmap;	/* Bit is set when TX block is in use */
-	sys_bitarray_t *rx_hold_bitmap;		/* Bit is set, if the buffer starting at
-						 * this block should be kept after exit
-						 * from receive handler.
-						 */
+	/** Mailbox specification for TX. */
+	struct mbox_dt_spec mbox_tx;
+	/** Mailbox specification for RX. */
+	struct mbox_dt_spec mbox_rx;
+	/** RX buffer heap. */
+	struct icbmsg_buf_heap rx;
+	/** TX buffer heap. */
+	struct icbmsg_buf_heap tx;
+	/** TX message queue configuration. */
+	struct icbmsg_msg_q_config tx_msg_q;
+	/** RX message queue configuration. */
+	struct icbmsg_msg_q_config rx_msg_q;
+	/** Bound packet. */
+	struct icbmsg_bound_packet bound_packet;
+#ifdef CONFIG_STATS
+	/** Statistics name. */
+	const char *stats_name;
+#endif
 };
 
 struct ept_data {
-	const struct ipc_ept_cfg *cfg;	/* Endpoint configuration. */
-	atomic_t state;			/* Bounding state. */
-	atomic_t rebound_state;		/* Rebounding state. */
-	uint8_t addr;			/* Endpoint address. */
+	/** Endpoint configuration. */
+	const struct ipc_ept_cfg *cfg;
+	/** Name hash. */
+	uint32_t name_hash;
+	/** Bounding state. */
+	uint8_t state;
+	/** Endpoint address. */
+	uint8_t addr;
 };
 
-struct backend_data {
-	const struct icbmsg_config *conf;/* Backend instance config. */
-	struct icmsg_data_t control_data;/* ICMsg data. */
+struct icbmsg_data {
+	/** Current RX packet. */
+	struct icbmsg_packet *rx_packet;
+	/** Message queue data. */
+	struct icbmsg_msg_q_data msg_q;
+	/** TX usage mask. */
+	atomic_t tx_usage_mask;
+	/** Lock. */
+	struct k_spinlock lock;
+	/** Statistics. */
+	STATS_SECT_DECL(icbmsg_stats) stats;
 #ifdef CONFIG_MULTITHREADING
-	struct k_mutex mutex;		/* Mutex to protect: ICMsg send call and
-					 * waiting_bound field.
-					 */
-	struct k_work ep_bound_work;	/* Work item for bounding processing. */
-	struct k_sem block_wait_sem;	/* Semaphore for waiting for free blocks. */
+	/** Block wait semaphore. */
+	struct k_sem block_wait_sem;
 #endif
-	struct ept_data ept[NUM_EPT];	/* Array of registered endpoints. */
-	uint8_t ept_map[NUM_EPT];	/* Array that maps endpoint address to index. */
-	uint16_t waiting_bound[NUM_EPT];/* The bound messages waiting to be registered. */
-	atomic_t flags;			/* Flags on higher bits, number of registered
-					 * endpoints on lower.
-					 */
-	bool is_initiator;		/* This side has an initiator role. */
+	struct ept_data ept[NUM_EPT];
+	/** Endpoint count. */
+	size_t ep_cnt;
+	/** State. */
+	uint8_t state;
 };
 
-struct block_header {
-	volatile size_t size;	/* Size of the data field. It must be volatile, because
-				 * when this value is read and validated for security
-				 * reasons, compiler cannot generate code that reads
-				 * it again after validation.
-				 */
-};
+BUILD_ASSERT(NUM_EPT <= EPT_CONTROL, "Too many endpoints");
 
-struct block_content {
-	struct block_header header;
-	uint8_t data[];		/* Buffer data. */
-};
+/** Cache flush. */
+#define MSG_QUEUE_CACHE_FLUSH(shmq)                                                                \
+	do {                                                                                       \
+		sys_cache_data_flush_range((void *)shmq, sizeof(*shmq));                           \
+		compiler_barrier();                                                                \
+	} while (0)
 
-struct control_message {
-	uint8_t msg_type;	/* Message type. */
-	uint8_t ept_addr;	/* Endpoint address or zero for MSG_RELEASE_DATA. */
-	uint8_t block_index;	/* Block index to send or release. */
-};
+/** Cache invalidate. */
+#define MSG_QUEUE_CACHE_INV(shmq)                                                                  \
+	do {                                                                                       \
+		sys_cache_data_invd_range((void *)shmq, sizeof(*shmq));                            \
+		compiler_barrier();                                                                \
+	} while (0)
 
-BUILD_ASSERT(NUM_EPT <= EPT_ADDR_INVALID, "Too many endpoints");
-
-#ifdef CONFIG_MULTITHREADING
-/* Work queue for bounding processing. */
-static struct k_work_q ep_bound_work_q;
-#endif
-
-/**
- * Calculate pointer to block from its index and channel configuration (RX or TX).
- * No validation is performed.
- */
-static struct block_content *block_from_index(const struct channel_config *ch_conf,
-					      size_t block_index)
+static inline struct icbmsg_packet *heap_packet_from_index(const struct icbmsg_buf_heap *heap,
+							   size_t block_index)
 {
-	return (struct block_content *)(ch_conf->blocks_ptr +
-					block_index * ch_conf->block_size);
+	return (struct icbmsg_packet *)(heap->blocks_ptr + block_index * heap->block_size);
 }
 
-/**
- * Calculate pointer to data buffer from block index and channel configuration (RX or TX).
- * Also validate the index and optionally the buffer size allocated on the this block.
- *
- * @param[in]  ch_conf		The channel
- * @param[in]  block_index	Block index
- * @param[out] size		Size of the buffer allocated on the block if not NULL.
- *				The size is also checked if it fits in the blocks area.
- *				If it is NULL, no size validation is performed.
- * @param[in]  invalidate_cache	If size is not NULL, invalidates cache for entire buffer
- *				(all blocks). Otherwise, it is ignored.
- * @return	Pointer to data buffer or NULL if validation failed.
- */
-static uint8_t *buffer_from_index_validate(const struct channel_config *ch_conf,
-					   size_t block_index, size_t *size,
-					   bool invalidate_cache)
+static inline struct icbmsg_packet *heap_packet_from_data(const void *data)
 {
-	size_t allocable_size;
-	size_t buffer_size;
-	uint8_t *end_ptr;
-	struct block_content *block;
-
-	if (block_index >= ch_conf->block_count) {
-		LOG_ERR("Block index invalid");
-		return NULL;
-	}
-
-	block = block_from_index(ch_conf, block_index);
-
-	if (size != NULL) {
-		if (invalidate_cache) {
-			sys_cache_data_invd_range(block, BLOCK_HEADER_SIZE);
-			barrier_sync_synchronize();
-		}
-		allocable_size = ch_conf->block_count * ch_conf->block_size;
-		end_ptr = ch_conf->blocks_ptr + allocable_size;
-		buffer_size = block->header.size;
-
-		if ((buffer_size > allocable_size - BLOCK_HEADER_SIZE) ||
-		    (&block->data[buffer_size] > end_ptr)) {
-			LOG_ERR("Block corrupted");
-			return NULL;
-		}
-
-		*size = buffer_size;
-		if (invalidate_cache) {
-			sys_cache_data_invd_range(block->data, buffer_size);
-			barrier_sync_synchronize();
-		}
-	}
-
-	return block->data;
+	return CONTAINER_OF(data, struct icbmsg_packet, data);
 }
 
-/**
- * Calculate block index based on data buffer pointer and validate it.
- *
- * @param[in]  ch_conf		The channel
- * @param[in]  buffer		Pointer to data buffer
- * @param[out] size		Size of the allocated buffer if not NULL.
- *				The size is also checked if it fits in the blocks area.
- *				If it is NULL, no size validation is performed.
- * @return		Block index or negative error code
- * @retval -EINVAL	The buffer is not correct
- */
-static int buffer_to_index_validate(const struct channel_config *ch_conf,
-				    const uint8_t *buffer, size_t *size)
+static inline size_t heap_max_data_size(const struct icbmsg_buf_heap *heap)
 {
-	size_t block_index;
-	uint8_t *expected;
-
-	block_index = (buffer - ch_conf->blocks_ptr) / ch_conf->block_size;
-
-	expected = buffer_from_index_validate(ch_conf, block_index, size, false);
-
-	if (expected == NULL || expected != buffer) {
-		LOG_ERR("Pointer invalid");
-		return -EINVAL;
-	}
-
-	return block_index;
+	return heap->block_size * heap->block_count - ICBMSG_BLOCK_HEADER_SIZE;
 }
 
-/**
- * Allocate buffer for transmission
- *
- * @param[in,out] size	Required size of the buffer. If set to zero, the first available block will
- *			be allocated, together with all contiguous free blocks that follow it.
- *			On success, size will contain the actually allocated size, which will be
- *			at least the requested size.
- * @param[out] buffer	Pointer to the newly allocated buffer.
- * @param[in] timeout	Timeout.
- *
- * @return		Positive index of the first allocated block or negative error.
- * @retval -ENOMEM	If requested size is bigger than entire allocable space, or
- *			the timeout was K_NO_WAIT and there was not enough space.
- * @retval -EAGAIN	If timeout occurred.
- */
-static int alloc_tx_buffer(struct backend_data *dev_data, uint32_t *size,
-			   uint8_t **buffer, k_timeout_t timeout)
+static struct icbmsg_packet *heap_get_packet(const struct icbmsg_buf_heap *heap, size_t blk_idx)
 {
-	const struct icbmsg_config *conf = dev_data->conf;
-	size_t total_size = *size + BLOCK_HEADER_SIZE;
-	size_t num_blocks = DIV_ROUND_UP(total_size, conf->tx.block_size);
-	struct block_content *block;
-#ifdef CONFIG_MULTITHREADING
-	bool sem_taken = false;
+	size_t packet_size;
+	size_t packet_blk_cnt;
+	struct icbmsg_packet *packet;
+
+	__ASSERT_NO_MSG(blk_idx < heap->block_count);
+
+	packet = heap_packet_from_index(heap, blk_idx);
+	sys_cache_data_invd_range(packet, ICBMSG_BLOCK_HEADER_SIZE);
+	compiler_barrier();
+
+	packet_size = packet->header.size;
+	packet_blk_cnt = DIV_ROUND_UP(packet_size + ICBMSG_BLOCK_HEADER_SIZE, heap->block_size);
+	(void)packet_blk_cnt;
+	__ASSERT_NO_MSG(blk_idx + packet_blk_cnt <= heap->block_count);
+
+	sys_cache_data_invd_range(packet->data, packet_size);
+	compiler_barrier();
+
+	return packet;
+}
+
+static int heap_free_blocks(const struct device *instance, size_t block_index, size_t block_count)
+{
+	struct icbmsg_data *data = instance->data;
+	uint32_t mask = BIT_MASK(block_count) << block_index;
+	atomic_val_t old;
+	int rv = 0;
+
+#ifdef CONFIG_STATS
+	k_spinlock_key_t key = k_spin_lock(&data->lock);
 #endif
-	size_t tx_block_index;
-	size_t next_bit;
-	int prev_bit_val;
-	int r;
-
+	old = atomic_and(&data->tx_usage_mask, ~mask);
+	if (!(old & mask)) {
+		rv = -EALREADY;
+	} else {
 #ifdef CONFIG_MULTITHREADING
-	do {
-		/* Try to allocate specified number of blocks. */
-		r = sys_bitarray_alloc(conf->tx_usage_bitmap, num_blocks,
-				       &tx_block_index);
-		if (r == -ENOSPC && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
-			/* Wait for releasing if there is no enough space and exit loop
-			 * on timeout.
-			 */
-			r = k_sem_take(&dev_data->block_wait_sem, timeout);
-			if (r < 0) {
-				break;
-			}
-			sem_taken = true;
-		} else {
-			/* Exit loop if space was allocated or other error occurred. */
-			break;
-		}
-	} while (true);
-
-	/* If semaphore was taken, give it back because this thread does not
-	 * necessary took all available space, so other thread may need it.
-	 */
-	if (sem_taken) {
-		k_sem_give(&dev_data->block_wait_sem);
+		k_sem_give(&data->block_wait_sem);
+#endif
+		STATS_INCN(data->stats, tx_curr_block_usage_count, -block_count);
 	}
-#else
-	/* Try to allocate specified number of blocks. */
-	r = sys_bitarray_alloc(conf->tx_usage_bitmap, num_blocks, &tx_block_index);
+#ifdef CONFIG_STATS
+	k_spin_unlock(&data->lock, key);
 #endif
 
-	if (r < 0) {
-		if (r != -ENOSPC && r != -EAGAIN) {
-			LOG_ERR("Failed to allocate buffer, err: %d", r);
-			/* Only -EINVAL is allowed in this place. Any other code
-			 * indicates something wrong with the logic.
-			 */
-			__ASSERT_NO_MSG(r == -EINVAL);
-		}
-
-		if (r == -ENOSPC || r == -EINVAL) {
-			/* IPC service require -ENOMEM error in case of no memory. */
-			r = -ENOMEM;
-		}
-		return r;
-	}
-
-	/* If size is 0 try to allocate more blocks after already allocated. */
-	if (*size == 0) {
-		prev_bit_val = 0;
-		for (next_bit = tx_block_index + 1; next_bit < conf->tx.block_count;
-		     next_bit++) {
-			r = sys_bitarray_test_and_set_bit(conf->tx_usage_bitmap, next_bit,
-							  &prev_bit_val);
-			/** Setting bit should always success. */
-			__ASSERT_NO_MSG(r == 0);
-			if (prev_bit_val) {
-				break;
-			}
-		}
-		num_blocks = next_bit - tx_block_index;
-	}
-
-	/* Get block pointer and adjust size to actually allocated space. */
-	*size = conf->tx.block_size * num_blocks - BLOCK_HEADER_SIZE;
-	block = block_from_index(&conf->tx, tx_block_index);
-	block->header.size = *size;
-	*buffer = block->data;
-	return tx_block_index;
+	return rv;
 }
 
-/**
- * Release all or part of the blocks occupied by the buffer.
- *
- * @param[in] tx_block_index	First block index to release, no validation is performed,
- *				so caller is responsible for passing valid index.
- * @param[in] size		Size of data buffer, no validation is performed,
- *				so caller is responsible for passing valid size.
- * @param[in] new_size		If less than zero, release all blocks, otherwise reduce
- *				size to this value and update size in block header.
- *
- * @returns		Positive block index where the buffer starts or negative error.
- * @retval -EINVAL	If invalid buffer was provided or size is greater than already
- *			allocated size.
- */
-static int release_tx_blocks(struct backend_data *dev_data, size_t tx_block_index,
-			     size_t size, int new_size)
+static int heap_free(const struct device *instance, struct icbmsg_packet *packet)
 {
-	const struct icbmsg_config *conf = dev_data->conf;
-	struct block_content *block;
-	size_t num_blocks;
-	size_t total_size;
+	const struct icbmsg_config *config = instance->config;
+	size_t block_count =
+		DIV_ROUND_UP(packet->header.size + ICBMSG_BLOCK_HEADER_SIZE, config->tx.block_size);
+
+	return heap_free_blocks(instance, packet->header.index, block_count);
+}
+
+static void icbmsg_heap_downsize(const struct device *instance, struct icbmsg_packet *packet,
+				 size_t new_size)
+{
+	const struct icbmsg_config *config = instance->config;
 	size_t new_total_size;
 	size_t new_num_blocks;
-	size_t release_index;
-	int r;
+	size_t prev_total_size;
+	size_t prev_num_blocks;
+	size_t index;
+	size_t count;
+	size_t size = packet->header.size;
 
-	/* Calculate number of blocks. */
-	total_size = size + BLOCK_HEADER_SIZE;
-	num_blocks = DIV_ROUND_UP(total_size, conf->tx.block_size);
+	packet->header.size = new_size;
+	if (size == new_size) {
+		return;
+	}
 
-	if (new_size >= 0) {
-		/* Calculate and validate new values. */
-		new_total_size = new_size + BLOCK_HEADER_SIZE;
-		new_num_blocks = DIV_ROUND_UP(new_total_size, conf->tx.block_size);
-		if (new_num_blocks > num_blocks) {
-			LOG_ERR("Requested %d blocks, allocated %d", new_num_blocks,
-				num_blocks);
-			return -EINVAL;
-		}
-		/* Update actual buffer size and number of blocks to release. */
-		block = block_from_index(&conf->tx, tx_block_index);
-		block->header.size = new_size;
-		release_index = tx_block_index + new_num_blocks;
-		num_blocks = num_blocks - new_num_blocks;
+	__ASSERT_NO_MSG(size > new_size);
+
+	prev_total_size = size + ICBMSG_BLOCK_HEADER_SIZE;
+	new_total_size = new_size + ICBMSG_BLOCK_HEADER_SIZE;
+	prev_num_blocks = DIV_ROUND_UP(prev_total_size, config->tx.block_size);
+	new_num_blocks = DIV_ROUND_UP(new_total_size, config->tx.block_size);
+	if (prev_num_blocks == new_num_blocks) {
+		return;
+	}
+
+	index = packet->header.index + new_num_blocks;
+	count = prev_num_blocks - new_num_blocks;
+
+	(void)heap_free_blocks(instance, index, count);
+}
+
+static void alloc_tx_stats_update(const struct device *instance, size_t num_blocks)
+{
+#ifdef CONFIG_STATS
+	struct icbmsg_data *data = instance->data;
+#endif
+
+	STATS_INCN(data->stats, tx_curr_block_usage_count, num_blocks);
+	STATS_SET(data->stats, tx_max_block_usage_count,
+		  MAX(data->stats.tx_max_block_usage_count,
+		      data->stats.tx_curr_block_usage_count));
+
+	if (num_blocks == 1) {
+		STATS_INC(data->stats, tx_packet_block1_count);
+	} else if (num_blocks == 2) {
+		STATS_INC(data->stats, tx_packet_block2_count);
 	} else {
-		/* If size is negative, release all blocks. */
-		release_index = tx_block_index;
+		STATS_INC(data->stats, tx_packet_block_more_count);
+	}
+}
+
+/** @brief Allocate a TX buffer from the heap.
+ *
+ * Allocator is using a bit mask which maps to N fixed size blocks. Requested buffer is
+ * allocated by finding the first gap in the bit mask that represents adjacent free blocks
+ * big enough to fit the requested size.
+ *
+ * @param[in] instance	Instance pointer.
+ * @param[in] ept	Endpoint pointer.
+ * @param[in] size	Size of the data to send.
+ * @param[out] packet	Pointer to the allocated packet.
+ * @param[in] timeout	Timeout.
+ *
+ * @return size of the allocated buffer, negative error code on failure.
+ */
+static int heap_alloc_tx_buffer(const struct device *instance, struct ept_data *ept, size_t size,
+				struct icbmsg_packet **packet, k_timeout_t timeout)
+{
+	const struct icbmsg_config *config = instance->config;
+	struct icbmsg_data *data = instance->data;
+	size_t num_blocks;
+	size_t block_index = 0;
+	bool max_size = size == 0;
+
+	if ((ept != NULL) && (ept->state != EPT_READY)) {
+		LOG_ERR("Endpoint %d is not ready", ept->addr);
+		return -ENOENT;
 	}
 
-	if (num_blocks > 0) {
-		/* Free bits in the bitmap. */
-		r = sys_bitarray_free(conf->tx_usage_bitmap, num_blocks,
-				      release_index);
-		if (r < 0) {
-			LOG_ERR("Cannot free bits, err %d", r);
-			return -EALREADY;
+	if (unlikely(max_size)) {
+		num_blocks = config->tx.block_count;
+	} else {
+		num_blocks = DIV_ROUND_UP(size + ICBMSG_BLOCK_HEADER_SIZE, config->tx.block_size);
+	}
+
+	while (true) {
+		int off;
+
+		K_SPINLOCK(&data->lock) {
+			off = bitmask_find_gap(data->tx_usage_mask, num_blocks,
+					       config->tx.block_count, false);
+			if (off >= 0) {
+				data->tx_usage_mask |= BIT_MASK(num_blocks) << off;
+				block_index = off;
+				alloc_tx_stats_update(instance, num_blocks);
+			}
+		}
+		/* Successfully allocated blocks. */
+		if (off >= 0) {
+			break;
 		}
 
+		if (max_size) {
+			num_blocks--;
+			if (num_blocks > 0) {
+				continue;
+			}
+		}
 #ifdef CONFIG_MULTITHREADING
-		/* Wake up all waiting threads. */
-		k_sem_give(&dev_data->block_wait_sem);
+		if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) && !k_is_in_isr() && !k_is_pre_kernel() &&
+		    (k_sem_take(&data->block_wait_sem, timeout) == 0)) {
+			continue;
+		}
 #endif
+		K_SPINLOCK(&data->lock) {
+			STATS_INC(data->stats, tx_alloc_failed_count);
+		}
+		return -ENOMEM;
 	}
 
-	return tx_block_index;
+	*packet = heap_packet_from_index(&config->tx, block_index);
+	(*packet)->header.index = block_index;
+	(*packet)->header.size = config->tx.block_size * num_blocks - ICBMSG_BLOCK_HEADER_SIZE;
+	(*packet)->header.ept = ept == NULL ? EPT_CONTROL : ept->addr;
+
+	return (*packet)->header.size;
 }
 
-/**
- * Release all or part of the blocks occupied by the buffer.
- *
- * @param[in] buffer	Buffer to release.
- * @param[in] new_size	If less than zero, release all blocks, otherwise reduce size to
- *			this value and update size in block header.
- *
- * @returns		Positive block index where the buffer starts or negative error.
- * @retval -EINVAL	If invalid buffer was provided or size is greater than already
- *			allocated size.
- */
-static int release_tx_buffer(struct backend_data *dev_data, const uint8_t *buffer,
-			     int new_size)
+static void msg_q_reset(const struct device *instance)
 {
-	const struct icbmsg_config *conf = dev_data->conf;
-	size_t size = 0;
-	int tx_block_index;
+	struct icbmsg_data *data = instance->data;
+	const struct icbmsg_config *config = instance->config;
 
-	tx_block_index = buffer_to_index_validate(&conf->tx, buffer, &size);
-	if (tx_block_index < 0) {
-		return tx_block_index;
+	if (IS_ENABLED(CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT)) {
+		data->msg_q.tx_active_count = 0;
+		data->msg_q.tx_local_cons_idx = 0;
+		data->msg_q.rx_local_prod_idx = 0;
+		data->msg_q.rx_local_hi_prio_cnt = 0;
 	}
 
-	return release_tx_blocks(dev_data, tx_block_index, size, new_size);
+	config->tx_msg_q.prod_shmq->hdr.block_idx = 0;
+	config->tx_msg_q.prod_shmq->hdr.hi_prio_cnt = 0;
+	config->rx_msg_q.cons_shmq->hdr.block_idx = 0;
+	config->rx_msg_q.cons_shmq->hdr.hi_prio_cnt = 0;
+
+	MSG_QUEUE_CACHE_FLUSH(config->tx_msg_q.prod_shmq);
+	MSG_QUEUE_CACHE_FLUSH(config->rx_msg_q.cons_shmq);
 }
 
-/**
- * Send control message over ICMsg with mutex locked. Mutex must be locked because
- * ICMsg may return error on concurrent invocations even when there is enough space
- * in queue.
+/** @brief Consume a block from the message queue.
+ *
+ * Update the consumer queue and flush cache.
+ *
+ * @param[in] instance		Instance pointer.
+ * @param[in] block_index	Block index to consume.
+ * @return 0 on success, negative error code on failure.
  */
-static int send_control_message(struct backend_data *dev_data, enum msg_type msg_type,
-				uint8_t ept_addr, uint8_t block_index)
+static int msg_q_consume(const struct device *instance, uint8_t block_index)
 {
-	const struct icbmsg_config *conf = dev_data->conf;
-	const struct control_message message = {
-		.msg_type = (uint8_t)msg_type,
-		.ept_addr = ept_addr,
-		.block_index = block_index,
-	};
-	int r;
+	const struct icbmsg_config *config = instance->config;
+	struct icbmsg_data *data = instance->data;
+	uint8_t idx;
 
-#ifdef CONFIG_MULTITHREADING
-	k_mutex_lock(&dev_data->mutex, K_FOREVER);
-#endif
-	r = icmsg_send(&conf->control_config, &dev_data->control_data, &message,
-		       sizeof(message));
-#ifdef CONFIG_MULTITHREADING
-	k_mutex_unlock(&dev_data->mutex);
-#endif
-	if (r < sizeof(message)) {
-		LOG_ERR("Cannot send over ICMsg, err %d", r);
+	K_SPINLOCK(&data->lock) {
+		idx = config->rx_msg_q.cons_shmq->hdr.block_idx % MAX_ACTIVE_COUNT;
+		config->rx_msg_q.cons_shmq->slots[idx] = block_index;
+		config->rx_msg_q.cons_shmq->hdr.block_idx++;
+		LOG_DBG("%p Consume index: %d, block_index: %d, %p",
+			(void *)config->rx_msg_q.cons_shmq, idx,
+			config->rx_msg_q.cons_shmq->hdr.block_idx,
+			(void *)&config->rx_msg_q.cons_shmq->slots[idx]);
 	}
-	return r;
+	MSG_QUEUE_CACHE_FLUSH(config->rx_msg_q.cons_shmq);
+
+	return 0;
 }
 
-/**
- * Release received buffer. This function will just send release control message.
- *
- * @param[in] buffer	Buffer to release.
- * @param[in] msg_type	Message type: MSG_RELEASE_BOUND or MSG_RELEASE_DATA.
- * @param[in] ept_addr	Endpoint address or zero for MSG_RELEASE_DATA.
- *
- * @return	zero or ICMsg send error.
- */
-static int send_release(struct backend_data *dev_data, const uint8_t *buffer,
-			enum msg_type msg_type, uint8_t ept_addr)
+static void msg_q_garbage_collect(const struct device *instance)
 {
-	const struct icbmsg_config *conf = dev_data->conf;
-	int rx_block_index;
+	struct icbmsg_data *data = instance->data;
+	const struct icbmsg_config *config = instance->config;
+	uint32_t remote_idx;
+	uint32_t local_idx;
+	uint32_t cnt;
 
-	rx_block_index = buffer_to_index_validate(&conf->rx, buffer, NULL);
-	if (rx_block_index < 0) {
-		return rx_block_index;
+	MSG_QUEUE_CACHE_INV(config->tx_msg_q.cons_shmq);
+
+	/* Get all pending consumed blocks. */
+	K_SPINLOCK(&data->lock) {
+		remote_idx = config->tx_msg_q.cons_shmq->hdr.block_idx;
+		local_idx = data->msg_q.tx_local_cons_idx;
+		cnt = remote_idx - local_idx;
+		LOG_DBG("%p Garbage collect remote_idx: %d local_idx: %d cnt:%d",
+			(void *)config->tx_msg_q.cons_shmq, remote_idx, local_idx, cnt);
+		__ASSERT_NO_MSG(cnt <= MAX_ACTIVE_COUNT);
+		for (uint8_t i = 0; i < cnt; i++) {
+			size_t idx = (local_idx + i) % MAX_ACTIVE_COUNT;
+			size_t blk_idx = config->tx_msg_q.cons_shmq->slots[idx];
+			struct icbmsg_packet *packet;
+
+			LOG_DBG("Garbage collect index: idx:%d, block_index: %d", idx, blk_idx);
+			packet = heap_get_packet(&config->tx, blk_idx);
+			(void)heap_free(instance, packet);
+			data->msg_q.tx_local_cons_idx++;
+			data->msg_q.tx_active_count--;
+		}
+	}
+}
+
+/** @brief Produce a packet to the message queue.
+ *
+ * Flush cache after updating the message queue.
+ *
+ * @param[in] instance		Instance pointer.
+ * @param[in] block_index		Block index to produce.
+ * @param[in] priority		Priority of the message.
+ * @return 0 on success, negative error code on failure.
+ */
+static int msg_q_produce(const struct device *instance, uint8_t block_index, int priority)
+{
+	struct icbmsg_data *data = instance->data;
+	const struct icbmsg_config *config = instance->config;
+	uint32_t active_count;
+	uint32_t idx;
+	int rv = 0;
+
+	if (priority != 0) {
+		block_index |= HI_PRIO_MASK;
 	}
 
-	return send_control_message(dev_data, msg_type, ept_addr, rx_block_index);
+	K_SPINLOCK(&data->lock) {
+		active_count = data->msg_q.tx_active_count;
+		if (active_count == MAX_ACTIVE_COUNT) {
+			rv = -ENOMEM;
+			break;
+		}
+
+		idx = config->tx_msg_q.prod_shmq->hdr.block_idx % MAX_ACTIVE_COUNT;
+		data->msg_q.tx_active_count++;
+		STATS_INC(data->stats, tx_packet_count);
+		STATS_INCN(data->stats, tx_data_count,
+			   heap_packet_from_index(&config->tx, block_index)->header.size);
+		STATS_SET(data->stats, tx_max_active_count,
+			  MAX(data->stats.tx_max_active_count, data->msg_q.tx_active_count));
+		config->tx_msg_q.prod_shmq->slots[idx] = block_index;
+		LOG_DBG("addr:%p Produce index: %d, block_index: %d, active_count: %d",
+			(void *)&config->tx_msg_q.prod_shmq->slots[idx], idx, block_index,
+			active_count);
+		if (priority != 0) {
+			config->tx_msg_q.prod_shmq->hdr.hi_prio_cnt++;
+		}
+		config->tx_msg_q.prod_shmq->hdr.block_idx++;
+	}
+
+	MSG_QUEUE_CACHE_FLUSH(config->tx_msg_q.prod_shmq);
+	return rv;
+}
+
+/** @brief Try to allocate a TX buffer.
+ *
+ * If allocation fails, try to garbage collect and retry once.
+ *
+ * @param[in] instance	Instance pointer.
+ * @param[in] ept	Endpoint pointer.
+ * @param[in] size	Size of the data to send.
+ * @param[out] packet	Pointer to the allocated packet.
+ * @param[in] timeout	Timeout.
+ *
+ * @return		size of the allocated buffer on success, negative error code on failure.
+ */
+static int try_alloc_tx_buffer(const struct device *instance, struct ept_data *ept, size_t size,
+			       struct icbmsg_packet **packet, k_timeout_t timeout)
+{
+	int rv;
+	bool do_gc = true;
+	bool cont;
+
+	do {
+		rv = heap_alloc_tx_buffer(instance, ept, size, packet, timeout);
+		if ((rv < 0) && do_gc && (ept != NULL)) {
+			msg_q_garbage_collect(instance);
+			do_gc = false;
+			cont = true;
+		} else {
+			cont = false;
+		}
+	} while (cont);
+
+	return rv;
 }
 
 /**
  * Send data contained in specified block. It will adjust data size and flush cache
  * if necessary. If sending failed, allocated blocks will be released.
  *
- * @param[in] msg_type		Message type: MSG_BOUND or MSG_DATA.
- * @param[in] ept_addr		Endpoints address.
- * @param[in] tx_block_index	Index of first block containing data, it is not validated,
- *				so caller is responsible for passing only valid index.
- * @param[in] size		Actual size of the data, can be smaller than allocated,
- *				but it cannot change number of required blocks.
+ * @param[in] packet		Packet to send.
+ * @param[in] size		Size of the data to send.
+ * @param[in] priority		Priority of the message.
  *
  * @return			number of bytes sent in the message or negative error code.
  */
-static int send_block(struct backend_data *dev_data, enum msg_type msg_type,
-		      uint8_t ept_addr, size_t tx_block_index, size_t size)
+static int send_packet(const struct device *instance, struct icbmsg_packet *packet, size_t size,
+		       int priority)
 {
-	struct block_content *block;
-	int r;
+	const struct icbmsg_config *config = instance->config;
+	bool retry = true;
+	bool cont;
+	int rv;
 
-	block = block_from_index(&dev_data->conf->tx, tx_block_index);
+	icbmsg_heap_downsize(instance, packet, size);
+	sys_cache_data_flush_range(packet->data, size);
 
-	block->header.size = size;
-	barrier_sync_synchronize();
-	sys_cache_data_flush_range(block, size + BLOCK_HEADER_SIZE);
+	LOG_DBG("send packet: %p [idx:%d, ept:%d prio:%d size:%d(%d)]", packet,
+		packet->header.index, packet->header.ept, priority, packet->header.size, size);
 
-	r = send_control_message(dev_data, msg_type, ept_addr, tx_block_index);
-	if (r < 0) {
-		release_tx_blocks(dev_data, tx_block_index, size, -1);
+	/* To reduce communication latency we want to postpone garbage collection after
+	 * notifying the remote side. However, if producing fails once we do the
+	 * garbage collection and retry as some slots may become available.
+	 */
+	do {
+		rv = msg_q_produce(instance, packet->header.index, priority);
+		if (rv == 0) {
+			rv = mbox_send_dt(&config->mbox_tx, NULL);
+			if (rv != 0) {
+				return rv;
+			}
+		}
+
+		if (packet->header.ept != EPT_CONTROL) {
+			msg_q_garbage_collect(instance);
+		}
+
+		if (rv != 0 && retry) {
+			cont = true;
+			retry = false;
+		} else {
+			cont = false;
+		}
+	} while (cont);
+
+	if (rv != 0) {
+		(void)heap_free(instance, packet);
+		return rv;
 	}
 
-	return r;
+	return (int)size;
 }
 
-/**
- * Find endpoint that was registered with name that matches name
- * contained in the endpoint bound message received from remote.
- *
- * @param[in] name	Endpoint name, it must be in a received block.
- *
- * @return	Found endpoint index or -ENOENT if not found.
- */
-static int find_ept_by_name(struct backend_data *dev_data, const char *name)
+/** Handle bound request. */
+static int handle_bound_request(const struct device *instance, struct icbmsg_packet *packet)
 {
-	const struct channel_config *rx_conf = &dev_data->conf->rx;
-	const char *buffer_end = (const char *)rx_conf->blocks_ptr +
-				 rx_conf->block_count * rx_conf->block_size;
-	struct ept_data *ept;
-	size_t name_size;
+	struct icbmsg_data *data = instance->data;
+	const struct icbmsg_config *config = instance->config;
+	struct icbmsg_bound_packet *pkt = (struct icbmsg_bound_packet *)packet->data;
+
+	LOG_DBG("Handle bound request: 0x%02X ep:%02x, magic: 0x%08X 0x%08X", packet->header.index,
+		packet->header.ept, pkt->magic[0], pkt->magic[1]);
+
+	if (pkt->magic[0] != config->bound_packet.magic[0] ||
+	    pkt->magic[1] != config->bound_packet.magic[1]) {
+		LOG_ERR("Received invalid bound request");
+		return -EINVAL;
+	}
+
+	if (pkt->buf_count[0] != config->bound_packet.buf_count[1] ||
+	    pkt->buf_count[1] != config->bound_packet.buf_count[0]) {
+		LOG_ERR("Received bound request but parameters do not match");
+		return -EINVAL;
+	}
+
+	data->state = STATE_CONNECTED;
+
+	return 0;
+}
+
+/** Handle endpoint bound request. */
+static int handle_ep_bound_request(const struct device *instance,
+				   struct icbmsg_control_packet *packet)
+{
+	struct icbmsg_data *data = instance->data;
+	bool bound = false;
 	size_t i;
 
-	/* Requested name is in shared memory, so we have to assume that it
-	 * can be corrupted. Extra care must be taken to avoid out of
-	 * bounds reads.
-	 */
-	name_size = strnlen(name, buffer_end - name - 1) + 1;
+	LOG_DBG("Received bound request: %p [ept:%d name hash:%08x]", packet,
+		packet->data.bound.ept_addr, packet->data.bound.name_hash);
 
 	for (i = 0; i < NUM_EPT; i++) {
-		ept = &dev_data->ept[i];
-		if (atomic_get(&ept->state) == EPT_CONFIGURED &&
-		    strncmp(ept->cfg->name, name, name_size) == 0) {
+		LOG_DBG("Checking endpoint %d name hash: %08x remote hash: %08x", i,
+			data->ept[i].name_hash, packet->data.bound.name_hash);
+		if ((data->ept[i].cfg != NULL) &&
+		    (data->ept[i].name_hash == packet->data.bound.name_hash)) {
+			data->ept[i].addr = packet->data.bound.ept_addr;
+			LOG_DBG("Bound request bounded, remote id:%d local:%d",
+				packet->data.bound.ept_addr, i);
+			bound = true;
+			goto bail;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT)) {
+		/* If deregistering is supported then there might be gaps in the array.
+		 * Search for free slot.
+		 */
+		for (i = 0; i < NUM_EPT; i++) {
+			if (data->ept[i].cfg == NULL && data->ept[i].state == EPT_UNBOUND) {
+				break;
+			}
+		}
+	} else {
+		i = data->ep_cnt;
+	}
+
+	if (i == NUM_EPT) {
+		return -ENOMEM;
+	}
+
+	data->ept[i].name_hash = packet->data.bound.name_hash;
+	data->ept[i].addr = packet->data.bound.ept_addr;
+	data->ep_cnt++;
+	LOG_DBG("Bound request pending, remote id:%d local:%d", packet->data.bound.ept_addr, i);
+bail:
+	if (bound) {
+		data->ept[i].state = EPT_READY;
+		if (data->ept[i].cfg->cb.bound != NULL) {
+			data->ept[i].cfg->cb.bound(data->ept[i].cfg->priv);
+		}
+	}
+
+	return 0;
+}
+
+/** Handle endpoint unbound request. */
+static int handle_ep_unbound_request(const struct device *instance,
+				     struct icbmsg_control_packet *packet)
+{
+	struct icbmsg_data *data = instance->data;
+	uint8_t ept_addr = packet->data.unbound.ept_addr;
+	typedef void (*unbound_callback_t)(void *priv);
+
+	if (ept_addr >= NUM_EPT) {
+		LOG_ERR("Invalid unbound request EP:%d", ept_addr);
+		return -EINVAL;
+	}
+
+	if (data->ept[ept_addr].cfg == NULL) {
+		LOG_ERR("Endpoint %d is already unbounded", ept_addr);
+		return 0;
+	}
+
+	LOG_DBG("Unbinding endpoint %d", ept_addr);
+
+	unbound_callback_t unbound_callback = data->ept[ept_addr].cfg->cb.unbound;
+	void *priv = data->ept[ept_addr].cfg->priv;
+
+	data->ept[ept_addr].state = EPT_UNBOUND;
+	data->ept[ept_addr].cfg = NULL;
+	data->ept[ept_addr].name_hash = 0;
+	data->ep_cnt--;
+
+	if (unbound_callback != NULL) {
+		unbound_callback(priv);
+	}
+	return 0;
+}
+
+/** Received control packet. */
+static int received_control(const struct device *instance, struct icbmsg_packet *packet)
+{
+	struct icbmsg_data *data = instance->data;
+	int rv;
+
+	if (data->state != STATE_CONNECTED) {
+		rv = handle_bound_request(instance, packet);
+	} else {
+		struct icbmsg_control_packet *pkt = (struct icbmsg_control_packet *)packet->data;
+
+		if (pkt->msg_type == MSG_EP_BOUND) {
+			rv = handle_ep_bound_request(instance, pkt);
+		} else if (IS_ENABLED(CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT) &&
+			   (pkt->msg_type == MSG_EP_UNBOUND)) {
+			rv = handle_ep_unbound_request(instance, pkt);
+		} else {
+			rv = -EINVAL;
+		}
+	}
+
+	if (rv < 0) {
+		LOG_ERR("Received invalid control packet");
+	}
+
+	msg_q_consume(instance, packet->header.index);
+
+	return rv;
+}
+
+/** Received data packet. */
+static void received_data(const struct device *instance, struct icbmsg_packet *packet)
+{
+	uint8_t ept_addr = packet->header.ept;
+	struct icbmsg_data *data = instance->data;
+	struct ept_data *ept;
+
+	if (ept_addr >= NUM_EPT) {
+		LOG_ERR("Invalid packet EP:%d", ept_addr);
+		return;
+	}
+
+	ept = &data->ept[ept_addr];
+	if (ept->state != EPT_READY) {
+		LOG_ERR("Received data packet in invalid state %d", ept->state);
+		return;
+	}
+
+	LOG_DBG("Received data: %p [idx:%d, ept:%d] size:%d cb:%p", packet, packet->header.index,
+		ept_addr, packet->header.size, ept->cfg->cb.received);
+	STATS_INC(data->stats, rx_packet_count);
+	STATS_INCN(data->stats, rx_data_count, packet->header.size);
+	/* Call the endpoint callback. */
+	ept->cfg->cb.received(packet->data, packet->header.size, ept->cfg->priv);
+
+	/* If packet was not hold then release it.*/
+	if (data->rx_packet != NULL) {
+		msg_q_consume(instance, packet->header.index);
+	}
+}
+
+static void handle_message(const struct device *instance, uint32_t block_index)
+{
+	const struct icbmsg_config *config = instance->config;
+	struct icbmsg_data *data = instance->data;
+
+	data->rx_packet = heap_get_packet(&config->rx, block_index);
+	if (data->rx_packet->header.ept == EPT_CONTROL) {
+		received_control(instance, data->rx_packet);
+	} else {
+		__ASSERT_NO_MSG(data->state == STATE_CONNECTED);
+		received_data(instance, data->rx_packet);
+	}
+}
+
+static void handle_pending_messages(const struct device *instance)
+{
+	const struct icbmsg_config *config = instance->config;
+	struct icbmsg_data *data = instance->data;
+	uint32_t local_idx;
+	uint32_t new_msgs;
+	uint32_t hi_prio_msgs;
+	bool cont;
+	bool high_prio_present;
+
+	MSG_QUEUE_CACHE_INV(config->rx_msg_q.prod_shmq);
+	local_idx = data->msg_q.rx_local_prod_idx;
+	new_msgs = config->rx_msg_q.prod_shmq->hdr.block_idx - local_idx;
+	LOG_DBG("new_msgs: %d local_idx: %d block_idx: %d",
+		new_msgs, local_idx, config->rx_msg_q.prod_shmq->hdr.block_idx);
+	if (likely(new_msgs == 1)) {
+		/* The most common case: only one new message. Handle it directly. */
+		uint32_t idx = local_idx % MAX_ACTIVE_COUNT;
+		uint32_t block_index = config->rx_msg_q.prod_shmq->slots[idx];
+
+		if (block_index & HI_PRIO_MASK) {
+			block_index &= ~HI_PRIO_MASK;
+			data->msg_q.rx_local_hi_prio_cnt++;
+		}
+		data->msg_q.rx_local_prod_idx++;
+		handle_message(instance, block_index);
+		return;
+	} else if (new_msgs == 0) {
+		return;
+	}
+	__ASSERT_NO_MSG(new_msgs <= MAX_ACTIVE_COUNT);
+
+	hi_prio_msgs =
+		config->rx_msg_q.prod_shmq->hdr.hi_prio_cnt - data->msg_q.rx_local_hi_prio_cnt;
+	data->msg_q.rx_local_hi_prio_cnt += hi_prio_msgs;
+
+	/* More than one message. Start by handling high priority messages*/
+	do {
+		high_prio_present = hi_prio_msgs != 0;
+		cont = high_prio_present && (new_msgs != hi_prio_msgs);
+		for (uint32_t i = 0; i < new_msgs; i++) {
+			uint32_t idx = (local_idx + i) % MAX_ACTIVE_COUNT;
+			uint32_t block_index = config->rx_msg_q.prod_shmq->slots[idx];
+			bool is_hi_prio = block_index & HI_PRIO_MASK;
+
+			if (high_prio_present) {
+				if (is_hi_prio) {
+					block_index &= ~HI_PRIO_MASK;
+					hi_prio_msgs--;
+				} else {
+					continue;
+				}
+			} else {
+				if (is_hi_prio) {
+					continue;
+				}
+			}
+			handle_message(instance, block_index);
+		}
+	} while (cont);
+
+	data->msg_q.rx_local_prod_idx += new_msgs;
+}
+
+static void mbox_callback(const struct device *dev, uint32_t channel, void *user_data,
+			  struct mbox_msg *msg_data)
+{
+	handle_pending_messages((const struct device *)user_data);
+}
+/** Endpoint send (with copy). */
+static int send(const struct device *instance, void *token, const void *msg, size_t len)
+{
+	struct ept_data *ept = token;
+	struct icbmsg_packet *packet;
+	int rv;
+
+	/* Allocate the buffer. */
+	rv = try_alloc_tx_buffer(instance, ept, len, &packet, K_NO_WAIT);
+	if (rv < 0) {
+		return rv;
+	}
+
+	/* Copy data to allocated buffer. */
+	if (IS_ALIGNED(msg, 4) && !IS_ENABLED(CONFIG_SPEED_OPTIMIZATIONS)) {
+		uint32_t *dst32 = (uint32_t *)packet->data;
+		const uint32_t *src32 = (const uint32_t *)msg;
+		uint8_t *dst8 = (uint8_t *)packet->data;
+		const uint8_t *src8 = (const uint8_t *)msg;
+		size_t len32 = len / sizeof(uint32_t);
+
+		for (size_t i = 0; i < len32; i++) {
+			dst32[i] = src32[i];
+		}
+
+		for (size_t i = len32 * sizeof(uint32_t); i < len; i++) {
+			dst8[i] = src8[i];
+		}
+	} else {
+		memcpy(packet->data, msg, len);
+	}
+
+	/* Send data message. */
+	return send_packet(instance, packet, len, ept ? ept->cfg->prio : 1);
+}
+
+static int send_bound_request(const struct device *instance)
+{
+	const struct icbmsg_config *config = instance->config;
+
+	return send(instance, NULL, &config->bound_packet, sizeof(config->bound_packet));
+}
+
+static int send_ep_bound_request(const struct device *instance, size_t id, uint32_t name_hash)
+{
+	struct icbmsg_control_packet pkt = {
+		.msg_type = MSG_EP_BOUND,
+		.data.bound.ept_addr = (uint8_t)id,
+		.data.bound.name_hash = name_hash,
+	};
+
+	return send(instance, NULL, &pkt, sizeof(pkt));
+}
+
+/* It is called with interrupts locked and it's expected that free slot is available. */
+static size_t get_free_ep_slot(struct icbmsg_data *data)
+{
+	if (!IS_ENABLED(CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT)) {
+		return data->ep_cnt;
+	}
+	/* If deregistering is supported then there might be
+	 * gaps in the array.
+	 */
+	for (size_t i = 0; i < NUM_EPT; i++) {
+		if (data->ept[i].cfg == NULL &&
+		    data->ept[i].state == EPT_UNBOUND) {
 			return i;
 		}
 	}
 
-	return -ENOENT;
+	return 0;
 }
 
-/**
- * Find registered endpoint that matches given "bound endpoint" message. When found,
- * the "release bound endpoint" message is send.
- *
- * @param[in] rx_block_index	Block containing the "bound endpoint" message.
- * @param[in] ept_addr		Endpoint address.
- *
- * @return	negative error code or non-negative search result.
- * @retval 0	match not found.
- * @retval 1	match found and processing was successful.
- */
-static int match_bound_msg(struct backend_data *dev_data, size_t rx_block_index,
-			   uint8_t ept_addr)
+/** Backend endpoint registration. */
+static int register_ept(const struct device *instance, void **token, const struct ipc_ept_cfg *cfg)
 {
-	const struct icbmsg_config *conf = dev_data->conf;
-	struct block_content *block;
-	uint8_t *buffer;
-	int ept_index;
-	struct ept_data *ept;
-	int r;
-	bool valid_state;
+	struct icbmsg_data *data = instance->data;
+	uint32_t name_hash;
+	k_spinlock_key_t key;
+	size_t id = 0;
+	bool bound = false;
+	int rv = 0;
 
-	/* Find endpoint that matches requested name. */
-	block = block_from_index(&conf->rx, rx_block_index);
-	buffer = block->data;
-	ept_index = find_ept_by_name(dev_data, buffer);
-	if (ept_index < 0) {
-		return 0;
-	}
+	name_hash = cfg->name == NULL ? 0 : sys_hash32_djb2(cfg->name, strlen(cfg->name));
 
-	/* Set endpoint address and mapping. Move it to "ready" state. */
-	ept = &dev_data->ept[ept_index];
-	ept->addr = ept_addr;
-	dev_data->ept_map[ept->addr] = ept_index;
-	valid_state = atomic_cas(&ept->state, EPT_CONFIGURED, EPT_READY);
-	if (!valid_state) {
-		LOG_ERR("Unexpected bounding from remote on endpoint %d", ept_addr);
-		return -EINVAL;
-	}
+	key = k_spin_lock(&data->lock);
 
-	/* Endpoint is ready to send messages, so call bound callback. */
-	if (ept->cfg->cb.bound != NULL) {
-		ept->cfg->cb.bound(ept->cfg->priv);
-	}
-
-	/* Release the bound message and inform remote that we are ready to receive. */
-	r = send_release(dev_data, buffer, MSG_RELEASE_BOUND, ept_addr);
-	if (r < 0) {
-		return r;
-	}
-
-	return 1;
-}
-
-/**
- * Send bound message on specified endpoint.
- *
- * @param[in] ept	Endpoint to use.
- *
- * @return		non-negative value in case of success or negative error code.
- */
-static int send_bound_message(struct backend_data *dev_data, struct ept_data *ept)
-{
-	size_t msg_len;
-	uint32_t alloc_size;
-	uint8_t *buffer;
-	int r;
-
-	msg_len = strlen(ept->cfg->name) + 1;
-	alloc_size = msg_len;
-	r = alloc_tx_buffer(dev_data, &alloc_size, &buffer, K_FOREVER);
-	if (r >= 0) {
-		strcpy(buffer, ept->cfg->name);
-		r = send_block(dev_data, MSG_BOUND, ept->addr, r, msg_len);
-	}
-
-	return r;
-}
-
-#ifdef CONFIG_MULTITHREADING
-/**
- * Put endpoint bound processing into system workqueue.
- */
-static void schedule_ept_bound_process(struct backend_data *dev_data)
-{
-	k_work_submit_to_queue(&ep_bound_work_q, &dev_data->ep_bound_work);
-}
-#endif
-
-/**
- * Work handler that is responsible to start bounding when ICMsg is bound.
- */
-#ifdef CONFIG_MULTITHREADING
-static void ept_bound_process(struct k_work *item)
-#else
-static void ept_bound_process(struct backend_data *dev_data)
-#endif
-{
-#ifdef CONFIG_MULTITHREADING
-	struct backend_data *dev_data = CONTAINER_OF(item, struct backend_data,
-						     ep_bound_work);
-#endif
-	struct ept_data *ept = NULL;
-	size_t i;
-	int r = 0;
-	bool matching_state;
-
-	/* Skip processing if ICMsg was not bounded yet. */
-	if (!(atomic_get(&dev_data->flags) & CONTROL_BOUNDED)) {
-		return;
-	}
-
-	if (dev_data->is_initiator) {
-		/* Initiator just sends bound message after endpoint was registered. */
-		for (i = 0; i < NUM_EPT; i++) {
-			ept = &dev_data->ept[i];
-			matching_state = atomic_cas(&ept->state, EPT_CONFIGURED,
-						    EPT_BOUNDING);
-			if (matching_state) {
-				r = send_bound_message(dev_data, ept);
-				if (r < 0) {
-					atomic_set(&ept->state, EPT_UNCONFIGURED);
-					LOG_ERR("Failed to send bound, err %d", r);
-				}
-			}
-		}
-	} else {
-		/* Walk over all waiting bound messages and match to local endpoints. */
-#ifdef CONFIG_MULTITHREADING
-		k_mutex_lock(&dev_data->mutex, K_FOREVER);
-#endif
-		for (i = 0; i < NUM_EPT; i++) {
-			if (dev_data->waiting_bound[i] != WAITING_BOUND_MSG_EMPTY) {
-#ifdef CONFIG_MULTITHREADING
-				k_mutex_unlock(&dev_data->mutex);
-#endif
-				r = match_bound_msg(dev_data,
-						    dev_data->waiting_bound[i], i);
-#ifdef CONFIG_MULTITHREADING
-				k_mutex_lock(&dev_data->mutex, K_FOREVER);
-#endif
-				if (r != 0) {
-					dev_data->waiting_bound[i] =
-						WAITING_BOUND_MSG_EMPTY;
-					if (r < 0) {
-						LOG_ERR("Failed bound, err %d", r);
-					}
-				}
-			}
-		}
-#ifdef CONFIG_MULTITHREADING
-		k_mutex_unlock(&dev_data->mutex);
-#endif
-	}
-
-	/* Check if any endpoint is ready to rebound and call the callback if it is. */
-	for (i = 0; i < NUM_EPT; i++) {
-		ept = &dev_data->ept[i];
-		matching_state = atomic_cas(&ept->rebound_state, EPT_REBOUNDING,
-						EPT_NORMAL);
-		if (matching_state) {
-			if (ept->cfg->cb.bound != NULL) {
-				ept->cfg->cb.bound(ept->cfg->priv);
-			}
+	/* Start by searching if there is already pending request with a given hash. If
+	 * yes then we are bounded on that side.
+	 */
+	for (size_t i = 0; i < NUM_EPT; i++) {
+		if ((data->ept[i].cfg == NULL) && (data->ept[i].name_hash == name_hash)) {
+			/* Remote bound request for that endpoint is already received. */
+			LOG_DBG("Register EP (bounded), remote id:%d local:%d",
+				data->ept[i].addr, i);
+			bound = true;
+			data->ept[i].cfg = cfg;
+			*token = (void *)&data->ept[i];
+			id = i;
+			break;
 		}
 	}
-}
 
-/**
- * Get endpoint from endpoint address. Also validates if the address is correct and
- * endpoint is in correct state for receiving. If bounding callback was not called yet,
- * then call it.
- */
-static struct ept_data *get_ept_and_rx_validate(struct backend_data *dev_data,
-						uint8_t ept_addr)
-{
-	struct ept_data *ept;
-	enum ept_bounding_state state;
+	/* If there is no pending bounding request then store the current one. In both cases
+	 * send bound request to the remote.
+	 */
+	if (!bound) {
+		if (data->ep_cnt >= NUM_EPT) {
+			rv = -ENOMEM;
+		} else {
+			id = get_free_ep_slot(data);
 
-	if (ept_addr >= NUM_EPT || dev_data->ept_map[ept_addr] >= NUM_EPT) {
-		LOG_ERR("Received invalid endpoint addr %d", ept_addr);
-		return NULL;
-	}
-
-	ept = &dev_data->ept[dev_data->ept_map[ept_addr]];
-
-	state = atomic_get(&ept->state);
-
-	if (state == EPT_READY) {
-		/* Ready state, ensure that it is not deregistered nor rebounding. */
-		if (atomic_get(&ept->rebound_state) != EPT_NORMAL) {
-			return NULL;
+			LOG_DBG("Register EP (pending), local:%d", id);
+			data->ept[id].cfg = cfg;
+			data->ept[id].name_hash = name_hash;
+			*token = (void *)&data->ept[id];
+			data->ep_cnt++;
 		}
-	} else if (state == EPT_BOUNDING) {
-		/* Endpoint bound callback was not called yet - call it. */
-		atomic_set(&ept->state, EPT_READY);
-		if (ept->cfg->cb.bound != NULL) {
-			ept->cfg->cb.bound(ept->cfg->priv);
+	}
+
+	k_spin_unlock(&data->lock, key);
+
+	if (rv != 0) {
+		return rv;
+	}
+
+	rv = send_ep_bound_request(instance, id, name_hash);
+	if (rv < 0) {
+		return rv;
+	}
+
+	if (bound) {
+		data->ept[id].state = EPT_READY;
+		if (cfg->cb.bound != NULL) {
+			cfg->cb.bound(cfg->priv);
 		}
-	} else {
-		LOG_ERR("Invalid state %d of receiving endpoint %d", state, ept->addr);
-		return NULL;
-	}
-
-	return ept;
-}
-
-/**
- * Data message received.
- */
-static int received_data(struct backend_data *dev_data, size_t rx_block_index,
-			 uint8_t ept_addr)
-{
-	const struct icbmsg_config *conf = dev_data->conf;
-	uint8_t *buffer;
-	struct ept_data *ept;
-	size_t size;
-	int bit_val;
-
-	/* Validate. */
-	buffer = buffer_from_index_validate(&conf->rx, rx_block_index, &size, true);
-	ept = get_ept_and_rx_validate(dev_data, ept_addr);
-	if (buffer == NULL || ept == NULL) {
-		LOG_ERR("Received invalid block index %d or addr %d", rx_block_index,
-			ept_addr);
-		return -EINVAL;
-	}
-
-	/* Clear bit. If cleared, specific block will not be hold after the callback. */
-	sys_bitarray_clear_bit(conf->rx_hold_bitmap, rx_block_index);
-
-	/* Call the endpoint callback. It can set the hold bit. */
-	ept->cfg->cb.received(buffer, size, ept->cfg->priv);
-
-	/* If the bit is still cleared, request release of the buffer. */
-	sys_bitarray_test_bit(conf->rx_hold_bitmap, rx_block_index, &bit_val);
-	if (!bit_val) {
-		send_release(dev_data, buffer, MSG_RELEASE_DATA, 0);
 	}
 
 	return 0;
 }
 
-/**
- * Release data message received.
- */
-static int received_release_data(struct backend_data *dev_data, size_t tx_block_index)
-{
-	const struct icbmsg_config *conf = dev_data->conf;
-	uint8_t *buffer;
-	size_t size;
-	int r;
-
-	/* Validate. */
-	buffer = buffer_from_index_validate(&conf->tx, tx_block_index, &size, false);
-	if (buffer == NULL) {
-		LOG_ERR("Received invalid block index %d", tx_block_index);
-		return -EINVAL;
-	}
-
-	/* Release. */
-	r = release_tx_blocks(dev_data, tx_block_index, size, -1);
-	if (r < 0) {
-		return r;
-	}
-
-	return r;
-}
-
-/**
- * Bound endpoint message received.
- */
-static int received_bound(struct backend_data *dev_data, size_t rx_block_index,
-			  uint8_t ept_addr)
-{
-	const struct icbmsg_config *conf = dev_data->conf;
-	size_t size;
-	uint8_t *buffer;
-
-	/* Validate */
-	buffer = buffer_from_index_validate(&conf->rx, rx_block_index, &size, true);
-	if (buffer == NULL) {
-		LOG_ERR("Received invalid block index %d", rx_block_index);
-		return -EINVAL;
-	}
-
-	/* Put message to waiting array. */
-#ifdef CONFIG_MULTITHREADING
-	k_mutex_lock(&dev_data->mutex, K_FOREVER);
-#endif
-	dev_data->waiting_bound[ept_addr] = rx_block_index;
-#ifdef CONFIG_MULTITHREADING
-	k_mutex_unlock(&dev_data->mutex);
-#endif
-
-#ifdef CONFIG_MULTITHREADING
-	/* Schedule processing the message. */
-	schedule_ept_bound_process(dev_data);
-#else
-	ept_bound_process(dev_data);
-#endif
-
-	return 0;
-}
-
-/**
- * Callback called by ICMsg that handles message (data or endpoint bound) received
- * from the remote.
- *
- * @param[in] data	Message received from the ICMsg.
- * @param[in] len	Number of bytes of data.
- * @param[in] priv	Opaque pointer to device instance.
- */
-static void control_received(const void *data, size_t len, void *priv)
-{
-	const struct device *instance = priv;
-	struct backend_data *dev_data = instance->data;
-	const struct control_message *message = (const struct control_message *)data;
-	struct ept_data *ept;
-	uint8_t ept_addr;
-	int r = 0;
-
-	/* Allow messages longer than 3 bytes, e.g. for future protocol versions. */
-	if (len < sizeof(struct control_message)) {
-		r = -EINVAL;
-		goto exit;
-	}
-
-	ept_addr = message->ept_addr;
-	if (ept_addr >= NUM_EPT) {
-		r = -EINVAL;
-		goto exit;
-	}
-
-	switch (message->msg_type) {
-	case MSG_RELEASE_DATA:
-		r = received_release_data(dev_data, message->block_index);
-		break;
-	case MSG_RELEASE_BOUND:
-		r = received_release_data(dev_data, message->block_index);
-		if (r >= 0) {
-			ept = get_ept_and_rx_validate(dev_data, ept_addr);
-			if (ept == NULL) {
-				r = -EINVAL;
-			}
-		}
-		break;
-	case MSG_BOUND:
-		r = received_bound(dev_data, message->block_index, ept_addr);
-		break;
-	case MSG_DATA:
-		r = received_data(dev_data, message->block_index, ept_addr);
-		break;
-	default:
-		/* Silently ignore other messages types. They can be used in future
-		 * protocol version.
-		 */
-		break;
-	}
-
-exit:
-	if (r < 0) {
-		LOG_ERR("Failed to receive, err %d", r);
-	}
-}
-
-/**
- * Callback called when ICMsg is bound.
- */
-static void control_bound(void *priv)
-{
-	const struct device *instance = priv;
-	struct backend_data *dev_data = instance->data;
-
-	/* Set flag that ICMsg is bounded and now, endpoint bounding may start. */
-	atomic_or(&dev_data->flags, CONTROL_BOUNDED);
-#ifdef CONFIG_MULTITHREADING
-	schedule_ept_bound_process(dev_data);
-#else
-	ept_bound_process(dev_data);
-#endif
-}
-
-/**
- * Open the backend instance callback.
- */
-static int open(const struct device *instance)
-{
-	const struct icbmsg_config *conf = instance->config;
-	struct backend_data *dev_data = instance->data;
-
-	static const struct ipc_service_cb cb = {
-		.bound = control_bound,
-		.received = control_received,
-		.error = NULL,
-	};
-
-	if (!device_is_ready(instance)) {
-		return -EAGAIN;
-	}
-
-	LOG_DBG("Open instance 0x%08X, initiator=%d", (uint32_t)instance,
-		dev_data->is_initiator ? 1 : 0);
-	LOG_DBG("  TX %d blocks of %d bytes at 0x%08X, max allocable %d bytes",
-		(uint32_t)conf->tx.block_count,
-		(uint32_t)conf->tx.block_size,
-		(uint32_t)conf->tx.blocks_ptr,
-		(uint32_t)(conf->tx.block_size * conf->tx.block_count -
-			   BLOCK_HEADER_SIZE));
-	LOG_DBG("  RX %d blocks of %d bytes at 0x%08X, max allocable %d bytes",
-		(uint32_t)conf->rx.block_count,
-		(uint32_t)conf->rx.block_size,
-		(uint32_t)conf->rx.blocks_ptr,
-		(uint32_t)(conf->rx.block_size * conf->rx.block_count -
-			   BLOCK_HEADER_SIZE));
-
-	return icmsg_open(&conf->control_config, &dev_data->control_data, &cb,
-			  (void *)instance);
-}
-
-/**
- * Close the backend instance callback.
- */
-static int close(const struct device *instance)
-{
-	const struct icbmsg_config *conf = instance->config;
-	struct backend_data *dev_data = instance->data;
-	struct ept_data *ept = NULL;
-	int ept_index;
-	int ret = 0;
-
-	ret = icmsg_close(&conf->control_config, &dev_data->control_data);
-	if (ret) {
-		return ret;
-	}
-
-#ifdef CONFIG_MULTITHREADING
-	(void)k_work_cancel(&dev_data->ep_bound_work);
-#endif
-
-	for (ept_index = 0; ept_index < NUM_EPT; ept_index++) {
-		ept = &dev_data->ept[ept_index];
-		ept->cfg = NULL;
-		atomic_set(&ept->state, EPT_UNCONFIGURED);
-		atomic_set(&ept->rebound_state, EPT_NORMAL);
-		ept->addr = EPT_ADDR_INVALID;
-	}
-	atomic_clear(&dev_data->flags);
-	memset(&dev_data->waiting_bound, 0xFF, sizeof(dev_data->waiting_bound));
-	memset(&dev_data->ept_map, EPT_ADDR_INVALID, sizeof(dev_data->ept_map));
-
-	(void)sys_bitarray_clear_region(conf->tx_usage_bitmap, conf->tx_usage_bitmap->num_bits, 0);
-	(void)sys_bitarray_clear_region(conf->rx_hold_bitmap, conf->rx_hold_bitmap->num_bits, 0);
-
-	return 0;
-}
-
-/**
- * Endpoint send callback function (with copy).
- */
-static int send(const struct device *instance, void *token, const void *msg, size_t len)
-{
-	struct backend_data *dev_data = instance->data;
-	struct ept_data *ept = token;
-	uint32_t alloc_size;
-	uint8_t *buffer;
-	int r;
-
-	/* Allocate the buffer. */
-	alloc_size = len;
-	r = alloc_tx_buffer(dev_data, &alloc_size, &buffer, K_NO_WAIT);
-	if (r < 0) {
-		return r;
-	}
-
-	/* Copy data to allocated buffer. */
-	memcpy(buffer, msg, len);
-
-	/* Send data message. */
-	r = send_block(dev_data, MSG_DATA, ept->addr, r, len);
-	if (r < 0) {
-		return r;
-	}
-
-	return len;
-}
-
-/**
- * Backend endpoint registration callback.
- */
-static int register_ept(const struct device *instance, void **token,
-			const struct ipc_ept_cfg *cfg)
-{
-	struct backend_data *dev_data = instance->data;
-	struct ept_data *ept = NULL;
-	bool matching_state;
-	int ept_index;
-
-	/* Try to find endpoint to rebound */
-	for (ept_index = 0; ept_index < NUM_EPT; ept_index++) {
-		ept = &dev_data->ept[ept_index];
-		if (ept->cfg == cfg) {
-			matching_state = atomic_cas(&ept->rebound_state, EPT_DEREGISTERED,
-						   EPT_REBOUNDING);
-			if (!matching_state) {
-				return -EINVAL;
-			}
-#ifdef CONFIG_MULTITHREADING
-			schedule_ept_bound_process(dev_data);
-#else
-			ept_bound_process(dev_data);
-#endif
-			return 0;
-		}
-	}
-
-	/* Reserve new endpoint index. */
-	ept_index = atomic_inc(&dev_data->flags) & FLAG_EPT_COUNT_MASK;
-	if (ept_index >= NUM_EPT) {
-		LOG_ERR("Too many endpoints");
-		__ASSERT_NO_MSG(false);
-		return -ENOMEM;
-	}
-
-	/* Add new endpoint. */
-	ept = &dev_data->ept[ept_index];
-	ept->cfg = cfg;
-	if (dev_data->is_initiator) {
-		ept->addr = ept_index;
-		dev_data->ept_map[ept->addr] = ept->addr;
-	}
-	atomic_set(&ept->state, EPT_CONFIGURED);
-
-	/* Keep endpoint address in token. */
-	*token = ept;
-
-#ifdef CONFIG_MULTITHREADING
-	/* Rest of the bounding will be done in the system workqueue. */
-	schedule_ept_bound_process(dev_data);
-#else
-	ept_bound_process(dev_data);
-#endif
-
-	return 0;
-}
-
-/**
- * Backend endpoint deregistration callback.
- */
+/** Backend endpoint deregistration. */
 static int deregister_ept(const struct device *instance, void *token)
 {
 	struct ept_data *ept = token;
-	bool matching_state;
+	struct icbmsg_data *data = instance->data;
+	int rv = 0;
+	size_t i;
 
-	matching_state = atomic_cas(&ept->rebound_state, EPT_NORMAL, EPT_DEREGISTERED);
-
-	if (!matching_state) {
-		return -EINVAL;
+	if (ept->state != EPT_READY) {
+		return -ENOENT;
 	}
 
-	return 0;
+	struct icbmsg_control_packet packet = {
+		.msg_type = MSG_EP_UNBOUND,
+		.data.unbound.ept_addr = ept->addr,
+	};
+
+	K_SPINLOCK(&data->lock) {
+		for (i = 0; i < NUM_EPT; i++) {
+			if (&data->ept[i] == ept) {
+				data->ept[i].cfg = NULL;
+				data->ept[i].name_hash = 0;
+				data->ept[i].state = EPT_UNBOUND;
+				data->ep_cnt--;
+				break;
+			}
+		}
+	}
+
+	if (i == NUM_EPT) {
+		return -EALREADY;
+	}
+
+	rv = send(instance, NULL, &packet, sizeof(packet));
+	return rv >= 0 ? 0 : rv;
 }
 
-/**
- * Returns maximum TX buffer size.
- */
+/** Returns maximum TX buffer size. */
 static int get_tx_buffer_size(const struct device *instance, void *token)
 {
 	const struct icbmsg_config *conf = instance->config;
 
-	return conf->tx.block_size * conf->tx.block_count - BLOCK_HEADER_SIZE;
+	return heap_max_data_size(&conf->tx);
 }
 
-/**
- * Endpoint TX buffer allocation callback for nocopy sending.
- */
-static int get_tx_buffer(const struct device *instance, void *token, void **data,
+/** Endpoint TX buffer allocation callback for nocopy sending. */
+static int get_tx_buffer(const struct device *instance, void *token, void **buffer,
 			 uint32_t *user_len, k_timeout_t wait)
 {
-	struct backend_data *dev_data = instance->data;
-	int r;
-
-	r = alloc_tx_buffer(dev_data, user_len, (uint8_t **)data, wait);
-	if (r < 0) {
-		return r;
-	}
-	return 0;
-}
-
-/**
- * Endpoint TX buffer release callback for nocopy sending.
- */
-static int drop_tx_buffer(const struct device *instance, void *token, const void *data)
-{
-	struct backend_data *dev_data = instance->data;
-	int r;
-
-	r =  release_tx_buffer(dev_data, data, -1);
-	if (r < 0) {
-		return r;
-	}
-
-	return 0;
-}
-
-/**
- * Endpoint nocopy sending.
- */
-static int send_nocopy(const struct device *instance, void *token, const void *data,
-		       size_t len)
-{
-	struct backend_data *dev_data = instance->data;
+	struct icbmsg_packet *packet;
 	struct ept_data *ept = token;
-	int r;
+	int rv;
 
-	/* Actual size may be smaller than requested, so shrink if possible. */
-	r = release_tx_buffer(dev_data, data, len);
-	if (r < 0) {
-		release_tx_buffer(dev_data, data, -1);
-		return r;
+	rv = try_alloc_tx_buffer(instance, ept, *user_len, &packet, wait);
+	if (rv < 0) {
+		return rv;
 	}
 
-	r = send_block(dev_data, MSG_DATA, ept->addr, r, len);
+	*user_len = rv;
+	*buffer = packet->data;
 
-	return r < 0 ? r : len;
-}
-
-/**
- * Holding RX buffer for nocopy receiving.
- */
-static int hold_rx_buffer(const struct device *instance, void *token, void *data)
-{
-	const struct icbmsg_config *conf = instance->config;
-	int rx_block_index;
-	uint8_t *buffer = data;
-
-	/* Calculate block index and set associated bit. */
-	rx_block_index = buffer_to_index_validate(&conf->rx, buffer, NULL);
-	__ASSERT_NO_MSG(rx_block_index >= 0);
-	return sys_bitarray_set_bit(conf->rx_hold_bitmap, rx_block_index);
-}
-
-/**
- * Release RX buffer that was previously held.
- */
-static int release_rx_buffer(const struct device *instance, void *token, void *data)
-{
-	struct backend_data *dev_data = instance->data;
-	int r;
-
-	r = send_release(dev_data, (uint8_t *)data, MSG_RELEASE_DATA, 0);
-	if (r < 0) {
-		return r;
-	}
 	return 0;
+}
+
+/** Endpoint TX buffer release callback for nocopy sending. */
+static int drop_tx_buffer(const struct device *instance, void *token, const void *buffer)
+{
+	ARG_UNUSED(token);
+	return heap_free(instance, heap_packet_from_data(buffer));
+}
+
+/** Endpoint nocopy sending. */
+static int send_nocopy(const struct device *instance, void *token, const void *buffer, size_t len)
+{
+	struct icbmsg_packet *packet = heap_packet_from_data(buffer);
+	struct ept_data *ept = token;
+
+	__ASSERT_NO_MSG(packet->header.ept == ept->addr);
+
+	return send_packet(instance, packet, len, ept->cfg->prio);
+}
+
+/** Holding RX buffer for nocopy receiving. */
+static int hold_rx_buffer(const struct device *instance, void *token, void *buffer)
+{
+	struct icbmsg_data *dev_data = instance->data;
+	struct icbmsg_packet *packet = heap_packet_from_data(buffer);
+
+	__ASSERT_NO_MSG(token != NULL);
+	if (packet == dev_data->rx_packet) {
+		dev_data->rx_packet = NULL;
+		return 0;
+	}
+
+	return -EINVAL;
+}
+
+/** Release RX buffer that was previously held. */
+static int release_rx_buffer(const struct device *instance, void *token, void *buffer)
+{
+	ARG_UNUSED(token);
+	struct icbmsg_packet *packet = heap_packet_from_data(buffer);
+
+	return msg_q_consume(instance, packet->header.index);
+}
+
+/** Close the backend instance. */
+static int close(const struct device *instance)
+{
+	struct icbmsg_data *data = instance->data;
+	const struct icbmsg_config *config = instance->config;
+	int rv;
+
+	if (data->ep_cnt != 0) {
+		return -EBUSY;
+	}
+
+	LOG_DBG("Closing instance %p", instance);
+	rv = mbox_set_enabled_dt(&config->mbox_rx, false);
+	msg_q_reset(instance);
+	data->state = STATE_IDLE;
+
+	return rv;
+}
+
+/** Open the backend instance. */
+static int open(const struct device *instance)
+{
+	const struct icbmsg_config *config = instance->config;
+	struct icbmsg_data *data = instance->data;
+	int rv;
+
+	if (!device_is_ready(instance) || !mbox_is_ready_dt(&config->mbox_rx) ||
+	    !mbox_is_ready_dt(&config->mbox_tx)) {
+		return -EAGAIN;
+	}
+
+	if (data->state != STATE_IDLE) {
+		return -EALREADY;
+	}
+
+	LOG_DBG("Shm_q TX prod: %p, cons: %p", (void *)config->tx_msg_q.prod_shmq,
+		(void *)config->tx_msg_q.cons_shmq);
+	LOG_DBG("Shm_q RX prod: %p, cons: %p", (void *)config->rx_msg_q.prod_shmq,
+		(void *)config->rx_msg_q.cons_shmq);
+	LOG_DBG("  TX %zu blocks of %zu bytes at %p, max allocable %zu bytes",
+		config->tx.block_count, config->tx.block_size,
+		(void *)config->tx.blocks_ptr, heap_max_data_size(&config->tx));
+	LOG_DBG("  RX %zu blocks of %zu bytes at %p, max allocable %zu bytes",
+		config->rx.block_count, config->rx.block_size,
+		(void *)config->rx.blocks_ptr, heap_max_data_size(&config->rx));
+
+	data->state = STATE_CONNECTING;
+	rv = send_bound_request(instance);
+	if (rv < 0) {
+		return rv;
+	}
+
+	MSG_QUEUE_CACHE_INV(config->rx_msg_q.prod_shmq);
+
+	rv = mbox_register_callback_dt(&config->mbox_rx, mbox_callback, (void *)instance);
+	if (rv < 0) {
+		return rv;
+	}
+
+	return mbox_set_enabled_dt(&config->mbox_rx, true);
 }
 
 /**
@@ -1295,37 +1316,33 @@ static int release_rx_buffer(const struct device *instance, void *token, void *d
  */
 static int backend_init(const struct device *instance)
 {
-	MAYBE_CONST struct icbmsg_config *conf = (struct icbmsg_config *)instance->config;
-	struct backend_data *dev_data = instance->data;
-#ifdef CONFIG_MULTITHREADING
-	static K_THREAD_STACK_DEFINE(ep_bound_work_q_stack, EP_BOUND_WORK_Q_STACK_SIZE);
-	static bool is_work_q_started;
-	struct k_work_queue_config work_q_cfg = { .name = "icbmsg_workq" };
-
 #if defined(CONFIG_ARCH_POSIX)
+	MAYBE_CONST struct icbmsg_config *conf = (struct icbmsg_config *)instance->config;
+
 	native_emb_addr_remap((void **)&conf->tx.blocks_ptr);
 	native_emb_addr_remap((void **)&conf->rx.blocks_ptr);
+	native_emb_addr_remap((void **)&conf->tx_msg_q.prod_shmq);
+	native_emb_addr_remap((void **)&conf->tx_msg_q.cons_shmq);
+	native_emb_addr_remap((void **)&conf->rx_msg_q.prod_shmq);
+	native_emb_addr_remap((void **)&conf->rx_msg_q.cons_shmq);
 #endif
 
-	if (!is_work_q_started) {
-		k_work_queue_init(&ep_bound_work_q);
-		k_work_queue_start(&ep_bound_work_q, ep_bound_work_q_stack,
-				   K_THREAD_STACK_SIZEOF(ep_bound_work_q_stack),
-				   EP_BOUND_WORK_Q_PRIORITY, &work_q_cfg);
-
-		is_work_q_started = true;
-	}
+#if defined(CONFIG_STATS_NAMES) || defined(CONFIG_MULTITHREADING)
+	struct icbmsg_data *data = instance->data;
 #endif
 
-	dev_data->conf = conf;
-	dev_data->is_initiator = (conf->rx.blocks_ptr < conf->tx.blocks_ptr);
 #ifdef CONFIG_MULTITHREADING
-	k_mutex_init(&dev_data->mutex);
-	k_work_init(&dev_data->ep_bound_work, ept_bound_process);
-	k_sem_init(&dev_data->block_wait_sem, 0, 1);
+	k_sem_init(&data->block_wait_sem, 0, 1);
 #endif
-	memset(&dev_data->waiting_bound, 0xFF, sizeof(dev_data->waiting_bound));
-	memset(&dev_data->ept_map, EPT_ADDR_INVALID, sizeof(dev_data->ept_map));
+
+#ifdef CONFIG_STATS
+	(void)stats_init(&data->stats.s_hdr, STATS_SIZE_INIT_PARMS(data->stats, STATS_SIZE_32),
+			 STATS_NAME_INIT_PARMS(icbmsg_stats));
+	stats_register(((struct icbmsg_config *)instance->config)->stats_name,
+		       &(data->stats.s_hdr));
+#endif
+	msg_q_reset(instance);
+
 	return 0;
 }
 
@@ -1334,10 +1351,12 @@ static int backend_init(const struct device *instance)
  */
 const static struct ipc_service_backend backend_ops = {
 	.open_instance = open,
-	.close_instance = close,
+	.close_instance = IS_ENABLED(CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT) ? close : NULL,
 	.send = send,
+	.send_critical = send,
 	.register_endpoint = register_ept,
-	.deregister_endpoint = deregister_ept,
+	.deregister_endpoint =
+		IS_ENABLED(CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT) ? deregister_ept : NULL,
 	.get_tx_buffer_size = get_tx_buffer_size,
 	.get_tx_buffer = get_tx_buffer,
 	.drop_tx_buffer = drop_tx_buffer,
@@ -1347,167 +1366,219 @@ const static struct ipc_service_backend backend_ops = {
 };
 
 /**
- * Required block alignment.
+ * Size of a single shared-memory message queue at the start of each region.
  */
-#define BLOCK_ALIGNMENT sizeof(uint32_t)
+#define GET_MSG_Q_AREA_SIZE(i) ROUND_UP(sizeof(struct icbmsg_shm_q), GET_CACHE_ALIGNMENT(i))
 
 /**
- * Number of bytes per each ICMsg message. It is used to calculate size of ICMsg area.
+ * Total queue area per region (producer + consumer queues).
  */
-#define BYTES_PER_ICMSG_MESSAGE (ROUND_UP(sizeof(struct control_message),		\
-					  sizeof(void *)) + PBUF_PACKET_LEN_SZ)
+#define GET_MSG_Q_REGION_SIZE(i) (2 * GET_MSG_Q_AREA_SIZE(i))
 
 /**
- * Maximum ICMsg overhead. It is used to calculate size of ICMsg area.
+ * Address of the consumer queue in a shared memory region.
  */
-#define ICMSG_BUFFER_OVERHEAD(i)							\
-	(PBUF_HEADER_OVERHEAD(GET_CACHE_ALIGNMENT(i)) + 2 * BYTES_PER_ICMSG_MESSAGE)
+#define GET_CONS_SHMQ_ADDR_INST(i, direction)                                                      \
+	(GET_MEM_ADDR_INST(i, direction) + GET_MSG_Q_AREA_SIZE(i))
 
 /**
- * Returns required data cache alignment for instance "i".
+ * Calculate aligned block size by evenly dividing remaining space after the queue area.
  */
-#define GET_CACHE_ALIGNMENT(i) \
-	MAX(BLOCK_ALIGNMENT, DT_INST_PROP_OR(i, dcache_alignment, 0))
+#define GET_BLOCK_SIZE(i, total_size, local_blocks, remote_blocks)                                 \
+	ROUND_DOWN(((total_size) - GET_MSG_Q_REGION_SIZE(i)) / (local_blocks),                     \
+		   GET_CACHE_ALIGNMENT(i))
 
 /**
- * Calculates minimum size required for ICMsg region for specific number of local
- * and remote blocks. The minimum size ensures that ICMsg queue is will never overflow
- * because it can hold data message for each local block and release message
- * for each remote block.
+ * Calculate offset where the blocks area starts (after the message queue).
  */
-#define GET_ICMSG_MIN_SIZE(i, local_blocks, remote_blocks) ROUND_UP(			\
-	(ICMSG_BUFFER_OVERHEAD(i) + BYTES_PER_ICMSG_MESSAGE *				\
-	 (local_blocks + remote_blocks)), GET_CACHE_ALIGNMENT(i))
-
-/**
- * Calculate aligned block size by evenly dividing remaining space after removing
- * the space for ICMsg.
- */
-#define GET_BLOCK_SIZE(i, total_size, local_blocks, remote_blocks) ROUND_DOWN(		\
-	((total_size) - GET_ICMSG_MIN_SIZE(i, (local_blocks), (remote_blocks))) /	\
-	(local_blocks), BLOCK_ALIGNMENT)
-
-/**
- * Calculate offset where area for blocks starts which is just after the ICMsg.
- */
-#define GET_BLOCKS_OFFSET(i, total_size, local_blocks, remote_blocks)			\
-	((total_size) - GET_BLOCK_SIZE(i, (total_size), (local_blocks),			\
-				       (remote_blocks)) * (local_blocks))
+#define GET_BLOCKS_OFFSET(i, total_size, local_blocks, remote_blocks)                              \
+	((total_size) -                                                                            \
+	 GET_BLOCK_SIZE(i, (total_size), (local_blocks), (remote_blocks)) * (local_blocks))
 
 /**
  * Return shared memory start address aligned to block alignment and cache line.
  */
-#define GET_MEM_ADDR_INST(i, direction) \
-	ROUND_UP(DT_REG_ADDR(DT_INST_PHANDLE(i, direction##_region)),			\
-		 GET_CACHE_ALIGNMENT(i))
+#define GET_MEM_ADDR_INST(i, direction)                                                            \
+	ROUND_UP(DT_REG_ADDR(DT_INST_PHANDLE(i, direction##_region)), GET_CACHE_ALIGNMENT(i))
 
 /**
  * Return shared memory end address aligned to block alignment and cache line.
  */
-#define GET_MEM_END_INST(i, direction)							\
-	ROUND_DOWN(DT_REG_ADDR(DT_INST_PHANDLE(i, direction##_region)) +		\
-		   DT_REG_SIZE(DT_INST_PHANDLE(i, direction##_region)),			\
+#define GET_MEM_END_INST(i, direction)                                                             \
+	ROUND_DOWN(DT_REG_ADDR(DT_INST_PHANDLE(i, direction##_region)) +                           \
+			   DT_REG_SIZE(DT_INST_PHANDLE(i, direction##_region)),                    \
 		   GET_CACHE_ALIGNMENT(i))
 
 /**
  * Return shared memory size aligned to block alignment and cache line.
  */
-#define GET_MEM_SIZE_INST(i, direction) \
+#define GET_MEM_SIZE_INST(i, direction)                                                            \
 	(GET_MEM_END_INST(i, direction) - GET_MEM_ADDR_INST(i, direction))
-
-/**
- * Returns GET_ICMSG_SIZE, but for specific instance and direction.
- * 'loc' and 'rem' parameters tells the direction. They can be either "tx, rx"
- *  or "rx, tx".
- */
-#define GET_ICMSG_SIZE_INST(i, loc, rem)					\
-	GET_BLOCKS_OFFSET(							\
-		i,								\
-		GET_MEM_SIZE_INST(i, loc),					\
-		DT_INST_PROP(i, loc##_blocks),					\
-		DT_INST_PROP(i, rem##_blocks))
 
 /**
  * Returns address where area for blocks starts for specific instance and direction.
  * 'loc' and 'rem' parameters tells the direction. They can be either "tx, rx"
  *  or "rx, tx".
  */
-#define GET_BLOCKS_ADDR_INST(i, loc, rem)					\
-	GET_MEM_ADDR_INST(i, loc) +						\
-	GET_BLOCKS_OFFSET(							\
-		i,								\
-		GET_MEM_SIZE_INST(i, loc),					\
-		DT_INST_PROP(i, loc##_blocks),					\
-		DT_INST_PROP(i, rem##_blocks))
+#define GET_BLOCKS_ADDR_INST(i, loc, rem)                                                          \
+	GET_MEM_ADDR_INST(i, loc) + GET_BLOCKS_OFFSET(i, GET_MEM_SIZE_INST(i, loc),                \
+						      DT_INST_PROP(i, loc##_blocks),               \
+						      DT_INST_PROP(i, rem##_blocks))
 
 /**
  * Returns block size for specific instance and direction.
  * 'loc' and 'rem' parameters tells the direction. They can be either "tx, rx"
  *  or "rx, tx".
  */
-#define GET_BLOCK_SIZE_INST(i, loc, rem)					\
-	GET_BLOCK_SIZE(								\
-		i,								\
-		GET_MEM_SIZE_INST(i, loc),					\
-		DT_INST_PROP(i, loc##_blocks),					\
-		DT_INST_PROP(i, rem##_blocks))
+#define GET_BLOCK_SIZE_INST(i, loc, rem)                                                           \
+	GET_BLOCK_SIZE(i, GET_MEM_SIZE_INST(i, loc), DT_INST_PROP(i, loc##_blocks),                \
+		       DT_INST_PROP(i, rem##_blocks))
 
-#define DEFINE_BACKEND_DEVICE(i)							\
-	SYS_BITARRAY_DEFINE_STATIC(tx_usage_bitmap_##i, DT_INST_PROP(i, tx_blocks));	\
-	SYS_BITARRAY_DEFINE_STATIC(rx_hold_bitmap_##i, DT_INST_PROP(i, rx_blocks));	\
-	PBUF_DEFINE(tx_icbmsg_pb_##i,							\
-			GET_MEM_ADDR_INST(i, tx),					\
-			GET_ICMSG_SIZE_INST(i, tx, rx),					\
-			GET_CACHE_ALIGNMENT(i), 0, 0);					\
-	PBUF_DEFINE(rx_icbmsg_pb_##i,							\
-			GET_MEM_ADDR_INST(i, rx),					\
-			GET_ICMSG_SIZE_INST(i, rx, tx),					\
-			GET_CACHE_ALIGNMENT(i), 0, 0);					\
-	static struct backend_data backend_data_##i = {					\
-		.control_data = {							\
-			.tx_pb = &tx_icbmsg_pb_##i,					\
-			.rx_pb = &rx_icbmsg_pb_##i,					\
-		}									\
-	};										\
-	static MAYBE_CONST struct icbmsg_config backend_config_##i =			\
-	{										\
-		.control_config = {							\
-			.mbox_tx = MBOX_DT_SPEC_INST_GET(i, tx),			\
-			.mbox_rx = MBOX_DT_SPEC_INST_GET(i, rx),			\
-			.unbound_mode = ICMSG_UNBOUND_MODE_DISABLE,			\
-		},									\
-		.tx = {									\
-			.blocks_ptr = (uint8_t *)GET_BLOCKS_ADDR_INST(i, tx, rx),	\
-			.block_count = DT_INST_PROP(i, tx_blocks),			\
-			.block_size = GET_BLOCK_SIZE_INST(i, tx, rx),			\
-		},									\
-		.rx = {									\
-			.blocks_ptr = (uint8_t *)GET_BLOCKS_ADDR_INST(i, rx, tx),	\
-			.block_count = DT_INST_PROP(i, rx_blocks),			\
-			.block_size = GET_BLOCK_SIZE_INST(i, rx, tx),			\
-		},									\
-		.tx_usage_bitmap = &tx_usage_bitmap_##i,				\
-		.rx_hold_bitmap = &rx_hold_bitmap_##i,					\
-	};										\
-	BUILD_ASSERT(IS_POWER_OF_TWO(GET_CACHE_ALIGNMENT(i)),				\
-		     "This module supports only power of two cache alignment");		\
-	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, tx, rx) >= BLOCK_ALIGNMENT) &&		\
-		     (GET_BLOCK_SIZE_INST(i, tx, rx) <					\
-		      GET_MEM_SIZE_INST(i, tx)),					\
-		     "TX region is too small for provided number of blocks");		\
-	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, rx, tx) >= BLOCK_ALIGNMENT) &&		\
-		     (GET_BLOCK_SIZE_INST(i, rx, tx) <					\
-		      GET_MEM_SIZE_INST(i, rx)),					\
-		     "RX region is too small for provided number of blocks");		\
-	BUILD_ASSERT(DT_INST_PROP(i, rx_blocks) <= 256, "Too many RX blocks");		\
-	BUILD_ASSERT(DT_INST_PROP(i, tx_blocks) <= 256, "Too many TX blocks");		\
-	DEVICE_DT_INST_DEFINE(i,							\
-			      &backend_init,						\
-			      NULL,							\
-			      &backend_data_##i,					\
-			      &backend_config_##i,					\
-			      POST_KERNEL,						\
-			      CONFIG_IPC_SERVICE_REG_BACKEND_PRIORITY,			\
-			      &backend_ops);
+#define DEFINE_BACKEND_DEVICE(i)                                                                   \
+	static struct icbmsg_data icbmsg_data_##i;                                                 \
+	static MAYBE_CONST struct icbmsg_config icbmsg_config_##i = {                              \
+		.mbox_tx = MBOX_DT_SPEC_INST_GET(i, tx),                                           \
+		.mbox_rx = MBOX_DT_SPEC_INST_GET(i, rx),                                           \
+		.rx =                                                                              \
+			{                                                                          \
+				.blocks_ptr = (uint8_t *)GET_BLOCKS_ADDR_INST(i, rx, tx),          \
+				.block_size = GET_BLOCK_SIZE_INST(i, rx, tx),                      \
+				.block_count = DT_INST_PROP(i, rx_blocks),                         \
+			},                                                                         \
+		.tx =                                                                              \
+			{                                                                          \
+				.blocks_ptr = (uint8_t *)GET_BLOCKS_ADDR_INST(i, tx, rx),          \
+				.block_size = GET_BLOCK_SIZE_INST(i, tx, rx),                      \
+				.block_count = DT_INST_PROP(i, tx_blocks),                         \
+			},                                                                         \
+		.tx_msg_q =                                                                        \
+			{                                                                          \
+				.prod_shmq = (struct icbmsg_shm_q *)GET_MEM_ADDR_INST(i, tx),      \
+				.cons_shmq =                                                       \
+					(struct icbmsg_shm_q *)GET_CONS_SHMQ_ADDR_INST(i, tx),     \
+			},                                                                         \
+		.rx_msg_q =                                                                        \
+			{                                                                          \
+				.prod_shmq = (struct icbmsg_shm_q *)GET_MEM_ADDR_INST(i, rx),      \
+				.cons_shmq =                                                       \
+					(struct icbmsg_shm_q *)GET_CONS_SHMQ_ADDR_INST(i, rx),     \
+			},                                                                         \
+		.bound_packet =                                                                    \
+			BOUND_PACKET_INIT(DT_INST_PROP(i, tx_blocks), DT_INST_PROP(i, rx_blocks)), \
+		IF_ENABLED(CONFIG_STATS_NAMES,                                              \
+			   (.stats_name = STRINGIFY(ipc_icbmsg_##i),)) };         \
+	BUILD_ASSERT(IS_ALIGNED(GET_MEM_ADDR_INST(i, tx), GET_CACHE_ALIGNMENT(i)),                 \
+		     "TX producer queue is not aligned to cache alignment");                       \
+	BUILD_ASSERT(IS_ALIGNED(GET_MEM_ADDR_INST(i, rx), GET_CACHE_ALIGNMENT(i)),                 \
+		     "RX producer queue is not aligned to cache alignment");                       \
+	BUILD_ASSERT(IS_ALIGNED(GET_CONS_SHMQ_ADDR_INST(i, tx), GET_CACHE_ALIGNMENT(i)),           \
+		     "TX consumer queue is not aligned to cache alignment");                       \
+	BUILD_ASSERT(IS_ALIGNED(GET_CONS_SHMQ_ADDR_INST(i, rx), GET_CACHE_ALIGNMENT(i)),           \
+		     "RX consumer queue is not aligned to cache alignment");                       \
+	BUILD_ASSERT(IS_POWER_OF_TWO(GET_CACHE_ALIGNMENT(i)),                                      \
+		     "This module supports only power of two cache alignment");                    \
+	BUILD_ASSERT(GET_MSG_Q_REGION_SIZE(i) <= GET_BLOCKS_OFFSET(i, GET_MEM_SIZE_INST(i, tx),    \
+								   DT_INST_PROP(i, tx_blocks),     \
+								   DT_INST_PROP(i, rx_blocks)),    \
+		     "TX region is too small for the message queues");                             \
+	BUILD_ASSERT(GET_MSG_Q_REGION_SIZE(i) <= GET_BLOCKS_OFFSET(i, GET_MEM_SIZE_INST(i, rx),    \
+								   DT_INST_PROP(i, rx_blocks),     \
+								   DT_INST_PROP(i, tx_blocks)),    \
+		     "RX region is too small for the message queues");                             \
+	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, tx, rx) >= BLOCK_ALIGNMENT) &&                        \
+			     (GET_BLOCK_SIZE_INST(i, tx, rx) < GET_MEM_SIZE_INST(i, tx)),          \
+		     "TX region is too small for provided number of blocks");                      \
+	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, rx, tx) >= BLOCK_ALIGNMENT) &&                        \
+			     (GET_BLOCK_SIZE_INST(i, rx, tx) < GET_MEM_SIZE_INST(i, rx)),          \
+		     "RX region is too small for provided number of blocks");                      \
+	BUILD_ASSERT(DT_INST_PROP(i, rx_blocks) <= 32, "Too many RX blocks");                      \
+	BUILD_ASSERT(DT_INST_PROP(i, tx_blocks) <= 32, "Too many TX blocks");                      \
+	DEVICE_DT_INST_DEFINE(i, &backend_init, NULL, &icbmsg_data_##i, &icbmsg_config_##i,        \
+			      POST_KERNEL, CONFIG_IPC_SERVICE_REG_BACKEND_PRIORITY, &backend_ops);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_BACKEND_DEVICE)
+
+#ifdef CONFIG_IPC_SERVICE_BACKEND_ICBMSG_SHELL
+
+#include <zephyr/shell/shell.h>
+#include <inttypes.h>
+
+static const char *icbmsg_state_str(uint8_t state)
+{
+	switch (state) {
+	case STATE_IDLE:
+		return "idle";
+	case STATE_CONNECTING:
+		return "connecting";
+	case STATE_CONNECTED:
+		return "connected";
+	default:
+		return "unknown";
+	}
+}
+
+static void icbmsg_print_instance_stats(const struct shell *sh, const struct device *instance)
+{
+	const struct icbmsg_config *conf = instance->config;
+	struct icbmsg_data *data = instance->data;
+
+	shell_print(sh, "ICBMsg instance: %s (%s)", instance->name, icbmsg_state_str(data->state));
+
+	shell_print(sh, "  TX memory: %zu blocks of %zu B (max payload %zu B)",
+		    conf->tx.block_count, conf->tx.block_size, heap_max_data_size(&conf->tx));
+	shell_print(sh, "  TX max block usage: peak %u/%u (%u%%)",
+		    data->stats.tx_max_block_usage_count, conf->tx.block_count,
+		    (unsigned int)((data->stats.tx_max_block_usage_count * 100U) /
+				   conf->tx.block_count));
+	shell_print(sh, "  TX max slot usage: peak %u/%u (%u%%)", data->stats.tx_max_active_count,
+		    MAX_ACTIVE_COUNT,
+		    (unsigned int)((data->stats.tx_max_active_count * 100U) / MAX_ACTIVE_COUNT));
+
+	shell_print(sh, "  RX memory: %zu blocks of %zu B (max payload %zu B)",
+		    conf->rx.block_count, conf->rx.block_size, heap_max_data_size(&conf->rx));
+
+	shell_print(sh, "  Endpoints: %d / %d registered", data->ep_cnt, NUM_EPT);
+	for (int i = 0; i < data->ep_cnt; i++) {
+		shell_print(sh, "    [%d] %s", i, data->ept[i].cfg->name);
+	}
+
+	shell_print(sh, "  TX traffic:");
+	shell_print(sh, "    packets: %u (%u bytes total)", data->stats.tx_packet_count,
+		    data->stats.tx_data_count);
+	shell_print(sh, "    by block count: 1=%u, 2=%u, 3+=%u", data->stats.tx_packet_block1_count,
+		    data->stats.tx_packet_block2_count, data->stats.tx_packet_block_more_count);
+	shell_print(sh, "    allocation failures: %u", data->stats.tx_alloc_failed_count);
+
+	shell_print(sh, "  RX traffic:");
+	shell_print(sh, "    packets: %u (%u bytes total)", data->stats.rx_packet_count,
+		    data->stats.rx_data_count);
+}
+
+#define ICBMSG_DEVICE(i) DEVICE_DT_INST_GET(i),
+
+static int cmd_icbmsg_stats(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+	static const struct device *const icbmsg_devices[] = {
+		DT_INST_FOREACH_STATUS_OKAY(ICBMSG_DEVICE)};
+
+	for (size_t i = 0; i < ARRAY_SIZE(icbmsg_devices); i++) {
+		if (!device_is_ready(icbmsg_devices[i])) {
+			shell_warn(sh, "ICBMsg instance %s is not ready", icbmsg_devices[i]->name);
+			continue;
+		}
+
+		icbmsg_print_instance_stats(sh, icbmsg_devices[i]);
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_icbmsg,
+			       SHELL_CMD(stats, NULL, "Print ICBMsg statistics", cmd_icbmsg_stats),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_REGISTER(icbmsg, &sub_icbmsg, "ICBMsg IPC backend commands", NULL);
+
+#endif /* CONFIG_IPC_SERVICE_BACKEND_ICBMSG_SHELL */

--- a/tests/subsys/ipc/ipc_service_api/Kconfig
+++ b/tests/subsys/ipc/ipc_service_api/Kconfig
@@ -11,10 +11,23 @@ config IPC_SERVICE_API_TEST_DEREGISTER
 	help
 	  Run the endpoint deregistration test case.
 
+config IPC_SERVICE_API_TEST_PRIORITY
+	bool "Test endpoint priorities"
+	default y if IPC_SERVICE_BACKEND_ICBMSG
+	help
+	  Run the endpoint priority test case.
+
 config IPC_SERVICE_API_TEST_SECOND_ENDPOINT
 	bool "Test second endpoint"
 	default y if IPC_SERVICE_BACKEND_ICBMSG || IPC_SERVICE_BACKEND_RPMSG
 	help
 	  Run the second endpoint test case.
+
+config IPC_SERVICE_API_TEST_ISR_SEND
+	bool "Test send from interrupt context"
+	default y if IPC_SERVICE_BACKEND_ICBMSG
+	help
+	  Run test cases that call ipc_service_send() and ipc_service_send_nocopy()
+	  from a k_timer expiry handler (interrupt context).
 
 endmenu

--- a/tests/subsys/ipc/ipc_service_api/remote/src/remote.c
+++ b/tests/subsys/ipc/ipc_service_api/remote/src/remote.c
@@ -112,12 +112,13 @@ static void ep_received(const void *data, size_t len, void *priv)
 	}
 }
 
-static int register_endpoint(struct test_context *ctx, const char *name, bool with_unbound)
+static int register_endpoint(struct test_context *ctx, const char *name, int priority)
 {
 	ctx->ep_cfg.name = name;
 	ctx->ep_cfg.priv = ctx;
+	ctx->ep_cfg.prio = priority;
 	ctx->ep_cfg.cb.bound = ep_bound;
-	ctx->ep_cfg.cb.unbound = with_unbound ? ep_unbound : NULL;
+	ctx->ep_cfg.cb.unbound = ep_unbound;
 	ctx->ep_cfg.cb.received = ep_received;
 	ctx->ep_cfg.cb.error = ep_error;
 
@@ -142,7 +143,7 @@ int main(void)
 	}
 
 	for (size_t i = 0; i < ep_cnt; i++) {
-		ret = register_endpoint(&test_ctx[i], ep_name[i], i == TEST_EP0);
+		ret = register_endpoint(&test_ctx[i], ep_name[i], i);
 		if (ret < 0) {
 			LOG_ERR("ipc_service_register_endpoint() failed: %d", ret);
 			return ret;

--- a/tests/subsys/ipc/ipc_service_api/src/main.c
+++ b/tests/subsys/ipc/ipc_service_api/src/main.c
@@ -171,12 +171,13 @@ static bool hold_rx_supported(void)
 	       IS_ENABLED(CONFIG_IPC_SERVICE_BACKEND_RPMSG);
 }
 
-static void register_endpoint(struct test_context *ctx, const char *name)
+static void register_endpoint(struct test_context *ctx, const char *name, int priority)
 {
 	int ret;
 
 	ctx->ep_cfg.name = name;
 	ctx->ep_cfg.priv = ctx;
+	ctx->ep_cfg.prio = priority;
 	ctx->ep_cfg.cb.bound = ep_bound;
 	ctx->ep_cfg.cb.unbound = ep_unbound;
 	ctx->ep_cfg.cb.received = ep_received;
@@ -215,7 +216,7 @@ static void setup_impl(void)
 
 	k_msleep(10);
 	for (size_t i = 0; i < ep_cnt; i++) {
-		register_endpoint(&test_ctx[i], ep_name[i]);
+		register_endpoint(&test_ctx[i], ep_name[i], i);
 		wait_for_remote_ready(&test_ctx[i]);
 	}
 }
@@ -284,7 +285,41 @@ ZTEST(ipc_service_api, test_deregister_endpoint)
 	ret = ipc_service_send(&ctx->ep, &cmd, sizeof(cmd));
 	zassert_equal(ret, -ENOENT, "Send after deregister should return -ENOENT, got %d", ret);
 
-	register_endpoint(ctx, ep_name[0]);
+	register_endpoint(ctx, ep_name[0], 0);
+}
+
+ZTEST(ipc_service_api, test_remote_deregister_endpoint)
+{
+	int ret;
+	struct api_test_msg cmd = {.cmd = API_TEST_CMD_DEREGISTER};
+	struct api_test_msg ping = {.cmd = API_TEST_CMD_PING};
+	struct api_test_msg rsp = {.cmd = API_TEST_CMD_PONG};
+	struct test_context *ctx = ep0();
+
+	if (!IS_ENABLED(CONFIG_IPC_SERVICE_API_TEST_DEREGISTER)) {
+		ztest_test_skip();
+		return;
+	}
+
+	ctx->unbound = false;
+	test_context_reset_rx(ctx);
+
+	ret = ipc_service_send(&ctx->ep, &cmd, sizeof(cmd));
+	zassert_equal(ret, sizeof(cmd), "DEREGISTER request send failed: %d", ret);
+
+	zassert_true(wait_for_flag(&ctx->unbound, 100),
+		     "Timed out waiting for unbound after remote deregister");
+	zassert_false(ctx->bound, "Endpoint should be unbound");
+
+	k_msleep(1);
+
+	register_endpoint(ctx, ep_name[0], 0);
+
+	ret = ipc_service_send(&ctx->ep, &ping, sizeof(ping));
+	zassert_equal(ret, sizeof(ping), "PING after re-register failed: %d", ret);
+
+	ret = wait_for_msg(ctx, &rsp, sizeof(rsp), 100);
+	zassert_ok(ret, "No PONG after remote-initiated deregister and re-bind");
 }
 
 ZTEST(ipc_service_api, test_get_tx_buffer_size)
@@ -705,5 +740,170 @@ ZTEST(ipc_service_api, test_send_critical)
 		zassert_ok(ret, "No PONG response after ISR send");
 	}
 }
+
+#ifdef CONFIG_IPC_SERVICE_API_TEST_ISR_SEND
+
+static volatile bool isr_send_done;
+static volatile int isr_send_ret;
+
+#if IS_ENABLED(CONFIG_MULTITHREADING)
+static K_SEM_DEFINE(isr_send_sem, 0, 1);
+#endif
+
+static void isr_send_signal_done(void)
+{
+	isr_send_done = true;
+#if IS_ENABLED(CONFIG_MULTITHREADING)
+	k_sem_give(&isr_send_sem);
+#endif
+}
+
+static void isr_send_wait_done(void)
+{
+#if IS_ENABLED(CONFIG_MULTITHREADING)
+	int ret = k_sem_take(&isr_send_sem, K_MSEC(1000));
+
+	zassert_ok(ret, "Timed out waiting for ISR send");
+#else
+	zassert_true(wait_for_flag(&isr_send_done, 1000), "Timed out waiting for ISR send");
+#endif
+}
+
+static struct api_test_msg isr_send_cmd;
+
+static void isr_send_timer_handler(struct k_timer *timer)
+{
+	ARG_UNUSED(timer);
+
+	zassert_true(k_is_in_isr(), "Timer handler should run in ISR context");
+
+	isr_send_ret = ipc_service_send(&ep0()->ep, &isr_send_cmd, sizeof(isr_send_cmd));
+	isr_send_signal_done();
+}
+
+static K_TIMER_DEFINE(isr_send_timer, isr_send_timer_handler, NULL);
+
+ZTEST(ipc_service_api, test_isr_send)
+{
+	int ret;
+	struct api_test_msg rsp = {.cmd = API_TEST_CMD_PONG};
+	struct test_context *ctx = ep0();
+
+	test_context_reset_rx(ctx);
+	isr_send_done = false;
+#if IS_ENABLED(CONFIG_MULTITHREADING)
+	k_sem_reset(&isr_send_sem);
+#endif
+
+	isr_send_cmd = (struct api_test_msg){.cmd = API_TEST_CMD_PING};
+
+	k_timer_start(&isr_send_timer, K_MSEC(1), K_NO_WAIT);
+	isr_send_wait_done();
+
+	zassert_equal(isr_send_ret, sizeof(isr_send_cmd), "ipc_service_send from ISR failed: %d",
+		      isr_send_ret);
+
+	ret = wait_for_msg(ctx, &rsp, sizeof(rsp), 100);
+	zassert_ok(ret, "No PONG response after ISR ipc_service_send");
+}
+
+static struct api_test_msg isr_nocopy_expected_rsp;
+
+static void isr_nocopy_timer_handler(struct k_timer *timer)
+{
+	int ret;
+	void *tx_buf;
+	uint32_t tx_size = 0;
+	struct api_test_msg *msg;
+
+	ARG_UNUSED(timer);
+
+	zassert_true(k_is_in_isr(), "Timer handler should run in ISR context");
+
+	ret = ipc_service_get_tx_buffer(&ep0()->ep, &tx_buf, &tx_size, K_NO_WAIT);
+	zassert_ok(ret, "ipc_service_get_tx_buffer from ISR failed: %d", ret);
+	zassert_true(tx_size >= sizeof(struct api_test_msg), "TX buffer too small: %u", tx_size);
+
+	msg = tx_buf;
+	msg->cmd = API_TEST_CMD_ECHO;
+	memset(msg->data, 0xab, sizeof(msg->data));
+
+	isr_nocopy_expected_rsp = *msg;
+	isr_nocopy_expected_rsp.cmd = API_TEST_CMD_ECHO_RSP;
+
+	isr_send_ret = ipc_service_send_nocopy(&ep0()->ep, tx_buf, sizeof(*msg));
+	isr_send_signal_done();
+}
+
+static K_TIMER_DEFINE(isr_nocopy_timer, isr_nocopy_timer_handler, NULL);
+
+ZTEST(ipc_service_api, test_isr_send_nocopy)
+{
+	int ret;
+	struct test_context *ctx = ep0();
+
+	if (!nocopy_supported(ctx)) {
+		ztest_test_skip();
+		return;
+	}
+
+	test_context_reset_rx(ctx);
+	isr_send_done = false;
+#if IS_ENABLED(CONFIG_MULTITHREADING)
+	k_sem_reset(&isr_send_sem);
+#endif
+
+	k_timer_start(&isr_nocopy_timer, K_MSEC(1), K_NO_WAIT);
+	isr_send_wait_done();
+
+	zassert_equal(isr_send_ret, sizeof(struct api_test_msg),
+		      "ipc_service_send_nocopy from ISR failed: %d", isr_send_ret);
+
+	ret = wait_for_msg(ctx, &isr_nocopy_expected_rsp, sizeof(isr_nocopy_expected_rsp), 100);
+	zassert_ok(ret, "No ECHO_RSP after ISR ipc_service_send_nocopy");
+}
+
+#endif /* CONFIG_IPC_SERVICE_API_TEST_ISR_SEND */
+
+#ifdef CONFIG_IPC_SERVICE_API_TEST_PRIORITY
+static struct test_context *priority_ctx[TEST_EP_COUNT];
+static int priority_count;
+
+static void priority_cb(const void *data, size_t len, struct test_context *ctx)
+{
+	priority_ctx[priority_count++] = ctx;
+}
+
+ZTEST(ipc_service_api, test_endpoint_priority)
+{
+	int ret;
+	struct api_test_msg cmd = {.cmd = API_TEST_CMD_PING};
+	static struct k_spinlock lock;
+
+	recv_override = priority_cb;
+
+	K_SPINLOCK(&lock) {
+		ret = ipc_service_send(&ep0()->ep, &cmd, sizeof(cmd));
+		zassert_equal(ret, sizeof(cmd), "Send failed: %d", ret);
+
+		ret = ipc_service_send(&ep1()->ep, &cmd, sizeof(cmd));
+		zassert_equal(ret, sizeof(cmd), "Send failed: %d", ret);
+
+		k_busy_wait(1000);
+	}
+
+	k_msleep(10);
+	zassert_equal(priority_count, TEST_EP_COUNT, "Expected %u priority contexts, got %u",
+		      TEST_EP_COUNT, priority_count);
+	zassert_equal(priority_ctx[0], ep1(), "Expected %p, got %p", ep1(), priority_ctx[0]);
+	zassert_equal(priority_ctx[1], ep0(), "Expected %p, got %p", ep0(), priority_ctx[1]);
+
+	for (int i = 0; i < TEST_EP_COUNT; i++) {
+		zassert_equal(priority_ctx[i]->ep_cfg.prio, TEST_EP_COUNT - i - 1,
+			      "Expected priority %u, got %u", TEST_EP_COUNT - i - 1,
+			      priority_ctx[i]->ep_cfg.prio);
+	}
+}
+#endif
 
 ZTEST_SUITE(ipc_service_api, NULL, suite_setup, suite_before, NULL, NULL);

--- a/tests/subsys/ipc/ipc_service_api/tests.yaml
+++ b/tests/subsys/ipc/ipc_service_api/tests.yaml
@@ -37,6 +37,9 @@ tests:
     extra_args:
       - FILE_SUFFIX=icbmsg
       - remote_FILE_SUFFIX=icbmsg
+      - remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT=y
+    extra_configs:
+      - CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT=y
   tests.ipc.ipc_service_api.static_vrings:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
@@ -73,6 +76,9 @@ tests:
       - remote_FILE_SUFFIX=icbmsg
       - SB_CONFIG_REMOTE_NRF54H20_CPUPPR_CORE=y
       - ipc_service_api_SNIPPET=nordic-ppr
+      - remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT=y
+    extra_configs:
+      - CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT=y
   tests.ipc.ipc_service_api.icmsg.cpuflpr:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
@@ -98,10 +104,13 @@ tests:
     extra_args:
       - FILE_SUFFIX=icbmsg_cpuflpr
       - remote_FILE_SUFFIX=icbmsg
+      - remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT=y
       - SB_CONFIG_REMOTE_NRF54H20_CPUFLPR_CORE=y
     required_snippets:
       - nordic-log-stm
       - nordic-flpr
+    extra_configs:
+      - CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT=y
   tests.ipc.ipc_service_api.icmsg.no_multithreading:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
@@ -132,5 +141,7 @@ tests:
       - FILE_SUFFIX=icbmsg
       - remote_FILE_SUFFIX=icbmsg
       - remote_CONFIG_MULTITHREADING=n
+      - remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT=y
     extra_configs:
       - CONFIG_MULTITHREADING=n
+      - CONFIG_IPC_SERVICE_BACKEND_ICBMSG_DEINIT=y


### PR DESCRIPTION
Major rework of ICBMSG backend. It's goal is to improve the backend in the following areas:
- performance - faster control path, handling data in the mailbox interrupt handler, faster block allocation, allow sending data from an interrupt context
- code size - do not use layered approach with ICMSG. Reduce code by not using bitarray, k_work/thread and using simplified control path, optional support for close and deregister which are rarely used in the typical application
- API coverage - add endpoint priority support (two levels are support 0 - normal, 1 - high), call unbound callback on remote deregister

Comparison with the legacy implementation:

|Feature | legacy | new |
| ------------- | ------------- | ----- |
| benchmark test code size reduction  | N/A  |  -5500 bytes |
| code size ipc service (no assert, logs) | 5267 bytes + 1000 bitarray  | 1980 bytes |
| turnaround time 16 byte nrf54l15 | 43 us | 14 us |
| Throughput 32 byte packets | 938 kB/s | 3779 kB/s |
| Throughput 128 byte packets  | 2420 kB/s | 8828 kB/s |
| Throughput mutliple contexts | 277 kB/s | 553 kB/s |

Overall, performance is improved around 3 times.

Work is based on:

- [x] #111765
- [x] #111764 
- [x] #111351