### PR TITLE
kconfig: Deprecate LEGACY_GENERATED_INCLUDE_PATH

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -1162,16 +1162,15 @@ endmenu
 menu "Compatibility"
 
 config LEGACY_GENERATED_INCLUDE_PATH
-	bool "Legacy include path for generated headers"
-	default y
+	bool "Legacy include path for generated headers [DEPRECATED]"
+	select DEPRECATED
 	help
 	  Allow applications and libraries to use the Zephyr legacy include
 	  path for the generated headers which does not use the `zephyr/` prefix.
 
 	  From now on, i.e., the preferred way to include the `version.h` header is to
-	  use <zephyr/version.h>, this Kconfig is currently enabled by default so that
-	  user applications won't immediately fail to compile.
+	  use <zephyr/version.h>.
 
-	  This Kconfig will be deprecated and eventually removed in the future releases.
+	  This Kconfig will be removed in a future release.
 
 endmenu

--- a/arch/openrisc/include/offsets_short_arch.h
+++ b/arch/openrisc/include/offsets_short_arch.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_ARCH_OPENRISC_INCLUDE_OFFSETS_SHORT_ARCH_H_
 #define ZEPHYR_ARCH_OPENRISC_INCLUDE_OFFSETS_SHORT_ARCH_H_
 
-#include <offsets.h>
+#include <zephyr/offsets.h>
 
 #define _thread_offset_to_r1 \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r1_OFFSET)

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -26,6 +26,9 @@ Common
 Build System
 ************
 
+* :kconfig:option:`CONFIG_LEGACY_GENERATED_INCLUDE_PATH` has been deprecated, and disabled by
+  default, includes must now be prefixed with ``zephyr/`` for zephyr files.
+
 Kernel
 ******
 

--- a/drivers/wifi/nrf_wifi/inc/fmac_main.h
+++ b/drivers/wifi/nrf_wifi/inc/fmac_main.h
@@ -14,7 +14,7 @@
 
 #include <stdio.h>
 
-#include <version.h>
+#include <zephyr/version.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/net/net_if.h>

--- a/samples/boards/st/bluetooth/interactive_gui/src/main.c
+++ b/samples/boards/st/bluetooth/interactive_gui/src/main.c
@@ -28,7 +28,7 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/hci_raw.h>
-#include <version.h>
+#include <zephyr/version.h>
 
 #define LOG_MODULE_NAME gui_hci_uart
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);

--- a/soc/intel/intel_adsp/ace/gdbstub.c
+++ b/soc/intel/intel_adsp/ace/gdbstub.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <xtensa_asm2_context.h>
 
-#include <offsets.h>
+#include <zephyr/offsets.h>
 
 static struct xtensa_register gdb_reg_list[] = {
 	{

--- a/soc/intel/intel_adsp/ace/gdbstub_ace40.c
+++ b/soc/intel/intel_adsp/ace/gdbstub_ace40.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <xtensa_asm2_context.h>
 
-#include <offsets.h>
+#include <zephyr/offsets.h>
 
 static struct xtensa_register gdb_reg_list[] = {
 	{

--- a/soc/intel/intel_adsp/cavs/gdbstub.c
+++ b/soc/intel/intel_adsp/cavs/gdbstub.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <xtensa_asm2_context.h>
 
-#include <offsets.h>
+#include <zephyr/offsets.h>
 
 static struct xtensa_register gdb_reg_list[] = {
 	{

--- a/soc/raspberrypi/rpi_pico/common/binary_info.h
+++ b/soc/raspberrypi/rpi_pico/common/binary_info.h
@@ -18,7 +18,7 @@
 #include <boot_stage2/config.h>
 #include <pico/binary_info.h>
 
-#include <version.h>
+#include <zephyr/version.h>
 
 #ifdef CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_NAME_OVERRIDDEN
 #define BI_PROGRAM_NAME CONFIG_RPI_PICO_BINARY_INFO_OVERRIDE_PROGRAM_NAME

--- a/soc/realtek/bee/rtl8752h/bee_image_header.c
+++ b/soc/realtek/bee/rtl8752h/bee_image_header.c
@@ -9,7 +9,7 @@
 #include <zephyr/devicetree/mapped-partition.h>
 #include <image_header.h>
 #include <rom_uuid.h>
-#include <version.h>
+#include <zephyr/version.h>
 
 extern void z_arm_reset(void);
 

--- a/soc/realtek/bee/rtl87x2g/bee_image_header.c
+++ b/soc/realtek/bee/rtl87x2g/bee_image_header.c
@@ -9,7 +9,7 @@
 #include <zephyr/devicetree/mapped-partition.h>
 #include <image_info.h>
 #include <rom_uuid.h>
-#include <version.h>
+#include <zephyr/version.h>
 
 extern void z_arm_reset(void);
 

--- a/soc/wch/ch32v/qingke_v2a/soc_irq.S
+++ b/soc/wch/ch32v/qingke_v2a/soc_irq.S
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <offsets.h>
+#include <zephyr/offsets.h>
 #include <zephyr/toolchain.h>
 
 /* Exports */

--- a/soc/wch/ch32v/qingke_v2c/soc_irq.S
+++ b/soc/wch/ch32v/qingke_v2c/soc_irq.S
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <offsets.h>
+#include <zephyr/offsets.h>
 #include <zephyr/toolchain.h>
 
 /* Exports */

--- a/soc/wch/ch32v/qingke_v4b/soc_irq.S
+++ b/soc/wch/ch32v/qingke_v4b/soc_irq.S
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <offsets.h>
+#include <zephyr/offsets.h>
 #include <zephyr/toolchain.h>
 
 /* Exports */

--- a/soc/wch/ch32v/qingke_v4c/soc_irq.S
+++ b/soc/wch/ch32v/qingke_v4c/soc_irq.S
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <offsets.h>
+#include <zephyr/offsets.h>
 #include <zephyr/toolchain.h>
 
 /* Exports */

--- a/soc/wch/ch32v/qingke_v4f/soc_irq.S
+++ b/soc/wch/ch32v/qingke_v4f/soc_irq.S
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <offsets.h>
+#include <zephyr/offsets.h>
 #include <zephyr/toolchain.h>
 
 /* Exports */


### PR DESCRIPTION
This Kconfig has been set for over 2 years, and is very long overdue for being marked as deprecated, therefore mark it as deprecated and disable it by default