### PR TITLE
xtensa: use inline asm for atomic functions using exclusive

### DIFF
--- a/include/zephyr/arch/xtensa/atomic_xtensa.h
+++ b/include/zephyr/arch/xtensa/atomic_xtensa.h
@@ -13,7 +13,8 @@
 /* Recent GCC versions actually do have working atomics support on
  * Xtensa with S32C1I and so should work with CONFIG_ATOMIC_OPERATIONS_BUILTIN.
  * Existing versions of Xtensa's XCC do not and GCC also do not support
- * L32EX/S32EX.  So we define an inline implementation here for atomic CAS.
+ * L32EX/S32EX.  So we need to define our own versions of atomic operations
+ * if we have exclusive access.
  */
 
 /** Implementation of @ref atomic_get. */
@@ -32,9 +33,239 @@ static ALWAYS_INLINE atomic_val_t atomic_get(const atomic_t *target)
 	return ret;
 }
 
+#if XCHAL_HAVE_EXCLUSIVE || defined(__DOXYGEN__)
+
+/** Implementation of @ref atomic_cas. */
+static ALWAYS_INLINE
+bool atomic_cas(atomic_t *target, atomic_val_t oldval, atomic_val_t newval)
+{
+	atomic_val_t mem_val;
+	uint32_t result = 0;
+
+	__asm__ volatile(
+		"	l32ex %0, %3	;" /* mem_val = *addr and set exclusive monitor		*/
+		"	bne %0, %4, 1f	;" /* Goto 1 if mem_val != oldval			*/
+		"	s32ex %1, %3	;" /* Try exclusive store *addr = newval		*/
+		"	getex %2	;" /* Get exclusive store result			*/
+		"	j 2f		;" /* Store success so jump to 2 to return		*/
+		"			;"
+		"1:			;" /* 1: Fail as *addr has unexpected value		*/
+		"	clrex		;" /*    Clear the monitor and return			*/
+		"			;"
+		"2:			;"
+		: "=&r"(mem_val), "+&r"(newval), "+&r"(result)
+		: "r"(target), "r"(oldval)
+		: "memory");
+
+	return result == 1;
+}
+
+/** Implementation of @ref atomic_ptr_cas. */
+static ALWAYS_INLINE
+bool atomic_ptr_cas(atomic_ptr_t *target, void *oldval, void *newval)
+{
+	return atomic_cas((atomic_t *)target, (atomic_val_t)oldval, (atomic_val_t)newval);
+}
+
+/** Implementation of @ref atomic_set. */
+static ALWAYS_INLINE
+atomic_val_t atomic_set(atomic_t *target, atomic_val_t value)
+{
+	atomic_val_t oldval;
+	uint32_t result;
+
+	do {
+		__asm__ volatile(
+			"l32ex %0, %2	;" /* oldval = *target and set exclusive monitor	*/
+			"mov %1, %3	;" /* S32EX writes to %1, so we need scratch register	*/
+			"s32ex %1, %2	;" /* Try exclusive store *target = value		*/
+			"getex %1	;" /* Get exclusive store result			*/
+			: "=&r"(oldval), "=&r"(result)
+			: "r"(target), "r"(value)
+			: "memory");
+	} while (result == 0);
+
+	return oldval;
+}
+
+/** Implementation of @ref atomic_add. */
+static ALWAYS_INLINE
+atomic_val_t atomic_add(atomic_t *target, atomic_val_t value)
+{
+	atomic_val_t oldval;
+	uint32_t result;
+
+	do {
+		__asm__ volatile(
+			"l32ex %0, %2	;" /* oldval = *target and set exclusive monitor	*/
+			"add %1, %0, %3	;" /* result = oldval + value				*/
+			"s32ex %1, %2	;" /* Try exclusive store *target = result		*/
+			"getex %1	;" /* Get exclusive store result			*/
+			: "=&r"(oldval), "=&r"(result)
+			: "r"(target), "r"(value)
+			: "memory");
+	} while (result == 0);
+
+	return oldval;
+}
+
+/** Implementation of @ref atomic_sub. */
+static ALWAYS_INLINE
+atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value)
+{
+	atomic_val_t oldval;
+	uint32_t result;
+
+	do {
+		__asm__ volatile(
+			"l32ex %0, %2	;" /* oldval = *target and set exclusive monitor	*/
+			"sub %1, %0, %3	;" /* result = oldval - value				*/
+			"s32ex %1, %2	;" /* Try exclusive store *target = result		*/
+			"getex %1	;" /* Get exclusive store result			*/
+			: "=&r"(oldval), "=&r"(result)
+			: "r"(target), "r"(value)
+			: "memory");
+	} while (result == 0);
+
+	return oldval;
+}
+
+/** Implementation of @ref atomic_inc. */
+static ALWAYS_INLINE
+atomic_val_t atomic_inc(atomic_t *target)
+{
+	atomic_val_t oldval;
+	uint32_t result;
+
+	do {
+		__asm__ volatile(
+			"l32ex %0, %2	;" /* oldval = *target and set exclusive monitor	*/
+			"addi %1, %0, 1	;" /* result = oldval + 1				*/
+			"s32ex %1, %2	;" /* Try exclusive store *target = result		*/
+			"getex %1	;" /* Get exclusive store result			*/
+			: "=&r"(oldval), "=&r"(result)
+			: "r"(target)
+			: "memory");
+	} while (result == 0);
+
+	return oldval;
+}
+
+/** Implementation of @ref atomic_dec. */
+static ALWAYS_INLINE
+atomic_val_t atomic_dec(atomic_t *target)
+{
+	atomic_val_t oldval;
+	uint32_t result;
+
+	do {
+		__asm__ volatile(
+			"l32ex %0, %2	;" /* oldval = *target and set exclusive monitor	*/
+			"addi %1, %0, -1;" /* result = oldval + (-1)				*/
+			"s32ex %1, %2	;" /* Try exclusive store *target = result		*/
+			"getex %1	;" /* Get exclusive store result			*/
+			: "=&r"(oldval), "=&r"(result)
+			: "r"(target)
+			: "memory");
+	} while (result == 0);
+
+	return oldval;
+}
+
+/** Implementation of @ref atomic_or. */
+static ALWAYS_INLINE atomic_val_t atomic_or(atomic_t *target, atomic_val_t value)
+{
+	atomic_val_t oldval;
+	uint32_t result;
+
+	do {
+		__asm__ volatile(
+			"l32ex %0, %2	;" /* oldval = *target and set exclusive monitor	*/
+			"or %1, %0, %3	;" /* result = oldval | value				*/
+			"s32ex %1, %2	;" /* Try exclusive store *target = result		*/
+			"getex %1	;" /* Get exclusive store result			*/
+			: "=&r"(oldval), "=&r"(result)
+			: "r"(target), "r"(value)
+			: "memory");
+	} while (result == 0);
+
+	return oldval;
+}
+
+/** Implementation of @ref atomic_xor. */
+static ALWAYS_INLINE atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value)
+{
+	atomic_val_t oldval;
+	uint32_t result;
+
+	do {
+		__asm__ volatile(
+			"l32ex %0, %2	;" /* oldval = *target and set exclusive monitor	*/
+			"xor %1, %0, %3	;" /* result = oldval ^ value				*/
+			"s32ex %1, %2	;" /* Try exclusive store *target = result		*/
+			"getex %1	;" /* Get exclusive store result			*/
+			: "=&r"(oldval), "=&r"(result)
+			: "r"(target), "r"(value)
+			: "memory");
+	} while (result == 0);
+
+	return oldval;
+}
+
+/** Implementation of @ref atomic_and. */
+static ALWAYS_INLINE atomic_val_t atomic_and(atomic_t *target,
+					     atomic_val_t value)
+{
+	atomic_val_t oldval;
+	uint32_t result;
+
+	do {
+		__asm__ volatile(
+			"l32ex %0, %2	;" /* oldval = *target and set exclusive monitor	*/
+			"and %1, %0, %3	;" /* result = oldval & value				*/
+			"s32ex %1, %2	;" /* Try exclusive store *target = result		*/
+			"getex %1	;" /* Get exclusive store result			*/
+			: "=&r"(oldval), "=&r"(result)
+			: "r"(target), "r"(value)
+			: "memory");
+	} while (result == 0);
+
+	return oldval;
+}
+
+/** Implementation of @ref atomic_nand. */
+static ALWAYS_INLINE atomic_val_t atomic_nand(atomic_t *target,
+					      atomic_val_t value)
+{
+	atomic_val_t oldval;
+	uint32_t result;
+
+	do {
+		__asm__ volatile(
+			"l32ex %0, %2	;" /* oldval = *target and set exclusive monitor	*/
+			"and %1, %0, %3	;" /* result = oldval & value				*/
+			"neg %1, %1	;" /* result = 0 - result - 1 as bitwise NOT		*/
+			"addi %1, %1, -1;"
+			"s32ex %1, %2	;" /* Try exclusive store *target = result		*/
+			"getex %1	;" /* Get exclusive store result			*/
+			: "=&r"(oldval), "=&r"(result)
+			: "r"(target), "r"(value)
+			: "memory");
+	} while (result == 0);
+
+	return oldval;
+}
+
+#elif XCHAL_HAVE_S32C1I
+
 /**
- * @fn static atomic_val_t xtensa_cas(atomic_t *addr, atomic_val_t oldval, atomic_val_t newval)
  * @brief Xtensa specific atomic compare-and-set (CAS).
+ *
+ * This utilizes SCOMPARE1 register and s32c1i instruction to
+ * perform compare-and-set atomic operation. This will
+ * unconditionally read from the atomic variable at @p addr
+ * before the comparison. This value is returned from
+ * the function.
  *
  * @param addr Address of atomic variable.
  * @param oldval Original value to compare against.
@@ -43,53 +274,6 @@ static ALWAYS_INLINE atomic_val_t atomic_get(const atomic_t *target)
  * @return The value at the memory location before CAS.
  *
  * @see atomic_cas.
- */
-
-#if XCHAL_HAVE_EXCLUSIVE || defined(__DOXYGEN__)
-
-/*
- * This utilizes L32EX/S32EX instructions to perform compare-and-set atomic
- * operation. This will unconditionally read from the atomic variable at @p addr
- * before the comparison. This value is returned from the function.
- */
-static ALWAYS_INLINE
-atomic_val_t xtensa_cas(atomic_t *addr, atomic_val_t oldval,
-			atomic_val_t newval)
-{
-	atomic_val_t mem_val;
-	uint32_t v = newval;
-
-	/* Read from address and mark it for exclusive access. */
-	__asm__ volatile("l32ex %0, %1" : "=r"(mem_val) : "r"(addr));
-
-	if (mem_val == oldval) {
-		uint32_t result;
-
-		__asm__ volatile("s32ex %1, %2; getex %0" : "=r"(result), "+r"(v) : "r"(addr));
-
-		/* If GETEX returns store successful, we return the old value.
-		 * Otherwise, we must return some other value to signal that
-		 * the store failed to function caller.
-		 */
-		return (result == 1U) ? oldval : ~oldval;
-	}
-
-	/* Since *addr != oldval, we skip writing to memory and
-	 * need to remove the exclusive lock before returning.
-	 */
-	__asm__("clrex");
-
-	return mem_val;
-}
-
-#elif XCHAL_HAVE_S32C1I
-
-/*
- * This utilizes SCOMPARE1 register and s32c1i instruction to
- * perform compare-and-set atomic operation. This will
- * unconditionally read from the atomic variable at @p addr
- * before the comparison. This value is returned from
- * the function.
  */
 static ALWAYS_INLINE
 atomic_val_t xtensa_cas(atomic_t *addr, atomic_val_t oldval,
@@ -100,10 +284,6 @@ atomic_val_t xtensa_cas(atomic_t *addr, atomic_val_t oldval,
 
 	return newval; /* got swapped with the old memory by s32c1i */
 }
-
-#else
-#error "No available hardware support for atomic operations"
-#endif
 
 /** Implementation of @ref atomic_cas. */
 static ALWAYS_INLINE
@@ -196,6 +376,10 @@ static ALWAYS_INLINE atomic_val_t atomic_nand(atomic_t *target,
 {
 	return Z__GEN_ATOMXCHG(~(cur & value));
 }
+
+#else
+#error "No available hardware support for atomic operations"
+#endif
 
 /** Implementation of @ref atomic_ptr_get. */
 static ALWAYS_INLINE void *atomic_ptr_get(const atomic_ptr_t *target)


### PR DESCRIPTION
The previous atomic implementation is tailored for using with S32C1I, and it is only for compare and store. Therefore, the macro Z__GEN_ATOMXCHG() is needed to do the loading part before we can change the values and store. With exclusive access, we now have a pair of load (L32EX) and store (S32EX). If we continue to use that macro, there would be two loads which is rather wasteful. So rework the atomic functions when we have exclusive access to utilize inline assembly for those operations.