### PR TITLE
net: zperf: handle socket hangup events

### DIFF
--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -124,7 +124,8 @@ static int tcp_recv_data(struct net_socket_service_event *pev)
 {
 	static uint8_t buf[CONFIG_NET_ZPERF_TCP_RECEIVER_BUF_SIZE];
 	int i, ret = 0;
-	int family, sock, sock_error;
+	int family, sock, sock_error = 0;
+	int default_error = EIO;
 	struct net_sockaddr addr_incoming_conn;
 	net_socklen_t optlen = sizeof(int);
 	net_socklen_t addrlen = sizeof(struct net_sockaddr);
@@ -134,11 +135,22 @@ static int tcp_recv_data(struct net_socket_service_event *pev)
 	}
 
 	if ((pev->event.revents & ZSOCK_POLLERR) ||
-	    (pev->event.revents & ZSOCK_POLLNVAL)) {
+	    (pev->event.revents & ZSOCK_POLLNVAL) ||
+	    (pev->event.revents & ZSOCK_POLLHUP)) {
+		if (pev->event.revents & ZSOCK_POLLNVAL) {
+			default_error = EBADF;
+		} else if (pev->event.revents & ZSOCK_POLLHUP) {
+			default_error = ENOTCONN;
+		}
+
 		(void)zsock_getsockopt(pev->event.fd, ZSOCK_SOL_SOCKET,
 				       ZSOCK_SO_DOMAIN, &family, &optlen);
-		(void)zsock_getsockopt(pev->event.fd, ZSOCK_SOL_SOCKET,
-				       ZSOCK_SO_ERROR, &sock_error, &optlen);
+		if (zsock_getsockopt(pev->event.fd, ZSOCK_SOL_SOCKET,
+				     ZSOCK_SO_ERROR, &sock_error, &optlen) < 0 ||
+		    sock_error == 0) {
+			sock_error = default_error;
+		}
+
 		NET_ERR("TCP receiver IPv%d socket error (%d)",
 			family == NET_AF_INET ? 4 : 6, sock_error);
 		ret = -sock_error;

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -320,7 +320,8 @@ static int udp_recv_data(struct net_socket_service_event *pev)
 {
 	static uint8_t buf[UDP_RECEIVER_BUF_SIZE];
 	int ret = 1;
-	int family, sock_error;
+	int family, sock_error = 0;
+	int default_error = EIO;
 	struct net_sockaddr addr;
 	net_socklen_t optlen = sizeof(int);
 	net_socklen_t addrlen = sizeof(addr);
@@ -330,11 +331,22 @@ static int udp_recv_data(struct net_socket_service_event *pev)
 	}
 
 	if ((pev->event.revents & ZSOCK_POLLERR) ||
-	    (pev->event.revents & ZSOCK_POLLNVAL)) {
+	    (pev->event.revents & ZSOCK_POLLNVAL) ||
+	    (pev->event.revents & ZSOCK_POLLHUP)) {
+		if (pev->event.revents & ZSOCK_POLLNVAL) {
+			default_error = EBADF;
+		} else if (pev->event.revents & ZSOCK_POLLHUP) {
+			default_error = ENOTCONN;
+		}
+
 		(void)zsock_getsockopt(pev->event.fd, ZSOCK_SOL_SOCKET,
 				       ZSOCK_SO_DOMAIN, &family, &optlen);
-		(void)zsock_getsockopt(pev->event.fd, ZSOCK_SOL_SOCKET,
-				       ZSOCK_SO_ERROR, &sock_error, &optlen);
+		if (zsock_getsockopt(pev->event.fd, ZSOCK_SOL_SOCKET,
+				     ZSOCK_SO_ERROR, &sock_error, &optlen) < 0 ||
+		    sock_error == 0) {
+			sock_error = default_error;
+		}
+
 		NET_ERR("UDP receiver IPv%d socket error (%d)",
 			family == NET_AF_INET ? 4 : 6, sock_error);
 		ret = -sock_error;


### PR DESCRIPTION
## Summary

Fix zperf TCP and UDP receiver handling for terminal socket poll events.

The receivers already handled `POLLERR` and `POLLNVAL`, but did not treat `POLLHUP` as a terminal event. Also, if `SO_ERROR` returned `0` after poll had reported an error-style event, the receivers could treat the condition as success and keep the socket registered.

## Changes

- Handle `ZSOCK_POLLHUP` in both TCP and UDP zperf receivers.
- Map terminal poll events to fallback errors when `SO_ERROR` is unavailable or returns `0`.
- Ensure the receiver cleanup path is reached instead of leaving the socket registered after a terminal event.

## Why

A terminal socket event should stop the zperf receiver path. Keeping the socket registered can cause repeated socket-service wakeups and unnecessary CPU usage, which can interfere with other networking work on constrained targets.