### PR TITLE
drivers: ethernet: dwc_mac: 1000: Advertise real capabilities

### DIFF
--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -56,14 +56,24 @@ static uint32_t phys_lo32(void *addr)
 	return (uint32_t)(uintptr_t)addr;
 }
 
-static enum ethernet_hw_caps dwmac_caps(const struct device *dev __unused,
-					struct net_if *iface __unused)
+static enum ethernet_hw_caps dwmac_caps(const struct device *dev, struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
+	struct dwmac_priv *p = dev->data;
+	enum ethernet_hw_caps caps = 0;
+
+	if (p->feature0 & DWMAC_HWFR_1000) {
+		caps |= ETHERNET_LINK_1000BASE;
+	}
+
+	if (p->feature0 & DWMAC_HWFR_10_100) {
+		caps |= ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
+	}
+
 #ifdef CONFIG_NET_PROMISCUOUS_MODE
-	       | ETHERNET_PROMISC_MODE
+	caps |= ETHERNET_PROMISC_MODE;
 #endif
-		;
+
+	return caps;
 }
 
 static __maybe_unused unsigned int net_pkt_get_nbfrags(struct net_pkt *pkt)
@@ -437,6 +447,10 @@ int dwmac_probe(const struct device *dev)
 
 	reg_val = REG_READ(DWMAC_MACVERR);
 	LOG_INF("HW version %u.%u0", (reg_val >> 4) & 0xf, reg_val & 0xf);
+
+	/* get configured hardware features */
+	p->feature0 = REG_READ(DWMAC_HWFR);
+	LOG_DBG("hw_feature: 0x%08x", p->feature0);
 
 	ret = dwmac_platform_init(dev);
 	if (ret < 0) {

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -435,7 +435,7 @@ int dwmac_probe(const struct device *dev)
 		}
 	}
 
-	reg_val = REG_READ(MAC_VERSION);
+	reg_val = REG_READ(DWMAC_MACVERR);
 	LOG_INF("HW version %u.%u0", (reg_val >> 4) & 0xf, reg_val & 0xf);
 
 	ret = dwmac_platform_init(dev);

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -106,8 +106,8 @@ struct dwmac_priv {
 
 	uint8_t mac_addr[6];
 
-#ifdef CONFIG_ETH_DWC_ETHER_QOS_CORE
 	uint32_t feature0;
+#ifdef CONFIG_ETH_DWC_ETHER_QOS_CORE
 	uint32_t feature1;
 	uint32_t feature2;
 	uint32_t feature3;
@@ -1286,6 +1286,7 @@ extern const struct ethernet_api dwmac_api;
 #define DWMAC_DMASR        0x1014
 #define DWMAC_DMAOMR       0x1018
 #define DWMAC_DMAIER       0x101C
+#define DWMAC_HWFR         0x1058
 
 /* MAC control bits */
 #define DWMAC_MACCR_RE     BIT(2)
@@ -1322,6 +1323,25 @@ extern const struct ethernet_api dwmac_api;
 #define DWMAC_DMAIER_RBUIE BIT(7)
 #define DWMAC_DMAIER_AISE  BIT(15)
 #define DWMAC_DMAIER_NISE  BIT(16)
+
+/* Hardware Feature Register */
+#define DWMAC_HWFR_10_100  BIT(0)
+#define DWMAC_HWFR_1000    BIT(1)
+#define DWMAC_HWFR_HD      BIT(2)
+#define DWMAC_HWFR_HASHF   BIT(4)
+#define DWMAC_HWFR_ADDMAC  BIT(5)
+#define DWMAC_HWFR_PCS     BIT(6)
+#define DWMAC_HWFR_SMA     BIT(8)
+#define DWMAC_HWFR_PMTW    BIT(9)
+#define DWMAC_HWFR_PMTM    BIT(10)
+#define DWMAC_HWFR_RMON    BIT(11)
+#define DWMAC_HWFR_TS2002  BIT(12)
+#define DWMAC_HWFR_TS2008  BIT(13)
+#define DWMAC_HWFR_TX_CHK  BIT(16)
+#define DWMAC_HWFR_RXCHKV1 BIT(17)
+#define DWMAC_HWFR_RXCHKV2 BIT(18)
+#define DWMAC_HWFR_FIFO2K  BIT(19)
+#define DWMAC_HWFR_ALTDESC BIT(24)
 
 /* DWMAC v3.x MDIO registers (GMAC core) */
 #define MAC_MDIO_ADDRESS 0x0010

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -1274,6 +1274,7 @@ extern const struct ethernet_api dwmac_api;
 /* GMAC register map */
 #define DWMAC_MACCR      0x0000
 #define DWMAC_MACFFR     0x0004
+#define DWMAC_MACVERR    0x0020
 #define DWMAC_MACA0HR    0x0040
 #define DWMAC_MACA0LR    0x0044
 
@@ -1334,8 +1335,6 @@ extern const struct ethernet_api dwmac_api;
 
 #define MAC_MDIO_DATA_RA GENMASK(31, 16)
 #define MAC_MDIO_DATA_GD GENMASK(15, 0)
-
-#define MAC_VERSION 0x0020
 
 #endif /* CONFIG_ETH_DWC_ETHER_1000_CORE */
 


### PR DESCRIPTION
Utilize the feature register to advertise caps based on real hardware features instead of hardcoded values.