### PR TITLE
xtensa: mpu: fix idx_e may be used uninitialized

### DIFF
--- a/arch/xtensa/core/mpu/mpu_core.c
+++ b/arch/xtensa/core/mpu/mpu_core.c
@@ -307,7 +307,8 @@ static int mpu_map_region_add(struct xtensa_mpu_map *map,
 			      uint32_t access_rights, uint8_t *first_idx)
 {
 	int ret;
-	uint8_t idx_s, idx_e, first_enabled_idx;
+	uint8_t idx_s, first_enabled_idx;
+	uint8_t idx_e = 0;
 	uint32_t memory_type;
 	struct xtensa_mpu_entry *entry_slot_s, *entry_slot_e = NULL;
 


### PR DESCRIPTION
Complier complains that idx_e may be used uninitialized. So set the default as 0 so that the for loop where it can be used uninitialized would be an no-op.