### PR TITLE
tests: kernel: queue: document tests and align group naming

### DIFF
--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -137,19 +137,28 @@ static void tqueue_isr_thread(struct k_queue *pqueue)
 
 /*test cases*/
 /**
- * @brief Verify data passing between threads using queue
+ * @brief Verify data passes between two threads through a queue in order.
  *
- * @details Static define and Dynamic define queues,
- * Then initialize them.
- * Create a new thread to wait for reading data.
- * Current thread will append item into queue.
- * Verify if rx_data is equal insert-data address.
- * Verify queue can be define at compile time.
+ * @details
+ * A consumer thread blocks on k_queue_get() while the main thread enqueues items
+ * using every insertion API (insert, append, prepend, append_list, merge_slist).
+ * The consumer must receive all items in the resulting dequeue order. Run against
+ * both a k_queue_init()ed and a K_QUEUE_DEFINE()d queue.
  *
- * @ingroup kernel_queue_tests
+ * Test steps:
+ * - Start a consumer thread that drains the queue.
+ * - Insert items via insert/append/prepend/append_list/merge_slist.
+ * - Synchronize on a semaphore once the consumer has read all items.
+ * - Repeat for a statically defined queue.
  *
- * @see k_queue_init(), k_queue_insert(), k_queue_append()
- * K_THREAD_STACK_DEFINE()
+ * Expected result:
+ * - The consumer dequeues every item, matching the expected ordering.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_append()
+ * @see k_queue_prepend()
+ * @see k_queue_get()
  */
 ZTEST(queue_api_1cpu, test_queue_thread2thread)
 {
@@ -162,18 +171,25 @@ ZTEST(queue_api_1cpu, test_queue_thread2thread)
 }
 
 /**
- * @brief Verify data passing between thread and ISR
+ * @brief Verify data passes from an ISR to a thread through a queue.
  *
- * @details Create a new ISR to insert data
- * And current thread is used for getting data
- * Verify if the rx_data is equal insert-data address.
- * If the received data address is the same as
- * the created array, prove that the queue data structures
- * are stored within the provided data items.
+ * @details
+ * Items are enqueued from interrupt context (via irq_offload()) and dequeued in
+ * thread context, confirming the queue insertion APIs are ISR-safe and the
+ * thread receives every item. Run against both an init()ed and a DEFINE()d queue.
  *
- * @ingroup kernel_queue_tests
+ * Test steps:
+ * - From an ISR, insert items into the queue.
+ * - In thread context, get all items and verify their addresses/order.
+ * - Repeat for a statically defined queue.
  *
- * @see k_queue_init(), k_queue_insert(), k_queue_append()
+ * Expected result:
+ * - The thread dequeues every ISR-enqueued item in the expected order.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_append()
+ * @see k_queue_get()
  */
 ZTEST(queue_api, test_queue_thread2isr)
 {
@@ -186,16 +202,25 @@ ZTEST(queue_api, test_queue_thread2isr)
 }
 
 /**
- * @brief Verify data passing between ISR and thread
+ * @brief Verify data passes from a thread to an ISR through a queue.
  *
- * @details Create a new ISR and ready for getting data
- * And current thread is used for inserting data
- * Verify if the rx_data is equal insert-data address.
+ * @details
+ * Items are enqueued in thread context and dequeued from interrupt context (via
+ * irq_offload()), confirming k_queue_get() is ISR-safe and the ISR receives
+ * every item. Run against both an init()ed and a DEFINE()d queue.
  *
- * @ingroup kernel_queue_tests
+ * Test steps:
+ * - In thread context, insert items into the queue.
+ * - From an ISR, get all items and verify their addresses/order.
+ * - Repeat for a statically defined queue.
  *
- * @see k_queue_init(), k_queue_insert(), k_queue_get(),
- * k_queue_append(), k_queue_remove()
+ * Expected result:
+ * - The ISR dequeues every thread-enqueued item in the expected order.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_append()
+ * @see k_queue_get()
  */
 ZTEST(queue_api, test_queue_isr2thread)
 {
@@ -239,10 +264,25 @@ static void tqueue_get_2threads(struct k_queue *pqueue)
 }
 
 /**
- * @brief Verify k_queue_get()
- * @ingroup kernel_queue_tests
- * @see k_queue_init(), k_queue_get(),
- * k_queue_append(), k_queue_alloc_prepend()
+ * @brief Verify two threads blocked on a queue are each woken by an append.
+ *
+ * @details
+ * When multiple threads block on an empty queue with K_FOREVER, each appended
+ * item must wake exactly one waiter so that every blocked getter eventually
+ * receives data.
+ *
+ * Test steps:
+ * - Start two threads that each block in k_queue_get(K_FOREVER).
+ * - Append two items to the queue.
+ * - Confirm both threads complete (each got one item).
+ *
+ * Expected result:
+ * - Both waiting threads are woken, each receiving one item.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_get()
+ * @see k_queue_append()
  */
 ZTEST(queue_api_1cpu, test_queue_get_2threads)
 {
@@ -291,11 +331,28 @@ static void tqueue_alloc(struct k_queue *pqueue)
 }
 
 /**
- * @brief Test queue alloc append and prepend
- * @ingroup kernel_queue_tests
- * @see k_queue_alloc_append(), k_queue_alloc_prepend(),
- * k_thread_heap_assign(), k_queue_is_empty(),
- * k_queue_get(), k_queue_remove()
+ * @brief Verify alloc append/prepend honor the thread's resource pool.
+ *
+ * @details
+ * k_queue_alloc_append()/k_queue_alloc_prepend() allocate a container from the
+ * calling thread's heap. With no pool (or a too-small pool) the insertion must
+ * fail and leave the queue empty; with a sufficient pool it must succeed and the
+ * item becomes retrievable.
+ *
+ * Test steps:
+ * - With no resource pool assigned, attempt an alloc append; verify it fails.
+ * - Assign a too-small pool, attempt an alloc prepend; verify it fails and the
+ *   queue stays empty.
+ * - Assign a sufficient pool, alloc prepend succeeds and the item can be gotten.
+ *
+ * Expected result:
+ * - Allocation fails without enough pool memory and succeeds with it.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_alloc_append()
+ * @see k_queue_alloc_prepend()
+ * @see k_thread_heap_assign()
  */
 ZTEST(queue_api, test_queue_alloc)
 {
@@ -327,11 +384,30 @@ static void queue_poll_race_consume(void *p1, void *p2, void *p3)
 	}
 }
 
