### PR TITLE
net: use diamond include for non-local header files

### DIFF
--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(net_ipv4, CONFIG_NET_IPV4_LOG_LEVEL);
 #include "icmpv4.h"
 #include "udp_internal.h"
 #include "tcp_internal.h"
-#include "dhcpv4/dhcpv4_internal.h"
+#include <dhcpv4/dhcpv4_internal.h>
 #include "ipv4.h"
 #include "pmtu.h"
 #include "route_ipv4.h"

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -44,7 +44,7 @@ LOG_MODULE_REGISTER(net_core, CONFIG_NET_CORE_LOG_LEVEL);
 #endif
 
 #include "net_private.h"
-#include "shell/net_shell.h"
+#include <shell/net_shell.h>
 
 #include "pmtu.h"
 
@@ -54,8 +54,8 @@ LOG_MODULE_REGISTER(net_core, CONFIG_NET_CORE_LOG_LEVEL);
 #include "icmpv4.h"
 #include "ipv4.h"
 
-#include "dhcpv4/dhcpv4_internal.h"
-#include "dhcpv6/dhcpv6_internal.h"
+#include <dhcpv4/dhcpv4_internal.h>
+#include <dhcpv6/dhcpv6_internal.h>
 
 #include "route_ipv4.h"
 #include "route_ipv6.h"

--- a/subsys/net/l2/dummy/any/any.c
+++ b/subsys/net/l2/dummy/any/any.c
@@ -12,8 +12,8 @@ LOG_MODULE_REGISTER(net_any, CONFIG_NET_PSEUDO_IFACE_LOG_LEVEL);
 #include <zephyr/net/dummy.h>
 #include <zephyr/net/virtual.h>
 
