### PR TITLE
tcp: recv: restore packet queue when peeking

### DIFF
--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1458,6 +1458,7 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 	const bool do_recv = !(buf == NULL || max_len == NULL);
 	size_t _max_len = (max_len == NULL) ? SIZE_MAX : *max_len;
 	const bool peek = (flags & ZSOCK_MSG_PEEK) == ZSOCK_MSG_PEEK;
+	const struct net_pkt *head = k_fifo_peek_head(&ctx->recv_q);
 
 	while (_max_len > 0) {
 		/* only peek until we know we can dequeue and / or requeue buffer */
@@ -1505,8 +1506,11 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 
 				net_pkt_unref(pkt);
 			}
-		} else if (!do_recv || peek) {
-			/* requeue packets when observing */
+		} else if ((!do_recv || peek) && _max_len > 0) {
+			/* requeue packets when observing, do not requeue if it is the last packet
+			 * as it will be requeued below. This allows to skip requeuing when
+			 * observing only the first packet
+			 */
 			k_fifo_put(&ctx->recv_q, k_fifo_get(&ctx->recv_q, K_NO_WAIT));
 		}
 	}
@@ -1514,6 +1518,11 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 	if (do_recv) {
 		/* convey remaining buffer size back to caller */
 		*max_len = _max_len;
+	}
+
+	/* when observing, the queue should return to the initial state */
+	while ((!do_recv || peek) && k_fifo_peek_head(&ctx->recv_q) != head) {
+		k_fifo_put(&ctx->recv_q, k_fifo_get(&ctx->recv_q, K_NO_WAIT));
 	}
 
 	return recv_len;

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -784,6 +784,9 @@ void tcp_server_block_thread(void *vps_sock, void *unused2, void *unused3)
 			chunk_size = remain;
 		}
 
+		/* Validate that peeking doesn't affect the next recv */
+		recved = zsock_recv(new_sock, buffer, 1, ZSOCK_MSG_PEEK);
+
 		recved = zsock_recv(new_sock, buffer, chunk_size, 0);
 
 		zassert(recved > 0, "received bigger then 0",


### PR DESCRIPTION
Addressing the issue for which packets may be reordered after a peek on TCP socket. The process of re queuing an observed packet may be incomplete, when the peek size is not large enough to visit all the packets in the queue.