### PR TITLE
drivers: ethernet: dwc_mac: 1000: add hardware checksum offloading

### DIFF
--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -20,6 +20,7 @@ config ETH_DWC_ETHER_1000_CORE
 	bool
 	depends on NET_BUF_FIXED_DATA_SIZE
 	select CACHE_MANAGEMENT if DCACHE
+	select NET_CHECKSUM_OFFLOAD_SUPPORTED if NET_L2_ETHERNET
 	help
 	  This is a driver for the Synopsys DesignWare Ethernet MAC 10/100/1G Universal,
 	  also referred to as "dwc_ether_mac10_100_1000_universal".
@@ -71,6 +72,12 @@ config ETH_DWMAC_MMU
 	  This enables the Synopsys DesignWare MAC driver on MMU based
 	  platforms.
 
+config ETH_DWC_ETHER_1000_CORE_EDFE
+	bool
+	depends on ETH_DWC_ETHER_1000_CORE
+	help
+	  Increases the descriptor size to 32 bytes.
+
 if ETH_DWC_ETHER_QOS_CORE || ETH_DWC_ETHER_1000_CORE
 
 configdefault NET_BUF_ALIGNMENT
@@ -109,6 +116,22 @@ config ETH_DWMAC_RX_REFILL_THREAD_PRIORITY
 	help
 	  Priority level of the internal thread which is used to refill
 	  the receive buffer pool.
+
+config ETH_DWC_ETHER_TX_HW_CHECKSUM
+	bool "Use TX hardware checksum"
+	depends on NET_CHECKSUM_OFFLOAD
+	default y
+	help
+	  Enable transmit checksum offload to enhance throughput
+	  performances.
+
+config ETH_DWC_ETHER_RX_HW_CHECKSUM
+	bool "Use RX hardware checksum"
+	depends on NET_CHECKSUM_OFFLOAD
+	default y
+	help
+	  Enable receive checksum offload to enhance throughput
+	  performances.
 
 endif # ETH_DWC_ETHER_QOS_CORE || ETH_DWC_ETHER_1000_CORE
 

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -34,6 +34,7 @@ LOG_MODULE_REGISTER(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
 #define TDES0_FS  BIT(28)
 #define TDES0_TCH BIT(20)
 #define TDES0_ES  BIT(15)
+#define TDES0_CIC GENMASK(23, 22)
 
 #define TDES1_TBS1 GENMASK(12, 0)
 
@@ -63,6 +64,12 @@ static enum ethernet_hw_caps dwmac_caps(const struct device *dev __unused,
 #ifdef CONFIG_NET_PROMISCUOUS_MODE
 	       | ETHERNET_PROMISC_MODE
 #endif
+#ifdef CONFIG_ETH_DWC_ETHER_RX_HW_CHECKSUM
+	       | ETHERNET_HW_RX_CHKSUM_OFFLOAD
+#endif
+#ifdef CONFIG_ETH_DWC_ETHER_TX_HW_CHECKSUM
+	       | ETHERNET_HW_TX_CHKSUM_OFFLOAD
+#endif
 		;
 }
 
@@ -77,6 +84,9 @@ static __maybe_unused unsigned int net_pkt_get_nbfrags(struct net_pkt *pkt)
 	return nbfrags;
 }
 
+#define TDES0_FLAGS_DEFAULT (TDES0_TCH | TDES0_IC | \
+	(IS_ENABLED(CONFIG_ETH_DWC_ETHER_TX_HW_CHECKSUM) ? TDES0_CIC : 0U))
+
 static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 {
 	struct dwmac_priv *p = dev->data;
@@ -87,7 +97,7 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 	LOG_DBG("pkt len/frags=%zu/%u", net_pkt_get_len(pkt), net_pkt_get_nbfrags(pkt));
 
 	d_idx = p->tx_desc_head;
-	des0_flags = TDES0_TCH | TDES0_IC;
+	des0_flags = TDES0_FLAGS_DEFAULT;
 
 	NET_PKT_FRAG_FOR_EACH(pkt, frag) {
 		if (k_sem_take(&p->free_tx_descs, TX_AVAIL_WAIT) != 0) {
@@ -108,14 +118,14 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 			d->des0 |= TDES0_LS;
 		}
 
-		des0_flags = TDES0_OWN | TDES0_TCH | TDES0_IC;
+		des0_flags = TDES0_OWN | TDES0_FLAGS_DEFAULT;
 		INC_WRAP(d_idx, NB_TX_DESCS);
 	};
 
 	barrier_dmem_fence_full();
 
 	d = &p->tx_descs[p->tx_desc_head];
-	d->des0 = TDES0_OWN | TDES0_FS | TDES0_TCH | TDES0_IC;
+	d->des0 = TDES0_OWN | TDES0_FS | TDES0_FLAGS_DEFAULT;
 
 	barrier_dmem_fence_full();
 	p->tx_desc_head = d_idx;
@@ -455,9 +465,17 @@ int dwmac_probe(const struct device *dev)
 		p->rx_descs[i].des3 = RXDESC_PHYS_L((i + 1) % NB_RX_DESCS);
 	}
 
+	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_1000_CORE_EDFE)) {
+		REG_WRITE(DWMAC_DMABMR, REG_READ(DWMAC_DMABMR) | DWMAC_DMABMR_EDFE);
+	}
+
 	REG_WRITE(DWMAC_DMATDLAR, TXDESC_PHYS_L(0));
 	REG_WRITE(DWMAC_DMARDLAR, RXDESC_PHYS_L(0));
 	REG_WRITE(DWMAC_DMAOMR, DWMAC_DMAOMR_TSF | DWMAC_DMAOMR_RSF);
