### PR TITLE
tests: drivers: pwm: pwm_gpio_loopback: add kit_pse84_eval m33/ns overlay

### DIFF
--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"


### PR DESCRIPTION
## Summary

`drivers.pwm.gpio_loopback.ifx` fails to build for
`kit_pse84_eval/pse846gps2dbzc4a/m33/ns`. The non-secure variant has no
board overlay under `tests/drivers/pwm/pwm_gpio_loopback/boards/`, so the
`zephyr,user` node has no `pwms`/`gpios` properties and the test does not
compile:

```
src/main.c: error: 'DT_N_S_zephyr_user_P_pwms_LEN' undeclared
            error: 'DT_N_S_zephyr_user_P_gpios_LEN' undeclared
            error: 'gpios_dt' undeclared
            error: unused variable 'duty' [-Werror=unused-variable]
```

## Change

Add `kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay`, a one-line include
of `kit_pse84_eval_common.overlay`, mirroring the existing secure `m33`
and `m55` variants. The common overlay supplies the `zephyr,user`
`pwms`/`gpios` and enables the TCPWM and GPIO nodes. Those nodelabels are
defined in the shared `pse84.cm33.dtsi`, so they resolve for the
non-secure image.

## Testing

Build for the affected target now links cleanly:

```
west build -p always -b kit_pse84_eval/pse846gps2dbzc4a/m33/ns \
  tests/drivers/pwm/pwm_gpio_loopback -T drivers.pwm.gpio_loopback.ifx
```
