### PR TITLE
net: lib: coap: client: Do not hold lock in callback

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -184,6 +184,7 @@ struct coap_client_internal_request {
 	uint8_t request_tkl;
 	bool request_ongoing;
 	atomic_t in_callback;
+	int unreported_error;
 	struct coap_block_context recv_blk_ctx;
 	struct coap_block_context send_blk_ctx;
 	struct coap_pending pending;

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -101,6 +101,7 @@ static void release_internal_request(struct coap_client_internal_request *reques
 {
 	request->request_ongoing = false;
 	request->pending.timeout = 0;
+	request->unreported_error = 0;
 }
 
 static void coap_client_schedule_poll(struct coap_client *client, int sock,
@@ -161,6 +162,7 @@ static struct coap_client_internal_request *get_free_request(struct coap_client 
 {
 	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
 		if (client->requests[i].request_ongoing == false &&
+		    atomic_get(&client->requests[i].in_callback) == 0 &&
 		    exchange_lifetime_exceeded(&client->requests[i])) {
 			return &client->requests[i];
 		}
@@ -554,36 +556,91 @@ out:
 	return ret;
 }
 
-static void report_callback_error(struct coap_client_internal_request *internal_req, int error_code)
+/* Invoke the user response callback with client->lock RELEASED.
+ *
+ * An application could hold its own lock while calling coap_client_req() (which
+ * takes client->lock), and the response callback could in turn take that same
+ * application lock. Holding client->lock across the callback would then be an
+ * AB-BA deadlock. The callback never needs client->lock itself, so drop it for
+ * the duration and re-acquire afterwards.
+ *
+ * The in_callback atomic keeps the slot reserved while the lock is dropped:
+ * get_free_request() skips in_callback slots and the cancel paths defer
+ * releasing them (see cancel_internal_request()), so the request can neither be
+ * reused nor reset underneath a running callback.
+ *
+ * Must be called with client->lock held; returns with it held.
+ */
+static bool invoke_request_callback(struct coap_client *client,
+				    struct coap_client_internal_request *internal_req,
+				    const struct coap_client_response_data *resp_data)
 {
-	if (internal_req->coap_request.cb != NULL) {
-		if (!atomic_set(&internal_req->in_callback, 1)) {
-			const struct coap_client_response_data resp_data = {
-				.result_code = error_code,
-				.last_block = true,
-			};
+	if (internal_req->coap_request.cb == NULL) {
+		return true;
+	}
 
-			internal_req->coap_request.cb(&resp_data,
-						      internal_req->coap_request.user_data);
-			atomic_clear(&internal_req->in_callback);
-		} else {
-			LOG_DBG("Cannot call the callback; already in it.");
-		}
+	if (atomic_set(&internal_req->in_callback, 1)) {
+		LOG_DBG("Cannot call the callback; already in it.");
+		return false;
+	}
+
+	k_mutex_unlock(&client->lock);
+	internal_req->coap_request.cb(resp_data, internal_req->coap_request.user_data);
+	k_mutex_lock(&client->lock, K_FOREVER);
+
+	atomic_clear(&internal_req->in_callback);
+	return true;
+}
+
+/* Release a cancelled request, unless its callback is currently running with
+ * client->lock dropped (in_callback). In that case leave the slot reserved and
+ * only mark it done; invoke_request_callback()'s owner resets it on return,
+ * which keeps the slot from being reused mid-callback.
+ */
+static void cancel_internal_request(struct coap_client_internal_request *internal_req)
+{
+	if (atomic_get(&internal_req->in_callback)) {
+		internal_req->request_ongoing = false;
+	} else {
+		reset_internal_request(internal_req);
+	}
+}
+
+static bool report_callback_error(struct coap_client *client,
+				  struct coap_client_internal_request *internal_req, int error_code)
+{
+	const struct coap_client_response_data resp_data = {
+		.result_code = error_code,
+		.last_block = true,
+	};
+
+	return invoke_request_callback(client, internal_req, &resp_data);
+}
+
+/* Deliver an error/cancellation callback now, or, if a response callback for
+ * this request is already running on the recv thread with client->lock dropped,
+ * record it so the recv thread delivers it when that callback returns (see
+ * handle_response()). A request cancelled from within its own callback (same
+ * thread) records nothing: re-entrant delivery is intentionally suppressed.
+ */
+static void report_or_defer_error(struct coap_client *client,
+				  struct coap_client_internal_request *internal_req, int error_code)
+{
+	if (!report_callback_error(client, internal_req, error_code) &&
+	    k_current_get() != coap_client_recv_tid) {
+		internal_req->unreported_error = error_code;
 	}
 }
 
 #if defined(CONFIG_COAP_CLIENT_MULTICAST)
-static void report_multicast_complete(struct coap_client_internal_request *internal_req)
+static void report_multicast_complete(struct coap_client *client,
+				      struct coap_client_internal_request *internal_req)
 {
-	if (internal_req->coap_request.cb != NULL &&
-	    !atomic_set(&internal_req->in_callback, 1)) {
-		const struct coap_client_response_data resp_data = {
-			.source = NULL,
-		};
+	const struct coap_client_response_data resp_data = {
+		.source = NULL,
+	};
 
-		internal_req->coap_request.cb(&resp_data, internal_req->coap_request.user_data);
-		atomic_clear(&internal_req->in_callback);
-	}
+	invoke_request_callback(client, internal_req, &resp_data);
 }
 #endif
 
@@ -652,7 +709,7 @@ static void coap_client_resend_handler(struct coap_client *client)
 		if (timeout_expired(internal_req)) {
 #if defined(CONFIG_COAP_CLIENT_MULTICAST)
 			if (internal_req->is_mcast) {
-				report_multicast_complete(internal_req);
+				report_multicast_complete(client, internal_req);
 				release_internal_request(internal_req);
 				continue;
 			}
@@ -665,7 +722,7 @@ static void coap_client_resend_handler(struct coap_client *client)
 
 			ret = resend_request(client, internal_req);
 			if (ret < 0) {
-				report_callback_error(internal_req, ret);
+				report_callback_error(client, internal_req, ret);
 				release_internal_request(internal_req);
 			}
 		}
@@ -992,7 +1049,7 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 			LOG_WRN("No matching request for RESET");
 			return 0;
 		}
-		report_callback_error(internal_req, -ECONNRESET);
+		report_callback_error(client, internal_req, -ECONNRESET);
 		release_internal_request(internal_req);
 		return 0;
 	}
@@ -1024,6 +1081,16 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 		}
 		return 0;
 	}
+
+	/* Snapshot the slot's keep-alive flags before dropping the lock for the
+	 * callback below: a concurrent coap_client_deregister_observe() may clear
+	 * is_observe while we are in the callback, which must not retroactively
+	 * change how THIS response is finalised at the end of the function.
+	 */
+	bool was_observe = internal_req->is_observe;
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+	bool was_mcast = internal_req->is_mcast;
+#endif
 
 	/* Received echo option */
 	if (find_echo_option(response, &client->echo_option)) {
@@ -1183,29 +1250,39 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 		payload_len = MIN(payload_len, CONFIG_COAP_CLIENT_BLOCK_SIZE);
 	}
 
-	/* Call user callback */
+	/* Call user callback (with client->lock dropped, see
+	 * invoke_request_callback()).
+	 */
 	if (internal_req->coap_request.cb != NULL) {
-		if (!atomic_set(&internal_req->in_callback, 1)) {
-			const struct coap_client_response_data resp_data = {
-				.result_code = response_code,
-				.packet = response,
-				.offset = internal_req->offset,
-				.payload = payload,
-				.payload_len = payload_len,
-				.last_block = last_block,
+		const struct coap_client_response_data resp_data = {
+			.result_code = response_code,
+			.packet = response,
+			.offset = internal_req->offset,
+			.payload = payload,
+			.payload_len = payload_len,
+			.last_block = last_block,
 #if defined(CONFIG_COAP_CLIENT_MULTICAST)
-				.source = addr,
-				.source_len = addrlen,
+			.source = addr,
+			.source_len = addrlen,
 #endif
-			};
+		};
 
-			internal_req->coap_request.cb(&resp_data,
-						      internal_req->coap_request.user_data);
-			atomic_clear(&internal_req->in_callback);
-		}
+		invoke_request_callback(client, internal_req, &resp_data);
+
 		if (!internal_req->request_ongoing) {
-			/* User callback must have called coap_client_cancel_requests(). */
-			goto fail;
+			/* Cancelled while the callback ran with the lock dropped,
+			 * by the callback itself (coap_client_cancel_requests()) or
+			 * by another thread. A cross-thread canceller that could not
+			 * deliver its callback (we were mid-callback) recorded the
+			 * error here; deliver it now. The slot stayed reserved via
+			 * in_callback; release it now that the callback returned.
+			 */
+			if (internal_req->unreported_error != 0) {
+				report_callback_error(client, internal_req,
+						      internal_req->unreported_error);
+			}
+			reset_internal_request(internal_req);
+			return 0;
 		}
 		/* Update the offset for next callback in a blockwise transfer */
 		if (blockwise_transfer) {
@@ -1243,17 +1320,17 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 	}
 fail:
 	if (ret < 0) {
-		report_callback_error(internal_req, ret);
+		report_callback_error(client, internal_req, ret);
 	}
 
 #if defined(CONFIG_COAP_CLIENT_MULTICAST)
-	if (internal_req->is_mcast) {
+	if (was_mcast) {
 		/* Multicast: keep request active until timeout */
 		return ret;
 	}
 #endif
 
-	if (internal_req->is_observe) {
+	if (was_observe) {
 		/* Observer: keep request active until unobserve */
 		return ret;
 	}
@@ -1278,18 +1355,18 @@ static void cancel_requests_with(struct coap_client *client, int error)
 	for (int i = 0; i < ARRAY_SIZE(client->requests); i++) {
 		if (client->requests[i].request_ongoing == true) {
 			LOG_DBG("Cancelling request %d", i);
-			/* Report the request was cancelled. This will be skipped if
-			 * this function was called from the user's callback so we
-			 * do not reenter it. In that case, the user knows their
-			 * request was cancelled anyway.
+			/* Report the cancellation, or defer it to the recv thread
+			 * if a callback for this slot is already running there.
 			 */
-			report_callback_error(&client->requests[i], error);
+			report_or_defer_error(client, &client->requests[i], error);
 		}
 
 		/* Clear all requests, even completed ones, so that our
-		 * handle_poll() does not poll() anymore for this socket.
+		 * handle_poll() does not poll() anymore for this socket. A slot
+		 * whose callback is still running stays reserved (see
+		 * cancel_internal_request()).
 		 */
-		reset_internal_request(&client->requests[i]);
+		cancel_internal_request(&client->requests[i]);
 	}
 	k_mutex_unlock(&client->lock);
 
@@ -1373,8 +1450,8 @@ void coap_client_cancel_request(struct coap_client *client, struct coap_client_r
 		if (client->requests[i].request_ongoing &&
 		    requests_match(&client->requests[i].coap_request, req)) {
 			LOG_DBG("Cancelling request %d", i);
-			report_callback_error(&client->requests[i], -ECANCELED);
-			reset_internal_request(&client->requests[i]);
+			report_or_defer_error(client, &client->requests[i], -ECANCELED);
+			cancel_internal_request(&client->requests[i]);
 		}
 	}
 
@@ -1417,8 +1494,8 @@ int coap_client_deregister_observe(struct coap_client *client, struct coap_clien
 
 		if (err < 0) {
 			LOG_ERR("Failed to build observe deregister packet: %d", err);
-			report_callback_error(internal_req, err);
-			reset_internal_request(internal_req);
+			report_or_defer_error(client, internal_req, err);
+			cancel_internal_request(internal_req);
 			ret = err;
 			continue;
 		}
@@ -1434,8 +1511,8 @@ int coap_client_deregister_observe(struct coap_client *client, struct coap_clien
 						net_sad(&internal_req->addr), &params);
 			if (err < 0) {
 				LOG_ERR("Failed to init pending for deregister: %d", err);
-				report_callback_error(internal_req, err);
-				reset_internal_request(internal_req);
+				report_or_defer_error(client, internal_req, err);
+				cancel_internal_request(internal_req);
 				ret = err;
 				continue;
 			}
@@ -1448,16 +1525,16 @@ int coap_client_deregister_observe(struct coap_client *client, struct coap_clien
 				   internal_req->addrlen);
 		if (err < 0) {
 			LOG_ERR("Failed to send observe deregister: %d", err);
-			report_callback_error(internal_req, err);
-			reset_internal_request(internal_req);
+			report_or_defer_error(client, internal_req, err);
+			cancel_internal_request(internal_req);
 			ret = err;
 			continue;
 		}
 
 		if (!internal_req->coap_request.confirmable) {
 			/* NON: no ACK expected, release immediately */
-			report_callback_error(internal_req, -ECANCELED);
-			reset_internal_request(internal_req);
+			report_or_defer_error(client, internal_req, -ECANCELED);
+			cancel_internal_request(internal_req);
 		}
 		/* CON: slot stays alive; retransmissions and final response
 		 * handled via the normal response path once the server ACKs


### PR DESCRIPTION
An application may hold its own lock while calling `coap_client_req()` (which takes the client lock), and the response callback may in turn take that same lock. Holding the client lock across the callback is then an AB-BA deadlock.

Invoke the callback with the lock released. The `in_callback` atomic already guards the slot, so additionally skip in-callback slots in `get_free_request()` and defer their release on cancel, preventing reuse or reset under a running callback.