### PR TITLE
boards: st: stm32: Factorize HEX file instructions when TF-M is embedded

### DIFF
--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns_defconfig
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns_defconfig
@@ -10,3 +10,6 @@ CONFIG_UART_CONSOLE=y
 # Enable TZ non-secure configuration
 CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 CONFIG_RUNTIME_NMI=y
+
+# Set HEX file to program non-secure image using flash secure address range
+CONFIG_SOC_FAMILY_STM32_HEX_FILE_SEC_RANGE=y

--- a/boards/st/b_u585i_iot02a/board.cmake
+++ b/boards/st/b_u585i_iot02a/board.cmake
@@ -1,16 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-if(CONFIG_BUILD_WITH_TFM)
-  # Flash merged TF-M + Zephyr binary
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
-
-  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
-  # hence locate non-secure image from the secure flash base address in HEX file.
-  dt_chosen(chosen_part_path PROPERTY "zephyr,code-partition")
-  dt_reg_addr(chosen_part_addr PATH "${chosen_part_path}")
-  math(EXPR TFM_HEX_BASE_ADDRESS_NS
-    "${chosen_part_addr} - ${CONFIG_FLASH_BASE_ADDRESS} + ${CONFIG_STM32_INT_FLASH_SECURE_BASE_ADDRESS}"
-  )
-endif()
 
 # keep first
 if(CONFIG_FLASH_STM32_NOR_MEMMAP)
@@ -18,6 +6,10 @@ if(CONFIG_FLASH_STM32_NOR_MEMMAP)
   board_runner_args(stm32cubeprogrammer "--extload=MX25LM51245G_STM32U585I-IOT02A.stldr")
 else()
   board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+endif()
+
+if(CONFIG_BUILD_WITH_TFM)
+  board_runner_args(stm32cubeprogrammer "--erase")
 endif()
 
 board_runner_args(openocd "--tcl-port=6666")
@@ -32,3 +24,4 @@ include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 # Check board documentation for more details.
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/st/common/common.cmake)

--- a/boards/st/common/common.cmake
+++ b/boards/st/common/common.cmake
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BUILD_WITH_TFM)
+  # Flash merged TF-M + Zephyr binary
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
+
+  if(CONFIG_SOC_FAMILY_STM32_HEX_FILE_SEC_RANGE)
+    # When using TF-M, generated script <build>/tfm/api_ns/regression.sh must be
+    # run prior programming the device. This script does not set the flash non-secure
+    # boundaries hence non-secure image must be programmed using the flash secure address
+    # range with TFM_HEX_BASE_ADDRESS_NS.
+    dt_chosen(ns_part_path PROPERTY "zephyr,code-partition")
+    dt_reg_addr(ns_part_addr PATH "${ns_part_path}")
+    dt_chosen(ns_part_flash_path PROPERTY "zephyr,flash")
+    dt_reg_addr(ns_part_flash_base PATH "${ns_part_flash_path}")
+    math(EXPR TFM_HEX_BASE_ADDRESS_NS
+      "${ns_part_addr} - ${ns_part_flash_base} + ${CONFIG_STM32_INT_FLASH_SECURE_BASE_ADDRESS}"
+    )
+  endif()
+endif()

--- a/boards/st/nucleo_l552ze_q/board.cmake
+++ b/boards/st/nucleo_l552ze_q/board.cmake
@@ -1,18 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_BUILD_WITH_TFM)
-  # Flash merged TF-M + Zephyr binary
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
-
-  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
-  # hence locate non-secure image from the secure flash base address in HEX file.
-  dt_chosen(chosen_part_path PROPERTY "zephyr,code-partition")
-  dt_reg_addr(chosen_part_addr PATH "${chosen_part_path}")
-  math(EXPR TFM_HEX_BASE_ADDRESS_NS
-    "${chosen_part_addr} - ${CONFIG_FLASH_BASE_ADDRESS} + ${CONFIG_STM32_INT_FLASH_SECURE_BASE_ADDRESS}"
-  )
-endif()
-
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(pyocd "--target=stm32l552zetxq")
@@ -21,3 +8,4 @@ board_runner_args(pyocd "--target=stm32l552zetxq")
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
+include(${ZEPHYR_BASE}/boards/st/common/common.cmake)

--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns_defconfig
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns_defconfig
@@ -13,3 +13,6 @@ CONFIG_ARM_MPU=y
 # Enable TZ non-secure configuration
 CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 CONFIG_RUNTIME_NMI=y
