### PR TITLE
doc: services: device_mgmt: smp_groups: Use byte str

### DIFF
--- a/doc/services/device_mgmt/smp_groups/smp_group_3.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_3.rst
@@ -84,7 +84,7 @@ CBOR data of successful response:
 .. code-block:: none
 
     {
-        (str)"val"          : (bstr)
+        (str)"val"          : (byte str)
         (str,opt)"max_size" : (uint)
     }
 
@@ -155,7 +155,7 @@ CBOR data of request:
 
     {
         (str)"name"    : (str)
-        (str)"val"     : (bstr)
+        (str)"val"     : (byte str)
     }
 
 where:

--- a/doc/services/device_mgmt/smp_groups/smp_group_8.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_8.rst
@@ -493,7 +493,7 @@ CBOR data of successful response:
         (str)"type"     : (str)
         (str,opt)"off"  : (uint)
         (str)"len"      : (uint)
-        (str)"output"   : (uint or bstr)
+        (str)"output"   : (uint or byte str)
     }
 
 In case of error the CBOR data takes the form:


### PR DESCRIPTION
Replaces bstr with byte str to align with other usage