### PR TITLE
crc: nxp: enable clocks / resets for the CRC peripheral

### DIFF
--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -17,6 +17,7 @@
 		zephyr,flash-controller = &fmu;
 		zephyr,console = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
+		zephyr,crc = &crc;
 	};
 
 	aliases {
@@ -99,6 +100,10 @@
 };
 
 &rtc {
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };
 

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -14,4 +14,5 @@ supported:
   - uart
   - gpio
   - rtc
+  - crc
 vendor: nxp

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -120,6 +120,12 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 	}
 #endif
 
+#if defined(CONFIG_CRC_DRIVER_NXP_LPC)
+	if ((uint32_t)sub_system == MCUX_CRC_CLK) {
+		CLOCK_EnableClock(kCLOCK_Crc);
+	}
+#endif
+
 #if defined(CONFIG_PINCTRL_NXP_PORT)
 	switch ((uint32_t)sub_system) {
 #if defined(CONFIG_SOC_FAMILY_MCXA) || defined(CONFIG_SOC_FAMILY_MCXL)

--- a/drivers/crc/crc_nxp_lpc.c
+++ b/drivers/crc/crc_nxp_lpc.c
@@ -6,6 +6,7 @@
 #define DT_DRV_COMPAT nxp_lpc_crc
 
 #include <zephyr/drivers/crc.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 
@@ -15,6 +16,8 @@ LOG_MODULE_REGISTER(nxp_lpc_crc, CONFIG_CRC_LOG_LEVEL);
 
 struct crc_nxp_lpc_config {
 	CRC_Type *base;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
 };
 
 struct crc_nxp_lpc_data {
@@ -197,19 +200,29 @@ static DEVICE_API(crc, crc_nxp_lpc_driver_api) = {
 
 static int crc_nxp_lpc_init(const struct device *dev)
 {
+	const struct crc_nxp_lpc_config *config = dev->config;
+	int ret;
+
 #ifdef CONFIG_MULTITHREADING
 	struct crc_nxp_lpc_data *data = dev->data;
-	int ret;
 
 	ret = k_sem_init(&data->lock, 1, 1);
 	if (ret != 0) {
 		return ret;
 	}
-
-#else
-	ARG_UNUSED(dev);
-
 #endif
+
+	if (config->clock_dev != NULL) {
+		if (!device_is_ready(config->clock_dev)) {
+			return -ENODEV;
+		}
+
+		ret = clock_control_on(config->clock_dev, config->clock_subsys);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
 	return 0;
 }
 
@@ -217,6 +230,11 @@ static int crc_nxp_lpc_init(const struct device *dev)
 	static struct crc_nxp_lpc_data crc_nxp_lpc_data_##inst;                                    \
 	static const struct crc_nxp_lpc_config crc_nxp_lpc_config_##inst = {                       \
 		.base = (CRC_Type *)DT_INST_REG_ADDR(inst),                                        \
+		.clock_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clocks),                      \
+			(DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(inst))), (NULL)),                       \
+		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clocks),                   \
+			((clock_control_subsys_t)DT_INST_CLOCKS_CELL(inst, name)),                 \
+			((clock_control_subsys_t)0U)),                                             \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, crc_nxp_lpc_init, NULL, &crc_nxp_lpc_data_##inst,              \
 			      &crc_nxp_lpc_config_##inst, POST_KERNEL,                             \

--- a/drivers/reset/reset_nxp_mrcc.c
+++ b/drivers/reset/reset_nxp_mrcc.c
@@ -15,10 +15,28 @@
 #define LPC_RESET_OFFSET(id) (id >> 16)
 #define LPC_RESET_BIT(id)    (BIT(id & 0xFFFF))
 
+/*
+ * The MRCC reset registers carry different instance and field names across MCX
+ * families. So the names need to be abstracted.
+ */
+#if defined(CONFIG_SOC_FAMILY_MCXL)
+#define Z_MRCC_INST           MRCC
+#define Z_MRCC_GLB_RST        GLB_RST0
+#define Z_MRCC_GLB_RST_SET    GLB_RSTSET0
+#define Z_MRCC_GLB_RST_CLR    GLB_RSTCLR0
+#define Z_MRCC_CLKUNLOCK_MASK SYSCON_CLKUNLOCK_CLKGEN_LOCKOUT_MASK
+#else
+#define Z_MRCC_INST           MRCC0
+#define Z_MRCC_GLB_RST        MRCC_GLB_RST0
+#define Z_MRCC_GLB_RST_SET    MRCC_GLB_RST0_SET
+#define Z_MRCC_GLB_RST_CLR    MRCC_GLB_RST0_CLR
+#define Z_MRCC_CLKUNLOCK_MASK SYSCON_CLKUNLOCK_UNLOCK_MASK
+#endif
+
 static int reset_mrcc_status(const struct device *dev, uint32_t id, uint8_t *status)
 {
 	const volatile uint32_t *ctrl_reg =
-		((uint32_t *)(&(MRCC0->MRCC_GLB_RST0))) + (LPC_RESET_OFFSET(id) << 2);
+		((uint32_t *)(&(Z_MRCC_INST->Z_MRCC_GLB_RST))) + (LPC_RESET_OFFSET(id) << 2);
 	*status = (uint8_t)FIELD_GET((uint32_t)LPC_RESET_BIT(id), *ctrl_reg);
 	return 0;
 }