-/* There was a historical race in the queue internals when CONFIG_POLL
- * was enabled -- it was possible to wake up a lower priority thread
- * with an insert but then steal it with a higher priority thread
- * before it got a chance to run, and the lower priority thread would
- * then return NULL before its timeout expired.
+/**
+ * @brief Verify an append wakes exactly one waiter (CONFIG_POLL race).
+ *
+ * @details
+ * Guards against a historical CONFIG_POLL race: an insert could wake a
+ * lower-priority waiter, then a higher-priority waiter could steal the item
+ * before the first ran, causing the lower-priority getter to spuriously return
+ * NULL before its timeout. Two consumers of different priority block on the
+ * queue; appending two items must deliver exactly one to each (two total) with
+ * no spurious early return.
+ *
+ * Test steps:
+ * - Start two consumer threads of different priority that block on the queue.
+ * - Append two items.
+ * - Verify neither consumer woke prematurely and exactly two gets succeeded.
+ *
+ * Expected result:
+ * - The two appended items are consumed (low_count + mid_count == 2) with no
+ *   spurious NULL return.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_append()
+ * @see k_queue_get()
  */
 ZTEST(queue_api_1cpu, test_queue_poll_race)
 {
@@ -373,13 +449,20 @@ ZTEST(queue_api_1cpu, test_queue_poll_race)
 }
 
 /**
- * @brief Verify that multiple queues can be defined
- * simultaneously
+ * @brief Verify multiple independent queues operate without interference.
  *
- * @details define multiple queues to verify
- * they can work.
+ * @details
+ * Several queues initialized from the same code must each store and return their
+ * own items correctly, confirming queue instances do not share state.
  *
- * @ingroup kernel_queue_tests
+ * Test steps:
+ * - Initialize an array of queues.
+ * - For each, append a set of items and drain it, verifying the contents.
+ *
+ * Expected result:
+ * - Every queue independently delivers its own items.
+ *
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_init()
  */
