### PR TITLE
samples: sensor: distance_polling: add ESP32 overlay for HC-SR04

### DIFF
--- a/samples/sensor/distance_polling/boards/esp32_devkitc_wroom.overlay
+++ b/samples/sensor/distance_polling/boards/esp32_devkitc_wroom.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Malluri Sai Raghu
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		distance0 = &hc_sr04;
+	};
+
+	hc_sr04: hc-sr04 {
+		compatible = "hc-sr04";
+		trigger-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+		echo-gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/samples/sensor/distance_polling/sample.yaml
+++ b/samples/sensor/distance_polling/sample.yaml
@@ -12,3 +12,4 @@ tests:
     filter: dt_alias_exists("distance0")
     integration_platforms:
       - arduino_nicla_vision/stm32h747xx/m7     # vl53l1x
+      - esp32_devkitc_wroom                      # hc-sr04


### PR DESCRIPTION
Add a board overlay for esp32_devkitc_wroom to the
distance_polling sample using the HC-SR04 ultrasonic
distance sensor.

The HC-SR04 uses two GPIOs:
- Trigger pin: GPIO0 pin 4 (output, active high)
- Echo pin: GPIO0 pin 5 (input, active high)

The driver measures distance by timing the echo pulse
duration and converting to millimetres using the speed
of sound (171 mm/ms).

Also add esp32_devkitc_wroom to the integration_platforms
list in sample.yaml.

Signed-off-by: Malluri Sai Raghu <sairaghu401@gmail.com>