### PR TITLE
authentication: use diamond include for non-local header files

### DIFF
--- a/subsys/authentication/fido2/fido2_cbor.c
+++ b/subsys/authentication/fido2/fido2_cbor.c
@@ -11,7 +11,7 @@
 
 #include "fido2_cbor.h"
 #include "fido2_crypto.h"
-#include "zcbor_common.h"
+#include <zcbor_common.h>
 #include <stdint.h>
 #include <string.h>
 


### PR DESCRIPTION
Use #include <> instead of #include "" to include a header file which path is not relative to the directory path of the file emitting the #include directive.

This change was made running scripts/check_quoted_includes.py script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with the Linux shell command below and manually selecting the applicable changes:
$ find subsys/authentication/ -type f -exec \
    ./scripts/check_quoted_includes.py -w {} \;