### PR TITLE
doc: board catalog: add scope filter for compatible search

### DIFF
--- a/doc/_extensions/zephyr/domain/static/js/board-catalog.js
+++ b/doc/_extensions/zephyr/domain/static/js/board-catalog.js
@@ -92,6 +92,14 @@ function populateFormFromURL() {
     }, 0);
   }
 
+  // Restore compatible search scope from URL
+  if (hashParams.has("compat-scope")) {
+    const toggle = document.getElementById("compat-scope-enabled");
+    if (toggle) {
+      toggle.checked = hashParams.get("compat-scope") !== "all";
+    }
+  }
+
   // Restore compatibles from URL
   if (hashParams.has("compatibles")) {
     const compatibles = hashParams.get("compatibles").split("|");
@@ -137,6 +145,7 @@ function hashIndicatesFilteredCatalogView() {
     if (key === "catalog") return true;
     if (fields.has(key) && value !== "") return true;
     if ((key === "show-boards" || key === "show-shields") && value === "false") return true;
+    if (key === "compat-scope" && value === "all") return true;
   }
   return false;
 }
@@ -188,6 +197,12 @@ function updateURL() {
   selectedCompatibles.length
     ? hashParams.set("compatibles", selectedCompatibles.join("|"))
     : hashParams.delete("compatibles");
+
+  // Persist compat-scope only when non-default (default is enabled/checked)
+  const compatScopeChecked = document.getElementById("compat-scope-enabled")?.checked ?? true;
+  !compatScopeChecked
+    ? hashParams.set("compat-scope", "all")
+    : hashParams.delete("compat-scope");
 
   window.history.replaceState({}, "", `#${hashParams.toString()}`);
 }
@@ -312,20 +327,16 @@ function setupCompatiblesField() {
   const tagInput = document.getElementById("compatibles-input");
   const datalist = document.getElementById("compatibles-list");
 
-  // Collect all unique compatibles from boards
-  const allCompatibles = Array.from(document.querySelectorAll(".board-card")).reduce(
-    (acc, board) => {
-      (board.getAttribute("data-compatibles") || "").split(" ").forEach((compat) => {
-        if (compat && !acc.includes(compat)) {
-          acc.push(compat);
-        }
-      });
-      return acc;
-    },
-    [],
-  );
+  function getCompatiblesForScope() {
+    const enabled = document.getElementById("compat-scope-enabled")?.checked ?? true;
+    const attr = enabled ? "data-compatibles-enabled" : "data-compatibles";
+    return [...new Set(
+      Array.from(document.querySelectorAll(".board-card"))
+        .flatMap((b) => (b.getAttribute(attr) || "").split(" ").filter(Boolean))
+    )].sort();
+  }
 
-  allCompatibles.sort();
+  let allCompatibles = getCompatiblesForScope();
 
   function addCompatible(compatible) {
     if (selectedCompatibles.includes(compatible) || compatible === "") return;
@@ -352,6 +363,7 @@ function setupCompatiblesField() {
   }
 
   function updateDatalist() {
+    allCompatibles = getCompatiblesForScope();
     datalist.innerHTML = "";
     const filteredCompatibles = allCompatibles.filter((c) => !selectedCompatibles.includes(c));
 
@@ -378,6 +390,12 @@ function setupCompatiblesField() {
       removeCompatible(selectedCompatibles[selectedCompatibles.length - 1]);
     }
   });
+
+  /* Refresh datalist and re-filter when the scope toggle changes */
+  const scopeToggle = document.getElementById("compat-scope-enabled");
+  if (scopeToggle) {
+    scopeToggle.addEventListener("change", updateDatalist);
+  }
 
   updateDatalist();
 }
