### PR TITLE
drivers: microchip: interrupt_controller: Updates g1 driver for supporting pic32cmjh

### DIFF
--- a/drivers/interrupt_controller/intc_mchp_eic_g1.c
+++ b/drivers/interrupt_controller/intc_mchp_eic_g1.c
@@ -37,19 +37,24 @@ LOG_MODULE_REGISTER(intc_mchp_eic_g1, CONFIG_INTC_LOG_LEVEL);
 #define EIC_TRIG_TYPE_BIT_POS(eic_line)                                                            \
 	(NUM_OF_BITS_FOR_EACH_LINE * EIC_CONFIG_EIC_LINE_OFFSET(eic_line))
 /* Port A */
-#define PORTA_UNSUPPORTED_PINS DT_INST_PROP(0, porta_unsupported_pins)
+#define PORTA_UNSUPPORTED_PINS      DT_INST_PROP(0, porta_unsupported_pins)
+#define PORTA_SPECIAL_PINS_1        DT_INST_PROP_BY_IDX(0, porta_special_pins_1, 0)
+#define PORTA_SPECIAL_PINS_1_OFFSET DT_INST_PROP_BY_IDX(0, porta_special_pins_1, 1)
 
 /* Port B */
+#define PORTB_UNSUPPORTED_PINS    DT_INST_PROP(0, portb_unsupported_pins)
 /* The special pins need an offset when calculating the eic line */
 #define PORTB_SPECIAL_PINS        DT_INST_PROP_BY_IDX(0, portb_special_pins_1, 0)
 #define PORTB_SPECIAL_PINS_OFFSET DT_INST_PROP_BY_IDX(0, portb_special_pins_1, 1)
 
 /* Port C */
-#define PORTC_UNSUPPORTED_PINS DT_INST_PROP(0, portc_unsupported_pins)
-
+#define PORTC_SUPPORTED_PINS        DT_INST_PROP(0, portc_supported_pins)
+#define PORTC_UNSUPPORTED_PINS      DT_INST_PROP(0, portc_unsupported_pins)
 /* The special pins need an offset when calculating the eic line */
-#define PORTC_SPECIAL_PINS        DT_INST_PROP_BY_IDX(0, portc_special_pins_1, 0)
-#define PORTC_SPECIAL_PINS_OFFSET DT_INST_PROP_BY_IDX(0, portc_special_pins_1, 1)
+#define PORTC_SPECIAL_PINS_1        DT_INST_PROP_BY_IDX(0, portc_special_pins_1, 0)
+#define PORTC_SPECIAL_PINS_1_OFFSET DT_INST_PROP_BY_IDX(0, portc_special_pins_1, 1)
+#define PORTC_SPECIAL_PINS_2        DT_INST_PROP_BY_IDX(0, portc_special_pins_2, 0)
+#define PORTC_SPECIAL_PINS_2_OFFSET DT_INST_PROP_BY_IDX(0, portc_special_pins_2, 1)
 
 /* Port D */
 #define PORTD_SUPPORTED_PINS DT_INST_PROP(0, portd_supported_pins)
