### PR TITLE
net: ethernet: remove ETHERNET_LINK_* from caps

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -287,6 +287,10 @@ Ethernet
   been updated accordingly, as have been the device trees of the Zynq-7000 and ZynqMP /
   UltraScale+ SoC families. (:github:`87313`)
 
+* ``ETHERNET_LINK_*`` flags have been removed from :c:enum:`ethernet_hw_caps`.
+  Out-of-tree drivers must remove any references to these flags from their
+  :c:struct:`ethernet_api` ``get_capabilities`` implementation. (:github:`112086`)
+
 Flash
 =====
 * :dtcompatible:`jedec,spi-nand` now requires a ``plane-bytes`` property, which indicates the size

--- a/doc/services/connectivity/networking/api/8021Qav.rst
+++ b/doc/services/connectivity/networking/api/8021Qav.rst
@@ -28,8 +28,7 @@ also priority queues ``ETHERNET_PRIORITY_QUEUES`` need to be supported.
 		ARG_UNUSED(dev);
 
 		return ETHERNET_QAV | ETHERNET_PRIORITY_QUEUES |
-		       ETHERNET_HW_VLAN | ETHERNET_LINK_10BASE |
-		       ETHERNET_LINK_100BASE;
+		       ETHERNET_HW_VLAN;
 	}
 
 See ``sam-e70-xplained`` board Ethernet driver

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -59,7 +59,7 @@ static uint32_t phys_lo32(void *addr)
 static enum ethernet_hw_caps dwmac_caps(const struct device *dev __unused,
 					struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
+	return 0
 #ifdef CONFIG_NET_PROMISCUOUS_MODE
 	       | ETHERNET_PROMISC_MODE
 #endif

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -97,18 +97,10 @@ static inline uint32_t phys_lo32(void *addr)
 	return lo32((uintptr_t)addr);
 }
 
