### PR TITLE
dts: arm: focaltech: ft9001: add ranges for mapped-partition

### DIFF
--- a/dts/arm/focaltech/ft9001/ft9001.dtsi
+++ b/dts/arm/focaltech/ft9001/ft9001.dtsi
@@ -72,6 +72,7 @@
 		flash_ctrl: flash-controller@40003000 {
 			compatible = "focaltech,ft9001-flash-controller";
 			reg = <0x40003000 0x1000>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
@@ -79,6 +80,9 @@
 			flash0: flash@10000000 {
 				compatible = "focaltech,ft9001-nv-flash", "soc-nv-flash";
 				reg = <0x10000000 0x200000>;
+				ranges = <0x0 0x10000000 0x200000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				write-block-size = <1>;
 			};
 		};


### PR DESCRIPTION
Commit 9945d207605  migrated the ft9001_eval partitions to the `zephyr,mapped-partition` binding, but the SoC flash controller and flash nodes were never given the `ranges` properties that the binding requires to map partition offsets into the CPU address space.

Without them the offsets are no longer translated onto the 0x10000000 flash base, so the code partition (offset 0x1000) links at 0x1000 instead of 0x10001000 and the image no longer matches the memory layout of the SoC.