### PR TITLE
doc: pm: describe policy constraints for ZLI paths

### DIFF
--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -179,7 +179,10 @@ zero-latency interrupt is outside the locked-resume ordering and may be
 dispatched during PM suspend/resume logic, before PM resume bookkeeping and
 SoC/device hardware restore have completed. Such an ISR must be PM-wake-safe, or
 the interrupt source must be masked or disabled while the system state does not
-allow the ISR to execute.
+allow the ISR to execute. See :ref:`device power policy constraints
+<pm-device-constraint>` for one way to keep unsafe states out of policy
+selection while a device path that can produce a zero-latency interrupt is
+active.
 
 .. important::
     Zero-latency interrupts are supported on an architecture-specific basis.

--- a/doc/services/pm/device.rst
+++ b/doc/services/pm/device.rst
@@ -675,6 +675,14 @@ After that devices can lock these state calling
            k_timer_start(&data->timer, K_MSEC(500), K_NO_WAIT);
     }
 
+The same pattern applies to device paths that can produce
+:ref:`zero-latency interrupts <zlis>`. A zero-latency ISR must not call PM APIs
+or other kernel APIs. If the ISR depends on resources that are unavailable in
+some system power states, the normal driver path that arms the interrupt source
+can hold the device power policy lock while that path is active. The driver
+should mask or disable the interrupt source before releasing the lock when the
+path is no longer active.
+
 Wakeup capability
 *****************
 


### PR DESCRIPTION
Document how device drivers can use existing PM policy constraints for paths that can produce zero-latency interrupts. A ZLI handler cannot call PM APIs, but the normal driver path can hold a device power policy lock while the interrupt-producing path is active.

Reference the PM device policy pattern from the ZLI documentation so users have a concrete mitigation for interrupt sources that are not safe in some system power states.