### PR TITLE
fs: use diamond include for non-local header files

### DIFF
--- a/subsys/fs/fuse_fs_access.c
+++ b/subsys/fs/fuse_fs_access.c
@@ -9,8 +9,8 @@
 #include <zephyr/fs/fs.h>
 #include <nsi_errno.h>
 
-#include "cmdline.h"
-#include "soc.h"
+#include <cmdline.h>
+#include <soc.h>
 
 #include "fuse_fs_access_bottom.h"
 

--- a/subsys/fs/native_mount_bottom.c
+++ b/subsys/fs/native_mount_bottom.c
@@ -17,9 +17,9 @@
 #include <dirent.h>
 #include <unistd.h>
 
-#include "nsi_errno.h"
-#include "nsi_fcntl.h"
-#include "nsi_tracing.h"
+#include <nsi_errno.h>
+#include <nsi_fcntl.h>
+#include <nsi_tracing.h>
 #include "native_mount_bottom.h"
 
 struct fs_mid_dir {

--- a/tests/subsys/fs/fcb/src/fcb_test.h
+++ b/tests/subsys/fs/fcb/src/fcb_test.h
@@ -13,7 +13,7 @@
 #include <zephyr/ztest.h>
 
 #include <zephyr/fs/fcb.h>
-#include "fcb_priv.h"
+#include <fcb_priv.h>
 #include <errno.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various FS related paths and manually selecting the applicable changes:
```
$ find subsys/fs/ -type f -exec ./scripts/check_quoted_includes.py -w {} ;