### PR TITLE
stm32h7: fix invalid smps-direct + VOS0 combination (Vcore overvoltage)

### DIFF
--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
@@ -60,9 +60,14 @@
 	status = "okay";
 };
 
+/*
+ * In its default hardware configuration, this board uses the
+ * SMPS as power supply which prevents entry in VOS0 power mode.
+ * Configure the board to run at the maximum VOS1 speed: 400 MHz.
+ */
 &pll {
 	div-m = <1>;
-	mul-n = <120>;
+	mul-n = <100>;
 	div-p = <2>;
 	div-q = <8>;
 	div-r = <2>;
@@ -72,7 +77,7 @@
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(480)>;
+	clock-frequency = <DT_FREQ_M(400)>;
 };
 
 &lpuart1 {

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
@@ -59,9 +59,14 @@
 	status = "okay";
 };
 
+/*
+ * In its default hardware configuration, this board uses the
+ * SMPS as power supply which prevents entry in VOS0 power mode.
+ * Configure the board to run at the maximum VOS1 speed: 400 MHz.
+ */
 &pll {
 	div-m = <1>;
-	mul-n = <120>;
+	mul-n = <100>;
 	div-p = <2>;
 	div-q = <8>;
 	div-r = <2>;
@@ -89,7 +94,7 @@
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(480)>;
+	clock-frequency = <DT_FREQ_M(400)>;
 };
 
 &lpuart1 {

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -21,6 +21,9 @@
 #include <stm32_backup_domain.h>
 #include <stm32_hsem.h>
 
+/* Power supply / regulator configuration node */
+#define PWRC_NODE DT_INST(0, st_stm32h7_pwr)
+
 /* Macros to fill up prescaler values */
 #if defined(CONFIG_SOC_SERIES_STM32H7RSX)
 #define hsi_divider(v) CONCAT(LL_RCC_HSI_DIV_, v)
@@ -285,16 +288,37 @@ static uint32_t get_sysclk_frequency(void)
 
 static int32_t prepare_regulator_voltage_scale(void)
 {
-	/* Make sure to put the CPU in highest Voltage scale during clock configuration */
-	/* Highest voltage is SCALE0 */
+	/* Put the CPU in the highest voltage scale supported by the board */
 #if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	/* VOS0 is always safe to use on STM32H7RS */
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
 	while (LL_PWR_IsActiveFlag_VOSRDY() == 0) {
+	}
+#elif defined(SYSCFG_PWRCR_ODEN)
+	/*
+	 * On STM32H74x/H75x lines, VOS0 is the overdrive scale entered by
+	 * setting SYSCFG_PWRCR.ODEN, and is only valid when Vcore is generated
+	 * by the LDO (H7 Data Sheets; stm32h7xx_hal_pwr.h). Other supply modes
+	 * (e.g. SMPS-direct, LDO off) are limited to VOS1.
+	 */
+	if (DT_ENUM_HAS_VALUE(PWRC_NODE, power_supply, ldo) ||
+	    DT_ENUM_HAS_VALUE(PWRC_NODE, power_supply, smps_ldo) ||
+	    DT_ENUM_HAS_VALUE(PWRC_NODE, power_supply, smps_ext_ldo)) {
+		/* Enable the SYSCFG clock so the ODEN write takes effect. */
+		LL_APB4_GRP1_EnableClock(LL_APB4_GRP1_PERIPH_SYSCFG);
+		__HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE0);
+	} else {
+		__HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+	}
+
+	while (LL_PWR_IsActiveFlag_VOS() == 0) {
+	}
 #else
+	/* On other STM32H7 lines VOS0 does not use ODEN and is always safe */
 	__HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE0);
 	while (LL_PWR_IsActiveFlag_VOS() == 0) {
-#endif
 	}
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
## Summary

On STM32H74x/H75x boards configured for `power-supply = "smps-direct"`, the
clock-control driver selects voltage scale VOS0 (`ODEN=1`). VOS0 is only valid
when Vcore is supplied through the LDO (DS12919 Table 23; `stm32h7xx_hal_pwr.h`
comment). In smps-direct mode the LDO is bypassed (`LDOEN=0`), so setting
`ODEN=1` drives the SMPS output out of spec — **~1.5 V Vcore measured on an
STM32H755**, above the 1.40 V absolute maximum, risking permanent damage.

This was latent until commit `66fb4e16a0a` correctly started honoring `ODEN`
when requesting VOS0 on H74x/H75x. Before that the ODEN write was silently
dropped and the part stayed at VOS1, so the incompatible board configuration
went unnoticed.

`nucleo_h755zi_q` and `nucleo_h745zi_q` both select `smps-direct` in their
`.dtsi` (factory-default supply config per UM2408 Table 10) while requesting
480 MHz on the M7 — a combination that is simply invalid: smps-direct tops out
at VOS1 / 400 MHz.

## Changes

1. **`drivers: clock_control: stm32h7`** — cap the voltage scale at VOS1 when
   the `pwr` node selects `smps-direct`, instead of unconditionally selecting
   VOS0. The LDO-supplied VOS0 path is unchanged.
2. **`boards: st: nucleo_h745zi_q` / `nucleo_h755zi_q`** — set the *default* M7
   PLL to 400 MHz (`mul-n` 120 → 100, VCO 800 MHz, /P = 400 MHz) so SYSCLK
   matches the voltage scale that the factory-default smps-direct supply
   supports. The H755 `pll2` (FDCAN source) is unchanged.

   This is intentionally the default-hardware value. A board reworked for an
   LDO-supplied Vcore (`power-supply = "ldo"`/`"smps-ldo"`/`"smps-ext-ldo"`)
   can run the M7 at 480 MHz again by restoring `mul-n = <120>` /
   `clock-frequency = <DT_FREQ_M(480)>` in an overlay — the driver change in
   (1) then selects VOS0 automatically for those supplies. A DTS comment in
   each board documents this.

## Test / measurement

Measured on a Nucleo-H755ZI-Q in factory-default smps-direct config (VCAP pin):

| Build | VCAP |
| --- | --- |
| Mass-erased, no firmware | 1.215 V |
| Affected build (VOS0 written in smps-direct) | **1.509 V** (out of spec) |
| With this fix (VOS1 / 400 MHz) | ~1.22 V |

## References

- DS12919 Rev 2 (STM32H755 datasheet) Table 23 — SMPS section has no VOS0 row; VOS1 max = 400 MHz
- `stm32h7xx_hal_pwr.h`: "configuring Voltage Scale 0 is only possible when Vcore is supplied from LDO"
- PR #104749 / commit `66fb4e16a0a` — the fix that exposed this
- ST community confirmation: Nucleo-H7x5ZI-Q factory default is 400 MHz + SMPS-direct; 480 MHz needs an LDO hardware mod

Fixes #108941
