### PR TITLE
drivers: sdhc: esp32: fix data sampling and add erase support

### DIFF
--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -18,6 +18,7 @@
 #include "sdhc_helpers.h"
 
 #include <esp_clk_tree.h>
+#include <esp_private/esp_clk_tree_common.h>
 #include <hal/sdmmc_ll.h>
 #include <esp_intr_alloc.h>
 #include <esp_timer.h>
@@ -143,6 +144,7 @@ static int sdmmc_host_set_clk_div(sdmmc_dev_t *sdio_hw, int div)
 	}
 
 	sdmmc_ll_set_clock_div(sdio_hw, div);
+	esp_clk_tree_enable_src(SDMMC_CLK_SRC_DEFAULT, true);
 	sdmmc_ll_select_clk_source(sdio_hw, SDMMC_CLK_SRC_DEFAULT);
 	sdmmc_ll_init_phase_delay(sdio_hw);
 #if SDMMC_LL_DELAY_PHASE_SUPPORTED

--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -145,6 +145,9 @@ static int sdmmc_host_set_clk_div(sdmmc_dev_t *sdio_hw, int div)
 	sdmmc_ll_set_clock_div(sdio_hw, div);
 	sdmmc_ll_select_clk_source(sdio_hw, SDMMC_CLK_SRC_DEFAULT);
 	sdmmc_ll_init_phase_delay(sdio_hw);
+#if SDMMC_LL_DELAY_PHASE_SUPPORTED
+	sdmmc_ll_set_din_delay_phase(sdio_hw, SDMMC_LL_DELAY_PHASE_0, SDMMC_LL_SPEED_MODE_LS);
+#endif
 
 	/* Wait for the clock to propagate */
 	esp_rom_delay_us(10);

--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -1261,6 +1261,20 @@ static int sdhc_esp32_request(const struct device *dev, struct sdhc_command *cmd
 		esp_cmd.flags = SCF_CMD_ADTC | SCF_RSP_R1;
 		break;
 
+	case SD_ERASE_BLOCK_START:
+	case SD_ERASE_BLOCK_END:
+		esp_cmd.flags = SCF_CMD_AC | SCF_RSP_R1;
+		break;
+
+	case SD_ERASE_BLOCK_OPERATION:
+		/*
+		 * The erase drives the card busy on DAT0 (R1b). Wait for the
+		 * busy signal to clear before returning so the caller does not
+		 * issue the next command while the erase is still in progress.
+		 */
+		esp_cmd.flags = SCF_CMD_AC | SCF_RSP_R1B | SCF_WAIT_BUSY;
+		break;
+
 	default:
 		LOG_INF("SDHC driver: command %u not supported", cmd->opcode);
 		return -ENOTSUP;


### PR DESCRIPTION
Program the SDMMC data-in sampling phase and enable the source clock before
selecting it, so reads sample correctly and high-speed/4-bit negotiation works
on cached SoCs (P4/S3). Also add the SD erase command sequence (CMD32/33/38).