### PR TITLE
pm: Add portable light, deep and soft-off sleep helpers

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -202,6 +202,12 @@ New APIs and options
 
   * Add :c:func:`net_eth_set_if_type_wifi` to set the ethernet interface type to Wi-Fi.
 
+* Power management
+
+  * :c:func:`pm_light_sleep`
+  * :c:func:`pm_deep_sleep`
+  * :c:func:`pm_soft_off`
+
 * Ring buffer
 
   * :c:struct:`sys_ringq` (see :ref:`fixed_size_ringq_api`)

--- a/doc/services/pm/system.rst
+++ b/doc/services/pm/system.rst
@@ -237,6 +237,47 @@ into certain power states. This can be used by devices when executing tasks in
 background to prevent the system from going to a specific state where it would
 lose context. See :c:func:`pm_policy_state_lock_get`.
 
+.. _pm-system-explicit-sleep:
+
+Entering sleep states explicitly
+================================
+
+In addition to the policy- and idle-driven flow described above, an application
+can request a low-power state directly and portably:
+
+* :c:func:`pm_light_sleep` enters the *shallowest* low-power state the board
+  declares (fastest wake-up) and returns once the system wakes up.
+* :c:func:`pm_deep_sleep` enters the *deepest context-retaining* state the board
+  declares (up to :c:enumerator:`PM_STATE_SUSPEND_TO_DISK`) and resumes in place.
+  :c:enumerator:`PM_STATE_SOFT_OFF` is never selected.
+* :c:func:`pm_soft_off` enters :c:enumerator:`PM_STATE_SOFT_OFF`, which does not
+  retain context: the system resets on wake-up and the call does not return.
+
+These helpers select the appropriate :c:struct:`pm_state_info` from the states
+declared for the CPU in devicetree and force it with :c:func:`pm_state_force`,
+so the same application code works across SoCs without any vendor-specific code.
+If the board declares no suitable low-power state, the helper returns
+``-ENOTSUP``.
+
+Interrupts that the chosen state keeps enabled still wake the CPU and run their
+handlers during the sleep, but the call returns when the timeout elapses, not on
+an interrupt. The state is forced for the *upcoming idle period*. After an early
+wake-up, subsequent idle periods follow the active PM policy rather than the
+forced state.
+
+.. code-block:: c
+
+   #include <zephyr/pm/pm.h>
+
+   /* Light sleep for up to 500 ms (shallowest state). */
+   pm_light_sleep(K_MSEC(500));
+
+   /* Deep sleep for up to 1 second (deepest context-retaining state). */
+   pm_deep_sleep(K_SECONDS(1));
+
+   /* Soft-off for up to 1 second (no context retention, resets on wake). */
+   pm_soft_off(K_SECONDS(1));
+
 Examples
 ========
 
@@ -245,6 +286,7 @@ Some helpful examples showing different power management features:
 * :zephyr_file:`samples/boards/st/power_mgmt/blinky/`
 * :zephyr_file:`samples/boards/espressif/deep_sleep/`
 * :zephyr_file:`samples/subsys/pm/device_pm/`
+* :zephyr_file:`samples/subsys/pm/pm_sleep/`
 * :zephyr_file:`tests/subsys/pm/power_mgmt/`
 * :zephyr_file:`tests/subsys/pm/power_mgmt_soc/`
 * :zephyr_file:`tests/subsys/pm/power_states_api/`

--- a/include/zephyr/pm/pm.h
+++ b/include/zephyr/pm/pm.h
@@ -15,6 +15,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/sys/slist.h>
+#include <zephyr/sys_clock.h>
 #include <zephyr/pm/state.h>
 #include <zephyr/toolchain.h>
 #include <errno.h>
@@ -104,6 +105,59 @@ struct pm_notifier {
  *	suspend operation.
  */
 bool pm_state_force(uint8_t cpu, const struct pm_state_info *info);
+
+/**
+ * @brief Enter a light (shallow, context-retaining) low-power sleep state.
+ *
+ * Enters the shallowest low-power state the board declares (fastest wake-up)
+ * for up to @p timeout, then returns. Context is always retained.
+ *
+ * @note Interrupts the chosen state keeps enabled still wake the CPU and run
+ *       their handlers, but the call returns when @p timeout elapses, not on an
+ *       interrupt. The state is forced for the upcoming idle period only. After
+ *       an early wake-up, later idle periods follow the active PM policy.
+ *
+ * @param timeout Maximum time to remain asleep (@ref K_FOREVER for no limit).
+ *
+ * @retval 0 Entered the state and resumed.
+ * @retval -ENOTSUP No suitable low-power state is declared.
+ */
+int pm_light_sleep(k_timeout_t timeout);
+
+/**
+ * @brief Enter a deep, context-retaining low-power sleep state.
+ *
+ * Enters the deepest @em context-retaining state the board declares (up to
+ * @ref PM_STATE_SUSPEND_TO_DISK) for up to @p timeout, then resumes in place.
+ * @ref PM_STATE_SOFT_OFF is never selected. For a full power-off that resets on
+ * wake-up use @c sys_poweroff() instead.
+ *
+ * @note Interrupts the chosen state keeps enabled still wake the CPU and run
+ *       their handlers, but the call returns when @p timeout elapses, not on an
+ *       interrupt. The state is forced for the upcoming idle period only. After
+ *       an early wake-up, later idle periods follow the active PM policy.
+ *
+ * @param timeout Maximum time to remain asleep (@ref K_FOREVER for no limit).
+ *
+ * @retval 0 Entered the state and resumed.
+ * @retval -ENOTSUP No context-retaining low-power state is declared.
+ */
+int pm_deep_sleep(k_timeout_t timeout);
+
+/**
+ * @brief Enter soft-off, the deepest state with no context retention.
+ *
+ * Enters @ref PM_STATE_SOFT_OFF for up to @p timeout. Context is not preserved:
+ * on platforms that power off, the system resets on wake-up and this does not
+ * return. A wake-up source must be configured. @p timeout is propagated to SoC
+ * backends that support a timed wake.
+ *
+ * @param timeout Maximum time to remain off (@ref K_FOREVER for no limit).
+ *
+ * @retval 0 The platform did not power off and resumed after @p timeout.
+ * @retval -ENOTSUP No soft-off state is declared.
+ */
+int pm_soft_off(k_timeout_t timeout);
 
 /**
  * @brief Register a power management notifier
@@ -242,6 +296,27 @@ static inline const struct pm_state_info *pm_state_next_get(uint8_t cpu)
 
 static inline void pm_system_resume(void)
 {
+}
+
+static inline int pm_light_sleep(k_timeout_t timeout)
+{
+	ARG_UNUSED(timeout);
+
+	return -ENOSYS;
+}
+
+static inline int pm_deep_sleep(k_timeout_t timeout)
+{
+	ARG_UNUSED(timeout);
+
+	return -ENOSYS;
+}
+
+static inline int pm_soft_off(k_timeout_t timeout)
+{
+	ARG_UNUSED(timeout);
+
+	return -ENOSYS;
 }
 
 #endif /* CONFIG_PM */

--- a/subsys/pm/CMakeLists.txt
+++ b/subsys/pm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PM)
-  zephyr_sources(pm.c state.c)
+  zephyr_sources(pm.c sleep.c state.c)
   zephyr_sources_ifdef(CONFIG_PM_STATS pm_stats.c)
 endif()
 

