### PR TITLE
include: dt-bindings: pinctrl: renesas: Organize Doxygen documentation

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a77951.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a77951.h
@@ -3,10 +3,19 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Renesas R-Car H3 (R8A77951) pin and function definitions
+ * @ingroup pinctrl_rcar
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_R8A77951_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_R8A77951_H_
 
 #include "pinctrl-rcar-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Pins declaration */
 #define PIN_NONE                   -1
@@ -939,5 +948,7 @@
 #define FUNC_TPU0TO3                    IPSR(18, 4, 0xB)
 #define FUNC_FMIN_C                     IPSR(18, 4, 0xC)
 #define FUNC_FMIN_D                     IPSR(18, 4, 0xD)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_R8A77951_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a77961.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a77961.h
@@ -4,10 +4,19 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Renesas R-Car M3-W (R8A77961) pin and function definitions
+ * @ingroup pinctrl_rcar
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_R8A77961_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_R8A77961_H_
 
 #include "pinctrl-rcar-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Pins declaration */
 #define PIN_NONE                   -1
@@ -935,5 +944,7 @@
 #define FUNC_TPU0TO3                    IPSR(18, 4, 0xB)
 #define FUNC_FMIN_C                     IPSR(18, 4, 0xC)
 #define FUNC_FMIN_D                     IPSR(18, 4, 0xD)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_R8A77961_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a779f0.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a779f0.h
@@ -3,10 +3,19 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Renesas R-Car S4 (R8A779F0) pin and function definitions
+ * @ingroup pinctrl_rcar
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_R8A779F0_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_R8A779F0_H_
 
 #include "pinctrl-rcar-common.h"
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Pins declaration */
 #define PIN_NONE                   -1
@@ -547,5 +556,7 @@
 #define FUNC_FLXA0TXDA             IP3SR7(20, 2)
 #define FUNC_FLXA0TXENB            IP3SR7(24, 2)
 #define FUNC_FLXA0TXENA            IP3SR7(28, 2)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_R8A779F0_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a779g0.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a779g0.h
@@ -6,12 +6,12 @@
 
 /**
  * @file
- * @brief Pin control (pinctrl) definitions for R-Car V4H Sparrowhawk board
+ * @brief Renesas R-Car V4H (R8A779G0) pin and function definitions
+ * @ingroup pinctrl_rcar
  *
  * This header provides macro constants for encoding pin function selections
- * and pin indices for R-Car V4H Sparrowhawk.
- * These values are used by the DeviceTree pinctrl subsystem to describe
- * peripheral pin mappings.
+ * and pin indices for R-Car V4H. These values are used by the DeviceTree
+ * pinctrl subsystem to describe peripheral pin mappings.
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_R8A779G0_H_

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a78000.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a78000.h
@@ -9,7 +9,8 @@
 
 /**
  * @file
- * @brief Renesas R-Car Gen5 R8A78000 pinctrl definitions.
+ * @brief Renesas R-Car Gen5 (R8A78000) pin and function definitions
+ * @ingroup pinctrl_rcar
  */
 
 #include "pinctrl-rcar-common.h"

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h
@@ -6,20 +6,56 @@
 
 /**
  * @file
- * @brief Renesas RA pin control (pinctrl) definitions for Zephyr.
- *
- * This header provides macro constants for encoding pin function selections
- * and pin indices for Renesas RA SoCs. These values are used by the DeviceTree
- * pinctrl subsystem to describe peripheral pin mappings.
+ * @brief Devicetree pin control helpers for Renesas RA
+ * @ingroup pinctrl_ra
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RA_H__
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RA_H__
 
 /**
- * @name Renesas RA Pinctrl Definitions.
+ * @addtogroup renesas_pinctrl Renesas pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_ra Renesas RA pin control helpers
+ * @brief Macros for pin control configuration of Renesas RA SoCs
+ * @ingroup renesas_pinctrl
+ *
+ * Each pin configuration is built with the RA_PSEL() macro, which combines a
+ * peripheral-function selector, the port number, and the pin number within that
+ * port.
+ *
+ * The selector follows the naming convention @c RA_PSEL_\<FUNCTION\>, where
+ * @c \<FUNCTION\> is one of:
+ *
+ * - Analog: @c ADC, @c DAC, @c ACMPHS, @c ACMPHS_VCOUT, @c CAC_ADC, @c CAC_DAC,
+ *   @c CTSU
+ * - Timers: @c AGT, @c GPT0, @c GPT1
+ * - Serial: @c SCI_0 ... @c SCI_9, @c SPI, @c I2C, @c I3C
+ * - Connectivity: @c CANFD, @c QSPI, @c OSPI, @c SSIE, @c USBFS, @c USBHS,
+ *   @c SDHI, @c ETH_MII, @c ETH_RMII, @c ETH_RGMII
+ * - Graphics / capture: @c GLCDC, @c CEU
+ * - System: @c HIZ_JTAG_SWD, @c CLKOUT_RTC, @c ETHPHYCLK, @c BUS
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
+ *
+ * &pinctrl {
+ *         sci0_default: sci0_default {
+ *                 group1 {
+ *                         psels = <RA_PSEL(RA_PSEL_SCI_0, 4, 11)>,
+ *                                 <RA_PSEL(RA_PSEL_SCI_0, 4, 10)>;
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
 
 /** @brief Bit position of the port number field. */
 #define RA_PORT_NUM_POS  0 /**< Port number position. */
@@ -89,6 +125,8 @@
 
 /** @brief Bit mask for the RA mode field (1-bit width). */
 #define RA_MODE_MASK 0x1 /** Mode field mask. */
