### PR TITLE
tests: drivers: uart: enable UART support for FLPR core

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&cpuflpr_code_partition {
+	reg = <0xf4000 DT_SIZE_K(64)>;
+};
+
+&pinctrl {
+	uart120_default: uart120_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 7, 7)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 7, 4)>;
+			bias-pull-up;
+		};
+	};
+
+	uart120_sleep: uart120_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 7, 7)>,
+				<NRF_PSEL(UART_RX, 7, 4)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart120 {
+	pinctrl-0 = <&uart120_default>;
+	pinctrl-1 = <&uart120_sleep>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <4000000>;
+	zephyr,pm-device-runtime-auto;
+};


### PR DESCRIPTION
Add proper test overlay so that the UART async api tests run correctly under Twister for the FLPR core.