### PR TITLE
drivers: lora: add CAD support to LBM backends

### DIFF
--- a/drivers/lora/lora-basics-modem/lbm_common.c
+++ b/drivers/lora/lora-basics-modem/lbm_common.c
@@ -22,8 +22,9 @@ LOG_MODULE_REGISTER(lbm_driver, CONFIG_LORA_LOG_LEVEL);
  * Additionally, enable LDRO in additional situations described in Lora Basic Modem lr1mac
  * where t < 16 from ral_compute_lora_ldro: Bandwidth less than 41 Khz, and SF9 with BW 41 KHz
  */
-#define LORA_LDRO(sf, bw) ((((1 << sf) / bw) >= 16 ? 1 : 0) \
-	| (bw < BW_41_KHZ || (bw == BW_41_KHZ && sf == SF_9) ? 1 : 0))
+#define LORA_LDRO(sf, bw)                                                                          \
+	((((1 << sf) / bw) >= 16 ? 1 : 0) |                                                        \
+	 (bw < BW_41_KHZ || (bw == BW_41_KHZ && sf == SF_9) ? 1 : 0))
 
 /**
  * @brief Attempt to acquire the modem for operations
@@ -80,24 +81,50 @@ static bool modem_release(const struct device *dev)
 	return true;
 }
 
+/**
+ * @brief Convert zephyr's lora_cad_symbol_num to ral_lora_cad_symbs_t
+ *
+ * @param sym variable containing Zephyr's symbol
+ *
+ * @retval converted symbol value to ral_lora_cad_symbs_t
+ */
+static ral_lora_cad_symbs_t lora_cad_symb_to_ral(enum lora_cad_symbol_num sym)
+{
+	switch (sym) {
+	case LORA_CAD_SYMB_2:
+		return RAL_LORA_CAD_02_SYMB;
+	case LORA_CAD_SYMB_4:
+		return RAL_LORA_CAD_04_SYMB;
+	case LORA_CAD_SYMB_8:
+		return RAL_LORA_CAD_08_SYMB;
+	case LORA_CAD_SYMB_16:
+		return RAL_LORA_CAD_16_SYMB;
+	default:
+		return RAL_LORA_CAD_01_SYMB;
+	}
+}
+
 int lbm_lora_config(const struct device *dev, const struct lora_modem_config *lora_config)
 {
 	const struct lbm_lora_config_common *config = dev->config;
 	struct lbm_lora_data_common *data = dev->data;
+	ral_lora_mod_params_t mod_params = {
+		.sf = lora_config->datarate,
+		.cr = lora_config->coding_rate,
+		.ldro = config->force_ldro
+				? 1
+				: LORA_LDRO(lora_config->datarate, lora_config->bandwidth),
+	};
+	ral_lora_pkt_params_t pkt_params = {
+		.preamble_len_in_symb = lora_config->preamble_len,
+		.header_type = RAL_LORA_PKT_EXPLICIT,
+		.pld_len_in_bytes = UINT8_MAX,
+		.crc_is_on = !lora_config->packet_crc_disable,
+		.invert_iq_is_on = lora_config->iq_inverted,
+	};
 	ralf_params_lora_t params = {
-		.mod_params = {
-			.sf = lora_config->datarate,
-			.cr = lora_config->coding_rate,
-			.ldro = config->force_ldro ? 1 : LORA_LDRO(lora_config->datarate,
-								   lora_config->bandwidth),
-		},
-		.pkt_params = {
-			.preamble_len_in_symb = lora_config->preamble_len,
-			.header_type = RAL_LORA_PKT_EXPLICIT,
-			.pld_len_in_bytes = UINT8_MAX,
-			.crc_is_on = !lora_config->packet_crc_disable,
-			.invert_iq_is_on = lora_config->iq_inverted,
-		},
+		.mod_params = mod_params,
+		.pkt_params = pkt_params,
 		.rf_freq_in_hz = lora_config->frequency,
 		.output_pwr_in_dbm = lora_config->tx_power,
 		.sync_word = 0,
@@ -180,6 +207,7 @@ int lbm_lora_config(const struct device *dev, const struct lora_modem_config *lo
 	/* Store TX parameters for use in the TX functions */
 	data->mod_params = params.mod_params;
 	data->pkt_params = params.pkt_params;
+	data->cad_config = lora_config->cad;
 
 	status = ralf_setup_lora(&config->ralf, &params);
 	ret = status == RAL_STATUS_OK ? 0 : -EIO;
@@ -471,6 +499,85 @@ release:
 	return ret;
 }
 
+static int lbm_cad_setup_and_start(const struct device *dev)
+{
+	const struct lbm_lora_config_common *config = dev->config;
+	struct lbm_lora_data_common *data = dev->data;
+	ral_lora_cad_params_t cad_params = {
+		.cad_symb_nb = lora_cad_symb_to_ral(data->cad_config.symbol_num),
+		.cad_det_peak_in_symb = data->cad_config.detection_peak,
+		.cad_det_min_in_symb = data->cad_config.detection_minimum,
+		.cad_exit_mode = (ral_lora_cad_exit_modes_t)data->cad_config.mode,
+		.cad_timeout_in_ms = data->cad_config.timeout,
+	};
+	ral_status_t status;
+
+	lbm_driver_antenna_configure(dev, MODE_CAD);
+	data->modem_mode = MODE_CAD;
+
+	status = ral_set_lora_cad_params(&config->ralf.ral, &cad_params);
+	if (status != RAL_STATUS_OK) {
+		return -EIO;
+	}
+
+	status = ral_set_lora_cad(&config->ralf.ral);
+	return status == RAL_STATUS_OK ? 0 : -EIO;
+}
+
+int lbm_lora_cad_async(const struct device *dev, lora_cad_cb cb, void *user_data)
+{
+	struct lbm_lora_data_common *data = dev->data;
+	int ret;
+
+	if (!modem_acquire(dev)) {
+		return -EBUSY;
+	}
+
+	data->cad_state.cb = cb;
+	data->cad_state.user_data = user_data;
+	data->operation_done = NULL;
+
+	ret = lbm_cad_setup_and_start(dev);
+	if (ret < 0) {
+		modem_release(dev);
+	}
+	return ret;
+}
+
+int lbm_lora_cad(const struct device *dev, k_timeout_t timeout)
+{
+	struct k_poll_signal done = K_POLL_SIGNAL_INITIALIZER(done);
+	struct k_poll_event evt =
+		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &done);
+	struct lbm_lora_data_common *data = dev->data;
+	int ret;
+
+	if (!modem_acquire(dev)) {
+		return -EBUSY;
+	}
+
+	data->cad_state.cb = NULL;
+	data->operation_done = &done;
+
+	ret = lbm_cad_setup_and_start(dev);
+	if (ret < 0) {
+		modem_release(dev);
+		return ret;
+	}
+
+	ret = k_poll(&evt, 1, timeout);
+	if (ret < 0) {
+		if (modem_release(dev)) {
+			LOG_INF("CAD timeout");
+			return -EAGAIN;
+		}
+		/* IRQ handler is currently running, wait for it to finish */
+		k_poll(&evt, 1, K_FOREVER);
+	}
+
+	return done.result;
+}
+
 static int op_done_sync_rx(const struct device *dev)
 {
 	const struct lbm_lora_config_common *config = dev->config;
@@ -544,6 +651,9 @@ static void op_done_work_handler(struct k_work *work)
 	const struct device *dev = data->dev;
 	const struct lbm_lora_config_common *config = dev->config;
 	struct k_poll_signal *sig_done;
+	lora_cad_cb cad_cb = NULL;
+	void *cad_user_data = NULL;
+	bool channel_busy = false;
 	ral_irq_t irq_state;
 	ral_status_t status;
 	bool release = false;
@@ -584,7 +694,17 @@ static void op_done_work_handler(struct k_work *work)
 		/* Don't release the modem here, RX continues */
 		break;
 	case MODE_CAD:
-		LOG_DBG("CAD complete (TBC)");
+		ral_irq_t cad_irq;
+
+		(void)ral_get_and_clear_irq_status(&config->ralf.ral, &cad_irq);
+		channel_busy = (cad_irq & RAL_IRQ_CAD_OK) != 0;
+		ret = channel_busy ? 1 : 0;
+		LOG_DBG("CAD complete, channel_busy=%d", channel_busy);
+		cad_cb = data->cad_state.cb;
+		cad_user_data = data->cad_state.user_data;
+		data->cad_state.cb = NULL;
+		/* Don't release the modem if exit mode is RAL_LORA_CAD_RX, Rx continues */
+		release = (data->cad_config.mode != LORA_CAD_MODE_RX);
 		break;
 	}
 
@@ -617,6 +737,11 @@ static void op_done_work_handler(struct k_work *work)
 	/* Notify user that operation has completed */
 	if (sig_done) {
 		k_poll_signal_raise(sig_done, error_irq ? -EAGAIN : ret);
+	}
+
+	/* Notify user space through the callback */
+	if (cad_cb) {
+		cad_cb(dev, channel_busy, cad_user_data);
 	}
 }
 
