### PR TITLE
scripts: zspdx: add SPDX 3.0 Build profile support

### DIFF
--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -75,12 +75,26 @@ See :zephyr_file:`share/zephyr-package/cmake` for details.
 Software bill of materials: ``west spdx``
 *****************************************
 
-This command generates SPDX documents (2.2, 2.3 tag-value format, or 3.0 JSON-LD format),
-creating relationships from source files to the corresponding generated build files.
-``SPDX-License-Identifier`` comments in source files are scanned and filled
-into the SPDX documents.
+This command generates a Software Bill of Materials (SBOM) for a Zephyr build as a set of `SPDX`_
+documents. It records the source files that went into the build, the build artifacts they produced,
+and the relationships between them. ``SPDX-License-Identifier`` comments found in source files are
+scanned and filled into the documents, together with file hashes and (best-effort) copyright
+notices.
 
-To use this command:
+.. _west-spdx-versions:
+
+Choosing an SPDX version
+------------------------
+
+``west spdx`` can emit either of the two major SPDX specification families. SPDX 2.3 is the default;
+select another version with the ``--spdx-version`` option.
+
+SPDX 2.3 is a superset of 2.2 and adds fields such as ``PrimaryPackagePurpose``. Pick SPDX 2.x for
+compatibility with tooling that does not yet understand SPDX 3.0; pick SPDX 3.0 for the richer,
+machine-readable build provenance described in :ref:`west-spdx-build-profile`.
+
+Generating SPDX documents
+-------------------------
 
 #. Pre-populate a build directory :file:`BUILD_DIR` like this:
 
@@ -88,10 +102,10 @@ To use this command:
 
       west spdx --init -d BUILD_DIR
 
-   This step ensures the build directory contains CMake metadata required for
-   SPDX document generation.
+   This step ensures the build directory contains the CMake metadata (a CMake file-API query)
+   required for SPDX document generation.
 
-#. Enable :file:`CONFIG_BUILD_OUTPUT_META` in your project.
+#. Enable :kconfig:option:`CONFIG_BUILD_OUTPUT_META` in your project.
 
 #. Build your application using this pre-created build directory, like so:
 
@@ -105,8 +119,8 @@ To use this command:
 
       west spdx -d BUILD_DIR
 
-   By default, this generates SPDX 2.3 tag-value documents. To generate SPDX 2.2 or 3.0 documents
-   instead, use the ``--spdx-version`` option. For example:
+   This generates SPDX 2.3 tag-value documents by default. To generate SPDX 2.2
+   or 3.0 documents instead, pass ``--spdx-version``:
 
    .. code-block:: bash
 
@@ -124,20 +138,23 @@ To use this command:
      west build -d BUILD_DIR/hello_world
      west spdx -d BUILD_DIR/hello_world
 
-This generates the following SPDX bill-of-materials (BOM) documents in
-:file:`BUILD_DIR/spdx/`:
+Output documents
+----------------
 
-**For SPDX 2.x (tag-value format):**
+The documents are written to :file:`BUILD_DIR/spdx/` (override with ``-s``). The same set of
+bill-of-materials (BOM) documents is produced regardless of the SPDX version; only the file
+extension differs: ``.spdx`` for the SPDX 2.x tag-value format and ``.jsonld`` for the SPDX 3.0
+JSON-LD format:
 
-- :file:`app.spdx`: BOM for the application source files used for the build
-- :file:`zephyr.spdx`: BOM for the specific Zephyr source code files used for the build
-- :file:`build.spdx`: BOM for the built output files
-- :file:`modules-deps.spdx`: BOM for modules dependencies. Check
-  :ref:`modules <modules-vulnerability-monitoring>` for more details.
+- ``app``: BOM for the application source files used for the build
+- ``zephyr``: BOM for the specific Zephyr source code files used for the build
+- ``build``: BOM for the built output files
+- ``modules-deps``: BOM for modules dependencies. Check :ref:`modules
+  <modules-vulnerability-monitoring>` for more details.
 
-**For SPDX 3.0 (JSON-LD format):**
-
-Same file names as above, but with the ``.jsonld`` extension.
+For SPDX 3.0, every document declares conformance to the Core, Software and Simple Licensing
+profiles, and :file:`build.jsonld` additionally declares the :ref:`Build profile
+<west-spdx-build-profile>` that captures how the artifacts were produced.
 
 Each file in the bill-of-materials is scanned, so that its hashes (SHA256, SHA1, and MD5)
 can be recorded, along with any detected licenses if an
@@ -151,9 +168,43 @@ or copyright properties (SPDX 3.0).
    Copyright extraction uses heuristics that may not capture complete notice text, so
    ``FileCopyrightText`` content is best-effort. This aligns with SPDX specification recommendations.
 
-SPDX Relationships are created to indicate dependencies between
-CMake build targets, build targets that are linked together, and
-source files that are compiled to generate the built library files.
+Relationships
+-------------
+
+SPDX relationships are created to indicate dependencies between CMake build targets, build targets
+that are linked together, and source files that are compiled to generate the built library files.
+
+The two specification families express build provenance differently:
+
+- In **SPDX 2.x**, each generated artifact carries file-level ``GENERATED_FROM`` relationships
+  pointing back at the source (and, with ``--analyze-includes``, header) files it was compiled from.
+
+- In **SPDX 3.0**, that provenance is carried by the :ref:`Build profile <west-spdx-build-profile>`
+  instead, using ``hasInput``/``hasOutput``/``usesTool`` relationships scoped to the ``build``
+  lifecycle.
+
+.. _west-spdx-build-profile:
+
+Build profile (SPDX 3.0)
+------------------------
+
+When generating SPDX 3.0 documents, ``west spdx`` populates the `SPDX 3.0 Build profile`_ so the
+SBOM records not just *what* was built but *how* it was built. The information is collected
+automatically from the CMake file-API, and lives in :file:`build.jsonld`.
+
+The profile adds a ``build_Build`` element describing the overall build: its build type, the CMake
+generator and build configuration, and selected environment variables such as ``BOARD`` and
+``ARCH``. The toolchain (CMake, the compilers, assembler, linker and archiver) is recorded as
+``Tool`` elements, each with its path and version. Build-scoped relationships then link the build to
+its inputs (the source packages and compiled files), its outputs (the final image) and the tools it
+used.
+
+Each intermediate target, such as a static library, also gets its own sub-build capturing the exact
+sources, tools and compile flags that produced its artifact, so any output can be traced back to how
+it was built.
+
+Command-line options
+--------------------
 
 ``west spdx`` accepts these additional options:
 
@@ -166,8 +217,8 @@ source files that are compiled to generate the built library files.
   should be written instead of :file:`BUILD_DIR/spdx/`.
 
 - ``--spdx-version {2.2,2.3,3.0}``: specifies which SPDX specification version to use.
-  Defaults to ``2.3``. SPDX 2.3 includes additional fields like ``PrimaryPackagePurpose``
-  that are not available in SPDX 2.2. SPDX 3.0 generates JSON-LD format documents.
+  Defaults to ``2.3``. See :ref:`west-spdx-versions` for the differences between
+  the versions.
 
 - ``--analyze-includes``: in addition to recording the compiled source code
   files (e.g. ``.c``, ``.S``) in the bills-of-materials, also attempt to
@@ -178,11 +229,17 @@ source files that are compiled to generate the built library files.
   build.
 
 - ``--include-sdk``: with ``--analyze-includes``, also create a fourth SPDX
-  document, :file:`sdk.spdx`, which lists header files included from the SDK.
+  document, :file:`sdk.spdx` (or :file:`sdk.jsonld`), which lists header files
+  included from the SDK.
 
 .. warning::
 
    The generation of SBOM documents for the ``native_sim`` platform is currently not supported.
+
+.. _SPDX: https://spdx.dev/
+
+.. _SPDX 3.0 Build profile:
+   https://spdx.github.io/spdx-spec/v3.0.1/model/Build/Build/
 
 .. _SPDX specification clause 6:
    https://spdx.github.io/spdx-spec/v2.2.2/document-creation-information/

--- a/scripts/pylib/zspdx/cmakefileapi.py
+++ b/scripts/pylib/zspdx/cmakefileapi.py
@@ -2,30 +2,45 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 from enum import Enum
 
 
+@dataclass
 class Codemodel:
-    def __init__(self):
-        super().__init__()
+    """Root of the CMake file-API codemodel-v2 reply.
 
-        self.paths_source = ""
-        self.paths_build = ""
-        self.configurations = []
+    Attributes:
+        paths_source: Absolute path to the top-level CMake source directory.
+        paths_build: Absolute path to the top-level CMake build directory.
+        configurations: Parsed build configurations, one per generator configuration.
+    """
+
+    paths_source: str = ""
+    paths_build: str = ""
+    configurations: list[Config] = field(default_factory=list)
 
     def __repr__(self):
         return f"Codemodel: source {self.paths_source}, build {self.paths_build}"
 
 
-# A member of the codemodel configurations array
+@dataclass
 class Config:
