### PR TITLE
net: sockets: deliver buffered data before recv() error 

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -273,6 +273,14 @@ __net_socket struct net_context {
 	struct k_sem recv_data_wait;
 #endif /* CONFIG_NET_CONTEXT_SYNC_RECV */
 
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+	/**
+	 * Semaphore used to wait for the TCP connection to be closed by the
+	 * stack when SO_LINGER is enabled with a non-zero timeout.
+	 */
+	struct k_sem linger_sem;
+#endif /* CONFIG_NET_CONTEXT_LINGER */
+
 #if defined(CONFIG_NET_SOCKETS)
 	/** BSD socket private data */
 	void *socket_data;
@@ -410,6 +418,13 @@ __net_socket struct net_context {
 		/** Enable RX, TX or both timestamps of packets send through sockets. */
 		uint8_t timestamping;
 #endif
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+		/** Socket SO_LINGER option. When enabled (l_onoff != 0) with a
+		 * zero timeout (l_linger == 0), close() aborts the connection
+		 * with a RST instead of a graceful FIN close.
+		 */
+		struct net_linger linger;
+#endif /* CONFIG_NET_CONTEXT_LINGER */
 	} options;
 
 	/** Protocol (UDP, TCP or IEEE 802.3 protocol value) */
@@ -1091,6 +1106,23 @@ int net_context_ref(struct net_context *context);
 int net_context_unref(struct net_context *context);
 
 /**
+ * @brief Signal that the connection backing a context has been closed by the
+ * transport, so a close() blocked on SO_LINGER can resume.
+ *
+ * @internal This is called by the TCP stack from tcp_conn_close().
+ *
+ * @param context The context whose connection has been closed
+ */
+static inline void net_context_signal_linger(struct net_context *context)
+{
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+	k_sem_give(&context->linger_sem);
+#else
+	ARG_UNUSED(context);
+#endif /* CONFIG_NET_CONTEXT_LINGER */
+}
+
+/**
  * @brief Create IPv4 packet in provided net_pkt from context
  *
  * @param context Network context for a connection
@@ -1409,6 +1441,7 @@ enum net_context_option {
 	NET_OPT_IPV4_MCAST_LOOP	  = 23, /**< IPV4 multicast loop */
 	NET_OPT_RECV_HOPLIMIT     = 24, /**< Receive hop limit information */
 	NET_OPT_DONT_FRAGMENT     = 25, /**< Disable local IP fragmentation */
+	NET_OPT_LINGER            = 26, /**< Socket linger (SO_LINGER) */
 };
 
 /**

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -310,6 +310,12 @@ struct net_cmsghdr {
 	z_max_align_t cmsg_data[]; /**< Flexible array member to force alignment of net_cmsghdr */
 };
 
+/** Linger option struct for the SO_LINGER socket option */
+struct net_linger {
+	int l_onoff;  /**< Whether the linger behaviour is enabled */
+	int l_linger; /**< Linger time in seconds */
+};
+
 /** @cond INTERNAL_HIDDEN */
 
 /* Alignment for headers and data. These are arch specific but define

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -929,7 +929,7 @@ int zsock_sendmsg_all(int sock, const struct net_msghdr *msg, int flags,
 #define ZSOCK_SO_OOBINLINE 10
 /** Socket priority */
 #define ZSOCK_SO_PRIORITY 12
-/** Socket lingers on close (ignored, for compatibility) */
+/** Socket lingers on close. Takes a struct net_linger as argument. */
 #define ZSOCK_SO_LINGER 13
 /** Allow multiple sockets to reuse a single port */
 #define ZSOCK_SO_REUSEPORT 15

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -572,6 +572,17 @@ config NET_CONTEXT_SNDBUF
 	  For TCP sockets, the sndbuf will determine the total size of queued
 	  data in the TCP layer.
 
+config NET_CONTEXT_LINGER
+	bool "Add SO_LINGER support to net_context"
+	depends on NET_TCP
+	help
+	  Allow setting the SO_LINGER option on a TCP socket. When linger is
+	  enabled with a zero timeout, closing the socket aborts the connection
+	  by sending a RST segment instead of performing a graceful FIN close.
+	  When linger is enabled with a non-zero timeout, close() blocks until
+	  the connection has been closed by the stack or the timeout (in
+	  seconds) expires, in which case the connection is aborted with a RST.
+
 config NET_CONTEXT_DSCP_ECN
 	bool "Add support for setting DSCP/ECN IP properties on net_context"
 	depends on NET_IP_DSCP_ECN

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -636,6 +636,10 @@ int net_context_get(net_sa_family_t family, enum net_sock_type type, uint16_t pr
 			k_sem_init(&contexts[i].recv_data_wait, 1, K_SEM_MAX_LIMIT);
 		}
 
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+		k_sem_init(&contexts[i].linger_sem, 0, 1);
+#endif
+
 		k_mutex_init(&contexts[i].lock);
 
 		contexts[i].flags |= NET_CONTEXT_IN_USE;
