### PR TITLE
include: zephyr: {devicetree|drivers}: format DT_DRV_COMPAT for doxygen

### DIFF
--- a/drivers/wifi/ameba/ameba_wifi_drv.c
+++ b/drivers/wifi/ameba/ameba_wifi_drv.c
@@ -673,7 +673,7 @@ static const struct net_wifi_mgmt_offload rtk_api = {
 	.wifi_mgmt_api = &ameba_wifi_mgmt,
 };
 
-/* inst replace by DT_DRV_COMPAT(inst) */
+/* inst replace by DT_DRV_INST(inst) */
 NET_DEVICE_DT_INST_DEFINE(0, ameba_wifi_dev_init, NULL, &ameba_data[STA_WLAN_INDEX], NULL,
 			  CONFIG_WIFI_INIT_PRIORITY, &rtk_api, ETHERNET_L2,
 			  NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU);

--- a/include/zephyr/devicetree/can.h
+++ b/include/zephyr/devicetree/can.h
@@ -121,8 +121,8 @@ extern "C" {
 		    MIN(DT_PROP_OR(DT_CHILD(node_id, can_transceiver), max_bitrate, max), max))
 
 /**
- * @brief Get the minimum transceiver bitrate for a DT_DRV_COMPAT CAN controller
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get the minimum transceiver bitrate for a @c DT_DRV_COMPAT CAN controller
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param min minimum bitrate supported by the CAN controller
  * @return the minimum bitrate supported by the CAN controller/transceiver combination
  * @see DT_CAN_TRANSCEIVER_MIN_BITRATE()
@@ -131,8 +131,8 @@ extern "C" {
 	DT_CAN_TRANSCEIVER_MIN_BITRATE(DT_DRV_INST(inst), min)
 
 /**
- * @brief Get the maximum transceiver bitrate for a DT_DRV_COMPAT CAN controller
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get the maximum transceiver bitrate for a @c DT_DRV_COMPAT CAN controller
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param max maximum bitrate supported by the CAN controller
  * @return the maximum bitrate supported by the CAN controller/transceiver combination
  * @see DT_CAN_TRANSCEIVER_MAX_BITRATE()

--- a/include/zephyr/devicetree/clocks.h
+++ b/include/zephyr/devicetree/clocks.h
@@ -255,7 +255,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_CLOCKS_HAS_IDX(DT_DRV_INST(inst), idx)
- * @param inst DT_DRV_COMPAT instance number; may or may not have any clocks property
+ * @param inst @c DT_DRV_COMPAT instance number; may or may not have any clocks property
  * @param idx index of a clocks property phandle-array whose existence to check
  * @return 1 if the index exists, 0 otherwise
  */
@@ -264,7 +264,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_CLOCK_HAS_NAME(DT_DRV_INST(inst), name)
- * @param inst DT_DRV_COMPAT instance number; may or may not have any clock-names property.
+ * @param inst @c DT_DRV_COMPAT instance number; may or may not have any clock-names property.
  * @param name lowercase-and-underscores clock-names cell value name to check
  * @return 1 if the clock name exists, 0 otherwise
  */
