### PR TITLE
tests: fcb: fix unaligned flash_area_write in test_fcb_append

### DIFF
--- a/tests/subsys/fs/fcb/src/fcb_test_append.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_append.c
@@ -16,14 +16,20 @@ static void test_fcb_append(struct fcb *_fcb)
 	int j;
 	int var_cnt;
 
+	uint8_t align;
+	size_t write_len;
+	align = fcb_get_align(_fcb);
+
 	for (i = 0; i < sizeof(test_data); i++) {
 		for (j = 0; j < i; j++) {
 			test_data[j] = fcb_test_append_data(i, j);
 		}
+		write_len = ROUND_UP(i, align);
+		memset(test_data + i, 0, write_len - i);
 		rc = fcb_append(_fcb, i, &loc);
 		zassert_true(rc == 0, "fcb_append call failure");
 		rc = flash_area_write(_fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc),
-				      test_data, i);
+				      test_data, write_len);
 		zassert_true(rc == 0, "flash_area_write call failure");
 		rc = fcb_append_finish(_fcb, &loc);
 		zassert_true(rc == 0, "fcb_append_finish call failure");

--- a/tests/subsys/fs/fcb/src/fcb_test_reset.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_reset.c
@@ -15,8 +15,11 @@ ZTEST(fcb_test_with_2sectors_set, test_fcb_reset)
 	struct fcb_entry loc;
 	uint8_t test_data[128];
 	int var_cnt;
+	uint8_t align;
+	size_t write_len;
 
 	fcb = &test_fcb;
+	align = fcb_get_align(fcb);
 
 	var_cnt = 0;
 	rc = fcb_walk(fcb, 0, fcb_test_data_walk_cb, &var_cnt);
@@ -39,8 +42,10 @@ ZTEST(fcb_test_with_2sectors_set, test_fcb_reset)
 	for (i = 0; i < sizeof(test_data); i++) {
 		test_data[i] = fcb_test_append_data(32, i);
 	}
+	write_len = ROUND_UP(32, align);
+	memset(test_data + 32, 0, write_len - 32);
 	rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc), test_data,
-			      32);
+			      write_len);
 	zassert_true(rc == 0, "flash_area_write call failure");
 
 	rc = fcb_append_finish(fcb, &loc);
@@ -77,8 +82,10 @@ ZTEST(fcb_test_with_2sectors_set, test_fcb_reset)
 	for (i = 0; i < sizeof(test_data); i++) {
 		test_data[i] = fcb_test_append_data(33, i);
 	}
+	write_len = ROUND_UP(33, align);
+	memset(test_data + 33, 0, write_len - 33);
 	rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc), test_data,
-			      33);
+			      write_len);
 	zassert_true(rc == 0, "flash_area_write call failure");
 
 	rc = fcb_append_finish(fcb, &loc);
@@ -119,8 +126,10 @@ ZTEST(fcb_test_with_2sectors_set, test_fcb_reset)
 	for (i = 0; i < sizeof(test_data); i++) {
 		test_data[i] = fcb_test_append_data(34, i);
 	}
+	write_len = ROUND_UP(34, align);
+	memset(test_data + 34, 0, write_len - 34);
 	rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc), test_data,
-			      34);
+			      write_len);
 	zassert_true(rc == 0, "flash_area_write call failure");
 
 	rc = fcb_append_finish(fcb, &loc);


### PR DESCRIPTION
The test called flash_area_write() with sizes 0..127 bytes without
considering the flash write block alignment requirement. On flash
devices with alignment > 1 (e.g. STM32U5 with 16-byte minimum write
size), unaligned write sizes cause the test to fail unconditionally.

Fix by rounding up the write length to the flash alignment boundary
using the existing fcb_get_align() helper and zero-padding the buffer
remainder to avoid writing uninitialized data.

Fixes #111889