### PR TITLE
DMAC support on Renesas RA SCI-B and SPI-B drivers

### DIFF
--- a/drivers/i2c/Kconfig.renesas_ra
+++ b/drivers/i2c/Kconfig.renesas_ra
@@ -63,9 +63,18 @@ config I2C_RENESAS_RA_SCI_B
 
 if I2C_RENESAS_RA_SCI_B
 
+config I2C_RENESAS_RA_SCI_B_DMAC
+	bool "RA MCU SCI-B I2C DMAC Support"
+	default $(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA_I2C_SCI_B),dmas)
+	select USE_RA_FSP_DMA
+	help
+	  Enable DMAC (Direct Memory Access Controller) support for the
+	  SCI-B I2C Driver of RA family.
+
 config I2C_RENESAS_RA_SCI_B_DTC
 	bool "DTC on Transmission and Reception"
-	default y
+	default ($(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA_I2C_SCI_B),rx-dtc,True) || \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA_I2C_SCI_B),tx-dtc,True))
 	select USE_RA_FSP_DTC
 	help
 	   Enable DTC on transmission and reception

--- a/drivers/i2c/i2c_renesas_ra_sci_b.c
+++ b/drivers/i2c/i2c_renesas_ra_sci_b.c
@@ -20,12 +20,20 @@
 #ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
 #include "r_dtc.h"
 #endif
+#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DMAC
+#include "r_dmac.h"
+#endif
 
 #include <soc.h>
 
 LOG_MODULE_REGISTER(renesas_ra_i2c_sci_b, CONFIG_I2C_LOG_LEVEL);
 
 #define I2C_MAX_MSG_LEN (1 << (sizeof(uint8_t) * 8))
+#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
+#define TRANSFER_INFO_ALIGNMENT DTC_TRANSFER_INFO_ALIGNMENT
+#else
+#define TRANSFER_INFO_ALIGNMENT
+#endif
 
 typedef void (*init_func_t)(const struct device *dev);
 struct sci_b_i2c_config {
@@ -53,21 +61,37 @@ struct sci_b_i2c_data {
 	void *p_context;
 #endif /* CONFIG_I2C_CALLBACK */
 
-#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
+#if defined(CONFIG_I2C_RENESAS_RA_SCI_B_DTC) || defined(CONFIG_I2C_RENESAS_RA_SCI_B_DMAC)
 	/* RX */
+	transfer_info_t rx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	transfer_instance_t rx_transfer;
-	transfer_info_t rx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	transfer_cfg_t rx_transfer_cfg;
-	dtc_instance_ctrl_t rx_transfer_ctrl;
-	dtc_extended_cfg_t rx_transfer_cfg_extend;
 
 	/* TX */
+	transfer_info_t tx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	transfer_instance_t tx_transfer;
-	transfer_info_t tx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	transfer_cfg_t tx_transfer_cfg;
-	dtc_instance_ctrl_t tx_transfer_ctrl;
-	dtc_extended_cfg_t tx_transfer_cfg_extend;
+#endif
+
+#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
+	/* DTC RX */
+	dtc_instance_ctrl_t rx_dtc_ctrl;
+	dtc_extended_cfg_t rx_dtc_cfg_extend;
+
+	/* DTC TX */
+	dtc_instance_ctrl_t tx_dtc_ctrl;
+	dtc_extended_cfg_t tx_dtc_cfg_extend;
 #endif /* CONFIG_I2C_RENESAS_RA_SCI_B_DTC */
+
+#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DMAC
+	/* DMAC RX */
+	dmac_instance_ctrl_t rx_dmac_ctrl;
+	dmac_extended_cfg_t rx_dmac_cfg_extend;
+
+	/* DMAC TX */
+	dmac_instance_ctrl_t tx_dmac_ctrl;
+	dmac_extended_cfg_t tx_dmac_cfg_extend;
+#endif /* CONFIG_I2C_RENESAS_RA_SCI_B_DMAC */
 };
 
 static void calc_sci_b_iic_clock_setting(const struct device *dev, const uint32_t fsp_i2c_rate,
@@ -77,6 +101,12 @@ static void calc_sci_b_iic_clock_setting(const struct device *dev, const uint32_
 void sci_b_i2c_txi_isr(void);
 void sci_b_i2c_tei_isr(void);
 void sci_b_i2c_rxi_isr(void);
+
+#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DMAC
+void dmac_int_isr(void);
+void sci_b_i2c_rx_dmac_callback(sci_b_i2c_instance_ctrl_t *const p_ctrl);
+void sci_b_i2c_tx_dmac_callback(sci_b_i2c_instance_ctrl_t *const p_ctrl);
+#endif
 
 static int renesas_ra_sci_b_i2c_configure(const struct device *dev, uint32_t dev_config)
 {
@@ -457,11 +487,6 @@ static int renesas_ra_sci_b_i2c_init(const struct device *dev)
 		return -ENOTSUP;
 	}
 
-#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
-	data->i2c_config.p_transfer_rx = &data->rx_transfer;
-	data->i2c_config.p_transfer_tx = &data->tx_transfer;
-#endif
-
 	fsp_err = R_SCI_B_I2C_Open(&data->ctrl, &data->i2c_config);
 
 	if (fsp_err != FSP_SUCCESS) {
@@ -593,12 +618,113 @@ static DEVICE_API(i2c, renesas_ra_sci_b_i2c_driver_api) = {
 #define EVENT_SCI_RXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _RXI))
 #define EVENT_SCI_TXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _TXI))
 #define EVENT_SCI_TEI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _TEI))
+#define EVENT_DMAC_INT(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_DMAC, channel, _INT))
+
+#define SCI_B_I2C_DMAC_IRQ(index, dir)                                                             \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		   (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                           \
+				   DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                 \
+				   irq)),                                                          \
+		   (FSP_INVALID_VECTOR))
+
+#define SCI_B_I2C_DMAC_IPL(index, dir)                                                             \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		   (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                           \
+				   DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                 \
+				   priority)),                                                     \
+		   (BSP_IRQ_DISABLED))
+
+#define SCI_B_I2C_ASSERT_NO_CONFLICT(index)                                                        \
+	BUILD_ASSERT(!(IS_ENABLED(CONFIG_I2C_RENESAS_RA_SCI_B_DMAC) &&                             \
+		       IS_ENABLED(CONFIG_I2C_RENESAS_RA_SCI_B_DTC)),                               \
+		     "SCI-B I2C driver cannot support both DMAC and DTC simultaneously.")
+
+#ifndef CONFIG_I2C_RENESAS_RA_SCI_B_DMAC
+#define SCI_B_I2C_DMAC_CFG_EXTEND(index)
+#define SCI_B_I2C_DMAC_CALLBACKS(index)
+#else
+#define SCI_B_I2C_DMAC_CFG_EXTEND(index)                                                           \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                               \
+		(.tx_dmac_cfg_extend = {                                                           \
+			.activation_source = EVENT_SCI_TXI(DT_INST_PROP(index, channel)),          \
+			.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                   \
+					       (DT_INST_DMAS_CELL_BY_NAME(index, tx, channel)),    \
+					       (0)),                                               \
+			.irq = SCI_B_I2C_DMAC_IRQ(index, tx),                                      \
+			.ipl = SCI_B_I2C_DMAC_IPL(index, tx),                                      \
+			.offset = 0, .src_buffer_size = 0, .p_callback = NULL},                    \
+	))                                                                                         \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                               \
+		(.rx_dmac_cfg_extend = {                                                           \
+			.activation_source = EVENT_SCI_RXI(DT_INST_PROP(index, channel)),          \
+			.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),                   \
+					       (DT_INST_DMAS_CELL_BY_NAME(index, rx, channel)),    \
+					       (0)),                                               \
+			.irq = SCI_B_I2C_DMAC_IRQ(index, rx),                                      \
+			.ipl = SCI_B_I2C_DMAC_IPL(index, rx),                                      \
+			.offset = 0, .src_buffer_size = 0, .p_callback = NULL},                    \
+	))
+
+#define SCI_B_I2C_DMAC_CALLBACKS(index)                                                            \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                               \
+		(static void sci_b_i2c_dmac_tx_cb_##index(dmac_callback_args_t *p_args)            \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			sci_b_i2c_tx_dmac_callback(&sci_b_i2c_data_##index.ctrl);                  \
+		}))                                                                                \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                               \
+		(static void sci_b_i2c_dmac_rx_cb_##index(dmac_callback_args_t *p_args)            \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			sci_b_i2c_rx_dmac_callback(&sci_b_i2c_data_##index.ctrl);                  \
+		}))
+#endif
 
 #ifndef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
-#define SCI_B_I2C_DTC_INIT(index)
-#define RXI_TRANSFER(index)
+#define SCI_B_I2C_DTC_CFG_EXTEND(index)
 #else
-#define SCI_B_I2C_DTC_INIT(index)                                                                  \
+#define SCI_B_I2C_DTC_CFG_EXTEND(index)                                                            \
+	IF_ENABLED(DT_INST_PROP_OR(index, rx_dtc, false),                                          \
+		(.rx_dtc_cfg_extend = {.activation_source =                                        \
+			   DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)},))                     \
+	IF_ENABLED(DT_INST_PROP_OR(index, tx_dtc, false),                                          \
+		(.tx_dtc_cfg_extend = {.activation_source =                                        \
+			   DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)},))
+#endif
+
+#if defined(CONFIG_I2C_RENESAS_RA_SCI_B_DTC) || defined(CONFIG_I2C_RENESAS_RA_SCI_B_DMAC)
+/*
+ * Select a transfer value for a given direction (@p dir: rx or tx).
+ * - If instance has DMAS for @p dir: use @p dmac_val
+ * - Else if instance has DTC property for @p dir: use @p dtc_val
+ * - Else: NULL
+ */
+#define SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, dir, dmac_val, dtc_val)                              \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		    (dmac_val),                                                                    \
+		    (COND_CODE_1(DT_INST_PROP_OR(index, dir##_dtc, false),                         \
+				 (dtc_val),                                                        \
+				 (NULL))))
+
+#define SCI_B_I2C_TRANSFER_INIT(index)                                                             \
+	do {                                                                                       \
+		if (DT_INST_PROP_OR(index, rx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, rx)) {   \
+			sci_b_i2c_data_##index.i2c_config.p_transfer_rx =                          \
+				&sci_b_i2c_data_##index.rx_transfer;                               \
+		}                                                                                  \
+		if (DT_INST_PROP_OR(index, tx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, tx)) {   \
+			sci_b_i2c_data_##index.i2c_config.p_transfer_tx =                          \
+				&sci_b_i2c_data_##index.tx_transfer;                               \
+		}                                                                                  \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                       \
+			(sci_b_i2c_data_##index.rx_dmac_cfg_extend.p_callback =                    \
+				 sci_b_i2c_dmac_rx_cb_##index;))                                   \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                       \
+			(sci_b_i2c_data_##index.tx_dmac_cfg_extend.p_callback =                    \
+				 sci_b_i2c_dmac_tx_cb_##index;))                                   \
+	} while (0)
+
+#define SCI_B_I2C_TRANSFER_CONFIGURE(index)                                                        \
 	.rx_transfer_info =                                                                        \
 		{                                                                                  \
 			.transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED, \
@@ -613,18 +739,21 @@ static DEVICE_API(i2c, renesas_ra_sci_b_i2c_driver_api) = {
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.rx_transfer_cfg_extend = {.activation_source =                                            \
-					   DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)},       \
 	.rx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &sci_b_i2c_data_##index.rx_transfer_info,                        \
-			.p_extend = &sci_b_i2c_data_##index.rx_transfer_cfg_extend,                \
+			.p_extend = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, rx,                      \
+						(&sci_b_i2c_data_##index.rx_dmac_cfg_extend),      \
+						(&sci_b_i2c_data_##index.rx_dtc_cfg_extend)),      \
 	},                                                                                         \
 	.rx_transfer =                                                                             \
 		{                                                                                  \
-			.p_ctrl = &sci_b_i2c_data_##index.rx_transfer_ctrl,                        \
+			.p_ctrl = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, rx,                        \
+					       (&sci_b_i2c_data_##index.rx_dmac_ctrl),             \
+					       (&sci_b_i2c_data_##index.rx_dtc_ctrl)),             \
 			.p_cfg = &sci_b_i2c_data_##index.rx_transfer_cfg,                          \
-			.p_api = &g_transfer_on_dtc,                                               \
+			.p_api = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, rx,                         \
+					      (&g_transfer_on_dmac), (&g_transfer_on_dtc)),        \
 	},                                                                                         \
 	.tx_transfer_info =                                                                        \
 		{                                                                                  \
@@ -640,47 +769,74 @@ static DEVICE_API(i2c, renesas_ra_sci_b_i2c_driver_api) = {
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.tx_transfer_cfg_extend = {.activation_source =                                            \
-					   DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)},       \
 	.tx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &sci_b_i2c_data_##index.tx_transfer_info,                        \
-			.p_extend = &sci_b_i2c_data_##index.tx_transfer_cfg_extend,                \
+			.p_extend = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, tx,                      \
+						(&sci_b_i2c_data_##index.tx_dmac_cfg_extend),      \
+						(&sci_b_i2c_data_##index.tx_dtc_cfg_extend)),      \
 	},                                                                                         \
 	.tx_transfer = {                                                                           \
-		.p_ctrl = &sci_b_i2c_data_##index.tx_transfer_ctrl,                                \
+		.p_ctrl = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, tx,                                \
+				       (&sci_b_i2c_data_##index.tx_dmac_ctrl),                     \
+				       (&sci_b_i2c_data_##index.tx_dtc_ctrl)),                     \
 		.p_cfg = &sci_b_i2c_data_##index.tx_transfer_cfg,                                  \
-		.p_api = &g_transfer_on_dtc,                                                       \
-	},
-
-#define RXI_TRANSFER(index)                                                                        \
-	/* rxi */                                                                                  \
-	R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)] =                            \
-		EVENT_SCI_RXI(DT_INST_PROP(index, channel));                                       \
-	BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SCI_RXI(DT_INST_PROP(index, channel)));             \
-	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),                               \
-		    DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, priority), sci_b_i2c_rxi_isr,       \
-		    DEVICE_DT_INST_GET(index), 0);                                                 \
-	irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq));
+		.p_api = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, tx,                                 \
+				      (&g_transfer_on_dmac), (&g_transfer_on_dtc)),                \
+	},                                                                                         \
+	SCI_B_I2C_DTC_CFG_EXTEND(index)                                                            \
+	SCI_B_I2C_DMAC_CFG_EXTEND(index)
+#else
+#define SCI_B_I2C_TRANSFER_INIT(index)
+#define SCI_B_I2C_TRANSFER_CONFIGURE(index)
 #endif
 
 #define SCI_B_I2C_RA_INIT(index)                                                                   \
 	static void renesas_ra_sci_b_i2c_irq_config_func##index(const struct device *dev)          \
 	{                                                                                          \
-		RXI_TRANSFER(index)                                                                \
-                                                                                                   \
+		/* DMA RX Interrupt */                                                             \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                       \
+		(                                                                                  \
+			R_ICU->IELSR[SCI_B_I2C_DMAC_IRQ(index, rx)] = EVENT_DMAC_INT(              \
+				     DT_INST_DMAS_CELL_BY_NAME(index, rx, channel));               \
+			IRQ_CONNECT(SCI_B_I2C_DMAC_IRQ(index, rx),                                 \
+				    SCI_B_I2C_DMAC_IPL(index, rx),                                 \
+				    dmac_int_isr, NULL, 0);                                        \
+			irq_enable(SCI_B_I2C_DMAC_IRQ(index, rx));                                 \
+		))                                                                                 \
+		/* DMA TX Interrupt */                                                             \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                       \
+		(                                                                                  \
+			R_ICU->IELSR[SCI_B_I2C_DMAC_IRQ(index, tx)] = EVENT_DMAC_INT(              \
+				     DT_INST_DMAS_CELL_BY_NAME(index, tx, channel));               \
+			IRQ_CONNECT(SCI_B_I2C_DMAC_IRQ(index, tx),                                 \
+				    SCI_B_I2C_DMAC_IPL(index, tx),                                 \
+				    dmac_int_isr, NULL, 0);                                        \
+			irq_enable(SCI_B_I2C_DMAC_IRQ(index, tx));                                 \
+		))                                                                                 \
+		/* rxi */                                                                          \
+		IF_ENABLED(CONFIG_I2C_RENESAS_RA_SCI_B_DTC,                                        \
+		(                                                                                  \
+			R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)] =            \
+				     EVENT_SCI_RXI(DT_INST_PROP(index, channel));                  \
+			BSP_ASSIGN_EVENT_TO_CURRENT_CORE(                                          \
+					EVENT_SCI_RXI(DT_INST_PROP(index, channel)));              \
+			IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),               \
+				    DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, priority),          \
+				    sci_b_i2c_rxi_isr, DEVICE_DT_INST_GET(index), 0);              \
+			irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq));               \
+		))                                                                                 \
 		/* txi */                                                                          \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)] =                    \
-			EVENT_SCI_TXI(DT_INST_PROP(index, channel));                               \
+			     EVENT_SCI_TXI(DT_INST_PROP(index, channel));                          \
 		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SCI_TXI(DT_INST_PROP(index, channel)));     \
 		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq),                       \
 			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, priority),                  \
 			    sci_b_i2c_txi_isr, DEVICE_DT_INST_GET(index), 0);                      \
 		irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq));                       \
-                                                                                                   \
 		/* tei */                                                                          \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq)] =                    \
-			EVENT_SCI_TEI(DT_INST_PROP(index, channel));                               \
+			     EVENT_SCI_TEI(DT_INST_PROP(index, channel));                          \
 		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SCI_TEI(DT_INST_PROP(index, channel)));     \
 		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq),                       \
 			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, priority),                  \
@@ -702,7 +858,9 @@ static DEVICE_API(i2c, renesas_ra_sci_b_i2c_driver_api) = {
 				.rate = I2C_MASTER_RATE_STANDARD,                                  \
 				.addr_mode = I2C_MASTER_ADDR_MODE_7BIT,                            \
 				.ipl = DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, priority),       \
-				.rxi_irq = DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),        \
+				.rxi_irq = COND_CODE_1(CONFIG_I2C_RENESAS_RA_SCI_B_DTC,            \
+					  (DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)),       \
+					  (FSP_INVALID_VECTOR)),                                   \
 				.txi_irq = DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq),        \
 				.tei_irq = DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq),        \
 				.p_callback = renesas_ra_sci_b_i2c_callback,                       \
@@ -716,8 +874,17 @@ static DEVICE_API(i2c, renesas_ra_sci_b_i2c_driver_api) = {
 					DT_DRV_INST(index), bit_rate_modulation),                  \
 				.clock_settings.clock_source = SCI_B_I2C_CLOCK_SOURCE_SCISPICLK,   \
 			},                                                                         \
-		SCI_B_I2C_DTC_INIT(index)};                                                        \
-	I2C_DEVICE_DT_INST_DEFINE(index, renesas_ra_sci_b_i2c_init, NULL, &sci_b_i2c_data_##index, \
+		SCI_B_I2C_TRANSFER_CONFIGURE(index)};                                              \
+	                                                                                           \
+	SCI_B_I2C_DMAC_CALLBACKS(index)                                                            \
+	static int sci_b_i2c_init_##index(const struct device *dev)                                \
+	{                                                                                          \
+		SCI_B_I2C_ASSERT_NO_CONFLICT(index);                                               \
+		SCI_B_I2C_TRANSFER_INIT(index);                                                    \
+		return renesas_ra_sci_b_i2c_init(dev);                                             \
+	}                                                                                          \
+	                                                                                           \
+	I2C_DEVICE_DT_INST_DEFINE(index, sci_b_i2c_init_##index, NULL, &sci_b_i2c_data_##index,    \
 				  &sci_b_i2c_config_##index, POST_KERNEL,                          \
 				  CONFIG_I2C_INIT_PRIORITY, &renesas_ra_sci_b_i2c_driver_api);
 

--- a/drivers/i2c/i2c_renesas_ra_sci_b.c
+++ b/drivers/i2c/i2c_renesas_ra_sci_b.c
@@ -20,12 +20,20 @@
 #ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
 #include "r_dtc.h"
 #endif
+#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DMAC
+#include "r_dmac.h"
+#endif
 
 #include <soc.h>
 
 LOG_MODULE_REGISTER(renesas_ra_i2c_sci_b, CONFIG_I2C_LOG_LEVEL);
 
 #define I2C_MAX_MSG_LEN (1 << (sizeof(uint8_t) * 8))
