### PR TITLE
Deprecate include/zephyr/sys_clock.h

### DIFF
--- a/arch/arm/core/cortex_m/timing.c
+++ b/arch/arm/core/cortex_m/timing.c
@@ -16,7 +16,7 @@
 #include <zephyr/timing/timing.h>
 #include <cortex_m/dwt.h>
 #include <cmsis_core.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 /**
  * @brief Return the current frequency of the cycle counter

--- a/arch/common/timing.c
+++ b/arch/common/timing.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/timing/timing.h>
 
 void arch_timing_init(void)

--- a/arch/x86/timing.c
+++ b/arch/x86/timing.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/arch/x86/arch.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/timing/timing.h>
 #include <zephyr/app_memory/app_memdomain.h>
 

--- a/boards/qemu/cortex_m0/nrf_timer_timer.c
+++ b/boards/qemu/cortex_m0/nrf_timer_timer.c
@@ -10,7 +10,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <hal/nrf_timer.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/irq.h>

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -23,6 +23,9 @@ the :ref:`release notes<zephyr_4.5>`.
 Common
 ******
 
+* Header files :file:`include/zephyr/sys_clock.h` is deprecated and will be removed in a future
+  release. One shall include :file:`include/zephyr/sys/clock.h` instead.
+
 Build System
 ************
 

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -10,7 +10,7 @@
 #include <zephyr/drivers/counter.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <fsl_rtc.h>
 #include <zephyr/logging/log.h>
 

--- a/drivers/counter/counter_mcux_rtc_jdp.c
+++ b/drivers/counter/counter_mcux_rtc_jdp.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/counter.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <fsl_rtc.h>
 #include <zephyr/logging/log.h>
 

--- a/drivers/counter/counter_npcx_lct.c
+++ b/drivers/counter/counter_npcx_lct.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include "soc_miwu.h"
 

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -14,7 +14,7 @@ LOG_MODULE_REGISTER(eth_nxp_enet_qos_mac, CONFIG_ETHERNET_LOG_LEVEL);
 
 #include <zephyr/net/phy.h>
 #include <zephyr/kernel/thread_stack.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #if defined(CONFIG_ETH_NXP_ENET_QOS_MAC_UNIQUE_MAC_ADDRESS)
 #include <zephyr/sys/crc.h>

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -6,7 +6,7 @@
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/phy.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/drivers/mdio.h>
 #include <zephyr/logging/log.h>
 #include "eth_smsc91x_priv.h"

--- a/drivers/ethernet/mdio/mdio_nxp_enet.c
+++ b/drivers/ethernet/mdio/mdio_nxp_enet.c
@@ -13,7 +13,7 @@
 #include <zephyr/drivers/ethernet/eth_nxp_enet.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 struct nxp_enet_mdio_config {
 	const struct pinctrl_dev_config *pincfg;

--- a/drivers/flash/flash_mcux_xspi.c
+++ b/drivers/flash/flash_mcux_xspi.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/drivers/clock_control.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -17,7 +17,7 @@
 #include <zephyr/init.h>
 #include <string.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 

--- a/drivers/input/input_sbus.c
+++ b/drivers/input/input_sbus.c
@@ -13,7 +13,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/time_units.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/drivers/uart.h>
 
 LOG_MODULE_REGISTER(futaba_sbus, CONFIG_INPUT_LOG_LEVEL);

--- a/drivers/misc/ethos_u/ethos_u_common.c
+++ b/drivers/misc/ethos_u/ethos_u_common.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>

--- a/drivers/mspi/mspi_ambiq_ap3.c
+++ b/drivers/mspi/mspi_ambiq_ap3.c
@@ -16,7 +16,7 @@ LOG_LEVEL_SET(CONFIG_MSPI_LOG_LEVEL);
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/mspi.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 
 #include "mspi_ambiq.h"

--- a/drivers/mspi/mspi_ambiq_ap5.c
+++ b/drivers/mspi/mspi_ambiq_ap5.c
@@ -16,7 +16,7 @@ LOG_LEVEL_SET(CONFIG_MSPI_LOG_LEVEL);
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/mspi.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 #include <../dts/common/mem.h>
 

--- a/drivers/regulator/regulator_cp9314.c
+++ b/drivers/regulator/regulator_cp9314.c
@@ -12,7 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/regulator.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 
 LOG_MODULE_REGISTER(CP9314, CONFIG_REGULATOR_LOG_LEVEL);

--- a/drivers/sensor/microchip/mtch9010/mtch9010.c
+++ b/drivers/sensor/microchip/mtch9010/mtch9010.c
@@ -15,7 +15,7 @@
 
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_instance.h>
 #include <zephyr/device.h>