+
+# Set HEX file to program non-secure image using flash secure address range
+CONFIG_SOC_FAMILY_STM32_HEX_FILE_SEC_RANGE=y

--- a/boards/st/nucleo_u3c5zi_q/board.cmake
+++ b/boards/st/nucleo_u3c5zi_q/board.cmake
@@ -1,22 +1,10 @@
 # SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+# keep first
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 if(CONFIG_BUILD_WITH_TFM)
-  # Flash merged TF-M + Zephyr binary
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
-
-  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
-  # hence locate non-secure image from the secure flash base address in HEX file.
-  dt_chosen(chosen_part_path PROPERTY "zephyr,code-partition")
-  dt_reg_addr(chosen_part_addr PATH "${chosen_part_path}")
-  math(EXPR ns_sec_flash_offset
-    "${CONFIG_STM32_INT_FLASH_SECURE_BASE_ADDRESS} - ${CONFIG_FLASH_BASE_ADDRESS}"
-  )
-  math(EXPR TFM_HEX_BASE_ADDRESS_NS "${chosen_part_addr} + ${ns_sec_flash_offset}")
-
-  board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw" "--erase")
-else()
-  board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
+  board_runner_args(stm32cubeprogrammer "--erase")
 endif()
 
 board_runner_args(pyocd "--target=stm32u3c5zit6q")
@@ -27,3 +15,4 @@ include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/st/common/common.cmake)

--- a/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q_stm32u3c5xx_ns_defconfig
+++ b/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q_stm32u3c5xx_ns_defconfig
@@ -20,3 +20,6 @@ CONFIG_ROM_START_OFFSET=0x400
 # Enable TZ non-secure configuration
 CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 CONFIG_RUNTIME_NMI=y
+
+# Set HEX file to program non-secure image using flash secure address range
+CONFIG_SOC_FAMILY_STM32_HEX_FILE_SEC_RANGE=y

--- a/boards/st/nucleo_wba65ri/board.cmake
+++ b/boards/st/nucleo_wba65ri/board.cmake
@@ -1,23 +1,12 @@
 # Copyright (c) 2025 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+# keep first
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 if(CONFIG_BUILD_WITH_TFM)
-  # Flash merged TF-M + Zephyr binary
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
-
-  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
-  # hence locate non-secure image from the secure flash base address in HEX file.
-  dt_chosen(chosen_part_path PROPERTY "zephyr,code-partition")
-  dt_reg_addr(chosen_part_addr PATH "${chosen_part_path}")
-  math(EXPR ns_sec_flash_offset
-    "${CONFIG_STM32_INT_FLASH_SECURE_BASE_ADDRESS} - ${CONFIG_FLASH_BASE_ADDRESS}"
-  )
-  math(EXPR TFM_HEX_BASE_ADDRESS_NS "${chosen_part_addr} + ${ns_sec_flash_offset}")
-
-  board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw" "--erase")
-else()
-  board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
+  board_runner_args(stm32cubeprogrammer "--erase")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
+include(${ZEPHYR_BASE}/boards/st/common/common.cmake)

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri_stm32wba65xx_ns_defconfig
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri_stm32wba65xx_ns_defconfig
@@ -20,3 +20,6 @@ CONFIG_ROM_START_OFFSET=0x400
 # Enable TZ non-secure configuration
 CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 CONFIG_RUNTIME_NMI=y
+
+# Set HEX file to program non-secure image using flash secure address range
+CONFIG_SOC_FAMILY_STM32_HEX_FILE_SEC_RANGE=y

--- a/boards/st/stm32h573i_dk/board.cmake
+++ b/boards/st/stm32h573i_dk/board.cmake
@@ -1,16 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-if(CONFIG_BUILD_WITH_TFM)
-  # Flash merged TF-M + Zephyr binary
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
-
-  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
-  # hence locate non-secure image from the secure flash base address in HEX file.
-  dt_chosen(chosen_part_path PROPERTY "zephyr,code-partition")
-  dt_reg_addr(chosen_part_addr PATH "${chosen_part_path}")
-  math(EXPR TFM_HEX_BASE_ADDRESS_NS
-    "${chosen_part_addr} - ${CONFIG_FLASH_BASE_ADDRESS} + ${CONFIG_STM32_INT_FLASH_SECURE_BASE_ADDRESS}"
-  )
-endif()
 
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
@@ -36,3 +24,4 @@ include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)
 # FIXME: official openocd runner not yet available.
+include(${ZEPHYR_BASE}/boards/st/common/common.cmake)