-    def __init__(self):
-        super().__init__()
+    """A member of the codemodel configurations array.
 
-        self.name = ""
-        self.directories = []
-        self.projects = []
-        self.config_targets = []
+    Attributes:
+        name: Configuration name (e.g. ``"Debug"``), or empty for single-config generators.
+        directories: Directories that make up this configuration.
+        projects: Projects that make up this configuration.
+        config_targets: Targets that make up this configuration.
+    """
+
+    name: str = ""
+    directories: list[ConfigDir] = field(default_factory=list)
+    projects: list[ConfigProject] = field(default_factory=list)
+    config_targets: list[ConfigTarget] = field(default_factory=list)
 
     def __repr__(self):
         if self.name == "":
@@ -34,75 +49,107 @@ class Config:
             return f"Config: {self.name}"
 
 
-# A member of the configuration.directories array
+@dataclass
 class ConfigDir:
-    def __init__(self):
-        super().__init__()
+    """A member of the configuration.directories array.
 
-        self.source = ""
-        self.build = ""
-        self.parent_index = -1
-        self.child_indexes = []
-        self.project_index = -1
-        self.target_indexes = []
-        self.minimum_cmake_version = ""
-        self.has_install_rule = False
+    Attributes:
+        source: Absolute path to the directory's source tree.
+        build: Absolute path to the directory's build tree.
+        parent_index: Index of the parent directory in the configuration, or -1 if none.
+        child_indexes: Indexes of child directories in the configuration.
+        project_index: Index of the owning project in the configuration.
+        target_indexes: Indexes of targets defined in this directory.
+        minimum_cmake_version: Minimum CMake version required by this directory, if specified.
+        has_install_rule: Whether this directory (or a subdirectory) has an install rule.
+        parent: Parent directory, resolved from parent_index after loading.
+        children: Child directories, resolved from child_indexes after loading.
+        project: Owning project, resolved from project_index after loading.
+        targets: Targets defined in this directory, resolved from target_indexes after loading.
+    """
 
-        # actual items, calculated from indices after loading
-        self.parent = None
-        self.children = []
-        self.project = None
-        self.targets = []
+    source: str = ""
+    build: str = ""
+    parent_index: int = -1
+    child_indexes: list[int] = field(default_factory=list)
+    project_index: int = -1
+    target_indexes: list[int] = field(default_factory=list)
+    minimum_cmake_version: str = ""
+    has_install_rule: bool = False
+
+    parent: ConfigDir | None = None
+    children: list[ConfigDir] = field(default_factory=list)
+    project: ConfigProject | None = None
+    targets: list[ConfigTarget] = field(default_factory=list)
 
     def __repr__(self):
         return f"ConfigDir: source {self.source}, build {self.build}"
 
 
-# A member of the configuration.projects array
+@dataclass
 class ConfigProject:
-    def __init__(self):
-        super().__init__()
+    """A member of the configuration.projects array.
 
-        self.name = ""
-        self.parent_index = -1
-        self.child_indexes = []
-        self.directory_indexes = []
-        self.target_indexes = []
+    Attributes:
+        name: Project name.
+        parent_index: Index of the parent project in the configuration, or -1 if none.
+        child_indexes: Indexes of child projects in the configuration.
+        directory_indexes: Indexes of directories that belong to this project.
+        target_indexes: Indexes of targets that belong to this project.
+        parent: Parent project, resolved from parent_index after loading.
+        children: Child projects, resolved from child_indexes after loading.
+        directories: Directories belonging to this project, resolved from directory_indexes.
+        targets: Targets belonging to this project, resolved from target_indexes after loading.
+    """
 
-        # actual items, calculated from indices after loading
-        self.parent = None
-        self.children = []
-        self.directories = []
-        self.targets = []
+    name: str = ""
+    parent_index: int = -1
+    child_indexes: list[int] = field(default_factory=list)
+    directory_indexes: list[int] = field(default_factory=list)
+    target_indexes: list[int] = field(default_factory=list)
+
+    parent: ConfigProject | None = None
+    children: list[ConfigProject] = field(default_factory=list)
+    directories: list[ConfigDir] = field(default_factory=list)
+    targets: list[ConfigTarget] = field(default_factory=list)
 
     def __repr__(self):
         return f"ConfigProject: {self.name}"
 
 
-# A member of the configuration.config_targets array
+@dataclass
 class ConfigTarget:
-    def __init__(self):
-        super().__init__()
+    """A member of the configuration.config_targets array.
 
-        self.name = ""
-        self.id = ""
-        self.directory_index = -1
-        self.project_index = -1
-        self.json_file = ""
+    Attributes:
+        name: Target name.
+        id: Target's unique CMake file-API ID.
+        directory_index: Index of the directory that defines this target.
+        project_index: Index of the project that owns this target.
+        json_file: Path to the target's own JSON reply file, relative to the reply directory.
+        target: Full target data, loaded from json_file.
+        directory: Owning directory, resolved from directory_index after loading.
+        project: Owning project, resolved from project_index after loading.
+    """
 
-        # actual target data, loaded from self.json_file
-        self.target = None
+    name: str = ""
+    id: str = ""
+    directory_index: int = -1
+    project_index: int = -1
+    json_file: str = ""
 
-        # actual items, calculated from indices after loading
-        self.directory = None
-        self.project = None
+    target: Target | None = None
+
+    directory: ConfigDir | None = None
+    project: ConfigProject | None = None
 
     def __repr__(self):
         return f"ConfigTarget: {self.name}"
 
 
-# The available values for Target.type
 class TargetType(Enum):
+    """The available values for Target.type."""
+
     UNKNOWN = 0
     EXECUTABLE = 1
     STATIC_LIBRARY = 2
@@ -112,196 +159,267 @@ class TargetType(Enum):
     UTILITY = 6
 
 
-# A member of the target.install_destinations array
+@dataclass
 class TargetInstallDestination:
-    def __init__(self):
-        super().__init__()
+    """A member of the target.install_destinations array.
 
-        self.path = ""
-        self.backtrace = -1
+    Attributes:
+        path: Absolute install destination path.
+        backtrace: Index into the target's backtrace graph, or -1 if none.
+    """
+
+    path: str = ""
+    backtrace: int = -1
 
     def __repr__(self):
         return f"TargetInstallDestination: {self.path}"
 
 
-# A member of the target.link_command_fragments and
-# archive_command_fragments array
+@dataclass
 class TargetCommandFragment:
-    def __init__(self):
-        super().__init__()
+    """A member of the target.link_command_fragments and archive_command_fragments arrays.
 
-        self.fragment = ""
-        self.role = ""
+    Attributes:
+        fragment: Command-line fragment text.
+        role: Role of the fragment (e.g. ``"flags"``, ``"libraries"``).
+    """
+
+    fragment: str = ""
+    role: str = ""
 
     def __repr__(self):
         return f"TargetCommandFragment: {self.fragment}"
 
 
-# A member of the target.dependencies array
+@dataclass
 class TargetDependency:
-    def __init__(self):
-        super().__init__()
+    """A member of the target.dependencies array.
 
-        self.id = ""
-        self.backtrace = -1
+    Attributes:
+        id: CMake file-API ID of the target this target depends on.
+        backtrace: Index into the target's backtrace graph, or -1 if none.
+    """
+
+    id: str = ""
+    backtrace: int = -1
 
     def __repr__(self):
         return f"TargetDependency: {self.id}"
 
 
-# A member of the target.sources array
+@dataclass
 class TargetSource:
-    def __init__(self):
-        super().__init__()
+    """A member of the target.sources array.
 
-        self.path = ""
-        self.compile_group_index = -1
-        self.source_group_index = -1
-        self.is_generated = False
-        self.backtrace = -1
+    Attributes:
+        path: Source file path, relative to the top-level source directory.
+        compile_group_index: Index of this source's compile group, or -1 if not compiled.
+        source_group_index: Index of this source's source group, or -1 if none.
+        is_generated: Whether this is a generated (not authored) source file.
+        backtrace: Index into the target's backtrace graph, or -1 if none.
+        compile_group: Compile group, resolved from compile_group_index after loading.
+        source_group: Source group, resolved from source_group_index after loading.
+    """
 
-        # actual items, calculated from indices after loading
-        self.compile_group = None
-        self.source_group = None
+    path: str = ""
+    compile_group_index: int = -1
+    source_group_index: int = -1
+    is_generated: bool = False
+    backtrace: int = -1
+
+    compile_group: TargetCompileGroup | None = None
+    source_group: TargetSourceGroup | None = None
 
     def __repr__(self):
         return f"TargetSource: {self.path}"
 
 
-# A member of the target.source_groups array
+@dataclass
 class TargetSourceGroup:
-    def __init__(self):
-        super().__init__()
+    """A member of the target.source_groups array.
 
-        self.name = ""
-        self.source_indexes = []
+    Attributes:
+        name: Source group name.
+        source_indexes: Indexes of the sources in this group.
+        sources: Sources in this group, resolved from source_indexes after loading.
+    """
 
-        # actual items, calculated from indices after loading
-        self.sources = []
+    name: str = ""
+    source_indexes: list[int] = field(default_factory=list)
+
+    sources: list[TargetSource] = field(default_factory=list)
 
     def __repr__(self):
         return f"TargetSourceGroup: {self.name}"
 
 
