### PR TITLE
tracing: Configurable init level

### DIFF
--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -23,6 +23,44 @@ config TRACING_CORE
 	  Automatically selected by formats that require the core
 	  tracing infrastructure.
 
+if TRACING_CORE
+
+choice TRACING_INIT_LEVEL
+	prompt "Tracing initialization level"
+	default TRACING_INIT_LEVEL_APPLICATION
+	help
+	  SYS_INIT level at which the tracing backend is initialized. A lower
+	  level starts tracing earlier and captures more of the boot sequence,
+	  but runs before subsystems initialized at later levels.
+
+config TRACING_INIT_LEVEL_PRE_KERNEL_2
+	bool "PRE_KERNEL_2"
+	depends on TRACING_SYNC
+	help
+	  Earliest supported level. Sync tracing only: async tracing creates its
+	  drainer thread in tracing_init(), which needs the kernel. The system
+	  timer also initializes at PRE_KERNEL_2 (sys_clock_driver_init at
+	  SYSTEM_CLOCK_INIT_PRIORITY), so TRACING_INIT_PRIORITY must be set higher
+	  than that - otherwise tracing runs before the cycle counter is live and
+	  event timestamps are invalid.
+
+config TRACING_INIT_LEVEL_POST_KERNEL
+	bool "POST_KERNEL"
+
+config TRACING_INIT_LEVEL_APPLICATION
+	bool "APPLICATION"
+
+endchoice
+
+config TRACING_INIT_PRIORITY
+	int "Tracing initialization priority"
+	default 0
+	help
+	  Initialization priority of the tracing backend within
+	  TRACING_INIT_LEVEL.
+
+endif # TRACING_CORE
+
 choice TRACING_FORMAT_CHOICE
 	prompt "Tracing Format"
 	default TRACING_NONE

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -1358,6 +1358,33 @@ void sys_trace_named_event(const char *name, uint32_t arg0, uint32_t arg1)
 	ctf_named_event(ctf_name, arg0, arg1);
 }
 
+static void _get_init_name(const struct init_entry *entry, ctf_bounded_string_t *name)
+{
+	const struct device *dev = entry->dev;
+
+	if (dev != NULL && dev->name != NULL && dev->name[0] != '\0') {
+		strncpy(name->buf, dev->name, sizeof(name->buf));
+		name->buf[sizeof(name->buf) - 1] = '\0';
+	}
+}
+
+void sys_trace_sys_init_enter(const struct init_entry *entry, int level)
+{
+	ctf_bounded_string_t name = {""};
+
+	_get_init_name(entry, &name);
+	ctf_sys_init_enter(name, (uint32_t)(uintptr_t)entry->init_fn, (uint8_t)level);
+}
+
+void sys_trace_sys_init_exit(const struct init_entry *entry, int level, int result)
+{
+	ctf_bounded_string_t name = {""};
+
+	_get_init_name(entry, &name);
+	ctf_sys_init_exit(name, (uint32_t)(uintptr_t)entry->init_fn, (uint8_t)level,
+			  (int32_t)result);
+}
+
 /* GPIO */
 void sys_port_trace_gpio_pin_interrupt_configure_enter(const struct device *port, gpio_pin_t pin,
 						       gpio_flags_t flags)

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -351,6 +351,8 @@ typedef enum {
 	CTF_EVENT_TIMER_EXPIRY_EXIT = 0x101,
 	CTF_EVENT_TIMER_STOP_FN_EXPIRY_ENTER = 0x102,
 	CTF_EVENT_TIMER_STOP_FN_EXPIRY_EXIT = 0x103,
+	CTF_EVENT_SYS_INIT_ENTER = 0x104,
+	CTF_EVENT_SYS_INIT_EXIT = 0x105,
 
 } ctf_event_t;
 
@@ -1411,6 +1413,17 @@ static inline void ctf_top_net_tx_time(int32_t if_index, uint32_t iface, uint32_
 static inline void ctf_named_event(ctf_bounded_string_t name, uint32_t arg0, uint32_t arg1)
 {
 	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_NAMED_EVENT), name, arg0, arg1);