+
+/** @endcond */
 
 /**
  * @brief Macro to encode a pin configuration for Renesas RA SoCs.

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra0.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra0.h
@@ -4,19 +4,63 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree pin control helpers for Renesas RA0
+ * @ingroup pinctrl_ra0
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RA0_H__
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RA0_H__
 
 /**
- * @file
- * @brief Renesas RA0 pinctrl pin configuration definitions.
+ * @addtogroup renesas_pinctrl Renesas pin control helpers
+ * @ingroup devicetree-pinctrl
  */
 
 /**
- * @name Renesas RA0 pin configuration bit field positions and masks.
+ * @defgroup pinctrl_ra0 Renesas RA0 pin control helpers
+ * @brief Macros for pin control configuration of Renesas RA0 SoCs
+ * @ingroup renesas_pinctrl
+ *
+ * Each pin configuration is built with the RA_PSEL() macro, which combines a
+ * per-port peripheral-function selector, the port number, and the pin number
+ * within that port.
+ *
+ * The selector follows the naming convention @c RA_PSEL_P\<PORT\>nPFS_\<SIGNAL\>,
+ * where @c \<PORT\> is the port number and @c \<SIGNAL\> is the peripheral signal
+ * routed to the pin (for example @c RA_PSEL_P1nPFS_TXDA0C selects the @c TXDA0C
+ * signal on port 1). Signals are grouped by peripheral:
+ *
+ * - Timer array unit (TAU): timer inputs @c TI and outputs @c TO
+ * - Serial array unit (SAU) in SPI mode: @c SCK, @c SI, @c SO, @c SSI;
+ *   in UART mode: @c TXD, @c RXD; in simple-I2C mode: @c SCL, @c SDA
+ * - IICA: @c SCLA0, @c SDAA0, @c SCLA1, @c SDAA1
+ * - UARTA: @c TXDA0, @c RXDA0, @c TXDA1, @c RXDA1
+ * - RTC: @c RTCOUT, @c RTCOUNTC
+ * - Clock output (CGC): @c PCLBUZ0, @c PCLBUZ1
+ * - Capacitive touch (CTSU): @c TS0 ... @c TS12, @c TSCAP
+ * - JTAG/SWD: @c SWDIO, @c SWCLK
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra0.h>
+ *
+ * &pinctrl {
+ *         uarta0_default: uarta0_default {
+ *                 group1 {
+ *                         psels = <RA_PSEL(RA_PSEL_P1nPFS_TXDA0C, 1, 5)>,
+ *                                 <RA_PSEL(RA_PSEL_P1nPFS_RXDA0C, 1, 6)>;
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
  * @{
  */
 
+/** @cond INTERNAL_HIDDEN */
+
+/* Pin configuration bit field positions and masks. */
 /** Position of the port field. */
 #define RA_PORT_NUM_POS  0
 /** Mask of the port field. */
@@ -30,12 +74,7 @@
 /** Mask for the function field. */
 #define RA_PSEL_MASK     0x1f
 
-/** @} */
-
-/**
- * @name Renesas RA0 pinctrl pin functions.
- * @{
- */
+/* Per-port peripheral-function selector (PSEL) values. */
 
 /** JTAG/SWD SWDIO */
 #define RA_PSEL_P1nPFS_SWDIO    0x1
@@ -337,7 +376,7 @@
 /** SAU_SPI01 SO01B */
 #define RA_PSEL_P9nPFS_SO01B  0x3
 
-/** @} */
+/** @endcond */
 
 /**
  * @brief Utility macro to build Renesas RA0 psels property entry.
@@ -348,5 +387,7 @@
  */
 #define RA_PSEL(psel, port_num, pin_num)                                                           \
 	(psel << RA_PSEL_POS | port_num << RA_PORT_NUM_POS | pin_num << RA_PIN_NUM_POS)
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RA0_H__ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h
@@ -7,14 +7,53 @@
 
 /**
  * @file
- * @brief Utility macro definitions to encode GPIO pin function for
- * Renesas R-Car Gen4 SoC.
+ * @brief Devicetree pin control helpers for Renesas R-Car
+ * @ingroup pinctrl_rcar
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RCAR_COMMON_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RCAR_COMMON_H_
 
-/** @cond INTERNAL_HIDDEN */
+/**
+ * @addtogroup renesas_pinctrl Renesas pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_rcar Renesas R-Car pin control helpers
+ * @brief Pin and function macros for Renesas R-Car Gen3/Gen4/Gen5 SoCs
+ * @ingroup renesas_pinctrl
+ *
+ * The R-Car Pin Function Controller (PFC) is configured by pairing a pin
+ * identifier with the alternate function to route to it. Both are defined per
+ * SoC in the matching header:
+ *
+ * - @c pinctrl-r8a77951.h — R-Car H3
+ * - @c pinctrl-r8a77961.h — R-Car M3-W
+ * - @c pinctrl-r8a779f0.h — R-Car S4
+ * - @c pinctrl-r8a779g0.h — R-Car V4H
+ * - @c pinctrl-r8a78000.h — R-Car Gen5
+ *
+ * Each of those headers provides @c PIN_\<NAME\> pin identifiers and
+ * @c FUNC_\<NAME\> alternate-function values, where @c \<NAME\> is the signal
+ * name from the SoC datasheet (for example @c PIN_RD and @c FUNC_CAN0_TX_A).
+ * Both are built from the encoding helpers defined here — RCAR_GP_PIN() and
+ * RCAR_NOGP_PIN() for pins, IPSR() / IPnSR() (Gen3/4) or RCAR_ALTSEL_FUNC()
+ * (Gen5) for functions.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a77951.h>
+ *
+ * &pfc {
+ *         can0_data_a_tx_default: can0_data_a_tx_default {
+ *                 pin = <PIN_RD FUNC_CAN0_TX_A>;
+ *         };
+ * };
+ * @endcode
+ *
+ * @{
+ */
+
 /**
  * @brief Utility macro to build IPSR property entry (Gen3/4 only).
  * IPSR: Peripheral Function Select Register
@@ -32,8 +71,10 @@
  */
 #define IPSR(bank, shift, func) (((bank) << 10U) | ((shift) << 4U) | (func))
 
+/** @cond INTERNAL_HIDDEN */
 /* Arbitrary number to encode non capable gpio pin */
 #define PIN_NOGPSR_START 1024U
