### PR TITLE
include: dt-bindings: clock: stm32: add Doxygen documentation

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32_clock.h
@@ -7,26 +7,44 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_CLOCK_H_
 
 /* clock bus references */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    1
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    2
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    3
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  4
+/** @brief IOP bus clock enable register offset */
 #define STM32_CLOCK_BUS_IOP     5
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3    6
+/** @brief AHB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB4    7
+/** @brief AHB5 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB5    8
+/** @brief AHB6 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB6    9
+/** @brief APB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3    10
+/** @brief APB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB4    11
+/** @brief APB5 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB5    12
+/** @brief AXI bus clock enable register offset */
 #define STM32_CLOCK_BUS_AXI     13
+/** @brief MLAHB bus clock enable register offset */
 #define STM32_CLOCK_BUS_MLAHB   14
+/** @brief APB4_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB4_2  15
 
+/** @brief Bit shift position for the STM32 clock divider field */
 #define STM32_CLOCK_DIV_SHIFT	12
 
-/** Clock divider */
+/* Clock divider */
+/** @brief Compute the STM32 clock divider configuration field value from a divisor */
 #define STM32_CLOCK_DIV(div)	(((div) - 1) << STM32_CLOCK_DIV_SHIFT)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32_common_clocks.h
+++ b/include/zephyr/dt-bindings/clock/stm32_common_clocks.h
@@ -6,28 +6,42 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_COMMON_CLOCKS_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_COMMON_CLOCKS_H_
 
-/** System clock */
+/* System clock */
+/** @brief Clock source identifier for SYSCLK */
 #define STM32_SRC_SYSCLK	0x001
-/** Fixed clocks  */
+/* Fixed clocks */
+/** @brief Clock source identifier for LSE */
 #define STM32_SRC_LSE		0x002
+/** @brief Clock source identifier for LSI */
 #define STM32_SRC_LSI		0x003
 
-/** Dummy: Add a specifier when no selection is possible */
+/* Dummy: Add a specifier when no selection is possible */
+/** @brief Dummy specifier used when no kernel clock source selection is available */
 #define NO_SEL			0xFF
 
+/** @brief Bit shift position for the STM32 clock divider field */
 #define STM32_CLOCK_DIV_SHIFT	12
 
-/** Clock divider */
+/* Clock divider */
+/** @brief Compute the STM32 clock divider configuration field value from a divisor */
 #define STM32_CLOCK_DIV(div)	(((div) - 1) << STM32_CLOCK_DIV_SHIFT)
 
-/** Helper macros to pack RCC clock source selection register info in the DT */
+/* Helper macros to pack RCC clock source selection register info in the DT */
+/** @brief DT clock select helper: reg mask */
 #define STM32_DT_CLKSEL_REG_MASK	0xFFFFU
+/** @brief DT clock select helper: reg shift */
 #define STM32_DT_CLKSEL_REG_SHIFT	0U
+/** @brief DT clock select helper: shift mask */
 #define STM32_DT_CLKSEL_SHIFT_MASK	0x1FU
+/** @brief DT clock select helper: shift shift */
 #define STM32_DT_CLKSEL_SHIFT_SHIFT	16U
+/** @brief DT clock select helper: width mask */
 #define STM32_DT_CLKSEL_WIDTH_MASK	0x3U
+/** @brief DT clock select helper: width shift */
 #define STM32_DT_CLKSEL_WIDTH_SHIFT	21U
+/** @brief DT clock select helper: val mask */
 #define STM32_DT_CLKSEL_VAL_MASK	0xFFU
+/** @brief DT clock select helper: val shift */
 #define STM32_DT_CLKSEL_VAL_SHIFT	24U
 
 /**

--- a/include/zephyr/dt-bindings/clock/stm32c0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c0_clock.h
@@ -8,13 +8,19 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief IOP bus clock enable register offset */
 #define STM32_CLOCK_BUS_IOP     0x034
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x038
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x03c
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x040
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_IOP
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1_2
 
 /** Domain clocks */
@@ -27,15 +33,21 @@
  * STM32_SRC_HSI relates to HSI48 clock mentioned in RM0490 Reference Manual
  * STM32_SRC_HSI48 relates to HSIUSB48 mentioned in RM0490 Reference Manual
  */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI + 1)
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_HSI48 + 1)
-/** Peripheral bus clock */
+/* Peripheral bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
 
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x54
+/** @brief RCC CCIPR2 register offset */
 #define CCIPR2_REG		0x58
 
 /** @brief RCC_CSR1 register offset */
@@ -45,31 +57,50 @@
 #define CFGR1_REG               0x08
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR devices */
+/* CCIPR devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR_REG)
+/** @brief Kernel clock source selection for FDCAN */
 #define FDCAN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C2_I2S1 */
 #define I2C2_I2S1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 15, 14, CCIPR_REG)
+/** @brief Kernel clock source selection for ADC */
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 30, CCIPR_REG)
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for USB */
 #define USB_SEL(val)		STM32_DT_CLOCK_SELECT((val), 12, 12, CCIPR2_REG)
-/** CSR1 devices */
+/* CSR1 devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CSR1_REG)
 
-/** CFGR1 devices */
+/* CFGR1 devices */
+/** @brief MCO2 clock source selection */
 #define MCO2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 19, 16, CFGR1_REG)
+/** @brief MCO2 prescaler selection */
 #define MCO2_PRE(val)           STM32_DT_CLOCK_SELECT((val), 23, 20, CFGR1_REG)
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 31, 28, CFGR1_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1   0
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2   1
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4   2
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8   3
+/** @brief MCO prescaler division factor: 16 */
 #define MCO_PRE_DIV_16  4
+/** @brief MCO prescaler division factor: 32 */
 #define MCO_PRE_DIV_32  5
+/** @brief MCO prescaler division factor: 64 */
 #define MCO_PRE_DIV_64  6
+/** @brief MCO prescaler division factor: 128 */
 #define MCO_PRE_DIV_128 7
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32c5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c5_clock.h
@@ -11,7 +11,6 @@
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C5_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C5_CLOCK_H_
-/** @cond INTERNAL_HIDDEN */
 
 #include "stm32_common_clocks.h"
 
@@ -21,39 +20,62 @@
 
 /** System clock */
 /* defined in stm32_common_clocks.h */
-/** Fixed clocks  */
+/* Fixed clocks */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSIS */
 #define STM32_SRC_HSIS		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for HSIDIV3 */
 #define STM32_SRC_HSIDIV3	(STM32_SRC_HSIS + 1)
+/** @brief Clock source identifier for HSIK */
 #define STM32_SRC_HSIK		(STM32_SRC_HSIDIV3 + 1)
+/** @brief Clock source identifier for PSIS */
 #define STM32_SRC_PSIS		(STM32_SRC_HSIK + 1)
+/** @brief Clock source identifier for PSIDIV3 */
 #define STM32_SRC_PSIDIV3	(STM32_SRC_PSIS + 1)
+/** @brief Clock source identifier for PSIK */
 #define STM32_SRC_PSIK		(STM32_SRC_PSIDIV3 + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for HCLK */
 #define STM32_SRC_HCLK		(STM32_SRC_PSIK + 1)
+/** @brief Clock source identifier for PCLK1 */
 #define STM32_SRC_PCLK1		(STM32_SRC_HCLK + 1)
+/** @brief Clock source identifier for PCLK2 */
 #define STM32_SRC_PCLK2		(STM32_SRC_PCLK1 + 1)
+/** @brief Clock source identifier for PCLK3 */
 #define STM32_SRC_PCLK3		(STM32_SRC_PCLK2 + 1)
 /* Clock muxes */
+/** @brief Clock source identifier for CK48 */
 #define STM32_SRC_CK48		(STM32_SRC_PCLK3 + 1)
 /** External clock */
 /* #define STM32_SRC_AUDIOCLK	TBD */
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x088
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x08C
+/** @brief AHB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB4    0x094
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x09C
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x0A0
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x0A4
+/** @brief APB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3    0x0A8
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB3
 
 /** @brief RCC_CCIPRx register offset (RM0522.pdf) */
 #define CCIPR1_REG		0xD8
+/** @brief RCC CCIPR2 register offset */
 #define CCIPR2_REG		0xDC
+/** @brief RCC CCIPR3 register offset */
 #define CCIPR3_REG		0xE0
 
 /** @brief RCC_BDCR register offset */
@@ -63,81 +85,143 @@
 #define CFGR1_REG               0x1C
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR1 devices */
+/* CCIPR1 devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR1_REG)
+/** @brief Kernel clock source selection for UART4 */
 #define UART4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR1_REG)
+/** @brief Kernel clock source selection for UART5 */
 #define UART5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART6 */
 #define USART6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR1_REG)
+/** @brief Kernel clock source selection for UART7 */
 #define UART7_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR1_REG)
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 15, 14, CCIPR1_REG)
+/** @brief Kernel clock source selection for SPI1 */
 #define SPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR1_REG)
+/** @brief Kernel clock source selection for SPI2 */
 #define SPI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR1_REG)
+/** @brief Kernel clock source selection for SPI3 */
 #define SPI3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR1_REG)
+/** @brief Kernel clock source selection for FDCAN */
 #define FDCAN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR1_REG)
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR2_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR2_REG)
+/** @brief Kernel clock source selection for I3C1 */
 #define I3C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR2_REG)
+/** @brief Kernel clock source selection for ADCDAC */
 #define ADCDAC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR2_REG)
+/** @brief Kernel clock source selection for ADCDACPRE */
 #define ADCDACPRE_SEL(val)	STM32_DT_CLOCK_SELECT((val), 14, 12, CCIPR2_REG)
+/** @brief Kernel clock source selection for DAC */
 #define DAC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 15, CCIPR2_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR2_REG)
+/** @brief Kernel clock source selection for CK48 */
 #define CK48_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 24, CCIPR2_REG)
+/** @brief Kernel clock source selection for SYSTICK */
 #define SYSTICK_SEL(val)	STM32_DT_CLOCK_SELECT((val), 31, 30, CCIPR2_REG)
-/** CCIPR3 devices */
+/* CCIPR3 devices */
+/** @brief Kernel clock source selection for XSPI1 */
 #define XSPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR3_REG)
+/** @brief Kernel clock source selection for ETH1REFCLK */
 #define ETH1REFCLK_SEL(val)	STM32_DT_CLOCK_SELECT((val), 8, 8, CCIPR3_REG)
+/** @brief Kernel clock source selection for ETH1PTPCLK */
 #define ETH1PTPCLK_SEL(val)	STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR3_REG)
+/** @brief Kernel clock source selection for ETH1CLK */
 #define ETH1CLK_SEL(val)	STM32_DT_CLOCK_SELECT((val), 14, 13, CCIPR3_REG)
+/** @brief Kernel clock source selection for ETH1CLKDIV */
 #define ETH1CLKDIV_SEL(val)	STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR3_REG)
+/** @brief Kernel clock source selection for ETH1PTPDIV */
 #define ETH1PTPDIV_SEL(val)	STM32_DT_CLOCK_SELECT((val), 31, 28, CCIPR3_REG)
-/** RTCCR devices */
+/* RTCCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, RTCCR_REG)
 
-/** CFGR1 devices */
+/* CFGR1 devices */
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)		STM32_DT_CLOCK_SELECT((val), 21, 18, CFGR1_REG)
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 24, 22, CFGR1_REG)
+/** @brief MCO2 prescaler selection */
 #define MCO2_PRE(val)		STM32_DT_CLOCK_SELECT((val), 28, 25, CFGR1_REG)
+/** @brief MCO2 clock source selection */
 #define MCO2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 29, CFGR1_REG)
 
-/** MCO prescaler : division factor */
+/* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1		1
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2		2
+/** @brief MCO prescaler division factor: 3 */
 #define MCO_PRE_DIV_3		3
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4		4
+/** @brief MCO prescaler division factor: 5 */
 #define MCO_PRE_DIV_5		5
+/** @brief MCO prescaler division factor: 6 */
 #define MCO_PRE_DIV_6		6
+/** @brief MCO prescaler division factor: 7 */
 #define MCO_PRE_DIV_7		7
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8		8
+/** @brief MCO prescaler division factor: 9 */
 #define MCO_PRE_DIV_9		9
+/** @brief MCO prescaler division factor: 10 */
 #define MCO_PRE_DIV_10		10
+/** @brief MCO prescaler division factor: 11 */
 #define MCO_PRE_DIV_11		11
+/** @brief MCO prescaler division factor: 12 */
 #define MCO_PRE_DIV_12		12
+/** @brief MCO prescaler division factor: 13 */
 #define MCO_PRE_DIV_13		13
+/** @brief MCO prescaler division factor: 14 */
 #define MCO_PRE_DIV_14		14
+/** @brief MCO prescaler division factor: 15 */
 #define MCO_PRE_DIV_15		15
 
-/** MCO1 clock output */
+/* MCO1 clock output */
+/** @brief MCO1 clock source selection value: SYSCLK */
 #define MCO1_SEL_SYSCLK		0
+/** @brief MCO1 clock source selection value: HSE */
 #define MCO1_SEL_HSE		1
+/** @brief MCO1 clock source selection value: LSE */
 #define MCO1_SEL_LSE		2
+/** @brief MCO1 clock source selection value: LSI */
 #define MCO1_SEL_LSI		3
+/** @brief MCO1 clock source selection value: PSIK */
 #define MCO1_SEL_PSIK		4
+/** @brief MCO1 clock source selection value: HSIK */
 #define MCO1_SEL_HSIK		5
+/** @brief MCO1 clock source selection value: PSIS */
 #define MCO1_SEL_PSIS		6
+/** @brief MCO1 clock source selection value: HSIS */
 #define MCO1_SEL_HSIS		7
 
-/** MCO2 clock output */
+/* MCO2 clock output */
+/** @brief MCO2 clock source selection value: SYSCLK */
 #define MCO2_SEL_SYSCLK		0
+/** @brief MCO2 clock source selection value: HSE */
 #define MCO2_SEL_HSE		1
+/** @brief MCO2 clock source selection value: LSE */
 #define MCO2_SEL_LSE		2
+/** @brief MCO2 clock source selection value: LSI */
 #define MCO2_SEL_LSI		3
+/** @brief MCO2 clock source selection value: PSIK */
 #define MCO2_SEL_PSIK		4
+/** @brief MCO2 clock source selection value: HSIK */
 #define MCO2_SEL_HSIK		5
+/** @brief MCO2 clock source selection value: PSIDIV3 */
 #define MCO2_SEL_PSIDIV3	6
+/** @brief MCO2 clock source selection value: HSIDIV3 */
 #define MCO2_SEL_HSIDIV3	7
 
-/** @endcond */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f0_clock.h
@@ -8,12 +8,17 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus gatting clocks */
+/* Bus gatting clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x014
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x018
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x01c
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1
 
 /** Domain clocks */
@@ -22,35 +27,51 @@
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI14 */
 #define STM32_SRC_HSI14		(STM32_SRC_HSI + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI14 + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_HSI48 + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
-/** PLL clock */
+/* PLL clock */
+/** @brief Clock source identifier for PLLCLK */
 #define STM32_SRC_PLLCLK	(STM32_SRC_TIMPCLK1 + 1)
 
 /** @brief RCC_CFGRx register offset */
 #define CFGR1_REG               0x04
+/** @brief RCC CFGR3 register offset */
 #define CFGR3_REG		0x30
 
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0x20
 
 /** @brief Device domain clocks selection helpers */
-/** CFGR3 devices */
+/* CFGR3 devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CFGR3_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 4, 4, CFGR3_REG)
+/** @brief Kernel clock source selection for CEC */
 #define CEC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 6, CFGR3_REG)
+/** @brief Kernel clock source selection for USB */
 #define USB_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 7, CFGR3_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CFGR3_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CFGR3_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
-/** CFGR1 devices */
+/* CFGR1 devices */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR1_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f10x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f10x_clock.h
@@ -14,11 +14,14 @@
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
 /* Common clocks with stm32f1x defined in stm32f1_clock.h */
+/** @brief Clock source identifier for PLL2CLK */
 #define STM32_SRC_PLL2CLK           (STM32_SRC_TIMPCLK2 + 1)
+/** @brief Clock source identifier for PLL3CLK */
 #define STM32_SRC_PLL3CLK           (STM32_SRC_PLL2CLK + 1)
 
 /** CFGR1 devices */
 #undef MCO1_SEL /* Need to redefine generic F1 MCO_SEL for connectivity line devices. */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
 /* No MCO prescaler support on STM32F1 series. */
 

--- a/include/zephyr/dt-bindings/clock/stm32f1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f1_clock.h
@@ -10,12 +10,17 @@
 
 /** Domain clocks */
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x014
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x018
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x01c
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1
 
 /** System clock */
@@ -23,37 +28,53 @@
 
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI           (STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE           (STM32_SRC_HSI + 1)
+/** @brief Clock source identifier for EXT_HSE */
 #define STM32_SRC_EXT_HSE       (STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for PLLCLK */
 #define STM32_SRC_PLLCLK        (STM32_SRC_EXT_HSE + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PLLCLK + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
 
 /** @brief RCC_CFGRx register offset */
 #define CFGR1_REG               0x04
+/** @brief RCC CFGR2 register offset */
 #define CFGR2_REG		0x2C
 
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0x20
 
 /** @brief Device domain clocks selection helpers */
-/** CFGR1 devices */
+/* CFGR1 devices */
+/** @brief Clock prescaler selection for ADC */
 #define ADC_PRE(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, CFGR1_REG)
-/** CFGR2 devices */
+/* CFGR2 devices */
+/** @brief Kernel clock source selection for I2S2 */
 #define I2S2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 17, CFGR2_REG)
+/** @brief Kernel clock source selection for I2S3 */
 #define I2S3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 18, CFGR2_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
-/** CFGR1 devices */
+/* CFGR1 devices */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 26, 24, CFGR1_REG)
 /* No MCO prescaler support on STM32F1 series. */
 
 /* ADC prescaler division factor */
+/** @brief ADC prescaler division factor: 2 */
 #define ADC_PRE_DIV_2		0
+/** @brief ADC prescaler division factor: 4 */
 #define ADC_PRE_DIV_4		1
+/** @brief ADC prescaler division factor: 6 */
 #define ADC_PRE_DIV_6		2
