### PR TITLE
boards: seeed: xiao_nrf54l15: wire openocd mass erase command

### DIFF
--- a/boards/seeed/xiao_nrf54l15/board.cmake
+++ b/boards/seeed/xiao_nrf54l15/board.cmake
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_SOC_NRF54L15_CPUAPP)
-  board_runner_args(openocd "--cmd-load=nrf54l-load" -c "targets nrf54l.cpu")
+  board_runner_args(openocd "--cmd-load=nrf54l-load" "--cmd-erase=nrf54l_mass_erase" -c "targets nrf54l.cpu")
   board_runner_args(jlink "--device=nRF54L15_M33" "--speed=4000")
 elseif(CONFIG_SOC_NRF54L15_CPUFLPR)
-  board_runner_args(openocd "--cmd-load=nrf54l-load" -c "targets nrf54l.aux")
+  board_runner_args(openocd "--cmd-load=nrf54l-load" "--cmd-erase=nrf54l_mass_erase" -c "targets nrf54l.aux")
   board_runner_args(jlink "--device=nRF54L15_RV32")
 endif()
 


### PR DESCRIPTION
### Description

The `xiao_nrf54l15` OpenOCD support file already defines a
`nrf54l_mass_erase` procedure (a CTRL-AP `ERASEALL` sequence used both
for explicit mass erase and for the auto-recover on a locked device),
but `board.cmake` never passed it to the runner as `--cmd-erase`.

Because of that, `west flash --erase` — and any flow that requests a
mass erase — aborts before talking to the target with:

```
ERROR: runners.openocd: --erase not supported for target without --cmd-erase
```

This wires `--cmd-erase=nrf54l_mass_erase` into both the `cpuapp` and
`cpuflpr` openocd runner argument sets. No new procedure is introduced;
this only exposes the existing one to the runner, bringing the openocd
runner in line with the erase support already available via `jlink` /
`nrfutil`.

### Change

- `boards/seeed/xiao_nrf54l15/board.cmake`: add
  `--cmd-erase=nrf54l_mass_erase` to the openocd `board_runner_args`
  for `CONFIG_SOC_NRF54L15_CPUAPP` and `CONFIG_SOC_NRF54L15_CPUFLPR`.

### Testing

Verified on a Seeed XIAO nRF54L15 (CMSIS-DAPv2) on the cpuapp target:

```
$ west flash --erase
-- runners.openocd: mass erase requested
...
[nrf54l.cpu] device has been successfully erased and unlocked.
downloaded 42164 bytes in 0.768s (53.6 KiB/s)
shutdown command invoked
```

Before this change the same command failed immediately with the
`--cmd-erase` error above. `west flash` without `--erase` is unaffected.