+/** @endcond */
 
 /**
  * @brief Utility macro to encode a GPIO capable pin
@@ -50,13 +91,21 @@
  */
 #define RCAR_NOGP_PIN(pin)         (PIN_NOGPSR_START + pin)
 
-/* Renesas Gen4 has IPSR registers at different base address
- * reg is here an index for the base address.
- * Each base address has 4 IPSR banks.
+/**
+ * @brief Utility macro to build an IPSR property entry for Gen4 SoCs.
+ *
+ * Renesas Gen4 has IPSR registers at different base addresses; @p reg is an
+ * index for the base address. Each base address has 4 IPSR banks.
+ *
+ * @param bank the IPSR register bank.
+ * @param reg the IPSR base address index.
+ * @param shift the bit shift for this alternate function.
+ * @param func the 4 bits encoded alternate function.
  */
 #define IPnSR(bank, reg, shift, func) \
 	IPSR(((reg) << 5U) | (bank), shift, func)
 
+/** @cond INTERNAL_HIDDEN */
 #define IP0SR0(shift, func) IPnSR(0, 0, shift, func)
 #define IP1SR0(shift, func) IPnSR(1, 0, shift, func)
 #define IP2SR0(shift, func) IPnSR(2, 0, shift, func)
@@ -93,6 +142,7 @@
 #define IP1SR8(shift, func) IPnSR(1, 8, shift, func)
 #define IP2SR8(shift, func) IPnSR(2, 8, shift, func)
 #define IP3SR8(shift, func) IPnSR(3, 8, shift, func)
+/** @endcond */
 
 /**
  * @brief Macro to define a dummy IPSR flag for a pin
@@ -122,9 +172,15 @@
  */
 #define RCAR_ALTSEL_FUNC(group, pin, func) (((pin) << 14U) | ((group) << 10U) | (func))
 
-#define PIN_VOLTAGE_NONE 0
-#define PIN_VOLTAGE_1P8V 1
-#define PIN_VOLTAGE_3P3V 2
+/**
+ * @name R-Car pin I/O voltage levels
+ * @{
+ */
+#define PIN_VOLTAGE_NONE 0 /**< No I/O voltage selection. */
+#define PIN_VOLTAGE_1P8V 1 /**< 1.8 V I/O voltage. */
+#define PIN_VOLTAGE_3P3V 2 /**< 3.3 V I/O voltage. */
+/** @} */
 
-/** @endcond */
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RCAR_COMMON_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rx.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rx.h
@@ -6,21 +6,71 @@
 
 /**
  * @file
- * @brief Renesas RX pin control (pinctrl) definitions for Zephyr.
- *
- * This header provides macro constants for encoding pin function selections
- * and pin indices for Renesas RX SoCs. These values are used by the DeviceTree
- * pinctrl subsystem to describe peripheral pin mappings.
+ * @brief Devicetree pin control helpers for Renesas RX
+ * @ingroup pinctrl_rx
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_PINCTRL_RX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_PINCTRL_RX_H_
 
 /**
- * @name Multi-Function Pin Controller (MPC) Definitions for Renesas RX SoCs.
+ * @addtogroup renesas_pinctrl Renesas pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_rx Renesas RX pin control helpers
+ * @brief Macros for pin control configuration of Renesas RX SoCs
+ * @ingroup renesas_pinctrl
+ *
+ * Pins are configured through the Multi-Function Pin Controller (MPC). Each pin
+ * configuration is built with the RX_PSEL() macro, which combines a
+ * peripheral-function selector, the port number, and the pin number within that
+ * port.
+ *
+ * Two flavors of selector are provided. Generic selectors named
+ * @c RX_PSEL_\<PERIPHERAL\> carry a function code shared by every pin of a
+ * peripheral, where @c \<PERIPHERAL\> is one of @c RSCI, @c SCI_1, @c SCI_5,
+ * @c SCI_6, @c SCI_12, @c TMR, @c POE, @c ADC or @c LVD.
+ *
+ * Per-pin selectors named @c RX_PSEL_P\<PORT\>nPFS_\<SIGNAL\> (for example
+ * @c RX_PSEL_P1nPFS_RXD1) give the exact code for one pin, where @c \<PORT\> is
+ * the port letter/number and @c \<SIGNAL\> is the peripheral signal routed to
+ * the pin. Signals are grouped by peripheral:
+ *
+ * - Multi-function timer (MTU): @c MTIOC0A ... @c MTIOC5W, @c MTCLKA ... @c MTCLKD
+ * - 8-bit timer (TMR): @c TMO0 ... @c TMO3, @c TMCI0 ... @c TMCI3, @c TMRI0 ...
+ *   @c TMRI3
+ * - Serial (SCI): @c RXD0 ... @c RXD12, @c TXD0 ... @c TXD12, @c SCK0 ... @c SCK12,
+ *   @c CTS, @c RTS, @c SS
+ * - SPI (RSPI, or SCI in simple-SPI mode): @c RSPCKA, @c MOSIA, @c MISOA,
+ *   @c SSLA0 ... @c SSLA3, @c SMOSI, @c SMISO
+ * - I2C (RIIC, or SCI in simple-I2C mode): @c SCL, @c SDA, @c SSCL, @c SSDA
+ * - Capacitive touch (CTSU): @c TS0 ... @c TS35, @c TSCAP
+ * - Comparator: @c CMPOB0, @c CMPOB1
+ * - Misc: @c POE0 ... @c POE8, @c ADTRG0, @c RTCOUT, @c CLKOUT, @c CACREF
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-rx.h>
+ *
+ * &pinctrl {
+ *         sci1_default: sci1_default {
+ *                 group1 {
+ *                         psels = <RX_PSEL(RX_PSEL_SCI_1, 2, 6)>;
+ *                 };
+ *                 group2 {
+ *                         psels = <RX_PSEL(RX_PSEL_SCI_1, 3, 0)>;
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
  * @{
  */
 