+/** @brief ADC prescaler division factor: 8 */
 #define ADC_PRE_DIV_8		3
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F1_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f37x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f37x_clock.h
@@ -26,13 +26,18 @@
 #undef ADC_PRE_DIV_256
 
 /** @brief Device domain clocks selection helpers */
-/** CFGR devices */
+/* CFGR devices */
+/** @brief Clock prescaler selection for ADC */
 #define ADC_PRE(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, CFGR_REG)
 
 /* ADC prescaler division factor for STM32F37x */
+/** @brief ADC prescaler division factor: 2 */
 #define ADC_PRE_DIV_2		0
+/** @brief ADC prescaler division factor: 4 */
 #define ADC_PRE_DIV_4		1
+/** @brief ADC prescaler division factor: 6 */
 #define ADC_PRE_DIV_6		2
+/** @brief ADC prescaler division factor: 8 */
 #define ADC_PRE_DIV_8		3
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F37X_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f3_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f3_clock.h
@@ -8,12 +8,17 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus gatting clocks */
+/* Bus gatting clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x014
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x018
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x01c
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1
 
 /** Domain clocks */
@@ -24,65 +29,108 @@
 
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
 /* #define STM32_SRC_HSI48	TDB */
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_HSI + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
+/** @brief Clock source identifier for TIMPLLCLK */
 #define STM32_SRC_TIMPLLCLK	(STM32_SRC_TIMPCLK2 + 1)
-/** PLL clock */
+/* PLL clock */
+/** @brief Clock source identifier for PLLCLK */
 #define STM32_SRC_PLLCLK	(STM32_SRC_TIMPLLCLK + 1)
 
 /** @brief RCC_CFGRx register offset */
 #define CFGR_REG		0x04
+/** @brief RCC CFGR2 register offset */
 #define CFGR2_REG		0x2C
+/** @brief RCC CFGR3 register offset */
 #define CFGR3_REG		0x30
 
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0x20
 
 /** @brief Device domain clocks selection helpers) */
-/** CFGR devices */
+/* CFGR devices */
+/** @brief Kernel clock source selection for I2S */
 #define I2S_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 23, CFGR_REG)
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 26, 24, CFGR_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR_REG)
-/** CFGR2 devices */
+/* CFGR2 devices */
+/** @brief Clock prescaler selection for ADC12 */
 #define ADC12_PRE(val)		STM32_DT_CLOCK_SELECT((val), 8, 4, CFGR2_REG)
+/** @brief Clock prescaler selection for ADC34 */
 #define ADC34_PRE(val)		STM32_DT_CLOCK_SELECT((val), 13, 9, CFGR2_REG)
-/** CFGR3 devices */
+/* CFGR3 devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CFGR3_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 4, 4, CFGR3_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 5, CFGR3_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 6, CFGR3_REG)
+/** @brief Kernel clock source selection for TIM1 */
 #define TIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 8, 8, CFGR3_REG)
+/** @brief Kernel clock source selection for TIM8 */
 #define TIM8_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 9, CFGR3_REG)
+/** @brief Kernel clock source selection for TIM15 */
 #define TIM15_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 10, CFGR3_REG)
+/** @brief Kernel clock source selection for TIM16 */
 #define TIM16_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 11, CFGR3_REG)
+/** @brief Kernel clock source selection for TIM17 */
 #define TIM17_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 13, CFGR3_REG)
+/** @brief Kernel clock source selection for TIM20 */
 #define TIM20_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 15, CFGR3_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CFGR3_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CFGR3_REG)
+/** @brief Kernel clock source selection for USART4 */
 #define USART4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CFGR3_REG)
+/** @brief Kernel clock source selection for USART5 */
 #define USART5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, CFGR3_REG)
+/** @brief Kernel clock source selection for TIM2 */
 #define TIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 24, 24, CFGR3_REG)
+/** @brief Kernel clock source selection for TIM3_4 */
 #define TIM3_4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 25, CFGR3_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
 /* ADC prescaler division factor for all F3 except F37x */
+/** @brief ADC_PRE_DISABLED: adc pre disabled */
 #define ADC_PRE_DISABLED	0x0
+/** @brief ADC prescaler division factor: 1 */
 #define ADC_PRE_DIV_1		0x10
+/** @brief ADC prescaler division factor: 2 */
 #define ADC_PRE_DIV_2		0x11
+/** @brief ADC prescaler division factor: 4 */
 #define ADC_PRE_DIV_4		0x12
+/** @brief ADC prescaler division factor: 6 */
 #define ADC_PRE_DIV_6		0x13
+/** @brief ADC prescaler division factor: 8 */
 #define ADC_PRE_DIV_8		0x14
+/** @brief ADC prescaler division factor: 10 */
 #define ADC_PRE_DIV_10		0x15
+/** @brief ADC prescaler division factor: 12 */
 #define ADC_PRE_DIV_12		0x16
+/** @brief ADC prescaler division factor: 16 */
 #define ADC_PRE_DIV_16		0x17
+/** @brief ADC prescaler division factor: 32 */
 #define ADC_PRE_DIV_32		0x18
+/** @brief ADC prescaler division factor: 64 */
 #define ADC_PRE_DIV_64		0x19
+/** @brief ADC prescaler division factor: 128 */
 #define ADC_PRE_DIV_128		0x1A
+/** @brief ADC prescaler division factor: 256 */
 #define ADC_PRE_DIV_256		0x1B
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F3_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f410_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f410_clock.h
@@ -10,22 +10,34 @@
 
 /** @brief RCC_DCKCFGR register offset */
 #define DCKCFGR_REG		0x8C
+/** @brief RCC DCKCFGR2 register offset */
 #define DCKCFGR2_REG		0x94
 
 /** @brief Device domain clocks selection helpers */
-/** DCKCFGR devices */
+/* DCKCFGR devices */
+/** @brief Kernel clock source selection for CKDFSDM2A */
 #define CKDFSDM2A_SEL(val)	STM32_DT_CLOCK_SELECT((val), 14, 14, DCKCFGR_REG)
+/** @brief Kernel clock source selection for CKDFSDM1A */
 #define CKDFSDM1A_SEL(val)	STM32_DT_CLOCK_SELECT((val), 15, 15, DCKCFGR_REG)
+/** @brief Kernel clock source selection for SAI1A */
 #define SAI1A_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, DCKCFGR_REG)
+/** @brief Kernel clock source selection for SAI1B */
 #define SAI1B_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, DCKCFGR_REG)
+/** @brief Kernel clock source selection for I2S1 */
 #define I2S1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 25, DCKCFGR_REG)
+/** @brief Kernel clock source selection for I2S2 */
 #define I2S2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 28, 27, DCKCFGR_REG)
+/** @brief Kernel clock source selection for CKDFSDM */
 #define CKDFSDM_SEL(val)	STM32_DT_CLOCK_SELECT((val), 31, 31, DCKCFGR_REG)
 
-/** DCKCFGR2 devices */
+/* DCKCFGR2 devices */
+/** @brief Kernel clock source selection for I2CFMP1 */
 #define I2CFMP1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 23, 22, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for CK48M */
 #define CK48M_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 27, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for SDIO */
 #define SDIO_SEL(val)		STM32_DT_CLOCK_SELECT((val), 28, 28, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 30, DCKCFGR2_REG)
 
 /* F4 generic I2S_SEL is not compatible with F410 devices */

--- a/include/zephyr/dt-bindings/clock/stm32f427_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f427_clock.h
@@ -12,13 +12,20 @@
 #define DCKCFGR_REG		0x8C
 
 /** @brief Device domain clocks selection helpers */
-/** DCKCFGR devices */
+/* DCKCFGR devices */
+/** @brief Kernel clock source selection for CKDFSDM2A */
 #define CKDFSDM2A_SEL(val)	STM32_DT_CLOCK_SELECT((val), 14, 14, DCKCFGR_REG)
+/** @brief Kernel clock source selection for CKDFSDM1A */
 #define CKDFSDM1A_SEL(val)	STM32_DT_CLOCK_SELECT((val), 15, 15, DCKCFGR_REG)
+/** @brief Kernel clock source selection for SAI1A */
 #define SAI1A_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, DCKCFGR_REG)
+/** @brief Kernel clock source selection for SAI1B */
 #define SAI1B_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, DCKCFGR_REG)
+/** @brief Kernel clock source selection for CK48M */
 #define CK48M_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 27, DCKCFGR_REG)
+/** @brief Kernel clock source selection for SDMMC */
 #define SDMMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 28, 28, DCKCFGR_REG)
+/** @brief Kernel clock source selection for DSI */
 #define DSI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 29, DCKCFGR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F427_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f4_clock.h
@@ -10,15 +10,23 @@
 
 /** Domain clocks */
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1 0x030
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2 0x034
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3 0x038
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1 0x040
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2 0x044
+/** @brief APB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3 0x0A8
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX STM32_CLOCK_BUS_APB3
 
 /** Domain clocks */
@@ -28,29 +36,48 @@
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_HSI + 1)
-/** PLL clock outputs */
+/* PLL clock outputs */
+/** @brief Clock source identifier for PLL_P */
 #define STM32_SRC_PLL_P		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for PLL_Q */
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
+/** @brief Clock source identifier for PLL_R */
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
+/** @brief Clock source identifier for PLL_POST_R */
 #define STM32_SRC_PLL_POST_R	(STM32_SRC_PLL_R + 1)
-/** PLLI2S clock outputs */
+/* PLLI2S clock outputs */
+/** @brief Clock source identifier for PLLI2S_P */
 #define STM32_SRC_PLLI2S_P	(STM32_SRC_PLL_POST_R + 1)
+/** @brief Clock source identifier for PLLI2S_Q */
 #define STM32_SRC_PLLI2S_Q	(STM32_SRC_PLLI2S_P + 1)
+/** @brief Clock source identifier for PLLI2S_POST_Q */
 #define STM32_SRC_PLLI2S_POST_Q	(STM32_SRC_PLLI2S_Q + 1)
+/** @brief Clock source identifier for PLLI2S_R */
 #define STM32_SRC_PLLI2S_R	(STM32_SRC_PLLI2S_POST_Q + 1)
+/** @brief Clock source identifier for PLLI2S_POST_R */
 #define STM32_SRC_PLLI2S_POST_R	(STM32_SRC_PLLI2S_R + 1)
 /* PLLSAI clock outputs */
+/** @brief Clock source identifier for PLLSAI_P */
 #define STM32_SRC_PLLSAI_P	(STM32_SRC_PLLI2S_POST_R + 1)
+/** @brief Clock source identifier for PLLSAI_Q */
 #define STM32_SRC_PLLSAI_Q	(STM32_SRC_PLLSAI_P + 1)
+/** @brief Clock source identifier for PLLSAI_POST_Q */
 #define STM32_SRC_PLLSAI_POST_Q	(STM32_SRC_PLLSAI_Q + 1)
+/** @brief Clock source identifier for PLLSAI_R */
 #define STM32_SRC_PLLSAI_R	(STM32_SRC_PLLSAI_POST_Q + 1)
+/** @brief Clock source identifier for PLLSAI_POST_R */
 #define STM32_SRC_PLLSAI_POST_R	(STM32_SRC_PLLSAI_R + 1)
 /* CLK48MHz sources */
+/** @brief Clock source identifier for CK48 */
 #define STM32_SRC_CK48		(STM32_SRC_PLLSAI_POST_R + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_CK48 + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
 
 
@@ -63,20 +90,31 @@
 #define BDCR_REG 0x70
 
 /** @brief Device domain clocks selection helpers */
-/** CFGR devices */
+/* CFGR devices */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val) STM32_DT_CLOCK_SELECT((val), 22, 21, CFGR_REG)
+/** @brief Kernel clock source selection for I2S */
 #define I2S_SEL(val)  STM32_DT_CLOCK_SELECT((val), 23, 23, CFGR_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val) STM32_DT_CLOCK_SELECT((val), 26, 24, CFGR_REG)
+/** @brief MCO2 prescaler selection */
 #define MCO2_PRE(val) STM32_DT_CLOCK_SELECT((val), 29, 27, CFGR_REG)
+/** @brief MCO2 clock source selection */
 #define MCO2_SEL(val) STM32_DT_CLOCK_SELECT((val), 31, 30, CFGR_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)  STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1 0
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2 4
+/** @brief MCO prescaler division factor: 3 */
 #define MCO_PRE_DIV_3 5
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4 6
+/** @brief MCO prescaler division factor: 5 */
 #define MCO_PRE_DIV_5 7
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f7_clock.h
@@ -10,15 +10,23 @@
 
 /** Domain clocks */
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x030
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x034
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3    0x038
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x040
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x044
+/** @brief APB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3    0x0A8
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB3
 
 /** Domain clocks */
@@ -29,26 +37,43 @@
 
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE           (STM32_SRC_HSI + 1)
-/** PLL clock outputs */
+/* PLL clock outputs */
+/** @brief Clock source identifier for PLL_P */
 #define STM32_SRC_PLL_P		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for PLL_Q */
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
+/** @brief Clock source identifier for PLL_R */
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
-/** PLLI2S clock outputs */
+/* PLLI2S clock outputs */
+/** @brief Clock source identifier for PLLI2S_P */
 #define STM32_SRC_PLLI2S_P	(STM32_SRC_PLL_R + 1)
+/** @brief Clock source identifier for PLLI2S_Q */
 #define STM32_SRC_PLLI2S_Q	(STM32_SRC_PLLI2S_P + 1)
+/** @brief Clock source identifier for PLLI2S_POST_Q */
 #define STM32_SRC_PLLI2S_POST_Q	(STM32_SRC_PLLI2S_Q + 1)
+/** @brief Clock source identifier for PLLI2S_R */
 #define STM32_SRC_PLLI2S_R	(STM32_SRC_PLLI2S_POST_Q + 1)
 /* PLLSAI clock outputs */
+/** @brief Clock source identifier for PLLSAI_P */
 #define STM32_SRC_PLLSAI_P	(STM32_SRC_PLLI2S_R + 1)
+/** @brief Clock source identifier for PLLSAI_Q */
 #define STM32_SRC_PLLSAI_Q	(STM32_SRC_PLLSAI_P + 1)
+/** @brief Clock source identifier for PLLSAI_POST_Q */
 #define STM32_SRC_PLLSAI_POST_Q	(STM32_SRC_PLLSAI_Q + 1)
+/** @brief Clock source identifier for PLLSAI_R */
 #define STM32_SRC_PLLSAI_R	(STM32_SRC_PLLSAI_POST_Q + 1)
+/** @brief Clock source identifier for PLLSAI_POST_R */
 #define STM32_SRC_PLLSAI_POST_R	(STM32_SRC_PLLSAI_R + 1)
-/** Peripheral bus clock */
+/* Peripheral bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_PLLSAI_POST_R + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
 
 /** @brief RCC_CFGRx register offset */
@@ -58,46 +83,76 @@
 #define BDCR_REG		0x70
 
 /** @brief Device domain clocks selection helpers */
-/** CFGR devices */
+/* CFGR devices */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 22, 21, CFGR_REG)
+/** @brief Kernel clock source selection for I2S */
 #define I2S_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 23, CFGR_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 26, 24, CFGR_REG)
+/** @brief MCO2 prescaler selection */
 #define MCO2_PRE(val)           STM32_DT_CLOCK_SELECT((val), 29, 27, CFGR_REG)
+/** @brief MCO2 clock source selection */
 #define MCO2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 31, 30, CFGR_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1 0
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2 4
+/** @brief MCO prescaler division factor: 3 */
 #define MCO_PRE_DIV_3 5
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4 6
+/** @brief MCO prescaler division factor: 5 */
 #define MCO_PRE_DIV_5 7
 
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
 /** @brief RCC_DKCFGR register offset */
 #define DCKCFGR1_REG		0x8C
+/** @brief RCC DCKCFGR2 register offset */
 #define DCKCFGR2_REG		0x90
 
 /** @brief Dedicated clocks configuration register selection helpers */
-/** DKCFGR2 devices */
+/* DKCFGR2 devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for USART4 */
 #define USART4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 6, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for USART5 */
 #define USART5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for USART6 */
 #define USART6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 10, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for USART7 */
 #define USART7_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for USART8 */
 #define USART8_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for I2C4 */
 #define I2C4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 24, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for CEC */
 #define CEC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 26, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for CK48M */
 #define CK48M_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 27, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for SDMMC1 */
 #define SDMMC1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 28, 28, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for SDMMC2 */
 #define SDMMC2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 29, DCKCFGR2_REG)
+/** @brief Kernel clock source selection for DSI */
 #define DSI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 30, 30, DCKCFGR2_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F7_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g0_b1x_c1x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_b1x_c1x_clock.h
@@ -8,15 +8,23 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_B1X_C1X_CLOCK_H_
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 256 */
 #define MCO_PRE_DIV_256  8
+/** @brief MCO prescaler division factor: 512 */
 #define MCO_PRE_DIV_512  9
+/** @brief MCO prescaler division factor: 1024 */
 #define MCO_PRE_DIV_1024 10
 
 /* MCO clock output */
+/** @brief MCO clock source selection value: HSI48 */
 #define MCO_SEL_HSI48     2
+/** @brief MCO clock source selection value: PLLPCLK */
 #define MCO_SEL_PLLPCLK   8
+/** @brief MCO clock source selection value: PLLQCLK */
 #define MCO_SEL_PLLQCLK   9
+/** @brief MCO clock source selection value: RTCCLK */
 #define MCO_SEL_RTCCLK    10
+/** @brief MCO clock source selection value: RTCWAKEUP */
 #define MCO_SEL_RTCWAKEUP 11
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_B1X_C1X_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_clock.h
@@ -8,13 +8,19 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief IOP bus clock enable register offset */
 #define STM32_CLOCK_BUS_IOP     0x034
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x038
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x03c
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x040
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_IOP
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1_2
 
 /** Domain clocks */
@@ -24,16 +30,25 @@
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI + 1)
+/** @brief Clock source identifier for MSI */
 #define STM32_SRC_MSI		(STM32_SRC_HSI48 + 1)
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_MSI + 1)
-/** Peripheral bus clock */
+/* Peripheral bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
-/** PLL clock outputs */
+/* PLL clock outputs */
+/** @brief Clock source identifier for PLL_P */
 #define STM32_SRC_PLL_P		(STM32_SRC_TIMPCLK1 + 1)
