### PR TITLE
Coredump smp thread support

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -14,6 +14,11 @@ config CPU_CORTEX_A
 	select CPU_HAS_DCACHE
 	select CPU_HAS_ICACHE
 	select ARCH_HAS_PMU
+	select ARCH_SUPPORTS_COREDUMP_THREADS
+	# On SMP, threads on other CPUs may be actively running with a stale
+	# callee_saved.sp_elx, so THREAD_STACK_TOP cannot rely on the saved SP.
+	# Dump the full stack allocation instead (matches RISC-V and Xtensa).
+	select ARCH_SUPPORTS_COREDUMP_STACK_PTR if !SMP
 	imply FPU
 	imply FPU_SHARING
 	help

--- a/arch/arm64/core/coredump.c
+++ b/arch/arm64/core/coredump.c
@@ -5,6 +5,7 @@
  */
 
 #include <string.h>
+#include <zephyr/kernel.h>
 #include <zephyr/debug/coredump.h>
 
 /*
@@ -48,6 +49,10 @@ struct arm64_arch_block {
  * if defined within function. So define it here.
  */
 static struct arm64_arch_block arch_blk;
+
+#if defined(CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP)
+static uintptr_t arm64_coredump_fault_sp;
+#endif
 
 void arch_coredump_info_dump(const struct arch_esf *esf)
 {
@@ -113,6 +118,9 @@ void arch_coredump_info_dump(const struct arch_esf *esf)
 		arch_blk.r.sp = esf->sp;
 	}
 #endif
+#if defined(CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP)
+	arm64_coredump_fault_sp = arch_blk.r.sp;
+#endif
 
 	/* Send for output */
 	coredump_buffer_output((uint8_t *)&hdr, sizeof(hdr));
@@ -122,4 +130,25 @@ void arch_coredump_info_dump(const struct arch_esf *esf)
 uint16_t arch_coredump_tgt_code_get(void)
 {
 	return COREDUMP_TGT_ARM64;
+}
+
+/*
+ * Return the saved stack pointer for a thread so the coredump THREADS mode
+ * can determine how much of the stack was in use at crash time and avoid
+ * dumping the idle lower portion (CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP).
+ *
+ * For sleeping/suspended threads the scheduler saves sp_elx (EL1 SP) in
+ * callee_saved before context-switching away.  For the currently faulting
+ * thread callee_saved is stale; return the SP captured from the ESF in
+ * arch_coredump_info_dump() (same approach as Cortex-M and RISC-V).
+ */
+uintptr_t arch_coredump_stack_ptr_get(const struct k_thread *thread)
+{
+#if defined(CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP)
+	if (thread == _current) {
+		return arm64_coredump_fault_sp;
+	}
+#endif
+
+	return thread->callee_saved.sp_elx;
 }

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -343,6 +343,9 @@ config DEBUG_THREAD_INFO
 	help
 	  This option exports an array of offsets to kernel structs to allow
 	  for debugger RTOS plugins to determine the state of running threads.
+	  Not supported on SMP: thread_info.c exports K_CURR_THREAD which
+	  only reflects cpus[0].current, confusing live RTOS debugger plugins
+	  on multi-core systems.
 
 rsource "coredump/Kconfig"
 rsource "symtab/Kconfig"

--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -119,14 +119,19 @@ config DEBUG_COREDUMP_MEMORY_DUMP_MIN
 
 config DEBUG_COREDUMP_MEMORY_DUMP_THREADS
 	bool "Threads"
-	depends on !SMP
 	depends on ARCH_SUPPORTS_COREDUMP_THREADS
 	select THREAD_STACK_INFO
-	select DEBUG_THREAD_INFO
+	select DEBUG_THREAD_INFO if !SMP
+	select THREAD_MONITOR if SMP
 	select DEBUG_COREDUMP_THREADS_METADATA
 	help
 	  Dumps the thread struct and stack of all
 	  threads and all data required to debug threads.
+	  On SMP systems all per-CPU ISR stacks are included.
+	  On non-SMP systems DEBUG_THREAD_INFO is also selected, providing
+	  kernel struct offsets for offline GDB thread enumeration.
+	  On SMP systems only THREAD_MONITOR is selected (DEBUG_THREAD_INFO
+	  is not SMP-safe due to the K_CURR_THREAD offset in thread_info.c).
 
 config DEBUG_COREDUMP_MEMORY_DUMP_LINKER_RAM
 	bool "RAM defined by linker section"
