### PR TITLE
subsys: modem: add optional raw RX logging to modem_chat

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -281,6 +281,10 @@ struct modem_chat {
 	uint16_t parse_match_len;
 	uint16_t parse_arg_len;
 	uint16_t parse_match_type;
+#if defined(CONFIG_MODEM_CHAT_LOG_RAW_RX)
+	uint8_t raw_log_separators[CONFIG_MODEM_CHAT_LOG_BUFFER_SIZE];
+	uint16_t raw_log_separators_len;
+#endif
 
 	/* Process received data */
 	struct k_work receive_work;

--- a/subsys/modem/Kconfig
+++ b/subsys/modem/Kconfig
@@ -36,6 +36,15 @@ config MODEM_CHAT_LOG_BUFFER_SIZE
 	int "Modem chat log buffer size in bytes"
 	default 128
 
+config MODEM_CHAT_LOG_RAW_RX
+	bool "Log raw received modem lines"
+	depends on LOG
+	depends on MODEM_MODULES_LOG_LEVEL_DBG
+	help
+	  Log the raw received modem line instead of the parsed debug logging.
+	  This preserves separators and empty fields exactly as
+	  received before modem_chat tokenizes the response.
+
 endif
 
 config MODEM_CMUX

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -33,6 +33,48 @@ static char log_buffer[CONFIG_MODEM_CHAT_LOG_BUFFER_SIZE];
 
 static void modem_chat_log_received_command(struct modem_chat *chat)
 {
+#if defined(CONFIG_MODEM_CHAT_LOG_RAW_RX)
+	uint16_t log_buffer_pos = 0;
+	uint16_t separators_pos = 0;
+	uint16_t argv_len;
+
+	for (uint16_t i = 0; i < chat->argc; i++) {
+		if ((i > 1) && (chat->raw_log_separators_len > separators_pos)) {
+			if ((log_buffer_pos + 1) >= sizeof(log_buffer)) {
+				LOG_WRN("raw log buffer overrun");
+				break;
+			}
+
+			log_buffer[log_buffer_pos] = (char)chat->raw_log_separators[separators_pos];
+			log_buffer_pos++;
+			separators_pos++;
+		}
+
+		argv_len = (uint16_t)strlen(chat->argv[i]);
+
+		if (sizeof(log_buffer) < (log_buffer_pos + argv_len + 1)) {
+			LOG_WRN("raw log buffer overrun");
+			break;
+		}
+
+		memcpy(&log_buffer[log_buffer_pos], chat->argv[i], argv_len);
+		log_buffer_pos += argv_len;
+	}
+
+	while (chat->raw_log_separators_len > separators_pos) {
+		if ((log_buffer_pos + 1) >= sizeof(log_buffer)) {
+			LOG_WRN("raw log buffer overrun");
+			break;
+		}
+
+		log_buffer[log_buffer_pos] = (char)chat->raw_log_separators[separators_pos];
+		log_buffer_pos++;
+		separators_pos++;
+	}
+
+	log_buffer[log_buffer_pos] = '\0';
+	LOG_DBG("raw: %s", log_buffer);
+#else
 	uint16_t log_buffer_pos = 0;
 	uint16_t argv_len;
 
@@ -57,6 +99,7 @@ static void modem_chat_log_received_command(struct modem_chat *chat)
 	log_buffer[log_buffer_pos] = '\0';
 
 	LOG_DBG("%s", log_buffer);
+#endif
 }
 
 #else
@@ -387,6 +430,10 @@ static void modem_chat_parse_reset(struct modem_chat *chat)
 	chat->delimiter_match_len = 0;
 	chat->argc = 0;
 	chat->parse_match = NULL;
+
+#if defined(CONFIG_MODEM_CHAT_LOG_RAW_RX)
+	chat->raw_log_separators_len = 0;
+#endif
 }
 
 /* Exact match is stored at end of receive buffer */
@@ -661,6 +708,15 @@ static void modem_chat_process_byte(struct modem_chat *chat, uint8_t byte)
 
 	/* Check if separator reached */
 	if (modem_chat_parse_is_separator(chat) == true) {
+
+#if defined(CONFIG_MODEM_CHAT_LOG_RAW_RX)
+		if (chat->raw_log_separators_len < ARRAY_SIZE(chat->raw_log_separators)) {
+			chat->raw_log_separators[chat->raw_log_separators_len] =
+				chat->receive_buf[chat->receive_buf_len - 1];
+			chat->raw_log_separators_len++;
+		}
+#endif
+
 		/* Check if argument is empty */
 		if (chat->parse_arg_len == 0) {
 			/* Save empty argument */


### PR DESCRIPTION
Add an optional raw RX logging path to modem_chat, controlled by CONFIG_MODEM_CHAT_LOG_RAW_RX. When enabled, modem_chat logs the received line with the original separators preserved and does not emit the existing parsed RX debug log for that line. When disabled, the current logging behaviour is unchanged.

Today the debug log for received modem lines is built from the parsed argument array. During parsing, separator bytes such as commas are replaced by string terminators and the log output is reconstructed with spaces.

That makes logs harder to use for real modem debugging:

- Many AT responses and URCs are positional and comma-delimited.
- Empty fields are significant and may indicate missing data or a different modem state.
- Replacing commas with spaces can make the logged line look different from the actual modem response.
- It becomes harder to compare the log directly with modem documentation, vendor traces, or a manually captured AT session.
- Preserving commas instead of spaces makes it possible to see the original modem response shape, including empty fields, while keeping the existing parsed callback behaviour intact.


Before:
```
+KUDP_DATA: 1  42  0
+KCELLMEAS:  -104.0 130.0   6.0 1 1
$PSGSA, 1                920    0 00 3 0 B  0 0 1 0 0 0 0 0 0  0 00

```
After:
```
+KUDP_DATA:1,,42,0
+KCELLMEAS: -103.0,129.0,23.0,,9.0,1,0
$PSGSA,1,,,,,,,,,,,,,,,,920,,,,0,00,3,0,B,,0,0,0,0,0,0,0,0,0,,0*01
```
The raw form keeps delimiter placement visible, which is the main debugging value of this change.