### PR TITLE
stm32: run the memc samples on mspi psram0

### DIFF
--- a/samples/drivers/memc/boards/b_u585i_iot02a_mspi_aps6408l.overlay
+++ b/samples/drivers/memc/boards/b_u585i_iot02a_mspi_aps6408l.overlay
@@ -35,6 +35,7 @@
 				     &octospim_p1_dqs_pe3>;
 			pinctrl-names = "default";
 			st,csbound = <3>;
+			st,dqs-port = <1>;
 			status = "okay";
 
 			memc: aps6408l: memory@0 {

--- a/samples/drivers/memc/boards/stm32h7s78_dk_mspi_psram.overlay
+++ b/samples/drivers/memc/boards/stm32h7s78_dk_mspi_psram.overlay
@@ -50,7 +50,7 @@
 				address-length = "ADDR_4_BYTE";
 				rx-dummy = <5>;
 				tx-dummy = <5>;
-				xip-config = <1 0 0 0>;
+				xip-config = <1 0 DT_SIZE_M(32) 0>;
 				ce-break-config = <1024 3>;
 				aps-version = "APS256";
 			};

--- a/samples/drivers/memc/tests.yaml
+++ b/samples/drivers/memc/tests.yaml
@@ -19,16 +19,19 @@ tests:
     integration_platforms:
       - apollo3p_evb
       - apollo510_evb
+    platform_exclude:
+      - stm32h7s78_dk
+      - b_u585i_iot02a
   sample.drivers.memc.stm32_mspi:
     tags: mspi
     platform_allow:
-      - b_u585i_iot02a
-      - stm32h7s78_dk
+      - b_u585i_iot02a/stm32u585xx
+      - stm32h7s78_dk/stm32h7s7xx
     integration_platforms:
       - b_u585i_iot02a
       - stm32h7s78_dk
     extra_args:
       - platform:b_u585i_iot02a/stm32u585xx:DTC_OVERLAY_FILE=boards/b_u585i_iot02a_mspi_aps6408l.overlay
       - platform:b_u585i_iot02a/stm32u585xx:EXTRA_CONF_FILE=boards/b_u585i_iot02a_mspi_aps6408l.conf
-      - platform:stm32h7s78_dk/stm32h7s78xx:CONF_FILE=boards/stm32h7s78_dk_mspi_psram.conf
-      - platform:stm32h7s78_dk/stm32h7s78xx:DTC_OVERLAY_FILE=boards/stm32h7s78_dk_mspi_psram.overlay
+      - platform:stm32h7s78_dk/stm32h7s7xx:CONF_FILE=boards/stm32h7s78_dk_mspi_psram.conf
+      - platform:stm32h7s78_dk/stm32h7s7xx:DTC_OVERLAY_FILE=boards/stm32h7s78_dk_mspi_psram.overlay


### PR DESCRIPTION
Fix the error when running the samples/drivers/memc on the MSPI psram0 of the **b_u585i_iot02a** target board
```
[00:00:00.000,000] <inf> ospi_stm32: MSPI config result: success
[00:00:05.001,000] <err> ospi_stm32: Failed to access data
[00:00:05.001,000] <err> memc_mspi_aps_z8: MSPI read transaction failed with code: -5/159
[00:00:05.001,000] <err> memc_mspi_aps_z8: Could not read vendor id/517
*** Booting Zephyr OS build v4.4.0-5598-gfc083043ac0e ***
Writing to memory region with base 0x90000000, size 0x800000
```



Expected result : 
```
... 88 89 8a 8b 8c 8d 8e 8f
90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f
a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aa ab ac ad ae af
b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 ba bb bc bd be bf
c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 ca cb cc cd ce cf
d0 d1 d2 d3 d4 d5 d6 d7 d8 d9 da db dc dd de df
e0 e1 e2 e3 e4 e5 e6 e7 e8 e9 ea eb ec ed ee ef
f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff


Read data matches written data 
```