### PR TITLE
testsuite: ztest: disable `ZTEST_NO_YIELD` for `SEMIHOSTING`

### DIFF
--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -101,7 +101,7 @@ config ZTEST_ASSERT_HOOK
 
 config ZTEST_NO_YIELD
 	bool "Do not yield to the idle thread after tests complete"
-	default n if COVERAGE_DUMP
+	default n if (COVERAGE_DUMP || COVERAGE_SEMIHOST)
 	default y if (PM || PM_DEVICE || PM_DEVICE_RUNTIME)
 	help
 	  When the tests complete, do not yield to the idle thread and instead


### PR DESCRIPTION
Disable `ZTEST_NO_YIELD` when `COVERAGE_SEMIHOST` is enabled, otherwise the coverage dump upon leaving `main` never runs.