### PR TITLE
drivers: sensor: nxp: Add EQDC (Enhanced Quadrature Decoder) sensor driver

### DIFF
--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -126,6 +126,18 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 	}
 #endif
 
+#if defined(CONFIG_EQDC_MCUX)
+	if ((uint32_t)sub_system == MCUX_EQDC_CLK ||
+	    (uint32_t)sub_system == MCUX_EQDC0_CLK) {
+		CLOCK_EnableClock(kCLOCK_GateQDC0);
+	}
+#if (defined(FSL_FEATURE_SOC_EQDC_COUNT) && (FSL_FEATURE_SOC_EQDC_COUNT > 1))
+	if ((uint32_t)sub_system == MCUX_EQDC1_CLK) {
+		CLOCK_EnableClock(kCLOCK_GateQDC1);
+	}
+#endif /* FSL_FEATURE_SOC_EQDC_COUNT > 1 */
+#endif
+
 #if defined(CONFIG_PINCTRL_NXP_PORT)
 	switch ((uint32_t)sub_system) {
 #if defined(CONFIG_SOC_FAMILY_MCXA) || defined(CONFIG_SOC_FAMILY_MCXL)
@@ -413,6 +425,17 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 static int mcux_lpc_syscon_clock_control_off(const struct device *dev,
 					     clock_control_subsys_t sub_system)
 {
+#if defined(CONFIG_EQDC_MCUX)
+	if ((uint32_t)sub_system == MCUX_EQDC_CLK ||
+	    (uint32_t)sub_system == MCUX_EQDC0_CLK) {
+		CLOCK_DisableClock(kCLOCK_GateQDC0);
+	}
+#if (defined(FSL_FEATURE_SOC_EQDC_COUNT) && (FSL_FEATURE_SOC_EQDC_COUNT > 1))
+	if ((uint32_t)sub_system == MCUX_EQDC1_CLK) {
+		CLOCK_DisableClock(kCLOCK_GateQDC1);
+	}
+#endif /* FSL_FEATURE_SOC_EQDC_COUNT > 1 */
+#endif
 	return 0;
 }
 
@@ -916,6 +939,15 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 #if DT_HAS_COMPAT_STATUS_OKAY(nxp_slcd)
 	case MCUX_SLCD_CLK:
 		*rate = 16384U; /* Fix 16.384kHz */
+		break;
+#endif
+
+#if defined(CONFIG_EQDC_MCUX)
+	case MCUX_EQDC_CLK:
+	case MCUX_EQDC0_CLK:
+	case MCUX_EQDC1_CLK:
+		/* EQDC is clocked from the AHB/bus clock on MCXA */
+		*rate = CLOCK_GetFreq(kCLOCK_BusClk);
 		break;
 #endif
 	}

--- a/drivers/sensor/nxp/CMakeLists.txt
+++ b/drivers/sensor/nxp/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # zephyr-keep-sorted-start
+add_subdirectory_ifdef(CONFIG_EQDC_MCUX eqdc_mcux)
 add_subdirectory_ifdef(CONFIG_FXAS21002 fxas21002)
 add_subdirectory_ifdef(CONFIG_FXLS8974 fxls8974)
 add_subdirectory_ifdef(CONFIG_FXOS8700 fxos8700)

--- a/drivers/sensor/nxp/Kconfig
+++ b/drivers/sensor/nxp/Kconfig
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # zephyr-keep-sorted-start
+source "drivers/sensor/nxp/eqdc_mcux/Kconfig"
 source "drivers/sensor/nxp/fxas21002/Kconfig"
 source "drivers/sensor/nxp/fxls8974/Kconfig"
 source "drivers/sensor/nxp/fxos8700/Kconfig"

--- a/drivers/sensor/nxp/eqdc_mcux/CMakeLists.txt
+++ b/drivers/sensor/nxp/eqdc_mcux/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources_ifdef(CONFIG_EQDC_MCUX eqdc_mcux.c)

--- a/drivers/sensor/nxp/eqdc_mcux/Kconfig
+++ b/drivers/sensor/nxp/eqdc_mcux/Kconfig
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# NXP enhanced Quadrature Decoder (eQDC) configuration options
+config EQDC_MCUX
+	bool "NXP eQDC driver"
+	default y
+	depends on DT_HAS_NXP_MCUX_EQDC_ENABLED
+	select NXP_INPUTMUX
+	select PINCTRL
+	help
+	  Enable the NXP eQDC driver. The EQDC phase inputs are routed
+	  through the on-chip INPUTMUX.
+
+if EQDC_MCUX
+
+config EQDC_MCUX_TRIGGER
+	bool "EQDC trigger support"
+	help
+	  Enable trigger support for EQDC. This allows the driver to
+	  generate interrupts on events like position roll-over/under.
+
+endif # EQDC_MCUX

