### PR TITLE
xtensa: fix tests failing with exclusive access

### DIFF
--- a/include/zephyr/arch/xtensa/atomic_xtensa.h
+++ b/include/zephyr/arch/xtensa/atomic_xtensa.h
@@ -71,7 +71,7 @@ atomic_val_t xtensa_cas(atomic_t *addr, atomic_val_t oldval,
 		 * Otherwise, we must return some other value to signal that
 		 * the store failed to function caller.
 		 */
-		return (result == 1U) ? oldval : newval;
+		return (result == 1U) ? oldval : ~oldval;
 	}
 
 	/* Since *addr != oldval, we skip writing to memory and
@@ -79,7 +79,7 @@ atomic_val_t xtensa_cas(atomic_t *addr, atomic_val_t oldval,
 	 */
 	__asm__("clrex");
 
-	return newval;
+	return mem_val;
 }
 
 #elif XCHAL_HAVE_S32C1I


### PR DESCRIPTION
This partially reverts commit
73af3d6c8d3bdf68ec0ba938010a5816c17b192d on the return values.

Some portability tests starts failing with the atomic_cas() changes, and it was traced to the changes to the return values of atomic_cas(). Skimmed at the disassembly and it seems like the compiler is emitting instructions ignoring the false path, or optimizing the true path too aggressively due to being an inlined function. Maybe this is due to GCC not understand L32EX/S32EX as GCC has no native atomic support for them, and thus not understanding the effects of these instructions. Root cause is not entirely understood but this seems to fix the issue so this is here to unblock CI.