@@ -119,6 +124,48 @@ struct eic_mchp_dev_data {
  * It returns the EIC line number corresponding to the given port and pin.
  *         If the pin is unsupported, returns INTC_LINE_FREE.
  */
+#if defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH)
+uint8_t find_eic_line_from_pin(int port, int pin)
+{
+	uint8_t eic_line = pin % EIC_LINES_PER_PORT;
+	uint32_t pin_mask = BIT(pin);
+
+	switch (port) {
+	case MCHP_PORT_ID0:
+		if ((PORTA_UNSUPPORTED_PINS & pin_mask) != 0) {
+			eic_line = INTC_LINE_FREE;
+		} else if ((PORTA_SPECIAL_PINS_1 & pin_mask) != 0) {
+			eic_line += PORTA_SPECIAL_PINS_1_OFFSET;
+		} else {
+			/* Nothing to be done */
+		}
+		break;
+	case MCHP_PORT_ID1:
+		if ((PORTB_UNSUPPORTED_PINS & pin_mask) != 0) {
+			eic_line = INTC_LINE_FREE;
+		}
+		break;
+	case MCHP_PORT_ID2:
+		if ((PORTC_SUPPORTED_PINS & pin_mask) == 0) {
+			eic_line = INTC_LINE_FREE;
+		} else if ((PORTC_SPECIAL_PINS_1 & pin_mask) != 0) {
+			eic_line += PORTC_SPECIAL_PINS_1_OFFSET;
+		} else if ((PORTC_SPECIAL_PINS_2 & pin_mask) != 0) {
+			eic_line -= PORTC_SPECIAL_PINS_2_OFFSET;
+		} else {
+			/* Nothing to be done */
+		}
+		break;
+	default:
+		LOG_ERR("Unsupported port id provided");
+		break;
+	}
+
+	return eic_line;
+}
+
+#else
+
 uint8_t find_eic_line_from_pin(int port, int pin)
 {
 	uint8_t eic_line = pin % EIC_LINES_PER_PORT;
@@ -138,10 +185,10 @@ uint8_t find_eic_line_from_pin(int port, int pin)
 	case MCHP_PORT_ID2:
 		if ((PORTC_UNSUPPORTED_PINS & pin_mask) != 0) {
 			eic_line = INTC_LINE_FREE;
-		} else if ((PORTC_SPECIAL_PINS & pin_mask) != 0) {
-			eic_line += PORTC_SPECIAL_PINS_OFFSET;
+		} else if ((PORTC_SPECIAL_PINS_1 & pin_mask) != 0) {
+			eic_line += PORTC_SPECIAL_PINS_1_OFFSET;
 		} else {
-			/*Nothing to be done*/
+			/* Nothing to be done */
 		}
 		break;
 	case MCHP_PORT_ID3:
@@ -162,6 +209,7 @@ uint8_t find_eic_line_from_pin(int port, int pin)
 
 	return eic_line;
 }
+#endif /* CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH */
 
 static inline void eic_sync_wait(eic_registers_t *eic_reg)
 {
@@ -312,11 +360,13 @@ int eic_mchp_config_interrupt(struct eic_config_params *eic_pin_config)
 	eic_pin_config->port_addr->PORT_PMUX[pmux_offset] &=
 		((pin & 1) == 0) ? (~PORT_PMUX_PMUXE_Msk) : (~PORT_PMUX_PMUXO_Msk);
 
-/* The bit position for respective eic line in the config
- * register is calculated and written into the respective config
- * register
- */
-#ifdef CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG
+	/* The bit position for respective eic line in the config
+	 * register is calculated and written into the respective config
+	 * register
+	 */
+
+#if defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG) ||                                             \
+	defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH)
 	if (EIC_CONFIG_REG_IDX(eic_line) == 0) {
 		eic_cfg->regs->EIC_CONFIG0 &=
 			~(EIC_CONFIG_EIC_LINE_MSK << EIC_TRIG_TYPE_BIT_POS(eic_line));
@@ -337,7 +387,7 @@ int eic_mchp_config_interrupt(struct eic_config_params *eic_pin_config)
 	eic_cfg->regs->EIC_CONFIG[EIC_CONFIG_REG_IDX(eic_line)] |=
 		((eic_pin_config->trig_type) << EIC_TRIG_TYPE_BIT_POS(eic_line));
 
-#endif /*CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG*/
+#endif /* CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG || CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH */
 
 	/* Set the debouncing feature of the eic line if required */
 	if (eic_pin_config->debounce != 0) {
@@ -392,9 +442,66 @@ static int eic_mchp_init(const struct device *dev)
 
 #define EIC_MCHP_DATA_DEFN(n)        static struct eic_mchp_dev_data eic_mchp_data_##n
 #define EIC_MCHP_IRQ_HANDLER_DECL(n) static void eic_irq_connect_##n(void)
-#define EIC_MCHP_CREATE_HANDLERS(n)  LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)), EIC_MCHP_CB_INIT, (;),)
+
+#ifdef CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH
+/* A single ISR is kept because in this family we only have a single IRQ line for all the
+ * interrupts
+ */
+#define EIC_MCHP_CREATE_HANDLERS(n)
+#define EIC_NIBS_BIT_COUNT 4
+#define EIC_INT_NIBS       4
+#define EIC_NIBS_MASK      0xf
+
+static void eic_mchp_isr(const struct device *dev)
+{
+	const struct eic_mchp_dev_cfg *eic_cfg = dev->config;
+	struct eic_mchp_dev_data *eic_data = dev->data;
+	uint16_t eic_int_flag = eic_cfg->regs->EIC_INTFLAG;
+	uint8_t eic_line = 0;
+
+	eic_cfg->regs->EIC_INTFLAG = eic_int_flag;
+	/* Divides the interrupt flag into nibbles and
+	 *checks whether it has a set bit inside it
+	 */
+	for (int nibs = 0; nibs < EIC_INT_NIBS; nibs++) {
+		if ((eic_int_flag & (EIC_NIBS_MASK << eic_line)) == 0) {
+			eic_line += EIC_NIBS_BIT_COUNT;
+			continue;
+		}
+		/* find the set eic line from within the nibble
+		 * and call the callback as expected
+		 */
+		for (int i = 0; i < EIC_NIBS_BIT_COUNT; i++) {
+			if ((eic_int_flag & BIT(eic_line)) == 0) {
+				eic_line++;
+				continue;
+			}
+			uint8_t port_id = eic_data->lines[eic_line].port;
+
+			if (eic_data->eic_line_callback != NULL) {
+				uint32_t pins = BIT(eic_data->lines[eic_line].pin);
+
+				eic_data->eic_line_callback(pins, eic_data->gpio_data[port_id]);
+			}
+			eic_int_flag &= ~BIT(eic_line);
+			eic_line++;
+		}
+	}
+}
 
 /* clang-format off */
+#define EIC_MCHP_IRQ_CONNECT(eic_line, inst)                                                    \
+	IF_ENABLED(DT_INST_IRQ_HAS_IDX(inst, eic_line), (					\
+	do {											\
+		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(inst, eic_line, irq),				\
+				DT_INST_IRQ_BY_IDX(inst, eic_line, priority), eic_mchp_isr,	\
+				DEVICE_DT_INST_GET(inst), inst);				\
+		irq_enable(DT_INST_IRQ_BY_IDX(inst, eic_line, irq));				\
+	} while (false);									\
+			))
+#else
+
+#define EIC_MCHP_CREATE_HANDLERS(n)  LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)), EIC_MCHP_CB_INIT, (;),)
 #define EIC_MCHP_CB_INIT(eic_line, _)							\
 	static void eic_mchp_isr_##eic_line(const struct device *dev)			\
 	{										\
@@ -413,12 +520,12 @@ static int eic_mchp_init(const struct device *dev)
 	IF_ENABLED(DT_INST_IRQ_HAS_IDX(inst, eic_line), (					\
 	do {											\
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(inst, eic_line, irq),				\
-			    DT_INST_IRQ_BY_IDX(inst, eic_line, priority), eic_mchp_isr_##eic_line,\
-			    DEVICE_DT_INST_GET(inst), inst);					\
+			DT_INST_IRQ_BY_IDX(inst, eic_line, priority), eic_mchp_isr_##eic_line,	\
+			DEVICE_DT_INST_GET(inst), inst);					\
 		irq_enable(DT_INST_IRQ_BY_IDX(inst, eic_line, irq));				\
 	} while (false);									\
 			))
-
+#endif /* CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH */
 
 #define EIC_MCHP_CLOCK_DEFN(n)                                                                  \
 	.eic_clock.clock_dev = DEVICE_DT_GET(DT_NODELABEL(clock)),                              \

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
@@ -124,10 +124,31 @@
 			status = "disabled";
 		};
 