--- a/drivers/sensor/nxp/eqdc_mcux/eqdc_mcux.c
+++ b/drivers/sensor/nxp/eqdc_mcux/eqdc_mcux.c
@@ -1,0 +1,470 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_mcux_eqdc
+
+#include <errno.h>
+#include <stdint.h>
+#include <fsl_eqdc.h>
+#include <fsl_inputmux.h>
+#include <zephyr/drivers/sensor/eqdc_mcux.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/irq.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+LOG_MODULE_REGISTER(eqdc_mcux, CONFIG_SENSOR_LOG_LEVEL);
+
+/* One INPUTMUX route (PHASEA / PHASEB) decoded from the inputmux-connections
+ * phandle-array. The connection value is an inputmux_connection_t taken from
+ * fsl_inputmux_connections.h.
+ */
+struct eqdc_mcux_inputmux_entry {
+	INPUTMUX_Type *base;
+	uint16_t channel;
+	uint32_t connection;
+};
+
+struct eqdc_mcux_config {
+	EQDC_Type *base;
+	const struct pinctrl_dev_config *pincfg;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
+	bool reverse_direction;
+	bool single_phase_mode;
+	uint8_t count_multiplier;
+	eqdc_revolution_count_condition_t revolution_count_mode;
+	uint32_t prescaler;
+	uint8_t input_filter_period;
+	uint8_t input_filter_count;
+	void (*irq_config_func)(const struct device *dev);
+	const struct eqdc_mcux_inputmux_entry *inputmux_entries;
+	uint8_t inputmux_entries_count;
+};
+
+struct eqdc_mcux_data {
+	uint32_t clock_freq;
+	uint32_t counts_per_revolution;
+	int32_t position;
+	int16_t position_diff;
+	uint16_t position_diff_period;
+	int16_t revolution_count;
+#ifdef CONFIG_EQDC_MCUX_TRIGGER
+	sensor_trigger_handler_t trigger_handler;
+	const struct sensor_trigger *trigger;
+	struct k_work work;
+	const struct device *dev;
+#endif
+};
+
+static int eqdc_mcux_check_channel(enum sensor_channel ch)
+{
+	if (ch != SENSOR_CHAN_ALL && ch != SENSOR_CHAN_ROTATION &&
+		ch != SENSOR_CHAN_ENCODER_COUNT && ch != SENSOR_CHAN_RPM &&
+		ch != SENSOR_CHAN_ENCODER_REVOLUTIONS) {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int eqdc_mcux_attr_set(const struct device *dev, enum sensor_channel ch,
+			      enum sensor_attribute attr, const struct sensor_value *val)
+{
+	const struct eqdc_mcux_config *config = dev->config;
+	struct eqdc_mcux_data *data = dev->data;
+
+	if (eqdc_mcux_check_channel(ch) != 0) {
+		return -ENOTSUP;
+	}
+
+	if ((enum sensor_attribute_eqdc_mcux)attr != SENSOR_ATTR_EQDC_COUNTS_PER_REVOLUTION) {
+		return -ENOTSUP;
+	}
+
+	if (val->val1 < 1 || (uint32_t)val->val1 > (UINT32_MAX / config->count_multiplier)) {
+		LOG_ERR("Counts per revolution value invalid: %d", val->val1);
+		return -EINVAL;
+	}
+
+	/* Scale by the count multiplier: 4 for quadrature X4, 1 for single-phase */
+	data->counts_per_revolution = (uint32_t)val->val1 * config->count_multiplier;
+	EQDC_SetPositionModulusValue(config->base, data->counts_per_revolution - 1U);
+	EQDC_SetEqdcLdok(config->base);
+
+	return 0;
+}
+
+static int eqdc_mcux_attr_get(const struct device *dev, enum sensor_channel ch,
+			      enum sensor_attribute attr, struct sensor_value *val)
+{
+	const struct eqdc_mcux_config *config = dev->config;
+	struct eqdc_mcux_data *data = dev->data;
+
+	if (eqdc_mcux_check_channel(ch) != 0) {
+		return -ENOTSUP;
+	}
+
+	switch ((enum sensor_attribute_eqdc_mcux)attr) {
+	case SENSOR_ATTR_EQDC_COUNTS_PER_REVOLUTION:
+		val->val1 = data->counts_per_revolution / config->count_multiplier;
+		val->val2 = 0;
+		return 0;
+	case SENSOR_ATTR_EQDC_PRESCALED_FREQUENCY:
+		val->val1 = data->clock_freq / (1U << config->prescaler);
+		val->val2 = 0;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int eqdc_mcux_sample_fetch(const struct device *dev, enum sensor_channel ch)
+{
+	const struct eqdc_mcux_config *config = dev->config;
+	struct eqdc_mcux_data *data = dev->data;
+
+	if (eqdc_mcux_check_channel(ch) != 0) {
+		return -ENOTSUP;
+	}
+
+	/* Dummy read to latch the POSDH and POSDPERH hold registers */
+	(void)config->base->POSD;
+
+	data->position = (int32_t)EQDC_GetPosition(config->base);
+
+	data->position_diff = (int16_t)EQDC_GetHoldPositionDifference(config->base);
+
+	data->position_diff_period = EQDC_GetHoldPositionDifferencePeriod(config->base);
+
+	/* REV is a signed 16-bit counter: it decrements for reverse rotation
+	 * (e.g. with reverse-direction enabled), so read it as int16_t.
+	 */
+	data->revolution_count = (int16_t)EQDC_GetHoldRevolution(config->base);
+
+	LOG_DBG("Current position value: %d, position difference: %d,"
+		"position difference period: %d.", data->position, data->position_diff,
+		data->position_diff_period);
+
+	return 0;
+}
+
+static int eqdc_mcux_channel_get(const struct device *dev, enum sensor_channel ch,
+				 struct sensor_value *val)
+{
+	const struct eqdc_mcux_config *config = dev->config;
+	struct eqdc_mcux_data *data = dev->data;
+	int32_t counter_value;
+	uint32_t prescaled_freq;
+	int32_t angle;
+	uint64_t rpm_calc;
+
+	switch (ch) {
+	case SENSOR_CHAN_ROTATION:
+		/* Calculate angle in degrees */
+		if (data->counts_per_revolution > 0) {
+			counter_value = data->position % (int32_t)data->counts_per_revolution;
+			/* Normalize negative modulo result to 0-360 range */
+			if (counter_value < 0) {
+				counter_value += data->counts_per_revolution;
+			}
+			/* Calculate angle in Q26.6 fixed-point format */
+			angle = (counter_value * 23040) / data->counts_per_revolution;
+			val->val1 = angle >> 6;
+			val->val2 = (angle & 0x3F) * 15625;
+		} else {
+			val->val1 = 0;
+			val->val2 = 0;
+		}
+		break;
+	case SENSOR_CHAN_RPM:
+		/* Calculate revolutions per minute, in RPM */
+		if (data->counts_per_revolution > 0 && data->position_diff_period > 0 &&
+			data->position_diff_period != UINT16_MAX && data->position_diff != 0) {
+			/*
+			 * Convert the held position difference into RPM: the
+			 * counts moved over counts-per-revolution give revolutions,
+			 * the prescaled clock over the difference period gives the
+			 * sampling rate, and a factor of 60 converts per-second to
+			 * per-minute.
+			 */
+			prescaled_freq = data->clock_freq / (1U << config->prescaler);
+
+			/* Calculate RPM using 64-bit arithmetic to avoid overflow */
+			rpm_calc = ((uint64_t)abs(data->position_diff)) * prescaled_freq * 60;
+			rpm_calc = rpm_calc / ((uint64_t)data->position_diff_period *
+								data->counts_per_revolution);
+
+			/* Handle direction (negative position_diff means reverse) */
+			val->val1 = (data->position_diff < 0) ? -(int32_t)rpm_calc :
+				(int32_t)rpm_calc;
+			val->val2 = 0;
+		} else {
+			val->val1 = 0;
+			val->val2 = 0;
+		}
+		break;
+	case SENSOR_CHAN_ENCODER_REVOLUTIONS:
+		val->val1 = data->revolution_count;
+		val->val2 = 0;
+		break;
+	case SENSOR_CHAN_ENCODER_COUNT:
+		val->val1 = data->position;
+		val->val2 = 0;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_EQDC_MCUX_TRIGGER
+
+static void eqdc_mcux_trigger_work_handler(struct k_work *work)
+{
+	struct eqdc_mcux_data *data = CONTAINER_OF(work, struct eqdc_mcux_data, work);
+
+	if (data->trigger_handler) {
+		data->trigger_handler(data->dev, data->trigger);
+	}
+}
+
+static int eqdc_mcux_trigger_set(const struct device *dev,
+				 const struct sensor_trigger *trig,
+				 sensor_trigger_handler_t handler)
+{
+	const struct eqdc_mcux_config *config = dev->config;
+	struct eqdc_mcux_data *data = dev->data;
+	uint32_t int_mask = 0;
+
+	if (trig->type != SENSOR_TRIG_OVERFLOW) {
+		return -ENOTSUP;
+	}
+
+	if (trig->chan != SENSOR_CHAN_ENCODER_REVOLUTIONS && trig->chan != SENSOR_CHAN_ALL) {
+		return -ENOTSUP;
+	}
+
+	/* Disable interrupts while configuring */
+	EQDC_DisableInterrupts(config->base, kEQDC_AllInterruptEnable);
+
+	data->trigger_handler = handler;
+	data->trigger = trig;
+
+	if (handler) {
+		if (config->revolution_count_mode == kEQDC_RevolutionCountOnIndexPulse) {
+			int_mask = kEQDC_IndexPresetPulseInterruptEnable;
+		} else {
+			int_mask = kEQDC_PositionRollOverInterruptEnable |
+				   kEQDC_PositionRollUnderInterruptEnable;
+		}
+
+		/* Clear any pending flags */
+		EQDC_ClearStatusFlags(config->base, kEQDC_StatusAllFlags);
+
+		/* Enable interrupts */
+		EQDC_EnableInterrupts(config->base, int_mask);
+	}
+
+	return 0;
+}
+
+static void eqdc_mcux_isr(const struct device *dev)
+{
+	const struct eqdc_mcux_config *config = dev->config;
+	struct eqdc_mcux_data *data = dev->data;
+	uint32_t flags;
+
+	flags = EQDC_GetStatusFlags(config->base);
+
+	/* Clear interrupt flags */
+	EQDC_ClearStatusFlags(config->base, flags);
+
+	LOG_DBG("ISR flags: 0x%08x", flags);
+
+	if (data->trigger_handler) {
+		k_work_submit(&data->work);
+	}
+}
+
+#endif /* CONFIG_EQDC_MCUX_TRIGGER */
+
+static DEVICE_API(sensor, eqdc_mcux_api) = {
+	.attr_set = eqdc_mcux_attr_set,
+	.attr_get = eqdc_mcux_attr_get,
+	.sample_fetch = eqdc_mcux_sample_fetch,
+	.channel_get = eqdc_mcux_channel_get,
+#ifdef CONFIG_EQDC_MCUX_TRIGGER
+	.trigger_set = eqdc_mcux_trigger_set,
+#endif
+};
+
+static int eqdc_mcux_init_pins(const struct device *dev)
+{
+	const struct eqdc_mcux_config *config = dev->config;
+	int ret;
+
+	ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+	if (ret != 0 && ret != -ENOENT) {
+		return ret;
+	}
+
+	/* Route the EQDC phase inputs through INPUTMUX */
+	for (uint8_t i = 0; i < config->inputmux_entries_count; i++) {
+		const struct eqdc_mcux_inputmux_entry *entry = &config->inputmux_entries[i];
+
+		INPUTMUX_Init(entry->base);
+		INPUTMUX_AttachSignal(entry->base, entry->channel,
+				      (inputmux_connection_t)entry->connection);
+		INPUTMUX_Deinit(entry->base);
+	}
+
+	return 0;
+}
+
+static int eqdc_mcux_init(const struct device *dev)
+{
+	const struct eqdc_mcux_config *config = dev->config;
+	struct eqdc_mcux_data *data = dev->data;
+	eqdc_config_t eqdc_config;
+	int ret;
+
+	LOG_DBG("Initializing %s", dev->name);
+
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
+	ret = clock_control_on(config->clock_dev, config->clock_subsys);
+	if (ret < 0) {
+		LOG_ERR("Could not enable EQDC clock (%d)", ret);
+		return ret;
+	}
+
+	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
+				   &data->clock_freq) || data->clock_freq == 0U) {
+		LOG_ERR("Could not get clock frequency");
+		return -EINVAL;
+	}
+
+	/* Initialize pins and INPUTMUX routing */
+	ret = eqdc_mcux_init_pins(dev);
+	if (ret != 0) {
+		LOG_ERR("Failed to configure pins/INPUTMUX (%d)", ret);
+		return ret;
+	}
+
+	/* Initialize EQDC peripheral */
+	EQDC_GetDefaultConfig(&eqdc_config);
+	if (config->single_phase_mode) {
+		eqdc_config.operateMode = kEQDC_SinglePhaseDecodeOperationMode;
+		eqdc_config.countMode = kEQDC_SignedCountSingleEdge;
+	}
+	eqdc_config.positionModulusValue = data->counts_per_revolution - 1U;
+	eqdc_config.enableReverseDirection = config->reverse_direction;
+	eqdc_config.revolutionCountCondition = config->revolution_count_mode;
+	eqdc_config.prescaler = config->prescaler;
+	eqdc_config.filterSamplePeriod = config->input_filter_period;
+	eqdc_config.filterSampleCount = config->input_filter_count;
+	eqdc_config.enablePeriodMeasurement = true;
+	EQDC_Init(config->base, &eqdc_config);
+	EQDC_DoSoftwareLoadInitialPositionValue(config->base);
+
+#ifdef CONFIG_EQDC_MCUX_TRIGGER
+	data->dev = dev;
+	k_work_init(&data->work, eqdc_mcux_trigger_work_handler);
+	config->irq_config_func(dev);
+#endif
+
+	return 0;
+}
+
+#define EQDC_MCUX_INPUTMUX_ENTRY(node_id, prop, idx)					\
+	{										\
+		.base = (INPUTMUX_Type *)DT_REG_ADDR(DT_PHANDLE_BY_IDX(node_id, prop, idx)), \
+		.channel = (uint16_t)DT_PHA_BY_IDX(node_id, prop, idx, channel),	\
+		.connection = (uint32_t)DT_PHA_BY_IDX(node_id, prop, idx, connection),	\
+	}
+
+#define EQDC_MCUX_INPUTMUX_DEFINE(n)							\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, inputmux_connections),			\
+		    (static const struct eqdc_mcux_inputmux_entry			\
+			    eqdc_mcux_inputmux_entries_##n[] = {			\
+			    DT_INST_FOREACH_PROP_ELEM_SEP(n, inputmux_connections,	\
+							  EQDC_MCUX_INPUTMUX_ENTRY, (,))}; \
+		    ), ())
+
+#define EQDC_MCUX_INPUTMUX_INIT(n)							\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, inputmux_connections),			\
+		    (.inputmux_entries = eqdc_mcux_inputmux_entries_##n,		\
+		     .inputmux_entries_count = DT_INST_PROP_LEN(n, inputmux_connections),), \
+		    ())
+
+#ifdef CONFIG_EQDC_MCUX_TRIGGER
+#define EQDC_MCUX_IRQ_CONFIG(inst)						\
+	static void eqdc_mcux_irq_config_##inst(const struct device *dev)	\
+	{									\
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, index, irq),		\
+			    DT_INST_IRQ_BY_NAME(inst, index, priority),		\
+			    eqdc_mcux_isr, DEVICE_DT_INST_GET(inst), 0);	\
+		irq_enable(DT_INST_IRQ_BY_NAME(inst, index, irq));		\
+	}
+
+#define EQDC_MCUX_IRQ_CONFIG_FUNC(inst) .irq_config_func = eqdc_mcux_irq_config_##inst,
+#else
+#define EQDC_MCUX_IRQ_CONFIG(inst)
+#define EQDC_MCUX_IRQ_CONFIG_FUNC(inst)
+#endif /* CONFIG_EQDC_MCUX_TRIGGER */
+
+/* Counts scaling: quadrature decode counts 4 edges per line (X4); single-phase
+ * decode counts 1 edge per pulse. Keep this in sync with the count mode set in
+ * eqdc_mcux_init().
+ */
+#define EQDC_MCUX_MULT(inst) (DT_INST_PROP(inst, single_phase_mode) ? 1U : 4U)
+
+#define EQDC_MCUX_DEVICE_INIT(inst)						\
+										\
+	EQDC_MCUX_IRQ_CONFIG(inst)						\
+										\
+	EQDC_MCUX_INPUTMUX_DEFINE(inst)						\
+										\
+	static struct eqdc_mcux_data eqdc_mcux_data_##inst = {			\
+		.counts_per_revolution = DT_INST_PROP(inst, counts_per_revolution)	\
+					 * EQDC_MCUX_MULT(inst),		\
+	};									\
+										\
+	PINCTRL_DT_INST_DEFINE(inst);						\
+										\
+	static const struct eqdc_mcux_config eqdc_mcux_config_##inst = {	\
+		.base = (EQDC_Type *)DT_INST_REG_ADDR(inst),			\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),			\
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(inst)),		\
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(inst, name),\
+		.reverse_direction = DT_INST_PROP(inst, reverse_direction),	\
+		.single_phase_mode = DT_INST_PROP(inst, single_phase_mode),	\
+		.count_multiplier = EQDC_MCUX_MULT(inst),			\
+		.revolution_count_mode = (eqdc_revolution_count_condition_t)DT_INST_PROP(	\
+			inst, revolution_count_mode),	\
+		.prescaler = DT_INST_PROP_OR(inst, prescaler, 0),	\
+		.input_filter_period = DT_INST_PROP(inst, input_filter_period),	\
+		.input_filter_count = DT_INST_PROP(inst, input_filter_count),	\
+		EQDC_MCUX_INPUTMUX_INIT(inst)					\
+		EQDC_MCUX_IRQ_CONFIG_FUNC(inst)					\
+	};									\
+										\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,					\
+				     eqdc_mcux_init,				\
+				     NULL,					\
+				     &eqdc_mcux_data_##inst,			\
+				     &eqdc_mcux_config_##inst,			\
+				     POST_KERNEL,				\
+				     CONFIG_SENSOR_INIT_PRIORITY,		\
+				     &eqdc_mcux_api);
+
+DT_INST_FOREACH_STATUS_OKAY(EQDC_MCUX_DEVICE_INIT)

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -126,6 +126,7 @@ static const char *const sensor_channel_name[SENSOR_CHAN_COMMON_COUNT] = {
 	[SENSOR_CHAN_GRAVITY_VECTOR] = "gravity_vector",
 	[SENSOR_CHAN_GBIAS_XYZ] = "gbias_xyz",
 	[SENSOR_CHAN_ENCODER_COUNT] = "encoder_count",
+	[SENSOR_CHAN_ENCODER_REVOLUTIONS] = "encoder_revolutions",
 	[SENSOR_CHAN_ALL] = "all",
 };
 

