### PR TITLE
drivers: i3c: stm32: run bus init without DTS-declared I3C devices

### DIFF
--- a/drivers/i3c/i3c_stm32.c
+++ b/drivers/i3c/i3c_stm32.c
@@ -1715,9 +1715,13 @@ static int i3c_stm32_init(const struct device *dev)
 	i3c_stm32_configure(dev, I3C_CONFIG_CONTROLLER, &data->drv_data.ctrl_config);
 	i3c_stm32_controller_init(dev);
 
-	/* Perform bus initialization only if there are devices that already exist on the bus */
-	if (config->drv_cfg.dev_list.num_i3c > 0 &&
-	    !(config->drv_cfg.flags & I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT)) {
+	/* Perform bus initialization.
+	 * Run i3c_bus_init() even when there are no DTS child nodes, so that
+	 * ENTDAA can discover devices dynamically via mem slab descriptors
+	 * (CONFIG_I3C_NUM_OF_DESC_MEM_SLABS). The DISABLE_BUS_INIT flag is
+	 * still honoured, matching the other I3C controller drivers.
+	 */
+	if (!(config->drv_cfg.flags & I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT)) {
 		ret = i3c_bus_init(dev, &config->drv_cfg.dev_list);
 		if (ret != 0) {
 			LOG_ERR("Failed to do i3c bus init, err=%d", ret);


### PR DESCRIPTION
### Description
  
Follow-up to #110517, which already absorbed the dynamic-discovery attach changes across the I3C drivers. This PR keeps only the remaining stm32-specific fix that was intentionally left out of that PR.

The stm32 controller driver gated `i3c_bus_init()` on `dev_list.num_i3c > 0`, so on a bus with no statically-declared I3C children, ENTDAA never ran and dynamically-discoverable targets (mem-slab descriptors, `CONFIG_I3C_NUM_OF_DESC_MEM_SLABS`) were never assigned a dynamic address.

This drops the `num_i3c > 0` condition so the bus initialises (and ENTDAA runs) regardless of whether DTS children are declared. The `I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT` opt-out is retained, matching the behaviour of every other I3C controller driver.

Depends on / coordinates with #110517.