+/** @brief Clock source identifier for PLL_Q */
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
+/** @brief Clock source identifier for PLL_R */
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
 
 /** @brief RCC_CFGR register offset */
@@ -41,56 +56,94 @@
 
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x54
+/** @brief RCC CCIPR2 register offset */
 #define CCIPR2_REG		0x58
 
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0x5C
 
 /** @brief Device domain clocks selection helpers */
-/** CFGR devices */
+/* CFGR devices */
+/** @brief MCO2 clock source selection */
 #define MCO2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 19, 16, CFGR_REG)
+/** @brief MCO2 prescaler selection */
 #define MCO2_PRE(val)           STM32_DT_CLOCK_SELECT((val), 23, 20, CFGR_REG)
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 31, 28, CFGR_REG)
-/** CCIPR devices */
+/* CCIPR devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR_REG)
+/** @brief Kernel clock source selection for CEC */
 #define CEC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 6, CCIPR_REG)
+/** @brief Kernel clock source selection for LPUART2 */
 #define LPUART2_SEL(val)	STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR_REG)
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C2_I2S1 */
 #define I2C2_I2S1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 15, 14, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR_REG)
+/** @brief Kernel clock source selection for TIM1 */
 #define TIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 22, 22, CCIPR_REG)
+/** @brief Kernel clock source selection for TIM15 */
 #define TIM15_SEL(val)		STM32_DT_CLOCK_SELECT((val), 24, 24, CCIPR_REG)
+/** @brief Kernel clock source selection for RNG */
 #define RNG_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR_REG)
+/** @brief Kernel clock source selection for ADC */
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 30, CCIPR_REG)
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for I2S1 */
 #define I2S1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR2_REG)
+/** @brief Kernel clock source selection for I2S2 */
 #define I2S2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR2_REG)
+/** @brief Kernel clock source selection for FDCAN */
 #define FDCAN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR2_REG)
+/** @brief Kernel clock source selection for USB */
 #define USB_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR2_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1   0
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2   1
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4   2
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8   3
+/** @brief MCO prescaler division factor: 16 */
 #define MCO_PRE_DIV_16  4
+/** @brief MCO prescaler division factor: 32 */
 #define MCO_PRE_DIV_32  5
+/** @brief MCO prescaler division factor: 64 */
 #define MCO_PRE_DIV_64  6
+/** @brief MCO prescaler division factor: 128 */
 #define MCO_PRE_DIV_128 7
 
 /* MCO clock output */
+/** @brief MCO clock source selection value: SYSCLK */
 #define MCO_SEL_SYSCLK  1
+/** @brief MCO clock source selection value: HSI16 */
 #define MCO_SEL_HSI16   3
+/** @brief MCO clock source selection value: HSE */
 #define MCO_SEL_HSE     4
+/** @brief MCO clock source selection value: PLLRCLK */
 #define MCO_SEL_PLLRCLK 5
+/** @brief MCO clock source selection value: LSI */
 #define MCO_SEL_LSI     6
+/** @brief MCO clock source selection value: LSE */
 #define MCO_SEL_LSE     7
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g4_clock.h
@@ -8,15 +8,23 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x048
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x04c
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3    0x050
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x058
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x05c
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x060
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB2
 
 /** Domain clocks */
@@ -27,49 +35,79 @@
 
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI + 1)
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_HSI48 + 1)
+/** @brief Clock source identifier for MSI */
 #define STM32_SRC_MSI		(STM32_SRC_HSE + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_MSI + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
-/** PLL clock outputs */
+/* PLL clock outputs */
+/** @brief Clock source identifier for PLL_P */
 #define STM32_SRC_PLL_P		(STM32_SRC_TIMPCLK2 + 1)
+/** @brief Clock source identifier for PLL_Q */
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
+/** @brief Clock source identifier for PLL_R */
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
 /* TODO: PLLSAI clocks */
 
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x88
+/** @brief RCC CCIPR2 register offset */
 #define CCIPR2_REG		0x9C
 
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0x90
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR devices */
+/* CCIPR devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR_REG)
+/** @brief Kernel clock source selection for USART4 */
 #define USART4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR_REG)
+/** @brief Kernel clock source selection for USART5 */
 #define USART5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR_REG)
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR_REG)
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR_REG)
+/** @brief Kernel clock source selection for I2S23 */
 #define I2S23_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, CCIPR_REG)
+/** @brief Kernel clock source selection for FDCAN */
 #define FDCAN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 24, CCIPR_REG)
+/** @brief Kernel clock source selection for CLK48 */
 #define CLK48_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR_REG)
+/** @brief Kernel clock source selection for ADC12 */
 #define ADC12_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 28, CCIPR_REG)
+/** @brief Kernel clock source selection for ADC34 */
 #define ADC34_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 30, CCIPR_REG)
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for I2C4 */
 #define I2C4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR2_REG)
+/** @brief Kernel clock source selection for QSPI */
 #define QSPI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR2_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32h5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h5_clock.h
@@ -5,7 +5,6 @@
  */
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H5_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H5_CLOCK_H_
-/** @cond INTERNAL_HIDDEN */
 
 #include "stm32_common_clocks.h"
 
@@ -17,48 +16,81 @@
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for CSI */
 #define STM32_SRC_CSI		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_CSI + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for HCLK */
 #define STM32_SRC_HCLK		(STM32_SRC_HSI48 + 1)
+/** @brief Clock source identifier for PCLK1 */
 #define STM32_SRC_PCLK1		(STM32_SRC_HCLK + 1)
+/** @brief Clock source identifier for PCLK2 */
 #define STM32_SRC_PCLK2		(STM32_SRC_PCLK1 + 1)
+/** @brief Clock source identifier for PCLK3 */
 #define STM32_SRC_PCLK3		(STM32_SRC_PCLK2 + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK3 + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
-/** PLL outputs */
+/* PLL outputs */
+/** @brief Clock source identifier for PLL1_P */
 #define STM32_SRC_PLL1_P	(STM32_SRC_TIMPCLK2 + 1)
+/** @brief Clock source identifier for PLL1_Q */
 #define STM32_SRC_PLL1_Q	(STM32_SRC_PLL1_P + 1)
+/** @brief Clock source identifier for PLL1_R */
 #define STM32_SRC_PLL1_R	(STM32_SRC_PLL1_Q + 1)
+/** @brief Clock source identifier for PLL2_P */
 #define STM32_SRC_PLL2_P	(STM32_SRC_PLL1_R + 1)
+/** @brief Clock source identifier for PLL2_Q */
 #define STM32_SRC_PLL2_Q	(STM32_SRC_PLL2_P + 1)
+/** @brief Clock source identifier for PLL2_R */
 #define STM32_SRC_PLL2_R	(STM32_SRC_PLL2_Q + 1)
+/** @brief Clock source identifier for PLL3_P */
 #define STM32_SRC_PLL3_P	(STM32_SRC_PLL2_R + 1)
+/** @brief Clock source identifier for PLL3_Q */
 #define STM32_SRC_PLL3_Q	(STM32_SRC_PLL3_P + 1)
+/** @brief Clock source identifier for PLL3_R */
 #define STM32_SRC_PLL3_R	(STM32_SRC_PLL3_Q + 1)
-/** Clock muxes */
+/* Clock muxes */
+/** @brief Clock source identifier for CKPER */
 #define STM32_SRC_CKPER		(STM32_SRC_PLL3_R + 1)
 
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x088
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x08C
+/** @brief AHB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB4    0x094
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x09c
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x0A0
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x0A4
+/** @brief APB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3    0x0A8
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB3
 
 /** @brief RCC_CCIPRx register offset (RM0456.pdf) */
 #define CCIPR1_REG		0xD8
+/** @brief RCC CCIPR2 register offset */
 #define CCIPR2_REG		0xDC
+/** @brief RCC CCIPR3 register offset */
 #define CCIPR3_REG		0xE0
+/** @brief RCC CCIPR4 register offset */
 #define CCIPR4_REG		0xE4
+/** @brief RCC CCIPR5 register offset */
 #define CCIPR5_REG		0xE8
 
 /** @brief RCC_BDCR register offset */
@@ -68,86 +100,150 @@
 #define CFGR1_REG               0x1C
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR1 devices */
+/* CCIPR1 devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 3, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 8, 6, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART4 */
 #define USART4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 9, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART5 */
 #define USART5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART6 */
 #define USART6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 15, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART7 */
 #define USART7_SEL(val)		STM32_DT_CLOCK_SELECT((val), 20, 18, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART8 */
 #define USART8_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 21, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART9 */
 #define USART9_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 24, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART10 */
 #define USART10_SEL(val)	STM32_DT_CLOCK_SELECT((val), 29, 27, CCIPR1_REG)
+/** @brief Kernel clock source selection for TIMIC */
 #define TIMIC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 31, CCIPR1_REG)
 
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for USART11 */
 #define USART11_SEL(val)	STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR2_REG)
+/** @brief Kernel clock source selection for USART12 */
 #define USART12_SEL(val)	STM32_DT_CLOCK_SELECT((val), 6, 4, CCIPR2_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR2_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, CCIPR2_REG)
+/** @brief Kernel clock source selection for LPTIM3 */
 #define LPTIM3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, CCIPR2_REG)
+/** @brief Kernel clock source selection for LPTIM4 */
 #define LPTIM4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 22, 20, CCIPR2_REG)
+/** @brief Kernel clock source selection for LPTIM5 */
 #define LPTIM5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 24, CCIPR2_REG)
+/** @brief Kernel clock source selection for LPTIM6 */
 #define LPTIM6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 30, 28, CCIPR2_REG)
 
-/** CCIPR3 devices */
+/* CCIPR3 devices */
+/** @brief Kernel clock source selection for SPI1 */
 #define SPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR3_REG)
+/** @brief Kernel clock source selection for SPI2 */
 #define SPI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 3, CCIPR3_REG)
+/** @brief Kernel clock source selection for SPI3 */
 #define SPI3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 8, 6, CCIPR3_REG)
+/** @brief Kernel clock source selection for SPI4 */
 #define SPI4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 9, CCIPR3_REG)
+/** @brief Kernel clock source selection for SPI5 */
 #define SPI5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, CCIPR3_REG)
+/** @brief Kernel clock source selection for SPI6 */
 #define SPI6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 15, CCIPR3_REG)
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 26, 24, CCIPR3_REG)
 
-/** CCIPR4 devices */
+/* CCIPR4 devices */
+/** @brief Kernel clock source selection for OCTOSPI1 */
 #define OCTOSPI1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR4_REG)
+/** @brief Kernel clock source selection for SYSTICK */
 #define SYSTICK_SEL(val)	STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR4_REG)
+/** @brief Kernel clock source selection for USB */
 #define USB_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR4_REG)
+/** @brief Kernel clock source selection for SDMMC1 */
 #define SDMMC1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 6, CCIPR4_REG)
+/** @brief Kernel clock source selection for SDMMC2 */
 #define SDMMC2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 7, CCIPR4_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR4_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR4_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR4_REG)
+/** @brief Kernel clock source selection for I2C4 */
 #define I2C4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, CCIPR4_REG)
+/** @brief Kernel clock source selection for I3C1 */
 #define I3C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 24, CCIPR4_REG)
 
-/** CCIPR5 devices */
+/* CCIPR5 devices */
+/** @brief Kernel clock source selection for ADCDAC */
 #define ADCDAC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR5_REG)
+/** @brief Kernel clock source selection for DAC */
 #define DAC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 3, CCIPR5_REG)
+/** @brief Kernel clock source selection for RNG */
 #define RNG_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR5_REG)
+/** @brief Kernel clock source selection for CEC */
 #define CEC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR5_REG)
+/** @brief Kernel clock source selection for FDCAN */
 #define FDCAN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR5_REG)
+/** @brief Kernel clock source selection for OCTOSPI2 */
 #define OCTOSPI2_SEL(val)	STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR5_REG)
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, CCIPR5_REG)
+/** @brief Kernel clock source selection for SAI2 */
 #define SAI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 19, CCIPR5_REG)
+/** @brief Kernel clock source selection for CKPER */
 #define CKPER_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 30, CCIPR5_REG)
 
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
-/** CFGR1 devices */
+/* CFGR1 devices */
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 21, 18, CFGR1_REG)
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 24, 22, CFGR1_REG)
+/** @brief MCO2 prescaler selection */
 #define MCO2_PRE(val)           STM32_DT_CLOCK_SELECT((val), 28, 25, CFGR1_REG)
+/** @brief MCO2 clock source selection */
 #define MCO2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 31, 29, CFGR1_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1 1
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2 2
+/** @brief MCO prescaler division factor: 3 */
 #define MCO_PRE_DIV_3 3
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4 4
+/** @brief MCO prescaler division factor: 5 */
 #define MCO_PRE_DIV_5 5
+/** @brief MCO prescaler division factor: 6 */
 #define MCO_PRE_DIV_6 6
+/** @brief MCO prescaler division factor: 7 */
 #define MCO_PRE_DIV_7 7
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8 8
+/** @brief MCO prescaler division factor: 9 */
 #define MCO_PRE_DIV_9 9
+/** @brief MCO prescaler division factor: 10 */
 #define MCO_PRE_DIV_10 10
+/** @brief MCO prescaler division factor: 11 */
 #define MCO_PRE_DIV_11 11
+/** @brief MCO prescaler division factor: 12 */
 #define MCO_PRE_DIV_12 12
+/** @brief MCO prescaler division factor: 13 */
 #define MCO_PRE_DIV_13 13
+/** @brief MCO prescaler division factor: 14 */
 #define MCO_PRE_DIV_14 14
+/** @brief MCO prescaler division factor: 15 */
 #define MCO_PRE_DIV_15 15
 
-/** @endcond */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32h7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7_clock.h
@@ -17,54 +17,88 @@
 
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for HSI_KER */
 #define STM32_SRC_HSI_KER	(STM32_SRC_HSI48 + 1) /* HSI + HSIKERON */
+/** @brief Clock source identifier for CSI_KER */
 #define STM32_SRC_CSI_KER	(STM32_SRC_HSI_KER + 1) /* CSI + CSIKERON */
-/** PLL outputs */
+/* PLL outputs */
+/** @brief Clock source identifier for PLL1_P */
 #define STM32_SRC_PLL1_P	(STM32_SRC_CSI_KER + 1)
+/** @brief Clock source identifier for PLL1_Q */
 #define STM32_SRC_PLL1_Q	(STM32_SRC_PLL1_P + 1)
+/** @brief Clock source identifier for PLL1_R */
 #define STM32_SRC_PLL1_R	(STM32_SRC_PLL1_Q + 1)
+/** @brief Clock source identifier for PLL2_P */
 #define STM32_SRC_PLL2_P	(STM32_SRC_PLL1_R + 1)
+/** @brief Clock source identifier for PLL2_Q */
 #define STM32_SRC_PLL2_Q	(STM32_SRC_PLL2_P + 1)
+/** @brief Clock source identifier for PLL2_R */
 #define STM32_SRC_PLL2_R	(STM32_SRC_PLL2_Q + 1)
+/** @brief Clock source identifier for PLL3_P */
 #define STM32_SRC_PLL3_P	(STM32_SRC_PLL2_R + 1)
+/** @brief Clock source identifier for PLL3_Q */
 #define STM32_SRC_PLL3_Q	(STM32_SRC_PLL3_P + 1)
+/** @brief Clock source identifier for PLL3_R */
 #define STM32_SRC_PLL3_R	(STM32_SRC_PLL3_Q + 1)
-/** Clock muxes */
+/* Clock muxes */
+/** @brief Clock source identifier for CKPER */
 #define STM32_SRC_CKPER		(STM32_SRC_PLL3_R + 1)
-/** Bus clocks */
+/* Bus clocks */
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_CKPER + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
 /** Others: Not yet supported */
 /* #define STM32_SRC_I2SCKIN	TBD */
 /* #define STM32_SRC_SPDIFRX	TBD */
 
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3    0x0D4
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x0D8
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x0DC
+/** @brief AHB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB4    0x0E0
+/** @brief APB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3    0x0E4
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x0E8
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x0EC
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x0F0
+/** @brief APB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB4    0x0F4
 /** Alias D1/2/3 domains clocks */ /* TBD: To remove ? */
 #define STM32_SRC_PCLK1		STM32_CLOCK_BUS_APB1
+/** @brief Clock source identifier for PCLK2 */
 #define STM32_SRC_PCLK2		STM32_CLOCK_BUS_APB2
+/** @brief Clock source identifier for HCLK3 */
 #define STM32_SRC_HCLK3		STM32_CLOCK_BUS_AHB3
+/** @brief Clock source identifier for PCLK3 */
 #define STM32_SRC_PCLK3		STM32_CLOCK_BUS_APB3
+/** @brief Clock source identifier for PCLK4 */
 #define STM32_SRC_PCLK4		STM32_CLOCK_BUS_APB4
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB3
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB4
 
 /** @brief RCC_DxCCIP register offset (RM0399.pdf) */
 #define D1CCIPR_REG		0x4C
+/** @brief RCC D2CCIP1R register offset */
 #define D2CCIP1R_REG		0x50
+/** @brief RCC D2CCIP2R register offset */
 #define D2CCIP2R_REG		0x54
+/** @brief RCC D3CCIPR register offset */
 #define D3CCIPR_REG		0x58
 
 /** @brief RCC_BDCR register offset */
@@ -74,78 +108,138 @@
 #define CFGR_REG                0x10
 
 /** @brief Device domain clocks selection helpers (RM0399.pdf) */
-/** D1CCIPR devices */
+/* D1CCIPR devices */
+/** @brief Kernel clock source selection for FMC */
 #define FMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, D1CCIPR_REG)
+/** @brief Kernel clock source selection for QSPI */
 #define QSPI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, D1CCIPR_REG)
+/** @brief Kernel clock source selection for DSI */
 #define DSI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 8, 8, D1CCIPR_REG)
+/** @brief Kernel clock source selection for SDMMC */
 #define SDMMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 16, 16, D1CCIPR_REG)
