### PR TITLE
net: dns: Fix unicast DNS resolution when CONFIG_MDNS_RESOLVER is enabled

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -748,9 +748,9 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 			local_addr = (struct net_sockaddr *)&local_addr6;
 			addr_len = sizeof(struct net_sockaddr_in6);
 
-			if (IS_ENABLED(CONFIG_MDNS_RESOLVER) &&
-			    ctx->servers[i].is_mdns && port == 0) {
-				local_addr6.sin6_port = net_htons(5353);
+			if (IS_ENABLED(CONFIG_MDNS_RESOLVER) && port == 0) {
+				local_addr6.sin6_port =
+					net_htons(ctx->servers[i].is_mdns ? 5353 : 0);
 			}
 #else
 			continue;
@@ -762,9 +762,9 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 			local_addr = (struct net_sockaddr *)&local_addr4;
 			addr_len = sizeof(struct net_sockaddr_in);
 
-			if (IS_ENABLED(CONFIG_MDNS_RESOLVER) &&
-			    ctx->servers[i].is_mdns && port == 0) {
-				local_addr4.sin_port = net_htons(5353);
+			if (IS_ENABLED(CONFIG_MDNS_RESOLVER) && port == 0) {
+				local_addr4.sin_port =
+					net_htons(ctx->servers[i].is_mdns ? 5353 : 0);
 			}
 #else
 			continue;

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -2190,10 +2190,11 @@ try_resolve:
 		}
 
 		/* If mDNS is enabled, then send .local queries only to
-		 * a well known multicast mDNS server address.
+		 * a well known multicast mDNS server and non .local only
+		 * to unicast servers.
 		 */
-		if (IS_ENABLED(CONFIG_MDNS_RESOLVER) && mdns_query &&
-		    !ctx->servers[j].is_mdns) {
+		if (IS_ENABLED(CONFIG_MDNS_RESOLVER) &&
+		    (mdns_query != !!ctx->servers[j].is_mdns)) {
 			continue;
 		}
 


### PR DESCRIPTION
With `CONFIG_MDNS_RESOLVER=y` and DNS servers learned via DHCP/RA, `.local` names resolve correctly but **all regular names fail to resolve** (queries are sent, replies never arrive, request times out). With mDNS disabled, the same setup resolves fine.

Two independent bugs in `subsys/net/lib/dns/resolve.c` combine to cause this:

### 1. Port leak in the resolver socket bind loop

`dns_resolve_init_locked()` reuses single `local_addr4`/`local_addr6` structs across all servers. The local port is set to `5353` for mDNS servers but never reset, so the unicast DNS servers added after the mDNS multicast servers inherited port 5353 and bound to it. Replies (which return to the source port) were then no longer delivered to the unicast socket.

### 2. Asymmetric server-selection guard

The guard in `dns_resolve_name_internal()` blocked `.local` queries from going to unicast servers, but not regular queries from going to the mDNS multicast servers. With `CONFIG_DNS_RESOLVER_QUERY_ALL_AVAILABLE_SERVERS` the loop `break`s on the first multicast server, so a regular query that landed on an mDNS server first never reached the real DNS servers.

## Fix

- Reset the reused `local_addr` port to the configured value (ephemeral when `port == 0`) for non-mDNS servers.
- Make the server-selection guard symmetric so unicast queries are not sent to mDNS servers.