### PR TITLE
testsuite: ztest: restore external linkage of ztest_thread_stack

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_test.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test.h
@@ -942,6 +942,17 @@ bool z_ztest_should_suite_run(const void *state, struct ztest_suite_node *suite)
 bool z_ztest_should_test_run(const char *suite, const char *test);
 
 /**
+ * @brief Stack used by the ztest runner thread.
+ *
+ * Defined by the active ztest backend. Declared here so the definition has a
+ * visible prior declaration (MISRA C:2012 Rule 8.4) and so that tests which
+ * inspect the runner thread's stack (e.g. the userspace memory-protection
+ * tests) can reference it.
+ */
+K_THREAD_STACK_DECLARE(ztest_thread_stack,
+		       CONFIG_ZTEST_STACK_SIZE + CONFIG_TEST_EXTRA_STACK_SIZE);
+
+/**
  * @}
  */
 

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -583,8 +583,12 @@ out:
 #define FAIL_FAST 0
 #endif
 
-static K_THREAD_STACK_DEFINE(ztest_thread_stack,
-			     CONFIG_ZTEST_STACK_SIZE + CONFIG_TEST_EXTRA_STACK_SIZE);
+/*
+ * Declared with external linkage (see ztest_test.h) so that tests inspecting
+ * the runner thread's stack (e.g. the userspace memory-protection tests) can
+ * reference it.
+ */
+K_THREAD_STACK_DEFINE(ztest_thread_stack, CONFIG_ZTEST_STACK_SIZE + CONFIG_TEST_EXTRA_STACK_SIZE);
 
 static void test_finalize(void)
 {

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -773,7 +773,6 @@ ZTEST(userspace_domain, test_1st_init_and_access_other_memdomain)
 #if (defined(CONFIG_ARM) || (defined(CONFIG_GEN_PRIV_STACKS) && defined(CONFIG_RISCV)))
 extern uint8_t *z_priv_stack_find(void *obj);
 #endif
-extern k_thread_stack_t ztest_thread_stack[];
 
 /**
  * Show that changing between memory domains and dropping to user mode works


### PR DESCRIPTION
Commit b1add060ac ("testsuite: ztest: address MISRA Rule 2.7 and 8.4")
gave ztest_thread_stack internal linkage to satisfy Rule 8.4. That broke
the userspace memory-protection test, which references the symbol from a
different translation unit to inspect the runner thread's stack, so the
test failed to link.

Restore external linkage and instead satisfy Rule 8.4 by declaring the
stack in ztest_test.h before its definition.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
