### PR TITLE
scripts: west: build: add fallback for srcrel to self.source_dir

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -563,7 +563,10 @@ class Build(Forceable):
             self.die(f'source and build directory {self.source_dir} cannot be the same; '
                     f'use --build-dir {self.build_dir} to specify a build directory')
 
-        srcrel = os.path.relpath(self.source_dir)
+        try:
+            srcrel = pathlib.Path(self.source_dir).relative_to(pathlib.Path.cwd(), walk_up=True)
+        except ValueError:
+            srcrel = self.source_dir
         self.check_force(
             not is_zephyr_build(self.source_dir),
             f'it looks like {srcrel} is a build directory: '


### PR DESCRIPTION
On Windows, if the working directory and source directory are on different drive letters, `os.path.relpath` will throw `ValueError: path is on mount 'D:', start on mount 'C:'`

This adds a fallback to use `self.source_dir` in that case, as `srcrel` is only used in the printout of the checks below, so does not need to be relative to the working directory