### PR TITLE
lorawan: use diamond include for non-local header files

### DIFF
--- a/subsys/lorawan/native/mac/join.c
+++ b/subsys/lorawan/native/mac/join.c
@@ -51,8 +51,8 @@
 #include <string.h>
 
 #include "mac_internal.h"
-#include "engine.h"
-#include "crypto/crypto.h"
+#include <engine.h>
+#include <crypto/crypto.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(lorawan_native_mac, CONFIG_LORAWAN_LOG_LEVEL);

--- a/subsys/lorawan/native/mac/mac.c
+++ b/subsys/lorawan/native/mac/mac.c
@@ -32,7 +32,7 @@
 #include <zephyr/kernel.h>
 
 #include "mac_internal.h"
-#include "radio.h"
+#include <radio.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lorawan_native_mac, CONFIG_LORAWAN_LOG_LEVEL);

--- a/subsys/lorawan/native/mac/mac.h
+++ b/subsys/lorawan/native/mac/mac.h
@@ -6,8 +6,8 @@
 #ifndef SUBSYS_LORAWAN_NATIVE_MAC_MAC_H_
 #define SUBSYS_LORAWAN_NATIVE_MAC_MAC_H_
 
-#include "engine.h"
-#include "lorawan.h"
+#include <engine.h>
+#include <lorawan.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/lorawan/native/mac/mac_commands.c
+++ b/subsys/lorawan/native/mac/mac_commands.c
@@ -6,7 +6,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "lorawan.h"
+#include <lorawan.h>
 #include "mac_commands.h"
 
 size_t mac_cmd_build_ul_fopts(struct lwan_ctx *ctx,

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -51,8 +51,8 @@
 
 #include "mac_internal.h"
 #include "mac_commands.h"
-#include "engine.h"
-#include "crypto/crypto.h"
+#include <engine.h>
+#include <crypto/crypto.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(lorawan_native_mac, CONFIG_LORAWAN_LOG_LEVEL);

--- a/subsys/lorawan/native/region/region_eu868.c
+++ b/subsys/lorawan/native/region/region_eu868.c
@@ -12,7 +12,7 @@
 #include <string.h>
 
 #include "region.h"
-#include "lorawan.h"
+#include <lorawan.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lorawan_native_eu868, CONFIG_LORAWAN_LOG_LEVEL);


### PR DESCRIPTION
Use #include <> instead of #include "" to include a header file which path is not relative to the directory path of the file emitting the #include directive.

This change was made running scripts/check_quoted_includes.py script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with the Linux shell command below and manually selecting the applicable changes:
$ find subsys/lorawan/ -type f -exec \
    ./scripts/check_quoted_includes.py -w {} \;