@@ -159,9 +164,9 @@ config DEBUG_COREDUMP_SHELL
 
 config DEBUG_COREDUMP_THREADS_METADATA
 	bool "Threads metadata"
-	depends on !SMP
 	depends on ARCH_SUPPORTS_COREDUMP_THREADS
-	select DEBUG_THREAD_INFO
+	select DEBUG_THREAD_INFO if !SMP
+	select THREAD_MONITOR if SMP
 	help
 	  Core dump will contain the threads metadata section containing
 	  any necessary data to enable debugging threads

--- a/subsys/debug/coredump/coredump_core.c
+++ b/subsys/debug/coredump/coredump_core.c
@@ -173,21 +173,79 @@ void process_memory_region_list(struct k_thread *current)
 #endif
 
 #ifdef CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS
-	/*
-	 * Content of _kernel.threads not being modified during dump
-	 * capture so no need to lock z_thread_monitor_lock.
-	 */
-	struct k_thread *thread;
+	{
+		struct k_thread *thread;
+		unsigned int n;
+		/*
+		 * Defensive bound on the walk below: not a real thread-count
+		 * limit, just insurance against an infinite loop if the list
+		 * is ever seen mid-corruption (e.g. a concurrent unlink on
+		 * another CPU leaves next_thread pointing back into itself).
+		 */
+		const unsigned int max_threads = 4096U;
+#ifdef CONFIG_SMP
+		k_spinlock_key_t key = {0};
+		bool locked = false;
 
-	for (thread = _kernel.threads; thread; thread = thread->next_thread) {
-		dump_thread(thread, thread == current);
+		/*
+		 * Try to take z_thread_monitor_lock so the list is stable
+		 * against concurrent k_thread_create()/k_thread_abort() on
+		 * another CPU. Use trylock rather than a blocking lock: if
+		 * the crashing CPU itself already holds this lock (e.g. it
+		 * faulted inside k_thread_create()/k_thread_abort()),
+		 * blocking here would deadlock the dump on the same CPU and
+		 * lose the entire capture. If the lock is contended or held,
+		 * fall back to a bounded lock-free walk -- a racy read of a
+		 * single thread entry is preferable to no dump at all.
+		 *
+		 * When CONFIG_SPIN_VALIDATE is enabled, k_spin_trylock()
+		 * asserts (via z_spinlock_validate_pre()) that the current
+		 * CPU does not already hold the lock. In the fatal path the
+		 * crashing CPU may indeed already hold it, so calling trylock
+		 * would trip the assert and recurse into the fault handler.
+		 * Probe with z_spin_lock_valid() first and skip locking in
+		 * that case, falling back to the bounded lock-free walk.
+		 */
+#ifdef CONFIG_SPIN_VALIDATE
+		if (z_spin_lock_valid(&z_thread_monitor_lock)) {
+			locked = k_spin_trylock(&z_thread_monitor_lock, &key) == 0;
+		}
+#else
+		locked = k_spin_trylock(&z_thread_monitor_lock, &key) == 0;
+#endif /* CONFIG_SPIN_VALIDATE */
+#else
+		/*
+		 * On uniprocessor, IRQs are already locked by the exception
+		 * entry path so no other context can modify the list.
+		 */
+#endif /* CONFIG_SMP */
+
+		for (thread = _kernel.threads, n = 0;
+		     (thread != NULL) && (n < max_threads);
+		     thread = thread->next_thread, n++) {
+			dump_thread(thread, thread == current);
+		}
+
+#ifdef CONFIG_SMP
+		if (locked) {
+			k_spin_unlock(&z_thread_monitor_lock, key);
+		}
+#endif /* CONFIG_SMP */
+
+		/*
+		 * Dump the ISR (interrupt) stack for every CPU so that crashes
+		 * occurring inside an interrupt handler on any core are captured.
+		 * On uniprocessor this is identical to the original single-CPU
+		 * dump; on SMP it covers all CONFIG_MP_MAX_NUM_CPUS cores.
+		 */
+		for (int cpu = 0; cpu < CONFIG_MP_MAX_NUM_CPUS; cpu++) {
+			char *irq_sp = _kernel.cpus[cpu].irq_stack;
+			uintptr_t isr_start =
+				POINTER_TO_UINT(irq_sp) - CONFIG_ISR_STACK_SIZE;
+
+			coredump_memory_dump(isr_start, POINTER_TO_UINT(irq_sp));
+		}
 	}
-
-	/* Also add interrupt stack, in case error occurred in an interrupt */
-	char *irq_stack = _kernel.cpus[0].irq_stack;
-	uintptr_t start_addr = POINTER_TO_UINT(irq_stack) - CONFIG_ISR_STACK_SIZE;
-
-	coredump_memory_dump(start_addr, POINTER_TO_UINT(irq_stack));
 #endif /* CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS */
 
 #if defined(CONFIG_COREDUMP_DEVICE)

--- a/tests/subsys/debug/coredump_threads/src/main.c
+++ b/tests/subsys/debug/coredump_threads/src/main.c
@@ -8,8 +8,37 @@
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 
-#define STACK_SIZE   1024
+#define STACK_SIZE   2048
 #define THREAD_COUNT 7
+
+/*
+ * crashed: atomic flag used to coordinate crash handling across SMP cores.
+ *
+ * Root causes fixed:
+ * 1. Busy-loop (k_sleep(0)) generated continuous IPIs causing z_arm64_mm_init
+ *    re-entry (MMU assertion) on other CPUs during the coredump.
+ * 2. Returning from handler for unexpected faults (stack overflow, spinlock
+ *    corruption) caused infinite panic loops on SMP.
+ * 3. 1024-byte stack overflowed with blocking k_sem_take + SMP overhead.
+ * 4. Double-panic possible if two threads both exited the wait simultaneously.
+ */
+static atomic_t crashed;
+
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf)
+{
+	ARG_UNUSED(esf);
+
+	/*
+	 * Only return for the expected K_ERR_KERNEL_PANIC so the panicking
+	 * thread can terminate and k_thread_join() completes.
+	 * For all other reasons (CPU exception, stack overflow, spinlock
+	 * corruption) halt the CPU -- returning from an unexpected fault
+	 * leaves state undefined and creates an infinite panic loop.
+	 */
+	if (reason != K_ERR_KERNEL_PANIC) {
+		k_fatal_halt(reason);
+	}
+}
 
 static struct k_thread threads[THREAD_COUNT];
 static uint32_t params[THREAD_COUNT];