+#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
+#define TRANSFER_INFO_ALIGNMENT DTC_TRANSFER_INFO_ALIGNMENT
+#else
+#define TRANSFER_INFO_ALIGNMENT
+#endif
 
 typedef void (*init_func_t)(const struct device *dev);
 struct sci_b_i2c_config {
@@ -53,21 +61,37 @@ struct sci_b_i2c_data {
 	void *p_context;
 #endif /* CONFIG_I2C_CALLBACK */
 
-#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
+#if defined(CONFIG_I2C_RENESAS_RA_SCI_B_DTC) || defined(CONFIG_I2C_RENESAS_RA_SCI_B_DMAC)
 	/* RX */
+	transfer_info_t rx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	transfer_instance_t rx_transfer;
-	transfer_info_t rx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	transfer_cfg_t rx_transfer_cfg;
-	dtc_instance_ctrl_t rx_transfer_ctrl;
-	dtc_extended_cfg_t rx_transfer_cfg_extend;
 
 	/* TX */
+	transfer_info_t tx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	transfer_instance_t tx_transfer;
-	transfer_info_t tx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	transfer_cfg_t tx_transfer_cfg;
-	dtc_instance_ctrl_t tx_transfer_ctrl;
-	dtc_extended_cfg_t tx_transfer_cfg_extend;
+#endif
+
+#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
+	/* DTC RX */
+	dtc_instance_ctrl_t rx_dtc_ctrl;
+	dtc_extended_cfg_t rx_dtc_cfg_extend;
+
+	/* DTC TX */
+	dtc_instance_ctrl_t tx_dtc_ctrl;
+	dtc_extended_cfg_t tx_dtc_cfg_extend;
 #endif /* CONFIG_I2C_RENESAS_RA_SCI_B_DTC */
+
+#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DMAC
+	/* DMAC RX */
+	dmac_instance_ctrl_t rx_dmac_ctrl;
+	dmac_extended_cfg_t rx_dmac_cfg_extend;
+
+	/* DMAC TX */
+	dmac_instance_ctrl_t tx_dmac_ctrl;
+	dmac_extended_cfg_t tx_dmac_cfg_extend;
+#endif /* CONFIG_I2C_RENESAS_RA_SCI_B_DMAC */
 };
 
 static void calc_sci_b_iic_clock_setting(const struct device *dev, const uint32_t fsp_i2c_rate,
@@ -77,6 +101,12 @@ static void calc_sci_b_iic_clock_setting(const struct device *dev, const uint32_
 void sci_b_i2c_txi_isr(void);
 void sci_b_i2c_tei_isr(void);
 void sci_b_i2c_rxi_isr(void);
+
+#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DMAC
+void dmac_int_isr(void);
+void sci_b_i2c_rx_dmac_callback(sci_b_i2c_instance_ctrl_t *const p_ctrl);
+void sci_b_i2c_tx_dmac_callback(sci_b_i2c_instance_ctrl_t *const p_ctrl);
+#endif
 
 static int renesas_ra_sci_b_i2c_configure(const struct device *dev, uint32_t dev_config)
 {
@@ -457,11 +487,6 @@ static int renesas_ra_sci_b_i2c_init(const struct device *dev)
 		return -ENOTSUP;
 	}
 
-#ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
-	data->i2c_config.p_transfer_rx = &data->rx_transfer;
-	data->i2c_config.p_transfer_tx = &data->tx_transfer;
-#endif
-
 	fsp_err = R_SCI_B_I2C_Open(&data->ctrl, &data->i2c_config);
 
 	if (fsp_err != FSP_SUCCESS) {
@@ -593,12 +618,125 @@ static DEVICE_API(i2c, renesas_ra_sci_b_i2c_driver_api) = {
 #define EVENT_SCI_RXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _RXI))
 #define EVENT_SCI_TXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _TXI))
 #define EVENT_SCI_TEI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _TEI))
+#define EVENT_DMAC_INT(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_DMAC, channel, _INT))
+
+#define SCI_B_I2C_DMAC_IRQ(index, dir)                                                             \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		   (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                           \
+				   DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                 \
+				   irq)),                                                          \
+		   (FSP_INVALID_VECTOR))
+
+#define SCI_B_I2C_DMAC_IPL(index, dir)                                                             \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		   (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                           \
+				   DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                 \
+				   priority)),                                                     \
+		   (BSP_IRQ_DISABLED))
+
+#define SCI_B_I2C_ASSERT_NO_CONFLICT(index)                                                        \
+	BUILD_ASSERT(!(IS_ENABLED(CONFIG_I2C_RENESAS_RA_SCI_B_DMAC) &&                             \
+		       IS_ENABLED(CONFIG_I2C_RENESAS_RA_SCI_B_DTC)),                               \
+		     "SCI-B I2C driver cannot support both DMAC and DTC simultaneously.")
+
+#define SCI_B_I2C_ASSERT_DTC_RX_REQUIRES_TX(index)                                                 \
+	BUILD_ASSERT(!(IS_ENABLED(CONFIG_I2C_RENESAS_RA_SCI_B_DTC) &&                              \
+		       DT_INST_PROP_OR(index, rx_dtc, false) &&                                    \
+		       !DT_INST_PROP_OR(index, tx_dtc, false)),                                    \
+		     "SCI-B I2C DTC read requires tx-dtc when rx-dtc is set")
+
+#define SCI_B_I2C_ASSERT_DMAC_RX_REQUIRES_TX(index)                                                \
+	BUILD_ASSERT(!(IS_ENABLED(CONFIG_I2C_RENESAS_RA_SCI_B_DMAC) &&                             \
+		       DT_INST_DMAS_HAS_NAME(index, rx) &&                                         \
+		       !DT_INST_DMAS_HAS_NAME(index, tx)),                                         \
+		     "SCI-B I2C DMAC read requires dmas tx when dmas rx is set")
+
+#ifndef CONFIG_I2C_RENESAS_RA_SCI_B_DMAC
+#define SCI_B_I2C_DMAC_CFG_EXTEND(index)
+#define SCI_B_I2C_DMAC_CALLBACKS(index)
+#else
+#define SCI_B_I2C_DMAC_CFG_EXTEND(index)                                                           \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                               \
+		(.tx_dmac_cfg_extend = {                                                           \
+			.activation_source = EVENT_SCI_TXI(DT_INST_PROP(index, channel)),          \
+			.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                   \
+					       (DT_INST_DMAS_CELL_BY_NAME(index, tx, channel)),    \
+					       (0)),                                               \
+			.irq = SCI_B_I2C_DMAC_IRQ(index, tx),                                      \
+			.ipl = SCI_B_I2C_DMAC_IPL(index, tx),                                      \
+			.offset = 0, .src_buffer_size = 0, .p_callback = NULL},                    \
+	))                                                                                         \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                               \
+		(.rx_dmac_cfg_extend = {                                                           \
+			.activation_source = EVENT_SCI_RXI(DT_INST_PROP(index, channel)),          \
+			.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),                   \
+					       (DT_INST_DMAS_CELL_BY_NAME(index, rx, channel)),    \
+					       (0)),                                               \
+			.irq = SCI_B_I2C_DMAC_IRQ(index, rx),                                      \
+			.ipl = SCI_B_I2C_DMAC_IPL(index, rx),                                      \
+			.offset = 0, .src_buffer_size = 0, .p_callback = NULL},                    \
+	))
+
+#define SCI_B_I2C_DMAC_CALLBACKS(index)                                                            \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                               \
+		(static void sci_b_i2c_dmac_tx_cb_##index(dmac_callback_args_t *p_args)            \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			sci_b_i2c_tx_dmac_callback(&sci_b_i2c_data_##index.ctrl);                  \
+		}))                                                                                \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                               \
+		(static void sci_b_i2c_dmac_rx_cb_##index(dmac_callback_args_t *p_args)            \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			sci_b_i2c_rx_dmac_callback(&sci_b_i2c_data_##index.ctrl);                  \
+		}))
+#endif
 
 #ifndef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
-#define SCI_B_I2C_DTC_INIT(index)
-#define RXI_TRANSFER(index)
+#define SCI_B_I2C_DTC_CFG_EXTEND(index)
 #else
-#define SCI_B_I2C_DTC_INIT(index)                                                                  \
+#define SCI_B_I2C_DTC_CFG_EXTEND(index)                                                            \
+	IF_ENABLED(DT_INST_PROP_OR(index, rx_dtc, false),                                          \
+		(.rx_dtc_cfg_extend = {.activation_source =                                        \
+			   DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)},))                     \
+	IF_ENABLED(DT_INST_PROP_OR(index, tx_dtc, false),                                          \
+		(.tx_dtc_cfg_extend = {.activation_source =                                        \
+			   DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)},))
+#endif
+
+#if defined(CONFIG_I2C_RENESAS_RA_SCI_B_DTC) || defined(CONFIG_I2C_RENESAS_RA_SCI_B_DMAC)
+/*
+ * Select a transfer value for a given direction (@p dir: rx or tx).
+ * - If instance has DMAS for @p dir: use @p dmac_val
+ * - Else if instance has DTC property for @p dir: use @p dtc_val
+ * - Else: NULL
+ */
+#define SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, dir, dmac_val, dtc_val)                              \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		    (dmac_val),                                                                    \
+		    (COND_CODE_1(DT_INST_PROP_OR(index, dir##_dtc, false),                         \
+				 (dtc_val),                                                        \
+				 (NULL))))
+
+#define SCI_B_I2C_TRANSFER_INIT(index)                                                             \
+	do {                                                                                       \
+		if (DT_INST_PROP_OR(index, rx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, rx)) {   \
+			sci_b_i2c_data_##index.i2c_config.p_transfer_rx =                          \
+				&sci_b_i2c_data_##index.rx_transfer;                               \
+		}                                                                                  \
+		if (DT_INST_PROP_OR(index, tx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, tx)) {   \
+			sci_b_i2c_data_##index.i2c_config.p_transfer_tx =                          \
+				&sci_b_i2c_data_##index.tx_transfer;                               \
+		}                                                                                  \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                       \
+			(sci_b_i2c_data_##index.rx_dmac_cfg_extend.p_callback =                    \
+				 sci_b_i2c_dmac_rx_cb_##index;))                                   \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                       \
+			(sci_b_i2c_data_##index.tx_dmac_cfg_extend.p_callback =                    \
+				 sci_b_i2c_dmac_tx_cb_##index;))                                   \
+	} while (0)
+
+#define SCI_B_I2C_TRANSFER_CONFIGURE(index)                                                        \
 	.rx_transfer_info =                                                                        \
 		{                                                                                  \
 			.transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED, \
@@ -613,18 +751,21 @@ static DEVICE_API(i2c, renesas_ra_sci_b_i2c_driver_api) = {
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.rx_transfer_cfg_extend = {.activation_source =                                            \
-					   DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)},       \
 	.rx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &sci_b_i2c_data_##index.rx_transfer_info,                        \
-			.p_extend = &sci_b_i2c_data_##index.rx_transfer_cfg_extend,                \
+			.p_extend = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, rx,                      \
+						(&sci_b_i2c_data_##index.rx_dmac_cfg_extend),      \
+						(&sci_b_i2c_data_##index.rx_dtc_cfg_extend)),      \
 	},                                                                                         \
 	.rx_transfer =                                                                             \
 		{                                                                                  \
-			.p_ctrl = &sci_b_i2c_data_##index.rx_transfer_ctrl,                        \
+			.p_ctrl = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, rx,                        \
+					       (&sci_b_i2c_data_##index.rx_dmac_ctrl),             \
+					       (&sci_b_i2c_data_##index.rx_dtc_ctrl)),             \
 			.p_cfg = &sci_b_i2c_data_##index.rx_transfer_cfg,                          \
-			.p_api = &g_transfer_on_dtc,                                               \
+			.p_api = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, rx,                         \
+					      (&g_transfer_on_dmac), (&g_transfer_on_dtc)),        \
 	},                                                                                         \
 	.tx_transfer_info =                                                                        \
 		{                                                                                  \
@@ -640,47 +781,74 @@ static DEVICE_API(i2c, renesas_ra_sci_b_i2c_driver_api) = {
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.tx_transfer_cfg_extend = {.activation_source =                                            \
-					   DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)},       \
 	.tx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &sci_b_i2c_data_##index.tx_transfer_info,                        \
-			.p_extend = &sci_b_i2c_data_##index.tx_transfer_cfg_extend,                \
+			.p_extend = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, tx,                      \
+						(&sci_b_i2c_data_##index.tx_dmac_cfg_extend),      \
+						(&sci_b_i2c_data_##index.tx_dtc_cfg_extend)),      \
 	},                                                                                         \
 	.tx_transfer = {                                                                           \
-		.p_ctrl = &sci_b_i2c_data_##index.tx_transfer_ctrl,                                \
+		.p_ctrl = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, tx,                                \
+				       (&sci_b_i2c_data_##index.tx_dmac_ctrl),                     \
+				       (&sci_b_i2c_data_##index.tx_dtc_ctrl)),                     \
 		.p_cfg = &sci_b_i2c_data_##index.tx_transfer_cfg,                                  \
-		.p_api = &g_transfer_on_dtc,                                                       \
-	},
-
-#define RXI_TRANSFER(index)                                                                        \
-	/* rxi */                                                                                  \
-	R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)] =                            \
-		EVENT_SCI_RXI(DT_INST_PROP(index, channel));                                       \
-	BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SCI_RXI(DT_INST_PROP(index, channel)));             \
-	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),                               \
-		    DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, priority), sci_b_i2c_rxi_isr,       \
-		    DEVICE_DT_INST_GET(index), 0);                                                 \
-	irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq));
+		.p_api = SCI_B_I2C_TRANSFER_DMAC_OR_DTC(index, tx,                                 \
+				      (&g_transfer_on_dmac), (&g_transfer_on_dtc)),                \
+	},                                                                                         \
+	SCI_B_I2C_DTC_CFG_EXTEND(index)                                                            \
+	SCI_B_I2C_DMAC_CFG_EXTEND(index)
+#else
+#define SCI_B_I2C_TRANSFER_INIT(index)
+#define SCI_B_I2C_TRANSFER_CONFIGURE(index)
 #endif
 
 #define SCI_B_I2C_RA_INIT(index)                                                                   \
 	static void renesas_ra_sci_b_i2c_irq_config_func##index(const struct device *dev)          \
 	{                                                                                          \
-		RXI_TRANSFER(index)                                                                \
-                                                                                                   \
+		/* DMA RX Interrupt */                                                             \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                       \
+		(                                                                                  \
+			R_ICU->IELSR[SCI_B_I2C_DMAC_IRQ(index, rx)] = EVENT_DMAC_INT(              \
+				     DT_INST_DMAS_CELL_BY_NAME(index, rx, channel));               \
+			IRQ_CONNECT(SCI_B_I2C_DMAC_IRQ(index, rx),                                 \
+				    SCI_B_I2C_DMAC_IPL(index, rx),                                 \
+				    dmac_int_isr, NULL, 0);                                        \
+			irq_enable(SCI_B_I2C_DMAC_IRQ(index, rx));                                 \
+		))                                                                                 \
+		/* DMA TX Interrupt */                                                             \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                       \
+		(                                                                                  \
+			R_ICU->IELSR[SCI_B_I2C_DMAC_IRQ(index, tx)] = EVENT_DMAC_INT(              \
+				     DT_INST_DMAS_CELL_BY_NAME(index, tx, channel));               \
+			IRQ_CONNECT(SCI_B_I2C_DMAC_IRQ(index, tx),                                 \
+				    SCI_B_I2C_DMAC_IPL(index, tx),                                 \
+				    dmac_int_isr, NULL, 0);                                        \
+			irq_enable(SCI_B_I2C_DMAC_IRQ(index, tx));                                 \
+		))                                                                                 \
+		/* rxi */                                                                          \
+		IF_ENABLED(CONFIG_I2C_RENESAS_RA_SCI_B_DTC,                                        \
+		(                                                                                  \
+			R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)] =            \
+				     EVENT_SCI_RXI(DT_INST_PROP(index, channel));                  \
+			BSP_ASSIGN_EVENT_TO_CURRENT_CORE(                                          \
+					EVENT_SCI_RXI(DT_INST_PROP(index, channel)));              \
+			IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),               \
+				    DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, priority),          \
+				    sci_b_i2c_rxi_isr, DEVICE_DT_INST_GET(index), 0);              \
+			irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq));               \
+		))                                                                                 \
 		/* txi */                                                                          \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)] =                    \
-			EVENT_SCI_TXI(DT_INST_PROP(index, channel));                               \
+			     EVENT_SCI_TXI(DT_INST_PROP(index, channel));                          \
 		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SCI_TXI(DT_INST_PROP(index, channel)));     \
 		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq),                       \
 			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, priority),                  \
 			    sci_b_i2c_txi_isr, DEVICE_DT_INST_GET(index), 0);                      \
 		irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq));                       \
-                                                                                                   \
 		/* tei */                                                                          \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq)] =                    \
-			EVENT_SCI_TEI(DT_INST_PROP(index, channel));                               \
+			     EVENT_SCI_TEI(DT_INST_PROP(index, channel));                          \
 		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SCI_TEI(DT_INST_PROP(index, channel)));     \
 		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq),                       \
 			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, priority),                  \
@@ -702,7 +870,9 @@ static DEVICE_API(i2c, renesas_ra_sci_b_i2c_driver_api) = {
 				.rate = I2C_MASTER_RATE_STANDARD,                                  \
 				.addr_mode = I2C_MASTER_ADDR_MODE_7BIT,                            \
 				.ipl = DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, priority),       \
-				.rxi_irq = DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),        \
+				.rxi_irq = COND_CODE_1(CONFIG_I2C_RENESAS_RA_SCI_B_DTC,            \
+					  (DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)),       \
+					  (FSP_INVALID_VECTOR)),                                   \
 				.txi_irq = DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq),        \
 				.tei_irq = DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq),        \
 				.p_callback = renesas_ra_sci_b_i2c_callback,                       \
@@ -716,8 +886,19 @@ static DEVICE_API(i2c, renesas_ra_sci_b_i2c_driver_api) = {
 					DT_DRV_INST(index), bit_rate_modulation),                  \
 				.clock_settings.clock_source = SCI_B_I2C_CLOCK_SOURCE_SCISPICLK,   \
 			},                                                                         \
-		SCI_B_I2C_DTC_INIT(index)};                                                        \
-	I2C_DEVICE_DT_INST_DEFINE(index, renesas_ra_sci_b_i2c_init, NULL, &sci_b_i2c_data_##index, \
+		SCI_B_I2C_TRANSFER_CONFIGURE(index)};                                              \
+	                                                                                           \
+	SCI_B_I2C_DMAC_CALLBACKS(index)                                                            \
+	static int sci_b_i2c_init_##index(const struct device *dev)                                \
+	{                                                                                          \
+		SCI_B_I2C_ASSERT_NO_CONFLICT(index);                                               \
+		SCI_B_I2C_ASSERT_DTC_RX_REQUIRES_TX(index);                                        \
+		SCI_B_I2C_ASSERT_DMAC_RX_REQUIRES_TX(index);                                       \
+		SCI_B_I2C_TRANSFER_INIT(index);                                                    \
+		return renesas_ra_sci_b_i2c_init(dev);                                             \
+	}                                                                                          \
+	                                                                                           \
+	I2C_DEVICE_DT_INST_DEFINE(index, sci_b_i2c_init_##index, NULL, &sci_b_i2c_data_##index,    \
 				  &sci_b_i2c_config_##index, POST_KERNEL,                          \
 				  CONFIG_I2C_INIT_PRIORITY, &renesas_ra_sci_b_i2c_driver_api);
 

--- a/drivers/serial/Kconfig.renesas_ra8
+++ b/drivers/serial/Kconfig.renesas_ra8
@@ -9,10 +9,27 @@ config UART_RA8_SCI_B
 	select SERIAL_SUPPORT_INTERRUPT
 	select SERIAL_SUPPORT_ASYNC
 	select USE_RA_FSP_SCI_B_UART
-	select USE_RA_FSP_DTC if UART_ASYNC_API
 	select PINCTRL
 	help
 	  Enable Renesas RA SCI_B UART Driver.
+
+config UART_RA8_SCI_B_UART_DTC
+	bool "Renesas RA SCI_B UART DTC"
+	default ($(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA8_UART_SCI_B),rx-dtc,True) || \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA8_UART_SCI_B),tx-dtc,True))
+	depends on UART_RA8_SCI_B && UART_ASYNC_API
+	select USE_RA_FSP_DTC
+	help
+	  Enable DTC (Data Transfer Controller) support for the SCI-B UART Driver of RA family.
+
+config UART_RA8_SCI_B_UART_DMAC
+	bool "Renesas RA SCI_B UART DMAC"
+	default $(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA8_UART_SCI_B),dmas)
+	depends on UART_RA8_SCI_B && UART_ASYNC_API
+	select USE_RA_FSP_DMA
+	help
+	  Enable DMAC (Direct Memory Access Controller) support for the
+	  SCI-B UART Driver of RA family.
 
 if UART_RA8_SCI_B && (UART_INTERRUPT_DRIVEN || UART_ASYNC_API)
 

--- a/drivers/serial/uart_renesas_ra8_sci_b.c
+++ b/drivers/serial/uart_renesas_ra8_sci_b.c
@@ -15,17 +15,33 @@
 #include <zephyr/pm/device_runtime.h>
 #include <soc.h>
 #include "r_sci_b_uart.h"
+#ifdef CONFIG_UART_RA8_SCI_B_UART_DTC
 #include "r_dtc.h"
+#endif
+#ifdef CONFIG_UART_RA8_SCI_B_UART_DMAC
+#include "r_dmac.h"
+#endif
 #include "r_transfer_api.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ra8_uart_sci_b);
+
+#ifdef CONFIG_UART_RA8_SCI_B_UART_DTC
+#define TRANSFER_INFO_ALIGNMENT DTC_TRANSFER_INFO_ALIGNMENT
+#else
+#define TRANSFER_INFO_ALIGNMENT
+#endif
 
 #if defined(CONFIG_UART_ASYNC_API)
 void sci_b_uart_rxi_isr(void);
 void sci_b_uart_txi_isr(void);
 void sci_b_uart_tei_isr(void);
 void sci_b_uart_eri_isr(void);
