### PR TITLE
shell: use diamond include for non-local header files

### DIFF
--- a/subsys/shell/modules/kernel_service/thread/kill.c
+++ b/subsys/shell/modules/kernel_service/thread/kill.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel_shell.h"
+#include <kernel_shell.h>
 
 #include <kernel_internal.h>
 #include <zephyr/kernel.h>

--- a/subsys/shell/modules/kernel_service/thread/list.c
+++ b/subsys/shell/modules/kernel_service/thread/list.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel_shell.h"
+#include <kernel_shell.h>
 
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/kernel.h>

--- a/subsys/shell/modules/kernel_service/thread/mask.c
+++ b/subsys/shell/modules/kernel_service/thread/mask.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel_shell.h"
+#include <kernel_shell.h>
 
 #include <zephyr/kernel.h>
 

--- a/subsys/shell/modules/kernel_service/thread/pin.c
+++ b/subsys/shell/modules/kernel_service/thread/pin.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel_shell.h"
+#include <kernel_shell.h>
 
 #include <zephyr/kernel.h>
 

--- a/subsys/shell/modules/kernel_service/thread/resume.c
+++ b/subsys/shell/modules/kernel_service/thread/resume.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel_shell.h"
+#include <kernel_shell.h>
 
 #include <kernel_internal.h>
 #include <zephyr/kernel.h>

--- a/subsys/shell/modules/kernel_service/thread/stacks.c
+++ b/subsys/shell/modules/kernel_service/thread/stacks.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel_shell.h"
+#include <kernel_shell.h>
 
 #include <string.h>
 

--- a/subsys/shell/modules/kernel_service/thread/suspend.c
+++ b/subsys/shell/modules/kernel_service/thread/suspend.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel_shell.h"
+#include <kernel_shell.h>
 
 #include <kernel_internal.h>
 #include <zephyr/kernel.h>

--- a/subsys/shell/modules/kernel_service/thread/thread.c
+++ b/subsys/shell/modules/kernel_service/thread/thread.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel_shell.h"
+#include <kernel_shell.h>
 
 #include <kernel_internal.h>
 

--- a/subsys/shell/modules/kernel_service/thread/unwind.c
+++ b/subsys/shell/modules/kernel_service/thread/unwind.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel_shell.h"
+#include <kernel_shell.h>
 
 #include <zephyr/debug/symtab.h>
 #include <zephyr/kernel.h>

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -57,7 +57,7 @@ const struct shell_alias shell_aliases[] = {
 	{ "?", "help" },
 
 #if defined(CONFIG_SHELL_ALIASES_HAS_FILE)
-#include "generated-shell-aliases.inc"
+#include <generated-shell-aliases.inc>
 #endif
 	/* NULL is used to mark the end of the array */
 	{ NULL, NULL }

--- a/subsys/shell/shell_remote.c
+++ b/subsys/shell/shell_remote.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/sys/__assert.h"
+#include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log.h>
 #include <stdlib.h>
 #include <zephyr/shell/shell_remote_common.h>

--- a/tests/subsys/shell/shell_remote/src/main.c
+++ b/tests/subsys/shell/shell_remote/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/tc_util.h"
+#include <zephyr/tc_util.h>
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <zephyr/shell/shell.h>


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Shell related paths and manually selecting the applicable changes:
```
$ find subsys/shell/ -type f -exec ./scripts/check_quoted_includes.py -w {} ;