### PR TITLE
drivers: reset: reset_arm_scmi: Fix missing argument error

### DIFF
--- a/drivers/reset/reset_arm_scmi.c
+++ b/drivers/reset/reset_arm_scmi.c
@@ -94,4 +94,5 @@ static struct scmi_reset_drv_data scmi_reset_data;
 
 DT_INST_SCMI_PROTOCOL_DEFINE(0, &reset_scmi_init, NULL, &scmi_reset_data, NULL,
 			     PRE_KERNEL_1, CONFIG_RESET_INIT_PRIORITY,
-			     &reset_arm_scmi_driver_api, SCMI_RESET_PROTOCOL_SUPPORTED_VERSION);
+			     &reset_arm_scmi_driver_api, SCMI_RESET_PROTOCOL_SUPPORTED_VERSION,
+			     NULL);


### PR DESCRIPTION
Macro DT_INST_SCMI_PROTOCOL_DEFINE() requires 10 arguments, but only 9 were given. This patch adds the missing one.