### PR TITLE
boards: st: [wba65] : Define a common DTSI file for variants

### DIFF
--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri-common.dtsi
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri-common.dtsi
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c)  2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <st/wba/stm32wba65Xi.dtsi>
+#include <st/wba/stm32wba65rivx-pinctrl.dtsi>
+#include "arduino_r3_connector.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "STMicroelectronics STM32WBA65RI-NUCLEO board";
+	compatible = "st,stm32wba65ri-nucleo";
+
+	chosen {
+		zephyr,bt-c2h-uart = &usart1;
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,system-timer = &lptim1;
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		blue_led_1: led_0 {
+			gpios = <&gpiod 8 GPIO_ACTIVE_LOW>;
+			label = "User LD1";
+		};
+
+		green_led_2: led_1 {
+			gpios = <&gpioc 4 GPIO_ACTIVE_LOW>;
+			label = "User LD2";
+		};
+
+		red_led_3: led_2 {
+			gpios = <&gpiob 8 GPIO_ACTIVE_LOW>;
+			label = "User LD3";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		user_button_1: button_0 {
+			label = "User B1";
+			gpios = <&gpioc 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+
+		user_button_2: button_1 {
+			label = "User B2";
+			gpios = <&gpioc 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			zephyr,code = <INPUT_KEY_1>;
+		};
+
+		user_button_3: button_2 {
+			label = "User B3";
+			gpios = <&gpiob 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			zephyr,code = <INPUT_KEY_2>;
+		};
+	};
+
+	aliases {
+		led0 = &blue_led_1;
+		led1 = &green_led_2;
+		led2 = &red_led_3;
+		sw0 = &user_button_1;
+		sw1 = &user_button_2;
+		sw2 = &user_button_3;
+		mcuboot-led0 = &blue_led_1;
+		mcuboot-button0 = &user_button_1;
+		die-temp0 = &die_temp;
+	};
+};
+
+&clk_lse {
+	status = "okay";
+};
+
+&clk_hse {
+	status = "okay";
+
+	/*
+	 * Disable HSE trim applied by Clock Control.
+	 * Board-specific init will apply trim from OTP.
+	 */
+	/delete-property/ hse-trimming;
+};
+
+&clk_hsi {
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hse>;
+	clock-frequency = <DT_FREQ_M(32)>; /* Lowest value to manage radio events */
+	ahb-prescaler = <1>;
+	ahb5-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <2>;
+	apb7-prescaler = <1>;
+};
+
+&pwr {
+	power-supply = "smps";
+};
+
+&iwdg {
+	status = "okay";
+};
+
+&rtc {
+	status = "okay";
+	clocks = <&rcc STM32_CLOCK(APB7, 21)>,
+		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
+	prescaler = <32768>;
+};
+
+&usart1 {
+	clocks = <&rcc STM32_CLOCK(APB2, 14)>,
+		 <&rcc STM32_SRC_HSI16 USART1_SEL(2)>;
+	pinctrl-0 = <&usart1_tx_pb12 &usart1_rx_pa8>;
+	pinctrl-1 = <&analog_pb12 &analog_pa8>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&spi2 {
+	pinctrl-0 = <&spi2_nss_pb9 &spi2_sck_pb10
+		     &spi2_miso_pa9 &spi2_mosi_pc3>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb2 &i2c1_sda_pb1>;
+	pinctrl-names = "default";
+	scl-gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&adc4 {
+	pinctrl-0 = <&adc4_in8_pa1>;
+	pinctrl-names = "default";
+	st,adc-clock-source = "ASYNC";
+	st,adc-prescaler = <4>;
+	status = "okay";
+};
+
+&die_temp {
+	status = "okay";
+};
+
+&lptim1 {
+	clocks = <&rcc STM32_CLOCK(APB7, 11)>,
+		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
+	status = "okay";
+};
+
+&radio {
+	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
+	interrupts = <66 0>, <61 14>;
+	interrupt-names = "radio", "radio-sw-low";
+
+	bt_hci_wba: bluetooth {
+		status = "okay";
+	};
+
+	ieee802154: ieee802154 {
+		status = "okay";
+	};
+};
+
+&aes {
+	status = "okay";
+};
+
+zephyr_udc0: &usbotg_hs {
+	status = "okay";
+};
+
+&otghs_phy {
+	/* Select 32 MHz HSE as OTG HS PHY clock source */
+	clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
+		 <&rcc STM32_SRC_HSE OTGHS_SEL(0)>;
+	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_32MHz";
+	status = "okay";
+};

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -5,27 +5,20 @@
  */
 
 /dts-v1/;
-#include <st/wba/stm32wba65Xi.dtsi>
-#include <st/wba/stm32wba65rivx-pinctrl.dtsi>
-#include "arduino_r3_connector.dtsi"
-#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include "nucleo_wba65ri-common.dtsi"
+#include <mem.h>
 
 / {
-	model = "STMicroelectronics STM32WBA65RI-NUCLEO board";
-	compatible = "st,stm32wba65ri-nucleo";
-
 	chosen {
-		zephyr,bt-c2h-uart = &usart1;
-		zephyr,console = &usart1;
-		zephyr,shell-uart = &usart1;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
-		zephyr,system-timer = &lptim1;
 	};
 
-	/*
-	 * Reserve a fixed retained RAM window for the S2RAM CPU context so both
+	/* Exclude the final 0x20 bytes reserved for the PM_S2RAM marker */
+	sram0: memory@20000000 {
+		reg = <0x20000000 (DT_SIZE_K(448) - 0x20)>;
+	};
+
+	/* Reserve a fixed retained RAM window for the S2RAM CPU context so both
 	 * the application and MCUboot place `_cpu_context` at the same physical
 	 * address.
 	 */
@@ -34,173 +27,6 @@
 		reg = <0x2006ffe0 0x20>;
 		zephyr,memory-region = "PM_S2RAM";
 	};
-
-	leds: leds {
-		compatible = "gpio-leds";
-
-		blue_led_1: led_0 {
-			gpios = <&gpiod 8 GPIO_ACTIVE_LOW>;
-			label = "User LD1";
-		};
-
-		green_led_2: led_1 {
-			gpios = <&gpioc 4 GPIO_ACTIVE_LOW>;
-			label = "User LD2";
-		};
-
-		red_led_3: led_2 {
-			gpios = <&gpiob 8 GPIO_ACTIVE_LOW>;
-			label = "User LD3";
-		};
-	};
-
-	gpio_keys {
-		compatible = "gpio-keys";
-
-		user_button_1: button_0 {
-			label = "User B1";
-			gpios = <&gpioc 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-			zephyr,code = <INPUT_KEY_0>;
-		};
-
-		user_button_2: button_1 {
-			label = "User B2";
-			gpios = <&gpioc 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-			zephyr,code = <INPUT_KEY_1>;
-		};
-
-		user_button_3: button_2 {
-			label = "User B3";
-			gpios = <&gpiob 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-			zephyr,code = <INPUT_KEY_2>;
-		};
-	};
-
-	aliases {
-		led0 = &blue_led_1;
-		led1 = &green_led_2;
-		led2 = &red_led_3;
-		sw0 = &user_button_1;
-		sw1 = &user_button_2;
-		sw2 = &user_button_3;
-		mcuboot-led0 = &blue_led_1;
-		mcuboot-button0 = &user_button_1;
-		die-temp0 = &die_temp;
-	};
-};
-
-&sram0 {
-	/* Exclude the final 0x20 bytes reserved for the PM_S2RAM marker. */
-	reg = <0x20000000 (DT_SIZE_K(448) - 0x20)>;
-};
-
-&clk_lse {
-	status = "okay";
-};
-
-&clk_hse {
-	status = "okay";
-
-	/*
-	 * Disable HSE trim applied by Clock Control.
-	 * Board-specific init will apply trim from OTP.
-	 */
-	/delete-property/ hse-trimming;
-};
-
-&clk_hsi {
-	status = "okay";
-};
-
-&rcc {
-	clocks = <&clk_hse>;
-	clock-frequency = <DT_FREQ_M(32)>; /* Lowest value to manage radio events */
-	ahb-prescaler = <1>;
-	ahb5-prescaler = <1>;
-	apb1-prescaler = <1>;
-	apb2-prescaler = <2>;
-	apb7-prescaler = <1>;
-};
-
-&pwr {
-	power-supply = "smps";
-};
-
-&iwdg {
-	status = "okay";
-};
-
-&rtc {
-	status = "okay";
-	clocks = <&rcc STM32_CLOCK(APB7, 21)>,
-		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
-	prescaler = <32768>;
-};
-
-&usart1 {
-	clocks = <&rcc STM32_CLOCK(APB2, 14)>,
-		 <&rcc STM32_SRC_HSI16 USART1_SEL(2)>;
-	pinctrl-0 = <&usart1_tx_pb12 &usart1_rx_pa8>;
-	pinctrl-1 = <&analog_pb12 &analog_pa8>;
-	pinctrl-names = "default", "sleep";
-	current-speed = <115200>;
-	status = "okay";
-};
-
-&spi2 {
-	pinctrl-0 = <&spi2_nss_pb9 &spi2_sck_pb10
-		     &spi2_miso_pa9 &spi2_mosi_pc3>;
-	pinctrl-names = "default";
-	status = "okay";
-};
-
-&i2c1 {
-	pinctrl-0 = <&i2c1_scl_pb2 &i2c1_sda_pb1>;
-	pinctrl-names = "default";
-	scl-gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
-	sda-gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
-	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
-};
-
-&adc4 {
-	pinctrl-0 = <&adc4_in8_pa1>;
-	pinctrl-names = "default";
-	st,adc-clock-source = "ASYNC";
-	st,adc-prescaler = <4>;
-	status = "okay";
-};
-
-&die_temp {
-	status = "okay";
-};
-
-&lptim1 {
-	clocks = <&rcc STM32_CLOCK(APB7, 11)>,
-		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
-	status = "okay";
-};
-
-&rng {
-	status = "okay";
-};
-
-&radio {
-	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
-	interrupts = <66 0>, <61 14>;
-	interrupt-names = "radio", "radio-sw-low";
-
-	bt_hci_wba: bluetooth {
-		status = "okay";
-	};
-
-	ieee802154: ieee802154 {
-		status = "okay";
-	};
-};
-
-&aes {
-	status = "okay";
 };
 
 &flash0 {
@@ -233,16 +59,4 @@
 			reg = <0x001f2000 DT_SIZE_K(56)>;
 		};
 	};
-};
-
-zephyr_udc0: &usbotg_hs {
-	status = "okay";
-};
-
-&otghs_phy {
-	/* Select 32 MHz HSE as OTG HS PHY clock source */
-	clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
-		 <&rcc STM32_SRC_HSE OTGHS_SEL(0)>;
-	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_32MHz";
-	status = "okay";
 };

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri_stm32wba65xx_ns.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri_stm32wba65xx_ns.dts
@@ -5,7 +5,8 @@
  */
 
 /dts-v1/;