-# A member of the target.compile_groups.includes array
+@dataclass
 class TargetCompileGroupInclude:
-    def __init__(self):
-        super().__init__()
+    """A member of the target.compile_groups.includes array.
 
-        self.path = ""
-        self.is_system = False
-        self.backtrace = -1
+    Attributes:
+        path: Include directory path.
+        is_system: Whether this is a system include directory.
+        backtrace: Index into the target's backtrace graph, or -1 if none.
+    """
+
+    path: str = ""
+    is_system: bool = False
+    backtrace: int = -1
 
     def __repr__(self):
         return f"TargetCompileGroupInclude: {self.path}"
 
 
-# A member of the target.compile_groups.precompile_headers array
+@dataclass
 class TargetCompileGroupPrecompileHeader:
-    def __init__(self):
-        super().__init__()
+    """A member of the target.compile_groups.precompile_headers array.
 
-        self.header = ""
-        self.backtrace = -1
+    Attributes:
+        header: Precompiled header path.
+        backtrace: Index into the target's backtrace graph, or -1 if none.
+    """
+
+    header: str = ""
+    backtrace: int = -1
 
     def __repr__(self):
         return f"TargetCompileGroupPrecompileHeader: {self.header}"
 
 
-# A member of the target.compile_groups.defines array
+@dataclass
 class TargetCompileGroupDefine:
-    def __init__(self):
-        super().__init__()
+    """A member of the target.compile_groups.defines array.
 
-        self.define = ""
-        self.backtrace = -1
+    Attributes:
+        define: Preprocessor define (e.g. ``"NDEBUG"`` or ``"FOO=1"``).
+        backtrace: Index into the target's backtrace graph, or -1 if none.
+    """
+
+    define: str = ""
+    backtrace: int = -1
 
     def __repr__(self):
         return f"TargetCompileGroupDefine: {self.define}"
 
 
-# A member of the target.compile_groups array
+@dataclass
 class TargetCompileGroup:
-    def __init__(self):
-        super().__init__()
+    """A member of the target.compile_groups array.
 
-        self.source_indexes = []
-        self.language = ""
-        self.compile_command_fragments = []
-        self.includes = []
-        self.precompile_headers = []
-        self.defines = []
-        self.sysroot = ""
+    Attributes:
+        source_indexes: Indexes of the sources compiled with this group's settings.
+        language: Source language compiled by this group (e.g. ``"C"``, ``"CXX"``).
+        compile_command_fragments: Compiler command-line fragments.
+        includes: Include directories used by this group.
+        precompile_headers: Precompiled headers used by this group.
+        defines: Preprocessor defines used by this group.
+        sysroot: Sysroot path passed to the compiler, if any.
+        sources: Sources compiled with this group's settings, resolved from source_indexes.
+    """
 
-        # actual items, calculated from indices after loading
-        self.sources = []
+    source_indexes: list[int] = field(default_factory=list)
+    language: str = ""
+    compile_command_fragments: list[str] = field(default_factory=list)
+    includes: list[TargetCompileGroupInclude] = field(default_factory=list)
+    precompile_headers: list[TargetCompileGroupPrecompileHeader] = field(default_factory=list)
+    defines: list[TargetCompileGroupDefine] = field(default_factory=list)
+    sysroot: str = ""
+
+    sources: list[TargetSource] = field(default_factory=list)
 
     def __repr__(self):
         return f"TargetCompileGroup: {self.sources}"
 
 
-# A member of the target.backtrace_graph_nodes array
+@dataclass
 class TargetBacktraceGraphNode:
-    def __init__(self):
-        super().__init__()
+    """A member of the target.backtrace_graph_nodes array.
 
-        self.file = -1
-        self.line = -1
-        self.command = -1
-        self.parent = -1
+    Attributes:
+        file: Index into the target's backtrace_graph_files array.
+        line: Line number in the file, or -1 if unknown.
+        command: Index into the target's backtrace_graph_commands array, or -1 if none.
+        parent: Index of the parent node in the backtrace graph, or -1 if none.
+    """
+
+    file: int = -1
+    line: int = -1
+    command: int = -1
+    parent: int = -1
 
     def __repr__(self):
         return f"TargetBacktraceGraphNode: {self.command}"
 
 
-# Actual data in config.target.target, loaded from
-# config.target.json_file
+@dataclass
 class Target:
-    def __init__(self):
-        super().__init__()
+    """Actual data in config.target.target, loaded from config.target.json_file.
 
-        self.name = ""
-        self.id = ""
-        self.type = TargetType.UNKNOWN
-        self.backtrace = -1
-        self.folder = ""
-        self.paths_source = ""
-        self.paths_build = ""
-        self.name_on_disk = ""
-        self.artifacts = []
-        self.is_generator_provided = False
+    Attributes:
+        name: Target name.
+        id: Target's unique CMake file-API ID.
+        type: Kind of target (executable, library, utility, etc.).
+        backtrace: Index into backtrace_graph_nodes, or -1 if none.
+        folder: IDE folder the target is organized under, if any.
+        paths_source: Absolute path to the target's source directory.
+        paths_build: Absolute path to the target's build directory.
+        name_on_disk: Name of the target's primary artifact on disk.
+        artifacts: Paths to the target's build artifacts.
+        is_generator_provided: Whether the target was added by CMake itself, not the project.
+        install_prefix: Install prefix, set only if the target has an install rule.
+        install_destinations: Install destinations, set only if the target has an install rule.
+        link_language: Link language, set only for executables and shared libraries.
+        link_command_fragments: Link command fragments, set only for executables and shared
+            libraries.
+        link_lto: Whether link-time optimization is enabled, set only for executables and
+            shared libraries.
+        link_sysroot: Link-time sysroot path, set only for executables and shared libraries.
+        archive_command_fragments: Archive command fragments, set only for static libraries.
+        archive_lto: Whether link-time optimization is enabled, set only for static libraries.
+        dependencies: Targets this target depends on, set only if there are any.
+        sources: Target's source files.
+        source_groups: Source groups, set only if sources are grouped by source_group() or by
+            default.
+        compile_groups: Compile groups, set only if the target has sources that compile.
+        backtrace_graph_nodes: Nodes of the target's backtrace graph.
+        backtrace_graph_commands: Commands referenced from the backtrace graph.
+        backtrace_graph_files: Files referenced from the backtrace graph.
+    """
 
-        # only if install rule is present
-        self.install_prefix = ""
-        self.install_destinations = []
+    name: str = ""
+    id: str = ""
+    type: TargetType = TargetType.UNKNOWN
+    backtrace: int = -1
+    folder: str = ""
+    paths_source: str = ""
+    paths_build: str = ""
+    name_on_disk: str = ""
+    artifacts: list[str] = field(default_factory=list)
+    is_generator_provided: bool = False
 
-        # only for executables and shared library targets that link into
-        # a runtime binary
-        self.link_language = ""
-        self.link_command_fragments = []
-        self.link_lto = False
-        self.link_sysroot = ""
+    install_prefix: str = ""
+    install_destinations: list[TargetInstallDestination] = field(default_factory=list)
 
-        # only for static library targets
-        self.archive_command_fragments = []
-        self.archive_lto = False
+    link_language: str = ""
+    link_command_fragments: list[TargetCommandFragment] = field(default_factory=list)
+    link_lto: bool = False
+    link_sysroot: str = ""
 
-        # only if the target depends on other targets
-        self.dependencies = []
+    archive_command_fragments: list[TargetCommandFragment] = field(default_factory=list)
+    archive_lto: bool = False
 
-        # corresponds to target's source files
-        self.sources = []
+    dependencies: list[TargetDependency] = field(default_factory=list)
 
-        # only if sources are grouped together by source_group() or by default
-        self.source_groups = []
+    sources: list[TargetSource] = field(default_factory=list)
 
-        # only if target has sources that compile
-        self.compile_groups = []
+    source_groups: list[TargetSourceGroup] = field(default_factory=list)
 
-        # graph of backtraces referenced from elsewhere
-        self.backtrace_graph_nodes = []
-        self.backtrace_graph_commands = []
-        self.backtrace_graph_files = []
+    compile_groups: list[TargetCompileGroup] = field(default_factory=list)
+
+    backtrace_graph_nodes: list[TargetBacktraceGraphNode] = field(default_factory=list)
+    backtrace_graph_commands: list[str] = field(default_factory=list)
+    backtrace_graph_files: list[str] = field(default_factory=list)
 
     def __repr__(self):
         return f"Target: {self.name}"

--- a/scripts/pylib/zspdx/cmakefileapi.py
+++ b/scripts/pylib/zspdx/cmakefileapi.py
@@ -423,3 +423,96 @@ class Target:
 
     def __repr__(self):
         return f"Target: {self.name}"