@@ -469,6 +487,12 @@ function resetForm() {
   // Clear compatibles
   document.querySelectorAll("#compatibles-tags .tag").forEach((tag) => tag.remove());
   document.getElementById("compatibles-input").value = "";
+
+  // Reset compatible scope to default (enabled/checked)
+  const scopeToggle = document.getElementById("compat-scope-enabled");
+  if (scopeToggle) {
+    scopeToggle.checked = true;
+  }
 
   // Reset memory sliders to full range
   ["ram", "flash"].forEach((type) => {
@@ -780,6 +804,9 @@ function filterBoards() {
     (tag) => tag.textContent,
   );
 
+  const compatScopeEnabled = document.getElementById("compat-scope-enabled")?.checked ?? true;
+  const compatAttr = compatScopeEnabled ? "data-compatibles-enabled" : "data-compatibles";
+
   const resetFiltersBtn = document.getElementById("reset-filters");
   const ramFiltered = ramMinBytes > 0 || ramMaxBytes < Infinity;
   const flashFiltered = flashMinBytes > 0 || flashMaxBytes < Infinity;
@@ -792,6 +819,7 @@ function filterBoards() {
     socSocSelect.selectedOptions.length ||
     selectedHWTags.length ||
     selectedCompatibles.length ||
+    !compatScopeEnabled ||
     !showBoards ||
     !showShields
   ) {
@@ -811,7 +839,7 @@ function filterBoards() {
     const boardSupportedFeatures = (board.getAttribute("data-supported-features") || "")
       .split(" ")
       .filter(Boolean);
-    const boardCompatibles = (board.getAttribute("data-compatibles") || "")
+    const boardCompatibles = (board.getAttribute(compatAttr) || "")
       .split(" ")
       .filter(Boolean);
     const isShield = board.classList.contains("shield");

--- a/doc/_extensions/zephyr/domain/templates/board-card.html
+++ b/doc/_extensions/zephyr/domain/templates/board-card.html
@@ -38,6 +38,17 @@
     {%- endfor -%}
     {{- all_compatibles|join(' ') -}}
   "
+  data-compatibles-enabled="
+    {%- set enabled_compatibles = [] -%}
+    {%- for target_compatibles in board.compatibles_enabled.values() -%}
+      {%- for compatible in target_compatibles -%}
+        {%- if compatible not in enabled_compatibles -%}
+          {%- set _ = enabled_compatibles.append(compatible) -%}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endfor -%}
+    {{- enabled_compatibles|join(' ') -}}
+  "
   data-maintained="{{ board.maintained | tojson }}"
   tabindex="0">
   <div class="vendor">{{ vendors[board.vendor] }}</div>

--- a/doc/_extensions/zephyr/domain/templates/board-catalog.html
+++ b/doc/_extensions/zephyr/domain/templates/board-catalog.html
@@ -112,7 +112,17 @@
   </div>
 
   <div class="form-group" style="flex-basis: 100%">
-    <label for="compatibles-input">Supported devices (compatible strings, supports wildcards)</label>
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+      <label for="compatibles-input">Supported devices (compatible strings, supports wildcards)</label>
+      <div class="toggle-group">
+        <input type="checkbox" id="compat-scope-enabled" checked
+          {% if not hw_features_present %}disabled{% endif %}>
+        <label for="compat-scope-enabled" class="toggle-label">
+          <span class="toggle-switch"></span>
+          <span class="toggle-text">Enabled</span>
+        </label>
+      </div>
+    </div>
     <div class="tag-container" id="compatibles-tags">
       <input list="compatibles-list" class="tag-input" id="compatibles-input"
         placeholder="{% if hw_features_present -%}

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -259,6 +259,7 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
 
         supported_features = {}
         compatibles = {}
+        compatibles_enabled = {}
         target_memory = []
 
         # Use pre-gathered build info and DTS files
@@ -266,6 +267,7 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
             for board_target, edt in board_devicetrees[board.name].items():
                 features = {}
                 target_compatibles = set()
+                target_enabled_compatibles = set()
                 ram_size = get_board_memory_size(edt, "zephyr,sram")
                 flash_size = get_board_memory_size(edt, "zephyr,flash")
                 if ram_size is not None or flash_size is not None:
@@ -308,6 +310,8 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
 
                     existing_feature = features.get(binding_type, {}).get(node.matching_compat)
                     target_compatibles.add(node.matching_compat)
+                    if node.status == "okay":
+                        target_enabled_compatibles.add(node.matching_compat)
 
                     node_info = {
                         "filename": str(filename),
@@ -341,6 +345,7 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
                     "features": features,
                 }
                 compatibles[board_target] = list(target_compatibles)
+                compatibles_enabled[board_target] = list(target_enabled_compatibles)
 
         board_runner_info = {}
         if board.name in board_runners:
@@ -378,6 +383,7 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
             "revision_default": board.revision_default,
             "supported_features": supported_features,
             "compatibles": compatibles,
+            "compatibles_enabled": compatibles_enabled,
             "image": guess_image(board),
             "maintained": is_board_maintained(doc_page_path) if doc_page_path else False,
             # Per-target zephyr,sram / zephyr,flash sizes in bytes.


### PR DESCRIPTION
The compatible search returned false positives: boards whose SoC has a peripheral but no on-board wiring (e.g. Ethernet MAC without a PHY) appeared in results.

Add an "Enabled" toggle next to the "Supported devices" label. When on (default), only components with DTS status = "okay" are matched. When off, all components including on-chip ones are searched, restoring the previous behavior.

gen_boards_catalog.py: track a second compatible set restricted to okay nodes; emit it as "compatibles_enabled" in the catalog dict.

board-card.html: expose it as data-compatibles-enabled on each card.

board-catalog.html: add the scope toggle on the right of the "Supported devices" label row; disabled when hw_features_present is false.

board-catalog.js: scope-aware attribute selection in filterBoards(), scope-aware datalist in setupCompatiblesField(), URL persistence in updateURL()/populateFormFromURL(), reset in resetForm().

Fixes #101257

Assisted-by: GitHub Copilot:claude-sonnet-4.6