### PR TITLE
bluetooth: use diamond include for non-local header files

### DIFF
--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -32,7 +32,7 @@
 #include <zephyr/types.h>
 
 #include "aics_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 LOG_MODULE_REGISTER(bt_aics_client, CONFIG_BT_AICS_CLIENT_LOG_LEVEL);
 

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -39,8 +39,8 @@
 
 LOG_MODULE_REGISTER(bt_ascs, CONFIG_BT_ASCS_LOG_LEVEL);
 
-#include "common/assert.h"
-#include "common/bt_str.h"
+#include <common/assert.h>
+#include <common/bt_str.h>
 
 #include "../host/att_internal.h"
 

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -46,7 +46,7 @@
 
 LOG_MODULE_REGISTER(bt_bap_broadcast_assistant, CONFIG_BT_BAP_BROADCAST_ASSISTANT_LOG_LEVEL);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "audio_internal.h"
 #include "bap_internal.h"

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -47,7 +47,7 @@
 
 LOG_MODULE_REGISTER(bt_bap_broadcast_sink, CONFIG_BT_BAP_BROADCAST_SINK_LOG_LEVEL);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define BROADCAST_SYNC_MIN_INDEX          (BIT(1U))

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -47,7 +47,7 @@ LOG_MODULE_REGISTER(bt_bap_scan_delegator, CONFIG_BT_BAP_SCAN_DELEGATOR_LOG_LEVE
 	 Use the CONFIG_LOG_MODE_DEFERRED Kconfig option when this feature is enabled.
 #endif
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "audio_internal.h"
 #include "bap_internal.h"

--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -37,7 +37,7 @@
 
 LOG_MODULE_REGISTER(bt_cap_commander, CONFIG_BT_CAP_COMMANDER_LOG_LEVEL);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 static void cap_commander_proc_complete(struct bt_cap_common_proc *active_proc);
 

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -32,7 +32,7 @@
 
 LOG_MODULE_REGISTER(bt_cap_common, CONFIG_BT_CAP_COMMON_LOG_LEVEL);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 static struct bt_cap_common_client bt_cap_common_clients[CONFIG_BT_MAX_CONN];
 static const struct bt_uuid *cas_uuid = BT_UUID_CAS;

--- a/subsys/bluetooth/audio/cap_handover.c
+++ b/subsys/bluetooth/audio/cap_handover.c
@@ -27,7 +27,7 @@
 
 #include "bap_endpoint.h"
 #include "cap_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "csip_internal.h"
 
 LOG_MODULE_REGISTER(bt_cap_handover, CONFIG_BT_CAP_HANDOVER_LOG_LEVEL);

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -43,7 +43,7 @@
 
 LOG_MODULE_REGISTER(bt_cap_initiator, CONFIG_BT_CAP_INITIATOR_LOG_LEVEL);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 static const struct bt_cap_initiator_cb *cap_cb;
 

--- a/subsys/bluetooth/audio/csip_crypto.c
+++ b/subsys/bluetooth/audio/csip_crypto.c
@@ -21,9 +21,9 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "crypto/bt_crypto.h"
+#include <crypto/bt_crypto.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "csip_crypto.h"
 

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -49,11 +49,11 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "csip_crypto.h"
 #include "csip_internal.h"
-#include "host/conn_internal.h"
-#include "host/keys.h"
+#include <host/conn_internal.h>
+#include <host/keys.h>
 
 LOG_MODULE_REGISTER(bt_csip_set_coordinator, CONFIG_BT_CSIP_SET_COORDINATOR_LOG_LEVEL);
 

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -43,8 +43,8 @@
 #include "../host/keys.h"
 #include "../host/settings.h"
 
-#include "common/bt_settings_commit.h"
-#include "common/bt_str.h"
+#include <common/bt_settings_commit.h>
+#include <common/bt_str.h>
 #include "audio_internal.h"
 #include "csip_internal.h"
 #include "csip_crypto.h"

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -35,10 +35,10 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
 
-#include "../bluetooth/host/settings.h"
+#include <../bluetooth/host/settings.h>
 
 #include "audio_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "has_internal.h"
 
 LOG_MODULE_REGISTER(bt_has, CONFIG_BT_HAS_LOG_LEVEL);

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -37,7 +37,7 @@
 #include <zephyr/types.h>
 
 #include "../services/ots/ots_client_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "mcc_internal.h"
 #include "mcs_internal.h"
 

--- a/subsys/bluetooth/audio/mcs.c
+++ b/subsys/bluetooth/audio/mcs.c
@@ -37,7 +37,7 @@
 #include <zephyr/types.h>
 
 #include "audio_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "media_proxy_internal.h"
 #include "mcs_internal.h"
 

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -32,7 +32,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "micp_internal.h"
 
 LOG_MODULE_REGISTER(bt_micp_mic_ctlr, CONFIG_BT_MICP_MIC_CTLR_LOG_LEVEL);

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -38,7 +38,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "audio_internal.h"
 #include "bap_unicast_server.h"

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -38,8 +38,8 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 #define SHELL_PRINT_INDENT_LEVEL_SIZE 2U
 #define MAX_CODEC_FRAMES_PER_SDU      4U
@@ -66,7 +66,7 @@ size_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_a
 #include <zephyr/bluetooth/audio/cap.h>
 
 #if defined(CONFIG_LIBLC3)
-#include "lc3.h"
+#include <lc3.h>
 
 #define USB_SAMPLE_RATE            48000U
 #define LC3_MAX_SAMPLE_RATE        48000U

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -55,8 +55,8 @@
 #include <zephyr/toolchain.h>
 
 #include "audio.h"
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 /* Determines if we can initiate streaming */
 #define IS_BAP_INITIATOR                                                                           \
@@ -292,7 +292,7 @@ uint16_t get_next_seq_num(struct bt_bap_stream *bap_stream)
 NET_BUF_POOL_FIXED_DEFINE(sine_tx_pool, CONFIG_BT_ISO_TX_BUF_COUNT, SINE_TX_POOL_SIZE,
 			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
-#include "math.h"
+#include <math.h>
 
 #define AUDIO_VOLUME            (INT16_MAX - 3000) /* codec does clipping above INT16_MAX - 3000 */
 #define AUDIO_TONE_FREQUENCY_HZ   400U

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -38,9 +38,9 @@
 #include <zephyr/types.h>
 
 #include "audio.h"
-#include "common/bt_shell_private.h"
-#include "host/hci_core.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/hci_core.h>
+#include <host/shell/bt.h>
 
 static uint8_t received_base[UINT8_MAX];
 static size_t received_base_size;

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -35,9 +35,9 @@
 
 #include <audio/bap_internal.h>
 #include "audio.h"
-#include "common/bt_shell_private.h"
-#include "common/bt_str.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <common/bt_str.h>
+#include <host/shell/bt.h>
 
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define PA_SYNC_SKIP              5U

--- a/subsys/bluetooth/audio/shell/cap_acceptor.c
+++ b/subsys/bluetooth/audio/shell/cap_acceptor.c
@@ -30,8 +30,8 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 static size_t ad_cap_announcement_data_add(struct bt_data data[], size_t data_size)
 {

--- a/subsys/bluetooth/audio/shell/cap_commander.c
+++ b/subsys/bluetooth/audio/shell/cap_commander.c
@@ -28,8 +28,8 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 #include "audio.h"
 
 static void cap_discover_cb(struct bt_conn *conn, int err,

--- a/subsys/bluetooth/audio/shell/cap_handover.c
+++ b/subsys/bluetooth/audio/shell/cap_handover.c
@@ -35,8 +35,8 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/audio/cap.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 #include "audio.h"
 
 static void unicast_to_broadcast_created_cb(struct bt_cap_broadcast_source *broadcast_source)

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -38,8 +38,8 @@
 #include <zephyr/types.h>
 
 #include "audio.h"
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 #define UNICAST_SINK_SUPPORTED (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0)

--- a/subsys/bluetooth/audio/shell/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/shell/ccp_call_control_client.c
@@ -21,8 +21,8 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 static struct bt_ccp_call_control_client *clients[CONFIG_BT_MAX_CONN];
 

--- a/subsys/bluetooth/audio/shell/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/shell/ccp_call_control_server.c
@@ -20,7 +20,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "audio/tbs_internal.h"
+#include <audio/tbs_internal.h>
 
 static struct bt_ccp_call_control_server_bearer
 	*bearers[CONFIG_BT_CCP_CALL_CONTROL_SERVER_BEARER_COUNT];

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -31,8 +31,8 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 static uint8_t members_found;
 static struct k_work_delayable discover_members_timer;

--- a/subsys/bluetooth/audio/shell/csip_set_member.c
+++ b/subsys/bluetooth/audio/shell/csip_set_member.c
@@ -32,8 +32,8 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 struct bt_csip_set_member_svc_inst *svc_inst;
 static uint8_t sirk_read_rsp = BT_CSIP_READ_SIRK_REQ_RSP_ACCEPT;

--- a/subsys/bluetooth/audio/shell/gmap.c
+++ b/subsys/bluetooth/audio/shell/gmap.c
@@ -35,8 +35,8 @@
 #include <zephyr/toolchain.h>
 
 #include "audio.h"
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 #define UNICAST_SINK_SUPPORTED (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0)
 #define UNICAST_SRC_SUPPORTED  (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0)

--- a/subsys/bluetooth/audio/shell/has.c
+++ b/subsys/bluetooth/audio/shell/has.c
@@ -22,7 +22,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 
 static int preset_select(uint8_t index, bool sync)
 {

--- a/subsys/bluetooth/audio/shell/has_client.c
+++ b/subsys/bluetooth/audio/shell/has_client.c
@@ -21,8 +21,8 @@
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/toolchain.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static struct bt_has *inst;
 

--- a/subsys/bluetooth/audio/shell/mcc.c
+++ b/subsys/bluetooth/audio/shell/mcc.c
@@ -29,8 +29,8 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #include "../media_proxy_internal.h"
 

--- a/subsys/bluetooth/audio/shell/media_controller.c
+++ b/subsys/bluetooth/audio/shell/media_controller.c
@@ -29,8 +29,8 @@
 
 #include "../media_proxy_internal.h" /* For MPL_NO_TRACK_ID - TODO: Fix */
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 LOG_MODULE_REGISTER(bt_media_controller_shell, CONFIG_BT_MCS_LOG_LEVEL);
 

--- a/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
@@ -22,8 +22,8 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static struct bt_micp_mic_ctlr *micp_mic_ctlr;
 #if defined(CONFIG_BT_MICP_MIC_CTLR_AICS)

--- a/subsys/bluetooth/audio/shell/micp_mic_dev.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_dev.c
@@ -24,7 +24,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 
 static void micp_mic_dev_mute_cb(uint8_t mute)
 {

--- a/subsys/bluetooth/audio/shell/pbp.c
+++ b/subsys/bluetooth/audio/shell/pbp.c
@@ -26,7 +26,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 
 #define PBS_DEMO                'P', 'B', 'P'
 

--- a/subsys/bluetooth/audio/shell/tbs.c
+++ b/subsys/bluetooth/audio/shell/tbs.c
@@ -26,7 +26,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "host/shell/bt.h"
+#include <host/shell/bt.h>
 
 static struct bt_conn *tbs_authorized_conn;
 

--- a/subsys/bluetooth/audio/shell/tbs_client.c
+++ b/subsys/bluetooth/audio/shell/tbs_client.c
@@ -26,7 +26,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "host/shell/bt.h"
+#include <host/shell/bt.h>
 
 static int cmd_tbs_client_discover(const struct shell *sh, size_t argc,
 				   char *argv[])

--- a/subsys/bluetooth/audio/shell/tmap.c
+++ b/subsys/bluetooth/audio/shell/tmap.c
@@ -21,8 +21,8 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static int cmd_tmap_init(const struct shell *sh, size_t argc, char **argv)
 {

--- a/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
@@ -23,8 +23,8 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static struct bt_vcp_vol_ctlr *vcp_vol_ctlr;
 static struct bt_vcp_included vcp_included;

--- a/subsys/bluetooth/audio/shell/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_rend.c
@@ -25,8 +25,8 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static struct bt_vcp_included vcp_included;
 

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -39,7 +39,7 @@
 
 #include "audio_internal.h"
 #include "tbs_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 LOG_MODULE_REGISTER(bt_tbs, CONFIG_BT_TBS_LOG_LEVEL);
 

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -33,7 +33,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "tbs_internal.h"
 
 LOG_MODULE_REGISTER(bt_tbs_client, CONFIG_BT_TBS_CLIENT_LOG_LEVEL);

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -33,7 +33,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "vcp_internal.h"
 
 LOG_MODULE_REGISTER(bt_vcp_vol_ctlr, CONFIG_BT_VCP_VOL_CTLR_LOG_LEVEL);

--- a/subsys/bluetooth/common/rpa.c
+++ b/subsys/bluetooth/common/rpa.c
@@ -15,7 +15,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include <zephyr/bluetooth/crypto.h>
 

--- a/subsys/bluetooth/controller/coex/coex_ticker.c
+++ b/subsys/bluetooth/controller/coex/coex_ticker.c
@@ -16,10 +16,10 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "controller/hal/ticker.h"
-#include "controller/ticker/ticker.h"
-#include "controller/include/ll.h"
-#include "controller/ll_sw/nordic/hal/nrf5/debug.h"
+#include <controller/hal/ticker.h>
+#include <controller/ticker/ticker.h>
+#include <controller/include/ll.h>
+#include <controller/ll_sw/nordic/hal/nrf5/debug.h>
 
 LOG_MODULE_REGISTER(coex_ticker);
 

--- a/subsys/bluetooth/controller/crypto/crypto.c
+++ b/subsys/bluetooth/controller/crypto/crypto.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "hal/ecb.h"
-#include "ll_sw/lll.h"
+#include <hal/ecb.h>
+#include <ll_sw/lll.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/flash/soc_flash_nrf_ticker.c
+++ b/subsys/bluetooth/controller/flash/soc_flash_nrf_ticker.c
@@ -13,11 +13,11 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ticker.h"
-#include "ticker/ticker.h"
-#include "ll.h"
+#include <hal/ticker.h>
+#include <ticker/ticker.h>
+#include <ll.h>
 
-#include "soc_flash_nrf.h"
+#include <soc_flash_nrf.h>
 
 #define FLASH_RADIO_ABORT_DELAY_US 1500
 #define FLASH_RADIO_WORK_DELAY_US  200

--- a/subsys/bluetooth/controller/hal/cntr.h
+++ b/subsys/bluetooth/controller/hal/cntr.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/cntr_vendor_hal.h"
+#include <hal/cntr_vendor_hal.h>
 
 void cntr_init(void);
 uint32_t cntr_start(void);

--- a/subsys/bluetooth/controller/hal/cpu.h
+++ b/subsys/bluetooth/controller/hal/cpu.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/cpu_vendor_hal.h"
+#include <hal/cpu_vendor_hal.h>

--- a/subsys/bluetooth/controller/hal/debug.h
+++ b/subsys/bluetooth/controller/hal/debug.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #if defined(CONFIG_BT_CTLR_ASSERT_HANDLER)
 void bt_ctlr_assert_handle(char *file, uint32_t line);
@@ -101,4 +101,4 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_CPU_CORTEX_M));
 #define LL_ASSERT_OVERHEAD(overhead) ARG_UNUSED(overhead)
 #endif /* !CONFIG_BT_CTLR_ASSERT_OVERHEAD_START */
 
-#include "hal/debug_vendor_hal.h"
+#include <hal/debug_vendor_hal.h>

--- a/subsys/bluetooth/controller/hal/radio.h
+++ b/subsys/bluetooth/controller/hal/radio.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/radio_vendor_hal.h"
+#include <hal/radio_vendor_hal.h>

--- a/subsys/bluetooth/controller/hal/radio_df.h
+++ b/subsys/bluetooth/controller/hal/radio_df.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/radio_df_vendor_hal.h"
+#include <hal/radio_df_vendor_hal.h>

--- a/subsys/bluetooth/controller/hal/swi.h
+++ b/subsys/bluetooth/controller/hal/swi.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/swi_vendor_hal.h"
+#include <hal/swi_vendor_hal.h>

--- a/subsys/bluetooth/controller/hal/ticker.h
+++ b/subsys/bluetooth/controller/hal/ticker.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/ticker_vendor_hal.h"
+#include <hal/ticker_vendor_hal.h>
 
 uint8_t hal_ticker_instance0_caller_id_get(uint8_t user_id);
 void hal_ticker_instance0_sched(uint8_t caller_id, uint8_t callee_id, uint8_t chain,

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -21,78 +21,78 @@
 #include <zephyr/bluetooth/hci_vs.h>
 #include <zephyr/bluetooth/buf.h>
 
-#include "common/hci_common_internal.h"
+#include <common/hci_common_internal.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/dbuf.h>
 
-#include "hal/ecb.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/ecb.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "ll_sw/pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "ll_sw/pdu.h"
+#include <ll_sw/pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <ll_sw/pdu.h>
 
-#include "ll_sw/lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
-#include "ll_sw/lll_adv.h"
-#include "lll/lll_adv_pdu.h"
-#include "ll_sw/lll_scan.h"
-#include "lll/lll_df_types.h"
-#include "ll_sw/lll_sync.h"
-#include "ll_sw/lll_sync_iso.h"
-#include "ll_sw/lll_conn.h"
-#include "ll_sw/lll_conn_iso.h"
-#include "ll_sw/lll_iso_tx.h"
+#include <ll_sw/lll.h>
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
+#include <ll_sw/lll_adv.h>
+#include <lll/lll_adv_pdu.h>
+#include <ll_sw/lll_scan.h>
+#include <lll/lll_df_types.h>
+#include <ll_sw/lll_sync.h>
+#include <ll_sw/lll_sync_iso.h>
+#include <ll_sw/lll_conn.h>
+#include <ll_sw/lll_conn_iso.h>
+#include <ll_sw/lll_iso_tx.h>
 
-#include "ll_sw/isoal.h"
+#include <ll_sw/isoal.h>
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
-#include "ll_sw/ull_adv_types.h"
-#include "ll_sw/ull_scan_types.h"
-#include "ll_sw/ull_sync_types.h"
-#include "ll_sw/ull_conn_types.h"
-#include "ll_sw/ull_iso_types.h"
-#include "ll_sw/ull_conn_iso_types.h"
-#include "ll_sw/ull_conn_iso_internal.h"
-#include "ll_sw/ull_df_types.h"
-#include "ll_sw/ull_internal.h"
+#include <ll_sw/ull_adv_types.h>
+#include <ll_sw/ull_scan_types.h>
+#include <ll_sw/ull_sync_types.h>
+#include <ll_sw/ull_conn_types.h>
+#include <ll_sw/ull_iso_types.h>
+#include <ll_sw/ull_conn_iso_types.h>
+#include <ll_sw/ull_conn_iso_internal.h>
+#include <ll_sw/ull_df_types.h>
+#include <ll_sw/ull_internal.h>
 
-#include "ll_sw/ull_adv_internal.h"
-#include "ll_sw/ull_sync_internal.h"
-#include "ll_sw/ull_conn_internal.h"
-#include "ll_sw/ull_sync_iso_internal.h"
-#include "ll_sw/ull_iso_internal.h"
-#include "ll_sw/ull_df_internal.h"
+#include <ll_sw/ull_adv_internal.h>
+#include <ll_sw/ull_sync_internal.h>
+#include <ll_sw/ull_conn_internal.h>
+#include <ll_sw/ull_sync_iso_internal.h>
+#include <ll_sw/ull_iso_internal.h>
+#include <ll_sw/ull_df_internal.h>
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include "hci_internal.h"
-#include "hci_vendor.h"
+#include <hci_vendor.h>
 
 #if defined(CONFIG_BT_HCI_MESH_EXT)
-#include "ll_sw/ll_mesh.h"
+#include <ll_sw/ll_mesh.h>
 #endif /* CONFIG_BT_HCI_MESH_EXT */
 
 #if defined(CONFIG_BT_CTLR_DTM_HCI)
-#include "ll_sw/ll_test.h"
+#include <ll_sw/ll_test.h>
 #endif /* CONFIG_BT_CTLR_DTM_HCI */
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)
 #include "hci_user_ext.h"
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
-#include "common/bt_str.h"
-#include "hal/debug.h"
+#include <common/bt_str.h>
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -27,38 +27,38 @@
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #endif /* CONFIG_CLOCK_CONTROL_NRF */
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
 #if defined(CONFIG_SOC_FAMILY_NORDIC_NRF)
-#include "hal/radio.h"
+#include <hal/radio.h>
 #endif /* CONFIG_SOC_FAMILY_NORDIC_NRF */
 
-#include "ll_sw/pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "ll_sw/pdu.h"
+#include <ll_sw/pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <ll_sw/pdu.h>
 
-#include "ll_sw/lll.h"
-#include "lll/lll_df_types.h"
-#include "ll_sw/lll_sync_iso.h"
-#include "ll_sw/lll_conn.h"
-#include "ll_sw/lll_conn_iso.h"
-#include "ll_sw/isoal.h"
+#include <ll_sw/lll.h>
+#include <lll/lll_df_types.h>
+#include <ll_sw/lll_sync_iso.h>
+#include <ll_sw/lll_conn.h>
+#include <ll_sw/lll_conn_iso.h>
+#include <ll_sw/isoal.h>
 
-#include "ll_sw/ull_iso_types.h"
-#include "ll_sw/ull_conn_iso_types.h"
+#include <ll_sw/ull_iso_types.h>
+#include <ll_sw/ull_conn_iso_types.h>
 
-#include "ll_sw/ull_iso_internal.h"
-#include "ll_sw/ull_sync_iso_internal.h"
-#include "ll_sw/ull_conn_internal.h"
-#include "ll_sw/ull_conn_iso_internal.h"
+#include <ll_sw/ull_iso_internal.h>
+#include <ll_sw/ull_sync_iso_internal.h>
+#include <ll_sw/ull_conn_internal.h>
+#include <ll_sw/ull_conn_iso_internal.h>
 
-#include "ll.h"
+#include <ll.h>
 
 #include "hci_internal.h"
 

--- a/subsys/bluetooth/controller/ll_sw/isoal.c
+++ b/subsys/bluetooth/controller/ll_sw/isoal.c
@@ -18,16 +18,16 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
+#include <ll.h>
 #include "lll.h"
 #include "lll_conn_iso.h"
 #include "lll_iso_tx.h"
@@ -47,7 +47,7 @@ LOG_MODULE_REGISTER(bt_ctlr_isoal, CONFIG_BT_CTLR_ISOAL_LOG_LEVEL);
 #define ISOAL_LOG_DBGV(...)    (void) 0
 #endif /* CONFIG_BT_CTLR_ISOAL_LOG_DBG_VERBOSE */
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define FSM_TO_STR(s) (s == ISOAL_START ? "START" : \
 	(s == ISOAL_CONTINUE ? "CONTINUE" : \

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -12,20 +12,20 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/controller.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
 
 #include "ull_adv_types.h"
@@ -33,7 +33,7 @@
 #include "ull_adv_internal.h"
 #include "ull_scan_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
 static uint8_t pub_addr[BDADDR_SIZE];
 static uint8_t rnd_addr[BDADDR_SIZE];

--- a/subsys/bluetooth/controller/ll_sw/ll_feat.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_feat.c
@@ -7,28 +7,28 @@
 
 #include <zephyr/kernel.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 
 #include "ull_conn_internal.h"
 
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CTLR_SET_HOST_FEATURE)
 static uint64_t host_features;

--- a/subsys/bluetooth/controller/ll_sw/ll_settings.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_settings.c
@@ -6,13 +6,13 @@
 
 #include <zephyr/settings/settings.h>
 
-#include "ll_settings.h"
+#include <ll_settings.h>
 
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(bt_ctlr_ll_settings, LOG_LEVEL_DBG);
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CTLR_VERSION_SETTINGS)
 

--- a/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
@@ -10,28 +10,28 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/hci_vs.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -41,7 +41,7 @@
 #include "ull_scan_internal.h"
 #include "ull_conn_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
 uint8_t ll_tx_pwr_lvl_get(uint8_t handle_type,
 		       uint16_t handle, uint8_t type, int8_t *tx_pwr_lvl)

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -5,7 +5,7 @@
  */
 
 #if defined(CONFIG_BT_CTLR_RX_PDU_META)
-#include "lll_meta.h"
+#include <lll_meta.h>
 #endif /* CONFIG_BT_CTLR_RX_PDU_META */
 
 #define TICKER_INSTANCE_ID_CTLR 0

--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -7,11 +7,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static uint8_t chan_sel_remap(uint8_t *chan_map, uint8_t chan_index);
 #if defined(CONFIG_BT_CTLR_CHAN_SEL_2)

--- a/subsys/bluetooth/controller/ll_sw/lll_common.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_common.c
@@ -8,12 +8,12 @@
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
+#include <util/mem.h>
+#include <util/memq.h>
 
 #include "lll.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /**
  * @brief Common entry point for LLL event prepare invocations from ULL.

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #if defined(CONFIG_BT_CTLR_CONN_META)
-#include "lll_conn_meta.h"
+#include <lll_conn_meta.h>
 #endif /* CONFIG_BT_CTLR_CONN_META */
 
 #define LLL_CONN_RSSI_SAMPLE_COUNT 10

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/cntr_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/cntr_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/cntr.h"
+#include <hal/nrf5/cntr.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/cpu_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/cpu_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/cpu.h"
+#include <hal/nrf5/cpu.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/debug_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/debug_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/debug.h"
+#include <hal/nrf5/debug.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cntr.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cntr.c
@@ -7,9 +7,9 @@
 
 #include <stdint.h>
 
-#include "hal/cntr.h"
+#include <hal/cntr.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if !defined(CONFIG_BT_CTLR_NRF_GRTC)
 #include <hal/nrf_rtc.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
@@ -12,12 +12,12 @@
 
 #include <hal/nrf_ecb.h>
 
-#include "util/mem.h"
+#include <util/mem.h>
 
-#include "hal/cpu.h"
-#include "hal/ecb.h"
+#include <hal/cpu.h>
+#include <hal/ecb.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(NRF_ECB00) /* In some devices NRF_ECB was renamed NRF_ECB00 */
 #define NRF_ECB                   NRF_ECB00

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
@@ -7,14 +7,14 @@
 
 #include <soc.h>
 
-#include "hal/nrf5/swi.h"
+#include <hal/nrf5/swi.h>
 
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ll_sw/lll.h"
+#include <ll_sw/lll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define MAYFLY_CALL_ID_LLL    TICKER_USER_ID_LLL
 #define MAYFLY_CALL_ID_WORKER TICKER_USER_ID_ULL_HIGH

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -14,18 +14,18 @@
 #include <nrfx_gpiote.h>
 #include <gpiote_nrfx.h>
 
-#include "util/mem.h"
+#include <util/mem.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/cntr.h"
-#include "hal/radio.h"
-#include "hal/radio_df.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/cntr.h>
+#include <hal/radio.h>
+#include <hal/radio_df.h>
+#include <hal/ticker.h>
 
-#include "ll_sw/pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "ll_sw/pdu.h"
+#include <ll_sw/pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <ll_sw/pdu.h>
 
 #include "radio_internal.h"
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
@@ -13,9 +13,9 @@
 #include <hal/nrf_gpio.h>
 #include <hal/ccm.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
 #include "radio_nrf5.h"
 #include "radio.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -79,7 +79,7 @@
 #include "radio_nrf5_fem.h"
 
 /* Include RTC/GRTC Compare Index used to Trigger Radio TXEN/RXEN */
-#include "hal/cntr.h"
+#include <hal/cntr.h>
 
 #if defined(CONFIG_SOC_SERIES_NRF51) || defined(CONFIG_SOC_COMPATIBLE_NRF52X)
 #include <hal/nrf_ppi.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.c
@@ -10,16 +10,16 @@
 
 #include <zephyr/sys/util.h>
 
-#include "hal/cntr.h"
+#include <hal/cntr.h>
 
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "ll_sw/lll.h"
+#include <ll_sw/lll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define TICKER_MAYFLY_CALL_ID_ISR     TICKER_USER_ID_LLL
 #define TICKER_MAYFLY_CALL_ID_TRIGGER TICKER_USER_ID_ULL_HIGH

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_df_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_df_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/radio/radio_df.h"
+#include <hal/nrf5/radio/radio_df.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_vendor_hal.h
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/radio/radio.h"
-#include "hal/nrf5/radio/radio_nrf5.h"
-#include "hal/nrf5/radio/radio_nrf5_txp.h"
+#include <hal/nrf5/radio/radio.h>
+#include <hal/nrf5/radio/radio_nrf5.h>
+#include <hal/nrf5/radio/radio_nrf5_txp.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/swi_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/swi_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/swi.h"
+#include <hal/nrf5/swi.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/ticker_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/ticker_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/ticker.h"
+#include <hal/nrf5/ticker.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -16,25 +16,25 @@
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/irq.h>
 
-#include "hal/swi.h"
-#include "hal/ccm.h"
-#include "hal/cntr.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/swi.h>
+#include <hal/ccm.h>
+#include <hal/cntr.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
+#include <lll_clock.h>
 #include "lll_internal.h"
 #include "lll_prof_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CTLR_ZLI)
 #define IRQ_CONNECT_FLAGS IRQ_ZERO_LATENCY

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -11,36 +11,36 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
+#include <lll_clock.h>
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
-#include "lll_adv_aux.h"
-#include "lll_adv_sync.h"
+#include <lll_adv_aux.h>
+#include <lll_adv_sync.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_chan.h"
-#include "lll_filter.h"
+#include <lll_conn.h>
+#include <lll_chan.h>
+#include <lll_filter.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
@@ -48,7 +48,7 @@
 #include "lll_prof_internal.h"
 #include "lll_df_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define PDU_FREE_TIMEOUT K_SECONDS(5)
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -11,41 +11,41 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <soc.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
+#include <lll_clock.h>
+#include <lll_chan.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
+#include <lll_conn.h>
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
-#include "lll_adv_aux.h"
-#include "lll_adv_sync.h"
-#include "lll_filter.h"
+#include <lll_adv_aux.h>
+#include <lll_adv_sync.h>
+#include <lll_filter.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_adv_internal.h"
 #include "lll_prof_internal.h"
 
-#include "ull_adv_types.h"
+#include <ull_adv_types.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -11,36 +11,36 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
+#include <lll.h>
+#include <lll_clock.h>
+#include <lll_chan.h>
 #include "lll_vendor.h"
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
-#include "lll_adv_iso.h"
-#include "lll_iso_tx.h"
+#include <lll_adv_iso.h>
+#include <lll_iso_tx.h>
 
 #include "lll_internal.h"
 #include "lll_adv_iso_internal.h"
 #include "lll_prof_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define TEST_WITH_DUMMY_PDU 0
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -10,30 +10,30 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
-#include "hal/radio_df.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
+#include <hal/radio_df.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
+#include <lll_clock.h>
+#include <lll_chan.h>
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
-#include "lll_adv_sync.h"
-#include "lll_adv_iso.h"
+#include <lll_adv_sync.h>
+#include <lll_adv_iso.h>
 #include "lll_df_types.h"
 
 #include "lll_internal.h"
@@ -42,7 +42,7 @@
 #include "lll_prof_internal.h"
 #include "lll_df_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
@@ -12,33 +12,33 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/radio_df.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/radio_df.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
+#include <lll_clock.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_central.h"
-#include "lll_chan.h"
+#include <lll_conn.h>
+#include <lll_central.h>
+#include <lll_chan.h>
 
 #include "lll_internal.h"
 #include "lll_df_internal.h"
 #include "lll_tim_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -8,37 +8,37 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
+#include <lll_clock.h>
+#include <lll_chan.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
-#include "lll_central_iso.h"
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
+#include <lll_central_iso.h>
 
-#include "lll_iso_tx.h"
+#include <lll_iso_tx.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -10,7 +10,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* LF (XO, RC) clock setup timeout.
  * LF settling time can vary on the type of the source.

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -13,26 +13,26 @@
 
 #include <zephyr/sys/util.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/radio_df.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/radio_df.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_clock.h"
+#include <lll.h>
+#include <lll_clock.h>
 #include "lll_df_types.h"
-#include "lll_df.h"
-#include "lll_conn.h"
+#include <lll_df.h>
+#include <lll_conn.h>
 
 #include "lll_internal.h"
 #include "lll_df_internal.h"
@@ -41,7 +41,7 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static void isr_done(void *param);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn_iso.c
@@ -10,20 +10,20 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/memq.h"
-#include "util/mem.h"
+#include <util/memq.h>
+#include <util/mem.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll_conn_iso.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 
 int lll_conn_iso_init(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -8,29 +8,29 @@
 #include <soc.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/dbuf.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio_df.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio_df.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
 #include "lll_df_types.h"
-#include "lll_sync.h"
-#include "lll_df.h"
+#include <lll_sync.h>
+#include <lll_df.h>
 #include "lll_df_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Minimum number of antenna switch patterns required by Direction Finding Extension to be
  * configured in SWTICHPATTER register. The value is set to 2, even though the radio peripheral

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -11,32 +11,32 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
+#include <lll_clock.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_peripheral.h"
-#include "lll_chan.h"
+#include <lll_conn.h>
+#include <lll_peripheral.h>
+#include <lll_chan.h>
 
 #include "lll_internal.h"
 #include "lll_df_internal.h"
 #include "lll_tim_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -8,37 +8,37 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_clock.h"
-#include "lll/lll_df_types.h"
-#include "lll_chan.h"
+#include <lll.h>
+#include <lll_clock.h>
+#include <lll/lll_df_types.h>
+#include <lll_chan.h>
 #include "lll_vendor.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
-#include "lll_peripheral_iso.h"
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
+#include <lll_peripheral_iso.h>
 
-#include "lll_iso_tx.h"
+#include <lll_iso_tx.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof.c
@@ -10,21 +10,21 @@
 
 #include <zephyr/toolchain.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Below profiling measurements using a sample with:
  * 1 connectable legacy advertising or 1 peripheral ACL,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -11,39 +11,39 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
+#include <lll_clock.h>
 #include "lll_df_types.h"
-#include "lll_scan.h"
-#include "lll_sync.h"
-#include "lll_conn.h"
-#include "lll_chan.h"
-#include "lll_filter.h"
-#include "lll_sched.h"
+#include <lll_scan.h>
+#include <lll_sync.h>
+#include <lll_conn.h>
+#include <lll_chan.h>
+#include <lll_filter.h>
+#include <lll_sched.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 #include "lll_scan_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Maximum primary Advertising Radio Channels to scan */
 #define ADV_CHAN_MAX 3U

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -11,32 +11,32 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
-#include "hal/radio_df.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
+#include <hal/radio_df.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
+#include <util/mayfly.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_filter.h"
-#include "lll_scan.h"
-#include "lll_scan_aux.h"
+#include <lll_clock.h>
+#include <lll_filter.h>
+#include <lll_scan.h>
+#include <lll_scan_aux.h>
 #include "lll_df_types.h"
 #include "lll_df_internal.h"
-#include "lll_sync.h"
-#include "lll_sync_iso.h"
-#include "lll_conn.h"
-#include "lll_sched.h"
+#include <lll_sync.h>
+#include <lll_sync_iso.h>
+#include <lll_conn.h>
+#include <lll_sched.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
@@ -44,11 +44,11 @@
 #include "lll_scan_internal.h"
 #include "lll_sync_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
 #include <soc.h>
 #include <ull_scan_types.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -9,41 +9,41 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
-#include "hal/radio_df.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
+#include <hal/radio_df.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
+#include <lll_clock.h>
+#include <lll_chan.h>
 #include "lll_df_types.h"
-#include "lll_scan.h"
-#include "lll_sync.h"
+#include <lll_scan.h>
+#include <lll_sync.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 #include "lll_scan_internal.h"
 
-#include "lll_df.h"
+#include <lll_df.h>
 #include "lll_df_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
 #include <zephyr/bluetooth/hci_types.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int create_prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -12,32 +12,32 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
-#include "lll_sync_iso.h"
+#include <lll_clock.h>
+#include <lll_chan.h>
+#include <lll_sync_iso.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int create_prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -11,40 +11,40 @@
 
 #include <soc.h>
 
-#include "hal/cpu.h"
-#include "hal/cntr.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
-#include "hal/radio.h"
-#include "hal/radio_df.h"
+#include <hal/cpu.h>
+#include <hal/cntr.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
+#include <hal/radio.h>
+#include <hal/radio_df.h>
 
-#include "util/memq.h"
-#include "util/util.h"
-#include "util/dbuf.h"
+#include <util/memq.h>
+#include <util/util.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_clock.h"
+#include <lll.h>
+#include <lll_clock.h>
 #include "lll_internal.h"
 
 #if defined(CONFIG_BT_CTLR_DF)
 #include "lll_df_types.h"
-#include "lll_df.h"
+#include <lll_df.h>
 #endif /* CONFIG_BT_CTLR_DF */
 
-#include "ll_test.h"
+#include <ll_test.h>
 
 #if defined(CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT)
-#include "ull_df_types.h"
-#include "ull_df_internal.h"
+#include <ull_df_types.h>
+#include <ull_df_internal.h>
 #endif /* CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT */
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Define to setup radio start offset by a maximum ISR latency value that is less than inter-frame
  * switching, plus minimum counter compare offset that can be set, plus minimum CPU latency to set

--- a/subsys/bluetooth/controller/ll_sw/nordic/ull/ull_iso_vendor.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/ull/ull_iso_vendor.c
@@ -11,23 +11,23 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/util.h"
-#include "util/memq.h"
+#include <util/util.h>
+#include <util/memq.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_conn.h"
+#include <lll.h>
+#include <lll_conn.h>
 
-#include "isoal.h"
+#include <isoal.h>
 
-#include "ull_iso_types.h"
-#include "ull_conn_internal.h"
-#include "ull_internal.h"
+#include <ull_iso_types.h>
+#include <ull_conn_internal.h>
+#include <ull_internal.h>
 
 /* FIXME: Implement vendor specific data path configuration */
 static bool dummy;

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/cntr.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/cntr.c
@@ -10,8 +10,8 @@
 
 #include <zephyr/dt-bindings/interrupt-controller/openisa-intmux.h>
 
-#include "hal/cntr.h"
-#include "hal/debug.h"
+#include <hal/cntr.h>
+#include <hal/debug.h>
 
 #include "ll_irqs.h"
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ecb.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ecb.c
@@ -12,12 +12,12 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ecb.h"
+#include <hal/ecb.h>
 
 #include <zephyr/logging/log.h>
 
-#include "hal/debug.h"
-#include "fsl_cau3_ble.h"
+#include <hal/debug.h>
+#include <fsl_cau3_ble.h>
 
 LOG_MODULE_REGISTER(bt_ctlr_rv32m1_ecb, LOG_LEVEL_DBG);
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/mayfly.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/mayfly.c
@@ -9,15 +9,15 @@
 #include <zephyr/types.h>
 #include <soc.h>
 
-#include "hal/RV32M1/swi.h"
+#include <hal/RV32M1/swi.h>
 
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_LL_SW_SPLIT)
-#include "ll_sw/lll.h"
+#include <ll_sw/lll.h>
 #define MAYFLY_CALL_ID_LLL    TICKER_USER_ID_LLL
 #define MAYFLY_CALL_ID_WORKER TICKER_USER_ID_ULL_HIGH
 #define MAYFLY_CALL_ID_JOB    TICKER_USER_ID_ULL_LOW

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.c
@@ -14,24 +14,24 @@
 #include <zephyr/irq.h>
 #include <errno.h>
 
-#include "util/mem.h"
+#include <util/mem.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
-#include "lll/pdu_vendor.h"
-#include "ll_sw/pdu.h"
+#include <lll/pdu_vendor.h>
+#include <ll_sw/pdu.h>
 
-#include "fsl_xcvr.h"
-#include "hal/cntr.h"
-#include "hal/ticker.h"
-#include "hal/swi.h"
-#include "fsl_cau3_ble.h"	/* must be after irq.h */
+#include <fsl_xcvr.h>
+#include <hal/cntr.h>
+#include <hal/ticker.h>
+#include <hal/swi.h>
+#include <fsl_cau3_ble.h>	/* must be after irq.h */
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ticker.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ticker.c
@@ -8,17 +8,17 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "hal/cntr.h"
+#include <hal/cntr.h>
 
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_LL_SW_SPLIT)
-#include "ll_sw/lll.h"
+#include <ll_sw/lll.h>
 #define TICKER_MAYFLY_CALL_ID_ISR     TICKER_USER_ID_LLL
 #define TICKER_MAYFLY_CALL_ID_TRIGGER TICKER_USER_ID_ULL_HIGH
 #define TICKER_MAYFLY_CALL_ID_WORKER  TICKER_USER_ID_ULL_HIGH

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/cntr_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/cntr_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/RV32M1/cntr.h"
+#include <hal/RV32M1/cntr.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/cpu_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/cpu_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/RV32M1/cpu.h"
+#include <hal/RV32M1/cpu.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/debug_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/debug_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/RV32M1/debug.h"
+#include <hal/RV32M1/debug.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/radio_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/radio_vendor_hal.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/RV32M1/radio/radio.h"
+#include <hal/RV32M1/radio/radio.h>
 
 /* The openisa vendor HAL does not have the GPIO support functions
  * required for handling radio front-end modules with PA/LNAs.

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/swi_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/swi_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/RV32M1/swi.h"
+#include <hal/RV32M1/swi.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/ticker_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/ticker_vendor_hal.h
@@ -3,4 +3,4 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "hal/RV32M1/ticker.h"
+#include <hal/RV32M1/ticker.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -17,22 +17,22 @@
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/irq.h>
 
-#include "hal/swi.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/swi.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
 #include "lll_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static struct {
 	struct {

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -13,37 +13,37 @@
 #include <zephyr/sys/byteorder.h>
 #include <soc.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_chan.h"
-#include "lll_filter.h"
+#include <lll_conn.h>
+#include <lll_chan.h>
+#include <lll_filter.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_adv_internal.h"
 #include "lll_prof_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *prepare_param);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_central.c
@@ -10,28 +10,28 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
+#include <util/util.h>
+#include <util/memq.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_central.h"
-#include "lll_chan.h"
+#include <lll_conn.h>
+#include <lll_central.h>
+#include <lll_chan.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_clock.c
@@ -9,7 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static uint16_t const sca_ppm_lut[] = {500, 250, 150, 100, 75, 50, 30, 20};
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
@@ -12,27 +12,27 @@
 #include <soc.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
+#include <lll_conn.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static void isr_done(void *param);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_peripheral.c
@@ -10,28 +10,28 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
+#include <util/util.h>
+#include <util/memq.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_peripheral.h"
-#include "lll_chan.h"
+#include <lll_conn.h>
+#include <lll_peripheral.h>
+#include <lll_chan.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_prof.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_prof.c
@@ -7,15 +7,15 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 
 static uint8_t latency_min = (uint8_t) -1;
 static uint8_t latency_max;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -13,34 +13,34 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_scan.h"
+#include <lll_clock.h>
+#include <lll_scan.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_chan.h"
-#include "lll_filter.h"
+#include <lll_conn.h>
+#include <lll_chan.h>
+#include <lll_filter.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *prepare_param);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_test.c
@@ -12,19 +12,19 @@
 #include <soc.h>
 #include <zephyr/drivers/clock_control.h>
 
-#include "hal/cpu.h"
-#include "hal/cntr.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/cpu.h>
+#include <hal/cntr.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_internal.h"
 
-#include "ll_test.h"
+#include <ll_test.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define CNTR_MIN_DELTA 3
 

--- a/subsys/bluetooth/controller/ll_sw/shell/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/shell/ll.c
@@ -19,10 +19,10 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "controller/util/memq.h"
-#include "controller/include/ll.h"
+#include <controller/util/memq.h>
+#include <controller/include/ll.h>
 
-#include "host/shell/bt.h"
+#include <host/shell/bt.h>
 
 int cmd_ll_addr_read(const struct shell *sh, size_t argc, char *argv[])
 {
@@ -51,7 +51,7 @@ int cmd_ll_addr_read(const struct shell *sh, size_t argc, char *argv[])
 }
 
 #if defined(CONFIG_BT_CTLR_DTM)
-#include "controller/ll_sw/ll_test.h"
+#include <controller/ll_sw/ll_test.h>
 
 int cmd_test_tx(const struct shell *sh, size_t  argc, char *argv[])
 {
@@ -121,7 +121,7 @@ int cmd_test_end(const struct shell *sh, size_t  argc, char *argv[])
 #endif /* CONFIG_BT_CTLR_DTM */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-#include "controller/ll_sw/lll.h"
+#include <controller/ll_sw/lll.h>
 
 #if defined(CONFIG_BT_BROADCASTER)
 #define OWN_ADDR_TYPE 1

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -14,33 +14,33 @@
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ecb.h"
-#include "hal/ccm.h"
-#include "hal/cntr.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ecb.h>
+#include <hal/ccm.h>
+#include <hal/cntr.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/mfifo.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/mfifo.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_chan.h"
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_iso_tx.h"
@@ -51,14 +51,14 @@
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
 #include "ull_sync_types.h"
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 #include "ull_conn_types.h"
 #include "ull_filter.h"
 #include "ull_df_types.h"
 #include "ull_df_internal.h"
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)
-#include "ull_vendor.h"
+#include <ull_vendor.h>
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
 #include "isoal.h"
@@ -81,14 +81,14 @@
 #include "ull_conn_iso_internal.h"
 #include "ull_peripheral_iso_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
+#include <ll.h>
+#include <ll_feat.h>
 #include "ll_test.h"
-#include "ll_settings.h"
+#include <ll_settings.h>
 
-#include "lll/lll_prof_internal.h"
+#include <lll/lll_prof_internal.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define TEST_TICKER_NODES         (TICKER_NODES)
 #define TEST_TICKER_TICKS_SLOT_US 100000U

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -12,37 +12,37 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
-#include "hal/cntr.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
+#include <hal/cntr.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_filter.h"
 #include "lll_conn_iso.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -54,18 +54,18 @@
 #include "ull_conn_internal.h"
 #include "ull_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
-#include "ll_sw/isoal.h"
-#include "ll_sw/ull_iso_types.h"
-#include "ll_sw/ull_conn_iso_types.h"
+#include <ll_sw/isoal.h>
+#include <ll_sw/ull_iso_types.h>
+#include <ll_sw/ull_conn_iso_types.h>
 
-#include "ll_sw/ull_llcp.h"
+#include <ll_sw/ull_llcp.h>
 
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 inline struct ll_adv_set *ull_adv_set_get(uint8_t handle);
 inline uint16_t ull_adv_handle_get(struct ll_adv_set *adv);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -9,31 +9,31 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_chan.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_adv_aux.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 
 #include "ull_adv_types.h"
@@ -43,9 +43,9 @@
 #include "ull_adv_internal.h"
 #include "ull_sched_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -9,27 +9,27 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_adv_iso.h"
 #include "lll_iso_tx.h"
 
@@ -44,12 +44,12 @@
 #include "ull_sched_internal.h"
 #include "ull_iso_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
+#include <ll.h>
+#include <ll_feat.h>
 
-#include "bt_crypto.h"
+#include <bt_crypto.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Controller implementation dependent minimum Pre-Transmission Offset and
  * Pre-Transmission Group Count to use when there is available time space in the

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -9,30 +9,30 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_adv_sync.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_chan.h"
 
@@ -51,9 +51,9 @@
 #include "ull_conn_iso_types.h"
 #include "ull_llcp.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_LINK)
 /* First PDU contains up to PDU_AC_EXT_AD_DATA_LEN_MAX, next ones PDU_AC_EXT_PAYLOAD_SIZE_MAX */

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -9,38 +9,38 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_chan.h"
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_central.h"
 #include "lll_filter.h"
 #include "lll_conn_iso.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -53,18 +53,18 @@
 #include "ull_conn_internal.h"
 #include "ull_central_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
-#include "ll_sw/isoal.h"
-#include "ll_sw/ull_iso_types.h"
-#include "ll_sw/ull_conn_iso_types.h"
-#include "ll_sw/ull_conn_iso_internal.h"
+#include <ll_sw/isoal.h>
+#include <ll_sw/ull_iso_types.h>
+#include <ll_sw/ull_conn_iso_types.h>
+#include <ll_sw/ull_conn_iso_internal.h>
 
-#include "ll_sw/ull_llcp.h"
+#include <ll_sw/ull_llcp.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static void ticker_op_stop_scan_cb(uint32_t status, void *param);
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CTLR_PHY_CODED)

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -10,24 +10,24 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/iso.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_clock.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_central_iso.h"
@@ -47,12 +47,12 @@
 #include "ull_conn_internal.h"
 #include "ull_conn_iso_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
+#include <ll.h>
+#include <ll_feat.h>
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define SDU_MAX_DRIFT_PPM 100
 #define SUB_INTERVAL_MIN  400

--- a/subsys/bluetooth/controller/ll_sw/ull_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_chan.c
@@ -11,22 +11,22 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/util.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_adv_pdu.h>
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 
 #include "ull_adv_types.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -13,32 +13,32 @@
 
 #include <soc.h>
 
-#include "hal/cpu.h"
-#include "hal/ecb.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ecb.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "isoal.h"
 #include "ull_iso_types.h"
@@ -46,7 +46,7 @@
 #include "ull_conn_iso_types.h"
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)
-#include "ull_vendor.h"
+#include <ull_vendor.h>
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
 #include "ull_internal.h"
@@ -61,7 +61,7 @@
 #include "ull_conn_iso_internal.h"
 #include "ull_central_iso_internal.h"
 #include "ull_peripheral_iso_internal.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
 #include "ull_adv_types.h"
 #include "ull_adv_internal.h"
@@ -72,14 +72,14 @@
 #include "ull_scan_types.h"
 #include "ull_sync_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
-#include "ll_sw/ull_llcp.h"
-#include "ll_sw/ull_llcp_features.h"
+#include <ll_sw/ull_llcp.h>
+#include <ll_sw/ull_llcp_features.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -9,32 +9,32 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_clock.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_central_iso.h"
 #include "lll_peripheral_iso.h"
 #include "lll_iso_tx.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "isoal.h"
 
@@ -50,9 +50,9 @@
 #include "ull_conn_iso_internal.h"
 #include "ull_peripheral_iso_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Used by LISTIFY */
 #define _INIT_MAYFLY_ARRAY(_i, _l, _fp) \

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -10,31 +10,31 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_df.h"
-#include "lll/lll_df_internal.h"
+#include <lll/lll_df_internal.h>
 
 #include "isoal.h"
 #include "ull_scan_types.h"
@@ -53,9 +53,9 @@
 #include "ull_conn_internal.h"
 #include "ull_df_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX) || defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX) || \
 	defined(CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT)

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -11,29 +11,29 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_filter.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -45,9 +45,9 @@
 #include "ull_scan_internal.h"
 #include "ull_conn_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -60,7 +60,7 @@ LOG_MODULE_REGISTER(bt_ctlr_ull_filter);
 static struct lll_filter fal_filter;
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-#include "common/rpa.h"
+#include <common/rpa.h>
 
 /* Filter Accept List peer list */
 static struct lll_fal fal[CONFIG_BT_CTLR_FAL_SIZE];

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -12,37 +12,37 @@
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_adv_iso.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_iso_tx.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "isoal.h"
 
@@ -60,10 +60,10 @@
 #include "ull_sync_iso_internal.h"
 #include "ull_conn_iso_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
+#include <ll.h>
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -12,33 +12,33 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
+#include <util/mayfly.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_scan.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 
 #include "ull_tx_queue.h"
 
@@ -64,7 +64,7 @@
 #include "ull_filter.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LLCTRL_PDU_SIZE (offsetof(struct pdu_data, llctrl) + sizeof(struct pdu_data_llctrl))
 #define PROC_CTX_BUF_SIZE WB_UP(sizeof(struct proc_ctx))

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -12,24 +12,24 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ecb.h"
-#include "hal/ccm.h"
+#include <hal/ecb.h>
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -51,7 +51,7 @@
 #include "ull_central_iso_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #include <zephyr/bluetooth/iso.h>
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
@@ -12,22 +12,22 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -44,7 +44,7 @@
 #include "ull_conn_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Hardcoded instant delta +6 */
 #define CHMU_INSTANT_DELTA 6U

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -12,32 +12,32 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
+#include <util/mayfly.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "ll_feat.h"
-#include "lll/lll_df_types.h"
+#include <ll_feat.h>
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_scan.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 
 #include "ull_tx_queue.h"
 
@@ -62,7 +62,7 @@
 #include "ull_llcp_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* LLCP Local Procedure FSM states */
 enum {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -12,23 +12,23 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 
 #include "lll_conn_iso.h"
@@ -44,7 +44,7 @@
 #include "ull_conn_types.h"
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)
-#include "ull_vendor.h"
+#include <ull_vendor.h>
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
 #include "ull_internal.h"
@@ -53,7 +53,7 @@
 #include "ull_llcp_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Hardcoded instant delta +6 */
 #define CONN_UPDATE_INSTANT_DELTA	6U

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -11,24 +11,24 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ecb.h"
-#include "hal/ccm.h"
+#include <hal/ecb.h>
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -47,7 +47,7 @@
 #include "ull_conn_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CENTRAL)
 /* LLCP Local Procedure Encryption FSM states */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -12,23 +12,23 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -46,7 +46,7 @@
 #include "ull_conn_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static struct proc_ctx *lr_dequeue(struct ll_conn *conn);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_past.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_past.c
@@ -9,19 +9,19 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
-#include "hal/debug.h"
+#include <hal/ccm.h>
+#include <hal/debug.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_filter.h"
 #include "lll_scan.h"
 #include "lll_sync.h"
@@ -38,8 +38,8 @@
 #include "ull_conn_types.h"
 #include "ull_conn_iso_types.h"
 
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <ll_settings.h>
+#include <ll_feat.h>
 
 #include "ull_llcp.h"
 #include "ull_llcp_features.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -12,24 +12,24 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_settings.h>
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -40,7 +40,7 @@
 #include "ull_conn_iso_types.h"
 #include "ull_conn_iso_internal.h"
 
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
 #include "ull_adv_types.h"
 #include "lll_sync.h"
@@ -50,10 +50,10 @@
 #include "ull_llcp.h"
 #include "ull_llcp_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /*
  * we need to filter on octet 0; the following mask has 7 octets

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -12,23 +12,23 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "ll_feat.h"
-#include "lll/lll_df_types.h"
+#include <ll_feat.h>
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -47,7 +47,7 @@
 #include "ull_conn_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* LLCP Local Procedure PHY Update FSM states */
 enum {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -12,23 +12,23 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <ll.h>
+#include <ll_settings.h>
+#include <ll_feat.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -47,7 +47,7 @@
 #include "ull_llcp_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static struct proc_ctx *rr_dequeue(struct ll_conn *conn);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -9,37 +9,37 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_chan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_peripheral.h"
 #include "lll_filter.h"
 #include "lll_conn_iso.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_conn_types.h"
@@ -50,15 +50,15 @@
 #include "ull_conn_internal.h"
 #include "ull_peripheral_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "ll_sw/isoal.h"
-#include "ll_sw/ull_iso_types.h"
-#include "ll_sw/ull_conn_iso_types.h"
+#include <ll_sw/isoal.h>
+#include <ll_sw/ull_iso_types.h>
+#include <ll_sw/ull_conn_iso_types.h>
 
-#include "ll_sw/ull_llcp.h"
+#include <ll_sw/ull_llcp.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static void invalid_release(struct ull_hdr *hdr, struct lll_conn *lll,
 			    memq_link_t *link, struct node_rx_pdu *rx);

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -12,30 +12,30 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_peripheral_iso.h"
 
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_conn_types.h"
 
@@ -50,7 +50,7 @@
 #include "ull_conn_iso_internal.h"
 #include "ull_llcp_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -9,34 +9,34 @@
 #include <soc.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_filter.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_filter.h"
@@ -48,9 +48,9 @@
 #include "ull_scan_internal.h"
 #include "ull_sched_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -9,35 +9,35 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/util.h"
-#include "util/dbuf.h"
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/util.h>
+#include <util/dbuf.h>
 
-#include "hal/ticker.h"
-#include "hal/ccm.h"
+#include <hal/ticker.h>
+#include <hal/ccm.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_scan.h"
 #include "lll_scan_aux.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "isoal.h"
 #include "ull_scan_types.h"
@@ -58,7 +58,7 @@
 #include <zephyr/bluetooth/hci_types.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -9,34 +9,34 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
-#include "util/mem.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
+#include <util/mem.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_adv_sync.h"
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -51,9 +51,9 @@
 #include "ull_conn_internal.h"
 #include "ull_conn_iso_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -10,32 +10,32 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_chan.h"
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_sync.h"
@@ -63,9 +63,9 @@
 #include "ull_df_internal.h"
 
 #include "ull_llcp.h"
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Check that timeout_reload member is at safe offset when ll_sync_set is
  * allocated using mem interface. timeout_reload being non-zero is used to

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -8,27 +8,27 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_clock.h"
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_conn.h"
@@ -52,11 +52,11 @@
 #include "ull_conn_internal.h"
 #include "ull_conn_iso_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "bt_crypto.h"
+#include <bt_crypto.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static struct ll_sync_iso_set *sync_iso_get(uint8_t handle);

--- a/subsys/bluetooth/controller/ticker/shell/ticker.c
+++ b/subsys/bluetooth/controller/ticker/shell/ticker.c
@@ -16,10 +16,10 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "controller/util/memq.h"
-#include "controller/util/mayfly.h"
-#include "controller/hal/ticker.h"
-#include "controller/ticker/ticker.h"
+#include <controller/util/memq.h>
+#include <controller/util/mayfly.h>
+#include <controller/hal/ticker.h>
+#include <controller/ticker/ticker.h>
 
 #if defined(CONFIG_BT_MAX_CONN)
 #define TICKERS_MAX (CONFIG_BT_MAX_CONN + 2)
@@ -27,7 +27,7 @@
 #define TICKERS_MAX 2
 #endif
 
-#include "host/shell/bt.h"
+#include <host/shell/bt.h>
 
 static void ticker_op_done(uint32_t err, void *context)
 {

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -9,13 +9,13 @@
 #include <zephyr/types.h>
 #include <soc.h>
 
-#include "hal/cntr.h"
-#include "hal/ticker.h"
-#include "hal/cpu.h"
+#include <hal/cntr.h>
+#include <hal/ticker.h>
+#include <hal/cpu.h>
 
 #include "ticker.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /*****************************************************************************
  * Defines

--- a/subsys/bluetooth/controller/util/dbuf.c
+++ b/subsys/bluetooth/controller/util/dbuf.c
@@ -9,9 +9,9 @@
 
 #include <soc.h>
 
-#include "hal/cpu.h"
+#include <hal/cpu.h>
 
-#include "util/util.h"
+#include <util/util.h>
 #include "dbuf.h"
 
 void *dbuf_alloc(struct dbuf_hdr *hdr, uint8_t *idx)

--- a/subsys/bluetooth/controller/util/mayfly.c
+++ b/subsys/bluetooth/controller/util/mayfly.c
@@ -11,7 +11,7 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/printk.h>
 
-#include "hal/cpu.h"
+#include <hal/cpu.h>
 
 #include "memq.h"
 #include "mayfly.h"

--- a/subsys/bluetooth/controller/util/memq.c
+++ b/subsys/bluetooth/controller/util/memq.c
@@ -36,7 +36,7 @@
 
 #include <soc.h>
 
-#include "hal/cpu.h"
+#include <hal/cpu.h>
 
 #include "memq.h"
 

--- a/subsys/bluetooth/controller/util/util.c
+++ b/subsys/bluetooth/controller/util/util.c
@@ -12,13 +12,13 @@
 #include <zephyr/drivers/entropy.h>
 
 #include "util.h"
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "ll_sw/lll.h"
+#include <ll_sw/lll.h>
 
-#include "ll_sw/pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "ll_sw/pdu.h"
+#include <ll_sw/pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <ll_sw/pdu.h>
 
 /**
  * @brief Population count: Count the number of bits set to 1

--- a/subsys/bluetooth/crypto/bt_crypto.c
+++ b/subsys/bluetooth/crypto/bt_crypto.c
@@ -7,9 +7,9 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "psa/crypto.h"
+#include <psa/crypto.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "bt_crypto.h"
 
 #define LOG_LEVEL CONFIG_BT_CRYPTO_LOG_LEVEL

--- a/subsys/bluetooth/crypto/bt_crypto_psa.c
+++ b/subsys/bluetooth/crypto/bt_crypto_psa.c
@@ -7,9 +7,9 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "psa/crypto.h"
+#include <psa/crypto.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "bt_crypto.h"
 
 #define LOG_LEVEL CONFIG_BT_CRYPTO_LOG_LEVEL

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -28,7 +28,7 @@
 #include <sys/types.h>
 
 #include "addr_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "conn_internal.h"
 #include "hci_core.h"
 #include "id.h"

--- a/subsys/bluetooth/host/aes_ccm.c
+++ b/subsys/bluetooth/host/aes_ccm.c
@@ -15,7 +15,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
 LOG_MODULE_REGISTER(bt_aes_ccm);

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -37,7 +37,7 @@
 #include <sys/types.h>
 
 #include "att_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "conn_internal.h"
 #include "gatt_internal.h"
 #include "hci_core.h"

--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -23,7 +23,7 @@
 #include <zephyr/sys_clock.h>
 
 #include "buf_view.h"
-#include "common/hci_common_internal.h"
+#include <common/hci_common_internal.h>
 #include "conn_internal.h"
 #include "hci_core.h"
 #include "iso_internal.h"

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -23,7 +23,7 @@
 #include <zephyr/bluetooth/classic/a2dp_codec_sbc.h>
 #include <zephyr/bluetooth/classic/a2dp.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #define A2DP_SBC_PAYLOAD_TYPE (0x60U)
 
@@ -41,9 +41,9 @@
 #define CTRL_PARAM(_ctrl_param) CONTAINER_OF(_ctrl_param, struct bt_a2dp, ctrl_param)
 #define DELAY_REPORT_REQ(_req)  CONTAINER_OF(_req, struct bt_avdtp_delay_report_params, req)
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 #include "avdtp_internal.h"
 #include "a2dp_internal.h"
 

--- a/subsys/bluetooth/host/classic/avctp.c
+++ b/subsys/bluetooth/host/classic/avctp.c
@@ -23,8 +23,8 @@
 #include <zephyr/bluetooth/classic/sdp.h>
 
 #include "avctp_internal.h"
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 
 #define LOG_LEVEL CONFIG_BT_AVCTP_LOG_LEVEL

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -20,8 +20,8 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/classic/avdtp.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "avdtp_internal.h"
 

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -22,9 +22,9 @@
 #include <zephyr/bluetooth/classic/sdp.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 #include "avctp_internal.h"
 #include "avrcp_internal.h"
 

--- a/subsys/bluetooth/host/classic/avrcp_cover_art.c
+++ b/subsys/bluetooth/host/classic/avrcp_cover_art.c
@@ -22,9 +22,9 @@
 #include <zephyr/bluetooth/classic/bip.h>
 #include <zephyr/bluetooth/classic/avrcp_cover_art.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 #include "avctp_internal.h"
 #include "avrcp_internal.h"
 

--- a/subsys/bluetooth/host/classic/bip.c
+++ b/subsys/bluetooth/host/classic/bip.c
@@ -12,14 +12,14 @@
 
 #include <zephyr/bluetooth/conn.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #include <zephyr/bluetooth/classic/sdp.h>
 #include <zephyr/bluetooth/classic/goep.h>
 #include <zephyr/bluetooth/classic/bip.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "obex_internal.h"
 

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -11,11 +11,11 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/buf.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
-#include "host/keys.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
+#include <host/keys.h>
 #include "br.h"
 #include "sco_internal.h"
 

--- a/subsys/bluetooth/host/classic/conn_br.c
+++ b/subsys/bluetooth/host/classic/conn_br.c
@@ -29,13 +29,13 @@
 #include <zephyr/bluetooth/hci_vs.h>
 #include <zephyr/bluetooth/att.h>
 
-#include "common/assert.h"
-#include "common/bt_str.h"
+#include <common/assert.h>
+#include <common/bt_str.h>
 
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
-#include "host/keys.h"
-#include "host/smp.h"
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
+#include <host/keys.h>
+#include <host/smp.h>
 #include "ssp.h"
 #include "sco_internal.h"
 

--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -22,7 +22,7 @@
 #include <zephyr/bluetooth/classic/sdp.h>
 #include <zephyr/bluetooth/classic/goep.h>
 
-#include "host/conn_internal.h"
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 #include "obex_internal.h"

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -13,14 +13,14 @@
 
 #include <zephyr/bluetooth/conn.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #include <zephyr/bluetooth/classic/rfcomm.h>
 #include <zephyr/bluetooth/classic/hfp_ag.h>
 #include <zephyr/bluetooth/classic/sdp.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 #include "at.h"

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -14,14 +14,14 @@
 
 #include <zephyr/bluetooth/conn.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #include <zephyr/bluetooth/classic/rfcomm.h>
 #include <zephyr/bluetooth/classic/hfp_hf.h>
 #include <zephyr/bluetooth/classic/sdp.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 #include "at.h"

--- a/subsys/bluetooth/host/classic/keys_br.c
+++ b/subsys/bluetooth/host/classic/keys_br.c
@@ -16,11 +16,11 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/settings/settings.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/hci_core.h"
-#include "host/settings.h"
-#include "host/keys.h"
+#include <host/hci_core.h>
+#include <host/settings.h>
+#include <host/keys.h>
 
 #define LOG_LEVEL CONFIG_BT_KEYS_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -21,10 +21,10 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/classic/l2cap_br.h>
 
-#include "host/buf_view.h"
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
-#include "host/keys.h"
+#include <host/buf_view.h>
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
+#include <host/keys.h>
 #include "l2cap_br_internal.h"
 #include "avdtp_internal.h"
 #include "a2dp_internal.h"

--- a/subsys/bluetooth/host/classic/map.c
+++ b/subsys/bluetooth/host/classic/map.c
@@ -12,14 +12,14 @@
 
 #include <zephyr/bluetooth/conn.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #include <zephyr/bluetooth/classic/sdp.h>
 #include <zephyr/bluetooth/classic/goep.h>
 #include <zephyr/bluetooth/classic/map.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "obex_internal.h"
 

--- a/subsys/bluetooth/host/classic/pbap.c
+++ b/subsys/bluetooth/host/classic/pbap.c
@@ -14,7 +14,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/kernel.h>
 
-#include "psa/crypto.h"
+#include <psa/crypto.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -25,7 +25,7 @@
 #include <zephyr/bluetooth/classic/goep.h>
 #include <zephyr/bluetooth/classic/pbap.h>
 
-#include "host/conn_internal.h"
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 #include "obex_internal.h"

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -23,8 +23,8 @@
 
 #include <zephyr/bluetooth/classic/rfcomm.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 

--- a/subsys/bluetooth/host/classic/sco.c
+++ b/subsys/bluetooth/host/classic/sco.c
@@ -17,12 +17,12 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/addr_internal.h"
-#include "host/hci_core.h"
+#include <host/addr_internal.h>
+#include <host/hci_core.h>
 #include "br.h"
-#include "host/conn_internal.h"
+#include <host/conn_internal.h>
 #include "sco_internal.h"
 
 #define LOG_LEVEL CONFIG_BT_CONN_LOG_LEVEL

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -17,11 +17,11 @@
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/classic/sdp.h>
 
-#include "common/bt_str.h"
-#include "common/assert.h"
+#include <common/bt_str.h>
+#include <common/assert.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "sdp_internal.h"
 

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -25,8 +25,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 struct bt_a2dp *default_a2dp;
 static uint8_t a2dp_sink_sdp_registered;

--- a/subsys/bluetooth/host/classic/shell/avrcp.c
+++ b/subsys/bluetooth/host/classic/shell/avrcp.c
@@ -26,8 +26,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 NET_BUF_POOL_DEFINE(avrcp_tx_pool, CONFIG_BT_MAX_CONN,
 		    BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU),

--- a/subsys/bluetooth/host/classic/shell/avrcp_cover_art.c
+++ b/subsys/bluetooth/host/classic/shell/avrcp_cover_art.c
@@ -25,8 +25,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define COVER_ART_MOPL CONFIG_BT_GOEP_L2CAP_MTU
 

--- a/subsys/bluetooth/host/classic/shell/bip.c
+++ b/subsys/bluetooth/host/classic/shell/bip.c
@@ -23,8 +23,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define BIP_MOPL CONFIG_BT_GOEP_RFCOMM_MTU
 

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -32,8 +32,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #if defined(CONFIG_BT_CONN)
 /* Connection context for BR/EDR legacy pairing in sec mode 3 */

--- a/subsys/bluetooth/host/classic/shell/goep.c
+++ b/subsys/bluetooth/host/classic/shell/goep.c
@@ -23,8 +23,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define GOEP_MOPL CONFIG_BT_GOEP_RFCOMM_MTU
 

--- a/subsys/bluetooth/host/classic/shell/hfp.c
+++ b/subsys/bluetooth/host/classic/shell/hfp.c
@@ -23,8 +23,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define HELP_NONE "[none]"
 

--- a/subsys/bluetooth/host/classic/shell/map.c
+++ b/subsys/bluetooth/host/classic/shell/map.c
@@ -24,8 +24,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define MAP_MOPL                   CONFIG_BT_GOEP_RFCOMM_MTU
 #define MAP_MCE_SUPPORTED_FEATURES 0x0077FFFF

--- a/subsys/bluetooth/host/classic/shell/pbap.c
+++ b/subsys/bluetooth/host/classic/shell/pbap.c
@@ -22,8 +22,8 @@
 #include <zephyr/bluetooth/classic/pbap.h>
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #ifdef CONFIG_ZTEST
 #define STATIC

--- a/subsys/bluetooth/host/classic/shell/spp.c
+++ b/subsys/bluetooth/host/classic/shell/spp.c
@@ -25,9 +25,9 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
-#include "common/bt_str.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
+#include <common/bt_str.h>
 
 #define HELP_NONE "[none]"
 #define SPP_RFCOMM_MTU     CONFIG_BT_RFCOMM_L2CAP_MTU

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -15,12 +15,12 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/addr.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/keys.h"
+#include <host/keys.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -48,8 +48,8 @@
 #include "classic/conn_br_internal.h"
 #include "classic/sco_internal.h"
 #include "classic/ssp.h"
-#include "common/assert.h"
-#include "common/bt_str.h"
+#include <common/assert.h>
+#include <common/bt_str.h>
 #include "conn_internal.h"
 #include "direction_internal.h"
 #include "gatt_gap_svc_validate.h"

--- a/subsys/bluetooth/host/crypto_psa.c
+++ b/subsys/bluetooth/host/crypto_psa.c
@@ -22,7 +22,7 @@
 #include <psa/crypto_types.h>
 #include <psa/crypto_values.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "hci_core.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL

--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -25,7 +25,7 @@
 #include <psa/crypto_types.h>
 #include <psa/crypto_values.h>
 
-#include "common/long_wq.h"
+#include <common/long_wq.h>
 #include "ecc.h"
 #include "hci_core.h"
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "sys/types.h"
+#include <sys/types.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -47,11 +47,11 @@
 
 #include "att_internal.h"
 #include "conn_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "gatt_internal.h"
 #include "hci_core.h"
 #include "keys.h"
-#include "common/long_wq.h"
+#include <common/long_wq.h>
 #include "l2cap_internal.h"
 #include "settings.h"
 #include "smp.h"

--- a/subsys/bluetooth/host/hci_common.c
+++ b/subsys/bluetooth/host/hci_common.c
@@ -14,7 +14,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 struct net_buf *bt_hci_evt_create(uint8_t evt, uint8_t len)
 {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -49,10 +49,10 @@
 #include "addr_internal.h"
 #include "adv.h"
 #include "classic/br.h"
-#include "common/hci_common_internal.h"
-#include "common/bt_str.h"
-#include "common/rpa.h"
-#include "common/assert.h"
+#include <common/hci_common_internal.h>
+#include <common/bt_str.h>
+#include <common/rpa.h>
+#include <common/assert.h>
 #include "conn_internal.h"
 #include "crypto.h"
 #include "ecc.h"

--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -29,7 +29,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
 
-#include "common/hci_common_internal.h"
+#include <common/hci_common_internal.h>
 #include "hci_raw_internal.h"
 #include "monitor.h"
 

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -32,8 +32,8 @@
 #include <zephyr/toolchain.h>
 
 #include "adv.h"
-#include "common/bt_str.h"
-#include "common/rpa.h"
+#include <common/bt_str.h>
+#include <common/rpa.h>
 #include "conn_internal.h"
 #include "hci_core.h"
 #include "id.h"

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -34,10 +34,10 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
 
-#include "common/assert.h"
-#include "host/buf_view.h"
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <common/assert.h>
+#include <host/buf_view.h>
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "iso_internal.h"
 
 LOG_MODULE_REGISTER(bt_iso, CONFIG_BT_ISO_LOG_LEVEL);

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -25,8 +25,8 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "common/bt_str.h"
-#include "common/rpa.h"
+#include <common/bt_str.h>
+#include <common/rpa.h>
 #include "conn_internal.h"
 #include "gatt_internal.h"
 #include "hci_core.h"
@@ -34,7 +34,7 @@
 #include "keys.h"
 #include "settings.h"
 #include "smp.h"
-#include "sys/types.h"
+#include <sys/types.h>
 
 #define LOG_LEVEL CONFIG_BT_KEYS_LOG_LEVEL
 LOG_MODULE_REGISTER(bt_keys);

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -18,7 +18,7 @@
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys_clock.h>
 
-#include "host/classic/l2cap_br_interface.h"
+#include <host/classic/l2cap_br_interface.h>
 /* TODO: we should include conn_internal.h for bt_conn_tx_cb_t but that causes redefinitions */
 
 enum l2cap_conn_list_action {

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -35,7 +35,7 @@
 #include <sys/types.h>
 
 #include "addr_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "conn_internal.h"
 #include "direction_internal.h"
 #include "hci_core.h"

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -22,12 +22,12 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_settings_commit.h"
-#include "common/bt_str.h"
+#include <common/bt_settings_commit.h>
+#include <common/bt_str.h>
 #include "classic/br.h"
 #include "hci_core.h"
 #include "settings.h"
-#include "sys/types.h"
+#include <sys/types.h>
 
 #define LOG_LEVEL CONFIG_BT_SETTINGS_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/settings/settings.h>
-#include "common/bt_settings_commit.h"
+#include <common/bt_settings_commit.h>
 
 /* Max settings key length (with all components) */
 #define BT_SETTINGS_KEY_MAX 36

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -48,14 +48,14 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "audio/shell/audio.h"
-#include "common/bt_shell_private.h"
+#include <audio/shell/audio.h>
+#include <common/bt_shell_private.h>
 #if defined(CONFIG_BT_LL_SW_SPLIT)
-#include "controller/ll_sw/shell/ll.h"
+#include <controller/ll_sw/shell/ll.h>
 #endif /* CONFIG_BT_LL_SW_SPLIT */
-#include "host/shell/bt.h"
+#include <host/shell/bt.h>
 #if defined(CONFIG_BT_CLASSIC)
-#include "host/classic/shell/bredr.h"
+#include <host/classic/shell/bredr.h>
 #endif
 
 static bool no_settings_load;

--- a/subsys/bluetooth/host/shell/cs.c
+++ b/subsys/bluetooth/host/shell/cs.c
@@ -27,8 +27,8 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 static int check_cs_sync_antenna_selection_input(uint16_t input)
 {

--- a/subsys/bluetooth/host/shell/gatt.c
+++ b/subsys/bluetooth/host/shell/gatt.c
@@ -31,8 +31,8 @@
 #include <zephyr/sys/util.h>
 #include <sys/types.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 #if defined(CONFIG_BT_GATT_CLIENT) || defined(CONFIG_BT_GATT_DYNAMIC_DB)
 extern uint8_t selected_id;

--- a/subsys/bluetooth/host/shell/iso.c
+++ b/subsys/bluetooth/host/shell/iso.c
@@ -30,8 +30,8 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #if defined(CONFIG_BT_ISO_TX)
 #define DEFAULT_IO_QOS                                                                             \

--- a/subsys/bluetooth/host/shell/l2cap.c
+++ b/subsys/bluetooth/host/shell/l2cap.c
@@ -34,8 +34,8 @@
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/util.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 #define CREDITS			10
 #define DATA_MTU		(23 * CREDITS)

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -38,9 +38,9 @@
 #include <zephyr/toolchain.h>
 
 #include "conn_internal.h"
-#include "common/bt_str.h"
-#include "common/rpa.h"
-#include "crypto/bt_crypto.h"
+#include <common/bt_str.h>
+#include <common/rpa.h>
+#include <crypto/bt_crypto.h>
 #include "ecc.h"
 #include "hci_core.h"
 #include "keys.h"

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -14,7 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "testing.h"
 

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -15,7 +15,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "net.h"
 #include "foundation.h"

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -14,9 +14,9 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/hci_core.h"
+#include <host/hci_core.h>
 
 #include "net.h"
 #include "proxy.h"

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -15,9 +15,9 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/hci_core.h"
+#include <host/hci_core.h>
 
 #include "net.h"
 #include "foundation.h"

--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -22,7 +22,7 @@
 #include "foundation.h"
 #include "access.h"
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define LOG_LEVEL CONFIG_BT_MESH_KEYS_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -14,7 +14,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "net.h"
 #include "prov.h"

--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -12,7 +12,7 @@
 
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "cdb.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -16,7 +16,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "access.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -16,7 +16,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "testing.h"
 

--- a/subsys/bluetooth/mesh/crypto.c
+++ b/subsys/bluetooth/mesh/crypto.c
@@ -11,7 +11,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "mesh.h"
 #include "crypto.h"

--- a/subsys/bluetooth/mesh/gatt_cli.c
+++ b/subsys/bluetooth/mesh/gatt_cli.c
@@ -15,7 +15,7 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "mesh.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -16,7 +16,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "net.h"
 #include "foundation.h"

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -17,7 +17,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "crypto.h"
 #include "mesh.h"

--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -15,7 +15,7 @@
 #include "beacon.h"
 #include "prov.h"
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define LOG_LEVEL CONFIG_BT_MESH_PROV_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -16,7 +16,7 @@
 
 #include <zephyr/bluetooth/hci.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define LOG_LEVEL CONFIG_BT_MESH_PROV_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -14,7 +14,7 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "mesh.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/provisionee.c
+++ b/subsys/bluetooth/mesh/provisionee.c
@@ -17,8 +17,8 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/uuid.h>
 
-#include "common/bt_str.h"
-#include "common/long_wq.h"
+#include <common/bt_str.h>
+#include <common/long_wq.h>
 
 #include "crypto.h"
 #include "mesh.h"

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -18,8 +18,8 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/uuid.h>
 
-#include "common/bt_str.h"
-#include "common/long_wq.h"
+#include <common/bt_str.h>
+#include <common/long_wq.h>
 
 #include "crypto.h"
 #include "mesh.h"

--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -18,7 +18,7 @@
 
 #include <zephyr/bluetooth/hci.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "mesh.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -17,7 +17,7 @@
 
 #include <zephyr/bluetooth/hci.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "net.h"
 #include "rpl.h"

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -15,7 +15,7 @@
 #include <common/bt_settings_commit.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "host/hci_core.h"
+#include <host/hci_core.h>
 #include "mesh.h"
 #include "subnet.h"
 #include "app_keys.h"

--- a/subsys/bluetooth/mesh/shell/blob.c
+++ b/subsys/bluetooth/mesh/shell/blob.c
@@ -11,7 +11,7 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/mesh/shell.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 #include "utils.h"
 
 /***************************************************************************************************

--- a/subsys/bluetooth/mesh/shell/brg_cfg.c
+++ b/subsys/bluetooth/mesh/shell/brg_cfg.c
@@ -9,7 +9,7 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/mesh/shell.h>
 
-#include "mesh/foundation.h"
+#include <mesh/foundation.h>
 #include "utils.h"
 
 static int cmd_subnet_bridge_get(const struct shell *sh, size_t argc, char *argv[])

--- a/subsys/bluetooth/mesh/shell/cfg.c
+++ b/subsys/bluetooth/mesh/shell/cfg.c
@@ -8,8 +8,8 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "mesh/net.h"
-#include "mesh/access.h"
+#include <mesh/net.h>
+#include <mesh/access.h>
 #include "utils.h"
 #include <zephyr/bluetooth/mesh/shell.h>
 

--- a/subsys/bluetooth/mesh/shell/dfu.c
+++ b/subsys/bluetooth/mesh/shell/dfu.c
@@ -16,7 +16,7 @@
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/storage/flash_map.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 #include "utils.h"
 #include "blob.h"
 #include "../dfu_slot.h"

--- a/subsys/bluetooth/mesh/shell/health.c
+++ b/subsys/bluetooth/mesh/shell/health.c
@@ -8,8 +8,8 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "mesh/net.h"
-#include "mesh/access.h"
+#include <mesh/net.h>
+#include <mesh/access.h>
 #include "utils.h"
 #include <zephyr/bluetooth/mesh/shell.h>
 

--- a/subsys/bluetooth/mesh/shell/large_comp_data.c
+++ b/subsys/bluetooth/mesh/shell/large_comp_data.c
@@ -9,7 +9,7 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/mesh/shell.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 #include "utils.h"
 
 static void status_print(int err, char *msg, uint16_t addr, struct bt_mesh_large_comp_data_rsp *rsp)

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -18,15 +18,15 @@
 #include <zephyr/bluetooth/mesh/shell.h>
 
 /* Private includes for raw Network & Transport layer access */
-#include "mesh/mesh.h"
-#include "mesh/net.h"
-#include "mesh/rpl.h"
-#include "mesh/transport.h"
-#include "mesh/foundation.h"
-#include "mesh/settings.h"
-#include "mesh/access.h"
-#include "mesh/prov.h"
-#include "common/bt_shell_private.h"
+#include <mesh/mesh.h>
+#include <mesh/net.h>
+#include <mesh/rpl.h>
+#include <mesh/transport.h>
+#include <mesh/foundation.h>
+#include <mesh/settings.h>
+#include <mesh/access.h>
+#include <mesh/prov.h>
+#include <common/bt_shell_private.h>
 #include "utils.h"
 #include "dfu.h"
 #include "blob.h"

--- a/subsys/bluetooth/mesh/shell/utils.c
+++ b/subsys/bluetooth/mesh/shell/utils.c
@@ -9,8 +9,8 @@
 #include <ctype.h>
 #include <string.h>
 
-#include "mesh/net.h"
-#include "mesh/access.h"
+#include <mesh/net.h>
+#include <mesh/access.h>
 #include "utils.h"
 
 bool bt_mesh_shell_mdl_first_get(uint16_t id, const struct bt_mesh_model **mod)

--- a/subsys/bluetooth/mesh/solicitation.c
+++ b/subsys/bluetooth/mesh/solicitation.c
@@ -19,9 +19,9 @@
 #include "proxy.h"
 #include "settings.h"
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/hci_core.h"
+#include <host/hci_core.h>
 
 #define LOG_LEVEL CONFIG_BT_MESH_MODEL_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -19,7 +19,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "crypto.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -17,7 +17,7 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "crypto.h"
 #include "mesh.h"

--- a/subsys/bluetooth/mesh/va.c
+++ b/subsys/bluetooth/mesh/va.c
@@ -15,7 +15,7 @@
 
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "va.h"
 #include "foundation.h"

--- a/subsys/bluetooth/services/ias/shell/ias.c
+++ b/subsys/bluetooth/services/ias/shell/ias.c
@@ -16,8 +16,8 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/services/ias.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static void alert_stop(void)
 {

--- a/subsys/bluetooth/services/ias/shell/ias_client.c
+++ b/subsys/bluetooth/services/ias/shell/ias_client.c
@@ -15,8 +15,8 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/services/ias.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static void ias_discover_cb(struct bt_conn *conn, int err)
 {


### PR DESCRIPTION
Use #include <> instead of #include "" to include a header file which path is not relative to the directory path of the file emitting the #include directive.

This change was made running scripts/check_quoted_includes.py script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with the Linux shell command below and manually selecting the applicable changes:
$ find subsys/bluetooth/ -type f -exec \
    ./scripts/check_quoted_includes.py -w {} \;