### PR TITLE
tracing: use diamond include for non-local header files

### DIFF
--- a/subsys/tracing/tracing_backend_posix_bottom.c
+++ b/subsys/tracing/tracing_backend_posix_bottom.c
@@ -6,7 +6,7 @@
  */
 
 #include <stdio.h>
-#include "nsi_tracing.h"
+#include <nsi_tracing.h>
 
 void *tracing_backend_posix_init_bottom(const char *file_name)
 {

--- a/tests/subsys/tracing/tracing_api/src/main.c
+++ b/tests/subsys/tracing/tracing_api/src/main.c
@@ -10,8 +10,9 @@
 #include <tracing_buffer.h>
 #include <tracing_core.h>
 #include <zephyr/tracing/tracing_format.h>
+
 #if defined(CONFIG_TRACING_BACKEND_UART)
-#include "../../../../subsys/tracing/include/tracing_backend.h"
+#include "../../../../../subsys/tracing/include/tracing_backend.h"
 #endif
 
 /**


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various tracing related paths and manually selecting the applicable changes:
```
$ find subsys/tracing/ -type f -exec ./scripts/check_quoted_includes.py -w {} ;