### PR TITLE
lib: os: p4wq: skip k_thread_cpu_mask_clear() in PIN_ONLY mode

### DIFF
--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -176,7 +176,7 @@ static int static_init(void)
 					  &pp->stacks[ssz * i],
 					  pp->stack_size);
 
-#ifdef CONFIG_SCHED_CPU_MASK
+#if defined(CONFIG_SCHED_CPU_MASK) && !defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY)
 			if (pp->flags & K_P4WQ_USER_CPU_MASK) {
 				int ret = k_thread_cpu_mask_clear(&pp->threads[i]);
 
@@ -196,6 +196,16 @@ void k_p4wq_enable_static_thread(struct k_p4wq *queue, struct k_thread *thread,
 {
 #ifdef CONFIG_SCHED_CPU_MASK
 	if (queue->flags & K_P4WQ_USER_CPU_MASK) {
+#ifdef CONFIG_SCHED_CPU_MASK_PIN_ONLY
+		__ASSERT(cpu_mask != 0 && (cpu_mask & (cpu_mask - 1)) == 0,
+			 "PIN_ONLY requires exactly one CPU in mask");
+		int cpu = (int)u32_count_trailing_zeros(cpu_mask);
+		int ret = k_thread_cpu_pin(thread, cpu);
+
+		if (ret < 0) {
+			LOG_ERR("Couldn't pin thread to CPU%d: %d", cpu, ret);
+		}
+#else
 		unsigned int i;
 
 		while ((i = find_lsb_set(cpu_mask))) {
@@ -206,8 +216,9 @@ void k_p4wq_enable_static_thread(struct k_p4wq *queue, struct k_thread *thread,
 			}
 			cpu_mask &= ~BIT(i - 1);
 		}
+#endif /* CONFIG_SCHED_CPU_MASK_PIN_ONLY */
 	}
-#endif
+#endif /* CONFIG_SCHED_CPU_MASK */
 
 	if (queue->flags & K_P4WQ_DELAYED_START) {
 		k_thread_start(thread);


### PR DESCRIPTION
In CONFIG_SCHED_CPU_MASK_PIN_ONLY mode a thread must always have exactly one CPU bit set in its mask.  The static_init() code was unconditionally calling k_thread_cpu_mask_clear() for threads with K_P4WQ_USER_CPU_MASK, which zeroes the mask and violates the PIN_ONLY invariant.

After commit 7798570a031d this violation triggers an assertion in cpu_mask_mod(), preventing SOF (and any other PIN_ONLY user of p4wq with USER_CPU_MASK) from booting.

Fix by guarding the k_thread_cpu_mask_clear() call with !CONFIG_SCHED_CPU_MASK_PIN_ONLY.  Under PIN_ONLY the thread keeps its default pin (CPU 0) until k_p4wq_enable_static_thread() sets the real affinity via k_thread_cpu_pin().

Fixes: 7798570a031d ("kernel: sched: enforce non-zero CPU mask invariant in PIN_ONLY mode")