### PR TITLE
net: ocpp: guard second strtok_r return before atoi

### DIFF
--- a/subsys/net/lib/ocpp/ocpp.c
+++ b/subsys/net/lib/ocpp/ocpp.c
@@ -364,6 +364,9 @@ static int ocpp_process_server_msg(struct ocpp_info *ctx)
 		sh = (struct ocpp_session *)(uintptr_t)atoi(buf);
 
 		buf = strtok_r(NULL, "-", &tmp);
+		if (buf == NULL) {
+			return -EINVAL;
+		}
 		pdu = atoi(buf);
 
 		if (!ocpp_session_is_valid(sh)) {


### PR DESCRIPTION
`ocpp_process_server_msg()` guards the first `strtok_r(uid, "-", &tmp)`
result but then calls `atoi()` on the second `strtok_r(NULL, "-", &tmp)`
result without the same check. When the CALLRESULT `uid` has a first
token but no second `-`-delimited token, `strtok_r` returns NULL and
`atoi(NULL)` is undefined behaviour.

Return `-EINVAL` when the second token is absent, matching the existing
first-token guard.

Fixes: #113755