### PR TITLE
tests: userspace: add integration platforms

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -12,6 +12,12 @@ tests:
     extra_args:
       - CONFIG_TEST_HW_STACK_PROTECTION=n
       - CONFIG_MINIMAL_LIBC=y
+    integration_platforms:
+      - frdm_k64f/mk64f12
+      - qemu_x86
+      - mps2/an385
+      - qemu_arc/qemu_arc_em
+      - qemu_riscv32e/qemu_virt_riscv32e
   kernel.memory_protection.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arc

--- a/tests/kernel/mem_protect/syscalls/testcase.yaml
+++ b/tests/kernel/mem_protect/syscalls/testcase.yaml
@@ -17,7 +17,17 @@ tests:
     extra_configs:
       - CONFIG_TIMESLICING=y
       - CONFIG_TIMESLICE_SIZE=20
+    integration_platforms:
+      - frdm_k64f/mk64f12
+      - qemu_x86
+      - mps2/an385
+      - qemu_riscv32e/qemu_virt_riscv32e
   kernel.memory_protection.syscalls.kyield:
     extra_configs:
       - CONFIG_TIMESLICING=y
       - CONFIG_TIMESLICE_SIZE=0
+    integration_platforms:
+      - frdm_k64f/mk64f12
+      - qemu_x86
+      - mps2/an385
+      - qemu_riscv32e/qemu_virt_riscv32e

--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -19,6 +19,12 @@ tests:
       - mimxrt1170_evk@A/mimxrt1176/cm4
       - mimxrt1170_evk@B/mimxrt1176/cm4
       - mimxrt1160_evk/mimxrt1166/cm4
+    integration_platforms:
+      - frdm_k64f/mk64f12
+      - qemu_x86
+      - mps2/an385
+      - qemu_arc/qemu_arc_em
+      - qemu_riscv32e/qemu_virt_riscv32e
   kernel.memory_protection.userspace.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arc


### PR DESCRIPTION
Add few integration platforms which get picked up in addition to default
platforms. This is mostly to cover the NXP MPU in userspace testcases
and catch regressions.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
