### PR TITLE
Use <> to include Zephyr header files instead of ""

### DIFF
--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -9,9 +9,9 @@
 #include <zephyr/drivers/interrupt_controller/gic.h>
 #include <ipi.h>
 #include "boot.h"
-#include "zephyr/cache.h"
-#include "zephyr/kernel/thread_stack.h"
-#include "zephyr/toolchain/gcc.h"
+#include <zephyr/cache.h>
+#include <zephyr/kernel/thread_stack.h>
+#include <zephyr/toolchain/gcc.h>
 #include <zephyr/platform/hooks.h>
 
 #define INV_MPID	UINT32_MAX

--- a/arch/arm/core/cortex_a_r/stacks.c
+++ b/arch/arm/core/cortex_a_r/stacks.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/kernel/thread_stack.h"
+#include <zephyr/kernel/thread_stack.h>
 #include <zephyr/kernel.h>
 #include <cortex_a_r/stack.h>
 #include <string.h>

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -26,7 +26,7 @@
  * modified.
  */
 
-#include "zephyr/toolchain.h"
+#include <zephyr/toolchain.h>
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <zephyr/linker/linker-defs.h>

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -8,7 +8,7 @@
 #include <st/h7rs/stm32h7s7X8.dtsi>
 #include <st/h7/stm32h7s7l8hxh-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
-#include "zephyr/dt-bindings/display/panel.h"
+#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 /*

--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -8,7 +8,7 @@
 
 #include <st/mp13/stm32mp135.dtsi>
 #include <st/mp13/stm32mp135faex-pinctrl.dtsi>
-#include "zephyr/dt-bindings/display/panel.h"
+#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/gpio/raspberrypi-csi-connector.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/video/video-interfaces.h>

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -6,7 +6,7 @@
 
 #include <st/n6/stm32n657X0.dtsi>
 #include <st/n6/stm32n657x0hxq-pinctrl.dtsi>
-#include "zephyr/dt-bindings/display/panel.h"
+#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <zephyr/dt-bindings/gpio/raspberrypi-csi-connector.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>

--- a/drivers/audio/dmic_stm32_dfsdm.c
+++ b/drivers/audio/dmic_stm32_dfsdm.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/sys/util_macro.h"
+#include <zephyr/sys/util_macro.h>
 #include <zephyr/arch/common/ffs.h>
 #include <zephyr/audio/dmic.h>
 #include <zephyr/device.h>

--- a/drivers/charger/charger_bq24190.c
+++ b/drivers/charger/charger_bq24190.c
@@ -10,12 +10,12 @@
 
 #include "bq24190.h"
 
-#include "zephyr/device.h"
-#include "zephyr/drivers/charger.h"
-#include "zephyr/drivers/i2c.h"
-#include "zephyr/kernel.h"
-#include "zephyr/sys/util.h"
-#include "zephyr/logging/log.h"
+#include <zephyr/device.h>
+#include <zephyr/drivers/charger.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/drivers/gpio.h>
 
 LOG_MODULE_REGISTER(ti_bq24190, CONFIG_CHARGER_LOG_LEVEL);

--- a/drivers/charger/charger_max20335.c
+++ b/drivers/charger/charger_max20335.c
@@ -14,7 +14,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/linear_range.h>
 
-#include "zephyr/logging/log.h"
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(max20335_charger, CONFIG_CHARGER_LOG_LEVEL);
 
 #define MAX20335_REG_STATUSA 0x02

--- a/drivers/clock_control/clock_control_rts5817.c
+++ b/drivers/clock_control/clock_control_rts5817.c
@@ -7,13 +7,13 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/rts5817_clock.h>
-#include "zephyr/arch/common/sys_io.h"
-#include "zephyr/device.h"
+#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/device.h>
 #include <errno.h>
 #include <stdint.h>
 #include "clock_control_rts5817_control.h"
 #include "clock_control_rts5817_gpll.h"
-#include "zephyr/devicetree.h"
+#include <zephyr/devicetree.h>
 
 #define DT_DRV_COMPAT realtek_rts5817_clock
 

--- a/drivers/display/display_st75256.c
+++ b/drivers/display/display_st75256.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/sys/util.h"
+#include <zephyr/sys/util.h>
 #define DT_DRV_COMPAT sitronix_st75256
 
 #include <zephyr/logging/log.h>

