### PR TITLE
Fix typo in inline comments: "true is" => "true if"

### DIFF
--- a/include/zephyr/cache.h
+++ b/include/zephyr/cache.h
@@ -558,7 +558,7 @@ static ALWAYS_INLINE void sys_cache_flush(void *addr, size_t size)
  *
  * @param ptr Pointer to be checked.
  *
- * @return True is pointer is in any coherence regions, false otherwise.
+ * @return True if pointer is in any coherence regions, false otherwise.
  */
 static ALWAYS_INLINE bool sys_cache_is_mem_coherent(void *ptr)
 {

--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -295,7 +295,7 @@ void k_mem_unmap_phys_bare(uint8_t *virt, size_t size);
  *             anonymous memory. Must be page-aligned.
  * @param size Size of the memory mapping. This must be page-aligned.
  * @param flags K_MEM_PERM_*, K_MEM_MAP_* control flags.
- * @param is_anon True is requesting mapping with anonymous memory.
+ * @param is_anon True if requesting mapping with anonymous memory.
  *
  * @return The mapped memory location, or NULL if insufficient virtual address
  *         space, insufficient physical memory to establish the mapping,

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -892,7 +892,7 @@ static bool is_fmt_spec(char c)
 	return (c >= 64) && (c <= 122);
 }
 
-/* Function checks if nth argument is a pointer (%p). Returns true is yes. Returns
+/* Function checks if nth argument is a pointer (%p). Returns true if yes. Returns
  * false if not or if string does not have nth argument.
  */
 bool is_ptr(const char *fmt, int n)


### PR DESCRIPTION
Fix 3 typos in inline comments (used in the generated documentation):  `true is` replaced with "true if".
These 3 are the sole one found grepping for equivalent forms in the file tree.    
**include/zephyr/cache.h**
**include/zephyr/kernel/internal/mm.h**
**lib/os/cbprintf_packaged.c**