### PR TITLE
dts: use diamond include for non-local header files

### DIFF
--- a/dts/arc/synopsys/arc_hs4xd.dtsi
+++ b/dts/arc/synopsys/arc_hs4xd.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arc/synopsys/arc_hsdk.dtsi
+++ b/dts/arc/synopsys/arc_hsdk.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arc/synopsys/arc_iot.dtsi
+++ b/dts/arc/synopsys/arc_iot.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arc/synopsys/emsdp.dtsi
+++ b/dts/arc/synopsys/emsdp.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 //#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arc/synopsys/emsk.dtsi
+++ b/dts/arc/synopsys/emsk.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 

--- a/dts/arm64/armv8-a.dtsi
+++ b/dts/arm64/armv8-a.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/arm64/armv8-r.dtsi
+++ b/dts/arm64/armv8-r.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/arm64/armv9-a.dtsi
+++ b/dts/arm64/armv9-a.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/posix/posix.dtsi
+++ b/dts/posix/posix.dtsi
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <mem.h>

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -18,7 +18,7 @@
 #include <zephyr/dt-bindings/sensor/it8xxx2_vcmp.h>
 #include <zephyr/dt-bindings/sensor/it8xxx2_tach.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
-#include "ite/it8xxx2-wuc-map.dtsi"
+#include <ite/it8xxx2-wuc-map.dtsi>
 
 / {
 	#address-cells = <1>;

--- a/dts/riscv/raspberrypi/hazard3.dtsi
+++ b/dts/riscv/raspberrypi/hazard3.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {

--- a/dts/sparc/gaisler/gr716a.dtsi
+++ b/dts/sparc/gaisler/gr716a.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {

--- a/dts/sparc/gaisler/leon3soc.dtsi
+++ b/dts/sparc/gaisler/leon3soc.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	cpus {

--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>

--- a/dts/x86/intel/apollo_lake.dtsi
+++ b/dts/x86/intel/apollo_lake.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>

--- a/dts/x86/intel/atom.dtsi
+++ b/dts/x86/intel/atom.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 
 / {

--- a/dts/x86/intel/bartlett_lake_s.dtsi
+++ b/dts/x86/intel/bartlett_lake_s.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>

--- a/dts/x86/intel/gpio_common.dtsi
+++ b/dts/x86/intel/gpio_common.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/acpi/acpi.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>

--- a/dts/x86/intel/lakemont.dtsi
+++ b/dts/x86/intel/lakemont.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 
 / {

--- a/dts/x86/intel/panther_lake_h.dtsi
+++ b/dts/x86/intel/panther_lake_h.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>

--- a/dts/x86/intel/raptor_lake_p.dtsi
+++ b/dts/x86/intel/raptor_lake_p.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/x86/intel/raptor_lake_s.dtsi
+++ b/dts/x86/intel/raptor_lake_s.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>

--- a/dts/x86/intel/wildcat_lake.dtsi
+++ b/dts/x86/intel/wildcat_lake.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>

--- a/dts/xtensa/dc233c.dtsi
+++ b/dts/xtensa/dc233c.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	cpus {

--- a/dts/xtensa/sample_controller.dtsi
+++ b/dts/xtensa/sample_controller.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	cpus {

--- a/dts/xtensa/sample_controller32.dtsi
+++ b/dts/xtensa/sample_controller32.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	cpus {

--- a/dts/xtensa/xtensa.dtsi
+++ b/dts/xtensa/xtensa.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "skeleton.dtsi"
+#include <skeleton.dtsi>
 
 / {
 	soc {


### PR DESCRIPTION
Use #include <> instead of #include "" to include a header file which path is not relative to the directory path of the file emitting the #include directive.

This change was made running scripts/check_quoted_includes.py script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with the Linux shell command below and manually selecting the applicable changes:
$ find dts/ -type f -exec ./scripts/check_quoted_includes.py -w {} \;

Actaully, this P-R considers all **dts/\*/** sub-directories but **dts/arm/** that are change through a dedicated P-R.