### PR TITLE
samples: usb: cdc_acm: consider available fill size in cdc acm sample

### DIFF
--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -19,6 +19,9 @@ LOG_MODULE_REGISTER(cdc_acm_echo, LOG_LEVEL_INF);
 
 const struct device *const uart_dev = DEVICE_DT_GET_ONE(zephyr_cdc_acm_uart);
 
+#define TX_BUF_SIZE 64
+#define RX_BUF_SIZE 64
+
 #define RING_BUF_SIZE 1024
 uint8_t ring_buffer[RING_BUF_SIZE];
 
@@ -101,6 +104,8 @@ static void interrupt_handler(const struct device *dev, void *user_data)
 {
 	ARG_UNUSED(user_data);
 
+	int space;
+
 	while (true) {
 		uart_irq_update(dev);
 
@@ -110,7 +115,7 @@ static void interrupt_handler(const struct device *dev, void *user_data)
 
 		if (!rx_throttled && uart_irq_rx_ready(dev)) {
 			int recv_len, rb_len;
-			uint8_t buffer[64];
+			uint8_t buffer[RX_BUF_SIZE];
 			size_t len = MIN(ring_buf_space_get(&ringbuf),
 					 sizeof(buffer));
 
@@ -138,11 +143,12 @@ static void interrupt_handler(const struct device *dev, void *user_data)
 			}
 		}
 
-		if (uart_irq_tx_ready(dev)) {
-			uint8_t buffer[64];
+		space = uart_irq_tx_ready(dev);
+		if (space > 0) {
+			uint8_t buffer[TX_BUF_SIZE];
 			int rb_len, send_len;
 
-			rb_len = ring_buf_get(&ringbuf, buffer, sizeof(buffer));
+			rb_len = ring_buf_get(&ringbuf, buffer, MIN(space, sizeof(buffer)));
 			if (!rb_len) {
 				LOG_DBG("Ring buffer empty, disable TX IRQ");
 				uart_irq_tx_disable(dev);


### PR DESCRIPTION
The sample didn't consider how much space is available for fifo_fill and always tried to send 64 bytes, thus making it possible for data loss.

Additionaly it's worth to extract rx and tx buf sizes into defines as it might be worth to test with different sizes. Writes that aren't a multiple of 64 test more edge cases.