### PR TITLE
MAINTAINER file: support defer to other areas...

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -89,6 +89,26 @@
 #           files-regex-exclude:
 #             - <regex pattern>
 #             - <regex pattern>
+#           defer-to-other-areas: true
+#
+#         defer-to-other-areas (optional, default false):
+#             When set to true on a file group, signals that the files in
+#             this group are not strictly maintained by this area alone.
+#             If another area also covers the same files without this flag,
+#             that other area's maintainer takes precedence as the PR
+#             assignee, and this area's maintainers are added as reviewers
+#             instead.  When no other area covers the files, this area is
+#             used for assignment as normal.
+#
+#             Typical use case: a subsystem area (e.g. Clock Control) owns
+#             generic driver infrastructure under drivers/clock_control/,
+#             but a platform area (e.g. a Nordic SoC area) also covers the
+#             platform-specific files in that directory.  The subsystem
+#             maintainer can add those platform-specific files to a
+#             file-group with defer-to-other-areas: true so that the
+#             platform maintainer becomes the assignee for PRs touching
+#             those files, while the subsystem maintainer is still
+#             notified as a reviewer.
 #
 #     description: >-
 #         Plain-English description. Describe what the system is about, from an

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1641,6 +1641,14 @@ Documentation Infrastructure:
     - include/zephyr/drivers/clock_control/
     - doc/hardware/peripherals/clock_control.rst
     - samples/drivers/clock_control_*/
+  file-groups:
+    - name: Clock control driver
+      defer-to-other-areas: true
+      files:
+        - drivers/clock_control/clock_control_*.c
+        - drivers/clock_control/Kconfig.*
+        - dts/bindings/clock/
+        - include/zephyr/dt-bindings/clock/
   labels:
     - "area: Clock control"
   tests:

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -108,26 +108,41 @@ Assignee selection
 Assignees are selected from area_counter (areas sorted by descending file
 weight) using the following priority rules:
 
-  1. If exactly one area is matched and it is a meta-area (Documentation,
-     Samples, Tests, Release Notes, Release), that area's maintainers are
-     assigned directly.  Meta-areas are not considered in mixed PRs.
-  2. Areas with a weight of 0 or no maintainers are skipped.
-  3. If the PR author is the area's only maintainer, the area is skipped
+  1. Areas with a weight of 0 or no maintainers are skipped.
+  2. If the PR author is the area's only maintainer, the area is skipped
      (to avoid self-assignment).  If the author is one of several maintainers,
      they are excluded from the candidate list and the remaining maintainers
      are used.
-  4. Non-platform areas (no "Platform" in the area name) take highest
+  3. Non-platform areas (no "Platform" in the area name) take highest
      priority: the first such area's maintainers are inserted at the front
      of the ranked list, and the search stops.
-  5. Platform areas (drivers, boards) are appended as lower-priority
+  4. Platform areas (drivers, boards) are appended as lower-priority
      fallbacks.
+  5. Meta-areas (Documentation, Samples, Tests, Release Notes, Release)
+     are skipped in mixed PRs.
 
 After iterating all areas, the first entry in the ranked list is chosen.
 If the ranking process yielded nothing (e.g. all areas had the author as sole
 maintainer), the maintainer with the highest cumulative file-weight score is
 used as a last resort.
 
-Assignees are only set when the PR currently has no assignee.
+Deferred file-groups
+--------------------
+A file-group in MAINTAINERS.yml may carry ``defer-to-other-areas: true``.
+When a changed file is matched by both a deferred file-group area **and** a
+non-deferred area, the deferred area's maintainers are added to the reviewer
+request instead of being considered for the assignee role.  Only the
+non-deferred area's maintainers are candidates for assignment.
+
+If a file is matched *only* by deferred file-groups and no other area also
+claims it, the deferral has no effect: the area is used normally for
+both assignment and review.
+
+Typical use-case: the Clock Control subsystem marks platform-specific files
+(e.g. ``drivers/clock_control/nrf_*.c``) in a deferred file-group.  A Nordic
+platform area also lists those files without the defer flag.  When a PR
+touches those files the platform maintainer is assigned and the clock-control
+maintainer is added as a reviewer.
 
 Manifest / MAINTAINERS.yml change handling
 -------------------------------------------
