### PR TITLE
drivers: ethernet: stm32: fix clang error

### DIFF
--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -757,7 +757,6 @@ int eth_stm32_hal_set_config(const struct device *dev,
 
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
-		BUILD_ASSERT(sizeof(dev_data->mac_addr) == sizeof(config->mac_address.addr));
 		memcpy(dev_data->mac_addr, config->mac_address.addr,
 		       sizeof(dev_data->mac_addr));
 		heth->Instance->MACA0HR = (dev_data->mac_addr[5] << 8) |


### PR DESCRIPTION
Fix error reported by clang:
```
/home/user/west_workspace/zephyr/drivers/ethernet/eth_stm32_hal_v2.c:760:3: warning: label followed by a declaration is a C23 extension [-Wc23-extensions]
  760 |                 BUILD_ASSERT(sizeof(dev_data->mac_addr) == sizeof(config->mac_address.addr));
      |                 ^
/home/user/west_workspace/zephyr/include/zephyr/toolchain/llvm.h:46:36: note: expanded from macro 'BUILD_ASSERT'
   46 | #define BUILD_ASSERT(EXPR, MSG...) _Static_assert((EXPR), "" MSG)
      | 
```