### PR TITLE
kernel: guard primitives with CHECKIF instead of __ASSERT

### DIFF
--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/toolchain.h>
+#include <zephyr/sys/check.h>
 #include <ksched.h>
 #include <scheduler.h>
 #include <wait_q.h>
@@ -107,6 +108,11 @@ int z_impl_k_condvar_wait(struct k_condvar *condvar, struct k_mutex *mutex,
 {
 	k_spinlock_key_t key;
 	int ret = -EAGAIN;
+
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_condvar, wait, condvar, timeout);
 

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -56,8 +56,6 @@ static struct k_obj_type obj_type_event;
 
 void z_impl_k_event_init(struct k_event *event)
 {
-	__ASSERT_NO_MSG(!arch_is_in_isr());
-
 	event->events = 0;
 	event->lock = (struct k_spinlock) {};
 
@@ -286,8 +284,10 @@ static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 	unsigned int  wait_condition;
 	struct k_thread  *thread;
 
-	__ASSERT(((arch_is_in_isr() == false) ||
-		  K_TIMEOUT_EQ(timeout, K_NO_WAIT)), "");
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_event, wait, event, events,
 					options, timeout);

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -8,6 +8,7 @@
 #include <zephyr/init.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/iterable_sections.h>
+#include <zephyr/sys/check.h>
 /* private kernel APIs */
 #include <ksched.h>
 #include <wait_q.h>
@@ -57,9 +58,12 @@ static void *z_heap_alloc_helper(struct k_heap *heap, size_t align, size_t bytes
 	k_timepoint_t end = sys_timepoint_calc(timeout);
 	void *ret = NULL;
 
-	k_spinlock_key_t key = k_spin_lock(&heap->lock);
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
-	__ASSERT(!arch_is_in_isr() || K_TIMEOUT_EQ(timeout, K_NO_WAIT), "");
+	k_spinlock_key_t key = k_spin_lock(&heap->lock);
 
 	bool blocked_alloc = false;
 
@@ -105,11 +109,12 @@ void *k_heap_alloc(struct k_heap *heap, size_t bytes, k_timeout_t timeout)
 void *k_heap_aligned_alloc(struct k_heap *heap, size_t align, size_t bytes,
 			k_timeout_t timeout)
 {
-	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_heap, aligned_alloc, heap, timeout);
-
 	/* A power of 2 as well as 0 is OK */
-	__ASSERT((align & (align - 1)) == 0,
-		 "align must be a power of 2");
+	CHECKIF((align & (align - 1)) != 0) {
+		return NULL;
+	}
+
+	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_heap, aligned_alloc, heap, timeout);
 
 	void *ret = z_heap_alloc_helper(heap, align, bytes, timeout,
 					sys_heap_aligned_alloc);
@@ -152,11 +157,14 @@ void *k_heap_realloc(struct k_heap *heap, void *ptr, size_t bytes, k_timeout_t t
 	k_timepoint_t end = sys_timepoint_calc(timeout);
 	void *ret = NULL;
 
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
+
 	k_spinlock_key_t key = k_spin_lock(&heap->lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_heap, realloc, heap, ptr, bytes, timeout);
-
-	__ASSERT(!arch_is_in_isr() || K_TIMEOUT_EQ(timeout, K_NO_WAIT), "");
 
 	while (ret == NULL) {
 		ret = sys_heap_realloc(&heap->heap, ptr, bytes);

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -14,6 +14,7 @@
 #include <zephyr/linker/sections.h>
 #include <string.h>
 #include <zephyr/sys/dlist.h>
+#include <zephyr/sys/check.h>
 /* private kernel APIs */
 #include <ksched.h>
 #include <kthread.h>
@@ -297,6 +298,11 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 int k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 	       k_timeout_t timeout)
 {
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
+
 	/* configure things for a synchronous send, then send the message */
 	tx_msg->_syncing_thread = _current;
 
@@ -388,6 +394,11 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 	struct k_mbox_msg *tx_msg;
 	k_spinlock_key_t key;
 	int result;
+
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	/* save receiver id so it can be used during message matching */
 	rx_msg->tx_target_thread = _current;

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -219,6 +219,11 @@ static bool slab_ptr_is_good(struct k_mem_slab *slab, const void *ptr)
 
 int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
 {
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
+
 	k_spinlock_key_t key = k_spin_lock(&slab->lock);
 	int result;
 

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/check.h>
 #include <wait_q.h>
 
 typedef void * (sys_heap_allocator_t)(struct sys_heap *heap, size_t align, size_t bytes);
@@ -21,8 +22,9 @@ static void *z_alloc_helper(struct k_heap *heap, size_t align, size_t size,
 	k_spinlock_key_t key;
 
 	/* A power of 2 as well as 0 is OK */
-	__ASSERT((align & (align - 1)) == 0,
-		"align must be a power of 2");
+	CHECKIF((align & (align - 1)) != 0) {
+		return NULL;
+	}
 
 	/*
 	 * Adjust the size to make room for our heap reference.

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -130,7 +130,10 @@ exit:
 static inline int put_msg_in_queue(struct k_msgq *msgq, const void *data,
 			k_timeout_t timeout, bool put_at_back)
 {
-	__ASSERT(!arch_is_in_isr() || K_TIMEOUT_EQ(timeout, K_NO_WAIT), "");
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	struct k_thread *pending_thread = NULL;
 	k_spinlock_key_t key;
@@ -286,7 +289,10 @@ static inline void z_vrfy_k_msgq_get_attrs(struct k_msgq *msgq,
 
 int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 {
-	__ASSERT(!arch_is_in_isr() || K_TIMEOUT_EQ(timeout, K_NO_WAIT), "");
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	k_spinlock_key_t key;
 	struct k_thread *pending_thread;

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -113,7 +113,10 @@ int z_impl_k_mutex_lock(struct k_mutex *mutex, k_timeout_t timeout)
 	int new_prio;
 #endif
 
-	__ASSERT(!arch_is_in_isr(), "mutexes cannot be used inside ISRs");
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_mutex, lock, mutex, timeout);
 
@@ -232,7 +235,10 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 {
 	struct k_thread *new_owner = NULL;
 
-	__ASSERT(!arch_is_in_isr(), "mutexes cannot be used inside ISRs");
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_mutex, unlock, mutex);
 

--- a/kernel/nothread.c
+++ b/kernel/nothread.c
@@ -4,6 +4,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/sys/check.h>
 #include <kernel_internal.h>
 
 /* We are not building thread.c when MULTITHREADING=n, so we
@@ -23,7 +24,10 @@ static K_TIMER_DEFINE(sleep_timer, NULL, NULL);
  */
 int32_t z_impl_k_sleep(k_timeout_t timeout)
 {
-	__ASSERT(!arch_is_in_isr(), "");
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	SYS_PORT_TRACING_FUNC_ENTER(k_thread, sleep, timeout);
 

--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/sys/minmax.h>
+#include <zephyr/sys/check.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/internal/syscall_handler.h>
@@ -153,9 +154,17 @@ int z_impl_k_pipe_write(struct k_pipe *pipe, const uint8_t *data, size_t len, k_
 {
 	int rc;
 	size_t written = 0;
-	k_timepoint_t end = sys_timepoint_calc(timeout);
-	k_spinlock_key_t key = k_spin_lock(&pipe->lock);
+	k_timepoint_t end;
+	k_spinlock_key_t key;
 	bool need_resched = false;
+
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
+
+	end = sys_timepoint_calc(timeout);
+	key = k_spin_lock(&pipe->lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_pipe, write, pipe, data, len, timeout);
 
@@ -226,9 +235,17 @@ int z_impl_k_pipe_read(struct k_pipe *pipe, uint8_t *data, size_t len, k_timeout
 {
 	struct pipe_buf_spec buf = { data, len, 0 };
 	int rc;
-	k_timepoint_t end = sys_timepoint_calc(timeout);
-	k_spinlock_key_t key = k_spin_lock(&pipe->lock);
+	k_timepoint_t end;
+	k_spinlock_key_t key;
 	bool need_resched = false;
+
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
+
+	end = sys_timepoint_calc(timeout);
+	key = k_spin_lock(&pipe->lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_pipe, read, pipe, data, len, timeout);
 

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -23,6 +23,7 @@
 #include <zephyr/sys/dlist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/sys/check.h>
 #include <stdbool.h>
 
 /* Single subsystem lock.  Locking per-event would be better on highly
@@ -286,15 +287,19 @@ int z_impl_k_poll(struct k_poll_event *events, int num_events,
 	k_spinlock_key_t key;
 	struct z_poller *poller = &_current->poller;
 
+	SYS_PORT_TRACING_FUNC_ENTER(k_poll_api, poll, events);
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
+
+	CHECKIF((events == NULL) || (num_events < 0)) {
+		SYS_PORT_TRACING_FUNC_EXIT(k_poll_api, poll, events, -EINVAL);
+		return -EINVAL;
+	}
+
 	poller->is_polling = true;
 	poller->mode = MODE_POLL;
-
-	__ASSERT(!arch_is_in_isr(), "");
-	__ASSERT(events != NULL, "NULL events\n");
-	__ASSERT(num_events >= 0, "<0 events\n");
-
-	SYS_PORT_TRACING_FUNC_ENTER(k_poll_api, poll, events);
-
 	events_registered = register_events(events, num_events, poller,
 					    K_TIMEOUT_EQ(timeout, K_NO_WAIT));
 
@@ -706,12 +711,12 @@ int k_work_poll_submit_to_queue(struct k_work_q *work_q,
 	int events_registered;
 	k_spinlock_key_t key;
 
-	__ASSERT(work_q != NULL, "NULL work_q\n");
-	__ASSERT(work != NULL, "NULL work\n");
-	__ASSERT(events != NULL, "NULL events\n");
-	__ASSERT(num_events >= 0, "<0 events\n");
-
 	SYS_PORT_TRACING_FUNC_ENTER(k_work_poll, submit_to_queue, work_q, work, timeout);
+	CHECKIF((work_q == NULL) || (work == NULL) || (events == NULL) || (num_events < 0)) {
+		SYS_PORT_TRACING_FUNC_EXIT(k_work_poll, submit_to_queue, work_q,
+			work, timeout, -EINVAL);
+		return -EINVAL;
+	}
 
 	/* Take ownership of the work if it is possible. */
 	key = k_spin_lock(&poll_lock);
@@ -829,9 +834,8 @@ int k_work_poll_cancel(struct k_work_poll *work)
 	SYS_PORT_TRACING_FUNC_ENTER(k_work_poll, cancel, work);
 
 	/* Check if the work was submitted. */
-	if (work == NULL || work->workq == NULL) {
+	CHECKIF(work == NULL || work->workq == NULL) {
 		SYS_PORT_TRACING_FUNC_EXIT(k_work_poll, cancel, work, -EINVAL);
-
 		return -EINVAL;
 	}
 

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -321,6 +321,11 @@ int k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list)
 
 void *z_impl_k_queue_get(struct k_queue *queue, k_timeout_t timeout)
 {
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
+
 	k_spinlock_key_t key = k_spin_lock(&queue->lock);
 	void *data;
 

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -128,8 +128,10 @@ int z_impl_k_sem_take(struct k_sem *sem, k_timeout_t timeout)
 {
 	int ret;
 
-	__ASSERT(((arch_is_in_isr() == false) ||
-		  K_TIMEOUT_EQ(timeout, K_NO_WAIT)), "");
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	k_spinlock_key_t key = k_spin_lock(&sem_lock);
 

--- a/kernel/sleep.c
+++ b/kernel/sleep.c
@@ -15,6 +15,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/sys/check.h>
 #include <ksched.h>
 #include <kthread.h>
 #include <kswap.h>
@@ -49,7 +50,10 @@ static int32_t z_tick_sleep(k_timeout_t timeout)
 {
 	uint32_t expected_wakeup_ticks;
 
-	__ASSERT(!arch_is_in_isr(), "");
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	/* K_NO_WAIT is treated as a 'yield' */
 	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
@@ -91,8 +95,6 @@ static int32_t z_tick_sleep(k_timeout_t timeout)
 int32_t z_impl_k_sleep(k_timeout_t timeout)
 {
 	k_ticks_t ticks;
-
-	__ASSERT(!arch_is_in_isr(), "");
 
 	SYS_PORT_TRACING_FUNC_ENTER(k_thread, sleep, timeout);
 

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -144,6 +144,11 @@ int z_impl_k_stack_pop(struct k_stack *stack, stack_data_t *data,
 	k_spinlock_key_t key;
 	int result;
 
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
+
 	key = k_spin_lock(&stack->lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_stack, pop, stack, timeout);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -999,7 +999,10 @@ k_tid_t z_impl_k_thread_create(struct k_thread *new_thread,
 			      void *p1, void *p2, void *p3,
 			      int prio, uint32_t options, k_timeout_t delay)
 {
-	__ASSERT(!arch_is_in_isr(), "Threads may not be created in ISRs");
+	CHECKIF(k_is_in_isr()) {
+		/* threads cannot be created from ISRs */
+		k_panic();
+	}
 
 	z_setup_new_thread(new_thread, stack, stack_size, entry, p1, p2, p3,
 			  prio, options, NULL);
@@ -1747,6 +1750,11 @@ void z_impl_k_thread_abort(k_tid_t thread)
 
 int z_impl_k_thread_join(struct k_thread *thread, k_timeout_t timeout)
 {
+	CHECKIF(k_is_in_isr() && !K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
+
 	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
 	int ret;
 
@@ -1761,7 +1769,6 @@ int z_impl_k_thread_join(struct k_thread *thread, k_timeout_t timeout)
 		   (thread->base.pended_on == &_current->join_queue)) {
 		ret = -EDEADLK;
 	} else {
-		__ASSERT(!arch_is_in_isr(), "cannot join in ISR");
 		z_sched_add_to_waitq_locked(_current, &thread->join_queue);
 		z_add_thread_timeout(_current, timeout);
 
@@ -1845,7 +1852,10 @@ bool k_can_yield(void)
 
 void z_impl_k_yield(void)
 {
-	__ASSERT(!arch_is_in_isr(), "");
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	SYS_PORT_TRACING_FUNC(k_thread, yield);
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -161,7 +161,10 @@ int k_timer_cleanup(struct k_timer *timer)
 	 * spin waiting for an in-flight handler, and an ISR spinning here
 	 * could starve the very CPU the handler needs to make progress.
 	 */
-	__ASSERT(!arch_is_in_isr(), "");
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, cleanup, timer);
 
@@ -351,8 +354,11 @@ static inline uint32_t z_vrfy_k_timer_status_get(struct k_timer *timer)
 
 uint32_t z_impl_k_timer_status_sync(struct k_timer *timer)
 {
-	__ASSERT(!arch_is_in_isr(), "");
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, status_sync, timer);
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	if (!IS_ENABLED(CONFIG_MULTITHREADING)) {
 		uint32_t result;

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -16,6 +16,7 @@
 #include <errno.h>
 #include <ksched.h>
 #include <scheduler.h>
+#include <zephyr/sys/check.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/logging/log.h>
 
@@ -456,13 +457,16 @@ bool k_work_flush(struct k_work *work,
 {
 	__ASSERT_NO_MSG(work != NULL);
 	__ASSERT_NO_MSG(!flag_test(&work->flags, K_WORK_DELAYABLE_BIT));
-	__ASSERT_NO_MSG(!k_is_in_isr());
 	__ASSERT_NO_MSG(sync != NULL);
 #ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(sys_cache_is_mem_coherent(sync));
 #endif /* CONFIG_KERNEL_COHERENCE */
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, flush, work);
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	struct z_work_flusher *flusher = &sync->flusher;
 	k_spinlock_key_t key = k_spin_lock(&work_lock);
@@ -569,12 +573,15 @@ bool k_work_cancel_sync(struct k_work *work,
 	__ASSERT_NO_MSG(work != NULL);
 	__ASSERT_NO_MSG(sync != NULL);
 	__ASSERT_NO_MSG(!flag_test(&work->flags, K_WORK_DELAYABLE_BIT));
-	__ASSERT_NO_MSG(!k_is_in_isr());
 #ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(sys_cache_is_mem_coherent(sync));
 #endif /* CONFIG_KERNEL_COHERENCE */
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, cancel_sync, work, sync);
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	struct z_work_canceller *canceller = &sync->canceller;
 	k_spinlock_key_t key = k_spin_lock(&work_lock);
@@ -903,10 +910,16 @@ void k_work_queue_start(struct k_work_q *queue,
 int k_work_queue_drain(struct k_work_q *queue,
 		       bool plug)
 {
-	__ASSERT_NO_MSG(queue);
-	__ASSERT_NO_MSG(!k_is_in_isr());
-
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work_queue, drain, queue);
+
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
+	CHECKIF(!queue) {
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, drain, queue, -EINVAL);
+		return -EINVAL;
+	}
 
 	int ret = 0;
 	k_spinlock_key_t key = k_spin_lock(&work_lock);
@@ -1246,12 +1259,16 @@ bool k_work_cancel_delayable_sync(struct k_work_delayable *dwork,
 {
 	__ASSERT_NO_MSG(dwork != NULL);
 	__ASSERT_NO_MSG(sync != NULL);
-	__ASSERT_NO_MSG(!k_is_in_isr());
+
 #ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(sys_cache_is_mem_coherent(sync));
 #endif /* CONFIG_KERNEL_COHERENCE */
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, cancel_delayable_sync, dwork, sync);
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	struct z_work_canceller *canceller = &sync->canceller;
 	k_spinlock_key_t key = k_spin_lock(&work_lock);
@@ -1278,12 +1295,15 @@ bool k_work_flush_delayable(struct k_work_delayable *dwork,
 {
 	__ASSERT_NO_MSG(dwork != NULL);
 	__ASSERT_NO_MSG(sync != NULL);
-	__ASSERT_NO_MSG(!k_is_in_isr());
 #ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(sys_cache_is_mem_coherent(sync));
 #endif /* CONFIG_KERNEL_COHERENCE */
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, flush_delayable, dwork, sync);
+	CHECKIF(k_is_in_isr()) {
+		/* calling a pending function from an ISR is not allowed. */
+		k_panic();
+	}
 
 	struct k_work *work = &dwork->work;
 	struct z_work_flusher *flusher = &sync->flusher;

--- a/tests/kernel/mem_heap/k_heap_api/src/test_kheap_api.c
+++ b/tests/kernel/mem_heap/k_heap_api/src/test_kheap_api.c
@@ -437,15 +437,16 @@ ZTEST(k_heap_api, test_k_heap_aligned_alloc)
 	p = k_heap_aligned_alloc(&k_heap_test, 8, HEAP_SIZE * 2, K_NO_WAIT);
 	zassert_is_null(p, "k_heap_aligned_alloc with oversize should fail");
 
-	ztest_set_fault_valid(true);
-	/* invalid alignment, should assert */
-	p = k_heap_aligned_alloc(&k_heap_test, 3, 64, K_NO_WAIT);
-	(void)p;
-	/*
-	 * If calling k_heap_aligned_alloc with invalid alignment didn't result in an assert
-	 * then the API isn't working as expected, and the test shall fail.
-	 */
-	ztest_test_fail();
+	if (IS_ENABLED(CONFIG_ASSERT_ON_ERRORS)) {
+		ztest_set_fault_valid(true);
+		p = k_heap_aligned_alloc(&k_heap_test, 3, 64, K_NO_WAIT);
+		(void)p;
+		ztest_test_fail();
+	} else if (IS_ENABLED(CONFIG_RUNTIME_ERROR_CHECKS)) {
+		p = k_heap_aligned_alloc(&k_heap_test, 3, 64, K_NO_WAIT);
+		zassert_is_null(p,
+			"k_heap_aligned_alloc with invalid alignment should return NULL");
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Standardise the kernel's caller-error and illegal-context checks on the `CHECKIF()` macro, replacing the mix of `__ASSERT()` and open-coded checks.
Behaviour is governed by the existing "Error checking behavior for CHECK macro" choice.

## Motivation

Misuse such as calling a blocking primitive from an ISR was guarded by `__ASSERT()`, which is compiled out in common builds. The checks never fired and real bugs shipped.
`CHECKIF()` lets the same condition:
- assert under `CONFIG_ASSERT_ON_ERRORS`,
- k_panic() / return an error under the default `CONFIG_RUNTIME_ERROR_CHECKS`,
- compile out under `CONFIG_NO_RUNTIME_CHECKS`.

Under the shipped default (`RUNTIME_ERROR_CHECKS`) these checks are now active, catching the misuse at the call site with no debug build required.
Production builds should set `CONFIG_NO_RUNTIME_CHECKS=y` to regain the size and performance of the kernel.

## What's included
- Illegal context (panic): every pend-capable primitive panics when called from an ISR with `timeout != K_NO_WAIT`, unconditionally ISR-forbidden blocking APIs panic on any ISR use.
- Illegal argument checks now return error instead of `__ASSERT()`.
- Each check runs before the primitive's spinlock is taken.

Behaviour changes
- `k_poll()` and `k_thread_join()` now permit ISR callers when `timeout == K_NO_WAIT` matching the other pending primitives.
- Default (`RUNTIME_ERROR_CHECKS`) builds gain a small text increase from the panic/return branches. `CONFIG_NO_RUNTIME_CHECKS` removes them entirely.


