### PR TITLE
pmci: mctp: Update libmctp and more

### DIFF
--- a/include/zephyr/pmci/mctp/mctp_memory.h
+++ b/include/zephyr/pmci/mctp/mctp_memory.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/**
+ * @file
+ * @brief MCTP memory management functions
+ */
+
+#ifndef ZEPHYR_MCTP_MEMORY_H_
+#define ZEPHYR_MCTP_MEMORY_H_
+
+/**
+ * Allocate memory from the MCTP heap.
+ *
+ * This function allocates memory from the MCTP heap. The memory returned is suitable
+ * to be sent to libmctp function that take ownership of the memory. The allocated memory
+ * should be freed using mctp_heap_free() when it is no longer needed.
+ *
+ * @param bytes Number of bytes to allocate.
+ *
+ * @return Pointer to the allocated memory, or NULL if allocation failed.
+ */
+void *mctp_heap_alloc(size_t bytes);
+
+/**
+ * Free memory allocated from the MCTP heap.
+ *
+ * This function frees memory that was previously allocated from the MCTP heap using
+ * mctp_heap_alloc(). The pointer passed to this function must have been returned by
+ * mctp_heap_alloc() and must not have been freed already.
+ *
+ * @param ptr Pointer to the memory to free.
+ */
+void mctp_heap_free(void *ptr);
+
+#endif /* ZEPHYR_MCTP_MEMORY_H_ */

--- a/subsys/pmci/mctp/Kconfig
+++ b/subsys/pmci/mctp/Kconfig
@@ -87,6 +87,13 @@ config MCTP_USB
 	help
 	  Build the MCTP USB binding to use MCTP over Zephyr's USB device interface.
 
+config LIBMCTP_CONTROL_HANDLER_ENABLED
+	bool "libmctp Control Handler"
+	help
+	  Enable the libmctp control handler for MCTP control messages. Applications
+	  may want to enable it if they don't want to handle MCTP control messages
+	  themselves or intercept them before libmctp's control handler.
+
 module = MCTP
 module-str = MCTP
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/pmci/mctp/mctp_memory.c
+++ b/subsys/pmci/mctp/mctp_memory.c
@@ -16,7 +16,7 @@ static struct {
 	struct sys_heap heap;
 } mctp_heap;
 
-static void *mctp_heap_alloc(size_t bytes)
+void *mctp_heap_alloc(size_t bytes)
 {
 	k_spinlock_key_t key = k_spin_lock(&mctp_heap.lock);
 
@@ -27,7 +27,7 @@ static void *mctp_heap_alloc(size_t bytes)
 	return ptr;
 }
 
-static void mctp_heap_free(void *ptr)
+void mctp_heap_free(void *ptr)
 {
 	k_spinlock_key_t key = k_spin_lock(&mctp_heap.lock);
 

--- a/west.yml
+++ b/west.yml
@@ -299,7 +299,7 @@ manifest:
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3
     - name: libmctp
-      revision: 782a9da666b6e7703b28dee65499a8f1f456f2b5
+      revision: b6be45dfc5c67c43c3a5e12589ae3845ea00ab5e
       path: modules/lib/libmctp
     - name: libmetal
       revision: c41f476ba425663cadf7e456b6432e4b21591278


### PR DESCRIPTION
- Get latest version of libmctp;
- Kconfig option to disable libmctp default handling of MCTP control messages - so that applications can do their own handling;
- Expose MCTP allocation/deallocation functions - as libmctp has this habit of taking ownership of buffers, we need to give it what it can also free.

Companion PR to libmctp at https://github.com/zephyrproject-rtos/libmctp/pull/3