### PR TITLE
drivers: dma: infineon: add suspend/resume support

### DIFF
--- a/drivers/dma/dma_infineon.c
+++ b/drivers/dma/dma_infineon.c
@@ -52,6 +52,13 @@ struct ifx_cat1_dma_channel {
 	uint32_t channel_direction: 3;
 	uint32_t error_callback_dis: 1;
 
+	/* Kept out of the bitfield above on purpose: suspend()/resume()/stop()
+	 * update this from contexts that can preempt a channel (re)configuration,
+	 * and a read-modify-write of a shared bitfield word would race with the
+	 * direction/error bits. A standalone byte is stored atomically.
+	 */
+	bool suspended;
+
 	cy_stc_dma_descriptor_t *descr;
 	IRQn_Type irq;
 
@@ -344,6 +351,7 @@ static int ifx_cat1_dma_configure(const struct device *dev, uint32_t channel,
 			/* allocate new descriptor */
 			if (_dma_alloc_descriptor((void **)&descriptor)) {
 				LOG_ERR("Can't allocate new descriptor");
+				irq_unlock(key);
 				return -EINVAL;
 			}
 
@@ -395,6 +403,7 @@ static int ifx_cat1_dma_configure(const struct device *dev, uint32_t channel,
 	/* Initialize channel */
 	dma_status = Cy_DMA_Channel_Init(cfg->regs, channel, &channel_config);
 	if (dma_status != CY_DMA_SUCCESS) {
+		irq_unlock(key);
 		return -EIO;
 	}
 
@@ -407,6 +416,26 @@ DW_Type *ifx_cat1_dma_get_regs(const struct device *dev)
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
 
 	return cfg->regs;
+}
+
+/* Issue the software trigger a memory-sourced DW transfer needs to (re)start.
+ * Shared by ifx_cat1_dma_start() and ifx_cat1_dma_resume() so both paths stay
+ * in sync.
+ */
+static void ifx_cat1_dma_sw_trigger(const struct device *dev, uint32_t channel)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
+
+	if ((data->channels[channel].channel_direction == MEMORY_TO_MEMORY) ||
+	    (data->channels[channel].channel_direction == MEMORY_TO_PERIPHERAL)) {
+		cyhal_dma_t dma_obj = {
+			.resource.type = CYHAL_RSC_DW,
+			.resource.block_num = _get_hw_block_num(cfg->regs),
+			.resource.channel_num = channel,
+		};
+		(void)cyhal_dma_start_transfer(&dma_obj);
+	}
 }
 
 static int ifx_cat1_dma_start(const struct device *dev, uint32_t channel)
@@ -427,14 +456,8 @@ static int ifx_cat1_dma_start(const struct device *dev, uint32_t channel)
 
 	/* Enable DMA channel */
 	Cy_DMA_Channel_Enable(cfg->regs, channel);
-	if ((data->channels[channel].channel_direction == MEMORY_TO_MEMORY) ||
-	    (data->channels[channel].channel_direction == MEMORY_TO_PERIPHERAL)) {
-		cyhal_dma_t dma_obj = {
-			.resource.type = CYHAL_RSC_DW,
-			.resource.block_num = _get_hw_block_num(cfg->regs),
-			.resource.channel_num = channel,
-		};
-		(void)cyhal_dma_start_transfer(&dma_obj);
+	if (!data->channels[channel].suspended) {
+		ifx_cat1_dma_sw_trigger(dev, channel);
 	}
 	return 0;
 }
@@ -442,14 +465,85 @@ static int ifx_cat1_dma_start(const struct device *dev, uint32_t channel)
 static int ifx_cat1_dma_stop(const struct device *dev, uint32_t channel)
 {
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
 
 	if (channel >= cfg->num_channels) {
 		LOG_ERR("Unsupported channel");
 		return -EINVAL;
 	}
 
+	/* A full stop clears any pending suspended state. */
+	data->channels[channel].suspended = false;
+
 	/* Disable DMA channel */
 	Cy_DMA_Channel_Disable(cfg->regs, channel);
+
+	return 0;
+}
+
+static int ifx_cat1_dma_suspend(const struct device *dev, uint32_t channel)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
+
+	if (channel >= cfg->num_channels) {
+		LOG_ERR("Unsupported channel");
+		return -EINVAL;
+	}
+
+	/* Suspend is realized by withholding the software trigger, so it only
+	 * applies to memory-sourced (software-triggered) transfers - the same
+	 * directions ifx_cat1_dma_sw_trigger() acts on. A hardware-triggered
+	 * channel is advanced by its peripheral trigger, which this driver cannot
+	 * gate, so report that suspend is unsupported for it instead of silently
+	 * failing to pause.
+	 */
+	if ((data->channels[channel].channel_direction != MEMORY_TO_MEMORY) &&
+	    (data->channels[channel].channel_direction != MEMORY_TO_PERIPHERAL)) {
+		return -ENOTSUP;
+	}
+
+	/* Pause by withholding the next software trigger: mark the channel
+	 * suspended so a software-rechained transfer (e.g. one kicked from the
+	 * completion callback) does not re-trigger it until ifx_cat1_dma_resume()
+	 * runs. The in-flight one-shot descriptor is allowed to finish on its
+	 * own; the channel is deliberately NOT disabled here because per the DW
+	 * TRM disabling an actively transferring channel by software leaves its
+	 * state undefined.
+	 */
+	data->channels[channel].suspended = true;
+
+	return 0;
+}
+
+static int ifx_cat1_dma_resume(const struct device *dev, uint32_t channel)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
+
+	if (channel >= cfg->num_channels) {
+		LOG_ERR("Unsupported channel");
+		return -EINVAL;
+	}
+
+	/* Only a channel that was actually suspended can be resumed. Resuming a
+	 * running or already-completed channel would issue a software trigger
+	 * with no valid current descriptor and raise a CURR_PTR_NULL error.
+	 */
+	if (!data->channels[channel].suspended) {
+		return -EINVAL;
+	}
+
+	/* Clear the suspended state so the software trigger is issued again. */
+	data->channels[channel].suspended = false;
+
+	/* Re-enable the channel (idempotent if the gated restart already did) and
+	 * re-issue the software trigger the withheld transfer needs to continue,
+	 * mirroring ifx_cat1_dma_start().
+	 */
+	Cy_DMA_Channel_Enable(cfg->regs, channel);
+
+	ifx_cat1_dma_sw_trigger(dev, channel);
 
 	return 0;
 }
