### PR TITLE
manifest: mbedtls|tf-psa-crypto: include fix for thread package search

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -324,7 +324,7 @@ manifest:
       revision: bbedf2656086a93a8468a1c98168a6b36631ce9a
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 554163f6f7b2ec71fed9b423e81f2217a8615d29
+      revision: pull/96/head
       path: modules/crypto/mbedtls
       groups:
         - crypto
@@ -389,7 +389,7 @@ manifest:
         - testing
         - tee
     - name: tf-psa-crypto
-      revision: 2d881593696aec687ca2246c53de207c2b9bf782
+      revision: pull/12/head
       path: modules/crypto/tf-psa-crypto
       groups:
         - crypto


### PR DESCRIPTION
Zephyr implements its own thread solution so there is no thread package that can be found by CMake. Let thread package search fail quietly for Mbed TLS and TF-PSA-Crypto.