### PR TITLE
MAINTAINERS: add parthitce as collaborator for Infineon platform

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3298,6 +3298,7 @@ Infineon Platforms:
     - lauracarlesso
     - merin-infineon
     - ifx-rmcs
+    - parthitce
   files:
     - boards/cypress/
     - boards/infineon/


### PR DESCRIPTION
Add myself as collaborator for Infineon platform. Am active in reviewing Infineon PSoC, XMC, T2G platforms and will continue to do so.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>