@@ -459,10 +553,16 @@ int ifx_cat1_dma_reload(const struct device *dev, uint32_t channel, uint32_t src
 {
 	struct ifx_cat1_dma_data *data = dev->data;
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
-	cy_stc_dma_descriptor_t *descriptor = data->channels[channel].descr;
+	cy_stc_dma_descriptor_t *descriptor;
 
 	if (channel >= cfg->num_channels) {
 		LOG_ERR("Unsupported channel");
+		return -EINVAL;
+	}
+
+	descriptor = data->channels[channel].descr;
+	if (descriptor == NULL) {
+		LOG_ERR("Channel not configured");
 		return -EINVAL;
 	}
 
@@ -560,7 +660,15 @@ static int ifx_cat1_dma_get_status(const struct device *dev, uint32_t channel,
 			uint32_t total_transfer_size = get_total_size(dev, channel);
 			uint32_t transferred_size = get_transferred_size(dev, channel);
 
-			stat->pending_length = total_transfer_size - transferred_size;
+			/* transferred_size can momentarily read >= total when the
+			 * transfer has just completed; clamp to avoid an unsigned
+			 * underflow wrapping pending_length to a huge value.
+			 */
+			if (total_transfer_size > transferred_size) {
+				stat->pending_length = total_transfer_size - transferred_size;
+			} else {
+				stat->pending_length = 0;
+			}
 		} else {
 			stat->pending_length = 0;
 		}
@@ -681,6 +789,8 @@ static DEVICE_API(dma, ifx_cat1_dma_api) = {
 	.config = ifx_cat1_dma_configure,
 	.start = ifx_cat1_dma_start,
 	.stop = ifx_cat1_dma_stop,
+	.suspend = ifx_cat1_dma_suspend,
+	.resume = ifx_cat1_dma_resume,
 	.reload = ifx_cat1_dma_reload,
 	.get_status = ifx_cat1_dma_get_status,
 };

--- a/drivers/dma/dma_infineon.c
+++ b/drivers/dma/dma_infineon.c
@@ -48,9 +48,30 @@ LOG_MODULE_REGISTER(ifx_cat1_dma, CONFIG_DMA_LOG_LEVEL);
 #define IFX_CAT1_DMA_SRC_ADDR(v) ((void *)v)
 #endif
 
+/* Per-channel state machine. A DW channel is a single-owner object, so these
+ * transitions are driven only by this channel's config/start/stop/suspend/
+ * resume calls and its own completion interrupt (see the dma.h channel state
+ * machine expectations).
+ */
+enum ifx_cat1_dma_ch_state {
+	IFX_DMA_CH_UNCONFIGURED = 0, /* reset state: no descriptor configured */
+	IFX_DMA_CH_CONFIGURED,      /* configured and idle (also after completion) */
+	IFX_DMA_CH_RUNNING,         /* enabled and triggered, transfer in flight */
+	IFX_DMA_CH_SUSPENDED,       /* paused: the next SW (re)start trigger is withheld */
+};
+
 struct ifx_cat1_dma_channel {
 	uint32_t channel_direction: 3;
 	uint32_t error_callback_dis: 1;
+
+	enum ifx_cat1_dma_ch_state state;
+
+	/* Set when a software (re)start withheld its trigger because the channel
+	 * was suspended; resume() re-issues exactly one such withheld trigger. A
+	 * transfer that completed while suspended never sets this, so resume()
+	 * cannot re-trigger a finished chain into a CURR_PTR_NULL error.
+	 */
+	bool restart_withheld;
 
 	cy_stc_dma_descriptor_t *descr;
 	IRQn_Type irq;
@@ -328,9 +349,6 @@ static int ifx_cat1_dma_configure(const struct device *dev, uint32_t channel,
 	_dma_free_linked_descriptors(data->channels[channel].descr);
 	data->channels[channel].descr = NULL;
 
-	/* Lock and page in the channel configuration */
-	uint32_t key = irq_lock();
-
 	struct dma_block_config *block_config = config->head_block;
 
 	for (uint32_t i = 0u; i < config->block_count; i++) {
@@ -398,7 +416,13 @@ static int ifx_cat1_dma_configure(const struct device *dev, uint32_t channel,
 		return -EIO;
 	}
 
-	irq_unlock(key);
+	/* A (re)configure of a suspended channel is the rechain of a paused
+	 * logical transfer, so keep it suspended; otherwise the channel is now
+	 * configured and idle.
+	 */
+	if (data->channels[channel].state != IFX_DMA_CH_SUSPENDED) {
+		data->channels[channel].state = IFX_DMA_CH_CONFIGURED;
+	}
 	return 0;
 }
 
@@ -407,6 +431,26 @@ DW_Type *ifx_cat1_dma_get_regs(const struct device *dev)
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
 
 	return cfg->regs;
+}
+
+/* Issue the software trigger a memory-sourced DW transfer needs to (re)start.
+ * Shared by ifx_cat1_dma_start() and ifx_cat1_dma_resume() so both paths stay
+ * in sync.
+ */
+static void ifx_cat1_dma_sw_trigger(const struct device *dev, uint32_t channel)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
+
+	if ((data->channels[channel].channel_direction == MEMORY_TO_MEMORY) ||
+	    (data->channels[channel].channel_direction == MEMORY_TO_PERIPHERAL)) {
+		cyhal_dma_t dma_obj = {
+			.resource.type = CYHAL_RSC_DW,
+			.resource.block_num = _get_hw_block_num(cfg->regs),
+			.resource.channel_num = channel,
+		};
+		(void)cyhal_dma_start_transfer(&dma_obj);
+	}
 }
 
 static int ifx_cat1_dma_start(const struct device *dev, uint32_t channel)
@@ -427,14 +471,12 @@ static int ifx_cat1_dma_start(const struct device *dev, uint32_t channel)
 
 	/* Enable DMA channel */
 	Cy_DMA_Channel_Enable(cfg->regs, channel);
-	if ((data->channels[channel].channel_direction == MEMORY_TO_MEMORY) ||
-	    (data->channels[channel].channel_direction == MEMORY_TO_PERIPHERAL)) {
-		cyhal_dma_t dma_obj = {
-			.resource.type = CYHAL_RSC_DW,
-			.resource.block_num = _get_hw_block_num(cfg->regs),
-			.resource.channel_num = channel,
-		};
-		(void)cyhal_dma_start_transfer(&dma_obj);
+	if (data->channels[channel].state == IFX_DMA_CH_SUSPENDED) {
+		/* Paused: withhold this restart's trigger for resume() to re-arm. */
+		data->channels[channel].restart_withheld = true;
+	} else {
+		ifx_cat1_dma_sw_trigger(dev, channel);
+		data->channels[channel].state = IFX_DMA_CH_RUNNING;
 	}
 	return 0;
 }
@@ -442,14 +484,95 @@ static int ifx_cat1_dma_start(const struct device *dev, uint32_t channel)
 static int ifx_cat1_dma_stop(const struct device *dev, uint32_t channel)
 {
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
 
 	if (channel >= cfg->num_channels) {
 		LOG_ERR("Unsupported channel");
 		return -EINVAL;
 	}
 
+	/* A full stop cancels any pause and returns the channel to idle. */
+	data->channels[channel].restart_withheld = false;
+	data->channels[channel].state = IFX_DMA_CH_CONFIGURED;
+
 	/* Disable DMA channel */
 	Cy_DMA_Channel_Disable(cfg->regs, channel);
+
+	return 0;
+}
+
+static int ifx_cat1_dma_suspend(const struct device *dev, uint32_t channel)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
+
+	if (channel >= cfg->num_channels) {
+		LOG_ERR("Unsupported channel");
+		return -EINVAL;
+	}
+
+	/* Suspend gates the driver's software trigger, so it only applies to a
+	 * memory-sourced (software-triggered) transfer. A hardware-triggered
+	 * channel is advanced by its peripheral trigger, which this driver cannot
+	 * gate, so report suspend unsupported rather than silently not pausing.
+	 */
+	if ((data->channels[channel].channel_direction != MEMORY_TO_MEMORY) &&
+	    (data->channels[channel].channel_direction != MEMORY_TO_PERIPHERAL)) {
+		return -ENOTSUP;
+	}
+
+	/* Only a running transfer can be suspended (per the dma.h channel state
+	 * machine). This rejects an unconfigured, idle, or already-completed
+	 * channel - including a zero-initialized one whose direction reads as
+	 * MEMORY_TO_MEMORY (direction 0).
+	 */
+	if (data->channels[channel].state != IFX_DMA_CH_RUNNING) {
+		return -EINVAL;
+	}
+
+	/* The pause takes effect at the next software-trigger boundary: the
+	 * in-flight descriptor is allowed to finish and the withheld restart is
+	 * deferred to resume(). The channel is deliberately NOT disabled, because
+	 * per the DW TRM disabling an active channel by software leaves its state
+	 * undefined.
+	 */
+	data->channels[channel].state = IFX_DMA_CH_SUSPENDED;
+
+	return 0;
+}
+
+static int ifx_cat1_dma_resume(const struct device *dev, uint32_t channel)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
+
+	if (channel >= cfg->num_channels) {
+		LOG_ERR("Unsupported channel");
+		return -EINVAL;
+	}
+
+	/* Only a suspended channel can be resumed. */
+	if (data->channels[channel].state != IFX_DMA_CH_SUSPENDED) {
+		return -EINVAL;
+	}
+
+	if (data->channels[channel].restart_withheld) {
+		/* A rechained segment's trigger was withheld while paused; re-enable
+		 * and issue exactly that trigger so the transfer continues.
+		 */
+		data->channels[channel].restart_withheld = false;
+		Cy_DMA_Channel_Enable(cfg->regs, channel);
+		ifx_cat1_dma_sw_trigger(dev, channel);
+		data->channels[channel].state = IFX_DMA_CH_RUNNING;
+	} else {
+		/* No trigger was withheld: the segment running when suspend() was
+		 * called was a single or final block that has since completed (or is
+		 * still finishing under its own trigger). There is nothing to re-arm,
+		 * so issue no trigger - avoiding a CURR_PTR_NULL on a freed chain -
+		 * and just clear the pause.
+		 */
+		data->channels[channel].state = IFX_DMA_CH_CONFIGURED;
+	}
 
 	return 0;
 }