--- a/drivers/sensor/sensor_clock_external.c
+++ b/drivers/sensor/sensor_clock_external.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/init.h>

--- a/drivers/sensor/sensor_clock_sys.c
+++ b/drivers/sensor/sensor_clock_sys.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/sensor_clock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 int sensor_clock_get_cycles(uint64_t *cycles)
 {

--- a/drivers/serial/uart_si32_usart.c
+++ b/drivers/serial/uart_si32_usart.c
@@ -10,7 +10,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include <SI32_CLKCTRL_A_Type.h>
 #include <SI32_USART_A_Type.h>

--- a/drivers/spi/spi_litex_common.h
+++ b/drivers/spi/spi_litex_common.h
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/spi.h>
 #include "spi_rtio.h"
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include "spi_context.h"
 #include <soc.h>

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -18,7 +18,7 @@
 #include <zephyr/drivers/dma/dma_mcux_lpc.h>
 #endif
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 #include <zephyr/drivers/reset.h>
 

--- a/drivers/stepper/gpio_stepper/h_bridge_stepper_ctrl.c
+++ b/drivers/stepper/gpio_stepper/h_bridge_stepper_ctrl.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/drivers/stepper/stepper.h>
 
 #include <gpio_stepper_common.h>

--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -16,7 +16,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
 

--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -5,7 +5,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/drivers/interrupt_controller/loapic.h>
 #include <zephyr/irq.h>

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -8,7 +8,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/x86/cpuid.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/drivers/interrupt_controller/loapic.h>
 #include <zephyr/irq.h>
 

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -6,7 +6,7 @@
  */
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/arch/arc/v2/aux_regs.h>
 #include <zephyr/irq.h>

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -7,7 +7,7 @@
 #include <zephyr/drivers/timer/arm_arch_timer.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/arch/cpu.h>
 
 #ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME

--- a/drivers/timer/cc13xx_cc26xx_rtc_timer.c
+++ b/drivers/timer/cc13xx_cc26xx_rtc_timer.c
@@ -21,7 +21,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 
 #include <driverlib/interrupt.h>

--- a/drivers/timer/cc23x0_rtc_timer.c
+++ b/drivers/timer/cc23x0_rtc_timer.c
@@ -13,7 +13,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 
 #include <inc/hw_rtc.h>

--- a/drivers/timer/cc23x0_systim_timer.c
+++ b/drivers/timer/cc23x0_systim_timer.c
@@ -18,7 +18,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 
 #include <inc/hw_types.h>

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -11,7 +11,7 @@
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include "timer_cmsdk_apb.h"
 
 #define TIMER_NODE DT_CHOSEN(zephyr_system_timer)

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <cmsis_core.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util.h>

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -15,7 +15,7 @@
 
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <soc.h>
 #include <zephyr/init.h>
 #include <zephyr/spinlock.h>

--- a/drivers/timer/gecko_burtc_timer.c
+++ b/drivers/timer/gecko_burtc_timer.c
@@ -20,7 +20,7 @@
 #include <soc.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/logging/log.h>

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT intel_hpet
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 #include <zephyr/linker/sections.h>
 

--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -15,7 +15,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/drivers/gpio.h>
 
 #include <cyhal_lptimer.h>

--- a/drivers/timer/infineon_lp_timer_pdl.c
+++ b/drivers/timer/infineon_lp_timer_pdl.c
@@ -15,7 +15,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/drivers/gpio.h>
 
 #include <zephyr/logging/log.h>

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/drivers/interrupt_controller/dw_ace.h>
 
 #include <cavs-idc.h>

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -10,7 +10,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 LOG_MODULE_REGISTER(timer, LOG_LEVEL_ERR);
 

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -10,7 +10,7 @@
 #include <zephyr/dt-bindings/interrupt-controller/ite-intc.h>
 #include <soc.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -24,7 +24,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 /* Shared prescaler division factor. The GPTIMER subtimers share a single
  * decrementer, so the minimum valid division factor is ntimers + 1 (GRLIB IP

--- a/drivers/timer/max32_wut_timer.c
+++ b/drivers/timer/max32_wut_timer.c
@@ -9,7 +9,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/irq.h>
 

--- a/drivers/timer/mchp_sam_pit64b_timer.c
+++ b/drivers/timer/mchp_sam_pit64b_timer.c
@@ -12,7 +12,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 LOG_MODULE_REGISTER(pit64b, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -11,7 +11,7 @@
 #include <soc.h>
 #include <zephyr/arch/common/sys_io.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <cmsis_core.h>
 #include <zephyr/irq.h>

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -9,7 +9,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <fsl_gpt.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/sys/time_units.h>
 #include <zephyr/irq.h>

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -12,7 +12,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/drivers/timer/nxp_os_timer.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/pm/pm.h>

--- a/drivers/timer/mcux_rtc_jdp_timer.c
+++ b/drivers/timer/mcux_rtc_jdp_timer.c
@@ -9,7 +9,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 #include <fsl_rtc.h>
 

--- a/drivers/timer/mcux_stm_timer.c
+++ b/drivers/timer/mcux_stm_timer.c
@@ -12,7 +12,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include <fsl_stm.h>
 

--- a/drivers/timer/mcux_sysctr_timer.c
+++ b/drivers/timer/mcux_sysctr_timer.c
@@ -30,7 +30,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/irq.h>
 #include <zephyr/devicetree.h>

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -12,7 +12,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <soc.h>
 #include <mips/mipsregs.h>

--- a/drivers/timer/native_sim_timer.c
+++ b/drivers/timer/native_sim_timer.c
@@ -12,7 +12,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include "nsi_hw_scheduler.h"
 #include "nsi_timer_model.h"
 #include "soc.h"

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -38,7 +38,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/minmax.h>
 #include <zephyr/spinlock.h>
 #include <soc.h>

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -12,7 +12,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/drivers/timer/nrf_rtc_timer.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/barrier.h>
 #include <haly/nrfy_rtc.h>
 #include <zephyr/irq.h>

--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -8,7 +8,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include <openrisc/openriscregs.h>
 

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -11,7 +11,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/drivers/timer/system_timer.h>

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <soc.h>
 
 #define DT_DRV_COMPAT renesas_ra_ulpt_timer

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/init.h>
 #include <soc.h>

--- a/drivers/timer/renesas_rz_gtm_timer.c
+++ b/drivers/timer/renesas_rz_gtm_timer.c
@@ -7,7 +7,7 @@
 #include <zephyr/spinlock.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/logging/log.h>
 #include <instances/rzg/r_gtm.h>
 

--- a/drivers/timer/renesas_rza2m_os_timer.c
+++ b/drivers/timer/renesas_rza2m_os_timer.c
@@ -10,7 +10,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #define DT_DRV_COMPAT renesas_rza2m_ostm_timer
 

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -10,7 +10,7 @@
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 
 #define DT_DRV_COMPAT riscv_machine_timer

--- a/drivers/timer/riscv_supervisor_timer.c
+++ b/drivers/timer/riscv_supervisor_timer.c
@@ -10,7 +10,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/irq.h>
 #include <zephyr/arch/riscv/csr.h>

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -22,7 +22,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util.h>
 

--- a/drivers/timer/silabs_sleeptimer_timer.c
+++ b/drivers/timer/silabs_sleeptimer_timer.c
@@ -11,7 +11,7 @@
 #include <zephyr/init.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/logging/log.h>
 

--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/smartbond_clock_control.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <cmsis_core.h>
 #include <zephyr/irq.h>

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -15,7 +15,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/reset.h>

--- a/drivers/timer/stm32wb0_radio_timer.c
+++ b/drivers/timer/stm32wb0_radio_timer.c
@@ -10,7 +10,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 #include "stm32wb0x_hal_radio_timer.h"
 

--- a/drivers/timer/ti_dmtimer.c
+++ b/drivers/timer/ti_dmtimer.c
@@ -9,7 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/drivers/syscon.h>

--- a/drivers/timer/ti_rti_timer.c
+++ b/drivers/timer/ti_rti_timer.c
@@ -6,7 +6,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/kernel.h>
 
 #include "ti_rti_timer.h"

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -10,7 +10,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <soc.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include "xlnx_psttc_timer_priv.h"

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -6,7 +6,7 @@
  */
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/irq.h>
 
 #include "xtensa_sys_timer.h"

--- a/drivers/uaol/uaol_intel_adsp.c
+++ b/drivers/uaol/uaol_intel_adsp.c
@@ -14,7 +14,7 @@
 #include <adsp_shim.h>
 #include <adsp_timestamp.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>

--- a/drivers/watchdog/wdt_bee_core.c
+++ b/drivers/watchdog/wdt_bee_core.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)
 #include <rtl_wdt.h>

--- a/drivers/watchdog/wdt_dw.c
+++ b/drivers/watchdog/wdt_dw.c
@@ -9,7 +9,7 @@
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/math/ilog2.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/drivers/clock_control.h>

--- a/drivers/watchdog/wdt_dw_common.c
+++ b/drivers/watchdog/wdt_dw_common.c
@@ -7,7 +7,7 @@
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/math/ilog2.h>
 
 #include "wdt_dw_common.h"

--- a/drivers/watchdog/wdt_fwdgt_gd32.c
+++ b/drivers/watchdog/wdt_fwdgt_gd32.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include <gd32_fwdgt.h>
 

--- a/drivers/watchdog/wdt_intel_adsp.c
+++ b/drivers/watchdog/wdt_intel_adsp.c
@@ -32,7 +32,7 @@
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/math/ilog2.h>
 
 #include "wdt_dw.h"

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -12,7 +12,7 @@
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <soc.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_rcc.h>

--- a/drivers/watchdog/wdt_iwdg_wch.c
+++ b/drivers/watchdog/wdt_iwdg_wch.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <errno.h>
 
 #include <hal_ch32fun.h>

--- a/drivers/watchdog/wdt_litex.c
+++ b/drivers/watchdog/wdt_litex.c
@@ -9,7 +9,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/device.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wdt_litex, CONFIG_WDT_LOG_LEVEL);

--- a/drivers/watchdog/wdt_mcux_imx_wdog.c
+++ b/drivers/watchdog/wdt_mcux_imx_wdog.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/sys/device_mmio.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <fsl_wdog.h>
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL

--- a/drivers/watchdog/wdt_mcux_rtwdog.c
+++ b/drivers/watchdog/wdt_mcux_rtwdog.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/drivers/clock_control.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <fsl_rtwdog.h>
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL

--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -14,7 +14,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/pm/device.h>
 #include <fsl_wwdt.h>
 #include <fsl_clock.h>

--- a/drivers/watchdog/wdt_rpi_pico.c
+++ b/drivers/watchdog/wdt_rpi_pico.c
@@ -11,7 +11,7 @@
 #include <hardware/structs/psm.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/watchdog.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wdt_rpi_pico, CONFIG_WDT_LOG_LEVEL);

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -16,7 +16,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include "wdt_wwdg_stm32.h"
 

--- a/drivers/watchdog/wdt_wwdgt_gd32.c
+++ b/drivers/watchdog/wdt_wwdgt_gd32.c
@@ -12,7 +12,7 @@
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include <gd32_wwdgt.h>
 

--- a/include/zephyr/arch/arc/v2/vpx/arc_vpx.h
+++ b/include/zephyr/arch/arc/v2/vpx/arc_vpx.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARC_V2_VPX_ARC_VPX_H_
 #define ZEPHYR_INCLUDE_ARCH_ARC_V2_VPX_ARC_VPX_H_
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 /**
  * @brief Obtain a cooperative lock on the VPX vector registers

--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -27,7 +27,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -21,7 +21,7 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <string.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -36,7 +36,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/devicetree/counter-capture.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <stdbool.h>
 
 #include <zephyr/dt-bindings/counter/counter-capture.h>

--- a/include/zephyr/drivers/dali.h
+++ b/include/zephyr/drivers/dali.h
@@ -25,7 +25,7 @@
  */
 
 #include <zephyr/device.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/__assert.h>
 #include <errno.h>
 #include <stdbool.h>

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -34,7 +34,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/toolchain.h>

--- a/include/zephyr/drivers/timer/nrf_grtc_timer.h
+++ b/include/zephyr/drivers/timer/nrf_grtc_timer.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 /** @brief GRTC timer compare event handler.
  *

--- a/include/zephyr/drivers/timer/nrf_rtc_timer.h
+++ b/include/zephyr/drivers/timer/nrf_rtc_timer.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_TIMER_NRF_RTC_TIMER_H
 #define ZEPHYR_INCLUDE_DRIVERS_TIMER_NRF_RTC_TIMER_H
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -24,7 +24,7 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 /** Special drive_column argument for not driving any column */

--- a/include/zephyr/kernel_includes.h
+++ b/include/zephyr/kernel_includes.h
@@ -35,7 +35,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/rb.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/fatal.h>
 #include <zephyr/irq.h>

--- a/include/zephyr/net/dhcpv4_server.h
+++ b/include/zephyr/net/dhcpv4_server.h
@@ -12,7 +12,7 @@
 #define ZEPHYR_INCLUDE_NET_DHCPV4_SERVER_H_
 
 #include <zephyr/net/net_ip.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/net/net_time.h
+++ b/include/zephyr/net/net_time.h
@@ -24,7 +24,7 @@
 #define ZEPHYR_INCLUDE_NET_NET_TIME_H_
 
 /* Include required for NSEC_PER_* constants. */
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/sys/mutex.h
+++ b/include/zephyr/sys/mutex.h
@@ -23,7 +23,7 @@ extern "C" {
 #ifdef CONFIG_USERSPACE
 #include <zephyr/sys/atomic.h>
 #include <zephyr/types.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 struct sys_mutex {
 	/* Currently unused, but will be used to store state for fast mutexes

--- a/include/zephyr/sys/timeutil.h
+++ b/include/zephyr/sys/timeutil.h
@@ -28,7 +28,7 @@
 #include <stdint.h>
 #include <time.h>
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/time_units.h>

--- a/include/zephyr/sys_clock.h
+++ b/include/zephyr/sys_clock.h
@@ -4,4 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief System clock APIs legacy header file
+ * @deprecated Please include zephyr/sys/clock.h straight instead
+ */
+
 #include <zephyr/sys/clock.h>

--- a/include/zephyr/usb/class/usb_dfu.h
+++ b/include/zephyr/usb/class/usb_dfu.h
@@ -46,7 +46,7 @@
 #ifndef ZEPHYR_INCLUDE_USB_CLASS_USB_DFU_H_
 #define ZEPHYR_INCLUDE_USB_CLASS_USB_DFU_H_
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 /** DFU Class Subclass */
 #define DFU_SUBCLASS			0x01 __DEPRECATED_MACRO

--- a/kernel/busy_wait.c
+++ b/kernel/busy_wait.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <kernel_arch_interface.h>
 
 #if defined(CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE)

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -14,7 +14,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/sys/math_extras.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <ksched.h>
 #include <kthread.h>
 #include <wait_q.h>

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -11,7 +11,7 @@
 #include <timeout_q.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/llext/symbol.h>
 
 #include <timeslicing.h>

--- a/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.c
+++ b/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.c
@@ -11,7 +11,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/reboot.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/init.h>
 

--- a/samples/bluetooth/audio/bap_broadcast_sink/src/lc3.c
+++ b/samples/bluetooth/audio/bap_broadcast_sink/src/lc3.c
@@ -31,7 +31,7 @@
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/usb/class/usb_audio.h>

--- a/samples/bluetooth/audio/bap_broadcast_sink/src/lc3.h
+++ b/samples/bluetooth/audio/bap_broadcast_sink/src/lc3.h
@@ -27,7 +27,7 @@
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/usb/class/usb_audio.h>

--- a/samples/bluetooth/audio/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/audio/bap_broadcast_sink/src/main.c
@@ -32,7 +32,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "lc3.h"

--- a/samples/bluetooth/audio/bap_broadcast_sink/src/usb.c
+++ b/samples/bluetooth/audio/bap_broadcast_sink/src/usb.c
@@ -29,7 +29,7 @@
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/usb/class/usbd_uac2.h>
 #include <zephyr/usb/usbd.h>

--- a/samples/bluetooth/audio/bap_broadcast_sink/src/usb.h
+++ b/samples/bluetooth/audio/bap_broadcast_sink/src/usb.h
@@ -28,7 +28,7 @@
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/usb/class/usb_audio.h>

--- a/samples/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -31,7 +31,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/usb/class/usbd_uac2.h>
 #include <zephyr/usb/usbd.h>

--- a/samples/bluetooth/audio/bap_unicast_client/src/stream_lc3.c
+++ b/samples/bluetooth/audio/bap_unicast_client/src/stream_lc3.c
@@ -16,7 +16,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/clock.h>
 #include <zephyr/sys/printk.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include <lc3.h>

--- a/samples/bluetooth/audio/bap_unicast_client/src/stream_lc3.h
+++ b/samples/bluetooth/audio/bap_unicast_client/src/stream_lc3.h
@@ -12,7 +12,7 @@
 #include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/net_buf.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 /* Since the lc3.h header file is not available when CONFIG_LIBLC3=n, we need to guard the include
  * and use of it

--- a/samples/bluetooth/audio/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/audio/bap_unicast_server/src/main.c
@@ -33,7 +33,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 

--- a/samples/bluetooth/audio/bap_unicast_server/src/stream_lc3.c
+++ b/samples/bluetooth/audio/bap_unicast_server/src/stream_lc3.c
@@ -16,7 +16,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/clock.h>
 #include <zephyr/sys/printk.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include <lc3.h>

--- a/samples/bluetooth/audio/bap_unicast_server/src/stream_lc3.h
+++ b/samples/bluetooth/audio/bap_unicast_server/src/stream_lc3.h
@@ -12,7 +12,7 @@
 #include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/net_buf.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 /* Since the lc3.h header file is not available when CONFIG_LIBLC3=n, we need to guard the include
  * and use of it

--- a/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
@@ -18,7 +18,7 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 LOG_MODULE_REGISTER(iso_broadcast_broadcaster, LOG_LEVEL_DBG);
 
 #define DEFAULT_BIS_RTN           2

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -13,7 +13,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/types.h>
 
 

--- a/samples/boards/nxp/frdm_mcxe31b/system_off/src/main.c
+++ b/samples/boards/nxp/frdm_mcxe31b/system_off/src/main.c
@@ -11,7 +11,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/sys/poweroff.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include <fsl_power.h>
 

--- a/samples/boards/nxp/mimxrt595_evk/system_off/src/main.c
+++ b/samples/boards/nxp/mimxrt595_evk/system_off/src/main.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/sys/poweroff.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 int main(void)
 {

--- a/samples/sensor/bmg160/src/main.c
+++ b/samples/sensor/bmg160/src/main.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 
 #include <zephyr/sys/printk.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <stdio.h>
 
 #include <zephyr/device.h>

--- a/samples/sensor/clock/src/main.c
+++ b/samples/sensor/clock/src/main.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/sensor_clock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/drivers/counter.h>
 #include <stdio.h>
 

--- a/samples/sensor/vcnl4040/src/main.c
+++ b/samples/sensor/vcnl4040/src/main.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 
 #include <zephyr/sys/printk.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <stdio.h>
 
 #include <zephyr/device.h>

--- a/samples/sensor/veml6031/src/main.c
+++ b/samples/sensor/veml6031/src/main.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 
 #include <zephyr/sys/printk.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <stdio.h>
 
 #include <zephyr/device.h>

--- a/samples/subsys/pm/latency/src/main.c
+++ b/samples/subsys/pm/latency/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/policy.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 LOG_MODULE_REGISTER(app, CONFIG_APP_LOG_LEVEL);
 

--- a/samples/subsys/pm/latency/src/test.c
+++ b/samples/subsys/pm/latency/src/test.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/policy.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 LOG_MODULE_REGISTER(dev_test, CONFIG_APP_LOG_LEVEL);
 

--- a/samples/subsys/sensing/simple/src/main.c
+++ b/samples/subsys/sensing/simple/src/main.c
@@ -7,7 +7,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sensing/sensing.h>
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);

--- a/soc/microchip/mec/mec15xx/timing.c
+++ b/soc/microchip/mec/mec15xx/timing.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/arch/arm/arch.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/timing/timing.h>
 #include <soc.h>
 

--- a/soc/microchip/mec/mec172x/timing.c
+++ b/soc/microchip/mec/mec172x/timing.c
@@ -7,7 +7,7 @@
 
 #include <zephyr/arch/arm/arch.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/timing/timing.h>
 #include <soc.h>
 

--- a/soc/nordic/timing.c
+++ b/soc/nordic/timing.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/arch/arm/arch.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/timing/timing.h>
 #include <nrfx.h>
 

--- a/soc/st/stm32/stm32wb0x/power.c
+++ b/soc/st/stm32/stm32wb0x/power.c
@@ -14,7 +14,7 @@
  */
 #include <zephyr/kernel.h>
 #include <zephyr/pm/pm.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/init.h>
 #include <zephyr/arch/common/pm_s2ram.h>
 

--- a/soc/st/stm32/stm32wbax/hci_if/stm32_timer.c
+++ b/soc/st/stm32/stm32wbax/hci_if/stm32_timer.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include <stm32_timer.h>
 

--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -27,7 +27,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/util_utf8.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "aics_internal.h"

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -34,7 +34,7 @@
 #include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -32,7 +32,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/util_utf8.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "../bluetooth/host/settings.h"

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -35,7 +35,7 @@
 #include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "common/bt_shell_private.h"

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -51,7 +51,7 @@
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "audio.h"

--- a/subsys/bluetooth/audio/shell/bap_usb.c
+++ b/subsys/bluetooth/audio/shell/bap_usb.c
@@ -29,7 +29,7 @@
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/usb/class/usbd_uac2.h>

--- a/subsys/bluetooth/audio/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/vcp_vol_rend.c
@@ -34,7 +34,7 @@
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "audio_internal.h"

--- a/subsys/bluetooth/audio/vocs.c
+++ b/subsys/bluetooth/audio/vocs.c
@@ -31,7 +31,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/util_utf8.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "audio_internal.h"

--- a/subsys/bluetooth/common/long_wq.c
+++ b/subsys/bluetooth/common/long_wq.c
@@ -10,7 +10,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel/thread_stack.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 K_THREAD_STACK_DEFINE(bt_lw_stack_area, CONFIG_BT_LONG_WQ_STACK_SIZE);
 static struct k_work_q bt_long_wq;

--- a/subsys/bluetooth/common/long_wq.h
+++ b/subsys/bluetooth/common/long_wq.h
@@ -7,7 +7,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 int bt_long_wq_schedule(struct k_work_delayable *dwork, k_timeout_t timeout);
 int bt_long_wq_reschedule(struct k_work_delayable *dwork, k_timeout_t timeout);

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -32,7 +32,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 #include <sys/types.h>
 

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -10,7 +10,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 /*
  * Copyright (c) 2015-2016 Intel Corporation

--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -20,7 +20,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include "buf_view.h"
 #include "common/hci_common_internal.h"

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -38,7 +38,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/debug/stack.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "addr_internal.h"

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -22,7 +22,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 typedef enum __packed {

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -35,7 +35,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #if defined(CONFIG_BT_GATT_CACHING)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -42,7 +42,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 #include <soc.h>
 

--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -26,7 +26,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "common/hci_common_internal.h"

--- a/subsys/bluetooth/host/id.h
+++ b/subsys/bluetooth/host/id.h
@@ -11,7 +11,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/time_units.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include "keys.h"
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -31,7 +31,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "common/assert.h"

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -18,7 +18,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/slist.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 enum bt_iso_cig_state {
 	BT_ISO_CIG_STATE_IDLE,

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -30,7 +30,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "buf_view.h"

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -16,7 +16,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/iterable_sections.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include "host/classic/l2cap_br_interface.h"
 /* TODO: we should include conn_internal.h for bt_conn_tx_cb_t but that causes redefinitions */

--- a/subsys/bluetooth/host/shell/gatt.c
+++ b/subsys/bluetooth/host/shell/gatt.c
@@ -27,7 +27,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/time_units.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 #include <sys/types.h>
 

--- a/subsys/bluetooth/host/shell/l2cap.c
+++ b/subsys/bluetooth/host/shell/l2cap.c
@@ -29,7 +29,7 @@
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/atomic_types.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/util.h>

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -34,7 +34,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "conn_internal.h"

--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -8,7 +8,7 @@
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #ifndef ZEPHYR_SUBSYS_BLUETOOTH_MESH_ADV_H_
 #define ZEPHYR_SUBSYS_BLUETOOTH_MESH_ADV_H_

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -12,7 +12,7 @@
 #include <zephyr/sys/mpsc_pbuf.h>
 #include <zephyr/logging/log_link.h>
 #include <zephyr/sys/printk.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/clock.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/__assert.h>

--- a/subsys/net/ip/net_timeout.c
+++ b/subsys/net/ip/net_timeout.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/net/net_timeout.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 void net_timeout_set(struct net_timeout *timeout,
 		     uint32_t lifetime,

--- a/subsys/net/lib/dns/dns_cache.h
+++ b/subsys/net/lib/dns/dns_cache.h
@@ -16,7 +16,7 @@
 #include <stdint.h>
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 struct dns_cache_entry {
 	char query[CONFIG_DNS_RESOLVER_MAX_QUERY_LEN];

--- a/subsys/net/lib/lwm2m/lwm2m_obj_server.h
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_server.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 /* Server resource IDs */
 #define SERVER_SHORT_SERVER_ID				0

--- a/subsys/net/lib/lwm2m/lwm2m_pull_context.h
+++ b/subsys/net/lib/lwm2m/lwm2m_pull_context.h
@@ -10,7 +10,7 @@
 
 #include <stdio.h>
 #include <zephyr/net/lwm2m.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #define LWM2M_PACKAGE_URI_LEN CONFIG_LWM2M_SWMGMT_PACKAGE_URI_LEN
 

--- a/subsys/pm/policy/policy_default.c
+++ b/subsys/pm/policy/policy_default.c
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/pm/policy.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/pm/device.h>
 
 const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)

--- a/subsys/pm/policy/policy_events.c
+++ b/subsys/pm/policy/policy_events.c
@@ -10,7 +10,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/__assert.h>
 

--- a/subsys/portability/posix/options/xsi_single_process.c
+++ b/subsys/portability/posix/options/xsi_single_process.c
@@ -14,7 +14,7 @@
 #include <zephyr/drivers/hwinfo.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 

--- a/subsys/sensing/sensor/phy_3d_sensor/phy_3d_sensor.c
+++ b/subsys/sensing/sensor/phy_3d_sensor/phy_3d_sensor.c
@@ -11,7 +11,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/rtio/rtio.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sensing/sensing.h>
 #include <zephyr/sensing/sensing_sensor.h>
 #include <zephyr/sys/util.h>

--- a/tests/bluetooth/host/id/mocks/kernel.h
+++ b/tests/bluetooth/host/id/mocks/kernel.h
@@ -6,7 +6,7 @@
 
 #include <zephyr/fff.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 /* List of fakes used by this unit tester */
 #define KERNEL_FFF_FAKES_LIST(FAKE)                                                                \

--- a/tests/bluetooth/tester/src/btp.c
+++ b/tests/bluetooth/tester/src/btp.c
@@ -23,7 +23,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -28,7 +28,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include "mesh/access.h"
 #include "mesh/dfu_slot.h"

--- a/tests/boards/intel_adsp/hda/src/tests.h
+++ b/tests/boards/intel_adsp/hda/src/tests.h
@@ -4,7 +4,7 @@
 #ifndef ZEPHYR_TESTS_INTEL_ADSP_TESTS_H
 #define ZEPHYR_TESTS_INTEL_ADSP_TESTS_H
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <intel_adsp_ipc.h>
 #include <cavstool.h>
 #include <stdint.h>

--- a/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
@@ -33,7 +33,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "bap_common.h"

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -34,7 +34,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/toolchain.h>
 
 #include "bap_stream_tx.h"

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -29,7 +29,7 @@
 #include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/types.h>
 
 #include "bstests.h"

--- a/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
@@ -7,7 +7,7 @@
 #include <errno.h>
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>

--- a/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_sync.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_sync.c
@@ -7,7 +7,7 @@
 #include <errno.h>
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>

--- a/tests/bsim/bluetooth/ll/cis/src/main.c
+++ b/tests/bsim/bluetooth/ll/cis/src/main.c
@@ -17,7 +17,7 @@
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.c
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.c
@@ -19,7 +19,7 @@
 #include <zephyr/sys/atomic_types.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include "babblekit/testcase.h"
 

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -25,7 +25,7 @@
 #include <zephyr/kernel_structs.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/irq_offload.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #if defined(CONFIG_SOC_POSIX)
 /* TIMER_TICK_IRQ <soc.h> header for certain platforms */

--- a/tests/kernel/early_sleep/src/main.c
+++ b/tests/kernel/early_sleep/src/main.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <stdbool.h>
 #include <zephyr/tc_util.h>
 #include <zephyr/ztest.h>

--- a/tests/lib/c_lib/thrd/src/mtx.c
+++ b/tests/lib/c_lib/thrd/src/mtx.c
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include <threads.h>
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/ztest.h>
 
 static const int valid_mtx_types[] = {

--- a/tests/lib/c_lib/thrd/src/thrd.c
+++ b/tests/lib/c_lib/thrd/src/thrd.c
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include <threads.h>
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/timeutil.h>
 #include <zephyr/ztest.h>
 

--- a/tests/lib/c_lib/thrd/src/thrd.h
+++ b/tests/lib/c_lib/thrd/src/thrd.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <time.h>
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/timeutil.h>
 
 /* arbitrary magic numbers used for testing */

--- a/tests/lib/timespec_util/src/main.c
+++ b/tests/lib/timespec_util/src/main.c
@@ -8,7 +8,7 @@
 #include <time.h>
 
 #include <zephyr/ztest.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/timeutil.h>
 #include <zephyr/sys/util.h>
 

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -9,7 +9,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include <stdio.h>
 #include <zephyr/ztest_assert.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/socket_net_mgmt.h>

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/pm/policy.h>
 #include <zephyr/sys/time_units.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/ztest.h>
 
 void pm_state_set(enum pm_state state, uint8_t substate_id)

--- a/tests/subsys/portability/posix/timers/src/nanosleep.c
+++ b/tests/subsys/portability/posix/timers/src/nanosleep.c
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <time.h>
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/ztest.h>
 
 #define SELECT_NANOSLEEP       1

--- a/tests/subsys/portability/posix/timers/src/nanosleep_common.c
+++ b/tests/subsys/portability/posix/timers/src/nanosleep_common.c
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <time.h>
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/ztest.h>
 
 #define SELECT_NANOSLEEP       1


### PR DESCRIPTION
This is a proposal (RFC) to deprecate **include/zephyr/sys_clock.h**.
This header file exists since Zephyr early days but has been moved to **include/zephyr/sys/clock.h** in 2025 while preserving availability of the legacy file path (commit c08544a87bb73e7bd5d4d949d71f6e46c953d74e) . It's a bit odd to have this specific **sys_clock.h** while all system headers are located in **sys/\*.h** in a standard way.

Proposal:
* Update all the in-tree files to include **include/zephyr/sys/clock.h** instead.~
* Mark **include/zephyr/sys_clock.h** deprecated ~~and emit a build warning when it is used~~.

Aside the first ~~and last~~ commit, these changes were merely done running the Linux shell command below:
```bash
$ sed -i 's/zephyr\/sys_clock\.h/zephyr\/sys\/clock\.h/' `grep -rsl "zephyr/sys_clock\.h" */`
```
Among the Zephyr standard modules, I found only 1 file that includes this header and would trigger the build warning (if added). If this RFC is acked, i'll create a P-R in `hal_nxp` module to move to `<sys/clock.h>`.
```
modules/hal/nxp/
└── mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-multicore/
    └── pmsg-lite/lib/rpmsg_lite/porting/environment/rpmsg_env_zephyr.c
```
*(edited) See https://github.com/zephyrproject-rtos/hal_nxp/pull/781*
