### PR TITLE
dts: arm: st: wba: Remove #{address|size}-cells in the radio node

### DIFF
--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -574,9 +574,6 @@
 
 			interrupt-names = "radio";
 
-			#address-cells = <0>;
-			#size-cells = <0>;
-
 			bt_hci_wba: bluetooth {
 				compatible = "st,hci-stm32wba";
 				status = "disabled";


### PR DESCRIPTION
Remove `#address-cells` and `#size-cells` properties from radio node in STM32WBAxx SOC series DTSI file. These are not needed as reported by the build warning trace message shown below (that is now addressed):

```
.../build/zephyr/zephyr.dts:795.25-816.5: Warning (avoid_unnecessary_addr_size): /soc/radio@48020000: unnecessary #address-cells/#size-cells without "ranges", "dma-ranges" or child "reg" property