### PR TITLE
tests: drivers: dma: loop_transfer: add cache coherence support

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/boards/sama7g54_ek.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/sama7g54_ek.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2026 Microchip Technology Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS=3
+CONFIG_DMA_TRANSFER_CHANNEL_NR_0=4
+CONFIG_DMA_TRANSFER_CHANNEL_NR_1=7

--- a/tests/drivers/dma/chan_blen_transfer/boards/sama7g54_ek.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/sama7g54_ek.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {};
+
+tst_dma1: &dma1 {};
+
+tst_dma2: &dma2 {};

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -17,6 +17,7 @@
  *   -# Data is transferred correctly from src to dest
  */
 
+#include <zephyr/cache.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/dma.h>
 #include <zephyr/ztest.h>
@@ -114,6 +115,14 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 
 	k_sem_reset(&transfer_end_sem);
 
+	/*
+	 * Flush tx_data so the DMA reads committed data from memory, and
+	 * invalidate rx_data (including guard area) so the CPU will not observe
+	 * stale cache lines after the DMA writes to it.
+	 */
+	sys_cache_data_flush_range(tx_data, TEST_BUF_SIZE);
+	sys_cache_data_flush_and_invd_range(rx_data, TEST_BUF_SIZE + GUARD_BUF_SIZE);
+
 	if (dma_start(dma, chan_id)) {
 		TC_PRINT("ERROR: transfer\n");
 		return TC_FAIL;
@@ -137,6 +146,12 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 		TC_PRINT("DMA transfer error\n");
 		return TC_FAIL;
 	}
+
+	/*
+	 * Invalidate rx_data again after DMA completion to ensure the CPU reads
+	 * what the DMA actually wrote, not any speculatively cached lines.
+	 */
+	sys_cache_data_invd_range(rx_data, TEST_BUF_SIZE + GUARD_BUF_SIZE);
 
 	TC_PRINT("DMA transfer successful\n");
 	TC_PRINT("%s\n", rx_data);

--- a/tests/drivers/dma/loop_transfer/boards/sama7g54_ek.conf
+++ b/tests/drivers/dma/loop_transfer/boards/sama7g54_ek.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2026 Microchip Technology Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=7

--- a/tests/drivers/dma/loop_transfer/boards/sama7g54_ek.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/sama7g54_ek.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dma-test-devs = <&dma0>, <&dma1>, <&dma2>;
+	};
+};

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -24,6 +24,7 @@
 
 #include <zephyr/kernel.h>
 
+#include <zephyr/cache.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/dma.h>
 #include <zephyr/pm/device.h>
@@ -60,9 +61,22 @@ static const struct device *const dma_test_devs[] = {
 	LISTIFY(DMA_TEST_DEV_COUNT, DMA_TEST_DEV_GET, (,))
 };
 
+/*
+ * Place DMA buffers in non-cacheable memory when a D-cache is present, so that
+ * DMA reads and writes are coherent without explicit cache maintenance.
+ * Fall back to ordinary BSS when no D-cache exists or no nocache region is
+ * configured, in which case sys_cache_data_flush/invd_range() are no-ops.
+ */
+#if defined(CONFIG_DCACHE) && defined(CONFIG_NOCACHE_MEMORY)
+static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE]
+	__used __nocache;
+static __aligned(DMA_DATA_ALIGNMENT) uint8_t
+	rx_data[TRANSFER_LOOPS][CONFIG_DMA_LOOP_TRANSFER_SIZE] __used __nocache;
+#else
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE];
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t
 	rx_data[TRANSFER_LOOPS][CONFIG_DMA_LOOP_TRANSFER_SIZE] = { { 0 } };
+#endif
 
 volatile uint32_t transfer_count;
 volatile uint32_t done;
@@ -82,6 +96,13 @@ static void test_transfer(const struct device *dev, uint32_t id)
 		dma_block_cfg.source_address = (uint32_t)tx_data;
 		dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];
 #endif
+		/*
+		 * Flush tx_data so DMA reads committed data, and invalidate the
+		 * next rx slot so the CPU will not see stale cache lines after
+		 * the DMA writes to it.
+		 */
+		sys_cache_data_flush_range(tx_data, sizeof(tx_data));
+		sys_cache_data_invd_range(rx_data[transfer_count], sizeof(rx_data[0]));
 
 		zassert_ok(dma_config(dev, id, &dma_cfg), "Not able to config transfer %d",
 			   transfer_count + 1);
@@ -166,6 +187,13 @@ static int test_loop(const struct device *dma)
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];
 #endif
+	/*
+	 * Flush tx_data to memory before DMA reads it, and invalidate the first
+	 * rx slot so the CPU will not observe stale cache lines after the DMA
+	 * writes to it.
+	 */
+	sys_cache_data_flush_range(tx_data, sizeof(tx_data));
+	sys_cache_data_flush_and_invd_range(rx_data[0], sizeof(rx_data[0]));
 
 	if (dma_config(dma, chan_id, &dma_cfg)) {
 		TC_PRINT("ERROR: transfer config (%d)\n", chan_id);
@@ -189,6 +217,12 @@ static int test_loop(const struct device *dma)
 	}
 
 	TC_PRINT("Each RX buffer should contain the full TX buffer string.\n");
+
+	/*
+	 * Invalidate all rx slots before reading so the CPU sees what the DMA
+	 * wrote, not stale cache lines.
+	 */
+	sys_cache_data_invd_range(rx_data, sizeof(rx_data));
 
 	for (int i = 0; i < TRANSFER_LOOPS; i++) {
 		TC_PRINT("RX data Loop %d\n", i);
@@ -259,6 +293,8 @@ static int test_loop_suspend_resume(const struct device *dma)
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];
 #endif
+	sys_cache_data_flush_range(tx_data, sizeof(tx_data));
+	sys_cache_data_flush_and_invd_range(rx_data[0], sizeof(rx_data[0]));
 
 	unsigned int irq_key;
 
@@ -336,6 +372,8 @@ static int test_loop_suspend_resume(const struct device *dma)
 	}
 
 	TC_PRINT("Each RX buffer should contain the full TX buffer string.\n");
+
+	sys_cache_data_invd_range(rx_data, sizeof(rx_data));
 
 	for (int i = 0; i < TRANSFER_LOOPS; i++) {
 		TC_PRINT("RX data Loop %d\n", i);
@@ -440,6 +478,8 @@ static int test_loop_repeated_start_stop(const struct device *dma)
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];
 #endif
+	sys_cache_data_flush_range(tx_data, sizeof(tx_data));
+	sys_cache_data_flush_and_invd_range(rx_data[0], sizeof(rx_data[0]));
 
 	if (dma_config(dma, chan_id, &dma_cfg)) {
 		TC_PRINT("ERROR: transfer config (%d)\n", chan_id);
@@ -484,6 +524,8 @@ static int test_loop_repeated_start_stop(const struct device *dma)
 	}
 
 	TC_PRINT("Each RX buffer should contain the full TX buffer string.\n");
+
+	sys_cache_data_invd_range(rx_data, sizeof(rx_data));
 
 	for (int i = 0; i < TRANSFER_LOOPS; i++) {
 		TC_PRINT("RX data Loop %d\n", i);


### PR DESCRIPTION
Changes in this PR includes:
- add cache coherence for `tests/drivers/dma/loop_transfer/src/test_dma_loop.c`
- add sama7g54_ek.conf and sama7g54_ek.overlay files for `tests/drivers/dma/loop_transfer` test
