### PR TITLE
drivers: wifi: nxp: add raw scan result support

### DIFF
--- a/drivers/wifi/nxp/src/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_drv.c
@@ -816,8 +816,16 @@ static int nxp_wifi_ap_config_params(const struct device *dev,
 
 static int nxp_wifi_process_results(unsigned int count)
 {
+#ifndef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS_ONLY
 	struct wlan_scan_result scan_result = {0};
 	struct wifi_scan_result res = {0};
+#endif
+#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+	struct wifi_raw_scan_result *raw_res = NULL;
+	size_t frame_len = 0;
+	uint32_t freq = 0;
+	int8_t rssi = 0;
+#endif
 
 	if (!count) {
 		LOG_DBG("No Wi-Fi AP found");
@@ -828,6 +836,36 @@ static int nxp_wifi_process_results(unsigned int count)
 		count = g_mlan.max_bss_cnt > count ? count : g_mlan.max_bss_cnt;
 	}
 
+#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+	/* First pass: emit raw scan result events */
+	for (int i = 0; i < count; i++) {
+		raw_res = k_malloc(sizeof(*raw_res));
+		if (raw_res == NULL) {
+			LOG_ERR("Failed to alloc raw scan result");
+			break;
+		}
+		memset(raw_res, 0, sizeof(*raw_res));
+
+		if (wlan_get_scan_raw_frame(i, raw_res->data,
+					    sizeof(raw_res->data),
+					    &frame_len, &freq, &rssi) != 0) {
+			k_free(raw_res);
+			continue;
+		}
+
+		raw_res->frame_length = (int)frame_len;
+		raw_res->frequency = (unsigned short)freq;
+		raw_res->rssi = rssi;
+
+		wifi_mgmt_raise_raw_scan_result_event(g_mlan.netif, raw_res);
+
+		k_free(raw_res);
+		k_yield();
+	}
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+
+#ifndef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS_ONLY
+	/* Second pass: emit normal scan result events */
 	for (int i = 0; i < count; i++) {
 		wlan_get_scan_result(i, &scan_result);
 
@@ -840,7 +878,8 @@ static int nxp_wifi_process_results(unsigned int count)
 
 		res.rssi = -scan_result.rssi;
 		res.channel = scan_result.channel;
-		res.band = scan_result.channel > 14 ? WIFI_FREQ_BAND_5_GHZ : WIFI_FREQ_BAND_2_4_GHZ;
+		res.band = scan_result.channel > 14 ?
+			   WIFI_FREQ_BAND_5_GHZ : WIFI_FREQ_BAND_2_4_GHZ;
 
 		res.security = WIFI_SECURITY_TYPE_NONE;
 
@@ -887,6 +926,7 @@ static int nxp_wifi_process_results(unsigned int count)
 			k_yield();
 		}
 	}
+#endif /* !CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS_ONLY */
 
 out:
 	/* report end of scan event */

--- a/drivers/wifi/nxp/src/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_drv.c
@@ -1940,7 +1940,7 @@ static int nxp_wifi_reg_domain(const struct device *dev, struct net_if *iface __
 			index += nxp_wifi_cfp_no;
 		}
 		reg_domain->num_channels = index;
-		wifi_get_country_code(reg_domain->country_code);
+		wlan_get_country_code(reg_domain->country_code);
 	} else {
 		if (is_uap_started()) {
 			LOG_ERR("region code can not be set after uAP start!");

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 168d46e1d386c870881ec25118733e75e864b359
+      revision: 9f81602140d779d5142bfd2ba41ebe7ba0f38d58
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Add support for CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS in the NXP WiFi
driver. When enabled, the driver emits NET_EVENT_WIFI_RAW_SCAN_RESULT
events containing reconstructed 802.11 beacon frames with raw IEs
from each scanned BSS.

This allows applications to access information not available in the
standard wifi_scan_result struct, such as country code, RSN IE, and
mobility domain.

When CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS_ONLY is set, normal parsed
scan results are suppressed.

Also cleans up the shim driver to use wlan layer APIs instead of
internal wifi driver APIs directly.

Depends on: https://github.com/zephyrproject-rtos/hal_nxp/pull/757

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/111960

---
_Generated by WChat AI Agent_