### PR TITLE
drivers/w1/gpio: provide error code when init fails

### DIFF
--- a/drivers/w1/w1_zephyr_gpio.c
+++ b/drivers/w1/w1_zephyr_gpio.c
@@ -291,8 +291,8 @@ static int w1_gpio_init(const struct device *dev)
 		int ret = gpio_pin_configure_dt(spec, GPIO_OUTPUT_INACTIVE | GPIO_OPEN_DRAIN |
 							      GPIO_INPUT);
 		if (ret < 0) {
-			LOG_ERR("Failed to configure GPIO port %s pin %d", spec->port->name,
-				spec->pin);
+			LOG_ERR("Failed to configure GPIO port %s pin %d: %d", spec->port->name,
+				spec->pin, ret);
 			return ret;
 		}
 	} else {


### PR DESCRIPTION
Makes diagnosis a little easier.