### PR TITLE
doc: migration-guide-4.5: Document Silabs Series 0/1 clock changes

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -114,6 +114,10 @@ Boards
 * All Kconfigs under modules/hal_silabs/gecko were renamed from ``SOC_GECKO_*``
   to ``SILABS_GECKO_*``. Adapt your board accordingly.
 
+* The clock configuration for all Silabs Series 0 and Series 1 boards needs to be specified in the
+  device tree now. The Kconfigs ``CONFIG_SOC_GECKO_HAS_HFRCO_FREQRANGE`` and ``CONFIG_CMU_*`` have
+  been removed. See :github:`111754` for examples of how to adapt your board.
+
 Device Drivers and Devicetree
 *****************************
 


### PR DESCRIPTION
This was introduced by 6c92db1979337ca55019e6b64bb78679ec24596e but I forgot to mention this in the migration guide.