### PR TITLE
sysbuild: extensions: add SNIPPET to ExternalZephyrProject_Add

### DIFF
--- a/doc/build/snippets/using.rst
+++ b/doc/build/snippets/using.rst
@@ -51,3 +51,16 @@ can be added to that application's ``CMakeLists.txt`` file. For example:
    endif()
 
    find_package(Zephyr ....)
+
+If :ref:`adding an extra zephyr application using sysbuild <sysbuild_zephyr_application>`, the
+required snippets can be provided to ``ExternalZephyrProject_Add()`` using the ``SNIPPET``
+argument. For example:
+
+.. code-block:: cmake
+
+   ExternalZephyrProject_Add(
+     APPLICATION sample
+     SOURCE_DIR <path-to>/sample
+     BOARD <board>
+     SNIPPET snippet1 snippet2 ...
+   )

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -194,6 +194,7 @@ endfunction()
 #                             SOURCE_DIR <dir>
 #                             [BOARD <board> [BOARD_REVISION <revision>]]
 #                             [APP_TYPE <MAIN|BOOTLOADER|FIRMWARE_LOADER>]
+#                             [SNIPPET <snippet>]
 #                             [BUILD_ONLY <bool>]
 #   )
 #
@@ -214,13 +215,14 @@ endfunction()
 #                             MAIN_APP unmodified.
 #                             BOOTLOADER indicates this app is a bootloader
 #                             FIRMWARE_LOADER indicates this app is a firmware loader image for MCUboot
+# SNIPPET <snippet>:          List of default snippets to append to the application.
 # BUILD_ONLY <bool>:          Mark the application as build-only. If <bool> evaluates to
 #                             true, then this application will be excluded from flashing
 #                             and debugging.
 #
 function(ExternalZephyrProject_Add)
   set(app_types MAIN BOOTLOADER FIRMWARE_LOADER)
-  cmake_parse_arguments(ZBUILD "" "APPLICATION;BOARD;BOARD_REVISION;SOURCE_DIR;APP_TYPE;BUILD_ONLY" "" ${ARGN})
+  cmake_parse_arguments(ZBUILD "" "APPLICATION;BOARD;BOARD_REVISION;SOURCE_DIR;APP_TYPE;SNIPPET;BUILD_ONLY" "" ${ARGN})
 
   if(ZBUILD_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR
@@ -426,6 +428,21 @@ function(ExternalZephyrProject_Add)
       "ExternalZephyrProject_Add(... BOARD_REVISION ${ZBUILD_BOARD_REVISION})"
       " requires BOARD."
     )
+  endif()
+
+  if(DEFINED ZBUILD_SNIPPET)
+    if(NOT ${ZBUILD_APPLICATION}_SNIPPET)
+      set(${ZBUILD_APPLICATION}_SNIPPET ${SNIPPET} CACHE INTERNAL "" FORCE)
+    endif()
+    foreach(snippet ${ZBUILD_SNIPPET})
+      if(NOT ${snippet} IN_LIST ${ZBUILD_APPLICATION}_SNIPPET)
+        set(
+          ${ZBUILD_APPLICATION}_SNIPPET
+          ${${ZBUILD_APPLICATION}_SNIPPET} ${snippet}
+          CACHE INTERNAL "" FORCE
+        )
+      endif()
+    endforeach()
   endif()
 
   if(DEFINED ZBUILD_BUILD_ONLY)


### PR DESCRIPTION
Add SNIPPET argument to ExternalZephyrProject_Add() which allows defining required snippets for the external project being added. The snippets will be appended to the external projects snippets provided by the user if they are not already present.

Adding required snippets to applications is described here https://docs.zephyrproject.org/latest/build/snippets/using.html#application-required-snippets This PR extends this logic to external projects added using sysbuild.

It is sort of similar to https://github.com/zephyrproject-rtos/zephyr/blob/f33aa2bc4a430e0a330a30cde38c35aea184962a/share/sysbuild/images/bootloader/CMakeLists.txt#L22-L27 though instead of adding the snippet to a duplicate of an existing image, this is adding the snippet to new image.