-#include "nucleo_wba65ri.dts"
+#include "nucleo_wba65ri-common.dtsi"
+#include <mem.h>
 
 / {
 	chosen {
@@ -18,9 +19,21 @@
 		status = "okay";
 	};
 
-	/* SRAM1 (node label sram0) last 64kByte are owned by TF-M */
-	memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(448 - 64)>;
+	/* SRAM1 (node label sram0) last 64kByte are owned by TF-M.
+	 * Exclude the final 0x20 bytes reserved for the PM_S2RAM marker.
+	 */
+	sram0: memory@20000000 {
+		reg = <0x20000000 (DT_SIZE_K(448 - 64) - 0x20)>;
+	};
+
+	/* Reserve a fixed retained RAM window for the S2RAM CPU context so both
+	 * the application and MCUboot place `_cpu_context` at the same physical
+	 * address.
+	 */
+	pm_s2ram: memory@2005ffe0 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x2005ffe0 0x20>;
+		zephyr,memory-region = "PM_S2RAM";
 	};
 
 	/* SRAM2 (node label sram1) is owned by TF-M */
@@ -28,12 +41,14 @@
 };
 
 &flash0 {
-	/delete-node/ partitions;
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
+
+		/* The flash layout defined in the partition nodes below must be synced
+		 * with TF-M flash layout implementation.
+		 */
 
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
@@ -59,9 +74,4 @@
 			reg = <0xcc000 (DT_SIZE_M(2) - DT_SIZE_K(48 + 256 + 512))>;
 		};
 	};