+/** @cond INTERNAL_HIDDEN */
+
+/* Multi-Function Pin Controller (MPC) bit field positions and masks. */
 /** @brief Bit position of the port number field. */
 #define RX_PORT_NUM_POS  0 /**< Port number position. */
 /** @brief Mask for the port number field. */
@@ -36,11 +86,7 @@
 /** @brief Mask for the Peripheral Select (PSEL) field. */
 #define RX_PSEL_POS  9 /**< PSEL position. */
 
-/**
- * @name Renesas RX Peripheral Selection (PSEL) Pins
- * @{
- */
-
+/* Peripheral-function selector (PSEL) values. */
 #define RX_PSEL_RSCI      0xA /**< RSCI function. */
 #define RX_PSEL_RSCI_TXDB 0xC /**< RSCI TXD/B function. */
 #define RX_PSEL_SCI_1     0xA /**< SCI1 function. */
@@ -51,8 +97,6 @@
 #define RX_PSEL_POE       0x7 /**< POE function. */
 #define RX_PSEL_ADC       0x0 /**< ADC function. */
 #define RX_PSEL_LVD       0x0 /**< LVD function. */
-
-/** @} */
 
 /**
  * @name Renesas RX MPC Port 0 Pin Function Select codes (PSEL values)
@@ -484,6 +528,8 @@
 #define RX_PSEL_PJnPFS_SS6  0xB /**< SPI slave select channel 6. */
 
 /** @} */
+
+/** @endcond */
 
 /**
  * @brief Macro to encode a pin configuration for Renesas RX SoCs.

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rza-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rza-common.h
@@ -3,8 +3,63 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree pin control helpers for Renesas RZ/A
+ * @ingroup pinctrl_rza
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZA_COMMON_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZA_COMMON_H_
+
+/**
+ * @addtogroup renesas_pinctrl Renesas pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_rza Renesas RZ/A pin control helpers
+ * @brief Macros for pin control configuration of Renesas RZ/A SoCs
+ * @ingroup renesas_pinctrl
+ *
+ * General-purpose pins are configured with the RZA_PINMUX() macro, which takes
+ * three fields:
+ *
+ * - @c port — the port identifier, one of the @c PORT_* values.
+ * - @c pin — the pin number within that port.
+ * - @c func — the alternate-function number selecting the peripheral signal
+ *   routed to the pin, taken from the SoC's Pin Function Controller table; it
+ *   has no symbolic macro and is passed as a plain integer.
+ *
+ * Dedicated-function pins that sit outside the general-purpose port matrix are
+ * referenced directly through their @c BSP_IO_* identifiers, covering debug
+ * (@c BSP_IO_NMI, @c BSP_IO_TMS_SWDIO, @c BSP_IO_TDO), audio clocks, SD/MMC,
+ * QSPI and octal-memory flash, RIIC (I2C) and watchdog overflow.
+ *
+ * An optional digital noise filter can be applied to a pin group with
+ * RZA_FILTER_SET(), built from a stage count (@c RZA_FILNUM_*) and a sampling
+ * clock divider (@c RZA_FILCLKSEL_*).
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-rza-common.h>
+ *
+ * &pinctrl {
+ *         scif0_default: scif0_default {
+ *                 device-pinmux {
+ *                         pinmux = <RZA_PINMUX(PORT_08, 1, 5)>,
+ *                                  <RZA_PINMUX(PORT_08, 2, 5)>;
+ *                         bias-pull-up;
+ *                         renesas,filter =
+ *                                 RZA_FILTER_SET(RZA_FILNUM_8_STAGE, RZA_FILCLKSEL_DIV_18000);
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Superset list of all possible IO ports. */
 #define PORT_00 0x0000 /* IO port 0 */
@@ -27,14 +82,20 @@
 #define PORT_17 0x1100 /* IO port 17 */
 #define PORT_18 0x1200 /* IO port 18 */
 
-/*
- * Create the value contain port/pin/function information
+/** @endcond */
+
+/**
+ * @brief Create an encoded value containing port/pin/function information.
  *
- * port: port number BSP_IO_PORT_00..BSP_IO_PORT_18
- * pin: pin number
- * func: pin function
+ * @param port Port identifier (PORT_00..PORT_18).
+ * @param pin Pin number within the port.
+ * @param func Pin function selector.
+ *
+ * @return Encoded pinmux value.
  */
 #define RZA_PINMUX(port, pin, func) (port | pin | (func << 4))
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Special purpose port */
 #define BSP_IO_NMI 0xFFFF0100 /* NMI */
@@ -91,18 +152,42 @@
 #define BSP_IO_RIIC1_SDA 0xFFFF0E02 /* RIIC1_SDA */
 #define BSP_IO_RIIC1_SCL 0xFFFF0E03 /* RIIC1_SCL */
 
-/* FILNUM */
-#define RZA_FILNUM_4_STAGE  0
-#define RZA_FILNUM_8_STAGE  1
-#define RZA_FILNUM_12_STAGE 2
-#define RZA_FILNUM_16_STAGE 3
+/** @endcond */
 
-/* FILCLKSEL */
-#define RZA_FILCLKSEL_NOT_DIV   0
-#define RZA_FILCLKSEL_DIV_9000  1
-#define RZA_FILCLKSEL_DIV_18000 2
-#define RZA_FILCLKSEL_DIV_36000 3
+/**
+ * @name Renesas RZ/A digital noise filter options
+ *
+ * Set the number of filter stages (FILNUM) and the sampling clock divider
+ * (FILCLKSEL).
+ * @{
+ */
 
