### PR TITLE
doc: remove invalid SNIPPET instruction

### DIFF
--- a/doc/build/snippets/using.rst
+++ b/doc/build/snippets/using.rst
@@ -37,17 +37,3 @@ snippet names you want to use. For example:
 
    cmake -Sapp -Bbuild -DSNIPPET="snippet1;snippet2" [...]
    cmake --build build
-
-Application required snippets
-*****************************
-
-If an application should always be compiled with a given snippet, it
-can be added to that application's ``CMakeLists.txt`` file. For example:
-
-.. code-block:: cmake
-
-   if(NOT snippet1 IN_LIST SNIPPET)
-     set(SNIPPET snippet1 ${SNIPPET} CACHE STRING "" FORCE)
-   endif()
-
-   find_package(Zephyr ....)


### PR DESCRIPTION
The instructions using `set(SNIPPET ...)` is not correct.

The use described is not an officially supported feature and therefore has never been tested.
The functionality doesn't work as documented in all cases.

A couple of issues with the approach described, and why it's not a supported use-case:
It sets cache variable directly in sample, but snippet feature fetches settings using zephyr_get().
`zephyr_get()` fetches settings from sysbuild when sysbuild is used, and where sysbuild fetched value takes precedence.
For example in code: `set(SNIPPET foo ...)`, first run
```
$ west build ... <sample> --sysbuild -- DSNIPPET=bar
   *********************************
   * Running CMake for <sample>*
   *********************************
...
-- Snippet(s): bar
...
```
but on CMake re-runs:
```
CMake Warning at /projects/github/ncs/zephyr/cmake/modules/extensions.cmake:3653 (message):
  The build directory must be cleaned pristinely when changing snippet,
  Current value="bar", Ignored value="foo;bar"
```

whereas running without sysbuild results in:
```
$ west build ... <sample> --no-sysbuild -- -DSNIPPET=bar
-- Snippet(s): foo bar
```

Snippet feature was a user intended feature, and never intended for samples to specify as `always use`.

Compared to a feature like `CONF_FILE` which is populated as described in https://docs.zephyrproject.org/latest/build/kconfig/setting.html#the-initial-configuration, and any user applied `-DCONF_FILE=<file>` opt-outs of that behavior.
In addition, `CONF_FILE` supports an `EXTRA_CONF_FILE`, where default files are still picked up.
Same applies to `DTC_OVERLAY_FILE`.

If something similar is desired for snippets, then a proper feature request --> implementation cycle is needed, and not by documenting what seems to work in a narrow use-case, but fails in other cases.
