### PR TITLE
settings: use diamond include for non-local header files

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 #include <zephyr/settings/settings.h>
-#include "settings/settings_fcb.h"
+#include <settings/settings_fcb.h>
 #include "settings_priv.h"
 
 #include <zephyr/logging/log.h>

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -12,7 +12,7 @@
 #include <zephyr/fs/fs.h>
 
 #include <zephyr/settings/settings.h>
-#include "settings/settings_file.h"
+#include <settings/settings_file.h>
 #include "settings_priv.h"
 
 #include <zephyr/logging/log.h>

--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -12,7 +12,7 @@
 #include <errno.h>
 
 #include <zephyr/settings/settings.h>
-#include "settings/settings_file.h"
+#include <settings/settings_file.h>
 #include <zephyr/kernel.h>
 #include "settings_priv.h"
 

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -9,7 +9,7 @@
 #include <string.h>
 
 #include <zephyr/settings/settings.h>
-#include "settings/settings_nvs.h"
+#include <settings/settings_nvs.h>
 #include <zephyr/sys/crc.h>
 #include "settings_priv.h"
 #include <zephyr/storage/flash_map.h>

--- a/subsys/settings/src/settings_zms.c
+++ b/subsys/settings/src/settings_zms.c
@@ -9,7 +9,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include "settings/settings_zms.h"
+#include <settings/settings_zms.h>
 #include "settings_priv.h"
 
 #include <zephyr/settings/settings.h>

--- a/tests/subsys/settings/fcb/src/settings_test_compress_deleted.c
+++ b/tests/subsys/settings/fcb/src/settings_test_compress_deleted.c
@@ -5,7 +5,7 @@
  */
 
 #include "settings_test.h"
-#include "settings/settings_fcb.h"
+#include <settings/settings_fcb.h>
 
 #define NAME_DELETABLE "4/deletable"
 

--- a/tests/subsys/settings/fcb/src/settings_test_compress_reset.c
+++ b/tests/subsys/settings/fcb/src/settings_test_compress_reset.c
@@ -6,7 +6,7 @@
  */
 
 #include "settings_test.h"
