### PR TITLE
scripts: twister: report unknown platform when loading a test plan

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -744,6 +744,11 @@ class TestPlan:
                     toolchain = ts["toolchain"]
 
                     platform = self.get_platform(ts["platform"])
+                    if platform is None:
+                        raise TwisterRuntimeError(
+                            f"{file}: unknown platform {ts['platform']} "
+                            f"for test {ts['name']}"
+                        )
                     if filter_platform and platform.name not in filter_platform:
                         continue
                     instance = TestInstance(

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -1874,6 +1874,33 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
     assert all([log in caplog.text for log in expected_logs])
 
 
+def test_testplan_load_from_file_unknown_platform():
+    env = mock_twister_env()
+    env.outdir = os.path.join('out', 'dir')
+    testplan = TestPlan(env=env)
+    testplan.options = mock.Mock(device_testing=False, test_only=True, report_summary=None)
+    testplan.testsuites = {'TestSuite 1': mock.Mock(testcases=[])}
+    testplan.get_platform = mock.Mock(return_value=None)
+
+    testplan_data = """\
+{
+    "testsuites": [
+        {
+            "name": "TestSuite 1",
+            "platform": "Unknown Platform",
+            "toolchain": "zephyr"
+        }
+    ]
+}
+"""
+
+    with mock.patch('builtins.open', mock.mock_open(read_data=testplan_data)), \
+         pytest.raises(TwisterRuntimeError) as exc:
+        testplan.load_from_file('dummy.yaml')
+
+    assert 'unknown platform Unknown Platform' in str(exc.value)
+
+
 def test_testplan_add_instances():
     testplan = TestPlan(env=mock_twister_env())
     instance1 = mock.Mock()


### PR DESCRIPTION
**Explain _what_ this PR does.**

When a saved test plan is loaded with `--load-tests`/`-F`, `TestPlan.get_platform()` returns `None` for any `platform` entry in the file that is not part of the current build (for example a stale test plan, or a platform/board variant that no longer exists). `load_from_file()` then passes that `None` straight into `TestInstance()`, which dereferences `platform.name` and fails with:

`
AttributeError: 'NoneType' object has no attribute 'name'
`

That traceback gives no indication of which entry in the test plan is at fault.

This change adds an explicit check: if the platform cannot be resolved, `load_from_file()` raises a `TwisterRuntimeError` naming the file, the unknown platform and the test, so the bad/stale entry is obvious. A unit test covering the unknown-platform case is included.