+#ifdef CONFIG_UART_RA8_SCI_B_UART_DMAC
+void dmac_int_isr(void);
+void sci_b_uart_tx_dmac_callback(sci_b_uart_instance_ctrl_t * const p_ctrl);
+void sci_b_uart_rx_dmac_callback(sci_b_uart_instance_ctrl_t * const p_ctrl);
+#endif
 #endif
 
 struct uart_ra_sci_b_config {
@@ -48,10 +64,8 @@ struct uart_ra_sci_b_data {
 #if defined(CONFIG_UART_ASYNC_API)
 	/* RX */
 	struct st_transfer_instance rx_transfer;
-	struct st_dtc_instance_ctrl rx_transfer_ctrl;
-	struct st_transfer_info rx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
+	struct st_transfer_info rx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg rx_transfer_cfg;
-	struct st_dtc_extended_cfg rx_transfer_cfg_extend;
 	struct k_work_delayable rx_timeout_work;
 	size_t rx_timeout;
 	uint8_t *rx_buffer;
@@ -63,10 +77,8 @@ struct uart_ra_sci_b_data {
 
 	/* TX */
 	struct st_transfer_instance tx_transfer;
-	struct st_dtc_instance_ctrl tx_transfer_ctrl;
-	struct st_transfer_info tx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
+	struct st_transfer_info tx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg tx_transfer_cfg;
-	struct st_dtc_extended_cfg tx_transfer_cfg_extend;
 	struct k_work_delayable tx_timeout_work;
 	size_t tx_timeout;
 	uint8_t *tx_buffer;
@@ -75,6 +87,25 @@ struct uart_ra_sci_b_data {
 
 	uart_callback_t async_user_cb;
 	void *async_user_cb_data;
+#ifdef CONFIG_UART_RA8_SCI_B_UART_DTC
+	/* DMAC RX */
+	struct st_dtc_instance_ctrl rx_dtc_ctrl;
+	struct st_dtc_extended_cfg rx_dtc_cfg_extend;
+
+	/* DMAC TX */
+	struct st_dtc_instance_ctrl tx_dtc_ctrl;
+	struct st_dtc_extended_cfg tx_dtc_cfg_extend;
+#endif
+
+#ifdef CONFIG_UART_RA8_SCI_B_UART_DMAC
+	/* DMAC RX */
+	struct st_dmac_instance_ctrl rx_dmac_ctrl;
+	struct st_dmac_extended_cfg rx_dmac_cfg_extend;
+
+	/* DMAC TX */
+	struct st_dmac_instance_ctrl tx_dmac_ctrl;
+	struct st_dmac_extended_cfg tx_dmac_cfg_extend;
+#endif
 #endif
 #ifdef CONFIG_PM
 	bool rx_ongoing;
@@ -776,7 +807,8 @@ static int uart_ra_sci_b_async_tx_abort(const struct device *dev)
 	if (data->fsp_config.p_transfer_tx) {
 		transfer_properties_t transfer_info;
 
-		err = fsp_err_to_errno(R_DTC_InfoGet(&data->tx_transfer_ctrl, &transfer_info));
+		err = fsp_err_to_errno(data->tx_transfer.p_api->infoGet(data->tx_transfer.p_ctrl,
+									&transfer_info));
 		if (err != 0) {
 			return err;
 		}
@@ -945,6 +977,19 @@ static void uart_ra_sci_b_callback_adapter(struct st_uart_callback_arg *fsp_args
 	}
 }
 
+#ifdef CONFIG_UART_RA8_SCI_B_UART_DMAC
+static __maybe_unused void uart_ra_sci_b_rx_callback_handler(struct uart_ra_sci_b_data *data)
+{
+	uart_ra_sci_b_async_timer_start(&data->rx_timeout_work, data->rx_timeout);
+
+	if (data->fsp_config.p_transfer_rx) {
+		data->rx_buffer_len++;
+		if (data->rx_buffer_offset + data->rx_buffer_len == data->rx_buffer_cap) {
+			sci_b_uart_rx_dmac_callback(&data->sci);
+		}
+	}
+}
+#endif
 #endif /* CONFIG_UART_ASYNC_API */
 
 #ifdef CONFIG_PM_DEVICE
@@ -1154,35 +1199,91 @@ static void uart_ra_sci_b_eri_isr(const struct device *dev)
 #define EVENT_SCI_TXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _TXI))
 #define EVENT_SCI_TEI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _TEI))
 #define EVENT_SCI_ERI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _ERI))
+#define EVENT_DMAC_INT(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_DMAC, channel, _INT))
+
+#define UART_SCI_B_ASSERT_NO_CONFLICT(index, dir)                                                  \
+	BUILD_ASSERT(!(DT_INST_DMAS_HAS_NAME(index, dir) &&                                        \
+		       DT_INST_PROP_OR(index, dir##_dtc, false)),                                  \
+		      "Cannot use both DMAS and " #dir "-dtc for the same direction")
+
+#define UART_SCI_B_DMAC_IRQ(index, dir)                                                            \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		   (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                           \
+				  DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                  \
+				  irq)),                                                           \
+		   (FSP_INVALID_VECTOR))
+
+#define UART_SCI_B_DMAC_IPL(index, dir)                                                            \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		   (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                           \
+				  DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                  \
+				  priority)),                                                      \
+		   (BSP_IRQ_DISABLED))
 
 #define UART_RA_SCI_B_IRQ_CONFIG_INIT(index)                                                       \
 	do {                                                                                       \
-		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)] =                    \
-			EVENT_SCI_RXI(DT_INST_PROP(index, channel));                               \
-		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)] =                    \
-			EVENT_SCI_TXI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq)] =                    \
 			EVENT_SCI_TEI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), eri, irq)] =                    \
 			EVENT_SCI_ERI(DT_INST_PROP(index, channel));                               \
-                                                                                                   \
-		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SCI_RXI(DT_INST_PROP(index, channel)));     \
-		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SCI_TXI(DT_INST_PROP(index, channel)));     \
+	                                                                                           \
 		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SCI_TEI(DT_INST_PROP(index, channel)));     \
 		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SCI_ERI(DT_INST_PROP(index, channel)));     \
-                                                                                                   \
-		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),                       \
-			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, priority),                  \
-			    uart_ra_sci_b_rxi_isr, DEVICE_DT_INST_GET(index), 0);                  \
-		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq),                       \
-			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, priority),                  \
-			    uart_ra_sci_b_txi_isr, DEVICE_DT_INST_GET(index), 0);                  \
+	                                                                                           \
 		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq),                       \
 			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, priority),                  \
 			    uart_ra_sci_b_tei_isr, DEVICE_DT_INST_GET(index), 0);                  \
 		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), eri, irq),                       \
 			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), eri, priority),                  \
 			    uart_ra_sci_b_eri_isr, DEVICE_DT_INST_GET(index), 0);                  \
+                                                                                                   \
+		irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), eri, irq));                       \
+		irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq));                       \
+                                                                                                   \
+		/* Enable DMAC interrupt instead of TXI/RXI for DMA transfers */                   \
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),                                      \
+		(                                                                                  \
+			BSP_ASSIGN_EVENT_TO_CURRENT_CORE(                                          \
+				    EVENT_DMAC_INT(DT_INST_DMAS_CELL_BY_NAME(index, rx, channel)));\
+			R_ICU->IELSR[UART_SCI_B_DMAC_IRQ(index, rx)] = EVENT_DMAC_INT(             \
+				    DT_INST_DMAS_CELL_BY_NAME(index, rx, channel));                \
+			IRQ_CONNECT(UART_SCI_B_DMAC_IRQ(index, rx),                                \
+				    UART_SCI_B_DMAC_IPL(index, rx),                                \
+				    dmac_int_isr, NULL, 0);                                        \
+			irq_enable(UART_SCI_B_DMAC_IRQ(index, rx));                                \
+		),                                                                                 \
+		(                                                                                  \
+			BSP_ASSIGN_EVENT_TO_CURRENT_CORE(                                          \
+				    EVENT_SCI_RXI(DT_INST_PROP(index, channel)));                  \
+			R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)] =            \
+				    EVENT_SCI_RXI(DT_INST_PROP(index, channel));                   \
+			IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),               \
+				    DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, priority),          \
+				    uart_ra_sci_b_rxi_isr, DEVICE_DT_INST_GET(index), 0);          \
+			irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq));               \
+		))                                                                                 \
+	                                                                                           \
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                                      \
+		(                                                                                  \
+			BSP_ASSIGN_EVENT_TO_CURRENT_CORE(                                          \
+				    EVENT_DMAC_INT(DT_INST_DMAS_CELL_BY_NAME(index, tx, channel)));\
+			R_ICU->IELSR[UART_SCI_B_DMAC_IRQ(index, tx)] = EVENT_DMAC_INT(             \
+				    DT_INST_DMAS_CELL_BY_NAME(index, tx, channel));                \
+			IRQ_CONNECT(UART_SCI_B_DMAC_IRQ(index, tx),                                \
+				    UART_SCI_B_DMAC_IPL(index, tx),                                \
+				    dmac_int_isr, NULL, 0);                                        \
+			irq_enable(UART_SCI_B_DMAC_IRQ(index, tx));                                \
+		),                                                                                 \
+		(                                                                                  \
+			BSP_ASSIGN_EVENT_TO_CURRENT_CORE(                                          \
+				    EVENT_SCI_TXI(DT_INST_PROP(index, channel)));                  \
+			R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)] =            \
+				    EVENT_SCI_TXI(DT_INST_PROP(index, channel));                   \
+			IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq),               \
+				    DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, priority),          \
+				    uart_ra_sci_b_txi_isr, DEVICE_DT_INST_GET(index), 0);          \
+			irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq));               \
+		))                                                                                 \
 	} while (0)
 
 #else
@@ -1190,44 +1291,125 @@ static void uart_ra_sci_b_eri_isr(const struct device *dev)
 #define UART_RA_SCI_B_IRQ_CONFIG_INIT(index)
 
 #endif
+#ifdef CONFIG_UART_RA8_SCI_B_UART_DMAC
+#define UART_RA_SCI_B_DMAC_CFG_EXTEND(index)                                                       \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx), (                                             \
+		.tx_dmac_cfg_extend = {                                                            \
+			.activation_source = EVENT_SCI_TXI(DT_INST_PROP(index, channel)),          \
+			.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                   \
+					      (DT_INST_DMAS_CELL_BY_NAME(index, tx, channel)),     \
+					      (0)),                                                \
+			.irq = UART_SCI_B_DMAC_IRQ(index, tx),                                     \
+			.ipl = UART_SCI_B_DMAC_IPL(index, tx),                                     \
+			.offset = 1, .src_buffer_size = 1},                                        \
+	))                                                                                         \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx), (                                             \
+		.rx_dmac_cfg_extend = {                                                            \
+			.activation_source = EVENT_SCI_RXI(DT_INST_PROP(index, channel)),          \
+			.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),                   \
+					      (DT_INST_DMAS_CELL_BY_NAME(index, rx, channel)),     \
+					      (0)),                                                \
+			.irq = UART_SCI_B_DMAC_IRQ(index, rx),                                     \
+			.ipl = UART_SCI_B_DMAC_IPL(index, rx),                                     \
+			.offset = 1, .src_buffer_size = 1},                                        \
+	))
+#define UART_RA_SCI_B_DMAC_CALLBACKS(index)                                                        \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx), (                                             \
+		static void uart_ra_sci_b_dmac_tx_cb_##index(dmac_callback_args_t *p_args)         \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			sci_b_uart_tx_dmac_callback(&uart_ra_sci_b_data_##index.sci);              \
+		}                                                                                  \
+	))                                                                                         \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx), (                                             \
+		static void uart_ra_sci_b_dmac_rx_cb_##index(dmac_callback_args_t *p_args)         \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			uart_ra_sci_b_rx_callback_handler(&uart_ra_sci_b_data_##index);            \
+		}                                                                                  \
+	))
+#else
+#define UART_RA_SCI_B_DMAC_CFG_EXTEND(index)
+#define UART_RA_SCI_B_DMAC_CALLBACKS(index)
+#endif
+
+#ifdef CONFIG_UART_RA8_SCI_B_UART_DTC
+#define UART_RA_SCI_B_DTC_CFG_EXTEND(index)                                                        \
+	IF_ENABLED(DT_INST_PROP_OR(index, rx_dtc, false),                                          \
+		   (.rx_dtc_cfg_extend = {.activation_source =                                     \
+					   DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)},))     \
+	IF_ENABLED(DT_INST_PROP_OR(index, tx_dtc, false),                                          \
+		   (.tx_dtc_cfg_extend = {.activation_source =                                     \
+					   DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)},))
+#else
+#define UART_RA_SCI_B_DTC_CFG_EXTEND(index)
+#endif
 
 #if defined(CONFIG_UART_ASYNC_API)
 
-#define UART_RA_SCI_B_DTC_INIT(index)                                                              \
+#define UART_RA_SCI_B_TRANSFER_INIT(index)                                                         \
 	do {                                                                                       \
-		uart_ra_sci_b_data_##index.fsp_config.p_transfer_rx =                              \
-			&uart_ra_sci_b_data_##index.rx_transfer;                                   \
-		uart_ra_sci_b_data_##index.fsp_config.p_transfer_tx =                              \
-			&uart_ra_sci_b_data_##index.tx_transfer;                                   \
+		if (DT_INST_PROP_OR(index, rx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, rx)) {   \
+			uart_ra_sci_b_data_##index.fsp_config.p_transfer_rx =                      \
+				&uart_ra_sci_b_data_##index.rx_transfer;                           \
+		}                                                                                  \
+		if (DT_INST_PROP_OR(index, tx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, tx)) {   \
+			uart_ra_sci_b_data_##index.fsp_config.p_transfer_tx =                      \
+				&uart_ra_sci_b_data_##index.tx_transfer;                           \
+		}                                                                                  \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                       \
+			(uart_ra_sci_b_data_##index.rx_dmac_cfg_extend.p_callback =                \
+				uart_ra_sci_b_dmac_rx_cb_##index;))                                \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                       \
+			(uart_ra_sci_b_data_##index.tx_dmac_cfg_extend.p_callback =                \
+				uart_ra_sci_b_dmac_tx_cb_##index;))                                \
 	} while (0)
+
+/*
+ * Select a transfer value for a given direction (@p dir: rx or tx).
+ * - If instance has DMAS for @p dir: use @p dmac_val
+ * - Else if instance has DTC property for @p dir: use @p dtc_val
+ * - Else: NULL
+ */
+#define UART_RA_SCI_B_DMAC_OR_DTC(index, dir, dmac_val, dtc_val)                                   \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		    (dmac_val),                                                                    \
+		    (COND_CODE_1(DT_INST_PROP_OR(index, dir##_dtc, false),                         \
+				 (dtc_val),                                                        \
+				 (NULL))))
 
 #define UART_RA_SCI_B_ASYNC_INIT(index)                                                            \
 	.rx_transfer_info =                                                                        \
 		{                                                                                  \
 			.transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED, \
-			.transfer_settings_word_b.repeat_area = TRANSFER_REPEAT_AREA_DESTINATION,  \
+			.transfer_settings_word_b.repeat_area = TRANSFER_REPEAT_AREA_SOURCE,       \
 			.transfer_settings_word_b.irq = TRANSFER_IRQ_EACH,                         \
 			.transfer_settings_word_b.chain_mode = TRANSFER_CHAIN_MODE_DISABLED,       \
 			.transfer_settings_word_b.src_addr_mode = TRANSFER_ADDR_MODE_FIXED,        \
 			.transfer_settings_word_b.size = TRANSFER_SIZE_1_BYTE,                     \
-			.transfer_settings_word_b.mode = TRANSFER_MODE_NORMAL,                     \
+			.transfer_settings_word_b.mode = COND_CODE_1(                              \
+					DT_INST_DMAS_HAS_NAME(index, rx), (TRANSFER_MODE_BLOCK),   \
+									  (TRANSFER_MODE_NORMAL)), \
 			.p_dest = (void *)NULL,                                                    \
 			.p_src = (void const *)NULL,                                               \
 			.num_blocks = 0,                                                           \
-			.length = 0,                                                               \
+			.length = 1,                                                               \
 	},                                                                                         \
-	.rx_transfer_cfg_extend = {.activation_source =                                            \
-					   DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)},       \
 	.rx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &uart_ra_sci_b_data_##index.rx_transfer_info,                    \
-			.p_extend = &uart_ra_sci_b_data_##index.rx_transfer_cfg_extend,            \
+			.p_extend = UART_RA_SCI_B_DMAC_OR_DTC(index, rx,                           \
+					(&uart_ra_sci_b_data_##index.rx_dmac_cfg_extend),          \
+					(&uart_ra_sci_b_data_##index.rx_dtc_cfg_extend)),          \
 	},                                                                                         \
 	.rx_transfer =                                                                             \
 		{                                                                                  \
-			.p_ctrl = &uart_ra_sci_b_data_##index.rx_transfer_ctrl,                    \
+			.p_ctrl = UART_RA_SCI_B_DMAC_OR_DTC(index, rx,                             \
+				      (&uart_ra_sci_b_data_##index.rx_dmac_ctrl),                  \
+				      (&uart_ra_sci_b_data_##index.rx_dtc_ctrl)),                  \
 			.p_cfg = &uart_ra_sci_b_data_##index.rx_transfer_cfg,                      \
-			.p_api = &g_transfer_on_dtc,                                               \
+			.p_api = UART_RA_SCI_B_DMAC_OR_DTC(index, rx,                              \
+					     (&g_transfer_on_dmac), (&g_transfer_on_dtc)),         \
 	},                                                                                         \
 	.tx_transfer_info =                                                                        \
 		{                                                                                  \
@@ -1243,22 +1425,26 @@ static void uart_ra_sci_b_eri_isr(const struct device *dev)
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.tx_transfer_cfg_extend = {.activation_source =                                            \
-					   DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)},       \
 	.tx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &uart_ra_sci_b_data_##index.tx_transfer_info,                    \
-			.p_extend = &uart_ra_sci_b_data_##index.tx_transfer_cfg_extend,            \
+			.p_extend = UART_RA_SCI_B_DMAC_OR_DTC(index, tx,                           \
+					(&uart_ra_sci_b_data_##index.tx_dmac_cfg_extend),          \
+					(&uart_ra_sci_b_data_##index.tx_dtc_cfg_extend)),          \
 	},                                                                                         \
 	.tx_transfer = {                                                                           \
-		.p_ctrl = &uart_ra_sci_b_data_##index.tx_transfer_ctrl,                            \
+		.p_ctrl = UART_RA_SCI_B_DMAC_OR_DTC(index, tx,                                     \
+				      (&uart_ra_sci_b_data_##index.tx_dmac_ctrl),                  \
+				      (&uart_ra_sci_b_data_##index.tx_dtc_ctrl)),                  \
 		.p_cfg = &uart_ra_sci_b_data_##index.tx_transfer_cfg,                              \
-		.p_api = &g_transfer_on_dtc,                                                       \
-	},
-
+		.p_api = UART_RA_SCI_B_DMAC_OR_DTC(index, tx,                                      \
+				     (&g_transfer_on_dmac), (&g_transfer_on_dtc)),                 \
+	},                                                                                         \
+	UART_RA_SCI_B_DMAC_CFG_EXTEND(index)                                                       \
+	UART_RA_SCI_B_DTC_CFG_EXTEND(index)
 #else
 #define UART_RA_SCI_B_ASYNC_INIT(index)
-#define UART_RA_SCI_B_DTC_INIT(index)
+#define UART_RA_SCI_B_TRANSFER_INIT(index)
 #endif
 
 #define FLOW_CTRL_PARAMETER(index)                                                                 \
@@ -1285,10 +1471,18 @@ static void uart_ra_sci_b_eri_isr(const struct device *dev)
 		.fsp_config =                                                                      \
 			{                                                                          \
 				.channel = DT_INST_PROP(index, channel),                           \
-				.rxi_ipl = DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, priority),   \
-				.rxi_irq = DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),        \
-				.txi_ipl = DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, priority),   \
-				.txi_irq = DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq),        \
+				.rxi_ipl = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),           \
+					  (BSP_IRQ_DISABLED),                                      \
+					  (DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, priority))), \
+				.rxi_irq = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),           \
+					  (FSP_INVALID_VECTOR),                                    \
+					  (DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq))),      \
+				.txi_ipl = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),           \
+					  (BSP_IRQ_DISABLED),                                      \
+					  (DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, priority))), \
+				.txi_irq = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),           \
+					  (FSP_INVALID_VECTOR),                                    \
+					  (DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq))),      \
 				.tei_ipl = DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, priority),   \
 				.tei_irq = DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq),        \
 				.eri_ipl = DT_IRQ_BY_NAME(DT_INST_PARENT(index), eri, priority),   \
@@ -1298,10 +1492,14 @@ static void uart_ra_sci_b_eri_isr(const struct device *dev)
 		.fsp_baud_setting = {},                                                            \
 		.dev = DEVICE_DT_GET(DT_DRV_INST(index)),                                          \
 		UART_RA_SCI_B_ASYNC_INIT(index)};                                                  \
+												   \
+	UART_RA_SCI_B_DMAC_CALLBACKS(index)                                                        \
                                                                                                    \
 	static int uart_ra_sci_b_init_##index(const struct device *dev)                            \
 	{                                                                                          \
-		UART_RA_SCI_B_DTC_INIT(index);                                                     \
+		UART_SCI_B_ASSERT_NO_CONFLICT(index, rx);                                          \
+		UART_SCI_B_ASSERT_NO_CONFLICT(index, tx);                                          \
+		UART_RA_SCI_B_TRANSFER_INIT(index);                                                \
 		UART_RA_SCI_B_IRQ_CONFIG_INIT(index);                                              \
 		int err = uart_ra_sci_b_init(dev);                                                 \
 		if (err != 0) {                                                                    \

--- a/drivers/spi/Kconfig.renesas_ra
+++ b/drivers/spi/Kconfig.renesas_ra
@@ -79,9 +79,19 @@ config SPI_RENESAS_RA_SCI_B_INTERRUPT
 	help
 	  Enable Interrupt support for the SCI B SPI Driver of RA family.
 
+config SPI_RENESAS_RA_SCI_B_DMAC
+	bool "RA MCU SCI B SPI DMAC Support"
+	default $(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA_SPI_SCI_B),dmas)
+	depends on SPI_RENESAS_RA_SCI_B_INTERRUPT
+	select USE_RA_FSP_DMA
+	help
+	  Enable DMAC (Direct Memory Access Controller) support for the
+	  SCI B SPI Driver of RA family.
+
 config SPI_RENESAS_RA_SCI_B_DTC
-	bool
-	default y
+	bool "RA MCU SCI B SPI DTC Support"
+	default ($(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA_SPI_SCI_B),rx-dtc,True) || \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA_SPI_SCI_B),tx-dtc,True))
 	depends on SPI_RENESAS_RA_SCI_B_INTERRUPT
 	select USE_RA_FSP_DTC
 	help

--- a/drivers/spi/Kconfig.renesas_ra8
+++ b/drivers/spi/Kconfig.renesas_ra8
@@ -19,9 +19,21 @@ config SPI_B_INTERRUPT
 	help
 	  Enable Interrupt support for the SPI B Driver of RA family.
 
