### PR TITLE
lorawan: multiple fixes

### DIFF
--- a/subsys/lorawan/services/clock_sync.c
+++ b/subsys/lorawan/services/clock_sync.c
@@ -118,6 +118,14 @@ static void clock_sync_package_callback(uint8_t port, uint8_t flags, int16_t rss
 			/* answer from application server */
 			int32_t time_correction;
 
+			/* AppTimeAns carries a 4-byte time correction plus a
+			 * 1-byte token; make sure they are present before reading.
+			 */
+			if ((len - rx_pos) < (sizeof(int32_t) + sizeof(uint8_t))) {
+				LOG_ERR("AppTimeAns too short");
+				return;
+			}
+
 			ctx.nb_transmissions = 0;
 
 			time_correction = (int32_t)sys_get_le32(&rx_buf[rx_pos]);

--- a/subsys/lorawan/services/frag_transport.c
+++ b/subsys/lorawan/services/frag_transport.c
@@ -203,6 +203,10 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 			break;
 		}
 		case FRAG_TRANSPORT_CMD_FRAG_SESSION_SETUP: {
+			if ((len - rx_pos) < sizeof(struct frag_transport_setup_req)) {
+				LOG_ERR("FragSessionSetupReq too short");
+				return;
+			}
 			const struct frag_transport_setup_req *req =
 				(const void *)(rx_buf + rx_pos);
 			uint8_t frag_session = req->frag_session & 0x3F;
@@ -308,6 +312,10 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 			break;
 		}
 		case FRAG_TRANSPORT_CMD_DATA_FRAGMENT: {
+			if ((len - rx_pos) < sizeof(struct frag_transport_data_header)) {
+				LOG_ERR("DataFragment header too short");
+				return;
+			}
 			const struct frag_transport_data_header *hdr =
 				(const void *)(rx_buf + rx_pos);
 			uint16_t frag_counter = hdr->frag_index_n & 0x3FFF;
@@ -323,6 +331,14 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 
 			if (frag_counter == 0U) {
 				LOG_DBG("Invalid fragment index 0");
+				break;
+			}
+
+			/* The decoder reads ctx.frag_size bytes from rx_buf[rx_pos].
+			 * Ensure the downlink payload is at least that long.
+			 */
+			if ((len - rx_pos) < ctx.frag_size) {
+				LOG_ERR("DataFragment payload shorter than frag_size");
 				break;
 			}
 

--- a/subsys/lorawan/services/multicast.c
+++ b/subsys/lorawan/services/multicast.c
@@ -135,6 +135,11 @@ static void multicast_package_callback(uint8_t port, uint8_t flags, int16_t rssi
 			LOG_ERR("McGroupStatusReq not implemented");
 			return;
 		case MULTICAST_CMD_MC_GROUP_SETUP: {
+			/* 1 (id) + 4 (McAddr) + 16 (McKeyE) + 4 (FCountMin) + 4 (FCountMax) */
+			if ((len - rx_pos) < 29U) {
+				LOG_ERR("McGroupSetupReq too short");
+				return;
+			}
 			uint8_t id = rx_buf[rx_pos++] & 0x03;
 			McChannelParams_t channel = {
 				.IsRemotelySetup = true,


### PR DESCRIPTION
- **lorawan: clock_sync: validate AppTimeAns payload length**
- **lorawan: frag_transport: validate downlink length before struct cast**
- **lorawan: multicast: validate McGroupSetupReq payload length**

Fixes: #113354