### PR TITLE
boards: infineon: kit_pse84_eval: advertise m55 userspace and mpu

### DIFF
--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
@@ -29,3 +29,5 @@ supported:
   - comparator
   - dmic
   - i2c
+  - mpu
+  - userspace


### PR DESCRIPTION
The PSOC Edge E84 M55 core (Armv8.1-M with PMSAv8 MPU) supports Zephyr
userspace. The board already enables `CONFIG_ARM_MPU`, which selects
`ARCH_HAS_USERSPACE`, so userspace/MPU test suites (e.g. `llext.readonly_mpu`
with `CONFIG_USERSPACE=y`) build, load, run and unload extensions from
userspace threads successfully on this board.

List `userspace` and `mpu` in the board's twister `supported:` features so
the capability is tracked and the relevant suites are selected for this
platform.

Verified on hardware (kit_pse84_eval/m55): `llext.readonly_mpu` passes.