--- a/drivers/display/ssd1322.c
+++ b/drivers/display/ssd1322.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/sys/util.h"
+#include <zephyr/sys/util.h>
 #define DT_DRV_COMPAT solomon_ssd1322
 
 #include <zephyr/logging/log.h>

--- a/drivers/eeprom/eeprom_fm25xxx.c
+++ b/drivers/eeprom/eeprom_fm25xxx.c
@@ -6,10 +6,10 @@
 
 /* This file implements the Infineon AN304 SPI Guide for F-RAM */
 
-#include "zephyr/devicetree.h"
-#include "zephyr/kernel.h"
-#include "zephyr/sys/byteorder.h"
-#include "zephyr/sys/util.h"
+#include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/eeprom.h>
 #include <zephyr/drivers/spi.h>

--- a/drivers/espi/espi_realtek_rts5912.c
+++ b/drivers/espi/espi_realtek_rts5912.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(espi, CONFIG_ESPI_LOG_LEVEL);
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
 #include "reg/reg_system.h"
-#include "zephyr/drivers/gpio/gpio_rts5912.h"
+#include <zephyr/drivers/gpio/gpio_rts5912.h>
 #endif
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1, "support only one espi compatible node");

--- a/drivers/firmware/tisci/tisci.h
+++ b/drivers/firmware/tisci/tisci.h
@@ -13,7 +13,7 @@
 #ifndef INCLUDE_ZEPHYR_DRIVERS_TISCI_PROTOCOL_H_
 #define INCLUDE_ZEPHYR_DRIVERS_TISCI_PROTOCOL_H_
 
-#include "zephyr/kernel.h"
+#include <zephyr/kernel.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/drivers/flash/flash_s3axx04.c
+++ b/drivers/flash/flash_s3axx04.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/devicetree.h"
-#include "zephyr/kernel.h"
-#include "zephyr/sys/byteorder.h"
-#include "zephyr/sys/util.h"
+#include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/drivers/spi.h>

--- a/drivers/gpio/gpio_rts5912.c
+++ b/drivers/gpio/gpio_rts5912.c
@@ -12,7 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/irq.h>
-#include "zephyr/drivers/gpio/gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/dt-bindings/gpio/realtek-gpio.h>
 #include <zephyr/pm/pm.h>

--- a/drivers/i2c/i2c_sy1xx.c
+++ b/drivers/i2c/i2c_sy1xx.c
@@ -6,7 +6,7 @@
 
 #define DT_DRV_COMPAT sensry_sy1xx_i2c
 
-#include "zephyr/sys/byteorder.h"
+#include <zephyr/sys/byteorder.h>
 
 #include <zephyr/sys/minmax.h>
 #include <zephyr/logging/log.h>

--- a/drivers/interrupt_controller/intc_vim.c
+++ b/drivers/interrupt_controller/intc_vim.c
@@ -15,7 +15,7 @@
 #include <zephyr/drivers/interrupt_controller/intc_vim.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include "zephyr/sys/__assert.h"
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util_macro.h>
 
 LOG_MODULE_REGISTER(vim);

--- a/drivers/misc/ethos_u/ethos_u_common.c
+++ b/drivers/misc/ethos_u/ethos_u_common.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/sys_clock.h"
+#include <zephyr/sys_clock.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>

--- a/drivers/pinctrl/pinctrl_arm_mps2.c
+++ b/drivers/pinctrl/pinctrl_arm_mps2.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/device.h"
-#include "zephyr/drivers/gpio.h"
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/devicetree/gpio.h>
 #include <zephyr/drivers/gpio/gpio_cmsdk_ahb.h>

--- a/drivers/pinctrl/pinctrl_arm_mps3.c
+++ b/drivers/pinctrl/pinctrl_arm_mps3.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/device.h"
-#include "zephyr/drivers/gpio.h"
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/devicetree/gpio.h>
 #include <zephyr/drivers/gpio/gpio_cmsdk_ahb.h>

