### PR TITLE
ztest: use snprintk instead of snprintf

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -858,12 +858,12 @@ static int z_ztest_run_test_dispatch(struct ztest_suite_node *suite,
 				const char *param_name =
 					inst->values->name_cb(i, z_ztest_param_state.value);
 
-				snprintf(z_ztest_param_state.display_name,
+				snprintk(z_ztest_param_state.display_name,
 					 sizeof(z_ztest_param_state.display_name),
 					 "%s[%s/%s]", test->name, inst->instance_name,
 					 param_name);
 			} else {
-				snprintf(z_ztest_param_state.display_name,
+				snprintk(z_ztest_param_state.display_name,
 					 sizeof(z_ztest_param_state.display_name),
 					 "%s[%s/%zu]", test->name, inst->instance_name, i);
 			}


### PR DESCRIPTION
This file introduced a couple of snprintf since 1d7d9341d12b, this resulted in a flash usage blowup of about 28kB for some of our downstream platform due to a cascade of string parsing libraries that are brought in by snprintf. Looks like snprintk does not have that problem and is already used in this file, switch to that instead.