### PR TITLE
net: various fixes in dns/dhcp/ptp

### DIFF
--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -922,6 +922,9 @@ static int dhcpv6_parse_option_iaaddr(struct net_pkt *pkt, uint16_t length,
 			break;
 		}
 
+		if (sublen + 4U > length) {
+			return -EBADMSG;
+		}
 		length -= (sublen + 4);
 	}
 
@@ -1015,6 +1018,9 @@ static int dhcpv6_parse_option_ia_na(struct net_pkt *pkt, uint16_t length,
 			break;
 		}
 
+		if (sublen + 4U > length) {
+			return -EBADMSG;
+		}
 		length -= (sublen + 4);
 	}
 
@@ -1098,6 +1104,9 @@ static int dhcpv6_parse_option_iaprefix(struct net_pkt *pkt, uint16_t length,
 			break;
 		}
 
+		if (sublen + 4U > length) {
+			return -EBADMSG;
+		}
 		length -= (sublen + 4);
 	}
 
@@ -1190,6 +1199,9 @@ static int dhcpv6_parse_option_ia_pd(struct net_pkt *pkt, uint16_t length,
 			break;
 		}
 
+		if (sublen + 4U > length) {
+			return -EBADMSG;
+		}
 		length -= (sublen + 4);
 	}
 

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -245,7 +245,7 @@ static int create_answer(enum dns_rr_type qtype,
 	if ((net_buf_max_len(query) - query->len) < (DNS_MSG_HEADER_SIZE + 1 +
 					  (DNS_QTYPE_LEN + DNS_QCLASS_LEN) * 2 +
 					  DNS_TTL_LEN + DNS_RDLENGTH_LEN +
-					  addr_len + query->len)) {
+					  addr_len)) {
 		return -ENOBUFS;
 	}
 

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -485,9 +485,9 @@ static int dns_read(int sock,
 			dns_qtype_to_str(qtype), "IN",
 			result->data, ret);
 
-		/* If the query matches to our hostname, then send reply */
-		if (!strncasecmp(hostname, result->data, hostname_len) &&
-		    (result->len) >= hostname_len) {
+		if (!strncasecmp(hostname, result->data,
+				 MIN(hostname_len, result->len)) &&
+		    (result->len) == hostname_len) {
 			NET_DBG("%s query to our hostname %s", "LLMNR",
 				hostname);
 			ret = send_response(sock, src_addr, addrlen, result, qtype,

--- a/subsys/net/lib/ptp/tlv.c
+++ b/subsys/net/lib/ptp/tlv.c
@@ -240,6 +240,9 @@ static int tlv_mgmt_post_recv(struct ptp_tlv_mgmt *mgmt_tlv, uint16_t length)
 		port_ds->mean_link_delay = net_ntohll(port_ds->mean_link_delay);
 		break;
 	case PTP_MGMT_TIME:
+		if (length < sizeof(struct ptp_timestamp)) {
+			return -EBADMSG;
+		}
 		ts = *(struct ptp_timestamp *)mgmt_tlv->data;
 
 		ts.seconds_high = net_ntohs(ts.seconds_high);


### PR DESCRIPTION
- **net: dns: fix LLMNR hostname match to require exact length**
- **net: dns: fix LLMNR reply space check arithmetic**
- **net: dhcpv6: prevent uint16_t underflow in nested-option loops**
- **net: ptp: validate TLV length for MGMT_TIME before timestamp access**

Fixes: #113352