### PR TITLE
drivers: fpga: fix sprintf misuse in mpfs driver

### DIFF
--- a/drivers/fpga/fpga_mpfs.c
+++ b/drivers/fpga/fpga_mpfs.c
@@ -374,7 +374,8 @@ static const char *mpfs_fpga_get_info(const struct device *dev)
 	}
 
 	design_version = scb_read(cfg->mailbox, 32);
-	sprintf(data->FPGA_design_ver, (uint8_t *)"Design Version : 0x%x", design_version);
+	snprintf(data->FPGA_design_ver, sizeof(data->FPGA_design_ver),
+		 "Design Version : 0x%x", design_version);
 
 	return data->FPGA_design_ver;
 }


### PR DESCRIPTION
## Summary

Fix two issues in `drivers/fpga/fpga_mpfs.c`:

1. **Remove invalid `(uint8_t *)` cast on format string**: `sprintf()` expects `const char *`, not `uint8_t *`. The cast is semantically wrong and produces `-Wint-conversion` warnings on strict compilers.

2. **Replace `sprintf()` with `snprintf()`**: The `FPGA_design_ver` buffer is 30 bytes and the formatted string `"Design Version : 0x%x"` can reach 29 characters with a full 32-bit hex value (`0xffffffff`), leaving no safety margin. `snprintf()` with `sizeof()` prevents any potential overflow.

## Changes

```diff
-	sprintf(data->FPGA_design_ver, (uint8_t *)"Design Version : 0x%x", design_version);
+	snprintf(data->FPGA_design_ver, sizeof(data->FPGA_design_ver),
+		 "Design Version : 0x%x", design_version);
```

## Testing

- Compile-only change, no behavioral difference for valid inputs
- Eliminates compiler warnings and hardens against buffer overflow