--- a/subsys/pm/sleep.c
+++ b/subsys/pm/sleep.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Rithic Chellaram Hariharan
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Portable light/deep system sleep helpers built on pm_state_force(). */
+
+#include <errno.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/state.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(pm, CONFIG_PM_LOG_LEVEL);
+
+/* Context-retaining states: everything except ACTIVE and SOFT_OFF. */
+#define PM_SLEEP_RETAIN_MIN PM_STATE_RUNTIME_IDLE
+#define PM_SLEEP_RETAIN_MAX PM_STATE_SUSPEND_TO_DISK
+
+/* Prefer @p a over @p b for the requested direction, ranking by state depth
+ * then by residency for substates of the same state.
+ */
+static bool pm_sleep_prefer(const struct pm_state_info *a, const struct pm_state_info *b,
+			    bool deepest)
+{
+	if (b == NULL) {
+		return true;
+	}
+
+	if (a->state != b->state) {
+		return deepest ? (a->state > b->state) : (a->state < b->state);
+	}
+
+	if (a->min_residency_us != b->min_residency_us) {
+		return deepest ? (a->min_residency_us > b->min_residency_us)
+			       : (a->min_residency_us < b->min_residency_us);
+	}
+
+	return false;
+}
+
+/* Pick the deepest or shallowest state in the inclusive [min, max] range. */
+static const struct pm_state_info *pm_sleep_pick_state(uint8_t cpu, enum pm_state min,
+						       enum pm_state max, bool deepest)
+{
+	const struct pm_state_info *states;
+	const struct pm_state_info *best = NULL;
+	uint8_t count;
+
+	/* Enabled states. */
+	count = pm_state_cpu_get_all(cpu, &states);
+	for (uint8_t i = 0; i < count; i++) {
+		if ((states[i].state < min) || (states[i].state > max)) {
+			continue;
+		}
+
+		if (pm_sleep_prefer(&states[i], best, deepest)) {
+			best = &states[i];
+		}
+	}
+
+	/* Disabled (forceable-only) states, not returned above. */
+	for (int s = (int)min; s <= (int)max; s++) {
+		const struct pm_state_info *info = pm_state_get(cpu, (enum pm_state)s, 0);
+
+		if ((info != NULL) && pm_sleep_prefer(info, best, deepest)) {
+			best = info;
+		}
+	}
+
+	return best;
+}
+
+static int pm_sleep_enter(enum pm_state min, enum pm_state max, bool deepest, k_timeout_t timeout)
+{
+	uint8_t cpu = CPU_ID;
+	const struct pm_state_info *info;
+
+	info = pm_sleep_pick_state(cpu, min, max, deepest);
+	if (info == NULL) {
+		return -ENOTSUP;
+	}
+
+	LOG_DBG("CPU %u entering %s (substate %u)", cpu, pm_state_to_str(info->state),
+		info->substate_id);
+
+	if (!pm_state_force(cpu, info)) {
+		return -ENOTSUP;
+	}
+
+	/* The idle thread enters the forced state for the upcoming idle period
+	 * while this thread sleeps. pm_state_force() is consumed on that first
+	 * idle entry, so an early wake-up returns to the active PM policy.
+	 */
+	(void)k_sleep(timeout);
+
+	return 0;
+}
+
+int pm_light_sleep(k_timeout_t timeout)
+{
+	return pm_sleep_enter(PM_SLEEP_RETAIN_MIN, PM_SLEEP_RETAIN_MAX, false, timeout);
+}
+
+int pm_deep_sleep(k_timeout_t timeout)
+{
+	return pm_sleep_enter(PM_SLEEP_RETAIN_MIN, PM_SLEEP_RETAIN_MAX, true, timeout);
+}
+
+int pm_soft_off(k_timeout_t timeout)
+{
+	return pm_sleep_enter(PM_STATE_SOFT_OFF, PM_STATE_SOFT_OFF, true, timeout);
+}


### PR DESCRIPTION
Add pm_light_sleep(), pm_deep_sleep() and pm_soft_off() built on pm_state_force(). Each picks a power state declared for the CPU in devicetree and returns -ENOTSUP when none is suitable.