@@ -716,6 +720,9 @@ int net_context_unref(struct net_context *context)
 int net_context_put(struct net_context *context)
 {
 	int ret = 0;
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+	bool linger = false;
+#endif
 
 	NET_ASSERT(context);
 
@@ -733,6 +740,17 @@ int net_context_put(struct net_context *context)
 		return ret;
 	}
 
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+	/* SO_LINGER with a non-zero timeout: block until the connection has
+	 * been closed by the stack or the timeout expires. The linger_sem is
+	 * signalled from tcp_conn_close() via net_context_signal_linger().
+	 */
+	linger = context->options.linger.l_onoff != 0 &&
+		 context->options.linger.l_linger > 0 &&
+		 net_context_get_type(context) == NET_SOCK_STREAM &&
+		 net_context_get_state(context) == NET_CONTEXT_CONNECTED;
+#endif /* CONFIG_NET_CONTEXT_LINGER */
+
 	context->connect_cb = NULL;
 	context->recv_cb = NULL;
 	context->send_cb = NULL;
@@ -741,6 +759,13 @@ int net_context_put(struct net_context *context)
 	net_tcp_put(context, false);
 
 	k_mutex_unlock(&context->lock);
+
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+	if (linger) {
+		(void)k_sem_take(&context->linger_sem,
+				 K_SECONDS(context->options.linger.l_linger));
+	}
+#endif /* CONFIG_NET_CONTEXT_LINGER */
 
 	/* Decrement refcount on user app's behalf */
 	net_context_unref(context);
@@ -1778,6 +1803,37 @@ static int get_context_sndbuf(struct net_context *context,
 
 	return -ENOTSUP;
 #endif
+}
+
+static int get_context_linger(struct net_context *context,
+			      void *value, uint32_t *len)
+{
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+	struct net_linger *linger = value;
+
+	/* SO_LINGER is only meaningful for connection-oriented (stream)
+	 * sockets.
+	 */
+	if (net_context_get_type(context) != NET_SOCK_STREAM) {
+		return -ENOTSUP;
+	}
+
+	if (value == NULL || len == NULL || *len != sizeof(struct net_linger)) {
+		return -EINVAL;
+	}
+
+	*linger = context->options.linger;
+
+	*len = sizeof(struct net_linger);
+
+	return 0;
+#else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
+	return -ENOTSUP;
+#endif /* CONFIG_NET_CONTEXT_LINGER */
 }
 
 static int get_context_dscp_ecn(struct net_context *context,
@@ -3614,6 +3670,39 @@ static int set_context_sndbuf(struct net_context *context,
 #endif
 }
 
+static int set_context_linger(struct net_context *context,
+			      const void *value, uint32_t len)
+{
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+	const struct net_linger *linger = value;
+
+	/* SO_LINGER is only meaningful for connection-oriented (stream)
+	 * sockets.
+	 */
+	if (net_context_get_type(context) != NET_SOCK_STREAM) {
+		return -ENOTSUP;
+	}
+
+	if (value == NULL || len != sizeof(struct net_linger)) {
+		return -EINVAL;
+	}
+
+	if (linger->l_linger < 0) {
+		return -EINVAL;
+	}
+
+	context->options.linger = *linger;
+
+	return 0;
+#else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
+	return -ENOTSUP;
+#endif /* CONFIG_NET_CONTEXT_LINGER */
+}
+
 static int set_context_dscp_ecn(struct net_context *context,
 				const void *value, uint32_t len)
 {
@@ -4114,6 +4203,9 @@ int net_context_set_option(struct net_context *context,
 	case NET_OPT_DONT_FRAGMENT:
 		ret = set_context_dont_fragment(context, value, len);
 		break;
+	case NET_OPT_LINGER:
+		ret = set_context_linger(context, value, len);
+		break;
 	}
 
 	k_mutex_unlock(&context->lock);
@@ -4210,6 +4302,9 @@ int net_context_get_option(struct net_context *context,
 		break;
 	case NET_OPT_DONT_FRAGMENT:
 		ret = get_context_dont_fragment(context, value, len);
+		break;
+	case NET_OPT_LINGER:
+		ret = get_context_linger(context, value, len);
 		break;
 	}
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -901,6 +901,9 @@ static void tcp_conn_release(struct k_work *work)
 	(void)k_work_cancel_delayable(&conn->ack_timer);
 	(void)k_work_cancel_delayable(&conn->send_timer);
 	(void)k_work_cancel_delayable(&conn->recv_queue_timer);
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+	(void)k_work_cancel_delayable(&conn->linger_timer);
+#endif /* CONFIG_NET_CONTEXT_LINGER */
 	keep_alive_timer_stop(conn);
 
 	k_mutex_unlock(&conn->lock);
@@ -982,6 +985,11 @@ static int tcp_conn_close(struct tcp *conn, int status)
 	}
 
 	k_sem_give(&conn->tx_sem);
+
+	/* Wake up any close() blocked on SO_LINGER for this connection. */
+	if (conn->context != NULL) {
+		net_context_signal_linger(conn->context);
+	}
 
 	return tcp_conn_unref(conn);
 }