+config SPI_B_DMAC
+	bool "RA MCU SPI DMAC Support"
+	default $(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA8_SPI_B),dmas)
+	select SPI_B_INTERRUPT
+	select USE_RA_FSP_DMA
+	help
+	  Enable DMAC (Direct Memory Access Controller) support for the SPI B Driver
+	  of RA8 family. Uses the FSP transfer module (g_transfer_on_dmac) to perform
+	  SPI data transfers.
+
 config SPI_B_RA_DTC
 	bool "RA MCU SPI DTC Support"
-	default y
+	default $(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA8_SPI_B),rx-dtc,True) || \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA8_SPI_B),tx-dtc,True)
+	select SPI_B_INTERRUPT
 	select USE_RA_FSP_DTC
 	help
 	  Enable the SPI DTC mode for SPI instances

--- a/drivers/spi/spi_b_renesas_ra8.c
+++ b/drivers/spi/spi_b_renesas_ra8.c
@@ -11,8 +11,15 @@
 #include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 #include <zephyr/irq.h>
 #include <soc.h>
-#include <instances/r_dtc.h>
 #include <instances/r_spi_b.h>
+
+#ifdef CONFIG_SPI_B_RA_DTC
+#include <instances/r_dtc.h>
+#endif /* CONFIG_SPI_B_RA_DTC */
+
+#ifdef CONFIG_SPI_B_DMAC
+#include <instances/r_dmac.h>
+#endif /* CONFIG_SPI_B_DMAC */
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ra8_spi_b);
@@ -22,6 +29,12 @@ LOG_MODULE_REGISTER(ra8_spi_b);
 #include "spi_rtio.h"
 #endif
 
+#ifdef CONFIG_SPI_B_RA_DTC
+#define TRANSFER_INFO_ALIGNMENT DTC_TRANSFER_INFO_ALIGNMENT
+#else
+#define TRANSFER_INFO_ALIGNMENT
+#endif
+
 #if defined(CONFIG_SPI_B_INTERRUPT)
 void spi_b_rxi_isr(void);
 void spi_b_txi_isr(void);
@@ -29,7 +42,14 @@ void spi_b_tei_isr(void);
 void spi_b_eri_isr(void);
 #endif
 
+#ifdef CONFIG_SPI_B_DMAC
+extern void dmac_int_isr(void);
+extern void spi_b_tx_dmac_callback(spi_b_instance_ctrl_t const *const p_ctrl);
+extern void spi_b_rx_dmac_callback(spi_b_instance_ctrl_t const *const p_ctrl);
+#endif
+
 struct ra_spi_config {
+	R_SPI_B0_Type *regs;
 	const struct pinctrl_dev_config *pcfg;
 	const struct device *clock_dev;
 	const struct clock_control_ra_subsys_cfg clock_subsys;
@@ -44,23 +64,38 @@ struct ra_spi_data {
 #if CONFIG_SPI_B_INTERRUPT
 	uint32_t data_len;
 #endif
-#if defined(CONFIG_SPI_B_RA_DTC)
+#if defined(CONFIG_SPI_B_RA_DTC) || defined(CONFIG_SPI_B_DMAC)
 	/* RX */
 	struct st_transfer_instance rx_transfer;
-	struct st_dtc_instance_ctrl rx_transfer_ctrl;
-	struct st_transfer_info rx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
+	struct st_transfer_info rx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg rx_transfer_cfg;
-	struct st_dtc_extended_cfg rx_transfer_cfg_extend;
 
 	/* TX */
 	struct st_transfer_instance tx_transfer;
-	struct st_dtc_instance_ctrl tx_transfer_ctrl;
-	struct st_transfer_info tx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
+	struct st_transfer_info tx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg tx_transfer_cfg;
-	struct st_dtc_extended_cfg tx_transfer_cfg_extend;
+#endif /* CONFIG_SPI_B_RA_DTC || CONFIG_SPI_B_DMAC */
+#if defined(CONFIG_SPI_B_RA_DTC)
+	/* DTC RX */
+	struct st_dtc_instance_ctrl rx_dtc_ctrl;
+	struct st_dtc_extended_cfg rx_dtc_cfg_extend;
+
+	/* DTC TX */
+	struct st_dtc_instance_ctrl tx_dtc_ctrl;
+	struct st_dtc_extended_cfg tx_dtc_cfg_extend;
+#endif
+#if defined(CONFIG_SPI_B_DMAC)
+	/* DMAC RX */
+	struct st_dmac_instance_ctrl rx_dmac_ctrl;
+	struct st_dmac_extended_cfg rx_dmac_cfg_extend;
+
+	/* DMAC TX */
+	struct st_dmac_instance_ctrl tx_dmac_ctrl;
+	struct st_dmac_extended_cfg tx_dmac_cfg_extend;
 #endif
 };
 
+#ifdef CONFIG_SPI_B_INTERRUPT
 static void spi_cb(spi_callback_args_t *p_args)
 {
 	struct device *dev = (struct device *)p_args->p_context;
@@ -84,6 +119,40 @@ static void spi_cb(spi_callback_args_t *p_args)
 		break;
 	}
 }
+#endif /* CONFIG_SPI_B_INTERRUPT */
+
+#if defined(CONFIG_SPI_B_INTERRUPT) && defined(CONFIG_SPI_SLAVE)
+static void ra_spi_slave_transfer_done(const struct device *dev)
+{
+	struct ra_spi_data *data = dev->data;
+
+	if (data->ctx.rx_buf != NULL && data->ctx.tx_buf != NULL) {
+		data->ctx.recv_frames = MIN(spi_context_total_tx_len(&data->ctx),
+					    spi_context_total_rx_len(&data->ctx));
+	} else if (data->ctx.tx_buf == NULL) {
+		/* RX-only */
+		data->ctx.recv_frames = data->data_len;
+	} else {
+		/* TX-only */
+		data->ctx.recv_frames = 0;
+	}
+
+	/*
+	 * Writing 0 to SPE generates a TXI IRQ. Disable TXI first,
+	 * clear SPE, then re-enable TXI and clear any pending IRQ.
+	 * (See Section 38.2.1 in the RA6T2 manual R01UH0886EJ0100).
+	 */
+	R_BSP_IrqDisable(data->fsp_config.tei_irq);
+	R_BSP_IrqDisable(data->fsp_config.txi_irq);
+
+	data->spi.p_regs->SPCR_b.SPE = 0;
+
+	R_BSP_IrqEnable(data->fsp_config.txi_irq);
+
+	spi_context_cs_control(&data->ctx, false);
+	spi_context_complete(&data->ctx, dev, data->ctx.recv_frames);
+}
+#endif /* CONFIG_SPI_B_INTERRUPT && CONFIG_SPI_SLAVE */
 
 static int ra_spi_b_configure(const struct device *dev, const struct spi_config *config)
 {
@@ -149,8 +218,11 @@ static int ra_spi_b_configure(const struct device *dev, const struct spi_config 
 	}
 
 	data->fsp_config.p_extend = &data->fsp_config_extend;
-
+#ifdef CONFIG_SPI_B_INTERRUPT
 	data->fsp_config.p_callback = spi_cb;
+#else
+	data->fsp_config.p_callback = NULL;
+#endif /* CONFIG_SPI_B_INTERRUPT */
 	data->fsp_config.p_context = (void *)dev;
 	fsp_err = R_SPI_B_Open(&data->spi, &data->fsp_config);
 	if (fsp_err != FSP_SUCCESS) {
@@ -329,9 +401,9 @@ static int transceive(const struct device *dev, const struct spi_config *config,
 					 : data->ctx.rx_len;
 	} else {
 		data->data_len = spi_context_is_slave(&data->ctx)
-					 ? MAX(spi_context_total_tx_len(&data->ctx),
-					       spi_context_total_rx_len(&data->ctx))
-					 : MIN(data->ctx.tx_len, data->ctx.rx_len);
+				 ? MAX(spi_context_total_tx_len(&data->ctx),
+				       spi_context_total_rx_len(&data->ctx))
+				 : MIN(data->ctx.tx_len, data->ctx.rx_len);
 	}
 
 	if (data->ctx.rx_buf == NULL) {
@@ -339,8 +411,8 @@ static int transceive(const struct device *dev, const struct spi_config *config,
 	} else if (data->ctx.tx_buf == NULL) {
 		R_SPI_B_Read(&data->spi, data->ctx.rx_buf, data->data_len, spi_width);
 	} else {
-		R_SPI_B_WriteRead(&data->spi, data->ctx.tx_buf, data->ctx.rx_buf, data->data_len,
-				  spi_width);
+		R_SPI_B_WriteRead(&data->spi, data->ctx.tx_buf, data->ctx.rx_buf,
+			data->data_len, spi_width);
 	}
 	ret = spi_context_wait_for_completion(&data->ctx);
 
@@ -500,7 +572,7 @@ static void ra_spi_retransmit(struct ra_spi_data *data)
 			(transfer_instance_t *)data->spi.p_cfg->p_transfer_rx;
 		transfer_info_t *p_info = p_transfer_rx->p_cfg->p_info;
 
-		/* Configure the receive DMA instance. */
+		/* Configure the receive transfer instance. */
 		p_info->transfer_settings_word_b.size = size;
 		p_info->length = (uint16_t)data->data_len;
 		p_info->transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED;
@@ -524,7 +596,7 @@ static void ra_spi_retransmit(struct ra_spi_data *data)
 			(transfer_instance_t *)data->spi.p_cfg->p_transfer_tx;
 		transfer_info_t *p_info = p_transfer_tx->p_cfg->p_info;
 
-		/* Configure the transmit DMA instance. */
+		/* Configure the transmit transfer instance. */
 		p_info->transfer_settings_word_b.size = size;
 		p_info->length = (uint16_t)data->data_len;
 		p_info->transfer_settings_word_b.src_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED;
@@ -543,7 +615,7 @@ static void ra_spi_retransmit(struct ra_spi_data *data)
 	data->spi.p_regs->SPSRC = R_SPI_B0_SPSRC_SPTEFC_Msk;
 }
 
-static void ra_spi_rxi_isr(const struct device *dev)
+static __maybe_unused void ra_spi_rxi_isr(const struct device *dev)
 {
 #ifndef CONFIG_SPI_SLAVE
 	ARG_UNUSED(dev);
@@ -553,36 +625,12 @@ static void ra_spi_rxi_isr(const struct device *dev)
 
 	spi_b_rxi_isr();
 	if (spi_context_is_slave(&data->ctx) && data->spi.rx_count == data->spi.count) {
-
-		if (data->ctx.rx_buf != NULL && data->ctx.tx_buf != NULL) {
-			data->ctx.recv_frames = MIN(spi_context_total_tx_len(&data->ctx),
-						    spi_context_total_rx_len(&data->ctx));
-		} else if (data->ctx.tx_buf == NULL) {
-			data->ctx.recv_frames = data->data_len;
-		} else {
-			/* Do nothing */
-		}
-
-		R_BSP_IrqDisable(data->fsp_config.tei_irq);
-
-		/* Writing 0 to SPE generatates a TXI IRQ. Disable the TXI IRQ.
-		 * (See Section 38.2.1 SPI Control Register in the RA6T2 manual R01UH0886EJ0100).
-		 */
-		R_BSP_IrqDisable(data->fsp_config.txi_irq);
-
-		/* Disable the SPI Transfer. */
-		data->spi.p_regs->SPCR_b.SPE = 0;
-
-		/* Re-enable the TXI IRQ and clear the pending IRQ. */
-		R_BSP_IrqEnable(data->fsp_config.txi_irq);
-
-		spi_context_cs_control(&data->ctx, false);
-		spi_context_complete(&data->ctx, dev, 0);
+		ra_spi_slave_transfer_done(dev);
 	}
 #endif
 }
 
-static void ra_spi_txi_isr(const struct device *dev)
+static __maybe_unused void ra_spi_txi_isr(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 	spi_b_txi_isr();
@@ -617,17 +665,67 @@ static void ra_spi_eri_isr(const struct device *dev)
 #define EVENT_SPI_TXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _TXI))
 #define EVENT_SPI_TEI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _TEI))
 #define EVENT_SPI_ERI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _ERI))
+#define EVENT_DMAC_INT(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_DMAC, channel, _INT))
 
 #if defined(CONFIG_SPI_B_INTERRUPT)
+
+#define SPI_B_DMAC_IRQ(index, dir)                                                                 \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		    (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                          \
+				   DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                 \
+				   irq)),                                                          \
+		    (FSP_INVALID_VECTOR))
+
+#define SPI_B_DMAC_IPL(index, dir)                                                                 \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		    (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                          \
+				   DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                 \
+				   priority)),                                                     \
+		    (BSP_IRQ_DISABLED))
 
 #define RA_SPI_B_IRQ_CONFIG_INIT(index)                                                            \
 	do {                                                                                       \
 		ARG_UNUSED(dev);                                                                   \
                                                                                                    \
-		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, rxi, irq)] =                               \
-			EVENT_SPI_RXI(DT_INST_PROP(index, channel));                               \
-		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, txi, irq)] =                               \
-			EVENT_SPI_TXI(DT_INST_PROP(index, channel));                               \
+		/* Enable DMAC interrupt instead of TXI/RXI for DMA transfers */                   \
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),                                      \
+		(                                                                                  \
+			R_ICU->IELSR[SPI_B_DMAC_IRQ(index, rx)] = EVENT_DMAC_INT(                  \
+					DT_INST_DMAS_CELL_BY_NAME(index, rx, channel));            \
+			IRQ_CONNECT(SPI_B_DMAC_IRQ(index, rx),                                     \
+				    SPI_B_DMAC_IPL(index, rx),                                     \
+				    dmac_int_isr, NULL, 0);                                        \
+			irq_enable(SPI_B_DMAC_IRQ(index, rx));                                     \
+		),                                                                                 \
+		(                                                                                  \
+			R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, rxi, irq)] =                       \
+				EVENT_SPI_RXI(DT_INST_PROP(index, channel));                       \
+                                                                                                   \
+			IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, rxi, irq),                          \
+				    DT_INST_IRQ_BY_NAME(index, rxi, priority),                     \
+				    ra_spi_rxi_isr, DEVICE_DT_INST_GET(index), 0);                 \
+			irq_enable(DT_INST_IRQ_BY_NAME(index, rxi, irq));                          \
+		))                                                                                 \
+                                                                                                   \
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                                      \
+		(                                                                                  \
+			R_ICU->IELSR[SPI_B_DMAC_IRQ(index, tx)] = EVENT_DMAC_INT(                  \
+					DT_INST_DMAS_CELL_BY_NAME(index, tx, channel));            \
+			IRQ_CONNECT(SPI_B_DMAC_IRQ(index, tx),                                     \
+				    SPI_B_DMAC_IPL(index, tx),                                     \
+				    dmac_int_isr, NULL, 0);                                        \
+			irq_enable(SPI_B_DMAC_IRQ(index, tx));                                     \
+		),                                                                                 \
+		(                                                                                  \
+			R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, txi, irq)] =                       \
+				EVENT_SPI_TXI(DT_INST_PROP(index, channel));                       \
+                                                                                                   \
+			IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, txi, irq),                          \
+				    DT_INST_IRQ_BY_NAME(index, txi, priority),                     \
+				    ra_spi_txi_isr, DEVICE_DT_INST_GET(index), 0);                 \
+			irq_enable(DT_INST_IRQ_BY_NAME(index, txi, irq));                          \
+		))                                                                                 \
+                                                                                                   \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, tei, irq)] =                               \
 			EVENT_SPI_TEI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, eri, irq)] =                               \
@@ -638,12 +736,6 @@ static void ra_spi_eri_isr(const struct device *dev)
 		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SPI_TEI(DT_INST_PROP(index, channel)));     \
 		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SPI_ERI(DT_INST_PROP(index, channel)));     \
                                                                                                    \
-		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, rxi, irq),                                  \
-			    DT_INST_IRQ_BY_NAME(index, rxi, priority), ra_spi_rxi_isr,             \
-			    DEVICE_DT_INST_GET(index), 0);                                         \
-		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, txi, irq),                                  \
-			    DT_INST_IRQ_BY_NAME(index, txi, priority), ra_spi_txi_isr,             \
-			    DEVICE_DT_INST_GET(index), 0);                                         \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, tei, irq),                                  \
 			    DT_INST_IRQ_BY_NAME(index, tei, priority), ra_spi_tei_isr,             \
 			    DEVICE_DT_INST_GET(index), 0);                                         \
@@ -651,8 +743,6 @@ static void ra_spi_eri_isr(const struct device *dev)
 			    DT_INST_IRQ_BY_NAME(index, eri, priority), ra_spi_eri_isr,             \
 			    DEVICE_DT_INST_GET(index), 0);                                         \
                                                                                                    \
-		irq_enable(DT_INST_IRQ_BY_NAME(index, rxi, irq));                                  \
-		irq_enable(DT_INST_IRQ_BY_NAME(index, txi, irq));                                  \
 		irq_enable(DT_INST_IRQ_BY_NAME(index, eri, irq));                                  \
 	} while (0)
 
@@ -662,22 +752,104 @@ static void ra_spi_eri_isr(const struct device *dev)
 
 #endif
 
-#ifndef CONFIG_SPI_B_RA_DTC
-#define RA_SPI_B_DTC_STRUCT_INIT(index)
-#define RA_SPI_B_DTC_INIT(index)
+#ifndef CONFIG_SPI_B_DMAC
+#define SPI_B_DMAC_CFG_EXTEND(index)
+#define SPI_B_DMAC_CALLBACKS(index)
 #else
