### PR TITLE
net: context: remove setting rx_timestamping on tx

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2236,10 +2236,6 @@ static int context_setup_udp_packet(struct net_context *context,
 	if (context->options.timestamping & ZSOCK_SOF_TIMESTAMPING_TX_HARDWARE) {
 		net_pkt_set_tx_timestamping(pkt, true);
 	}
-
-	if (context->options.timestamping & ZSOCK_SOF_TIMESTAMPING_RX_HARDWARE) {
-		net_pkt_set_rx_timestamping(pkt, true);
-	}
 #endif
 
 	return 0;
@@ -2855,10 +2851,6 @@ skip_alloc:
 #if defined(CONFIG_NET_CONTEXT_TIMESTAMPING)
 		if (context->options.timestamping & ZSOCK_SOF_TIMESTAMPING_TX_HARDWARE) {
 			net_pkt_set_tx_timestamping(pkt, true);
-		}
-
-		if (context->options.timestamping & ZSOCK_SOF_TIMESTAMPING_RX_HARDWARE) {
-			net_pkt_set_rx_timestamping(pkt, true);
 		}
 #endif
 


### PR DESCRIPTION
setting net_pkt_set_rx_timestamping on a
packet that is going to be send is wrong.

net_pkt_set_rx_timestamping is rather used
by a ethernet driver to indecate that the
timestamp is valid.