### PR TITLE
drivers: rtc: ti_mspm0: Improve dow and dom writing

### DIFF
--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -65,8 +65,15 @@ static int rtc_ti_mspm0_set_time(const struct device *dev,
 		DL_RTC_Common_setCalendarSecondsBinary(cfg->regs, timeptr->tm_sec);
 		DL_RTC_Common_setCalendarMinutesBinary(cfg->regs, timeptr->tm_min);
 		DL_RTC_Common_setCalendarHoursBinary(cfg->regs, timeptr->tm_hour);
-		DL_RTC_Common_setCalendarDayOfWeekBinary(cfg->regs, timeptr->tm_wday);
-		DL_RTC_Common_setCalendarDayOfMonthBinary(cfg->regs, timeptr->tm_mday);
+		/*
+		 * Back to back writes to counter/calendar registers such as
+		 * SEC, MIN, HOUR, DAY, MON, YEAR need to be avoided since writes
+		 * to calendar registers take 2 to 3 RTCCLK cycles to take effect.
+		 */
+		DL_Common_updateReg(&cfg->regs->DAY,
+				    (uint32_t)timeptr->tm_wday |
+					    ((uint32_t)timeptr->tm_mday << RTC_DAY_DOMBIN_OFS),
+				    RTC_DAY_DOW_MASK | RTC_DAY_DOMBIN_MASK);
 		DL_RTC_Common_setCalendarMonthBinary(cfg->regs, timeptr->tm_mon);
 		DL_RTC_Common_setCalendarYearBinary(cfg->regs, timeptr->tm_year);
 	}


### PR DESCRIPTION
- Back to back writes to counter/calendar registers such as SEC, MIN, HOUR, DAY, MON, YEAR need to be avoided since writes to calendar registers take 2 to 3 RTCCLK cycles to take effect.
- The implementation here is taken from TI mspm0 sdk driverlib [0]
- Tested on `beagleconnect_zepto`  with `tests/drivers/rtc/rtc_api`. Makes errors more deterministic, does not completely fix them.

[0]: https://github.com/zephyrproject-rtos/hal_ti/blob/e66677c8c8d8b5e521c744f6b9788137b41b98fc/mspm0/source/ti/driverlib/dl_rtc_common.c#L38