+/** @brief Kernel clock source selection for CKPER */
 #define CKPER_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 28, D1CCIPR_REG)
 /* Device domain clocks selection helpers (RM0468.pdf) */
+/** @brief Kernel clock source selection for OSPI */
 #define OSPI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, D1CCIPR_REG)
-/** D2CCIP1R devices */
+/* D2CCIP1R devices */
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, D2CCIP1R_REG)
+/** @brief Kernel clock source selection for SAI23 */
 #define SAI23_SEL(val)		STM32_DT_CLOCK_SELECT((val), 8, 6, D2CCIP1R_REG)
+/** @brief Kernel clock source selection for SPI123 */
 #define SPI123_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, D2CCIP1R_REG)
+/** @brief Kernel clock source selection for SPI45 */
 #define SPI45_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, D2CCIP1R_REG)
+/** @brief Kernel clock source selection for SPDIF */
 #define SPDIF_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, D2CCIP1R_REG)
+/** @brief Kernel clock source selection for DFSDM1 */
 #define DFSDM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 24, 24, D2CCIP1R_REG)
+/** @brief Kernel clock source selection for FDCAN */
 #define FDCAN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 28, D2CCIP1R_REG)
+/** @brief Kernel clock source selection for SWP */
 #define SWP_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 31, D2CCIP1R_REG)
-/** D2CCIP2R devices */
+/* D2CCIP2R devices */
+/** @brief Kernel clock source selection for USART2345678 */
 #define USART2345678_SEL(val)	STM32_DT_CLOCK_SELECT((val), 2, 0, D2CCIP2R_REG)
+/** @brief Kernel clock source selection for USART16 */
 #define USART16_SEL(val)	STM32_DT_CLOCK_SELECT((val), 5, 3, D2CCIP2R_REG)
+/** @brief Kernel clock source selection for RNG */
 #define RNG_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, D2CCIP2R_REG)
+/** @brief Kernel clock source selection for I2C123 */
 #define I2C123_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, D2CCIP2R_REG)
+/** @brief Kernel clock source selection for USB */
 #define USB_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, D2CCIP2R_REG)
+/** @brief Kernel clock source selection for CEC */
 #define CEC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, D2CCIP2R_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 30, 28, D2CCIP2R_REG)
-/** D3CCIPR devices */
+/* D3CCIPR devices */
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 2, 0, D3CCIPR_REG)
+/** @brief Kernel clock source selection for I2C4 */
 #define I2C4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, D3CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 12, 10, D3CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM345 */
 #define LPTIM345_SEL(val)	STM32_DT_CLOCK_SELECT((val), 15, 13, D3CCIPR_REG)
+/** @brief Kernel clock source selection for ADC */
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, D3CCIPR_REG)
+/** @brief Kernel clock source selection for SAI4A */
 #define SAI4A_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 21, D3CCIPR_REG)
+/** @brief Kernel clock source selection for SAI4B */
 #define SAI4B_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 24, D3CCIPR_REG)
+/** @brief Kernel clock source selection for SPI6 */
 #define SPI6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 30, 28, D3CCIPR_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
-/** CFGR devices */
+/* CFGR devices */
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 21, 18, CFGR_REG)
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 24, 22, CFGR_REG)
+/** @brief MCO2 prescaler selection */
 #define MCO2_PRE(val)           STM32_DT_CLOCK_SELECT((val), 28, 25, CFGR_REG)
+/** @brief MCO2 clock source selection */
 #define MCO2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 31, 29, CFGR_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1 1
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2 2
+/** @brief MCO prescaler division factor: 3 */
 #define MCO_PRE_DIV_3 3
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4 4
+/** @brief MCO prescaler division factor: 5 */
 #define MCO_PRE_DIV_5 5
+/** @brief MCO prescaler division factor: 6 */
 #define MCO_PRE_DIV_6 6
+/** @brief MCO prescaler division factor: 7 */
 #define MCO_PRE_DIV_7 7
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8 8
+/** @brief MCO prescaler division factor: 9 */
 #define MCO_PRE_DIV_9 9
+/** @brief MCO prescaler division factor: 10 */
 #define MCO_PRE_DIV_10 10
+/** @brief MCO prescaler division factor: 11 */
 #define MCO_PRE_DIV_11 11
+/** @brief MCO prescaler division factor: 12 */
 #define MCO_PRE_DIV_12 12
+/** @brief MCO prescaler division factor: 13 */
 #define MCO_PRE_DIV_13 13
+/** @brief MCO prescaler division factor: 14 */
 #define MCO_PRE_DIV_14 14
+/** @brief MCO prescaler division factor: 15 */
 #define MCO_PRE_DIV_15 15
 
 /* MCO1 clock output */
+/** @brief MCO1 clock source selection value: HSI */
 #define MCO1_SEL_HSI		0
+/** @brief MCO1 clock source selection value: LSE */
 #define MCO1_SEL_LSE		1
+/** @brief MCO1 clock source selection value: HSE */
 #define MCO1_SEL_HSE		2
+/** @brief MCO1 clock source selection value: PLL1QCLK */
 #define MCO1_SEL_PLL1QCLK	3
+/** @brief MCO1 clock source selection value: HSI48 */
 #define MCO1_SEL_HSI48		4
 
 /* MCO2 clock output */
+/** @brief MCO2 clock source selection value: SYSCLK */
 #define MCO2_SEL_SYSCLK		0
+/** @brief MCO2 clock source selection value: PLL2PCLK */
 #define MCO2_SEL_PLL2PCLK	1
+/** @brief MCO2 clock source selection value: HSE */
 #define MCO2_SEL_HSE		2
+/** @brief MCO2 clock source selection value: PLL1PCLK */
 #define MCO2_SEL_PLL1PCLK	3
+/** @brief MCO2 clock source selection value: CSI */
 #define MCO2_SEL_CSI		4
+/** @brief MCO2 clock source selection value: LSI */
 #define MCO2_SEL_LSI		5
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32h7rs_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7rs_clock.h
@@ -17,58 +17,102 @@
 
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for HSI_KER */
 #define STM32_SRC_HSI_KER	(STM32_SRC_HSI48 + 1) /* HSI + HSIKERON */
+/** @brief Clock source identifier for CSI_KER */
 #define STM32_SRC_CSI_KER	(STM32_SRC_HSI_KER + 1) /* CSI + CSIKERON */
-/** PLL outputs */
+/* PLL outputs */
+/** @brief Clock source identifier for PLL1_P */
 #define STM32_SRC_PLL1_P	(STM32_SRC_CSI_KER + 1)
+/** @brief Clock source identifier for PLL1_Q */
 #define STM32_SRC_PLL1_Q	(STM32_SRC_PLL1_P + 1)
+/** @brief Clock source identifier for PLL1_R */
 #define STM32_SRC_PLL1_R	(STM32_SRC_PLL1_Q + 1)
+/** @brief Clock source identifier for PLL1_S */
 #define STM32_SRC_PLL1_S	(STM32_SRC_PLL1_R + 1)
+/** @brief Clock source identifier for PLL2_P */
 #define STM32_SRC_PLL2_P	(STM32_SRC_PLL1_S + 1)
+/** @brief Clock source identifier for PLL2_Q */
 #define STM32_SRC_PLL2_Q	(STM32_SRC_PLL2_P + 1)
+/** @brief Clock source identifier for PLL2_R */
 #define STM32_SRC_PLL2_R	(STM32_SRC_PLL2_Q + 1)
+/** @brief Clock source identifier for PLL2_S */
 #define STM32_SRC_PLL2_S	(STM32_SRC_PLL2_R + 1)
+/** @brief Clock source identifier for PLL2_T */
 #define STM32_SRC_PLL2_T	(STM32_SRC_PLL2_S + 1)
+/** @brief Clock source identifier for PLL3_P */
 #define STM32_SRC_PLL3_P	(STM32_SRC_PLL2_T + 1)
+/** @brief Clock source identifier for PLL3_Q */
 #define STM32_SRC_PLL3_Q	(STM32_SRC_PLL3_P + 1)
+/** @brief Clock source identifier for PLL3_R */
 #define STM32_SRC_PLL3_R	(STM32_SRC_PLL3_Q + 1)
+/** @brief Clock source identifier for PLL3_S */
 #define STM32_SRC_PLL3_S	(STM32_SRC_PLL3_R + 1)
 
-/** Clock muxes */
+/* Clock muxes */
+/** @brief Clock source identifier for CKPER */
 #define STM32_SRC_CKPER		(STM32_SRC_PLL3_S + 1)
+/** @brief Clock source identifier for HCLK1 */
 #define STM32_SRC_HCLK1		(STM32_SRC_CKPER + 1)
+/** @brief Clock source identifier for HCLK2 */
 #define STM32_SRC_HCLK2		(STM32_SRC_HCLK1 + 1)
+/** @brief Clock source identifier for HCLK3 */
 #define STM32_SRC_HCLK3		(STM32_SRC_HCLK2 + 1)
+/** @brief Clock source identifier for HCLK4 */
 #define STM32_SRC_HCLK4		(STM32_SRC_HCLK3 + 1)
+/** @brief Clock source identifier for HCLK5 */
 #define STM32_SRC_HCLK5		(STM32_SRC_HCLK4 + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_HCLK5 + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
+/** @brief Clock source identifier for PCLK1 */
 #define STM32_SRC_PCLK1		(STM32_SRC_TIMPCLK2 + 1)
+/** @brief Clock source identifier for PCLK2 */
 #define STM32_SRC_PCLK2		(STM32_SRC_PCLK1 + 1)
+/** @brief Clock source identifier for PCLK4 */
 #define STM32_SRC_PCLK4		(STM32_SRC_PCLK2 + 1)
+/** @brief Clock source identifier for PCLK5 */
 #define STM32_SRC_PCLK5		(STM32_SRC_PCLK4 + 1)
 /** Others: Not yet supported */
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x138
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x13C
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3    0x158
+/** @brief AHB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB4    0x140
+/** @brief AHB5 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB5    0x134
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x148
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x14C
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x150
+/** @brief APB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB4    0x154
+/** @brief APB5 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB5    0x144
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB5
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_AHB3
 
 /** @brief RCC_DxCCIP register offset (RM0477.pdf) */
 #define D1CCIPR_REG		0x4C
+/** @brief RCC D2CCIPR register offset */
 #define D2CCIPR_REG		0x50
+/** @brief RCC D3CCIPR register offset */
 #define D3CCIPR_REG		0x54
+/** @brief RCC D4CCIPR register offset */
 #define D4CCIPR_REG		0x58
 
 /** @brief RCC_BDCR register offset */
@@ -81,60 +125,102 @@
 
 /* TODO to be completed */
 
-/** D1CCIPR devices */
+/* D1CCIPR devices */
+/** @brief Kernel clock source selection for FMC */
 #define FMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, D1CCIPR_REG)
+/** @brief Kernel clock source selection for SDMMC */
 #define SDMMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 2, D1CCIPR_REG)
+/** @brief Kernel clock source selection for XSPI1 */
 #define XSPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, D1CCIPR_REG)
+/** @brief Kernel clock source selection for XSPI2 */
 #define XSPI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 6, D1CCIPR_REG)
+/** @brief Kernel clock source selection for OTGFS */
 #define OTGFS_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, D1CCIPR_REG)
+/** @brief Kernel clock source selection for ADC */
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 24, D1CCIPR_REG)
+/** @brief Kernel clock source selection for CKPER */
 #define CKPER_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 28, D1CCIPR_REG)
 
-/** D2CCIPR devices */
+/* D2CCIPR devices */
+/** @brief Kernel clock source selection for USART234578 */
 #define USART234578_SEL(val)	STM32_DT_CLOCK_SELECT((val), 2, 0, D2CCIPR_REG)
+/** @brief Kernel clock source selection for SPI23 */
 #define SPI23_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 4, D2CCIPR_REG)
+/** @brief Kernel clock source selection for I2C23 */
 #define I2C23_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, D2CCIPR_REG)
+/** @brief Kernel clock source selection for I2C1_I3C1 */
 #define I2C1_I3C1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 13, 12, D2CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, D2CCIPR_REG)
+/** @brief Kernel clock source selection for FDCAN */
 #define FDCAN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, D2CCIPR_REG)
 
-/** D3CCIPR devices */
+/* D3CCIPR devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, D3CCIPR_REG)
+/** @brief Kernel clock source selection for SPI45 */
 #define SPI45_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 4, D3CCIPR_REG)
+/** @brief Kernel clock source selection for SPI1 */
 #define SPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, D3CCIPR_REG)
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, D3CCIPR_REG)
+/** @brief Kernel clock source selection for SAI2 */
 #define SAI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 22, 20, D3CCIPR_REG)
 
-/** D4CCIPR devices */
+/* D4CCIPR devices */
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 2, 0, D4CCIPR_REG)
+/** @brief Kernel clock source selection for SPI6 */
 #define SPI6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 4, D4CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM23 */
 #define LPTIM23_SEL(val)	STM32_DT_CLOCK_SELECT((val), 10, 8, D4CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM45 */
 #define LPTIM45_SEL(val)	STM32_DT_CLOCK_SELECT((val), 14, 12, D4CCIPR_REG)
 
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
-/** CFGR devices */
+/* CFGR devices */
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 21, 18, CFGR_REG)
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 24, 22, CFGR_REG)
+/** @brief MCO2 prescaler selection */
 #define MCO2_PRE(val)           STM32_DT_CLOCK_SELECT((val), 28, 25, CFGR_REG)
+/** @brief MCO2 clock source selection */
 #define MCO2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 31, 29, CFGR_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1 1
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2 2
+/** @brief MCO prescaler division factor: 3 */
 #define MCO_PRE_DIV_3 3
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4 4
+/** @brief MCO prescaler division factor: 5 */
 #define MCO_PRE_DIV_5 5
+/** @brief MCO prescaler division factor: 6 */
 #define MCO_PRE_DIV_6 6
+/** @brief MCO prescaler division factor: 7 */
 #define MCO_PRE_DIV_7 7
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8 8
+/** @brief MCO prescaler division factor: 9 */
 #define MCO_PRE_DIV_9 9
+/** @brief MCO prescaler division factor: 10 */
 #define MCO_PRE_DIV_10 10
+/** @brief MCO prescaler division factor: 11 */
 #define MCO_PRE_DIV_11 11
+/** @brief MCO prescaler division factor: 12 */
 #define MCO_PRE_DIV_12 12
+/** @brief MCO prescaler division factor: 13 */
 #define MCO_PRE_DIV_13 13
+/** @brief MCO prescaler division factor: 14 */
 #define MCO_PRE_DIV_14 14
+/** @brief MCO prescaler division factor: 15 */
 #define MCO_PRE_DIV_15 15
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7RS_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l0_clock.h
@@ -8,13 +8,19 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus gatting clocks */
+/* Bus gatting clocks */
+/** @brief IOP bus clock enable register offset */
 #define STM32_CLOCK_BUS_IOP     0x02c
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x030
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x034
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x038
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_IOP
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1
 
 /** Domain clocks */
@@ -25,12 +31,18 @@
 
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_HSI48 + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
 
 /** @brief RCC_CCIPR register offset */
@@ -40,15 +52,23 @@
 #define CSR_REG		0x50
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR devices */
+/* CCIPR devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR_REG)
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR_REG)
+/** @brief Kernel clock source selection for HSI48 */
 #define HSI48_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 26, CCIPR_REG)
-/** CSR devices */
+/* CSR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CSR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l1_clock.h
@@ -8,12 +8,17 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus gatting clocks */
+/* Bus gatting clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x01c
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x020
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x024
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1
 
 /** Domain clocks */
@@ -23,15 +28,20 @@
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_HSE + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_HSI + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
 
 /** @brief RCC_CSR register offset */
 #define CSR_REG		0x34
 
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CSR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L1_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4_clock.h
@@ -8,15 +8,23 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x048
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x04c
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3    0x050
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x058
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x05c
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x060
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB2
 
 /** Domain clocks */
@@ -26,41 +34,58 @@
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
-/** External High Speed oscillator */
+/* External High Speed oscillator */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
-/** Internal High Speed 16MHz oscillator */
+/* Internal High Speed 16MHz oscillator */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_HSE + 1)
-/** Internal High Speed 48MHz oscillator */
+/* Internal High Speed 48MHz oscillator */
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI + 1)
-/** Internal Multi Speed oscillator */
+/* Internal Multi Speed oscillator */
+/** @brief Clock source identifier for MSI */
 #define STM32_SRC_MSI		(STM32_SRC_HSI48 + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_MSI + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
-/** PLL clock outputs */
+/* PLL clock outputs */
+/** @brief Clock source identifier for PLL_P */
 #define STM32_SRC_PLL_P		(STM32_SRC_TIMPCLK2 + 1)
+/** @brief Clock source identifier for PLL_Q */
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
+/** @brief Clock source identifier for PLL_R */
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
 /* PLLSAI1 clocks */
-/** PLLSAI1 P output, can be selected for SAI peripherals */
+/* PLLSAI1 P output, can be selected for SAI peripherals */
+/** @brief Clock source identifier for PLLSAI1_P */
 #define STM32_SRC_PLLSAI1_P	(STM32_SRC_PLL_R + 1)
 /** PLLSAI1 Q output, 48MHz clock which can be selected for USB / RNG */
 #define STM32_SRC_PLLSAI1_Q	(STM32_SRC_PLLSAI1_P + 1)
-/** PLLSAI1 R output, can be selected for ADC peripherals */
+/* PLLSAI1 R output, can be selected for ADC peripherals */
+/** @brief Clock source identifier for PLLSAI1_R */
 #define STM32_SRC_PLLSAI1_R	(STM32_SRC_PLLSAI1_Q + 1)
 /* PLLSAI2 clocks */
-/** PLLSAI2 P output, can be selected for SAI peripherals */
+/* PLLSAI2 P output, can be selected for SAI peripherals */
+/** @brief Clock source identifier for PLLSAI2_P */
 #define STM32_SRC_PLLSAI2_P	(STM32_SRC_PLLSAI1_R + 1)
-/** PLLSAI2 Q output, can be selected for DSI peripheral */
+/* PLLSAI2 Q output, can be selected for DSI peripheral */
+/** @brief Clock source identifier for PLLSAI2_Q */
 #define STM32_SRC_PLLSAI2_Q	(STM32_SRC_PLLSAI2_P + 1)