+		eic: interrupt-controller@40002800 {
+			compatible = "microchip,eic-g1-intc";
+			reg = <0x40002800 0x38>;
+			interrupts = <3 0>;
+			interrupt-names = "extint0-15";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBA_EIC>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_EIC>;
+			clock-names = "mclk", "gclk";
+			low-power-mode;
+
+			porta-unsupported-pins = <0xf4000100>; /*8|26|28|29|30|31*/
+			porta-special-pins-1 = <0xb000000 0x4>; /*24|25|27*/
+
+			portb-unsupported-pins = <0x20004300>; /*26|27|28|29*/
+
+			portc-supported-pins = <0xffef>; /*0|1|2|3|5|6|7|8|9|10|1|12|13|14|15*/
+			portc-special-pins-1 = <0xef 0x8>; /*0|1|2|3|5|6|7*/
+			portc-special-pins-2 = <0xff00 0x8>; /*8|9|10|1|12|13|14|15*/
+		};
+
 		pinctrl: pinctrl@41000000 {
 			compatible = "microchip,port-g1-pinctrl";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			reg = <0x41000000 0x180>;
 			ranges = <0x41000000 0x41000000 0x180>;
 
 			porta: gpio@41000000 {

--- a/dts/bindings/interrupt-controller/microchip,eic-g1-intc.yaml
+++ b/dts/bindings/interrupt-controller/microchip,eic-g1-intc.yaml
@@ -1,8 +1,19 @@
 # Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+title: Microchip EIC G1 device
+
 description: |
-  Microchip External Interrupt Controller for g1 peripherals
+  The Microchip G1 External Interrupt Controller (EIC) device provides interrupt
+  support for GPIO pins on Microchip G1 group of devices. As the mapping between
+  GPIO pins and EIC interrupt lines differs across devices, the devicetree
+  properties describes device-specific interrupt capabilities instead of hardcoding
+  them.
+
+  The devicetree binding provides the hardware-specific information including:
+   - GPIO pins that support external interrupts.
+   - GPIO pins that do not support external interrupts.
+   - GPIO pins whose EIC line mapping differs from the default mapping.
 
   Group g1 EIC supports following hardware peripherals:
     - module name="EIC" id="U2254" version="3.0.0"
@@ -49,12 +60,33 @@ properties:
       Each bit in the property denotes a pin number. This shows the pins which
       do not support interrupt for portc.
 
+  portc-supported-pins:
+    type: int
+    default: 0
+    description: |
+      Each bit in the property denotes a pin number. This shows the pins which
+      support interrupt in portc
+
   portd-supported-pins:
     type: int
     default: 0
     description: |
       Each bit in the property denotes a pin number. This shows the pins which
       support interrupt in portd
+
+  porta-special-pins-1:
+    type: array
+    default: [0, 0]
+    description: |
+      Each bit in this number denotes a pin number. These pins are derived from datasheet
+      by listing down the eic line and port-pin mapping.
+      The eic line mapping to the pin number requires a manipulation with an offset.
+
+  "#porta-special-pins-1-cells":
+    type: int
+    default: 2
+    description: |
+      Number of cells in portb-special-pins-1 property
 
   portb-special-pins-1:
     type: array
@@ -78,6 +110,19 @@ properties:
       The eic line mapping to the pin number requires a manipulation with an offset.
 
   "#portc-special-pins-1-cells":
+    type: int
+    default: 2
+    description: |
+      Number of cells in portc-special-pins-1 property
+
+  portc-special-pins-2:
+    type: array
+    default: [0, 0]
+    description: |
+      Each bit in this number denotes a pin number. These pins are derived from datasheet
+      The eic line mapping to the pin number requires a manipulation with an offset.
+
+  "#portc-special-pins-2-cells":
     type: int
     default: 2
     description: |
@@ -124,3 +169,28 @@ portd-special-pins-1-cells:
 portd-special-pins-2-cells:
   - pins_val
   - offset
+
+examples:
+  - |
+    The following example shows an EIC node in the SoC devicetree. The
+    `*-supported-pins` and `*-unsupported-pins` properties describe the
+    interrupt capabilities of GPIO pins for each port.
+
+    The `*-special-pins-*` properties are used for GPIO pins whose EIC line
+    cannot be derived directly from the pin number (for example, using
+    `pin_number % 16`). Each entry consists of a pin bitmask and an offset.
+
+    GPIO pins can be configured for interrupt operation using the standard Zephyr
+    GPIO APIs in the same way as any other GPIO pin.
+
+    eic: interrupt-controller@40001800 {
+      compatible = "microchip,eic-g1-intc";
+      reg = <0x40001800 0x400>;
+      interrupts = <20>;
+      interrupt-controller;
+      #interrupt-cells = <2>;
+
+      porta-unsupported-pins = <0x00000030>;
+      portc-supported-pins = <0x00FF0000>;
+      portc-special-pins-1 = <0x03000000 16>;
+    };


### PR DESCRIPTION
- Adds support for pic32cm jh family
- Adds new logic for eic line mapping to the port and pin
- Adds new ISR for devices with a single IRQ line in NVIC for interrupt
  controller