-#define RA_SPI_B_DTC_INIT(index)                                                                   \
+#define SPI_B_DMAC_CFG_EXTEND(index)                                                               \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx), (                                             \
+		.tx_dmac_cfg_extend = {                                                            \
+			.activation_source = EVENT_SPI_TXI(DT_INST_PROP(index, channel)),          \
+			.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                   \
+					      (DT_INST_DMAS_CELL_BY_NAME(index, tx, channel)),     \
+					      (0)),                                                \
+			.irq = SPI_B_DMAC_IRQ(index, tx),                                          \
+			.ipl = SPI_B_DMAC_IPL(index, tx),                                          \
+			.offset = 1, .src_buffer_size = 1},                                        \
+	))                                                                                         \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx), (                                             \
+		.rx_dmac_cfg_extend = {                                                            \
+			.activation_source = EVENT_SPI_RXI(DT_INST_PROP(index, channel)),          \
+			.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),                   \
+					      (DT_INST_DMAS_CELL_BY_NAME(index, rx, channel)),     \
+					      (0)),                                                \
+			.irq = SPI_B_DMAC_IRQ(index, rx),                                          \
+			.ipl = SPI_B_DMAC_IPL(index, rx),                                          \
+			.offset = 1, .src_buffer_size = 1},                                        \
+	))
+
+#define SPI_B_DMAC_CALLBACKS(index)                                                                \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx), (                                             \
+		static void ra_spi_b_dmac_tx_cb_##index(dmac_callback_args_t *p_args)              \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			spi_b_tx_dmac_callback(&ra_spi_data_##index.spi);                          \
+		}                                                                                  \
+	))                                                                                         \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx), (                                             \
+		static void ra_spi_b_dmac_rx_cb_##index(dmac_callback_args_t *p_args)              \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			IF_ENABLED(CONFIG_SPI_SLAVE, (                                             \
+			if (spi_context_is_slave(&ra_spi_data_##index.ctx)) {                      \
+				ra_spi_slave_transfer_done(DEVICE_DT_INST_GET(index));             \
+				return;                                                            \
+			}))                                                                        \
+			spi_b_rx_dmac_callback(&ra_spi_data_##index.spi);                          \
+		}                                                                                  \
+	))
+#endif /* CONFIG_SPI_B_DMAC */
+
+#ifndef CONFIG_SPI_B_RA_DTC
+#define SPI_B_DTC_CFG_EXTEND(index)
+#else
+#define SPI_B_DTC_CFG_EXTEND(index)                                                                \
+	IF_ENABLED(DT_INST_PROP_OR(index, rx_dtc, false),                                          \
+		   (.rx_dtc_cfg_extend = {.activation_source =                                     \
+				      DT_INST_IRQ_BY_NAME(index, rxi, irq)},))                     \
+	IF_ENABLED(DT_INST_PROP_OR(index, tx_dtc, false),                                          \
+		   (.tx_dtc_cfg_extend = {.activation_source =                                     \
+					   DT_INST_IRQ_BY_NAME(index, txi, irq)},))
+#endif
+
+#define SPI_B_ASSERT_NO_CONFLICT(index, dir)                                                       \
+	BUILD_ASSERT(!(DT_INST_DMAS_HAS_NAME(index, dir) &&                                        \
+		       DT_INST_PROP_OR(index, dir##_dtc, false)),                                  \
+		      "Cannot use both DMAS and " #dir "-dtc for the same direction")
+
+#if defined(CONFIG_SPI_B_RA_DTC) || defined(CONFIG_SPI_B_DMAC)
+/*
+ * Select a transfer value for a given direction (@p dir: rx or tx).
+ * - If instance has DMAS for @p dir: use @p dmac_val
+ * - Else if instance has DTC property for @p dir: use @p dtc_val
+ * - Else: NULL
+ */
+#define SPI_B_TRANSFER_DMAC_OR_DTC(index, dir, dmac_val, dtc_val)                                  \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		    (dmac_val),                                                                    \
+		    (COND_CODE_1(DT_INST_PROP_OR(index, dir##_dtc, false),                         \
+				 (dtc_val),                                                        \
+				 (NULL))))
+
+#define SPI_B_TRANSFER_INIT(index)                                                                 \
 	do {                                                                                       \
-		if (DT_INST_PROP_OR(index, rx_dtc, false)) {                                       \
+		if (DT_INST_PROP_OR(index, rx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, rx)) {   \
 			ra_spi_data_##index.fsp_config.p_transfer_rx =                             \
 				&ra_spi_data_##index.rx_transfer;                                  \
 		}                                                                                  \
-		if (DT_INST_PROP_OR(index, tx_dtc, false)) {                                       \
+		if (DT_INST_PROP_OR(index, tx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, tx)) {   \
 			ra_spi_data_##index.fsp_config.p_transfer_tx =                             \
 				&ra_spi_data_##index.tx_transfer;                                  \
 		}                                                                                  \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                       \
+			(ra_spi_data_##index.rx_dmac_cfg_extend.p_callback =                       \
+				ra_spi_b_dmac_rx_cb_##index;))                                     \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                       \
+			(ra_spi_data_##index.tx_dmac_cfg_extend.p_callback =                       \
+				ra_spi_b_dmac_tx_cb_##index;))                                     \
 	} while (0)
-#define RA_SPI_B_DTC_STRUCT_INIT(index)                                                            \
+
+#define SPI_B_TRANSFER_CONFIGURE(index)                                                            \
 	.rx_transfer_info =                                                                        \
 		{                                                                                  \
 			.transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED, \
@@ -692,17 +864,22 @@ static void ra_spi_eri_isr(const struct device *dev)
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.rx_transfer_cfg_extend = {.activation_source = DT_INST_IRQ_BY_NAME(index, rxi, irq)},     \
 	.rx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &ra_spi_data_##index.rx_transfer_info,                           \
-			.p_extend = &ra_spi_data_##index.rx_transfer_cfg_extend,                   \
+			.p_extend = SPI_B_TRANSFER_DMAC_OR_DTC(index, rx,                          \
+					(&ra_spi_data_##index.rx_dmac_cfg_extend),                 \
+					(&ra_spi_data_##index.rx_dtc_cfg_extend)),                 \
 	},                                                                                         \
 	.rx_transfer =                                                                             \
 		{                                                                                  \
-			.p_ctrl = &ra_spi_data_##index.rx_transfer_ctrl,                           \
+			.p_ctrl = SPI_B_TRANSFER_DMAC_OR_DTC(index, rx,                            \
+						(&ra_spi_data_##index.rx_dmac_ctrl),               \
+						(&ra_spi_data_##index.rx_dtc_ctrl)),               \
 			.p_cfg = &ra_spi_data_##index.rx_transfer_cfg,                             \
-			.p_api = &g_transfer_on_dtc,                                               \
+			.p_api = SPI_B_TRANSFER_DMAC_OR_DTC(index, rx,                             \
+						(&g_transfer_on_dmac),                             \
+						(&g_transfer_on_dtc)),                             \
 	},                                                                                         \
 	.tx_transfer_info =                                                                        \
 		{                                                                                  \
@@ -718,24 +895,40 @@ static void ra_spi_eri_isr(const struct device *dev)
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.tx_transfer_cfg_extend = {.activation_source = DT_INST_IRQ_BY_NAME(index, txi, irq)},     \
 	.tx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &ra_spi_data_##index.tx_transfer_info,                           \
-			.p_extend = &ra_spi_data_##index.tx_transfer_cfg_extend,                   \
+			.p_extend = SPI_B_TRANSFER_DMAC_OR_DTC(index, tx,                          \
+					(&ra_spi_data_##index.tx_dmac_cfg_extend),                 \
+					(&ra_spi_data_##index.tx_dtc_cfg_extend)),                 \
 	},                                                                                         \
 	.tx_transfer = {                                                                           \
-		.p_ctrl = &ra_spi_data_##index.tx_transfer_ctrl,                                   \
+		.p_ctrl = SPI_B_TRANSFER_DMAC_OR_DTC(index, tx,                                    \
+					(&ra_spi_data_##index.tx_dmac_ctrl),                       \
+					(&ra_spi_data_##index.tx_dtc_ctrl)),                       \
 		.p_cfg = &ra_spi_data_##index.tx_transfer_cfg,                                     \
-		.p_api = &g_transfer_on_dtc,                                                       \
-	},
-#endif
+		.p_api = SPI_B_TRANSFER_DMAC_OR_DTC(index, tx,                                     \
+					(&g_transfer_on_dmac),                                     \
+					(&g_transfer_on_dtc)),                                     \
+	},                                                                                         \
+	SPI_B_DTC_CFG_EXTEND(index)                                                                \
+	SPI_B_DMAC_CFG_EXTEND(index)
+#else
+#define SPI_B_TRANSFER_INIT(index)
+#define SPI_B_TRANSFER_CONFIGURE(index)
+#endif /* CONFIG_SPI_B_RA_DTC || CONFIG_SPI_B_DMAC */
+
+#define SPI_B_IRQ_GET(index, name, cell)                                                           \
+	COND_CODE_1(DT_IRQ_HAS_NAME(index, name),                                                  \
+		    (DT_IRQ_BY_NAME(index, name, cell)),                                           \
+		    ((IRQn_Type)FSP_INVALID_VECTOR))
 
 #define RA_SPI_INIT(index)                                                                         \
                                                                                                    \
 	PINCTRL_DT_INST_DEFINE(index);                                                             \
                                                                                                    \
 	static const struct ra_spi_config ra_spi_config_##index = {                                \
+		.regs = (R_SPI_B0_Type *)DT_INST_REG_ADDR(index),                                  \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                     \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(index)),                            \
 		.clock_subsys =                                                                    \
@@ -753,20 +946,33 @@ static void ra_spi_eri_isr(const struct device *dev)
 		.fsp_config =                                                                      \
 			{                                                                          \
 				.channel = DT_INST_PROP(index, channel),                           \
-				.rxi_ipl = DT_INST_IRQ_BY_NAME(index, rxi, priority),              \
-				.rxi_irq = DT_INST_IRQ_BY_NAME(index, rxi, irq),                   \
-				.txi_ipl = DT_INST_IRQ_BY_NAME(index, txi, priority),              \
-				.txi_irq = DT_INST_IRQ_BY_NAME(index, txi, irq),                   \
-				.tei_ipl = DT_INST_IRQ_BY_NAME(index, tei, priority),              \
-				.tei_irq = DT_INST_IRQ_BY_NAME(index, tei, irq),                   \
-				.eri_ipl = DT_INST_IRQ_BY_NAME(index, eri, priority),              \
-				.eri_irq = DT_INST_IRQ_BY_NAME(index, eri, irq),                   \
+				.rxi_ipl = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),           \
+					   (BSP_IRQ_DISABLED),                                     \
+					   (SPI_B_IRQ_GET(DT_DRV_INST(index), rxi, priority))),    \
+				.rxi_irq = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),           \
+					   (FSP_INVALID_VECTOR),                                   \
+					   (SPI_B_IRQ_GET(DT_DRV_INST(index), rxi, irq))),         \
+				.txi_ipl = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),           \
+					   (BSP_IRQ_DISABLED),                                     \
+					   (SPI_B_IRQ_GET(DT_DRV_INST(index), txi, priority))),    \
+				.txi_irq = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),           \
+					   (FSP_INVALID_VECTOR),                                   \
+					   (SPI_B_IRQ_GET(DT_DRV_INST(index), txi, irq))),         \
+				.tei_ipl = SPI_B_IRQ_GET(DT_DRV_INST(index), tei, priority),       \
+				.tei_irq = SPI_B_IRQ_GET(DT_DRV_INST(index), tei, irq),            \
+				.eri_ipl = SPI_B_IRQ_GET(DT_DRV_INST(index), eri, priority),       \
+				.eri_irq = SPI_B_IRQ_GET(DT_DRV_INST(index), eri, irq),            \
+				.p_context = (void *)DEVICE_DT_GET(DT_DRV_INST(index)),            \
 			},                                                                         \
-		RA_SPI_B_DTC_STRUCT_INIT(index)};                                                  \
+		SPI_B_TRANSFER_CONFIGURE(index)};                                                  \
+                                                                                                   \
+	SPI_B_DMAC_CALLBACKS(index)                                                                \
                                                                                                    \
 	static int spi_b_ra_init##index(const struct device *dev)                                  \
 	{                                                                                          \
-		RA_SPI_B_DTC_INIT(index);                                                          \
+		SPI_B_ASSERT_NO_CONFLICT(index, tx);                                               \
+		SPI_B_ASSERT_NO_CONFLICT(index, rx);                                               \
+		SPI_B_TRANSFER_INIT(index);                                                        \
 		int err = spi_b_ra_init(dev);                                                      \
 		if (err != 0) {                                                                    \
 			return err;                                                                \

--- a/drivers/spi/spi_b_renesas_ra8.c
+++ b/drivers/spi/spi_b_renesas_ra8.c
@@ -11,8 +11,15 @@
 #include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 #include <zephyr/irq.h>
 #include <soc.h>
-#include <instances/r_dtc.h>
 #include <instances/r_spi_b.h>
+
+#ifdef CONFIG_SPI_B_RA_DTC
+#include <instances/r_dtc.h>
+#endif /* CONFIG_SPI_B_RA_DTC */
+
+#ifdef CONFIG_SPI_B_DMAC
+#include <instances/r_dmac.h>
+#endif /* CONFIG_SPI_B_DMAC */
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ra8_spi_b);
@@ -22,6 +29,12 @@ LOG_MODULE_REGISTER(ra8_spi_b);
 #include "spi_rtio.h"
 #endif
 
+#ifdef CONFIG_SPI_B_RA_DTC
+#define TRANSFER_INFO_ALIGNMENT DTC_TRANSFER_INFO_ALIGNMENT
+#else
+#define TRANSFER_INFO_ALIGNMENT
+#endif
+
 #if defined(CONFIG_SPI_B_INTERRUPT)
 void spi_b_rxi_isr(void);
 void spi_b_txi_isr(void);
@@ -29,7 +42,14 @@ void spi_b_tei_isr(void);
 void spi_b_eri_isr(void);
 #endif
 
+#ifdef CONFIG_SPI_B_DMAC
+extern void dmac_int_isr(void);
+extern void spi_b_tx_dmac_callback(spi_b_instance_ctrl_t const *const p_ctrl);
+extern void spi_b_rx_dmac_callback(spi_b_instance_ctrl_t const *const p_ctrl);
+#endif
+
 struct ra_spi_config {
+	R_SPI_B0_Type *regs;
 	const struct pinctrl_dev_config *pcfg;
 	const struct device *clock_dev;
 	const struct clock_control_ra_subsys_cfg clock_subsys;
@@ -44,23 +64,38 @@ struct ra_spi_data {
 #if CONFIG_SPI_B_INTERRUPT
 	uint32_t data_len;
 #endif
-#if defined(CONFIG_SPI_B_RA_DTC)
+#if defined(CONFIG_SPI_B_RA_DTC) || defined(CONFIG_SPI_B_DMAC)
 	/* RX */
 	struct st_transfer_instance rx_transfer;
-	struct st_dtc_instance_ctrl rx_transfer_ctrl;
-	struct st_transfer_info rx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
+	struct st_transfer_info rx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg rx_transfer_cfg;
-	struct st_dtc_extended_cfg rx_transfer_cfg_extend;
 
 	/* TX */
 	struct st_transfer_instance tx_transfer;
-	struct st_dtc_instance_ctrl tx_transfer_ctrl;
-	struct st_transfer_info tx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
+	struct st_transfer_info tx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg tx_transfer_cfg;
-	struct st_dtc_extended_cfg tx_transfer_cfg_extend;
+#endif /* CONFIG_SPI_B_RA_DTC || CONFIG_SPI_B_DMAC */
+#if defined(CONFIG_SPI_B_RA_DTC)
+	/* DTC RX */
+	struct st_dtc_instance_ctrl rx_dtc_ctrl;
+	struct st_dtc_extended_cfg rx_dtc_cfg_extend;
+
+	/* DTC TX */
+	struct st_dtc_instance_ctrl tx_dtc_ctrl;
+	struct st_dtc_extended_cfg tx_dtc_cfg_extend;
+#endif
+#if defined(CONFIG_SPI_B_DMAC)
+	/* DMAC RX */
+	struct st_dmac_instance_ctrl rx_dmac_ctrl;
+	struct st_dmac_extended_cfg rx_dmac_cfg_extend;
+
+	/* DMAC TX */
+	struct st_dmac_instance_ctrl tx_dmac_ctrl;
+	struct st_dmac_extended_cfg tx_dmac_cfg_extend;
 #endif
 };
 
+#ifdef CONFIG_SPI_B_INTERRUPT
 static void spi_cb(spi_callback_args_t *p_args)
 {
 	struct device *dev = (struct device *)p_args->p_context;
@@ -84,6 +119,44 @@ static void spi_cb(spi_callback_args_t *p_args)
 		break;
 	}
 }
+#endif /* CONFIG_SPI_B_INTERRUPT */
+
+#if defined(CONFIG_SPI_B_INTERRUPT) && defined(CONFIG_SPI_PERIPHERAL)
+static void ra_spi_peripheral_transfer_done(const struct device *dev)
+{
+	struct ra_spi_data *data = dev->data;
+
+	if (data->ctx.rx_buf != NULL && data->ctx.tx_buf != NULL) {
+		data->ctx.recv_frames = MIN(spi_context_total_tx_len(&data->ctx),
+					    spi_context_total_rx_len(&data->ctx));
+	} else if (data->ctx.tx_buf == NULL) {
+		/* RX-only */
+		data->ctx.recv_frames = data->data_len;
+	} else {
+		/* TX-only */
+		data->ctx.recv_frames = 0;
+	}
+
+	/*
+	 * Writing 0 to SPE generates a TXI IRQ. Disable TXI first,
+	 * clear SPE, then re-enable TXI and clear any pending IRQ.
+	 * (See Section 38.2.1 in the RA6T2 manual R01UH0886EJ0100).
+	 */
+	R_BSP_IrqDisable(data->fsp_config.tei_irq);
+	if (data->fsp_config.txi_irq != FSP_INVALID_VECTOR) {
+		R_BSP_IrqDisable(data->fsp_config.txi_irq);
+	}
+
+	data->spi.p_regs->SPCR_b.SPE = 0;
+
+	if (data->fsp_config.txi_irq != FSP_INVALID_VECTOR) {
+		R_BSP_IrqEnable(data->fsp_config.txi_irq);
+	}
+
+	spi_context_cs_control(&data->ctx, false);
+	spi_context_complete(&data->ctx, dev, data->ctx.recv_frames);
+}
+#endif /* CONFIG_SPI_B_INTERRUPT && CONFIG_SPI_PERIPHERAL */
 
 static int ra_spi_b_configure(const struct device *dev, const struct spi_config *config)
 {
@@ -149,8 +222,11 @@ static int ra_spi_b_configure(const struct device *dev, const struct spi_config 
 	}
 
 	data->fsp_config.p_extend = &data->fsp_config_extend;
-
+#ifdef CONFIG_SPI_B_INTERRUPT
 	data->fsp_config.p_callback = spi_cb;
+#else
+	data->fsp_config.p_callback = NULL;
+#endif /* CONFIG_SPI_B_INTERRUPT */
 	data->fsp_config.p_context = (void *)dev;
 	fsp_err = R_SPI_B_Open(&data->spi, &data->fsp_config);
 	if (fsp_err != FSP_SUCCESS) {
@@ -339,8 +415,8 @@ static int transceive(const struct device *dev, const struct spi_config *config,
 	} else if (data->ctx.tx_buf == NULL) {
 		R_SPI_B_Read(&data->spi, data->ctx.rx_buf, data->data_len, spi_width);
 	} else {
-		R_SPI_B_WriteRead(&data->spi, data->ctx.tx_buf, data->ctx.rx_buf, data->data_len,
-				  spi_width);
+		R_SPI_B_WriteRead(&data->spi, data->ctx.tx_buf, data->ctx.rx_buf,
+			data->data_len, spi_width);
 	}
 	ret = spi_context_wait_for_completion(&data->ctx);
 
@@ -480,8 +556,8 @@ static void ra_spi_retransmit(struct ra_spi_data *data)
 	data->spi.rx_count = 0;
 	data->spi.tx_count = 0;
 	data->spi.count = data->data_len;
-#ifdef CONFIG_SPI_B_RA_DTC
-	/* Determine DTC transfer size */
+#if defined(CONFIG_SPI_B_RA_DTC) || defined(CONFIG_SPI_B_DMAC)
+	/* Determine transfer size */
 	transfer_size_t size;
 
 	if (spi_width > SPI_BIT_WIDTH_16_BITS) { /* Bit Widths of 17-32 bits */
@@ -500,7 +576,7 @@ static void ra_spi_retransmit(struct ra_spi_data *data)
 			(transfer_instance_t *)data->spi.p_cfg->p_transfer_rx;
 		transfer_info_t *p_info = p_transfer_rx->p_cfg->p_info;
 
-		/* Configure the receive DMA instance. */
+		/* Configure the receive transfer instance. */
 		p_info->transfer_settings_word_b.size = size;
 		p_info->length = (uint16_t)data->data_len;
 		p_info->transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED;
@@ -524,7 +600,7 @@ static void ra_spi_retransmit(struct ra_spi_data *data)
 			(transfer_instance_t *)data->spi.p_cfg->p_transfer_tx;
 		transfer_info_t *p_info = p_transfer_tx->p_cfg->p_info;
 
-		/* Configure the transmit DMA instance. */
+		/* Configure the transmit transfer instance. */
 		p_info->transfer_settings_word_b.size = size;
 		p_info->length = (uint16_t)data->data_len;
 		p_info->transfer_settings_word_b.src_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED;
@@ -539,11 +615,11 @@ static void ra_spi_retransmit(struct ra_spi_data *data)
 
 		p_transfer_tx->p_api->reconfigure(p_transfer_tx->p_ctrl, p_info);
 	}
-#endif
+#endif /* CONFIG_SPI_B_RA_DTC || CONFIG_SPI_B_DMAC */
 	data->spi.p_regs->SPSRC = R_SPI_B0_SPSRC_SPTEFC_Msk;
 }
 
-static void ra_spi_rxi_isr(const struct device *dev)
+static __maybe_unused void ra_spi_rxi_isr(const struct device *dev)
 {
 #ifndef CONFIG_SPI_PERIPHERAL
 	ARG_UNUSED(dev);
@@ -554,35 +630,12 @@ static void ra_spi_rxi_isr(const struct device *dev)
 	spi_b_rxi_isr();
 	if (spi_context_is_peripheral(&data->ctx) && data->spi.rx_count == data->spi.count) {
 
-		if (data->ctx.rx_buf != NULL && data->ctx.tx_buf != NULL) {
-			data->ctx.recv_frames = MIN(spi_context_total_tx_len(&data->ctx),
-						    spi_context_total_rx_len(&data->ctx));
-		} else if (data->ctx.tx_buf == NULL) {
-			data->ctx.recv_frames = data->data_len;
-		} else {
-			/* Do nothing */
-		}
-
-		R_BSP_IrqDisable(data->fsp_config.tei_irq);
-
-		/* Writing 0 to SPE generatates a TXI IRQ. Disable the TXI IRQ.
-		 * (See Section 38.2.1 SPI Control Register in the RA6T2 manual R01UH0886EJ0100).
-		 */
-		R_BSP_IrqDisable(data->fsp_config.txi_irq);
-
-		/* Disable the SPI Transfer. */
-		data->spi.p_regs->SPCR_b.SPE = 0;
-
-		/* Re-enable the TXI IRQ and clear the pending IRQ. */
-		R_BSP_IrqEnable(data->fsp_config.txi_irq);
-
-		spi_context_cs_control(&data->ctx, false);
-		spi_context_complete(&data->ctx, dev, 0);
+		ra_spi_peripheral_transfer_done(dev);
 	}
 #endif
 }
 
-static void ra_spi_txi_isr(const struct device *dev)
+static __maybe_unused void ra_spi_txi_isr(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 	spi_b_txi_isr();
@@ -617,17 +670,67 @@ static void ra_spi_eri_isr(const struct device *dev)
 #define EVENT_SPI_TXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _TXI))
 #define EVENT_SPI_TEI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _TEI))
 #define EVENT_SPI_ERI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _ERI))
+#define EVENT_DMAC_INT(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_DMAC, channel, _INT))
 
 #if defined(CONFIG_SPI_B_INTERRUPT)
+
+#define SPI_B_DMAC_IRQ(index, dir)                                                                 \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		    (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                          \
+				   DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                 \
+				   irq)),                                                          \
+		    (FSP_INVALID_VECTOR))
+
+#define SPI_B_DMAC_IPL(index, dir)                                                                 \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		    (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                          \
+				   DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                 \
+				   priority)),                                                     \
+		    (BSP_IRQ_DISABLED))
 
 #define RA_SPI_B_IRQ_CONFIG_INIT(index)                                                            \
 	do {                                                                                       \
 		ARG_UNUSED(dev);                                                                   \
                                                                                                    \
-		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, rxi, irq)] =                               \
-			EVENT_SPI_RXI(DT_INST_PROP(index, channel));                               \
-		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, txi, irq)] =                               \
-			EVENT_SPI_TXI(DT_INST_PROP(index, channel));                               \
+		/* Enable DMAC interrupt instead of TXI/RXI for DMA transfers */                   \
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),                                      \
+		(                                                                                  \
+			R_ICU->IELSR[SPI_B_DMAC_IRQ(index, rx)] = EVENT_DMAC_INT(                  \
+					DT_INST_DMAS_CELL_BY_NAME(index, rx, channel));            \
+			IRQ_CONNECT(SPI_B_DMAC_IRQ(index, rx),                                     \
+				    SPI_B_DMAC_IPL(index, rx),                                     \
+				    dmac_int_isr, NULL, 0);                                        \
+			irq_enable(SPI_B_DMAC_IRQ(index, rx));                                     \
+		),                                                                                 \
+		(                                                                                  \
+			R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, rxi, irq)] =                       \
+				EVENT_SPI_RXI(DT_INST_PROP(index, channel));                       \
+                                                                                                   \
+			IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, rxi, irq),                          \
+				    DT_INST_IRQ_BY_NAME(index, rxi, priority),                     \
+				    ra_spi_rxi_isr, DEVICE_DT_INST_GET(index), 0);                 \
+			irq_enable(DT_INST_IRQ_BY_NAME(index, rxi, irq));                          \
+		))                                                                                 \
+                                                                                                   \
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                                      \
+		(                                                                                  \
+			R_ICU->IELSR[SPI_B_DMAC_IRQ(index, tx)] = EVENT_DMAC_INT(                  \
+					DT_INST_DMAS_CELL_BY_NAME(index, tx, channel));            \
+			IRQ_CONNECT(SPI_B_DMAC_IRQ(index, tx),                                     \
+				    SPI_B_DMAC_IPL(index, tx),                                     \
+				    dmac_int_isr, NULL, 0);                                        \
+			irq_enable(SPI_B_DMAC_IRQ(index, tx));                                     \
+		),                                                                                 \
+		(                                                                                  \
+			R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, txi, irq)] =                       \
+				EVENT_SPI_TXI(DT_INST_PROP(index, channel));                       \
+                                                                                                   \
+			IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, txi, irq),                          \
+				    DT_INST_IRQ_BY_NAME(index, txi, priority),                     \
+				    ra_spi_txi_isr, DEVICE_DT_INST_GET(index), 0);                 \
+			irq_enable(DT_INST_IRQ_BY_NAME(index, txi, irq));                          \
+		))                                                                                 \
+                                                                                                   \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, tei, irq)] =                               \
 			EVENT_SPI_TEI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, eri, irq)] =                               \