-#include "net_private.h"
-#include "net_stats.h"
+#include <net_private.h>
+#include <net_stats.h>
 
 struct any_context {
 	struct net_if *iface;

--- a/subsys/net/l2/dummy/dummy.c
+++ b/subsys/net/l2/dummy/dummy.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(net_l2_dummy, LOG_LEVEL_NONE);
 
 #include <zephyr/net/dummy.h>
 
-#include "net_stats.h"
+#include <net_stats.h>
 
 static inline enum net_verdict dummy_recv(struct net_if *iface,
 					  struct net_pkt *pkt)

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -20,9 +20,9 @@ LOG_MODULE_REGISTER(net_arp, CONFIG_NET_ARP_LOG_LEVEL);
 #include <zephyr/net/net_mgmt.h>
 
 #include "arp.h"
-#include "ipv4.h"
-#include "route_ipv4.h"
-#include "net_private.h"
+#include <ipv4.h>
+#include <route_ipv4.h>
+#include <net_private.h>
 
 #define NET_BUF_TIMEOUT K_MSEC(100)
 #define ARP_REQUEST_TIMEOUT (2 * MSEC_PER_SEC)

--- a/subsys/net/l2/ethernet/bridge/bridge.c
+++ b/subsys/net/l2/ethernet/bridge/bridge.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(net_eth_bridge, CONFIG_NET_ETHERNET_BRIDGE_LOG_LEVEL);
 #include <zephyr/sys/slist.h>
 #include <zephyr/random/random.h>
 
-#include "net_private.h"
+#include <net_private.h>
 
 #if defined(CONFIG_NET_ETHERNET_BRIDGE_TXRX_DEBUG)
 #define DEBUG_TX 1

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -30,9 +30,9 @@ LOG_MODULE_REGISTER(net_ethernet, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 
 #include "arp.h"
 #include "eth_stats.h"
-#include "net_private.h"
-#include "ipv6.h"
-#include "ipv4.h"
+#include <net_private.h>
+#include <ipv6.h>
+#include <ipv4.h>
 
 #define NET_BUF_TIMEOUT K_MSEC(100)
 

--- a/subsys/net/l2/ethernet/ethernet_stats.c
+++ b/subsys/net/l2/ethernet/ethernet_stats.c
@@ -13,7 +13,7 @@ LOG_MODULE_REGISTER(net_ethernet_stats, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/ethernet.h>
 
-#include "net_stats.h"
+#include <net_stats.h>
 
 #if defined(CONFIG_NET_STATISTICS_USER_API)
 

--- a/subsys/net/l2/ethernet/gptp/gptp_user_api.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_user_api.c
@@ -13,7 +13,7 @@ LOG_MODULE_DECLARE(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 #include "gptp_messages.h"
 #include "gptp_data_set.h"
 
-#include "net_private.h"
+#include <net_private.h>
 
 static sys_slist_t phase_dis_callbacks;
 

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(net_ethernet_vlan, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 #include <zephyr/net/virtual.h>
 #include <zephyr/random/random.h>
 
-#include "net_private.h"
+#include <net_private.h>
 
 #if defined(CONFIG_NET_VLAN_TXRX_DEBUG)
 #define DEBUG_TX 1

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -53,7 +53,7 @@ NET_BUF_POOL_DEFINE(tx_frame_buf_pool, 1, IEEE802154_MTU, 8, NULL);
 
 #ifdef CONFIG_NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET
 
-#include "net_private.h"
+#include <net_private.h>
 
 static inline void pkt_hexdump(const char *title, struct net_pkt *pkt, bool in)
 {

--- a/subsys/net/l2/ieee802154/ieee802154_6lo_fragment.c
+++ b/subsys/net/l2/ieee802154/ieee802154_6lo_fragment.c
@@ -12,10 +12,10 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_ieee802154_6lo_fragment, CONFIG_NET_L2_IEEE802154_LOG_LEVEL);
 
-#include "6lo.h"
-#include "6lo_private.h"
+#include <6lo.h>
+#include <6lo_private.h>
 #include "ieee802154_6lo_fragment.h"
-#include "net_private.h"
+#include <net_private.h>
 
 #include <errno.h>
 

--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -15,7 +15,7 @@ LOG_MODULE_DECLARE(net_l2_openthread, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 #include <openthread/ip6.h>
 #include <openthread/thread.h>
 
-#include "net_private.h"
+#include <net_private.h>
 #include "openthread_utils.h"
 
 #define ALOC16_MASK 0xfc

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -15,7 +15,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include <zephyr/net/ppp.h>
 #include <zephyr/random/random.h>
 
-#include "net_private.h"
+#include <net_private.h>
 
 #include "ppp_internal.h"
 

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -15,7 +15,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include <zephyr/net/ppp.h>
 #include <zephyr/net/dns_resolve.h>
 
-#include "net_private.h"
+#include <net_private.h>
 
 #include "ppp_internal.h"
 

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -13,8 +13,8 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/ppp.h>
 
-#include "net_private.h"
-#include "ipv6.h"
+#include <net_private.h>
+#include <ipv6.h>
 
 #include "ppp_internal.h"
 

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -16,7 +16,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/ppp.h>
 
-#include "net_private.h"
+#include <net_private.h>
 
 #include "ppp_stats.h"
 #include "ppp_internal.h"

--- a/subsys/net/l2/ppp/link.c
+++ b/subsys/net/l2/ppp/link.c
@@ -13,7 +13,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/net/ppp.h>
 
-#include "net_private.h"
+#include <net_private.h>
 
 #include "ppp_internal.h"
 

--- a/subsys/net/l2/ppp/misc.c
+++ b/subsys/net/l2/ppp/misc.c
@@ -13,7 +13,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/ppp.h>
 
-#include "net_private.h"
+#include <net_private.h>
 
 #include "ppp_internal.h"
 

--- a/subsys/net/l2/ppp/network.c
+++ b/subsys/net/l2/ppp/network.c
@@ -13,7 +13,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/net/ppp.h>
 
-#include "net_private.h"
+#include <net_private.h>
 
 #include "ppp_internal.h"
 

--- a/subsys/net/l2/ppp/options.c
+++ b/subsys/net/l2/ppp/options.c
@@ -13,7 +13,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/ppp.h>
 
-#include "net_private.h"
+#include <net_private.h>
 
 #include "ppp_internal.h"
 

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/iterable_sections.h>
 
-#include "net_private.h"
+#include <net_private.h>
 
 #include "ppp_stats.h"
 #include "ppp_internal.h"

--- a/subsys/net/l2/ppp/ppp_stats.c
+++ b/subsys/net/l2/ppp/ppp_stats.c
@@ -13,7 +13,7 @@ LOG_MODULE_REGISTER(net_ppp_stats, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/ppp.h>
 
-#include "net_stats.h"
+#include <net_stats.h>
 
 #if defined(CONFIG_NET_STATISTICS_USER_API)
 

--- a/subsys/net/l2/virtual/ipip/ipip.c
+++ b/subsys/net/l2/virtual/ipip/ipip.c
@@ -16,9 +16,9 @@ LOG_MODULE_REGISTER(net_virtual_ipip, CONFIG_NET_L2_IPIP_LOG_LEVEL);
 #include <zephyr/net/net_log.h>
 #include <zephyr/net/virtual.h>
 
-#include "ipv4.h"
-#include "ipv6.h"
-#include "net_private.h"
+#include <ipv4.h>
+#include <ipv6.h>
+#include <net_private.h>
 
 #if defined(CONFIG_NET_L2_IPIP_TXRX_DEBUG)
 #define DEBUG_TX 1

--- a/subsys/net/l2/virtual/virtual.c
+++ b/subsys/net/l2/virtual/virtual.c
@@ -16,8 +16,8 @@ LOG_MODULE_REGISTER(net_virtual, CONFIG_NET_L2_VIRTUAL_LOG_LEVEL);
 #include <zephyr/net/virtual_mgmt.h>
 #include <zephyr/random/random.h>
 
-#include "net_private.h"
-#include "net_stats.h"
+#include <net_private.h>
+#include <net_stats.h>
 
 #define NET_BUF_TIMEOUT K_MSEC(100)
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(net_wifi_shell, LOG_LEVEL_INF);
 #endif
 #include <zephyr/sys/slist.h>
 
-#include "net_shell_private.h"
+#include <net_shell_private.h>
 #include <math.h>
 
 #include <ctype.h>

--- a/subsys/net/lib/capture/capture.c
+++ b/subsys/net/lib/capture/capture.c
@@ -20,11 +20,11 @@ LOG_MODULE_REGISTER(net_capture, CONFIG_NET_CAPTURE_LOG_LEVEL);
 #include <zephyr/net/capture.h>
 #include <zephyr/net/ethernet.h>
 
-#include "net_private.h"
-#include "ipv4.h"
-#include "ipv6.h"
-#include "udp_internal.h"
-#include "net_stats.h"
+#include <net_private.h>
+#include <ipv4.h>
+#include <ipv6.h>
+#include <udp_internal.h>
+#include <net_stats.h>
 
 #define PKT_ALLOC_TIME K_MSEC(50)
 #define DEFAULT_PORT 4242

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -23,10 +23,10 @@ LOG_MODULE_REGISTER(net_dhcpv4, CONFIG_NET_DHCPV4_LOG_LEVEL);
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/hostname.h>
-#include "net_private.h"
+#include <net_private.h>
 
 #include <zephyr/net/udp.h>
-#include "udp_internal.h"
+#include <udp_internal.h>
 #include <zephyr/net/dhcpv4.h>
 #include <zephyr/net/dns_resolve.h>
 
@@ -35,8 +35,8 @@ LOG_MODULE_REGISTER(net_dhcpv4, CONFIG_NET_DHCPV4_LOG_LEVEL);
 #include <zephyr/logging/log_ctrl.h>
 
 #include "dhcpv4_internal.h"
-#include "ipv4.h"
-#include "net_stats.h"
+#include <ipv4.h>
+#include <net_stats.h>
 
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>

--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -25,7 +25,7 @@
 LOG_MODULE_REGISTER(net_dhcpv4_server, CONFIG_NET_DHCPV4_SERVER_LOG_LEVEL);
 
 #include "dhcpv4_internal.h"
-#include "net_private.h"
+#include <net_private.h>
 #include "../../l2/ethernet/arp.h"
 
 #define DHCPV4_OPTIONS_MSG_TYPE_SIZE 3

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -19,9 +19,9 @@ LOG_MODULE_REGISTER(net_dhcpv6, CONFIG_NET_DHCPV6_LOG_LEVEL);
 #include <zephyr/sys/math_extras.h>
 
 #include "dhcpv6_internal.h"
-#include "ipv6.h"
-#include "net_private.h"
-#include "udp_internal.h"
+#include <ipv6.h>
+#include <net_private.h>
+#include <udp_internal.h>
 
 #define PKT_WAIT_TIME K_MSEC(100)
 

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -31,10 +31,10 @@ LOG_MODULE_REGISTER(net_llmnr_responder, CONFIG_LLMNR_RESPONDER_LOG_LEVEL);
 #include <zephyr/net/igmp.h>
 
 #include "dns_pack.h"
-#include "ipv6.h"
+#include <ipv6.h>
 #include "../../ip/net_stats.h"
 
-#include "net_private.h"
+#include <net_private.h>
 
 #define LLMNR_LISTEN_PORT 5355
 

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -35,10 +35,10 @@ LOG_MODULE_REGISTER(net_mdns_responder, CONFIG_MDNS_RESPONDER_LOG_LEVEL);
 
 #include "dns_sd.h"
 #include "dns_pack.h"
-#include "ipv6.h"
+#include <ipv6.h>
 #include "../../ip/net_stats.h"
 
-#include "net_private.h"
+#include <net_private.h>
 
 /*
  * GCC complains about struct net_sockaddr accesses due to the various

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(net_http_client, CONFIG_NET_HTTP_LOG_LEVEL);
 #include <zephyr/net/http/client.h>
 #include <zephyr/net/http/status.h>
 
-#include "net_private.h"
+#include <net_private.h>
 
 #define HTTP_CONTENT_LEN_SIZE 11
 #define MAX_SEND_BUF_LEN CONFIG_HTTP_CLIENT_SEND_BUF_SIZE

--- a/subsys/net/lib/http/http_server_http2.c
+++ b/subsys/net/lib/http/http_server_http2.c
@@ -25,7 +25,7 @@ LOG_MODULE_DECLARE(net_http_server, CONFIG_NET_HTTP_SERVER_LOG_LEVEL);
 
 static const char content_404[] = {
 #ifdef INCLUDE_HTML_CONTENT
-#include "not_found_page.html.gz.inc"
+#include <not_found_page.html.gz.inc>
 #endif
 };
 

--- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor.patch
+++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor.patch
@@ -13,7 +13,7 @@ index f8006525d79..0bd686d8174 100644
 
 @@ -16,10 +16,6 @@
  #include "lwm2m_senml_cbor_decode.h"
- #include "zcbor_print.h"
+ #include <zcbor_print.h>
 
 -#if DEFAULT_MAX_QTY != 99
 -#error "The type file was generated with a different default_max_qty than this file"
@@ -80,7 +80,7 @@ index 851cf994c6d..4ec898e656d 100644
 
 @@ -16,10 +16,6 @@
  #include "lwm2m_senml_cbor_encode.h"
- #include "zcbor_print.h"
+ #include <zcbor_print.h>
 
 -#if DEFAULT_MAX_QTY != 99
 -#error "The type file was generated with a different default_max_qty than this file"

--- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.c
+++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.c
@@ -12,9 +12,9 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
-#include "zcbor_decode.h"
+#include <zcbor_decode.h>
 #include "lwm2m_senml_cbor_decode.h"
-#include "zcbor_print.h"
+#include <zcbor_print.h>
 
 #define log_result(state, result, func)                                                            \
 	do {                                                                                       \

--- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.c
+++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.c
@@ -12,9 +12,9 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
-#include "zcbor_encode.h"
+#include <zcbor_encode.h>
 #include "lwm2m_senml_cbor_encode.h"
-#include "zcbor_print.h"
+#include <zcbor_print.h>
 
 #define log_result(state, result, func)                                                            \
 	do {                                                                                       \

--- a/subsys/net/lib/lwm2m/send_scheduler/lwm2m_obj_send_scheduler.c
+++ b/subsys/net/lib/lwm2m/send_scheduler/lwm2m_obj_send_scheduler.c
@@ -17,9 +17,9 @@ LOG_MODULE_DECLARE(lwm2m_send_sched, CONFIG_LWM2M_SEND_SCHEDULER_LOG_LEVEL);
 #include <zephyr/net/lwm2m.h>
 #include <zephyr/sys/util.h>
 
-#include "lwm2m_engine.h"
-#include "lwm2m_object.h"
-#include "lwm2m_registry.h"
+#include <lwm2m_engine.h>
+#include <lwm2m_object.h>
+#include <lwm2m_registry.h>
 
 #include <zephyr/net/lwm2m_send_scheduler.h>
 #include "send_scheduler_internal.h"

--- a/subsys/net/lib/lwm2m/send_scheduler/send_scheduler_core.c
+++ b/subsys/net/lib/lwm2m/send_scheduler/send_scheduler_core.c
@@ -19,9 +19,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_LWM2M_SEND_SCHEDULER_LOG_LEVEL);
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 
-#include "lwm2m_engine.h"
-#include "lwm2m_object.h"
-#include "lwm2m_registry.h"
+#include <lwm2m_engine.h>
+#include <lwm2m_object.h>
+#include <lwm2m_registry.h>
 
 #include <zephyr/net/lwm2m_send_scheduler.h>
 #include "send_scheduler_internal.h"

--- a/subsys/net/lib/ocpp/ocpp_i.h
+++ b/subsys/net/lib/ocpp/ocpp_i.h
@@ -7,7 +7,7 @@
 #ifndef __OCPP_I_
 #define __OCPP_I_
 
-#include "string.h"
+#include <string.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net/ocpp.h>
 #include <zephyr/net/socket.h>

--- a/subsys/net/lib/quic/quic.c
+++ b/subsys/net/lib/quic/quic.c
@@ -47,9 +47,9 @@ LOG_MODULE_REGISTER(net_quic, CONFIG_QUIC_LOG_LEVEL);
 #include <zephyr_mbedtls_priv.h>
 #endif
 
-#include "net_private.h"
-#include "sockets_internal.h"
-#include "tls_internal.h"
+#include <net_private.h>
+#include <sockets_internal.h>
+#include <tls_internal.h>
 #include "quic_internal.h"
 #include "quic_stats.h"
 

--- a/subsys/net/lib/shell/arp.c
+++ b/subsys/net/lib/shell/arp.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include "net_shell_private.h"
 
 #if defined(CONFIG_NET_ARP)
-#include "ethernet/arp.h"
+#include <ethernet/arp.h>
 #include <zephyr/net/net_if.h>
 #endif
 

--- a/subsys/net/lib/shell/cm.c
+++ b/subsys/net/lib/shell/cm.c
@@ -15,7 +15,7 @@ LOG_MODULE_DECLARE(net_shell);
 
 #if defined(CONFIG_NET_CONNECTION_MANAGER)
 
-#include "conn_mgr_private.h"
+#include <conn_mgr_private.h>
 #include <zephyr/net/conn_mgr_connectivity.h>
 #include <zephyr/net/conn_mgr_monitor.h>
 

--- a/subsys/net/lib/shell/conn.c
+++ b/subsys/net/lib/shell/conn.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include "net_shell_private.h"
 
 #if defined(CONFIG_NET_TCP)
-#include "tcp_internal.h"
+#include <tcp_internal.h>
 #include <zephyr/sys/slist.h>
 #endif
 

--- a/subsys/net/lib/shell/dns.c
+++ b/subsys/net/lib/shell/dns.c
@@ -14,7 +14,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include <zephyr/net/socket.h>
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/net/dns_sd.h>
-#include "dns/dns_sd.h"
+#include <dns/dns_sd.h>
 
 #include "net_shell_private.h"
 

--- a/subsys/net/lib/shell/gptp.c
+++ b/subsys/net/lib/shell/gptp.c
@@ -12,11 +12,11 @@ LOG_MODULE_DECLARE(net_shell);
 
 #if defined(CONFIG_NET_GPTP)
 #include <zephyr/net/gptp.h>
-#include "ethernet/gptp/gptp_messages.h"
-#include "ethernet/gptp/gptp_md.h"
-#include "ethernet/gptp/gptp_state.h"
-#include "ethernet/gptp/gptp_data_set.h"
-#include "ethernet/gptp/gptp_private.h"
+#include <ethernet/gptp/gptp_messages.h>
+#include <ethernet/gptp/gptp_md.h>
+#include <ethernet/gptp/gptp_state.h>
+#include <ethernet/gptp/gptp_data_set.h>
+#include <ethernet/gptp/gptp_private.h>
 #endif
 
 #include "net_shell_private.h"

--- a/subsys/net/lib/shell/http_client.c
+++ b/subsys/net/lib/shell/http_client.c
@@ -351,7 +351,7 @@ static int http_client_connect(struct http_client_sh_ctx *ctx)
 
 #if defined(CONFIG_NET_SHELL_HTTP_CLIENT_HAS_CERTIFICATE)
 static const uint8_t ca_certificate[] = {
-#include "net_shell_http_client_ca.der.inc"
+#include <net_shell_http_client_ca.der.inc>
 };
 
 static int http_client_certificate(void)

--- a/subsys/net/lib/shell/iptables.c
+++ b/subsys/net/lib/shell/iptables.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(net_shell);
 
 #if defined(CONFIG_NET_IPV4_NAT)
 #include <zephyr/net/ipv4_nat.h>
-#include "../ip/ipv4_nat_internal.h"
+#include <../ip/ipv4_nat_internal.h>
 #endif
 
 #define IPSTR "%hhu.%hhu.%hhu.%hhu"

--- a/subsys/net/lib/shell/iptables.c
+++ b/subsys/net/lib/shell/iptables.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(net_shell);
 
 #if defined(CONFIG_NET_IPV4_NAT)
 #include <zephyr/net/ipv4_nat.h>
-#include <../ip/ipv4_nat_internal.h>
+#include <ipv4_nat_internal.h>
 #endif
 
 #define IPSTR "%hhu.%hhu.%hhu.%hhu"

--- a/subsys/net/lib/shell/ipv4.c
+++ b/subsys/net/lib/shell/ipv4.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include <zephyr/net/igmp.h>
 
 #include "net_shell_private.h"
-#include "../ip/ipv4.h"
+#include <../ip/ipv4.h>
 
 #if defined(CONFIG_NET_IPV4)
 static void ip_address_info_cb(struct net_if *iface, void *user_data)

--- a/subsys/net/lib/shell/ipv4.c
+++ b/subsys/net/lib/shell/ipv4.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include <zephyr/net/igmp.h>
 
 #include "net_shell_private.h"
-#include <../ip/ipv4.h>
+#include <ipv4.h>
 
 #if defined(CONFIG_NET_IPV4)
 static void ip_address_info_cb(struct net_if *iface, void *user_data)

--- a/subsys/net/lib/shell/ipv6.c
+++ b/subsys/net/lib/shell/ipv6.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include <zephyr/net/mld.h>
 
 #include "net_shell_private.h"
-#include "../ip/ipv6.h"
+#include <../ip/ipv6.h>
 
 #if defined(CONFIG_NET_IPV6_FRAGMENT)
 void ipv6_frag_cb(struct net_ipv6_reassembly *reass, void *user_data)

--- a/subsys/net/lib/shell/ipv6.c
+++ b/subsys/net/lib/shell/ipv6.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include <zephyr/net/mld.h>
 
 #include "net_shell_private.h"
-#include <../ip/ipv6.h>
+#include <ipv6.h>
 
 #if defined(CONFIG_NET_IPV6_FRAGMENT)
 void ipv6_frag_cb(struct net_ipv6_reassembly *reass, void *user_data)

--- a/subsys/net/lib/shell/net_shell_private.h
+++ b/subsys/net/lib/shell/net_shell_private.h
@@ -54,7 +54,7 @@
 	} while (false)
 
 #include <net_private.h>
-#include <../ip/ipv6.h>
+#include <ipv6.h>
 
 struct net_shell_user_data {
 	const struct shell *sh;

--- a/subsys/net/lib/shell/net_shell_private.h
+++ b/subsys/net/lib/shell/net_shell_private.h
@@ -53,8 +53,8 @@
 		}                                                               \
 	} while (false)
 
-#include "net_private.h"
-#include "../ip/ipv6.h"
+#include <net_private.h>
+#include <../ip/ipv6.h>
 
 struct net_shell_user_data {
 	const struct shell *sh;

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -16,11 +16,11 @@ LOG_MODULE_DECLARE(net_shell);
 
 #include "net_shell_private.h"
 
-#include "../ip/icmpv6.h"
-#include "../ip/icmpv4.h"
-#include "../ip/route_ipv6.h"
-#include "../ip/route_ipv4.h"
-#include "../ip/route.h"
+#include <../ip/icmpv6.h>
+#include <../ip/icmpv4.h>
+#include <../ip/route_ipv6.h>
+#include <../ip/route_ipv4.h>
+#include <../ip/route.h>
 
 #if defined(CONFIG_NET_IP)
 

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -16,11 +16,11 @@ LOG_MODULE_DECLARE(net_shell);
 
 #include "net_shell_private.h"
 
-#include <../ip/icmpv6.h>
-#include <../ip/icmpv4.h>
-#include <../ip/route_ipv6.h>
-#include <../ip/route_ipv4.h>
-#include <../ip/route.h>
+#include <icmpv6.h>
+#include <icmpv4.h>
+#include <route_ipv6.h>
+#include <route_ipv4.h>
+#include <route.h>
 
 #if defined(CONFIG_NET_IP)
 

--- a/subsys/net/lib/shell/pmtu.c
+++ b/subsys/net/lib/shell/pmtu.c
@@ -9,7 +9,7 @@ LOG_MODULE_DECLARE(net_shell);
 
 #include "net_shell_private.h"
 
-#include "pmtu.h"
+#include <pmtu.h>
 
 #if !defined(CONFIG_NET_PMTU)
 static void print_pmtu_error(const struct shell *sh)

--- a/subsys/net/lib/shell/ppp.c
+++ b/subsys/net/lib/shell/ppp.c
@@ -13,7 +13,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include "net_shell_private.h"
 
 #if defined(CONFIG_NET_L2_PPP)
-#include "ppp/ppp_internal.h"
+#include <ppp/ppp_internal.h>
 #endif
 
 static int cmd_net_ppp_ping(const struct shell *sh, size_t argc, char *argv[])

--- a/subsys/net/lib/shell/ptp.c
+++ b/subsys/net/lib/shell/ptp.c
@@ -14,8 +14,8 @@ LOG_MODULE_DECLARE(net_shell);
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/drivers/ptp_clock.h>
-#include "ptp/clock.h"
-#include "ptp/port.h"
+#include <ptp/clock.h>
+#include <ptp/port.h>
 #endif
 
 #include "net_shell_private.h"

--- a/subsys/net/lib/shell/quic_shell.c
+++ b/subsys/net/lib/shell/quic_shell.c
@@ -17,7 +17,7 @@ LOG_MODULE_DECLARE(net_shell);
 #if defined(CONFIG_QUIC_SHELL)
 
 #include <zephyr/net/quic.h>
-#include "quic/quic_internal.h"
+#include <quic/quic_internal.h>
 
 static void quic_endpoint_cb(struct quic_endpoint *ep, void *user_data)
 {
@@ -292,7 +292,7 @@ static int cmd_net_quic(const struct shell *sh, size_t argc, char *argv[])
 }
 
 #if defined(CONFIG_NET_STATISTICS_QUIC) && defined(CONFIG_NET_STATISTICS_USER_API)
-#include "quic_stats.h"
+#include <quic_stats.h>
 
 static uint64_t quic_shell_uptime_ms(void)
 {

--- a/subsys/net/lib/shell/route.c
+++ b/subsys/net/lib/shell/route.c
@@ -10,13 +10,13 @@ LOG_MODULE_DECLARE(net_shell);
 
 #include "net_shell_private.h"
 
-#include "../ip/route_ipv6.h"
-#include "../ip/route_ipv4.h"
+#include <../ip/route_ipv6.h>
+#include <../ip/route_ipv4.h>
 
 #if defined(CONFIG_WIREGUARD)
 #include <zephyr/net/virtual.h>
 #include <zephyr/net/wireguard.h>
-#include "wg_internal.h"
+#include <wg_internal.h>
 #endif
 
 #if (defined(CONFIG_NET_NATIVE_IPV6) && defined(CONFIG_NET_IPV6_ROUTE)) || \
@@ -179,7 +179,7 @@ static int print_wireguard_route_status(const struct shell *sh,
 #endif /* CONFIG_WIREGUARD */
 
 #if defined(CONFIG_NET_ARP)
-#include "ethernet/arp.h"
+#include <ethernet/arp.h>
 
 static void arp_cb(struct arp_entry *entry, void *user_data)
 {

--- a/subsys/net/lib/shell/route.c
+++ b/subsys/net/lib/shell/route.c
@@ -10,8 +10,8 @@ LOG_MODULE_DECLARE(net_shell);
 
 #include "net_shell_private.h"
 
-#include <../ip/route_ipv6.h>
-#include <../ip/route_ipv4.h>
+#include <route_ipv6.h>
+#include <route_ipv4.h>
 
 #if defined(CONFIG_WIREGUARD)
 #include <zephyr/net/virtual.h>

--- a/subsys/net/lib/shell/ssh_shell.c
+++ b/subsys/net/lib/shell/ssh_shell.c
@@ -24,7 +24,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include "net_shell_private.h"
 
 #if defined(CONFIG_SSH)
-#include "ssh_transport.h"
+#include <ssh_transport.h>
 #endif
 
 #if defined(CONFIG_SSH_SHELL)

--- a/subsys/net/lib/shell/stats.c
+++ b/subsys/net/lib/shell/stats.c
@@ -16,7 +16,7 @@ LOG_MODULE_DECLARE(net_shell);
 
 #include "net_shell_private.h"
 
-#include "../ip/net_stats.h"
+#include <../ip/net_stats.h>
 
 enum net_shell_stats_format {
 	NET_SHELL_STATS_FORMAT_DEFAULT,

--- a/subsys/net/lib/shell/stats.c
+++ b/subsys/net/lib/shell/stats.c
@@ -16,7 +16,7 @@ LOG_MODULE_DECLARE(net_shell);
 
 #include "net_shell_private.h"
 
-#include <../ip/net_stats.h>
+#include <net_stats.h>
 
 enum net_shell_stats_format {
 	NET_SHELL_STATS_FORMAT_DEFAULT,

--- a/subsys/net/lib/shell/websocket.c
+++ b/subsys/net/lib/shell/websocket.c
@@ -18,7 +18,7 @@ LOG_MODULE_DECLARE(net_shell);
 
 #if defined(CONFIG_WEBSOCKET_CLIENT)
 
-#include "websocket/websocket_internal.h"
+#include <websocket/websocket_internal.h>
 
 static void websocket_context_cb(struct websocket_context *context,
 				 void *user_data)

--- a/subsys/net/lib/shell/wg_shell.c
+++ b/subsys/net/lib/shell/wg_shell.c
@@ -18,7 +18,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include "net_shell_private.h"
 
 #if defined(CONFIG_WIREGUARD)
-#include "wg_internal.h"
+#include <wg_internal.h>
 #endif
 
 #if defined(CONFIG_WIREGUARD_SHELL)

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -25,7 +25,7 @@ LOG_MODULE_DECLARE(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/sys/iterable_sections.h>
 
 #if defined(CONFIG_SOCKS)
-#include "socks.h"
+#include <socks.h>
 #endif
 
 #include <zephyr/net/igmp.h>

--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(net_sock_mgmt, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/net/ethernet_mgmt.h>
 
 #include "sockets_internal.h"
-#include "net_private.h"
+#include <net_private.h>
 
 #define MSG_ALLOC_TIMEOUT K_MSEC(100)
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -53,7 +53,7 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #endif /* CONFIG_MBEDTLS */
 
 #include "sockets_internal.h"
-#include "tls_internal.h"
+#include <tls_internal.h>
 #include "../../ip/net_private.h"
 
 #if defined(CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT)

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -33,8 +33,8 @@ LOG_MODULE_REGISTER(net_websocket, CONFIG_NET_WEBSOCKET_LOG_LEVEL);
 
 #include <psa/crypto.h>
 
-#include "net_private.h"
-#include "sockets_internal.h"
+#include <net_private.h>
+#include <sockets_internal.h>
 #include "websocket_internal.h"
 
 /* If you want to see the data that is being sent or received,

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_backend_psa.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_backend_psa.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/psa/key_ids.h>
-#include "psa/crypto.h"
+#include <psa/crypto.h>
 
 #include "wifi_credentials_internal.h"
 

--- a/subsys/net/lib/wireguard/ns_rtc.c
+++ b/subsys/net/lib/wireguard/ns_rtc.c
@@ -14,7 +14,7 @@ LOG_MODULE_DECLARE(wireguard, CONFIG_WIREGUARD_LOG_LEVEL);
 #include <zephyr/net/wireguard.h>
 #include <zephyr/net/net_log.h>
 
-#include "native_rtc.h"
+#include <native_rtc.h>
 
 int wireguard_get_current_time(uint64_t *seconds, uint32_t *nanoseconds)
 {

--- a/subsys/net/lib/wireguard/wg.c
+++ b/subsys/net/lib/wireguard/wg.c
@@ -28,11 +28,11 @@ LOG_MODULE_REGISTER(wireguard, CONFIG_WIREGUARD_LOG_LEVEL);
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_log.h>
 
-#include "net_private.h"
-#include "udp_internal.h"
-#include "ipv4.h"
-#include "ipv6.h"
-#include "net_stats.h"
+#include <net_private.h>
+#include <udp_internal.h>
+#include <ipv4.h>
+#include <ipv6.h>
+#include <net_stats.h>
 
 /* Constants */
 /* The UTF-8 string literal "Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s", 37 bytes of output */

--- a/subsys/net/lib/zperf/zperf_common.c
+++ b/subsys/net/lib/zperf/zperf_common.c
@@ -18,9 +18,9 @@ LOG_MODULE_REGISTER(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
  * that NET_LOG_ENABLED is set.
  */
 #define NET_LOG_ENABLED 1
-#include "net_private.h"
+#include <net_private.h>
 
-#include "ipv6.h" /* to get infinite lifetime */
+#include <ipv6.h> /* to get infinite lifetime */
 
 static struct net_sockaddr_in6 ipv6_addr_my = {
 	.sin6_family = NET_AF_INET6,

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -31,9 +31,9 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
  * that NET_LOG_ENABLED is set.
  */
 #define NET_LOG_ENABLED 1
-#include "net_private.h"
+#include <net_private.h>
 
-#include "ipv6.h" /* to get infinite lifetime */
+#include <ipv6.h> /* to get infinite lifetime */
 
 
 static const char *CONFIG =

--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -23,7 +23,7 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 
 /* To get net_sprint_ipv{4|6}_addr() */
 #define NET_LOG_ENABLED 1
-#include "net_private.h"
+#include <net_private.h>
 
 #define SOCK_ID_IPV4_LISTEN 0
 #define SOCK_ID_IPV6_LISTEN 1

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -23,10 +23,10 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 
 /* To get net_sprint_ipv{4|6}_addr() */
 #define NET_LOG_ENABLED 1
-#include "net_private.h"
+#include <net_private.h>
 
 /* To support multicast */
-#include "ipv6.h"
+#include <ipv6.h>
 #include <zephyr/net/igmp.h>
 
 static struct net_sockaddr_in6 *in6_addr_my;

--- a/subsys/net/pkt_filter/base.c
+++ b/subsys/net/pkt_filter/base.c
@@ -361,7 +361,7 @@ void npf_rules_foreach(npf_rule_cb_t cb, void *user_data)
 #endif /* CONFIG_NET_PKT_FILTER_IPV6_HOOK */
 }
 
-#include "net_private.h" /* for net_sprint_addr() */
+#include <net_private.h> /* for net_sprint_addr() */
 
 const char *npf_test_get_str(struct npf_test *test, char *buf, size_t len)
 {


### PR DESCRIPTION
Use #include <> instead of #include "" to include a header file which path is not relative to the directory path of the file emitting the #include directive.

This change was made running scripts/check_quoted_includes.py script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with the Linux shell command below and manually selecting the applicable changes:
$ find subsys/net/ -type f -exec \
    ./scripts/check_quoted_includes.py -w {} \;