### PR TITLE
Revert "net: ethernet: check mac address when bringing a eth iface up"

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -816,7 +816,6 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 {
 	const struct device *dev = net_if_get_device(iface);
 	const struct ethernet_api *eth = dev->api;
-	struct net_linkaddr *mac_addr;
 
 	NET_ASSERT(eth != NULL);
 
@@ -826,20 +825,10 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 		if (eth->stop) {
 			return eth->stop(dev, iface);
 		}
-
-		return 0;
-	}
-
-	mac_addr = net_if_get_link_addr(iface);
-
-	if ((mac_addr->len != NET_ETH_ADDR_LEN) ||
-	    !net_eth_is_addr_valid((struct net_eth_addr *)mac_addr->addr)) {
-		NET_ERR("Invalid MAC address for iface %d (%p)", net_if_get_by_iface(iface), iface);
-		return -EINVAL;
-	}
-
-	if (eth->start) {
-		return eth->start(dev, iface);
+	} else {
+		if (eth->start) {
+			return eth->start(dev, iface);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
This reverts commit 481035cf8e1e65a12e9755c639cc563b62220a0d. As nRF Wi-Fi is broken with this commit.