### PR TITLE
tests: drivers: pwm: pwm-api: add sama7g54_ek conf and overlay files

### DIFF
--- a/tests/drivers/pwm/pwm_api/boards/sama7g54_ek.conf
+++ b/tests/drivers/pwm/pwm_api/boards/sama7g54_ek.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Microchip Technology Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_DEFAULT_PWM_PORT=2
+CONFIG_INVALID_PWM_PORT=4

--- a/tests/drivers/pwm/pwm_api/boards/sama7g54_ek.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/sama7g54_ek.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm;
+	};
+};
+
+&pwm {
+	status = "okay";
+};


### PR DESCRIPTION
Add sama7g54_ek.conf and sama7g54_ek.overlay files for test `tests/drivers/pwm/pwm_api`.

Test log:
```
*** Booting Zephyr OS build v4.4.0-6056-gb5255638bfe0 ***
Running TESTSUITE pwm_basic
===================================================================
START - test_pwm_cycle
[PWM]: 2, [period]: 64000, [pulse]: 32000
[PWM]: 2, [period]: 64000, [pulse]: 64000
[PWM]: 2, [period]: 64000, [pulse]: 0
 PASS - test_pwm_cycle in 3.012 seconds
===================================================================
START - test_pwm_invalid_port
[PWM]: 4, [period]: 64000, [pulse]: 32000
 PASS - test_pwm_invalid_port in 0.004 seconds
===================================================================
START - test_pwm_nsec
[PWM]: 2, [period]: 2000000, [pulse]: 1000000
[PWM]: 2, [period]: 2000000, [pulse]: 2000000
[PWM]: 2, [period]: 2000000, [pulse]: 0
 PASS - test_pwm_nsec in 3.012 seconds
===================================================================
TESTSUITE pwm_basic succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [pwm_basic]: pass = 3, fail = 0, skip = 0, total = 3 duration = 6.028 seconds
 - PASS - [pwm_basic.test_pwm_cycle] duration = 3.012 seconds
 - PASS - [pwm_basic.test_pwm_invalid_port] duration = 0.004 seconds
 - PASS - [pwm_basic.test_pwm_nsec] duration = 3.012 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```