-/** PLLSAI2 R output, can be selected for ADC or LTDC peripheral */
+/* PLLSAI2 R output, can be selected for ADC or LTDC peripheral */
+/** @brief Clock source identifier for PLLSAI2_R */
 #define STM32_SRC_PLLSAI2_R	(STM32_SRC_PLLSAI2_Q + 1)
-/** PLLSAI2 R output with addition divider, used for LTDC peripheral */
+/* PLLSAI2 R output with addition divider, used for LTDC peripheral */
+/** @brief Clock source identifier for PLLSAI2_POST_R */
 #define STM32_SRC_PLLSAI2_POST_R	(STM32_SRC_PLLSAI2_R + 1)
 
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x88
+/** @brief RCC CCIPR2 register offset */
 #define CCIPR2_REG		0x9C
 
 /** @brief RCC_BDCR register offset */
@@ -70,52 +95,91 @@
 #define CFGR_REG                0x08
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR devices */
+/* CCIPR devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR_REG)
+/** @brief Kernel clock source selection for UART4 */
 #define UART4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR_REG)
+/** @brief Kernel clock source selection for UART5 */
 #define UART5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR_REG)
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR_REG)
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, CCIPR_REG)
+/** @brief Kernel clock source selection for SAI2 */
 #define SAI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 24, CCIPR_REG)
+/** @brief Kernel clock source selection for CLK48 */
 #define CLK48_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR_REG)
+/** @brief Kernel clock source selection for ADC */
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 28, CCIPR_REG)
+/** @brief Kernel clock source selection for SWPMI1 */
 #define SWPMI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 30, 30, CCIPR_REG)
+/** @brief Kernel clock source selection for DFSDM1 */
 #define DFSDM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 31, CCIPR_REG)
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for I2C4 */
 #define I2C4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR2_REG)
+/** @brief Kernel clock source selection for DFSDM */
 #define DFSDM_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 2, CCIPR2_REG)
+/** @brief Kernel clock source selection for ADFSDM */
 #define ADFSDM_SEL(val)		STM32_DT_CLOCK_SELECT((val), 4, 3, CCIPR2_REG)
+/** @brief Kernel clock source selection for DSI */
 #define DSI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 12, 12, CCIPR2_REG)
+/** @brief Kernel clock source selection for SDMMC */
 #define SDMMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 14, CCIPR2_REG)
+/** @brief Kernel clock source selection for OSPI */
 #define OSPI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR2_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
-/** CFGR devices */
+/* CFGR devices */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1	0
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2	1
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4	2
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8	3
+/** @brief MCO prescaler division factor: 16 */
 #define MCO_PRE_DIV_16	4
 
 /* MCO clock output */
+/** @brief MCO clock source selection value: SYSCLK */
 #define MCO_SEL_SYSCLK	1
+/** @brief MCO clock source selection value: MSI */
 #define MCO_SEL_MSI	2
+/** @brief MCO clock source selection value: HSI16 */
 #define MCO_SEL_HSI16	3
+/** @brief MCO clock source selection value: HSE */
 #define MCO_SEL_HSE	4
+/** @brief MCO clock source selection value: PLLCLK */
 #define MCO_SEL_PLLCLK	5
+/** @brief MCO clock source selection value: LSI */
 #define MCO_SEL_LSI	6
+/** @brief MCO clock source selection value: LSE */
 #define MCO_SEL_LSE	7
+/** @brief MCO clock source selection value: HSI48 */
 #define MCO_SEL_HSI48	8
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l4plus_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4plus_clock.h
@@ -15,8 +15,10 @@
 #undef SAI1_SEL(val)
 #undef SAI2_SEL(val)
 
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 5, CCIPR2_REG)
+/** @brief Kernel clock source selection for SAI2 */
 #define SAI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR2_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4PLUS_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l5_clock.h
@@ -8,15 +8,23 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x048
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x04c
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3    0x050
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x058
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x05c
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x060
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB2
 
 /** Domain clocks */
@@ -26,30 +34,43 @@
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI + 1)
+/** @brief Clock source identifier for MSI */
 #define STM32_SRC_MSI		(STM32_SRC_HSI48 + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_MSI + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
-/** PLL clock outputs */
+/* PLL clock outputs */
+/** @brief Clock source identifier for PLL_P */
 #define STM32_SRC_PLL_P		(STM32_SRC_TIMPCLK2 + 1)
+/** @brief Clock source identifier for PLL_Q */
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
+/** @brief Clock source identifier for PLL_R */
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
 /* PLLSAI1 clocks */
-/** PLLSAI1 P output, can be selected for SAI, FDCAN and DFSDM peripherals */
+/* PLLSAI1 P output, can be selected for SAI, FDCAN and DFSDM peripherals */
+/** @brief Clock source identifier for PLLSAI1_P */
 #define STM32_SRC_PLLSAI1_P	(STM32_SRC_PLL_R + 1)
 /** PLLSAI1 Q output, 48MHz clock which can be selected for USB / RNG */
 #define STM32_SRC_PLLSAI1_Q	(STM32_SRC_PLLSAI1_P + 1)
-/** PLLSAI2 R output, can be selected for ADC peripheral */
+/* PLLSAI2 R output, can be selected for ADC peripheral */
+/** @brief Clock source identifier for PLLSAI1_R */
 #define STM32_SRC_PLLSAI1_R	(STM32_SRC_PLLSAI1_Q + 1)
 /* PLLSAI2 clocks */
-/** PLLSAI2 P output, can be selected for SAI and DFSDM peripherals */
+/* PLLSAI2 P output, can be selected for SAI and DFSDM peripherals */
+/** @brief Clock source identifier for PLLSAI2_P */
 #define STM32_SRC_PLLSAI2_P	(STM32_SRC_PLLSAI1_R + 1)
 
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x88
+/** @brief RCC CCIPR2 register offset */
 #define CCIPR2_REG		0x9C
 
 /** @brief RCC_BDCR register offset */
@@ -59,35 +80,60 @@
 #define CFGR_REG                0x08
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR devices */
+/* CCIPR devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR_REG)
+/** @brief Kernel clock source selection for UART4 */
 #define UART4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR_REG)
+/** @brief Kernel clock source selection for UART5 */
 #define UART5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR_REG)
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM3 */
 #define LPTIM3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, CCIPR_REG)
+/** @brief Kernel clock source selection for FDCAN */
 #define FDCAN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 24, CCIPR_REG)
+/** @brief Kernel clock source selection for CLK48 */
 #define CLK48_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR_REG)
+/** @brief Kernel clock source selection for ADC */
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 28, CCIPR_REG)
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for I2C4 */
 #define I2C4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR2_REG)
+/** @brief Kernel clock source selection for DFSDM */
 #define DFSDM_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 2, CCIPR2_REG)
+/** @brief Kernel clock source selection for ADFSDM */
 #define ADFSDM_SEL(val)		STM32_DT_CLOCK_SELECT((val), 4, 3, CCIPR2_REG)
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 5, CCIPR2_REG)
+/** @brief Kernel clock source selection for SAI2 */
 #define SAI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR2_REG)
+/** @brief Kernel clock source selection for SDMMC */
 #define SDMMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 14, CCIPR2_REG)
+/** @brief Kernel clock source selection for OSPI */
 #define OSPI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR2_REG)
 
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
-/** CFGR devices */
+/* CFGR devices */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
@@ -10,146 +10,267 @@
 
 /** System clock */
 /* defined in stm32_common_clocks.h */
-/** Fixed clocks  */
+/* Fixed clocks */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_HSE + 1)
 
-/** PLL outputs */
+/* PLL outputs */
+/** @brief Clock source identifier for PLL1_P */
 #define STM32_SRC_PLL1_P	(STM32_SRC_HSI + 1)
+/** @brief Clock source identifier for PLL2_P */
 #define STM32_SRC_PLL2_P	(STM32_SRC_PLL1_P + 1)
+/** @brief Clock source identifier for PLL2_Q */
 #define STM32_SRC_PLL2_Q	(STM32_SRC_PLL2_P + 1)
+/** @brief Clock source identifier for PLL2_R */
 #define STM32_SRC_PLL2_R	(STM32_SRC_PLL2_Q + 1)
+/** @brief Clock source identifier for PLL3_P */
 #define STM32_SRC_PLL3_P	(STM32_SRC_PLL2_R + 1)
+/** @brief Clock source identifier for PLL3_Q */
 #define STM32_SRC_PLL3_Q	(STM32_SRC_PLL3_P + 1)
+/** @brief Clock source identifier for PLL3_R */
 #define STM32_SRC_PLL3_R	(STM32_SRC_PLL3_Q + 1)
+/** @brief Clock source identifier for PLL4_P */
 #define STM32_SRC_PLL4_P	(STM32_SRC_PLL3_R + 1)
+/** @brief Clock source identifier for PLL4_Q */
 #define STM32_SRC_PLL4_Q	(STM32_SRC_PLL4_P + 1)
+/** @brief Clock source identifier for PLL4_R */
 #define STM32_SRC_PLL4_R	(STM32_SRC_PLL4_Q + 1)
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x700
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x708
+/** @brief APB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3    0x710
+/** @brief APB3_S bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3_S  0x718
+/** @brief APB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB4    0x728
+/** @brief APB4_NS bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB4_NS	0x738
+/** @brief APB5 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB5    0x740
+/** @brief APB6 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB6    0x748
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x750
+/** @brief AHB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB4    0x768
+/** @brief AHB5 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB5    0x778
+/** @brief AHB6 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB6    0x780
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_APB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_AHB6
 
 /** @brief Device domain clocks selection helpers */
 #define MCO1CFGR_REG		0x460
+/** @brief RCC MCO2CFGR register offset */
 #define MCO2CFGR_REG		0x464
+/** @brief RCC I2C12CKSELR register offset */
 #define I2C12CKSELR_REG		0x600
+/** @brief RCC I2C345CKSELR register offset */
 #define I2C345CKSELR_REG	0x604
+/** @brief RCC SPI2S1CKSELR register offset */
 #define SPI2S1CKSELR_REG	0x608
+/** @brief RCC SPI2S23CKSELR register offset */
 #define SPI2S23CKSELR_REG	0x60c
+/** @brief RCC SPI45CKSELR register offset */
 #define SPI45CKSELR_REG		0x610
+/** @brief RCC UART12CKSELR register offset */
 #define UART12CKSELR_REG	0x614
+/** @brief RCC UART35CKSELR register offset */
 #define UART35CKSELR_REG	0x618
+/** @brief RCC UART4CKSELR register offset */
 #define UART4CKSELR_REG		0x61c
+/** @brief RCC UART6CKSELR register offset */
 #define UART6CKSELR_REG		0x620
+/** @brief RCC UART78CKSELR register offset */
 #define UART78CKSELR_REG	0x624
+/** @brief RCC LPTIM1CKSELR register offset */
 #define LPTIM1CKSELR_REG	0x628
+/** @brief RCC LPTIM23CKSELR register offset */
 #define LPTIM23CKSELR_REG	0x62c
+/** @brief RCC LPTIM45CKSELR register offset */
 #define LPTIM45CKSELR_REG	0x630
+/** @brief RCC SAI1CKSELR register offset */
 #define SAI1CKSELR_REG		0x634
+/** @brief RCC SAI2CKSELR register offset */
 #define SAI2CKSELR_REG		0x638
+/** @brief RCC FDCANCKSELR register offset */
 #define FDCANCKSELR_REG		0x63c
+/** @brief RCC SPDIFCKSELR register offset */
 #define SPDIFCKSELR_REG		0x640
+/** @brief RCC ADC12CKSELR register offset */
 #define ADC12CKSELR_REG		0x644
+/** @brief RCC SDMMC12CKSELR register offset */
 #define SDMMC12CKSELR_REG	0x648
+/** @brief RCC ETH12CKSELR register offset */
 #define ETH12CKSELR_REG		0x64c
+/** @brief RCC USBCKSELR register offset */
 #define USBCKSELR_REG		0x650
+/** @brief RCC QSPICKSELR register offset */
 #define QSPICKSELR_REG		0x654
+/** @brief RCC FMCCKSELR register offset */
 #define FMCCKSELR_REG		0x658
+/** @brief RCC RNG1CKSELR register offset */
 #define RNG1CKSELR_REG		0x65c
+/** @brief RCC STGENCKSELR register offset */
 #define STGENCKSELR_REG		0x660
+/** @brief RCC DCMIPPCKSELR register offset */
 #define DCMIPPCKSELR_REG	0x664
+/** @brief RCC SAESCKSELR register offset */
 #define SAESCKSELR_REG		0x668
 
 /** MCO1CFGR / MCO2CFGR devices */
 #define MCO1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, MCO1CFGR_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)		STM32_DT_CLOCK_SELECT((val), 7, 4, MCO1CFGR_REG)
+/** @brief MCO2 clock source selection */
 #define MCO2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, MCO2CFGR_REG)
+/** @brief MCO2 prescaler selection */
 #define MCO2_PRE(val)		STM32_DT_CLOCK_SELECT((val), 7, 4, MCO2CFGR_REG)
 
+/** @brief MCO output enable bit */
 #define MCOX_ON	BIT(12)
 
 /* MCO1 source */
+/** @brief MCO1 clock source selection value: HSI */
 #define MCO1_SEL_HSI	0
+/** @brief MCO1 clock source selection value: HSE */
 #define MCO1_SEL_HSE	1
+/** @brief MCO1 clock source selection value: CSI */
 #define MCO1_SEL_CSI	2
+/** @brief MCO1 clock source selection value: LSI */
 #define MCO1_SEL_LSI	3
+/** @brief MCO1 clock source selection value: LSE */
 #define MCO1_SEL_LSE	4
 
 /* MCO2 source */
+/** @brief MCO2 clock source selection value: MPU */
 #define MCO2_SEL_MPU	0
+/** @brief MCO2 clock source selection value: AXI */
 #define MCO2_SEL_AXI	1
+/** @brief MCO2 clock source selection value: MLAHB */
 #define MCO2_SEL_MLAHB	2
+/** @brief MCO2 clock source selection value: PLL4 */
 #define MCO2_SEL_PLL4	3
+/** @brief MCO2 clock source selection value: HSE */
 #define MCO2_SEL_HSE	4
+/** @brief MCO2 clock source selection value: HSI */
 #define MCO2_SEL_HSI	5
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1	0
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2	1
+/** @brief MCO prescaler division factor: 3 */
 #define MCO_PRE_DIV_3	2
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4	3
+/** @brief MCO prescaler division factor: 5 */
 #define MCO_PRE_DIV_5	4
+/** @brief MCO prescaler division factor: 6 */
 #define MCO_PRE_DIV_6	5
+/** @brief MCO prescaler division factor: 7 */
 #define MCO_PRE_DIV_7	6
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8	7
+/** @brief MCO prescaler division factor: 9 */
 #define MCO_PRE_DIV_9	8
+/** @brief MCO prescaler division factor: 10 */
 #define MCO_PRE_DIV_10	9
+/** @brief MCO prescaler division factor: 11 */
 #define MCO_PRE_DIV_11	10
+/** @brief MCO prescaler division factor: 12 */
 #define MCO_PRE_DIV_12	11
+/** @brief MCO prescaler division factor: 13 */
 #define MCO_PRE_DIV_13	12
+/** @brief MCO prescaler division factor: 14 */
 #define MCO_PRE_DIV_14	13
+/** @brief MCO prescaler division factor: 15 */
 #define MCO_PRE_DIV_15	14
+/** @brief MCO prescaler division factor: 16 */
 #define MCO_PRE_DIV_16	15
 
+/** @brief Kernel clock source selection for I2C12 */
 #define I2C12_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, I2C12CKSELR_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, I2C345CKSELR_REG)
+/** @brief Kernel clock source selection for I2C4 */
 #define I2C4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 3, I2C345CKSELR_REG)
+/** @brief Kernel clock source selection for I2C5 */
 #define I2C5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 8, 6, I2C345CKSELR_REG)
+/** @brief Kernel clock source selection for SPI1 */
 #define SPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, SPI2S1CKSELR_REG)
+/** @brief Kernel clock source selection for SPI23 */
 #define SPI23_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, SPI2S23CKSELR_REG)
+/** @brief Kernel clock source selection for SPI4 */
 #define SPI4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, SPI45CKSELR_REG)
+/** @brief Kernel clock source selection for SPI5 */
 #define SPI5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 3, SPI45CKSELR_REG)
+/** @brief Kernel clock source selection for UART1 */
 #define UART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, UART12CKSELR_REG)
+/** @brief Kernel clock source selection for UART2 */
 #define UART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 3, UART12CKSELR_REG)
+/** @brief Kernel clock source selection for UART35 */
 #define UART35_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, UART35CKSELR_REG)
+/** @brief Kernel clock source selection for UART4 */
 #define UART4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, UART4CKSELR_REG)
+/** @brief Kernel clock source selection for UART6 */
 #define UART6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, UART6CKSELR_REG)
+/** @brief Kernel clock source selection for UART78 */
 #define UART78_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, UART78CKSELR_REG)
+/** @brief Kernel clock source selection for LPTIME1 */
 #define LPTIME1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 2, 0, LPTIM1CKSELR_REG)
+/** @brief Kernel clock source selection for LPTIME2 */
 #define LPTIME2_SEL(val)	STM32_DT_CLOCK_SELECT((val), 2, 0, LPTIM23CKSELR_REG)
+/** @brief Kernel clock source selection for LPTIME3 */
 #define LPTIME3_SEL(val)	STM32_DT_CLOCK_SELECT((val), 5, 3, LPTIM23CKSELR_REG)
+/** @brief Kernel clock source selection for LPTIME45 */
 #define LPTIME45_SEL(val)	STM32_DT_CLOCK_SELECT((val), 2, 0, LPTIM45CKSELR_REG)
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, SAI1CKSELR_REG)
+/** @brief Kernel clock source selection for SAI2 */
 #define SAI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, SAI2CKSELR_REG)
+/** @brief Kernel clock source selection for FDCAN */
 #define FDCAN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, FDCANCKSELR_REG)
+/** @brief Kernel clock source selection for SPDIF */
 #define SPDIF_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, SPDIFCKSELR_REG)
+/** @brief Kernel clock source selection for ADC1 */
 #define ADC1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, ADC12CKSELR_REG)
