### PR TITLE
net: lwm2m: fix put_string handle empty buffer avoid malformed CoAP packet

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -151,6 +151,18 @@ static int put_string(struct lwm2m_output_context *out,
 {
 	int ret;
 
+	if (buflen == 0) {
+		/* Remove the payload marker (0xFF) that was appended before this writer was called,
+		 * to avoid sending a malformed CoAP packet with a payload marker but no payload.
+		 */
+		struct coap_packet *cpkt = out->out_cpkt;
+
+		if (cpkt->offset > 0 && cpkt->data[cpkt->offset - 1] == 0xFF) {
+			cpkt->offset--;
+		}
+		return 0;
+	}
+
 	ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), buf, buflen);
 	if (ret < 0) {
 		return ret;


### PR DESCRIPTION
Reading an empty string buffer with plain text format would result in a timeout from the server with the following error:
`2026-06-26 11:34:50.834 [CoapServer(main)#1] INFO  org.eclipse.californium.ban - [LWM2M Server-coaps://0.0.0.0:5684] Found payload marker (0xFF) but message contains no payload;`