### PR TITLE
drivers: wifi: airoc: free undersized net_buf in host_buffer_get

### DIFF
--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -381,7 +381,14 @@ static whd_result_t airoc_wifi_host_buffer_get(whd_buffer_t *buffer, whd_buffer_
 	struct net_buf *buf;
 
 	buf = net_buf_alloc_len(&airoc_pool, size, K_NO_WAIT);
-	if ((buf == NULL) || (buf->size < size)) {
+	if (buf == NULL) {
+		return WHD_BUFFER_ALLOC_FAIL;
+	}
+	if (buf->size < size) {
+		/* net_buf_alloc_len() returned a buffer smaller than requested;
+		 * release it before failing or it leaks from airoc_pool.
+		 */
+		net_buf_unref(buf);
 		return WHD_BUFFER_ALLOC_FAIL;
 	}
 	*buffer = buf;


### PR DESCRIPTION
### Summary
`airoc_wifi_host_buffer_get()` allocates a `net_buf` from the fixed `airoc_pool`,
then returns `WHD_BUFFER_ALLOC_FAIL` if the buffer is smaller than requested —
without releasing it, leaking it from the pool. This frees the undersized buffer
with `net_buf_unref()` before returning the failure.

### Relation to #111163
This is a sibling of the buffer-leak fix in #111163, in a *different* function:
that PR released the TX buffer in `airoc_mgmt_send()` on a synchronous
`whd_network_send_ethernet_data()` failure; this one covers the allocation path in
`airoc_wifi_host_buffer_get()`, which is still present on `main`.

### Testing
Found while characterizing `airoc_pool` exhaustion under sustained traffic on
rpi_pico2/rp2350a/m33/w (CYW43439). Build- and runtime-tested on that board: WiFi
associate + DHCP + sustained ping with no pool exhaustion from this path.

### Context
Surfaced during the shared-bus BT/WiFi coexistence work in RFC
zephyrproject-rtos/zephyr#111811.
