### PR TITLE
testsuite: use diamond include for non-local header files

### DIFF
--- a/subsys/testsuite/include/zephyr/tc_util.h
+++ b/subsys/testsuite/include/zephyr/tc_util.h
@@ -26,7 +26,7 @@
 #endif
 
 #if defined CONFIG_ARCH_POSIX
-#include "posix_board_if.h"
+#include <posix_board_if.h>
 #endif
 
 /**

--- a/subsys/testsuite/ztest/src/ztest_posix.c
+++ b/subsys/testsuite/ztest/src/ztest_posix.c
@@ -6,11 +6,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "cmdline.h" /* native_sim command line options header */
-#include "soc.h"
+#include <cmdline.h> /* native_sim command line options header */
+#include <soc.h>
 #include <zephyr/tc_util.h>
 #include <zephyr/ztest_test.h>
-#include "nsi_host_trampolines.h"
+#include <nsi_host_trampolines.h>
 #include <nsi_tracing.h>
 
 static const char *test_args;


### PR DESCRIPTION
Use #include <> instead of #include "" to include a header file which path is not relative to the directory path of the file emitting the #include directive.

This change was made running scripts/check_quoted_includes.py script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with the Linux shell command below and manually selecting the applicable changes:
$ find subsys/testsuite/ -type f -exec \
    ./scripts/check_quoted_includes.py -w {} \;