+/** @brief Kernel clock source selection for ADC2 */
 #define ADC2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, ADC12CKSELR_REG)
+/** @brief Kernel clock source selection for SDMMC1 */
 #define SDMMC1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, SDMMC12CKSELR_REG)
+/** @brief Kernel clock source selection for SDMMC2 */
 #define SDMMC2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 3, SDMMC12CKSELR_REG)
+/** @brief Kernel clock source selection for ETH1 */
 #define ETH1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, ETH12CKSELR_REG)
+/** @brief Kernel clock source selection for ETH2 */
 #define ETH2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, ETH12CKSELR_REG)
+/** @brief Kernel clock source selection for USBPHY */
 #define USBPHY_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, USBCKSELR_REG)
+/** @brief Kernel clock source selection for USBOTG */
 #define USBOTG_SEL(val)		STM32_DT_CLOCK_SELECT((val), 4, 4, USBCKSELR_REG)
+/** @brief Kernel clock source selection for QSPI */
 #define QSPI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, QSPICKSELR_REG)
+/** @brief Kernel clock source selection for FMC */
 #define FMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, FMCCKSELR_REG)
+/** @brief Kernel clock source selection for RNG1 */
 #define RNG1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, RNG1CKSELR_REG)
+/** @brief Kernel clock source selection for STGEN */
 #define STGEN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, STGENCKSELR_REG)
+/** @brief Kernel clock source selection for DCMIPP */
 #define DCMIPP_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, DCMIPPCKSELR_REG)
+/** @brief Kernel clock source selection for SAES */
 #define SAES_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, SAESCKSELR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP13_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32mp2_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32mp2_clock.h
@@ -6,7 +6,6 @@
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP2_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP2_CLOCK_H_
-/** @cond INTERNAL_HIDDEN */
 
 #include "stm32_common_clocks.h"
 
@@ -23,71 +22,118 @@
 #define STM32_CLOCK(per, bit) (STM32_CLOCK_PERIPH_##per) (1 << bit)
 
 /* Clock reg */
+/** @brief STM32_CLK: stm32 clk */
 #define STM32_CLK		1U
+/** @brief STM32_LP_CLK: stm32 lp clk */
 #define STM32_LP_CLK		2U
 
 /* GPIO Peripheral */
+/** @brief STM32 clock periph gpioa */
 #define STM32_CLOCK_PERIPH_GPIOA	0x52C
+/** @brief STM32 clock periph gpiob */
 #define STM32_CLOCK_PERIPH_GPIOB	0x530
+/** @brief STM32 clock periph gpioc */
 #define STM32_CLOCK_PERIPH_GPIOC	0x534
+/** @brief STM32 clock periph gpiod */
 #define STM32_CLOCK_PERIPH_GPIOD	0x538
+/** @brief STM32 clock periph gpioe */
 #define STM32_CLOCK_PERIPH_GPIOE	0x53C
+/** @brief STM32 clock periph gpiof */
 #define STM32_CLOCK_PERIPH_GPIOF	0x540
+/** @brief STM32 clock periph gpiog */
 #define STM32_CLOCK_PERIPH_GPIOG	0x544
+/** @brief STM32 clock periph gpioh */
 #define STM32_CLOCK_PERIPH_GPIOH	0x548
+/** @brief STM32 clock periph gpioi */
 #define STM32_CLOCK_PERIPH_GPIOI	0x54C
+/** @brief STM32 clock periph gpioj */
 #define STM32_CLOCK_PERIPH_GPIOJ	0x550
+/** @brief STM32 clock periph gpiok */
 #define STM32_CLOCK_PERIPH_GPIOK	0x554
+/** @brief STM32 clock periph gpioz */
 #define STM32_CLOCK_PERIPH_GPIOZ	0x558
 
 /* SPI Peripheral */
+/** @brief STM32 clock periph spi1 */
 #define STM32_CLOCK_PERIPH_SPI1		0x758
+/** @brief STM32 clock periph spi2 */
 #define STM32_CLOCK_PERIPH_SPI2		0x75C
+/** @brief STM32 clock periph spi3 */
 #define STM32_CLOCK_PERIPH_SPI3		0x760
+/** @brief STM32 clock periph spi4 */
 #define STM32_CLOCK_PERIPH_SPI4		0x764
+/** @brief STM32 clock periph spi5 */
 #define STM32_CLOCK_PERIPH_SPI5		0x768
+/** @brief STM32 clock periph spi6 */
 #define STM32_CLOCK_PERIPH_SPI6		0x76C
+/** @brief STM32 clock periph spi7 */
 #define STM32_CLOCK_PERIPH_SPI7		0x770
 
 /* USART/UART Peripheral */
+/** @brief STM32 clock periph usart1 */
 #define STM32_CLOCK_PERIPH_USART1	0x77C
+/** @brief STM32 clock periph usart2 */
 #define STM32_CLOCK_PERIPH_USART2	0x780
+/** @brief STM32 clock periph usart3 */
 #define STM32_CLOCK_PERIPH_USART3	0x784
+/** @brief STM32 clock periph uart4 */
 #define STM32_CLOCK_PERIPH_UART4	0x788
+/** @brief STM32 clock periph uart5 */
 #define STM32_CLOCK_PERIPH_UART5	0x78C
+/** @brief STM32 clock periph usart6 */
 #define STM32_CLOCK_PERIPH_USART6	0x790
+/** @brief STM32 clock periph uart7 */
 #define STM32_CLOCK_PERIPH_UART7	0x794
+/** @brief STM32 clock periph uart8 */
 #define STM32_CLOCK_PERIPH_UART8	0x798
+/** @brief STM32 clock periph uart9 */
 #define STM32_CLOCK_PERIPH_UART9	0x79C
 
 /* I2C Peripheral */
+/** @brief STM32 clock periph i2c1 */
 #define STM32_CLOCK_PERIPH_I2C1		0x7A0
+/** @brief STM32 clock periph i2c2 */
 #define STM32_CLOCK_PERIPH_I2C2		0x7A8
+/** @brief STM32 clock periph i2c3 */
 #define STM32_CLOCK_PERIPH_I2C3		0x7AC
+/** @brief STM32 clock periph i2c4 */
 #define STM32_CLOCK_PERIPH_I2C4		0x7B0
+/** @brief STM32 clock periph i2c5 */
 #define STM32_CLOCK_PERIPH_I2C5		0x7B4
+/** @brief STM32 clock periph i2c6 */
 #define STM32_CLOCK_PERIPH_I2C6		0x7B8
+/** @brief STM32 clock periph i2c7 */
 #define STM32_CLOCK_PERIPH_I2C7		0x7BC
+/** @brief STM32 clock periph i2c8 */
 #define STM32_CLOCK_PERIPH_I2C8		0x7C0
 
 /* FDCAN Peripheral */
+/** @brief STM32 clock periph fdcan */
 #define STM32_CLOCK_PERIPH_FDCAN	0x7E0
 
 /* Watchdog Peripheral */
+/** @brief STM32 clock periph iwdg4 */
 #define STM32_CLOCK_PERIPH_IWDG4	0x894
+/** @brief STM32 clock periph wwdg1 */
 #define STM32_CLOCK_PERIPH_WWDG1	0x89C
 
 /* CRC peripheral */
+/** @brief STM32 clock periph crc */
 #define STM32_CLOCK_PERIPH_CRC		0x8B4
 
 /* I3C Peripheral */
+/** @brief STM32 clock periph i3c1 */
 #define STM32_CLOCK_PERIPH_I3C1		0x8C8
+/** @brief STM32 clock periph i3c2 */
 #define STM32_CLOCK_PERIPH_I3C2		0x8CC
+/** @brief STM32 clock periph i3c3 */
 #define STM32_CLOCK_PERIPH_I3C3		0x8D0
+/** @brief STM32 clock periph i3c4 */
 #define STM32_CLOCK_PERIPH_I3C4		0x8D4
 
+/** @brief STM32 clock periph min */
 #define STM32_CLOCK_PERIPH_MIN	STM32_CLOCK_PERIPH_GPIOA
+/** @brief STM32 clock periph max */
 #define STM32_CLOCK_PERIPH_MAX	STM32_CLOCK_PERIPH_I3C4
 
-/** @endcond */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP2_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32n6_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32n6_clock.h
@@ -14,198 +14,357 @@
 
 /** System clock */
 /* defined in stm32_common_clocks.h */
-/** Fixed clocks  */
+/* Fixed clocks */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for MSI */
 #define STM32_SRC_MSI		(STM32_SRC_HSI + 1)
-/** PLL outputs */
+/* PLL outputs */
+/** @brief Clock source identifier for PLL1 */
 #define STM32_SRC_PLL1		(STM32_SRC_MSI + 1)
+/** @brief Clock source identifier for PLL2 */
 #define STM32_SRC_PLL2		(STM32_SRC_PLL1 + 1)
+/** @brief Clock source identifier for PLL3 */
 #define STM32_SRC_PLL3		(STM32_SRC_PLL2 + 1)
+/** @brief Clock source identifier for PLL4 */
 #define STM32_SRC_PLL4		(STM32_SRC_PLL3 + 1)
-/** Clock muxes */
+/* Clock muxes */
+/** @brief Clock source identifier for CKPER */
 #define STM32_SRC_CKPER		(STM32_SRC_PLL4 + 1)
+/** @brief Clock source identifier for IC1 */
 #define STM32_SRC_IC1		(STM32_SRC_CKPER + 1)
+/** @brief Clock source identifier for IC2 */
 #define STM32_SRC_IC2		(STM32_SRC_IC1 + 1)
+/** @brief Clock source identifier for IC3 */
 #define STM32_SRC_IC3		(STM32_SRC_IC2 + 1)
+/** @brief Clock source identifier for IC4 */
 #define STM32_SRC_IC4		(STM32_SRC_IC3 + 1)
+/** @brief Clock source identifier for IC5 */
 #define STM32_SRC_IC5		(STM32_SRC_IC4 + 1)
+/** @brief Clock source identifier for IC6 */
 #define STM32_SRC_IC6		(STM32_SRC_IC5 + 1)
+/** @brief Clock source identifier for IC7 */
 #define STM32_SRC_IC7		(STM32_SRC_IC6 + 1)
+/** @brief Clock source identifier for IC8 */
 #define STM32_SRC_IC8		(STM32_SRC_IC7 + 1)
+/** @brief Clock source identifier for IC9 */
 #define STM32_SRC_IC9		(STM32_SRC_IC8 + 1)
+/** @brief Clock source identifier for IC10 */
 #define STM32_SRC_IC10		(STM32_SRC_IC9 + 1)
+/** @brief Clock source identifier for IC11 */
 #define STM32_SRC_IC11		(STM32_SRC_IC10 + 1)
+/** @brief Clock source identifier for IC12 */
 #define STM32_SRC_IC12		(STM32_SRC_IC11 + 1)
+/** @brief Clock source identifier for IC13 */
 #define STM32_SRC_IC13		(STM32_SRC_IC12 + 1)
+/** @brief Clock source identifier for IC14 */
 #define STM32_SRC_IC14		(STM32_SRC_IC13 + 1)
+/** @brief Clock source identifier for IC15 */
 #define STM32_SRC_IC15		(STM32_SRC_IC14 + 1)
+/** @brief Clock source identifier for IC16 */
 #define STM32_SRC_IC16		(STM32_SRC_IC15 + 1)
+/** @brief Clock source identifier for IC17 */
 #define STM32_SRC_IC17		(STM32_SRC_IC16 + 1)
+/** @brief Clock source identifier for IC18 */
 #define STM32_SRC_IC18		(STM32_SRC_IC17 + 1)
+/** @brief Clock source identifier for IC19 */
 #define STM32_SRC_IC19		(STM32_SRC_IC18 + 1)
+/** @brief Clock source identifier for IC20 */
 #define STM32_SRC_IC20		(STM32_SRC_IC19 + 1)
+/** @brief Clock source identifier for HSI_DIV */
 #define STM32_SRC_HSI_DIV	(STM32_SRC_IC20 + 1)
+/** @brief Clock source identifier for TIMG */
 #define STM32_SRC_TIMG		(STM32_SRC_HSI_DIV + 1)
+/** @brief Clock source identifier for HCLK1 */
 #define STM32_SRC_HCLK1		(STM32_SRC_TIMG + 1)
+/** @brief Clock source identifier for HCLK2 */
 #define STM32_SRC_HCLK2		(STM32_SRC_HCLK1 + 1)
+/** @brief Clock source identifier for HCLK3 */
 #define STM32_SRC_HCLK3		(STM32_SRC_HCLK2 + 1)
+/** @brief Clock source identifier for HCLK4 */
 #define STM32_SRC_HCLK4		(STM32_SRC_HCLK3 + 1)
+/** @brief Clock source identifier for HCLK5 */
 #define STM32_SRC_HCLK5		(STM32_SRC_HCLK4 + 1)
+/** @brief Clock source identifier for PCLK1 */
 #define STM32_SRC_PCLK1		(STM32_SRC_HCLK5 + 1)
+/** @brief Clock source identifier for PCLK2 */
 #define STM32_SRC_PCLK2		(STM32_SRC_PCLK1 + 1)
+/** @brief Clock source identifier for PCLK4 */
 #define STM32_SRC_PCLK4		(STM32_SRC_PCLK2 + 1)
+/** @brief Clock source identifier for PCLK5 */
 #define STM32_SRC_PCLK5		(STM32_SRC_PCLK4 + 1)
 
 /** Others: Not yet supported */
 /* #define STM32_SRC_I2SCKIN	TBD */
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief MISC bus clock enable register offset */
 #define STM32_CLOCK_BUS_MISC	0x248
+/** @brief MEM bus clock enable register offset */
 #define STM32_CLOCK_BUS_MEM	0x24C
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1	0x250
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2	0x254
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3	0x258
+/** @brief AHB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB4	0x25C
+/** @brief AHB5 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB5	0x260
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1	0x264
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2	0x268
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2	0x26C
+/** @brief APB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3	0x270
+/** @brief APB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB4	0x274
+/** @brief APB4_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB4_2	0x278
+/** @brief APB5 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB5	0x27C
 
+/** @brief STM32 clock lp bus shift */
 #define STM32_CLOCK_LP_BUS_SHIFT	0x40
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_MISC
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB5
 
 /** @brief RCC_CCIPRx register offset (RM0486.pdf) */
 #define CCIPR1_REG		0x144
+/** @brief RCC CCIPR2 register offset */
 #define CCIPR2_REG		0x148
+/** @brief RCC CCIPR3 register offset */
 #define CCIPR3_REG		0x14C
+/** @brief RCC CCIPR4 register offset */
 #define CCIPR4_REG		0x150
+/** @brief RCC CCIPR5 register offset */
 #define CCIPR5_REG		0x154
+/** @brief RCC CCIPR6 register offset */
 #define CCIPR6_REG		0x158
+/** @brief RCC CCIPR7 register offset */
 #define CCIPR7_REG		0x15C
+/** @brief RCC CCIPR8 register offset */
 #define CCIPR8_REG		0x160
+/** @brief RCC CCIPR9 register offset */
 #define CCIPR9_REG		0x164
+/** @brief RCC CCIPR12 register offset */
 #define CCIPR12_REG		0x170
+/** @brief RCC CCIPR13 register offset */
 #define CCIPR13_REG		0x174
+/** @brief RCC CCIPR14 register offset */
 #define CCIPR14_REG		0x178
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR1 devices */
+/* CCIPR1 devices */
+/** @brief Kernel clock source selection for ADF1 */
 #define ADF1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR1_REG)
+/** @brief Kernel clock source selection for ADC12 */
 #define ADC12_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 4, CCIPR1_REG)
+/** @brief Clock prescaler selection for ADC */
 #define ADC_PRE(val)		STM32_DT_CLOCK_SELECT((val), 15, 8, CCIPR1_REG)
+/** @brief Kernel clock source selection for DCMIPP */
 #define DCMIPP_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR1_REG)
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for ETH1PTP */
 #define ETH1PTP_SEL(val)	STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR2_REG)
+/** @brief Kernel clock source selection for ETH1CLK */
 #define ETH1CLK_SEL(val)	STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR2_REG)
+/** @brief Kernel clock source selection for ETH1 */
 #define ETH1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, CCIPR2_REG)
+/** @brief Kernel clock source selection for ETH1REFCLK */
 #define ETH1REFCLK_SEL(val)	STM32_DT_CLOCK_SELECT((val), 20, 20, CCIPR2_REG)
+/** @brief Kernel clock source selection for ETH1GTXCLK */
 #define ETH1GTXCLK_SEL(val)	STM32_DT_CLOCK_SELECT((val), 24, 24, CCIPR2_REG)
-/** CCIPR3 devices */
+/* CCIPR3 devices */
+/** @brief Kernel clock source selection for FDCAN */
 #define FDCAN_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR3_REG)
+/** @brief Kernel clock source selection for FMC */
 #define FMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR3_REG)
-/** CCIPR4 devices */
+/* CCIPR4 devices */
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR4_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 4, CCIPR4_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR4_REG)
+/** @brief Kernel clock source selection for I2C4 */
 #define I2C4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, CCIPR4_REG)
+/** @brief Kernel clock source selection for I3C1 */
 #define I3C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, CCIPR4_REG)
+/** @brief Kernel clock source selection for I3C2 */
 #define I3C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 22, 20, CCIPR4_REG)
+/** @brief Kernel clock source selection for LTDC */
 #define LTDC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 24, CCIPR4_REG)
-/** CCIPR5 devices */
+/* CCIPR5 devices */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR5_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)		STM32_DT_CLOCK_SELECT((val), 7, 4, CCIPR5_REG)
+/** @brief MCO2 clock source selection */
 #define MCO2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR5_REG)
+/** @brief MCO2 prescaler selection */
 #define MCO2_PRE(val)		STM32_DT_CLOCK_SELECT((val), 15, 12, CCIPR5_REG)
 
 /* MCO1 source */
+/** @brief MCO1 clock source selection value: HSI */
 #define MCO1_SEL_HSI  0
+/** @brief MCO1 clock source selection value: LSE */
 #define MCO1_SEL_LSE  1
+/** @brief MCO1 clock source selection value: MSI */
 #define MCO1_SEL_MSI  2