--- a/boards/st/stm32h573i_dk/stm32h573i_dk_stm32h573xx_ns_defconfig
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk_stm32h573xx_ns_defconfig
@@ -18,3 +18,6 @@ CONFIG_UART_CONSOLE=y
 # Enable TZ non-secure configuration
 CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 CONFIG_RUNTIME_NMI=y
+
+# Set HEX file to program non-secure image using flash secure address range
+CONFIG_SOC_FAMILY_STM32_HEX_FILE_SEC_RANGE=y

--- a/boards/st/stm32l562e_dk/board.cmake
+++ b/boards/st/stm32l562e_dk/board.cmake
@@ -1,16 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-if(CONFIG_BUILD_WITH_TFM)
-  # Flash merged TF-M + Zephyr binary
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
-
-  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
-  # hence locate non-secure image from the secure flash base address in HEX file.
-  dt_chosen(chosen_part_path PROPERTY "zephyr,code-partition")
-  dt_reg_addr(chosen_part_addr PATH "${chosen_part_path}")
-  math(EXPR TFM_HEX_BASE_ADDRESS_NS
-    "${chosen_part_addr} - ${CONFIG_FLASH_BASE_ADDRESS} + ${CONFIG_STM32_INT_FLASH_SECURE_BASE_ADDRESS}"
-  )
-endif()
 
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
@@ -22,3 +10,4 @@ include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/st/common/common.cmake)

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns_defconfig
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns_defconfig
@@ -13,3 +13,6 @@ CONFIG_ARM_MPU=y
 # Enable TZ non-secure configuration
 CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 CONFIG_RUNTIME_NMI=y
+
+# Set HEX file to program non-secure image using flash secure address range
+CONFIG_SOC_FAMILY_STM32_HEX_FILE_SEC_RANGE=y

--- a/boards/st/stm32wba65i_dk1/board.cmake
+++ b/boards/st/stm32wba65i_dk1/board.cmake
@@ -1,23 +1,12 @@
 # Copyright (c) 2025 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+# keep first
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 if(CONFIG_BUILD_WITH_TFM)
-  # Flash merged TF-M + Zephyr binary
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
-
-  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
-  # hence locate non-secure image from the secure flash base address in HEX file.
-  dt_chosen(chosen_part_path PROPERTY "zephyr,code-partition")
-  dt_reg_addr(chosen_part_addr PATH "${chosen_part_path}")
-  math(EXPR ns_sec_flash_offset
-    "${CONFIG_STM32_INT_FLASH_SECURE_BASE_ADDRESS} - ${CONFIG_FLASH_BASE_ADDRESS}"
-  )
-  math(EXPR TFM_HEX_BASE_ADDRESS_NS "${chosen_part_addr} + ${ns_sec_flash_offset}")
-
-  board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw" "--erase")
-else()
-  board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
+  board_runner_args(stm32cubeprogrammer "--erase")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
+include(${ZEPHYR_BASE}/boards/st/common/common.cmake)

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1_stm32wba65xx_ns_defconfig
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1_stm32wba65xx_ns_defconfig
@@ -23,3 +23,6 @@ CONFIG_ROM_START_OFFSET=0x400
 # Enable TZ non-secure configuration
 CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 CONFIG_RUNTIME_NMI=y
+
+# Set HEX file to program non-secure image using flash secure address range
+CONFIG_SOC_FAMILY_STM32_HEX_FILE_SEC_RANGE=y

--- a/soc/st/stm32/Kconfig
+++ b/soc/st/stm32/Kconfig
@@ -68,4 +68,13 @@ config STM32_INT_FLASH_SECURE_BASE_ADDRESS
 	  Secure internal flash based address when TZEN is enabled on
 	  applicable STM32 SoCs.
 
+config SOC_FAMILY_STM32_HEX_FILE_SEC_RANGE
+	bool "Board HEX file loads non-secure image through flash secure address range"
+	depends on TRUSTED_EXECUTION_NONSECURE
+	help
+	  Enable this option if the target board Option Bytes are configured for
+	  internal flash as secure (e.g. with <build>/tfm/api_ns/regression.sh)
+	  before flash is programmed. In this cases, the generated HEX file shall
+	  locate the non-secure image in the flash secure memory address range.
+
 endif # SOC_FAMILY_STM32


### PR DESCRIPTION
Factorize CMake instruction when programming a STM32 SoC based board when TF-M is embedded: the HEX file merges non-secure and secure firmware and the non-secure firmware must be programmed with the flash secure address range due to target configuration set before programming the flash which make the flash non-secure address range possibly not accessible.