### PR TITLE
usb: use diamond include for non-local header files

### DIFF
--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -12,20 +12,20 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/pinctrl.h>
-#include "usb.h"
-#include "usb_device.h"
-#include "usb_device_config.h"
-#include "usb_device_dci.h"
+#include <usb.h>
+#include <usb_device.h>
+#include <usb_device_config.h>
+#include <usb_device_dci.h>
 
 #ifdef CONFIG_USB_DC_NXP_EHCI
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT nxp_ehci
-#include "usb_device_ehci.h"
+#include <usb_device_ehci.h>
 #endif
 #ifdef CONFIG_USB_DC_NXP_LPCIP3511
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT nxp_lpcip3511
-#include "usb_device_lpcip3511.h"
+#include <usb_device_lpcip3511.h>
 #endif
 #ifdef CONFIG_HAS_MCUX_CACHE
 #include <fsl_cache.h>

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -25,7 +25,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
-#include "stm32_hsem.h"
+#include <stm32_hsem.h>
 
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -19,11 +19,11 @@
 #include <zephyr/drivers/clock_control.h>
 
 #include "udc_common.h"
-#include "usb.h"
-#include "usb_device_config.h"
-#include "usb_device_mcux_drv_port.h"
-#include "usb_device_ehci.h"
-#include "usb_phy.h"
+#include <usb.h>
+#include <usb_device_config.h>
+#include <usb_device_mcux_drv_port.h>
+#include <usb_device_ehci.h>
+#include <usb_phy.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(udc_mcux, CONFIG_UDC_DRIVER_LOG_LEVEL);

--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -16,11 +16,11 @@
 #include <zephyr/drivers/pinctrl.h>
 
 #include "udc_common.h"
-#include "usb.h"
-#include "usb_device_config.h"
-#include "usb_device_mcux_drv_port.h"
-#include "usb_device_lpcip3511.h"
-#include "usb_phy.h"
+#include <usb.h>
+#include <usb_device_config.h>
+#include <usb_device_mcux_drv_port.h>
+#include <usb_device_lpcip3511.h>
+#include <usb_phy.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(udc_mcux, CONFIG_UDC_DRIVER_LOG_LEVEL);

--- a/drivers/usb/udc/udc_renesas_ra.c
+++ b/drivers/usb/udc/udc_renesas_ra.c
@@ -10,7 +10,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 #include <zephyr/drivers/usb/udc.h>
-#include "r_usb_device.h"
+#include <r_usb_device.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(udc_renesas_ra, CONFIG_UDC_DRIVER_LOG_LEVEL);

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -14,9 +14,9 @@
 #include <zephyr/drivers/usb/uhc.h>
 
 #include "uhc_common.h"
-#include "usb.h"
-#include "usb_host_config.h"
-#include "usb_host_mcux_drv_port.h"
+#include <usb.h>
+#include <usb_host_config.h>
+#include <usb_host_mcux_drv_port.h>
 #include "uhc_mcux_common.h"
 
 #include <zephyr/logging/log.h>

--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -18,12 +18,12 @@
 #include <zephyr/drivers/clock_control.h>
 
 #include "uhc_common.h"
-#include "usb.h"
-#include "usb_host_config.h"
-#include "usb_host_mcux_drv_port.h"
+#include <usb.h>
+#include <usb_host_config.h>
+#include <usb_host_mcux_drv_port.h>
 #include "uhc_mcux_common.h"
-#include "usb_host_ehci.h"
-#include "usb_phy.h"
+#include <usb_host_ehci.h>
+#include <usb_phy.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(uhc_mcux);

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -17,12 +17,12 @@
 #include <zephyr/drivers/pinctrl.h>
 
 #include "uhc_common.h"
-#include "usb.h"
-#include "usb_host_config.h"
-#include "usb_host_mcux_drv_port.h"
+#include <usb.h>
+#include <usb_host_config.h>
+#include <usb_host_mcux_drv_port.h>
 #include "uhc_mcux_common.h"
-#include "usb_host_ip3516hs.h"
-#include "usb_phy.h"
+#include <usb_host_ip3516hs.h>
+#include <usb_phy.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(uhc_mcux);

--- a/drivers/usb/uhc/uhc_mcux_khci.c
+++ b/drivers/usb/uhc/uhc_mcux_khci.c
@@ -17,11 +17,11 @@
 #include <zephyr/drivers/pinctrl.h>
 
 #include "uhc_common.h"
-#include "usb.h"
-#include "usb_host_config.h"
-#include "usb_host_mcux_drv_port.h"
+#include <usb.h>
+#include <usb_host_config.h>
+#include <usb_host_mcux_drv_port.h>
 #include "uhc_mcux_common.h"
-#include "usb_host_khci.h"
+#include <usb_host_khci.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(uhc_mcux);

--- a/drivers/usb/uhc/uhc_mcux_ohci.c
+++ b/drivers/usb/uhc/uhc_mcux_ohci.c
@@ -17,11 +17,11 @@
 #include <zephyr/drivers/pinctrl.h>
 
 #include "uhc_common.h"