@@ -680,6 +695,7 @@ def process_pr(gh, args, maintainer_file, number: int):
     found_maintainers = defaultdict(int)
     collab_per_path = set()
     additional_reviews = set()
+    deferred_reviewers = set()
 
     changed_files = list(pr.get_files())
     num_files = len(changed_files)
@@ -741,6 +757,24 @@ def process_pr(gh, args, maintainer_file, number: int):
         if not areas:
             continue
 
+        # Handle deferred file-groups: when a file is matched by both a
+        # deferred area (file-group with defer-to-other-areas: true) and a
+        # non-deferred area, the deferred area's maintainers become reviewers
+        # only and do not count toward assignee weighting for this file.
+        _deferred = [a for a in areas if a.is_deferred_for_path(filename)]
+        _non_deferred = [a for a in areas if not a.is_deferred_for_path(filename)]
+        if _deferred and _non_deferred:
+            for _area in _deferred:
+                deferred_reviewers.update(_area.maintainers)
+                logger.debug(
+                    "  area '%s' defers to other areas for '%s'; "
+                    "maintainers %s added as reviewers only",
+                    _area.name,
+                    filename,
+                    _area.maintainers,
+                )
+            areas = _non_deferred
+
         # Sort so that Platform (driver/board) areas are processed first.  This
         # sets is_instance=True early, preventing the same file from being
         # counted again for the corresponding subsystem area.
@@ -784,6 +818,7 @@ def process_pr(gh, args, maintainer_file, number: int):
         collab += maintainer_file.areas[area.name].collaborators
     collab += list(collab_per_path)
     collab += list(additional_reviews)
+    collab += sorted(deferred_reviewers)
     # Deduplicate while preserving insertion order.
     collab = list(dict.fromkeys(collab))
     logger.debug("Reviewer candidates: %s", collab)

--- a/scripts/get_maintainer.py
+++ b/scripts/get_maintainer.py
@@ -226,6 +226,8 @@ class Maintainers:
                     file_group.name = group_dict.get("name", "Unnamed Group")
                     file_group.description = group_dict.get("description")
                     file_group.collaborators = group_dict.get("collaborators", [])
+                    file_group.defer_to_other_areas = \
+                        bool(group_dict.get("defer-to-other-areas", False))
 
                     # Create match functions for this file group
                     file_group._match_fn = \
@@ -582,6 +584,25 @@ class Area:
                 return file_group
         return None
 
+    def is_deferred_for_path(self, path):
+        """
+        Returns True if *path* matches this area only through file-groups
+        that have ``defer-to-other-areas: true``.
+
+        When at least one non-deferred file-group (or the area's own
+        top-level patterns) matches the path this method returns False,
+        meaning the area claims normal maintainership for that file.
+        """
+        matched_via_deferred = False
+        for file_group in self.file_groups:
+            if file_group._contains(path):
+                if not getattr(file_group, 'defer_to_other_areas', False):
+                    return False  # non-deferred match wins
+                matched_via_deferred = True
+        # True only if matched solely via deferred file-groups; otherwise
+        # no file-group matched and the path is covered by area-level patterns.
+        return matched_via_deferred
+
     def __repr__(self):
         return "<Area {}>".format(self.name)
 
@@ -764,7 +785,8 @@ def _check_maintainers(maints_path, yaml):
                      .format(area_name))
 
             ok_group_keys = {"name", "description", "collaborators", "files",
-                           "files-exclude", "files-regex", "files-regex-exclude"}
+                           "files-exclude", "files-regex", "files-regex-exclude",
+                           "defer-to-other-areas"}
 
             for i, group_dict in enumerate(file_groups):
                 if not isinstance(group_dict, dict):