@@ -2055,6 +2063,28 @@ static void tcp_fin_timeout(struct k_work *work)
 	(void)tcp_conn_close(conn, -ETIMEDOUT);
 }
 
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+static void tcp_linger_timeout(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct tcp *conn = CONTAINER_OF(dwork, struct tcp, linger_timer);
+
+	k_mutex_lock(&conn->lock, K_FOREVER);
+
+	/* The graceful close (SO_LINGER) may have completed already; only
+	 * abort with a RST if the connection is still open.
+	 */
+	if (conn->state != TCP_CLOSED && conn->state != TCP_UNUSED) {
+		NET_DBG("[%p] Linger timeout, aborting connection", conn);
+
+		tcp_out(conn, RST);
+		(void)tcp_conn_close(conn, -ECONNRESET);
+	}
+
+	k_mutex_unlock(&conn->lock);
+}
+#endif /* CONFIG_NET_CONTEXT_LINGER */
+
 static void tcp_last_ack_timeout(struct k_work *work)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
@@ -2227,6 +2257,9 @@ static struct tcp *tcp_conn_alloc(void)
 	k_work_init_delayable(&conn->recv_queue_timer, tcp_cleanup_recv_queue);
 	k_work_init_delayable(&conn->persist_timer, tcp_send_zwp);
 	k_work_init_delayable(&conn->ack_timer, tcp_send_ack);
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+	k_work_init_delayable(&conn->linger_timer, tcp_linger_timeout);
+#endif /* CONFIG_NET_CONTEXT_LINGER */
 	k_work_init(&conn->conn_release, tcp_conn_release);
 	keep_alive_timer_init(conn);
 