@@ -18,14 +47,23 @@ static K_SEM_DEFINE(sem, 0, 1);
 
 static void func0(uint32_t param)
 {
-	int ret = -EAGAIN;
+	/*
+	 * Block on the semaphore with a per-thread timeout instead of
+	 * busy-looping with k_sleep(0). Blocked threads are NOT running so
+	 * they generate no scheduling IPIs during the coredump walk.
+	 * atomic_cas ensures only one thread calls k_panic() even if two
+	 * threads wake simultaneously on SMP.
+	 */
+	int ret = k_sem_take(&sem, K_MSEC(500 + param));
 
-	while (ret != 0) {
-		ret = k_sem_take(&sem, K_NO_WAIT);
-		k_sleep(K_MSEC(param));
+	if (ret == 0) {
+		int expected = 0;
+
+		if (atomic_cas(&crashed, expected, 1)) {
+			k_panic();
+		}
 	}
-
-	k_panic();
+	/* Timed out or lost the CAS -- exit cleanly */
 }
 
 static void test_thread_entry(void *p1, void *p2, void *p3)

--- a/tests/subsys/debug/coredump_threads/tests.yaml
+++ b/tests/subsys/debug/coredump_threads/tests.yaml
@@ -11,6 +11,7 @@ common:
     - qemu_riscv32
     - qemu_riscv64
     - qemu_riscv32e
+    - qemu_cortex_a53/qemu_cortex_a53/smp
 tests:
   debug.coredump.threads:
     platform_exclude:
@@ -18,12 +19,14 @@ tests:
       # arch_coredump_info_dump() returns immediately when esf is NULL so
       # the coredump output is never produced.
       - qemu_riscv64/qemu_virt_riscv64/smode
-    filter: CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS and CONFIG_MP_MAX_NUM_CPUS == 1
+    filter: CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS
     harness: console
     harness_config:
       type: multi_line
       # Verify core dump contains threads metadata section and several
-      # memory sections, two for each thread
+      # memory sections, two per thread, plus per-CPU ISR stacks.
+      # uniprocessor: 7 threads x 2 + 1 ISR stack  = 15 memory sections
+      # SMP 4-CPU:    7 threads x 2 + 4 ISR stacks  = 18 memory sections
       regex:
         - "E: #CD:BEGIN#"
         - "E: #CD:5([aA])45([0-9a-fA-F]+)"


### PR DESCRIPTION
Enable MEMORY_DUMP_THREADS coredump mode on SMP platforms and add ARM64 (Cortex-A) support for thread stack capture. The
  coredump_threads test is updated for SMP stability and verified on versalnet_apu/amd_versalnet_apu/smp hardware.

  Motivation

  DEBUG_COREDUMP_MEMORY_DUMP_THREADS was previously restricted to uniprocessor builds (depends on !SMP), so SMP systems
  could not dump all thread stacks and metadata after a fatal error. ARM64 also lacked the arch hooks needed for THREADS
  mode (ARCH_SUPPORTS_COREDUMP_THREADS, arch_coredump_stack_ptr_get()).

  Changes

  arch: arm64 — THREADS mode support

  * Select ARCH_SUPPORTS_COREDUMP_THREADS and ARCH_SUPPORTS_COREDUMP_STACK_PTR for CPU_CORTEX_A.
  * Implement arch_coredump_stack_ptr_get() using thread->callee_saved.sp_elx (saved EL1 SP from context switch). For the
  faulting thread, callee_saved is stale, so the full stack allocation is dumped (conservative and correct).

  subsys: debug — SMP support for MEMORY_DUMP_THREADS

  * Remove !SMP dependency from DEBUG_COREDUMP_MEMORY_DUMP_THREADS and DEBUG_COREDUMP_THREADS_METADATA.
  * On SMP, walk _kernel.threads under z_thread_monitor_lock taken via k_spin_trylock(): this stabilizes the list against
  concurrent thread create/exit on other CPUs while avoiding a self-deadlock if the crashing CPU already holds the lock.
  If the lock is contended or held, fall back to a bounded lock-free walk (racy read of one entry beats losing the whole
  dump). The walk is capped at a fixed sanity bound as insurance against a corrupted/cyclic list.
  * Dump ISR stacks for all CPUs (CONFIG_MP_MAX_NUM_CPUS), not only cpus[0].
  * On SMP, select THREAD_MONITOR instead of DEBUG_THREAD_INFO (not SMP-safe: K_CURR_THREAD reflects only 
  cpus[0].current). Document this in Kconfig help.

  tests: coredump_threads — SMP enablement and stability

  * Keep the existing CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS filter (runs broadly, skips cleanly on unsupported 
  platforms) and add versalnet_apu/amd_versalnet_apu/smp to integration_platforms so the new SMP path is exercised in CI 
  without narrowing overall platform coverage.
  * Fix SMP test stability:
    * Replace busy-loop k_sem_take(K_NO_WAIT) + k_sleep(0) with blocking k_sem_take(K_MSEC(...)) to avoid IPI storms 
  during coredump.
    * Use atomic_cas so only one thread calls k_panic().
    * Override k_sys_fatal_error_handler() to return only for K_ERR_KERNEL_PANIC (allows k_thread_join() to complete);
  halt on other fault types.
    * Increase STACK_SIZE from 1024 to 2048 (SMP blocking path needs more stack).

  Testing

  Ran tests/subsys/debug/coredump_threads on real versalnet_apu/amd_versalnet_apu/smp hardware (4-core Cortex-A78):

  * Confirmed all 4 cores boot up (primary + 3 secondaries) before the test triggers the crash.
  * Fault triggered a Kernel panic on CPU 2 (a secondary core), exercising the SMP-crash coredump path this series adds — 
  including the k_spin_trylock()/bounded-walk thread list capture and the per-CPU ISR stack dump.
  * Exactly one ZEPHYR FATAL ERROR occurred, with no cascading panics and no z_arm64_mm_init/MMU re-entry (the IPI-storm
  failure mode this series fixes), confirming the atomic_cas single-panic guard and k_sys_fatal_error_handler override 
  behave correctly under a real crash.
  * Coredump captured a single well-formed #CD:BEGIN#...#CD:END# block containing the header, arch register block, threads metadata
  * Twister console harness matched the full expected regex sequence: SUITE PASS - 100.00% [coredump_threads], PROJECT
  EXECUTION SUCCESSFUL (13.811s).

  Also build-verified: qemu_cortex_m3, qemu_riscv32, versalnet_apu (uniprocessor, ARM64 Cortex-A THREADS path),
  versalnet_apu/amd_versalnet_apu/smp.
  
  Known issues:
  --> info threads shows only current thread only working on changes will create a seperate pull request to support for it