+#define RZA_FILNUM_4_STAGE  0 /**< FILNUM: 4-stage filter */
+#define RZA_FILNUM_8_STAGE  1 /**< FILNUM: 8-stage filter */
+#define RZA_FILNUM_12_STAGE 2 /**< FILNUM: 12-stage filter */
+#define RZA_FILNUM_16_STAGE 3 /**< FILNUM: 16-stage filter */
+
+#define RZA_FILCLKSEL_NOT_DIV   0 /**< FILCLKSEL: no division */
+#define RZA_FILCLKSEL_DIV_9000  1 /**< FILCLKSEL: divided by 9000 */
+#define RZA_FILCLKSEL_DIV_18000 2 /**< FILCLKSEL: divided by 18000 */
+#define RZA_FILCLKSEL_DIV_36000 3 /**< FILCLKSEL: divided by 36000 */
+
+/** @} */
+
+/**
+ * @brief Encode filter stage count and clock selection into one configuration value.
+ *
+ * Encoding:
+ * - bits [3:2] = FILNUM (masked to 2 bits)
+ * - bits [1:0] = FILCLKSEL (masked to 2 bits)
+ *
+ * @param filnum Filter stage selection (RZA_FILNUM_*).
+ * @param filclksel Filter clock selection (RZA_FILCLKSEL_*).
+ *
+ * @return Encoded filter configuration value.
+ */
 #define RZA_FILTER_SET(filnum, filclksel) (((filnum) & 0x3) << 0x2) | (filclksel & 0x3)
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZA_COMMON_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rza2m.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rza2m.h
@@ -3,10 +3,55 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Devicetree pin control helpers for Renesas RZ/A2M
+ * @ingroup pinctrl_rza2m
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZA2M_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZA2M_H_
 
+/**
+ * @addtogroup renesas_pinctrl Renesas pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_rza2m Renesas RZ/A2M pin control helpers
+ * @brief Macros for pin control configuration of the Renesas RZ/A2M SoC
+ * @ingroup renesas_pinctrl
+ *
+ * Each pin configuration is built with the RZA2M_PINMUX() macro, which takes a
+ * port, the pin number within that port, and the alternate-function number.
+ * Ports are named as in the hardware manual: @c PORT_00 ... @c PORT_09,
+ * @c PORT_A ... @c PORT_M, plus @c PORT_CKIO and @c PORT_PPOC.
+ *
+ * RZ/A2M uses an older pinmux scheme than the other RZ/A SoCs: the
+ * alternate-function index is encoded in the upper bits and taken from the SoC's
+ * pin-function table (there is no symbolic macro for it).
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-rza2m.h>
+ *
+ * &pinctrl {
+ *         scifa4_default: scifa4_default {
+ *                 device-pinmux {
+ *                         pinmux = <RZA2M_PINMUX(PORT_09, 0, 4)>,
+ *                                  <RZA2M_PINMUX(PORT_09, 1, 4)>;
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
+ * @{
+ */
+
+/** Number of pins per port. */
 #define RZA2M_PIN_NUM_IN_PORT 8
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Port names as labeled in the Hardware Manual */
 #define PORT_00 0
@@ -40,12 +85,26 @@
 #define PIN_POC2  1 /* Sets function for SSD host 0, 0 - 1.8v 1 - 3.3v */
 #define PIN_POC3  2 /* Sets function for SSD host 1, 0 - 1.8v 1 - 3.3v */
 
-/*
- * Create the pin index from its bank and position numbers and store in
- * the upper 16 bits the alternate function identifier
+/** @endcond */
+
+/**
+ * @brief Create an encoded pinmux value from a port, pin and function.
+ *
+ * The pin index is built from the port and pin position numbers; the alternate
+ * function identifier is stored in the upper 16 bits.
+ *
+ * @param b Port identifier (PORT_00..PORT_M, plus PORT_CKIO / PORT_PPOC).
+ * @param p Pin number within the port.
+ * @param f Alternate function identifier.
+ *
+ * @return Encoded pinmux value.
  */
 #define RZA2M_PINMUX(b, p, f) ((b) * RZA2M_PIN_NUM_IN_PORT + (p) | (f << 16))
 
+/** @cond INTERNAL_HIDDEN */
 #define CKIO_DRV RZA2M_PINMUX(PORT_CKIO, 0, 0)
+/** @endcond */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZA2M_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzg-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzg-common.h
@@ -3,8 +3,70 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree pin control helpers for Renesas RZ/G (RZ/G3S)
+ * @ingroup pinctrl_rzg
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZG_COMMON_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZG_COMMON_H_
+
+/**
+ * @addtogroup renesas_pinctrl Renesas pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_rzg Renesas RZ/G pin control helpers
+ * @brief Macros for pin control configuration of Renesas RZ/G SoCs
+ * @ingroup renesas_pinctrl
+ *
+ * General-purpose pins are configured with the RZG_PINMUX() macro, which takes
+ * three fields:
+ *
+ * - @c port — the port identifier, one of the @c PORT_* values.
+ * - @c pin — the pin number within that port.
+ * - @c func — the alternate-function number selecting the peripheral signal
+ *   routed to the pin, taken from the SoC's Pin Function Controller table; it
+ *   has no symbolic macro and is passed as a plain integer.
+ *
+ * Dedicated-function pins that sit outside the general-purpose port matrix are
+ * referenced directly through their @c BSP_IO_* identifiers, covering debug
+ * (@c BSP_IO_NMI, @c BSP_IO_TMS_SWDIO, @c BSP_IO_TDO), audio clocks, XSPI flash,
+ * I3C, SD/MMC and watchdog overflow.
+ *
+ * An optional digital noise filter can be applied to a pin group with
+ * RZG_FILTER_SET(), built from a stage count (@c RZG_FILNUM_*) and a sampling
+ * clock divider (@c RZG_FILCLKSEL_*).
+ *
+ * The pre-defined port/pin combinations differ between RZ/G variants and are
+ * provided by a dedicated header per variant:
+ *
+ * - @c pinctrl-rzg-common.h — RZ/G3S
+ * - @c pinctrl-rzg2-common.h — RZ/G2L, RZ/G2LC, RZ/G2UL
+ * - @c pinctrl-rzg3e.h — RZ/G3E
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzg-common.h>
+ *
+ * &pinctrl {
+ *         scif0_default: scif0_default {
+ *                 device-pinmux {
+ *                         pinmux = <RZG_PINMUX(PORT_08, 1, 5)>,
+ *                                  <RZG_PINMUX(PORT_08, 2, 5)>;
+ *                         bias-pull-up;
+ *                         renesas,filter =
+ *                                 RZG_FILTER_SET(RZG_FILNUM_8_STAGE, RZG_FILCLKSEL_DIV_18000);
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Superset list of all possible IO ports. */
 #define PORT_00 0x0000 /* IO port 0 */
