### PR TITLE
drivers: sensor: Add fixed-point conversion helpers to sensor.h

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -33,6 +33,7 @@
 #include <zephyr/dsp/types.h>
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/sys/iterable_sections.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus
@@ -1401,6 +1402,44 @@ static inline float sensor_value_to_float(const struct sensor_value *val)
 }
 
 /**
+ * @brief Helper function for converting struct sensor_value to fixed-point.
+ *
+ * @param val A pointer to a fixed-point value in Qm.n format.
+ * @param inp A pointer to a sensor_value struct.
+ * @param m Number of integer bits.
+ * @param n Number of fractional bits.
+ * @param is_signed Indicates whether the fixed-point value is signed or unsigned.
+ * @return 0 if successful, negative errno code if failure.
+ */
+static inline int sensor_value_to_fixed_point(uint32_t *val, struct sensor_value *inp, uint8_t m,
+					      uint8_t n, bool is_signed)
+{
+	uint8_t num_bits = m + n + (is_signed ? 1U : 0U);
+
+	if (m > 31 || !IN_RANGE(n, 1, 32) || !IN_RANGE(num_bits, 1, 32)) {
+		return -EINVAL;
+	}
+
+	int64_t raw = ((int64_t)inp->val1 << n) + ((int64_t)inp->val2 << n) / 1000000LL;
+
+	if (is_signed) {
+		if (!IN_RANGE(raw, -(int64_t)BIT(num_bits - 1), (int64_t)BIT_MASK(num_bits - 1))) {
+			return -ERANGE;
+		}
+
+		*val = (uint32_t)(raw & BIT64_MASK(num_bits));
+	} else {
+		if (!IN_RANGE(raw, 0, BIT64_MASK(num_bits))) {
+			return -ERANGE;
+		}
+
+		*val = (uint32_t)raw;
+	}
+
+	return 0;
+}
+
+/**
  * @brief Helper function for converting double to struct sensor_value.
  *
  * @param val A pointer to a sensor_value struct.
@@ -1440,6 +1479,39 @@ static inline int sensor_value_from_float(struct sensor_value *val, float inp)
 
 	val->val1 = val1;
 	val->val2 = val2;
+
+	return 0;
+}
+
+/**
+ * @brief Helper function for converting fixed-point to struct sensor_value.
+ *
+ * @param val A pointer to a sensor_value struct.
+ * @param inp Fixed-point value in Qm.n format.
+ * @param m Number of integer bits.
+ * @param n Number of fractional bits.
+ * @param is_signed Indicates whether the fixed-point value is signed or unsigned.
+ * @return 0 if successful, negative errno code if failure.
+ */
+static inline int sensor_value_from_fixed_point(struct sensor_value *val, uint32_t inp, uint8_t m,
+						uint8_t n, bool is_signed)
+{
+	uint8_t num_bits = m + n + (is_signed ? 1U : 0U);
+
+	if (m > 31 || !IN_RANGE(n, 1, 32) || !IN_RANGE(num_bits, 1, 32)) {
+		return -EINVAL;
+	}
+
+	inp &= BIT64_MASK(num_bits);
+
+	int64_t inp_int64 = is_signed ? sign_extend_64((uint64_t)inp, m + n) : (int64_t)inp;
+
+	val->val1 = arithmetic_shift_right(inp_int64 + (inp_int64 < 0 ? BIT64_MASK(n) : 0), n);
+
+	inp_int64 -= ((int64_t)val->val1 << n);
+	inp_int64 *= 1000000LL;
+
+	val->val2 = arithmetic_shift_right(inp_int64 + (inp_int64 < 0 ? BIT64_MASK(n) : 0), n);
 
 	return 0;
 }

--- a/tests/drivers/sensor/generic/src/main.c
+++ b/tests/drivers/sensor/generic/src/main.c
@@ -274,6 +274,7 @@ ZTEST(sensor_api, test_sensor_handle_triggers)
 ZTEST(sensor_api, test_sensor_unit_conversion)
 {
 	struct sensor_value data;
+	int ret;
 
 	/* Test acceleration unit conversion */
 	sensor_g_to_ms2(1, &data);
@@ -327,8 +328,6 @@ ZTEST(sensor_api, test_sensor_unit_conversion)
 			"the data does not match");
 
 	/* Extensive tests for edge cases */
-	int ret;
-
 	sensor_value_from_double(&data, -2147483648.0);
 	zassert_equal(data.val1, -2147483648, "the data does not match");
 	zassert_equal(data.val2, 0, "the data does not match");
@@ -358,6 +357,116 @@ ZTEST(sensor_api, test_sensor_unit_conversion)
 	zassert_equal(ret, -ERANGE, "range error expected");
 
 #endif
