### PR TITLE
Add TI TDP2004 DisplayPort and HDMI linear redriver support

### DIFF
--- a/boards/renesas/rcar_ironhide_x5h/rcar_ironhide_x5h_r8a78000_r52-pinctrl.dtsi
+++ b/boards/renesas/rcar_ironhide_x5h/rcar_ironhide_x5h_r8a78000_r52-pinctrl.dtsi
@@ -45,6 +45,11 @@
 		bias-disable;
 	};
 
+	gpio9_14_default: gpio9_14_default {
+		pin = <PIN_RSW3_PPS>;
+		bias-disable;
+	};
+
 	i2c5_scl_default: i2c5_scl_default {
 		pin = <PIN_SCL5 FUNC_SCL5>;
 	};

--- a/boards/renesas/rcar_ironhide_x5h/rcar_ironhide_x5h_r8a78000_r52.dts
+++ b/boards/renesas/rcar_ironhide_x5h/rcar_ironhide_x5h_r8a78000_r52.dts
@@ -94,7 +94,8 @@
 &gpio9 {
 	pinctrl-0 = <&gpio9_3_default
 		     &gpio9_4_default
-		     &gpio9_5_default>;
+		     &gpio9_5_default
+		     &gpio9_14_default>;
 	pinctrl-names = "default";
 	status = "okay";
 };
@@ -105,4 +106,10 @@
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
+
+	dp_redriver_0: displayport-redriver@18 {
+		compatible = "ti,tdp2004";
+		reg = <0x18>;
+		pd-gpios = <&gpio9 14 GPIO_ACTIVE_HIGH>;
+	};
 };