-static enum ethernet_hw_caps dwmac_caps(const struct device *dev, struct net_if *iface __unused)
+static enum ethernet_hw_caps dwmac_caps(const struct device *dev __unused,
+					struct net_if *iface __unused)
 {
-	struct dwmac_priv *p = dev->data;
 	enum ethernet_hw_caps caps = 0;
-
-	if (p->feature0 & MAC_HW_FEATURE0_GMIISEL) {
-		caps |= ETHERNET_LINK_1000BASE;
-	}
-
-	if (p->feature0 & MAC_HW_FEATURE0_MIISEL) {
-		caps |= ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
-	}
 
 	caps |= ETHERNET_PROMISC_MODE;
 

--- a/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
+++ b/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
@@ -1595,8 +1595,6 @@ static enum ethernet_hw_caps eth_dwc_xgmac_get_capabilities(const struct device 
 {
 	enum ethernet_hw_caps caps = (enum ethernet_hw_caps)0;
 
-	caps = (ETHERNET_LINK_1000BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_10BASE);
-
 #ifdef CONFIG_ETH_DWC_XGMAC_RX_CS_OFFLOAD
 	caps |= ETHERNET_HW_RX_CHKSUM_OFFLOAD;
 #endif

--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -1212,8 +1212,7 @@ static void adin2111_port_iface_init(struct net_if *iface)
 static enum ethernet_hw_caps adin2111_port_get_capabilities(const struct device *dev __unused,
 							    struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE |
-		ETHERNET_HW_FILTERING
+	return ETHERNET_HW_FILTERING
 #if defined(CONFIG_NET_LLDP)
 		| ETHERNET_LLDP
 #endif

--- a/drivers/ethernet/eth_cyclonev.c
+++ b/drivers/ethernet/eth_cyclonev.c
@@ -368,13 +368,6 @@ static enum ethernet_hw_caps eth_cyclonev_caps(const struct device *dev,
 	struct eth_cyclonev_priv *p = dev->data;
 	enum ethernet_hw_caps caps = 0;
 
-	if (p->feature & EMAC_DMA_HW_FEATURE_MIISEL) {
-		caps |= ETHERNET_LINK_10BASE;
-		caps |= ETHERNET_LINK_100BASE;
-	}
-	if (p->feature & EMAC_DMA_HW_FEATURE_GMIISEL) {
-		caps |= ETHERNET_LINK_1000BASE;
-	}
 	if (p->feature & EMAC_DMA_HW_FEATURE_RXTYP2COE) {
 		caps |= ETHERNET_HW_RX_CHKSUM_OFFLOAD;
 	}

--- a/drivers/ethernet/eth_dm9051.c
+++ b/drivers/ethernet/eth_dm9051.c
@@ -744,7 +744,7 @@ static void eth_dm9051_iface_init(struct net_if *iface)
 static enum ethernet_hw_caps eth_dm9051_get_capabilities(const struct device *dev __unused,
 							 struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
+	return 0
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
 #endif

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -83,8 +83,6 @@ static enum ethernet_hw_caps e1000_caps(const struct device *dev, struct net_if 
 #if defined(CONFIG_ETH_E1000_PTP_CLOCK)
 		ETHERNET_PTP |
 #endif
-		ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE |
-		ETHERNET_LINK_1000BASE |
 		/* The driver does not really support TXTIME atm but mark
 		 * it to support it so that we can test the txtime sample.
 		 */

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -733,7 +733,7 @@ static enum ethernet_hw_caps eth_enc28j60_get_capabilities(const struct device *
 {
 	ARG_UNUSED(dev);
 
-	return ETHERNET_LINK_10BASE
+	return 0
 #if defined(CONFIG_NET_VLAN)
 		| ETHERNET_HW_VLAN
 #endif

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -495,12 +495,6 @@ static void enc424j600_rx_thread(void *p1, void *p2, void *p3)
 	}
 }
 
-static enum ethernet_hw_caps enc424j600_get_capabilities(const struct device *dev __unused,
-							 struct net_if *iface __unused)
-{
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
-}
-
 static int enc424j600_set_config(const struct device *dev,
 				 struct net_if *iface __unused,
 				 enum ethernet_config_type type,
@@ -631,7 +625,6 @@ static int enc424j600_stop_device(const struct device *dev, struct net_if *iface
 static const struct ethernet_api api_funcs = {
 	.iface_api.init		= enc424j600_iface_init,
 	.set_config		= enc424j600_set_config,
-	.get_capabilities	= enc424j600_get_capabilities,
 	.send			= enc424j600_tx,
 	.start			= enc424j600_start_device,
 	.stop			= enc424j600_stop_device,

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -481,12 +481,6 @@ static void eth_esp32_iomux_init_mii(void)
 	}
 }
 
-static enum ethernet_hw_caps eth_esp32_caps(const struct device *dev __unused,
-					    struct net_if *iface __unused)
-{
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
-}
-
 static int eth_esp32_set_config(const struct device *dev,
 				struct net_if *iface __unused,
 				enum ethernet_config_type type,
@@ -817,7 +811,6 @@ static void eth_esp32_iface_init(struct net_if *iface)
 
 static const struct ethernet_api eth_esp32_api = {
 	.iface_api.init		= eth_esp32_iface_init,
-	.get_capabilities	= eth_esp32_caps,
 	.set_config		= eth_esp32_set_config,
 	.get_phy		= eth_esp32_phy_get,
 	.send			= eth_esp32_send,

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -624,15 +624,8 @@ static void eth_iface_init(struct net_if *iface)
 			0, K_NO_WAIT);
 }
 
-static enum ethernet_hw_caps eth_gecko_get_capabilities(const struct device *dev __unused,
-						      struct net_if *iface __unused)
-{
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
-}
-
 static const struct ethernet_api eth_api = {
 	.iface_api.init = eth_iface_init,
-	.get_capabilities = eth_gecko_get_capabilities,
 	.send = eth_tx,
 };
 

--- a/drivers/ethernet/eth_ivshmem.c
+++ b/drivers/ethernet/eth_ivshmem.c
@@ -86,12 +86,6 @@ static int eth_ivshmem_stop(const struct device *dev, struct net_if *iface __unu
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_ivshmem_caps(const struct device *dev __unused,
-					      struct net_if *iface __unused)
-{
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE;
-}
-
 static int eth_ivshmem_send(const struct device *dev, struct net_pkt *pkt)
 {
 	struct eth_ivshmem_dev_data *dev_data = dev->data;
@@ -380,7 +374,6 @@ static const struct ethernet_api eth_ivshmem_api = {
 #endif
 	.start			= eth_ivshmem_start,
 	.stop			= eth_ivshmem_stop,
-	.get_capabilities	= eth_ivshmem_caps,
 	.send			= eth_ivshmem_send,
 };
 

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -118,7 +118,7 @@ static void lan865x_iface_init(struct net_if *iface)
 static enum ethernet_hw_caps lan865x_port_get_capabilities(const struct device *dev __unused,
 							   struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_PROMISC_MODE
+	return ETHERNET_PROMISC_MODE
 #if defined(CONFIG_NET_VLAN)
 	       | ETHERNET_HW_VLAN
 #endif

--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -780,7 +780,7 @@ static void lan9250_thread(void *p1, void *p2, void *p3)
 static enum ethernet_hw_caps lan9250_get_capabilities(const struct device *dev __unused,
 						      struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
+	return 0
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
 #endif

--- a/drivers/ethernet/eth_litex_liteeth.c
+++ b/drivers/ethernet/eth_litex_liteeth.c
@@ -271,7 +271,7 @@ static enum ethernet_hw_caps eth_caps(const struct device *dev __unused,
 #ifdef CONFIG_NET_LLDP
 		ETHERNET_LLDP |
 #endif
-		ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE;
+		0;
 }
 
 static const struct ethernet_api eth_api = {

--- a/drivers/ethernet/eth_numaker.c
+++ b/drivers/ethernet/eth_numaker.c
@@ -547,9 +547,9 @@ static enum ethernet_hw_caps numaker_eth_get_cap(const struct device *dev __unus
 						 struct net_if *iface __unused)
 {
 #if defined(NU_USING_HW_CHECKSUM)
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_HW_RX_CHKSUM_OFFLOAD;
+	return ETHERNET_HW_RX_CHKSUM_OFFLOAD;
 #else
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
+	return 0;
 #endif
 }
 

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -243,14 +243,12 @@ static int eth_nxp_enet_tx(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *dev,
+static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *dev __unused,
 							   struct net_if *iface __unused)
 {
-	const struct nxp_enet_mac_config *config = dev->config;
 	enum ethernet_hw_caps caps;
 
-	caps = ETHERNET_LINK_10BASE |
-		ETHERNET_HW_FILTERING |
+	caps = ETHERNET_HW_FILTERING |
 #if defined(CONFIG_NET_VLAN)
 		ETHERNET_HW_VLAN |
 #endif
@@ -264,11 +262,7 @@ static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		ETHERNET_PROMISC_MODE |
 #endif
-		ETHERNET_LINK_100BASE;
-
-	if (config->phy_mode == NXP_ENET_RGMII_MODE) {
-		caps |= ETHERNET_LINK_1000BASE;
-	}
+		0;
 
 	return caps;
 }

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -265,7 +265,7 @@ skip:
 static enum ethernet_hw_caps eth_nxp_enet_qos_get_capabilities(const struct device *dev __unused,
 							      struct net_if *iface __unused)
 {
-	enum ethernet_hw_caps caps = ETHERNET_LINK_100BASE | ETHERNET_LINK_10BASE;
+	enum ethernet_hw_caps caps = 0;
 
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 	caps |= ETHERNET_PROMISC_MODE;

--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -502,12 +502,7 @@ static int eth_nxp_s32_set_config(const struct device *dev,
 static enum ethernet_hw_caps eth_nxp_s32_get_capabilities(const struct device *dev __unused,
 							  struct net_if *iface __unused)
 {
-	return (ETHERNET_LINK_10BASE
-		| ETHERNET_LINK_100BASE
-#if (FEATURE_GMAC_RGMII_EN == 1U)
-		| ETHERNET_LINK_1000BASE
-#endif
-		| ETHERNET_HW_TX_CHKSUM_OFFLOAD
+	return (ETHERNET_HW_TX_CHKSUM_OFFLOAD
 		| ETHERNET_HW_RX_CHKSUM_OFFLOAD
 #if defined(CONFIG_NET_VLAN)
 		| ETHERNET_HW_VLAN

--- a/drivers/ethernet/eth_nxp_s32_netc.c
+++ b/drivers/ethernet/eth_nxp_s32_netc.c
@@ -254,10 +254,7 @@ static void nxp_s32_eth_rx_thread(void *arg1, void *unused1, void *unused2)
 enum ethernet_hw_caps nxp_s32_eth_get_capabilities(const struct device *dev __unused,
 						   struct net_if *iface __unused)
 {
-	return (ETHERNET_LINK_10BASE
-		| ETHERNET_LINK_100BASE
-		| ETHERNET_LINK_1000BASE
-		| ETHERNET_HW_RX_CHKSUM_OFFLOAD
+	return (ETHERNET_HW_RX_CHKSUM_OFFLOAD
 		| ETHERNET_HW_FILTERING
 #if defined(CONFIG_NET_VLAN)
 		| ETHERNET_HW_VLAN

--- a/drivers/ethernet/eth_renesas_ra.c
+++ b/drivers/ethernet/eth_renesas_ra.c
@@ -146,13 +146,6 @@ const ether_cfg_t g_ether0_cfg = {
 static struct renesas_ra_eth_config eth_0_config = {
 	.p_cfg = &g_ether0_cfg, .phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, phy_handle))};
 
-/* Driver functions */
-static enum ethernet_hw_caps renesas_ra_eth_get_capabilities(const struct device *dev __unused,
-							     struct net_if *iface __unused)
-{
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
-}
-
 void renesas_ra_eth_callback(ether_callback_args_t *p_args)
 {
 	struct device *dev = (struct device *)p_args->p_context;
@@ -316,7 +309,6 @@ static const struct device *renesas_ra_eth_get_phy(const struct device *dev,
 
 static const struct ethernet_api api_funcs = {
 	.iface_api.init = renesas_ra_eth_initialize,
-	.get_capabilities = renesas_ra_eth_get_capabilities,
 	.get_phy = renesas_ra_eth_get_phy,
 	.send = renesas_ra_eth_tx,
 };

--- a/drivers/ethernet/eth_renesas_ra_rmac.c
+++ b/drivers/ethernet/eth_renesas_ra_rmac.c
@@ -236,12 +236,6 @@ static void phy_type_setting(const struct device *dev)
 	}
 }
 
-static enum ethernet_hw_caps eth_renesas_ra_get_capabilities(const struct device *dev __unused,
-							     struct net_if *iface __unused)
-{
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE;
-}
-
 static bool renesas_ra_eth_rx(const struct device *dev)
 {
 	struct eth_renesas_ra_data *data = dev->data;
@@ -527,7 +521,6 @@ static const struct ethernet_api eth_renesas_ra_api = {
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	.get_stats = eth_renesas_ra_get_stats,
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
-	.get_capabilities = eth_renesas_ra_get_capabilities,
 	.get_phy = eth_renesas_ra_get_phy,
 	.send = eth_renesas_ra_tx,
 };

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1805,7 +1805,7 @@ static void eth_iface_init(struct net_if *iface)
 static enum ethernet_hw_caps eth_sam_gmac_get_capabilities(const struct device *dev __unused,
 							   struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE |
+	return
 #if defined(CONFIG_NET_VLAN)
 		ETHERNET_HW_VLAN |
 #endif
@@ -1816,7 +1816,7 @@ static enum ethernet_hw_caps eth_sam_gmac_get_capabilities(const struct device *
 #if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 		ETHERNET_QAV |
 #endif
-		ETHERNET_LINK_100BASE;
+		0;
 }
 
 #if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1

--- a/drivers/ethernet/eth_sensry_sy1xx_mac.c
+++ b/drivers/ethernet/eth_sensry_sy1xx_mac.c
@@ -314,8 +314,6 @@ static enum ethernet_hw_caps sy1xx_mac_get_caps(const struct device *dev __unuse
 
 	/* basic implemented features */
 	supported |= ETHERNET_PROMISC_MODE;
-	supported |= ETHERNET_LINK_1000BASE;
-	supported |= ETHERNET_PROMISC_MODE;
 
 	return supported;
 }

--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -412,12 +412,6 @@ int smsc_init(void)
 
 /* Driver functions */
 
-static enum ethernet_hw_caps eth_smsc911x_get_capabilities(const struct device *dev __unused,
-							struct net_if *iface __unused)
-{
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
-}
-
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 static struct net_stats_eth *get_stats(const struct device *dev, struct net_if *iface __unused)
 {
@@ -508,7 +502,6 @@ error:
 static const struct ethernet_api api_funcs = {
 	.iface_api.init = eth_initialize,
 
-	.get_capabilities = eth_smsc911x_get_capabilities,
 	.send = eth_tx,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	.get_stats = get_stats,

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -683,8 +683,7 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 static enum ethernet_hw_caps eth_smsc_get_caps(const struct device *dev __unused,
 					       struct net_if *iface __unused)
 {
-	return (ETHERNET_LINK_10BASE
-		| ETHERNET_LINK_100BASE
+	return (0
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
 #endif

--- a/drivers/ethernet/eth_stm32_hal2.c
+++ b/drivers/ethernet/eth_stm32_hal2.c
@@ -362,7 +362,7 @@ static const struct device *eth_stm32_hal_get_phy(const struct device *dev __unu
 static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device *dev __unused,
 							    struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
+	return 0
 #if defined(CONFIG_ETH_STM32_HW_CHECKSUM)
 		| ETHERNET_HW_RX_CHKSUM_OFFLOAD | ETHERNET_HW_TX_CHKSUM_OFFLOAD
 #endif

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -296,7 +296,7 @@ static void eth_iface_init(struct net_if *iface)
 static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device *dev __unused,
 							    struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
+	return 0
 #if defined(CONFIG_NET_VLAN)
 		| ETHERNET_HW_VLAN
 #endif

--- a/drivers/ethernet/eth_virtio_net.c
+++ b/drivers/ethernet/eth_virtio_net.c
@@ -123,13 +123,6 @@ static uint16_t virtnet_enum_queues_cb(uint16_t q_index, uint16_t q_size_max, vo
 	}
 }
 
-static enum ethernet_hw_caps virtnet_get_capabilities(const struct device *dev __unused,
-						     struct net_if *iface __unused)
-{
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE |
-	       ETHERNET_LINK_2500BASE | ETHERNET_LINK_5000BASE;
-}
-
 static int virtnet_send(const struct device *dev, struct net_pkt *pkt)
 {
 	const struct virtnet_config *config = dev->config;
@@ -231,7 +224,6 @@ static int virtnet_dev_init(const struct device *dev)
 
 static struct ethernet_api virtnet_api = {
 	.iface_api.init = virtnet_if_init,
-	.get_capabilities = virtnet_get_capabilities,
 	.send = virtnet_send,
 };
 

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -444,7 +444,7 @@ static void w5500_iface_init(struct net_if *iface)
 static enum ethernet_hw_caps w5500_get_capabilities(const struct device *dev __unused,
 						    struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
+	return 0
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
 #endif

--- a/drivers/ethernet/eth_w6100.c
+++ b/drivers/ethernet/eth_w6100.c
@@ -375,7 +375,7 @@ static void w6100_iface_init(struct net_if *iface)
 static enum ethernet_hw_caps w6100_get_capabilities(const struct device *dev __unused,
 						    struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_HW_FILTERING
+	return ETHERNET_HW_FILTERING
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
 #endif

--- a/drivers/ethernet/eth_w6300.c
+++ b/drivers/ethernet/eth_w6300.c
@@ -501,7 +501,7 @@ static enum ethernet_hw_caps w6300_get_capabilities(const struct device *dev,
 	ARG_UNUSED(dev);
 	ARG_UNUSED(iface);
 
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
+	return 0
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
 #endif

--- a/drivers/ethernet/eth_wch.c
+++ b/drivers/ethernet/eth_wch.c
@@ -551,7 +551,7 @@ static void eth_wch_iface_init(struct net_if *iface)
 static enum ethernet_hw_caps eth_wch_get_capabilities(const struct device *dev __unused,
 						      struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
+	return 0
 #if defined(CONFIG_ETH_WCH_HW_CHECKSUM)
 	       | ETHERNET_HW_RX_CHKSUM_OFFLOAD
 #endif

--- a/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
+++ b/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
@@ -164,12 +164,6 @@ static const struct device *axi_eth_lite_get_phy(const struct device *dev,
 	return config->phy;
 }
 
-static enum ethernet_hw_caps axi_eth_lite_get_caps(const struct device *dev __unused,
-						    struct net_if *iface __unused)
-{
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
-}
-
 static void axi_eth_lite_phy_link_state_changed(const struct device *phydev __unused,
 						struct phy_link_state *state, void *user_data)
 {
@@ -320,7 +314,6 @@ static int axi_eth_lite_send(const struct device *dev, struct net_pkt *pkt)
 
 static const struct ethernet_api axi_eth_lite_api = {
 	.get_phy = axi_eth_lite_get_phy,
-	.get_capabilities = axi_eth_lite_get_caps,
 	.iface_api.init = axi_eth_lite_iface_init,
 	.set_config = axi_eth_lite_set_config,
 	.send = axi_eth_lite_send,

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -366,8 +366,7 @@ static enum ethernet_hw_caps xilinx_axienet_caps(const struct device *dev,
 						 struct net_if *iface __unused)
 {
 	const struct xilinx_axienet_config *config = dev->config;
-	enum ethernet_hw_caps ret = ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE |
-				    ETHERNET_LINK_1000BASE;
+	enum ethernet_hw_caps ret = 0;
 
 	if (config->have_rx_csum_offload) {
 		ret |= ETHERNET_HW_RX_CHKSUM_OFFLOAD;

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -594,10 +594,6 @@ static enum ethernet_hw_caps eth_xlnx_gem_get_capabilities(
 	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
 	enum ethernet_hw_caps caps = (enum ethernet_hw_caps)0;
 
-	caps |= ETHERNET_LINK_1000BASE |
-		ETHERNET_LINK_100BASE |
-		ETHERNET_LINK_10BASE;
-
 	if (!dev_conf->disable_rx_chksum_offload) {
 		caps |= ETHERNET_HW_RX_CHKSUM_OFFLOAD;
 	}

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -1110,8 +1110,7 @@ static enum ethernet_hw_caps eth_xmc4xxx_capabilities(const struct device *dev _
 						     struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
-	enum ethernet_hw_caps caps = ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE |
-				     ETHERNET_HW_TX_CHKSUM_OFFLOAD | ETHERNET_HW_RX_CHKSUM_OFFLOAD;
+	enum ethernet_hw_caps caps = ETHERNET_HW_TX_CHKSUM_OFFLOAD | ETHERNET_HW_RX_CHKSUM_OFFLOAD;
 
 #if defined(CONFIG_PTP_CLOCK_XMC4XXX)
 	caps |= ETHERNET_PTP;

--- a/drivers/ethernet/intel/eth_intel_igc.c
+++ b/drivers/ethernet/intel/eth_intel_igc.c
@@ -471,14 +471,6 @@ static void eth_intel_igc_iface_init(struct net_if *iface)
 	eth_intel_igc_intr_enable(dev);
 }
 
-static enum ethernet_hw_caps eth_intel_igc_get_caps(const struct device *dev,
-						    struct net_if *iface __unused)
-{
-	ARG_UNUSED(dev);
-
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE;
-}
-
 static int eth_intel_igc_set_config(const struct device *dev,
 				    struct net_if *iface __unused,
 				    enum ethernet_config_type type,
@@ -1204,7 +1196,6 @@ static int eth_intel_igc_init(const struct device *dev)
 
 static const struct ethernet_api eth_api = {
 	.iface_api.init = eth_intel_igc_iface_init,
-	.get_capabilities = eth_intel_igc_get_caps,
 	.set_config = eth_intel_igc_set_config,
 	.send = eth_intel_igc_tx_data,
 	.get_phy = eth_intel_igc_get_phy,

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -566,8 +566,7 @@ enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev __maybe
 {
 	uint32_t caps;
 
-	caps = (ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE |
-		ETHERNET_HW_RX_CHKSUM_OFFLOAD
+	caps = (ETHERNET_HW_RX_CHKSUM_OFFLOAD
 #if defined(CONFIG_NET_VLAN)
 		| ETHERNET_HW_VLAN
 #endif

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -360,8 +360,7 @@ void nrf_wifi_if_sniffer_rx_frm(void *os_vif_ctx, void *frm,
 enum ethernet_hw_caps nrf_wifi_if_caps_get(const struct device *dev __unused,
 					   struct net_if *iface __unused)
 {
-	enum ethernet_hw_caps caps = (ETHERNET_LINK_10BASE |
-			ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE);
+	enum ethernet_hw_caps caps = 0;
 
 #ifdef CONFIG_NRF70_TCP_IP_CHECKSUM_OFFLOAD
 	caps |= ETHERNET_HW_TX_CHKSUM_OFFLOAD |

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -151,21 +151,6 @@ enum ethernet_hw_caps {
 	/** VLAN supported */
 	ETHERNET_HW_VLAN		= BIT(2),
 
-	/** 10 Mbits link supported */
-	ETHERNET_LINK_10BASE		= BIT(3),
-
-	/** 100 Mbits link supported */
-	ETHERNET_LINK_100BASE		= BIT(4),
-
-	/** 1 Gbits link supported */
-	ETHERNET_LINK_1000BASE		= BIT(5),
-
-	/** 2.5 Gbits link supported */
-	ETHERNET_LINK_2500BASE		= BIT(6),
-
-	/** 5 Gbits link supported */
-	ETHERNET_LINK_5000BASE		= BIT(7),
-
 	/** IEEE 802.1AS (gPTP) clock supported */
 	ETHERNET_PTP			= BIT(8),
 

--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -48,11 +48,6 @@ static struct ethernet_capabilities eth_hw_caps[] = {
 	EC(ETHERNET_HW_VLAN,              "Virtual LAN"),
 	EC(ETHERNET_HW_VLAN_TAG_STRIP,    "VLAN Tag stripping"),
 #endif
-	EC(ETHERNET_LINK_10BASE,          "10 Mbits"),
-	EC(ETHERNET_LINK_100BASE,         "100 Mbits"),
-	EC(ETHERNET_LINK_1000BASE,        "1 Gbits"),
-	EC(ETHERNET_LINK_2500BASE,        "2.5 Gbits"),
-	EC(ETHERNET_LINK_5000BASE,        "5 Gbits"),
 #ifdef CONFIG_PTP_CLOCK
 	EC(ETHERNET_PTP,                  "IEEE 802.1AS gPTP clock"),
 #endif

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -572,7 +572,7 @@ static int cdc_ecm_set_config(const struct device *dev,
 static enum ethernet_hw_caps cdc_ecm_get_capabilities(const struct device *dev __unused,
 						      struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_PROMISC_MODE;
+	return ETHERNET_PROMISC_MODE;
 }
 
 static int cdc_ecm_iface_start(const struct device *dev, struct net_if *iface)

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -1142,7 +1142,7 @@ static enum ethernet_hw_caps cdc_ncm_get_capabilities(const struct device *dev _
 {
 	ARG_UNUSED(dev);
 
-	return ETHERNET_LINK_10BASE | ETHERNET_PROMISC_MODE;
+	return ETHERNET_PROMISC_MODE;
 }
 
 static int cdc_ncm_iface_start(const struct device *dev, struct net_if *iface)

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -97,9 +97,8 @@ static int eth_fake_send(const struct device *dev,
 static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev __unused,
 						       struct net_if *iface __unused)
 {
-	return  ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_QAV |
-		ETHERNET_PROMISC_MODE | ETHERNET_PRIORITY_QUEUES |
-		ETHERNET_QBV | ETHERNET_QBU | ETHERNET_TXTIME;
+	return ETHERNET_QAV | ETHERNET_PROMISC_MODE | ETHERNET_PRIORITY_QUEUES | ETHERNET_QBV |
+	       ETHERNET_QBU | ETHERNET_TXTIME;
 }
 
 static int eth_fake_get_total_bandwidth(struct eth_fake_context *ctx)

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -225,8 +225,7 @@ static int eth_fake_get_config(const struct device *dev,
 static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev __unused,
 						       struct net_if *iface __unused)
 {
-	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_QAV |
-	       ETHERNET_PROMISC_MODE | ETHERNET_PRIORITY_QUEUES;
+	return ETHERNET_QAV | ETHERNET_PROMISC_MODE | ETHERNET_PRIORITY_QUEUES;
 }
 
 static struct ethernet_api eth_fake_api_funcs = {


### PR DESCRIPTION
remove ETHERNET_LINK_* from enum ethernet_hw_caps. Since #90652 they no longer have a real use, exept being shown in the net shell. But that info is not that relevant, as we are also showing the negotiated speed of the phy.