@@ -26,8 +44,8 @@ static int reset_mrcc_status(const struct device *dev, uint32_t id, uint8_t *sta
 static int reset_mrcc_line_assert(const struct device *dev, uint32_t id)
 {
 	volatile uint32_t *ctrl_reg =
-		((uint32_t *)(&(MRCC0->MRCC_GLB_RST0_CLR))) + (LPC_RESET_OFFSET(id) << 2);
-	SYSCON->CLKUNLOCK &= ~SYSCON_CLKUNLOCK_UNLOCK_MASK;
+		((uint32_t *)(&(Z_MRCC_INST->Z_MRCC_GLB_RST_CLR))) + (LPC_RESET_OFFSET(id) << 2);
+	SYSCON->CLKUNLOCK &= ~Z_MRCC_CLKUNLOCK_MASK;
 	*ctrl_reg = FIELD_PREP(LPC_RESET_BIT(id), 0b1);
 	return 0;
 }
@@ -35,8 +53,8 @@ static int reset_mrcc_line_assert(const struct device *dev, uint32_t id)
 static int reset_mrcc_line_deassert(const struct device *dev, uint32_t id)
 {
 	volatile uint32_t *ctrl_reg =
-		((uint32_t *)(&(MRCC0->MRCC_GLB_RST0_SET))) + (LPC_RESET_OFFSET(id) << 2);
-	SYSCON->CLKUNLOCK &= ~SYSCON_CLKUNLOCK_UNLOCK_MASK;
+		((uint32_t *)(&(Z_MRCC_INST->Z_MRCC_GLB_RST_SET))) + (LPC_RESET_OFFSET(id) << 2);
+	SYSCON->CLKUNLOCK &= ~Z_MRCC_CLKUNLOCK_MASK;
 	*ctrl_reg = FIELD_PREP(LPC_RESET_BIT(id), 0b1);
 	return 0;
 }

--- a/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
@@ -278,6 +278,7 @@
 	crc: crc@120000 {
 		compatible = "nxp,lpc-crc";
 		reg = <0x120000 0x1000>;
+		clocks = <&clkctl1 MCUX_CRC_CLK>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
@@ -285,6 +285,7 @@
 	crc: crc@120000 {
 		compatible = "nxp,lpc-crc";
 		reg = <0x120000 0x1000>;
+		clocks = <&clkctl1 MCUX_CRC_CLK>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1236,6 +1236,8 @@
 	crc: crc@151000 {
 		compatible = "nxp,crc";
 		reg = <0x151000 0x1000>;
+		clocks = <&clkctl0 MCUX_CRC_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 18)>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/nxp/kinetis/nxp_k2x.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_k2x.dtsi
@@ -405,6 +405,7 @@
 		crc: crc@40032000 {
 			compatible = "nxp,crc";
 			reg = <0x40032000 0x1000>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103C, 18)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/kinetis/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke1xf.dtsi
@@ -618,6 +618,7 @@
 		crc: crc@40032000 {
 			compatible = "nxp,crc";
 			reg = <0x40032000 0x1000>;
+			clocks = <&pcc 0xc8 KINETIS_PCC_SRC_NONE_OR_EXT>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/kinetis/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke1xz.dtsi
@@ -592,6 +592,7 @@
 		crc: crc@40032000 {
 			compatible = "nxp,crc";
 			reg = <0x40032000 0x1000>;
+			clocks = <&pcc 0xc8 KINETIS_PCC_SRC_NONE_OR_EXT>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/lpc/nxp_lpc51u68.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc51u68.dtsi
@@ -198,6 +198,7 @@
 		crc: crc@40095000 {
 			compatible = "nxp,lpc-crc";
 			reg = <0x40095000 0x1000>;
+			clocks = <&syscon MCUX_CRC_CLK>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/lpc/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S0x_common.dtsi
@@ -237,6 +237,7 @@
 	crc: crc@95000 {
 		compatible = "nxp,lpc-crc";
 		reg = <0x95000 0x1000>;
+		clocks = <&syscon MCUX_CRC_CLK>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/lpc/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S1x_common.dtsi
@@ -312,6 +312,7 @@
 	crc: crc@95000 {
 		compatible = "nxp,lpc-crc";
 		reg = <0x95000 0x1000>;
+		clocks = <&syscon MCUX_CRC_CLK>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/lpc/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S2x_common.dtsi
@@ -380,6 +380,7 @@
 	crc: crc@95000 {
 		compatible = "nxp,lpc-crc";
 		reg = <0x95000 0x1000>;
+		clocks = <&syscon MCUX_CRC_CLK>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/nxp/lpc/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S3x_common.dtsi
@@ -575,6 +575,7 @@
 	crc: crc@95000 {
 		compatible = "nxp,crc";
 		reg = <0x95000 0x1000>;
+		clocks = <&syscon MCUX_CRC_CLK>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
@@ -318,6 +318,7 @@
 	crc: crc@95000 {
 		compatible = "nxp,lpc-crc";
 		reg = <0x95000 0x1000>;
+		clocks = <&syscon MCUX_CRC_CLK>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxc_common.dtsi
@@ -444,6 +444,7 @@
 		crc: crc@40032000 {
 			compatible = "nxp,crc";
 			reg = <0x40032000 0x1000>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103C, 18)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/mcx/nxp_mcxe24x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxe24x_common.dtsi
@@ -743,6 +743,7 @@
 		crc: crc@40032000 {
 			compatible = "nxp,crc";
 			reg = <0x40032000 0x1000>;
+			clocks = <&pcc 0xc8 KINETIS_PCC_SRC_NONE_OR_EXT>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/mcx/nxp_mcxl.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl.dtsi
@@ -74,7 +74,7 @@
 		#clock-cells = <1>;
 
 		reset: reset {
-			compatible = "nxp,lpc-syscon-reset";
+			compatible = "nxp,mrcc-reset";
 			#reset-cells = <1>;
 		};
 	};
@@ -211,6 +211,8 @@
 	crc: crc@8a000 {
 		compatible = "nxp,crc";
 		reg = <0x8a000 0x1000>;
+		clocks = <&syscon MCUX_CRC_CLK>;
+		resets = <&reset NXP_SYSCON_RESET(0, 9)>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
@@ -1166,6 +1166,7 @@
 	crc: crc@cb000 {
 		compatible = "nxp,crc";
 		reg = <0xcb000 0x1000>;
+		clocks = <&syscon MCUX_CRC_CLK>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -1310,6 +1310,7 @@
 	crc: crc@cb000 {
 		compatible = "nxp,crc";
 		reg = <0xcb000 0x1000>;
+		clocks = <&syscon MCUX_CRC_CLK>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxw23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw23x_common.dtsi
@@ -223,6 +223,7 @@
 	crc: crc@95000 {
 		compatible = "nxp,lpc-crc";
 		reg = <0x95000 0x1000>;
+		clocks = <&syscon MCUX_CRC_CLK>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
@@ -325,6 +325,7 @@
 	crc: crc@120000 {
 		compatible = "nxp,lpc-crc";
 		reg = <0x120000 0x1000>;
+		clocks = <&clkctl1 MCUX_CRC_CLK>;
 		status = "disabled";
 	};
 

--- a/dts/xtensa/nxp/nxp_rt685_hifi4.dtsi
+++ b/dts/xtensa/nxp/nxp_rt685_hifi4.dtsi
@@ -226,6 +226,7 @@
 			crc: crc@120000 {
 				compatible = "nxp,lpc-crc";
 				reg = <0x120000 0x1000>;
+				clocks = <&clkctl1 MCUX_CRC_CLK>;
 				status = "disabled";
 			};
 		};

--- a/soc/nxp/mcx/mcxl/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxl/Kconfig.defconfig
@@ -25,4 +25,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config FLASH_FILL_BUFFER_SIZE
 	default 512
 
+config RESET
+	default y if DT_HAS_NXP_MRCC_RESET_ENABLED
+
 endif # SOC_FAMILY_MCXL


### PR DESCRIPTION
- adds the clocks/resets properties to the rest of NXP CRC devicetree nodes (for others, these were added before)
- adds optional clock control to the NXP LPC CRC driver so the CRC peripheral clock is enabled during initialization when a clocks property is present in devicetree. 
- adds support of nxp,mrcc-reset for the MCXL family. The MRCC reset registers use different instance and field names across MCX families, so abstraction macros select the correct names per SoC family. 

Tested on lpcxpresso55s69, lpcxpresso55s36, frdm-rw612, frdm-mcxw23, mimxrt685-evk, mimxrt700-evk, frdm-mcxe247, frdm-mcxl255, frdm-mcxn236, frdm-mcxn947