--- a/drivers/misc/CMakeLists.txt
+++ b/drivers/misc/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory_ifdef(CONFIG_RENESAS_RA_EXTERNAL_INTERRUPT renesas_ra_external_
 add_subdirectory_ifdef(CONFIG_RENESAS_RX_DTC renesas_rx_dtc)
 add_subdirectory_ifdef(CONFIG_RENESAS_RX_EXTERNAL_INTERRUPT renesas_rx_external_interrupt)
 add_subdirectory_ifdef(CONFIG_STM32N6_AXISRAM stm32n6_axisram)
+add_subdirectory_ifdef(CONFIG_TI_TDP2004 ti_tdp2004)
 # zephyr-keep-sorted-stop
 
 add_subdirectory(interconn)

--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -25,6 +25,7 @@ source "drivers/misc/renesas_ra_external_interrupt/Kconfig"
 source "drivers/misc/renesas_rx_dtc/Kconfig"
 source "drivers/misc/renesas_rx_external_interrupt/Kconfig"
 source "drivers/misc/stm32n6_axisram/Kconfig"
+source "drivers/misc/ti_tdp2004/Kconfig"
 # zephyr-keep-sorted-stop
 
 endmenu

--- a/drivers/misc/ti_tdp2004/CMakeLists.txt
+++ b/drivers/misc/ti_tdp2004/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 BayLibre, SAS
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(ti_tdp2004.c)

--- a/drivers/misc/ti_tdp2004/Kconfig
+++ b/drivers/misc/ti_tdp2004/Kconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 BayLibre, SAS
+# SPDX-License-Identifier: Apache-2.0
+
+config TI_TDP2004
+	bool "TDP2004 Four-Channel 20Gbps DisplayPort 2.1 and 12Gbps HDMI2.1 Linear Redriver"
+	default y
+	depends on DT_HAS_TI_TDP2004_ENABLED
+	select GPIO
+	select I2C
+	help
+	  The TDP2004 is a four-channel linear repeater or redriver designed
+	  to support DisplayPort 2.1 up to 20Gbps and AC coupled HDMI2.1 source
+	  up to 12Gbps.
+
+if TI_TDP2004
+
+module = TI_TDP2004
+module-str = TI TDP2004 DisplayPort and HDMI linear redriver
+source "subsys/logging/Kconfig.template.log_config"
+
+config TI_TDP2004_INIT_PRIORITY
+	int "TI TDP2004 init priority"
+	default I2C_INIT_PRIORITY
+	help
+	  The init priority of the TI TDP2004 redriver.
+
+endif # TI_TDP2004

--- a/drivers/misc/ti_tdp2004/ti_tdp2004.c
+++ b/drivers/misc/ti_tdp2004/ti_tdp2004.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 BayLibre, SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ti_tdp2004
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util_macro.h>
+
+LOG_MODULE_REGISTER(ti_tdp2004, CONFIG_TI_TDP2004_LOG_LEVEL);
+
+#define TI_TDP2004_TEST_MODE_REG 0x84
+#define TI_TDP2004_TEST_MODE_DISABLE BIT(2)
+
+struct ti_tdp2004_config {
+	struct gpio_dt_spec redriver_pd_gpio;
+	struct i2c_dt_spec redriver_dev;
+};
+
+static int ti_tdp2004_init(const struct device *dev)
+{
+	const struct ti_tdp2004_config *cfg = dev->config;
+	const uint8_t redriver_tx_buf[] = {TI_TDP2004_TEST_MODE_REG, TI_TDP2004_TEST_MODE_DISABLE};
+	int ret;
+
+	if (!gpio_is_ready_dt(&cfg->redriver_pd_gpio)) {
+		LOG_ERR("Redriver power GPIO not ready");
+		return -ENODEV;
+	}
+
+	if (!i2c_is_ready_dt(&cfg->redriver_dev)) {
+		LOG_ERR("Redriver I2C bus not ready");
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&cfg->redriver_pd_gpio, GPIO_OUTPUT_INACTIVE);
+	if (ret) {
+		LOG_ERR("Failed to configure redriver power GPIO (%d)", ret);
+		return ret;
+	}
+
+	ret = i2c_write_dt(&cfg->redriver_dev, redriver_tx_buf, sizeof(redriver_tx_buf));
+	if (ret) {
+		LOG_ERR("Failed to disable redriver test mode (%d)", ret);
+	}
+
+	return ret;
+}
+
+#define TI_TDP2004_INIT(n)						\
+	static const struct ti_tdp2004_config ti_tdp2004_config##n = {	\
+		.redriver_pd_gpio = GPIO_DT_SPEC_INST_GET(n, pd_gpios),	\
+		.redriver_dev = I2C_DT_SPEC_INST_GET(n)};		\
+									\
+	DEVICE_DT_INST_DEFINE(n,					\
+			      &ti_tdp2004_init,				\
+			      NULL,					\
+			      NULL,					\
+			      &ti_tdp2004_config##n,			\
+			      POST_KERNEL,				\
+			      CONFIG_TI_TDP2004_INIT_PRIORITY,		\
+			      NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(TI_TDP2004_INIT)

--- a/dts/bindings/misc/ti,tdp2004.yaml
+++ b/dts/bindings/misc/ti,tdp2004.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 BayLibre, SAS
+# SPDX-License-Identifier: Apache-2.0
+
+description: TI Four-Channel 20Gbps DisplayPort 2.1 and 12Gbps HDMI2.1 Linear Redriver.
+
+compatible: "ti,tdp2004"
+
+include: i2c-device.yaml
+
+properties:
+  pd-gpios:
+    type: phandle-array
+    description: Phandle to the GPIO used to power down/up the redriver.
+    required: true
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/gpio/gpio.h>
+    #include <zephyr/dt-bindings/i2c/i2c.h>
+
+    &i2c5 {
+      dp_redriver_0: displayport-redriver@18 {
+        compatible = "ti,tdp2004";
+        reg = <0x18>;
+        pd-gpios = <&gpio9 14 GPIO_ACTIVE_HIGH>;
+      };
+    };


### PR DESCRIPTION
2 commits are introduced:
- The TI TDP2004 driver (misc API, since it does not fit in any standard sub-system).
- The device tree patch for the R-Car Gen5 board, which uses this device.
