### PR TITLE
dts: bindings: adc: document ti,mspm0-adc12 properties

### DIFF
--- a/dts/bindings/adc/ti,mspm0-adc12.yaml
+++ b/dts/bindings/adc/ti,mspm0-adc12.yaml
@@ -56,12 +56,26 @@ properties:
       - 24
       - 32
       - 48
+    description: |
+      Divider applied to the ADC sample clock source. Together with
+      ti,clk-range it sets the ADC sample clock: the effective sampling
+      period scales with this divider. A value of 1 leaves the clock
+      undivided.
 
   auto-powerdown:
     type: boolean
+    description: |
+      Enable automatic power-down mode, in which the ADC powers down
+      between conversions to reduce power consumption. When omitted, the
+      ADC uses manual power-down mode and stays powered between conversions.
 
   vref:
     type: phandle
+    description: |
+      Phandle to the voltage reference regulator supplying the ADC
+      reference voltage. This may be the on-chip VREF module or an external
+      reference. The driver reads the referenced regulator's configured
+      output voltage to determine the reference voltage in millivolts.
 
   max-result-reg:
     type: int


### PR DESCRIPTION
## Description

The `ti,clk-divider`, `auto-powerdown` and `vref` properties of the
`ti,mspm0-adc12` ADC binding were declared without a `description:`,
leaving their semantics unclear to anyone writing a devicetree node.

This adds descriptions documenting:

- **`ti,clk-divider`** – the divider's effect on the ADC sample clock
  (used together with `ti,clk-range`).
- **`auto-powerdown`** – manual vs. automatic power-down behaviour, and
  the default when the property is omitted.
- **`vref`** – how the referenced regulator's configured output voltage
  is used to derive the ADC reference voltage in millivolts.

Documentation-only change; no functional behaviour is affected and no
driver code is touched.

## Type of change

- [x] Documentation

## Testing

- Binding validated against Zephyr's `.yamllint` rules (line length,
  indentation, trailing whitespace, EOF newline) and confirmed to parse
  as valid YAML.
- Documentation-only change; relies on CI for the full compliance suite.
