### PR TITLE
manifest: hal_nxp: update revision to fix PM3 entry failure

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 4a9c0a9fd157e8fcbe54c4cc99d93586a2de596d
+      revision: 21e58a65f1a6d0c3130d2d21a3cbc6df41fe0d55
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
When PM3 entry fails (PMU->PWR_MODE_STATUS != 2), PostPowerMode() resets s_gdetSensorContext.disableCount to 0, since ROM never ran, GDET is still disabled from PrePowerMode().

This causes disableCount to underflow (0xFFFFFFFF) if POWER_EnableGDetVSensors() is called later (e.g., during Wi-Fi FW download), and subsequent POWER_DisableGDetVSensors() restores it to 0. The next PM2/PM3 entry then hits the assert in POWER_PrePowerMode() because disableCount == 0.