+}
+
+static inline void ctf_sys_init_enter(ctf_bounded_string_t name, uint32_t fn, uint8_t level)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_SYS_INIT_ENTER), name, fn, level);
+}
+
+static inline void ctf_sys_init_exit(ctf_bounded_string_t name, uint32_t fn, uint8_t level,
+				     int32_t result)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_SYS_INIT_EXIT), name, fn, level, result);
 }
 
 /* GPIO */

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -284,9 +284,6 @@ extern "C" {
 #define sys_port_trace_k_event_wait_exit(event, events, ret)                                       \
 	sys_trace_k_event_wait_exit(event, events, ret)
 
-#define sys_trace_sys_init_enter(...)
-#define sys_trace_sys_init_exit(...)
-
 void sys_trace_idle(void);
 void sys_trace_idle_exit(void);
 void sys_trace_isr_enter(void);
@@ -641,6 +638,10 @@ void sys_trace_net_rx_time(struct net_pkt *pkt, uint32_t end_time);
 void sys_trace_net_tx_time(struct net_pkt *pkt, uint32_t end_time);
 
 void sys_trace_named_event(const char *name, uint32_t arg0, uint32_t arg1);
+
+struct init_entry;
+void sys_trace_sys_init_enter(const struct init_entry *entry, int level);
+void sys_trace_sys_init_exit(const struct init_entry *entry, int level, int result);
 
 /* GPIO */
 struct gpio_callback;

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -2229,3 +2229,24 @@ event {
 		uint32_t id;
 	};
 };
+
+event {
+	name = sys_init_enter;
+	id = 0x104;
+	fields := struct {
+		ctf_bounded_string_t name[20];
+		uint32_t fn;
+		uint8_t level;
+	};
+};
+
+event {
+	name = sys_init_exit;
+	id = 0x105;
+	fields := struct {
+		ctf_bounded_string_t name[20];
+		uint32_t fn;
+		uint8_t level;
+		int32_t result;
+	};
+};

--- a/subsys/tracing/tracing_core.c
+++ b/subsys/tracing/tracing_core.c
@@ -140,7 +140,27 @@ static int tracing_init(void)
 	return 0;
 }
 
-SYS_INIT(tracing_init, APPLICATION, 0);
+/* The init level is configurable (TRACING_INIT_LEVEL): a lower level captures
+ * more of the boot sequence. PRE_KERNEL_2 is the earliest supported (sync only,
+ * after the system timer so timestamps are valid); async tracing needs the
+ * kernel for its drainer thread, so it cannot go below POST_KERNEL.
+ */
+#define TRACING_INIT_LEVEL                                                                         \
+	COND_CASE_1(CONFIG_TRACING_INIT_LEVEL_PRE_KERNEL_2, (PRE_KERNEL_2),                        \
+		    CONFIG_TRACING_INIT_LEVEL_POST_KERNEL, (POST_KERNEL), (APPLICATION))
+
+SYS_INIT(tracing_init, TRACING_INIT_LEVEL, CONFIG_TRACING_INIT_PRIORITY);
+
+/* At PRE_KERNEL_2 the system timer initializes at the same level; tracing must
+ * run after it or k_cycle_get_32() is not yet ticking and event timestamps are
+ * invalid. Every in-tree timer registers sys_clock_driver_init() at PRE_KERNEL_2
+ * with SYSTEM_CLOCK_INIT_PRIORITY, so require a strictly higher tracing priority.
+ */
+#if defined(CONFIG_TRACING_INIT_LEVEL_PRE_KERNEL_2) && defined(CONFIG_SYS_CLOCK_EXISTS)
+BUILD_ASSERT(CONFIG_TRACING_INIT_PRIORITY > CONFIG_SYSTEM_CLOCK_INIT_PRIORITY,
+	     "Tracing at PRE_KERNEL_2 must init after the system timer: set "
+	     "TRACING_INIT_PRIORITY > SYSTEM_CLOCK_INIT_PRIORITY for valid timestamps");
+#endif
 
 #ifdef CONFIG_TRACING_ASYNC
 void tracing_trigger_output(bool before_put_is_empty)


### PR DESCRIPTION
The tracing backend initialized at a fixed `APPLICATION` level. Make the `SYS_INIT` level (`TRACING_INIT_LEVEL`) and priority (`TRACING_INIT_PRIORITY`) configurable so tracing can come up earlier and capture more of the boot sequence.

The earliest level is `PRE_KERNEL_2` (sync tracing only — async needs the kernel for its drainer thread), and it requires a priority above the system timer (`SYSTEM_CLOCK_INIT_PRIORITY`) so the cycle counter is live and event timestamps are valid. The defaults (`APPLICATION`, priority 0) preserve the previous behavior.

The kernel already calls `sys_trace_sys_init_enter/exit` around every `SYS_INIT` and device init, but the CTF backend stubbed them out. Implement them so per-init timing is captured.

Record the device name when the entry is a device, so the event is self-describing in any CTF reader. Bare `SYS_INIT` entries have no runtime name, so the `init_fn` pointer is recorded instead for offline resolution. The init level and result are included as well.