### PR TITLE
tests: drivers: disk: Remove the redundant extra config files for Renesas RA

### DIFF
--- a/tests/drivers/disk/disk_access/boards/ek_ra8m1_sci_b_spi.conf
+++ b/tests/drivers/disk/disk_access/boards/ek_ra8m1_sci_b_spi.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2025 Renesas Electronics Corporation
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_MAIN_STACK_SIZE=1280

--- a/tests/drivers/disk/disk_access/boards/ek_ra8p1_r7ka8p1kflcac_cm85_sci_b_spi.conf
+++ b/tests/drivers/disk/disk_access/boards/ek_ra8p1_r7ka8p1kflcac_cm85_sci_b_spi.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2025 Renesas Electronics Corporation
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_MAIN_STACK_SIZE=1280

--- a/tests/drivers/disk/disk_access/boards/mck_ra8t1_sci_b_spi.conf
+++ b/tests/drivers/disk/disk_access/boards/mck_ra8t1_sci_b_spi.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2025 Renesas Electronics Corporation
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_MAIN_STACK_SIZE=1280

--- a/tests/drivers/disk/disk_access/testcase.yaml
+++ b/tests/drivers/disk/disk_access/testcase.yaml
@@ -74,7 +74,6 @@ tests:
     filter: dt_compat_enabled("zephyr,sdhc-spi-slot") and dt_compat_enabled("renesas,ra-spi-sci-b")
     extra_args:
       - DTC_OVERLAY_FILE="boards/${BOARD}_sci_b_spi.overlay"
-      - CONF_FILE="prj.conf boards/${BOARD}_sci_b_spi.conf"
     integration_platforms:
       - ek_ra8m1
     platform_allow:
@@ -88,6 +87,5 @@ tests:
     filter: dt_compat_enabled("zephyr,sdhc-spi-slot") and dt_compat_enabled("renesas,ra-spi-sci-b")
     extra_args:
       - DTC_OVERLAY_FILE="boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}_sci_b_spi.overlay"
-      - CONF_FILE="prj.conf boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}_sci_b_spi.conf"
     platform_allow:
       - ek_ra8p1/r7ka8p1kflcac/cm85


### PR DESCRIPTION
Fix the build failure on EK_RA8D1 and update the Renesas RA disk_access test configuration:

- Remove the redundant config files after the main stack size was moved to the project configuration file.

- Remove the extra config files argument in `testcase.yaml`