### PR TITLE
drivers: i2s: stm32_sai: support shared and separate kernel clocks

### DIFF
--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -121,8 +121,11 @@ struct stm32_sai_sub_cfg {
 };
 
 struct stm32_sai_cfg {
-	const struct stm32_pclken *pclken;
-	size_t pclk_len;
+	const struct stm32_pclken sai_ck;
+	const struct stm32_pclken sai_ker_ck;
+	const struct stm32_pclken sai_b_ker_ck; /* Dedicated to SAIn_B, if applicable */
+	bool has_sai_ker_ck: 1;
+	bool has_sai_b_ker_ck: 1;
 };
 
 void HAL_SAI_RxCpltCallback(SAI_HandleTypeDef *hsai)
@@ -285,16 +288,25 @@ static int stm32_sai_clock_en(const struct device *dev)
 	int ret;
 
 	/* Turn on SAI peripheral clock */
-	ret = clock_control_on(clk, (clock_control_subsys_t)&sai_cfg->pclken[0]);
+	ret = clock_control_on(clk, (clock_control_subsys_t)&sai_cfg->sai_ck);
 	if (ret != 0) {
 		return -EIO;
 	}
 
-	if (sai_cfg->pclk_len > 1) {
-		/* Enable SAI clock source */
-		ret = clock_control_configure(clk, (clock_control_subsys_t)&sai_cfg->pclken[1],
+	/* Configure shared SAIn_A & SAIn_B or dedicated SAIn_A kernel clock */
+	if (sai_cfg->has_sai_ker_ck) {
+		ret = clock_control_configure(clk, (clock_control_subsys_t)&sai_cfg->sai_ker_ck,
 					      NULL);
-		if (ret < 0) {
+		if (ret != 0) {
+			return -EIO;
+		}
+	}
+
+	/* Configure dedicated SAI B kernel clock */
+	if (sai_cfg->has_sai_b_ker_ck) {
+		ret = clock_control_configure(clk, (clock_control_subsys_t)&sai_cfg->sai_b_ker_ck,
+					      NULL);
+		if (ret != 0) {
 			return -EIO;
 		}
 	}
@@ -483,8 +495,8 @@ static int stm32_sai_sub_f4_clk_src_conf(const struct device *dev)
 	SAI_HandleTypeDef *hsai = &sub_data->hsai;
 	uint32_t clock_source = 0U;
 
-	if (sai_cfg->pclk_len > 1) {
-		clock_source = sai_cfg->pclken[1].bus;
+	if (sai_cfg->has_sai_ker_ck) {
+		clock_source = sai_cfg->sai_ker_ck.bus;
 	}
 
 	switch (clock_source) {
@@ -1055,15 +1067,24 @@ static DEVICE_API(i2s, i2s_stm32_sai_api) = {
 			 POST_KERNEL, CONFIG_I2S_INIT_PRIORITY, &i2s_stm32_sai_api);               \
 	K_MSGQ_DEFINE(queue_##node, sizeof(struct queue_item), CONFIG_I2S_STM32_SAI_BLOCK_COUNT, 4);
 
+#define SAI_KER_CK_FIELD_INIT(inst, n)                                                             \
+	COND_CODE_1(DT_INST_CLOCKS_HAS_NAME(inst, n),                                              \
+		(.n = STM32_DT_INST_CLOCK_INFO_BY_NAME(inst, n), .has_##n = true,),                \
+		(.has_##n = false,))
+
+#define SAI_KER_CK_INIT(inst)                                                                      \
+	SAI_KER_CK_FIELD_INIT(inst, sai_ker_ck)                                                    \
+	SAI_KER_CK_FIELD_INIT(inst, sai_b_ker_ck)
+
 /* Controller Node */
 #define SAI_INIT(inst)                                                                             \
-	static const struct stm32_pclken clk_##inst[] = STM32_DT_INST_CLOCKS(inst);                \
 	static const struct stm32_sai_cfg sai_cfg_##inst = {                                       \
-		.pclken = clk_##inst,                                                              \
-		.pclk_len = DT_INST_NUM_CLOCKS(inst),                                              \
+		.sai_ck = STM32_DT_INST_CLOCK_INFO_BY_NAME(inst, sai_ck),                          \
+		SAI_KER_CK_INIT(inst)                                                              \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, &sai_init, NULL, NULL, &sai_cfg_##inst, POST_KERNEL,           \
 			      CONFIG_I2S_INIT_PRIORITY, NULL);                                     \
+                                                                                                   \
 	DT_INST_FOREACH_CHILD_STATUS_OKAY(inst, SAI_SUB_INIT)
 
 DT_INST_FOREACH_STATUS_OKAY(SAI_INIT)

--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -89,6 +89,7 @@
 			reg = <0x40015800 0x400>;
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
+			clock-names = "sai_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015804 {

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -123,6 +123,7 @@
 			reg = <0x40015800 0x400>;
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
+			clock-names = "sai_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015804 {

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -179,6 +179,7 @@
 			reg = <0x40015800 0x400>;
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
+			clock-names = "sai_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015804 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -1079,6 +1079,7 @@
 		reg = <0x40015800 0x400>;
 		ranges;
 		clocks = <&rcc STM32_CLOCK(APB2, 22)>;
+		clock-names = "sai_ck";
 		status = "disabled";
 
 		sai1_a: sai1a@40015804 {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -784,6 +784,7 @@
 			reg = <0x40015400 0x400>;
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
+			clock-names = "sai_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -133,6 +133,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL1_Q SAI1_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1304,6 +1304,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015804 {

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -164,6 +164,35 @@
 			resets = <&rctl STM32_RESET(AHB3, 5)>;
 			status = "disabled";
 		};
+
+		sai2: sai2@40015c00 {
+			compatible = "st,stm32-sai";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x40015c00 0x400>;
+			ranges;
+			clocks = <&rcc STM32_CLOCK(APB2, 23)>,
+				 <&rcc STM32_SRC_PLL1_Q SAI2A_SEL(0)>,
+				 <&rcc STM32_SRC_PLL1_Q SAI2B_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck", "sai_b_ker_ck";
+			status = "disabled";
+
+			sai2_a: sai2a@40015c04 {
+				reg = <0x40015c04 0x20>;
+				dmas = <&dma1 2 89 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			sai2_b: sai2b@40015c24 {
+				reg = <0x40015c24 0x20>;
+				dmas = <&dma1 3 90 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
 	};
 
 	/* System data RAM accessible over AXI bus: AXI SRAM1 in CD domain */

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1085,6 +1085,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL3_P SAI1_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@42005804 {

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -129,6 +129,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -99,6 +99,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -179,6 +179,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -336,6 +336,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -479,6 +479,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -851,6 +851,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1512,6 +1512,7 @@
 				reg = <0x52005800 0x400>;
 				ranges;
 				clocks = <&rcc STM32_CLOCK(APB2, 21)>;
+				clock-names = "sai_ck";
 				status = "disabled";
 
 				sai1_a: sai1a@52005804 {
@@ -1540,6 +1541,7 @@
 				reg = <0x52005c00 0x400>;
 				ranges;
 				clocks = <&rcc STM32_CLOCK(APB2, 22)>;
+				clock-names = "sai_ck";
 				status = "disabled";
 
 				sai2_a: sai2a@52005c04 {

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -505,6 +505,7 @@
 			reg = <0x40015400 0x400>;
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
+			clock-names = "sai_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -547,6 +547,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {

--- a/dts/arm/st/wba/stm32wba55.dtsi
+++ b/dts/arm/st/wba/stm32wba55.dtsi
@@ -18,6 +18,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL1_P SAI1_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {

--- a/dts/bindings/i2s/st,stm32-sai.yaml
+++ b/dts/bindings/i2s/st,stm32-sai.yaml
@@ -15,6 +15,28 @@ properties:
     type: compound
     required: true
 
+  clock-names:
+    required: true
+    enum:
+      - "sai_ck"
+      - "sai_ker_ck"
+      - "sai_b_ker_ck"
+    description: |
+      Expected names are the following:
+      - "sai_ck" for configuring the peripheral bus clock
+      - "sai_ker_ck" for configuring a shared SAI or dedicated SAI A kernel clock
+      - "sai_b_ker_ck" for configuring a dedicated SAI B kernel clock
+
+      Depending on the platform, SAI A and SAI B may either share a single
+      kernel clock selector or have independent selectors.
+
+      - Platforms with independent kernel clock selectors must provide the kernel clock
+      corresponding to each enabled SAI node.
+      For example, "sai_ker_ck" is required for SAI A and "sai_b_ker_ck" for SAI B.
+
+      - Platforms with a shared kernel clock selector only need to provide "sai_ker_ck",
+      which applies to both SAI A and SAI B.
+
   "#address-cells":
     const: 1
 

--- a/include/zephyr/dt-bindings/clock/stm32h7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7_clock.h
@@ -8,6 +8,8 @@
 
 #include "stm32_common_clocks.h"
 
+/** @cond INTERNAL_HIDDEN */
+
 /** Domain clocks */
 
 /* RM0468, Table 56 Kernel clock dictribution summary */
@@ -85,6 +87,9 @@
 /** D2CCIP1R devices */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, D2CCIP1R_REG)
 #define SAI23_SEL(val)		STM32_DT_CLOCK_SELECT((val), 8, 6, D2CCIP1R_REG)
+/* Device domain clocks selection helpers for SAI2A and SAI2B (RM0455.pdf) */
+#define SAI2A_SEL(val)		SAI23_SEL(val)
+#define SAI2B_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 9, D2CCIP1R_REG)
 #define SPI123_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, D2CCIP1R_REG)
 #define SPI45_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, D2CCIP1R_REG)
 #define SPDIF_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, D2CCIP1R_REG)
@@ -147,5 +152,7 @@
 #define MCO2_SEL_PLL1PCLK	3
 #define MCO2_SEL_CSI		4
 #define MCO2_SEL_LSI		5
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7_CLOCK_H_ */

--- a/samples/drivers/i2s/output/boards/nucleo_h7a3zi_q.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_h7a3zi_q.conf
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Mario Paja
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_h7a3zi_q.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_h7a3zi_q.overlay
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Mario Paja
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		i2s-tx = &sai2_a;
+	};
+};
+
+&pll2 {
+	/* 44.1KHz (0.03% Error) - PLL2_P SAI2A_SEL(1)  */
+	div-m = <8>;
+	mul-n = <192>;
+	div-q = <2>;
+	div-r = <2>;
+	div-p = <17>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+/*
+ * SAI2 clock configuration examples
+ *
+ * Alternative: SAI2B using PLL3_P
+ *
+ * PLL3 configuration:
+ *
+ *   &pll3 {
+ *           div-m = <8>;
+ *           mul-n = <184>;
+ *           div-q = <2>;
+ *           div-r = <2>;
+ *           div-p = <17>;
+ *           clocks = <&clk_hse>;
+ *           status = "okay";
+ *   };
+ *
+ * SAI2B only:
+ *
+ *   &sai2 {
+ *           status = "okay";
+ *           clocks = <&rcc STM32_CLOCK(APB2, 23)>,
+ *                    <&rcc STM32_SRC_PLL3_P SAI2B_SEL(2)>;
+ *           clock-names = "sai_ck", "sai_b_ker_ck";
+ *   };
+ *
+ * SAI2A + SAI2B:
+ *
+ *   &sai2 {
+ *           status = "okay";
+ *           clocks = <&rcc STM32_CLOCK(APB2, 23)>,
+ *                    <&rcc STM32_SRC_PLL2_P SAI2A_SEL(1)>,
+ *                    <&rcc STM32_SRC_PLL3_P SAI2B_SEL(2)>;
+ *   };
+ */
+&sai2 {
+	status = "okay";
+	clocks = <&rcc STM32_CLOCK(APB2, 23)>,
+		 <&rcc STM32_SRC_PLL2_P SAI2A_SEL(1)>;
+	clock-names = "sai_ck", "sai_ker_ck";
+};
+
+/*
+ * Optional SAI2B configuration.
+ *
+ * Enable this node when using the SAI2B sub-block. The example below
+ * configures:
+ *   - MCLK output enabled
+ *   - MCLK divider set to 256
+ *   - TX DMA channel
+ *   - Pin multiplexing for MCLK, SD, FS, and SCK
+ *
+ * &sai2_b {
+ *         pinctrl-0 = <&sai2_mclk_b_pe6 &sai2_sd_b_pa0
+ *                      &sai2_fs_b_pc0 &sai2_sck_b_pa2>;
+ *         pinctrl-names = "default";
+ *         mclk-enable;
+ *         mclk-divider = "div-256";
+ *         dma-names = "tx";
+ *         status = "okay";
+ * };
+ */
+&sai2_a {
+	pinctrl-0 = <&sai2_mclk_a_pe0 &sai2_sd_a_pd11
+		     &sai2_fs_a_pd12 &sai2_sck_a_pd13>;
+	pinctrl-names = "default";
+	status = "okay";
+	mclk-enable;
+	mclk-divider = "div-256";
+	dma-names = "tx";
+};
+
+&dma1 {
+	status = "okay";
+};

--- a/samples/drivers/i2s/output/boards/nucleo_n657x0_q.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_n657x0_q.overlay
@@ -34,6 +34,7 @@
 	status = "okay";
 	clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 		 <&rcc STM32_SRC_IC7 SAI2_SEL(2)>;
+	clock-names = "sai_ck", "sai_ker_ck";
 };
 
 &sai2_b {


### PR DESCRIPTION
Some STM32 SAI nodes may expose a shared kernel clock for both sub-blocks, while others may provide different kernel clocks for sub-block A and sub-block B.

These changes allow the driver to handle SAI nodes with different kernel clock layouts. Nodes with sai_ker_ck use a shared kernel clock for both sub-blocks, while nodes with sai_a_ker_ck and sai_b_ker_ck use separate kernel clocks for each sub-block.