### PR TITLE
subsys: shell: Increase argc count for CAN shell

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -124,6 +124,7 @@ config SHELL_ARGC_MAX
 	int "Maximum arguments in shell command"
 	range 3 $(UINT8_MAX)
 	default 30 if NET_L2_WIFI_SHELL
+	default 71 if CAN_SHELL
 	default 20
 	help
 	  Maximum number of arguments that can build a command.


### PR DESCRIPTION
The `send` command of the CAN shell allows to send also CAN FD frames, which can contain up to 64 bytes of data.

Increase the shell argc count to be able to send a fully complete CAN FD frame with all the payload.

The exact count of argc is determined by the following command, which uses extended ID, enables CAN FD and bit rate switch, and specify the maximum payload size :

```
can send can0 -e -f -b 12345678 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63
```