### PR TITLE
soc: esp32: don't overwrite disassembly_flag_inline_source

### DIFF
--- a/soc/espressif/common/CMakeLists.txt
+++ b/soc/espressif/common/CMakeLists.txt
@@ -88,8 +88,6 @@ if((CONFIG_ESP_SIMPLE_BOOT OR CONFIG_MCUBOOT) AND NOT (CONFIG_SOC_ESP32C5_LPCORE
   endif()
 endif()
 
-set_property(TARGET bintools PROPERTY disassembly_flag_inline_source)
-
 if(CONFIG_ESP_SIMPLE_BOOT AND NOT (CONFIG_SOC_ESP32C5_LPCORE OR CONFIG_SOC_ESP32C6_LPCORE OR CONFIG_SOC_ESP32P4_LPCORE))
   dt_nodelabel(image_part_path NODELABEL "boot_partition")
 else()


### PR DESCRIPTION
Don't overwrite disassembly_flag_inline_source
otherwise CONFIG_OUTPUT_DISASSEMBLY_WITH_SOURCE
does not work.

This is should only be set in
zephyr/cmake/bintools/*/target_bintools.cmake