### PR TITLE
dts: arduino: Rectify usage of mapped partitions

### DIFF
--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -153,17 +153,19 @@ zephyr_i2c: &i2c1 {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "bootloader";
 			reg = <0x0 0x40000>;
 			read-only;
 		};
 
 		slot0_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x40000 0x000c0000>;
 		};

--- a/dts/vendor/arduino/partitions_qspi_h7_r3.dtsi
+++ b/dts/vendor/arduino/partitions_qspi_h7_r3.dtsi
@@ -16,48 +16,42 @@
 
 &qspi_flash {
 	partitions {
-		ranges;
+		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Partition 1: Master Boot Record 4kB */
 		mbr_partition: partition@0 {
-			compatible = "zephyr,mapped-partition";
 			label = "mbr";
 			reg = <0x0 DT_SIZE_K(4)>;
 		};
 
 		/* Partition 2: WiFi firmware and certificates 1MB - 4kB */
 		wlan_partition: partition@1000 {
-			compatible = "zephyr,mapped-partition";
 			label = "wlan";
 			reg = <0x001000 DT_SIZE_K(1020)>;
 		};
 
 		/* Partition 3: OTA 5MB */
 		ota_partition: partition@100000 {
-			compatible = "zephyr,mapped-partition";
 			label = "ota";
 			reg = <0x100000 DT_SIZE_M(5)>;
 		};
 
 		/* Partition 4: Provisioning KVStore 1MB */
 		kvs_partition: partition@600000 {
-			compatible = "zephyr,mapped-partition";
 			label = "kvs";
 			reg = <0x600000 DT_SIZE_M(1)>;
 		};
 
 		/* Partition 5: User data 7MB */
 		storage_partition: partition@700000 {
-			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x700000 DT_SIZE_M(7)>;
 		};
 
 		/* Partition 6: Binary FW image for the Airoc WLAN */
 		airoc_firmware: partition@f80000 {
-			compatible = "zephyr,mapped-partition";
 			label = "4343WA1.bin";
 			reg = <0xf80000 DT_SIZE_K(512)>;
 		};


### PR DESCRIPTION
The external memory device was updated instead of the internal memory device which has the bootable partitions, this recfities it to be the internal flash which is set to use mapped partitions