### PR TITLE
fs: ext2: reject s_blocks_count exceeding single-group bitmap capacity

### DIFF
--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -361,6 +361,11 @@ int ext2_init_fs(struct ext2_data *fs)
 	struct ext2_superblock *sb = &fs->sblock;
 	uint32_t fs_blocks = sb->s_blocks_count - sb->s_first_data_block;
 
+	if (fs_blocks > (uint32_t)(fs->block_size * 8U)) {
+		error_behavior(fs, "s_blocks_count exceeds single-group bitmap capacity");
+		return -EINVAL;
+	}
+
 	set = ext2_bitmap_count_set(BGROUP_BLOCK_BITMAP(&fs->bgroup), fs_blocks);
 
 	if (set != sb->s_blocks_count - sb->s_free_blocks_count - sb->s_first_data_block) {


### PR DESCRIPTION
The block bitmap validation passed fs_blocks = s_blocks_count - s_first_data_block
directly to ext2_bitmap_count_set() without checking whether it exceeds
the bitmap's capacity of block_size × 8 bits. A crafted image could
trigger a ~512 MB bitmap scan with a heap over-read.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>

Fixes: #113350