### PR TITLE
FRDM-MCXL255: AON_TMR support for CM33/CM0+

### DIFF
--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -127,6 +127,25 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_GateAonUART);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_qtmr0)) || \
+	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_qtmr1))
+	CLOCK_AttachClk(kFROdiv4_to_AON_TMR);
+
+	/*
+	 * AON QTMR0 and AON QTMR1 are controlled by a shared
+	 * AON QTMR reset line.
+	 */
+	RESET_ReleasePeripheralReset(kAonQTMR0_RST_SHIFT_RSTn);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_qtmr0))
+	CLOCK_EnableClock(kCLOCK_GateAonQTMR0);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_qtmr1))
+	CLOCK_EnableClock(kCLOCK_GateAonQTMR1);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(rtc))
 	if (!CLOCK_IsRoscInitialized()) {
 		rosc_init_config_t rosc_init_config;

--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -304,14 +304,18 @@ static DEVICE_API(counter, mcux_qtmr_driver_api) = {
 	.get_freq = mcux_qtmr_get_freq,
 };
 
+#define MCUX_QTMR_CLK_SUBSYS(n)                            \
+	COND_CODE_1(DT_PHA_HAS_CELL_AT_IDX(DT_INST_PARENT(n), clocks, 0, name),    \
+		((clock_control_subsys_t)DT_CLOCKS_CELL_BY_IDX(DT_INST_PARENT(n), 0, name)), \
+		((clock_control_subsys_t)0))
+
 #define TMR_DEVICE_INIT_MCUX(n)									\
 	static struct mcux_qtmr_data mcux_qtmr_data_ ## n;					\
 												\
 	static const struct mcux_qtmr_config mcux_qtmr_config_ ## n = {				\
 		.base = (void *)DT_REG_ADDR(DT_INST_PARENT(n)),					\
 		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_INST_PARENT(n))),			\
-		.clock_subsys =									\
-			(clock_control_subsys_t)DT_CLOCKS_CELL(DT_INST_PARENT(n), name),	\
+		.clock_subsys = MCUX_QTMR_CLK_SUBSYS(n),				\
 		.info = {									\
 			.max_top_value = UINT16_MAX,						\
 			.freq = DT_INST_PROP_OR(n, freq, 0),					\
@@ -324,7 +328,7 @@ static DEVICE_API(counter, mcux_qtmr_driver_api) = {
 			.enableExternalForce = false,						\
 			.enableMasterMode = false,						\
 			.faultFilterCount = DT_INST_PROP_OR(n, filter_count, 0),		\
-			.faultFilterPeriod = DT_INST_PROP_OR(n, filter_count, 0),		\
+			.faultFilterPeriod = DT_INST_PROP_OR(n, filter_period, 0),		\
 			.primarySource = DT_INST_ENUM_IDX(n, primary_source),			\
 			.secondarySource = DT_INST_ENUM_IDX_OR(n, secondary_source, 0),		\
 		},										\

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
@@ -42,3 +42,11 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&aon_qtmr0 {
+	interrupts = <151 0>;
+};
+
+&aon_qtmr1 {
+	interrupts = <152 0>;
+};

--- a/dts/arm/nxp/mcx/nxp_mcxl_aon.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl_aon.dtsi
@@ -73,4 +73,74 @@
 		alarms-count = <3>;
 		status = "disabled";
 	};
+
+	aon_qtmr_clock: aon-qtmr-clock {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <2500000>;
+	};
+
+	aon_qtmr0: qtmr@8e000 {
+		compatible = "nxp,imx-qtmr";
+		reg = <0x8e000 0x1000>;
+		interrupts = <24 0>;
+		clocks = <&aon_qtmr_clock>;
+		status = "disabled";
+
+		aon_qtmr0_timer0: timer0 {
+			compatible = "nxp,imx-tmr";
+			channel = <0>;
+			status = "disabled";
+		};
+
+		aon_qtmr0_timer1: timer1 {
+			compatible = "nxp,imx-tmr";
+			channel = <1>;
+			status = "disabled";
+		};
+
+		aon_qtmr0_timer2: timer2 {
+			compatible = "nxp,imx-tmr";
+			channel = <2>;
+			status = "disabled";
+		};
+
+		aon_qtmr0_timer3: timer3 {
+			compatible = "nxp,imx-tmr";
+			channel = <3>;
+			status = "disabled";
+		};
+	};
+
+	aon_qtmr1: qtmr@8f000 {
+		compatible = "nxp,imx-qtmr";
+		reg = <0x8f000 0x1000>;
+		interrupts = <25 0>;
+		clocks = <&aon_qtmr_clock>;
+		status = "disabled";
+
+		aon_qtmr1_timer0: timer0 {
+			compatible = "nxp,imx-tmr";
+			channel = <0>;
+			status = "disabled";
+		};
+
+		aon_qtmr1_timer1: timer1 {
+			compatible = "nxp,imx-tmr";
+			channel = <1>;
+			status = "disabled";
+		};
+
+		aon_qtmr1_timer2: timer2 {
+			compatible = "nxp,imx-tmr";
+			channel = <2>;
+			status = "disabled";
+		};
+
+		aon_qtmr1_timer3: timer3 {
+			compatible = "nxp,imx-tmr";
+			channel = <3>;
+			status = "disabled";
+		};
+	};
 };


### PR DESCRIPTION
Add AON QTMR support for the FRDM-MCXL255 CM33 and CM0PLUS.

This PR adds the MCXL255 AON QTMR0 and QTMR1 devicetree nodes, models the
AON QTMR clock as a fixed-clock provider, and configures the required
AON QTMR clock source, clock gates, and reset.

The shared AON QTMR devicetree nodes use the CM0+ interrupt numbers
24 and 25. The CM33 devicetree overrides these with the corresponding
CM33 interrupt numbers 151 and 152.

The MCUX QTMR counter driver is also updated to support clock providers
without a named clock cell, such as fixed-clock providers. Existing users
with named clock cells keep the previous behavior.

Tested with:

- tests/drivers/counter/counter_basic_api on frdm_mcxl255/mcxl255/cpu0
- custom simple counter application on frdm_mcxl255/mcxl255/cpu1 (counter_basic_api is too large for CM0PLUS)