+/** @brief MCO1 clock source selection value: LSI */
 #define MCO1_SEL_LSI  3
+/** @brief MCO1 clock source selection value: HSE */
 #define MCO1_SEL_HSE  4
+/** @brief MCO1 clock source selection value: IC5 */
 #define MCO1_SEL_IC5  5
+/** @brief MCO1 clock source selection value: IC10 */
 #define MCO1_SEL_IC10 6
+/** @brief MCO1 clock source selection value: SYSA */
 #define MCO1_SEL_SYSA 7
 
 /* MCO2 source */
+/** @brief MCO2 clock source selection value: HSI */
 #define MCO2_SEL_HSI  0
+/** @brief MCO2 clock source selection value: LSE */
 #define MCO2_SEL_LSE  1
+/** @brief MCO2 clock source selection value: MSI */
 #define MCO2_SEL_MSI  2
+/** @brief MCO2 clock source selection value: LSI */
 #define MCO2_SEL_LSI  3
+/** @brief MCO2 clock source selection value: HSE */
 #define MCO2_SEL_HSE  4
+/** @brief MCO2 clock source selection value: IC15 */
 #define MCO2_SEL_IC15 5
+/** @brief MCO2 clock source selection value: IC20 */
 #define MCO2_SEL_IC20 6
+/** @brief MCO2 clock source selection value: SYSB */
 #define MCO2_SEL_SYSB 7
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1  0
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2  1
+/** @brief MCO prescaler division factor: 3 */
 #define MCO_PRE_DIV_3  2
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4  3
+/** @brief MCO prescaler division factor: 5 */
 #define MCO_PRE_DIV_5  4
+/** @brief MCO prescaler division factor: 6 */
 #define MCO_PRE_DIV_6  5
+/** @brief MCO prescaler division factor: 7 */
 #define MCO_PRE_DIV_7  6
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8  7
+/** @brief MCO prescaler division factor: 9 */
 #define MCO_PRE_DIV_9  8
+/** @brief MCO prescaler division factor: 10 */
 #define MCO_PRE_DIV_10 9
+/** @brief MCO prescaler division factor: 11 */
 #define MCO_PRE_DIV_11 10
+/** @brief MCO prescaler division factor: 12 */
 #define MCO_PRE_DIV_12 11
+/** @brief MCO prescaler division factor: 13 */
 #define MCO_PRE_DIV_13 12
+/** @brief MCO prescaler division factor: 14 */
 #define MCO_PRE_DIV_14 13
+/** @brief MCO prescaler division factor: 15 */
 #define MCO_PRE_DIV_15 14
+/** @brief MCO prescaler division factor: 16 */
 #define MCO_PRE_DIV_16 15
 
+/** @brief MDF1SEL: mdf1sel */
 #define MDF1SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, CCIPR5_REG)
-/** CCIPR6 devices */
+/* CCIPR6 devices */
+/** @brief Kernel clock source selection for XSPI1 */
 #define XSPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR6_REG)
+/** @brief Kernel clock source selection for XSPI2 */
 #define XSPI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR6_REG)
+/** @brief Kernel clock source selection for XSPI3 */
 #define XSPI3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR6_REG)
+/** @brief Kernel clock source selection for OTGPHY1 */
 #define OTGPHY1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR6_REG)
+/** @brief Kernel clock source selection for OTGPHY1CKREF */
 #define OTGPHY1CKREF_SEL(val)	STM32_DT_CLOCK_SELECT((val), 16, 16, CCIPR6_REG)
+/** @brief Kernel clock source selection for OTGPHY2 */
 #define OTGPHY2_SEL(val)	STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR6_REG)
+/** @brief Kernel clock source selection for OTGPHY2CKREF */
 #define OTGPHY2CKREF_SEL(val)	STM32_DT_CLOCK_SELECT((val), 24, 24, CCIPR6_REG)
-/** CCIPR7 devices */
+/* CCIPR7 devices */
+/** @brief Kernel clock source selection for PER */
 #define PER_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR7_REG)
+/** @brief Kernel clock source selection for PSSI */
 #define PSSI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR7_REG)
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR7_REG)
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 22, 20, CCIPR7_REG)
+/** @brief Kernel clock source selection for SAI2 */
 #define SAI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 24, CCIPR7_REG)
-/** CCIPR8 devices */
+/* CCIPR8 devices */
+/** @brief Kernel clock source selection for SDMMC1 */
 #define SDMMC1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR8_REG)
+/** @brief Kernel clock source selection for SDMMC2 */
 #define SDMMC2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR8_REG)
-/** CCIPR9 devices */
+/* CCIPR9 devices */
+/** @brief Kernel clock source selection for SPDIFRX1 */
 #define SPDIFRX1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR9_REG)
+/** @brief Kernel clock source selection for SPI1 */
 #define SPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 4, CCIPR9_REG)
+/** @brief Kernel clock source selection for SPI2 */
 #define SPI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR9_REG)
+/** @brief Kernel clock source selection for SPI3 */
 #define SPI3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, CCIPR9_REG)
+/** @brief Kernel clock source selection for SPI4 */
 #define SPI4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, CCIPR9_REG)
+/** @brief Kernel clock source selection for SPI5 */
 #define SPI5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 22, 20, CCIPR9_REG)
+/** @brief Kernel clock source selection for SPI6 */
 #define SPI6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 24, CCIPR9_REG)
-/** CCIPR12 devices */
+/* CCIPR12 devices */
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR12_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, CCIPR12_REG)
+/** @brief Kernel clock source selection for LPTIM3 */
 #define LPTIM3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, CCIPR12_REG)
+/** @brief Kernel clock source selection for LPTIM4 */
 #define LPTIM4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 22, 20, CCIPR12_REG)
+/** @brief Kernel clock source selection for LPTIM5 */
 #define LPTIM5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 24, CCIPR12_REG)
-/** CCIPR13 devices */
+/* CCIPR13 devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR13_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 4, CCIPR13_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR13_REG)
+/** @brief Kernel clock source selection for UART4 */
 #define UART4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, CCIPR13_REG)
+/** @brief Kernel clock source selection for UART5 */
 #define UART5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, CCIPR13_REG)
+/** @brief Kernel clock source selection for USART6 */
 #define USART6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 22, 20, CCIPR13_REG)
+/** @brief Kernel clock source selection for UART7 */
 #define UART7_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 24, CCIPR13_REG)
+/** @brief Kernel clock source selection for UART8 */
 #define UART8_SEL(val)		STM32_DT_CLOCK_SELECT((val), 30, 28, CCIPR13_REG)
-/** CCIPR14 devices */
+/* CCIPR14 devices */
+/** @brief Kernel clock source selection for UART9 */
 #define UART9_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR14_REG)
+/** @brief Kernel clock source selection for USART10 */
 #define USART10_SEL(val)	STM32_DT_CLOCK_SELECT((val), 6, 4, CCIPR14_REG)
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR14_REG)
 
 /** @brief RCC_ICxCFGR register offset (RM0486.pdf) */
@@ -221,6 +380,7 @@
 #define CPU_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CFGR1_REG)
 
 /* ADC prescaler division factor helper */
+/** @brief ADC_PRE_DIV: adc pre div */
 #define ADC_PRE_DIV(pres)	((pres - 1) & 0xFFU)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32N6_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32u0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u0_clock.h
@@ -8,13 +8,19 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus gatting clocks */
+/* Bus gatting clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x48
+/** @brief IOP bus clock enable register offset */
 #define STM32_CLOCK_BUS_IOP     0x4C
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x58
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x60
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1_2
 
 /** Domain clocks */
@@ -25,16 +31,25 @@
 
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI + 1)
+/** @brief Clock source identifier for MSI */
 #define STM32_SRC_MSI		(STM32_SRC_HSI48 + 1)
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_MSI + 1)
-/** Peripheral bus clock */
+/* Peripheral bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_HSE + 1)
-/** PLL clock outputs */
+/* PLL clock outputs */
+/** @brief Clock source identifier for PLL_P */
 #define STM32_SRC_PLL_P		(STM32_SRC_PCLK + 1)
+/** @brief Clock source identifier for PLL_Q */
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
+/** @brief Clock source identifier for PLL_R */
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
+/** @brief Clock source identifier for CK48 */
 #define STM32_SRC_CK48		(STM32_SRC_PLL_R + 1)
 
 /** @brief RCC_CCIPR register offset */
@@ -44,22 +59,37 @@
 #define BDCR_REG		0x90
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR devices */
+/* CCIPR devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR_REG)
+/** @brief Kernel clock source selection for LPUART3 */
 #define LPUART3_SEL(val)	STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR_REG)
+/** @brief Kernel clock source selection for LPUART2 */
 #define LPUART2_SEL(val)	STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR_REG)
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM3 */
 #define LPTIM3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, CCIPR_REG)
+/** @brief Kernel clock source selection for TIM1 */
 #define TIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 24, 24, CCIPR_REG)
+/** @brief Kernel clock source selection for TIM15 */
 #define TIM15_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 25, CCIPR_REG)
+/** @brief Kernel clock source selection for CLK48 */
 #define CLK48_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR_REG)
+/** @brief Kernel clock source selection for ADC */
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 28, CCIPR_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32u3_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u3_clock.h
@@ -14,38 +14,61 @@
 
 /** System clock */
 /* defined in stm32_common_clocks.h */
-/** Fixed clocks  */
+/* Fixed clocks */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI16 */
 #define STM32_SRC_HSI16		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI16 + 1)
+/** @brief Clock source identifier for MSIS */
 #define STM32_SRC_MSIS		(STM32_SRC_HSI48 + 1)
+/** @brief Clock source identifier for MSIK */
 #define STM32_SRC_MSIK		(STM32_SRC_MSIS + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for HCLK */
 #define STM32_SRC_HCLK		(STM32_SRC_MSIK + 1)
+/** @brief Clock source identifier for PCLK1 */
 #define STM32_SRC_PCLK1		(STM32_SRC_HCLK + 1)
+/** @brief Clock source identifier for PCLK2 */
 #define STM32_SRC_PCLK2		(STM32_SRC_PCLK1 + 1)
+/** @brief Clock source identifier for PCLK3 */
 #define STM32_SRC_PCLK3		(STM32_SRC_PCLK2 + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK3 + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
 /** Clock muxes */
 /* #define STM32_SRC_ICLK	TBD */
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x088
+/** @brief AHB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1_2  0x094
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x08C
+/** @brief AHB2_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2_2  0x090
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x09C
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x0A0
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x0A4
+/** @brief APB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3    0x0A8
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB3
 
 /** @brief RCC_CCIPRx register offset (RM0487.pdf) */
 #define CCIPR1_REG		0x100
+/** @brief RCC CCIPR2 register offset */
 #define CCIPR2_REG		0x104
+/** @brief RCC CCIPR3 register offset */
 #define CCIPR3_REG		0x108
 
 /** @brief RCC_BDCR register offset */
@@ -55,64 +78,113 @@
 #define CFGR1_REG               0x0C
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR1 devices */
+/* CCIPR1 devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 0, 0, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 2, CCIPR1_REG)
+/** @brief Kernel clock source selection for UART4 */
 #define UART4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 4, 4, CCIPR1_REG)
+/** @brief Kernel clock source selection for UART5 */
 #define UART5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 6, CCIPR1_REG)
+/** @brief Kernel clock source selection for I3C1 */
 #define I3C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 8, 8, CCIPR1_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 10, CCIPR1_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 12, 12, CCIPR1_REG)
+/** @brief Kernel clock source selection for I3C2 */
 #define I3C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 14, CCIPR1_REG)
+/** @brief Kernel clock source selection for SPI2 */
 #define SPI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 16, 16, CCIPR1_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR1_REG)
+/** @brief Kernel clock source selection for SPI1 */
 #define SPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 20, 20, CCIPR1_REG)
+/** @brief Kernel clock source selection for SYSTICK */
 #define SYSTICK_SEL(val)	STM32_DT_CLOCK_SELECT((val), 23, 22, CCIPR1_REG)
+/** @brief Kernel clock source selection for FDCAN1 */
 #define FDCAN1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 24, 24, CCIPR1_REG)
+/** @brief Kernel clock source selection for ICLK */
 #define ICLK_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR1_REG)
+/** @brief Kernel clock source selection for USB1 */
 #define USB1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 28, 28, CCIPR1_REG)
+/** @brief Kernel clock source selection for TIMIC */
 #define TIMIC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 29, CCIPR1_REG)
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for ADF1 */
 #define ADF1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR2_REG)
+/** @brief Kernel clock source selection for SPI3 */
 #define SPI3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 3, CCIPR2_REG)
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 5, CCIPR2_REG)
+/** @brief Kernel clock source selection for RNG */
 #define RNG_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 11, CCIPR2_REG)
+/** @brief Clock prescaler selection for ADCDAC */
 #define ADCDAC_PRE(val)		STM32_DT_CLOCK_SELECT((val), 15, 12, CCIPR2_REG)
+/** @brief Kernel clock source selection for ADCDAC */
 #define ADCDAC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR2_REG)
+/** @brief Kernel clock source selection for DAC1SH */
 #define DAC1SH_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 19, CCIPR2_REG)
+/** @brief Kernel clock source selection for OCTOSPI */
 #define OCTOSPI_SEL(val)	STM32_DT_CLOCK_SELECT((val), 20, 20, CCIPR2_REG)
-/** CCIPR3 devices */
+/* CCIPR3 devices */
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR3_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 6, 6, CCIPR3_REG)
+/** @brief Kernel clock source selection for LPTIM34 */
 #define LPTIM34_SEL(val)	STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR3_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR3_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
-/** CFGR1 devices */
+/* CFGR1 devices */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR1_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1   0
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2   1
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4   2
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8   3
+/** @brief MCO prescaler division factor: 16 */
 #define MCO_PRE_DIV_16  4
+/** @brief MCO prescaler division factor: 32 */
 #define MCO_PRE_DIV_32  5
+/** @brief MCO prescaler division factor: 64 */
 #define MCO_PRE_DIV_64  6
+/** @brief MCO prescaler division factor: 128 */
 #define MCO_PRE_DIV_128 7
 
 /* ADC/DAC prescaler division factor */
+/** @brief ADC/DAC prescaler division factor: 1 */
 #define ADCDAC_PRE_DIV_1	0x0
+/** @brief ADC/DAC prescaler division factor: 2 */
 #define ADCDAC_PRE_DIV_2	0x1
+/** @brief ADC/DAC prescaler division factor: 4 */
 #define ADCDAC_PRE_DIV_4	0x8
+/** @brief ADC/DAC prescaler division factor: 8 */
 #define ADCDAC_PRE_DIV_8	0x9
+/** @brief ADC/DAC prescaler division factor: 16 */
 #define ADCDAC_PRE_DIV_16	0xA
+/** @brief ADC/DAC prescaler division factor: 32 */
 #define ADCDAC_PRE_DIV_32	0xB
+/** @brief ADC/DAC prescaler division factor: 64 */
 #define ADCDAC_PRE_DIV_64	0xC
+/** @brief ADC/DAC prescaler division factor: 128 */
 #define ADCDAC_PRE_DIV_128	0xD
+/** @brief ADC/DAC prescaler division factor: 256 */
 #define ADCDAC_PRE_DIV_256	0xE
+/** @brief ADC/DAC prescaler division factor: 512 */
 #define ADCDAC_PRE_DIV_512	0xF
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U3_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32u5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u5_clock.h
@@ -15,50 +15,83 @@
 
 /** System clock */
 /* defined in stm32_common_clocks.h */
-/** Fixed clocks  */
+/* Fixed clocks */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI16 */
 #define STM32_SRC_HSI16		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI16 + 1)
+/** @brief Clock source identifier for MSIS */
 #define STM32_SRC_MSIS		(STM32_SRC_HSI48 + 1)
+/** @brief Clock source identifier for MSIK */
 #define STM32_SRC_MSIK		(STM32_SRC_MSIS + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for HCLK */
 #define STM32_SRC_HCLK		(STM32_SRC_MSIK + 1)
+/** @brief Clock source identifier for PCLK1 */
 #define STM32_SRC_PCLK1		(STM32_SRC_HCLK + 1)
+/** @brief Clock source identifier for PCLK2 */
 #define STM32_SRC_PCLK2		(STM32_SRC_PCLK1 + 1)
+/** @brief Clock source identifier for PCLK3 */
 #define STM32_SRC_PCLK3		(STM32_SRC_PCLK2 + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK3 + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
-/** PLL outputs */
+/* PLL outputs */
+/** @brief Clock source identifier for PLL1_P */
 #define STM32_SRC_PLL1_P	(STM32_SRC_TIMPCLK2 + 1)
+/** @brief Clock source identifier for PLL1_Q */
 #define STM32_SRC_PLL1_Q	(STM32_SRC_PLL1_P + 1)
+/** @brief Clock source identifier for PLL1_R */
 #define STM32_SRC_PLL1_R	(STM32_SRC_PLL1_Q + 1)
+/** @brief Clock source identifier for PLL2_P */
 #define STM32_SRC_PLL2_P	(STM32_SRC_PLL1_R + 1)
+/** @brief Clock source identifier for PLL2_Q */
 #define STM32_SRC_PLL2_Q	(STM32_SRC_PLL2_P + 1)
+/** @brief Clock source identifier for PLL2_R */
 #define STM32_SRC_PLL2_R	(STM32_SRC_PLL2_Q + 1)
+/** @brief Clock source identifier for PLL3_P */
 #define STM32_SRC_PLL3_P	(STM32_SRC_PLL2_R + 1)
+/** @brief Clock source identifier for PLL3_Q */
 #define STM32_SRC_PLL3_Q	(STM32_SRC_PLL3_P + 1)
+/** @brief Clock source identifier for PLL3_R */
 #define STM32_SRC_PLL3_R	(STM32_SRC_PLL3_Q + 1)
-/** DSI PHY clock */
+/* DSI PHY clock */
+/** @brief Clock source identifier for DSIPHY */
 #define STM32_SRC_DSIPHY	(STM32_SRC_PLL3_R + 1)
 /** Clock muxes */
 /* #define STM32_SRC_ICLK	TBD */
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x088
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x08C
+/** @brief AHB2_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2_2  0x090
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3    0x094
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x09C
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x0A0
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x0A4
+/** @brief APB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3    0x0A8
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB3
 
 /** @brief RCC_CCIPRx register offset (RM0456.pdf) */
 #define CCIPR1_REG		0xE0