@@ -638,12 +741,6 @@ static void ra_spi_eri_isr(const struct device *dev)
 		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SPI_TEI(DT_INST_PROP(index, channel)));     \
 		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_SPI_ERI(DT_INST_PROP(index, channel)));     \
                                                                                                    \
-		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, rxi, irq),                                  \
-			    DT_INST_IRQ_BY_NAME(index, rxi, priority), ra_spi_rxi_isr,             \
-			    DEVICE_DT_INST_GET(index), 0);                                         \
-		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, txi, irq),                                  \
-			    DT_INST_IRQ_BY_NAME(index, txi, priority), ra_spi_txi_isr,             \
-			    DEVICE_DT_INST_GET(index), 0);                                         \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, tei, irq),                                  \
 			    DT_INST_IRQ_BY_NAME(index, tei, priority), ra_spi_tei_isr,             \
 			    DEVICE_DT_INST_GET(index), 0);                                         \
@@ -651,8 +748,6 @@ static void ra_spi_eri_isr(const struct device *dev)
 			    DT_INST_IRQ_BY_NAME(index, eri, priority), ra_spi_eri_isr,             \
 			    DEVICE_DT_INST_GET(index), 0);                                         \
                                                                                                    \
-		irq_enable(DT_INST_IRQ_BY_NAME(index, rxi, irq));                                  \
-		irq_enable(DT_INST_IRQ_BY_NAME(index, txi, irq));                                  \
 		irq_enable(DT_INST_IRQ_BY_NAME(index, eri, irq));                                  \
 	} while (0)
 
@@ -662,22 +757,104 @@ static void ra_spi_eri_isr(const struct device *dev)
 
 #endif
 
-#ifndef CONFIG_SPI_B_RA_DTC
-#define RA_SPI_B_DTC_STRUCT_INIT(index)
-#define RA_SPI_B_DTC_INIT(index)
+#ifndef CONFIG_SPI_B_DMAC
+#define SPI_B_DMAC_CFG_EXTEND(index)
+#define SPI_B_DMAC_CALLBACKS(index)
 #else
-#define RA_SPI_B_DTC_INIT(index)                                                                   \
+#define SPI_B_DMAC_CFG_EXTEND(index)                                                               \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx), (                                             \
+		.tx_dmac_cfg_extend = {                                                            \
+			.activation_source = EVENT_SPI_TXI(DT_INST_PROP(index, channel)),          \
+			.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                   \
+					      (DT_INST_DMAS_CELL_BY_NAME(index, tx, channel)),     \
+					      (0)),                                                \
+			.irq = SPI_B_DMAC_IRQ(index, tx),                                          \
+			.ipl = SPI_B_DMAC_IPL(index, tx),                                          \
+			.offset = 1, .src_buffer_size = 1},                                        \
+	))                                                                                         \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx), (                                             \
+		.rx_dmac_cfg_extend = {                                                            \
+			.activation_source = EVENT_SPI_RXI(DT_INST_PROP(index, channel)),          \
+			.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),                   \
+					      (DT_INST_DMAS_CELL_BY_NAME(index, rx, channel)),     \
+					      (0)),                                                \
+			.irq = SPI_B_DMAC_IRQ(index, rx),                                          \
+			.ipl = SPI_B_DMAC_IPL(index, rx),                                          \
+			.offset = 1, .src_buffer_size = 1},                                        \
+	))
+
+#define SPI_B_DMAC_CALLBACKS(index)                                                                \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx), (                                             \
+		static void ra_spi_b_dmac_tx_cb_##index(dmac_callback_args_t *p_args)              \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			spi_b_tx_dmac_callback(&ra_spi_data_##index.spi);                          \
+		}                                                                                  \
+	))                                                                                         \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx), (                                             \
+		static void ra_spi_b_dmac_rx_cb_##index(dmac_callback_args_t *p_args)              \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			IF_ENABLED(CONFIG_SPI_PERIPHERAL, (                                        \
+			if (spi_context_is_peripheral(&ra_spi_data_##index.ctx)) {                 \
+				ra_spi_peripheral_transfer_done(DEVICE_DT_INST_GET(index));        \
+				return;                                                            \
+			}))                                                                        \
+			spi_b_rx_dmac_callback(&ra_spi_data_##index.spi);                          \
+		}                                                                                  \
+	))
+#endif /* CONFIG_SPI_B_DMAC */
+
+#ifndef CONFIG_SPI_B_RA_DTC
+#define SPI_B_DTC_CFG_EXTEND(index)
+#else
+#define SPI_B_DTC_CFG_EXTEND(index)                                                                \
+	IF_ENABLED(DT_INST_PROP_OR(index, rx_dtc, false),                                          \
+		   (.rx_dtc_cfg_extend = {.activation_source =                                     \
+				      DT_INST_IRQ_BY_NAME(index, rxi, irq)},))                     \
+	IF_ENABLED(DT_INST_PROP_OR(index, tx_dtc, false),                                          \
+		   (.tx_dtc_cfg_extend = {.activation_source =                                     \
+					   DT_INST_IRQ_BY_NAME(index, txi, irq)},))
+#endif
+
+#define SPI_B_ASSERT_NO_CONFLICT(index, dir)                                                       \
+	BUILD_ASSERT(!(DT_INST_DMAS_HAS_NAME(index, dir) &&                                        \
+		       DT_INST_PROP_OR(index, dir##_dtc, false)),                                  \
+		      "Cannot use both DMAS and " #dir "-dtc for the same direction")
+
+#if defined(CONFIG_SPI_B_RA_DTC) || defined(CONFIG_SPI_B_DMAC)
+/*
+ * Select a transfer value for a given direction (@p dir: rx or tx).
+ * - If instance has DMAS for @p dir: use @p dmac_val
+ * - Else if instance has DTC property for @p dir: use @p dtc_val
+ * - Else: NULL
+ */
+#define SPI_B_TRANSFER_DMAC_OR_DTC(index, dir, dmac_val, dtc_val)                                  \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		    (dmac_val),                                                                    \
+		    (COND_CODE_1(DT_INST_PROP_OR(index, dir##_dtc, false),                         \
+				 (dtc_val),                                                        \
+				 (NULL))))
+
+#define SPI_B_TRANSFER_INIT(index)                                                                 \
 	do {                                                                                       \
-		if (DT_INST_PROP_OR(index, rx_dtc, false)) {                                       \
+		if (DT_INST_PROP_OR(index, rx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, rx)) {   \
 			ra_spi_data_##index.fsp_config.p_transfer_rx =                             \
 				&ra_spi_data_##index.rx_transfer;                                  \
 		}                                                                                  \
-		if (DT_INST_PROP_OR(index, tx_dtc, false)) {                                       \
+		if (DT_INST_PROP_OR(index, tx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, tx)) {   \
 			ra_spi_data_##index.fsp_config.p_transfer_tx =                             \
 				&ra_spi_data_##index.tx_transfer;                                  \
 		}                                                                                  \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                       \
+			(ra_spi_data_##index.rx_dmac_cfg_extend.p_callback =                       \
+				ra_spi_b_dmac_rx_cb_##index;))                                     \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                       \
+			(ra_spi_data_##index.tx_dmac_cfg_extend.p_callback =                       \
+				ra_spi_b_dmac_tx_cb_##index;))                                     \
 	} while (0)
-#define RA_SPI_B_DTC_STRUCT_INIT(index)                                                            \
+
+#define SPI_B_TRANSFER_CONFIGURE(index)                                                            \
 	.rx_transfer_info =                                                                        \
 		{                                                                                  \
 			.transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED, \
@@ -692,17 +869,22 @@ static void ra_spi_eri_isr(const struct device *dev)
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.rx_transfer_cfg_extend = {.activation_source = DT_INST_IRQ_BY_NAME(index, rxi, irq)},     \
 	.rx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &ra_spi_data_##index.rx_transfer_info,                           \
-			.p_extend = &ra_spi_data_##index.rx_transfer_cfg_extend,                   \
+			.p_extend = SPI_B_TRANSFER_DMAC_OR_DTC(index, rx,                          \
+					(&ra_spi_data_##index.rx_dmac_cfg_extend),                 \
+					(&ra_spi_data_##index.rx_dtc_cfg_extend)),                 \
 	},                                                                                         \
 	.rx_transfer =                                                                             \
 		{                                                                                  \
-			.p_ctrl = &ra_spi_data_##index.rx_transfer_ctrl,                           \
+			.p_ctrl = SPI_B_TRANSFER_DMAC_OR_DTC(index, rx,                            \
+						(&ra_spi_data_##index.rx_dmac_ctrl),               \
+						(&ra_spi_data_##index.rx_dtc_ctrl)),               \
 			.p_cfg = &ra_spi_data_##index.rx_transfer_cfg,                             \
-			.p_api = &g_transfer_on_dtc,                                               \
+			.p_api = SPI_B_TRANSFER_DMAC_OR_DTC(index, rx,                             \
+						(&g_transfer_on_dmac),                             \
+						(&g_transfer_on_dtc)),                             \
 	},                                                                                         \
 	.tx_transfer_info =                                                                        \
 		{                                                                                  \
@@ -718,24 +900,40 @@ static void ra_spi_eri_isr(const struct device *dev)
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.tx_transfer_cfg_extend = {.activation_source = DT_INST_IRQ_BY_NAME(index, txi, irq)},     \
 	.tx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &ra_spi_data_##index.tx_transfer_info,                           \
-			.p_extend = &ra_spi_data_##index.tx_transfer_cfg_extend,                   \
+			.p_extend = SPI_B_TRANSFER_DMAC_OR_DTC(index, tx,                          \
+					(&ra_spi_data_##index.tx_dmac_cfg_extend),                 \
+					(&ra_spi_data_##index.tx_dtc_cfg_extend)),                 \
 	},                                                                                         \
 	.tx_transfer = {                                                                           \
-		.p_ctrl = &ra_spi_data_##index.tx_transfer_ctrl,                                   \
+		.p_ctrl = SPI_B_TRANSFER_DMAC_OR_DTC(index, tx,                                    \
+					(&ra_spi_data_##index.tx_dmac_ctrl),                       \
+					(&ra_spi_data_##index.tx_dtc_ctrl)),                       \
 		.p_cfg = &ra_spi_data_##index.tx_transfer_cfg,                                     \
-		.p_api = &g_transfer_on_dtc,                                                       \
-	},
-#endif
+		.p_api = SPI_B_TRANSFER_DMAC_OR_DTC(index, tx,                                     \
+					(&g_transfer_on_dmac),                                     \
+					(&g_transfer_on_dtc)),                                     \
+	},                                                                                         \
+	SPI_B_DTC_CFG_EXTEND(index)                                                                \
+	SPI_B_DMAC_CFG_EXTEND(index)
+#else
+#define SPI_B_TRANSFER_INIT(index)
+#define SPI_B_TRANSFER_CONFIGURE(index)
+#endif /* CONFIG_SPI_B_RA_DTC || CONFIG_SPI_B_DMAC */
+
+#define SPI_B_IRQ_GET(index, name, cell)                                                           \
+	COND_CODE_1(DT_IRQ_HAS_NAME(index, name),                                                  \
+		    (DT_IRQ_BY_NAME(index, name, cell)),                                           \
+		    ((IRQn_Type)FSP_INVALID_VECTOR))
 
 #define RA_SPI_INIT(index)                                                                         \
                                                                                                    \
 	PINCTRL_DT_INST_DEFINE(index);                                                             \
                                                                                                    \
 	static const struct ra_spi_config ra_spi_config_##index = {                                \
+		.regs = (R_SPI_B0_Type *)DT_INST_REG_ADDR(index),                                  \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                     \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(index)),                            \
 		.clock_subsys =                                                                    \
@@ -753,20 +951,33 @@ static void ra_spi_eri_isr(const struct device *dev)
 		.fsp_config =                                                                      \
 			{                                                                          \
 				.channel = DT_INST_PROP(index, channel),                           \
-				.rxi_ipl = DT_INST_IRQ_BY_NAME(index, rxi, priority),              \
-				.rxi_irq = DT_INST_IRQ_BY_NAME(index, rxi, irq),                   \
-				.txi_ipl = DT_INST_IRQ_BY_NAME(index, txi, priority),              \
-				.txi_irq = DT_INST_IRQ_BY_NAME(index, txi, irq),                   \
-				.tei_ipl = DT_INST_IRQ_BY_NAME(index, tei, priority),              \
-				.tei_irq = DT_INST_IRQ_BY_NAME(index, tei, irq),                   \
-				.eri_ipl = DT_INST_IRQ_BY_NAME(index, eri, priority),              \
-				.eri_irq = DT_INST_IRQ_BY_NAME(index, eri, irq),                   \
+				.rxi_ipl = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),           \
+					   (BSP_IRQ_DISABLED),                                     \
+					   (SPI_B_IRQ_GET(DT_DRV_INST(index), rxi, priority))),    \
+				.rxi_irq = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),           \
+					   (FSP_INVALID_VECTOR),                                   \
+					   (SPI_B_IRQ_GET(DT_DRV_INST(index), rxi, irq))),         \
+				.txi_ipl = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),           \
+					   (BSP_IRQ_DISABLED),                                     \
+					   (SPI_B_IRQ_GET(DT_DRV_INST(index), txi, priority))),    \
+				.txi_irq = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),           \
+					   (FSP_INVALID_VECTOR),                                   \
+					   (SPI_B_IRQ_GET(DT_DRV_INST(index), txi, irq))),         \
+				.tei_ipl = SPI_B_IRQ_GET(DT_DRV_INST(index), tei, priority),       \
+				.tei_irq = SPI_B_IRQ_GET(DT_DRV_INST(index), tei, irq),            \
+				.eri_ipl = SPI_B_IRQ_GET(DT_DRV_INST(index), eri, priority),       \
+				.eri_irq = SPI_B_IRQ_GET(DT_DRV_INST(index), eri, irq),            \
+				.p_context = (void *)DEVICE_DT_GET(DT_DRV_INST(index)),            \
 			},                                                                         \
-		RA_SPI_B_DTC_STRUCT_INIT(index)};                                                  \
+		SPI_B_TRANSFER_CONFIGURE(index)};                                                  \
+                                                                                                   \
+	SPI_B_DMAC_CALLBACKS(index)                                                                \
                                                                                                    \
 	static int spi_b_ra_init##index(const struct device *dev)                                  \
 	{                                                                                          \
-		RA_SPI_B_DTC_INIT(index);                                                          \
+		SPI_B_ASSERT_NO_CONFLICT(index, tx);                                               \
+		SPI_B_ASSERT_NO_CONFLICT(index, rx);                                               \
+		SPI_B_TRANSFER_INIT(index);                                                        \
 		int err = spi_b_ra_init(dev);                                                      \
 		if (err != 0) {                                                                    \
 			return err;                                                                \

--- a/drivers/spi/spi_renesas_ra_sci_b.c
+++ b/drivers/spi/spi_renesas_ra_sci_b.c
@@ -21,11 +21,21 @@
 #include <instances/r_dtc.h>
 #endif /* CONFIG_SPI_RENESAS_RA_SCI_B_DTC */
 
+#ifdef CONFIG_SPI_RENESAS_RA_SCI_B_DMAC
+#include <instances/r_dmac.h>
+#endif /* CONFIG_SPI_RENESAS_RA_SCI_B_DMAC */
+
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(renesas_ra_spi_sci_b, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
+
+#ifdef CONFIG_SPI_RENESAS_RA_SCI_B_DTC
+#define TRANSFER_INFO_ALIGNMENT DTC_TRANSFER_INFO_ALIGNMENT
+#else
+#define TRANSFER_INFO_ALIGNMENT
+#endif
 
 struct spi_renesas_ra_sci_b_config {
 	const struct pinctrl_dev_config *pcfg;
@@ -39,21 +49,35 @@ struct spi_renesas_ra_sci_b_data {
 #ifdef CONFIG_SPI_RENESAS_RA_SCI_B_INTERRUPT
 	uint32_t data_len;
 #endif
-#ifdef CONFIG_SPI_RENESAS_RA_SCI_B_DTC
+#if defined(CONFIG_SPI_RENESAS_RA_SCI_B_DTC) || defined(CONFIG_SPI_RENESAS_RA_SCI_B_DMAC)
 	/* RX */
 	struct st_transfer_instance rx_transfer;
-	struct st_dtc_instance_ctrl rx_transfer_ctrl;
-	struct st_transfer_info rx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
+	struct st_transfer_info rx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg rx_transfer_cfg;
-	struct st_dtc_extended_cfg rx_transfer_cfg_extend;
 
 	/* TX */
 	struct st_transfer_instance tx_transfer;
-	struct st_dtc_instance_ctrl tx_transfer_ctrl;
-	struct st_transfer_info tx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
+	struct st_transfer_info tx_transfer_info TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg tx_transfer_cfg;
-	struct st_dtc_extended_cfg tx_transfer_cfg_extend;
-#endif /* CONFIG_SPI_RENESAS_RA_SCI_B_DTC */
+#endif /* CONFIG_SPI_RENESAS_RA_SCI_B_DTC || CONFIG_SPI_RENESAS_RA_SCI_B_DMAC */
+#if defined(CONFIG_SPI_RENESAS_RA_SCI_B_DTC)
+	/* DTC RX */
+	struct st_dtc_instance_ctrl rx_dtc_ctrl;
+	struct st_dtc_extended_cfg rx_dtc_cfg_extend;
+
+	/* DTC TX */
+	struct st_dtc_instance_ctrl tx_dtc_ctrl;
+	struct st_dtc_extended_cfg tx_dtc_cfg_extend;
+#endif
+#if defined(CONFIG_SPI_RENESAS_RA_SCI_B_DMAC)
+	/* DMAC RX */
+	struct st_dmac_instance_ctrl rx_dmac_ctrl;
+	struct st_dmac_extended_cfg rx_dmac_cfg_extend;
+
+	/* DMAC TX */
+	struct st_dmac_instance_ctrl tx_dmac_ctrl;
+	struct st_dmac_extended_cfg tx_dmac_cfg_extend;
+#endif
 	sci_b_spi_instance_ctrl_t fsp_ctrl;
 	spi_cfg_t fsp_cfg;
 	sci_b_spi_extended_cfg_t fsp_ext_cfg;
@@ -65,6 +89,12 @@ extern void sci_b_spi_txi_isr(void);
 extern void sci_b_spi_rxi_isr(void);
 extern void sci_b_spi_tei_isr(void);
 extern void sci_b_spi_eri_isr(void);
+#endif
+
+#ifdef CONFIG_SPI_RENESAS_RA_SCI_B_DMAC
+extern void dmac_int_isr(void);
+extern void sci_b_spi_tx_dmac_callback(sci_b_spi_instance_ctrl_t const *const p_ctrl);
+extern void sci_b_spi_rx_dmac_callback(sci_b_spi_instance_ctrl_t const *const p_ctrl);
 #endif
 
 #define CS_GPIO_LOW_WHEN_ACTIVE  true
@@ -575,27 +605,36 @@ static DEVICE_API(spi, spi_renesas_ra_sci_b_driver_api) = {
 #define EVENT_SCI_TXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _TXI))
 #define EVENT_SCI_TEI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _TEI))
 #define EVENT_SCI_ERI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _ERI))
+#define EVENT_DMAC_INT(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_DMAC, channel, _INT))
+
+#define SPI_SCI_B_DMAC_IRQ(index, dir)                                                             \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		   (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                           \
+				  DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                  \
+				  irq)),                                                           \
+		   (FSP_INVALID_VECTOR))
+
+#define SPI_SCI_B_DMAC_IPL(index, dir)                                                             \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		   (DT_IRQ_BY_IDX(DT_INST_DMAS_CTLR_BY_NAME(index, dir),                           \
+				  DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                  \
+				  priority)),                                                      \
+		   (BSP_IRQ_DISABLED))
+
+#define SPI_SCI_B_ASSERT_NO_CONFLICT(index, dir)                                                   \
+	BUILD_ASSERT(!(DT_INST_DMAS_HAS_NAME(index, dir) &&                                        \
+		       DT_INST_PROP_OR(index, dir##_dtc, false)),                                  \
+		      "Cannot use both DMAS and " #dir "-dtc for the same direction")
 
 #ifdef CONFIG_SPI_RENESAS_RA_SCI_B_INTERRUPT
 
 #define SPI_RENESAS_RA_SCI_B_IRQ_CONFIGURE(index)                                                  \
 	do {                                                                                       \
-                                                                                                   \
-		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)] =                    \
-			EVENT_SCI_RXI(DT_INST_PROP(index, channel));                               \
-		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)] =                    \
-			EVENT_SCI_TXI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq)] =                    \
 			EVENT_SCI_TEI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), eri, irq)] =                    \
 			EVENT_SCI_ERI(DT_INST_PROP(index, channel));                               \
                                                                                                    \
-		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),                       \
-			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, priority),                  \
-			    sci_b_spi_rxi_isr, DEVICE_DT_INST_GET(index), 0);                      \
-		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq),                       \
-			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, priority),                  \
-			    sci_b_spi_txi_isr, DEVICE_DT_INST_GET(index), 0);                      \
 		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq),                       \
 			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, priority),                  \
 			    sci_b_spi_tei_isr, DEVICE_DT_INST_GET(index), 0);                      \