-#include "usb.h"
-#include "usb_host_config.h"
-#include "usb_host_mcux_drv_port.h"
+#include <usb.h>
+#include <usb_host_config.h>
+#include <usb_host_mcux_drv_port.h>
 #include "uhc_mcux_common.h"
-#include "usb_host_ohci.h"
+#include <usb_host_ohci.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(uhc_mcux);

--- a/samples/subsys/usb_c/drp/src/main.c
+++ b/samples/subsys/usb_c/drp/src/main.c
@@ -13,7 +13,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
-#include "power_ctrl.h"
+#include <power_ctrl.h>
 
 #define USBC_PORT0_NODE         DT_ALIAS(usbc_port0)
 #define USBC_PORT0_PWRCTRL_NODE DT_ALIAS(usbc_port0_pwrctrl)

--- a/samples/subsys/usb_c/source/src/main.c
+++ b/samples/subsys/usb_c/source/src/main.c
@@ -12,7 +12,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
-#include "power_ctrl.h"
+#include <power_ctrl.h>
 
 #define USBC_PORT0_NODE         DT_ALIAS(usbc_port0)
 #define USBC_PORT0_PWRCTRL_NODE DT_ALIAS(usbc_port0_pwrctrl)

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -19,7 +19,7 @@
 
 #include <zephyr/drivers/usb/udc.h>
 
-#include "usbd_msg.h"
+#include <usbd_msg.h>
 
 #include <zephyr/logging/log.h>
 /* Prevent endless recursive logging loop and warn user about it */

--- a/subsys/usb/device_next/class/usbd_dfu.c
+++ b/subsys/usb/device_next/class/usbd_dfu.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "usbd_msg.h"
+#include <usbd_msg.h>
 
 #include <zephyr/init.h>
 #include <zephyr/usb/usbd.h>

--- a/subsys/usb/device_next/class/usbd_dfu_flash.c
+++ b/subsys/usb/device_next/class/usbd_dfu_flash.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "usbd_msg.h"
+#include <usbd_msg.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/usb/usbd.h>

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -23,7 +23,8 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/usb/class/usbd_uvc.h>
 
-#include "uvc.h"
+#include <uvc.h>
+
 #include "../../../../drivers/video/video_common.h"
 
 LOG_MODULE_REGISTER(usbd_uvc, CONFIG_USBD_VIDEO_LOG_LEVEL);

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -19,12 +19,13 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 
-#include "usbh_ch9.h"
-#include "usbh_class.h"
-#include "usbh_desc.h"
-#include "usbh_device.h"
+#include <usbh_ch9.h>
+#include <usbh_class.h>
+#include <usbh_desc.h>
+#include <usbh_device.h>
 
-#include "uvc.h"
+#include <uvc.h>
+
 #include "../../../../drivers/video/video_common.h"
 
 LOG_MODULE_REGISTER(usbh_uvc, CONFIG_USBH_UVC_LOG_LEVEL);

--- a/tests/subsys/usb/device_next/src/main.c
+++ b/tests/subsys/usb/device_next/src/main.c
@@ -8,8 +8,8 @@
 #include <zephyr/usb/usbd.h>
 #include <zephyr/usb/usbh.h>
 
-#include "usbh_ch9.h"
-#include "usbh_device.h"
+#include <usbh_ch9.h>
+#include <usbh_device.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(usb_test, LOG_LEVEL_INF);

--- a/tests/subsys/usb/host/src/class.c
+++ b/tests/subsys/usb/host/src/class.c
@@ -7,14 +7,14 @@
 #include <zephyr/usb/usbh.h>
 #include <zephyr/logging/log.h>
 
-#include "usbh_ch9.h"
-#include "usbh_class.h"
-#include "usbh_class_api.h"
-#include "usbh_desc.h"
-#include "usbh_device.h"
-#include "usbh_host.h"
+#include <usbh_ch9.h>
+#include <usbh_class.h>
+#include <usbh_class_api.h>
+#include <usbh_desc.h>
+#include <usbh_device.h>
+#include <usbh_host.h>
 
-#include "usbh_test_common.h"
+#include <usbh_test_common.h>
 
 LOG_MODULE_REGISTER(test_class, LOG_LEVEL_DBG);
 

--- a/tests/subsys/usb/host/src/main.c
+++ b/tests/subsys/usb/host/src/main.c
@@ -9,15 +9,15 @@
 #include <zephyr/logging/log.h>
 #include <sample_usbd.h>
 
-#include "usbh_ch9.h"
-#include "usbh_class.h"
-#include "usbh_class_api.h"
-#include "usbh_desc.h"
-#include "usbh_device.h"
-#include "usbh_device.h"
-#include "usbh_host.h"
+#include <usbh_ch9.h>
+#include <usbh_class.h>
+#include <usbh_class_api.h>
+#include <usbh_desc.h>
+#include <usbh_device.h>
+#include <usbh_device.h>
+#include <usbh_host.h>
 
-#include "usbh_test_common.h"
+#include <usbh_test_common.h>
 
 LOG_MODULE_REGISTER(usbh_test, LOG_LEVEL_INF);
 


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various USB related paths and manually selecting the applicable changes:
```
$ find subsys/usb/ -type f -exec ./scripts/check_quoted_includes.py -w {} ;