--- a/drivers/pinctrl/pinctrl_arm_mps4.c
+++ b/drivers/pinctrl/pinctrl_arm_mps4.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/device.h"
-#include "zephyr/drivers/gpio.h"
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/devicetree/gpio.h>
 #include <zephyr/drivers/gpio/gpio_cmsdk_ahb.h>

--- a/drivers/pinctrl/pinctrl_arm_v2m_beetle.c
+++ b/drivers/pinctrl/pinctrl_arm_v2m_beetle.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/device.h"
-#include "zephyr/drivers/gpio.h"
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/devicetree/gpio.h>
 #include <zephyr/drivers/gpio/gpio_cmsdk_ahb.h>

--- a/drivers/regulator/regulator_pca9422.c
+++ b/drivers/regulator/regulator_pca9422.c
@@ -13,7 +13,7 @@
 #include <zephyr/drivers/mfd/pca9422.h>
 #include <zephyr/sys/linear_range.h>
 #include <zephyr/sys/util.h>
-#include "zephyr/logging/log.h"
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(pca9422_regulator);
 

--- a/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
@@ -5,7 +5,7 @@
 #include "bma4xx.h"
 #include "bma4xx_emul.h"
 
-#include "zephyr/sys/util.h"
+#include <zephyr/sys/util.h>
 
 #include <errno.h>
 #include <stdint.h>

--- a/drivers/sensor/bosch/bma4xx/bma4xx_emul.h
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_emul.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_DRIVERS_SENSOR_BMA4XX_BMA4XX_EMUL_H_
 
 #include <zephyr/drivers/emul.h>
-#include "zephyr/dsp/types.h"
+#include <zephyr/dsp/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/sensor/maxim/ds18b20/ds18b20.c
+++ b/drivers/sensor/maxim/ds18b20/ds18b20.c
@@ -19,7 +19,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/sensor/w1_sensor.h>
-#include "zephyr/drivers/w1.h"
+#include <zephyr/drivers/w1.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>

--- a/drivers/serial/uart_realtek_rts5912.c
+++ b/drivers/serial/uart_realtek_rts5912.c
@@ -18,7 +18,7 @@
 #include <zephyr/pm/pm.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/pm/device.h>
-#include "zephyr/drivers/gpio/gpio_rts5912.h"
+#include <zephyr/drivers/gpio/gpio_rts5912.h>
 
 LOG_MODULE_REGISTER(uart_rts5912, CONFIG_UART_LOG_LEVEL);
 

--- a/drivers/serial/uart_rzt2m.c
+++ b/drivers/serial/uart_rzt2m.c
@@ -5,8 +5,8 @@
  */
 
 #include "uart_rzt2m.h"
-#include "zephyr/spinlock.h"
-#include "zephyr/sys/printk.h"
+#include <zephyr/spinlock.h>
+#include <zephyr/sys/printk.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/sys/util.h>

--- a/drivers/spi/spi_sy1xx.c
+++ b/drivers/spi/spi_sy1xx.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(spi_sy1xx);
 #include <zephyr/sys/util.h>
 #include <udma.h>
 #include <zephyr/drivers/pinctrl.h>
-#include "zephyr/sys/byteorder.h"
+#include <zephyr/sys/byteorder.h>
 
 /* SPI udma command interface definitions */
 #define SPI_CMD_OFFSET (4)

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/sys_clock.h"
+#include <zephyr/sys_clock.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/init.h>
 #include <soc.h>

--- a/drivers/wifi/nxp/incl/nxp_wifi_net.h
+++ b/drivers/wifi/nxp/incl/nxp_wifi_net.h
@@ -29,7 +29,7 @@
 #endif
 #endif
 #ifdef CONFIG_NET_DHCPV4_SERVER
-#include "zephyr/net/dhcpv4_server.h"
+#include <zephyr/net/dhcpv4_server.h>
 #endif
 #include <mlan_api.h>
 #include <wmlog.h>

--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -15,7 +15,7 @@
 /* npcx4 series low-voltage io controls mapping table */
 #include "npcx4/npcx4-lvol-ctrl-map.dtsi"
 /* npcx4 series reset mapping table */
-#include "zephyr/dt-bindings/reset/npcx4_reset.h"
+#include <zephyr/dt-bindings/reset/npcx4_reset.h>
 
 /* Device tree declarations of npcx soc family */
 #include "npcx.dtsi"