+
+
+@dataclass
+class CMakeInfo:
+    """Generator and version from the "cmake" object of the file-based API index reply.
+
+    Attributes:
+        generator_name: CMake generator name (e.g. ``"Ninja"``).
+        generator_multi_config: Whether the generator supports multiple configurations.
+        cmake_path: Absolute path to the cmake executable.
+        version_major: CMake major version.
+        version_minor: CMake minor version.
+        version_patch: CMake patch version.
+        version_string: Full CMake version string.
+    """
+
+    generator_name: str = ""
+    generator_multi_config: bool = False
+    cmake_path: str = ""
+    version_major: int = 0
+    version_minor: int = 0
+    version_patch: int = 0
+    version_string: str = ""
+
+    def __repr__(self):
+        return f"CMakeInfo: version {self.version_string}, generator {self.generator_name}"
+
+
+@dataclass
+class ToolchainCompiler:
+    """Compiler information for a single language from the toolchains-v1 reply.
+
+    Attributes:
+        path: Absolute path to the compiler executable.
+        id: Compiler identifier (e.g. ``"GNU"``, ``"Clang"``).
+        version: Compiler version string.
+        target: Compiler target triple, if known.
+    """
+
+    path: str = ""
+    id: str = ""
+    version: str = ""
+    target: str = ""
+
+    def __repr__(self):
+        return f"ToolchainCompiler: {self.id} {self.version} at {self.path}"
+
+
+@dataclass
+class Toolchain:
+    """A member of the toolchains-v1 reply toolchains array.
+
+    Attributes:
+        language: Source language this toolchain compiles (e.g. ``"C"``, ``"CXX"``).
+        compiler: Compiler used for this language, if known.
+        source_file_extensions: File extensions associated with this language.
+    """
+
+    language: str = ""
+    compiler: ToolchainCompiler | None = None
+    source_file_extensions: list[str] = field(default_factory=list)
+
+    def __repr__(self):
+        return f"Toolchain: {self.language}"
+
+
+@dataclass
+class Toolchains:
+    """Collection of toolchains keyed by language, from the toolchains-v1 reply.
+
+    Attributes:
+        by_language: Toolchains keyed by source language.
+    """
+
+    by_language: dict[str, Toolchain] = field(default_factory=dict)
+
+    def get_compiler_path(self, language):
+        """Get the compiler path for a given language, or "" if unknown."""
+        tc = self.by_language.get(language)
+        return tc.compiler.path if tc and tc.compiler else ""
+
+    def get_compiler_version(self, language):
+        """Get the compiler version for a given language, or "" if unknown."""
+        tc = self.by_language.get(language)
+        return tc.compiler.version if tc and tc.compiler else ""
+
+    def get_compiler_id(self, language):
+        """Get the compiler ID for a given language, or "" if unknown."""
+        tc = self.by_language.get(language)
+        return tc.compiler.id if tc and tc.compiler else ""
+
+    def __repr__(self):
+        return f"Toolchains: {list(self.by_language.keys())}"

--- a/scripts/pylib/zspdx/cmakefileapijson.py
+++ b/scripts/pylib/zspdx/cmakefileapijson.py
@@ -45,6 +45,101 @@ def parse_reply(reply_index_path):
         return None
 
 
+def parse_toolchains_and_info(reply_index_path):
+    """Parse the CMake info and toolchains-v1 reply from the file-API index.
+
+    Returns a ``(CMakeInfo, Toolchains)`` tuple, each falling back to an empty object when its data
+    is missing or unparsable.
+    """
+    cmake_info = cmakefileapi.CMakeInfo()
+    toolchains = cmakefileapi.Toolchains()
+
+    reply_dir, _ = os.path.split(reply_index_path)
+    try:
+        with open(reply_index_path) as index_file:
+            js = json.load(index_file)
+    except OSError:
+        _logger.exception("Error loading %s", reply_index_path)
+        return cmake_info, toolchains
+    except json.decoder.JSONDecodeError:
+        _logger.exception("Error parsing JSON in %s", reply_index_path)
+        return cmake_info, toolchains
+
+    cmake_info = parse_cmake_info(js)
+
+    reply_dict = js.get("reply", {})
+    toolchains_dict = reply_dict.get("toolchains-v1", {})
+    toolchains_json_file = toolchains_dict.get("jsonFile", "")
+    if toolchains_json_file:
+        toolchains = parse_toolchains(reply_dir, toolchains_json_file)
+    else:
+        _logger.debug('no "toolchains-v1" reply found in CMake file API index')
+
+    return cmake_info, toolchains
+
+
+def parse_cmake_info(js):
+    """Parse the ``cmake`` object (generator and version) from the index file."""
+    cmake_info = cmakefileapi.CMakeInfo()
+
+    cmake_dict = js.get("cmake", {})
+    if cmake_dict:
+        generator_dict = cmake_dict.get("generator", {})
+        cmake_info.generator_name = generator_dict.get("name", "")
+        cmake_info.generator_multi_config = generator_dict.get("multiConfig", False)
+
+        paths_dict = cmake_dict.get("paths", {})
+        cmake_info.cmake_path = paths_dict.get("cmake", "")
+
+        version_dict = cmake_dict.get("version", {})
+        cmake_info.version_major = version_dict.get("major", 0)
+        cmake_info.version_minor = version_dict.get("minor", 0)
+        cmake_info.version_patch = version_dict.get("patch", 0)
+        cmake_info.version_string = version_dict.get("string", "")
+
+    return cmake_info
+
+
+def parse_toolchains(reply_dir, toolchains_file):
+    """Parse a toolchains-v1 reply file into a ``Toolchains`` object."""
+    toolchains_path = os.path.join(reply_dir, toolchains_file)
+    toolchains = cmakefileapi.Toolchains()
+
+    try:
+        with open(toolchains_path) as f:
+            js = json.load(f)
+    except OSError:
+        _logger.exception("Error loading %s", toolchains_path)
+        return toolchains
+    except json.decoder.JSONDecodeError:
+        _logger.exception("Error parsing JSON in %s", toolchains_path)
+        return toolchains
+
+    kind = js.get("kind", "")
+    if kind != "toolchains":
+        _logger.warning('Expected "kind":"toolchains" in %s, got %s', toolchains_path, kind)
+
+    for tc_dict in js.get("toolchains", []):
+        tc = cmakefileapi.Toolchain()
+        tc.language = tc_dict.get("language", "")
+        tc.source_file_extensions = tc_dict.get("sourceFileExtensions", [])
+
+        compiler_dict = tc_dict.get("compiler", {})
+        if compiler_dict:
+            compiler = cmakefileapi.ToolchainCompiler()
+            compiler.path = compiler_dict.get("path", "")
+            compiler.id = compiler_dict.get("id", "")
+            compiler.version = compiler_dict.get("version", "")
+            compiler.target = compiler_dict.get("target", "")
+            tc.compiler = compiler
+
+        if tc.language:
+            toolchains.by_language[tc.language] = tc
+
+    _logger.debug("parsed %d toolchains from CMake file API", len(toolchains.by_language))
+    return toolchains
+
+
 def parse_codemodel(reply_dir, codemodel_file):
     codemodel_path = os.path.join(reply_dir, codemodel_file)
 

--- a/scripts/pylib/zspdx/model.py
+++ b/scripts/pylib/zspdx/model.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any
+from typing import Any, TypedDict
 
 # SPDX sentinel used when a value is intentionally left unasserted.
 NOASSERTION = "NOASSERTION"
@@ -312,6 +312,46 @@ class SBOMDocument:
         return all_files
 
 
+class BuildInfo(TypedDict, total=False):
+    """Compiler, linker and CMake details stored on ``SBOMBuild.metadata``"""
+
+    # compiler binaries (``cmake_compiler`` is the generic/C compiler path)
+    cmake_compiler: str
+    cmake_c_compiler: str
+    cmake_cxx_compiler: str
+    cmake_asm_compiler: str
+    # compiler versions and ids, per language
+    c_compiler_version: str
+    cxx_compiler_version: str
+    asm_compiler_version: str
+    c_compiler_id: str
+    cxx_compiler_id: str
+    asm_compiler_id: str
+    # linker and archiver binaries and versions
+    cmake_linker: str
+    cmake_ar: str
+    linker_version: str
+    ar_version: str
+    # build type and target system
+    cmake_build_type: str
+    cmake_system_name: str
+    cmake_system_processor: str
+    # CMake generator and version
+    cmake_generator: str
+    cmake_version: str
+
+
+@dataclass
+class SBOMBuild:
+    """Format-agnostic identity of the build that produced the graph's artifacts."""
+
+    id: str = ""
+    build_type: str = ""
+    started_at: str = ""
+    finished_at: str = ""
+    metadata: BuildInfo = field(default_factory=dict)
+
+
 @dataclass
 class SBOMGraph:
     """Format-agnostic SBOM graph and consistency boundary.
@@ -328,6 +368,7 @@ class SBOMGraph:
         files: Files in the graph, keyed by absolute path.
         relationships: Relationships in the graph.
         custom_license_ids: Custom license IDs that need to be declared by serializers.
+        build: Build that produced the graph's artifacts, or ``None`` if it carries no build.
         metadata: Additional data not represented by the common model fields.
     """
 
@@ -338,6 +379,7 @@ class SBOMGraph:
     files: dict[str, SBOMFile] = field(default_factory=dict)
     relationships: list[SBOMRelationship] = field(default_factory=list)
     custom_license_ids: set[str] = field(default_factory=set)
+    build: SBOMBuild | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def add_document(self, document: SBOMDocument) -> None:

