### PR TITLE
lib: heap: use single evaluation min

### DIFF
--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -713,7 +713,7 @@ void *sys_heap_realloc(struct sys_heap *heap, void *ptr, size_t bytes)
 		 */
 		IF_ENABLED(CONFIG_SYS_HEAP_SANITIZER_HOOKS,
 			   (heap_sanitizer_on_alloc(heap, ptr, prev_size)));
-		memcpy(ptr2, ptr, MIN(prev_size, bytes));
+		memcpy(ptr2, ptr, min(prev_size, bytes));
 		sys_heap_free(heap, ptr);
 	}
 	return ptr2;
@@ -763,7 +763,7 @@ void *sys_heap_aligned_realloc(struct sys_heap *heap, void *ptr,
 		 */
 		IF_ENABLED(CONFIG_SYS_HEAP_SANITIZER_HOOKS,
 			   (heap_sanitizer_on_alloc(heap, ptr, prev_size)));
-		memcpy(ptr2, ptr, MIN(prev_size, bytes));
+		memcpy(ptr2, ptr, min(prev_size, bytes));
 		sys_heap_free(heap, ptr);
 	}
 	return ptr2;


### PR DESCRIPTION
Change these (back) to the single use version, they have been changed recently for "consistency" reasons but that seems to be incorrect.

See https://github.com/zephyrproject-rtos/zephyr/pull/101479