### PR TITLE
dts: arm: renesas: Add SDHC node for Renesas RA6M5

### DIFF
--- a/boards/arduino/portenta_c33/arduino_portenta_c33-pinctrl.dtsi
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33-pinctrl.dtsi
@@ -105,6 +105,26 @@
 		};
 	};
 
+	sdhc0_default: sdhc0_default {
+		group1 {
+			/* SDCMD SDDAT0 SDDAT1 SDDAT2 SDDAT3 SDCD */
+			psels = <RA_PSEL(RA_PSEL_SDHI, 4, 12)>,
+				<RA_PSEL(RA_PSEL_SDHI, 4, 11)>,
+				<RA_PSEL(RA_PSEL_SDHI, 4, 10)>,
+				<RA_PSEL(RA_PSEL_SDHI, 2, 6)>,
+				<RA_PSEL(RA_PSEL_SDHI, 2, 5)>,
+				<RA_PSEL(RA_PSEL_SDHI, 4, 15)>;
+			drive-strength = "high";
+			bias-pull-up;
+		};
+
+		group2 {
+			/* SDCLK */
+			psels = <RA_PSEL(RA_PSEL_SDHI, 4, 13)>;
+			drive-strength = "highspeed-high";
+		};
+	};
+
 	ether_default: ether_default {
 		group1 {
 			psels = <RA_PSEL(RA_PSEL_ETH_RMII, 2, 14)>, /* ET0_MDC */

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -341,6 +341,21 @@
 			status = "disabled";
 		};
 
+		sdhc0: sdhc@40092000 {
+			compatible = "renesas,ra-sdhc";
+			channel = <0>;
+			bus-width = <4>;
+			sd-support;
+			mmc-support;
+			card-detect;
+			max-bus-freq = <DT_FREQ_M(52)>;
+			interrupts = <57 12>, <58 12>, <59 12>;
+			interrupt-names = "accs", "card", "dma-req";
+			reg = <0x40092000 0x400>;
+			clocks = <&pclkb MSTPC 12>;
+			status = "disabled";
+		};
+
 		usbhs: usbhs@40111000 {
 			compatible = "renesas,ra-usbhs";
 			reg = <0x40111000 0x2000>;


### PR DESCRIPTION
Enable SD card support on the Arduino Portenta C33 (RA6M5).
* Add SDHC node for Renesas RA6M5
* Add SD card pinctrl for Arduino Portenta C33.
* Followed exiting patterns for RA8.
* Tested by mounting an exFAT SD card on a Portenta C33.