### PR TITLE
drivers: ethernet: stm32: skip HAL restart on link down

### DIFF
--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -240,8 +240,8 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 	/* The hal also needs to be stopped before changing the MAC config.
 	 * The speed can change without receiving a link down callback before.
 	 */
-	eth_stm32_hal_stop(dev, dev_data->iface);
 	if (state->is_up) {
+		eth_stm32_hal_stop(dev, dev_data->iface);
 		eth_stm32_set_mac_config(dev, state);
 		eth_stm32_hal_start(dev, dev_data->iface);
 	}


### PR DESCRIPTION
## Summary

- Avoid restarting the STM32 Ethernet HAL when the PHY reports link down
- Clear the network carrier immediately on link-down events
- Keep MAC reconfiguration and HAL restart behavior for link-up events