--- a/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
@@ -137,6 +137,15 @@
 			channels = <0 1>;
 		};
 
+		eqdc0: eqdc@400a7000 {
+			compatible = "nxp,mcux-eqdc";
+			reg = <0x400a7000 0x1000>;
+			interrupts = <50 0>, <51 0>, <52 0>, <53 0>;
+			interrupt-names = "compare", "home", "watchdog", "index";
+			clocks = <&syscon MCUX_EQDC_CLK>;
+			status = "disabled";
+		};
+
 		flexpwm0: flexpwm@400a9000 {
 			compatible = "nxp,flexpwm";
 			reg = <0x400a9000 0x1000>;

--- a/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
@@ -310,6 +310,30 @@
 			};
 		};
 
+		inputmux0: inputmux@40001000 {
+			compatible = "nxp,inputmux";
+			reg = <0x40001000 0x1000>;
+			#inputmux-cells = <2>;
+		};
+
+		eqdc0: eqdc@400a7000 {
+			compatible = "nxp,mcux-eqdc";
+			reg = <0x400a7000 0x1000>;
+			interrupts = <50 0>, <51 0>, <52 0>, <53 0>;
+			interrupt-names = "compare", "home", "watchdog", "index";
+			clocks = <&syscon MCUX_EQDC0_CLK>;
+			status = "disabled";
+		};
+
+		eqdc1: eqdc@400a8000 {
+			compatible = "nxp,mcux-eqdc";
+			reg = <0x400a8000 0x1000>;
+			interrupts = <85 0>, <86 0>, <87 0>, <88 0>;
+			interrupt-names = "compare", "home", "watchdog", "index";
+			clocks = <&syscon MCUX_EQDC1_CLK>;
+			status = "disabled";
+		};
+
 		flexpwm0: flexpwm@400a9000 {
 			compatible = "nxp,flexpwm";
 			reg = <0x400a9000 0x1000>;

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -288,6 +288,30 @@
 			status = "disabled";
 		};
 