@@ -661,4 +786,6 @@ DEVICE_API(lora, lbm_lora_api) = {
 	.recv = lbm_lora_recv,
 	.recv_async = lbm_lora_recv_async,
 	.test_cw = lbm_lora_test_cw,
+	.cad = lbm_lora_cad,
+	.cad_async = lbm_lora_cad_async,
 };

--- a/drivers/lora/lora-basics-modem/lbm_common.h
+++ b/drivers/lora/lora-basics-modem/lbm_common.h
@@ -64,6 +64,13 @@ struct lbm_lora_data_common {
 			void *user_data;
 		} async;
 	} rx_state;
+	/* CAD configuration (saved from lora_config) */
+	struct lora_cad_config cad_config;
+	/* CAD async state */
+	struct {
+		lora_cad_cb cb;
+		void *user_data;
+	} cad_state;
 	/* User signal */
 	struct k_poll_signal *operation_done;
 	/* Current modem state */

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -38,21 +38,21 @@ extern "C" {
  * higher data rates but typically reduce sensitivity and range.
  */
 enum lora_signal_bandwidth {
-	BW_7_KHZ = 7,		/**< 7.81 kHz */
-	BW_10_KHZ = 10,		/**< 10.42 kHz */
-	BW_15_KHZ = 15,		/**< 15.63 kHz */
-	BW_20_KHZ = 20,		/**< 20.83 kHz */
-	BW_31_KHZ = 31,		/**< 31.25 kHz */
-	BW_41_KHZ = 41,		/**< 41.67 kHz */
-	BW_62_KHZ = 62,		/**< 62.5 kHz */
-	BW_125_KHZ = 125,	/**< 125 kHz */
-	BW_200_KHZ = 200,	/**< 203 kHz */
-	BW_250_KHZ = 250,	/**< 250 kHz */
-	BW_400_KHZ = 400,	/**< 406 kHz */
-	BW_500_KHZ = 500,	/**< 500 kHz */
-	BW_800_KHZ = 800,	/**< 812 kHz */
-	BW_1000_KHZ = 1000,	/**< 1000 kHz */
-	BW_1600_KHZ = 1600,	/**< 1625 kHz */
+	BW_7_KHZ = 7,       /**< 7.81 kHz */
+	BW_10_KHZ = 10,     /**< 10.42 kHz */
+	BW_15_KHZ = 15,     /**< 15.63 kHz */
+	BW_20_KHZ = 20,     /**< 20.83 kHz */
+	BW_31_KHZ = 31,     /**< 31.25 kHz */
+	BW_41_KHZ = 41,     /**< 41.67 kHz */
+	BW_62_KHZ = 62,     /**< 62.5 kHz */
+	BW_125_KHZ = 125,   /**< 125 kHz */
+	BW_200_KHZ = 200,   /**< 203 kHz */
+	BW_250_KHZ = 250,   /**< 250 kHz */
+	BW_400_KHZ = 400,   /**< 406 kHz */
+	BW_500_KHZ = 500,   /**< 500 kHz */
+	BW_800_KHZ = 800,   /**< 812 kHz */
+	BW_1000_KHZ = 1000, /**< 1000 kHz */
+	BW_1600_KHZ = 1600, /**< 1625 kHz */
 };
 
 /**
@@ -64,14 +64,14 @@ enum lora_signal_bandwidth {
  * symbol). Higher values result in lower data rates but increased range and robustness.
  */
 enum lora_datarate {
-	SF_5 = 5,	/**< Spreading factor 5 (fastest, shortest range) */
-	SF_6 = 6,	/**< Spreading factor 6 */
-	SF_7 = 7,	/**< Spreading factor 7 */
-	SF_8 = 8,	/**< Spreading factor 8 */
-	SF_9 = 9,	/**< Spreading factor 9 */
-	SF_10 = 10,	/**< Spreading factor 10 */
-	SF_11 = 11,	/**< Spreading factor 11 */
-	SF_12 = 12,	/**< Spreading factor 12 (slowest, longest range) */
+	SF_5 = 5,   /**< Spreading factor 5 (fastest, shortest range) */
+	SF_6 = 6,   /**< Spreading factor 6 */
+	SF_7 = 7,   /**< Spreading factor 7 */
+	SF_8 = 8,   /**< Spreading factor 8 */
+	SF_9 = 9,   /**< Spreading factor 9 */
+	SF_10 = 10, /**< Spreading factor 10 */
+	SF_11 = 11, /**< Spreading factor 11 */
+	SF_12 = 12, /**< Spreading factor 12 (slowest, longest range) */
 };
 
 /**
@@ -84,10 +84,10 @@ enum lora_datarate {
  * error tolerance at the cost of data rate.
  */
 enum lora_coding_rate {
-	CR_4_5 = 1,  /**< Coding rate 4/5 (4 information bits, 1 error correction bit) */
-	CR_4_6 = 2,  /**< Coding rate 4/6 (4 information bits, 2 error correction bits) */
-	CR_4_7 = 3,  /**< Coding rate 4/7 (4 information bits, 3 error correction bits) */
-	CR_4_8 = 4,  /**< Coding rate 4/8 (4 information bits, 4 error correction bits) */
+	CR_4_5 = 1, /**< Coding rate 4/5 (4 information bits, 1 error correction bit) */
+	CR_4_6 = 2, /**< Coding rate 4/6 (4 information bits, 2 error correction bits) */
+	CR_4_7 = 3, /**< Coding rate 4/7 (4 information bits, 3 error correction bits) */
+	CR_4_8 = 4, /**< Coding rate 4/8 (4 information bits, 4 error correction bits) */
 };
 
 /**
@@ -97,11 +97,11 @@ enum lora_coding_rate {
  * consumption.
  */
 enum lora_cad_symbol_num {
-	LORA_CAD_SYMB_1 = 1,	/**< 1 symbol */
-	LORA_CAD_SYMB_2 = 2,	/**< 2 symbols */
-	LORA_CAD_SYMB_4 = 4,	/**< 4 symbols */
-	LORA_CAD_SYMB_8 = 8,	/**< 8 symbols */
-	LORA_CAD_SYMB_16 = 16,	/**< 16 symbols */
+	LORA_CAD_SYMB_1 = 1,   /**< 1 symbol */
+	LORA_CAD_SYMB_2 = 2,   /**< 2 symbols */
+	LORA_CAD_SYMB_4 = 4,   /**< 4 symbols */
+	LORA_CAD_SYMB_8 = 8,   /**< 8 symbols */
+	LORA_CAD_SYMB_16 = 16, /**< 16 symbols */
 };
 
 /**
@@ -127,6 +127,36 @@ enum lora_cad_mode {
 	 * transmitting and returns -EBUSY if the channel is busy.
 	 */
 	LORA_CAD_MODE_LBT,
+};
+
+/**
+ * @struct lora_cad_config
+ * Structure containing the configuration of a LoRa modem's Channel Activity detection (CAD)
+ */
+struct lora_cad_config {
+	/** CAD mode. See @ref lora_cad_mode for details. */
+	enum lora_cad_mode mode;
+
+	/** Number of symbols for CAD detection. 0 = driver default. */
+	enum lora_cad_symbol_num symbol_num;
+
+	/**
+	 * Detection peak threshold (hardware-specific, dimensionless).
+	 * Passed directly to the radio. 0 = auto-derive from SF/BW.
+	 */
+	uint8_t detection_peak;
+
+	/**
+	 * Minimum detection threshold (hardware-specific, dimensionless).
+	 * Passed directly to the radio. 0 = auto-derive from SF/BW.
+	 */
+	uint8_t detection_minimum;
+
+	/**
+	 * Timeout in ms to prevent the radio staying in Rx mode indefinitely
+	 * if LORA_CAD_MODE_RX has been selected.
+	 */
+	uint32_t timeout;
 };
 
 /**
@@ -186,25 +216,7 @@ struct lora_modem_config {
 	bool packet_crc_disable;
 
 	/** Channel Activity Detection parameters. */