@@ -3697,6 +3730,7 @@ out:
 int net_tcp_put(struct net_context *context, bool force_close)
 {
 	struct tcp *conn = context->tcp;
+	bool linger_abort = false;
 
 	if (!conn) {
 		return -ENOENT;
@@ -3720,8 +3754,49 @@ int net_tcp_put(struct net_context *context, bool force_close)
 		return 0;
 	}
 
-	if (conn->state == TCP_ESTABLISHED ||
-	    conn->state == TCP_SYN_RECEIVED) {
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+	/* SO_LINGER with a zero timeout requests an abortive close: send a RST
+	 * to the peer and tear down the connection immediately, instead of
+	 * performing a graceful FIN handshake.
+	 */
+	linger_abort = context->options.linger.l_onoff != 0 &&
+		       context->options.linger.l_linger == 0 &&
+		       (conn->state == TCP_ESTABLISHED ||
+			conn->state == TCP_SYN_RECEIVED ||
+			conn->state == TCP_CLOSE_WAIT);
+#endif /* CONFIG_NET_CONTEXT_LINGER */
+
+	if (linger_abort) {
+		NET_DBG("[%p] Aborting connection (SO_LINGER)", conn);
+
+		k_work_cancel_delayable(&conn->send_data_timer);
+		keep_alive_timer_stop(conn);
+
+		tcp_out(conn, RST);
+
+		/* An established connection holds two references. Like the
+		 * graceful close path below, this falls through to the common
+		 * tcp_conn_unref() at the end: tcp_conn_close() drops one
+		 * reference and the common epilogue drops the other, fully
+		 * releasing the (immediately closed) connection.
+		 */
+		tcp_conn_close(conn, -ECONNRESET);
+	} else if (conn->state == TCP_ESTABLISHED ||
+		   conn->state == TCP_SYN_RECEIVED) {
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+		/* SO_LINGER with a non-zero timeout: arm a timer that aborts
+		 * the connection with a RST if the graceful close does not
+		 * complete within the linger period. The timer is cancelled
+		 * once the connection is released (tcp_conn_release()).
+		 */
+		if (context->options.linger.l_onoff != 0 &&
+		    context->options.linger.l_linger > 0) {
+			k_work_reschedule_for_queue(
+				&tcp_work_q, &conn->linger_timer,
+				K_SECONDS(context->options.linger.l_linger));
+		}
+#endif /* CONFIG_NET_CONTEXT_LINGER */
+
 		/* Send all remaining data if possible. */
 		if (conn->send_data_total > 0) {
 			NET_DBG("[%p] pending %zu bytes", conn,

--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -292,6 +292,9 @@ struct tcp { /* TCP connection */
 	struct k_work_delayable timewait_timer;
 	struct k_work_delayable persist_timer;
 	struct k_work_delayable ack_timer;
+#if defined(CONFIG_NET_CONTEXT_LINGER)
+	struct k_work_delayable linger_timer;
+#endif /* CONFIG_NET_CONTEXT_LINGER */
 #if defined(CONFIG_NET_TCP_KEEPALIVE)
 	struct k_work_delayable keepalive_timer;
 #endif /* CONFIG_NET_TCP_KEEPALIVE */

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1989,6 +1989,20 @@ int zsock_getsockopt_ctx(struct net_context *ctx, int level, int optname,
 			}
 			break;
 
+		case ZSOCK_SO_LINGER:
+			if (IS_ENABLED(CONFIG_NET_CONTEXT_LINGER)) {
+				ret = net_context_get_option(ctx,
+							     NET_OPT_LINGER,
+							     optval, optlen);
+				if (ret < 0) {
+					errno = -ret;
+					return -1;
+				}
+
+				return 0;
+			}
+			break;
+
 		case ZSOCK_SO_KEEPALIVE:
 			if (IS_ENABLED(CONFIG_NET_TCP_KEEPALIVE) &&
 			    net_context_get_proto(ctx) == NET_IPPROTO_TCP) {
@@ -2651,7 +2665,21 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 		}
 
 		case ZSOCK_SO_LINGER:
-			/* ignored. for compatibility purposes only */
+			if (IS_ENABLED(CONFIG_NET_CONTEXT_LINGER)) {
+				ret = net_context_set_option(ctx,
+							     NET_OPT_LINGER,
+							     optval, optlen);
+				if (ret < 0) {
+					errno = -ret;
+					return -1;
+				}
+
+				return 0;
+			}
+
+			/* Without linger support, accept the option for
+			 * compatibility purposes only.
+			 */
 			return 0;
 
 		case ZSOCK_SO_KEEPALIVE:

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1490,12 +1490,30 @@ static ssize_t zsock_recv_stream_timed(struct net_context *ctx, struct net_msghd
 
 	for (end = sys_timepoint_calc(timeout); max_len > 0; timeout = sys_timepoint_timeout(end)) {
 
-		if (sock_is_error(ctx)) {
-			return -POINTER_TO_INT(ctx->user_data);
-		}
+		/* Drain any buffered data before reporting a pending error or
+		 * EOF. This ensures data received before the connection was
+		 * closed (for example just before a peer RST) is delivered to
+		 * the application prior to returning the error. If some data
+		 * was already received in this call (for example with
+		 * MSG_WAITALL), return it now and let the next recv() report
+		 * the pending error or EOF.
+		 */
+		if (k_fifo_is_empty(&ctx->recv_q)) {
+			if (sock_is_error(ctx)) {
+				if (recv_len > 0) {
+					break;
+				}
 
-		if (sock_is_eof(ctx)) {
-			return 0;
+				return -POINTER_TO_INT(ctx->user_data);
+			}
+
+			if (sock_is_eof(ctx)) {
+				if (recv_len > 0) {
+					break;
+				}
+
+				return 0;
+			}
 		}
 
 		if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {

--- a/tests/net/socket/tcp/prj.conf
+++ b/tests/net/socket/tcp/prj.conf
@@ -51,6 +51,7 @@ CONFIG_NET_CONTEXT_RCVTIMEO=y
 CONFIG_NET_CONTEXT_SNDTIMEO=y
 CONFIG_NET_CONTEXT_RCVBUF=y
 CONFIG_NET_CONTEXT_SNDBUF=y
+CONFIG_NET_CONTEXT_LINGER=y
 
 # If you want to debug the tests, you can get logging using these statements
 #CONFIG_LOG=y

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -250,6 +250,20 @@ static void test_context_cleanup(void)
 		      "Not all TCP contexts properly cleaned up");
 }
 
+/* Control the packet drop ratio at the loopback adapter */
+static void set_packet_loss_ratio(void)
+{
+	/* drop one every 8 packets */
+	zassert_equal(loopback_set_packet_drop_ratio(0.125f), 0,
+		      "Error setting packet drop rate");
+}
+
+static void restore_packet_loss_ratio(void)
+{
+	/* no packet dropping any more */
+	zassert_equal(loopback_set_packet_drop_ratio(0.0f), 0,
+		      "Error setting packet drop rate");
+}
 
 ZTEST_USER(net_socket_tcp, test_v4_send_recv)
 {
@@ -492,6 +506,180 @@ ZTEST_USER(net_socket_tcp, test_v6_recv_before_rst)
 	test_recv_before_rst_common(NET_AF_INET6);
 }
 
+static void test_so_linger_common(int family)
+{
+	/* SO_LINGER with a non-zero timeout makes close() block until the
+	 * connection is closed by the stack (or the timeout expires). A normal
+	 * graceful close on the loopback interface completes well before the
+	 * timeout, so the peer must observe a graceful EOF rather than a RST.
+	 */
+	int c_sock;
+	int s_sock;
+	int new_sock;
+	struct net_sockaddr_in c_saddr4;
+	struct net_sockaddr_in s_saddr4;
+	struct net_sockaddr_in6 c_saddr6;
+	struct net_sockaddr_in6 s_saddr6;
+	struct net_sockaddr *s_saddr;
+	net_socklen_t saddrlen;
+	struct net_sockaddr addr;
+	net_socklen_t addrlen = sizeof(addr);
+	struct net_linger linger_opt = {
+		.l_onoff = 1,
+		.l_linger = 3,
+	};
+	struct net_linger got_opt = { 0 };
+	net_socklen_t optlen = sizeof(got_opt);
+	char rx_buf[30] = {0};
+	char rx_buf2[30] = {0};
+	ssize_t recved;
+	int64_t close_start;
+	int64_t close_ms;
+	int ret;
+
+	if (family == NET_AF_INET) {
+		prepare_sock_tcp_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock, &c_saddr4);
+		prepare_sock_tcp_v4(MY_IPV4_ADDR, SERVER_PORT, &s_sock, &s_saddr4);
+		s_saddr = (struct net_sockaddr *)&s_saddr4;
+		saddrlen = sizeof(s_saddr4);
+	} else {
+		prepare_sock_tcp_v6(MY_IPV6_ADDR, ANY_PORT, &c_sock, &c_saddr6);
+		prepare_sock_tcp_v6(MY_IPV6_ADDR, SERVER_PORT, &s_sock, &s_saddr6);
+		s_saddr = (struct net_sockaddr *)&s_saddr6;
+		saddrlen = sizeof(s_saddr6);
+	}
+
+	test_bind(s_sock, s_saddr, saddrlen);
+	test_listen(s_sock);
+
+	test_connect(c_sock, s_saddr, saddrlen);
+
+	test_accept(s_sock, &new_sock, &addr, &addrlen);
+
+	/* Enable SO_LINGER on the client and read it back. */
+	ret = zsock_setsockopt(c_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_LINGER,
+			       &linger_opt, sizeof(linger_opt));
+	zassert_equal(ret, 0, "setsockopt SO_LINGER failed (%d)", errno);
+
+	ret = zsock_getsockopt(c_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_LINGER,
+			       &got_opt, &optlen);
+	zassert_equal(ret, 0, "getsockopt SO_LINGER failed (%d)", errno);
+	zassert_equal(got_opt.l_onoff, linger_opt.l_onoff,
+		      "unexpected l_onoff (%d)", got_opt.l_onoff);
+	zassert_equal(got_opt.l_linger, linger_opt.l_linger,
+		      "unexpected l_linger (%d)", got_opt.l_linger);
+
+	/* Client sends some data and then closes with SO_LINGER set. */
+	test_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
+
+	close_start = k_uptime_get();
+	ret = zsock_close(c_sock);
+	close_ms = k_uptime_get() - close_start;
+	zassert_equal(ret, 0, "close failed (%d)", errno);
+	zassert_true(close_ms < MSEC_PER_SEC * linger_opt.l_linger,
+		     "close blocked until the linger timeout (%lld ms)",
+		     close_ms);
+
+	/* Server reads the data the client sent before closing... */
+	recved = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
+	zassert_equal(recved, strlen(TEST_STR_SMALL),
+		      "unexpected received bytes (%zd)", recved);
+	zassert_equal(strncmp(rx_buf, TEST_STR_SMALL, strlen(TEST_STR_SMALL)),
+		      0, "unexpected data");
+
+	/* ...and then a graceful EOF (0), not a RST. */
+	recved = zsock_recv(new_sock, rx_buf2, sizeof(rx_buf2), 0);
+	zassert_equal(recved, 0, "expected graceful EOF, got %zd", recved);
+
+	test_close(new_sock);
+	test_close(s_sock);
+
+	k_sleep(TCP_TEARDOWN_TIMEOUT);
+}
+
+ZTEST_USER(net_socket_tcp, test_v4_so_linger)
+{
+	test_so_linger_common(NET_AF_INET);
+}
+
+ZTEST_USER(net_socket_tcp, test_v6_so_linger)
+{
+	test_so_linger_common(NET_AF_INET6);
+}
+
+#define TCP_CLOSE_FAILURE_TIMEOUT 90000
+
+ZTEST(net_socket_tcp, test_z_so_linger_timeout)
+{
+	/* When SO_LINGER is enabled with a non-zero timeout and the graceful
+	 * close cannot complete (communication is broken), close() must block
+	 * for about the linger period and then the connection must be aborted
+	 * with a RST instead of lingering on the FIN retransmissions.
+	 */
+	struct net_sockaddr_in c_saddr;
+	struct net_sockaddr_in s_saddr;
+	struct net_sockaddr addr;
+	net_socklen_t addrlen = sizeof(addr);
+	struct net_linger linger_opt = {
+		.l_onoff = 1,
+		.l_linger = 1,
+	};
+	int c_sock;
+	int s_sock;
+	int new_sock;
+	int count_before = 0;
+	int count_after = 0;
+	int64_t close_start;
+	int64_t close_ms;
+	int ret;
+
+	restore_packet_loss_ratio();
+
+	prepare_sock_tcp_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock, &c_saddr);
+	prepare_sock_tcp_v4(MY_IPV4_ADDR, SERVER_PORT, &s_sock, &s_saddr);
+
+	test_bind(s_sock, (struct net_sockaddr *)&s_saddr, sizeof(s_saddr));
+	test_listen(s_sock);
+
+	test_connect(c_sock, (struct net_sockaddr *)&s_saddr, sizeof(s_saddr));
+	test_accept(s_sock, &new_sock, &addr, &addrlen);
+
+	ret = zsock_setsockopt(c_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_LINGER,
+			       &linger_opt, sizeof(linger_opt));
+	zassert_equal(ret, 0, "setsockopt SO_LINGER failed (%d)", errno);
+
+	net_context_foreach(calc_net_context, &count_before);
+
+	/* Break communication so the graceful close cannot complete. */
+	loopback_set_packet_drop_ratio(1.0f);
+
+	close_start = k_uptime_get();
+	ret = zsock_close(c_sock);
+	close_ms = k_uptime_get() - close_start;
+	zassert_equal(ret, 0, "close failed (%d)", errno);
+
+	/* close() must have blocked for roughly the linger timeout (1s) before
+	 * the connection was aborted, then returned.
+	 */
+	zassert_true(close_ms >= 500 && close_ms <= 3000,
+		     "unexpected close duration %lld ms", close_ms);
+
+	/* The aborted connection's context must be released. */
+	wait_for_n_tcp_contexts(count_before - 1,
+				K_MSEC(TCP_CLOSE_FAILURE_TIMEOUT));
+	net_context_foreach(calc_net_context, &count_after);
+	zassert_equal(count_before - 1, count_after,
+		      "net_context still in use (before %d vs after %d)",
+		      count_before - 1, count_after);
+
+	restore_packet_loss_ratio();
+
+	test_close(new_sock);
+	test_close(s_sock);
+
+	test_context_cleanup();
+}
+
 /* Test the stack behavior with a reasonable sized block data, be sure to have multiple packets */
 #define TEST_LARGE_TRANSFER_SIZE 60000
 #define TEST_PRIME 811
@@ -632,21 +820,6 @@ void test_send_recv_large_common(int tcp_nodelay, int family)
 	test_close(c_sock);
 
 	k_sleep(TCP_TEARDOWN_TIMEOUT);
-}
-
-/* Control the packet drop ratio at the loopback adapter 8 */
-static void set_packet_loss_ratio(void)
-{
-	/* drop one every 8 packets */
-	zassert_equal(loopback_set_packet_drop_ratio(0.125f), 0,
-		"Error setting packet drop rate");
-}
-
-static void restore_packet_loss_ratio(void)
-{
-	/* no packet dropping any more */
-	zassert_equal(loopback_set_packet_drop_ratio(0.0f), 0,
-		"Error setting packet drop rate");
 }
 
 ZTEST(net_socket_tcp, test_v4_send_recv_large_normal)
@@ -1496,8 +1669,6 @@ ZTEST(net_socket_tcp, test_async_connect_socket_close)
 
 	test_context_cleanup();
 }
-
-#define TCP_CLOSE_FAILURE_TIMEOUT 90000
 
 ZTEST(net_socket_tcp, test_z_close_obstructed)
 {
@@ -3244,6 +3415,8 @@ ZTEST(net_socket_tcp, test_zsock_send_all_failure)
 static void after(void *arg)
 {
 	ARG_UNUSED(arg);
+
+	restore_packet_loss_ratio();
 
 	for (int i = 0; i < ZVFS_OPEN_SIZE; ++i) {
 		(void)zsock_close(i);

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -321,6 +321,78 @@ ZTEST_USER(net_socket_tcp, test_v6_send_recv)
 	k_sleep(TCP_TEARDOWN_TIMEOUT);
 }
 
+static void test_recv_before_eof_common(int family)
+{
+	/* Data received before the peer gracefully closes the connection should
+	 * still be readable with recv() before EOF (0) is returned.
+	 */
+	int c_sock;
+	int s_sock;
+	int new_sock;
+	struct net_sockaddr_in c_saddr4;
+	struct net_sockaddr_in s_saddr4;
+	struct net_sockaddr_in6 c_saddr6;
+	struct net_sockaddr_in6 s_saddr6;
+	struct net_sockaddr *s_saddr;
+	net_socklen_t saddrlen;
+	struct net_sockaddr addr;
+	net_socklen_t addrlen = sizeof(addr);
+	char rx_buf[30] = {0};
+	ssize_t recved;
+
+	if (family == NET_AF_INET) {
+		prepare_sock_tcp_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock, &c_saddr4);
+		prepare_sock_tcp_v4(MY_IPV4_ADDR, SERVER_PORT, &s_sock, &s_saddr4);
+		s_saddr = (struct net_sockaddr *)&s_saddr4;
+		saddrlen = sizeof(s_saddr4);
+	} else {
+		prepare_sock_tcp_v6(MY_IPV6_ADDR, ANY_PORT, &c_sock, &c_saddr6);
+		prepare_sock_tcp_v6(MY_IPV6_ADDR, SERVER_PORT, &s_sock, &s_saddr6);
+		s_saddr = (struct net_sockaddr *)&s_saddr6;
+		saddrlen = sizeof(s_saddr6);
+	}
+
+	test_bind(s_sock, s_saddr, saddrlen);
+	test_listen(s_sock);
+
+	test_connect(c_sock, s_saddr, saddrlen);
+
+	test_accept(s_sock, &new_sock, &addr, &addrlen);
+
+	/* Server sends some data and immediately closes the connection. */
+	test_send(new_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
+	test_close(new_sock);
+
+	/* Let the data and FIN packets pass through. */
+	k_msleep(THREAD_SLEEP);
+
+	/* Client should be able to read the data first... */
+	recved = zsock_recv(c_sock, rx_buf, sizeof(rx_buf), 0);
+	zassert_equal(recved, strlen(TEST_STR_SMALL),
+		      "unexpected received bytes (%zd)", recved);
+	zassert_equal(strncmp(rx_buf, TEST_STR_SMALL, strlen(TEST_STR_SMALL)),
+		      0, "unexpected data");
+
+	/* ...and only then get EOF (0). */
+	recved = zsock_recv(c_sock, rx_buf, sizeof(rx_buf), 0);
+	zassert_equal(recved, 0, "expected EOF, got %zd", recved);
+
+	test_close(c_sock);
+	test_close(s_sock);
+
+	k_sleep(TCP_TEARDOWN_TIMEOUT);
+}
+
+ZTEST_USER(net_socket_tcp, test_v4_recv_before_eof)
+{
+	test_recv_before_eof_common(NET_AF_INET);
+}
+
+ZTEST_USER(net_socket_tcp, test_v6_recv_before_eof)
+{
+	test_recv_before_eof_common(NET_AF_INET6);
+}
+
 /* Test the stack behavior with a reasonable sized block data, be sure to have multiple packets */
 #define TEST_LARGE_TRANSFER_SIZE 60000
 #define TEST_PRIME 811

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -393,6 +393,105 @@ ZTEST_USER(net_socket_tcp, test_v6_recv_before_eof)
 	test_recv_before_eof_common(NET_AF_INET6);
 }
 
+static void test_recv_before_rst_common(int family)
+{
+	/* Data received before the peer abruptly closes the connection (RST)
+	 * should still be readable with recv() before an error is returned.
+	 *
+	 * The peer is forced to send a RST instead of a graceful FIN by enabling
+	 * the SO_LINGER socket option with a zero linger timeout before close().
+	 */
+	int c_sock;
+	int s_sock;
+	int new_sock;
+	struct net_sockaddr_in c_saddr4;
+	struct net_sockaddr_in s_saddr4;
+	struct net_sockaddr_in6 c_saddr6;
+	struct net_sockaddr_in6 s_saddr6;
+	struct net_sockaddr *s_saddr;
+	net_socklen_t saddrlen;
+	struct net_sockaddr addr;
+	net_socklen_t addrlen = sizeof(addr);
+	struct net_linger linger_opt = {
+		.l_onoff = 1,
+		.l_linger = 0,
+	};
+	char rx_buf[30] = {0};
+	char rx_buf2[30] = {0};
+	ssize_t recved_data;
+	ssize_t recved_eof;
+	int recv_errno;
+	int ret;
+
+	if (family == NET_AF_INET) {
+		prepare_sock_tcp_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock, &c_saddr4);
+		prepare_sock_tcp_v4(MY_IPV4_ADDR, SERVER_PORT, &s_sock, &s_saddr4);
+		s_saddr = (struct net_sockaddr *)&s_saddr4;
+		saddrlen = sizeof(s_saddr4);
+	} else {
+		prepare_sock_tcp_v6(MY_IPV6_ADDR, ANY_PORT, &c_sock, &c_saddr6);
+		prepare_sock_tcp_v6(MY_IPV6_ADDR, SERVER_PORT, &s_sock, &s_saddr6);
+		s_saddr = (struct net_sockaddr *)&s_saddr6;
+		saddrlen = sizeof(s_saddr6);
+	}
+
+	test_bind(s_sock, s_saddr, saddrlen);
+	test_listen(s_sock);
+
+	test_connect(c_sock, s_saddr, saddrlen);
+
+	test_accept(s_sock, &new_sock, &addr, &addrlen);
+
+	/* Server sends some data... */
+	test_send(new_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
+
+	/* ...and forces an abrupt close (RST) by setting SO_LINGER with a zero
+	 * timeout before closing the socket.
+	 */
+	ret = zsock_setsockopt(new_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_LINGER,
+			       &linger_opt, sizeof(linger_opt));
+	zassert_equal(ret, 0, "setsockopt SO_LINGER failed (%d)", errno);
+
+	test_close(new_sock);
+
+	/* Let the data and RST packets pass through. */
+	k_msleep(THREAD_SLEEP);
+
+	/* Client should still be able to read the data first... */
+	recved_data = zsock_recv(c_sock, rx_buf, sizeof(rx_buf), 0);
+
+	/* ...and only then get an error indicating the connection was reset. */
+	recved_eof = zsock_recv(c_sock, rx_buf2, sizeof(rx_buf2), 0);
+	recv_errno = errno;
+
+	/* Clean up before evaluating the result, so that a failed assertion
+	 * does not leak the bound port and poison subsequent test cases.
+	 */
+	test_close(c_sock);
+	test_close(s_sock);
+
+	k_sleep(TCP_TEARDOWN_TIMEOUT);
+
+	zassert_equal(recved_data, strlen(TEST_STR_SMALL),
+		      "unexpected received bytes (%zd)", recved_data);
+	zassert_equal(strncmp(rx_buf, TEST_STR_SMALL, strlen(TEST_STR_SMALL)),
+		      0, "unexpected data");
+
+	zassert_equal(recved_eof, -1, "expected error, got %zd", recved_eof);
+	zassert_equal(recv_errno, ECONNRESET, "unexpected errno value: %d",
+		      recv_errno);
+}
+
+ZTEST_USER(net_socket_tcp, test_v4_recv_before_rst)
+{
+	test_recv_before_rst_common(NET_AF_INET);
+}
+
+ZTEST_USER(net_socket_tcp, test_v6_recv_before_rst)
+{
+	test_recv_before_rst_common(NET_AF_INET6);
+}
+
 /* Test the stack behavior with a reasonable sized block data, be sure to have multiple packets */
 #define TEST_LARGE_TRANSFER_SIZE 60000
 #define TEST_PRIME 811


### PR DESCRIPTION
* Allow to return already received data in `recv()`/`recvfrom()` before reporting an error, similarily to what Linux does (for examlpe in case connection was abruptly closed with RST).
* Implement ZSOCK_SO_LINGER socket option, which allows to abort TCP connection with RST on close() (mostly to simplify tests)
* Add new tests for data reception after RST error, data reception after graceful close and for the new SO_LINGER option.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/112028