@@ -603,10 +642,45 @@ static DEVICE_API(spi, spi_renesas_ra_sci_b_driver_api) = {
 			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), eri, priority),                  \
 			    sci_b_spi_eri_isr, DEVICE_DT_INST_GET(index), 0);                      \
                                                                                                    \
-		irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq));                       \
-		irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq));                       \
 		irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), eri, irq));                       \
 		irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq));                       \
+                                                                                                   \
+		/* Enable DMAC interrupt instead of TXI/RXI for DMA transfers */                   \
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),                                      \
+		(                                                                                  \
+			R_ICU->IELSR[SPI_SCI_B_DMAC_IRQ(index, rx)] = EVENT_DMAC_INT(              \
+					DT_INST_DMAS_CELL_BY_NAME(index, rx, channel));            \
+			IRQ_CONNECT(SPI_SCI_B_DMAC_IRQ(index, rx),                                 \
+					SPI_SCI_B_DMAC_IPL(index, rx),                             \
+					dmac_int_isr, NULL, 0);                                    \
+			irq_enable(SPI_SCI_B_DMAC_IRQ(index, rx));                                 \
+		),                                                                                 \
+		(                                                                                  \
+			R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)] =            \
+				EVENT_SCI_RXI(DT_INST_PROP(index, channel));                       \
+			IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),               \
+					DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, priority),      \
+					sci_b_spi_rxi_isr, DEVICE_DT_INST_GET(index), 0);          \
+			irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq));               \
+		))                                                                                 \
+                                                                                                   \
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                                      \
+		(                                                                                  \
+			R_ICU->IELSR[SPI_SCI_B_DMAC_IRQ(index, tx)] = EVENT_DMAC_INT(              \
+					DT_INST_DMAS_CELL_BY_NAME(index, tx, channel));            \
+			IRQ_CONNECT(SPI_SCI_B_DMAC_IRQ(index, tx),                                 \
+					SPI_SCI_B_DMAC_IPL(index, tx),                             \
+					dmac_int_isr, NULL, 0);                                    \
+			irq_enable(SPI_SCI_B_DMAC_IRQ(index, tx));                                 \
+		),                                                                                 \
+		(                                                                                  \
+			R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)] =            \
+				EVENT_SCI_TXI(DT_INST_PROP(index, channel));                       \
+			IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq),               \
+					DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, priority),      \
+					sci_b_spi_txi_isr, DEVICE_DT_INST_GET(index), 0);          \
+			irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq));               \
+		))                                                                                 \
 	} while (0)
 #else
 
@@ -614,18 +688,93 @@ static DEVICE_API(spi, spi_renesas_ra_sci_b_driver_api) = {
 
 #endif
 
-#ifndef CONFIG_SPI_RENESAS_RA_SCI_B_DTC
-#define SPI_RENESAS_RA_SCI_B_DTC_CONFIGURE(index)
-#define SPI_RENESAS_RA_SCI_B_DTC_INIT(index)
+#ifndef CONFIG_SPI_RENESAS_RA_SCI_B_DMAC
+#define SPI_RENESAS_RA_SCI_B_DMAC_CFG_EXTEND(index)
+#define SPI_RENESAS_RA_SCI_B_DMAC_CALLBACKS(index)
 #else
-#define SPI_RENESAS_RA_SCI_B_DTC_INIT(index)                                                       \
+#define SPI_RENESAS_RA_SCI_B_DMAC_CFG_EXTEND(index)                                                \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx), (                                             \
+	.tx_dmac_cfg_extend = {                                                                    \
+		.activation_source = EVENT_SCI_TXI(DT_INST_PROP(index, channel)),                  \
+		.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                           \
+				      (DT_INST_DMAS_CELL_BY_NAME(index, tx, channel)),             \
+				      (0)),                                                        \
+		.irq = SPI_SCI_B_DMAC_IRQ(index, tx),                                              \
+		.ipl = SPI_SCI_B_DMAC_IPL(index, tx),                                              \
+		.offset = 1, .src_buffer_size = 1},                                                \
+	))                                                                                         \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx), (                                             \
+	.rx_dmac_cfg_extend = {                                                                    \
+		.activation_source = EVENT_SCI_RXI(DT_INST_PROP(index, channel)),		   \
+		.channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),                           \
+				      (DT_INST_DMAS_CELL_BY_NAME(index, rx, channel)),             \
+				      (0)),                                                        \
+		.irq = SPI_SCI_B_DMAC_IRQ(index, rx),                                              \
+		.ipl = SPI_SCI_B_DMAC_IPL(index, rx),                                              \
+		.offset = 1, .src_buffer_size = 1},                                                \
+	))
+#define SPI_RENESAS_RA_SCI_B_DMAC_CALLBACKS(index)                                                 \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx), (                                             \
+		static void spi_renesas_ra_sci_b_dmac_tx_cb_##index(dmac_callback_args_t *p_args)  \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			sci_b_spi_tx_dmac_callback(&spi_renesas_ra_sci_b_data_##index.fsp_ctrl);   \
+		}                                                                                  \
+	))                                                                                         \
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx), (                                             \
+		static void spi_renesas_ra_sci_b_dmac_rx_cb_##index(dmac_callback_args_t *p_args)  \
+		{                                                                                  \
+			FSP_PARAMETER_NOT_USED(p_args);                                            \
+			sci_b_spi_rx_dmac_callback(&spi_renesas_ra_sci_b_data_##index.fsp_ctrl);   \
+		}                                                                                  \
+	))
+#endif /* CONFIG_SPI_RENESAS_RA_SCI_B_DMAC */
+
+#ifndef CONFIG_SPI_RENESAS_RA_SCI_B_DTC
+#define SPI_RENESAS_RA_SCI_B_DTC_CFG_EXTEND(index)
+#else
+#define SPI_RENESAS_RA_SCI_B_DTC_CFG_EXTEND(index)                                                 \
+	IF_ENABLED(DT_INST_PROP_OR(index, rx_dtc, false),                                          \
+		   (.rx_dtc_cfg_extend = {.activation_source =                                     \
+					  DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)},))      \
+	IF_ENABLED(DT_INST_PROP_OR(index, tx_dtc, false),                                          \
+		   (.tx_dtc_cfg_extend = {.activation_source =                                     \
+					   DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)},))
+#endif
+
+#if defined(CONFIG_SPI_RENESAS_RA_SCI_B_DMAC) || defined(CONFIG_SPI_RENESAS_RA_SCI_B_DTC)
+/*
+ * Select a transfer value for a given direction (@p dir: rx or tx).
+ * - If instance has DMAS for @p dir: use @p dmac_val
+ * - Else if instance has DTC property for @p dir: use @p dtc_val
+ * - Else: NULL
+ */
+#define SPI_RENESAS_RA_SCI_B_DMAC_OR_DTC(index, dir, dmac_val, dtc_val)                            \
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                             \
+		    (dmac_val),                                                                    \
+		    (COND_CODE_1(DT_INST_PROP_OR(index, dir##_dtc, false),                         \
+				 (dtc_val),                                                        \
+				 (NULL))))
+
+#define SPI_RENESAS_RA_SCI_B_TRANSFER_INIT(index)                                                  \
 	do {                                                                                       \
-		spi_renesas_ra_sci_b_data_##index.fsp_cfg.p_transfer_rx =                          \
-			&spi_renesas_ra_sci_b_data_##index.rx_transfer;                            \
-		spi_renesas_ra_sci_b_data_##index.fsp_cfg.p_transfer_tx =                          \
-			&spi_renesas_ra_sci_b_data_##index.tx_transfer;                            \
+		if (DT_INST_PROP_OR(index, rx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, rx)) {   \
+			spi_renesas_ra_sci_b_data_##index.fsp_cfg.p_transfer_rx =                  \
+				&spi_renesas_ra_sci_b_data_##index.rx_transfer;                    \
+		}                                                                                  \
+		if (DT_INST_PROP_OR(index, tx_dtc, false) || DT_INST_DMAS_HAS_NAME(index, tx)) {   \
+			spi_renesas_ra_sci_b_data_##index.fsp_cfg.p_transfer_tx =                  \
+				&spi_renesas_ra_sci_b_data_##index.tx_transfer;                    \
+		}                                                                                  \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),                                       \
+			(spi_renesas_ra_sci_b_data_##index.rx_dmac_cfg_extend.p_callback =         \
+				spi_renesas_ra_sci_b_dmac_rx_cb_##index;))                         \
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),                                       \
+			(spi_renesas_ra_sci_b_data_##index.tx_dmac_cfg_extend.p_callback =         \
+				spi_renesas_ra_sci_b_dmac_tx_cb_##index;))                         \
 	} while (0)
