### PR TITLE
drivers: spi: spi_mcux_ecspi: derive SCLK idle level from CPOL

### DIFF
--- a/drivers/spi/spi_mcux_ecspi.c
+++ b/drivers/spi/spi_mcux_ecspi.c
@@ -184,6 +184,10 @@ static int spi_mcux_configure(const struct device *dev,
 
 	master_config.channel =
 		spi_cs_is_gpio(spi_cfg) ? kECSPI_Channel0 : (ecspi_channel_source_t)spi_cfg->slave;
+	master_config.channelConfig.clockInactiveState =
+		(SPI_MODE_GET(spi_cfg->operation) & SPI_MODE_CPOL)
+		? kECSPI_ClockInactiveStateHigh
+		: kECSPI_ClockInactiveStateLow;
 	master_config.channelConfig.polarity =
 		(SPI_MODE_GET(spi_cfg->operation) & SPI_MODE_CPOL)
 		? kECSPI_PolarityActiveLow


### PR DESCRIPTION
I just checked two sources according to them:
https://www.analog.com/en/resources/analog-dialogue/articles/introduction-to-spi-interface.html
https://ww1.microchip.com/downloads/en/Appnotes/TB3215-Getting-Started-with-SPI-90003215A.pdf (page 14)

The clock idle has to be high if CPOL =1.

The spi_mcux_ecspi driver does not set the clockInactiveState.
I want to provide a patch with this PR.

The NXP ECSPI represents clock polarity with two separate fields: channelConfig.polarity (SCLK_POL), the active polarity, and channelConfig.clockInactiveState (SCLK_CTL), the level SCLK idles at between bursts. spi_mcux_configure() set polarity from the CPOL bit but left clockInactiveState at the kECSPI_ClockInactiveStateLow default applied by ECSPI_MasterGetDefaultConfig().

As a result, transfers to CPOL=1 devices (SPI modes 2 and 3) ran with an inconsistent clock: the active polarity was inverted as requested while the idle SCLK level stayed low. Drive clockInactiveState from the same CPOL bit so the idle level matches the configured mode.