--- a/scripts/pylib/zspdx/model.py
+++ b/scripts/pylib/zspdx/model.py
@@ -339,6 +339,8 @@ class BuildInfo(TypedDict, total=False):
     # CMake generator and version
     cmake_generator: str
     cmake_version: str
+    # build environment variables, keyed by name (e.g. BOARD, ARCH)
+    environment: dict[str, str]
 
 
 @dataclass

--- a/scripts/pylib/zspdx/sbom.py
+++ b/scripts/pylib/zspdx/sbom.py
@@ -55,19 +55,21 @@ def setup_cmake_query(build_dir):
         # create the directory
         os.makedirs(cmake_api_dir_path, exist_ok=False)
 
-    # check that codemodel-v2 exists as a file, or else create it
-    query_file_path = os.path.join(cmake_api_dir_path, "codemodel-v2")
-    if os.path.exists(query_file_path):
-        if not os.path.isfile(query_file_path):
-            _logger.error("cmake api query file %s exists and is not a directory", query_file_path)
-            return False
-        # file exists, we're good
-        return True
-    else:
+    # request the codemodel (targets/sources) and toolchains-v1 (compiler ids and versions, used by
+    # the SPDX 3.0 Build profile) file-based API objects by creating an empty query file for each
+    for query_object in ("codemodel-v2", "toolchains-v1"):
+        query_file_path = os.path.join(cmake_api_dir_path, query_object)
+        if os.path.exists(query_file_path):
+            if not os.path.isfile(query_file_path):
+                _logger.error("cmake api query file %s exists and is not a file", query_file_path)
+                return False
+            # file exists, we're good
+            continue
         # file doesn't exist, let's create an empty file
         with open(query_file_path, "w"):
             pass
-        return True
+
+    return True
 
 
 # main entry point for SBOM maker

--- a/scripts/pylib/zspdx/serializers/spdx3/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx3/serializer.py
@@ -12,6 +12,7 @@ from zspdx.model import (
     NOASSERTION,
     ComponentPurpose,
     ExternalReferenceType,
+    RelationshipType,
     SBOMComponent,
     SBOMDocument,
     SBOMFile,
@@ -42,6 +43,13 @@ class SPDX3Serializer:
         "sdk": "Zephyr SDK",
     }
 
+    # Name of the SBOMDocument that hosts the Build profile (build targets).
+    _BUILD_DOCUMENT = "build"
+
+    # build_buildType is mandatory and must be a URI; used when the SBOMBuild
+    # does not provide an absolute URI of its own.
+    _DEFAULT_BUILD_TYPE = "urn:spdx.dev:zephyr-cmake"
+
     def __init__(self, sbom_graph: SBOMGraph, spdx_version=None):
         self.sbom_data = sbom_graph
         self.spdx_version = spdx_version  # Not used for SPDX 3.0, but kept for API consistency
@@ -62,6 +70,12 @@ class SPDX3Serializer:
         self.creator_agent = None  # SoftwareAgent for createdBy
         self.creation_info = None
         self.documents = {}  # doc_name -> SpdxDocument
+
+        # SPDX 3.0 Build profile state
+        self.build = None  # overall build_Build element
+        self.target_builds = {}  # component name -> per-target build_Build element
+        self.build_tools = {}  # tool key -> Tool element
+        self.build_info = sbom_graph.build.metadata if sbom_graph.build else {}
 
         # Track file IDs for uniqueness
         self.filename_counts = {}
@@ -151,6 +165,335 @@ class SPDX3Serializer:
             # Now set the tool's and agent's creationInfo
             self.tool.creationInfo = self.creation_info._id
             self.creator_agent.creationInfo = self.creation_info._id