+	/* Test struct sensor_value to fixed point */
+	uint32_t val;
+
+	data.val1 = -1;
+	data.val2 = -500000;
+	ret = sensor_value_to_fixed_point(&val, &data, 1, 30, true);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(val, 0xA0000000U, "the result does not match");
+
+	data.val1 = 1;
+	data.val2 = 500000;
+	ret = sensor_value_to_fixed_point(&val, &data, 1, 30, true);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(val, 0x60000000U, "the result does not match");
+
+	data.val1 = 25;
+	data.val2 = 500000;
+	ret = sensor_value_to_fixed_point(&val, &data, 12, 4, false);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(val, 0x00000198U, "the result does not match");
+
+	data.val1 = -25;
+	data.val2 = -500000;
+	ret = sensor_value_to_fixed_point(&val, &data, 11, 4, true);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(val, 0x0000FE68U, "the result does not match");
+
+	/* Test struct sensor_value from fixed point */
+	ret = sensor_value_from_fixed_point(&data, 0xA0000000U, 1, 30, true);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(data.val1, -1, "the result does not match");
+	zassert_equal(data.val2, -500000, "the result does not match");
+
+	ret = sensor_value_from_fixed_point(&data, 0x60000000U, 1, 30, true);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(data.val1, 1, "the result does not match");
+	zassert_equal(data.val2, 500000, "the result does not match");
+
+	ret = sensor_value_from_fixed_point(&data, 0x00000198U, 12, 4, false);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(data.val1, 25, "the result does not match");
+	zassert_equal(data.val2, 500000, "the result does not match");
+
+	ret = sensor_value_from_fixed_point(&data, 0x0000FE68U, 11, 4, true);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(data.val1, -25, "the result does not match");
+	zassert_equal(data.val2, -500000, "the result does not match");
+
+	/* Test edge cases for struct sensor_value to/from fixed point */
+	ret = sensor_value_to_fixed_point(&val, &data, 10, 30, false);
+	zassert_equal(ret, -EINVAL, "invalid argument error expected");
+
+	ret = sensor_value_from_fixed_point(&data, val, 10, 30, false);
+	zassert_equal(ret, -EINVAL, "invalid argument error expected");
+
+	ret = sensor_value_to_fixed_point(&val, &data, 0, 32, true);
+	zassert_equal(ret, -EINVAL, "invalid argument error expected");
+
+	ret = sensor_value_from_fixed_point(&data, val, 0, 32, true);
+	zassert_equal(ret, -EINVAL, "invalid argument error expected");
+
+	ret = sensor_value_to_fixed_point(&val, &data, 10, 0, true);
+	zassert_equal(ret, -EINVAL, "invalid argument error expected");
+
+	ret = sensor_value_from_fixed_point(&data, val, 10, 0, true);
+	zassert_equal(ret, -EINVAL, "invalid argument error expected");
+
+	data.val1 = 1;
+	data.val2 = 0;
+	ret = sensor_value_to_fixed_point(&val, &data, 0, 31, true);
+	zassert_equal(ret, -ERANGE, "range error expected");
+
+	data.val1 = -1;
+	data.val2 = 0;
+	ret = sensor_value_to_fixed_point(&val, &data, 0, 31, true);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(val, 0x80000000U, "the result does not match");
+
+	ret = sensor_value_from_fixed_point(&data, 0x80000000U, 0, 31, true);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(data.val1, -1, "the result does not match");
+	zassert_equal(data.val2, 0, "the result does not match");
+
+	data.val1 = 0;
+	data.val2 = 0;
+	ret = sensor_value_to_fixed_point(&val, &data, 0, 31, true);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(val, 0x00000000U, "the result does not match");
+
+	ret = sensor_value_from_fixed_point(&data, 0x00000000U, 0, 31, true);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(data.val1, 0, "the result does not match");
+	zassert_equal(data.val2, 0, "the result does not match");
+
+	data.val1 = 0;
+	data.val2 = 500000;
+	ret = sensor_value_to_fixed_point(&val, &data, 0, 1, false);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(val, 0x00000001U, "the result does not match");
+
+	ret = sensor_value_from_fixed_point(&data, 0x00000001U, 0, 1, false);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(data.val1, 0, "the result does not match");
+	zassert_equal(data.val2, 500000, "the result does not match");
+
+	ret = sensor_value_from_fixed_point(&data, 0x7FFFFFFFU, 0, 31, true);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(data.val1, 0, "the result does not match");
+	zassert_equal(data.val2, 999999, "the result does not match");
+
 	/* reset test data to positive value */
 	data.val1 = 3;
 	data.val2 = 300000;


### PR DESCRIPTION
Adds helper functions to convert to/from fixed-point values in [Qm.n format](https://en.wikipedia.org/wiki/Q_(number_format)) and adds a suite of tests to `/tests/drivers/sensor/generic/` to verify:
- some simple examples
- invalid and out-of-range arguments
- a subset of edge cases (e.g., signed Q0.31, unsigned Q0.1, etc.)

Devices commonly store values in binary fixed-point format, so these functions will generically support device drivers converting to/from fixed-point and `struct sensor_value`, e.g., [qdec_stm32.c](https://github.com/zephyrproject-rtos/zephyr/blob/4b3d6fa0412940311b04083993b39828e3133d76/drivers/sensor/st/qdec_stm32/qdec_stm32.c). The impetus for implementing these functions now is to support haptics device drivers implementing the newly introduced `haptics_monitor_get()` which writes sensor values to a `struct sensor_value` (see #109442).

Verified `west twister -T tests/drivers/sensor/generic -p qemu_x86` locally.