@@ -786,6 +808,13 @@ def _check_maintainers(maints_path, yaml):
                     if str_field in group_dict and not isinstance(group_dict[str_field], str):
                         ferr("malformed '{}' in file group {} in area '{}' -- should be a string"
                              .format(str_field, i, area_name))
+
+                # Validate defer-to-other-areas boolean
+                if "defer-to-other-areas" in group_dict:
+                    if not isinstance(group_dict["defer-to-other-areas"], bool):
+                        ferr("malformed 'defer-to-other-areas' in file group {} in area '{}'"
+                             " -- should be a boolean"
+                             .format(i, area_name))
 
                 # Validate list fields in file groups
                 for list_field in ["collaborators", "files", "files-exclude", "files-regex", "files-regex-exclude"]:

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -54,13 +54,26 @@ import set_assignees as sut  # noqa: E402, I001  (import after sys.modules manip
 
 
 class _Area:
-    """Lightweight hashable area stub accepted by _pick_assignees."""
+    """Lightweight hashable area stub accepted by _pick_assignees and process_pr."""
 
     def __init__(self, name, maintainers=None, labels=None, collaborators=None):
         self.name = name
         self.maintainers = list(maintainers or [])
         self.labels = list(labels or [])
         self.collaborators = list(collaborators or [])
+
+    def is_deferred_for_path(self, path):
+        return False
+
+    def get_collaborators_for_path(self, path):
+        return self.collaborators
+
+
+class _DeferredArea(_Area):
+    """Area stub where is_deferred_for_path always returns True."""
+
+    def is_deferred_for_path(self, path):
+        return True
 
 
 def _make_area(name, maintainers=None, labels=None, collaborators=None):
@@ -476,3 +489,145 @@ class TestSetupLogging:
         with patch("logging.basicConfig") as mock_cfg:
             sut.setup_logging(3)
             assert mock_cfg.call_args.kwargs["level"] == logging.DEBUG