+
+        # Build profile elements; no-ops when no build information was collected.
+        self._create_build_tools()
+        self._create_build_object()
+
+    # ---- SPDX 3.0 Build profile -------------------------------------------------
+
+    def _create_tool(
+        self, key: str, name: str, path: str = "", version: str = "", identifiers=None
+    ) -> spdx.Tool:
+        """Create and register a build Tool element keyed by ``key``.
+
+        Tool identity lives on the Tool itself: ``path`` is recorded as an ``other`` external
+        identifier and ``version`` as a ``packageUrl`` (``pkg:generic/<tool>@<version>``), since
+        SPDX 3.0 has no Tool version field. Extra ``(ExternalIdentifierType, value)`` tuples may be
+        passed in ``identifiers``.
+        """
+        namespace = self.sbom_data.namespace_prefix.rstrip("/")
+        tool = spdx.Tool()
+        tool._id = self._shorten_id(f"{namespace}/tools/{key}")
+        tool.name = name
+        tool.creationInfo = self.creation_info._id
+
+        ext_ids = []
+        if path:
+            ext_ids.append((spdx.ExternalIdentifierType.other, path))
+        if version:
+            pkg = os.path.basename(path) if path else key
+            ext_ids.append((spdx.ExternalIdentifierType.packageUrl, f"pkg:generic/{pkg}@{version}"))
+        ext_ids += identifiers or []
+
+        for id_type, id_value in ext_ids:
+            if not id_value:
+                continue
+            ext_id = spdx.ExternalIdentifier()
+            ext_id.externalIdentifierType = id_type
+            ext_id.identifier = id_value
+            tool.externalIdentifier.append(ext_id)
+
+        self.elements.append(tool)
+        self.build_tools[key] = tool
+        return tool
+
+    def _create_build_tools(self):
+        """Create a Tool element for each build tool we collected information for."""
+        if self.build_tools or not self.build_info:
+            return
+
+        info = self.build_info
+        self._create_cmake_tool(info)
+
+        # the C compiler also records the target architecture
+        c_path = info.get("cmake_compiler") or info.get("cmake_c_compiler", "")
+        if c_path:
+            version = info.get("c_compiler_version", "")
+            self._create_tool(
+                "c-compiler",
+                self._compiler_tool_name("C Compiler", c_path, version),
+                path=c_path,
+                version=version,
+                identifiers=self._compiler_arch_identifiers(info),
+            )
+
+        tool_specs = [
+            ("cxx-compiler", "C++ Compiler", "cmake_cxx_compiler", "cxx_compiler_version"),
+            ("asm-compiler", "Assembler", "cmake_asm_compiler", "asm_compiler_version"),
+            ("linker", "Linker", "cmake_linker", "linker_version"),
+            ("archiver", "Archiver", "cmake_ar", "ar_version"),
+        ]
+        for key, label, path_key, version_key in tool_specs:
+            path = info.get(path_key, "")
+            # skip missing tools and the C++ compiler when it is the same binary as the C compiler
+            if not path or (key == "cxx-compiler" and path == c_path):
+                continue
+            version = info.get(version_key, "")
+            self._create_tool(
+                key,
+                self._compiler_tool_name(label, path, version),
+                path=path,
+                version=version,
+            )
+
+    def _create_cmake_tool(self, info: dict):
+        """Create the CMake build Tool from the collected build info, when present."""
+        if not (info.get("cmake_version") or info.get("cmake_generator")):
+            return
+        name = "CMake"
+        if info.get("cmake_version"):
+            name += f" {info['cmake_version']}"
+        if info.get("cmake_generator"):
+            name += f" ({info['cmake_generator']})"
+        self._create_tool("cmake", name, version=info.get("cmake_version", ""))
+
+    @staticmethod
+    def _compiler_arch_identifiers(info: dict):
+        """Target-architecture external identifier for a compiler, or ``None`` if unknown."""
+        processor = info.get("cmake_system_processor")
+        if not processor:
+            return None
+        return [(spdx.ExternalIdentifierType.other, f"target-arch:{processor}")]
+
+    @staticmethod
+    def _compiler_tool_name(label: str, path: str, version: str) -> str:
+        """Build a tool display name like ``C Compiler (gcc 12.2.0)``."""
+        basename = os.path.basename(path)
+        if version:
+            return f"{label} ({basename} {version})"
+        return f"{label} ({basename})"
+
+    def _create_build_object(self):
+        """Create the SPDX 3.0 ``build_Build`` element."""
+        if self.build is not None:
+            return
+        if not self.build_info and not self.sbom_data.build:
+            return
+
+        namespace = self.sbom_data.namespace_prefix.rstrip("/")
+        self.build = spdx.build_Build()
+        self.build._id = self._shorten_id(f"{namespace}/builds/default")
+        self.build.creationInfo = self.creation_info._id
+        self.build.build_buildType = self._DEFAULT_BUILD_TYPE
+
+        sbom_build = self.sbom_data.build
+        if sbom_build:
+            if sbom_build.id:
+                self.build.build_buildId = sbom_build.id
+            if sbom_build.build_type:
+                build_type = sbom_build.build_type
+                if not build_type.startswith("http"):
+                    build_type = f"https://zephyrproject.org/build-types/{build_type}"
+                self.build.build_buildType = build_type
+            if sbom_build.started_at:
+                self.build.build_buildStartTime = sbom_build.started_at
+            if sbom_build.finished_at:
+                self.build.build_buildEndTime = sbom_build.finished_at
+
+        self._add_build_parameters()
+        self.elements.append(self.build)
+
+    def _add_build_parameters(self):
+        """Populate ``build_parameter`` with the global build configuration."""
+        info = self.build_info
+        if not self.build or not info:
+            return
+
+        for key, info_key in (
+            ("cmake:generator", "cmake_generator"),
+            ("cmake:buildType", "cmake_build_type"),
+            ("target:system", "cmake_system_name"),
+            ("target:processor", "cmake_system_processor"),
+        ):
+            value = info.get(info_key, "")
+            if value:
+                entry = spdx.DictionaryEntry()
+                entry.key = key
+                entry.value = str(value)
+                self.build.build_parameter.append(entry)
+
+    @staticmethod
+    def _is_build_target_component(component: SBOMComponent) -> bool:
+        """Whether a component is a build target (produces an artifact).
+
+        Source aggregation and ``*-deps`` components are inputs, not outputs.
+        """
+        if component.name in {"app-sources", "zephyr-sources", "sdk-sources"}:
+            return False
+        return not component.name.endswith("-deps")
+
+    def _new_build_relationship(
+        self,
+        rel_type: spdx.RelationshipType,
+        from_id: str,
+        to_ids: list[str],
+        description: str = "",
+    ) -> spdx.LifecycleScopedRelationship:
+        """Create and register a relationship scoped to the ``build`` lifecycle."""
+        rel = spdx.LifecycleScopedRelationship()
+        rel._id = self._generate_relationship_id(len(self.relationship_elements))
+        rel.relationshipType = rel_type
+        rel.from_ = from_id
+        rel.to = list(to_ids)
+        rel.scope = spdx.LifecycleScopeType.build
+        rel.creationInfo = self.creation_info._id
+        if description:
+            rel.description = description
+        self.elements.append(rel)
+        self.relationship_elements.append(rel)
+        return rel
+
+    def _create_build_relationships(self):
+        """Create the Build profile's build-scoped relationships.
+
+        The overall build ``usesTool`` every build tool, ``hasInput`` the source/dependency packages
+        and ``hasOutput`` the final image(s). Each other build target gets its own sub-build
+        recording the exact sources and tools that produced its artifact. Every relationship's
+        ``from`` is a Build, so they all stay in the build document.
+        """
+        if not self.build:
+            return
+
+        for tool in self.build_tools.values():
+            self._new_build_relationship(spdx.RelationshipType.usesTool, self.build._id, [tool._id])
+
+        self._create_build_output_relationships()
+
+        input_ids = self._build_input_ids()
+        if input_ids:
+            self._new_build_relationship(spdx.RelationshipType.hasInput, self.build._id, input_ids)
+
+    def _create_build_output_relationships(self):
+        """Emit ``hasOutput`` for the final image(s) and a sub-build for every other target."""
+        for component in self.sbom_data.components.values():
+            if not self._is_build_target_component(component):
+                continue
+            if not component.target_build_file:
+                continue
+            build_file = self.file_elements.get(component.target_build_file.path)
+            if not build_file:
+                continue
+            if component.metadata.get("target_type") == "EXECUTABLE":
+                # final images are outputs of the overall build; their compiled
+                # sources/headers are inputs of that same build
+                self._new_build_relationship(
+                    spdx.RelationshipType.hasOutput, self.build._id, [build_file._id]
+                )
+                input_ids = self._artifact_input_ids(component)
+                if input_ids:
+                    self._new_build_relationship(
+                        spdx.RelationshipType.hasInput, self.build._id, input_ids
+                    )
+            else:
+                self._create_target_build(component, build_file)
+
+    def _artifact_input_ids(self, component: SBOMComponent) -> list[str]:
+        """Element IDs of the files that fed a target's artifact.
+
+        These are the artifact's ``GENERATED_FROM`` endpoints: the compiled sources and, when
+        include analysis is enabled, the headers they pulled in. They become the Build's
+        ``hasInput`` for the target.
+        """
+        input_ids = []
+        for rel in component.target_build_file.relationships:
+            if rel.relationship_type != RelationshipType.GENERATED_FROM:
+                continue
+            for source in rel.to_elements:
+                source_id = self._get_element_id(source)
+                if source_id and source_id not in input_ids:
+                    input_ids.append(source_id)
+        return input_ids
+
+    def _create_target_build(self, component: SBOMComponent, build_file) -> None:
+        """Create a per-target sub-build for one artifact-producing target.
+
+        The sub-build ``hasOutput`` the target's artifact, ``hasInput`` its compiled sources/headers
+        and ``usesTool`` the specific compiler(s) and archiver/linker that produced it. Sub-builds
+        connect to the overall build through the artifacts they share, which carry ``hasStaticLink``
+        edges to the final image.
+        """
+        namespace = self.sbom_data.namespace_prefix.rstrip("/")
+        target_build = spdx.build_Build()
+        target_build._id = self._shorten_id(
+            f"{namespace}/builds/{normalize_spdx_name(component.name)}"
+        )
+        target_build.creationInfo = self.creation_info._id
+        target_build.build_buildType = self.build.build_buildType
+        self.elements.append(target_build)
+        self.target_builds[component.name] = target_build
+
+        self._new_build_relationship(
+            spdx.RelationshipType.hasOutput, target_build._id, [build_file._id]
+        )
+
+        # the target's compiled sources/headers are the artifact's GENERATED_FROM endpoints
+        input_ids = self._artifact_input_ids(component)
+        if input_ids:
+            self._new_build_relationship(
+                spdx.RelationshipType.hasInput, target_build._id, input_ids
+            )
+
+        for tool_id in self._target_tool_ids(component):
+            self._new_build_relationship(
+                spdx.RelationshipType.usesTool, target_build._id, [tool_id]
+            )
+
+    def _target_tool_ids(self, component: SBOMComponent) -> list[str]:
+        """Tool IDs that built ``component``: compiler(s) per language plus the archiver (static
+        libraries) or linker (shared/module libraries).
+        """
+        language_to_tool = {
+            "C": "c-compiler",
+            "CXX": "cxx-compiler",
+            "ASM": "asm-compiler",
+            "ASM-ATT": "asm-compiler",
+        }
+        tool_ids = []
+        for lang in component.metadata.get("compile_languages", []):
+            tool = self.build_tools.get(language_to_tool.get(lang, ""))
+            if tool and tool._id not in tool_ids:
+                tool_ids.append(tool._id)
+
+        target_type = component.metadata.get("target_type", "")
+        if target_type == "STATIC_LIBRARY":
+            extra = self.build_tools.get("archiver")
+        elif target_type in ("SHARED_LIBRARY", "MODULE_LIBRARY"):
+            extra = self.build_tools.get("linker")
+        else:
+            extra = None
+        if extra and extra._id not in tool_ids:
+            tool_ids.append(extra._id)
+        return tool_ids
+
+    def _build_input_ids(self) -> list[str]:
+        """Package IDs of the build's inputs (the source/dependency roots).
+
+        The described (root) components of every non-build document, falling back to all of a
+        document's components when it declares no root.
+        """
+        input_ids = []
+        seen = set()
+        for sbom_doc in self.sbom_data.documents.values():
+            if sbom_doc.name == self._BUILD_DOCUMENT:
+                continue
+            names = sbom_doc.described_components or list(sbom_doc.components.keys())
+            for name in names:
+                package = self.component_elements.get(name)
+                if package and package._id not in seen:
+                    seen.add(package._id)
+                    input_ids.append(package._id)
+        return input_ids
 
     def _create_software_package(self, component: SBOMComponent) -> spdx.software_Package:
         """Convert SBOMComponent to SPDX 3.0 software_Package."""
@@ -245,9 +588,10 @@ class SPDX3Serializer:
         """Map relationship type string to SPDX 3.0 RelationshipType enum.
         Returns a tuple of (RelationshipType, reversed).
         """