+/** @brief RCC CCIPR2 register offset */
 #define CCIPR2_REG		0xE4
+/** @brief RCC CCIPR3 register offset */
 #define CCIPR3_REG		0xE8
 
 /** @brief RCC_BDCR register offset */
@@ -68,58 +101,103 @@
 #define CFGR1_REG               0x1C
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR1 devices */
+/* CCIPR1 devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR1_REG)
+/** @brief Kernel clock source selection for UART4 */
 #define UART4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR1_REG)
+/** @brief Kernel clock source selection for UART5 */
 #define UART5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR1_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR1_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR1_REG)
+/** @brief Kernel clock source selection for I2C4 */
 #define I2C4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, CCIPR1_REG)
+/** @brief Kernel clock source selection for SPI2 */
 #define SPI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR1_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR1_REG)
+/** @brief Kernel clock source selection for SPI1 */
 #define SPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR1_REG)
+/** @brief Kernel clock source selection for SYSTICK */
 #define SYSTICK_SEL(val)	STM32_DT_CLOCK_SELECT((val), 23, 22, CCIPR1_REG)
+/** @brief Kernel clock source selection for FDCAN1 */
 #define FDCAN1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 24, CCIPR1_REG)
+/** @brief Kernel clock source selection for ICKLK */
 #define ICKLK_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR1_REG)
+/** @brief Kernel clock source selection for TIMIC */
 #define TIMIC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 29, CCIPR1_REG)
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for MDF1 */
 #define MDF1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR2_REG)
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 5, CCIPR2_REG)
+/** @brief Kernel clock source selection for SAI2 */
 #define SAI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR2_REG)
+/** @brief Kernel clock source selection for SAE */
 #define SAE_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 11, CCIPR2_REG)
+/** @brief Kernel clock source selection for RNG */
 #define RNG_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR2_REG)
+/** @brief Kernel clock source selection for SDMMC */
 #define SDMMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 14, CCIPR2_REG)
+/** @brief Kernel clock source selection for DSI */
 #define DSI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 15, CCIPR2_REG)
+/** @brief Kernel clock source selection for USART6 */
 #define USART6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 16, 16, CCIPR2_REG)
+/** @brief Kernel clock source selection for LTDC */
 #define LTDC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 18, CCIPR2_REG)
+/** @brief Kernel clock source selection for OCTOSPI */
 #define OCTOSPI_SEL(val)	STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR2_REG)
+/** @brief Kernel clock source selection for HSPI */
 #define HSPI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, CCIPR2_REG)
+/** @brief Kernel clock source selection for I2C5 */
 #define I2C5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 25, 24, CCIPR2_REG)
+/** @brief Kernel clock source selection for I2C6 */
 #define I2C6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR2_REG)
+/** @brief Kernel clock source selection for OTGHS */
 #define OTGHS_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 30, CCIPR2_REG)
-/** CCIPR3 devices */
+/* CCIPR3 devices */
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 2, 0, CCIPR3_REG)
+/** @brief Kernel clock source selection for SPI3 */
 #define SPI3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 4, 3, CCIPR3_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR3_REG)
+/** @brief Kernel clock source selection for LPTIM34 */
 #define LPTIM34_SEL(val)	STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR3_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR3_REG)
+/** @brief Kernel clock source selection for ADCDAC */
 #define ADCDAC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, CCIPR3_REG)
+/** @brief Kernel clock source selection for DAC1 */
 #define DAC1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 15, CCIPR3_REG)
+/** @brief Kernel clock source selection for ADF1 */
 #define ADF1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, CCIPR3_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
-/** CFGR1 devices */
+/* CFGR1 devices */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR1_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1  0
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2  1
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4  2
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8  3
+/** @brief MCO prescaler division factor: 16 */
 #define MCO_PRE_DIV_16 4
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wb0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb0_clock.h
@@ -15,16 +15,24 @@
  * - CLK32MHZ: secondary clock for SPI3/I2S and BLE
  */
 #define STM32_SRC_CLKSLOWMUX		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for CLK16MHZ */
 #define STM32_SRC_CLK16MHZ		(STM32_SRC_CLKSLOWMUX + 1)
+/** @brief Clock source identifier for CLK32MHZ */
 #define STM32_SRC_CLK32MHZ		(STM32_SRC_CLK16MHZ + 1)
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB0 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB0	0x50
+/** @brief APB0 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB0	0x54
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1	0x58
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2	0x60
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB0
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB2
 
 /** @brief RCC_CFGR register offset */
@@ -36,10 +44,13 @@
 /** @brief Device clk sources selection helpers */
 
 /* WB05/WB09 only */
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 13, 13, CFGR_REG)
 /* WB06/WB07 only */
+/** @brief Kernel clock source selection for SPI2_I2S2 */
 #define SPI2_I2S2_SEL(val)	STM32_DT_CLOCK_SELECT((val), 22, 22, CFGR_REG)
 /* `msb` is only 22 for WB06/WB07, but a single definition with msb=23 is acceptable */
+/** @brief Kernel clock source selection for SPI3_I2S3 */
 #define SPI3_I2S3_SEL(val)	STM32_DT_CLOCK_SELECT((val), 23, 22, CFGR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wb_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb_clock.h
@@ -8,15 +8,23 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x048
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x04c
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3    0x050
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x058
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x05c
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x060
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB2
 
 /** Domain clocks */
@@ -26,17 +34,27 @@
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI48 */
 #define STM32_SRC_HSI48		(STM32_SRC_HSI + 1)
+/** @brief Clock source identifier for MSI */
 #define STM32_SRC_MSI		(STM32_SRC_HSI48 + 1)
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_MSI + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_HSE + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
-/** PLL clock outputs */
+/* PLL clock outputs */
+/** @brief Clock source identifier for PLL_P */
 #define STM32_SRC_PLL_P		(STM32_SRC_TIMPCLK2 + 1)
+/** @brief Clock source identifier for PLL_Q */
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
+/** @brief Clock source identifier for PLL_R */
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
 /* TODO: PLLSAI clocks */
 
@@ -50,20 +68,32 @@
 #define CSR_REG		0x94
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR devices */
+/* CCIPR devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR_REG)
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR_REG)
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, CCIPR_REG)
+/** @brief Kernel clock source selection for CLK48 */
 #define CLK48_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR_REG)
+/** @brief Kernel clock source selection for ADC */
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 28, CCIPR_REG)
+/** @brief Kernel clock source selection for RNG */
 #define RNG_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 30, CCIPR_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
-/** CSR devices */
+/* CSR devices */
+/** @brief Kernel clock source selection for RFWKP */
 #define RFWKP_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, CSR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wba_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wba_clock.h
@@ -17,91 +17,153 @@
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSE */
 #define STM32_SRC_HSE		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for HSI16 */
 #define STM32_SRC_HSI16		(STM32_SRC_HSE + 1)
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for HCLK1 */
 #define STM32_SRC_HCLK1		(STM32_SRC_HSI16 + 1)
+/** @brief Clock source identifier for HCLK5 */
 #define STM32_SRC_HCLK5		(STM32_SRC_HCLK1 + 1)
+/** @brief Clock source identifier for PCLK1 */
 #define STM32_SRC_PCLK1		(STM32_SRC_HCLK5 + 1)
+/** @brief Clock source identifier for PCLK2 */
 #define STM32_SRC_PCLK2		(STM32_SRC_PCLK1 + 1)
+/** @brief Clock source identifier for PCLK7 */
 #define STM32_SRC_PCLK7		(STM32_SRC_PCLK2 + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK7 + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
-/** PLL outputs */
+/* PLL outputs */
+/** @brief Clock source identifier for PLL1_P */
 #define STM32_SRC_PLL1_P	(STM32_SRC_TIMPCLK2 + 1)
+/** @brief Clock source identifier for PLL1_Q */
 #define STM32_SRC_PLL1_Q	(STM32_SRC_PLL1_P + 1)
+/** @brief Clock source identifier for PLL1_R */
 #define STM32_SRC_PLL1_R	(STM32_SRC_PLL1_Q + 1)
 
+/** @brief Clock source identifier for CLOCK_MIN */
 #define STM32_SRC_CLOCK_MIN	STM32_SRC_PLL1_P
+/** @brief Clock source identifier for CLOCK_MAX */
 #define STM32_SRC_CLOCK_MAX	STM32_SRC_SYSCLK
 
-/** Bus clocks (Register address offsets) */
+/* Bus clocks (Register address offsets) */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x088
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x08C
+/** @brief AHB4 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB4    0x094
+/** @brief AHB5 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB5    0x098
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x09C
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x0A0
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x0A4
+/** @brief APB7 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB7    0x0A8
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB7
 
 /** @brief RCC_CCIPRx register offset (RM0493.pdf) */
 #define CCIPR1_REG		0xE0
+/** @brief RCC CCIPR2 register offset */
 #define CCIPR2_REG		0xE4
+/** @brief RCC CCIPR3 register offset */
 #define CCIPR3_REG		0xE8
 /** @brief RCC_BCDR1 register offset (RM0493.pdf) */
 #define BCDR1_REG		0xF0
 
 /** @brief Device clk sources selection helpers */
-/** CCIPR1 devices */
+/* CCIPR1 devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR1_REG)
+/** @brief Kernel clock source selection for USART3 */
 #define USART3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR1_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR1_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR1_REG)
+/** @brief Kernel clock source selection for I2C4 */
 #define I2C4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, CCIPR1_REG)
+/** @brief Kernel clock source selection for SPI2 */
 #define SPI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR1_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR1_REG)
+/** @brief Kernel clock source selection for SPI1 */
 #define SPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR1_REG)
+/** @brief Kernel clock source selection for SYSTICK */
 #define SYSTICK_SEL(val)	STM32_DT_CLOCK_SELECT((val), 23, 22, CCIPR1_REG)
+/** @brief Kernel clock source selection for TIMIC */
 #define TIMIC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 31, CCIPR1_REG)
-/** CCIPR2 devices */
+/* CCIPR2 devices */
+/** @brief Kernel clock source selection for SAI1 */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 5, CCIPR2_REG)
+/** @brief Kernel clock source selection for RNG */
 #define RNG_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR2_REG)
+/** @brief Kernel clock source selection for OTGHS */
 #define OTGHS_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 28, CCIPR2_REG)
-/** CCIPR3 devices */
+/* CCIPR3 devices */
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR3_REG)
+/** @brief Kernel clock source selection for SPI3 */
 #define SPI3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 4, 3, CCIPR3_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR3_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR3_REG)
+/** @brief Kernel clock source selection for ADC */
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, CCIPR3_REG)
-/** BCDR1 devices */
+/* BCDR1 devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BCDR1_REG)
 /** @brief RCC_CFGRx register offset */
 #define CFGR1_REG               0x1C
-/** CFGR1 devices */
+/* CFGR1 devices */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR1_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1 0
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2 1
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4 2
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8 3
+/** @brief MCO prescaler division factor: 16 */
 #define MCO_PRE_DIV_16 4
 
 /* MCO clock output */
+/** @brief MCO clock source selection value: SYSCLKPRE */
 #define MCO_SEL_SYSCLKPRE 1
+/** @brief MCO clock source selection value: HSI16 */
 #define MCO_SEL_HSI16 3
+/** @brief MCO clock source selection value: HSE32 */
 #define MCO_SEL_HSE32 4
+/** @brief MCO clock source selection value: PLL1RCLK */
 #define MCO_SEL_PLL1RCLK 5
+/** @brief MCO clock source selection value: LSI */
 #define MCO_SEL_LSI 6
+/** @brief MCO clock source selection value: LSE */
 #define MCO_SEL_LSE 7
+/** @brief MCO clock source selection value: PLL1PCLK */
 #define MCO_SEL_PLL1PCLK 8
+/** @brief MCO clock source selection value: PLL1QCLK */
 #define MCO_SEL_PLL1QCLK 9
+/** @brief MCO clock source selection value: HCLK5 */
 #define MCO_SEL_HCLK5 10
 
 

--- a/include/zephyr/dt-bindings/clock/stm32wl_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wl_clock.h
@@ -8,17 +8,27 @@
 
 #include "stm32_common_clocks.h"
 
-/** Bus clocks */
+/* Bus clocks */
+/** @brief AHB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB1    0x048
+/** @brief AHB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB2    0x04c
+/** @brief AHB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_AHB3    0x050
+/** @brief APB0 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB0    0x054
+/** @brief APB1 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1    0x058
+/** @brief APB1_2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB1_2  0x05c
+/** @brief APB2 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB2    0x060
+/** @brief APB3 bus clock enable register offset */
 #define STM32_CLOCK_BUS_APB3    0x064
 
+/** @brief First peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+/** @brief Last peripheral bus clock enable register offset */
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB3
 
 /** Domain clocks */
@@ -29,16 +39,24 @@
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
+/** @brief Clock source identifier for HSI */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
+/** @brief Clock source identifier for MSI */
 #define STM32_SRC_MSI		(STM32_SRC_HSI + 1)
 /* #define STM32_SRC_HSI48	TBD */
-/** Bus clock */
+/* Bus clock */
+/** @brief Clock source identifier for PCLK */
 #define STM32_SRC_PCLK		(STM32_SRC_MSI + 1)
+/** @brief Clock source identifier for TIMPCLK1 */
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
+/** @brief Clock source identifier for TIMPCLK2 */
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
-/** PLL clock outputs */
+/* PLL clock outputs */
+/** @brief Clock source identifier for PLL_P */
 #define STM32_SRC_PLL_P		(STM32_SRC_TIMPCLK2 + 1)
+/** @brief Clock source identifier for PLL_Q */
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
+/** @brief Clock source identifier for PLL_R */
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
 
 /** @brief RCC_CCIPR register offset */
@@ -51,42 +69,72 @@
 #define CFGR1_REG        0x08
 
 /** @brief Device domain clocks selection helpers */
-/** CCIPR devices */
+/* CCIPR devices */
+/** @brief Kernel clock source selection for USART1 */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR_REG)
+/** @brief Kernel clock source selection for USART2 */
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR_REG)
+/** @brief Kernel clock source selection for SPI2 */
 #define SPI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR_REG)
+/** @brief Kernel clock source selection for LPUART1 */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C1 */
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C2 */
 #define I2C2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, CCIPR_REG)
+/** @brief Kernel clock source selection for I2C3 */
 #define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM1 */
 #define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM2 */
 #define LPTIM2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR_REG)
+/** @brief Kernel clock source selection for LPTIM3 */
 #define LPTIM3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 23, 22, CCIPR_REG)
+/** @brief Kernel clock source selection for ADC */
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 28, CCIPR_REG)
+/** @brief Kernel clock source selection for RNG */
 #define RNG_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 30, CCIPR_REG)
-/** BDCR devices */
+/* BDCR devices */
+/** @brief Kernel clock source selection for RTC */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
-/** CFGR1 devices */
+/* CFGR1 devices */
+/** @brief MCO1 clock source selection */
 #define MCO1_SEL(val)       STM32_DT_CLOCK_SELECT(val, 27, 24, CFGR1_REG)
+/** @brief MCO1 prescaler selection */
 #define MCO1_PRE(val)       STM32_DT_CLOCK_SELECT(val, 30, 28, CFGR1_REG)
 
 /* MCO prescaler : division factor */
+/** @brief MCO prescaler division factor: 1 */
 #define MCO_PRE_DIV_1  0
+/** @brief MCO prescaler division factor: 2 */
 #define MCO_PRE_DIV_2  1
+/** @brief MCO prescaler division factor: 4 */
 #define MCO_PRE_DIV_4  2
+/** @brief MCO prescaler division factor: 8 */
 #define MCO_PRE_DIV_8  3
+/** @brief MCO prescaler division factor: 16 */
 #define MCO_PRE_DIV_16 4
 
 /* MCO clock output */
+/** @brief MCO clock source selection value: NOCLK */
 #define MCO_SEL_NOCLK     0
+/** @brief MCO clock source selection value: SYSCLKPRE */
 #define MCO_SEL_SYSCLKPRE 1
+/** @brief MCO clock source selection value: MSI */
 #define MCO_SEL_MSI       2
+/** @brief MCO clock source selection value: HSI16 */
 #define MCO_SEL_HSI16     3
+/** @brief MCO clock source selection value: HSE32 */
 #define MCO_SEL_HSE32     4
+/** @brief MCO clock source selection value: PLL1RCLK */
 #define MCO_SEL_PLL1RCLK  5
+/** @brief MCO clock source selection value: LSI */
 #define MCO_SEL_LSI       6
+/** @brief MCO clock source selection value: LSE */
 #define MCO_SEL_LSE       8
+/** @brief MCO clock source selection value: PLL1PCLK */
 #define MCO_SEL_PLL1PCLK  13
+/** @brief MCO clock source selection value: PLL1QCLK */
 #define MCO_SEL_PLL1QCLK  14
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WL_CLOCK_H_ */


### PR DESCRIPTION
Add per-symbol /** @brief ... */ Doxygen documentation to every #define in all STM32 clock DT-binding headers. This fixes the Doxygen Coverage Delta Check CI failure that occurs when new symbols are added to these files (e.g. stm32mp13_clock.h).

Changes applied across all 34 affected headers under include/zephyr/dt-bindings/clock/stm32*:

- Convert bare section-header /** text */ comments preceding a #define to plain /* text */ so they do not mis-document the wrong symbol.
- Add /** @brief <description> */ above every #define that had no existing Doxygen comment, following patterns already in tree:
    STM32_SRC_*       : Clock source identifier for <name>
    STM32_CLOCK_BUS_* : <bus> bus clock enable register offset
    *_REG             : RCC <name> register offset
    *_SEL(val)        : Kernel clock source selection for <periph>
    *_PRE(val)        : Clock prescaler selection for <periph>
    MCO_PRE_DIV_*     : MCO prescaler division factor: <n>
- Preserve existing full /** @param / @note */ blocks intact
  (e.g. STM32_DT_CLOCK_SELECT, STM32_CLOCK).

Assisted-by: GitHub Copilot:Claude Sonnet 4.6