### PR TITLE
bluetooth: classic: remove redundant connect pointer clearing

### DIFF
--- a/subsys/bluetooth/host/classic/avctp.c
+++ b/subsys/bluetooth/host/classic/avctp.c
@@ -120,7 +120,6 @@ static void avctp_l2cap_disconnected(struct bt_l2cap_chan *chan)
 
 	session = AVCTP_CHAN(chan);
 	LOG_DBG("chan %p session %p", chan, session);
-	session->br_chan.chan.conn = NULL;
 
 	net_buf_drop(&session->reassembly_buf);
 

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -300,7 +300,7 @@ void bt_avdtp_media_l2cap_disconnected(struct bt_l2cap_chan *chan)
 	}
 
 	LOG_DBG("chan %p", chan);
-	chan->conn = NULL;
+
 	avdtp_cancel_media_disconnect_work(sep);
 
 	avdtp_sep_lock(sep);
@@ -1820,7 +1820,7 @@ void bt_avdtp_l2cap_disconnected(struct bt_l2cap_chan *chan)
 	struct bt_avdtp *session = AVDTP_CHAN(chan);
 
 	LOG_DBG("chan %p session %p", chan, session);
-	session->br_chan.chan.conn = NULL;
+
 	/* Clear the Pending req if set*/
 	if (session->req) {
 		struct bt_avdtp_req *req = session->req;


### PR DESCRIPTION
The connection pointer is already cleared by the L2CAP layer when the channel is disconnected, so there's no need to manually set it to NULL in the AVDTP/AVCTP disconnect callback.

