### PR TITLE
arch: arm: only dump fpu registers if stack has extended frame

### DIFF
--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -29,25 +29,36 @@ static void esf_dump(const struct arch_esf *esf)
 		esf->basic.a4, esf->basic.ip, esf->basic.lr);
 	EXCEPTION_DUMP(" xpsr:  0x%08x", esf->basic.xpsr);
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-	for (int i = 0; i < ARRAY_SIZE(esf->fpu.s); i += 4) {
-		EXCEPTION_DUMP("s[%2d]:  0x%08x  s[%2d]:  0x%08x"
-			"  s[%2d]:  0x%08x  s[%2d]:  0x%08x",
-			i, (uint32_t)esf->fpu.s[i],
-			i + 1, (uint32_t)esf->fpu.s[i + 1],
-			i + 2, (uint32_t)esf->fpu.s[i + 2],
-			i + 3, (uint32_t)esf->fpu.s[i + 3]);
-	}
-#ifdef CONFIG_VFP_FEATURE_REGS_S64_D32
-	for (int i = 0; i < ARRAY_SIZE(esf->fpu.d); i += 4) {
-		EXCEPTION_DUMP("d[%2d]:  0x%16llx  d[%2d]:  0x%16llx"
-			"  d[%2d]:  0x%16llx  d[%2d]:  0x%16llx",
-			i, (uint64_t)esf->fpu.d[i],
-			i + 1, (uint64_t)esf->fpu.d[i + 1],
-			i + 2, (uint64_t)esf->fpu.d[i + 2],
-			i + 3, (uint64_t)esf->fpu.d[i + 3]);
-	}
+	bool extended_frame;
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	extended_frame = ((esf->extra_info.exc_return & EXC_RETURN_STACK_FRAME_TYPE_Msk) ==
+			  EXC_RETURN_STACK_FRAME_TYPE_EXTENDED);
+#else
+	/* assume true when we don't have exc_return info */
+	extended_frame = true;
+	EXCEPTION_DUMP("No EXC_RETURN available; assuming extended FP stack frame");
 #endif
-	EXCEPTION_DUMP("fpscr:  0x%08x", esf->fpu.fpscr);
+	if (extended_frame) {
+		for (int i = 0; i < ARRAY_SIZE(esf->fpu.s); i += 4) {
+			EXCEPTION_DUMP("s[%2d]:  0x%08x  s[%2d]:  0x%08x"
+				       "  s[%2d]:  0x%08x  s[%2d]:  0x%08x",
+				       i, (uint32_t)esf->fpu.s[i],
+				       i + 1, (uint32_t)esf->fpu.s[i + 1],
+				       i + 2, (uint32_t)esf->fpu.s[i + 2],
+				       i + 3, (uint32_t)esf->fpu.s[i + 3]);
+		}
+#ifdef CONFIG_VFP_FEATURE_REGS_S64_D32
+		for (int i = 0; i < ARRAY_SIZE(esf->fpu.d); i += 4) {
+			EXCEPTION_DUMP("d[%2d]:  0x%16llx  d[%2d]:  0x%16llx"
+				       "  d[%2d]:  0x%16llx  d[%2d]:  0x%16llx",
+				       i, (uint64_t)esf->fpu.d[i],
+				       i + 1, (uint64_t)esf->fpu.d[i + 1],
+				       i + 2, (uint64_t)esf->fpu.d[i + 2],
+				       i + 3, (uint64_t)esf->fpu.d[i + 3]);
+		}
+#endif
+		EXCEPTION_DUMP("fpscr:  0x%08x", esf->fpu.fpscr);
+	}
 #endif
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
 	const struct _callee_saved *callee = esf->extra_info.callee;


### PR DESCRIPTION
Check the exc_return flags to determine if the FPU registers were actually pushed onto the stack by the exception handler and only dump them if they are used. Otherwise the stack locations for the FPU registers are invalid and we're just dumping garbage.