### PR TITLE
include: zephyr: drivers: Condition API documentation with __DOXYGEN__ where applicable

### DIFF
--- a/include/zephyr/drivers/adc/adc_npcx_threshold.h
+++ b/include/zephyr/drivers/adc/adc_npcx_threshold.h
@@ -15,22 +15,22 @@ enum adc_npcx_threshold_param_l_h {
 };
 
 enum adc_npcx_threshold_param_type {
-	/* Selects ADC channel to be used for measurement */
+	/** Selects ADC channel to be used for measurement */
 	ADC_NPCX_THRESHOLD_PARAM_CHNSEL,
-	/* Sets relation between measured value and assetion threshold value.*/
+	/** Sets relation between measured value and assetion threshold value.*/
 	ADC_NPCX_THRESHOLD_PARAM_L_H,
-	/* Sets the threshold value to which measured data is compared. */
+	/** Sets the threshold value to which measured data is compared. */
 	ADC_NPCX_THRESHOLD_PARAM_THVAL,
-	/* Sets worker queue thread to be notified */
+	/** Sets worker queue thread to be notified */
 	ADC_NPCX_THRESHOLD_PARAM_WORK,
-
+	/** Enum value bound */
 	ADC_NPCX_THRESHOLD_PARAM_MAX,
 };
 
 struct adc_npcx_threshold_param {
-	/* Threshold ocntrol parameter */
+	/** Threshold ocntrol parameter */
 	enum adc_npcx_threshold_param_type type;
-	/* Parameter value */
+	/** Parameter value */
 	uint32_t val;
 };
 

--- a/include/zephyr/drivers/adc/adc_npcx_v2t.h
+++ b/include/zephyr/drivers/adc/adc_npcx_v2t.h
@@ -9,11 +9,10 @@
 
 #include <zephyr/device.h>
 
-#ifdef CONFIG_ADC_V2T_NPCX
-
 /**
  * @brief Set ADC V2T channels
  *
+ * @kconfig_dep{CONFIG_ADC_V2T_NPCX}
  *
  * @param dev       Pointer to the ADC device instance.
  * @param channels  Bit-mask indicating the channels to be configured as V2T
@@ -25,6 +24,7 @@ int adc_npcx_v2t_set_channels(const struct device *dev, uint32_t channels);
 /**
  * @brief Get ADC V2T configured channels
  *
+ * @kconfig_dep{CONFIG_ADC_V2T_NPCX}
  *
  * @param dev  Pointer to the ADC device instance.
  *
@@ -33,5 +33,4 @@ int adc_npcx_v2t_set_channels(const struct device *dev, uint32_t channels);
  */
 uint32_t adc_npcx_v2t_get_channels(const struct device *dev);
 
-#endif /* CONFIG_ADC_V2T_NPCX */
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ADC_ADC_NPCX_V2T_H_ */

--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -28,12 +28,12 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_DCACHE)
-
 /**
  * @brief Enable the d-cache
  *
  * Enable the data cache.
+ *
+ * @kconfig_dep{CONFIG_DCACHE}
  */
 void cache_data_enable(void);
 
@@ -41,6 +41,8 @@ void cache_data_enable(void);
  * @brief Disable the d-cache
  *
  * Disable the data cache.
+ *
+ * @kconfig_dep{CONFIG_DCACHE}
  */
 void cache_data_disable(void);
 
@@ -48,6 +50,8 @@ void cache_data_disable(void);
  * @brief Flush the d-cache
  *
  * Flush the whole data cache.
+ *
+ * @kconfig_dep{CONFIG_DCACHE}
  *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
@@ -59,6 +63,8 @@ int cache_data_flush_all(void);
  *
  * Invalidate the whole data cache.
  *
+ * @kconfig_dep{CONFIG_DCACHE}
+ *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
  */
@@ -69,6 +75,8 @@ int cache_data_invd_all(void);
  *
  * Flush and Invalidate the whole data cache.
  *
+ * @kconfig_dep{CONFIG_DCACHE}
+ *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
  */
@@ -78,6 +86,8 @@ int cache_data_flush_and_invd_all(void);
  * @brief Flush an address range in the d-cache
  *
  * Flush the specified address range of the data cache.
+ *
+ * @kconfig_dep{CONFIG_DCACHE}
  *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being flushed, all the portions of the
@@ -98,6 +108,8 @@ int cache_data_flush_range(void *addr, size_t size);
  * @brief Invalidate an address range in the d-cache
  *
  * Invalidate the specified address range of the data cache.
+ *
+ * @kconfig_dep{CONFIG_DCACHE}
  *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being invalidated, all the portions of the
@@ -120,6 +132,8 @@ int cache_data_invd_range(void *addr, size_t size);
  *
  * Flush and Invalidate the specified address range of the data cache.
  *
+ * @kconfig_dep{CONFIG_DCACHE}
+ *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being flushed, all the portions of the
  *       data structures sharing the same line will be flushed before being
@@ -136,7 +150,6 @@ int cache_data_invd_range(void *addr, size_t size);
  */
 int cache_data_flush_and_invd_range(void *addr, size_t size);
 
-#if defined(CONFIG_DCACHE_LINE_SIZE_DETECT)
 /**
  *
  * @brief Get the d-cache line size.
@@ -147,19 +160,17 @@ int cache_data_flush_and_invd_range(void *addr, size_t size);
  * The function must be implemented only when CONFIG_DCACHE_LINE_SIZE_DETECT is
  * defined.
  *
+ * @kconfig_dep{CONFIG_DCACHE_LINE_SIZE_DETECT}
+ *
  * @retval size Size of the d-cache line.
  * @retval 0 The d-cache is not enabled.
  */
 size_t cache_data_line_size_get(void);
 
-#endif /* CONFIG_DCACHE_LINE_SIZE_DETECT */
-
-#endif /* CONFIG_DCACHE */
-
-#if defined(CONFIG_ICACHE)
-
 /**
  * @brief Enable the i-cache
+ *
+ * @kconfig_dep{CONFIG_ICACHE}
  *
  * Enable the instruction cache.
  */
@@ -167,6 +178,8 @@ void cache_instr_enable(void);
 
 /**
  * @brief Disable the i-cache
+ *
+ * @kconfig_dep{CONFIG_ICACHE}
  *
  * Disable the instruction cache.
  */
@@ -176,6 +189,8 @@ void cache_instr_disable(void);
  * @brief Flush the i-cache
  *
  * Flush the whole instruction cache.
+ *
+ * @kconfig_dep{CONFIG_ICACHE}
  *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
@@ -187,6 +202,8 @@ int cache_instr_flush_all(void);
  *
  * Invalidate the whole instruction cache.
  *
+ * @kconfig_dep{CONFIG_ICACHE}
+ *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
  */
@@ -197,6 +214,8 @@ int cache_instr_invd_all(void);
  *
  * Flush and Invalidate the whole instruction cache.
  *
+ * @kconfig_dep{CONFIG_ICACHE}
+ *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
  */
@@ -206,6 +225,8 @@ int cache_instr_flush_and_invd_all(void);
  * @brief Flush an address range in the i-cache
  *
  * Flush the specified address range of the instruction cache.
+ *
+ * @kconfig_dep{CONFIG_ICACHE}
  *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being flushed, all the portions of the
@@ -226,6 +247,8 @@ int cache_instr_flush_range(void *addr, size_t size);
  * @brief Invalidate an address range in the i-cache
  *
  * Invalidate the specified address range of the instruction cache.
+ *
+ * @kconfig_dep{CONFIG_ICACHE}
  *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being invalidated, all the portions of the
@@ -248,6 +271,8 @@ int cache_instr_invd_range(void *addr, size_t size);
  *
  * Flush and Invalidate the specified address range of the instruction cache.
  *
+ * @kconfig_dep{CONFIG_ICACHE}
+ *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being flushed, all the portions of the
  *       data structures sharing the same line will be flushed before being
@@ -264,7 +289,6 @@ int cache_instr_invd_range(void *addr, size_t size);
  */
 int cache_instr_flush_and_invd_range(void *addr, size_t size);
 
-#ifdef CONFIG_ICACHE_LINE_SIZE_DETECT
 /**
  *
  * @brief Get the i-cache line size.
@@ -272,17 +296,15 @@ int cache_instr_flush_and_invd_range(void *addr, size_t size);
  * The API is provided to dynamically detect the instruction cache line size at
  * run time.
  *
- * The function must be implemented only when CONFIG_ICACHE_LINE_SIZE_DETECT is
+ * The function must be implemented only when @kconfig{CONFIG_ICACHE_LINE_SIZE_DETECT} is
  * defined.
+ *
+ * @kconfig_dep{CONFIG_ICACHE_LINE_SIZE_DETECT}
  *
  * @retval size Size of the i-cache line.
  * @retval 0 The i-cache is not enabled.
  */
 size_t cache_instr_line_size_get(void);
-
-#endif /* CONFIG_ICACHE_LINE_SIZE_DETECT */
-
-#endif /* CONFIG_ICACHE */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -350,10 +350,10 @@ struct can_driver_config {
 	uint32_t bitrate;
 	/** Initial CAN classic/CAN FD arbitration phase sample point in permille. */
 	uint16_t sample_point;
-#ifdef CONFIG_CAN_FD_MODE
-	/** Initial CAN FD data phase sample point in permille. */
+#if defined(CONFIG_CAN_FD_MODE) || defined(__DOXYGEN__)
+	/** Initial CAN FD data phase sample point in permille. @kconfig_dep{CONFIG_CAN_FD_MODE} */
 	uint16_t sample_point_data;
-	/** Initial CAN FD data phase bitrate. */
+	/** Initial CAN FD data phase bitrates. @kconfig_dep{CONFIG_CAN_FD_MODE} */
 	uint32_t bitrate_data;
 #endif /* CONFIG_CAN_FD_MODE */
 };
