### PR TITLE
soc: nxp: rw: fix GDET disableCount corruption on PM3 entry failure

### DIFF
--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -249,6 +249,14 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 				board_early_init_hook();
 
 				if (!(POWER_EnterPowerMode(POWER_MODE3, &slp_cfg))) {
+					/* PM3 entry failed — GDET still disabled from
+					 * PrePowerMode, but PostPowerMode reset
+					 * disableCount=0. Re-disable to restore count
+					 * to match actual HW state.
+					 */
+					if (PMU->PWR_MODE_STATUS != (POWER_MODE3 - 1U)) {
+						POWER_DisableGDetVSensors();
+					}
 					break;
 				}
 			}
@@ -259,6 +267,15 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 			clock_init();
 
 			sys_clock_idle_exit();
+		} else {
+			/* PM3 entry failed — GDET still disabled from
+			 * PrePowerMode, but PostPowerMode reset
+			 * disableCount=0. Re-disable to restore count
+			 * to match actual HW state.
+			 */
+			if (PMU->PWR_MODE_STATUS != (POWER_MODE3 - 1U)) {
+				POWER_DisableGDetVSensors();
+			}
 		}
 
 		POWER_DisableWakeup(DT_IRQN(DT_NODELABEL(rtc)));


### PR DESCRIPTION
When PM3 entry fails (PMU->PWR_MODE_STATUS != 2), PostPowerMode() resets s_gdetSensorContext.disableCount to 0, since ROM never ran, GDET is still disabled from PrePowerMode().

This causes disableCount to underflow (0xFFFFFFFF) if POWER_EnableGDetVSensors() is called later (e.g., during Wi-Fi FW download), and subsequent POWER_DisableGDetVSensors() restores it to 0. The next PM2/PM3 entry then hits the assert in POWER_PrePowerMode() because disableCount == 0.

Fix by calling POWER_DisableGDetVSensors() after a failed PM3 entry to re-align disableCount with the actual hardware state.