### PR TITLE
scripts: runners: openocd: support -i/--dev-id for adapter selection

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -858,6 +858,15 @@ Random
 
 * ``CONFIG_CS_CTR_DRBG_PERSONALIZATION`` has been removed. It did not have any effect.
 
+Tools
+*****
+
+* The ``openocd`` runner now selects a debug adapter by serial number through the
+  canonical ``-i``/``--dev-id`` option, like the other runners. The previous
+  ``--serial`` option is deprecated and kept as an alias; it maps onto the same
+  mechanism (the value is still passed to the OpenOCD config as
+  ``_ZEPHYR_BOARD_SERIAL``). Update any scripts to use ``west flash -i <serial>``.
+
 Modules
 *******
 

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -142,16 +142,21 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'rtt'},
-                          rtt=True, erase=True, skip_load=True, file=True)
+                          dev_id=True, rtt=True, erase=True, skip_load=True, file=True)
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return '''Selects the debug adapter by its serial number. The value is
+                  passed to the OpenOCD config as _ZEPHYR_BOARD_SERIAL.'''
 
     @classmethod
     def do_add_parser(cls, parser):
         parser.add_argument('--config', action='append',
                             help='''if given, override default config file;
                             may be given multiple times''')
-        parser.add_argument('--serial', default="",
-                            help='''if given, selects FTDI instance by its serial number,
-                            defaults to empty''')
+        parser.add_argument('--serial', dest='dev_id', default="",
+                            help='''Deprecated: use -i/--dev-id instead. Selects the
+                            debug adapter by its serial number.''')
         # Deprecated --use-* flags for backward compatibility
         parser.add_argument('--use-hex', action='store_const',
                             dest='use_image_type', const='hex',
@@ -252,7 +257,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             pre_load=args.cmd_pre_load, erase_cmd=args.cmd_erase, load_cmd=args.cmd_load,
             verify_cmd=args.cmd_verify, post_verify=args.cmd_post_verify,
             do_verify=args.verify, do_verify_only=args.verify_only, do_erase=args.erase,
-            tui=args.tui, config=args.config, serial=args.serial,
+            tui=args.tui, config=args.config, serial=args.dev_id,
             image_type=image_type,
             flash_address=args.flash_address, no_halt=args.no_halt, no_init=args.no_init,
             no_targets=args.no_targets, tcl_port=args.tcl_port,

--- a/scripts/west_commands/tests/test_openocd.py
+++ b/scripts/west_commands/tests/test_openocd.py
@@ -2,12 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 from unittest.mock import MagicMock, patch
 
 import pytest
 from conftest import RC_GDB, RC_OPENOCD
 
 from runners.openocd import OpenOcdBinaryRunner
+
+TEST_SERIAL = 'E7038EAD'
+SERIAL_CMD = '-c set _ZEPHYR_BOARD_SERIAL ' + TEST_SERIAL
 
 #
 # OpenOCD's '-rtos Zephyr' target awareness is only implemented for the
@@ -107,3 +111,42 @@ def test_debugserver_rtos_old_openocd(
 
     cmd = openocd_cmd(command, check_call, popen_ignore_int)
     assert RTOS_COMMAND not in cmd
+
+
+def create_from_args(runner_config, argv):
+    '''Build an OpenOcdBinaryRunner from command-line arguments.'''
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    OpenOcdBinaryRunner.add_parser(parser)
+    args = parser.parse_args(argv)
+    # The shared fixture leaves a non-None cfg.file (an artifact of its
+    # positional construction); force it to None so the runner, which builds
+    # a Path() from it, constructs cleanly.
+    return OpenOcdBinaryRunner.create(runner_config._replace(file=None), args)
+
+
+@pytest.mark.parametrize(
+    'argv',
+    [
+        ['-i', TEST_SERIAL],  # canonical selector
+        ['--dev-id', TEST_SERIAL],  # long form
+        ['--serial', TEST_SERIAL],  # deprecated alias
+    ],
+)
+def test_dev_id_selects_serial(argv, runner_config):
+    '''-i/--dev-id and the deprecated --serial alias all set the adapter
+    serial, which is passed to OpenOCD as _ZEPHYR_BOARD_SERIAL.'''
+    runner = create_from_args(runner_config, argv)
+    assert runner.serial == [SERIAL_CMD]
+
+
+def test_dev_id_overrides_serial(runner_config):
+    '''Both flags land in the same destination, so argparse precedence
+    applies and the last one given wins.'''
+    runner = create_from_args(runner_config, ['--serial', 'OLD', '-i', TEST_SERIAL])
+    assert runner.serial == [SERIAL_CMD]
+
+
+def test_no_dev_id_no_serial(runner_config):
+    '''Without a selector no _ZEPHYR_BOARD_SERIAL command is emitted.'''
+    runner = create_from_args(runner_config, [])
+    assert runner.serial == []


### PR DESCRIPTION
### Description

The `openocd` runner can already select a specific debug adapter by serial number
via `--serial` (the value is passed to the OpenOCD config as `_ZEPHYR_BOARD_SERIAL`),
but it never advertised the `dev_id` capability. As a result the canonical
`west flash -i <serial>` form — supported by virtually every other runner
(`jlink`, `nrfjprog`, `pyocd`, `stm32cubeprogrammer`, …) — fails for openocd with:

```
FATAL ERROR: openocd doesn't support --dev-id option
```

This is surprising and inconsistent, especially when several identical adapters
(e.g. Seeed/CMSIS-DAP boards) are connected and the user just wants to target one
by serial.

### Change

- Declare `dev_id=True` in `OpenOcdBinaryRunner.capabilities()`.
- Add `dev_id_help()` describing that the id is the adapter serial.
- Map `-i/--dev-id` onto the existing serial mechanism in `do_create()`
  (`serial=args.dev_id or args.serial`).
- Keep `--serial` working as a backward-compatible alias.

No behavioural change for existing `--serial` users; this only makes the common
`-i/--dev-id` selector work for openocd as well.

### Testing

Verified on a Seeed XIAO nRF54L15 (CMSIS-DAPv2, `VID:PID=0x2886:0x0066`) with two
adapters connected:

```
west flash --runner openocd -i E7038EAD
...
Info : Using CMSIS-DAPv2 interface with VID:PID=0x2886:0x0066, serial=E7038EAD
downloaded 48976 bytes ... shutdown command invoked
```

Previously the same command aborted with the `--dev-id` error above; `--serial`
continues to behave identically.
