### PR TITLE
add missing tests for lifo, fifo, timer and msgq

### DIFF
--- a/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
@@ -196,6 +196,38 @@ ZTEST(fifo_api, test_fifo_is_empty_isr)
 	/**TESTPOINT: check fifo is empty from isr*/
 	irq_offload((irq_offload_routine_t)tfifo_is_empty, &fifo);
 }
+
+/**
+ * @brief Test peeking at the front and back items of a FIFO
+ *
+ * @details Enqueue two data items, then use k_fifo_peek_head() and
+ * k_fifo_peek_tail() to inspect the items at the front and back of the FIFO and
+ * verify the returned pointers match the first and last enqueued items without
+ * removing them (a subsequent get still returns both items in order). Peeking an
+ * empty FIFO returns NULL.
+ *
+ * @ingroup kernel_fifo_tests
+ * @see k_fifo_peek_head(), k_fifo_peek_tail()
+ */
+ZTEST(fifo_api, test_fifo_peek)
+{
+	k_fifo_init(&fifo);
+
+	k_fifo_put(&fifo, (void *)&data[0]);
+	k_fifo_put(&fifo, (void *)&data[1]);
+
+	/**TESTPOINT: peek front and back without removing*/
+	zassert_equal(k_fifo_peek_head(&fifo), (void *)&data[0]);
+	zassert_equal(k_fifo_peek_tail(&fifo), (void *)&data[1]);
+
+	/* Peeking does not dequeue: both items are still retrievable in order. */
+	zassert_equal(k_fifo_get(&fifo, K_NO_WAIT), (void *)&data[0]);
+	zassert_equal(k_fifo_get(&fifo, K_NO_WAIT), (void *)&data[1]);
+
+	/**TESTPOINT: peek of an empty fifo returns NULL*/
+	zassert_is_null(k_fifo_peek_head(&fifo));
+	zassert_is_null(k_fifo_peek_tail(&fifo));
+}
 /**
  * @}
  */

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
@@ -228,6 +228,32 @@ ZTEST(fifo_api, test_fifo_peek)
 	zassert_is_null(k_fifo_peek_head(&fifo));
 	zassert_is_null(k_fifo_peek_tail(&fifo));
 }
+
+K_HEAP_DEFINE(fifo_alloc_pool, 256);
+
+/**
+ * @brief Test enqueuing a data item to a FIFO with implicit memory allocation
+ *
+ * @details Use k_fifo_alloc_put() to enqueue a data item that does not reserve
+ * space for the bookkeeping word, so the kernel allocates the container from the
+ * calling thread's resource pool. Verify the call succeeds and that the same
+ * data pointer is returned by a subsequent get.
+ *
+ * @ingroup kernel_fifo_tests
+ * @see k_fifo_alloc_put()
+ */
+ZTEST(fifo_api, test_fifo_alloc_put)
+{
+	static uint32_t payload = 0xDEADBEEF;
+
+	k_fifo_init(&fifo);
+	k_thread_heap_assign(k_current_get(), &fifo_alloc_pool);
+
+	/**TESTPOINT: allocate the queue container from the thread resource pool*/
+	zassert_equal(k_fifo_alloc_put(&fifo, &payload), 0);
+
+	zassert_equal(k_fifo_get(&fifo, K_NO_WAIT), (void *)&payload);
+}
 /**
  * @}
  */

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
@@ -130,6 +130,32 @@ ZTEST(lifo_contexts, test_lifo_isr2thread)
 	tlifo_isr_thread(&klifo);
 }
 
