### PR TITLE
pmci: use diamond include for non-local header files

### DIFF
--- a/subsys/pmci/mctp/mctp_i2c_gpio_controller.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_controller.c
@@ -5,9 +5,9 @@
  *
  */
 
-#include "zephyr/drivers/gpio.h"
-#include "zephyr/pmci/mctp/mctp_i2c_gpio_common.h"
-#include "zephyr/rtio/rtio.h"
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/pmci/mctp/mctp_i2c_gpio_common.h>
+#include <zephyr/rtio/rtio.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>

--- a/subsys/pmci/mctp/mctp_i2c_gpio_target.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_target.c
@@ -5,7 +5,7 @@
  *
  */
 
-#include "zephyr/pmci/mctp/mctp_i2c_gpio_common.h"
+#include <zephyr/pmci/mctp/mctp_i2c_gpio_common.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>

--- a/subsys/pmci/mctp/mctp_i3c_target.c
+++ b/subsys/pmci/mctp/mctp_i3c_target.c
@@ -5,7 +5,7 @@
  *
  */
 
-#include "zephyr/pmci/mctp/mctp_i3c_common.h"
+#include <zephyr/pmci/mctp/mctp_i3c_common.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>

--- a/subsys/pmci/mctp/mctp_usb.c
+++ b/subsys/pmci/mctp/mctp_usb.c
@@ -16,7 +16,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mctp_usb, CONFIG_MCTP_LOG_LEVEL);
 
-#include "libmctp-alloc.h"
+#include <libmctp-alloc.h>
 
 #define MCTP_USB_DMTF_0 0x1A
 #define MCTP_USB_DMTF_1 0xB4


### PR DESCRIPTION
Use #include <> instead of #include "" to include a header file which path is not relative to the directory path of the file emitting the #include directive.

This change was made running scripts/check_quoted_includes.py script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with the Linux shell command below and manually selecting the applicable changes:
$ find subsys/pmci/ -type f -exec \
    ./scripts/check_quoted_includes.py -w {} \;