### PR TITLE
arch: xtensa: change backtrace to use `EXCEPTION_DUMP`

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -36,17 +36,6 @@ config XTENSA_ENABLE_BACKTRACE
 	help
 	  Enable this config option to print backtrace on panic exception
 
-config XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK
-	bool "Send backtrace to exception dump hook"
-	depends on XTENSA_ENABLE_BACKTRACE && EXCEPTION_DUMP_HOOK
-	default y if EXCEPTION_DUMP_HOOK_ONLY
-	help
-	  Enable this option to forward Xtensa panic backtrace output to
-	  exception dump hook.
-
-	  When EXCEPTION_DUMP_HOOK_ONLY is enabled, this defaults to y to
-	  preserve hook-only backtrace output.
-
 config XTENSA_SMALL_VECTOR_TABLE_ENTRY
 	bool "Workaround for small vector table entries"
 	help

--- a/arch/xtensa/core/xtensa_backtrace.c
+++ b/arch/xtensa/core/xtensa_backtrace.c
@@ -19,6 +19,9 @@
 #include <xtensa_asm2_context.h>
 #include <xtensa_stack.h>
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
+
 static int mask, cause;
 
 static inline uint32_t xtensa_cpu_process_stack_pc(uint32_t pc)
@@ -139,17 +142,11 @@ int xtensa_backtrace_print(int depth, int *interrupted_stack)
 	if (cause != EXCCAUSE_INSTR_PROHIBITED) {
 		mask = stk_frame.pc & 0xc0000000;
 	}
-#if defined(CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK)
-	arch_exception_call_dump_hook("BT 0x%08x:0x%08x ",
-				      xtensa_cpu_process_stack_pc(stk_frame.pc),
-				      stk_frame.sp);
-#endif
-#if !defined(CONFIG_EXCEPTION_DUMP_HOOK_ONLY)
-	printk("\r\n\r\nBacktrace:");
-	printk("0x%08x:0x%08x ",
-			xtensa_cpu_process_stack_pc(stk_frame.pc),
-			stk_frame.sp);
-#endif
+	EXCEPTION_DUMP("Backtrace:");
+	EXCEPTION_DUMP("0x%08x:0x%08x",
+		       xtensa_cpu_process_stack_pc(stk_frame.pc),
+		       stk_frame.sp);
+
 	/* Check if first frame is valid */
 	bool corrupted = !(xtensa_stack_ptr_is_sane(stk_frame.sp) &&
 				(xtensa_ptr_executable((void *)
@@ -162,36 +159,20 @@ int xtensa_backtrace_print(int depth, int *interrupted_stack)
 		if (!xtensa_backtrace_get_next_frame(&stk_frame)) {
 			corrupted = true;
 		}
-#if defined(CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK)
-		arch_exception_call_dump_hook("0x%08x:0x%08x ",
-					      xtensa_cpu_process_stack_pc(stk_frame.pc),
-					      stk_frame.sp);
-#endif
-#if !defined(CONFIG_EXCEPTION_DUMP_HOOK_ONLY)
-		printk("0x%08x:0x%08x ", xtensa_cpu_process_stack_pc(stk_frame.pc), stk_frame.sp);
-#endif
+		EXCEPTION_DUMP("0x%08x:0x%08x",
+			       xtensa_cpu_process_stack_pc(stk_frame.pc),
+			       stk_frame.sp);
 	}
 
 	/* Print backtrace termination marker */
 	int ret = 0;
 
-#if defined(CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK)
 	if (corrupted) {
-		arch_exception_call_dump_hook("CORRUPTED");
+		EXCEPTION_DUMP("CORRUPTED");
 		ret = -1;
 	} else if (stk_frame.next_pc != 0) {    /* Backtrace continues */
-		arch_exception_call_dump_hook("CONTINUES");
+		EXCEPTION_DUMP("CONTINUES");
 	}
-	arch_exception_call_dump_hook("\n");
-#endif
-#if !defined(CONFIG_EXCEPTION_DUMP_HOOK_ONLY)
-	if (corrupted) {
-		printk(" |<-CORRUPTED");
-		ret =  -1;
-	} else if (stk_frame.next_pc != 0) {    /* Backtrace continues */
-		printk(" |<-CONTINUES");
-	}
-	printk("\r\n\r\n");
-#endif
+
 	return ret;
 }

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -921,3 +921,6 @@ Architectures
 
 * ``CONFIG_XTENSA_MPU_DEFAULT_MEM_TYPE`` is removed since memory types are now defined via
   ``xtensa_mpu_mem_type_ranges[]``.
+
+* ``CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK`` is removed, since backtrace is now always
+  using :c:macro:`EXCEPTION_DUMP` for output.

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -62,6 +62,12 @@ API Changes
 Removed APIs and options
 ========================
 
+* Architectures
+
+   * Xtensa
+
+      * ``CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK``
+
 * Counter
 
     * ``CONFIG_COUNTER_MAXIM_DS3231``


### PR DESCRIPTION
The backtrace code was either calling the arch exception dump hook or printk based on the value of its own config called `CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP`.

However, this made fault output inconsistent when `CONFIG_LOG` is enabled because other output (like `xtensa_dump_stack()`) would use the macro `EXCEPTION_DUMP()`, which would use `LOG_ERR` instead of `printk`. Fault output would be a mix of log lines for register dumps and `printk` lines for backtrace (no domains, timestamps, etc).

This PR changes backtrace to use the `EXCEPTION_DUMP()` macro so output now is consistent. It also fixes an issue where if `printk` was going to the logging subsystem (`CONFIG_LOG_PRINTK=y`), because the printk calls in backtrace had no `\n` termination, the output would be lost in the log format buffer.