### PR TITLE
stm32: drivers: adc:  skip buffer check in stream mode

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -382,7 +382,7 @@ static int adc_stm32_dma_start(const struct device *dev,
 }
 #endif /* CONFIG_ADC_STM32_DMA */
 
-static int check_buffer(const struct adc_sequence *sequence,
+static int __maybe_unused check_buffer(const struct adc_sequence *sequence,
 			     uint8_t active_channels)
 {
 	size_t needed_buffer_size;
@@ -1240,11 +1240,18 @@ static int start_read(const struct device *dev,
 		return err;
 	}
 
+#ifndef CONFIG_ADC_STREAM
+	/*
+	 * In streaming mode the application does not provide a buffer in the
+	 * sequence: sample data is written to a buffer allocated from the RTIO
+	 * mempool inside the ISR. Skip the sequence buffer validation here.
+	 */
 	err = check_buffer(sequence, data->channel_count);
 	if (err) {
 		LOG_ERR("ADC buffer error");
 		return err;
 	}
+#endif /* !CONFIG_ADC_STREAM */
 
 #ifdef HAS_OVERSAMPLING
 	err = adc_stm32_oversampling(dev, sequence->oversampling);


### PR DESCRIPTION
This PR fixes a regression encountered in the `samples/drivers/adc/adc_stream` sample on the `nucleo_h753zi` platform. 

`start_read()` function  unconditionally called `check_buffer()`, which validates `sequence->buffer_size`. Since no buffer is supplied in streaming mode, this check fails and aborts the stream with a spurious error : 

```
[00:00:00.000,000] <dbg> adc_stm32.adc_stm32_init: Initializing adc@58026000
[00:00:00.000,000] <dbg> adc_stm32.adc_stm32_init: Initializing adc@40022000
*** Booting Zephyr OS build v4.4.0-6330-g769c4f2846db ***
[00:00:00.044,000] <dbg> adc_stm32.adc_stm32_channel_setup: Channel setup succeeded!
[00:00:00.044,000] <dbg> adc_stm32.adc_stm32_channel_setup: Channel setup succeeded!
[00:00:00.044,000] <err> adc_stm32: Provided buffer is too small (0/93324)
[00:00:00.044,000] <err> adc_stm32: ADC buffer error
[00:00:00.044,000] <err> adc_stm32: Error starting conversion (-12)
```

To reproduce :  

`west build -p -b nucleo_h753zi samples/drivers/adc/adc_stream -T sample.drivers.adc.adc_stream`