+
+
+# ---------------------------------------------------------------------------
+# Deferred file-groups  (process_pr integration)
+# ---------------------------------------------------------------------------
+
+
+def _make_process_pr_harness(areas_per_file, pr_user="someone"):
+    """Return (gh, args, maintainer_file, pr) ready for sut.process_pr().
+
+    *areas_per_file* maps filename strings to lists of _Area (or _DeferredArea)
+    instances.  All GitHub API calls are stubbed; dry_run is False so that
+    create_review_request and add_to_assignees are actually invoked.
+    """
+    pr = MagicMock()
+    pr.draft = False
+    pr.state = "open"
+    pr.commits = 1
+    pr.additions = 5
+    pr.deletions = 0
+    pr.number = 99
+    pr.labels = []
+    pr.user = SimpleNamespace(login=pr_user)
+    pr.assignee = None
+    pr.get_files.return_value = [SimpleNamespace(filename=fn) for fn in areas_per_file]
+    pr.get_reviews.return_value = []
+    pr.get_review_requests.return_value = ([], [])
+    pr.get_issue_events.return_value = []
+
+    mf = MagicMock()
+    mf.path2areas.side_effect = lambda p: areas_per_file.get(p, [])
+    mf.name2areas.return_value = []
+    mf.areas = {}
+    for fname_areas in areas_per_file.values():
+        for area in fname_areas:
+            mf.areas[area.name] = area
+
+    # Use MagicMock for user objects so they are hashable (required by
+    # _add_reviewers which stores them in a set).
+    user_cache = {}
+
+    def _get_user(login):
+        if login not in user_cache:
+            u = MagicMock()
+            u.login = login
+            user_cache[login] = u
+        return user_cache[login]
+
+    gh = MagicMock()
+    gh_repo = MagicMock()
+    gh.get_repo.return_value = gh_repo
+    gh.get_user.side_effect = _get_user
+    gh_repo.get_pull.return_value = pr
+    gh_repo.has_in_collaborators.return_value = True
+
+    args = SimpleNamespace(
+        org="testorg",
+        repo="testrepo",
+        dry_run=False,
+        updated_manifest=None,
+        updated_maintainer_file=None,
+        size_labels=False,
+    )
+    return gh, args, mf, pr
+
+
+def _reviewers_requested(pr):
+    """Collect all logins passed to pr.create_review_request across all calls."""
+    result = []
+    for call in pr.create_review_request.call_args_list:
+        reviewers = call.kwargs.get("reviewers", call.args[0] if call.args else [])
+        result.extend(reviewers)
+    return result
+
+
+def _assignees_set(pr):
+    """Collect all logins passed to pr.add_to_assignees across all calls."""
+    result = []
+    for call in pr.add_to_assignees.call_args_list:
+        if call.args:
+            result.append(call.args[0].login)
+    return result
+
+
+class TestDeferredFileGroups:
+    """Verify defer-to-other-areas file-group behaviour in process_pr."""
+
+    def test_deferred_maintainer_added_as_reviewer(self):
+        """Deferred area maintainer must appear in the review request."""
+        clock_area = _DeferredArea("Clock Control", maintainers=["clock_m"])
+        platform_area = _make_area("Platform: nrf52", maintainers=["platform_m"])
+        areas = {"drivers/clk/nrf.c": [clock_area, platform_area]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "clock_m" in _reviewers_requested(pr)
+
+    def test_deferred_maintainer_not_set_as_assignee(self):
+        """When a non-deferred area covers the same file, the deferred area's
+        maintainer must not become the PR assignee."""
+        clock_area = _DeferredArea("Clock Control", maintainers=["clock_m"])
+        platform_area = _make_area("Platform: nrf52", maintainers=["platform_m"])
+        areas = {"drivers/clk/nrf.c": [clock_area, platform_area]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "clock_m" not in _assignees_set(pr)
+
+    def test_non_deferred_maintainer_becomes_assignee(self):
+        """The non-deferred area's maintainer must be set as the assignee."""
+        clock_area = _DeferredArea("Clock Control", maintainers=["clock_m"])
+        platform_area = _make_area("Platform: nrf52", maintainers=["platform_m"])
+        areas = {"drivers/clk/nrf.c": [clock_area, platform_area]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "platform_m" in _assignees_set(pr)
+
+    def test_exclusively_deferred_area_used_normally(self):
+        """When only a deferred area covers a file (no competing area),
+        the deferral flag has no effect and the maintainer is assigned."""
+        clock_area = _DeferredArea("Clock Control", maintainers=["clock_m"])
+        areas = {"drivers/clk/nrf.c": [clock_area]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "clock_m" in _assignees_set(pr)
+
+    def test_non_deferred_area_unaffected(self):
+        """A normal (non-deferred) area without any competing deferred area
+        works exactly as before."""
+        subsys_area = _make_area("Networking", maintainers=["net_m"])
+        areas = {"subsys/net/foo.c": [subsys_area]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "net_m" in _assignees_set(pr)


### PR DESCRIPTION
Add a new optional boolean field defer-to-other-areas to file-groups in
MAINTAINERS.yml.  When set to true it signals that the files in that
group are not the sole responsibility of the enclosing area: if another
area also covers the same files without the flag, that other area's
maintainer takes precedence as the PR assignee and the deferred area's
maintainers are added as reviewers instead.  When no non-deferred area
covers the files, the deferral has no effect and the area is used for
assignment as normal.

Typical use-case: the Clock Control subsystem owns generic driver
infrastructure under drivers/clock_control/, but a platform area also
covers the platform-specific files there.  The subsystem maintainer
adds those files to a deferred file-group so the platform maintainer
becomes the assignee while the subsystem maintainer is still notified
as a reviewer.
