### PR TITLE
dfu: Fix mcuboot_shell to use boot_fetch_active_slot()

### DIFF
--- a/include/zephyr/dfu/mcuboot.h
+++ b/include/zephyr/dfu/mcuboot.h
@@ -81,6 +81,9 @@ extern "C" {
 
 #define BOOT_IMG_VER_STRLEN_MAX 25  /* 255.255.65535.4294967295\0 */
 
+/** Value reserved to signalize invalid slot or failure to determine slot number */
+#define BOOT_INVALID_SLOT_ID 255
+
 /** Sector at which firmware update should be placed by application in swap using offset mode */
 #define SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN 1
 

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -77,7 +77,6 @@ enum IMAGE_INDEXES {
 	defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD_WITH_REVERT)
 /* For RAM LOAD mode, the active image must be fetched from the bootloader */
 #define ACTIVE_SLOT_FLASH_AREA_ID boot_fetch_active_slot()
-#define INVALID_SLOT_ID 255
 #else
 /* Get active partition. zephyr,code-partition chosen node must be defined */
 #define ACTIVE_SLOT_FLASH_AREA_ID DT_PARTITION_ID(DT_CHOSEN(zephyr_code_partition))
@@ -118,7 +117,7 @@ uint8_t boot_fetch_active_slot(void)
 	if (rc <= 0) {
 		LOG_ERR("Failed to fetch active slot: %d", rc);
 
-		return INVALID_SLOT_ID;
+		return BOOT_INVALID_SLOT_ID;
 	}
 
 	LOG_DBG("Active slot: %d", slot);
@@ -206,7 +205,7 @@ uint8_t boot_fetch_active_slot(void)
 		break;
 	}
 
-	return INVALID_SLOT_ID;
+	return BOOT_INVALID_SLOT_ID;
 }
 #else  /* CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD ||
 	* CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD_WITH_REVERT

--- a/subsys/dfu/boot/mcuboot_shell.c
+++ b/subsys/dfu/boot/mcuboot_shell.c
@@ -88,6 +88,7 @@ static int cmd_mcuboot_erase(const struct shell *sh, size_t argc,
 			     char **argv)
 {
 	unsigned int id;
+	unsigned int active_slot;
 	int err;
 
 	id = strtoul(argv[1], NULL, 0);
@@ -100,12 +101,17 @@ static int cmd_mcuboot_erase(const struct shell *sh, size_t argc,
 	}
 #endif
 
-#if DT_PARTITION_EXISTS(DT_CHOSEN(zephyr_code_partition))
-	if (id == DT_PARTITION_ID(DT_CHOSEN(zephyr_code_partition))) {
+	active_slot = boot_fetch_active_slot();
+
+	if (active_slot == BOOT_INVALID_SLOT_ID) {
+		shell_error(sh, "Failed to determive active partition");
+		return -EFAULT;
+	}
+
+	if (id == active_slot) {
 		shell_error(sh, "Cannot erase active partitions");
 		return -EACCES;
 	}
-#endif
 
 	err = boot_erase_img_bank(id);
 	if (err) {


### PR DESCRIPTION
This commit makes mcuboot_shell use boot API to determine active image slot. Previously it used static zephyr_code_partition to determine active slot, which wasn't compatible with configurations using blinfo.