### PR TITLE
dts: nxp: mcxn23x: enable ELS TRNG support

### DIFF
--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
@@ -471,3 +471,7 @@ dvp_20pin_interface: &video_sdma {};
 &crc {
 	status = "okay";
 };
+
+&trng {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
@@ -18,6 +18,7 @@ supported:
   - can
   - counter
   - dma
+  - entropy
   - flash
   - gpio
   - i2c

--- a/drivers/entropy/entropy_nxp_els_trng.c
+++ b/drivers/entropy/entropy_nxp_els_trng.c
@@ -6,19 +6,25 @@
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/entropy.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util_macro.h>
 
 #define TRNG_NODE DT_INST(0, nxp_els_trng)
 #define ELS_NODE DT_PARENT(TRNG_NODE)
 #define CLOCK_DEV DT_CLOCKS_CTLR(ELS_NODE)
 #define CLOCK_CELL DT_CLOCKS_CELL(ELS_NODE, name)
-#define ELS_BASE DT_REG_ADDR(ELS_NODE)
-#define ELS_STATUS (ELS_BASE + 0U)
+#define ELS_REG_BASE DT_REG_ADDR(ELS_NODE)
+#define ELS_STATUS (ELS_REG_BASE + 0U)
 #define ELS_STATUS_BUSY_MASK BIT(0)
+#define ELS_STATUS_ERR_MASK BIT(2)
+#define ELS_STATUS_PRNG_RDY_MASK BIT(3)
 #define ELS_STATUS_DRBG_ENT_LVL_MASK (BIT(9) | BIT(8))
-#define ELS_CTRL (ELS_BASE + 4U)
+#define ELS_CTRL (ELS_REG_BASE + 4U)
 #define ELS_CTRL_EN_MASK BIT(0)
-#define ELS_PRNG_DATOUT (ELS_BASE + 0x5c)
+#define ELS_PRNG_DATOUT (ELS_REG_BASE + 0x5c)
+
+#define ELS_INIT_TIMEOUT_US 1000000
+#define ELS_POLL_INTERVAL_US 100
 
 static uint8_t els_entropy_level(volatile uint32_t *status)
 {
@@ -28,10 +34,48 @@ static uint8_t els_entropy_level(volatile uint32_t *status)
 	return (uint8_t)level;
 }
 
+static bool els_status_has_error(volatile uint32_t *status)
+{
+	return (*status & ELS_STATUS_ERR_MASK) != 0U;
+}
+
+static bool els_is_ready(volatile uint32_t *status)
+{
+	uint32_t val = *status;
+
+	return (val & ELS_STATUS_BUSY_MASK) == 0U &&
+	       (val & ELS_STATUS_PRNG_RDY_MASK) != 0U &&
+	       els_entropy_level(status) >= 1;
+}
+
+static int els_wait_ready(volatile uint32_t *status, int32_t timeout_us)
+{
+	while (timeout_us > 0) {
+		if (els_status_has_error(status)) {
+			return -EIO;
+		}
+
+		if (els_is_ready(status)) {
+			return 0;
+		}
+
+		k_busy_wait(ELS_POLL_INTERVAL_US);
+		timeout_us -= ELS_POLL_INTERVAL_US;
+	}
+
+	return -ETIMEDOUT;
+}
+
 static int entropy_els_get_entropy(const struct device *dev, uint8_t *buf, uint16_t len)
 {
 	volatile uint32_t *status = (uint32_t *)ELS_STATUS;
 	volatile uint32_t *prng_datout = (uint32_t *)ELS_PRNG_DATOUT;
+
+	ARG_UNUSED(dev);
+
+	if (els_status_has_error(status)) {
+		return -EIO;
+	}
 
 	if (els_entropy_level(status) < 1) {
 		return -EIO;
@@ -60,6 +104,8 @@ static int entropy_els_init(const struct device *dev)
 	volatile uint32_t *ctrl = (uint32_t *)ELS_CTRL;
 	int ret;
 
+	ARG_UNUSED(dev);
+
 	ret = clock_control_on(DEVICE_DT_GET(CLOCK_DEV), (clock_control_subsys_t)CLOCK_CELL);
 	if (ret) {
 		return ret;
@@ -67,10 +113,7 @@ static int entropy_els_init(const struct device *dev)
 
 	*ctrl |= ELS_CTRL_EN_MASK;
 
-	while (*status & ELS_STATUS_BUSY_MASK) {
-	}
-
-	return 0;
+	return els_wait_ready(status, ELS_INIT_TIMEOUT_US);
 }
 
 static DEVICE_API(entropy, entropy_els_api_funcs) = {

--- a/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
@@ -13,6 +13,10 @@
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
 / {
+	chosen {
+		zephyr,entropy = &trng;
+	};
+
 	cpus: cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -1167,6 +1171,17 @@
 		compatible = "nxp,crc";
 		reg = <0xcb000 0x1000>;
 		status = "disabled";
+	};
+
+	crypto@54000 {
+		compatible = "nxp,els";
+		reg = <0x54000 0x200>;
+		clocks = <&syscon MCUX_ELS_CLK>;
+
+		trng: rng {
+			compatible = "nxp,els-trng";
+			status = "disabled";
+		};
 	};
 };
 

--- a/tests/drivers/entropy/api/testcase.yaml
+++ b/tests/drivers/entropy/api/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   drivers.entropy:
     filter: CONFIG_ENTROPY_HAS_DRIVER
+    integration_platforms:
+      - frdm_mcxn236
     tags:
       - drivers
       - entropy

--- a/tests/subsys/random/rng/testcase.yaml
+++ b/tests/subsys/random/rng/testcase.yaml
@@ -18,12 +18,14 @@ tests:
     min_ram: 16
     integration_platforms:
       - native_sim
+      - frdm_mcxn236
   crypto.rng.random_ctr_drbg:
     extra_args: CONF_FILE=prj_ctr_drbg.conf
     filter: CONFIG_ENTROPY_HAS_DRIVER
     min_ram: 16
     integration_platforms:
       - native_sim
+      - frdm_mcxn236
   drivers.rng.random_psa_crypto:
     filter: CONFIG_BUILD_WITH_TFM
     arch_exclude: posix


### PR DESCRIPTION
Enabled the `tests/drivers/entropy/api` and `tests/subsys/random/rng` tests with both `prj_hw_random_xoshiro.conf` and `prj_ctr_drbg.conf`. 

Followed reference of `nxp_mcxn94x_common.dtsi`.

Hardened the init path to not hang the system if it fails to initialize and wait through each step of the initialization sequence with some timeout.