### PR TITLE
boards: frdm_mcxa577: add ostimer clock init

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -268,6 +268,10 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kPll1ClkDiv_to_CTIMER4);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(os_timer))
+	CLOCK_AttachClk(kCLK_1M_to_OSTIMER);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lptmr0))
 
 /*


### PR DESCRIPTION
Attach the 1 MHz reference clock to the OS Event Timer peripheral in board_early_init_hook(). The call is guarded by DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(os_timer)) so it is a no-op unless os_timer is explicitly enabled (e.g. via a devicetree overlay).

The os_timer node is already defined as disabled in nxp_mcxa5x_common.dtsi. Systick remains the default RTOS tick source. When os_timer is enabled, the 1 MHz clock matches CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=1000000 set by the MCXA SOC Kconfig when CONFIG_MCUX_OS_TIMER is selected.

Add the OStimer support.
By default, the Systick is used.
The ostimer could be tested with below configure in frdm_mcxa577.overlay:

&systick {
status = "disabled";
};
&os_timer{
status = "okay";
};