### PR TITLE
dsp: use diamond include for non-local header files

### DIFF
--- a/subsys/dsp/arcmwdt/public/zdsp_backend.h
+++ b/subsys/dsp/arcmwdt/public/zdsp_backend.h
@@ -17,7 +17,7 @@ extern "C" {
 #include <zephyr/kernel.h>
 
 #include <arm_math.h>
-#include "dsplib.h"
+#include <dsplib.h>
 
 static inline void zdsp_mult_q7(const DSP_DATA q7_t *src_a, const DSP_DATA q7_t *src_b,
 				DSP_DATA q7_t *dst, uint32_t block_size)

--- a/tests/subsys/dsp/basicmath/src/f16.c
+++ b/tests/subsys/dsp/basicmath/src/f16.c
@@ -9,7 +9,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
 #include <stdlib.h>
-#include "common/test_common.h"
+#include <common/test_common.h>
 
 #include "f16.pat"
 

--- a/tests/subsys/dsp/basicmath/src/f32.c
+++ b/tests/subsys/dsp/basicmath/src/f32.c
@@ -9,7 +9,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
 #include <stdlib.h>
-#include "common/test_common.h"
+#include <common/test_common.h>
 
 #include "f32.pat"
 

--- a/tests/subsys/dsp/basicmath/src/q15.c
+++ b/tests/subsys/dsp/basicmath/src/q15.c
@@ -9,7 +9,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
 #include <stdlib.h>
-#include "common/test_common.h"
+#include <common/test_common.h>
 
 #include "q15.pat"
 

--- a/tests/subsys/dsp/basicmath/src/q31.c
+++ b/tests/subsys/dsp/basicmath/src/q31.c
@@ -9,7 +9,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
 #include <stdlib.h>
-#include "common/test_common.h"
+#include <common/test_common.h>
 
 #include "q31.pat"
 

--- a/tests/subsys/dsp/basicmath/src/q7.c
+++ b/tests/subsys/dsp/basicmath/src/q7.c
@@ -9,7 +9,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
 #include <stdlib.h>
-#include "common/test_common.h"
+#include <common/test_common.h>
 
 #include "q7.pat"
 

--- a/tests/subsys/dsp/utils/src/f32.c
+++ b/tests/subsys/dsp/utils/src/f32.c
@@ -11,7 +11,7 @@
 #include <zephyr/dsp/dsp.h>
 #include <zephyr/dsp/utils.h>
 
-#include "common/test_common.h"
+#include <common/test_common.h>
 
 #define DEFINE_MULTIPLE_TEST_CASES(constructor, variant, array)                                    \
 	FOR_EACH_IDX_FIXED_ARG(constructor, (), variant, array)

--- a/tests/subsys/dsp/utils/src/f64.c
+++ b/tests/subsys/dsp/utils/src/f64.c
@@ -11,7 +11,7 @@
 #include <zephyr/dsp/dsp.h>
 #include <zephyr/dsp/utils.h>
 
-#include "common/test_common.h"
+#include <common/test_common.h>
 
 #define DEFINE_MULTIPLE_TEST_CASES(constructor, variant, array)                                    \
 	FOR_EACH_IDX_FIXED_ARG(constructor, (), variant, array)

--- a/tests/subsys/dsp/utils/src/q15.c
+++ b/tests/subsys/dsp/utils/src/q15.c
@@ -11,7 +11,7 @@
 #include <zephyr/dsp/dsp.h>
 #include <zephyr/dsp/utils.h>
 
-#include "common/test_common.h"
+#include <common/test_common.h>
 
 #define DEFINE_MULTIPLE_TEST_CASES(constructor, variant, array)                                    \
 	FOR_EACH_IDX_FIXED_ARG(constructor, (), variant, array)

--- a/tests/subsys/dsp/utils/src/q31.c
+++ b/tests/subsys/dsp/utils/src/q31.c
@@ -11,7 +11,7 @@
 #include <zephyr/dsp/dsp.h>
 #include <zephyr/dsp/utils.h>
 
-#include "common/test_common.h"
+#include <common/test_common.h>
 
 #define DEFINE_MULTIPLE_TEST_CASES(constructor, variant, array)                                    \
 	FOR_EACH_IDX_FIXED_ARG(constructor, (), variant, array)

--- a/tests/subsys/dsp/utils/src/q7.c
+++ b/tests/subsys/dsp/utils/src/q7.c
@@ -11,7 +11,7 @@
 #include <zephyr/dsp/dsp.h>
 #include <zephyr/dsp/utils.h>
 
-#include "common/test_common.h"
+#include <common/test_common.h>
 
 #define DEFINE_MULTIPLE_TEST_CASES(constructor, variant, array)                                    \
 	FOR_EACH_IDX_FIXED_ARG(constructor, (), variant, array)


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various DSP related paths and manually selecting the applicable changes:
```
$ find subsys/dsp/ -type f -exec ./scripts/check_quoted_includes.py -w {} ;