@@ -621,6 +621,8 @@ STATS_NAME_END(can);
 /**
  * @brief CAN specific device state which allows for CAN device class specific
  * additions
+ *
+ * @kconfig_dep{CONFIG_CAN_STATS}
  */
 struct can_device_state {
 	/** Common device state. */
@@ -645,6 +647,8 @@ struct can_device_state {
  * The bit error counter is incremented when the CAN controller is unable to
  * transmit either a dominant or a recessive bit.
  *
+ * @kconfig_dep{CONFIG_CAN_STATS}
+ *
  * @note This error counter should only be incremented if the CAN controller is unable to
  * distinguish between failure to transmit a dominant versus failure to transmit a recessive bit. If
  * the CAN controller supports distinguishing between the two, the `bit0` or `bit1` error counter
@@ -667,6 +671,8 @@ struct can_device_state {
  * Incrementing this counter will automatically increment the bit error counter.
  * @see CAN_STATS_BIT_ERROR_INC()
  *
+ * @kconfig_dep{CONFIG_CAN_STATS}
+ *
  * @param dev_ Pointer to the device structure for the driver instance.
  */
 #define CAN_STATS_BIT0_ERROR_INC(dev_)				\
@@ -684,6 +690,8 @@ struct can_device_state {
  * Incrementing this counter will automatically increment the bit error counter.
  * @see CAN_STATS_BIT_ERROR_INC()
  *
+ * @kconfig_dep{CONFIG_CAN_STATS}
+ *
  * @param dev_ Pointer to the device structure for the driver instance.
  */
 #define CAN_STATS_BIT1_ERROR_INC(dev_)				\
@@ -698,6 +706,8 @@ struct can_device_state {
  * The stuffing error counter is incremented when the CAN controller detects a
  * bit stuffing error.
  *
+ * @kconfig_dep{CONFIG_CAN_STATS}
+ *
  * @param dev_ Pointer to the device structure for the driver instance.
  */
 #define CAN_STATS_STUFF_ERROR_INC(dev_)			\
@@ -708,6 +718,8 @@ struct can_device_state {
  *
  * The CRC error counter is incremented when the CAN controller detects a frame
  * with an invalid CRC.
+ *
+ * @kconfig_dep{CONFIG_CAN_STATS}
  *
  * @param dev_ Pointer to the device structure for the driver instance.
  */
@@ -720,6 +732,8 @@ struct can_device_state {
  * The form error counter is incremented when the CAN controller detects a
  * fixed-form bit field containing illegal bits.
  *
+ * @kconfig_dep{CONFIG_CAN_STATS}
+ *
  * @param dev_ Pointer to the device structure for the driver instance.
  */
 #define CAN_STATS_FORM_ERROR_INC(dev_)			\
@@ -730,6 +744,8 @@ struct can_device_state {
  *
  * The acknowledge error counter is incremented when the CAN controller does not
  * monitor a dominant bit in the ACK slot.
+ *
+ * @kconfig_dep{CONFIG_CAN_STATS}
  *
  * @param dev_ Pointer to the device structure for the driver instance.
  */
@@ -743,6 +759,8 @@ struct can_device_state {
  * frame matching an installed filter but lacks the capacity to store it (either
  * due to an already full RX mailbox or a full RX FIFO).
  *
+ * @kconfig_dep{CONFIG_CAN_STATS}
+ *
  * @param dev_ Pointer to the device structure for the driver instance.
  */
 #define CAN_STATS_RX_OVERRUN_INC(dev_)			\
@@ -754,6 +772,8 @@ struct can_device_state {
  * The driver is responsible for resetting the statistics before starting the CAN
  * controller.
  *
+ * @kconfig_dep{CONFIG_CAN_STATS}
+ *
  * @param dev_ Pointer to the device structure for the driver instance.
  */
 #define CAN_STATS_RESET(dev_)				\
@@ -763,6 +783,8 @@ struct can_device_state {
 
 /**
  * @brief Define a statically allocated and section assigned CAN device state
+ *
+ * @kconfig_dep{CONFIG_CAN_STATS}
  */
 #define Z_CAN_DEVICE_STATE_DEFINE(dev_id)				\
 	static struct can_device_state Z_DEVICE_STATE_NAME(dev_id)	\
@@ -773,6 +795,8 @@ struct can_device_state {
  *
  * This does device instance specific initialization of common data (such as stats)
  * and calls the given init_fn
+ *
+ * @kconfig_dep{CONFIG_CAN_STATS}
  */
 #define Z_CAN_INIT_FN(dev_id, init_fn)					\
 	static inline int UTIL_CAT(dev_id, _init)(const struct device *dev) \

--- a/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
+++ b/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
@@ -96,7 +96,9 @@ enum ifx_cat1_clock_block {
 	IFX_CAT1_CLOCK_BLOCK_ALTLF, /*!< Alternate Low Frequency Input Clock */
 	IFX_CAT1_CLOCK_BLOCK_ILO,   /*!< Internal Low Speed Oscillator Input Clock */
 #if !(defined(SRSS_HT_VARIANT) && (SRSS_HT_VARIANT > 0))
-	IFX_CAT1_CLOCK_BLOCK_PILO, /*!< Precision ILO Input Clock */
+	IFX_CAT1_CLOCK_BLOCK_PILO, /*!< Precision ILO Input Clock.
+				    * Depends on @kconfig{SRSS_HT_VARIANT} > 0
+				    */
 #endif
 
 	IFX_CAT1_CLOCK_BLOCK_WCO, /*!< Watch Crystal Oscillator Input Clock */
@@ -106,10 +108,19 @@ enum ifx_cat1_clock_block {
 
 	IFX_CAT1_CLOCK_BLOCK_FLL, /*!< Frequency-Locked Loop Clock */
 #if defined(CY_IP_MXS40SRSS) && (CY_IP_MXS40SRSS_VERSION >= 3)
-	IFX_CAT1_CLOCK_BLOCK_PLL200, /*!< 200MHz Phase-Locked Loop Clock */
-	IFX_CAT1_CLOCK_BLOCK_PLL400, /*!< 400MHz Phase-Locked Loop Clock */
+	IFX_CAT1_CLOCK_BLOCK_PLL200, /*!< 200MHz Phase-Locked Loop Clock.
+				      * Depends on @kconfig{CY_IP_MXS40SRSS} and
+				      * @kconfig{CY_IP_MXS40SRSS_VERSION} >= 3.
+				      */
+	IFX_CAT1_CLOCK_BLOCK_PLL400, /*!< 400MHz Phase-Locked Loop Clock.
+				      * Depends on @kconfig{CY_IP_MXS40SRSS} and
+				      * @kconfig{CY_IP_MXS40SRSS_VERSION} >= 3.
+				      */
 #else
-	IFX_CAT1_CLOCK_BLOCK_PLL, /*!< Phase-Locked Loop Clock */
+	IFX_CAT1_CLOCK_BLOCK_PLL, /*!< Phase-Locked Loop Clock.
+				   * Depends on @kconfig{CY_IP_MXS40SRSS} being disabled
+				   * @kconfig{CY_IP_MXS40SRSS_VERSION} < 3.
+				   */
 #endif
 
 	IFX_CAT1_CLOCK_BLOCK_LF, /*!< Low Frequency Clock */
@@ -544,28 +555,36 @@ static inline cy_rslt_t ifx_cat1_utils_peri_pclk_assign_divider(en_clk_dst_t clk
 #endif
 }
 
-#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE) || defined(__DOXYGEN__)
 /**
  * @brief Pack a PERI instance and group number into a single switch key.
  *
  * PSE84 has multiple PERI instances (PERI0, PERI1), each with its own set of
  * peri clock groups.  This macro combines the two into a unique value for use
  * in switch statements that map (instance, group) → HF clock index.
+ *
+ * @kconfig_dep{CONFIG_SOC_FAMILY_INFINEON_EDGE}
  */
 #define IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(instance, group) (((instance) << 4) | (group))
+#endif /* CONFIG_SOC_FAMILY_INFINEON_EDGE */
 
 /**
  * @brief Map a peripheral group index to the HF clock that sources it.
  *
  * The mapping is SoC-specific and fixed in hardware.
  *
+ * Fallback for SoC families that do not yet implement this mapping
+ * when @kconfiog{CONFIG_SOC_FAMILY_INFINEON_EDGE} and @kconfig{CONFIG_SOC_FAMILY_INFINEON_CAT1B}
+ * and both disabled in which case always returns -EINVAL.
+ *
  * @param peri_group Peripheral group index (or instance|group composite
  *                   on EDGE family SoCs).
- * @return HF clock index suitable for Cy_SysClk_ClkHfGetFrequency().
+ * @return HF clock index suitable for Cy_SysClk_ClkHfGetFrequency() or -EINVAL
  */
 static inline uint8_t ifx_cat1_utils_peri_pclk_get_hfclk(uint8_t peri_group)
 {
 	switch (peri_group) {
+#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
 	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 0):
 	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(1, 4):
 		return CLK_HF0;
@@ -590,25 +609,7 @@ static inline uint8_t ifx_cat1_utils_peri_pclk_get_hfclk(uint8_t peri_group)
 	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 6):
 	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 9):
 		return CLK_HF13;
-	default:
-		break;
-	}
-	return -EINVAL;
-}
-
 #elif defined(CONFIG_SOC_FAMILY_INFINEON_CAT1B)
-/**
- * @brief Map a peripheral group index to the HF clock that sources it.
- *
- * The mapping is SoC-specific and fixed in hardware.
- *
- * @param peri_group Peripheral group index (or instance|group composite
- *                   on EDGE family SoCs).
- * @return HF clock index suitable for Cy_SysClk_ClkHfGetFrequency().
- */
-static inline uint8_t ifx_cat1_utils_peri_pclk_get_hfclk(uint8_t peri_group)
-{
-	switch (peri_group) {
 	case 0:
 	case 2:
 		return CLK_HF0;
@@ -621,28 +622,11 @@ static inline uint8_t ifx_cat1_utils_peri_pclk_get_hfclk(uint8_t peri_group)
 		return CLK_HF3;
 	case 6:
 		return CLK_HF4;
+#endif /* CONFIG_SOC_FAMILY_INFINEON_CAT1 */
 	default:
 		break;
 	}
 	return -EINVAL;
 }
-
-#else /* !CONFIG_SOC_FAMILY_INFINEON_EDGE && !CONFIG_SOC_FAMILY_INFINEON_CAT1B */
-/**
- * @brief Map a peripheral group index to the HF clock that sources it.
- *
- * Fallback for SoC families that do not yet implement this mapping.
- * Always returns -EINVAL.
- *
- * @param peri_group Peripheral group index (unused).
- * @return -EINVAL always.
- */
-static inline uint8_t ifx_cat1_utils_peri_pclk_get_hfclk(uint8_t peri_group)
-{
-	ARG_UNUSED(peri_group);
-
-	return -EINVAL;
-}
-#endif
 
 /** @} */

--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -27,13 +27,14 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
+#if defined(CONFIG_CLOCK_CONTROL_NRF) || defined(__DOXYGEN__)
 
 #include <hal/nrf_clock.h>
 
 /** @brief Clocks handled by the CLOCK peripheral.
  *
  * Used as the @c sys argument to the clock_control API.
+ * @kconfig_dep{CONFIG_CLOCK_CONTROL_NRF}
  */
 enum clock_control_nrf_type {
 	CLOCK_CONTROL_NRF_TYPE_HFCLK, /**< High-frequency clock. */
@@ -54,6 +55,9 @@ enum clock_control_nrf_type {
  *
  * These can be used with the clock control API instead of casting the
  * @ref clock_control_nrf_type enumerators directly, to improve readability.
+ *
+ * @kconfig_dep{CONFIG_CLOCK_CONTROL_NRF}
+ *
  * @{
  */
 /** @brief High-frequency clock subsystem. */
@@ -73,7 +77,9 @@ enum clock_control_nrf_type {
 	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLKAUDIO)
 /** @} */
 
-/** @brief LF clock start modes. */
+/** @brief LF clock start modes
+ * @kconfig_dep{CONFIG_CLOCK_CONTROL_NRF}
+ */
 enum nrf_lfclk_start_mode {
 	CLOCK_CONTROL_NRF_LF_START_NOWAIT,    /**< Return without waiting for the clock. */
 	CLOCK_CONTROL_NRF_LF_START_AVAILABLE, /**< Wait until the clock is available. */

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -795,69 +795,83 @@ __subsystem struct counter_driver_api {
 	 * @driver_ops_optional @copybrief counter_get_frequency
 	 */
 	counter_api_get_freq get_freq;
-#ifdef CONFIG_COUNTER_64BITS_FREQ
+#if defined(CONFIG_COUNTER_64BITS_FREQ) || defined(__DOXYGEN__)
 	/**
 	 * @driver_ops_optional @copybrief counter_get_frequency_64
+	 * @kconfig_dep{CONFIG_COUNTER_64BITS_FREQ}
 	 */
 	counter_api_get_freq_64 get_freq_64;
 #endif /* CONFIG_COUNTER_64BITS_FREQ */
-#ifdef CONFIG_COUNTER_64BITS_TICKS
+#if defined(CONFIG_COUNTER_64BITS_TICKS) || defined(__DOXYGEN__)
 	/**
 	 * @driver_ops_optional @copybrief counter_get_value_64
+	 * @kconfig_dep{CONFIG_COUNTER_64BITS_TICKS}
 	 */
 	counter_api_get_value_64 get_value_64;
 	/**
 	 * @driver_ops_optional @copybrief counter_set_value_64
+	 * @kconfig_dep{CONFIG_COUNTER_64BITS_TICKS}
 	 */
 	counter_api_set_value_64 set_value_64;
 	/**
 	 * @driver_ops_mandatory @copybrief counter_set_channel_alarm_64
+	 * @kconfig_dep{CONFIG_COUNTER_64BITS_TICKS}
 	 */
 	counter_api_set_alarm_64 set_alarm_64;
 	/**
 	 * @driver_ops_optional @copybrief counter_get_guard_period_64
+	 * @kconfig_dep{CONFIG_COUNTER_64BITS_TICKS}
 	 */
 	counter_api_get_guard_period_64 get_guard_period_64;
 	/**
 	 * @driver_ops_optional @copybrief counter_set_guard_period_64
+	 * @kconfig_dep{CONFIG_COUNTER_64BITS_TICKS}
 	 */
 	counter_api_set_guard_period_64 set_guard_period_64;
 	/**
 	 * @driver_ops_mandatory @copybrief counter_get_top_value_64
+	 * @kconfig_dep{CONFIG_COUNTER_64BITS_TICKS}
 	 */
 	counter_api_get_top_value_64 get_top_value_64;
 	/**
 	 * @driver_ops_mandatory @copybrief counter_set_top_value_64
+	 * @kconfig_dep{CONFIG_COUNTER_64BITS_TICKS}
 	 */
 	counter_api_set_top_value_64 set_top_value_64;
 #endif /* CONFIG_COUNTER_64BITS_TICKS */
-#ifdef CONFIG_COUNTER_CAPTURE
+#if defined(CONFIG_COUNTER_CAPTURE) || defined(__DOXYGEN__)
 	/**
 	 * @driver_ops_mandatory @copybrief counter_capture_configure
+	 * @kconfig_dep{CONFIG_COUNTER_CAPTURE}
 	 */
 	counter_api_capture_configure capture_configure;
-#ifdef CONFIG_COUNTER_64BITS_TICKS
+#if defined(CONFIG_COUNTER_64BITS_TICKS) || defined(__DOXYGEN__)
 	/**
 	 * @driver_ops_mandatory @copybrief counter_capture_configure_64
+	 * @kconfig_dep{CONFIG_COUNTER_CAPTURE,CONFIG_COUNTER_64BITS_TICKS}
 	 */
 	counter_api_capture_configure_64 capture_configure_64;
 #endif /* CONFIG_COUNTER_64BITS_TICKS */
 	/**
 	 * @driver_ops_mandatory @copybrief counter_enable_capture
+	 * @kconfig_dep{CONFIG_COUNTER_CAPTURE}
 	 */
 	counter_api_enable_capture enable_capture;
 	/**
 	 * @driver_ops_mandatory @copybrief counter_disable_capture
+	 * @kconfig_dep{CONFIG_COUNTER_CAPTURE}
 	 */
 	counter_api_disable_capture disable_capture;
 #endif /* CONFIG_COUNTER_CAPTURE */
 #if defined(CONFIG_COUNTER_CALIBRATION) || defined(__DOXYGEN__)
 	/**
 	 * @driver_ops_optional @copybrief counter_set_calibration
+	 * @kconfig_dep{CONFIG_COUNTER_CALIBRATION}
 	 */
 	counter_api_set_calibration set_calibration;
 	/**
 	 * @driver_ops_optional @copybrief counter_get_calibration
+	 * @kconfig_dep{CONFIG_COUNTER_CALIBRATION}
 	 */
 	counter_api_get_calibration get_calibration;
 #endif /* CONFIG_COUNTER_CALIBRATION */
@@ -1760,6 +1774,8 @@ static inline int z_impl_counter_set_value_64(const struct device *dev, uint64_t
  * continuous) for a capture channel, and registers the callback that
  * delivers captured tick values.
  *
+ * @kconfig_dep{CONFIG_COUNTER_CAPTURE}
+ *
  * @note The mapping from a capture channel to its input source (e.g. a
  *       physical pad or an internal signal) is vendor-specific and
  *       is not part of this API. On most SoCs the channel-to-pin
@@ -1800,6 +1816,8 @@ static inline int counter_capture_configure(const struct device *dev, uint8_t ch
 /**
  * @brief Configure a capture channel and register its callback using a DT spec.
  *
+ * @kconfig_dep{CONFIG_COUNTER_CAPTURE}
+ *
  * @param spec Pointer to the counter capture DT spec.
  * @param cb Callback function reference.
  * @param user_data Argument passed to the callback function.
@@ -1820,6 +1838,8 @@ static inline int counter_capture_configure_dt(const struct counter_capture_dt_s
  * Configures the edge polarity and capture mode (single-shot vs
  * continuous) for a capture channel, and registers the 64b callback that
  * delivers captured tick values.
+ *
+ * @kconfig_dep{CONFIG_COUNTER_CAPTURE,CONFIG_COUNTER_64BITS_TICKS}
  *
  * @note The mapping from a capture channel to its input source (e.g. a
  *       physical pad or an internal signal) is vendor-specific and
@@ -1861,6 +1881,8 @@ static inline int counter_capture_configure_64(const struct device *dev, uint8_t
 /**
  * @brief Configure a capture channel and register its 64-bit callback using a DT spec.
  *
+ * @kconfig_dep{CONFIG_COUNTER_CAPTURE,CONFIG_COUNTER_64BITS_TICKS}
+ *
  * @param spec Pointer to the counter capture DT spec.
  * @param cb Callback function reference.
  * @param user_data Argument passed to the callback function.
@@ -1878,6 +1900,8 @@ static inline int counter_capture_configure_64_dt(const struct counter_capture_d
 
 /**
  * @brief Enable capture on a channel.
+ *
+ * @kconfig_dep{CONFIG_COUNTER_CAPTURE}
  *
  * @param dev  Pointer to the device structure for the driver instance.
  * @param chan_id Channel ID.
@@ -1905,6 +1929,8 @@ static inline int z_impl_counter_enable_capture(const struct device *dev, uint8_
 /**
  * @brief Enable capture on a channel using a DT spec.
  *
+ * @kconfig_dep{CONFIG_COUNTER_CAPTURE}
+ *
  * @param spec Pointer to the counter capture DT spec.
  *
  * @retval 0 If successful.
@@ -1917,6 +1943,8 @@ static inline int counter_enable_capture_dt(const struct counter_capture_dt_spec
 
 /**
  * @brief Disable capture on a channel.
+ *
+ * @kconfig_dep{CONFIG_COUNTER_CAPTURE}
  *
  * @param dev  Pointer to the device structure for the driver instance.
  * @param chan_id Channel ID.
@@ -1944,6 +1972,8 @@ static inline int z_impl_counter_disable_capture(const struct device *dev, uint8
 /**
  * @brief Disable capture on a channel using a DT spec.
  *
+ * @kconfig_dep{CONFIG_COUNTER_CAPTURE}
+ *
  * @param spec Pointer to the counter capture DT spec.
  *
  * @retval 0 If successful.
@@ -1963,6 +1993,8 @@ static inline int counter_disable_capture_dt(const struct counter_capture_dt_spe
  *
  * Calibration is specified in parts per billion (ppb). A positive value
  * speeds up the counter, a negative value slows it down.
+ *
+ * @kconfig_dep{CONFIG_COUNTER_CALIBRATION}
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param calibration Calibration value in ppb.
@@ -1986,6 +2018,8 @@ static inline int z_impl_counter_set_calibration(const struct device *dev, int32
 
 /**
  * @brief Get counter calibration value.
+ *
+ * @kconfig_dep{CONFIG_COUNTER_CALIBRATION}
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param calibration Pointer to store the calibration value in ppb.

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -63,16 +63,16 @@ typedef int (*emul_espi_api_set_vw)(const struct emul *target, enum espi_vwire_s
 typedef int (*emul_espi_api_get_vw)(const struct emul *target, enum espi_vwire_signal vw,
 				    uint8_t *level);
 
-#ifdef CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION
 /**
  * Get the ACPI shared memory address owned by the emulator.
+ *
+ * @kconfig_dep{CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION}
  *
  * @param target The device Emulator instance
  *
  * @return The address of the memory.
  */
 typedef uintptr_t (*emul_espi_api_get_acpi_shm)(const struct emul *target);
-#endif
 
 /**
  * Find an emulator present on a eSPI bus
@@ -101,9 +101,14 @@ typedef int (*emul_trigger_event)(const struct device *dev, struct espi_event *e
 
 /** Definition of the eSPI device emulator API */
 struct emul_espi_device_api {
+	/** eSPI virtual wires set handler */
 	emul_espi_api_set_vw set_vw;
+	/** eSPI virtual wires get handler */
 	emul_espi_api_get_vw get_vw;
-#ifdef CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION
+#if defined(CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION) || defined(__DOXYGEN__)
+	/** ACPI shared memory address get handler
+	 * @kconfig_dep{CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION}
+	 */
 	emul_espi_api_get_acpi_shm get_acpi_shm;
 #endif
 };
@@ -168,16 +173,16 @@ int emul_espi_host_send_vw(const struct device *espi_dev, enum espi_vwire_signal
  */
 int emul_espi_host_port80_write(const struct device *espi_dev, uint32_t data);
 
-#ifdef CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION
 /**
  * Get the host device's ACPI shared memory start address. The size of the region is
  * CONFIG_EMUL_ESPI_HOST_ACPI_SHM_REGION_SIZE.
+ *
+ * @kconfig_dep{CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION}
  *
  * @param espi_dev eSPI emulation controller device.
  * @return Address of the start of the ACPI shared memory.
  */
 uintptr_t emul_espi_host_get_acpi_shm(const struct device *espi_dev);
-#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -592,6 +592,7 @@ __subsystem struct i3c_driver_api {
 	 * Controller only API.
 	 *
 	 * @see i3c_recover_bus()
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 *
@@ -605,6 +606,7 @@ __subsystem struct i3c_driver_api {
 	 * Optional API.
 	 *
 	 * @see i3c_attach_i3c_device()
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param target Pointer to target device descriptor.
@@ -620,6 +622,7 @@ __subsystem struct i3c_driver_api {
 	 * Optional API.
 	 *
 	 * @see i3c_reattach_i3c_device()
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param target Pointer to target device descriptor.
@@ -637,6 +640,7 @@ __subsystem struct i3c_driver_api {
 	 * Optional API.
 	 *
 	 * @see i3c_detach_i3c_device()
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param target Pointer to target device descriptor.
@@ -652,6 +656,7 @@ __subsystem struct i3c_driver_api {
 	 * Optional API.
 	 *
 	 * @see i3c_attach_i2c_device()
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param target Pointer to target device descriptor.
@@ -667,6 +672,7 @@ __subsystem struct i3c_driver_api {
 	 * Optional API.
 	 *
 	 * @see i3c_detach_i2c_device()
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param target Pointer to target device descriptor.
@@ -682,6 +688,7 @@ __subsystem struct i3c_driver_api {
 	 * Controller only API.
 	 *
 	 * @see i3c_do_daa()
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 *
@@ -695,6 +702,7 @@ __subsystem struct i3c_driver_api {
 	 * Controller only API.
 	 *
 	 * @see i3c_do_ccc()
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param payload Pointer to the CCC payload.
@@ -708,6 +716,7 @@ __subsystem struct i3c_driver_api {
 	 * Transfer messages in I3C mode.
 	 *
 	 * @see i3c_transfer()
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param target Pointer to target device descriptor.
@@ -727,6 +736,7 @@ __subsystem struct i3c_driver_api {
 	 * Controller only API.
 	 *
 	 * @see i3c_do_ccc_cb()
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER,CONFIG_I3C_CALLBACK}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param payload Pointer to the CCC payload.
@@ -744,6 +754,7 @@ __subsystem struct i3c_driver_api {
 	 * Transfer async messages in I3C mode with a callback.
 	 *
 	 * @see i3c_transfer_cb()
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER,CONFIG_I3C_CALLBACK}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param target Pointer to target device descriptor.
@@ -760,7 +771,7 @@ __subsystem struct i3c_driver_api {
 			    uint8_t num_msgs,
 			    i3c_callback_t cb,
 			    void *userdata);
-#endif
+#endif /* CONFIG_I3C_CALLBACK */
 	/**
 	 * Find a registered I3C target device.
 	 *
@@ -768,6 +779,8 @@ __subsystem struct i3c_driver_api {
 	 *
 	 * This returns the I3C device descriptor of the I3C device
 	 * matching the incoming @p id.
+	 *
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param id Pointer to I3C device ID.
@@ -777,7 +790,7 @@ __subsystem struct i3c_driver_api {
 	struct i3c_device_desc *(*i3c_device_find)(const struct device *dev,
 						   const struct i3c_device_id *id);
 #endif /* CONFIG_I3C_CONTROLLER */
-#ifdef CONFIG_I3C_USE_IBI
+#if defined(CONFIG_I3C_USE_IBI) || defined(__DOXYGEN__)
 #if defined(CONFIG_I3C_TARGET) || defined(__DOXYGEN__)
 	/**
 	 * Raise In-Band Interrupt (IBI).
@@ -785,6 +798,7 @@ __subsystem struct i3c_driver_api {
 	 * Target device only API.
 	 *
 	 * @see i3c_ibi_request()
+	 * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_TARGET}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param request Pointer to IBI request struct.
@@ -799,6 +813,7 @@ __subsystem struct i3c_driver_api {
 	 * ACK or NACK IBI HJ Requests
 	 *
 	 * @see ibi_hj_response()
+	 * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param ack True to ack, False to nack
@@ -812,6 +827,7 @@ __subsystem struct i3c_driver_api {
 	 * ACK or NACK IBI Controller Role Requests
 	 *
 	 * @see i3c_ibi_crr_response()
+	 * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param target Pointer to target device descriptor.
 	 * @param ack True to ack, False to nack
@@ -827,6 +843,7 @@ __subsystem struct i3c_driver_api {
 	 * Controller only API.
 	 *
 	 * @see i3c_ibi_enable()
+	 * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param target Pointer to target device descriptor.
@@ -842,6 +859,7 @@ __subsystem struct i3c_driver_api {
 	 * Controller only API.
 	 *
 	 * @see i3c_ibi_disable()
+	 * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
 	 *
 	 * @param dev Pointer to controller device driver instance.
 	 * @param target Pointer to target device descriptor.
@@ -862,6 +880,7 @@ __subsystem struct i3c_driver_api {
 	 * Target device only API.
 	 *
 	 * @see i3c_target_register()
+	 * @kconfig_dep{CONFIG_I3C_TARGET}
 	 *
 	 * @param dev Pointer to the controller device driver instance.
 	 * @param cfg I3C target device configuration
@@ -880,6 +899,7 @@ __subsystem struct i3c_driver_api {
 	 * Target device only API.
 	 *
 	 * @see i3c_target_unregister()
+	 * @kconfig_dep{CONFIG_I3C_TARGET}
 	 *
 	 * @param dev Pointer to the controller device driver instance.
 	 * @param cfg I3C target device configuration
@@ -897,6 +917,7 @@ __subsystem struct i3c_driver_api {
 	 * Target device only API.
 	 *
 	 * @see i3c_target_tx_write()
+	 * @kconfig_dep{CONFIG_I3C_TARGET}
 	 *
 	 * @param dev Pointer to the controller device driver instance.
 	 * @param buf Pointer to the buffer
@@ -917,6 +938,7 @@ __subsystem struct i3c_driver_api {
 	 * Target device only API.
 	 *
 	 * @see i3c_target_controller_handoff()
+	 * @kconfig_dep{CONFIG_I3C_TARGET}
 	 *
 	 * @param dev Pointer to the controller device driver instance.
 	 * @param accept True to ACK controller handoffs, False to NACK.
@@ -931,6 +953,7 @@ __subsystem struct i3c_driver_api {
 	 * RTIO
 	 *
 	 * @see i3c_iodev_submit()
+	 * @kconfig_dep{CONFIG_I3C_RTIO}
 	 *
 	 * @param dev Pointer to the controller device driver instance.
 	 * @param iodev_sqe Pointer to the
@@ -1304,20 +1327,23 @@ struct i3c_driver_data {
 	/** Controller Configuration */
 	struct i3c_config_controller ctrl_config;
 #if defined(CONFIG_I3C_CONTROLLER) || defined(__DOXYGEN__)
-	/** Attached I3C/I2C devices and addresses */
+	/** Attached I3C/I2C devices and addresses. @kconfig_dep{CONFIG_I3C_CONTROLLER} */
 	struct i3c_dev_attached_list attached_dev;
 #if defined(CONFIG_I3C_TARGET) || defined(__DOXYGEN__)
-	/** Received DEFTGTS Pointer */
+	/** Received DEFTGTS Pointer. @kconfig_dep{CONFIG_I3C_TARGET} */
 	struct i3c_ccc_deftgts *deftgts;
 
-	/** DEFTGTS refreshed */
+	/** DEFTGTS refreshed. @kconfig_dep{CONFIG_I3C_TARGET} */
 	bool deftgts_refreshed;
 #endif /* CONFIG_I3C_TARGET */
 #endif /* CONFIG_I3C_CONTROLLER */
 };
+
 #if defined(CONFIG_I3C_CONTROLLER) || defined(__DOXYGEN__)
 /**
  * @brief iterate over all I3C devices present on the bus
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param bus: the I3C bus device pointer
  * @param desc: an I3C device descriptor pointer updated to point to the current slot
@@ -1330,6 +1356,8 @@ struct i3c_driver_data {
 /**
  * @brief iterate over all I2C devices present on the bus
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param bus: the I3C bus device pointer
  * @param desc: an I2C device descriptor pointer updated to point to the current slot
  *	 at each iteration of the loop
@@ -1340,6 +1368,8 @@ struct i3c_driver_data {
 
 /**
  * @brief safely iterate over all I3C devices present on the bus
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param bus: the I3C bus device pointer
  * @param desc: an I3C device descriptor pointer updated to point to the current slot
@@ -1353,6 +1383,8 @@ struct i3c_driver_data {
 
 /**
  * @brief safely iterate over all I2C devices present on the bus
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param bus: the I3C bus device pointer
  * @param desc: an I2C device descriptor pointer updated to point to the current slot
@@ -1370,6 +1402,8 @@ struct i3c_driver_data {
  * This finds the I3C target device descriptor in the device list
  * matching the provided ID struct (@p id).
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param dev_list Pointer to the device list struct.
  * @param id Pointer to I3C device ID struct.
  *
@@ -1384,6 +1418,8 @@ struct i3c_device_desc *i3c_dev_list_find(const struct i3c_dev_list *dev_list,
  *
  * This finds the I3C target device descriptor in the attached
  * device list matching the dynamic address (@p addr)
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param dev Pointer to controller device driver instance.
  * @param addr Dynamic address to be matched.
@@ -1400,6 +1436,8 @@ struct i3c_device_desc *i3c_dev_list_i3c_addr_find(const struct device *dev,
  * This finds the I3C target device descriptor in the attached
  * device list matching the static address (@p addr)
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param dev Pointer to controller device driver instance.
  * @param addr static address to be matched.
  *
@@ -1414,6 +1452,8 @@ struct i3c_device_desc *i3c_dev_list_i3c_static_addr_find(const struct device *d
  *
  * This finds the I2C target device descriptor in the attached
  * device list matching the address (@p addr)
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param dev Pointer to controller device driver instance.
  * @param addr Address to be matched.
@@ -1456,6 +1496,8 @@ struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct device *dev,
  * assigned already (that i3c_device_desc::dynamic_addr is not
  * zero). This is mainly used during the initial DAA.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param[in] addr_slots Pointer to address slots struct.
  * @param[in] dev_list Pointer to the device list struct.
  * @param[in] pid Provisioned ID of device to be assigned address.
@@ -1482,6 +1524,7 @@ int i3c_dev_list_daa_addr_helper(struct i3c_addr_slots *addr_slots,
 				 struct i3c_device_desc **target,
 				 uint8_t *addr);
 #endif /* CONFIG_I3C_CONTROLLER */
+
 /**
  * @brief Configure the I3C hardware.
  *
@@ -1506,6 +1549,7 @@ static inline int i3c_configure(const struct device *dev,
 
 	return api->configure(dev, type, config);
 }
+
 #if defined(CONFIG_I3C_CONTROLLER) || defined(__DOXYGEN__)
 /**
  * @brief Set the controller device configuration for an I3C device.
@@ -1513,6 +1557,8 @@ static inline int i3c_configure(const struct device *dev,
  * This function applies the configuration parameters specific to an
  * I3C controller device. It is a type-safe wrapper around @ref i3c_configure
  * that ensures the correct structure type is passed.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param dev Pointer to the I3C controller device instance.
  * @param config Pointer to a @ref i3c_config_controller structure
@@ -1528,6 +1574,7 @@ static inline int i3c_configure_controller(const struct device *dev,
 	return i3c_configure(dev, I3C_CONFIG_CONTROLLER, config);
 }
 #endif /* CONFIG_I3C_CONTROLLER */
+
 #if defined(CONFIG_I3C_TARGET) || defined(__DOXYGEN__)
 /**
  * @brief Set the target device configuration for an I3C device.
@@ -1535,6 +1582,8 @@ static inline int i3c_configure_controller(const struct device *dev,
  * This function applies the configuration parameters specific to an
  * I3C target device. It is a type-safe wrapper around @ref i3c_configure
  * that ensures the correct structure type is passed.
+ *
+ * @kconfig_dep{CONFIG_I3C_TARGET}
  *
  * @param dev Pointer to the I3C controller device instance.
  * @param config Pointer to a @ref i3c_config_target structure
@@ -1550,6 +1599,7 @@ static inline int i3c_configure_target(const struct device *dev,
 	return i3c_configure(dev, I3C_CONFIG_TARGET, config);
 }
 #endif /* CONFIG_I3C_TARGET */
+
 /**
  * @brief Get configuration of the I3C hardware.
  *
@@ -1581,6 +1631,7 @@ static inline int i3c_config_get(const struct device *dev,
 
 	return api->config_get(dev, type, config);
 }
+
 #if defined(CONFIG_I3C_CONTROLLER) || defined(__DOXYGEN__)
 /**
  * @brief Get the controller device configuration for an I3C device.
@@ -1588,6 +1639,8 @@ static inline int i3c_config_get(const struct device *dev,
  * This function gets the configuration parameters specific to an
  * I3C controller device. It is a type-safe wrapper around @ref i3c_config_get
  * that ensures the correct structure type is passed.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param[in] dev Pointer to the I3C controller device instance.
  * @param[out] config Pointer to a @ref i3c_config_controller structure
@@ -1603,6 +1656,7 @@ static inline int i3c_config_get_controller(const struct device *dev,
 	return i3c_config_get(dev, I3C_CONFIG_CONTROLLER, config);
 }
 #endif /* CONFIG_I3C_CONTROLLER */
+
 #if defined(CONFIG_I3C_TARGET) || defined(__DOXYGEN__)
 /**
  * @brief Get the target device configuration for an I3C device.
@@ -1610,6 +1664,8 @@ static inline int i3c_config_get_controller(const struct device *dev,
  * This function gets the configuration parameters specific to an
  * I3C target device. It is a type-safe wrapper around @ref i3c_config_get
  * that ensures the correct structure type is passed.
+ *
+ * @kconfig_dep{CONFIG_I3C_TARGET}
  *
  * @param[in] dev Pointer to the I3C controller device instance.
  * @param[out] config Pointer to a @ref i3c_config_target structure
@@ -1625,11 +1681,14 @@ static inline int i3c_config_get_target(const struct device *dev,
 	return i3c_config_get(dev, I3C_CONFIG_TARGET, config);
 }
 #endif /* CONFIG_I3C_TARGET */
+
 #if defined(CONFIG_I3C_CONTROLLER) || defined(__DOXYGEN__)
 /**
  * @brief Attempt bus recovery on the I3C bus.
  *
  * This routine asks the controller to attempt bus recovery.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @retval 0 on success.
  * @retval -EBUSY Bus recovery fails.
@@ -1654,6 +1713,8 @@ static inline int i3c_recover_bus(const struct device *dev)
  * typically called before a SETDASA or ENTDAA to reserve
  * the addresses. This will also call the optional api to
  * update any registers within the driver if implemented.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @warning
  * Use cases involving multiple writers to the i3c/i2c devices must prevent
@@ -1680,6 +1741,8 @@ int i3c_attach_i3c_device(struct i3c_device_desc *target);
  * optional api to update any registers within the driver
  * if implemented.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @warning
  * Use cases involving multiple writers to the i3c/i2c devices must prevent
  * concurrent write operations, either by preventing all writers from
@@ -1703,6 +1766,8 @@ int i3c_reattach_i3c_device(struct i3c_device_desc *target, uint8_t old_dyn_addr
  * This will also call the optional api to update any registers
  * within the driver if implemented.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @warning
  * Use cases involving multiple writers to the i3c/i2c devices must prevent
  * concurrent write operations, either by preventing all writers from
@@ -1720,6 +1785,8 @@ int i3c_detach_i3c_device(struct i3c_device_desc *target);
  *
  * Checks whether @p target is present in the controller's attached device
  * list.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param target Pointer to the target device descriptor
  *
@@ -1745,6 +1812,8 @@ static inline bool i3c_is_i3c_device_attached(struct i3c_device_desc *target)
  * also call the optional api to update any registers within
  * the driver if implemented.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @warning
  * Use cases involving multiple writers to the i3c/i2c devices must prevent
  * concurrent write operations, either by preventing all writers from
@@ -1764,6 +1833,8 @@ int i3c_attach_i2c_device(struct i3c_i2c_device_desc *target);
  * called to remove an I2C device and to free up the address
  * that it used. This will also call the optional api to
  * update any registers within the driver if implemented.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @warning
  * Use cases involving multiple writers to the i3c/i2c devices must prevent
@@ -1807,6 +1878,8 @@ static inline bool i3c_is_i2c_device_attached(struct i3c_i2c_device_desc *target
  * where the controller belongs. Only the active controller of the bus
  * should do this.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @note For controller driver implementation, the controller should perform
  * SETDASA to allow static addresses to be the dynamic addresses before
  * actually doing ENTDAA.
@@ -1836,6 +1909,8 @@ static inline int i3c_do_daa(const struct device *dev)
 
 /**
  * @brief Send CCC to the bus.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param dev Pointer to the device structure for the controller driver
  *            instance.
@@ -1871,6 +1946,8 @@ static inline int z_impl_i3c_do_ccc(const struct device *dev,
  *
  * @see i3c_do_ccc()
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER,CONFIG_I3C_CALLBACK}
+ *
  * @param dev Pointer to the device structure for the controller driver
  *            instance.
  * @param payload Pointer to the structure describing the CCC payload.
@@ -1902,7 +1979,7 @@ static inline int z_impl_i3c_do_ccc_cb(const struct device *dev,
 
 	return api->do_ccc_cb(dev, payload, cb, userdata);
 }
-#endif
+#endif /* CONFIG_I3C_CALLBACK */
 
 /**
  * @addtogroup i3c_transfer_api
@@ -1918,6 +1995,8 @@ static inline int z_impl_i3c_do_ccc_cb(const struct device *dev,
  *
  * The array of message @p msgs must not be `NULL`.  The number of
  * message @p num_msgs may be zero, in which case no transfer occurs.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @note Not all scatter/gather transactions can be supported by all
  * drivers.  As an example, a gather write (multiple consecutive
@@ -1954,6 +2033,8 @@ static inline int z_impl_i3c_transfer(struct i3c_device_desc *target,
  *
  * The array of message @p msgs must not be `NULL`.  The number of
  * message @p num_msgs may be zero, in which case no transfer occurs.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER,CONFIG_I3C_CALLBACK}
  *
  * @note Not all scatter/gather transactions can be supported by all
  * drivers.  As an example, a gather write (multiple consecutive
@@ -1993,7 +2074,7 @@ static inline int z_impl_i3c_transfer_cb(struct i3c_device_desc *target,
 
 	return api->i3c_xfers_cb(target->bus, target, msgs, num_msgs, cb, userdata);
 }
-#endif
+#endif /* CONFIG_I3C_CALLBACK */
 
 /** @} */
 
@@ -2004,6 +2085,8 @@ static inline int z_impl_i3c_transfer_cb(struct i3c_device_desc *target,
  *
  * This returns the I3C device descriptor of the I3C device
  * matching the incoming @p id.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param dev Pointer to controller device driver instance.
  * @param id Pointer to I3C device ID.
@@ -2024,6 +2107,7 @@ struct i3c_device_desc *i3c_device_find(const struct device *dev,
 	return api->i3c_device_find(dev, id);
 }
 #endif /* CONFIG_I3C_CONTROLLER */
+
 #if defined(CONFIG_I3C_USE_IBI) || defined(__DOXYGEN__)
 /**
  * @addtogroup i3c_ibi
@@ -2036,6 +2120,8 @@ struct i3c_device_desc *i3c_device_find(const struct device *dev,
  *
  * This tells the controller to Acknowledge or Not Acknowledge
  * In-Band Interrupt Hot-Join Requests.
+ *
+ * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
  *
  * @param dev Pointer to controller device driver instance.
  * @param ack True to ack, False to nack
@@ -2061,6 +2147,8 @@ static inline int i3c_ibi_hj_response(const struct device *dev,
  * This tells the controller to Acknowledge or Not Acknowledge
  * In-Band Interrupt Controller Role Requests from a specific target.
  *
+ * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
+ *
  * @param target Pointer to target device descriptor.
  * @param ack True to ack, False to nack
  *
@@ -2080,11 +2168,14 @@ static inline int i3c_ibi_crr_response(struct i3c_device_desc *target,
 	return api->ibi_crr_response(target, ack);
 }
 #endif /* CONFIG_I3C_CONTROLLER */
+
 #if defined(CONFIG_I3C_TARGET) || defined(__DOXYGEN__)
 /**
  * @brief Raise an In-Band Interrupt (IBI).
  *
  * This raises an In-Band Interrupt (IBI) to the active controller.
+ *
+ * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
  *
  * @param dev Pointer to controller device driver instance.
  * @param request Pointer to the IBI request struct.
@@ -2104,12 +2195,15 @@ static inline int i3c_ibi_raise(const struct device *dev,
 	return api->ibi_raise(dev, request);
 }
 #endif /* CONFIG_I3C_TARGET */
+
 #if defined(CONFIG_I3C_CONTROLLER) || defined(__DOXYGEN__)
 /**
  * @brief Enable IBI of a target device.
  *
  * This enables IBI of a target device where the IBI has already been
  * request.
+ *
+ * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
  *
  * @param target I3C target device descriptor.
  *
@@ -2136,6 +2230,8 @@ static inline int i3c_ibi_enable(struct i3c_device_desc *target)
  * This disables IBI of a target device where the IBI has already been
  * request.
  *
+ * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
+ *
  * @param target I3C target device descriptor.
  *
  * @retval 0 on success.
@@ -2154,6 +2250,7 @@ static inline int i3c_ibi_disable(struct i3c_device_desc *target)
 }
 #endif /* CONFIG_I3C_CONTROLLER */
 #endif /* CONFIG_I3C_USE_IBI */
+
 /**
  * @brief Check if target's IBI has payload.
  *
@@ -2206,6 +2303,7 @@ static inline int i3c_device_is_controller_capable(struct i3c_device_desc *targe
 }
 
 /** @} */
+
 #if defined(CONFIG_I3C_CONTROLLER) || defined(__DOXYGEN__)
 /**
  * @addtogroup i3c_transfer_api
@@ -2216,6 +2314,8 @@ static inline int i3c_device_is_controller_capable(struct i3c_device_desc *targe
  * @brief Write a set amount of data to an I3C target device.
  *
  * This routine writes a set amount of data synchronously.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param target I3C target device descriptor.
  * @param buf Memory pool from which the data is transferred.
@@ -2243,6 +2343,8 @@ static inline int i3c_write(struct i3c_device_desc *target,
  * @brief Read a set amount of data from an I3C target device.
  *
  * This routine reads a set amount of data synchronously.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param target I3C target device descriptor.
  * @param buf Memory pool that stores the retrieved data.
@@ -2272,6 +2374,8 @@ static inline int i3c_read(struct i3c_device_desc *target,
  * This supports the common operation "this is what I want", "now give
  * it to me" transaction pair through a combined write-then-read bus
  * transaction.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param target I3C target device descriptor.
  * @param write_buf Pointer to the data to be written
@@ -2312,6 +2416,8 @@ static inline int i3c_write_read(struct i3c_device_desc *target,
  *
  * Instances of this may be replaced by i3c_write_read().
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param target I3C target device descriptor,
  * @param start_addr Internal address from which the data is being read.
  * @param buf Memory pool that stores the retrieved data.
@@ -2336,6 +2442,8 @@ static inline int i3c_burst_read(struct i3c_device_desc *target,
  *
  * This routine writes multiple bytes to an internal address of an
  * I3C target device synchronously.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @warning The combined write synthesized by this API may not be
  * supported on all I3C devices.  Uses of this API may be made more
@@ -2379,6 +2487,8 @@ static inline int i3c_burst_write(struct i3c_device_desc *target,
  * This routine reads the value of an 8-bit internal register of an I3C target
  * device synchronously.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param target I3C target device descriptor.
  * @param reg_addr Address of the internal register being read.
  * @param value Memory pool that stores the retrieved register value.
@@ -2400,6 +2510,8 @@ static inline int i3c_reg_read_byte(struct i3c_device_desc *target,
  *
  * This routine writes a value to an 8-bit internal register of an I3C target
  * device synchronously.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @note This function internally combines the register and value into
  * a single bus transaction.
@@ -2425,6 +2537,8 @@ static inline int i3c_reg_write_byte(struct i3c_device_desc *target,
  *
  * This routine updates the value of a set of bits from an 8-bit internal
  * register of an I3C target device synchronously.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @note If the calculated new register value matches the value that
  * was read this function will not generate a write operation.
@@ -2477,6 +2591,8 @@ static inline int i3c_reg_update_byte(struct i3c_device_desc *target,
  * D: 08 09 0a 0b 0c 0d       |......
  * @endcode
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param name Name of this dump, displayed at the top.
  * @param msgs Array of messages to dump.
  * @param num_msgs Number of messages to dump.
@@ -2489,6 +2605,8 @@ void i3c_dump_msgs(const char *name, const struct i3c_msg *msgs,
 
 /**
  * @brief Generic helper function to perform bus initialization.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param dev Pointer to controller device driver instance.
  * @param i3c_dev_list Pointer to I3C device list.
@@ -2517,6 +2635,8 @@ int i3c_bus_init(const struct device *dev,
  * This only updates the field(s) in device descriptor
  * only if CCC operations succeed.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param[in,out] target I3C target device descriptor.
  *
  * @retval 0 on success.
@@ -2537,6 +2657,8 @@ int i3c_device_basic_info_get(struct i3c_device_desc *target);
  *
  * This only updates the field(s) in device descriptor
  * only if CCC operations succeed.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @note This should only be called after i3c_device_basic_info_get() or
  * if the BCR was already obtained through ENTDAA, DEFTGTS, or GETBCR.
@@ -2564,6 +2686,8 @@ int i3c_device_adv_info_get(struct i3c_device_desc *target);
  * This only updates the field(s) in device descriptor
  * only if CCC operations succeed.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param[in,out] target I3C target device descriptor.
  *
  * @retval 0 on success.
@@ -2587,6 +2711,8 @@ static inline int i3c_device_info_get(struct i3c_device_desc *target)
  * Reads the LVR of all I2C devices and returns the I3C bus
  * mode.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param dev_list Pointer to the device list struct.
  *
  * @return @see enum i3c_bus_mode
@@ -2599,6 +2725,8 @@ enum i3c_bus_mode i3c_bus_mode(const struct i3c_dev_list *dev_list);
  * This reads the BCR from the device descriptor struct of all targets
  * to determine whether a device is a secondary controller.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param dev Pointer to controller device driver instance.
  *
  * @return True if the bus has a secondary controller, false otherwise.
@@ -2609,6 +2737,8 @@ bool i3c_bus_has_sec_controller(const struct device *dev);
  * @brief Reset all devices on the bus and clear their dynamic addresses.
  *
  * Sends the RSTDAA (Reset Dynamic Address Assignment) CCC to all devices on the bus.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param dev Pointer to the controller device driver instance.
  *
@@ -2621,6 +2751,8 @@ int i3c_bus_rstdaa_all(const struct device *dev);
  * @brief Assign a dynamic address to a device using its static address.
  *
  * Sends the SETDASA (Set Dynamic Address from Static Address) CCC to the target device.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param desc Pointer to the target device descriptor.
  * @param dynamic_addr The dynamic address to assign to the device.
@@ -2636,6 +2768,8 @@ int i3c_bus_setdasa(struct i3c_device_desc *desc, uint8_t dynamic_addr);
  *
  * Sends the SETNEWDA (Set New Dynamic Address) CCC to the target device.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param desc Pointer to the target device descriptor.
  * @param dynamic_addr The new dynamic address to assign to the device.
  *
@@ -2650,6 +2784,8 @@ int i3c_bus_setnewda(struct i3c_device_desc *desc, uint8_t dynamic_addr);
  *
  * Sends the SETAASA (Set All Addresses to Static Address) CCC to all devices on the bus.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param dev Pointer to the controller device driver instance.
  *
  * @retval 0 on success.
@@ -2661,6 +2797,8 @@ int i3c_bus_setaasa(const struct device *dev);
  * @brief Retrieve the Bus Characteristics Register (BCR) of a device.
  *
  * Sends the GETBCR CCC to the target device and updates its descriptor.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param desc Pointer to the target device descriptor.
  *
@@ -2674,6 +2812,8 @@ int i3c_bus_getbcr(struct i3c_device_desc *desc);
  *
  * Sends the GETDCR CCC to the target device and updates its descriptor.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param desc Pointer to the target device descriptor.
  *
  * @retval 0 on success.
@@ -2685,6 +2825,8 @@ int i3c_bus_getdcr(struct i3c_device_desc *desc);
  * @brief Retrieve the Provisional ID (PID) of a device.
  *
  * Sends the GETPID CCC to the target device and updates its descriptor.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param desc Pointer to the target device descriptor.
  *
@@ -2698,6 +2840,8 @@ int i3c_bus_getpid(struct i3c_device_desc *desc);
  *
  * Sends the GETMRL CCC to the target device and updates its descriptor.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param desc Pointer to the target device descriptor.
  *
  * @retval 0 on success.
@@ -2710,6 +2854,8 @@ int i3c_bus_getmrl(struct i3c_device_desc *desc);
  *
  * Sends the GETMWL CCC to the target device and updates its descriptor.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param desc Pointer to the target device descriptor.
  *
  * @retval 0 on success.
@@ -2721,6 +2867,8 @@ int i3c_bus_getmwl(struct i3c_device_desc *desc);
  * @brief Set the Maximum Read Length (MRL) for a device.
  *
  * Sends the SETMRL CCC to the target device.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param desc Pointer to the target device descriptor.
  * @param mrl Maximum read length to set.
@@ -2736,6 +2884,8 @@ int i3c_bus_setmrl(struct i3c_device_desc *desc, uint16_t mrl, uint8_t ibi_len);
  *
  * Sends the SETMWL CCC to the target device.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param desc Pointer to the target device descriptor.
  * @param mwl Maximum write length to set.
  *
@@ -2748,6 +2898,8 @@ int i3c_bus_setmwl(struct i3c_device_desc *desc, uint16_t mwl);
  * @brief Set the Maximum Read Length (MRL) for all devices on the bus.
  *
  * Sends the SETMRL CCC to all devices on the bus.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param dev Pointer to the controller device driver instance.
  * @param mrl Maximum read length to set.
@@ -2764,6 +2916,8 @@ int i3c_bus_setmrl_all(const struct device *dev, uint16_t mrl, uint8_t ibi_len, 
  *
  * Sends the SETMWL CCC to all devices on the bus.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param dev Pointer to the controller device driver instance.
  * @param mwl Maximum write length to set.
  *
@@ -2778,6 +2932,8 @@ int i3c_bus_setmwl_all(const struct device *dev, uint16_t mwl);
  *
  * Sends the GETACCCR CCC to the target device and verifies the response.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER,CONFIG_I3C_TARGET}
+ *
  * @param desc Pointer to the target device descriptor.
  *
  * @retval 0 on success.
@@ -2789,6 +2945,8 @@ int i3c_bus_getacccr(struct i3c_device_desc *desc);
  * @brief Send the CCC DEFTGTS
  *
  * This builds the payload required for DEFTGTS and transmits it out
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER,CONFIG_I3C_TARGET}
  *
  * @param dev Pointer to controller device driver instance.
  *
@@ -2804,6 +2962,8 @@ int i3c_bus_deftgts(const struct device *dev);
  *
  * Calculate the Odd Parity of a Target Address.
  *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
+ *
  * @param p The 7b target dynamic address
  *
  * @return The odd parity bit
@@ -2815,6 +2975,8 @@ uint8_t i3c_odd_parity(uint8_t p);
  *
  * This performs the controller handoff according to 5.1.7.1 of
  * I3C v1.1.1 Specification.
+ *
+ * @kconfig_dep{CONFIG_I3C_CONTROLLER}
  *
  * @param target I3C target device descriptor.
  * @param requested True if the target requested the Handoff, False if
@@ -2838,6 +3000,8 @@ int i3c_device_controller_handoff(struct i3c_device_desc *target, bool requested
  * for i3c_device_desc. It will then obtain the standard I3C information
  * from the device.
  *
+ * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER,CONFIG_I3C_TARGET}
+ *
  * @param work pointer to the work item.
  */
 void i3c_sec_handoffed(struct k_work *work);
@@ -2852,6 +3016,8 @@ void i3c_sec_handoffed(struct k_work *work);
  *
  * This allocates memory from a mem slab for a i3c_device_desc
  *
+ * Depends on @kconfig{CONFIG_I3C_NUM_OF_DESC_MEM_SLABS} being higher than 0.
+ *
  * @return Pointer to allocated i3c_device_desc
  * @retval NULL No mem slabs available.
  */
@@ -2862,6 +3028,8 @@ struct i3c_device_desc *i3c_device_desc_alloc(void);
  *
  * This frees memory from a mem slab of a i3c_device_desc
  *
+ * Depends on @kconfig{CONFIG_I3C_NUM_OF_DESC_MEM_SLABS} being higher than 0.
+ *
  * @param desc Pointer to allocated i3c_device_desc
  */
 void i3c_device_desc_free(struct i3c_device_desc *desc);
@@ -2870,6 +3038,8 @@ void i3c_device_desc_free(struct i3c_device_desc *desc);
  * @brief Report if the i3c device descriptor was from a mem slab
  *
  * This reports if the i3c_device_desc was from a memory slab
+ *
+ * Depends on @kconfig{CONFIG_I3C_NUM_OF_DESC_MEM_SLABS} being higher than 0.
  *
  * @param desc Pointer to a i3c_device_desc
  *
@@ -2905,6 +3075,8 @@ static inline bool i3c_device_desc_in_pool(struct i3c_device_desc *desc)
  *
  * This allocates memory from a mem slab for a i3c_i2c_device_desc
  *
+ * Depends on @kconfig{CONFIG_I3C_I2C_NUM_OF_DESC_MEM_SLABS} being higher than 0.
+ *
  * @return Pointer to allocated i3c_i2c_device_desc, NULL if none
  *         available
  */
@@ -2915,6 +3087,8 @@ struct i3c_i2c_device_desc *i3c_i2c_device_desc_alloc(void);
  *
  * This frees memory from a mem slab of a i3c_i2c_device_desc
  *
+ * Depends on @kconfig{CONFIG_I3C_I2C_NUM_OF_DESC_MEM_SLABS} being higher than 0.
+ *
  * @param desc Pointer to allocated i3c_i2c_device_desc
  */
 void i3c_i2c_device_desc_free(struct i3c_i2c_device_desc *desc);
@@ -2923,6 +3097,8 @@ void i3c_i2c_device_desc_free(struct i3c_i2c_device_desc *desc);
  * @brief Report if the i3c i2c device descriptor was from a mem slab
  *
  * This reports if the i3c_i2c_device_desc was from a memory slab
+ *
+ * Depends on @kconfig{CONFIG_I3C_I2C_NUM_OF_DESC_MEM_SLABS} being higher than 0.
  *
  * @param desc Pointer to a i3c_i2c_device_desc
  *
@@ -2963,6 +3139,8 @@ struct i3c_iodev_data {
  * This implementation will schedule a blocking I3C transaction on the bus via the RTIO work
  * queue. It is only used if the I3C driver did not implement the iodev_submit function.
  *
+ * @kconfig_dep{CONFIG_I3C_RTIO}
+ *
  * @param dev Pointer to the device structure for an I3C controller driver.
  * @param iodev_sqe Prepared submissions queue entry connected to an iodev
  *                  defined by I3C_DT_IODEV_DEFINE.
@@ -2971,6 +3149,8 @@ void i3c_iodev_submit_fallback(const struct device *dev, struct rtio_iodev_sqe *
 
 /**
  * @brief Submit request(s) to an I3C device with RTIO
+ *
+ * @kconfig_dep{CONFIG_I3C_RTIO}
  *
  * @param iodev_sqe Prepared submissions queue entry connected to an iodev
  *                  defined by I3C_DT_IODEV_DEFINE.
@@ -2996,6 +3176,8 @@ extern const struct rtio_iodev_api i3c_iodev_api;
  * These do not need to be shared globally but doing so
  * will save a small amount of memory.
  *
+ * @kconfig_dep{CONFIG_I3C_RTIO}
+ *
  * @param name Symbolic name of the iodev to define
  * @param node_id Devicetree node identifier
  */
@@ -3012,6 +3194,8 @@ extern const struct rtio_iodev_api i3c_iodev_api;
  * This is equivalent to
  * <tt>I3C_DT_IODEV_DEFINE(name, DT_DRV_INST(inst))</tt>.
  *
+ * @kconfig_dep{CONFIG_I3C_RTIO}
+ *
  * @param name Symbolic name of the iodev to define
  * @param inst Devicetree instance number
  */
@@ -3020,6 +3204,8 @@ extern const struct rtio_iodev_api i3c_iodev_api;
 
 /**
  * @brief Copy the i3c_msgs into a set of RTIO requests
+ *
+ * @kconfig_dep{CONFIG_I3C_RTIO}
  *
  * @param r RTIO context
  * @param iodev RTIO IODev to target for the submissions

--- a/include/zephyr/drivers/i3c/target_device.h
+++ b/include/zephyr/drivers/i3c/target_device.h
@@ -190,12 +190,14 @@ struct i3c_target_callbacks {
 	int (*read_processed_cb)(struct i3c_target_config *config,
 				 uint8_t *val);
 
-#ifdef CONFIG_I3C_TARGET_BUFFER_MODE
+#if defined(CONFIG_I3C_TARGET_BUFFER_MODE) || defined(__DOXYGEN__)
 	/** @brief Function called when a write to the device is completed.
 	 *
 	 * This function is invoked by the controller when it completes
 	 * reception of data from the source buffer to the destination
 	 * buffer in an ongoing write operation to the device.
+	 *
+	 * @kconfig_dep{CONFIG_I3C_TARGET_BUFFER_MODE}
 	 *
 	 * @param config Configuration structure associated with the
 	 *               device to which the operation is addressed.
@@ -217,6 +219,8 @@ struct i3c_target_callbacks {
 	 * An error return shall cause the controller to ignore bus operations until
 	 * a new start condition is received.
 	 *
+	 * @kconfig_dep{CONFIG_I3C_TARGET_BUFFER_MODE}
+	 *
 	 * @param config the configuration structure associated with the
 	 * device to which the operation is addressed.
 	 *
@@ -232,7 +236,8 @@ struct i3c_target_callbacks {
 	 */
 	int (*buf_read_requested_cb)(struct i3c_target_config *config, uint8_t **ptr, uint32_t *len,
 				     uint8_t *hdr_mode);
-#endif
+#endif /* CONFIG_I3C_TARGET_BUFFER_MODE */
+
 	/**
 	 * @brief Function called when a stop condition is observed after a
 	 * start condition addressed to a particular device.

--- a/include/zephyr/drivers/interrupt_controller/gic.h
+++ b/include/zephyr/drivers/interrupt_controller/gic.h
@@ -126,7 +126,7 @@
  */
 #define GICD_ISACTIVERnE (GIC_DIST_BASE + 0x1A00)
 
-#if CONFIG_GIC_VER >= 2
+#if (CONFIG_GIC_VER >= 2) || defined(__DOXYGEN__)
 /*
  * 0x380  Interrupt Clear-Active Registers
  * v2/v3	GICD_ICACTIVERn
@@ -138,7 +138,7 @@
  * v3.1		GICD_ICACTIVERnE
  */
 #define GICD_ICACTIVERnE (GIC_DIST_BASE + 0x1C00)
-#endif
+#endif /* CONFIG_GIC_VER >= 2 */
 
 /*
  * 0x400  Interrupt Priority Registers
@@ -184,7 +184,7 @@
  * GIC CPU Interface
  */
 
-#if CONFIG_GIC_VER <= 2
+#if (CONFIG_GIC_VER <= 2) || defined(__DOXYGEN__)
 
 /*
  * 0x0000  CPU Interface Control Register
@@ -401,7 +401,7 @@ unsigned int arm_gic_get_active(void);
  */
 void arm_gic_eoi(unsigned int irq);
 
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) || defined(__DOXYGEN__)
 /**
  * @brief Initialize GIC of secondary cores
  */

--- a/include/zephyr/drivers/interrupt_controller/gic.h
+++ b/include/zephyr/drivers/interrupt_controller/gic.h
@@ -27,158 +27,188 @@
  * GIC Distributor Interface
  */
 
-/*
- * 0x000  Distributor Control Register
+/**
+ * @brief GIC Distributor Control Register
+ *
  * v1		ICDDCR
  * v2/v3	GICD_CTLR
  */
 #define GICD_CTLR (GIC_DIST_BASE + 0x0)
 
-/*
- * 0x004  Interrupt Controller Type Register
+/**
+ * @brief GIC Distributor Interrupt Controller Type Register
+ *
  * v1		ICDICTR
  * v2/v3	GICD_TYPER
  */
 #define GICD_TYPER (GIC_DIST_BASE + 0x4)
 
-/*
- * 0x008  Distributor Implementer Identification Register
+/**
+ * @brief GIC Distributor Implementer Identification Register
+ *
  * v1		ICDIIDR
  * v2/v3	GICD_IIDR
  */
 #define GICD_IIDR (GIC_DIST_BASE + 0x8)
 
-/*
- * 0x080  Interrupt Group Registers
+/**
+ * @brief GIC Distributor Interrupt Group Registers
+ *
  * v1		ICDISRn
  * v2/v3	GICD_IGROUPRn
  */
 #define GICD_IGROUPRn (GIC_DIST_BASE + 0x80)
 
-/*
- * 0x1000  Interrupt Group Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Group Registers for Extended SPI Range
+ *
  * v3.1		GICD_IGROUPRnE
  */
 #define GICD_IGROUPRnE (GIC_DIST_BASE + 0x1000)
 
-/*
- * 0x100  Interrupt Set-Enable Registers
+/**
+ * @brief GIC Distributor Interrupt Set-Enable Registers
+ *
  * v1		ICDISERn
  * v2/v3	GICD_ISENABLERn
  */
 #define GICD_ISENABLERn (GIC_DIST_BASE + 0x100)
 
-/*
- * 0x1200  Interrupt Set-Enable Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Set-Enable Registers for Extended SPI Range
+ *
  * v3.1		GICD_ISENABLERnE
  */
 #define GICD_ISENABLERnE (GIC_DIST_BASE + 0x1200)
 
-/*
- * 0x180  Interrupt Clear-Enable Registers
+/**
+ * @brief GIC Distributor Interrupt Clear-Enable Registers
+ *
  * v1		ICDICERn
  * v2/v3	GICD_ICENABLERn
  */
 #define GICD_ICENABLERn (GIC_DIST_BASE + 0x180)
 
-/*
- * 0x1400  Interrupt Clear-Enable Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Clear-Enable Registers for Extended SPI Range
+ *
  * v3.1		GICD_ICENABLERnE
  */
 #define GICD_ICENABLERnE (GIC_DIST_BASE + 0x1400)
 
-/*
- * 0x200  Interrupt Set-Pending Registers
+/**
+ * @brief GIC Distributor Interrupt Set-Pending Registers
+ *
  * v1		ICDISPRn
  * v2/v3	GICD_ISPENDRn
  */
 #define GICD_ISPENDRn (GIC_DIST_BASE + 0x200)
 
-/*
- * 1600  Interrupt Set-Pending Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Set-Pending Registers for Extended SPI Range
+ *
  * v3.1		GICD_ISPENDRnE
  */
 #define GICD_ISPENDRnE (GIC_DIST_BASE + 0x1600)
 
-/*
- * 0x280  Interrupt Clear-Pending Registers
+/**
+ * @brief GIC Distributor Interrupt Clear-Pending Registers
+ *
  * v1		ICDICPRn
  * v2/v3	GICD_ICPENDRn
  */
 #define GICD_ICPENDRn (GIC_DIST_BASE + 0x280)
 
-/*
- * 0x1800  Interrupt Clear-Pending Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Clear-Pending Registers for Extended SPI Range
+ *
  * v3.1		GICD_ICPENDRnE
  */
 #define GICD_ICPENDRnE (GIC_DIST_BASE + 0x1800)
 
-/*
- * 0x300  Interrupt Set-Active Registers
+/**
+ * @brief GIC Distributor Interrupt Set-Active Registers
+ *
  * v1		ICDABRn
  * v2/v3	GICD_ISACTIVERn
  */
 #define GICD_ISACTIVERn (GIC_DIST_BASE + 0x300)
 
-/*
- * 0x1A00  Interrupt Set-Active Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Set-Active Registers for Extended SPI Range
+ *
  * v3.1		GICD_ISACTIVERnE
  */
 #define GICD_ISACTIVERnE (GIC_DIST_BASE + 0x1A00)
 
 #if (CONFIG_GIC_VER >= 2) || defined(__DOXYGEN__)
-/*
- * 0x380  Interrupt Clear-Active Registers
+/**
+ * @brief GIC Distributor Interrupt Clear-Active Registers
+ *
  * v2/v3	GICD_ICACTIVERn
  */
 #define GICD_ICACTIVERn (GIC_DIST_BASE + 0x380)
 
-/*
- * 0x1C00  Interrupt Clear-Active Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Clear-Active Registers for Extended SPI Range
+ *
  * v3.1		GICD_ICACTIVERnE
  */
 #define GICD_ICACTIVERnE (GIC_DIST_BASE + 0x1C00)
 #endif /* CONFIG_GIC_VER >= 2 */
 
-/*
- * 0x400  Interrupt Priority Registers
+/**
+ * @brief GIC Distributor Interrupt Priority Registers
+ *
  * v1		ICDIPRn
  * v2/v3	GICD_IPRIORITYRn
  */
 #define GICD_IPRIORITYRn (GIC_DIST_BASE + 0x400)
 
-/*
- * 0x2000  Interrupt Priority Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Priority Registers for Extended SPI Range
+ *
  * v3.1		GICD_IPRIORITYRnE
  */
 #define GICD_IPRIORITYRnE (GIC_DIST_BASE + 0x2000)
 
-/*
- * 0x800  Interrupt Processor Targets Registers
+/**
+ * @brief GIC Distributor Interrupt Processor Targets Registers
+ *
  * v1		ICDIPTRn
  * v2/v3	GICD_ITARGETSRn
  */
 #define GICD_ITARGETSRn (GIC_DIST_BASE + 0x800)
 
-/*
- * 0xC00  Interrupt Configuration Registers
+/**
+ * @brief GIC Distributor Interrupt Configuration Registers
+ *
  * v1		ICDICRn
  * v2/v3	GICD_ICFGRn
  */
 #define GICD_ICFGRn (GIC_DIST_BASE + 0xc00)
 
-/*
- * 0x3000  Interrupt Configuration Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Configuration Registers for Extended SPI Range
+ *
  * v3.1		GICD_ICFGRnE
  */
 #define GICD_ICFGRnE (GIC_DIST_BASE + 0x3000)
 
-/*
- * 0xF00  Software Generated Interrupt Register
+/**
+ * @brief GIC Distributor Software Generated Interrupt Register
+ *
  * v1		ICDSGIR
  * v2/v3	GICD_SGIR
  */
 #define GICD_SGIR (GIC_DIST_BASE + 0xf00)
+
+/**
+ * @brief Disable Security (DS) bit in @ref GICD_CTLR
+ *
+ * v3/v3.1	See ARM GIC architecture spec, GICD_CTLR
+ */
+#define GICD_CTLR_DS BIT(6)
 
 /*
  * GIC CPU Interface
@@ -186,44 +216,51 @@
 
 #if (CONFIG_GIC_VER <= 2) || defined(__DOXYGEN__)
 
-/*
- * 0x0000  CPU Interface Control Register
+/**
+ * @brief GIC CPU Interface Control Register
+ *
  * v1		ICCICR
- * v2/v3	GICC_CTLR
+ * v2		GICC_CTLR
  */
 #define GICC_CTLR (GIC_CPU_BASE + 0x0)
 
-/*
- * 0x0004  Interrupt Priority Mask Register
+/**
+ * @brief GIC CPU Interface Interrupt Priority Mask Register
+ *
  * v1		ICCPMR
- * v2/v3	GICC_PMR
+ * v2		GICC_PMR
  */
 #define GICC_PMR (GIC_CPU_BASE + 0x4)
 
-/*
- * 0x0008  Binary Point Register
+/**
+ * @brief GIC CPU Interface Binary Point Register
+ *
  * v1		ICCBPR
- * v2/v3	GICC_BPR
+ * v2		GICC_BPR
  */
 #define GICC_BPR (GIC_CPU_BASE + 0x8)
 
-/*
- * 0x000C  Interrupt Acknowledge Register
+/**
+ * @brief GIC CPU Interface Interrupt Acknowledge Register
+ *
  * v1		ICCIAR
- * v2/v3	GICC_IAR
+ * v2		GICC_IAR
  */
 #define GICC_IAR (GIC_CPU_BASE + 0xc)
 
-/*
- * 0x0010  End of Interrupt Register
+/**
+ * @brief GIC CPU Interface End of Interrupt Register
+ *
  * v1		ICCEOIR
- * v2/v3	GICC_EOIR
+ * v2		GICC_EOIR
  */
 #define GICC_EOIR (GIC_CPU_BASE + 0x10)
 
 /*
  * Helper Constants
  */
+
+/** @cond INTERNAL_HIDDEN */
 
 /* GICC_CTLR */
 #define GICC_CTLR_ENABLEGRP0 BIT(0)
@@ -258,13 +295,11 @@
 
 #define GICD_SGIR_SGIINTID(x) (x)
 
+/** @endcond  */
+
 #endif /* CONFIG_GIC_VER <= 2 */
 
-/**
- * 0x000  GICD_CTLR — DS (Disable Security), bit 6
- * v3/v3.1	See ARM GIC architecture spec, GICD_CTLR
- */
-#define GICD_CTLR_DS BIT(6)
+/** @cond INTERNAL_HIDDEN */
 
 /* GICD_ICFGR */
 #define GICD_ICFGR_MASK BIT_MASK(2)
@@ -279,17 +314,27 @@
 /* GICD_TYPER.IDbits */
 #define GICD_TYPER_IDBITS(typer) ((((typer) >> 19) & 0x1f) + 1)
 
+/** @endcond  */
+
 /*
  * Common Helper Constants
  */
+
+/** Base ID of SGI interrupts */
 #define GIC_SGI_INT_BASE 0
+
+/** Base ID of PPI interrupts */
 #define GIC_PPI_INT_BASE 16
 
 #define GIC_IS_SGI(intid) (((intid) >= GIC_SGI_INT_BASE) && ((intid) < GIC_PPI_INT_BASE))
 
+/** Base ID of SPI interrupts */
 #define GIC_SPI_INT_BASE 32
 
+/** Max ID of SPI interrupts */
 #define GIC_SPI_MAX_INTID 1019
+
+/** @cond INTERNAL_HIDDEN */
 
 #define GIC_IS_SPI(intid) (((intid) >= GIC_SPI_INT_BASE) && ((intid) <= GIC_SPI_MAX_INTID))
 
@@ -299,13 +344,17 @@
 
 #define GIC_NUM_PRI_PER_REG 4
 
-/* GIC idle priority : value '0xff' will allow all interrupts */
+/** @endcond  */
+
+/** GIC idle priority : value '0xff' will allow all interrupts */
 #define GIC_IDLE_PRIO 0xff
 
-/* Priority levels 0:255 */
+/** Priority levels 0:255 */
 #define GIC_PRI_MASK 0xff
 
-/*
+/**
+ * @brief Default priority initializer helper macro
+ *
  * '0xa0'is used to initialize each interrupt default priority.
  * This is an arbitrary value in current context.
  * Any value '0x80' to '0xff' will work for both NS and S state.
@@ -314,7 +363,7 @@
  */
 #define GIC_INT_DEF_PRI_X4 0xa0a0a0a0
 
-/* GIC special interrupt id */
+/** GIC special interrupt id */
 #define GIC_INTID_SPURIOUS 1023
 
 /**

--- a/include/zephyr/drivers/misc/flexram/nxp_flexram.h
+++ b/include/zephyr/drivers/misc/flexram/nxp_flexram.h
@@ -10,6 +10,8 @@
 #include <zephyr/devicetree.h>
 #include <soc.h>
 
+/**  @cond INTERNAL_HIDDEN */
+
 #define FLEXRAM_DT_NODE    DT_INST(0, nxp_flexram)
 #define IOMUXC_GPR_DT_NODE DT_NODELABEL(iomuxcgpr)
 
@@ -68,11 +70,14 @@ static inline void flexram_dt_partition(void)
 }
 #endif /* FLEXRAM_RUNTIME_BANKS_USED */
 
-#ifdef CONFIG_NXP_FLEXRAM_MAGIC_ADDR_API
+/** @endcond */
+
 /** @brief Sets magic address for OCRAM
  *
  * Magic address allows core interrupt from FlexRAM when address
  * is accessed.
+ *
+ * @kconfig_dep{CONFIG_NXP_FLEXRAM_MAGIC_ADDR_API}
  *
  * @param ocram_addr: An address in OCRAM to set magic function on.
  * @retval 0 on success
@@ -86,6 +91,8 @@ int flexram_set_ocram_magic_addr(uint32_t ocram_addr);
  * Magic address allows core interrupt from FlexRAM when address
  * is accessed.
  *
+ * @kconfig_dep{CONFIG_NXP_FLEXRAM_MAGIC_ADDR_API}
+ *
  * @param itcm_addr: An address in ITCM to set magic function on.
  * @retval 0 on success
  * @retval -EINVAL if itcm_addr is not in ITCM
@@ -98,13 +105,13 @@ int flexram_set_itcm_magic_addr(uint32_t itcm_addr);
  * Magic address allows core interrupt from FlexRAM when address
  * is accessed.
  *
+ * @kconfig_dep{CONFIG_NXP_FLEXRAM_MAGIC_ADDR_API}
+ *
  * @param dtcm_addr: An address in DTCM to set magic function on.
  * @retval 0 on success
  * @retval -EINVAL if dtcm_addr is not in DTCM
  * @retval -ENODEV if there is no DTCM allocation in flexram
  */
 int flexram_set_dtcm_magic_addr(uint32_t dtcm_addr);
-
-#endif /* CONFIG_NXP_FLEXRAM_MAGIC_ADDR_API */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MISC_FLEXRAM_NXP_FLEXRAM_H_ */

--- a/include/zephyr/drivers/modem/hl7800.h
+++ b/include/zephyr/drivers/modem/hl7800.h
@@ -366,6 +366,8 @@ int32_t mdm_hl7800_update_apn(char *access_point_name);
 int32_t mdm_hl7800_update_rat(enum mdm_hl7800_radio_mode value);
 
 /**
+ * @brief Test if @value is a valid RAT value
+ * @param value Value to be tested
  * @retval true if RAT value is valid
  */
 bool mdm_hl7800_valid_rat(uint8_t value);
@@ -406,17 +408,17 @@ void mdm_hl7800_generate_status_events(void);
  */
 int32_t mdm_hl7800_get_local_time(struct tm *tm, int32_t *offset);
 
-#ifdef CONFIG_MODEM_HL7800_FW_UPDATE
 /**
  * @brief Update the HL7800 via XMODEM protocol.  During the firmware update
  * no other modem functions will be available.
  *
+ * @kconfig_dep{CONFIG_MODEM_HL7800_FW_UPDATE}
+ *
  * @param file_path Absolute path of the update file
  *
- * @param 0 if successful
+ * @retval 0 on success, negative on failure
  */
 int32_t mdm_hl7800_update_fw(char *file_path);
-#endif
 
 /**
  * @brief Read the operator index from the modem.

--- a/include/zephyr/drivers/modem/hl78xx_apis.h
+++ b/include/zephyr/drivers/modem/hl78xx_apis.h
@@ -22,6 +22,7 @@
 #include <time.h>
 #include <zephyr/drivers/cellular.h>
 #include <zephyr/sys/util_macro.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -189,6 +190,7 @@ extern "C" {
 			.direct = false,                                                           \
 			.paused = HL78XX_MONITOR_INITIAL_PAUSED(__VA_ARGS__),                      \
 		}}
+
 /**
  * @brief Define an AT monitor to receive parsed unsolicited AT notifications directly
  * in the HL78xx modem RX workqueue context.
@@ -224,18 +226,24 @@ enum hl78xx_cell_rat_mode {
 	HL78XX_RAT_CAT_M1 = 0,
 	/** NB-IoT radio access technology */
 	HL78XX_RAT_NB1,
-#ifdef CONFIG_MODEM_HL78XX_12
-	/** GSM radio access technology (HL7812 only) */
+#if defined(CONFIG_MODEM_HL78XX_12) || defined(__DOXYGEN__)
+	/** GSM radio access technology (HL7812 only)
+	 * @kconfig_dep{CONFIG_MODEM_HL78XX_12}
+	 */
 	HL78XX_RAT_GSM,
-#ifdef CONFIG_MODEM_HL78XX_12_FW_R6
-	/** NB-IoT Non-Terrestrial Network (HL7812 FW R6+) */
+#if defined(CONFIG_MODEM_HL78XX_12_FW_R6) || defined(__DOXYGEN__)
+	/** NB-IoT Non-Terrestrial Network (HL7812 FW R6+)
+	 * @kconfig_dep{CONFIG_MODEM_HL78XX_12_FW_R6}
+	 */
 	HL78XX_RAT_NBNTN,
 #endif /* CONFIG_MODEM_HL78XX_12_FW_R6 */
 #endif /* CONFIG_MODEM_HL78XX_12 */
-#ifdef CONFIG_MODEM_HL78XX_AUTORAT
-	/** Automatic RAT selection mode */
+#if defined(CONFIG_MODEM_HL78XX_AUTORAT) || defined(__DOXYGEN__)
+	/** Automatic RAT selection mode
+	 * @kconfig_dep{CONFIG_MODEM_HL78XX_AUTORAT}
+	 */
 	HL78XX_RAT_MODE_AUTO,
-#endif
+#endif /* CONFIG_MODEM_HL78XX_AUTORAT */
 	/** No RAT mode */
 	HL78XX_RAT_MODE_NONE,
 	/** Number of valid RAT modes */
@@ -500,11 +508,11 @@ enum nmea_output_port {
 	NMEA_OUTPUT_CMUX_DLC4 = 0x08
 };
 
-#if defined(CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE) || defined(__DOXYGEN__)
 /**
  * @brief A-GNSS assistance data validity mode
  *
  * Mode value returned by AT+GNSSAD? read command or used by write command
+ * @kconfig_dep{CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE}
  */
 enum hl78xx_agnss_mode {
 	/** Data is not valid (read) / Delete data (write) */
@@ -518,6 +526,7 @@ enum hl78xx_agnss_mode {
  * or number of days before it expires (read command)
  *
  * Only these values are accepted by the AT+GNSSAD=1,\<days\> command
+ * @kconfig_dep{CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE}
  */
 enum hl78xx_agnss_days {
 	/** Request 1 day of A-GNSS assistance data */
@@ -539,6 +548,8 @@ enum hl78xx_agnss_days {
  *
  * Contains the parsed response from AT+GNSSAD? command.
  * When mode is VALID, the expiry fields indicate time remaining.
+ *
+ * @kconfig_dep{CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE}
  */
 struct hl78xx_agnss_status {
 	/** Validity mode: 0 = invalid/empty, 1 = valid */
@@ -550,14 +561,15 @@ struct hl78xx_agnss_status {
 	/** Minutes remaining before expiry (0-59), valid only when mode=1 */
 	uint8_t minutes;
 };
-#endif /* CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE */
 
-#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
-#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE) || defined(__DOXYGEN__)
+#if defined(CONFIG_MODEM_HL78XX_POWER_DOWN) || defined(__DOXYGEN__)
 /**
  * @brief Power down event types
  *
  * Types of power down events reported by the modem
+ *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE,CONFIG_MODEM_HL78XX_POWER_DOWN}
  */
 enum power_down_event {
 	/** Power down event: Modem is entering power down mode */
@@ -573,6 +585,8 @@ enum power_down_event {
  *
  * These values control how the driver handles the stage-2 shutdown work after
  * HL78XX_POWER_DOWN_UPDATE is dispatched with POWER_DOWN_EVENT_ENTER.
+ *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE,CONFIG_MODEM_HL78XX_POWER_DOWN}
  */
 enum hl78xx_power_down_response {
 	/** Proceed with shutdown as soon as the driver workqueue can run it */
@@ -582,11 +596,13 @@ enum hl78xx_power_down_response {
 };
 #endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
 
-#ifdef CONFIG_MODEM_HL78XX_EDRX
+#if defined(CONFIG_MODEM_HL78XX_EDRX) || defined(__DOXYGEN__)
 /**
  * @brief eDRX event types
  *
  * Types of eDRX events reported by the modem
+ *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE,CONFIG_MODEM_HL78XX_EDRX}
  */
 enum hl78xx_edrx_event {
 	/** Modem exited eDRX idle mode */
@@ -597,11 +613,14 @@ enum hl78xx_edrx_event {
 	HL78XX_EDRX_EVENT_IDLE_NONE,
 };
 #endif /* CONFIG_MODEM_HL78XX_EDRX */
-#ifdef CONFIG_MODEM_HL78XX_PSM
+
+#if defined(CONFIG_MODEM_HL78XX_PSM) || defined(__DOXYGEN__)
 /**
  * @brief PSM event types
  *
  * Types of Power Saving Mode events reported by the modem
+ *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE,CONFIG_MODEM_HL78XX_PSM}
  */
 enum hl78xx_psmev_event {
 	/** Modem exited PSM mode */
@@ -685,44 +704,58 @@ enum hl78xx_evt_type {
 	HL78XX_LTE_PHONE_FUNCTIONALITY_UPDATE,
 	/** Extended timezone and universal time update (+CTZEU) */
 	HL78XX_LTE_CTZEU_UPDATE,
-#ifdef CONFIG_HL78XX_GNSS
-	/** GNSS engine initialized and ready */
+#if defined(CONFIG_HL78XX_GNSS) || defined(__DOXYGEN__)
+	/** GNSS engine initialized and ready. @kconfig_dep{CONFIG_HL78XX_GNSS} */
 	HL78XX_GNSS_ENGINE_READY,
-	/** GNSS engine initialization event */
+	/** GNSS engine initialization event. @kconfig_dep{CONFIG_HL78XX_GNSS} */
 	HL78XX_GNSS_EVENT_INIT,
-	/** GNSS search started */
+	/** GNSS search started. @kconfig_dep{CONFIG_HL78XX_GNSS} */
 	HL78XX_GNSS_EVENT_START,
-	/** GNSS search stopped */
+	/** GNSS search stopped. @kconfig_dep{CONFIG_HL78XX_GNSS} */
 	HL78XX_GNSS_EVENT_STOP,
-	/** GNSS position fix obtained */
+	/** GNSS position fix obtained. @kconfig_dep{CONFIG_HL78XX_GNSS} */
 	HL78XX_GNSS_EVENT_POSITION,
-	/** GNSS start failed because LTE is active (shared RF path) */
+	/** GNSS start failed because LTE is active (shared RF path)
+	 * @kconfig_dep{CONFIG_HL78XX_GNSS}
+	 */
 	HL78XX_GNSS_EVENT_START_BLOCKED,
-	/** GNSS search timeout expired */
+	/** GNSS search timeout expired. @kconfig_dep{CONFIG_HL78XX_GNSS} */
 	HL78XX_GNSS_EVENT_SEARCH_TIMEOUT,
-	/** GNSS mode exited - modem is now in airplane mode, user can decide next step */
+	/** GNSS mode exited - modem is now in airplane mode, user can decide next step
+	 * @kconfig_dep{CONFIG_HL78XX_GNSS}
+	 */
 	HL78XX_GNSS_EVENT_MODE_EXITED,
 #endif /* CONFIG_HL78XX_GNSS */
-#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-	/** eDRX idle mode entered */
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE) || defined(__DOXYGEN__)
+#if defined(CONFIG_MODEM_HL78XX_EDRX) || defined(__DOXYGEN__)
+	/** eDRX idle mode entered
+	 * @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE,CONFIG_MODEM_HL78XX_EDRX}
+	 */
 	HL78XX_EDRX_IDLE_UPDATE,
 #endif /* CONFIG_MODEM_HL78XX_EDRX */
-#ifdef CONFIG_MODEM_HL78XX_PSM
-	/** Modem PSM event update */
+#if defined(CONFIG_MODEM_HL78XX_PSM) || defined(__DOXYGEN__)
+	/** Modem PSM event update
+	 * @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE,CONFIG_MODEM_HL78XX_PSM}
+	 */
 	HL78XX_LTE_PSMEV_UPDATE,
 #endif /* CONFIG_MODEM_HL78XX_PSM */
-#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
-	/** Modem power-down event update */
+#if defined(CONFIG_MODEM_HL78XX_POWER_DOWN) || defined(__DOXYGEN__)
+	/** Modem power-down event update
+	 * @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE,CONFIG_MODEM_HL78XX_POWER_DOWN}
+	 */
 	HL78XX_POWER_DOWN_UPDATE,
 #endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
-	/** VGPIO pin went LOW */
+	/** VGPIO pin went LOW. @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE} */
 	HL78XX_VGPIO_LOW,
-	/** VGPIO pin went HIGH */
+	/** VGPIO pin went HIGH. @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE} */
 	HL78XX_VGPIO_HIGH,
-	/** GPIO6 pin went LOW indicating sleep or power-down entry */
+	/** GPIO6 pin went LOW indicating sleep or power-down entry
+	 * @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE}
+	 */
 	HL78XX_GPIO6_LOW,
-	/** GPIO6 pin went HIGH indicating wake from sleep or power-down */
+	/** GPIO6 pin went HIGH indicating wake from sleep or power-down
+	 * @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE}
+	 */
 	HL78XX_GPIO6_HIGH,
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 	/** Cellular measurement update */
@@ -730,11 +763,13 @@ enum hl78xx_evt_type {
 	/** Event type count */
 	HL78XX_EVT_TYPE_COUNT
 };
-#ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
+
+#if defined(CONFIG_MODEM_HL78XX_AIRVANTAGE) || defined(__DOXYGEN__)
 /**
  * @brief Device Services Indications (+WDSI)
  *
  * Enum representing AirVantage Device Services Indications
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_AIRVANTAGE}
  */
 enum wdsi_indication {
 	/** Raised at startup if credentials for Bootstrap Server are present */
@@ -778,11 +813,12 @@ enum wdsi_indication {
 };
 #endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
 
-#ifdef CONFIG_HL78XX_GNSS
+#if defined(CONFIG_HL78XX_GNSS) || defined(__DOXYGEN__)
 /**
  * @brief GNSS event type
  *
  * Types of GNSS events reported by the modem
+ * @kconfig_dep{CONFIG_HL78XX_GNSS}
  */
 enum hl78xx_gnss_event_type {
 	/** GNSS engine initialization event */
@@ -794,10 +830,12 @@ enum hl78xx_gnss_event_type {
 	/** GNSS position fix event */
 	HL78XX_GNSSEV_POSITION = 3
 };
+
 /**
  * @brief GNSS event status
  *
  * Status codes for GNSS operations
+ * @kconfig_dep{CONFIG_HL78XX_GNSS}
  */
 enum hl78xx_event_status {
 	/** Operation failed */
@@ -805,10 +843,12 @@ enum hl78xx_event_status {
 	/** Operation succeeded */
 	HL78XX_STATUS_SUCCESS = 1
 };
+
 /**
  * @brief GNSS position events (eventType = 3)
  *
  * Position fix status reported by the modem
+ * @kconfig_dep{CONFIG_HL78XX_GNSS}
  */
 enum gnss_position_events {
 	/** 0 — The GNSS fix is lost or not available yet */
@@ -840,27 +880,29 @@ struct hl78xx_evt {
 		enum cellular_registration_status reg_status;
 		/** Radio access technology mode (for HL78XX_LTE_RAT_UPDATE) */
 		enum hl78xx_cell_rat_mode rat_mode;
-#ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
-		/** AirVantage device service indication */
+#if defined(CONFIG_MODEM_HL78XX_AIRVANTAGE) || defined(__DOXYGEN__)
+		/** AirVantage device service indication
+		 * @kconfig_dep{CONFIG_MODEM_HL78XX_AIRVANTAGE}
+		 */
 		enum wdsi_indication wdsi_indication;
 #endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
-#ifdef CONFIG_HL78XX_GNSS
-		/** GNSS event status */
+#if defined(CONFIG_HL78XX_GNSS) || defined(__DOXYGEN__)
+		/** GNSS event status. @kconfig_dep{CONFIG_HL78XX_GNSS} */
 		enum hl78xx_event_status event_status;
-		/** GNSS position event type */
+		/** GNSS position event type. @kconfig_dep{CONFIG_HL78XX_GNSS} */
 		enum gnss_position_events position_event;
 #endif /* CONFIG_HL78XX_GNSS */
-#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
-#ifdef CONFIG_MODEM_HL78XX_PSM
-		/* PSM event */
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE) || defined(__DOXYGEN__)
+#if defined(CONFIG_MODEM_HL78XX_PSM) || defined(__DOXYGEN__)
+		/** PSM event. @kconfig_dep{CONFIG_MODEM_HL78XX_PSM} */
 		enum hl78xx_psmev_event psm_event;
 #endif /* CONFIG_MODEM_HL78XX_PSM */
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-		/* eDRX event */
+#if defined(CONFIG_MODEM_HL78XX_EDRX) || defined(__DOXYGEN__)
+		/** eDRX event. @kconfig_dep{CONFIG_MODEM_HL78XX_EDRX} */
 		enum hl78xx_edrx_event edrx_event;
 #endif /* CONFIG_MODEM_HL78XX_EDRX */
-#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
-		/* Power-down event */
+#if defined(CONFIG_MODEM_HL78XX_POWER_DOWN) || defined(__DOXYGEN__)
+		/** Power-down event. @kconfig_dep{CONFIG_MODEM_HL78XX_POWER_DOWN} */
 		enum power_down_event power_down_event;
 #endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
@@ -1015,6 +1057,7 @@ struct hl78xx_gnss_aux_data_callback {
 		.dev = _dev,                                                                       \
 		.callback = _callback,                                                             \
 	}
+
 /**
  * @brief Register a callback structure for GNSS auxiliary data published
  *
@@ -1382,7 +1425,6 @@ int hl78xx_api_func_get_sinr_validity(const struct device *dev, bool *is_valid);
 int hl78xx_api_func_set_network_operator_format(const struct device *dev,
 						enum hl78xx_operator_format format);
 
-#ifdef CONFIG_MODEM_HL78XX_AUTORAT
 /**
  * @brief Set a new Preferred RAT List through AT+KSELACQ.
  *
@@ -1392,6 +1434,8 @@ int hl78xx_api_func_set_network_operator_format(const struct device *dev,
  * Duplicate RAT entries are allowed to bias the modem's search order. To clear
  * the PRL and disable automatic RAT switching, pass rat1/rat2/rat3 as
  * HL78XX_KSELACQ_RAT_CLEAR; the driver emits `AT+KSELACQ=0,0` for that case.
+ *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_AUTORAT}
  *
  * @param dev Cellular network device instance
  * @param kselacq_rats Raw `AT+KSELACQ` PRL entries to set
@@ -1404,12 +1448,13 @@ int hl78xx_api_func_set_prl(const struct device *dev, const struct kselacq_synta
  *
  * Retrieves the current raw `AT+KSELACQ` PRL values from the modem cache.
  *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_AUTORAT}
+ *
  * @param dev Cellular network device instance
  * @param kselacq_rats Pointer to store the current PRL entries
  * @return 0 if successful, negative errno on failure
  */
 int hl78xx_api_func_get_prl(const struct device *dev, struct kselacq_syntax *kselacq_rats);
-#endif /* CONFIG_MODEM_HL78XX_AUTORAT */
 
 /**
  * @brief Register or clear a runtime band provider for the driver.
@@ -1554,9 +1599,11 @@ static inline int hl78xx_get_sinr_validity(const struct device *dev, bool *is_va
 	return hl78xx_api_func_get_sinr_validity(dev, is_valid);
 }
 
-#ifdef CONFIG_MODEM_HL78XX_AUTORAT
+#if defined(CONFIG_MODEM_HL78XX_AUTORAT) || defined(__DOXYGEN__)
 /**
  * @brief Set a new raw `AT+KSELACQ` Preferred RAT List.
+ *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_AUTORAT}
  *
  * @param dev Pointer to the modem device instance.
  * @param prl Preferred RAT List expressed as raw `AT+KSELACQ` values.
@@ -1627,6 +1674,7 @@ static inline int hl78xx_get_phone_functionality(const struct device *dev,
 {
 	return hl78xx_api_func_get_phone_functionality(dev, functionality);
 }
+
 /**
  * @brief Send an AT command to the modem and wait for a matched response.
  *
@@ -1680,6 +1728,7 @@ static inline int hl78xx_modem_at_err(int error)
 {
 	return (error & 0xff00ffffU);
 }
+
 /**
  * @brief Convert raw RSSI value from the modem to dBm.
  *
@@ -1707,6 +1756,7 @@ static inline int hl78xx_parse_rssi(uint8_t rssi, int16_t *value)
 	*value = (int16_t)CSQ_RSSI_TO_DB(rssi);
 	return 0;
 }
+
 /**
  * @brief Convert raw RSRP value from the modem to dBm.
  *
@@ -1740,6 +1790,7 @@ static inline int hl78xx_parse_rsrp(uint8_t rsrp, int16_t *value)
 	*value = (int16_t)CESQ_RSRP_TO_DB(rsrp);
 	return 0;
 }
+
 /**
  * @brief Convert raw RSRQ value from the modem to dB.
  *
@@ -1765,6 +1816,7 @@ static inline int hl78xx_parse_rsrq(uint8_t rsrq, int16_t *value)
 	*value = (int16_t)CESQ_RSRQ_TO_DB(rsrq);
 	return 0;
 }
+
 /**
  * @brief Pause monitor.
  *
@@ -1776,6 +1828,7 @@ static inline void hl78xx_evt_monitor_pause(struct hl78xx_evt_monitor_entry *mon
 {
 	mon->flags.paused = true;
 }
+
 /**
  * @brief Resume monitor.
  *
@@ -1927,12 +1980,14 @@ enum cellular_access_technology hl78xx_rat_to_access_tech(enum hl78xx_cell_rat_m
  * @return Corresponding HL78xx RAT mode.
  */
 enum hl78xx_cell_rat_mode hl78xx_access_tech_to_rat(enum cellular_access_technology access_tech);
-#ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
+
 /**
  * @brief Start an AirVantage Device Management (DM) session
  *
  * Initiates a connection to the Sierra Wireless AirVantage server
  * for device management operations.
+ *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_AIRVANTAGE}
  *
  * @param dev Pointer to the modem device
  * @return 0 on success, negative errno on failure
@@ -1944,11 +1999,12 @@ int hl78xx_start_airvantage_dm_session(const struct device *dev);
  *
  * Terminates the active connection to the AirVantage server.
  *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_AIRVANTAGE}
+ *
  * @param dev Pointer to the modem device
  * @return 0 on success, negative errno on failure
  */
 int hl78xx_stop_airvantage_dm_session(const struct device *dev);
-#endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
 
 /**
  * @brief Drive the modem WAKE pin low.
@@ -1996,7 +2052,6 @@ int hl78xx_set_wake_pin_high(const struct device *dev);
  */
 int hl78xx_set_active_sim(const struct device *dev, enum hl78xx_sim_slot sim_slot);
 
-#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 /**
  * @brief Wake the modem from PSM sleep
  *
@@ -2014,6 +2069,8 @@ int hl78xx_set_active_sim(const struct device *dev, enum hl78xx_sim_slot sim_slo
  * Can also be used independently of GNSS to wake the modem for any
  * purpose (e.g. sending data earlier than the next PSM cycle).
  *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE}
+ *
  * @param dev Pointer to the modem device
  * @return 0 on success
  * @return -EALREADY if modem is not in sleep state
@@ -2021,18 +2078,16 @@ int hl78xx_set_active_sim(const struct device *dev, enum hl78xx_sim_slot sim_slo
  */
 int hl78xx_wakeup_modem(const struct device *dev);
 
-#ifdef CONFIG_MODEM_HL78XX_EDRX
 /**
  * @brief Get the remaining time for the modem to go in eDRX idle state
+ *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_LOW_POWER_MODE,CONFIG_MODEM_HL78XX_EDRX}
  *
  * @param dev Pointer to the modem device
  * @return Remaining time in milliseconds, or negative errno on failure
  */
 int hl78xx_edrx_get_time_to_sleep(const struct device *dev);
-#endif /* CONFIG_MODEM_HL78XX_EDRX */
-#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 
-#ifdef CONFIG_HL78XX_GNSS
 /**
  * @brief Enter GNSS mode
  *
@@ -2057,6 +2112,8 @@ int hl78xx_edrx_get_time_to_sleep(const struct device *dev);
  *
  * After entering GNSS mode, call hl78xx_queue_gnss_search() to start fix acquisition.
  *
+ * @kconfig_dep{CONFIG_HL78XX_GNSS}
+ *
  * @param dev Pointer to the modem device
  * @return 0 on success, negative errno on failure
  */
@@ -2079,6 +2136,8 @@ int hl78xx_enter_gnss_mode(const struct device *dev);
  *  * - **LOW-POWER-PSM mode**: User does not need to do anything, the modem will automatically
  * transition back to LTE registration after the kcellmeasure or socket data transmission starts.
  *
+ * @kconfig_dep{CONFIG_HL78XX_GNSS}
+ *
  * @param dev Pointer to the modem device
  * @return 0 on success, -EALREADY if not in GNSS mode, negative errno on failure
  */
@@ -2090,6 +2149,8 @@ int hl78xx_exit_gnss_mode(const struct device *dev);
  * Starts GNSS satellite search to obtain a position fix.
  * Must be called after hl78xx_enter_gnss_mode().
  *
+ * @kconfig_dep{CONFIG_HL78XX_GNSS}
+ *
  * @param dev Pointer to the GNSS device
  * @return 0 on success, negative errno on failure
  */
@@ -2097,6 +2158,8 @@ int hl78xx_queue_gnss_search(const struct device *dev);
 
 /**
  * @brief Set NMEA output port for GNSS
+ *
+ * @kconfig_dep{CONFIG_HL78XX_GNSS}
  *
  * @param dev Pointer to the GNSS device
  * @param port NMEA output port configuration
@@ -2111,6 +2174,8 @@ int hl78xx_gnss_set_nmea_output(const struct device *dev, enum nmea_output_port 
  * the moment this function is called. Setting @p timeout_ms to 0 disables the
  * active search timeout.
  *
+ * @kconfig_dep{CONFIG_HL78XX_GNSS}
+ *
  * @param dev Pointer to the GNSS device
  * @param timeout_ms Timeout in milliseconds (0 = no timeout)
  * @return 0 on success, negative errno on failure
@@ -2123,17 +2188,20 @@ int hl78xx_gnss_set_search_timeout(const struct device *dev, uint32_t timeout_ms
  * Queries the modem for the last known position using AT+GNSSLOC?
  * Result is delivered via GNSS data callback.
  *
+ * @kconfig_dep{CONFIG_HL78XX_GNSS}
+ *
  * @param dev Pointer to the GNSS device
  * @return 0 on success, -EBUSY if another script is running, other negative errno on failure
  */
 int hl78xx_gnss_get_latest_known_fix(const struct device *dev);
 
-#ifdef CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE
 /**
  * @brief Get A-GNSS assistance data status
  *
  * Queries the modem for A-GNSS assistance data validity and expiry
  * using AT+GNSSAD? command.
+ *
+ * @kconfig_dep{CONFIG_HL78XX_GNSS,CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE}
  *
  * @param dev Pointer to the GNSS device
  * @param status Pointer to structure to receive the status
@@ -2148,6 +2216,8 @@ int hl78xx_gnss_assist_data_get_status(const struct device *dev,
  * Initiates download of predicted assistance data from the network
  * using AT+GNSSAD=1,\<days\> command. Requires active network connection.
  *
+ * @kconfig_dep{CONFIG_HL78XX_GNSS,CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE}
+ *
  * @param dev Pointer to the GNSS device
  * @param days Number of days of prediction data to download.
  *             Valid values: 1, 2, 3, 7, 14, 28
@@ -2161,21 +2231,21 @@ int hl78xx_gnss_assist_data_download(const struct device *dev, enum hl78xx_agnss
  * Deletes any stored assistance data from the modem
  * using AT+GNSSAD=0 command.
  *
+ * @kconfig_dep{CONFIG_HL78XX_GNSS,CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE}
+ *
  * @param dev Pointer to the GNSS device
  * @return 0 on success, negative errno on failure
  */
 int hl78xx_gnss_assist_data_delete(const struct device *dev);
-#endif /* CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE */
 
-#endif /* CONFIG_HL78XX_GNSS */
-
-#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
 /**
  * @brief Trigger the HL78xx shutdown process after a caller-supplied delay.
  *
  * This overrides any currently pending stage-1 power-down delay. Pass
  * K_NO_WAIT to dispatch HL78XX_POWER_DOWN_UPDATE immediately, or a relative
  * delay such as K_SECONDS(5) to start the graceful shutdown flow later.
+ *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_POWER_DOWN}
  *
  * @param dev Pointer to the HL78xx modem device.
  * @param delay Delay before stage-1 power-down notification runs.
@@ -2186,6 +2256,8 @@ int hl78xx_power_down_trigger(const struct device *dev, k_timeout_t delay);
 
 /**
  * @brief Cancel a pending stage-1 HL78xx shutdown timer.
+ *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_POWER_DOWN}
  *
  * @param dev Pointer to the HL78xx modem device.
  *
@@ -2202,6 +2274,8 @@ int hl78xx_power_down_cancel(const struct device *dev);
  * the modem to proceed with physical shutdown right away, or
  * HL78XX_POWER_DOWN_RESPONSE_RESCHEDULE to extend the shutdown grace period by
  * @p timeout_s seconds from the time of this call.
+ *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_POWER_DOWN}
  *
  * @param dev Pointer to the HL78xx modem device.
  * @param response Requested handling of the pending shutdown.
@@ -2220,10 +2294,11 @@ int hl78xx_power_down_respond(const struct device *dev, enum hl78xx_power_down_r
  *
  * If no shutdown is pending this call is a no-op.
  *
+ * @kconfig_dep{CONFIG_MODEM_HL78XX_POWER_DOWN}
+ *
  * @param dev Pointer to the HL78xx modem device.
  */
 void hl78xx_power_down_confirm(const struct device *dev);
-#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/pcie/controller.h
+++ b/include/zephyr/drivers/pcie/controller.h
@@ -128,7 +128,13 @@ typedef bool (*pcie_ctrl_region_translate_t)(const struct device *dev, pcie_bdf_
 					     bool mem, bool mem64, uintptr_t bar_bus_addr,
 					     uintptr_t *bar_addr);
 
-#ifdef CONFIG_PCIE_MSI
+#if defined(CONFIG_PCIE_MSI) || defined(__DOXYGEN__)
+/**
+ * @brief Function called to configure the given PCI endpoint to generate MSIs.
+ * See pcie_ctrl_msi_device_setup() for description.
+ *
+ * @kconfig_dep{CONFIG_PCIE_MSI}
+ */
 typedef uint8_t (*pcie_ctrl_msi_device_setup_t)(const struct device *dev, unsigned int priority,
 						msi_vector_t *vectors, uint8_t n_vector);
 #endif

--- a/include/zephyr/drivers/pcie/msi.h
+++ b/include/zephyr/drivers/pcie/msi.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+/**  @cond INTERNAL_HIDDEN */
+
 #ifdef CONFIG_PCIE_CONTROLLER
 struct msi_vector_generic {
 	unsigned int irq;
@@ -57,12 +59,16 @@ struct msi_vector {
 #endif /* CONFIG_PCIE_MSI_X */
 };
 
+/** @endcond */
+
+/** Type for MSI interrupt vector */
 typedef struct msi_vector msi_vector_t;
 
-#ifdef CONFIG_PCIE_MSI_MULTI_VECTOR
 
 /**
  * @brief Allocate vector(s) for the endpoint MSI message(s)
+ *
+ * @kconfig_dep{CONFIG_PCIE_MSI_MULTI_VECTOR}
  *
  * @param bdf the target PCI endpoint
  * @param priority the MSI vectors base interrupt priority
@@ -79,6 +85,8 @@ extern uint8_t pcie_msi_vectors_allocate(pcie_bdf_t bdf,
 /**
  * @brief Connect the MSI vector to the handler
  *
+ * @kconfig_dep{CONFIG_PCIE_MSI_MULTI_VECTOR}
+ *
  * @param bdf the target PCI endpoint
  * @param vector the MSI vector to connect
  * @param routine Interrupt service routine
@@ -92,8 +100,6 @@ extern bool pcie_msi_vector_connect(pcie_bdf_t bdf,
 				    void (*routine)(const void *parameter),
 				    const void *parameter,
 				    uint32_t flags);
-
-#endif /* CONFIG_PCIE_MSI_MULTI_VECTOR */
 
 /**
  * @brief Compute the target address for an MSI posted write.
@@ -142,6 +148,8 @@ extern bool pcie_msi_enable(pcie_bdf_t bdf,
  * @return true if the endpoint support MSI/MSI-X
  */
 extern bool pcie_is_msi(pcie_bdf_t bdf);
+
+/**  @cond INTERNAL_HIDDEN */
 
 /*
  * The first word of the MSI capability is shared with the
@@ -192,6 +200,8 @@ extern bool pcie_is_msi(pcie_bdf_t bdf);
 #define PCIE_VTBL_MUA			4U /* Msg Upper Address offset */
 #define PCIE_VTBL_MD			8U /* Msg Data offset */
 #define PCIE_VTBL_VCTRL			12U /* Vector control offset */
+
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -79,8 +79,10 @@ struct pinctrl_dev_config {
 
 /** @cond INTERNAL_HIDDEN */
 
-#if !defined(CONFIG_PINCTRL_KEEP_SLEEP_STATE)
-/** Out of power management configurations, ignore "sleep" state. */
+#if !defined(CONFIG_PINCTRL_KEEP_SLEEP_STATE) || defined(__DOXYGEN__)
+/** Out of power management configurations, ignore "sleep" state.
+ * Defined only when @kconfig{CONFIG_PINCTRL_KEEP_SLEEP_STATE} is disabled.
+ */
 #define PINCTRL_SKIP_SLEEP 1
 #endif
 
@@ -176,7 +178,7 @@ struct pinctrl_dev_config {
 			     Z_PINCTRL_STATE_INIT, (,), node_id)	       \
 	};
 
-#ifdef CONFIG_PINCTRL_STORE_REG
+#if defined(CONFIG_PINCTRL_STORE_REG) || defined(__DOXYGEN__)
 /**
  * @brief Helper macro to initialize pin control config.
  *
@@ -369,6 +371,8 @@ static inline int pinctrl_apply_state(const struct pinctrl_dev_config *config,
  * The name of the defined state pins variable is the same used by @p prop. This
  * macro is expected to be used in conjunction with #PINCTRL_DT_STATE_INIT.
  *
+ * @kconfig_dep{CONFIG_PINCTRL_DYNAMIC}
+ *
  * @param node_id Node identifier containing @p prop.
  * @param prop Property within @p node_id containing state configuration.
  *
@@ -384,6 +388,8 @@ static inline int pinctrl_apply_state(const struct pinctrl_dev_config *config,
  * This macro should be used in conjunction with #PINCTRL_DT_STATE_PINS_DEFINE
  * when using dynamic pin control to define an alternative state configuration
  * stored in Devicetree.
+ *
+ * @kconfig_dep{CONFIG_PINCTRL_DYNAMIC}
  *
  * Example:
  *
@@ -427,6 +433,8 @@ static inline int pinctrl_apply_state(const struct pinctrl_dev_config *config,
  * have to be provided. For example, if @c default and @c sleep are in the
  * current list of states, it is expected that the new array of states also
  * contains both.
+ *
+ * @kconfig_dep{CONFIG_PINCTRL_DYNAMIC}
  *
  * @param config Pin control configuration.
  * @param states New states to be set.

--- a/include/zephyr/drivers/sensor/wsen_pads_2511020213301.h
+++ b/include/zephyr/drivers/sensor/wsen_pads_2511020213301.h
@@ -32,8 +32,10 @@ enum sensor_attribute_wsen_pads_2511020213301 {
 	SENSOR_ATTR_WSEN_PADS_2511020213301_REFERENCE_POINT = SENSOR_ATTR_PRIV_START,
 };
 
-#ifdef CONFIG_WSEN_PADS_2511020213301_PRESSURE_THRESHOLD
-/** @brief Pressure-threshold triggers for the WSEN-PADS-2511020213301. */
+#if defined(CONFIG_WSEN_PADS_2511020213301_PRESSURE_THRESHOLD) || defined(__DOXYGEN__)
+/** @brief Pressure-threshold triggers for the WSEN-PADS-2511020213301.
+ * @kconfig_dep{CONFIG_WSEN_PADS_2511020213301_PRESSURE_THRESHOLD}
+ */
 enum sensor_trigger_wsen_pads_2511020213301 {
 	/** Pressure rose above the upper threshold. */
 	SENSOR_TRIG_WSEN_PADS_2511020213301_THRESHOLD_UPPER = SENSOR_TRIG_PRIV_START,

--- a/include/zephyr/drivers/virtualization/ivshmem.h
+++ b/include/zephyr/drivers/virtualization/ivshmem.h
@@ -23,6 +23,8 @@
 extern "C" {
 #endif
 
+/**  @cond INTERNAL_HIDDEN */
+
 #define IVSHMEM_V2_PROTO_UNDEFINED	0x0000
 #define IVSHMEM_V2_PROTO_NET		0x0001
 
@@ -80,6 +82,8 @@ __subsystem struct ivshmem_driver_api {
 	ivshmem_enable_interrupts_f enable_interrupts;
 #endif
 };
+
+/** @endcond */
 
 /**
  * @brief Get the inter-VM shared memory
@@ -176,10 +180,11 @@ static inline int z_impl_ivshmem_register_handler(const struct device *dev,
 	return DEVICE_API_GET(ivshmem, dev)->register_handler(dev, signal, vector);
 }
 
-#ifdef CONFIG_IVSHMEM_V2
-
+#if defined(CONFIG_IVSHMEM_V2) || defined(__DOXYGEN__)
 /**
  * @brief Get the ivshmem read/write section (ivshmem-v2 only)
+ *
+ * @kconfig_dep{CONFIG_IVSHMEM_V2}
  *
  * @param dev Pointer to the device structure for the driver instance
  * @param memmap A pointer to fill in with the memory address
@@ -197,6 +202,8 @@ static inline size_t z_impl_ivshmem_get_rw_mem_section(const struct device *dev,
 
 /**
  * @brief Get the ivshmem output section for a peer (ivshmem-v2 only)
+ *
+ * @kconfig_dep{CONFIG_IVSHMEM_V2}
  *
  * @param dev Pointer to the device structure for the driver instance
  * @param peer_id The VM ID whose output memory section to get
@@ -218,6 +225,8 @@ static inline size_t z_impl_ivshmem_get_output_mem_section(const struct device *
 /**
  * @brief Get the state value of a peer (ivshmem-v2 only)
  *
+ * @kconfig_dep{CONFIG_IVSHMEM_V2}
+ *
  * @param dev Pointer to the device structure for the driver instance
  * @param peer_id The VM ID whose state to get
  *
@@ -234,6 +243,8 @@ static inline uint32_t z_impl_ivshmem_get_state(const struct device *dev,
 
 /**
  * @brief Set our state (ivshmem-v2 only)
+ *
+ * @kconfig_dep{CONFIG_IVSHMEM_V2}
  *
  * @param dev Pointer to the device structure for the driver instance
  * @param state The state value to set
@@ -252,6 +263,8 @@ static inline int z_impl_ivshmem_set_state(const struct device *dev,
 /**
  * @brief Get the maximum number of peers supported (ivshmem-v2 only)
  *
+ * @kconfig_dep{CONFIG_IVSHMEM_V2}
+ *
  * @param dev Pointer to the device structure for the driver instance
  *
  * @return the maximum number of peers supported, or 0
@@ -266,6 +279,8 @@ static inline uint32_t z_impl_ivshmem_get_max_peers(const struct device *dev)
 /**
  * @brief Get the protocol used by this ivshmem instance (ivshmem-v2 only)
  *
+ * @kconfig_dep{CONFIG_IVSHMEM_V2}
+ *
  * @param dev Pointer to the device structure for the driver instance
  *
  * @return the protocol
@@ -279,6 +294,8 @@ static inline uint16_t z_impl_ivshmem_get_protocol(const struct device *dev)
 
 /**
  * @brief Set the interrupt enablement for our VM (ivshmem-v2 only)
+ *
+ * @kconfig_dep{CONFIG_IVSHMEM_V2}
  *
  * @param dev Pointer to the device structure for the driver instance
  * @param enable True to enable interrupts, false to disable


### PR DESCRIPTION
Add `defined(__DOXYGEN__)` directives in zephyr drivers include files where there is doxygen format information that was not considered when building Zephyr documentation.

~~Also done in **include/zephyr/shell/**.~~ *(edited: Dropped, possibly addressed later)*

Also add some empty lines between definition blocks in some of the modified header files, for consistency.
    