-	struct {
-		/** CAD mode. See @ref lora_cad_mode for details. */
-		enum lora_cad_mode mode;
-
-		/** Number of symbols for CAD detection. 0 = driver default. */
-		enum lora_cad_symbol_num symbol_num;
-
-		/**
-		 * Detection peak threshold (hardware-specific, dimensionless).
-		 * Passed directly to the radio. 0 = auto-derive from SF/BW.
-		 */
-		uint8_t detection_peak;
-
-		/**
-		 * Minimum detection threshold (hardware-specific, dimensionless).
-		 * Passed directly to the radio. 0 = auto-derive from SF/BW.
-		 */
-		uint8_t detection_minimum;
-	} cad;
+	struct lora_cad_config cad;
 };
 
 /**
@@ -218,8 +230,8 @@ struct lora_modem_config {
  *
  * @see lora_recv() for argument descriptions.
  */
-typedef void (*lora_recv_cb)(const struct device *dev, uint8_t *data, uint16_t size,
-			     int16_t rssi, int8_t snr, void *user_data);
+typedef void (*lora_recv_cb)(const struct device *dev, uint8_t *data, uint16_t size, int16_t rssi,
+			     int8_t snr, void *user_data);
 
 /**
  * @brief Callback API for channel activity detection asynchronously
@@ -228,16 +240,14 @@ typedef void (*lora_recv_cb)(const struct device *dev, uint8_t *data, uint16_t s
  * @param activity_detected true if LoRa activity was detected on the channel
  * @param user_data         User data passed to @ref lora_cad_async
  */
