### PR TITLE
manifest: hal_nxp: upgrade wifi version to v1.3.r54.z_up.p2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 21e58a65f1a6d0c3130d2d21a3cbc6df41fe0d55
+      revision: 168d46e1d386c870881ec25118733e75e864b359
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp revision to pull/758/head to pick up wifi_nxp changes:
- Fix csi task exit assert
- Add register type support in register access command
- Optimize independent reset for wifi recovery
- Fix infinite loop on wpa supp with nxp driver
- Custom IE Improvement
- Optimize SDIO code relocation to reduce ITCM usage
- Fix WiFi UDP TX throughput is lower(10Mbps) in COEX baseline test
- Fix wakelock semaphore creation order causing hardfault

Depends on: https://github.com/zephyrproject-rtos/hal_nxp/pull/758

---
_Generated by WChat AI Agent_