@@ -27,14 +89,20 @@
 #define PORT_17 0x0900 /* IO port 17 */
 #define PORT_18 0x0A00 /* IO port 18 */
 
-/*
- * Create the value contain port/pin/function information
+/** @endcond */
+
+/**
+ * @brief Create an encoded value containing port/pin/function information.
  *
- * port: port number BSP_IO_PORT_00..BSP_IO_PORT_18
- * pin: pin number
- * func: pin function
+ * @param port Port identifier (PORT_00..PORT_18).
+ * @param pin Pin number within the port.
+ * @param func Pin function selector.
+ *
+ * @return Encoded pinmux value.
  */
 #define RZG_PINMUX(port, pin, func) (port | pin | (func << 4))
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Special purpose port */
 #define BSP_IO_NMI 0xFFFF0000 /* NMI */
@@ -87,18 +155,42 @@
 #define BSP_IO_SD1_DATA2 0xFFFF1302 /* SD1_DATA2 */
 #define BSP_IO_SD1_DATA3 0xFFFF1303 /* SD1_DATA3 */
 
-/*FILNUM*/
-#define RZG_FILNUM_4_STAGE  0
-#define RZG_FILNUM_8_STAGE  1
-#define RZG_FILNUM_12_STAGE 2
-#define RZG_FILNUM_16_STAGE 3
+/** @endcond */
 
-/*FILCLKSEL*/
-#define RZG_FILCLKSEL_NOT_DIV   0
-#define RZG_FILCLKSEL_DIV_9000  1
-#define RZG_FILCLKSEL_DIV_18000 2
-#define RZG_FILCLKSEL_DIV_36000 3
+/**
+ * @name Renesas RZ/G digital noise filter options
+ *
+ * Set the number of filter stages (FILNUM) and the sampling clock divider
+ * (FILCLKSEL).
+ * @{
+ */
 
+#define RZG_FILNUM_4_STAGE  0 /**< FILNUM: 4-stage filter */
+#define RZG_FILNUM_8_STAGE  1 /**< FILNUM: 8-stage filter */
+#define RZG_FILNUM_12_STAGE 2 /**< FILNUM: 12-stage filter */
+#define RZG_FILNUM_16_STAGE 3 /**< FILNUM: 16-stage filter */
+
+#define RZG_FILCLKSEL_NOT_DIV   0 /**< FILCLKSEL: no division */
+#define RZG_FILCLKSEL_DIV_9000  1 /**< FILCLKSEL: divided by 9000 */
+#define RZG_FILCLKSEL_DIV_18000 2 /**< FILCLKSEL: divided by 18000 */
+#define RZG_FILCLKSEL_DIV_36000 3 /**< FILCLKSEL: divided by 36000 */
+
+/** @} */
+
+/**
+ * @brief Encode filter stage count and clock selection into one configuration value.
+ *
+ * Encoding:
+ * - bits [3:2] = FILNUM (masked to 2 bits)
+ * - bits [1:0] = FILCLKSEL (masked to 2 bits)
+ *
+ * @param filnum Filter stage selection (RZG_FILNUM_*).
+ * @param filclksel Filter clock selection (RZG_FILCLKSEL_*).
+ *
+ * @return Encoded filter configuration value.
+ */
 #define RZG_FILTER_SET(filnum, filclksel) (((filnum) & 0x3) << 0x2) | (filclksel & 0x3)
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZG_COMMON_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzg2-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzg2-common.h
@@ -3,8 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RZ/G2L, RZ/G2LC and RZ/G2UL pin and function definitions
+ * @ingroup pinctrl_rzg
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZG2_COMMON_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZG2_COMMON_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Superset list of all possible IO ports. */
 #define PORT_00 0x0000 /* IO port 0 */
@@ -134,5 +142,7 @@
 #define RZG_FILCLKSEL_DIV_36000 3
 
 #define RZG_FILTER_SET(filnum, filclksel) (((filnum) & 0x3) << 0x2) | (filclksel & 0x3)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZG2_COMMON_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzg3e.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzg3e.h
@@ -5,7 +5,8 @@
 
 /**
  * @file
- * @brief Renesas RZ/G3E pin control (pinctrl) definitions for Zephyr.
+ * @brief Renesas RZ/G3E pin and function definitions
+ * @ingroup pinctrl_rzg
  *
  * This header provides macro constants for encoding pin function selections
  * and pin indices for Renesas RZ/G3E SoCs. These values are used by the DeviceTree
@@ -14,6 +15,8 @@
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZG3E_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZG3E_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @name Renesas RZ/G3E I/O Ports.
@@ -116,5 +119,7 @@
  * @return Encoded filter configuration value.
  */
 #define RZG_FILTER_SET(filnum, filclksel) (((filnum) & 0x3) << 0x2) | (filclksel & 0x3)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZG3E_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzn-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzn-common.h