@@ -316,9 +316,9 @@ extern "C" {
 	DT_CLOCKS_CTLR_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's clock specifier's cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's clock specifier's cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into clocks property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index "idx"
@@ -328,8 +328,8 @@ extern "C" {
 	DT_CLOCKS_CELL_BY_IDX(DT_DRV_INST(inst), idx, cell)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's clock specifier's cell value by name
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get a @c DT_DRV_COMPAT instance's clock specifier's cell value by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a clocks element
  *             as defined by the node's clock-names property
  * @param cell lowercase-and-underscores cell name
@@ -341,7 +341,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_CLOCKS_CELL_BY_IDX(inst, 0, cell)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param cell lowercase-and-underscores cell name
  * @return the value of the cell inside the specifier at index 0
  */

--- a/include/zephyr/devicetree/dma.h
+++ b/include/zephyr/devicetree/dma.h
@@ -92,9 +92,9 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the DMA controller from a
- *        DT_DRV_COMPAT instance's dmas property at an index
+ *        @c DT_DRV_COMPAT instance's dmas property at an index
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into dmas property
  * @return the node identifier for the DMA controller referenced at
  *         index "idx"
@@ -105,8 +105,8 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the DMA controller from a
- *        DT_DRV_COMPAT instance's dmas property by name
- * @param inst DT_DRV_COMPAT instance number
+ *        @c DT_DRV_COMPAT instance's dmas property by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a dmas element
  *             as defined by the node's dma-names property
  * @return the node identifier for the DMA controller in the named element
@@ -117,7 +117,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_DMAS_CTLR_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the node identifier for the DMA controller at index 0
  *         in the instance's "dmas" property
  * @see DT_DMAS_CTLR_BY_IDX()
@@ -167,8 +167,8 @@ extern "C" {
 	DT_PHA_BY_IDX(node_id, dmas, idx, cell)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's DMA specifier's cell value at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get a @c DT_DRV_COMPAT instance's DMA specifier's cell value at an index
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into dmas property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index "idx"
@@ -241,8 +241,8 @@ extern "C" {
 	DT_PHA_BY_NAME_OR(node_id, dmas, name, cell, default_value)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's DMA specifier's cell value by name
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get a @c DT_DRV_COMPAT instance's DMA specifier's cell value by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a dmas element
  *             as defined by the node's dma-names property
  * @param cell lowercase-and-underscores cell name
@@ -262,8 +262,8 @@ extern "C" {
 	IS_ENABLED(DT_CAT4(node_id, _P_dmas_IDX_, idx, _EXISTS))
 
 /**
- * @brief Is index "idx" valid for a DT_DRV_COMPAT instance's dmas property?
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Is index "idx" valid for a @c DT_DRV_COMPAT instance's dmas property?
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into dmas property
  * @return 1 if the "dmas" property has a specifier at index "idx", 0 otherwise
  */
@@ -281,8 +281,8 @@ extern "C" {
 	DT_PROP_HAS_NAME(node_id, dmas, name)
 
 /**
- * @brief Does a DT_DRV_COMPAT instance's dmas property have a named element?
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Does a @c DT_DRV_COMPAT instance's dmas property have a named element?
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a dmas element
  *             as defined by the node's dma-names property
  * @return 1 if the dmas property has the named element, 0 otherwise

--- a/include/zephyr/devicetree/gpio.h
+++ b/include/zephyr/devicetree/gpio.h
@@ -315,9 +315,9 @@ extern "C" {
 		    (DT_CAT4(node_id, _GPIO_HOGS_IDX_, idx, _VAL_flags)), (0))
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's GPIO specifier's pin cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's GPIO specifier's pin cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
  * @param idx logical index into "gpio_pha"
@@ -329,7 +329,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_GPIO_PIN_BY_IDX(inst, gpio_pha, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
  * @return the pin cell value at index 0
@@ -339,9 +339,9 @@ extern "C" {
 	DT_INST_GPIO_PIN_BY_IDX(inst, gpio_pha, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's GPIO specifier's flags cell
+ * @brief Get a @c DT_DRV_COMPAT instance's GPIO specifier's flags cell
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
  * @param idx logical index into "gpio_pha"
@@ -353,7 +353,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_GPIO_FLAGS_BY_IDX(inst, gpio_pha, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
  * @return the flags cell value at index 0, or zero if there is none

--- a/include/zephyr/devicetree/interrupt_controller.h
+++ b/include/zephyr/devicetree/interrupt_controller.h
@@ -38,7 +38,7 @@ extern "C" {
 #define DT_INTC_GET_AGGREGATOR_LEVEL(node_id) UTIL_INC(DT_IRQ_LEVEL(node_id))
 
 /**
- * @brief Get the aggregator level of a `DT_DRV_COMPAT` interrupt controller
+ * @brief Get the aggregator level of a @c DT_DRV_COMPAT interrupt controller
  *
  * @note Aggregator level is equivalent to IRQ_LEVEL + 1 (a 2nd level aggregator has Zephyr level 1
  * IRQ encoding)

--- a/include/zephyr/devicetree/io-channels.h
+++ b/include/zephyr/devicetree/io-channels.h
@@ -89,10 +89,10 @@ extern "C" {
 #define DT_IO_CHANNELS_CTLR(node_id) DT_IO_CHANNELS_CTLR_BY_IDX(node_id, 0)
 
 /**
- * @brief Get the node identifier from a DT_DRV_COMPAT instance's io-channels
+ * @brief Get the node identifier from a @c DT_DRV_COMPAT instance's io-channels
  *        property at an index
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into io-channels property
  * @return the node identifier for the node referenced at index "idx"
  * @see DT_IO_CHANNELS_CTLR_BY_IDX()
@@ -101,9 +101,9 @@ extern "C" {
 	DT_IO_CHANNELS_CTLR_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Get the node identifier from a DT_DRV_COMPAT instance's io-channels
+ * @brief Get the node identifier from a @c DT_DRV_COMPAT instance's io-channels
  *        property by name
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of an io-channels element
  *             as defined by the node's io-channel-names property
  * @return the node identifier for the node referenced at the named element
@@ -114,7 +114,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_IO_CHANNELS_CTLR_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the node identifier for the node referenced at index 0
  *         in the node's "io-channels" property
  * @see DT_IO_CHANNELS_CTLR_BY_IDX()
@@ -213,7 +213,7 @@ extern "C" {
 /**
  * @brief Get an input cell from the "DT_DRV_INST(inst)" io-channels
  *        property at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into io-channels property
  * @return the input cell in the specifier at index "idx"
  * @see DT_IO_CHANNELS_INPUT_BY_IDX()
@@ -224,7 +224,7 @@ extern "C" {
 /**
  * @brief Get an input cell from the "DT_DRV_INST(inst)" io-channels
  *        property by name
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of an io-channels element
  *             as defined by the instance's io-channel-names property
  * @return the input cell in the specifier at the named element
@@ -235,7 +235,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_IO_CHANNELS_INPUT_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the input cell in the specifier at index 0
  */
 #define DT_INST_IO_CHANNELS_INPUT(inst) DT_INST_IO_CHANNELS_INPUT_BY_IDX(inst, 0)
@@ -333,7 +333,7 @@ extern "C" {
 /**
  * @brief Get an output cell from the "DT_DRV_INST(inst)" io-channels
  *        property at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into io-channels property
  * @return the output cell in the specifier at index "idx"
  * @see DT_IO_CHANNELS_OUTPUT_BY_IDX()
@@ -344,7 +344,7 @@ extern "C" {
 /**
  * @brief Get an output cell from the "DT_DRV_INST(inst)" io-channels
  *        property by name
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of an io-channels element
  *             as defined by the instance's io-channel-names property
  * @return the output cell in the specifier at the named element
@@ -355,7 +355,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_IO_CHANNELS_OUTPUT_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the output cell in the specifier at index 0
  */
 #define DT_INST_IO_CHANNELS_OUTPUT(inst) DT_INST_IO_CHANNELS_OUTPUT_BY_IDX(inst, 0)

--- a/include/zephyr/devicetree/nvmem.h
+++ b/include/zephyr/devicetree/nvmem.h
@@ -200,11 +200,11 @@ extern "C" {
 #define DT_NVMEM_CELL_BY_NAME(node_id, name) DT_PHANDLE_BY_NAME(node_id, nvmem_cells, name)
 
 /**
- * @brief Test if a DT_DRV_COMPAT instance has an nvmem-cells property at a given index.
+ * @brief Test if a @c DT_DRV_COMPAT instance has an nvmem-cells property at a given index.
  *
  * Equivalent to DT_NVMEM_CELLS_HAS_IDX(DT_DRV_INST(inst), idx).
  *
- * @param inst DT_DRV_COMPAT instance number that may or may not have an nvmem-cells property.
+ * @param inst @c DT_DRV_COMPAT instance number that may or may not have an nvmem-cells property.
  * @param idx Index of an nvmem-cells property phandle-array whose existence to check.
  *
  * @return 1 if the index exists, 0 otherwise.
@@ -212,11 +212,12 @@ extern "C" {
 #define DT_INST_NVMEM_CELLS_HAS_IDX(inst, idx) DT_NVMEM_CELLS_HAS_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Test if a DT_DRV_COMPAT instance has an nvmem-cell-names property with a given name.
+ * @brief Test if a @c DT_DRV_COMPAT instance has an nvmem-cell-names property with a given name.
  *
  * Equivalent to DT_NVMEM_CELLS_HAS_NAME(DT_DRV_INST(inst), name).
  *
- * @param inst DT_DRV_COMPAT instance number that may or may not have an nvmem-cell-names property.
+ * @param inst @c DT_DRV_COMPAT instance number that may or may not have an nvmem-cell-names
+ *             property.
  * @param name Lowercase-and-underscores nvmem-cell-names cell value name to check.
  *
  * @return 1 if the nvmem cell name exists, 0 otherwise.
@@ -224,11 +225,11 @@ extern "C" {
 #define DT_INST_NVMEM_CELLS_HAS_NAME(inst, name) DT_NVMEM_CELLS_HAS_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get the number of elements in a DT_DRV_COMPAT instance's nvmem-cells property.
+ * @brief Get the number of elements in a @c DT_DRV_COMPAT instance's nvmem-cells property.
  *
  * Equivalent to DT_NUM_NVMEM_CELLS(DT_DRV_INST(inst)).
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  *
  * @return Number of elements in the nvmem-cells property.
  */
@@ -238,7 +239,7 @@ extern "C" {
  * @brief Get the node identifier for the controller phandle from an
  *        nvmem-cells phandle-array property at an index
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into nvmem-cells property.
  *
  * @return The node identifier for the nvmem cell referenced at
@@ -249,11 +250,11 @@ extern "C" {
 #define DT_INST_NVMEM_CELL_BY_IDX(inst, idx) DT_NVMEM_CELL_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Get the node identifier for a DT_DRV_COMPAT instance's NVMEM cell at index 0.
+ * @brief Get the node identifier for a @c DT_DRV_COMPAT instance's NVMEM cell at index 0.
  *
  * Equivalent to DT_INST_NVMEM_CELL_BY_IDX(inst, 0).
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  *
  * @return A node identifier for the nvmem cell at index 0
  *         in nvmem-cells.
@@ -266,7 +267,7 @@ extern "C" {
  * @brief Get the node identifier for the controller phandle from an
  *        nvmem-cells phandle-array property by name
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name of an nvmem-cells element
  *             as defined by the node's nvmem-cell-names property.
  *

--- a/include/zephyr/devicetree/ordinals.h
+++ b/include/zephyr/devicetree/ordinals.h
@@ -68,7 +68,7 @@
 #define DT_SUPPORTS_DEP_ORDS(node_id) DT_CAT(node_id, _SUPPORTS_ORDS)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's dependency ordinal
+ * @brief Get a @c DT_DRV_COMPAT instance's dependency ordinal
  *
  * Equivalent to DT_DEP_ORD(DT_DRV_INST(inst)).
  *
@@ -78,7 +78,7 @@
 #define DT_INST_DEP_ORD(inst) DT_DEP_ORD(DT_DRV_INST(inst))
 
 /**
- * @brief Get a list of dependency ordinals of a DT_DRV_COMPAT instance's
+ * @brief Get a list of dependency ordinals of a @c DT_DRV_COMPAT instance's
  *        direct dependencies
  *
  * Equivalent to DT_REQUIRES_DEP_ORDS(DT_DRV_INST(inst)).
@@ -91,7 +91,7 @@
 
 /**
  * @brief Get a list of dependency ordinals of what depends directly on a
- *        DT_DRV_COMPAT instance
+ *        @c DT_DRV_COMPAT instance
  *
  * Equivalent to DT_SUPPORTS_DEP_ORDS(DT_DRV_INST(inst)).
  *

--- a/include/zephyr/devicetree/pinctrl.h
+++ b/include/zephyr/devicetree/pinctrl.h
@@ -300,7 +300,7 @@
 
 /**
  * @brief Get a node identifier for a phandle in a pinctrl property by index
- *        for a DT_DRV_COMPAT instance
+ *        for a @c DT_DRV_COMPAT instance
  *
  * This is equivalent to DT_PINCTRL_BY_IDX(DT_DRV_INST(inst), pc_idx, idx).
  *
@@ -314,7 +314,7 @@
 
 /**
  * @brief Get a node identifier from a pinctrl-0 property for a
- *        DT_DRV_COMPAT instance
+ *        @c DT_DRV_COMPAT instance
  *
  * This is equivalent to:
  *
@@ -332,7 +332,7 @@
 
 /**
  * @brief Get a node identifier for a phandle inside a pinctrl node
- *        for a DT_DRV_COMPAT instance
+ *        for a @c DT_DRV_COMPAT instance
  *
  * This is equivalent to DT_PINCTRL_BY_NAME(DT_DRV_INST(inst), name, idx).
  *
@@ -347,7 +347,7 @@
 
 /**
  * @brief Convert a pinctrl name to its corresponding index
- *        for a DT_DRV_COMPAT instance
+ *        for a @c DT_DRV_COMPAT instance
  *
  * This is equivalent to DT_PINCTRL_NAME_TO_IDX(DT_DRV_INST(inst),
  * name).
@@ -387,7 +387,7 @@
 
 /**
  * @brief Get the number of phandles in a pinctrl property
- *        for a DT_DRV_COMPAT instance
+ *        for a @c DT_DRV_COMPAT instance
  *
  * This is equivalent to DT_NUM_PINCTRLS_BY_IDX(DT_DRV_INST(inst),
  * pc_idx).
@@ -413,7 +413,7 @@
 	DT_NUM_PINCTRLS_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get the number of pinctrl properties in a DT_DRV_COMPAT instance
+ * @brief Get the number of pinctrl properties in a @c DT_DRV_COMPAT instance
  *
  * This is equivalent to DT_NUM_PINCTRL_STATES(DT_DRV_INST(inst)).
  *
@@ -424,7 +424,7 @@
 	DT_NUM_PINCTRL_STATES(DT_DRV_INST(inst))
 
 /**
- * @brief Test if a DT_DRV_COMPAT instance has a pinctrl property
+ * @brief Test if a @c DT_DRV_COMPAT instance has a pinctrl property
  *        with an index
  *
  * This is equivalent to DT_PINCTRL_HAS_IDX(DT_DRV_INST(inst), pc_idx).
@@ -437,7 +437,7 @@
 	DT_PINCTRL_HAS_IDX(DT_DRV_INST(inst), pc_idx)
 
 /**
- * @brief Test if a DT_DRV_COMPAT instance has a pinctrl property with a name
+ * @brief Test if a @c DT_DRV_COMPAT instance has a pinctrl property with a name
  *
  * This is equivalent to DT_PINCTRL_HAS_NAME(DT_DRV_INST(inst), name).
  *

--- a/include/zephyr/devicetree/pwms.h
+++ b/include/zephyr/devicetree/pwms.h
@@ -321,9 +321,9 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the PWM controller from a
- *        DT_DRV_COMPAT instance's pwms property at an index
+ *        @c DT_DRV_COMPAT instance's pwms property at an index
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @return the node identifier for the PWM controller referenced at
  *         index "idx"
@@ -334,8 +334,8 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the PWM controller from a
- *        DT_DRV_COMPAT instance's pwms property by name
- * @param inst DT_DRV_COMPAT instance number
+ *        @c DT_DRV_COMPAT instance's pwms property by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
  * @return the node identifier for the PWM controller in the named element
@@ -346,7 +346,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CTLR_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the node identifier for the PWM controller at index 0
  *         in the instance's "pwms" property
  * @see DT_PWMS_CTLR_BY_IDX()
@@ -354,9 +354,9 @@ extern "C" {
 #define DT_INST_PWMS_CTLR(inst) DT_INST_PWMS_CTLR_BY_IDX(inst, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's PWM specifier's cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's PWM specifier's cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index "idx"
@@ -365,8 +365,8 @@ extern "C" {
 	DT_PWMS_CELL_BY_IDX(DT_DRV_INST(inst), idx, cell)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's PWM specifier's cell value by name
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get a @c DT_DRV_COMPAT instance's PWM specifier's cell value by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
  * @param cell lowercase-and-underscores cell name
@@ -378,7 +378,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, 0, cell)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index 0
  */
@@ -387,7 +387,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, channel)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @return the channel cell value at index "idx"
  * @see DT_INST_PWMS_CELL_BY_IDX()
@@ -397,7 +397,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_NAME(inst, name, channel)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
  * @return the channel cell value in the specifier at the named element
@@ -408,7 +408,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CHANNEL_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the channel cell value at index 0
  * @see DT_INST_PWMS_CHANNEL_BY_IDX()
  */
@@ -416,7 +416,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, period)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @return the period cell value at index "idx"
  * @see DT_INST_PWMS_CELL_BY_IDX()
@@ -426,7 +426,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_NAME(inst, name, period)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
  * @return the period cell value in the specifier at the named element
@@ -437,7 +437,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_PERIOD_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the period cell value at index 0
  * @see DT_INST_PWMS_PERIOD_BY_IDX()
  */
@@ -445,7 +445,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, flags)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @return the flags cell value at index "idx", or zero if there is none
  * @see DT_INST_PWMS_CELL_BY_IDX()
@@ -455,7 +455,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_NAME(inst, name, flags)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
  * @return the flags cell value in the specifier at the named element,
@@ -467,7 +467,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_PWMS_FLAGS_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the flags cell value at index 0, or zero if there is none
  * @see DT_INST_PWMS_FLAGS_BY_IDX()
  */

--- a/include/zephyr/devicetree/reset.h
+++ b/include/zephyr/devicetree/reset.h
@@ -204,9 +204,9 @@ extern "C" {
 	DT_RESET_CTLR_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's reset specifier's cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's reset specifier's cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into resets property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index "idx"
@@ -216,8 +216,8 @@ extern "C" {
 	DT_RESET_CELL_BY_IDX(DT_DRV_INST(inst), idx, cell)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's reset specifier's cell value by name
- * @param inst DT_DRV_COMPAT instance number
+ * @brief Get a @c DT_DRV_COMPAT instance's reset specifier's cell value by name
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a resets element
  *             as defined by the node's reset-names property
  * @param cell lowercase-and-underscores cell name
@@ -229,7 +229,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_RESET_CELL_BY_IDX(inst, 0, cell)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param cell lowercase-and-underscores cell name
  * @return the value of the cell inside the specifier at index 0
  */
@@ -280,9 +280,9 @@ extern "C" {
 	DT_RESET_ID_BY_IDX(node_id, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's Reset Controller specifier's id cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's Reset Controller specifier's id cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into "resets"
  * @return the id cell value at index "idx"
  * @see DT_RESET_ID_BY_IDX()
@@ -292,7 +292,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_RESET_ID_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the id cell value at index 0
  * @see DT_INST_RESET_ID_BY_IDX()
  */

--- a/include/zephyr/devicetree/spi.h
+++ b/include/zephyr/devicetree/spi.h
@@ -215,7 +215,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_SPI_DEV_HAS_CS_GPIOS(DT_DRV_INST(inst)).
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return 1 if the instance's bus has a CS pin at index
  *         DT_INST_REG_ADDR(inst), 0 otherwise
  * @see DT_SPI_DEV_HAS_CS_GPIOS()
@@ -226,7 +226,7 @@ extern "C" {
 /**
  * @brief Get GPIO controller node identifier for a SPI device instance
  * This is equivalent to DT_SPI_DEV_CS_GPIOS_CTLR(DT_DRV_INST(inst)).
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return node identifier for instance's chip select GPIO controller
  * @see DT_SPI_DEV_CS_GPIOS_CTLR()
  */
@@ -235,7 +235,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_SPI_DEV_CS_GPIOS_PIN(DT_DRV_INST(inst)).
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return pin number of the instance's chip select GPIO
  * @see DT_SPI_DEV_CS_GPIOS_PIN()
  */
@@ -244,7 +244,7 @@ extern "C" {
 
 /**
  * @brief DT_SPI_DEV_CS_GPIOS_FLAGS(DT_DRV_INST(inst)).
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return flags value of the instance's chip select GPIO specifier,
  *         or zero if there is none
  * @see DT_SPI_DEV_CS_GPIOS_FLAGS()

--- a/include/zephyr/devicetree/wuc.h
+++ b/include/zephyr/devicetree/wuc.h
@@ -121,9 +121,9 @@ extern "C" {
 #define DT_INST_WUC(inst) DT_INST_WUC_BY_IDX(inst, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's wakeup controller specifier's cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's wakeup controller specifier's cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into wakeup-ctrls property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index "idx"
@@ -133,7 +133,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_WUC_CELL_BY_IDX(inst, 0, cell)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param cell lowercase-and-underscores cell name
  * @return the value of the cell inside the specifier at index 0
  */
@@ -181,9 +181,9 @@ extern "C" {
 #define DT_WUC_ID(node_id) DT_WUC_ID_BY_IDX(node_id, 0)
 
 /**
- * @brief Get a DT_DRV_COMPAT instance's Wakeup Controller specifier's id cell value
+ * @brief Get a @c DT_DRV_COMPAT instance's Wakeup Controller specifier's id cell value
  *        at an index
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into "wakeup-ctrls"
  * @return the id cell value at index "idx"
  * @see DT_WUC_ID_BY_IDX()
@@ -192,7 +192,7 @@ extern "C" {
 
 /**
  * @brief Equivalent to DT_INST_WUC_ID_BY_IDX(inst, 0)
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the id cell value at index 0
  * @see DT_INST_WUC_ID_BY_IDX()
  */

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -449,12 +449,12 @@ struct adc_dt_spec {
 	COND_CODE_1(DT_PROP_HAS_NAME(node_id, io_channels, name), \
 		    (ADC_DT_SPEC_GET_BY_NAME(node_id, name)), (default_value))
 
-/** @brief Get ADC io-channel information from a DT_DRV_COMPAT devicetree
+/** @brief Get ADC io-channel information from a @c DT_DRV_COMPAT devicetree
  *         instance by name.
  *
  * @see ADC_DT_SPEC_GET_BY_NAME()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Channel name.
  *
  * @return Static initializer for an adc_dt_spec structure.
@@ -465,7 +465,7 @@ struct adc_dt_spec {
 /**
  * @brief Like ADC_DT_SPEC_INST_GET_BY_NAME(), with a fallback to a default value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Channel name.
  * @param default_value Fallback value to expand to.
  *
@@ -566,12 +566,12 @@ struct adc_dt_spec {
 	COND_CODE_1(DT_PROP_HAS_IDX(node_id, io_channels, idx), \
 		    (ADC_DT_SPEC_GET_BY_IDX(node_id, idx)), (default_value))
 
-/** @brief Get ADC io-channel information from a DT_DRV_COMPAT devicetree
+/** @brief Get ADC io-channel information from a @c DT_DRV_COMPAT devicetree
  *         instance.
  *
  * @see ADC_DT_SPEC_GET_BY_IDX()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Channel index.
  *
  * @return Static initializer for an adc_dt_spec structure.
@@ -582,7 +582,7 @@ struct adc_dt_spec {
 /**
  * @brief Like ADC_DT_SPEC_INST_GET_BY_IDX(), with a fallback to a default value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Channel index.
  * @param default_value Fallback value to expand to.
  *
@@ -623,7 +623,7 @@ struct adc_dt_spec {
  *
  * @see ADC_DT_SPEC_GET()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  *
  * @return Static initializer for an adc_dt_spec structure.
  */
@@ -634,7 +634,7 @@ struct adc_dt_spec {
  *
  * @see ADC_DT_SPEC_GET_OR()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param default_value Fallback value to expand to.
  *
  * @return Static initializer for a struct adc_dt_spec for the property,
@@ -1508,7 +1508,7 @@ static inline bool adc_is_ready_dt(const struct adc_dt_spec *spec)
 /**
  * @brief Get the decoder name for the current driver
  *
- * This function depends on `DT_DRV_COMPAT` being defined.
+ * This function depends on @c DT_DRV_COMPAT being defined.
  */
 #define ADC_DECODER_NAME() UTIL_CAT(DT_DRV_COMPAT, __adc_decoder_api)
 

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -108,9 +108,9 @@ struct bt_hci_driver_config {
 
 /**
  * @brief Static initializer for @p bt_hci_driver_config struct from
- * DT_DRV_COMPAT instance.
+ * @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @see BT_DT_HCI_DRIVER_CONFIG_GET()
  */
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -380,9 +380,9 @@ struct can_driver_config {
 	}
 
 /**
- * @brief Static initializer for @p can_driver_config struct from DT_DRV_COMPAT instance
+ * @brief Static initializer for @p can_driver_config struct from @c DT_DRV_COMPAT instance
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param _min_bitrate minimum bitrate supported by the CAN controller
  * @param _max_bitrate maximum bitrate supported by the CAN controller
  * @see CAN_DT_DRIVER_CONFIG_GET()
@@ -843,7 +843,7 @@ struct can_device_state {
 #endif /* CONFIG_CAN_STATS */
 
 /**
- * @brief Like CAN_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
+ * @brief Like CAN_DEVICE_DT_DEFINE() for an instance of a @c DT_DRV_COMPAT compatible
  *
  * @param inst Instance number. This is replaced by <tt>DT_DRV_INST(inst)</tt>
  *             in the call to CAN_DEVICE_DT_DEFINE().

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -845,7 +845,7 @@ struct can_device_state {
 /**
  * @brief Like CAN_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
  *
- * @param inst Instance number. This is replaced by <tt>DT_DRV_COMPAT(inst)</tt>
+ * @param inst Instance number. This is replaced by <tt>DT_DRV_INST(inst)</tt>
  *             in the call to CAN_DEVICE_DT_DEFINE().
  * @param ...  Other parameters as expected by CAN_DEVICE_DT_DEFINE().
  */

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -884,15 +884,15 @@ struct stm32_pclken {
 			STM32_CLOCK_INFO, (,), node_id)			\
 	}
 
-/* Get an array of STM32 clocks information for clocks listed in a DT_DRV_COMPAT instance node */
+/* Get an array of STM32 clocks information for clocks listed in a @c DT_DRV_COMPAT instance node */
 #define STM32_DT_INST_CLOCKS(inst)					\
 	STM32_DT_CLOCKS(DT_DRV_INST(inst))
 
-/* Get STM32 clock information for an indexed clock phandle in a DT_DRV_COMPAT instance node */
+/* Get STM32 clock information for an indexed clock phandle in a @c DT_DRV_COMPAT instance node */
 #define STM32_DT_INST_CLOCK_INFO_BY_IDX(clk_index, inst)		\
 	STM32_CLOCK_INFO(clk_index, DT_DRV_INST(inst))
 
-/* Get STM32 clock information for clock index 0 in a DT_DRV_COMPAT instance node */
+/* Get STM32 clock information for clock index 0 in a @c DT_DRV_COMPAT instance node */
 #define STM32_DT_INST_CLOCK_INFO(inst)					\
 	STM32_DT_INST_CLOCK_INFO_BY_IDX(0, inst)
 
@@ -906,11 +906,11 @@ struct stm32_pclken {
 		       STM32_CLOCK_DIV_SHIFT,				\
 	}
 
-/* Get STM32 clock information for named clock phandle in a DT_DRV_COMPAT instance node */
+/* Get STM32 clock information for named clock phandle in a @c DT_DRV_COMPAT instance node */
 #define STM32_DT_INST_CLOCK_INFO_BY_NAME(inst, name)			\
 	STM32_CLOCK_INFO_BY_NAME(DT_DRV_INST(inst), name)
 
-/* Return true only if at least an enabled instance of the DT_DRV_COMPAT has at least 2 clocks */
+/* Return true only if at least an enabled instance of the @c DT_DRV_COMPAT has at least 2 clocks */
 #define STM32_DOMAIN_CLOCK_INST_SUPPORT(inst) DT_INST_CLOCKS_HAS_IDX(inst, 1) ||
 #define STM32_DT_INST_DEV_DOMAIN_CLOCK_SUPPORT				\
 		(DT_INST_FOREACH_STATUS_OKAY(STM32_DOMAIN_CLOCK_INST_SUPPORT) 0)

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -254,12 +254,12 @@ struct dac_dt_spec {
 	COND_CODE_1(DT_PROP_HAS_NAME(node_id, io_channels, name), \
 		    (DAC_DT_SPEC_GET_BY_NAME(node_id, name)), (default_value))
 
-/** @brief Get DAC io-channel information from a DT_DRV_COMPAT devicetree
+/** @brief Get DAC io-channel information from a @c DT_DRV_COMPAT devicetree
  *         instance by name.
  *
  * @see DAC_DT_SPEC_GET_BY_NAME()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Channel name.
  *
  * @return Static initializer for an dac_dt_spec structure.
@@ -271,7 +271,7 @@ struct dac_dt_spec {
 /**
  * @brief Like DAC_DT_SPEC_INST_GET_BY_NAME(), with a fallback to a default value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Channel name.
  * @param default_value Fallback value to expand to.
  *
@@ -365,12 +365,12 @@ struct dac_dt_spec {
 	COND_CODE_1(DT_PROP_HAS_IDX(node_id, io_channels, idx), \
 		    (DAC_DT_SPEC_GET_BY_IDX(node_id, idx)), (default_value))
 
-/** @brief Get DAC io-channel information from a DT_DRV_COMPAT devicetree
+/** @brief Get DAC io-channel information from a @c DT_DRV_COMPAT devicetree
  *         instance.
  *
  * @see DAC_DT_SPEC_GET_BY_IDX()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Channel index.
  *
  * @return Static initializer for an dac_dt_spec structure.
@@ -381,7 +381,7 @@ struct dac_dt_spec {
 /**
  * @brief Like DAC_DT_SPEC_INST_GET_BY_IDX(), with a fallback to a default value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Channel index.
  * @param default_value Fallback value to expand to.
  *
@@ -422,7 +422,7 @@ struct dac_dt_spec {
  *
  * @see DAC_DT_SPEC_GET()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  *
  * @return Static initializer for an dac_dt_spec structure.
  */
@@ -433,7 +433,7 @@ struct dac_dt_spec {
  *
  * @see DAC_DT_SPEC_GET_OR()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param default_value Fallback value to expand to.
  *
  * @return Static initializer for a struct dac_dt_spec for the property,

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -160,7 +160,7 @@ struct emul {
 	};
 
 /**
- * @brief Like EMUL_DT_DEFINE(), but uses an instance of a DT_DRV_COMPAT compatible instead of a
+ * @brief Like EMUL_DT_DEFINE(), but uses an instance of a @c DT_DRV_COMPAT compatible instead of a
  *        node identifier.
  *
  * @param inst instance number. The @p node_id argument to EMUL_DT_DEFINE is set to

--- a/include/zephyr/drivers/emul_stub_device.h
+++ b/include/zephyr/drivers/emul_stub_device.h
@@ -24,7 +24,7 @@ struct emul_stub_dev_api {
 	/* Stub */
 };
 
-/* For every instance of a DT_DRV_COMPAT stub out a device for that instance */
+/* For every instance of a @c DT_DRV_COMPAT stub out a device for that instance */
 #define EMUL_STUB_DEVICE(n)                                                                        \
 	__maybe_unused static int emul_init_stub_##n(const struct device *dev)                     \
 	{                                                                                          \

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -198,7 +198,7 @@
  * @brief Declare SCMI TX/RX channels using node instance number
  *
  * Same as DT_SCMI_TRANSPORT_CHANNELS_DECLARE() but uses the
- * protocol's node instance number and the DT_DRV_COMPAT macro.
+ * protocol's node instance number and the @c DT_DRV_COMPAT macro.
  *
  * @param protocol node instance number
  */
@@ -374,7 +374,7 @@
 
 /**
  * @brief Just like DT_SCMI_PROTOCOL_DEFINE(), but uses an instance
- * of a `DT_DRV_COMPAT` compatible instead of a node identifier
+ * of a @c DT_DRV_COMPAT compatible instead of a node identifier
  *
  * @param inst Instance number
  * @param init_fn Pointer to protocol's initialization function

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -390,10 +390,10 @@ struct gpio_dt_spec {
 	GPIO_DT_SPEC_GET_BY_IDX_OR(node_id, prop, 0, default_value)
 
 /**
- * @brief Static initializer for a @p gpio_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @p gpio_dt_spec from a @c DT_DRV_COMPAT
  * instance's GPIO property at an index.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param prop lowercase-and-underscores property name
  * @param idx logical index into "prop"
  * @return static initializer for a struct gpio_dt_spec for the property
@@ -403,10 +403,10 @@ struct gpio_dt_spec {
 	GPIO_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), prop, idx)
 
 /**
- * @brief Static initializer for a @p gpio_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @p gpio_dt_spec from a @c DT_DRV_COMPAT
  *        instance's GPIO property at an index, with fallback
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param prop lowercase-and-underscores property name
  * @param idx logical index into "prop"
  * @param default_value fallback value to expand to
@@ -421,7 +421,7 @@ struct gpio_dt_spec {
 /**
  * @brief Equivalent to GPIO_DT_SPEC_INST_GET_BY_IDX(inst, prop, 0).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param prop lowercase-and-underscores property name
  * @return static initializer for a struct gpio_dt_spec for the property
  * @see GPIO_DT_SPEC_INST_GET_BY_IDX()
@@ -433,7 +433,7 @@ struct gpio_dt_spec {
  * @brief Equivalent to
  *        GPIO_DT_SPEC_INST_GET_BY_IDX_OR(inst, prop, 0, default_value).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param prop lowercase-and-underscores property name
  * @param default_value fallback value to expand to
  * @return static initializer for a struct gpio_dt_spec for the property
@@ -592,10 +592,10 @@ struct gpio_dt_spec {
 	GPIO_DT_RESERVED_RANGES_NGPIOS(node_id, DT_PROP(node_id, ngpios))
 
 /**
- * @brief Makes a bitmask of reserved GPIOs from a DT_DRV_COMPAT instance's
+ * @brief Makes a bitmask of reserved GPIOs from a @c DT_DRV_COMPAT instance's
  *        @p "gpio-reserved-ranges" property and @p "ngpios" argument
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the bitmask of reserved gpios
  * @param ngpios  number of GPIOs
  * @see GPIO_DT_RESERVED_RANGES()
@@ -604,10 +604,10 @@ struct gpio_dt_spec {
 		GPIO_DT_RESERVED_RANGES_NGPIOS(DT_DRV_INST(inst), ngpios)
 
 /**
- * @brief Make a bitmask of reserved GPIOs from a DT_DRV_COMPAT instance's GPIO
+ * @brief Make a bitmask of reserved GPIOs from a @c DT_DRV_COMPAT instance's GPIO
  *        @p "gpio-reserved-ranges" and @p "ngpios" properties
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the bitmask of reserved gpios
  * @see GPIO_DT_RESERVED_RANGES()
  */
@@ -674,10 +674,10 @@ struct gpio_dt_spec {
 	))
 
 /**
- * @brief Makes a bitmask of allowed GPIOs from a DT_DRV_COMPAT instance's
+ * @brief Makes a bitmask of allowed GPIOs from a @c DT_DRV_COMPAT instance's
  *        @p "gpio-reserved-ranges" property and @p "ngpios" argument
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param ngpios number of GPIOs
  * @return the bitmask of allowed gpios
  * @see GPIO_DT_NGPIOS_PORT_PIN_MASK_EXC()

--- a/include/zephyr/drivers/gpio/gpio_utils.h
+++ b/include/zephyr/drivers/gpio/gpio_utils.h
@@ -53,10 +53,10 @@ extern "C" {
 	GPIO_DT_PORT_PIN_MASK_NGPIOS_EXC(node_id, DT_PROP(node_id, ngpios))
 
 /**
- * @brief Make a bitmask of allowed GPIOs from a DT_DRV_COMPAT instance's GPIO
+ * @brief Make a bitmask of allowed GPIOs from a @c DT_DRV_COMPAT instance's GPIO
  *        @p "gpio-reserved-ranges" and @p "ngpios" DT properties values
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return the bitmask of allowed gpios
  * @see GPIO_DT_PORT_PIN_MASK_NGPIOS_EXC()
  */
@@ -76,9 +76,9 @@ extern "C" {
 	}
 
 /**
- * @brief Make a struct gpio_driver_config initializer from a DT_DRV_COMPAT instance number
+ * @brief Make a struct gpio_driver_config initializer from a @c DT_DRV_COMPAT instance number
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return a struct gpio_driver_config initializer
  */
 #define GPIO_COMMON_CONFIG_FROM_DT_INST(inst)                   \

--- a/include/zephyr/drivers/hwspinlock.h
+++ b/include/zephyr/drivers/hwspinlock.h
@@ -159,7 +159,7 @@ struct hwspinlock_dt_spec {
 /**
  * @brief Instance version of HWSPINLOCK_DT_SPEC_GET_BY_IDX()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Index of the hwlocks element
  *
  * @see HWSPINLOCK_DT_SPEC_GET_BY_IDX()
@@ -170,7 +170,7 @@ struct hwspinlock_dt_spec {
 /**
  * @brief Instance version of HWSPINLOCK_DT_SPEC_GET_BY_NAME()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of the hwlocks element
  *
  * @see HWSPINLOCK_DT_SPEC_GET_BY_NAME()
@@ -180,7 +180,7 @@ struct hwspinlock_dt_spec {
 /**
  * @brief Instance version of HWSPINLOCK_DT_SPEC_GET()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  *
  * @see HWSPINLOCK_DT_SPEC_GET()
  */

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -771,7 +771,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 				    __VA_ARGS__)
 
 /**
- * @brief Like I2C_DEVICE_DT_DEINIT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
+ * @brief Like I2C_DEVICE_DT_DEINIT_DEFINE() for an instance of a @c DT_DRV_COMPAT compatible
  *
  * @param inst instance number. This is replaced by
  * <tt>DT_DRV_INST(inst)</tt> in the call to I2C_DEVICE_DT_DEINIT_DEFINE().
@@ -782,7 +782,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 	I2C_DEVICE_DT_DEINIT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
- * @brief Like I2C_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
+ * @brief Like I2C_DEVICE_DT_DEFINE() for an instance of a @c DT_DRV_COMPAT compatible
  *
  * @param inst instance number. This is replaced by
  * <tt>DT_DRV_INST(inst)</tt> in the call to I2C_DEVICE_DT_DEFINE().

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -774,7 +774,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  * @brief Like I2C_DEVICE_DT_DEINIT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
  *
  * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to I2C_DEVICE_DT_DEINIT_DEFINE().
+ * <tt>DT_DRV_INST(inst)</tt> in the call to I2C_DEVICE_DT_DEINIT_DEFINE().
  *
  * @param ... other parameters as expected by I2C_DEVICE_DT_DEINIT_DEFINE().
  */
@@ -785,7 +785,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  * @brief Like I2C_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
  *
  * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to I2C_DEVICE_DT_DEFINE().
+ * <tt>DT_DRV_INST(inst)</tt> in the call to I2C_DEVICE_DT_DEFINE().
  *
  * @param ... other parameters as expected by I2C_DEVICE_DT_DEFINE().
  */

--- a/include/zephyr/drivers/i3c/devicetree.h
+++ b/include/zephyr/drivers/i3c/devicetree.h
@@ -193,7 +193,7 @@ extern "C" {
 			 prio, api, __VA_ARGS__)
 
 /**
- * @brief Like I3C_TARGET_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
+ * @brief Like I3C_TARGET_DT_DEFINE() for an instance of a @c DT_DRV_COMPAT compatible
  *
  * @param inst instance number. This is replaced by <tt>DT_DRV_INST(inst)</tt> in the call
  * to I3C_TARGET_DT_DEFINE().

--- a/include/zephyr/drivers/i3c/devicetree.h
+++ b/include/zephyr/drivers/i3c/devicetree.h
@@ -195,8 +195,8 @@ extern "C" {
 /**
  * @brief Like I3C_TARGET_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
  *
- * @param inst instance number. This is replaced by
- * `DT_DRV_COMPAT(inst)` in the call to I3C_TARGET_DT_DEFINE().
+ * @param inst instance number. This is replaced by <tt>DT_DRV_INST(inst)</tt> in the call
+ * to I3C_TARGET_DT_DEFINE().
  *
  * @param ... other parameters as expected by I3C_TARGET_DT_DEFINE().
  */

--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -134,7 +134,7 @@ struct mbox_dt_spec {
 /**
  * @brief Instance version of MBOX_DT_CHANNEL_GET()
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of the mboxes element
  *
  * @return static initializer for a struct mbox_dt_spec

--- a/include/zephyr/drivers/misc/interconn/renesas_elc/renesas_elc.h
+++ b/include/zephyr/drivers/misc/interconn/renesas_elc/renesas_elc.h
@@ -97,9 +97,9 @@ struct renesas_elc_dt_spec {
 
 /**
  * @brief Get the device pointer from the "renesas-elcs" property by element name for a
- * DT_DRV_COMPAT instance.
+ * @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  *
  * @return Device pointer.
@@ -108,10 +108,10 @@ struct renesas_elc_dt_spec {
 	DEVICE_DT_GET(DT_PHANDLE_BY_NAME(DT_DRV_INST(inst), renesas_elcs, name))
 
 /**
- * @brief Get the device pointer from the "renesas-elcs" property by index for a DT_DRV_COMPAT
+ * @brief Get the device pointer from the "renesas-elcs" property by index for a @c DT_DRV_COMPAT
  * instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  *
  * @return Device pointer.
@@ -121,9 +121,9 @@ struct renesas_elc_dt_spec {
 
 /**
  * @brief Get the device pointer from the "renesas-elcs" property by element name
- *        for a DT_DRV_COMPAT instance, or return NULL if the property does not exist.
+ *        for a @c DT_DRV_COMPAT instance, or return NULL if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  *
  * @return Device pointer or NULL.
@@ -133,9 +133,9 @@ struct renesas_elc_dt_spec {
 
 /**
  * @brief Get the device pointer from the "renesas-elcs" property by index
- *        for a DT_DRV_COMPAT instance, or return NULL if the property does not exist.
+ *        for a @c DT_DRV_COMPAT instance, or return NULL if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  *
  * @return Device pointer or NULL.
@@ -196,9 +196,9 @@ struct renesas_elc_dt_spec {
 		(default_value))
 
 /**
- * @brief Get the peripheral cell value by element name for a DT_DRV_COMPAT instance.
+ * @brief Get the peripheral cell value by element name for a @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  *
  * @return Peripheral cell value.
@@ -207,9 +207,9 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_PERIPHERAL_GET_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get the peripheral cell value by index for a DT_DRV_COMPAT instance.
+ * @brief Get the peripheral cell value by index for a @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  *
  * @return Peripheral cell value.
@@ -218,10 +218,10 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_PERIPHERAL_GET_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Get the peripheral cell value by element name for a DT_DRV_COMPAT instance,
+ * @brief Get the peripheral cell value by element name for a @c DT_DRV_COMPAT instance,
  *        or return a default value if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  * @param default_value Value to return if the property is not present.
  *
@@ -231,10 +231,10 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_PERIPHERAL_GET_BY_NAME_OR(DT_DRV_INST(inst), name, default_value)
 
 /**
- * @brief Get the peripheral cell value by index for a DT_DRV_COMPAT instance,
+ * @brief Get the peripheral cell value by index for a @c DT_DRV_COMPAT instance,
  *        or return a default value if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  * @param default_value Value to return if the property is not present.
  *
@@ -296,9 +296,9 @@ struct renesas_elc_dt_spec {
 		(default_value))
 
 /**
- * @brief Get the event cell value by element name for a DT_DRV_COMPAT instance.
+ * @brief Get the event cell value by element name for a @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  *
  * @return Event cell value.
@@ -307,9 +307,9 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_EVENT_GET_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
- * @brief Get the event cell value by index for a DT_DRV_COMPAT instance.
+ * @brief Get the event cell value by index for a @c DT_DRV_COMPAT instance.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  *
  * @return Event cell value.
@@ -318,10 +318,10 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_EVENT_GET_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Get the event cell value by element name for a DT_DRV_COMPAT instance,
+ * @brief Get the event cell value by element name for a @c DT_DRV_COMPAT instance,
  *        or return a default value if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param name Lowercase-and-underscores name as specified in the renesas-elcs-names property.
  * @param default_value Value to return if the property is not present.
  *
@@ -331,10 +331,10 @@ struct renesas_elc_dt_spec {
 	RENESAS_ELC_DT_SPEC_EVENT_GET_BY_NAME_OR(DT_DRV_INST(inst), name, default_value)
 
 /**
- * @brief Get the event cell value by index for a DT_DRV_COMPAT instance,
+ * @brief Get the event cell value by index for a @c DT_DRV_COMPAT instance,
  *        or return a default value if the property does not exist.
  *
- * @param inst DT_DRV_COMPAT instance number.
+ * @param inst @c DT_DRV_COMPAT instance number.
  * @param idx Logical index into the renesas-elcs property.
  * @param default_value Value to return if the property is not present.
  *

--- a/include/zephyr/drivers/mspi/devicetree.h
+++ b/include/zephyr/drivers/mspi/devicetree.h
@@ -312,7 +312,7 @@ extern "C" {
  * This is equivalent to
  * <tt>MSPI_CE_CONTROL_INIT(DT_DRV_INST(inst), delay)</tt>.
  *
- * Therefore, @p DT_DRV_COMPAT must already be defined before using
+ * Therefore, @c DT_DRV_COMPAT must already be defined before using
  * this macro.
  *
  * @param inst Devicetree node instance number

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -202,10 +202,10 @@ struct pwm_dt_spec {
 	}
 
 /**
- * @brief Static initializer for a struct pwm_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a struct pwm_dt_spec from a @c DT_DRV_COMPAT
  *        instance.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Lowercase-and-underscores name of a pwms element as defined by
  *             the node's pwm-names property.
  *
@@ -243,7 +243,7 @@ struct pwm_dt_spec {
  * @brief Like PWM_DT_SPEC_INST_GET_BY_NAME(), with a fallback to a default
  *        value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param name Lowercase-and-underscores name of a pwms element as defined by
  *             the node's pwm-names property.
  * @param default_value Fallback value to expand to.
@@ -307,10 +307,10 @@ struct pwm_dt_spec {
 	}
 
 /**
- * @brief Static initializer for a struct pwm_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a struct pwm_dt_spec from a @c DT_DRV_COMPAT
  *        instance.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Logical index into 'pwms' property.
  *
  * @return Static initializer for a struct pwm_dt_spec for the property.
@@ -346,7 +346,7 @@ struct pwm_dt_spec {
  * @brief Like PWM_DT_SPEC_INST_GET_BY_IDX(), with a fallback to a default
  *        value.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx Logical index into 'pwms' property.
  * @param default_value Fallback value to expand to.
  *
@@ -373,7 +373,7 @@ struct pwm_dt_spec {
 /**
  * @brief Equivalent to <tt>PWM_DT_SPEC_INST_GET_BY_IDX(inst, 0)</tt>.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  *
  * @return Static initializer for a struct pwm_dt_spec for the property.
  *
@@ -401,7 +401,7 @@ struct pwm_dt_spec {
  * @brief Equivalent to
  *        <tt>PWM_DT_SPEC_INST_GET_BY_IDX_OR(inst, 0, default_value)</tt>.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param default_value Fallback value to expand to.
  *
  * @return Static initializer for a struct pwm_dt_spec for the property.

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -119,10 +119,10 @@ struct reset_dt_spec {
 	RESET_DT_SPEC_GET_BY_IDX_OR(node_id, 0, default_value)
 
 /**
- * @brief Static initializer for a @p reset_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @p reset_dt_spec from a @c DT_DRV_COMPAT
  * instance's Reset Controller property at an index.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into "resets"
  * @return static initializer for a struct reset_dt_spec for the property
  * @see RESET_DT_SPEC_GET_BY_IDX()
@@ -131,10 +131,10 @@ struct reset_dt_spec {
 	RESET_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Static initializer for a @p reset_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @p reset_dt_spec from a @c DT_DRV_COMPAT
  *	  instance's 'resets' property at an index, with fallback
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into the 'resets' property
  * @param default_value fallback value to expand to
  * @return static initializer for a struct reset_dt_spec for the property,
@@ -148,7 +148,7 @@ struct reset_dt_spec {
 /**
  * @brief Equivalent to RESET_DT_SPEC_INST_GET_BY_IDX(inst, 0).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return static initializer for a struct reset_dt_spec for the property
  * @see RESET_DT_SPEC_INST_GET_BY_IDX()
  */
@@ -159,7 +159,7 @@ struct reset_dt_spec {
  * @brief Equivalent to
  *	  RESET_DT_SPEC_INST_GET_BY_IDX_OR(node_id, 0, default_value).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param default_value fallback value to expand to
  * @return static initializer for a struct reset_dt_spec for the property,
  *         or default_value if the node or property do not exist

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1518,7 +1518,7 @@ struct sensor_info {
  * compatible
  *
  * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to SENSOR_DEVICE_DT_DEFINE().
+ * <tt>DT_DRV_INST(inst)</tt> in the call to SENSOR_DEVICE_DT_DEFINE().
  *
  * @param ... other parameters as expected by SENSOR_DEVICE_DT_DEFINE().
  */

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1514,7 +1514,7 @@ struct sensor_info {
 	SENSOR_INFO_DT_DEFINE(node_id);
 
 /**
- * @brief Like SENSOR_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT
+ * @brief Like SENSOR_DEVICE_DT_DEFINE() for an instance of a @c DT_DRV_COMPAT
  * compatible
  *
  * @param inst instance number. This is replaced by
@@ -1616,7 +1616,7 @@ static inline int sensor_value_from_micro(struct sensor_value *val, int64_t micr
 /**
  * @brief Get the decoder name for the current driver
  *
- * This function depends on `DT_DRV_COMPAT` being defined.
+ * This function depends on @c DT_DRV_COMPAT being defined.
  */
 #define SENSOR_DECODER_NAME() UTIL_CAT(DT_DRV_COMPAT, __decoder_api)
 

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -538,7 +538,7 @@ static inline void smbus_xfer_stats(const struct device *dev, uint8_t sent,
 #endif /* CONFIG_SMBUS_STATS */
 
 /**
- * @brief Like SMBUS_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT
+ * @brief Like SMBUS_DEVICE_DT_DEFINE() for an instance of a @c DT_DRV_COMPAT
  * compatible
  *
  * @param inst instance number. This is replaced by

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -542,7 +542,7 @@ static inline void smbus_xfer_stats(const struct device *dev, uint8_t sent,
  * compatible
  *
  * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to SMBUS_DEVICE_DT_DEFINE().
+ * <tt>DT_DRV_INST(inst)</tt> in the call to SMBUS_DEVICE_DT_DEFINE().
  *
  * @param ... other parameters as expected by SMBUS_DEVICE_DT_DEFINE().
  */

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -405,7 +405,7 @@ struct spi_cs_control {
  * This is equivalent to
  * <tt>SPI_CS_CONTROL_INIT(DT_DRV_INST(inst), delay)</tt>.
  *
- * Therefore, @p DT_DRV_COMPAT must already be defined before using
+ * Therefore, @c DT_DRV_COMPAT must already be defined before using
  * this macro.
  *
  * @param inst Devicetree node instance number
@@ -836,7 +836,7 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
 				    level, prio, api, __VA_ARGS__)
 
 /**
- * @brief Like SPI_DEVICE_DT_DEINIT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`
+ * @brief Like SPI_DEVICE_DT_DEINIT_DEFINE(), but uses an instance of a @c DT_DRV_COMPAT
  * compatible instead of a node identifier.
  *
  * @param inst Instance number. The `node_id` argument to SPI_DEVICE_DT_DEINIT_DEFINE() is
@@ -847,7 +847,7 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
 	SPI_DEVICE_DT_DEINIT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
- * @brief Like SPI_DEVICE_DT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`
+ * @brief Like SPI_DEVICE_DT_DEFINE(), but uses an instance of a @c DT_DRV_COMPAT
  * compatible instead of a node identifier.
  *
  * @param inst Instance number. The `node_id` argument to SPI_DEVICE_DT_DEFINE() is

--- a/include/zephyr/drivers/wuc.h
+++ b/include/zephyr/drivers/wuc.h
@@ -115,10 +115,10 @@ struct wuc_dt_spec {
 	WUC_DT_SPEC_GET_BY_IDX_OR(node_id, 0, default_value)
 
 /**
- * @brief Static initializer for a @p wuc_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @p wuc_dt_spec from a @c DT_DRV_COMPAT
  * instance's Wakeup Controller property at an index.
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into "wakeup-ctrls"
  * @return static initializer for a struct wuc_dt_spec for the property
  * @see WUC_DT_SPEC_GET_BY_IDX()
@@ -126,10 +126,10 @@ struct wuc_dt_spec {
 #define WUC_DT_SPEC_INST_GET_BY_IDX(inst, idx) WUC_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
- * @brief Static initializer for a @p wuc_dt_spec from a DT_DRV_COMPAT
+ * @brief Static initializer for a @p wuc_dt_spec from a @c DT_DRV_COMPAT
  *	  instance's 'wakeup-ctrls' property at an index, with fallback
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param idx logical index into the 'wakeup-ctrls' property
  * @param default_value fallback value to expand to
  * @return static initializer for a struct wuc_dt_spec for the property,
@@ -143,7 +143,7 @@ struct wuc_dt_spec {
 /**
  * @brief Equivalent to WUC_DT_SPEC_INST_GET_BY_IDX(inst, 0).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @return static initializer for a struct wuc_dt_spec for the property
  * @see WUC_DT_SPEC_INST_GET_BY_IDX()
  */
@@ -153,7 +153,7 @@ struct wuc_dt_spec {
  * @brief Equivalent to
  *	  WUC_DT_SPEC_INST_GET_BY_IDX_OR(node_id, 0, default_value).
  *
- * @param inst DT_DRV_COMPAT instance number
+ * @param inst @c DT_DRV_COMPAT instance number
  * @param default_value fallback value to expand to
  * @return static initializer for a struct wuc_dt_spec for the property,
  *         or default_value if the node or property do not exist

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -1186,7 +1186,7 @@ static inline bool net_eth_is_vlan_interface(struct net_if *iface)
  * compatible
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to ETH_NET_DEVICE_DT_DEFINE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to ETH_NET_DEVICE_DT_DEFINE.
  *
  * @param ... other parameters as expected by ETH_NET_DEVICE_DT_DEFINE.
  */

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -3586,7 +3586,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * @brief Forward declaration of a network interface
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_ADD_IFACE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_DEVICE_DT_ADD_IFACE.
  * @param ... other parameters as expected by NET_DEVICE_DT_ADD_IFACE.
  */
 #define NET_IF_DT_INST_DECLARE(inst, ...) NET_IF_DT_DECLARE(DT_DRV_INST(inst), __VA_ARGS__)
@@ -3605,7 +3605,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * NET_DEVICE_DT_ADD_IFACE.
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_IF_DT_GET.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_IF_DT_GET.
  * @param ... other parameters as expected by NET_DEVICE_DT_ADD_IFACE.
  */
 #define NET_IF_DT_INST_GET(inst, ...) NET_IF_DT_GET(DT_DRV_INST(inst), __VA_ARGS__)
@@ -3652,7 +3652,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * @brief Like NET_DEVICE_DT_ADD_IFACE for an instance of a DT_DRV_COMPAT compatible
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_ADD_IFACE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_DEVICE_DT_ADD_IFACE.
  *
  * @param ... other parameters as expected by NET_DEVICE_DT_ADD_IFACE.
  */
@@ -3687,7 +3687,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * @brief Like NET_DEVICE_DT_DEFINE for an instance of a DT_DRV_COMPAT compatible
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_DEFINE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_DEVICE_DT_DEFINE.
  *
  * @param ... other parameters as expected by NET_DEVICE_DT_DEFINE.
  */
@@ -3760,7 +3760,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * compatible
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_DEFINE_INSTANCE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_DEVICE_DT_DEFINE_INSTANCE.
  *
  * @param ... other parameters as expected by NET_DEVICE_DT_DEFINE_INSTANCE.
  */
@@ -3830,7 +3830,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * compatible
  *
  * @param inst instance number.  This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_OFFLOAD_DEFINE.
+ * <tt>DT_DRV_INST(inst)</tt> in the call to NET_DEVICE_DT_OFFLOAD_DEFINE.
  *
  * @param ... other parameters as expected by NET_DEVICE_DT_OFFLOAD_DEFINE.
  */

--- a/include/zephyr/sensing/sensing_sensor.h
+++ b/include/zephyr/sensing/sensing_sensor.h
@@ -385,7 +385,7 @@ extern const struct rtio_iodev_api __sensing_iodev_api;
  * compatible
  *
  * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to SENSING_SENSORS_DT_DEFINE().
+ * <tt>DT_DRV_INST(inst)</tt> in the call to SENSING_SENSORS_DT_DEFINE().
  * @param ... other parameters as expected by SENSING_SENSORS_DT_DEFINE().
  */
 #define SENSING_SENSORS_DT_INST_DEFINE(inst, ...)	\


### PR DESCRIPTION
Insert a `@c` specifier before `DT_DRV_COMPAT` occurrences in inline description comments of header files in **include/zephyr/devicetree/** and **include/zephyr/drivers/** to enhance rendering in the generated documentation.

These changes were basically made running a 'sed' command line and manually fixing or discarding where needed.

Also fix a few place where `DT_DRV_COMPAT` was mentioned while `DT_DRV_INST` should be.