+K_HEAP_DEFINE(lifo_alloc_pool, 256);
+
+/**
+ * @brief Test enqueuing a data item to a LIFO with implicit memory allocation
+ *
+ * @details Use k_lifo_alloc_put() to enqueue a data item that does not reserve
+ * space for the bookkeeping word, so the kernel allocates the container from the
+ * calling thread's resource pool. Verify the call succeeds and that the same
+ * data pointer is returned by a subsequent get.
+ *
+ * @ingroup kernel_lifo_tests
+ * @see k_lifo_alloc_put()
+ */
+ZTEST(lifo_contexts, test_lifo_alloc_put)
+{
+	static uint32_t payload = 0xDEADBEEF;
+
+	k_lifo_init(&lifo);
+	k_thread_heap_assign(k_current_get(), &lifo_alloc_pool);
+
+	/**TESTPOINT: allocate the queue container from the thread resource pool*/
+	zassert_equal(k_lifo_alloc_put(&lifo, &payload), 0);
+
+	zassert_equal(k_lifo_get(&lifo, K_NO_WAIT), (void *)&payload);
+}
+
 /**
  * @}
  */

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
@@ -521,5 +521,41 @@ ZTEST(msgq_api_1cpu, test_msgq_thread_pending)
 }
 
 /**
+ * @brief Test peeking at a message by index without removing it
+ *
+ * @details Put two distinct messages into a message queue, then use
+ * k_msgq_peek_at() to read the message at each valid index and verify the
+ * returned values match what was enqueued, without removing them (the used
+ * count stays unchanged). Also verify that peeking at an index beyond the
+ * number of queued messages returns -ENOMSG.
+ *
+ * @ingroup kernel_message_queue_tests
+ * @see k_msgq_peek_at()
+ */
+ZTEST_USER(msgq_api, test_msgq_peek_at)
+{
+	uint32_t read_data;
+
+	k_msgq_purge(&kmsgq);
+
+	zassert_equal(k_msgq_put(&kmsgq, &data[0], K_NO_WAIT), 0);
+	zassert_equal(k_msgq_put(&kmsgq, &data[1], K_NO_WAIT), 0);
+
+	/* Peek at each index; messages are queued FIFO so index 0 is oldest. */
+	zassert_equal(k_msgq_peek_at(&kmsgq, &read_data, 0), 0);
+	zassert_equal(read_data, data[0]);
+	zassert_equal(k_msgq_peek_at(&kmsgq, &read_data, 1), 0);
+	zassert_equal(read_data, data[1]);
+
+	/* Peeking must not remove any message. */
+	zassert_equal(k_msgq_num_used_get(&kmsgq), MSGQ_LEN);
+
+	/* An index at or beyond the number of queued messages returns -ENOMSG. */
+	zassert_equal(k_msgq_peek_at(&kmsgq, &read_data, MSGQ_LEN), -ENOMSG);
+
+	k_msgq_purge(&kmsgq);
+}
+
+/**
  * @}
  */

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -939,6 +939,47 @@ ZTEST_USER(timer_api, test_sleep_abs)
 
 }
 
+static struct k_timer isr_ctx_timer;
+static volatile bool isr_ctx_expiry_ran;
+static volatile bool isr_ctx_expiry_in_isr;
+
+static void isr_ctx_expire(struct k_timer *timer)
+{
+	isr_ctx_expiry_in_isr = k_is_in_isr();
+	isr_ctx_expiry_ran = true;
+}
+
+/**
+ * @brief Test that a timer expiry function runs in interrupt context
+ *
+ * @ingroup kernel_timer_tests
+ *
+ * @details Start a one-shot timer whose expiry callback records, via
+ * k_is_in_isr(), whether it executes in interrupt context. After the timer has
+ * expired, verify the callback ran and that it observed itself running in
+ * interrupt context.
+ *
+ * @see k_timer_start(), k_is_in_isr()
+ */
+ZTEST(timer_api, test_timer_expiry_in_isr)
+{
+	isr_ctx_expiry_ran = false;
+	isr_ctx_expiry_in_isr = false;
+
+	k_timer_init(&isr_ctx_timer, isr_ctx_expire, NULL);
+	k_timer_start(&isr_ctx_timer, K_MSEC(DURATION), K_NO_WAIT);
+
+	/* Wait long enough for the one-shot timer to expire. */
+	k_msleep(DURATION * 2);
+
+	zassert_true(isr_ctx_expiry_ran,
+		     "timer expiry function did not run");
+	zassert_true(isr_ctx_expiry_in_isr,
+		     "timer expiry function did not run in interrupt context");
+
+	k_timer_stop(&isr_ctx_timer);
+}
+
 static void timer_init(struct k_timer *timer, k_timer_expiry_t expiry_fn,
 		       k_timer_stop_t stop_fn)
 {


### PR DESCRIPTION
- **tests: kernel: timer: verify expiry function runs in interrupt context**
- **tests: kernel: lifo: add implicit-allocation enqueue test**
- **tests: kernel: msgq: add peek-by-index test**
- **tests: kernel: fifo: add peek front/back test**
- **tests: kernel: fifo: add implicit-allocation enqueue test**