@@ -5,20 +5,57 @@
 
 /**
  * @file
- * @brief Renesas RZ/N pin control (pinctrl) definitions for Zephyr.
- *
- * This header provides macro constants for encoding pin function selections
- * and pin indices for Renesas RZ/N Series. These values are used by the DeviceTree
- * pinctrl subsystem to describe peripheral pin mappings.
+ * @brief Devicetree pin control helpers for Renesas RZ/N
+ * @ingroup pinctrl_rzn
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZN_COMMON_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZN_COMMON_H_
 
 /**
- * @name Renesas RZ/N I/O Ports.
+ * @addtogroup renesas_pinctrl Renesas pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_rzn Renesas RZ/N pin control helpers
+ * @brief Macros for pin control configuration of Renesas RZ/N Series
+ * @ingroup renesas_pinctrl
+ *
+ * Each pin configuration is built with the RZN_PINMUX() macro, which takes three
+ * fields:
+ *
+ * - @c port — the port identifier, one of the @c PORT_* values.
+ * - @c pin — the pin number within that port.
+ * - @c func — the alternate-function number that selects which peripheral signal
+ *   is routed to the pin. There is no symbolic macro for it: @c func is the
+ *   function index for the pin taken from the SoC's Pin Function Controller
+ *   table (the multiplexing table in the hardware manual / pin-assignment
+ *   spreadsheet), passed as a plain integer.
+ *
+ * For example, @c RZN_PINMUX(PORT_16, 5, 1) routes function 1 of port 16 pin 5
+ * (UART0 TXD on the supported SoCs).
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzn-common.h>
+ *
+ * &pinctrl {
+ *         uart0_default: uart0_default {
+ *                 group1 {
+ *                         pinmux = <RZN_PINMUX(PORT_16, 5, 1)>;
+ *                 };
+ *                 group2 {
+ *                         pinmux = <RZN_PINMUX(PORT_16, 6, 2)>;
+ *                         input-enable;
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
 
 #define PORT_00 0x0000 /**< IO port 0 */
 #define PORT_01 0x0100 /**< IO port 1 */
@@ -54,7 +91,7 @@
 #define PORT_33 0x2100 /**< IO port 33 */
 #define PORT_34 0x2200 /**< IO port 34 */
 
-/** @} */
+/** @endcond */
 
 /**
  * @brief Create an encoded value containing port/pin/function information.
@@ -66,5 +103,7 @@
  * @return Encoded pinmux value.
  */
 #define RZN_PINMUX(port, pin, func) (port | pin | (func << 16))
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZN_COMMON_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzt-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzt-common.h
@@ -5,20 +5,57 @@
 
 /**
  * @file
- * @brief Renesas RZ/T pin control (pinctrl) definitions for Zephyr.
- *
- * This header provides macro constants for encoding pin function selections
- * and pin indices for Renesas RZ/T Series. These values are used by the DeviceTree
- * pinctrl subsystem to describe peripheral pin mappings.
+ * @brief Devicetree pin control helpers for Renesas RZ/T
+ * @ingroup pinctrl_rzt
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZT_COMMON_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZT_COMMON_H_
 
 /**
- * @name Renesas RZ/T I/O Ports.
+ * @addtogroup renesas_pinctrl Renesas pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_rzt Renesas RZ/T pin control helpers
+ * @brief Macros for pin control configuration of Renesas RZ/T Series
+ * @ingroup renesas_pinctrl
+ *
+ * Each pin configuration is built with the RZT_PINMUX() macro, which takes three
+ * fields:
+ *
+ * - @c port — the port identifier, one of the @c PORT_* values.
+ * - @c pin — the pin number within that port.
+ * - @c func — the alternate-function number that selects which peripheral signal
+ *   is routed to the pin. There is no symbolic macro for it: @c func is the
+ *   function index for the pin taken from the SoC's Pin Function Controller
+ *   table (the multiplexing table in the hardware manual / pin-assignment
+ *   spreadsheet), passed as a plain integer.
+ *
+ * For example, @c RZT_PINMUX(PORT_16, 5, 1) routes function 1 of port 16 pin 5
+ * (UART0 TXD on the supported SoCs).
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzt-common.h>
+ *
+ * &pinctrl {
+ *         uart0_default: uart0_default {
+ *                 group1 {
+ *                         pinmux = <RZT_PINMUX(PORT_16, 5, 1)>;
+ *                 };
+ *                 group2 {
+ *                         pinmux = <RZT_PINMUX(PORT_16, 6, 2)>;
+ *                         input-enable;
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
  * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Superset list of all possible IO ports. */
 #define PORT_00 0x0000 /**< IO port 0 */
@@ -56,7 +93,7 @@
 #define PORT_34 0x2200 /**< IO port 34 */
 #define PORT_35 0x2300 /**< IO port 35 */
 
-/** @} */
+/** @endcond */
 
 /**
  * @brief Create an encoded value containing port/pin/function information.
@@ -68,5 +105,7 @@
  * @return Encoded pinmux value.
  */
 #define RZT_PINMUX(port, pin, func) (port | pin | (func << 16))
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZT_COMMON_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzv-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzv-common.h
@@ -3,8 +3,71 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree pin control helpers for Renesas RZ/V
+ * @ingroup pinctrl_rzv
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZV_COMMON_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZV_COMMON_H_
+
+/**
+ * @addtogroup renesas_pinctrl Renesas pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_rzv Renesas RZ/V pin control helpers
+ * @brief Macros for pin control configuration of Renesas RZ/V SoCs
+ * @ingroup renesas_pinctrl
+ *
+ * General-purpose pins are configured with the RZV_PINMUX() macro, which takes
+ * three fields:
+ *
+ * - @c port — the port identifier, one of the @c PORT_* values.
+ * - @c pin — the pin number within that port.
+ * - @c func — the alternate-function number selecting the peripheral signal
+ *   routed to the pin, taken from the SoC's Pin Function Controller table; it
+ *   has no symbolic macro and is passed as a plain integer.
+ *
+ * Dedicated-function pins that sit outside the general-purpose port matrix are
+ * referenced directly through their @c BSP_IO_* identifiers, covering debug
+ * (@c BSP_IO_NMI, @c BSP_IO_TMS_SWDIO, @c BSP_IO_TDO), audio clocks, SD/MMC,
+ * QSPI flash, RIIC (I2C), watchdog overflow and, on some variants, Ethernet and
+ * PCIe reset.
+ *
+ * An optional digital noise filter can be applied to a pin group with
+ * RZV_FILTER_SET(), built from a stage count (@c RZV_FILNUM_*) and a sampling
+ * clock divider (@c RZV_FILCLKSEL_*).
+ *
+ * The pre-defined port/pin combinations differ between RZ/V variants and are
+ * provided by a dedicated header per variant:
+ *
+ * - @c pinctrl-rzv-common.h — RZ/V general-purpose port superset
+ * - @c pinctrl-rzv2h.h — RZ/V2H
+ * - @c pinctrl-rzv2n.h — RZ/V2N
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzv-common.h>
+ *
+ * &pinctrl {
+ *         scif0_default: scif0_default {
+ *                 device-pinmux {
+ *                         pinmux = <RZV_PINMUX(PORT_04, 0, 2)>,
+ *                                  <RZV_PINMUX(PORT_04, 1, 2)>;
+ *                         bias-pull-up;
+ *                         renesas,filter =
+ *                                 RZV_FILTER_SET(RZV_FILNUM_8_STAGE, RZV_FILCLKSEL_DIV_18000);
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Superset list of all possible IO ports. */
 #define PORT_00 0x0000 /* IO port 0 */
