### PR TITLE
drivers: ethernet: stm32: Clean MAC address size assertions

### DIFF
--- a/drivers/ethernet/eth_stm32_hal2.c
+++ b/drivers/ethernet/eth_stm32_hal2.c
@@ -49,6 +49,9 @@ LOG_MODULE_REGISTER(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 NET_BUF_POOL_DEFINE(rx_net_buf_pool, CONFIG_ETH_STM32_HAL_RX_BUF_POOL_COUNT, ETH_STM32_RX_BUF_SIZE,
 		    0, NULL);
 
+/* Make memcpy() for MAC address array safe between the HAL structure and the Zephyr one */
+BUILD_ASSERT(sizeof(((hal_eth_config_t *)NULL)->mac_addr) == NET_ETH_ADDR_LEN);
+
 static struct net_buf *rx_net_buf[CONFIG_ETH_STM32_HAL_RX_DMA_BUF_COUNT];
 
 static hal_eth_tx_channel_config_t tx_ch_cfg;
@@ -562,7 +565,6 @@ static int eth_initialize(const struct device *dev)
 		return ret;
 	}
 
-	BUILD_ASSERT(sizeof(config_eth.mac_addr) == sizeof(dev_data->mac_addr));
 	memcpy(config_eth.mac_addr, dev_data->mac_addr, sizeof(dev_data->mac_addr));
 
 	config_eth.media_interface = HAL_ETH_MEDIA_IF_RMII;
@@ -607,7 +609,6 @@ static int eth_stm32_hal_set_config(const struct device *dev,
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		HAL_ETH_GetConfig(heth, &eth_cfg);
-		BUILD_ASSERT(sizeof(eth_cfg.mac_addr) == sizeof(dev_data->mac_addr));
 		memcpy(eth_cfg.mac_addr, dev_data->mac_addr, sizeof(dev_data->mac_addr));
 
 		if (HAL_ETH_SetConfig(heth, &eth_cfg) != HAL_OK) {

--- a/drivers/ethernet/eth_stm32_hal_v1.c
+++ b/drivers/ethernet/eth_stm32_hal_v1.c
@@ -264,7 +264,6 @@ int eth_stm32_hal_set_config(const struct device *dev,
 
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
-		BUILD_ASSERT(sizeof(dev_data->mac_addr) == sizeof(config->mac_address.addr));
 		memcpy(dev_data->mac_addr, config->mac_address.addr, sizeof(dev_data->mac_addr));
 		heth->Instance->MACA0HR = (dev_data->mac_addr[5] << 8) |
 			dev_data->mac_addr[4];


### PR DESCRIPTION
Remove the assertion in eth_stm32_hal_v1.c recently introduce between byte array sizes storing MAC address value. It was useless since both byte array sizes are based on NET_ETH_ADDR_LEN macro. Moreover the assertion may produce a build warning as reported (and fixed) in eth_stm32_hal_v2.c by commit 0ee22dc99841 ("drivers: ethernet: stm32: fix clang error").

Factorize the 2 build assertions in eth_stm32_hal2.c with an explicit comment why it's used.