### PR TITLE
dts: arm: use diamond include for non-local header files

### DIFF
--- a/dts/arm/armv5.dtsi
+++ b/dts/arm/armv5.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/arm/armv6-m.dtsi
+++ b/dts/arm/armv6-m.dtsi
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/arm/armv7-a.dtsi
+++ b/dts/arm/armv7-a.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/arm/armv7-m.dtsi
+++ b/dts/arm/armv7-m.dtsi
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/arm/armv7-r.dtsi
+++ b/dts/arm/armv7-r.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/arm/armv8-a.dtsi
+++ b/dts/arm/armv8-a.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/arm/armv8-m.dtsi
+++ b/dts/arm/armv8-m.dtsi
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/arm/armv8-r.dtsi
+++ b/dts/arm/armv8-r.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/arm/armv8.1-m.dtsi
+++ b/dts/arm/armv8.1-m.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/arm/infineon/psoc4/psoc4100smax/system_clocks.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100smax/system_clocks.dtsi
@@ -11,7 +11,7 @@
 
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_psoc4xx.h>
-#include "freq.h"
+#include <freq.h>
 
 / {
 	clocks {

--- a/dts/arm/infineon/psoc4/psoc4100tp/system_clocks.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100tp/system_clocks.dtsi
@@ -11,7 +11,7 @@
 
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_psoc4xx.h>
-#include "freq.h"
+#include <freq.h>
 
 / {
 	clocks {

--- a/dts/arm/infineon/psoc6/psoc6_02/psoc6_02.124-bga.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_02/psoc6_02.124-bga.dtsi
@@ -7,7 +7,7 @@
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pinctrl/ifx_cat1-pinctrl.h>
-#include "psoc6_02.dtsi"
+#include <psoc6_02.dtsi>
 
 / {
 	soc {

--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -15,7 +15,7 @@
 /* npcx4 series low-voltage io controls mapping table */
 #include "npcx4/npcx4-lvol-ctrl-map.dtsi"
 /* npcx4 series reset mapping table */
-#include "zephyr/dt-bindings/reset/npcx4_reset.h"
+#include <zephyr/dt-bindings/reset/npcx4_reset.h>
 
 /* Device tree declarations of npcx soc family */
 #include "npcx.dtsi"

--- a/dts/arm/nxp/kinetis/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke1xz.dtsi
@@ -6,7 +6,7 @@
 
 #include <mem.h>
 #include <freq.h>
-#include "armv6-m.dtsi"
+#include <armv6-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_pcc.h>
 #include <zephyr/dt-bindings/clock/kinetis_scg.h>

--- a/dts/arm/nxp/kinetis/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_kl25z.dtsi
@@ -6,7 +6,7 @@
 
 #include <mem.h>
 #include <freq.h>
-#include "armv6-m.dtsi"
+#include <armv6-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/dt-bindings/clock/kinetis_mcg.h>

--- a/dts/arm/nxp/kinetis/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_kw40z.dtsi
@@ -6,7 +6,7 @@
 
 #include <mem.h>
 #include <freq.h>
-#include "armv6-m.dtsi"
+#include <armv6-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/dt-bindings/clock/kinetis_mcg.h>


### PR DESCRIPTION
Use #include <> instead of #include "" to include a header file which path is not relative to the directory path of the file emitting the #include directive.

This change was made running scripts/check_quoted_includes.py script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with the Linux shell command below and manually selecting the applicable changes:
`$ find dts/arm -type f -exec ./scripts/check_quoted_includes.py -w {} \;`