### PR TITLE
drivers: spi: omap_mcspi: correct CS handling

### DIFF
--- a/drivers/spi/spi_omap_mcspi.c
+++ b/drivers/spi/spi_omap_mcspi.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2026 Siemens Mobility GmbH
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -117,6 +118,37 @@ static void omap_mcspi_channel_enable(const struct device *dev, bool enable)
 		regs->CHAN[chan].CHCTRL |= OMAP_MCSPI_CHCTRL_EN;
 	} else {
 		regs->CHAN[chan].CHCTRL &= ~OMAP_MCSPI_CHCTRL_EN;
+	}
+}
+
+static void omap_mcspi_hw_cs_control(const struct device *dev, bool enabled)
+{
+	struct omap_mcspi_regs *regs = DEV_REGS(dev);
+	uint8_t chan = DEV_DATA(dev)->ctx.config->slave;
+	struct omap_mcspi_data *data = DEV_DATA(dev);
+
+	/*
+	 * This works due to omap_mcspi_transceive_one writing data->chconf to the
+	 * CHCONF register, meaning we also can't just write into CHCONF directly.
+	 * After the transfer we can clear the FORCE bit directly inside the
+	 * register.
+	 */
+	if (enabled) {
+		data->chconf |= OMAP_MCSPI_CHCONF_FORCE;
+	} else {
+		regs->CHAN[chan].CHCONF &= ~OMAP_MCSPI_CHCONF_FORCE;
+	}
+}
+
+static void omap_mcspi_cs_control(const struct device *dev, bool enabled)
+{
+	struct omap_mcspi_data *data = DEV_DATA(dev);
+	struct spi_context *ctx = &data->ctx;
+
+	if (spi_cs_is_gpio(ctx->config)) {
+		spi_context_cs_control(ctx, enabled);
+	} else {
+		omap_mcspi_hw_cs_control(dev, enabled);
 	}
 }
 
@@ -238,7 +270,6 @@ static int omap_mcspi_configure(const struct device *dev, const struct spi_confi
 		if (ch != chan) {
 			/* only when MODULCTRL_SINGLE is set */
 			regs->CHAN[ch].CHCTRL &= ~OMAP_MCSPI_CHCTRL_EN;
-			regs->CHAN[ch].CHCONF &= ~OMAP_MCSPI_CHCONF_FORCE;
 		}
 
 		/* disable FIFO for all channels */
@@ -292,13 +323,6 @@ static int omap_mcspi_configure(const struct device *dev, const struct spi_confi
 		data->chconf |= OMAP_MCSPI_CHCONF_PHA;
 	} else {
 		data->chconf &= ~OMAP_MCSPI_CHCONF_PHA;
-	}
-
-	/* set force */
-	if (!spi_cs_is_gpio(config)) {
-		data->chconf |= OMAP_MCSPI_CHCONF_FORCE;
-	} else {
-		data->chconf &= ~OMAP_MCSPI_CHCONF_FORCE;
 	}
 
 	rv = omap_mcspi_configure_clk_freq(dev, config->frequency, cfg->clock_frequency);
@@ -565,12 +589,12 @@ static int omap_mcspi_transceive_all(const struct device *dev, const struct spi_
 	ret = omap_mcspi_configure(dev, config, tx_bufs, rx_bufs);
 	if (ret) {
 		LOG_ERR("An error occurred in the SPI configuration");
-		goto cleanup;
+		goto cleanup_no_cs;
 	}
 
 	spi_context_buffers_setup(ctx, tx_bufs, rx_bufs, data->dfs);
 
-	spi_context_cs_control(ctx, true);
+	omap_mcspi_cs_control(dev, true);
 
 	while (spi_context_tx_on(ctx) || spi_context_rx_on(ctx)) {
 		ret = omap_mcspi_transceive_one(dev);
@@ -583,8 +607,9 @@ static int omap_mcspi_transceive_all(const struct device *dev, const struct spi_
 	}
 
 cleanup:
-	spi_context_cs_control(ctx, false);
+	omap_mcspi_cs_control(dev, false);
 
+cleanup_no_cs:
 	if (!(config->operation & SPI_LOCK_ON)) {
 		spi_context_release(ctx, ret);
 	}
@@ -642,6 +667,14 @@ static int omap_mcspi_init(const struct device *dev)
 
 	data->fifo_depth = FIELD_GET(OMAP_MCSPI_HWINFO_FFNBYTE, regs->HWINFO) << 4;
 
+	ARRAY_FOR_EACH(regs->CHAN, ch) {
+		regs->CHAN[ch].CHCONF &= ~OMAP_MCSPI_CHCONF_FORCE;
+	}
+
+	ret = spi_context_cs_configure_all(&data->ctx);
+	if (ret < 0) {
+		return ret;
+	}
 	spi_context_unlock_unconditionally(&data->ctx);
 
 	return 0;

--- a/tests/drivers/spi/spi_loopback/boards/lp_am243_am2434_r5f0_0.conf
+++ b/tests/drivers/spi/spi_loopback/boards/lp_am243_am2434_r5f0_0.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Texas Instruments
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_LOOPBACK_MODE_LOOP=y
+CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=25

--- a/tests/drivers/spi/spi_loopback/boards/lp_am243_am2434_r5f0_0.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/lp_am243_am2434_r5f0_0.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Texas Instruments
+ * Copyright (c) 2026 Siemens Mobility GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <freq.h>
+
+&main_pinctrl {
+	spi0_cs1: spi0_cs1_default {
+		pinmux = <K3_PINMUX(0x20c, PIN_OUTPUT_PULLUP, MUX_MODE_0)>;
+	};
+
+	spi0_clk: spi0_clk_default {
+		pinmux = <K3_PINMUX(0x210, PIN_OUTPUT, MUX_MODE_0)>;
+	};
+
+	spi0_d0: spi0_d0_default {
+		pinmux = <K3_PINMUX(0x214, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	spi0_d1: spi0_d1_default {
+		pinmux = <K3_PINMUX(0x218, PIN_OUTPUT, MUX_MODE_0)>;
+	};
+
+	status = "okay";
+};
+
+/* CS1 is used so it's observable with a logic analyzer */
+&main_mcspi0 {
+	pinctrl-0 = <&spi0_clk &spi0_cs1 &spi0_d0 &spi0_d1>;
+	pinctrl-names = "default";
+
+	slow@1 {
+		compatible = "test-spi-loopback-slow";
+		reg = <1>;
+		spi-max-frequency = <DT_FREQ_K(500)>;
+	};
+
+	fast@1 {
+		compatible = "test-spi-loopback-fast";
+		reg = <1>;
+		spi-max-frequency = <DT_FREQ_M(50)>;
+	};
+
+	status = "okay";
+};


### PR DESCRIPTION
This PR adds CS deassertions between transfers for the OMAP MCSPI driver. Some (but not all) peripherals require a CS deassertion between transfers (i.e. the Microchip LAN8651).

Additionally a missing call to `spi_context_cs_configure_all` has been added