### PR TITLE
drivers: adc: nrfx_saadc: Enable support for connecting PSELP to ground

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -33,6 +33,9 @@ BUILD_ASSERT((NRF_SAADC_AIN0 == NRFX_ANALOG_EXTERNAL_AIN0) &&
 #if NRF_SAADC_HAS_INPUT_VDD
 	     (NRF_SAADC_VDD == NRFX_ANALOG_INTERNAL_VDD) &&
 #endif
+#if NRF_SAADC_HAS_INPUT_AVSS
+		 (NRF_SAADC_AVSS == NRFX_ANALOG_TEST_AVSS) &&
+#endif
 	     1,
 	     "Definitions from nrf-saadc.h do not match those from nrfx_analog_common.h");
 

--- a/include/zephyr/dt-bindings/adc/nrf-saadc.h
+++ b/include/zephyr/dt-bindings/adc/nrf-saadc.h
@@ -47,6 +47,11 @@
  */
 #define NRF_SAADC_GND  (NRF_SAADC_AIN_VDD_SHIM_OFFSET - 1)
 
+/** @brief Symbol specifying offset to configure "TEST" SAADC inputs */
+#define NRF_SAADC_AIN_TEST_SHIM_OFFSET 64
+/** @brief Symbol specifying offset to configure AVSS as a channel input */
+#define NRF_SAADC_AVSS		      (NRF_SAADC_AIN_TEST_SHIM_OFFSET + 0)
+
 #define NRF_SAADC_AIN_VDD_SHIM_OFFSET 128
 #define NRF_SAADC_VDD		      (NRF_SAADC_AIN_VDD_SHIM_OFFSET + 0)
 #define NRF_SAADC_VDDDIV2	      (NRF_SAADC_AIN_VDD_SHIM_OFFSET + 1)


### PR DESCRIPTION
For any adc measurements where the input must selected on PSELN, PSELP must be grounded in order to obtain a valid reading. This can be achieved using AVSS input selection. This commit adds support for this.