-#include "settings/settings_fcb.h"
+#include <settings/settings_fcb.h>
 
 ZTEST(settings_config_fcb, test_config_compress_reset)
 {

--- a/tests/subsys/settings/fcb/src/settings_test_delete_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_delete_fcb.c
@@ -5,7 +5,7 @@
  */
 
 #include "settings_test.h"
-#include "settings/settings_fcb.h"
+#include <settings/settings_fcb.h>
 
 ZTEST(settings_config_fcb, test_config_delete_fcb)
 {

--- a/tests/subsys/settings/fcb/src/settings_test_empty_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_empty_fcb.c
@@ -6,7 +6,7 @@
  */
 
 #include "settings_test.h"
-#include "settings/settings_fcb.h"
+#include <settings/settings_fcb.h>
 
 ZTEST(settings_config_fcb, test_config_empty_fcb)
 {

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -8,7 +8,7 @@
 #include <string.h>
 
 #include "settings_test.h"
-#include "settings_priv.h"
+#include <settings_priv.h>
 #include <zephyr/storage/flash_map.h>
 
 #define TEST_PARTITION		storage_partition

--- a/tests/subsys/settings/fcb/src/settings_test_save_1_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_1_fcb.c
@@ -6,7 +6,7 @@
  */
 
 #include "settings_test.h"
-#include "settings/settings_fcb.h"
+#include <settings/settings_fcb.h>
 
 ZTEST(settings_config_fcb, test_config_save_1_fcb)
 {

--- a/tests/subsys/settings/fcb/src/settings_test_save_2_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_2_fcb.c
@@ -6,7 +6,7 @@
  */
 
 #include "settings_test.h"
-#include "settings/settings_fcb.h"
+#include <settings/settings_fcb.h>
 
 #ifdef TEST_LONG
 #define TESTS_S2_FCB_ITERATIONS 32

--- a/tests/subsys/settings/fcb/src/settings_test_save_3_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_3_fcb.c
@@ -6,7 +6,7 @@
  */
 
 #include "settings_test.h"
-#include "settings/settings_fcb.h"
+#include <settings/settings_fcb.h>
 
 #ifdef TEST_LONG
 #define TESTS_S3_FCB_ITERATIONS 4096

--- a/tests/subsys/settings/fcb/src/settings_test_save_one_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_one_fcb.c
@@ -6,7 +6,7 @@
  */
 
 #include "settings_test.h"
-#include "settings/settings_fcb.h"
+#include <settings/settings_fcb.h>
 
 static int test_config_save_one_byte_value(const char *name, uint8_t val)
 {

--- a/tests/subsys/settings/fcb/src/settings_test_save_unaligned.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_unaligned.c
@@ -5,7 +5,7 @@
  */
 
 #include "settings_test.h"
-#include "settings/settings_fcb.h"
+#include <settings/settings_fcb.h>
 
 ZTEST(settings_config_fcb, test_config_save_fcb_unaligned)
 {

--- a/tests/subsys/settings/file/src/settings_setup_littlefs.c
+++ b/tests/subsys/settings/file/src/settings_setup_littlefs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
+#include <settings_test.h>
 #include <zephyr/device.h>
 #include <zephyr/fs/fs.h>
 #include <zephyr/fs/littlefs.h>

--- a/tests/subsys/settings/file/src/settings_test_compress_file.c
+++ b/tests/subsys/settings/file/src/settings_test_compress_file.c
@@ -7,8 +7,8 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include "settings_test.h"
-#include "settings/settings_file.h"
+#include <settings_test.h>
+#include <settings/settings_file.h>
 
 #define EXP_STR_CONTENT_1 "\x10\x00myfoo/mybar16=\x00\x01"\
 			  "\x0d\x00myfoo/mybar=\x14"\

--- a/tests/subsys/settings/file/src/settings_test_empty_file.c
+++ b/tests/subsys/settings/file/src/settings_test_empty_file.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
-#include "settings/settings_file.h"
+#include <settings_test.h>
+#include <settings/settings_file.h>
 #include <zephyr/fs/fs.h>
 
 ZTEST(settings_config_fs, test_config_empty_file)

--- a/tests/subsys/settings/file/src/settings_test_file.c
+++ b/tests/subsys/settings/file/src/settings_test_file.c
@@ -6,8 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "settings_test.h"
-#include "settings_priv.h"
+#include <settings_test.h>
+#include <settings_priv.h>
 
 
 uint8_t val8;

--- a/tests/subsys/settings/file/src/settings_test_fs.c
+++ b/tests/subsys/settings/file/src/settings_test_fs.c
@@ -6,9 +6,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "settings_test_file.h"
-#include "settings_test.h"
-#include "settings_priv.h"
+#include <settings_test_file.h>
+#include <settings_test.h>
+#include <settings_priv.h>
 
 ZTEST_SUITE(settings_config, NULL, settings_config_setup, NULL, NULL,
 	    settings_config_teardown);

--- a/tests/subsys/settings/file/src/settings_test_multiple_in_file.c
+++ b/tests/subsys/settings/file/src/settings_test_multiple_in_file.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
-#include "settings/settings_file.h"
+#include <settings_test.h>
+#include <settings/settings_file.h>
 
 #define CF_MFG_TEST1 "\x0d\x00myfoo/mybar=\x01"\
 		     "\x0d\x00myfoo/mybar=\x0e"

--- a/tests/subsys/settings/file/src/settings_test_save_in_file.c
+++ b/tests/subsys/settings/file/src/settings_test_save_in_file.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
-#include "settings/settings_file.h"
+#include <settings_test.h>
+#include <settings/settings_file.h>
 
 #define CF_FILE_CONTENT_1 "\x0d\x00myfoo/mybar=\x08"
 #define CF_FILE_CONTENT_2 "\x0d\x00myfoo/mybar=\x2b"

--- a/tests/subsys/settings/file/src/settings_test_save_one_file.c
+++ b/tests/subsys/settings/file/src/settings_test_save_one_file.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
-#include "settings/settings_file.h"
+#include <settings_test.h>
+#include <settings/settings_file.h>
 
 static int test_config_save_one_byte_value(const char *name, uint8_t val)
 {

--- a/tests/subsys/settings/file/src/settings_test_small_file.c
+++ b/tests/subsys/settings/file/src/settings_test_small_file.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
-#include "settings/settings_file.h"
+#include <settings_test.h>
+#include <settings/settings_file.h>
 
 #define CF_MFG_TEST_STR "\x0D\x00myfoo/mybar=\x01"
 #define CF_RUNNING_TEST_STR "\x0D\x00myfoo/mybar=\x08"

--- a/tests/subsys/settings/nvs/src/settings_test_nvs.c
+++ b/tests/subsys/settings/nvs/src/settings_test_nvs.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "settings_priv.h"
+#include <settings_priv.h>
 #include "settings_test.h"
 
 uint8_t val8;

--- a/tests/subsys/settings/performance/settings_test_perf.c
+++ b/tests/subsys/settings/performance/settings_test_perf.c
@@ -5,7 +5,7 @@
  */
 #include <stdlib.h>
 
-#include "settings_priv.h"
+#include <settings_priv.h>
 #include <zephyr/ztest.h>
 #include <zephyr/settings/settings.h>
 #include <zephyr/bluetooth/bluetooth.h>

--- a/tests/subsys/settings/retention/src/main.c
+++ b/tests/subsys/settings/retention/src/main.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "settings_priv.h"
+#include <settings_priv.h>
 #include "settings_test.h"
 
 uint8_t val8;

--- a/tests/subsys/settings/src/settings_empty_lookups.c
+++ b/tests/subsys/settings/src/settings_empty_lookups.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
+#include <settings_test.h>
 
 ZTEST(settings_config, test_config_empty_lookups)
 {

--- a/tests/subsys/settings/src/settings_test_commit.c
+++ b/tests/subsys/settings/src/settings_test_commit.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
+#include <settings_test.h>
 
 ZTEST(settings_config, test_config_commit)
 {

--- a/tests/subsys/settings/src/settings_test_getset_int.c
+++ b/tests/subsys/settings/src/settings_test_getset_int.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
+#include <settings_test.h>
 
 ZTEST(settings_config, test_config_getset_int)
 {

--- a/tests/subsys/settings/src/settings_test_getset_int64.c
+++ b/tests/subsys/settings/src/settings_test_getset_int64.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
+#include <settings_test.h>
 
 ZTEST(settings_config, test_config_getset_int64)
 {

--- a/tests/subsys/settings/src/settings_test_getset_unknown.c
+++ b/tests/subsys/settings/src/settings_test_getset_unknown.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
+#include <settings_test.h>
 #include <errno.h>
 
 ZTEST(settings_config, test_config_getset_unknown)

--- a/tests/subsys/settings/src/settings_test_insert.c
+++ b/tests/subsys/settings/src/settings_test_insert.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "settings_test.h"
+#include <settings_test.h>
 
 void test_config_insert_x(int idx)
 {

--- a/tests/subsys/settings/tfm_psa/src/settings_test_psa.c
+++ b/tests/subsys/settings/tfm_psa/src/settings_test_psa.c
@@ -8,7 +8,7 @@
 #include <string.h>
 
 #include "settings_test.h"
-#include "settings_priv.h"
+#include <settings_priv.h>
 
 uint8_t val8;
 uint8_t val8_un;

--- a/tests/subsys/settings/zms/src/settings_test_zms.c
+++ b/tests/subsys/settings/zms/src/settings_test_zms.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "settings_priv.h"
+#include <settings_priv.h>
 #include "settings_test.h"
 
 uint8_t val8;


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Settings related paths and manually selecting the applicable changes:
```
$ find subsys/settings/ -type f -exec ./scripts/check_quoted_includes.py -w {} ;