-#define SPI_RENESAS_RA_SCI_B_DTC_CONFIGURE(index)                                                  \
+
+#define SPI_RENESAS_RA_SCI_B_TRANSFER_CONFIGURE(index)                                             \
 	.rx_transfer_info =                                                                        \
 		{                                                                                  \
 			.transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED, \
@@ -640,18 +789,21 @@ static DEVICE_API(spi, spi_renesas_ra_sci_b_driver_api) = {
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.rx_transfer_cfg_extend = {.activation_source =                                            \
-					   DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)},       \
 	.rx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &spi_renesas_ra_sci_b_data_##index.rx_transfer_info,             \
-			.p_extend = &spi_renesas_ra_sci_b_data_##index.rx_transfer_cfg_extend,     \
+			.p_extend = SPI_RENESAS_RA_SCI_B_DMAC_OR_DTC(index, rx,                    \
+					(&spi_renesas_ra_sci_b_data_##index.rx_dmac_cfg_extend),   \
+					(&spi_renesas_ra_sci_b_data_##index.rx_dtc_cfg_extend)),   \
 	},                                                                                         \
 	.rx_transfer =                                                                             \
 		{                                                                                  \
-			.p_ctrl = &spi_renesas_ra_sci_b_data_##index.rx_transfer_ctrl,             \
+			.p_ctrl = SPI_RENESAS_RA_SCI_B_DMAC_OR_DTC(index, rx,                      \
+					      (&spi_renesas_ra_sci_b_data_##index.rx_dmac_ctrl),   \
+					      (&spi_renesas_ra_sci_b_data_##index.rx_dtc_ctrl)),   \
 			.p_cfg = &spi_renesas_ra_sci_b_data_##index.rx_transfer_cfg,               \
-			.p_api = &g_transfer_on_dtc,                                               \
+			.p_api = SPI_RENESAS_RA_SCI_B_DMAC_OR_DTC(index, rx,                       \
+					     (&g_transfer_on_dmac), (&g_transfer_on_dtc)),         \
 	},                                                                                         \
 	.tx_transfer_info =                                                                        \
 		{                                                                                  \
@@ -667,20 +819,27 @@ static DEVICE_API(spi, spi_renesas_ra_sci_b_driver_api) = {
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.tx_transfer_cfg_extend = {.activation_source =                                            \
-					   DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)},       \
 	.tx_transfer_cfg =                                                                         \
 		{                                                                                  \
 			.p_info = &spi_renesas_ra_sci_b_data_##index.tx_transfer_info,             \
-			.p_extend = &spi_renesas_ra_sci_b_data_##index.tx_transfer_cfg_extend,     \
+			.p_extend = SPI_RENESAS_RA_SCI_B_DMAC_OR_DTC(index, tx,                    \
+					(&spi_renesas_ra_sci_b_data_##index.tx_dmac_cfg_extend),   \
+					(&spi_renesas_ra_sci_b_data_##index.tx_dtc_cfg_extend)),   \
 	},                                                                                         \
 	.tx_transfer = {                                                                           \
-		.p_ctrl = &spi_renesas_ra_sci_b_data_##index.tx_transfer_ctrl,                     \
+		.p_ctrl = SPI_RENESAS_RA_SCI_B_DMAC_OR_DTC(index, tx,                              \
+				      (&spi_renesas_ra_sci_b_data_##index.tx_dmac_ctrl),           \
+				      (&spi_renesas_ra_sci_b_data_##index.tx_dtc_ctrl)),           \
 		.p_cfg = &spi_renesas_ra_sci_b_data_##index.tx_transfer_cfg,                       \
-		.p_api = &g_transfer_on_dtc,                                                       \
-	},
-#endif
-
+		.p_api = SPI_RENESAS_RA_SCI_B_DMAC_OR_DTC(index, tx,                               \
+				     (&g_transfer_on_dmac), (&g_transfer_on_dtc)),                 \
+	},                                                                                         \
+	SPI_RENESAS_RA_SCI_B_DTC_CFG_EXTEND(index)                                                 \
+	SPI_RENESAS_RA_SCI_B_DMAC_CFG_EXTEND(index)
+#else
+#define SPI_RENESAS_RA_SCI_B_TRANSFER_INIT(index)
+#define SPI_RENESAS_RA_SCI_B_TRANSFER_CONFIGURE(index)
+#endif /* CONFIG_SPI_RENESAS_RA_SCI_B_DMAC || CONFIG_SPI_RENESAS_RA_SCI_B_DTC */
 #define RENESAS_RA_SPI_SCI_B_INIT(index)                                                           \
                                                                                                    \
 	PINCTRL_DT_DEFINE(DT_INST_PARENT(index));                                                  \
@@ -705,14 +864,22 @@ static DEVICE_API(spi, spi_renesas_ra_sci_b_driver_api) = {
 		.fsp_cfg =                                                                         \
 			{                                                                          \
 				.channel = DT_INST_PROP(index, channel),                           \
-				.rxi_ipl = SPI_RENESAS_RA_SCI_B_IRQ_GET(DT_INST_PARENT(index),     \
-									rxi, priority),            \
-				.rxi_irq = SPI_RENESAS_RA_SCI_B_IRQ_GET(DT_INST_PARENT(index),     \
-									rxi, irq),                 \
-				.txi_ipl = SPI_RENESAS_RA_SCI_B_IRQ_GET(DT_INST_PARENT(index),     \
-									txi, priority),            \
-				.txi_irq = SPI_RENESAS_RA_SCI_B_IRQ_GET(DT_INST_PARENT(index),     \
-									txi, irq),                 \
+				.rxi_ipl = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),           \
+					(BSP_IRQ_DISABLED),                                        \
+					(SPI_RENESAS_RA_SCI_B_IRQ_GET(DT_INST_PARENT(index),       \
+									rxi, priority))),          \
+				.rxi_irq = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, rx),           \
+					(FSP_INVALID_VECTOR),                                      \
+					(SPI_RENESAS_RA_SCI_B_IRQ_GET(DT_INST_PARENT(index),       \
+									rxi, irq))),               \
+				.txi_ipl = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),           \
+					(BSP_IRQ_DISABLED),                                        \
+					(SPI_RENESAS_RA_SCI_B_IRQ_GET(DT_INST_PARENT(index),       \
+									txi, priority))),          \
+				.txi_irq = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),           \
+					(FSP_INVALID_VECTOR),                                      \
+					(SPI_RENESAS_RA_SCI_B_IRQ_GET(DT_INST_PARENT(index),       \
+									txi, irq))),               \
 				.tei_ipl = SPI_RENESAS_RA_SCI_B_IRQ_GET(DT_INST_PARENT(index),     \
 									tei, priority),            \
 				.tei_irq = SPI_RENESAS_RA_SCI_B_IRQ_GET(DT_INST_PARENT(index),     \
@@ -723,11 +890,15 @@ static DEVICE_API(spi, spi_renesas_ra_sci_b_driver_api) = {
 									eri, irq),                 \
 				.p_context = (void *)DEVICE_DT_GET(DT_DRV_INST(index)),            \
 			},                                                                         \
-		SPI_RENESAS_RA_SCI_B_DTC_CONFIGURE(index)};                                        \
+		SPI_RENESAS_RA_SCI_B_TRANSFER_CONFIGURE(index)};                                   \
+                                                                                                   \
+	SPI_RENESAS_RA_SCI_B_DMAC_CALLBACKS(index)                                                 \
                                                                                                    \
 	static int spi_renesas_ra_sci_b_init##index(const struct device *dev)                      \
 	{                                                                                          \
-		SPI_RENESAS_RA_SCI_B_DTC_INIT(index);                                              \
+		SPI_SCI_B_ASSERT_NO_CONFLICT(index, tx);                                           \
+		SPI_SCI_B_ASSERT_NO_CONFLICT(index, rx);                                           \
+		SPI_RENESAS_RA_SCI_B_TRANSFER_INIT(index);                                         \
 		int err = spi_renesas_ra_sci_b_init(dev);                                          \
 		if (err != 0) {                                                                    \
 			return err;                                                                \

--- a/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
@@ -144,7 +144,7 @@
 			reg-names = "channel", "common";
 			clocks = <&iclk MSTPA 22>;
 			dma-channels = <8>;
-			#dma-cells = <2>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
@@ -118,7 +118,7 @@
 			reg-names = "channel", "common";
 			clocks = <&iclk MSTPA 22>;
 			dma-channels = <8>;
-			#dma-cells = <2>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
@@ -117,7 +117,7 @@
 			reg-names = "channel", "common";
 			clocks = <&iclk MSTPA 22>;
 			dma-channels = <8>;
-			#dma-cells = <2>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -125,7 +125,7 @@
 			reg-names = "channel", "common";
 			clocks = <&iclk MSTPA 22>;
 			dma-channels = <4>;
-			#dma-cells = <2>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -124,7 +124,7 @@
 			reg-names = "channel", "common";
 			clocks = <&iclk MSTPA 22>;
 			dma-channels = <4>;
-			#dma-cells = <2>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -109,7 +109,7 @@
 			reg-names = "channel", "common";
 			clocks = <&iclk MSTPA 22>;
 			dma-channels = <8>;
-			#dma-cells = <2>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -127,7 +127,7 @@
 			reg-names = "channel", "common";
 			clocks = <&iclk MSTPA 22>;
 			dma-channels = <8>;
-			#dma-cells = <2>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -216,7 +216,7 @@
 			reg-names = "channel", "common";
 			clocks = <&iclk MSTPA 22>;
 			dma-channels = <8>;
-			#dma-cells = <2>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra8/ra8x2.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x2.dtsi
@@ -904,7 +904,7 @@
 			reg-names = "channel", "common";
 			clocks = <&iclk MSTPA 22>;
 			dma-channels = <8>;
-			#dma-cells = <2>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/dma/renesas,ra-dma.yaml
+++ b/dts/bindings/dma/renesas,ra-dma.yaml
@@ -67,8 +67,7 @@ properties:
     required: true
 
   "#dma-cells":
-    const: 2
+    const: 1
 
 dma-cells:
   - channel
-  - config

--- a/dts/bindings/i2c/renesas,ra-i2c-sci-b.yaml
+++ b/dts/bindings/i2c/renesas,ra-i2c-sci-b.yaml
@@ -32,3 +32,9 @@ properties:
     description: |
       Enabling bitrate modulation reduces the percent error
       of the actual bitrate with respect to the requested baud rate.
+
+  rx-dtc:
+    type: boolean
+
+  tx-dtc:
+    type: boolean

--- a/dts/bindings/i2c/renesas,ra-i2c-sci-b.yaml
+++ b/dts/bindings/i2c/renesas,ra-i2c-sci-b.yaml
@@ -32,3 +32,18 @@ properties:
     description: |
       Enabling bitrate modulation reduces the percent error
       of the actual bitrate with respect to the requested baud rate.
+
+  rx-dtc:
+    type: boolean
+    description: |
+      Use DTC (Data Transfer Controller) for RX transfers.
+
+  tx-dtc:
+    type: boolean
+    description: |
+      Use DTC (Data Transfer Controller) for TX transfers.
+
+  dma-names:
+    enum: ["tx", "rx"]
+    description: |
+      Names of the DMA channels used for TX and RX transfers.

--- a/dts/bindings/serial/renesas,ra8-uart-sci-b.yaml
+++ b/dts/bindings/serial/renesas,ra8-uart-sci-b.yaml
@@ -11,3 +11,13 @@ properties:
   channel:
     type: int
     required: true
+
+  tx-dtc:
+    type: boolean
+    description: |
+      Use DTC (Data Transfer Controller) for TX transfers.
+
+  rx-dtc:
+    type: boolean
+    description: |
+      Use DTC (Data Transfer Controller) for RX transfers.

--- a/dts/bindings/serial/renesas,ra8-uart-sci-b.yaml
+++ b/dts/bindings/serial/renesas,ra8-uart-sci-b.yaml
@@ -11,3 +11,18 @@ properties:
   channel:
     type: int
     required: true
+
+  tx-dtc:
+    type: boolean
+    description: |
+      Use DTC (Data Transfer Controller) for TX transfers.
+
+  rx-dtc:
+    type: boolean
+    description: |
+      Use DTC (Data Transfer Controller) for RX transfers.
+
+  dma-names:
+    enum: ["tx", "rx"]
+    description: |
+      Names of the DMA channels used for TX and RX transfers.

--- a/dts/bindings/spi/renesas,ra-spi-sci-b.yaml
+++ b/dts/bindings/spi/renesas,ra-spi-sci-b.yaml
@@ -13,3 +13,9 @@ properties:
   channel:
     type: int
     required: true
+
+  tx-dtc:
+    type: boolean
+
+  rx-dtc:
+    type: boolean

--- a/dts/bindings/spi/renesas,ra-spi-sci-b.yaml
+++ b/dts/bindings/spi/renesas,ra-spi-sci-b.yaml
@@ -13,3 +13,18 @@ properties:
   channel:
     type: int
     required: true
+
+  tx-dtc:
+    type: boolean
+    description: |
+      Use DTC (Data Transfer Controller) for TX transfers.
+
+  rx-dtc:
+    type: boolean
+    description: |
+      Use DTC (Data Transfer Controller) for RX transfers.
+
+  dma-names:
+    enum: ["tx", "rx"]
+    description: |
+      Names of the DMA channels used for TX and RX transfers.

--- a/dts/bindings/spi/renesas,ra8-spi-b.yaml
+++ b/dts/bindings/spi/renesas,ra8-spi-b.yaml
@@ -20,9 +20,13 @@ properties:
 
   tx-dtc:
     type: boolean
+    description: |
+      Use DTC (Data Transfer Controller) for TX transfers.
 
   rx-dtc:
     type: boolean
+    description: |
+      Use DTC (Data Transfer Controller) for RX transfers.
 
   pinctrl-0:
     required: true
@@ -35,3 +39,11 @@ properties:
 
   interrupt-names:
     required: true
+    enum: ["rxi", "txi", "tei", "eri"]
+    description: |
+      Names of the interrupts used by the SPI controller.
+
+  dma-names:
+    enum: ["tx", "rx"]
+    description: |
+      Names of the DMA channels used for TX and RX transfers.

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra8d1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra8d1_sci_b_spi.overlay
@@ -45,6 +45,8 @@
 	};
 
 	spi {
+		rx-dtc;
+		tx-dtc;
 		cs-gpios = <&ioport7 0x6 GPIO_ACTIVE_LOW>;
 		status = "okay";
 
@@ -61,6 +63,8 @@
 	pinctrl-names = "default";
 
 	dut_spis: spi {
+		rx-dtc;
+		tx-dtc;
 		status = "okay";
 	};
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra8m1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra8m1_sci_b_spi.overlay
@@ -35,6 +35,8 @@
 	pinctrl-names = "default";
 
 	spi {
+		rx-dtc;
+		tx-dtc;
 		cs-gpios = <&ioport7 13 GPIO_ACTIVE_LOW>;
 		status = "okay";
 
@@ -59,6 +61,8 @@
 	pinctrl-names = "default";
 
 	dut_spis: spi {
+		rx-dtc;
+		tx-dtc;
 		status = "okay";
 	};
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/fpb_ra8e1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/fpb_ra8e1_sci_b_spi.overlay
@@ -36,6 +36,8 @@
 	pinctrl-names = "default";
 
 	spi {
+		rx-dtc;
+		tx-dtc;
 		cs-gpios = <&ioport7 13 GPIO_ACTIVE_LOW>;
 		status = "okay";
 
@@ -60,6 +62,8 @@
 	pinctrl-names = "default";
 
 	dut_spis: spi {
+		rx-dtc;
+		tx-dtc;
 		status = "okay";
 	};
 

--- a/tests/drivers/spi/spi_loopback/boards/aik_ra8d1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/aik_ra8d1_sci_b_spi.overlay
@@ -9,6 +9,8 @@
  */
 
 &pmod1_spi {
+	rx-dtc;
+	tx-dtc;
 	status = "okay";
 
 	slow@0 {

--- a/tests/drivers/spi/spi_loopback/boards/aik_ra8d1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/aik_ra8d1_sci_b_spi.overlay
@@ -8,7 +8,7 @@
  * To run this test on AIK-RA8D1 board on PMOD 1, set S4-1 to UART/SPI position.
  */
 
-&pmod1_spi {
+spi: &pmod1_spi {
 	rx-dtc;
 	tx-dtc;
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8d1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8d1_sci_b_spi.overlay
@@ -19,7 +19,7 @@
 	pinctrl-0 = <&sci3_spi_default>;
 	pinctrl-names = "default";
 
-	spi {
+	spi: spi {
 		rx-dtc;
 		tx-dtc;
 		status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8d1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8d1_sci_b_spi.overlay
@@ -20,6 +20,8 @@
 	pinctrl-names = "default";
 
 	spi {
+		rx-dtc;
+		tx-dtc;
 		status = "okay";
 
 		slow@0 {

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8m1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8m1_sci_b_spi.overlay
@@ -19,7 +19,7 @@
 	pinctrl-0 = <&sci2_spi_default>;
 	pinctrl-names = "default";
 
-	spi {
+	spi: spi {
 		rx-dtc;
 		tx-dtc;
 		status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8m1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8m1_sci_b_spi.overlay
@@ -20,6 +20,8 @@
 	pinctrl-names = "default";
 
 	spi {
+		rx-dtc;
+		tx-dtc;
 		status = "okay";
 
 		slow@0 {

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8p1_r7ka8p1kflcac_cm85_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8p1_r7ka8p1kflcac_cm85_sci_b_spi.overlay
@@ -23,6 +23,8 @@
 	status = "okay";
 
 	spi {
+		rx-dtc;
+		tx-dtc;
 		status = "okay";
 
 		slow@0 {

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8p1_r7ka8p1kflcac_cm85_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8p1_r7ka8p1kflcac_cm85_sci_b_spi.overlay
@@ -22,7 +22,7 @@
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 
-	spi {
+	spi: spi {
 		rx-dtc;
 		tx-dtc;
 		status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8t2_r7ka8t2lflcac_cm85_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8t2_r7ka8t2lflcac_cm85_sci_b_spi.overlay
@@ -23,6 +23,8 @@
 	status = "okay";
 
 	spi {
+		rx-dtc;
+		tx-dtc;
 		status = "okay";
 
 		slow@0 {

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8t2_r7ka8t2lflcac_cm85_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8t2_r7ka8t2lflcac_cm85_sci_b_spi.overlay
@@ -22,7 +22,7 @@
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 
-	spi {
+	spi: spi {
 		rx-dtc;
 		tx-dtc;
 		status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/fpb_ra8e1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/fpb_ra8e1_sci_b_spi.overlay
@@ -21,6 +21,8 @@
 	pinctrl-names = "default";
 
 	spi {
+		rx-dtc;
+		tx-dtc;
 		status = "okay";
 
 		slow@0 {

--- a/tests/drivers/spi/spi_loopback/boards/fpb_ra8e1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/fpb_ra8e1_sci_b_spi.overlay
@@ -20,7 +20,7 @@
 	pinctrl-0 = <&sci0_spi_default>;
 	pinctrl-names = "default";
 
-	spi {
+	spi: spi {
 		rx-dtc;
 		tx-dtc;
 		status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/mck_ra8t1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mck_ra8t1_sci_b_spi.overlay
@@ -20,6 +20,8 @@
 	pinctrl-names = "default";
 
 	spi {
+		rx-dtc;
+		tx-dtc;
 		status = "okay";
 
 		slow@0 {

--- a/tests/drivers/spi/spi_loopback/boards/mck_ra8t1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mck_ra8t1_sci_b_spi.overlay
@@ -19,7 +19,7 @@
 	pinctrl-0 = <&sci0_spi_default>;
 	pinctrl-names = "default";
 
-	spi {
+	spi: spi {
 		rx-dtc;
 		tx-dtc;
 		status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/mck_ra8t2_r7ka8t2lflcac_cm85_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mck_ra8t2_r7ka8t2lflcac_cm85_sci_b_spi.overlay
@@ -22,7 +22,7 @@
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 
-	spi {
+	spi: spi {
 		status = "okay";
 
 		slow@0 {

--- a/tests/drivers/spi/spi_loopback/boards/ra8_sci_b_dmac_common.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ra8_sci_b_dmac_common.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+	interrupts = <86 2>, <85 2>;
+	interrupt-names = "ch0", "ch1";
+};
+
+&spi {
+	/delete-property/ tx-dtc;
+	/delete-property/ rx-dtc;
+	dmas = <&dma0 0>, <&dma0 1>;
+	dma-names = "tx", "rx";
+};

--- a/tests/drivers/spi/spi_loopback/boards/ra8_spi_b_dmac_common.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ra8_spi_b_dmac_common.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+	interrupts = <86 1>, <85 1>, <84 1>, <83 1>;
+	interrupt-names = "ch0", "ch1", "ch2", "ch3";
+};
+
+&spi0 {
+	/delete-property/ tx-dtc;
+	/delete-property/ rx-dtc;
+	dmas = <&dma0 0>, <&dma0 1>;
+	dma-names = "tx", "rx";
+};
+
+&spi1 {
+	/delete-property/ tx-dtc;
+	/delete-property/ rx-dtc;
+	dmas = <&dma0 2>, <&dma0 3>;
+	dma-names = "tx", "rx";
+};

--- a/tests/drivers/spi/spi_loopback/tests.yaml
+++ b/tests/drivers/spi/spi_loopback/tests.yaml
@@ -451,6 +451,18 @@ tests:
       - ek_ra8d1
       - mck_ra8t1
       - fpb_ra8e1
+  drivers.spi.loopback.renesas_sci_b_spi.dmac:
+    filter: dt_compat_enabled("renesas,ra-spi-sci-b")
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/${BOARD}_sci_b_spi.overlay"
+      - EXTRA_DTC_OVERLAY_FILE="boards/ra8_sci_b_dmac_common.overlay"
+      - CONF_FILE="prj.conf" # to exclude "boards/${BOARD}.conf"
+    platform_allow:
+      - ek_ra8m1
+      - ek_ra8m1
+      - ek_ra8d1
+      - mck_ra8t1
+      - fpb_ra8e1
   drivers.spi.loopback.renesas_sci_b_spi.no_async:
     filter: dt_compat_enabled("renesas,ra-spi-sci-b")
     extra_configs:
@@ -476,6 +488,17 @@ tests:
     extra_args:
       - DTC_OVERLAY_FILE="boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}_sci_b_spi.overlay"
       - CONF_FILE="prj.conf" # to exclude "boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}.overlay"
+  drivers.spi.loopback.renesas_sci_b_spi_ra8x2.dmac:
+    filter: dt_compat_enabled("renesas,ra-spi-sci-b")
+    platform_allow:
+      - ek_ra8p1/r7ka8p1kflcac/cm85
+      - ek_ra8p1/r7ka8p1kflcac/cm85
+      - mck_ra8t2/r7ka8t2lflcac/cm85
+      - ek_ra8t2/r7ka8t2lflcac/cm85
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}_sci_b_spi.overlay"
+      - EXTRA_DTC_OVERLAY_FILE="boards/ra8_sci_b_dmac_common.overlay"
+      - CONF_FILE="prj.conf" # to exclude "boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}.conf"
   drivers.spi.loopback.renesas_sci_b_spi_ra8x2.no_async:
     filter: dt_compat_enabled("renesas,ra-spi-sci-b")
     integration_platforms:

--- a/tests/drivers/spi/spi_loopback/tests.yaml
+++ b/tests/drivers/spi/spi_loopback/tests.yaml
@@ -439,6 +439,19 @@ tests:
     platform_allow:
       - frdm_mcxn947/mcxn947/cpu0
       - mimxrt1050_evk/mimxrt1052/hyperflash
+  drivers.spi.loopback.renesas_spi_b.dmac:
+    filter: dt_compat_enabled("renesas,ra8-spi-b")
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="boards/ra8_spi_b_dmac_common.overlay"
+    platform_allow:
+      - ek_ra8m1
+      - ek_ra8d1
+      - mck_ra8t1
+      - fpb_ra8e1
+      - ek_ra8p1/r7ka8p1kflcac/cm85
+      - ek_ra8p1/r7ka8p1kflcac/cm85
+      - mck_ra8t2/r7ka8t2lflcac/cm85
+      - ek_ra8t2/r7ka8t2lflcac/cm85
   drivers.spi.loopback.renesas_sci_b_spi:
     filter: dt_compat_enabled("renesas,ra-spi-sci-b")
     extra_args:

--- a/tests/drivers/spi/spi_loopback/tests.yaml
+++ b/tests/drivers/spi/spi_loopback/tests.yaml
@@ -443,6 +443,19 @@ tests:
     platform_allow:
       - frdm_mcxn947/mcxn947/cpu0
       - mimxrt1050_evk/mimxrt1052/hyperflash
+  drivers.spi.loopback.renesas_spi_b.dmac:
+    filter: dt_compat_enabled("renesas,ra8-spi-b")
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="boards/ra8_spi_b_dmac_common.overlay"
+    platform_allow:
+      - ek_ra8m1
+      - ek_ra8d1
+      - mck_ra8t1
+      - fpb_ra8e1
+      - ek_ra8p1/r7ka8p1kflcac/cm85
+      - ek_ra8p1/r7ka8p1kflcac/cm85
+      - mck_ra8t2/r7ka8t2lflcac/cm85
+      - ek_ra8t2/r7ka8t2lflcac/cm85
   drivers.spi.loopback.renesas_sci_b_spi:
     filter: dt_compat_enabled("renesas,ra-spi-sci-b")
     extra_args:

--- a/tests/drivers/spi/spi_loopback/tests.yaml
+++ b/tests/drivers/spi/spi_loopback/tests.yaml
@@ -455,6 +455,18 @@ tests:
       - ek_ra8d1
       - mck_ra8t1
       - fpb_ra8e1
+  drivers.spi.loopback.renesas_sci_b_spi.dmac:
+    filter: dt_compat_enabled("renesas,ra-spi-sci-b")
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/${BOARD}_sci_b_spi.overlay"
+      - EXTRA_DTC_OVERLAY_FILE="boards/ra8_sci_b_dmac_common.overlay"
+      - CONF_FILE="prj.conf" # to exclude "boards/${BOARD}.conf"
+    platform_allow:
+      - ek_ra8m1
+      - ek_ra8m1
+      - ek_ra8d1
+      - mck_ra8t1
+      - fpb_ra8e1
   drivers.spi.loopback.renesas_sci_b_spi.no_async:
     filter: dt_compat_enabled("renesas,ra-spi-sci-b")
     extra_configs:
@@ -480,6 +492,17 @@ tests:
     extra_args:
       - DTC_OVERLAY_FILE="boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}_sci_b_spi.overlay"
       - CONF_FILE="prj.conf" # to exclude "boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}.overlay"
+  drivers.spi.loopback.renesas_sci_b_spi_ra8x2.dmac:
+    filter: dt_compat_enabled("renesas,ra-spi-sci-b")
+    platform_allow:
+      - ek_ra8p1/r7ka8p1kflcac/cm85
+      - ek_ra8p1/r7ka8p1kflcac/cm85
+      - mck_ra8t2/r7ka8t2lflcac/cm85
+      - ek_ra8t2/r7ka8t2lflcac/cm85
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}_sci_b_spi.overlay"
+      - EXTRA_DTC_OVERLAY_FILE="boards/ra8_sci_b_dmac_common.overlay"
+      - CONF_FILE="prj.conf" # to exclude "boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}.conf"
   drivers.spi.loopback.renesas_sci_b_spi_ra8x2.no_async:
     filter: dt_compat_enabled("renesas,ra-spi-sci-b")
     integration_platforms:

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8d1.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8d1.overlay
@@ -24,6 +24,8 @@
 	status = "okay";
 
 	dut: uart {
+		tx-dtc;
+		rx-dtc;
 		current-speed = <115200>;
 		status = "okay";
 	};

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8d2_r7ka8d2kflcac_cm33.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8d2_r7ka8d2kflcac_cm33.overlay
@@ -4,6 +4,8 @@
  */
 
 dut: &uart7 {
+	tx-dtc;
+	rx-dtc;
 	current-speed = <115200>;
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8d2_r7ka8d2kflcac_cm85.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8d2_r7ka8d2kflcac_cm85.overlay
@@ -4,6 +4,8 @@
  */
 
 dut: &uart7 {
+	tx-dtc;
+	rx-dtc;
 	current-speed = <115200>;
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8m1.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8m1.overlay
@@ -24,6 +24,8 @@
 	status = "okay";
 
 	dut: uart {
+		tx-dtc;
+		rx-dtc;
 		current-speed = <115200>;
 		status = "okay";
 	};

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8m2_r7ka8m2jflcac_cm33.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8m2_r7ka8m2jflcac_cm33.overlay
@@ -4,6 +4,8 @@
  */
 
 dut: &uart7 {
+	tx-dtc;
+	rx-dtc;
 	current-speed = <115200>;
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8m2_r7ka8m2jflcac_cm85.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8m2_r7ka8m2jflcac_cm85.overlay
@@ -4,6 +4,8 @@
  */
 
 dut: &uart7 {
+	tx-dtc;
+	rx-dtc;
 	current-speed = <115200>;
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
@@ -26,6 +26,8 @@
 	status = "okay";
 
 	dut: uart {
+		tx-dtc;
+		rx-dtc;
 		current-speed = <115200>;
 		status = "okay";
 	};

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
@@ -26,6 +26,8 @@
 	status = "okay";
 
 	dut: uart {
+		tx-dtc;
+		rx-dtc;
 		current-speed = <115200>;
 		status = "okay";
 	};

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8t2_r7ka8t2lflcac_cm33.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8t2_r7ka8t2lflcac_cm33.overlay
@@ -4,6 +4,8 @@
  */
 
 dut: &uart7 {
+	tx-dtc;
+	rx-dtc;
 	current-speed = <115200>;
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8t2_r7ka8t2lflcac_cm85.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8t2_r7ka8t2lflcac_cm85.overlay
@@ -4,6 +4,8 @@
  */
 
 dut: &uart7 {
+	tx-dtc;
+	rx-dtc;
 	current-speed = <115200>;
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/boards/mck_ra8t1.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mck_ra8t1.overlay
@@ -24,6 +24,8 @@
 	status = "okay";
 
 	dut: uart {
+		tx-dtc;
+		rx-dtc;
 		current-speed = <115200>;
 		status = "okay";
 	};

--- a/tests/drivers/uart/uart_async_api/boards/mck_ra8t2_r7ka8t2lflcac_cm33.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mck_ra8t2_r7ka8t2lflcac_cm33.overlay
@@ -4,6 +4,8 @@
  */
 
 dut: &uart1 {
+	tx-dtc;
+	rx-dtc;
 	current-speed = <115200>;
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/boards/mck_ra8t2_r7ka8t2lflcac_cm85.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mck_ra8t2_r7ka8t2lflcac_cm85.overlay
@@ -4,6 +4,8 @@
  */
 
 dut: &uart1 {
+	tx-dtc;
+	rx-dtc;
 	current-speed = <115200>;
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/socs/ra8_sci_b_dmac_common.overlay
+++ b/tests/drivers/uart/uart_async_api/socs/ra8_sci_b_dmac_common.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+	interrupts = <91 1>, <90 1>;
+	interrupt-names = "ch0", "ch1";
+};
+
+&dut {
+	/delete-property/ tx-dtc;
+	/delete-property/ rx-dtc;
+	dmas = <&dma0 0>, <&dma0 1>;
+	dma-names = "tx", "rx";
+};

--- a/tests/drivers/uart/uart_async_api/tests.yaml
+++ b/tests/drivers/uart/uart_async_api/tests.yaml
@@ -207,3 +207,26 @@ tests:
       - CONFIG_PM_DEVICE=y
       - CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP=y
       - CONFIG_ESP32_SLEEP_POWER_DOWN_FLASH=y
+  drivers.uart.async_api.renesas_ra8_sci_b.dmac:
+    filter: CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_UART_RA8_SCI_B_UART_DMAC
+    platform_allow:
+      - ek_ra8m1
+      - ek_ra8d1
+      - mck_ra8t1
+      - fpb_ra8e1
+      - ek_ra8p1/r7ka8p1kflcac/cm85
+      - ek_ra8p1/r7ka8p1kflcac/cm33
+      - mck_ra8t2/r7ka8t2lflcac/cm85
+      - mck_ra8t2/r7ka8t2lflcac/cm33
+      - ek_ra8d2/r7ka8d2kflcac/cm85
+      - ek_ra8d2/r7ka8d2kflcac/cm33
+      - ek_ra8m2/r7ka8m2jflcac/cm85
+      - ek_ra8m2/r7ka8m2jflcac/cm33
+      - ek_ra8t2/r7ka8t2lflcac/cm85
+      - ek_ra8t2/r7ka8t2lflcac/cm33
+    harness: ztest
+    harness_config:
+      fixture: gpio_loopback
+    depends_on: gpio
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="./socs/ra8_sci_b_dmac_common.overlay"

--- a/tests/drivers/uart/uart_async_api/tests.yaml
+++ b/tests/drivers/uart/uart_async_api/tests.yaml
@@ -170,3 +170,27 @@ tests:
       - sam_e54_xpro
       - pic32cm_jh01_cpro
       - pic32cx_sg41_cult
+
+  drivers.uart.async_api.renesas_ra8_sci_b.dmac:
+    filter: CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_UART_RA8_SCI_B_UART_DMAC
+    platform_allow:
+      - ek_ra8m1
+      - ek_ra8d1
+      - mck_ra8t1
+      - fpb_ra8e1
+      - ek_ra8p1/r7ka8p1kflcac/cm85
+      - ek_ra8p1/r7ka8p1kflcac/cm33
+      - mck_ra8t2/r7ka8t2lflcac/cm85
+      - mck_ra8t2/r7ka8t2lflcac/cm33
+      - ek_ra8d2/r7ka8d2kflcac/cm85
+      - ek_ra8d2/r7ka8d2kflcac/cm33
+      - ek_ra8m2/r7ka8m2jflcac/cm85
+      - ek_ra8m2/r7ka8m2jflcac/cm33
+      - ek_ra8t2/r7ka8t2lflcac/cm85
+      - ek_ra8t2/r7ka8t2lflcac/cm33
+    harness: ztest
+    harness_config:
+      fixture: gpio_loopback
+    depends_on: gpio
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="./socs/ra8_sci_b_dmac_common.overlay"

--- a/west.yml
+++ b/west.yml
@@ -234,7 +234,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 29d0d3b9c7f9e3929839c74a6cb10c487c24994f
+      revision: pull/214/head
       groups:
         - hal
     - name: hal_rpi_pico

--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: c7bf2092a0d6b26a1113689579bd2255b20c54c1
+      revision: c10d455b34eeaee33a267c73e29cc824bf856c32
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
- Add DMAC support for Renesas RA SCI-B I2C, SCI-B UART, SCI-B SPI, and SPI-B drivers.
- Add Devicetree binding properties for DMAC transfers.
- Add DMAC test support for the affected drivers.