### PR TITLE
drivers: eth: harden RX length validation in Ethernet drivers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1918,6 +1918,7 @@ Documentation Infrastructure:
   tests:
     - net.ethernet
     - sample.drivers.ethernet
+    - net.ethernet.build
 
 "Drivers: FPGA":
   status: maintained

--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -575,6 +575,15 @@ static int adin2111_read_fifo(const struct device *dev, const uint16_t port_idx)
 		return ret;
 	}
 
+	/* fsize is a 32-bit register value that must fit in ctx->buf before
+	 * the SPI burst read; reject frames that would overflow the static buf.
+	 */
+	if (fsize > CONFIG_ETH_ADIN2111_BUFFER_SIZE) {
+		eth_stats_update_errors_rx(iface);
+		LOG_ERR("Port %u RX fsize %u exceeds buffer", port_idx, fsize);
+		return -EMSGSIZE;
+	}
+
 	/* burst read must be in multiples of 4 */
 	padding_len = ((fsize % 4) == 0) ? 0U : (ROUND_UP(fsize, 4U) - fsize);
 	/* actual available frame length is FSIZE - FRAME HEADER */

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -660,6 +660,10 @@ static int eth_enc28j60_rx(const struct device *dev)
 		/* Get the frame length from the rx status vector,
 		 * minus CRC size at the end which is always present
 		 */
+		if (sys_get_le16(info) <= 4U) {
+			LOG_ERR("Invalid enc28j60 frame length %u", sys_get_le16(info));
+			break;
+		}
 		frm_len = sys_get_le16(info) - 4;
 
 		enc28j60_read_packet(dev, frm_len);

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -227,7 +227,13 @@ static void w5500_rx(const struct device *dev)
 	w5500_spi_read(dev, W5500_S0_RX_RD, tmp, 2);
 	off = sys_get_be16(tmp);
 
-	w5500_readbuf(dev, off, header, 2);
+	if (w5500_readbuf(dev, off, header, 2) < 0) {
+		return;
+	}
+	if (sys_get_be16(header) <= 2U) {
+		LOG_ERR("Invalid W5500 header size %u", sys_get_be16(header));
+		return;
+	}
 	rx_len = sys_get_be16(header) - 2;
 
 	pkt = net_pkt_rx_alloc_with_buffer(ctx->iface, rx_len, NET_AF_UNSPEC, 0,

--- a/drivers/ethernet/eth_w6100.c
+++ b/drivers/ethernet/eth_w6100.c
@@ -204,6 +204,10 @@ static void w6100_rx(const struct device *dev)
 	off = sys_get_be16(tmp);
 
 	w6100_readbuf(dev, off, header, 2);
+	if (sys_get_be16(header) <= 2U) {
+		LOG_ERR("Invalid W6100 header size %u", sys_get_be16(header));
+		return;
+	}
 	rx_len = sys_get_be16(header) - 2;
 
 	pkt = net_pkt_rx_alloc_with_buffer(ctx->iface, rx_len,


### PR DESCRIPTION
Harden several Ethernet drivers against malformed or unexpected device-reported RX length values that could otherwise cause integer underflow, oversized allocations, buffer overflows, or NULL fragment dereferences.

