### PR TITLE
samples: drivers: counter: alarm: add kit_pse84_eval m33/ns overlay

### DIFF
--- a/samples/drivers/counter/alarm/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
+++ b/samples/drivers/counter/alarm/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"


### PR DESCRIPTION
This adds a board overlay for the `kit_pse84_eval/pse846gps2dbzc4a/m33/ns`
(non-secure) target to the `samples/drivers/counter/alarm` sample.

Without it, `sample.drivers.counter.alarm` fails to build for that target:
the `counter0_1` TCPWM node is left disabled, so the sample falls through to
the `#error Unable to find a counter device node in devicetree` clause and
the counter driver is excluded from the build.

The overlay mirrors the existing secure `m33`/`m55` variants — a one-line
include of `kit_pse84_eval_common.overlay`, which enables the TCPWM instance
and its `counter0_1` child and configures the counter clock. `counter0_1` is
non-secure-visible in `pse84.dtsi`, so it resolves for the non-secure image
and the sample builds.

Build-validated:
`west build -p always -b kit_pse84_eval/pse846gps2dbzc4a/m33/ns samples/drivers/counter/alarm`
links cleanly.