-};
-
-/* RNG is owned by TF-M */
-&rng {
-	status = "disabled";
 };

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1-common.dtsi
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1-common.dtsi
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <st/wba/stm32wba65Xi.dtsi>
+#include <st/wba/stm32wba65rivx-pinctrl.dtsi>
+#include "arduino_r3_connector.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "STMicroelectronics STM32WBA65I Discovery kit board";
+	compatible = "st,stm32wba65i-dk1";
+
+	chosen {
+		zephyr,bt-c2h-uart = &usart1;
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,system-timer = &lptim1;
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		green_led_1: led_0 {
+			gpios = <&gpiod 8 GPIO_ACTIVE_LOW>;
+			label = "User LD6";
+		};
+
+		red_led_2: led_1 {
+			gpios = <&gpiod 9 GPIO_ACTIVE_LOW>;
+			label = "User LD5";
+		};
+
+		blue_led_3: led_2 {
+			/* Not functional w/o a 0Ohm resistor on MB2143 R42 */
+			gpios = <&gpiob 10 GPIO_ACTIVE_LOW>;
+			label = "User LD3";
+		};
+	};
+
+	adc-keys {
+		compatible = "adc-keys";
+		io-channels = <&adc4 6>;
+		keyup-threshold-mv = <3300>;
+
+		select_key {
+			press-thresholds-mv = <0>;
+			zephyr,code = <INPUT_KEY_ENTER>;
+		};
+
+		left_key {
+			press-thresholds-mv = <670>;
+			zephyr,code = <INPUT_KEY_LEFT>;
+		};
+
+		down_key {
+			press-thresholds-mv = <1320>;
+			zephyr,code = <INPUT_KEY_DOWN>;
+		};
+
+		up_key {
+			press-thresholds-mv = <2010>;
+			zephyr,code = <INPUT_KEY_UP>;
+		};
+
+		right_key {
+			press-thresholds-mv = <2650>;
+			zephyr,code = <INPUT_KEY_RIGHT>;
+		};
+	};
+
+	aliases {
+		led0 = &green_led_1;
+		led1 = &red_led_2;
+		die-temp0 = &die_temp;
+	};
+};
+
+&clk_lse {
+	status = "okay";
+};
+
+&clk_hse {
+	status = "okay";
+
+	/*
+	 * Disable HSE trim applied by Clock Control.
+	 * Board-specific init will apply trim from OTP.
+	 */
+	/delete-property/ hse-trimming;
+};
+
+&clk_hsi {
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hse>;
+	clock-frequency = <DT_FREQ_M(32)>; /* Lowest value to manage radio events */
+	ahb-prescaler = <1>;
+	ahb5-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <2>;
+	apb7-prescaler = <1>;
+};
+
+&pwr {
+	power-supply = "smps";
+};
+
+&iwdg {
+	status = "okay";
+};
+
+&rtc {
+	status = "okay";
+	clocks = <&rcc STM32_CLOCK(APB7, 21)>,
+		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
+	prescaler = <32768>;
+};
+
+&usart1 {
+	clocks = <&rcc STM32_CLOCK(APB2, 14)>,
+		 <&rcc STM32_SRC_HSI16 USART1_SEL(2)>;
+	pinctrl-0 = <&usart1_tx_pb12 &usart1_rx_pa8>;
+	pinctrl-1 = <&analog_pb12 &analog_pa8>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&spi1 {
+	pinctrl-0 = <&spi1_nss_pa12 &spi1_sck_pb4
+		     &spi1_miso_pb3 &spi1_mosi_pa15>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb2 &i2c1_sda_pb1>;
+	pinctrl-names = "default";
+	scl-gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&adc4 {
+	pinctrl-0 = <&adc4_in6_pa3>;
+	pinctrl-names = "default";
+	st,adc-clock-source = "ASYNC";
+	st,adc-prescaler = <4>;
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@6 {
+		reg = <0x6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};
+
+&die_temp {
+	status = "okay";
+};
+
+&lptim1 {
+	clocks = <&rcc STM32_CLOCK(APB7, 11)>,
+		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
+	status = "okay";
+};
+
+&bt_hci_wba {
+	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
+	interrupts = <66 0>, <61 14>;
+	interrupt-names = "radio", "radio-sw-low";
+};
+
+&ieee802154 {
+	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
+	interrupts = <66 0>, <61 14>;
+	interrupt-names = "radio", "radio-sw-low";
+	status = "okay";
+};
+
+&aes {
+	status = "okay";
+};
+
+&radio {
+	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
+	interrupts = <66 0>, <61 14>;
+	interrupt-names = "radio", "radio-sw-low";
+
+	bt_hci_wba: bluetooth {
+		status = "okay";
+	};
+
+	ieee802154: ieee802154 {
+		status = "okay";
+	};
+};

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
@@ -5,27 +5,20 @@
  */
 
 /dts-v1/;
-#include <st/wba/stm32wba65Xi.dtsi>
-#include <st/wba/stm32wba65rivx-pinctrl.dtsi>
-#include "arduino_r3_connector.dtsi"
-#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include "stm32wba65i_dk1-common.dtsi"
+#include <mem.h>
 
 / {
-	model = "STMicroelectronics STM32WBA65I Discovery kit board";
-	compatible = "st,stm32wba65i-dk1";
-
 	chosen {
-		zephyr,bt-c2h-uart = &usart1;
-		zephyr,console = &usart1;
-		zephyr,shell-uart = &usart1;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
-		zephyr,system-timer = &lptim1;
 	};
 
-	/*
-	 * Reserve a fixed retained RAM window for the S2RAM CPU context so both
+	sram0: memory@20000000 {
+		/* Exclude the final 0x20 bytes reserved for the PM_S2RAM marker */
+		reg = <0x20000000 (DT_SIZE_K(448) - 0x20)>;
+	};
+
+	/* Reserve a fixed retained RAM window for the S2RAM CPU context so both
 	 * the application and MCUboot place `_cpu_context` at the same physical
 	 * address.
 	 */
@@ -34,201 +27,10 @@
 		reg = <0x2006ffe0 0x20>;
 		zephyr,memory-region = "PM_S2RAM";
 	};
-
-	leds: leds {
-		compatible = "gpio-leds";
-
-		green_led_1: led_0 {
-			gpios = <&gpiod 8 GPIO_ACTIVE_LOW>;
-			label = "User LD6";
-		};
-
-		red_led_2: led_1 {
-			gpios = <&gpiod 9 GPIO_ACTIVE_LOW>;
-			label = "User LD5";
-		};
-
-		blue_led_3: led_2 {
-			/* Not functional w/o a 0Ohm resistor on MB2143 R42 */
-			gpios = <&gpiob 10 GPIO_ACTIVE_LOW>;
-			label = "User LD3";
-		};
-	};
-
-	adc-keys {
-		compatible = "adc-keys";
-		io-channels = <&adc4 6>;
-		keyup-threshold-mv = <3300>;
-
-		select_key {
-			press-thresholds-mv = <0>;
-			zephyr,code = <INPUT_KEY_ENTER>;
-		};
-
-		left_key {
-			press-thresholds-mv = <670>;
-			zephyr,code = <INPUT_KEY_LEFT>;
-		};
-
-		down_key {
-			press-thresholds-mv = <1320>;
-			zephyr,code = <INPUT_KEY_DOWN>;
-		};
-
-		up_key {
-			press-thresholds-mv = <2010>;
-			zephyr,code = <INPUT_KEY_UP>;
-		};
-
-		right_key {
-			press-thresholds-mv = <2650>;
-			zephyr,code = <INPUT_KEY_RIGHT>;
-		};
-	};
-
-	aliases {
-		led0 = &green_led_1;
-		led1 = &red_led_2;
-		die-temp0 = &die_temp;
-	};
-};
-
-&sram0 {
-	/* Exclude the final 0x20 bytes reserved for the PM_S2RAM marker. */
-	reg = <0x20000000 (DT_SIZE_K(448) - 0x20)>;
-};
-
-&clk_lse {
-	status = "okay";
-};
-
-&clk_hse {
-	status = "okay";
-
-	/*
-	 * Disable HSE trim applied by Clock Control.
-	 * Board-specific init will apply trim from OTP.
-	 */
-	/delete-property/ hse-trimming;
-};
-
-&clk_hsi {
-	status = "okay";
-};
-
-&rcc {
-	clocks = <&clk_hse>;
-	clock-frequency = <DT_FREQ_M(32)>; /* Lowest value to manage radio events */
-	ahb-prescaler = <1>;
-	ahb5-prescaler = <1>;
-	apb1-prescaler = <1>;
-	apb2-prescaler = <2>;
-	apb7-prescaler = <1>;
-};
-
-&pwr {
-	power-supply = "smps";
-};
-
-&iwdg {
-	status = "okay";
-};
-
-&rtc {
-	status = "okay";
-	clocks = <&rcc STM32_CLOCK(APB7, 21)>,
-		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
-	prescaler = <32768>;
-};
-
-&usart1 {
-	clocks = <&rcc STM32_CLOCK(APB2, 14)>,
-		 <&rcc STM32_SRC_HSI16 USART1_SEL(2)>;
-	pinctrl-0 = <&usart1_tx_pb12 &usart1_rx_pa8>;
-	pinctrl-1 = <&analog_pb12 &analog_pa8>;
-	pinctrl-names = "default", "sleep";
-	current-speed = <115200>;
-	status = "okay";
-};
-
-&spi1 {
-	pinctrl-0 = <&spi1_nss_pa12 &spi1_sck_pb4
-		     &spi1_miso_pb3 &spi1_mosi_pa15>;
-	pinctrl-names = "default";
-	status = "okay";
-};
-
-&i2c1 {
-	pinctrl-0 = <&i2c1_scl_pb2 &i2c1_sda_pb1>;
-	pinctrl-names = "default";
-	scl-gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
-	sda-gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
-	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
-};
-
-&adc4 {
-	pinctrl-0 = <&adc4_in6_pa3>;
-	pinctrl-names = "default";
-	st,adc-clock-source = "ASYNC";
-	st,adc-prescaler = <4>;
-	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	channel@6 {
-		reg = <0x6>;
-		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
-	};
-};
-
-&die_temp {
-	status = "okay";
-};
-
-&lptim1 {
-	clocks = <&rcc STM32_CLOCK(APB7, 11)>,
-		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
-	status = "okay";
 };
 
 &rng {
 	status = "okay";
-};
-
-&bt_hci_wba {
-	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
-	interrupts = <66 0>, <61 14>;
-	interrupt-names = "radio", "radio-sw-low";
-};
-
-&ieee802154 {
-	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
-	interrupts = <66 0>, <61 14>;
-	interrupt-names = "radio", "radio-sw-low";
-	status = "okay";
-};
-
-&aes {
-	status = "okay";
-};
-
-&radio {
-	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
-	interrupts = <66 0>, <61 14>;
-	interrupt-names = "radio", "radio-sw-low";
-
-	bt_hci_wba: bluetooth {
-		status = "okay";
-	};
-
-	ieee802154: ieee802154 {
-		status = "okay";
-	};
 };
 
 &flash0 {

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1_stm32wba65xx_ns.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1_stm32wba65xx_ns.dts
@@ -5,7 +5,8 @@
  */
 
 /dts-v1/;
-#include "stm32wba65i_dk1.dts"
+#include "stm32wba65i_dk1-common.dtsi"
+#include <mem.h>
 
 / {
 	chosen {
@@ -18,9 +19,21 @@
 		status = "okay";
 	};
 
-	/* SRAM1 (node label sram0) last 64kByte are owned by TF-M */
+	/* SRAM1 (node label sram0) last 64kByte are owned by TF-M.
+	 * Exclude the final 0x20 bytes reserved for the PM_S2RAM marker.
+	 */
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(448 - 64)>;
+		reg = <0x20000000 (DT_SIZE_K(448 - 64) - 0x20)>;
+	};
+
+	/* Reserve a fixed retained RAM window for the S2RAM CPU context so both
+	 * the application and MCUboot place `_cpu_context` at the same physical
+	 * address.
+	 */
+	pm_s2ram: memory@2005ffe0 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x2005ffe0 0x20>;
+		zephyr,memory-region = "PM_S2RAM";
 	};
 
 	/* SRAM2 (node label sram1) is owned by TF-M */
@@ -28,12 +41,14 @@
 };
 
 &flash0 {
-	/delete-node/ partitions;
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
+
+		/* The flash layout defined in the partition nodes below must be synced
+		 * with TF-M flash layout implementation.
+		 */
 
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
@@ -59,9 +74,4 @@
 			reg = <0xcc000 (DT_SIZE_M(2) - DT_SIZE_K(48 + 256 + 512))>;
 		};
 	};
-};
-
-/* RNG is owned by TF-M */
-&rng {
-	status = "disabled";
 };


### PR DESCRIPTION
Define a common board DTSI file which board variants include instead of including default variant from the ns variant DTS file, overriding the default variant configuration that do not apply.

This P-R makes **nucleo_wba65ri** and **stm32wba65i_dk1** boards integration more consistent with the other ST boards.