@@ -459,10 +582,16 @@ int ifx_cat1_dma_reload(const struct device *dev, uint32_t channel, uint32_t src
 {
 	struct ifx_cat1_dma_data *data = dev->data;
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
-	cy_stc_dma_descriptor_t *descriptor = data->channels[channel].descr;
+	cy_stc_dma_descriptor_t *descriptor;
 
 	if (channel >= cfg->num_channels) {
 		LOG_ERR("Unsupported channel");
+		return -EINVAL;
+	}
+
+	descriptor = data->channels[channel].descr;
+	if (descriptor == NULL) {
+		LOG_ERR("Channel not configured");
 		return -EINVAL;
 	}
 
@@ -560,7 +689,15 @@ static int ifx_cat1_dma_get_status(const struct device *dev, uint32_t channel,
 			uint32_t total_transfer_size = get_total_size(dev, channel);
 			uint32_t transferred_size = get_transferred_size(dev, channel);
 
-			stat->pending_length = total_transfer_size - transferred_size;
+			/* transferred_size can momentarily read >= total when the
+			 * transfer has just completed; clamp to avoid an unsigned
+			 * underflow wrapping pending_length to a huge value.
+			 */
+			if (total_transfer_size > transferred_size) {
+				stat->pending_length = total_transfer_size - transferred_size;
+			} else {
+				stat->pending_length = 0;
+			}
 		} else {
 			stat->pending_length = 0;
 		}
@@ -669,6 +806,16 @@ static void ifx_cat1_dma_isr(struct ifx_cat1_dma_irq_context *irq_context)
 		break;
 	}
 
+	/* The in-flight segment has ended. A running channel returns to idle; a
+	 * suspended channel stays suspended so a rechained start() issued from the
+	 * callback below withholds its trigger. If this was a single or final
+	 * block (no rechain follows), the channel is simply left suspended-idle
+	 * and resume()/stop() resolve it without a spurious trigger.
+	 */
+	if (data->channels[channel].state == IFX_DMA_CH_RUNNING) {
+		data->channels[channel].state = IFX_DMA_CH_CONFIGURED;
+	}
+
 	if ((callback != NULL && status == 0) ||
 	    (callback != NULL && data->channels[channel].error_callback_dis)) {
 		void *callback_arg = data->channels[channel].user_data;
@@ -681,6 +828,8 @@ static DEVICE_API(dma, ifx_cat1_dma_api) = {
 	.config = ifx_cat1_dma_configure,
 	.start = ifx_cat1_dma_start,
 	.stop = ifx_cat1_dma_stop,
+	.suspend = ifx_cat1_dma_suspend,
+	.resume = ifx_cat1_dma_resume,
 	.reload = ifx_cat1_dma_reload,
 	.get_status = ifx_cat1_dma_get_status,
 };

--- a/drivers/dma/dma_infineon_pdl.c
+++ b/drivers/dma/dma_infineon_pdl.c
@@ -37,6 +37,13 @@ struct ifx_cat1_dma_channel {
 	uint32_t error_callback_dis: 1;
 	uint32_t sw_triggered: 1;
 
+	/* Kept out of the bitfield above on purpose: suspend()/resume()/stop()
+	 * update this from contexts that can preempt a channel (re)configuration,
+	 * and a read-modify-write of a shared bitfield word would race with the
+	 * other bits. A standalone byte is stored atomically.
+	 */
+	bool suspended;
+
 	cy_stc_dma_descriptor_t descr[DESCRIPTOR_COUNT];
 	IRQn_Type irq;
 
@@ -60,6 +67,16 @@ int ifx_cat1_dma_trig(const struct device *dev, uint32_t channel)
 {
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
 	struct ifx_cat1_dma_data *data = dev->data;
+
+	/* While the channel is suspended, defer the software trigger. The
+	 * transfer is restarted by ifx_cat1_dma_resume(). This prevents a
+	 * software-rechained transfer (e.g. a new transfer kicked from the
+	 * completion callback) from re-triggering the channel while it is
+	 * meant to be paused.
+	 */
+	if (data->channels[channel].suspended) {
+		return 0;
+	}
 
 	/* Set SW trigger for the channel */
 	if (data->channels[channel].sw_triggered) {
@@ -324,14 +341,83 @@ static int ifx_cat1_dma_start(const struct device *dev, uint32_t channel)
 static int ifx_cat1_dma_stop(const struct device *dev, uint32_t channel)
 {
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
 
 	if (channel >= cfg->num_channels) {
 		LOG_ERR("Unsupported channel");
 		return -EINVAL;
 	}
 
+	/* A full stop clears any pending suspended state. */
+	data->channels[channel].suspended = false;
+
 	/* Disable DMA channel */
 	Cy_DMA_Channel_Disable(cfg->regs, channel);
+
+	return 0;
+}
+
+static int ifx_cat1_dma_suspend(const struct device *dev, uint32_t channel)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
+
+	if (channel >= cfg->num_channels) {
+		LOG_ERR("Unsupported channel");
+		return -EINVAL;
+	}
+
+	/* Suspend is realized by withholding the software trigger, so it only
+	 * applies to software-triggered transfers. A hardware-triggered channel
+	 * is advanced by its peripheral trigger, which this driver cannot gate,
+	 * so report that suspend is unsupported for it instead of silently
+	 * failing to pause.
+	 */
+	if (!data->channels[channel].sw_triggered) {
+		return -ENOTSUP;
+	}
+
+	/* Pause by withholding the next software trigger: mark the channel
+	 * suspended so a software-rechained transfer (e.g. one kicked from the
+	 * completion callback) does not re-trigger it until ifx_cat1_dma_resume()
+	 * runs. The in-flight one-shot descriptor is allowed to finish on its
+	 * own; the channel is deliberately NOT disabled here because per the DW
+	 * TRM disabling an actively transferring channel by software leaves its
+	 * state undefined.
+	 */
+	data->channels[channel].suspended = true;
+
+	return 0;
+}
+
+static int ifx_cat1_dma_resume(const struct device *dev, uint32_t channel)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
+
+	if (channel >= cfg->num_channels) {
+		LOG_ERR("Unsupported channel");
+		return -EINVAL;
+	}
+
+	/* Only a channel that was actually suspended can be resumed. Resuming a
+	 * running or already-completed channel would issue a software trigger
+	 * with no valid current descriptor and raise a CURR_PTR_NULL error.
+	 */
+	if (!data->channels[channel].suspended) {
+		return -EINVAL;
+	}
+
+	/* Clear the suspended state so the software trigger is issued again. */
+	data->channels[channel].suspended = false;
+
+	/* Re-enable the channel (idempotent if the gated restart already did) and
+	 * re-issue the software trigger so the withheld transfer continues,
+	 * mirroring ifx_cat1_dma_start().
+	 */
+	Cy_DMA_Channel_Enable(cfg->regs, channel);
+
+	ifx_cat1_dma_trig(dev, channel);
 
 	return 0;
 }
@@ -341,12 +427,18 @@ int ifx_cat1_dma_reload(const struct device *dev, uint32_t channel, uint32_t src
 {
 	struct ifx_cat1_dma_data *data = dev->data;
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
-	cy_stc_dma_descriptor_t *descriptor = &data->channels[channel].descr[0];
+	cy_stc_dma_descriptor_t *descriptor;
 
 	if (channel >= cfg->num_channels) {
 		LOG_ERR("Unsupported channel");
 		return -EINVAL;
 	}
+
+	/* descr is an inline array member (cy_stc_dma_descriptor_t descr[]), so
+	 * &descr[0] is always valid; unlike the HAL driver where descr is a
+	 * pointer that needs a NULL check, no NULL check is required here.
+	 */
+	descriptor = &data->channels[channel].descr[0];
 
 	/* Set a descriptor for the specified DMA channel
 	 *
@@ -464,9 +556,15 @@ static int ifx_cat1_dma_get_status(const struct device *dev, uint32_t channel,
 		uint32_t total_transfer_size = get_total_size(dev, channel);
 		uint32_t transferred_size = get_transferred_size(dev, channel);
 
-		/* pending_length expressed in user units (items), same as get_total/get_transferred
+		/* pending_length is in user units (items), same as get_total/get_transferred.
+		 * transferred_size can momentarily read >= total when the transfer has just
+		 * completed; clamp to avoid an unsigned underflow wrapping to a huge value.
 		 */
-		stat->pending_length = total_transfer_size - transferred_size;
+		if (total_transfer_size > transferred_size) {
+			stat->pending_length = total_transfer_size - transferred_size;
+		} else {
+			stat->pending_length = 0;
+		}
 	} else {
 		stat->pending_length = 0;
 	}
@@ -565,6 +663,8 @@ static DEVICE_API(dma, ifx_cat1_dma_api) = {
 	.config = ifx_cat1_dma_config,
 	.start = ifx_cat1_dma_start,
 	.stop = ifx_cat1_dma_stop,
+	.suspend = ifx_cat1_dma_suspend,
+	.resume = ifx_cat1_dma_resume,
 	.reload = ifx_cat1_dma_reload,
 	.get_status = ifx_cat1_dma_get_status,
 };

--- a/drivers/dma/dma_infineon_pdl.c
+++ b/drivers/dma/dma_infineon_pdl.c
@@ -31,11 +31,31 @@ LOG_MODULE_REGISTER(ifx_cat1_dma, CONFIG_DMA_LOG_LEVEL);
 
 #define DESCRIPTOR_COUNT (CONFIG_DMA_INFINEON_DESCRIPTOR_COUNT)
 
+enum ifx_cat1_dma_ch_state {
+	IFX_DMA_CH_UNCONFIGURED = 0, /* reset state: no descriptor configured */
+	IFX_DMA_CH_CONFIGURED,      /* configured and idle (also after completion) */
+	IFX_DMA_CH_RUNNING,         /* enabled and triggered, transfer in flight */
+	IFX_DMA_CH_SUSPENDED,       /* paused: the next SW (re)start trigger is withheld */
+};
+
 struct ifx_cat1_dma_channel {
 	uint32_t channel_direction: 3;
 	uint32_t complete_callback_en: 1;
 	uint32_t error_callback_dis: 1;
 	uint32_t sw_triggered: 1;
+
+	/* Per-channel state machine; see the dma.h channel state machine
+	 * expectations. A DW channel is single-owner, so only this channel's calls
+	 * and its completion interrupt drive these transitions.
+	 */
+	enum ifx_cat1_dma_ch_state state;
+
+	/* Set when a software (re)start withheld its trigger because the channel
+	 * was suspended; resume() re-issues exactly one such withheld trigger. A
+	 * transfer that completed while suspended never sets this, so resume()
+	 * cannot re-trigger a finished chain into a CURR_PTR_NULL error.
+	 */
+	bool restart_withheld;
 
 	cy_stc_dma_descriptor_t descr[DESCRIPTOR_COUNT];
 	IRQn_Type irq;
@@ -61,7 +81,11 @@ int ifx_cat1_dma_trig(const struct device *dev, uint32_t channel)
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
 	struct ifx_cat1_dma_data *data = dev->data;
 
-	/* Set SW trigger for the channel */
+	/* Issue the software trigger a memory-sourced transfer needs to (re)start.
+	 * The suspend pause is applied by ifx_cat1_dma_start()/resume() gating this
+	 * call, not here, so start()/resume() remain the single owners of the state
+	 * machine.
+	 */
 	if (data->channels[channel].sw_triggered) {
 		Cy_DMA_Channel_SetSWTrigger(cfg->regs, channel);
 	}
@@ -294,12 +318,21 @@ static int ifx_cat1_dma_config(const struct device *dev, uint32_t channel,
 	/* Enable the interrupt  */
 	irq_enable(data->channels[channel].irq);
 
+	/* A (re)configure of a suspended channel is the rechain of a paused
+	 * logical transfer, so keep it suspended; otherwise it is configured and
+	 * idle.
+	 */
+	if (data->channels[channel].state != IFX_DMA_CH_SUSPENDED) {
+		data->channels[channel].state = IFX_DMA_CH_CONFIGURED;
+	}
+
 	return 0;
 }
 
 static int ifx_cat1_dma_start(const struct device *dev, uint32_t channel)
 {
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
 
 	if (channel >= cfg->num_channels) {
 		LOG_ERR("Unsupported channel");
@@ -316,7 +349,13 @@ static int ifx_cat1_dma_start(const struct device *dev, uint32_t channel)
 	/* Enable DMA channel */
 	Cy_DMA_Channel_Enable(cfg->regs, channel);
 
-	ifx_cat1_dma_trig(dev, channel);
+	if (data->channels[channel].state == IFX_DMA_CH_SUSPENDED) {
+		/* Paused: withhold this restart's trigger for resume() to re-arm. */
+		data->channels[channel].restart_withheld = true;
+	} else {
+		ifx_cat1_dma_trig(dev, channel);
+		data->channels[channel].state = IFX_DMA_CH_RUNNING;
+	}
 
 	return 0;
 }
@@ -324,14 +363,92 @@ static int ifx_cat1_dma_start(const struct device *dev, uint32_t channel)
 static int ifx_cat1_dma_stop(const struct device *dev, uint32_t channel)
 {
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
 
 	if (channel >= cfg->num_channels) {
 		LOG_ERR("Unsupported channel");
 		return -EINVAL;
 	}
 
+	/* A full stop cancels any pause and returns the channel to idle. */
+	data->channels[channel].restart_withheld = false;
+	data->channels[channel].state = IFX_DMA_CH_CONFIGURED;
+
 	/* Disable DMA channel */
 	Cy_DMA_Channel_Disable(cfg->regs, channel);
+
+	return 0;
+}
+
+static int ifx_cat1_dma_suspend(const struct device *dev, uint32_t channel)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
+
+	if (channel >= cfg->num_channels) {
+		LOG_ERR("Unsupported channel");
+		return -EINVAL;
+	}
+
+	/* Suspend gates the driver's software trigger, so it only applies to a
+	 * software-triggered transfer. A hardware-triggered channel is advanced by
+	 * its peripheral trigger, which this driver cannot gate, so report suspend
+	 * unsupported rather than silently not pausing.
+	 */
+	if (!data->channels[channel].sw_triggered) {
+		return -ENOTSUP;
+	}
+
+	/* Only a running transfer can be suspended (per the dma.h channel state
+	 * machine). This rejects an unconfigured, idle, or already-completed
+	 * channel.
+	 */
+	if (data->channels[channel].state != IFX_DMA_CH_RUNNING) {
+		return -EINVAL;
+	}
+
+	/* The pause takes effect at the next software-trigger boundary: the
+	 * in-flight descriptor is allowed to finish and the withheld restart is
+	 * deferred to resume(). The channel is deliberately NOT disabled, because
+	 * per the DW TRM disabling an active channel by software leaves its state
+	 * undefined.
+	 */
+	data->channels[channel].state = IFX_DMA_CH_SUSPENDED;
+
+	return 0;
+}
+
+static int ifx_cat1_dma_resume(const struct device *dev, uint32_t channel)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	struct ifx_cat1_dma_data *data = dev->data;
+
+	if (channel >= cfg->num_channels) {
+		LOG_ERR("Unsupported channel");
+		return -EINVAL;
+	}
+
+	/* Only a suspended channel can be resumed. */
+	if (data->channels[channel].state != IFX_DMA_CH_SUSPENDED) {
+		return -EINVAL;
+	}
+
+	if (data->channels[channel].restart_withheld) {
+		/* A rechained segment's trigger was withheld while paused; re-enable
+		 * and issue exactly that trigger so the transfer continues.
+		 */
+		data->channels[channel].restart_withheld = false;
+		Cy_DMA_Channel_Enable(cfg->regs, channel);
+		ifx_cat1_dma_trig(dev, channel);
+		data->channels[channel].state = IFX_DMA_CH_RUNNING;
+	} else {
+		/* No trigger was withheld: the segment running when suspend() was
+		 * called was a single or final block that has since completed (or is
+		 * still finishing under its own trigger). There is nothing to re-arm,
+		 * so issue no trigger - avoiding a CURR_PTR_NULL - and clear the pause.
+		 */
+		data->channels[channel].state = IFX_DMA_CH_CONFIGURED;
+	}
 
 	return 0;
 }
@@ -341,12 +458,18 @@ int ifx_cat1_dma_reload(const struct device *dev, uint32_t channel, uint32_t src
 {
 	struct ifx_cat1_dma_data *data = dev->data;
 	const struct ifx_cat1_dma_config *const cfg = dev->config;
-	cy_stc_dma_descriptor_t *descriptor = &data->channels[channel].descr[0];
+	cy_stc_dma_descriptor_t *descriptor;
 
 	if (channel >= cfg->num_channels) {
 		LOG_ERR("Unsupported channel");
 		return -EINVAL;
 	}
+
+	/* descr is an inline array member (cy_stc_dma_descriptor_t descr[]), so
+	 * &descr[0] is always valid; unlike the HAL driver where descr is a
+	 * pointer that needs a NULL check, no NULL check is required here.
+	 */
+	descriptor = &data->channels[channel].descr[0];
 
 	/* Set a descriptor for the specified DMA channel
 	 *
@@ -464,9 +587,15 @@ static int ifx_cat1_dma_get_status(const struct device *dev, uint32_t channel,
 		uint32_t total_transfer_size = get_total_size(dev, channel);
 		uint32_t transferred_size = get_transferred_size(dev, channel);
 
-		/* pending_length expressed in user units (items), same as get_total/get_transferred
+		/* pending_length is in user units (items), same as get_total/get_transferred.
+		 * transferred_size can momentarily read >= total when the transfer has just
+		 * completed; clamp to avoid an unsigned underflow wrapping to a huge value.
 		 */
-		stat->pending_length = total_transfer_size - transferred_size;
+		if (total_transfer_size > transferred_size) {
+			stat->pending_length = total_transfer_size - transferred_size;
+		} else {
+			stat->pending_length = 0;
+		}
 	} else {
 		stat->pending_length = 0;
 	}
@@ -548,6 +677,15 @@ static void ifx_cat1_dma_isr(struct ifx_cat1_dma_irq_context *irq_context)
 	/* Clear all interrupts */
 	Cy_DMA_Channel_ClearInterrupt(cfg->regs, channel);
 
+	/* The in-flight segment has ended. A running channel returns to idle; a
+	 * suspended channel stays suspended so a rechained start() from the
+	 * callback withholds its trigger, and a single/final block completing while
+	 * suspended is resolved by resume()/stop() without a spurious trigger.
+	 */
+	if (data->channels[channel].state == IFX_DMA_CH_RUNNING) {
+		data->channels[channel].state = IFX_DMA_CH_CONFIGURED;
+	}
+
 	/* return if callback is not registered */
 	if (callback == NULL) {
 		return;
@@ -565,6 +703,8 @@ static DEVICE_API(dma, ifx_cat1_dma_api) = {
 	.config = ifx_cat1_dma_config,
 	.start = ifx_cat1_dma_start,
 	.stop = ifx_cat1_dma_stop,
+	.suspend = ifx_cat1_dma_suspend,
+	.resume = ifx_cat1_dma_resume,
 	.reload = ifx_cat1_dma_reload,
 	.get_status = ifx_cat1_dma_get_status,
 };


### PR DESCRIPTION
## Description

The Infineon DMA drivers did not implement the
`dma_suspend()` / `dma_resume()` API hooks, so those calls returned
`-ENOSYS`. Any consumer that relies on pausing an in-flight transfer was
unable to do so, and the `drivers.dma.loop_transfer` suspend/resume test
skipped on Infineon DW-based platforms.

This adds `.suspend` and `.resume` to both DW DMA drivers:

- `drivers/dma/dma_infineon.c` (CAT1 HAL variant)
- `drivers/dma/dma_infineon_pdl.c` (PDL variant)

`suspend` disables the channel and records a per-channel `suspended`
flag. `resume` clears the flag, re-enables the channel and re-issues the
software trigger for memory-sourced transfers, mirroring the `start`
path. A full `stop` also clears the flag.

### Why the `suspended` flag is needed

A one-shot memory-to-memory transfer can be software-rechained from the
completion callback (the callback configures and starts the next block,
e.g. the loop_transfer test). On a fast core the DW controller cannot
abort a single software-triggered descriptor mid-flight, so without the
flag the rechained transfer would immediately re-trigger the channel and
defeat the suspend. While the channel is suspended the software trigger
is deferred; `resume` issues it so the transfer continues.

## Testing

`tests/drivers/dma/loop_transfer` on `kit_pse84_eval` (Cortex-M33), PDL
driver:

- Before: `test_*_m2m_loop_suspend_resume` reported "suspend not
  supported" and was skipped.
- After: full suite passes (`pass = 3, fail = 0, skip = 0`). The
  suspend/resume test pauses the loop mid-sequence ("suspended after 3
  transfers"), resumes, and completes all 4 transfers; verified stable
  across repeated reset/flash runs.

The CAT1 HAL variant (`dma_infineon.c`) builds clean for
`cyw920829m2evk_02`; the same logic is applied for consistency.