+		inputmux0: inputmux@40001000 {
+			compatible = "nxp,inputmux";
+			reg = <0x40001000 0x1000>;
+			#inputmux-cells = <2>;
+		};
+
+		eqdc0: eqdc@400a7000 {
+			compatible = "nxp,mcux-eqdc";
+			reg = <0x400a7000 0x1000>;
+			interrupts = <50 0>, <51 0>, <52 0>, <53 0>;
+			interrupt-names = "compare", "home", "watchdog", "index";
+			clocks = <&syscon MCUX_EQDC0_CLK>;
+			status = "disabled";
+		};
+
+		eqdc1: eqdc@400a8000 {
+			compatible = "nxp,mcux-eqdc";
+			reg = <0x400a8000 0x1000>;
+			interrupts = <85 0>, <86 0>, <87 0>, <88 0>;
+			interrupt-names = "compare", "home", "watchdog", "index";
+			clocks = <&syscon MCUX_EQDC1_CLK>;
+			status = "disabled";
+		};
+
 		flexpwm0: flexpwm@400a9000 {
 			compatible = "nxp,flexpwm";
 			reg = <0x400a9000 0x1000>;

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -666,6 +666,30 @@
 			status = "disabled";
 		};
 
+		inputmux0: inputmux@40001000 {
+			compatible = "nxp,inputmux";
+			reg = <0x40001000 0x1000>;
+			#inputmux-cells = <2>;
+		};
+
+		eqdc0: eqdc@400a7000 {
+			compatible = "nxp,mcux-eqdc";
+			reg = <0x400a7000 0x1000>;
+			interrupts = <50 0>, <51 0>, <52 0>, <53 0>;
+			interrupt-names = "compare", "home", "watchdog", "index";
+			clocks = <&syscon MCUX_EQDC0_CLK>;
+			status = "disabled";
+		};
+
+		eqdc1: eqdc@400a8000 {
+			compatible = "nxp,mcux-eqdc";
+			reg = <0x400a8000 0x1000>;
+			interrupts = <85 0>, <86 0>, <87 0>, <88 0>;
+			interrupt-names = "compare", "home", "watchdog", "index";
+			clocks = <&syscon MCUX_EQDC1_CLK>;
+			status = "disabled";
+		};
+
 		flexpwm0: flexpwm@400a9000 {
 			compatible = "nxp,flexpwm";
 			reg = <0x400a9000 0x1000>;

--- a/dts/bindings/sensor/nxp,mcux-eqdc.yaml
+++ b/dts/bindings/sensor/nxp,mcux-eqdc.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP MCUX Enhanced Quadrature Decoder (EQDC)
+
+compatible: "nxp,mcux-eqdc"
+
+include: [sensor-device.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  counts-per-revolution:
+    type: int
+    required: true
+    min: 1
+    description: |
+      Number of encoder counts per full revolution (360 degrees).
+      This is used to convert position to angle. The value is scaled
+      internally by the count multiplier of the active decode mode, so the
+      effective modulus is (counts-per-revolution * multiplier - 1):
+      - Quadrature X4 (default): multiplier 4
+      - single-phase-mode: multiplier 1
+
+  input-filter-count:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+    description: |
+      Input filter sample count
+      The Input Filter Sample Count represents the number of consecutive samples
+      that must agree, before the input filter accepts an input transition:
+      - A value of 0x0 represents 3 samples
+      - A value of 0x7 represents 10 samples
+      The value of the Input Filter Sample Count (FILT_CNT) affects the
+      input latency.
+
+  input-filter-period:
+    type: int
+    default: 0
+    min: 0
+    max: 255
+    description: |
+      The Input Filter Sample Period represents the sampling period
+      (in IPBus clock cycles) of the decoder input signals. Each input
+      is sampled multiple times at the rate specified by the Input Filter
+      Sample Period.
+      - If it is set to 0x0(default), then the input filter is bypassed.
+      The value of the Input Filter Sample Period (FILT_PER) affects the
+      input latency.
+
+  prescaler:
+    type: int
+    default: 0
+    min: 0
+    max: 15
+    description: |
+      The Prescaler field is used to prescale the peripheral clock that
+      is used by the LASTEDGE and POSDPER counters as well as watchdog timer
+      and Input Filter.
+      The clock is prescaled by a value of 2^PRSC. For example:
+      prescaler = 0, divide by 1
+      prescaler = 1, divide by 2
+      ...
+      prescaler = 15, divide by 32768
+
+  reverse-direction:
+    type: boolean
+    description: |
+      Selects the direction of the count and position counter initial value.
+      false: Count normally.
+      true: Count in the reverse direction.
+
+  single-phase-mode:
+    type: boolean
+    description: |
+      Bypass the quadrature decoder and use single-phase decode mode. A
+      transition on the PHASEA input generates a count; PHASEB and the
+      reverse-direction setting control the count direction. In this mode the
+      controller counts one edge per pulse (no X4 quadrature multiply), so
+      counts-per-revolution is the raw pulse count per revolution.
+      When unset (default), standard quadrature X4 decoding is used.
+
+  revolution-count-mode:
+    type: int
+    default: 1
+    enum: [0, 1]
+    description: |
+      0: Use INDEX pulse to increment/decrement revolution counter.
+      1: Use modulus counting roll-over or roll-under events instead of the
+      INDEX pulse.
+
+  inputmux-connections:
+    type: phandle-array
+    specifier-space: inputmux
+    description: |
+      INPUTMUX routing for the EQDC PHASEA/PHASEB inputs. Each phandle-array
+      entry is <&inputmuxN channel connection> where:
+        - &inputmuxN is the INPUTMUX node providing the route
+        - channel is the INPUTMUX destination index
+        - connection is an inputmux_connection_t value from the NXP HAL
+          header fsl_inputmux_connections.h
+
+      Example (MCXA153: route TRIG_IN10 to EQDC PHASEA and TRIG_IN5 to
+      EQDC PHASEB via INPUTMUX0):
+        inputmux-connections = <&inputmux0 0 0x37000022>, /* TrigIn10ToQdc0Phasea */
+                               <&inputmux0 0 0x36c0001d>; /* TrigIn5ToQdc0Phaseb */

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -232,6 +232,9 @@ enum sensor_channel {
 	/** Raw quadrature decoder count, in counts */
 	SENSOR_CHAN_ENCODER_COUNT,
 
+	/** Number of revolutions for quadrature decoder */
+	SENSOR_CHAN_ENCODER_REVOLUTIONS,
+
 	/** All channels. */
 	SENSOR_CHAN_ALL,
 

--- a/include/zephyr/drivers/sensor/eqdc_mcux.h
+++ b/include/zephyr/drivers/sensor/eqdc_mcux.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for extended sensor API of NXP MCUX EQDC sensor
+ * @ingroup sensor_eqdc_mcux
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_EQDC_MCUX_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_EQDC_MCUX_H_
+
+/**
+ * @brief NXP MCUX EQDC sensor
+ * @defgroup sensor_eqdc_mcux EQDC MCUX
+ * @ingroup sensor_interface_ext
+ * @{
+ */
+
+#include <zephyr/drivers/sensor.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Extended sensor attributes for NXP MCUX EQDC
+ */
+enum sensor_attribute_eqdc_mcux {
+	/** Counts per revolution - uint32_t */
+	SENSOR_ATTR_EQDC_COUNTS_PER_REVOLUTION = SENSOR_ATTR_PRIV_START,
+
+	/** Clock frequency of the EQDC module after prescaled - uint32_t */
+	SENSOR_ATTR_EQDC_PRESCALED_FREQUENCY,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_EQDC_MCUX_H_ */

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -231,4 +231,11 @@
 /** SYSTEM clock identifier. */
 #define MCUX_SYSTEM_CLK MCUX_LPC_CLK_ID(0x36, 0x00)
 
+/** EQDC peripheral clock identifier. */
+#define MCUX_EQDC_CLK MCUX_LPC_CLK_ID(0x37, 0x00)
+/** EQDC0 peripheral clock identifier. */
+#define MCUX_EQDC0_CLK MCUX_LPC_CLK_ID(0x38, 0x00)
+/** EQDC1 peripheral clock identifier. */
+#define MCUX_EQDC1_CLK MCUX_LPC_CLK_ID(0x38, 0x01)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -137,6 +137,7 @@ set_variable_ifdef(CONFIG_MCUX_SDIF             CONFIG_MCUX_COMPONENT_driver.sdi
 set_variable_ifdef(CONFIG_MCUX_XBARA            CONFIG_MCUX_COMPONENT_driver.xbara)
 set_variable_ifdef(CONFIG_MCUX_XBARB            CONFIG_MCUX_COMPONENT_driver.xbarb)
 set_variable_ifdef(CONFIG_QDC_MCUX              CONFIG_MCUX_COMPONENT_driver.qdc)
+set_variable_ifdef(CONFIG_EQDC_MCUX             CONFIG_MCUX_COMPONENT_driver.eqdc)
 set_variable_ifdef(CONFIG_QDEC_MCUX             CONFIG_MCUX_COMPONENT_driver.enc)
 set_variable_ifdef(CONFIG_CRYPTO_MCUX_DCP       CONFIG_MCUX_COMPONENT_driver.dcp)
 set_variable_ifdef(CONFIG_DAC_MCUX_LPDAC        CONFIG_MCUX_COMPONENT_driver.dac_1)

--- a/samples/sensor/qdec/README.rst
+++ b/samples/sensor/qdec/README.rst
@@ -62,6 +62,24 @@ console
     Position = 30 degrees
     ...
 
+If the driver supports getting speed (RPM) and revolution count channels, these
+data will be displayed on the console.
+
+When ``CONFIG_EQDC_MCUX_TRIGGER=y`` (e.g. on ``frdm_mcxa153``), the sample also
+registers the ``SENSOR_TRIG_OVERFLOW`` trigger on the revolution channel and
+prints the trigger count each cycle:
+
+.. code-block:: console
+
+    Quadrature decoder sensor test
+    Registered SENSOR_TRIG_OVERFLOW on SENSOR_CHAN_ENCODER_REVOLUTIONS
+    Position = 0 degrees
+    Revolutions = 0
+    Triggers = 0
+    Position = 180 degrees
+    Revolutions = 1
+    Triggers = 1
+    ...
 
 Of course the read value changes once the user manually rotates the mechanical
 encoder.

--- a/samples/sensor/qdec/boards/frdm_mcxa153.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa153.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable EQDC overflow-trigger support so the qdec sample exercises the
+# SENSOR_TRIG_OVERFLOW path on the revolution channel.
+CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxa153.overlay
+++ b/samples/sensor/qdec/boards/frdm_mcxa153.overlay
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &eqdc0;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpio3 12 GPIO_ACTIVE_LOW>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpio3 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+/* J1-12 ---> J3-3 (EQDC PHASEA)
+ * J1-14 ---> J3-1 (EQDC PHASEB)
+ */
+&pinctrl {
+	eqdc_pinmux: eqdc_pinmux {
+		group0 {
+			pinmux = <TRIG_IN5_P2_7>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+
+		group1 {
+			pinmux = <TRIG_IN10_P3_31>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
+};
+
+&inputmux0 {
+	status = "okay";
+};
+
+&eqdc0 {
+	status = "okay";
+	pinctrl-0 = <&eqdc_pinmux>;
+	pinctrl-names = "default";
+	counts-per-revolution = <120>;
+	revolution-count-mode = <1>;
+	prescaler = <15>;
+	input-filter-period = <1>;
+	inputmux-connections = <&inputmux0 0 0x37000022>,
+			       <&inputmux0 0 0x36c0001d>;
+};

--- a/samples/sensor/qdec/boards/frdm_mcxa156.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa156.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable EQDC overflow-trigger support so the qdec sample exercises the
+# SENSOR_TRIG_OVERFLOW path on the revolution channel.
+CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxa156.overlay
+++ b/samples/sensor/qdec/boards/frdm_mcxa156.overlay
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &eqdc0;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpio3 14 GPIO_ACTIVE_LOW>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpio3 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+/*  J1-11 --->  J4-5 (EQDC PHASEA)
+ *  J1-7 --->  J4-3 (EQDC PHASEB)
+ */
+&pinctrl {
+	eqdc_pinmux: eqdc_pinmux {
+		group0 {
+			pinmux = <TRIG_IN10_P3_31>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+
+		group1 {
+			pinmux = <TRIG_IN9_P2_17>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
+};
+
+&inputmux0 {
+	status = "okay";
+};
+
+&eqdc0 {
+	status = "okay";
+	pinctrl-0 = <&eqdc_pinmux>;
+	pinctrl-names = "default";
+	counts-per-revolution = <120>;
+	revolution-count-mode = <1>;
+	prescaler = <15>;
+	input-filter-period = <1>;
+	/* Route TRIG_IN10 (P3_31) to EQDC PHASEA and TRIG_IN9 (P2_17) to
+	 * EQDC PHASEB through INPUTMUX0. Connection values are
+	 * inputmux_connection_t enums from fsl_inputmux_connections.h:
+	 *   kINPUTMUX_TrigIn10ToQdc0Phasea = 0x37000022
+	 *   kINPUTMUX_TrigIn9ToQdc0Phaseb  = 0x36c00021
+	 */
+	inputmux-connections = <&inputmux0 0 0x37000022>,
+			       <&inputmux0 0 0x36c00021>;
+};

--- a/samples/sensor/qdec/boards/frdm_mcxa266.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa266.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable EQDC overflow-trigger support so the qdec sample exercises the
+# SENSOR_TRIG_OVERFLOW path on the revolution channel.
+CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxa266.overlay
+++ b/samples/sensor/qdec/boards/frdm_mcxa266.overlay
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &eqdc0;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpio3 1 GPIO_ACTIVE_LOW>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpio3 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+/*  J3-13 ---> J3-3 (EQDC PHASEA)
+ *  J1-5 --->  J3-1 (EQDC PHASEB)
+ */
+&pinctrl {
+	eqdc_pinmux: eqdc_pinmux {
+		group0 {
+			pinmux = <TRIG_IN3_P1_13>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+
+		group1 {
+			pinmux = <TRIG_IN10_P3_31>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
+};
+
+&inputmux0 {
+	status = "okay";
+};
+
+&eqdc0 {
+	status = "okay";
+	pinctrl-0 = <&eqdc_pinmux>;
+	pinctrl-names = "default";
+	counts-per-revolution = <120>;
+	revolution-count-mode = <1>;
+	prescaler = <15>;
+	input-filter-period = <1>;
+	/* Route TRIG_IN3 (P1_13) to EQDC PHASEA and TRIG_IN10 (P3_31) to
+	 * EQDC PHASEB through INPUTMUX0. Connection values are
+	 * inputmux_connection_t enums from fsl_inputmux_connections.h:
+	 *   kINPUTMUX_TrigIn3ToQdc0Phasea  = 0x3700001b
+	 *   kINPUTMUX_TrigIn10ToQdc0Phaseb = 0x36c00022
+	 */
+	inputmux-connections = <&inputmux0 0 0x3700001b>,
+			       <&inputmux0 0 0x36c00022>;
+};

--- a/samples/sensor/qdec/boards/frdm_mcxa344.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa344.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable EQDC overflow-trigger support so the qdec sample exercises the
+# SENSOR_TRIG_OVERFLOW path on the revolution channel.
+CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxa344.overlay
+++ b/samples/sensor/qdec/boards/frdm_mcxa344.overlay
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &eqdc0;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpio3 1 GPIO_ACTIVE_LOW>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpio3 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+/* Emulated encoder outputs are jumpered to the EQDC trigger inputs.
+ * Per the SDK frdmmcxa344 eqdc_basic readme the EQDC PHASE inputs are on J3:
+ *   gpio3.1  = Arduino D5  --->  J3-3 = P1_13 / TRIG_IN3   -> EQDC PHASEA
+ *   gpio3.17 = Arduino D6  --->  J3-1 = P3_31 / TRIG_IN10  -> EQDC PHASEB
+ */
+&pinctrl {
+	eqdc_pinmux: eqdc_pinmux {
+		group0 {
+			pinmux = <TRIG_IN3_P1_13>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+
+		group1 {
+			pinmux = <TRIG_IN10_P3_31>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
+};
+
+&inputmux0 {
+	status = "okay";
+};
+
+&eqdc0 {
+	status = "okay";
+	pinctrl-0 = <&eqdc_pinmux>;
+	pinctrl-names = "default";
+	counts-per-revolution = <120>;
+	revolution-count-mode = <1>;
+	prescaler = <15>;
+	input-filter-period = <1>;
+	/* Route TRIG_IN3 (P1_13) to EQDC PHASEA and TRIG_IN10 (P3_31) to
+	 * EQDC PHASEB through INPUTMUX0. Connection values are
+	 * inputmux_connection_t enums from fsl_inputmux_connections.h:
+	 *   kINPUTMUX_TrigIn3ToQdc0Phasea  = 0x3700001b
+	 *   kINPUTMUX_TrigIn10ToQdc0Phaseb = 0x36c00022
+	 */
+	inputmux-connections = <&inputmux0 0 0x3700001b>,
+			       <&inputmux0 0 0x36c00022>;
+};

--- a/samples/sensor/qdec/boards/frdm_mcxa346.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa346.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable EQDC overflow-trigger support so the qdec sample exercises the
+# SENSOR_TRIG_OVERFLOW path on the revolution channel.
+CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxa346.overlay
+++ b/samples/sensor/qdec/boards/frdm_mcxa346.overlay
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &eqdc0;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpio3 1 GPIO_ACTIVE_LOW>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpio3 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+/*  J3-13 ---> J3-3 (EQDC PHASEA)
+ *  J1-5 --->  J3-1 (EQDC PHASEB)
+ */
+&pinctrl {
+	eqdc_pinmux: eqdc_pinmux {
+		group0 {
+			pinmux = <TRIG_IN3_P1_13>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+
+		group1 {
+			pinmux = <TRIG_IN10_P3_31>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
+};
+
+&inputmux0 {
+	status = "okay";
+};
+
+&eqdc0 {
+	status = "okay";
+	pinctrl-0 = <&eqdc_pinmux>;
+	pinctrl-names = "default";
+	counts-per-revolution = <120>;
+	revolution-count-mode = <1>;
+	prescaler = <15>;
+	input-filter-period = <1>;
+	/* Route TRIG_IN3 (P1_13) to EQDC PHASEA and TRIG_IN10 (P3_31) to
+	 * EQDC PHASEB through INPUTMUX0. Connection values are
+	 * inputmux_connection_t enums from fsl_inputmux_connections.h:
+	 *   kINPUTMUX_TrigIn3ToQdc0Phasea  = 0x3700001b
+	 *   kINPUTMUX_TrigIn10ToQdc0Phaseb = 0x36c00022
+	 */
+	inputmux-connections = <&inputmux0 0 0x3700001b>,
+			       <&inputmux0 0 0x36c00022>;
+};

--- a/samples/sensor/qdec/boards/frdm_mcxa366.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa366.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable EQDC overflow-trigger support so the qdec sample exercises the
+# SENSOR_TRIG_OVERFLOW path on the revolution channel.
+CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxa366.overlay
+++ b/samples/sensor/qdec/boards/frdm_mcxa366.overlay
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &eqdc0;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpio3 1 GPIO_ACTIVE_LOW>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpio3 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+/*  J3-13 ---> J3-3 (EQDC PHASEA)
+ *  J1-5 --->  J3-1 (EQDC PHASEB)
+ */
+&pinctrl {
+	eqdc_pinmux: eqdc_pinmux {
+		group0 {
+			pinmux = <TRIG_IN3_P1_13>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+
+		group1 {
+			pinmux = <TRIG_IN10_P3_31>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
+};
+
+&inputmux0 {
+	status = "okay";
+};
+
+&eqdc0 {
+	status = "okay";
+	pinctrl-0 = <&eqdc_pinmux>;
+	pinctrl-names = "default";
+	counts-per-revolution = <120>;
+	revolution-count-mode = <1>;
+	prescaler = <15>;
+	input-filter-period = <1>;
+	/* Route TRIG_IN3 (P1_13) to EQDC PHASEA and TRIG_IN10 (P3_31) to
+	 * EQDC PHASEB through INPUTMUX0. Connection values are
+	 * inputmux_connection_t enums from fsl_inputmux_connections.h:
+	 *   kINPUTMUX_TrigIn3ToQdc0Phasea  = 0x3700001b
+	 *   kINPUTMUX_TrigIn10ToQdc0Phaseb = 0x36c00022
+	 */
+	inputmux-connections = <&inputmux0 0 0x3700001b>,
+			       <&inputmux0 0 0x36c00022>;
+};

--- a/samples/sensor/qdec/sample.yaml
+++ b/samples/sensor/qdec/sample.yaml
@@ -18,6 +18,29 @@ tests:
         - "Quadrature decoder sensor test"
         - "Position = (.*) degrees"
 
+  sample.sensor.eqdc_trigger:
+    platform_allow:
+      - frdm_mcxa153
+      - frdm_mcxa156
+      - frdm_mcxa266
+      - frdm_mcxa344
+      - frdm_mcxa346
+      - frdm_mcxa366
+    integration_platforms:
+      - frdm_mcxa153
+    depends_on: gpio
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "Quadrature decoder sensor test"
+        - "Quadrature encoder emulator enabled with (.*) ms period"
+        - "Registered SENSOR_TRIG_OVERFLOW on SENSOR_CHAN_ENCODER_REVOLUTIONS"
+        - "Position = (.*) degrees"
+        - "Speed = (.*) RPM"
+        - "Revolutions = (.*)"
+        - "Triggers = (.*)"
+
   sample.sensor.sam_qdec_sensor:
     platform_allow:
       - sam_e70_xplained/same70q21

--- a/samples/sensor/qdec/src/main.c
+++ b/samples/sensor/qdec/src/main.c
@@ -70,6 +70,52 @@ static void qenc_emulate_init(void) { };
 
 #endif /* QUAD_ENC_EMUL_ENABLED */
 
+#ifdef CONFIG_EQDC_MCUX_TRIGGER
+
+#include <zephyr/sys/atomic.h>
+
+/* Incremented from the trigger handler (system workqueue context). */
+static atomic_t trigger_count;
+
+static void revolution_trigger_handler(const struct device *dev,
+				       const struct sensor_trigger *trig)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(trig);
+
+	atomic_inc(&trigger_count);
+}
+
+/*
+ * Register SENSOR_TRIG_OVERFLOW on the revolution channel. With
+ * revolution-count-mode = modulus, the EQDC revolution counter rolls
+ * over/under without an INDEX signal, firing this trigger as the emulated
+ * encoder drives the position counter past a full revolution.
+ */
+static void qdec_trigger_init(const struct device *dev)
+{
+	struct sensor_trigger trig = {
+		.type = SENSOR_TRIG_OVERFLOW,
+		.chan = SENSOR_CHAN_ENCODER_REVOLUTIONS,
+	};
+	int rc = sensor_trigger_set(dev, &trig, revolution_trigger_handler);
+
+	if (rc != 0) {
+		printk("Failed to set SENSOR_TRIG_OVERFLOW (%d)\n", rc);
+		return;
+	}
+	printk("Registered SENSOR_TRIG_OVERFLOW on SENSOR_CHAN_ENCODER_REVOLUTIONS\n");
+}
+
+#else
+
+static void qdec_trigger_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+};
+
+#endif /* CONFIG_EQDC_MCUX_TRIGGER */
+
 int main(void)
 {
 	struct sensor_value val;
@@ -84,6 +130,8 @@ int main(void)
 	printk("Quadrature decoder sensor test\n");
 
 	qenc_emulate_init();
+
+	qdec_trigger_init(dev);
 
 #ifndef CONFIG_COVERAGE
 	while (true) {
@@ -106,6 +154,28 @@ int main(void)
 		}
 
 		printk("Position = %d degrees\n", val.val1);
+
+		/* Get speed (optional)*/
+		rc = sensor_channel_get(dev, SENSOR_CHAN_RPM, &val);
+		if (rc == 0) {
+			printk("Speed = %d RPM\n", val.val1);
+		}
+
+		/* Get revolutions (optional)*/
+		rc = sensor_channel_get(dev, SENSOR_CHAN_ENCODER_REVOLUTIONS, &val);
+		if (rc == 0) {
+			printk("Revolutions = %d\n", val.val1);
+		}
+
+#ifdef CONFIG_EQDC_MCUX_TRIGGER
+		/*
+		 * "triggers" is how many times the SENSOR_TRIG_OVERFLOW handler
+		 * ran. If the trigger path works it tracks the revolution
+		 * roll-over events; if it stays 0 while revolutions change, the
+		 * IRQ never reaches the handler.
+		 */
+		printk("Triggers = %ld\n", (long)atomic_get(&trigger_count));
+#endif
 	}
 	return 0;
 }


### PR DESCRIPTION
Adds a sensor driver for the NXP MCUX Enhanced Quadrature Decoder (EQDC).

The driver exposes rotation (degrees), RPM, encoder count and revolutions. 

The qdec sample is enabled on FRDM-MCXA153/156/266/344/346/366 and test pass.