@@ -406,23 +489,25 @@ void user_access_queue_private_data(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test access kernel object with private data using system call
+ * @brief Verify a user thread faults accessing a queue it has no permission on.
  *
  * @details
- * - When defining system calls, it is very important to ensure that
- *   access to the API’s private data is done exclusively through system call
- *   interfaces. Private kernel data should never be made available to user mode
- *   threads directly. For example, the k_queue APIs were intentionally not made
- *   available as they store bookkeeping information about the queue directly
- *   in the queue buffers which are visible from user mode.
- * - Current test makes user thread try to access private kernel data within
- *   their associated data structures. Kernel will track that system call
- *   access to these object with the kernel object permission system.
- *   Current user thread doesn't have permission on it, trying to access
- *   &pqueue kernel object will happen kernel oops, because current user
- *   thread doesn't have permission on k_queue object with private kernel data.
+ * The k_queue APIs keep bookkeeping data inside structures visible from user
+ * mode, so direct access must be gated by the kernel object permission system. A
+ * user thread without permission on the queue object that calls a k_queue API
+ * must trigger a kernel oops rather than read private kernel data.
  *
- * @ingroup kernel_memprotect_tests
+ * Test steps:
+ * - Initialize a queue and insert an item from supervisor mode.
+ * - Spawn a user thread (with no granted access) that calls k_queue_is_empty().
+ * - Mark the fault as expected and join the thread.
+ *
+ * Expected result:
+ * - The unprivileged access triggers the expected kernel oops.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_is_empty()
  */
 ZTEST(queue_api, test_access_kernel_obj_with_priv_data)
 {
@@ -464,17 +549,28 @@ static void high_prio_t2_wait_for_queue(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test multi-threads to get data from a queue.
+ * @brief Verify queued data is delivered by priority then wait time.
  *
- * @details Define three threads, and set a higher priority for two of them,
- * and set a lower priority for the last one. Then Add a delay between
- * creating the two high priority threads.
- * Test point:
- * 1. Any number of threads may wait on an empty FIFO simultaneously.
- * 2. When a data item is added, it is given to the highest priority
- * thread that has waited longest.
+ * @details
+ * Any number of threads may block on an empty queue. When data arrives it must
+ * go to the highest-priority waiter, and among equal-priority waiters to the one
+ * that has waited longest. Three threads (one low priority, two equal higher
+ * priority created with a delay between them) block, then three items are
+ * appended; each thread must receive the item matching its expected order.
  *
- * @ingroup kernel_queue_tests
+ * Test steps:
+ * - Start a low-priority waiter and two higher-priority waiters (staggered).
+ * - Append three distinct items.
+ * - Each thread asserts it received the item matching its priority/wait rank.
+ *
+ * Expected result:
+ * - The longest-waiting highest-priority thread gets the first item, the other
+ *   high-priority thread next, and the low-priority thread last.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_get()
+ * @see k_queue_append()
  */
 ZTEST(queue_api_1cpu, test_queue_multithread_competition)
 {
@@ -528,14 +624,22 @@ ZTEST(queue_api_1cpu, test_queue_multithread_competition)
 }
 
 /**
- * @brief Verify k_queue_unique_append()
+ * @brief Verify k_queue_unique_append() rejects duplicate entries.
  *
- * @ingroup kernel_queue_tests
+ * @details
+ * k_queue_unique_append() must add an item only if it is not already queued: a
+ * first append of an item succeeds, a second append of the same item fails, and
+ * appending a different item succeeds.
  *
- * @details Append the same data to the queue repeatedly,
- * see if it returns expected value.
- * And verify operation succeed if append different data to
- * the queue.
+ * Test steps:
+ * - Append an item and verify it succeeds.
+ * - Append the same item again and verify it fails.
+ * - Append a different item and verify it succeeds.
+ *
+ * Expected result:
+ * - Duplicate appends return false; unique appends return true.
+ *
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_unique_append()
  */

--- a/tests/kernel/queue/src/test_queue_fail.c
+++ b/tests/kernel/queue/src/test_queue_fail.c
@@ -16,8 +16,23 @@ K_SEM_DEFINE(sem, 0, 1);
 
 /*test cases*/
 /**
- * @brief Test k_queue_get() failure scenario
- * @ingroup kernel_queue_tests
+ * @brief Verify k_queue_get() on an empty queue returns NULL.
+ *
+ * @details
+ * With no data queued, k_queue_get() must return NULL rather than block forever
+ * or return stale data. Checked both with K_NO_WAIT (immediate) and with a finite
+ * timeout that is allowed to expire.
+ *
+ * Test steps:
+ * - Initialize an empty queue.
+ * - Call k_queue_get() with K_NO_WAIT and verify it returns NULL.
+ * - Call k_queue_get() with a finite timeout and verify it returns NULL.
+ *
+ * Expected result:
+ * - Both k_queue_get() calls return NULL.
+ *
+ * @ingroup tests_kernel_queue
+ *
  * @see k_queue_get()
  */
 ZTEST(queue_api_1cpu, test_queue_get_fail)
@@ -52,7 +67,7 @@ static void tThread_entry(void *p1, void *p2, void *p3)
  *	3. Verify that append list to the queue when a
  * sub-thread is waiting for data.
  *
- * @ingroup kernel_queue_tests
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_append_list()
  */
@@ -98,7 +113,7 @@ ZTEST(queue_api, test_queue_append_list_error)
  * @details Verify the API k_queue_merge_slist when
  * a slist is empty or a slist's tail is null.
  *
- * @ingroup kernel_queue_tests
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_merge_slist()
  */
@@ -130,7 +145,7 @@ ZTEST(queue_api, test_queue_merge_list_error)
  * @details Verify that the parameter of API k_queue_init() is
  * NULL, what will happen.
  *
- * @ingroup kernel_queue_tests
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_init()
  */
@@ -146,7 +161,7 @@ ZTEST_USER(queue_api, test_queue_init_null)
  * @details Verify that the parameter of the API is
  * NULL, what will happen.
  *
- * @ingroup kernel_queue_tests
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_alloc_append()
  */
@@ -165,7 +180,7 @@ ZTEST_USER(queue_api, test_queue_alloc_append_null)
  * @details Verify that the parameter of the API is
  * NULL, what will happen.
  *
- * @ingroup kernel_queue_tests
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_alloc_prepend()
  */
@@ -184,7 +199,7 @@ ZTEST_USER(queue_api, test_queue_alloc_prepend_null)
  * @details Verify that the parameter of the API is
  * NULL, what will happen.
  *
- * @ingroup kernel_queue_tests
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_get()
  */
@@ -200,7 +215,7 @@ ZTEST_USER(queue_api, test_queue_get_null)
  * @details Verify that the parameter of the API is
  * NULL, what will happen.
  *
- * @ingroup kernel_queue_tests
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_is_empty()
  */
@@ -216,7 +231,7 @@ ZTEST_USER(queue_api, test_queue_is_empty_null)
  * @details Verify that the parameter of the API is
  * NULL, what will happen.
  *
- * @ingroup kernel_queue_tests
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_peek_head()
  */
@@ -232,7 +247,7 @@ ZTEST_USER(queue_api, test_queue_peek_head_null)
  * @details Verify that the parameter of the API is
  * NULL, what will happen.
  *
- * @ingroup kernel_queue_tests
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_peek_tail()
  */
@@ -248,7 +263,7 @@ ZTEST_USER(queue_api, test_queue_peek_tail_null)
  * @details Verify that the parameter of the API is
  * NULL, what will happen.
  *
- * @ingroup kernel_queue_tests
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_merge_slist()
  */

--- a/tests/kernel/queue/src/test_queue_loop.c
+++ b/tests/kernel/queue/src/test_queue_loop.c
@@ -102,10 +102,27 @@ static void tqueue_read_write(struct k_queue *pqueue)
 
 /*test cases*/
 /**
- * @brief Test queue operations in loop
- * @ingroup kernel_queue_tests
- * @see k_queue_append(), k_queue_get(),
- * k_queue_init(), k_queue_remove()
+ * @brief Verify queue data integrity under repeated cross-context traffic.
+ *
+ * @details
+ * Stresses the queue by cycling append/prepend/get/remove operations through
+ * main-thread, ISR and spawned-thread contexts many times. Across every
+ * iteration the items must be passed and removed without loss, duplication or
+ * reordering.
+ *
+ * Test steps:
+ * - For LOOPS iterations: append/prepend from the main thread, find-and-remove
+ *   plus get/append from an ISR and a spawned thread, then drain.
+ * - Verify each get returns the expected item and each remove succeeds.
+ *
+ * Expected result:
+ * - Data passes correctly across all contexts on every iteration.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_append()
+ * @see k_queue_get()
+ * @see k_queue_remove()
  */
 ZTEST(queue_api_1cpu, test_queue_loop)
 {

--- a/tests/kernel/queue/src/test_queue_user.c
+++ b/tests/kernel/queue/src/test_queue_user.c
@@ -17,7 +17,7 @@ static ZTEST_BMEM struct qdata qdata[LIST_LEN * 2];
 
 /**
  * @brief Tests for queue
- * @defgroup kernel_queue_tests Queues
+ * @defgroup tests_kernel_queue Queue tests
  * @ingroup all_tests
  * @{
  * @}
@@ -58,17 +58,28 @@ void child_thread_get(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Verify queue elements and cancel wait from a user thread
+ * @brief Verify supervisor-queued data reaches a user thread and cancel wait.
  *
- * @details The test adds elements to queue and then
- * verified by the child user thread.
- * Get data from a empty queue,and use K_FORVER to wait for available
- * And to cancel wait from current thread.
+ * @details
+ * A supervisor thread fills a queue with both plain and alloc-appended elements,
+ * which a user-mode child thread must read back in order (with correct head/tail
+ * peeks). The child then blocks on an empty queue and must be released by
+ * k_queue_cancel_wait() returning NULL.
  *
- * @ingroup kernel_queue_tests
+ * Test steps:
+ * - Supervisor appends interleaved plain and alloc-appended items.
+ * - Start a user child that peeks head/tail, gets all items in order, then
+ *   blocks on an empty get.
+ * - Call k_queue_cancel_wait() and verify the child's blocked get returns NULL.
  *
- * @see k_queue_append(), k_queue_alloc_append(),
- * k_queue_init(), k_queue_cancel_wait()
+ * Expected result:
+ * - The user thread reads every item in order and the cancel releases its wait.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_alloc_append()
+ * @see k_queue_get()
+ * @see k_queue_cancel_wait()
  */
 ZTEST(queue_api_1cpu, test_queue_supv_to_user)
 {
@@ -119,16 +130,24 @@ ZTEST(queue_api_1cpu, test_queue_supv_to_user)
 }
 
 /**
- * @brief verify allocate and feature "Last In, First Out"
+ * @brief Verify k_queue_alloc_prepend() yields LIFO order from user mode.
  *
- * @details Create a new queue
- * And allocated memory for the queue
- * Initialize and insert data item in sequence.
- * Verify the feather "Last in,First out"
+ * @details
+ * Prepending items pushes each to the front, so reading the queue back returns
+ * them in reverse insertion (LIFO) order. Exercised from a user-mode thread on an
+ * allocated queue object.
  *
- * @ingroup kernel_queue_tests
+ * Test steps:
+ * - Alloc-prepend a sequence of items 0..N-1 from a user thread.
+ * - Get all items and verify they come out in reverse order (N-1..0).
+ *
+ * Expected result:
+ * - Items are returned newest-first (LIFO).
+ *
+ * @ingroup tests_kernel_queue
  *
  * @see k_queue_alloc_prepend()
+ * @see k_queue_get()
  */
 ZTEST_USER(queue_api, test_queue_alloc_prepend_user)
 {
@@ -153,16 +172,24 @@ ZTEST_USER(queue_api, test_queue_alloc_prepend_user)
 }
 
 /**
- * @brief verify feature of queue "First In, First Out"
+ * @brief Verify k_queue_alloc_append() yields FIFO order from user mode.
  *
- * @details Create a new queue
- * And allocated memory for the queue
- * Initialize and insert data item in sequence.
- * Verify the feather "First in,First out"
+ * @details
+ * Appending items adds each to the tail, so reading the queue back returns them
+ * in insertion (FIFO) order. Exercised from a user-mode thread on an allocated
+ * queue object.
  *
- * @ingroup kernel_queue_tests
+ * Test steps:
+ * - Alloc-append a sequence of items 0..N-1 from a user thread.
+ * - Get all items and verify they come out in insertion order (0..N-1).
  *
- * @see k_queue_init(), k_queue_alloc_append()
+ * Expected result:
+ * - Items are returned oldest-first (FIFO).
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_alloc_append()
+ * @see k_queue_get()
  */
 ZTEST_USER(queue_api, test_queue_alloc_append_user)
 {
@@ -187,8 +214,24 @@ ZTEST_USER(queue_api, test_queue_alloc_append_user)
 }
 
 /**
- * @brief Test to verify free of allocated elements of queue
- * @ingroup kernel_queue_tests
+ * @brief Verify allocated queue resources are auto-freed back to the pool.
+ *
+ * @details
+ * Elements added with the alloc APIs and the kernel objects allocated by the
+ * previous user-mode test must be released automatically (queue elements when
+ * dequeued, objects when permitted threads exit). The test confirms the whole
+ * pool is available again by reallocating all of it.
+ *
+ * Test steps:
+ * - After the preceding alloc-heavy test, allocate the entire pool in chunks.
+ * - Verify every allocation succeeds, then free them.
+ *
+ * Expected result:
+ * - All pool memory is reclaimable, proving prior resources were auto-freed.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_alloc_append()
  */
 ZTEST(queue_api, test_auto_free)
 {


### PR DESCRIPTION
Bring the queue test documentation in line with the test documentation
conventions. Rename the Doxygen module from kernel_queue_tests to the
tests_-prefixed tests_kernel_queue under all_tests, and rewrite the terse
and translated-English per-test blocks into the @details / Test steps /
Expected result template so each case states its requirement-level intent
(FIFO/LIFO ordering, priority-then-wait-time delivery, alloc honouring the
thread resource pool, unique-append rejecting duplicates, ...).