+
+	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_RX_HW_CHECKSUM)) {
+		REG_WRITE(DWMAC_MACCR, REG_READ(DWMAC_MACCR) | DWMAC_MACCR_IPCO);
+	}
 
 	return 0;
 }

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -97,13 +97,12 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 
 		net_pkt_frag_ref(frag);
 		sys_cache_data_flush_range(frag->data, frag->len);
+		p->tx_frags[d_idx] = frag;
 
 		d = &p->tx_descs[d_idx];
 		d->des0 = des0_flags;
 		d->des1 = FIELD_PREP(TDES1_TBS1, frag->len);
 		d->des2 = phys_lo32(frag->data);
-		/* track the net_buf associated with this desc for later release */
-		d->frag = frag;
 
 		if (!frag->frags) {
 			d->des0 |= TDES0_LS;
@@ -127,8 +126,7 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 abort:
 	while (d_idx != p->tx_desc_head) {
 		DEC_WRAP(d_idx, NB_TX_DESCS);
-		d = &p->tx_descs[d_idx];
-		net_pkt_frag_unref(d->frag);
+		net_pkt_frag_unref(p->tx_frags[d_idx]);
 		k_sem_give(&p->free_tx_descs);
 	}
 
@@ -151,7 +149,7 @@ static void dwmac_tx_release(const struct device *dev)
 			break;
 		}
 
-		frag = d->frag;
+		frag = p->tx_frags[d_idx];
 		net_pkt_frag_unref(frag);
 
 		if ((des0 & TDES0_LS) != 0U && (des0 & TDES0_ES) != 0U) {
@@ -199,8 +197,9 @@ static void dwmac_receive(const struct device *dev)
 			continue;
 		}
 
-		frag = d->frag;
-		d->frag = NULL;
+		frag = p->rx_frags[d_idx];
+		p->rx_frags[d_idx] = NULL;
+
 		sys_cache_data_invd_range(frag->data, frag->size);
 
 		bytes_so_far = RX_LEN_FROM_RDES0(des0);
@@ -241,7 +240,7 @@ static void dwmac_rx_refill(const struct device *dev, unsigned int d_idx)
 	d = &p->rx_descs[d_idx];
 	__ASSERT(!(d->des0 & RDES0_OWN), "rx desc still owned");
 
-	frag = d->frag;
+	frag = p->rx_frags[d_idx];
 	if (frag == NULL) {
 		frag = net_pkt_get_reserve_rx_data(RX_FRAG_SIZE, K_FOREVER);
 		if (frag == NULL) {
@@ -249,7 +248,7 @@ static void dwmac_rx_refill(const struct device *dev, unsigned int d_idx)
 			return;
 		}
 		__ASSERT_NO_MSG(frag->size == RX_FRAG_SIZE);
-		d->frag = frag;
+		p->rx_frags[d_idx] = frag;
 	}
 
 	d->des1 = FIELD_PREP(RDES1_RBS1, frag->size) | RDES1_RCH;

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -86,6 +86,12 @@ struct dwmac_dma_desc {
 	uint32_t des1;
 	uint32_t des2;
 	uint32_t des3;
+#ifdef CONFIG_ETH_DWC_ETHER_1000_CORE_EDFE
+	uint32_t des4;
+	uint32_t des5;
+	uint32_t des6;
+	uint32_t des7;
+#endif
 };
 
 /* our private instance structure */
@@ -1285,6 +1291,7 @@ extern const struct ethernet_api dwmac_api;
 /* MAC control bits */
 #define DWMAC_MACCR_RE     BIT(2)
 #define DWMAC_MACCR_TE     BIT(3)
+#define DWMAC_MACCR_IPCO   BIT(10)
 #define DWMAC_MACCR_DM     BIT(11)
 #define DWMAC_MACCR_FES    BIT(14)
 #define DWMAC_MACCR_PS     BIT(15)
@@ -1309,6 +1316,7 @@ extern const struct ethernet_api dwmac_api;
 
 /* DMA bus mode bits */
 #define DWMAC_DMABMR_SR    BIT(0)
+#define DWMAC_DMABMR_EDFE  BIT(7)
 
 /* DMA interrupt enable bits */
 #define DWMAC_DMAIER_TIE   BIT(0)

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -86,10 +86,6 @@ struct dwmac_dma_desc {
 	uint32_t des1;
 	uint32_t des2;
 	uint32_t des3;
-#ifndef CONFIG_ETH_DWC_ETHER_QOS_CORE
-	/* software-only field for tracking the net_buf associated with this desc */
-	struct net_buf *frag;
-#endif
 };
 
 /* our private instance structure */
@@ -121,10 +117,10 @@ struct dwmac_priv {
 #ifdef CONFIG_MMU
 	uintptr_t tx_descs_phys, rx_descs_phys;
 #endif
-#ifdef CONFIG_ETH_DWC_ETHER_QOS_CORE
+
 	struct net_buf *tx_frags[NB_TX_DESCS]; /* index shared with tx_descs */
 	struct net_buf *rx_frags[NB_RX_DESCS]; /* index shared with rx_descs */
-#endif
+
 	struct net_pkt *rx_pkt;
 	uint16_t rx_bytes;
 


### PR DESCRIPTION
- add checksum offloading for the designware 1000 universal mac
- have the frag pointer in the designware 1000 universal mac driver also not in the descriptor, that way the pointer can be cached and also it should be no problem in the future if we have to align the fragments on 64 bit for some platform