-typedef void (*lora_cad_cb)(const struct device *dev, bool activity_detected,
-			    void *user_data);
+typedef void (*lora_cad_cb)(const struct device *dev, bool activity_detected, void *user_data);
 
 /**
  * @brief Callback API for configuring the LoRa module
  *
  * @see lora_config() for argument descriptions.
  */
-typedef int (*lora_api_config)(const struct device *dev,
-			       const struct lora_modem_config *config);
+typedef int (*lora_api_config)(const struct device *dev, const struct lora_modem_config *config);
 
 /**
  * @brief Callback API for querying packet airtime
@@ -251,16 +261,14 @@ typedef uint32_t (*lora_api_airtime)(const struct device *dev, uint32_t data_len
  *
  * @see lora_send() for argument descriptions.
  */
-typedef int (*lora_api_send)(const struct device *dev,
-			     uint8_t *data, uint32_t data_len);
+typedef int (*lora_api_send)(const struct device *dev, uint8_t *data, uint32_t data_len);
 
 /**
  * @brief Callback API for sending data asynchronously over LoRa
  *
  * @see lora_send_async() for argument descriptions.
  */
-typedef int (*lora_api_send_async)(const struct device *dev,
-				   uint8_t *data, uint32_t data_len,
+typedef int (*lora_api_send_async)(const struct device *dev, uint8_t *data, uint32_t data_len,
 				   struct k_poll_signal *async);
 
 /**
@@ -268,8 +276,7 @@ typedef int (*lora_api_send_async)(const struct device *dev,
  *
  * @see lora_recv() for argument descriptions.
  */
-typedef int (*lora_api_recv)(const struct device *dev, uint8_t *data,
-			     uint8_t size,
+typedef int (*lora_api_recv)(const struct device *dev, uint8_t *data, uint8_t size,
 			     k_timeout_t timeout, int16_t *rssi, int8_t *snr);
 
 /**
@@ -278,8 +285,7 @@ typedef int (*lora_api_recv)(const struct device *dev, uint8_t *data,
  * @param dev Modem to receive data on.
  * @param cb Callback to run on receiving data.
  */
-typedef int (*lora_api_recv_async)(const struct device *dev, lora_recv_cb cb,
-			     void *user_data);
+typedef int (*lora_api_recv_async)(const struct device *dev, lora_recv_cb cb, void *user_data);
 
 /**
  * @brief Callback API for channel activity detection
@@ -293,8 +299,7 @@ typedef int (*lora_api_cad)(const struct device *dev, k_timeout_t timeout);
  *
  * @see lora_cad_async() for argument descriptions.
  */
-typedef int (*lora_api_cad_async)(const struct device *dev, lora_cad_cb cb,
-				  void *user_data);
+typedef int (*lora_api_cad_async)(const struct device *dev, lora_cad_cb cb, void *user_data);
 
 /**
  * @typedef lora_api_recv_duty_cycle()
@@ -302,12 +307,9 @@ typedef int (*lora_api_cad_async)(const struct device *dev, lora_cad_cb cb,
  *
  * @see lora_recv_duty_cycle() for argument descriptions.
  */
-typedef int (*lora_api_recv_duty_cycle)(const struct device *dev,
-					k_timeout_t rx_period,
-					k_timeout_t sleep_period,
-					uint8_t *data, uint8_t size,
-					k_timeout_t timeout,
-					int16_t *rssi, int8_t *snr);
+typedef int (*lora_api_recv_duty_cycle)(const struct device *dev, k_timeout_t rx_period,
+					k_timeout_t sleep_period, uint8_t *data, uint8_t size,
+					k_timeout_t timeout, int16_t *rssi, int8_t *snr);
 
 /**
  * @typedef lora_api_recv_duty_cycle_async()
@@ -315,18 +317,17 @@ typedef int (*lora_api_recv_duty_cycle)(const struct device *dev,
  *
  * @see lora_recv_duty_cycle_async() for argument descriptions.
  */
-typedef int (*lora_api_recv_duty_cycle_async)(const struct device *dev,
-					      k_timeout_t rx_period,
-					      k_timeout_t sleep_period,
-					      lora_recv_cb cb, void *user_data);
+typedef int (*lora_api_recv_duty_cycle_async)(const struct device *dev, k_timeout_t rx_period,
+					      k_timeout_t sleep_period, lora_recv_cb cb,
+					      void *user_data);
 
 /**
  * @brief Callback API for transmitting a continuous wave
  *
  * @see lora_test_cw() for argument descriptions.
  */
-typedef int (*lora_api_test_cw)(const struct device *dev, uint32_t frequency,
-				int8_t tx_power, uint16_t duration);
+typedef int (*lora_api_test_cw)(const struct device *dev, uint32_t frequency, int8_t tx_power,
+				uint16_t duration);
 
 /**
  * @driver_ops{LoRa}
@@ -366,8 +367,7 @@ __subsystem struct lora_driver_api {
 		  modem
  * @return 0 on success, negative on error
  */
-static inline int lora_config(const struct device *dev,
-			      const struct lora_modem_config *config)
+static inline int lora_config(const struct device *dev, const struct lora_modem_config *config)
 {
 	return DEVICE_API_GET(lora, dev)->config(dev, config);
 }
@@ -398,8 +398,7 @@ static inline uint32_t lora_airtime(const struct device *dev, uint32_t data_len)
  * @param data_len  Length of the data to be sent
  * @return 0 on success, negative on error
  */
-static inline int lora_send(const struct device *dev,
-			    uint8_t *data, uint32_t data_len)
+static inline int lora_send(const struct device *dev, uint8_t *data, uint32_t data_len)
 {
 	return DEVICE_API_GET(lora, dev)->send(dev, data, data_len);
 }
@@ -420,8 +419,7 @@ static inline int lora_send(const struct device *dev,
  *        notify the end of the transmission).
  * @return 0 on success, negative on error
  */
-static inline int lora_send_async(const struct device *dev,
-				  uint8_t *data, uint32_t data_len,
+static inline int lora_send_async(const struct device *dev, uint8_t *data, uint32_t data_len,
 				  struct k_poll_signal *async)
 {
 	return DEVICE_API_GET(lora, dev)->send_async(dev, data, data_len, async);
@@ -443,8 +441,7 @@ static inline int lora_send_async(const struct device *dev,
  * @param snr       SNR of received data
  * @return Length of the data received on success, negative on error
  */
-static inline int lora_recv(const struct device *dev, uint8_t *data,
-			    uint8_t size,
+static inline int lora_recv(const struct device *dev, uint8_t *data, uint8_t size,
 			    k_timeout_t timeout, int16_t *rssi, int8_t *snr)
 {
 	return DEVICE_API_GET(lora, dev)->recv(dev, data, size, timeout, rssi, snr);
@@ -465,8 +462,7 @@ static inline int lora_recv(const struct device *dev, uint8_t *data,
  * @param user_data User data passed to callback
  * @return 0 when reception successfully setup, negative on error
  */
-static inline int lora_recv_async(const struct device *dev, lora_recv_cb cb,
-			       void *user_data)
+static inline int lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user_data)
 {
 	return DEVICE_API_GET(lora, dev)->recv_async(dev, cb, user_data);
 }
@@ -512,8 +508,7 @@ static inline int lora_cad(const struct device *dev, k_timeout_t timeout)
  * @param user_data  User data passed to callback
  * @return 0 on success, negative on error
  */
-static inline int lora_cad_async(const struct device *dev, lora_cad_cb cb,
-				 void *user_data)
+static inline int lora_cad_async(const struct device *dev, lora_cad_cb cb, void *user_data)
 {
 	const struct lora_driver_api *api = DEVICE_API_GET(lora, dev);
 
@@ -546,12 +541,9 @@ static inline int lora_cad_async(const struct device *dev, lora_cad_cb cb,
  * @param snr           SNR of received data
  * @return Length of the data received on success, negative on error
  */
-static inline int lora_recv_duty_cycle(const struct device *dev,
-				       k_timeout_t rx_period,
-				       k_timeout_t sleep_period,
-				       uint8_t *data, uint8_t size,
-				       k_timeout_t timeout,
-				       int16_t *rssi, int8_t *snr)
+static inline int lora_recv_duty_cycle(const struct device *dev, k_timeout_t rx_period,
+				       k_timeout_t sleep_period, uint8_t *data, uint8_t size,
+				       k_timeout_t timeout, int16_t *rssi, int8_t *snr)
 {
 	const struct lora_driver_api *api = DEVICE_API_GET(lora, dev);
 
@@ -559,8 +551,7 @@ static inline int lora_recv_duty_cycle(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	return api->recv_duty_cycle(dev, rx_period, sleep_period,
-				    data, size, timeout, rssi, snr);
+	return api->recv_duty_cycle(dev, rx_period, sleep_period, data, size, timeout, rssi, snr);
 }
 
 /**
@@ -581,10 +572,9 @@ static inline int lora_recv_duty_cycle(const struct device *dev,
  * @param user_data     User data passed to callback
  * @return 0 on success, negative on error
  */
-static inline int lora_recv_duty_cycle_async(const struct device *dev,
-					     k_timeout_t rx_period,
-					     k_timeout_t sleep_period,
-					     lora_recv_cb cb, void *user_data)
+static inline int lora_recv_duty_cycle_async(const struct device *dev, k_timeout_t rx_period,
+					     k_timeout_t sleep_period, lora_recv_cb cb,
+					     void *user_data)
 {
 	const struct lora_driver_api *api = DEVICE_API_GET(lora, dev);
 
@@ -607,8 +597,8 @@ static inline int lora_recv_duty_cycle_async(const struct device *dev,
  * @param duration  Transmission duration in seconds.
  * @return 0 on success, negative on error
  */
-static inline int lora_test_cw(const struct device *dev, uint32_t frequency,
-			       int8_t tx_power, uint16_t duration)
+static inline int lora_test_cw(const struct device *dev, uint32_t frequency, int8_t tx_power,
+			       uint16_t duration)
 {
 	const struct lora_driver_api *api = DEVICE_API_GET(lora, dev);
 
@@ -627,4 +617,4 @@ static inline int lora_test_cw(const struct device *dev, uint32_t frequency,
  * @}
  */
 
-#endif	/* ZEPHYR_INCLUDE_DRIVERS_LORA_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_LORA_H_ */


### PR DESCRIPTION
# Sumary

Add Channel Activity Detection (CAD) support for the LoRa Basics Modem (LBM) backend


The LBM common layer gains:
- `cad_config` / `cad_state` fields in `lbm_lora_data_common`
- `lora_cad_symb_to_ral()` conversion helper
- `lbm_cad_setup_and_start()` and `lbm_lora_cad_async()` entry points

# Video example

Here's an example running on Quectel's KG100S (patch to support it incoming after full support for the EFR32BG21 is added to Zephyr).

https://github.com/user-attachments/assets/88a4a511-e10a-44e4-8255-6cecaaaf57fc

On the left terminal there is a KG100S running the CAD example which checks if the channel is busy every 1 second. On the right terminal, the `lora/send` example is sending data every 100ms. Finally, there's an instance of SDRAngel running that shows traffic on the 915MHz channel.

NOTE: https://github.com/zephyrproject-rtos/zephyr/pull/111638 implements the CAD sample for testing and the lora native driver.

