### PR TITLE
net: ptp: make PI servo gains configurable

### DIFF
--- a/subsys/net/lib/ptp/Kconfig
+++ b/subsys/net/lib/ptp/Kconfig
@@ -280,6 +280,30 @@ config PTP_SYNC_LOG_INTERVAL
 	  when transmitted as multicast messages. The value is the converted
 	  to nanoseconds as follow: nanoseconds = (10^9) * 2^(value)
 
+config PTP_SERVO_KP
+	int "PI servo proportional gain in thousandths"
+	default 700
+	range 0 10000
+	help
+	  Proportional gain used by the PTP clock PI servo, expressed in
+	  thousandths. For example, 700 configures a gain of 0.7
+
+	  The default is suitable for a Sync interval around one second.
+	  Shorter Sync intervals may require a smaller gain to avoid
+	  oscillation.
+
+config PTP_SERVO_KI
+	int "PI servo integral gain in thousandths"
+	default 300
+	range 0 10000
+	help
+	  Integral gain used by the PTP clock PI servo, expressed in
+	  thousandths. For example, 300 configures a gain of 0.3
+
+	  The default is suitable for a Sync interval around one second.
+	  Shorter Sync intervals may require a smaller gain to avoid
+	  oscillation.
+
 config PTP_MIN_PDELAY_REQ_LOG_INTERVAL
 	int "PDelay Req interval in Log2 base"
 	default 0

--- a/subsys/net/lib/ptp/clock.c
+++ b/subsys/net/lib/ptp/clock.c
@@ -50,6 +50,7 @@ LOG_MODULE_REGISTER(ptp_clock, CONFIG_PTP_LOG_LEVEL);
 #define SYNC_SERVO_OUTLIER_NS (100LL * NSEC_PER_MSEC)
 #define SYNC_SERVO_LOCK_SAMPLES 3U
 #define SYNC_SERVO_OUTLIER_SAMPLES 2U
+#define PTP_SERVO_GAIN_SCALE 1000.0
 
 /**
  * @brief PTP Clock structure.
@@ -542,8 +543,8 @@ int ptp_clock_management_msg_process(struct ptp_port *port, struct ptp_msg *msg)
 
 static double ptp_servo_pi(int64_t nanosecond_diff)
 {
-	double kp = 0.7;
-	double ki = 0.3;
+	const double kp = (double)CONFIG_PTP_SERVO_KP / PTP_SERVO_GAIN_SCALE;
+	const double ki = (double)CONFIG_PTP_SERVO_KI / PTP_SERVO_GAIN_SCALE;
 	double ppb;
 
 	ptp_clk.pi_drift += ki * nanosecond_diff;

--- a/tests/net/ptp/clock_decision/Kconfig
+++ b/tests/net/ptp/clock_decision/Kconfig
@@ -20,6 +20,12 @@ config PTP_PRIORITY1
 config PTP_PRIORITY2
 	default 128
 
+config PTP_SERVO_KP
+	default 700
+
+config PTP_SERVO_KI
+	default 300
+
 config PTP_PEER_DELAY_MAX_NS
 	default 10000000
 

--- a/tests/net/ptp/clock_wakeup/Kconfig
+++ b/tests/net/ptp/clock_wakeup/Kconfig
@@ -20,6 +20,12 @@ config PTP_PRIORITY1
 config PTP_PRIORITY2
 	default 128
 
+config PTP_SERVO_KP
+	default 600
+
+config PTP_SERVO_KI
+	default 200
+
 config PTP_PEER_DELAY_MAX_NS
 	default 10000000
 

--- a/tests/net/ptp/clock_wakeup/src/main.c
+++ b/tests/net/ptp/clock_wakeup/src/main.c
@@ -496,6 +496,22 @@ ZTEST(ptp_clock_wakeup, test_synchronize_stops_when_phc_read_fails)
 		      "failed PHC read should not adjust the clock");
 }
 
+ZTEST(ptp_clock_wakeup, test_pi_servo_uses_configured_gains)
+{
+	const int64_t offset = 1000;
+	const double kp = (double)CONFIG_PTP_SERVO_KP / PTP_SERVO_GAIN_SCALE;
+	const double ki = (double)CONFIG_PTP_SERVO_KI / PTP_SERVO_GAIN_SCALE;
+	double correction;
+
+	correction = ptp_servo_pi(offset);
+	zassert_within(correction, (kp + ki) * offset, 0.000001,
+		       "first PI correction mismatch");
+
+	correction = ptp_servo_pi(offset);
+	zassert_within(correction, (kp + 2.0 * ki) * offset, 0.000001,
+		       "integral accumulation mismatch");
+}
+
 ZTEST(ptp_clock_wakeup, test_synchronize_applies_pi_rate_adjustment)
 {
 	ptp_clk.phc = &fake_phc;


### PR DESCRIPTION
## Summary

The PTP PI servo currently uses fixed proportional and integral gains of 0.7 and 0.3.

Add `CONFIG_PTP_SERVO_KP` and `CONFIG_PTP_SERVO_KI` so applications can tune the servo for their configured Sync interval and clock characteristics.
The values are expressed in thousandths because Kconfig does not support floating-point types.

The existing gains remain the defaults, preserving current behavior.
Unit coverage verifies that configured, non-default gains are applied.