### PR TITLE
portability: use diamond include for non-local header files

### DIFF
--- a/samples/subsys/portability/posix/philosophers/src/main.c
+++ b/samples/subsys/portability/posix/philosophers/src/main.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "posix_internal.h"
+#include <posix_internal.h>
 
 #include <pthread.h>
 #include <stdbool.h>

--- a/subsys/portability/posix/c_lib_ext/getopt_shim.c
+++ b/subsys/portability/posix/c_lib_ext/getopt_shim.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/sys/sys_getopt.h>
 
-#include "getopt.h"
+#include <getopt.h>
 
 char *optarg;
 int opterr, optind, optopt;

--- a/subsys/portability/posix/options/signal.c
+++ b/subsys/portability/posix/options/signal.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "posix/strsignal_table.h"
+#include <posix/strsignal_table.h>
 
 #include <errno.h>
 #include <signal.h>

--- a/tests/subsys/portability/posix/common/src/clock.c
+++ b/tests/subsys/portability/posix/common/src/clock.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "posix_clock.h"
+#include <posix_clock.h>
 
 #include <limits.h>
 #include <sys/time.h>

--- a/tests/subsys/portability/posix/timers/src/clock.c
+++ b/tests/subsys/portability/posix/timers/src/clock.c
@@ -6,7 +6,7 @@
  */
 
 /* for tp_ge(), tp_diff() */
-#include "posix_clock.h"
+#include <posix_clock.h>
 
 #include <sys/time.h>
 #include <time.h>

--- a/tests/subsys/portability/posix/xsi_single_process/src/gettimeofday.c
+++ b/tests/subsys/portability/posix/xsi_single_process/src/gettimeofday.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "posix_clock.h"
+#include <posix_clock.h>
 
 #include <sys/time.h>
 #include <time.h>


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Portability related paths and manually selecting the applicable changes:
```
$ find subsys/portability/ -type f -exec ./scripts/check_quoted_includes.py -w {} ;