### PR TITLE
FRDM-MCXL255: WWDT support for CM33

### DIFF
--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -27,6 +27,7 @@
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
 		rtc = &rtc;
+		watchdog0 = &wwdt0;
 	};
 
 	leds {
@@ -108,5 +109,9 @@
 };
 
 &systick {
+	status = "okay";
+};
+
+&wwdt0 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -15,4 +15,5 @@ supported:
   - gpio
   - rtc
   - crc
+  - watchdog
 vendor: nxp

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -393,7 +393,7 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 #if defined(CONFIG_WDT_MCUX_WWDT)
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt0)) || DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt))
 	if ((uint32_t)sub_system == MCUX_WWDT0_CLK) {
-#if defined(CONFIG_SOC_FAMILY_MCXA)
+#if defined(CONFIG_SOC_FAMILY_MCXA) || defined(CONFIG_SOC_FAMILY_MCXL)
 		CLOCK_EnableClock(kCLOCK_GateWWDT0);
 #elif defined(CONFIG_SOC_SERIES_MCXW2XX) || defined(CONFIG_SOC_FAMILY_LPC)
 		CLOCK_EnableClock(kCLOCK_Wwdt);
@@ -941,7 +941,7 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 		*rate = CLOCK_GetWdtClkFreq(0);
 #elif defined(CONFIG_SOC_MCXA577)
 		*rate = CLOCK_GetWwdt0ClkFreq();
-#elif defined(CONFIG_SOC_FAMILY_MCXA)
+#elif defined(CONFIG_SOC_FAMILY_MCXA) || defined(CONFIG_SOC_FAMILY_MCXL)
 		*rate = CLOCK_GetWwdtClkFreq();
 #else
 		*rate = CLOCK_GetWdtClkFreq();

--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -59,7 +59,7 @@ static inline int mcux_wwdt_get_clock_frequency(const struct device *dev, uint32
 	defined(CONFIG_SOC_SERIES_LPC54XXX) || defined(CONFIG_SOC_SERIES_LPC51U68) ||              \
 	defined(CONFIG_SOC_SERIES_LPC11U6X)
 		CLOCK_SetClkDiv(kCLOCK_DivWdtClk, config->clk_divider, true);
-#elif defined(CONFIG_SOC_FAMILY_MCXA)
+#elif defined(CONFIG_SOC_FAMILY_MCXA) || defined(CONFIG_SOC_FAMILY_MCXL)
 		CLOCK_SetClockDiv(kCLOCK_DivWWDT0, config->clk_divider);
 #elif defined(CONFIG_SOC_FAMILY_MCXN)
 		CLOCK_SetClkDiv(kCLOCK_DivWdt0Clk, config->clk_divider);

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
@@ -60,3 +60,4 @@
 
 &aon_qtmr1 {
 	interrupts = <152 0>;
+};

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
@@ -43,10 +43,20 @@
 	arm,num-irq-priority-bits = <3>;
 };
 
+&peripheral {
+	wwdt0: watchdog@c000 {
+		compatible = "nxp,lpc-wwdt";
+		reg = <0xc000 0x1000>;
+		interrupts = <60 0>;
+		clocks = <&syscon MCUX_WWDT0_CLK>;
+		status = "disabled";
+		clk-divider = <1>;
+	};
+};
+
 &aon_qtmr0 {
 	interrupts = <151 0>;
 };
 
 &aon_qtmr1 {
 	interrupts = <152 0>;
-};


### PR DESCRIPTION
Add WWDT0 support for the FRDM-MCXL255 CM33 target.

This adds the MCXL255 WWDT0 devicetree node, enables WWDT0 as the
default watchdog on FRDM-MCXL255 CM33, and adds MCXL clock handling for
the MCUX syscon clock-control and WWDT watchdog drivers.

Tested on `frdm_mcxl255/mcxl255/cpu0`:
- `samples/hello_world`
- `samples/drivers/watchdog`
- `tests/drivers/watchdog/wdt_basic_api`