@@ -57,14 +120,20 @@
 #define PORT_47 0x2F00 /* IO port 47 */
 #define PORT_48 0x3000 /* IO port 48 */
 
-/*
- * Create the value contain port/pin/function information
+/** @endcond */
+
+/**
+ * @brief Create an encoded value containing port/pin/function information.
  *
- * port: port number BSP_IO_PORT_00..BSP_IO_PORT_48
- * pin: pin number
- * func: pin function
+ * @param port Port identifier (PORT_00..PORT_48).
+ * @param pin Pin number within the port.
+ * @param func Pin function selector.
+ *
+ * @return Encoded pinmux value.
  */
 #define RZV_PINMUX(port, pin, func) (port | pin | (func << 4))
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Special purpose port */
 #define BSP_IO_NMI 0xFFFF0100 /* NMI */
@@ -122,18 +191,42 @@
 #define BSP_IO_RIIC1_SDA 0xFFFF0E02 /* RIIC1_SDA */
 #define BSP_IO_RIIC1_SCL 0xFFFF0E03 /* RIIC1_SCL */
 
-/* FILNUM */
-#define RZV_FILNUM_4_STAGE  0
-#define RZV_FILNUM_8_STAGE  1
-#define RZV_FILNUM_12_STAGE 2
-#define RZV_FILNUM_16_STAGE 3
+/** @endcond */
 
-/* FILCLKSEL */
-#define RZV_FILCLKSEL_NOT_DIV   0
-#define RZV_FILCLKSEL_DIV_9000  1
-#define RZV_FILCLKSEL_DIV_18000 2
-#define RZV_FILCLKSEL_DIV_36000 3
+/**
+ * @name Renesas RZ/V digital noise filter options
+ *
+ * Set the number of filter stages (FILNUM) and the sampling clock divider
+ * (FILCLKSEL).
+ * @{
+ */
 
+#define RZV_FILNUM_4_STAGE  0 /**< FILNUM: 4-stage filter */
+#define RZV_FILNUM_8_STAGE  1 /**< FILNUM: 8-stage filter */
+#define RZV_FILNUM_12_STAGE 2 /**< FILNUM: 12-stage filter */
+#define RZV_FILNUM_16_STAGE 3 /**< FILNUM: 16-stage filter */
+
+#define RZV_FILCLKSEL_NOT_DIV   0 /**< FILCLKSEL: no division */
+#define RZV_FILCLKSEL_DIV_9000  1 /**< FILCLKSEL: divided by 9000 */
+#define RZV_FILCLKSEL_DIV_18000 2 /**< FILCLKSEL: divided by 18000 */
+#define RZV_FILCLKSEL_DIV_36000 3 /**< FILCLKSEL: divided by 36000 */
+
+/** @} */
+
+/**
+ * @brief Encode filter stage count and clock selection into one configuration value.
+ *
+ * Encoding:
+ * - bits [3:2] = FILNUM (masked to 2 bits)
+ * - bits [1:0] = FILCLKSEL (masked to 2 bits)
+ *
+ * @param filnum Filter stage selection (RZV_FILNUM_*).
+ * @param filclksel Filter clock selection (RZV_FILCLKSEL_*).
+ *
+ * @return Encoded filter configuration value.
+ */
 #define RZV_FILTER_SET(filnum, filclksel) (((filnum) & 0x3) << 0x2) | (filclksel & 0x3)
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZV_COMMON_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzv2h.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzv2h.h
@@ -3,8 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RZ/V2H pin and function definitions
+ * @ingroup pinctrl_rzv
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZV2H_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZV2H_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Superset list of all possible IO ports. */
 #define PORT_00 0x0000 /* IO port 0 */
@@ -139,5 +147,7 @@
 #define RZV_FILCLKSEL_DIV_36000 3
 
 #define RZV_FILTER_SET(filnum, filclksel) (((filnum) & 0x3) << 0x2) | (filclksel & 0x3)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZV2H_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzv2n.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rzv2n.h
@@ -3,8 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RZ/V2N pin and function definitions
+ * @ingroup pinctrl_rzv
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZV2N_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZV2N_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Superset list of all possible IO ports. */
 #define PORT_00 0x0000 /* IO port 0 */
@@ -138,5 +146,7 @@
 #define RZV_FILCLKSEL_DIV_36000 3
 
 #define RZV_FILTER_SET(filnum, filclksel) (((filnum) & 0x3) << 0x2) | (filclksel & 0x3)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RZV2N_H_ */


### PR DESCRIPTION
Reorganizes the Renesas pinctrl devicetree-binding headers into a proper Doxygen group hierarchy and hides the hundreds of self-describing pin/function macros, so the docs explain the encoding conventions instead of dumping every macro.

---

* https://builds.zephyrproject.io/zephyr/pr/112010/docs/doxygen/html/group__renesas__pinctrl.html
* [Coverage report](https://builds.zephyrproject.io/zephyr/pr/112010/api-coverage/zephyr/dt-bindings/pinctrl/renesas/index.html)