--- a/include/zephyr/net/http/service.h
+++ b/include/zephyr/net/http/service.h
@@ -19,7 +19,7 @@
  * @{
  */
 
-#include "zephyr/net/http/server.h"
+#include <zephyr/net/http/server.h>
 #include <stdint.h>
 #include <stddef.h>
 

--- a/include/zephyr/shell/shell_remote.h
+++ b/include/zephyr/shell/shell_remote.h
@@ -21,7 +21,7 @@
  * @{
  */
 
-#include "zephyr/shell/shell_remote_common.h"
+#include <zephyr/shell/shell_remote_common.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/ipc/ipc_service.h>
 #include <zephyr/sys/slist.h>

--- a/modules/openthread/platform/diag.c
+++ b/modules/openthread/platform/diag.c
@@ -14,7 +14,7 @@
 #include <openthread/platform/radio.h>
 
 #include "platform-zephyr.h"
-#include "zephyr/sys/util.h"
+#include <zephyr/sys/util.h>
 
 enum {
 	DIAG_TRANSMIT_MODE_IDLE,

--- a/samples/drivers/charger/src/main.c
+++ b/samples/drivers/charger/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/sys/printk.h"
+#include <zephyr/sys/printk.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>

--- a/samples/drivers/fuel_gauge/src/main.c
+++ b/samples/drivers/fuel_gauge/src/main.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/sys/util.h"
+#include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>

--- a/samples/drivers/pwm/capture/src/main.c
+++ b/samples/drivers/pwm/capture/src/main.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <zephyr/kernel.h>
-#include "zephyr/drivers/pwm.h"
+#include <zephyr/drivers/pwm.h>
 
 int main(void)
 {

--- a/samples/net/sockets/http_server/src/main.c
+++ b/samples/net/sockets/http_server/src/main.c
@@ -14,8 +14,8 @@
 #include <zephyr/net/http/service.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/socket.h>
-#include "zephyr/device.h"
-#include "zephyr/sys/util.h"
+#include <zephyr/device.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/drivers/led.h>
 #include <zephyr/data/json.h>
 #include <zephyr/sys/util_macro.h>

--- a/subsys/net/ip/net_tc_mapping.h
+++ b/subsys/net/ip/net_tc_mapping.h
@@ -13,7 +13,7 @@
 #ifndef __TC_MAPPING_H
 #define __TC_MAPPING_H
 
-#include "zephyr/net/net_core.h"
+#include <zephyr/net/net_core.h>
 
 /* All the maps below use priorities and indexes, below is the list of them
  * according to 802.1Q - table I-2.

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -27,7 +27,7 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 
 /* To support multicast */
 #include "ipv6.h"
-#include "zephyr/net/igmp.h"
+#include <zephyr/net/igmp.h>
 
 static struct net_sockaddr_in6 *in6_addr_my;
 static struct net_sockaddr_in *in4_addr_my;

--- a/subsys/pmci/mctp/mctp_i2c_gpio_controller.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_controller.c
@@ -5,9 +5,9 @@
  *
  */
 
-#include "zephyr/drivers/gpio.h"
-#include "zephyr/pmci/mctp/mctp_i2c_gpio_common.h"
-#include "zephyr/rtio/rtio.h"
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/pmci/mctp/mctp_i2c_gpio_common.h>
+#include <zephyr/rtio/rtio.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>

--- a/subsys/pmci/mctp/mctp_i2c_gpio_target.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_target.c
@@ -5,7 +5,7 @@
  *
  */
 
-#include "zephyr/pmci/mctp/mctp_i2c_gpio_common.h"
+#include <zephyr/pmci/mctp/mctp_i2c_gpio_common.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>

--- a/subsys/pmci/mctp/mctp_i3c_target.c
+++ b/subsys/pmci/mctp/mctp_i3c_target.c
@@ -5,7 +5,7 @@
  *
  */
 
-#include "zephyr/pmci/mctp/mctp_i3c_common.h"
+#include <zephyr/pmci/mctp/mctp_i3c_common.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>

--- a/subsys/sensing/sensor/phy_3d_sensor/phy_3d_sensor.c
+++ b/subsys/sensing/sensor/phy_3d_sensor/phy_3d_sensor.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/devicetree.h"
+#include <zephyr/devicetree.h>
 #define DT_DRV_COMPAT zephyr_sensing_phy_3d_sensor
 
 #include <stdlib.h>

--- a/subsys/shell/shell_remote.c
+++ b/subsys/shell/shell_remote.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/sys/__assert.h"
+#include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log.h>
 #include <stdlib.h>
 #include <zephyr/shell/shell_remote_common.h>

--- a/tests/arch/rx/acc/src/main.c
+++ b/tests/arch/rx/acc/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/kernel.h"
+#include <zephyr/kernel.h>
 #include <stdint.h>
 #include <zephyr/ztest.h>
 #include <soc.h>

--- a/tests/bluetooth/audio/cap_initiator/uut/cap_initiator.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/cap_initiator.c
@@ -10,7 +10,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 
 #include "cap_initiator.h"
-#include "zephyr/fff.h"
+#include <zephyr/fff.h>
 
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE)                                                                       \

--- a/tests/bluetooth/audio/mocks/src/bap_broadcast_source.c
+++ b/tests/bluetooth/audio/mocks/src/bap_broadcast_source.c
@@ -8,7 +8,7 @@
 #include <zephyr/bluetooth/audio/bap.h>
 
 #include "bap_broadcast_source.h"
-#include "zephyr/fff.h"
+#include <zephyr/fff.h>
 
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE)                                                                       \

--- a/tests/drivers/counter/rpi_pico_pit/src/main.c
+++ b/tests/drivers/counter/rpi_pico_pit/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/device.h"
-#include "zephyr/kernel.h"
-#include "zephyr/devicetree.h"
-#include "zephyr/ztest_assert.h"
-#include "zephyr/ztest_test.h"
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/ztest_assert.h>
+#include <zephyr/ztest_test.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <zephyr/ztest.h>

--- a/tests/drivers/sensor/mtch9010/src/main.c
+++ b/tests/drivers/sensor/mtch9010/src/main.c
@@ -17,7 +17,7 @@
 #include <zephyr/dt-bindings/sensor/mtch9010.h>
 
 #include "../drivers/sensor/microchip/mtch9010/mtch9010_priv.h"
-#include "zephyr/drivers/sensor/mtch9010.h"
+#include <zephyr/drivers/sensor/mtch9010.h>
 
 #define DUT_NODE DT_NODELABEL(dut)
 

--- a/tests/kernel/spinlock/spinlock_api/src/spinlock_fairness.c
+++ b/tests/kernel/spinlock/spinlock_api/src/spinlock_fairness.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/ztest_test.h"
+#include <zephyr/ztest_test.h>
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <zephyr/spinlock.h>

--- a/tests/lib/lockfree/src/test_mpsc.c
+++ b/tests/lib/lockfree/src/test_mpsc.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/irq.h"
+#include <zephyr/irq.h>
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util_loops.h>

--- a/tests/net/lib/wifi_credentials_backend_psa/src/normalized_crypto.h
+++ b/tests/net/lib/wifi_credentials_backend_psa/src/normalized_crypto.h
@@ -7,7 +7,7 @@
 #ifndef PSA_CRYPTO_H
 #define PSA_CRYPTO_H
 
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 #include "psa/crypto_types.h"
 #include "psa/crypto_values.h"
 

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/pm/device_runtime.h>
 
 #include "test_driver.h"
-#include "zephyr/sys/util_macro.h"
+#include <zephyr/sys/util_macro.h>
 
 
 static const struct device *test_dev;

--- a/tests/subsys/shell/shell_remote/src/main.c
+++ b/tests/subsys/shell/shell_remote/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/tc_util.h"
+#include <zephyr/tc_util.h>
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <zephyr/shell/shell.h>


### PR DESCRIPTION
Use `<>` operator to include a Zephyr header file instead of `""` that is intended to local header files, not header files relative to specifically defined search paths.

This change was made running the `sed` shell command below and split commits per main subdirs to ease review or later herry picking.
```
$ sed -i -E 's/#include "zephyr\/([^"]+)\.h"/#include <zephyr\/\1.h>/g' `grep -rsl "#include \"zephyr/" */`
```