-        # Map SPDX 2.x relationship types to SPDX 3.0 RelationshipType
+        # Map SPDX 2.x relationship types to SPDX 3.0 RelationshipType.
+        # GENERATED_FROM is intentionally absent: it is handled by the Build profile
+        # (see _create_relationships and _artifact_input_ids).
         type_map = {
-            "GENERATED_FROM": (spdx.RelationshipType.generates, True),
             "HAS_PREREQUISITE": (spdx.RelationshipType.dependsOn, False),
             "STATIC_LINK": (spdx.RelationshipType.hasStaticLink, False),
             "CONTAINS": (spdx.RelationshipType.contains, False),
@@ -408,7 +752,7 @@ class SPDX3Serializer:
         components = sbom_doc.components.values()
 
         element_ids = self._collect_document_element_ids(sbom_doc, components)
-        self._populate_document(document, element_ids, components)
+        self._populate_document(document, element_ids, components, sbom_doc)
 
         self.elements.append(document)
         self.documents[sbom_doc.name] = document
@@ -444,6 +788,9 @@ class SPDX3Serializer:
         document.profileConformance.append(spdx.ProfileIdentifierType.core)
         document.profileConformance.append(spdx.ProfileIdentifierType.software)
         document.profileConformance.append(spdx.ProfileIdentifierType.simpleLicensing)
+        # Only the build document conforms to the Build profile.
+        if self.build and sbom_doc.name == self._BUILD_DOCUMENT:
+            document.profileConformance.append(spdx.ProfileIdentifierType.build)
         return document
 
     def _collect_document_element_ids(self, sbom_doc: SBOMDocument, components) -> set:
@@ -459,6 +806,9 @@ class SPDX3Serializer:
         # Custom licenses recorded on the document must exist as elements even
         # if no package or file references them directly.
         self._register_custom_licenses(sbom_doc)
+
+        # Seed the build document so its build-scoped relationships are collected.
+        self._seed_build_element_ids(sbom_doc, element_ids)
 
         self._collect_relationship_ids(element_ids)
 
@@ -504,6 +854,19 @@ class SPDX3Serializer:
         for lic in sbom_doc.custom_license_ids:
             self._create_license_expression(lic)
 
+    def _seed_build_element_ids(self, sbom_doc: SBOMDocument, element_ids: set):
+        """Add the Build elements and build tool IDs to the build document's set.
+
+        No-op for any other document, or when no Build element was produced.
+        """
+        if not self.build or sbom_doc.name != self._BUILD_DOCUMENT:
+            return
+        element_ids.add(self.build._id)
+        for target_build in self.target_builds.values():
+            element_ids.add(target_build._id)
+        for tool in self.build_tools.values():
+            element_ids.add(tool._id)
+
     def _collect_relationship_ids(self, element_ids: set):
         """Add this document's relationships and their endpoints to ``element_ids``.
 
@@ -526,7 +889,13 @@ class SPDX3Serializer:
         element_ids.update(relationship_ids)
         element_ids.update(endpoint_ids)
 
-    def _populate_document(self, document: spdx.SpdxDocument, element_ids: set, components):
+    def _populate_document(
+        self,
+        document: spdx.SpdxDocument,
+        element_ids: set,
+        components,
+        sbom_doc: SBOMDocument,
+    ):
         """Attach the selected elements and root components to the document."""
         for element in self.elements:
             if self._belongs_in_document(element, document._id, element_ids):
@@ -536,6 +905,10 @@ class SPDX3Serializer:
             package = self.component_elements.get(component.name)
             if package:
                 document.rootElement.append(package)
+
+        # The Build element is a root of the build document.
+        if self.build and sbom_doc.name == self._BUILD_DOCUMENT:
+            document.rootElement.append(self.build)
 
     @staticmethod
     def _belongs_in_document(element, document_id: str, element_ids: set) -> bool:
@@ -560,6 +933,7 @@ class SPDX3Serializer:
             self._create_files()
             self._create_relationships()
             self._create_contains_relationships()
+            self._create_build_relationships()
             self._create_license_relationships()
             self._create_documents()
             self._write_documents(output_dir)
@@ -607,18 +981,24 @@ class SPDX3Serializer:
             self._create_software_file(file_obj)
 
     def _create_relationships(self):
-        """Create the relationships declared by components and files."""
-        for component in self.sbom_data.components.values():
-            for rel in component.relationships:
-                if not self._create_relationship(rel):
-                    _logger.warning(
-                        f"Failed to create relationship from component {component.name}"
-                    )
+        """Create the relationships declared by components and files.
 
+        ``GENERATED_FROM`` edges are skipped: build provenance is carried by the Build profile
+        (the Build's ``hasInput``/``hasOutput``), not by file-level ``generates`` edges like it
+        would for SPDX 2.x.
+        """
+        for component in self.sbom_data.components.values():
+            self._create_owner_relationships(component.relationships, "component", component.name)
         for file_obj in self.sbom_data.files.values():
-            for rel in file_obj.relationships:
-                if not self._create_relationship(rel):
-                    _logger.warning(f"Failed to create relationship from file {file_obj.path}")
+            self._create_owner_relationships(file_obj.relationships, "file", file_obj.path)
+
+    def _create_owner_relationships(self, relationships, owner_kind, owner_id):
+        """Create each declared relationship, skipping ``GENERATED_FROM`` (see above)."""
+        for rel in relationships:
+            if rel.relationship_type == RelationshipType.GENERATED_FROM:
+                continue
+            if not self._create_relationship(rel):
+                _logger.warning(f"Failed to create relationship from {owner_kind} {owner_id}")
 
     def _create_contains_relationships(self):
         """Create a CONTAINS relationship from each package to each of its files."""

--- a/scripts/pylib/zspdx/serializers/spdx3/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx3/serializer.py
@@ -302,7 +302,20 @@ class SPDX3Serializer:
                 self.build.build_buildEndTime = sbom_build.finished_at
 
         self._add_build_parameters()
+        self._add_build_environment()
         self.elements.append(self.build)
+
+    def _add_build_environment(self):
+        """Populate ``build_environment`` from the collected environment variables."""
+        if not self.build:
+            return
+        for key, value in sorted(self.build_info.get("environment", {}).items()):
+            if not value:
+                continue
+            entry = spdx.DictionaryEntry()
+            entry.key = key
+            entry.value = str(value)
+            self.build.build_environment.append(entry)
 
     def _add_build_parameters(self):
         """Populate ``build_parameter`` with the global build configuration."""
@@ -430,6 +443,13 @@ class SPDX3Serializer:
         )
         target_build.creationInfo = self.creation_info._id
         target_build.build_buildType = self.build.build_buildType
+        # per-language compile flags and defines used to produce this artifact
+        for kind in ("flags", "defines"):
+            for lang, value in sorted(component.metadata.get(f"compile_{kind}", {}).items()):
+                entry = spdx.DictionaryEntry()
+                entry.key = f"compile:{kind}:{lang}"
+                entry.value = value
+                target_build.build_parameter.append(entry)
         self.elements.append(target_build)
         self.target_builds[component.name] = target_build
 

--- a/scripts/pylib/zspdx/walker.py
+++ b/scripts/pylib/zspdx/walker.py
@@ -300,6 +300,20 @@ class Walker:
             build_info["cmake_generator"] = self.cmake_info.generator_name
             build_info["cmake_version"] = self.cmake_info.version_string
 
+        # build environment: Zephyr config inputs surfaced as build_environment
+        environment = {}
+        for var in (
+            "BOARD",
+            "ARCH",
+            "ZEPHYR_TOOLCHAIN_VARIANT",
+            "ZEPHYR_SDK_INSTALL_DIR",
+            "CMAKE_BUILD_TYPE",
+        ):
+            value = self.cmake_cache.get(var, "")
+            if value:
+                environment[var] = value
+        build_info["environment"] = environment
+
         # linker and archiver versions are not in toolchains-v1; query the tools
         for version_key, path in (
             ("linker_version", build_info["cmake_linker"]),
@@ -586,15 +600,36 @@ class Walker:
             # get its target dependencies
             self.collect_target_dependencies(cfg_targets, cfg_target, component)
 
-    # capture the per-target metadata the SPDX 3.0 Build profile needs to
-    # attribute a compiler/archiver to each artifact: the CMake target type and
-    # the languages compiled into it
+    # capture the per-target metadata the SPDX 3.0 Build profile needs to attribute a compiler/
+    # archiver to each artifact: target type, compiled languages and per-language compile flags
     def capture_build_metadata(self, cfg_target, component):
         target = cfg_target.target
         component.metadata["target_type"] = target.type.name
-        languages = sorted({cg.language for cg in target.compile_groups if cg.language})
+
+        languages = set()
+        compile_flags = {}
+        compile_defines = {}
+        for cg in target.compile_groups:
+            if not cg.language:
+                continue
+            languages.add(cg.language)
+            flags = [frag for frag in (cg.compile_command_fragments or []) if frag]
+            if flags:
+                compile_flags.setdefault(cg.language, []).extend(flags)
+            defines = [f"-D{d.define}" for d in (cg.defines or []) if d.define]
+            if defines:
+                compile_defines.setdefault(cg.language, []).extend(defines)
+
         if languages:
-            component.metadata["compile_languages"] = languages
+            component.metadata["compile_languages"] = sorted(languages)
+        if compile_flags:
+            component.metadata["compile_flags"] = {
+                lang: " ".join(flags) for lang, flags in compile_flags.items()
+            }
+        if compile_defines:
+            component.metadata["compile_defines"] = {
+                lang: " ".join(defs) for lang, defs in compile_defines.items()
+            }
 
     # build a Component for the given ConfigTarget
     def init_config_target_component(self, cfg_target):

--- a/scripts/pylib/zspdx/walker.py
+++ b/scripts/pylib/zspdx/walker.py
@@ -5,17 +5,20 @@
 import logging
 import os
 import re
+import subprocess
 from dataclasses import dataclass
 
 import yaml
 from west.util import WestNotFound, west_topdir
 
 from zspdx.cmakecache import parse_cmake_cache_file
-from zspdx.cmakefileapijson import parse_reply
+from zspdx.cmakefileapijson import parse_reply, parse_toolchains_and_info
 from zspdx.getincludes import get_c_includes
 from zspdx.model import (
+    BuildInfo,
     ComponentPurpose,
     RelationshipType,
+    SBOMBuild,
     SBOMComponent,
     SBOMDocument,
     SBOMFile,
@@ -23,6 +26,44 @@ from zspdx.model import (
 )
 
 _logger = logging.getLogger(__name__)
+
+
+def get_tool_version(tool_path):
+    """Get a tool's version by running it with ``--version``.
+
+    Used for the linker and archiver, which the CMake toolchains-v1 reply does
+    not describe. Returns "" when the tool is missing or no version can be parsed.
+    """
+    if not tool_path or not os.path.isfile(tool_path):
+        return ""
+
+    try:
+        result = subprocess.run(
+            [tool_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,  # avoid hanging on a misbehaving tool
+        )
+        output = result.stdout or result.stderr
+        if not output:
+            return ""
+
+        # parse the version from the first line of output, e.g.
+        # "GNU ld (Zephyr SDK 0.17.4) 2.38" -> "2.38",
+        # "cmake version 3.28.1" -> "3.28.1"
+        first_line = output.strip().split('\n')[0]
+        for pattern in (
+            r'version\s+(\d+\.\d+(?:\.\d+)?)',
+            r'\b(\d+\.\d+(?:\.\d+)?)\s*$',
+            r'\b(\d+\.\d+(?:\.\d+)?)\b',
+        ):
+            match = re.search(pattern, first_line, re.IGNORECASE)
+            if match:
+                return match.group(1)
+        return ""
+    except (subprocess.SubprocessError, OSError) as e:
+        _logger.debug(f"Could not get version for {tool_path}: {e}")
+        return ""
 
 
 # WalkerConfig contains configuration data for the Walker.
@@ -81,6 +122,12 @@ class Walker:
         # parsed CMake codemodel
         self.cm = None
 
+        # parsed CMake toolchains-v1 reply (compiler ids and versions)
+        self.toolchains = None
+
+        # parsed CMake info (generator and version) from the file API index
+        self.cmake_info = None
+
         # parsed CMake cache dict
         self.cmake_cache = {}
 
@@ -138,6 +185,11 @@ class Walker:
             _logger.error("could not parse codemodel from CMake API reply; bailing")
             return None
 
+        # extract Build profile info; non-fatal, the profile is omitted if absent
+        _logger.info("extracting build information from CMake file-based API")
+        self.get_toolchains_and_info()
+        self.extract_build_info()
+
         # set up components
         _logger.info("setting up SBOM components")
         retval = self.setup_components()
@@ -167,12 +219,8 @@ class Walker:
             self.sdk_path = self.cmake_cache.get("ZEPHYR_SDK_INSTALL_DIR", "")
             self.meta_file = self.cmake_cache.get("KERNEL_META_PATH", "")
 
-    # determine path from build dir to CMake file-based API index file, then
-    # parse it and return the Codemodel
-    def get_codemodel(self):
-        _logger.debug("getting codemodel from CMake API reply files")
-
-        # make sure the reply directory exists
+    # locate the CMake file-based API reply index file within the build dir
+    def get_reply_index_path(self):
         cmake_reply_dir_path = os.path.join(self.cfg.build_dir, ".cmake", "api", "v1", "reply")
         if not os.path.exists(cmake_reply_dir_path):
             _logger.error(f'cmake api reply directory {cmake_reply_dir_path} does not exist')
@@ -185,18 +233,93 @@ class Walker:
             return None
 
         # find file with "index" prefix; there should only be one
-        index_file_path = ""
         for f in os.listdir(cmake_reply_dir_path):
             if f.startswith("index"):
-                index_file_path = os.path.join(cmake_reply_dir_path, f)
-                break
-        if index_file_path == "":
-            # didn't find it
-            _logger.error(f'cmake api reply index file not found in {cmake_reply_dir_path}')
+                return os.path.join(cmake_reply_dir_path, f)
+
+        _logger.error(f'cmake api reply index file not found in {cmake_reply_dir_path}')
+        return None
+
+    # determine path from build dir to CMake file-based API index file, then
+    # parse it and return the Codemodel
+    def get_codemodel(self):
+        _logger.debug("getting codemodel from CMake API reply files")
+
+        index_file_path = self.get_reply_index_path()
+        if not index_file_path:
             return None
 
         # parse it
         return parse_reply(index_file_path)
+
+    # parse the toolchains-v1 reply and CMake info from the file-based API index
+    def get_toolchains_and_info(self):
+        _logger.debug("getting toolchains and CMake info from CMake API reply files")
+
+        index_file_path = self.get_reply_index_path()
+        if not index_file_path:
+            return
+
+        self.cmake_info, self.toolchains = parse_toolchains_and_info(index_file_path)
+
+    def extract_build_info(self):
+        """Collect global build information for the SPDX 3.0 Build profile.
+
+        Stores the details on the graph's ``SBOMBuild`` (its ``id``, ``build_type`` and
+        the detailed ``metadata`` mapping); serializers without a build vocabulary ignore
+        them.
+        """
+        if not self.cmake_cache:
+            _logger.debug("no CMake cache parsed; skipping build info extraction")
+            return
+
+        build_info: BuildInfo = {}
+
+        # compiler paths, ids and versions: prefer toolchains-v1, fall back to cache
+        if self.toolchains and self.toolchains.by_language:
+            for lang, key in (("C", "c"), ("CXX", "cxx"), ("ASM", "asm")):
+                build_info[f"cmake_{key}_compiler"] = self.toolchains.get_compiler_path(lang)
+                build_info[f"{key}_compiler_version"] = self.toolchains.get_compiler_version(lang)
+                build_info[f"{key}_compiler_id"] = self.toolchains.get_compiler_id(lang)
+            # generic compiler-path key, set to the C compiler
+            build_info["cmake_compiler"] = build_info.get("cmake_c_compiler", "")
+        else:
+            build_info["cmake_compiler"] = self.cmake_cache.get("CMAKE_C_COMPILER", "")
+            build_info["cmake_cxx_compiler"] = self.cmake_cache.get("CMAKE_CXX_COMPILER", "")
+            build_info["cmake_asm_compiler"] = self.cmake_cache.get("CMAKE_ASM_COMPILER", "")
+
+        # linker, archiver, build type and target system always come from the cache
+        build_info["cmake_linker"] = self.cmake_cache.get("CMAKE_LINKER", "")
+        build_info["cmake_ar"] = self.cmake_cache.get("CMAKE_AR", "")
+        build_info["cmake_build_type"] = self.cmake_cache.get("CMAKE_BUILD_TYPE", "")
+        build_info["cmake_system_name"] = self.cmake_cache.get("CMAKE_SYSTEM_NAME", "")
+        build_info["cmake_system_processor"] = self.cmake_cache.get("CMAKE_SYSTEM_PROCESSOR", "")
+
+        # CMake generator and version from the file-API index
+        if self.cmake_info:
+            build_info["cmake_generator"] = self.cmake_info.generator_name
+            build_info["cmake_version"] = self.cmake_info.version_string
+
+        # linker and archiver versions are not in toolchains-v1; query the tools
+        for version_key, path in (
+            ("linker_version", build_info["cmake_linker"]),
+            ("ar_version", build_info["cmake_ar"]),
+        ):
+            version = get_tool_version(path)
+            if version:
+                build_info[version_key] = version
+
+        # drop empty entries to keep the build_parameter output tidy
+        build_info = {k: v for k, v in build_info.items() if v}
+        if not build_info:
+            _logger.debug("no build information available; skipping Build profile inputs")
+            return
+
+        # summarise as an SBOMBuild; build timestamps are omitted to keep builds reproducible
+        self.sbom_graph.build = SBOMBuild(
+            build_type=build_info.get("cmake_build_type", ""),
+            metadata=build_info,
+        )
 
     def _create_document(self, name: str, title: str = "") -> SBOMDocument:
         """Create a document with the given name and register it with SBOM data.
@@ -452,6 +575,8 @@ class Walker:
                 else:
                     component.purpose = ComponentPurpose.LIBRARY
 
+                self.capture_build_metadata(cfg_target, component)
+
                 # get its source files if build file is found
                 if bf:
                     self.collect_pending_source_files(cfg_target, component, bf)
@@ -460,6 +585,16 @@ class Walker:
 
             # get its target dependencies
             self.collect_target_dependencies(cfg_targets, cfg_target, component)
+
+    # capture the per-target metadata the SPDX 3.0 Build profile needs to
+    # attribute a compiler/archiver to each artifact: the CMake target type and
+    # the languages compiled into it
+    def capture_build_metadata(self, cfg_target, component):
+        target = cfg_target.target
+        component.metadata["target_type"] = target.type.name
+        languages = sorted({cg.language for cg in target.compile_groups if cg.language})
+        if languages:
+            component.metadata["compile_languages"] = languages
 
     # build a Component for the given ConfigTarget
     def init_config_target_component(self, cfg_target):


### PR DESCRIPTION
Adds generation of a full Build profile to the `west spdx` SPDX 3 output, so the SBOM records *how* the artifacts were built, i.e. toolchain info (compiler, assembler, linker, ... and their versions), compilation flags, etc.

Build info is sourced from the CMake file-based API (a `toolchains-v1` query is now requested alongside `codemodel-v2`) and `CMakeCache.txt`.

~First 3 commits are bug fixes submitted as part of #112223.~

Example of the information now being captured for a build step, as visualized through https://kartben.github.io/spdx3_viz

<img width="1123" height="872" alt="image" src="https://github.com/user-attachments/assets/74794fc5-b251-4900-9d2c-4b065f547012" />